### PR TITLE
ci(.github/workflows/doc-check): update agents-chat-action to v0.2.0

### DIFF
--- a/.github/workflows/doc-check.yaml
+++ b/.github/workflows/doc-check.yaml
@@ -213,7 +213,7 @@ jobs:
 
       - name: Run doc-check via Coder Agent Chat
         if: steps.check-secrets.outputs.skip != 'true'
-        uses: coder/agents-chat-action@abc4ebbc80a5b2bb15b9e8a740b003bfbb5d6ef0 # node24
+        uses: coder/agents-chat-action@354442171b5ae9afb21e5f117e52d65e4a60b3f4 # v0.2.0
         with:
           coder-url: ${{ secrets.DOC_CHECK_CODER_URL }}
           coder-token: ${{ secrets.DOC_CHECK_CODER_SESSION_TOKEN }}

--- a/.github/workflows/doc-check.yaml
+++ b/.github/workflows/doc-check.yaml
@@ -213,7 +213,7 @@ jobs:
 
       - name: Run doc-check via Coder Agent Chat
         if: steps.check-secrets.outputs.skip != 'true'
-        uses: coder/agents-chat-action@354442171b5ae9afb21e5f117e52d65e4a60b3f4 # v0.2.0
+        uses: coder/agents-chat-action@354442115103a9d674686661d2076a8c62eb7cb2 # v0.2.0
         with:
           coder-url: ${{ secrets.DOC_CHECK_CODER_URL }}
           coder-token: ${{ secrets.DOC_CHECK_CODER_SESSION_TOKEN }}

--- a/.github/workflows/doc-check.yaml
+++ b/.github/workflows/doc-check.yaml
@@ -213,7 +213,7 @@ jobs:
 
       - name: Run doc-check via Coder Agent Chat
         if: steps.check-secrets.outputs.skip != 'true'
-        uses: coder/agents-chat-action@f0b975f503d3ff3e4478517baae290d4d01a2c7e # v0
+        uses: coder/agents-chat-action@abc4ebbc80a5b2bb15b9e8a740b003bfbb5d6ef0 # node24
         with:
           coder-url: ${{ secrets.DOC_CHECK_CODER_URL }}
           coder-token: ${{ secrets.DOC_CHECK_CODER_SESSION_TOKEN }}


### PR DESCRIPTION
Pin doc-check workflow to agents-chat-action v0.2.0 (node24 runtime).

Tested via workflow_dispatch against PR #25706.

> 🤖 Generated by Coder Agents.