### PR TITLE
fix: resolve badge content color

### DIFF
--- a/site/src/pages/DeploymentSettingsPage/Option.tsx
+++ b/site/src/pages/DeploymentSettingsPage/Option.tsx
@@ -129,7 +129,7 @@ export const OptionConfigFlag: FC<HTMLAttributes<HTMLDivElement>> = (props) => {
 			data-slot="option-config-flag"
 			className={cn(
 				"block rounded-[1px] bg-border-secondary px-1 py-0.5",
-				"text-[10px] font-semibold leading-none",
+				"text-[10px] font-semibold leading-none text-content-primary",
 				props.className,
 			)}
 		/>


### PR DESCRIPTION
I noticed that the content on our badges for options broke, I've restored this to using `text-content-primary` so that the content will always be legible and not inherit from the base body css.

| Old | New |
| --- | --- |
| <img width="718" height="488" alt="CLI_PREVIEW_OLD" src="https://github.com/user-attachments/assets/98c91591-b8b8-4ed0-bdd5-0bd2fb5f2802" /> | <img width="718" height="488" alt="CLI_PREVIEW_NEW" src="https://github.com/user-attachments/assets/5c07a5e0-3fbf-41a0-8454-0e7bd6ee52e8" /> | 