### PR TITLE
fix: update gnutls to address 4 CVEs

### DIFF
--- a/scripts/ironbank/Dockerfile
+++ b/scripts/ironbank/Dockerfile
@@ -19,6 +19,10 @@ RUN microdnf update --assumeyes && \
     # Remove python3-urllib3 if present to address CVE-2026-44431.
     # Coder is a Go binary and does not use Python at runtime.
     microdnf remove --assumeyes python3-urllib3 2>/dev/null || true && \
+    # Ensure GnuTLS is updated to address CVE-2026-42012, CVE-2026-42013,
+    # CVE-2026-42015, and CVE-2026-5260. Coder does not link against GnuTLS,
+    # but updating removes the finding from IronBank scans.
+    microdnf update --assumeyes gnutls && \
     microdnf clean all
 
 # Configure the cryptography policy manually. These policies likely


### PR DESCRIPTION
Explicitly update `gnutls` in the IronBank Dockerfile to address 4 medium-severity CVEs found in the v2.32.4 IronBank scan:

- CVE-2026-42012: Remote attacker can exploit URI/SRV SAN handling in certificate validation
- CVE-2026-42013: Oversized SAN causes incorrect fallback to CN field validation
- CVE-2026-42015: Off-by-one error in PKCS#12 bag element bounds check
- CVE-2026-5260: Short premaster secret in RSA key exchange triggers short buffer read

**Mitigating factor:** Coder is a Go binary and does not link against GnuTLS. Go uses its own TLS implementation. Updating removes the finding from IronBank scans.

Linear: ENT-89

> Generated with [Coder Agents](https://coder.com) by @Shelnutt2