### PR TITLE
chore: Style fixes and nits across the AI Governance docs

### DIFF
--- a/docs/ai-coder/agent-firewall/index.md
+++ b/docs/ai-coder/agent-firewall/index.md
@@ -48,8 +48,8 @@ In your Terraform module, enable Agent Firewall with minimal configuration:
 
 ```tf
 module "claude-code" {
-  source              = "dev.registry.coder.com/coder/claude-code/coder"
-  version             = "4.7.0"
+  source              = "registry.coder.com/coder/claude-code/coder"
+  version             = "5.2.0"
   enable_boundary     = true
 }
 ```
@@ -59,7 +59,7 @@ Claude Code module, use the following minimal configuration:
 
 ```yaml
 allowlist:
-  - "domain=dev.coder.com" # Required - use your Coder deployment domain
+  - "domain=coder.example.com" # Required - use your Coder deployment domain
   - "domain=api.anthropic.com" # Required - API endpoint for Claude
   - "domain=statsig.anthropic.com" # Required - Feature flags and analytics
   - "domain=claude.ai" # Recommended - WebFetch/WebSearch features
@@ -225,5 +225,5 @@ such as Grafana Loki.
 Example of an allowed request (assuming stderr):
 
 ```console
-2026-01-16 00:11:40.564 [info]  coderd.agentrpc: boundary_request owner=joe  workspace_name=some-task-c88d agent_name=dev  decision=allow  workspace_id=f2bd4e9f-7e27-49fc-961e-be4d1c2aa987  http_method=GET http_url=https://dev.coder.com  event_time=2026-01-16T00:11:39.388607657Z  matched_rule=domain=dev.coder.com request_id=9f30d667-1fc9-47ba-b9e5-8eac46e0abef trace=478b2b45577307c4fd1bcfc64fad6ffb span=9ece4bc70c311edb
+2026-01-16 00:11:40.564 [info]  coderd.agentrpc: boundary_request owner=joe  workspace_name=some-task-c88d agent_name=dev  decision=allow  workspace_id=f2bd4e9f-7e27-49fc-961e-be4d1c2aa987  http_method=GET http_url=https://coder.example.com  event_time=2026-01-16T00:11:39.388607657Z  matched_rule=domain=coder.example.com request_id=9f30d667-1fc9-47ba-b9e5-8eac46e0abef trace=478b2b45577307c4fd1bcfc64fad6ffb span=9ece4bc70c311edb
 ```

--- a/docs/ai-coder/ai-governance.md
+++ b/docs/ai-coder/ai-governance.md
@@ -48,7 +48,6 @@ adoption patterns and potential issues.
 ### Restricting agent network access
 
 AI agents can make arbitrary network requests, potentially accessing unauthorized services or exfiltrating data.
-<!--They can also execute destructive commands within a workspace.-->
 Agent Firewall enforces process-level policies that restrict which domains agents can reach and what actions they can perform,
 preventing unintended data exposure and destructive operations like `rm -rf`.
 

--- a/docs/ai-coder/ai-governance.md
+++ b/docs/ai-coder/ai-governance.md
@@ -45,12 +45,11 @@ being used across the organization. AI Gateway provides audit trails of prompts,
 token usage, and tool invocations, giving administrators insight into AI
 adoption patterns and potential issues.
 
-### Restricting agent network and command access
+### Restricting agent network access
 
-AI agents can make arbitrary network requests, potentially accessing
-unauthorized services or exfiltrating data. They can also execute destructive
-commands within a workspace. Agent Firewall enforces process-level policies
-that restrict which domains agents can reach and what actions they can perform,
+AI agents can make arbitrary network requests, potentially accessing unauthorized services or exfiltrating data.
+<!--They can also execute destructive commands within a workspace.-->
+Agent Firewall enforces process-level policies that restrict which domains agents can reach and what actions they can perform,
 preventing unintended data exposure and destructive operations like `rm -rf`.
 
 ### Centralizing API key management

--- a/docs/ai-coder/usage-data-reporting.md
+++ b/docs/ai-coder/usage-data-reporting.md
@@ -12,7 +12,7 @@ To send usage data, your Coder deployment must be able to make outbound HTTPS re
 Example of a successful request (requires debug logging enabled [`CODER_LOG_FILTER=.*`](../reference/cli/server.md#-l---log-filter)):
 
 ```sh
-[debug] published usage events to tallyman accepted=5 rejected=0
+[debu] published usage events to tallyman accepted=5 rejected=0
 ```
 
 Example of a request payload:

--- a/docs/ai-coder/usage-data-reporting.md
+++ b/docs/ai-coder/usage-data-reporting.md
@@ -5,19 +5,19 @@ The [AI Governance Add-On](./ai-governance.md) requires reporting usage data to 
 - number of agent workspace builds consumed
 - number of AI Governance seats consumed
 
-No user-identifiable information or additional metrics are sent to Tallyman. This information is also shared with [Metronome](https://metronome.com), a Stripe product and Coder partner for usage-based and reporting.
+No user-identifiable information or additional metrics are sent to Tallyman. This information is also shared with [Metronome](https://metronome.com), a Stripe product and Coder partner for usage-based billing and reporting.
 
 To send usage data, your Coder deployment must be able to make outbound HTTPS requests to `https://tallyman-prod.coder.com`. Usage data is sent approximately every 17 minutes and can be monitored via `coderd` logs.
 
 Example of a successful request (requires debug logging enabled [`CODER_LOG_FILTER=.*`](../reference/cli/server.md#-l---log-filter)):
 
 ```sh
-[debu] published usage events to tallyman accepted=5 rejected=0
+[debug] published usage events to tallyman accepted=5 rejected=0
 ```
 
 Example of a request payload:
 
-```sh
+```txt
 POST /api/v1/events/ingest HTTP/1.1
 Host: tallyman-prod.coder.com
 Content-Type: application/json

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1144,85 +1144,99 @@
 								{
 									"title": "Setup",
 									"description": "How to set up and configure AI Gateway",
-									"path": "./ai-coder/ai-gateway/setup.md"
+									"path": "./ai-coder/ai-gateway/setup.md",
+									"state": ["ai governance add-on"]
 								},
 								{
 									"title": "Authentication",
 									"description": "Learn how to authenticate against AI Gateway",
-									"path": "./ai-coder/ai-gateway/auth.md"
+									"path": "./ai-coder/ai-gateway/auth.md",
+									"state": ["ai governance add-on"]
 								},
 								{
 									"title": "Client Configuration",
 									"description": "How to configure your AI coding tools to use AI Gateway",
 									"path": "./ai-coder/ai-gateway/clients/index.md",
+									"state": ["ai governance add-on"],
 									"children": [
 										{
 											"title": "Coder Agents",
 											"description": "Route Coder Agents traffic through AI Gateway",
-											"path": "./ai-coder/ai-gateway/clients/coder-agents.md"
+											"path": "./ai-coder/ai-gateway/clients/coder-agents.md",
+											"state": ["ai governance add-on"]
 										},
 										{
 											"title": "Claude Code",
 											"description": "Configure Claude Code to use AI Gateway",
-											"path": "./ai-coder/ai-gateway/clients/claude-code.md"
+											"path": "./ai-coder/ai-gateway/clients/claude-code.md",
+											"state": ["ai governance add-on"]
 										},
 										{
 											"title": "Codex",
 											"description": "Configure Codex to use AI Gateway",
-											"path": "./ai-coder/ai-gateway/clients/codex.md"
+											"path": "./ai-coder/ai-gateway/clients/codex.md",
+											"state": ["ai governance add-on"]
 										},
 										{
 											"title": "Mux",
 											"description": "Configure Mux to use AI Gateway",
-											"path": "./ai-coder/ai-gateway/clients/mux.md"
+											"path": "./ai-coder/ai-gateway/clients/mux.md",
+											"state": ["ai governance add-on"]
 										},
 										{
 											"title": "OpenCode",
 											"description": "Configure OpenCode to use AI Gateway",
-											"path": "./ai-coder/ai-gateway/clients/opencode.md"
+											"path": "./ai-coder/ai-gateway/clients/opencode.md",
+											"state": ["ai governance add-on"]
 										},
 										{
 											"title": "Factory",
 											"description": "Configure Factory to use AI Gateway",
-											"path": "./ai-coder/ai-gateway/clients/factory.md"
+											"path": "./ai-coder/ai-gateway/clients/factory.md",
+											"state": ["ai governance add-on"]
 										},
 										{
 											"title": "Cline",
 											"description": "Configure Cline to use AI Gateway",
-											"path": "./ai-coder/ai-gateway/clients/cline.md"
+											"path": "./ai-coder/ai-gateway/clients/cline.md",
+											"state": ["ai governance add-on"]
 										},
 										{
 											"title": "Kilo Code",
 											"description": "Configure Kilo Code to use AI Gateway",
-											"path": "./ai-coder/ai-gateway/clients/kilo-code.md"
+											"path": "./ai-coder/ai-gateway/clients/kilo-code.md",
+											"state": ["ai governance add-on"]
 										},
 										{
 											"title": "VS Code",
 											"description": "Configure VS Code to use AI Gateway",
-											"path": "./ai-coder/ai-gateway/clients/vscode.md"
+											"path": "./ai-coder/ai-gateway/clients/vscode.md",
+											"state": ["ai governance add-on"]
 										},
 										{
 											"title": "JetBrains",
 											"description": "Configure JetBrains IDEs to use AI Gateway",
-											"path": "./ai-coder/ai-gateway/clients/jetbrains.md"
+											"path": "./ai-coder/ai-gateway/clients/jetbrains.md",
+											"state": ["ai governance add-on"]
 										},
 										{
 											"title": "Zed",
 											"description": "Configure Zed to use AI Gateway",
-											"path": "./ai-coder/ai-gateway/clients/zed.md"
+											"path": "./ai-coder/ai-gateway/clients/zed.md",
+											"state": ["ai governance add-on"]
 										},
 										{
 											"title": "GitHub Copilot",
 											"description": "Configure GitHub Copilot to use AI Gateway via AI Gateway Proxy",
-											"path": "./ai-coder/ai-gateway/clients/copilot.md"
+											"path": "./ai-coder/ai-gateway/clients/copilot.md",
+											"state": ["ai governance add-on"]
 										}
 									]
 								},
 								{
 									"title": "MCP Tools Injection",
 									"description": "How to configure MCP servers for tools injection through AI Gateway",
-									"path": "./ai-coder/ai-gateway/mcp.md",
-									"state": ["early access"]
+									"path": "./ai-coder/ai-gateway/mcp.md"
 								},
 								{
 									"title": "AI Gateway Proxy",
@@ -1233,31 +1247,36 @@
 										{
 											"title": "Setup",
 											"description": "How to set up and configure AI Gateway Proxy",
-											"path": "./ai-coder/ai-gateway/ai-gateway-proxy/setup.md"
+											"path": "./ai-coder/ai-gateway/ai-gateway-proxy/setup.md",
+											"state": ["ai governance add-on"]
 										}
 									]
 								},
 								{
 									"title": "Auditing AI Sessions",
 									"description": "How to audit AI sessions",
-									"path": "./ai-coder/ai-gateway/audit.md"
+									"path": "./ai-coder/ai-gateway/audit.md",
+									"state": ["ai governance add-on"]
 								},
 								{
 									"title": "Monitoring",
 									"description": "How to monitor AI Gateway",
-									"path": "./ai-coder/ai-gateway/monitoring.md"
+									"path": "./ai-coder/ai-gateway/monitoring.md",
+									"state": ["ai governance add-on"]
 								},
 								{
 									"title": "Reference",
 									"description": "Technical reference for AI Gateway",
-									"path": "./ai-coder/ai-gateway/reference.md"
+									"path": "./ai-coder/ai-gateway/reference.md",
+									"state": ["ai governance add-on"]
 								}
 							]
 						},
 						{
 							"title": "Usage Data Reporting",
 							"description": "Configure AI usage data reporting",
-							"path": "./ai-coder/usage-data-reporting.md"
+							"path": "./ai-coder/usage-data-reporting.md",
+							"state": ["ai governance add-on"]
 						}
 					]
 				},


### PR DESCRIPTION
- Add the "AI Governance Add-On" label across all pages
- Use a generic `coder.example.com` URL across examples
- Fix a few typos
- Remove mentions of command access as a feature of AI Gov

Fixes DOCS-262

<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->
