### PR TITLE
fix: bump github.com/go-git/go-git/v5 from 5.19.0 to 5.19.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -502,7 +502,7 @@ require (
 	github.com/dgraph-io/ristretto/v2 v2.4.0
 	github.com/elazarl/goproxy v1.8.0
 	github.com/fsnotify/fsnotify v1.9.0
-	github.com/go-git/go-git/v5 v5.19.0
+	github.com/go-git/go-git/v5 v5.19.1
 	github.com/mark3labs/mcp-go v0.38.0
 	github.com/shopspring/decimal v1.4.0
 	github.com/smallstep/pkcs7 v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -516,8 +516,8 @@ github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66D
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
 github.com/go-git/go-billy/v5 v5.9.0 h1:jItGXszUDRtR/AlferWPTMN4j38BQ88XnXKbilmmBPA=
 github.com/go-git/go-billy/v5 v5.9.0/go.mod h1:jCnQMLj9eUgGU7+ludSTYoZL/GGmii14RxKFj7ROgHw=
-github.com/go-git/go-git/v5 v5.19.0 h1:+WkVUQZSy/F1Gb13udrMKjIM2PrzsNfDKFSfo5tkMtc=
-github.com/go-git/go-git/v5 v5.19.0/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
+github.com/go-git/go-git/v5 v5.19.1 h1:nX27AnaU43/K5bKktKwgBmR9lawoYVe1Ckg0rgzzN00=
+github.com/go-git/go-git/v5 v5.19.1/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
 github.com/go-ini/ini v1.67.0 h1:z6ZrTEZqSWOTyH2FlglNbNgARyHG8oLW9gMELqKr06A=
 github.com/go-ini/ini v1.67.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=


### PR DESCRIPTION
Cherry-pick of go-git v5.19.1 bump to `release/2.32` to fix CVE-2026-45570 and CVE-2026-45571.

Original PR: https://github.com/coder/coder/pull/25494

## CVEs fixed

| CVE | GHSA | Severity | Description |
|-----|------|----------|-------------|
| CVE-2026-45570 | [GHSA-m7cr-m3pv-hgrp](https://github.com/go-git/go-git/security/advisories/GHSA-m7cr-m3pv-hgrp) | Low | Improper single-quote escaping in SSH transport |
| CVE-2026-45571 | [GHSA-crhj-59gh-8x96](https://github.com/go-git/go-git/security/advisories/GHSA-crhj-59gh-8x96) | Medium | Crafted repositories may modify main and submodule .git directories |

## Changes

- `go.mod`: `go-git/go-git/v5` v5.19.0 -> v5.19.1
- `go.sum`: updated checksums

Linear: ENT-91

> [!NOTE]
> This PR was generated by [Coder Agents](https://coder.com) on behalf of @Shelnutt2.