### PR TITLE
fix(coderd/x/chatd): gate default branch agent pushes

### DIFF
--- a/coderd/x/chatd/instruction_test.go
+++ b/coderd/x/chatd/instruction_test.go
@@ -116,6 +116,25 @@ func TestRenderPlanPathPrompt(t *testing.T) {
 	})
 }
 
+func TestDefaultSystemPromptContainsVersionControlSafety(t *testing.T) {
+	t.Parallel()
+
+	require.Contains(t, DefaultSystemPrompt, "<version-control-safety>")
+	require.Contains(t, DefaultSystemPrompt, "</version-control-safety>")
+	require.Contains(t, DefaultSystemPrompt, "check the current branch and push target")
+	require.Contains(t, DefaultSystemPrompt, "Do not commit directly to default or protected branches")
+	require.Contains(t, DefaultSystemPrompt, "including main, master, trunk")
+	require.Contains(t, DefaultSystemPrompt, "unless the user explicitly confirms after you identify the exact branch")
+	require.Contains(t, DefaultSystemPrompt, "Do not push when the target would update a default or protected branch unless the user explicitly confirms")
+	require.Contains(t, DefaultSystemPrompt, "Before asking for confirmation, warn that the push bypasses")
+	require.Contains(t, DefaultSystemPrompt, "state the exact remote ref that would be updated")
+	require.Contains(t, DefaultSystemPrompt, "Confirmation must be separate and must name the exact protected branch")
+	require.Contains(t, DefaultSystemPrompt, "Do not run plain git push while checked out on a default or protected branch")
+	require.Contains(t, DefaultSystemPrompt, "use an explicit refspec")
+	require.Contains(t, DefaultSystemPrompt, "create and switch to a feature branch first")
+	require.Contains(t, DefaultSystemPrompt, "Never treat the original request as confirmation")
+}
+
 func TestInsertSystemInstructionAfterSystemMessages(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/x/chatd/prompt.go
+++ b/coderd/x/chatd/prompt.go
@@ -24,6 +24,15 @@ Ask concise clarifying questions only when:
 If a task is too ambiguous to implement with confidence, ask for clarification before proceeding.
 </behavior>
 
+<version-control-safety>
+Before committing or pushing in a Git repository, check the current branch and push target.
+Do not commit directly to default or protected branches, including main, master, trunk, or the repository's remote default branch, unless the user explicitly confirms after you identify the exact branch.
+Do not push when the target would update a default or protected branch unless the user explicitly confirms. Before asking for confirmation, warn that the push bypasses the normal feature branch or pull request workflow and state the exact remote ref that would be updated.
+Do not run plain git push while checked out on a default or protected branch. When pushing after explicit confirmation, use an explicit refspec.
+If the user asks you to commit or push from a default or protected branch without that confirmation, create and switch to a feature branch first. If a branch name is not obvious, choose a concise descriptive branch name that follows the repository's conventions, or ask when the choice is material.
+Never treat the original request as confirmation. Confirmation must be separate and must name the exact protected branch or accept the exact branch you named.
+</version-control-safety>
+
 <personality>
 Analytical — You break problems into measurable steps, relying on tool output and data rather than intuition.
 Organized — You structure every interaction with clear tags, TODO lists, and section boundaries.


### PR DESCRIPTION
> Mux is opening this PR on behalf of Mike.

Agents could interpret a generic "commit and push" request on `main` as permission to commit on the current branch and push its upstream.

Add version-control safety guidance to the default agent system prompt so agents check the current branch and push target, avoid default or protected branch commits and pushes unless the user explicitly confirms after a warning, avoid plain git push from those branches, and create a feature branch first when no explicit confirmation is present.
