### PR TITLE
fix(codersdk): fix stale comment reference

### DIFF
--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -3208,7 +3208,7 @@ Write out the current server config as YAML to stdout.`,
 			Hidden:      false,
 		},
 		{
-			// Env handling is done in cli.ReadGitAuthFromEnvironment
+			// Env handling is done in cli.ReadExternalAuthProvidersFromEnv
 			Name:        "External Auth Providers",
 			Description: "External Authentication providers.",
 			YAML:        "externalAuthProviders",


### PR DESCRIPTION
The comment on the `External Auth Providers` option references `cli.ReadGitAuthFromEnvironment`, which doesn't exist. The actual function is `cli.ReadExternalAuthProvidersFromEnv`. Looks like this was left behind when git auth was renamed to external auth.

> Generated with [Coder Agents](https://coder.com/agents)