### PR TITLE
chore(site): enable eslint/no-implicit-coercion

### DIFF
--- a/site/.oxlintrc.jsonc
+++ b/site/.oxlintrc.jsonc
@@ -49,6 +49,7 @@
 		"typescript/prefer-enum-initializers": "error",
 		"typescript/no-inferrable-types": "error",
 		"eslint/no-else-return": "error",
+		"eslint/no-implicit-coercion": "error",
 		"eslint/no-restricted-imports": [
 			"error",
 			{

--- a/site/src/contexts/useWebpushNotifications.ts
+++ b/site/src/contexts/useWebpushNotifications.ts
@@ -21,7 +21,7 @@ export const useWebpushNotifications = (): WebpushNotifications => {
 	const enabled =
 		"Notification" in window &&
 		"serviceWorker" in navigator &&
-		!!buildInfoQuery.data?.webpush_public_key;
+		Boolean(buildInfoQuery.data?.webpush_public_key);
 
 	useEffect(() => {
 		// Check if browser supports push notifications

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -1449,7 +1449,7 @@ const WorkspacePickerList: FC<WorkspacePickerListProps> = ({
 				<CommandGroup>
 					{workspaceOptions?.map((workspace) => {
 						const isCrossOrg =
-							!!chatOrganizationId &&
+							Boolean(chatOrganizationId) &&
 							workspace.organization_id !== chatOrganizationId;
 
 						const item = (

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
@@ -53,7 +53,7 @@ export const ExecuteTool: React.FC<ExecuteToolProps> = (props) => {
 		props.output.length > 0 ||
 		props.status === "running" ||
 		props.isBackgrounded ||
-		!!props.killedBySignal
+		Boolean(props.killedBySignal)
 			? "preview"
 			: "collapsed";
 	const resolvedDisplayState = resolveAgentDisplayState(

--- a/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugStepCard.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugStepCard.tsx
@@ -95,10 +95,10 @@ export const DebugStepCard: FC<DebugStepCardProps> = ({
 
 	// Detect whether there is meaningful output.
 	const hasOutput =
-		!!response.content ||
+		Boolean(response.content) ||
 		response.toolCalls.length > 0 ||
 		response.warnings.length > 0 ||
-		!!response.finishReason;
+		Boolean(response.finishReason);
 
 	// Detect whether there is an error payload. `step.error` is typed
 	// as an object but the runtime may deliver either a string or a

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerKeysPage/OrganizationProvisionerKeysPage.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerKeysPage/OrganizationProvisionerKeysPage.tsx
@@ -17,7 +17,7 @@ const OrganizationProvisionerKeysPage: FC = () => {
 	const { entitlements } = useDashboard();
 	const provisionerKeyDaemonsQuery = useQuery({
 		...provisionerDaemonGroups(organizationName),
-		enabled: !!organization,
+		enabled: Boolean(organization),
 		select: (data) =>
 			[...data].sort((a, b) => b.daemons.length - a.daemons.length),
 	});

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/OrganizationProvisionersPage.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/OrganizationProvisionersPage.tsx
@@ -30,7 +30,7 @@ const OrganizationProvisionersPage: FC = () => {
 			...queryParams,
 			limit: 100,
 		}),
-		enabled: !!organization,
+		enabled: Boolean(organization),
 	});
 
 	if (!organization) {

--- a/site/src/pages/TerminalPage/TerminalPage.tsx
+++ b/site/src/pages/TerminalPage/TerminalPage.tsx
@@ -78,7 +78,8 @@ const TerminalPage: FC = () => {
 
 	// Raw ?command= params require explicit user confirmation.
 	// Trusted ?app= commands bypass the dialog.
-	const commandPendingConfirmation = !!command && !appSlug && !commandConfirmed;
+	const commandPendingConfirmation =
+		Boolean(command) && !appSlug && !commandConfirmed;
 	const initialCommand = appCommand
 		? appCommand
 		: command && commandConfirmed


### PR DESCRIPTION
This draft PR targets #25486 and enables the `eslint/no-implicit-coercion` rule in `site/.oxlintrc.jsonc`.

**Changes**
- Add `"eslint/no-implicit-coercion": "error"` to `.oxlintrc.jsonc`
- Auto-fix all existing `!!<expr>` violations to `Boolean(<expr>)` via `oxlint --fix`
- Run `pnpm format` (oxfmt) to ensure formatting is consistent

**Verification**
- `pnpm lint:check` passes with 0 warnings and 0 errors.

<!--
If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.
-->