### PR TITLE
feat!: default `CODER_AI_GATEWAY_ENABLED` to true

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -157,7 +157,7 @@ AI GATEWAY OPTIONS:
           Length of time to retain data such as interceptions and all related
           records (token, prompt, tool use).
 
-      --ai-gateway-enabled bool, $CODER_AI_GATEWAY_ENABLED (default: false)
+      --ai-gateway-enabled bool, $CODER_AI_GATEWAY_ENABLED (default: true)
           Whether to start an in-memory AI Gateway instance.
 
       --ai-gateway-max-concurrency int, $CODER_AI_GATEWAY_MAX_CONCURRENCY (default: 0)

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -768,8 +768,8 @@ chat:
 aibridge:
   # Deprecated: use --ai-gateway-enabled or CODER_AI_GATEWAY_ENABLED instead.
   # Whether to start an in-memory aibridged instance.
-  # (default: false, type: bool)
-  enabled: false
+  # (default: true, type: bool)
+  enabled: true
   # Deprecated: use --ai-gateway-openai-base-url or CODER_AI_GATEWAY_OPENAI_BASE_URL
   # instead. The base URL of the OpenAI API.
   # (default: https://api.openai.com/v1/, type: string)
@@ -867,8 +867,8 @@ aibridge:
   circuit_breaker_max_requests: 3
 ai_gateway:
   # Whether to start an in-memory AI Gateway instance.
-  # (default: false, type: bool)
-  enabled: false
+  # (default: true, type: bool)
+  enabled: true
   # The base URL of the OpenAI API.
   # (default: https://api.openai.com/v1/, type: string)
   openai_base_url: https://api.openai.com/v1/

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -250,7 +250,7 @@ func (n FeatureName) Humanize() string {
 	case FeatureSCIM:
 		return "SCIM"
 	case FeatureAIBridge:
-		return "AI Bridge"
+		return "AI Gateway"
 	case FeatureAIGovernanceUserLimit:
 		return "AI Governance User Limit"
 	default:
@@ -1705,7 +1705,7 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		Flag:        "ai-gateway-enabled",
 		Env:         "CODER_AI_GATEWAY_ENABLED",
 		Value:       &c.AI.BridgeConfig.Enabled,
-		Default:     "false",
+		Default:     "true",
 		Group:       &deploymentGroupAIGateway,
 		YAML:        "enabled",
 	}
@@ -4055,7 +4055,7 @@ Write out the current server config as YAML to stdout.`,
 			Flag:        "aibridge-enabled",
 			Env:         "CODER_AIBRIDGE_ENABLED",
 			Value:       &c.AI.BridgeConfig.Enabled,
-			Default:     "false",
+			Default:     "true",
 			Group:       &deploymentGroupAIBridge,
 			YAML:        "enabled",
 			Hidden:      true,

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1730,7 +1730,7 @@ Force chat debug logging on for every chat, bypassing the runtime admin and user
 | Type        | <code>bool</code>                      |
 | Environment | <code>$CODER_AI_GATEWAY_ENABLED</code> |
 | YAML        | <code>ai_gateway.enabled</code>        |
-| Default     | <code>false</code>                     |
+| Default     | <code>true</code>                      |
 
 Whether to start an in-memory AI Gateway instance.
 

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -158,7 +158,7 @@ AI GATEWAY OPTIONS:
           Length of time to retain data such as interceptions and all related
           records (token, prompt, tool use).
 
-      --ai-gateway-enabled bool, $CODER_AI_GATEWAY_ENABLED (default: false)
+      --ai-gateway-enabled bool, $CODER_AI_GATEWAY_ENABLED (default: true)
           Whether to start an in-memory AI Gateway instance.
 
       --ai-gateway-max-concurrency int, $CODER_AI_GATEWAY_MAX_CONCURRENCY (default: 0)

--- a/enterprise/coderd/aibridge_test.go
+++ b/enterprise/coderd/aibridge_test.go
@@ -54,7 +54,7 @@ func TestAIBridgeListInterceptions(t *testing.T) {
 		var sdkErr *codersdk.Error
 		require.ErrorAs(t, err, &sdkErr)
 		require.Equal(t, http.StatusForbidden, sdkErr.StatusCode())
-		require.Equal(t, "AI Bridge is a Premium feature. Contact sales!", sdkErr.Message)
+		require.Equal(t, "AI Gateway is a Premium feature. Contact sales!", sdkErr.Message)
 	})
 
 	t.Run("EmptyDB", func(t *testing.T) {

--- a/enterprise/coderd/coderd_test.go
+++ b/enterprise/coderd/coderd_test.go
@@ -94,6 +94,7 @@ func TestEntitlements(t *testing.T) {
 		features[codersdk.FeatureUserLimit] = 100
 		coderdenttest.AddLicense(t, adminClient, coderdenttest.LicenseOptions{
 			Features: features,
+			Addons:   []codersdk.Addon{codersdk.AddonAIGovernance},
 			GraceAt:  time.Now().Add(59 * 24 * time.Hour),
 		})
 		res, err := adminClient.Entitlements(context.Background()) //nolint:gocritic // adding another user would put us over user limit


### PR DESCRIPTION
`CODER_AI_GATEWAY_ENABLED` / `CODER_AIBRIDGE_ENABLED` is now being defaulted to `true` now that it will be used by Coder Agents.

If you previously had this value disabled explicitly, that value will persist.