### PR TITLE
test(coderd/x/chatd): wait for settled state in PromoteQueued ordering

### DIFF
--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -10484,20 +10484,12 @@ func TestPromoteQueuedWhileRunningRespectsMessageOrder(t *testing.T) {
 	require.Zero(t, promoteResult.PromotedMessage.ID,
 		"running-case promotion is deferred to auto-promote")
 
-	// PromoteQueued reorders to [B, A, C]. IDs are stable because
-	// only created_at is mutated.
-	queuedAfterPromote, err := db.GetChatQueuedMessages(ctx, chat.ID)
-	require.NoError(t, err)
-	require.Len(t, queuedAfterPromote, 3)
-	require.Equal(t, queueB.QueuedMessage.ID, queuedAfterPromote[0].ID,
-		"promoted message must be first in the queue")
-	require.Equal(t, queueA.QueuedMessage.ID, queuedAfterPromote[1].ID,
-		"non-promoted messages preserve their relative order")
-	require.Equal(t, queueC.QueuedMessage.ID, queuedAfterPromote[2].ID,
-		"non-promoted messages preserve their relative order")
-
-	// Poll for B in history rather than asserting the queue
-	// state, which races the worker's auto-promote pipeline.
+	// Wait for the worker to drain all three queued messages into
+	// chat history, then verify ordering. Reading queue state right
+	// after PromoteQueued races the worker's auto-promote pipeline
+	// (TOCTOU), so we wait for the settled outcome instead.
+	var posB, posA, posC int
+	var foundA, foundB, foundC bool
 	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
 		messages, getErr := db.GetChatMessagesByChatID(ctx, database.GetChatMessagesByChatIDParams{
 			ChatID:  chat.ID,
@@ -10506,7 +10498,8 @@ func TestPromoteQueuedWhileRunningRespectsMessageOrder(t *testing.T) {
 		if getErr != nil {
 			return false
 		}
-		for _, msg := range messages {
+		foundA, foundB, foundC = false, false, false
+		for i, msg := range messages {
 			if msg.Role != database.ChatMessageRoleUser {
 				continue
 			}
@@ -10515,44 +10508,33 @@ func TestPromoteQueuedWhileRunningRespectsMessageOrder(t *testing.T) {
 				return false
 			}
 			for _, part := range parts {
-				if part.Type == codersdk.ChatMessagePartTypeText && part.Text == "B" {
-					return true
+				if part.Type != codersdk.ChatMessagePartTypeText {
+					continue
+				}
+				// Only A, B, C are tracked; other user messages are ignored.
+				switch part.Text {
+				case "A":
+					posA = i
+					foundA = true
+				case "B":
+					posB = i
+					foundB = true
+				case "C":
+					posC = i
+					foundC = true
 				}
 			}
 		}
-		return false
+		return foundA && foundB && foundC
 	}, testutil.IntervalFast,
-		"the promoted message B must appear in chat history")
+		"queued messages not found in chat history: foundA=%v, foundB=%v, foundC=%v", foundA, foundB, foundC)
 
-	// A and C must end up in queue or history, not dropped.
-	remainingIDs := map[int64]bool{}
-	remainingQueue, err := db.GetChatQueuedMessages(ctx, chat.ID)
-	require.NoError(t, err)
-	for _, qm := range remainingQueue {
-		remainingIDs[qm.ID] = true
-	}
-	messages, err := db.GetChatMessagesByChatID(ctx, database.GetChatMessagesByChatIDParams{
-		ChatID:  chat.ID,
-		AfterID: 0,
-	})
-	require.NoError(t, err)
-	promotedTexts := map[string]bool{}
-	for _, msg := range messages {
-		if msg.Role != database.ChatMessageRoleUser {
-			continue
-		}
-		parts, parseErr := chatprompt.ParseContent(msg)
-		require.NoError(t, parseErr)
-		for _, part := range parts {
-			if part.Type == codersdk.ChatMessagePartTypeText {
-				promotedTexts[part.Text] = true
-			}
-		}
-	}
-	require.True(t, remainingIDs[queueA.QueuedMessage.ID] || promotedTexts["A"],
-		"message A must not be lost")
-	require.True(t, remainingIDs[queueC.QueuedMessage.ID] || promotedTexts["C"],
-		"message C must not be lost")
+	// PromoteQueued reorders the queue to [B, A, C], so the worker
+	// processes B first, then A, then C. Verify that ordering.
+	require.Less(t, posB, posA,
+		"promoted message B must appear before A in history")
+	require.Less(t, posA, posC,
+		"non-promoted messages must preserve relative order (A before C)")
 }
 
 // TestFinishActiveChatExternalWaitingInsertsSyntheticResults


### PR DESCRIPTION
`TestPromoteQueuedWhileRunningRespectsMessageOrder` was flaky because it read queue state from the database immediately after `PromoteQueued` returned. The active server worker drains queued messages concurrently, so the DB read races the auto-promote pipeline (TOCTOU).

Instead of asserting intermediate queue state, wait for all three promoted messages to appear in chat history and verify their relative order (B before A before C). This asserts the same invariant (promote reorders B to the front) without reading during the race window.

Closes https://linear.app/codercom/issue/CODAGT-384

<details>
<summary>Proof of method (dlv-based)</summary>

### 1. The TOCTOU race is real

dlv breakpoint on the DB read line (`chatd_test.go:10490`), pausing the test goroutine while the worker runs concurrently:

```
> [Breakpoint 1] chatd_test.go:10490 (hits goroutine(134):1 total:1)
  10489:        time.Sleep(3 * time.Second) // simulate debugger pause
=>10490:        queuedAfterPromote, err := db.GetChatQueuedMessages(ctx, chat.ID)
```

Goroutine listing confirms concurrent worker goroutines:
```
  Goroutine 122 - chatd.go:4701 (*Server).heartbeatLoop [select]
  Goroutine 123 - chatd.go:4619 (*Server).streamJanitorLoop [select]
  Goroutine 124 - chatd.go:4231 (*Server).acquireLoop [select]
* Goroutine 134 - chatd_test.go:10490 TestPromoteQueuedWhileRunning... (thread 2357386)
```

Worker drained all 3 messages during the pause:
```
chatd_test.go:10492:
    Error: "[]" should have 3 item(s), but has 0
--- FAIL: TestPromoteQueuedWhileRunningRespectsMessageOrder (3.43s)
```

### 2. The new assertion catches broken reordering

dlv breakpoint at `chatd.go:2439` with `ReorderChatQueuedMessageToFront` disabled:

```
> [Breakpoint 1] chatd.go:2439 (hits goroutine(110):1 total:1)
  2440:             // PROOF-2: Reorder DISABLED to prove assertion catches it.
  2441:             // rowsAffected, err := tx.ReorderChatQueuedMessageToFront(...)
```

Without reordering, queue stays [A, B, C]. Worker processes A first. New assertion catches it:
```
chatd_test.go:10532:
    Error:    "4" is not less than "2"
    Messages: promoted message B must appear before A in history
--- FAIL: TestPromoteQueuedWhileRunningRespectsMessageOrder (0.46s)
```

### 3. Fixed test passes

```
$ go test ./coderd/x/chatd/ -run TestPromoteQueuedWhileRunningRespectsMessageOrder -race -count=10
ok  github.com/coder/coder/v2/coderd/x/chatd    4.392s
```

Reviewers can verify: `go test ./coderd/x/chatd/ -run TestPromoteQueuedWhileRunningRespectsMessageOrder -race -count=50`

</details>

> Generated by Coder Agents on behalf of @mafredri