### PR TITLE
test(coderd/x/chatd): skip signal wake send flake

### DIFF
--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -8372,6 +8372,9 @@ func TestSignalWakeImmediateAcquisition(t *testing.T) {
 // triggers immediate processing via signalWake.
 func TestSignalWakeSendMessage(t *testing.T) {
 	t.Parallel()
+	// TODO(CODAGT-353): Re-enable this after the chatd notification
+	// flow can distinguish stale status notifications from interrupts.
+	t.Skip("skipped until chatd notification flow refactor handles stale control notifications")
 
 	db, ps := dbtestutil.NewDB(t)
 	ctx := testutil.Context(t, testutil.WaitSuperLong)


### PR DESCRIPTION
Skips `TestSignalWakeSendMessage`, which flakes because the current chatd control notification flow can deliver stale status notifications after a new processing run starts.

This mirrors the existing CODAGT-353 skips for the same stale-notification class and leaves the deterministic fix to that notification-flow refactor.

Closes: ENG-2727 - flake-testsignalwakesendmessage

> Generated by Coder Agents on behalf of @ibetitsmike.
