### PR TITLE
docs: mark user secrets as beta

### DIFF
--- a/docs/admin/security/secrets.md
+++ b/docs/admin/security/secrets.md
@@ -44,7 +44,7 @@ Users can view their public key in their account settings:
 > SSH keys are never stored in Coder workspaces, and are fetched only when
 > SSH is invoked. The keys are held in-memory and never written to disk.
 
-## User secrets (Early Access)
+## User secrets (Beta)
 
 User secrets are developer-managed values that Coder injects at workspace start.
 If a user secret targets the same environment variable name or file path as a

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -372,7 +372,7 @@
 					"description": "Store secret values in Coder and automatically inject them into workspaces",
 					"path": "./user-guides/user-secrets.md",
 					"icon_path": "./images/icons/secrets.svg",
-					"state": ["early access"]
+					"state": ["beta"]
 				}
 			]
 		},

--- a/docs/user-guides/user-secrets.md
+++ b/docs/user-guides/user-secrets.md
@@ -1,11 +1,11 @@
-# User secrets (Early Access)
+# User secrets (Beta)
 
 User secrets let you store secret values in Coder and make them available in
 every workspace you own.
 
 > [!NOTE]
-> User secrets are in Early Access and may change. For more information, see
-> [feature stages](../install/releases/feature-stages.md#early-access-features).
+> User secrets are in Beta and may change. For more information, see
+> [feature stages](../install/releases/feature-stages.md#beta).
 
 ## How user secrets work
 


### PR DESCRIPTION
Update the user secrets user guide, the admin security secrets reference, and the docs manifest to label the feature as Beta instead of Early Access, and link to the beta section of the feature stages doc.
