### PR TITLE
test: add integration tests for gitlab git provider

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@ agent/agentcontainers/acmock/acmock.go linguist-generated=true
 agent/agentcontainers/dcspec/dcspec_gen.go linguist-generated=true
 agent/agentcontainers/testdata/devcontainercli/*/*.log linguist-generated=true
 coderd/apidoc/docs.go linguist-generated=true
+coderd/externalauth/gitprovider/testdata/*/*/*.yaml linguist-generated=true
 docs/reference/api/*.md linguist-generated=true
 docs/reference/cli/*.md linguist-generated=true
 coderd/apidoc/swagger.json linguist-generated=true

--- a/.github/workflows/typos.toml
+++ b/.github/workflows/typos.toml
@@ -61,4 +61,6 @@ extend-exclude = [
 	"agent/agentcontainers/testdata/devcontainercli/**",
 	# aibridge fixtures contain truncated streaming chunks that look like typos
 	"aibridge/fixtures/**",
+	# go-vcr cassettes contain real API responses with 3rd-party content
+	"coderd/externalauth/gitprovider/testdata/**",
 ]

--- a/coderd/externalauth/gitprovider/gitlab_integration_test.go
+++ b/coderd/externalauth/gitprovider/gitlab_integration_test.go
@@ -1,0 +1,817 @@
+package gitprovider_test
+
+import (
+	"net/http"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/dnaeon/go-vcr.v4/pkg/cassette"
+	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
+
+	"github.com/coder/coder/v2/coderd/externalauth/gitprovider"
+	"github.com/coder/coder/v2/testutil"
+)
+
+// newGitLabVCR creates a go-vcr recorder for GitLab integration tests.
+// In replay mode (default), it serves responses from the cassette file.
+// When GITLAB_UPDATE_GOLDEN=true, it records live responses to the cassette.
+func newGitLabVCR(t *testing.T, cassetteName string) *recorder.Recorder {
+	t.Helper()
+
+	mode := recorder.ModeReplayOnly
+	if update, _ := strconv.ParseBool(os.Getenv("GITLAB_UPDATE_GOLDEN")); update {
+		mode = recorder.ModeRecordOnly
+	}
+
+	rec, err := recorder.New(
+		"testdata/gitlab_cassettes/"+cassetteName,
+		recorder.WithMode(mode),
+		recorder.WithSkipRequestLatency(true),
+		// Match only on method + URL; the default matcher is too strict
+		// (compares proto, all headers, etc.) and breaks replay.
+		// TODO: consider verifying that an Authorization header is present
+		// during replay to catch auth-wiring regressions.
+		recorder.WithMatcher(func(r *http.Request, i cassette.Request) bool {
+			return r.Method == i.Method && r.URL.String() == i.URL
+		}),
+		// Strip headers down to an allowlist to reduce cassette noise.
+		recorder.WithHook(func(i *cassette.Interaction) error {
+			allowedRequestHeaders := map[string]struct{}{
+				"Accept":       {},
+				"Content-Type": {},
+			}
+			for h := range i.Request.Headers {
+				if _, ok := allowedRequestHeaders[h]; !ok {
+					i.Request.Headers[h] = []string{"stripped"}
+				}
+			}
+
+			allowedResponseHeaders := map[string]struct{}{
+				"Content-Type": {},
+				"X-Total":      {},
+			}
+			for h := range i.Response.Headers {
+				if _, ok := allowedResponseHeaders[h]; !ok {
+					i.Response.Headers[h] = []string{"stripped"}
+				}
+			}
+			return nil
+		}, recorder.AfterCaptureHook),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, rec.Stop())
+	})
+
+	return rec
+}
+
+// TestGitLabIntegration exercises every gitprovider.Provider method
+// against recorded GitLab API responses (go-vcr cassettes).
+//
+// To update cassettes from live GitLab:
+//
+//	GITLAB_UPDATE_GOLDEN=true GITLAB_TOKEN=<pat> go test ./coderd/externalauth/gitprovider/ -run TestGitLabIntegration -count=1
+//
+// Fixtures:
+//
+//  1. https://gitlab.com/test-group9945421/test-project/-/merge_requests/3
+//     Simple namespace (single-level group).
+//     State: open. Same-repo MR, 1 file, mergeable.
+//
+//  2. https://gitlab.com/test-group9945421/test-project/-/merge_requests/2
+//     Simple namespace (single-level group).
+//     State: open. Same-repo MR, 1 file, has conflicts.
+//
+//  3. https://gitlab.com/test-group9945421/test-subgroup/another-test-project/-/merge_requests/1
+//     Nested group (multi-level namespace: test-group9945421/test-subgroup).
+//     State: merged. Same-repo MR, 1 file. Source branch deleted after merge.
+//
+//  4. https://gitlab.com/test-group9945421/test-subgroup/another-test-project/-/merge_requests/3
+//     Nested group. State: closed (not merged). From a fork.
+//     Source branch "forked" does not exist on the target project.
+func TestGitLabIntegration(t *testing.T) {
+	t.Parallel()
+
+	apiURL := "https://gitlab.com"
+
+	// Token is only used when recording (GITLAB_UPDATE_GOLDEN=true).
+	token := os.Getenv("GITLAB_TOKEN")
+
+	// URL parsing tests don't need VCR (no API calls).
+	provider, err := gitprovider.New("gitlab", apiURL, http.DefaultClient)
+	require.NoError(t, err)
+	require.NotNil(t, provider, "gitprovider.New returned nil for \"gitlab\"")
+
+	// --- URL parsing (no API calls) ---
+
+	t.Run("ParseRepositoryOrigin", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name             string
+			raw              string
+			expectOK         bool
+			expectOwner      string
+			expectRepo       string
+			expectNormalized string
+		}{
+			{
+				name:             "HTTPS simple",
+				raw:              "https://gitlab.com/test-group9945421/test-project.git",
+				expectOK:         true,
+				expectOwner:      "test-group9945421",
+				expectRepo:       "test-project",
+				expectNormalized: "https://gitlab.com/test-group9945421/test-project",
+			},
+			{
+				name:             "HTTPS no .git",
+				raw:              "https://gitlab.com/test-group9945421/test-project",
+				expectOK:         true,
+				expectOwner:      "test-group9945421",
+				expectRepo:       "test-project",
+				expectNormalized: "https://gitlab.com/test-group9945421/test-project",
+			},
+			{
+				name:             "HTTPS trailing slash",
+				raw:              "https://gitlab.com/test-group9945421/test-project/",
+				expectOK:         true,
+				expectOwner:      "test-group9945421",
+				expectRepo:       "test-project",
+				expectNormalized: "https://gitlab.com/test-group9945421/test-project",
+			},
+			{
+				name:             "SSH",
+				raw:              "git@gitlab.com:test-group9945421/test-project.git",
+				expectOK:         true,
+				expectOwner:      "test-group9945421",
+				expectRepo:       "test-project",
+				expectNormalized: "https://gitlab.com/test-group9945421/test-project",
+			},
+			{
+				name:             "SSH prefix",
+				raw:              "ssh://git@gitlab.com/test-group9945421/test-project.git",
+				expectOK:         true,
+				expectOwner:      "test-group9945421",
+				expectRepo:       "test-project",
+				expectNormalized: "https://gitlab.com/test-group9945421/test-project",
+			},
+			{
+				name:             "Nested group HTTPS",
+				raw:              "https://gitlab.com/test-group9945421/test-subgroup/another-test-project.git",
+				expectOK:         true,
+				expectOwner:      "test-group9945421/test-subgroup",
+				expectRepo:       "another-test-project",
+				expectNormalized: "https://gitlab.com/test-group9945421/test-subgroup/another-test-project",
+			},
+			{
+				name:             "Nested group HTTPS no .git",
+				raw:              "https://gitlab.com/test-group9945421/test-subgroup/another-test-project",
+				expectOK:         true,
+				expectOwner:      "test-group9945421/test-subgroup",
+				expectRepo:       "another-test-project",
+				expectNormalized: "https://gitlab.com/test-group9945421/test-subgroup/another-test-project",
+			},
+			{
+				name:             "Nested group SSH",
+				raw:              "git@gitlab.com:test-group9945421/test-subgroup/another-test-project.git",
+				expectOK:         true,
+				expectOwner:      "test-group9945421/test-subgroup",
+				expectRepo:       "another-test-project",
+				expectNormalized: "https://gitlab.com/test-group9945421/test-subgroup/another-test-project",
+			},
+			{
+				name:             "Nested group SSH prefix",
+				raw:              "ssh://git@gitlab.com/test-group9945421/test-subgroup/another-test-project.git",
+				expectOK:         true,
+				expectOwner:      "test-group9945421/test-subgroup",
+				expectRepo:       "another-test-project",
+				expectNormalized: "https://gitlab.com/test-group9945421/test-subgroup/another-test-project",
+			},
+			{
+				name:     "GitHub does not match",
+				raw:      "https://github.com/coder/coder",
+				expectOK: false,
+			},
+			{
+				name:     "Empty string",
+				raw:      "",
+				expectOK: false,
+			},
+			{
+				name:     "Not a URL",
+				raw:      "not-a-url",
+				expectOK: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				owner, repo, normalized, ok := provider.ParseRepositoryOrigin(tt.raw)
+				assert.Equal(t, tt.expectOK, ok)
+				if tt.expectOK {
+					assert.Equal(t, tt.expectOwner, owner)
+					assert.Equal(t, tt.expectRepo, repo)
+					assert.Equal(t, tt.expectNormalized, normalized)
+				}
+			})
+		}
+	})
+
+	t.Run("ParsePullRequestURL", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name         string
+			raw          string
+			expectOK     bool
+			expectOwner  string
+			expectRepo   string
+			expectNumber int
+		}{
+			{
+				name:         "Simple namespace",
+				raw:          "https://gitlab.com/test-group9945421/test-project/-/merge_requests/3",
+				expectOK:     true,
+				expectOwner:  "test-group9945421",
+				expectRepo:   "test-project",
+				expectNumber: 3,
+			},
+			{
+				name:         "Nested group",
+				raw:          "https://gitlab.com/test-group9945421/test-subgroup/another-test-project/-/merge_requests/1",
+				expectOK:     true,
+				expectOwner:  "test-group9945421/test-subgroup",
+				expectRepo:   "another-test-project",
+				expectNumber: 1,
+			},
+			{
+				name:         "Nested group second MR",
+				raw:          "https://gitlab.com/test-group9945421/test-subgroup/another-test-project/-/merge_requests/3",
+				expectOK:     true,
+				expectOwner:  "test-group9945421/test-subgroup",
+				expectRepo:   "another-test-project",
+				expectNumber: 3,
+			},
+			{
+				name:         "With query string",
+				raw:          "https://gitlab.com/test-group9945421/test-project/-/merge_requests/3?tab=diffs",
+				expectOK:     true,
+				expectOwner:  "test-group9945421",
+				expectRepo:   "test-project",
+				expectNumber: 3,
+			},
+			{
+				name:         "With fragment",
+				raw:          "https://gitlab.com/test-group9945421/test-subgroup/another-test-project/-/merge_requests/1#note_123",
+				expectOK:     true,
+				expectOwner:  "test-group9945421/test-subgroup",
+				expectRepo:   "another-test-project",
+				expectNumber: 1,
+			},
+			{
+				name:         "With path suffix (diffs tab)",
+				raw:          "https://gitlab.com/test-group9945421/test-subgroup/another-test-project/-/merge_requests/3/diffs",
+				expectOK:     true,
+				expectOwner:  "test-group9945421/test-subgroup",
+				expectRepo:   "another-test-project",
+				expectNumber: 3,
+			},
+			{
+				name:     "GitHub PR does not match",
+				raw:      "https://github.com/coder/coder/pull/123",
+				expectOK: false,
+			},
+			{
+				name:     "Not a MR URL",
+				raw:      "https://gitlab.com/test-group9945421/test-project/-/issues/1",
+				expectOK: false,
+			},
+			{
+				name:     "Empty string",
+				raw:      "",
+				expectOK: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				ref, ok := provider.ParsePullRequestURL(tt.raw)
+				assert.Equal(t, tt.expectOK, ok)
+				if tt.expectOK {
+					assert.Equal(t, tt.expectOwner, ref.Owner)
+					assert.Equal(t, tt.expectRepo, ref.Repo)
+					assert.Equal(t, tt.expectNumber, ref.Number)
+				}
+			})
+		}
+	})
+
+	t.Run("NormalizePullRequestURL", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name     string
+			raw      string
+			expected string
+		}{
+			{
+				name:     "Simple, already normalized",
+				raw:      "https://gitlab.com/test-group9945421/test-project/-/merge_requests/3",
+				expected: "https://gitlab.com/test-group9945421/test-project/-/merge_requests/3",
+			},
+			{
+				name:     "Simple with query and fragment",
+				raw:      "https://gitlab.com/test-group9945421/test-project/-/merge_requests/3?tab=diffs#note_123",
+				expected: "https://gitlab.com/test-group9945421/test-project/-/merge_requests/3",
+			},
+			{
+				name:     "Nested group with query",
+				raw:      "https://gitlab.com/test-group9945421/test-subgroup/another-test-project/-/merge_requests/1?diff_id=1234",
+				expected: "https://gitlab.com/test-group9945421/test-subgroup/another-test-project/-/merge_requests/1",
+			},
+			{
+				name:     "Nested group with path suffix",
+				raw:      "https://gitlab.com/test-group9945421/test-subgroup/another-test-project/-/merge_requests/3/diffs",
+				expected: "https://gitlab.com/test-group9945421/test-subgroup/another-test-project/-/merge_requests/3",
+			},
+			{
+				name:     "Not a MR URL",
+				raw:      "https://example.com/foo",
+				expected: "",
+			},
+			{
+				name:     "Empty string",
+				raw:      "",
+				expected: "",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				got := provider.NormalizePullRequestURL(tt.raw)
+				assert.Equal(t, tt.expected, got)
+			})
+		}
+	})
+
+	t.Run("BuildBranchURL", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name     string
+			owner    string
+			repo     string
+			branch   string
+			expected string
+		}{
+			{
+				name:     "Simple namespace",
+				owner:    "test-group9945421",
+				repo:     "test-project",
+				branch:   "main",
+				expected: "https://gitlab.com/test-group9945421/test-project/-/tree/main",
+			},
+			{
+				name:     "Nested group",
+				owner:    "test-group9945421/test-subgroup",
+				repo:     "another-test-project",
+				branch:   "main",
+				expected: "https://gitlab.com/test-group9945421/test-subgroup/another-test-project/-/tree/main",
+			},
+			{
+				name:     "Branch with special name",
+				owner:    "test-group9945421/test-subgroup",
+				repo:     "another-test-project",
+				branch:   "johnstcn-main-patch-54711",
+				expected: "https://gitlab.com/test-group9945421/test-subgroup/another-test-project/-/tree/johnstcn-main-patch-54711",
+			},
+			{
+				name:     "Empty owner",
+				owner:    "",
+				repo:     "test-project",
+				branch:   "main",
+				expected: "",
+			},
+			{
+				name:     "Empty repo",
+				owner:    "test-group9945421",
+				repo:     "",
+				branch:   "main",
+				expected: "",
+			},
+			{
+				name:     "Empty branch",
+				owner:    "test-group9945421",
+				repo:     "test-project",
+				branch:   "",
+				expected: "",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				got := provider.BuildBranchURL(tt.owner, tt.repo, tt.branch)
+				assert.Equal(t, tt.expected, got)
+			})
+		}
+	})
+
+	t.Run("BuildRepositoryURL", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name     string
+			owner    string
+			repo     string
+			expected string
+		}{
+			{
+				name:     "Simple namespace",
+				owner:    "test-group9945421",
+				repo:     "test-project",
+				expected: "https://gitlab.com/test-group9945421/test-project",
+			},
+			{
+				name:     "Nested group",
+				owner:    "test-group9945421/test-subgroup",
+				repo:     "another-test-project",
+				expected: "https://gitlab.com/test-group9945421/test-subgroup/another-test-project",
+			},
+			{
+				name:     "Empty owner",
+				owner:    "",
+				repo:     "test-project",
+				expected: "",
+			},
+			{
+				name:     "Empty repo",
+				owner:    "test-group9945421",
+				repo:     "",
+				expected: "",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				got := provider.BuildRepositoryURL(tt.owner, tt.repo)
+				assert.Equal(t, tt.expected, got)
+			})
+		}
+	})
+
+	t.Run("BuildPullRequestURL", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name     string
+			ref      gitprovider.PRRef
+			expected string
+		}{
+			{
+				name:     "Simple namespace",
+				ref:      gitprovider.PRRef{Owner: "test-group9945421", Repo: "test-project", Number: 3},
+				expected: "https://gitlab.com/test-group9945421/test-project/-/merge_requests/3",
+			},
+			{
+				name:     "Nested group",
+				ref:      gitprovider.PRRef{Owner: "test-group9945421/test-subgroup", Repo: "another-test-project", Number: 1},
+				expected: "https://gitlab.com/test-group9945421/test-subgroup/another-test-project/-/merge_requests/1",
+			},
+			{
+				name:     "Empty owner",
+				ref:      gitprovider.PRRef{Owner: "", Repo: "test-project", Number: 3},
+				expected: "",
+			},
+			{
+				name:     "Empty repo",
+				ref:      gitprovider.PRRef{Owner: "test-group9945421", Repo: "", Number: 3},
+				expected: "",
+			},
+			{
+				name:     "Zero number",
+				ref:      gitprovider.PRRef{Owner: "test-group9945421", Repo: "test-project", Number: 0},
+				expected: "",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				got := provider.BuildPullRequestURL(tt.ref)
+				assert.Equal(t, tt.expected, got)
+			})
+		}
+	})
+
+	// --- API calls (use VCR cassettes) ---
+
+	t.Run("FetchPullRequestStatus", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name                string
+			ref                 gitprovider.PRRef
+			expectState         gitprovider.PRState
+			expectAuthor        string
+			expectHead          string
+			expectBase          string
+			expectBranch        string
+			expectTitle         string
+			expectDraft         bool
+			expectChanges       int32
+			expectApproved      bool
+			expectReviewerCount int32
+			expectChangesReq    bool
+		}{
+			{
+				name:                "open_mergeable",
+				ref:                 gitprovider.PRRef{Owner: "test-group9945421", Repo: "test-project", Number: 3},
+				expectState:         gitprovider.PRStateOpen,
+				expectAuthor:        "johnstcn",
+				expectHead:          "da57fca657e02c1fbe131402f927d134a34b257b",
+				expectBase:          "main",
+				expectBranch:        "johnstcn-main-patch-98822",
+				expectTitle:         "Open mergeable",
+				expectDraft:         false,
+				expectChanges:       1,
+				expectApproved:      true,
+				expectReviewerCount: 0,
+				expectChangesReq:    false,
+			},
+			{
+				name:                "open_with_conflicts",
+				ref:                 gitprovider.PRRef{Owner: "test-group9945421", Repo: "test-project", Number: 2},
+				expectState:         gitprovider.PRStateOpen,
+				expectAuthor:        "johnstcn",
+				expectHead:          "642379758fa148ff24cba5f676226a3f8e560d73",
+				expectBase:          "main",
+				expectBranch:        "johnstcn-main-patch-84369",
+				expectTitle:         "Open with conflicts",
+				expectDraft:         false,
+				expectChanges:       1,
+				expectApproved:      true,
+				expectReviewerCount: 0,
+				expectChangesReq:    false,
+			},
+			{
+				name:                "nested_merged",
+				ref:                 gitprovider.PRRef{Owner: "test-group9945421/test-subgroup", Repo: "another-test-project", Number: 1},
+				expectState:         gitprovider.PRStateMerged,
+				expectAuthor:        "johnstcn",
+				expectHead:          "ff919f3dc418e4fbffb6fbded7b4c9ae60a4531b",
+				expectBase:          "main",
+				expectBranch:        "johnstcn-main-patch-54711",
+				expectTitle:         "Nested merged",
+				expectDraft:         false,
+				expectChanges:       1,
+				expectApproved:      true,
+				expectReviewerCount: 0,
+				expectChangesReq:    false,
+			},
+			{
+				name:                "nested_closed_from_fork",
+				ref:                 gitprovider.PRRef{Owner: "test-group9945421/test-subgroup", Repo: "another-test-project", Number: 3},
+				expectState:         gitprovider.PRStateClosed,
+				expectAuthor:        "johnstcn",
+				expectHead:          "6b743c6728fa248e3654657e0e576eafcf472953",
+				expectBase:          "main",
+				expectBranch:        "forked",
+				expectTitle:         "Nested closed from fork",
+				expectDraft:         false,
+				expectChanges:       1,
+				expectApproved:      true,
+				expectReviewerCount: 0,
+				expectChangesReq:    false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				ctx := testutil.Context(t, testutil.WaitLong)
+
+				rec := newGitLabVCR(t, "FetchPullRequestStatus/"+tt.name)
+				vcrProvider, err := gitprovider.New("gitlab", apiURL, rec.GetDefaultClient())
+				require.NoError(t, err)
+				require.NotNil(t, vcrProvider)
+
+				status, err := vcrProvider.FetchPullRequestStatus(ctx, token, tt.ref)
+				require.NoError(t, err)
+				require.NotNil(t, status)
+
+				assert.Equal(t, tt.expectState, status.State)
+				assert.Equal(t, tt.expectDraft, status.Draft)
+				assert.Equal(t, tt.ref.Number, status.PRNumber)
+				assert.False(t, status.FetchedAt.IsZero())
+				assert.WithinDuration(t, time.Now(), status.FetchedAt, 10*time.Second)
+
+				// Fields that are always populated.
+				assert.NotEmpty(t, status.Title)
+				assert.NotEmpty(t, status.HeadSHA)
+				assert.NotEmpty(t, status.HeadBranch)
+				assert.NotEmpty(t, status.BaseBranch)
+				assert.NotEmpty(t, status.AuthorLogin)
+
+				// Exact assertions for publicly-verifiable fixtures.
+				if tt.expectAuthor != "" {
+					assert.Equal(t, tt.expectAuthor, status.AuthorLogin)
+				}
+				if tt.expectHead != "" {
+					assert.Equal(t, tt.expectHead, status.HeadSHA)
+				}
+				if tt.expectBase != "" {
+					assert.Equal(t, tt.expectBase, status.BaseBranch)
+				}
+				if tt.expectBranch != "" {
+					assert.Equal(t, tt.expectBranch, status.HeadBranch)
+				}
+				if tt.expectTitle != "" {
+					assert.Equal(t, tt.expectTitle, status.Title)
+				}
+				if tt.expectChanges > 0 {
+					assert.Equal(t, tt.expectChanges, status.DiffStats.ChangedFiles)
+				}
+
+				// Approval-related fields populated from GitLab approvals endpoint.
+				assert.Equal(t, tt.expectApproved, status.Approved)
+				assert.Equal(t, tt.expectReviewerCount, status.ReviewerCount)
+				assert.Equal(t, tt.expectChangesReq, status.ChangesRequested)
+			})
+		}
+	})
+
+	t.Run("FetchPullRequestDiff", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name string
+			ref  gitprovider.PRRef
+		}{
+			{
+				name: "open_mergeable",
+				ref:  gitprovider.PRRef{Owner: "test-group9945421", Repo: "test-project", Number: 3},
+			},
+			{
+				name: "open_with_conflicts",
+				ref:  gitprovider.PRRef{Owner: "test-group9945421", Repo: "test-project", Number: 2},
+			},
+			{
+				name: "nested_merged",
+				ref:  gitprovider.PRRef{Owner: "test-group9945421/test-subgroup", Repo: "another-test-project", Number: 1},
+			},
+			{
+				name: "nested_closed_from_fork",
+				ref:  gitprovider.PRRef{Owner: "test-group9945421/test-subgroup", Repo: "another-test-project", Number: 3},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				ctx := testutil.Context(t, testutil.WaitLong)
+
+				rec := newGitLabVCR(t, "FetchPullRequestDiff/"+tt.name)
+				vcrProvider, err := gitprovider.New("gitlab", apiURL, rec.GetDefaultClient())
+				require.NoError(t, err)
+				require.NotNil(t, vcrProvider)
+
+				diff, err := vcrProvider.FetchPullRequestDiff(ctx, token, tt.ref)
+				require.NoError(t, err)
+				assert.NotEmpty(t, diff)
+				assert.Contains(t, diff, "diff --git")
+			})
+		}
+	})
+
+	t.Run("ResolveBranchPullRequest", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name      string
+			ref       gitprovider.BranchRef
+			expectNil bool // true if branch is known-deleted or from a fork
+		}{
+			{
+				name: "open_mr_branch",
+				ref: gitprovider.BranchRef{
+					Owner:  "test-group9945421",
+					Repo:   "test-project",
+					Branch: "johnstcn-main-patch-98822",
+				},
+				expectNil: false,
+			},
+			{
+				name: "nested_branch_deleted_after_merge",
+				ref: gitprovider.BranchRef{
+					Owner:  "test-group9945421/test-subgroup",
+					Repo:   "another-test-project",
+					Branch: "johnstcn-main-patch-54711",
+				},
+				expectNil: true,
+			},
+			{
+				name: "nested_fork_branch_not_on_target",
+				ref: gitprovider.BranchRef{
+					Owner:  "test-group9945421/test-subgroup",
+					Repo:   "another-test-project",
+					Branch: "forked",
+				},
+				expectNil: true,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				ctx := testutil.Context(t, testutil.WaitLong)
+
+				rec := newGitLabVCR(t, "ResolveBranchPullRequest/"+tt.name)
+				vcrProvider, err := gitprovider.New("gitlab", apiURL, rec.GetDefaultClient())
+				require.NoError(t, err)
+				require.NotNil(t, vcrProvider)
+
+				ref, err := vcrProvider.ResolveBranchPullRequest(ctx, token, tt.ref)
+				require.NoError(t, err)
+				if tt.expectNil {
+					assert.Nil(t, ref)
+				} else {
+					require.NotNil(t, ref)
+					assert.Equal(t, tt.ref.Owner, ref.Owner)
+					assert.Equal(t, tt.ref.Repo, ref.Repo)
+					assert.Greater(t, ref.Number, 0)
+				}
+			})
+		}
+	})
+
+	t.Run("FetchBranchDiff", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name      string
+			ref       gitprovider.BranchRef
+			expectErr bool // true if branch no longer exists
+		}{
+			{
+				name: "open_mr_branch",
+				ref: gitprovider.BranchRef{
+					Owner:  "test-group9945421",
+					Repo:   "test-project",
+					Branch: "johnstcn-main-patch-98822",
+				},
+			},
+			{
+				name: "nested_branch_deleted_after_merge",
+				ref: gitprovider.BranchRef{
+					Owner:  "test-group9945421/test-subgroup",
+					Repo:   "another-test-project",
+					Branch: "johnstcn-main-patch-54711",
+				},
+				// Branch was removed after merge.
+				expectErr: true,
+			},
+			{
+				name: "nested_fork_branch_not_on_target",
+				ref: gitprovider.BranchRef{
+					Owner:  "test-group9945421/test-subgroup",
+					Repo:   "another-test-project",
+					Branch: "forked",
+				},
+				// Branch only existed in the fork, not on the target repo.
+				expectErr: true,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				ctx := testutil.Context(t, testutil.WaitLong)
+
+				rec := newGitLabVCR(t, "FetchBranchDiff/"+tt.name)
+				vcrProvider, err := gitprovider.New("gitlab", apiURL, rec.GetDefaultClient())
+				require.NoError(t, err)
+				require.NotNil(t, vcrProvider)
+
+				diff, err := vcrProvider.FetchBranchDiff(ctx, token, tt.ref)
+				if tt.expectErr {
+					// TODO: assert on error content (not just presence) to
+					// distinguish real API errors from stale-cassette mismatches.
+					require.Error(t, err)
+					return
+				}
+				require.NoError(t, err)
+				assert.NotEmpty(t, diff)
+			})
+		}
+	})
+}

--- a/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/FetchBranchDiff/nested_branch_deleted_after_merge.yaml
+++ b/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/FetchBranchDiff/nested_branch_deleted_after_merge.yaml
@@ -1,0 +1,61 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            Accept:
+                - application/json
+            Private-Token:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-subgroup%2Fanother-test-project
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":82312037,"description":null,"name":"another-test-project","name_with_namespace":"test-group / test-subgroup / another-test-project","path":"another-test-project","path_with_namespace":"test-group9945421/test-subgroup/another-test-project","created_at":"2026-05-18T15:20:05.607Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:test-group9945421/test-subgroup/another-test-project.git","http_url_to_repo":"https://gitlab.com/test-group9945421/test-subgroup/another-test-project.git","web_url":"https://gitlab.com/test-group9945421/test-subgroup/another-test-project","readme_url":"https://gitlab.com/test-group9945421/test-subgroup/another-test-project/-/blob/main/README.md","forks_count":1,"avatar_url":null,"star_count":0,"last_activity_at":"2026-05-18T15:20:05.517Z","visibility":"public","namespace":{"id":132531619,"name":"test-subgroup","path":"test-subgroup","kind":"group","full_path":"test-group9945421/test-subgroup","parent_id":132520176,"avatar_url":null,"web_url":"https://gitlab.com/groups/test-group9945421/test-subgroup"}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 100.000000ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            Accept:
+                - application/json
+            Private-Token:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-subgroup%2Fanother-test-project/repository/compare?from=main&to=johnstcn-main-patch-54711
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"message":"404 Ref Not Found"}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 404 Not Found
+        code: 404
+        duration: 100.000000ms

--- a/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/FetchBranchDiff/nested_fork_branch_not_on_target.yaml
+++ b/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/FetchBranchDiff/nested_fork_branch_not_on_target.yaml
@@ -1,0 +1,61 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            Accept:
+                - application/json
+            Private-Token:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-subgroup%2Fanother-test-project
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":82312037,"description":null,"name":"another-test-project","name_with_namespace":"test-group / test-subgroup / another-test-project","path":"another-test-project","path_with_namespace":"test-group9945421/test-subgroup/another-test-project","created_at":"2026-05-18T15:20:05.607Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:test-group9945421/test-subgroup/another-test-project.git","http_url_to_repo":"https://gitlab.com/test-group9945421/test-subgroup/another-test-project.git","web_url":"https://gitlab.com/test-group9945421/test-subgroup/another-test-project","readme_url":"https://gitlab.com/test-group9945421/test-subgroup/another-test-project/-/blob/main/README.md","forks_count":1,"avatar_url":null,"star_count":0,"last_activity_at":"2026-05-18T15:20:05.517Z","visibility":"public","namespace":{"id":132531619,"name":"test-subgroup","path":"test-subgroup","kind":"group","full_path":"test-group9945421/test-subgroup","parent_id":132520176,"avatar_url":null,"web_url":"https://gitlab.com/groups/test-group9945421/test-subgroup"}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 100.000000ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            Accept:
+                - application/json
+            Private-Token:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-subgroup%2Fanother-test-project/repository/compare?from=main&to=forked
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"message":"404 Ref Not Found"}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 404 Not Found
+        code: 404
+        duration: 100.000000ms

--- a/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/FetchBranchDiff/open_mr_branch.yaml
+++ b/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/FetchBranchDiff/open_mr_branch.yaml
@@ -1,0 +1,61 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            Accept:
+                - application/json
+            Private-Token:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-project
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":82310987,"description":null,"name":"test-project","name_with_namespace":"test-group / test-project","path":"test-project","path_with_namespace":"test-group9945421/test-project","created_at":"2026-05-18T14:50:04.401Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:test-group9945421/test-project.git","http_url_to_repo":"https://gitlab.com/test-group9945421/test-project.git","web_url":"https://gitlab.com/test-group9945421/test-project","readme_url":"https://gitlab.com/test-group9945421/test-project/-/blob/main/README.md","forks_count":0,"avatar_url":null,"star_count":0,"last_activity_at":"2026-05-18T14:50:04.313Z","visibility":"public","namespace":{"id":132520176,"name":"test-group","path":"test-group9945421","kind":"group","full_path":"test-group9945421","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/test-group9945421"}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 100.000000ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            Accept:
+                - application/json
+            Private-Token:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-project/repository/compare?from=main&to=johnstcn-main-patch-98822&unidiff=true
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"commit":{"id":"da57fca657e02c1fbe131402f927d134a34b257b","short_id":"da57fca6","created_at":"2026-05-18T14:53:46.000+00:00","parent_ids":["bc2d14403364db33c7811b29598509b8cf0223c4"],"title":"Open mergeable","message":"Open mergeable","author_name":"Cian Johnston","author_email":"public@cianjohnston.ie","authored_date":"2026-05-18T14:53:46.000+00:00","committer_name":"Cian Johnston","committer_email":"public@cianjohnston.ie","committed_date":"2026-05-18T14:53:46.000+00:00","trailers":{},"extended_trailers":{},"web_url":"https://gitlab.com/test-group9945421/test-project/-/commit/da57fca657e02c1fbe131402f927d134a34b257b"},"commits":[{"id":"da57fca657e02c1fbe131402f927d134a34b257b","short_id":"da57fca6","created_at":"2026-05-18T14:53:46.000+00:00","parent_ids":["bc2d14403364db33c7811b29598509b8cf0223c4"],"title":"Open mergeable","message":"Open mergeable","author_name":"Cian Johnston","author_email":"public@cianjohnston.ie","authored_date":"2026-05-18T14:53:46.000+00:00","committer_name":"Cian Johnston","committer_email":"public@cianjohnston.ie","committed_date":"2026-05-18T14:53:46.000+00:00","trailers":{},"extended_trailers":{},"web_url":"https://gitlab.com/test-group9945421/test-project/-/commit/da57fca657e02c1fbe131402f927d134a34b257b"}],"diffs":[{"diff":"@@ -1,6 +1,6 @@\n # test-project\n \n-\n+This is a test project for testing things.\n \n ## Next Steps\n \n","collapsed":false,"too_large":false,"new_path":"README.md","old_path":"README.md","a_mode":"100644","b_mode":"100644","new_file":false,"renamed_file":false,"deleted_file":false,"generated_file":null}],"compare_timeout":false,"compare_same_ref":false,"web_url":"https://gitlab.com/test-group9945421/test-project/-/compare/bc2d14403364db33c7811b29598509b8cf0223c4...da57fca657e02c1fbe131402f927d134a34b257b"}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 100.000000ms

--- a/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/FetchPullRequestDiff/nested_closed_from_fork.yaml
+++ b/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/FetchPullRequestDiff/nested_closed_from_fork.yaml
@@ -1,0 +1,30 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            Authorization:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-subgroup%2Fanother-test-project/merge_requests/3/raw_diffs
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: 'diff --git a/README.md b/README.md\nindex b48d45443e349c6dd113da4bb7546504a07a5cce..2474182060dcbf875e7c54ffc60ecea9bbd60da3 100644\n--- a/README.md\n+++ b/README.md\n@@ -2,6 +2,8 @@\n \n This is another test project for testing stuff.\n \n+Here''s a change. Might not merge it.\n+\n ## Getting started\n \n To make it easy for you to get started with GitLab, here''s a list of recommended next steps.\n'
+        headers:
+            Content-Type:
+                - text/plain
+        status: 200 OK
+        code: 200
+        duration: 100.000000ms

--- a/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/FetchPullRequestDiff/nested_merged.yaml
+++ b/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/FetchPullRequestDiff/nested_merged.yaml
@@ -1,0 +1,30 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            Authorization:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-subgroup%2Fanother-test-project/merge_requests/1/raw_diffs
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: 'diff --git a/README.md b/README.md\nindex c1dc7b34c381ad6f417bb3f11dba4b1e8f076ff4..b48d45443e349c6dd113da4bb7546504a07a5cce 100644\n--- a/README.md\n+++ b/README.md\n@@ -1,6 +1,6 @@\n # another-test-project\n \n-\n+This is another test project for testing stuff.\n \n ## Getting started\n \n'
+        headers:
+            Content-Type:
+                - text/plain
+        status: 200 OK
+        code: 200
+        duration: 100.000000ms

--- a/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/FetchPullRequestDiff/open_mergeable.yaml
+++ b/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/FetchPullRequestDiff/open_mergeable.yaml
@@ -1,0 +1,30 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            Authorization:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-project/merge_requests/3/raw_diffs
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: 'diff --git a/README.md b/README.md\nindex 6e58dc2a1e909f3454154f1e8a9f69a4de8198ba..29ea424e45078bbf94f921c281e894c7c97777cc 100644\n--- a/README.md\n+++ b/README.md\n@@ -1,6 +1,6 @@\n # test-project\n \n-\n+This is a test project for testing things.\n \n ## Next Steps\n \n'
+        headers:
+            Content-Type:
+                - text/plain
+        status: 200 OK
+        code: 200
+        duration: 100.000000ms

--- a/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/FetchPullRequestDiff/open_with_conflicts.yaml
+++ b/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/FetchPullRequestDiff/open_with_conflicts.yaml
@@ -1,0 +1,30 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            Authorization:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-project/merge_requests/2/raw_diffs
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: 'diff --git a/README.md b/README.md\nindex 021416c15be3198c727d9a1d5a9e233f40caa940..a48adb327c52e95878f32c0ab39e9ff4c29954e0 100644\n--- a/README.md\n+++ b/README.md\n@@ -2,7 +2,7 @@\n \n \n \n-## Getting started\n+## What Next\n \n To make it easy for you to get started with GitLab, here''s a list of recommended next steps.\n \n'
+        headers:
+            Content-Type:
+                - text/plain
+        status: 200 OK
+        code: 200
+        duration: 100.000000ms

--- a/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/FetchPullRequestStatus/nested_closed_from_fork.yaml
+++ b/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/FetchPullRequestStatus/nested_closed_from_fork.yaml
@@ -1,0 +1,343 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            Accept:
+                - application/json
+            Private-Token:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-subgroup%2Fanother-test-project/merge_requests/3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":486265263,"iid":3,"project_id":82312037,"title":"Nested closed from fork","description":"","state":"closed","created_at":"2026-05-18T15:31:35.464Z","updated_at":"2026-05-18T15:31:51.925Z","merged_by":null,"merge_user":null,"merged_at":null,"closed_by":{"id":687093,"username":"johnstcn","public_email":"","name":"Cian Johnston","state":"active","locked":false,"avatar_url":"https://gitlab.com/uploads/-/system/user/avatar/687093/avatar.png","web_url":"https://gitlab.com/johnstcn"},"closed_at":"2026-05-18T15:31:51.941Z","target_branch":"main","source_branch":"forked","user_notes_count":0,"upvotes":0,"downvotes":0,"author":{"id":687093,"username":"johnstcn","public_email":"","name":"Cian Johnston","state":"active","locked":false,"avatar_url":"https://gitlab.com/uploads/-/system/user/avatar/687093/avatar.png","web_url":"https://gitlab.com/johnstcn"},"assignees":[{"id":687093,"username":"johnstcn","public_email":"","name":"Cian Johnston","state":"active","locked":false,"avatar_url":"https://gitlab.com/uploads/-/system/user/avatar/687093/avatar.png","web_url":"https://gitlab.com/johnstcn"}],"assignee":{"id":687093,"username":"johnstcn","public_email":"","name":"Cian Johnston","state":"active","locked":false,"avatar_url":"https://gitlab.com/uploads/-/system/user/avatar/687093/avatar.png","web_url":"https://gitlab.com/johnstcn"},"reviewers":[],"source_project_id":82312091,"target_project_id":82312037,"labels":[],"draft":false,"imported":false,"imported_from":"none","work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"can_be_merged","detailed_merge_status":"not_open","merge_after":null,"sha":"6b743c6728fa248e3654657e0e576eafcf472953","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":true,"prepared_at":"2026-05-18T15:31:37.673Z","allow_collaboration":true,"allow_maintainer_to_push":true,"reference":"!3","references":{"short":"!3","relative":"!3","full":"test-group9945421/test-subgroup/another-test-project!3"},"web_url":"https://gitlab.com/test-group9945421/test-subgroup/another-test-project/-/merge_requests/3","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":false,"squash_on_merge":false,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":false,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":false,"changes_count":"1","latest_build_started_at":null,"latest_build_finished_at":null,"first_deployed_to_production_at":null,"pipeline":null,"head_pipeline":null,"diff_refs":{"base_sha":"76b308af8b4711f47887c6862607f6d5924f47c0","head_sha":"6b743c6728fa248e3654657e0e576eafcf472953","start_sha":"76b308af8b4711f47887c6862607f6d5924f47c0"},"merge_error":null,"first_contribution":false,"user":{"can_merge":false}}'
+        headers:
+            Cache-Control:
+                - stripped
+            Cf-Cache-Status:
+                - stripped
+            Cf-Ray:
+                - stripped
+            Content-Security-Policy:
+                - stripped
+            Content-Type:
+                - application/json
+            Date:
+                - stripped
+            Etag:
+                - stripped
+            Gitlab-Lb:
+                - stripped
+            Gitlab-Sv:
+                - stripped
+            Nel:
+                - stripped
+            Ratelimit-Limit:
+                - stripped
+            Ratelimit-Name:
+                - stripped
+            Ratelimit-Observed:
+                - stripped
+            Ratelimit-Remaining:
+                - stripped
+            Ratelimit-Reset:
+                - stripped
+            Referrer-Policy:
+                - stripped
+            Server:
+                - stripped
+            Set-Cookie:
+                - stripped
+            Strict-Transport-Security:
+                - stripped
+            Vary:
+                - stripped
+            X-Content-Type-Options:
+                - stripped
+            X-Frame-Options:
+                - stripped
+            X-Gitlab-Meta:
+                - stripped
+            X-Request-Id:
+                - stripped
+            X-Runtime:
+                - stripped
+        status: 200 OK
+        code: 200
+        duration: 264.50708ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            Accept:
+                - application/json
+            Private-Token:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-subgroup%2Fanother-test-project/merge_requests/3/approvals
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":486265263,"iid":3,"project_id":82312037,"title":"Nested closed from fork","description":"","state":"closed","created_at":"2026-05-18T15:31:35.464Z","updated_at":"2026-05-18T15:31:51.925Z","merge_status":"can_be_merged","approved":true,"approvals_required":0,"approvals_left":0,"require_password_to_approve":false,"approved_by":[],"suggested_approvers":[],"approvers":[],"approver_groups":[],"user_has_approved":false,"user_can_approve":false,"approval_rules_left":[],"has_approval_rules":false,"merge_request_approvers_available":false,"multiple_approval_rules_available":false,"invalid_approvers_rules":[]}'
+        headers:
+            Cache-Control:
+                - stripped
+            Cf-Cache-Status:
+                - stripped
+            Cf-Ray:
+                - stripped
+            Content-Security-Policy:
+                - stripped
+            Content-Type:
+                - application/json
+            Date:
+                - stripped
+            Etag:
+                - stripped
+            Gitlab-Lb:
+                - stripped
+            Gitlab-Sv:
+                - stripped
+            Nel:
+                - stripped
+            Ratelimit-Limit:
+                - stripped
+            Ratelimit-Name:
+                - stripped
+            Ratelimit-Observed:
+                - stripped
+            Ratelimit-Remaining:
+                - stripped
+            Ratelimit-Reset:
+                - stripped
+            Referrer-Policy:
+                - stripped
+            Server:
+                - stripped
+            Set-Cookie:
+                - stripped
+            Strict-Transport-Security:
+                - stripped
+            Vary:
+                - stripped
+            X-Content-Type-Options:
+                - stripped
+            X-Frame-Options:
+                - stripped
+            X-Gitlab-Meta:
+                - stripped
+            X-Request-Id:
+                - stripped
+            X-Runtime:
+                - stripped
+        status: 200 OK
+        code: 200
+        duration: 219.958602ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        form:
+            per_page:
+                - "100"
+        headers:
+            Accept:
+                - application/json
+            Private-Token:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-subgroup%2Fanother-test-project/merge_requests/3/commits?per_page=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"6b743c6728fa248e3654657e0e576eafcf472953","short_id":"6b743c67","created_at":"2026-05-18T15:23:06.000+00:00","parent_ids":["76b308af8b4711f47887c6862607f6d5924f47c0"],"title":"Nested closed","message":"Nested closed","author_name":"Cian Johnston","author_email":"public@cianjohnston.ie","authored_date":"2026-05-18T15:23:06.000+00:00","committer_name":"Cian Johnston","committer_email":"public@cianjohnston.ie","committed_date":"2026-05-18T15:23:06.000+00:00","trailers":{},"extended_trailers":{},"web_url":"https://gitlab.com/test-group9945421/test-subgroup/another-test-project/-/commit/6b743c6728fa248e3654657e0e576eafcf472953"}]'
+        headers:
+            Cache-Control:
+                - stripped
+            Cf-Cache-Status:
+                - stripped
+            Cf-Ray:
+                - stripped
+            Content-Security-Policy:
+                - stripped
+            Content-Type:
+                - application/json
+            Date:
+                - stripped
+            Etag:
+                - stripped
+            Gitlab-Lb:
+                - stripped
+            Gitlab-Sv:
+                - stripped
+            Link:
+                - stripped
+            Nel:
+                - stripped
+            Ratelimit-Limit:
+                - stripped
+            Ratelimit-Name:
+                - stripped
+            Ratelimit-Observed:
+                - stripped
+            Ratelimit-Remaining:
+                - stripped
+            Ratelimit-Reset:
+                - stripped
+            Referrer-Policy:
+                - stripped
+            Server:
+                - stripped
+            Set-Cookie:
+                - stripped
+            Strict-Transport-Security:
+                - stripped
+            Vary:
+                - stripped
+            X-Content-Type-Options:
+                - stripped
+            X-Frame-Options:
+                - stripped
+            X-Gitlab-Meta:
+                - stripped
+            X-Next-Page:
+                - stripped
+            X-Page:
+                - stripped
+            X-Per-Page:
+                - stripped
+            X-Prev-Page:
+                - stripped
+            X-Request-Id:
+                - stripped
+            X-Runtime:
+                - stripped
+            X-Total:
+                - "1"
+            X-Total-Pages:
+                - stripped
+        status: 200 OK
+        code: 200
+        duration: 209.568896ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        form:
+            per_page:
+                - "100"
+        headers:
+            Accept:
+                - application/json
+            Private-Token:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-subgroup%2Fanother-test-project/merge_requests/3/diffs?per_page=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"diff":"@@ -2,6 +2,8 @@\n \n This is another test project for testing stuff.\n \n+Here''s a change. Might not merge it.\n+\n ## Getting started\n \n To make it easy for you to get started with GitLab, here''s a list of recommended next steps.\n","collapsed":false,"too_large":false,"new_path":"README.md","old_path":"README.md","a_mode":"100644","b_mode":"100644","new_file":false,"renamed_file":false,"deleted_file":false,"generated_file":false}]'
+        headers:
+            Cache-Control:
+                - stripped
+            Cf-Cache-Status:
+                - stripped
+            Cf-Ray:
+                - stripped
+            Content-Security-Policy:
+                - stripped
+            Content-Type:
+                - application/json
+            Date:
+                - stripped
+            Etag:
+                - stripped
+            Gitlab-Lb:
+                - stripped
+            Gitlab-Sv:
+                - stripped
+            Link:
+                - stripped
+            Nel:
+                - stripped
+            Ratelimit-Limit:
+                - stripped
+            Ratelimit-Name:
+                - stripped
+            Ratelimit-Observed:
+                - stripped
+            Ratelimit-Remaining:
+                - stripped
+            Ratelimit-Reset:
+                - stripped
+            Server:
+                - stripped
+            Set-Cookie:
+                - stripped
+            Strict-Transport-Security:
+                - stripped
+            Vary:
+                - stripped
+            X-Content-Type-Options:
+                - stripped
+            X-Frame-Options:
+                - stripped
+            X-Gitlab-Meta:
+                - stripped
+            X-Next-Page:
+                - stripped
+            X-Page:
+                - stripped
+            X-Per-Page:
+                - stripped
+            X-Prev-Page:
+                - stripped
+            X-Request-Id:
+                - stripped
+            X-Runtime:
+                - stripped
+            X-Total:
+                - "1"
+            X-Total-Pages:
+                - stripped
+        status: 200 OK
+        code: 200
+        duration: 343.393368ms

--- a/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/FetchPullRequestStatus/nested_merged.yaml
+++ b/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/FetchPullRequestStatus/nested_merged.yaml
@@ -1,0 +1,345 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            Accept:
+                - application/json
+            Private-Token:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-subgroup%2Fanother-test-project/merge_requests/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":486261628,"iid":1,"project_id":82312037,"title":"Nested merged","description":"","state":"merged","created_at":"2026-05-18T15:21:59.875Z","updated_at":"2026-05-18T15:22:07.620Z","merged_by":{"id":687093,"username":"johnstcn","public_email":"","name":"Cian Johnston","state":"active","locked":false,"avatar_url":"https://gitlab.com/uploads/-/system/user/avatar/687093/avatar.png","web_url":"https://gitlab.com/johnstcn"},"merge_user":{"id":687093,"username":"johnstcn","public_email":"","name":"Cian Johnston","state":"active","locked":false,"avatar_url":"https://gitlab.com/uploads/-/system/user/avatar/687093/avatar.png","web_url":"https://gitlab.com/johnstcn"},"merged_at":"2026-05-18T15:22:07.165Z","closed_by":null,"closed_at":null,"target_branch":"main","source_branch":"johnstcn-main-patch-54711","user_notes_count":0,"upvotes":0,"downvotes":0,"author":{"id":687093,"username":"johnstcn","public_email":"","name":"Cian Johnston","state":"active","locked":false,"avatar_url":"https://gitlab.com/uploads/-/system/user/avatar/687093/avatar.png","web_url":"https://gitlab.com/johnstcn"},"assignees":[{"id":687093,"username":"johnstcn","public_email":"","name":"Cian Johnston","state":"active","locked":false,"avatar_url":"https://gitlab.com/uploads/-/system/user/avatar/687093/avatar.png","web_url":"https://gitlab.com/johnstcn"}],"assignee":{"id":687093,"username":"johnstcn","public_email":"","name":"Cian Johnston","state":"active","locked":false,"avatar_url":"https://gitlab.com/uploads/-/system/user/avatar/687093/avatar.png","web_url":"https://gitlab.com/johnstcn"},"reviewers":[],"source_project_id":82312037,"target_project_id":82312037,"labels":[],"draft":false,"imported":false,"imported_from":"none","work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"can_be_merged","detailed_merge_status":"not_open","merge_after":null,"sha":"ff919f3dc418e4fbffb6fbded7b4c9ae60a4531b","merge_commit_sha":"76b308af8b4711f47887c6862607f6d5924f47c0","squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":true,"force_remove_source_branch":true,"prepared_at":"2026-05-18T15:22:02.380Z","reference":"!1","references":{"short":"!1","relative":"!1","full":"test-group9945421/test-subgroup/another-test-project!1"},"web_url":"https://gitlab.com/test-group9945421/test-subgroup/another-test-project/-/merge_requests/1","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":false,"squash_on_merge":false,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":false,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":false,"changes_count":"1","latest_build_started_at":null,"latest_build_finished_at":null,"first_deployed_to_production_at":null,"pipeline":null,"head_pipeline":null,"diff_refs":{"base_sha":"ecd06ae70b01b8185c16bddb19db6e7e000e6fc3","head_sha":"ff919f3dc418e4fbffb6fbded7b4c9ae60a4531b","start_sha":"ecd06ae70b01b8185c16bddb19db6e7e000e6fc3"},"merge_error":null,"first_contribution":true,"user":{"can_merge":false}}'
+        headers:
+            Cache-Control:
+                - stripped
+            Cf-Cache-Status:
+                - stripped
+            Cf-Ray:
+                - stripped
+            Content-Security-Policy:
+                - stripped
+            Content-Type:
+                - application/json
+            Date:
+                - stripped
+            Etag:
+                - stripped
+            Gitlab-Lb:
+                - stripped
+            Gitlab-Sv:
+                - stripped
+            Nel:
+                - stripped
+            Ratelimit-Limit:
+                - stripped
+            Ratelimit-Name:
+                - stripped
+            Ratelimit-Observed:
+                - stripped
+            Ratelimit-Remaining:
+                - stripped
+            Ratelimit-Reset:
+                - stripped
+            Referrer-Policy:
+                - stripped
+            Server:
+                - stripped
+            Set-Cookie:
+                - stripped
+            Strict-Transport-Security:
+                - stripped
+            Vary:
+                - stripped
+            X-Content-Type-Options:
+                - stripped
+            X-Frame-Options:
+                - stripped
+            X-Gitlab-Meta:
+                - stripped
+            X-Request-Id:
+                - stripped
+            X-Runtime:
+                - stripped
+        status: 200 OK
+        code: 200
+        duration: 255.584981ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            Accept:
+                - application/json
+            Private-Token:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-subgroup%2Fanother-test-project/merge_requests/1/approvals
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":486261628,"iid":1,"project_id":82312037,"title":"Nested merged","description":"","state":"merged","created_at":"2026-05-18T15:21:59.875Z","updated_at":"2026-05-18T15:22:07.620Z","merge_status":"can_be_merged","approved":true,"approvals_required":0,"approvals_left":0,"require_password_to_approve":false,"approved_by":[],"suggested_approvers":[],"approvers":[],"approver_groups":[],"user_has_approved":false,"user_can_approve":false,"approval_rules_left":[],"has_approval_rules":false,"merge_request_approvers_available":false,"multiple_approval_rules_available":false,"invalid_approvers_rules":[]}'
+        headers:
+            Cache-Control:
+                - stripped
+            Cf-Cache-Status:
+                - stripped
+            Cf-Ray:
+                - stripped
+            Content-Security-Policy:
+                - stripped
+            Content-Type:
+                - application/json
+            Date:
+                - stripped
+            Etag:
+                - stripped
+            Gitlab-Lb:
+                - stripped
+            Gitlab-Sv:
+                - stripped
+            Nel:
+                - stripped
+            Ratelimit-Limit:
+                - stripped
+            Ratelimit-Name:
+                - stripped
+            Ratelimit-Observed:
+                - stripped
+            Ratelimit-Remaining:
+                - stripped
+            Ratelimit-Reset:
+                - stripped
+            Referrer-Policy:
+                - stripped
+            Server:
+                - stripped
+            Set-Cookie:
+                - stripped
+            Strict-Transport-Security:
+                - stripped
+            Vary:
+                - stripped
+            X-Content-Type-Options:
+                - stripped
+            X-Frame-Options:
+                - stripped
+            X-Gitlab-Meta:
+                - stripped
+            X-Request-Id:
+                - stripped
+            X-Runtime:
+                - stripped
+        status: 200 OK
+        code: 200
+        duration: 238.750519ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        form:
+            per_page:
+                - "100"
+        headers:
+            Accept:
+                - application/json
+            Private-Token:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-subgroup%2Fanother-test-project/merge_requests/1/commits?per_page=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"ff919f3dc418e4fbffb6fbded7b4c9ae60a4531b","short_id":"ff919f3d","created_at":"2026-05-18T15:21:50.000+00:00","parent_ids":["ecd06ae70b01b8185c16bddb19db6e7e000e6fc3"],"title":"Nested merged","message":"Nested merged","author_name":"Cian Johnston","author_email":"public@cianjohnston.ie","authored_date":"2026-05-18T15:21:50.000+00:00","committer_name":"Cian Johnston","committer_email":"public@cianjohnston.ie","committed_date":"2026-05-18T15:21:50.000+00:00","trailers":{},"extended_trailers":{},"web_url":"https://gitlab.com/test-group9945421/test-subgroup/another-test-project/-/commit/ff919f3dc418e4fbffb6fbded7b4c9ae60a4531b"}]'
+        headers:
+            Cache-Control:
+                - stripped
+            Cf-Cache-Status:
+                - stripped
+            Cf-Ray:
+                - stripped
+            Content-Security-Policy:
+                - stripped
+            Content-Type:
+                - application/json
+            Date:
+                - stripped
+            Etag:
+                - stripped
+            Gitlab-Lb:
+                - stripped
+            Gitlab-Sv:
+                - stripped
+            Link:
+                - stripped
+            Nel:
+                - stripped
+            Ratelimit-Limit:
+                - stripped
+            Ratelimit-Name:
+                - stripped
+            Ratelimit-Observed:
+                - stripped
+            Ratelimit-Remaining:
+                - stripped
+            Ratelimit-Reset:
+                - stripped
+            Referrer-Policy:
+                - stripped
+            Server:
+                - stripped
+            Set-Cookie:
+                - stripped
+            Strict-Transport-Security:
+                - stripped
+            Vary:
+                - stripped
+            X-Content-Type-Options:
+                - stripped
+            X-Frame-Options:
+                - stripped
+            X-Gitlab-Meta:
+                - stripped
+            X-Next-Page:
+                - stripped
+            X-Page:
+                - stripped
+            X-Per-Page:
+                - stripped
+            X-Prev-Page:
+                - stripped
+            X-Request-Id:
+                - stripped
+            X-Runtime:
+                - stripped
+            X-Total:
+                - "1"
+            X-Total-Pages:
+                - stripped
+        status: 200 OK
+        code: 200
+        duration: 243.115989ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        form:
+            per_page:
+                - "100"
+        headers:
+            Accept:
+                - application/json
+            Private-Token:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-subgroup%2Fanother-test-project/merge_requests/1/diffs?per_page=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"diff":"@@ -1,6 +1,6 @@\n # another-test-project\n \n-\n+This is another test project for testing stuff.\n \n ## Getting started\n \n","collapsed":false,"too_large":false,"new_path":"README.md","old_path":"README.md","a_mode":"100644","b_mode":"100644","new_file":false,"renamed_file":false,"deleted_file":false,"generated_file":false}]'
+        headers:
+            Cache-Control:
+                - stripped
+            Cf-Cache-Status:
+                - stripped
+            Cf-Ray:
+                - stripped
+            Content-Security-Policy:
+                - stripped
+            Content-Type:
+                - application/json
+            Date:
+                - stripped
+            Etag:
+                - stripped
+            Gitlab-Lb:
+                - stripped
+            Gitlab-Sv:
+                - stripped
+            Link:
+                - stripped
+            Nel:
+                - stripped
+            Ratelimit-Limit:
+                - stripped
+            Ratelimit-Name:
+                - stripped
+            Ratelimit-Observed:
+                - stripped
+            Ratelimit-Remaining:
+                - stripped
+            Ratelimit-Reset:
+                - stripped
+            Referrer-Policy:
+                - stripped
+            Server:
+                - stripped
+            Set-Cookie:
+                - stripped
+            Strict-Transport-Security:
+                - stripped
+            Vary:
+                - stripped
+            X-Content-Type-Options:
+                - stripped
+            X-Frame-Options:
+                - stripped
+            X-Gitlab-Meta:
+                - stripped
+            X-Next-Page:
+                - stripped
+            X-Page:
+                - stripped
+            X-Per-Page:
+                - stripped
+            X-Prev-Page:
+                - stripped
+            X-Request-Id:
+                - stripped
+            X-Runtime:
+                - stripped
+            X-Total:
+                - "1"
+            X-Total-Pages:
+                - stripped
+        status: 200 OK
+        code: 200
+        duration: 271.552894ms

--- a/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/FetchPullRequestStatus/open_mergeable.yaml
+++ b/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/FetchPullRequestStatus/open_mergeable.yaml
@@ -1,0 +1,345 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            Accept:
+                - application/json
+            Private-Token:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-project/merge_requests/3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":486249709,"iid":3,"project_id":82310987,"title":"Open mergeable","description":"","state":"opened","created_at":"2026-05-18T14:53:54.688Z","updated_at":"2026-05-18T14:53:55.972Z","merged_by":null,"merge_user":null,"merged_at":null,"closed_by":null,"closed_at":null,"target_branch":"main","source_branch":"johnstcn-main-patch-98822","user_notes_count":0,"upvotes":0,"downvotes":0,"author":{"id":687093,"username":"johnstcn","public_email":"","name":"Cian Johnston","state":"active","locked":false,"avatar_url":"https://gitlab.com/uploads/-/system/user/avatar/687093/avatar.png","web_url":"https://gitlab.com/johnstcn"},"assignees":[{"id":687093,"username":"johnstcn","public_email":"","name":"Cian Johnston","state":"active","locked":false,"avatar_url":"https://gitlab.com/uploads/-/system/user/avatar/687093/avatar.png","web_url":"https://gitlab.com/johnstcn"}],"assignee":{"id":687093,"username":"johnstcn","public_email":"","name":"Cian Johnston","state":"active","locked":false,"avatar_url":"https://gitlab.com/uploads/-/system/user/avatar/687093/avatar.png","web_url":"https://gitlab.com/johnstcn"},"reviewers":[],"source_project_id":82310987,"target_project_id":82310987,"labels":[],"draft":false,"imported":false,"imported_from":"none","work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"can_be_merged","detailed_merge_status":"mergeable","merge_after":null,"sha":"da57fca657e02c1fbe131402f927d134a34b257b","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":true,"prepared_at":"2026-05-18T14:53:55.966Z","reference":"!3","references":{"short":"!3","relative":"!3","full":"test-group9945421/test-project!3"},"web_url":"https://gitlab.com/test-group9945421/test-project/-/merge_requests/3","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":false,"squash_on_merge":false,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":false,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":false,"changes_count":"1","latest_build_started_at":null,"latest_build_finished_at":null,"first_deployed_to_production_at":null,"pipeline":null,"head_pipeline":null,"diff_refs":{"base_sha":"bc2d14403364db33c7811b29598509b8cf0223c4","head_sha":"da57fca657e02c1fbe131402f927d134a34b257b","start_sha":"bc2d14403364db33c7811b29598509b8cf0223c4"},"merge_error":null,"first_contribution":false,"user":{"can_merge":false}}'
+        headers:
+            Cache-Control:
+                - stripped
+            Cf-Cache-Status:
+                - stripped
+            Cf-Ray:
+                - stripped
+            Content-Security-Policy:
+                - stripped
+            Content-Type:
+                - application/json
+            Date:
+                - stripped
+            Etag:
+                - stripped
+            Gitlab-Lb:
+                - stripped
+            Gitlab-Sv:
+                - stripped
+            Nel:
+                - stripped
+            Ratelimit-Limit:
+                - stripped
+            Ratelimit-Name:
+                - stripped
+            Ratelimit-Observed:
+                - stripped
+            Ratelimit-Remaining:
+                - stripped
+            Ratelimit-Reset:
+                - stripped
+            Referrer-Policy:
+                - stripped
+            Server:
+                - stripped
+            Set-Cookie:
+                - stripped
+            Strict-Transport-Security:
+                - stripped
+            Vary:
+                - stripped
+            X-Content-Type-Options:
+                - stripped
+            X-Frame-Options:
+                - stripped
+            X-Gitlab-Meta:
+                - stripped
+            X-Request-Id:
+                - stripped
+            X-Runtime:
+                - stripped
+        status: 200 OK
+        code: 200
+        duration: 381.20188ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            Accept:
+                - application/json
+            Private-Token:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-project/merge_requests/3/approvals
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":486249709,"iid":3,"project_id":82310987,"title":"Open mergeable","description":"","state":"opened","created_at":"2026-05-18T14:53:54.688Z","updated_at":"2026-05-18T14:53:55.972Z","merge_status":"can_be_merged","approved":true,"approvals_required":0,"approvals_left":0,"require_password_to_approve":false,"approved_by":[],"suggested_approvers":[],"approvers":[],"approver_groups":[],"user_has_approved":false,"user_can_approve":false,"approval_rules_left":[],"has_approval_rules":false,"merge_request_approvers_available":false,"multiple_approval_rules_available":false,"invalid_approvers_rules":[]}'
+        headers:
+            Cache-Control:
+                - stripped
+            Cf-Cache-Status:
+                - stripped
+            Cf-Ray:
+                - stripped
+            Content-Security-Policy:
+                - stripped
+            Content-Type:
+                - application/json
+            Date:
+                - stripped
+            Etag:
+                - stripped
+            Gitlab-Lb:
+                - stripped
+            Gitlab-Sv:
+                - stripped
+            Nel:
+                - stripped
+            Ratelimit-Limit:
+                - stripped
+            Ratelimit-Name:
+                - stripped
+            Ratelimit-Observed:
+                - stripped
+            Ratelimit-Remaining:
+                - stripped
+            Ratelimit-Reset:
+                - stripped
+            Referrer-Policy:
+                - stripped
+            Server:
+                - stripped
+            Set-Cookie:
+                - stripped
+            Strict-Transport-Security:
+                - stripped
+            Vary:
+                - stripped
+            X-Content-Type-Options:
+                - stripped
+            X-Frame-Options:
+                - stripped
+            X-Gitlab-Meta:
+                - stripped
+            X-Request-Id:
+                - stripped
+            X-Runtime:
+                - stripped
+        status: 200 OK
+        code: 200
+        duration: 196.210578ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        form:
+            per_page:
+                - "100"
+        headers:
+            Accept:
+                - application/json
+            Private-Token:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-project/merge_requests/3/commits?per_page=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"da57fca657e02c1fbe131402f927d134a34b257b","short_id":"da57fca6","created_at":"2026-05-18T14:53:46.000+00:00","parent_ids":["bc2d14403364db33c7811b29598509b8cf0223c4"],"title":"Open mergeable","message":"Open mergeable","author_name":"Cian Johnston","author_email":"public@cianjohnston.ie","authored_date":"2026-05-18T14:53:46.000+00:00","committer_name":"Cian Johnston","committer_email":"public@cianjohnston.ie","committed_date":"2026-05-18T14:53:46.000+00:00","trailers":{},"extended_trailers":{},"web_url":"https://gitlab.com/test-group9945421/test-project/-/commit/da57fca657e02c1fbe131402f927d134a34b257b"}]'
+        headers:
+            Cache-Control:
+                - stripped
+            Cf-Cache-Status:
+                - stripped
+            Cf-Ray:
+                - stripped
+            Content-Security-Policy:
+                - stripped
+            Content-Type:
+                - application/json
+            Date:
+                - stripped
+            Etag:
+                - stripped
+            Gitlab-Lb:
+                - stripped
+            Gitlab-Sv:
+                - stripped
+            Link:
+                - stripped
+            Nel:
+                - stripped
+            Ratelimit-Limit:
+                - stripped
+            Ratelimit-Name:
+                - stripped
+            Ratelimit-Observed:
+                - stripped
+            Ratelimit-Remaining:
+                - stripped
+            Ratelimit-Reset:
+                - stripped
+            Referrer-Policy:
+                - stripped
+            Server:
+                - stripped
+            Set-Cookie:
+                - stripped
+            Strict-Transport-Security:
+                - stripped
+            Vary:
+                - stripped
+            X-Content-Type-Options:
+                - stripped
+            X-Frame-Options:
+                - stripped
+            X-Gitlab-Meta:
+                - stripped
+            X-Next-Page:
+                - stripped
+            X-Page:
+                - stripped
+            X-Per-Page:
+                - stripped
+            X-Prev-Page:
+                - stripped
+            X-Request-Id:
+                - stripped
+            X-Runtime:
+                - stripped
+            X-Total:
+                - "1"
+            X-Total-Pages:
+                - stripped
+        status: 200 OK
+        code: 200
+        duration: 217.874878ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        form:
+            per_page:
+                - "100"
+        headers:
+            Accept:
+                - application/json
+            Private-Token:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-project/merge_requests/3/diffs?per_page=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"diff":"@@ -1,6 +1,6 @@\n # test-project\n \n-\n+This is a test project for testing things.\n \n ## Next Steps\n \n","collapsed":false,"too_large":false,"new_path":"README.md","old_path":"README.md","a_mode":"100644","b_mode":"100644","new_file":false,"renamed_file":false,"deleted_file":false,"generated_file":false}]'
+        headers:
+            Cache-Control:
+                - stripped
+            Cf-Cache-Status:
+                - stripped
+            Cf-Ray:
+                - stripped
+            Content-Security-Policy:
+                - stripped
+            Content-Type:
+                - application/json
+            Date:
+                - stripped
+            Etag:
+                - stripped
+            Gitlab-Lb:
+                - stripped
+            Gitlab-Sv:
+                - stripped
+            Link:
+                - stripped
+            Nel:
+                - stripped
+            Ratelimit-Limit:
+                - stripped
+            Ratelimit-Name:
+                - stripped
+            Ratelimit-Observed:
+                - stripped
+            Ratelimit-Remaining:
+                - stripped
+            Ratelimit-Reset:
+                - stripped
+            Referrer-Policy:
+                - stripped
+            Server:
+                - stripped
+            Set-Cookie:
+                - stripped
+            Strict-Transport-Security:
+                - stripped
+            Vary:
+                - stripped
+            X-Content-Type-Options:
+                - stripped
+            X-Frame-Options:
+                - stripped
+            X-Gitlab-Meta:
+                - stripped
+            X-Next-Page:
+                - stripped
+            X-Page:
+                - stripped
+            X-Per-Page:
+                - stripped
+            X-Prev-Page:
+                - stripped
+            X-Request-Id:
+                - stripped
+            X-Runtime:
+                - stripped
+            X-Total:
+                - "1"
+            X-Total-Pages:
+                - stripped
+        status: 200 OK
+        code: 200
+        duration: 266.716685ms

--- a/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/FetchPullRequestStatus/open_with_conflicts.yaml
+++ b/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/FetchPullRequestStatus/open_with_conflicts.yaml
@@ -1,0 +1,345 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            Accept:
+                - application/json
+            Private-Token:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-project/merge_requests/2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":486248759,"iid":2,"project_id":82310987,"title":"Open with conflicts","description":"","state":"opened","created_at":"2026-05-18T14:51:51.015Z","updated_at":"2026-05-18T14:53:08.449Z","merged_by":null,"merge_user":null,"merged_at":null,"closed_by":null,"closed_at":null,"target_branch":"main","source_branch":"johnstcn-main-patch-84369","user_notes_count":0,"upvotes":0,"downvotes":0,"author":{"id":687093,"username":"johnstcn","public_email":"","name":"Cian Johnston","state":"active","locked":false,"avatar_url":"https://gitlab.com/uploads/-/system/user/avatar/687093/avatar.png","web_url":"https://gitlab.com/johnstcn"},"assignees":[{"id":687093,"username":"johnstcn","public_email":"","name":"Cian Johnston","state":"active","locked":false,"avatar_url":"https://gitlab.com/uploads/-/system/user/avatar/687093/avatar.png","web_url":"https://gitlab.com/johnstcn"}],"assignee":{"id":687093,"username":"johnstcn","public_email":"","name":"Cian Johnston","state":"active","locked":false,"avatar_url":"https://gitlab.com/uploads/-/system/user/avatar/687093/avatar.png","web_url":"https://gitlab.com/johnstcn"},"reviewers":[],"source_project_id":82310987,"target_project_id":82310987,"labels":[],"draft":false,"imported":false,"imported_from":"none","work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"cannot_be_merged","detailed_merge_status":"conflict","merge_after":null,"sha":"642379758fa148ff24cba5f676226a3f8e560d73","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":true,"prepared_at":"2026-05-18T14:51:52.481Z","reference":"!2","references":{"short":"!2","relative":"!2","full":"test-group9945421/test-project!2"},"web_url":"https://gitlab.com/test-group9945421/test-project/-/merge_requests/2","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":false,"squash_on_merge":false,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":true,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":false,"changes_count":"1","latest_build_started_at":null,"latest_build_finished_at":null,"first_deployed_to_production_at":null,"pipeline":null,"head_pipeline":null,"diff_refs":{"base_sha":"c71f88a175d4b5506805edb70b43c5885f087860","head_sha":"642379758fa148ff24cba5f676226a3f8e560d73","start_sha":"c71f88a175d4b5506805edb70b43c5885f087860"},"merge_error":null,"first_contribution":false,"user":{"can_merge":false}}'
+        headers:
+            Cache-Control:
+                - stripped
+            Cf-Cache-Status:
+                - stripped
+            Cf-Ray:
+                - stripped
+            Content-Security-Policy:
+                - stripped
+            Content-Type:
+                - application/json
+            Date:
+                - stripped
+            Etag:
+                - stripped
+            Gitlab-Lb:
+                - stripped
+            Gitlab-Sv:
+                - stripped
+            Nel:
+                - stripped
+            Ratelimit-Limit:
+                - stripped
+            Ratelimit-Name:
+                - stripped
+            Ratelimit-Observed:
+                - stripped
+            Ratelimit-Remaining:
+                - stripped
+            Ratelimit-Reset:
+                - stripped
+            Referrer-Policy:
+                - stripped
+            Server:
+                - stripped
+            Set-Cookie:
+                - stripped
+            Strict-Transport-Security:
+                - stripped
+            Vary:
+                - stripped
+            X-Content-Type-Options:
+                - stripped
+            X-Frame-Options:
+                - stripped
+            X-Gitlab-Meta:
+                - stripped
+            X-Request-Id:
+                - stripped
+            X-Runtime:
+                - stripped
+        status: 200 OK
+        code: 200
+        duration: 295.911218ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            Accept:
+                - application/json
+            Private-Token:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-project/merge_requests/2/approvals
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":486248759,"iid":2,"project_id":82310987,"title":"Open with conflicts","description":"","state":"opened","created_at":"2026-05-18T14:51:51.015Z","updated_at":"2026-05-18T14:53:08.449Z","merge_status":"cannot_be_merged","approved":true,"approvals_required":0,"approvals_left":0,"require_password_to_approve":false,"approved_by":[],"suggested_approvers":[],"approvers":[],"approver_groups":[],"user_has_approved":false,"user_can_approve":false,"approval_rules_left":[],"has_approval_rules":false,"merge_request_approvers_available":false,"multiple_approval_rules_available":false,"invalid_approvers_rules":[]}'
+        headers:
+            Cache-Control:
+                - stripped
+            Cf-Cache-Status:
+                - stripped
+            Cf-Ray:
+                - stripped
+            Content-Security-Policy:
+                - stripped
+            Content-Type:
+                - application/json
+            Date:
+                - stripped
+            Etag:
+                - stripped
+            Gitlab-Lb:
+                - stripped
+            Gitlab-Sv:
+                - stripped
+            Nel:
+                - stripped
+            Ratelimit-Limit:
+                - stripped
+            Ratelimit-Name:
+                - stripped
+            Ratelimit-Observed:
+                - stripped
+            Ratelimit-Remaining:
+                - stripped
+            Ratelimit-Reset:
+                - stripped
+            Referrer-Policy:
+                - stripped
+            Server:
+                - stripped
+            Set-Cookie:
+                - stripped
+            Strict-Transport-Security:
+                - stripped
+            Vary:
+                - stripped
+            X-Content-Type-Options:
+                - stripped
+            X-Frame-Options:
+                - stripped
+            X-Gitlab-Meta:
+                - stripped
+            X-Request-Id:
+                - stripped
+            X-Runtime:
+                - stripped
+        status: 200 OK
+        code: 200
+        duration: 188.621935ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        form:
+            per_page:
+                - "100"
+        headers:
+            Accept:
+                - application/json
+            Private-Token:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-project/merge_requests/2/commits?per_page=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"642379758fa148ff24cba5f676226a3f8e560d73","short_id":"64237975","created_at":"2026-05-18T14:51:45.000+00:00","parent_ids":["c71f88a175d4b5506805edb70b43c5885f087860"],"title":"Edit README.md","message":"Edit README.md","author_name":"Cian Johnston","author_email":"public@cianjohnston.ie","authored_date":"2026-05-18T14:51:45.000+00:00","committer_name":"Cian Johnston","committer_email":"public@cianjohnston.ie","committed_date":"2026-05-18T14:51:45.000+00:00","trailers":{},"extended_trailers":{},"web_url":"https://gitlab.com/test-group9945421/test-project/-/commit/642379758fa148ff24cba5f676226a3f8e560d73"}]'
+        headers:
+            Cache-Control:
+                - stripped
+            Cf-Cache-Status:
+                - stripped
+            Cf-Ray:
+                - stripped
+            Content-Security-Policy:
+                - stripped
+            Content-Type:
+                - application/json
+            Date:
+                - stripped
+            Etag:
+                - stripped
+            Gitlab-Lb:
+                - stripped
+            Gitlab-Sv:
+                - stripped
+            Link:
+                - stripped
+            Nel:
+                - stripped
+            Ratelimit-Limit:
+                - stripped
+            Ratelimit-Name:
+                - stripped
+            Ratelimit-Observed:
+                - stripped
+            Ratelimit-Remaining:
+                - stripped
+            Ratelimit-Reset:
+                - stripped
+            Referrer-Policy:
+                - stripped
+            Server:
+                - stripped
+            Set-Cookie:
+                - stripped
+            Strict-Transport-Security:
+                - stripped
+            Vary:
+                - stripped
+            X-Content-Type-Options:
+                - stripped
+            X-Frame-Options:
+                - stripped
+            X-Gitlab-Meta:
+                - stripped
+            X-Next-Page:
+                - stripped
+            X-Page:
+                - stripped
+            X-Per-Page:
+                - stripped
+            X-Prev-Page:
+                - stripped
+            X-Request-Id:
+                - stripped
+            X-Runtime:
+                - stripped
+            X-Total:
+                - "1"
+            X-Total-Pages:
+                - stripped
+        status: 200 OK
+        code: 200
+        duration: 231.443536ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        form:
+            per_page:
+                - "100"
+        headers:
+            Accept:
+                - application/json
+            Private-Token:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-project/merge_requests/2/diffs?per_page=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"diff":"@@ -2,7 +2,7 @@\n \n \n \n-## Getting started\n+## What Next\n \n To make it easy for you to get started with GitLab, here''s a list of recommended next steps.\n \n","collapsed":false,"too_large":false,"new_path":"README.md","old_path":"README.md","a_mode":"100644","b_mode":"100644","new_file":false,"renamed_file":false,"deleted_file":false,"generated_file":false}]'
+        headers:
+            Cache-Control:
+                - stripped
+            Cf-Cache-Status:
+                - stripped
+            Cf-Ray:
+                - stripped
+            Content-Security-Policy:
+                - stripped
+            Content-Type:
+                - application/json
+            Date:
+                - stripped
+            Etag:
+                - stripped
+            Gitlab-Lb:
+                - stripped
+            Gitlab-Sv:
+                - stripped
+            Link:
+                - stripped
+            Nel:
+                - stripped
+            Ratelimit-Limit:
+                - stripped
+            Ratelimit-Name:
+                - stripped
+            Ratelimit-Observed:
+                - stripped
+            Ratelimit-Remaining:
+                - stripped
+            Ratelimit-Reset:
+                - stripped
+            Referrer-Policy:
+                - stripped
+            Server:
+                - stripped
+            Set-Cookie:
+                - stripped
+            Strict-Transport-Security:
+                - stripped
+            Vary:
+                - stripped
+            X-Content-Type-Options:
+                - stripped
+            X-Frame-Options:
+                - stripped
+            X-Gitlab-Meta:
+                - stripped
+            X-Next-Page:
+                - stripped
+            X-Page:
+                - stripped
+            X-Per-Page:
+                - stripped
+            X-Prev-Page:
+                - stripped
+            X-Request-Id:
+                - stripped
+            X-Runtime:
+                - stripped
+            X-Total:
+                - "1"
+            X-Total-Pages:
+                - stripped
+        status: 200 OK
+        code: 200
+        duration: 244.621276ms

--- a/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/ResolveBranchPullRequest/nested_branch_deleted_after_merge.yaml
+++ b/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/ResolveBranchPullRequest/nested_branch_deleted_after_merge.yaml
@@ -1,0 +1,32 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            Accept:
+                - application/json
+            Private-Token:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-subgroup%2Fanother-test-project/merge_requests?order_by=updated_at&per_page=1&sort=desc&source_branch=johnstcn-main-patch-54711&state=opened
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[]'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 100.000000ms

--- a/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/ResolveBranchPullRequest/nested_fork_branch_not_on_target.yaml
+++ b/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/ResolveBranchPullRequest/nested_fork_branch_not_on_target.yaml
@@ -1,0 +1,32 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            Accept:
+                - application/json
+            Private-Token:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-subgroup%2Fanother-test-project/merge_requests?order_by=updated_at&per_page=1&sort=desc&source_branch=forked&state=opened
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[]'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 100.000000ms

--- a/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/ResolveBranchPullRequest/open_mr_branch.yaml
+++ b/coderd/externalauth/gitprovider/testdata/gitlab_cassettes/ResolveBranchPullRequest/open_mr_branch.yaml
@@ -1,0 +1,32 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: gitlab.com
+        headers:
+            Accept:
+                - application/json
+            Private-Token:
+                - stripped
+            User-Agent:
+                - stripped
+        url: https://gitlab.com/api/v4/projects/test-group9945421%2Ftest-project/merge_requests?order_by=updated_at&per_page=1&sort=desc&source_branch=johnstcn-main-patch-98822&state=opened
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":486249709,"iid":3,"project_id":82310987,"title":"Open mergeable","description":"","state":"opened","created_at":"2026-05-18T14:53:54.688Z","updated_at":"2026-05-18T14:53:55.972Z","merged_by":null,"merge_user":null,"merged_at":null,"closed_by":null,"closed_at":null,"target_branch":"main","source_branch":"johnstcn-main-patch-98822","user_notes_count":0,"upvotes":0,"downvotes":0,"author":{"id":687093,"username":"johnstcn","public_email":"","name":"Cian Johnston","state":"active","locked":false,"avatar_url":"https://gitlab.com/uploads/-/system/user/avatar/687093/avatar.png","web_url":"https://gitlab.com/johnstcn"},"assignees":[{"id":687093,"username":"johnstcn","public_email":"","name":"Cian Johnston","state":"active","locked":false,"avatar_url":"https://gitlab.com/uploads/-/system/user/avatar/687093/avatar.png","web_url":"https://gitlab.com/johnstcn"}],"assignee":{"id":687093,"username":"johnstcn","public_email":"","name":"Cian Johnston","state":"active","locked":false,"avatar_url":"https://gitlab.com/uploads/-/system/user/avatar/687093/avatar.png","web_url":"https://gitlab.com/johnstcn"},"reviewers":[],"source_project_id":82310987,"target_project_id":82310987,"labels":[],"draft":false,"imported":false,"imported_from":"none","work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"can_be_merged","detailed_merge_status":"mergeable","merge_after":null,"sha":"da57fca657e02c1fbe131402f927d134a34b257b","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":true,"prepared_at":"2026-05-18T14:53:55.966Z","reference":"!3","references":{"short":"!3","relative":"!3","full":"johnstcn/test-project!3"},"web_url":"https://gitlab.com/test-group9945421/test-project/-/merge_requests/3","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":false,"squash_on_merge":false,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":false,"blocking_discussions_resolved":true,"approvals_before_merge":null}]'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 100.000000ms

--- a/go.mod
+++ b/go.mod
@@ -523,6 +523,7 @@ require (
 	github.com/tidwall/sjson v1.2.5
 	gitlab.com/gitlab-org/api/client-go v1.46.0
 	gonum.org/v1/gonum v0.17.0
+	gopkg.in/dnaeon/go-vcr.v4 v4.0.6
 	mvdan.cc/sh/v3 v3.13.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1551,6 +1551,8 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/dnaeon/go-vcr.v4 v4.0.6 h1:PiJkrakkmzc5s7EfBnZOnyiLwi7o7A9fwPzN0X2uwe0=
+gopkg.in/dnaeon/go-vcr.v4 v4.0.6/go.mod h1:sbq5oMEcM4PXngbcNbHhzfCP9OdZodLhrbRYoyg09HY=
 gopkg.in/ini.v1 v1.67.1 h1:tVBILHy0R6e4wkYOn3XmiITt/hEVH4TFMYvAX2Ytz6k=
 gopkg.in/ini.v1 v1.67.1/go.mod h1:x/cyOwCgZqOkJoDIJ3c1KNHMo10+nLGAhh+kn3Zizss=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=


### PR DESCRIPTION
Part of CODAGT-146

Add go-vcr based integration tests for the GitLab provider, covering all four provider interface methods against recorded API responses.

Test coverage:
- `FetchPullRequestStatus`: 4 fixtures (open/mergeable, open/conflicts, nested/merged, nested/closed from fork)
- `FetchPullRequestDiff`: 4 fixtures
- `FetchBranchDiff`: 3 fixtures (open MR branch, deleted after merge, fork branch not on target)
- `ResolveBranchPullRequest`: 3 fixtures

Includes cassette YAML files with sanitized GitLab API responses, `.gitattributes` marking them as generated, and `typos.toml` exclusion.

Stacked on #25652. Part 3 of 3.

> Generated with [Coder](https://coder.com) by @johnstcn