### PR TITLE
chore: 'go generate' mockgen to use `go tool` wrapper

### DIFF
--- a/agent/agentcontainers/acmock/doc.go
+++ b/agent/agentcontainers/acmock/doc.go
@@ -1,4 +1,4 @@
 // Package acmock contains a mock implementation of agentcontainers.Lister for use in tests.
 package acmock
 
-//go:generate mockgen -destination ./acmock.go -package acmock .. ContainerCLI,DevcontainerCLI,SubAgentClient
+//go:generate go tool mockgen -destination ./acmock.go -package acmock .. ContainerCLI,DevcontainerCLI,SubAgentClient

--- a/aibridge/mcpmock/doc.go
+++ b/aibridge/mcpmock/doc.go
@@ -1,3 +1,3 @@
 package mcpmock
 
-//go:generate mockgen -destination ./mcpmock.go -package mcpmock github.com/coder/aibridge/mcp ServerProxier
+//go:generate go tool mockgen -destination ./mcpmock.go -package mcpmock github.com/coder/aibridge/mcp ServerProxier

--- a/coderd/database/dbmock/doc.go
+++ b/coderd/database/dbmock/doc.go
@@ -1,4 +1,4 @@
 // package dbmock contains a mocked implementation of the database.Store interface for use in tests
 package dbmock
 
-//go:generate mockgen -destination ./dbmock.go -package dbmock github.com/coder/coder/v2/coderd/database Store
+//go:generate go tool mockgen -destination ./dbmock.go -package dbmock github.com/coder/coder/v2/coderd/database Store

--- a/coderd/database/pubsub/psmock/doc.go
+++ b/coderd/database/pubsub/psmock/doc.go
@@ -1,4 +1,4 @@
 // package psmock contains a mocked implementation of the pubsub.Pubsub interface for use in tests
 package psmock
 
-//go:generate mockgen -destination ./psmock.go -package psmock github.com/coder/coder/v2/coderd/database/pubsub Pubsub
+//go:generate go tool mockgen -destination ./psmock.go -package psmock github.com/coder/coder/v2/coderd/database/pubsub Pubsub

--- a/coderd/dynamicparameters/rendermock/mock.go
+++ b/coderd/dynamicparameters/rendermock/mock.go
@@ -1,2 +1,2 @@
-//go:generate mockgen -destination ./rendermock.go -package rendermock github.com/coder/coder/v2/coderd/dynamicparameters Renderer
+//go:generate go tool mockgen -destination ./rendermock.go -package rendermock github.com/coder/coder/v2/coderd/dynamicparameters Renderer
 package rendermock

--- a/coderd/notifications/notificationsmock/doc.go
+++ b/coderd/notifications/notificationsmock/doc.go
@@ -2,4 +2,4 @@
 // notifications.Enqueuer interface for use in tests.
 package notificationsmock
 
-//go:generate mockgen -destination ./notificationsmock.go -package notificationsmock github.com/coder/coder/v2/coderd/notifications Enqueuer
+//go:generate go tool mockgen -destination ./notificationsmock.go -package notificationsmock github.com/coder/coder/v2/coderd/notifications Enqueuer

--- a/codersdk/workspacesdk/agentconnmock/doc.go
+++ b/codersdk/workspacesdk/agentconnmock/doc.go
@@ -1,4 +1,4 @@
 // Package agentconnmock contains a mock implementation of workspacesdk.AgentConn for use in tests.
 package agentconnmock
 
-//go:generate mockgen -destination ./agentconnmock.go -package agentconnmock .. AgentConn
+//go:generate go tool mockgen -destination ./agentconnmock.go -package agentconnmock .. AgentConn

--- a/enterprise/aibridged/aibridgedmock/doc.go
+++ b/enterprise/aibridged/aibridgedmock/doc.go
@@ -1,4 +1,4 @@
 package aibridgedmock
 
-//go:generate mockgen -destination ./clientmock.go -package aibridgedmock github.com/coder/coder/v2/enterprise/aibridged DRPCClient
-//go:generate mockgen -destination ./poolmock.go -package aibridgedmock github.com/coder/coder/v2/enterprise/aibridged Pooler
+//go:generate go tool mockgen -destination ./clientmock.go -package aibridgedmock github.com/coder/coder/v2/enterprise/aibridged DRPCClient
+//go:generate go tool mockgen -destination ./poolmock.go -package aibridgedmock github.com/coder/coder/v2/enterprise/aibridged Pooler

--- a/tailnet/tailnettest/tailnettest.go
+++ b/tailnet/tailnettest/tailnettest.go
@@ -24,10 +24,10 @@ import (
 	"github.com/coder/coder/v2/testutil"
 )
 
-//go:generate mockgen -destination ./coordinatormock.go -package tailnettest github.com/coder/coder/v2/tailnet Coordinator
-//go:generate mockgen -destination ./coordinateemock.go -package tailnettest github.com/coder/coder/v2/tailnet Coordinatee
-//go:generate mockgen -destination ./workspaceupdatesprovidermock.go -package tailnettest github.com/coder/coder/v2/tailnet WorkspaceUpdatesProvider
-//go:generate mockgen -destination ./subscriptionmock.go -package tailnettest github.com/coder/coder/v2/tailnet Subscription
+//go:generate go tool mockgen -destination ./coordinatormock.go -package tailnettest github.com/coder/coder/v2/tailnet Coordinator
+//go:generate go tool mockgen -destination ./coordinateemock.go -package tailnettest github.com/coder/coder/v2/tailnet Coordinatee
+//go:generate go tool mockgen -destination ./workspaceupdatesprovidermock.go -package tailnettest github.com/coder/coder/v2/tailnet WorkspaceUpdatesProvider
+//go:generate go tool mockgen -destination ./subscriptionmock.go -package tailnettest github.com/coder/coder/v2/tailnet Subscription
 
 type derpAndSTUNCfg struct {
 	DisableSTUN    bool


### PR DESCRIPTION
Calling `mockgen` relies on the executable in the `$PATH`. Using `go tool` uses the one defined in `go.mod`