### PR TITLE
docs: fix broken references and add users oidc-claims to manifest

### DIFF
--- a/docs/admin/integrations/oauth2-provider.md
+++ b/docs/admin/integrations/oauth2-provider.md
@@ -239,7 +239,7 @@ eval $(./setup-test-app.sh)
 ./cleanup-test-app.sh
 ```
 
-For more details on testing, see the [OAuth2 test scripts README](../../../scripts/oauth2/README.md).
+For more details on testing, see the [OAuth2 test scripts README](https://github.com/coder/coder/blob/main/scripts/oauth2/README.md).
 
 ## Common Issues
 

--- a/docs/install/releases/feature-stages.md
+++ b/docs/install/releases/feature-stages.md
@@ -129,7 +129,7 @@ For support, consult our knowledgeable and growing community on
 already. Customers with a valid Coder license, can submit a support request or
 contact your [account team](https://coder.com/contact).
 
-We intend [Coder documentation](../../README.md) to be the
+We intend [Coder documentation](../../about/contributing/documentation.md) to be the
 [single source of truth](https://en.wikipedia.org/wiki/Single_source_of_truth)
 and all features should have some form of complete documentation that outlines
 how to use or implement a feature. If you discover an error or if you have a

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2389,6 +2389,11 @@
 							"path": "reference/cli/users_list.md"
 						},
 						{
+							"title": "users oidc-claims",
+							"description": "Display the OIDC claims for the authenticated user.",
+							"path": "reference/cli/users_oidc-claims.md"
+						},
+						{
 							"title": "users show",
 							"description": "Show a single user. Use 'me' to indicate the currently authenticated user.",
 							"path": "reference/cli/users_show.md"


### PR DESCRIPTION
## Summary

Three small docs fixes:

- **`docs/admin/integrations/oauth2-provider.md`**: Replace broken relative link to `scripts/oauth2/README.md` with an absolute GitHub URL. The previous link escaped the `docs/` tree (`../../../scripts/oauth2/README.md`) and does not resolve in the published docs site.
- **`docs/install/releases/feature-stages.md`**: Point the "Coder documentation" link to `docs/about/contributing/documentation.md`. The previous `../../README.md` target does not exist under `docs/`.
- **`docs/manifest.json`**: Add the missing `users oidc-claims` entry alongside the other `users` CLI subcommands so the generated reference page (`docs/reference/cli/users_oidc-claims.md`) is reachable from the sidebar.

## Validation

- Confirmed each new link target exists on `main` (`docs/about/contributing/documentation.md`, `scripts/oauth2/README.md`, `docs/reference/cli/users_oidc-claims.md`).
- Pre-commit hooks pass (`fmt/markdown`, `lint/markdown`, `lint/emdash`, `lint/typos`, etc.).

---

_This PR was prepared by a [Coder Agents](https://coder.com/) session on behalf of @nickvigilante. Human review requested since this is a docs-only change._