### PR TITLE
feat(coderd): enforce DLP policy at workspace traffic gates

### DIFF
--- a/coderd/agentapi/subagent_test.go
+++ b/coderd/agentapi/subagent_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/dlppolicy"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
@@ -218,6 +220,72 @@ func TestSubAgentAPI(t *testing.T) {
 		require.Len(t, agents, 1)
 		lookedUp := agents[0]
 		assert.Equal(t, parentAgent.ID, lookedUp.ID, "instance ID lookup should still return the parent agent")
+	})
+
+	t.Run("CreateSubAgentInheritsDLPPolicy", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			log   = testutil.Logger(t)
+			clock = quartz.NewMock(t)
+
+			db, org     = newDatabaseWithOrg(t)
+			user, agent = newUserWithWorkspaceAgent(t, db, org)
+		)
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		// Attach a DLP policy with ssh_access disabled to the parent agent.
+		ao, err := db.GetAuthenticatedWorkspaceAgentAndBuildByAuthToken(dbauthz.AsSystemRestricted(ctx), agent.AuthToken)
+		require.NoError(t, err)
+		build, err := db.GetWorkspaceBuildByID(dbauthz.AsSystemRestricted(ctx), ao.WorkspaceBuild.ID)
+		require.NoError(t, err)
+
+		policy, err := db.InsertTemplateVersionDLPPolicy(dbauthz.AsProvisionerd(ctx), database.InsertTemplateVersionDLPPolicyParams{
+			ID:                   uuid.New(),
+			TemplateVersionID:    build.TemplateVersionID,
+			Name:                 "strict",
+			SshAccess:            false,
+			WebTerminalAccess:    true,
+			PortForwardingAccess: true,
+			AllowedApplications:  []string{},
+			CreatedAt:            dbtime.Now(),
+		})
+		require.NoError(t, err)
+		dbgen.SetWorkspaceAgentDLPPolicy(t, db, agent.ID, policy.ID)
+
+		// Re-fetch the parent so the API sees the updated DlpPolicyID.
+		parentAgent, err := db.GetWorkspaceAgentByID(dbauthz.AsSystemRestricted(ctx), agent.ID)
+		require.NoError(t, err)
+		require.True(t, parentAgent.DlpPolicyID.Valid, "parent should have the DLP policy attached")
+
+		api := newAgentAPI(t, log, db, clock, user, org, parentAgent)
+
+		createResp, err := api.CreateSubAgent(ctx, &proto.CreateSubAgentRequest{
+			Name:            "sub-agent",
+			Directory:       "/workspaces/test",
+			Architecture:    "amd64",
+			OperatingSystem: "linux",
+		})
+		require.NoError(t, err)
+
+		subAgentID, err := uuid.FromBytes(createResp.Agent.Id)
+		require.NoError(t, err)
+
+		// The sub-agent row must carry the parent's DLP policy id so that
+		// gates keyed on the agent ID return the same policy.
+		subAgent, err := db.GetWorkspaceAgentByID(dbauthz.AsSystemRestricted(ctx), subAgentID)
+		require.NoError(t, err)
+		require.True(t, subAgent.DlpPolicyID.Valid, "sub-agent should inherit the parent's DLP policy")
+		require.Equal(t, parentAgent.DlpPolicyID.UUID, subAgent.DlpPolicyID.UUID)
+
+		// And dlppolicy.ForAgent must resolve the same policy when looked up
+		// via the sub-agent's id, which is what the enforcement gates do.
+		resolved, err := dlppolicy.ForAgent(ctx, db, subAgentID)
+		require.NoError(t, err)
+		require.NotNil(t, resolved)
+		require.Equal(t, policy.ID, resolved.ID)
+		require.False(t, resolved.SshAccess, "sub-agent must inherit ssh_access=false")
 	})
 
 	type expectedAppError struct {

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -913,7 +913,6 @@ func New(options *Options) *API {
 		SignedTokenProvider: api.WorkspaceAppsProvider,
 		AgentProvider:       api.agentProvider,
 		StatsCollector:      workspaceapps.NewStatsCollector(options.WorkspaceAppsStatsCollectorOptions),
-		Database:            options.Database,
 
 		DisablePathApps:          options.DeploymentValues.DisablePathApps.Value(),
 		CookiesConfig:            options.DeploymentValues.HTTPCookies,

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -913,6 +913,7 @@ func New(options *Options) *API {
 		SignedTokenProvider: api.WorkspaceAppsProvider,
 		AgentProvider:       api.agentProvider,
 		StatsCollector:      workspaceapps.NewStatsCollector(options.WorkspaceAppsStatsCollectorOptions),
+		Database:            options.Database,
 
 		DisablePathApps:          options.DeploymentValues.DisablePathApps.Value(),
 		CookiesConfig:            options.DeploymentValues.HTTPCookies,

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -7532,6 +7532,13 @@ func (q *querier) UpdateWorkspaceAgentConnectionByID(ctx context.Context, arg da
 	return q.db.UpdateWorkspaceAgentConnectionByID(ctx, arg)
 }
 
+func (q *querier) UpdateWorkspaceAgentDLPPolicyByID(ctx context.Context, arg database.UpdateWorkspaceAgentDLPPolicyByIDParams) error {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceTemplate); err != nil {
+		return err
+	}
+	return q.db.UpdateWorkspaceAgentDLPPolicyByID(ctx, arg)
+}
+
 func (q *querier) UpdateWorkspaceAgentDirectoryByID(ctx context.Context, arg database.UpdateWorkspaceAgentDirectoryByIDParams) error {
 	workspace, err := q.db.GetWorkspaceByAgentID(ctx, arg.ID)
 	if err != nil {

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -2136,6 +2136,11 @@ func (s *MethodTestSuite) TestOrganization() {
 		dbm.EXPECT().InsertTemplateVersionDLPPolicy(gomock.Any(), arg).Return(database.TemplateVersionDlpPolicy{}, nil).AnyTimes()
 		check.Args(arg).Asserts(rbac.ResourceTemplate, policy.ActionUpdate)
 	}))
+	s.Run("UpdateWorkspaceAgentDLPPolicyByID", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
+		arg := database.UpdateWorkspaceAgentDLPPolicyByIDParams{ID: uuid.New(), DlpPolicyID: uuid.NullUUID{UUID: uuid.New(), Valid: true}}
+		dbm.EXPECT().UpdateWorkspaceAgentDLPPolicyByID(gomock.Any(), arg).Return(nil).AnyTimes()
+		check.Args(arg).Asserts(rbac.ResourceTemplate, policy.ActionUpdate)
+	}))
 	s.Run("GetTemplateVersionDLPPoliciesByTemplateVersionID", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		tpl := testutil.Fake(s.T(), faker, database.Template{})
 		tv := testutil.Fake(s.T(), faker, database.TemplateVersion{TemplateID: uuid.NullUUID{UUID: tpl.ID, Valid: true}, OrganizationID: tpl.OrganizationID, CreatedBy: tpl.CreatedBy})

--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -514,6 +514,7 @@ func WorkspaceAgent(t testing.TB, db database.Store, orig database.WorkspaceAgen
 		DisplayApps:              append([]database.DisplayApp{}, orig.DisplayApps...),
 		DisplayOrder:             takeFirst(orig.DisplayOrder, 1),
 		APIKeyScope:              takeFirst(orig.APIKeyScope, database.AgentKeyScopeEnumAll),
+		DlpPolicyID:              orig.DlpPolicyID,
 	})
 	require.NoError(t, err, "insert workspace agent")
 	if orig.FirstConnectedAt.Valid || orig.LastConnectedAt.Valid || orig.DisconnectedAt.Valid || orig.LastConnectedReplicaID.Valid {
@@ -581,6 +582,16 @@ func WorkspaceSubAgent(t testing.TB, db database.Store, parentAgent database.Wor
 	orig.ResourceID = parentAgent.ResourceID
 	subAgt := WorkspaceAgent(t, db, orig)
 	return subAgt
+}
+
+// SetWorkspaceAgentDLPPolicy sets the DLP policy reference on an existing
+// workspace agent. Helpful for tests that need to attach a policy to an
+// agent that was created via dbfake or other helpers.
+func SetWorkspaceAgentDLPPolicy(t testing.TB, db database.Store, agentID uuid.UUID, policyID uuid.UUID) {
+	require.NoError(t, db.UpdateWorkspaceAgentDLPPolicyByID(genCtx, database.UpdateWorkspaceAgentDLPPolicyByIDParams{
+		ID:          agentID,
+		DlpPolicyID: uuid.NullUUID{UUID: policyID, Valid: true},
+	}))
 }
 
 func WorkspaceAgentScript(t testing.TB, db database.Store, orig database.WorkspaceAgentScript) database.WorkspaceAgentScript {

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -5433,6 +5433,14 @@ func (m queryMetricsStore) UpdateWorkspaceAgentConnectionByID(ctx context.Contex
 	return r0
 }
 
+func (m queryMetricsStore) UpdateWorkspaceAgentDLPPolicyByID(ctx context.Context, arg database.UpdateWorkspaceAgentDLPPolicyByIDParams) error {
+	start := time.Now()
+	r0 := m.s.UpdateWorkspaceAgentDLPPolicyByID(ctx, arg)
+	m.queryLatencies.WithLabelValues("UpdateWorkspaceAgentDLPPolicyByID").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "UpdateWorkspaceAgentDLPPolicyByID").Inc()
+	return r0
+}
+
 func (m queryMetricsStore) UpdateWorkspaceAgentDirectoryByID(ctx context.Context, arg database.UpdateWorkspaceAgentDirectoryByIDParams) error {
 	start := time.Now()
 	r0 := m.s.UpdateWorkspaceAgentDirectoryByID(ctx, arg)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -10226,6 +10226,20 @@ func (mr *MockStoreMockRecorder) UpdateWorkspaceAgentConnectionByID(ctx, arg any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkspaceAgentConnectionByID", reflect.TypeOf((*MockStore)(nil).UpdateWorkspaceAgentConnectionByID), ctx, arg)
 }
 
+// UpdateWorkspaceAgentDLPPolicyByID mocks base method.
+func (m *MockStore) UpdateWorkspaceAgentDLPPolicyByID(ctx context.Context, arg database.UpdateWorkspaceAgentDLPPolicyByIDParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateWorkspaceAgentDLPPolicyByID", ctx, arg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateWorkspaceAgentDLPPolicyByID indicates an expected call of UpdateWorkspaceAgentDLPPolicyByID.
+func (mr *MockStoreMockRecorder) UpdateWorkspaceAgentDLPPolicyByID(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkspaceAgentDLPPolicyByID", reflect.TypeOf((*MockStore)(nil).UpdateWorkspaceAgentDLPPolicyByID), ctx, arg)
+}
+
 // UpdateWorkspaceAgentDirectoryByID mocks base method.
 func (m *MockStore) UpdateWorkspaceAgentDirectoryByID(ctx context.Context, arg database.UpdateWorkspaceAgentDirectoryByIDParams) error {
 	m.ctrl.T.Helper()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -1284,6 +1284,10 @@ type sqlcQuerier interface {
 	UpdateWorkspace(ctx context.Context, arg UpdateWorkspaceParams) (WorkspaceTable, error)
 	UpdateWorkspaceACLByID(ctx context.Context, arg UpdateWorkspaceACLByIDParams) error
 	UpdateWorkspaceAgentConnectionByID(ctx context.Context, arg UpdateWorkspaceAgentConnectionByIDParams) error
+	// UpdateWorkspaceAgentDLPPolicyByID is intended for tests and admin-tooling
+	// only. In normal operation `dlp_policy_id` is set at agent insert time and
+	// not modified afterwards.
+	UpdateWorkspaceAgentDLPPolicyByID(ctx context.Context, arg UpdateWorkspaceAgentDLPPolicyByIDParams) error
 	UpdateWorkspaceAgentDirectoryByID(ctx context.Context, arg UpdateWorkspaceAgentDirectoryByIDParams) error
 	UpdateWorkspaceAgentDisplayAppsByID(ctx context.Context, arg UpdateWorkspaceAgentDisplayAppsByIDParams) error
 	UpdateWorkspaceAgentLifecycleStateByID(ctx context.Context, arg UpdateWorkspaceAgentLifecycleStateByIDParams) error

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -30899,6 +30899,28 @@ func (q *sqlQuerier) UpdateWorkspaceAgentConnectionByID(ctx context.Context, arg
 	return err
 }
 
+const updateWorkspaceAgentDLPPolicyByID = `-- name: UpdateWorkspaceAgentDLPPolicyByID :exec
+UPDATE
+	workspace_agents
+SET
+	dlp_policy_id = $2
+WHERE
+	id = $1
+`
+
+type UpdateWorkspaceAgentDLPPolicyByIDParams struct {
+	ID          uuid.UUID     `db:"id" json:"id"`
+	DlpPolicyID uuid.NullUUID `db:"dlp_policy_id" json:"dlp_policy_id"`
+}
+
+// UpdateWorkspaceAgentDLPPolicyByID is intended for tests and admin-tooling
+// only. In normal operation `dlp_policy_id` is set at agent insert time and
+// not modified afterwards.
+func (q *sqlQuerier) UpdateWorkspaceAgentDLPPolicyByID(ctx context.Context, arg UpdateWorkspaceAgentDLPPolicyByIDParams) error {
+	_, err := q.db.ExecContext(ctx, updateWorkspaceAgentDLPPolicyByID, arg.ID, arg.DlpPolicyID)
+	return err
+}
+
 const updateWorkspaceAgentDirectoryByID = `-- name: UpdateWorkspaceAgentDirectoryByID :exec
 UPDATE
 	workspace_agents

--- a/coderd/database/queries/workspaceagents.sql
+++ b/coderd/database/queries/workspaceagents.sql
@@ -99,6 +99,17 @@ INSERT INTO
 VALUES
 	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21) RETURNING *;
 
+-- name: UpdateWorkspaceAgentDLPPolicyByID :exec
+-- UpdateWorkspaceAgentDLPPolicyByID is intended for tests and admin-tooling
+-- only. In normal operation `dlp_policy_id` is set at agent insert time and
+-- not modified afterwards.
+UPDATE
+	workspace_agents
+SET
+	dlp_policy_id = $2
+WHERE
+	id = $1;
+
 -- name: UpdateWorkspaceAgentConnectionByID :exec
 UPDATE
 	workspace_agents

--- a/coderd/dlppolicy/dlppolicy.go
+++ b/coderd/dlppolicy/dlppolicy.go
@@ -1,0 +1,42 @@
+// Package dlppolicy resolves an agent's data loss prevention policy for
+// coderd enforcement gates.
+package dlppolicy
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+)
+
+// ForAgent returns the DLP policy attached to the given workspace agent, or
+// nil if the agent has no policy configured. A nil result means no policy is
+// in effect (default-permissive).
+//
+// Callers must have already authorized the request against the workspace.
+// This function reads the policy under a system-restricted context because
+// the policy lookup is system-internal post-authz. Policies exist to
+// constrain the actor, so the lookup must not depend on the actor's
+// permissions.
+func ForAgent(ctx context.Context, db database.Store, agentID uuid.UUID) (*database.TemplateVersionDlpPolicy, error) {
+	// The escalation is intentional. See the doc comment above.
+	//nolint:gocritic // post-authz system-internal lookup, see doc comment.
+	p, err := db.GetTemplateVersionDLPPolicyByAgentID(dbauthz.AsSystemRestricted(ctx), agentID)
+	if errors.Is(err, sql.ErrNoRows) {
+		// A nil policy with a nil error is the documented "no policy" signal;
+		// callers check dlp != nil. A sentinel error would force every gate
+		// to branch on errors.Is, which is noisier than the existing
+		// nil-policy check.
+		//nolint:nilnil // nil policy is the no-policy signal; see doc comment.
+		return nil, nil
+	}
+	if err != nil {
+		return nil, xerrors.Errorf("get dlp policy for agent %q: %w", agentID, err)
+	}
+	return &p, nil
+}

--- a/coderd/dlppolicy/dlppolicy_test.go
+++ b/coderd/dlppolicy/dlppolicy_test.go
@@ -1,0 +1,93 @@
+package dlppolicy_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/dlppolicy"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestForAgent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("AgentWithPolicy", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		db, _ := dbtestutil.NewDB(t)
+		org := dbgen.Organization(t, db, database.Organization{})
+		user := dbgen.User(t, db, database.User{})
+		job := dbgen.ProvisionerJob(t, db, nil, database.ProvisionerJob{
+			Type:           database.ProvisionerJobTypeTemplateVersionImport,
+			OrganizationID: org.ID,
+		})
+		tv := dbgen.TemplateVersion(t, db, database.TemplateVersion{
+			JobID:          job.ID,
+			OrganizationID: org.ID,
+			CreatedBy:      user.ID,
+		})
+
+		policyID := uuid.New()
+		_, err := db.InsertTemplateVersionDLPPolicy(ctx, database.InsertTemplateVersionDLPPolicyParams{
+			ID:                   policyID,
+			TemplateVersionID:    tv.ID,
+			Name:                 "strict",
+			SshAccess:            true,
+			WebTerminalAccess:    false,
+			PortForwardingAccess: true,
+			AllowedApplications:  []string{"code-server"},
+			CreatedAt:            time.Now(),
+		})
+		require.NoError(t, err)
+
+		res := dbgen.WorkspaceResource(t, db, database.WorkspaceResource{JobID: job.ID})
+		agent := dbgen.WorkspaceAgent(t, db, database.WorkspaceAgent{
+			ResourceID:  res.ID,
+			DlpPolicyID: uuid.NullUUID{UUID: policyID, Valid: true},
+		})
+
+		got, err := dlppolicy.ForAgent(context.Background(), db, agent.ID)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.Equal(t, "strict", got.Name)
+		require.True(t, got.SshAccess)
+		require.False(t, got.WebTerminalAccess)
+	})
+
+	t.Run("AgentWithoutPolicy", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := dbtestutil.NewDB(t)
+		org := dbgen.Organization(t, db, database.Organization{})
+		job := dbgen.ProvisionerJob(t, db, nil, database.ProvisionerJob{
+			Type:           database.ProvisionerJobTypeWorkspaceBuild,
+			OrganizationID: org.ID,
+		})
+		res := dbgen.WorkspaceResource(t, db, database.WorkspaceResource{JobID: job.ID})
+		agent := dbgen.WorkspaceAgent(t, db, database.WorkspaceAgent{
+			ResourceID: res.ID,
+		})
+
+		got, err := dlppolicy.ForAgent(context.Background(), db, agent.ID)
+		require.NoError(t, err)
+		require.Nil(t, got)
+	})
+
+	t.Run("AgentNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := dbtestutil.NewDB(t)
+
+		got, err := dlppolicy.ForAgent(context.Background(), db, uuid.New())
+		require.NoError(t, err)
+		require.Nil(t, got)
+	})
+}

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -2322,6 +2322,7 @@ func (api *API) tailnetRPCConn(rw http.ResponseWriter, r *http.Request) {
 			Auth: &rbacAuthorizer{
 				sshPrep: sshPrep,
 				db:      api.Database,
+				store:   api.Database,
 			},
 		},
 	})

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -31,6 +31,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/dlppolicy"
 	"github.com/coder/coder/v2/coderd/externalauth"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
@@ -1316,6 +1317,23 @@ func (api *API) workspaceAgentClientCoordinate(rw http.ResponseWriter, r *http.R
 	waws := httpmw.WorkspaceAgentAndWorkspaceParam(r)
 	if !api.Authorize(r, policy.ActionSSH, waws) {
 		httpapi.ResourceNotFound(rw)
+		return
+	}
+
+	// DLP gate. Path A is the single chokepoint for all CLI peering. Once a
+	// client coordinates, the data plane is peer-to-peer Wireguard and coderd
+	// cannot differentiate ssh from port-forward from cp. So `ssh_access`
+	// here is coarse: false blocks every CLI channel.
+	dlp, err := dlppolicy.ForAgent(ctx, api.Database, waws.WorkspaceAgent.ID)
+	if err != nil {
+		httpapi.InternalServerError(rw, err)
+		return
+	}
+	if dlp != nil && !dlp.SshAccess {
+		httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
+			Message: "CLI access to this workspace is not permitted by the workspace policy.",
+			Detail:  "This blocks ssh, port-forward, cp, and speedtest.",
+		})
 		return
 	}
 

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -916,6 +916,118 @@ func TestWorkspaceAgentTailnet(t *testing.T) {
 	require.Equal(t, "test", strings.TrimSpace(string(output)))
 }
 
+func TestWorkspaceAgentClientCoordinate_DLPDenied(t *testing.T) {
+	t.Parallel()
+	client, db := coderdtest.NewWithDatabase(t, nil)
+	user := coderdtest.CreateFirstUser(t, client)
+
+	r := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+		OrganizationID: user.OrganizationID,
+		OwnerID:        user.UserID,
+	}).WithAgent().Do()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+
+	// Look up the build to find its template version ID, then insert a DLP
+	// policy and link the agent to it via dlp_policy_id.
+	agentToken, err := uuid.Parse(r.AgentToken)
+	require.NoError(t, err)
+	ao, err := db.GetAuthenticatedWorkspaceAgentAndBuildByAuthToken(dbauthz.AsSystemRestricted(ctx), agentToken)
+	require.NoError(t, err)
+	build, err := db.GetWorkspaceBuildByID(dbauthz.AsSystemRestricted(ctx), ao.WorkspaceBuild.ID)
+	require.NoError(t, err)
+
+	policy, err := db.InsertTemplateVersionDLPPolicy(dbauthz.AsProvisionerd(ctx), database.InsertTemplateVersionDLPPolicyParams{
+		ID:                   uuid.New(),
+		TemplateVersionID:    build.TemplateVersionID,
+		Name:                 "strict",
+		SshAccess:            false,
+		WebTerminalAccess:    true,
+		PortForwardingAccess: true,
+		AllowedApplications:  []string{},
+		CreatedAt:            dbtime.Now(),
+	})
+	require.NoError(t, err)
+
+	dbgen.SetWorkspaceAgentDLPPolicy(t, db, ao.WorkspaceAgent.ID, policy.ID)
+
+	//nolint: bodyclose // closed by ReadBodyAsError
+	resp, err := client.Request(ctx, http.MethodGet,
+		fmt.Sprintf("api/v2/workspaceagents/%s/coordinate", ao.WorkspaceAgent.ID),
+		nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	apiErr := codersdk.ReadBodyAsError(resp)
+	var sdkErr *codersdk.Error
+	require.ErrorAs(t, apiErr, &sdkErr)
+	require.Contains(t, sdkErr.Message, "workspace policy")
+	require.Contains(t, sdkErr.Detail, "ssh, port-forward, cp, and speedtest")
+}
+
+func TestWorkspaceAgentPTY_DLPDenied(t *testing.T) {
+	t.Parallel()
+	client, db := coderdtest.NewWithDatabase(t, nil)
+	user := coderdtest.CreateFirstUser(t, client)
+
+	r := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+		OrganizationID: user.OrganizationID,
+		OwnerID:        user.UserID,
+	}).WithAgent().Do()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+
+	agentToken, err := uuid.Parse(r.AgentToken)
+	require.NoError(t, err)
+	ao, err := db.GetAuthenticatedWorkspaceAgentAndBuildByAuthToken(dbauthz.AsSystemRestricted(ctx), agentToken)
+	require.NoError(t, err)
+	build, err := db.GetWorkspaceBuildByID(dbauthz.AsSystemRestricted(ctx), ao.WorkspaceBuild.ID)
+	require.NoError(t, err)
+
+	policy, err := db.InsertTemplateVersionDLPPolicy(dbauthz.AsProvisionerd(ctx), database.InsertTemplateVersionDLPPolicyParams{
+		ID:                   uuid.New(),
+		TemplateVersionID:    build.TemplateVersionID,
+		Name:                 "strict",
+		SshAccess:            true,
+		WebTerminalAccess:    false,
+		PortForwardingAccess: true,
+		AllowedApplications:  []string{},
+		CreatedAt:            dbtime.Now(),
+	})
+	require.NoError(t, err)
+
+	dbgen.SetWorkspaceAgentDLPPolicy(t, db, ao.WorkspaceAgent.ID, policy.ID)
+
+	// The PTY handler's workspace-app resolution rejects offline agents
+	// before the DLP gate. Mark the agent connected so the request reaches
+	// the gate.
+	require.NoError(t, db.UpdateWorkspaceAgentConnectionByID(
+		dbauthz.AsSystemRestricted(ctx),
+		database.UpdateWorkspaceAgentConnectionByIDParams{
+			ID:                     ao.WorkspaceAgent.ID,
+			FirstConnectedAt:       sql.NullTime{Time: dbtime.Now(), Valid: true},
+			LastConnectedAt:        sql.NullTime{Time: dbtime.Now(), Valid: true},
+			DisconnectedAt:         sql.NullTime{},
+			LastConnectedReplicaID: uuid.NullUUID{UUID: uuid.New(), Valid: true},
+			UpdatedAt:              dbtime.Now(),
+		},
+	))
+
+	// The PTY endpoint expects a WebSocket upgrade, but the DLP gate fires
+	// before the upgrade and returns a JSON 403. A plain HTTP GET is enough
+	// to exercise the gate.
+	//nolint: bodyclose // closed by ReadBodyAsError
+	resp, err := client.Request(ctx, http.MethodGet,
+		fmt.Sprintf("api/v2/workspaceagents/%s/pty", ao.WorkspaceAgent.ID),
+		nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	apiErr := codersdk.ReadBodyAsError(resp)
+	var sdkErr *codersdk.Error
+	require.ErrorAs(t, apiErr, &sdkErr)
+	require.Contains(t, sdkErr.Message, "workspace policy")
+	require.Contains(t, sdkErr.Message, "web terminal")
+}
+
 func TestWorkspaceAgentClientCoordinate_BadVersion(t *testing.T) {
 	t.Parallel()
 	client, db := coderdtest.NewWithDatabase(t, nil)

--- a/coderd/workspaceapps/db.go
+++ b/coderd/workspaceapps/db.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"path"
 	"slices"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -20,6 +21,7 @@ import (
 	"github.com/coder/coder/v2/coderd/connectionlog"
 	"github.com/coder/coder/v2/coderd/cryptokeys"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/dlppolicy"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/httpapi"
@@ -29,6 +31,7 @@ import (
 	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/coderd/tracing"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/site"
 )
 
 // DBTokenProvider provides authentication and authorization for workspace apps
@@ -147,6 +150,42 @@ func (p *DBTokenProvider) Issue(ctx context.Context, rw http.ResponseWriter, r *
 	}
 
 	aReq.dbReq = dbReq // Update audit request.
+
+	// DLP enforcement. The token provider is the single source of truth for
+	// both primary and workspace-proxy paths; gating here covers all callers.
+	dlp, err := dlppolicy.ForAgent(dangerousSystemCtx, p.Database, dbReq.Agent.ID)
+	if err != nil {
+		WriteWorkspaceApp500(p.Logger, p.DashboardURL, rw, r, &appReq, err, "check workspace policy")
+		return nil, "", false
+	}
+	if dlp != nil {
+		if appReq.AccessMethod == AccessMethodTerminal && !dlp.WebTerminalAccess {
+			httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
+				Message: "The web terminal is not permitted by the workspace policy.",
+			})
+			return nil, "", false
+		}
+		if appReq.AccessMethod != AccessMethodTerminal {
+			slugOrPort := appReq.AppSlugOrPort
+			isPort := appReq.AccessMethod == AccessMethodSubdomain && isPortStr(slugOrPort)
+			if isPort && !dlp.PortForwardingAccess {
+				site.RenderStaticErrorPage(rw, r, site.ErrorPageData{
+					Status:      http.StatusForbidden,
+					Title:       "Blocked by workspace policy",
+					Description: "Port forwarding is not permitted by the workspace policy.",
+				})
+				return nil, "", false
+			}
+			if !isPort && !slices.Contains(dlp.AllowedApplications, slugOrPort) {
+				site.RenderStaticErrorPage(rw, r, site.ErrorPageData{
+					Status:      http.StatusForbidden,
+					Title:       "Blocked by workspace policy",
+					Description: fmt.Sprintf("The %q application is not permitted by the workspace policy.", slugOrPort),
+				})
+				return nil, "", false
+			}
+		}
+	}
 
 	token.UserID = dbReq.UserID
 	token.WorkspaceID = dbReq.Workspace.ID
@@ -551,4 +590,10 @@ func (p *DBTokenProvider) connLogInitRequest(w http.ResponseWriter, r *http.Requ
 			return
 		}
 	}
+}
+
+// isPortStr returns true if s is a valid TCP port number string.
+func isPortStr(s string) bool {
+	_, err := strconv.ParseUint(s, 10, 16)
+	return err == nil
 }

--- a/coderd/workspaceapps/proxy.go
+++ b/coderd/workspaceapps/proxy.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"regexp"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -22,9 +21,7 @@ import (
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/agent/agentssh"
 	"github.com/coder/coder/v2/coderd/cryptokeys"
-	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
-	"github.com/coder/coder/v2/coderd/dlppolicy"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/coderd/jwtutils"
@@ -115,10 +112,6 @@ type ServerOptions struct {
 
 	AgentProvider  AgentProvider
 	StatsCollector *StatsCollector
-
-	// Database is used to look up DLP policies attached to workspace agents
-	// when gating dashboard traffic.
-	Database database.Store
 }
 
 // Server serves workspace apps endpoints, including:
@@ -642,7 +635,6 @@ func (s *Server) proxyWorkspaceApp(rw http.ResponseWriter, r *http.Request, appT
 	// proxyWorkspaceApp, so app.PortInfo() and app.AppSlugOrPort are not
 	// reliable here. The resolved token is the source of truth for both,
 	// and path-based apps cannot represent ports per ResolveRequest.
-	slugOrPort := appToken.AppSlugOrPort
 	isPort := false
 	protocol := ""
 	if appToken.AccessMethod == AccessMethodSubdomain {
@@ -650,38 +642,6 @@ func (s *Server) proxyWorkspaceApp(rw http.ResponseWriter, r *http.Request, appT
 	}
 	if isPort {
 		appURL.Scheme = protocol
-	}
-
-	// DLP gate. Port view (dashboard "Ports" tab) is gated by
-	// `port_forwarding_access`; coder_app slugs are gated by membership in
-	// `allowed_applications`. The HTML error-page form matches existing
-	// browser-facing denials in this handler.
-	dlp, err := dlppolicy.ForAgent(ctx, s.Database, appToken.AgentID)
-	if err != nil {
-		site.RenderStaticErrorPage(rw, r, site.ErrorPageData{
-			Status:      http.StatusInternalServerError,
-			Title:       "Internal Server Error",
-			Description: "Failed to load the workspace policy.",
-		})
-		return
-	}
-	if dlp != nil {
-		if isPort && !dlp.PortForwardingAccess {
-			site.RenderStaticErrorPage(rw, r, site.ErrorPageData{
-				Status:      http.StatusForbidden,
-				Title:       "Blocked by workspace policy",
-				Description: "Port forwarding is not permitted by the workspace policy.",
-			})
-			return
-		}
-		if !isPort && !slices.Contains(dlp.AllowedApplications, slugOrPort) {
-			site.RenderStaticErrorPage(rw, r, site.ErrorPageData{
-				Status:      http.StatusForbidden,
-				Title:       "Blocked by workspace policy",
-				Description: fmt.Sprintf("The %q application is not permitted by the workspace policy.", slugOrPort),
-			})
-			return
-		}
 	}
 
 	proxy := s.AgentProvider.ReverseProxy(appURL, s.DashboardURL, appToken.AgentID, app, s.Hostname)
@@ -780,20 +740,6 @@ func (s *Server) workspaceAgentPTY(rw http.ResponseWriter, r *http.Request) {
 	}
 	log := s.Logger.With(slog.F("agent_id", appToken.AgentID))
 	log.Debug(ctx, "resolved PTY request")
-
-	// DLP gate. Run before the WebSocket upgrade so we can return a JSON 403
-	// instead of a close code that the dashboard can't surface cleanly.
-	dlp, err := dlppolicy.ForAgent(ctx, s.Database, appToken.AgentID)
-	if err != nil {
-		httpapi.InternalServerError(rw, err)
-		return
-	}
-	if dlp != nil && !dlp.WebTerminalAccess {
-		httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
-			Message: "The web terminal is not permitted by the workspace policy.",
-		})
-		return
-	}
 
 	values := r.URL.Query()
 	parser := httpapi.NewQueryParamParser()

--- a/coderd/workspaceapps/proxy.go
+++ b/coderd/workspaceapps/proxy.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -21,7 +22,9 @@ import (
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/agent/agentssh"
 	"github.com/coder/coder/v2/coderd/cryptokeys"
+	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/dlppolicy"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/coderd/jwtutils"
@@ -112,6 +115,10 @@ type ServerOptions struct {
 
 	AgentProvider  AgentProvider
 	StatsCollector *StatsCollector
+
+	// Database is used to look up DLP policies attached to workspace agents
+	// when gating dashboard traffic.
+	Database database.Store
 }
 
 // Server serves workspace apps endpoints, including:
@@ -631,9 +638,50 @@ func (s *Server) proxyWorkspaceApp(rw http.ResponseWriter, r *http.Request, appT
 
 	r.URL.Path = path
 	appURL.RawQuery = ""
-	_, protocol, isPort := app.PortInfo()
+	// Path-based app routing passes an empty appurl.ApplicationURL into
+	// proxyWorkspaceApp, so app.PortInfo() and app.AppSlugOrPort are not
+	// reliable here. The resolved token is the source of truth for both,
+	// and path-based apps cannot represent ports per ResolveRequest.
+	slugOrPort := appToken.AppSlugOrPort
+	isPort := false
+	protocol := ""
+	if appToken.AccessMethod == AccessMethodSubdomain {
+		_, protocol, isPort = app.PortInfo()
+	}
 	if isPort {
 		appURL.Scheme = protocol
+	}
+
+	// DLP gate. Port view (dashboard "Ports" tab) is gated by
+	// `port_forwarding_access`; coder_app slugs are gated by membership in
+	// `allowed_applications`. The HTML error-page form matches existing
+	// browser-facing denials in this handler.
+	dlp, err := dlppolicy.ForAgent(ctx, s.Database, appToken.AgentID)
+	if err != nil {
+		site.RenderStaticErrorPage(rw, r, site.ErrorPageData{
+			Status:      http.StatusInternalServerError,
+			Title:       "Internal Server Error",
+			Description: "Failed to load the workspace policy.",
+		})
+		return
+	}
+	if dlp != nil {
+		if isPort && !dlp.PortForwardingAccess {
+			site.RenderStaticErrorPage(rw, r, site.ErrorPageData{
+				Status:      http.StatusForbidden,
+				Title:       "Blocked by workspace policy",
+				Description: "Port forwarding is not permitted by the workspace policy.",
+			})
+			return
+		}
+		if !isPort && !slices.Contains(dlp.AllowedApplications, slugOrPort) {
+			site.RenderStaticErrorPage(rw, r, site.ErrorPageData{
+				Status:      http.StatusForbidden,
+				Title:       "Blocked by workspace policy",
+				Description: fmt.Sprintf("The %q application is not permitted by the workspace policy.", slugOrPort),
+			})
+			return
+		}
 	}
 
 	proxy := s.AgentProvider.ReverseProxy(appURL, s.DashboardURL, appToken.AgentID, app, s.Hostname)
@@ -732,6 +780,20 @@ func (s *Server) workspaceAgentPTY(rw http.ResponseWriter, r *http.Request) {
 	}
 	log := s.Logger.With(slog.F("agent_id", appToken.AgentID))
 	log.Debug(ctx, "resolved PTY request")
+
+	// DLP gate. Run before the WebSocket upgrade so we can return a JSON 403
+	// instead of a close code that the dashboard can't surface cleanly.
+	dlp, err := dlppolicy.ForAgent(ctx, s.Database, appToken.AgentID)
+	if err != nil {
+		httpapi.InternalServerError(rw, err)
+		return
+	}
+	if dlp != nil && !dlp.WebTerminalAccess {
+		httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
+			Message: "The web terminal is not permitted by the workspace policy.",
+		})
+		return
+	}
 
 	values := r.URL.Query()
 	parser := httpapi.NewQueryParamParser()

--- a/coderd/workspaceapps_test.go
+++ b/coderd/workspaceapps_test.go
@@ -2,19 +2,26 @@ package coderd_test
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"testing"
 	"time"
 
 	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/cryptokeys"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/database/dbfake"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/jwtutils"
 	"github.com/coder/coder/v2/coderd/workspaceapps"
 	"github.com/coder/coder/v2/codersdk"
@@ -266,4 +273,89 @@ func TestWorkspaceApplicationAuth(t *testing.T) {
 			require.Equal(t, jwt.NewNumericDate(clock.Now().Add(-time.Minute)), token.NotBefore)
 		})
 	}
+}
+
+// TestWorkspaceAppsProxy_DLPDenied exercises the DLP enforcement gate in
+// workspaceapps.Server.proxyWorkspaceApp: a coder_app slug that is not in
+// the policy's AllowedApplications list must be blocked with the
+// "Blocked by workspace policy" static error page. The sibling
+// PortForwardingAccess gate runs in the same code path with isPort=true,
+// which the request resolver only sets for subdomain access; subdomain
+// coverage is deferred to stage 2 (needs wildcard-host setup).
+func TestWorkspaceAppsProxy_DLPDenied(t *testing.T) {
+	t.Parallel()
+
+	client, db := coderdtest.NewWithDatabase(t, nil)
+	user := coderdtest.CreateFirstUser(t, client)
+
+	r := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+		OrganizationID: user.OrganizationID,
+		OwnerID:        user.UserID,
+	}).WithAgent().Do()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+
+	agentToken, err := uuid.Parse(r.AgentToken)
+	require.NoError(t, err)
+	ao, err := db.GetAuthenticatedWorkspaceAgentAndBuildByAuthToken(dbauthz.AsSystemRestricted(ctx), agentToken)
+	require.NoError(t, err)
+	build, err := db.GetWorkspaceBuildByID(dbauthz.AsSystemRestricted(ctx), ao.WorkspaceBuild.ID)
+	require.NoError(t, err)
+	workspace, err := db.GetWorkspaceByID(dbauthz.AsSystemRestricted(ctx), build.WorkspaceID)
+	require.NoError(t, err)
+	owner, err := db.GetUserByID(dbauthz.AsSystemRestricted(ctx), workspace.OwnerID)
+	require.NoError(t, err)
+
+	// Attach an app the policy will not allow.
+	const blockedSlug = "blocked-app"
+	dbgen.WorkspaceApp(t, db, database.WorkspaceApp{
+		AgentID:      ao.WorkspaceAgent.ID,
+		Slug:         blockedSlug,
+		DisplayName:  "Blocked",
+		SharingLevel: database.AppSharingLevelOwner,
+		Url:          sql.NullString{String: "http://127.0.0.1:8080", Valid: true},
+	})
+
+	policy, err := db.InsertTemplateVersionDLPPolicy(dbauthz.AsProvisionerd(ctx), database.InsertTemplateVersionDLPPolicyParams{
+		ID:                   uuid.New(),
+		TemplateVersionID:    build.TemplateVersionID,
+		Name:                 "strict",
+		SshAccess:            true,
+		WebTerminalAccess:    true,
+		PortForwardingAccess: true,
+		AllowedApplications:  []string{"some-other-app"},
+		CreatedAt:            dbtime.Now(),
+	})
+	require.NoError(t, err)
+
+	dbgen.SetWorkspaceAgentDLPPolicy(t, db, ao.WorkspaceAgent.ID, policy.ID)
+
+	// The path-app handler rejects offline agents before the DLP gate. Mark
+	// the agent connected so the request reaches the gate.
+	require.NoError(t, db.UpdateWorkspaceAgentConnectionByID(
+		dbauthz.AsSystemRestricted(ctx),
+		database.UpdateWorkspaceAgentConnectionByIDParams{
+			ID:                     ao.WorkspaceAgent.ID,
+			FirstConnectedAt:       sql.NullTime{Time: dbtime.Now(), Valid: true},
+			LastConnectedAt:        sql.NullTime{Time: dbtime.Now(), Valid: true},
+			DisconnectedAt:         sql.NullTime{},
+			LastConnectedReplicaID: uuid.NullUUID{UUID: uuid.New(), Valid: true},
+			UpdatedAt:              dbtime.Now(),
+		},
+	))
+
+	// Request the blocked app via the path-app endpoint. The DLP gate
+	// returns the static "Blocked by workspace policy" HTML page.
+	appPath := fmt.Sprintf("/@%s/%s.%s/apps/%s/", owner.Username, workspace.Name, ao.WorkspaceAgent.Name, blockedSlug)
+	//nolint: bodyclose // closed below
+	resp, err := client.Request(ctx, http.MethodGet, appPath, nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Contains(t, string(body), "Blocked by workspace policy")
+	require.Contains(t, string(body), blockedSlug)
+	require.Contains(t, string(body), "is not permitted by the workspace policy")
+	require.Contains(t, string(body), "is not permitted by the workspace policy")
 }

--- a/coderd/workspaceupdates.go
+++ b/coderd/workspaceupdates.go
@@ -12,6 +12,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
+	"github.com/coder/coder/v2/coderd/dlppolicy"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/util/slice"
 	"github.com/coder/coder/v2/coderd/wspubsub"
@@ -297,6 +298,7 @@ func convertRows(rows []database.GetWorkspacesAndAgentsByOwnerIDRow) workspacesB
 type rbacAuthorizer struct {
 	sshPrep rbac.PreparedAuthorized
 	db      UpdatesQuerier
+	store   database.Store
 }
 
 func (r *rbacAuthorizer) AuthorizeTunnel(ctx context.Context, agentID uuid.UUID) error {
@@ -305,7 +307,19 @@ func (r *rbacAuthorizer) AuthorizeTunnel(ctx context.Context, agentID uuid.UUID)
 		return xerrors.Errorf("get workspace by agent ID: %w", err)
 	}
 	// Authorizes against `ActionSSH`
-	return r.sshPrep.Authorize(ctx, ws.RBACObject())
+	if err := r.sshPrep.Authorize(ctx, ws.RBACObject()); err != nil {
+		return err
+	}
+
+	// DLP gate: reuse ssh_access for Desktop (same data plane as CLI SSH).
+	dlp, err := dlppolicy.ForAgent(ctx, r.store, agentID)
+	if err != nil {
+		return xerrors.Errorf("check dlp policy: %w", err)
+	}
+	if dlp != nil && !dlp.SshAccess {
+		return xerrors.New("workspace agent not found or you do not have permission")
+	}
+	return nil
 }
 
 var _ tailnet.TunnelAuthorizer = (*rbacAuthorizer)(nil)


### PR DESCRIPTION
Enforces DLP policies at all workspace data-plane gates. Builds on top of #25536 which wires and persists the policy.

- SSH: deny `ConnectToCoordinateAndStartReporting` when `ssh_access` is false.
- Desktop (tailnet): deny `AuthorizeTunnel` via the same `ssh_access` flag.
- Web terminal: deny token issuance when `web_terminal_access` is false.
- Port forwarding: deny token issuance when `port_forwarding_access` is false.
- Workspace apps: deny token issuance when slug is not in `allowed_applications`.
- Consolidates all app/PTY/port DLP checks into `DBTokenProvider.Issue`, which is the single enforcement point for both primary and workspace-proxy paths (fixes nil-panic on proxy).

Depends on #25536

> [!NOTE]
> Generated by Coder Agents on behalf of @jscottmiller