### PR TITLE
feat: add chat workspace upload UI

### DIFF
--- a/site/src/api/api.test.ts
+++ b/site/src/api/api.test.ts
@@ -8,12 +8,41 @@ import {
 	MockWorkspaceBuild,
 	MockWorkspaceBuildParameter1,
 } from "#/testHelpers/entities";
-import { API, getURLWithSearchParams, MissingBuildParameters } from "./api";
+import {
+	API,
+	encodeRFC5987Value,
+	getURLWithSearchParams,
+	MissingBuildParameters,
+	sanitizeAsciiFilename,
+} from "./api";
 import type * as TypesGen from "./typesGenerated";
 
 const axiosInstance = API.getAxiosInstance();
 
 describe("api.ts", () => {
+	describe("sanitizeAsciiFilename", () => {
+		it.each([
+			["report.pdf", "report.pdf"],
+			['quote"name.txt', "quote_name.txt"],
+			["path\\name.txt", "path_name.txt"],
+			["résumé.pdf", "r_sum_.pdf"],
+			["line\nfeed.txt", "line_feed.txt"],
+			["", ""],
+		])("sanitizes %j to %j", (input, expected) => {
+			expect(sanitizeAsciiFilename(input)).toBe(expected);
+		});
+	});
+
+	describe("encodeRFC5987Value", () => {
+		it.each([
+			["report.pdf", "report.pdf"],
+			["résumé (final)*.pdf", "r%C3%A9sum%C3%A9%20%28final%29%2A.pdf"],
+			["quote'name.txt", "quote%27name.txt"],
+		])("encodes %j to %j", (input, expected) => {
+			expect(encodeRFC5987Value(input)).toBe(expected);
+		});
+	});
+
 	describe("login", () => {
 		it("should return LoginResponse", async () => {
 			// given

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -183,7 +183,7 @@ export const watchChatDesktop = (chatId: string): WebSocket => {
 	const socket = createWebSocket(
 		`/api/experimental/chats/${chatId}/stream/desktop`,
 	);
-	// RFB is a binary protocol — noVNC expects arraybuffer, not blob.
+	// RFB is a binary protocol, noVNC expects arraybuffer, not blob.
 	socket.binaryType = "arraybuffer";
 	return socket;
 };
@@ -416,6 +416,26 @@ const userSkillsPath = (user: string) =>
 const userSkillPath = (user: string, name: string) =>
 	`${userSkillsPath(user)}/${encodeURIComponent(name)}`;
 const mcpServerConfigsPath = "/api/experimental/mcp/servers";
+
+// Map non-printable, quote, backslash, and non-ASCII bytes to '_'
+// so the HTTP Content-Disposition fallback stays printable ASCII.
+export function sanitizeAsciiFilename(name: string): string {
+	let out = "";
+	for (let i = 0; i < name.length; i++) {
+		const code = name.charCodeAt(i);
+		const printable = code >= 0x20 && code <= 0x7e;
+		const safe = printable && code !== 0x22 && code !== 0x5c;
+		out += safe ? name[i] : "_";
+	}
+	return out;
+}
+
+export function encodeRFC5987Value(value: string): string {
+	return encodeURIComponent(value).replace(
+		/['()*]/g,
+		(char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+	);
+}
 
 type ChatCostDateParams = {
 	start_date?: string;
@@ -3136,7 +3156,7 @@ class ExperimentalApiMethods {
 					// non-ASCII characters. Placing the raw name directly in
 					// the header causes XMLHttpRequest to throw because HTTP
 					// headers only allow ISO-8859-1 code points.
-					"Content-Disposition": `attachment; filename="file"; filename*=UTF-8''${encodeURIComponent(file.name)}`,
+					"Content-Disposition": `attachment; filename="file"; filename*=UTF-8''${encodeRFC5987Value(file.name)}`,
 				},
 			},
 		);
@@ -3149,6 +3169,26 @@ class ExperimentalApiMethods {
 			{ responseType: "text" },
 		);
 		return response.data as string;
+	};
+
+	uploadChatWorkspaceFile = async (
+		chatId: string,
+		file: File,
+		signal?: AbortSignal,
+	): Promise<TypesGen.UploadChatWorkspaceFileResponse> => {
+		const asciiName = sanitizeAsciiFilename(file.name) || "upload";
+		const response = await this.axios.post(
+			`/api/experimental/chats/${chatId}/workspace-files`,
+			file,
+			{
+				headers: {
+					"Content-Type": file.type || "application/octet-stream",
+					"Content-Disposition": `attachment; filename="${asciiName}"; filename*=UTF-8''${encodeRFC5987Value(file.name)}`,
+				},
+				signal,
+			},
+		);
+		return response.data;
 	};
 
 	// Chat API methods

--- a/site/src/pages/AgentsPage/AgentChatPage.test.ts
+++ b/site/src/pages/AgentsPage/AgentChatPage.test.ts
@@ -14,6 +14,7 @@ import {
 import type { ChatMessageInputRef } from "./components/AgentChatInput";
 import { createChatStore } from "./components/ChatConversation/chatStore";
 import type { PendingAttachment } from "./components/ChatPageContent";
+import type { PendingWorkspaceUpload } from "./utils/chatAttachments";
 import {
 	clearPersistedSidebarTabId,
 	getPersistedSidebarTabId,
@@ -483,7 +484,7 @@ describe("useConversationEditingState", () => {
 		expect(result.current.remountKey).toBe(remountKeyBefore + 1);
 
 		await act(async () => {
-			await result.current.handleSendFromInput("hello");
+			await result.current.handleSendFromInput({ message: "hello" });
 		});
 
 		const remountKeyAfterSend = result.current.remountKey;
@@ -496,7 +497,12 @@ describe("useConversationEditingState", () => {
 		// the same text, so the editor is forced to reinitialize.
 		expect(result.current.remountKey).toBe(remountKeyAfterSend + 1);
 		expect(result.current.editorInitialValue).toBe("hello");
-		expect(onSend).toHaveBeenCalledWith("hello", undefined, 7);
+		expect(onSend).toHaveBeenCalledWith({
+			message: "hello",
+			attachments: undefined,
+			workspaceUploads: undefined,
+			editedMessageID: 7,
+		});
 		unmount();
 	});
 
@@ -511,10 +517,49 @@ describe("useConversationEditingState", () => {
 		});
 
 		await act(async () => {
-			await result.current.handleSendFromInput("hello", attachments);
+			await result.current.handleSendFromInput({
+				message: "hello",
+				attachments,
+			});
 		});
 
-		expect(onSend).toHaveBeenCalledWith("hello", attachments, 7);
+		expect(onSend).toHaveBeenCalledWith({
+			message: "hello",
+			attachments,
+			workspaceUploads: undefined,
+			editedMessageID: 7,
+		});
+		unmount();
+	});
+
+	it("forwards pending workspace uploads through history-edit send", async () => {
+		const { result, onSend, unmount } = renderEditing();
+		const workspaceUploads: PendingWorkspaceUpload[] = [
+			{
+				path: "/home/coder/.coder/chats/chat-1/files/data.csv",
+				name: "data.csv",
+				size: 128,
+				mediaType: "text/csv",
+			},
+		];
+
+		act(() => {
+			result.current.handleEditUserMessage(7, "hello");
+		});
+
+		await act(async () => {
+			await result.current.handleSendFromInput({
+				message: "hello",
+				workspaceUploads,
+			});
+		});
+
+		expect(onSend).toHaveBeenCalledWith({
+			message: "hello",
+			attachments: undefined,
+			workspaceUploads,
+			editedMessageID: 7,
+		});
 		unmount();
 	});
 
@@ -545,7 +590,7 @@ describe("useConversationEditingState", () => {
 
 		await act(async () => {
 			await expect(
-				result.current.handleSendFromInput("edited message"),
+				result.current.handleSendFromInput({ message: "edited message" }),
 			).rejects.toThrow("boom");
 		});
 
@@ -569,9 +614,9 @@ describe("useConversationEditingState", () => {
 		});
 
 		await act(async () => {
-			await expect(result.current.handleSendFromInput("hello")).rejects.toThrow(
-				"boom",
-			);
+			await expect(
+				result.current.handleSendFromInput({ message: "hello" }),
+			).rejects.toThrow("boom");
 		});
 
 		expect(mockInput.clear).not.toHaveBeenCalled();
@@ -588,10 +633,15 @@ describe("useConversationEditingState", () => {
 		result.current.chatInputRef.current = mockInput.handle;
 
 		await act(async () => {
-			await result.current.handleSendFromInput("hello");
+			await result.current.handleSendFromInput({ message: "hello" });
 		});
 
-		expect(onSend).toHaveBeenCalledWith("hello", undefined, undefined);
+		expect(onSend).toHaveBeenCalledWith({
+			message: "hello",
+			attachments: undefined,
+			workspaceUploads: undefined,
+			editedMessageID: undefined,
+		});
 		expect(mockInput.clear).toHaveBeenCalled();
 		expect(mockInput.focus).toHaveBeenCalled();
 		expect(localStorage.getItem(expectedKey)).toBeNull();
@@ -628,13 +678,18 @@ describe("useConversationEditingState", () => {
 			getValue: vi.fn().mockReturnValue(""),
 			addFileReference: vi.fn(),
 			getContentParts: vi.fn().mockReturnValue([]),
-		}; // The hook exposes chatInputRef – assign the mock to it.
+		}; // The hook exposes chatInputRef, assign the mock to it.
 		result.current.chatInputRef.current = mockInputRef;
 
 		await act(async () => {
-			result.current.handleSendFromInput("hello");
+			result.current.handleSendFromInput({ message: "hello" });
 			await vi.waitFor(() => {
-				expect(onSend).toHaveBeenCalledWith("hello", undefined, undefined);
+				expect(onSend).toHaveBeenCalledWith({
+					message: "hello",
+					attachments: undefined,
+					workspaceUploads: undefined,
+					editedMessageID: undefined,
+				});
 			});
 		});
 
@@ -649,7 +704,7 @@ describe("useConversationEditingState", () => {
 		localStorage.setItem(`${draftInputStorageKeyPrefix}${chatA}`, "draft A");
 		localStorage.setItem(`${draftInputStorageKeyPrefix}${chatB}`, "draft B");
 
-		// Each chatID should initialize with its own draft — this is
+		// Each chatID should initialize with its own draft, this is
 		// what the key={agentId} wrapper guarantees at the component
 		// level (a new chatID means a full remount).
 		const hookA = renderEditing(chatA);
@@ -669,7 +724,7 @@ describe("useConversationEditingState", () => {
 		expect(localStorage.getItem(expectedKey)).toBe("draft to clear");
 
 		await act(async () => {
-			result.current.handleSendFromInput("hello");
+			result.current.handleSendFromInput({ message: "hello" });
 			await vi.waitFor(() => {
 				expect(localStorage.getItem(expectedKey)).toBeNull();
 			});
@@ -829,7 +884,7 @@ describe("useConversationEditingState", () => {
 		expect(result.current.initialEditorState).toBeUndefined();
 		expect(result.current.editorInitialValue).toBe("old message text");
 
-		// Cancel — should restore both plain text and serialized state.
+		// Cancel should restore both plain text and serialized state.
 		act(() => {
 			result.current.handleCancelHistoryEdit();
 		});

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -77,7 +77,10 @@ import {
 	useChatStore,
 } from "./components/ChatConversation/chatStore";
 import { useChatToolInvalidations } from "./components/ChatConversation/useChatToolInvalidations";
-import type { PendingAttachment } from "./components/ChatPageContent";
+import type {
+	PendingAttachment,
+	SendChatMessageOptions,
+} from "./components/ChatPageContent";
 import {
 	getDefaultMCPSelection,
 	getSavedMCPSelection,
@@ -86,6 +89,10 @@ import {
 import { getModelSelectorHelp } from "./components/ModelSelectorHelp";
 import { useGitWatcher } from "./hooks/useGitWatcher";
 import { getAgentChatSendShortcut } from "./utils/agentChatSendShortcut";
+import {
+	type PendingWorkspaceUpload,
+	workspaceFileReferencePart,
+} from "./utils/chatAttachments";
 import { type ParsedDraft, parseStoredDraft } from "./utils/draftStorage";
 import {
 	countConfiguredProviderConfigs,
@@ -112,6 +119,13 @@ export const draftInputStorageKeyPrefix = "agents.draft-input.";
 const clearChatPlanMode = "" satisfies ChatPlanModeOrClear;
 
 type PlanModeSwitch = TypesGen.ChatPlanMode | "clear";
+
+export type SendChatTurnOptions = {
+	message: string;
+	attachments?: readonly PendingAttachment[];
+	workspaceUploads?: readonly PendingWorkspaceUpload[];
+	editedMessageID?: number;
+};
 
 /**
  * Read the persisted plain-text draft for a given chat ID.
@@ -290,11 +304,7 @@ const buildAttachmentMediaTypes = (
 /** @internal Exported for testing. */
 export function useConversationEditingState(deps: {
 	chatID: string | undefined;
-	onSend: (
-		message: string,
-		attachments?: readonly PendingAttachment[],
-		editedMessageID?: number,
-	) => Promise<void>;
+	onSend: (options: SendChatTurnOptions) => Promise<void>;
 	onDeleteQueuedMessage: (id: number) => Promise<void>;
 	chatInputRef: React.RefObject<ChatMessageInputRef | null>;
 	inputValueRef: React.RefObject<string>;
@@ -335,7 +345,7 @@ export function useConversationEditingState(deps: {
 		}
 	}, [editorInitialValue, inputValueRef]);
 
-	// -- History editing state --
+	// History editing state.
 	const [editingMessageId, setEditingMessageId] = useState<number | null>(null);
 	const [draftBeforeHistoryEdit, setDraftBeforeHistoryEdit] =
 		useState<ParsedDraft | null>(null);
@@ -386,7 +396,7 @@ export function useConversationEditingState(deps: {
 		setEditingFileBlocks([]);
 	};
 
-	// -- Queue editing state --
+	// Queue editing state.
 	const [editingQueuedMessageID, setEditingQueuedMessageID] = useState<
 		number | null
 	>(null);
@@ -488,14 +498,20 @@ export function useConversationEditingState(deps: {
 
 	// Wraps the parent onSend to clear local input/editing state
 	// and handle queue-edit deletion.
-	const handleSendFromInput = async (
-		message: string,
-		attachments?: readonly PendingAttachment[],
-	) => {
+	const handleSendFromInput = async ({
+		message,
+		attachments,
+		workspaceUploads,
+	}: SendChatMessageOptions) => {
 		const editedMessageID =
 			editingMessageId !== null ? editingMessageId : undefined;
 		const queueEditID = editingQueuedMessageID;
-		const sendPromise = onSend(message, attachments, editedMessageID);
+		const sendPromise = onSend({
+			message,
+			attachments,
+			workspaceUploads,
+			editedMessageID,
+		});
 
 		// For history edits, clear input immediately and prepare
 		// a rollback in case the send fails.
@@ -523,7 +539,7 @@ export function useConversationEditingState(deps: {
 		serializedEditorStateRef.current = serializedEditorState;
 
 		// Don't overwrite the persisted draft while editing a
-		// history or queued message — the original draft (possibly
+		// history or queued message, the original draft (possibly
 		// containing file-reference chips) is saved in React state
 		// and should survive a cancel.
 		if (editingMessageId !== null || editingQueuedMessageID !== null) {
@@ -536,7 +552,7 @@ export function useConversationEditingState(deps: {
 				try {
 					localStorage.setItem(draftStorageKey, serializedEditorState);
 				} catch {
-					// QuotaExceededError — silently discard the draft.
+					// QuotaExceededError, silently discard the draft.
 				}
 			} else {
 				localStorage.removeItem(draftStorageKey);
@@ -1297,10 +1313,12 @@ const AgentChatPage: FC = () => {
 	function buildChatInputContent({
 		message,
 		attachments,
+		workspaceUploads,
 		useComposerContent = true,
 	}: {
 		message: string;
 		attachments?: readonly PendingAttachment[];
+		workspaceUploads?: readonly PendingWorkspaceUpload[];
 		useComposerContent?: boolean;
 	}): { content: TypesGen.ChatInputPart[]; hasContent: boolean } {
 		const content: TypesGen.ChatInputPart[] = [];
@@ -1344,18 +1362,26 @@ const AgentChatPage: FC = () => {
 			}
 		}
 
+		if (workspaceUploads && workspaceUploads.length > 0) {
+			for (const upload of workspaceUploads) {
+				content.push(workspaceFileReferencePart(upload));
+			}
+		}
+
 		return { content, hasContent: content.length > 0 };
 	}
 
 	async function submitChatTurn({
 		message,
 		attachments,
+		workspaceUploads,
 		editedMessageID,
 		useComposerContent = true,
 		planModeSwitch,
 	}: {
 		message: string;
 		attachments?: readonly PendingAttachment[];
+		workspaceUploads?: readonly PendingWorkspaceUpload[];
 		editedMessageID?: number;
 		useComposerContent?: boolean;
 		planModeSwitch?: PlanModeSwitch;
@@ -1363,6 +1389,7 @@ const AgentChatPage: FC = () => {
 		const { content, hasContent } = buildChatInputContent({
 			message,
 			attachments,
+			workspaceUploads,
 			useComposerContent,
 		});
 		if (!hasContent || isSubmissionPending || !agentId || !hasModelOptions) {
@@ -1498,14 +1525,16 @@ const AgentChatPage: FC = () => {
 		}
 	}
 
-	async function handleSend(
-		message: string,
-		attachments?: readonly PendingAttachment[],
-		editedMessageID?: number,
-	) {
+	async function handleSend({
+		message,
+		attachments,
+		workspaceUploads,
+		editedMessageID,
+	}: SendChatTurnOptions) {
 		await submitChatTurn({
 			message,
 			attachments,
+			workspaceUploads,
 			editedMessageID,
 		});
 	}
@@ -1645,9 +1674,7 @@ const AgentChatPage: FC = () => {
 	);
 };
 
-// Keyed wrapper so that navigating between agents (changing the
-// :agentId param) fully remounts the component, resetting all
-// internal state — drafts, editing, queries — cleanly.
+// Force a remount when :agentId changes so per-agent drafts, editing state, and queries reset.
 const KeyedAgentChatPage: FC = () => {
 	const { agentId } = useParams<{ agentId: string }>();
 	return <AgentChatPage key={agentId} />;

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -29,7 +29,7 @@ import {
 import type { useChatStore } from "./components/ChatConversation/chatStore";
 import type { ModelSelectorOption } from "./components/ChatElements";
 import { DesktopPanelContext } from "./components/ChatElements/tools/DesktopPanelContext";
-import type { PendingAttachment } from "./components/ChatPageContent";
+import type { SendChatMessageOptions } from "./components/ChatPageContent";
 import { ChatPageInput, ChatPageTimeline } from "./components/ChatPageContent";
 import { ChatScrollContainer } from "./components/ChatScrollContainer";
 import { ChatSharingPopoverContent } from "./components/ChatSharingPopover";
@@ -73,10 +73,7 @@ interface EditingState {
 		fileBlocks: readonly ChatMessagePart[],
 	) => void;
 	handleCancelQueueEdit: () => void;
-	handleSendFromInput: (
-		message: string,
-		attachments?: readonly PendingAttachment[],
-	) => void;
+	handleSendFromInput: (options: SendChatMessageOptions) => void;
 	handleContentChange: (
 		content: string,
 		serializedEditorState: string,

--- a/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
@@ -5,6 +5,7 @@ import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import type * as TypesGen from "#/api/typesGenerated";
 import { MockWorkspace, MockWorkspaceAgent } from "#/testHelpers/entities";
 import { withProxyProvider } from "#/testHelpers/storybook";
+import type { WorkspaceUploadState } from "../hooks/useWorkspaceFileUploads";
 import {
 	AgentChatInput,
 	type AgentContextUsage,
@@ -488,6 +489,100 @@ export const WithAttachmentError: Story = {
 	})(),
 };
 
+export const WithWorkspaceUpload: Story = {
+	args: (() => {
+		const file = createMockFile("archive.zip", "application/zip");
+		return {
+			workspaceUploadProps: {
+				files: [file],
+				states: new Map<File, WorkspaceUploadState>([
+					[
+						file,
+						{
+							status: "uploaded",
+							path: "/home/coder/.coder/chats/abcd1234/files/archive.zip",
+							name: "archive.zip",
+							size: 1024 * 512,
+							mediaType: "application/zip",
+						},
+					],
+				]),
+				onAttach: fn(),
+				onRemove: fn(),
+			},
+			initialValue: "unzip this archive please",
+		};
+	})(),
+	play: async ({ args, canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(await canvas.findByText("archive.zip")).toBeInTheDocument();
+		expect(canvas.getByText("Ready to send")).toBeInTheDocument();
+		const removeButton = canvas.getByRole("button", {
+			name: "Remove archive.zip",
+		});
+		await userEvent.click(removeButton);
+		expect(args.workspaceUploadProps?.onRemove).toHaveBeenCalledTimes(1);
+	},
+};
+
+export const WithUploadingWorkspaceFile: Story = {
+	args: (() => {
+		const file = createMockFile("video.mp4", "video/mp4");
+		return {
+			workspaceUploadProps: {
+				files: [file],
+				states: new Map<File, WorkspaceUploadState>([
+					[file, { status: "uploading" }],
+				]),
+				onAttach: fn(),
+				onRemove: fn(),
+			},
+		};
+	})(),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(await canvas.findByText("video.mp4")).toBeInTheDocument();
+		expect(canvas.getByText(/Uploading/)).toBeInTheDocument();
+		expect(
+			canvas.queryByRole("button", {
+				name: /Copy workspace path/i,
+			}),
+		).not.toBeInTheDocument();
+	},
+};
+
+export const WithWorkspaceUploadError: Story = {
+	args: (() => {
+		const file = createMockFile("huge.iso", "application/octet-stream");
+		return {
+			workspaceUploadProps: {
+				files: [file],
+				states: new Map<File, WorkspaceUploadState>([
+					[
+						file,
+						{
+							status: "error",
+							error: "Upload failed. Agent disconnected.",
+						},
+					],
+				]),
+				onAttach: fn(),
+				onRemove: fn(),
+			},
+		};
+	})(),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(await canvas.findByText("huge.iso")).toBeInTheDocument();
+		expect(canvas.getByText(/Upload failed/i)).toBeInTheDocument();
+		expect(
+			canvas.queryByRole("button", {
+				name: /Copy workspace path/i,
+			}),
+		).not.toBeInTheDocument();
+	},
+};
+
 /** File reference chip rendered inline with text in the editor. */
 export const WithFileReference: Story = {
 	render: (args) => {
@@ -753,7 +848,7 @@ const mcpDefaults = {
 
 // ── MCP stories ────────────────────────────────────────────────
 
-/** Input with multiple MCP servers selected — shows icon stack in toolbar. */
+/** Input with multiple MCP servers selected, shows icon stack in toolbar. */
 export const WithMCPServers: Story = {
 	args: {
 		...mcpDefaults,
@@ -762,7 +857,7 @@ export const WithMCPServers: Story = {
 	},
 };
 
-/** MCP server needing OAuth — shows Auth button instead of toggle. */
+/** MCP server needing OAuth, shows Auth button instead of toggle. */
 export const WithMCPNeedingAuth: Story = {
 	args: {
 		...mcpDefaults,
@@ -771,7 +866,7 @@ export const WithMCPNeedingAuth: Story = {
 	},
 };
 
-/** No MCP servers active — shows only "MCP" label with chevron. */
+/** No MCP servers active, shows only "MCP" label with chevron. */
 export const WithMCPNoneActive: Story = {
 	args: {
 		...mcpDefaults,
@@ -967,7 +1062,7 @@ const pagerdutyMCP = makeMCPServer({
 	enabled: true,
 });
 
-/** Many tools with a workspace at 414px — forces overflow and "+N" pill. */
+/** Many tools with a workspace at 414px, forces overflow and "+N" pill. */
 export const OverflowBadges: Story = {
 	args: {
 		...mcpDefaults,
@@ -1090,7 +1185,7 @@ export const ContextNearLimit: Story = {
 	},
 };
 
-/** Long workspace name at iPhone SE width — verifies truncation. */
+/** Long workspace name at iPhone SE width, verifies truncation. */
 export const LongWorkspaceNameMobile: Story = {
 	args: {
 		...mcpDefaults,

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -3,6 +3,7 @@ import {
 	ArrowUpIcon,
 	CheckIcon,
 	ChevronRightIcon,
+	HardDriveIcon,
 	MicIcon,
 	MonitorIcon,
 	PaperclipIcon,
@@ -21,6 +22,7 @@ import {
 	useState,
 } from "react";
 import { Link } from "react-router";
+import { toast } from "sonner";
 import type * as TypesGen from "#/api/typesGenerated";
 import type {
 	AgentChatSendShortcut,
@@ -59,12 +61,17 @@ import { chatWidthClass, useChatFullWidth } from "../hooks/useChatFullWidth";
 import { useOverflowCount } from "../hooks/useOverflowCount";
 import { useSpeechRecognition } from "../hooks/useSpeechRecognition";
 import {
+	isWorkspaceUploadInProgress,
+	type WorkspaceUploadState,
+} from "../hooks/useWorkspaceFileUploads";
+import {
 	DEFAULT_AGENT_CHAT_SEND_SHORTCUT,
 	MODIFIER_AGENT_CHAT_SEND_SHORTCUT,
 } from "../utils/agentChatSendShortcut";
 import {
 	chatAttachmentAcceptAttribute,
 	isChatAttachmentFile,
+	isStrictChatAttachmentFile,
 } from "../utils/chatAttachments";
 import { formatProviderLabel } from "../utils/modelOptions";
 import {
@@ -91,6 +98,21 @@ export {
 } from "./AttachmentPreview";
 export type { ChatMessageInputRef } from "./ChatMessageInput/ChatMessageInput";
 export type { AgentContextUsage } from "./ContextUsageIndicator";
+
+interface WorkspaceUploadProps {
+	files: readonly File[];
+	states: Map<File, WorkspaceUploadState>;
+	onRemove: (attachment: number | File) => void;
+	onAttach?: (files: File[]) => void;
+}
+
+const workspaceRequiredAttachmentMessage =
+	"This file type requires a connected workspace. Start a workspace from the sidebar, then try again.";
+
+const shouldRouteFileToWorkspace = (file: File): boolean =>
+	Boolean(file.type) &&
+	file.type !== "application/octet-stream" &&
+	!isStrictChatAttachmentFile(file);
 
 interface AgentChatInputProps {
 	onSend: (message: string) => void;
@@ -167,6 +189,7 @@ interface AgentChatInputProps {
 	uploadStates?: Map<File, UploadState>;
 	previewUrls?: Map<File, string>;
 	textContents?: Map<File, string>;
+	workspaceUploadProps?: WorkspaceUploadProps;
 	onTextPreview?: (
 		content: string,
 		fileName: string,
@@ -331,6 +354,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	uploadStates,
 	previewUrls,
 	textContents,
+	workspaceUploadProps,
 	onTextPreview,
 	mcpServers,
 	selectedMCPServerIds,
@@ -367,6 +391,11 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	const cycleHistorySnapshotRef = useRef<readonly string[] | null>(null);
 	const currentCycleValueRef = useRef<string | null>(null);
 	const previousRemountKeyRef = useRef(remountKey);
+
+	const workspaceUploads = workspaceUploadProps?.files ?? [];
+	const workspaceUploadStates = workspaceUploadProps?.states;
+	const onWorkspaceAttach = workspaceUploadProps?.onAttach;
+	const onRemoveWorkspaceUpload = workspaceUploadProps?.onRemove;
 
 	const resetPromptCycle = () => {
 		setCycleIndex(null);
@@ -538,6 +567,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	const handleDisablePlanMode = () => onPlanModeToggle?.(false);
 
 	const fileInputRef = useRef<HTMLInputElement>(null);
+	const workspaceFileInputRef = useRef<HTMLInputElement>(null);
 	const [composerElement, setComposerElement] = useState<HTMLDivElement | null>(
 		null,
 	);
@@ -576,7 +606,27 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 		e.target.value = "";
 	};
 
+	const handleWorkspaceFileSelect = (
+		e: React.ChangeEvent<HTMLInputElement>,
+	) => {
+		if (e.target.files && onWorkspaceAttach) {
+			resetPromptCycle();
+			onWorkspaceAttach(Array.from(e.target.files));
+		}
+		e.target.value = "";
+	};
+
 	const handleFilePaste = (file: File) => {
+		const requiresWorkspace = shouldRouteFileToWorkspace(file);
+		if (requiresWorkspace) {
+			if (onWorkspaceAttach) {
+				resetPromptCycle();
+				onWorkspaceAttach([file]);
+				return;
+			}
+			toast.error(workspaceRequiredAttachmentMessage);
+			return;
+		}
 		resetPromptCycle();
 		onAttach?.([file]);
 	};
@@ -624,13 +674,42 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	const handleDrop = (e: React.DragEvent) => {
 		e.preventDefault();
 		setIsDragging(false);
-		if (!onAttach || !e.dataTransfer.files.length) return;
-		const attachable = Array.from(e.dataTransfer.files).filter(
-			isChatAttachmentFile,
-		);
-		if (attachable.length === 0) return;
+		const all = Array.from(e.dataTransfer.files);
+		if (all.length === 0) return;
+		// Keep empty and octet-stream MIME files on the regular attachment
+		// pipeline. That path deliberately lets the server inspect unknown
+		// bytes, while declared non-allowlisted MIME files use workspace upload.
+		const attachable: File[] = [];
+		const forWorkspace: File[] = [];
+		const nonAttachable: File[] = [];
+		for (const file of all) {
+			if (onWorkspaceAttach) {
+				if (shouldRouteFileToWorkspace(file)) {
+					forWorkspace.push(file);
+				} else {
+					attachable.push(file);
+				}
+				continue;
+			}
+			if (isChatAttachmentFile(file)) {
+				attachable.push(file);
+			} else {
+				nonAttachable.push(file);
+			}
+		}
+		if (attachable.length === 0 && forWorkspace.length === 0) {
+			if (nonAttachable.length > 0) {
+				toast.error(workspaceRequiredAttachmentMessage);
+			}
+			return;
+		}
 		resetPromptCycle();
-		onAttach(attachable);
+		if (attachable.length > 0 && onAttach) {
+			onAttach(attachable);
+		}
+		if (forWorkspace.length > 0) {
+			onWorkspaceAttach?.(forWorkspace);
+		}
 	};
 
 	// Track whether the editor has content so we can gate the
@@ -677,20 +756,33 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	const hasActiveUploads = attachments.some((file) =>
 		isUploadInProgress(uploadStates?.get(file)),
 	);
+	const hasActiveWorkspaceUploads = workspaceUploads.some((file) =>
+		isWorkspaceUploadInProgress(workspaceUploadStates?.get(file)),
+	);
 	const hasUploadedAttachments = attachments.some(
 		(f) => uploadStates?.get(f)?.status === "uploaded",
 	);
+	const hasUploadedWorkspaceFiles = workspaceUploads.some(
+		(f) => workspaceUploadStates?.get(f)?.status === "uploaded",
+	);
 	const hasDraftContext =
-		hasContent || attachments.length > 0 || hasFileReferences;
+		hasContent ||
+		attachments.length > 0 ||
+		workspaceUploads.length > 0 ||
+		hasFileReferences;
 	const isComposerEffectivelyEmpty = !hasDraftContext;
 	const hasSendableContent =
-		hasContent || hasUploadedAttachments || hasFileReferences;
+		hasContent ||
+		hasUploadedAttachments ||
+		hasUploadedWorkspaceFiles ||
+		hasFileReferences;
 	const canSend =
 		!isDisabled &&
 		!isLoading &&
 		hasModelOptions &&
 		hasSendableContent &&
-		!hasActiveUploads;
+		!hasActiveUploads &&
+		!hasActiveWorkspaceUploads;
 	const handleSubmit = () => {
 		const text = internalRef.current?.getValue()?.trim() ?? "";
 
@@ -699,10 +791,12 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 		if (
 			!text &&
 			!hasUploadedAttachments &&
+			!hasUploadedWorkspaceFiles &&
 			!hasFileReferences &&
 			!isDisabled &&
 			!isLoading &&
 			!hasActiveUploads &&
+			!hasActiveWorkspaceUploads &&
 			queuedMessages.length > 0 &&
 			onPromoteQueuedMessage
 		) {
@@ -711,10 +805,14 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 		}
 
 		if (
-			(!text && !hasUploadedAttachments && !hasFileReferences) ||
+			(!text &&
+				!hasUploadedAttachments &&
+				!hasUploadedWorkspaceFiles &&
+				!hasFileReferences) ||
 			isDisabled ||
 			isLoading ||
 			hasActiveUploads ||
+			hasActiveWorkspaceUploads ||
 			!hasModelOptions
 		) {
 			return;
@@ -954,6 +1052,63 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 						onInlineText={handleInlineText}
 					/>
 				)}
+				{workspaceUploads.length > 0 && onRemoveWorkspaceUpload && (
+					<div className="flex flex-wrap gap-2 border-b border-border-default/50 px-3 py-2">
+						{workspaceUploads.map((file, index) => {
+							const state = workspaceUploadStates?.get(file);
+							const uploading = state?.status === "uploading";
+							const errorMessage =
+								state?.status === "error" ? state.error : undefined;
+							const name =
+								state?.status === "uploaded" ? state.name : file.name;
+							const statusLabel = uploading
+								? "Uploading to workspace"
+								: state?.status === "uploaded"
+									? "Ready to send"
+									: (errorMessage ?? "Waiting to upload");
+							return (
+								<div
+									key={`${file.name}-${file.size}-${file.lastModified}-${index}`}
+									className="flex max-w-64 items-center gap-2 rounded-md border border-border-default bg-surface-tertiary px-2.5 py-1.5 text-xs"
+								>
+									{uploading ? (
+										<Spinner
+											className="h-3.5 w-3.5 shrink-0 text-content-secondary"
+											loading
+										/>
+									) : (
+										<HardDriveIcon className="h-3.5 w-3.5 shrink-0 text-content-secondary" />
+									)}
+									<div className="min-w-0 flex-1">
+										<div className="truncate font-medium text-content-primary">
+											{name}
+										</div>
+										<div
+											className={cn(
+												"truncate text-2xs",
+												errorMessage
+													? "text-content-destructive"
+													: "text-content-secondary",
+											)}
+										>
+											{statusLabel}
+										</div>
+									</div>
+									<Button
+										type="button"
+										variant="subtle"
+										size="icon"
+										className="size-5 shrink-0 text-content-secondary hover:text-content-primary"
+										aria-label={`Remove ${name}`}
+										onClick={() => onRemoveWorkspaceUpload(file)}
+									>
+										<XIcon className="h-3.5 w-3.5" />
+									</Button>
+								</div>
+							);
+						})}
+					</div>
+				)}
 				<ChatMessageInput
 					ref={internalRef}
 					onFilePaste={onAttach ? handleFilePaste : undefined}
@@ -999,6 +1154,16 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 						multiple
 						accept={chatAttachmentAcceptAttribute}
 						onChange={handleFileSelect}
+						className="hidden"
+					/>
+				)}
+				{/* Hidden file input for uploading any file type to the chat's workspace. */}
+				{onWorkspaceAttach && (
+					<input
+						ref={workspaceFileInputRef}
+						type="file"
+						multiple
+						onChange={handleWorkspaceFileSelect}
 						className="hidden"
 					/>
 				)}
@@ -1066,6 +1231,20 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 											>
 												<PaperclipIcon className="size-3.5 shrink-0" />
 												Attach file
+											</button>
+										)}
+										{onWorkspaceAttach && (
+											<button
+												type="button"
+												onClick={() => {
+													resetPromptCycle();
+													setPlusMenuOpen(false);
+													workspaceFileInputRef.current?.click();
+												}}
+												className="group flex h-8 w-full cursor-pointer items-center gap-1.5 border-none bg-transparent px-1 text-xs text-content-secondary shadow-none transition-colors hover:text-content-primary"
+											>
+												<HardDriveIcon className="size-3.5 shrink-0" />
+												Upload to workspace
 											</button>
 										)}
 										{onPlanModeToggle && (

--- a/site/src/pages/AgentsPage/components/ChatMessageInput/ChatMessageInput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatMessageInput/ChatMessageInput.tsx
@@ -41,7 +41,6 @@ import {
 	DEFAULT_AGENT_CHAT_SEND_SHORTCUT,
 	MODIFIER_AGENT_CHAT_SEND_SHORTCUT,
 } from "../../utils/agentChatSendShortcut";
-import { isChatAttachmentFile } from "../../utils/chatAttachments";
 import {
 	filterPersonalSkills,
 	isPersonalSkillTriggerToken,
@@ -223,20 +222,16 @@ const PasteSanitizationPlugin: FC<{
 					}
 					// Native paste event (ClipboardEvent).
 
-					// Check for attachable files in the clipboard (e.g.
-					// pasted screenshots). Forward them to the parent
-					// via callback instead of inserting text.
+					// Check for files in the clipboard, such as pasted screenshots
+					// or archives. Forward all files to the parent so it can route
+					// each one to regular attachments or workspace uploads.
 					if (onFilePaste && dataTransfer?.files.length) {
-						const attachable = Array.from(dataTransfer.files).filter(
-							isChatAttachmentFile,
-						);
-						if (attachable.length > 0) {
-							event.preventDefault();
-							for (const file of attachable) {
-								onFilePaste(file);
-							}
-							return true;
+						const files = Array.from(dataTransfer.files);
+						event.preventDefault();
+						for (const file of files) {
+							onFilePaste(file);
 						}
+						return true;
 					}
 
 					const text = getPastedPlainText(event, dataTransfer);

--- a/site/src/pages/AgentsPage/components/ChatPageContent.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import type { WorkspaceUploadState } from "../hooks/useWorkspaceFileUploads";
+import type { PendingWorkspaceUpload } from "../utils/chatAttachments";
+import type { UploadState } from "./AttachmentPreview";
+import {
+	collectUploadedAttachments,
+	collectUploadedWorkspaceFiles,
+	collectWorkspaceUploadsForSend,
+} from "./ChatPageContent";
+
+describe("collectUploadedAttachments", () => {
+	it("returns uploaded attachments and counts failed uploads", () => {
+		const uploaded = new File(["ok"], "image.png", { type: "image/png" });
+		const failed = new File(["bad"], "broken.png", { type: "image/png" });
+		const pending = new File(["wait"], "pending.png", { type: "image/png" });
+		const states = new Map<File, UploadState>([
+			[uploaded, { status: "uploaded", fileId: "file-1" }],
+			[failed, { status: "error", error: "boom" }],
+			[pending, { status: "uploading" }],
+		]);
+
+		expect(
+			collectUploadedAttachments([uploaded, failed, pending], states),
+		).toEqual({
+			attachments: [{ fileId: "file-1", mediaType: "image/png" }],
+			skippedErrors: 1,
+		});
+	});
+});
+
+describe("collectUploadedWorkspaceFiles", () => {
+	it("returns uploaded workspace files and counts failed uploads", () => {
+		const uploaded = new File(["ok"], "data.csv", { type: "text/csv" });
+		const failed = new File(["bad"], "broken.csv", { type: "text/csv" });
+		const states = new Map<File, WorkspaceUploadState>([
+			[
+				uploaded,
+				{
+					status: "uploaded",
+					path: "/home/coder/.coder/chats/chat-1/files/data.csv",
+					name: "data.csv",
+					size: 128,
+					mediaType: "text/csv",
+				},
+			],
+			[failed, { status: "error", error: "boom" }],
+		]);
+
+		expect(collectUploadedWorkspaceFiles([uploaded, failed], states)).toEqual({
+			uploads: [
+				{
+					path: "/home/coder/.coder/chats/chat-1/files/data.csv",
+					name: "data.csv",
+					size: 128,
+					mediaType: "text/csv",
+				},
+			],
+			skippedErrors: 1,
+		});
+	});
+});
+
+describe("collectWorkspaceUploadsForSend", () => {
+	it("keeps edited workspace references and appends new uploads", () => {
+		const edited: PendingWorkspaceUpload = {
+			path: "/home/coder/.coder/chats/chat-1/files/old.csv",
+			name: "old.csv",
+			size: 64,
+			mediaType: "text/csv",
+		};
+		const uploaded = new File(["ok"], "new.csv", { type: "text/csv" });
+		const states = new Map<File, WorkspaceUploadState>([
+			[
+				uploaded,
+				{
+					status: "uploaded",
+					path: "/home/coder/.coder/chats/chat-1/files/new.csv",
+					name: "new.csv",
+					size: 32,
+					mediaType: "text/csv",
+				},
+			],
+		]);
+
+		expect(
+			collectWorkspaceUploadsForSend({
+				isEditing: true,
+				editingUploads: [edited],
+				files: [uploaded],
+				states,
+			}),
+		).toEqual({
+			uploads: [
+				edited,
+				{
+					path: "/home/coder/.coder/chats/chat-1/files/new.csv",
+					name: "new.csv",
+					size: 32,
+					mediaType: "text/csv",
+				},
+			],
+			skippedErrors: 0,
+		});
+	});
+
+	it("omits edited workspace references outside edit mode", () => {
+		const edited: PendingWorkspaceUpload = {
+			path: "/home/coder/.coder/chats/chat-1/files/old.csv",
+			name: "old.csv",
+			size: 64,
+			mediaType: "text/csv",
+		};
+
+		expect(
+			collectWorkspaceUploadsForSend({
+				isEditing: false,
+				editingUploads: [edited],
+				files: [],
+				states: new Map(),
+			}),
+		).toEqual({ uploads: [], skippedErrors: 0 });
+	});
+});

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -1,4 +1,11 @@
-import { type FC, Profiler, type ReactNode, useEffect, useRef } from "react";
+import {
+	type FC,
+	Profiler,
+	type ReactNode,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
 import { useQuery } from "react-query";
 import { toast } from "sonner";
 import type { UrlTransform } from "streamdown";
@@ -9,7 +16,16 @@ import { cn } from "#/utils/cn";
 import { useChatDraftAttachments } from "../hooks/useChatDraftAttachments";
 import { chatWidthClass, useChatFullWidth } from "../hooks/useChatFullWidth";
 import { useFileAttachments } from "../hooks/useFileAttachments";
-import { getChatFileURL } from "../utils/chatAttachments";
+import {
+	isWorkspaceUploadInProgress,
+	useWorkspaceFileUploads,
+	type WorkspaceUploadState,
+} from "../hooks/useWorkspaceFileUploads";
+import {
+	getChatFileURL,
+	isWorkspaceFileReferencePart,
+	type PendingWorkspaceUpload,
+} from "../utils/chatAttachments";
 import { getProviderForModelOption } from "../utils/modelOptions";
 import type { ChatDetailError } from "../utils/usageLimitMessage";
 import {
@@ -150,15 +166,108 @@ export type PendingAttachment = {
 	mediaType: string;
 };
 
+export type SendChatMessageOptions = {
+	message: string;
+	attachments?: readonly PendingAttachment[];
+	workspaceUploads?: readonly PendingWorkspaceUpload[];
+};
+
+type EditableWorkspaceUpload = PendingWorkspaceUpload & { file: File };
+
+const pendingWorkspaceUploadFromPart = (
+	part: TypesGen.ChatWorkspaceFileReferencePart,
+): PendingWorkspaceUpload => ({
+	path: part.workspace_file_path,
+	name: part.workspace_file_name,
+	size: part.workspace_file_size,
+	mediaType: part.workspace_file_media_type || "application/octet-stream",
+});
+
+const editableWorkspaceUploadFromPart = (
+	part: TypesGen.ChatWorkspaceFileReferencePart,
+): EditableWorkspaceUpload => {
+	const upload = pendingWorkspaceUploadFromPart(part);
+	return {
+		...upload,
+		file: new File([], upload.name, { type: upload.mediaType }),
+	};
+};
+
+const pendingWorkspaceUploadFromEditable = ({
+	file: _file,
+	...upload
+}: EditableWorkspaceUpload): PendingWorkspaceUpload => upload;
+
+export const collectUploadedAttachments = (
+	files: readonly File[],
+	states: Map<File, UploadState>,
+): { attachments: PendingAttachment[]; skippedErrors: number } => {
+	const attachments: PendingAttachment[] = [];
+	let skippedErrors = 0;
+	for (const file of files) {
+		const state = states.get(file);
+		if (state?.status === "error") {
+			skippedErrors++;
+			continue;
+		}
+		if (state?.status === "uploaded" && state.fileId) {
+			attachments.push({
+				fileId: state.fileId,
+				mediaType: file.type || "application/octet-stream",
+			});
+		}
+	}
+	return { attachments, skippedErrors };
+};
+
+export const collectUploadedWorkspaceFiles = (
+	files: readonly File[],
+	states: Map<File, WorkspaceUploadState>,
+): { uploads: PendingWorkspaceUpload[]; skippedErrors: number } => {
+	const uploads: PendingWorkspaceUpload[] = [];
+	let skippedErrors = 0;
+	for (const file of files) {
+		const state = states.get(file);
+		if (state?.status === "error") {
+			skippedErrors++;
+			continue;
+		}
+		if (state?.status === "uploaded") {
+			uploads.push({
+				path: state.path,
+				name: state.name,
+				size: state.size,
+				mediaType: state.mediaType,
+			});
+		}
+	}
+	return { uploads, skippedErrors };
+};
+
+export const collectWorkspaceUploadsForSend = ({
+	isEditing,
+	editingUploads,
+	files,
+	states,
+}: {
+	isEditing: boolean;
+	editingUploads: readonly PendingWorkspaceUpload[];
+	files: readonly File[];
+	states: Map<File, WorkspaceUploadState>;
+}): { uploads: PendingWorkspaceUpload[]; skippedErrors: number } => {
+	const collected = collectUploadedWorkspaceFiles(files, states);
+	return {
+		uploads: [...(isEditing ? editingUploads : []), ...collected.uploads],
+		skippedErrors: collected.skippedErrors,
+	};
+};
+
 interface ChatPageInputProps {
 	// Organization that owns this chat. Used to scope file uploads.
 	organizationId: string | undefined;
 	store: ChatStoreHandle;
 	compressionThreshold: number | undefined;
-	onSend: (
-		message: string,
-		attachments?: readonly PendingAttachment[],
-	) => Promise<void> | void;
+	onSend: (options: SendChatMessageOptions) => Promise<void> | void;
 	sendShortcut: AgentChatSendShortcut;
 	onDeleteQueuedMessage: (id: number) => Promise<void>;
 	onPromoteQueuedMessage: (id: number) => Promise<void>;
@@ -301,6 +410,8 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	const composeAttachments = useChatDraftAttachments(organizationId, chatId, {
 		provider: getProviderForModelOption(modelOptions, selectedModel),
 	});
+	const composeWorkspaceUploads = useWorkspaceFileUploads(chatId);
+	const editWorkspaceUploads = useWorkspaceFileUploads(chatId);
 	const editAttachments = useFileAttachments(organizationId, {
 		provider: getProviderForModelOption(modelOptions, selectedModel),
 	});
@@ -321,6 +432,23 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 		handleRemoveAttachment,
 	} = modeAttachments;
 
+	const [editingWorkspaceUploads, setEditingWorkspaceUploads] = useState<
+		EditableWorkspaceUpload[]
+	>([]);
+	const editingWorkspaceUploadFiles = editingWorkspaceUploads.map(
+		(upload) => upload.file,
+	);
+	const editingWorkspaceUploadStates = new Map<File, WorkspaceUploadState>();
+	for (const upload of editingWorkspaceUploads) {
+		editingWorkspaceUploadStates.set(upload.file, {
+			status: "uploaded",
+			path: upload.path,
+			name: upload.name,
+			size: upload.size,
+			mediaType: upload.mediaType,
+		});
+	}
+
 	// Edit attachments are scoped to the chat being edited, not the compose
 	// draft. Clear them when navigation changes the chat scope.
 	const editScopeRef = useRef({ organizationId, chatId });
@@ -332,6 +460,7 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 		editScopeRef.current = { organizationId, chatId };
 		if (scopeChanged) {
 			resetEditAttachments();
+			setEditingWorkspaceUploads([]);
 		}
 	}, [organizationId, chatId, resetEditAttachments]);
 
@@ -345,10 +474,18 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 			setEditAttachments([]);
 			setEditUploadStates(new Map());
 			setEditPreviewUrls(new Map());
+			editWorkspaceUploads.reset();
+			setEditingWorkspaceUploads([]);
 			return;
 		}
+		editWorkspaceUploads.reset();
 		const fileBlocks = editingFileBlocks.filter(
 			(b): b is TypesGen.ChatFilePart => b.type === "file",
+		);
+		setEditingWorkspaceUploads(
+			editingFileBlocks
+				.filter(isWorkspaceFileReferencePart)
+				.map(editableWorkspaceUploadFromPart),
 		);
 		const files = fileBlocks.map((block, i) => {
 			const mt = block.media_type ?? "application/octet-stream";
@@ -380,6 +517,7 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 		setEditAttachments,
 		setEditPreviewUrls,
 		setEditUploadStates,
+		editWorkspaceUploads.reset,
 	]);
 
 	// Exiting edit mode should only clear the edit bucket. Compose draft
@@ -395,6 +533,43 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 		hasStreamState || chatStatus === "running" || chatStatus === "pending";
 
 	const [chatFullWidth] = useChatFullWidth();
+	const modeWorkspaceUploads = isEditing
+		? editWorkspaceUploads
+		: composeWorkspaceUploads;
+	const visibleWorkspaceUploadFiles = isEditing
+		? [...editingWorkspaceUploadFiles, ...editWorkspaceUploads.files]
+		: composeWorkspaceUploads.files;
+	const visibleWorkspaceUploadStates = isEditing
+		? new Map([
+				...editingWorkspaceUploadStates,
+				...editWorkspaceUploads.uploadStates,
+			])
+		: composeWorkspaceUploads.uploadStates;
+	const resetEditWorkspaceDraft = () => {
+		editWorkspaceUploads.reset();
+		setEditingWorkspaceUploads([]);
+	};
+	const handleRemoveVisibleWorkspaceUpload = (attachment: number | File) => {
+		if (!isEditing) {
+			composeWorkspaceUploads.handleRemove(attachment);
+			return;
+		}
+		const index =
+			typeof attachment === "number"
+				? attachment
+				: editingWorkspaceUploadFiles.indexOf(attachment);
+		if (index >= 0 && index < editingWorkspaceUploadFiles.length) {
+			setEditingWorkspaceUploads((current) =>
+				current.filter((_, i) => i !== index),
+			);
+			return;
+		}
+		editWorkspaceUploads.handleRemove(
+			typeof attachment === "number"
+				? attachment - editingWorkspaceUploadFiles.length
+				: attachment,
+		);
+	};
 
 	const inputElement = (
 		<AgentChatInput
@@ -403,45 +578,61 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 					const hasActiveUploads = attachments.some((file) =>
 						isUploadInProgress(uploadStates.get(file)),
 					);
-					if (hasActiveUploads) {
+					const hasActiveWorkspaceUploads = modeWorkspaceUploads.files.some(
+						(file) =>
+							isWorkspaceUploadInProgress(
+								modeWorkspaceUploads.uploadStates.get(file),
+							),
+					);
+					if (hasActiveUploads || hasActiveWorkspaceUploads) {
 						toast.warning("Wait for file uploads to finish before sending.");
 						return;
 					}
-					// Collect uploaded attachment metadata for the optimistic
-					// transcript builder while keeping the server payload
-					// shape unchanged downstream.
-					const pendingAttachments: PendingAttachment[] = [];
-					let skippedErrors = 0;
-					for (const file of attachments) {
-						const state = uploadStates.get(file);
-						if (state?.status === "error") {
-							skippedErrors++;
-							continue;
-						}
-						if (state?.status === "uploaded" && state.fileId) {
-							pendingAttachments.push({
-								fileId: state.fileId,
-								mediaType: file.type || "application/octet-stream",
-							});
-						}
-					}
+					const { attachments: pendingAttachments, skippedErrors } =
+						collectUploadedAttachments(attachments, uploadStates);
+					const {
+						uploads: pendingWorkspaceUploads,
+						skippedErrors: skippedWorkspaceErrors,
+					} = collectWorkspaceUploadsForSend({
+						isEditing,
+						editingUploads: editingWorkspaceUploads.map(
+							pendingWorkspaceUploadFromEditable,
+						),
+						files: modeWorkspaceUploads.files,
+						states: modeWorkspaceUploads.uploadStates,
+					});
 					if (skippedErrors > 0) {
 						toast.warning(
 							`${skippedErrors} attachment${skippedErrors > 1 ? "s" : ""} could not be sent (upload failed)`,
 						);
 					}
+					if (skippedWorkspaceErrors > 0) {
+						toast.warning(
+							`${skippedWorkspaceErrors} workspace file${skippedWorkspaceErrors > 1 ? "s" : ""} could not be sent (upload failed)`,
+						);
+					}
 					const attachmentArg =
 						pendingAttachments.length > 0 ? pendingAttachments : undefined;
+					const workspaceUploadArg =
+						pendingWorkspaceUploads.length > 0
+							? pendingWorkspaceUploads
+							: undefined;
 					try {
-						await onSend(message, attachmentArg);
+						await onSend({
+							message,
+							attachments: attachmentArg,
+							workspaceUploads: workspaceUploadArg,
+						});
 					} catch {
 						// Attachments preserved for retry on failure.
 						return;
 					}
 					if (isEditing) {
 						editAttachments.resetAttachments();
+						resetEditWorkspaceDraft();
 					} else {
 						composeAttachments.resetAttachments();
+						composeWorkspaceUploads.reset();
 					}
 				})();
 			}}
@@ -452,6 +643,15 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 			uploadStates={uploadStates}
 			previewUrls={previewUrls}
 			textContents={textContents}
+			workspaceUploadProps={{
+				files: visibleWorkspaceUploadFiles,
+				states: visibleWorkspaceUploadStates,
+				onAttach:
+					workspace && workspaceAgent?.status === "connected" && chatId
+						? modeWorkspaceUploads.handleAttach
+						: undefined,
+				onRemove: handleRemoveVisibleWorkspaceUpload,
+			}}
 			inputRef={inputRef}
 			initialValue={initialValue}
 			initialEditorState={initialEditorState}
@@ -462,9 +662,15 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 			onPromoteQueuedMessage={onPromoteQueuedMessage}
 			editingQueuedMessageID={editingQueuedMessageID}
 			onStartQueueEdit={onStartQueueEdit}
-			onCancelQueueEdit={onCancelQueueEdit}
+			onCancelQueueEdit={() => {
+				resetEditWorkspaceDraft();
+				onCancelQueueEdit();
+			}}
 			isEditingHistoryMessage={isEditingHistoryMessage}
-			onCancelHistoryEdit={onCancelHistoryEdit}
+			onCancelHistoryEdit={() => {
+				resetEditWorkspaceDraft();
+				onCancelHistoryEdit();
+			}}
 			userPromptHistory={userPromptHistory}
 			isDisabled={isInputDisabled}
 			isLoading={isSendPending}

--- a/site/src/pages/AgentsPage/components/QueuedMessagesList.test.ts
+++ b/site/src/pages/AgentsPage/components/QueuedMessagesList.test.ts
@@ -66,6 +66,25 @@ describe("getQueuedMessageInfo", () => {
 		});
 	});
 
+	it("counts workspace file references as editable file blocks", () => {
+		const workspaceFile = {
+			type: "workspace-file-reference" as const,
+			workspace_file_path: "/home/coder/.coder/chats/chat-1/files/data.csv",
+			workspace_file_name: "data.csv",
+			workspace_file_size: 2048,
+			workspace_file_media_type: "text/csv",
+		};
+		const result = getQueuedMessageInfo(
+			makeMessage([{ type: "text", text: "use data" }, workspaceFile]),
+		);
+		expect(result).toEqual({
+			displayText: "use data",
+			rawText: "use data",
+			attachmentCount: 1,
+			fileBlocks: [workspaceFile],
+		});
+	});
+
 	it("returns text with attachment count for text + file", () => {
 		const result = getQueuedMessageInfo(
 			makeMessage([

--- a/site/src/pages/AgentsPage/components/QueuedMessagesList.tsx
+++ b/site/src/pages/AgentsPage/components/QueuedMessagesList.tsx
@@ -1,7 +1,7 @@
 import {
 	ArrowUpIcon,
 	CornerDownLeftIcon,
-	ImageIcon,
+	PaperclipIcon,
 	PencilIcon,
 	Trash2Icon,
 } from "lucide-react";
@@ -40,7 +40,9 @@ export const getQueuedMessageInfo = (
 	message: ChatQueuedMessage,
 ): QueuedMessageInfo => {
 	const { content } = message;
-	const fileBlocks = content.filter((p) => p.type === "file");
+	const fileBlocks = content.filter(
+		(p) => p.type === "file" || p.type === "workspace-file-reference",
+	);
 	const rawText = content
 		.filter((p) => p.type === "text")
 		.map((p) => p.text)
@@ -206,10 +208,10 @@ export const QueuedMessagesList: FC<QueuedMessagesListProps> = ({
 							{item.attachmentCount > 0 && (
 								<span
 									role="img"
-									aria-label={`${item.attachmentCount} image attachment${item.attachmentCount !== 1 ? "s" : ""}`}
+									aria-label={`${item.attachmentCount} attachment${item.attachmentCount !== 1 ? "s" : ""}`}
 									className="flex shrink-0 items-center gap-1 text-xs text-content-secondary"
 								>
-									<ImageIcon className="h-3 w-3" aria-hidden="true" />
+									<PaperclipIcon className="h-3 w-3" aria-hidden="true" />
 									<span aria-hidden="true">{item.attachmentCount}</span>
 								</span>
 							)}

--- a/site/src/pages/AgentsPage/hooks/useWorkspaceFileUploads.test.ts
+++ b/site/src/pages/AgentsPage/hooks/useWorkspaceFileUploads.test.ts
@@ -1,0 +1,259 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useWorkspaceFileUploads } from "./useWorkspaceFileUploads";
+
+vi.mock("#/api/api", () => ({
+	API: {
+		experimental: {
+			uploadChatWorkspaceFile: vi.fn(),
+		},
+	},
+}));
+
+const { API } = await import("#/api/api");
+const uploadMock = API.experimental.uploadChatWorkspaceFile as ReturnType<
+	typeof vi.fn
+>;
+
+const makeFile = (name = "doc.txt", size = 16, type = "text/plain"): File => {
+	const file = new File([new Uint8Array(size)], name, { type });
+	Object.defineProperty(file, "size", { value: size });
+	return file;
+};
+
+const okResponse = {
+	path: "/home/coder/.coder/chats/chat-1/files/doc.txt",
+	name: "doc.txt",
+	size: 16,
+	media_type: "text/plain",
+};
+
+describe("useWorkspaceFileUploads", () => {
+	beforeEach(() => {
+		uploadMock.mockReset();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("transitions a file from uploading to uploaded", async () => {
+		uploadMock.mockResolvedValueOnce(okResponse);
+		const { result } = renderHook(() => useWorkspaceFileUploads("chat-1"));
+
+		act(() => {
+			result.current.handleAttach([makeFile()]);
+		});
+
+		const [attached] = result.current.files;
+		expect(result.current.uploadStates.get(attached)?.status).toBe("uploading");
+
+		await waitFor(() => {
+			expect(result.current.uploadStates.get(attached)?.status).toBe(
+				"uploaded",
+			);
+		});
+		const state = result.current.uploadStates.get(attached);
+		expect(state).toMatchObject({
+			status: "uploaded",
+			path: okResponse.path,
+			name: okResponse.name,
+			size: okResponse.size,
+			mediaType: okResponse.media_type,
+		});
+	});
+
+	it("records an error state when the API rejects", async () => {
+		uploadMock.mockRejectedValueOnce(new Error("boom"));
+		const { result } = renderHook(() => useWorkspaceFileUploads("chat-1"));
+
+		act(() => {
+			result.current.handleAttach([makeFile()]);
+		});
+
+		await waitFor(() => {
+			const [attached] = result.current.files;
+			expect(result.current.uploadStates.get(attached)?.status).toBe("error");
+		});
+	});
+
+	it("records an error state when no chat id is supplied", async () => {
+		const { result } = renderHook(() => useWorkspaceFileUploads(undefined));
+
+		act(() => {
+			result.current.handleAttach([makeFile()]);
+		});
+
+		const [attached] = result.current.files;
+		const state = result.current.uploadStates.get(attached);
+		expect(state?.status).toBe("error");
+		expect(uploadMock).not.toHaveBeenCalled();
+	});
+
+	it("removes a file by reference and clears its state", async () => {
+		uploadMock.mockResolvedValueOnce(okResponse);
+		const { result } = renderHook(() => useWorkspaceFileUploads("chat-1"));
+
+		act(() => {
+			result.current.handleAttach([makeFile()]);
+		});
+		const [attached] = result.current.files;
+		await waitFor(() => {
+			expect(result.current.uploadStates.get(attached)?.status).toBe(
+				"uploaded",
+			);
+		});
+
+		act(() => {
+			result.current.handleRemove(attached);
+		});
+
+		expect(result.current.files).toHaveLength(0);
+		expect(result.current.uploadStates.get(attached)).toBeUndefined();
+	});
+
+	it("removes a pending file by reference and aborts it", async () => {
+		let abortedDuringUpload = false;
+		uploadMock.mockImplementation(
+			(_chatId: string, _file: File, signal?: AbortSignal) =>
+				new Promise((_resolve, reject) => {
+					signal?.addEventListener("abort", () => {
+						abortedDuringUpload = true;
+						reject(new DOMException("aborted", "AbortError"));
+					});
+				}),
+		);
+		const { result } = renderHook(() => useWorkspaceFileUploads("chat-1"));
+
+		act(() => {
+			result.current.handleAttach([makeFile()]);
+		});
+		const [attached] = result.current.files;
+		expect(result.current.uploadStates.get(attached)?.status).toBe("uploading");
+		await waitFor(() => {
+			expect(uploadMock).toHaveBeenCalledTimes(1);
+		});
+
+		act(() => {
+			result.current.handleRemove(attached);
+		});
+
+		await waitFor(() => {
+			expect(abortedDuringUpload).toBe(true);
+		});
+		expect(result.current.files).toHaveLength(0);
+		expect(result.current.uploadStates.get(attached)).toBeUndefined();
+	});
+
+	it("removes a file by index", async () => {
+		uploadMock.mockResolvedValue(okResponse);
+		const { result } = renderHook(() => useWorkspaceFileUploads("chat-1"));
+
+		act(() => {
+			result.current.handleAttach([makeFile("a.txt"), makeFile("b.txt")]);
+		});
+		await waitFor(() => {
+			expect(result.current.files).toHaveLength(2);
+		});
+
+		act(() => {
+			result.current.handleRemove(0);
+		});
+
+		expect(result.current.files).toHaveLength(1);
+		expect(result.current.files[0].name).toBe("b.txt");
+	});
+
+	it("aborts pending requests on unmount", async () => {
+		let abortedDuringUpload = false;
+		uploadMock.mockImplementation(
+			(_chatId: string, _file: File, signal?: AbortSignal) =>
+				new Promise((_resolve, reject) => {
+					signal?.addEventListener("abort", () => {
+						abortedDuringUpload = true;
+						reject(new DOMException("aborted", "AbortError"));
+					});
+				}),
+		);
+		const { result, unmount } = renderHook(() =>
+			useWorkspaceFileUploads("chat-1"),
+		);
+
+		act(() => {
+			result.current.handleAttach([makeFile()]);
+		});
+		await waitFor(() => {
+			expect(uploadMock).toHaveBeenCalledTimes(1);
+		});
+		unmount();
+
+		await waitFor(() => {
+			expect(abortedDuringUpload).toBe(true);
+		});
+	});
+
+	it("clears pending uploads when the chat changes", async () => {
+		let abortedDuringUpload = false;
+		uploadMock.mockImplementation(
+			(_chatId: string, _file: File, signal?: AbortSignal) =>
+				new Promise((_resolve, reject) => {
+					signal?.addEventListener("abort", () => {
+						abortedDuringUpload = true;
+						reject(new DOMException("aborted", "AbortError"));
+					});
+				}),
+		);
+		const { result, rerender } = renderHook(
+			({ chatId }: { chatId: string }) => useWorkspaceFileUploads(chatId),
+			{ initialProps: { chatId: "chat-1" } },
+		);
+
+		act(() => {
+			result.current.handleAttach([makeFile()]);
+		});
+		expect(result.current.files).toHaveLength(1);
+		await waitFor(() => {
+			expect(uploadMock).toHaveBeenCalledTimes(1);
+		});
+
+		rerender({ chatId: "chat-2" });
+
+		await waitFor(() => {
+			expect(abortedDuringUpload).toBe(true);
+		});
+		expect(result.current.files).toHaveLength(0);
+		expect(result.current.uploadStates.size).toBe(0);
+	});
+
+	it("aborts pending requests on reset", async () => {
+		let abortedDuringUpload = false;
+		uploadMock.mockImplementation(
+			(_chatId: string, _file: File, signal?: AbortSignal) =>
+				new Promise((_resolve, reject) => {
+					signal?.addEventListener("abort", () => {
+						abortedDuringUpload = true;
+						reject(new DOMException("aborted", "AbortError"));
+					});
+				}),
+		);
+		const { result } = renderHook(() => useWorkspaceFileUploads("chat-1"));
+
+		act(() => {
+			result.current.handleAttach([makeFile()]);
+		});
+		await waitFor(() => {
+			expect(uploadMock).toHaveBeenCalledTimes(1);
+		});
+
+		act(() => {
+			result.current.reset();
+		});
+
+		await waitFor(() => {
+			expect(abortedDuringUpload).toBe(true);
+		});
+		expect(result.current.files).toHaveLength(0);
+		expect(result.current.uploadStates.size).toBe(0);
+	});
+});

--- a/site/src/pages/AgentsPage/hooks/useWorkspaceFileUploads.ts
+++ b/site/src/pages/AgentsPage/hooks/useWorkspaceFileUploads.ts
@@ -1,0 +1,165 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { API } from "#/api/api";
+import type { UploadChatWorkspaceFileResponse } from "#/api/typesGenerated";
+import { renameChatFileForUpload } from "../utils/chatAttachments";
+import { formatAgentAttachmentUploadError } from "../utils/fileAttachmentLimits";
+
+export type WorkspaceUploadState =
+	| { status: "uploading" }
+	| {
+			status: "uploaded";
+			path: string;
+			name: string;
+			size: number;
+			mediaType: string;
+	  }
+	| { status: "error"; error: string };
+
+export const isWorkspaceUploadInProgress = (
+	state: WorkspaceUploadState | undefined,
+): boolean => state?.status === "uploading";
+
+interface UseWorkspaceFileUploadsReturn {
+	files: File[];
+	uploadStates: Map<File, WorkspaceUploadState>;
+	handleAttach: (files: File[]) => void;
+	handleRemove: (file: File | number) => void;
+	reset: () => void;
+}
+
+const newUploadStates = () => new Map<File, WorkspaceUploadState>();
+
+export function useWorkspaceFileUploads(
+	chatId: string | undefined,
+): UseWorkspaceFileUploadsReturn {
+	const [files, setFiles] = useState<File[]>([]);
+	const [uploadStates, setUploadStates] = useState(newUploadStates);
+	const previousChatIdRef = useRef(chatId);
+	const uploadRunRef = useRef(0);
+	const abortControllersRef = useRef(new Map<File, AbortController>());
+
+	const abortAllUploads = useCallback(() => {
+		for (const controller of abortControllersRef.current.values()) {
+			controller.abort();
+		}
+		abortControllersRef.current.clear();
+	}, []);
+
+	const reset = useCallback(() => {
+		uploadRunRef.current += 1;
+		abortAllUploads();
+		setFiles([]);
+		setUploadStates(newUploadStates());
+	}, [abortAllUploads]);
+
+	useEffect(() => {
+		return () => {
+			abortAllUploads();
+		};
+	}, [abortAllUploads]);
+
+	useEffect(() => {
+		if (previousChatIdRef.current === chatId) {
+			return;
+		}
+		previousChatIdRef.current = chatId;
+		reset();
+	}, [chatId, reset]);
+
+	const setUploadState = useCallback(
+		(file: File, uploadRun: number, state: WorkspaceUploadState) => {
+			setUploadStates((prev) => {
+				if (uploadRunRef.current !== uploadRun || !prev.has(file)) {
+					return prev;
+				}
+				return new Map(prev).set(file, state);
+			});
+		},
+		[],
+	);
+
+	const startUpload = useCallback(
+		(file: File, uploadRun: number) => {
+			if (!chatId) {
+				setUploadStates((prev) =>
+					new Map(prev).set(file, {
+						status: "error",
+						error: "Cannot upload: no active chat. Open or start a chat first.",
+					}),
+				);
+				return;
+			}
+
+			const controller = new AbortController();
+			abortControllersRef.current.set(file, controller);
+			setUploadStates((prev) =>
+				new Map(prev).set(file, { status: "uploading" }),
+			);
+
+			void (async () => {
+				let result: UploadChatWorkspaceFileResponse;
+				try {
+					result = await API.experimental.uploadChatWorkspaceFile(
+						chatId,
+						file,
+						controller.signal,
+					);
+				} catch (err: unknown) {
+					abortControllersRef.current.delete(file);
+					if (!controller.signal.aborted) {
+						setUploadState(file, uploadRun, {
+							status: "error",
+							error: formatAgentAttachmentUploadError(err),
+						});
+					}
+					return;
+				}
+
+				abortControllersRef.current.delete(file);
+				setUploadState(file, uploadRun, {
+					status: "uploaded",
+					path: result.path,
+					name: result.name,
+					size: result.size,
+					mediaType: result.media_type,
+				});
+			})();
+		},
+		[chatId, setUploadState],
+	);
+
+	const handleAttach = useCallback(
+		(incoming: File[]) => {
+			const renamed = incoming.map(renameChatFileForUpload);
+			const uploadRun = uploadRunRef.current;
+			setFiles((prev) => [...prev, ...renamed]);
+			for (const file of renamed) {
+				startUpload(file, uploadRun);
+			}
+		},
+		[startUpload],
+	);
+
+	const handleRemove = useCallback(
+		(attachment: File | number) => {
+			const index =
+				typeof attachment === "number" ? attachment : files.indexOf(attachment);
+			if (index === -1) {
+				return;
+			}
+
+			const removed = files[index];
+			abortControllersRef.current.get(removed)?.abort();
+			abortControllersRef.current.delete(removed);
+			setUploadStates((states) => {
+				const next = new Map(states);
+				next.delete(removed);
+				return next;
+			});
+			setFiles((prev) => prev.filter((_, i) => i !== index));
+		},
+		[files],
+	);
+
+	return { files, uploadStates, handleAttach, handleRemove, reset };
+}

--- a/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
 	isChatAttachmentFile,
+	isStrictChatAttachmentFile,
 	renameChatFileForUpload,
 	sanitizeChatFileName,
+	workspaceFileReferencePart,
 } from "./chatAttachments";
 
 describe("isChatAttachmentFile", () => {
@@ -35,6 +37,36 @@ describe("isChatAttachmentFile", () => {
 	});
 });
 
+describe("isStrictChatAttachmentFile", () => {
+	it("accepts allowlisted MIME types", () => {
+		const file = new File(["png"], "image.png", { type: "image/png" });
+
+		expect(isStrictChatAttachmentFile(file)).toBe(true);
+	});
+
+	it("rejects files with an empty MIME type", () => {
+		const file = new File(["markdown"], "notes.md");
+
+		expect(isStrictChatAttachmentFile(file)).toBe(false);
+	});
+
+	it("rejects application/octet-stream files", () => {
+		const file = new File(["unknown"], "attachment.bin", {
+			type: "application/octet-stream",
+		});
+
+		expect(isStrictChatAttachmentFile(file)).toBe(false);
+	});
+
+	it("rejects unsupported MIME types", () => {
+		const file = new File(["zip"], "archive.zip", {
+			type: "application/zip",
+		});
+
+		expect(isStrictChatAttachmentFile(file)).toBe(false);
+	});
+});
+
 describe("sanitizeChatFileName", () => {
 	it.each([
 		// Already safe.
@@ -61,6 +93,21 @@ describe("sanitizeChatFileName", () => {
 		["foo!.pdf ", "foo!.pdf"],
 	])("sanitizes %j to %j", (input, expected) => {
 		expect(sanitizeChatFileName(input)).toBe(expected);
+	});
+});
+
+describe("workspaceFileReferencePart", () => {
+	it("defaults missing media type to application/octet-stream", () => {
+		expect(
+			workspaceFileReferencePart({
+				path: "/home/coder/.coder/chats/chat-1/files/data.bin",
+				name: "data.bin",
+				size: 12,
+				mediaType: "",
+			}),
+		).toMatchObject({
+			workspace_file_media_type: "application/octet-stream",
+		});
 	});
 });
 

--- a/site/src/pages/AgentsPage/utils/chatAttachments.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.ts
@@ -1,7 +1,19 @@
 import { isApiErrorResponse } from "#/api/errors";
-import { ChatAttachmentMediaTypes } from "#/api/typesGenerated";
+import {
+	ChatAttachmentMediaTypes,
+	type ChatInputPart,
+	type ChatMessagePart,
+	type ChatWorkspaceFileReferencePart,
+} from "#/api/typesGenerated";
 
 const undisplayableAttachmentDetail = "File exists but could not be displayed.";
+
+export type PendingWorkspaceUpload = {
+	path: string;
+	name: string;
+	size: number;
+	mediaType: string;
+};
 
 export type AttachmentFailure =
 	| { kind: "expired" }
@@ -99,6 +111,16 @@ export const isChatAttachmentFile = (file: File): boolean => {
 	return ChatAttachmentMediaTypes.some((mediaType) => mediaType === file.type);
 };
 
+/**
+ * Returns true only for files whose MIME type positively matches the
+ * chat attachment allowlist. Unknown or octet-stream files return
+ * false so callers can route them to the workspace upload flow.
+ */
+export const isStrictChatAttachmentFile = (file: File): boolean =>
+	Boolean(file.type) &&
+	file.type !== "application/octet-stream" &&
+	ChatAttachmentMediaTypes.some((mediaType) => mediaType === file.type);
+
 // Matches characters that commonly cause trouble downstream: bracketing
 // punctuation, quotes, shell or URL or path metacharacters, path
 // separators, any whitespace, and control characters. ASCII alphanumerics,
@@ -127,6 +149,21 @@ export const sanitizeChatFileName = (name: string): string => {
 	const trimmed = collapsed.replace(/^[_.\s]+|[_.\s]+$/g, "");
 	return trimmed === "" ? "file" : trimmed;
 };
+
+export const isWorkspaceFileReferencePart = (
+	part: ChatMessagePart,
+): part is ChatWorkspaceFileReferencePart =>
+	part.type === "workspace-file-reference";
+
+export const workspaceFileReferencePart = (
+	upload: PendingWorkspaceUpload,
+): ChatInputPart => ({
+	type: "workspace-file-reference",
+	workspace_file_path: upload.path,
+	workspace_file_name: upload.name,
+	workspace_file_size: upload.size,
+	workspace_file_media_type: upload.mediaType || "application/octet-stream",
+});
 
 /**
  * Returns a new File whose `name` is sanitized via `sanitizeChatFileName`.


### PR DESCRIPTION
> Mux is working on behalf of Mike.

## Stack Context

This is PR 3 of 3 for direct chat workspace file uploads:

1. Agent API layer, #25539
2. Backend, SDK, prompt integration, and frontend compatibility, #25540
3. Simple frontend upload UI, this PR

## What?

Adds the simple frontend path for uploading files to the active workspace from the chat composer:

- calls the experimental workspace upload API and stores returned path, name, size, and media type metadata
- routes declared non-chat-attachment MIME files from paste and drag/drop into workspace upload when a workspace upload handler is available
- renders compact composer preview chips with uploading, ready, error, and remove states
- sends completed uploads as `workspace-file-reference` message parts
- preserves workspace references when editing existing messages and blocks sending while workspace uploads are still pending
- keeps queued message summaries and chat attachment helpers tolerant of workspace file references

## Deferred

This PR intentionally does not add the full transcript tile experience. Copy-path actions, shared attachment tile refactors, regular attachment size display, and polished workspace-file metadata display remain out of scope for this stack.
