### PR TITLE
fix(coderd/x/chatd): serialize quickgen prompts without AI Bridge skips

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -3212,9 +3212,9 @@ func (p *Server) generateManualTitleCandidate(
 		}
 	}
 
-	model, modelConfig, modelKeys, err := p.resolveManualTitleModel(ctx, store, chat, keys, modelOpts)
+	modelResolution, err := p.resolveManualTitleModel(ctx, store, chat, keys, modelOpts)
 	result := manualTitleCandidateResult{
-		modelConfig:    modelConfig,
+		modelConfig:    modelResolution.config,
 		activeAPIKeyID: modelOpts.ActiveAPIKeyID,
 		hasMessages:    true,
 	}
@@ -3223,22 +3223,27 @@ func (p *Server) generateManualTitleCandidate(
 	}
 
 	titleCtx := ctx
-	titleModel := model
+	titleModel := modelResolution.model
 	finishDebugRun := func(error) {}
 	if debugSvc := p.debugService(); debugSvc != nil && debugSvc.IsEnabled(ctx, chat.ID, chat.OwnerID) {
 		titleCtx, titleModel, finishDebugRun = p.prepareManualTitleDebugRun(
 			ctx,
 			debugSvc,
 			chat,
-			modelConfig,
-			modelKeys,
+			modelResolution.config,
+			modelResolution.keys,
 			modelOpts,
 			messages,
-			model,
+			modelResolution.model,
 		)
 	}
 
-	title, usage, err := generateManualTitle(titleCtx, messages, titleModel)
+	title, usage, err := generateManualTitleWithPromptMode(
+		titleCtx,
+		messages,
+		titleModel,
+		quickgenPromptModeForRoute(modelResolution.route),
+	)
 	finishDebugRun(err)
 	result.title = title
 	result.usage = usage
@@ -3249,7 +3254,7 @@ func (p *Server) generateManualTitleCandidate(
 		}
 		return result, &manualTitleGenerationError{
 			cause:          wrappedErr,
-			modelConfig:    modelConfig,
+			modelConfig:    modelResolution.config,
 			usage:          usage,
 			activeAPIKeyID: modelOpts.ActiveAPIKeyID,
 		}
@@ -3599,14 +3604,21 @@ func prepareChatTurnDebugRun(
 	return runCtx, finishDebugRun
 }
 
+type manualTitleModelResolution struct {
+	model  fantasy.LanguageModel
+	config database.ChatModelConfig
+	keys   chatprovider.ProviderAPIKeys
+	route  resolvedModelRoute
+}
+
 func (p *Server) resolveManualTitleModel(
 	ctx context.Context,
 	store database.Store,
 	chat database.Chat,
 	keys chatprovider.ProviderAPIKeys,
 	modelOpts modelBuildOptions,
-) (fantasy.LanguageModel, database.ChatModelConfig, chatprovider.ProviderAPIKeys, error) {
-	overrideConfig, overrideModel, overrideKeys, _, overrideSet, overrideErr := p.resolveTitleGenerationModelOverride(
+) (manualTitleModelResolution, error) {
+	overrideConfig, overrideModel, overrideKeys, overrideRoute, overrideSet, overrideErr := p.resolveTitleGenerationModelOverride(
 		ctx,
 		chat,
 		keys,
@@ -3614,7 +3626,7 @@ func (p *Server) resolveManualTitleModel(
 	)
 	if overrideErr != nil {
 		if overrideSet {
-			return nil, database.ChatModelConfig{}, chatprovider.ProviderAPIKeys{}, xerrors.Errorf(
+			return manualTitleModelResolution{}, xerrors.Errorf(
 				"resolve manual title generation model override: %w",
 				overrideErr,
 			)
@@ -3624,7 +3636,12 @@ func (p *Server) resolveManualTitleModel(
 			slog.Error(overrideErr),
 		)
 	} else if overrideSet {
-		return overrideModel, overrideConfig, overrideKeys, nil
+		return manualTitleModelResolution{
+			model:  overrideModel,
+			config: overrideConfig,
+			keys:   overrideKeys,
+			route:  overrideRoute,
+		}, nil
 	}
 
 	configs, err := store.GetEnabledChatModelConfigs(ctx)
@@ -3667,7 +3684,12 @@ func (p *Server) resolveManualTitleModel(
 		return p.resolveFallbackManualTitleModel(ctx, chat, keys, modelOpts)
 	}
 
-	return model, config, route.directProviderKeys(), nil
+	return manualTitleModelResolution{
+		model:  model,
+		config: config,
+		keys:   route.directProviderKeys(),
+		route:  route,
+	}, nil
 }
 
 func (p *Server) resolveFallbackManualTitleModel(
@@ -3675,17 +3697,17 @@ func (p *Server) resolveFallbackManualTitleModel(
 	chat database.Chat,
 	keys chatprovider.ProviderAPIKeys,
 	modelOpts modelBuildOptions,
-) (fantasy.LanguageModel, database.ChatModelConfig, chatprovider.ProviderAPIKeys, error) {
+) (manualTitleModelResolution, error) {
 	config, err := p.resolveModelConfig(ctx, chat)
 	if err != nil {
-		return nil, database.ChatModelConfig{}, chatprovider.ProviderAPIKeys{}, xerrors.Errorf(
+		return manualTitleModelResolution{}, xerrors.Errorf(
 			"resolve fallback manual title model config: %w",
 			err,
 		)
 	}
 	route, err := p.resolveModelRouteForConfig(ctx, chat.OwnerID, config, keys)
 	if err != nil {
-		return nil, database.ChatModelConfig{}, chatprovider.ProviderAPIKeys{}, err
+		return manualTitleModelResolution{}, err
 	}
 	model, err := p.newModel(ctx, modelClientRequest{
 		Chat:         chat,
@@ -3694,12 +3716,17 @@ func (p *Server) resolveFallbackManualTitleModel(
 		ExtraHeaders: chatprovider.CoderHeaders(chat),
 	}, route, modelOpts)
 	if err != nil {
-		return nil, database.ChatModelConfig{}, chatprovider.ProviderAPIKeys{}, xerrors.Errorf(
+		return manualTitleModelResolution{}, xerrors.Errorf(
 			"create fallback manual title model: %w",
 			err,
 		)
 	}
-	return model, config, route.directProviderKeys(), nil
+	return manualTitleModelResolution{
+		model:  model,
+		config: config,
+		keys:   route.directProviderKeys(),
+		route:  route,
+	}, nil
 }
 
 func mergeManualTitleMessages(

--- a/coderd/x/chatd/model_routing_aibridge.go
+++ b/coderd/x/chatd/model_routing_aibridge.go
@@ -27,19 +27,6 @@ const (
 	aibridgeDelegatedBYOKMarker = "delegated"
 )
 
-// Synthetic quickgen calls are still routed through AI Bridge, but they should
-// not become promptless root cards in the user's chat session timeline.
-type suppressAIBridgeSessionHeadersKey struct{}
-
-func contextWithoutAIBridgeSessionHeaders(ctx context.Context) context.Context {
-	return context.WithValue(ctx, suppressAIBridgeSessionHeadersKey{}, true)
-}
-
-func suppressAIBridgeSessionHeadersFromContext(ctx context.Context) bool {
-	suppress, _ := ctx.Value(suppressAIBridgeSessionHeadersKey{}).(bool)
-	return suppress
-}
-
 type aiGatewayModelRoute struct {
 	Provider          database.AIProvider
 	ModelProviderHint string
@@ -89,10 +76,6 @@ type aiGatewayRoundTripper struct {
 func (t *aiGatewayRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx := aibridge.WithDelegatedAPIKeyID(req.Context(), t.apiKeyID)
 	cloned := req.Clone(ctx)
-	if suppressAIBridgeSessionHeadersFromContext(req.Context()) {
-		cloned.Header.Del(chatprovider.HeaderCoderChatID)
-		cloned.Header.Del(chatprovider.HeaderCoderSubchatID)
-	}
 	for name, value := range t.providerAuth.Headers {
 		cloned.Header.Set(name, value)
 	}

--- a/coderd/x/chatd/model_routing_aibridge.go
+++ b/coderd/x/chatd/model_routing_aibridge.go
@@ -27,6 +27,19 @@ const (
 	aibridgeDelegatedBYOKMarker = "delegated"
 )
 
+// Synthetic quickgen calls are still routed through AI Bridge, but they should
+// not become promptless root cards in the user's chat session timeline.
+type suppressAIBridgeSessionHeadersKey struct{}
+
+func contextWithoutAIBridgeSessionHeaders(ctx context.Context) context.Context {
+	return context.WithValue(ctx, suppressAIBridgeSessionHeadersKey{}, true)
+}
+
+func suppressAIBridgeSessionHeadersFromContext(ctx context.Context) bool {
+	suppress, _ := ctx.Value(suppressAIBridgeSessionHeadersKey{}).(bool)
+	return suppress
+}
+
 type aiGatewayModelRoute struct {
 	Provider          database.AIProvider
 	ModelProviderHint string
@@ -76,6 +89,10 @@ type aiGatewayRoundTripper struct {
 func (t *aiGatewayRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx := aibridge.WithDelegatedAPIKeyID(req.Context(), t.apiKeyID)
 	cloned := req.Clone(ctx)
+	if suppressAIBridgeSessionHeadersFromContext(req.Context()) {
+		cloned.Header.Del(chatprovider.HeaderCoderChatID)
+		cloned.Header.Del(chatprovider.HeaderCoderSubchatID)
+	}
 	for name, value := range t.providerAuth.Headers {
 		cloned.Header.Set(name, value)
 	}

--- a/coderd/x/chatd/model_routing_internal_test.go
+++ b/coderd/x/chatd/model_routing_internal_test.go
@@ -1,6 +1,7 @@
 package chatd
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io"
@@ -372,6 +373,66 @@ func TestAIGatewayModelForwardsProviderAuth(t *testing.T) {
 		require.Empty(t, got.coderToken)
 		require.Equal(t, apiKeyID, got.apiKeyID)
 	})
+}
+
+func TestAIGatewayRoundTripperCanSuppressSessionHeaders(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		ctx         func() context.Context
+		wantChatID  string
+		wantSubchat string
+	}{
+		{
+			name:        "preserves session headers by default",
+			ctx:         func() context.Context { return t.Context() },
+			wantChatID:  "chat-id",
+			wantSubchat: "subchat-id",
+		},
+		{
+			name: "suppresses session headers when marked",
+			ctx: func() context.Context {
+				return contextWithoutAIBridgeSessionHeaders(t.Context())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			seen := make(chan http.Header, 1)
+			rt := &aiGatewayRoundTripper{
+				base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					seen <- req.Header.Clone()
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     http.Header{},
+						Body:       io.NopCloser(strings.NewReader("")),
+						Request:    req,
+					}, nil
+				}),
+				apiKeyID: uuid.NewString(),
+			}
+			req, err := http.NewRequestWithContext(tt.ctx(), http.MethodPost, "http://coder-aibridge/v1/responses", nil)
+			require.NoError(t, err)
+			req.Header.Set(chatprovider.HeaderCoderOwnerID, "owner-id")
+			req.Header.Set(chatprovider.HeaderCoderChatID, "chat-id")
+			req.Header.Set(chatprovider.HeaderCoderSubchatID, "subchat-id")
+			req.Header.Set(chatprovider.HeaderCoderWorkspaceID, "workspace-id")
+
+			resp, err := rt.RoundTrip(req)
+			require.NoError(t, err)
+			require.NoError(t, resp.Body.Close())
+
+			got := <-seen
+			require.Equal(t, "owner-id", got.Get(chatprovider.HeaderCoderOwnerID))
+			require.Equal(t, tt.wantChatID, got.Get(chatprovider.HeaderCoderChatID))
+			require.Equal(t, tt.wantSubchat, got.Get(chatprovider.HeaderCoderSubchatID))
+			require.Equal(t, "workspace-id", got.Get(chatprovider.HeaderCoderWorkspaceID))
+		})
+	}
 }
 
 func TestActiveTurnAPIKeyIDFromMessages(t *testing.T) {

--- a/coderd/x/chatd/model_routing_internal_test.go
+++ b/coderd/x/chatd/model_routing_internal_test.go
@@ -379,16 +379,16 @@ func TestAIGatewayRoundTripperCanSuppressSessionHeaders(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		ctx         func() context.Context
-		wantChatID  string
-		wantSubchat string
+		name          string
+		ctx           func() context.Context
+		wantChatID    string
+		wantSubchatID string
 	}{
 		{
-			name:        "preserves session headers by default",
-			ctx:         func() context.Context { return t.Context() },
-			wantChatID:  "chat-id",
-			wantSubchat: "subchat-id",
+			name:          "preserves session headers by default",
+			ctx:           func() context.Context { return t.Context() },
+			wantChatID:    "chat-id",
+			wantSubchatID: "subchat-id",
 		},
 		{
 			name: "suppresses session headers when marked",
@@ -429,7 +429,7 @@ func TestAIGatewayRoundTripperCanSuppressSessionHeaders(t *testing.T) {
 			got := <-seen
 			require.Equal(t, "owner-id", got.Get(chatprovider.HeaderCoderOwnerID))
 			require.Equal(t, tt.wantChatID, got.Get(chatprovider.HeaderCoderChatID))
-			require.Equal(t, tt.wantSubchat, got.Get(chatprovider.HeaderCoderSubchatID))
+			require.Equal(t, tt.wantSubchatID, got.Get(chatprovider.HeaderCoderSubchatID))
 			require.Equal(t, "workspace-id", got.Get(chatprovider.HeaderCoderWorkspaceID))
 		})
 	}

--- a/coderd/x/chatd/model_routing_internal_test.go
+++ b/coderd/x/chatd/model_routing_internal_test.go
@@ -1,8 +1,8 @@
 package chatd
 
 import (
-	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -375,26 +375,67 @@ func TestAIGatewayModelForwardsProviderAuth(t *testing.T) {
 	})
 }
 
-func TestAIGatewayRoundTripperCanSuppressSessionHeaders(t *testing.T) {
+func TestAIGatewayRoundTripperPreservesSessionHeaders(t *testing.T) {
 	t.Parallel()
 
+	seen := make(chan http.Header, 1)
+	rt := &aiGatewayRoundTripper{
+		base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			seen <- req.Header.Clone()
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{},
+				Body:       io.NopCloser(strings.NewReader("")),
+				Request:    req,
+			}, nil
+		}),
+		apiKeyID: uuid.NewString(),
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://coder-aibridge/v1/responses", nil)
+	require.NoError(t, err)
+	req.Header.Set(chatprovider.HeaderCoderOwnerID, "owner-id")
+	req.Header.Set(chatprovider.HeaderCoderChatID, "chat-id")
+	req.Header.Set(chatprovider.HeaderCoderSubchatID, "subchat-id")
+	req.Header.Set(chatprovider.HeaderCoderWorkspaceID, "workspace-id")
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	got := <-seen
+	require.Equal(t, "owner-id", got.Get(chatprovider.HeaderCoderOwnerID))
+	require.Equal(t, "chat-id", got.Get(chatprovider.HeaderCoderChatID))
+	require.Equal(t, "subchat-id", got.Get(chatprovider.HeaderCoderSubchatID))
+	require.Equal(t, "workspace-id", got.Get(chatprovider.HeaderCoderWorkspaceID))
+}
+
+func TestAIGatewayQuickgenPromptSerializesFinalAssistantMessage(t *testing.T) {
+	t.Parallel()
+
+	const quickgenInput = "summarize failed workspace build logs"
 	tests := []struct {
-		name          string
-		ctx           func() context.Context
-		wantChatID    string
-		wantSubchatID string
+		name         string
+		providerType database.AIProviderType
+		modelName    string
+		wantPath     string
 	}{
 		{
-			name:          "preserves session headers by default",
-			ctx:           func() context.Context { return t.Context() },
-			wantChatID:    "chat-id",
-			wantSubchatID: "subchat-id",
+			name:         "OpenAIResponses",
+			providerType: database.AiProviderTypeOpenai,
+			modelName:    "gpt-4",
+			wantPath:     "/v1/responses",
 		},
 		{
-			name: "suppresses session headers when marked",
-			ctx: func() context.Context {
-				return contextWithoutAIBridgeSessionHeaders(t.Context())
-			},
+			name:         "AnthropicMessages",
+			providerType: database.AiProviderTypeAnthropic,
+			modelName:    "claude-haiku-4-5",
+			wantPath:     "/v1/messages",
+		},
+		{
+			name:         "OpenAICompatibleChatCompletions",
+			providerType: database.AiProviderTypeGoogle,
+			modelName:    "gemini-2.5-flash",
+			wantPath:     "/v1/chat/completions",
 		},
 	}
 
@@ -402,37 +443,172 @@ func TestAIGatewayRoundTripperCanSuppressSessionHeaders(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			seen := make(chan http.Header, 1)
-			rt := &aiGatewayRoundTripper{
-				base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-					seen <- req.Header.Clone()
-					return &http.Response{
-						StatusCode: http.StatusOK,
-						Header:     http.Header{},
-						Body:       io.NopCloser(strings.NewReader("")),
-						Request:    req,
-					}, nil
-				}),
-				apiKeyID: uuid.NewString(),
+			provider := aibridgeTestAIProvider(uuid.New(), "primary-"+tt.name, tt.providerType)
+			route := aibridgeTestRoute(provider)
+			model, requests := newCapturedAIGatewayModel(
+				t,
+				provider,
+				tt.modelName,
+				aibridgeQuickgenTitleResponse(tt.providerType),
+			)
+
+			title, _, err := generateStructuredTitleWithUsagePromptMode(
+				t.Context(),
+				model,
+				titleGenerationPrompt,
+				quickgenInput,
+				quickgenPromptModeForRoute(route),
+			)
+			require.NoError(t, err)
+			require.Equal(t, "Failed workspace logs", title)
+
+			got := <-requests
+			require.Equal(t, tt.wantPath, got.path)
+			switch tt.providerType {
+			case database.AiProviderTypeOpenai:
+				assertAIGatewayFinalRole(t, got.body, "input", "assistant", quickgenInput)
+			case database.AiProviderTypeAnthropic:
+				assertAIGatewayFinalRole(t, got.body, "messages", "assistant", quickgenInput)
+			default:
+				assertAIGatewayFinalRole(t, got.body, "messages", "assistant", quickgenInput)
+				require.Equal(t, "required", got.body["tool_choice"])
 			}
-			req, err := http.NewRequestWithContext(tt.ctx(), http.MethodPost, "http://coder-aibridge/v1/responses", nil)
-			require.NoError(t, err)
-			req.Header.Set(chatprovider.HeaderCoderOwnerID, "owner-id")
-			req.Header.Set(chatprovider.HeaderCoderChatID, "chat-id")
-			req.Header.Set(chatprovider.HeaderCoderSubchatID, "subchat-id")
-			req.Header.Set(chatprovider.HeaderCoderWorkspaceID, "workspace-id")
-
-			resp, err := rt.RoundTrip(req)
-			require.NoError(t, err)
-			require.NoError(t, resp.Body.Close())
-
-			got := <-seen
-			require.Equal(t, "owner-id", got.Get(chatprovider.HeaderCoderOwnerID))
-			require.Equal(t, tt.wantChatID, got.Get(chatprovider.HeaderCoderChatID))
-			require.Equal(t, tt.wantSubchatID, got.Get(chatprovider.HeaderCoderSubchatID))
-			require.Equal(t, "workspace-id", got.Get(chatprovider.HeaderCoderWorkspaceID))
 		})
 	}
+}
+
+func TestAIGatewayChatTurnSerializesFinalUserMessage(t *testing.T) {
+	t.Parallel()
+
+	const userInput = "please inspect the failing test"
+	model, requests := newCapturedAIGatewayModel(
+		t,
+		aibridgeTestAIProvider(uuid.New(), "primary-openai", database.AiProviderTypeOpenai),
+		"gpt-4",
+		`{"id":"resp_test","object":"response","created_at":0,"status":"completed","model":"gpt-4","output":[{"id":"msg_test","type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`,
+	)
+
+	_, err := model.Generate(t.Context(), fantasy.Call{Prompt: fantasy.Prompt{
+		{
+			Role: fantasy.MessageRoleSystem,
+			Content: []fantasy.MessagePart{
+				fantasy.TextPart{Text: "You are a coding assistant."},
+			},
+		},
+		{
+			Role: fantasy.MessageRoleUser,
+			Content: []fantasy.MessagePart{
+				fantasy.TextPart{Text: userInput},
+			},
+		},
+	}})
+	require.NoError(t, err)
+
+	got := <-requests
+	require.Equal(t, "/v1/responses", got.path)
+	assertAIGatewayFinalRole(t, got.body, "input", "user", userInput)
+}
+
+type capturedAIGatewayRequest struct {
+	path string
+	body map[string]any
+}
+
+func newCapturedAIGatewayModel(
+	t *testing.T,
+	provider database.AIProvider,
+	modelName string,
+	responseBody string,
+) (fantasy.LanguageModel, <-chan capturedAIGatewayRequest) {
+	t.Helper()
+
+	requests := make(chan capturedAIGatewayRequest, 1)
+	factory := &aibridgeTestFactory{rt: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+		requests <- capturedAIGatewayRequest{path: req.URL.Path, body: body}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(responseBody)),
+			Request:    req,
+		}, nil
+	})}
+	server := &Server{
+		aiGatewayRoutingEnabled:  true,
+		aibridgeTransportFactory: aibridgeTestFactoryPointer(factory),
+	}
+	model, err := server.newModel(
+		t.Context(),
+		aibridgeTestRequest(database.Chat{ID: uuid.New(), OwnerID: uuid.New()}, modelName),
+		aibridgeTestRoute(provider),
+		modelBuildOptions{ActiveAPIKeyID: uuid.NewString()},
+	)
+	require.NoError(t, err)
+	return model, requests
+}
+
+func aibridgeQuickgenTitleResponse(providerType database.AIProviderType) string {
+	switch providerType {
+	case database.AiProviderTypeOpenai:
+		return `{"id":"resp_test","object":"response","created_at":0,"status":"completed","model":"gpt-4","output":[{"id":"msg_test","type":"message","role":"assistant","content":[{"type":"output_text","text":"{\"title\":\"Failed workspace logs\"}"}]}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`
+	case database.AiProviderTypeAnthropic:
+		return `{"id":"msg_test","type":"message","role":"assistant","model":"claude-haiku-4-5","content":[{"type":"tool_use","id":"toolu_test","name":"propose_title","input":{"title":"Failed workspace logs"}}],"stop_reason":"tool_use","stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}}`
+	default:
+		return `{"id":"chatcmpl_test","object":"chat.completion","created":0,"model":"gemini-2.5-flash","choices":[{"index":0,"message":{"role":"assistant","content":"","tool_calls":[{"id":"call_structured_output","type":"function","function":{"name":"propose_title","arguments":"{\"title\":\"Failed workspace logs\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`
+	}
+}
+
+func assertAIGatewayFinalRole(
+	t *testing.T,
+	body map[string]any,
+	messageKey string,
+	role string,
+	text string,
+) {
+	t.Helper()
+
+	messages, ok := body[messageKey].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, messages)
+	last, ok := messages[len(messages)-1].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, role, last["role"])
+	requireRoleText(t, messages, "user", text)
+}
+
+func requireRoleText(t *testing.T, messages []any, role string, text string) {
+	t.Helper()
+
+	for _, message := range messages {
+		messageMap, ok := message.(map[string]any)
+		if !ok || messageMap["role"] != role {
+			continue
+		}
+		if messageContentContainsText(messageMap["content"], text) {
+			return
+		}
+	}
+	t.Fatalf("no %s message contained %q", role, text)
+}
+
+func messageContentContainsText(value any, text string) bool {
+	switch typed := value.(type) {
+	case string:
+		return strings.Contains(typed, text)
+	case []any:
+		for _, item := range typed {
+			itemMap, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			itemText, ok := itemMap["text"].(string)
+			if ok && strings.Contains(itemText, text) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func TestActiveTurnAPIKeyIDFromMessages(t *testing.T) {

--- a/coderd/x/chatd/quickgen.go
+++ b/coderd/x/chatd/quickgen.go
@@ -424,6 +424,31 @@ func (p *Server) prepareQuickgenDebugCandidate(
 	return runCtx, debugModel, finishDebugRun
 }
 
+const quickgenStructuredOutputReady = "Ready to provide the structured output."
+
+func syntheticObjectGenerationPrompt(systemPrompt string, userInput string) fantasy.Prompt {
+	return fantasy.Prompt{
+		{
+			Role: fantasy.MessageRoleSystem,
+			Content: []fantasy.MessagePart{
+				fantasy.TextPart{Text: systemPrompt},
+			},
+		},
+		{
+			Role: fantasy.MessageRoleUser,
+			Content: []fantasy.MessagePart{
+				fantasy.TextPart{Text: userInput},
+			},
+		},
+		{
+			Role: fantasy.MessageRoleAssistant,
+			Content: []fantasy.MessagePart{
+				fantasy.TextPart{Text: quickgenStructuredOutputReady},
+			},
+		},
+	}
+}
+
 // generateTitle calls the model with a title-generation system prompt
 // and returns the normalized result. It retries transient LLM errors
 // (rate limits, overloaded, etc.) with exponential backoff.
@@ -468,20 +493,7 @@ func generateStructuredTitleWithUsage(
 		return "", fantasy.Usage{}, xerrors.New("title input was empty")
 	}
 
-	prompt := fantasy.Prompt{
-		{
-			Role: fantasy.MessageRoleSystem,
-			Content: []fantasy.MessagePart{
-				fantasy.TextPart{Text: systemPrompt},
-			},
-		},
-		{
-			Role: fantasy.MessageRoleUser,
-			Content: []fantasy.MessagePart{
-				fantasy.TextPart{Text: userInput},
-			},
-		},
-	}
+	prompt := syntheticObjectGenerationPrompt(systemPrompt, userInput)
 
 	var maxOutputTokens int64 = 256
 	var result *fantasy.ObjectResult[generatedTitle]
@@ -908,20 +920,7 @@ func generateStructuredTurnStatusLabel(
 		return "", xerrors.New("turn status label input was empty")
 	}
 
-	prompt := fantasy.Prompt{
-		{
-			Role: fantasy.MessageRoleSystem,
-			Content: []fantasy.MessagePart{
-				fantasy.TextPart{Text: systemPrompt},
-			},
-		},
-		{
-			Role: fantasy.MessageRoleUser,
-			Content: []fantasy.MessagePart{
-				fantasy.TextPart{Text: userInput},
-			},
-		},
-	}
+	prompt := syntheticObjectGenerationPrompt(systemPrompt, userInput)
 
 	var maxOutputTokens int64 = 64
 	var result *fantasy.ObjectResult[generatedTurnStatusLabel]

--- a/coderd/x/chatd/quickgen.go
+++ b/coderd/x/chatd/quickgen.go
@@ -424,10 +424,6 @@ func (p *Server) prepareQuickgenDebugCandidate(
 	return runCtx, debugModel, finishDebugRun
 }
 
-// Synthetic quickgen prompts end with an assistant marker because AI Bridge
-// records final user-role messages as user prompts.
-const quickgenStructuredOutputReady = "Ready to provide the structured output."
-
 func syntheticObjectGenerationPrompt(systemPrompt, userInput string) fantasy.Prompt {
 	return fantasy.Prompt{
 		{
@@ -440,12 +436,6 @@ func syntheticObjectGenerationPrompt(systemPrompt, userInput string) fantasy.Pro
 			Role: fantasy.MessageRoleUser,
 			Content: []fantasy.MessagePart{
 				fantasy.TextPart{Text: userInput},
-			},
-		},
-		{
-			Role: fantasy.MessageRoleAssistant,
-			Content: []fantasy.MessagePart{
-				fantasy.TextPart{Text: quickgenStructuredOutputReady},
 			},
 		},
 	}

--- a/coderd/x/chatd/quickgen.go
+++ b/coderd/x/chatd/quickgen.go
@@ -424,6 +424,8 @@ func (p *Server) prepareQuickgenDebugCandidate(
 	return runCtx, debugModel, finishDebugRun
 }
 
+// Synthetic quickgen prompts end with an assistant marker because AI Bridge
+// records final user-role messages as user prompts.
 const quickgenStructuredOutputReady = "Ready to provide the structured output."
 
 func syntheticObjectGenerationPrompt(systemPrompt, userInput string) fantasy.Prompt {

--- a/coderd/x/chatd/quickgen.go
+++ b/coderd/x/chatd/quickgen.go
@@ -426,7 +426,7 @@ func (p *Server) prepareQuickgenDebugCandidate(
 
 const quickgenStructuredOutputReady = "Ready to provide the structured output."
 
-func syntheticObjectGenerationPrompt(systemPrompt string, userInput string) fantasy.Prompt {
+func syntheticObjectGenerationPrompt(systemPrompt, userInput string) fantasy.Prompt {
 	return fantasy.Prompt{
 		{
 			Role: fantasy.MessageRoleSystem,

--- a/coderd/x/chatd/quickgen.go
+++ b/coderd/x/chatd/quickgen.go
@@ -28,6 +28,22 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 )
 
+type quickgenPromptMode int
+
+const (
+	quickgenPromptModeDefault quickgenPromptMode = iota
+	quickgenPromptModeAIGateway
+)
+
+const quickgenAssistantPromptMarker = "Ready to produce the requested structured response."
+
+func quickgenPromptModeForRoute(route resolvedModelRoute) quickgenPromptMode {
+	if route.kind == modelRouteKindAIGateway {
+		return quickgenPromptModeAIGateway
+	}
+	return quickgenPromptModeDefault
+}
+
 const titleGenerationPrompt = "Write a short title for the user's message. " +
 	"Populate the title field with the result. " +
 	"Return only the title text in 2-8 words. " +
@@ -246,7 +262,12 @@ func (p *Server) maybeGenerateChatTitle(
 			)
 		}
 
-		title, err := generateTitle(candidateCtx, candidateModel, input)
+		title, err := generateTitle(
+			candidateCtx,
+			candidateModel,
+			input,
+			quickgenPromptModeForRoute(candidate.route),
+		)
 		finishDebugRun(err)
 		if err != nil {
 			lastErr = err
@@ -424,8 +445,12 @@ func (p *Server) prepareQuickgenDebugCandidate(
 	return runCtx, debugModel, finishDebugRun
 }
 
-func syntheticObjectGenerationPrompt(systemPrompt, userInput string) fantasy.Prompt {
-	return fantasy.Prompt{
+func syntheticObjectGenerationPrompt(
+	systemPrompt string,
+	userInput string,
+	promptMode quickgenPromptMode,
+) fantasy.Prompt {
+	prompt := fantasy.Prompt{
 		{
 			Role: fantasy.MessageRoleSystem,
 			Content: []fantasy.MessagePart{
@@ -439,6 +464,15 @@ func syntheticObjectGenerationPrompt(systemPrompt, userInput string) fantasy.Pro
 			},
 		},
 	}
+	if promptMode == quickgenPromptModeAIGateway {
+		prompt = append(prompt, fantasy.Message{
+			Role: fantasy.MessageRoleAssistant,
+			Content: []fantasy.MessagePart{
+				fantasy.TextPart{Text: quickgenAssistantPromptMarker},
+			},
+		})
+	}
+	return prompt
 }
 
 // generateTitle calls the model with a title-generation system prompt
@@ -448,8 +482,9 @@ func generateTitle(
 	ctx context.Context,
 	model fantasy.LanguageModel,
 	input string,
+	promptMode quickgenPromptMode,
 ) (string, error) {
-	title, err := generateStructuredTitle(ctx, model, titleGenerationPrompt, input)
+	title, err := generateStructuredTitle(ctx, model, titleGenerationPrompt, input, promptMode)
 	if err != nil {
 		return "", err
 	}
@@ -461,12 +496,14 @@ func generateStructuredTitle(
 	model fantasy.LanguageModel,
 	systemPrompt string,
 	userInput string,
+	promptMode quickgenPromptMode,
 ) (string, error) {
-	title, _, err := generateStructuredTitleWithUsage(
+	title, _, err := generateStructuredTitleWithUsagePromptMode(
 		ctx,
 		model,
 		systemPrompt,
 		userInput,
+		promptMode,
 	)
 	if err != nil {
 		return "", err
@@ -480,13 +517,28 @@ func generateStructuredTitleWithUsage(
 	systemPrompt string,
 	userInput string,
 ) (string, fantasy.Usage, error) {
+	return generateStructuredTitleWithUsagePromptMode(
+		ctx,
+		model,
+		systemPrompt,
+		userInput,
+		quickgenPromptModeDefault,
+	)
+}
+
+func generateStructuredTitleWithUsagePromptMode(
+	ctx context.Context,
+	model fantasy.LanguageModel,
+	systemPrompt string,
+	userInput string,
+	promptMode quickgenPromptMode,
+) (string, fantasy.Usage, error) {
 	userInput = strings.TrimSpace(userInput)
 	if userInput == "" {
 		return "", fantasy.Usage{}, xerrors.New("title input was empty")
 	}
 
-	ctx = contextWithoutAIBridgeSessionHeaders(ctx)
-	prompt := syntheticObjectGenerationPrompt(systemPrompt, userInput)
+	prompt := syntheticObjectGenerationPrompt(systemPrompt, userInput, promptMode)
 
 	var maxOutputTokens int64 = 256
 	var result *fantasy.ObjectResult[generatedTitle]
@@ -776,6 +828,20 @@ func generateManualTitle(
 	messages []database.ChatMessage,
 	fallbackModel fantasy.LanguageModel,
 ) (string, fantasy.Usage, error) {
+	return generateManualTitleWithPromptMode(
+		ctx,
+		messages,
+		fallbackModel,
+		quickgenPromptModeDefault,
+	)
+}
+
+func generateManualTitleWithPromptMode(
+	ctx context.Context,
+	messages []database.ChatMessage,
+	fallbackModel fantasy.LanguageModel,
+	promptMode quickgenPromptMode,
+) (string, fantasy.Usage, error) {
 	turns := extractManualTitleTurns(messages)
 	selected := selectManualTitleTurnIndexes(turns)
 
@@ -802,11 +868,12 @@ func generateManualTitle(
 		userInput = strings.TrimSpace(firstUserText)
 	}
 
-	title, usage, err := generateStructuredTitleWithUsage(
+	title, usage, err := generateStructuredTitleWithUsagePromptMode(
 		titleCtx,
 		fallbackModel,
 		systemPrompt,
 		userInput,
+		promptMode,
 	)
 	if err != nil {
 		return "", usage, err
@@ -884,11 +951,12 @@ func (p *Server) generateTurnStatusLabel(
 			)
 		}
 
-		generatedLabel, err := generateStructuredTurnStatusLabel(
+		generatedLabel, err := generateStructuredTurnStatusLabelWithPromptMode(
 			candidateCtx,
 			candidateModel,
 			turnStatusLabelPrompt,
 			input,
+			quickgenPromptModeForRoute(candidate.route),
 		)
 		finishDebugRun(err)
 		if err != nil {
@@ -908,13 +976,28 @@ func generateStructuredTurnStatusLabel(
 	systemPrompt string,
 	userInput string,
 ) (string, error) {
+	return generateStructuredTurnStatusLabelWithPromptMode(
+		ctx,
+		model,
+		systemPrompt,
+		userInput,
+		quickgenPromptModeDefault,
+	)
+}
+
+func generateStructuredTurnStatusLabelWithPromptMode(
+	ctx context.Context,
+	model fantasy.LanguageModel,
+	systemPrompt string,
+	userInput string,
+	promptMode quickgenPromptMode,
+) (string, error) {
 	userInput = strings.TrimSpace(userInput)
 	if userInput == "" {
 		return "", xerrors.New("turn status label input was empty")
 	}
 
-	ctx = contextWithoutAIBridgeSessionHeaders(ctx)
-	prompt := syntheticObjectGenerationPrompt(systemPrompt, userInput)
+	prompt := syntheticObjectGenerationPrompt(systemPrompt, userInput, promptMode)
 
 	var maxOutputTokens int64 = 64
 	var result *fantasy.ObjectResult[generatedTurnStatusLabel]

--- a/coderd/x/chatd/quickgen.go
+++ b/coderd/x/chatd/quickgen.go
@@ -495,6 +495,7 @@ func generateStructuredTitleWithUsage(
 		return "", fantasy.Usage{}, xerrors.New("title input was empty")
 	}
 
+	ctx = contextWithoutAIBridgeSessionHeaders(ctx)
 	prompt := syntheticObjectGenerationPrompt(systemPrompt, userInput)
 
 	var maxOutputTokens int64 = 256
@@ -922,6 +923,7 @@ func generateStructuredTurnStatusLabel(
 		return "", xerrors.New("turn status label input was empty")
 	}
 
+	ctx = contextWithoutAIBridgeSessionHeaders(ctx)
 	prompt := syntheticObjectGenerationPrompt(systemPrompt, userInput)
 
 	var maxOutputTokens int64 = 64

--- a/coderd/x/chatd/quickgen_internal_test.go
+++ b/coderd/x/chatd/quickgen_internal_test.go
@@ -417,6 +417,7 @@ func TestMaybeGenerateChatTitlePreservesUpdatedAt(t *testing.T) {
 	model := &chattest.FakeModel{
 		GenerateObjectFn: func(_ context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
 			require.Equal(t, "propose_title", call.SchemaName)
+			requireSyntheticQuickgenPrompt(t, call.Prompt, userPrompt)
 			return &fantasy.ObjectResponse{
 				Object: map[string]any{"title": wantTitle},
 			}, nil
@@ -494,7 +495,7 @@ func Test_generateManualTitle_UsesTimeout(t *testing.T) {
 				deadline,
 				2*time.Second,
 			)
-			require.Len(t, call.Prompt, 2)
+			requireSyntheticQuickgenPrompt(t, call.Prompt, "refresh chat title")
 			require.Equal(t, "propose_title", call.SchemaName)
 			return &fantasy.ObjectResponse{Object: map[string]any{"title": "Refresh title"}}, nil
 		},
@@ -524,7 +525,7 @@ func Test_generateManualTitle_TruncatesFirstUserInput(t *testing.T) {
 
 	model := &chattest.FakeModel{
 		GenerateObjectFn: func(_ context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
-			require.Len(t, call.Prompt, 2)
+			requireSyntheticQuickgenPrompt(t, call.Prompt, truncateRunes(longFirstUserText, 1000))
 			systemText, ok := call.Prompt[0].Content[0].(fantasy.TextPart)
 			require.True(t, ok)
 			require.Contains(t, systemText.Text, truncateRunes(longFirstUserText, 1000))
@@ -687,6 +688,7 @@ func TestGenerateStructuredTitleWithUsage_OpenAICompatibleRequiredToolChoice(t *
 
 	body := testutil.TryReceive(t.Context(), t, requests)
 	require.Equal(t, "required", body["tool_choice"])
+	requireOpenAICompatLastMessageRole(t, body, "assistant")
 }
 
 func newOpenAICompatStructuredOutputServer(
@@ -764,6 +766,40 @@ func openAICompatTestModel(t *testing.T, baseURL string) fantasy.LanguageModel {
 	return model
 }
 
+func requireSyntheticQuickgenPrompt(t *testing.T, prompt fantasy.Prompt, userInput string) {
+	t.Helper()
+
+	require.Len(t, prompt, 3)
+	require.Equal(t, fantasy.MessageRoleSystem, prompt[0].Role)
+	require.Equal(t, fantasy.MessageRoleUser, prompt[1].Role)
+	require.Equal(t, fantasy.MessageRoleAssistant, prompt[2].Role)
+	require.NotEqual(t, fantasy.MessageRoleUser, prompt[len(prompt)-1].Role)
+
+	require.NotEmpty(t, prompt[1].Content)
+	require.NotEmpty(t, prompt[2].Content)
+
+	userText, ok := prompt[1].Content[0].(fantasy.TextPart)
+	require.True(t, ok)
+	require.Equal(t, userInput, userText.Text)
+
+	assistantText, ok := prompt[2].Content[0].(fantasy.TextPart)
+	require.True(t, ok)
+	require.Equal(t, quickgenStructuredOutputReady, assistantText.Text)
+}
+
+func requireOpenAICompatLastMessageRole(t *testing.T, body map[string]any, want string) {
+	t.Helper()
+
+	messages, ok := body["messages"].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, messages)
+
+	lastMessage, ok := messages[len(messages)-1].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, want, lastMessage["role"])
+	require.NotEqual(t, "user", lastMessage["role"])
+}
+
 func TestGenerateStructuredTurnStatusLabel(t *testing.T) {
 	t.Parallel()
 
@@ -773,6 +809,7 @@ func TestGenerateStructuredTurnStatusLabel(t *testing.T) {
 		model := &chattest.FakeModel{
 			GenerateObjectFn: func(_ context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
 				require.Equal(t, "propose_turn_status_label", call.SchemaName)
+				requireSyntheticQuickgenPrompt(t, call.Prompt, "done")
 				return &fantasy.ObjectResponse{
 					Object: map[string]any{"label": "Submitted PR"},
 				}, nil
@@ -797,6 +834,7 @@ func TestGenerateStructuredTurnStatusLabel(t *testing.T) {
 
 		body := testutil.TryReceive(t.Context(), t, requests)
 		require.Equal(t, "required", body["tool_choice"])
+		requireOpenAICompatLastMessageRole(t, body, "assistant")
 	})
 
 	t.Run("rejects narrative label", func(t *testing.T) {

--- a/coderd/x/chatd/quickgen_internal_test.go
+++ b/coderd/x/chatd/quickgen_internal_test.go
@@ -415,9 +415,8 @@ func TestMaybeGenerateChatTitlePreservesUpdatedAt(t *testing.T) {
 
 	const wantTitle = "Failed workspace logs"
 	model := &chattest.FakeModel{
-		GenerateObjectFn: func(ctx context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+		GenerateObjectFn: func(_ context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
 			require.Equal(t, "propose_title", call.SchemaName)
-			require.True(t, suppressAIBridgeSessionHeadersFromContext(ctx))
 			requireSyntheticQuickgenPrompt(t, call.Prompt, userPrompt)
 			return &fantasy.ObjectResponse{
 				Object: map[string]any{"title": wantTitle},
@@ -496,7 +495,6 @@ func Test_generateManualTitle_UsesTimeout(t *testing.T) {
 				deadline,
 				2*time.Second,
 			)
-			require.True(t, suppressAIBridgeSessionHeadersFromContext(ctx))
 			requireSyntheticQuickgenPrompt(t, call.Prompt, "refresh chat title")
 			require.Equal(t, "propose_title", call.SchemaName)
 			return &fantasy.ObjectResponse{Object: map[string]any{"title": "Refresh title"}}, nil
@@ -526,8 +524,7 @@ func Test_generateManualTitle_TruncatesFirstUserInput(t *testing.T) {
 	}
 
 	model := &chattest.FakeModel{
-		GenerateObjectFn: func(ctx context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
-			require.True(t, suppressAIBridgeSessionHeadersFromContext(ctx))
+		GenerateObjectFn: func(_ context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
 			requireSyntheticQuickgenPrompt(t, call.Prompt, truncateRunes(longFirstUserText, maxLatestUserMessageRunes))
 			// The manual title system prompt also includes the latest user excerpt.
 			systemText, ok := call.Prompt[0].Content[0].(fantasy.TextPart)
@@ -672,6 +669,97 @@ func TestFallbackTurnStatusLabel(t *testing.T) {
 	}
 }
 
+func TestQuickgenAIGatewayPromptModeEndsWithAssistant(t *testing.T) {
+	t.Parallel()
+
+	t.Run("automatic title", func(t *testing.T) {
+		t.Parallel()
+
+		model := &chattest.FakeModel{
+			GenerateObjectFn: func(_ context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+				require.Equal(t, "propose_title", call.SchemaName)
+				requireSyntheticQuickgenPromptMode(
+					t,
+					call.Prompt,
+					"summarize failed workspace build logs",
+					quickgenPromptModeAIGateway,
+				)
+				return &fantasy.ObjectResponse{Object: map[string]any{"title": "Failed workspace logs"}}, nil
+			},
+		}
+
+		title, _, err := generateStructuredTitleWithUsagePromptMode(
+			t.Context(),
+			model,
+			titleGenerationPrompt,
+			"summarize failed workspace build logs",
+			quickgenPromptModeAIGateway,
+		)
+		require.NoError(t, err)
+		require.Equal(t, "Failed workspace logs", title)
+	})
+
+	t.Run("manual title", func(t *testing.T) {
+		t.Parallel()
+
+		model := &chattest.FakeModel{
+			GenerateObjectFn: func(_ context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+				require.Equal(t, "propose_title", call.SchemaName)
+				requireSyntheticQuickgenPromptMode(
+					t,
+					call.Prompt,
+					"refresh chat title",
+					quickgenPromptModeAIGateway,
+				)
+				return &fantasy.ObjectResponse{Object: map[string]any{"title": "Refresh title"}}, nil
+			},
+		}
+
+		title, _, err := generateManualTitleWithPromptMode(
+			t.Context(),
+			[]database.ChatMessage{
+				mustChatMessage(
+					t,
+					database.ChatMessageRoleUser,
+					database.ChatMessageVisibilityBoth,
+					codersdk.ChatMessageText("refresh chat title"),
+				),
+			},
+			model,
+			quickgenPromptModeAIGateway,
+		)
+		require.NoError(t, err)
+		require.Equal(t, "Refresh title", title)
+	})
+
+	t.Run("turn status label", func(t *testing.T) {
+		t.Parallel()
+
+		model := &chattest.FakeModel{
+			GenerateObjectFn: func(_ context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+				require.Equal(t, "propose_turn_status_label", call.SchemaName)
+				requireSyntheticQuickgenPromptMode(
+					t,
+					call.Prompt,
+					"done",
+					quickgenPromptModeAIGateway,
+				)
+				return &fantasy.ObjectResponse{Object: map[string]any{"label": "Submitted PR"}}, nil
+			},
+		}
+
+		label, err := generateStructuredTurnStatusLabelWithPromptMode(
+			t.Context(),
+			model,
+			turnStatusLabelPrompt,
+			"done",
+			quickgenPromptModeAIGateway,
+		)
+		require.NoError(t, err)
+		require.Equal(t, "Submitted PR", label)
+	})
+}
+
 func TestGenerateStructuredTitleWithUsage_OpenAICompatibleRequiredToolChoice(t *testing.T) {
 	t.Parallel()
 
@@ -769,8 +857,22 @@ func openAICompatTestModel(t *testing.T, baseURL string) fantasy.LanguageModel {
 
 func requireSyntheticQuickgenPrompt(t *testing.T, prompt fantasy.Prompt, userInput string) {
 	t.Helper()
+	requireSyntheticQuickgenPromptMode(t, prompt, userInput, quickgenPromptModeDefault)
+}
 
-	require.Len(t, prompt, 2)
+func requireSyntheticQuickgenPromptMode(
+	t *testing.T,
+	prompt fantasy.Prompt,
+	userInput string,
+	promptMode quickgenPromptMode,
+) {
+	t.Helper()
+
+	wantLen := 2
+	if promptMode == quickgenPromptModeAIGateway {
+		wantLen = 3
+	}
+	require.Len(t, prompt, wantLen)
 	require.Equal(t, fantasy.MessageRoleSystem, prompt[0].Role)
 	require.Equal(t, fantasy.MessageRoleUser, prompt[1].Role)
 	require.Len(t, prompt[1].Content, 1)
@@ -778,6 +880,15 @@ func requireSyntheticQuickgenPrompt(t *testing.T, prompt fantasy.Prompt, userInp
 	userText, ok := prompt[1].Content[0].(fantasy.TextPart)
 	require.True(t, ok)
 	require.Equal(t, userInput, userText.Text)
+
+	if promptMode != quickgenPromptModeAIGateway {
+		return
+	}
+	require.Equal(t, fantasy.MessageRoleAssistant, prompt[2].Role)
+	require.Len(t, prompt[2].Content, 1)
+	assistantText, ok := prompt[2].Content[0].(fantasy.TextPart)
+	require.True(t, ok)
+	require.Equal(t, quickgenAssistantPromptMarker, assistantText.Text)
 }
 
 func requireOpenAICompatFinalUserMessage(t *testing.T, body map[string]any, userInput string) {
@@ -800,9 +911,8 @@ func TestGenerateStructuredTurnStatusLabel(t *testing.T) {
 		t.Parallel()
 
 		model := &chattest.FakeModel{
-			GenerateObjectFn: func(ctx context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+			GenerateObjectFn: func(_ context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
 				require.Equal(t, "propose_turn_status_label", call.SchemaName)
-				require.True(t, suppressAIBridgeSessionHeadersFromContext(ctx))
 				requireSyntheticQuickgenPrompt(t, call.Prompt, "done")
 				return &fantasy.ObjectResponse{
 					Object: map[string]any{"label": "Submitted PR"},

--- a/coderd/x/chatd/quickgen_internal_test.go
+++ b/coderd/x/chatd/quickgen_internal_test.go
@@ -526,6 +526,7 @@ func Test_generateManualTitle_TruncatesFirstUserInput(t *testing.T) {
 	model := &chattest.FakeModel{
 		GenerateObjectFn: func(_ context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
 			requireSyntheticQuickgenPrompt(t, call.Prompt, truncateRunes(longFirstUserText, 1000))
+			// The manual title system prompt also includes the latest user excerpt.
 			systemText, ok := call.Prompt[0].Content[0].(fantasy.TextPart)
 			require.True(t, ok)
 			require.Contains(t, systemText.Text, truncateRunes(longFirstUserText, 1000))

--- a/coderd/x/chatd/quickgen_internal_test.go
+++ b/coderd/x/chatd/quickgen_internal_test.go
@@ -530,9 +530,6 @@ func Test_generateManualTitle_TruncatesFirstUserInput(t *testing.T) {
 			require.True(t, ok)
 			require.Contains(t, systemText.Text, truncateRunes(longFirstUserText, 1000))
 
-			userText, ok := call.Prompt[1].Content[0].(fantasy.TextPart)
-			require.True(t, ok)
-			require.Equal(t, truncateRunes(longFirstUserText, 1000), userText.Text)
 			return &fantasy.ObjectResponse{Object: map[string]any{"title": "Refresh title"}}, nil
 		},
 	}
@@ -774,8 +771,8 @@ func requireSyntheticQuickgenPrompt(t *testing.T, prompt fantasy.Prompt, userInp
 	require.Equal(t, fantasy.MessageRoleUser, prompt[1].Role)
 	require.Equal(t, fantasy.MessageRoleAssistant, prompt[2].Role)
 
-	require.NotEmpty(t, prompt[1].Content)
-	require.NotEmpty(t, prompt[2].Content)
+	require.Len(t, prompt[1].Content, 1)
+	require.Len(t, prompt[2].Content, 1)
 
 	userText, ok := prompt[1].Content[0].(fantasy.TextPart)
 	require.True(t, ok)
@@ -796,6 +793,7 @@ func requireOpenAICompatAssistantFinalMessage(t *testing.T, body map[string]any)
 	lastMessage, ok := messages[len(messages)-1].(map[string]any)
 	require.True(t, ok)
 	require.Equal(t, "assistant", lastMessage["role"])
+	require.Equal(t, quickgenStructuredOutputReady, lastMessage["content"])
 }
 
 func TestGenerateStructuredTurnStatusLabel(t *testing.T) {

--- a/coderd/x/chatd/quickgen_internal_test.go
+++ b/coderd/x/chatd/quickgen_internal_test.go
@@ -688,7 +688,7 @@ func TestGenerateStructuredTitleWithUsage_OpenAICompatibleRequiredToolChoice(t *
 
 	body := testutil.TryReceive(t.Context(), t, requests)
 	require.Equal(t, "required", body["tool_choice"])
-	requireOpenAICompatLastMessageRole(t, body, "assistant")
+	requireOpenAICompatAssistantFinalMessage(t, body)
 }
 
 func newOpenAICompatStructuredOutputServer(
@@ -773,7 +773,6 @@ func requireSyntheticQuickgenPrompt(t *testing.T, prompt fantasy.Prompt, userInp
 	require.Equal(t, fantasy.MessageRoleSystem, prompt[0].Role)
 	require.Equal(t, fantasy.MessageRoleUser, prompt[1].Role)
 	require.Equal(t, fantasy.MessageRoleAssistant, prompt[2].Role)
-	require.NotEqual(t, fantasy.MessageRoleUser, prompt[len(prompt)-1].Role)
 
 	require.NotEmpty(t, prompt[1].Content)
 	require.NotEmpty(t, prompt[2].Content)
@@ -787,7 +786,7 @@ func requireSyntheticQuickgenPrompt(t *testing.T, prompt fantasy.Prompt, userInp
 	require.Equal(t, quickgenStructuredOutputReady, assistantText.Text)
 }
 
-func requireOpenAICompatLastMessageRole(t *testing.T, body map[string]any, want string) {
+func requireOpenAICompatAssistantFinalMessage(t *testing.T, body map[string]any) {
 	t.Helper()
 
 	messages, ok := body["messages"].([]any)
@@ -796,8 +795,7 @@ func requireOpenAICompatLastMessageRole(t *testing.T, body map[string]any, want 
 
 	lastMessage, ok := messages[len(messages)-1].(map[string]any)
 	require.True(t, ok)
-	require.Equal(t, want, lastMessage["role"])
-	require.NotEqual(t, "user", lastMessage["role"])
+	require.Equal(t, "assistant", lastMessage["role"])
 }
 
 func TestGenerateStructuredTurnStatusLabel(t *testing.T) {
@@ -834,7 +832,7 @@ func TestGenerateStructuredTurnStatusLabel(t *testing.T) {
 
 		body := testutil.TryReceive(t.Context(), t, requests)
 		require.Equal(t, "required", body["tool_choice"])
-		requireOpenAICompatLastMessageRole(t, body, "assistant")
+		requireOpenAICompatAssistantFinalMessage(t, body)
 	})
 
 	t.Run("rejects narrative label", func(t *testing.T) {

--- a/coderd/x/chatd/quickgen_internal_test.go
+++ b/coderd/x/chatd/quickgen_internal_test.go
@@ -415,8 +415,9 @@ func TestMaybeGenerateChatTitlePreservesUpdatedAt(t *testing.T) {
 
 	const wantTitle = "Failed workspace logs"
 	model := &chattest.FakeModel{
-		GenerateObjectFn: func(_ context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+		GenerateObjectFn: func(ctx context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
 			require.Equal(t, "propose_title", call.SchemaName)
+			requireSyntheticQuickgenContext(ctx, t)
 			requireSyntheticQuickgenPrompt(t, call.Prompt, userPrompt)
 			return &fantasy.ObjectResponse{
 				Object: map[string]any{"title": wantTitle},
@@ -495,6 +496,7 @@ func Test_generateManualTitle_UsesTimeout(t *testing.T) {
 				deadline,
 				2*time.Second,
 			)
+			requireSyntheticQuickgenContext(ctx, t)
 			requireSyntheticQuickgenPrompt(t, call.Prompt, "refresh chat title")
 			require.Equal(t, "propose_title", call.SchemaName)
 			return &fantasy.ObjectResponse{Object: map[string]any{"title": "Refresh title"}}, nil
@@ -524,7 +526,8 @@ func Test_generateManualTitle_TruncatesFirstUserInput(t *testing.T) {
 	}
 
 	model := &chattest.FakeModel{
-		GenerateObjectFn: func(_ context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+		GenerateObjectFn: func(ctx context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+			requireSyntheticQuickgenContext(ctx, t)
 			requireSyntheticQuickgenPrompt(t, call.Prompt, truncateRunes(longFirstUserText, maxLatestUserMessageRunes))
 			// The manual title system prompt also includes the latest user excerpt.
 			systemText, ok := call.Prompt[0].Content[0].(fantasy.TextPart)
@@ -764,6 +767,12 @@ func openAICompatTestModel(t *testing.T, baseURL string) fantasy.LanguageModel {
 	return model
 }
 
+func requireSyntheticQuickgenContext(ctx context.Context, t *testing.T) {
+	t.Helper()
+
+	require.True(t, suppressAIBridgeSessionHeadersFromContext(ctx))
+}
+
 func requireSyntheticQuickgenPrompt(t *testing.T, prompt fantasy.Prompt, userInput string) {
 	t.Helper()
 
@@ -804,8 +813,9 @@ func TestGenerateStructuredTurnStatusLabel(t *testing.T) {
 		t.Parallel()
 
 		model := &chattest.FakeModel{
-			GenerateObjectFn: func(_ context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+			GenerateObjectFn: func(ctx context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
 				require.Equal(t, "propose_turn_status_label", call.SchemaName)
+				requireSyntheticQuickgenContext(ctx, t)
 				requireSyntheticQuickgenPrompt(t, call.Prompt, "done")
 				return &fantasy.ObjectResponse{
 					Object: map[string]any{"label": "Submitted PR"},

--- a/coderd/x/chatd/quickgen_internal_test.go
+++ b/coderd/x/chatd/quickgen_internal_test.go
@@ -417,7 +417,7 @@ func TestMaybeGenerateChatTitlePreservesUpdatedAt(t *testing.T) {
 	model := &chattest.FakeModel{
 		GenerateObjectFn: func(ctx context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
 			require.Equal(t, "propose_title", call.SchemaName)
-			requireSyntheticQuickgenContext(ctx, t)
+			require.True(t, suppressAIBridgeSessionHeadersFromContext(ctx))
 			requireSyntheticQuickgenPrompt(t, call.Prompt, userPrompt)
 			return &fantasy.ObjectResponse{
 				Object: map[string]any{"title": wantTitle},
@@ -496,7 +496,7 @@ func Test_generateManualTitle_UsesTimeout(t *testing.T) {
 				deadline,
 				2*time.Second,
 			)
-			requireSyntheticQuickgenContext(ctx, t)
+			require.True(t, suppressAIBridgeSessionHeadersFromContext(ctx))
 			requireSyntheticQuickgenPrompt(t, call.Prompt, "refresh chat title")
 			require.Equal(t, "propose_title", call.SchemaName)
 			return &fantasy.ObjectResponse{Object: map[string]any{"title": "Refresh title"}}, nil
@@ -527,7 +527,7 @@ func Test_generateManualTitle_TruncatesFirstUserInput(t *testing.T) {
 
 	model := &chattest.FakeModel{
 		GenerateObjectFn: func(ctx context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
-			requireSyntheticQuickgenContext(ctx, t)
+			require.True(t, suppressAIBridgeSessionHeadersFromContext(ctx))
 			requireSyntheticQuickgenPrompt(t, call.Prompt, truncateRunes(longFirstUserText, maxLatestUserMessageRunes))
 			// The manual title system prompt also includes the latest user excerpt.
 			systemText, ok := call.Prompt[0].Content[0].(fantasy.TextPart)
@@ -689,7 +689,7 @@ func TestGenerateStructuredTitleWithUsage_OpenAICompatibleRequiredToolChoice(t *
 
 	body := testutil.TryReceive(t.Context(), t, requests)
 	require.Equal(t, "required", body["tool_choice"])
-	requireOpenAICompatAssistantFinalMessage(t, body)
+	requireOpenAICompatFinalUserMessage(t, body, "summarize failed workspace build logs")
 }
 
 func newOpenAICompatStructuredOutputServer(
@@ -767,33 +767,20 @@ func openAICompatTestModel(t *testing.T, baseURL string) fantasy.LanguageModel {
 	return model
 }
 
-func requireSyntheticQuickgenContext(ctx context.Context, t *testing.T) {
-	t.Helper()
-
-	require.True(t, suppressAIBridgeSessionHeadersFromContext(ctx))
-}
-
 func requireSyntheticQuickgenPrompt(t *testing.T, prompt fantasy.Prompt, userInput string) {
 	t.Helper()
 
-	require.Len(t, prompt, 3)
+	require.Len(t, prompt, 2)
 	require.Equal(t, fantasy.MessageRoleSystem, prompt[0].Role)
 	require.Equal(t, fantasy.MessageRoleUser, prompt[1].Role)
-	require.Equal(t, fantasy.MessageRoleAssistant, prompt[2].Role)
-
 	require.Len(t, prompt[1].Content, 1)
-	require.Len(t, prompt[2].Content, 1)
 
 	userText, ok := prompt[1].Content[0].(fantasy.TextPart)
 	require.True(t, ok)
 	require.Equal(t, userInput, userText.Text)
-
-	assistantText, ok := prompt[2].Content[0].(fantasy.TextPart)
-	require.True(t, ok)
-	require.Equal(t, quickgenStructuredOutputReady, assistantText.Text)
 }
 
-func requireOpenAICompatAssistantFinalMessage(t *testing.T, body map[string]any) {
+func requireOpenAICompatFinalUserMessage(t *testing.T, body map[string]any, userInput string) {
 	t.Helper()
 
 	messages, ok := body["messages"].([]any)
@@ -802,8 +789,8 @@ func requireOpenAICompatAssistantFinalMessage(t *testing.T, body map[string]any)
 
 	lastMessage, ok := messages[len(messages)-1].(map[string]any)
 	require.True(t, ok)
-	require.Equal(t, "assistant", lastMessage["role"])
-	require.Equal(t, quickgenStructuredOutputReady, lastMessage["content"])
+	require.Equal(t, "user", lastMessage["role"])
+	require.Equal(t, userInput, lastMessage["content"])
 }
 
 func TestGenerateStructuredTurnStatusLabel(t *testing.T) {
@@ -815,7 +802,7 @@ func TestGenerateStructuredTurnStatusLabel(t *testing.T) {
 		model := &chattest.FakeModel{
 			GenerateObjectFn: func(ctx context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
 				require.Equal(t, "propose_turn_status_label", call.SchemaName)
-				requireSyntheticQuickgenContext(ctx, t)
+				require.True(t, suppressAIBridgeSessionHeadersFromContext(ctx))
 				requireSyntheticQuickgenPrompt(t, call.Prompt, "done")
 				return &fantasy.ObjectResponse{
 					Object: map[string]any{"label": "Submitted PR"},
@@ -841,7 +828,7 @@ func TestGenerateStructuredTurnStatusLabel(t *testing.T) {
 
 		body := testutil.TryReceive(t.Context(), t, requests)
 		require.Equal(t, "required", body["tool_choice"])
-		requireOpenAICompatAssistantFinalMessage(t, body)
+		requireOpenAICompatFinalUserMessage(t, body, "done")
 	})
 
 	t.Run("rejects narrative label", func(t *testing.T) {

--- a/coderd/x/chatd/quickgen_internal_test.go
+++ b/coderd/x/chatd/quickgen_internal_test.go
@@ -525,11 +525,11 @@ func Test_generateManualTitle_TruncatesFirstUserInput(t *testing.T) {
 
 	model := &chattest.FakeModel{
 		GenerateObjectFn: func(_ context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
-			requireSyntheticQuickgenPrompt(t, call.Prompt, truncateRunes(longFirstUserText, 1000))
+			requireSyntheticQuickgenPrompt(t, call.Prompt, truncateRunes(longFirstUserText, maxLatestUserMessageRunes))
 			// The manual title system prompt also includes the latest user excerpt.
 			systemText, ok := call.Prompt[0].Content[0].(fantasy.TextPart)
 			require.True(t, ok)
-			require.Contains(t, systemText.Text, truncateRunes(longFirstUserText, 1000))
+			require.Contains(t, systemText.Text, truncateRunes(longFirstUserText, maxLatestUserMessageRunes))
 
 			return &fantasy.ObjectResponse{Object: map[string]any{"title": "Refresh title"}}, nil
 		},

--- a/coderd/x/chatd/title_override_internal_test.go
+++ b/coderd/x/chatd/title_override_internal_test.go
@@ -412,7 +412,7 @@ func TestResolveManualTitleModel_TitleGenerationOverrideUnset(t *testing.T) {
 	}, nil)
 
 	server := titleOverrideTestServer(db, logger)
-	model, gotConfig, _, err := server.resolveManualTitleModel(
+	got, err := server.resolveManualTitleModel(
 		ctx,
 		db,
 		chat,
@@ -420,8 +420,8 @@ func TestResolveManualTitleModel_TitleGenerationOverrideUnset(t *testing.T) {
 		modelBuildOptions{},
 	)
 	require.NoError(t, err)
-	require.NotNil(t, model)
-	require.Equal(t, preferredConfig, gotConfig)
+	require.NotNil(t, got.model)
+	require.Equal(t, preferredConfig, got.config)
 }
 
 func TestResolveManualTitleModel_TitleGenerationOverrideUnsetAIProvider(t *testing.T) {
@@ -462,7 +462,7 @@ func TestResolveManualTitleModel_TitleGenerationOverrideUnsetAIProvider(t *testi
 	}}, nil)
 
 	server := titleOverrideTestServer(db, logger)
-	model, gotConfig, gotKeys, err := server.resolveManualTitleModel(
+	got, err := server.resolveManualTitleModel(
 		ctx,
 		db,
 		chat,
@@ -470,9 +470,9 @@ func TestResolveManualTitleModel_TitleGenerationOverrideUnsetAIProvider(t *testi
 		modelBuildOptions{},
 	)
 	require.NoError(t, err)
-	require.NotNil(t, model)
-	require.Equal(t, preferredConfig, gotConfig)
-	require.Equal(t, "test-key", gotKeys.APIKey("openai"))
+	require.NotNil(t, got.model)
+	require.Equal(t, preferredConfig, got.config)
+	require.Equal(t, "test-key", got.keys.APIKey("openai"))
 }
 
 func TestResolveManualTitleModel_TitleGenerationOverrideReadDBError(t *testing.T) {
@@ -497,7 +497,7 @@ func TestResolveManualTitleModel_TitleGenerationOverrideReadDBError(t *testing.T
 	}, nil)
 
 	server := titleOverrideTestServer(db, logger)
-	model, gotConfig, _, err := server.resolveManualTitleModel(
+	got, err := server.resolveManualTitleModel(
 		ctx,
 		db,
 		chat,
@@ -505,8 +505,8 @@ func TestResolveManualTitleModel_TitleGenerationOverrideReadDBError(t *testing.T
 		modelBuildOptions{},
 	)
 	require.NoError(t, err)
-	require.NotNil(t, model)
-	require.Equal(t, preferredConfig, gotConfig)
+	require.NotNil(t, got.model)
+	require.Equal(t, preferredConfig, got.config)
 }
 
 func TestResolveManualTitleModel_TitleGenerationOverrideSetUsable(t *testing.T) {
@@ -525,7 +525,7 @@ func TestResolveManualTitleModel_TitleGenerationOverrideSetUsable(t *testing.T) 
 	db.EXPECT().GetAIProviderKeysByProviderIDs(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
 	server := titleOverrideTestServer(db, logger)
-	model, gotConfig, _, err := server.resolveManualTitleModel(
+	got, err := server.resolveManualTitleModel(
 		ctx,
 		db,
 		chat,
@@ -533,8 +533,8 @@ func TestResolveManualTitleModel_TitleGenerationOverrideSetUsable(t *testing.T) 
 		modelBuildOptions{},
 	)
 	require.NoError(t, err)
-	require.NotNil(t, model)
-	require.Equal(t, overrideConfig, gotConfig)
+	require.NotNil(t, got.model)
+	require.Equal(t, overrideConfig, got.config)
 }
 
 func TestResolveManualTitleModel_TitleGenerationOverrideMissingCredentials(t *testing.T) {
@@ -553,7 +553,7 @@ func TestResolveManualTitleModel_TitleGenerationOverrideMissingCredentials(t *te
 	db.EXPECT().GetAIProviderKeysByProviderIDs(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
 	server := titleOverrideTestServer(db, logger)
-	model, gotConfig, _, err := server.resolveManualTitleModel(
+	got, err := server.resolveManualTitleModel(
 		ctx,
 		db,
 		chat,
@@ -563,8 +563,8 @@ func TestResolveManualTitleModel_TitleGenerationOverrideMissingCredentials(t *te
 	require.Error(t, err)
 	require.ErrorContains(t, err, "resolve manual title generation model override")
 	require.ErrorContains(t, err, "credentials are unavailable")
-	require.Nil(t, model)
-	require.Equal(t, database.ChatModelConfig{}, gotConfig)
+	require.Nil(t, got.model)
+	require.Equal(t, database.ChatModelConfig{}, got.config)
 }
 
 func TestGenerateManualTitleCandidate_ActiveAPIKeyIDFallback(t *testing.T) {
@@ -687,7 +687,7 @@ func TestResolveManualTitleModel_TitleGenerationOverrideSetUnusable(t *testing.T
 	db.EXPECT().GetChatModelConfigByID(gomock.Any(), overrideConfig.ID).Return(overrideConfig, nil)
 
 	server := titleOverrideTestServer(db, logger)
-	model, gotConfig, _, err := server.resolveManualTitleModel(
+	got, err := server.resolveManualTitleModel(
 		ctx,
 		db,
 		chat,
@@ -697,8 +697,8 @@ func TestResolveManualTitleModel_TitleGenerationOverrideSetUnusable(t *testing.T
 	require.Error(t, err)
 	require.ErrorContains(t, err, "resolve manual title generation model override")
 	require.ErrorContains(t, err, "title generation model override is unavailable")
-	require.Nil(t, model)
-	require.Equal(t, database.ChatModelConfig{}, gotConfig)
+	require.Nil(t, got.model)
+	require.Equal(t, database.ChatModelConfig{}, got.config)
 }
 
 func titleOverrideTestChatAndMessages(t *testing.T) (database.Chat, []database.ChatMessage) {


### PR DESCRIPTION
Synthetic chatd quickgen requests for titles and turn status labels were being recorded as user prompt traffic in AI Sessions.

This keeps AI Bridge unchanged. For AI Gateway quickgen calls, chatd preserves the user task input but appends a short assistant marker so the provider-visible prompt ends as non-user. Direct provider quickgen calls and normal chat turns keep their existing final user message shape.

> Mux updated this PR on behalf of Mike.
