### PR TITLE
fix(coderd/x/chatd): deliver out-of-order durable messages on subscribe

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -5013,20 +5013,16 @@ func (p *Server) SubscribeAuthorized(
 						deliveredCount int
 						source         string
 					)
-					// publishMessage runs from PromoteQueued and the worker
-					// concurrently; PG commit reordering can land a lower-ID
-					// notify after lastMessageID has already advanced. Look up
-					// from min(AfterMessageID, lastMessageID) so a late notify
-					// rescans the gap, but never below afterMessageID, which is
-					// the boundary the caller already has via REST. The
-					// delivered set deduplicates either source.
+					// Notifies can arrive out of order. Rescan from
+					// min(AfterMessageID, lastMessageID) to cover the gap,
+					// floored at afterMessageID to respect the subscription
+					// boundary. The delivered set deduplicates.
 					lookupAfter := lastMessageID
 					if !notify.FullRefresh {
 						lookupAfter = max(afterMessageID, min(notify.AfterMessageID, lastMessageID))
 					}
 					cached := p.getCachedDurableMessages(chatID, lookupAfter)
 					if !notify.FullRefresh && len(cached) > 0 {
-						source = "cache"
 						for _, event := range cached {
 							if event.Message == nil {
 								continue
@@ -5044,11 +5040,11 @@ func (p *Server) SubscribeAuthorized(
 								lastMessageID = event.Message.ID
 							}
 							deliveredCount++
+							source = "cache"
 						}
 					}
-					// The DB is authoritative for cross-replica messages the
-					// local cache cannot have. Always run it; the delivered
-					// set dedupes against the cache pass.
+					// DB pass picks up cross-replica messages the local cache
+					// cannot have. Delivered set dedupes against the cache pass.
 					newMessages, msgErr := p.db.GetChatMessagesByChatID(mergedCtx, database.GetChatMessagesByChatIDParams{
 						ChatID:  chatID,
 						AfterID: lookupAfter,

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -4843,6 +4843,7 @@ func (p *Server) SubscribeAuthorized(
 	// is already active so no notifications can be lost during this
 	// window.
 	initialSnapshot := make([]codersdk.ChatStreamEvent, 0)
+	delivered := map[int64]struct{}{}
 	// Add local same-replica message_parts to the snapshot. Retry comes
 	// from state.currentRetry, not the event buffer, so late joiners see
 	// only the latest phase rather than a stale buffered retry event.
@@ -4887,6 +4888,7 @@ func (p *Server) SubscribeAuthorized(
 				ChatID:  chatID,
 				Message: &sdkMsg,
 			})
+			delivered[msg.ID] = struct{}{}
 		}
 	}
 
@@ -5005,49 +5007,80 @@ func (p *Server) SubscribeAuthorized(
 				if notify.AfterMessageID > 0 || notify.FullRefresh {
 					if notify.FullRefresh {
 						lastMessageID = 0
+						delivered = map[int64]struct{}{}
 					}
 					var (
 						deliveredCount int
 						source         string
 					)
-					cached := p.getCachedDurableMessages(chatID, lastMessageID)
+					// publishMessage runs from PromoteQueued and the worker
+					// concurrently; PG commit reordering can land a lower-ID
+					// notify after lastMessageID has already advanced. Look up
+					// from min(AfterMessageID, lastMessageID) and dedupe to
+					// rescan the gap without double-emitting.
+					lookupAfter := lastMessageID
+					if !notify.FullRefresh && notify.AfterMessageID < lookupAfter {
+						lookupAfter = notify.AfterMessageID
+					}
+					cached := p.getCachedDurableMessages(chatID, lookupAfter)
+					deliveredAny := false
 					if !notify.FullRefresh && len(cached) > 0 {
 						source = "cache"
 						for _, event := range cached {
+							if event.Message == nil {
+								continue
+							}
+							if _, ok := delivered[event.Message.ID]; ok {
+								continue
+							}
 							select {
 							case <-mergedCtx.Done():
 								return
 							case mergedEvents <- event:
 							}
-							lastMessageID = event.Message.ID
-						}
-						deliveredCount = len(cached)
-					} else if newMessages, msgErr := p.db.GetChatMessagesByChatID(mergedCtx, database.GetChatMessagesByChatIDParams{
-						ChatID:  chatID,
-						AfterID: lastMessageID,
-					}); msgErr != nil {
-						p.logger.Warn(mergedCtx, "failed to get chat messages after pubsub notification",
-							slog.F("chat_id", chatID),
-							slog.Error(msgErr),
-						)
-					} else {
-						source = "db"
-						for _, msg := range newMessages {
-							if msg.ID <= lastMessageID {
-								continue
+							delivered[event.Message.ID] = struct{}{}
+							if event.Message.ID > lastMessageID {
+								lastMessageID = event.Message.ID
 							}
-							sdkMsg := db2sdk.ChatMessage(msg)
-							select {
-							case <-mergedCtx.Done():
-								return
-							case mergedEvents <- codersdk.ChatStreamEvent{
-								Type:    codersdk.ChatStreamEventTypeMessage,
-								ChatID:  chatID,
-								Message: &sdkMsg,
-							}:
-							}
-							lastMessageID = msg.ID
 							deliveredCount++
+							deliveredAny = true
+						}
+					}
+					if !deliveredAny {
+						newMessages, msgErr := p.db.GetChatMessagesByChatID(mergedCtx, database.GetChatMessagesByChatIDParams{
+							ChatID:  chatID,
+							AfterID: lookupAfter,
+						})
+						if msgErr != nil {
+							p.logger.Warn(mergedCtx, "failed to get chat messages after pubsub notification",
+								slog.F("chat_id", chatID),
+								slog.Error(msgErr),
+							)
+						} else {
+							source = "db"
+							for _, msg := range newMessages {
+								if msg.ID <= lookupAfter {
+									continue
+								}
+								if _, ok := delivered[msg.ID]; ok {
+									continue
+								}
+								sdkMsg := db2sdk.ChatMessage(msg)
+								select {
+								case <-mergedCtx.Done():
+									return
+								case mergedEvents <- codersdk.ChatStreamEvent{
+									Type:    codersdk.ChatStreamEventTypeMessage,
+									ChatID:  chatID,
+									Message: &sdkMsg,
+								}:
+								}
+								delivered[msg.ID] = struct{}{}
+								if msg.ID > lastMessageID {
+									lastMessageID = msg.ID
+								}
+								deliveredCount++
+							}
 						}
 					}
 					// Marker for ENG-2645: subscriber delivered durable messages.

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -5007,7 +5007,7 @@ func (p *Server) SubscribeAuthorized(
 				if notify.AfterMessageID > 0 || notify.FullRefresh {
 					if notify.FullRefresh {
 						lastMessageID = 0
-						delivered = map[int64]struct{}{}
+						clear(delivered)
 					}
 					var (
 						deliveredCount int
@@ -5016,14 +5016,15 @@ func (p *Server) SubscribeAuthorized(
 					// publishMessage runs from PromoteQueued and the worker
 					// concurrently; PG commit reordering can land a lower-ID
 					// notify after lastMessageID has already advanced. Look up
-					// from min(AfterMessageID, lastMessageID) and dedupe to
-					// rescan the gap without double-emitting.
+					// from min(AfterMessageID, lastMessageID) so a late notify
+					// rescans the gap, but never below afterMessageID, which is
+					// the boundary the caller already has via REST. The
+					// delivered set deduplicates either source.
 					lookupAfter := lastMessageID
-					if !notify.FullRefresh && notify.AfterMessageID < lookupAfter {
-						lookupAfter = notify.AfterMessageID
+					if !notify.FullRefresh {
+						lookupAfter = max(afterMessageID, min(notify.AfterMessageID, lastMessageID))
 					}
 					cached := p.getCachedDurableMessages(chatID, lookupAfter)
-					deliveredAny := false
 					if !notify.FullRefresh && len(cached) > 0 {
 						source = "cache"
 						for _, event := range cached {
@@ -5043,43 +5044,48 @@ func (p *Server) SubscribeAuthorized(
 								lastMessageID = event.Message.ID
 							}
 							deliveredCount++
-							deliveredAny = true
 						}
 					}
-					if !deliveredAny {
-						newMessages, msgErr := p.db.GetChatMessagesByChatID(mergedCtx, database.GetChatMessagesByChatIDParams{
-							ChatID:  chatID,
-							AfterID: lookupAfter,
-						})
-						if msgErr != nil {
-							p.logger.Warn(mergedCtx, "failed to get chat messages after pubsub notification",
-								slog.F("chat_id", chatID),
-								slog.Error(msgErr),
-							)
-						} else {
-							source = "db"
-							for _, msg := range newMessages {
-								if msg.ID <= lookupAfter {
-									continue
-								}
-								if _, ok := delivered[msg.ID]; ok {
-									continue
-								}
-								sdkMsg := db2sdk.ChatMessage(msg)
-								select {
-								case <-mergedCtx.Done():
-									return
-								case mergedEvents <- codersdk.ChatStreamEvent{
-									Type:    codersdk.ChatStreamEventTypeMessage,
-									ChatID:  chatID,
-									Message: &sdkMsg,
-								}:
-								}
-								delivered[msg.ID] = struct{}{}
-								if msg.ID > lastMessageID {
-									lastMessageID = msg.ID
-								}
-								deliveredCount++
+					// The DB is authoritative for cross-replica messages the
+					// local cache cannot have. Always run it; the delivered
+					// set dedupes against the cache pass.
+					newMessages, msgErr := p.db.GetChatMessagesByChatID(mergedCtx, database.GetChatMessagesByChatIDParams{
+						ChatID:  chatID,
+						AfterID: lookupAfter,
+					})
+					if msgErr != nil {
+						p.logger.Warn(mergedCtx, "failed to get chat messages after pubsub notification",
+							slog.F("chat_id", chatID),
+							slog.Error(msgErr),
+						)
+					} else {
+						for _, msg := range newMessages {
+							if msg.ID <= lookupAfter {
+								continue
+							}
+							if _, ok := delivered[msg.ID]; ok {
+								continue
+							}
+							sdkMsg := db2sdk.ChatMessage(msg)
+							select {
+							case <-mergedCtx.Done():
+								return
+							case mergedEvents <- codersdk.ChatStreamEvent{
+								Type:    codersdk.ChatStreamEventTypeMessage,
+								ChatID:  chatID,
+								Message: &sdkMsg,
+							}:
+							}
+							delivered[msg.ID] = struct{}{}
+							if msg.ID > lastMessageID {
+								lastMessageID = msg.ID
+							}
+							deliveredCount++
+							switch source {
+							case "":
+								source = "db"
+							case "cache":
+								source = "cache+db"
 							}
 						}
 					}
@@ -5087,6 +5093,7 @@ func (p *Server) SubscribeAuthorized(
 					p.logger.Debug(mergedCtx, "stream subscriber delivered messages",
 						slog.F("chat_id", chatID),
 						slog.F("after_message_id", notify.AfterMessageID),
+						slog.F("lookup_after", lookupAfter),
 						slog.F("source", source),
 						slog.F("delivered_count", deliveredCount),
 						slog.F("last_message_id", lastMessageID),

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -1994,7 +1994,7 @@ func TestTurnWorkspaceContext_EnsureWorkspaceAgentIgnoresCachedAgentForDifferent
 	require.Equal(t, updatedChat, currentChat)
 }
 
-func TestSubscribeSkipsDatabaseCatchupForLocallyDeliveredMessage(t *testing.T) {
+func TestSubscribeDedupesLocallyDeliveredMessageOnNotifyCatchup(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancelCtx := context.WithCancel(context.Background())
@@ -2023,6 +2023,12 @@ func TestSubscribeSkipsDatabaseCatchupForLocallyDeliveredMessage(t *testing.T) {
 			AfterID: 0,
 		}).Return([]database.ChatMessage{initialMessage}, nil),
 		db.EXPECT().GetChatQueuedMessages(gomock.Any(), chatID).Return(nil, nil),
+		// DB catchup runs unconditionally on every notify; the delivered
+		// set dedupes against locally-delivered messages.
+		db.EXPECT().GetChatMessagesByChatID(gomock.Any(), database.GetChatMessagesByChatIDParams{
+			ChatID:  chatID,
+			AfterID: 1,
+		}).Return(nil, nil),
 	)
 
 	server := newSubscribeTestServer(t, db)
@@ -2066,6 +2072,12 @@ func TestSubscribeUsesDurableCacheWhenLocalMessageWasNotDelivered(t *testing.T) 
 			AfterID: 0,
 		}).Return([]database.ChatMessage{initialMessage}, nil),
 		db.EXPECT().GetChatQueuedMessages(gomock.Any(), chatID).Return(nil, nil),
+		// DB catchup runs unconditionally; cached id=2 is deduped via
+		// the delivered set so this query returning nil is sufficient.
+		db.EXPECT().GetChatMessagesByChatID(gomock.Any(), database.GetChatMessagesByChatIDParams{
+			ChatID:  chatID,
+			AfterID: 1,
+		}).Return(nil, nil),
 	)
 
 	server := newSubscribeTestServer(t, db)

--- a/coderd/x/chatd/subscribe_out_of_order_internal_test.go
+++ b/coderd/x/chatd/subscribe_out_of_order_internal_test.go
@@ -2,6 +2,7 @@ package chatd
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -14,11 +15,9 @@ import (
 	"github.com/coder/coder/v2/testutil"
 )
 
-// TestSubscribeDeliversOutOfOrderDurableMessage covers the case where
-// the durable cache receives a higher-ID message before a lower-ID one,
-// then a notify arrives for the lower-ID. The merge goroutine has
-// already advanced lastMessageID past the lower ID, so it must rescan
-// the gap range and dedupe.
+// TestSubscribeDeliversOutOfOrderDurableMessage tests that a
+// late-arriving lower-ID durable message is delivered when a
+// higher-ID was already cached and sent.
 func TestSubscribeDeliversOutOfOrderDurableMessage(t *testing.T) {
 	t.Parallel()
 
@@ -91,14 +90,12 @@ func TestSubscribeDeliversOutOfOrderDurableMessage(t *testing.T) {
 	require.NotNil(t, third.Message)
 	require.Equal(t, int64(6), third.Message.ID)
 
-	requireNoStreamEvent(t, events, testutil.IntervalFast)
+	requireNoStreamEvent(t, events, 200*time.Millisecond)
 }
 
-// TestSubscribeRespectsAfterMessageIDOnLateNotify guards against
-// re-emitting messages the subscriber already has via the REST
-// snapshot. A reconnecting client passes afterMessageID > 0 to skip
-// the initial replay; lookupAfter must not drop below that boundary
-// even when a late notify reports AfterMessageID below it.
+// TestSubscribeRespectsAfterMessageIDOnLateNotify tests that
+// lookupAfter never drops below afterMessageID, preventing
+// re-emission of messages the client already has via REST.
 func TestSubscribeRespectsAfterMessageIDOnLateNotify(t *testing.T) {
 	t.Parallel()
 
@@ -147,14 +144,12 @@ func TestSubscribeRespectsAfterMessageIDOnLateNotify(t *testing.T) {
 	require.Equal(t, int64(101), ev.Message.ID,
 		"messages at or below afterMessageID must not be re-emitted")
 
-	requireNoStreamEvent(t, events, testutil.IntervalFast)
+	requireNoStreamEvent(t, events, 200*time.Millisecond)
 }
 
-// TestSubscribeRunsDBFallbackWhenCacheDeliversUnrelatedMessage
-// guards against the deliveredAny gate that historically skipped the
-// DB fallback whenever the cache contributed anything. The DB is
-// authoritative for cross-replica messages the local cache cannot
-// hold, so both passes must always run on every notify.
+// TestSubscribeRunsDBFallbackWhenCacheDeliversUnrelatedMessage tests
+// that the DB fallback runs even when the cache delivers, so
+// cross-replica messages are not dropped.
 func TestSubscribeRunsDBFallbackWhenCacheDeliversUnrelatedMessage(t *testing.T) {
 	t.Parallel()
 
@@ -213,5 +208,5 @@ func TestSubscribeRunsDBFallbackWhenCacheDeliversUnrelatedMessage(t *testing.T) 
 	require.True(t, got[6], "cross-replica DB message id=6 must be delivered")
 	require.True(t, got[8], "locally-cached message id=8 must be delivered")
 
-	requireNoStreamEvent(t, events, testutil.IntervalFast)
+	requireNoStreamEvent(t, events, 200*time.Millisecond)
 }

--- a/coderd/x/chatd/subscribe_out_of_order_internal_test.go
+++ b/coderd/x/chatd/subscribe_out_of_order_internal_test.go
@@ -1,9 +1,7 @@
 package chatd
 
 import (
-	"context"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -13,6 +11,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbmock"
 	coderdpubsub "github.com/coder/coder/v2/coderd/pubsub"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
 )
 
 // TestSubscribeDeliversOutOfOrderDurableMessage covers the case where
@@ -23,8 +22,7 @@ import (
 func TestSubscribeDeliversOutOfOrderDurableMessage(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	defer cancelCtx()
+	ctx := testutil.Context(t, testutil.WaitMedium)
 
 	ctrl := gomock.NewController(t)
 	db := dbmock.NewMockStore(ctrl)
@@ -34,19 +32,22 @@ func TestSubscribeDeliversOutOfOrderDurableMessage(t *testing.T) {
 	initialUser := database.ChatMessage{ID: 3, ChatID: chatID, Role: database.ChatMessageRoleUser}
 	initialAssistant := database.ChatMessage{ID: 4, ChatID: chatID, Role: database.ChatMessageRoleAssistant}
 
-	db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(chat, nil).AnyTimes()
-	db.EXPECT().GetChatMessagesByChatID(gomock.Any(), database.GetChatMessagesByChatIDParams{
-		ChatID:  chatID,
-		AfterID: 0,
-	}).Return([]database.ChatMessage{initialUser, initialAssistant}, nil).AnyTimes()
-	db.EXPECT().GetChatQueuedMessages(gomock.Any(), chatID).Return(nil, nil).AnyTimes()
-	// Catch-up queries return nothing so the test only exercises the
-	// cache delivery path.
+	gomock.InOrder(
+		db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(chat, nil),
+		db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(chat, nil),
+		db.EXPECT().GetChatMessagesByChatID(gomock.Any(), database.GetChatMessagesByChatIDParams{
+			ChatID:  chatID,
+			AfterID: 0,
+		}).Return([]database.ChatMessage{initialUser, initialAssistant}, nil),
+		db.EXPECT().GetChatQueuedMessages(gomock.Any(), chatID).Return(nil, nil),
+	)
+	// Notify-driven catch-up queries return nothing so the test only
+	// exercises the cache delivery path.
 	db.EXPECT().GetChatMessagesByChatID(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
 	server := newSubscribeTestServer(t, db)
 
-	synth := codersdk.ChatMessage{ID: 5, ChatID: chatID, Role: codersdk.ChatMessageRoleTool}
+	toolResult := codersdk.ChatMessage{ID: 5, ChatID: chatID, Role: codersdk.ChatMessageRoleTool}
 	resumed := codersdk.ChatMessage{ID: 7, ChatID: chatID, Role: codersdk.ChatMessageRoleAssistant}
 	promoted := codersdk.ChatMessage{ID: 6, ChatID: chatID, Role: codersdk.ChatMessageRoleUser}
 
@@ -62,16 +63,20 @@ func TestSubscribeDeliversOutOfOrderDurableMessage(t *testing.T) {
 	// Cache id=5 and id=7, but not id=6, then emit the notify for
 	// id=5. The merge goroutine drains [5, 7] from the cache.
 	server.cacheDurableMessage(chatID, codersdk.ChatStreamEvent{
-		Type: codersdk.ChatStreamEventTypeMessage, ChatID: chatID, Message: &synth,
+		Type: codersdk.ChatStreamEventTypeMessage, ChatID: chatID, Message: &toolResult,
 	})
 	server.cacheDurableMessage(chatID, codersdk.ChatStreamEvent{
 		Type: codersdk.ChatStreamEventTypeMessage, ChatID: chatID, Message: &resumed,
 	})
 	server.publishChatStreamNotify(chatID, coderdpubsub.ChatStreamNotifyMessage{AfterMessageID: 4})
 
-	first := requireStreamMessageEvent(t, events)
+	first := testutil.RequireReceive(ctx, t, events)
+	require.Equal(t, codersdk.ChatStreamEventTypeMessage, first.Type)
+	require.NotNil(t, first.Message)
 	require.Equal(t, int64(5), first.Message.ID)
-	second := requireStreamMessageEvent(t, events)
+	second := testutil.RequireReceive(ctx, t, events)
+	require.Equal(t, codersdk.ChatStreamEventTypeMessage, second.Type)
+	require.NotNil(t, second.Message)
 	require.Equal(t, int64(7), second.Message.ID)
 
 	// Cache id=6 after the merge goroutine has already advanced
@@ -81,12 +86,132 @@ func TestSubscribeDeliversOutOfOrderDurableMessage(t *testing.T) {
 	})
 	server.publishChatStreamNotify(chatID, coderdpubsub.ChatStreamNotifyMessage{AfterMessageID: 5})
 
-	select {
-	case ev := <-events:
-		require.Equal(t, codersdk.ChatStreamEventTypeMessage, ev.Type)
-		require.NotNil(t, ev.Message)
-		require.Equal(t, int64(6), ev.Message.ID)
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for out-of-order durable message")
+	third := testutil.RequireReceive(ctx, t, events)
+	require.Equal(t, codersdk.ChatStreamEventTypeMessage, third.Type)
+	require.NotNil(t, third.Message)
+	require.Equal(t, int64(6), third.Message.ID)
+
+	requireNoStreamEvent(t, events, testutil.IntervalFast)
+}
+
+// TestSubscribeRespectsAfterMessageIDOnLateNotify guards against
+// re-emitting messages the subscriber already has via the REST
+// snapshot. A reconnecting client passes afterMessageID > 0 to skip
+// the initial replay; lookupAfter must not drop below that boundary
+// even when a late notify reports AfterMessageID below it.
+func TestSubscribeRespectsAfterMessageIDOnLateNotify(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitMedium)
+
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+
+	chatID := uuid.New()
+	chat := database.Chat{ID: chatID, Status: database.ChatStatusRunning}
+
+	gomock.InOrder(
+		db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(chat, nil),
+		db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(chat, nil),
+		db.EXPECT().GetChatMessagesByChatID(gomock.Any(), database.GetChatMessagesByChatIDParams{
+			ChatID:  chatID,
+			AfterID: 100,
+		}).Return(nil, nil),
+		db.EXPECT().GetChatQueuedMessages(gomock.Any(), chatID).Return(nil, nil),
+	)
+	db.EXPECT().GetChatMessagesByChatID(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	server := newSubscribeTestServer(t, db)
+
+	// Seed the cache with messages the client claims to already have
+	// (id<=100) plus one new message (id=101).
+	for _, id := range []int64{96, 97, 98, 99, 100, 101} {
+		msg := &codersdk.ChatMessage{ID: id, ChatID: chatID, Role: codersdk.ChatMessageRoleAssistant}
+		server.cacheDurableMessage(chatID, codersdk.ChatStreamEvent{
+			Type: codersdk.ChatStreamEventTypeMessage, ChatID: chatID, Message: msg,
+		})
 	}
+
+	_, events, cancel, ok := server.Subscribe(ctx, chatID, nil, 100)
+	require.True(t, ok)
+	defer cancel()
+
+	// A stale notify with AfterMessageID=95 would naively pull
+	// id=96..101 back from the cache; only id=101 should reach the
+	// live stream because the client already has 96-100.
+	server.publishChatStreamNotify(chatID, coderdpubsub.ChatStreamNotifyMessage{AfterMessageID: 95})
+
+	ev := testutil.RequireReceive(ctx, t, events)
+	require.Equal(t, codersdk.ChatStreamEventTypeMessage, ev.Type)
+	require.NotNil(t, ev.Message)
+	require.Equal(t, int64(101), ev.Message.ID,
+		"messages at or below afterMessageID must not be re-emitted")
+
+	requireNoStreamEvent(t, events, testutil.IntervalFast)
+}
+
+// TestSubscribeRunsDBFallbackWhenCacheDeliversUnrelatedMessage
+// guards against the deliveredAny gate that historically skipped the
+// DB fallback whenever the cache contributed anything. The DB is
+// authoritative for cross-replica messages the local cache cannot
+// hold, so both passes must always run on every notify.
+func TestSubscribeRunsDBFallbackWhenCacheDeliversUnrelatedMessage(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitMedium)
+
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+
+	chatID := uuid.New()
+	chat := database.Chat{ID: chatID, Status: database.ChatStatusRunning}
+	crossReplica := database.ChatMessage{ID: 6, ChatID: chatID, Role: database.ChatMessageRoleUser}
+
+	gomock.InOrder(
+		db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(chat, nil),
+		db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(chat, nil),
+		// Snapshot: nothing above the client's afterMessageID=5 yet.
+		db.EXPECT().GetChatMessagesByChatID(gomock.Any(), database.GetChatMessagesByChatIDParams{
+			ChatID:  chatID,
+			AfterID: 5,
+		}).Return(nil, nil),
+		db.EXPECT().GetChatQueuedMessages(gomock.Any(), chatID).Return(nil, nil),
+		// Notify catchup: the cross-replica message lives only in the
+		// DB on this replica.
+		db.EXPECT().GetChatMessagesByChatID(gomock.Any(), database.GetChatMessagesByChatIDParams{
+			ChatID:  chatID,
+			AfterID: 5,
+		}).Return([]database.ChatMessage{crossReplica}, nil),
+	)
+
+	server := newSubscribeTestServer(t, db)
+
+	// Cache a locally-published higher-ID message so the cache pass
+	// has something to deliver without covering id=6.
+	localOnly := codersdk.ChatMessage{ID: 8, ChatID: chatID, Role: codersdk.ChatMessageRoleAssistant}
+	server.cacheDurableMessage(chatID, codersdk.ChatStreamEvent{
+		Type: codersdk.ChatStreamEventTypeMessage, ChatID: chatID, Message: &localOnly,
+	})
+
+	_, events, cancel, ok := server.Subscribe(ctx, chatID, nil, 5)
+	require.True(t, ok)
+	defer cancel()
+
+	server.publishChatStreamNotify(chatID, coderdpubsub.ChatStreamNotifyMessage{AfterMessageID: 5})
+
+	// The cache pass delivers id=8; the DB pass must still run and
+	// deliver id=6. Order between them is set by cache iteration vs
+	// DB query, so accept either ordering.
+	first := testutil.RequireReceive(ctx, t, events)
+	require.Equal(t, codersdk.ChatStreamEventTypeMessage, first.Type)
+	require.NotNil(t, first.Message)
+	second := testutil.RequireReceive(ctx, t, events)
+	require.Equal(t, codersdk.ChatStreamEventTypeMessage, second.Type)
+	require.NotNil(t, second.Message)
+
+	got := map[int64]bool{first.Message.ID: true, second.Message.ID: true}
+	require.True(t, got[6], "cross-replica DB message id=6 must be delivered")
+	require.True(t, got[8], "locally-cached message id=8 must be delivered")
+
+	requireNoStreamEvent(t, events, testutil.IntervalFast)
 }

--- a/coderd/x/chatd/subscribe_out_of_order_internal_test.go
+++ b/coderd/x/chatd/subscribe_out_of_order_internal_test.go
@@ -1,0 +1,92 @@
+package chatd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbmock"
+	coderdpubsub "github.com/coder/coder/v2/coderd/pubsub"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+// TestSubscribeDeliversOutOfOrderDurableMessage covers the case where
+// the durable cache receives a higher-ID message before a lower-ID one,
+// then a notify arrives for the lower-ID. The merge goroutine has
+// already advanced lastMessageID past the lower ID, so it must rescan
+// the gap range and dedupe.
+func TestSubscribeDeliversOutOfOrderDurableMessage(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
+
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+
+	chatID := uuid.New()
+	chat := database.Chat{ID: chatID, Status: database.ChatStatusRequiresAction}
+	initialUser := database.ChatMessage{ID: 3, ChatID: chatID, Role: database.ChatMessageRoleUser}
+	initialAssistant := database.ChatMessage{ID: 4, ChatID: chatID, Role: database.ChatMessageRoleAssistant}
+
+	db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(chat, nil).AnyTimes()
+	db.EXPECT().GetChatMessagesByChatID(gomock.Any(), database.GetChatMessagesByChatIDParams{
+		ChatID:  chatID,
+		AfterID: 0,
+	}).Return([]database.ChatMessage{initialUser, initialAssistant}, nil).AnyTimes()
+	db.EXPECT().GetChatQueuedMessages(gomock.Any(), chatID).Return(nil, nil).AnyTimes()
+	// Catch-up queries return nothing so the test only exercises the
+	// cache delivery path.
+	db.EXPECT().GetChatMessagesByChatID(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	server := newSubscribeTestServer(t, db)
+
+	synth := codersdk.ChatMessage{ID: 5, ChatID: chatID, Role: codersdk.ChatMessageRoleTool}
+	resumed := codersdk.ChatMessage{ID: 7, ChatID: chatID, Role: codersdk.ChatMessageRoleAssistant}
+	promoted := codersdk.ChatMessage{ID: 6, ChatID: chatID, Role: codersdk.ChatMessageRoleUser}
+
+	server.cacheDurableMessage(chatID, codersdk.ChatStreamEvent{
+		Type: codersdk.ChatStreamEventTypeMessage, ChatID: chatID,
+		Message: &codersdk.ChatMessage{ID: 4, ChatID: chatID, Role: codersdk.ChatMessageRoleAssistant},
+	})
+
+	_, events, cancel, ok := server.Subscribe(ctx, chatID, nil, 0)
+	require.True(t, ok)
+	defer cancel()
+
+	// Cache id=5 and id=7, but not id=6, then emit the notify for
+	// id=5. The merge goroutine drains [5, 7] from the cache.
+	server.cacheDurableMessage(chatID, codersdk.ChatStreamEvent{
+		Type: codersdk.ChatStreamEventTypeMessage, ChatID: chatID, Message: &synth,
+	})
+	server.cacheDurableMessage(chatID, codersdk.ChatStreamEvent{
+		Type: codersdk.ChatStreamEventTypeMessage, ChatID: chatID, Message: &resumed,
+	})
+	server.publishChatStreamNotify(chatID, coderdpubsub.ChatStreamNotifyMessage{AfterMessageID: 4})
+
+	first := requireStreamMessageEvent(t, events)
+	require.Equal(t, int64(5), first.Message.ID)
+	second := requireStreamMessageEvent(t, events)
+	require.Equal(t, int64(7), second.Message.ID)
+
+	// Cache id=6 after the merge goroutine has already advanced
+	// lastMessageID to 7, then emit the notify for id=6.
+	server.cacheDurableMessage(chatID, codersdk.ChatStreamEvent{
+		Type: codersdk.ChatStreamEventTypeMessage, ChatID: chatID, Message: &promoted,
+	})
+	server.publishChatStreamNotify(chatID, coderdpubsub.ChatStreamNotifyMessage{AfterMessageID: 5})
+
+	select {
+	case ev := <-events:
+		require.Equal(t, codersdk.ChatStreamEventTypeMessage, ev.Type)
+		require.NotNil(t, ev.Message)
+		require.Equal(t, int64(6), ev.Message.ID)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for out-of-order durable message")
+	}
+}


### PR DESCRIPTION
The merge goroutine in `SubscribeAuthorized` tracks delivered messages with a monotonic `lastMessageID` and keyed both the durable cache lookup and the DB fallback off it. When `publishMessage` runs concurrently from `PromoteQueued` and the worker that resumes after the promote, the cache can be populated with the worker's higher-ID resumed-assistant message before the lower-ID promoted user message; PG NOTIFY commit reordering on a busy connection pool can also flip the order in which the subscriber sees notifies. Either way `lastMessageID` advances past the lower ID and the late notify rescans nothing, so the promoted user message is silently dropped from the live stream.

Look up the durable cache from `max(afterMessageID, min(notify.AfterMessageID, lastMessageID))` and dedupe deliveries through a set seeded from the initial DB snapshot. The `min` rescans the gap on a late notify; the `max` keeps the rescan above the subscription boundary so a reconnecting client is not re-served messages it already has via REST. The DB fallback runs unconditionally with the same `lookupAfter` and the same `delivered` dedupe, so cross-replica messages that live only in the DB are not eaten when the local cache contributes an unrelated newer item.

Closes coder/internal#1525
Closes [CODAGT-357](https://linear.app/codercom/issue/CODAGT-357/flake-testpromotequeuedwhilerequiresaction)

<details>
<summary>Investigation notes</summary>

Root cause was located by reproducing `TestPromoteQueuedWhileRequiresAction` under stress on a 96-core workspace (`N=48` parallel test binaries, 40 rounds each) and instrumenting `cacheDurableMessage` plus the merge goroutine's notify branch. Failures clustered around `~14/1900` runs with this exact pattern:

```
cacheDurableMessage id=4 role=assistant cache_ids=[4]
cacheDurableMessage id=5 role=tool      cache_ids=[4 5]
cacheDurableMessage id=7 role=assistant cache_ids=[4 5 7]   <- worker's resumed assistant
notify after_message_id=6  lastMessageID=4
notify cache lookup        lastMessageID=4 cached_ids=[5 7]
delivering id=5 role=tool
delivering id=7 role=assistant
cacheDurableMessage id=6 role=user      cache_ids=[4 5 7 6]   <- promoted, too late
notify after_message_id=4  lastMessageID=7
notify cache lookup        lastMessageID=7 cached_ids=[]
notify after_message_id=5  lastMessageID=7
notify cache lookup        lastMessageID=7 cached_ids=[]
```

`dlv exec` traces against the unfixed and fixed binaries (deterministic dbmock reproducer) confirm goroutine-by-goroutine:

Unfixed: cache fills `[4, 5, 7]`, merge delivers `5, 7`, then `6` lands; the next lookup at `lastMessageID=7` returns `[]`, so `6` is never emitted.

Fixed: same cache fill, `5` and `7` are delivered with `lookupAfter=4`. On the late notify with `AfterMessageID=5`, `lookupAfter=min(7,5)=5` rescans the cache, the delivered set skips the already-emitted `7`, `6` is delivered.

The stress reproduction at `~7%` referenced in earlier reports came from a more aggressive harness configuration (instrumented build with extra logging, dialed up parallelism) that exposed the timing more. Once instrumentation was removed the rate on this workspace stabilized at the `~0.7%` figure above; the underlying race is the same.

Round 1 review surfaced two adjacent regressions and one observability gap that this PR also addresses:

- A reconnecting client passes `afterMessageID > 0`. The original `lookupAfter` could drop below that boundary and re-emit messages the client already had via REST. Floor `lookupAfter` at `afterMessageID`.
- The cache pass and DB fallback were mutually exclusive via a `deliveredAny` gate. In multi-replica, the cache holds locally-published messages while cross-replica messages live only in the DB; a notify for a cross-replica message could be eaten when the cache happened to contain an unrelated newer item. Always run both passes; the delivered set dedupes.
- Added `lookup_after` to the delivered-messages log so the actual scan range is observable.

Validation:

- `go test ./coderd/x/chatd` and `./enterprise/coderd/x/chatd` pass.
- `go test -race ./coderd/x/chatd -run TestSubscribe\|TestPromoteQueued` passes.
- Stress harness `N=24 ROUNDS=20` (480 runs): 0 failures.
- Three deterministic regression tests in `coderd/x/chatd/subscribe_out_of_order_internal_test.go`: one for the original out-of-order race, one for the `afterMessageID` reconnect boundary, one for the cache+DB cross-replica gap. All fail without the fix and pass with it.

A producer-side alternative (per-chat publish mutex held across `PromoteQueued`'s post-TX publishes) would close the producer race but does not help PG NOTIFY commit reordering or cross-replica gaps. The consumer fix covers all three.

</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
