### PR TITLE
test(coderd/x/chatd): drain all subscriber events per tick in PromoteQueued tests

### DIFF
--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -9000,27 +9000,32 @@ func TestPromoteQueuedWhileRequiresAction(t *testing.T) {
 		messagesSeen         int
 	)
 	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
-		select {
-		case ev := <-events:
-			if ev.Type != codersdk.ChatStreamEventTypeMessage || ev.Message == nil {
+		for {
+			select {
+			case ev := <-events:
+				if ev.Type != codersdk.ChatStreamEventTypeMessage || ev.Message == nil {
+					continue
+				}
+				messagesSeen++
+				switch ev.Message.Role {
+				case codersdk.ChatMessageRoleTool:
+					if syntheticPublishedAt == 0 {
+						syntheticPublishedAt = messagesSeen
+					}
+				case codersdk.ChatMessageRoleUser:
+					if ev.Message.ID == promoteResult.PromotedMessage.ID {
+						userPublishedAt = messagesSeen
+					}
+				}
+				if syntheticPublishedAt > 0 && userPublishedAt > 0 {
+					return true
+				}
+			default:
 				return false
 			}
-			messagesSeen++
-			switch ev.Message.Role {
-			case codersdk.ChatMessageRoleTool:
-				if syntheticPublishedAt == 0 {
-					syntheticPublishedAt = messagesSeen
-				}
-			case codersdk.ChatMessageRoleUser:
-				if ev.Message.ID == promoteResult.PromotedMessage.ID {
-					userPublishedAt = messagesSeen
-				}
-			}
-			return syntheticPublishedAt > 0 && userPublishedAt > 0
-		default:
-			return false
 		}
 	}, testutil.IntervalFast)
+
 	require.Less(t, syntheticPublishedAt, userPublishedAt,
 		"synthetic tool-result must be published before the promoted user message")
 
@@ -9221,26 +9226,31 @@ func TestPromoteQueuedWhileRequiresActionMixedTools(t *testing.T) {
 		userPublished         bool
 	)
 	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
-		select {
-		case ev := <-events:
-			if ev.Type != codersdk.ChatStreamEventTypeMessage || ev.Message == nil {
-				t.Logf("subscriber consumed non-message event type=%s", ev.Type)
+		for {
+			select {
+			case ev := <-events:
+				if ev.Type != codersdk.ChatStreamEventTypeMessage || ev.Message == nil {
+					t.Logf("subscriber consumed non-message event type=%s", ev.Type)
+					continue
+				}
+				t.Logf("subscriber consumed message id=%d role=%s match_promoted=%t", ev.Message.ID, ev.Message.Role, ev.Message.ID == promoteResult.PromotedMessage.ID)
+				switch ev.Message.Role {
+				case codersdk.ChatMessageRoleTool:
+					syntheticPublishCount++
+				case codersdk.ChatMessageRoleUser:
+					if ev.Message.ID == promoteResult.PromotedMessage.ID {
+						userPublished = true
+					}
+				}
+				if userPublished {
+					return true
+				}
+			default:
 				return false
 			}
-			t.Logf("subscriber consumed message id=%d role=%s match_promoted=%t", ev.Message.ID, ev.Message.Role, ev.Message.ID == promoteResult.PromotedMessage.ID)
-			switch ev.Message.Role {
-			case codersdk.ChatMessageRoleTool:
-				syntheticPublishCount++
-			case codersdk.ChatMessageRoleUser:
-				if ev.Message.ID == promoteResult.PromotedMessage.ID {
-					userPublished = true
-				}
-			}
-			return userPublished
-		default:
-			return false
 		}
 	}, testutil.IntervalFast)
+
 	require.Equal(t, 1, syntheticPublishCount,
 		"only the dynamic tool's synthetic result must be published; the built-in's pre-existing result must not be republished")
 	messages, err := db.GetChatMessagesByChatID(ctx, database.GetChatMessagesByChatIDParams{


### PR DESCRIPTION
The root cause of the `TestPromoteQueuedWhileRequiresActionMixedTools` flake (CODAGT-425) was the subscriber out-of-order durable message delivery bug, fixed by #25433. All five CI failures predate that fix; zero failures since May 18.

This change hardens the subscriber event-drain pattern in both `TestPromoteQueuedWhileRequiresAction` and `TestPromoteQueuedWhileRequiresActionMixedTools`: wrap the channel `select` in a `for` loop so interleaved non-target events (status, queue_update, message_parts) are consumed in the same `Eventually` tick instead of each burning a 25ms interval.

Defense-in-depth for slow CI runners, not a standalone bug fix.

<details>
<summary>Proof chain</summary>

### Root cause

The subscriber merge goroutine tracked deliveries with a monotonic `lastMessageID` cursor. When `PromoteQueued` published two durable messages (synthetic tool result + promoted user message) in rapid succession, PG NOTIFY commit reordering could flip arrival order. The late notify rescanned above its own message ID and silently dropped the message. Fixed in #25433 (ec1e861152).

### CI failures (all pre-#25433)

| Date | CI Run | Platform |
|------|--------|----------|
| May 7 | [25477222206](https://github.com/coder/coder/actions/runs/25477222206) | windows-2022 |
| May 7 | [25524831533](https://github.com/coder/coder/actions/runs/25524831533) | - |
| May 8 | [25578658121](https://github.com/coder/coder/actions/runs/25578658121) | ubuntu-latest |
| May 11 | [25653887987](https://github.com/coder/coder/actions/runs/25653887987) | - |
| May 13 | [25827430566](https://github.com/coder/coder/actions/runs/25827430566) | ubuntu-latest |

PR #25433 merged May 18. Zero failures since.

### Red herring: tool error

The CI log showed `tool_error="workspace agent connector is not configured"` from the builtin `read_file` tool. This is expected in `newActiveTestServer` (no agent connector configured). The error is handled as `TextErrorResponse` (readfile.go:33-34), recorded as `ToolResultOutputContentError` (chatloop.go:1573-1580), and does not prevent the chat from reaching `requires_action`.

### Debugger proof: old vs new pattern mechanism

Delve tracepoints on `TestPromoteQueuedWhileRequiresActionMixedTools`, binary built with `-gcflags='all=-N -l'` (optimizations disabled). Reproduced independently by orchestrator after sub-agent session.

**Old pattern** (bare `select`, one-event-per-tick), goroutine 148:

```
> goroutine(148): .func4(...)    [TP1: entry]
  ev.Type: (unreadable, before select)

> goroutine(148): .func4(...)    [TP2: return false]
  ev.Type: "queue_update"                              ← tick 1 WASTED

> goroutine(148): .func4(...)    [TP1: entry]
  ev.Type: (unreadable)

> goroutine(148): .func4(...)    [TP3: return userPublished]
  userPublished: false                                  ← tick 2, tool msg
  syntheticPublishCount: 1

> goroutine(148): .func4(...)    [TP1: entry]
  ev.Type: (unreadable)

> goroutine(148): .func4(...)    [TP3: return userPublished]
  userPublished: true                                   ← tick 3, done
  syntheticPublishCount: 1
```

TP1 hit 3 times = 3 ticks (75ms minimum). Tick 1 wasted on `queue_update`.

**New pattern** (`for { select { ... } }`, drain-all-per-tick), goroutine 112:

```
> goroutine(112): .func4(...)    [TP1: for-entry]
  ev.Type: (unreadable, before select)

> goroutine(112): .func4(...)    [TP2: continue]
  ev.Type: "queue_update"                              ← drained, loop continues

> goroutine(112): .func4(...)    [TP3: return true]
  userPublished: true                                  ← done in same tick
  syntheticPublishCount: 1
```

TP1 hit 1 time = 1 tick (25ms minimum). TP4 (`default: return false`) never hit.

| Metric | Old pattern | New pattern |
|--------|-------------|-------------|
| Ticks (TP1 hit count) | 3 | 1 |
| Minimum wall time | 75ms | 25ms |
| Ticks wasted on non-message events | 1 | 0 |

### Stress test (with fix, fresh worktree)

```
$ go test -race -count=50 -timeout=600s \
    -run 'TestPromoteQueuedWhileRequiresAction$|TestPromoteQueuedWhileRequiresActionMixedTools$' \
    ./coderd/x/chatd/
ok  github.com/coder/coder/v2/coderd/x/chatd  18.111s
```

50 iterations, zero failures, race detector clean.

### Full package (with fix, fresh worktree)

```
$ go test -race -timeout=600s ./coderd/x/chatd/
ok  github.com/coder/coder/v2/coderd/x/chatd  21.897s
```

### Sibling consistency

All four `case ev := <-events:` sites in `chatd_test.go` now use the `for { select { ... } }` drain pattern:

- Line 1706: pre-existing drain pattern
- Line 7115: pre-existing drain pattern
- Line 9005: updated by this PR
- Line 9231: updated by this PR

</details>

Closes coder/internal#1523
Closes https://linear.app/codercom/issue/CODAGT-425

Disclosure: this change was generated by Coder Agents.

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
