### PR TITLE
perf(site/src): reduce mobile chat sticky work

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -20,6 +20,7 @@ import {
 	withProxyProvider,
 	withWebSocket,
 } from "#/testHelpers/storybook";
+import { mobileViewportMediaQuery } from "#/utils/mobile";
 import {
 	AgentChatPageLoadingView,
 	AgentChatPageNotFoundView,
@@ -859,8 +860,6 @@ const scrollStoryDecorators: Decorator[] = [
 		</div>
 	),
 ];
-
-const mobileViewportMediaQuery = "(max-width: 639px)";
 
 const mobileScrollStoryDecorators: Decorator[] = [
 	(Story) => (

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -860,6 +860,57 @@ const scrollStoryDecorators: Decorator[] = [
 	),
 ];
 
+const mobileViewportMediaQuery = "(max-width: 639px)";
+
+const mobileScrollStoryDecorators: Decorator[] = [
+	(Story) => (
+		<div
+			style={{
+				width: "390px",
+				height: "600px",
+				display: "flex",
+				flexDirection: "column",
+			}}
+		>
+			<Story />
+		</div>
+	),
+];
+
+const mockMobileViewport = () => {
+	const originalMatchMedia = matchMedia;
+	const mobileMatchMedia: typeof matchMedia = (query) => {
+		if (query !== mobileViewportMediaQuery) {
+			return originalMatchMedia(query);
+		}
+
+		return {
+			matches: true,
+			media: query,
+			onchange: null,
+			addListener: () => undefined,
+			removeListener: () => undefined,
+			addEventListener: () => undefined,
+			removeEventListener: () => undefined,
+			dispatchEvent: () => true,
+		} satisfies MediaQueryList;
+	};
+
+	Object.defineProperty(globalThis, "matchMedia", {
+		configurable: true,
+		writable: true,
+		value: mobileMatchMedia,
+	});
+
+	return () => {
+		Object.defineProperty(globalThis, "matchMedia", {
+			configurable: true,
+			writable: true,
+			value: originalMatchMedia,
+		});
+	};
+};
+
 const waitForScrollOverflow = async (scrollContainer: HTMLElement) => {
 	await waitFor(() => {
 		expect(scrollContainer.scrollHeight).toBeGreaterThan(
@@ -1239,6 +1290,33 @@ export const StickyUserMessagePinsOnScroll: Story = {
 		expect(window.getComputedStyle(pinnedContainer).position).toBe("sticky");
 		expect(pinnedRect.top - scrollerRect.top).toBeGreaterThanOrEqual(-1);
 		expect(pinnedRect.top - scrollerRect.top).toBeLessThan(40);
+	},
+};
+
+const mobileLongChatStore = buildStoreWithMessages(buildLongConversation(120));
+
+export const MobileLongChatSkipsStickyUserMessages: Story = {
+	parameters: {
+		chromatic: { disableSnapshot: true },
+		viewport: { defaultViewport: "iphone12" },
+	},
+	decorators: mobileScrollStoryDecorators,
+	beforeEach: mockMobileViewport,
+	render: () => <StoryAgentChatPageView store={mobileLongChatStore} />,
+	play: async ({ canvasElement }) => {
+		resetScrollStoryStore(mobileLongChatStore, 120);
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+
+		await waitForScrollOverflow(scrollContainer);
+		await waitFor(() => {
+			expect(
+				scrollContainer.querySelectorAll("[data-user-sentinel]"),
+			).toHaveLength(0);
+		});
+		expect(
+			canvas.getByText("Question 60: Can you explain concept 60 in detail?"),
+		).toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -23,7 +23,7 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { cn } from "#/utils/cn";
-import { isMobileViewport } from "#/utils/mobile";
+import { isMobileViewport, mobileViewportMediaQuery } from "#/utils/mobile";
 
 import {
 	ConversationItem,
@@ -71,8 +71,6 @@ const getChatMessageTextContent = (
 
 	return textContent.length > 0 ? textContent : undefined;
 };
-
-const mobileViewportMediaQuery = "(max-width: 639px)";
 
 const useIsMobileViewport = (): boolean => {
 	const [isMobile, setIsMobile] = useState(() => isMobileViewport());
@@ -1127,33 +1125,35 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 			}
 		}
 
-		// Ordered list of visible user message IDs, used to drive the
-		// per-bubble prev/next arrow buttons that jump the transcript
-		// to the neighbouring user prompt.
-		const visibleUserMessageIds: number[] = [];
-		for (const { message, parsed } of parsedMessages) {
-			if (message.role !== "user") continue;
-			const { shouldHide } = deriveMessageDisplayState({
-				message,
-				parsed,
-				hideActions: false,
-				hasActiveStream: false,
-				isAwaitingFirstStreamChunk: false,
-			});
-			if (!shouldHide) visibleUserMessageIds.push(message.id);
-		}
 		const userNeighborsById = new Map<
 			number,
 			{ prevId?: number; nextId?: number }
 		>();
-		for (let i = 0; i < visibleUserMessageIds.length; i++) {
-			userNeighborsById.set(visibleUserMessageIds[i], {
-				prevId: i > 0 ? visibleUserMessageIds[i - 1] : undefined,
-				nextId:
-					i < visibleUserMessageIds.length - 1
-						? visibleUserMessageIds[i + 1]
-						: undefined,
-			});
+		if (!isMobile) {
+			// Ordered list of visible user message IDs, used to drive the
+			// per-bubble prev/next arrow buttons that jump the transcript
+			// to the neighbouring user prompt.
+			const visibleUserMessageIds: number[] = [];
+			for (const { message, parsed } of parsedMessages) {
+				if (message.role !== "user") continue;
+				const { shouldHide } = deriveMessageDisplayState({
+					message,
+					parsed,
+					hideActions: false,
+					hasActiveStream: false,
+					isAwaitingFirstStreamChunk: false,
+				});
+				if (!shouldHide) visibleUserMessageIds.push(message.id);
+			}
+			for (let i = 0; i < visibleUserMessageIds.length; i++) {
+				userNeighborsById.set(visibleUserMessageIds[i], {
+					prevId: i > 0 ? visibleUserMessageIds[i - 1] : undefined,
+					nextId:
+						i < visibleUserMessageIds.length - 1
+							? visibleUserMessageIds[i + 1]
+							: undefined,
+				});
+			}
 		}
 		let latestAskUserQuestionToolId: string | undefined;
 		let hasUserResponseAfterAskQuestion = false;

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -3,6 +3,7 @@ import {
 	type FC,
 	Fragment,
 	memo,
+	useEffect,
 	useLayoutEffect,
 	useRef,
 	useState,
@@ -22,6 +23,7 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { cn } from "#/utils/cn";
+import { isMobileViewport } from "#/utils/mobile";
 
 import {
 	ConversationItem,
@@ -68,6 +70,22 @@ const getChatMessageTextContent = (
 	}
 
 	return textContent.length > 0 ? textContent : undefined;
+};
+
+const mobileViewportMediaQuery = "(max-width: 639px)";
+
+const useIsMobileViewport = (): boolean => {
+	const [isMobile, setIsMobile] = useState(() => isMobileViewport());
+
+	useEffect(() => {
+		const mediaQuery = matchMedia(mobileViewportMediaQuery);
+		const update = () => setIsMobile(mediaQuery.matches);
+		update();
+		mediaQuery.addEventListener("change", update);
+		return () => mediaQuery.removeEventListener("change", update);
+	}, []);
+
+	return isMobile;
 };
 
 const ReasoningDisclosure = memo<{
@@ -1071,6 +1089,7 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 		hasActiveStream,
 		isAwaitingFirstStreamChunk,
 	}) => {
+		const isMobile = useIsMobileViewport();
 		const sentinelsRef = useRef<Map<number, HTMLDivElement>>(new Map());
 		const registerSentinel = (messageId: number, el: HTMLDivElement | null) => {
 			if (el) {
@@ -1190,6 +1209,21 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 							if (shouldHide) {
 								return null;
 							}
+							const isAfterEditingMessage = afterEditingMessageIds.has(
+								message.id,
+							);
+							if (isMobile) {
+								return (
+									<ChatMessageItem
+										key={message.id}
+										message={message}
+										parsed={parsed}
+										onEditUserMessage={onEditUserMessage}
+										editingMessageId={editingMessageId}
+										isAfterEditingMessage={isAfterEditingMessage}
+									/>
+								);
+							}
 							return (
 								<StickyUserMessage
 									key={message.id}
@@ -1197,7 +1231,7 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 									parsed={parsed}
 									onEditUserMessage={onEditUserMessage}
 									editingMessageId={editingMessageId}
-									isAfterEditingMessage={afterEditingMessageIds.has(message.id)}
+									isAfterEditingMessage={isAfterEditingMessage}
 									prevUserMessageId={userNeighborsById.get(message.id)?.prevId}
 									nextUserMessageId={userNeighborsById.get(message.id)?.nextId}
 									onJumpToUserMessage={jumpToUserMessage}

--- a/site/src/utils/mobile.ts
+++ b/site/src/utils/mobile.ts
@@ -1,3 +1,5 @@
+export const mobileViewportMediaQuery = "(max-width: 639px)";
+
 /**
  * Returns `true` when the viewport width is at or below the `sm`
  * Tailwind breakpoint (< 640 px), which is a reasonable proxy for a
@@ -5,7 +7,7 @@
  * virtual keyboard to pop up unexpectedly.
  */
 export const isMobileViewport = (): boolean => {
-	return window.matchMedia("(max-width: 639px)").matches;
+	return matchMedia(mobileViewportMediaQuery).matches;
 };
 
 /**


### PR DESCRIPTION
Long mobile agent chats can hit Mobile Safari resource limits because every user message mounts sticky-message sentinel and observer machinery.

Render user messages without sticky pinning on mobile viewports while keeping desktop sticky behavior, and add a Storybook regression that verifies long mobile chats do not render sticky sentinels.

Refs CODAGT-450

<details>
<summary>Coder Agents context</summary>

Generated by Coder Agents.

Investigation pointed to mobile sticky user messages as the lowest-risk hotspot: each user message mounted sentinel, observer, listener, and overlay DOM. This PR keeps that work on non-mobile viewports instead of introducing transcript virtualization, which is higher risk with inverse infinite scroll and dynamic tool output.

</details>
