### PR TITLE
perf(site/src/pages/AgentsPage): combine array iterations

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
@@ -32,13 +32,13 @@ const buildOrderedMessageIDs = (
 	// still exists in a later page). The Map-based messagesByID
 	// already deduplicates, but orderedMessageIDs must match.
 	const seen = new Set<number>();
-	return sorted
-		.map((message) => message.id)
-		.filter((id) => {
-			if (seen.has(id)) return false;
-			seen.add(id);
-			return true;
-		});
+	const orderedMessageIDs: number[] = [];
+	for (const message of sorted) {
+		if (seen.has(message.id)) continue;
+		seen.add(message.id);
+		orderedMessageIDs.push(message.id);
+	}
+	return orderedMessageIDs;
 };
 
 const mapsEqualByRef = <K, V>(left: Map<K, V>, right: Map<K, V>): boolean => {

--- a/site/src/pages/AgentsPage/components/MCPServerPicker.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerPicker.tsx
@@ -78,13 +78,17 @@ const MCPIcon: FC<{ iconUrl: string; name: string; className?: string }> = ({
 export const getDefaultMCPSelection = (
 	servers: readonly TypesGen.MCPServerConfig[],
 ): string[] => {
-	return servers
-		.filter(
-			(s) =>
-				s.enabled &&
-				(s.availability === "force_on" || s.availability === "default_on"),
-		)
-		.map((s) => s.id);
+	const ids: string[] = [];
+	for (const server of servers) {
+		if (
+			server.enabled &&
+			(server.availability === "force_on" ||
+				server.availability === "default_on")
+		) {
+			ids.push(server.id);
+		}
+	}
+	return ids;
 };
 
 /** localStorage key for persisting the user's MCP server selection. */
@@ -113,13 +117,15 @@ export const mcpSelectionStorageKey = "agents.selected-mcp-server-ids";
 		if (!Array.isArray(parsed)) {
 			return null;
 		}
-		const enabledIds = new Set(
-			servers.filter((s) => s.enabled).map((s) => s.id),
-		);
-		// Always include force_on servers even if the user didn't save them.
-		const forceOnIds = servers
-			.filter((s) => s.enabled && s.availability === "force_on")
-			.map((s) => s.id);
+		const enabledIds = new Set<string>();
+		const forceOnIds: string[] = [];
+		for (const server of servers) {
+			if (!server.enabled) continue;
+			enabledIds.add(server.id);
+			if (server.availability === "force_on") {
+				forceOnIds.push(server.id);
+			}
+		}
 		const restored = parsed.filter(
 			(id): id is string => typeof id === "string" && enabledIds.has(id),
 		);

--- a/site/src/pages/AgentsPage/components/QueuedMessagesList.tsx
+++ b/site/src/pages/AgentsPage/components/QueuedMessagesList.tsx
@@ -41,12 +41,13 @@ export const getQueuedMessageInfo = (
 ): QueuedMessageInfo => {
 	const { content } = message;
 	const fileBlocks = content.filter((p) => p.type === "file");
-	const rawText = content
-		.filter((p) => p.type === "text")
-		.map((p) => p.text)
-		.filter((t): t is string => Boolean(t?.trim()))
-		.join(" ")
-		.trim();
+	const textParts: string[] = [];
+	for (const part of content) {
+		if (part.type === "text" && part.text?.trim()) {
+			textParts.push(part.text);
+		}
+	}
+	const rawText = textParts.join(" ").trim();
 
 	if (rawText) {
 		return {

--- a/site/src/pages/AgentsPage/utils/personalSkills.ts
+++ b/site/src/pages/AgentsPage/utils/personalSkills.ts
@@ -59,22 +59,24 @@ export const filterPersonalSkills = (
 		return skills.toSorted((a, b) => a.name.localeCompare(b.name, "en-US"));
 	}
 
-	return skills
-		.map((skill, index): RankedPersonalSkill => {
-			const name = skill.name.toLocaleLowerCase("en-US");
-			const description = skill.description.toLocaleLowerCase("en-US");
-			let rank = Number.POSITIVE_INFINITY;
-			if (name.startsWith(normalizedQuery)) {
-				rank = 0;
-			} else if (name.includes(normalizedQuery)) {
-				rank = 1;
-			} else if (description.includes(normalizedQuery)) {
-				rank = 2;
-			}
+	const rankedSkills: RankedPersonalSkill[] = [];
+	for (const [index, skill] of skills.entries()) {
+		const name = skill.name.toLocaleLowerCase("en-US");
+		const description = skill.description.toLocaleLowerCase("en-US");
+		let rank: number | undefined;
+		if (name.startsWith(normalizedQuery)) {
+			rank = 0;
+		} else if (name.includes(normalizedQuery)) {
+			rank = 1;
+		} else if (description.includes(normalizedQuery)) {
+			rank = 2;
+		}
+		if (rank !== undefined) {
+			rankedSkills.push({ skill, rank, index });
+		}
+	}
 
-			return { skill, rank, index };
-		})
-		.filter(({ rank }) => Number.isFinite(rank))
+	return rankedSkills
 		.toSorted((a, b) => {
 			if (a.rank !== b.rank) {
 				return a.rank - b.rank;


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

Replace a set of AgentsPage `map().filter()` and `filter().map()` pipelines with single-pass loops in well-covered chat, MCP server selection, queued message, and personal skill helpers. This addresses the group of low-risk React Doctor `js-combine-iterations` findings while preserving existing ordering and filtering behavior.

## Microbenchmark

I ran a temporary Node microbenchmark in the workspace using 10k-item sample data and 20k iterations to compare the old chained array methods against the new single-pass loops. This is not a user-visible performance test, but it validates the expected CPU/allocation direction for larger inputs:

```text
chatStore map/filter -> chatStore loop
  before: 12691.3ms, 1576 ops/s
  after:   8618.9ms, 2320 ops/s
  delta:   32.1% faster, 1.47x

MCP default filter/map -> MCP default loop
  before: 1008.5ms, 19831 ops/s
  after:   534.3ms, 37435 ops/s
  delta:   47.0% faster, 1.89x

queued text filter/map/filter -> queued text loop
  before: 5857.4ms, 3414 ops/s
  after:  4203.9ms, 4757 ops/s
  delta:   28.2% faster, 1.39x

personal skills map/filter -> personal skills loop
  before: 14362.0ms, 1393 ops/s
  after:  13585.7ms, 1472 ops/s
  delta:    5.4% faster, 1.06x
```

## Verification

- `pnpm format -- src/pages/AgentsPage/components/ChatConversation/chatStore.ts src/pages/AgentsPage/components/MCPServerPicker.tsx src/pages/AgentsPage/components/QueuedMessagesList.tsx src/pages/AgentsPage/utils/personalSkills.ts`
- `pnpm test -- src/pages/AgentsPage/components/MCPServerPicker.test.ts src/pages/AgentsPage/components/QueuedMessagesList.test.ts src/pages/AgentsPage/utils/personalSkills.test.ts src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts`
- `pnpm dlx react-doctor@latest . --verbose`, verified this group is down to `0` `js-combine-iterations` findings
- `pnpm lint`
