### PR TITLE
fix(dogfood/coder): override mise oci build MISE_CONFIG_DIR bake

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -508,6 +508,16 @@ resource "coder_agent" "dev" {
   env = merge(
     {
       OIDC_TOKEN : data.coder_workspace_owner.me.oidc_access_token,
+      # `mise oci build` bakes `ENV MISE_CONFIG_DIR=/etc/mise` into
+      # the image layer above Dockerfile.base, so mise treats
+      # /etc/mise as the user config dir and never reads
+      # ~/.config/mise/conf.d/*, silently dropping the trust file
+      # the install-deps coder_script below seeds. `[oci.env]` in
+      # mise.toml would be the natural place for this, but mise's
+      # internal env bake currently wins on MISE_* key collisions
+      # (non-MISE keys flow through). Move this back to `[oci.env]`
+      # once upstream mise fixes that.
+      MISE_CONFIG_DIR : "/home/coder/.config/mise",
     },
     data.coder_parameter.enable_ai_gateway.value ? {
       ANTHROPIC_BASE_URL : "https://dev.coder.com/api/v2/aibridge/anthropic",


### PR DESCRIPTION
Inside the dogfood workspace, `mise config ls` doesn't load `~/.config/mise/config.toml` or `~/.config/mise/conf.d/*` because `mise oci build` bakes `ENV MISE_CONFIG_DIR=/etc/mise` into the synthesized image layer that sits on top of Dockerfile.base. That silently drops the user-owned trust file the `install-deps` coder_script seeds at workspace start (`dogfood/coder/main.tf:705-727`), so the user-editable mise trust path config never takes effect.

The natural place for this would be `[oci.env]` in the project `mise.toml`, but a probe build confirms mise's internal env bake currently wins on `MISE_*` key collisions (non-MISE keys flow through). Setting `MISE_CONFIG_DIR` in `coder_agent.env` works around that by applying after the image ENV resolves. The comment in the diff calls out moving this back to `[oci.env]` once upstream mise respects user values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)