### PR TITLE
fix(site): link agents sidebar Providers to /ai/settings

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatsSidebar/settings/SettingsPanel.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/settings/SettingsPanel.tsx
@@ -1,5 +1,6 @@
 import {
 	ArrowLeftIcon,
+	ArrowUpRightIcon,
 	BotIcon,
 	BoxesIcon,
 	ChevronRightIcon,
@@ -158,9 +159,9 @@ export const SettingsPanel: FC<SettingsPanelProps> = ({
 					<SettingsNavItem
 						icon={PlugIcon}
 						label="Providers"
-						active={settingsSection === "providers"}
-						to="/agents/settings/providers"
-						state={location.state}
+						active={false}
+						to="/ai/settings"
+						trailingIcon={ArrowUpRightIcon}
 					/>
 					<SettingsNavItem
 						icon={BoxesIcon}


### PR DESCRIPTION
> 🤖 Generated with [Coder Agents](https://coder.com/agents) on behalf of @tracyjohnsonux

Points the Providers entry in the agents settings sidebar to the new AI settings page (`/ai/settings`) instead of `/agents/settings/providers`, and adds an `ArrowUpRightIcon` to indicate navigation outside the agents area.

Companion to #25551 which introduces the top-level AI admin section.