### PR TITLE
docs: clarify argv quoting behavior with `--`

### DIFF
--- a/docs/user-guides/workspace-access/index.md
+++ b/docs/user-guides/workspace-access/index.md
@@ -43,6 +43,51 @@ Or, you can configure plain SSH on your client below.
 > SSH command. For users who need the full functionality of SSH, use the
 > configuration method below.
 
+### Running remote commands with quoting
+
+Arguments after `--` are joined with spaces into a single command
+string before being sent to the workspace agent (per
+[RFC 4254 §6.5](https://www.rfc-editor.org/rfc/rfc4254#section-6.5),
+which defines the SSH exec request as a single string). Your local
+shell consumes outer quotes before the CLI ever sees the arguments,
+so inner quoting is not preserved on the wire.
+
+This means a common pattern from interactive shells does not behave
+as you might expect:
+
+```console
+# Surprising: prints an empty line, NOT "ready"
+coder ssh my-workspace -- bash -c 'echo ready'
+```
+
+The local shell strips the single-quotes, the CLI receives the argv
+`[bash, -c, echo, ready]`, and the remote agent runs
+`bash -c echo ready` — `echo` with no arguments and `ready` bound to
+`$0`. The same caveat applies to plain `ssh user@host -- bash -c '...'`;
+this is SSH protocol semantics, not a `coder ssh` limitation.
+
+For commands that need preserved quoting, use one of these patterns:
+
+**Heredoc via stdin** (recommended for multi-line scripts):
+
+```console
+coder ssh my-workspace -- bash <<'EOF'
+echo ready
+EOF
+```
+
+**A single-argument script payload**:
+
+```console
+coder ssh my-workspace -- /path/to/script.sh
+```
+
+**Exit-code-only probe** (when you only need to know if the command succeeded):
+
+```console
+coder ssh my-workspace -- true && echo "agent is reachable"
+```
+
 ### Configure SSH
 
 Coder generates [SSH key pairs](../../admin/security/secrets.md#ssh-keys) for

--- a/docs/user-guides/workspace-access/index.md
+++ b/docs/user-guides/workspace-access/index.md
@@ -62,7 +62,7 @@ coder ssh my-workspace -- bash -c 'echo ready'
 
 The local shell strips the single-quotes, the CLI receives the argv
 `[bash, -c, echo, ready]`, and the remote agent runs
-`bash -c echo ready` — `echo` with no arguments and `ready` bound to
+`bash -c echo ready`; `echo` gets no arguments and `ready` is bound to
 `$0`. The same caveat applies to plain `ssh user@host -- bash -c '...'`;
 this is SSH protocol semantics, not a `coder ssh` limitation.
 


### PR DESCRIPTION
## Summary

Adds a short "Running remote commands with quoting" subsection to `docs/user-guides/workspace-access/index.md` explaining that arguments after `--` in `coder ssh ws -- ...` are joined with spaces into a single command string before being sent to the workspace agent, and that the local shell consumes outer quotes before the CLI ever sees them. The change is documentation-only; no code is modified.

## Motivation

`coder ssh ws -- bash -c 'echo ready' | grep ready` looks correct but actually produces an empty line and never matches the grep. The inner single-quotes are stripped by the local shell, the CLI receives the argv `[bash, -c, echo, ready]`, and the remote agent runs `bash -c echo ready` — `echo` with no args, `ready` as `$0`.

This is RFC 4254 §6.5 SSH semantics, not a `coder ssh` defect — `ssh user@host -- bash -c '...'` against any OpenSSH server has the same outcome — but the gotcha was undocumented and surprised at least one project that spent ~6 rounds of CI debugging diagnosing the resulting empty-output false-negative (we observed `copy output done bytes=2` in the agent's session log: a single `\n` from the empty echo, PTY-translated to `\r\n`).

The added subsection:

1. States the behavior plainly with a worked example showing what NOT to do.
2. Calls out that this matches standard SSH semantics (so users don't expect a `coder ssh`-specific workaround).
3. Recommends three concrete working patterns:
    - Heredoc via stdin (multi-line scripts)
    - Single-argument script payload
    - Exit-code-only probe (when stdout doesn't matter)

The note is placed immediately after the existing "does not have full parity with the standard SSH command" disclaimer so the reader encounters both caveats together before being directed to `coder config-ssh` for full SSH parity.

## Test plan

- [x] No code changes — markdown only
- [x] `mkdocs`-style heading hierarchy preserved (new `### Running remote commands with quoting` sits under the existing `## SSH`)
- [x] Examples are runnable as-is
- [x] References to RFC 4254 §6.5 link to the IETF datatracker
- [ ] Maintainer review of placement and tone

## Out of scope

- Modifying the actual argv handling in `cli/ssh.go`. The current behavior is consistent with OpenSSH and changing it would require per-remote-shell escape rules (bash/dash/zsh/fish) which is an inherently leaky abstraction. This PR documents the existing behavior rather than changing it.
- Regenerating `docs/reference/cli/ssh.md`, which is autogenerated from CLI source.