### PR TITLE
fix(agent/agentproc): atomic process output and status snapshot

### DIFF
--- a/agent/agentproc/api.go
+++ b/agent/agentproc/api.go
@@ -200,8 +200,7 @@ func (api *API) handleProcessOutput(rw http.ResponseWriter, r *http.Request) {
 		// Fall through to read snapshot below.
 	}
 
-	output, truncated := proc.output()
-	info := proc.info()
+	output, truncated, info := proc.snapshot()
 
 	httpapi.Write(ctx, rw, http.StatusOK, workspacesdk.ProcessOutputResponse{
 		Output:    output,

--- a/agent/agentproc/process.go
+++ b/agent/agentproc/process.go
@@ -63,10 +63,24 @@ func (p *process) info() workspacesdk.ProcessInfo {
 	}
 }
 
-// output returns the truncated output from the process buffer
-// along with optional truncation metadata.
-func (p *process) output() (string, *workspacesdk.ProcessTruncation) {
-	return p.buf.Output()
+// snapshot returns a consistent pair of output and process info.
+// Holding proc.mu prevents the exit goroutine from updating process
+// state between the output read and the info read.
+func (p *process) snapshot() (string, *workspacesdk.ProcessTruncation, workspacesdk.ProcessInfo) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	output, truncated := p.buf.Output()
+	return output, truncated, workspacesdk.ProcessInfo{
+		ID:         p.id,
+		Command:    p.command,
+		WorkDir:    p.workDir,
+		Background: p.background,
+		Running:    p.running,
+		ExitCode:   p.exitCode,
+		StartedAt:  p.startedAt,
+		ExitedAt:   p.exitedAt,
+	}
 }
 
 // manager tracks processes spawned by the agent.


### PR DESCRIPTION
`handleProcessOutput` read output and status via separate calls (`proc.output()` then `proc.info()`) using different mutexes (`buf.mu` vs `proc.mu`). On a loaded system, the exit goroutine could complete between the two calls, returning a stale buffer snapshot with fresh `running=false` status. This caused `TestProcessLifecycle/OutputExceedsBuffer` to flake on Windows CI when the buffer was captured mid-write (16KB < totalBytes < 32KB, so `OmittedBytes=0`) but the process had already exited.

Replace the two calls with a single `proc.snapshot()` that holds `proc.mu` across both reads. Lock ordering (`proc.mu` then `buf.mu`) is safe; no code path acquires `buf.mu` then `proc.mu`.

Closes https://linear.app/codercom/issue/CODAGT-399

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻