### PR TITLE
fix(site/src/pages/AgentsPage/components/ChatConversation): stabilize streaming thinking placeholder row

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatConversation/ChatStatusCallout.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ChatStatusCallout.tsx
@@ -40,6 +40,10 @@ const StatusPlaceholder: FC<{
 	);
 };
 
+export const ThinkingStatusPlaceholder: FC = () => (
+	<StatusPlaceholder text={THINKING_TEXT} shimmer />
+);
+
 const StartingPlaceholder: FC = () => {
 	const [isDelayed, setIsDelayed] = useState(false);
 
@@ -50,11 +54,10 @@ const StartingPlaceholder: FC = () => {
 		return () => window.clearTimeout(timeout);
 	}, []);
 
-	return (
-		<StatusPlaceholder
-			text={isDelayed ? DELAYED_STARTUP_TEXT : THINKING_TEXT}
-			shimmer={!isDelayed}
-		/>
+	return isDelayed ? (
+		<StatusPlaceholder text={DELAYED_STARTUP_TEXT} />
+	) : (
+		<ThinkingStatusPlaceholder />
 	);
 };
 
@@ -202,14 +205,14 @@ export const ChatStatusCallout: FC<{
 			return (
 				<>
 					<StatusAlert status={status} />
-					<StatusPlaceholder text={THINKING_TEXT} shimmer />
+					<ThinkingStatusPlaceholder />
 				</>
 			);
 		case "reconnecting":
 			return (
 				<>
 					<ReconnectingAlert status={status} />
-					<StatusPlaceholder text={THINKING_TEXT} shimmer />
+					<ThinkingStatusPlaceholder />
 				</>
 			);
 		case "failed":

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.stories.tsx
@@ -33,6 +33,21 @@ const meta: Meta<typeof StreamingOutput> = {
 export default meta;
 type Story = StoryObj<typeof StreamingOutput>;
 
+const toolOnlyStreamState = buildStreamRenderState([
+	{
+		type: "tool-call",
+		tool_name: "execute",
+		tool_call_id: "tc-1",
+		args: { command: "ls -la" },
+	},
+	{
+		type: "tool-call",
+		tool_name: "read_file",
+		tool_call_id: "tc-2",
+		args: { path: "README.md" },
+	},
+]);
+
 /** Default shimmer placeholder with no stream state. */
 export const ThinkingPlaceholder: Story = {
 	args: {
@@ -261,25 +276,12 @@ export const RetryStartupTimeout: Story = {
  */
 export const ThinkingDuringStreamingWithToolCalls: Story = {
 	args: {
-		...buildStreamRenderState([
-			{
-				type: "tool-call",
-				tool_name: "execute",
-				tool_call_id: "tc-1",
-				args: { command: "ls -la" },
-			},
-			{
-				type: "tool-call",
-				tool_name: "read_file",
-				tool_call_id: "tc-2",
-				args: { path: "README.md" },
-			},
-		]),
+		...toolOnlyStreamState,
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		// Tool-only stream chunks can otherwise clear the activity indicator before text arrives.
-		expect(canvas.getAllByText("Thinking").length).toBeGreaterThanOrEqual(1);
+		expect(canvas.getAllByText(/Thinking/).length).toBeGreaterThanOrEqual(1);
 
 		const toolCallWrappers = Array.from(
 			canvasElement.querySelectorAll("[data-transcript-row]"),
@@ -290,7 +292,7 @@ export const ThinkingDuringStreamingWithToolCalls: Story = {
 		const previousToolWrapper = toolCallWrappers.at(-2);
 		expect(thinkingWrapper).toBeInstanceOf(HTMLElement);
 		expect(previousToolWrapper).toBeInstanceOf(HTMLElement);
-		expect(thinkingWrapper).toHaveTextContent("Thinking");
+		expect(thinkingWrapper).toHaveTextContent(/Thinking/);
 
 		const gap = Math.round(
 			(thinkingWrapper as HTMLElement).getBoundingClientRect().top -

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -1,15 +1,12 @@
 import type { FC } from "react";
 import type { UrlTransform } from "streamdown";
 import type * as TypesGen from "#/api/typesGenerated";
-import {
-	ConversationItem,
-	Message,
-	MessageContent,
-	Shimmer,
-} from "../ChatElements";
-import { TranscriptRow } from "../ChatElements/TranscriptRow";
+import { ConversationItem, Message, MessageContent } from "../ChatElements";
 import type { SubagentVariant } from "../ChatElements/tools/subagentDescriptor";
-import { ChatStatusCallout } from "./ChatStatusCallout";
+import {
+	ChatStatusCallout,
+	ThinkingStatusPlaceholder,
+} from "./ChatStatusCallout";
 import { BlockList } from "./ConversationTimeline";
 import type { LiveStatusModel } from "./liveStatusModel";
 import type { MergedTool, RenderBlock, StreamState } from "./types";
@@ -27,21 +24,6 @@ const hasTransientLiveStatus = (liveStatus: LiveStatusModel): boolean =>
  */
 const hasTextOrReasoningBlock = (blocks: readonly RenderBlock[]): boolean =>
 	blocks.some((b) => b.type === "response" || b.type === "thinking");
-
-/**
- * Placeholder shown during streaming before text or reasoning
- * blocks arrive. Uses the same shimmer animation and typography
- * as the ChatStatusCallout status placeholder.
- */
-const StreamingThinkingPlaceholder: FC = () => (
-	<div data-transcript-row="" className="text-content-secondary">
-		<TranscriptRow className="w-full gap-2">
-			<Shimmer as="span" className="text-[13px] leading-relaxed">
-				Thinking
-			</Shimmer>
-		</TranscriptRow>
-	</div>
-);
 
 export const StreamingOutput: FC<{
 	streamState: StreamState | null;
@@ -109,7 +91,11 @@ export const StreamingOutput: FC<{
 								mcpServers={mcpServers}
 							/>
 						)}
-						{needsStreamingThinking && <StreamingThinkingPlaceholder />}
+						{needsStreamingThinking && (
+							<div data-transcript-row="">
+								<ThinkingStatusPlaceholder />
+							</div>
+						)}
 						{!needsStreamingThinking && hasTransientLiveStatus(liveStatus) && (
 							<ChatStatusCallout
 								status={liveStatus}


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

Previously, the startup and retry "Thinking..." placeholder used a different row implementation than the tool-only streaming state, so the label shifted inside the reserved transcript row when streaming advanced.

This reuses the same thinking placeholder component for both states while keeping the transcript row wrapper unchanged, so the inner label stays visually stable as the stream moves from startup to tool calls.
