### PR TITLE
chore: mark database codegen files as linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,20 @@ docs/reference/api/*.md linguist-generated=true
 docs/reference/cli/*.md linguist-generated=true
 coderd/apidoc/swagger.json linguist-generated=true
 coderd/database/dump.sql linguist-generated=true
+
+# Database codegen (sqlc)
+coderd/database/queries.sql.go linguist-generated=true
+coderd/database/models.go linguist-generated=true
+coderd/database/querier.go linguist-generated=true
+
+# Database codegen (gomock)
+coderd/database/dbmock/dbmock.go linguist-generated=true
+
+# Database codegen (dbgen)
+coderd/database/dbmetrics/querymetrics.go linguist-generated=true
+coderd/database/unique_constraint.go linguist-generated=true
+coderd/database/foreign_key_constraint.go linguist-generated=true
+coderd/database/check_constraint.go linguist-generated=true
 peerbroker/proto/*.go linguist-generated=true
 provisionerd/proto/*.go linguist-generated=true
 provisionerd/proto/version.go linguist-generated=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -22,6 +22,7 @@ coderd/database/dbmetrics/querymetrics.go linguist-generated=true
 coderd/database/unique_constraint.go linguist-generated=true
 coderd/database/foreign_key_constraint.go linguist-generated=true
 coderd/database/check_constraint.go linguist-generated=true
+
 peerbroker/proto/*.go linguist-generated=true
 provisionerd/proto/*.go linguist-generated=true
 provisionerd/proto/version.go linguist-generated=false


### PR DESCRIPTION
Eight database codegen files have `Code generated` / `DO NOT EDIT` headers but aren't in `.gitattributes`. GitHub shows them expanded in PR diffs and counts them toward diff stats. This adds noise to reviews and inflates LOC metrics.

Adds `linguist-generated=true` for:
- sqlc output: `queries.sql.go`, `models.go`, `querier.go`
- gomock output: `dbmock/dbmock.go`
- dbgen output: `dbmetrics/querymetrics.go`, `unique_constraint.go`, `foreign_key_constraint.go`, `check_constraint.go`

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻