### PR TITLE
chore(site): rename AI Bridge Sessions dropdown to AI Sessions

### DIFF
--- a/site/src/modules/dashboard/Navbar/DeploymentDropdown.tsx
+++ b/site/src/modules/dashboard/Navbar/DeploymentDropdown.tsx
@@ -90,7 +90,7 @@ const DeploymentDropdownContent: FC<DeploymentDropdownProps> = ({
 			)}
 			{canViewAIBridge && (
 				<DropdownMenuItem asChild>
-					<Link to="/aibridge/sessions">AI Bridge Sessions</Link>
+					<Link to="/aibridge/sessions">AI Sessions</Link>
 				</DropdownMenuItem>
 			)}
 			{canViewHealth && (


### PR DESCRIPTION
Renames the admin settings dropdown label from "AI Bridge Sessions" to "AI Sessions". The link target (`/aibridge/sessions`) is unchanged.