### PR TITLE
fix(site/e2e): wait for dynamic-parameters WebSocket round-trip in fillParameters

### DIFF
--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -128,14 +128,15 @@ export const createWorkspace = async (
 			? template
 			: `${template.organization}/${template.name}`;
 
-	const socketPromise = page.waitForEvent("websocket", {
-		predicate: (ws) => ws.url().includes("/dynamic-parameters"),
-	});
-	await page.goto(`/templates/${templatePath}/workspace`, {
-		waitUntil: "domcontentloaded",
-	});
+	const [paramsSocket] = await Promise.all([
+		page.waitForEvent("websocket", {
+			predicate: (ws) => ws.url().includes("/dynamic-parameters"),
+		}),
+		page.goto(`/templates/${templatePath}/workspace`, {
+			waitUntil: "domcontentloaded",
+		}),
+	]);
 	await expectUrl(page).toHavePathName(`/templates/${templatePath}/workspace`);
-	const paramsSocket = await socketPromise;
 
 	const name = randomName();
 	await page.getByLabel("name").fill(name);
@@ -439,12 +440,13 @@ export const startWorkspaceWithEphemeralParameters = async (
 		waitUntil: "domcontentloaded",
 	});
 
-	const socketPromise = page.waitForEvent("websocket", {
-		predicate: (ws) => ws.url().includes("/dynamic-parameters"),
-	});
 	await page.getByTestId("workspace-start").click();
-	await page.getByTestId("workspace-parameters").click();
-	const paramsSocket = await socketPromise;
+	const [paramsSocket] = await Promise.all([
+		page.waitForEvent("websocket", {
+			predicate: (ws) => ws.url().includes("/dynamic-parameters"),
+		}),
+		page.getByTestId("workspace-parameters").click(),
+	]);
 
 	await fillParameters(page, richParameters, buildParameters, {
 		paramsSocket,
@@ -1232,13 +1234,12 @@ export const updateWorkspace = async (
 	await page.getByTestId("workspace-update-button").click();
 	await page.getByTestId("confirm-button").click();
 
-	const socketPromise = page.waitForEvent("websocket", {
-		predicate: (ws) => ws.url().includes("/dynamic-parameters"),
-	});
-	await page
-		.getByRole("button", { name: /go to workspace parameters/i })
-		.click();
-	const paramsSocket = await socketPromise;
+	const [paramsSocket] = await Promise.all([
+		page.waitForEvent("websocket", {
+			predicate: (ws) => ws.url().includes("/dynamic-parameters"),
+		}),
+		page.getByRole("button", { name: /go to workspace parameters/i }).click(),
+	]);
 
 	await fillParameters(page, richParameters, buildParameters, {
 		paramsSocket,
@@ -1262,13 +1263,14 @@ export const updateWorkspaceParameters = async (
 ) => {
 	const user = currentUser(page);
 
-	const socketPromise = page.waitForEvent("websocket", {
-		predicate: (ws) => ws.url().includes("/dynamic-parameters"),
-	});
-	await page.goto(`/@${user.username}/${workspaceName}/settings/parameters`, {
-		waitUntil: "domcontentloaded",
-	});
-	const paramsSocket = await socketPromise;
+	const [paramsSocket] = await Promise.all([
+		page.waitForEvent("websocket", {
+			predicate: (ws) => ws.url().includes("/dynamic-parameters"),
+		}),
+		page.goto(`/@${user.username}/${workspaceName}/settings/parameters`, {
+			waitUntil: "domcontentloaded",
+		}),
+	]);
 
 	await fillParameters(page, richParameters, buildParameters, {
 		paramsSocket,

--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -7,8 +7,8 @@ import {
 	type BrowserContext,
 	expect,
 	type Page,
-	type WebSocket as PlaywrightWebSocket,
 	test,
+	type WebSocket,
 } from "@playwright/test";
 import express from "express";
 import capitalize from "lodash/capitalize";
@@ -128,12 +128,14 @@ export const createWorkspace = async (
 			? template
 			: `${template.organization}/${template.name}`;
 
-	const wsPromise = captureDynamicParamsWebSocket(page);
+	const socketPromise = page.waitForEvent("websocket", {
+		predicate: (ws) => ws.url().includes("/dynamic-parameters"),
+	});
 	await page.goto(`/templates/${templatePath}/workspace`, {
 		waitUntil: "domcontentloaded",
 	});
 	await expectUrl(page).toHavePathName(`/templates/${templatePath}/workspace`);
-	const dynamicParamsWS = await wsPromise;
+	const paramsSocket = await socketPromise;
 
 	const name = randomName();
 	await page.getByLabel("name").fill(name);
@@ -143,7 +145,7 @@ export const createWorkspace = async (
 	}
 
 	await fillParameters(page, richParameters, buildParameters, {
-		dynamicParamsWS,
+		paramsSocket,
 	});
 
 	if (useExternalAuth) {
@@ -437,13 +439,15 @@ export const startWorkspaceWithEphemeralParameters = async (
 		waitUntil: "domcontentloaded",
 	});
 
-	const wsPromise = captureDynamicParamsWebSocket(page);
+	const socketPromise = page.waitForEvent("websocket", {
+		predicate: (ws) => ws.url().includes("/dynamic-parameters"),
+	});
 	await page.getByTestId("workspace-start").click();
 	await page.getByTestId("workspace-parameters").click();
-	const dynamicParamsWS = await wsPromise;
+	const paramsSocket = await socketPromise;
 
 	await fillParameters(page, richParameters, buildParameters, {
-		dynamicParamsWS,
+		paramsSocket,
 	});
 
 	await page.getByRole("button", { name: /update and start/i }).click();
@@ -1061,9 +1065,9 @@ const fillParameters = async (
 	page: Page,
 	richParameters: RichParameter[] = [],
 	buildParameters: WorkspaceBuildParameter[] = [],
-	options: { dynamicParamsWS?: PlaywrightWebSocket } = {},
+	options: { paramsSocket?: WebSocket } = {},
 ) => {
-	const { dynamicParamsWS } = options;
+	const { paramsSocket } = options;
 
 	for (const buildParameter of buildParameters) {
 		const richParameter = richParameters.find(
@@ -1084,9 +1088,10 @@ const fillParameters = async (
 			const parameterValue = parameterLabel.getByRole("button", {
 				name: buildParameter.value,
 			});
-			await withDynamicParamsFrame(dynamicParamsWS, () =>
+			await Promise.all([
+				paramsSocket?.waitForEvent("framereceived", { timeout: 15_000 }),
 				parameterValue.click(),
-			);
+			]);
 			continue;
 		}
 
@@ -1094,9 +1099,12 @@ const fillParameters = async (
 			case "bool":
 				{
 					const parameterField = parameterLabel.locator("button");
-					await withDynamicParamsFrame(dynamicParamsWS, () =>
+					await Promise.all([
+						paramsSocket?.waitForEvent("framereceived", {
+							timeout: 15_000,
+						}),
 						parameterField.click(),
-					);
+					]);
 				}
 				break;
 			case "string":
@@ -1107,9 +1115,12 @@ const fillParameters = async (
 					// overwrite an early fill. Re-apply until the desired value
 					// is stable.
 					for (let attempt = 0; attempt < 3; attempt++) {
-						await withDynamicParamsFrame(dynamicParamsWS, () =>
+						await Promise.all([
+							paramsSocket?.waitForEvent("framereceived", {
+								timeout: 15_000,
+							}),
 							parameterField.fill(buildParameter.value),
-						);
+						]);
 						try {
 							await expect(parameterField).toHaveValue(buildParameter.value, {
 								timeout: 1000,
@@ -1128,22 +1139,6 @@ const fillParameters = async (
 				throw new Error("not implemented yet");
 		}
 	}
-};
-
-const captureDynamicParamsWebSocket = (page: Page, timeout = 30_000) =>
-	page.waitForEvent("websocket", {
-		predicate: (ws) => ws.url().includes("/dynamic-parameters"),
-		timeout,
-	});
-
-const withDynamicParamsFrame = async (
-	ws: PlaywrightWebSocket | undefined,
-	action: () => Promise<void>,
-	timeout = 15_000,
-) => {
-	const framePromise = ws?.waitForEvent("framereceived", { timeout });
-	await action();
-	await framePromise;
 };
 
 export const updateTemplate = async (
@@ -1237,14 +1232,16 @@ export const updateWorkspace = async (
 	await page.getByTestId("workspace-update-button").click();
 	await page.getByTestId("confirm-button").click();
 
-	const wsPromise = captureDynamicParamsWebSocket(page);
+	const socketPromise = page.waitForEvent("websocket", {
+		predicate: (ws) => ws.url().includes("/dynamic-parameters"),
+	});
 	await page
 		.getByRole("button", { name: /go to workspace parameters/i })
 		.click();
-	const dynamicParamsWS = await wsPromise;
+	const paramsSocket = await socketPromise;
 
 	await fillParameters(page, richParameters, buildParameters, {
-		dynamicParamsWS,
+		paramsSocket,
 	});
 
 	if (workspaceStatus === "running") {
@@ -1265,14 +1262,16 @@ export const updateWorkspaceParameters = async (
 ) => {
 	const user = currentUser(page);
 
-	const wsPromise = captureDynamicParamsWebSocket(page);
+	const socketPromise = page.waitForEvent("websocket", {
+		predicate: (ws) => ws.url().includes("/dynamic-parameters"),
+	});
 	await page.goto(`/@${user.username}/${workspaceName}/settings/parameters`, {
 		waitUntil: "domcontentloaded",
 	});
-	const dynamicParamsWS = await wsPromise;
+	const paramsSocket = await socketPromise;
 
 	await fillParameters(page, richParameters, buildParameters, {
-		dynamicParamsWS,
+		paramsSocket,
 	});
 
 	if (workspaceStatus === "running") {

--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -432,7 +432,9 @@ export const startWorkspaceWithEphemeralParameters = async (
 
 	await fillParameters(page, richParameters, buildParameters);
 
-	await clickWhenSubmitEnabled(page, /update and start/i);
+	await page
+		.getByRole("button", { name: /update and start/i })
+		.click({ timeout: 15_000 });
 
 	await page.waitForSelector("text=Workspace status: Running", {
 		state: "visible",
@@ -1107,23 +1109,6 @@ const fillParameters = async (
 	}
 };
 
-// clickWhenSubmitEnabled clicks a submit button by accessible name after
-// waiting for it to become enabled. The workspace parameters settings page
-// disables its submit button until a WebSocket round-trip syncs the form
-// values with the backend (see `hasUnsyncedParameters` in
-// `WorkspaceParametersPageViewExperimental`). Under load the round-trip can
-// take longer than the default 5s action timeout, causing flaky failures
-// where the submit click times out on a still-disabled button.
-const clickWhenSubmitEnabled = async (
-	page: Page,
-	name: RegExp | string,
-	timeout = 15_000,
-) => {
-	const button = page.getByRole("button", { name });
-	await expect(button).toBeEnabled({ timeout });
-	await button.click();
-};
-
 export const updateTemplate = async (
 	page: Page,
 	organization: string,
@@ -1222,11 +1207,20 @@ export const updateWorkspace = async (
 	await fillParameters(page, richParameters, buildParameters);
 
 	if (workspaceStatus === "running") {
-		await clickWhenSubmitEnabled(page, /update and restart/i);
+		// The submit button on the workspace parameters settings page stays
+		// disabled until a WebSocket round-trip syncs the form values with
+		// the backend (see `hasUnsyncedParameters` in
+		// `WorkspaceParametersPageViewExperimental`). Under CI load this can
+		// exceed the default 5s action timeout, so wait longer here.
+		await page
+			.getByRole("button", { name: /update and restart/i })
+			.click({ timeout: 15_000 });
 		// Confirmation dialog.
 		await page.getByRole("button", { name: /restart/i }).click();
 	} else {
-		await clickWhenSubmitEnabled(page, /update and start/i);
+		await page
+			.getByRole("button", { name: /update and start/i })
+			.click({ timeout: 15_000 });
 	}
 };
 
@@ -1245,11 +1239,17 @@ export const updateWorkspaceParameters = async (
 	await fillParameters(page, richParameters, buildParameters);
 
 	if (workspaceStatus === "running") {
-		await clickWhenSubmitEnabled(page, /update and restart/i);
+		// See the note in `updateWorkspace` for why this needs a longer
+		// timeout than the default 5s action timeout.
+		await page
+			.getByRole("button", { name: /update and restart/i })
+			.click({ timeout: 15_000 });
 		// Confirmation dialog.
 		await page.getByRole("button", { name: /restart/i }).click();
 	} else {
-		await clickWhenSubmitEnabled(page, /update and start/i);
+		await page
+			.getByRole("button", { name: /update and start/i })
+			.click({ timeout: 15_000 });
 	}
 
 	await page.waitForSelector("text=Workspace status: Running", {

--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -1130,22 +1130,12 @@ const fillParameters = async (
 	}
 };
 
-// captureDynamicParamsWebSocket returns a promise that resolves to the
-// `/api/v2/templateversions/.../dynamic-parameters` WebSocket opened by the
-// workspace create/parameters pages. Call this BEFORE the navigation that
-// triggers the connection.
 const captureDynamicParamsWebSocket = (page: Page, timeout = 30_000) =>
 	page.waitForEvent("websocket", {
 		predicate: (ws) => ws.url().includes("/dynamic-parameters"),
 		timeout,
 	});
 
-// withDynamicParamsFrame runs `action` and waits for the next `framereceived`
-// event on the dynamic-parameters WebSocket. The experimental workspace
-// parameters page keeps the submit button disabled until the WS echo arrives
-// (`hasUnsyncedParameters`), so each parameter change must round-trip before
-// we can submit. Falls back to just running the action when no WS is given
-// (e.g. classic parameter flow).
 const withDynamicParamsFrame = async (
 	ws: PlaywrightWebSocket | undefined,
 	action: () => Promise<void>,

--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -3,7 +3,13 @@ import { randomUUID } from "node:crypto";
 import net from "node:net";
 import path from "node:path";
 import { Duplex } from "node:stream";
-import { type BrowserContext, expect, type Page, test } from "@playwright/test";
+import {
+	type BrowserContext,
+	expect,
+	type Page,
+	type WebSocket as PlaywrightWebSocket,
+	test,
+} from "@playwright/test";
 import express from "express";
 import capitalize from "lodash/capitalize";
 import * as ssh from "ssh2";
@@ -122,10 +128,12 @@ export const createWorkspace = async (
 			? template
 			: `${template.organization}/${template.name}`;
 
+	const wsPromise = captureDynamicParamsWebSocket(page);
 	await page.goto(`/templates/${templatePath}/workspace`, {
 		waitUntil: "domcontentloaded",
 	});
 	await expectUrl(page).toHavePathName(`/templates/${templatePath}/workspace`);
+	const dynamicParamsWS = await wsPromise;
 
 	const name = randomName();
 	await page.getByLabel("name").fill(name);
@@ -134,7 +142,9 @@ export const createWorkspace = async (
 		await page.waitForSelector("form", { state: "visible" });
 	}
 
-	await fillParameters(page, richParameters, buildParameters);
+	await fillParameters(page, richParameters, buildParameters, {
+		dynamicParamsWS,
+	});
 
 	if (useExternalAuth) {
 		// Create a new context for the popup which will be created when clicking the button
@@ -427,14 +437,16 @@ export const startWorkspaceWithEphemeralParameters = async (
 		waitUntil: "domcontentloaded",
 	});
 
+	const wsPromise = captureDynamicParamsWebSocket(page);
 	await page.getByTestId("workspace-start").click();
 	await page.getByTestId("workspace-parameters").click();
+	const dynamicParamsWS = await wsPromise;
 
-	await fillParameters(page, richParameters, buildParameters);
+	await fillParameters(page, richParameters, buildParameters, {
+		dynamicParamsWS,
+	});
 
-	await page
-		.getByRole("button", { name: /update and start/i })
-		.click({ timeout: 15_000 });
+	await page.getByRole("button", { name: /update and start/i }).click();
 
 	await page.waitForSelector("text=Workspace status: Running", {
 		state: "visible",
@@ -1049,7 +1061,10 @@ const fillParameters = async (
 	page: Page,
 	richParameters: RichParameter[] = [],
 	buildParameters: WorkspaceBuildParameter[] = [],
+	options: { dynamicParamsWS?: PlaywrightWebSocket } = {},
 ) => {
+	const { dynamicParamsWS } = options;
+
 	for (const buildParameter of buildParameters) {
 		const richParameter = richParameters.find(
 			(richParam) => richParam.name === buildParameter.name,
@@ -1069,7 +1084,9 @@ const fillParameters = async (
 			const parameterValue = parameterLabel.getByRole("button", {
 				name: buildParameter.value,
 			});
-			await parameterValue.click();
+			await withDynamicParamsFrame(dynamicParamsWS, () =>
+				parameterValue.click(),
+			);
 			continue;
 		}
 
@@ -1077,7 +1094,9 @@ const fillParameters = async (
 			case "bool":
 				{
 					const parameterField = parameterLabel.locator("button");
-					await parameterField.click();
+					await withDynamicParamsFrame(dynamicParamsWS, () =>
+						parameterField.click(),
+					);
 				}
 				break;
 			case "string":
@@ -1088,7 +1107,9 @@ const fillParameters = async (
 					// overwrite an early fill. Re-apply until the desired value
 					// is stable.
 					for (let attempt = 0; attempt < 3; attempt++) {
-						await parameterField.fill(buildParameter.value);
+						await withDynamicParamsFrame(dynamicParamsWS, () =>
+							parameterField.fill(buildParameter.value),
+						);
 						try {
 							await expect(parameterField).toHaveValue(buildParameter.value, {
 								timeout: 1000,
@@ -1107,6 +1128,32 @@ const fillParameters = async (
 				throw new Error("not implemented yet");
 		}
 	}
+};
+
+// captureDynamicParamsWebSocket returns a promise that resolves to the
+// `/api/v2/templateversions/.../dynamic-parameters` WebSocket opened by the
+// workspace create/parameters pages. Call this BEFORE the navigation that
+// triggers the connection.
+const captureDynamicParamsWebSocket = (page: Page, timeout = 30_000) =>
+	page.waitForEvent("websocket", {
+		predicate: (ws) => ws.url().includes("/dynamic-parameters"),
+		timeout,
+	});
+
+// withDynamicParamsFrame runs `action` and waits for the next `framereceived`
+// event on the dynamic-parameters WebSocket. The experimental workspace
+// parameters page keeps the submit button disabled until the WS echo arrives
+// (`hasUnsyncedParameters`), so each parameter change must round-trip before
+// we can submit. Falls back to just running the action when no WS is given
+// (e.g. classic parameter flow).
+const withDynamicParamsFrame = async (
+	ws: PlaywrightWebSocket | undefined,
+	action: () => Promise<void>,
+	timeout = 15_000,
+) => {
+	const framePromise = ws?.waitForEvent("framereceived", { timeout });
+	await action();
+	await framePromise;
 };
 
 export const updateTemplate = async (
@@ -1200,22 +1247,22 @@ export const updateWorkspace = async (
 	await page.getByTestId("workspace-update-button").click();
 	await page.getByTestId("confirm-button").click();
 
+	const wsPromise = captureDynamicParamsWebSocket(page);
 	await page
 		.getByRole("button", { name: /go to workspace parameters/i })
 		.click();
+	const dynamicParamsWS = await wsPromise;
 
-	await fillParameters(page, richParameters, buildParameters);
+	await fillParameters(page, richParameters, buildParameters, {
+		dynamicParamsWS,
+	});
 
 	if (workspaceStatus === "running") {
-		await page
-			.getByRole("button", { name: /update and restart/i })
-			.click({ timeout: 15_000 });
+		await page.getByRole("button", { name: /update and restart/i }).click();
 		// Confirmation dialog.
 		await page.getByRole("button", { name: /restart/i }).click();
 	} else {
-		await page
-			.getByRole("button", { name: /update and start/i })
-			.click({ timeout: 15_000 });
+		await page.getByRole("button", { name: /update and start/i }).click();
 	}
 };
 
@@ -1227,22 +1274,23 @@ export const updateWorkspaceParameters = async (
 	buildParameters: WorkspaceBuildParameter[] = [],
 ) => {
 	const user = currentUser(page);
+
+	const wsPromise = captureDynamicParamsWebSocket(page);
 	await page.goto(`/@${user.username}/${workspaceName}/settings/parameters`, {
 		waitUntil: "domcontentloaded",
 	});
+	const dynamicParamsWS = await wsPromise;
 
-	await fillParameters(page, richParameters, buildParameters);
+	await fillParameters(page, richParameters, buildParameters, {
+		dynamicParamsWS,
+	});
 
 	if (workspaceStatus === "running") {
-		await page
-			.getByRole("button", { name: /update and restart/i })
-			.click({ timeout: 15_000 });
+		await page.getByRole("button", { name: /update and restart/i }).click();
 		// Confirmation dialog.
 		await page.getByRole("button", { name: /restart/i }).click();
 	} else {
-		await page
-			.getByRole("button", { name: /update and start/i })
-			.click({ timeout: 15_000 });
+		await page.getByRole("button", { name: /update and start/i }).click();
 	}
 
 	await page.waitForSelector("text=Workspace status: Running", {

--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -1207,11 +1207,6 @@ export const updateWorkspace = async (
 	await fillParameters(page, richParameters, buildParameters);
 
 	if (workspaceStatus === "running") {
-		// The submit button on the workspace parameters settings page stays
-		// disabled until a WebSocket round-trip syncs the form values with
-		// the backend (see `hasUnsyncedParameters` in
-		// `WorkspaceParametersPageViewExperimental`). Under CI load this can
-		// exceed the default 5s action timeout, so wait longer here.
 		await page
 			.getByRole("button", { name: /update and restart/i })
 			.click({ timeout: 15_000 });
@@ -1239,8 +1234,6 @@ export const updateWorkspaceParameters = async (
 	await fillParameters(page, richParameters, buildParameters);
 
 	if (workspaceStatus === "running") {
-		// See the note in `updateWorkspace` for why this needs a longer
-		// timeout than the default 5s action timeout.
 		await page
 			.getByRole("button", { name: /update and restart/i })
 			.click({ timeout: 15_000 });

--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -432,7 +432,7 @@ export const startWorkspaceWithEphemeralParameters = async (
 
 	await fillParameters(page, richParameters, buildParameters);
 
-	await page.getByRole("button", { name: /update and start/i }).click();
+	await clickWhenSubmitEnabled(page, /update and start/i);
 
 	await page.waitForSelector("text=Workspace status: Running", {
 		state: "visible",
@@ -1107,6 +1107,23 @@ const fillParameters = async (
 	}
 };
 
+// clickWhenSubmitEnabled clicks a submit button by accessible name after
+// waiting for it to become enabled. The workspace parameters settings page
+// disables its submit button until a WebSocket round-trip syncs the form
+// values with the backend (see `hasUnsyncedParameters` in
+// `WorkspaceParametersPageViewExperimental`). Under load the round-trip can
+// take longer than the default 5s action timeout, causing flaky failures
+// where the submit click times out on a still-disabled button.
+const clickWhenSubmitEnabled = async (
+	page: Page,
+	name: RegExp | string,
+	timeout = 15_000,
+) => {
+	const button = page.getByRole("button", { name });
+	await expect(button).toBeEnabled({ timeout });
+	await button.click();
+};
+
 export const updateTemplate = async (
 	page: Page,
 	organization: string,
@@ -1205,11 +1222,11 @@ export const updateWorkspace = async (
 	await fillParameters(page, richParameters, buildParameters);
 
 	if (workspaceStatus === "running") {
-		await page.getByRole("button", { name: /update and restart/i }).click();
+		await clickWhenSubmitEnabled(page, /update and restart/i);
 		// Confirmation dialog.
 		await page.getByRole("button", { name: /restart/i }).click();
 	} else {
-		await page.getByRole("button", { name: /update and start/i }).click();
+		await clickWhenSubmitEnabled(page, /update and start/i);
 	}
 };
 
@@ -1228,11 +1245,11 @@ export const updateWorkspaceParameters = async (
 	await fillParameters(page, richParameters, buildParameters);
 
 	if (workspaceStatus === "running") {
-		await page.getByRole("button", { name: /update and restart/i }).click();
+		await clickWhenSubmitEnabled(page, /update and restart/i);
 		// Confirmation dialog.
 		await page.getByRole("button", { name: /restart/i }).click();
 	} else {
-		await page.getByRole("button", { name: /update and start/i }).click();
+		await clickWhenSubmitEnabled(page, /update and start/i);
 	}
 
 	await page.waitForSelector("text=Workspace status: Running", {


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

## Problem

The `update workspace with ephemeral parameter enabled` e2e test has been flaking with a `locator.click` timeout on `getByRole('button', { name: /update and restart/i })` because the button stays `disabled` past the default 5s `actionTimeout`:

```
TimeoutError: locator.click: Timeout 5000ms exceeded.
Call log:
  - waiting for getByRole('button', { name: /update and restart/i })
  - locator resolved to <button disabled type="submit" ...>Update and restart</button>
  - attempting click action
    - element is not enabled
    at updateWorkspaceParameters (site/e2e/helpers.ts:1231:67)
    at site/e2e/tests/workspaces/updateWorkspace.spec.ts:147:2
```

## Root cause

New templates use the experimental workspace parameters flow (`WorkspaceParametersPageViewExperimental`), which keeps its submit button disabled while the form values are out of sync with the backend:

```tsx
const hasUnsyncedParameters = (form.values.rich_parameter_values ?? []).some(
  (formParam) => {
    const responseParam = parameters.find((p) => p.name === formParam.name);
    if (!responseParam) return true;
    const responseValue = responseParam.value.valid
      ? responseParam.value.value
      : "";
    return formParam.value !== responseValue;
  },
);

<Button
  type="submit"
  disabled={isSubmitting || disabled || hasUnsyncedParameters || /* diagnostics */}
>
  {submitLabel}
</Button>
```

When `fillParameters` toggles the ephemeral switch, the form updates locally and a debounced WebSocket request is sent to the backend. The submit button only becomes enabled once the WebSocket response confirms the new value. Under CI load this round trip can exceed Playwright's default 5s `actionTimeout`, so `click()` times out on a disabled button.

## Fix

Wait deterministically for the dynamic-parameters WebSocket round-trip instead of relying on a bumped timeout.

- `captureDynamicParamsWebSocket(page)` registers a `page.waitForEvent('websocket', { predicate })` for `/api/v2/templateversions/.../dynamic-parameters`. Helpers call it BEFORE the navigation that opens the connection and resolve the handle before `fillParameters`.
- `withDynamicParamsFrame(ws, action)` wraps each parameter interaction in `ws.waitForEvent('framereceived')`, so we only proceed once the backend has echoed the change. By the time `fillParameters` returns, `hasUnsyncedParameters` is `false` and the submit button is enabled, no extra `click` timeout needed.
- Threaded through `createWorkspace`, `startWorkspaceWithEphemeralParameters`, `updateWorkspace`, and `updateWorkspaceParameters`. The `ws` arg on `fillParameters` is optional so the classic flow (and any future caller without a WS) keeps working unchanged.

Fixes [DEVEX-329](https://linear.app/codercom/issue/DEVEX-329/flake-test-e2e-updateworkspacespects-update-workspace-with-ephemeral) / coder/internal#824.

<details>
<summary>Decision log</summary>

- **Why per-interaction WS waiting vs. one bigger wait at the end?** Each parameter change triggers its own request/response on the WS, and the input retry loop in `fillParameters` already re-applies values until they stick. Wrapping each interaction keeps that loop honest and avoids ambiguity about which response we are waiting for.
- **Why not `expect(submit).toBeEnabled({ timeout })`?** That still relies on a timeout and on the button being a faithful proxy for "form is synced". The WS frame is the actual signal that drives `hasUnsyncedParameters`, so waiting on it removes the race instead of widening the window.
- **Why opt-in via an options bag?** `fillParameters` is shared with flows that may not run on the dynamic-params page (or any future caller that doesn't have a WS handle). The optional `dynamicParamsWS` keeps the helper backward-compatible.

</details>