### PR TITLE
ci: extract go-test-failure-report composite action

### DIFF
--- a/.github/actions/go-test-failure-report/action.yaml
+++ b/.github/actions/go-test-failure-report/action.yaml
@@ -1,0 +1,76 @@
+name: "Go Test Failure Report"
+description: "Publish Go test failure summaries and upload failure artifacts"
+
+inputs:
+  json-file:
+    description: "Path to the gotestsum JSON file. Use default for RUNNER_TEMP/go-test.json."
+    required: false
+    default: "default"
+  failures-file:
+    description: "Path to write newline-delimited failure details. Use default for RUNNER_TEMP/go-test-failures.ndjson."
+    required: false
+    default: "default"
+  artifact-name:
+    description: "Artifact name for uploaded failure details"
+    required: true
+  retention-days:
+    description: "Artifact retention in days"
+    required: false
+    default: "7"
+  max-output-bytes:
+    description: "Maximum bytes to include in the markdown summary"
+    required: false
+    default: "16384"
+  max-failures:
+    description: "Maximum failures to include in the summary output"
+    required: false
+    default: "50"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Resolve Go test report paths
+      id: paths
+      shell: bash
+      env:
+        JSON_FILE: ${{ inputs.json-file }}
+        FAILURES_FILE: ${{ inputs.failures-file }}
+      run: |
+        set -euo pipefail
+        json_file="$JSON_FILE"
+        if [[ "$json_file" == "default" ]]; then
+          json_file="${RUNNER_TEMP}/go-test.json"
+        fi
+        failures_file="$FAILURES_FILE"
+        if [[ "$failures_file" == "default" ]]; then
+          failures_file="${RUNNER_TEMP}/go-test-failures.ndjson"
+        fi
+        {
+          echo "json-file=${json_file}"
+          echo "failures-file=${failures_file}"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Publish Go test failure summary
+      shell: bash
+      env:
+        JSON_FILE: ${{ steps.paths.outputs.json-file }}
+        FAILURES_FILE: ${{ steps.paths.outputs.failures-file }}
+        MAX_OUTPUT_BYTES: ${{ inputs.max-output-bytes }}
+        MAX_FAILURES: ${{ inputs.max-failures }}
+      run: |
+        set -euo pipefail
+        go run ./scripts/gotestsummary \
+          --jsonfile "${JSON_FILE}" \
+          --markdown-out - \
+          --failures-out "${FAILURES_FILE}" \
+          --max-output-bytes "${MAX_OUTPUT_BYTES}" \
+          --max-failures "${MAX_FAILURES}" \
+          >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Upload Go test failures
+      if: ${{ always() }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ steps.paths.outputs.failures-file }}
+        retention-days: ${{ inputs.retention-days }}

--- a/.github/actions/test-go-pg/action.yaml
+++ b/.github/actions/test-go-pg/action.yaml
@@ -26,6 +26,18 @@ inputs:
     description: "Packages to test (default: ./...)"
     required: false
     default: "./..."
+  run-regex:
+    description: "Go test name regex passed via RUN"
+    required: false
+    default: ""
+  test-shuffle:
+    description: "Go test shuffle mode passed via TEST_SHUFFLE"
+    required: false
+    default: ""
+  gotestsum-json-file:
+    description: "Optional Linux path for gotestsum --jsonfile output. Use default for RUNNER_TEMP/go-test.json."
+    required: false
+    default: ""
   embedded-pg-path:
     description: "Path for embedded postgres data (Windows/macOS only)"
     required: false
@@ -61,14 +73,29 @@ runs:
         TEST_NUM_PARALLEL_PACKAGES: ${{ inputs.test-parallelism-packages }}
         TEST_NUM_PARALLEL_TESTS: ${{ inputs.test-parallelism-tests }}
         TEST_COUNT: ${{ inputs.test-count }}
+        RUN: ${{ inputs.run-regex }}
+        TEST_SHUFFLE: ${{ inputs.test-shuffle }}
         TEST_PACKAGES: ${{ inputs.test-packages }}
         RACE_DETECTION: ${{ inputs.race-detection }}
+        GOTESTSUM_JSONFILE_INPUT: ${{ inputs.gotestsum-json-file }}
         TS_DEBUG_DISCO: "true"
         TS_DEBUG_DERP: "true"
         LC_CTYPE: "en_US.UTF-8"
         LC_ALL: "en_US.UTF-8"
       run: |
         set -euo pipefail
+
+        # gotestsum natively reads GOTESTSUM_JSONFILE; set it directly instead
+        # of writing a PATH shim. "default" is the historical
+        # ${RUNNER_TEMP}/go-test.json location consumed by
+        # ./.github/actions/go-test-failure-report.
+        if [[ -n "${GOTESTSUM_JSONFILE_INPUT}" ]]; then
+          if [[ "${GOTESTSUM_JSONFILE_INPUT}" == "default" ]]; then
+            export GOTESTSUM_JSONFILE="${RUNNER_TEMP}/go-test.json"
+          else
+            export GOTESTSUM_JSONFILE="${GOTESTSUM_JSONFILE_INPUT}"
+          fi
+        fi
 
         if [[ ${RACE_DETECTION} == true ]]; then
           make test-race

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -505,24 +505,6 @@ jobs:
           source scripts/normalize_path.sh
           normalize_path_with_symlinks "$RUNNER_TEMP/sym" "$(dirname "$(which terraform)")"
 
-      - name: Configure Go test JSON capture
-        if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          set -euo pipefail
-          bin_dir="${RUNNER_TEMP}/go-test-json-bin"
-          mkdir -p "$bin_dir"
-
-          real_gotestsum="$(command -v gotestsum)"
-          real_gotestsum_quoted="$(printf '%q' "$real_gotestsum")"
-          printf '%s\n' \
-            '#!/usr/bin/env bash' \
-            'set -euo pipefail' \
-            "exec ${real_gotestsum_quoted} --jsonfile \"\${RUNNER_TEMP}/go-test.json\" \"\$@\"" \
-            > "${bin_dir}/gotestsum"
-          chmod +x "${bin_dir}/gotestsum"
-          echo "$bin_dir" >> "$GITHUB_PATH"
-
       - name: Setup RAM disk for Embedded Postgres (Windows)
         if: runner.os == 'Windows'
         shell: bash
@@ -560,6 +542,7 @@ jobs:
           # By default, run tests with cache for improved speed (possibly at the expense of correctness).
           # On main, run tests without cache for the inverse.
           test-count: ${{ github.ref == 'refs/heads/main' && '1' || '' }}
+          gotestsum-json-file: default
 
       - name: Test with PostgreSQL Database (macOS)
         if: runner.os == 'macOS'
@@ -599,24 +582,11 @@ jobs:
           embedded-pg-path: "R:/temp/embedded-pg"
           embedded-pg-cache: ${{ steps.embedded-pg-cache.outputs.embedded-pg-cache }}
 
-      - name: Publish Go test failure summary
-        if: failure() && github.actor != 'dependabot[bot]' && runner.os == 'Linux' && !github.event.pull_request.head.repo.fork
-        run: |
-          go run ./scripts/gotestsummary \
-            --jsonfile "${RUNNER_TEMP}/go-test.json" \
-            --markdown-out - \
-            --failures-out "${RUNNER_TEMP}/go-test-failures.ndjson" \
-            --max-output-bytes 16384 \
-            --max-failures 50 \
-            >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload Go test failures
-        if: failure() && github.actor != 'dependabot[bot]' && runner.os == 'Linux' && !github.event.pull_request.head.repo.fork
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - name: Publish Go test failure report
+        if: failure() && github.actor != 'dependabot[bot]' && runner.os == 'Linux' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
+        uses: ./.github/actions/go-test-failure-report
         with:
-          name: go-test-failures-${{ github.job }}-${{ github.sha }}
-          path: ${{ runner.temp }}/go-test-failures.ndjson
-          retention-days: 7
+          artifact-name: go-test-failures-${{ github.job }}-${{ github.sha }}
 
       - name: Upload failed test db dumps
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -688,24 +658,6 @@ jobs:
           source scripts/normalize_path.sh
           normalize_path_with_symlinks "$RUNNER_TEMP/sym" "$(dirname "$(which terraform)")"
 
-      - name: Configure Go test JSON capture
-        if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          set -euo pipefail
-          bin_dir="${RUNNER_TEMP}/go-test-json-bin"
-          mkdir -p "$bin_dir"
-
-          real_gotestsum="$(command -v gotestsum)"
-          real_gotestsum_quoted="$(printf '%q' "$real_gotestsum")"
-          printf '%s\n' \
-            '#!/usr/bin/env bash' \
-            'set -euo pipefail' \
-            "exec ${real_gotestsum_quoted} --jsonfile \"\${RUNNER_TEMP}/go-test.json\" \"\$@\"" \
-            > "${bin_dir}/gotestsum"
-          chmod +x "${bin_dir}/gotestsum"
-          echo "$bin_dir" >> "$GITHUB_PATH"
-
       - name: Test with PostgreSQL Database
         uses: ./.github/actions/test-go-pg
         with:
@@ -716,25 +668,13 @@ jobs:
           # By default, run tests with cache for improved speed (possibly at the expense of correctness).
           # On main, run tests without cache for the inverse.
           test-count: ${{ github.ref == 'refs/heads/main' && '1' || '' }}
+          gotestsum-json-file: default
 
-      - name: Publish Go test failure summary
-        if: failure() && github.actor != 'dependabot[bot]' && runner.os == 'Linux' && !github.event.pull_request.head.repo.fork
-        run: |
-          go run ./scripts/gotestsummary \
-            --jsonfile "${RUNNER_TEMP}/go-test.json" \
-            --markdown-out - \
-            --failures-out "${RUNNER_TEMP}/go-test-failures.ndjson" \
-            --max-output-bytes 16384 \
-            --max-failures 50 \
-            >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload Go test failures
-        if: failure() && github.actor != 'dependabot[bot]' && runner.os == 'Linux' && !github.event.pull_request.head.repo.fork
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - name: Publish Go test failure report
+        if: failure() && github.actor != 'dependabot[bot]' && runner.os == 'Linux' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
+        uses: ./.github/actions/go-test-failure-report
         with:
-          name: go-test-failures-${{ github.job }}-${{ github.sha }}
-          path: ${{ runner.temp }}/go-test-failures.ndjson
-          retention-days: 7
+          artifact-name: go-test-failures-${{ github.job }}-${{ github.sha }}
 
       - name: Upload Test Cache
         uses: ./.github/actions/test-cache/upload
@@ -793,24 +733,6 @@ jobs:
       # c.f. discussion on https://github.com/coder/coder/pull/15106
       # Our Linux runners have 16 cores, but we reduce parallelism since race detection adds a lot of overhead.
       # We aim to have parallelism match CPU count (4*4=16) to avoid making flakes worse.
-      - name: Configure Go test JSON capture
-        if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          set -euo pipefail
-          bin_dir="${RUNNER_TEMP}/go-test-json-bin"
-          mkdir -p "$bin_dir"
-
-          real_gotestsum="$(command -v gotestsum)"
-          real_gotestsum_quoted="$(printf '%q' "$real_gotestsum")"
-          printf '%s\n' \
-            '#!/usr/bin/env bash' \
-            'set -euo pipefail' \
-            "exec ${real_gotestsum_quoted} --jsonfile \"\${RUNNER_TEMP}/go-test.json\" \"\$@\"" \
-            > "${bin_dir}/gotestsum"
-          chmod +x "${bin_dir}/gotestsum"
-          echo "$bin_dir" >> "$GITHUB_PATH"
-
       - name: Run Tests
         uses: ./.github/actions/test-go-pg
         with:
@@ -818,25 +740,13 @@ jobs:
           test-parallelism-packages: "4"
           test-parallelism-tests: "4"
           race-detection: "true"
+          gotestsum-json-file: default
 
-      - name: Publish Go test failure summary
-        if: failure() && github.actor != 'dependabot[bot]' && runner.os == 'Linux' && !github.event.pull_request.head.repo.fork
-        run: |
-          go run ./scripts/gotestsummary \
-            --jsonfile "${RUNNER_TEMP}/go-test.json" \
-            --markdown-out - \
-            --failures-out "${RUNNER_TEMP}/go-test-failures.ndjson" \
-            --max-output-bytes 16384 \
-            --max-failures 50 \
-            >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload Go test failures
-        if: failure() && github.actor != 'dependabot[bot]' && runner.os == 'Linux' && !github.event.pull_request.head.repo.fork
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - name: Publish Go test failure report
+        if: failure() && github.actor != 'dependabot[bot]' && runner.os == 'Linux' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
+        uses: ./.github/actions/go-test-failure-report
         with:
-          name: go-test-failures-${{ github.job }}-${{ github.sha }}
-          path: ${{ runner.temp }}/go-test-failures.ndjson
-          retention-days: 7
+          artifact-name: go-test-failures-${{ github.job }}-${{ github.sha }}
 
       - name: Upload Test Cache
         uses: ./.github/actions/test-cache/upload


### PR DESCRIPTION
The Go test jobs in `ci.yaml` each had ~30 lines of inline shell that wrapped `gotestsum` with a PATH shim to capture JSON, then ran `gotestsummary` and `upload-artifact` to publish a failure report. Three jobs carried three near-identical copies.

This change replaces the three inline blocks with a single composite action at `.github/actions/go-test-failure-report/` that runs the same `gotestsummary` invocation, writes the same markdown to `GITHUB_STEP_SUMMARY`, and uploads the same NDJSON artifact. The PATH shim is gone; gotestsum's native `GOTESTSUM_JSONFILE` env variable is used instead, plumbed through the `test-go-pg` composite.

`test-go-pg` gains three optional inputs:

- `gotestsum-json-file` — explicit JSON file path (or `default` for `${RUNNER_TEMP}/go-test.json`)
- `run-regex` — passed to `go test -run`
- `test-shuffle` — passed to `go test -shuffle`

All three have safe defaults so existing callers are unaffected.

No observable change in CI behavior: the three existing test-go-pg jobs continue to emit the same JSON, render the same failure summary, and upload the same artifact.

Stacked under #25667, which uses the new composite and inputs to power a new flake-detector workflow.
