### PR TITLE
ci(.github/workflows/doc-check): update agents-chat-action to v0.3.0

### DIFF
--- a/.github/workflows/doc-check.yaml
+++ b/.github/workflows/doc-check.yaml
@@ -213,7 +213,7 @@ jobs:
 
       - name: Run doc-check via Coder Agent Chat
         if: steps.check-secrets.outputs.skip != 'true'
-        uses: coder/agents-chat-action@354442115103a9d674686661d2076a8c62eb7cb2 # v0.2.0
+        uses: coder/agents-chat-action@b3fc81d7dae5006dd124e98ef6fada1a36cdd86e # v0.3.0
         with:
           coder-url: ${{ secrets.DOC_CHECK_CODER_URL }}
           coder-token: ${{ secrets.DOC_CHECK_CODER_SESSION_TOKEN }}


### PR DESCRIPTION
Pin doc-check workflow to agents-chat-action v0.3.0 (codegen schemas from codersdk).

Tested via workflow_dispatch against 3 PRs:
- #25463: prior failed chat with structured last_error (CODAGT-507 scenario)
- #25750: docs PR
- #25748: code PR

All passed.

> 🤖 Generated by Coder Agents.