### PR TITLE
test(codersdk/toolsdk): scope err in SendTaskInput and GetTaskLogs subtests

### DIFF
--- a/codersdk/toolsdk/toolsdk_test.go
+++ b/codersdk/toolsdk/toolsdk_test.go
@@ -2139,7 +2139,7 @@ func TestTools(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitShort)
 
 		// Ensure the app is healthy (required to send task input).
-		err = store.UpdateWorkspaceAppHealthByID(dbauthz.AsSystemRestricted(ctx), database.UpdateWorkspaceAppHealthByIDParams{
+		err := store.UpdateWorkspaceAppHealthByID(dbauthz.AsSystemRestricted(ctx), database.UpdateWorkspaceAppHealthByIDParams{
 			ID:     task.WorkspaceAppID.UUID,
 			Health: database.WorkspaceAppHealthHealthy,
 		})
@@ -2279,7 +2279,7 @@ func TestTools(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitShort)
 
 		// Ensure the app is healthy (required to read task logs).
-		err = store.UpdateWorkspaceAppHealthByID(dbauthz.AsSystemRestricted(ctx), database.UpdateWorkspaceAppHealthByIDParams{
+		err := store.UpdateWorkspaceAppHealthByID(dbauthz.AsSystemRestricted(ctx), database.UpdateWorkspaceAppHealthByIDParams{
 			ID:     task.WorkspaceAppID.UUID,
 			Health: database.WorkspaceAppHealthHealthy,
 		})


### PR DESCRIPTION
Both `TestTools/SendTaskInput` and `TestTools/GetTaskLogs` subtests run with `t.Parallel()` and write to the outer-scope `err` (declared in `TestTools` at `ws, err := client.Workspace(setupCtx, r.Workspace.ID)`) via `err = store.UpdateWorkspaceAppHealthByID(...)`. Two parallel goroutines updating the same `err` is a data race.

Fix: use `:=` so each subtest gets its own local `err`.

Fixes coder/internal#1475 ([Linear CODAGT-364](https://linear.app/codercom/issue/CODAGT-364/flake-testtools-data-race-on-shared-err-variable-sendtaskinput)).

<details>
<summary>Investigation</summary>

The race was reported with a stack trace passing through `dbfake.WorkspaceBuildBuilder.doInTX` at `dbfake.go:463`, which made the root cause look like a `dbfake` issue. It is not. Two checks confirm the outer-scope `err` is the racy variable:

1. Adding `t.Logf("&err=%p", &err)` at both write sites prints the same address from the two parallel subtest goroutines.
2. `dlv` breakpoints at both lines show the same `*error` pointer with a simple call stack: `func3X -> testing.tRunner -> testing.(*T).Run.gowrap1 -> runtime.goexit`. No `dbfake` frames are present at the actual write site.

The `dbfake.WorkspaceBuildBuilder.doInTX` frames in the CI race trace are an artifact of inlined-frame reporting in Go's race detector with `-race`; they do not represent the physical stack at the assignment.

Reproduction (on the bug commit fb53003, before the fix):

```
cd codersdk/toolsdk
go test -race -run 'TestTools$' -count=2 -timeout 5m
```

With the fix applied: 20 race-enabled runs (`-count=2 × 10 iterations`) of the full `TestTools` suite pass with no race detected.

</details>

---
Disclosure: prepared with assistance from a Coder Agents bot.