### PR TITLE
DNM: deliberate breakage to validate dogfood CI

### DIFF
--- a/coderd/util/shellparse/shellparse.go
+++ b/coderd/util/shellparse/shellparse.go
@@ -107,3 +107,6 @@ func firstNonFlagLiteral(ws []*syntax.Word) string {
 	}
 	return ""
 }
+
+// Deliberate breakage to test dogfood CI validation.
+var _ = thisVariableDoesNotExist

--- a/dogfood/coder/ubuntu-22.04/Dockerfile
+++ b/dogfood/coder/ubuntu-22.04/Dockerfile
@@ -263,3 +263,4 @@ ENV GOPRIVATE="coder.com,cdr.dev,go.coder.com,github.com/cdr,github.com/coder"
 
 # Increase memory allocation to NodeJS
 ENV NODE_OPTIONS="--max-old-space-size=8192"
+# test: trigger dogfood workflow


### PR DESCRIPTION
**DO NOT MERGE** - This PR intentionally introduces a compile error to verify that the `test_image` job in the dogfood workflow catches tooling breakage.

Changes:
- Adds an undefined variable reference in `coderd/util/shellparse/shellparse.go`
- Adds a comment to `dogfood/coder/ubuntu-22.04/Dockerfile` to trigger the dogfood workflow

Expected result: `test_image (22.04)` and `test_image (26.04)` should fail at the `build` step with `undefined: thisVariableDoesNotExist`.

> [!NOTE]
> Generated with [Coder Agents](https://coder.com/agents)