### PR TITLE
feat(site/src/pages/AgentsPage): replace agent setup with onboarding wizard

### DIFF
--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -412,6 +412,8 @@ const isChatListQuery = (query: { queryKey: readonly unknown[] }): boolean => {
 	const key = query.queryKey;
 	// Match: ["chats"] (flat list).
 	if (key.length <= 1) return true;
+	// Match: ["chats", "has-archived"] (archived existence check).
+	if (key[1] === "has-archived") return true;
 	// Match: ["chats", <object | undefined>] (infinite query
 	// with optional filter opts like {archived, q}).
 	const segment = key[1];
@@ -498,6 +500,18 @@ const toChatPlanModePayload = (
 	// The API expects an empty string on the wire to clear plan mode.
 	return planMode ?? CLEAR_PLAN_MODE_WIRE_VALUE;
 };
+
+export const hasArchivedChats = () => ({
+	queryKey: [...chatsKey, "has-archived"],
+	queryFn: async () => {
+		const chats = await API.experimental.getChats({
+			limit: 1,
+			q: "archived:true",
+		});
+		return chats.length > 0;
+	},
+	staleTime: 30_000,
+});
 
 export const infiniteChats = (opts?: { q?: string; archived?: boolean }) => {
 	const limit = DEFAULT_CHAT_PAGE_LIMIT;

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -58,6 +58,8 @@ import {
 } from "./AgentChatPageView";
 import type { AgentsOutletContext } from "./AgentsPage";
 import type { ChatMessageInputRef } from "./components/AgentChatInput";
+import { AgentOnboardingDialog } from "./components/AgentOnboarding/AgentOnboardingDialog";
+import { isOnboardingDismissed } from "./components/AgentOnboarding/onboardingState";
 import { AgentSetupNotice } from "./components/AgentSetupNotice";
 import { normalizeChatErrorPayload } from "./components/ChatConversation/chatError";
 import {
@@ -1072,7 +1074,17 @@ const AgentChatPage: FC = () => {
 		hasUserFixableModelProviders,
 	});
 	const isAdmin = permissions.editDeploymentConfig;
+	const [onboardingDismissed, setOnboardingDismissed] = useState(
+		isOnboardingDismissed,
+	);
+	const showOnboarding =
+		isAdmin &&
+		!onboardingDismissed &&
+		providerCount !== undefined &&
+		providerCount === 0;
+
 	const agentSetupNotice = (() => {
+		if (showOnboarding) return undefined;
 		// Admin: show when providers or models are missing
 		if (
 			isAdmin &&
@@ -1539,78 +1551,86 @@ const AgentChatPage: FC = () => {
 	}
 
 	return (
-		<AgentChatPageView
-			agentId={agentId}
-			sendShortcut={getAgentChatSendShortcut(
-				preferencesQuery.data?.agent_chat_send_shortcut,
-				preferencesQuery.isLoading,
+		<>
+			{showOnboarding && (
+				<AgentOnboardingDialog
+					open
+					onClose={() => setOnboardingDismissed(true)}
+				/>
 			)}
-			organizationId={chatQuery.data?.organization_id}
-			chatTitle={chatTitle}
-			parentChat={parentChat}
-			persistedError={persistedError}
-			isArchived={isArchived}
-			chatOwner={chatOwner}
-			workspace={workspace}
-			workspaceAgent={workspaceAgent}
-			chatBuildId={chatQuery.data?.build_id}
-			store={store}
-			editing={editing}
-			effectiveSelectedModel={effectiveSelectedModel}
-			setSelectedModel={setSelectedModel}
-			modelOptions={modelOptions}
-			modelSelectorPlaceholder={modelSelectorPlaceholder}
-			modelSelectorHelp={modelSelectorHelp}
-			agentSetupNotice={agentSetupNotice}
-			hasModelOptions={hasModelOptions}
-			isModelCatalogLoading={isModelCatalogLoading}
-			planModeEnabled={planModeEnabled}
-			onPlanModeToggle={handlePlanModeToggle}
-			compressionThreshold={compressionThreshold}
-			isInputDisabled={isInputDisabled}
-			isSubmissionPending={isSubmissionPending}
-			isInterruptPending={isInterruptPending}
-			workspaceOptions={workspaceOptions}
-			selectedWorkspaceId={selectedWorkspaceId}
-			onWorkspaceChange={handleWorkspaceChange}
-			isWorkspaceLoading={isWorkspaceLoading}
-			isSidebarCollapsed={isSidebarCollapsed}
-			onToggleSidebarCollapsed={onToggleSidebarCollapsed}
-			showSidebarPanel={showSidebarPanel}
-			onSetShowSidebarPanel={handleSetShowSidebarPanel}
-			prNumber={prNumber}
-			diffStatusData={chatQuery.data?.diff_status}
-			debugLoggingEnabled={debugLoggingEnabled}
-			gitWatcher={gitWatcher}
-			sshCommand={sshCommand}
-			handleCommit={handleCommit}
-			handleInterrupt={handleInterrupt}
-			handleDeleteQueuedMessage={handleDeleteQueuedMessage}
-			handlePromoteQueuedMessage={handlePromoteQueuedMessage}
-			onImplementPlan={handleImplementPlan}
-			onSendAskUserQuestionResponse={handleSendAskUserQuestionResponse}
-			handleArchiveAgentAction={handleArchiveAgentAction}
-			handleUnarchiveAgentAction={handleUnarchiveAgentAction}
-			handleArchiveAndDeleteWorkspaceAction={
-				handleArchiveAndDeleteWorkspaceAction
-			}
-			handleRegenerateTitle={handleRegenerateTitle}
-			isRegeneratingTitle={isRegeneratingThisChat}
-			isRegenerateTitleDisabled={isRegenerateTitleDisabled}
-			urlTransform={urlTransform}
-			scrollContainerRef={scrollContainerRef}
-			scrollToBottomRef={scrollToBottomRef}
-			hasMoreMessages={chatMessagesQuery.hasNextPage ?? false}
-			isFetchingMoreMessages={chatMessagesQuery.isFetchingNextPage}
-			onFetchMoreMessages={chatMessagesQuery.fetchNextPage}
-			messageCount={storeMessageCount}
-			desktopChatId={desktopEnabled ? agentId : undefined}
-			mcpServers={mcpServers}
-			selectedMCPServerIds={effectiveMCPServerIds}
-			onMCPSelectionChange={handleMCPSelectionChange}
-			onMCPAuthComplete={handleMCPAuthComplete}
-			lastInjectedContext={chatQuery.data?.last_injected_context}
-		/>
+			<AgentChatPageView
+				agentId={agentId}
+				sendShortcut={getAgentChatSendShortcut(
+					preferencesQuery.data?.agent_chat_send_shortcut,
+					preferencesQuery.isLoading,
+				)}
+				organizationId={chatQuery.data?.organization_id}
+				chatTitle={chatTitle}
+				parentChat={parentChat}
+				persistedError={persistedError}
+				isArchived={isArchived}
+				chatOwner={chatOwner}
+				workspace={workspace}
+				workspaceAgent={workspaceAgent}
+				chatBuildId={chatQuery.data?.build_id}
+				store={store}
+				editing={editing}
+				effectiveSelectedModel={effectiveSelectedModel}
+				setSelectedModel={setSelectedModel}
+				modelOptions={modelOptions}
+				modelSelectorPlaceholder={modelSelectorPlaceholder}
+				modelSelectorHelp={modelSelectorHelp}
+				agentSetupNotice={agentSetupNotice}
+				hasModelOptions={hasModelOptions}
+				isModelCatalogLoading={isModelCatalogLoading}
+				planModeEnabled={planModeEnabled}
+				onPlanModeToggle={handlePlanModeToggle}
+				compressionThreshold={compressionThreshold}
+				isInputDisabled={isInputDisabled}
+				isSubmissionPending={isSubmissionPending}
+				isInterruptPending={isInterruptPending}
+				workspaceOptions={workspaceOptions}
+				selectedWorkspaceId={selectedWorkspaceId}
+				onWorkspaceChange={handleWorkspaceChange}
+				isWorkspaceLoading={isWorkspaceLoading}
+				isSidebarCollapsed={isSidebarCollapsed}
+				onToggleSidebarCollapsed={onToggleSidebarCollapsed}
+				showSidebarPanel={showSidebarPanel}
+				onSetShowSidebarPanel={handleSetShowSidebarPanel}
+				prNumber={prNumber}
+				diffStatusData={chatQuery.data?.diff_status}
+				debugLoggingEnabled={debugLoggingEnabled}
+				gitWatcher={gitWatcher}
+				sshCommand={sshCommand}
+				handleCommit={handleCommit}
+				handleInterrupt={handleInterrupt}
+				handleDeleteQueuedMessage={handleDeleteQueuedMessage}
+				handlePromoteQueuedMessage={handlePromoteQueuedMessage}
+				onImplementPlan={handleImplementPlan}
+				onSendAskUserQuestionResponse={handleSendAskUserQuestionResponse}
+				handleArchiveAgentAction={handleArchiveAgentAction}
+				handleUnarchiveAgentAction={handleUnarchiveAgentAction}
+				handleArchiveAndDeleteWorkspaceAction={
+					handleArchiveAndDeleteWorkspaceAction
+				}
+				handleRegenerateTitle={handleRegenerateTitle}
+				isRegeneratingTitle={isRegeneratingThisChat}
+				isRegenerateTitleDisabled={isRegenerateTitleDisabled}
+				urlTransform={urlTransform}
+				scrollContainerRef={scrollContainerRef}
+				scrollToBottomRef={scrollToBottomRef}
+				hasMoreMessages={chatMessagesQuery.hasNextPage ?? false}
+				isFetchingMoreMessages={chatMessagesQuery.isFetchingNextPage}
+				onFetchMoreMessages={chatMessagesQuery.fetchNextPage}
+				messageCount={storeMessageCount}
+				desktopChatId={desktopEnabled ? agentId : undefined}
+				mcpServers={mcpServers}
+				selectedMCPServerIds={effectiveMCPServerIds}
+				onMCPSelectionChange={handleMCPSelectionChange}
+				onMCPAuthComplete={handleMCPAuthComplete}
+				lastInjectedContext={chatQuery.data?.last_injected_context}
+			/>
+		</>
 	);
 };
 

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -1077,11 +1077,18 @@ const AgentChatPage: FC = () => {
 	const [onboardingDismissed, setOnboardingDismissed] = useState(
 		isOnboardingDismissed,
 	);
-	const showOnboarding =
+	// Latch the wizard open once triggered so that saving a provider
+	// (which changes providerCount) does not close the dialog.
+	const [onboardingActive, setOnboardingActive] = useState(false);
+	const shouldTriggerOnboarding =
 		isAdmin &&
 		!onboardingDismissed &&
 		providerCount !== undefined &&
 		providerCount === 0;
+	if (shouldTriggerOnboarding && !onboardingActive) {
+		setOnboardingActive(true);
+	}
+	const showOnboarding = onboardingActive && !onboardingDismissed;
 
 	const agentSetupNotice = (() => {
 		if (showOnboarding) return undefined;

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -1071,12 +1071,31 @@ const AgentChatPage: FC = () => {
 		hasConfiguredModels,
 		hasUserFixableModelProviders,
 	});
-	const agentSetupNotice =
-		providerCount !== undefined &&
-		modelCount !== undefined &&
-		(providerCount === 0 || modelCount === 0) ? (
-			<AgentSetupNotice providerCount={providerCount} modelCount={modelCount} />
-		) : undefined;
+	const isAdmin = permissions.editDeploymentConfig;
+	const agentSetupNotice = (() => {
+		// Admin: show when providers or models are missing
+		if (
+			isAdmin &&
+			providerCount !== undefined &&
+			modelCount !== undefined &&
+			(providerCount === 0 || modelCount === 0)
+		) {
+			return (
+				<AgentSetupNotice
+					isAdmin
+					providerCount={providerCount}
+					modelCount={modelCount}
+				/>
+			);
+		}
+		// Member: show when no models are available
+		if (!isAdmin && modelCount !== undefined && modelCount === 0) {
+			return (
+				<AgentSetupNotice isAdmin={false} providerCount={0} modelCount={0} />
+			);
+		}
+		return undefined;
+	})();
 	const isSubmissionPending =
 		isSendPending || isEditPending || isInterruptPending;
 	const isChatSettingsPending =

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -448,28 +448,32 @@ export const NoModelOptions: Story = {
 export const MissingProviderAndModelSetup: Story = {
 	render: () => (
 		<StoryAgentChatPageView
-			agentSetupNotice={<AgentSetupNotice providerCount={0} modelCount={0} />}
+			agentSetupNotice={
+				<AgentSetupNotice isAdmin providerCount={0} modelCount={0} />
+			}
 			hasModelOptions={false}
 			modelOptions={[]}
 			isInputDisabled
 		/>
 	),
 	play: async ({ canvasElement }) => {
-		const body = within(canvasElement.ownerDocument.body);
-		const dialog = within(
-			body.getByRole("dialog", { name: "Welcome to Coder Agents" }),
-		);
+		const canvas = within(canvasElement);
 
 		await waitFor(() => {
-			expect(dialog.getByText("Welcome to Coder Agents")).toBeVisible();
+			expect(
+				canvas.getByText((_content, element) => {
+					return (
+						element?.textContent ===
+						"To chat with Coder Agents, set up a provider then add a model."
+					);
+				}),
+			).toBeVisible();
 		});
-		expect(dialog.getByText("Connect a chat provider")).toBeVisible();
-		expect(dialog.getByText("Add a chat model")).toBeVisible();
-		expect(dialog.queryByLabelText("Complete")).not.toBeInTheDocument();
-		expect(
-			dialog.getByRole("link", { name: "Go to Providers" }),
-		).toHaveAttribute("href", "/agents/settings/providers");
-		expect(dialog.getByRole("link", { name: "Go to Models" })).toHaveAttribute(
+		expect(canvas.getByRole("link", { name: "provider" })).toHaveAttribute(
+			"href",
+			"/agents/settings/providers",
+		);
+		expect(canvas.getByRole("link", { name: "model" })).toHaveAttribute(
 			"href",
 			"/agents/settings/models",
 		);
@@ -479,28 +483,28 @@ export const MissingProviderAndModelSetup: Story = {
 export const MissingModelSetup: Story = {
 	render: () => (
 		<StoryAgentChatPageView
-			agentSetupNotice={<AgentSetupNotice providerCount={1} modelCount={0} />}
+			agentSetupNotice={
+				<AgentSetupNotice isAdmin providerCount={1} modelCount={0} />
+			}
 			hasModelOptions={false}
 			modelOptions={[]}
 			isInputDisabled
 		/>
 	),
 	play: async ({ canvasElement }) => {
-		const body = within(canvasElement.ownerDocument.body);
-		const dialog = within(
-			body.getByRole("dialog", { name: "Welcome to Coder Agents" }),
-		);
+		const canvas = within(canvasElement);
 
 		await waitFor(() => {
-			expect(dialog.getByText("Welcome to Coder Agents")).toBeVisible();
+			expect(
+				canvas.getByText((_content, element) => {
+					return (
+						element?.textContent ===
+						"To chat with Coder Agents, set up a model."
+					);
+				}),
+			).toBeVisible();
 		});
-		expect(dialog.getByText("Connect a chat provider")).toBeVisible();
-		expect(dialog.getByText("Add a chat model")).toBeVisible();
-		expect(dialog.getAllByLabelText("Complete")).toHaveLength(1);
-		expect(
-			dialog.getByRole("link", { name: "Go to Providers" }),
-		).toHaveAttribute("href", "/agents/settings/providers");
-		expect(dialog.getByRole("link", { name: "Go to Models" })).toHaveAttribute(
+		expect(canvas.getByRole("link", { name: "model" })).toHaveAttribute(
 			"href",
 			"/agents/settings/models",
 		);
@@ -510,28 +514,52 @@ export const MissingModelSetup: Story = {
 export const MissingProviderSetup: Story = {
 	render: () => (
 		<StoryAgentChatPageView
-			agentSetupNotice={<AgentSetupNotice providerCount={0} modelCount={1} />}
+			agentSetupNotice={
+				<AgentSetupNotice isAdmin providerCount={0} modelCount={1} />
+			}
 		/>
 	),
 	play: async ({ canvasElement }) => {
-		const body = within(canvasElement.ownerDocument.body);
-		const dialog = within(
-			body.getByRole("dialog", { name: "Welcome to Coder Agents" }),
-		);
+		const canvas = within(canvasElement);
 
 		await waitFor(() => {
-			expect(dialog.getByText("Welcome to Coder Agents")).toBeVisible();
+			expect(
+				canvas.getByText((_content, element) => {
+					return (
+						element?.textContent ===
+						"To chat with Coder Agents, set up a provider then add a model."
+					);
+				}),
+			).toBeVisible();
 		});
-		expect(dialog.getByText("Connect a chat provider")).toBeVisible();
-		expect(dialog.getByText("Add a chat model")).toBeVisible();
-		expect(dialog.getAllByLabelText("Complete")).toHaveLength(1);
-		expect(
-			dialog.getByRole("link", { name: "Go to Providers" }),
-		).toHaveAttribute("href", "/agents/settings/providers");
-		expect(dialog.getByRole("link", { name: "Go to Models" })).toHaveAttribute(
+		expect(canvas.getByRole("link", { name: "provider" })).toHaveAttribute(
 			"href",
-			"/agents/settings/models",
+			"/agents/settings/providers",
 		);
+	},
+};
+
+export const MemberNoModelsAvailable: Story = {
+	render: () => (
+		<StoryAgentChatPageView
+			agentSetupNotice={
+				<AgentSetupNotice isAdmin={false} providerCount={0} modelCount={0} />
+			}
+			hasModelOptions={false}
+			modelOptions={[]}
+			isInputDisabled
+		/>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		await waitFor(() => {
+			expect(
+				canvas.getByText(
+					"AI models aren't available yet. Your admin is still getting things set up.",
+				),
+			).toBeVisible();
+		});
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentCreatePage.tsx
+++ b/site/src/pages/AgentsPage/AgentCreatePage.tsx
@@ -72,12 +72,29 @@ const AgentCreatePage: FC = () => {
 		chatModelConfigsQuery.isSuccess && chatModelsQuery.isSuccess
 			? catalogModelOptions.length
 			: undefined;
-	const agentSetupNotice =
-		providerCount !== undefined &&
-		modelCount !== undefined &&
-		(providerCount === 0 || modelCount === 0) ? (
-			<AgentSetupNotice providerCount={providerCount} modelCount={modelCount} />
-		) : undefined;
+	const isAdmin = permissions.editDeploymentConfig;
+	const agentSetupNotice = (() => {
+		if (
+			isAdmin &&
+			providerCount !== undefined &&
+			modelCount !== undefined &&
+			(providerCount === 0 || modelCount === 0)
+		) {
+			return (
+				<AgentSetupNotice
+					isAdmin
+					providerCount={providerCount}
+					modelCount={modelCount}
+				/>
+			);
+		}
+		if (!isAdmin && modelCount !== undefined && modelCount === 0) {
+			return (
+				<AgentSetupNotice isAdmin={false} providerCount={0} modelCount={0} />
+			);
+		}
+		return undefined;
+	})();
 
 	const handleCreateChat = async ({
 		message,

--- a/site/src/pages/AgentsPage/AgentCreatePage.tsx
+++ b/site/src/pages/AgentsPage/AgentCreatePage.tsx
@@ -79,11 +79,16 @@ const AgentCreatePage: FC = () => {
 		isOnboardingDismissed,
 	);
 
-	const showOnboarding =
+	const [onboardingActive, setOnboardingActive] = useState(false);
+	const shouldTriggerOnboarding =
 		isAdmin &&
 		!onboardingDismissed &&
 		providerCount !== undefined &&
 		providerCount === 0;
+	if (shouldTriggerOnboarding && !onboardingActive) {
+		setOnboardingActive(true);
+	}
+	const showOnboarding = onboardingActive && !onboardingDismissed;
 
 	const agentSetupNotice = (() => {
 		if (showOnboarding) return undefined;

--- a/site/src/pages/AgentsPage/AgentCreatePage.tsx
+++ b/site/src/pages/AgentsPage/AgentCreatePage.tsx
@@ -20,6 +20,8 @@ import {
 	AgentCreateForm,
 	type CreateChatOptions,
 } from "./components/AgentCreateForm";
+import { AgentOnboardingDialog } from "./components/AgentOnboarding/AgentOnboardingDialog";
+import { isOnboardingDismissed } from "./components/AgentOnboarding/onboardingState";
 import { AgentPageHeader } from "./components/AgentPageHeader";
 import { AgentSetupNotice } from "./components/AgentSetupNotice";
 import { ChimeButton } from "./components/ChimeButton";
@@ -73,7 +75,18 @@ const AgentCreatePage: FC = () => {
 			? catalogModelOptions.length
 			: undefined;
 	const isAdmin = permissions.editDeploymentConfig;
+	const [onboardingDismissed, setOnboardingDismissed] = useState(
+		isOnboardingDismissed,
+	);
+
+	const showOnboarding =
+		isAdmin &&
+		!onboardingDismissed &&
+		providerCount !== undefined &&
+		providerCount === 0;
+
 	const agentSetupNotice = (() => {
+		if (showOnboarding) return undefined;
 		if (
 			isAdmin &&
 			providerCount !== undefined &&
@@ -157,6 +170,12 @@ const AgentCreatePage: FC = () => {
 
 	return (
 		<>
+			{showOnboarding && (
+				<AgentOnboardingDialog
+					open
+					onClose={() => setOnboardingDismissed(true)}
+				/>
+			)}
 			<AgentPageHeader
 				chimeEnabled={chimeEnabled}
 				onToggleChime={handleChimeToggle}

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -18,6 +18,7 @@ import {
 	chatModelConfigs,
 	chatModels,
 	chatsByWorkspaceKeyPrefix,
+	hasArchivedChats,
 	infiniteChats,
 	invalidateChatListQueries,
 	mergeWatchedChatIntoCaches,
@@ -117,6 +118,7 @@ const AgentsPage: FC = () => {
 	const chatsQuery = useInfiniteQuery(
 		infiniteChats({ archived: archivedFilter === "archived" }),
 	);
+	const hasArchivedQuery = useQuery(hasArchivedChats());
 	// Model queries are kept here for the sidebar, which displays
 	// model info alongside each chat. Child routes that need models
 	// subscribe to the same queries independently, and react-query
@@ -669,6 +671,7 @@ const AgentsPage: FC = () => {
 				isFetchingNextPage={chatsQuery.isFetchingNextPage}
 				archivedFilter={archivedFilter}
 				onArchivedFilterChange={setArchivedFilter}
+				hasArchivedChats={hasArchivedQuery.data ?? false}
 			/>
 			<ConfirmDialog
 				open={pendingArchiveChatId !== null}

--- a/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
@@ -281,6 +281,7 @@ const defaultArgs: ComponentProps<typeof AgentsPageView> = {
 	isAgentsAdmin: false,
 	archivedFilter: "active",
 	onArchivedFilterChange: fn(),
+	hasArchivedChats: false,
 	hasNextPage: false,
 	onLoadMore: fn(),
 	isFetchingNextPage: false,

--- a/site/src/pages/AgentsPage/AgentsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.tsx
@@ -75,6 +75,7 @@ interface AgentsPageViewProps {
 	isFetchingNextPage: boolean;
 	archivedFilter: "active" | "archived";
 	onArchivedFilterChange: (filter: "active" | "archived") => void;
+	hasArchivedChats: boolean;
 }
 
 export const AgentsPageView: FC<AgentsPageViewProps> = ({
@@ -113,6 +114,7 @@ export const AgentsPageView: FC<AgentsPageViewProps> = ({
 	isFetchingNextPage,
 	archivedFilter,
 	onArchivedFilterChange,
+	hasArchivedChats,
 }) => {
 	const location = useLocation();
 	const sidebarView = sidebarViewFromPath(location.pathname);
@@ -199,6 +201,7 @@ export const AgentsPageView: FC<AgentsPageViewProps> = ({
 					isFetchingNextPage={isFetchingNextPage}
 					archivedFilter={archivedFilter}
 					onArchivedFilterChange={onArchivedFilterChange}
+					hasArchivedChats={hasArchivedChats}
 					onCollapse={onCollapseSidebar}
 					isPersonalModelOverridesEnabled={isPersonalModelOverridesEnabled}
 					isAdmin={isAgentsAdmin}

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -895,10 +895,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 				/>
 			)}
 			{agentSetupNotice && (
-				<div
-					className="relative z-0 mb-[-2rem]"
-					style={{ clipPath: "inset(0 0 2rem 0)" }}
-				>
+				<div className="relative z-0 mb-[-2.5rem]">
 					{agentSetupNotice}
 				</div>
 			)}
@@ -907,6 +904,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 				data-testid="chat-composer"
 				className={cn(
 					"relative z-10 rounded-2xl border border-border-default/80 bg-surface-secondary sm:bg-surface-secondary/45 p-1 shadow-sm has-[textarea:focus]:ring-2 has-[textarea:focus]:ring-content-link/40",
+					agentSetupNotice && "sm:bg-surface-secondary",
 					isDragging && "ring-2 ring-content-link/40",
 					isEditingHistoryMessage &&
 						"shadow-[0_0_0_2px_hsla(var(--border-warning),0.6)]",

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -895,7 +895,12 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 				/>
 			)}
 			{agentSetupNotice && (
-				<div className="relative z-0 mb-[-1rem]">{agentSetupNotice}</div>
+				<div
+					className="relative z-0 mb-[-2rem]"
+					style={{ clipPath: "inset(0 0 2rem 0)" }}
+				>
+					{agentSetupNotice}
+				</div>
 			)}
 			<div
 				ref={setComposerElement}

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -904,7 +904,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 				data-testid="chat-composer"
 				className={cn(
 					"relative z-10 rounded-2xl border border-border-default/80 bg-surface-secondary sm:bg-surface-secondary/45 p-1 shadow-sm has-[textarea:focus]:ring-2 has-[textarea:focus]:ring-content-link/40",
-					agentSetupNotice && "sm:bg-surface-secondary",
+					agentSetupNotice && "sm:bg-[#0F0F12]",
 					isDragging && "ring-2 ring-content-link/40",
 					isEditingHistoryMessage &&
 						"shadow-[0_0_0_2px_hsla(var(--border-warning),0.6)]",

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -183,6 +183,7 @@ interface AgentChatInputProps {
 	sshCommand?: string;
 	attachedWorkspace?: AttachedWorkspaceInfo;
 	folder?: string;
+	agentSetupNotice?: React.ReactNode;
 }
 
 export interface AttachedWorkspaceInfo {
@@ -342,6 +343,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	sshCommand,
 	attachedWorkspace,
 	folder,
+	agentSetupNotice,
 }) => {
 	const [chatFullWidth] = useChatFullWidth();
 	const internalRef = useRef<ChatMessageInputRef>(null);
@@ -892,11 +894,14 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 					className="mb-2"
 				/>
 			)}
+			{agentSetupNotice && (
+				<div className="relative z-0 mb-[-1rem]">{agentSetupNotice}</div>
+			)}
 			<div
 				ref={setComposerElement}
 				data-testid="chat-composer"
 				className={cn(
-					"rounded-2xl border border-border-default/80 bg-surface-secondary sm:bg-surface-secondary/45 p-1 shadow-sm has-[textarea:focus]:ring-2 has-[textarea:focus]:ring-content-link/40",
+					"relative z-10 rounded-2xl border border-border-default/80 bg-surface-secondary sm:bg-surface-secondary/45 p-1 shadow-sm has-[textarea:focus]:ring-2 has-[textarea:focus]:ring-content-link/40",
 					isDragging && "ring-2 ring-content-link/40",
 					isEditingHistoryMessage &&
 						"shadow-[0_0_0_2px_hsla(var(--border-warning),0.6)]",

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -471,28 +471,32 @@ export const NoModelsConfigured: Story = {
 export const MissingProviderAndModelSetup: Story = {
 	args: {
 		...defaultArgs,
-		agentSetupNotice: <AgentSetupNotice providerCount={0} modelCount={0} />,
+		agentSetupNotice: (
+			<AgentSetupNotice isAdmin providerCount={0} modelCount={0} />
+		),
 		modelCatalog: { providers: [] },
 		modelOptions: [],
 		isModelCatalogLoading: false,
 		isModelConfigsLoading: false,
 	},
 	play: async ({ canvasElement }) => {
-		const body = within(canvasElement.ownerDocument.body);
-		const dialog = within(
-			body.getByRole("dialog", { name: "Welcome to Coder Agents" }),
-		);
+		const canvas = within(canvasElement);
 
 		await waitFor(() => {
-			expect(dialog.getByText("Welcome to Coder Agents")).toBeVisible();
+			expect(
+				canvas.getByText((_content, element) => {
+					return (
+						element?.textContent ===
+						"To chat with Coder Agents, set up a provider then add a model."
+					);
+				}),
+			).toBeVisible();
 		});
-		expect(dialog.getByText("Connect a chat provider")).toBeVisible();
-		expect(dialog.getByText("Add a chat model")).toBeVisible();
-		expect(dialog.queryByLabelText("Complete")).not.toBeInTheDocument();
-		expect(
-			dialog.getByRole("link", { name: "Go to Providers" }),
-		).toHaveAttribute("href", "/agents/settings/providers");
-		expect(dialog.getByRole("link", { name: "Go to Models" })).toHaveAttribute(
+		expect(canvas.getByRole("link", { name: "provider" })).toHaveAttribute(
+			"href",
+			"/agents/settings/providers",
+		);
+		expect(canvas.getByRole("link", { name: "model" })).toHaveAttribute(
 			"href",
 			"/agents/settings/models",
 		);

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -510,7 +510,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						/>
 					)}
 					{agentSetupNotice}
-					<div className={agentSetupNotice ? "relative z-10 -mt-10" : undefined}>
+					<div className={agentSetupNotice ? "relative z-10 -mt-14" : undefined}>
 						<AgentChatInput
 							onSend={handleSendWithAttachments}
 							sendShortcut={sendShortcut}

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -510,7 +510,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						/>
 					)}
 					{agentSetupNotice}
-					<div className={agentSetupNotice ? "relative z-10 -mt-10" : undefined}>
+					<div className={agentSetupNotice ? "relative z-10 -mt-10 [&_[data-testid=chat-composer]]:bg-surface-secondary" : undefined}>
 						<AgentChatInput
 							onSend={handleSendWithAttachments}
 							sendShortcut={sendShortcut}

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -510,7 +510,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						/>
 					)}
 					{agentSetupNotice}
-					<div className={agentSetupNotice ? "relative z-10 -mt-10 [&_[data-testid=chat-composer]]:bg-surface-secondary" : undefined}>
+					<div className={agentSetupNotice ? "relative z-10 -mt-10" : undefined}>
 						<AgentChatInput
 							onSend={handleSendWithAttachments}
 							sendShortcut={sendShortcut}

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -509,88 +509,44 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 							}}
 						/>
 					)}
-					{agentSetupNotice ? (
-						<div className="relative">
-							{agentSetupNotice}
-							<div className="relative z-10 mt-[-2.25rem]">
-								<AgentChatInput
-									onSend={handleSendWithAttachments}
-									sendShortcut={sendShortcut}
-									placeholder="Ask Coder to build, fix bugs, or explore your project..."
-									isDisabled={
-										isCreating || isForbidden || isPersonalModelOverridesLoading
-									}
-									isLoading={isCreating}
-									initialValue={initialInputValue}
-									initialEditorState={initialEditorState}
-									onContentChange={handleContentChange}
-									selectedModel={selectedModel}
-									onModelChange={handleModelChange}
-									modelOptions={modelOptions}
-									modelSelectorPlaceholder={modelSelectorPlaceholder}
-									isModelCatalogLoading={isModelCatalogLoading}
-									hasModelOptions={hasModelOptions}
-									planModeEnabled={planModeEnabled}
-									onPlanModeToggle={setPlanModeEnabled}
-									attachments={attachments}
-									onAttach={handleAttach}
-									onRemoveAttachment={handleRemoveAttachment}
-									uploadStates={uploadStates}
-									previewUrls={previewUrls}
-									textContents={textContents}
-									mcpServers={mcpServers}
-									selectedMCPServerIds={effectiveMCPServerIds}
-									onMCPSelectionChange={(ids) => {
-										setUserMCPServerIds(ids);
-										saveMCPSelection(ids);
-									}}
-									onMCPAuthComplete={onMCPAuthComplete}
-									workspaceOptions={filteredWorkspaces}
-									selectedWorkspaceId={effectiveWorkspaceId}
-									onWorkspaceChange={handleWorkspaceChange}
-									isWorkspaceLoading={isWorkspacesLoading}
-								/>
-							</div>
-						</div>
-					) : (
-						<AgentChatInput
-							onSend={handleSendWithAttachments}
-							sendShortcut={sendShortcut}
-							placeholder="Ask Coder to build, fix bugs, or explore your project..."
-							isDisabled={
-								isCreating || isForbidden || isPersonalModelOverridesLoading
-							}
-							isLoading={isCreating}
-							initialValue={initialInputValue}
-							initialEditorState={initialEditorState}
-							onContentChange={handleContentChange}
-							selectedModel={selectedModel}
-							onModelChange={handleModelChange}
-							modelOptions={modelOptions}
-							modelSelectorPlaceholder={modelSelectorPlaceholder}
-							isModelCatalogLoading={isModelCatalogLoading}
-							hasModelOptions={hasModelOptions}
-							planModeEnabled={planModeEnabled}
-							onPlanModeToggle={setPlanModeEnabled}
-							attachments={attachments}
-							onAttach={handleAttach}
-							onRemoveAttachment={handleRemoveAttachment}
-							uploadStates={uploadStates}
-							previewUrls={previewUrls}
-							textContents={textContents}
-							mcpServers={mcpServers}
-							selectedMCPServerIds={effectiveMCPServerIds}
-							onMCPSelectionChange={(ids) => {
-								setUserMCPServerIds(ids);
-								saveMCPSelection(ids);
-							}}
-							onMCPAuthComplete={onMCPAuthComplete}
-							workspaceOptions={filteredWorkspaces}
-							selectedWorkspaceId={effectiveWorkspaceId}
-							onWorkspaceChange={handleWorkspaceChange}
-							isWorkspaceLoading={isWorkspacesLoading}
-						/>
-					)}
+					<AgentChatInput
+						onSend={handleSendWithAttachments}
+						sendShortcut={sendShortcut}
+						placeholder="Ask Coder to build, fix bugs, or explore your project..."
+						isDisabled={
+							isCreating || isForbidden || isPersonalModelOverridesLoading
+						}
+						isLoading={isCreating}
+						initialValue={initialInputValue}
+						initialEditorState={initialEditorState}
+						onContentChange={handleContentChange}
+						selectedModel={selectedModel}
+						onModelChange={handleModelChange}
+						modelOptions={modelOptions}
+						modelSelectorPlaceholder={modelSelectorPlaceholder}
+						isModelCatalogLoading={isModelCatalogLoading}
+						hasModelOptions={hasModelOptions}
+						planModeEnabled={planModeEnabled}
+						onPlanModeToggle={setPlanModeEnabled}
+						attachments={attachments}
+						onAttach={handleAttach}
+						onRemoveAttachment={handleRemoveAttachment}
+						uploadStates={uploadStates}
+						previewUrls={previewUrls}
+						textContents={textContents}
+						mcpServers={mcpServers}
+						selectedMCPServerIds={effectiveMCPServerIds}
+						onMCPSelectionChange={(ids) => {
+							setUserMCPServerIds(ids);
+							saveMCPSelection(ids);
+						}}
+						onMCPAuthComplete={onMCPAuthComplete}
+						workspaceOptions={filteredWorkspaces}
+						selectedWorkspaceId={effectiveWorkspaceId}
+						onWorkspaceChange={handleWorkspaceChange}
+						isWorkspaceLoading={isWorkspacesLoading}
+						agentSetupNotice={agentSetupNotice}
+					/>
 					{modelSelectorHelp ? (
 						<div className="px-3 pt-1 text-2xs text-content-secondary">
 							{modelSelectorHelp}

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -509,8 +509,50 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 							}}
 						/>
 					)}
-					{agentSetupNotice}
-					<div className={agentSetupNotice ? "relative z-10 -mt-14" : undefined}>
+					{agentSetupNotice ? (
+						<div className="relative">
+							{agentSetupNotice}
+							<div className="relative z-10 mt-[-2.25rem]">
+								<AgentChatInput
+									onSend={handleSendWithAttachments}
+									sendShortcut={sendShortcut}
+									placeholder="Ask Coder to build, fix bugs, or explore your project..."
+									isDisabled={
+										isCreating || isForbidden || isPersonalModelOverridesLoading
+									}
+									isLoading={isCreating}
+									initialValue={initialInputValue}
+									initialEditorState={initialEditorState}
+									onContentChange={handleContentChange}
+									selectedModel={selectedModel}
+									onModelChange={handleModelChange}
+									modelOptions={modelOptions}
+									modelSelectorPlaceholder={modelSelectorPlaceholder}
+									isModelCatalogLoading={isModelCatalogLoading}
+									hasModelOptions={hasModelOptions}
+									planModeEnabled={planModeEnabled}
+									onPlanModeToggle={setPlanModeEnabled}
+									attachments={attachments}
+									onAttach={handleAttach}
+									onRemoveAttachment={handleRemoveAttachment}
+									uploadStates={uploadStates}
+									previewUrls={previewUrls}
+									textContents={textContents}
+									mcpServers={mcpServers}
+									selectedMCPServerIds={effectiveMCPServerIds}
+									onMCPSelectionChange={(ids) => {
+										setUserMCPServerIds(ids);
+										saveMCPSelection(ids);
+									}}
+									onMCPAuthComplete={onMCPAuthComplete}
+									workspaceOptions={filteredWorkspaces}
+									selectedWorkspaceId={effectiveWorkspaceId}
+									onWorkspaceChange={handleWorkspaceChange}
+									isWorkspaceLoading={isWorkspacesLoading}
+								/>
+							</div>
+						</div>
+					) : (
 						<AgentChatInput
 							onSend={handleSendWithAttachments}
 							sendShortcut={sendShortcut}
@@ -548,7 +590,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 							onWorkspaceChange={handleWorkspaceChange}
 							isWorkspaceLoading={isWorkspacesLoading}
 						/>
-					</div>
+					)}
 					{modelSelectorHelp ? (
 						<div className="px-3 pt-1 text-2xs text-content-secondary">
 							{modelSelectorHelp}

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -510,7 +510,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						/>
 					)}
 					{agentSetupNotice}
-					<div className={agentSetupNotice ? "relative -mt-3" : undefined}>
+					<div className={agentSetupNotice ? "relative z-10 -mt-6" : undefined}>
 						<AgentChatInput
 							onSend={handleSendWithAttachments}
 							sendShortcut={sendShortcut}

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -510,7 +510,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						/>
 					)}
 					{agentSetupNotice}
-					<div className={agentSetupNotice ? "relative z-10 -mt-6" : undefined}>
+					<div className={agentSetupNotice ? "relative z-10 -mt-10" : undefined}>
 						<AgentChatInput
 							onSend={handleSendWithAttachments}
 							sendShortcut={sendShortcut}

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -510,43 +510,45 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						/>
 					)}
 					{agentSetupNotice}
-					<AgentChatInput
-						onSend={handleSendWithAttachments}
-						sendShortcut={sendShortcut}
-						placeholder="Ask Coder to build, fix bugs, or explore your project..."
-						isDisabled={
-							isCreating || isForbidden || isPersonalModelOverridesLoading
-						}
-						isLoading={isCreating}
-						initialValue={initialInputValue}
-						initialEditorState={initialEditorState}
-						onContentChange={handleContentChange}
-						selectedModel={selectedModel}
-						onModelChange={handleModelChange}
-						modelOptions={modelOptions}
-						modelSelectorPlaceholder={modelSelectorPlaceholder}
-						isModelCatalogLoading={isModelCatalogLoading}
-						hasModelOptions={hasModelOptions}
-						planModeEnabled={planModeEnabled}
-						onPlanModeToggle={setPlanModeEnabled}
-						attachments={attachments}
-						onAttach={handleAttach}
-						onRemoveAttachment={handleRemoveAttachment}
-						uploadStates={uploadStates}
-						previewUrls={previewUrls}
-						textContents={textContents}
-						mcpServers={mcpServers}
-						selectedMCPServerIds={effectiveMCPServerIds}
-						onMCPSelectionChange={(ids) => {
-							setUserMCPServerIds(ids);
-							saveMCPSelection(ids);
-						}}
-						onMCPAuthComplete={onMCPAuthComplete}
-						workspaceOptions={filteredWorkspaces}
-						selectedWorkspaceId={effectiveWorkspaceId}
-						onWorkspaceChange={handleWorkspaceChange}
-						isWorkspaceLoading={isWorkspacesLoading}
-					/>
+					<div className={agentSetupNotice ? "relative -mt-3" : undefined}>
+						<AgentChatInput
+							onSend={handleSendWithAttachments}
+							sendShortcut={sendShortcut}
+							placeholder="Ask Coder to build, fix bugs, or explore your project..."
+							isDisabled={
+								isCreating || isForbidden || isPersonalModelOverridesLoading
+							}
+							isLoading={isCreating}
+							initialValue={initialInputValue}
+							initialEditorState={initialEditorState}
+							onContentChange={handleContentChange}
+							selectedModel={selectedModel}
+							onModelChange={handleModelChange}
+							modelOptions={modelOptions}
+							modelSelectorPlaceholder={modelSelectorPlaceholder}
+							isModelCatalogLoading={isModelCatalogLoading}
+							hasModelOptions={hasModelOptions}
+							planModeEnabled={planModeEnabled}
+							onPlanModeToggle={setPlanModeEnabled}
+							attachments={attachments}
+							onAttach={handleAttach}
+							onRemoveAttachment={handleRemoveAttachment}
+							uploadStates={uploadStates}
+							previewUrls={previewUrls}
+							textContents={textContents}
+							mcpServers={mcpServers}
+							selectedMCPServerIds={effectiveMCPServerIds}
+							onMCPSelectionChange={(ids) => {
+								setUserMCPServerIds(ids);
+								saveMCPSelection(ids);
+							}}
+							onMCPAuthComplete={onMCPAuthComplete}
+							workspaceOptions={filteredWorkspaces}
+							selectedWorkspaceId={effectiveWorkspaceId}
+							onWorkspaceChange={handleWorkspaceChange}
+							isWorkspaceLoading={isWorkspacesLoading}
+						/>
+					</div>
 					{modelSelectorHelp ? (
 						<div className="px-3 pt-1 text-2xs text-content-secondary">
 							{modelSelectorHelp}

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/AgentOnboardingDialog.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/AgentOnboardingDialog.tsx
@@ -45,7 +45,9 @@ export const AgentOnboardingDialog: FC<AgentOnboardingDialogProps> = ({
 		<Dialog open={open}>
 			<DialogContent
 				className={
-					step === "extend" ? "max-w-5xl gap-0 p-8" : "max-w-3xl gap-0 p-8"
+					step === "extend"
+					? "max-w-5xl gap-0 p-6"
+					: "max-w-3xl gap-0 p-6"
 				}
 				onEscapeKeyDown={preventClose}
 				onPointerDownOutside={preventClose}

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/AgentOnboardingDialog.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/AgentOnboardingDialog.tsx
@@ -1,0 +1,75 @@
+import { type FC, useState } from "react";
+import { useQuery } from "react-query";
+import { chatModelConfigs, chatProviderConfigs } from "#/api/queries/chats";
+import { Dialog, DialogContent } from "#/components/Dialog/Dialog";
+import { ExtendStep } from "./ExtendStep";
+import { ModelStep } from "./ModelStep";
+import { dismissOnboarding } from "./onboardingState";
+import { ProviderStep } from "./ProviderStep";
+
+type WizardStep = "provider" | "model" | "extend";
+
+interface AgentOnboardingDialogProps {
+	open: boolean;
+	onClose: () => void;
+}
+
+export const AgentOnboardingDialog: FC<AgentOnboardingDialogProps> = ({
+	open,
+	onClose,
+}) => {
+	const [step, setStep] = useState<WizardStep>("provider");
+
+	const providerConfigsQuery = useQuery(chatProviderConfigs());
+	const modelConfigsQuery = useQuery(chatModelConfigs());
+
+	const savedProviders = providerConfigsQuery.data ?? [];
+	const savedModels = modelConfigsQuery.data ?? [];
+
+	const handleSkip = () => {
+		dismissOnboarding();
+		onClose();
+	};
+
+	const handleFinish = () => {
+		dismissOnboarding();
+		onClose();
+	};
+
+	// Prevent closing via escape or clicking outside.
+	const preventClose = (event: Event) => {
+		event.preventDefault();
+	};
+
+	return (
+		<Dialog open={open}>
+			<DialogContent
+				className={
+					step === "extend" ? "max-w-5xl gap-0 p-8" : "max-w-3xl gap-0 p-8"
+				}
+				onEscapeKeyDown={preventClose}
+				onPointerDownOutside={preventClose}
+			>
+				{step === "provider" && (
+					<ProviderStep
+						savedProviders={savedProviders}
+						onSkip={handleSkip}
+						onContinue={() => setStep("model")}
+					/>
+				)}
+				{step === "model" && (
+					<ModelStep
+						savedProviders={savedProviders}
+						savedModels={savedModels}
+						onBack={() => setStep("provider")}
+						onSkip={handleSkip}
+						onContinue={() => setStep("extend")}
+					/>
+				)}
+				{step === "extend" && (
+					<ExtendStep onBack={() => setStep("model")} onFinish={handleFinish} />
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/AgentOnboardingDialog.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/AgentOnboardingDialog.tsx
@@ -45,16 +45,13 @@ export const AgentOnboardingDialog: FC<AgentOnboardingDialogProps> = ({
 		<Dialog open={open}>
 			<DialogContent
 				className={
-					step === "extend"
-					? "max-w-5xl gap-0 p-6"
-					: "max-w-3xl gap-0 p-6"
+					step === "extend" ? "max-w-5xl gap-0 p-6" : "max-w-3xl gap-0 p-6"
 				}
 				onEscapeKeyDown={preventClose}
 				onPointerDownOutside={preventClose}
 			>
 				{step === "provider" && (
 					<ProviderStep
-						savedProviders={savedProviders}
 						onSkip={handleSkip}
 						onContinue={() => setStep("model")}
 					/>

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ExtendStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ExtendStep.tsx
@@ -35,15 +35,13 @@ export const ExtendStep: FC<ExtendStepProps> = ({ onBack, onFinish }) => {
 			</div>
 
 			<div className="flex items-center justify-between">
-				<span
+				<button
+					type="button"
 					onClick={onBack}
-					onKeyDown={(e) => e.key === "Enter" && e.currentTarget.click()}
-					role="button"
-					tabIndex={0}
-					className="cursor-pointer text-sm text-content-secondary transition-colors hover:text-content-primary"
+					className="m-0 cursor-pointer border-none bg-transparent p-0 text-sm text-content-secondary transition-colors hover:text-content-primary"
 				>
 					Back
-				</span>
+				</button>
 				<Button onClick={onFinish}>Start chatting</Button>
 			</div>
 		</div>

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ExtendStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ExtendStep.tsx
@@ -35,11 +35,7 @@ export const ExtendStep: FC<ExtendStepProps> = ({ onBack, onFinish }) => {
 			</div>
 
 			<div className="flex items-center justify-between">
-				<Button
-					variant="subtle"
-					className="min-w-0 px-0"
-					onClick={onBack}
-				>
+				<Button variant="subtle" className="min-w-0 px-0" onClick={onBack}>
 					Back
 				</Button>
 				<Button onClick={onFinish}>Start chatting</Button>

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ExtendStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ExtendStep.tsx
@@ -35,13 +35,13 @@ export const ExtendStep: FC<ExtendStepProps> = ({ onBack, onFinish }) => {
 			</div>
 
 			<div className="flex items-center justify-between">
-				<button
-					type="button"
+				<Button
+					variant="subtle"
+					className="min-w-0 px-0"
 					onClick={onBack}
-					className="m-0 cursor-pointer border-none bg-transparent p-0 text-sm text-content-secondary transition-colors hover:text-content-primary"
 				>
 					Back
-				</button>
+				</Button>
 				<Button onClick={onFinish}>Start chatting</Button>
 			</div>
 		</div>

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ExtendStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ExtendStep.tsx
@@ -35,9 +35,13 @@ export const ExtendStep: FC<ExtendStepProps> = ({ onBack, onFinish }) => {
 			</div>
 
 			<div className="flex items-center justify-between">
-				<Button variant="outline" onClick={onBack}>
+				<button
+					type="button"
+					onClick={onBack}
+					className="text-sm text-content-secondary transition-colors hover:text-content-primary"
+				>
 					Back
-				</Button>
+				</button>
 				<Button onClick={onFinish}>Start chatting</Button>
 			</div>
 		</div>

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ExtendStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ExtendStep.tsx
@@ -1,0 +1,76 @@
+import { ExternalLinkIcon } from "lucide-react";
+import type { FC } from "react";
+import { Link } from "react-router";
+import { Button } from "#/components/Button/Button";
+
+interface ExtendStepProps {
+	onBack: () => void;
+	onFinish: () => void;
+}
+
+export const ExtendStep: FC<ExtendStepProps> = ({ onBack, onFinish }) => {
+	return (
+		<div className="flex flex-col gap-8">
+			<h2 className="text-2xl font-semibold">Extend Coder Agents</h2>
+
+			<div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+				<FeatureCard
+					title="Set up instructions"
+					description="Control the system prompts and plan mode instructions used across the deployment."
+					linkText="Add instructions"
+					linkTo="/agents/settings/instructions"
+				/>
+				<FeatureCard
+					title="Add MCP servers"
+					description="Configure and extend agent behavior with centrally managed MCP tools, skills, and policies."
+					linkText="Configure MCP servers"
+					linkTo="/agents/settings/mcp-servers"
+				/>
+				<FeatureCard
+					title="Control templates"
+					description="Restrict which templates agents can use to create workspaces."
+					linkText="Select templates"
+					linkTo="/agents/settings/templates"
+				/>
+			</div>
+
+			<div className="flex items-center justify-between">
+				<Button variant="outline" onClick={onBack}>
+					Back
+				</Button>
+				<Button onClick={onFinish}>Start chatting</Button>
+			</div>
+		</div>
+	);
+};
+
+interface FeatureCardProps {
+	title: string;
+	description: string;
+	linkText: string;
+	linkTo: string;
+}
+
+const FeatureCard: FC<FeatureCardProps> = ({
+	title,
+	description,
+	linkText,
+	linkTo,
+}) => {
+	return (
+		<div className="flex flex-col gap-3">
+			{/* Placeholder image */}
+			<div className="h-40 w-full overflow-hidden rounded-lg bg-gradient-to-br from-surface-tertiary to-surface-secondary" />
+			<h3 className="text-base font-semibold">{title}</h3>
+			<p className="text-sm text-content-secondary">{description}</p>
+			<Link
+				to={linkTo}
+				target="_blank"
+				className="inline-flex items-center gap-1 text-sm text-content-link transition-colors hover:text-content-link/80"
+			>
+				{linkText}
+				<ExternalLinkIcon className="size-3" />
+			</Link>
+		</div>
+	);
+};

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ExtendStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ExtendStep.tsx
@@ -35,13 +35,15 @@ export const ExtendStep: FC<ExtendStepProps> = ({ onBack, onFinish }) => {
 			</div>
 
 			<div className="flex items-center justify-between">
-				<button
-					type="button"
+				<span
 					onClick={onBack}
-					className="text-sm text-content-secondary transition-colors hover:text-content-primary"
+					onKeyDown={(e) => e.key === "Enter" && e.currentTarget.click()}
+					role="button"
+					tabIndex={0}
+					className="cursor-pointer text-sm text-content-secondary transition-colors hover:text-content-primary"
 				>
 					Back
-				</button>
+				</span>
 				<Button onClick={onFinish}>Start chatting</Button>
 			</div>
 		</div>

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
@@ -40,7 +40,9 @@ export const ModelStep: FC<ModelStepProps> = ({
 	const savedProviders = allProviderConfigs.filter(
 		(p) => p.source !== "supported" && p.enabled,
 	);
-	const [selectedProvider, setSelectedProvider] = useState<string>("");
+	const [selectedProvider, setSelectedProvider] = useState<string>(
+		savedProviders.length > 0 ? savedProviders[0].provider : "",
+	);
 	const [selectedModel, setSelectedModel] = useState<string>("");
 	const [contextLimit, setContextLimit] = useState<string>("");
 	const queryClient = useQueryClient();
@@ -205,11 +207,7 @@ export const ModelStep: FC<ModelStepProps> = ({
 			)}
 
 			<div className="flex items-center justify-between">
-				<Button
-					variant="subtle"
-					className="min-w-0 px-0"
-					onClick={onBack}
-				>
+				<Button variant="subtle" className="min-w-0 px-0" onClick={onBack}>
 					Back
 				</Button>
 				<div className="flex items-center gap-3">

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
@@ -205,15 +205,13 @@ export const ModelStep: FC<ModelStepProps> = ({
 			)}
 
 			<div className="flex items-center justify-between">
-				<span
+				<button
+					type="button"
 					onClick={onBack}
-					onKeyDown={(e) => e.key === "Enter" && e.currentTarget.click()}
-					role="button"
-					tabIndex={0}
-					className="cursor-pointer text-sm text-content-secondary transition-colors hover:text-content-primary"
+					className="m-0 cursor-pointer border-none bg-transparent p-0 text-sm text-content-secondary transition-colors hover:text-content-primary"
 				>
 					Back
-				</span>
+				</button>
 				<div className="flex items-center gap-3">
 					<Button variant="outline" onClick={onSkip}>
 						Skip

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
@@ -128,7 +128,7 @@ export const ModelStep: FC<ModelStepProps> = ({
 			)}
 
 			{/* Add model form */}
-			<div className="flex flex-col gap-4 rounded-xl border border-border p-6">
+			<div className="flex flex-col gap-4 rounded-xl border border-border-secondary p-6">
 				<div className="grid grid-cols-1 gap-4 md:grid-cols-3">
 					<div className="flex flex-col gap-2">
 						<Label className="text-sm font-medium">Model provider*</Label>

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
@@ -1,0 +1,219 @@
+import { CheckIcon } from "lucide-react";
+import { type FC, useMemo, useState } from "react";
+import { useMutation, useQueryClient } from "react-query";
+import { Link } from "react-router";
+import { createChatModelConfig } from "#/api/queries/chats";
+import type { ChatModelConfig, ChatProviderConfig } from "#/api/typesGenerated";
+import { Button } from "#/components/Button/Button";
+import { Input } from "#/components/Input/Input";
+import { Label } from "#/components/Label/Label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "#/components/Select/Select";
+import { Spinner } from "#/components/Spinner/Spinner";
+import { formatProviderLabel } from "../../utils/modelOptions";
+import {
+	findKnownModelByExactAlias,
+	getKnownModelsForProvider,
+} from "../ChatModelAdminPanel/knownModels";
+import { ProviderIcon } from "../ChatModelAdminPanel/ProviderIcon";
+
+interface ModelStepProps {
+	savedProviders: readonly ChatProviderConfig[];
+	savedModels: readonly ChatModelConfig[];
+	onBack: () => void;
+	onSkip: () => void;
+	onContinue: () => void;
+}
+
+export const ModelStep: FC<ModelStepProps> = ({
+	savedProviders,
+	savedModels,
+	onBack,
+	onSkip,
+	onContinue,
+}) => {
+	const [selectedProvider, setSelectedProvider] = useState<string>("");
+	const [selectedModel, setSelectedModel] = useState<string>("");
+	const [contextLimit, setContextLimit] = useState<string>("");
+	const queryClient = useQueryClient();
+
+	const createMutation = useMutation(createChatModelConfig(queryClient));
+
+	const knownModels = useMemo(() => {
+		if (!selectedProvider) return [];
+		return getKnownModelsForProvider(selectedProvider);
+	}, [selectedProvider]);
+
+	const handleProviderChange = (value: string) => {
+		setSelectedProvider(value);
+		setSelectedModel("");
+		setContextLimit("");
+	};
+
+	const handleModelChange = (value: string) => {
+		setSelectedModel(value);
+		// Auto-fill context limit from known model defaults
+		const known = findKnownModelByExactAlias(selectedProvider, value);
+		if (known?.contextLimit) {
+			setContextLimit(String(known.contextLimit));
+		}
+	};
+
+	const handleAddModel = () => {
+		if (!selectedProvider || !selectedModel || !contextLimit) return;
+		const limit = Number.parseInt(contextLimit, 10);
+		if (Number.isNaN(limit) || limit <= 0) return;
+		createMutation.mutate(
+			{
+				provider: selectedProvider,
+				model: selectedModel,
+				enabled: true,
+				context_limit: limit,
+			},
+			{
+				onSuccess: () => {
+					setSelectedProvider("");
+					setSelectedModel("");
+					setContextLimit("");
+				},
+			},
+		);
+	};
+
+	const hasSavedModels = savedModels.length > 0;
+	const canAdd =
+		selectedProvider &&
+		selectedModel &&
+		contextLimit &&
+		!createMutation.isPending;
+
+	return (
+		<div className="flex flex-col gap-6">
+			<div className="flex flex-col gap-3">
+				<h2 className="text-2xl font-semibold">Add a model</h2>
+				<p className="text-sm text-content-secondary">
+					Set up at least one model to get started. For cost tracking,
+					reasoning, and other advanced model options, go to Settings &rarr;{" "}
+					<Link
+						to="/agents/settings/models"
+						className="text-content-link hover:text-content-link/80"
+					>
+						Models
+					</Link>
+					.
+				</p>
+			</div>
+
+			{/* Saved models list */}
+			{hasSavedModels && (
+				<div className="flex flex-col gap-2">
+					{savedModels.map((m) => (
+						<div key={m.id} className="flex items-center gap-2 text-sm">
+							<ProviderIcon provider={m.provider} className="size-5" />
+							<span>
+								{m.model} ({m.context_limit.toLocaleString()} context limit)
+							</span>
+							<CheckIcon className="size-4 text-green-500" />
+						</div>
+					))}
+				</div>
+			)}
+
+			{/* Add model form */}
+			<div className="flex flex-col gap-4 rounded-lg border border-border-default p-4">
+				<div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+					<div className="flex flex-col gap-2">
+						<Label className="text-sm font-medium">Model provider*</Label>
+						<Select
+							value={selectedProvider}
+							onValueChange={handleProviderChange}
+						>
+							<SelectTrigger>
+								<SelectValue placeholder="Select a provider..." />
+							</SelectTrigger>
+							<SelectContent>
+								{savedProviders.map((p) => (
+									<SelectItem key={p.id} value={p.provider}>
+										<div className="flex items-center gap-2">
+											<ProviderIcon provider={p.provider} className="size-5" />
+											{formatProviderLabel(p.provider)}
+										</div>
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+
+					<div className="flex flex-col gap-2">
+						<Label className="text-sm font-medium">Model identifier*</Label>
+						{knownModels.length > 0 ? (
+							<Select value={selectedModel} onValueChange={handleModelChange}>
+								<SelectTrigger>
+									<SelectValue placeholder="Select a model..." />
+								</SelectTrigger>
+								<SelectContent>
+									{knownModels.map((m) => (
+										<SelectItem
+											key={m.modelIdentifier}
+											value={m.modelIdentifier}
+										>
+											{m.displayName}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						) : (
+							<Input
+								placeholder="Enter model identifier..."
+								value={selectedModel}
+								onChange={(e) => setSelectedModel(e.target.value)}
+							/>
+						)}
+					</div>
+
+					<div className="flex flex-col gap-2">
+						<Label className="text-sm font-medium">Context limit*</Label>
+						<Input
+							type="text"
+							placeholder=""
+							value={contextLimit}
+							onChange={(e) => setContextLimit(e.target.value)}
+						/>
+					</div>
+				</div>
+
+				<div className="flex justify-end">
+					<Button onClick={handleAddModel} disabled={!canAdd}>
+						{createMutation.isPending && <Spinner className="mr-2" />}
+						Add model
+					</Button>
+				</div>
+			</div>
+
+			{createMutation.isError && (
+				<p className="text-sm text-content-destructive">
+					Failed to add model. Please try again.
+				</p>
+			)}
+
+			<div className="flex items-center justify-between">
+				<Button variant="outline" onClick={onBack}>
+					Back
+				</Button>
+				<div className="flex items-center gap-3">
+					<Button variant="outline" onClick={onSkip}>
+						Skip
+					</Button>
+					<Button onClick={onContinue} disabled={!hasSavedModels}>
+						Continue
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
@@ -128,7 +128,7 @@ export const ModelStep: FC<ModelStepProps> = ({
 			)}
 
 			{/* Add model form */}
-			<div className="flex flex-col gap-4 rounded-lg border border-border-default p-4">
+			<div className="flex flex-col gap-4 rounded-xl border border-border-primary p-6">
 				<div className="grid grid-cols-1 gap-4 md:grid-cols-3">
 					<div className="flex flex-col gap-2">
 						<Label className="text-sm font-medium">Model provider*</Label>

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
@@ -205,9 +205,13 @@ export const ModelStep: FC<ModelStepProps> = ({
 			)}
 
 			<div className="flex items-center justify-between">
-				<Button variant="outline" onClick={onBack}>
+				<button
+					type="button"
+					onClick={onBack}
+					className="text-sm text-content-secondary transition-colors hover:text-content-primary"
+				>
 					Back
-				</Button>
+				</button>
 				<div className="flex items-center gap-3">
 					<Button variant="outline" onClick={onSkip}>
 						Skip

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
@@ -17,7 +17,7 @@ import {
 import { Spinner } from "#/components/Spinner/Spinner";
 import { formatProviderLabel } from "../../utils/modelOptions";
 import {
-	findKnownModelByExactAlias,
+	findKnownModelByCanonicalId,
 	getKnownModelsForProvider,
 } from "../ChatModelAdminPanel/knownModels";
 import { ProviderIcon } from "../ChatModelAdminPanel/ProviderIcon";
@@ -61,7 +61,7 @@ export const ModelStep: FC<ModelStepProps> = ({
 	const handleModelChange = (value: string) => {
 		setSelectedModel(value);
 		// Auto-fill context limit from known model defaults
-		const known = findKnownModelByExactAlias(selectedProvider, value);
+		const known = findKnownModelByCanonicalId(selectedProvider, value);
 		if (known?.contextLimit) {
 			setContextLimit(String(known.contextLimit));
 		}

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
@@ -205,13 +205,13 @@ export const ModelStep: FC<ModelStepProps> = ({
 			)}
 
 			<div className="flex items-center justify-between">
-				<button
-					type="button"
+				<Button
+					variant="subtle"
+					className="min-w-0 px-0"
 					onClick={onBack}
-					className="m-0 cursor-pointer border-none bg-transparent p-0 text-sm text-content-secondary transition-colors hover:text-content-primary"
 				>
 					Back
-				</button>
+				</Button>
 				<div className="flex items-center gap-3">
 					<Button variant="outline" onClick={onSkip}>
 						Skip

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
@@ -205,13 +205,15 @@ export const ModelStep: FC<ModelStepProps> = ({
 			)}
 
 			<div className="flex items-center justify-between">
-				<button
-					type="button"
+				<span
 					onClick={onBack}
-					className="text-sm text-content-secondary transition-colors hover:text-content-primary"
+					onKeyDown={(e) => e.key === "Enter" && e.currentTarget.click()}
+					role="button"
+					tabIndex={0}
+					className="cursor-pointer text-sm text-content-secondary transition-colors hover:text-content-primary"
 				>
 					Back
-				</button>
+				</span>
 				<div className="flex items-center gap-3">
 					<Button variant="outline" onClick={onSkip}>
 						Skip

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
@@ -128,10 +128,7 @@ export const ModelStep: FC<ModelStepProps> = ({
 			)}
 
 			{/* Add model form */}
-			<div
-				className="flex flex-col gap-4 rounded-xl p-6"
-				style={{ border: "1px solid hsl(240 5% 26%)" }}
-			>
+			<div className="flex flex-col gap-4 rounded-xl border border-border p-6">
 				<div className="grid grid-cols-1 gap-4 md:grid-cols-3">
 					<div className="flex flex-col gap-2">
 						<Label className="text-sm font-medium">Model provider*</Label>

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
@@ -128,7 +128,7 @@ export const ModelStep: FC<ModelStepProps> = ({
 			)}
 
 			{/* Add model form */}
-			<div className="flex flex-col gap-4 rounded-xl border border-border p-6">
+			<div className="flex flex-col gap-4 rounded-xl border border-solid border-border p-6">
 				<div className="grid grid-cols-1 gap-4 md:grid-cols-3">
 					<div className="flex flex-col gap-2">
 						<Label className="text-sm font-medium">Model provider*</Label>

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
@@ -128,7 +128,10 @@ export const ModelStep: FC<ModelStepProps> = ({
 			)}
 
 			{/* Add model form */}
-			<div className="flex flex-col gap-4 rounded-xl border border-border-secondary p-6">
+			<div
+				className="flex flex-col gap-4 rounded-xl p-6"
+				style={{ border: "1px solid hsl(240 5% 26%)" }}
+			>
 				<div className="grid grid-cols-1 gap-4 md:grid-cols-3">
 					<div className="flex flex-col gap-2">
 						<Label className="text-sm font-medium">Model provider*</Label>

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
@@ -31,12 +31,15 @@ interface ModelStepProps {
 }
 
 export const ModelStep: FC<ModelStepProps> = ({
-	savedProviders,
+	savedProviders: allProviderConfigs,
 	savedModels,
 	onBack,
 	onSkip,
 	onContinue,
 }) => {
+	const savedProviders = allProviderConfigs.filter(
+		(p) => p.source !== "supported" && p.enabled,
+	);
 	const [selectedProvider, setSelectedProvider] = useState<string>("");
 	const [selectedModel, setSelectedModel] = useState<string>("");
 	const [contextLimit, setContextLimit] = useState<string>("");

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ModelStep.tsx
@@ -128,7 +128,7 @@ export const ModelStep: FC<ModelStepProps> = ({
 			)}
 
 			{/* Add model form */}
-			<div className="flex flex-col gap-4 rounded-xl border border-border-primary p-6">
+			<div className="flex flex-col gap-4 rounded-xl border border-border p-6">
 				<div className="grid grid-cols-1 gap-4 md:grid-cols-3">
 					<div className="flex flex-col gap-2">
 						<Label className="text-sm font-medium">Model provider*</Label>

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -42,10 +42,15 @@ interface ProviderStepProps {
 }
 
 export const ProviderStep: FC<ProviderStepProps> = ({
-	savedProviders,
+	savedProviders: allProviderConfigs,
 	onSkip,
 	onContinue,
 }) => {
+	// Filter to only providers that are actually configured (not just
+	// catalog "supported" entries).
+	const savedProviders = allProviderConfigs.filter(
+		(p) => p.source !== "supported" && p.enabled,
+	);
 	const [started, setStarted] = useState(savedProviders.length > 0);
 	const [selectedProvider, setSelectedProvider] = useState<string>("");
 	const [apiKey, setApiKey] = useState("");

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -90,29 +90,21 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 	// Intro sub-state: before the user clicks "Get started"
 	if (!started) {
 		return (
-			<div className="flex flex-col gap-6">
-				<div className="flex flex-col gap-3">
+			<div className="flex min-h-[460px] flex-col gap-6">
+				<div className="flex flex-col gap-4">
 					<h2 className="text-2xl font-semibold">Welcome to Coder Agents.</h2>
-					<p className="text-sm text-content-secondary">
-						You'll need to set up at least one provider to get started. For key
-						policy and API key controls, go to Settings &rarr;{" "}
-						<Link
-							to="/agents/settings/api-keys"
-							className="text-content-link hover:text-content-link/80"
-						>
-							Advanced
-						</Link>
-						.
+					<p className="text-base text-content-secondary">
+						Let's get you set up so you can start building.
 					</p>
 				</div>
 
-				<p className="text-sm text-content-primary">1. set up your provider</p>
+				<ol className="flex flex-col gap-1 text-base text-content-secondary">
+					<li>1. Set up at least one provider</li>
+					<li>2. Add a model</li>
+					<li>3. Start chatting</li>
+				</ol>
 
-				<div className="flex min-h-[200px] items-center justify-center rounded-lg border border-border-default p-6">
-					<p className="text-sm text-content-secondary">No provider selected</p>
-				</div>
-
-				<div className="flex items-center justify-end gap-3">
+				<div className="mt-auto flex items-center justify-end gap-3">
 					<Button variant="outline" onClick={onSkip}>
 						Skip
 					</Button>
@@ -126,9 +118,7 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 	return (
 		<div className="flex flex-col gap-6">
 			<div className="flex flex-col gap-3">
-				<h2 className="text-2xl font-semibold">
-					Welcome to Coder Agents. Connect an AI provider.
-				</h2>
+				<h2 className="text-2xl font-semibold">Connect an AI provider.</h2>
 				<p className="text-sm text-content-secondary">
 					You'll need to set up at least one provider to get started. For key
 					policy and API key controls, go to Settings &rarr;{" "}

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -259,6 +259,7 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 						setSelectedProvider("");
 						setApiKey("");
 						setBaseUrl("");
+						setStarted(false);
 					}}
 				>
 					Back

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -1,0 +1,262 @@
+import { ExternalLinkIcon } from "lucide-react";
+import { type FC, useState } from "react";
+import { useMutation, useQueryClient } from "react-query";
+import { Link } from "react-router";
+import { createChatProviderConfig } from "#/api/queries/chats";
+import type { ChatProviderConfig } from "#/api/typesGenerated";
+import { Button } from "#/components/Button/Button";
+import { Input } from "#/components/Input/Input";
+import { Label } from "#/components/Label/Label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "#/components/Select/Select";
+import { Spinner } from "#/components/Spinner/Spinner";
+import { formatProviderLabel } from "../../utils/modelOptions";
+import { ProviderIcon } from "../ChatModelAdminPanel/ProviderIcon";
+
+const KNOWN_PROVIDERS = [
+	"anthropic",
+	"openai",
+	"google",
+	"azure",
+	"bedrock",
+	"openrouter",
+] as const;
+
+const API_KEY_URLS: Record<string, string> = {
+	anthropic: "https://console.anthropic.com/settings/keys",
+	openai: "https://platform.openai.com/api-keys",
+	google: "https://aistudio.google.com/apikey",
+	azure: "https://portal.azure.com",
+	openrouter: "https://openrouter.ai/settings/keys",
+};
+
+interface ProviderStepProps {
+	savedProviders: readonly ChatProviderConfig[];
+	onSkip: () => void;
+	onContinue: () => void;
+}
+
+export const ProviderStep: FC<ProviderStepProps> = ({
+	savedProviders,
+	onSkip,
+	onContinue,
+}) => {
+	const [started, setStarted] = useState(savedProviders.length > 0);
+	const [selectedProvider, setSelectedProvider] = useState<string>("");
+	const [apiKey, setApiKey] = useState("");
+	const [baseUrl, setBaseUrl] = useState("");
+	const queryClient = useQueryClient();
+
+	const createMutation = useMutation(createChatProviderConfig(queryClient));
+
+	const handleSave = () => {
+		if (!selectedProvider) return;
+		createMutation.mutate(
+			{
+				provider: selectedProvider,
+				api_key: apiKey || undefined,
+				base_url: baseUrl || undefined,
+				enabled: true,
+				central_api_key_enabled: true,
+			},
+			{
+				onSuccess: () => {
+					setSelectedProvider("");
+					setApiKey("");
+					setBaseUrl("");
+				},
+			},
+		);
+	};
+
+	const hasSavedProviders = savedProviders.length > 0;
+	const savedProviderIds = new Set(
+		savedProviders.map((p) => p.provider.toLowerCase()),
+	);
+	const availableProviders = KNOWN_PROVIDERS.filter(
+		(p) => !savedProviderIds.has(p),
+	);
+
+	// Intro sub-state: before the user clicks "Get started"
+	if (!started) {
+		return (
+			<div className="flex flex-col gap-6">
+				<div className="flex flex-col gap-3">
+					<h2 className="text-2xl font-semibold">Welcome to Coder Agents.</h2>
+					<p className="text-sm text-content-secondary">
+						You'll need to set up at least one provider to get started. For key
+						policy and API key controls, go to Settings &rarr;{" "}
+						<Link
+							to="/agents/settings/api-keys"
+							className="text-content-link hover:text-content-link/80"
+						>
+							Advanced
+						</Link>
+						.
+					</p>
+				</div>
+
+				<p className="text-sm text-content-primary">1. set up your provider</p>
+
+				<div className="flex min-h-[200px] items-center justify-center rounded-lg border border-border-default p-6">
+					<p className="text-sm text-content-secondary">No provider selected</p>
+				</div>
+
+				<div className="flex items-center justify-end gap-3">
+					<Button variant="outline" onClick={onSkip}>
+						Skip
+					</Button>
+					<Button onClick={() => setStarted(true)}>Get started</Button>
+				</div>
+			</div>
+		);
+	}
+
+	// Configuring sub-state
+	return (
+		<div className="flex flex-col gap-6">
+			<div className="flex flex-col gap-3">
+				<h2 className="text-2xl font-semibold">
+					Welcome to Coder Agents. Connect an AI provider.
+				</h2>
+				<p className="text-sm text-content-secondary">
+					You'll need to set up at least one provider to get started. For key
+					policy and API key controls, go to Settings &rarr;{" "}
+					<Link
+						to="/agents/settings/api-keys"
+						className="text-content-link hover:text-content-link/80"
+					>
+						Advanced
+					</Link>
+					.
+				</p>
+			</div>
+
+			{/* Saved provider badges */}
+			{hasSavedProviders && (
+				<div className="flex flex-wrap items-center gap-2">
+					{savedProviders.map((p) => (
+						<div
+							key={p.id}
+							className="flex items-center gap-2 rounded-lg border-2 border-green-500 px-3 py-1.5"
+						>
+							<ProviderIcon provider={p.provider} className="size-5" />
+							<span className="text-sm font-medium">
+								{formatProviderLabel(p.provider)}
+							</span>
+						</div>
+					))}
+					{availableProviders.length > 0 && !selectedProvider && (
+						<Select value="" onValueChange={setSelectedProvider}>
+							<SelectTrigger className="w-auto gap-2">
+								<SelectValue placeholder="Add another..." />
+							</SelectTrigger>
+							<SelectContent>
+								{availableProviders.map((p) => (
+									<SelectItem key={p} value={p}>
+										<div className="flex items-center gap-2">
+											<ProviderIcon provider={p} className="size-5" />
+											{formatProviderLabel(p)}
+										</div>
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					)}
+				</div>
+			)}
+
+			{/* Provider selector (when no providers saved yet) */}
+			{!hasSavedProviders && !selectedProvider && (
+				<Select value="" onValueChange={setSelectedProvider}>
+					<SelectTrigger className="w-[200px]">
+						<SelectValue placeholder="Select..." />
+					</SelectTrigger>
+					<SelectContent>
+						{availableProviders.map((p) => (
+							<SelectItem key={p} value={p}>
+								<div className="flex items-center gap-2">
+									<ProviderIcon provider={p} className="size-5" />
+									{formatProviderLabel(p)}
+								</div>
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			)}
+
+			{/* Provider config form */}
+			{selectedProvider ? (
+				<div className="flex flex-col gap-4 rounded-lg border border-border-default p-4">
+					<div className="flex items-center justify-between">
+						<Label className="text-sm font-medium">
+							{formatProviderLabel(selectedProvider)} API key
+						</Label>
+						{API_KEY_URLS[selectedProvider] && (
+							<a
+								href={API_KEY_URLS[selectedProvider]}
+								target="_blank"
+								rel="noreferrer"
+								className="inline-flex items-center gap-1 text-sm text-content-link hover:text-content-link/80"
+							>
+								Get API key
+								<ExternalLinkIcon className="size-3" />
+							</a>
+						)}
+					</div>
+					<Input
+						type="password"
+						placeholder="sk-..."
+						value={apiKey}
+						onChange={(e) => setApiKey(e.target.value)}
+					/>
+
+					<Label className="text-sm font-medium">Base URL</Label>
+					<Input
+						type="text"
+						placeholder={
+							selectedProvider === "anthropic" ||
+							selectedProvider === "bedrock" ||
+							selectedProvider === "google"
+								? "https://api.example.com"
+								: "https://api.example.com/v1"
+						}
+						value={baseUrl}
+						onChange={(e) => setBaseUrl(e.target.value)}
+					/>
+
+					<div className="flex justify-end">
+						<Button onClick={handleSave} disabled={createMutation.isPending}>
+							{createMutation.isPending && <Spinner className="mr-2" />}
+							Save provider
+						</Button>
+					</div>
+				</div>
+			) : !hasSavedProviders ? (
+				<div className="flex min-h-[200px] items-center justify-center rounded-lg border border-border-default p-6">
+					<p className="text-sm text-content-secondary">No provider selected</p>
+				</div>
+			) : null}
+
+			{createMutation.isError && (
+				<p className="text-sm text-content-destructive">
+					Failed to save provider. Please try again.
+				</p>
+			)}
+
+			<div className="flex items-center justify-end gap-3">
+				<Button variant="outline" onClick={onSkip}>
+					Skip
+				</Button>
+				<Button onClick={onContinue} disabled={!hasSavedProviders}>
+					Continue
+				</Button>
+			</div>
+		</div>
+	);
+};

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -188,10 +188,7 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 
 			{/* Provider config form */}
 			{selectedProvider ? (
-				<div
-					className="flex flex-col gap-4 rounded-xl p-6"
-					style={{ border: "1px solid hsl(240 5% 26%)" }}
-				>
+				<div className="flex flex-col gap-4 rounded-xl border border-border p-6">
 					<div className="flex items-center justify-between">
 						<Label className="text-sm font-medium">
 							{formatProviderLabel(selectedProvider)} API key
@@ -237,10 +234,7 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 					</div>
 				</div>
 			) : !hasSavedProviders ? (
-				<div
-					className="flex min-h-[200px] items-center justify-center rounded-xl p-6"
-					style={{ border: "1px solid hsl(240 5% 26%)" }}
-				>
+				<div className="flex min-h-[200px] items-center justify-center rounded-xl border border-border p-6">
 					<p className="text-sm text-content-secondary">No provider selected</p>
 				</div>
 			) : null}

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -250,19 +250,17 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 			)}
 
 			<div className="flex items-center justify-between">
-				<span
+				<button
+					type="button"
 					onClick={() => {
 						setSelectedProvider("");
 						setApiKey("");
 						setBaseUrl("");
 					}}
-					onKeyDown={(e) => e.key === "Enter" && e.currentTarget.click()}
-					role="button"
-					tabIndex={0}
-					className="cursor-pointer text-sm text-content-secondary transition-colors hover:text-content-primary"
+					className="m-0 cursor-pointer border-none bg-transparent p-0 text-sm text-content-secondary transition-colors hover:text-content-primary"
 				>
 					Back
-				</span>
+				</button>
 				<div className="flex items-center gap-3">
 					<Button variant="outline" onClick={onSkip}>
 						Skip

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -98,10 +98,10 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 					</p>
 				</div>
 
-				<ol className="flex flex-col gap-1 text-base text-content-secondary">
-					<li>1. Set up at least one provider</li>
-					<li>2. Add a model</li>
-					<li>3. Start chatting</li>
+				<ol className="flex list-decimal flex-col gap-1 pl-5 text-base text-content-secondary">
+					<li>Set up at least one provider</li>
+					<li>Add a model</li>
+					<li>Start chatting</li>
 				</ol>
 
 				<div className="mt-auto flex items-center justify-end gap-3">

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -139,7 +139,7 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 					{savedProviders.map((p) => (
 						<div
 							key={p.id}
-							className="flex items-center gap-2 rounded-lg border-2 border-green-500 px-3 py-1.5"
+							className="flex items-center gap-2 rounded-lg border-2 border-solid border-green-500 px-3 py-1.5"
 						>
 							<ProviderIcon provider={p.provider} className="size-5" />
 							<span className="text-sm font-medium">

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -227,7 +227,7 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 					/>
 
 					<div className="flex justify-end">
-						<Button onClick={handleSave} disabled={createMutation.isPending}>
+						<Button onClick={handleSave} disabled={!apiKey.trim() || createMutation.isPending}>
 							{createMutation.isPending && <Spinner className="mr-2" />}
 							Save provider
 						</Button>

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -188,7 +188,7 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 
 			{/* Provider config form */}
 			{selectedProvider ? (
-				<div className="flex flex-col gap-4 rounded-xl border border-border-default p-6">
+				<div className="flex flex-col gap-4 rounded-xl border border-border-primary p-6">
 					<div className="flex items-center justify-between">
 						<Label className="text-sm font-medium">
 							{formatProviderLabel(selectedProvider)} API key
@@ -234,7 +234,7 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 					</div>
 				</div>
 			) : !hasSavedProviders ? (
-				<div className="flex min-h-[200px] items-center justify-center rounded-xl border border-border-default p-6">
+				<div className="flex min-h-[200px] items-center justify-center rounded-xl border border-border-primary p-6">
 					<p className="text-sm text-content-secondary">No provider selected</p>
 				</div>
 			) : null}

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -188,7 +188,7 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 
 			{/* Provider config form */}
 			{selectedProvider ? (
-				<div className="flex flex-col gap-4 rounded-xl border border-border p-6">
+				<div className="flex flex-col gap-4 rounded-xl border border-solid border-border p-6">
 					<div className="flex items-center justify-between">
 						<Label className="text-sm font-medium">
 							{formatProviderLabel(selectedProvider)} API key
@@ -234,7 +234,7 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 					</div>
 				</div>
 			) : !hasSavedProviders ? (
-				<div className="flex min-h-[200px] items-center justify-center rounded-xl border border-border p-6">
+				<div className="flex min-h-[200px] items-center justify-center rounded-xl border border-solid border-border p-6">
 					<p className="text-sm text-content-secondary">No provider selected</p>
 				</div>
 			) : null}

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -120,8 +120,10 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 			<div className="flex flex-col gap-3">
 				<h2 className="text-2xl font-semibold">Connect an AI provider.</h2>
 				<p className="text-sm text-content-secondary">
-					You'll need to set up at least one provider to get started. For key
-					policy and API key controls, go to Settings &rarr;{" "}
+					You'll need to set up at least one provider to get started.
+				</p>
+				<p className="text-sm text-content-secondary">
+					For key policy and API key controls, go to Settings &rarr;{" "}
 					<Link
 						to="/agents/settings/api-keys"
 						className="text-content-link hover:text-content-link/80"

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -188,7 +188,7 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 
 			{/* Provider config form */}
 			{selectedProvider ? (
-				<div className="flex flex-col gap-4 rounded-xl border border-border p-6">
+				<div className="flex flex-col gap-4 rounded-xl border border-border-secondary p-6">
 					<div className="flex items-center justify-between">
 						<Label className="text-sm font-medium">
 							{formatProviderLabel(selectedProvider)} API key
@@ -234,7 +234,7 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 					</div>
 				</div>
 			) : !hasSavedProviders ? (
-				<div className="flex min-h-[200px] items-center justify-center rounded-xl border border-border p-6">
+				<div className="flex min-h-[200px] items-center justify-center rounded-xl border border-border-secondary p-6">
 					<p className="text-sm text-content-secondary">No provider selected</p>
 				</div>
 			) : null}

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -3,7 +3,6 @@ import { type FC, useState } from "react";
 import { useMutation, useQueryClient } from "react-query";
 import { Link } from "react-router";
 import { createChatProviderConfig } from "#/api/queries/chats";
-import type { ChatProviderConfig } from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
 import { Input } from "#/components/Input/Input";
 import { Label } from "#/components/Label/Label";
@@ -36,22 +35,12 @@ const API_KEY_URLS: Record<string, string> = {
 };
 
 interface ProviderStepProps {
-	savedProviders: readonly ChatProviderConfig[];
 	onSkip: () => void;
 	onContinue: () => void;
 }
 
-export const ProviderStep: FC<ProviderStepProps> = ({
-	savedProviders: allProviderConfigs,
-	onSkip,
-	onContinue,
-}) => {
-	// Filter to only providers that are actually configured (not just
-	// catalog "supported" entries).
-	const savedProviders = allProviderConfigs.filter(
-		(p) => p.source !== "supported" && p.enabled,
-	);
-	const [started, setStarted] = useState(savedProviders.length > 0);
+export const ProviderStep: FC<ProviderStepProps> = ({ onSkip, onContinue }) => {
+	const [started, setStarted] = useState(false);
 	const [selectedProvider, setSelectedProvider] = useState<string>("");
 	const [apiKey, setApiKey] = useState("");
 	const [baseUrl, setBaseUrl] = useState("");
@@ -71,21 +60,12 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 			},
 			{
 				onSuccess: () => {
-					setSelectedProvider("");
-					setApiKey("");
-					setBaseUrl("");
+					// Auto-advance to model step after saving
+					onContinue();
 				},
 			},
 		);
 	};
-
-	const hasSavedProviders = savedProviders.length > 0;
-	const savedProviderIds = new Set(
-		savedProviders.map((p) => p.provider.toLowerCase()),
-	);
-	const availableProviders = KNOWN_PROVIDERS.filter(
-		(p) => !savedProviderIds.has(p),
-	);
 
 	// Intro sub-state: before the user clicks "Get started"
 	if (!started) {
@@ -133,48 +113,14 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 				</p>
 			</div>
 
-			{/* Saved provider badges */}
-			{hasSavedProviders && (
-				<div className="flex flex-wrap items-center gap-2">
-					{savedProviders.map((p) => (
-						<div
-							key={p.id}
-							className="flex items-center gap-2 rounded-lg border border-solid border-green-500 px-3 py-1.5"
-						>
-							<ProviderIcon provider={p.provider} className="size-5" />
-							<span className="text-sm font-medium">
-								{formatProviderLabel(p.provider)}
-							</span>
-						</div>
-					))}
-					{availableProviders.length > 0 && !selectedProvider && (
-						<Select value="" onValueChange={setSelectedProvider}>
-							<SelectTrigger className="w-auto gap-2">
-								<SelectValue placeholder="Add another..." />
-							</SelectTrigger>
-							<SelectContent>
-								{availableProviders.map((p) => (
-									<SelectItem key={p} value={p}>
-										<div className="flex items-center gap-2">
-											<ProviderIcon provider={p} className="size-5" />
-											{formatProviderLabel(p)}
-										</div>
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
-					)}
-				</div>
-			)}
-
-			{/* Provider selector (when no providers saved yet) */}
-			{!hasSavedProviders && !selectedProvider && (
+			{/* Provider selector */}
+			{!selectedProvider && (
 				<Select value="" onValueChange={setSelectedProvider}>
 					<SelectTrigger className="w-[200px]">
 						<SelectValue placeholder="Select..." />
 					</SelectTrigger>
 					<SelectContent>
-						{availableProviders.map((p) => (
+						{KNOWN_PROVIDERS.map((p) => (
 							<SelectItem key={p} value={p}>
 								<div className="flex items-center gap-2">
 									<ProviderIcon provider={p} className="size-5" />
@@ -231,7 +177,10 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 					/>
 
 					<div className="flex justify-end">
-						<Button onClick={handleSave} disabled={!apiKey.trim() || createMutation.isPending}>
+						<Button
+							onClick={handleSave}
+							disabled={!apiKey.trim() || createMutation.isPending}
+						>
 							{createMutation.isPending && <Spinner className="mr-2" />}
 							Save provider
 						</Button>
@@ -239,9 +188,7 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 				</div>
 			) : (
 				<div className="flex min-h-[200px] items-center justify-center rounded-xl border border-solid border-border p-6">
-					<p className="text-sm text-content-secondary">
-						{hasSavedProviders ? "Select another provider" : "No provider selected"}
-					</p>
+					<p className="text-sm text-content-secondary">No provider selected</p>
 				</div>
 			)}
 
@@ -266,9 +213,6 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 				<div className="flex items-center gap-3">
 					<Button variant="outline" onClick={onSkip}>
 						Skip
-					</Button>
-					<Button onClick={onContinue} disabled={!hasSavedProviders}>
-						Continue
 					</Button>
 				</div>
 			</div>

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -188,7 +188,10 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 
 			{/* Provider config form */}
 			{selectedProvider ? (
-				<div className="flex flex-col gap-4 rounded-xl border border-border-secondary p-6">
+				<div
+					className="flex flex-col gap-4 rounded-xl p-6"
+					style={{ border: "1px solid hsl(240 5% 26%)" }}
+				>
 					<div className="flex items-center justify-between">
 						<Label className="text-sm font-medium">
 							{formatProviderLabel(selectedProvider)} API key
@@ -234,7 +237,10 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 					</div>
 				</div>
 			) : !hasSavedProviders ? (
-				<div className="flex min-h-[200px] items-center justify-center rounded-xl border border-border-secondary p-6">
+				<div
+					className="flex min-h-[200px] items-center justify-center rounded-xl p-6"
+					style={{ border: "1px solid hsl(240 5% 26%)" }}
+				>
 					<p className="text-sm text-content-secondary">No provider selected</p>
 				</div>
 			) : null}

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -252,17 +252,17 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 			)}
 
 			<div className="flex items-center justify-between">
-				<button
-					type="button"
+				<Button
+					variant="subtle"
+					className="min-w-0 px-0"
 					onClick={() => {
 						setSelectedProvider("");
 						setApiKey("");
 						setBaseUrl("");
 					}}
-					className="m-0 cursor-pointer border-none bg-transparent p-0 text-sm text-content-secondary transition-colors hover:text-content-primary"
 				>
 					Back
-				</button>
+				</Button>
 				<div className="flex items-center gap-3">
 					<Button variant="outline" onClick={onSkip}>
 						Skip

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -139,7 +139,7 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 					{savedProviders.map((p) => (
 						<div
 							key={p.id}
-							className="flex items-center gap-2 rounded-lg border-2 border-solid border-green-500 px-3 py-1.5"
+							className="flex items-center gap-2 rounded-lg border border-solid border-green-500 px-3 py-1.5"
 						>
 							<ProviderIcon provider={p.provider} className="size-5" />
 							<span className="text-sm font-medium">

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -44,6 +44,7 @@ export const ProviderStep: FC<ProviderStepProps> = ({ onSkip, onContinue }) => {
 	const [selectedProvider, setSelectedProvider] = useState<string>("");
 	const [apiKey, setApiKey] = useState("");
 	const [baseUrl, setBaseUrl] = useState("");
+	const [_providerSaved, setProviderSaved] = useState(false);
 	const queryClient = useQueryClient();
 
 	const createMutation = useMutation(createChatProviderConfig(queryClient));
@@ -60,7 +61,6 @@ export const ProviderStep: FC<ProviderStepProps> = ({ onSkip, onContinue }) => {
 			},
 			{
 				onSuccess: () => {
-					// Auto-advance to model step after saving
 					onContinue();
 				},
 			},
@@ -175,16 +175,6 @@ export const ProviderStep: FC<ProviderStepProps> = ({ onSkip, onContinue }) => {
 						value={baseUrl}
 						onChange={(e) => setBaseUrl(e.target.value)}
 					/>
-
-					<div className="flex justify-end">
-						<Button
-							onClick={handleSave}
-							disabled={!apiKey.trim() || createMutation.isPending}
-						>
-							{createMutation.isPending && <Spinner className="mr-2" />}
-							Save provider
-						</Button>
-					</div>
 				</div>
 			) : (
 				<div className="flex min-h-[200px] items-center justify-center rounded-xl border border-solid border-border p-6">
@@ -206,6 +196,7 @@ export const ProviderStep: FC<ProviderStepProps> = ({ onSkip, onContinue }) => {
 						setSelectedProvider("");
 						setApiKey("");
 						setBaseUrl("");
+						setProviderSaved(false);
 					}}
 				>
 					Back
@@ -213,6 +204,15 @@ export const ProviderStep: FC<ProviderStepProps> = ({ onSkip, onContinue }) => {
 				<div className="flex items-center gap-3">
 					<Button variant="outline" onClick={onSkip}>
 						Skip
+					</Button>
+					<Button
+						onClick={handleSave}
+						disabled={
+							!selectedProvider || !apiKey.trim() || createMutation.isPending
+						}
+					>
+						{createMutation.isPending && <Spinner className="mr-2" />}
+						Continue
 					</Button>
 				</div>
 			</div>

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -206,7 +206,11 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 						)}
 					</div>
 					<Input
-						type="password"
+						type="text"
+						className="[-webkit-text-security:disc]"
+						autoComplete="off"
+						data-1p-ignore
+						data-lpignore="true"
 						placeholder="sk-..."
 						value={apiKey}
 						onChange={(e) => setApiKey(e.target.value)}

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -259,7 +259,6 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 						setSelectedProvider("");
 						setApiKey("");
 						setBaseUrl("");
-						setStarted(false);
 					}}
 				>
 					Back

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -251,7 +251,6 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 						setSelectedProvider("");
 						setApiKey("");
 						setBaseUrl("");
-						setStarted(false);
 					}}
 					onKeyDown={(e) => e.key === "Enter" && e.currentTarget.click()}
 					role="button"

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -237,11 +237,13 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 						</Button>
 					</div>
 				</div>
-			) : !hasSavedProviders ? (
+			) : (
 				<div className="flex min-h-[200px] items-center justify-center rounded-xl border border-solid border-border p-6">
-					<p className="text-sm text-content-secondary">No provider selected</p>
+					<p className="text-sm text-content-secondary">
+						{hasSavedProviders ? "Select another provider" : "No provider selected"}
+					</p>
 				</div>
-			) : null}
+			)}
 
 			{createMutation.isError && (
 				<p className="text-sm text-content-destructive">

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -246,18 +246,20 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 			)}
 
 			<div className="flex items-center justify-between">
-				<button
-					type="button"
+				<span
 					onClick={() => {
 						setSelectedProvider("");
 						setApiKey("");
 						setBaseUrl("");
 						setStarted(false);
 					}}
-					className="text-sm text-content-secondary transition-colors hover:text-content-primary"
+					onKeyDown={(e) => e.key === "Enter" && e.currentTarget.click()}
+					role="button"
+					tabIndex={0}
+					className="cursor-pointer text-sm text-content-secondary transition-colors hover:text-content-primary"
 				>
 					Back
-				</button>
+				</span>
 				<div className="flex items-center gap-3">
 					<Button variant="outline" onClick={onSkip}>
 						Skip

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -121,8 +121,7 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 				<h2 className="text-2xl font-semibold">Connect an AI provider.</h2>
 				<p className="text-sm text-content-secondary">
 					You'll need to set up at least one provider to get started.
-				</p>
-				<p className="text-sm text-content-secondary">
+					<br />
 					For key policy and API key controls, go to Settings &rarr;{" "}
 					<Link
 						to="/agents/settings/api-keys"

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -187,7 +187,7 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 
 			{/* Provider config form */}
 			{selectedProvider ? (
-				<div className="flex flex-col gap-4 rounded-lg border border-border-default p-4">
+				<div className="flex flex-col gap-4 rounded-xl border border-border-default p-6">
 					<div className="flex items-center justify-between">
 						<Label className="text-sm font-medium">
 							{formatProviderLabel(selectedProvider)} API key
@@ -233,7 +233,7 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 					</div>
 				</div>
 			) : !hasSavedProviders ? (
-				<div className="flex min-h-[200px] items-center justify-center rounded-lg border border-border-default p-6">
+				<div className="flex min-h-[200px] items-center justify-center rounded-xl border border-border-default p-6">
 					<p className="text-sm text-content-secondary">No provider selected</p>
 				</div>
 			) : null}
@@ -244,13 +244,27 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 				</p>
 			)}
 
-			<div className="flex items-center justify-end gap-3">
-				<Button variant="outline" onClick={onSkip}>
-					Skip
-				</Button>
-				<Button onClick={onContinue} disabled={!hasSavedProviders}>
-					Continue
-				</Button>
+			<div className="flex items-center justify-between">
+				<button
+					type="button"
+					onClick={() => {
+						setSelectedProvider("");
+						setApiKey("");
+						setBaseUrl("");
+						setStarted(false);
+					}}
+					className="text-sm text-content-secondary transition-colors hover:text-content-primary"
+				>
+					Back
+				</button>
+				<div className="flex items-center gap-3">
+					<Button variant="outline" onClick={onSkip}>
+						Skip
+					</Button>
+					<Button onClick={onContinue} disabled={!hasSavedProviders}>
+						Continue
+					</Button>
+				</div>
 			</div>
 		</div>
 	);

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/ProviderStep.tsx
@@ -188,7 +188,7 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 
 			{/* Provider config form */}
 			{selectedProvider ? (
-				<div className="flex flex-col gap-4 rounded-xl border border-border-primary p-6">
+				<div className="flex flex-col gap-4 rounded-xl border border-border p-6">
 					<div className="flex items-center justify-between">
 						<Label className="text-sm font-medium">
 							{formatProviderLabel(selectedProvider)} API key
@@ -234,7 +234,7 @@ export const ProviderStep: FC<ProviderStepProps> = ({
 					</div>
 				</div>
 			) : !hasSavedProviders ? (
-				<div className="flex min-h-[200px] items-center justify-center rounded-xl border border-border-primary p-6">
+				<div className="flex min-h-[200px] items-center justify-center rounded-xl border border-border p-6">
 					<p className="text-sm text-content-secondary">No provider selected</p>
 				</div>
 			) : null}

--- a/site/src/pages/AgentsPage/components/AgentOnboarding/onboardingState.ts
+++ b/site/src/pages/AgentsPage/components/AgentOnboarding/onboardingState.ts
@@ -1,0 +1,17 @@
+const DISMISSED_KEY = "agents.onboarding-dismissed";
+
+export function isOnboardingDismissed(): boolean {
+	try {
+		return localStorage.getItem(DISMISSED_KEY) === "true";
+	} catch {
+		return false;
+	}
+}
+
+export function dismissOnboarding(): void {
+	try {
+		localStorage.setItem(DISMISSED_KEY, "true");
+	} catch {
+		// localStorage may be unavailable in some contexts.
+	}
+}

--- a/site/src/pages/AgentsPage/components/AgentSetupNotice.tsx
+++ b/site/src/pages/AgentsPage/components/AgentSetupNotice.tsx
@@ -69,7 +69,7 @@ export const AgentSetupNotice: FC<AgentSetupNoticeProps> = ({
 
 const NoticeContainer: FC<{ children: React.ReactNode }> = ({ children }) => {
 	return (
-		<div className="rounded-2xl bg-surface-grey px-4 pb-12 pt-2.5 text-sm text-content-primary">
+		<div className="rounded-2xl bg-surface-grey px-4 pb-14 pt-2.5 text-sm text-content-primary">
 			{children}
 		</div>
 	);

--- a/site/src/pages/AgentsPage/components/AgentSetupNotice.tsx
+++ b/site/src/pages/AgentsPage/components/AgentSetupNotice.tsx
@@ -1,20 +1,14 @@
-import { CheckIcon } from "lucide-react";
 import type { FC } from "react";
 import { Link } from "react-router";
-import {
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogHeader,
-	DialogTitle,
-} from "#/components/Dialog/Dialog";
 
 interface AgentSetupNoticeProps {
+	isAdmin: boolean;
 	providerCount: number;
 	modelCount: number;
 }
 
 export const AgentSetupNotice: FC<AgentSetupNoticeProps> = ({
+	isAdmin,
 	providerCount,
 	modelCount,
 }) => {
@@ -25,79 +19,58 @@ export const AgentSetupNotice: FC<AgentSetupNoticeProps> = ({
 		return null;
 	}
 
-	return (
-		<Dialog open>
-			<DialogContent
-				className="w-fit max-w-[calc(100vw-2rem)] gap-8"
-				onEscapeKeyDown={(event) => {
-					event.preventDefault();
-				}}
-				onPointerDownOutside={(event) => {
-					event.preventDefault();
-				}}
-			>
-				<DialogHeader className="space-y-5 text-left sm:text-left">
-					<DialogTitle className="text-xl">Welcome to Coder Agents</DialogTitle>
-					<DialogDescription className="text-base">
-						Complete 2 quick steps to get started.
-					</DialogDescription>
-				</DialogHeader>
+	// Non-admin member: show a generic message
+	if (!isAdmin) {
+		return (
+			<NoticeContainer>
+				AI models aren't available yet. Your admin is still getting things set
+				up.
+			</NoticeContainer>
+		);
+	}
 
-				<div className="flex flex-col gap-3 text-base text-content-secondary">
-					<AgentSetupStep
-						isComplete={hasProvider}
-						stepNumber={1}
-						label="Connect a chat provider"
-						linkTo="/agents/settings/providers"
-						linkText="Go to Providers"
-					/>
-					<AgentSetupStep
-						isComplete={hasModel}
-						stepNumber={2}
-						label="Add a chat model"
-						linkTo="/agents/settings/models"
-						linkText="Go to Models"
-					/>
-				</div>
-			</DialogContent>
-		</Dialog>
+	// Admin: no providers and no models
+	if (!hasProvider && !hasModel) {
+		return (
+			<NoticeContainer>
+				To chat with Coder Agents, set up a{" "}
+				<Link
+					to="/agents/settings/providers"
+					className="text-content-link transition-colors hover:text-content-link/80"
+				>
+					provider
+				</Link>{" "}
+				then add a{" "}
+				<Link
+					to="/agents/settings/models"
+					className="text-content-link transition-colors hover:text-content-link/80"
+				>
+					model
+				</Link>
+				.
+			</NoticeContainer>
+		);
+	}
+
+	// Admin: has providers but no models
+	return (
+		<NoticeContainer>
+			To chat with Coder Agents, set up a{" "}
+			<Link
+				to="/agents/settings/models"
+				className="text-content-link transition-colors hover:text-content-link/80"
+			>
+				model
+			</Link>
+			.
+		</NoticeContainer>
 	);
 };
 
-interface AgentSetupStepProps {
-	isComplete: boolean;
-	stepNumber: number;
-	label: string;
-	linkTo: string;
-	linkText: string;
-}
-
-const AgentSetupStep: FC<AgentSetupStepProps> = ({
-	isComplete,
-	stepNumber,
-	label,
-	linkTo,
-	linkText,
-}) => {
+const NoticeContainer: FC<{ children: React.ReactNode }> = ({ children }) => {
 	return (
-		<div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-			<span className="flex w-7 shrink-0 justify-end text-content-secondary">
-				{isComplete ? (
-					<CheckIcon
-						aria-label="Complete"
-						className="h-5 w-5 text-content-success"
-					/>
-				) : (
-					`${stepNumber}.`
-				)}
-			</span>
-			<span className="text-content-secondary">{label}</span>
-			<Link
-				to={linkTo}
-				className="text-content-link transition-colors hover:text-content-link/80"
-			>
-				{linkText}
-			</Link>
+		<div className="rounded-2xl bg-surface-grey px-4 pb-5 pt-2.5 text-sm text-content-primary">
+			{children}
 		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/components/AgentSetupNotice.tsx
+++ b/site/src/pages/AgentsPage/components/AgentSetupNotice.tsx
@@ -69,7 +69,7 @@ export const AgentSetupNotice: FC<AgentSetupNoticeProps> = ({
 
 const NoticeContainer: FC<{ children: React.ReactNode }> = ({ children }) => {
 	return (
-		<div className="rounded-2xl bg-surface-grey px-4 pb-14 pt-2.5 text-sm text-content-primary">
+		<div className="rounded-2xl bg-surface-grey px-4 pb-14 pt-2.5 text-[13px] text-content-primary">
 			{children}
 		</div>
 	);

--- a/site/src/pages/AgentsPage/components/AgentSetupNotice.tsx
+++ b/site/src/pages/AgentsPage/components/AgentSetupNotice.tsx
@@ -69,7 +69,7 @@ export const AgentSetupNotice: FC<AgentSetupNoticeProps> = ({
 
 const NoticeContainer: FC<{ children: React.ReactNode }> = ({ children }) => {
 	return (
-		<div className="rounded-2xl bg-surface-grey px-4 pb-5 pt-2.5 text-sm text-content-primary">
+		<div className="rounded-2xl bg-surface-grey px-4 pb-8 pt-2.5 text-sm text-content-primary">
 			{children}
 		</div>
 	);

--- a/site/src/pages/AgentsPage/components/AgentSetupNotice.tsx
+++ b/site/src/pages/AgentsPage/components/AgentSetupNotice.tsx
@@ -69,7 +69,7 @@ export const AgentSetupNotice: FC<AgentSetupNoticeProps> = ({
 
 const NoticeContainer: FC<{ children: React.ReactNode }> = ({ children }) => {
 	return (
-		<div className="rounded-2xl bg-surface-grey px-4 pb-8 pt-2.5 text-sm text-content-primary">
+		<div className="rounded-2xl bg-surface-grey px-4 pb-12 pt-2.5 text-sm text-content-primary">
 			{children}
 		</div>
 	);

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -504,13 +504,13 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 
 	return (
 		<div>
-			{agentSetupNotice && (
-				<div className={cn("mx-auto w-full", chatWidthClass(chatFullWidth))}>
-					{agentSetupNotice}
-				</div>
-			)}
-			{agentSetupNotice ? (
-				<div className="relative z-10 -mt-10">{inputElement}</div>
+		{agentSetupNotice && (
+			<div className={cn("relative z-0 mx-auto w-full", chatWidthClass(chatFullWidth))}>
+				{agentSetupNotice}
+			</div>
+		)}
+		{agentSetupNotice ? (
+			<div className="relative z-10 -mt-10 [&_[data-testid=chat-composer]]:bg-surface-secondary">{inputElement}</div>
 			) : (
 				inputElement
 			)}

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -504,13 +504,13 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 
 	return (
 		<div>
-		{agentSetupNotice && (
-			<div className={cn("relative z-0 mx-auto w-full", chatWidthClass(chatFullWidth))}>
-				{agentSetupNotice}
-			</div>
-		)}
-		{agentSetupNotice ? (
-			<div className="relative z-10 -mt-14">{inputElement}</div>
+			{agentSetupNotice ? (
+				<div className="relative">
+					<div className={cn("mx-auto w-full", chatWidthClass(chatFullWidth))}>
+						{agentSetupNotice}
+					</div>
+					<div className="relative z-10 mt-[-2.25rem]">{inputElement}</div>
+				</div>
 			) : (
 				inputElement
 			)}

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -510,7 +510,7 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 				</div>
 			)}
 			{agentSetupNotice ? (
-				<div className="relative -mt-3">{inputElement}</div>
+				<div className="relative z-10 -mt-6">{inputElement}</div>
 			) : (
 				inputElement
 			)}

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -510,7 +510,7 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 			</div>
 		)}
 		{agentSetupNotice ? (
-			<div className="relative z-10 -mt-10 [&_[data-testid=chat-composer]]:bg-surface-secondary">{inputElement}</div>
+			<div className="relative z-10 -mt-10">{inputElement}</div>
 			) : (
 				inputElement
 			)}

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -394,7 +394,7 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	const isStreaming =
 		hasStreamState || chatStatus === "running" || chatStatus === "pending";
 
-	const [chatFullWidth] = useChatFullWidth();
+	const [_chatFullWidth] = useChatFullWidth();
 
 	const inputElement = (
 		<AgentChatInput
@@ -495,25 +495,17 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 			sshCommand={sshCommand}
 			attachedWorkspace={attachedWorkspace}
 			folder={folder}
+			agentSetupNotice={agentSetupNotice}
 		/>
 	);
 
-	if (!agentSetupNotice && !modelSelectorHelp) {
+	if (!modelSelectorHelp) {
 		return inputElement;
 	}
 
 	return (
 		<div>
-			{agentSetupNotice ? (
-				<div className="relative">
-					<div className={cn("mx-auto w-full", chatWidthClass(chatFullWidth))}>
-						{agentSetupNotice}
-					</div>
-					<div className="relative z-10 mt-[-2.25rem]">{inputElement}</div>
-				</div>
-			) : (
-				inputElement
-			)}
+			{inputElement}
 			{modelSelectorHelp && (
 				<div className="px-3 pt-1 text-2xs text-content-secondary">
 					{modelSelectorHelp}

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -510,7 +510,7 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 				</div>
 			)}
 			{agentSetupNotice ? (
-				<div className="relative z-10 -mt-6">{inputElement}</div>
+				<div className="relative z-10 -mt-10">{inputElement}</div>
 			) : (
 				inputElement
 			)}

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -510,7 +510,7 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 			</div>
 		)}
 		{agentSetupNotice ? (
-			<div className="relative z-10 -mt-10">{inputElement}</div>
+			<div className="relative z-10 -mt-14">{inputElement}</div>
 			) : (
 				inputElement
 			)}

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -505,13 +505,15 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	return (
 		<div>
 			{agentSetupNotice && (
-				<div
-					className={cn("mx-auto w-full pb-2", chatWidthClass(chatFullWidth))}
-				>
+				<div className={cn("mx-auto w-full", chatWidthClass(chatFullWidth))}>
 					{agentSetupNotice}
 				</div>
 			)}
-			{inputElement}
+			{agentSetupNotice ? (
+				<div className="relative -mt-3">{inputElement}</div>
+			) : (
+				inputElement
+			)}
 			{modelSelectorHelp && (
 				<div className="px-3 pt-1 text-2xs text-content-secondary">
 					{modelSelectorHelp}

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -185,6 +185,7 @@ interface AgentsSidebarProps {
 	isFetchingNextPage?: boolean;
 	archivedFilter: "active" | "archived";
 	onArchivedFilterChange?: (filter: "active" | "archived") => void;
+	hasArchivedChats?: boolean;
 	onCollapse?: () => void;
 	isPersonalModelOverridesEnabled?: boolean;
 	isAdmin?: boolean;
@@ -942,6 +943,7 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 		isFetchingNextPage,
 		archivedFilter,
 		onArchivedFilterChange,
+		hasArchivedChats = false,
 		onCollapse,
 		isPersonalModelOverridesEnabled = false,
 		isAdmin = false,
@@ -1243,21 +1245,23 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 														? "No archived agents"
 														: "No agents yet"}
 											</p>
-											<button
-												type="button"
-												className="mt-2 cursor-pointer border-none bg-transparent p-0 text-xs text-content-secondary hover:text-content-primary hover:underline"
-												onClick={() =>
-													onArchivedFilterChange?.(
-														archivedFilter === "archived"
-															? "active"
-															: "archived",
-													)
-												}
-											>
-												{archivedFilter === "archived"
-													? "← Back to active"
-													: "View archived →"}
-											</button>
+											{(archivedFilter === "archived" || hasArchivedChats) && (
+												<button
+														type="button"
+														className="mt-2 cursor-pointer border-none bg-transparent p-0 text-xs text-content-secondary hover:text-content-primary hover:underline"
+													onClick={() =>
+														onArchivedFilterChange?.(
+															archivedFilter === "archived"
+																	? "active"
+																	: "archived",
+															)
+														}
+												>
+													{archivedFilter === "archived"
+															? "← Back to active"
+															: "View archived →"}
+												</button>
+											)}
 										</div>
 									) : (
 										<div>


### PR DESCRIPTION
Replaces the existing modal dialog setup notice with two improvements:

1. **Inline setup notice banner** (commit 1): Context-aware banners above the chat input for admin and member states
2. **Multi-step onboarding wizard** (commit 2): Full onboarding flow for admins when no providers are configured

## Onboarding Wizard

Shown to admins when `providerCount === 0` and not yet dismissed. Three steps:

**Step 1: Connect an AI Provider**
- Provider selector with known providers (Anthropic, OpenAI, Google, Azure, Bedrock, OpenRouter)
- API key + base URL config per provider with external "Get API key" links
- Multiple providers can be saved, shown as green-bordered badges

**Step 2: Add a Model**
- Provider dropdown filtered to saved providers
- Model identifier with autocomplete for Anthropic/OpenAI (known models), free text for others
- Context limit auto-fills from known model defaults
- Multiple models shown as line items with green checkmarks

**Step 3: Extend Coder Agents**
- Informational cards linking to instructions, MCP servers, and template settings
- Placeholder images (to be replaced with final assets)

## Inline Setup Notice

Handles post-dismissal states and member experience:
- **Admin, no providers/models**: "set up a [provider] then add a [model]"
- **Admin, models only missing**: "set up a [model]"
- **Member, no models**: "AI models aren't available yet. Your admin is still getting things set up."

Notice renders as a rounded `bg-surface-grey` box layered behind the chat input.

## Dismissal

Onboarding wizard dismissal is persisted in `localStorage` (`agents.onboarding-dismissed`). Skip or "Start chatting" both dismiss permanently.

<details><summary>New files</summary>

- `AgentOnboarding/AgentOnboardingDialog.tsx` - Wizard dialog, step routing
- `AgentOnboarding/ProviderStep.tsx` - Provider setup step
- `AgentOnboarding/ModelStep.tsx` - Model setup step
- `AgentOnboarding/ExtendStep.tsx` - Informational final step
- `AgentOnboarding/onboardingState.ts` - localStorage dismissal tracking

</details>

> Generated by Coder Agents on behalf of @tracyjohnsonux