### PR TITLE
test: wait for devcontainer readiness

### DIFF
--- a/cli/open_test.go
+++ b/cli/open_test.go
@@ -437,9 +437,9 @@ func TestOpenVSCodeDevContainer(t *testing.T) {
 	parentAgent := coderdtest.RequireWorkspaceAgentByName(t, resources, parentAgentName)
 	parentAgentID := parentAgent.ID
 
-	// WorkspaceAgentWaiter only observes coderd state. The CLI exercises
-	// the parent agent container API through tailnet, so wait for that path
-	// before starting parallel open commands.
+	// Agent connection does not guarantee the parent agent's container API
+	// has completed its first devcontainer update. Wait for that endpoint so
+	// parallel open commands do not race the initial cache population.
 	ctx := testutil.Context(t, testutil.WaitSuperLong)
 	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
 		resp, err := client.WorkspaceAgentListContainers(ctx, parentAgentID, nil)

--- a/cli/open_test.go
+++ b/cli/open_test.go
@@ -433,7 +433,62 @@ func TestOpenVSCodeDevContainer(t *testing.T) {
 			agentcontainers.WithContainerLabelIncludeFilter("coder.test", t.Name()),
 		)
 	})
-	coderdtest.NewWorkspaceAgentWaiter(t, client, workspace.ID).AgentNames([]string{parentAgentName, devcontainerName}).Wait()
+	resources := coderdtest.NewWorkspaceAgentWaiter(t, client, workspace.ID).AgentNames([]string{parentAgentName}).Wait()
+
+	var parentAgentID uuid.UUID
+	for _, resource := range resources {
+		for _, workspaceAgent := range resource.Agents {
+			if workspaceAgent.Name == parentAgentName {
+				parentAgentID = workspaceAgent.ID
+			}
+		}
+	}
+	require.NotEqual(t, uuid.Nil, parentAgentID)
+
+	// WorkspaceAgentWaiter only observes coderd state. The CLI exercises
+	// the parent agent container API through tailnet, so wait for that path
+	// before starting parallel open commands.
+	ctx := testutil.Context(t, testutil.WaitSuperLong)
+	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
+		resp, err := client.WorkspaceAgentListContainers(ctx, parentAgentID, nil)
+		if err != nil {
+			t.Logf("list containers: %v", err)
+			return false
+		}
+		var devcontainerAgentID uuid.UUID
+		for _, dc := range resp.Devcontainers {
+			if dc.ID != devcontainerID {
+				continue
+			}
+			if dc.Status != codersdk.WorkspaceAgentDevcontainerStatusRunning {
+				return false
+			}
+			if dc.Container == nil || dc.Container.ID != containerID {
+				return false
+			}
+			if dc.Agent == nil || dc.Agent.Name != devcontainerName {
+				return false
+			}
+			devcontainerAgentID = dc.Agent.ID
+		}
+		if devcontainerAgentID == uuid.Nil {
+			return false
+		}
+
+		workspace, err := client.Workspace(ctx, workspace.ID)
+		if err != nil {
+			t.Logf("get workspace: %v", err)
+			return false
+		}
+		for _, resource := range workspace.LatestBuild.Resources {
+			for _, workspaceAgent := range resource.Agents {
+				if workspaceAgent.ID == devcontainerAgentID && workspaceAgent.Status == codersdk.WorkspaceAgentConnected {
+					return true
+				}
+			}
+		}
+		return false
+	}, testutil.IntervalMedium, "devcontainer did not become ready")
 
 	insideWorkspaceEnv := map[string]string{
 		"CODER":                      "true",

--- a/cli/open_test.go
+++ b/cli/open_test.go
@@ -434,16 +434,8 @@ func TestOpenVSCodeDevContainer(t *testing.T) {
 		)
 	})
 	resources := coderdtest.NewWorkspaceAgentWaiter(t, client, workspace.ID).AgentNames([]string{parentAgentName}).Wait()
-
-	var parentAgentID uuid.UUID
-	for _, resource := range resources {
-		for _, workspaceAgent := range resource.Agents {
-			if workspaceAgent.Name == parentAgentName {
-				parentAgentID = workspaceAgent.ID
-			}
-		}
-	}
-	require.NotEqual(t, uuid.Nil, parentAgentID)
+	parentAgent := coderdtest.RequireWorkspaceAgentByName(t, resources, parentAgentName)
+	parentAgentID := parentAgent.ID
 
 	// WorkspaceAgentWaiter only observes coderd state. The CLI exercises
 	// the parent agent container API through tailnet, so wait for that path
@@ -461,17 +453,29 @@ func TestOpenVSCodeDevContainer(t *testing.T) {
 				continue
 			}
 			if dc.Status != codersdk.WorkspaceAgentDevcontainerStatusRunning {
+				t.Logf("devcontainer %s status %q", devcontainerName, dc.Status)
 				return false
 			}
-			if dc.Container == nil || dc.Container.ID != containerID {
+			if dc.Container == nil {
+				t.Logf("devcontainer %s missing container", devcontainerName)
 				return false
 			}
-			if dc.Agent == nil || dc.Agent.Name != devcontainerName {
+			if dc.Container.ID != containerID {
+				t.Logf("devcontainer %s has container %s, want %s", devcontainerName, dc.Container.ID, containerID)
+				return false
+			}
+			if dc.Agent == nil {
+				t.Logf("devcontainer %s missing subagent", devcontainerName)
+				return false
+			}
+			if dc.Agent.Name != devcontainerName {
+				t.Logf("devcontainer %s has subagent %s, want %s", devcontainerName, dc.Agent.Name, devcontainerName)
 				return false
 			}
 			devcontainerAgentID = dc.Agent.ID
 		}
 		if devcontainerAgentID == uuid.Nil {
+			t.Logf("devcontainer %s not found", devcontainerName)
 			return false
 		}
 
@@ -482,11 +486,17 @@ func TestOpenVSCodeDevContainer(t *testing.T) {
 		}
 		for _, resource := range workspace.LatestBuild.Resources {
 			for _, workspaceAgent := range resource.Agents {
-				if workspaceAgent.ID == devcontainerAgentID && workspaceAgent.Status == codersdk.WorkspaceAgentConnected {
-					return true
+				if workspaceAgent.ID != devcontainerAgentID {
+					continue
 				}
+				if workspaceAgent.Status != codersdk.WorkspaceAgentConnected {
+					t.Logf("devcontainer subagent %s status %q", devcontainerAgentID, workspaceAgent.Status)
+					return false
+				}
+				return true
 			}
 		}
+		t.Logf("devcontainer subagent %s not found in workspace", devcontainerAgentID)
 		return false
 	}, testutil.IntervalMedium, "devcontainer did not become ready")
 

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -1278,6 +1278,22 @@ func NewWorkspaceAgentWaiter(t testing.TB, client *codersdk.Client, workspaceID 
 	}
 }
 
+// RequireWorkspaceAgentByName avoids weak nil UUID assertions when a fixture requires a specific agent.
+func RequireWorkspaceAgentByName(t testing.TB, resources []codersdk.WorkspaceResource, name string) codersdk.WorkspaceAgent {
+	t.Helper()
+
+	for _, resource := range resources {
+		for _, agent := range resource.Agents {
+			if agent.Name == name {
+				return agent
+			}
+		}
+	}
+
+	require.FailNowf(t, "workspace agent not found", "workspace agent %q not found in resources", name)
+	return codersdk.WorkspaceAgent{}
+}
+
 // AgentNames instructs the waiter to wait for the given, named agents to be connected and will
 // return even if other agents are not connected.
 func (w WorkspaceAgentWaiter) AgentNames(names []string) WorkspaceAgentWaiter {

--- a/coderd/workspaceapps/db_test.go
+++ b/coderd/workspaceapps/db_test.go
@@ -218,17 +218,8 @@ func Test_ResolveRequest(t *testing.T) {
 
 	_ = agenttest.New(t, client.URL, agentAuthToken)
 	resources := coderdtest.AwaitWorkspaceAgents(t, client, workspace.ID, agentName)
-
-	agentID := uuid.Nil
-	for _, resource := range resources {
-		for _, agnt := range resource.Agents {
-			if agnt.Name == agentName {
-				agentID = agnt.ID
-				break
-			}
-		}
-	}
-	require.NotEqual(t, uuid.Nil, agentID)
+	agent := coderdtest.RequireWorkspaceAgentByName(t, resources, agentName)
+	agentID := agent.ID
 
 	// Reset audit logs so cleanup check can pass.
 	connLogger.Reset()


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

`TestOpenVSCodeDevContainer` could start its parallel `coder open vscode` subtests before the parent agent's container API was ready through tailnet. This adds a setup wait for the parent container API to return the running devcontainer and for the devcontainer subagent to be visible as connected before the parallel CLI checks begin.

<details><summary>Research</summary>

A recent CI failure timed out in `coder open vscode` while listing parent workspace agent containers. The coderd request took nearly the full test deadline and the parent agent logged a container update after the subtest had already timed out.

The existing `WorkspaceAgentWaiter` only waits for coderd's workspace agent state. It does not prove that the parent agent's HTTP API is reachable through tailnet or that the agent container cache has a running devcontainer with the subagent populated. The CLI path under test depends on that API before building the VS Code devcontainer link.

The targeted fix keeps the parallel subtests but moves the readiness wait into setup. The wait exercises the same parent container endpoint the CLI uses and also confirms the devcontainer subagent is present in the workspace before the subtests run.

</details>
