### PR TITLE
fix: ignore drifting timestamp in stories

### DIFF
--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -769,7 +769,11 @@ const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 												aria-hidden="true"
 											/>
 										) : (
-											shortRelativeTime(chat.updated_at)
+											// data-chromatic="ignore" keeps Chromatic snapshots
+											// stable as wall-clock time advances (e.g. "now" → "5m").
+											<span data-chromatic="ignore">
+												{shortRelativeTime(chat.updated_at)}
+											</span>
 										)}
 									</span>
 									<DropdownMenu>


### PR DESCRIPTION
The `SectionHeadersCollapse` story (and every other Chromatic-snapshotted story rendering the agents sidebar) was flaky because each chat row renders `shortRelativeTime(chat.updated_at)` — `"now"`, `"5m"`, `"7h"`, `"1d"`, etc. The values are computed against the live wall clock from fixed fixture timestamps, so the rendered text drifts on every run (e.g. `"7h"` → `"now"` mid-day) and Chromatic diffs the change.

This wraps the timestamp in `<span data-chromatic="ignore">`, the dominant codebase convention for time-varying text. `data-chromatic="ignore"` appears 35 times across 20 files in `site/src`, including `utils/schedule.tsx:139,153`, `components/LastSeen/LastSeen.tsx:42`, `modules/provisioners/Provisioner.tsx:80`, `pages/OrganizationSettingsPage/.../ProvisionerRow.tsx:119`, `JobRow.tsx:139`, `ProvisionerKeyRow.tsx:81`, `pages/AIBridgePage/RequestLogsPage/RequestLogsRow/RequestLogsRow.tsx` (multiple rows), `pages/HealthPage/WorkspaceProxyPage.tsx:144`, and `pages/UserSettingsPage/TokensPage/TokensPageView.tsx:117`. By comparison, only one component (`AppStatuses`) plumbs a reference date through props, and there is no `Date.now`-stubbing precedent that would actually stabilize `dayjs()`-based output like `shortRelativeTime`.

The wrap is scoped tightly: only the text node returned by `shortRelativeTime` is ignored, so the sibling unread-indicator dot and surrounding layout still participate in snapshots.
