### PR TITLE
fix: strip route prefix when passing request to aibridged handler

### DIFF
--- a/coderd/aibridged.go
+++ b/coderd/aibridged.go
@@ -42,9 +42,9 @@ func (api *API) RegisterInMemoryAIBridgedHTTPHandler(srv http.Handler) {
 		panic("aibridged cannot be nil")
 	}
 
-	api.aibridgedHandler = srv
+	api.aibridgedHandler = http.StripPrefix("/api/v2/aibridge", srv)
 
-	factory := aibridged.NewTransportFactory(srv)
+	factory := aibridged.NewTransportFactory(api.aibridgedHandler)
 	var asInterface agplaibridge.TransportFactory = factory
 	api.AIBridgeTransportFactory.Store(&asInterface)
 }

--- a/enterprise/coderd/aibridge.go
+++ b/enterprise/coderd/aibridge.go
@@ -86,7 +86,7 @@ func aibridgeHandler(api *API, middlewares ...func(http.Handler) http.Handler) f
 					return
 				}
 
-				http.StripPrefix("/api/v2/aibridge", api.AGPL.GetAIBridgedHandler()).ServeHTTP(rw, r)
+				api.AGPL.GetAIBridgedHandler().ServeHTTP(rw, r)
 			})
 		})
 	}


### PR DESCRIPTION
We weren't stripping the API base (`/api/v2/aibridge`), leading to 404s when using the in-memory transport.