### PR TITLE
fix: collapse agent command output by default

### DIFF
--- a/coderd/users.go
+++ b/coderd/users.go
@@ -1336,7 +1336,7 @@ func (api *API) userPreferenceSettings(rw http.ResponseWriter, r *http.Request) 
 	httpapi.Write(ctx, rw, http.StatusOK, codersdk.UserPreferenceSettings{
 		TaskNotificationAlertDismissed: taskAlertDismissed,
 		ThinkingDisplayMode:            sanitizeThinkingDisplayMode(thinkingMode),
-		ShellToolDisplayMode:           sanitizeAgentDisplayMode(shellToolMode),
+		ShellToolDisplayMode:           sanitizeShellToolDisplayMode(shellToolMode),
 		CodeDiffDisplayMode:            sanitizeAgentDisplayMode(codeDiffMode),
 		AgentChatSendShortcut:          sanitizeAgentChatSendShortcut(agentChatSendShortcut),
 	})
@@ -1446,13 +1446,13 @@ func (api *API) putUserPreferenceSettings(rw http.ResponseWriter, r *http.Reques
 			if err != nil {
 				return newUserPreferenceSettingsAPIError("Internal error updating shell tool display mode.", err)
 			}
-			settings.ShellToolDisplayMode = sanitizeAgentDisplayMode(updated)
+			settings.ShellToolDisplayMode = sanitizeShellToolDisplayMode(updated)
 		} else {
 			stored, err := tx.GetUserShellToolDisplayMode(ctx, user.ID)
 			if err != nil && !errors.Is(err, sql.ErrNoRows) {
 				return newUserPreferenceSettingsAPIError("Error reading shell tool display mode.", err)
 			}
-			settings.ShellToolDisplayMode = sanitizeAgentDisplayMode(stored)
+			settings.ShellToolDisplayMode = sanitizeShellToolDisplayMode(stored)
 		}
 
 		if params.CodeDiffDisplayMode != "" {
@@ -1545,12 +1545,20 @@ func sanitizeThinkingDisplayMode(raw string) codersdk.ThinkingDisplayMode {
 	return codersdk.ThinkingDisplayModeAuto
 }
 
+func sanitizeShellToolDisplayMode(raw string) codersdk.AgentDisplayMode {
+	mode := sanitizeAgentDisplayMode(raw)
+	if mode == "" {
+		return codersdk.AgentDisplayModeAlwaysCollapsed
+	}
+	return mode
+}
+
 func sanitizeAgentDisplayMode(raw string) codersdk.AgentDisplayMode {
 	mode := codersdk.AgentDisplayMode(raw)
 	if slices.Contains(codersdk.ValidAgentDisplayModes, mode) {
 		return mode
 	}
-	return codersdk.AgentDisplayModeAlwaysCollapsed
+	return ""
 }
 
 func sanitizeAgentChatSendShortcut(raw string) codersdk.AgentChatSendShortcut {

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -1550,7 +1550,7 @@ func sanitizeAgentDisplayMode(raw string) codersdk.AgentDisplayMode {
 	if slices.Contains(codersdk.ValidAgentDisplayModes, mode) {
 		return mode
 	}
-	return codersdk.AgentDisplayModeAuto
+	return codersdk.AgentDisplayModeAlwaysCollapsed
 }
 
 func sanitizeAgentChatSendShortcut(raw string) codersdk.AgentChatSendShortcut {

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -2423,7 +2423,7 @@ func TestAgentDisplayModePreferences(t *testing.T) {
 		require.Equal(t, field, sdkErr.Validations[0].Field)
 	}
 
-	t.Run("defaults to always collapsed", func(t *testing.T) {
+	t.Run("defaults shell tools to always collapsed", func(t *testing.T) {
 		t.Parallel()
 
 		client, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
@@ -2434,7 +2434,7 @@ func TestAgentDisplayModePreferences(t *testing.T) {
 		settings, err := client.GetUserPreferenceSettings(ctx, codersdk.Me)
 		require.NoError(t, err)
 		require.Equal(t, codersdk.AgentDisplayModeAlwaysCollapsed, settings.ShellToolDisplayMode)
-		require.Equal(t, codersdk.AgentDisplayModeAlwaysCollapsed, settings.CodeDiffDisplayMode)
+		require.Empty(t, settings.CodeDiffDisplayMode)
 	})
 
 	t.Run("round-trips shell tool display mode", func(t *testing.T) {

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -2423,7 +2423,7 @@ func TestAgentDisplayModePreferences(t *testing.T) {
 		require.Equal(t, field, sdkErr.Validations[0].Field)
 	}
 
-	t.Run("defaults to auto", func(t *testing.T) {
+	t.Run("defaults to always collapsed", func(t *testing.T) {
 		t.Parallel()
 
 		client, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
@@ -2433,8 +2433,8 @@ func TestAgentDisplayModePreferences(t *testing.T) {
 
 		settings, err := client.GetUserPreferenceSettings(ctx, codersdk.Me)
 		require.NoError(t, err)
-		require.Equal(t, codersdk.AgentDisplayModeAuto, settings.ShellToolDisplayMode)
-		require.Equal(t, codersdk.AgentDisplayModeAuto, settings.CodeDiffDisplayMode)
+		require.Equal(t, codersdk.AgentDisplayModeAlwaysCollapsed, settings.ShellToolDisplayMode)
+		require.Equal(t, codersdk.AgentDisplayModeAlwaysCollapsed, settings.CodeDiffDisplayMode)
 	})
 
 	t.Run("round-trips shell tool display mode", func(t *testing.T) {

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -303,7 +303,7 @@ export const BlockList: FC<{
 	const shellToolDisplayMode: TypesGen.AgentDisplayMode =
 		prefQuery.data?.shell_tool_display_mode || "always_collapsed";
 	const codeDiffDisplayMode: TypesGen.AgentDisplayMode =
-		prefQuery.data?.code_diff_display_mode || "always_collapsed";
+		prefQuery.data?.code_diff_display_mode || "auto";
 
 	const toolByID = new Map(tools.map((tool) => [tool.id, tool]));
 	const displayBlocks = groupSequentialReadFileBlocks(blocks, tools);

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -301,9 +301,9 @@ export const BlockList: FC<{
 	const thinkingDisplayMode: ThinkingDisplayMode =
 		prefQuery.data?.thinking_display_mode || "auto";
 	const shellToolDisplayMode: TypesGen.AgentDisplayMode =
-		prefQuery.data?.shell_tool_display_mode || "auto";
+		prefQuery.data?.shell_tool_display_mode || "always_collapsed";
 	const codeDiffDisplayMode: TypesGen.AgentDisplayMode =
-		prefQuery.data?.code_diff_display_mode || "auto";
+		prefQuery.data?.code_diff_display_mode || "always_collapsed";
 
 	const toolByID = new Map(tools.map((tool) => [tool.id, tool]));
 	const displayBlocks = groupSequentialReadFileBlocks(blocks, tools);

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.stories.tsx
@@ -282,7 +282,7 @@ export const ThinkingDuringStreamingWithToolCalls: Story = {
 		expect(canvas.getAllByText("Thinking").length).toBeGreaterThanOrEqual(1);
 
 		const executeButton = canvas.getByRole("button", {
-			name: /collapse command/i,
+			name: /expand command/i,
 		});
 		const readFileLabel = canvas.getByText(/reading README\.md/i);
 		const thinkingText = canvas.getAllByText("Thinking").at(-1);

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -299,6 +299,7 @@ export const ExecuteModelIntent: Story = {
 
 export const ExecuteModelIntentRunning: Story = {
 	args: {
+		shellToolDisplayMode: "always_expanded",
 		status: "running",
 		args: {
 			command: executeCommand,


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

Coder Agents shell tool output now defaults to collapsed when the user has not saved a shell display preference.

This updates the API preference fallback and conversation UI fallback for `shell_tool_display_mode` to use `always_collapsed`. Code diff display behavior is unchanged and continues to use its existing `auto` behavior when unset.
