### PR TITLE
chore(pty/ptytest): log scanner errors during shutdown

### DIFF
--- a/pty/ptytest/ptytest.go
+++ b/pty/ptytest/ptytest.go
@@ -132,6 +132,15 @@ func newExpecter(t *testing.T, r io.Reader, name string) outExpecter {
 		for s.Scan() {
 			ex.logf("%q", stripansi.Strip(s.Text()))
 		}
+		// s.Err() returns nil on EOF (the normal shutdown path when
+		// logw is closed). A non-nil error here means the scanner
+		// aborted early (e.g. bufio.ErrTooLong), which would leave
+		// logr undrained and wedge logw.Write upstream. Surface it so
+		// downstream "copy did not close in time" failures have an
+		// explanation.
+		if err := s.Err(); err != nil {
+			ex.logf("log scanner stopped: %v", err)
+		}
 	}()
 
 	return ex

--- a/pty/ptytest/ptytest.go
+++ b/pty/ptytest/ptytest.go
@@ -132,12 +132,7 @@ func newExpecter(t *testing.T, r io.Reader, name string) outExpecter {
 		for s.Scan() {
 			ex.logf("%q", stripansi.Strip(s.Text()))
 		}
-		// s.Err() returns nil on EOF (the normal shutdown path when
-		// logw is closed). A non-nil error here means the scanner
-		// aborted early (e.g. bufio.ErrTooLong), which would leave
-		// logr undrained and wedge logw.Write upstream. Surface it so
-		// downstream "copy did not close in time" failures have an
-		// explanation.
+		// Surface non-EOF scanner errors; otherwise they're invisible.
 		if err := s.Err(); err != nil {
 			ex.logf("log scanner stopped: %v", err)
 		}


### PR DESCRIPTION
Log `bufio.Scanner.Err()` from the goroutine piping PTY output into `t.Logf`.

Today `for s.Scan()` exits silently on both EOF and on a real read error. If the scanner ever aborts (e.g. `bufio.ErrTooLong` on a >64 KiB line), `logr` stops being drained, `logw.Write` upstream wedges, and the test fails with `copy did not close in time` and no explanation.

`s.Err()` is `nil` on EOF, so the normal path stays quiet. No behavior change.