### PR TITLE
docs: add authentication page to AI Gateway docs

### DIFF
--- a/docs/ai-coder/ai-gateway/audit.md
+++ b/docs/ai-coder/ai-gateway/audit.md
@@ -109,6 +109,7 @@ session data is kept.
 
 ## Next steps
 
-- [Monitoring](./monitoring.md) — Dashboards, data export, and tracing
-- [Setup](./setup.md) — Configure AI Gateway and data retention
-- [Reference](./reference.md) — API and technical reference
+- [Monitoring](./monitoring.md): Dashboards, data export, and tracing
+- [Setup](./setup.md): Configure AI Gateway and data retention
+- [Authentication](./auth.md): Token format, auth paths, and credential modes
+- [Reference](./reference.md): API and technical reference

--- a/docs/ai-coder/ai-gateway/auth.md
+++ b/docs/ai-coder/ai-gateway/auth.md
@@ -1,0 +1,144 @@
+# Authentication
+
+> [!NOTE]
+> AI Gateway requires the [AI Governance Add-On](../ai-governance.md).
+
+AI Gateway uses standard Coder API tokens to authenticate clients. The same
+token a user uses to interact with the Coder API grants access to AI Gateway.
+No additional credentials or separate login flow is required.
+
+## Token format
+
+Coder tokens are opaque strings with the format `<ID>-<secret>`:
+
+- **ID**: 10 characters, stored in plaintext and used to look up the key record.
+- **Secret**: 22 characters, stored only as a bcrypt hash; never persisted in
+  plaintext.
+
+Tokens are not JWTs and carry no embedded claims. All validation happens
+server-side by looking up the key record in the database.
+
+Generate a token from the Coder UI (**Account settings > Tokens**) or via the
+CLI:
+
+```sh
+coder tokens create --lifetime 30d my-ai-token
+```
+
+## How AI Gateway validates a token
+
+When AI Gateway receives a request, `aibridged` runs the following checks in
+order. Any failure short-circuits the sequence and returns an error.
+
+| Step | Check                                                        | Error on failure |
+|------|--------------------------------------------------------------|------------------|
+| 1    | Token matches `<ID>-<secret>` format                         | `ErrInvalidKey`  |
+| 2    | Key ID exists in the database                                | `ErrUnknownKey`  |
+| 3    | Key has not passed its `expires_at` timestamp                | `ErrExpired`     |
+| 4    | bcrypt hash of the secret matches the stored `hashed_secret` | `ErrInvalidKey`  |
+| 5    | Owner user record exists                                     | `ErrUnknownUser` |
+| 6    | Owner has not been deleted                                   | `ErrDeletedUser` |
+| 7    | Owner is not a system user                                   | `ErrSystemUser`  |
+
+On success, `aibridged` returns the owner's user ID, API key ID, and username
+for attribution in session records and audit logs.
+
+> [!NOTE]
+> AI Gateway does not currently update the `last_used` timestamp on a token
+> when it is used to authenticate. This is a known limitation and does not
+> affect the validity check.
+
+## Authentication paths
+
+There are two ways a client authenticates to AI Gateway, depending on whether it
+uses the direct API or AI Gateway Proxy.
+
+### Direct API
+
+Clients that support a configurable base URL send requests directly to
+`coderd` using standard Coder token authentication.
+
+**How it works:**
+
+1. Client sets its base URL to `https://<deployment-url>/api/v2/aibridge/<NAME>/`.
+1. Client presents the Coder token in one of two headers:
+   - `Authorization: Bearer <token>`
+   - `X-Api-Key: <token>`
+1. `coderd` validates the token via standard API key middleware.
+1. `coderd` forwards the request to the configured upstream provider, injecting
+   the deployment's upstream provider key.
+
+This path is available to any client that supports a custom base URL, such as
+Claude Code, Codex, Cline, and most OpenAI-compatible tools. See
+[Client Configuration](./clients/index.md) for per-client setup instructions.
+
+### Proxy mode (AI Gateway Proxy)
+
+For clients that do not support a configurable base URL, AI Gateway Proxy
+intercepts outbound HTTPS traffic using a MITM TLS proxy. The Coder token
+travels in the HTTP proxy credentials during the `CONNECT` handshake.
+
+**How it works:**
+
+1. Client's environment is configured to route traffic through the proxy:
+
+   ```sh
+   HTTPS_PROXY=http://ignored:<coder-token>@<proxy-host>:8888
+   ```
+
+1. The proxy authenticates the token from the `Proxy-Authorization: Basic
+   base64(ignored:<token>)` header.
+1. The proxy intercepts TLS connections to allowlisted AI provider domains
+   (`api.anthropic.com`, `api.openai.com`, `api.individual.githubcopilot.com`)
+   using a MITM CA certificate.
+1. All other HTTPS traffic passes through unmodified.
+
+The MITM CA certificate must be installed on client machines. Download it from:
+
+```text
+GET https://<deployment-url>/api/v2/aibridge/proxy/ca-cert.pem
+```
+
+See [AI Gateway Proxy](./ai-gateway-proxy/index.md) for full setup instructions,
+including CA certificate installation and per-client configuration.
+
+## Credential modes
+
+AI Gateway supports two credential modes that control whose upstream provider
+key is used when forwarding requests to the LLM provider.
+
+### Centralized mode
+
+The deployment's upstream provider key, configured by the admin in
+`CODER_AIBRIDGE_<PROVIDER>_KEY`, is used for all requests. Clients authenticate
+with their Coder token only. No LLM credentials need to be distributed to users.
+
+This is the default mode and the recommended approach for most deployments.
+
+### BYOK mode (Bring Your Own Key)
+
+Users supply their own LLM credentials in the `Authorization` or `X-Api-Key`
+header alongside their Coder token. AI Gateway forwards the user's key to the
+upstream provider while adding a `X-Coder-AI-Governance-Token` header carrying
+the Coder token for attribution.
+
+BYOK is useful in deployments where users already have individual provider
+accounts, or where per-user billing is required.
+
+## Token lifecycle
+
+| Property          | Details                                                                                                                             |
+|-------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| **Expiry**        | Set at creation time via `--lifetime`. Expired tokens are rejected at validation step 3 with `ErrExpired`.                          |
+| **Revocation**    | Tokens can be deleted from the UI or CLI (`coder tokens rm <name>`). Deleted tokens fail at validation step 2 with `ErrUnknownKey`. |
+| **User deletion** | When a user is deleted, all their tokens fail at validation step 6 with `ErrDeletedUser`.                                           |
+| **Rotation**      | Create a new token and update client configuration, then delete the old token.                                                      |
+
+Keep tokens short-lived for non-interactive use cases (CI, automation). Use
+the `--lifetime` flag to match the expected duration of the task.
+
+## Next steps
+
+- [Setup](./setup.md): Enable AI Gateway and configure providers
+- [Client Configuration](./clients/index.md): Configure individual AI coding tools
+- [Auditing AI Sessions](./audit.md): Review session records and attribution

--- a/docs/ai-coder/ai-gateway/auth.md
+++ b/docs/ai-coder/ai-gateway/auth.md
@@ -3,8 +3,8 @@
 > [!NOTE]
 > AI Gateway requires the [AI Governance Add-On](../ai-governance.md).
 
-AI Gateway uses standard Coder API tokens to authenticate clients. The same
-token a user uses to interact with the Coder API grants access to AI Gateway.
+AI Gateway uses standard Coder API tokens to authenticate clients.
+The same token a user uses to interact with the Coder API grants access to AI Gateway.
 No additional credentials or separate login flow is required.
 
 ## Token format
@@ -12,14 +12,12 @@ No additional credentials or separate login flow is required.
 Coder tokens are opaque strings with the format `<ID>-<secret>`:
 
 - **ID**: 10 characters, stored in plaintext and used to look up the key record.
-- **Secret**: 22 characters, stored only as a bcrypt hash; never persisted in
-  plaintext.
+- **Secret**: 22 characters, stored only as a bcrypt hash; never persisted in plaintext.
 
-Tokens are not JWTs and carry no embedded claims. All validation happens
-server-side by looking up the key record in the database.
+Tokens are not JWTs and carry no embedded claims.
+All validation happens server-side by looking up the key record in the database.
 
-Generate a token from the Coder UI (**Account settings > Tokens**) or via the
-CLI:
+Generate a token from the Coder UI (**Account settings > Tokens**) or via the CLI:
 
 ```sh
 coder tokens create --lifetime 30d my-ai-token
@@ -27,8 +25,8 @@ coder tokens create --lifetime 30d my-ai-token
 
 ## How AI Gateway validates a token
 
-When AI Gateway receives a request, `aibridged` runs the following checks in
-order. Any failure short-circuits the sequence and returns an error.
+When AI Gateway receives a request, `aibridged` runs the following checks in order.
+Any failure short-circuits the sequence and returns an error.
 
 | Step | Check                                                        | Error on failure |
 |------|--------------------------------------------------------------|------------------|
@@ -45,18 +43,18 @@ for attribution in session records and audit logs.
 
 > [!NOTE]
 > AI Gateway does not currently update the `last_used` timestamp on a token
-> when it is used to authenticate. This is a known limitation and does not
-> affect the validity check.
+> when it is used to authenticate.
+> This is a known limitation and does not affect the validity check.
 
 ## Authentication paths
 
-There are two ways a client authenticates to AI Gateway, depending on whether it
-uses the direct API or AI Gateway Proxy.
+There are two ways a client authenticates to AI Gateway,
+depending on whether it uses the direct API or AI Gateway Proxy.
 
 ### Direct API
 
-Clients that support a configurable base URL send requests directly to
-`coderd` using standard Coder token authentication.
+Clients that support a configurable base URL send requests directly to `coderd`
+using standard Coder token authentication.
 
 **How it works:**
 
@@ -65,18 +63,18 @@ Clients that support a configurable base URL send requests directly to
    - `Authorization: Bearer <token>`
    - `X-Api-Key: <token>`
 1. `coderd` validates the token via standard API key middleware.
-1. `coderd` forwards the request to the configured upstream provider, injecting
-   the deployment's upstream provider key.
+1. `coderd` forwards the request to the configured upstream provider,
+   injecting the deployment's upstream provider key.
 
-This path is available to any client that supports a custom base URL, such as
-Claude Code, Codex, Cline, and most OpenAI-compatible tools. See
-[Client Configuration](./clients/index.md) for per-client setup instructions.
+This path is available to any client that supports a custom base URL,
+such as Claude Code, Codex, Cline, and most OpenAI-compatible tools.
+See [Client Configuration](./clients/index.md) for per-client setup instructions.
 
 ### Proxy mode (AI Gateway Proxy)
 
-For clients that do not support a configurable base URL, AI Gateway Proxy
-intercepts outbound HTTPS traffic using a MITM TLS proxy. The Coder token
-travels in the HTTP proxy credentials during the `CONNECT` handshake.
+For clients that do not support a configurable base URL,
+AI Gateway Proxy intercepts outbound HTTPS traffic using a MITM TLS proxy.
+The Coder token travels in the HTTP proxy credentials during the `CONNECT` handshake.
 
 **How it works:**
 
@@ -86,14 +84,15 @@ travels in the HTTP proxy credentials during the `CONNECT` handshake.
    HTTPS_PROXY=http://ignored:<coder-token>@<proxy-host>:8888
    ```
 
-1. The proxy authenticates the token from the `Proxy-Authorization: Basic
-   base64(ignored:<token>)` header.
+1. The proxy authenticates the token from the
+   `Proxy-Authorization: Basic base64(ignored:<token>)` header.
 1. The proxy intercepts TLS connections to allowlisted AI provider domains
    (`api.anthropic.com`, `api.openai.com`, `api.individual.githubcopilot.com`)
    using a MITM CA certificate.
 1. All other HTTPS traffic passes through unmodified.
 
-The MITM CA certificate must be installed on client machines. Download it from:
+The MITM CA certificate must be installed on client machines.
+Download it from:
 
 ```text
 GET https://<deployment-url>/api/v2/aibridge/proxy/ca-cert.pem
@@ -104,26 +103,27 @@ including CA certificate installation and per-client configuration.
 
 ## Credential modes
 
-AI Gateway supports two credential modes that control whose upstream provider
-key is used when forwarding requests to the LLM provider.
+AI Gateway supports two credential modes
+that control whose upstream provider key is used when forwarding requests to the LLM provider.
 
 ### Centralized mode
 
-The deployment's upstream provider key, configured by the admin in
-`CODER_AIBRIDGE_<PROVIDER>_KEY`, is used for all requests. Clients authenticate
-with their Coder token only. No LLM credentials need to be distributed to users.
+The deployment's upstream provider key, configured by the admin in `CODER_AIBRIDGE_<PROVIDER>_KEY`,
+is used for all requests.
+Clients authenticate with their Coder token only.
+No LLM credentials need to be distributed to users.
 
 This is the default mode and the recommended approach for most deployments.
 
 ### BYOK mode (Bring Your Own Key)
 
-Users supply their own LLM credentials in the `Authorization` or `X-Api-Key`
-header alongside their Coder token. AI Gateway forwards the user's key to the
-upstream provider while adding a `X-Coder-AI-Governance-Token` header carrying
-the Coder token for attribution.
+Users supply their own LLM credentials in the `Authorization` or `X-Api-Key` header
+alongside their Coder token.
+AI Gateway forwards the user's key to the upstream provider
+while adding a `X-Coder-AI-Governance-Token` header carrying the Coder token for attribution.
 
-BYOK is useful in deployments where users already have individual provider
-accounts, or where per-user billing is required.
+BYOK is useful in deployments where users already have individual provider accounts,
+or where per-user billing is required.
 
 ## Token lifecycle
 
@@ -134,8 +134,8 @@ accounts, or where per-user billing is required.
 | **User deletion** | When a user is deleted, all their tokens fail at validation step 6 with `ErrDeletedUser`.                                           |
 | **Rotation**      | Create a new token and update client configuration, then delete the old token.                                                      |
 
-Keep tokens short-lived for non-interactive use cases (CI, automation). Use
-the `--lifetime` flag to match the expected duration of the task.
+Keep tokens short-lived for non-interactive use cases (CI, automation).
+Use the `--lifetime` flag to match the expected duration of the task.
 
 ## Next steps
 

--- a/docs/ai-coder/ai-gateway/auth.md
+++ b/docs/ai-coder/ai-gateway/auth.md
@@ -20,7 +20,7 @@ All validation happens server-side by looking up the key record in the database.
 Generate a token from the Coder UI (**Account settings > Tokens**) or via the CLI:
 
 ```sh
-coder tokens create --lifetime 30d my-ai-token
+coder tokens create --lifetime 30d -n my-ai-token
 ```
 
 ## How AI Gateway validates a token

--- a/docs/ai-coder/ai-gateway/setup.md
+++ b/docs/ai-coder/ai-gateway/setup.md
@@ -305,3 +305,9 @@ indicates the kind of event captured:
 | `prompt_usage`       | The last user prompt in a request.      | `interception_id`, `prompt`, `created_at`                                      |
 | `tool_usage`         | A tool/function call made by the model. | `interception_id`, `tool`, `input`, `server_url`, `injected`, `created_at`     |
 | `model_thought`      | Model reasoning or thinking content.    | `interception_id`, `content`, `created_at`                                     |
+
+## Next steps
+
+- [Authentication](./auth.md): Token format, auth paths, and credential modes
+- [Client Configuration](./clients/index.md): Configure individual AI coding tools
+- [Auditing AI Sessions](./audit.md): Review session records and attribution

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1141,6 +1141,11 @@
 									"path": "./ai-coder/ai-gateway/setup.md"
 								},
 								{
+									"title": "Authentication",
+									"description": "How clients authenticate to AI Gateway, token format, auth paths, and credential modes",
+									"path": "./ai-coder/ai-gateway/auth.md"
+								},
+								{
 									"title": "Client Configuration",
 									"description": "How to configure your AI coding tools to use AI Gateway",
 									"path": "./ai-coder/ai-gateway/clients/index.md",


### PR DESCRIPTION
Closes DOCS-148.

Adds `docs/ai-coder/ai-gateway/auth.md` covering how clients authenticate to AI Gateway.

## What's in this PR

**New page: `docs/ai-coder/ai-gateway/auth.md`**
- Token format: opaque ID-secret strings (not JWTs)
- 7-step server-side validation sequence in `aibridged`
- Two auth paths: direct API (Authorization/X-Api-Key) and proxy mode (Proxy-Authorization CONNECT handshake)
- Credential modes: centralized vs. BYOK
- Token lifecycle: expiry, revocation, rotation

**`docs/manifest.json`** inserts `auth.md` after `setup.md` in the AI Gateway nav.

**`docs/ai-coder/ai-gateway/setup.md`** adds a Next steps section with links to auth, clients, and audit.

**`docs/ai-coder/ai-gateway/audit.md`** adds cross-link to `auth.md` in the existing Next steps section, and converts em-dashes to colons (lint requirement).

<details>
<summary>Research notes</summary>

Key source files reviewed:
- `coderd/httpmw/apikey.go` (SplitAPIToken) for token format
- `enterprise/aibridgedserver/aibridgedserver.go` (IsAuthorized) for the validation sequence and error types
- `enterprise/aibridgeproxyd/aibridgeproxyd.go` (extractCoderTokenFromProxyAuth) for proxy auth
- `coderd/database/models.go` for CredentialKindCentralized / CredentialKindByok
- `coderd/aibridge/aibridge.go` for HeaderCoderToken

Known limitation documented: aibridged.IsAuthorized does not currently update last_used on the token (explicit TODO in source).
</details>

---
*Generated by Coder Agents*