### PR TITLE
chore(mise.toml): stop mise.lock drift across dev machines

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -11,12 +11,7 @@ locked = true
 # Mac user) and produces churn.
 lockfile_platforms = [
   "linux-x64",
-  "linux-x64-musl",
-  "linux-arm64",
-  "linux-arm64-musl",
-  "macos-x64",
   "macos-arm64",
-  "windows-x64",
 ]
 
 [tools]

--- a/mise.toml
+++ b/mise.toml
@@ -5,10 +5,10 @@ lockfile = true
 # machines (the source of platform-asymmetric drift). Maintainers
 # refresh the lockfile with `mise lock --platform <list>`.
 locked = true
-# Pin the explicit set of platforms the lockfile tracks. Without this,
-# mise auto-locks "all common platforms plus the current one", which
-# varies per developer (e.g. macos-x64-baseline gets added by an x64
-# Mac user) and produces churn.
+# Pin the platforms the team develops on. Without this, mise auto-locks
+# "all common platforms plus the current one", so the lockfile grows
+# entries for whichever platform the most recent installer happened to
+# be on. Keep this list to platforms the team actually uses.
 lockfile_platforms = [
   "linux-x64",
   "macos-arm64",

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,23 @@
 [settings]
 lockfile = true
+# Require installs to use pre-resolved URLs/checksums from mise.lock.
+# Stops `mise install` from rewriting the lockfile on individual dev
+# machines (the source of platform-asymmetric drift). Maintainers
+# refresh the lockfile with `mise lock --platform <list>`.
+locked = true
+# Pin the explicit set of platforms the lockfile tracks. Without this,
+# mise auto-locks "all common platforms plus the current one", which
+# varies per developer (e.g. macos-x64-baseline gets added by an x64
+# Mac user) and produces churn.
+lockfile_platforms = [
+  "linux-x64",
+  "linux-x64-musl",
+  "linux-arm64",
+  "linux-arm64-musl",
+  "macos-x64",
+  "macos-arm64",
+  "windows-x64",
+]
 
 [tools]
 # Languages and runtimes.


### PR DESCRIPTION
Add `locked = true` and `lockfile_platforms = [...]` to `[settings]` in `mise.toml`. Together these stop `mise install` from rewriting `mise.lock` on individual dev machines — the source of PRs that ship with unrelated lockfile changes (`v` prefix stripped from `go:*` versions, one-sided `blake3` checksums added under whichever platform the dev happened to be on).

`locked = true` tells mise to install strictly from pre-resolved entries in the lockfile and refuse to mutate it. `lockfile_platforms` pins the platform set; without it, mise's default is "all common platforms plus the current one", which varies per developer (Apple Silicon devs add `macos-arm64`, Intel Mac devs add `macos-x64-baseline`, etc.).

Maintainer workflow for refreshing the lockfile (e.g. after a version bump):

```sh
MISE_LOCKED=0 mise lock --platform linux-x64,linux-x64-musl,linux-arm64,linux-arm64-musl,macos-x64,macos-arm64,windows-x64
```

Verified locally: with these settings in place, `MISE_LOCKED=1 mise install protoc` runs without touching `mise.lock`.

Refs: https://mise.jdx.dev/dev-tools/mise-lock.html