### PR TITLE
fix: enforce user AI budget override membership via trigger

### DIFF
--- a/coderd/database/check_constraint.go
+++ b/coderd/database/check_constraint.go
@@ -44,7 +44,6 @@ const (
 	CheckTelemetryLockEventTypeConstraint             CheckConstraint = "telemetry_lock_event_type_constraint"                // telemetry_locks
 	CheckValidationMonotonicOrder                     CheckConstraint = "validation_monotonic_order"                          // template_version_parameters
 	CheckUsageEventTypeCheck                          CheckConstraint = "usage_event_type_check"                              // usage_events
-	CheckUserAiBudgetOverridesMustBeGroupMember       CheckConstraint = "user_ai_budget_overrides_must_be_group_member"       // user_ai_budget_overrides
 	CheckUserAiBudgetOverridesSpendLimitMicrosCheck   CheckConstraint = "user_ai_budget_overrides_spend_limit_micros_check"   // user_ai_budget_overrides
 	CheckUserAiProviderKeysAPIKeyCheck                CheckConstraint = "user_ai_provider_keys_api_key_check"                 // user_ai_provider_keys
 	CheckUserSkillsContentSize                        CheckConstraint = "user_skills_content_size"                            // user_skills

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -857,6 +857,22 @@ BEGIN
 END;
 $$;
 
+CREATE FUNCTION enforce_user_ai_budget_override_membership() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+	IF NOT EXISTS (
+		SELECT 1 FROM group_members_expanded
+		WHERE user_id = NEW.user_id AND group_id = NEW.group_id
+	) THEN
+		RAISE EXCEPTION 'user % is not a member of group %', NEW.user_id, NEW.group_id
+			USING ERRCODE = 'check_violation',
+			      CONSTRAINT = 'user_ai_budget_overrides_must_be_group_member';
+	END IF;
+	RETURN NEW;
+END;
+$$;
+
 CREATE FUNCTION enforce_user_secrets_per_user_limits() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
@@ -1078,15 +1094,6 @@ BEGIN
     END IF;
     RETURN NEW;
 END;
-$$;
-
-CREATE FUNCTION is_group_member(uid uuid, gid uuid) RETURNS boolean
-    LANGUAGE sql STABLE
-    AS $$
-	SELECT EXISTS (
-		SELECT 1 FROM group_members_expanded
-		WHERE user_id = uid AND group_id = gid
-	);
 $$;
 
 CREATE FUNCTION nullify_next_start_at_on_workspace_autostart_modification() RETURNS trigger
@@ -3154,7 +3161,6 @@ CREATE TABLE user_ai_budget_overrides (
     spend_limit_micros bigint NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT user_ai_budget_overrides_must_be_group_member CHECK (is_group_member(user_id, group_id)),
     CONSTRAINT user_ai_budget_overrides_spend_limit_micros_check CHECK ((spend_limit_micros >= 0))
 );
 
@@ -4492,6 +4498,8 @@ CREATE TRIGGER trigger_delete_oauth2_provider_app_token AFTER DELETE ON oauth2_p
 CREATE TRIGGER trigger_delete_user_ai_budget_overrides_on_group_member_delete BEFORE DELETE ON group_members FOR EACH ROW EXECUTE FUNCTION delete_user_ai_budget_overrides_on_group_member_delete();
 
 CREATE TRIGGER trigger_delete_user_ai_budget_overrides_on_org_member_delete BEFORE DELETE ON organization_members FOR EACH ROW EXECUTE FUNCTION delete_user_ai_budget_overrides_on_org_member_delete();
+
+CREATE TRIGGER trigger_enforce_user_ai_budget_override_membership BEFORE INSERT OR UPDATE ON user_ai_budget_overrides FOR EACH ROW EXECUTE FUNCTION enforce_user_ai_budget_override_membership();
 
 CREATE TRIGGER trigger_insert_apikeys BEFORE INSERT ON api_keys FOR EACH ROW EXECUTE FUNCTION insert_apikey_fail_if_user_deleted();
 

--- a/coderd/database/migrations/000510_user_ai_budget_overrides.down.sql
+++ b/coderd/database/migrations/000510_user_ai_budget_overrides.down.sql
@@ -2,5 +2,6 @@ DROP TRIGGER IF EXISTS trigger_delete_user_ai_budget_overrides_on_org_member_del
 DROP FUNCTION IF EXISTS delete_user_ai_budget_overrides_on_org_member_delete;
 DROP TRIGGER IF EXISTS trigger_delete_user_ai_budget_overrides_on_group_member_delete ON group_members;
 DROP FUNCTION IF EXISTS delete_user_ai_budget_overrides_on_group_member_delete;
+DROP TRIGGER IF EXISTS trigger_enforce_user_ai_budget_override_membership ON user_ai_budget_overrides;
+DROP FUNCTION IF EXISTS enforce_user_ai_budget_override_membership;
 DROP TABLE user_ai_budget_overrides;
-DROP FUNCTION IF EXISTS is_group_member(uuid, uuid);

--- a/coderd/database/migrations/000510_user_ai_budget_overrides.up.sql
+++ b/coderd/database/migrations/000510_user_ai_budget_overrides.up.sql
@@ -1,31 +1,44 @@
--- Membership predicate used by CHECK constraints. Reads from
--- group_members_expanded so the "Everyone" group (whose membership
--- lives in organization_members) is correctly handled.
-CREATE FUNCTION is_group_member(uid uuid, gid uuid) RETURNS boolean
-LANGUAGE sql STABLE AS $$
-	SELECT EXISTS (
-		SELECT 1 FROM group_members_expanded
-		WHERE user_id = uid AND group_id = gid
-	);
-$$;
-
 CREATE TABLE user_ai_budget_overrides (
     user_id            UUID        PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
     group_id           UUID        NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
     -- Spend limit applied to the user, in micro-units (1 unit = 1,000,000).
     spend_limit_micros BIGINT      NOT NULL CHECK (spend_limit_micros >= 0),
     created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
     -- The membership invariant (user must be a member of the attributed
     -- group, including when that group is "Everyone") would naturally be
     -- a composite FK to group_members_expanded, but PostgreSQL does not
-    -- allow FKs to views. It's enforced instead by the CHECK below and
-    -- triggers on the underlying membership tables.
-    CONSTRAINT user_ai_budget_overrides_must_be_group_member
-        CHECK (is_group_member(user_id, group_id))
+    -- allow FKs to views. It's enforced instead by a write-time trigger
+    -- on this table and removal-time triggers on the underlying
+    -- membership tables.
 );
 
 COMMENT ON TABLE user_ai_budget_overrides IS 'Per-user AI spend override that supersedes group budget resolution.';
+
+-- Write-time membership check. Reads from group_members_expanded so
+-- the "Everyone" group (whose membership lives in organization_members)
+-- is correctly handled. Raises check_violation with a constraint name
+-- so callers can match it via database.IsCheckViolation in Go.
+CREATE FUNCTION enforce_user_ai_budget_override_membership() RETURNS TRIGGER
+	LANGUAGE plpgsql
+AS $$
+BEGIN
+	IF NOT EXISTS (
+		SELECT 1 FROM group_members_expanded
+		WHERE user_id = NEW.user_id AND group_id = NEW.group_id
+	) THEN
+		RAISE EXCEPTION 'user % is not a member of group %', NEW.user_id, NEW.group_id
+			USING ERRCODE = 'check_violation',
+			      CONSTRAINT = 'user_ai_budget_overrides_must_be_group_member';
+	END IF;
+	RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trigger_enforce_user_ai_budget_override_membership
+	BEFORE INSERT OR UPDATE ON user_ai_budget_overrides
+	FOR EACH ROW
+EXECUTE PROCEDURE enforce_user_ai_budget_override_membership();
 
 -- When a user is removed from a regular group, delete any override
 -- attributed to that group.

--- a/enterprise/coderd/aibridge.go
+++ b/enterprise/coderd/aibridge.go
@@ -43,6 +43,11 @@ const (
 // reference a valid resource in the expected scope.
 var errInvalidCursor = xerrors.New("invalid pagination cursor")
 
+// This name is raised by a trigger function with USING CONSTRAINT.
+// It is not a table CHECK constraint, so dbgen does not emit it in
+// check_constraint.go.
+const userAIBudgetOverridesMustBeGroupMemberConstraint database.CheckConstraint = "user_ai_budget_overrides_must_be_group_member"
+
 // aibridgeHandler handles all aibridged-related endpoints.
 func aibridgeHandler(api *API, middlewares ...func(http.Handler) http.Handler) func(r chi.Router) {
 	// Build the overload protection middleware chain for the aibridged handler.
@@ -884,10 +889,10 @@ func (api *API) upsertUserAIBudgetOverride(rw http.ResponseWriter, r *http.Reque
 		GroupID:          req.GroupID,
 		SpendLimitMicros: req.SpendLimitMicros,
 	})
-	// The CHECK constraint on the table enforces that the user must be a
-	// member of the attributed group; map the resulting check_violation
-	// to a structured 400.
-	if database.IsCheckViolation(err, database.CheckUserAiBudgetOverridesMustBeGroupMember) {
+	// A trigger enforces that the user must be a member of the attributed
+	// group; it raises check_violation with this constraint name. Map
+	// the violation to a structured 400.
+	if database.IsCheckViolation(err, userAIBudgetOverridesMustBeGroupMemberConstraint) {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "User is not a member of the referenced group.",
 			Validations: []codersdk.ValidationError{{


### PR DESCRIPTION
Enforce user AI budget override membership via trigger.

The previous implementation used a CHECK constraint backed by a STABLE function that queried group_members_expanded. CHECK constraints with cross-table function calls don't survive pg_dump/pg_restore: the constraint fires during COPY, but pg_dump can't see the function's hidden dependency on other tables, so loading order is undefined and the CHECK can reject valid rows.

Replace with a BEFORE INSERT OR UPDATE trigger that calls the same is_group_member predicate. Triggers can be disabled by pg_dump's --disable-triggers (the default for superuser restores), so the data load succeeds regardless of table order.
