### PR TITLE
refactor(site): update BYOK link to use "View docs" on AI settings page

### DIFF
--- a/site/src/pages/AISettingsPage/ProvidersPage/ProvidersPageView.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/ProvidersPageView.tsx
@@ -1,5 +1,5 @@
 import { ChevronDownIcon, PlusIcon } from "lucide-react";
-import { Link, useNavigate } from "react-router";
+import { useNavigate } from "react-router";
 import type { AIProvider } from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Button } from "#/components/Button/Button";
@@ -9,6 +9,7 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "#/components/DropdownMenu/DropdownMenu";
+import { Link } from "#/components/Link/Link";
 import {
 	SettingsHeader,
 	SettingsHeaderDescription,
@@ -87,12 +88,8 @@ const ProvidersPageView: React.FC<ProvidersPageViewProps> = ({
 					Bedrock. Providers configured here power Coder Agents, AI Gateway, and
 					other capabilities such as APIs, CLI or IDEs that use LLMs. By
 					default, users can supply their own keys for any provider.{" "}
-					<Link
-						to={docs("/ai-coder/ai-gateway/auth#enable-or-disable-byok")}
-						target="_blank"
-						rel="noreferrer"
-					>
-						Manage deployment-wide BYOK
+					<Link href={docs("/ai-coder/ai-gateway/auth#enable-or-disable-byok")}>
+						View docs
 					</Link>
 				</SettingsHeaderDescription>
 			</SettingsHeader>


### PR DESCRIPTION
Changes the "Manage deployment-wide BYOK" link on the AI Providers settings page (`/ai/settings`) to "View docs", matching the pattern used on the provisioner keys page (`/organizations/{org}/provisioner-keys`).

### Changes
- Swapped `Link` from `react-router` to `#/components/Link/Link` (uses `href` instead of `to`)
- Removed `target="_blank"` and `rel="noreferrer"`: the link now navigates in the same tab, matching the provisioner keys page convention
- Changed link text from "Manage deployment-wide BYOK" to "View docs"

> Generated by Coder Agents on behalf of @tracyjohnsonux