### PR TITLE
fix(site/src/pages/AgentsPage/components/ChatConversation): add min-h-6 to StatusPlaceholder to prevent layout shift

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatConversation/ChatStatusCallout.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ChatStatusCallout.tsx
@@ -20,7 +20,7 @@ const StatusPlaceholder: FC<{
 	shimmer?: boolean;
 }> = ({ text, shimmer = false }) => {
 	return (
-		<div className="relative">
+		<div className="relative min-h-6">
 			{/* Reserve the final response height without exposing a selectable copy. */}
 			<Response aria-hidden className="invisible select-none">
 				{text}


### PR DESCRIPTION
`StatusPlaceholder` rendered a `relative` container with no minimum height. Its invisible `<Response>` reserved ~21px while `StreamingThinkingPlaceholder` and `ReasoningDisclosure` both enforce `min-h-6` (24px) via `TranscriptRow`. During phase transitions this ~3px difference produced a visible layout shift.

Add `min-h-6` to the outer `<div>` in `StatusPlaceholder` so all "Thinking" states in the conversation timeline share a consistent 24px row height.