### PR TITLE
fix: stop treating pending chat notification as cancel signal

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -5782,8 +5782,17 @@ func shouldCancelChatFromControlNotification(
 ) bool {
 	status := database.ChatStatus(strings.TrimSpace(notify.Status))
 	switch status {
-	case database.ChatStatusWaiting, database.ChatStatusPending, database.ChatStatusError:
+	case database.ChatStatusWaiting, database.ChatStatusError:
 		return true
+	case database.ChatStatusPending:
+		// Pending is not a cancel signal. SendMessage and auto-promote
+		// produce stale echoes (the notification that triggered this
+		// run, or one published after processing finishes). EditMessage
+		// produces a live signal, but cancellation for that case is
+		// handled by the persistStep ownership guard at the next step
+		// boundary, not by the control subscriber.
+		// See CODAGT-383.
+		return false
 	case database.ChatStatusRunning:
 		worker := strings.TrimSpace(notify.WorkerID)
 		if worker == "" {

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -6690,3 +6690,29 @@ func TestPersistChatContextSummarySetsAPIKeyID(t *testing.T) {
 	}
 	require.True(t, foundUserSummary, "expected to find compressed user summary message")
 }
+
+func TestShouldCancelChatFromControlNotification(t *testing.T) {
+	t.Parallel()
+	myWorker := uuid.New()
+	otherWorker := uuid.New()
+	tests := []struct {
+		name   string
+		notify coderdpubsub.ChatStreamNotifyMessage
+		want   bool
+	}{
+		{"waiting cancels", coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusWaiting)}, true},
+		{"error cancels", coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusError)}, true},
+		{"pending does not cancel", coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusPending)}, false},
+		{"running different worker cancels", coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusRunning), WorkerID: otherWorker.String()}, true},
+		{"running same worker does not cancel", coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusRunning), WorkerID: myWorker.String()}, false},
+		{"running empty worker does not cancel", coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusRunning)}, false},
+		{"running malformed worker does not cancel", coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusRunning), WorkerID: "not-a-uuid"}, false},
+		{"unknown status does not cancel", coderdpubsub.ChatStreamNotifyMessage{Status: "completed"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, shouldCancelChatFromControlNotification(tt.notify, myWorker))
+		})
+	}
+}

--- a/enterprise/coderd/x/chatd/chatd_test.go
+++ b/enterprise/coderd/x/chatd/chatd_test.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1435,12 +1436,6 @@ func TestSubscribeRelayDialCanceledOnFastCompletion(t *testing.T) {
 // condition where the relay is too slow.
 func TestSubscribeRelayEstablishedMidStream(t *testing.T) {
 	t.Parallel()
-	// TODO(CODAGT-353): Re-enable this test after the chatd notification flow
-	// refactor gives workers enough causal information to distinguish stale
-	// control NOTIFY messages from real interrupts. The current design reuses
-	// the same status notification shape for wake-only and interrupt intents,
-	// so a stale NOTIFY can cancel a new processChat run.
-	t.Skip("skipped until chatd notification flow refactor handles stale control notifications")
 
 	db, ps := dbtestutil.NewDB(t)
 	workerID := uuid.New()
@@ -1620,4 +1615,220 @@ waitForStream:
 	// arrive because the relay is never established.
 	require.NotEmpty(t, messageParts,
 		"streaming parts should be received when relay establishes while worker is still streaming")
+}
+
+// delayedPendingPubsub wraps a real Pubsub and holds back any
+// Publish call whose payload contains a "pending" status on a chat
+// stream notify channel. Held messages are published when
+// releaseHeld() is called. This is a test-only wrapper (no production
+// code changes) that widens the race window in CODAGT-383 so the
+// stale "pending" notification arrives at the worker's control
+// subscriber AFTER close(controlArmed).
+type delayedPendingPubsub struct {
+	dbpubsub.Pubsub
+	held chan heldMsg
+}
+
+type heldMsg struct {
+	event   string
+	message []byte
+}
+
+func newDelayedPendingPubsub(inner dbpubsub.Pubsub) *delayedPendingPubsub {
+	return &delayedPendingPubsub{
+		Pubsub: inner,
+		held:   make(chan heldMsg, 16),
+	}
+}
+
+func (d *delayedPendingPubsub) Publish(event string, message []byte) error {
+	// Intercept chat stream notify messages with status=pending.
+	if strings.HasPrefix(event, "chat:stream:") {
+		var notify coderdpubsub.ChatStreamNotifyMessage
+		if err := json.Unmarshal(message, &notify); err == nil && notify.Status == string(database.ChatStatusPending) {
+			// Hold the message; it will be replayed on releaseHeld().
+			d.held <- heldMsg{event: event, message: message}
+			return nil
+		}
+	}
+	return d.Pubsub.Publish(event, message)
+}
+
+// releaseHeld publishes all held pending messages on the inner Pubsub.
+func (d *delayedPendingPubsub) releaseHeld() {
+	for {
+		select {
+		case msg := <-d.held:
+			_ = d.Pubsub.Publish(msg.event, msg.message)
+		default:
+			return
+		}
+	}
+}
+
+// TestSubscribeRelayDialCanceledOnFastCompletion_StalePendingDoesNotInterrupt
+// is a deterministic reproduction of CODAGT-383. It uses a pubsub
+// wrapper to delay the "pending" notification from SendMessage until
+// the worker's control subscriber is armed (close(controlArmed) has
+// executed), then replays it while the LLM is still streaming.
+// With the fix applied, the stale pending notification is ignored
+// and the assistant message commits successfully.
+func TestSubscribeRelayDialCanceledOnFastCompletion_StalePendingDoesNotInterrupt(t *testing.T) {
+	t.Parallel()
+
+	db, realPS := dbtestutil.NewDB(t)
+	// Wrap pubsub to hold back "pending" notifications.
+	ps := newDelayedPendingPubsub(realPS)
+
+	workerID := uuid.New()
+	subscriberID := uuid.New()
+
+	workerDone := make(chan struct{})
+
+	// Gate: the LLM blocks until we release it. This keeps the
+	// worker in active processing while we inject the stale
+	// pending notification.
+	llmContinue := make(chan struct{})
+
+	openAIURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
+		if !req.Stream {
+			return chattest.OpenAINonStreamingResponse("stale-pending-repro")
+		}
+		// Block until the test releases us. This keeps the worker
+		// in active processing so the stale notification can arrive
+		// while processChat is running.
+		<-llmContinue
+		return chattest.OpenAIStreamingResponse(
+			chattest.OpenAITextChunks("hello ", "world")...,
+		)
+	})
+
+	workerLogger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	worker := osschatd.New(osschatd.Config{
+		Logger:                     workerLogger,
+		Database:                   db,
+		ReplicaID:                  workerID,
+		Pubsub:                     ps,
+		PendingChatAcquireInterval: time.Hour,
+		InFlightChatStaleAfter:     testutil.WaitSuperLong,
+	})
+	worker.Start()
+	t.Cleanup(func() {
+		require.NoError(t, worker.Close())
+	})
+
+	subscriber := newTestServer(t, db, ps, subscriberID, func(
+		ctx context.Context,
+		chatID uuid.UUID,
+		_ uuid.UUID,
+		requestHeader http.Header,
+	) (
+		[]codersdk.ChatStreamEvent,
+		<-chan codersdk.ChatStreamEvent,
+		func(),
+		error,
+	) {
+		select {
+		case <-workerDone:
+		case <-ctx.Done():
+			return nil, nil, nil, ctx.Err()
+		}
+		snapshot, relayEvents, cancel, ok := worker.Subscribe(ctx, chatID, requestHeader, math.MaxInt64)
+		if !ok {
+			return nil, nil, nil, xerrors.New("worker subscribe failed")
+		}
+		return snapshot, relayEvents, cancel, nil
+	}, nil)
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, org, model := seedChatDependencies(t, db)
+	setOpenAIProviderBaseURL(ctx, t, db, openAIURL)
+
+	chat := seedWaitingChat(t, db, org.ID, user, model, "stale-pending-repro")
+
+	_, events, subCancel, ok := subscriber.Subscribe(ctx, chat.ID, nil, 0)
+	require.True(t, ok)
+	defer subCancel()
+
+	// SendMessage publishes {Status: "pending"} which our wrapper
+	// holds back instead of delivering immediately.
+	_, err := worker.SendMessage(ctx, osschatd.SendMessageOptions{
+		ChatID:    chat.ID,
+		CreatedBy: user.ID,
+		Content:   []codersdk.ChatMessagePart{codersdk.ChatMessageText("hello")},
+	})
+	require.NoError(t, err)
+
+	// Wait for the worker to reach "running" state, which means
+	// close(controlArmed) has already executed.
+	require.Eventually(t, func() bool {
+		fromDB, dbErr := db.GetChatByID(ctx, chat.ID)
+		if dbErr != nil {
+			return false
+		}
+		return fromDB.Status == database.ChatStatusRunning
+	}, testutil.WaitMedium, testutil.IntervalFast)
+
+	// NOW release the held "pending" notification while the LLM is
+	// still blocked. The notification propagates through pubsub to
+	// the control subscriber while the worker is actively processing.
+	// With the bug, shouldCancelChatFromControlNotification returns
+	// true for "pending" and the chat is interrupted.
+	ps.releaseHeld()
+
+	// Allow the stale notification to propagate through real pubsub.
+	// A deterministic signal (e.g. delivery callback) would require
+	// instrumenting the production subscriber, which is disproportionate
+	// for a race reproduction test. The sleep widens the window so the
+	// notification arrives while the LLM is still blocked.
+	time.Sleep(200 * time.Millisecond)
+
+	// Release the LLM to complete (or, with the bug, the worker is
+	// already interrupted so this unblocks the OpenAI handler which
+	// then returns to a canceled context).
+	close(llmContinue)
+
+	// Give the worker time to finish.
+	require.Eventually(t, func() bool {
+		fromDB, dbErr := db.GetChatByID(ctx, chat.ID)
+		if dbErr != nil {
+			return false
+		}
+		return fromDB.Status == database.ChatStatusWaiting ||
+			fromDB.Status == database.ChatStatusError
+	}, testutil.WaitMedium, testutil.IntervalFast)
+
+	close(workerDone)
+
+	// Collect events. With the bug, the chat was interrupted and
+	// no assistant message was committed, so this times out.
+	var committedAssistantMsgs int
+	timedOut := false
+	func() {
+		shortCtx, shortCancel := context.WithTimeout(ctx, testutil.WaitShort)
+		defer shortCancel()
+		for {
+			select {
+			case event := <-events:
+				if event.Type == codersdk.ChatStreamEventTypeMessage &&
+					event.Message != nil &&
+					event.Message.Role == codersdk.ChatMessageRoleAssistant {
+					committedAssistantMsgs++
+					return
+				}
+			case <-shortCtx.Done():
+				timedOut = true
+				return
+			}
+		}
+	}()
+
+	if timedOut {
+		fromDB, dbErr := db.GetChatByID(ctx, chat.ID)
+		require.NoError(t, dbErr)
+		t.Logf("chat status: %s (interrupted=%v)", fromDB.Status, fromDB.Status == database.ChatStatusWaiting)
+	}
+
+	require.Equal(t, 1, committedAssistantMsgs,
+		"committed assistant message should arrive; stale pending notification must not interrupt processing")
 }


### PR DESCRIPTION
## Summary

Stale "pending" pubsub notifications from `SendMessage` can arrive at the worker control subscriber after the `gatedCancel` gate is armed, causing a spurious `ErrInterrupted` that aborts the LLM call before the assistant message is committed. This is the root cause of the `TestSubscribeRelayDialCanceledOnFastCompletion` flake (CODAGT-383) and the `TestSubscribeRelayEstablishedMidStream` flake (CODAGT-179, skipped under CODAGT-353).

## Root cause

`shouldCancelChatFromControlNotification` treated `ChatStatusPending` as a cancel signal. `SendMessage` sets the chat to "pending" and publishes a control notification via PostgreSQL NOTIFY. Due to async delivery, this notification can arrive at the worker's control subscriber after `close(controlArmed)`, passing the `gatedCancel` gate and triggering `cancel(ErrInterrupted)`.

<details><summary>Evidence: dlv session showing the bug mechanism</summary>

The debugger breakpoint at `shouldCancelChatFromControlNotification` shows a notification with `Status: "pending"` arriving through the async pubsub dispatch path (`msgQueue.run` -> `subscribeChatControl.func1`), about to return `true` (cancel):

```
> [Breakpoint 1] shouldCancelChatFromControlNotification() chatd.go:5648
  notify.Status = "pending"
  => return true

Goroutine stack:
  shouldCancelChatFromControlNotification  chatd.go:5649
  subscribeChatControl.func1              chatd.go:5687
  (*msgQueue).run                         pubsub.go:115
  newMsgQueue.gowrap1                     pubsub.go:87
```

</details>

## Fix

Remove `ChatStatusPending` from the cancel-trigger set. A "pending" notification reaching an active worker is always a stale echo in two of the three paths:

1. **SendMessage**: publishes "pending" as the trigger for processing (stale by the time `processChat` runs).
2. **Auto-promote**: publishes "pending" after `processChat` returns (control subscriber already unsubscribed).

The third path, **EditMessage**, produces a live "pending" signal (not a stale echo), but it also clears `WorkerID`. Cancellation for this case is handled by the `persistStep` ownership guard at the next step boundary, not by the control subscriber. See CODAGT-383.

The remaining cancel-triggering statuses (waiting, error, running-different-worker) represent genuine state changes that should interrupt the active run.

## Tests

- **Table-driven unit test**: `TestShouldCancelChatFromControlNotification` covers all 8 branches of the predicate. (Renamed from the proof-of-concept version used during investigation.)
- **Integration test**: `TestSubscribeRelayDialCanceledOnFastCompletion_StalePendingDoesNotInterrupt` reproduces the race deterministically with a `delayedPendingPubsub` wrapper that holds back the "pending" notification until the worker reaches "running" status.
- **Unskipped**: `TestSubscribeRelayEstablishedMidStream` (previously skipped under CODAGT-353). See proof below.

<details><summary>Unskip proof: red/green/revert cycle for TestSubscribeRelayEstablishedMidStream</summary>

### Method

A `delayedPendingPubsub` wrapper holds the "pending" notification from `SendMessage`, then releases it after the worker reaches "running" (i.e. after `close(controlArmed)` has executed). This deterministically reproduces the race window that caused the flake.

The red/green/revert cycle uses this wrapper to prove the fix is both necessary and sufficient:

### Red (without fix): 5/5 FAIL

Error signature on every run:

```
processor: chat interrupted  chat_id=...
...
Error:      Condition never satisfied
```

The stale "pending" notification passes the `gatedCancel` gate, `shouldCancelChatFromControlNotification` returns `true`, and the chat is interrupted before the LLM can commit an assistant message.

### Green (with fix): 5/5 PASS

```
--- PASS: ...StalePendingDoesNotInterrupt (0.53s)
--- PASS: ...StalePendingDoesNotInterrupt (0.41s)
--- PASS: ...StalePendingDoesNotInterrupt (0.41s)
--- PASS: ...StalePendingDoesNotInterrupt (0.50s)
--- PASS: ...StalePendingDoesNotInterrupt (0.51s)
```

### Revert (fix reverted): 5/5 FAIL

Same `chat interrupted` / `Condition never satisfied` error signature as the red run, confirming the fix is the cause of the green result.

### Why pending is the only stale cancel vector in this test

The skip comment (CODAGT-353) warns about "stale control NOTIFY messages" generally, not just pending. To justify the unskip, we must show that no OTHER stale notification can cancel this test.

`TestSubscribeRelayEstablishedMidStream` runs a single `SendMessage` -> `processChat` cycle with one worker. An instrumented build (println in `shouldCancelChatFromControlNotification`) across 20 runs shows the control subscriber receives exactly three notification types:

| Status | Source | Cancel? |
|--------|--------|---------|
| `running` (same workerID) | `processChat` publishing its own status | No (same-worker check returns false) |
| empty string | Data notification (`AfterMessageID` set, no `Status`); falls to default | No (default returns false) |
| `waiting` | `finishActiveChat` cleanup | Yes, legitimate end-of-processing |

No `pending`, `error`, or `running`-different-worker notifications were observed. This is consistent with the notification trace: between `SendMessage` (publishes pending) and `finishActiveChat` (publishes waiting), the only other publishes on `chat:stream:{chatID}` are `running` (own worker) and data messages (message persistence). The `pending` from `SendMessage` is published BEFORE `subscribeChatControl` creates the listener, so it only arrives stale if async NOTIFY delivery delays it past `close(controlArmed)`.

The fix makes `pending` return `false`. The other two notification types already return `false`. The `waiting` terminator is the only `true` result and it is the legitimate end signal. No stale notification of any cancel-triggering status can reach the control subscriber in this test's single-run scenario.

</details>

---

> [!NOTE]
> Generated by Coder agent on behalf of @mafredri.

Fixes [CODAGT-383](https://linear.app/codercom/issue/CODAGT-383)
Refs [CODAGT-179](https://linear.app/codercom/issue/CODAGT-179), [CODAGT-353](https://linear.app/codercom/issue/CODAGT-353)
