### PR TITLE
fix(site): preserve localhost port-forward URL fragments

### DIFF
--- a/site/src/utils/portForward.test.ts
+++ b/site/src/utils/portForward.test.ts
@@ -68,6 +68,23 @@ describe("port forward URL", () => {
 			"http://12345--my-agent--my-workspace--my-username.proxy-host.tld/path1/path2?key1=value1&key2=value2",
 		);
 	});
+
+	it("http, host, port, path, query params and hash", () => {
+		const forwarded = portForwardURL(
+			proxyHostWildcard,
+			samplePort,
+			sampleAgent,
+			sampleWorkspace,
+			sampleUsername,
+			"http",
+			"/path1/path2",
+			"?key=value",
+			"#section-2",
+		);
+		expect(forwarded).toEqual(
+			"http://12345--my-agent--my-workspace--my-username.proxy-host.tld/path1/path2?key=value#section-2",
+		);
+	});
 });
 
 describe("resolveLocalhostPort", () => {
@@ -178,6 +195,32 @@ describe("rewriteLocalhostURL", () => {
 		);
 		expect(result).toEqual(
 			"http://3000--my-agent--my-workspace--my-username.proxy-host.tld/path?key=value",
+		);
+	});
+
+	it("preserves hash fragments", () => {
+		const result = rewriteLocalhostURL(
+			"http://localhost:3000/path?key=value#section-2",
+			proxyHost,
+			agent,
+			workspace,
+			username,
+		);
+		expect(result).toEqual(
+			"http://3000--my-agent--my-workspace--my-username.proxy-host.tld/path?key=value#section-2",
+		);
+	});
+
+	it("rewrites IPv6 loopback", () => {
+		const result = rewriteLocalhostURL(
+			"http://[::1]:3000/path",
+			proxyHost,
+			agent,
+			workspace,
+			username,
+		);
+		expect(result).toEqual(
+			"http://3000--my-agent--my-workspace--my-username.proxy-host.tld/path",
 		);
 	});
 

--- a/site/src/utils/portForward.ts
+++ b/site/src/utils/portForward.ts
@@ -1,6 +1,6 @@
 import type { WorkspaceAgentPortShareProtocol } from "#/api/typesGenerated";
 
-const localHosts = new Set(["localhost", "127.0.0.1", "0.0.0.0"]);
+const localHosts = new Set(["localhost", "127.0.0.1", "0.0.0.0", "[::1]"]);
 
 /**
  * Parse a port string from a URL, falling back to the protocol default
@@ -31,6 +31,7 @@ export const portForwardURL = (
 	protocol: WorkspaceAgentPortShareProtocol,
 	pathname?: string,
 	search?: string,
+	hash?: string,
 ): string => {
 	const { location } = window;
 	const suffix = protocol === "https" ? "s" : "";
@@ -45,6 +46,9 @@ export const portForwardURL = (
 		}
 		if (search) {
 			url.search = search;
+		}
+		if (hash) {
+			url.hash = hash;
 		}
 		return url.toString();
 	} catch {
@@ -84,6 +88,7 @@ export const rewriteLocalhostURL = (
 			protocol,
 			parsed.pathname,
 			parsed.search,
+			parsed.hash,
 		);
 	} catch {
 		return url;


### PR DESCRIPTION
## Summary
- preserve URL hash fragments when constructing port-forward links
- rewrite IPv6 loopback localhost URLs like http://[::1]:3000
- add focused coverage for fragment and IPv6 loopback behavior

## Why
Agent/chat-generated localhost URLs can point at hash-routed pages or docs sections. The existing rewrite path preserved pathname and query params, but dropped fragments, which can land users on the wrong view after the link is converted to a port-forward URL.

## Tests
- pnpm --dir ./site exec vitest run --project=unit src/utils/portForward.test.ts
- pnpm --dir ./site exec biome check --error-on-warnings src/utils/portForward.ts src/utils/portForward.test.ts
- git diff --check