### PR TITLE
docs(docs/ai-coder/agents/extending-agents.md): fill skill and MCP discovery gaps

### DIFF
--- a/docs/ai-coder/agents/extending-agents.md
+++ b/docs/ai-coder/agents/extending-agents.md
@@ -114,6 +114,10 @@ Workspace templates can expose custom
 these tools automatically when it connects to a workspace and registers
 them alongside its built-in tools.
 
+For deployment-level MCP servers that admins register once for the whole
+deployment instead of per workspace, see
+[MCP Servers](./platform-controls/mcp-servers.md) under platform controls.
+
 ### Configuration
 
 Define MCP servers in `.mcp.json` at the workspace root. Each entry under
@@ -143,12 +147,38 @@ agent spawns the process in the workspace.
 **HTTP transport** — set `url`, and optionally `headers`. The agent connects
 to the HTTP endpoint from the workspace.
 
+`env` values in stdio configs support `${VAR}` substitution from the
+agent's process environment, so secrets can live in the workspace template
+or dotfiles rather than the committed `.mcp.json`. References to unset
+variables expand to the empty string.
+
+Server names (the keys under `mcpServers`) are used as a prefix for tool
+names. They cannot contain `__` (the reserved tool-name separator) and
+cannot start or end with an underscore. A single invalid server name
+causes the entire config file to be skipped.
+
+### Environment variables
+
+Override the default config file location with an environment variable on
+the workspace. Typically these are set in the workspace template,
+container image, or dotfiles:
+
+| Variable                           | Default     | Description                                                                                                                                                                                         |
+|------------------------------------|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `CODER_AGENT_EXP_MCP_CONFIG_FILES` | `.mcp.json` | Comma-separated list of MCP config files to read. Entries are resolved relative to the workspace working directory. When the same server name appears in multiple files, the first occurrence wins. |
+
 ### How discovery works
 
-The agent reads `.mcp.json` via the workspace agent connection on each chat
-turn. Discovery uses a 5-second timeout. Servers that fail to
-respond are skipped — partial success is acceptable. Empty results are not
-cached because the MCP servers may still be starting.
+The agent reads its MCP config files via the workspace agent connection on
+each chat turn and reuses connected servers across turns. Edits to a
+config file trigger an automatic reload (the agent watches the parent
+directories via fsnotify, debounced by 250 ms), so you do not need to
+restart the chat after changing `.mcp.json`. Empty results are not cached,
+because the MCP servers may still be starting up.
+
+Per-server connect attempts are bounded by a 30-second timeout. Servers
+that fail to respond within that budget are skipped, and partial success
+is acceptable.
 
 ### Tool naming
 
@@ -157,5 +187,7 @@ avoid collisions between servers and with built-in tools.
 
 ### Timeouts
 
-- **Discovery**: 5-second timeout.
+- **Discovery**: 35 seconds per chat turn.
+- **Per-server connect**: 30 seconds.
 - **Tool calls**: 60 seconds per invocation.
+- **Watcher debounce**: 250 ms after a config file change.

--- a/docs/ai-coder/agents/extending-agents.md
+++ b/docs/ai-coder/agents/extending-agents.md
@@ -13,15 +13,20 @@ automatically when a chat attaches to a workspace.
 
 ### How skills work
 
-Place skill directories under `.agents/skills/` relative to the workspace
-working directory. Each directory contains a required `SKILL.md` file and
-any supporting files the skill needs.
+Place skill directories under `.agents/skills/` (project-scoped, relative
+to the workspace working directory) or `~/.coder/skills/` (user-scoped, in
+the home directory of the user running the agent). Each directory contains
+a required `SKILL.md` file and any supporting files the skill needs.
 
-On the first turn of a workspace-attached chat, the agent scans
-`.agents/skills/` and builds an `<available-skills>` block in its system
-prompt listing each skill's name and description. Only frontmatter is read
-during discovery — the full skill content is loaded lazily when the agent
-calls a tool.
+On the first turn of a workspace-attached chat, the agent scans both
+locations in order (`~/.coder/skills/` first, then `.agents/skills/`) and
+builds an `<available-skills>` block in its system prompt listing each
+skill's name and description. If the same skill name appears in both
+locations, the copy in `~/.coder/skills/` wins, which lets developers keep
+user-specific skills on the workspace without committing them to the repo.
+
+Only frontmatter is read during discovery. The full skill content is
+loaded lazily when the agent calls a tool.
 
 Two tools are registered when skills are present:
 
@@ -74,6 +79,32 @@ Instructions for the skill go here...
 `read_skill_file` rejects absolute paths, paths containing `..`, and
 references to hidden files. All paths are resolved relative to the skill
 directory.
+
+### Environment variables
+
+Override the default discovery paths and meta filename with environment
+variables on the workspace. Typically these are set in the workspace
+template, container image, or dotfiles:
+
+| Variable                          | Default                          | Description                                                                                                          |
+|-----------------------------------|----------------------------------|----------------------------------------------------------------------------------------------------------------------|
+| `CODER_AGENT_EXP_SKILLS_DIRS`     | `~/.coder/skills,.agents/skills` | Comma-separated list of directories to search for skills. Earlier entries override later entries on name collisions. |
+| `CODER_AGENT_EXP_SKILL_META_FILE` | `SKILL.md`                       | Filename to look for inside each skill directory.                                                                    |
+
+### Claude Code interoperability
+
+The `SKILL.md` format the agent expects follows the same Agent Skills
+standard as [Claude Code skills](https://docs.claude.com/en/docs/claude-code/skills):
+kebab-case directory name, YAML frontmatter with `name` and `description`,
+free-form markdown body. Only the discovery path differs. Claude Code
+looks under `.claude/skills/` and `~/.claude/skills/`, while Coder looks
+under `.agents/skills/` and `~/.coder/skills/` by default.
+
+To share a skill with both runtimes, either:
+
+- Symlink `.agents/skills` to `.claude/skills` in the workspace.
+- Set `CODER_AGENT_EXP_SKILLS_DIRS=.claude/skills,~/.claude/skills` to
+  point the Coder agent at the Claude Code paths.
 
 ## Workspace MCP tools
 


### PR DESCRIPTION
## Summary

Fill gaps in the skills and MCP sections of `docs/ai-coder/agents/extending-agents.md` that customers ask about but the public docs do not currently cover. One file, two commits, no behavior changes.

### Skills

- **Home-scoped search path.** Note that `~/.coder/skills/` is also searched by default and overrides same-named skills in `.agents/skills/` (the default is `~/.coder/skills,.agents/skills`, first match wins per `discoverSkills` in `agent/agentcontextconfig/api.go`).
- **Environment variable overrides.** Add a table documenting `CODER_AGENT_EXP_SKILLS_DIRS` and `CODER_AGENT_EXP_SKILL_META_FILE`.
- **Claude Code interoperability.** Call out that `SKILL.md` follows the shared Agent Skills standard (kebab-case dir, frontmatter `name`/`description`, free-form body), explain that only the discovery path differs (`.claude/skills/` and `~/.claude/skills/` vs `.agents/skills/` and `~/.coder/skills/`), and give two concrete ways to share a single skill with both runtimes (symlink or env override).

DB-backed personal skills are intentionally not documented here: `coderd/x/skills/doc.go` says the v1 design explicitly excludes "stable public API documentation."

### MCP

- **Cross-link to deployment-level MCP servers.** Add a pointer to `platform-controls/mcp-servers.md` so customers know admin-registered MCP servers exist as a separate path from workspace `.mcp.json`.
- **`${VAR}` expansion in stdio `env` values** (per `resolveEnvVars` in `agent/x/agentmcp/config.go`), so secrets do not have to live in the committed `.mcp.json`.
- **Server-name restrictions:** keys under `mcpServers` cannot contain `__` (the reserved tool-name separator) or start/end with an underscore; one invalid name fails the whole file (`ParseConfig` returns an error which the manager logs and skips).
- **Environment variables subsection** documenting `CODER_AGENT_EXP_MCP_CONFIG_FILES` (comma-separated, multi-file, first-wins server-name dedup per `parseAndDedup`).
- **Auto-reload** via fsnotify with a 250 ms debounce, so editing `.mcp.json` does not require a chat restart.
- **Fix stale timeout claims.** The doc said "Discovery: 5-second timeout," which is wrong by ~7x. Actual values: `workspaceMCPDiscoveryTimeout = 35 * time.Second` in `coderd/x/chatd/chatd.go`, `connectTimeout = 30 * time.Second` in `agent/x/agentmcp/manager.go`, `toolCallTimeout = 60 * time.Second`. Updated `### Timeouts` to list discovery (35 s), per-server connect (30 s), tool calls (60 s), and watcher debounce (250 ms).

Also renames the new skills subsection heading from `### Configuration` to `### Environment variables` to avoid clashing with the existing `### Configuration` under "Workspace MCP tools."

## Verification

- `bash scripts/check_emdash.sh` passes (no new emdash/endash in the diff).
- `pnpm run lint-docs` passes (0 errors across 459 files).
- `pre-commit-light` git hook passes on both commits.

Docs-only change; no UI/UX proof needed.

<details>
<summary>Implementation plan</summary>

```
# Docs: fill skill and MCP discovery gaps in extending-agents.md

## Skills (commit 1)
1. "How skills work" intro: expand to mention both default search paths
   and override order.
2. New subsection "Environment variables" (between "Path safety" and the
   Workspace MCP tools section): table of supported env vars and defaults.
3. New subsection "Claude Code interoperability": note that SKILL.md
   follows the Agent Skills standard shared with Claude Code, explain
   the discovery-path difference, give two ways to bridge.

## MCP (commit 2)
4. Add a platform-controls cross-link at the top of the MCP section.
5. Document ${VAR} env expansion and server-name restrictions.
6. Add a "### Environment variables" subsection for
   CODER_AGENT_EXP_MCP_CONFIG_FILES.
7. Rewrite "### How discovery works" to mention fsnotify auto-reload
   and correct the stale "5-second timeout" claim.
8. Fix "### Timeouts" to reflect the real values.

## Constraints
- No emdashes or endashes in added lines (lint/emdash).
- Preserve existing wrap width (~75 chars).
- Do not rewrite unrelated sections.
```

</details>

---

_This PR was generated by Coder Agents on behalf of @david-fraley._