### PR TITLE
fix: append `asChild` to `<AgentApps />`

### DIFF
--- a/site/src/modules/resources/AgentApps/AgentApps.tsx
+++ b/site/src/modules/resources/AgentApps/AgentApps.tsx
@@ -35,7 +35,7 @@ export const AgentApps: FC<AgentAppsProps> = ({
 			</DropdownMenuTrigger>
 			<DropdownMenuContent align="start">
 				{section.apps.map((app) => (
-					<DropdownMenuItem key={app.slug}>
+					<DropdownMenuItem key={app.slug} asChild>
 						<AppLink grouped app={app} agent={agent} workspace={workspace} />
 					</DropdownMenuItem>
 				))}


### PR DESCRIPTION
This pull-request resolves a stupid issue wherein the `<DropdownItem />` would wrap into an `<AppLink />` causing two hit targets. This now is a single one and inline with the Figma Coder Kit after the parent merges onto the child.

| Old | New |
| --- | --- |
| <img width="400" alt="preview-broken-button" src="https://github.com/user-attachments/assets/b74018a7-9279-4464-b71b-a16901e844c9" /> | <img width="308" height="141" alt="image" src="https://github.com/user-attachments/assets/8b4a1371-e1bb-4341-9a6a-033a7b48c31d" /> |
