### PR TITLE
fix(dogfood/coder): fix install-deps heredoc and /opt/mise ownership

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -679,11 +679,26 @@ resource "coder_script" "install-deps" {
   display_name       = "Installing Dependencies"
   run_on_start       = true
   start_blocks_login = false
-  script             = <<EOT
+  script             = <<-EOT
     #!/usr/bin/env bash
     set -euo pipefail
 
     trap 'coder exp sync complete install-deps' EXIT
+
+    # Ensure /opt/mise is writable by coder before any login shell
+    # or other script touches mise. `mise oci build` emits its tar
+    # layers in deterministic mode with hardcoded uid=0/gid=0 (see
+    # mise's src/oci/layer.rs), and `prefix_parents` walks the full
+    # mount_point chain, so the final image stamps /opt, /opt/mise,
+    # and /opt/mise/data as root:root regardless of what the base
+    # Dockerfile sets. Without this chown mise warns `migrate:
+    # failed create_dir_all: /opt/mise/data/migrations` and skips
+    # its state writes. /opt/mise is image-resident (not on the
+    # home volume), so this runs every workspace start. Runs
+    # before the git-clone sync barrier so early shells never
+    # observe the unwritable state.
+    sudo chown -R coder:coder /opt/mise
+
     coder exp sync want install-deps git-clone
     coder exp sync start install-deps
 

--- a/dogfood/coder/ubuntu-22.04/Dockerfile.base
+++ b/dogfood/coder/ubuntu-22.04/Dockerfile.base
@@ -209,7 +209,12 @@ EOF
 
 # Reserve the mount_point declared in mise.toml [oci]. The path is
 # duplicated below in MISE_SHARED_INSTALL_DIRS and PATH; if it ever
-# changes, update all three plus mise.toml.
+# changes, update all three plus mise.toml. Ownership of /opt/mise
+# and /opt/mise/data is reasserted at workspace start by the
+# install-deps coder_script in dogfood/coder/main.tf: `mise oci
+# build` emits deterministic tar layers with hardcoded uid=0/gid=0
+# (see src/oci/layer.rs), so the final image always overwrites
+# whatever ownership we set here.
 RUN install --directory --owner=coder --group=coder --mode=0755 /opt/mise /opt/mise/data
 
 # Install Homebrew as the coder user so the supported Linux prefix remains

--- a/dogfood/coder/ubuntu-26.04/Dockerfile.base
+++ b/dogfood/coder/ubuntu-26.04/Dockerfile.base
@@ -219,7 +219,12 @@ EOF
 
 # Reserve the mount_point declared in mise.toml [oci]. The path is
 # duplicated below in MISE_SHARED_INSTALL_DIRS and PATH; if it ever
-# changes, update all three plus mise.toml.
+# changes, update all three plus mise.toml. Ownership of /opt/mise
+# and /opt/mise/data is reasserted at workspace start by the
+# install-deps coder_script in dogfood/coder/main.tf: `mise oci
+# build` emits deterministic tar layers with hardcoded uid=0/gid=0
+# (see src/oci/layer.rs), so the final image always overwrites
+# whatever ownership we set here.
 RUN install --directory --owner=coder --group=coder --mode=0755 /opt/mise /opt/mise/data
 
 # Install Homebrew as the coder user so the supported Linux prefix remains


### PR DESCRIPTION
The install-deps startup script was failing with `here-document at line 19 delimited by end-of-file (wanted TRUST)`. The script uses Terraform's non-stripping `<<EOT` heredoc, so the 4-space source indentation is preserved verbatim and the inner bash `<<'TRUST'` terminator never lands at column 0. Switching to `<<-EOT` strips the common prefix.

Separately, `mise oci build` writes its tar layers in deterministic mode with hardcoded `uid=0/gid=0` (see mise's `src/oci/layer.rs`), and `prefix_parents` walks the full `mount_point` chain, so the final dogfood image stamps `/opt/mise` and `/opt/mise/data` as `root:root` regardless of what the base Dockerfile sets. Without a fix, mise warns `migrate: failed create_dir_all: /opt/mise/data/migrations` at workspace start. Adds `sudo chown -R coder:coder /opt/mise` to install-deps before the git-clone sync barrier so early shells never observe the unwritable state. An upstream PR to add a `--owner UID[:GID]` flag to `mise oci build` will follow; once landed, the runtime chown can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)