### PR TITLE
fix(site/src/modules/resources): clarify agent log download button label

### DIFF
--- a/site/src/modules/resources/DownloadAgentLogsButton.stories.tsx
+++ b/site/src/modules/resources/DownloadAgentLogsButton.stories.tsx
@@ -34,7 +34,7 @@ export const ClickOnDownload: Story = {
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
 		await userEvent.click(
-			canvas.getByRole("button", { name: "Download logs" }),
+			canvas.getByRole("button", { name: "Download agent logs" }),
 		);
 		await waitFor(() =>
 			expect(args.download).toHaveBeenCalledWith(

--- a/site/src/modules/resources/DownloadAgentLogsButton.tsx
+++ b/site/src/modules/resources/DownloadAgentLogsButton.tsx
@@ -58,7 +58,7 @@ export const DownloadAgentLogsButton: FC<DownloadAgentLogsButtonProps> = ({
 			}}
 		>
 			<DownloadIcon />
-			{isDownloading ? "Downloading..." : "Download logs"}
+			{isDownloading ? "Downloading..." : "Download agent logs"}
 		</Button>
 	);
 };

--- a/site/src/modules/resources/DownloadSelectedAgentLogsButton.tsx
+++ b/site/src/modules/resources/DownloadSelectedAgentLogsButton.tsx
@@ -63,7 +63,7 @@ export const DownloadSelectedAgentLogsButton: FC<
 				>
 					<DownloadIcon />
 					<span className="sr-only">
-						{isDownloading ? "Downloading..." : "Download logs"}
+						{isDownloading ? "Downloading..." : "Download agent logs"}
 					</span>
 					<ChevronDownIcon className="size-icon-sm" />
 				</Button>


### PR DESCRIPTION
## Summary
Renames the agent log download action from `Download logs` to `Download agent logs` so it does not appear equivalent to the workspace-level log export action.

## Validation
- `pnpm format:check src/modules/resources/DownloadAgentLogsButton.tsx src/modules/resources/DownloadAgentLogsButton.stories.tsx src/modules/resources/DownloadSelectedAgentLogsButton.tsx`
- `pnpm test:storybook src/modules/resources/DownloadAgentLogsButton.stories.tsx`
- `pnpm lint:types`
- pre-commit hook

Closes #22138

> 🤖 This PR was created with the help of Coder Agents, and needs a human review.  🧑💻
