### PR TITLE
fix(agent): set utf8 locale for tmux terminals

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -2324,15 +2324,30 @@ func TestAgent_ReconnectingPTY(t *testing.T) {
 					"%s -L %s new-session %q",
 					strconv.Quote(tmuxPath),
 					tmuxSocket,
-					fmt.Sprintf("printf '%%s\\n' '%s'; sleep 0.1", glyphs),
+					fmt.Sprintf("printf '%%s\\n' '%s'; sleep 5", glyphs),
 				)
 				netConn6, err := conn.ReconnectingPTY(ctx, uuid.New(), 80, 80, command)
 				require.NoError(t, err)
 				defer netConn6.Close()
 
-				bytes, err := io.ReadAll(netConn6)
-				require.NoError(t, err)
-				require.Contains(t, string(bytes), glyphs)
+				var output strings.Builder
+				buffer := make([]byte, 1024)
+				deadline := time.Now().Add(testutil.WaitMedium)
+				for !strings.Contains(output.String(), glyphs) {
+					if time.Now().After(deadline) {
+						require.Contains(t, output.String(), glyphs)
+					}
+					require.NoError(t, netConn6.SetReadDeadline(time.Now().Add(testutil.IntervalMedium)))
+					read, err := netConn6.Read(buffer)
+					if read > 0 {
+						_, _ = output.Write(buffer[:read])
+					}
+					var netErr net.Error
+					if errors.As(err, &netErr) && netErr.Timeout() {
+						continue
+					}
+					require.NoError(t, err)
+				}
 			}
 		})
 	}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -2314,17 +2314,21 @@ func TestAgent_ReconnectingPTY(t *testing.T) {
 			require.NoError(t, err)
 			require.Contains(t, string(bytes), "❯")
 
-			if hasTmux {
+			if !hasTmux {
+				t.Log("`tmux` not found, skipping tmux glyph regression")
+			} else {
 				glyphs := "⚠╭╮╰╯•›│─█▓░▄❯✔╌"
 				tmuxSocket := "coder-test-" + strings.ReplaceAll(uuid.NewString(), "-", "")
 				t.Cleanup(func() {
 					_ = exec.Command(tmuxPath, "-L", tmuxSocket, "kill-server").Run()
 				})
+				// Keep the pane alive with a shell builtin until the read loop sees
+				// the glyphs, otherwise tmux can restore the alternate screen first.
 				command := fmt.Sprintf(
 					"%s -L %s new-session %q",
 					strconv.Quote(tmuxPath),
 					tmuxSocket,
-					fmt.Sprintf("printf '%%s\\n' '%s'; sleep 5", glyphs),
+					fmt.Sprintf("printf '%%s\\n' '%s'; read _", glyphs),
 				)
 				netConn6, err := conn.ReconnectingPTY(ctx, uuid.New(), 80, 80, command)
 				require.NoError(t, err)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -2164,8 +2164,13 @@ func TestAgent_ReconnectingPTY(t *testing.T) {
 	_, err := exec.LookPath("screen")
 	hasScreen := err == nil
 
-	// Make sure UTF-8 works even with LANG set to something like C.
+	tmuxPath, err := exec.LookPath("tmux")
+	hasTmux := err == nil
+
+	// Make sure UTF-8 works even with locale variables set to C.
 	t.Setenv("LANG", "C")
+	t.Setenv("LC_CTYPE", "C")
+	t.Setenv("LC_ALL", "")
 
 	for _, backendType := range backends {
 		t.Run(backendType, func(t *testing.T) {
@@ -2308,6 +2313,27 @@ func TestAgent_ReconnectingPTY(t *testing.T) {
 			bytes, err := io.ReadAll(netConn5)
 			require.NoError(t, err)
 			require.Contains(t, string(bytes), "❯")
+
+			if hasTmux {
+				glyphs := "⚠╭╮╰╯•›│─█▓░▄❯✔╌"
+				tmuxSocket := "coder-test-" + strings.ReplaceAll(uuid.NewString(), "-", "")
+				t.Cleanup(func() {
+					_ = exec.Command(tmuxPath, "-L", tmuxSocket, "kill-server").Run()
+				})
+				command := fmt.Sprintf(
+					"%s -L %s new-session %q",
+					strconv.Quote(tmuxPath),
+					tmuxSocket,
+					fmt.Sprintf("printf '%%s\\n' '%s'; sleep 0.1", glyphs),
+				)
+				netConn6, err := conn.ReconnectingPTY(ctx, uuid.New(), 80, 80, command)
+				require.NoError(t, err)
+				defer netConn6.Close()
+
+				bytes, err := io.ReadAll(netConn6)
+				require.NoError(t, err)
+				require.Contains(t, string(bytes), glyphs)
+			}
 		})
 	}
 }

--- a/agent/reconnectingpty/buffered.go
+++ b/agent/reconnectingpty/buffered.go
@@ -59,8 +59,7 @@ func newBuffered(ctx context.Context, logger slog.Logger, execer agentexec.Exece
 	// Add TERM then start the command with a pty.  pty.Cmd duplicates Path as the
 	// first argument so remove it.
 	cmdWithEnv := execer.PTYCommandContext(ctx, cmd.Path, cmd.Args[1:]...)
-	//nolint:gocritic
-	cmdWithEnv.Env = append(rpty.command.Env, "TERM="+xterm256Color)
+	cmdWithEnv.Env = withTerminalEnv(rpty.command.Env)
 	cmdWithEnv.Dir = rpty.command.Dir
 	ptty, process, err := pty.Start(cmdWithEnv)
 	if err != nil {

--- a/agent/reconnectingpty/buffered.go
+++ b/agent/reconnectingpty/buffered.go
@@ -56,8 +56,8 @@ func newBuffered(ctx context.Context, logger slog.Logger, execer agentexec.Exece
 	}
 	rpty.circularBuffer = circularBuffer
 
-	// Add TERM then start the command with a pty.  pty.Cmd duplicates Path as the
-	// first argument so remove it.
+	// Add terminal environment then start the command with a pty.  pty.Cmd
+	// duplicates Path as the first argument so remove it.
 	cmdWithEnv := execer.PTYCommandContext(ctx, cmd.Path, cmd.Args[1:]...)
 	cmdWithEnv.Env = withTerminalEnv(rpty.command.Env)
 	cmdWithEnv.Dir = rpty.command.Dir

--- a/agent/reconnectingpty/reconnectingpty.go
+++ b/agent/reconnectingpty/reconnectingpty.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os/exec"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -30,6 +31,59 @@ const (
 	// terminal.
 	xterm256Color = "xterm-256color"
 )
+
+func withTerminalEnv(env []string) []string {
+	next := make([]string, 0, len(env)+2)
+	next = append(next, env...)
+	next = append(next, "TERM="+xterm256Color)
+	// tmux uses the process locale for glyph width and replacement behavior.
+	// Set only LC_CTYPE so other locale categories keep the user's settings.
+	// Preserve non-empty LC_ALL because it has higher precedence than LC_CTYPE.
+	if runtime.GOOS != "windows" && !effectiveLocaleIsUTF8(next) && !hasNonEmptyEnv(next, "LC_ALL") {
+		next = append(next, "LC_CTYPE="+terminalUTF8Locale())
+	}
+	return next
+}
+
+func terminalUTF8Locale() string {
+	if runtime.GOOS == "darwin" {
+		return "UTF-8"
+	}
+	return "C.UTF-8"
+}
+
+func effectiveLocaleIsUTF8(env []string) bool {
+	if value, ok := envValue(env, "LC_ALL"); ok {
+		return localeIsUTF8(value)
+	}
+	if value, ok := envValue(env, "LC_CTYPE"); ok {
+		return localeIsUTF8(value)
+	}
+	if value, ok := envValue(env, "LANG"); ok {
+		return localeIsUTF8(value)
+	}
+	return false
+}
+
+func localeIsUTF8(locale string) bool {
+	lower := strings.ToLower(locale)
+	return strings.Contains(lower, "utf-8") || strings.Contains(lower, "utf8")
+}
+
+func hasNonEmptyEnv(env []string, name string) bool {
+	value, ok := envValue(env, name)
+	return ok && value != ""
+}
+
+func envValue(env []string, name string) (string, bool) {
+	prefix := name + "="
+	for i := len(env) - 1; i >= 0; i-- {
+		if strings.HasPrefix(env[i], prefix) {
+			return strings.TrimPrefix(env[i], prefix), true
+		}
+	}
+	return "", false
+}
 
 // Options allows configuring the reconnecting pty.
 type Options struct {

--- a/agent/reconnectingpty/reconnectingpty.go
+++ b/agent/reconnectingpty/reconnectingpty.go
@@ -32,19 +32,22 @@ const (
 	xterm256Color = "xterm-256color"
 )
 
+// withTerminalEnv returns env with the terminal type and UTF-8 character locale expected by the web terminal.
 func withTerminalEnv(env []string) []string {
 	next := make([]string, 0, len(env)+2)
 	next = append(next, env...)
 	next = append(next, "TERM="+xterm256Color)
-	// tmux uses the process locale for glyph width and replacement behavior.
-	// Set only LC_CTYPE so other locale categories keep the user's settings.
-	// Preserve non-empty LC_ALL because it has higher precedence than LC_CTYPE.
+	// Some terminal applications use the process locale for glyph width and
+	// replacement behavior. Set only LC_CTYPE so other locale categories keep
+	// the user's settings. Preserve non-empty LC_ALL because it has higher
+	// precedence than LC_CTYPE.
 	if runtime.GOOS != "windows" && !effectiveLocaleIsUTF8(next) && !hasNonEmptyEnv(next, "LC_ALL") {
 		next = append(next, "LC_CTYPE="+terminalUTF8Locale())
 	}
 	return next
 }
 
+// terminalUTF8Locale returns a widely available UTF-8 character locale for the host OS.
 func terminalUTF8Locale() string {
 	if runtime.GOOS == "darwin" {
 		return "UTF-8"
@@ -52,14 +55,13 @@ func terminalUTF8Locale() string {
 	return "C.UTF-8"
 }
 
+// effectiveLocaleIsUTF8 reports whether the locale precedence chain resolves to UTF-8.
 func effectiveLocaleIsUTF8(env []string) bool {
-	if value, ok := envValue(env, "LC_ALL"); ok {
-		return localeIsUTF8(value)
-	}
-	if value, ok := envValue(env, "LC_CTYPE"); ok {
-		return localeIsUTF8(value)
-	}
-	if value, ok := envValue(env, "LANG"); ok {
+	for _, name := range []string{"LC_ALL", "LC_CTYPE", "LANG"} {
+		value, ok := envValue(env, name)
+		if !ok || value == "" {
+			continue
+		}
 		return localeIsUTF8(value)
 	}
 	return false
@@ -75,11 +77,12 @@ func hasNonEmptyEnv(env []string, name string) bool {
 	return ok && value != ""
 }
 
+// envValue returns the effective value for name using the last assignment.
 func envValue(env []string, name string) (string, bool) {
 	prefix := name + "="
 	for i := len(env) - 1; i >= 0; i-- {
-		if strings.HasPrefix(env[i], prefix) {
-			return strings.TrimPrefix(env[i], prefix), true
+		if value, ok := strings.CutPrefix(env[i], prefix); ok {
+			return value, true
 		}
 	}
 	return "", false

--- a/agent/reconnectingpty/reconnectingpty_test.go
+++ b/agent/reconnectingpty/reconnectingpty_test.go
@@ -79,15 +79,16 @@ func TestWithTerminalEnv(t *testing.T) {
 			require.True(t, ok)
 			require.Equal(t, xterm256Color, term)
 
+			wantLCCTYPE := tt.wantLCCTYPE
 			wantLCCTYPESet := tt.wantLCCTYPESet
-			if runtime.GOOS == "windows" && tt.wantLCCTYPE == defaultLocale {
-				wantLCCTYPESet = false
+			if runtime.GOOS == "windows" {
+				wantLCCTYPE, wantLCCTYPESet = envValue(tt.env, "LC_CTYPE")
 			}
 
 			locale, ok := envValue(got, "LC_CTYPE")
 			require.Equal(t, wantLCCTYPESet, ok)
 			if wantLCCTYPESet {
-				require.Equal(t, tt.wantLCCTYPE, locale)
+				require.Equal(t, wantLCCTYPE, locale)
 			}
 		})
 	}

--- a/agent/reconnectingpty/reconnectingpty_test.go
+++ b/agent/reconnectingpty/reconnectingpty_test.go
@@ -1,0 +1,86 @@
+//nolint:testpackage // Tests private env helpers directly.
+package reconnectingpty
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestWithTerminalEnv(t *testing.T) {
+	t.Parallel()
+
+	defaultLocale := "C.UTF-8"
+	if runtime.GOOS == "darwin" {
+		defaultLocale = "UTF-8"
+	}
+
+	tests := []struct {
+		name       string
+		env        []string
+		wantLocale string
+	}{
+		{
+			name:       "adds locale when missing",
+			env:        []string{"PATH=/bin"},
+			wantLocale: defaultLocale,
+		},
+		{
+			name:       "adds locale when lang is not utf8",
+			env:        []string{"LANG=C"},
+			wantLocale: defaultLocale,
+		},
+		{
+			name:       "keeps utf8 lang",
+			env:        []string{"LANG=C.UTF-8"},
+			wantLocale: "",
+		},
+		{
+			name:       "overrides non utf8 ctype",
+			env:        []string{"LANG=C.UTF-8", "LC_CTYPE=C"},
+			wantLocale: defaultLocale,
+		},
+		{
+			name:       "keeps utf8 lc all",
+			env:        []string{"LC_ALL=C.UTF-8"},
+			wantLocale: "",
+		},
+		{
+			name:       "preserves non empty lc all",
+			env:        []string{"LC_ALL=C"},
+			wantLocale: "",
+		},
+		{
+			name:       "ignores empty lc all",
+			env:        []string{"LC_ALL="},
+			wantLocale: defaultLocale,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := withTerminalEnv(tt.env)
+			if term, ok := envValue(got, "TERM"); !ok || term != xterm256Color {
+				t.Fatalf("TERM = %q, %v, want %q, true", term, ok, xterm256Color)
+			}
+
+			locale, ok := envValue(got, "LC_CTYPE")
+			if runtime.GOOS == "windows" {
+				if ok && locale == defaultLocale {
+					t.Fatalf("LC_CTYPE = %q, want no default", locale)
+				}
+				return
+			}
+			if tt.wantLocale == "" {
+				if ok && locale == defaultLocale {
+					t.Fatalf("LC_CTYPE = %q, want no default", locale)
+				}
+				return
+			}
+			if !ok || locale != tt.wantLocale {
+				t.Fatalf("LC_CTYPE = %q, %v, want %q, true", locale, ok, tt.wantLocale)
+			}
+		})
+	}
+}

--- a/agent/reconnectingpty/reconnectingpty_test.go
+++ b/agent/reconnectingpty/reconnectingpty_test.go
@@ -4,6 +4,8 @@ package reconnectingpty
 import (
 	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestWithTerminalEnv(t *testing.T) {
@@ -15,44 +17,56 @@ func TestWithTerminalEnv(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		env        []string
-		wantLocale string
+		name           string
+		env            []string
+		wantLCCTYPE    string
+		wantLCCTYPESet bool
 	}{
 		{
-			name:       "adds locale when missing",
-			env:        []string{"PATH=/bin"},
-			wantLocale: defaultLocale,
+			name:           "adds locale when missing",
+			env:            []string{"PATH=/bin"},
+			wantLCCTYPE:    defaultLocale,
+			wantLCCTYPESet: true,
 		},
 		{
-			name:       "adds locale when lang is not utf8",
-			env:        []string{"LANG=C"},
-			wantLocale: defaultLocale,
+			name:           "adds locale when lang is not utf8",
+			env:            []string{"LANG=C"},
+			wantLCCTYPE:    defaultLocale,
+			wantLCCTYPESet: true,
 		},
 		{
-			name:       "keeps utf8 lang",
-			env:        []string{"LANG=C.UTF-8"},
-			wantLocale: "",
+			name: "keeps utf8 lang",
+			env:  []string{"LANG=C.UTF-8"},
 		},
 		{
-			name:       "overrides non utf8 ctype",
-			env:        []string{"LANG=C.UTF-8", "LC_CTYPE=C"},
-			wantLocale: defaultLocale,
+			name:           "keeps utf8 ctype",
+			env:            []string{"LC_CTYPE=C.UTF-8"},
+			wantLCCTYPE:    "C.UTF-8",
+			wantLCCTYPESet: true,
 		},
 		{
-			name:       "keeps utf8 lc all",
-			env:        []string{"LC_ALL=C.UTF-8"},
-			wantLocale: "",
+			name:           "overrides non utf8 ctype",
+			env:            []string{"LANG=C.UTF-8", "LC_CTYPE=C"},
+			wantLCCTYPE:    defaultLocale,
+			wantLCCTYPESet: true,
 		},
 		{
-			name:       "preserves non empty lc all",
-			env:        []string{"LC_ALL=C"},
-			wantLocale: "",
+			name: "keeps utf8 lc all",
+			env:  []string{"LC_ALL=C.UTF-8"},
 		},
 		{
-			name:       "ignores empty lc all",
-			env:        []string{"LC_ALL="},
-			wantLocale: defaultLocale,
+			name: "preserves non empty lc all",
+			env:  []string{"LC_ALL=C"},
+		},
+		{
+			name:           "ignores empty lc all",
+			env:            []string{"LC_ALL="},
+			wantLCCTYPE:    defaultLocale,
+			wantLCCTYPESet: true,
+		},
+		{
+			name: "continues after empty lc all",
+			env:  []string{"LC_ALL=", "LANG=C.UTF-8"},
 		},
 	}
 
@@ -61,25 +75,19 @@ func TestWithTerminalEnv(t *testing.T) {
 			t.Parallel()
 
 			got := withTerminalEnv(tt.env)
-			if term, ok := envValue(got, "TERM"); !ok || term != xterm256Color {
-				t.Fatalf("TERM = %q, %v, want %q, true", term, ok, xterm256Color)
+			term, ok := envValue(got, "TERM")
+			require.True(t, ok)
+			require.Equal(t, xterm256Color, term)
+
+			wantLCCTYPESet := tt.wantLCCTYPESet
+			if runtime.GOOS == "windows" && tt.wantLCCTYPE == defaultLocale {
+				wantLCCTYPESet = false
 			}
 
 			locale, ok := envValue(got, "LC_CTYPE")
-			if runtime.GOOS == "windows" {
-				if ok && locale == defaultLocale {
-					t.Fatalf("LC_CTYPE = %q, want no default", locale)
-				}
-				return
-			}
-			if tt.wantLocale == "" {
-				if ok && locale == defaultLocale {
-					t.Fatalf("LC_CTYPE = %q, want no default", locale)
-				}
-				return
-			}
-			if !ok || locale != tt.wantLocale {
-				t.Fatalf("LC_CTYPE = %q, %v, want %q, true", locale, ok, tt.wantLocale)
+			require.Equal(t, wantLCCTYPESet, ok)
+			if wantLCCTYPESet {
+				require.Equal(t, tt.wantLCCTYPE, locale)
 			}
 		})
 	}

--- a/agent/reconnectingpty/reconnectingpty_test.go
+++ b/agent/reconnectingpty/reconnectingpty_test.go
@@ -39,6 +39,10 @@ func TestWithTerminalEnv(t *testing.T) {
 			env:  []string{"LANG=C.UTF-8"},
 		},
 		{
+			name: "keeps unhyphenated utf8 lang",
+			env:  []string{"LANG=C.UTF8"},
+		},
+		{
 			name:           "keeps utf8 ctype",
 			env:            []string{"LC_CTYPE=C.UTF-8"},
 			wantLCCTYPE:    "C.UTF-8",

--- a/agent/reconnectingpty/screen.go
+++ b/agent/reconnectingpty/screen.go
@@ -236,8 +236,7 @@ func (rpty *screenReconnectingPTY) doAttach(ctx context.Context, conn net.Conn, 
 		rpty.command.Path,
 		// pty.Cmd duplicates Path as the first argument so remove it.
 	}, rpty.command.Args[1:]...)...)
-	//nolint:gocritic
-	cmd.Env = append(rpty.command.Env, "TERM="+xterm256Color)
+	cmd.Env = withTerminalEnv(rpty.command.Env)
 	cmd.Dir = rpty.command.Dir
 	ptty, process, err := pty.Start(cmd, pty.WithPTYOption(
 		pty.WithSSHRequest(ssh.Pty{
@@ -352,8 +351,7 @@ func (rpty *screenReconnectingPTY) sendCommand(ctx context.Context, command stri
 			// -X runs a command in the matching session.
 			"-X", command,
 		)
-		//nolint:gocritic
-		cmd.Env = append(rpty.command.Env, "TERM="+xterm256Color)
+		cmd.Env = withTerminalEnv(rpty.command.Env)
 		cmd.Dir = rpty.command.Dir
 		cmd.Stdout = &stdout
 		err := cmd.Run()


### PR DESCRIPTION
> Mux is updating this PR on behalf of Mike.

## Summary
- Set a UTF-8 `LC_CTYPE` fallback for reconnecting PTYs when no effective UTF-8 locale is present.
- Preserve non-empty `LC_ALL` so explicit user locale choices still win.
- Add tmux glyph regression coverage for reconnecting PTYs, plus unit coverage for the env helper.
- Stabilize the tmux regression by keeping the pane alive until the glyph output is observed.
- Keep the env helper unit test expectations OS-aware for Windows and cover unhyphenated UTF8 locales.

## Validation
- `go test ./agent/reconnectingpty -run TestWithTerminalEnv -count=1`
- `go test ./agent -run '^TestAgent_ReconnectingPTY$/Buffered$' -count=1`
- `go test ./agent -run '^TestAgent_ReconnectingPTY$' -count=1`
- `make lint`
- `git commit` pre-commit hook
- `git push` pre-push hook
