### PR TITLE
ci: don't fail job if commenting on locked PR

### DIFF
--- a/.github/workflows/cherry-pick.yaml
+++ b/.github/workflows/cherry-pick.yaml
@@ -154,4 +154,5 @@ jobs:
           if [ "$CONFLICT" = true ]; then
             COMMENT="${COMMENT} (⚠️ conflicts need manual resolution)"
           fi
-          gh pr comment "$PR_NUMBER" --body "$COMMENT"
+          # Don't fail the job if commenting fails (e.g. the original PR is locked).
+          gh pr comment "$PR_NUMBER" --body "$COMMENT" || echo "::warning::Failed to comment on #${PR_NUMBER} (PR may be locked)."


### PR DESCRIPTION
The final step of `.github/workflows/cherry-pick.yaml` comments on the original PR with a link to the cherry-pick PR. If the original PR is locked, `gh pr comment` fails and the whole job exits with status 1, even though the backport branch and PR were created successfully.

See https://github.com/coder/coder/actions/runs/26559681779/job/78239379200 for an example.

Make the comment non-fatal: log a warning and continue.