### PR TITLE
fix(site/src/pages/AgentsPage): avoid skills popup flash

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatMessageInput/ChatMessageInput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatMessageInput/ChatMessageInput.stories.tsx
@@ -76,6 +76,13 @@ const expectNoVisibleText = async (text: string) => {
 	});
 };
 
+const expectNoVisibleTextImmediately = (text: string) => {
+	const matches = within(document.body).queryAllByText(text);
+	expect(
+		matches.every((element) => element.getClientRects().length === 0),
+	).toBe(true);
+};
+
 const editorFromCanvas = (canvasElement: HTMLElement) => {
 	const canvas = within(canvasElement);
 	return canvas.getByTestId("chat-message-input");
@@ -188,6 +195,18 @@ export const EmptyDescriptionInsertsNameOnly: Story = {
 export const SlashInsideUrlDoesNotOpen: Story = {
 	play: async ({ canvasElement }) => {
 		await typeInEditor(canvasElement, "https://");
+		await expectNoVisibleText("/reviewer");
+	},
+};
+
+export const BackspaceClosesWithoutEmptyStateFlash: Story = {
+	play: async ({ canvasElement }) => {
+		const editor = await typeInEditor(canvasElement, "/");
+		await findVisibleText("/reviewer");
+		await userEvent.keyboard("{Backspace}");
+
+		expect(editor.textContent).toBe("");
+		expectNoVisibleTextImmediately("No personal skills found.");
 		await expectNoVisibleText("/reviewer");
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatMessageInput/PersonalSkillsTriggerMenu.tsx
+++ b/site/src/pages/AgentsPage/components/ChatMessageInput/PersonalSkillsTriggerMenu.tsx
@@ -54,87 +54,90 @@ export const PersonalSkillsTriggerMenu = ({
 		}
 	};
 
-	const shouldRender = open && anchorRect;
+	const anchor = open ? anchorRect : null;
 
 	return (
 		<Popover
-			open={Boolean(shouldRender)}
+			open={Boolean(anchor)}
 			onOpenChange={(nextOpen) => {
 				if (!nextOpen) {
 					onClose();
 				}
 			}}
 		>
-			{shouldRender && (
-				<PopoverAnchor asChild>
-					<span
-						aria-hidden="true"
-						style={{
-							position: "fixed",
-							top: anchorRect.top,
-							left: anchorRect.left,
-							width: 1,
-							height: Math.max(anchorRect.height, MIN_ANCHOR_HEIGHT_PX),
-							pointerEvents: "none",
-						}}
-					/>
-				</PopoverAnchor>
-			)}
-			<PopoverContent
-				align="start"
-				side="bottom"
-				className="w-80 overflow-hidden p-1 mobile-full-width-dropdown mobile-full-width-dropdown-above-composer"
-				onMouseDown={(event) => event.preventDefault()}
-				onOpenAutoFocus={(event) => event.preventDefault()}
-				onCloseAutoFocus={(event) => event.preventDefault()}
-			>
-				<Command
-					shouldFilter={false}
-					loop={false}
-					onValueChange={handleHighlightedValueChange}
-					value={skills[selectedIndex]?.name ?? ""}
-				>
-					<CommandList className="max-h-72 border-t-0 mobile-full-width-dropdown-scroll-area">
-						{isLoading ? (
-							<CommandItem value="loading" disabled>
-								Loading personal skills...
-							</CommandItem>
-						) : isError ? (
-							<CommandItem value="error" disabled>
-								Could not load personal skills. Close and type / again to retry.
-							</CommandItem>
-						) : skills.length === 0 ? (
-							<CommandEmpty>
-								{query
-									? "No personal skills match that query."
-									: "No personal skills found."}
-							</CommandEmpty>
-						) : (
-							<CommandGroup heading="Personal skills">
-								{skills.map((skill) => (
-									<CommandItem
-										key={skill.id}
-										value={skill.name}
-										className="items-start"
-										onSelect={() => onSelect(skill)}
-									>
-										<div className="min-w-0 space-y-1">
-											<div className="truncate font-mono text-content-primary text-xs">
-												{personalSkillTriggerText(skill)}
-											</div>
-											{skill.description.trim() && (
-												<div className="line-clamp-2 text-content-secondary text-xs leading-snug">
-													{skill.description}
-												</div>
-											)}
-										</div>
+			{anchor && (
+				<>
+					<PopoverAnchor asChild>
+						<span
+							aria-hidden="true"
+							style={{
+								position: "fixed",
+								top: anchor.top,
+								left: anchor.left,
+								width: 1,
+								height: Math.max(anchor.height, MIN_ANCHOR_HEIGHT_PX),
+								pointerEvents: "none",
+							}}
+						/>
+					</PopoverAnchor>
+					<PopoverContent
+						align="start"
+						side="bottom"
+						className="w-80 overflow-hidden p-1 mobile-full-width-dropdown mobile-full-width-dropdown-above-composer"
+						onMouseDown={(event) => event.preventDefault()}
+						onOpenAutoFocus={(event) => event.preventDefault()}
+						onCloseAutoFocus={(event) => event.preventDefault()}
+					>
+						<Command
+							shouldFilter={false}
+							loop={false}
+							onValueChange={handleHighlightedValueChange}
+							value={skills[selectedIndex]?.name ?? ""}
+						>
+							<CommandList className="max-h-72 border-t-0 mobile-full-width-dropdown-scroll-area">
+								{isLoading ? (
+									<CommandItem value="loading" disabled>
+										Loading personal skills...
 									</CommandItem>
-								))}
-							</CommandGroup>
-						)}
-					</CommandList>
-				</Command>
-			</PopoverContent>
+								) : isError ? (
+									<CommandItem value="error" disabled>
+										Could not load personal skills. Close and type / again to
+										retry.
+									</CommandItem>
+								) : skills.length === 0 ? (
+									<CommandEmpty>
+										{query
+											? "No personal skills match that query."
+											: "No personal skills found."}
+									</CommandEmpty>
+								) : (
+									<CommandGroup heading="Personal skills">
+										{skills.map((skill) => (
+											<CommandItem
+												key={skill.id}
+												value={skill.name}
+												className="items-start"
+												onSelect={() => onSelect(skill)}
+											>
+												<div className="min-w-0 space-y-1">
+													<div className="truncate font-mono text-content-primary text-xs">
+														{personalSkillTriggerText(skill)}
+													</div>
+													{skill.description.trim() && (
+														<div className="line-clamp-2 text-content-secondary text-xs leading-snug">
+															{skill.description}
+														</div>
+													)}
+												</div>
+											</CommandItem>
+										))}
+									</CommandGroup>
+								)}
+							</CommandList>
+						</Command>
+					</PopoverContent>
+				</>
+			)}
 		</Popover>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatMessageInput/PersonalSkillsTriggerMenu.tsx
+++ b/site/src/pages/AgentsPage/components/ChatMessageInput/PersonalSkillsTriggerMenu.tsx
@@ -1,3 +1,4 @@
+import { useLayoutEffect, useState } from "react";
 import type * as TypesGen from "#/api/typesGenerated";
 import {
 	Command,
@@ -35,6 +36,15 @@ type PersonalSkillsTriggerMenuProps = {
 	onClose: () => void;
 };
 
+type PersonalSkillsMenuState = {
+	anchorRect: CaretAnchorRect;
+	query: string;
+	skills: readonly TypesGen.UserSkillMetadata[];
+	isLoading?: boolean;
+	isError?: boolean;
+	selectedIndex: number;
+};
+
 export const PersonalSkillsTriggerMenu = ({
 	open,
 	anchorRect,
@@ -47,97 +57,132 @@ export const PersonalSkillsTriggerMenu = ({
 	onSelect,
 	onClose,
 }: PersonalSkillsTriggerMenuProps) => {
+	const [lastOpenMenuState, setLastOpenMenuState] =
+		useState<PersonalSkillsMenuState | null>(null);
+	const isAnchoredOpen = open && anchorRect !== null;
+	const activeMenuState: PersonalSkillsMenuState | null = isAnchoredOpen
+		? {
+				anchorRect,
+				query,
+				skills,
+				isLoading,
+				isError,
+				selectedIndex,
+			}
+		: null;
+	const menuState = activeMenuState ?? lastOpenMenuState;
+	const menuAnchorRect = menuState?.anchorRect ?? null;
+	const menuSkills = menuState?.skills ?? [];
+	const menuSelectedIndex = menuState?.selectedIndex ?? -1;
+
+	useLayoutEffect(() => {
+		if (!isAnchoredOpen) {
+			return;
+		}
+		setLastOpenMenuState({
+			anchorRect,
+			query,
+			skills,
+			isLoading,
+			isError,
+			selectedIndex,
+		});
+	}, [
+		anchorRect,
+		isAnchoredOpen,
+		isError,
+		isLoading,
+		query,
+		selectedIndex,
+		skills,
+	]);
+
 	const handleHighlightedValueChange = (value: string) => {
-		const nextIndex = skills.findIndex((skill) => skill.name === value);
+		const nextIndex = menuSkills.findIndex((skill) => skill.name === value);
 		if (nextIndex >= 0) {
 			onSelectedIndexChange(nextIndex);
 		}
 	};
 
-	const anchor = open ? anchorRect : null;
-
 	return (
 		<Popover
-			open={Boolean(anchor)}
+			open={isAnchoredOpen}
 			onOpenChange={(nextOpen) => {
 				if (!nextOpen) {
 					onClose();
 				}
 			}}
 		>
-			{anchor && (
-				<>
-					<PopoverAnchor asChild>
-						<span
-							aria-hidden="true"
-							style={{
-								position: "fixed",
-								top: anchor.top,
-								left: anchor.left,
-								width: 1,
-								height: Math.max(anchor.height, MIN_ANCHOR_HEIGHT_PX),
-								pointerEvents: "none",
-							}}
-						/>
-					</PopoverAnchor>
-					<PopoverContent
-						align="start"
-						side="bottom"
-						className="w-80 overflow-hidden p-1 mobile-full-width-dropdown mobile-full-width-dropdown-above-composer"
-						onMouseDown={(event) => event.preventDefault()}
-						onOpenAutoFocus={(event) => event.preventDefault()}
-						onCloseAutoFocus={(event) => event.preventDefault()}
-					>
-						<Command
-							shouldFilter={false}
-							loop={false}
-							onValueChange={handleHighlightedValueChange}
-							value={skills[selectedIndex]?.name ?? ""}
-						>
-							<CommandList className="max-h-72 border-t-0 mobile-full-width-dropdown-scroll-area">
-								{isLoading ? (
-									<CommandItem value="loading" disabled>
-										Loading personal skills...
-									</CommandItem>
-								) : isError ? (
-									<CommandItem value="error" disabled>
-										Could not load personal skills. Close and type / again to
-										retry.
-									</CommandItem>
-								) : skills.length === 0 ? (
-									<CommandEmpty>
-										{query
-											? "No personal skills match that query."
-											: "No personal skills found."}
-									</CommandEmpty>
-								) : (
-									<CommandGroup heading="Personal skills">
-										{skills.map((skill) => (
-											<CommandItem
-												key={skill.id}
-												value={skill.name}
-												className="items-start"
-												onSelect={() => onSelect(skill)}
-											>
-												<div className="min-w-0 space-y-1">
-													<div className="truncate font-mono text-content-primary text-xs">
-														{personalSkillTriggerText(skill)}
-													</div>
-													{skill.description.trim() && (
-														<div className="line-clamp-2 text-content-secondary text-xs leading-snug">
-															{skill.description}
-														</div>
-													)}
-												</div>
-											</CommandItem>
-										))}
-									</CommandGroup>
-								)}
-							</CommandList>
-						</Command>
-					</PopoverContent>
-				</>
+			{menuAnchorRect && (
+				<PopoverAnchor asChild>
+					<span
+						aria-hidden="true"
+						style={{
+							position: "fixed",
+							top: menuAnchorRect.top,
+							left: menuAnchorRect.left,
+							width: 1,
+							height: Math.max(menuAnchorRect.height, MIN_ANCHOR_HEIGHT_PX),
+							pointerEvents: "none",
+						}}
+					/>
+				</PopoverAnchor>
 			)}
+			<PopoverContent
+				align="start"
+				side="bottom"
+				className="w-80 overflow-hidden p-1 mobile-full-width-dropdown mobile-full-width-dropdown-above-composer"
+				onMouseDown={(event) => event.preventDefault()}
+				onOpenAutoFocus={(event) => event.preventDefault()}
+				onCloseAutoFocus={(event) => event.preventDefault()}
+			>
+				<Command
+					shouldFilter={false}
+					loop={false}
+					onValueChange={handleHighlightedValueChange}
+					value={menuSkills[menuSelectedIndex]?.name ?? ""}
+				>
+					<CommandList className="max-h-72 border-t-0 mobile-full-width-dropdown-scroll-area">
+						{menuState?.isLoading ? (
+							<CommandItem value="loading" disabled>
+								Loading personal skills...
+							</CommandItem>
+						) : menuState?.isError ? (
+							<CommandItem value="error" disabled>
+								Could not load personal skills. Close and type / again to retry.
+							</CommandItem>
+						) : menuSkills.length === 0 ? (
+							<CommandEmpty>
+								{menuState?.query
+									? "No personal skills match that query."
+									: "No personal skills found."}
+							</CommandEmpty>
+						) : (
+							<CommandGroup heading="Personal skills">
+								{menuSkills.map((skill) => (
+									<CommandItem
+										key={skill.id}
+										value={skill.name}
+										className="items-start"
+										onSelect={() => onSelect(skill)}
+									>
+										<div className="min-w-0 space-y-1">
+											<div className="truncate font-mono text-content-primary text-xs">
+												{personalSkillTriggerText(skill)}
+											</div>
+											{skill.description.trim() && (
+												<div className="line-clamp-2 text-content-secondary text-xs leading-snug">
+													{skill.description}
+												</div>
+											)}
+										</div>
+									</CommandItem>
+								))}
+							</CommandGroup>
+						)}
+					</CommandList>
+				</Command>
+			</PopoverContent>
 		</Popover>
 	);
 };


### PR DESCRIPTION
When removing the `/` personal skill trigger, the popover content stayed mounted during its close transition and briefly rendered the empty skills state at the viewport origin.

This keeps the menu content mounted for stable Radix positioning, preserves the last open menu state during the close transition, and adds a Storybook regression for the backspace path.

> Mux is creating this PR on behalf of Mike.
