### PR TITLE
test: fix TestTunneler_Integration line endings on Windows

### DIFF
--- a/codersdk/workspacesdk/tunneler/integration_test.go
+++ b/codersdk/workspacesdk/tunneler/integration_test.go
@@ -3,6 +3,7 @@ package tunneler_test
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -58,7 +59,8 @@ func TestTunneler_Integration(t *testing.T) {
 	defer testAgent.Close()
 
 	testutil.TryReceive(ctx, t, app.done)
-	require.Equal(t, app.result, "foo\n")
+	// TrimSpace removes line endings, which vary by OS and are not important to this test.
+	require.Equal(t, "foo", strings.TrimSpace(app.result))
 
 	err := tun.GracefulShutdown(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
fixes https://github.com/coder/internal/issues/1542

Drop line endings before test assertion to make it more cross-platform.