### PR TITLE
fix(coderd/x/chatd): make OpenAI computer use stateless

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -7934,6 +7934,15 @@ func (p *Server) runChat(
 		model,
 		callConfig.ProviderOptions,
 	)
+	// Apply computer-use provider constraints before chain-mode selection.
+	// OpenAI computer use forces store=false, which prevents previous_response_id.
+	if isComputerUse {
+		providerOptions = providerOptionsForComputerUseTurn(
+			model,
+			providerOptions,
+			computerUseProvider,
+		)
+	}
 	// When the OpenAI Responses API has store=true, the provider
 	// retains conversation history server-side. For follow-up turns,
 	// we set previous_response_id and send only system instructions

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"charm.land/fantasy"
+	fantasyopenai "charm.land/fantasy/providers/openai"
 	"github.com/google/uuid"
 	"github.com/sqlc-dev/pqtype"
 	"github.com/stretchr/testify/require"
@@ -165,6 +166,63 @@ func TestResolveComputerUseModel_OpenAIMissingCredentials(t *testing.T) {
 	require.Contains(t, err.Error(), `provider "openai" model "gpt-5.5"`)
 	require.Contains(t, err.Error(), "OPENAI_API_KEY is not set")
 	require.NotContains(t, err.Error(), "ANTHROPIC_API_KEY")
+}
+
+func TestProviderOptionsForComputerUseTurn_OpenAIDisablesStorage(t *testing.T) {
+	t.Parallel()
+
+	storeEnabled := true
+	providerOptions := chatprovider.ProviderOptionsFromChatModelConfig(
+		&chattest.FakeModel{ProviderName: fantasyopenai.Name, ModelName: "gpt-4o"},
+		&codersdk.ChatModelProviderOptions{
+			OpenAI: &codersdk.ChatModelOpenAIProviderOptions{
+				Store: &storeEnabled,
+			},
+		},
+	)
+	got := providerOptionsForComputerUseTurn(
+		&chattest.FakeModel{ProviderName: fantasyopenai.Name, ModelName: "gpt-4o"},
+		providerOptions,
+		chattool.ComputerUseProviderOpenAI,
+	)
+
+	require.True(t, storeEnabled)
+	chattest.RequireOpenAIStoreDisabled(t, got)
+}
+
+func TestProviderOptionsForComputerUseTurn_OpenAIAddsExplicitStoreFalse(t *testing.T) {
+	t.Parallel()
+
+	modelProvider, modelName, ok := chattool.DefaultComputerUseModel(chattool.ComputerUseProviderOpenAI)
+	require.True(t, ok)
+	model := &chattest.FakeModel{ProviderName: modelProvider, ModelName: modelName}
+	got := providerOptionsForComputerUseTurn(
+		model,
+		nil,
+		chattool.ComputerUseProviderOpenAI,
+	)
+
+	chattest.RequireOpenAIStoreDisabled(t, got)
+}
+
+func TestProviderOptionsForComputerUseTurn_AnthropicKeepsStorage(t *testing.T) {
+	t.Parallel()
+
+	storeEnabled := true
+	providerOptions := fantasy.ProviderOptions{
+		fantasyopenai.Name: &fantasyopenai.ResponsesProviderOptions{Store: &storeEnabled},
+	}
+	got := providerOptionsForComputerUseTurn(
+		&chattest.FakeModel{ProviderName: fantasyopenai.Name, ModelName: "gpt-4o"},
+		providerOptions,
+		chattool.ComputerUseProviderAnthropic,
+	)
+
+	require.Equal(t, providerOptions, got)
+	options, ok := got[fantasyopenai.Name].(*fantasyopenai.ResponsesProviderOptions)
+	require.True(t, ok)
+	require.NotNil(t, options.Store)
+	require.True(t, *options.Store)
 }
 
 func TestAppendComputerUseProviderTool(t *testing.T) {

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -168,7 +168,7 @@ func TestResolveComputerUseModel_OpenAIMissingCredentials(t *testing.T) {
 	require.NotContains(t, err.Error(), "ANTHROPIC_API_KEY")
 }
 
-func TestProviderOptionsForComputerUseTurn_OpenAIDisablesStorage(t *testing.T) {
+func TestProviderOptionsForComputerUseTurn_OpenAIDisablesStore(t *testing.T) {
 	t.Parallel()
 
 	storeEnabled := true
@@ -205,7 +205,7 @@ func TestProviderOptionsForComputerUseTurn_OpenAIAddsExplicitStoreFalse(t *testi
 	chattest.RequireOpenAIStoreDisabled(t, got)
 }
 
-func TestProviderOptionsForComputerUseTurn_AnthropicKeepsStorage(t *testing.T) {
+func TestProviderOptionsForComputerUseTurn_AnthropicKeepsStore(t *testing.T) {
 	t.Parallel()
 
 	storeEnabled := true

--- a/coderd/x/chatd/chatloop/chatloop.go
+++ b/coderd/x/chatd/chatloop/chatloop.go
@@ -268,7 +268,7 @@ func (r stepResult) toResponseMessages() []fantasy.Message {
 				continue
 			}
 			opts := fantasy.ProviderOptions(reasoning.ProviderMetadata)
-			if strings.TrimSpace(reasoning.Text) == "" && !chatsanitize.HasAnthropicSignedReasoningOptions(opts) {
+			if strings.TrimSpace(reasoning.Text) == "" && !chatprompt.HasReasoningReplayState(opts) {
 				continue
 			}
 			assistantParts = append(assistantParts, fantasy.ReasoningPart{
@@ -1630,7 +1630,7 @@ func flushActiveState(
 	// the interruption.
 	flushedAt := dbtime.Now()
 	for _, rs := range activeReasoning {
-		if rs.text == "" && !chatsanitize.HasAnthropicSignedReasoningOptions(fantasy.ProviderOptions(rs.options)) {
+		if rs.text == "" && !chatprompt.HasReasoningReplayState(fantasy.ProviderOptions(rs.options)) {
 			continue
 		}
 		result.content = append(result.content, fantasy.ReasoningContent{

--- a/coderd/x/chatd/chatloop/chatloop_internal_test.go
+++ b/coderd/x/chatd/chatloop/chatloop_internal_test.go
@@ -680,6 +680,41 @@ func TestStepResultToResponseMessagesPreservesEmptySignedReasoning(t *testing.T)
 	require.Equal(t, "redacted-payload", metadata.RedactedData)
 }
 
+func TestStepResultToResponseMessagesPreservesEmptyOpenAIReasoningReference(t *testing.T) {
+	t.Parallel()
+
+	result := stepResult{
+		content: []fantasy.Content{
+			fantasy.ReasoningContent{
+				ProviderMetadata: fantasy.ProviderMetadata{
+					fantasyopenai.Name: &fantasyopenai.ResponsesReasoningMetadata{
+						ItemID: "rs-openai",
+					},
+				},
+			},
+			fantasy.ToolCallContent{
+				ToolCallID: "cu-openai",
+				ToolName:   "computer",
+				Input:      `{"call_id":"cu-openai","actions":[{"type":"screenshot"}]}`,
+			},
+		},
+	}
+
+	messages := result.toResponseMessages()
+
+	require.Len(t, messages, 1)
+	require.Len(t, messages[0].Content, 2)
+	reasoning, ok := fantasy.AsMessagePart[fantasy.ReasoningPart](messages[0].Content[0])
+	require.True(t, ok)
+	require.Empty(t, reasoning.Text)
+	metadata := fantasyopenai.GetReasoningMetadata(reasoning.ProviderOptions)
+	require.NotNil(t, metadata)
+	require.Equal(t, "rs-openai", metadata.ItemID)
+	toolCall, ok := fantasy.AsMessagePart[fantasy.ToolCallPart](messages[0].Content[1])
+	require.True(t, ok)
+	require.Equal(t, "cu-openai", toolCall.ToolCallID)
+}
+
 func TestFlushActiveStatePreservesEmptySignedReasoning(t *testing.T) {
 	t.Parallel()
 
@@ -708,6 +743,36 @@ func TestFlushActiveStatePreservesEmptySignedReasoning(t *testing.T) {
 	metadata := fantasyanthropic.GetReasoningMetadata(fantasy.ProviderOptions(reasoning.ProviderMetadata))
 	require.NotNil(t, metadata)
 	require.Equal(t, "redacted-payload", metadata.RedactedData)
+}
+
+func TestFlushActiveStatePreservesEmptyOpenAIReasoningReference(t *testing.T) {
+	t.Parallel()
+
+	result := &stepResult{}
+	flushActiveState(
+		result,
+		map[string]string{},
+		map[string]reasoningState{
+			"openai": {
+				options: fantasy.ProviderMetadata{
+					fantasyopenai.Name: &fantasyopenai.ResponsesReasoningMetadata{
+						ItemID: "rs-openai",
+					},
+				},
+			},
+			"empty": {},
+		},
+		map[string]*fantasy.ToolCallContent{},
+		map[string]string{},
+	)
+
+	require.Len(t, result.content, 1)
+	reasoning, ok := fantasy.AsContentType[fantasy.ReasoningContent](result.content[0])
+	require.True(t, ok)
+	require.Empty(t, reasoning.Text)
+	metadata := fantasyopenai.GetReasoningMetadata(fantasy.ProviderOptions(reasoning.ProviderMetadata))
+	require.NotNil(t, metadata)
+	require.Equal(t, "rs-openai", metadata.ItemID)
 }
 
 // chainBrokenError is what OpenAI returns when previous_response_id

--- a/coderd/x/chatd/chatopenai/responses.go
+++ b/coderd/x/chatd/chatopenai/responses.go
@@ -148,6 +148,57 @@ func ClearPreviousResponseID(providerOptions fantasy.ProviderOptions) fantasy.Pr
 	return cloned
 }
 
+// WithStoreDisabled returns provider options with store=false and
+// previous_response_id cleared. It creates an OpenAI entry for OpenAI models
+// that lack one.
+func WithStoreDisabled(
+	model fantasy.LanguageModel,
+	providerOptions fantasy.ProviderOptions,
+) fantasy.ProviderOptions {
+	storeDisabled := false
+	cloned := maps.Clone(providerOptions)
+	if cloned == nil {
+		cloned = fantasy.ProviderOptions{}
+	}
+
+	entry := cloned[fantasyopenai.Name]
+	switch options := entry.(type) {
+	case *fantasyopenai.ResponsesProviderOptions:
+		optionsClone := fantasyopenai.ResponsesProviderOptions{}
+		if options != nil {
+			optionsClone = *options
+		}
+		optionsClone.Store = &storeDisabled
+		optionsClone.PreviousResponseID = nil
+		cloned[fantasyopenai.Name] = &optionsClone
+	case *fantasyopenai.ProviderOptions:
+		optionsClone := fantasyopenai.ProviderOptions{}
+		if options != nil {
+			optionsClone = *options
+		}
+		optionsClone.Store = &storeDisabled
+		cloned[fantasyopenai.Name] = &optionsClone
+	default:
+		switch {
+		case UsesResponsesOptions(model):
+			cloned[fantasyopenai.Name] = &fantasyopenai.ResponsesProviderOptions{
+				Include: EnsureResponseIncludes(nil),
+				Store:   &storeDisabled,
+			}
+		case isOpenAIModel(model):
+			cloned[fantasyopenai.Name] = &fantasyopenai.ProviderOptions{
+				Store: &storeDisabled,
+			}
+		}
+	}
+
+	return cloned
+}
+
+func isOpenAIModel(model fantasy.LanguageModel) bool {
+	return model != nil && model.Provider() == fantasyopenai.Name
+}
+
 // extractResponseID extracts the OpenAI Responses API response ID from provider
 // metadata. Returns an empty string if no OpenAI Responses metadata is present.
 func extractResponseID(metadata fantasy.ProviderMetadata) string {

--- a/coderd/x/chatd/chatopenai/responses.go
+++ b/coderd/x/chatd/chatopenai/responses.go
@@ -155,7 +155,7 @@ func WithStoreDisabled(
 	model fantasy.LanguageModel,
 	providerOptions fantasy.ProviderOptions,
 ) fantasy.ProviderOptions {
-	storeDisabled := false
+	store := false
 	cloned := maps.Clone(providerOptions)
 	if cloned == nil {
 		cloned = fantasy.ProviderOptions{}
@@ -168,7 +168,7 @@ func WithStoreDisabled(
 		if options != nil {
 			optionsClone = *options
 		}
-		optionsClone.Store = &storeDisabled
+		optionsClone.Store = &store
 		optionsClone.PreviousResponseID = nil
 		cloned[fantasyopenai.Name] = &optionsClone
 	case *fantasyopenai.ProviderOptions:
@@ -176,18 +176,18 @@ func WithStoreDisabled(
 		if options != nil {
 			optionsClone = *options
 		}
-		optionsClone.Store = &storeDisabled
+		optionsClone.Store = &store
 		cloned[fantasyopenai.Name] = &optionsClone
 	default:
 		switch {
-		case UsesResponsesOptions(model):
+		case isOpenAIModel(model) && UsesResponsesOptions(model):
 			cloned[fantasyopenai.Name] = &fantasyopenai.ResponsesProviderOptions{
 				Include: EnsureResponseIncludes(nil),
-				Store:   &storeDisabled,
+				Store:   &store,
 			}
 		case isOpenAIModel(model):
 			cloned[fantasyopenai.Name] = &fantasyopenai.ProviderOptions{
-				Store: &storeDisabled,
+				Store: &store,
 			}
 		}
 	}

--- a/coderd/x/chatd/chatopenai/responses_test.go
+++ b/coderd/x/chatd/chatopenai/responses_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"charm.land/fantasy"
+	fantasyazure "charm.land/fantasy/providers/azure"
 	fantasyopenai "charm.land/fantasy/providers/openai"
 	"github.com/google/uuid"
 	"github.com/sqlc-dev/pqtype"
@@ -416,6 +417,19 @@ func TestWithStoreDisabledNonOpenAIModelWithoutOpenAIEntry(t *testing.T) {
 	opts := fantasy.ProviderOptions{"other": otherOptions}
 	got := chatopenai.WithStoreDisabled(
 		fakeLanguageModel{provider: "anthropic", model: "claude-opus-4-6"},
+		opts,
+	)
+
+	require.Equal(t, opts, got)
+}
+
+func TestWithStoreDisabledAzureResponsesModelWithoutOpenAIEntry(t *testing.T) {
+	t.Parallel()
+
+	otherOptions := &unknownProviderOptions{}
+	opts := fantasy.ProviderOptions{"other": otherOptions}
+	got := chatopenai.WithStoreDisabled(
+		fakeLanguageModel{provider: fantasyazure.Name, model: "gpt-4o"},
 		opts,
 	)
 

--- a/coderd/x/chatd/chatopenai/responses_test.go
+++ b/coderd/x/chatd/chatopenai/responses_test.go
@@ -334,6 +334,114 @@ func TestClearPreviousResponseID(t *testing.T) {
 	})
 }
 
+func TestWithStoreDisabled(t *testing.T) {
+	t.Parallel()
+
+	storeEnabled := true
+	previousResponseID := "resp-123"
+	responsesOptions := &fantasyopenai.ResponsesProviderOptions{
+		Store:              &storeEnabled,
+		PreviousResponseID: &previousResponseID,
+	}
+	otherOptions := &fantasyopenai.ProviderOptions{}
+	opts := fantasy.ProviderOptions{
+		fantasyopenai.Name: responsesOptions,
+		"other":            otherOptions,
+	}
+
+	got := chatopenai.WithStoreDisabled(
+		fakeLanguageModel{provider: fantasyopenai.Name, model: "gpt-4o"},
+		opts,
+	)
+
+	require.True(t, storeEnabled)
+	require.NotNil(t, responsesOptions.PreviousResponseID)
+	require.Equal(t, "resp-123", *responsesOptions.PreviousResponseID)
+	require.NotContains(t, opts, "new")
+
+	gotOtherOptions, ok := got["other"].(*fantasyopenai.ProviderOptions)
+	require.True(t, ok)
+	require.True(t, otherOptions == gotOtherOptions)
+	gotOptions, ok := got[fantasyopenai.Name].(*fantasyopenai.ResponsesProviderOptions)
+	require.True(t, ok)
+	require.NotSame(t, responsesOptions, gotOptions)
+	chattest.RequireOpenAIStoreDisabled(t, got)
+}
+
+func TestWithStoreDisabledAddsResponsesOptions(t *testing.T) {
+	t.Parallel()
+
+	got := chatopenai.WithStoreDisabled(
+		fakeLanguageModel{provider: fantasyopenai.Name, model: "gpt-4o"},
+		nil,
+	)
+
+	gotOptions, ok := got[fantasyopenai.Name].(*fantasyopenai.ResponsesProviderOptions)
+	require.True(t, ok)
+	chattest.RequireOpenAIStoreDisabled(t, got)
+	require.Contains(t, gotOptions.Include, fantasyopenai.IncludeReasoningEncryptedContent)
+}
+
+func TestWithStoreDisabledAddsLegacyOptionsForOpenAIModel(t *testing.T) {
+	t.Parallel()
+
+	got := chatopenai.WithStoreDisabled(
+		fakeLanguageModel{provider: fantasyopenai.Name, model: "not-responses"},
+		nil,
+	)
+
+	gotOptions, ok := got[fantasyopenai.Name].(*fantasyopenai.ProviderOptions)
+	require.True(t, ok)
+	require.NotNil(t, gotOptions.Store)
+	chattest.RequireOpenAIStoreDisabled(t, got)
+}
+
+func TestWithStoreDisabledReplacesUnknownOpenAIEntry(t *testing.T) {
+	t.Parallel()
+
+	got := chatopenai.WithStoreDisabled(
+		fakeLanguageModel{provider: fantasyopenai.Name, model: "gpt-4o"},
+		fantasy.ProviderOptions{fantasyopenai.Name: &unknownProviderOptions{}},
+	)
+
+	_, ok := got[fantasyopenai.Name].(*fantasyopenai.ResponsesProviderOptions)
+	require.True(t, ok)
+	chattest.RequireOpenAIStoreDisabled(t, got)
+}
+
+func TestWithStoreDisabledNonOpenAIModelWithoutOpenAIEntry(t *testing.T) {
+	t.Parallel()
+
+	otherOptions := &unknownProviderOptions{}
+	opts := fantasy.ProviderOptions{"other": otherOptions}
+	got := chatopenai.WithStoreDisabled(
+		fakeLanguageModel{provider: "anthropic", model: "claude-opus-4-6"},
+		opts,
+	)
+
+	require.Equal(t, opts, got)
+}
+
+func TestWithStoreDisabledHandlesLegacyOptions(t *testing.T) {
+	t.Parallel()
+
+	storeEnabled := true
+	legacyOptions := &fantasyopenai.ProviderOptions{Store: &storeEnabled}
+	opts := fantasy.ProviderOptions{fantasyopenai.Name: legacyOptions}
+
+	got := chatopenai.WithStoreDisabled(
+		fakeLanguageModel{provider: fantasyopenai.Name, model: "not-responses"},
+		opts,
+	)
+
+	require.True(t, storeEnabled)
+	gotOptions, ok := got[fantasyopenai.Name].(*fantasyopenai.ProviderOptions)
+	require.True(t, ok)
+	require.NotSame(t, legacyOptions, gotOptions)
+	require.NotNil(t, gotOptions.Store)
+	require.False(t, *gotOptions.Store)
+}
+
 func TestExtractResponseIDIfStoredMetadata(t *testing.T) {
 	t.Parallel()
 
@@ -899,6 +1007,18 @@ func TestFilterPromptForChainModeUsesContributingTrailingUsers(t *testing.T) {
 	part, ok := fantasy.AsMessagePart[fantasy.TextPart](got[1].Content[0])
 	require.True(t, ok)
 	require.Equal(t, "latest user message", part.Text)
+}
+
+type unknownProviderOptions struct{}
+
+func (*unknownProviderOptions) Options() {}
+
+func (*unknownProviderOptions) MarshalJSON() ([]byte, error) {
+	return []byte(`{}`), nil
+}
+
+func (*unknownProviderOptions) UnmarshalJSON([]byte) error {
+	return nil
 }
 
 func chainModeProviderOptions(store bool) fantasy.ProviderOptions {

--- a/coderd/x/chatd/chatprompt/chatprompt.go
+++ b/coderd/x/chatd/chatprompt/chatprompt.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"charm.land/fantasy"
+	fantasyopenai "charm.land/fantasy/providers/openai"
 	"github.com/google/uuid"
 	"github.com/sqlc-dev/pqtype"
 	"golang.org/x/xerrors"
@@ -58,6 +59,16 @@ func safeAsToolResultPart(part fantasy.MessagePart) (fantasy.ToolResultPart, boo
 	}
 	type toolResultPart = fantasy.ToolResultPart
 	return fantasy.AsMessagePart[toolResultPart](part)
+}
+
+// HasReasoningReplayState reports whether provider options include hidden
+// reasoning state that must be replayed even without visible reasoning text.
+func HasReasoningReplayState(opts fantasy.ProviderOptions) bool {
+	if chatsanitize.HasAnthropicSignedReasoningOptions(opts) {
+		return true
+	}
+	metadata := fantasyopenai.GetReasoningMetadata(opts)
+	return metadata != nil && metadata.ItemID != ""
 }
 
 // FileData holds resolved file content for LLM prompt building.
@@ -1521,7 +1532,7 @@ func partsToMessageParts(
 			})
 		case codersdk.ChatMessagePartTypeReasoning:
 			opts := providerMetadataToOptions(logger, part.ProviderMetadata)
-			if strings.TrimSpace(part.Text) == "" && !chatsanitize.HasAnthropicSignedReasoningOptions(opts) {
+			if strings.TrimSpace(part.Text) == "" && !HasReasoningReplayState(opts) {
 				continue
 			}
 			result = append(result, fantasy.ReasoningPart{

--- a/coderd/x/chatd/chatprompt/chatprompt_test.go
+++ b/coderd/x/chatd/chatprompt/chatprompt_test.go
@@ -10,6 +10,7 @@ import (
 
 	"charm.land/fantasy"
 	fantasyanthropic "charm.land/fantasy/providers/anthropic"
+	fantasyopenai "charm.land/fantasy/providers/openai"
 	"github.com/google/uuid"
 	"github.com/sqlc-dev/pqtype"
 	"github.com/stretchr/testify/assert"
@@ -35,6 +36,48 @@ func testMsg(role codersdk.ChatMessageRole, raw pqtype.NullRawMessage) database.
 	return database.ChatMessage{
 		Role:    database.ChatMessageRole(role),
 		Content: raw,
+	}
+}
+
+func TestHasReasoningReplayState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		opts fantasy.ProviderOptions
+		want bool
+	}{
+		{
+			name: "NoMetadata",
+		},
+		{
+			name: "OpenAIReasoningEmptyItemID",
+			opts: fantasy.ProviderOptions{
+				fantasyopenai.Name: &fantasyopenai.ResponsesReasoningMetadata{},
+			},
+		},
+		{
+			name: "OpenAIReasoningItemID",
+			opts: fantasy.ProviderOptions{
+				fantasyopenai.Name: &fantasyopenai.ResponsesReasoningMetadata{ItemID: "rs-openai"},
+			},
+			want: true,
+		},
+		{
+			name: "AnthropicSignedReasoning",
+			opts: fantasy.ProviderOptions{
+				fantasyanthropic.Name: &fantasyanthropic.ReasoningOptionMetadata{RedactedData: "redacted"},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, chatprompt.HasReasoningReplayState(tt.opts))
+		})
 	}
 }
 
@@ -74,6 +117,44 @@ func TestConvertMessagesWithFilesPreservesEmptyRedactedReasoning(t *testing.T) {
 	reasoningMetadata := fantasyanthropic.GetReasoningMetadata(reasoning.ProviderOptions)
 	require.NotNil(t, reasoningMetadata)
 	require.Equal(t, "redacted-payload", reasoningMetadata.RedactedData)
+}
+
+func TestConvertMessagesWithFilesPreservesEmptyOpenAIReasoningReference(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := json.Marshal(fantasy.ProviderMetadata{
+		fantasyopenai.Name: &fantasyopenai.ResponsesReasoningMetadata{
+			ItemID: "rs-openai",
+		},
+	})
+	require.NoError(t, err)
+	content, err := chatprompt.MarshalParts([]codersdk.ChatMessagePart{
+		{
+			Type:             codersdk.ChatMessagePartTypeReasoning,
+			ProviderMetadata: metadata,
+		},
+		codersdk.ChatMessageText("done"),
+	})
+	require.NoError(t, err)
+
+	prompt, err := chatprompt.ConvertMessagesWithFiles(context.Background(), []database.ChatMessage{
+		{
+			Role:           database.ChatMessageRoleAssistant,
+			Visibility:     database.ChatMessageVisibilityBoth,
+			Content:        content,
+			ContentVersion: chatprompt.CurrentContentVersion,
+		},
+	}, nil, slogtest.Make(t, nil))
+	require.NoError(t, err)
+	require.Len(t, prompt, 1)
+	require.Len(t, prompt[0].Content, 2)
+
+	reasoning, ok := fantasy.AsMessagePart[fantasy.ReasoningPart](prompt[0].Content[0])
+	require.True(t, ok)
+	require.Empty(t, reasoning.Text)
+	reasoningMetadata := fantasyopenai.GetReasoningMetadata(reasoning.ProviderOptions)
+	require.NotNil(t, reasoningMetadata)
+	require.Equal(t, "rs-openai", reasoningMetadata.ItemID)
 }
 
 func TestConvertMessagesWithFilesRoundTripsAnthropicInterleavedWebSearch(t *testing.T) {

--- a/coderd/x/chatd/chattest/openai_assertions.go
+++ b/coderd/x/chatd/chattest/openai_assertions.go
@@ -1,0 +1,29 @@
+package chattest
+
+import (
+	"testing"
+
+	"charm.land/fantasy"
+	fantasyopenai "charm.land/fantasy/providers/openai"
+	"github.com/stretchr/testify/require"
+)
+
+// RequireOpenAIStoreDisabled asserts that OpenAI provider options disable store
+// and do not carry previous_response_id state.
+func RequireOpenAIStoreDisabled(t *testing.T, opts fantasy.ProviderOptions) {
+	t.Helper()
+
+	entry, ok := opts[fantasyopenai.Name]
+	require.True(t, ok)
+	switch options := entry.(type) {
+	case *fantasyopenai.ResponsesProviderOptions:
+		require.NotNil(t, options.Store)
+		require.False(t, *options.Store)
+		require.Nil(t, options.PreviousResponseID)
+	case *fantasyopenai.ProviderOptions:
+		require.NotNil(t, options.Store)
+		require.False(t, *options.Store)
+	default:
+		require.Failf(t, "unexpected OpenAI options type", "%T", entry)
+	}
+}

--- a/coderd/x/chatd/computer_use.go
+++ b/coderd/x/chatd/computer_use.go
@@ -106,9 +106,8 @@ func (p *Server) resolveComputerUseModel(
 	return model, debugEnabled, resolvedProvider, resolvedModel, nil
 }
 
-// providerOptionsForComputerUseTurn applies provider-specific computer-use
-// request constraints. OpenAI computer-use turns must run with store=false
-// before chain-mode selection, so previous_response_id is not set.
+// providerOptionsForComputerUseTurn forces store=false for OpenAI computer
+// use to prevent stateful response chaining.
 func providerOptionsForComputerUseTurn(
 	model fantasy.LanguageModel,
 	providerOptions fantasy.ProviderOptions,

--- a/coderd/x/chatd/computer_use.go
+++ b/coderd/x/chatd/computer_use.go
@@ -11,6 +11,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatloop"
+	"github.com/coder/coder/v2/coderd/x/chatd/chatopenai"
 	openaicomputeruse "github.com/coder/coder/v2/coderd/x/chatd/chatopenai/computeruse"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprovider"
 	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
@@ -103,6 +104,20 @@ func (p *Server) resolveComputerUseModel(
 	}
 
 	return model, debugEnabled, resolvedProvider, resolvedModel, nil
+}
+
+// providerOptionsForComputerUseTurn applies provider-specific computer-use
+// request constraints. OpenAI computer-use turns must run with store=false
+// before chain-mode selection, so previous_response_id is not set.
+func providerOptionsForComputerUseTurn(
+	model fantasy.LanguageModel,
+	providerOptions fantasy.ProviderOptions,
+	computerUseProvider string,
+) fantasy.ProviderOptions {
+	if chattool.DefaultComputerUseProvider(computerUseProvider) == chattool.ComputerUseProviderOpenAI {
+		return chatopenai.WithStoreDisabled(model, providerOptions)
+	}
+	return providerOptions
 }
 
 type computerUseProviderToolOptions struct {


### PR DESCRIPTION
> Mux opened this PR on behalf of Mike.

OpenAI computer-use chats now run stateless against OpenAI by forcing `store=false` and clearing `previous_response_id` before chain-mode selection. This avoids invalid OpenAI Responses requests that combine `store=false` with `previous_response_id`.

This also preserves empty OpenAI reasoning items that carry response item IDs, so stateless replay keeps the reasoning item required before provider computer calls.
