### PR TITLE
fix(agent/agentscripts): create script log directories

### DIFF
--- a/agent/agentscripts/agentscripts.go
+++ b/agent/agentscripts/agentscripts.go
@@ -275,6 +275,11 @@ func (r *Runner) run(ctx context.Context, script codersdk.WorkspaceAgentScript, 
 	if err != nil {
 		return xerrors.Errorf("%s script: create script temp dir: %w", scriptDataDir, err)
 	}
+	logDir := filepath.Dir(logPath)
+	err = r.Filesystem.MkdirAll(logDir, 0o700)
+	if err != nil {
+		return xerrors.Errorf("%s script: create script log dir: %w", logDir, err)
+	}
 
 	logger := r.Logger.With(
 		slog.F("log_source_id", script.LogSourceID),

--- a/agent/agentscripts/agentscripts_test.go
+++ b/agent/agentscripts/agentscripts_test.go
@@ -47,6 +47,32 @@ func TestExecuteBasic(t *testing.T) {
 	require.Equal(t, "hello", log.Output)
 }
 
+func TestExecuteCreatesLogPathParents(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitShort)
+	fLogger := newFakeScriptLogger()
+	runner := setupWithFilesystem(t, afero.NewOsFs(), t.TempDir(), t.TempDir(), func(uuid.UUID) agentscripts.ScriptLogger {
+		return fLogger
+	})
+	defer runner.Close()
+
+	logPath := filepath.Join("nested", "install.log")
+	aAPI := agenttest.NewFakeAgentAPI(t, testutil.Logger(t), nil, nil)
+	err := runner.Init([]codersdk.WorkspaceAgentScript{{
+		LogSourceID: uuid.New(),
+		LogPath:     logPath,
+		Script:      "echo hello",
+	}}, aAPI.ScriptCompleted)
+	require.NoError(t, err)
+	require.NoError(t, runner.Execute(context.Background(), agentscripts.ExecuteAllScripts))
+
+	log := testutil.TryReceive(ctx, t, fLogger.logs)
+	require.Equal(t, "hello", log.Output)
+
+	_, err = runner.Filesystem.Stat(filepath.Join(runner.LogDir, logPath))
+	require.NoError(t, err)
+}
+
 func TestEnv(t *testing.T) {
 	t.Parallel()
 	fLogger := newFakeScriptLogger()
@@ -299,13 +325,23 @@ func (*executeOptionTestLogger) Flush(context.Context) error {
 
 func setup(t *testing.T, getScriptLogger func(logSourceID uuid.UUID) agentscripts.ScriptLogger) *agentscripts.Runner {
 	t.Helper()
+	return setupWithFilesystem(t, afero.NewMemMapFs(), t.TempDir(), t.TempDir(), getScriptLogger)
+}
+
+func setupWithFilesystem(
+	t *testing.T,
+	fs afero.Fs,
+	logDir string,
+	dataDirBase string,
+	getScriptLogger func(logSourceID uuid.UUID) agentscripts.ScriptLogger,
+) *agentscripts.Runner {
+	t.Helper()
 	if getScriptLogger == nil {
 		// noop
 		getScriptLogger = func(uuid.UUID) agentscripts.ScriptLogger {
 			return noopScriptLogger{}
 		}
 	}
-	fs := afero.NewMemMapFs()
 	logger := testutil.Logger(t)
 	s, err := agentssh.NewServer(context.Background(), logger, prometheus.NewRegistry(), fs, agentexec.DefaultExecer, nil)
 	require.NoError(t, err)
@@ -313,8 +349,8 @@ func setup(t *testing.T, getScriptLogger func(logSourceID uuid.UUID) agentscript
 		_ = s.Close()
 	})
 	return agentscripts.New(agentscripts.Options{
-		LogDir:          t.TempDir(),
-		DataDirBase:     t.TempDir(),
+		LogDir:          logDir,
+		DataDirBase:     dataDirBase,
 		Logger:          logger,
 		SSHServer:       s,
 		Filesystem:      fs,


### PR DESCRIPTION
Fixes #21986

## Summary

- Create the parent directory for the resolved script log path before opening the log file.
- Add a regression test that uses the OS filesystem and a nested relative `LogPath`, matching the reported failure mode.

## Test plan

- `go test ./agent/agentscripts -run TestExecuteCreatesLogPathParents -count=1`
- `go test ./agent/agentscripts -count=1`
- `make fmt/go FILE=agent/agentscripts/agentscripts.go`
- `make fmt/go FILE=agent/agentscripts/agentscripts_test.go`
- `git diff --check --cached`

I also attempted the normal pre-commit hook after installing local Make and pnpm tooling. On this Windows host, the hook did not reach project validation because GNU Make invoked Bash incorrectly and tried to execute generated Go files as shell scripts, for example `coderd/database/querier.go: line 1: //: Is a directory`. The focused Go checks above passed after that attempt.

## Disclosure

I used AI assistance while preparing this change. I reviewed the diff and verification results myself.

<!-- cla-recheck: 2026-05-25 -->
