### PR TITLE
fix(coderd/x/chatd/chatsanitize): sanitize web_search history for non-Anthropic providers

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -7327,6 +7327,10 @@ func (p *Server) runChat(
 	chatsanitize.LogAnthropicProviderToolSanitization(
 		ctx, logger, "persisted_history_replay", model.Provider(), model.Model(), sanitizeStats,
 	)
+	prompt, unsupportedStats := chatsanitize.SanitizeUnsupportedProviderToolHistory(model.Provider(), prompt)
+	chatsanitize.LogUnsupportedProviderToolSanitization(
+		ctx, logger, "persisted_history_replay", model.Provider(), model.Model(), unsupportedStats,
+	)
 	subagentInstruction := ""
 	if !isRootChat {
 		subagentInstruction = defaultSubagentInstruction
@@ -8047,6 +8051,10 @@ func (p *Server) runChat(
 			reloadedPrompt, sanitizeStats := chatsanitize.SanitizeAnthropicProviderToolHistory(model.Provider(), reloadedPrompt)
 			chatsanitize.LogAnthropicProviderToolSanitization(
 				reloadCtx, logger, "reload_messages", model.Provider(), model.Model(), sanitizeStats,
+			)
+			reloadedPrompt, unsupportedStats := chatsanitize.SanitizeUnsupportedProviderToolHistory(model.Provider(), reloadedPrompt)
+			chatsanitize.LogUnsupportedProviderToolSanitization(
+				reloadCtx, logger, "reload_messages", model.Provider(), model.Model(), unsupportedStats,
 			)
 			// Re-derive instruction and skills from the reloaded
 			// messages so that any context added during the

--- a/coderd/x/chatd/chatloop/chatloop.go
+++ b/coderd/x/chatd/chatloop/chatloop.go
@@ -760,6 +760,12 @@ func prepareMessagesForRequest(
 		slog.F("step_index", step),
 		slog.F("total_steps", totalSteps),
 	)
+	prompt, unsupportedStats := chatsanitize.SanitizeUnsupportedProviderToolHistory(provider, prompt)
+	chatsanitize.LogUnsupportedProviderToolSanitization(
+		ctx, opts.Logger, "pre_request", provider, modelName, unsupportedStats,
+		slog.F("step_index", step),
+		slog.F("total_steps", totalSteps),
+	)
 	prompt, err = chatsanitize.ApplyAnthropicProviderToolGuard(
 		ctx, opts.Logger, provider, modelName, prompt,
 	)

--- a/coderd/x/chatd/chatsanitize/anthropic.go
+++ b/coderd/x/chatd/chatsanitize/anthropic.go
@@ -304,6 +304,93 @@ func SanitizeAnthropicProviderToolHistory(
 	}
 }
 
+// SanitizeUnsupportedProviderToolHistory removes Anthropic provider-
+// executed tool blocks (e.g. web_search) when sending to a provider that
+// does not recognize them. Tool calls are dropped and tool results are
+// preserved as plain text so the model can still see the payload.
+//
+// Bedrock shares the Anthropic message format but rejects
+// web_search_tool_result blocks with HTTP 400. This lets a chat switch
+// from Anthropic to Bedrock mid-conversation without leaking unsupported
+// provider-executed tool blocks into the next request.
+func SanitizeUnsupportedProviderToolHistory(
+	provider string,
+	messages []fantasy.Message,
+) ([]fantasy.Message, AnthropicProviderToolSanitizationStats) {
+	var stats AnthropicProviderToolSanitizationStats
+	if provider == "" || provider == fantasyanthropic.Name || len(messages) == 0 {
+		return messages, stats
+	}
+
+	affected := providerExecutedToolMessageIndexes(messages)
+	if len(affected) == 0 {
+		return messages, stats
+	}
+
+	out := make([]fantasy.Message, 0, len(messages))
+	for messageIndex, message := range messages {
+		if _, ok := affected[messageIndex]; !ok {
+			out = appendSanitizedMessage(out, message)
+			continue
+		}
+		parts := make([]fantasy.MessagePart, 0, len(message.Content))
+		removed := 0
+		for _, part := range message.Content {
+			if toolCall, ok := safeMessageToolCallPart(part); ok && toolCall.ProviderExecuted {
+				stats.RemovedToolCalls++
+				removed++
+				continue
+			}
+			if toolResult, ok := safeMessageToolResultPart(part); ok && toolResult.ProviderExecuted {
+				stats.RemovedToolResults++
+				if textPart, ok := AnthropicProviderToolResultTextPart(part); ok {
+					parts = append(parts, textPart)
+				}
+				removed++
+				continue
+			}
+			parts = append(parts, part)
+		}
+		if removed > 0 && len(parts) == 0 {
+			stats.DroppedMessages++
+			continue
+		}
+		if removed > 0 {
+			message.Content = parts
+		}
+		out = appendSanitizedMessage(out, message)
+	}
+	return out, stats
+}
+
+// LogUnsupportedProviderToolSanitization logs prompt changes made while
+// removing provider-executed tool blocks unsupported by the target
+// provider.
+func LogUnsupportedProviderToolSanitization(
+	ctx context.Context,
+	logger slog.Logger,
+	phase string,
+	provider string,
+	modelName string,
+	stats AnthropicProviderToolSanitizationStats,
+	extra ...slog.Field,
+) {
+	if stats.RemovedToolCalls == 0 && stats.RemovedToolResults == 0 {
+		return
+	}
+	fields := []slog.Field{
+		slog.F("phase", phase),
+		slog.F("tool_type", "provider_executed_unsupported"),
+		slog.F("provider", provider),
+		slog.F("model", modelName),
+		slog.F("removed_tool_calls", stats.RemovedToolCalls),
+		slog.F("removed_tool_results", stats.RemovedToolResults),
+		slog.F("dropped_messages", stats.DroppedMessages),
+	}
+	fields = append(fields, extra...)
+	logger.Warn(ctx, "removed provider-executed tool history unsupported by target provider", fields...)
+}
+
 // SanitizeAnthropicProviderToolStepContent removes invalid Anthropic
 // provider-executed tool content from a streamed step and logs removals.
 func SanitizeAnthropicProviderToolStepContent(

--- a/coderd/x/chatd/chatsanitize/unsupported_provider_test.go
+++ b/coderd/x/chatd/chatsanitize/unsupported_provider_test.go
@@ -1,0 +1,152 @@
+package chatsanitize_test
+
+import (
+	"testing"
+
+	"charm.land/fantasy"
+	fantasyanthropic "charm.land/fantasy/providers/anthropic"
+	fantasybedrock "charm.land/fantasy/providers/bedrock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/x/chatd/chatsanitize"
+)
+
+func TestSanitizeUnsupportedProviderToolHistory(t *testing.T) {
+	t.Parallel()
+
+	providerCall := fantasy.ToolCallPart{
+		ToolCallID:       "srvtoolu_ws",
+		ToolName:         "web_search",
+		Input:            `{"query":"coder"}`,
+		ProviderExecuted: true,
+	}
+	providerResult := fantasy.ToolResultPart{
+		ToolCallID:       "srvtoolu_ws",
+		Output:           fantasy.ToolResultOutputContentText{Text: `{"ok":true}`},
+		ProviderExecuted: true,
+		ProviderOptions:  validWebSearchProviderOptionsForTest(),
+	}
+	resultText := fantasy.TextPart{Text: `{"ok":true}`}
+	textPart := fantasy.TextPart{Text: "Here is a summary."}
+	userMessage := fantasy.Message{
+		Role:    fantasy.MessageRoleUser,
+		Content: []fantasy.MessagePart{fantasy.TextPart{Text: "search"}},
+	}
+
+	testCases := []struct {
+		name               string
+		provider           string
+		messages           []fantasy.Message
+		want               []fantasy.Message
+		wantRemovedCalls   int
+		wantRemovedResults int
+		wantDropped        int
+	}{
+		{
+			name:     "anthropic is left alone",
+			provider: fantasyanthropic.Name,
+			messages: []fantasy.Message{
+				userMessage,
+				{
+					Role:    fantasy.MessageRoleAssistant,
+					Content: []fantasy.MessagePart{providerCall, providerResult, textPart},
+				},
+			},
+			want: []fantasy.Message{
+				userMessage,
+				{
+					Role:    fantasy.MessageRoleAssistant,
+					Content: []fantasy.MessagePart{providerCall, providerResult, textPart},
+				},
+			},
+		},
+		{
+			name:     "bedrock strips call and textifies result",
+			provider: fantasybedrock.Name,
+			messages: []fantasy.Message{
+				userMessage,
+				{
+					Role:    fantasy.MessageRoleAssistant,
+					Content: []fantasy.MessagePart{providerCall, providerResult, textPart},
+				},
+			},
+			want: []fantasy.Message{
+				userMessage,
+				{
+					Role:    fantasy.MessageRoleAssistant,
+					Content: []fantasy.MessagePart{resultText, textPart},
+				},
+			},
+			wantRemovedCalls:   1,
+			wantRemovedResults: 1,
+		},
+		{
+			name:     "bedrock drops assistant message containing only provider tool blocks",
+			provider: fantasybedrock.Name,
+			messages: []fantasy.Message{
+				userMessage,
+				{
+					Role:    fantasy.MessageRoleAssistant,
+					Content: []fantasy.MessagePart{providerCall},
+				},
+				userMessage,
+			},
+			want: []fantasy.Message{
+				userMessage,
+				userMessage,
+			},
+			wantRemovedCalls: 1,
+			wantDropped:      1,
+		},
+		{
+			name:     "bedrock leaves messages with no provider blocks untouched",
+			provider: fantasybedrock.Name,
+			messages: []fantasy.Message{
+				userMessage,
+				{
+					Role:    fantasy.MessageRoleAssistant,
+					Content: []fantasy.MessagePart{textPart},
+				},
+			},
+			want: []fantasy.Message{
+				userMessage,
+				{
+					Role:    fantasy.MessageRoleAssistant,
+					Content: []fantasy.MessagePart{textPart},
+				},
+			},
+		},
+		{
+			name:     "empty provider is a no-op",
+			provider: "",
+			messages: []fantasy.Message{
+				userMessage,
+				{
+					Role:    fantasy.MessageRoleAssistant,
+					Content: []fantasy.MessagePart{providerCall, providerResult},
+				},
+			},
+			want: []fantasy.Message{
+				userMessage,
+				{
+					Role:    fantasy.MessageRoleAssistant,
+					Content: []fantasy.MessagePart{providerCall, providerResult},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, stats := chatsanitize.SanitizeUnsupportedProviderToolHistory(tc.provider, tc.messages)
+			require.Equal(t, tc.want, got)
+			require.Equal(t, chatsanitize.AnthropicProviderToolSanitizationStats{
+				RemovedToolCalls:   tc.wantRemovedCalls,
+				RemovedToolResults: tc.wantRemovedResults,
+				DroppedMessages:    tc.wantDropped,
+			}, stats)
+		})
+	}
+}


### PR DESCRIPTION
Switching providers mid-chat from Anthropic to Bedrock currently fails because Bedrock shares the Anthropic message format but rejects `web_search_tool_result` blocks with HTTP 400.

Add `SanitizeUnsupportedProviderToolHistory` which strips Anthropic provider-executed tool calls and converts their results to plain text whenever the target provider is not Anthropic. Wired in alongside the existing Anthropic sanitization in the chatloop pre-request path and in chatd's persisted/reloaded history replay paths.
