### PR TITLE
docs: add common policy patterns to rules engine reference

### DIFF
--- a/docs/ai-coder/agent-firewall/index.md
+++ b/docs/ai-coder/agent-firewall/index.md
@@ -135,7 +135,7 @@ rules, see the [rules engine documentation](./rules-engine.md).
 
 > [!TIP]
 > For worked examples of common policy patterns,
-> see [Common policy patterns](./rules-engine.md#common-policy-patterns)
+> refer to [Common policy patterns](./rules-engine.md#common-policy-patterns)
 > in the rules engine reference.
 
 You can also run Agent Firewall directly in your workspace and configure it

--- a/docs/ai-coder/agent-firewall/index.md
+++ b/docs/ai-coder/agent-firewall/index.md
@@ -133,6 +133,11 @@ version control.
 For detailed information about the rules engine and how to construct allowlist
 rules, see the [rules engine documentation](./rules-engine.md).
 
+> [!TIP]
+> For worked examples of common policy patterns,
+> see [Common policy patterns](./rules-engine.md#common-policy-patterns)
+> in the rules engine reference.
+
 You can also run Agent Firewall directly in your workspace and configure it
 per template. You can do so by installing the
 [binary](https://github.com/coder/boundary) into the workspace image or at

--- a/docs/ai-coder/agent-firewall/rules-engine.md
+++ b/docs/ai-coder/agent-firewall/rules-engine.md
@@ -110,3 +110,131 @@ allowlist:
 
 `NOTE`: The pattern `/api/*` does not include the base path `/api`. To match
 both, use `path=/api,/api/*`.
+
+---
+
+## Common policy patterns
+
+The following examples show complete `config.yaml` allowlists for common deployment scenarios.
+Each is a self-contained configuration you can adapt for your templates.
+
+### Minimal Claude Code starter
+
+The minimum allowlist required to run Claude Code,
+based on [Anthropic's default allowed domains](https://code.claude.com/docs/en/claude-code-on-the-web#default-allowed-domains).
+
+```yaml
+allowlist:
+  # Replace with your Coder deployment domain
+  - domain=dev.coder.com
+
+  # Anthropic services (required)
+  - domain=api.anthropic.com
+  - domain=statsig.anthropic.com
+
+  # Claude.ai (recommended - enables WebFetch and WebSearch tools)
+  - domain=claude.ai
+
+  # Error tracking (recommended - helps Anthropic diagnose issues)
+  - domain=*.sentry.io
+jail_type: nsjail
+log_dir: /tmp/boundary_logs
+log_level: warn
+proxy_port: 8087
+```
+
+Every rule is load-bearing: removing `api.anthropic.com` breaks all inference,
+and removing `statsig.anthropic.com` breaks feature-flag initialization.
+This is the smallest policy that keeps Claude Code fully functional.
+Add domains only as your agent's actual network requirements grow.
+
+### Read-only VCS access
+
+An agent that reads source code or calls read-only APIs should not be able to
+push branches, create pull requests, or modify remote state.
+Because the rules engine is a pure allowlist,
+restricting writes means listing only the HTTP methods you want to permit.
+
+```yaml
+allowlist:
+  # GitHub - read operations only
+  - method=GET,HEAD domain=github.com
+  - method=GET,HEAD domain=api.github.com
+  - method=GET,HEAD domain=raw.githubusercontent.com
+  - method=GET,HEAD domain=objects.githubusercontent.com
+
+  # GitLab - read operations only
+  - method=GET,HEAD domain=gitlab.com
+  - method=GET,HEAD domain=api.gitlab.com
+
+  # Required Anthropic services
+  - domain=api.anthropic.com
+  - domain=statsig.anthropic.com
+jail_type: nsjail
+log_dir: /tmp/boundary_logs
+log_level: warn
+proxy_port: 8087
+```
+
+`POST`, `PUT`, `PATCH`, and `DELETE` requests to these domains are denied by default
+because they are absent from the allowlist.
+Agent Firewall handles only HTTP/HTTPS traffic,
+so SSH-based `git push` (port 22) must be blocked separately at the network level if needed.
+
+### Path-scoped internal API
+
+When an agent needs only a few endpoints from a broader internal service,
+limit the allowlist to those specific paths rather than opening the entire host.
+
+```yaml
+allowlist:
+  # Read and post results; deny all other paths on this host
+  - method=GET,POST domain=internal-api.example.com path=/api/v1/results,/api/v1/results/*
+
+  # Health check endpoint (read only)
+  - method=GET domain=internal-api.example.com path=/healthz
+
+  # Required Anthropic services
+  - domain=api.anthropic.com
+  - domain=statsig.anthropic.com
+jail_type: nsjail
+log_dir: /tmp/boundary_logs
+log_level: warn
+proxy_port: 8087
+```
+
+`path=/api/v1/results` matches only that exact path,
+and `path=/api/v1/results/*` matches one or more segments beneath it.
+Use both together (comma-separated) to cover the collection root and its members.
+Any request to `internal-api.example.com` on a path not in the allowlist is denied.
+
+### Locked-down task agent
+
+A minimal policy for a single-purpose agent that calls one AI provider and one
+internal endpoint, with no broader internet access.
+Use this pattern for automated tasks where minimizing the blast radius of a
+compromised or misbehaving agent is a priority.
+
+```yaml
+allowlist:
+  # Required Anthropic services
+  - domain=api.anthropic.com
+  - domain=statsig.anthropic.com
+
+  # One specific internal endpoint, write-only
+  - method=POST domain=tasks.internal.example.com path=/run
+
+  # Coder deployment (required for agent heartbeat and log streaming)
+  - domain=coder.example.com
+jail_type: nsjail
+log_dir: /tmp/boundary_logs
+log_level: info
+proxy_port: 8087
+```
+
+`log_level: info` records every request, not just blocked ones.
+This is recommended for automated tasks where a full request history may be needed for incident review.
+Once the policy is stable and request volume is high,
+switch to `log_level: warn` to reduce log storage costs.
+The agent has no access to package registries, CDNs, or any other external host.
+If the task ever needs a new network dependency, the allowlist must be explicitly updated.

--- a/docs/ai-coder/agent-firewall/rules-engine.md
+++ b/docs/ai-coder/agent-firewall/rules-engine.md
@@ -126,7 +126,7 @@ based on [Anthropic's default allowed domains](https://code.claude.com/docs/en/c
 ```yaml
 allowlist:
   # Replace with your Coder deployment domain
-  - domain=dev.coder.com
+  - domain=coder.example.com
 
   # Anthropic services (required)
   - domain=api.anthropic.com


### PR DESCRIPTION
The rules engine reference page had solid syntax documentation but no worked examples. Security reviewers and new adopters had no concrete starting point for writing real policies.

Adds a "Common policy patterns" section to `rules-engine.md` with four self-contained `config.yaml` examples: a minimal Claude Code starter, read-only VCS access, a path-scoped internal API, and a locked-down task agent. Each includes a code block and a short commentary paragraph explaining what the rules allow, what they implicitly deny, and why.

Also adds a `[!TIP]` callout to `agent-firewall/index.md` pointing to the new section.

Closes https://linear.app/codercom/issue/DOCS-146

> Generated by Coder Agents