### PR TITLE
fix: wrap `latestVersion?.message` with `<div />`

### DIFF
--- a/site/src/modules/workspaces/WorkspaceUpdateDialogs.tsx
+++ b/site/src/modules/workspaces/WorkspaceUpdateDialogs.tsx
@@ -131,11 +131,13 @@ const UpdateConfirmationDialog: FC<UpdateConfirmationDialogProps> = ({
 						template version. This can{" "}
 						<strong>delete non-persistent data</strong>.
 					</p>
-					{latestVersion?.message && (
-						<MemoizedInlineMarkdown allowedElements={["ol", "ul", "li"]}>
-							{latestVersion.message}
-						</MemoizedInlineMarkdown>
-					)}
+					<div>
+						{latestVersion?.message && (
+							<MemoizedInlineMarkdown allowedElements={["ol", "ul", "li"]}>
+								{latestVersion.message}
+							</MemoizedInlineMarkdown>
+						)}
+					</div>
 				</div>
 			}
 		/>


### PR DESCRIPTION
This pull-request wraps the `latestVersion?.message` in a `<div />` so that our content is affected by the `flex flex-col` class from the parent. 

| Old | New |
| --- | --- |
| <img width="441" height="363" alt="PREVIEW_1" src="https://github.com/user-attachments/assets/0693136a-cfcc-4f17-a94d-35c14943c3bd" /> | <img width="441" height="295" alt="PREVIEW_1_NEW" src="https://github.com/user-attachments/assets/ce6c1126-6153-4d7f-a4b8-f01a5a98e270" /> |
| <img width="441" height="396" alt="PREVIEW_2" src="https://github.com/user-attachments/assets/b26e81b4-09fb-4317-9d25-3ca8b5989c54" /> | <img width="441" height="294" alt="PREVIEW_2_NEW" src="https://github.com/user-attachments/assets/241afe85-c278-4593-a985-bcc2400ac52f" /> |