### PR TITLE
test: dont assert websocket closes without error

### DIFF
--- a/coderd/workspaceconnwatcher/watcher_test.go
+++ b/coderd/workspaceconnwatcher/watcher_test.go
@@ -277,8 +277,7 @@ func TestWatcher_LostAccess(t *testing.T) {
 	dec, err := h.Dial(ctx, "wss://local.test/")
 	require.NoError(t, err)
 	defer func() {
-		err := dec.Close()
-		require.NoError(t, err)
+		_ = dec.Close()
 	}()
 	events := dec.Chan()
 	e0 := testutil.RequireReceive(ctx, t, events)
@@ -312,8 +311,7 @@ func TestWatcher_PublishChanges(t *testing.T) {
 	dec, err := h.Dial(ctx, "wss://local.test/")
 	require.NoError(t, err)
 	defer func() {
-		err := dec.Close()
-		require.NoError(t, err)
+		_ = dec.Close()
 	}()
 	events := dec.Chan()
 


### PR DESCRIPTION
<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->

fixes https://github.com/coder/internal/issues/1541  
  
Closing websockets can race whether they return an error or not if the remote side closes too. Dropping some test assertions about this since it is not critical to what we are testing.