### PR TITLE
docs(docs/admin/monitoring): document log-human disable workaround

### DIFF
--- a/docs/admin/monitoring/logs.md
+++ b/docs/admin/monitoring/logs.md
@@ -19,6 +19,11 @@ machine/VM.
   the[`CODER_LOG_FILTER`](../../reference/cli/server.md#-l---log-filter) server
   config. Using `.*` will result in the `DEBUG` log level being used.
 
+> [!NOTE]
+> To disable human-readable logging, set `--log-human` (or
+> `CODER_LOGGING_HUMAN`) to `/dev/null`. An empty string does not disable
+> logging.
+
 Events such as server errors, audit logs, user activities, and SSO & OpenID
 Connect logs are all captured in the `coderd` logs.
 


### PR DESCRIPTION
Closes DOCS-66.

Adds a `[!NOTE]` callout to `docs/admin/monitoring/logs.md` documenting that `--log-human=""` (empty string) does not disable human-readable logging; the working value is `--log-human=/dev/null`.

## Context

Reported by Bjorn Robertsson in `#docs` on 2026-04-29. Operators trying to silence the human-readable log stream had been setting `--log-human` (or `CODER_LOGGING_HUMAN`) to an empty string and getting unchanged log output. The empty-string path hits a 2023-vintage code path that falls back to the default `/dev/stderr` instead of disabling output.

This PR documents the workaround on the admin-facing logs page. The CLI flag reference under `docs/reference/cli/server.md` is auto-generated and intentionally left unchanged. A separate engineering issue may be worth filing to fix the root cause (empty string should either disable or surface a warning).

> [!NOTE]
> This is a docs-only change. No product code was modified.

---

*Generated by Coder Agents on behalf of @nickvigilante.*