### PR TITLE
feat: add workspace file upload agent API

### DIFF
--- a/agent/agentfiles/api.go
+++ b/agent/agentfiles/api.go
@@ -35,6 +35,9 @@ func (api *API) Routes() http.Handler {
 	r.Get("/read-file", api.HandleReadFile)
 	r.Get("/read-file-lines", api.HandleReadFileLines)
 	r.Post("/write-file", api.HandleWriteFile)
+	// Workspace chat uploads are workspace-owned after creation, so this
+	// agent API intentionally does not expose chat archive cleanup routes.
+	r.Post("/upload-chat-file", api.HandleUploadChatFile)
 	r.Post("/edit-files", api.HandleEditFiles)
 
 	return r

--- a/agent/agentfiles/uploadchatfile.go
+++ b/agent/agentfiles/uploadchatfile.go
@@ -1,0 +1,157 @@
+package agentfiles
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/google/uuid"
+	"github.com/spf13/afero"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/coderd/x/chatfiles"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/codersdk/workspacesdk"
+)
+
+// maxUploadChatFileCollisionAttempts bounds the collision-suffix
+// search so a poisoned directory cannot wedge the handler.
+const maxUploadChatFileCollisionAttempts = 1000
+
+// HandleUploadChatFile streams a request body into the workspace upload directory.
+func (api *API) HandleUploadChatFile(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	query := r.URL.Query()
+	parser := httpapi.NewQueryParamParser().
+		RequiredNotEmpty("chat_id").
+		RequiredNotEmpty("name")
+	chatID := parser.UUID(query, uuid.Nil, "chat_id")
+	rawName := parser.String(query, "", "name")
+	parser.ErrorExcessParams(query)
+	if len(parser.Errors) > 0 {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message:     "Query parameters have invalid values.",
+			Validations: parser.Errors,
+		})
+		return
+	}
+
+	name, err := chatfiles.SanitizeWorkspaceUploadName(rawName)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: err.Error(),
+		})
+		return
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: fmt.Sprintf("resolve home directory: %s", err),
+		})
+		return
+	}
+
+	// Workspace uploads intentionally stream without a MaxBytesReader cap.
+	// The uploaded bytes land in the user's workspace filesystem rather than
+	// coderd storage, so workspace disk limits are the enforcement boundary.
+	dir := chatfiles.WorkspaceUploadDir(home, chatID.String())
+	finalName, finalPath, size, err := api.writeUploadExclusiveSecure(home, chatID.String(), dir, name, r.Body)
+	if errors.Is(err, errUploadSecureUnsupported) {
+		err = api.prepareUploadDirPath(home, chatID.String(), dir)
+		if err == nil {
+			finalName, finalPath, size, err = api.writeUploadExclusivePath(dir, name, r.Body)
+		}
+	}
+	if err != nil {
+		status := http.StatusInternalServerError
+		switch {
+		case errors.Is(err, errUploadCollisionExhausted):
+			status = http.StatusConflict
+		case errors.Is(err, errUploadDirSymlink), errors.Is(err, os.ErrPermission):
+			status = http.StatusForbidden
+		}
+		httpapi.Write(ctx, rw, status, codersdk.Response{
+			Message: err.Error(),
+		})
+		return
+	}
+
+	httpapi.Write(ctx, rw, http.StatusOK, workspacesdk.AgentUploadChatFileResponse{
+		Path: finalPath,
+		Name: finalName,
+		Size: size,
+	})
+}
+
+var errUploadDirSymlink = xerrors.New("workspace upload directory must not contain symlinks")
+
+var errUploadSecureUnsupported = xerrors.New("secure workspace upload unsupported by filesystem")
+
+var errUploadCollisionExhausted = xerrors.New("too many existing files with the same name")
+
+func (api *API) prepareUploadDirPath(homeDir, chatID, dir string) error {
+	if err := api.rejectSymlinkedUploadDir(homeDir, chatID); err != nil {
+		return err
+	}
+	if err := api.filesystem.MkdirAll(dir, 0o755); err != nil {
+		return xerrors.Errorf("create upload directory: %w", err)
+	}
+	return api.rejectSymlinkedUploadDir(homeDir, chatID)
+}
+
+func (api *API) rejectSymlinkedUploadDir(homeDir, chatID string) error {
+	lstater, ok := api.filesystem.(afero.Lstater)
+	if !ok {
+		return nil
+	}
+	for _, dir := range []string{
+		filepath.Join(homeDir, ".coder"),
+		filepath.Join(homeDir, chatfiles.WorkspaceChatsDir),
+		chatfiles.WorkspaceChatDir(homeDir, chatID),
+		chatfiles.WorkspaceUploadDir(homeDir, chatID),
+	} {
+		info, _, err := lstater.LstatIfPossible(dir)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return xerrors.Errorf("check upload directory: %w", err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return xerrors.Errorf("%w: %s", errUploadDirSymlink, dir)
+		}
+	}
+	return nil
+}
+
+func (api *API) writeUploadExclusivePath(dir, name string, r io.Reader) (finalName, finalPath string, size int64, err error) {
+	for i := 1; i <= maxUploadChatFileCollisionAttempts; i++ {
+		candidate := chatfiles.AddCollisionSuffix(name, i)
+		candidatePath := filepath.Join(dir, candidate)
+
+		f, err := api.filesystem.OpenFile(candidatePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+		if err != nil {
+			if errors.Is(err, os.ErrExist) {
+				continue
+			}
+			return "", "", 0, xerrors.Errorf("create upload target: %w", err)
+		}
+
+		n, err := io.Copy(f, r)
+		if cerr := f.Close(); err == nil {
+			err = cerr
+		}
+		if err != nil {
+			_ = api.filesystem.Remove(candidatePath)
+			return "", "", 0, xerrors.Errorf("write upload: %w", err)
+		}
+		return candidate, candidatePath, n, nil
+	}
+	return "", "", 0, errUploadCollisionExhausted
+}

--- a/agent/agentfiles/uploadchatfile_secure_other.go
+++ b/agent/agentfiles/uploadchatfile_secure_other.go
@@ -1,0 +1,9 @@
+//go:build !unix
+
+package agentfiles
+
+import "io"
+
+func (api *API) writeUploadExclusiveSecure(homeDir, chatID, dir, name string, r io.Reader) (finalName, finalPath string, size int64, err error) {
+	return "", "", 0, errUploadSecureUnsupported
+}

--- a/agent/agentfiles/uploadchatfile_secure_unix.go
+++ b/agent/agentfiles/uploadchatfile_secure_unix.go
@@ -1,0 +1,90 @@
+//go:build unix
+
+package agentfiles
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/afero"
+	"golang.org/x/sys/unix"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/x/chatfiles"
+)
+
+func (api *API) writeUploadExclusiveSecure(homeDir, chatID, dir, name string, r io.Reader) (finalName, finalPath string, size int64, err error) {
+	switch api.filesystem.(type) {
+	case afero.OsFs, *afero.OsFs:
+	default:
+		return "", "", 0, errUploadSecureUnsupported
+	}
+
+	filesFD, err := openWorkspaceUploadDirNoFollow(homeDir, chatID)
+	if err != nil {
+		return "", "", 0, err
+	}
+	defer func() {
+		if cerr := unix.Close(filesFD); err == nil && cerr != nil {
+			err = cerr
+		}
+	}()
+
+	for i := 1; i <= maxUploadChatFileCollisionAttempts; i++ {
+		candidate := chatfiles.AddCollisionSuffix(name, i)
+		fd, err := unix.Openat(
+			filesFD,
+			candidate,
+			unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+			0o644,
+		)
+		if err != nil {
+			if errors.Is(err, unix.EEXIST) {
+				continue
+			}
+			if errors.Is(err, unix.ELOOP) {
+				return "", "", 0, xerrors.Errorf("%w: %s", errUploadDirSymlink, filepath.Join(dir, candidate))
+			}
+			return "", "", 0, xerrors.Errorf("create upload target: %w", err)
+		}
+
+		f := os.NewFile(uintptr(fd), candidate)
+		n, err := io.Copy(f, r)
+		if cerr := f.Close(); err == nil {
+			err = cerr
+		}
+		if err != nil {
+			_ = unix.Unlinkat(filesFD, candidate, 0)
+			return "", "", 0, xerrors.Errorf("write upload: %w", err)
+		}
+		return candidate, filepath.Join(dir, candidate), n, nil
+	}
+	return "", "", 0, errUploadCollisionExhausted
+}
+
+func openWorkspaceUploadDirNoFollow(homeDir, chatID string) (fd int, err error) {
+	current, err := unix.Open(homeDir, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return -1, xerrors.Errorf("open home directory: %w", err)
+	}
+
+	for _, component := range []string{".coder", "chats", chatID, chatfiles.WorkspaceUploadFilesSubdir} {
+		if err := unix.Mkdirat(current, component, 0o755); err != nil && !errors.Is(err, unix.EEXIST) {
+			_ = unix.Close(current)
+			return -1, xerrors.Errorf("create upload directory: %w", err)
+		}
+		next, err := unix.Openat(current, component, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+		if err != nil {
+			_ = unix.Close(current)
+			if errors.Is(err, unix.ELOOP) || errors.Is(err, unix.ENOTDIR) {
+				return -1, xerrors.Errorf("%w: %s", errUploadDirSymlink, filepath.Join(homeDir, component))
+			}
+			return -1, xerrors.Errorf("open upload directory: %w", err)
+		}
+		_ = unix.Close(current)
+		current = next
+	}
+	return current, nil
+}

--- a/agent/agentfiles/uploadchatfile_test.go
+++ b/agent/agentfiles/uploadchatfile_test.go
@@ -1,0 +1,251 @@
+package agentfiles_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"testing/iotest"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+
+	"cdr.dev/slog/v3"
+	"cdr.dev/slog/v3/sloggers/slogtest"
+	"github.com/coder/coder/v2/agent/agentfiles"
+	"github.com/coder/coder/v2/coderd/x/chatfiles"
+	"github.com/coder/coder/v2/codersdk/workspacesdk"
+)
+
+const uploadChatFileTestChatID = "00000000-0000-0000-0000-000000000001"
+
+// newUploadChatFileRouter wires the upload handler against the
+// supplied filesystem so each test gets its own router and fs.
+func newUploadChatFileRouter(t *testing.T, fs afero.Fs) http.Handler {
+	t.Helper()
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	api := agentfiles.NewAPI(logger, fs, nil)
+	r := chi.NewRouter()
+	r.Post("/upload-chat-file", api.HandleUploadChatFile)
+	return r
+}
+
+func uploadChatFileURL(chatID, name string) string {
+	q := url.Values{}
+	if chatID != "" {
+		q.Set("chat_id", chatID)
+	}
+	if name != "" {
+		q.Set("name", name)
+	}
+	return "/upload-chat-file?" + q.Encode()
+}
+
+func TestHandleUploadChatFile_HappyPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// macOS resolves $HOME through getpwuid by default; we already
+	// override it but USERPROFILE is read on Windows.
+	t.Setenv("USERPROFILE", home)
+
+	fs := afero.NewOsFs()
+	r := newUploadChatFileRouter(t, fs)
+
+	body := strings.NewReader("zip bytes")
+	req := httptest.NewRequest(http.MethodPost, uploadChatFileURL(uploadChatFileTestChatID, "archive.zip"), body)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp workspacesdk.AgentUploadChatFileResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+
+	want := filepath.Join(home, ".coder", "chats", uploadChatFileTestChatID, "files", "archive.zip")
+	require.Equal(t, want, resp.Path)
+	require.Equal(t, "archive.zip", resp.Name)
+	require.Equal(t, int64(len("zip bytes")), resp.Size)
+
+	contents, err := afero.ReadFile(fs, resp.Path)
+	require.NoError(t, err)
+	require.Equal(t, "zip bytes", string(contents))
+}
+
+func TestHandleUploadChatFile_SanitizesName(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	fs := afero.NewOsFs()
+	r := newUploadChatFileRouter(t, fs)
+
+	body := strings.NewReader("payload")
+	// Path components and unsafe whitespace must be stripped before
+	// the file lands on disk.
+	req := httptest.NewRequest(http.MethodPost, uploadChatFileURL(uploadChatFileTestChatID, "../etc/secret file.zip"), body)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp workspacesdk.AgentUploadChatFileResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+
+	require.Equal(t, "secret_file.zip", resp.Name)
+	require.Equal(t, filepath.Join(home, ".coder", "chats", uploadChatFileTestChatID, "files", "secret_file.zip"), resp.Path)
+}
+
+func TestHandleUploadChatFile_CollisionSuffix(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	fs := afero.NewOsFs()
+	r := newUploadChatFileRouter(t, fs)
+
+	uploadOnce := func(t *testing.T, body string) workspacesdk.AgentUploadChatFileResponse {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, uploadChatFileURL(uploadChatFileTestChatID, "archive.zip"),
+			strings.NewReader(body))
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+		var resp workspacesdk.AgentUploadChatFileResponse
+		require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+		return resp
+	}
+
+	first := uploadOnce(t, "first")
+	second := uploadOnce(t, "second")
+	third := uploadOnce(t, "third")
+
+	require.Equal(t, "archive.zip", first.Name)
+	require.Equal(t, "archive_2.zip", second.Name)
+	require.Equal(t, "archive_3.zip", third.Name)
+
+	for _, tt := range []struct {
+		resp workspacesdk.AgentUploadChatFileResponse
+		body string
+	}{
+		{resp: first, body: "first"},
+		{resp: second, body: "second"},
+		{resp: third, body: "third"},
+	} {
+		contents, err := os.ReadFile(tt.resp.Path)
+		require.NoError(t, err)
+		require.Equal(t, tt.body, string(contents))
+	}
+}
+
+func TestHandleUploadChatFile_CollisionExhausted(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	fs := afero.NewOsFs()
+	r := newUploadChatFileRouter(t, fs)
+	dir := chatfiles.WorkspaceUploadDir(home, uploadChatFileTestChatID)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	for i := 1; i <= 1000; i++ {
+		name := chatfiles.AddCollisionSuffix("archive.zip", i)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(name), 0o600))
+	}
+
+	req := httptest.NewRequest(http.MethodPost, uploadChatFileURL(uploadChatFileTestChatID, "archive.zip"), strings.NewReader("payload"))
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusConflict, rr.Code, rr.Body.String())
+	require.Contains(t, rr.Body.String(), "too many existing files")
+}
+
+func TestHandleUploadChatFile_RejectsSymlinkedUploadDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires elevated privileges on Windows")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	fs := afero.NewOsFs()
+	r := newUploadChatFileRouter(t, fs)
+	target := t.TempDir()
+	chatParent := filepath.Join(home, ".coder", "chats")
+	require.NoError(t, os.MkdirAll(chatParent, 0o755))
+	require.NoError(t, os.Symlink(target, filepath.Join(chatParent, uploadChatFileTestChatID)))
+
+	req := httptest.NewRequest(http.MethodPost,
+		uploadChatFileURL(uploadChatFileTestChatID, "archive.zip"),
+		strings.NewReader("payload"),
+	)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusForbidden, rr.Code, rr.Body.String())
+	require.Contains(t, rr.Body.String(), "symlink")
+	_, err := os.Stat(filepath.Join(target, "files", "archive.zip"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestHandleUploadChatFile_WriteErrorRemovesPartialFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	fs := afero.NewOsFs()
+	r := newUploadChatFileRouter(t, fs)
+
+	req := httptest.NewRequest(http.MethodPost,
+		uploadChatFileURL(uploadChatFileTestChatID, "archive.zip"),
+		iotest.ErrReader(os.ErrClosed),
+	)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code, rr.Body.String())
+
+	dir := chatfiles.WorkspaceUploadDir(home, uploadChatFileTestChatID)
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Empty(t, entries)
+}
+
+func TestHandleUploadChatFile_BadRequest(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewOsFs()
+	r := newUploadChatFileRouter(t, fs)
+
+	tests := []struct {
+		name     string
+		chatID   string
+		filename string
+		wantSub  string
+	}{
+		{name: "missing_chat_id", chatID: "", filename: "foo.zip", wantSub: "chat_id"},
+		{name: "missing_name", chatID: uploadChatFileTestChatID, filename: "", wantSub: "name"},
+		{name: "name_only_dots", chatID: uploadChatFileTestChatID, filename: "....", wantSub: "required"},
+		{name: "name_only_whitespace", chatID: uploadChatFileTestChatID, filename: "   ", wantSub: "required"},
+		{name: "chat_id_path_traversal", chatID: "../etc", filename: "foo.zip", wantSub: "chat_id"},
+		{name: "chat_id_with_slash", chatID: "a/b", filename: "foo.zip", wantSub: "chat_id"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodPost, uploadChatFileURL(tt.chatID, tt.filename), strings.NewReader("x"))
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req)
+
+			require.Equal(t, http.StatusBadRequest, rr.Code, rr.Body.String())
+			require.Contains(t, strings.ToLower(rr.Body.String()), tt.wantSub)
+		})
+	}
+}

--- a/coderd/x/chatfiles/workspace.go
+++ b/coderd/x/chatfiles/workspace.go
@@ -1,0 +1,130 @@
+package chatfiles
+
+import (
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"golang.org/x/xerrors"
+)
+
+const (
+	// MaxWorkspaceUploadFileNameBytes matches the stored attachment name limit.
+	MaxWorkspaceUploadFileNameBytes = MaxStoredFileNameBytes
+
+	// WorkspaceChatsDir is the directory under the agent's home directory
+	// that holds per-chat coder artifacts.
+	WorkspaceChatsDir = ".coder/chats"
+
+	// WorkspaceUploadFilesSubdir is the subdirectory of a chat's
+	// workspace folder that holds uploaded files.
+	WorkspaceUploadFilesSubdir = "files"
+)
+
+// ErrWorkspaceUploadNameRequired indicates that a workspace upload name
+// is empty after sanitization.
+var ErrWorkspaceUploadNameRequired = xerrors.New("workspace upload file name is required")
+
+// SanitizeWorkspaceUploadName extracts a basename, normalizes unsafe
+// whitespace, control characters, and Windows-invalid punctuation to
+// underscores, strips edge dots, and truncates the result to
+// MaxWorkspaceUploadFileNameBytes. It returns
+// ErrWorkspaceUploadNameRequired when no safe name remains.
+func SanitizeWorkspaceUploadName(name string) (string, error) {
+	name = strings.ReplaceAll(strings.TrimSpace(name), `\`, "/")
+	name = path.Base(name)
+	if name == "." || name == "/" {
+		return "", ErrWorkspaceUploadNameRequired
+	}
+	name = replaceUnsafeWorkspaceUploadRunes(name)
+	name = strings.Trim(name, ".")
+	name = truncateUTF8Bytes(name, MaxWorkspaceUploadFileNameBytes)
+	name = strings.Trim(name, ".")
+	if name == "" || name == "_" || isWindowsReservedUploadName(name) {
+		return "", ErrWorkspaceUploadNameRequired
+	}
+	return name, nil
+}
+
+func replaceUnsafeWorkspaceUploadRunes(name string) string {
+	var b strings.Builder
+	lastUnsafe := false
+	for _, r := range name {
+		if isUnsafeWorkspaceUploadRune(r) {
+			if !lastUnsafe {
+				_, _ = b.WriteString("_")
+				lastUnsafe = true
+			}
+			continue
+		}
+		_, _ = b.WriteRune(r)
+		lastUnsafe = false
+	}
+	return b.String()
+}
+
+func isUnsafeWorkspaceUploadRune(r rune) bool {
+	if unicode.IsSpace(r) || unicode.IsControl(r) || unicode.In(r, unicode.Cf) {
+		return true
+	}
+	switch r {
+	case '<', '>', ':', '"', '|', '?', '*':
+		return true
+	default:
+		return false
+	}
+}
+
+func isWindowsReservedUploadName(name string) bool {
+	stem, _, _ := strings.Cut(name, ".")
+	stem = strings.ToUpper(stem)
+	if stem == "CON" || stem == "PRN" || stem == "AUX" || stem == "NUL" {
+		return true
+	}
+	runes := []rune(stem)
+	if len(runes) != 4 {
+		return false
+	}
+	suffix := runes[3]
+	if !isWindowsReservedDeviceSuffix(suffix) {
+		return false
+	}
+	return strings.HasPrefix(stem, "COM") || strings.HasPrefix(stem, "LPT")
+}
+
+func isWindowsReservedDeviceSuffix(suffix rune) bool {
+	return (suffix >= '1' && suffix <= '9') || suffix == '¹' || suffix == '²' || suffix == '³'
+}
+
+// WorkspaceChatDir returns the per-chat directory under the agent home directory.
+func WorkspaceChatDir(homeDir, chatID string) string {
+	return filepath.Join(homeDir, WorkspaceChatsDir, chatID)
+}
+
+// WorkspaceUploadDir returns the per-chat workspace upload directory.
+func WorkspaceUploadDir(homeDir, chatID string) string {
+	return filepath.Join(WorkspaceChatDir(homeDir, chatID), WorkspaceUploadFilesSubdir)
+}
+
+// AddCollisionSuffix inserts a `_<n>` suffix before the extension when n > 1.
+func AddCollisionSuffix(name string, n int) string {
+	if n <= 1 {
+		return name
+	}
+	suffix := "_" + strconv.Itoa(n)
+	ext := path.Ext(name)
+	stem := strings.TrimSuffix(name, ext)
+	if stem == "" {
+		stem = name
+		ext = ""
+	}
+
+	stemBytes := MaxWorkspaceUploadFileNameBytes - len(suffix) - len(ext)
+	if stemBytes <= 0 {
+		return truncateUTF8Bytes(name, MaxWorkspaceUploadFileNameBytes-len(suffix)) + suffix
+	}
+	stem = truncateUTF8Bytes(stem, stemBytes)
+	return stem + suffix + ext
+}

--- a/coderd/x/chatfiles/workspace_test.go
+++ b/coderd/x/chatfiles/workspace_test.go
@@ -1,0 +1,131 @@
+package chatfiles_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/x/chatfiles"
+)
+
+func TestSanitizeWorkspaceUploadName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "plain", input: "foo.zip", want: "foo.zip"},
+		{name: "trim_spaces", input: "  foo.zip  ", want: "foo.zip"},
+		{name: "replace_whitespace", input: "my file.zip", want: "my_file.zip"},
+		{name: "strip_path_components", input: "/etc/passwd", want: "passwd"},
+		{name: "windows_path_components", input: "C:\\Windows\\System32\\evil.dll", want: "evil.dll"},
+		{name: "parent_dir_only", input: "../../etc/passwd", want: "passwd"},
+		{name: "strip_control_chars", input: "foo\x00\x01\x1fbar.zip", want: "foo_bar.zip"},
+		{name: "strip_unicode_control_chars", input: "foo\u202ebar.zip", want: "foo_bar.zip"},
+		{name: "replace_windows_invalid_chars", input: `bad:name*?.zip`, want: "bad_name_.zip"},
+		{name: "trim_leading_dots", input: "....bashrc", want: "bashrc"},
+		{name: "trim_trailing_dots", input: "report...", want: "report"},
+		{name: "unicode_passes_through", input: "résumé.pdf", want: "résumé.pdf"},
+		{name: "cjk_passes_through", input: "测试.zip", want: "测试.zip"},
+		{name: "reserved_windows_name", input: "CON", wantErr: true},
+		{name: "reserved_windows_name_with_extension", input: "com1.txt", wantErr: true},
+		{name: "reserved_windows_name_multiple_extensions", input: "COM1.txt.jpg", wantErr: true},
+		{name: "reserved_windows_name_archive_extensions", input: "NUL.tar.gz", wantErr: true},
+		{name: "reserved_windows_superscript_name", input: "COM¹.txt", wantErr: true},
+		{name: "empty_after_trim", input: "   ", wantErr: true},
+		{name: "all_unsafe", input: "/ ", wantErr: true},
+		{name: "only_dots", input: "....", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := chatfiles.SanitizeWorkspaceUploadName(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSanitizeWorkspaceUploadName_TrimsAfterTruncate(t *testing.T) {
+	t.Parallel()
+
+	long := strings.Repeat("a", chatfiles.MaxWorkspaceUploadFileNameBytes-1) + "." + strings.Repeat("b", 10)
+	got, err := chatfiles.SanitizeWorkspaceUploadName(long)
+	require.NoError(t, err)
+	require.Equal(t, strings.Repeat("a", chatfiles.MaxWorkspaceUploadFileNameBytes-1), got)
+}
+
+func TestSanitizeWorkspaceUploadName_Truncates(t *testing.T) {
+	t.Parallel()
+
+	long := strings.Repeat("a", chatfiles.MaxWorkspaceUploadFileNameBytes+50)
+	got, err := chatfiles.SanitizeWorkspaceUploadName(long)
+	require.NoError(t, err)
+	require.LessOrEqual(t, len(got), chatfiles.MaxWorkspaceUploadFileNameBytes)
+}
+
+func TestWorkspaceUploadDir(t *testing.T) {
+	t.Parallel()
+
+	const chatID = "00000000-0000-0000-0000-000000000001"
+	homeDir := filepath.Join("home", "coder")
+	require.Equal(t,
+		filepath.Join(homeDir, chatfiles.WorkspaceChatsDir, chatID, chatfiles.WorkspaceUploadFilesSubdir),
+		chatfiles.WorkspaceUploadDir(homeDir, chatID),
+	)
+}
+
+func TestWorkspaceChatDir(t *testing.T) {
+	t.Parallel()
+
+	const chatID = "00000000-0000-0000-0000-000000000001"
+	homeDir := filepath.Join("home", "coder")
+	require.Equal(t,
+		filepath.Join(homeDir, chatfiles.WorkspaceChatsDir, chatID),
+		chatfiles.WorkspaceChatDir(homeDir, chatID),
+	)
+}
+
+func TestAddCollisionSuffix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		n    int
+		want string
+	}{
+		{name: "no_suffix_when_first", in: "foo.zip", n: 1, want: "foo.zip"},
+		{name: "no_suffix_when_zero", in: "foo.zip", n: 0, want: "foo.zip"},
+		{name: "second", in: "foo.zip", n: 2, want: "foo_2.zip"},
+		{name: "tenth", in: "foo.zip", n: 10, want: "foo_10.zip"},
+		{name: "no_extension", in: "Dockerfile", n: 3, want: "Dockerfile_3"},
+		{name: "multi_dot", in: "archive.tar.gz", n: 2, want: "archive.tar_2.gz"},
+		{name: "only_extension", in: ".env", n: 2, want: ".env_2"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, chatfiles.AddCollisionSuffix(tt.in, tt.n))
+		})
+	}
+
+	longName := strings.Repeat("a", chatfiles.MaxWorkspaceUploadFileNameBytes)
+	got := chatfiles.AddCollisionSuffix(longName, 2)
+	require.LessOrEqual(t, len(got), chatfiles.MaxWorkspaceUploadFileNameBytes)
+	require.True(t, strings.HasSuffix(got, "_2"))
+
+	longStem := strings.Repeat("a", chatfiles.MaxWorkspaceUploadFileNameBytes-len(".zip")) + ".zip"
+	got = chatfiles.AddCollisionSuffix(longStem, 2)
+	require.LessOrEqual(t, len(got), chatfiles.MaxWorkspaceUploadFileNameBytes)
+	require.True(t, strings.HasSuffix(got, "_2.zip"))
+}

--- a/codersdk/workspacesdk/agentconn.go
+++ b/codersdk/workspacesdk/agentconn.go
@@ -121,6 +121,7 @@ type AgentConn interface {
 	ReadFile(ctx context.Context, path string, offset, limit int64) (io.ReadCloser, string, error)
 	ReadFileLines(ctx context.Context, path string, offset, limit int64, limits ReadFileLinesLimits) (ReadFileLinesResponse, error)
 	WriteFile(ctx context.Context, path string, reader io.Reader) error
+	UploadChatFile(ctx context.Context, req UploadChatFileRequest) (AgentUploadChatFileResponse, error)
 	EditFiles(ctx context.Context, edits FileEditRequest) (FileEditResponse, error)
 	SSH(ctx context.Context) (*gonet.TCPConn, error)
 	SSHClient(ctx context.Context) (*ssh.Client, error)
@@ -1018,6 +1019,53 @@ func (c *agentConn) WriteFile(ctx context.Context, path string, reader io.Reader
 		return xerrors.Errorf("decode response body: %w", err)
 	}
 	return nil
+}
+
+// UploadChatFileRequest is the streaming request for the agent's
+// chat-file upload endpoint.
+type UploadChatFileRequest struct {
+	// ChatID is the full chat UUID used to namespace the upload directory.
+	ChatID string
+	// Name is the filename. Coderd sanitizes it before the call; the
+	// agent sanitizes again as defense in depth for direct tailnet
+	// callers.
+	Name string
+	// Body must remain readable until UploadChatFile returns.
+	Body io.Reader
+}
+
+// AgentUploadChatFileResponse is the response from uploading to a workspace agent.
+type AgentUploadChatFileResponse struct {
+	// Path is the absolute path where the file was written on the workspace.
+	Path string `json:"path"`
+	// Name is the final basename after sanitization and collision suffixing.
+	Name string `json:"name"`
+	// Size is the number of bytes written to the workspace.
+	Size int64 `json:"size"`
+}
+
+// UploadChatFile streams a file body to the workspace agent.
+func (c *agentConn) UploadChatFile(ctx context.Context, req UploadChatFileRequest) (AgentUploadChatFileResponse, error) {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
+
+	res, err := c.apiRequest(ctx, http.MethodPost, agentAPIPath("/api/v0/upload-chat-file", neturl.Values{
+		"chat_id": []string{req.ChatID},
+		"name":    []string{req.Name},
+	}), req.Body)
+	if err != nil {
+		return AgentUploadChatFileResponse{}, xerrors.Errorf("upload chat file: %w", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return AgentUploadChatFileResponse{}, codersdk.ReadBodyAsError(res)
+	}
+
+	var out AgentUploadChatFileResponse
+	if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+		return AgentUploadChatFileResponse{}, xerrors.Errorf("decode upload chat file response: %w", err)
+	}
+	return out, nil
 }
 
 // ReadFileLinesResponse is the response from the line-based file reader.

--- a/codersdk/workspacesdk/agentconnmock/agentconnmock.go
+++ b/codersdk/workspacesdk/agentconnmock/agentconnmock.go
@@ -624,6 +624,21 @@ func (mr *MockAgentConnMockRecorder) TailnetConn() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TailnetConn", reflect.TypeOf((*MockAgentConn)(nil).TailnetConn))
 }
 
+// UploadChatFile mocks base method.
+func (m *MockAgentConn) UploadChatFile(ctx context.Context, req workspacesdk.UploadChatFileRequest) (workspacesdk.AgentUploadChatFileResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UploadChatFile", ctx, req)
+	ret0, _ := ret[0].(workspacesdk.AgentUploadChatFileResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UploadChatFile indicates an expected call of UploadChatFile.
+func (mr *MockAgentConnMockRecorder) UploadChatFile(ctx, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadChatFile", reflect.TypeOf((*MockAgentConn)(nil).UploadChatFile), ctx, req)
+}
+
 // WatchContainers mocks base method.
 func (m *MockAgentConn) WatchContainers(ctx context.Context, logger slog.Logger) (<-chan codersdk.WorkspaceAgentListContainersResponse, io.Closer, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
> Mux is working on behalf of Mike.

## Stack Context

This is PR 1 of 2 for the workspace file reference foundation:

1. Agent API layer, this PR
2. Backend, SDK, prompt integration, and frontend compatibility, #25540

The earlier full UI pass is being deferred and reworked outside this foundation stack.

## What?

Adds the agent-side file API used by coderd to stream workspace uploads directly onto the workspace agent:

- `POST /api/v0/upload-chat-file`
- shared workspace path and filename helpers
- collision-safe exclusive writes under `~/.coder/chats/<chat_id>/files/`
- symlink-resistant Unix writes using descriptor-relative `openat` calls
- workspacesdk client method and mock update

## Why?

Workspace uploads should bypass Postgres and coderd buffering. This layer gives coderd a narrow agent API for safe filename handling and chat-scoped writes without imposing a workspace upload size cap.
