### PR TITLE
fix(site/src/pages/AgentsPage): widen inline desktop preview to fill chat

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatElements/tools/InlineDesktopPreview.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/InlineDesktopPreview.tsx
@@ -6,7 +6,7 @@ import {
 	type UseDesktopConnectionResult,
 	useDesktopConnection,
 } from "#/pages/AgentsPage/hooks/useDesktopConnection";
-import { DEFAULT_ASPECT, PREVIEW_HEIGHT } from "./previewConstants";
+import { DEFAULT_ASPECT } from "./previewConstants";
 
 /**
  * Non-interactive inline VNC desktop preview. The noVNC canvas is
@@ -98,8 +98,8 @@ export const InlineDesktopPreview: React.FC<{
 	if (status === "idle" || status === "connecting") {
 		return wrapWithOverlay(
 			<div
-				className="flex items-center justify-center text-content-secondary"
-				style={{ aspectRatio: DEFAULT_ASPECT, height: PREVIEW_HEIGHT }}
+				className="flex w-full items-center justify-center text-content-secondary"
+				style={{ aspectRatio: DEFAULT_ASPECT }}
 			>
 				<Spinner loading className="h-5 w-5" />
 			</div>,
@@ -109,8 +109,8 @@ export const InlineDesktopPreview: React.FC<{
 	if (status === "disconnected") {
 		return wrapWithOverlay(
 			<div
-				className="flex items-center justify-center text-xs text-content-secondary"
-				style={{ aspectRatio, height: PREVIEW_HEIGHT }}
+				className="flex w-full items-center justify-center text-xs text-content-secondary"
+				style={{ aspectRatio }}
 			>
 				Desktop disconnected. Reconnecting…
 			</div>,
@@ -120,8 +120,8 @@ export const InlineDesktopPreview: React.FC<{
 	if (status === "error") {
 		return wrapWithOverlay(
 			<div
-				className="flex items-center justify-center text-xs text-content-secondary"
-				style={{ aspectRatio: DEFAULT_ASPECT, height: PREVIEW_HEIGHT }}
+				className="flex w-full items-center justify-center text-xs text-content-secondary"
+				style={{ aspectRatio: DEFAULT_ASPECT }}
 			>
 				Could not connect to desktop.
 			</div>,
@@ -136,8 +136,8 @@ export const InlineDesktopPreview: React.FC<{
 				containerRef.current = el;
 				if (el) attach(el);
 			}}
-			className="pointer-events-none"
-			style={{ aspectRatio, height: PREVIEW_HEIGHT }}
+			className="pointer-events-none w-full"
+			style={{ aspectRatio }}
 		/>,
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
@@ -244,7 +244,7 @@ export const SubagentTool: React.FC<{
 			</button>
 
 			{showDesktopPreview && desktopChatId && toolStatus !== "completed" && (
-				<div className="mt-1.5 w-fit overflow-hidden rounded-lg border border-solid border-border-default">
+				<div className="mt-1.5 overflow-hidden rounded-lg border border-solid border-border-default">
 					<InlineDesktopPreview
 						chatId={desktopChatId}
 						onClick={onOpenDesktop}


### PR DESCRIPTION
Restores the pre-#23780 sizing for the live VNC preview shown while a computer-use subagent is running so it fills the available chat width again, with height derived from the remote framebuffer's aspect ratio instead of a fixed 128 px thumbnail.

In the `WithWaitAgentComputerUseVNC` storybook (chat layout, 1400 px viewport), the preview area goes from ~229 x 130 px to ~768 x 433 px. The recording preview (shown after the subagent completes) is unchanged.

Closes [CODAGT-336](https://linear.app/codercom/issue/CODAGT-336/make-desktop-preview-fill-available-chat-width)

<details>
<summary>Coder Agents notes</summary>

Authored on behalf of @ibetitsmike by a Coder Agent.

- Before #23780, `InlineDesktopPreview` rendered with `w-full` and an aspect-ratio style so it spanned the full chat width.
- #23780 wrapped it in `w-fit` and added a fixed `PREVIEW_HEIGHT` (128 px), shrinking it to a thumbnail.
- This change drops the `w-fit` wrapper and the fixed-height style for every preview state (idle/connecting, disconnected, error, connected) so the preview tracks the chat container width again. `PREVIEW_HEIGHT` is still used by `RecordingPreview` and is left in place.

</details>
