### PR TITLE
feat(site/src/pages/AgentsPage): show MCP tool inputs

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -17,6 +17,12 @@ const executeCommand = "git fetch origin";
 const executeIntentCommand = "npm test";
 const longExecuteCommand =
 	"docker build --no-cache --build-arg NODE_ENV=production --build-arg API_URL=https://coder.example.com/api --build-arg SENTRY_DSN=https://example.com/sentry --build-arg FEATURE_FLAGS=agents,shell-tools --tag coder-agent:latest .";
+
+const getDiffsText = (element: HTMLElement) =>
+	Array.from(element.querySelectorAll("diffs-container"))
+		.map((container) => container.shadowRoot?.textContent ?? "")
+		.join("\n");
+
 const meta: Meta<typeof Tool> = {
 	title: "pages/AgentsPage/ChatElements/tools/Tool",
 	component: Tool,
@@ -1080,17 +1086,15 @@ export const MCPToolCompleted: Story = {
 		expect(canvasElement.querySelector(".animate-spin")).toBeNull();
 		// Icon should still be monochrome when completed.
 		expect(canvasElement.querySelector(".brightness-0")).not.toBeNull();
-		// Result should be collapsed by default.
 		const toggle = canvas.getByRole("button");
 		expect(toggle).toBeInTheDocument();
-		// Expand to see result content.
 		await userEvent.click(toggle);
-		// @pierre/diffs renders inside a Shadow DOM (<diffs-container>)
-		// so textContent on the host element can't see the content.
-		// Query into the shadow root to verify the JSON rendered.
+		expect(canvas.getByText("Input")).toBeVisible();
+		expect(canvas.getByText("Output")).toBeVisible();
 		await waitFor(() => {
-			const shadow = canvasElement.querySelector("diffs-container")?.shadowRoot;
-			expect(shadow?.textContent).toContain("Fix auth flow");
+			const diffsText = getDiffsText(canvasElement);
+			expect(diffsText).toContain("backend");
+			expect(diffsText).toContain("Fix auth flow");
 		});
 	},
 };
@@ -1124,8 +1128,12 @@ export const MCPToolNoResult: Story = {
 		mcpServers: sampleMCPServers,
 	},
 	play: async ({ canvasElement }) => {
-		// No toggle button when there is no result content.
-		expect(canvasElement.querySelector("button")).toBeNull();
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button"));
+		expect(canvas.getByText("Input")).toBeVisible();
+		await waitFor(() => {
+			expect(getDiffsText(canvasElement)).toContain("New issue");
+		});
 	},
 };
 
@@ -1193,6 +1201,27 @@ export const MCPToolNoServer: Story = {
 		const canvas = within(canvasElement);
 		// Falls through to generic wrench icon + raw tool name.
 		expect(canvas.getByText("some_custom_tool")).toBeInTheDocument();
+	},
+};
+
+export const WorkspaceMCPToolCompleted: Story = {
+	args: {
+		name: "workspace-mcp__echo",
+		status: "completed",
+		args: { message: "hello from workspace MCP" },
+		result: { output: "hello from workspace MCP" },
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("workspace-mcp__echo")).toBeInTheDocument();
+		await userEvent.click(canvas.getByRole("button"));
+		expect(canvas.getByText("Input")).toBeVisible();
+		expect(canvas.getByText("Output")).toBeVisible();
+		await waitFor(() => {
+			const diffsText = getDiffsText(canvasElement);
+			expect(diffsText).toContain("message");
+			expect(diffsText).toContain("hello from workspace MCP");
+		});
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -51,6 +51,7 @@ import {
 	DIFFS_FONT_STYLE,
 	formatModelIntentLabel,
 	formatResultOutput,
+	formatToolInput,
 	getFileContentForViewer,
 	getFileViewerOptions,
 	getFileViewerOptionsNoHeader,
@@ -834,6 +835,7 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 }) => {
 	const theme = useTheme();
 	const isDark = theme.palette.mode === "dark";
+	const toolInput = formatToolInput(args);
 	const resultOutput = formatResultOutput(result);
 	const fileContent = getFileContentForViewer(name, args, result);
 	const fileViewerOpts = getFileViewerOptions(isDark);
@@ -850,7 +852,7 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 		? mcpServers?.find((s) => s.id === mcpServerConfigId)
 		: undefined;
 
-	const hasContent = Boolean(fileContent || resultOutput);
+	const hasContent = Boolean(toolInput || fileContent || resultOutput);
 	const isRunning = status === "running";
 	const rec = asRecord(result);
 	const errorMessage = rec ? asString(rec.error || rec.message) : "";
@@ -892,23 +894,11 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 
 	const toolContent = (
 		<>
-			{fileContent ? (
-				<ScrollArea
-					className="mt-1.5 rounded-md border border-solid border-border-default text-2xs"
-					viewportClassName="max-h-64"
-					scrollBarClassName="w-1.5"
-				>
-					<FileViewer
-						file={{
-							name: fileContent.path,
-							contents: fileContent.content,
-						}}
-						options={fileContentOptions}
-						style={DIFFS_FONT_STYLE}
-					/>
-				</ScrollArea>
-			) : (
-				resultOutput && (
+			{toolInput && (
+				<>
+					<div className="mt-2 text-2xs font-medium text-content-secondary">
+						Input
+					</div>
 					<ScrollArea
 						className="mt-1.5 rounded-md border border-solid border-border-default text-2xs"
 						viewportClassName="max-h-64"
@@ -916,13 +906,60 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 					>
 						<FileViewer
 							file={{
-								name: "output.json",
-								contents: resultOutput,
+								name: "input.json",
+								contents: toolInput,
 							}}
 							options={getFileViewerOptionsNoHeader(isDark)}
 							style={DIFFS_FONT_STYLE}
 						/>
 					</ScrollArea>
+				</>
+			)}
+			{fileContent ? (
+				<>
+					{toolInput && (
+						<div className="mt-2 text-2xs font-medium text-content-secondary">
+							Output
+						</div>
+					)}
+					<ScrollArea
+						className="mt-1.5 rounded-md border border-solid border-border-default text-2xs"
+						viewportClassName="max-h-64"
+						scrollBarClassName="w-1.5"
+					>
+						<FileViewer
+							file={{
+								name: fileContent.path,
+								contents: fileContent.content,
+							}}
+							options={fileContentOptions}
+							style={DIFFS_FONT_STYLE}
+						/>
+					</ScrollArea>
+				</>
+			) : (
+				resultOutput && (
+					<>
+						{toolInput && (
+							<div className="mt-2 text-2xs font-medium text-content-secondary">
+								Output
+							</div>
+						)}
+						<ScrollArea
+							className="mt-1.5 rounded-md border border-solid border-border-default text-2xs"
+							viewportClassName="max-h-64"
+							scrollBarClassName="w-1.5"
+						>
+							<FileViewer
+								file={{
+									name: "output.json",
+									contents: resultOutput,
+								}}
+								options={getFileViewerOptionsNoHeader(isDark)}
+								style={DIFFS_FONT_STYLE}
+							/>
+						</ScrollArea>
+					</>
 				)
 			)}
 		</>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -56,6 +56,7 @@ import {
 	getFileViewerOptions,
 	getFileViewerOptionsNoHeader,
 	getWriteFileDiff,
+	hasToolInput,
 	isSubagentSuccessStatus,
 	mapSubagentStatusToToolStatus,
 	parseArgs,
@@ -823,6 +824,77 @@ const ComputerRenderer: FC<ToolRendererProps> = ({
 	);
 };
 
+type ToolFileViewerProps = {
+	label?: string;
+	file: ComponentPropsWithRef<typeof FileViewer>["file"];
+	options: ComponentPropsWithRef<typeof FileViewer>["options"];
+};
+
+const ToolFileViewer: FC<ToolFileViewerProps> = ({ label, file, options }) => (
+	<>
+		{label && (
+			<div className="mt-2 text-2xs font-medium text-content-secondary">
+				{label}
+			</div>
+		)}
+		<ScrollArea
+			className="mt-1.5 rounded-md border border-solid border-border-default text-2xs"
+			viewportClassName="max-h-64"
+			scrollBarClassName="w-1.5"
+		>
+			<FileViewer file={file} options={options} style={DIFFS_FONT_STYLE} />
+		</ScrollArea>
+	</>
+);
+
+type GenericToolContentProps = {
+	args: unknown;
+	fileContent: ReturnType<typeof getFileContentForViewer>;
+	fileContentOptions: ComponentPropsWithRef<typeof FileViewer>["options"];
+	isDark: boolean;
+	resultOutput: string | null;
+};
+
+const GenericToolContent: FC<GenericToolContentProps> = ({
+	args,
+	fileContent,
+	fileContentOptions,
+	isDark,
+	resultOutput,
+}) => {
+	const toolInput = formatToolInput(args);
+	const output = fileContent
+		? {
+				file: { name: fileContent.path, contents: fileContent.content },
+				options: fileContentOptions,
+			}
+		: resultOutput
+			? {
+					file: { name: "output.json", contents: resultOutput },
+					options: getFileViewerOptionsNoHeader(isDark),
+				}
+			: undefined;
+
+	return (
+		<>
+			{toolInput && (
+				<ToolFileViewer
+					label="Input"
+					file={{ name: "input.json", contents: toolInput }}
+					options={getFileViewerOptionsNoHeader(isDark)}
+				/>
+			)}
+			{output && (
+				<ToolFileViewer
+					label={toolInput ? "Output" : undefined}
+					file={output.file}
+					options={output.options}
+				/>
+			)}
+		</>
+	);
+};
+
 const GenericToolRenderer: FC<ToolRendererProps> = ({
 	name,
 	status,
@@ -835,7 +907,6 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 }) => {
 	const theme = useTheme();
 	const isDark = theme.palette.mode === "dark";
-	const toolInput = formatToolInput(args);
 	const resultOutput = formatResultOutput(result);
 	const fileContent = getFileContentForViewer(name, args, result);
 	const fileViewerOpts = getFileViewerOptions(isDark);
@@ -852,7 +923,7 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 		? mcpServers?.find((s) => s.id === mcpServerConfigId)
 		: undefined;
 
-	const hasContent = Boolean(toolInput || fileContent || resultOutput);
+	const hasContent = Boolean(hasToolInput(args) || fileContent || resultOutput);
 	const isRunning = status === "running";
 	const rec = asRecord(result);
 	const errorMessage = rec ? asString(rec.error || rec.message) : "";
@@ -893,76 +964,13 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 	);
 
 	const toolContent = (
-		<>
-			{toolInput && (
-				<>
-					<div className="mt-2 text-2xs font-medium text-content-secondary">
-						Input
-					</div>
-					<ScrollArea
-						className="mt-1.5 rounded-md border border-solid border-border-default text-2xs"
-						viewportClassName="max-h-64"
-						scrollBarClassName="w-1.5"
-					>
-						<FileViewer
-							file={{
-								name: "input.json",
-								contents: toolInput,
-							}}
-							options={getFileViewerOptionsNoHeader(isDark)}
-							style={DIFFS_FONT_STYLE}
-						/>
-					</ScrollArea>
-				</>
-			)}
-			{fileContent ? (
-				<>
-					{toolInput && (
-						<div className="mt-2 text-2xs font-medium text-content-secondary">
-							Output
-						</div>
-					)}
-					<ScrollArea
-						className="mt-1.5 rounded-md border border-solid border-border-default text-2xs"
-						viewportClassName="max-h-64"
-						scrollBarClassName="w-1.5"
-					>
-						<FileViewer
-							file={{
-								name: fileContent.path,
-								contents: fileContent.content,
-							}}
-							options={fileContentOptions}
-							style={DIFFS_FONT_STYLE}
-						/>
-					</ScrollArea>
-				</>
-			) : (
-				resultOutput && (
-					<>
-						{toolInput && (
-							<div className="mt-2 text-2xs font-medium text-content-secondary">
-								Output
-							</div>
-						)}
-						<ScrollArea
-							className="mt-1.5 rounded-md border border-solid border-border-default text-2xs"
-							viewportClassName="max-h-64"
-							scrollBarClassName="w-1.5"
-						>
-							<FileViewer
-								file={{
-									name: "output.json",
-									contents: resultOutput,
-								}}
-								options={getFileViewerOptionsNoHeader(isDark)}
-								style={DIFFS_FONT_STYLE}
-							/>
-						</ScrollArea>
-					</>
-				)
-			)}
-		</>
+		<GenericToolContent
+			args={args}
+			fileContent={fileContent}
+			fileContentOptions={fileContentOptions}
+			isDark={isDark}
+			resultOutput={resultOutput}
+		/>
 	);
 
 	return (

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -56,7 +56,6 @@ import {
 	getFileViewerOptions,
 	getFileViewerOptionsNoHeader,
 	getWriteFileDiff,
-	hasToolInput,
 	isSubagentSuccessStatus,
 	mapSubagentStatusToToolStatus,
 	parseArgs,
@@ -848,7 +847,7 @@ const ToolFileViewer: FC<ToolFileViewerProps> = ({ label, file, options }) => (
 );
 
 type GenericToolContentProps = {
-	args: unknown;
+	toolInput: string | null;
 	fileContent: ReturnType<typeof getFileContentForViewer>;
 	fileContentOptions: ComponentPropsWithRef<typeof FileViewer>["options"];
 	isDark: boolean;
@@ -856,13 +855,12 @@ type GenericToolContentProps = {
 };
 
 const GenericToolContent: FC<GenericToolContentProps> = ({
-	args,
+	toolInput,
 	fileContent,
 	fileContentOptions,
 	isDark,
 	resultOutput,
 }) => {
-	const toolInput = formatToolInput(args);
 	const output = fileContent
 		? {
 				file: { name: fileContent.path, contents: fileContent.content },
@@ -907,6 +905,7 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 }) => {
 	const theme = useTheme();
 	const isDark = theme.palette.mode === "dark";
+	const toolInput = formatToolInput(args);
 	const resultOutput = formatResultOutput(result);
 	const fileContent = getFileContentForViewer(name, args, result);
 	const fileViewerOpts = getFileViewerOptions(isDark);
@@ -923,7 +922,7 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 		? mcpServers?.find((s) => s.id === mcpServerConfigId)
 		: undefined;
 
-	const hasContent = Boolean(hasToolInput(args) || fileContent || resultOutput);
+	const hasContent = Boolean(toolInput || fileContent || resultOutput);
 	const isRunning = status === "running";
 	const rec = asRecord(result);
 	const errorMessage = rec ? asString(rec.error || rec.message) : "";
@@ -965,7 +964,7 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 
 	const toolContent = (
 		<GenericToolContent
-			args={args}
+			toolInput={toolInput}
 			fileContent={fileContent}
 			fileContentOptions={fileContentOptions}
 			isDark={isDark}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
@@ -10,6 +10,7 @@ import {
 	formatModelIntentLabel,
 	formatResultOutput,
 	formatShellDurationMs,
+	formatToolInput,
 	getDiffViewerOptions,
 	getFileContentForViewer,
 	getFileViewerOptions,
@@ -303,6 +304,49 @@ describe("parseArgs", () => {
 
 	it("returns null for arrays", () => {
 		expect(parseArgs([1, 2, 3])).toBeNull();
+	});
+});
+
+describe("formatToolInput", () => {
+	it("returns null for null, undefined, and empty inputs", () => {
+		expect(formatToolInput(null)).toBeNull();
+		expect(formatToolInput(undefined)).toBeNull();
+		expect(formatToolInput("")).toBeNull();
+		expect(formatToolInput({})).toBeNull();
+		expect(formatToolInput([])).toBeNull();
+		expect(formatToolInput("{}")).toBeNull();
+		expect(formatToolInput("[]")).toBeNull();
+	});
+
+	it("formats object input as pretty JSON", () => {
+		expect(formatToolInput({ project: "backend", limit: 2 })).toBe(
+			JSON.stringify({ project: "backend", limit: 2 }, null, 2),
+		);
+	});
+
+	it("formats JSON string input as pretty JSON", () => {
+		expect(formatToolInput('{"project":"backend","limit":2}')).toBe(
+			JSON.stringify({ project: "backend", limit: 2 }, null, 2),
+		);
+	});
+
+	it("unwraps model intent input wrappers", () => {
+		expect(
+			formatToolInput({
+				model_intent: "Reading backend issues",
+				properties: { project: "backend" },
+			}),
+		).toBe(JSON.stringify({ project: "backend" }, null, 2));
+		expect(
+			formatToolInput({
+				model_intent: "Reading backend issues",
+				project: "backend",
+			}),
+		).toBe(JSON.stringify({ project: "backend" }, null, 2));
+	});
+
+	it("preserves non-JSON string input", () => {
+		expect(formatToolInput("search text")).toBe("search text");
 	});
 });
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
@@ -17,7 +17,6 @@ import {
 	getFileViewerOptionsMinimal,
 	getFileViewerOptionsNoHeader,
 	getWriteFileDiff,
-	hasToolInput,
 	humanizeMCPToolName,
 	isSubagentRunningStatus,
 	isSubagentSuccessStatus,
@@ -309,17 +308,6 @@ describe("parseArgs", () => {
 });
 
 describe("formatToolInput", () => {
-	it("detects displayable input", () => {
-		expect(hasToolInput(null)).toBe(false);
-		expect(hasToolInput(undefined)).toBe(false);
-		expect(hasToolInput("")).toBe(false);
-		expect(hasToolInput({})).toBe(false);
-		expect(hasToolInput([])).toBe(false);
-		expect(hasToolInput("{}")).toBe(false);
-		expect(hasToolInput("[]")).toBe(false);
-		expect(hasToolInput({ project: "backend" })).toBe(true);
-	});
-
 	it("returns null for null, undefined, and empty inputs", () => {
 		expect(formatToolInput(null)).toBeNull();
 		expect(formatToolInput(undefined)).toBeNull();
@@ -328,6 +316,15 @@ describe("formatToolInput", () => {
 		expect(formatToolInput([])).toBeNull();
 		expect(formatToolInput("{}")).toBeNull();
 		expect(formatToolInput("[]")).toBeNull();
+		expect(formatToolInput("null")).toBeNull();
+		expect(
+			formatToolInput(
+				JSON.stringify({
+					model_intent: "Reading backend issues",
+					properties: {},
+				}),
+			),
+		).toBeNull();
 	});
 
 	it("formats object input as pretty JSON", () => {
@@ -354,6 +351,14 @@ describe("formatToolInput", () => {
 				model_intent: "Reading backend issues",
 				project: "backend",
 			}),
+		).toBe(JSON.stringify({ project: "backend" }, null, 2));
+		expect(
+			formatToolInput(
+				JSON.stringify({
+					model_intent: "Reading backend issues",
+					properties: { project: "backend" },
+				}),
+			),
 		).toBe(JSON.stringify({ project: "backend" }, null, 2));
 	});
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
@@ -17,6 +17,7 @@ import {
 	getFileViewerOptionsMinimal,
 	getFileViewerOptionsNoHeader,
 	getWriteFileDiff,
+	hasToolInput,
 	humanizeMCPToolName,
 	isSubagentRunningStatus,
 	isSubagentSuccessStatus,
@@ -308,6 +309,17 @@ describe("parseArgs", () => {
 });
 
 describe("formatToolInput", () => {
+	it("detects displayable input", () => {
+		expect(hasToolInput(null)).toBe(false);
+		expect(hasToolInput(undefined)).toBe(false);
+		expect(hasToolInput("")).toBe(false);
+		expect(hasToolInput({})).toBe(false);
+		expect(hasToolInput([])).toBe(false);
+		expect(hasToolInput("{}")).toBe(false);
+		expect(hasToolInput("[]")).toBe(false);
+		expect(hasToolInput({ project: "backend" })).toBe(true);
+	});
+
 	it("returns null for null, undefined, and empty inputs", () => {
 		expect(formatToolInput(null)).toBeNull();
 		expect(formatToolInput(undefined)).toBeNull();

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
@@ -249,18 +249,6 @@ const formatValue = (value: unknown): string => {
 	return String(value);
 };
 
-export const hasToolInput = (args: unknown): boolean => {
-	const input = getToolInputPayload(args);
-	if (input === undefined || input === null) {
-		return false;
-	}
-	if (typeof input === "string") {
-		const trimmed = input.trim();
-		return Boolean(trimmed && trimmed !== "{}" && trimmed !== "[]");
-	}
-	return !isEmptyObjectOrArray(input);
-};
-
 export const formatToolInput = (args: unknown): string | null => {
 	const input = getToolInputPayload(args);
 	if (input === undefined || input === null) {

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
@@ -230,6 +230,37 @@ const getToolInputPayload = (args: unknown): unknown => {
 	);
 };
 
+const isEmptyObjectOrArray = (value: unknown): boolean => {
+	if (Array.isArray(value)) {
+		return value.length === 0;
+	}
+	const rec = asRecord(value);
+	return rec ? Object.keys(rec).length === 0 : false;
+};
+
+const formatValue = (value: unknown): string => {
+	if (typeof value === "object") {
+		try {
+			return JSON.stringify(value, null, 2) ?? String(value);
+		} catch {
+			return String(value);
+		}
+	}
+	return String(value);
+};
+
+export const hasToolInput = (args: unknown): boolean => {
+	const input = getToolInputPayload(args);
+	if (input === undefined || input === null) {
+		return false;
+	}
+	if (typeof input === "string") {
+		const trimmed = input.trim();
+		return Boolean(trimmed && trimmed !== "{}" && trimmed !== "[]");
+	}
+	return !isEmptyObjectOrArray(input);
+};
+
 export const formatToolInput = (args: unknown): string | null => {
 	const input = getToolInputPayload(args);
 	if (input === undefined || input === null) {
@@ -246,22 +277,7 @@ export const formatToolInput = (args: unknown): string | null => {
 			return trimmed;
 		}
 	}
-	if (Array.isArray(input) && input.length === 0) {
-		return null;
-	}
-	const rec = asRecord(input);
-	if (rec && Object.keys(rec).length === 0) {
-		return null;
-	}
-	if (typeof input === "object") {
-		try {
-			const formatted = JSON.stringify(input, null, 2);
-			return formatted === "{}" || formatted === "[]" ? null : formatted;
-		} catch {
-			return String(input);
-		}
-	}
-	return String(input);
+	return isEmptyObjectOrArray(input) ? null : formatValue(input);
 };
 
 export const formatResultOutput = (result: unknown): string | null => {
@@ -285,14 +301,7 @@ export const formatResultOutput = (result: unknown): string | null => {
 			return content;
 		}
 	}
-	if (typeof result === "object") {
-		try {
-			return JSON.stringify(result, null, 2);
-		} catch {
-			return String(result);
-		}
-	}
-	return String(result);
+	return formatValue(result);
 };
 
 export const fileViewerCSS =

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
@@ -217,6 +217,53 @@ export const parseArgs = (args: unknown): Record<string, unknown> | null => {
 	return asRecord(args);
 };
 
+const getToolInputPayload = (args: unknown): unknown => {
+	const rec = asRecord(args);
+	if (!rec || typeof rec.model_intent !== "string") {
+		return args;
+	}
+	if ("properties" in rec) {
+		return rec.properties;
+	}
+	return Object.fromEntries(
+		Object.entries(rec).filter(([key]) => key !== "model_intent"),
+	);
+};
+
+export const formatToolInput = (args: unknown): string | null => {
+	const input = getToolInputPayload(args);
+	if (input === undefined || input === null) {
+		return null;
+	}
+	if (typeof input === "string") {
+		const trimmed = input.trim();
+		if (!trimmed) {
+			return null;
+		}
+		try {
+			return formatToolInput(JSON.parse(trimmed));
+		} catch {
+			return trimmed;
+		}
+	}
+	if (Array.isArray(input) && input.length === 0) {
+		return null;
+	}
+	const rec = asRecord(input);
+	if (rec && Object.keys(rec).length === 0) {
+		return null;
+	}
+	if (typeof input === "object") {
+		try {
+			const formatted = JSON.stringify(input, null, 2);
+			return formatted === "{}" || formatted === "[]" ? null : formatted;
+		} catch {
+			return String(input);
+		}
+	}
+	return String(input);
+};
+
 export const formatResultOutput = (result: unknown): string | null => {
 	if (result === undefined || result === null) {
 		return null;


### PR DESCRIPTION
Generic agent chat tool cards now render an `Input` section before the existing output viewer, so MCP and workspace MCP tools expose the arguments sent to the tool. Empty inputs stay hidden, model-intent wrappers are stripped before display, and the formatted input is the single source of truth for whether an input block renders.

Refs https://linear.app/codercom/issue/CODAGT-260/show-mcp-tool-inputs-in-agent-chats

> Mux worked on this on Mike's behalf.
