### PR TITLE
fix: avoid 500 when generating chat title from rename dialog

### DIFF
--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -114,6 +114,35 @@ func maybeWriteLimitErr(ctx context.Context, rw http.ResponseWriter, err error) 
 	return false
 }
 
+// statusClientClosedRequest is nginx's non-standard 499 status code,
+// used here to distinguish a client-initiated cancel from a server-
+// side failure when the manual title generation context is canceled.
+const statusClientClosedRequest = 499
+
+// maybeWriteManualTitleTimeoutErr translates context-cancel or
+// context-deadline errors from the manual title pipeline into
+// friendly 499/504 responses. Returns true when the response was
+// written.
+func maybeWriteManualTitleTimeoutErr(
+	ctx context.Context,
+	rw http.ResponseWriter,
+	err error,
+) bool {
+	switch {
+	case errors.Is(err, context.Canceled):
+		httpapi.Write(ctx, rw, statusClientClosedRequest, codersdk.Response{
+			Message: "Title generation was canceled.",
+		})
+		return true
+	case errors.Is(err, context.DeadlineExceeded):
+		httpapi.Write(ctx, rw, http.StatusGatewayTimeout, codersdk.Response{
+			Message: "Title generation timed out. Try again or rename manually.",
+		})
+		return true
+	}
+	return false
+}
+
 func publishChatTitleChange(logger slog.Logger, ps dbpubsub.Pubsub, chat database.Chat) {
 	if ps == nil {
 		return
@@ -3579,6 +3608,9 @@ func (api *API) regenerateChatTitle(rw http.ResponseWriter, r *http.Request) {
 			httpapi.ResourceNotFound(rw)
 			return
 		}
+		if maybeWriteManualTitleTimeoutErr(ctx, rw, err) {
+			return
+		}
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Failed to regenerate chat title.",
 			Detail:  err.Error(),
@@ -3630,6 +3662,9 @@ func (api *API) proposeChatTitle(rw http.ResponseWriter, r *http.Request) {
 		}
 		if httpapi.Is404Error(err) {
 			httpapi.ResourceNotFound(rw)
+			return
+		}
+		if maybeWriteManualTitleTimeoutErr(ctx, rw, err) {
 			return
 		}
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{

--- a/coderd/exp_chats_internal_test.go
+++ b/coderd/exp_chats_internal_test.go
@@ -1,9 +1,14 @@
 package coderd
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/codersdk"
 )
@@ -71,6 +76,61 @@ func TestRewriteChatStartWorkspaceManualUpdateResponse(t *testing.T) {
 			require.Equal(t, retryInstructions, got.Message)
 			require.Equal(t, tt.wantDetail, got.Detail)
 			require.Equal(t, tt.resp.Validations, got.Validations)
+		})
+	}
+}
+
+func TestMaybeWriteManualTitleTimeoutErr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		err         error
+		wantWrote   bool
+		wantStatus  int
+		wantMessage string
+	}{
+		{
+			name:        "DeadlineExceededMapsTo504",
+			err:         xerrors.Errorf("generate manual title: %w", context.DeadlineExceeded),
+			wantWrote:   true,
+			wantStatus:  http.StatusGatewayTimeout,
+			wantMessage: "Title generation timed out. Try again or rename manually.",
+		},
+		{
+			name:        "CanceledMapsTo499",
+			err:         xerrors.Errorf("generate manual title: %w", context.Canceled),
+			wantWrote:   true,
+			wantStatus:  statusClientClosedRequest,
+			wantMessage: "Title generation was canceled.",
+		},
+		{
+			// Unrelated errors must fall through so the handler keeps
+			// its existing 500 surface for genuine failures.
+			name:      "UnrelatedErrorFallsThrough",
+			err:       xerrors.New("something else"),
+			wantWrote: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rw := httptest.NewRecorder()
+			wrote := maybeWriteManualTitleTimeoutErr(context.Background(), rw, tt.err)
+			require.Equal(t, tt.wantWrote, wrote)
+			if !tt.wantWrote {
+				require.Equal(t, http.StatusOK, rw.Code, "must not write a response when err is unrelated")
+				return
+			}
+			require.Equal(t, tt.wantStatus, rw.Code)
+
+			var resp codersdk.Response
+			require.NoError(t, json.NewDecoder(rw.Body).Decode(&resp))
+			require.Equal(t, tt.wantMessage, resp.Message)
+			require.Empty(t, resp.Detail, "translated copy must not leak the raw error detail")
 		})
 	}
 }

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -2802,6 +2802,16 @@ type manualTitleCandidateResult struct {
 	hasMessages bool
 }
 
+// manualTitleCandidate pairs a usable language model with the
+// database config row used for usage accounting. The candidate walk
+// in generateManualTitleCandidate iterates these in order, falling
+// through to the next one on retryable or per-attempt-timeout
+// failures.
+type manualTitleCandidate struct {
+	config database.ChatModelConfig
+	model  fantasy.LanguageModel
+}
+
 type manualTitleGenerationError struct {
 	cause       error
 	modelConfig database.ChatModelConfig
@@ -3089,47 +3099,124 @@ func (p *Server) generateManualTitleCandidate(
 		return manualTitleCandidateResult{}, nil
 	}
 
-	model, modelConfig, err := p.resolveManualTitleModel(ctx, store, chat, keys)
+	inputs, ok := buildManualTitlePromptInputs(messages)
+	if !ok {
+		return manualTitleCandidateResult{hasMessages: true}, nil
+	}
+
+	candidates, err := p.resolveManualTitleCandidates(ctx, store, chat, keys)
+	if err != nil {
+		return manualTitleCandidateResult{hasMessages: true}, err
+	}
+
+	overallCtx, overallCancel := context.WithTimeout(ctx, manualTitleTotalTimeout)
+	defer overallCancel()
+
+	debugSvc := p.debugService()
+	var prepDebug manualTitleDebugPrepFn
+	if debugSvc != nil && debugSvc.IsEnabled(ctx, chat.ID, chat.OwnerID) {
+		prepDebug = func(c context.Context, cand manualTitleCandidate) (context.Context, fantasy.LanguageModel, func(error)) {
+			return p.prepareManualTitleDebugRun(c, debugSvc, chat, cand.config, keys, messages, cand.model)
+		}
+	}
+
+	return walkManualTitleCandidates(overallCtx, inputs, candidates, prepDebug)
+}
+
+// manualTitleDebugPrepFn wraps prepareManualTitleDebugRun for a
+// single candidate. The candidate walk uses it to opt each attempt
+// into debug instrumentation; passing nil disables debug wiring.
+type manualTitleDebugPrepFn func(
+	ctx context.Context,
+	cand manualTitleCandidate,
+) (context.Context, fantasy.LanguageModel, func(error))
+
+// walkManualTitleCandidates issues a structured-title call against
+// each candidate in order, falling through on per-attempt timeouts
+// and retryable provider errors. The first successful candidate
+// wins. On final failure it preserves the last attempt's usage so
+// callers can record the spend.
+func walkManualTitleCandidates(
+	ctx context.Context,
+	inputs manualTitlePromptInputs,
+	candidates []manualTitleCandidate,
+	prepDebug manualTitleDebugPrepFn,
+) (manualTitleCandidateResult, error) {
+	var (
+		lastErr    error
+		lastConfig database.ChatModelConfig
+		lastUsage  fantasy.Usage
+	)
+	for i, cand := range candidates {
+		// If the overall budget is exhausted or the parent context
+		// was canceled, stop walking before issuing another model
+		// call.
+		if ctx.Err() != nil {
+			break
+		}
+
+		titleCtx := ctx
+		titleModel := cand.model
+		finishDebugRun := func(error) {}
+		if prepDebug != nil {
+			titleCtx, titleModel, finishDebugRun = prepDebug(ctx, cand)
+		}
+
+		title, usage, genErr := generateManualTitleOnce(titleCtx, inputs, titleModel)
+		finishDebugRun(genErr)
+
+		if genErr == nil {
+			return manualTitleCandidateResult{
+				title:       title,
+				modelConfig: cand.config,
+				usage:       usage,
+				hasMessages: true,
+			}, nil
+		}
+
+		lastErr = xerrors.Errorf("generate manual title: %w", genErr)
+		lastConfig = cand.config
+		lastUsage = usage
+
+		// If the user canceled the parent context, or the overall
+		// budget elapsed mid-attempt, stop walking and surface the
+		// underlying error so the handler can translate it into
+		// 499/504.
+		if ctx.Err() != nil {
+			break
+		}
+		if i == len(candidates)-1 {
+			break
+		}
+		// Per-attempt timeout: try the next candidate.
+		if errors.Is(genErr, context.DeadlineExceeded) {
+			continue
+		}
+		// Anything chatretry classifies as retryable (rate limit,
+		// overloaded, transient 5xx, etc.) is worth re-trying on the
+		// next provider; non-retryable provider errors (auth/config)
+		// are not.
+		if !chatretry.IsRetryable(genErr) {
+			break
+		}
+	}
+
 	result := manualTitleCandidateResult{
-		modelConfig: modelConfig,
+		modelConfig: lastConfig,
+		usage:       lastUsage,
 		hasMessages: true,
 	}
-	if err != nil {
-		return result, err
+	if lastErr == nil {
+		return result, nil
 	}
-
-	titleCtx := ctx
-	titleModel := model
-	finishDebugRun := func(error) {}
-	if debugSvc := p.debugService(); debugSvc != nil && debugSvc.IsEnabled(ctx, chat.ID, chat.OwnerID) {
-		titleCtx, titleModel, finishDebugRun = p.prepareManualTitleDebugRun(
-			ctx,
-			debugSvc,
-			chat,
-			modelConfig,
-			keys,
-			messages,
-			model,
-		)
+	if lastUsage == (fantasy.Usage{}) {
+		return result, lastErr
 	}
-
-	title, usage, err := generateManualTitle(titleCtx, messages, titleModel)
-	finishDebugRun(err)
-	result.title = title
-	result.usage = usage
-	if err != nil {
-		wrappedErr := xerrors.Errorf("generate manual title: %w", err)
-		if usage == (fantasy.Usage{}) {
-			return result, wrappedErr
-		}
-		return result, &manualTitleGenerationError{
-			cause:       wrappedErr,
-			modelConfig: modelConfig,
-			usage:       usage,
-		}
+	return result, &manualTitleGenerationError{
+		cause:       lastErr,
+		modelConfig: lastConfig,
+		usage:       lastUsage,
 	}
-
-	return result, nil
 }
 
 func (p *Server) proposeChatTitleWithStore(
@@ -3523,6 +3610,102 @@ func (p *Server) resolveManualTitleModel(
 	}
 
 	return model, config, nil
+}
+
+// resolveManualTitleCandidates returns the ordered list of model
+// candidates to try for manual title generation. When a deployment
+// override is set we honor it exclusively (same semantics as the
+// auto-title path). Otherwise we iterate every enabled, preferred
+// short-text model the user has credentials for, and append the
+// chat's own model as a last resort. Duplicates are dropped.
+func (p *Server) resolveManualTitleCandidates(
+	ctx context.Context,
+	store database.Store,
+	chat database.Chat,
+	keys chatprovider.ProviderAPIKeys,
+) ([]manualTitleCandidate, error) {
+	overrideConfig, overrideModel, overrideSet, overrideErr := p.resolveTitleGenerationModelOverride(
+		ctx,
+		chat,
+		keys,
+	)
+	if overrideErr != nil {
+		if overrideSet {
+			return nil, xerrors.Errorf(
+				"resolve manual title generation model override: %w",
+				overrideErr,
+			)
+		}
+		p.logger.Debug(ctx, "failed to resolve title generation model override for manual title",
+			slog.F("chat_id", chat.ID),
+			slog.Error(overrideErr),
+		)
+	} else if overrideSet {
+		return []manualTitleCandidate{{
+			config: overrideConfig,
+			model:  overrideModel,
+		}}, nil
+	}
+
+	candidates := make([]manualTitleCandidate, 0, len(preferredTitleModels)+1)
+	seen := make(map[uuid.UUID]bool, len(preferredTitleModels)+1)
+
+	configs, configsErr := store.GetEnabledChatModelConfigs(ctx)
+	if configsErr != nil {
+		p.logger.Debug(ctx, "failed to list manual title model configs",
+			slog.F("chat_id", chat.ID),
+			slog.Error(configsErr),
+		)
+	} else {
+		for _, cfg := range selectAllConfiguredShortTextModelConfigs(configs) {
+			if seen[cfg.ID] {
+				continue
+			}
+			model, err := chatprovider.ModelFromConfig(
+				cfg.Provider,
+				cfg.Model,
+				keys,
+				chatprovider.UserAgent(),
+				chatprovider.CoderHeaders(chat),
+				nil,
+			)
+			if err != nil {
+				p.logger.Debug(ctx, "manual title preferred model unavailable",
+					slog.F("chat_id", chat.ID),
+					slog.F("provider", cfg.Provider),
+					slog.F("model", cfg.Model),
+					slog.Error(err),
+				)
+				continue
+			}
+			seen[cfg.ID] = true
+			candidates = append(candidates, manualTitleCandidate{
+				config: cfg,
+				model:  model,
+			})
+		}
+	}
+
+	fallbackModel, fallbackConfig, fallbackErr := p.resolveFallbackManualTitleModel(ctx, chat, keys)
+	switch {
+	case fallbackErr == nil && !seen[fallbackConfig.ID]:
+		candidates = append(candidates, manualTitleCandidate{
+			config: fallbackConfig,
+			model:  fallbackModel,
+		})
+	case fallbackErr != nil && len(candidates) == 0:
+		return nil, fallbackErr
+	case fallbackErr != nil:
+		p.logger.Debug(ctx, "manual title fallback model unavailable; relying on preferred candidates",
+			slog.F("chat_id", chat.ID),
+			slog.Error(fallbackErr),
+		)
+	}
+
+	if len(candidates) == 0 {
+		return nil, xerrors.New("no manual title model candidates available")
+	}
+	return candidates, nil
 }
 
 func (p *Server) resolveFallbackManualTitleModel(

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -3150,8 +3150,13 @@ func walkManualTitleCandidates(
 	for i, cand := range candidates {
 		// If the overall budget is exhausted or the parent context
 		// was canceled, stop walking before issuing another model
-		// call.
-		if ctx.Err() != nil {
+		// call. Surface ctx.Err() so the handler can translate
+		// pre-loop cancellation/timeout into 499/504 rather than
+		// silently returning an empty title.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			if lastErr == nil {
+				lastErr = ctxErr
+			}
 			break
 		}
 

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -2802,15 +2802,12 @@ type manualTitleCandidateResult struct {
 	hasMessages bool
 }
 
-// manualTitleCandidate pairs a usable language model with the
-// database config row used for usage accounting. The candidate walk
-// in generateManualTitleCandidate iterates these in order, falling
-// through to the next one on retryable or per-attempt-timeout
-// failures.
-type manualTitleCandidate struct {
-	config database.ChatModelConfig
-	model  fantasy.LanguageModel
-}
+// The manual title candidate walk uses the shared titleCandidate
+// type from titlewalk.go. configID on a manual-title candidate is
+// always set because manual generation needs the ChatModelConfig
+// for usage accounting (recordManualTitleUsage). The caller keeps
+// an indexed []database.ChatModelConfig alongside the candidates
+// to look up the winning config after the walk returns.
 
 type manualTitleGenerationError struct {
 	cause       error
@@ -3104,124 +3101,108 @@ func (p *Server) generateManualTitleCandidate(
 		return manualTitleCandidateResult{hasMessages: true}, nil
 	}
 
-	candidates, err := p.resolveManualTitleCandidates(ctx, store, chat, keys)
+	candidates, configs, err := p.resolveManualTitleCandidates(ctx, store, chat, keys)
 	if err != nil {
 		return manualTitleCandidateResult{hasMessages: true}, err
 	}
 
-	overallCtx, overallCancel := context.WithTimeout(ctx, manualTitleTotalTimeout)
+	overallCtx, overallCancel := context.WithTimeout(ctx, titleOverallTimeout)
 	defer overallCancel()
 
 	debugSvc := p.debugService()
-	var prepDebug manualTitleDebugPrepFn
-	if debugSvc != nil && debugSvc.IsEnabled(ctx, chat.ID, chat.OwnerID) {
-		prepDebug = func(c context.Context, cand manualTitleCandidate) (context.Context, fantasy.LanguageModel, func(error)) {
-			return p.prepareManualTitleDebugRun(c, debugSvc, chat, cand.config, keys, messages, cand.model)
-		}
+	debugEnabled := debugSvc != nil && debugSvc.IsEnabled(ctx, chat.ID, chat.OwnerID)
+
+	// generateStructuredTitleWithUsage can return non-zero usage
+	// even on error (e.g. validateGeneratedTitle rejects an empty
+	// title after the model billed for tokens), and the caller
+	// needs that usage on final failure to record the spend.
+	// Closure-capture it from attempt and look up the matching
+	// config via the candidate index.
+	type manualTitleAttemptResult struct {
+		title string
+		usage fantasy.Usage
 	}
+	var lastUsage fantasy.Usage
 
-	return walkManualTitleCandidates(overallCtx, inputs, candidates, prepDebug)
-}
-
-// manualTitleDebugPrepFn wraps prepareManualTitleDebugRun for a
-// single candidate. The candidate walk uses it to opt each attempt
-// into debug instrumentation; passing nil disables debug wiring.
-type manualTitleDebugPrepFn func(
-	ctx context.Context,
-	cand manualTitleCandidate,
-) (context.Context, fantasy.LanguageModel, func(error))
-
-// walkManualTitleCandidates issues a structured-title call against
-// each candidate in order, falling through on per-attempt timeouts
-// and retryable provider errors. The first successful candidate
-// wins. On final failure it preserves the last attempt's usage so
-// callers can record the spend.
-func walkManualTitleCandidates(
-	ctx context.Context,
-	inputs manualTitlePromptInputs,
-	candidates []manualTitleCandidate,
-	prepDebug manualTitleDebugPrepFn,
-) (manualTitleCandidateResult, error) {
-	var (
-		lastErr    error
-		lastConfig database.ChatModelConfig
-		lastUsage  fantasy.Usage
-	)
-	for i, cand := range candidates {
-		// If the overall budget is exhausted or the parent context
-		// was canceled, stop walking before issuing another model
-		// call. Surface ctx.Err() so the handler can translate
-		// pre-loop cancellation/timeout into 499/504 rather than
-		// silently returning an empty title.
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			if lastErr == nil {
-				lastErr = ctxErr
-			}
-			break
-		}
-
-		titleCtx := ctx
-		titleModel := cand.model
+	attempt := func(attemptCtx context.Context, cand titleCandidate) (manualTitleAttemptResult, error) {
+		// candidates and configs are parallel slices built by
+		// resolveManualTitleCandidates, so the debug-run wiring
+		// can recover the full ChatModelConfig (for ModelConfigID
+		// on the debug row) by indexing configs with the
+		// candidate's position. We look it up by configID rather
+		// than carrying the index because attempt is index-blind
+		// by design.
+		titleCtx := attemptCtx
+		titleModel := cand.lm
 		finishDebugRun := func(error) {}
-		if prepDebug != nil {
-			titleCtx, titleModel, finishDebugRun = prepDebug(ctx, cand)
+		if debugEnabled {
+			cfg := lookupManualTitleConfig(candidates, configs, cand)
+			titleCtx, titleModel, finishDebugRun = p.prepareManualTitleDebugRun(
+				attemptCtx, debugSvc, chat, cfg, keys, messages, cand.lm,
+			)
 		}
-
-		title, usage, genErr := generateManualTitleOnce(titleCtx, inputs, titleModel)
+		title, usage, genErr := generateStructuredTitleWithUsage(
+			titleCtx, titleModel, inputs.systemPrompt, inputs.userInput,
+		)
 		finishDebugRun(genErr)
-
-		if genErr == nil {
-			return manualTitleCandidateResult{
-				title:       title,
-				modelConfig: cand.config,
-				usage:       usage,
-				hasMessages: true,
-			}, nil
-		}
-
-		lastErr = xerrors.Errorf("generate manual title: %w", genErr)
-		lastConfig = cand.config
 		lastUsage = usage
-
-		// If the user canceled the parent context, or the overall
-		// budget elapsed mid-attempt, stop walking and surface the
-		// underlying error so the handler can translate it into
-		// 499/504.
-		if ctx.Err() != nil {
-			break
+		if genErr != nil {
+			return manualTitleAttemptResult{}, xerrors.Errorf("generate manual title: %w", genErr)
 		}
-		if i == len(candidates)-1 {
-			break
-		}
-		// Per-attempt timeout: try the next candidate.
-		if errors.Is(genErr, context.DeadlineExceeded) {
-			continue
-		}
-		// Anything chatretry classifies as retryable (rate limit,
-		// overloaded, transient 5xx, etc.) is worth re-trying on the
-		// next provider; non-retryable provider errors (auth/config)
-		// are not.
-		if !chatretry.IsRetryable(genErr) {
-			break
-		}
+		return manualTitleAttemptResult{title: title, usage: usage}, nil
 	}
 
+	res, idx, walkErr := walkTitleCandidates(overallCtx, candidates, titleWalkConfig{
+		perAttempt:        titleAttemptTimeout,
+		shouldFallThrough: retryableOrTimeoutFallThrough,
+	}, attempt)
+	if walkErr == nil {
+		return manualTitleCandidateResult{
+			title:       res.title,
+			modelConfig: configs[idx],
+			usage:       res.usage,
+			hasMessages: true,
+		}, nil
+	}
+
+	var lastConfig database.ChatModelConfig
+	if idx >= 0 && idx < len(configs) {
+		lastConfig = configs[idx]
+	}
 	result := manualTitleCandidateResult{
 		modelConfig: lastConfig,
 		usage:       lastUsage,
 		hasMessages: true,
 	}
-	if lastErr == nil {
-		return result, nil
-	}
 	if lastUsage == (fantasy.Usage{}) {
-		return result, lastErr
+		return result, walkErr
 	}
 	return result, &manualTitleGenerationError{
-		cause:       lastErr,
+		cause:       walkErr,
 		modelConfig: lastConfig,
 		usage:       lastUsage,
 	}
+}
+
+// lookupManualTitleConfig finds the ChatModelConfig that produced
+// the given candidate by matching configID across the parallel
+// candidates/configs slices. Used by manual title debug
+// instrumentation which needs the full config row to set
+// ModelConfigID on the debug run.
+func lookupManualTitleConfig(
+	candidates []titleCandidate,
+	configs []database.ChatModelConfig,
+	cand titleCandidate,
+) database.ChatModelConfig {
+	if !cand.configID.Valid {
+		return database.ChatModelConfig{}
+	}
+	for i, c := range candidates {
+		if c.configID == cand.configID {
+			return configs[i]
+		}
+	}
+	return database.ChatModelConfig{}
 }
 
 func (p *Server) proposeChatTitleWithStore(
@@ -3556,79 +3537,24 @@ func prepareChatTurnDebugRun(
 	return runCtx, finishDebugRun
 }
 
-func (p *Server) resolveManualTitleModel(
-	ctx context.Context,
-	store database.Store,
-	chat database.Chat,
-	keys chatprovider.ProviderAPIKeys,
-) (fantasy.LanguageModel, database.ChatModelConfig, error) {
-	overrideConfig, overrideModel, overrideSet, overrideErr := p.resolveTitleGenerationModelOverride(
-		ctx,
-		chat,
-		keys,
-	)
-	if overrideErr != nil {
-		if overrideSet {
-			return nil, database.ChatModelConfig{}, xerrors.Errorf(
-				"resolve manual title generation model override: %w",
-				overrideErr,
-			)
-		}
-		p.logger.Debug(ctx, "failed to resolve title generation model override for manual title",
-			slog.F("chat_id", chat.ID),
-			slog.Error(overrideErr),
-		)
-	} else if overrideSet {
-		return overrideModel, overrideConfig, nil
-	}
-
-	configs, err := store.GetEnabledChatModelConfigs(ctx)
-	if err != nil {
-		p.logger.Debug(ctx, "failed to list manual title model configs",
-			slog.F("chat_id", chat.ID),
-			slog.Error(err),
-		)
-		return p.resolveFallbackManualTitleModel(ctx, chat, keys)
-	}
-
-	config, ok := selectPreferredConfiguredShortTextModelConfig(configs)
-	if !ok {
-		return p.resolveFallbackManualTitleModel(ctx, chat, keys)
-	}
-
-	model, err := chatprovider.ModelFromConfig(
-		config.Provider,
-		config.Model,
-		keys,
-		chatprovider.UserAgent(),
-		chatprovider.CoderHeaders(chat),
-		nil,
-	)
-	if err != nil {
-		p.logger.Debug(ctx, "manual title preferred model unavailable",
-			slog.F("chat_id", chat.ID),
-			slog.F("provider", config.Provider),
-			slog.F("model", config.Model),
-			slog.Error(err),
-		)
-		return p.resolveFallbackManualTitleModel(ctx, chat, keys)
-	}
-
-	return model, config, nil
-}
-
 // resolveManualTitleCandidates returns the ordered list of model
 // candidates to try for manual title generation. When a deployment
 // override is set we honor it exclusively (same semantics as the
 // auto-title path). Otherwise we iterate every enabled, preferred
 // short-text model the user has credentials for, and append the
 // chat's own model as a last resort. Duplicates are dropped.
+//
+// The configs slice is a parallel-indexed companion: configs[i] is
+// the ChatModelConfig that produced candidates[i]. Manual title
+// usage accounting needs the full config row (provider, model,
+// options, cost), so it would be wasteful to look it up from
+// configID a second time after the walk picks a winner.
 func (p *Server) resolveManualTitleCandidates(
 	ctx context.Context,
 	store database.Store,
 	chat database.Chat,
 	keys chatprovider.ProviderAPIKeys,
-) ([]manualTitleCandidate, error) {
+) ([]titleCandidate, []database.ChatModelConfig, error) {
 	overrideConfig, overrideModel, overrideSet, overrideErr := p.resolveTitleGenerationModelOverride(
 		ctx,
 		chat,
@@ -3636,7 +3562,7 @@ func (p *Server) resolveManualTitleCandidates(
 	)
 	if overrideErr != nil {
 		if overrideSet {
-			return nil, xerrors.Errorf(
+			return nil, nil, xerrors.Errorf(
 				"resolve manual title generation model override: %w",
 				overrideErr,
 			)
@@ -3646,23 +3572,26 @@ func (p *Server) resolveManualTitleCandidates(
 			slog.Error(overrideErr),
 		)
 	} else if overrideSet {
-		return []manualTitleCandidate{{
-			config: overrideConfig,
-			model:  overrideModel,
-		}}, nil
+		return []titleCandidate{{
+			configID: uuid.NullUUID{UUID: overrideConfig.ID, Valid: true},
+			provider: overrideConfig.Provider,
+			model:    overrideConfig.Model,
+			lm:       overrideModel,
+		}}, []database.ChatModelConfig{overrideConfig}, nil
 	}
 
-	candidates := make([]manualTitleCandidate, 0, len(preferredTitleModels)+1)
+	candidates := make([]titleCandidate, 0, len(preferredTitleModels)+1)
+	configs := make([]database.ChatModelConfig, 0, len(preferredTitleModels)+1)
 	seen := make(map[uuid.UUID]bool, len(preferredTitleModels)+1)
 
-	configs, configsErr := store.GetEnabledChatModelConfigs(ctx)
+	dbConfigs, configsErr := store.GetEnabledChatModelConfigs(ctx)
 	if configsErr != nil {
 		p.logger.Debug(ctx, "failed to list manual title model configs",
 			slog.F("chat_id", chat.ID),
 			slog.Error(configsErr),
 		)
 	} else {
-		for _, cfg := range selectAllConfiguredShortTextModelConfigs(configs) {
+		for _, cfg := range selectAllConfiguredShortTextModelConfigs(dbConfigs) {
 			if seen[cfg.ID] {
 				continue
 			}
@@ -3684,22 +3613,28 @@ func (p *Server) resolveManualTitleCandidates(
 				continue
 			}
 			seen[cfg.ID] = true
-			candidates = append(candidates, manualTitleCandidate{
-				config: cfg,
-				model:  model,
+			candidates = append(candidates, titleCandidate{
+				configID: uuid.NullUUID{UUID: cfg.ID, Valid: true},
+				provider: cfg.Provider,
+				model:    cfg.Model,
+				lm:       model,
 			})
+			configs = append(configs, cfg)
 		}
 	}
 
 	fallbackModel, fallbackConfig, fallbackErr := p.resolveFallbackManualTitleModel(ctx, chat, keys)
 	switch {
 	case fallbackErr == nil && !seen[fallbackConfig.ID]:
-		candidates = append(candidates, manualTitleCandidate{
-			config: fallbackConfig,
-			model:  fallbackModel,
+		candidates = append(candidates, titleCandidate{
+			configID: uuid.NullUUID{UUID: fallbackConfig.ID, Valid: true},
+			provider: fallbackConfig.Provider,
+			model:    fallbackConfig.Model,
+			lm:       fallbackModel,
 		})
+		configs = append(configs, fallbackConfig)
 	case fallbackErr != nil && len(candidates) == 0:
-		return nil, fallbackErr
+		return nil, nil, fallbackErr
 	case fallbackErr != nil:
 		p.logger.Debug(ctx, "manual title fallback model unavailable; relying on preferred candidates",
 			slog.F("chat_id", chat.ID),
@@ -3708,9 +3643,9 @@ func (p *Server) resolveManualTitleCandidates(
 	}
 
 	if len(candidates) == 0 {
-		return nil, xerrors.New("no manual title model candidates available")
+		return nil, nil, xerrors.New("no manual title model candidates available")
 	}
-	return candidates, nil
+	return candidates, configs, nil
 }
 
 func (p *Server) resolveFallbackManualTitleModel(

--- a/coderd/x/chatd/quickgen.go
+++ b/coderd/x/chatd/quickgen.go
@@ -46,6 +46,15 @@ const (
 	// recentTurnWindow is the number of most recent turns included
 	// alongside the first user turn in manual title context.
 	recentTurnWindow = 3
+	// manualTitleAttemptTimeout bounds a single model call during
+	// manual title generation. The auto-title path uses the same value
+	// for its single attempt.
+	manualTitleAttemptTimeout = 30 * time.Second
+	// manualTitleTotalTimeout bounds the entire candidate walk for a
+	// manual title request. Tuned to allow three per-attempt timeouts
+	// to elapse without exceeding the budget, so transient slowness on
+	// one provider lets us reach a faster one.
+	manualTitleTotalTimeout = 90 * time.Second
 )
 
 // preferredTitleModels are lightweight models used for title
@@ -87,6 +96,31 @@ func selectPreferredConfiguredShortTextModelConfig(
 		}
 	}
 	return database.ChatModelConfig{}, false
+}
+
+// selectAllConfiguredShortTextModelConfigs returns every enabled model
+// config that matches a preferredTitleModels entry, ordered by the
+// preferredTitleModels list. Each (provider, model) pair appears at
+// most once. The manual title candidate walk uses this so a slow or
+// unavailable provider falls back to another configured one before
+// dropping to the chat's own model.
+func selectAllConfiguredShortTextModelConfigs(
+	configs []database.ChatModelConfig,
+) []database.ChatModelConfig {
+	out := make([]database.ChatModelConfig, 0, len(preferredTitleModels))
+	for _, preferred := range preferredTitleModels {
+		for _, config := range configs {
+			if chatprovider.NormalizeProvider(config.Provider) != preferred.provider {
+				continue
+			}
+			if !strings.EqualFold(strings.TrimSpace(config.Model), preferred.model) {
+				continue
+			}
+			out = append(out, config)
+			break
+		}
+	}
+	return out
 }
 
 func normalizeShortTextOutput(text string) string {
@@ -762,11 +796,21 @@ func renderManualTitlePrompt(
 	return prompt.String()
 }
 
-func generateManualTitle(
-	ctx context.Context,
+// manualTitlePromptInputs holds the rendered system prompt and user
+// input for a manual title generation. The candidate walk computes
+// these once and reuses them across attempts.
+type manualTitlePromptInputs struct {
+	systemPrompt string
+	userInput    string
+}
+
+// buildManualTitlePromptInputs renders the prompt pieces for a manual
+// title generation. It returns ok=false when there is no user message
+// to summarize, so the caller can short-circuit without contacting a
+// model.
+func buildManualTitlePromptInputs(
 	messages []database.ChatMessage,
-	fallbackModel fantasy.LanguageModel,
-) (string, fantasy.Usage, error) {
+) (manualTitlePromptInputs, bool) {
 	turns := extractManualTitleTurns(messages)
 	selected := selectManualTitleTurnIndexes(turns)
 
@@ -774,7 +818,7 @@ func generateManualTitle(
 		return turn.role == string(database.ChatMessageRoleUser)
 	})
 	if firstUserIndex == -1 {
-		return "", fantasy.Usage{}, nil
+		return manualTitlePromptInputs{}, false
 	}
 	firstUserText := truncateRunes(turns[firstUserIndex].text, maxLatestUserMessageRunes)
 
@@ -785,20 +829,45 @@ func generateManualTitle(
 		latestUserMsg,
 	)
 
-	titleCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
 	userInput := strings.TrimSpace(latestUserMsg)
 	if userInput == "" {
 		userInput = strings.TrimSpace(firstUserText)
 	}
+	return manualTitlePromptInputs{
+		systemPrompt: systemPrompt,
+		userInput:    userInput,
+	}, true
+}
 
-	title, usage, err := generateStructuredTitleWithUsage(
-		titleCtx,
-		fallbackModel,
-		systemPrompt,
-		userInput,
+// generateManualTitleOnce performs one structured-title call against
+// the given model, applying the per-attempt deadline so a stuck or
+// slow provider cannot consume the full manual title budget.
+func generateManualTitleOnce(
+	ctx context.Context,
+	inputs manualTitlePromptInputs,
+	model fantasy.LanguageModel,
+) (string, fantasy.Usage, error) {
+	attemptCtx, cancel := context.WithTimeout(ctx, manualTitleAttemptTimeout)
+	defer cancel()
+	return generateStructuredTitleWithUsage(
+		attemptCtx,
+		model,
+		inputs.systemPrompt,
+		inputs.userInput,
 	)
+}
+
+func generateManualTitle(
+	ctx context.Context,
+	messages []database.ChatMessage,
+	fallbackModel fantasy.LanguageModel,
+) (string, fantasy.Usage, error) {
+	inputs, ok := buildManualTitlePromptInputs(messages)
+	if !ok {
+		return "", fantasy.Usage{}, nil
+	}
+
+	title, usage, err := generateManualTitleOnce(ctx, inputs, fallbackModel)
 	if err != nil {
 		return "", usage, err
 	}

--- a/coderd/x/chatd/quickgen.go
+++ b/coderd/x/chatd/quickgen.go
@@ -18,6 +18,7 @@ import (
 	fantasyopenai "charm.land/fantasy/providers/openai"
 	fantasyopenrouter "charm.land/fantasy/providers/openrouter"
 	fantasyvercel "charm.land/fantasy/providers/vercel"
+	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
@@ -46,15 +47,6 @@ const (
 	// recentTurnWindow is the number of most recent turns included
 	// alongside the first user turn in manual title context.
 	recentTurnWindow = 3
-	// manualTitleAttemptTimeout bounds a single model call during
-	// manual title generation. The auto-title path uses the same value
-	// for its single attempt.
-	manualTitleAttemptTimeout = 30 * time.Second
-	// manualTitleTotalTimeout bounds the entire candidate walk for a
-	// manual title request. Tuned to allow three per-attempt timeouts
-	// to elapse without exceeding the budget, so transient slowness on
-	// one provider lets us reach a faster one.
-	manualTitleTotalTimeout = 90 * time.Second
 )
 
 // preferredTitleModels are lightweight models used for title
@@ -73,29 +65,6 @@ var preferredTitleModels = []struct {
 	{fantasybedrock.Name, "anthropic.claude-haiku-4-5-20251001-v1:0"},
 	{fantasyopenrouter.Name, "anthropic/claude-3.5-haiku"},
 	{fantasyvercel.Name, "anthropic/claude-haiku-4.5"},
-}
-
-type shortTextCandidate struct {
-	provider string
-	model    string
-	lm       fantasy.LanguageModel
-}
-
-func selectPreferredConfiguredShortTextModelConfig(
-	configs []database.ChatModelConfig,
-) (database.ChatModelConfig, bool) {
-	for _, preferred := range preferredTitleModels {
-		for _, config := range configs {
-			if chatprovider.NormalizeProvider(config.Provider) != preferred.provider {
-				continue
-			}
-			if !strings.EqualFold(strings.TrimSpace(config.Model), preferred.model) {
-				continue
-			}
-			return config, true
-		}
-	}
-	return database.ChatModelConfig{}, false
 }
 
 // selectAllConfiguredShortTextModelConfigs returns every enabled model
@@ -166,7 +135,7 @@ func (p *Server) maybeGenerateChatTitle(
 	}
 	debugEnabled := debugSvc != nil && debugSvc.IsEnabled(ctx, chat.ID, chat.OwnerID)
 
-	titleCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	titleCtx, cancel := context.WithTimeout(ctx, titleOverallTimeout)
 	defer cancel()
 
 	overrideConfig, overrideModel, overrideSet, overrideErr := p.resolveTitleGenerationModelOverride(
@@ -190,17 +159,22 @@ func (p *Server) maybeGenerateChatTitle(
 		)
 	}
 
-	var candidates []shortTextCandidate
+	var candidates []titleCandidate
 	if overrideSet {
-		candidates = []shortTextCandidate{{
+		candidates = []titleCandidate{{
+			configID: uuid.NullUUID{UUID: overrideConfig.ID, Valid: true},
 			provider: overrideConfig.Provider,
 			model:    overrideConfig.Model,
 			lm:       overrideModel,
 		}}
 	} else {
 		// Build candidate list: preferred lightweight models first,
-		// then the user's chat model as last resort.
-		candidates = make([]shortTextCandidate, 0, len(preferredTitleModels)+1)
+		// then the user's chat model as last resort. preferredTitleModels
+		// entries don't carry a configID because they bypass the
+		// chat_model_configs lookup (auto title is best-effort and
+		// doesn't record usage), and the fallback also uses the chat's
+		// own model without an additional row lookup.
+		candidates = make([]titleCandidate, 0, len(preferredTitleModels)+1)
 		for _, c := range preferredTitleModels {
 			m, err := chatprovider.ModelFromConfig(
 				c.provider, c.model, keys, chatprovider.UserAgent(),
@@ -208,14 +182,14 @@ func (p *Server) maybeGenerateChatTitle(
 				nil,
 			)
 			if err == nil {
-				candidates = append(candidates, shortTextCandidate{
+				candidates = append(candidates, titleCandidate{
 					provider: c.provider,
 					model:    c.model,
 					lm:       m,
 				})
 			}
 		}
-		candidates = append(candidates, shortTextCandidate{
+		candidates = append(candidates, titleCandidate{
 			provider: fallbackProvider,
 			model:    fallbackModelName,
 			lm:       fallbackModel,
@@ -242,36 +216,30 @@ func (p *Server) maybeGenerateChatTitle(
 		chatdebug.TruncateLabel(input, chatdebug.MaxLabelLength),
 	)
 
-	var lastErr error
-	for _, candidate := range candidates {
-		candidateCtx := titleCtx
-		candidateModel := candidate.lm
+	attempt := func(attemptCtx context.Context, cand titleCandidate) (string, error) {
+		candidateCtx := attemptCtx
+		candidateModel := cand.lm
 		finishDebugRun := func(error) {}
 		if debugEnabled {
 			candidateCtx, candidateModel, finishDebugRun = prepareQuickgenDebugCandidate(
-				titleCtx,
-				chat,
-				keys,
-				debugSvc,
-				candidate,
+				attemptCtx, chat, keys, debugSvc, cand,
 				chatdebug.KindTitleGeneration,
-				triggerMessageID,
-				historyTipMessageID,
-				seedSummary,
-				logger,
+				triggerMessageID, historyTipMessageID, seedSummary, logger,
 			)
 		}
-
 		title, err := generateTitle(candidateCtx, candidateModel, input)
 		finishDebugRun(err)
 		if err != nil {
-			lastErr = err
+			// Per-candidate failure logging mirrors the prior
+			// implementation: the override path is admin-visible
+			// (so warn), while preferred/fallback rotations are
+			// best-effort (so debug).
 			if overrideSet {
 				logger.Warn(ctx, "title model candidate failed",
 					slog.F("chat_id", chat.ID),
 					slog.F("override_context", titleGenerationOverrideContext),
-					slog.F("provider", candidate.provider),
-					slog.F("model", candidate.model),
+					slog.F("provider", cand.provider),
+					slog.F("model", cand.model),
 					slog.Error(err),
 				)
 			} else {
@@ -280,47 +248,50 @@ func (p *Server) maybeGenerateChatTitle(
 					slog.Error(err),
 				)
 			}
-			continue
 		}
-		if title == "" || title == chat.Title {
-			return
-		}
-
-		_, err = p.db.UpdateChatTitleByID(ctx, database.UpdateChatTitleByIDParams{
-			ID:    chat.ID,
-			Title: title,
-		})
-		if err != nil {
-			logger.Warn(ctx, "failed to update generated chat title",
-				slog.F("chat_id", chat.ID),
-				slog.Error(err),
-			)
-			return
-		}
-		chat.Title = title
-		generatedTitle.Store(title)
-		p.publishChatPubsubEvent(chat, codersdk.ChatWatchEventKindTitleChange, nil)
-
-		// AcquireChats uses SKIP LOCKED; re-wake so a wake racing this
-		// UPDATE's row lock does not strand a freshly-pending chat.
-		p.signalWake()
-		return
+		return title, err
 	}
 
-	if lastErr != nil {
+	title, _, walkErr := walkTitleCandidates(titleCtx, candidates, titleWalkConfig{
+		perAttempt:        titleAttemptTimeout,
+		shouldFallThrough: alwaysFallThrough,
+	}, attempt)
+	if walkErr != nil {
 		if overrideSet {
 			logger.Warn(ctx, "all title model candidates failed",
 				slog.F("chat_id", chat.ID),
 				slog.F("override_context", titleGenerationOverrideContext),
-				slog.Error(lastErr),
+				slog.Error(walkErr),
 			)
 		} else {
 			logger.Debug(ctx, "all title model candidates failed",
 				slog.F("chat_id", chat.ID),
-				slog.Error(lastErr),
+				slog.Error(walkErr),
 			)
 		}
+		return
 	}
+	if title == "" || title == chat.Title {
+		return
+	}
+
+	if _, err := p.db.UpdateChatTitleByID(ctx, database.UpdateChatTitleByIDParams{
+		ID:    chat.ID,
+		Title: title,
+	}); err != nil {
+		logger.Warn(ctx, "failed to update generated chat title",
+			slog.F("chat_id", chat.ID),
+			slog.Error(err),
+		)
+		return
+	}
+	chat.Title = title
+	generatedTitle.Store(title)
+	p.publishChatPubsubEvent(chat, codersdk.ChatWatchEventKindTitleChange, nil)
+
+	// AcquireChats uses SKIP LOCKED; re-wake so a wake racing this
+	// UPDATE's row lock does not strand a freshly-pending chat.
+	p.signalWake()
 }
 
 func newQuickgenDebugModel(
@@ -363,7 +334,7 @@ func prepareQuickgenDebugCandidate(
 	chat database.Chat,
 	keys chatprovider.ProviderAPIKeys,
 	debugSvc *chatdebug.Service,
-	candidate shortTextCandidate,
+	candidate titleCandidate,
 	kind chatdebug.RunKind,
 	triggerMessageID int64,
 	historyTipMessageID int64,
@@ -394,15 +365,20 @@ func prepareQuickgenDebugCandidate(
 	}
 
 	// Debug instrumentation must not eat into the quickgen budget
-	// (30s titleCtx / summaryCtx on the caller). Detach and bound
-	// the insert so a slow DB can't delay title generation or push
+	// (titleAttemptTimeout on the caller). Detach and bound the
+	// insert so a slow DB can't delay title generation or push
 	// summaries, matching prepareManualTitleDebugRun,
 	// prepareChatTurnDebugRun, and startCompactionDebugRun.
 	createRunCtx, createRunCancel := context.WithTimeout(
 		context.WithoutCancel(ctx), debugCreateRunTimeout,
 	)
+	var modelConfigID uuid.UUID
+	if candidate.configID.Valid {
+		modelConfigID = candidate.configID.UUID
+	}
 	run, err := debugSvc.CreateRun(createRunCtx, chatdebug.CreateRunParams{
 		ChatID:              chat.ID,
+		ModelConfigID:       modelConfigID,
 		TriggerMessageID:    triggerMessageID,
 		HistoryTipMessageID: historyTipMessageID,
 		Kind:                kind,
@@ -428,6 +404,7 @@ func prepareQuickgenDebugCandidate(
 		&chatdebug.RunContext{
 			RunID:               run.ID,
 			ChatID:              chat.ID,
+			ModelConfigID:       modelConfigID,
 			TriggerMessageID:    triggerMessageID,
 			HistoryTipMessageID: historyTipMessageID,
 			Kind:                kind,
@@ -839,24 +816,12 @@ func buildManualTitlePromptInputs(
 	}, true
 }
 
-// generateManualTitleOnce performs one structured-title call against
-// the given model, applying the per-attempt deadline so a stuck or
-// slow provider cannot consume the full manual title budget.
-func generateManualTitleOnce(
-	ctx context.Context,
-	inputs manualTitlePromptInputs,
-	model fantasy.LanguageModel,
-) (string, fantasy.Usage, error) {
-	attemptCtx, cancel := context.WithTimeout(ctx, manualTitleAttemptTimeout)
-	defer cancel()
-	return generateStructuredTitleWithUsage(
-		attemptCtx,
-		model,
-		inputs.systemPrompt,
-		inputs.userInput,
-	)
-}
-
+// generateManualTitle is a test seam that runs the full
+// manual-title pipeline (prompt build + structured call) against a
+// single model. Production callers go through walkTitleCandidates
+// in generateManualTitleCandidate, which also owns the per-attempt
+// deadline; this helper bypasses that loop so tests can exercise
+// the prompt and structured-output handling in isolation.
 func generateManualTitle(
 	ctx context.Context,
 	messages []database.ChatMessage,
@@ -867,12 +832,14 @@ func generateManualTitle(
 		return "", fantasy.Usage{}, nil
 	}
 
-	title, usage, err := generateManualTitleOnce(ctx, inputs, fallbackModel)
-	if err != nil {
-		return "", usage, err
-	}
-
-	return title, usage, nil
+	attemptCtx, cancel := context.WithTimeout(ctx, titleAttemptTimeout)
+	defer cancel()
+	return generateStructuredTitleWithUsage(
+		attemptCtx,
+		fallbackModel,
+		inputs.systemPrompt,
+		inputs.userInput,
+	)
 }
 
 const turnStatusLabelPrompt = "You write compact chat status labels for a sidebar or push notification. " +
@@ -905,7 +872,7 @@ func generateTurnStatusLabel(
 ) string {
 	debugEnabled := debugSvc != nil && debugSvc.IsEnabled(ctx, chat.ID, chat.OwnerID)
 
-	labelCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	labelCtx, cancel := context.WithTimeout(ctx, titleOverallTimeout)
 	defer cancel()
 
 	assistantText = truncateRunes(assistantText, maxConversationContextRunes)
@@ -913,7 +880,7 @@ func generateTurnStatusLabel(
 		"\nChat title: " + chat.Title +
 		"\n\nAgent's latest message:\n" + assistantText
 
-	candidates := make([]shortTextCandidate, 0, len(preferredTitleModels)+1)
+	candidates := make([]titleCandidate, 0, len(preferredTitleModels)+1)
 	for _, c := range preferredTitleModels {
 		m, err := chatprovider.ModelFromConfig(
 			c.provider, c.model, keys, chatprovider.UserAgent(),
@@ -921,14 +888,14 @@ func generateTurnStatusLabel(
 			nil,
 		)
 		if err == nil {
-			candidates = append(candidates, shortTextCandidate{
+			candidates = append(candidates, titleCandidate{
 				provider: c.provider,
 				model:    c.model,
 				lm:       m,
 			})
 		}
 	}
-	candidates = append(candidates, shortTextCandidate{
+	candidates = append(candidates, titleCandidate{
 		provider: fallbackProvider,
 		model:    fallbackModelName,
 		lm:       fallbackModel,
@@ -936,41 +903,34 @@ func generateTurnStatusLabel(
 
 	statusSeedSummary := chatdebug.SeedSummary("Turn status label")
 
-	for _, candidate := range candidates {
-		candidateCtx := labelCtx
-		candidateModel := candidate.lm
+	attempt := func(attemptCtx context.Context, cand titleCandidate) (string, error) {
+		candidateCtx := attemptCtx
+		candidateModel := cand.lm
 		finishDebugRun := func(error) {}
 		if debugEnabled {
 			candidateCtx, candidateModel, finishDebugRun = prepareQuickgenDebugCandidate(
-				labelCtx,
-				chat,
-				keys,
-				debugSvc,
-				candidate,
+				attemptCtx, chat, keys, debugSvc, cand,
 				chatdebug.KindQuickgen,
-				triggerMessageID,
-				historyTipMessageID,
-				statusSeedSummary,
-				logger,
+				triggerMessageID, historyTipMessageID, statusSeedSummary, logger,
 			)
 		}
-
 		generatedLabel, err := generateStructuredTurnStatusLabel(
-			candidateCtx,
-			candidateModel,
-			turnStatusLabelPrompt,
-			input,
+			candidateCtx, candidateModel, turnStatusLabelPrompt, input,
 		)
 		finishDebugRun(err)
 		if err != nil {
 			logger.Debug(ctx, "turn status label model candidate failed",
 				slog.Error(err),
 			)
-			continue
 		}
-		return generatedLabel
+		return generatedLabel, err
 	}
-	return ""
+
+	label, _, _ := walkTitleCandidates(labelCtx, candidates, titleWalkConfig{
+		perAttempt:        titleAttemptTimeout,
+		shouldFallThrough: alwaysFallThrough,
+	}, attempt)
+	return label
 }
 
 func generateStructuredTurnStatusLabel(

--- a/coderd/x/chatd/quickgen_test.go
+++ b/coderd/x/chatd/quickgen_test.go
@@ -8,8 +8,10 @@ import (
 	"time"
 
 	"charm.land/fantasy"
+	"github.com/google/uuid"
 	"github.com/sqlc-dev/pqtype"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
@@ -592,6 +594,228 @@ func Test_selectPreferredConfiguredShortTextModelConfig(t *testing.T) {
 		}})
 		require.False(t, ok)
 		require.Equal(t, database.ChatModelConfig{}, got)
+	})
+}
+
+func Test_walkManualTitleCandidates(t *testing.T) {
+	t.Parallel()
+
+	inputs := manualTitlePromptInputs{
+		systemPrompt: "system",
+		userInput:    "user",
+	}
+
+	// errCandidateUnreachable lets fatal-on-call candidates return a
+	// sentinel error from the unreachable path after t.Fatalf, which
+	// makes the linter happy without changing test semantics.
+	errCandidateUnreachable := xerrors.New("test: candidate must not be invoked")
+
+	newCandidate := func(provider, model string, fn func(ctx context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error)) manualTitleCandidate {
+		return manualTitleCandidate{
+			config: database.ChatModelConfig{
+				ID:       uuid.New(),
+				Provider: provider,
+				Model:    model,
+			},
+			model: &chattest.FakeModel{GenerateObjectFn: fn},
+		}
+	}
+
+	t.Run("FirstCandidateWins", func(t *testing.T) {
+		t.Parallel()
+
+		successCalls := 0
+		skipped := newCandidate("never", "called", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+			t.Fatalf("walkManualTitleCandidates must not advance past the first successful candidate")
+			return nil, errCandidateUnreachable
+		})
+		winner := newCandidate("openai", "gpt-4o-mini", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+			successCalls++
+			return &fantasy.ObjectResponse{
+				Object: map[string]any{"title": "First wins"},
+				Usage:  fantasy.Usage{InputTokens: 11, OutputTokens: 7, TotalTokens: 18},
+			}, nil
+		})
+
+		result, err := walkManualTitleCandidates(
+			context.Background(),
+			inputs,
+			[]manualTitleCandidate{winner, skipped},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Equal(t, "First wins", result.title)
+		require.Equal(t, winner.config, result.modelConfig)
+		require.Equal(t, int64(18), result.usage.TotalTokens)
+		require.True(t, result.hasMessages)
+		require.Equal(t, 1, successCalls)
+	})
+
+	t.Run("FallsThroughOnPerAttemptTimeout", func(t *testing.T) {
+		t.Parallel()
+
+		var firstCalls, secondCalls int
+		first := newCandidate("openai", "gpt-4o-mini", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+			firstCalls++
+			return nil, context.DeadlineExceeded
+		})
+		second := newCandidate("anthropic", "claude-haiku-4-5", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+			secondCalls++
+			return &fantasy.ObjectResponse{
+				Object: map[string]any{"title": "Second wins"},
+			}, nil
+		})
+
+		result, err := walkManualTitleCandidates(
+			context.Background(),
+			inputs,
+			[]manualTitleCandidate{first, second},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Equal(t, "Second wins", result.title)
+		require.Equal(t, second.config, result.modelConfig)
+		require.Equal(t, 1, firstCalls, "first candidate must be tried exactly once")
+		require.Equal(t, 1, secondCalls, "second candidate must be tried after the first times out")
+	})
+
+	t.Run("StopsOnNonRetryableProviderError", func(t *testing.T) {
+		t.Parallel()
+
+		// Auth failure is non-retryable: the walk must surface it
+		// instead of moving on to the next candidate.
+		authErr := xerrors.New("401 invalid_api_key")
+		first := newCandidate("openai", "gpt-4o-mini", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+			return nil, authErr
+		})
+		second := newCandidate("anthropic", "claude-haiku-4-5", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+			t.Fatalf("walkManualTitleCandidates must not fall through after a non-retryable error")
+			return nil, errCandidateUnreachable
+		})
+
+		_, err := walkManualTitleCandidates(
+			context.Background(),
+			inputs,
+			[]manualTitleCandidate{first, second},
+			nil,
+		)
+		require.Error(t, err)
+		require.ErrorIs(t, err, authErr)
+	})
+
+	t.Run("AllCandidatesTimeOutReturnsDeadlineErr", func(t *testing.T) {
+		t.Parallel()
+
+		first := newCandidate("openai", "gpt-4o-mini", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+			return nil, context.DeadlineExceeded
+		})
+		second := newCandidate("anthropic", "claude-haiku-4-5", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+			return nil, context.DeadlineExceeded
+		})
+
+		_, err := walkManualTitleCandidates(
+			context.Background(),
+			inputs,
+			[]manualTitleCandidate{first, second},
+			nil,
+		)
+		require.Error(t, err)
+		require.ErrorIs(t, err, context.DeadlineExceeded,
+			"all-deadlines path must preserve DeadlineExceeded so the handler can map it to 504")
+	})
+
+	t.Run("ParentCancelStopsWalk", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		var attempts int
+		first := newCandidate("openai", "gpt-4o-mini", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+			attempts++
+			cancel()
+			return nil, context.DeadlineExceeded
+		})
+		second := newCandidate("anthropic", "claude-haiku-4-5", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+			t.Fatalf("walkManualTitleCandidates must not start a new attempt after the parent context is canceled")
+			return nil, errCandidateUnreachable
+		})
+
+		_, err := walkManualTitleCandidates(
+			ctx,
+			inputs,
+			[]manualTitleCandidate{first, second},
+			nil,
+		)
+		require.Error(t, err)
+		require.Equal(t, 1, attempts)
+	})
+
+	t.Run("PreservesLastUsageOnFinalFailure", func(t *testing.T) {
+		t.Parallel()
+
+		// A model that returns usage along with a non-retryable
+		// error must surface that usage so the caller can record
+		// the spend, mirroring the previous single-model path.
+		first := newCandidate("openai", "gpt-4o-mini", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+			return &fantasy.ObjectResponse{
+				Object: map[string]any{"title": "\"\""},
+				Usage:  fantasy.Usage{InputTokens: 9, OutputTokens: 4, TotalTokens: 13},
+			}, nil
+		})
+		// The first candidate returns an empty title which the
+		// validation step rejects as non-retryable. The walk must
+		// surface its usage rather than overwriting it with the
+		// second candidate.
+		second := newCandidate("anthropic", "claude-haiku-4-5", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+			t.Fatalf("walkManualTitleCandidates must not fall through after a non-retryable validation error")
+			return nil, errCandidateUnreachable
+		})
+
+		_, err := walkManualTitleCandidates(
+			context.Background(),
+			inputs,
+			[]manualTitleCandidate{first, second},
+			nil,
+		)
+		require.Error(t, err)
+		var genErr *manualTitleGenerationError
+		require.ErrorAs(t, err, &genErr)
+		require.Equal(t, int64(13), genErr.usage.TotalTokens)
+		require.Equal(t, first.config, genErr.modelConfig)
+	})
+}
+
+func Test_selectAllConfiguredShortTextModelConfigs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns every matching preferred model in preferred order", func(t *testing.T) {
+		t.Parallel()
+
+		// Cover at least two preferred entries to verify ordering is
+		// driven by preferredTitleModels, not configs order.
+		configs := []database.ChatModelConfig{
+			{Provider: preferredTitleModels[2].provider, Model: preferredTitleModels[2].model},
+			{Provider: preferredTitleModels[0].provider, Model: preferredTitleModels[0].model},
+			{Provider: "openai", Model: "gpt-4.1"},
+		}
+
+		got := selectAllConfiguredShortTextModelConfigs(configs)
+		require.Len(t, got, 2)
+		require.Equal(t, preferredTitleModels[0].provider, got[0].Provider)
+		require.Equal(t, preferredTitleModels[0].model, got[0].Model)
+		require.Equal(t, preferredTitleModels[2].provider, got[1].Provider)
+		require.Equal(t, preferredTitleModels[2].model, got[1].Model)
+	})
+
+	t.Run("returns empty when no preferred lightweight model is configured", func(t *testing.T) {
+		t.Parallel()
+
+		got := selectAllConfiguredShortTextModelConfigs([]database.ChatModelConfig{{
+			Provider: "openai",
+			Model:    "gpt-4.1",
+		}})
+		require.Empty(t, got)
 	})
 }
 

--- a/coderd/x/chatd/quickgen_test.go
+++ b/coderd/x/chatd/quickgen_test.go
@@ -751,6 +751,34 @@ func Test_walkManualTitleCandidates(t *testing.T) {
 		require.Equal(t, 1, attempts)
 	})
 
+	t.Run("PreCanceledContextSurfacesCtxErr", func(t *testing.T) {
+		t.Parallel()
+
+		// Regression: if the parent context is canceled before the
+		// loop ever issues a model call, walkManualTitleCandidates
+		// must surface ctx.Err() so the handler can translate it
+		// into 499/504. Previously it broke out with lastErr==nil
+		// and the propose handler returned 200 with an empty
+		// title.
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		first := newCandidate("openai", "gpt-4o-mini", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+			t.Fatalf("walkManualTitleCandidates must not invoke any candidate when ctx is already canceled")
+			return nil, errCandidateUnreachable
+		})
+
+		result, err := walkManualTitleCandidates(
+			ctx,
+			inputs,
+			[]manualTitleCandidate{first},
+			nil,
+		)
+		require.Error(t, err)
+		require.ErrorIs(t, err, context.Canceled)
+		require.Empty(t, result.title)
+	})
+
 	t.Run("PreservesLastUsageOnFinalFailure", func(t *testing.T) {
 		t.Parallel()
 

--- a/coderd/x/chatd/quickgen_test.go
+++ b/coderd/x/chatd/quickgen_test.go
@@ -567,114 +567,75 @@ func Test_generateManualTitle_ReturnsUsageForEmptyNormalizedTitle(t *testing.T) 
 	require.Equal(t, int64(18), usage.TotalTokens)
 }
 
-func Test_selectPreferredConfiguredShortTextModelConfig(t *testing.T) {
+func Test_walkTitleCandidates(t *testing.T) {
 	t.Parallel()
 
-	t.Run("chooses the highest-priority configured lightweight model", func(t *testing.T) {
-		t.Parallel()
-
-		configs := []database.ChatModelConfig{
-			{Provider: preferredTitleModels[2].provider, Model: preferredTitleModels[2].model},
-			{Provider: preferredTitleModels[1].provider, Model: preferredTitleModels[1].model},
-			{Provider: "openai", Model: "gpt-4.1"},
-		}
-
-		got, ok := selectPreferredConfiguredShortTextModelConfig(configs)
-		require.True(t, ok)
-		require.Equal(t, preferredTitleModels[1].provider, got.Provider)
-		require.Equal(t, preferredTitleModels[1].model, got.Model)
-	})
-
-	t.Run("returns false when no preferred lightweight model is configured", func(t *testing.T) {
-		t.Parallel()
-
-		got, ok := selectPreferredConfiguredShortTextModelConfig([]database.ChatModelConfig{{
-			Provider: "openai",
-			Model:    "gpt-4.1",
-		}})
-		require.False(t, ok)
-		require.Equal(t, database.ChatModelConfig{}, got)
-	})
-}
-
-func Test_walkManualTitleCandidates(t *testing.T) {
-	t.Parallel()
-
-	inputs := manualTitlePromptInputs{
-		systemPrompt: "system",
-		userInput:    "user",
-	}
-
-	// errCandidateUnreachable lets fatal-on-call candidates return a
+	// errCandidateUnreachable lets fatal-on-call attempts return a
 	// sentinel error from the unreachable path after t.Fatalf, which
 	// makes the linter happy without changing test semantics.
 	errCandidateUnreachable := xerrors.New("test: candidate must not be invoked")
 
-	newCandidate := func(provider, model string, fn func(ctx context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error)) manualTitleCandidate {
-		return manualTitleCandidate{
-			config: database.ChatModelConfig{
-				ID:       uuid.New(),
-				Provider: provider,
-				Model:    model,
-			},
-			model: &chattest.FakeModel{GenerateObjectFn: fn},
+	newCandidate := func(provider, model string) titleCandidate {
+		return titleCandidate{
+			configID: uuid.NullUUID{UUID: uuid.New(), Valid: true},
+			provider: provider,
+			model:    model,
 		}
 	}
 
 	t.Run("FirstCandidateWins", func(t *testing.T) {
 		t.Parallel()
 
-		successCalls := 0
-		skipped := newCandidate("never", "called", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
-			t.Fatalf("walkManualTitleCandidates must not advance past the first successful candidate")
-			return nil, errCandidateUnreachable
-		})
-		winner := newCandidate("openai", "gpt-4o-mini", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
-			successCalls++
-			return &fantasy.ObjectResponse{
-				Object: map[string]any{"title": "First wins"},
-				Usage:  fantasy.Usage{InputTokens: 11, OutputTokens: 7, TotalTokens: 18},
-			}, nil
-		})
+		winner := newCandidate("openai", "gpt-4o-mini")
+		skipped := newCandidate("anthropic", "claude-haiku-4-5")
 
-		result, err := walkManualTitleCandidates(
+		var winnerCalls int
+		attempt := func(_ context.Context, c titleCandidate) (string, error) {
+			if c == skipped {
+				t.Fatalf("walkTitleCandidates must not advance past the first successful candidate")
+				return "", errCandidateUnreachable
+			}
+			winnerCalls++
+			return "First wins", nil
+		}
+
+		title, idx, err := walkTitleCandidates(
 			context.Background(),
-			inputs,
-			[]manualTitleCandidate{winner, skipped},
-			nil,
+			[]titleCandidate{winner, skipped},
+			titleWalkConfig{shouldFallThrough: alwaysFallThrough},
+			attempt,
 		)
 		require.NoError(t, err)
-		require.Equal(t, "First wins", result.title)
-		require.Equal(t, winner.config, result.modelConfig)
-		require.Equal(t, int64(18), result.usage.TotalTokens)
-		require.True(t, result.hasMessages)
-		require.Equal(t, 1, successCalls)
+		require.Equal(t, "First wins", title)
+		require.Equal(t, 0, idx)
+		require.Equal(t, 1, winnerCalls)
 	})
 
 	t.Run("FallsThroughOnPerAttemptTimeout", func(t *testing.T) {
 		t.Parallel()
 
-		var firstCalls, secondCalls int
-		first := newCandidate("openai", "gpt-4o-mini", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
-			firstCalls++
-			return nil, context.DeadlineExceeded
-		})
-		second := newCandidate("anthropic", "claude-haiku-4-5", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
-			secondCalls++
-			return &fantasy.ObjectResponse{
-				Object: map[string]any{"title": "Second wins"},
-			}, nil
-		})
+		first := newCandidate("openai", "gpt-4o-mini")
+		second := newCandidate("anthropic", "claude-haiku-4-5")
 
-		result, err := walkManualTitleCandidates(
+		var firstCalls, secondCalls int
+		attempt := func(_ context.Context, c titleCandidate) (string, error) {
+			if c == first {
+				firstCalls++
+				return "", context.DeadlineExceeded
+			}
+			secondCalls++
+			return "Second wins", nil
+		}
+
+		title, idx, err := walkTitleCandidates(
 			context.Background(),
-			inputs,
-			[]manualTitleCandidate{first, second},
-			nil,
+			[]titleCandidate{first, second},
+			titleWalkConfig{shouldFallThrough: retryableOrTimeoutFallThrough},
+			attempt,
 		)
 		require.NoError(t, err)
-		require.Equal(t, "Second wins", result.title)
-		require.Equal(t, second.config, result.modelConfig)
+		require.Equal(t, "Second wins", title)
+		require.Equal(t, 1, idx)
 		require.Equal(t, 1, firstCalls, "first candidate must be tried exactly once")
 		require.Equal(t, 1, secondCalls, "second candidate must be tried after the first times out")
 	})
@@ -682,44 +643,100 @@ func Test_walkManualTitleCandidates(t *testing.T) {
 	t.Run("StopsOnNonRetryableProviderError", func(t *testing.T) {
 		t.Parallel()
 
-		// Auth failure is non-retryable: the walk must surface it
+		// Auth failure is non-retryable under
+		// retryableOrTimeoutFallThrough: the walk must surface it
 		// instead of moving on to the next candidate.
 		authErr := xerrors.New("401 invalid_api_key")
-		first := newCandidate("openai", "gpt-4o-mini", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
-			return nil, authErr
-		})
-		second := newCandidate("anthropic", "claude-haiku-4-5", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
-			t.Fatalf("walkManualTitleCandidates must not fall through after a non-retryable error")
-			return nil, errCandidateUnreachable
-		})
+		first := newCandidate("openai", "gpt-4o-mini")
+		second := newCandidate("anthropic", "claude-haiku-4-5")
 
-		_, err := walkManualTitleCandidates(
+		attempt := func(_ context.Context, c titleCandidate) (string, error) {
+			if c == first {
+				return "", authErr
+			}
+			t.Fatalf("walkTitleCandidates must not fall through after a non-retryable error")
+			return "", errCandidateUnreachable
+		}
+
+		_, _, err := walkTitleCandidates(
 			context.Background(),
-			inputs,
-			[]manualTitleCandidate{first, second},
-			nil,
+			[]titleCandidate{first, second},
+			titleWalkConfig{shouldFallThrough: retryableOrTimeoutFallThrough},
+			attempt,
 		)
-		require.Error(t, err)
 		require.ErrorIs(t, err, authErr)
+	})
+
+	t.Run("AlwaysFallThroughIgnoresNonRetryableErrors", func(t *testing.T) {
+		t.Parallel()
+
+		// The auto-title / turn-status policy falls through even
+		// auth failures, matching their previous best-effort
+		// behavior.
+		first := newCandidate("openai", "gpt-4o-mini")
+		second := newCandidate("anthropic", "claude-haiku-4-5")
+
+		attempt := func(_ context.Context, c titleCandidate) (string, error) {
+			if c == first {
+				return "", xerrors.New("401 invalid_api_key")
+			}
+			return "Recovered", nil
+		}
+
+		title, idx, err := walkTitleCandidates(
+			context.Background(),
+			[]titleCandidate{first, second},
+			titleWalkConfig{shouldFallThrough: alwaysFallThrough},
+			attempt,
+		)
+		require.NoError(t, err)
+		require.Equal(t, "Recovered", title)
+		require.Equal(t, 1, idx)
+	})
+
+	t.Run("PerAttemptDeadlineDoesNotLeakToCallerCtx", func(t *testing.T) {
+		t.Parallel()
+
+		// Without a per-attempt deadline the caller's ctx governs.
+		// With one set, each candidate gets its own bounded
+		// attemptCtx. This test verifies the walker is honoring
+		// the per-attempt config by giving each attempt a deadline
+		// when configured, and not setting one otherwise.
+		first := newCandidate("openai", "gpt-4o-mini")
+		var firstDeadline time.Time
+		var firstHasDeadline bool
+		attempt := func(ctx context.Context, _ titleCandidate) (string, error) {
+			firstDeadline, firstHasDeadline = ctx.Deadline()
+			return "ok", nil
+		}
+
+		_, _, err := walkTitleCandidates(
+			context.Background(),
+			[]titleCandidate{first},
+			titleWalkConfig{perAttempt: 250 * time.Millisecond},
+			attempt,
+		)
+		require.NoError(t, err)
+		require.True(t, firstHasDeadline, "perAttempt > 0 must give attempt a deadline")
+		require.WithinDuration(t, time.Now().Add(250*time.Millisecond), firstDeadline, 100*time.Millisecond)
 	})
 
 	t.Run("AllCandidatesTimeOutReturnsDeadlineErr", func(t *testing.T) {
 		t.Parallel()
 
-		first := newCandidate("openai", "gpt-4o-mini", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
-			return nil, context.DeadlineExceeded
-		})
-		second := newCandidate("anthropic", "claude-haiku-4-5", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
-			return nil, context.DeadlineExceeded
-		})
+		first := newCandidate("openai", "gpt-4o-mini")
+		second := newCandidate("anthropic", "claude-haiku-4-5")
 
-		_, err := walkManualTitleCandidates(
+		attempt := func(_ context.Context, _ titleCandidate) (string, error) {
+			return "", context.DeadlineExceeded
+		}
+
+		_, _, err := walkTitleCandidates(
 			context.Background(),
-			inputs,
-			[]manualTitleCandidate{first, second},
-			nil,
+			[]titleCandidate{first, second},
+			titleWalkConfig{shouldFallThrough: retryableOrTimeoutFallThrough},
+			attempt,
 		)
-		require.Error(t, err)
 		require.ErrorIs(t, err, context.DeadlineExceeded,
 			"all-deadlines path must preserve DeadlineExceeded so the handler can map it to 504")
 	})
@@ -730,22 +747,25 @@ func Test_walkManualTitleCandidates(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
 
+		first := newCandidate("openai", "gpt-4o-mini")
+		second := newCandidate("anthropic", "claude-haiku-4-5")
+
 		var attempts int
-		first := newCandidate("openai", "gpt-4o-mini", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+		attempt := func(_ context.Context, c titleCandidate) (string, error) {
+			if c == second {
+				t.Fatalf("walkTitleCandidates must not start a new attempt after the parent context is canceled")
+				return "", errCandidateUnreachable
+			}
 			attempts++
 			cancel()
-			return nil, context.DeadlineExceeded
-		})
-		second := newCandidate("anthropic", "claude-haiku-4-5", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
-			t.Fatalf("walkManualTitleCandidates must not start a new attempt after the parent context is canceled")
-			return nil, errCandidateUnreachable
-		})
+			return "", context.DeadlineExceeded
+		}
 
-		_, err := walkManualTitleCandidates(
+		_, _, err := walkTitleCandidates(
 			ctx,
-			inputs,
-			[]manualTitleCandidate{first, second},
-			nil,
+			[]titleCandidate{first, second},
+			titleWalkConfig{shouldFallThrough: retryableOrTimeoutFallThrough},
+			attempt,
 		)
 		require.Error(t, err)
 		require.Equal(t, 1, attempts)
@@ -755,62 +775,27 @@ func Test_walkManualTitleCandidates(t *testing.T) {
 		t.Parallel()
 
 		// Regression: if the parent context is canceled before the
-		// loop ever issues a model call, walkManualTitleCandidates
-		// must surface ctx.Err() so the handler can translate it
-		// into 499/504. Previously it broke out with lastErr==nil
-		// and the propose handler returned 200 with an empty
-		// title.
+		// loop ever issues a model call, walkTitleCandidates must
+		// surface ctx.Err() so the handler can translate it into
+		// 499/504. Previously it broke out with lastErr==nil and
+		// the propose handler returned 200 with an empty title.
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		first := newCandidate("openai", "gpt-4o-mini", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
-			t.Fatalf("walkManualTitleCandidates must not invoke any candidate when ctx is already canceled")
-			return nil, errCandidateUnreachable
-		})
+		first := newCandidate("openai", "gpt-4o-mini")
+		attempt := func(_ context.Context, _ titleCandidate) (string, error) {
+			t.Fatalf("walkTitleCandidates must not invoke any candidate when ctx is already canceled")
+			return "", errCandidateUnreachable
+		}
 
-		result, err := walkManualTitleCandidates(
+		title, _, err := walkTitleCandidates(
 			ctx,
-			inputs,
-			[]manualTitleCandidate{first},
-			nil,
+			[]titleCandidate{first},
+			titleWalkConfig{shouldFallThrough: retryableOrTimeoutFallThrough},
+			attempt,
 		)
-		require.Error(t, err)
 		require.ErrorIs(t, err, context.Canceled)
-		require.Empty(t, result.title)
-	})
-
-	t.Run("PreservesLastUsageOnFinalFailure", func(t *testing.T) {
-		t.Parallel()
-
-		// A model that returns usage along with a non-retryable
-		// error must surface that usage so the caller can record
-		// the spend, mirroring the previous single-model path.
-		first := newCandidate("openai", "gpt-4o-mini", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
-			return &fantasy.ObjectResponse{
-				Object: map[string]any{"title": "\"\""},
-				Usage:  fantasy.Usage{InputTokens: 9, OutputTokens: 4, TotalTokens: 13},
-			}, nil
-		})
-		// The first candidate returns an empty title which the
-		// validation step rejects as non-retryable. The walk must
-		// surface its usage rather than overwriting it with the
-		// second candidate.
-		second := newCandidate("anthropic", "claude-haiku-4-5", func(_ context.Context, _ fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
-			t.Fatalf("walkManualTitleCandidates must not fall through after a non-retryable validation error")
-			return nil, errCandidateUnreachable
-		})
-
-		_, err := walkManualTitleCandidates(
-			context.Background(),
-			inputs,
-			[]manualTitleCandidate{first, second},
-			nil,
-		)
-		require.Error(t, err)
-		var genErr *manualTitleGenerationError
-		require.ErrorAs(t, err, &genErr)
-		require.Equal(t, int64(13), genErr.usage.TotalTokens)
-		require.Equal(t, first.config, genErr.modelConfig)
+		require.Empty(t, title)
 	})
 }
 

--- a/coderd/x/chatd/title_override_test.go
+++ b/coderd/x/chatd/title_override_test.go
@@ -359,7 +359,7 @@ func TestMaybeGenerateChatTitle_TitleGenerationOverrideCallFailureSkipsFallback(
 	require.False(t, ok)
 }
 
-func TestResolveManualTitleModel_TitleGenerationOverrideUnset(t *testing.T) {
+func TestResolveManualTitleCandidates_TitleGenerationOverrideUnset(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitShort)
@@ -373,26 +373,35 @@ func TestResolveManualTitleModel_TitleGenerationOverrideUnset(t *testing.T) {
 		Model:    preferredTitleModels[1].model,
 		Enabled:  true,
 	}
+	chat.LastModelConfigID = preferredConfig.ID
 
 	db.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return("", nil)
 	db.EXPECT().GetEnabledChatModelConfigs(gomock.Any()).Return([]database.ChatModelConfig{
 		{Provider: "openai", Model: "gpt-4.1", Enabled: true},
 		preferredConfig,
 	}, nil)
+	// The fallback path also runs (it resolves the chat's own model
+	// as the last-resort candidate). With LastModelConfigID set to
+	// preferredConfig.ID, the configCache hits GetChatModelConfigByID
+	// once and the resulting fallback candidate is deduplicated by
+	// the seen-by-id guard.
+	db.EXPECT().GetChatModelConfigByID(gomock.Any(), preferredConfig.ID).Return(preferredConfig, nil)
 
 	server := titleOverrideTestServer(db, logger)
-	model, gotConfig, err := server.resolveManualTitleModel(
+	candidates, configs, err := server.resolveManualTitleCandidates(
 		ctx,
 		db,
 		chat,
 		chatprovider.ProviderAPIKeys{ByProvider: map[string]string{"openai": "test-key"}},
 	)
 	require.NoError(t, err)
-	require.NotNil(t, model)
-	require.Equal(t, preferredConfig, gotConfig)
+	require.Len(t, candidates, 1, "fallback candidate must be deduped because seen[preferredConfig.ID] is true")
+	require.Equal(t, len(candidates), len(configs))
+	require.Equal(t, preferredConfig.ID, candidates[0].configID.UUID)
+	require.Equal(t, preferredConfig, configs[0])
 }
 
-func TestResolveManualTitleModel_TitleGenerationOverrideReadDBError(t *testing.T) {
+func TestResolveManualTitleCandidates_TitleGenerationOverrideReadDBError(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitShort)
@@ -406,26 +415,29 @@ func TestResolveManualTitleModel_TitleGenerationOverrideReadDBError(t *testing.T
 		Model:    preferredTitleModels[1].model,
 		Enabled:  true,
 	}
+	chat.LastModelConfigID = preferredConfig.ID
 
 	db.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return("", sql.ErrConnDone)
 	db.EXPECT().GetEnabledChatModelConfigs(gomock.Any()).Return([]database.ChatModelConfig{
 		{Provider: "openai", Model: "gpt-4.1", Enabled: true},
 		preferredConfig,
 	}, nil)
+	db.EXPECT().GetChatModelConfigByID(gomock.Any(), preferredConfig.ID).Return(preferredConfig, nil)
 
 	server := titleOverrideTestServer(db, logger)
-	model, gotConfig, err := server.resolveManualTitleModel(
+	candidates, configs, err := server.resolveManualTitleCandidates(
 		ctx,
 		db,
 		chat,
 		chatprovider.ProviderAPIKeys{ByProvider: map[string]string{"openai": "test-key"}},
 	)
 	require.NoError(t, err)
-	require.NotNil(t, model)
-	require.Equal(t, preferredConfig, gotConfig)
+	require.Len(t, candidates, 1)
+	require.Equal(t, preferredConfig.ID, candidates[0].configID.UUID)
+	require.Equal(t, preferredConfig, configs[0])
 }
 
-func TestResolveManualTitleModel_TitleGenerationOverrideSetUsable(t *testing.T) {
+func TestResolveManualTitleCandidates_TitleGenerationOverrideSetUsable(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitShort)
@@ -440,18 +452,21 @@ func TestResolveManualTitleModel_TitleGenerationOverrideSetUsable(t *testing.T) 
 	db.EXPECT().GetEnabledChatProviders(gomock.Any()).Return([]database.ChatProvider{{Provider: "openai"}}, nil)
 
 	server := titleOverrideTestServer(db, logger)
-	model, gotConfig, err := server.resolveManualTitleModel(
+	candidates, configs, err := server.resolveManualTitleCandidates(
 		ctx,
 		db,
 		chat,
 		chatprovider.ProviderAPIKeys{ByProvider: map[string]string{"openai": "test-key"}},
 	)
 	require.NoError(t, err)
-	require.NotNil(t, model)
-	require.Equal(t, overrideConfig, gotConfig)
+	// Override is exclusive: a single candidate with the override
+	// config and nothing else.
+	require.Len(t, candidates, 1)
+	require.Equal(t, overrideConfig.ID, candidates[0].configID.UUID)
+	require.Equal(t, []database.ChatModelConfig{overrideConfig}, configs)
 }
 
-func TestResolveManualTitleModel_TitleGenerationOverrideMissingCredentials(t *testing.T) {
+func TestResolveManualTitleCandidates_TitleGenerationOverrideMissingCredentials(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitShort)
@@ -466,7 +481,7 @@ func TestResolveManualTitleModel_TitleGenerationOverrideMissingCredentials(t *te
 	db.EXPECT().GetEnabledChatProviders(gomock.Any()).Return([]database.ChatProvider{{Provider: "openai"}}, nil)
 
 	server := titleOverrideTestServer(db, logger)
-	model, gotConfig, err := server.resolveManualTitleModel(
+	candidates, configs, err := server.resolveManualTitleCandidates(
 		ctx,
 		db,
 		chat,
@@ -475,11 +490,11 @@ func TestResolveManualTitleModel_TitleGenerationOverrideMissingCredentials(t *te
 	require.Error(t, err)
 	require.ErrorContains(t, err, "resolve manual title generation model override")
 	require.ErrorContains(t, err, "credentials are unavailable")
-	require.Nil(t, model)
-	require.Equal(t, database.ChatModelConfig{}, gotConfig)
+	require.Nil(t, candidates)
+	require.Nil(t, configs)
 }
 
-func TestResolveManualTitleModel_TitleGenerationOverrideSetUnusable(t *testing.T) {
+func TestResolveManualTitleCandidates_TitleGenerationOverrideSetUnusable(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitShort)
@@ -493,7 +508,7 @@ func TestResolveManualTitleModel_TitleGenerationOverrideSetUnusable(t *testing.T
 	db.EXPECT().GetChatModelConfigByID(gomock.Any(), overrideConfig.ID).Return(overrideConfig, nil)
 
 	server := titleOverrideTestServer(db, logger)
-	model, gotConfig, err := server.resolveManualTitleModel(
+	candidates, configs, err := server.resolveManualTitleCandidates(
 		ctx,
 		db,
 		chat,
@@ -502,8 +517,8 @@ func TestResolveManualTitleModel_TitleGenerationOverrideSetUnusable(t *testing.T
 	require.Error(t, err)
 	require.ErrorContains(t, err, "resolve manual title generation model override")
 	require.ErrorContains(t, err, "title generation model override is unavailable")
-	require.Nil(t, model)
-	require.Equal(t, database.ChatModelConfig{}, gotConfig)
+	require.Nil(t, candidates)
+	require.Nil(t, configs)
 }
 
 func titleOverrideTestChatAndMessages(t *testing.T) (database.Chat, []database.ChatMessage) {

--- a/coderd/x/chatd/titlewalk.go
+++ b/coderd/x/chatd/titlewalk.go
@@ -1,0 +1,149 @@
+package chatd
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"charm.land/fantasy"
+	"github.com/google/uuid"
+
+	"github.com/coder/coder/v2/coderd/x/chatd/chatretry"
+)
+
+const (
+	// titleAttemptTimeout bounds a single model call inside a title
+	// walk. A slow or hung provider gets killed at this deadline so
+	// the walker can fall through to the next candidate instead of
+	// burning the overall budget.
+	titleAttemptTimeout = 30 * time.Second
+	// titleOverallTimeout bounds the entire candidate walk. Three
+	// per-attempt timeouts can elapse without exceeding it, so the
+	// walker has room to fall through transient failures and still
+	// land a result.
+	titleOverallTimeout = 90 * time.Second
+)
+
+// titleCandidate is a single (provider, model, runnable model) tuple
+// the title walker can try.
+//
+// configID is set when the candidate was selected from a
+// chat_model_configs row (manual title generation needs it to record
+// usage). It is zero-valued for candidates built directly from
+// preferredTitleModels or the chat's fallback model, where no DB
+// row applies.
+type titleCandidate struct {
+	configID uuid.NullUUID
+	provider string
+	model    string
+	lm       fantasy.LanguageModel
+}
+
+// titleWalkConfig parameterizes walkTitleCandidates.
+type titleWalkConfig struct {
+	// perAttempt bounds a single attempt against one candidate. Zero
+	// disables it and lets ctx govern. Set this when multiple
+	// candidates share a single ctx so a slow first candidate does
+	// not starve later ones.
+	perAttempt time.Duration
+
+	// shouldFallThrough decides whether to advance to the next
+	// candidate after attempt returns err != nil. Nil means "always
+	// fall through". Manual title generation uses a stricter
+	// policy (timeout + chatretry-retryable only) so non-retryable
+	// provider errors like auth/config surface to the user instead
+	// of silently moving on.
+	shouldFallThrough func(err error) bool
+}
+
+// alwaysFallThrough is the policy used by best-effort short-text
+// walkers (auto title, turn status label): every error advances to
+// the next candidate so a slow or misconfigured first provider does
+// not block other candidates from running. Both call sites swallow
+// failures, so falling through on auth/config errors is safe.
+func alwaysFallThrough(error) bool { return true }
+
+// retryableOrTimeoutFallThrough is the manual-title policy: fall
+// through only on per-attempt deadline expiry and chatretry-
+// classified transient errors. Non-retryable errors (auth, config)
+// stop the walk so the user sees the real failure surfaced as 500
+// instead of silently trying every provider and timing out.
+func retryableOrTimeoutFallThrough(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	return chatretry.IsRetryable(err)
+}
+
+// walkTitleCandidates calls attempt against each candidate in
+// sequence, applying a per-attempt deadline and a fall-through
+// policy. It returns the first success along with the winning
+// candidate's index. On exhaustion it returns the last attempt's
+// index and error.
+//
+// When ctx is canceled or its deadline expires, walkTitleCandidates
+// surfaces ctx.Err() so callers can distinguish "all candidates
+// exhausted" from "caller asked us to stop" (the manual title
+// handler maps the latter to 499/504).
+func walkTitleCandidates[T any](
+	ctx context.Context,
+	candidates []titleCandidate,
+	cfg titleWalkConfig,
+	attempt func(ctx context.Context, cand titleCandidate) (T, error),
+) (result T, used int, err error) {
+	used = -1
+	var lastErr error
+	for i, cand := range candidates {
+		// Surface a pre-loop or between-iterations ctx cancel so
+		// the caller sees ctx.Err() rather than an empty result.
+		// Without this, a parent-canceled ctx would exit with
+		// lastErr == nil and the caller could treat it as "no
+		// candidates tried" (manual title) or silently skip the
+		// walk (auto/turn).
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			if lastErr == nil {
+				lastErr = ctxErr
+				used = i
+			}
+			return result, used, lastErr
+		}
+
+		attemptResult, attemptErr := callTitleAttempt(ctx, cfg.perAttempt, cand, attempt)
+		if attemptErr == nil {
+			return attemptResult, i, nil
+		}
+
+		lastErr = attemptErr
+		used = i
+
+		// Caller-side cancellation wins over candidate errors.
+		if ctx.Err() != nil {
+			return result, used, lastErr
+		}
+		if i == len(candidates)-1 {
+			break
+		}
+		if cfg.shouldFallThrough != nil && !cfg.shouldFallThrough(attemptErr) {
+			break
+		}
+	}
+	return result, used, lastErr
+}
+
+// callTitleAttempt wraps a single attempt with its per-attempt
+// timeout so the deferred cancel runs at the end of each iteration
+// rather than at function return.
+func callTitleAttempt[T any](
+	ctx context.Context,
+	perAttempt time.Duration,
+	cand titleCandidate,
+	attempt func(ctx context.Context, cand titleCandidate) (T, error),
+) (T, error) {
+	attemptCtx := ctx
+	if perAttempt > 0 {
+		var cancel context.CancelFunc
+		attemptCtx, cancel = context.WithTimeout(ctx, perAttempt)
+		defer cancel()
+	}
+	return attempt(attemptCtx, cand)
+}

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -3175,9 +3175,14 @@ class ExperimentalApiMethods {
 		return response.data;
 	};
 
-	proposeChatTitle = async (chatId: string): Promise<{ title: string }> => {
+	proposeChatTitle = async (
+		chatId: string,
+		signal?: AbortSignal,
+	): Promise<{ title: string }> => {
 		const response = await this.axios.post<{ title: string }>(
 			`/api/experimental/chats/${chatId}/title/propose`,
+			undefined,
+			{ signal },
 		);
 		return response.data;
 	};

--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -1357,7 +1357,7 @@ describe("mutation invalidation scope", () => {
 			seedAllActiveQueries(queryClient, chatId);
 
 			const mutation = proposeChatTitle(queryClient);
-			await mutation.onSettled(undefined, error, chatId);
+			await mutation.onSettled(undefined, error, { chatId });
 
 			expect(
 				queryClient.getQueryState(chatDebugRunsKey(chatId))?.isInvalidated,

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -1024,13 +1024,19 @@ export const regenerateChatTitle = (queryClient: QueryClient) => ({
 	},
 });
 
+type ProposeChatTitleVariables = {
+	chatId: string;
+	signal?: AbortSignal;
+};
+
 export const proposeChatTitle = (queryClient: QueryClient) => ({
-	mutationFn: (chatId: string) => API.experimental.proposeChatTitle(chatId),
+	mutationFn: ({ chatId, signal }: ProposeChatTitleVariables) =>
+		API.experimental.proposeChatTitle(chatId, signal),
 
 	onSettled: (
 		_data: { title: string } | undefined,
 		_error: unknown,
-		chatId: string,
+		{ chatId }: ProposeChatTitleVariables,
 	) => {
 		void invalidateChatDebugRuns(queryClient, chatId);
 	},

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -455,8 +455,11 @@ const AgentsPage: FC = () => {
 		regeneratingTitlePromisesRef.current.set(chatId, promise);
 		return promise;
 	};
-	const requestProposeTitle = async (chatId: string): Promise<string> => {
-		const result = await proposeTitleMutation.mutateAsync(chatId);
+	const requestProposeTitle = async (
+		chatId: string,
+		signal?: AbortSignal,
+	): Promise<string> => {
+		const result = await proposeTitleMutation.mutateAsync({ chatId, signal });
 		return result.title;
 	};
 	const requestRenameTitle = async (chatId: string, title: string) => {

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.stories.tsx
@@ -952,7 +952,10 @@ export const RenameChatGenerateFillsInput: Story = {
 		);
 		expect(body.getByRole("button", { name: "Generate" })).toBeEnabled();
 		expect(body.getByRole("button", { name: "Save" })).toBeEnabled();
-		expect(args.onProposeTitle).toHaveBeenCalledWith("rename-generate");
+		expect(args.onProposeTitle).toHaveBeenCalledWith(
+			"rename-generate",
+			expect.any(AbortSignal),
+		);
 		expect(args.onRenameTitle).not.toHaveBeenCalled();
 	},
 };
@@ -1209,6 +1212,123 @@ export const RenameChatGenerateLateResponseDoesNotClobberSameChatReopen: Story =
 			expect(body.queryByRole("alert")).not.toBeInTheDocument();
 		},
 	};
+
+export const RenameChatGenerateCancelMidFlightRestoresButton: Story = {
+	args: {
+		chats: [
+			buildChat({
+				id: "rename-generate-cancel-mid",
+				title: "Original title",
+				updated_at: recentTimestamp,
+			}),
+		],
+		// Mock that only settles when the caller aborts the request,
+		// matching how the propose endpoint behaves with an AbortSignal.
+		onProposeTitle: fn(
+			(_chatId: string, signal?: AbortSignal) =>
+				new Promise<string>((_resolve, reject) => {
+					signal?.addEventListener("abort", () => {
+						reject(
+							Object.assign(new Error("canceled"), { code: "ERR_CANCELED" }),
+						);
+					});
+				}),
+		),
+		onRenameTitle: fn(() => Promise.resolve()),
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: { path: "/agents" },
+			routing: agentsRouting,
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(document.body);
+
+		await userEvent.click(
+			canvas.getByRole("button", {
+				name: "Open actions for Original title",
+			}),
+		);
+		await userEvent.click(
+			await body.findByRole("menuitem", { name: "Rename chat" }),
+		);
+
+		const input = await body.findByRole<HTMLInputElement>("textbox", {
+			name: "Chat title",
+		});
+		await userEvent.click(body.getByRole("button", { name: "Generate" }));
+
+		// While generating, the header button switches to a Cancel
+		// affordance with its own accessible name so it does not
+		// collide with the footer Cancel button.
+		const cancelButton = await body.findByRole("button", {
+			name: "Cancel title generation",
+		});
+		expect(cancelButton).toBeEnabled();
+
+		await userEvent.click(cancelButton);
+
+		// Dialog stays open, input is unchanged, the button returns
+		// to the generate affordance, and no error alert appears.
+		await waitFor(() => {
+			expect(body.getByRole("button", { name: "Generate" })).toBeEnabled();
+		});
+		expect(input).toHaveValue("Original title");
+		expect(body.queryByRole("alert")).not.toBeInTheDocument();
+	},
+};
+
+export const RenameChatGenerateTimeoutShowsFriendlyMessage: Story = {
+	args: {
+		chats: [
+			buildChat({
+				id: "rename-generate-timeout",
+				title: "Original title",
+				updated_at: recentTimestamp,
+			}),
+		],
+		// Match the friendly 504 copy the backend writes when title
+		// generation runs past its budget.
+		onProposeTitle: fn(async () => {
+			throw new Error(
+				"Title generation timed out. Try again or rename manually.",
+			);
+		}),
+		onRenameTitle: fn(() => Promise.resolve()),
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: { path: "/agents" },
+			routing: agentsRouting,
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(document.body);
+
+		await userEvent.click(
+			canvas.getByRole("button", {
+				name: "Open actions for Original title",
+			}),
+		);
+		await userEvent.click(
+			await body.findByRole("menuitem", { name: "Rename chat" }),
+		);
+
+		await body.findByRole<HTMLInputElement>("textbox", {
+			name: "Chat title",
+		});
+		await userEvent.click(body.getByRole("button", { name: "Generate" }));
+
+		const alert = await body.findByRole("alert");
+		expect(alert).toHaveTextContent(
+			"Title generation timed out. Try again or rename manually.",
+		);
+		expect(body.getByRole("button", { name: "Generate" })).toBeEnabled();
+	},
+};
 
 export const ActiveFilterShowsActiveAgents: Story = {
 	args: {

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.stories.tsx
@@ -1280,6 +1280,96 @@ export const RenameChatGenerateCancelMidFlightRestoresButton: Story = {
 	},
 };
 
+export const RenameChatGenerateStaleCancelDoesNotClobberNewAttempt: Story = {
+	// Regression: when a Generate is canceled mid-flight and a new
+	// Generate is started before the canceled request's catch
+	// handler has resolved, the stale catch must not clobber the
+	// new attempt's loading state.
+	args: {
+		chats: [
+			buildChat({
+				id: "rename-generate-stale-cancel",
+				title: "Original title",
+				updated_at: recentTimestamp,
+			}),
+		],
+		// First call hangs until aborted (simulates the canceled
+		// request whose catch fires after the second Generate
+		// click). Subsequent calls also hang until aborted, so the
+		// second Generate stays in-flight while we observe the
+		// first one's stale callback land.
+		onProposeTitle: fn(
+			(_chatId: string, signal?: AbortSignal) =>
+				new Promise<string>((_resolve, reject) => {
+					signal?.addEventListener("abort", () => {
+						// Simulate the network actually taking some
+						// time to surface the abort. Without the
+						// delay, the catch fires synchronously
+						// before the second Generate click and the
+						// race never happens.
+						setTimeout(() => {
+							reject(
+								Object.assign(new Error("canceled"), {
+									code: "ERR_CANCELED",
+								}),
+							);
+						}, 50);
+					});
+				}),
+		),
+		onRenameTitle: fn(() => Promise.resolve()),
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: { path: "/agents" },
+			routing: agentsRouting,
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(document.body);
+
+		await userEvent.click(
+			canvas.getByRole("button", {
+				name: "Open actions for Original title",
+			}),
+		);
+		await userEvent.click(
+			await body.findByRole("menuitem", { name: "Rename chat" }),
+		);
+
+		await body.findByRole<HTMLInputElement>("textbox", {
+			name: "Chat title",
+		});
+
+		// First Generate click starts a request that will hang
+		// until the Cancel click below aborts it.
+		await userEvent.click(body.getByRole("button", { name: "Generate" }));
+		await userEvent.click(
+			await body.findByRole("button", { name: "Cancel title generation" }),
+		);
+
+		// Second Generate click while the first request's abort
+		// is still settling on the network. The stale catch must
+		// not flip isGeneratingTitle back to false.
+		await userEvent.click(
+			await body.findByRole("button", { name: "Generate" }),
+		);
+		await body.findByRole("button", { name: "Cancel title generation" });
+
+		// Give the first attempt's stale catch time to fire.
+		await new Promise((resolve) => setTimeout(resolve, 200));
+
+		// The header button stays in the Cancel-while-generating
+		// state. If the stale catch from the first attempt
+		// clobbered state, the button would flip back to Generate
+		// and the Cancel affordance would be gone.
+		expect(
+			body.getByRole("button", { name: "Cancel title generation" }),
+		).toBeEnabled();
+	},
+};
+
 export const RenameChatGenerateTimeoutShowsFriendlyMessage: Story = {
 	args: {
 		chats: [

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -171,7 +171,7 @@ interface AgentsSidebarProps {
 	onUnpinAgent: (chatId: string) => void;
 	onReorderPinnedAgent?: (chatId: string, pinOrder: number) => void;
 	onRenameTitle?: (chatId: string, title: string) => Promise<void>;
-	onProposeTitle?: (chatId: string) => Promise<string>;
+	onProposeTitle?: (chatId: string, signal?: AbortSignal) => Promise<string>;
 	onBeforeNewAgent?: () => void;
 	isCreating: boolean;
 	isArchiving?: boolean;

--- a/site/src/pages/AgentsPage/components/Sidebar/RenameChatDialog.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/RenameChatDialog.tsx
@@ -23,7 +23,10 @@ import { Spinner } from "#/components/Spinner/Spinner";
 type RenameChatDialogProps = {
 	readonly chat: Chat | null;
 	readonly onRename: (chatId: string, title: string) => Promise<void>;
-	readonly onPropose?: (chatId: string) => Promise<string>;
+	readonly onPropose?: (
+		chatId: string,
+		signal?: AbortSignal,
+	) => Promise<string>;
 	readonly onOpenChange: (open: boolean) => void;
 };
 
@@ -60,8 +63,19 @@ export const RenameChatDialog: FC<RenameChatDialogProps> = ({
 	const generatedTitleTypingFrameRef = useRef<number | null>(null);
 	const synchronizedChatIdRef = useRef<string | null | undefined>(undefined);
 	const sessionRef = useRef(0);
+	// Tracks the in-flight propose request so the user can cancel via
+	// the Generate-turned-Cancel button (and chat switches / closes
+	// abort it implicitly).
+	const proposeAbortRef = useRef<AbortController | null>(null);
 	const inputId = useId();
 	const errorId = `${inputId}-error`;
+
+	const abortInFlightPropose = () => {
+		if (proposeAbortRef.current) {
+			proposeAbortRef.current.abort();
+			proposeAbortRef.current = null;
+		}
+	};
 
 	const cancelGeneratedTitleTyping = () => {
 		if (generatedTitleTypingFrameRef.current !== null) {
@@ -138,6 +152,7 @@ export const RenameChatDialog: FC<RenameChatDialogProps> = ({
 
 	const closeDialog = () => {
 		sessionRef.current += 1;
+		abortInFlightPropose();
 		cancelGeneratedTitleTyping();
 		setIsGeneratingTitle(false);
 		onOpenChange(false);
@@ -158,6 +173,7 @@ export const RenameChatDialog: FC<RenameChatDialogProps> = ({
 		if (synchronizedChatIdRef.current === prevChatId) return;
 		synchronizedChatIdRef.current = prevChatId;
 		sessionRef.current += 1;
+		abortInFlightPropose();
 		if (generatedTitleTypingFrameRef.current !== null) {
 			cancelAnimationFrame(generatedTitleTypingFrameRef.current);
 			generatedTitleTypingFrameRef.current = null;
@@ -166,8 +182,10 @@ export const RenameChatDialog: FC<RenameChatDialogProps> = ({
 		setIsGeneratingTitle(false);
 	});
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: unmount-only cleanup. Adding abortInFlightPropose would tear the effect down on every render and abort the in-flight request.
 	useEffect(() => {
 		return () => {
+			abortInFlightPropose();
 			if (generatedTitleTypingFrameRef.current !== null) {
 				cancelAnimationFrame(generatedTitleTypingFrameRef.current);
 			}
@@ -186,21 +204,52 @@ export const RenameChatDialog: FC<RenameChatDialogProps> = ({
 	const handleGenerate = async () => {
 		if (!chat || !onPropose) return;
 		const requestedSession = sessionRef.current;
+		abortInFlightPropose();
 		cancelGeneratedTitleTyping();
+		const controller = new AbortController();
+		proposeAbortRef.current = controller;
 		setIsGeneratingTitle(true);
 		setGenerateTitleError(null);
+
+		// Clear our slot on the ref so a later handleGenerate or
+		// cancel can install its own controller. Avoid try/finally
+		// because the React Compiler does not support a finalizer
+		// clause; inline this at every return path instead.
+		const clearAbortSlot = () => {
+			if (proposeAbortRef.current === controller) {
+				proposeAbortRef.current = null;
+			}
+		};
+
+		let newTitle: string;
 		try {
-			const newTitle = await onPropose(chat.id);
-			if (sessionRef.current !== requestedSession) return;
-			setIsGeneratingTitle(false);
-			startGeneratedTitleTyping(newTitle, requestedSession);
+			newTitle = await onPropose(chat.id, controller.signal);
 		} catch (error) {
+			clearAbortSlot();
 			if (sessionRef.current !== requestedSession) return;
+			// User-initiated cancel resets state silently. The aborted
+			// signal is the source of truth. Axios surfaces canceled
+			// requests as errors, but we only care that we asked for
+			// the cancel.
+			if (controller.signal.aborted) {
+				setIsGeneratingTitle(false);
+				return;
+			}
 			setGenerateTitleError(
 				getErrorMessage(error, "Failed to generate a new title."),
 			);
 			setIsGeneratingTitle(false);
+			return;
 		}
+		clearAbortSlot();
+		if (sessionRef.current !== requestedSession) return;
+		setIsGeneratingTitle(false);
+		startGeneratedTitleTyping(newTitle, requestedSession);
+	};
+
+	const cancelGenerate = () => {
+		abortInFlightPropose();
+		setIsGeneratingTitle(false);
 	};
 
 	const handleSubmit = async () => {
@@ -257,10 +306,19 @@ export const RenameChatDialog: FC<RenameChatDialogProps> = ({
 							size="sm"
 							className="h-auto min-w-0 gap-1 px-2 py-1.5 text-xs font-normal"
 							onClick={() => {
+								if (isGeneratingTitle) {
+									cancelGenerate();
+									return;
+								}
 								void handleGenerate();
 							}}
-							disabled={
-								isRenamingChat || isGeneratingTitle || isTypingGeneratedTitle
+							disabled={isRenamingChat || isTypingGeneratedTitle}
+							// Override the accessible name while generating so the
+							// Cancel-shaped generate button doesn't collide with the
+							// footer Cancel button (which closes the dialog) in
+							// assistive tech and tests.
+							aria-label={
+								isGeneratingTitle ? "Cancel title generation" : undefined
 							}
 						>
 							{isGeneratingTitle ? (
@@ -268,7 +326,7 @@ export const RenameChatDialog: FC<RenameChatDialogProps> = ({
 							) : (
 								<SparklesIcon className="h-[18px] w-[18px]" />
 							)}
-							Generate
+							{isGeneratingTitle ? "Cancel" : "Generate"}
 						</Button>
 					)}
 				</DialogHeader>

--- a/site/src/pages/AgentsPage/components/Sidebar/RenameChatDialog.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/RenameChatDialog.tsx
@@ -70,10 +70,21 @@ export const RenameChatDialog: FC<RenameChatDialogProps> = ({
 	const inputId = useId();
 	const errorId = `${inputId}-error`;
 
+	// Aborting an in-flight propose also has to invalidate that
+	// request's stale callback. Without bumping the session, the
+	// canceled request's catch handler can land after the user
+	// starts a new Generate or after cancelGenerate runs, see its
+	// own controller.signal.aborted == true, and clobber the newer
+	// request's `isGeneratingTitle` state. Bumping sessionRef here
+	// makes every code path that aborts (cancel button, new
+	// Generate click, closeDialog, chat switch, unmount) trip the
+	// `sessionRef.current !== requestedSession` guard in the
+	// callbacks.
 	const abortInFlightPropose = () => {
 		if (proposeAbortRef.current) {
 			proposeAbortRef.current.abort();
 			proposeAbortRef.current = null;
+			sessionRef.current += 1;
 		}
 	};
 


### PR DESCRIPTION
Clicking **Generate** in the Rename Chat dialog returned a 500 with `tool-based generation failed: context deadline exceeded` whenever the configured title-generation model took longer than 30s. The propose-title endpoint ran a single model with a hard 30s budget, and chatretry treats `context.DeadlineExceeded` as non-retryable, so the first timeout killed the request.

Make manual title generation walk every enabled preferred small model the user has credentials for, ending with the chat's own model. The walk uses a 90s overall budget with a 30s per-attempt deadline, falls through on `context.DeadlineExceeded` and on errors `chatretry` classifies as retryable, and stops on non-retryable provider errors (auth, config). On final failure it preserves the last attempt's usage so accounting still records the spend.

Translate `context.DeadlineExceeded` to 504 ("Title generation timed out. Try again or rename manually.") and `context.Canceled` to 499 in both `propose-title` and `regenerate-title` handlers, so the dialog shows a clean message instead of leaking the wrapped chain.

Thread an `AbortSignal` from `RenameChatDialog` through the mutation, queries, and `API.experimental.proposeChatTitle`. While generation is in flight the header sparkles button switches to a **Cancel** affordance (with its own `aria-label` so it does not collide with the footer Cancel button) that aborts the request and silently resets state. Closing the dialog, switching chats, or unmounting also abort the in-flight request.

Storybook stories `RenameChatGenerateCancelMidFlightRestoresButton` and `RenameChatGenerateTimeoutShowsFriendlyMessage` cover the new UI states; `Test_walkManualTitleCandidates` and `TestMaybeWriteManualTitleTimeoutErr` cover the Go-side behavior.
