### PR TITLE
fix: resolve incorrect class on `<Logs />`

### DIFF
--- a/site/src/components/Logs/Logs.tsx
+++ b/site/src/components/Logs/Logs.tsx
@@ -23,7 +23,7 @@ export const Logs: FC<LogsProps> = ({
 				"min-h-40 py-2 rounded-lg overflow-x-auto bg-surface-primary",
 				"[&:not(:last-child)]:border-0",
 				"[&:not(:last-child)]:border-solid",
-				"[&:not(:last-child)]:border-b-border",
+				"[&:not(:last-child)]:border-b",
 				"[&:not(:last-child)]:rounded-none",
 				className,
 			)}


### PR DESCRIPTION
This pull-request addresses the class `border-b-border` issue on `<LogsContainer />` this should've been a `border-b` and was a regression 🙂 