### PR TITLE
chore: update cli install link to use local deployment URL instead of coder.com

### DIFF
--- a/site/src/modules/resources/SSHButton/SSHButton.tsx
+++ b/site/src/modules/resources/SSHButton/SSHButton.tsx
@@ -61,9 +61,7 @@ export const AgentSSHButton: FC<AgentSSHButtonProps> = ({
 				</ol>
 
 				<HelpPopoverLinksGroup>
-					<HelpPopoverLink href="/install">
-						Install Coder CLI
-					</HelpPopoverLink>
+					<HelpPopoverLink href="/install">Install Coder CLI</HelpPopoverLink>
 					<HelpPopoverLink href={docs("/user-guides/workspace-access/vscode")}>
 						Connect via VS Code Remote SSH
 					</HelpPopoverLink>

--- a/site/src/modules/resources/SSHButton/SSHButton.tsx
+++ b/site/src/modules/resources/SSHButton/SSHButton.tsx
@@ -61,7 +61,7 @@ export const AgentSSHButton: FC<AgentSSHButtonProps> = ({
 				</ol>
 
 				<HelpPopoverLinksGroup>
-					<HelpPopoverLink href={docs("/install")}>
+					<HelpPopoverLink href="/install">
 						Install Coder CLI
 					</HelpPopoverLink>
 					<HelpPopoverLink href={docs("/user-guides/workspace-access/vscode")}>


### PR DESCRIPTION
Updates the connect via SSH menu shown in workspaces to redirect to `/install` on the local deployment instead of `https://coder.com/docs/<version>/install`. This ensures consistency with the user account dropdown menu which also references the local deployment.

End goal is to ensure the user running install script receives the same CLI version as is running on the Coder deployment.