### PR TITLE
fix(cli): isolate CLI HTTP transport from global DefaultTransport

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -818,6 +818,10 @@ func (r *RootCmd) createHTTPClient(ctx context.Context, serverURL *url.URL, inv 
 		customTransport := defaultTransport.Clone()
 		customTransport.TLSClientConfig = r.tlsConfig
 		transport = customTransport
+	} else if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok {
+		// Clone the default transport so we don't share it with other code
+		// (including parallel tests that may call CloseIdleConnections).
+		transport = defaultTransport.Clone()
 	}
 
 	transport = wrapTransportWithTelemetryHeader(transport, inv)

--- a/cli/root.go
+++ b/cli/root.go
@@ -806,22 +806,19 @@ func (r *RootCmd) HeaderTransport(ctx context.Context, serverURL *url.URL) (*cod
 }
 
 func (r *RootCmd) createHTTPClient(ctx context.Context, serverURL *url.URL, inv *serpent.Invocation) (*http.Client, error) {
-	transport := http.DefaultTransport
-
-	// Apply custom TLS config if specified
-	if r.tlsConfig != nil {
-		// Clone the default transport and apply TLS config
-		defaultTransport, ok := http.DefaultTransport.(*http.Transport)
-		if !ok {
-			return nil, xerrors.New("cannot apply TLS config: http.DefaultTransport is not *http.Transport")
-		}
-		customTransport := defaultTransport.Clone()
-		customTransport.TLSClientConfig = r.tlsConfig
-		transport = customTransport
-	} else if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok {
-		// Clone the default transport so we don't share it with other code
-		// (including parallel tests that may call CloseIdleConnections).
+	var transport http.RoundTripper
+	if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok {
 		transport = defaultTransport.Clone()
+	} else {
+		transport = &http.Transport{Proxy: http.ProxyFromEnvironment}
+	}
+
+	if r.tlsConfig != nil {
+		t, ok := transport.(*http.Transport)
+		if !ok {
+			return nil, xerrors.New("cannot apply TLS config: transport is not *http.Transport")
+		}
+		t.TLSClientConfig = r.tlsConfig
 	}
 
 	transport = wrapTransportWithTelemetryHeader(transport, inv)
@@ -1694,8 +1691,7 @@ func (r roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 // if it is set to add headers for all outbound requests.
 func headerTransport(ctx context.Context, serverURL *url.URL, header []string, headerCommand string) (*codersdk.HeaderTransport, error) {
 	transport := &codersdk.HeaderTransport{
-		Transport: http.DefaultTransport,
-		Header:    http.Header{},
+		Header: http.Header{},
 	}
 	headers := header
 	if headerCommand != "" {


### PR DESCRIPTION
`httptest.Server.Close()` unconditionally calls `http.DefaultTransport.CloseIdleConnections()`. When parallel CLI tests finish and their servers close, that global call severs idle connections for other parallel tests still using the default transport.

`createHTTPClient` already clones the transport when a TLS config is present, but left the non-TLS path sharing `http.DefaultTransport` directly. Clone it in both paths so the CLI's connections are isolated from any other code touching the global.

This mirrors the existing `coderdtest.NewIsolatedHTTPClient` pattern and also defends the CLI in production against libraries or background goroutines that close the global transport.

Fixes https://github.com/coder/internal/issues/1515

*Generated by Coder Agents*