### PR TITLE
fix(site): restore iOS backspace in agent chat input

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatMessageInput/ChatMessageInput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatMessageInput/ChatMessageInput.tsx
@@ -41,6 +41,7 @@ import {
 	$createFileReferenceNode,
 	FileReferenceNode,
 } from "./FileReferenceNode";
+import { IOSBackspacePlugin } from "./iosBackspace";
 import {
 	createPasteFile,
 	getPasteDataTransfer,
@@ -376,7 +377,7 @@ const ValueSyncPlugin: FC<{
 				editor.setEditorState(parsed);
 				return;
 			} catch {
-				// Malformed state — fall through to plain-text path.
+				// Malformed state, fall through to plain-text path.
 			}
 		}
 
@@ -736,6 +737,7 @@ const ChatMessageInput = ({
 					onEnter={disabled ? undefined : onEnter}
 					sendShortcut={sendShortcut}
 				/>
+				<IOSBackspacePlugin />
 				<ContentChangePlugin onChange={onChange} />
 				<ValueSyncPlugin
 					initialValue={initialValue}

--- a/site/src/pages/AgentsPage/components/ChatMessageInput/iosBackspace.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatMessageInput/iosBackspace.test.ts
@@ -1,0 +1,192 @@
+import {
+	$createParagraphNode,
+	$createRangeSelection,
+	$createTextNode,
+	$getRoot,
+	$getSelection,
+	$setSelection,
+	COMMAND_PRIORITY_HIGH,
+	createEditor,
+	DELETE_CHARACTER_COMMAND,
+	KEY_BACKSPACE_COMMAND,
+} from "lexical";
+import { describe, expect, it } from "vitest";
+import {
+	$createFileReferenceNode,
+	FileReferenceNode,
+} from "./FileReferenceNode";
+import {
+	registerIOSBackspaceCommand,
+	shouldUseNativeIOSBackspace,
+} from "./iosBackspace";
+
+function readBackspaceDecision(setup: () => void) {
+	const editor = createEditor({
+		namespace: "ios-backspace-test",
+		nodes: [FileReferenceNode],
+		onError: (error) => {
+			throw error;
+		},
+	});
+	let result = false;
+
+	editor.update(
+		() => {
+			setup();
+			result = shouldUseNativeIOSBackspace($getSelection());
+		},
+		{ discrete: true },
+	);
+
+	return result;
+}
+
+describe("shouldUseNativeIOSBackspace", () => {
+	it("allows native deletion from plain text selections", () => {
+		const result = readBackspaceDecision(() => {
+			const root = $getRoot();
+			const paragraph = $createParagraphNode();
+			const text = $createTextNode("hello");
+			root.append(paragraph);
+			paragraph.append(text);
+			text.select(5, 5);
+		});
+
+		expect(result).toBe(true);
+	});
+
+	it("keeps Lexical deletion when backspace would hit a file reference", () => {
+		const result = readBackspaceDecision(() => {
+			const root = $getRoot();
+			const paragraph = $createParagraphNode();
+			const fileReference = $createFileReferenceNode(
+				"main.go",
+				1,
+				1,
+				"package main",
+			);
+			const text = $createTextNode("hello");
+			root.append(paragraph);
+			paragraph.append(fileReference, text);
+			text.select(0, 0);
+		});
+
+		expect(result).toBe(false);
+	});
+
+	it("keeps Lexical deletion when the selection contains a file reference", () => {
+		const result = readBackspaceDecision(() => {
+			const root = $getRoot();
+			const paragraph = $createParagraphNode();
+			const before = $createTextNode("before");
+			const fileReference = $createFileReferenceNode(
+				"main.go",
+				1,
+				1,
+				"package main",
+			);
+			const after = $createTextNode("after");
+			root.append(paragraph);
+			paragraph.append(before, fileReference, after);
+
+			const selection = $createRangeSelection();
+			selection.anchor.set(before.getKey(), 0, "text");
+			selection.focus.set(after.getKey(), 5, "text");
+			$setSelection(selection);
+		});
+
+		expect(result).toBe(false);
+	});
+});
+
+describe("registerIOSBackspaceCommand", () => {
+	it("prevents default and dispatches Lexical deletion near file references", () => {
+		const editor = createEditor({
+			namespace: "ios-backspace-command-test",
+			nodes: [FileReferenceNode],
+			onError: (error) => {
+				throw error;
+			},
+		});
+		let deleteCharacterDirection: boolean | undefined;
+
+		registerIOSBackspaceCommand(editor, true);
+		editor.registerCommand(
+			DELETE_CHARACTER_COMMAND,
+			(isBackward) => {
+				deleteCharacterDirection = isBackward;
+				return true;
+			},
+			COMMAND_PRIORITY_HIGH,
+		);
+
+		editor.update(
+			() => {
+				const root = $getRoot();
+				const paragraph = $createParagraphNode();
+				const fileReference = $createFileReferenceNode(
+					"main.go",
+					1,
+					1,
+					"package main",
+				);
+				const text = $createTextNode("hello");
+				root.append(paragraph);
+				paragraph.append(fileReference, text);
+				text.select(0, 0);
+			},
+			{ discrete: true },
+		);
+
+		const event = new KeyboardEvent("keydown", {
+			cancelable: true,
+			key: "Backspace",
+		});
+
+		expect(editor.dispatchCommand(KEY_BACKSPACE_COMMAND, event)).toBe(true);
+		expect(event.defaultPrevented).toBe(true);
+		expect(deleteCharacterDirection).toBe(true);
+	});
+
+	it("does not prevent default for plain text iOS backspace", () => {
+		const editor = createEditor({
+			namespace: "ios-backspace-command-test",
+			nodes: [FileReferenceNode],
+			onError: (error) => {
+				throw error;
+			},
+		});
+		let deleteCharacterDirection: boolean | undefined;
+
+		registerIOSBackspaceCommand(editor, true);
+		editor.registerCommand(
+			DELETE_CHARACTER_COMMAND,
+			(isBackward) => {
+				deleteCharacterDirection = isBackward;
+				return true;
+			},
+			COMMAND_PRIORITY_HIGH,
+		);
+
+		editor.update(
+			() => {
+				const root = $getRoot();
+				const paragraph = $createParagraphNode();
+				const text = $createTextNode("hello");
+				root.append(paragraph);
+				paragraph.append(text);
+				text.select(5, 5);
+			},
+			{ discrete: true },
+		);
+
+		const event = new KeyboardEvent("keydown", {
+			cancelable: true,
+			key: "Backspace",
+		});
+
+		expect(editor.dispatchCommand(KEY_BACKSPACE_COMMAND, event)).toBe(true);
+		expect(event.defaultPrevented).toBe(false);
+		expect(deleteCharacterDirection).toBeUndefined();
+	});
+});

--- a/site/src/pages/AgentsPage/components/ChatMessageInput/iosBackspace.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatMessageInput/iosBackspace.test.ts
@@ -16,8 +16,8 @@ import {
 	FileReferenceNode,
 } from "./FileReferenceNode";
 import {
+	$shouldUseNativeBackspace,
 	registerIOSBackspaceCommand,
-	shouldUseNativeIOSBackspace,
 } from "./iosBackspace";
 
 function readBackspaceDecision(setup: () => void) {
@@ -33,7 +33,7 @@ function readBackspaceDecision(setup: () => void) {
 	editor.update(
 		() => {
 			setup();
-			result = shouldUseNativeIOSBackspace($getSelection());
+			result = $shouldUseNativeBackspace($getSelection());
 		},
 		{ discrete: true },
 	);
@@ -41,7 +41,7 @@ function readBackspaceDecision(setup: () => void) {
 	return result;
 }
 
-describe("shouldUseNativeIOSBackspace", () => {
+describe("$shouldUseNativeBackspace", () => {
 	it("allows native deletion from plain text selections", () => {
 		const result = readBackspaceDecision(() => {
 			const root = $getRoot();
@@ -50,6 +50,25 @@ describe("shouldUseNativeIOSBackspace", () => {
 			root.append(paragraph);
 			paragraph.append(text);
 			text.select(5, 5);
+		});
+
+		expect(result).toBe(true);
+	});
+
+	it("allows native deletion when a file reference precedes a mid-text caret", () => {
+		const result = readBackspaceDecision(() => {
+			const root = $getRoot();
+			const paragraph = $createParagraphNode();
+			const fileReference = $createFileReferenceNode(
+				"main.go",
+				1,
+				1,
+				"package main",
+			);
+			const text = $createTextNode("hello");
+			root.append(paragraph);
+			paragraph.append(fileReference, text);
+			text.select(3, 3);
 		});
 
 		expect(result).toBe(true);
@@ -68,6 +87,27 @@ describe("shouldUseNativeIOSBackspace", () => {
 			const text = $createTextNode("hello");
 			root.append(paragraph);
 			paragraph.append(fileReference, text);
+			text.select(0, 0);
+		});
+
+		expect(result).toBe(false);
+	});
+
+	it("keeps Lexical deletion when backspace would hit a file reference in the previous paragraph", () => {
+		const result = readBackspaceDecision(() => {
+			const root = $getRoot();
+			const previousParagraph = $createParagraphNode();
+			const currentParagraph = $createParagraphNode();
+			const fileReference = $createFileReferenceNode(
+				"main.go",
+				1,
+				1,
+				"package main",
+			);
+			const text = $createTextNode("hello");
+			root.append(previousParagraph, currentParagraph);
+			previousParagraph.append(fileReference);
+			currentParagraph.append(text);
 			text.select(0, 0);
 		});
 
@@ -100,6 +140,35 @@ describe("shouldUseNativeIOSBackspace", () => {
 });
 
 describe("registerIOSBackspaceCommand", () => {
+	it("falls through when native backspace is disabled", () => {
+		const editor = createEditor({
+			namespace: "ios-backspace-command-disabled-test",
+			onError: (error) => {
+				throw error;
+			},
+		});
+		let deleteCharacterDispatched = false;
+
+		registerIOSBackspaceCommand(editor, false);
+		editor.registerCommand(
+			DELETE_CHARACTER_COMMAND,
+			() => {
+				deleteCharacterDispatched = true;
+				return true;
+			},
+			COMMAND_PRIORITY_HIGH,
+		);
+
+		const event = new KeyboardEvent("keydown", {
+			cancelable: true,
+			key: "Backspace",
+		});
+
+		expect(editor.dispatchCommand(KEY_BACKSPACE_COMMAND, event)).toBe(false);
+		expect(event.defaultPrevented).toBe(false);
+		expect(deleteCharacterDispatched).toBe(false);
+	});
+
 	it("prevents default and dispatches Lexical deletion near file references", () => {
 		const editor = createEditor({
 			namespace: "ios-backspace-command-test",

--- a/site/src/pages/AgentsPage/components/ChatMessageInput/iosBackspace.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatMessageInput/iosBackspace.test.ts
@@ -137,6 +137,44 @@ describe("$shouldUseNativeBackspace", () => {
 
 		expect(result).toBe(false);
 	});
+
+	it("keeps Lexical deletion for element anchor at offset 0 after a file reference paragraph", () => {
+		const result = readBackspaceDecision(() => {
+			const root = $getRoot();
+			const firstParagraph = $createParagraphNode();
+			const secondParagraph = $createParagraphNode();
+			const fileReference = $createFileReferenceNode(
+				"main.go",
+				1,
+				1,
+				"package main",
+			);
+			root.append(firstParagraph, secondParagraph);
+			firstParagraph.append(fileReference);
+			secondParagraph.selectStart();
+		});
+
+		expect(result).toBe(false);
+	});
+
+	it("keeps Lexical deletion for element anchor at offset > 0 next to a file reference child", () => {
+		const result = readBackspaceDecision(() => {
+			const root = $getRoot();
+			const paragraph = $createParagraphNode();
+			const fileReference = $createFileReferenceNode(
+				"main.go",
+				1,
+				1,
+				"package main",
+			);
+			const text = $createTextNode("hello");
+			root.append(paragraph);
+			paragraph.append(fileReference, text);
+			paragraph.select(1, 1);
+		});
+
+		expect(result).toBe(false);
+	});
 });
 
 describe("registerIOSBackspaceCommand", () => {

--- a/site/src/pages/AgentsPage/components/ChatMessageInput/iosBackspace.tsx
+++ b/site/src/pages/AgentsPage/components/ChatMessageInput/iosBackspace.tsx
@@ -2,6 +2,7 @@ import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext
 import { CAN_USE_BEFORE_INPUT, IS_IOS } from "@lexical/utils";
 import {
 	$getSelection,
+	$isDecoratorNode,
 	$isElementNode,
 	$isRangeSelection,
 	type BaseSelection,
@@ -13,41 +14,40 @@ import {
 	type RangeSelection,
 } from "lexical";
 import { type FC, useEffect } from "react";
-import { FileReferenceNode } from "./FileReferenceNode";
 
-function containsFileReference(node: LexicalNode | null): boolean {
+function $containsDecoratorNode(node: LexicalNode | null): boolean {
 	if (!node) return false;
-	if (node instanceof FileReferenceNode) return true;
+	if ($isDecoratorNode(node)) return true;
 	if (!$isElementNode(node)) return false;
-	return node.getChildren().some(containsFileReference);
+	return node.getChildren().some($containsDecoratorNode);
 }
 
-function backspaceHitsFileReference(selection: RangeSelection): boolean {
+function $backspaceHitsDecoratorNode(selection: RangeSelection): boolean {
 	const { anchor } = selection;
 	if (anchor.type === "element") {
 		const node = anchor.getNode();
 		if (anchor.offset === 0) {
 			const topBlock = node.getTopLevelElement() ?? node;
-			return containsFileReference(topBlock.getPreviousSibling());
+			return $containsDecoratorNode(topBlock.getPreviousSibling());
 		}
-		return containsFileReference(node.getChildAtIndex(anchor.offset - 1));
+		return $containsDecoratorNode(node.getChildAtIndex(anchor.offset - 1));
 	}
 
 	if (anchor.offset !== 0) return false;
 	const textNode = anchor.getNode();
-	if (containsFileReference(textNode.getPreviousSibling())) return true;
+	if ($containsDecoratorNode(textNode.getPreviousSibling())) return true;
 
 	const topBlock = textNode.getTopLevelElement();
 	if (topBlock?.getFirstDescendant() !== textNode) return false;
-	return containsFileReference(topBlock.getPreviousSibling());
+	return $containsDecoratorNode(topBlock.getPreviousSibling());
 }
 
-export function shouldUseNativeIOSBackspace(
+export function $shouldUseNativeBackspace(
 	selection: BaseSelection | null,
 ): boolean {
 	if (!$isRangeSelection(selection)) return false;
-	if (selection.getNodes().some(containsFileReference)) return false;
-	return !selection.isCollapsed() || !backspaceHitsFileReference(selection);
+	if (selection.getNodes().some($containsDecoratorNode)) return false;
+	return !selection.isCollapsed() || !$backspaceHitsDecoratorNode(selection);
 }
 
 export function registerIOSBackspaceCommand(
@@ -60,10 +60,10 @@ export function registerIOSBackspaceCommand(
 			if (!useNativeBackspace) return false;
 
 			const selection = $getSelection();
-			if (shouldUseNativeIOSBackspace(selection)) return true;
+			if ($shouldUseNativeBackspace(selection)) return true;
 			if (!$isRangeSelection(selection)) return false;
 
-			// WebKit native deletion can desynchronize contentEditable=false chips.
+			// WebKit native deletion can desynchronize contentEditable=false decorator nodes.
 			event.preventDefault();
 			return editor.dispatchCommand(DELETE_CHARACTER_COMMAND, true);
 		},
@@ -75,8 +75,7 @@ const IOSBackspacePlugin: FC = function IOSBackspacePlugin() {
 	const [editor] = useLexicalComposerContext();
 
 	useEffect(() => {
-		// Lexical's default Backspace command prevents the beforeinput
-		// event that WebKit uses for keyboard state and delete acceleration.
+		// Lexical's default Backspace handler blocks the beforeinput event WebKit needs for delete acceleration.
 		return registerIOSBackspaceCommand(editor, IS_IOS && CAN_USE_BEFORE_INPUT);
 	}, [editor]);
 

--- a/site/src/pages/AgentsPage/components/ChatMessageInput/iosBackspace.tsx
+++ b/site/src/pages/AgentsPage/components/ChatMessageInput/iosBackspace.tsx
@@ -1,0 +1,86 @@
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { CAN_USE_BEFORE_INPUT, IS_IOS } from "@lexical/utils";
+import {
+	$getSelection,
+	$isElementNode,
+	$isRangeSelection,
+	type BaseSelection,
+	COMMAND_PRIORITY_HIGH,
+	DELETE_CHARACTER_COMMAND,
+	KEY_BACKSPACE_COMMAND,
+	type LexicalEditor,
+	type LexicalNode,
+	type RangeSelection,
+} from "lexical";
+import { type FC, useEffect } from "react";
+import { FileReferenceNode } from "./FileReferenceNode";
+
+function containsFileReference(node: LexicalNode | null): boolean {
+	if (!node) return false;
+	if (node instanceof FileReferenceNode) return true;
+	if (!$isElementNode(node)) return false;
+	return node.getChildren().some(containsFileReference);
+}
+
+function backspaceHitsFileReference(selection: RangeSelection): boolean {
+	const { anchor } = selection;
+	if (anchor.type === "element") {
+		const node = anchor.getNode();
+		if (anchor.offset === 0) {
+			const topBlock = node.getTopLevelElement() ?? node;
+			return containsFileReference(topBlock.getPreviousSibling());
+		}
+		return containsFileReference(node.getChildAtIndex(anchor.offset - 1));
+	}
+
+	if (anchor.offset !== 0) return false;
+	const textNode = anchor.getNode();
+	if (containsFileReference(textNode.getPreviousSibling())) return true;
+
+	const topBlock = textNode.getTopLevelElement();
+	if (topBlock?.getFirstDescendant() !== textNode) return false;
+	return containsFileReference(topBlock.getPreviousSibling());
+}
+
+export function shouldUseNativeIOSBackspace(
+	selection: BaseSelection | null,
+): boolean {
+	if (!$isRangeSelection(selection)) return false;
+	if (selection.getNodes().some(containsFileReference)) return false;
+	return !selection.isCollapsed() || !backspaceHitsFileReference(selection);
+}
+
+export function registerIOSBackspaceCommand(
+	editor: LexicalEditor,
+	useNativeBackspace: boolean,
+): () => void {
+	return editor.registerCommand(
+		KEY_BACKSPACE_COMMAND,
+		(event) => {
+			if (!useNativeBackspace) return false;
+
+			const selection = $getSelection();
+			if (shouldUseNativeIOSBackspace(selection)) return true;
+			if (!$isRangeSelection(selection)) return false;
+
+			// WebKit native deletion can desynchronize contentEditable=false chips.
+			event.preventDefault();
+			return editor.dispatchCommand(DELETE_CHARACTER_COMMAND, true);
+		},
+		COMMAND_PRIORITY_HIGH,
+	);
+}
+
+const IOSBackspacePlugin: FC = function IOSBackspacePlugin() {
+	const [editor] = useLexicalComposerContext();
+
+	useEffect(() => {
+		// Lexical's default Backspace command prevents the beforeinput
+		// event that WebKit uses for keyboard state and delete acceleration.
+		return registerIOSBackspaceCommand(editor, IS_IOS && CAN_USE_BEFORE_INPUT);
+	}, [editor]);
+
+	return null;
+};
+
+export { IOSBackspacePlugin };


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

iOS Safari long-press Backspace in the Agents chat composer was being handled by Lexical instead of native WebKit, so deletion stayed slow and character-by-character.

Let native iOS `beforeinput` handle plain text Backspace while keeping Lexical deletion for file-reference chips, where native `contentEditable=false` deletion can desynchronize the editor.

Refs https://github.com/facebook/lexical/issues/5040
Refs https://github.com/facebook/lexical/issues/7994
