### PR TITLE
fix(agent/agentcontextconfig): isolate TestContextPartsFromDir from host HOME

### DIFF
--- a/agent/agentcontextconfig/api_test.go
+++ b/agent/agentcontextconfig/api_test.go
@@ -42,8 +42,11 @@ func writeSkillMetaFile(t *testing.T, dir, name, description string) string {
 	return writeSkillMetaFileInRoot(t, filepath.Join(dir, ".agents", "skills"), name, description)
 }
 
+//nolint:paralleltest,tparallel // Uses t.Setenv to isolate HOME.
 func TestContextPartsFromDir(t *testing.T) {
-	t.Parallel()
+	// Prevent ~/.coder/skills on the host from leaking into results.
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
 
 	t.Run("ReturnsInstructionFilePart", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
`ContextPartsFromDir` scans `~/.coder/skills` via `DefaultSkillsDir`. On dogfood machines with real skills installed, these leaked into test results, causing `ReturnsEmptyForEmptyDir`, `ReturnsInstructionFilePart`, and `ReturnsCombinedResults` to fail.

Set `HOME`/`USERPROFILE` to temp dirs on the parent test so the `~` expansion resolves to an empty directory. Subtests remain parallel.

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻