### PR TITLE
fix(coderd): enforce api_key_id on user messages at type level

### DIFF
--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -2562,9 +2562,9 @@ func (api *API) workspaceAgentAddChatContext(rw http.ResponseWriter, r *http.Req
 		if locked.OwnerID != workspace.OwnerID {
 			return errChatDoesNotBelongToWorkspaceOwner
 		}
-		if _, err := tx.InsertChatMessages(sysCtx, chatd.BuildSingleChatMessageInsertParams(
+		if _, err := tx.InsertChatMessages(sysCtx, chatd.BuildSingleUserChatMessageInsertParams(
 			chat.ID,
-			database.ChatMessageRoleUser,
+			"", // Agent-initiated context injection has no caller API key.
 			content,
 			database.ChatMessageVisibilityBoth,
 			locked.LastModelConfigID,

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -1680,7 +1680,7 @@ func (p *Server) CreateChat(ctx context.Context, opts CreateOptions) (database.C
 			opts.ModelConfigID,
 			chatprompt.CurrentContentVersion,
 		)
-		userMsg.chatMessage = userMsg.chatMessage.withCreatedBy(opts.OwnerID)
+		userMsg = userMsg.withCreatedBy(opts.OwnerID)
 		appendUserChatMessage(&msgParams, userMsg)
 
 		_, err = tx.InsertChatMessages(ctx, msgParams)
@@ -2113,7 +2113,7 @@ func (p *Server) EditMessage(
 		// InsertChatMessages CTE updates chats.last_model_config_id
 		// when the new message's model differs, so the assistant turn
 		// that follows picks up the new selection.
-		msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by append[User]ChatMessage.
+		msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendUserChatMessage.
 			ChatID: opts.ChatID,
 		}
 		editUserMsg := newUserChatMessage(
@@ -2123,7 +2123,7 @@ func (p *Server) EditMessage(
 			messageModelConfigID,
 			chatprompt.CurrentContentVersion,
 		)
-		editUserMsg.chatMessage = editUserMsg.chatMessage.withCreatedBy(opts.CreatedBy)
+		editUserMsg = editUserMsg.withCreatedBy(opts.CreatedBy)
 		appendUserChatMessage(&msgParams, editUserMsg)
 		newMessages, err := insertChatMessageWithStore(ctx, tx, msgParams)
 		if err != nil {
@@ -3903,9 +3903,8 @@ func insertChatMessageWithStore(
 	return messages, nil
 }
 
-// chatMessage describes a non-user message to insert as part of a batch.
-// Use newChatMessage to create one, then chain builder methods for
-// optional fields. For user messages, use userChatMessage instead.
+// chatMessage is the base message type for batch inserts. Use directly
+// only for non-user messages; for user messages, use userChatMessage.
 // For nullable UUID fields (ModelConfigID, CreatedBy), use uuid.Nil to
 // represent NULL. For nullable int64 fields, use 0 to represent NULL.
 type chatMessage struct {
@@ -3933,6 +3932,16 @@ type chatMessage struct {
 type userChatMessage struct {
 	chatMessage
 	apiKeyID string
+}
+
+func (m userChatMessage) withCreatedBy(id uuid.UUID) userChatMessage {
+	m.chatMessage = m.chatMessage.withCreatedBy(id)
+	return m
+}
+
+func (m userChatMessage) withCompressed() userChatMessage {
+	m.chatMessage = m.chatMessage.withCompressed()
+	return m
 }
 
 func newChatMessage(
@@ -4044,16 +4053,17 @@ func appendMessageFields(
 }
 
 // appendChatMessage appends a non-user message to the batch insert params.
-// For user messages, use appendUserChatMessage instead.
 func appendChatMessage(
 	params *database.InsertChatMessagesParams,
 	msg chatMessage,
 ) {
+	if msg.role == database.ChatMessageRoleUser {
+		panic("developer error: use appendUserChatMessage for user-role messages")
+	}
 	appendMessageFields(params, msg, "")
 }
 
 // appendUserChatMessage appends a user message to the batch insert params.
-// The userChatMessage type guarantees that an apiKeyID was provided.
 func appendUserChatMessage(
 	params *database.InsertChatMessagesParams,
 	msg userChatMessage,
@@ -4077,7 +4087,7 @@ func BuildSingleUserChatMessageInsertParams(
 	}
 	msg := newUserChatMessage(apiKeyID, content, visibility, modelConfigID, contentVersion)
 	if createdBy != uuid.Nil {
-		msg.chatMessage = msg.chatMessage.withCreatedBy(createdBy)
+		msg = msg.withCreatedBy(createdBy)
 	}
 	appendUserChatMessage(&params, msg)
 	return params
@@ -4094,7 +4104,7 @@ func insertUserMessageAndSetPending(
 	createdBy uuid.UUID,
 	apiKeyID string,
 ) (database.ChatMessage, database.Chat, error) {
-	msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by append[User]ChatMessage.
+	msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendUserChatMessage.
 		ChatID: lockedChat.ID,
 	}
 	insertUserMsg := newUserChatMessage(
@@ -4104,7 +4114,7 @@ func insertUserMessageAndSetPending(
 		modelConfigID,
 		chatprompt.CurrentContentVersion,
 	)
-	insertUserMsg.chatMessage = insertUserMsg.chatMessage.withCreatedBy(createdBy)
+	insertUserMsg = insertUserMsg.withCreatedBy(createdBy)
 	appendUserChatMessage(&msgParams, insertUserMsg)
 	messages, err := insertChatMessageWithStore(ctx, store, msgParams)
 	if err != nil {
@@ -5918,7 +5928,7 @@ func (p *Server) tryAutoPromoteQueuedMessage(
 		return nil, nil, false, xerrors.New("popped queued message out of order")
 	}
 
-	msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by append[User]ChatMessage.
+	msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendUserChatMessage.
 		ChatID: chat.ID,
 	}
 	queuedUserMsg := newUserChatMessage(
@@ -5931,7 +5941,7 @@ func (p *Server) tryAutoPromoteQueuedMessage(
 		effectiveModelConfigID,
 		chatprompt.CurrentContentVersion,
 	)
-	queuedUserMsg.chatMessage = queuedUserMsg.chatMessage.withCreatedBy(chat.OwnerID)
+	queuedUserMsg = queuedUserMsg.withCreatedBy(chat.OwnerID)
 	appendUserChatMessage(&msgParams, queuedUserMsg)
 	msgs, err := insertChatMessageWithStore(ctx, tx, msgParams)
 	if err != nil {
@@ -7701,7 +7711,7 @@ func (p *Server) runChat(
 				}
 			}
 
-			stepParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by append[User]ChatMessage.
+			stepParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendChatMessage.
 				ChatID: chat.ID,
 			}
 
@@ -8520,7 +8530,7 @@ func (p *Server) persistChatContextSummary(
 			modelConfigID,
 			chatprompt.CurrentContentVersion,
 		)
-		summaryUserMsg.chatMessage = summaryUserMsg.chatMessage.withCompressed()
+		summaryUserMsg = summaryUserMsg.withCompressed()
 		appendUserChatMessage(&summaryParams, summaryUserMsg)
 
 		// Assistant tool-call message.
@@ -9076,12 +9086,12 @@ func (p *Server) persistInstructionFiles(
 		return "", nil, xerrors.Errorf("marshal context-file parts: %w", err)
 	}
 
-	contentAPIKeyID, _ := aibridge.DelegatedAPIKeyIDFromContext(ctx)
+	contextAPIKeyID, _ := aibridge.DelegatedAPIKeyIDFromContext(ctx)
 	msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendUserChatMessage.
 		ChatID: chat.ID,
 	}
 	appendUserChatMessage(&msgParams, newUserChatMessage(
-		contentAPIKeyID,
+		contextAPIKeyID,
 		content,
 		database.ChatMessageVisibilityBoth,
 		modelConfigID,

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -1629,7 +1629,7 @@ func (p *Server) CreateChat(ctx context.Context, opts CreateOptions) (database.C
 			return xerrors.Errorf("marshal initial user content: %w", err)
 		}
 
-		msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendChatMessage.
+		msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by append[User]ChatMessage.
 			ChatID: insertedChat.ID,
 		}
 
@@ -2113,7 +2113,7 @@ func (p *Server) EditMessage(
 		// InsertChatMessages CTE updates chats.last_model_config_id
 		// when the new message's model differs, so the assistant turn
 		// that follows picks up the new selection.
-		msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendChatMessage.
+		msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by append[User]ChatMessage.
 			ChatID: opts.ChatID,
 		}
 		editUserMsg := newUserChatMessage(
@@ -4015,14 +4015,16 @@ func (m chatMessage) withProviderResponseID(id string) chatMessage {
 	return m
 }
 
-// appendChatMessage appends a non-user message to the batch insert params.
-// For user messages, use appendUserChatMessage instead.
-func appendChatMessage(
+// appendMessageFields appends the common fields from a chatMessage to the
+// batch insert params. apiKeyID is passed explicitly so that non-user
+// messages always get "" and user messages get the caller's key.
+func appendMessageFields(
 	params *database.InsertChatMessagesParams,
 	msg chatMessage,
+	apiKeyID string,
 ) {
 	params.CreatedBy = append(params.CreatedBy, msg.createdBy)
-	params.APIKeyID = append(params.APIKeyID, "")
+	params.APIKeyID = append(params.APIKeyID, apiKeyID)
 	params.ModelConfigID = append(params.ModelConfigID, msg.modelConfigID)
 	params.Role = append(params.Role, msg.role)
 	params.Content = append(params.Content, string(msg.content.RawMessage))
@@ -4039,6 +4041,15 @@ func appendChatMessage(
 	params.TotalCostMicros = append(params.TotalCostMicros, msg.totalCostMicros)
 	params.RuntimeMs = append(params.RuntimeMs, msg.runtimeMs)
 	params.ProviderResponseID = append(params.ProviderResponseID, msg.providerResponseID)
+}
+
+// appendChatMessage appends a non-user message to the batch insert params.
+// For user messages, use appendUserChatMessage instead.
+func appendChatMessage(
+	params *database.InsertChatMessagesParams,
+	msg chatMessage,
+) {
+	appendMessageFields(params, msg, "")
 }
 
 // appendUserChatMessage appends a user message to the batch insert params.
@@ -4047,46 +4058,7 @@ func appendUserChatMessage(
 	params *database.InsertChatMessagesParams,
 	msg userChatMessage,
 ) {
-	params.CreatedBy = append(params.CreatedBy, msg.createdBy)
-	params.APIKeyID = append(params.APIKeyID, msg.apiKeyID)
-	params.ModelConfigID = append(params.ModelConfigID, msg.modelConfigID)
-	params.Role = append(params.Role, msg.role)
-	params.Content = append(params.Content, string(msg.content.RawMessage))
-	params.ContentVersion = append(params.ContentVersion, msg.contentVersion)
-	params.Visibility = append(params.Visibility, msg.visibility)
-	params.InputTokens = append(params.InputTokens, msg.inputTokens)
-	params.OutputTokens = append(params.OutputTokens, msg.outputTokens)
-	params.TotalTokens = append(params.TotalTokens, msg.totalTokens)
-	params.ReasoningTokens = append(params.ReasoningTokens, msg.reasoningTokens)
-	params.CacheCreationTokens = append(params.CacheCreationTokens, msg.cacheCreationTokens)
-	params.CacheReadTokens = append(params.CacheReadTokens, msg.cacheReadTokens)
-	params.ContextLimit = append(params.ContextLimit, msg.contextLimit)
-	params.Compressed = append(params.Compressed, msg.compressed)
-	params.TotalCostMicros = append(params.TotalCostMicros, msg.totalCostMicros)
-	params.RuntimeMs = append(params.RuntimeMs, msg.runtimeMs)
-	params.ProviderResponseID = append(params.ProviderResponseID, msg.providerResponseID)
-}
-
-// BuildSingleChatMessageInsertParams creates batch insert params for one
-// message using the shared chat message builder.
-func BuildSingleChatMessageInsertParams(
-	chatID uuid.UUID,
-	role database.ChatMessageRole,
-	content pqtype.NullRawMessage,
-	visibility database.ChatMessageVisibility,
-	modelConfigID uuid.UUID,
-	contentVersion int16,
-	createdBy uuid.UUID,
-) database.InsertChatMessagesParams {
-	params := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendChatMessage.
-		ChatID: chatID,
-	}
-	msg := newChatMessage(role, content, visibility, modelConfigID, contentVersion)
-	if createdBy != uuid.Nil {
-		msg = msg.withCreatedBy(createdBy)
-	}
-	appendChatMessage(&params, msg)
-	return params
+	appendMessageFields(params, msg.chatMessage, msg.apiKeyID)
 }
 
 // BuildSingleUserChatMessageInsertParams creates batch insert params for
@@ -4122,7 +4094,7 @@ func insertUserMessageAndSetPending(
 	createdBy uuid.UUID,
 	apiKeyID string,
 ) (database.ChatMessage, database.Chat, error) {
-	msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendChatMessage.
+	msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by append[User]ChatMessage.
 		ChatID: lockedChat.ID,
 	}
 	insertUserMsg := newUserChatMessage(
@@ -5946,7 +5918,7 @@ func (p *Server) tryAutoPromoteQueuedMessage(
 		return nil, nil, false, xerrors.New("popped queued message out of order")
 	}
 
-	msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendChatMessage.
+	msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by append[User]ChatMessage.
 		ChatID: chat.ID,
 	}
 	queuedUserMsg := newUserChatMessage(
@@ -7729,7 +7701,7 @@ func (p *Server) runChat(
 				}
 			}
 
-			stepParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendChatMessage.
+			stepParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by append[User]ChatMessage.
 				ChatID: chat.ID,
 			}
 
@@ -8535,7 +8507,7 @@ func (p *Server) persistChatContextSummary(
 	var insertedMessages []database.ChatMessage
 
 	txErr := p.db.InTx(func(tx database.Store) error {
-		summaryParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendChatMessage.
+		summaryParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by append[User]ChatMessage.
 			ChatID: chatID,
 		}
 
@@ -9080,12 +9052,12 @@ func (p *Server) persistInstructionFiles(
 		if err != nil {
 			return "", nil, nil
 		}
-		blankAPIKeyID, _ := aibridge.DelegatedAPIKeyIDFromContext(ctx)
+		contextAPIKeyID, _ := aibridge.DelegatedAPIKeyIDFromContext(ctx)
 		msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendUserChatMessage.
 			ChatID: chat.ID,
 		}
 		appendUserChatMessage(&msgParams, newUserChatMessage(
-			blankAPIKeyID,
+			contextAPIKeyID,
 			content,
 			database.ChatMessageVisibilityBoth,
 			modelConfigID,

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -1673,13 +1673,15 @@ func (p *Server) CreateChat(ctx context.Context, opts CreateOptions) (database.C
 			chatprompt.CurrentContentVersion,
 		))
 
-		appendChatMessage(&msgParams, newChatMessage(
-			database.ChatMessageRoleUser,
+		userMsg := newUserChatMessage(
+			opts.APIKeyID,
 			userContent,
 			database.ChatMessageVisibilityBoth,
 			opts.ModelConfigID,
 			chatprompt.CurrentContentVersion,
-		).withCreatedBy(opts.OwnerID).withAPIKeyID(opts.APIKeyID))
+		)
+		userMsg.chatMessage = userMsg.chatMessage.withCreatedBy(opts.OwnerID)
+		appendUserChatMessage(&msgParams, userMsg)
 
 		_, err = tx.InsertChatMessages(ctx, msgParams)
 		if err != nil {
@@ -2114,13 +2116,15 @@ func (p *Server) EditMessage(
 		msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendChatMessage.
 			ChatID: opts.ChatID,
 		}
-		appendChatMessage(&msgParams, newChatMessage(
-			database.ChatMessageRoleUser,
+		editUserMsg := newUserChatMessage(
+			opts.APIKeyID,
 			content,
 			editedMsg.Visibility,
 			messageModelConfigID,
 			chatprompt.CurrentContentVersion,
-		).withCreatedBy(opts.CreatedBy).withAPIKeyID(opts.APIKeyID))
+		)
+		editUserMsg.chatMessage = editUserMsg.chatMessage.withCreatedBy(opts.CreatedBy)
+		appendUserChatMessage(&msgParams, editUserMsg)
 		newMessages, err := insertChatMessageWithStore(ctx, tx, msgParams)
 		if err != nil {
 			return xerrors.Errorf("insert replacement message: %w", err)
@@ -3899,19 +3903,17 @@ func insertChatMessageWithStore(
 	return messages, nil
 }
 
-// chatMessage describes a single message to insert as part of a batch.
+// chatMessage describes a non-user message to insert as part of a batch.
 // Use newChatMessage to create one, then chain builder methods for
-// optional fields. For nullable UUID fields (ModelConfigID, CreatedBy),
-// use uuid.Nil to represent NULL — the SQL uses NULLIF to convert zero
-// UUIDs to NULL. For nullable int64 fields, use 0 to represent NULL —
-// the SQL uses NULLIF to convert zeros to NULL.
+// optional fields. For user messages, use userChatMessage instead.
+// For nullable UUID fields (ModelConfigID, CreatedBy), use uuid.Nil to
+// represent NULL. For nullable int64 fields, use 0 to represent NULL.
 type chatMessage struct {
 	role                database.ChatMessageRole
 	content             pqtype.NullRawMessage
 	visibility          database.ChatMessageVisibility
 	modelConfigID       uuid.UUID
 	createdBy           uuid.UUID
-	apiKeyID            string
 	contentVersion      int16
 	compressed          bool
 	inputTokens         int64
@@ -3924,6 +3926,13 @@ type chatMessage struct {
 	totalCostMicros     int64
 	runtimeMs           int64
 	providerResponseID  string
+}
+
+// userChatMessage describes a user message. The apiKeyID field is
+// required by newUserChatMessage so that omitting it is a compile error.
+type userChatMessage struct {
+	chatMessage
+	apiKeyID string
 }
 
 func newChatMessage(
@@ -3942,13 +3951,29 @@ func newChatMessage(
 	}
 }
 
-func (m chatMessage) withCreatedBy(id uuid.UUID) chatMessage {
-	m.createdBy = id
-	return m
+// newUserChatMessage creates a user message. apiKeyID is required so
+// that forgetting it is a compile error rather than a silent data bug.
+func newUserChatMessage(
+	apiKeyID string,
+	content pqtype.NullRawMessage,
+	visibility database.ChatMessageVisibility,
+	modelConfigID uuid.UUID,
+	contentVersion int16,
+) userChatMessage {
+	return userChatMessage{
+		chatMessage: newChatMessage(
+			database.ChatMessageRoleUser,
+			content,
+			visibility,
+			modelConfigID,
+			contentVersion,
+		),
+		apiKeyID: apiKeyID,
+	}
 }
 
-func (m chatMessage) withAPIKeyID(id string) chatMessage {
-	m.apiKeyID = id
+func (m chatMessage) withCreatedBy(id uuid.UUID) chatMessage {
+	m.createdBy = id
 	return m
 }
 
@@ -3990,10 +4015,37 @@ func (m chatMessage) withProviderResponseID(id string) chatMessage {
 	return m
 }
 
-// appendChatMessage appends a single message to the batch insert params.
+// appendChatMessage appends a non-user message to the batch insert params.
+// For user messages, use appendUserChatMessage instead.
 func appendChatMessage(
 	params *database.InsertChatMessagesParams,
 	msg chatMessage,
+) {
+	params.CreatedBy = append(params.CreatedBy, msg.createdBy)
+	params.APIKeyID = append(params.APIKeyID, "")
+	params.ModelConfigID = append(params.ModelConfigID, msg.modelConfigID)
+	params.Role = append(params.Role, msg.role)
+	params.Content = append(params.Content, string(msg.content.RawMessage))
+	params.ContentVersion = append(params.ContentVersion, msg.contentVersion)
+	params.Visibility = append(params.Visibility, msg.visibility)
+	params.InputTokens = append(params.InputTokens, msg.inputTokens)
+	params.OutputTokens = append(params.OutputTokens, msg.outputTokens)
+	params.TotalTokens = append(params.TotalTokens, msg.totalTokens)
+	params.ReasoningTokens = append(params.ReasoningTokens, msg.reasoningTokens)
+	params.CacheCreationTokens = append(params.CacheCreationTokens, msg.cacheCreationTokens)
+	params.CacheReadTokens = append(params.CacheReadTokens, msg.cacheReadTokens)
+	params.ContextLimit = append(params.ContextLimit, msg.contextLimit)
+	params.Compressed = append(params.Compressed, msg.compressed)
+	params.TotalCostMicros = append(params.TotalCostMicros, msg.totalCostMicros)
+	params.RuntimeMs = append(params.RuntimeMs, msg.runtimeMs)
+	params.ProviderResponseID = append(params.ProviderResponseID, msg.providerResponseID)
+}
+
+// appendUserChatMessage appends a user message to the batch insert params.
+// The userChatMessage type guarantees that an apiKeyID was provided.
+func appendUserChatMessage(
+	params *database.InsertChatMessagesParams,
+	msg userChatMessage,
 ) {
 	params.CreatedBy = append(params.CreatedBy, msg.createdBy)
 	params.APIKeyID = append(params.APIKeyID, msg.apiKeyID)
@@ -4037,6 +4089,28 @@ func BuildSingleChatMessageInsertParams(
 	return params
 }
 
+// BuildSingleUserChatMessageInsertParams creates batch insert params for
+// one user message, requiring an apiKeyID for AI Gateway attribution.
+func BuildSingleUserChatMessageInsertParams(
+	chatID uuid.UUID,
+	apiKeyID string,
+	content pqtype.NullRawMessage,
+	visibility database.ChatMessageVisibility,
+	modelConfigID uuid.UUID,
+	contentVersion int16,
+	createdBy uuid.UUID,
+) database.InsertChatMessagesParams {
+	params := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendUserChatMessage.
+		ChatID: chatID,
+	}
+	msg := newUserChatMessage(apiKeyID, content, visibility, modelConfigID, contentVersion)
+	if createdBy != uuid.Nil {
+		msg.chatMessage = msg.chatMessage.withCreatedBy(createdBy)
+	}
+	appendUserChatMessage(&params, msg)
+	return params
+}
+
 // insertUserMessageAndSetPending inserts a user message, transitions the
 // chat to pending when needed, and returns the refreshed chat row.
 func insertUserMessageAndSetPending(
@@ -4051,13 +4125,15 @@ func insertUserMessageAndSetPending(
 	msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendChatMessage.
 		ChatID: lockedChat.ID,
 	}
-	appendChatMessage(&msgParams, newChatMessage(
-		database.ChatMessageRoleUser,
+	insertUserMsg := newUserChatMessage(
+		apiKeyID,
 		content,
 		database.ChatMessageVisibilityBoth,
 		modelConfigID,
 		chatprompt.CurrentContentVersion,
-	).withCreatedBy(createdBy).withAPIKeyID(apiKeyID))
+	)
+	insertUserMsg.chatMessage = insertUserMsg.chatMessage.withCreatedBy(createdBy)
+	appendUserChatMessage(&msgParams, insertUserMsg)
 	messages, err := insertChatMessageWithStore(ctx, store, msgParams)
 	if err != nil {
 		return database.ChatMessage{}, database.Chat{}, err
@@ -5873,8 +5949,8 @@ func (p *Server) tryAutoPromoteQueuedMessage(
 	msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendChatMessage.
 		ChatID: chat.ID,
 	}
-	appendChatMessage(&msgParams, newChatMessage(
-		database.ChatMessageRoleUser,
+	queuedUserMsg := newUserChatMessage(
+		nextQueued.APIKeyID.String,
 		pqtype.NullRawMessage{
 			RawMessage: nextQueued.Content,
 			Valid:      len(nextQueued.Content) > 0,
@@ -5882,7 +5958,9 @@ func (p *Server) tryAutoPromoteQueuedMessage(
 		database.ChatMessageVisibilityBoth,
 		effectiveModelConfigID,
 		chatprompt.CurrentContentVersion,
-	).withCreatedBy(chat.OwnerID).withAPIKeyID(nextQueued.APIKeyID.String))
+	)
+	queuedUserMsg.chatMessage = queuedUserMsg.chatMessage.withCreatedBy(chat.OwnerID)
+	appendUserChatMessage(&msgParams, queuedUserMsg)
 	msgs, err := insertChatMessageWithStore(ctx, tx, msgParams)
 	if err != nil {
 		return nil, nil, false, xerrors.Errorf("insert promoted message: %w", err)
@@ -8462,13 +8540,16 @@ func (p *Server) persistChatContextSummary(
 		}
 
 		// Hidden summary user message (not published to subscribers).
-		appendChatMessage(&summaryParams, newChatMessage(
-			database.ChatMessageRoleUser,
+		summaryAPIKeyID, _ := aibridge.DelegatedAPIKeyIDFromContext(ctx)
+		summaryUserMsg := newUserChatMessage(
+			summaryAPIKeyID,
 			systemContent,
 			database.ChatMessageVisibilityModel,
 			modelConfigID,
 			chatprompt.CurrentContentVersion,
-		).withCompressed())
+		)
+		summaryUserMsg.chatMessage = summaryUserMsg.chatMessage.withCompressed()
+		appendUserChatMessage(&summaryParams, summaryUserMsg)
 
 		// Assistant tool-call message.
 		appendChatMessage(&summaryParams, newChatMessage(
@@ -8999,11 +9080,12 @@ func (p *Server) persistInstructionFiles(
 		if err != nil {
 			return "", nil, nil
 		}
-		msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendChatMessage.
+		blankAPIKeyID, _ := aibridge.DelegatedAPIKeyIDFromContext(ctx)
+		msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendUserChatMessage.
 			ChatID: chat.ID,
 		}
-		appendChatMessage(&msgParams, newChatMessage(
-			database.ChatMessageRoleUser,
+		appendUserChatMessage(&msgParams, newUserChatMessage(
+			blankAPIKeyID,
 			content,
 			database.ChatMessageVisibilityBoth,
 			modelConfigID,
@@ -9022,11 +9104,12 @@ func (p *Server) persistInstructionFiles(
 		return "", nil, xerrors.Errorf("marshal context-file parts: %w", err)
 	}
 
-	msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendChatMessage.
+	contentAPIKeyID, _ := aibridge.DelegatedAPIKeyIDFromContext(ctx)
+	msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendUserChatMessage.
 		ChatID: chat.ID,
 	}
-	appendChatMessage(&msgParams, newChatMessage(
-		database.ChatMessageRoleUser,
+	appendUserChatMessage(&msgParams, newUserChatMessage(
+		contentAPIKeyID,
 		content,
 		database.ChatMessageVisibilityBoth,
 		modelConfigID,

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -3927,8 +3927,8 @@ type chatMessage struct {
 	providerResponseID  string
 }
 
-// userChatMessage describes a user message. The apiKeyID field is
-// required by newUserChatMessage so that omitting it is a compile error.
+// userChatMessage wraps chatMessage with a required apiKeyID so that
+// omitting it for user messages is a compile error, not a silent data bug.
 type userChatMessage struct {
 	chatMessage
 	apiKeyID string
@@ -4024,9 +4024,9 @@ func (m chatMessage) withProviderResponseID(id string) chatMessage {
 	return m
 }
 
-// appendMessageFields appends the common fields from a chatMessage to the
-// batch insert params. apiKeyID is passed explicitly so that non-user
-// messages always get "" and user messages get the caller's key.
+// appendMessageFields writes all chatMessage fields into the batch insert
+// params. apiKeyID is explicit so non-user messages always get "" while
+// user messages carry the caller's key for AI Gateway routing.
 func appendMessageFields(
 	params *database.InsertChatMessagesParams,
 	msg chatMessage,
@@ -4063,7 +4063,7 @@ func appendChatMessage(
 	appendMessageFields(params, msg, "")
 }
 
-// appendUserChatMessage appends a user message to the batch insert params.
+// appendUserChatMessage inserts a user message with its apiKeyID preserved.
 func appendUserChatMessage(
 	params *database.InsertChatMessagesParams,
 	msg userChatMessage,

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -19,9 +19,12 @@ import (
 
 	"cdr.dev/slog/v3"
 	"cdr.dev/slog/v3/sloggers/slogtest"
+	"github.com/coder/coder/v2/coderd/aibridge"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	dbpubsub "github.com/coder/coder/v2/coderd/database/pubsub"
 	coderdpubsub "github.com/coder/coder/v2/coderd/pubsub"
 	"github.com/coder/coder/v2/coderd/rbac"
@@ -1339,6 +1342,8 @@ func TestPersistInstructionFilesIncludesAgentMetadata(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
+	testAPIKeyID := uuid.NewString()
+	ctx = aibridge.WithDelegatedAPIKeyID(ctx, testAPIKeyID)
 	ctrl := gomock.NewController(t)
 	db := dbmock.NewMockStore(ctrl)
 
@@ -1367,6 +1372,18 @@ func TestPersistInstructionFilesIncludesAgentMetadata(t *testing.T) {
 		agentID,
 	).Return(workspaceAgent, nil).Times(1)
 	db.EXPECT().InsertChatMessages(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	db.EXPECT().InsertChatMessages(gomock.Any(), gomock.Cond(func(x any) bool {
+		params, ok := x.(database.InsertChatMessagesParams)
+		if !ok {
+			return false
+		}
+		for i, role := range params.Role {
+			if role == database.ChatMessageRoleUser && params.APIKeyID[i] != testAPIKeyID {
+				return false
+			}
+		}
+		return true
+	})).Return(nil, nil).AnyTimes()
 	db.EXPECT().UpdateChatLastInjectedContext(gomock.Any(),
 		gomock.Cond(func(x any) bool {
 			arg, ok := x.(database.UpdateChatLastInjectedContextParams)
@@ -6615,4 +6632,61 @@ func TestPrimeWorkspaceMCPCache_ExitsOnContextCancel(t *testing.T) {
 
 	_, ok := server.workspaceMCPToolsCache.Load(chat.ID)
 	require.False(t, ok, "primer must not cache anything when canceled")
+}
+
+func TestPersistChatContextSummarySetsAPIKeyID(t *testing.T) {
+	t.Parallel()
+
+	db, _ := dbtestutil.NewDB(t)
+	ctx := context.Background()
+
+	user := dbgen.User(t, db, database.User{})
+	org := dbgen.Organization(t, db, database.Organization{})
+	modelConfig := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{})
+	chat := dbgen.Chat(t, db, database.Chat{
+		OwnerID:           user.ID,
+		OrganizationID:    org.ID,
+		LastModelConfigID: modelConfig.ID,
+	})
+	apiKey, _ := dbgen.APIKey(t, db, database.APIKey{
+		UserID: user.ID,
+	})
+
+	ctx = aibridge.WithDelegatedAPIKeyID(ctx, apiKey.ID)
+
+	server := &Server{db: db}
+
+	err := server.persistChatContextSummary(
+		ctx,
+		chat.ID,
+		modelConfig.ID,
+		"tool-call-id-1",
+		chatloop.CompactionResult{
+			SystemSummary:    "summarized context",
+			SummaryReport:    "context was summarized",
+			ThresholdPercent: 70,
+			UsagePercent:     85.0,
+			ContextTokens:    8500,
+			ContextLimit:     10000,
+		},
+	)
+	require.NoError(t, err)
+
+	msgs, err := db.GetChatMessagesForPromptByChatID(ctx, chat.ID)
+	require.NoError(t, err)
+
+	// GetChatMessagesForPromptByChatID applies compaction boundaries,
+	// so only the compressed user summary is returned. The assistant
+	// and tool messages have non-model visibility and are filtered.
+	require.NotEmpty(t, msgs)
+
+	var foundUserSummary bool
+	for _, msg := range msgs {
+		if msg.Role == database.ChatMessageRoleUser {
+			foundUserSummary = true
+			require.True(t, msg.APIKeyID.Valid, "summary user message must have APIKeyID set")
+			require.Equal(t, apiKey.ID, msg.APIKeyID.String, "summary user message APIKeyID must match")
+		}
+	}
+	require.True(t, foundUserSummary, "expected to find compressed user summary message")
 }

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -6674,9 +6674,10 @@ func TestPersistChatContextSummarySetsAPIKeyID(t *testing.T) {
 	msgs, err := db.GetChatMessagesForPromptByChatID(ctx, chat.ID)
 	require.NoError(t, err)
 
-	// GetChatMessagesForPromptByChatID applies compaction boundaries,
-	// so only the compressed user summary is returned. The assistant
-	// and tool messages have non-model visibility and are filtered.
+	// GetChatMessagesForPromptByChatID uses a compaction boundary CTE
+	// that selects compressed=true, visibility='model'. Only the user
+	// summary qualifies; the assistant (visibility=user) and tool
+	// result (visibility=both) are excluded by the CTE filter.
 	require.NotEmpty(t, msgs)
 
 	var foundUserSummary bool

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -1371,7 +1371,6 @@ func TestPersistInstructionFilesIncludesAgentMetadata(t *testing.T) {
 		gomock.Any(),
 		agentID,
 	).Return(workspaceAgent, nil).Times(1)
-	db.EXPECT().InsertChatMessages(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	db.EXPECT().InsertChatMessages(gomock.Any(), gomock.Cond(func(x any) bool {
 		params, ok := x.(database.InsertChatMessagesParams)
 		if !ok {

--- a/coderd/x/chatd/subagent.go
+++ b/coderd/x/chatd/subagent.go
@@ -1033,7 +1033,7 @@ func (p *Server) createChildSubagentChatWithOptions(
 			return xerrors.Errorf("marshal initial user content: %w", err)
 		}
 
-		systemParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by append[User]ChatMessage.
+		systemParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendChatMessage.
 			ChatID: insertedChat.ID,
 		}
 		if deploymentPrompt != "" {
@@ -1090,7 +1090,7 @@ func (p *Server) createChildSubagentChatWithOptions(
 			return xerrors.Errorf("update child injected context: %w", err)
 		}
 
-		userParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by append[User]ChatMessage.
+		userParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendUserChatMessage.
 			ChatID: insertedChat.ID,
 		}
 		childUserMsg := newUserChatMessage(
@@ -1100,7 +1100,7 @@ func (p *Server) createChildSubagentChatWithOptions(
 			modelConfigID,
 			chatprompt.CurrentContentVersion,
 		)
-		childUserMsg.chatMessage = childUserMsg.chatMessage.withCreatedBy(parent.OwnerID)
+		childUserMsg = childUserMsg.withCreatedBy(parent.OwnerID)
 		appendUserChatMessage(&userParams, childUserMsg)
 		if _, err := tx.InsertChatMessages(ctx, userParams); err != nil {
 			return xerrors.Errorf("insert initial child user message: %w", err)
@@ -1178,7 +1178,7 @@ func copyParentContextMessages(
 		return nil, xerrors.Errorf("marshal filtered context parts: %w", err)
 	}
 
-	msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by append(User)ChatMessage.
+	msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by append[User]ChatMessage.
 		ChatID: child.ID,
 	}
 	if copiedRole == database.ChatMessageRoleUser {

--- a/coderd/x/chatd/subagent.go
+++ b/coderd/x/chatd/subagent.go
@@ -1033,7 +1033,7 @@ func (p *Server) createChildSubagentChatWithOptions(
 			return xerrors.Errorf("marshal initial user content: %w", err)
 		}
 
-		systemParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendChatMessage.
+		systemParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by append[User]ChatMessage.
 			ChatID: insertedChat.ID,
 		}
 		if deploymentPrompt != "" {
@@ -1090,7 +1090,7 @@ func (p *Server) createChildSubagentChatWithOptions(
 			return xerrors.Errorf("update child injected context: %w", err)
 		}
 
-		userParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendChatMessage.
+		userParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by append[User]ChatMessage.
 			ChatID: insertedChat.ID,
 		}
 		childUserMsg := newUserChatMessage(

--- a/coderd/x/chatd/subagent.go
+++ b/coderd/x/chatd/subagent.go
@@ -1093,13 +1093,15 @@ func (p *Server) createChildSubagentChatWithOptions(
 		userParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendChatMessage.
 			ChatID: insertedChat.ID,
 		}
-		appendChatMessage(&userParams, newChatMessage(
-			database.ChatMessageRoleUser,
+		childUserMsg := newUserChatMessage(
+			childAPIKeyID,
 			userContent,
 			database.ChatMessageVisibilityBoth,
 			modelConfigID,
 			chatprompt.CurrentContentVersion,
-		).withCreatedBy(parent.OwnerID).withAPIKeyID(childAPIKeyID))
+		)
+		childUserMsg.chatMessage = childUserMsg.chatMessage.withCreatedBy(parent.OwnerID)
+		appendUserChatMessage(&userParams, childUserMsg)
 		if _, err := tx.InsertChatMessages(ctx, userParams); err != nil {
 			return xerrors.Errorf("insert initial child user message: %w", err)
 		}
@@ -1176,16 +1178,27 @@ func copyParentContextMessages(
 		return nil, xerrors.Errorf("marshal filtered context parts: %w", err)
 	}
 
-	msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by appendChatMessage.
+	msgParams := database.InsertChatMessagesParams{ //nolint:exhaustruct // Fields populated by append(User)ChatMessage.
 		ChatID: child.ID,
 	}
-	appendChatMessage(&msgParams, newChatMessage(
-		copiedRole,
-		filteredContent,
-		copiedVisibility,
-		child.LastModelConfigID,
-		copiedVersion,
-	))
+	if copiedRole == database.ChatMessageRoleUser {
+		copiedAPIKeyID, _ := aibridge.DelegatedAPIKeyIDFromContext(ctx)
+		appendUserChatMessage(&msgParams, newUserChatMessage(
+			copiedAPIKeyID,
+			filteredContent,
+			copiedVisibility,
+			child.LastModelConfigID,
+			copiedVersion,
+		))
+	} else {
+		appendChatMessage(&msgParams, newChatMessage(
+			copiedRole,
+			filteredContent,
+			copiedVisibility,
+			child.LastModelConfigID,
+			copiedVersion,
+		))
+	}
 	if _, err := store.InsertChatMessages(ctx, msgParams); err != nil {
 		return nil, xerrors.Errorf("insert context message: %w", err)
 	}

--- a/coderd/x/chatd/subagent_context_internal_test.go
+++ b/coderd/x/chatd/subagent_context_internal_test.go
@@ -464,13 +464,16 @@ func TestCreateChildSubagentChatUpdatesInheritedLastInjectedContext(t *testing.T
 		AfterID: 0,
 	})
 	require.NoError(t, err)
+	var userMsgCount int
 	for _, msg := range childMessages {
 		if msg.Role != database.ChatMessageRoleUser {
 			continue
 		}
+		userMsgCount++
 		require.True(t, msg.APIKeyID.Valid, "child user message (id=%d) should have api_key_id set", msg.ID)
 		require.Equal(t, apiKey.ID, msg.APIKeyID.String, "child user message (id=%d) api_key_id mismatch", msg.ID)
 	}
+	require.Greater(t, userMsgCount, 0, "expected at least one user-role message in child chat")
 }
 
 func TestSpawnComputerUseAgentInheritsContext(t *testing.T) {

--- a/coderd/x/chatd/subagent_context_internal_test.go
+++ b/coderd/x/chatd/subagent_context_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/coderd/aibridge"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
@@ -446,10 +447,30 @@ func TestCreateChildSubagentChatUpdatesInheritedLastInjectedContext(t *testing.T
 	ctx := chatdTestContext(t)
 	parentChat := createParentChatWithInheritedContext(ctx, t, db, server)
 
+	// Set a delegated API key so that copied user-role context messages
+	// are stamped with api_key_id, preserving AI Gateway routing.
+	apiKey, _ := dbgen.APIKey(t, db, database.APIKey{UserID: parentChat.OwnerID})
+	ctx = aibridge.WithDelegatedAPIKeyID(ctx, apiKey.ID)
+
 	child, err := server.createChildSubagentChat(ctx, parentChat, "inspect bindings", "")
 	require.NoError(t, err)
 
 	assertChildInheritedContext(ctx, t, db, child.ID, "inspect bindings")
+
+	// Verify that all user-role messages in the child chat carry
+	// api_key_id so activeTurnAPIKeyIDFromMessages resolves correctly.
+	childMessages, err := db.GetChatMessagesByChatID(ctx, database.GetChatMessagesByChatIDParams{
+		ChatID:  child.ID,
+		AfterID: 0,
+	})
+	require.NoError(t, err)
+	for _, msg := range childMessages {
+		if msg.Role != database.ChatMessageRoleUser {
+			continue
+		}
+		require.True(t, msg.APIKeyID.Valid, "child user message (id=%d) should have api_key_id set", msg.ID)
+		require.Equal(t, apiKey.ID, msg.APIKeyID.String, "child user message (id=%d) api_key_id mismatch", msg.ID)
+	}
 }
 
 func TestSpawnComputerUseAgentInheritsContext(t *testing.T) {


### PR DESCRIPTION
## Problem

Several code paths insert `role=user` chat messages without setting `api_key_id`: injected workspace context, AGENTS.md, skills, compaction summaries, and copied subagent context. When one of these becomes the latest visible user message, `activeTurnAPIKeyIDFromMessages` returns empty and `newAIGatewayModel` fails closed, breaking AI Gateway routing.

## Fix

Split `chatMessage` into two types: `chatMessage` for system/assistant/tool messages, and `userChatMessage` which embeds `chatMessage` and adds a required `apiKeyID string` field. This makes a missing `api_key_id` a compile error rather than a silent data bug.

- `newChatMessage()` returns `chatMessage`; `newUserChatMessage(apiKeyID, ...)` returns `userChatMessage`
- `appendChatMessage` panics on `ChatMessageRoleUser` (runtime backstop; see CODAGT-506 for DB-level enforcement)
- All 9 user-message insertion sites updated to use `newUserChatMessage`
- `withCreatedBy`/`withCompressed` wrappers on `userChatMessage` prevent the promoted-method footgun where `chatMessage.withCreatedBy` strips `apiKeyID`
- `BuildSingleUserChatMessageInsertParams` exported helper for `workspaceagents.go`

## Test coverage

**Pre-existing tests** (already assert `api_key_id` on messages read back from DB):
- `TestCreateChatPersistsAPIKeyIDOnInitialUserMessage` (CreateChat path)
- `TestSendMessagePersistsAPIKeyIDOnUserMessage` (SendMessage path)
- `TestEditMessageUpdatesAndTruncatesAndClearsQueue` (EditMessage path)
- `TestPromoteQueuedAllowsAlreadyQueuedMessageWhenUsageLimitReached` (queue promotion)
- `TestCreateChildSubagentChatPropagatesActiveTurnAPIKeyID` (subagent initial user message)
- `TestSendSubagentMessagePropagatesActiveTurnAPIKeyID` (subagent follow-up)

**Updated tests** (assert `api_key_id` on previously-uncovered indirect injection paths):
- `TestCreateChildSubagentChatUpdatesInheritedLastInjectedContext`: sets delegated API key on context, asserts all child user messages (including copied context) carry `api_key_id`. **RED on `main`** (`child user message (id=7) should have api_key_id set`), **GREEN on fix branch**.
- `TestPersistInstructionFilesIncludesAgentMetadata`: added gomock matcher verifying `InsertChatMessages` params carry `api_key_id` for user-role messages.
- `TestPersistChatContextSummarySetsAPIKeyID` (new, real DB): calls `persistChatContextSummary` with delegated API key on context, reads back compressed user summary, asserts `api_key_id`.

Related to #25723 (manual title generation fix, merged). Follow-up: [CODAGT-506](https://linear.app/codercom/issue/CODAGT-506) for DB-level enforcement.

<details><summary>Implementation notes</summary>

- Empty string is valid for `apiKeyID` in paths that genuinely lack a caller key (e.g. agent-initiated context injection in `workspaceAgentAddChatContext`). AI Gateway fail-closed check remains the runtime safety net.
- Context injection paths (`persistInstructionFiles`, compaction) read the key from `aibridge.DelegatedAPIKeyIDFromContext(ctx)`, set upstream by `contextWithActiveTurnAPIKeyID`.
- Subagent context copy branches on `copiedRole == database.ChatMessageRoleUser` to choose the right append function.

</details>

> Generated by Coder Agents