### PR TITLE
feat: stream shell command output

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -7727,7 +7727,7 @@ func (p *Server) runChat(
 				p.publishMessagePart(chat.ID, codersdk.ChatMessageRoleTool, codersdk.ChatMessagePart{
 					Type:        codersdk.ChatMessagePartTypeToolResult,
 					ToolCallID:  toolCallID,
-					ToolName:    "execute",
+					ToolName:    chattool.ExecuteToolName,
 					ResultDelta: delta,
 				})
 			},
@@ -7738,7 +7738,7 @@ func (p *Server) runChat(
 				p.publishMessagePart(chat.ID, codersdk.ChatMessageRoleTool, codersdk.ChatMessagePart{
 					Type:        codersdk.ChatMessagePartTypeToolResult,
 					ToolCallID:  toolCallID,
-					ToolName:    "execute",
+					ToolName:    chattool.ExecuteToolName,
 					ResultReset: true,
 				})
 			},

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -7720,6 +7720,28 @@ func (p *Server) runChat(
 		}),
 		chattool.Execute(chattool.ExecuteOptions{
 			GetWorkspaceConn: workspaceCtx.getWorkspaceConn,
+			PublishResultDelta: func(toolCallID string, delta string) {
+				if toolCallID == "" || delta == "" {
+					return
+				}
+				p.publishMessagePart(chat.ID, codersdk.ChatMessageRoleTool, codersdk.ChatMessagePart{
+					Type:        codersdk.ChatMessagePartTypeToolResult,
+					ToolCallID:  toolCallID,
+					ToolName:    "execute",
+					ResultDelta: delta,
+				})
+			},
+			PublishResultReset: func(toolCallID string) {
+				if toolCallID == "" {
+					return
+				}
+				p.publishMessagePart(chat.ID, codersdk.ChatMessageRoleTool, codersdk.ChatMessagePart{
+					Type:        codersdk.ChatMessagePartTypeToolResult,
+					ToolCallID:  toolCallID,
+					ToolName:    "execute",
+					ResultReset: true,
+				})
+			},
 		}),
 		chattool.ProcessOutput(chattool.ProcessToolOptions{
 			GetWorkspaceConn: workspaceCtx.getWorkspaceConn,

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -4073,6 +4073,227 @@ func TestPersistToolResultWithBinaryData(t *testing.T) {
 	require.True(t, foundToolResultInSecondCall, "expected second streamed model call to include execute tool output")
 }
 
+func TestExecuteToolStreamsResultDeltas(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitLong)
+
+	const command = "printf stream"
+	const output = "stream \"coder\"\n"
+
+	var streamedCallCount atomic.Int32
+	var streamedCallsMu sync.Mutex
+	var finalCallMessages []chattest.OpenAIMessage
+	openAIURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
+		if !req.Stream {
+			return chattest.OpenAINonStreamingResponse("Execute streaming test")
+		}
+		if streamedCallCount.Add(1) == 1 {
+			return chattest.OpenAIStreamingResponse(
+				chattest.OpenAIToolCallChunk("execute", `{"command":"printf stream"}`),
+			)
+		}
+		streamedCallsMu.Lock()
+		finalCallMessages = append([]chattest.OpenAIMessage(nil), req.Messages...)
+		streamedCallsMu.Unlock()
+		return chattest.OpenAIStreamingResponse(chattest.OpenAITextChunks("done")...)
+	})
+
+	user, org, model := seedChatDependenciesWithProvider(t, db, "openai-compat", openAIURL)
+	ws, dbAgent := seedWorkspaceWithAgent(t, db, user.ID)
+
+	ctrl := gomock.NewController(t)
+	mockConn := agentconnmock.NewMockAgentConn(ctrl)
+	mockConn.EXPECT().
+		SetExtraHeaders(gomock.Any()).
+		AnyTimes()
+	mockConn.EXPECT().
+		ContextConfig(gomock.Any()).
+		Return(workspacesdk.ContextConfigResponse{}, xerrors.New("not supported")).
+		AnyTimes()
+	mockConn.EXPECT().
+		ListMCPTools(gomock.Any()).
+		Return(workspacesdk.ListMCPToolsResponse{}, nil).
+		AnyTimes()
+	mockConn.EXPECT().
+		LS(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(workspacesdk.LSResponse{}, nil).
+		AnyTimes()
+	mockConn.EXPECT().
+		ReadFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(io.NopCloser(strings.NewReader("")), "", nil).
+		AnyTimes()
+	mockConn.EXPECT().
+		StartProcess(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req workspacesdk.StartProcessRequest) (workspacesdk.StartProcessResponse, error) {
+			require.Equal(t, command, req.Command)
+			return workspacesdk.StartProcessResponse{ID: "proc-stream", Started: true}, nil
+		}).
+		Times(1)
+
+	releaseOutput := make(chan struct{})
+	var releaseOutputOnce sync.Once
+	release := func() {
+		releaseOutputOnce.Do(func() {
+			close(releaseOutput)
+		})
+	}
+	t.Cleanup(release)
+	mockConn.EXPECT().
+		ProcessOutput(gomock.Any(), "proc-stream", gomock.Nil()).
+		DoAndReturn(func(_ context.Context, _ string, _ *workspacesdk.ProcessOutputOptions) (workspacesdk.ProcessOutputResponse, error) {
+			select {
+			case <-releaseOutput:
+			case <-ctx.Done():
+				return workspacesdk.ProcessOutputResponse{}, ctx.Err()
+			}
+			return workspacesdk.ProcessOutputResponse{
+				Output:   output,
+				Running:  false,
+				ExitCode: ptrRef(0),
+			}, nil
+		}).
+		AnyTimes()
+
+	server := newActiveTestServer(t, db, ps, func(cfg *chatd.Config) {
+		cfg.AgentConn = func(_ context.Context, agentID uuid.UUID) (workspacesdk.AgentConn, func(), error) {
+			require.Equal(t, dbAgent.ID, agentID)
+			return mockConn, func() {}, nil
+		}
+	})
+
+	chat, err := server.CreateChat(ctx, chatd.CreateOptions{
+		OrganizationID: org.ID,
+		OwnerID:        user.ID,
+		Title:          "execute-streaming-tool-result",
+		ModelConfigID:  model.ID,
+		WorkspaceID:    uuid.NullUUID{UUID: ws.ID, Valid: true},
+		InitialUserContent: []codersdk.ChatMessagePart{
+			codersdk.ChatMessageText("Run printf stream."),
+		},
+	})
+	require.NoError(t, err)
+
+	_, liveEvents, cancelLive, ok := server.Subscribe(ctx, chat.ID, nil, 0)
+	require.True(t, ok)
+	var (
+		livePartsMu       sync.Mutex
+		liveExecuteDeltas []string
+		liveExecuteResets int
+		liveCollectorDone = make(chan struct{})
+	)
+	go func() {
+		defer close(liveCollectorDone)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event, eventsOK := <-liveEvents:
+				if !eventsOK {
+					return
+				}
+				if event.Type != codersdk.ChatStreamEventTypeMessagePart ||
+					event.MessagePart == nil {
+					continue
+				}
+				part := event.MessagePart.Part
+				if event.MessagePart.Role != codersdk.ChatMessageRoleTool ||
+					part.Type != codersdk.ChatMessagePartTypeToolResult ||
+					part.ToolName != "execute" {
+					continue
+				}
+				livePartsMu.Lock()
+				if part.ResultReset {
+					liveExecuteResets++
+				}
+				if part.ResultDelta != "" {
+					liveExecuteDeltas = append(liveExecuteDeltas, part.ResultDelta)
+				}
+				livePartsMu.Unlock()
+			}
+		}
+	}()
+
+	release()
+
+	var chatResult database.Chat
+	require.Eventually(t, func() bool {
+		got, getErr := db.GetChatByID(ctx, chat.ID)
+		if getErr != nil {
+			return false
+		}
+		chatResult = got
+		return got.Status == database.ChatStatusWaiting || got.Status == database.ChatStatusError
+	}, testutil.WaitLong, testutil.IntervalFast)
+	if chatResult.Status == database.ChatStatusError {
+		require.FailNowf(t, "chat run failed", "last_error=%q", chatLastErrorMessage(chatResult.LastError))
+	}
+	require.GreaterOrEqual(t, streamedCallCount.Load(), int32(2))
+
+	require.Eventually(t, func() bool {
+		livePartsMu.Lock()
+		defer livePartsMu.Unlock()
+		return len(liveExecuteDeltas) > 0
+	}, testutil.WaitLong, testutil.IntervalFast)
+
+	cancelLive()
+	<-liveCollectorDone
+	livePartsMu.Lock()
+	collectedExecuteDeltas := append([]string(nil), liveExecuteDeltas...)
+	collectedExecuteResets := liveExecuteResets
+	livePartsMu.Unlock()
+
+	require.Zero(t, collectedExecuteResets)
+	var streamed map[string]string
+	require.NoError(t, json.Unmarshal([]byte(strings.Join(collectedExecuteDeltas, "")+`"}`), &streamed))
+	require.Equal(t, output, streamed["output"])
+
+	streamedCallsMu.Lock()
+	gotFinalMessages := append([]chattest.OpenAIMessage(nil), finalCallMessages...)
+	streamedCallsMu.Unlock()
+	require.NotEmpty(t, gotFinalMessages, "parent must make a follow-up call after the execute result")
+
+	var foundToolResultInFinalCall bool
+	for _, message := range gotFinalMessages {
+		if message.Role != "tool" || !json.Valid([]byte(message.Content)) {
+			continue
+		}
+		var result chattool.ExecuteResult
+		if err := json.Unmarshal([]byte(message.Content), &result); err != nil {
+			continue
+		}
+		if result.Output == output {
+			foundToolResultInFinalCall = true
+			break
+		}
+	}
+	require.True(t, foundToolResultInFinalCall, "expected follow-up model call to include execute tool output")
+
+	persisted, err := db.GetChatMessagesByChatID(ctx, database.GetChatMessagesByChatIDParams{
+		ChatID:  chat.ID,
+		AfterID: 0,
+	})
+	require.NoError(t, err)
+	var toolMessage *database.ChatMessage
+	for i := range persisted {
+		require.NotContains(t, string(persisted[i].Content.RawMessage), "result_delta")
+		if persisted[i].Role == database.ChatMessageRoleTool {
+			toolMessage = &persisted[i]
+		}
+	}
+	require.NotNil(t, toolMessage)
+	parts, err := chatprompt.ParseContent(*toolMessage)
+	require.NoError(t, err)
+	require.Len(t, parts, 1)
+	require.Empty(t, parts[0].ResultDelta)
+	var result chattool.ExecuteResult
+	require.NoError(t, json.Unmarshal(parts[0].Result, &result))
+	require.True(t, result.Success)
+	require.Equal(t, output, result.Output)
+	require.Equal(t, 0, result.ExitCode)
+}
+
 func TestRequiresActionChatPersistsWaitingStatusLabel(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -4095,7 +4095,7 @@ func TestExecuteToolStreamsResultDeltas(t *testing.T) {
 			)
 		}
 		streamedCallsMu.Lock()
-		finalCallMessages = append([]chattest.OpenAIMessage(nil), req.Messages...)
+		finalCallMessages = slices.Clone(req.Messages)
 		streamedCallsMu.Unlock()
 		return chattest.OpenAIStreamingResponse(chattest.OpenAITextChunks("done")...)
 	})
@@ -4133,12 +4133,9 @@ func TestExecuteToolStreamsResultDeltas(t *testing.T) {
 		Times(1)
 
 	releaseOutput := make(chan struct{})
-	var releaseOutputOnce sync.Once
-	release := func() {
-		releaseOutputOnce.Do(func() {
-			close(releaseOutput)
-		})
-	}
+	release := sync.OnceFunc(func() {
+		close(releaseOutput)
+	})
 	t.Cleanup(release)
 	mockConn.EXPECT().
 		ProcessOutput(gomock.Any(), "proc-stream", gomock.Nil()).
@@ -4240,7 +4237,7 @@ func TestExecuteToolStreamsResultDeltas(t *testing.T) {
 	cancelLive()
 	<-liveCollectorDone
 	livePartsMu.Lock()
-	collectedExecuteDeltas := append([]string(nil), liveExecuteDeltas...)
+	collectedExecuteDeltas := slices.Clone(liveExecuteDeltas)
 	collectedExecuteResets := liveExecuteResets
 	livePartsMu.Unlock()
 
@@ -4250,7 +4247,7 @@ func TestExecuteToolStreamsResultDeltas(t *testing.T) {
 	require.Equal(t, output, streamed["output"])
 
 	streamedCallsMu.Lock()
-	gotFinalMessages := append([]chattest.OpenAIMessage(nil), finalCallMessages...)
+	gotFinalMessages := slices.Clone(finalCallMessages)
 	streamedCallsMu.Unlock()
 	require.NotEmpty(t, gotFinalMessages, "parent must make a follow-up call after the execute result")
 

--- a/coderd/x/chatd/chattool/execute.go
+++ b/coderd/x/chatd/chattool/execute.go
@@ -27,8 +27,7 @@ const (
 	// output snapshot after a blocking wait times out.
 	snapshotTimeout = 30 * time.Second
 
-	// defaultProcessOutputPollInterval balances responsiveness with
-	// the cost of fetching whole retained snapshots from the agent.
+	// defaultProcessOutputPollInterval is moderate because each poll re-fetches the retained output buffer from the agent.
 	defaultProcessOutputPollInterval = 250 * time.Millisecond
 )
 
@@ -86,7 +85,7 @@ type executeToolOptions struct {
 	processOutputPollInterval time.Duration
 }
 
-func (o executeToolOptions) streamResults() bool {
+func (o executeToolOptions) canStreamResults() bool {
 	return o.toolCallID != "" && o.publishResultDelta != nil && o.publishResultReset != nil
 }
 
@@ -260,7 +259,7 @@ func executeForeground(
 	}
 
 	var result ExecuteResult
-	if options.streamResults() {
+	if options.canStreamResults() {
 		result = streamProcessOutput(cmdCtx, ctx, conn, resp.ID, timeout, options)
 	} else {
 		result = waitForProcess(cmdCtx, ctx, conn, resp.ID, timeout)
@@ -289,19 +288,13 @@ func truncateOutput(output string) string {
 	return output
 }
 
-type streamProcessOutputRecoveryReason int
-
-const (
-	streamProcessOutputRecoveryError streamProcessOutputRecoveryReason = iota
-	streamProcessOutputRecoveryTimeout
-)
-
 type executeOutputStreamer struct {
 	toolCallID         string
 	publishResultDelta func(toolCallID string, delta string)
 	publishResultReset func(toolCallID string)
 	started            bool
 	output             string
+	suppressedRetained bool
 }
 
 func newExecuteOutputStreamer(options executeToolOptions) executeOutputStreamer {
@@ -312,11 +305,13 @@ func newExecuteOutputStreamer(options executeToolOptions) executeOutputStreamer 
 	}
 }
 
-func (s *executeOutputStreamer) publish(output string) {
+// publish keeps deltas as partial JSON so the chat stream can merge
+// progressive output without replacing the final tool result.
+func (s *executeOutputStreamer) publish(resp workspacesdk.ProcessOutputResponse) {
 	if s.publishResultDelta == nil || s.toolCallID == "" {
 		return
 	}
-	output = truncateOutput(output)
+	output := truncateOutput(resp.Output)
 	if output == s.output {
 		return
 	}
@@ -324,9 +319,20 @@ func (s *executeOutputStreamer) publish(output string) {
 		if !s.started || s.publishResultReset == nil {
 			return
 		}
+		if resp.Running && resp.Truncated != nil && s.suppressedRetained {
+			// Head-tail snapshots can rewrite the omission marker and moving tail while the process is still append-only.
+			return
+		}
+		if resp.Running && resp.Truncated != nil {
+			s.suppressedRetained = true
+		} else {
+			s.suppressedRetained = false
+		}
 		s.publishResultReset(s.toolCallID)
 		s.started = false
 		s.output = ""
+	} else {
+		s.suppressedRetained = false
 	}
 	delta := strings.TrimPrefix(output, s.output)
 	if delta == "" {
@@ -341,11 +347,14 @@ func (s *executeOutputStreamer) publish(output string) {
 	s.output = output
 }
 
+// jsonStringFragment leaves the JSON string open because chat message deltas are merged before the final quote and object brace are appended.
 func jsonStringFragment(value string) string {
 	data, _ := json.Marshal(value)
 	return string(data[1 : len(data)-1])
 }
 
+// streamProcessOutput polls because foreground commands need live deltas
+// while the agent API still returns retained output snapshots.
 func streamProcessOutput(
 	ctx context.Context,
 	parentCtx context.Context,
@@ -360,13 +369,9 @@ func streamProcessOutput(
 	for {
 		resp, err := conn.ProcessOutput(ctx, processID, nil)
 		if err != nil {
-			reason := streamProcessOutputRecoveryError
-			if ctx.Err() != nil {
-				reason = streamProcessOutputRecoveryTimeout
-			}
-			return recoverStreamProcessOutput(parentCtx, conn, processID, timeout, err, reason, &streamer)
+			return recoverProcessOutputSnapshot(parentCtx, conn, processID, timeout, err, processOutputRecoveryReasonFromContextErr(ctx.Err()), streamer.publish)
 		}
-		streamer.publish(resp.Output)
+		streamer.publish(resp)
 		if !resp.Running {
 			return processOutputResult(resp)
 		}
@@ -378,28 +383,45 @@ func streamProcessOutput(
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			return recoverStreamProcessOutput(parentCtx, conn, processID, timeout, ctx.Err(), streamProcessOutputRecoveryTimeout, &streamer)
+			return recoverProcessOutputSnapshot(parentCtx, conn, processID, timeout, ctx.Err(), processOutputRecoveryTimeout, streamer.publish)
 		case <-timer.C:
 			timer.Stop()
 		}
 	}
 }
 
-func recoverStreamProcessOutput(
+type processOutputRecoveryReason int
+
+const (
+	processOutputRecoveryError processOutputRecoveryReason = iota
+	processOutputRecoveryTimeout
+)
+
+func processOutputRecoveryReasonFromContextErr(err error) processOutputRecoveryReason {
+	if err != nil {
+		return processOutputRecoveryTimeout
+	}
+	return processOutputRecoveryError
+}
+
+// recoverProcessOutputSnapshot is shared so streaming and blocking waits
+// surface identical timeout and transport-error results.
+func recoverProcessOutputSnapshot(
 	parentCtx context.Context,
 	conn workspacesdk.AgentConn,
 	processID string,
 	timeout time.Duration,
 	origErr error,
-	reason streamProcessOutputRecoveryReason,
-	streamer *executeOutputStreamer,
+	reason processOutputRecoveryReason,
+	publish func(workspacesdk.ProcessOutputResponse),
 ) ExecuteResult {
+	// Use the parent context so timeout recovery can still retrieve a final snapshot after the command wait context expires.
 	bgCtx, bgCancel := context.WithTimeout(parentCtx, snapshotTimeout)
 	defer bgCancel()
 	resp, err := conn.ProcessOutput(bgCtx, processID, nil)
 	if err != nil {
 		errMsg := fmt.Sprintf("get process output: %v; use process_output with ID %s to retry", origErr, processID)
-		if reason == streamProcessOutputRecoveryTimeout {
+		if reason == processOutputRecoveryTimeout {
 			errMsg = fmt.Sprintf("command timed out after %s; failed to get output: %v", timeout, err)
 		}
 		return ExecuteResult{
@@ -410,13 +432,15 @@ func recoverStreamProcessOutput(
 		}
 	}
 
-	streamer.publish(resp.Output)
+	if publish != nil {
+		publish(resp)
+	}
 	if !resp.Running {
 		return processOutputResult(resp)
 	}
 
 	errMsg := fmt.Sprintf("command timed out after %s", timeout)
-	if reason != streamProcessOutputRecoveryTimeout {
+	if reason != processOutputRecoveryTimeout {
 		errMsg = fmt.Sprintf("get process output: %v (process still running, use process_output to check later)", origErr)
 	}
 	return runningProcessResult(resp, processID, errMsg)
@@ -467,42 +491,7 @@ func waitForProcess(
 		Wait: true,
 	})
 	if err != nil {
-		origErr := err
-		timedOut := ctx.Err() != nil
-
-		// Fetch a snapshot with a fresh context. The blocking
-		// request may have failed due to a context timeout or
-		// a transport error (e.g. the server's WriteTimeout
-		// killed the connection). Either way, the process may
-		// still have output available.
-		bgCtx, bgCancel := context.WithTimeout(
-			parentCtx,
-			snapshotTimeout,
-		)
-		defer bgCancel()
-		resp, err = conn.ProcessOutput(bgCtx, processID, nil)
-		if err != nil {
-			errMsg := fmt.Sprintf("get process output: %v; use process_output with ID %s to retry", origErr, processID)
-			if timedOut {
-				errMsg = fmt.Sprintf("command timed out after %s; failed to get output: %v", timeout, err)
-			}
-			return ExecuteResult{
-				Success:             false,
-				ExitCode:            -1,
-				Error:               errMsg,
-				BackgroundProcessID: processID,
-			}
-		}
-
-		if !resp.Running {
-			return processOutputResult(resp)
-		}
-
-		errMsg := fmt.Sprintf("command timed out after %s", timeout)
-		if !timedOut {
-			errMsg = fmt.Sprintf("get process output: %v (process still running, use process_output to check later)", origErr)
-		}
-		return runningProcessResult(resp, processID, errMsg)
+		return recoverProcessOutputSnapshot(parentCtx, conn, processID, timeout, err, processOutputRecoveryReasonFromContextErr(ctx.Err()), nil)
 	}
 
 	// The server-side wait may return before the

--- a/coderd/x/chatd/chattool/execute.go
+++ b/coderd/x/chatd/chattool/execute.go
@@ -11,6 +11,7 @@ import (
 	"charm.land/fantasy"
 
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
+	"github.com/coder/quartz"
 )
 
 const (
@@ -25,6 +26,10 @@ const (
 	// request is allowed to take when retrieving a process
 	// output snapshot after a blocking wait times out.
 	snapshotTimeout = 30 * time.Second
+
+	// defaultProcessOutputPollInterval balances responsiveness with
+	// the cost of fetching whole retained snapshots from the agent.
+	defaultProcessOutputPollInterval = 250 * time.Millisecond
 )
 
 // nonInteractiveEnvVars are set on every process to prevent
@@ -64,8 +69,39 @@ type ExecuteResult struct {
 
 // ExecuteOptions configures the execute tool.
 type ExecuteOptions struct {
-	GetWorkspaceConn func(context.Context) (workspacesdk.AgentConn, error)
-	DefaultTimeout   time.Duration
+	GetWorkspaceConn          func(context.Context) (workspacesdk.AgentConn, error)
+	DefaultTimeout            time.Duration
+	PublishResultDelta        func(toolCallID string, delta string)
+	PublishResultReset        func(toolCallID string)
+	Clock                     quartz.Clock
+	ProcessOutputPollInterval time.Duration
+}
+
+type executeToolOptions struct {
+	defaultTimeout            time.Duration
+	toolCallID                string
+	publishResultDelta        func(toolCallID string, delta string)
+	publishResultReset        func(toolCallID string)
+	clock                     quartz.Clock
+	processOutputPollInterval time.Duration
+}
+
+func (o executeToolOptions) streamResults() bool {
+	return o.toolCallID != "" && o.publishResultDelta != nil
+}
+
+func (o executeToolOptions) clockOrReal() quartz.Clock {
+	if o.clock != nil {
+		return o.clock
+	}
+	return quartz.NewReal()
+}
+
+func (o executeToolOptions) pollInterval() time.Duration {
+	if o.processOutputPollInterval > 0 {
+		return o.processOutputPollInterval
+	}
+	return defaultProcessOutputPollInterval
 }
 
 // ProcessToolOptions configures a process management tool
@@ -93,7 +129,7 @@ func Execute(options ExecuteOptions) fantasy.AgentTool {
 	return fantasy.NewAgentTool(
 		ExecuteToolName,
 		"Execute a shell command in the workspace. Runs the command and waits for completion up to the timeout (default 10s, override with the timeout parameter e.g. '30s', '5m'). If the command exceeds the timeout, the response includes a background_process_id; use process_output with that ID to re-attach and wait for the result. Use run_in_background=true for persistent processes (dev servers, file watchers) or when you want to continue other work while the command runs. Never use shell '&' for backgrounding.",
-		func(ctx context.Context, args ExecuteArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
+		func(ctx context.Context, args ExecuteArgs, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
 			if options.GetWorkspaceConn == nil {
 				return fantasy.NewTextErrorResponse("workspace connection resolver is not configured"), nil
 			}
@@ -101,7 +137,14 @@ func Execute(options ExecuteOptions) fantasy.AgentTool {
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil
 			}
-			return executeTool(ctx, conn, args, options.DefaultTimeout), nil
+			return executeTool(ctx, conn, args, executeToolOptions{
+				defaultTimeout:            options.DefaultTimeout,
+				toolCallID:                call.ID,
+				publishResultDelta:        options.PublishResultDelta,
+				publishResultReset:        options.PublishResultReset,
+				clock:                     options.Clock,
+				processOutputPollInterval: options.ProcessOutputPollInterval,
+			}), nil
 		},
 	)
 }
@@ -110,7 +153,7 @@ func executeTool(
 	ctx context.Context,
 	conn workspacesdk.AgentConn,
 	args ExecuteArgs,
-	optTimeout time.Duration,
+	options executeToolOptions,
 ) fantasy.ToolResponse {
 	if args.Command == "" {
 		return fantasy.NewTextErrorResponse("command is required")
@@ -143,7 +186,7 @@ func executeTool(
 	if background {
 		return executeBackground(ctx, conn, args.Command, workDir, env)
 	}
-	return executeForeground(ctx, conn, args, optTimeout, workDir, env)
+	return executeForeground(ctx, conn, args, options, workDir, env)
 }
 
 // executeBackground starts a process in the background and
@@ -182,11 +225,11 @@ func executeForeground(
 	ctx context.Context,
 	conn workspacesdk.AgentConn,
 	args ExecuteArgs,
-	optTimeout time.Duration,
+	options executeToolOptions,
 	workDir string,
 	env map[string]string,
 ) fantasy.ToolResponse {
-	timeout := optTimeout
+	timeout := options.defaultTimeout
 	if timeout <= 0 {
 		timeout = defaultTimeout
 	}
@@ -203,7 +246,8 @@ func executeForeground(
 	cmdCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	start := time.Now()
+	clock := options.clockOrReal()
+	start := clock.Now()
 
 	resp, err := conn.StartProcess(cmdCtx, workspacesdk.StartProcessRequest{
 		Command:    args.Command,
@@ -215,8 +259,13 @@ func executeForeground(
 		return errorResult(fmt.Sprintf("start process: %v", err))
 	}
 
-	result := waitForProcess(cmdCtx, ctx, conn, resp.ID, timeout)
-	result.WallDurationMs = time.Since(start).Milliseconds()
+	var result ExecuteResult
+	if options.streamResults() {
+		result = streamProcessOutput(cmdCtx, ctx, conn, resp.ID, timeout, options)
+	} else {
+		result = waitForProcess(cmdCtx, ctx, conn, resp.ID, timeout)
+	}
+	result.WallDurationMs = clock.Since(start).Milliseconds()
 
 	// Add an advisory note for file-dump commands.
 	if note := detectFileDump(args.Command); note != "" {
@@ -238,6 +287,165 @@ func truncateOutput(output string) string {
 		output = strings.ToValidUTF8(output[:maxOutputToModel], "")
 	}
 	return output
+}
+
+type streamProcessOutputRecoveryReason int
+
+const (
+	streamProcessOutputRecoveryError streamProcessOutputRecoveryReason = iota
+	streamProcessOutputRecoveryTimeout
+)
+
+type executeOutputStreamer struct {
+	toolCallID         string
+	publishResultDelta func(toolCallID string, delta string)
+	publishResultReset func(toolCallID string)
+	started            bool
+	output             string
+}
+
+func newExecuteOutputStreamer(options executeToolOptions) executeOutputStreamer {
+	return executeOutputStreamer{
+		toolCallID:         options.toolCallID,
+		publishResultDelta: options.publishResultDelta,
+		publishResultReset: options.publishResultReset,
+	}
+}
+
+func (s *executeOutputStreamer) publish(output string) {
+	if s.publishResultDelta == nil || s.toolCallID == "" {
+		return
+	}
+	output = truncateOutput(output)
+	if output == s.output {
+		return
+	}
+	if !strings.HasPrefix(output, s.output) {
+		if !s.started || s.publishResultReset == nil {
+			return
+		}
+		s.publishResultReset(s.toolCallID)
+		s.started = false
+		s.output = ""
+	}
+	delta := strings.TrimPrefix(output, s.output)
+	if delta == "" {
+		return
+	}
+	encoded := jsonStringFragment(delta)
+	if !s.started {
+		encoded = `{"output":"` + encoded
+		s.started = true
+	}
+	s.publishResultDelta(s.toolCallID, encoded)
+	s.output = output
+}
+
+func jsonStringFragment(value string) string {
+	data, _ := json.Marshal(value)
+	return string(data[1 : len(data)-1])
+}
+
+func streamProcessOutput(
+	ctx context.Context,
+	parentCtx context.Context,
+	conn workspacesdk.AgentConn,
+	processID string,
+	timeout time.Duration,
+	options executeToolOptions,
+) ExecuteResult {
+	streamer := newExecuteOutputStreamer(options)
+	clock := options.clockOrReal()
+	pollInterval := options.pollInterval()
+	for {
+		resp, err := conn.ProcessOutput(ctx, processID, nil)
+		if err != nil {
+			reason := streamProcessOutputRecoveryError
+			if ctx.Err() != nil {
+				reason = streamProcessOutputRecoveryTimeout
+			}
+			return recoverStreamProcessOutput(parentCtx, conn, processID, timeout, err, reason, &streamer)
+		}
+		streamer.publish(resp.Output)
+		if !resp.Running {
+			return processOutputResult(resp)
+		}
+		if ctx.Err() != nil {
+			return runningProcessResult(resp, processID, fmt.Sprintf("command timed out after %s", timeout))
+		}
+
+		timer := clock.NewTimer(pollInterval, "execute", "process-output-poll")
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return recoverStreamProcessOutput(parentCtx, conn, processID, timeout, ctx.Err(), streamProcessOutputRecoveryTimeout, &streamer)
+		case <-timer.C:
+			timer.Stop()
+		}
+	}
+}
+
+func recoverStreamProcessOutput(
+	parentCtx context.Context,
+	conn workspacesdk.AgentConn,
+	processID string,
+	timeout time.Duration,
+	origErr error,
+	reason streamProcessOutputRecoveryReason,
+	streamer *executeOutputStreamer,
+) ExecuteResult {
+	bgCtx, bgCancel := context.WithTimeout(parentCtx, snapshotTimeout)
+	defer bgCancel()
+	resp, err := conn.ProcessOutput(bgCtx, processID, nil)
+	if err != nil {
+		errMsg := fmt.Sprintf("get process output: %v; use process_output with ID %s to retry", origErr, processID)
+		if reason == streamProcessOutputRecoveryTimeout {
+			errMsg = fmt.Sprintf("command timed out after %s; failed to get output: %v", timeout, err)
+		}
+		return ExecuteResult{
+			Success:             false,
+			ExitCode:            -1,
+			Error:               errMsg,
+			BackgroundProcessID: processID,
+		}
+	}
+
+	streamer.publish(resp.Output)
+	if !resp.Running {
+		return processOutputResult(resp)
+	}
+
+	errMsg := fmt.Sprintf("command timed out after %s", timeout)
+	if reason != streamProcessOutputRecoveryTimeout {
+		errMsg = fmt.Sprintf("get process output: %v (process still running, use process_output to check later)", origErr)
+	}
+	return runningProcessResult(resp, processID, errMsg)
+}
+
+func processOutputResult(resp workspacesdk.ProcessOutputResponse) ExecuteResult {
+	exitCode := 0
+	if resp.ExitCode != nil {
+		exitCode = *resp.ExitCode
+	}
+	output := truncateOutput(resp.Output)
+	return ExecuteResult{
+		Success:   exitCode == 0,
+		Output:    output,
+		ExitCode:  exitCode,
+		Truncated: resp.Truncated,
+	}
+}
+
+func runningProcessResult(resp workspacesdk.ProcessOutputResponse, processID string, errMsg string) ExecuteResult {
+	output := truncateOutput(resp.Output)
+	return ExecuteResult{
+		Success:             false,
+		Output:              output,
+		ExitCode:            -1,
+		Error:               errMsg,
+		Truncated:           resp.Truncated,
+		BackgroundProcessID: processID,
+	}
 }
 
 // waitForProcess waits for process completion using the

--- a/coderd/x/chatd/chattool/execute.go
+++ b/coderd/x/chatd/chattool/execute.go
@@ -87,7 +87,7 @@ type executeToolOptions struct {
 }
 
 func (o executeToolOptions) streamResults() bool {
-	return o.toolCallID != "" && o.publishResultDelta != nil
+	return o.toolCallID != "" && o.publishResultDelta != nil && o.publishResultReset != nil
 }
 
 func (o executeToolOptions) clockOrReal() quartz.Clock {
@@ -494,36 +494,15 @@ func waitForProcess(
 			}
 		}
 
-		// Snapshot succeeded. If the process finished, return
-		// its real result (transparent recovery).
 		if !resp.Running {
-			exitCode := 0
-			if resp.ExitCode != nil {
-				exitCode = *resp.ExitCode
-			}
-			output := truncateOutput(resp.Output)
-			return ExecuteResult{
-				Success:   exitCode == 0,
-				Output:    output,
-				ExitCode:  exitCode,
-				Truncated: resp.Truncated,
-			}
+			return processOutputResult(resp)
 		}
 
-		// Process still running, return partial output.
-		output := truncateOutput(resp.Output)
 		errMsg := fmt.Sprintf("command timed out after %s", timeout)
 		if !timedOut {
 			errMsg = fmt.Sprintf("get process output: %v (process still running, use process_output to check later)", origErr)
 		}
-		return ExecuteResult{
-			Success:             false,
-			Output:              output,
-			ExitCode:            -1,
-			Error:               errMsg,
-			Truncated:           resp.Truncated,
-			BackgroundProcessID: processID,
-		}
+		return runningProcessResult(resp, processID, errMsg)
 	}
 
 	// The server-side wait may return before the
@@ -535,28 +514,10 @@ func waitForProcess(
 			// Still within the caller's timeout, retry.
 			return waitForProcess(ctx, parentCtx, conn, processID, timeout)
 		}
-		output := truncateOutput(resp.Output)
-		return ExecuteResult{
-			Success:             false,
-			Output:              output,
-			ExitCode:            -1,
-			Error:               fmt.Sprintf("command timed out after %s", timeout),
-			Truncated:           resp.Truncated,
-			BackgroundProcessID: processID,
-		}
+		return runningProcessResult(resp, processID, fmt.Sprintf("command timed out after %s", timeout))
 	}
 
-	exitCode := 0
-	if resp.ExitCode != nil {
-		exitCode = *resp.ExitCode
-	}
-	output := truncateOutput(resp.Output)
-	return ExecuteResult{
-		Success:   exitCode == 0,
-		Output:    output,
-		ExitCode:  exitCode,
-		Truncated: resp.Truncated,
-	}
+	return processOutputResult(resp)
 }
 
 // errorResult builds a ToolResponse from an ExecuteResult with

--- a/coderd/x/chatd/chattool/execute_test.go
+++ b/coderd/x/chatd/chattool/execute_test.go
@@ -3,7 +3,9 @@ package chattool_test
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
+	"time"
 
 	"charm.land/fantasy"
 	"github.com/stretchr/testify/assert"
@@ -15,6 +17,7 @@ import (
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk/agentconnmock"
 	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/quartz"
 )
 
 func TestExecuteTool(t *testing.T) {
@@ -263,6 +266,145 @@ func TestExecuteTool(t *testing.T) {
 		var resultMap map[string]any
 		require.NoError(t, json.Unmarshal([]byte(resp.Content), &resultMap))
 		assert.NotContains(t, resultMap, "model_intent")
+	})
+
+	t.Run("ForegroundStreamsOutputDeltas", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		clock := quartz.NewMock(t)
+		ctx := testutil.Context(t, testutil.WaitMedium)
+
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			Return(workspacesdk.StartProcessResponse{ID: "proc-1"}, nil)
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Nil()).
+			Return(workspacesdk.ProcessOutputResponse{
+				Running: true,
+				Output:  "hello",
+			}, nil)
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Nil()).
+			Return(workspacesdk.ProcessOutputResponse{
+				Running:  false,
+				ExitCode: ptr(0),
+				Output:   "hello \"coder\"\n",
+			}, nil)
+
+		var deltas []string
+		tool := newStreamingExecuteTool(t, mockConn, clock, func(toolCallID string, delta string) {
+			require.Equal(t, "call-stream", toolCallID)
+			deltas = append(deltas, delta)
+		}, nil)
+		trap := clock.Trap().NewTimer("execute", "process-output-poll")
+
+		type runResult struct {
+			resp fantasy.ToolResponse
+			err  error
+		}
+		done := make(chan runResult, 1)
+		go func() {
+			resp, err := tool.Run(ctx, fantasy.ToolCall{
+				ID:    "call-stream",
+				Name:  "execute",
+				Input: `{"command":"printf hello"}`,
+			})
+			done <- runResult{resp: resp, err: err}
+		}()
+
+		trap.MustWait(ctx).MustRelease(ctx)
+		trap.Close()
+		clock.Advance(time.Second).MustWait(ctx)
+
+		var got runResult
+		select {
+		case got = <-done:
+		case <-ctx.Done():
+			t.Fatal("timed out waiting for execute tool")
+		}
+		require.NoError(t, got.err)
+		assert.False(t, got.resp.IsError)
+
+		var result chattool.ExecuteResult
+		require.NoError(t, json.Unmarshal([]byte(got.resp.Content), &result))
+		assert.True(t, result.Success)
+		assert.Equal(t, 0, result.ExitCode)
+		assert.Equal(t, "hello \"coder\"\n", result.Output)
+
+		var streamed map[string]string
+		require.NoError(t, json.Unmarshal([]byte(strings.Join(deltas, "")+`"}`), &streamed))
+		assert.Equal(t, "hello \"coder\"\n", streamed["output"])
+	})
+
+	t.Run("ForegroundStreamingResetsWhenSnapshotIsNotAppendOnly", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		clock := quartz.NewMock(t)
+		ctx := testutil.Context(t, testutil.WaitMedium)
+
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			Return(workspacesdk.StartProcessResponse{ID: "proc-1"}, nil)
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Nil()).
+			Return(workspacesdk.ProcessOutputResponse{
+				Running: true,
+				Output:  "before",
+			}, nil)
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Nil()).
+			Return(workspacesdk.ProcessOutputResponse{
+				Running:  false,
+				ExitCode: ptr(0),
+				Output:   "after",
+			}, nil)
+
+		var deltas []string
+		var resets int
+		tool := newStreamingExecuteTool(t, mockConn, clock, func(toolCallID string, delta string) {
+			require.Equal(t, "call-stream", toolCallID)
+			deltas = append(deltas, delta)
+		}, func(toolCallID string) {
+			require.Equal(t, "call-stream", toolCallID)
+			resets++
+		})
+		trap := clock.Trap().NewTimer("execute", "process-output-poll")
+
+		type runResult struct {
+			resp fantasy.ToolResponse
+			err  error
+		}
+		done := make(chan runResult, 1)
+		go func() {
+			resp, err := tool.Run(ctx, fantasy.ToolCall{
+				ID:    "call-stream",
+				Name:  "execute",
+				Input: `{"command":"printf hello"}`,
+			})
+			done <- runResult{resp: resp, err: err}
+		}()
+
+		trap.MustWait(ctx).MustRelease(ctx)
+		trap.Close()
+		clock.Advance(time.Second).MustWait(ctx)
+
+		var got runResult
+		select {
+		case got = <-done:
+		case <-ctx.Done():
+			t.Fatal("timed out waiting for execute tool")
+		}
+		require.NoError(t, got.err)
+		assert.False(t, got.resp.IsError)
+
+		var result chattool.ExecuteResult
+		require.NoError(t, json.Unmarshal([]byte(got.resp.Content), &result))
+		assert.True(t, result.Success)
+		assert.Equal(t, "after", result.Output)
+		assert.Equal(t, 1, resets)
+		assert.Equal(t, []string{`{"output":"before`, `{"output":"after`}, deltas)
 	})
 
 	t.Run("ForegroundNonZeroExit", func(t *testing.T) {
@@ -635,6 +777,25 @@ func newExecuteTool(t *testing.T, mockConn *agentconnmock.MockAgentConn) fantasy
 		GetWorkspaceConn: func(_ context.Context) (workspacesdk.AgentConn, error) {
 			return mockConn, nil
 		},
+	})
+}
+
+func newStreamingExecuteTool(
+	t *testing.T,
+	mockConn *agentconnmock.MockAgentConn,
+	clock quartz.Clock,
+	publishDelta func(toolCallID string, delta string),
+	publishReset func(toolCallID string),
+) fantasy.AgentTool {
+	t.Helper()
+	return chattool.Execute(chattool.ExecuteOptions{
+		GetWorkspaceConn: func(_ context.Context) (workspacesdk.AgentConn, error) {
+			return mockConn, nil
+		},
+		PublishResultDelta:        publishDelta,
+		PublishResultReset:        publishReset,
+		Clock:                     clock,
+		ProcessOutputPollInterval: time.Second,
 	})
 }
 

--- a/coderd/x/chatd/chattool/execute_test.go
+++ b/coderd/x/chatd/chattool/execute_test.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/mock/gomock"
 	"golang.org/x/xerrors"
 
+	"github.com/coder/coder/v2/agent/agentproc"
 	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk/agentconnmock"
@@ -301,30 +302,13 @@ func TestExecuteTool(t *testing.T) {
 		})
 		trap := clock.Trap().NewTimer("execute", "process-output-poll")
 
-		type runResult struct {
-			resp fantasy.ToolResponse
-			err  error
-		}
-		done := make(chan runResult, 1)
-		go func() {
-			resp, err := tool.Run(ctx, fantasy.ToolCall{
-				ID:    "call-stream",
-				Name:  "execute",
-				Input: `{"command":"printf hello"}`,
-			})
-			done <- runResult{resp: resp, err: err}
-		}()
+		done := runExecuteToolAsync(ctx, tool, `{"command":"printf hello"}`)
 
 		trap.MustWait(ctx).MustRelease(ctx)
 		trap.Close()
 		clock.Advance(time.Second).MustWait(ctx)
 
-		var got runResult
-		select {
-		case got = <-done:
-		case <-ctx.Done():
-			t.Fatal("timed out waiting for execute tool")
-		}
+		got := waitExecuteToolRunResult(ctx, t, done)
 		require.NoError(t, got.err)
 		assert.False(t, got.resp.IsError)
 
@@ -374,30 +358,13 @@ func TestExecuteTool(t *testing.T) {
 		})
 		trap := clock.Trap().NewTimer("execute", "process-output-poll")
 
-		type runResult struct {
-			resp fantasy.ToolResponse
-			err  error
-		}
-		done := make(chan runResult, 1)
-		go func() {
-			resp, err := tool.Run(ctx, fantasy.ToolCall{
-				ID:    "call-stream",
-				Name:  "execute",
-				Input: `{"command":"printf hello"}`,
-			})
-			done <- runResult{resp: resp, err: err}
-		}()
+		done := runExecuteToolAsync(ctx, tool, `{"command":"printf hello"}`)
 
 		trap.MustWait(ctx).MustRelease(ctx)
 		trap.Close()
 		clock.Advance(time.Second).MustWait(ctx)
 
-		var got runResult
-		select {
-		case got = <-done:
-		case <-ctx.Done():
-			t.Fatal("timed out waiting for execute tool")
-		}
+		got := waitExecuteToolRunResult(ctx, t, done)
 		require.NoError(t, got.err)
 		assert.False(t, got.resp.IsError)
 
@@ -407,6 +374,66 @@ func TestExecuteTool(t *testing.T) {
 		assert.Equal(t, "after", result.Output)
 		assert.Equal(t, 1, resets)
 		assert.Equal(t, []string{`{"output":"before`, `{"output":"after`}, deltas)
+	})
+
+	t.Run("ForegroundStreamingSuppressesRepeatedRunningHeadTailSnapshots", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		clock := quartz.NewMock(t)
+		ctx := testutil.Context(t, testutil.WaitMedium)
+
+		buf := agentproc.NewHeadTailBufferSized(4, 4)
+		_, _ = buf.Write([]byte("12345678"))
+		initialOutput, _ := buf.Output()
+		_, _ = buf.Write([]byte("9"))
+		firstRetainedOutput, firstTruncated := buf.Output()
+		_, _ = buf.Write([]byte("0"))
+		secondRetainedOutput, secondTruncated := buf.Output()
+		_, _ = buf.Write([]byte("1"))
+		finalRetainedOutput, finalTruncated := buf.Output()
+
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			Return(workspacesdk.StartProcessResponse{ID: "proc-1"}, nil)
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Nil()).
+			Return(workspacesdk.ProcessOutputResponse{Running: true, Output: initialOutput}, nil)
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Nil()).
+			Return(workspacesdk.ProcessOutputResponse{Running: true, Output: firstRetainedOutput, Truncated: firstTruncated}, nil)
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Nil()).
+			Return(workspacesdk.ProcessOutputResponse{Running: true, Output: secondRetainedOutput, Truncated: secondTruncated}, nil)
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Nil()).
+			Return(workspacesdk.ProcessOutputResponse{Running: false, ExitCode: ptr(0), Output: finalRetainedOutput, Truncated: finalTruncated}, nil)
+
+		recorder, publishDelta, publishReset := newStreamPublishRecorder(t)
+		tool := newStreamingExecuteTool(t, mockConn, clock, publishDelta, publishReset)
+		trap := clock.Trap().NewTimer("execute", "process-output-poll")
+		done := runExecuteToolAsync(ctx, tool, `{"command":"printf hello"}`)
+
+		for range 3 {
+			trap.MustWait(ctx).MustRelease(ctx)
+			clock.Advance(time.Second).MustWait(ctx)
+		}
+		trap.Close()
+
+		got := waitExecuteToolRunResult(ctx, t, done)
+		require.NoError(t, got.err)
+		assert.False(t, got.resp.IsError)
+
+		result := decodeExecuteResult(t, got.resp)
+		assert.True(t, result.Success)
+		assert.Equal(t, finalRetainedOutput, result.Output)
+		assert.Equal(t, 2, recorder.resets)
+		require.Len(t, recorder.deltas, 3)
+		for i, expected := range []string{initialOutput, firstRetainedOutput, finalRetainedOutput} {
+			var streamed map[string]string
+			require.NoError(t, json.Unmarshal([]byte(recorder.deltas[i]+`"}`), &streamed))
+			assert.Equal(t, expected, streamed["output"])
+		}
 	})
 
 	t.Run("ForegroundStreamingRecoveryProcessOutputErrorSnapshotFails", func(t *testing.T) {

--- a/coderd/x/chatd/chattool/execute_test.go
+++ b/coderd/x/chatd/chattool/execute_test.go
@@ -296,7 +296,9 @@ func TestExecuteTool(t *testing.T) {
 		tool := newStreamingExecuteTool(t, mockConn, clock, func(toolCallID string, delta string) {
 			require.Equal(t, "call-stream", toolCallID)
 			deltas = append(deltas, delta)
-		}, nil)
+		}, func(toolCallID string) {
+			require.Equal(t, "call-stream", toolCallID)
+		})
 		trap := clock.Trap().NewTimer("execute", "process-output-poll")
 
 		type runResult struct {
@@ -405,6 +407,303 @@ func TestExecuteTool(t *testing.T) {
 		assert.Equal(t, "after", result.Output)
 		assert.Equal(t, 1, resets)
 		assert.Equal(t, []string{`{"output":"before`, `{"output":"after`}, deltas)
+	})
+
+	t.Run("ForegroundStreamingRecoveryProcessOutputErrorSnapshotFails", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			Return(workspacesdk.StartProcessResponse{ID: "proc-1"}, nil)
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Nil()).
+			Return(workspacesdk.ProcessOutputResponse{}, xerrors.New("EOF"))
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Nil()).
+			Return(workspacesdk.ProcessOutputResponse{}, xerrors.New("agent disconnected"))
+
+		recorder, publishDelta, publishReset := newStreamPublishRecorder(t)
+		tool := newStreamingExecuteTool(t, mockConn, nil, publishDelta, publishReset)
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		resp, err := tool.Run(ctx, fantasy.ToolCall{
+			ID:    "call-stream",
+			Name:  "execute",
+			Input: `{"command":"printf hello"}`,
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.IsError)
+
+		result := decodeExecuteResult(t, resp)
+		assert.False(t, result.Success)
+		assert.Contains(t, result.Error, "get process output: EOF")
+		assert.Contains(t, result.Error, "use process_output with ID proc-1 to retry")
+		assert.Equal(t, "proc-1", result.BackgroundProcessID)
+		assert.Empty(t, recorder.deltas)
+		assert.Zero(t, recorder.resets)
+	})
+
+	t.Run("ForegroundStreamingRecoveryProcessOutputErrorProcessDone", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		clock := quartz.NewMock(t)
+		ctx := testutil.Context(t, testutil.WaitMedium)
+
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			Return(workspacesdk.StartProcessResponse{ID: "proc-1"}, nil)
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Nil()).
+			Return(workspacesdk.ProcessOutputResponse{
+				Running: true,
+				Output:  "hello",
+			}, nil)
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Nil()).
+			Return(workspacesdk.ProcessOutputResponse{}, xerrors.New("EOF"))
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Nil()).
+			Return(workspacesdk.ProcessOutputResponse{
+				Running:  false,
+				ExitCode: ptr(0),
+				Output:   "hello world",
+			}, nil)
+
+		recorder, publishDelta, publishReset := newStreamPublishRecorder(t)
+		tool := newStreamingExecuteTool(t, mockConn, clock, publishDelta, publishReset)
+		trap := clock.Trap().NewTimer("execute", "process-output-poll")
+		done := runExecuteToolAsync(ctx, tool, `{"command":"printf hello"}`)
+
+		trap.MustWait(ctx).MustRelease(ctx)
+		trap.Close()
+		clock.Advance(time.Second).MustWait(ctx)
+
+		got := waitExecuteToolRunResult(ctx, t, done)
+		require.NoError(t, got.err)
+		assert.False(t, got.resp.IsError)
+
+		result := decodeExecuteResult(t, got.resp)
+		assert.True(t, result.Success)
+		assert.Equal(t, "hello world", result.Output)
+		assert.Equal(t, []string{`{"output":"hello`, ` world`}, recorder.deltas)
+		assert.Zero(t, recorder.resets)
+	})
+
+	t.Run("ForegroundStreamingRecoveryProcessOutputErrorProcessStillRunning", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		clock := quartz.NewMock(t)
+		ctx := testutil.Context(t, testutil.WaitMedium)
+
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			Return(workspacesdk.StartProcessResponse{ID: "proc-1"}, nil)
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Nil()).
+			Return(workspacesdk.ProcessOutputResponse{
+				Running: true,
+				Output:  "before",
+			}, nil)
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Nil()).
+			Return(workspacesdk.ProcessOutputResponse{}, xerrors.New("EOF"))
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Nil()).
+			Return(workspacesdk.ProcessOutputResponse{
+				Running: true,
+				Output:  "after",
+			}, nil)
+
+		recorder, publishDelta, publishReset := newStreamPublishRecorder(t)
+		tool := newStreamingExecuteTool(t, mockConn, clock, publishDelta, publishReset)
+		trap := clock.Trap().NewTimer("execute", "process-output-poll")
+		done := runExecuteToolAsync(ctx, tool, `{"command":"printf hello"}`)
+
+		trap.MustWait(ctx).MustRelease(ctx)
+		trap.Close()
+		clock.Advance(time.Second).MustWait(ctx)
+
+		got := waitExecuteToolRunResult(ctx, t, done)
+		require.NoError(t, got.err)
+		assert.False(t, got.resp.IsError)
+
+		result := decodeExecuteResult(t, got.resp)
+		assert.False(t, result.Success)
+		assert.Equal(t, "after", result.Output)
+		assert.Contains(t, result.Error, "get process output: EOF")
+		assert.Contains(t, result.Error, "process still running")
+		assert.Equal(t, "proc-1", result.BackgroundProcessID)
+		assert.Equal(t, []string{`{"output":"before`, `{"output":"after`}, recorder.deltas)
+		assert.Equal(t, 1, recorder.resets)
+	})
+
+	t.Run("ForegroundStreamingRecoveryTimeoutSnapshotFails", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		clock := quartz.NewMock(t)
+		ctx := testutil.Context(t, testutil.WaitMedium)
+
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			Return(workspacesdk.StartProcessResponse{ID: "proc-1"}, nil)
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Nil()).
+			Return(workspacesdk.ProcessOutputResponse{
+				Running: true,
+				Output:  "hello",
+			}, nil)
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Nil()).
+			Return(workspacesdk.ProcessOutputResponse{}, xerrors.New("agent disconnected"))
+
+		recorder, publishDelta, publishReset := newStreamPublishRecorder(t)
+		tool := newStreamingExecuteTool(t, mockConn, clock, publishDelta, publishReset)
+		trap := clock.Trap().NewTimer("execute", "process-output-poll")
+		done := runExecuteToolAsync(ctx, tool, `{"command":"printf hello","timeout":"50ms"}`)
+
+		trap.MustWait(ctx).MustRelease(ctx)
+		trap.Close()
+
+		got := waitExecuteToolRunResult(ctx, t, done)
+		require.NoError(t, got.err)
+		assert.False(t, got.resp.IsError)
+
+		result := decodeExecuteResult(t, got.resp)
+		assert.False(t, result.Success)
+		assert.Contains(t, result.Error, "command timed out after 50ms")
+		assert.Contains(t, result.Error, "failed to get output: agent disconnected")
+		assert.Equal(t, "proc-1", result.BackgroundProcessID)
+		assert.Equal(t, []string{`{"output":"hello`}, recorder.deltas)
+		assert.Zero(t, recorder.resets)
+	})
+
+	t.Run("ForegroundStreamingRecoveryTimeoutProcessDone", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		clock := quartz.NewMock(t)
+		ctx := testutil.Context(t, testutil.WaitMedium)
+
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			Return(workspacesdk.StartProcessResponse{ID: "proc-1"}, nil)
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Nil()).
+			Return(workspacesdk.ProcessOutputResponse{
+				Running: true,
+				Output:  "hello",
+			}, nil)
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Nil()).
+			Return(workspacesdk.ProcessOutputResponse{
+				Running:  false,
+				ExitCode: ptr(0),
+				Output:   "hello world",
+			}, nil)
+
+		recorder, publishDelta, publishReset := newStreamPublishRecorder(t)
+		tool := newStreamingExecuteTool(t, mockConn, clock, publishDelta, publishReset)
+		trap := clock.Trap().NewTimer("execute", "process-output-poll")
+		done := runExecuteToolAsync(ctx, tool, `{"command":"printf hello","timeout":"50ms"}`)
+
+		trap.MustWait(ctx).MustRelease(ctx)
+		trap.Close()
+
+		got := waitExecuteToolRunResult(ctx, t, done)
+		require.NoError(t, got.err)
+		assert.False(t, got.resp.IsError)
+
+		result := decodeExecuteResult(t, got.resp)
+		assert.True(t, result.Success)
+		assert.Equal(t, "hello world", result.Output)
+		assert.Equal(t, []string{`{"output":"hello`, ` world`}, recorder.deltas)
+		assert.Zero(t, recorder.resets)
+	})
+
+	t.Run("ForegroundStreamingRecoveryTimeoutProcessStillRunning", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		clock := quartz.NewMock(t)
+		ctx := testutil.Context(t, testutil.WaitMedium)
+
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			Return(workspacesdk.StartProcessResponse{ID: "proc-1"}, nil)
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Nil()).
+			Return(workspacesdk.ProcessOutputResponse{
+				Running: true,
+				Output:  "before",
+			}, nil)
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Nil()).
+			Return(workspacesdk.ProcessOutputResponse{
+				Running: true,
+				Output:  "after",
+			}, nil)
+
+		recorder, publishDelta, publishReset := newStreamPublishRecorder(t)
+		tool := newStreamingExecuteTool(t, mockConn, clock, publishDelta, publishReset)
+		trap := clock.Trap().NewTimer("execute", "process-output-poll")
+		done := runExecuteToolAsync(ctx, tool, `{"command":"printf hello","timeout":"50ms"}`)
+
+		trap.MustWait(ctx).MustRelease(ctx)
+		trap.Close()
+
+		got := waitExecuteToolRunResult(ctx, t, done)
+		require.NoError(t, got.err)
+		assert.False(t, got.resp.IsError)
+
+		result := decodeExecuteResult(t, got.resp)
+		assert.False(t, result.Success)
+		assert.Equal(t, "after", result.Output)
+		assert.Contains(t, result.Error, "command timed out after 50ms")
+		assert.Equal(t, "proc-1", result.BackgroundProcessID)
+		assert.Equal(t, []string{`{"output":"before`, `{"output":"after`}, recorder.deltas)
+		assert.Equal(t, 1, recorder.resets)
+	})
+
+	t.Run("ForegroundStreamingRequiresResetCallback", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			Return(workspacesdk.StartProcessResponse{ID: "proc-1"}, nil)
+		exitCode := 0
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, opts *workspacesdk.ProcessOutputOptions) (workspacesdk.ProcessOutputResponse, error) {
+				require.NotNil(t, opts)
+				assert.True(t, opts.Wait)
+				return workspacesdk.ProcessOutputResponse{
+					Running:  false,
+					ExitCode: &exitCode,
+					Output:   "hello",
+				}, nil
+			})
+
+		recorder, publishDelta, _ := newStreamPublishRecorder(t)
+		tool := newStreamingExecuteTool(t, mockConn, nil, publishDelta, nil)
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		resp, err := tool.Run(ctx, fantasy.ToolCall{
+			ID:    "call-stream",
+			Name:  "execute",
+			Input: `{"command":"printf hello"}`,
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.IsError)
+
+		result := decodeExecuteResult(t, resp)
+		assert.True(t, result.Success)
+		assert.Equal(t, "hello", result.Output)
+		assert.Empty(t, recorder.deltas)
 	})
 
 	t.Run("ForegroundNonZeroExit", func(t *testing.T) {
@@ -797,6 +1096,61 @@ func newStreamingExecuteTool(
 		Clock:                     clock,
 		ProcessOutputPollInterval: time.Second,
 	})
+}
+
+type streamPublishRecorder struct {
+	deltas []string
+	resets int
+}
+
+func newStreamPublishRecorder(t *testing.T) (*streamPublishRecorder, func(string, string), func(string)) {
+	t.Helper()
+	recorder := &streamPublishRecorder{}
+	publishDelta := func(toolCallID string, delta string) {
+		require.Equal(t, "call-stream", toolCallID)
+		recorder.deltas = append(recorder.deltas, delta)
+	}
+	publishReset := func(toolCallID string) {
+		require.Equal(t, "call-stream", toolCallID)
+		recorder.resets++
+	}
+	return recorder, publishDelta, publishReset
+}
+
+type executeToolRunResult struct {
+	resp fantasy.ToolResponse
+	err  error
+}
+
+func runExecuteToolAsync(ctx context.Context, tool fantasy.AgentTool, input string) <-chan executeToolRunResult {
+	done := make(chan executeToolRunResult, 1)
+	go func() {
+		resp, err := tool.Run(ctx, fantasy.ToolCall{
+			ID:    "call-stream",
+			Name:  "execute",
+			Input: input,
+		})
+		done <- executeToolRunResult{resp: resp, err: err}
+	}()
+	return done
+}
+
+func waitExecuteToolRunResult(ctx context.Context, t *testing.T, done <-chan executeToolRunResult) executeToolRunResult {
+	t.Helper()
+	select {
+	case got := <-done:
+		return got
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for execute tool")
+		return executeToolRunResult{}
+	}
+}
+
+func decodeExecuteResult(t *testing.T, resp fantasy.ToolResponse) chattool.ExecuteResult {
+	t.Helper()
+	var result chattool.ExecuteResult
+	require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+	return result
 }
 
 func ptr[T any](v T) *T {

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.stories.tsx
@@ -1,9 +1,32 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { userEvent, within } from "storybook/test";
+import { type ComponentProps, useEffect, useState } from "react";
+import { expect, userEvent, waitFor, within } from "storybook/test";
 import { ExecuteTool } from "./ExecuteTool";
 
 const longCommand =
 	"find /home/coder/project/src -type f -name '*.ts' -not -path '*/node_modules/*' -not -path '*/.git/*' | xargs grep -l 'deprecated' | sort | head -50";
+
+const initialStreamingOutput = Array.from(
+	{ length: 40 },
+	(_, index) => `stream line ${index + 1}`,
+).join("\n");
+const completeStreamingOutput = Array.from(
+	{ length: 80 },
+	(_, index) => `stream line ${index + 1}`,
+).join("\n");
+
+const StreamingOutputHarness = (props: ComponentProps<typeof ExecuteTool>) => {
+	const [output, setOutput] = useState(initialStreamingOutput);
+
+	useEffect(() => {
+		const timerId = setTimeout(() => {
+			setOutput(completeStreamingOutput);
+		}, 50);
+		return () => clearTimeout(timerId);
+	}, []);
+
+	return <ExecuteTool {...props} output={output} />;
+};
 
 const meta: Meta<typeof ExecuteTool> = {
 	title: "components/ai-elements/tool/ExecuteTool",
@@ -110,6 +133,30 @@ export const Running: Story = {
 		status: "running",
 		output:
 			"=== RUN   TestWorkspaceAgent\n--- PASS: TestWorkspaceAgent (0.42s)",
+	},
+};
+
+export const RunningOutputFollowsLatestText: Story = {
+	args: {
+		command: "for i in $(seq 1 80); do echo stream line $i; done",
+		status: "running",
+		output: initialStreamingOutput,
+	},
+	render: (args) => <StreamingOutputHarness {...args} />,
+	play: async ({ canvasElement }) => {
+		const viewport = canvasElement.querySelector(
+			"[data-radix-scroll-area-viewport]",
+		);
+		if (!(viewport instanceof HTMLElement)) {
+			throw new Error("Expected shell output scroll viewport.");
+		}
+		viewport.scrollTop = 0;
+		await waitFor(() => {
+			expect(canvasElement).toHaveTextContent("stream line 80");
+		});
+		await waitFor(() => {
+			expect(viewport.scrollTop).toBeGreaterThan(0);
+		});
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.stories.tsx
@@ -144,19 +144,35 @@ export const RunningOutputFollowsLatestText: Story = {
 	},
 	render: (args) => <StreamingOutputHarness {...args} />,
 	play: async ({ canvasElement }) => {
-		const viewport = canvasElement.querySelector(
-			"[data-radix-scroll-area-viewport]",
-		);
-		if (!(viewport instanceof HTMLElement)) {
-			throw new Error("Expected shell output scroll viewport.");
-		}
-		viewport.scrollTop = 0;
+		const viewport = getShellOutputViewport(canvasElement);
+		viewport.scrollTop = viewport.scrollHeight;
+		viewport.dispatchEvent(new Event("scroll"));
+
 		await waitFor(() => {
 			expect(canvasElement).toHaveTextContent("stream line 80");
 		});
 		await waitFor(() => {
 			expect(viewport.scrollTop).toBeGreaterThan(0);
 		});
+	},
+};
+
+export const RunningOutputPreservesManualScrollback: Story = {
+	args: {
+		command: "for i in $(seq 1 80); do echo stream line $i; done",
+		status: "running",
+		output: initialStreamingOutput,
+	},
+	render: (args) => <StreamingOutputHarness {...args} />,
+	play: async ({ canvasElement }) => {
+		const viewport = getShellOutputViewport(canvasElement);
+		viewport.scrollTop = 0;
+		viewport.dispatchEvent(new Event("scroll"));
+
+		await waitFor(() => {
+			expect(canvasElement).toHaveTextContent("stream line 80");
+		});
+		expect(viewport.scrollTop).toBeLessThanOrEqual(24);
 	},
 };
 
@@ -200,4 +216,14 @@ export const ParsedCommandsWithIntent: Story = {
 			["go", "test"],
 		],
 	},
+};
+
+const getShellOutputViewport = (canvasElement: HTMLElement) => {
+	const viewport = canvasElement.querySelector(
+		"[data-radix-scroll-area-viewport]",
+	);
+	if (!(viewport instanceof HTMLElement)) {
+		throw new Error("Expected shell output scroll viewport.");
+	}
+	return viewport;
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
@@ -9,7 +9,7 @@ import {
 	TriangleAlertIcon,
 } from "lucide-react";
 import type React from "react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type * as TypesGen from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
 import { CopyButton } from "#/components/CopyButton/CopyButton";
@@ -224,8 +224,26 @@ const ShellTranscriptBody: React.FC<{
 	output: string;
 	isError: boolean;
 }> = ({ command, output, isError }) => {
+	const rootRef = useRef<HTMLDivElement | null>(null);
+
+	useEffect(() => {
+		if (output.length === 0) {
+			return;
+		}
+
+		const viewport = rootRef.current?.querySelector(
+			"[data-radix-scroll-area-viewport]",
+		);
+		if (!(viewport instanceof HTMLElement)) {
+			return;
+		}
+
+		viewport.scrollTop = viewport.scrollHeight;
+	}, [output]);
+
 	return (
 		<ScrollArea
+			ref={rootRef}
 			className="col-start-1 col-span-2 mt-2 rounded-xl bg-surface-secondary/60 text-2xs"
 			viewportClassName="max-h-64"
 			scrollBarClassName="w-1.5"

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
@@ -9,7 +9,7 @@ import {
 	TriangleAlertIcon,
 } from "lucide-react";
 import type React from "react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type * as TypesGen from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
 import { CopyButton } from "#/components/CopyButton/CopyButton";
@@ -225,9 +225,28 @@ const ShellTranscriptBody: React.FC<{
 	isError: boolean;
 }> = ({ command, output, isError }) => {
 	const rootRef = useRef<HTMLDivElement | null>(null);
+	const wasPinnedToBottomRef = useRef(true);
+	const hadOutputRef = useRef(false);
 
 	useEffect(() => {
+		const viewport = rootRef.current?.querySelector(
+			"[data-radix-scroll-area-viewport]",
+		);
+		if (!(viewport instanceof HTMLElement)) {
+			return;
+		}
+
+		const updatePinnedState = () => {
+			wasPinnedToBottomRef.current = isNearScrollBottom(viewport);
+		};
+		updatePinnedState();
+		viewport.addEventListener("scroll", updatePinnedState);
+		return () => viewport.removeEventListener("scroll", updatePinnedState);
+	}, []);
+
+	useLayoutEffect(() => {
 		if (output.length === 0) {
+			hadOutputRef.current = false;
 			return;
 		}
 
@@ -238,7 +257,11 @@ const ShellTranscriptBody: React.FC<{
 			return;
 		}
 
-		viewport.scrollTop = viewport.scrollHeight;
+		if (!hadOutputRef.current || wasPinnedToBottomRef.current) {
+			viewport.scrollTop = viewport.scrollHeight;
+		}
+		hadOutputRef.current = true;
+		wasPinnedToBottomRef.current = isNearScrollBottom(viewport);
 	}, [output]);
 
 	return (
@@ -269,6 +292,9 @@ const ShellTranscriptBody: React.FC<{
 		</ScrollArea>
 	);
 };
+
+const isNearScrollBottom = (element: HTMLElement) =>
+	element.scrollHeight - element.scrollTop - element.clientHeight <= 24;
 
 export const ExecuteAuthRequiredTool: React.FC<{
 	command: string;


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

Streams shell command output from chatd while foreground commands run, so the chat UI can display live command progress instead of waiting for process completion. The backend publishes append-only tool result deltas with reset support when output snapshots are not append-only, while preserving the final persisted tool result for the model and database.

Updates the AgentsPage execute tool transcript to follow newly streamed output in its nested scroll area and adds Storybook regression coverage for that behavior.
