### PR TITLE
fix(site): make chat prompt links clickable

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -345,6 +345,50 @@ export const UserMessageBubbleAlignment: Story = {
 	},
 };
 
+export const UserAndAssistantLinks: Story = {
+	args: buildStoryArgs(
+		buildUserMessage({
+			text: "Please review https://github.com/coder/coder/pull/1234 and [docs](https://coder.com/docs).",
+		}),
+		{
+			...baseMessage,
+			id: 2,
+			role: "assistant",
+			content: [
+				buildTextPart(
+					"I found https://linear.app/codercom/issue/CODAGT-478 and [release notes](https://coder.com/changelog).",
+				),
+			],
+		},
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		const userURL = await canvas.findByRole("link", {
+			name: "https://github.com/coder/coder/pull/1234",
+		});
+		expect(userURL).toHaveAttribute(
+			"href",
+			"https://github.com/coder/coder/pull/1234",
+		);
+		expect(userURL).toHaveAttribute("target", "_blank");
+
+		expect(canvas.getByRole("link", { name: "docs" })).toHaveAttribute(
+			"href",
+			"https://coder.com/docs",
+		);
+		expect(
+			canvas.getByRole("link", {
+				name: "https://linear.app/codercom/issue/CODAGT-478",
+			}),
+		).toHaveAttribute("href", "https://linear.app/codercom/issue/CODAGT-478");
+		expect(canvas.getByRole("link", { name: "release notes" })).toHaveAttribute(
+			"href",
+			"https://coder.com/changelog",
+		);
+	},
+};
+
 /** Regression guard: a single image attachment must not be duplicated. */
 export const UserMessageWithSingleImage: Story = {
 	args: {

--- a/site/src/pages/AgentsPage/components/ChatConversation/LinkifiedText.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/LinkifiedText.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { parseLinkifiedText } from "./LinkifiedText";
+
+describe("parseLinkifiedText", () => {
+	it("links bare URLs without trailing punctuation", () => {
+		expect(parseLinkifiedText("Open https://coder.com/docs.")).toEqual([
+			{ type: "text", text: "Open " },
+			{
+				type: "link",
+				text: "https://coder.com/docs",
+				href: "https://coder.com/docs",
+			},
+			{ type: "text", text: "." },
+		]);
+	});
+
+	it("keeps balanced URL parentheses", () => {
+		expect(parseLinkifiedText("See https://example.com/path(foo).")).toEqual([
+			{ type: "text", text: "See " },
+			{
+				type: "link",
+				text: "https://example.com/path(foo)",
+				href: "https://example.com/path(foo)",
+			},
+			{ type: "text", text: "." },
+		]);
+	});
+
+	it("normalizes www URLs", () => {
+		expect(parseLinkifiedText("Go to www.coder.com")).toEqual([
+			{ type: "text", text: "Go to " },
+			{
+				type: "link",
+				text: "www.coder.com",
+				href: "https://www.coder.com",
+			},
+		]);
+	});
+
+	it("links markdown URLs", () => {
+		expect(
+			parseLinkifiedText("Read [the docs](https://coder.com/docs) now."),
+		).toEqual([
+			{ type: "text", text: "Read " },
+			{
+				type: "link",
+				text: "the docs",
+				href: "https://coder.com/docs",
+			},
+			{ type: "text", text: " now." },
+		]);
+	});
+
+	it("links angle-bracket markdown URLs", () => {
+		expect(
+			parseLinkifiedText(
+				"Open [Slack](<https://codercom.slack.com/archives/C0AGTPWLA3U/p1779700516296669?thread_ts=1779700516.296669&cid=C0AGTPWLA3U>).",
+			),
+		).toEqual([
+			{ type: "text", text: "Open " },
+			{
+				type: "link",
+				text: "Slack",
+				href: "https://codercom.slack.com/archives/C0AGTPWLA3U/p1779700516296669?thread_ts=1779700516.296669&cid=C0AGTPWLA3U",
+			},
+			{ type: "text", text: "." },
+		]);
+	});
+});

--- a/site/src/pages/AgentsPage/components/ChatConversation/LinkifiedText.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/LinkifiedText.tsx
@@ -1,0 +1,141 @@
+import { Fragment } from "react";
+
+const LINK_PATTERN =
+	/\[([^\]\n]+)\]\(\s*<((?:https?:\/\/|mailto:|www\.)[^>\s]+)>\s*\)|\[([^\]\n]+)\]\(\s*((?:https?:\/\/|mailto:|www\.)[^\s)]+)\s*\)|<((?:https?:\/\/|mailto:|www\.)[^>\s]+)>|((?:https?:\/\/|mailto:|www\.)[^\s<>"']+)/gi;
+
+const TRAILING_PUNCTUATION = new Set([".", ",", "!", "?", ";", ":"]);
+const CLOSING_PAIRS: Record<string, string> = {
+	")": "(",
+	"]": "[",
+	"}": "{",
+};
+
+type TextSegment = {
+	type: "text";
+	text: string;
+};
+
+type LinkSegment = {
+	type: "link";
+	text: string;
+	href: string;
+};
+
+type LinkifiedTextSegment = TextSegment | LinkSegment;
+
+const countChar = (value: string, char: string): number => {
+	let count = 0;
+	for (const current of value) {
+		if (current === char) {
+			count += 1;
+		}
+	}
+	return count;
+};
+
+const trimTrailingUrlText = (value: string) => {
+	let linkText = value;
+	let trailingText = "";
+
+	while (linkText.length > 0) {
+		const lastChar = linkText[linkText.length - 1];
+		const matchingOpen = CLOSING_PAIRS[lastChar];
+
+		if (TRAILING_PUNCTUATION.has(lastChar)) {
+			trailingText = `${lastChar}${trailingText}`;
+			linkText = linkText.slice(0, -1);
+			continue;
+		}
+
+		if (
+			matchingOpen &&
+			countChar(linkText, lastChar) > countChar(linkText, matchingOpen)
+		) {
+			trailingText = `${lastChar}${trailingText}`;
+			linkText = linkText.slice(0, -1);
+			continue;
+		}
+
+		break;
+	}
+
+	return { linkText, trailingText };
+};
+
+const toHref = (url: string): string => {
+	if (url.toLowerCase().startsWith("www.")) {
+		return `https://${url}`;
+	}
+	return url;
+};
+
+const appendTextSegment = (segments: LinkifiedTextSegment[], text: string) => {
+	if (text.length === 0) {
+		return;
+	}
+	const previous = segments[segments.length - 1];
+	if (previous?.type === "text") {
+		previous.text += text;
+		return;
+	}
+	segments.push({ type: "text", text });
+};
+
+export const parseLinkifiedText = (text: string): LinkifiedTextSegment[] => {
+	const segments: LinkifiedTextSegment[] = [];
+	let lastIndex = 0;
+
+	for (const match of text.matchAll(LINK_PATTERN)) {
+		const matchText = match[0];
+		const matchIndex = match.index ?? 0;
+		const label = match[1] ?? match[3];
+		const markdownURL = match[2] ?? match[4];
+		const angleURL = match[5];
+		const bareURL = match[6];
+		const previousChar = matchIndex > 0 ? text[matchIndex - 1] : "";
+
+		if (label && previousChar === "!") {
+			continue;
+		}
+
+		appendTextSegment(segments, text.slice(lastIndex, matchIndex));
+
+		if (markdownURL) {
+			segments.push({ type: "link", text: label, href: toHref(markdownURL) });
+			lastIndex = matchIndex + matchText.length;
+			continue;
+		}
+
+		const { linkText, trailingText } = trimTrailingUrlText(angleURL ?? bareURL);
+		segments.push({ type: "link", text: linkText, href: toHref(linkText) });
+		appendTextSegment(segments, trailingText);
+		lastIndex = matchIndex + matchText.length;
+	}
+
+	appendTextSegment(segments, text.slice(lastIndex));
+	return segments;
+};
+
+export const LinkifiedText = ({ text }: { text: string }) => {
+	return (
+		<>
+			{parseLinkifiedText(text).map((segment, index) => {
+				if (segment.type === "text") {
+					return <Fragment key={index}>{segment.text}</Fragment>;
+				}
+
+				return (
+					<a
+						key={index}
+						href={segment.href}
+						target="_blank"
+						rel="noopener noreferrer"
+						className="text-content-link no-underline hover:underline hover:decoration-content-link"
+					>
+						{segment.text}
+					</a>
+				);
+			})}
+		</>
+	);
+};

--- a/site/src/pages/AgentsPage/components/ChatConversation/UserMessageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/UserMessageContent.tsx
@@ -1,4 +1,4 @@
-import { type FC, Fragment } from "react";
+import type { FC } from "react";
 import { cn } from "#/utils/cn";
 import { Message, MessageContent } from "../ChatElements";
 import { FileReferenceChip } from "../ChatMessageInput/FileReferenceNode";
@@ -6,6 +6,7 @@ import {
 	AttachmentBlock,
 	type PreviewTextAttachment,
 } from "./AttachmentBlocks";
+import { LinkifiedText } from "./LinkifiedText";
 import type {
 	MessageDisplayState,
 	UserInlineRenderBlock,
@@ -13,7 +14,7 @@ import type {
 
 const renderUserInlineBlock = (block: UserInlineRenderBlock, index: number) => {
 	if (block.type === "response") {
-		return <Fragment key={index}>{block.text}</Fragment>;
+		return <LinkifiedText key={index} text={block.text} />;
 	}
 
 	return (
@@ -60,11 +61,13 @@ export const UserMessageContent: FC<{
 						<div className="flex items-start gap-2">
 							{displayState.hasUserMessageBody && (
 								<span className="min-w-0 flex-1">
-									{displayState.userInlineContent.length > 0
-										? displayState.userInlineContent.map((block, index) =>
-												renderUserInlineBlock(block, index),
-											)
-										: markdown || ""}
+									{displayState.userInlineContent.length > 0 ? (
+										displayState.userInlineContent.map((block, index) =>
+											renderUserInlineBlock(block, index),
+										)
+									) : (
+										<LinkifiedText text={markdown || ""} />
+									)}
 								</span>
 							)}
 						</div>


### PR DESCRIPTION
Previously, user prompt bubbles rendered text literally, so raw URLs and markdown links were not clickable while assistant responses already relied on markdown rendering.

This adds link parsing for user prompt text while preserving the existing plain-text rendering, plus Storybook coverage for user and assistant links. Refs CODAGT-478.

Generated by Coder Agents.
