### PR TITLE
chore: remove dogfood skill disclosure guidance

### DIFF
--- a/.agents/skills/dogfood/SKILL.md
+++ b/.agents/skills/dogfood/SKILL.md
@@ -219,17 +219,9 @@ Preferred order:
 
 Only post to GitHub when the user asked for it or explicitly allowed it.
 
-When posting on Mike's behalf, include:
-
-```markdown
-> Mux working on Mike's behalf
-```
-
 Keep comments concise:
 
 ```markdown
-> Mux working on Mike's behalf
-
 Dogfood results:
 
 Passed:


### PR DESCRIPTION
> Mux created this PR for Mike.

Removes the dogfood skill instruction and sample PR comment that told agents to add a Mux disclosure when posting comments for Mike.

The PR comment template now starts directly with the dogfood results while keeping the explicit guard to only post to GitHub when asked or allowed.
