### PR TITLE
fix(dogfood): harden curl downloads with --fail and retry

### DIFF
--- a/dogfood/coder/ubuntu-22.04/Dockerfile
+++ b/dogfood/coder/ubuntu-22.04/Dockerfile
@@ -111,7 +111,9 @@ RUN sed -i 's|http://archive.ubuntu.com/ubuntu/|http://mirrors.edge.kernel.org/u
 # by dogfood/coder/files/etc/apt/apt.conf.d/99-chrome-flags.
 COPY dogfood/coder/ubuntu-22.04/configure-chrome-flags.sh /usr/local/bin/configure-chrome-flags.sh
 RUN chmod a+x /usr/local/bin/configure-chrome-flags.sh && \
-	wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
+	curl --silent --show-error --fail --location --retry 5 --retry-all-errors --retry-delay 2 \
+		--output google-chrome-stable_current_amd64.deb \
+		https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
 	apt-get install --yes ./google-chrome-stable_current_amd64.deb && \
 	rm google-chrome-stable_current_amd64.deb
 
@@ -119,21 +121,35 @@ RUN chmod a+x /usr/local/bin/configure-chrome-flags.sh && \
 # toolchain.
 ENV RUSTUP_HOME=/usr/local/rustup \
 	CARGO_HOME=/usr/local/cargo
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+RUN set -o pipefail && \
+	curl --proto '=https' --tlsv1.2 --silent --show-error --fail --location \
+		--retry 5 --retry-all-errors --retry-delay 2 https://sh.rustup.rs | \
 	sh -s -- -y --default-toolchain stable --profile default -c rust-src
 ENV PATH=$CARGO_HOME/bin:$PATH
 
 # Install the docker buildx component.
-RUN DOCKER_BUILDX_VERSION=$(curl -s "https://api.github.com/repos/docker/buildx/releases/latest" | grep '"tag_name":' |  sed -E 's/.*"(v[^"]+)".*/\1/') && \
+# pipefail surfaces a curl failure in the version probe instead of letting
+# the empty $DOCKER_BUILDX_VERSION poison the download URL.
+RUN set -o pipefail && \
+	DOCKER_BUILDX_VERSION=$(curl --silent --show-error --fail --retry 5 --retry-all-errors --retry-delay 2 \
+		"https://api.github.com/repos/docker/buildx/releases/latest" | grep '"tag_name":' | sed -E 's/.*"(v[^"]+)".*/\1/') && \
+	test -n "${DOCKER_BUILDX_VERSION}" && \
 	mkdir -p /usr/local/lib/docker/cli-plugins && \
-	curl -Lo /usr/local/lib/docker/cli-plugins/docker-buildx "https://github.com/docker/buildx/releases/download/${DOCKER_BUILDX_VERSION}/buildx-${DOCKER_BUILDX_VERSION}.linux-amd64" && \
+	curl --silent --show-error --fail --location --retry 5 --retry-all-errors --retry-delay 2 \
+		--output /usr/local/lib/docker/cli-plugins/docker-buildx \
+		"https://github.com/docker/buildx/releases/download/${DOCKER_BUILDX_VERSION}/buildx-${DOCKER_BUILDX_VERSION}.linux-amd64" && \
 	chmod a+x /usr/local/lib/docker/cli-plugins/docker-buildx
 
 # GitHub CLI to /usr/bin/gh. The wrapper at files/usr/local/bin/gh
 # execs this for coder external-auth fallback. Apt repo is unreliable:
 # https://github.com/cli/cli/issues/6175#issuecomment-1235984381
-RUN GH_CLI_VERSION=$(curl -s "https://api.github.com/repos/cli/cli/releases/latest" | grep '"tag_name":' |  sed -E 's/.*"v([^"]+)".*/\1/') && \
-	curl -L https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.deb -o gh.deb && \
+RUN set -o pipefail && \
+	GH_CLI_VERSION=$(curl --silent --show-error --fail --retry 5 --retry-all-errors --retry-delay 2 \
+		"https://api.github.com/repos/cli/cli/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
+	test -n "${GH_CLI_VERSION}" && \
+	curl --silent --show-error --fail --location --retry 5 --retry-all-errors --retry-delay 2 \
+		--output gh.deb \
+		"https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.deb" && \
 	dpkg -i gh.deb && \
 	rm gh.deb
 
@@ -173,7 +189,7 @@ ARG MISE_VERSION=v2026.4.19 \
 	MISE_SHA256=6b58ff5f1e1ce98ed2b7e5372c344ea48182c460e5b6df12d9e0def35aad4438 \
 	MISE_INSTALL_DIR=/opt/mise/bin
 RUN install --directory --owner=coder --group=coder --mode=0755 "${MISE_INSTALL_DIR}" && \
-	curl --silent --show-error --location --fail \
+	curl --silent --show-error --fail --location --retry 5 --retry-all-errors --retry-delay 2 \
 		"https://github.com/jdx/mise/releases/download/${MISE_VERSION}/mise-${MISE_VERSION}-linux-x64" \
 		--output "${MISE_INSTALL_DIR}/mise" && \
 	echo "${MISE_SHA256}  ${MISE_INSTALL_DIR}/mise" | sha256sum -c && \
@@ -225,7 +241,7 @@ RUN --mount=type=secret,id=github_token,required=false \
 
 # Install Homebrew as the coder user so the supported Linux prefix remains
 # writable after the image build.
-RUN sudo --login --user=coder env NONINTERACTIVE=1 CI=1 /bin/bash -lc 'set -euo pipefail && curl --silent --show-error --location --fail https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | /bin/bash' && \
+RUN sudo --login --user=coder env NONINTERACTIVE=1 CI=1 /bin/bash -lc 'set -euo pipefail && curl --silent --show-error --fail --location --retry 5 --retry-all-errors --retry-delay 2 https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | /bin/bash' && \
 	test -x /home/linuxbrew/.linuxbrew/bin/brew && \
 	sudo --login --user=coder /bin/bash -lc '/home/linuxbrew/.linuxbrew/bin/brew --version'
 

--- a/dogfood/coder/ubuntu-26.04/Dockerfile
+++ b/dogfood/coder/ubuntu-26.04/Dockerfile
@@ -118,7 +118,9 @@ RUN sed -i 's|http://archive.ubuntu.com/ubuntu/|http://mirrors.edge.kernel.org/u
 # configure-chrome-flags.sh is automatically run after dpkg operations
 # by dogfood/coder/files/etc/apt/apt.conf.d/99-chrome-flags.
 RUN chmod a+x /opt/configure-chrome-flags.sh && \
-	wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
+	curl --silent --show-error --fail --location --retry 5 --retry-all-errors --retry-delay 2 \
+		--output google-chrome-stable_current_amd64.deb \
+		https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
 	apt-get install --yes ./google-chrome-stable_current_amd64.deb && \
 	rm google-chrome-stable_current_amd64.deb
 
@@ -126,21 +128,35 @@ RUN chmod a+x /opt/configure-chrome-flags.sh && \
 # toolchain.
 ENV RUSTUP_HOME=/usr/local/rustup \
 	CARGO_HOME=/usr/local/cargo
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+RUN set -o pipefail && \
+	curl --proto '=https' --tlsv1.2 --silent --show-error --fail --location \
+		--retry 5 --retry-all-errors --retry-delay 2 https://sh.rustup.rs | \
 	sh -s -- -y --default-toolchain stable --profile default -c rust-src
 ENV PATH=$CARGO_HOME/bin:$PATH
 
 # Install the docker buildx component.
-RUN DOCKER_BUILDX_VERSION=$(curl -s "https://api.github.com/repos/docker/buildx/releases/latest" | grep '"tag_name":' |  sed -E 's/.*"(v[^"]+)".*/\1/') && \
+# pipefail surfaces a curl failure in the version probe instead of letting
+# the empty $DOCKER_BUILDX_VERSION poison the download URL.
+RUN set -o pipefail && \
+	DOCKER_BUILDX_VERSION=$(curl --silent --show-error --fail --retry 5 --retry-all-errors --retry-delay 2 \
+		"https://api.github.com/repos/docker/buildx/releases/latest" | grep '"tag_name":' | sed -E 's/.*"(v[^"]+)".*/\1/') && \
+	test -n "${DOCKER_BUILDX_VERSION}" && \
 	mkdir -p /usr/local/lib/docker/cli-plugins && \
-	curl -Lo /usr/local/lib/docker/cli-plugins/docker-buildx "https://github.com/docker/buildx/releases/download/${DOCKER_BUILDX_VERSION}/buildx-${DOCKER_BUILDX_VERSION}.linux-amd64" && \
+	curl --silent --show-error --fail --location --retry 5 --retry-all-errors --retry-delay 2 \
+		--output /usr/local/lib/docker/cli-plugins/docker-buildx \
+		"https://github.com/docker/buildx/releases/download/${DOCKER_BUILDX_VERSION}/buildx-${DOCKER_BUILDX_VERSION}.linux-amd64" && \
 	chmod a+x /usr/local/lib/docker/cli-plugins/docker-buildx
 
 # GitHub CLI to /usr/bin/gh. The wrapper at files/usr/local/bin/gh
 # execs this for coder external-auth fallback. Apt repo is unreliable:
 # https://github.com/cli/cli/issues/6175#issuecomment-1235984381
-RUN GH_CLI_VERSION=$(curl -s "https://api.github.com/repos/cli/cli/releases/latest" | grep '"tag_name":' |  sed -E 's/.*"v([^"]+)".*/\1/') && \
-	curl -L https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.deb -o gh.deb && \
+RUN set -o pipefail && \
+	GH_CLI_VERSION=$(curl --silent --show-error --fail --retry 5 --retry-all-errors --retry-delay 2 \
+		"https://api.github.com/repos/cli/cli/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
+	test -n "${GH_CLI_VERSION}" && \
+	curl --silent --show-error --fail --location --retry 5 --retry-all-errors --retry-delay 2 \
+		--output gh.deb \
+		"https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.deb" && \
 	dpkg -i gh.deb && \
 	rm gh.deb
 
@@ -183,7 +199,7 @@ ARG MISE_VERSION=v2026.4.19 \
 	MISE_SHA256=6b58ff5f1e1ce98ed2b7e5372c344ea48182c460e5b6df12d9e0def35aad4438 \
 	MISE_INSTALL_DIR=/opt/mise/bin
 RUN install --directory --owner=coder --group=coder --mode=0755 "${MISE_INSTALL_DIR}" && \
-	curl --silent --show-error --location --fail \
+	curl --silent --show-error --fail --location --retry 5 --retry-all-errors --retry-delay 2 \
 		"https://github.com/jdx/mise/releases/download/${MISE_VERSION}/mise-${MISE_VERSION}-linux-x64" \
 		--output "${MISE_INSTALL_DIR}/mise" && \
 	echo "${MISE_SHA256}  ${MISE_INSTALL_DIR}/mise" | sha256sum -c && \
@@ -235,7 +251,7 @@ RUN --mount=type=secret,id=github_token,required=false \
 
 # Install Homebrew as the coder user so the supported Linux prefix remains
 # writable after the image build.
-RUN sudo --login --user=coder env NONINTERACTIVE=1 CI=1 /bin/bash -lc 'set -euo pipefail && curl --silent --show-error --location --fail https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | /bin/bash' && \
+RUN sudo --login --user=coder env NONINTERACTIVE=1 CI=1 /bin/bash -lc 'set -euo pipefail && curl --silent --show-error --fail --location --retry 5 --retry-all-errors --retry-delay 2 https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | /bin/bash' && \
 	test -x /home/linuxbrew/.linuxbrew/bin/brew && \
 	sudo --login --user=coder /bin/bash -lc '/home/linuxbrew/.linuxbrew/bin/brew --version'
 

--- a/dogfood/vscode-coder/Dockerfile
+++ b/dogfood/vscode-coder/Dockerfile
@@ -2,6 +2,10 @@ FROM node:24-slim@sha256:879b21aec4a1ad820c27ccd565e7c7ed955f24b92e6694556154f25
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+# bash for `set -o pipefail` in the gh CLI install below.
+# node:24-slim ships /bin/sh as dash, which has no pipefail.
+SHELL ["/bin/bash", "-c"]
+
 # Electron/Chromium system libs are installed at startup via
 # `playwright install-deps chromium` so they track the project's
 # Electron version automatically.

--- a/dogfood/vscode-coder/Dockerfile
+++ b/dogfood/vscode-coder/Dockerfile
@@ -10,9 +10,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # gh CLI from releases (apt repo is unreliable, see cli/cli#6175).
-RUN GH_CLI_VERSION=$(curl -s "https://api.github.com/repos/cli/cli/releases/latest" \
+RUN set -o pipefail && \
+    GH_CLI_VERSION=$(curl --silent --show-error --fail --retry 5 --retry-all-errors --retry-delay 2 \
+    "https://api.github.com/repos/cli/cli/releases/latest" \
     | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    curl -L "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.deb" -o /tmp/gh.deb && \
+    test -n "${GH_CLI_VERSION}" && \
+    curl --silent --show-error --fail --location --retry 5 --retry-all-errors --retry-delay 2 \
+    --output /tmp/gh.deb \
+    "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.deb" && \
     dpkg -i /tmp/gh.deb && rm /tmp/gh.deb
 
 # pnpm version is controlled by the project's packageManager field.


### PR DESCRIPTION
Closes [coder/internal#1372](https://github.com/coder/internal/issues/1372).

The flake in coder/internal#1372 was a `curl | tar` pipeline that downloaded `dive` without `--fail`, so a transient GitHub Releases hiccup wrote an HTML error body into `tar`, which produced the misleading `gzip: stdin: not in gzip format` error.

That specific download is already gone (removed in #23378), but the same anti-pattern is still scattered across the dogfood Dockerfiles. This hardens the remaining downloads against the same class of failure.

### Changes

- Standardize every external download in the three dogfood Dockerfiles on:
  ```
  curl --silent --show-error --fail --location \
       --retry 5 --retry-all-errors --retry-delay 2
  ```
- Replace `wget -q` with the same hardened curl invocation for the Chrome `.deb` so we surface HTTP errors instead of installing an HTML page.
- For the two version-probe pipelines (docker-buildx, gh CLI), add `set -o pipefail` and a `test -n` guard so a transient curl failure aborts the `RUN` immediately instead of producing an empty version string that poisons the next download URL.
- Apply the same hardening to `dogfood/vscode-coder/Dockerfile` for consistency.

### Files

- `dogfood/coder/ubuntu-22.04/Dockerfile`
- `dogfood/coder/ubuntu-26.04/Dockerfile`
- `dogfood/vscode-coder/Dockerfile`

### Validation

- `make pre-commit-light` passes (shellcheck, emdash, markdown, helm, typos, actionlint).
- `docker buildx build --check` passes on all three Dockerfiles.
- Functional test in an `ubuntu:jammy` container:
  - Happy path: the new gh CLI snippet resolved `2.92.0` and downloaded a valid `.deb`.
  - Failure path: forced a 404 on the version probe and confirmed curl retries the configured number of times, prints a clear `curl: (22) The requested URL returned error: 404`, and the `&&` chain short-circuits, leaving the `RUN` with a non-zero exit code instead of silently chugging on with an empty version.

<details>
<summary>Why these flags</summary>

| Flag | Why |
| --- | --- |
| `--fail` | Make curl exit non-zero on HTTP >= 400 instead of writing the error body to disk/stdout. Directly fixes the class of flake that produced `gzip: stdin: not in gzip format` in coder/internal#1372. |
| `--retry 5 --retry-all-errors --retry-delay 2` | Smooth over transient network and 5xx errors instead of failing the whole image build on the first hiccup. `--retry-all-errors` (curl >= 7.71) is required to retry on errors other than the default set. |
| `--silent --show-error` | Keep build logs clean on success but still print the final curl error on failure. Matches the existing mise/Homebrew pattern. |
| `--location` | Follow redirects; required for `github.com/.../releases/download/...` style URLs. |
| `set -o pipefail` + `test -n "${VAR}"` | For `VAR=$(curl ... \| grep \| sed)` chains: without pipefail, a curl failure inside `$()` is masked by the last pipeline command. With pipefail, the substitution exits non-zero; `test -n` is belt-and-suspenders for the case where curl returns a valid response that simply lacks the expected `tag_name`. |

</details>

> [!NOTE]
> Coder Agents created this PR on Michael's request.
