### PR TITLE
fix(pty/ptytest): handle backpressure due to slow t.Log

### DIFF
--- a/pty/ptytest/ptytest.go
+++ b/pty/ptytest/ptytest.go
@@ -71,10 +71,14 @@ func newExpecter(t *testing.T, r io.Reader, name string) outExpecter {
 	logDone := make(chan struct{})
 	logr, logw := io.Pipe()
 
-	// Write to log and output buffer.
+	// Write to output buffer and logw.
 	copyDone := make(chan struct{})
 	out := newStdbuf()
-	w := io.MultiWriter(logw, out)
+	w := io.MultiWriter(out, logw)
+
+	// closeCh signals the log goroutine to stop processing buffered lines.
+	closeCh := make(chan struct{})
+	var closeOnce sync.Once
 
 	ex := outExpecter{
 		t:    t,
@@ -96,14 +100,22 @@ func newExpecter(t *testing.T, r io.Reader, name string) outExpecter {
 
 		ex.logf("closing expecter: %s", reason)
 
-		// Caller needs to have closed the PTY so that copying can complete
+		// Signal the log goroutine to stop processing buffered lines,
+		// then close the log pipe writer to unblock any io.Copy that
+		// may be stuck in a Write() call due to pipe backpressure from
+		// slow t.Log() under heavy test parallelism + race detector.
+		closeOnce.Do(func() { close(closeCh) })
+		logClose("logw", logw)
+
+		// Caller needs to have closed the PTY so that copying can complete.
+		// With logw closed, io.Copy will fail on its next Write even if
+		// Read still has data, so this should resolve quickly.
 		select {
 		case <-ctx.Done():
 			ex.fatalf("close", "copy did not close in time")
 		case <-copyDone:
 		}
 
-		logClose("logw", logw)
 		logClose("logr", logr)
 		select {
 		case <-ctx.Done():
@@ -130,6 +142,11 @@ func newExpecter(t *testing.T, r io.Reader, name string) outExpecter {
 		defer close(logDone)
 		s := bufio.NewScanner(logr)
 		for s.Scan() {
+			select {
+			case <-closeCh:
+				return
+			default:
+			}
 			ex.logf("%q", stripansi.Strip(s.Text()))
 		}
 	}()


### PR DESCRIPTION
Relates to PLAT-224

Addresses a [review comment](https://github.com/coder/coder/pull/25444#pullrequestreview-4317247992) from @mafredri.

When we go to close the PTY, we need to wait for the `io.Copy` to `logw` to complete. In situations with high test parallelism and lots of logging, there can be a bit of backpressure on `t.Log()` as it has its own mutex. When run under the race detector, the above situation is exacerbated as we need to wait for the pipe to drain.

Suggested fix is to:
- Write first to output buffer and _second_ to `logw`.
- Close `logw` first so we have time to handle the backpressure

[This gist](https://gist.github.com/johnstcn/2a9e74e4611aedde606be0f19ed28cca) has a test that attempts to reproduce this situation. I observed it taking ~20s before the change, and ~10s after. 

> 🤖🤝🧑‍💻 Written by a Coder Agent with guidance and prodding from a human.