### PR TITLE
chore: rename types AIBridgeConfig -> AIGatewayConfig, AIBridgeProxyConfig -> AIGatewayProxyConfig

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -14436,90 +14436,6 @@ const docTemplate = `{
                 }
             }
         },
-        "codersdk.AIBridgeConfig": {
-            "type": "object",
-            "properties": {
-                "allow_byok": {
-                    "type": "boolean"
-                },
-                "anthropic": {
-                    "description": "Deprecated: Use Providers with indexed CODER_AI_GATEWAY_PROVIDER_\u003cN\u003e_* env vars instead.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/codersdk.AIBridgeAnthropicConfig"
-                        }
-                    ]
-                },
-                "bedrock": {
-                    "description": "Deprecated: Use Providers with indexed CODER_AI_GATEWAY_PROVIDER_\u003cN\u003e_* env vars instead.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/codersdk.AIBridgeBedrockConfig"
-                        }
-                    ]
-                },
-                "budget_period": {
-                    "type": "string"
-                },
-                "budget_policy": {
-                    "description": "Budget settings for AI Governance cost controls.",
-                    "type": "string"
-                },
-                "circuit_breaker_enabled": {
-                    "description": "Circuit breaker protects against cascading failures from upstream AI\nprovider overload (503, 529).",
-                    "type": "boolean"
-                },
-                "circuit_breaker_failure_threshold": {
-                    "type": "integer"
-                },
-                "circuit_breaker_interval": {
-                    "type": "integer"
-                },
-                "circuit_breaker_max_requests": {
-                    "type": "integer"
-                },
-                "circuit_breaker_timeout": {
-                    "type": "integer"
-                },
-                "enabled": {
-                    "type": "boolean"
-                },
-                "inject_coder_mcp_tools": {
-                    "description": "Deprecated: Injected MCP in AI Bridge is deprecated and will be removed in a future release.",
-                    "type": "boolean"
-                },
-                "max_concurrency": {
-                    "type": "integer"
-                },
-                "openai": {
-                    "description": "Deprecated: Use Providers with indexed CODER_AI_GATEWAY_PROVIDER_\u003cN\u003e_* env vars instead.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/codersdk.AIBridgeOpenAIConfig"
-                        }
-                    ]
-                },
-                "providers": {
-                    "description": "Providers holds provider instances populated from CODER_AI_GATEWAY_PROVIDER_\u003cN\u003e_\u003cKEY\u003e\nenv vars and/or the deprecated LegacyOpenAI/LegacyAnthropic/LegacyBedrock fields above.",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/codersdk.AIProviderConfig"
-                    }
-                },
-                "rate_limit": {
-                    "type": "integer"
-                },
-                "retention": {
-                    "type": "integer"
-                },
-                "send_actor_headers": {
-                    "type": "boolean"
-                },
-                "structured_logging": {
-                    "type": "boolean"
-                }
-            }
-        },
         "codersdk.AIBridgeInterception": {
             "type": "object",
             "properties": {
@@ -14620,50 +14536,6 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "key": {
-                    "type": "string"
-                }
-            }
-        },
-        "codersdk.AIBridgeProxyConfig": {
-            "type": "object",
-            "properties": {
-                "allowed_private_cidrs": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "api_dump_dir": {
-                    "type": "string"
-                },
-                "cert_file": {
-                    "type": "string"
-                },
-                "domain_allowlist": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "enabled": {
-                    "type": "boolean"
-                },
-                "key_file": {
-                    "type": "string"
-                },
-                "listen_addr": {
-                    "type": "string"
-                },
-                "tls_cert_file": {
-                    "type": "string"
-                },
-                "tls_key_file": {
-                    "type": "string"
-                },
-                "upstream_proxy": {
-                    "type": "string"
-                },
-                "upstream_proxy_ca": {
                     "type": "string"
                 }
             }
@@ -14995,13 +14867,141 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "aibridge_proxy": {
-                    "$ref": "#/definitions/codersdk.AIBridgeProxyConfig"
+                    "$ref": "#/definitions/codersdk.AIGatewayProxyConfig"
                 },
                 "bridge": {
-                    "$ref": "#/definitions/codersdk.AIBridgeConfig"
+                    "$ref": "#/definitions/codersdk.AIGatewayConfig"
                 },
                 "chat": {
                     "$ref": "#/definitions/codersdk.ChatConfig"
+                }
+            }
+        },
+        "codersdk.AIGatewayConfig": {
+            "type": "object",
+            "properties": {
+                "allow_byok": {
+                    "type": "boolean"
+                },
+                "anthropic": {
+                    "description": "Deprecated: Use Providers with indexed CODER_AI_GATEWAY_PROVIDER_\u003cN\u003e_* env vars instead.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/codersdk.AIBridgeAnthropicConfig"
+                        }
+                    ]
+                },
+                "bedrock": {
+                    "description": "Deprecated: Use Providers with indexed CODER_AI_GATEWAY_PROVIDER_\u003cN\u003e_* env vars instead.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/codersdk.AIBridgeBedrockConfig"
+                        }
+                    ]
+                },
+                "budget_period": {
+                    "type": "string"
+                },
+                "budget_policy": {
+                    "description": "Budget settings for AI Governance cost controls.",
+                    "type": "string"
+                },
+                "circuit_breaker_enabled": {
+                    "description": "Circuit breaker protects against cascading failures from upstream AI\nprovider overload (503, 529).",
+                    "type": "boolean"
+                },
+                "circuit_breaker_failure_threshold": {
+                    "type": "integer"
+                },
+                "circuit_breaker_interval": {
+                    "type": "integer"
+                },
+                "circuit_breaker_max_requests": {
+                    "type": "integer"
+                },
+                "circuit_breaker_timeout": {
+                    "type": "integer"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "inject_coder_mcp_tools": {
+                    "description": "Deprecated: Injected MCP in AI Bridge is deprecated and will be removed in a future release.",
+                    "type": "boolean"
+                },
+                "max_concurrency": {
+                    "type": "integer"
+                },
+                "openai": {
+                    "description": "Deprecated: Use Providers with indexed CODER_AI_GATEWAY_PROVIDER_\u003cN\u003e_* env vars instead.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/codersdk.AIBridgeOpenAIConfig"
+                        }
+                    ]
+                },
+                "providers": {
+                    "description": "Providers holds provider instances populated from CODER_AI_GATEWAY_PROVIDER_\u003cN\u003e_\u003cKEY\u003e\nenv vars and/or the deprecated LegacyOpenAI/LegacyAnthropic/LegacyBedrock fields above.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.AIProviderConfig"
+                    }
+                },
+                "rate_limit": {
+                    "type": "integer"
+                },
+                "retention": {
+                    "type": "integer"
+                },
+                "send_actor_headers": {
+                    "type": "boolean"
+                },
+                "structured_logging": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "codersdk.AIGatewayProxyConfig": {
+            "type": "object",
+            "properties": {
+                "allowed_private_cidrs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "api_dump_dir": {
+                    "type": "string"
+                },
+                "cert_file": {
+                    "type": "string"
+                },
+                "domain_allowlist": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "key_file": {
+                    "type": "string"
+                },
+                "listen_addr": {
+                    "type": "string"
+                },
+                "tls_cert_file": {
+                    "type": "string"
+                },
+                "tls_key_file": {
+                    "type": "string"
+                },
+                "upstream_proxy": {
+                    "type": "string"
+                },
+                "upstream_proxy_ca": {
+                    "type": "string"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -12840,90 +12840,6 @@
 				}
 			}
 		},
-		"codersdk.AIBridgeConfig": {
-			"type": "object",
-			"properties": {
-				"allow_byok": {
-					"type": "boolean"
-				},
-				"anthropic": {
-					"description": "Deprecated: Use Providers with indexed CODER_AI_GATEWAY_PROVIDER_\u003cN\u003e_* env vars instead.",
-					"allOf": [
-						{
-							"$ref": "#/definitions/codersdk.AIBridgeAnthropicConfig"
-						}
-					]
-				},
-				"bedrock": {
-					"description": "Deprecated: Use Providers with indexed CODER_AI_GATEWAY_PROVIDER_\u003cN\u003e_* env vars instead.",
-					"allOf": [
-						{
-							"$ref": "#/definitions/codersdk.AIBridgeBedrockConfig"
-						}
-					]
-				},
-				"budget_period": {
-					"type": "string"
-				},
-				"budget_policy": {
-					"description": "Budget settings for AI Governance cost controls.",
-					"type": "string"
-				},
-				"circuit_breaker_enabled": {
-					"description": "Circuit breaker protects against cascading failures from upstream AI\nprovider overload (503, 529).",
-					"type": "boolean"
-				},
-				"circuit_breaker_failure_threshold": {
-					"type": "integer"
-				},
-				"circuit_breaker_interval": {
-					"type": "integer"
-				},
-				"circuit_breaker_max_requests": {
-					"type": "integer"
-				},
-				"circuit_breaker_timeout": {
-					"type": "integer"
-				},
-				"enabled": {
-					"type": "boolean"
-				},
-				"inject_coder_mcp_tools": {
-					"description": "Deprecated: Injected MCP in AI Bridge is deprecated and will be removed in a future release.",
-					"type": "boolean"
-				},
-				"max_concurrency": {
-					"type": "integer"
-				},
-				"openai": {
-					"description": "Deprecated: Use Providers with indexed CODER_AI_GATEWAY_PROVIDER_\u003cN\u003e_* env vars instead.",
-					"allOf": [
-						{
-							"$ref": "#/definitions/codersdk.AIBridgeOpenAIConfig"
-						}
-					]
-				},
-				"providers": {
-					"description": "Providers holds provider instances populated from CODER_AI_GATEWAY_PROVIDER_\u003cN\u003e_\u003cKEY\u003e\nenv vars and/or the deprecated LegacyOpenAI/LegacyAnthropic/LegacyBedrock fields above.",
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/codersdk.AIProviderConfig"
-					}
-				},
-				"rate_limit": {
-					"type": "integer"
-				},
-				"retention": {
-					"type": "integer"
-				},
-				"send_actor_headers": {
-					"type": "boolean"
-				},
-				"structured_logging": {
-					"type": "boolean"
-				}
-			}
-		},
 		"codersdk.AIBridgeInterception": {
 			"type": "object",
 			"properties": {
@@ -13024,50 +12940,6 @@
 					"type": "string"
 				},
 				"key": {
-					"type": "string"
-				}
-			}
-		},
-		"codersdk.AIBridgeProxyConfig": {
-			"type": "object",
-			"properties": {
-				"allowed_private_cidrs": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				"api_dump_dir": {
-					"type": "string"
-				},
-				"cert_file": {
-					"type": "string"
-				},
-				"domain_allowlist": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				"enabled": {
-					"type": "boolean"
-				},
-				"key_file": {
-					"type": "string"
-				},
-				"listen_addr": {
-					"type": "string"
-				},
-				"tls_cert_file": {
-					"type": "string"
-				},
-				"tls_key_file": {
-					"type": "string"
-				},
-				"upstream_proxy": {
-					"type": "string"
-				},
-				"upstream_proxy_ca": {
 					"type": "string"
 				}
 			}
@@ -13399,13 +13271,141 @@
 			"type": "object",
 			"properties": {
 				"aibridge_proxy": {
-					"$ref": "#/definitions/codersdk.AIBridgeProxyConfig"
+					"$ref": "#/definitions/codersdk.AIGatewayProxyConfig"
 				},
 				"bridge": {
-					"$ref": "#/definitions/codersdk.AIBridgeConfig"
+					"$ref": "#/definitions/codersdk.AIGatewayConfig"
 				},
 				"chat": {
 					"$ref": "#/definitions/codersdk.ChatConfig"
+				}
+			}
+		},
+		"codersdk.AIGatewayConfig": {
+			"type": "object",
+			"properties": {
+				"allow_byok": {
+					"type": "boolean"
+				},
+				"anthropic": {
+					"description": "Deprecated: Use Providers with indexed CODER_AI_GATEWAY_PROVIDER_\u003cN\u003e_* env vars instead.",
+					"allOf": [
+						{
+							"$ref": "#/definitions/codersdk.AIBridgeAnthropicConfig"
+						}
+					]
+				},
+				"bedrock": {
+					"description": "Deprecated: Use Providers with indexed CODER_AI_GATEWAY_PROVIDER_\u003cN\u003e_* env vars instead.",
+					"allOf": [
+						{
+							"$ref": "#/definitions/codersdk.AIBridgeBedrockConfig"
+						}
+					]
+				},
+				"budget_period": {
+					"type": "string"
+				},
+				"budget_policy": {
+					"description": "Budget settings for AI Governance cost controls.",
+					"type": "string"
+				},
+				"circuit_breaker_enabled": {
+					"description": "Circuit breaker protects against cascading failures from upstream AI\nprovider overload (503, 529).",
+					"type": "boolean"
+				},
+				"circuit_breaker_failure_threshold": {
+					"type": "integer"
+				},
+				"circuit_breaker_interval": {
+					"type": "integer"
+				},
+				"circuit_breaker_max_requests": {
+					"type": "integer"
+				},
+				"circuit_breaker_timeout": {
+					"type": "integer"
+				},
+				"enabled": {
+					"type": "boolean"
+				},
+				"inject_coder_mcp_tools": {
+					"description": "Deprecated: Injected MCP in AI Bridge is deprecated and will be removed in a future release.",
+					"type": "boolean"
+				},
+				"max_concurrency": {
+					"type": "integer"
+				},
+				"openai": {
+					"description": "Deprecated: Use Providers with indexed CODER_AI_GATEWAY_PROVIDER_\u003cN\u003e_* env vars instead.",
+					"allOf": [
+						{
+							"$ref": "#/definitions/codersdk.AIBridgeOpenAIConfig"
+						}
+					]
+				},
+				"providers": {
+					"description": "Providers holds provider instances populated from CODER_AI_GATEWAY_PROVIDER_\u003cN\u003e_\u003cKEY\u003e\nenv vars and/or the deprecated LegacyOpenAI/LegacyAnthropic/LegacyBedrock fields above.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.AIProviderConfig"
+					}
+				},
+				"rate_limit": {
+					"type": "integer"
+				},
+				"retention": {
+					"type": "integer"
+				},
+				"send_actor_headers": {
+					"type": "boolean"
+				},
+				"structured_logging": {
+					"type": "boolean"
+				}
+			}
+		},
+		"codersdk.AIGatewayProxyConfig": {
+			"type": "object",
+			"properties": {
+				"allowed_private_cidrs": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"api_dump_dir": {
+					"type": "string"
+				},
+				"cert_file": {
+					"type": "string"
+				},
+				"domain_allowlist": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"enabled": {
+					"type": "boolean"
+				},
+				"key_file": {
+					"type": "string"
+				},
+				"listen_addr": {
+					"type": "string"
+				},
+				"tls_cert_file": {
+					"type": "string"
+				},
+				"tls_key_file": {
+					"type": "string"
+				},
+				"upstream_proxy": {
+					"type": "string"
+				},
+				"upstream_proxy_ca": {
+					"type": "string"
 				}
 			}
 		},

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -1577,7 +1577,7 @@ func TestDeleteOldAIBridgeRecords(t *testing.T) {
 			done := awaitDoTick(ctx, t, clk)
 			closer := dbpurge.New(ctx, logger, db, &codersdk.DeploymentValues{
 				AI: codersdk.AIConfig{
-					BridgeConfig: codersdk.AIBridgeConfig{
+					BridgeConfig: codersdk.AIGatewayConfig{
 						Retention: serpent.Duration(tc.retention),
 					},
 				},

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -4603,7 +4603,7 @@ Write out the current server config as YAML to stdout.`,
 	return opts
 }
 
-type AIBridgeConfig struct {
+type AIGatewayConfig struct {
 	Enabled serpent.Bool `json:"enabled" typescript:",notnull"`
 	// Deprecated: Use Providers with indexed CODER_AI_GATEWAY_PROVIDER_<N>_* env vars instead.
 	LegacyOpenAI AIBridgeOpenAIConfig `json:"openai" typescript:",notnull"`
@@ -4686,7 +4686,7 @@ type AIProviderConfig struct {
 	BedrockSmallFastModel   string   `json:"bedrock_small_fast_model,omitempty"`
 }
 
-type AIBridgeProxyConfig struct {
+type AIGatewayProxyConfig struct {
 	Enabled             serpent.Bool        `json:"enabled" typescript:",notnull"`
 	ListenAddr          serpent.String      `json:"listen_addr" typescript:",notnull"`
 	TLSCertFile         serpent.String      `json:"tls_cert_file" typescript:",notnull"`
@@ -4706,9 +4706,9 @@ type ChatConfig struct {
 }
 
 type AIConfig struct {
-	BridgeConfig      AIBridgeConfig      `json:"bridge,omitempty"`
-	BridgeProxyConfig AIBridgeProxyConfig `json:"aibridge_proxy,omitempty"`
-	Chat              ChatConfig          `json:"chat,omitempty" typescript:",notnull"`
+	BridgeConfig      AIGatewayConfig      `json:"bridge,omitempty"`
+	BridgeProxyConfig AIGatewayProxyConfig `json:"aibridge_proxy,omitempty"`
+	Chat              ChatConfig           `json:"chat,omitempty" typescript:",notnull"`
 }
 
 type TemplateBuilderConfig struct {

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -433,79 +433,6 @@
 | `region`            | string | false    |              |             |
 | `small_fast_model`  | string | false    |              |             |
 
-## codersdk.AIBridgeConfig
-
-```json
-{
-  "allow_byok": true,
-  "anthropic": {
-    "base_url": "string",
-    "key": "string"
-  },
-  "bedrock": {
-    "access_key": "string",
-    "access_key_secret": "string",
-    "base_url": "string",
-    "model": "string",
-    "region": "string",
-    "small_fast_model": "string"
-  },
-  "budget_period": "string",
-  "budget_policy": "string",
-  "circuit_breaker_enabled": true,
-  "circuit_breaker_failure_threshold": 0,
-  "circuit_breaker_interval": 0,
-  "circuit_breaker_max_requests": 0,
-  "circuit_breaker_timeout": 0,
-  "enabled": true,
-  "inject_coder_mcp_tools": true,
-  "max_concurrency": 0,
-  "openai": {
-    "base_url": "string",
-    "key": "string"
-  },
-  "providers": [
-    {
-      "base_url": "string",
-      "bedrock_model": "string",
-      "bedrock_region": "string",
-      "bedrock_small_fast_model": "string",
-      "dump_dir": "string",
-      "name": "string",
-      "type": "string"
-    }
-  ],
-  "rate_limit": 0,
-  "retention": 0,
-  "send_actor_headers": true,
-  "structured_logging": true
-}
-```
-
-### Properties
-
-| Name                                | Type                                                                 | Required | Restrictions | Description                                                                                                                                                                   |
-|-------------------------------------|----------------------------------------------------------------------|----------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `allow_byok`                        | boolean                                                              | false    |              |                                                                                                                                                                               |
-| `anthropic`                         | [codersdk.AIBridgeAnthropicConfig](#codersdkaibridgeanthropicconfig) | false    |              | Deprecated: Use Providers with indexed CODER_AI_GATEWAY_PROVIDER_<N>_* env vars instead.                                                                                      |
-| `bedrock`                           | [codersdk.AIBridgeBedrockConfig](#codersdkaibridgebedrockconfig)     | false    |              | Deprecated: Use Providers with indexed CODER_AI_GATEWAY_PROVIDER_<N>_* env vars instead.                                                                                      |
-| `budget_period`                     | string                                                               | false    |              |                                                                                                                                                                               |
-| `budget_policy`                     | string                                                               | false    |              | Budget settings for AI Governance cost controls.                                                                                                                              |
-| `circuit_breaker_enabled`           | boolean                                                              | false    |              | Circuit breaker protects against cascading failures from upstream AI provider overload (503, 529).                                                                            |
-| `circuit_breaker_failure_threshold` | integer                                                              | false    |              |                                                                                                                                                                               |
-| `circuit_breaker_interval`          | integer                                                              | false    |              |                                                                                                                                                                               |
-| `circuit_breaker_max_requests`      | integer                                                              | false    |              |                                                                                                                                                                               |
-| `circuit_breaker_timeout`           | integer                                                              | false    |              |                                                                                                                                                                               |
-| `enabled`                           | boolean                                                              | false    |              |                                                                                                                                                                               |
-| `inject_coder_mcp_tools`            | boolean                                                              | false    |              | Deprecated: Injected MCP in AI Bridge is deprecated and will be removed in a future release.                                                                                  |
-| `max_concurrency`                   | integer                                                              | false    |              |                                                                                                                                                                               |
-| `openai`                            | [codersdk.AIBridgeOpenAIConfig](#codersdkaibridgeopenaiconfig)       | false    |              | Deprecated: Use Providers with indexed CODER_AI_GATEWAY_PROVIDER_<N>_* env vars instead.                                                                                      |
-| `providers`                         | array of [codersdk.AIProviderConfig](#codersdkaiproviderconfig)      | false    |              | Providers holds provider instances populated from CODER_AI_GATEWAY_PROVIDER_<N>_<KEY> env vars and/or the deprecated LegacyOpenAI/LegacyAnthropic/LegacyBedrock fields above. |
-| `rate_limit`                        | integer                                                              | false    |              |                                                                                                                                                                               |
-| `retention`                         | integer                                                              | false    |              |                                                                                                                                                                               |
-| `send_actor_headers`                | boolean                                                              | false    |              |                                                                                                                                                                               |
-| `structured_logging`                | boolean                                                              | false    |              |                                                                                                                                                                               |
-
 ## codersdk.AIBridgeInterception
 
 ```json
@@ -756,44 +683,6 @@
 |------------|--------|----------|--------------|-------------|
 | `base_url` | string | false    |              |             |
 | `key`      | string | false    |              |             |
-
-## codersdk.AIBridgeProxyConfig
-
-```json
-{
-  "allowed_private_cidrs": [
-    "string"
-  ],
-  "api_dump_dir": "string",
-  "cert_file": "string",
-  "domain_allowlist": [
-    "string"
-  ],
-  "enabled": true,
-  "key_file": "string",
-  "listen_addr": "string",
-  "tls_cert_file": "string",
-  "tls_key_file": "string",
-  "upstream_proxy": "string",
-  "upstream_proxy_ca": "string"
-}
-```
-
-### Properties
-
-| Name                    | Type            | Required | Restrictions | Description |
-|-------------------------|-----------------|----------|--------------|-------------|
-| `allowed_private_cidrs` | array of string | false    |              |             |
-| `api_dump_dir`          | string          | false    |              |             |
-| `cert_file`             | string          | false    |              |             |
-| `domain_allowlist`      | array of string | false    |              |             |
-| `enabled`               | boolean         | false    |              |             |
-| `key_file`              | string          | false    |              |             |
-| `listen_addr`           | string          | false    |              |             |
-| `tls_cert_file`         | string          | false    |              |             |
-| `tls_key_file`          | string          | false    |              |             |
-| `upstream_proxy`        | string          | false    |              |             |
-| `upstream_proxy_ca`     | string          | false    |              |             |
 
 ## codersdk.AIBridgeSession
 
@@ -1292,11 +1181,122 @@
 
 ### Properties
 
-| Name             | Type                                                         | Required | Restrictions | Description |
-|------------------|--------------------------------------------------------------|----------|--------------|-------------|
-| `aibridge_proxy` | [codersdk.AIBridgeProxyConfig](#codersdkaibridgeproxyconfig) | false    |              |             |
-| `bridge`         | [codersdk.AIBridgeConfig](#codersdkaibridgeconfig)           | false    |              |             |
-| `chat`           | [codersdk.ChatConfig](#codersdkchatconfig)                   | false    |              |             |
+| Name             | Type                                                           | Required | Restrictions | Description |
+|------------------|----------------------------------------------------------------|----------|--------------|-------------|
+| `aibridge_proxy` | [codersdk.AIGatewayProxyConfig](#codersdkaigatewayproxyconfig) | false    |              |             |
+| `bridge`         | [codersdk.AIGatewayConfig](#codersdkaigatewayconfig)           | false    |              |             |
+| `chat`           | [codersdk.ChatConfig](#codersdkchatconfig)                     | false    |              |             |
+
+## codersdk.AIGatewayConfig
+
+```json
+{
+  "allow_byok": true,
+  "anthropic": {
+    "base_url": "string",
+    "key": "string"
+  },
+  "bedrock": {
+    "access_key": "string",
+    "access_key_secret": "string",
+    "base_url": "string",
+    "model": "string",
+    "region": "string",
+    "small_fast_model": "string"
+  },
+  "budget_period": "string",
+  "budget_policy": "string",
+  "circuit_breaker_enabled": true,
+  "circuit_breaker_failure_threshold": 0,
+  "circuit_breaker_interval": 0,
+  "circuit_breaker_max_requests": 0,
+  "circuit_breaker_timeout": 0,
+  "enabled": true,
+  "inject_coder_mcp_tools": true,
+  "max_concurrency": 0,
+  "openai": {
+    "base_url": "string",
+    "key": "string"
+  },
+  "providers": [
+    {
+      "base_url": "string",
+      "bedrock_model": "string",
+      "bedrock_region": "string",
+      "bedrock_small_fast_model": "string",
+      "dump_dir": "string",
+      "name": "string",
+      "type": "string"
+    }
+  ],
+  "rate_limit": 0,
+  "retention": 0,
+  "send_actor_headers": true,
+  "structured_logging": true
+}
+```
+
+### Properties
+
+| Name                                | Type                                                                 | Required | Restrictions | Description                                                                                                                                                                   |
+|-------------------------------------|----------------------------------------------------------------------|----------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `allow_byok`                        | boolean                                                              | false    |              |                                                                                                                                                                               |
+| `anthropic`                         | [codersdk.AIBridgeAnthropicConfig](#codersdkaibridgeanthropicconfig) | false    |              | Deprecated: Use Providers with indexed CODER_AI_GATEWAY_PROVIDER_<N>_* env vars instead.                                                                                      |
+| `bedrock`                           | [codersdk.AIBridgeBedrockConfig](#codersdkaibridgebedrockconfig)     | false    |              | Deprecated: Use Providers with indexed CODER_AI_GATEWAY_PROVIDER_<N>_* env vars instead.                                                                                      |
+| `budget_period`                     | string                                                               | false    |              |                                                                                                                                                                               |
+| `budget_policy`                     | string                                                               | false    |              | Budget settings for AI Governance cost controls.                                                                                                                              |
+| `circuit_breaker_enabled`           | boolean                                                              | false    |              | Circuit breaker protects against cascading failures from upstream AI provider overload (503, 529).                                                                            |
+| `circuit_breaker_failure_threshold` | integer                                                              | false    |              |                                                                                                                                                                               |
+| `circuit_breaker_interval`          | integer                                                              | false    |              |                                                                                                                                                                               |
+| `circuit_breaker_max_requests`      | integer                                                              | false    |              |                                                                                                                                                                               |
+| `circuit_breaker_timeout`           | integer                                                              | false    |              |                                                                                                                                                                               |
+| `enabled`                           | boolean                                                              | false    |              |                                                                                                                                                                               |
+| `inject_coder_mcp_tools`            | boolean                                                              | false    |              | Deprecated: Injected MCP in AI Bridge is deprecated and will be removed in a future release.                                                                                  |
+| `max_concurrency`                   | integer                                                              | false    |              |                                                                                                                                                                               |
+| `openai`                            | [codersdk.AIBridgeOpenAIConfig](#codersdkaibridgeopenaiconfig)       | false    |              | Deprecated: Use Providers with indexed CODER_AI_GATEWAY_PROVIDER_<N>_* env vars instead.                                                                                      |
+| `providers`                         | array of [codersdk.AIProviderConfig](#codersdkaiproviderconfig)      | false    |              | Providers holds provider instances populated from CODER_AI_GATEWAY_PROVIDER_<N>_<KEY> env vars and/or the deprecated LegacyOpenAI/LegacyAnthropic/LegacyBedrock fields above. |
+| `rate_limit`                        | integer                                                              | false    |              |                                                                                                                                                                               |
+| `retention`                         | integer                                                              | false    |              |                                                                                                                                                                               |
+| `send_actor_headers`                | boolean                                                              | false    |              |                                                                                                                                                                               |
+| `structured_logging`                | boolean                                                              | false    |              |                                                                                                                                                                               |
+
+## codersdk.AIGatewayProxyConfig
+
+```json
+{
+  "allowed_private_cidrs": [
+    "string"
+  ],
+  "api_dump_dir": "string",
+  "cert_file": "string",
+  "domain_allowlist": [
+    "string"
+  ],
+  "enabled": true,
+  "key_file": "string",
+  "listen_addr": "string",
+  "tls_cert_file": "string",
+  "tls_key_file": "string",
+  "upstream_proxy": "string",
+  "upstream_proxy_ca": "string"
+}
+```
+
+### Properties
+
+| Name                    | Type            | Required | Restrictions | Description |
+|-------------------------|-----------------|----------|--------------|-------------|
+| `allowed_private_cidrs` | array of string | false    |              |             |
+| `api_dump_dir`          | string          | false    |              |             |
+| `cert_file`             | string          | false    |              |             |
+| `domain_allowlist`      | array of string | false    |              |             |
+| `enabled`               | boolean         | false    |              |             |
+| `key_file`              | string          | false    |              |             |
+| `listen_addr`           | string          | false    |              |             |
+| `tls_cert_file`         | string          | false    |              |             |
+| `tls_key_file`          | string          | false    |              |             |
+| `upstream_proxy`        | string          | false    |              |             |
+| `upstream_proxy_ca`     | string          | false    |              |             |
 
 ## codersdk.AIProvider
 

--- a/enterprise/aibridgedserver/aibridgedserver.go
+++ b/enterprise/aibridgedserver/aibridgedserver.go
@@ -88,7 +88,7 @@ type Server struct {
 }
 
 func NewServer(lifecycleCtx context.Context, store store, logger slog.Logger, accessURL string,
-	bridgeCfg codersdk.AIBridgeConfig, externalAuthConfigs []*externalauth.Config, experiments codersdk.Experiments,
+	bridgeCfg codersdk.AIGatewayConfig, externalAuthConfigs []*externalauth.Config, experiments codersdk.Experiments,
 	aiSeatTracker aiseats.SeatTracker,
 ) (*Server, error) {
 	eac := make(map[string]*externalauth.Config, len(externalAuthConfigs))

--- a/enterprise/aibridgedserver/aibridgedserver_test.go
+++ b/enterprise/aibridgedserver/aibridgedserver_test.go
@@ -178,7 +178,7 @@ func TestAuthorization(t *testing.T) {
 				tc.mocksFn(db, apiKey, user)
 			}
 
-			srv, err := aibridgedserver.NewServer(t.Context(), db, logger, "/", codersdk.AIBridgeConfig{}, nil, requiredExperiments, agplaiseats.Noop{})
+			srv, err := aibridgedserver.NewServer(t.Context(), db, logger, "/", codersdk.AIGatewayConfig{}, nil, requiredExperiments, agplaiseats.Noop{})
 			require.NoError(t, err)
 			require.NotNil(t, srv)
 
@@ -268,7 +268,7 @@ func TestGetMCPServerConfigs(t *testing.T) {
 			logger := testutil.Logger(t)
 
 			accessURL := "https://my-cool-deployment.com"
-			srv, err := aibridgedserver.NewServer(t.Context(), db, logger, accessURL, codersdk.AIBridgeConfig{
+			srv, err := aibridgedserver.NewServer(t.Context(), db, logger, accessURL, codersdk.AIGatewayConfig{
 				InjectCoderMCPTools: serpent.Bool(!tc.disableCoderMCPInjection),
 			}, tc.externalAuthConfigs, tc.experiments, agplaiseats.Noop{})
 			require.NoError(t, err)
@@ -308,7 +308,7 @@ func TestGetMCPServerAccessTokensBatch(t *testing.T) {
 	logger := testutil.Logger(t)
 
 	// Given: 2 external auth configured with MCP and 1 without.
-	srv, err := aibridgedserver.NewServer(t.Context(), db, logger, "/", codersdk.AIBridgeConfig{}, []*externalauth.Config{
+	srv, err := aibridgedserver.NewServer(t.Context(), db, logger, "/", codersdk.AIGatewayConfig{}, []*externalauth.Config{
 		{
 			ID:     "1",
 			MCPURL: "1.com/mcp",
@@ -1216,7 +1216,7 @@ func testRecordMethod[Req any, Resp any](
 			}
 
 			ctx := testutil.Context(t, testutil.WaitLong)
-			srv, err := aibridgedserver.NewServer(ctx, db, logger, "/", codersdk.AIBridgeConfig{}, nil, requiredExperiments, agplaiseats.Noop{})
+			srv, err := aibridgedserver.NewServer(ctx, db, logger, "/", codersdk.AIGatewayConfig{}, nil, requiredExperiments, agplaiseats.Noop{})
 			require.NoError(t, err)
 
 			resp, err := callMethod(srv, ctx, tc.request)
@@ -1532,7 +1532,7 @@ func TestStructuredLogging(t *testing.T) {
 			tc.setupMocks(db, interceptionID)
 
 			ctx := testutil.Context(t, testutil.WaitLong)
-			srv, err := aibridgedserver.NewServer(ctx, db, logger, "/", codersdk.AIBridgeConfig{
+			srv, err := aibridgedserver.NewServer(ctx, db, logger, "/", codersdk.AIGatewayConfig{
 				StructuredLogging: serpent.Bool(tc.structuredLogging),
 			}, nil, requiredExperiments, agplaiseats.Noop{})
 			require.NoError(t, err)
@@ -1576,7 +1576,7 @@ func TestInferredThreadsByToolCalls(t *testing.T) {
 
 	user := dbgen.User(t, db, database.User{})
 
-	srv, err := aibridgedserver.NewServer(ctx, db, logger, "/", codersdk.AIBridgeConfig{}, nil, requiredExperiments, agplaiseats.Noop{})
+	srv, err := aibridgedserver.NewServer(ctx, db, logger, "/", codersdk.AIGatewayConfig{}, nil, requiredExperiments, agplaiseats.Noop{})
 	require.NoError(t, err)
 
 	aID := uuid.New()

--- a/enterprise/cli/aibridged.go
+++ b/enterprise/cli/aibridged.go
@@ -50,7 +50,7 @@ func newAIBridgeDaemon(coderAPI *coderd.API, providers []aibridge.Provider) (*ai
 //     If a legacy name conflicts with an indexed provider, startup fails with
 //     a clear error asking the admin to remove one or the other.
 //  2. Indexed providers (from CODER_AI_GATEWAY_PROVIDER_<N>_*) are added next.
-func buildProviders(cfg codersdk.AIBridgeConfig) ([]aibridge.Provider, error) {
+func buildProviders(cfg codersdk.AIGatewayConfig) ([]aibridge.Provider, error) {
 	var cbConfig *config.CircuitBreaker
 	if cfg.CircuitBreakerEnabled.Value() {
 		cbConfig = &config.CircuitBreaker{

--- a/enterprise/cli/aibridged_internal_test.go
+++ b/enterprise/cli/aibridged_internal_test.go
@@ -19,14 +19,14 @@ func TestBuildProviders(t *testing.T) {
 
 	t.Run("EmptyConfig", func(t *testing.T) {
 		t.Parallel()
-		providers, err := buildProviders(codersdk.AIBridgeConfig{})
+		providers, err := buildProviders(codersdk.AIGatewayConfig{})
 		require.NoError(t, err)
 		assert.Empty(t, providers)
 	})
 
 	t.Run("LegacyOnly", func(t *testing.T) {
 		t.Parallel()
-		cfg := codersdk.AIBridgeConfig{}
+		cfg := codersdk.AIGatewayConfig{}
 		cfg.LegacyOpenAI.Key = serpent.String("sk-openai")
 		cfg.LegacyAnthropic.Key = serpent.String("sk-anthropic")
 
@@ -41,7 +41,7 @@ func TestBuildProviders(t *testing.T) {
 
 	t.Run("IndexedOnly", func(t *testing.T) {
 		t.Parallel()
-		cfg := codersdk.AIBridgeConfig{
+		cfg := codersdk.AIGatewayConfig{
 			Providers: []codersdk.AIProviderConfig{
 				{
 					Type:    aibridge.ProviderAnthropic,
@@ -70,7 +70,7 @@ func TestBuildProviders(t *testing.T) {
 
 	t.Run("LegacyOpenAIConflictsWithIndexed", func(t *testing.T) {
 		t.Parallel()
-		cfg := codersdk.AIBridgeConfig{
+		cfg := codersdk.AIGatewayConfig{
 			Providers: []codersdk.AIProviderConfig{
 				{Type: aibridge.ProviderOpenAI, Name: aibridge.ProviderOpenAI, Keys: []string{"sk-indexed"}},
 			},
@@ -84,7 +84,7 @@ func TestBuildProviders(t *testing.T) {
 
 	t.Run("LegacyAnthropicConflictsWithIndexed", func(t *testing.T) {
 		t.Parallel()
-		cfg := codersdk.AIBridgeConfig{
+		cfg := codersdk.AIGatewayConfig{
 			Providers: []codersdk.AIProviderConfig{
 				{Type: aibridge.ProviderAnthropic, Name: aibridge.ProviderAnthropic, Keys: []string{"sk-indexed"}},
 			},
@@ -98,7 +98,7 @@ func TestBuildProviders(t *testing.T) {
 
 	t.Run("MixedLegacyAndIndexed", func(t *testing.T) {
 		t.Parallel()
-		cfg := codersdk.AIBridgeConfig{
+		cfg := codersdk.AIGatewayConfig{
 			Providers: []codersdk.AIProviderConfig{
 				{Type: aibridge.ProviderAnthropic, Name: "anthropic-zdr", Keys: []string{"sk-zdr"}},
 			},
@@ -117,7 +117,7 @@ func TestBuildProviders(t *testing.T) {
 
 	t.Run("LegacyAnthropicWithBedrock", func(t *testing.T) {
 		t.Parallel()
-		cfg := codersdk.AIBridgeConfig{}
+		cfg := codersdk.AIGatewayConfig{}
 		cfg.LegacyAnthropic.Key = serpent.String("sk-anthropic")
 		cfg.LegacyBedrock.Region = serpent.String("us-west-2")
 		cfg.LegacyBedrock.AccessKey = serpent.String("AKID")
@@ -134,7 +134,7 @@ func TestBuildProviders(t *testing.T) {
 		t.Parallel()
 		// Bedrock credentials alone should be enough to create an
 		// Anthropic provider — no CODER_AIBRIDGE_ANTHROPIC_KEY needed.
-		cfg := codersdk.AIBridgeConfig{}
+		cfg := codersdk.AIGatewayConfig{}
 		cfg.LegacyBedrock.Region = serpent.String("us-west-2")
 		cfg.LegacyBedrock.AccessKey = serpent.String("AKID")
 		cfg.LegacyBedrock.AccessKeySecret = serpent.String("secret")
@@ -150,7 +150,7 @@ func TestBuildProviders(t *testing.T) {
 
 	t.Run("UnknownType", func(t *testing.T) {
 		t.Parallel()
-		cfg := codersdk.AIBridgeConfig{
+		cfg := codersdk.AIGatewayConfig{
 			Providers: []codersdk.AIProviderConfig{
 				{Type: "gemini", Name: "gemini-pro"},
 			},
@@ -165,7 +165,7 @@ func TestBuildProviders(t *testing.T) {
 		t.Parallel()
 		// Copilot providers can target any of the three GitHub
 		// Copilot API hosts via an explicit BASE_URL.
-		cfg := codersdk.AIBridgeConfig{
+		cfg := codersdk.AIGatewayConfig{
 			Providers: []codersdk.AIProviderConfig{
 				{Type: aibridge.ProviderCopilot, Name: aibridge.ProviderCopilot, DumpDir: "/tmp/copilot-dump"},
 				{Type: aibridge.ProviderCopilot, Name: agplaibridge.ProviderCopilotBusiness, BaseURL: "https://" + agplaibridge.HostCopilotBusiness},
@@ -189,7 +189,7 @@ func TestBuildProviders(t *testing.T) {
 		t.Parallel()
 		// ChatGPT is an OpenAI-compatible provider with a custom
 		// base URL. Admins configure it as an indexed openai provider.
-		cfg := codersdk.AIBridgeConfig{
+		cfg := codersdk.AIGatewayConfig{
 			Providers: []codersdk.AIProviderConfig{
 				{Type: aibridge.ProviderOpenAI, Name: agplaibridge.ProviderChatGPT, BaseURL: agplaibridge.BaseURLChatGPT},
 			},
@@ -218,7 +218,7 @@ func TestDomainsFromProviders(t *testing.T) {
 	t.Run("ExtractsHostnames", func(t *testing.T) {
 		t.Parallel()
 
-		providers, err := buildProviders(codersdk.AIBridgeConfig{
+		providers, err := buildProviders(codersdk.AIGatewayConfig{
 			Providers: []codersdk.AIProviderConfig{
 				{Type: aibridge.ProviderOpenAI, Name: "openai", Keys: []string{"k"}},
 				{Type: aibridge.ProviderAnthropic, Name: "anthropic", Keys: []string{"k"}},
@@ -242,7 +242,7 @@ func TestDomainsFromProviders(t *testing.T) {
 	t.Run("DeduplicatesSameHost", func(t *testing.T) {
 		t.Parallel()
 
-		providers, err := buildProviders(codersdk.AIBridgeConfig{
+		providers, err := buildProviders(codersdk.AIGatewayConfig{
 			Providers: []codersdk.AIProviderConfig{
 				{Type: aibridge.ProviderOpenAI, Name: "first", Keys: []string{"k"}, BaseURL: "https://api.example.com/v1"},
 				{Type: aibridge.ProviderOpenAI, Name: "second", Keys: []string{"k"}, BaseURL: "https://api.example.com/v2"},
@@ -267,7 +267,7 @@ func TestDomainsFromProviders(t *testing.T) {
 	t.Run("CaseInsensitive", func(t *testing.T) {
 		t.Parallel()
 
-		providers, err := buildProviders(codersdk.AIBridgeConfig{
+		providers, err := buildProviders(codersdk.AIGatewayConfig{
 			Providers: []codersdk.AIProviderConfig{
 				{Type: aibridge.ProviderOpenAI, Name: "provider", Keys: []string{"k"}, BaseURL: "https://API.Example.COM/v1"},
 			},

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -38,52 +38,6 @@ export interface AIBridgeBedrockConfig {
 	readonly small_fast_model: string;
 }
 
-// From codersdk/deployment.go
-export interface AIBridgeConfig {
-	readonly enabled: boolean;
-	/**
-	 * @deprecated Use Providers with indexed CODER_AI_GATEWAY_PROVIDER_<N>_* env vars instead.
-	 */
-	readonly openai: AIBridgeOpenAIConfig;
-	/**
-	 * @deprecated Use Providers with indexed CODER_AI_GATEWAY_PROVIDER_<N>_* env vars instead.
-	 */
-	readonly anthropic: AIBridgeAnthropicConfig;
-	/**
-	 * @deprecated Use Providers with indexed CODER_AI_GATEWAY_PROVIDER_<N>_* env vars instead.
-	 */
-	readonly bedrock: AIBridgeBedrockConfig;
-	/**
-	 * Providers holds provider instances populated from CODER_AI_GATEWAY_PROVIDER_<N>_<KEY>
-	 * env vars and/or the deprecated LegacyOpenAI/LegacyAnthropic/LegacyBedrock fields above.
-	 */
-	readonly providers?: readonly AIProviderConfig[];
-	/**
-	 * @deprecated Injected MCP in AI Bridge is deprecated and will be removed in a future release.
-	 */
-	readonly inject_coder_mcp_tools: boolean;
-	readonly retention: number;
-	readonly max_concurrency: number;
-	readonly rate_limit: number;
-	readonly structured_logging: boolean;
-	readonly send_actor_headers: boolean;
-	readonly allow_byok: boolean;
-	/**
-	 * Budget settings for AI Governance cost controls.
-	 */
-	readonly budget_policy?: string;
-	readonly budget_period?: string;
-	/**
-	 * Circuit breaker protects against cascading failures from upstream AI
-	 * provider overload (503, 529).
-	 */
-	readonly circuit_breaker_enabled: boolean;
-	readonly circuit_breaker_failure_threshold: number;
-	readonly circuit_breaker_interval: number;
-	readonly circuit_breaker_timeout: number;
-	readonly circuit_breaker_max_requests: number;
-}
-
 // From codersdk/aibridge.go
 export interface AIBridgeInterception {
 	readonly id: string;
@@ -127,21 +81,6 @@ export interface AIBridgeModelThought {
 export interface AIBridgeOpenAIConfig {
 	readonly base_url: string;
 	readonly key: string;
-}
-
-// From codersdk/deployment.go
-export interface AIBridgeProxyConfig {
-	readonly enabled: boolean;
-	readonly listen_addr: string;
-	readonly tls_cert_file: string;
-	readonly tls_key_file: string;
-	readonly cert_file: string;
-	readonly key_file: string;
-	readonly domain_allowlist: string;
-	readonly upstream_proxy: string;
-	readonly upstream_proxy_ca: string;
-	readonly allowed_private_cidrs: string;
-	readonly api_dump_dir: string;
 }
 
 // From codersdk/aibridge.go
@@ -293,9 +232,70 @@ export type AIBudgetPolicy = "highest";
 
 // From codersdk/deployment.go
 export interface AIConfig {
-	readonly bridge?: AIBridgeConfig;
-	readonly aibridge_proxy?: AIBridgeProxyConfig;
+	readonly bridge?: AIGatewayConfig;
+	readonly aibridge_proxy?: AIGatewayProxyConfig;
 	readonly chat?: ChatConfig;
+}
+
+// From codersdk/deployment.go
+export interface AIGatewayConfig {
+	readonly enabled: boolean;
+	/**
+	 * @deprecated Use Providers with indexed CODER_AI_GATEWAY_PROVIDER_<N>_* env vars instead.
+	 */
+	readonly openai: AIBridgeOpenAIConfig;
+	/**
+	 * @deprecated Use Providers with indexed CODER_AI_GATEWAY_PROVIDER_<N>_* env vars instead.
+	 */
+	readonly anthropic: AIBridgeAnthropicConfig;
+	/**
+	 * @deprecated Use Providers with indexed CODER_AI_GATEWAY_PROVIDER_<N>_* env vars instead.
+	 */
+	readonly bedrock: AIBridgeBedrockConfig;
+	/**
+	 * Providers holds provider instances populated from CODER_AI_GATEWAY_PROVIDER_<N>_<KEY>
+	 * env vars and/or the deprecated LegacyOpenAI/LegacyAnthropic/LegacyBedrock fields above.
+	 */
+	readonly providers?: readonly AIProviderConfig[];
+	/**
+	 * @deprecated Injected MCP in AI Bridge is deprecated and will be removed in a future release.
+	 */
+	readonly inject_coder_mcp_tools: boolean;
+	readonly retention: number;
+	readonly max_concurrency: number;
+	readonly rate_limit: number;
+	readonly structured_logging: boolean;
+	readonly send_actor_headers: boolean;
+	readonly allow_byok: boolean;
+	/**
+	 * Budget settings for AI Governance cost controls.
+	 */
+	readonly budget_policy?: string;
+	readonly budget_period?: string;
+	/**
+	 * Circuit breaker protects against cascading failures from upstream AI
+	 * provider overload (503, 529).
+	 */
+	readonly circuit_breaker_enabled: boolean;
+	readonly circuit_breaker_failure_threshold: number;
+	readonly circuit_breaker_interval: number;
+	readonly circuit_breaker_timeout: number;
+	readonly circuit_breaker_max_requests: number;
+}
+
+// From codersdk/deployment.go
+export interface AIGatewayProxyConfig {
+	readonly enabled: boolean;
+	readonly listen_addr: string;
+	readonly tls_cert_file: string;
+	readonly tls_key_file: string;
+	readonly cert_file: string;
+	readonly key_file: string;
+	readonly domain_allowlist: string;
+	readonly upstream_proxy: string;
+	readonly upstream_proxy_ca: string;
+	readonly allowed_private_cidrs: string;
+	readonly api_dump_dir: string;
 }
 
 // From codersdk/aiproviders.go


### PR DESCRIPTION
Changes types names `AIBridgeConfig` -> `AIGatewayConfig` and `AIBridgeProxyConfig` -> `AIGatewayProxyConfig` to match the new branding to match new branding.

Those types are exported by `codersdk` and visible in schemas page, eg: https://coder.com/docs/reference/api/schemas#codersdkaibridgeconfig