### PR TITLE
fix(site): use ToolCollapsible for thinking blocks

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -2433,7 +2433,27 @@ export const WithEveryTool: Story = {
 			expect(canvas.getByText(/Editing 2 files/)).toBeInTheDocument();
 			expect(canvas.getByText(/Reading CHANGELOG\.md/)).toBeInTheDocument();
 			expect(canvas.getByText(/Writing CHANGELOG\.md/)).toBeInTheDocument();
+			expect(canvas.getByText(/Attached auth-split\.md/)).toBeInTheDocument();
+			expect(
+				canvas.getByRole("button", { name: /Spawned Workspace diagnostics/i }),
+			).toBeInTheDocument();
+			expect(
+				canvas.getByRole("button", { name: /Read skill deep-review/i }),
+			).toBeInTheDocument();
 		});
+
+		const rowHeights = [
+			canvas.getByText(/Attached auth-split\.md/),
+			canvas.getByRole("button", {
+				name: /Spawned Workspace diagnostics/i,
+			}),
+			canvas.getByRole("button", { name: /Read skill deep-review/i }),
+		].map((label) => {
+			const row = label.closest("[data-transcript-row]");
+			expect(row).toBeInstanceOf(HTMLElement);
+			return Math.round((row as HTMLElement).getBoundingClientRect().height);
+		});
+		expect(new Set(rowHeights)).toEqual(new Set([24]));
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -2228,6 +2228,9 @@ export const ThinkingBlockWithToolCall: Story = {
 		expect(thinkingContainer?.firstElementChild).not.toHaveAttribute(
 			"data-state",
 		);
+		expect(
+			canvas.queryByTestId("assistant-bottom-spacer"),
+		).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -2234,6 +2234,121 @@ export const ThinkingBlockWithToolCall: Story = {
 	},
 };
 
+/** Shell-style tool rows should keep the same collapsed height as Thinking. */
+export const ThinkingBlockWithShellTools: Story = {
+	parameters: {
+		queries: [
+			{
+				key: ["me", "preferences"],
+				data: {
+					task_notification_alert_dismissed: false,
+					thinking_display_mode: "always_collapsed" as const,
+					shell_tool_display_mode: "always_collapsed" as const,
+					code_diff_display_mode: "auto" as const,
+					agent_chat_send_shortcut: "enter" as const,
+				},
+			},
+		],
+	},
+	args: {
+		...defaultArgs,
+		parsedMessages: buildMessages([
+			{
+				...baseMessage,
+				id: 1,
+				role: "assistant",
+				content: [
+					{
+						type: "reasoning",
+						text: "I should inspect the current chat spacing before patching it.",
+					},
+					{
+						type: "tool-call",
+						tool_call_id: "tool-1",
+						tool_name: "execute",
+						args: { command: "pnpm test" },
+					},
+					{
+						type: "tool-call",
+						tool_call_id: "tool-2",
+						tool_name: "process_output",
+						args: { process_id: "process-1" },
+					},
+				],
+			},
+			{
+				...baseMessage,
+				id: 2,
+				role: "tool",
+				content: [
+					{
+						type: "tool-result",
+						tool_call_id: "tool-1",
+						tool_name: "execute",
+						result: { output: "", wall_duration_ms: "667" },
+					},
+				],
+			},
+			{
+				...baseMessage,
+				id: 3,
+				role: "tool",
+				content: [
+					{
+						type: "tool-result",
+						tool_call_id: "tool-2",
+						tool_name: "process_output",
+						result: { output: "Spacing looks stable." },
+					},
+				],
+			},
+		]),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const thinkingButton = canvas.getByRole("button", { name: /thinking/i });
+		const executeButton = canvas.getByRole("button", {
+			name: /expand command/i,
+		});
+		const processOutputButton = canvas.getByRole("button", {
+			name: /expand process output/i,
+		});
+
+		const thinkingRow =
+			thinkingButton.closest("[data-tool-call]")?.firstElementChild;
+		const executeRow =
+			executeButton.closest("[data-tool-call]")?.firstElementChild;
+		const processOutputRow =
+			processOutputButton.closest("[data-tool-call]")?.firstElementChild;
+
+		expect(thinkingRow).toBeInstanceOf(HTMLElement);
+		expect(executeRow).toBeInstanceOf(HTMLElement);
+		expect(processOutputRow).toBeInstanceOf(HTMLElement);
+
+		const rowHeights = [thinkingRow, executeRow, processOutputRow].map((row) =>
+			Math.round((row as HTMLElement).getBoundingClientRect().height),
+		);
+		expect(new Set(rowHeights)).toHaveLength(1);
+
+		const wrappers = [
+			thinkingButton.closest("[data-tool-call]"),
+			executeButton.closest("[data-tool-call]"),
+			processOutputButton.closest("[data-tool-call]"),
+		].map((row) => row as HTMLElement);
+		const gaps = [
+			Math.round(
+				wrappers[1].getBoundingClientRect().top -
+					wrappers[0].getBoundingClientRect().bottom,
+			),
+			Math.round(
+				wrappers[2].getBoundingClientRect().top -
+					wrappers[1].getBoundingClientRect().bottom,
+			),
+		];
+		expect(gaps).toEqual([8, 8]);
+	},
+};
+
 /**
  * A completed thinking block with auto mode should be collapsed
  * (non-streaming state means auto collapses).

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1899,6 +1899,72 @@ export const NoRenderableContentFallbackSpacing: Story = {
 };
 
 /**
+ * Regression: assistant messages whose only tool row resolves to null
+ * must not leave behind an empty transcript wrapper or an extra gap.
+ */
+export const HiddenAssistantToolMessageDoesNotRenderGap: Story = {
+	args: {
+		...defaultArgs,
+		parsedMessages: buildMessages([
+			{
+				...baseMessage,
+				id: 201,
+				role: "user",
+				content: [{ type: "text", text: "Run the command" }],
+			},
+			{
+				...baseMessage,
+				id: 202,
+				role: "assistant",
+				content: [{ type: "text", text: "Done." }],
+			},
+			{
+				...baseMessage,
+				id: 203,
+				role: "assistant",
+				content: [
+					{
+						type: "tool-call",
+						tool_call_id: "hidden-execute",
+						tool_name: "execute",
+						args: {},
+					},
+				],
+			},
+			{
+				...baseMessage,
+				id: 204,
+				role: "user",
+				content: [{ type: "text", text: "Thanks!" }],
+			},
+		]),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.queryByText("Message has no renderable content."),
+		).not.toBeInTheDocument();
+
+		for (const el of canvasElement.querySelectorAll(
+			'[data-testid="message-actions"]',
+		)) {
+			if (el instanceof HTMLElement) {
+				el.style.opacity = "1";
+			}
+		}
+
+		const timeline = canvas.getByTestId("conversation-timeline");
+		const renderedRows = Array.from(
+			timeline.querySelectorAll('[data-role="user"], [data-role="assistant"]'),
+		);
+		expect(renderedRows).toHaveLength(3);
+		expect(renderedRows[1]).toHaveAttribute("data-role", "assistant");
+		expect(renderedRows[1]).toHaveTextContent("Done.");
+		expect(canvas.getAllByTestId("message-actions")).toHaveLength(3);
+	},
+};
+
+/**
  * Regression: action bar must appear on the last *visible* assistant
  * message even when invisible assistant messages (provider-executed
  * tool-result-only) follow it before the next user turn.

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1869,35 +1869,6 @@ export const SourcesOnlyAssistantSpacing: Story = {
 	},
 };
 
-export const NoRenderableContentFallbackSpacing: Story = {
-	args: {
-		...defaultArgs,
-		parsedMessages: buildMessages([
-			{
-				...baseMessage,
-				id: 101,
-				role: "assistant",
-				content: [],
-			},
-			{
-				...baseMessage,
-				id: 102,
-				role: "user",
-				content: [{ type: "text", text: "Thanks for trying!" }],
-			},
-		]),
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(
-			canvas.getByText("Message has no renderable content."),
-		).toBeInTheDocument();
-		expect(
-			document.querySelector('[data-testid="assistant-bottom-spacer"]'),
-		).toBeInTheDocument();
-	},
-};
-
 /**
  * Regression: assistant messages whose only tool row resolves to null
  * must not leave behind an empty transcript wrapper or an extra gap.

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -2211,12 +2211,23 @@ export const ThinkingBlockWithToolCall: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		expect(
-			canvas.getByRole("button", { name: /thinking/i }),
-		).toBeInTheDocument();
+		const thinkingButton = canvas.getByRole("button", { name: /thinking/i });
+		expect(thinkingButton).toBeInTheDocument();
 		expect(
 			canvas.getByRole("button", { name: /read package\.json/i }),
 		).toBeInTheDocument();
+
+		const toolButton = canvas.getByRole("button", {
+			name: /read package\.json/i,
+		});
+		const thinkingContainer = thinkingButton.closest("[data-tool-call]");
+		const toolContainer = toolButton.closest("[data-tool-call]");
+		expect(thinkingContainer).toBeInstanceOf(HTMLElement);
+		expect(toolContainer).toBeInstanceOf(HTMLElement);
+		expect(toolContainer?.firstElementChild).not.toHaveAttribute("data-state");
+		expect(thinkingContainer?.firstElementChild).not.toHaveAttribute(
+			"data-state",
+		);
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -2257,8 +2257,8 @@ export const ThinkingBlockWithToolCall: Story = {
 		const toolButton = canvas.getByRole("button", {
 			name: /read package\.json/i,
 		});
-		const thinkingContainer = thinkingButton.closest("[data-tool-call]");
-		const toolContainer = toolButton.closest("[data-tool-call]");
+		const thinkingContainer = thinkingButton.closest("[data-transcript-row]");
+		const toolContainer = toolButton.closest("[data-transcript-row]");
 		expect(thinkingContainer).toBeInstanceOf(HTMLElement);
 		expect(toolContainer).toBeInstanceOf(HTMLElement);
 		expect(toolContainer?.firstElementChild).not.toHaveAttribute("data-state");
@@ -2351,12 +2351,15 @@ export const ThinkingBlockWithShellTools: Story = {
 			name: /expand process output/i,
 		});
 
-		const thinkingRow =
-			thinkingButton.closest("[data-tool-call]")?.firstElementChild;
-		const executeRow =
-			executeButton.closest("[data-tool-call]")?.firstElementChild;
-		const processOutputRow =
-			processOutputButton.closest("[data-tool-call]")?.firstElementChild;
+		const thinkingRow = thinkingButton.closest(
+			"[data-transcript-row]",
+		)?.firstElementChild;
+		const executeRow = executeButton.closest(
+			"[data-transcript-row]",
+		)?.firstElementChild;
+		const processOutputRow = processOutputButton.closest(
+			"[data-transcript-row]",
+		)?.firstElementChild;
 
 		expect(thinkingRow).toBeInstanceOf(HTMLElement);
 		expect(executeRow).toBeInstanceOf(HTMLElement);
@@ -2368,9 +2371,9 @@ export const ThinkingBlockWithShellTools: Story = {
 		expect(new Set(rowHeights)).toHaveLength(1);
 
 		const wrappers = [
-			thinkingButton.closest("[data-tool-call]"),
-			executeButton.closest("[data-tool-call]"),
-			processOutputButton.closest("[data-tool-call]"),
+			thinkingButton.closest("[data-transcript-row]"),
+			executeButton.closest("[data-transcript-row]"),
+			processOutputButton.closest("[data-transcript-row]"),
 		].map((row) => row as HTMLElement);
 		const gaps = [
 			Math.round(

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -143,15 +143,7 @@ const ReasoningDisclosure = memo<{
 		}, [displayTextLength, isPreviewConstrained]);
 
 		return (
-			<div
-				data-tool-call=""
-				className={cn(
-					"py-0.5",
-					// Collapse padding between adjacent tool/thinking blocks.
-					"[&:has(+[data-tool-call])]:pb-0",
-					"[[data-tool-call]+&]:pt-0",
-				)}
-			>
+			<div data-tool-call="">
 				<ToolCollapsible
 					className="w-full"
 					expanded={expanded}
@@ -529,10 +521,6 @@ const ChatMessageItem = memo<{
 			return null;
 		}
 
-		const hasRenderableContent =
-			parsed.blocks.length > 0 ||
-			parsed.tools.length > 0 ||
-			parsed.sources.length > 0;
 		const conversationItemProps: { role: "user" | "assistant" } = {
 			role: isUser ? "user" : "assistant",
 		};
@@ -557,8 +545,8 @@ const ChatMessageItem = memo<{
 					) : (
 						<Message className="w-full">
 							<MessageContent className="whitespace-normal">
-								{/* Keep consecutive tool and thinking rows tighter so activity-heavy turns read as a single timeline. */}
-								<div className="relative space-y-3 overflow-visible [&>[data-tool-call]+[data-tool-call]]:mt-2">
+								{/* Keep assistant content spacing consistent by letting the parent stack own every top-level gap. */}
+								<div className="relative flex flex-col gap-2 overflow-visible">
 									<BlockList
 										blocks={parsed.blocks}
 										tools={parsed.tools}
@@ -583,7 +571,7 @@ const ChatMessageItem = memo<{
 										urlTransform={urlTransform}
 										mcpServers={mcpServers}
 									/>
-									{!hasRenderableContent && (
+									{!displayState.hasRenderableContent && (
 										<div className="text-xs text-content-secondary">
 											Message has no renderable content.
 										</div>

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -143,7 +143,7 @@ const ReasoningDisclosure = memo<{
 		}, [displayTextLength, isPreviewConstrained]);
 
 		return (
-			<div data-tool-call="">
+			<div data-transcript-row="">
 				<ToolCollapsible
 					className="w-full"
 					expanded={expanded}

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -571,11 +571,6 @@ const ChatMessageItem = memo<{
 										urlTransform={urlTransform}
 										mcpServers={mcpServers}
 									/>
-									{!displayState.hasRenderableContent && (
-										<div className="text-xs text-content-secondary">
-											Message has no renderable content.
-										</div>
-									)}
 								</div>
 							</MessageContent>
 						</Message>

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -1,9 +1,4 @@
-import {
-	ChevronDownIcon,
-	ChevronLeftIcon,
-	ChevronRightIcon,
-	PencilIcon,
-} from "lucide-react";
+import { ChevronLeftIcon, ChevronRightIcon, PencilIcon } from "lucide-react";
 import {
 	type FC,
 	Fragment,
@@ -20,11 +15,6 @@ import type * as TypesGen from "#/api/typesGenerated";
 import type { ThinkingDisplayMode } from "#/api/typesGenerated";
 
 import { Button } from "#/components/Button/Button";
-import {
-	Collapsible,
-	CollapsibleContent,
-	CollapsibleTrigger,
-} from "#/components/Collapsible/Collapsible";
 import { CopyButton } from "#/components/CopyButton/CopyButton";
 import {
 	Tooltip,
@@ -43,6 +33,7 @@ import {
 } from "../ChatElements";
 import { WebSearchSources } from "../ChatElements/tools";
 import type { SubagentVariant } from "../ChatElements/tools/subagentDescriptor";
+import { ToolCollapsible } from "../ChatElements/tools/ToolCollapsible";
 import { ImageLightbox } from "../ImageLightbox";
 import { TextPreviewDialog } from "../TextPreviewDialog";
 import {
@@ -161,52 +152,38 @@ const ReasoningDisclosure = memo<{
 					"[[data-tool-call]+&]:pt-0",
 				)}
 			>
-				<Collapsible
-					open={expanded}
-					onOpenChange={(open) => setManualToggle(open)}
+				<ToolCollapsible
 					className="w-full"
-				>
-					<CollapsibleTrigger
-						className={cn(
-							"border-0 bg-transparent p-0 m-0 font-[inherit] text-[inherit] text-left",
-							"flex w-full items-center gap-2 cursor-pointer",
-							"text-content-secondary transition-colors hover:text-content-primary",
-						)}
-					>
-						{isStreaming ? (
+					expanded={expanded}
+					onExpandedChange={(open) => setManualToggle(open)}
+					header={
+						isStreaming ? (
 							<Shimmer as="span" className="text-[13px]">
 								Thinking
 							</Shimmer>
 						) : (
 							<span className="text-[13px]">Thinking</span>
-						)}
-						<ChevronDownIcon
-							className={cn(
-								"h-3 w-3 shrink-0 text-current transition-transform",
-								expanded ? "rotate-0" : "-rotate-90",
-							)}
-						/>
-					</CollapsibleTrigger>
+						)
+					}
+				>
 					{hasText && (
-						<CollapsibleContent>
-							<div
-								ref={previewScrollRef}
-								className={cn(
-									"mt-1.5",
-									isPreviewConstrained && "max-h-24 overflow-y-auto",
-								)}
+						<div
+							ref={previewScrollRef}
+							className={cn(
+								"mt-1.5",
+								isPreviewConstrained && "max-h-24 overflow-y-auto",
+							)}
+						>
+							<Response
+								className="text-[11px] text-content-secondary"
+								urlTransform={urlTransform}
+								streaming={isStreaming}
 							>
-								<Response
-									className="text-[11px] text-content-secondary"
-									urlTransform={urlTransform}
-									streaming={isStreaming}
-								>
-									{displayText}
-								</Response>
-							</div>
-						</CollapsibleContent>
+								{displayText}
+							</Response>
+						</div>
 					)}
-				</Collapsible>
+				</ToolCollapsible>
 			</div>
 		);
 	},

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -557,8 +557,8 @@ const ChatMessageItem = memo<{
 					) : (
 						<Message className="w-full">
 							<MessageContent className="whitespace-normal">
-								{/* Keep consecutive shell tools tighter because execute/process_output pairs read as one terminal interaction. */}
-								<div className="relative space-y-3 overflow-visible [&>[data-shell-tool]+[data-shell-tool]]:mt-2">
+								{/* Keep consecutive tool and thinking rows tighter so activity-heavy turns read as a single timeline. */}
+								<div className="relative space-y-3 overflow-visible [&>[data-tool-call]+[data-tool-call]]:mt-2">
 									<BlockList
 										blocks={parsed.blocks}
 										tools={parsed.tools}

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.stories.tsx
@@ -282,7 +282,7 @@ export const ThinkingDuringStreamingWithToolCalls: Story = {
 		expect(canvas.getAllByText("Thinking").length).toBeGreaterThanOrEqual(1);
 
 		const toolCallWrappers = Array.from(
-			canvasElement.querySelectorAll("[data-tool-call]"),
+			canvasElement.querySelectorAll("[data-transcript-row]"),
 		);
 		expect(toolCallWrappers).toHaveLength(3);
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.stories.tsx
@@ -279,13 +279,23 @@ export const ThinkingDuringStreamingWithToolCalls: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		// Tool-only stream chunks can otherwise clear the activity indicator before text arrives.
-		const matches = canvas.getAllByText("Thinking");
-		expect(matches.length).toBeGreaterThanOrEqual(1);
+		expect(canvas.getAllByText("Thinking").length).toBeGreaterThanOrEqual(1);
 
-		const thinkingBlock = matches[0].parentElement;
-		expect(thinkingBlock).toBeInstanceOf(HTMLElement);
-		expect(getComputedStyle(thinkingBlock as HTMLElement).marginTop).toBe(
-			"8px",
+		const toolCallWrappers = Array.from(
+			canvasElement.querySelectorAll("[data-tool-call]"),
 		);
+		expect(toolCallWrappers).toHaveLength(3);
+
+		const thinkingWrapper = toolCallWrappers.at(-1);
+		const previousToolWrapper = toolCallWrappers.at(-2);
+		expect(thinkingWrapper).toBeInstanceOf(HTMLElement);
+		expect(previousToolWrapper).toBeInstanceOf(HTMLElement);
+		expect(thinkingWrapper).toHaveTextContent("Thinking");
+
+		const gap = Math.round(
+			(thinkingWrapper as HTMLElement).getBoundingClientRect().top -
+				(previousToolWrapper as HTMLElement).getBoundingClientRect().bottom,
+		);
+		expect(gap).toBe(8);
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.stories.tsx
@@ -297,5 +297,16 @@ export const ThinkingDuringStreamingWithToolCalls: Story = {
 				(previousToolWrapper as HTMLElement).getBoundingClientRect().bottom,
 		);
 		expect(gap).toBe(8);
+
+		// The placeholder inner row must match the committed collapsed
+		// Thinking row height so the transition from streaming to settled
+		// does not jump. ToolCollapsible enforces min-h-6 (24px).
+		const placeholderRow = (thinkingWrapper as HTMLElement).firstElementChild;
+		expect(placeholderRow).toBeInstanceOf(HTMLElement);
+		expect(
+			Math.round(
+				(placeholderRow as HTMLElement).getBoundingClientRect().height,
+			),
+		).toBe(24);
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -33,7 +33,7 @@ const hasTextOrReasoningBlock = (blocks: readonly RenderBlock[]): boolean =>
  * as the ChatStatusCallout status placeholder.
  */
 const StreamingThinkingPlaceholder: FC = () => (
-	<div data-tool-call="" className="text-content-secondary">
+	<div data-transcript-row="" className="text-content-secondary">
 		<div className="flex w-full items-center gap-2">
 			<Shimmer as="span" className="text-[13px] leading-relaxed">
 				Thinking

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -7,8 +7,8 @@ import {
 	MessageContent,
 	Shimmer,
 } from "../ChatElements";
+import { TranscriptRow } from "../ChatElements/TranscriptRow";
 import type { SubagentVariant } from "../ChatElements/tools/subagentDescriptor";
-import { transcriptRowMinHeightClass } from "../ChatElements/tools/transcriptStyles";
 import { ChatStatusCallout } from "./ChatStatusCallout";
 import { BlockList } from "./ConversationTimeline";
 import type { LiveStatusModel } from "./liveStatusModel";
@@ -35,13 +35,11 @@ const hasTextOrReasoningBlock = (blocks: readonly RenderBlock[]): boolean =>
  */
 const StreamingThinkingPlaceholder: FC = () => (
 	<div data-transcript-row="" className="text-content-secondary">
-		<div
-			className={`flex w-full items-center gap-2 ${transcriptRowMinHeightClass}`}
-		>
+		<TranscriptRow className="w-full gap-2">
 			<Shimmer as="span" className="text-[13px] leading-relaxed">
 				Thinking
 			</Shimmer>
-		</div>
+		</TranscriptRow>
 	</div>
 );
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -34,7 +34,7 @@ const hasTextOrReasoningBlock = (blocks: readonly RenderBlock[]): boolean =>
  */
 const StreamingThinkingPlaceholder: FC = () => (
 	<div data-transcript-row="" className="text-content-secondary">
-		<div className="flex w-full items-center gap-2">
+		<div className="flex w-full items-center gap-2 min-h-6">
 			<Shimmer as="span" className="text-[13px] leading-relaxed">
 				Thinking
 			</Shimmer>

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -33,10 +33,15 @@ const hasTextOrReasoningBlock = (blocks: readonly RenderBlock[]): boolean =>
  * as the ChatStatusCallout status placeholder.
  */
 const StreamingThinkingPlaceholder: FC = () => (
-	<div className="flex w-full items-center gap-2 py-0.5 text-content-secondary">
-		<Shimmer as="span" className="text-[13px] leading-relaxed">
-			Thinking
-		</Shimmer>
+	<div
+		data-tool-call=""
+		className="py-0.5 text-content-secondary [&:has(+[data-tool-call])]:pb-0 [[data-tool-call]+&]:pt-0"
+	>
+		<div className="flex w-full items-center gap-2">
+			<Shimmer as="span" className="text-[13px] leading-relaxed">
+				Thinking
+			</Shimmer>
+		</div>
 	</div>
 );
 
@@ -92,7 +97,7 @@ export const StreamingOutput: FC<{
 		<ConversationItem {...conversationItemProps}>
 			<Message className="w-full">
 				<MessageContent className="whitespace-normal">
-					<div className="space-y-2">
+					<div className="relative space-y-3 overflow-visible [&>[data-tool-call]+[data-tool-call]]:mt-2">
 						{shouldShowBlocks && (
 							<BlockList
 								blocks={blocks}

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -33,10 +33,7 @@ const hasTextOrReasoningBlock = (blocks: readonly RenderBlock[]): boolean =>
  * as the ChatStatusCallout status placeholder.
  */
 const StreamingThinkingPlaceholder: FC = () => (
-	<div
-		data-tool-call=""
-		className="py-0.5 text-content-secondary [&:has(+[data-tool-call])]:pb-0 [[data-tool-call]+&]:pt-0"
-	>
+	<div data-tool-call="" className="text-content-secondary">
 		<div className="flex w-full items-center gap-2">
 			<Shimmer as="span" className="text-[13px] leading-relaxed">
 				Thinking
@@ -97,7 +94,7 @@ export const StreamingOutput: FC<{
 		<ConversationItem {...conversationItemProps}>
 			<Message className="w-full">
 				<MessageContent className="whitespace-normal">
-					<div className="relative space-y-3 overflow-visible [&>[data-tool-call]+[data-tool-call]]:mt-2">
+					<div className="relative flex flex-col gap-2 overflow-visible">
 						{shouldShowBlocks && (
 							<BlockList
 								blocks={blocks}

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -8,6 +8,7 @@ import {
 	Shimmer,
 } from "../ChatElements";
 import type { SubagentVariant } from "../ChatElements/tools/subagentDescriptor";
+import { transcriptRowMinHeightClass } from "../ChatElements/tools/transcriptStyles";
 import { ChatStatusCallout } from "./ChatStatusCallout";
 import { BlockList } from "./ConversationTimeline";
 import type { LiveStatusModel } from "./liveStatusModel";
@@ -34,7 +35,9 @@ const hasTextOrReasoningBlock = (blocks: readonly RenderBlock[]): boolean =>
  */
 const StreamingThinkingPlaceholder: FC = () => (
 	<div data-transcript-row="" className="text-content-secondary">
-		<div className="flex w-full items-center gap-2 min-h-6">
+		<div
+			className={`flex w-full items-center gap-2 ${transcriptRowMinHeightClass}`}
+		>
 			<Shimmer as="span" className="text-[13px] leading-relaxed">
 				Thinking
 			</Shimmer>

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.test.ts
@@ -93,6 +93,23 @@ describe("deriveMessageDisplayState", () => {
 		expect(getDisplayState(message).needsAssistantBottomSpacer).toBe(false);
 	});
 
+	it("shows the assistant spacer when thinking is followed by a hidden execute tool", () => {
+		const message = buildMessage(
+			[
+				{ type: "reasoning", text: "I should think before acting." },
+				{
+					type: "tool-call",
+					tool_call_id: "tool-1",
+					tool_name: "execute",
+					args: {},
+				},
+			],
+			"assistant",
+		);
+
+		expect(getDisplayState(message).needsAssistantBottomSpacer).toBe(true);
+	});
+
 	it("suppresses the assistant spacer while awaiting the first stream chunk", () => {
 		const message = buildMessage(
 			[{ type: "reasoning", text: "I should think before answering." }],

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.test.ts
@@ -135,6 +135,12 @@ describe("deriveMessageDisplayState", () => {
 		expect(getDisplayState(message).needsAssistantBottomSpacer).toBe(false);
 	});
 
+	it("hides assistant messages with no renderable content", () => {
+		const message = buildMessage([], "assistant");
+
+		expect(getDisplayState(message).shouldHide).toBe(true);
+	});
+
 	it("hides assistant messages whose execute tool renders nothing", () => {
 		const message = buildMessage(
 			[

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { ChatMessage, ChatMessagePart } from "#/api/typesGenerated";
 import { deriveMessageDisplayState } from "./messageHelpers";
-import { parseMessageContent } from "./messageParsing";
+import { parseMessagesWithMergedTools } from "./messageParsing";
+import type { ParsedMessageContent } from "./types";
 
 const buildMessage = (
 	content: ChatMessagePart[],
@@ -14,13 +15,16 @@ const buildMessage = (
 	content,
 });
 
+const getParsedMessage = (message: ChatMessage) =>
+	parseMessagesWithMergedTools([message])[0].parsed;
+
 const getDisplayState = (
 	message: ChatMessage,
 	overrides: Partial<Parameters<typeof deriveMessageDisplayState>[0]> = {},
 ) =>
 	deriveMessageDisplayState({
 		message,
-		parsed: parseMessageContent(message.content),
+		parsed: getParsedMessage(message),
 		hideActions: false,
 		hasActiveStream: false,
 		...overrides,
@@ -129,5 +133,63 @@ describe("deriveMessageDisplayState", () => {
 		const message = buildMessage([{ type: "text", text: "Hello" }], "user");
 
 		expect(getDisplayState(message).needsAssistantBottomSpacer).toBe(false);
+	});
+
+	it("hides assistant messages whose execute tool renders nothing", () => {
+		const message = buildMessage(
+			[
+				{
+					type: "tool-call",
+					tool_call_id: "tool-1",
+					tool_name: "execute",
+					args: {},
+				},
+			],
+			"assistant",
+		);
+
+		expect(getDisplayState(message).shouldHide).toBe(true);
+	});
+
+	it("keeps assistant messages visible when execute shows a real command", () => {
+		const message = buildMessage(
+			[
+				{
+					type: "tool-call",
+					tool_call_id: "tool-1",
+					tool_name: "execute",
+					args: { command: "pnpm test" },
+				},
+			],
+			"assistant",
+		);
+
+		expect(getDisplayState(message).shouldHide).toBe(false);
+	});
+
+	it("hides running wait_agent messages until the chat id is available", () => {
+		const message = buildMessage([], "assistant");
+		const parsed: ParsedMessageContent = {
+			...getParsedMessage(message),
+			blocks: [{ type: "tool", id: "wait-1" }],
+			tools: [
+				{
+					id: "wait-1",
+					name: "wait_agent",
+					args: {},
+					isError: false,
+					status: "running",
+				},
+			],
+		};
+
+		expect(
+			deriveMessageDisplayState({
+				message,
+				parsed,
+				hideActions: false,
+				hasActiveStream: false,
+			}).shouldHide,
+		).toBe(true);
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.test.ts
@@ -63,13 +63,30 @@ describe("deriveMessageDisplayState", () => {
 		expect(getDisplayState(message).hasCopyableContent).toBe(false);
 	});
 
-	it("shows the assistant spacer for reasoning messages when no suppressing flags apply", () => {
+	it("shows the assistant spacer for thinking-only messages when no suppressing flags apply", () => {
 		const message = buildMessage(
 			[{ type: "reasoning", text: "I should think before answering." }],
 			"assistant",
 		);
 
 		expect(getDisplayState(message).needsAssistantBottomSpacer).toBe(true);
+	});
+
+	it("hides the assistant spacer when thinking is followed by a tool call", () => {
+		const message = buildMessage(
+			[
+				{ type: "reasoning", text: "I should think before acting." },
+				{
+					type: "tool-call",
+					tool_call_id: "tool-1",
+					tool_name: "execute",
+					args: { command: "pnpm storybook --no-open" },
+				},
+			],
+			"assistant",
+		);
+
+		expect(getDisplayState(message).needsAssistantBottomSpacer).toBe(false);
 	});
 
 	it("suppresses the assistant spacer while awaiting the first stream chunk", () => {

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.ts
@@ -10,7 +10,6 @@ type FileRenderBlock = Extract<RenderBlock, { type: "file" }>;
 
 export type MessageDisplayState = {
 	shouldHide: boolean;
-	hasRenderableContent: boolean;
 	userInlineContent: UserInlineRenderBlock[];
 	userFileBlocks: FileRenderBlock[];
 	hasUserMessageBody: boolean;
@@ -112,7 +111,6 @@ export const deriveMessageDisplayState = ({
 			isProviderToolResultOnlyMessage(parts) ||
 			isMetadataOnlyMessage(parts) ||
 			(!isUser && !hasRenderableContent),
-		hasRenderableContent,
 		userInlineContent,
 		userFileBlocks,
 		hasUserMessageBody,

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.ts
@@ -92,18 +92,13 @@ export const deriveMessageDisplayState = ({
 		Boolean(parsed.markdown.trim()) && !hasFileAttachments;
 	const { hasRenderableContent, hasThinkingOnlyContent } =
 		getRenderableContentState(parsed);
-	const hasVisibleToolPlaceholders =
-		parsed.blocks.some((block) => block.type === "tool") ||
-		parsed.tools.length > 0;
 	const needsAssistantBottomSpacer =
 		!hideActions &&
 		!hasActiveStream &&
 		!isAwaitingFirstStreamChunk &&
 		!isUser &&
 		!hasCopyableContent &&
-		(hasThinkingOnlyContent ||
-			parsed.sources.length > 0 ||
-			(!hasRenderableContent && !hasVisibleToolPlaceholders));
+		(hasThinkingOnlyContent || parsed.sources.length > 0);
 	const hasToolResultsOnly =
 		parsed.toolResults.length > 0 &&
 		parsed.toolCalls.length === 0 &&
@@ -116,7 +111,7 @@ export const deriveMessageDisplayState = ({
 			hasToolResultsOnly ||
 			isProviderToolResultOnlyMessage(parts) ||
 			isMetadataOnlyMessage(parts) ||
-			(!isUser && !hasRenderableContent && hasVisibleToolPlaceholders),
+			(!isUser && !hasRenderableContent),
 		hasRenderableContent,
 		userInlineContent,
 		userFileBlocks,

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.ts
@@ -1,4 +1,5 @@
 import type * as TypesGen from "#/api/typesGenerated";
+import { shouldRenderTool } from "../ChatElements/tools/toolVisibility";
 import type { ParsedMessageContent, RenderBlock } from "./types";
 
 export type UserInlineRenderBlock =
@@ -9,6 +10,7 @@ type FileRenderBlock = Extract<RenderBlock, { type: "file" }>;
 
 export type MessageDisplayState = {
 	shouldHide: boolean;
+	hasRenderableContent: boolean;
 	userInlineContent: UserInlineRenderBlock[];
 	userFileBlocks: FileRenderBlock[];
 	hasUserMessageBody: boolean;
@@ -37,6 +39,33 @@ const isMetadataOnlyMessage = (
 	parts.length > 0 &&
 	parts.every((part) => part.type === "context-file" || part.type === "skill");
 
+const getRenderableContentState = (parsed: ParsedMessageContent) => {
+	const visibleTools = parsed.tools.filter((tool) =>
+		shouldRenderTool({
+			name: tool.name,
+			status: tool.status,
+			args: tool.args,
+			result: tool.result,
+		}),
+	);
+	const visibleToolIds = new Set(visibleTools.map((tool) => tool.id));
+	const visibleBlocks = parsed.blocks.filter(
+		(block) => block.type !== "tool" || visibleToolIds.has(block.id),
+	);
+	const hasRenderableContent =
+		visibleBlocks.length > 0 ||
+		visibleTools.length > 0 ||
+		parsed.sources.length > 0;
+	const hasThinkingOnlyContent =
+		visibleBlocks.length > 0 &&
+		visibleBlocks.every((block) => block.type === "thinking");
+
+	return {
+		hasRenderableContent,
+		hasThinkingOnlyContent,
+	};
+};
+
 export const deriveMessageDisplayState = ({
 	message,
 	parsed,
@@ -61,13 +90,11 @@ export const deriveMessageDisplayState = ({
 	const hasFileBlocks = userFileBlocks.length > 0;
 	const hasCopyableContent =
 		Boolean(parsed.markdown.trim()) && !hasFileAttachments;
-	const hasRenderableContent =
-		parsed.blocks.length > 0 ||
-		parsed.tools.length > 0 ||
-		parsed.sources.length > 0;
-	const hasThinkingOnlyContent =
-		parsed.blocks.length > 0 &&
-		parsed.blocks.every((block) => block.type === "thinking");
+	const { hasRenderableContent, hasThinkingOnlyContent } =
+		getRenderableContentState(parsed);
+	const hasVisibleToolPlaceholders =
+		parsed.blocks.some((block) => block.type === "tool") ||
+		parsed.tools.length > 0;
 	const needsAssistantBottomSpacer =
 		!hideActions &&
 		!hasActiveStream &&
@@ -76,7 +103,7 @@ export const deriveMessageDisplayState = ({
 		!hasCopyableContent &&
 		(hasThinkingOnlyContent ||
 			parsed.sources.length > 0 ||
-			!hasRenderableContent);
+			(!hasRenderableContent && !hasVisibleToolPlaceholders));
 	const hasToolResultsOnly =
 		parsed.toolResults.length > 0 &&
 		parsed.toolCalls.length === 0 &&
@@ -88,7 +115,9 @@ export const deriveMessageDisplayState = ({
 		shouldHide:
 			hasToolResultsOnly ||
 			isProviderToolResultOnlyMessage(parts) ||
-			isMetadataOnlyMessage(parts),
+			isMetadataOnlyMessage(parts) ||
+			(!isUser && !hasRenderableContent && hasVisibleToolPlaceholders),
+		hasRenderableContent,
 		userInlineContent,
 		userFileBlocks,
 		hasUserMessageBody,

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.ts
@@ -65,13 +65,16 @@ export const deriveMessageDisplayState = ({
 		parsed.blocks.length > 0 ||
 		parsed.tools.length > 0 ||
 		parsed.sources.length > 0;
+	const hasThinkingOnlyContent =
+		parsed.blocks.length > 0 &&
+		parsed.blocks.every((block) => block.type === "thinking");
 	const needsAssistantBottomSpacer =
 		!hideActions &&
 		!hasActiveStream &&
 		!isAwaitingFirstStreamChunk &&
 		!isUser &&
 		!hasCopyableContent &&
-		(Boolean(parsed.reasoning) ||
+		(hasThinkingOnlyContent ||
 			parsed.sources.length > 0 ||
 			!hasRenderableContent);
 	const hasToolResultsOnly =

--- a/site/src/pages/AgentsPage/components/ChatElements/TranscriptRow.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/TranscriptRow.tsx
@@ -1,0 +1,23 @@
+import { Slot } from "radix-ui";
+import type { ComponentPropsWithRef, FC } from "react";
+import { cn } from "#/utils/cn";
+
+type TranscriptRowProps = ComponentPropsWithRef<"div"> & {
+	asChild?: boolean;
+};
+
+/**
+ * Some transcript rows bypass ToolCollapsible, so they need one shared place
+ * to keep the collapsed row height aligned across the chat timeline.
+ */
+export const TranscriptRow: FC<TranscriptRowProps> = ({
+	asChild = false,
+	className,
+	...props
+}) => {
+	const Comp = asChild ? Slot.Root : "div";
+
+	return (
+		<Comp {...props} className={cn("flex min-h-6 items-center", className)} />
+	);
+};

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/AskUserQuestionTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/AskUserQuestionTool.tsx
@@ -9,7 +9,7 @@ import { Button } from "#/components/Button/Button";
 import { Input } from "#/components/Input/Input";
 import { RadioGroup, RadioGroupItem } from "#/components/RadioGroup/RadioGroup";
 import { cn } from "#/utils/cn";
-import { transcriptRowMinHeightClass } from "./transcriptStyles";
+import { TranscriptRow } from "../TranscriptRow";
 import type { ToolStatus } from "./utils";
 
 export type AskUserQuestion = {
@@ -537,19 +537,16 @@ export const AskUserQuestionTool: FC<AskUserQuestionToolProps> = ({
 	if (isError) {
 		return (
 			<div className="w-full">
-				<div
+				<TranscriptRow
 					role="alert"
-					className={cn(
-						"flex items-center gap-1.5 text-[13px] text-content-secondary",
-						transcriptRowMinHeightClass,
-					)}
+					className="gap-1.5 text-[13px] text-content-secondary"
 				>
 					<TriangleAlertIcon
 						aria-label="Error"
 						className="h-3.5 w-3.5 shrink-0 text-content-secondary"
 					/>
 					<span>{errorMessage || "Failed to ask questions"}</span>
-				</div>
+				</TranscriptRow>
 			</div>
 		);
 	}
@@ -558,14 +555,7 @@ export const AskUserQuestionTool: FC<AskUserQuestionToolProps> = ({
 		return (
 			<div className="w-full">
 				{isRunning ? (
-					<div
-						role="status"
-						aria-live="polite"
-						className={cn(
-							"flex items-center gap-1.5",
-							transcriptRowMinHeightClass,
-						)}
-					>
+					<TranscriptRow role="status" aria-live="polite" className="gap-1.5">
 						<span className="text-[13px] text-content-secondary">
 							Asking for clarification...
 						</span>
@@ -573,7 +563,7 @@ export const AskUserQuestionTool: FC<AskUserQuestionToolProps> = ({
 							data-testid="ask-user-question-loading-icon"
 							className="h-3.5 w-3.5 shrink-0 animate-spin text-content-secondary motion-reduce:animate-none"
 						/>
-					</div>
+					</TranscriptRow>
 				) : (
 					<p className="text-[13px] italic text-content-secondary">
 						No questions available.
@@ -687,14 +677,7 @@ export const AskUserQuestionTool: FC<AskUserQuestionToolProps> = ({
 	return (
 		<div className="w-full">
 			{isRunning && (
-				<div
-					role="status"
-					aria-live="polite"
-					className={cn(
-						"flex items-center gap-1.5",
-						transcriptRowMinHeightClass,
-					)}
-				>
+				<TranscriptRow role="status" aria-live="polite" className="gap-1.5">
 					<span className="text-[13px] text-content-secondary">
 						Asking for clarification...
 					</span>
@@ -702,7 +685,7 @@ export const AskUserQuestionTool: FC<AskUserQuestionToolProps> = ({
 						data-testid="ask-user-question-loading-icon"
 						className="h-3.5 w-3.5 shrink-0 animate-spin text-content-secondary motion-reduce:animate-none"
 					/>
-				</div>
+				</TranscriptRow>
 			)}
 
 			{isInteractive ? (

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/AskUserQuestionTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/AskUserQuestionTool.tsx
@@ -9,6 +9,7 @@ import { Button } from "#/components/Button/Button";
 import { Input } from "#/components/Input/Input";
 import { RadioGroup, RadioGroupItem } from "#/components/RadioGroup/RadioGroup";
 import { cn } from "#/utils/cn";
+import { transcriptRowMinHeightClass } from "./transcriptStyles";
 import type { ToolStatus } from "./utils";
 
 export type AskUserQuestion = {
@@ -538,7 +539,10 @@ export const AskUserQuestionTool: FC<AskUserQuestionToolProps> = ({
 			<div className="w-full">
 				<div
 					role="alert"
-					className="flex items-center gap-1.5 py-0.5 text-[13px] text-content-secondary"
+					className={cn(
+						"flex items-center gap-1.5 text-[13px] text-content-secondary",
+						transcriptRowMinHeightClass,
+					)}
 				>
 					<TriangleAlertIcon
 						aria-label="Error"
@@ -557,7 +561,10 @@ export const AskUserQuestionTool: FC<AskUserQuestionToolProps> = ({
 					<div
 						role="status"
 						aria-live="polite"
-						className="flex items-center gap-1.5 py-0.5"
+						className={cn(
+							"flex items-center gap-1.5",
+							transcriptRowMinHeightClass,
+						)}
 					>
 						<span className="text-[13px] text-content-secondary">
 							Asking for clarification...
@@ -683,7 +690,10 @@ export const AskUserQuestionTool: FC<AskUserQuestionToolProps> = ({
 				<div
 					role="status"
 					aria-live="polite"
-					className="flex items-center gap-1.5 py-0.5"
+					className={cn(
+						"flex items-center gap-1.5",
+						transcriptRowMinHeightClass,
+					)}
 				>
 					<span className="text-[13px] text-content-secondary">
 						Asking for clarification...

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
@@ -20,12 +20,12 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { cn } from "#/utils/cn";
+import { TranscriptRow } from "../TranscriptRow";
 import {
 	type AgentDisplayState,
 	isAgentDisplayOpen,
 	resolveAgentDisplayState,
 } from "./displayMode";
-import { transcriptRowMinHeightClass } from "./transcriptStyles";
 import {
 	formatShellDurationMs,
 	sanitizeExecuteModelIntent,
@@ -94,29 +94,25 @@ const ExecuteToolInner: React.FC<ExecuteToolInnerProps> = ({
 
 	return (
 		<div className="group/exec grid w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2 rounded-md bg-surface-primary font-sans font-normal text-xs leading-5">
-			<button
-				type="button"
-				aria-expanded={outputOpen}
-				aria-label={outputToggleLabel}
-				onClick={() => setOutputOpen((value) => !value)}
-				className={cn(
-					"col-start-1 row-start-1 m-0 flex w-full min-w-0 cursor-pointer items-center gap-2 border-0 bg-transparent p-0 text-left font-[inherit] font-normal text-[inherit] text-content-secondary transition-colors hover:text-content-primary",
-					transcriptRowMinHeightClass,
-				)}
+			<TranscriptRow
+				asChild
+				className="col-start-1 row-start-1 m-0 w-full min-w-0 cursor-pointer gap-2 border-0 bg-transparent p-0 text-left font-[inherit] font-normal text-[inherit] text-content-secondary transition-colors hover:text-content-primary"
 			>
-				<ShellCommandLine
-					command={command}
-					modelIntent={modelIntent}
-					durationLabel={durationLabel}
-					expanded={outputOpen}
-				/>
-			</button>
-			<div
-				className={cn(
-					"col-start-2 row-start-1 flex shrink-0 items-center gap-1",
-					transcriptRowMinHeightClass,
-				)}
-			>
+				<button
+					type="button"
+					aria-expanded={outputOpen}
+					aria-label={outputToggleLabel}
+					onClick={() => setOutputOpen((value) => !value)}
+				>
+					<ShellCommandLine
+						command={command}
+						modelIntent={modelIntent}
+						durationLabel={durationLabel}
+						expanded={outputOpen}
+					/>
+				</button>
+			</TranscriptRow>
+			<TranscriptRow className="col-start-2 row-start-1 shrink-0 gap-1">
 				{isRunning && (
 					<LoaderIcon className="h-3.5 w-3.5 shrink-0 animate-spin motion-reduce:animate-none text-content-secondary" />
 				)}
@@ -166,7 +162,7 @@ const ExecuteToolInner: React.FC<ExecuteToolInnerProps> = ({
 					label="Copy command"
 					className="-my-0.5 size-6 p-0 opacity-0 transition-opacity hover:bg-surface-tertiary group-hover/exec:opacity-100"
 				/>
-			</div>
+			</TranscriptRow>
 			{outputOpen && (
 				<ShellTranscriptBody
 					command={command}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
@@ -25,6 +25,7 @@ import {
 	isAgentDisplayOpen,
 	resolveAgentDisplayState,
 } from "./displayMode";
+import { transcriptRowMinHeightClass } from "./transcriptStyles";
 import {
 	formatShellDurationMs,
 	sanitizeExecuteModelIntent,
@@ -98,7 +99,10 @@ const ExecuteToolInner: React.FC<ExecuteToolInnerProps> = ({
 				aria-expanded={outputOpen}
 				aria-label={outputToggleLabel}
 				onClick={() => setOutputOpen((value) => !value)}
-				className="col-start-1 row-start-1 m-0 flex min-h-6 w-full min-w-0 cursor-pointer items-center gap-2 border-0 bg-transparent p-0 text-left font-[inherit] font-normal text-[inherit] text-content-secondary transition-colors hover:text-content-primary"
+				className={cn(
+					"col-start-1 row-start-1 m-0 flex w-full min-w-0 cursor-pointer items-center gap-2 border-0 bg-transparent p-0 text-left font-[inherit] font-normal text-[inherit] text-content-secondary transition-colors hover:text-content-primary",
+					transcriptRowMinHeightClass,
+				)}
 			>
 				<ShellCommandLine
 					command={command}
@@ -107,7 +111,12 @@ const ExecuteToolInner: React.FC<ExecuteToolInnerProps> = ({
 					expanded={outputOpen}
 				/>
 			</button>
-			<div className="col-start-2 row-start-1 flex min-h-6 shrink-0 items-center gap-1">
+			<div
+				className={cn(
+					"col-start-2 row-start-1 flex shrink-0 items-center gap-1",
+					transcriptRowMinHeightClass,
+				)}
+			>
 				{isRunning && (
 					<LoaderIcon className="h-3.5 w-3.5 shrink-0 animate-spin motion-reduce:animate-none text-content-secondary" />
 				)}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
@@ -98,7 +98,7 @@ const ExecuteToolInner: React.FC<ExecuteToolInnerProps> = ({
 				aria-expanded={outputOpen}
 				aria-label={outputToggleLabel}
 				onClick={() => setOutputOpen((value) => !value)}
-				className="col-start-1 row-start-1 m-0 flex w-full min-w-0 cursor-pointer items-center gap-2 border-0 bg-transparent p-0 text-left font-[inherit] font-normal text-[inherit] text-content-secondary transition-colors hover:text-content-primary"
+				className="col-start-1 row-start-1 m-0 flex min-h-6 w-full min-w-0 cursor-pointer items-center gap-2 border-0 bg-transparent p-0 text-left font-[inherit] font-normal text-[inherit] text-content-secondary transition-colors hover:text-content-primary"
 			>
 				<ShellCommandLine
 					command={command}
@@ -107,7 +107,7 @@ const ExecuteToolInner: React.FC<ExecuteToolInnerProps> = ({
 					expanded={outputOpen}
 				/>
 			</button>
-			<div className="col-start-2 row-start-1 flex shrink-0 items-center gap-1">
+			<div className="col-start-2 row-start-1 flex min-h-6 shrink-0 items-center gap-1">
 				{isRunning && (
 					<LoaderIcon className="h-3.5 w-3.5 shrink-0 animate-spin motion-reduce:animate-none text-content-secondary" />
 				)}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessOutputTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessOutputTool.tsx
@@ -111,7 +111,13 @@ const ProcessOutputToolInner: React.FC<ProcessOutputToolInnerProps> = ({
 								exit {exitCode}
 							</span>
 						)}
-						{hasOutput && <CopyButton text={output} label="Copy output" />}
+						{hasOutput && (
+							<CopyButton
+								text={output}
+								label="Copy output"
+								className="-my-0.5 size-6 p-0"
+							/>
+						)}
 					</>
 				) : undefined
 			}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ProposePlanTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ProposePlanTool.tsx
@@ -10,6 +10,7 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { Response } from "../Response";
+import { transcriptRowMinHeightClass } from "./transcriptStyles";
 import type { ToolStatus } from "./utils";
 
 export const ProposePlanTool: React.FC<{
@@ -72,7 +73,9 @@ export const ProposePlanTool: React.FC<{
 
 	return (
 		<div className="w-full">
-			<div className="flex items-center gap-1.5 py-0.5 text-content-secondary">
+			<div
+				className={`flex items-center gap-1.5 text-content-secondary ${transcriptRowMinHeightClass}`}
+			>
 				<span className="text-[13px]">
 					{isRunning ? `Proposing ${filename}…` : `Proposed ${filename}`}
 				</span>
@@ -137,7 +140,9 @@ export const ProposePlanTool: React.FC<{
 				)
 			)}
 			{fetchLoading && (
-				<div className="flex items-center gap-1.5 py-2 text-[13px] text-content-secondary">
+				<div
+					className={`flex items-center gap-1.5 text-[13px] text-content-secondary ${transcriptRowMinHeightClass}`}
+				>
 					<LoaderIcon className="h-3.5 w-3.5 animate-spin motion-reduce:animate-none" />
 					Loading plan…
 				</div>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ProposePlanTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ProposePlanTool.tsx
@@ -10,7 +10,7 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { Response } from "../Response";
-import { transcriptRowMinHeightClass } from "./transcriptStyles";
+import { TranscriptRow } from "../TranscriptRow";
 import type { ToolStatus } from "./utils";
 
 export const ProposePlanTool: React.FC<{
@@ -73,9 +73,7 @@ export const ProposePlanTool: React.FC<{
 
 	return (
 		<div className="w-full">
-			<div
-				className={`flex items-center gap-1.5 text-content-secondary ${transcriptRowMinHeightClass}`}
-			>
+			<TranscriptRow className="gap-1.5 text-content-secondary">
 				<span className="text-[13px]">
 					{isRunning ? `Proposing ${filename}…` : `Proposed ${filename}`}
 				</span>
@@ -95,7 +93,7 @@ export const ProposePlanTool: React.FC<{
 				{isRunning && (
 					<LoaderIcon className="h-3.5 w-3.5 shrink-0 animate-spin motion-reduce:animate-none text-current" />
 				)}
-			</div>
+			</TranscriptRow>
 			{hasDisplayContent ? (
 				<>
 					<Response>{displayContent}</Response>
@@ -140,12 +138,10 @@ export const ProposePlanTool: React.FC<{
 				)
 			)}
 			{fetchLoading && (
-				<div
-					className={`flex items-center gap-1.5 text-[13px] text-content-secondary ${transcriptRowMinHeightClass}`}
-				>
+				<TranscriptRow className="gap-1.5 text-[13px] text-content-secondary">
 					<LoaderIcon className="h-3.5 w-3.5 animate-spin motion-reduce:animate-none" />
 					Loading plan…
-				</div>
+				</TranscriptRow>
 			)}
 		</div>
 	);

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ReadTemplateTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ReadTemplateTool.tsx
@@ -5,6 +5,7 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
+import { transcriptRowMinHeightClass } from "./transcriptStyles";
 import type { ToolStatus } from "./utils";
 
 /**
@@ -26,7 +27,9 @@ export const ReadTemplateTool: React.FC<{
 			: "Read template";
 
 	return (
-		<div className="flex items-center gap-1.5 text-content-secondary">
+		<div
+			className={`flex items-center gap-1.5 text-content-secondary ${transcriptRowMinHeightClass}`}
+		>
 			<span className="text-[13px]">{label}</span>
 			{isError && (
 				<Tooltip>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ReadTemplateTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ReadTemplateTool.tsx
@@ -5,7 +5,7 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { transcriptRowMinHeightClass } from "./transcriptStyles";
+import { TranscriptRow } from "../TranscriptRow";
 import type { ToolStatus } from "./utils";
 
 /**
@@ -27,9 +27,7 @@ export const ReadTemplateTool: React.FC<{
 			: "Read template";
 
 	return (
-		<div
-			className={`flex items-center gap-1.5 text-content-secondary ${transcriptRowMinHeightClass}`}
-		>
+		<TranscriptRow className="gap-1.5 text-content-secondary">
 			<span className="text-[13px]">{label}</span>
 			{isError && (
 				<Tooltip>
@@ -44,6 +42,6 @@ export const ReadTemplateTool: React.FC<{
 			{isRunning && (
 				<LoaderIcon className="h-3.5 w-3.5 shrink-0 animate-spin motion-reduce:animate-none text-current" />
 			)}
-		</div>
+		</TranscriptRow>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
@@ -15,11 +15,11 @@ import { cn } from "#/utils/cn";
 import { safeBuildAgentChatPath } from "../../../utils/navigation";
 import { Response } from "../Response";
 import { Shimmer } from "../Shimmer";
+import { TranscriptRow } from "../TranscriptRow";
 import { useDesktopPanel } from "./DesktopPanelContext";
 import { InlineDesktopPreview } from "./InlineDesktopPreview";
 import { RecordingPreview } from "./RecordingPreview";
 import type { SubagentAction, SubagentDescriptor } from "./subagentDescriptor";
-import { transcriptRowMinHeightClass } from "./transcriptStyles";
 import {
 	isSubagentSuccessStatus,
 	shortDurationMs,
@@ -193,59 +193,60 @@ export const SubagentTool: React.FC<{
 
 	return (
 		<div className="w-full">
-			<button
-				type="button"
-				aria-expanded={hasExpandableContent ? expanded : undefined}
-				onClick={() => hasExpandableContent && setExpanded((v) => !v)}
+			<TranscriptRow
+				asChild
 				className={cn(
-					"border-0 bg-transparent p-0 m-0 font-[inherit] text-[inherit] text-left",
-					"flex w-full items-center gap-2",
-					transcriptRowMinHeightClass,
-					"text-content-secondary transition-colors",
+					"m-0 w-full gap-2 border-0 bg-transparent p-0 text-left font-[inherit] text-[inherit] text-content-secondary transition-colors",
 					hasExpandableContent && "cursor-pointer hover:text-content-primary",
 				)}
 			>
-				<SubagentStatusIcon
-					subagentStatus={subagentStatus}
-					toolStatus={toolStatus}
-					isError={isError}
-					isTimeout={isTimeout}
-					iconKind={descriptor.iconKind}
-					showDesktopPreview={showDesktopPreview}
-				/>{" "}
-				<span className="min-w-0 truncate text-[13px]">
-					{getSubagentLabel(
-						showDesktopPreview,
-						toolStatus,
-						descriptor,
-						title,
-						isTimeout,
-					)}
-					{agentChatPath && (
-						<Link
-							to={{ pathname: agentChatPath, search: location.search }}
-							onClick={(e) => e.stopPropagation()}
-							className="ml-1 inline-flex align-middle text-content-secondary opacity-50 transition-opacity hover:opacity-100"
-							aria-label="View agent"
-						>
-							<ExternalLinkIcon className="h-3 w-3" />
-						</Link>
-					)}
-				</span>
-				{hasExpandableContent && (
-					<ChevronDownIcon
-						className={cn(
-							"h-3 w-3 shrink-0 text-current transition-transform",
-							expanded ? "rotate-0" : "-rotate-90",
+				<button
+					type="button"
+					aria-expanded={hasExpandableContent ? expanded : undefined}
+					onClick={() => hasExpandableContent && setExpanded((v) => !v)}
+				>
+					<SubagentStatusIcon
+						subagentStatus={subagentStatus}
+						toolStatus={toolStatus}
+						isError={isError}
+						isTimeout={isTimeout}
+						iconKind={descriptor.iconKind}
+						showDesktopPreview={showDesktopPreview}
+					/>{" "}
+					<span className="min-w-0 truncate text-[13px]">
+						{getSubagentLabel(
+							showDesktopPreview,
+							toolStatus,
+							descriptor,
+							title,
+							isTimeout,
 						)}
-					/>
-				)}
-				{durationLabel && (
-					<span className="ml-auto shrink-0 text-xs">
-						{`Worked for ${durationLabel}`}
+						{agentChatPath && (
+							<Link
+								to={{ pathname: agentChatPath, search: location.search }}
+								onClick={(e) => e.stopPropagation()}
+								className="ml-1 inline-flex align-middle text-content-secondary opacity-50 transition-opacity hover:opacity-100"
+								aria-label="View agent"
+							>
+								<ExternalLinkIcon className="h-3 w-3" />
+							</Link>
+						)}
 					</span>
-				)}
-			</button>
+					{hasExpandableContent && (
+						<ChevronDownIcon
+							className={cn(
+								"h-3 w-3 shrink-0 text-current transition-transform",
+								expanded ? "rotate-0" : "-rotate-90",
+							)}
+						/>
+					)}
+					{durationLabel && (
+						<span className="ml-auto shrink-0 text-xs">
+							{`Worked for ${durationLabel}`}
+						</span>
+					)}
+				</button>
+			</TranscriptRow>
 
 			{showDesktopPreview && desktopChatId && toolStatus !== "completed" && (
 				<div className="mt-1.5 overflow-hidden rounded-lg border border-solid border-border-default">

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
@@ -19,6 +19,7 @@ import { useDesktopPanel } from "./DesktopPanelContext";
 import { InlineDesktopPreview } from "./InlineDesktopPreview";
 import { RecordingPreview } from "./RecordingPreview";
 import type { SubagentAction, SubagentDescriptor } from "./subagentDescriptor";
+import { transcriptRowMinHeightClass } from "./transcriptStyles";
 import {
 	isSubagentSuccessStatus,
 	shortDurationMs,
@@ -199,6 +200,7 @@ export const SubagentTool: React.FC<{
 				className={cn(
 					"border-0 bg-transparent p-0 m-0 font-[inherit] text-[inherit] text-left",
 					"flex w-full items-center gap-2",
+					transcriptRowMinHeightClass,
 					"text-content-secondary transition-colors",
 					hasExpandableContent && "cursor-pointer hover:text-content-primary",
 				)}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -848,6 +848,7 @@ export const CloseAgentRunningWithoutChatId: Story = {
 		await waitFor(() => {
 			expect(canvasElement.textContent?.trim()).toBe("");
 		});
+		expect(canvasElement.querySelector("[data-transcript-row]")).toBeNull();
 		expect(canvas.queryByRole("button")).toBeNull();
 		expect(canvas.queryByRole("link", { name: "View agent" })).toBeNull();
 	},

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -42,7 +42,7 @@ import {
 import { ToolCollapsible } from "./ToolCollapsible";
 import { ToolIcon } from "./ToolIcon";
 import { ToolLabel } from "./ToolLabel";
-import { getExecuteRenderData, shouldHideExecuteTool } from "./toolVisibility";
+import { getExecuteRenderData, shouldRenderTool } from "./toolVisibility";
 import {
 	asNumber,
 	asRecord,
@@ -226,10 +226,6 @@ const ExecuteRenderer: FC<ToolRendererProps> = ({
 	shellToolDisplayMode,
 }) => {
 	const data = getExecuteRenderData(args, result);
-
-	if (shouldHideExecuteTool(data)) {
-		return null;
-	}
 
 	if (data.authenticateURL) {
 		return (
@@ -549,20 +545,6 @@ const SubagentRenderer: FC<ToolRendererProps> = ({
 		const timedOutInError = errorStr.toLowerCase().includes("timed out");
 		if (timedOutInResult || timedOutInError) {
 			isTimeout = true;
-		}
-	}
-
-	// Postpone rendering wait_agent, message_agent, and close_agent
-	// until the chat_id has been parsed from the streaming args.
-	// Without it we cannot determine variant or title, which causes
-	// a brief flash of the generic lifecycle copy.
-	if (!chatId && status === "running") {
-		if (
-			descriptor.action === "wait" ||
-			descriptor.action === "message" ||
-			descriptor.action === "close"
-		) {
-			return null;
 		}
 	}
 
@@ -1050,18 +1032,14 @@ export const Tool = memo(
 			? SubagentRenderer
 			: (toolRenderers[name] ?? GenericToolRenderer);
 		const isShellTool = name === "execute" || name === "process_output";
-		if (
-			name === "execute" &&
-			shouldHideExecuteTool(getExecuteRenderData(args, result))
-		) {
+		if (!shouldRenderTool({ name, status, args, result })) {
 			return null;
 		}
 
 		return (
 			<div
 				ref={ref}
-				data-tool-call=""
-				data-shell-tool={isShellTool ? "" : undefined}
+				data-transcript-row=""
 				className={cn(
 					isShellTool || name === "propose_plan" || name === "advisor"
 						? "w-full"

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -42,6 +42,7 @@ import {
 import { ToolCollapsible } from "./ToolCollapsible";
 import { ToolIcon } from "./ToolIcon";
 import { ToolLabel } from "./ToolLabel";
+import { getExecuteRenderData, shouldHideExecuteTool } from "./toolVisibility";
 import {
 	asNumber,
 	asRecord,
@@ -213,53 +214,6 @@ const parseAskUserQuestionResult = (
 	}
 
 	return null;
-};
-
-type ExecuteRenderData = {
-	command: string;
-	output: string;
-	durationMs?: number;
-	isBackgrounded: boolean;
-	authenticateURL: string;
-	providerLabel: string;
-};
-
-const getExecuteRenderData = (
-	args: unknown,
-	result: unknown,
-): ExecuteRenderData => {
-	const parsedArgs = parseArgs(args);
-	const command = parsedArgs ? asString(parsedArgs.command) : "";
-	const rec = asRecord(result);
-	const output = rec ? asString(rec.output).trim() : "";
-	const durationMs = rec
-		? (asNumber(rec.wall_duration_ms, { parseString: true }) ??
-			asNumber(rec.duration_ms, { parseString: true }))
-		: undefined;
-	const isBackgrounded = Boolean(
-		rec && asString(rec.background_process_id).trim(),
-	);
-	const authenticateURL = rec?.auth_required
-		? asString(rec.authenticate_url).trim()
-		: "";
-	const providerLabel = toProviderLabel(
-		rec ? asString(rec.provider_display_name).trim() : "",
-		rec ? asString(rec.provider_id).trim() : "",
-		rec ? asString(rec.provider_type).trim() : "",
-	);
-
-	return {
-		command,
-		output,
-		durationMs,
-		isBackgrounded,
-		authenticateURL,
-		providerLabel,
-	};
-};
-
-const shouldHideExecuteTool = (data: ExecuteRenderData): boolean => {
-	return data.command.trim().length === 0 && !data.authenticateURL;
 };
 
 const ExecuteRenderer: FC<ToolRendererProps> = ({
@@ -1110,11 +1064,8 @@ export const Tool = memo(
 				data-shell-tool={isShellTool ? "" : undefined}
 				className={cn(
 					isShellTool || name === "propose_plan" || name === "advisor"
-						? "w-full py-0.5"
-						: "py-0.5",
-					// Keep back-to-back tool cards visually grouped so stacked tool calls do not look double-spaced.
-					"[&:has(+[data-tool-call])]:pb-0",
-					"[[data-tool-call]+&]:pt-0",
+						? "w-full"
+						: undefined,
 					className,
 				)}
 				{...props}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCollapsible.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCollapsible.tsx
@@ -79,7 +79,7 @@ export const ToolCollapsible: FC<ToolCollapsibleProps> = ({
 			onClick={toggleExpanded}
 			className={cn(
 				"border-0 bg-transparent p-0 m-0 font-[inherit] text-[inherit] text-left",
-				"flex items-center gap-2 cursor-pointer",
+				"flex min-h-6 items-center gap-2 cursor-pointer",
 				"text-content-secondary transition-colors hover:text-content-primary",
 				headerActions ? "min-w-0 flex-1" : "w-full",
 				headerClassName,
@@ -96,7 +96,7 @@ export const ToolCollapsible: FC<ToolCollapsibleProps> = ({
 	) : (
 		<div
 			className={cn(
-				"flex items-center gap-2 text-content-secondary",
+				"flex min-h-6 items-center gap-2 text-content-secondary",
 				headerActions && "min-w-0 flex-1",
 				headerClassName,
 			)}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCollapsible.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCollapsible.tsx
@@ -8,6 +8,7 @@ import {
 	isAgentDisplayOpen,
 	resolveAgentDisplayState,
 } from "./displayMode";
+import { transcriptRowMinHeightClass } from "./transcriptStyles";
 
 type ToolCollapsibleAriaLabel = string | ((expanded: boolean) => string);
 type ToolCollapsibleHeader = ReactNode | ((expanded: boolean) => ReactNode);
@@ -79,7 +80,8 @@ export const ToolCollapsible: FC<ToolCollapsibleProps> = ({
 			onClick={toggleExpanded}
 			className={cn(
 				"border-0 bg-transparent p-0 m-0 font-[inherit] text-[inherit] text-left",
-				"flex min-h-6 items-center gap-2 cursor-pointer",
+				"flex items-center gap-2 cursor-pointer",
+				transcriptRowMinHeightClass,
 				"text-content-secondary transition-colors hover:text-content-primary",
 				headerActions ? "min-w-0 flex-1" : "w-full",
 				headerClassName,
@@ -96,7 +98,8 @@ export const ToolCollapsible: FC<ToolCollapsibleProps> = ({
 	) : (
 		<div
 			className={cn(
-				"flex min-h-6 items-center gap-2 text-content-secondary",
+				"flex items-center gap-2 text-content-secondary",
+				transcriptRowMinHeightClass,
 				headerActions && "min-w-0 flex-1",
 				headerClassName,
 			)}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCollapsible.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCollapsible.tsx
@@ -3,12 +3,12 @@ import type { FC, ReactNode } from "react";
 import { useState } from "react";
 import type { AgentDisplayMode } from "#/api/typesGenerated";
 import { cn } from "#/utils/cn";
+import { TranscriptRow } from "../TranscriptRow";
 import {
 	type AgentDisplayState,
 	isAgentDisplayOpen,
 	resolveAgentDisplayState,
 } from "./displayMode";
-import { transcriptRowMinHeightClass } from "./transcriptStyles";
 
 type ToolCollapsibleAriaLabel = string | ((expanded: boolean) => string);
 type ToolCollapsibleHeader = ReactNode | ((expanded: boolean) => ReactNode);
@@ -71,41 +71,41 @@ export const ToolCollapsible: FC<ToolCollapsibleProps> = ({
 		onExpandedChange?.(nextExpanded);
 	};
 	const headerButton = hasContent ? (
-		<button
-			type="button"
-			aria-expanded={expanded}
-			aria-label={
-				typeof ariaLabel === "function" ? ariaLabel(expanded) : ariaLabel
-			}
-			onClick={toggleExpanded}
+		<TranscriptRow
+			asChild
 			className={cn(
-				"border-0 bg-transparent p-0 m-0 font-[inherit] text-[inherit] text-left",
-				"flex items-center gap-2 cursor-pointer",
-				transcriptRowMinHeightClass,
-				"text-content-secondary transition-colors hover:text-content-primary",
+				"m-0 cursor-pointer gap-2 border-0 bg-transparent p-0 text-left font-[inherit] text-[inherit] text-content-secondary transition-colors hover:text-content-primary",
 				headerActions ? "min-w-0 flex-1" : "w-full",
 				headerClassName,
 			)}
 		>
-			{renderedHeader}
-			<ChevronDownIcon
-				className={cn(
-					"h-3 w-3 shrink-0 text-current transition-transform",
-					expanded ? "rotate-0" : "-rotate-90",
-				)}
-			/>
-		</button>
+			<button
+				type="button"
+				aria-expanded={expanded}
+				aria-label={
+					typeof ariaLabel === "function" ? ariaLabel(expanded) : ariaLabel
+				}
+				onClick={toggleExpanded}
+			>
+				{renderedHeader}
+				<ChevronDownIcon
+					className={cn(
+						"h-3 w-3 shrink-0 text-current transition-transform",
+						expanded ? "rotate-0" : "-rotate-90",
+					)}
+				/>
+			</button>
+		</TranscriptRow>
 	) : (
-		<div
+		<TranscriptRow
 			className={cn(
-				"flex items-center gap-2 text-content-secondary",
-				transcriptRowMinHeightClass,
+				"gap-2 text-content-secondary",
 				headerActions && "min-w-0 flex-1",
 				headerClassName,
 			)}
 		>
 			{renderedHeader}
-		</div>
+		</TranscriptRow>
 	);
 
 	return (

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCollapsible.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCollapsible.tsx
@@ -18,6 +18,8 @@ interface ToolCollapsibleProps {
 	headerActions?: ReactNode;
 	hasContent?: boolean;
 	defaultExpanded?: boolean;
+	expanded?: boolean;
+	onExpandedChange?: (expanded: boolean) => void;
 	ariaLabel?: ToolCollapsibleAriaLabel;
 	className?: string;
 	headerClassName?: string;
@@ -49,13 +51,24 @@ export const ToolCollapsible: FC<ToolCollapsibleProps> = ({
 	headerActions,
 	hasContent = true,
 	defaultExpanded = false,
+	expanded: expandedProp,
+	onExpandedChange,
 	ariaLabel,
 	className,
 	headerClassName,
 }) => {
-	const [expanded, setExpanded] = useState(defaultExpanded);
+	const [uncontrolledExpanded, setUncontrolledExpanded] =
+		useState(defaultExpanded);
+	const expanded = expandedProp ?? uncontrolledExpanded;
 	const renderedHeader =
 		typeof header === "function" ? header(expanded) : header;
+	const toggleExpanded = () => {
+		const nextExpanded = !expanded;
+		if (expandedProp === undefined) {
+			setUncontrolledExpanded(nextExpanded);
+		}
+		onExpandedChange?.(nextExpanded);
+	};
 	const headerButton = hasContent ? (
 		<button
 			type="button"
@@ -63,7 +76,7 @@ export const ToolCollapsible: FC<ToolCollapsibleProps> = ({
 			aria-label={
 				typeof ariaLabel === "function" ? ariaLabel(expanded) : ariaLabel
 			}
-			onClick={() => setExpanded(!expanded)}
+			onClick={toggleExpanded}
 			className={cn(
 				"border-0 bg-transparent p-0 m-0 font-[inherit] text-[inherit] text-left",
 				"flex items-center gap-2 cursor-pointer",

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/toolVisibility.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/toolVisibility.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { getExecuteRenderData, shouldRenderTool } from "./toolVisibility";
+
+describe("toolVisibility", () => {
+	describe("getExecuteRenderData", () => {
+		it("parses execute output and auth metadata from result payloads", () => {
+			expect(
+				getExecuteRenderData(
+					{ command: "git fetch origin" },
+					{
+						output: " fetched ",
+						wall_duration_ms: "47200",
+						background_process_id: "process-1",
+						auth_required: true,
+						authenticate_url: "https://example.com/auth",
+						provider_display_name: "GitHub",
+					},
+				),
+			).toEqual({
+				command: "git fetch origin",
+				output: "fetched",
+				durationMs: 47200,
+				isBackgrounded: true,
+				authenticateURL: "https://example.com/auth",
+				providerLabel: "GitHub",
+			});
+		});
+	});
+
+	describe("shouldRenderTool", () => {
+		it("hides execute rows with neither a command nor an auth prompt", () => {
+			expect(
+				shouldRenderTool({
+					name: "execute",
+					status: "completed",
+					args: {},
+					result: { output: "ignored" },
+				}),
+			).toBe(false);
+		});
+
+		it("keeps execute rows when auth is required even without a command", () => {
+			expect(
+				shouldRenderTool({
+					name: "execute",
+					status: "completed",
+					args: {},
+					result: {
+						auth_required: true,
+						authenticate_url: "https://example.com/auth",
+					},
+				}),
+			).toBe(true);
+		});
+
+		it("hides running wait_agent rows until chat_id is available", () => {
+			expect(
+				shouldRenderTool({
+					name: "wait_agent",
+					status: "running",
+					args: {},
+					result: { status: "pending" },
+				}),
+			).toBe(false);
+		});
+
+		it("hides running message_agent rows until chat_id is available", () => {
+			expect(
+				shouldRenderTool({
+					name: "message_agent",
+					status: "running",
+					args: { message: "continue" },
+					result: { status: "pending" },
+				}),
+			).toBe(false);
+		});
+
+		it("hides running close_agent rows until chat_id is available", () => {
+			expect(
+				shouldRenderTool({
+					name: "close_agent",
+					status: "running",
+					args: {},
+					result: { status: "running" },
+				}),
+			).toBe(false);
+		});
+
+		it("renders running lifecycle rows once args provide the chat_id", () => {
+			expect(
+				shouldRenderTool({
+					name: "wait_agent",
+					status: "running",
+					args: { chat_id: "child-chat-1" },
+					result: { status: "pending" },
+				}),
+			).toBe(true);
+		});
+
+		it("renders completed lifecycle rows even if chat_id is absent", () => {
+			expect(
+				shouldRenderTool({
+					name: "close_agent",
+					status: "completed",
+					args: {},
+					result: { status: "completed" },
+				}),
+			).toBe(true);
+		});
+
+		it("keeps unrelated tools visible", () => {
+			expect(
+				shouldRenderTool({
+					name: "read_file",
+					status: "completed",
+					args: { path: "README.md" },
+					result: { content: "docs" },
+				}),
+			).toBe(true);
+		});
+	});
+});

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/toolVisibility.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/toolVisibility.ts
@@ -51,10 +51,44 @@ export const getExecuteRenderData = (
 	};
 };
 
-export const shouldHideExecuteTool = (data: ExecuteRenderData): boolean => {
-	return data.command.trim().length === 0 && !data.authenticateURL;
+const shouldRenderExecuteTool = (data: ExecuteRenderData): boolean => {
+	return data.command.trim().length > 0 || Boolean(data.authenticateURL);
 };
 
+const shouldHideSubagentLifecycleTool = ({
+	name,
+	status,
+	args,
+	result,
+}: {
+	name: string;
+	status: ToolStatus;
+	args?: unknown;
+	result?: unknown;
+}): boolean => {
+	const descriptor = getSubagentDescriptor({ name, args, result });
+	if (!descriptor || status !== "running") {
+		return false;
+	}
+
+	if (
+		descriptor.action !== "wait" &&
+		descriptor.action !== "message" &&
+		descriptor.action !== "close"
+	) {
+		return false;
+	}
+
+	// Wait, message, and close rows can stream before their target chat_id
+	// arrives. Hiding them until that id exists avoids flashing generic
+	// lifecycle copy before the transcript can resolve the real title.
+	return !getSubagentChatId({ args, result });
+};
+
+/**
+ * Centralize tool-row visibility so transcript message hiding stays in sync
+ * with <Tool> row rendering and hidden rows never leave empty gaps behind.
+ */
 export const shouldRenderTool = ({
 	name,
 	status,
@@ -67,22 +101,10 @@ export const shouldRenderTool = ({
 	result?: unknown;
 }): boolean => {
 	if (name === "execute") {
-		return !shouldHideExecuteTool(getExecuteRenderData(args, result));
+		return shouldRenderExecuteTool(getExecuteRenderData(args, result));
 	}
 
-	const descriptor = getSubagentDescriptor({ name, args, result });
-	if (!descriptor) {
-		return true;
-	}
-
-	const chatId = getSubagentChatId({ args, result });
-	if (
-		!chatId &&
-		status === "running" &&
-		(descriptor.action === "wait" ||
-			descriptor.action === "message" ||
-			descriptor.action === "close")
-	) {
+	if (shouldHideSubagentLifecycleTool({ name, status, args, result })) {
 		return false;
 	}
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/toolVisibility.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/toolVisibility.ts
@@ -17,6 +17,10 @@ type ExecuteRenderData = {
 	providerLabel: string;
 };
 
+/**
+ * Execute payloads can arrive partially populated, so visibility and rendering
+ * share one defensive, normalized interpretation of args and results here.
+ */
 export const getExecuteRenderData = (
 	args: unknown,
 	result: unknown,
@@ -55,7 +59,7 @@ const shouldRenderExecuteTool = (data: ExecuteRenderData): boolean => {
 	return data.command.trim().length > 0 || Boolean(data.authenticateURL);
 };
 
-const shouldHideSubagentLifecycleTool = ({
+const shouldRenderSubagentLifecycleTool = ({
 	name,
 	status,
 	args,
@@ -68,7 +72,7 @@ const shouldHideSubagentLifecycleTool = ({
 }): boolean => {
 	const descriptor = getSubagentDescriptor({ name, args, result });
 	if (!descriptor || status !== "running") {
-		return false;
+		return true;
 	}
 
 	if (
@@ -76,13 +80,13 @@ const shouldHideSubagentLifecycleTool = ({
 		descriptor.action !== "message" &&
 		descriptor.action !== "close"
 	) {
-		return false;
+		return true;
 	}
 
 	// Wait, message, and close rows can stream before their target chat_id
 	// arrives. Hiding them until that id exists avoids flashing generic
 	// lifecycle copy before the transcript can resolve the real title.
-	return !getSubagentChatId({ args, result });
+	return Boolean(getSubagentChatId({ args, result }));
 };
 
 /**
@@ -104,9 +108,5 @@ export const shouldRenderTool = ({
 		return shouldRenderExecuteTool(getExecuteRenderData(args, result));
 	}
 
-	if (shouldHideSubagentLifecycleTool({ name, status, args, result })) {
-		return false;
-	}
-
-	return true;
+	return shouldRenderSubagentLifecycleTool({ name, status, args, result });
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/toolVisibility.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/toolVisibility.ts
@@ -1,0 +1,90 @@
+import { getSubagentChatId, getSubagentDescriptor } from "./subagentDescriptor";
+import {
+	asNumber,
+	asRecord,
+	asString,
+	parseArgs,
+	type ToolStatus,
+	toProviderLabel,
+} from "./utils";
+
+type ExecuteRenderData = {
+	command: string;
+	output: string;
+	durationMs?: number;
+	isBackgrounded: boolean;
+	authenticateURL: string;
+	providerLabel: string;
+};
+
+export const getExecuteRenderData = (
+	args: unknown,
+	result: unknown,
+): ExecuteRenderData => {
+	const parsedArgs = parseArgs(args);
+	const command = parsedArgs ? asString(parsedArgs.command) : "";
+	const rec = asRecord(result);
+	const output = rec ? asString(rec.output).trim() : "";
+	const durationMs = rec
+		? (asNumber(rec.wall_duration_ms, { parseString: true }) ??
+			asNumber(rec.duration_ms, { parseString: true }))
+		: undefined;
+	const isBackgrounded = Boolean(
+		rec && asString(rec.background_process_id).trim(),
+	);
+	const authenticateURL = rec?.auth_required
+		? asString(rec.authenticate_url).trim()
+		: "";
+	const providerLabel = toProviderLabel(
+		rec ? asString(rec.provider_display_name).trim() : "",
+		rec ? asString(rec.provider_id).trim() : "",
+		rec ? asString(rec.provider_type).trim() : "",
+	);
+
+	return {
+		command,
+		output,
+		durationMs,
+		isBackgrounded,
+		authenticateURL,
+		providerLabel,
+	};
+};
+
+export const shouldHideExecuteTool = (data: ExecuteRenderData): boolean => {
+	return data.command.trim().length === 0 && !data.authenticateURL;
+};
+
+export const shouldRenderTool = ({
+	name,
+	status,
+	args,
+	result,
+}: {
+	name: string;
+	status: ToolStatus;
+	args?: unknown;
+	result?: unknown;
+}): boolean => {
+	if (name === "execute") {
+		return !shouldHideExecuteTool(getExecuteRenderData(args, result));
+	}
+
+	const descriptor = getSubagentDescriptor({ name, args, result });
+	if (!descriptor) {
+		return true;
+	}
+
+	const chatId = getSubagentChatId({ args, result });
+	if (
+		!chatId &&
+		status === "running" &&
+		(descriptor.action === "wait" ||
+			descriptor.action === "message" ||
+			descriptor.action === "close")
+	) {
+		return false;
+	}
+
+	return true;
+};

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/transcriptStyles.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/transcriptStyles.ts
@@ -1,6 +1,0 @@
-/*
- * Mixed transcript renderers stack in the same assistant column. A shared
- * 24px minimum keeps bespoke rows from looking uneven next to
- * ToolCollapsible-based rows.
- */
-export const transcriptRowMinHeightClass = "min-h-6";

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/transcriptStyles.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/transcriptStyles.ts
@@ -1,0 +1,6 @@
+/*
+ * Mixed transcript renderers stack in the same assistant column. A shared
+ * 24px minimum keeps bespoke rows from looking uneven next to
+ * ToolCollapsible-based rows.
+ */
+export const transcriptRowMinHeightClass = "min-h-6";

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -71,6 +71,22 @@ const buildRegressionStore = () => {
 	return store;
 };
 
+const buildThinkingSpacerStore = () => {
+	const store = createChatStore();
+
+	store.replaceMessages([
+		buildMessage(1, "user", [{ type: "text", text: "Read the source files" }]),
+		buildMessage(2, "assistant", [
+			{
+				type: "reasoning",
+				text: "I should think before answering.",
+			},
+		]),
+	]);
+
+	return store;
+};
+
 export const StreamingToolCallGapRegression: Story = {
 	render: () => {
 		const store = buildRegressionStore();
@@ -121,7 +137,7 @@ export const StartingPhaseToolCallGapRegression: Story = {
 
 export const SpacerVisibleWhenNotStreaming: Story = {
 	render: () => {
-		const store = buildRegressionStore();
+		const store = buildThinkingSpacerStore();
 
 		return (
 			<ChatPageTimeline
@@ -133,6 +149,39 @@ export const SpacerVisibleWhenNotStreaming: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
+		canvas.getByRole("button", { name: /thinking/i });
 		expect(canvas.getByTestId("assistant-bottom-spacer")).toBeInTheDocument();
+	},
+};
+
+export const HiddenAssistantPlaceholderDoesNotRender: Story = {
+	render: () => {
+		const store = createChatStore();
+
+		store.replaceMessages([
+			buildMessage(1, "user", [{ type: "text", text: "Run the command" }]),
+			buildMessage(2, "assistant", [{ type: "text", text: "Done." }]),
+			buildMessage(3, "assistant", []),
+			buildMessage(4, "user", [{ type: "text", text: "Thanks!" }]),
+		]);
+
+		return (
+			<ChatPageTimeline
+				chatID={CHAT_ID}
+				store={store}
+				persistedError={undefined}
+			/>
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.queryByText("Message has no renderable content.")).toBeNull();
+
+		const rows = canvasElement.querySelectorAll(
+			'[data-role="user"], [data-role="assistant"]',
+		);
+		expect(rows).toHaveLength(3);
+		expect(rows[1]).toHaveAttribute("data-role", "assistant");
+		expect(rows[1]).toHaveTextContent("Done.");
 	},
 };


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

This PR is broader than just moving the Thinking row onto `ToolCollapsible`. It normalizes how the Agent Chat transcript decides which rows render and how collapsed one-line rows are sized, which fixes the phantom gaps and uneven spacing around thinking, tool, and streaming rows.

Shared `toolVisibility` now drives both `<Tool>` rendering and assistant message hiding, so hidden execute and subagent lifecycle rows do not leave empty wrappers behind. The transcript also uses a shared 24px collapsed-row height contract for bespoke one-line rows, and the Storybook regressions now cover hidden-row gap cases plus representative collapsed row height alignment across `AgentChatPage`, `ConversationTimeline`, `StreamingOutput`, and `ChatPageContent`.