### PR TITLE
fix(coderd/x/chatd): recover stale OpenAI response items

### DIFF
--- a/coderd/x/chatd/chaterror/classify.go
+++ b/coderd/x/chatd/chaterror/classify.go
@@ -352,18 +352,18 @@ func streamIncompleteMessage(provider string) string {
 	return providerSubject(provider) + " stream closed unexpectedly before the response completed."
 }
 
-// chainBrokenClassification recognizes the OpenAI error
-// "Previous response with id ... not found" returned when a
-// chained turn references a previous_response_id the provider no
-// longer recognizes.
+// chainBrokenClassification recognizes OpenAI errors returned when a
+// chained turn references stored Responses API state that the provider
+// no longer recognizes.
 func chainBrokenClassification(
 	lowerMessage string,
 	provider string,
 	statusCode int,
 	structured providerErrorDetails,
 ) (ClassifiedError, bool) {
-	if !(strings.Contains(lowerMessage, "previous response with id") &&
-		strings.Contains(lowerMessage, "not found")) {
+	lowerDetail := strings.ToLower(structured.detail)
+	if !isResponsesStateNotFound(lowerMessage, statusCode) &&
+		!isResponsesStateNotFound(lowerDetail, statusCode) {
 		return ClassifiedError{}, false
 	}
 	// This class of error has so far only been observed with OpenAI.
@@ -379,6 +379,20 @@ func chainBrokenClassification(
 		RetryAfter:  structured.retryAfter,
 		ChainBroken: true,
 	}), true
+}
+
+func isResponsesStateNotFound(message string, statusCode int) bool {
+	if strings.Contains(message, "previous response with id") &&
+		strings.Contains(message, "not found") {
+		return true
+	}
+	if statusCode != 0 && statusCode != 404 {
+		return false
+	}
+	if !(strings.Contains(message, "item with id") && strings.Contains(message, "not found")) {
+		return false
+	}
+	return containsAny(message, "rs_", "msg_", "ws_")
 }
 
 func responsesAPIDiagnostic(lowerMessage, detail string) (string, bool) {

--- a/coderd/x/chatd/chaterror/classify_test.go
+++ b/coderd/x/chatd/chaterror/classify_test.go
@@ -1019,10 +1019,44 @@ func TestClassify_ChainBroken(t *testing.T) {
 			wantStatusCode:  404,
 		},
 		{
+			name: "OpenAIReasoningItemNotFoundProviderError",
+			err: testProviderError(
+				"Item with id 'rs_0d3b694947efe551006a0ae902a9bc8190a3c90b4fb62629e6' not found.",
+				404,
+				nil,
+			),
+			wantChainBroken: true,
+			wantRetryable:   true,
+			wantProvider:    "openai",
+			wantStatusCode:  404,
+		},
+		{
+			name: "OpenAIStoredItemNotPersistedProviderDetail",
+			err: testProviderError(
+				"",
+				404,
+				nil,
+				testProviderResponseDump("{\"error\":{\"message\":\"Item with id 'msg_abc' not found. Items are not persisted when store is set to false.\"}}"),
+			),
+			wantChainBroken: true,
+			wantRetryable:   true,
+			wantProvider:    "openai",
+			wantStatusCode:  404,
+		},
+		{
 			name: "PreviousResponseWithoutNotFoundIsNotChainBroken",
 			err: testProviderError(
 				"Previous response with id 'resp_abc' is invalid.",
 				400,
+				nil,
+			),
+			wantChainBroken: false,
+		},
+		{
+			name: "UnrelatedFileItemNotFoundIsNotChainBroken",
+			err: testProviderError(
+				"Item with id 'file_abc' not found.",
+				404,
 				nil,
 			),
 			wantChainBroken: false,

--- a/coderd/x/chatd/chatloop/chatloop.go
+++ b/coderd/x/chatd/chatloop/chatloop.go
@@ -372,6 +372,7 @@ func Run(ctx context.Context, opts RunOptions) error {
 	tools := buildToolDefinitions(opts.Tools, opts.ActiveTools, opts.ProviderTools)
 
 	messages := opts.Messages
+	suppressResponsesItemReferences := false
 	var lastUsage fantasy.Usage
 	var lastProviderMetadata fantasy.ProviderMetadata
 	needsFullHistoryReload := false
@@ -428,6 +429,9 @@ func Run(ctx context.Context, opts RunOptions) error {
 			)
 			if prepareErr != nil {
 				return xerrors.Errorf("prepare prompt: %w", prepareErr)
+			}
+			if suppressResponsesItemReferences {
+				prepared = chatopenai.StripResponsesItemReferences(prepared)
 			}
 			opts.Metrics.MessageCount.WithLabelValues(provider, modelName).Observe(float64(len(prepared)))
 			opts.Metrics.PromptSizeBytes.WithLabelValues(provider, modelName).Observe(float64(EstimatePromptSize(prepared)))
@@ -489,6 +493,8 @@ func Run(ctx context.Context, opts RunOptions) error {
 				classified = classified.WithProvider(provider)
 				opts.Metrics.RecordStreamRetry(provider, modelName, classified)
 				if classified.ChainBroken {
+					suppressResponsesItemReferences = true
+					call.Prompt = chatopenai.StripResponsesItemReferences(call.Prompt)
 					if chatopenai.HasPreviousResponseID(opts.ProviderOptions) {
 						opts.ProviderOptions = chatopenai.ClearPreviousResponseID(opts.ProviderOptions)
 					}
@@ -522,7 +528,7 @@ func Run(ctx context.Context, opts RunOptions) error {
 								retryPrepareErr = prepareErr
 							} else {
 								messages = reloadedCanonical
-								call.Prompt = retryPrompt
+								call.Prompt = chatopenai.StripResponsesItemReferences(retryPrompt)
 							}
 						}
 					}

--- a/coderd/x/chatd/chatloop/chatloop_internal_test.go
+++ b/coderd/x/chatd/chatloop/chatloop_internal_test.go
@@ -94,6 +94,127 @@ func TestRun_ChainBrokenRecovers(t *testing.T) {
 	)
 }
 
+func TestRun_ResponsesItemNotFoundRecoversWithStrippedReferences(t *testing.T) {
+	t.Parallel()
+
+	var (
+		streamCalls   int
+		secondCallOpt fantasy.ProviderOptions
+		secondPrompt  []fantasy.Message
+	)
+	model := &chattest.FakeModel{
+		ProviderName: fantasyopenai.Name,
+		StreamFn: func(_ context.Context, call fantasy.Call) (fantasy.StreamResponse, error) {
+			streamCalls++
+			switch streamCalls {
+			case 1:
+				return nil, xerrors.New(responsesItemNotFoundErrorMessage)
+			default:
+				secondCallOpt = call.ProviderOptions
+				secondPrompt = call.Prompt
+				return finishingStream(), nil
+			}
+		},
+	}
+
+	reloadedHistory := []fantasy.Message{
+		textMessage(fantasy.MessageRoleUser, "search"),
+		staleOpenAIResponsesMessage(),
+		textMessage(fantasy.MessageRoleUser, "continue"),
+	}
+
+	err := Run(context.Background(), RunOptions{
+		Model:                model,
+		MaxSteps:             1,
+		ContextLimitFallback: 4096,
+		Messages: []fantasy.Message{
+			textMessage(fantasy.MessageRoleUser, "chain-filtered"),
+		},
+		ProviderOptions: chainModeProviderOptions("resp_poisoned"),
+		PersistStep: func(_ context.Context, _ PersistedStep) error {
+			return nil
+		},
+		DisableChainMode: func() {},
+		ReloadMessages: func(_ context.Context) ([]fantasy.Message, error) {
+			return reloadedHistory, nil
+		},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 2, streamCalls)
+	require.False(t, chatopenai.HasPreviousResponseID(secondCallOpt))
+	requireResponsesStoreEnabled(t, secondCallOpt)
+	requireResponsesItemReferencesStripped(t, secondPrompt)
+	requireResponsesItemReferencesPresent(t, reloadedHistory)
+}
+
+func TestRun_ResponsesItemSuppressionPersistsAfterRecovery(t *testing.T) {
+	t.Parallel()
+
+	var (
+		streamCalls int
+		prompts     [][]fantasy.Message
+	)
+	model := &chattest.FakeModel{
+		ProviderName: fantasyopenai.Name,
+		StreamFn: func(_ context.Context, call fantasy.Call) (fantasy.StreamResponse, error) {
+			streamCalls++
+			switch streamCalls {
+			case 1:
+				return nil, xerrors.New(responsesItemNotFoundErrorMessage)
+			case 2:
+				prompts = append(prompts, call.Prompt)
+				return streamFromParts([]fantasy.StreamPart{
+					{Type: fantasy.StreamPartTypeToolInputStart, ID: "tc-1", ToolCallName: "read_file"},
+					{Type: fantasy.StreamPartTypeToolInputDelta, ID: "tc-1", Delta: `{"path":"main.go"}`},
+					{Type: fantasy.StreamPartTypeToolInputEnd, ID: "tc-1"},
+					{
+						Type:          fantasy.StreamPartTypeToolCall,
+						ID:            "tc-1",
+						ToolCallName:  "read_file",
+						ToolCallInput: `{"path":"main.go"}`,
+					},
+					{Type: fantasy.StreamPartTypeFinish, FinishReason: fantasy.FinishReasonToolCalls},
+				}), nil
+			default:
+				prompts = append(prompts, call.Prompt)
+				return finishingStream(), nil
+			}
+		},
+	}
+
+	err := Run(context.Background(), RunOptions{
+		Model:                model,
+		MaxSteps:             3,
+		ContextLimitFallback: 4096,
+		Messages: []fantasy.Message{
+			textMessage(fantasy.MessageRoleUser, "chain-filtered"),
+		},
+		Tools: []fantasy.AgentTool{
+			newNoopTool("read_file"),
+		},
+		ProviderOptions: chainModeProviderOptions("resp_poisoned"),
+		PersistStep: func(_ context.Context, _ PersistedStep) error {
+			return nil
+		},
+		DisableChainMode: func() {},
+		ReloadMessages: func(_ context.Context) ([]fantasy.Message, error) {
+			return []fantasy.Message{
+				textMessage(fantasy.MessageRoleUser, "search"),
+				staleOpenAIResponsesMessage(),
+				textMessage(fantasy.MessageRoleUser, "continue"),
+			}, nil
+		},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 3, streamCalls)
+	require.Len(t, prompts, 2)
+	for _, prompt := range prompts {
+		requireResponsesItemReferencesStripped(t, prompt)
+	}
+}
+
 func TestRun_ChainBrokenRecoveryPreparesReloadedMessages(t *testing.T) {
 	t.Parallel()
 
@@ -702,6 +823,98 @@ func TestFlushActiveStatePreservesEmptySignedReasoning(t *testing.T) {
 // chainBrokenError is what OpenAI returns when previous_response_id
 // points at a response it does not have stored.
 const chainBrokenErrorMessage = "Previous response with id 'resp_abc' not found."
+
+// responsesItemNotFoundErrorMessage is what OpenAI returns when a
+// Responses API input references a stored item it cannot resolve.
+const responsesItemNotFoundErrorMessage = "Item with id 'rs_stale' not found."
+
+func staleOpenAIResponsesMessage() fantasy.Message {
+	return fantasy.Message{
+		Role: fantasy.MessageRoleAssistant,
+		Content: []fantasy.MessagePart{
+			fantasy.ReasoningPart{
+				Text: "thinking",
+				ProviderOptions: fantasy.ProviderOptions{
+					fantasyopenai.Name: &fantasyopenai.ResponsesReasoningMetadata{
+						ItemID:  "rs_stale",
+						Summary: []string{"summary"},
+					},
+				},
+			},
+			fantasy.ToolResultPart{
+				ToolCallID:       "ws_stale",
+				ProviderExecuted: true,
+				ProviderOptions: fantasy.ProviderOptions{
+					fantasyopenai.Name: &fantasyopenai.WebSearchCallMetadata{
+						ItemID: "ws_stale",
+						Action: &fantasyopenai.WebSearchAction{Type: "search", Query: "coder"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func requireResponsesStoreEnabled(t *testing.T, providerOptions fantasy.ProviderOptions) {
+	t.Helper()
+	entry, ok := providerOptions[fantasyopenai.Name]
+	require.True(t, ok)
+	options, ok := entry.(*fantasyopenai.ResponsesProviderOptions)
+	require.True(t, ok)
+	require.NotNil(t, options.Store)
+	require.True(t, *options.Store)
+}
+
+func requireResponsesItemReferencesStripped(t *testing.T, prompt []fantasy.Message) {
+	t.Helper()
+	reasoning, webSearch := requireResponsesMetadata(t, prompt)
+	require.Empty(t, reasoning.ItemID)
+	require.Empty(t, webSearch.ItemID)
+}
+
+func requireResponsesItemReferencesPresent(t *testing.T, prompt []fantasy.Message) {
+	t.Helper()
+	reasoning, webSearch := requireResponsesMetadata(t, prompt)
+	require.Equal(t, "rs_stale", reasoning.ItemID)
+	require.Equal(t, "ws_stale", webSearch.ItemID)
+}
+
+func requireResponsesMetadata(t *testing.T, prompt []fantasy.Message) (*fantasyopenai.ResponsesReasoningMetadata, *fantasyopenai.WebSearchCallMetadata) {
+	t.Helper()
+	for _, msg := range prompt {
+		for _, part := range msg.Content {
+			reasoning, ok := part.(fantasy.ReasoningPart)
+			if !ok {
+				continue
+			}
+			metadata := fantasyopenai.GetReasoningMetadata(reasoning.ProviderOptions)
+			if metadata == nil {
+				continue
+			}
+			webSearch := findResponsesWebSearchMetadata(prompt)
+			require.NotNil(t, webSearch)
+			return metadata, webSearch
+		}
+	}
+	require.FailNow(t, "missing OpenAI reasoning metadata")
+	return nil, nil
+}
+
+func findResponsesWebSearchMetadata(prompt []fantasy.Message) *fantasyopenai.WebSearchCallMetadata {
+	for _, msg := range prompt {
+		for _, part := range msg.Content {
+			entry, ok := part.Options()[fantasyopenai.Name]
+			if !ok {
+				continue
+			}
+			metadata, ok := entry.(*fantasyopenai.WebSearchCallMetadata)
+			if ok {
+				return metadata
+			}
+		}
+	}
+	return nil
+}
 
 // finishingStream returns a stream that emits a single Finish part.
 // The chatloop treats a finishReason of Stop as "stoppedByModel" and

--- a/coderd/x/chatd/chatopenai/responses.go
+++ b/coderd/x/chatd/chatopenai/responses.go
@@ -285,6 +285,137 @@ func FilterPromptForChainMode(
 	return filtered
 }
 
+// StripResponsesItemReferences returns a prompt copy with OpenAI Responses
+// item IDs removed from provider metadata that fantasy would otherwise replay
+// as item_reference input. This is used after OpenAI reports stale stored
+// response state so recovery can replay visible history without asking OpenAI
+// to resolve the stale reasoning or provider-tool items again.
+func StripResponsesItemReferences(prompt []fantasy.Message) []fantasy.Message {
+	stripped := slices.Clone(prompt)
+	changed := false
+	for i, msg := range stripped {
+		updated, ok := stripResponsesItemReferencesFromMessage(msg)
+		if !ok {
+			continue
+		}
+		stripped[i] = updated
+		changed = true
+	}
+	if !changed {
+		return prompt
+	}
+	return stripped
+}
+
+func stripResponsesItemReferencesFromMessage(msg fantasy.Message) (fantasy.Message, bool) {
+	content := slices.Clone(msg.Content)
+	changed := false
+	for i, part := range content {
+		updated, ok := stripResponsesItemReferencesFromPart(part)
+		if !ok {
+			continue
+		}
+		content[i] = updated
+		changed = true
+	}
+	if !changed {
+		return msg, false
+	}
+	msg.Content = content
+	return msg, true
+}
+
+func stripResponsesItemReferencesFromPart(part fantasy.MessagePart) (fantasy.MessagePart, bool) {
+	switch p := part.(type) {
+	case fantasy.ReasoningPart:
+		providerOptions, changed := stripResponsesItemID(p.ProviderOptions)
+		if !changed {
+			return part, false
+		}
+		p.ProviderOptions = providerOptions
+		return p, true
+	case *fantasy.ReasoningPart:
+		if p == nil {
+			return part, false
+		}
+		providerOptions, changed := stripResponsesItemID(p.ProviderOptions)
+		if !changed {
+			return part, false
+		}
+		clone := *p
+		clone.ProviderOptions = providerOptions
+		return &clone, true
+	case fantasy.ToolCallPart:
+		providerOptions, changed := stripResponsesItemID(p.ProviderOptions)
+		if !changed {
+			return part, false
+		}
+		p.ProviderOptions = providerOptions
+		return p, true
+	case *fantasy.ToolCallPart:
+		if p == nil {
+			return part, false
+		}
+		providerOptions, changed := stripResponsesItemID(p.ProviderOptions)
+		if !changed {
+			return part, false
+		}
+		clone := *p
+		clone.ProviderOptions = providerOptions
+		return &clone, true
+	case fantasy.ToolResultPart:
+		providerOptions, changed := stripResponsesItemID(p.ProviderOptions)
+		if !changed {
+			return part, false
+		}
+		p.ProviderOptions = providerOptions
+		return p, true
+	case *fantasy.ToolResultPart:
+		if p == nil {
+			return part, false
+		}
+		providerOptions, changed := stripResponsesItemID(p.ProviderOptions)
+		if !changed {
+			return part, false
+		}
+		clone := *p
+		clone.ProviderOptions = providerOptions
+		return &clone, true
+	default:
+		return part, false
+	}
+}
+
+func stripResponsesItemID(providerOptions fantasy.ProviderOptions) (fantasy.ProviderOptions, bool) {
+	entry, ok := providerOptions[fantasyopenai.Name]
+	if !ok {
+		return providerOptions, false
+	}
+
+	switch metadata := entry.(type) {
+	case *fantasyopenai.ResponsesReasoningMetadata:
+		if metadata == nil || metadata.ItemID == "" {
+			return providerOptions, false
+		}
+		metadataClone := *metadata
+		metadataClone.ItemID = ""
+		cloned := maps.Clone(providerOptions)
+		cloned[fantasyopenai.Name] = &metadataClone
+		return cloned, true
+	case *fantasyopenai.WebSearchCallMetadata:
+		if metadata == nil || metadata.ItemID == "" {
+			return providerOptions, false
+		}
+		metadataClone := *metadata
+		metadataClone.ItemID = ""
+		cloned := maps.Clone(providerOptions)
+		cloned[fantasyopenai.Name] = &metadataClone
+		return cloned, true
+	default:
+		return providerOptions, false
+	}
+}
+
 func userMessageContributesToChainMode(msg database.ChatMessage) bool {
 	parts, err := chatprompt.ParseContent(msg)
 	if err != nil {

--- a/coderd/x/chatd/chatopenai/responses_test.go
+++ b/coderd/x/chatd/chatopenai/responses_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"charm.land/fantasy"
+	fantasyanthropic "charm.land/fantasy/providers/anthropic"
 	fantasyopenai "charm.land/fantasy/providers/openai"
 	"github.com/google/uuid"
 	"github.com/sqlc-dev/pqtype"
@@ -87,6 +88,69 @@ func TestIsResponsesStoreEnabledIgnoresMalformedNonOpenAIKey(t *testing.T) {
 	}
 
 	require.False(t, chatopenai.IsResponsesStoreEnabled(opts))
+}
+
+func TestStripResponsesItemReferences(t *testing.T) {
+	t.Parallel()
+
+	prompt := []fantasy.Message{
+		{
+			Role: fantasy.MessageRoleAssistant,
+			Content: []fantasy.MessagePart{
+				fantasy.ReasoningPart{
+					Text: "thinking",
+					ProviderOptions: fantasy.ProviderOptions{
+						fantasyopenai.Name: &fantasyopenai.ResponsesReasoningMetadata{
+							ItemID:  "rs_stale",
+							Summary: []string{"summary"},
+						},
+						fantasyanthropic.Name: &fantasyanthropic.ReasoningOptionMetadata{
+							Signature: "sig",
+						},
+					},
+				},
+				fantasy.ToolResultPart{
+					ToolCallID:       "ws_stale",
+					ProviderExecuted: true,
+					ProviderOptions: fantasy.ProviderOptions{
+						fantasyopenai.Name: &fantasyopenai.WebSearchCallMetadata{
+							ItemID: "ws_stale",
+							Action: &fantasyopenai.WebSearchAction{Type: "search", Query: "coder"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	stripped := chatopenai.StripResponsesItemReferences(prompt)
+
+	require.NotSame(t, &prompt[0], &stripped[0])
+	reasoning, ok := fantasy.AsMessagePart[fantasy.ReasoningPart](stripped[0].Content[0])
+	require.True(t, ok)
+	require.Equal(t, "thinking", reasoning.Text)
+	openaiReasoning := fantasyopenai.GetReasoningMetadata(reasoning.ProviderOptions)
+	require.NotNil(t, openaiReasoning)
+	require.Empty(t, openaiReasoning.ItemID)
+	require.Equal(t, []string{"summary"}, openaiReasoning.Summary)
+	anthropicReasoning := fantasyanthropic.GetReasoningMetadata(reasoning.ProviderOptions)
+	require.NotNil(t, anthropicReasoning)
+	require.Equal(t, "sig", anthropicReasoning.Signature)
+
+	toolResult, ok := fantasy.AsMessagePart[fantasy.ToolResultPart](stripped[0].Content[1])
+	require.True(t, ok)
+	openaiWebSearch, ok := toolResult.ProviderOptions[fantasyopenai.Name].(*fantasyopenai.WebSearchCallMetadata)
+	require.True(t, ok)
+	require.Empty(t, openaiWebSearch.ItemID)
+	require.NotNil(t, openaiWebSearch.Action)
+	require.Equal(t, "coder", openaiWebSearch.Action.Query)
+
+	originalReasoning := fantasyopenai.GetReasoningMetadata(prompt[0].Content[0].Options())
+	require.NotNil(t, originalReasoning)
+	require.Equal(t, "rs_stale", originalReasoning.ItemID)
+	originalWebSearch, ok := prompt[0].Content[1].Options()[fantasyopenai.Name].(*fantasyopenai.WebSearchCallMetadata)
+	require.True(t, ok)
+	require.Equal(t, "ws_stale", originalWebSearch.ItemID)
 }
 
 func TestShouldActivateChainMode(t *testing.T) {


### PR DESCRIPTION
> Mux opened this PR on behalf of Mike.

OpenAI Responses chain recovery previously only handled missing `previous_response_id` errors, so stale stored item references such as reasoning or web search item IDs could keep retries failing.

This broadens chain-broken detection for stale stored item IDs and strips OpenAI Responses item references while preserving visible reasoning and web search content. The retry still clears `previous_response_id` and keeps `store=true` so successful recovery can establish fresh Responses state.
