### PR TITLE
fix(coderd): skip stale agents from prior builds in instance-identity auth

### DIFF
--- a/coderd/workspaceresourceauth.go
+++ b/coderd/workspaceresourceauth.go
@@ -184,12 +184,44 @@ func (api *API) handleAuthInstanceID(rw http.ResponseWriter, r *http.Request, in
 			})
 			return
 		}
-		if job.Type == database.ProvisionerJobTypeWorkspaceBuild {
-			buildCandidates = append(buildCandidates, instanceCandidate{
-				agent: candidate,
-				job:   job,
-			})
+		if job.Type != database.ProvisionerJobTypeWorkspaceBuild {
+			continue
 		}
+		// Skip agents that are not from the latest build of their
+		// workspace. Without this, workspaces that have been through
+		// multiple builds accumulate agents sharing the same instance
+		// ID, causing a false HTTP 409 ambiguity error.
+		var jobData provisionerdserver.WorkspaceProvisionJob
+		if err := json.Unmarshal(job.Input, &jobData); err != nil {
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Internal error extracting job data.",
+				Detail:  err.Error(),
+			})
+			return
+		}
+		build, err := api.Database.GetWorkspaceBuildByID(systemCtx, jobData.WorkspaceBuildID)
+		if err != nil {
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Internal error fetching workspace build.",
+				Detail:  err.Error(),
+			})
+			return
+		}
+		latestBuild, err := api.Database.GetLatestWorkspaceBuildByWorkspaceID(systemCtx, build.WorkspaceID)
+		if err != nil {
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Internal error fetching the latest workspace build.",
+				Detail:  err.Error(),
+			})
+			return
+		}
+		if build.ID != latestBuild.ID {
+			continue
+		}
+		buildCandidates = append(buildCandidates, instanceCandidate{
+			agent: candidate,
+			job:   job,
+		})
 	}
 	if len(buildCandidates) == 0 {
 		httpapi.Write(ctx, rw, http.StatusNotFound, codersdk.Response{


### PR DESCRIPTION
Fixes the HTTP 409 ambiguity errors that occur during instance-identity auth when stale workspace agents from prior builds accumulate with the same `auth_instance_id`.

## Problem

#24325 changed the instance-identity auth path from a `:one` lookup (which silently picked the newest agent) to a `:many` lookup with ambiguity rejection. This caused HTTP 409 errors for workspaces whose EC2/Azure/GCP instances had been through multiple builds, because old agents from prior builds (sharing the same instance ID) were still returned by the query.

## Solution

Inside the existing per-candidate loop in `handleAuthInstanceID` (which already does per-candidate DB calls for resource and job lookups), add a latest-build check: parse the provisioner job input to get the workspace build, compare against the latest build for that workspace, and `continue` past candidates whose build is not current.

1 file changed, no SQL/migration/schema changes.

> Generated by Coder Agents on behalf of @f0ssel