### PR TITLE
fix(coderd): fix flaky TestSendMessageWithModelOverrideUpdatesLastModelConfigID

### DIFF
--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -6391,9 +6391,14 @@ func TestSendMessageWithModelOverrideUpdatesLastModelConfigID(t *testing.T) {
 		AfterID: 0,
 	})
 	require.NoError(t, err)
-	require.Len(t, messages, 1)
-	require.True(t, messages[0].ModelConfigID.Valid)
-	require.Equal(t, modelConfigB.ID, messages[0].ModelConfigID.UUID)
+	// The chat daemon may have inserted an assistant response, so find
+	// the user message rather than asserting an exact count.
+	userMsgIdx := slices.IndexFunc(messages, func(m database.ChatMessage) bool {
+		return m.Role == database.ChatMessageRoleUser
+	})
+	require.NotEqual(t, -1, userMsgIdx, "expected to find a user message")
+	require.True(t, messages[userMsgIdx].ModelConfigID.Valid)
+	require.Equal(t, modelConfigB.ID, messages[userMsgIdx].ModelConfigID.UUID)
 }
 
 func TestSendMessageQueuesEffectiveModelConfigID(t *testing.T) {
@@ -6532,9 +6537,14 @@ func TestSubsequentSendWithoutOverrideUsesPersistedModel(t *testing.T) {
 		AfterID: 0,
 	})
 	require.NoError(t, err)
-	require.Len(t, messages, 1)
-	require.True(t, messages[0].ModelConfigID.Valid)
-	require.Equal(t, modelConfigB.ID, messages[0].ModelConfigID.UUID)
+	// The chat daemon may have inserted an assistant response, so find
+	// the user message rather than asserting an exact count.
+	userMsgIdx := slices.IndexFunc(messages, func(m database.ChatMessage) bool {
+		return m.Role == database.ChatMessageRoleUser
+	})
+	require.NotEqual(t, -1, userMsgIdx, "expected to find a user message")
+	require.True(t, messages[userMsgIdx].ModelConfigID.Valid)
+	require.Equal(t, modelConfigB.ID, messages[userMsgIdx].ModelConfigID.UUID)
 }
 
 func TestWatchChatsStatusChangeCarriesUpdatedLastModelConfigID(t *testing.T) {

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -128,6 +128,17 @@ func newChatClientWithAPIAndDatabase(t testing.TB, overrides ...func(*coderdtest
 	return codersdk.NewExperimentalClient(client), api.Database, api
 }
 
+// findUserMessage returns the first user-role message from a slice of chat
+// messages, failing the test if none is found.
+func findUserMessage(t testing.TB, messages []database.ChatMessage) database.ChatMessage {
+	t.Helper()
+	idx := slices.IndexFunc(messages, func(m database.ChatMessage) bool {
+		return m.Role == database.ChatMessageRoleUser
+	})
+	require.NotEqual(t, -1, idx, "expected to find a user message")
+	return messages[idx]
+}
+
 type failNextChatSystemPromptStore struct {
 	database.Store
 
@@ -6391,14 +6402,10 @@ func TestSendMessageWithModelOverrideUpdatesLastModelConfigID(t *testing.T) {
 		AfterID: 0,
 	})
 	require.NoError(t, err)
-	// The chat daemon may have inserted an assistant response, so find
-	// the user message rather than asserting an exact count.
-	userMsgIdx := slices.IndexFunc(messages, func(m database.ChatMessage) bool {
-		return m.Role == database.ChatMessageRoleUser
-	})
-	require.NotEqual(t, -1, userMsgIdx, "expected to find a user message")
-	require.True(t, messages[userMsgIdx].ModelConfigID.Valid)
-	require.Equal(t, modelConfigB.ID, messages[userMsgIdx].ModelConfigID.UUID)
+	// The chat daemon may insert an assistant response before this runs.
+	userMsg := findUserMessage(t, messages)
+	require.True(t, userMsg.ModelConfigID.Valid)
+	require.Equal(t, modelConfigB.ID, userMsg.ModelConfigID.UUID)
 }
 
 func TestSendMessageQueuesEffectiveModelConfigID(t *testing.T) {
@@ -6537,14 +6544,10 @@ func TestSubsequentSendWithoutOverrideUsesPersistedModel(t *testing.T) {
 		AfterID: 0,
 	})
 	require.NoError(t, err)
-	// The chat daemon may have inserted an assistant response, so find
-	// the user message rather than asserting an exact count.
-	userMsgIdx := slices.IndexFunc(messages, func(m database.ChatMessage) bool {
-		return m.Role == database.ChatMessageRoleUser
-	})
-	require.NotEqual(t, -1, userMsgIdx, "expected to find a user message")
-	require.True(t, messages[userMsgIdx].ModelConfigID.Valid)
-	require.Equal(t, modelConfigB.ID, messages[userMsgIdx].ModelConfigID.UUID)
+	// The chat daemon may insert an assistant response before this runs.
+	userMsg := findUserMessage(t, messages)
+	require.True(t, userMsg.ModelConfigID.Valid)
+	require.Equal(t, modelConfigB.ID, userMsg.ModelConfigID.UUID)
 }
 
 func TestWatchChatsStatusChangeCarriesUpdatedLastModelConfigID(t *testing.T) {


### PR DESCRIPTION
Fixes the flake in `TestSendMessageWithModelOverrideUpdatesLastModelConfigID` (and the same pattern in `TestSubsequentSendWithoutOverrideUsesPersistedModel`).

## Root Cause

Both tests assert `require.Len(t, messages, 1)` immediately after a direct-send `CreateChatMessage`. The background chat daemon can process the message and insert an assistant response before the assertion runs, resulting in 2 messages instead of 1.

## Fix

Replace the strict count assertion with `slices.IndexFunc` to find the user message by role, then verify its `ModelConfigID`. The test's actual purpose is verifying model override persistence, not message count.

Fixes: ENG-2719

> Generated with [Coder Agents](https://coder.com/agents)