### PR TITLE
fix(dogfood): chown /etc/mise to coder so mise can update lockfile

### DIFF
--- a/dogfood/coder/ubuntu-22.04/Dockerfile
+++ b/dogfood/coder/ubuntu-22.04/Dockerfile
@@ -200,10 +200,12 @@ ENV MISE_DATA_DIR=/home/coder/.local/share/mise \
 #
 # We pre-create /etc/mise as 0755 because COPY's implicitly-created
 # parent dirs inherit the --chmod, which would leave /etc/mise
-# without the `x` bit and unreachable to the coder user.
-RUN install --directory --mode=0755 /etc/mise
-COPY --chmod=0644 mise.toml /etc/mise/config.toml
-COPY --chmod=0644 mise.lock /etc/mise/mise.lock
+# without the `x` bit and unreachable to the coder user. We also
+# chown to coder so mise can write the temp lockfile it uses for
+# atomic rename when updating /etc/mise/mise.lock during installs.
+RUN install --directory --owner=coder --group=coder --mode=0755 /etc/mise
+COPY --chown=coder:coder --chmod=0644 mise.toml /etc/mise/config.toml
+COPY --chown=coder:coder --chmod=0644 mise.lock /etc/mise/mise.lock
 
 # Pre-install tools into /opt/mise/data so they survive the home
 # volume's copy-on-first-mount. MISE_SHARED_INSTALL_DIRS (set below)

--- a/dogfood/coder/ubuntu-26.04/Dockerfile
+++ b/dogfood/coder/ubuntu-26.04/Dockerfile
@@ -210,10 +210,12 @@ ENV MISE_DATA_DIR=/home/coder/.local/share/mise \
 #
 # We pre-create /etc/mise as 0755 because COPY's implicitly-created
 # parent dirs inherit the --chmod, which would leave /etc/mise
-# without the `x` bit and unreachable to the coder user.
-RUN install --directory --mode=0755 /etc/mise
-COPY --chmod=0644 mise.toml /etc/mise/config.toml
-COPY --chmod=0644 mise.lock /etc/mise/mise.lock
+# without the `x` bit and unreachable to the coder user. We also
+# chown to coder so mise can write the temp lockfile it uses for
+# atomic rename when updating /etc/mise/mise.lock during installs.
+RUN install --directory --owner=coder --group=coder --mode=0755 /etc/mise
+COPY --chown=coder:coder --chmod=0644 mise.toml /etc/mise/config.toml
+COPY --chown=coder:coder --chmod=0644 mise.lock /etc/mise/mise.lock
 
 # Pre-install tools into /opt/mise/data so they survive the home
 # volume's copy-on-first-mount. MISE_SHARED_INSTALL_DIRS (set below)


### PR DESCRIPTION
Mise writes a temp file like `/etc/mise/.mise.lock.XXXXXX` and renames it onto `mise.lock` for atomic updates, which requires write access to the parent directory. `/etc/mise` was previously root-owned (`install --directory --mode=0755` and `COPY` without `--chown` default to root), so any mise command that updated the lockfile failed for the coder user:

```
mise ERROR failed to update lockfiles
mise ERROR Permission denied (os error 13) at path "/etc/mise/.mise.lock.HbuLAN"
```

Chown `/etc/mise` and the baked `config.toml` / `mise.lock` to `coder:coder`, matching how `/opt/mise` is already set up. The dogfood image is single-user, and mise is expected to update its own lockfile when the coder user installs new tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)