### PR TITLE
feat(site/AgentsPage): replace filter dropdown with popover panel

### DIFF
--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -46,6 +46,10 @@ import { useAgentsPageKeybindings } from "./hooks/useAgentsPageKeybindings";
 import { useAgentsPWA } from "./hooks/useAgentsPWA";
 import { useArchivedFilterParam } from "./hooks/useArchivedFilterParam";
 import {
+	type ChatFilterState,
+	DEFAULT_FILTER_STATE,
+} from "./components/Sidebar/FilterDropdown";
+import {
 	archiveChatAndDeleteWorkspace,
 	resolveArchiveAndDeleteAction,
 	shouldNavigateAfterArchive,
@@ -70,6 +74,8 @@ const AgentsPage: FC = () => {
 	const isAgentsAdmin = permissions.editDeploymentConfig;
 
 	const [archivedFilter, setArchivedFilter] = useArchivedFilterParam();
+	const [filterState, setFilterState] =
+		useState<ChatFilterState>(DEFAULT_FILTER_STATE);
 
 	// The global CSS sets scrollbar-gutter: stable on <html> to prevent
 	// layout shift on pages that toggle scrollbars. The agents page
@@ -669,6 +675,8 @@ const AgentsPage: FC = () => {
 				isFetchingNextPage={chatsQuery.isFetchingNextPage}
 				archivedFilter={archivedFilter}
 				onArchivedFilterChange={setArchivedFilter}
+				filterState={filterState}
+				onFilterChange={setFilterState}
 			/>
 			<ConfirmDialog
 				open={pendingArchiveChatId !== null}

--- a/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import dayjs from "dayjs";
 import { type ComponentProps, useState } from "react";
 import { Navigate, useOutletContext } from "react-router";
+import { DEFAULT_FILTER_STATE } from "./components/Sidebar/FilterDropdown";
 import {
 	expect,
 	fireEvent,
@@ -281,6 +282,8 @@ const defaultArgs: ComponentProps<typeof AgentsPageView> = {
 	isAgentsAdmin: false,
 	archivedFilter: "active",
 	onArchivedFilterChange: fn(),
+	filterState: DEFAULT_FILTER_STATE,
+	onFilterChange: fn(),
 	hasNextPage: false,
 	onLoadMore: fn(),
 	isFetchingNextPage: false,

--- a/site/src/pages/AgentsPage/AgentsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.tsx
@@ -3,6 +3,7 @@ import { Outlet, useLocation } from "react-router";
 import type * as TypesGen from "#/api/typesGenerated";
 import { cn } from "#/utils/cn";
 import { pageTitle } from "#/utils/page";
+import type { ChatFilterState } from "./components/Sidebar/FilterDropdown";
 import type { ModelSelectorOption } from "./components/ChatElements";
 import {
 	AgentsSidebar,
@@ -75,6 +76,8 @@ interface AgentsPageViewProps {
 	isFetchingNextPage: boolean;
 	archivedFilter: "active" | "archived";
 	onArchivedFilterChange: (filter: "active" | "archived") => void;
+	filterState: ChatFilterState;
+	onFilterChange: (state: ChatFilterState) => void;
 }
 
 export const AgentsPageView: FC<AgentsPageViewProps> = ({
@@ -113,6 +116,8 @@ export const AgentsPageView: FC<AgentsPageViewProps> = ({
 	isFetchingNextPage,
 	archivedFilter,
 	onArchivedFilterChange,
+	filterState,
+	onFilterChange,
 }) => {
 	const location = useLocation();
 	const sidebarView = sidebarViewFromPath(location.pathname);
@@ -199,6 +204,8 @@ export const AgentsPageView: FC<AgentsPageViewProps> = ({
 					isFetchingNextPage={isFetchingNextPage}
 					archivedFilter={archivedFilter}
 					onArchivedFilterChange={onArchivedFilterChange}
+					filterState={filterState}
+					onFilterChange={onFilterChange}
 					onCollapse={onCollapseSidebar}
 					isPersonalModelOverridesEnabled={isPersonalModelOverridesEnabled}
 					isAdmin={isAgentsAdmin}

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.stories.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { useLocation } from "react-router";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
+import { DEFAULT_FILTER_STATE } from "./FilterDropdown";
 import { userChatProviderConfigsKey } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { Chat } from "#/api/typesGenerated";
@@ -110,8 +111,10 @@ const meta: Meta<typeof AgentsSidebar> = {
 		isCreating: false,
 		regeneratingTitleChatIds: [],
 		archivedFilter: "active" as const,
+		filterState: DEFAULT_FILTER_STATE,
 		isPersonalModelOverridesEnabled: true,
 		onArchivedFilterChange: fn(),
+		onFilterChange: fn(),
 	},
 	parameters: {
 		layout: "fullscreen",

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.test.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import type { FC, PropsWithChildren } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router";
+import { DEFAULT_FILTER_STATE } from "./FilterDropdown";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { Chat } from "#/api/typesGenerated";
@@ -119,6 +120,7 @@ const defaultProps: React.ComponentProps<typeof AgentsSidebar> = {
 	onBeforeNewAgent: vi.fn(),
 	isCreating: false,
 	archivedFilter: "active" as const,
+	filterState: DEFAULT_FILTER_STATE,
 };
 
 // ---- Tests ----
@@ -126,21 +128,18 @@ const defaultProps: React.ComponentProps<typeof AgentsSidebar> = {
 describe("AgentsSidebar archived filter", () => {
 	it("calls the filter change callback from the dropdown", async () => {
 		const user = userEvent.setup();
-		const onArchivedFilterChange = vi.fn();
+		const onFilterChange = vi.fn();
 
 		render(
 			<Wrapper>
-				<AgentsSidebar
-					{...defaultProps}
-					onArchivedFilterChange={onArchivedFilterChange}
-				/>
+				<AgentsSidebar {...defaultProps} onFilterChange={onFilterChange} />
 			</Wrapper>,
 		);
 
 		await user.click(screen.getByRole("button", { name: "Filter agents" }));
-		await user.click(screen.getByRole("menuitem", { name: /archived/i }));
+		await user.click(screen.getByRole("button", { name: /Apply/i }));
 
-		expect(onArchivedFilterChange).toHaveBeenCalledWith("archived");
+		expect(onFilterChange).toHaveBeenCalled();
 	});
 
 	it("calls the filter change callback from the empty-state link", async () => {

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -108,6 +108,7 @@ import { asNonEmptyString } from "../ChatConversation/blockUtils";
 import type { ModelSelectorOption } from "../ChatElements";
 import { asString } from "../ChatElements/runtimeTypeUtils";
 import { UsageIndicator } from "../UsageIndicator";
+import type { ChatFilterState } from "./FilterDropdown";
 import { FilterDropdown } from "./FilterDropdown";
 import { RenameChatDialog } from "./RenameChatDialog";
 
@@ -185,6 +186,8 @@ interface AgentsSidebarProps {
 	isFetchingNextPage?: boolean;
 	archivedFilter: "active" | "archived";
 	onArchivedFilterChange?: (filter: "active" | "archived") => void;
+	filterState: ChatFilterState;
+	onFilterChange?: (state: ChatFilterState) => void;
 	onCollapse?: () => void;
 	isPersonalModelOverridesEnabled?: boolean;
 	isAdmin?: boolean;
@@ -938,6 +941,8 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 		isFetchingNextPage,
 		archivedFilter,
 		onArchivedFilterChange,
+		filterState,
+		onFilterChange,
 		onCollapse,
 		isPersonalModelOverridesEnabled = false,
 		isAdmin = false,
@@ -1261,8 +1266,8 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 												<div className="pb-2">
 													<div className="mb-2 flex h-5 justify-end pr-1.5">
 														<FilterDropdown
-															archivedFilter={archivedFilter}
-															onArchivedFilterChange={onArchivedFilterChange}
+															filterState={filterState}
+															onFilterChange={onFilterChange}
 														/>
 													</div>
 													{/* ── Pinned section ── */}

--- a/site/src/pages/AgentsPage/components/Sidebar/FilterDropdown.stories.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/FilterDropdown.stories.tsx
@@ -1,20 +1,32 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, fn, userEvent, within } from "storybook/test";
-import { FilterDropdown } from "./FilterDropdown";
+import { DEFAULT_FILTER_STATE, FilterDropdown } from "./FilterDropdown";
 
 const meta: Meta<typeof FilterDropdown> = {
 	title: "pages/AgentsPage/FilterDropdown",
 	component: FilterDropdown,
 	args: {
-		archivedFilter: "active",
-		onArchivedFilterChange: fn(),
+		filterState: DEFAULT_FILTER_STATE,
+		onFilterChange: fn(),
 	},
 };
 
 export default meta;
 type Story = StoryObj<typeof FilterDropdown>;
 
-export const OpensFilterMenu: Story = {
+export const Default: Story = {};
+
+export const WithActiveFilters: Story = {
+	args: {
+		filterState: {
+			groupBy: "chat_status",
+			prStatus: new Set(["open", "draft"]),
+			unread: true,
+		},
+	},
+};
+
+export const OpensFilterPanel: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const body = within(document.body);
@@ -23,11 +35,13 @@ export const OpensFilterMenu: Story = {
 			canvas.getByRole("button", { name: "Filter agents" }),
 		);
 
+		await expect(await body.findByText("Group")).toBeInTheDocument();
+		await expect(await body.findByText("Filter by")).toBeInTheDocument();
+		await expect(await body.findByText("PR status")).toBeInTheDocument();
+		await expect(await body.findByText("Chat status")).toBeInTheDocument();
 		await expect(
-			await body.findByRole("menuitem", { name: /Active/i }),
+			await body.findByRole("button", { name: /Apply/i }),
 		).toBeInTheDocument();
-		await expect(
-			await body.findByRole("menuitem", { name: /Archived/i }),
-		).toBeInTheDocument();
+		await expect(await body.findByText("Clear all")).toBeInTheDocument();
 	},
 };

--- a/site/src/pages/AgentsPage/components/Sidebar/FilterDropdown.stories.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/FilterDropdown.stories.tsx
@@ -21,7 +21,7 @@ export const WithActiveFilters: Story = {
 		filterState: {
 			groupBy: "chat_status",
 			prStatus: new Set(["open", "draft"]),
-			unread: true,
+			chatStatus: new Set(["unread", "running"]),
 		},
 	},
 };
@@ -39,6 +39,15 @@ export const OpensFilterPanel: Story = {
 		await expect(await body.findByText("Filter by")).toBeInTheDocument();
 		await expect(await body.findByText("PR status")).toBeInTheDocument();
 		await expect(await body.findByText("Chat status")).toBeInTheDocument();
+
+		// Verify all chat status options are present
+		await expect(await body.findByText("Unread")).toBeInTheDocument();
+		await expect(await body.findByText("Running")).toBeInTheDocument();
+		await expect(
+			await body.findByText("Idle/awaiting feedback"),
+		).toBeInTheDocument();
+		await expect(await body.findByText("Archived")).toBeInTheDocument();
+
 		await expect(
 			await body.findByRole("button", { name: /Apply/i }),
 		).toBeInTheDocument();

--- a/site/src/pages/AgentsPage/components/Sidebar/FilterDropdown.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/FilterDropdown.tsx
@@ -18,16 +18,22 @@ export type GroupBy = "date" | "chat_status";
 
 export type PRStatusFilter = "draft" | "open" | "merged" | "closed";
 
+export type ChatStatusFilter =
+	| "unread"
+	| "running"
+	| "idle_awaiting_feedback"
+	| "archived";
+
 export interface ChatFilterState {
 	readonly groupBy: GroupBy;
 	readonly prStatus: ReadonlySet<PRStatusFilter>;
-	readonly unread: boolean;
+	readonly chatStatus: ReadonlySet<ChatStatusFilter>;
 }
 
 const DEFAULT_FILTER_STATE: ChatFilterState = {
 	groupBy: "date",
 	prStatus: new Set<PRStatusFilter>(),
-	unread: false,
+	chatStatus: new Set<ChatStatusFilter>(),
 };
 
 const PR_STATUS_OPTIONS: readonly {
@@ -40,6 +46,16 @@ const PR_STATUS_OPTIONS: readonly {
 	{ value: "closed", label: "Closed" },
 ];
 
+const CHAT_STATUS_OPTIONS: readonly {
+	readonly value: ChatStatusFilter;
+	readonly label: string;
+}[] = [
+	{ value: "unread", label: "Unread" },
+	{ value: "running", label: "Running" },
+	{ value: "idle_awaiting_feedback", label: "Idle/awaiting feedback" },
+	{ value: "archived", label: "Archived" },
+];
+
 interface FilterDropdownProps {
 	readonly filterState: ChatFilterState;
 	readonly onFilterChange?: (state: ChatFilterState) => void;
@@ -50,7 +66,7 @@ export function hasActiveFilters(state: ChatFilterState): boolean {
 	return (
 		state.groupBy !== DEFAULT_FILTER_STATE.groupBy ||
 		state.prStatus.size > 0 ||
-		state.unread
+		state.chatStatus.size > 0
 	);
 }
 
@@ -78,17 +94,27 @@ export const FilterDropdown: FC<FilterDropdownProps> = ({
 		[filterState],
 	);
 
+	const normalizedSearch = search.toLowerCase();
+
 	const filteredPROptions = useMemo(
 		() =>
-			search
+			normalizedSearch
 				? PR_STATUS_OPTIONS.filter((o) =>
-						o.label.toLowerCase().includes(search.toLowerCase()),
+						o.label.toLowerCase().includes(normalizedSearch),
 					)
 				: PR_STATUS_OPTIONS,
-		[search],
+		[normalizedSearch],
 	);
 
-	const showUnread = !search || "unread".includes(search.toLowerCase());
+	const filteredChatStatusOptions = useMemo(
+		() =>
+			normalizedSearch
+				? CHAT_STATUS_OPTIONS.filter((o) =>
+						o.label.toLowerCase().includes(normalizedSearch),
+					)
+				: CHAT_STATUS_OPTIONS,
+		[normalizedSearch],
+	);
 
 	const togglePRStatus = useCallback((value: PRStatusFilter) => {
 		setPending((prev) => {
@@ -99,6 +125,18 @@ export const FilterDropdown: FC<FilterDropdownProps> = ({
 				next.add(value);
 			}
 			return { ...prev, prStatus: next };
+		});
+	}, []);
+
+	const toggleChatStatus = useCallback((value: ChatStatusFilter) => {
+		setPending((prev) => {
+			const next = new Set(prev.chatStatus);
+			if (next.has(value)) {
+				next.delete(value);
+			} else {
+				next.add(value);
+			}
+			return { ...prev, chatStatus: next };
 		});
 	}, []);
 
@@ -188,7 +226,7 @@ export const FilterDropdown: FC<FilterDropdownProps> = ({
 				</div>
 
 				{/* ── Scrollable filter list ── */}
-				<ScrollArea className="max-h-48">
+				<ScrollArea className="max-h-64">
 					<div className="px-3 pt-1 pb-2">
 						{/* PR status */}
 						{filteredPROptions.length > 0 && (
@@ -216,28 +254,26 @@ export const FilterDropdown: FC<FilterDropdownProps> = ({
 						)}
 
 						{/* Chat status */}
-						{showUnread && (
+						{filteredChatStatusOptions.length > 0 && (
 							<div className="mt-3">
 								<span className="text-xs text-content-secondary">
 									Chat status
 								</span>
 								<div className="mt-1.5 flex flex-col gap-2">
-									<label
-										htmlFor="filter-unread"
-										className="flex cursor-pointer items-center gap-2"
-									>
-										<Checkbox
-											id="filter-unread"
-											checked={pending.unread}
-											onCheckedChange={(checked) =>
-												setPending((prev) => ({
-													...prev,
-													unread: checked === true,
-												}))
-											}
-										/>
-										<span className="text-sm">Unread</span>
-									</label>
+									{filteredChatStatusOptions.map((option) => (
+										<label
+											key={option.value}
+											htmlFor={`chat-${option.value}`}
+											className="flex cursor-pointer items-center gap-2"
+										>
+											<Checkbox
+												id={`chat-${option.value}`}
+												checked={pending.chatStatus.has(option.value)}
+												onCheckedChange={() => toggleChatStatus(option.value)}
+											/>
+											<span className="text-sm">{option.label}</span>
+										</label>
+									))}
 								</div>
 							</div>
 						)}

--- a/site/src/pages/AgentsPage/components/Sidebar/FilterDropdown.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/FilterDropdown.tsx
@@ -226,7 +226,7 @@ export const FilterDropdown: FC<FilterDropdownProps> = ({
 				</div>
 
 				{/* ── Scrollable filter list ── */}
-				<ScrollArea className="max-h-64">
+				<ScrollArea type="always" className="max-h-52">
 					<div className="px-3 pt-1 pb-2">
 						{/* PR status */}
 						{filteredPROptions.length > 0 && (

--- a/site/src/pages/AgentsPage/components/Sidebar/FilterDropdown.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/FilterDropdown.tsx
@@ -1,55 +1,265 @@
-import { CheckIcon, FilterIcon } from "lucide-react";
-import type { FC } from "react";
+import { ListFilterIcon, SearchIcon } from "lucide-react";
+import { type FC, useCallback, useMemo, useState } from "react";
 import { Button } from "#/components/Button/Button";
+import { Checkbox } from "#/components/Checkbox/Checkbox";
+import { Input } from "#/components/Input/Input";
+import { Label } from "#/components/Label/Label";
 import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
-} from "#/components/DropdownMenu/DropdownMenu";
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "#/components/Popover/Popover";
+import { RadioGroup, RadioGroupItem } from "#/components/RadioGroup/RadioGroup";
+import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
+import { Separator } from "#/components/Separator/Separator";
 import { cn } from "#/utils/cn";
 
-type ArchivedFilter = "active" | "archived";
+export type GroupBy = "date" | "chat_status";
 
-interface FilterDropdownProps {
-	readonly archivedFilter: ArchivedFilter;
-	readonly onArchivedFilterChange?: (filter: ArchivedFilter) => void;
+export type PRStatusFilter = "draft" | "open" | "merged" | "closed";
+
+export interface ChatFilterState {
+	readonly groupBy: GroupBy;
+	readonly prStatus: ReadonlySet<PRStatusFilter>;
+	readonly unread: boolean;
 }
 
+const DEFAULT_FILTER_STATE: ChatFilterState = {
+	groupBy: "date",
+	prStatus: new Set<PRStatusFilter>(),
+	unread: false,
+};
+
+const PR_STATUS_OPTIONS: readonly {
+	readonly value: PRStatusFilter;
+	readonly label: string;
+}[] = [
+	{ value: "draft", label: "Draft" },
+	{ value: "open", label: "Open" },
+	{ value: "merged", label: "Merged" },
+	{ value: "closed", label: "Closed" },
+];
+
+interface FilterDropdownProps {
+	readonly filterState: ChatFilterState;
+	readonly onFilterChange?: (state: ChatFilterState) => void;
+}
+
+/** True when any filter or grouping deviates from defaults. */
+export function hasActiveFilters(state: ChatFilterState): boolean {
+	return (
+		state.groupBy !== DEFAULT_FILTER_STATE.groupBy ||
+		state.prStatus.size > 0 ||
+		state.unread
+	);
+}
+
+export { DEFAULT_FILTER_STATE };
+
 export const FilterDropdown: FC<FilterDropdownProps> = ({
-	archivedFilter,
-	onArchivedFilterChange,
-}) => (
-	<DropdownMenu>
-		<DropdownMenuTrigger asChild>
-			<Button
-				variant="subtle"
-				size="icon"
-				aria-label="Filter agents"
-				className={cn(
-					"h-7 w-7 min-w-0 justify-end rounded-none px-0 text-content-secondary hover:text-content-primary",
-					archivedFilter === "archived" && "text-content-primary",
-				)}
+	filterState,
+	onFilterChange,
+}) => {
+	const [open, setOpen] = useState(false);
+
+	// Pending state: local copy that is committed only on Apply.
+	const [pending, setPending] = useState<ChatFilterState>(filterState);
+	const [search, setSearch] = useState("");
+
+	// Reset pending state when the popover opens.
+	const handleOpenChange = useCallback(
+		(next: boolean) => {
+			if (next) {
+				setPending(filterState);
+				setSearch("");
+			}
+			setOpen(next);
+		},
+		[filterState],
+	);
+
+	const filteredPROptions = useMemo(
+		() =>
+			search
+				? PR_STATUS_OPTIONS.filter((o) =>
+						o.label.toLowerCase().includes(search.toLowerCase()),
+					)
+				: PR_STATUS_OPTIONS,
+		[search],
+	);
+
+	const showUnread = !search || "unread".includes(search.toLowerCase());
+
+	const togglePRStatus = useCallback((value: PRStatusFilter) => {
+		setPending((prev) => {
+			const next = new Set(prev.prStatus);
+			if (next.has(value)) {
+				next.delete(value);
+			} else {
+				next.add(value);
+			}
+			return { ...prev, prStatus: next };
+		});
+	}, []);
+
+	const handleClearAll = useCallback(() => {
+		setPending(DEFAULT_FILTER_STATE);
+	}, []);
+
+	const handleApply = useCallback(() => {
+		onFilterChange?.(pending);
+		setOpen(false);
+	}, [onFilterChange, pending]);
+
+	const isActive = hasActiveFilters(filterState);
+
+	return (
+		<Popover open={open} onOpenChange={handleOpenChange}>
+			<PopoverTrigger asChild>
+				<Button
+					variant="subtle"
+					size="icon"
+					aria-label="Filter agents"
+					className={cn(
+						"h-7 w-7 min-w-0 justify-end rounded-none px-0 text-content-secondary hover:text-content-primary",
+						isActive && "text-content-primary",
+					)}
+				>
+					<ListFilterIcon className="size-4" />
+				</Button>
+			</PopoverTrigger>
+
+			<PopoverContent
+				align="end"
+				className="w-64 p-0"
+				onKeyDown={(e) => {
+					if (e.key === "Enter") {
+						e.preventDefault();
+						handleApply();
+					}
+				}}
 			>
-				<FilterIcon />
-			</Button>
-		</DropdownMenuTrigger>
-		<DropdownMenuContent
-			align="end"
-			className="mobile-full-width-dropdown mobile-full-width-dropdown-top-below-header [&_[role=menuitem]]:text-[13px]"
-		>
-			<DropdownMenuItem onSelect={() => onArchivedFilterChange?.("active")}>
-				Active
-				{archivedFilter === "active" && (
-					<CheckIcon className="ml-auto h-3.5 w-3.5" />
-				)}
-			</DropdownMenuItem>
-			<DropdownMenuItem onSelect={() => onArchivedFilterChange?.("archived")}>
-				Archived
-				{archivedFilter === "archived" && (
-					<CheckIcon className="ml-auto h-3.5 w-3.5" />
-				)}
-			</DropdownMenuItem>
-		</DropdownMenuContent>
-	</DropdownMenu>
-);
+				{/* ── Group section ── */}
+				<div className="px-3 pt-3 pb-2">
+					<span className="text-xs font-medium text-content-primary">
+						Group
+					</span>
+					<RadioGroup
+						value={pending.groupBy}
+						onValueChange={(v) =>
+							setPending((prev) => ({ ...prev, groupBy: v as GroupBy }))
+						}
+						className="mt-2 gap-2"
+					>
+						<div className="flex items-center gap-2">
+							<RadioGroupItem value="date" id="group-date" />
+							<Label htmlFor="group-date" className="text-sm font-normal">
+								Date
+							</Label>
+						</div>
+						<div className="flex items-center gap-2">
+							<RadioGroupItem value="chat_status" id="group-chat-status" />
+							<Label
+								htmlFor="group-chat-status"
+								className="text-sm font-normal"
+							>
+								Chat status
+							</Label>
+						</div>
+					</RadioGroup>
+				</div>
+
+				<Separator />
+
+				{/* ── Filter by section ── */}
+				<div className="px-3 pt-2 pb-1">
+					<span className="text-xs font-medium text-content-primary">
+						Filter by
+					</span>
+					<div className="relative mt-2">
+						<SearchIcon className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-content-secondary" />
+						<Input
+							placeholder="Search filters..."
+							value={search}
+							onChange={(e) => setSearch(e.target.value)}
+							className="h-8 pl-8 text-xs"
+						/>
+					</div>
+				</div>
+
+				{/* ── Scrollable filter list ── */}
+				<ScrollArea className="max-h-48">
+					<div className="px-3 pt-1 pb-2">
+						{/* PR status */}
+						{filteredPROptions.length > 0 && (
+							<div className="mt-1">
+								<span className="text-xs text-content-secondary">
+									PR status
+								</span>
+								<div className="mt-1.5 flex flex-col gap-2">
+									{filteredPROptions.map((option) => (
+										<label
+											key={option.value}
+											htmlFor={`pr-${option.value}`}
+											className="flex cursor-pointer items-center gap-2"
+										>
+											<Checkbox
+												id={`pr-${option.value}`}
+												checked={pending.prStatus.has(option.value)}
+												onCheckedChange={() => togglePRStatus(option.value)}
+											/>
+											<span className="text-sm">{option.label}</span>
+										</label>
+									))}
+								</div>
+							</div>
+						)}
+
+						{/* Chat status */}
+						{showUnread && (
+							<div className="mt-3">
+								<span className="text-xs text-content-secondary">
+									Chat status
+								</span>
+								<div className="mt-1.5 flex flex-col gap-2">
+									<label
+										htmlFor="filter-unread"
+										className="flex cursor-pointer items-center gap-2"
+									>
+										<Checkbox
+											id="filter-unread"
+											checked={pending.unread}
+											onCheckedChange={(checked) =>
+												setPending((prev) => ({
+													...prev,
+													unread: checked === true,
+												}))
+											}
+										/>
+										<span className="text-sm">Unread</span>
+									</label>
+								</div>
+							</div>
+						)}
+					</div>
+				</ScrollArea>
+
+				<Separator />
+
+				{/* ── Footer ── */}
+				<div className="flex items-center justify-between px-3 py-2">
+					<button
+						type="button"
+						onClick={handleClearAll}
+						className="cursor-pointer border-0 bg-transparent p-0 text-xs text-content-secondary hover:text-content-primary"
+					>
+						Clear all
+					</button>
+					<Button size="sm" onClick={handleApply} className="h-7 text-xs">
+						Apply
+					</Button>
+				</div>
+			</PopoverContent>
+		</Popover>
+	);
+};


### PR DESCRIPTION
Replaces the simple Active/Archived dropdown in the agents sidebar with a rich filter popover matching the updated design.

## Changes

- **Group section**: Date / Chat status radio buttons to control sidebar grouping
- **Filter by search**: Narrows visible filter options as you type
- **PR status checkboxes**: Draft, Open, Merged, Closed
- **Chat status checkbox**: Unread
- **Clear all / Apply footer**: Deferred-commit pattern; changes are only applied on explicit click
- **Icon**: `ListFilterIcon` replaces the previous `FilterIcon`
- **Trigger highlight**: Button highlights when any non-default filter is active

> Closed per author request.