### PR TITLE
POC: chatd uses aibridged routing in OSS

### DIFF
--- a/cli/aibridged.go
+++ b/cli/aibridged.go
@@ -4,6 +4,8 @@ package cli
 
 import (
 	"context"
+	"net/url"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/xerrors"
@@ -17,6 +19,36 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/quartz"
 )
+
+// providerNameFromHost builds a host -> provider-name lookup from the given
+// providers' BaseURLs, so the in-memory transport can rewrite SDK-style paths
+// like "POST api.anthropic.com/v1/messages" to bridge-style paths like
+// "POST /anthropic/v1/messages" before invoking the aibridged handler.
+// Matches the host-to-provider mapping that aibridgeproxyd uses for the
+// network path; see [enterprise/cli/aibridgeproxyd.go:domainsFromProviders].
+func providerNameFromHost(providers []aibridge.Provider) func(host string) string {
+	hostToProvider := make(map[string]string, len(providers))
+	for _, p := range providers {
+		raw := p.BaseURL()
+		if raw == "" {
+			continue
+		}
+		u, err := url.Parse(raw)
+		if err != nil || u.Hostname() == "" {
+			continue
+		}
+		host := strings.ToLower(u.Hostname())
+		// First provider wins; duplicates can occur when multiple
+		// providers share a base-URL host.
+		if _, exists := hostToProvider[host]; exists {
+			continue
+		}
+		hostToProvider[host] = p.Name()
+	}
+	return func(host string) string {
+		return hostToProvider[strings.ToLower(host)]
+	}
+}
 
 func newAIBridgeDaemon(coderAPI *coderd.API, providers []aibridge.Provider) (*aibridged.Server, error) {
 	ctx := context.Background()

--- a/cli/server.go
+++ b/cli/server.go
@@ -1042,7 +1042,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				if err != nil {
 					return xerrors.Errorf("create aibridged: %w", err)
 				}
-				coderAPI.RegisterInMemoryAIBridgedHTTPHandler(aibridgeDaemon)
+				coderAPI.RegisterInMemoryAIBridgedHTTPHandler(aibridgeDaemon, providerNameFromHost(providers))
 				// The handler is bound to coderAPI's lifecycle; Close() on the
 				// daemon does not affect in-flight requests but is needed to
 				// release pool/recorder resources at shutdown.

--- a/coderd/aibridged.go
+++ b/coderd/aibridged.go
@@ -37,14 +37,20 @@ func (api *API) GetAIBridgedHandler() http.Handler {
 // the HTTP route. No license entitlement gate is applied at the factory layer:
 // the entitlement check stays on the HTTP route for external callers, while
 // in-process coder-agent traffic is the explicit carve-out.
-func (api *API) RegisterInMemoryAIBridgedHTTPHandler(srv http.Handler) {
+//
+// providerFromHost maps an upstream hostname to the configured aibridge
+// provider name so the in-memory transport can rewrite SDK-style paths
+// ("/v1/messages" against "api.anthropic.com") to bridge-style paths
+// ("/anthropic/v1/messages"). May be nil; the gated /api/v2/aibridge HTTP
+// route is unaffected either way.
+func (api *API) RegisterInMemoryAIBridgedHTTPHandler(srv http.Handler, providerFromHost func(host string) string) {
 	if srv == nil {
 		panic("aibridged cannot be nil")
 	}
 
 	api.aibridgedHandler = srv
 
-	factory := aibridged.NewTransportFactory(srv)
+	factory := aibridged.NewTransportFactory(srv, providerFromHost)
 	var asInterface agplaibridge.TransportFactory = factory
 	api.AIBridgeTransportFactory.Store(&asInterface)
 }

--- a/coderd/aibridged/transport.go
+++ b/coderd/aibridged/transport.go
@@ -3,6 +3,7 @@ package aibridged
 import (
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/google/uuid"
@@ -18,12 +19,22 @@ import (
 //
 // handler is typically the aibridged HTTP entrypoint registered via
 // [API.RegisterInMemoryAIBridgedHTTPHandler].
-func NewTransportFactory(handler http.Handler) aibridge.TransportFactory {
-	return &transportFactory{handler: handler}
+//
+// providerFromHost maps an upstream hostname (e.g. "api.anthropic.com") to the
+// aibridge provider name (e.g. "anthropic"). The roundtripper prepends
+// "/{providerName}" to the request path when a match is found, since the
+// aibridge mux dispatches on the provider-prefixed path
+// (e.g. "/anthropic/v1/messages") rather than the upstream-native path
+// ("/v1/messages") that SDK clients construct. May be nil; in that case the
+// path is passed through unchanged and callers are expected to set the
+// provider-prefixed path themselves.
+func NewTransportFactory(handler http.Handler, providerFromHost func(host string) string) aibridge.TransportFactory {
+	return &transportFactory{handler: handler, providerFromHost: providerFromHost}
 }
 
 type transportFactory struct {
-	handler http.Handler
+	handler          http.Handler
+	providerFromHost func(host string) string
 }
 
 // TransportFor returns an in-process [http.RoundTripper] for coder-agent
@@ -39,13 +50,14 @@ func (f *transportFactory) TransportFor(_ uuid.UUID, isCoderAgent bool) (http.Ro
 	if !isCoderAgent {
 		return nil, nil
 	}
-	return &inMemoryRoundTripper{handler: f.handler}, nil
+	return &inMemoryRoundTripper{handler: f.handler, providerFromHost: f.providerFromHost}, nil
 }
 
 // inMemoryRoundTripper implements [http.RoundTripper] by invoking handler
 // in a goroutine and streaming its response back through an [io.Pipe].
 type inMemoryRoundTripper struct {
-	handler http.Handler
+	handler          http.Handler
+	providerFromHost func(host string) string
 }
 
 func (t *inMemoryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -61,6 +73,30 @@ func (t *inMemoryRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 	// handler operate on its own request value without surprising the caller
 	// if it mutates Headers or stores the request.
 	served := req.Clone(req.Context())
+
+	// SDK clients (e.g. fantasy/anthropic) construct URLs against the
+	// upstream host ("https://api.anthropic.com/v1/messages") so the path
+	// arrives here as "/v1/messages". The aibridge mux dispatches on the
+	// provider-prefixed path ("/anthropic/v1/messages"), so we rewrite
+	// based on the request's Host. If providerFromHost is nil or the host
+	// is unknown, leave the path alone; the bridge will return 404 and
+	// surface the misconfiguration.
+	if t.providerFromHost != nil && served.URL != nil {
+		host := served.URL.Host
+		if host == "" {
+			host = served.Host
+		}
+		if name := t.providerFromHost(host); name != "" {
+			prefix := "/" + name
+			if !strings.HasPrefix(served.URL.Path, prefix+"/") && served.URL.Path != prefix {
+				served.URL.Path = prefix + served.URL.Path
+				// Force net/http to recompute the escaped path from
+				// the rewritten Path field on the next read.
+				served.URL.RawPath = ""
+				served.RequestURI = ""
+			}
+		}
+	}
 
 	go func() {
 		defer func() {

--- a/coderd/aibridged/transport_test.go
+++ b/coderd/aibridged/transport_test.go
@@ -23,7 +23,7 @@ func TestTransportFactory_TransportFor(t *testing.T) {
 
 	t.Run("CoderAgentReturnsTransport", func(t *testing.T) {
 		t.Parallel()
-		f := aibridged.NewTransportFactory(http.NotFoundHandler())
+		f := aibridged.NewTransportFactory(http.NotFoundHandler(), nil)
 		rt, err := f.TransportFor(uuid.New(), true)
 		require.NoError(t, err)
 		require.NotNil(t, rt)
@@ -31,7 +31,7 @@ func TestTransportFactory_TransportFor(t *testing.T) {
 
 	t.Run("NonCoderAgentFallsThrough", func(t *testing.T) {
 		t.Parallel()
-		f := aibridged.NewTransportFactory(http.NotFoundHandler())
+		f := aibridged.NewTransportFactory(http.NotFoundHandler(), nil)
 		rt, err := f.TransportFor(uuid.New(), false)
 		require.NoError(t, err)
 		require.Nil(t, rt)
@@ -39,7 +39,7 @@ func TestTransportFactory_TransportFor(t *testing.T) {
 
 	t.Run("NilHandlerErrors", func(t *testing.T) {
 		t.Parallel()
-		f := aibridged.NewTransportFactory(nil)
+		f := aibridged.NewTransportFactory(nil, nil)
 		_, err := f.TransportFor(uuid.New(), true)
 		require.Error(t, err)
 	})
@@ -55,7 +55,7 @@ func TestInMemoryRoundTripper_PassesHeadersAndStatus(t *testing.T) {
 		_, _ = w.Write([]byte(`{"ok":true}`))
 	})
 
-	rt, err := aibridged.NewTransportFactory(handler).TransportFor(uuid.New(), true)
+	rt, err := aibridged.NewTransportFactory(handler, nil).TransportFor(uuid.New(), true)
 	require.NoError(t, err)
 
 	ctx := testutil.Context(t, testutil.WaitShort)
@@ -100,7 +100,7 @@ func TestInMemoryRoundTripper_Streams(t *testing.T) {
 		}
 	})
 
-	rt, err := aibridged.NewTransportFactory(handler).TransportFor(uuid.New(), true)
+	rt, err := aibridged.NewTransportFactory(handler, nil).TransportFor(uuid.New(), true)
 	require.NoError(t, err)
 
 	ctx := testutil.Context(t, testutil.WaitShort)
@@ -139,7 +139,7 @@ func TestInMemoryRoundTripper_CancelCloses(t *testing.T) {
 		close(handlerCtxObserved)
 	})
 
-	rt, err := aibridged.NewTransportFactory(handler).TransportFor(uuid.New(), true)
+	rt, err := aibridged.NewTransportFactory(handler, nil).TransportFor(uuid.New(), true)
 	require.NoError(t, err)
 
 	parentCtx := testutil.Context(t, testutil.WaitShort)
@@ -173,7 +173,7 @@ func TestInMemoryRoundTripper_ConcurrentRequests(t *testing.T) {
 		_, _ = w.Write(body)
 	})
 
-	rt, err := aibridged.NewTransportFactory(handler).TransportFor(uuid.New(), true)
+	rt, err := aibridged.NewTransportFactory(handler, nil).TransportFor(uuid.New(), true)
 	require.NoError(t, err)
 
 	const n = 16
@@ -222,7 +222,7 @@ func TestInMemoryRoundTripper_HandlerReturnsWithoutWriting(t *testing.T) {
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
-	rt, err := aibridged.NewTransportFactory(handler).TransportFor(uuid.New(), true)
+	rt, err := aibridged.NewTransportFactory(handler, nil).TransportFor(uuid.New(), true)
 	require.NoError(t, err)
 
 	ctx := testutil.Context(t, testutil.WaitShort)

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -828,6 +828,13 @@ func New(options *Options) *API {
 			UsageTracker:                   options.WorkspaceUsageTracker,
 			PrometheusRegistry:             options.PrometheusRegistry,
 			OIDCTokenSource:                oidcMCPSrc,
+			AIBridgeTransportFactory: func() aibridge.TransportFactory {
+				p := api.AIBridgeTransportFactory.Load()
+				if p == nil {
+					return nil
+				}
+				return *p
+			},
 		}).Start()
 		gitSyncLogger := options.Logger.Named("gitsync")
 		refresher := gitsync.NewRefresher(

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/coderd/aibridge"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
@@ -232,6 +233,7 @@ type Server struct {
 	providerAPIKeys                chatprovider.ProviderAPIKeys
 	allowBYOK                      bool
 	oidcTokenSource                mcpclient.UserOIDCTokenSource
+	aibridgeTransportFactory       func() aibridge.TransportFactory
 	debugSvc                       *chatdebug.Service
 	debugSvcFactory                func() *chatdebug.Service
 	debugSvcReady                  atomic.Bool
@@ -4066,6 +4068,13 @@ type Config struct {
 	// May be nil if the deployment has no OIDC provider; servers
 	// using user_oidc will then send no Authorization header.
 	OIDCTokenSource mcpclient.UserOIDCTokenSource
+
+	// AIBridgeTransportFactory, when non-nil, is called per LLM request to
+	// look up an in-process aibridge transport. Returning nil makes chatd
+	// fall back to calling the upstream provider directly. The callback is
+	// re-evaluated each request so a factory registered by enterprise after
+	// chatd starts is picked up without a restart.
+	AIBridgeTransportFactory func() aibridge.TransportFactory
 }
 
 // New creates a new chat processor. The processor polls for pending
@@ -4132,6 +4141,7 @@ func New(cfg Config) *Server {
 		providerAPIKeys:                cfg.ProviderAPIKeys,
 		allowBYOK:                      allowBYOK,
 		oidcTokenSource:                cfg.OIDCTokenSource,
+		aibridgeTransportFactory:       cfg.AIBridgeTransportFactory,
 		debugSvcFactory: func() *chatdebug.Service {
 			debugSvc := chatdebug.NewService(
 				cfg.Database,

--- a/coderd/x/chatd/chatd_debug.go
+++ b/coderd/x/chatd/chatd_debug.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"charm.land/fantasy"
+	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
@@ -109,6 +110,33 @@ func (p *Server) scheduleDebugCleanup(
 	}()
 }
 
+// aibridgeRoundTripper asks the registered factory for an in-process aibridge
+// transport. Returns nil when no factory is registered (AGPL builds, or before
+// the enterprise wiring runs), when the factory itself returns nil (the carve-
+// out does not apply), or when the factory returns an error.
+//
+// chatd is treated as coder-agent traffic for the licensing carve-out, so we
+// pass isCoderAgent=true. providerID is uuid.Nil for now; chatd does not yet
+// resolve the ai_providers row that backs a given chat config, and the current
+// factory implementation does not branch on it.
+func (p *Server) aibridgeRoundTripper() http.RoundTripper {
+	if p.aibridgeTransportFactory == nil {
+		return nil
+	}
+	factory := p.aibridgeTransportFactory()
+	if factory == nil {
+		return nil
+	}
+	rt, err := factory.TransportFor(uuid.Nil, true)
+	if err != nil {
+		p.logger.Warn(p.ctx, "aibridge transport factory returned error, falling back to direct upstream",
+			slog.Error(err),
+		)
+		return nil
+	}
+	return rt
+}
+
 func (p *Server) newDebugAwareModelFromConfig(
 	ctx context.Context,
 	chat database.Chat,
@@ -127,8 +155,18 @@ func (p *Server) newDebugAwareModelFromConfig(
 	debugEnabled := debugSvc != nil && debugSvc.IsEnabled(ctx, chat.ID, chat.OwnerID)
 
 	var httpClient *http.Client
-	if debugEnabled {
+	switch {
+	case debugEnabled:
 		httpClient = &http.Client{Transport: &chatdebug.RecordingTransport{}}
+	default:
+		if rt := p.aibridgeRoundTripper(); rt != nil {
+			httpClient = &http.Client{Transport: rt}
+			p.logger.Debug(ctx, "routing chat through in-process aibridge transport",
+				slog.F("chat_id", chat.ID),
+				slog.F("provider", provider),
+				slog.F("model", resolvedModel),
+			)
+		}
 	}
 
 	model, err := chatprovider.ModelFromConfig(

--- a/enterprise/coderd/aibridge_test.go
+++ b/enterprise/coderd/aibridge_test.go
@@ -1844,7 +1844,7 @@ func TestAIBridgeRouting(t *testing.T) {
 		rw.WriteHeader(http.StatusOK)
 		_, _ = rw.Write([]byte(r.URL.Path))
 	})
-	api.AGPL.RegisterInMemoryAIBridgedHTTPHandler(testHandler)
+	api.AGPL.RegisterInMemoryAIBridgedHTTPHandler(testHandler, nil)
 
 	cases := []struct {
 		name         string
@@ -1907,7 +1907,7 @@ func TestAIBridgeRateLimiting(t *testing.T) {
 	testHandler := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		rw.WriteHeader(http.StatusOK)
 	})
-	api.AGPL.RegisterInMemoryAIBridgedHTTPHandler(testHandler)
+	api.AGPL.RegisterInMemoryAIBridgedHTTPHandler(testHandler, nil)
 
 	ctx := testutil.Context(t, testutil.WaitLong)
 	httpClient := &http.Client{}
@@ -1967,7 +1967,7 @@ func TestAIBridgeConcurrencyLimiting(t *testing.T) {
 		<-unblock
 		rw.WriteHeader(http.StatusOK)
 	})
-	api.AGPL.RegisterInMemoryAIBridgedHTTPHandler(testHandler)
+	api.AGPL.RegisterInMemoryAIBridgedHTTPHandler(testHandler, nil)
 
 	ctx := testutil.Context(t, testutil.WaitLong)
 	httpClient := &http.Client{}
@@ -2583,7 +2583,7 @@ func TestAIBridgeAllowBYOK(t *testing.T) {
 			testHandler := http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 				rw.WriteHeader(http.StatusOK)
 			})
-			api.AGPL.RegisterInMemoryAIBridgedHTTPHandler(testHandler)
+			api.AGPL.RegisterInMemoryAIBridgedHTTPHandler(testHandler, nil)
 
 			ctx := testutil.Context(t, testutil.WaitLong)
 			reqURL := client.URL.String() + "/api/v2/aibridge/test"


### PR DESCRIPTION
This is not a real PR intended to be merged; it's merely a validation that Agents + OSS can target AI Gateway while the HTTP API cannot be accessed directly without a license.