### PR TITLE
fix(coderd/database): filter instance-identity lookup to latest build per workspace

### DIFF
--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -7518,6 +7518,71 @@ func TestGetWorkspaceBuildAgentsByInstanceID(t *testing.T) {
 		assert.Equal(t, active.Agent.ID, agents[0].WorkspaceAgent.ID)
 		assert.Equal(t, active.Workspace.ID, agents[0].WorkspaceTable.ID)
 	})
+
+	// Regression: stale agents from prior builds of the same workspace
+	// must not appear, even when they have not been soft-deleted. This is
+	// the core scenario that caused HTTP 409 errors on upgrade to v2.33.
+	t.Run("ExcludesStaleAgentsFromPriorBuilds", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := dbtestutil.NewDB(t)
+		authInstanceID := fmt.Sprintf("instance-%s-%d", t.Name(), time.Now().UnixNano())
+		baseCreatedAt := dbtime.Now()
+
+		// Create one workspace with three successive builds, all
+		// sharing the same instance ID (typical EC2 fleet pattern).
+		workspace := setupWorkspaceBuildAgentQueryWorkspace(t, db, false)
+
+		// Build helper that creates a build with an explicit build
+		// number, then attaches an agent with the shared instance ID.
+		createBuildAgent := func(buildNum int32, agentCreatedAt time.Time) workspaceBuildAgentQueryFixture {
+			t.Helper()
+			templateVersion := dbgen.TemplateVersion(t, db, database.TemplateVersion{
+				TemplateID:     uuid.NullUUID{UUID: workspace.TemplateID, Valid: true},
+				OrganizationID: workspace.OrganizationID,
+				CreatedBy:      workspace.OwnerID,
+			})
+			job := dbgen.ProvisionerJob(t, db, nil, database.ProvisionerJob{
+				OrganizationID: workspace.OrganizationID,
+				Type:           database.ProvisionerJobTypeWorkspaceBuild,
+			})
+			build := dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{
+				WorkspaceID:       workspace.ID,
+				TemplateVersionID: templateVersion.ID,
+				JobID:             job.ID,
+				BuildNumber:       buildNum,
+			})
+			resource := dbgen.WorkspaceResource(t, db, database.WorkspaceResource{
+				JobID: job.ID,
+			})
+			agent := dbgen.WorkspaceAgent(t, db, database.WorkspaceAgent{
+				Name:       "dev",
+				ResourceID: resource.ID,
+				CreatedAt:  agentCreatedAt,
+				AuthInstanceID: sql.NullString{
+					String: authInstanceID,
+					Valid:  true,
+				},
+			})
+			return workspaceBuildAgentQueryFixture{
+				Workspace: workspace,
+				Build:     build,
+				Agent:     agent,
+			}
+		}
+
+		_ = createBuildAgent(1, baseCreatedAt.Add(-2*time.Hour))
+		_ = createBuildAgent(2, baseCreatedAt.Add(-time.Hour))
+		latest := createBuildAgent(3, baseCreatedAt)
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		agents, err := db.GetWorkspaceBuildAgentsByInstanceID(ctx, authInstanceID)
+		require.NoError(t, err)
+		require.Len(t, agents, 1, "only the latest build's agent should be returned")
+		assert.Equal(t, latest.Agent.ID, agents[0].WorkspaceAgent.ID)
+		assert.Equal(t, latest.Build.ID, agents[0].WorkspaceBuildID)
+	})
 }
 
 func requireUsersMatch(t testing.TB, expected []database.User, found []database.GetUsersRow, msg string) {

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -30240,6 +30240,17 @@ WHERE
 	AND workspace_agents.parent_id IS NULL
 	AND provisioner_jobs.type = 'workspace_build'::provisioner_job_type
 	AND workspaces.deleted = FALSE
+	-- Only include agents from the latest build of each workspace.
+	-- This filters out stale agents from prior builds that share
+	-- the same instance ID, preventing false ambiguity (HTTP 409)
+	-- without requiring a backfill migration.
+	AND workspace_builds.id = (
+		SELECT wb2.id
+		FROM workspace_builds AS wb2
+		WHERE wb2.workspace_id = workspace_builds.workspace_id
+		ORDER BY wb2.build_number DESC
+		LIMIT 1
+	)
 ORDER BY
 	workspace_agents.created_at DESC
 `

--- a/coderd/database/queries/workspaceagents.sql
+++ b/coderd/database/queries/workspaceagents.sql
@@ -51,6 +51,17 @@ WHERE
 	AND workspace_agents.parent_id IS NULL
 	AND provisioner_jobs.type = 'workspace_build'::provisioner_job_type
 	AND workspaces.deleted = FALSE
+	-- Only include agents from the latest build of each workspace.
+	-- This filters out stale agents from prior builds that share
+	-- the same instance ID, preventing false ambiguity (HTTP 409)
+	-- without requiring a backfill migration.
+	AND workspace_builds.id = (
+		SELECT wb2.id
+		FROM workspace_builds AS wb2
+		WHERE wb2.workspace_id = workspace_builds.workspace_id
+		ORDER BY wb2.build_number DESC
+		LIMIT 1
+	)
 ORDER BY
 	workspace_agents.created_at DESC;
 


### PR DESCRIPTION
Fixes the HTTP 409 ambiguity errors that occur during instance-identity auth when stale workspace agents from prior builds accumulate with the same `auth_instance_id`.

## Problem

#24325 changed the instance-identity auth path from a `:one` lookup (which silently picked the newest agent) to a `:many` lookup with ambiguity rejection. This caused HTTP 409 errors for workspaces whose EC2/Azure/GCP instances had been through multiple builds, because old agents from prior builds (sharing the same instance ID) were still returned by the query.

#25207 addressed this with a backfill migration (000498) and runtime soft-delete calls. However, migrations cannot be backported to release branches.

## Solution

Add a subquery to `GetWorkspaceBuildAgentsByInstanceID` that restricts results to agents belonging to the latest build (`MAX(build_number)`) of each workspace. This filters out stale agents at query time, without requiring any migration or schema change.

The existing `latestHistory.ID != selected.WorkspaceBuildID` check in the handler remains as defense-in-depth for the recycled-instance-ID case.

<details><summary>Context</summary>

The soft-delete infrastructure from #25207 (runtime calls in `wsbuilder` and `provisionerdserver`) is still valuable as defense-in-depth for new deployments. This query-level fix is complementary and independently backportable.

</details>

> Generated by Coder Agents on behalf of @f0ssel