### PR TITLE
fix(agent/agentproc): read process info before output to prevent TOCTOU

### DIFF
--- a/agent/agentproc/api.go
+++ b/agent/agentproc/api.go
@@ -200,8 +200,13 @@ func (api *API) handleProcessOutput(rw http.ResponseWriter, r *http.Request) {
 		// Fall through to read snapshot below.
 	}
 
-	output, truncated := proc.output()
+	// Read info before output to avoid a TOCTOU race. The exit
+	// goroutine completes all buffer writes (cmd.Wait) before
+	// setting running=false, so if info reports the process as
+	// exited, the subsequent output read is guaranteed to reflect
+	// the final buffer state.
 	info := proc.info()
+	output, truncated := proc.output()
 
 	httpapi.Write(ctx, rw, http.StatusOK, workspacesdk.ProcessOutputResponse{
 		Output:    output,


### PR DESCRIPTION
`handleProcessOutput` read `proc.output()` then `proc.info()` using separate locks (`buf.mu` vs `proc.mu`). Between the two reads, the exit goroutine could finish I/O and set `running=false`, pairing a stale buffer snapshot with final process status.

On Windows CI this caused `TestProcessLifecycle/OutputExceedsBuffer` to flake: the buffer was captured mid-write (`OmittedBytes=0`) while info reported the process as exited.

Swap the read order: `info()` first, then `output()`. The exit goroutine completes `cmd.Wait()` (draining all pipe data) before setting `running=false`, so `Running=false` guarantees the subsequent output read reflects the final buffer state.

<details><summary>Proof: dlv-controlled TOCTOU reproduction</summary>

Used dlv to freeze execution between the two reads and mutate process state, proving the race under controlled conditions.

**Buggy order** (output-first, breakpoint between reads):

```
=> 204:    info := proc.info()   // output() already returned

(dlv) print truncated
  OmittedBytes: 0          // stale: captured before mutation
(dlv) print proc.running
  true
(dlv) print proc.buf.totalBytes
  96

# Simulate exit goroutine via dlv:
(dlv) call proc.buf.Write(...)
(dlv) set proc.running = false
(dlv) print proc.buf.totalBytes
  500

# Continue -> info() returns Running=false
# Response: Running=false, OmittedBytes=0  <- TOCTOU proven
```

**Fixed order** (info-first, breakpoint between reads):

```
=> 217:    output, truncated := proc.output()  // info() already returned

(dlv) print info
  Running: true            // captured before mutation

# Same mutation via dlv
# Continue -> output() returns fresh buffer
# Response: Running=true, OmittedBytes=372  <- safe, client polls again
```

</details>

Closes https://linear.app/codercom/issue/CODAGT-399

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻