### PR TITLE
docs: document chat sharing

### DIFF
--- a/docs/ai-coder/agents/chat-sharing.md
+++ b/docs/ai-coder/agents/chat-sharing.md
@@ -1,0 +1,26 @@
+# Chat Sharing
+
+Chat sharing lets you give other users or groups read-only access to a Coder Agents conversation.
+
+## Share a chat
+
+1. Open the root chat you want to share on the **Agents** page.
+1. Click the share icon in the chat top bar.
+1. Click the **Search for user or group** field.
+1. Search for and select a user or group.
+1. Click **Add member** to grant **Read** access.
+1. Copy the chat URL from your browser and send it to the users or groups you shared with.
+
+Coder does not create a separate share link or notify recipients. Shared users and groups must open the chat from the URL you send them.
+
+Sub-agent child chats inherit sharing from the root chat and cannot be shared separately.
+
+## Shared chat access
+
+Shared users can open the chat from a direct link, view messages, stream live updates, and download chat attachments.
+
+Shared chats do not appear in the recipient's normal chat list. Read-only users cannot continue the chat, edit messages, archive it, regenerate its title, or change sharing.
+
+## Disable chat sharing
+
+Administrators can disable chat sharing for a deployment with `--disable-chat-sharing`, `CODER_DISABLE_CHAT_SHARING`, or `disableChatSharing`. When disabled, only chat owners can access their chats.

--- a/docs/ai-coder/agents/chat-sharing.md
+++ b/docs/ai-coder/agents/chat-sharing.md
@@ -4,22 +4,20 @@ Chat sharing lets you give other users or groups read-only access to a Coder Age
 
 ## Share a chat
 
-1. Open the root chat you want to share on the **Agents** page.
+1. Open the chat you want to share on the **Agents** page. Only top-level chats can be shared; sub-agent chats inherit sharing from their parent.
 1. Click the share icon in the chat top bar.
 1. Click the **Search for user or group** field.
 1. Search for and select a user or group.
 1. Click **Add member** to grant **Read** access.
-1. Copy the chat URL from your browser and send it to the users or groups you shared with.
+1. Copy the chat URL from your browser and send it to the recipients.
 
-Coder does not create a separate share link or notify recipients. Shared users and groups must open the chat from the URL you send them.
-
-Sub-agent child chats inherit sharing from the root chat and cannot be shared separately.
+Coder does not create a separate share link or notify recipients. They must open the chat from the URL you send them.
 
 ## Shared chat access
 
-Shared users can open the chat from a direct link, view messages, stream live updates, and download chat attachments.
+Viewers can open the chat from a direct link, view messages, stream live updates, and download chat attachments. They reach sub-agent chats by following sub-agent links inside the parent chat or by opening a direct URL.
 
-Shared chats do not appear in the recipient's normal chat list. Read-only users cannot continue the chat, edit messages, archive it, regenerate its title, or change sharing.
+Shared chats do not appear in the viewer's normal chat list. Viewers have read-only access: they cannot send or edit messages, regenerate the chat title, archive the chat, or change its sharing settings.
 
 ## Disable chat sharing
 

--- a/docs/ai-coder/agents/index.md
+++ b/docs/ai-coder/agents/index.md
@@ -125,6 +125,21 @@ are queued and delivered when the agent completes its current step, so there is
 no need to wait for a response before providing additional context or changing
 direction.
 
+### Chat sharing
+
+Users with chat share permission can share root chats with other users or
+groups from the chat top bar. Click **Share chat**, add a user or group, and
+Coder grants **Read** access to that conversation.
+
+Shared users can open the chat from a direct link, view messages, stream live
+updates, and download chat attachments. Shared chats do not appear in the
+recipient's normal chat list. Read-only users cannot continue the chat,
+edit messages, archive it, regenerate its title, or change sharing. Sub-agent
+child chats inherit sharing from the root chat and are not shared separately.
+
+Administrators can disable chat sharing with `--disable-chat-sharing`,
+`CODER_DISABLE_CHAT_SHARING`, or `disableChatSharing`.
+
 ### Image attachments
 
 Users can attach images to chat messages by pasting from the clipboard, dragging

--- a/docs/ai-coder/agents/index.md
+++ b/docs/ai-coder/agents/index.md
@@ -125,21 +125,6 @@ are queued and delivered when the agent completes its current step, so there is
 no need to wait for a response before providing additional context or changing
 direction.
 
-### Chat sharing
-
-Users with chat share permission can share root chats with other users or
-groups from the chat top bar. Click **Share chat**, add a user or group, and
-Coder grants **Read** access to that conversation.
-
-Shared users can open the chat from a direct link, view messages, stream live
-updates, and download chat attachments. Shared chats do not appear in the
-recipient's normal chat list. Read-only users cannot continue the chat,
-edit messages, archive it, regenerate its title, or change sharing. Sub-agent
-child chats inherit sharing from the root chat and are not shared separately.
-
-Administrators can disable chat sharing with `--disable-chat-sharing`,
-`CODER_DISABLE_CHAT_SHARING`, or `disableChatSharing`.
-
 ### Image attachments
 
 Users can attach images to chat messages by pasting from the clipboard, dragging

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1002,6 +1002,12 @@
 							"state": ["beta"]
 						},
 						{
+							"title": "Chat Sharing",
+							"description": "Share Coder Agents conversations with users and groups",
+							"path": "./ai-coder/agents/chat-sharing.md",
+							"state": ["beta"]
+						},
+						{
 							"title": "Models",
 							"description": "Configure LLM providers and models for Coder Agents",
 							"path": "./ai-coder/agents/models.md",


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

Adds a dedicated Coder Agents Chat Sharing page instead of putting this detail in the overview.

The page covers sharing root chats with users or groups, read-only access behavior, direct-link access, inherited sub-agent chat sharing, and the deployment options for disabling chat sharing.
