### PR TITLE
fix: pin Terraform 1.15.5 for all Nix platforms

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -148,40 +148,36 @@
           vendorHash = "sha256-OuQWmZmofdJKq1hvk43RPkILQwAuFzqhmB22Xf6Z3lA=";
         };
 
-        # Keep Terraform aligned with provisioner/terraform/testdata/version.txt
-        # so `make gen` remains deterministic across platforms.
+        # Pin to provisioner/terraform/testdata/version.txt for deterministic
+        # `make gen` across platforms.
         terraform_1_15_5 =
           let
-            terraformPlatform =
-              if pkgs.stdenv.isLinux && pkgs.stdenv.hostPlatform.isx86_64 then
-                {
-                  platform = "linux_amd64";
-                  hash = "sha256-cCshNq9nKMj/A3+EPdLbzit62IeGtzgdHXKu+iUPYBw=";
-                }
-              else if pkgs.stdenv.isLinux && pkgs.stdenv.hostPlatform.isAarch64 then
-                {
-                  platform = "linux_arm64";
-                  hash = "sha256-Bue0jegmFGxtkzG6NbE9oSMy2Dkr4w0d1reJukcT//A=";
-                }
-              else if pkgs.stdenv.isDarwin && pkgs.stdenv.hostPlatform.isAarch64 then
-                {
-                  platform = "darwin_arm64";
-                  hash = "sha256-ARN2YFEABbkYu6ghVIZvvqxDkxY9gnfCq+hh37WELDw=";
-                }
-              else if pkgs.stdenv.isDarwin && pkgs.stdenv.hostPlatform.isx86_64 then
-                {
-                  platform = "darwin_amd64";
-                  hash = "sha256-NofQfANLPn3u1bByzYris0g1vLE5uuw/xPX9U02r9e0=";
-                }
-              else
-                null;
+            hashes = {
+              x86_64-linux = {
+                platform = "linux_amd64";
+                hash = "sha256-cCshNq9nKMj/A3+EPdLbzit62IeGtzgdHXKu+iUPYBw=";
+              };
+              aarch64-linux = {
+                platform = "linux_arm64";
+                hash = "sha256-Bue0jegmFGxtkzG6NbE9oSMy2Dkr4w0d1reJukcT//A=";
+              };
+              aarch64-darwin = {
+                platform = "darwin_arm64";
+                hash = "sha256-ARN2YFEABbkYu6ghVIZvvqxDkxY9gnfCq+hh37WELDw=";
+              };
+              x86_64-darwin = {
+                platform = "darwin_amd64";
+                hash = "sha256-NofQfANLPn3u1bByzYris0g1vLE5uuw/xPX9U02r9e0=";
+              };
+            };
+            target = hashes.${system} or null;
           in
-          if terraformPlatform != null then
+          if target != null then
             pkgs.runCommand "terraform-1.15.5" {
               nativeBuildInputs = [ pkgs.unzip ];
               src = pkgs.fetchurl {
-                url = "https://releases.hashicorp.com/terraform/1.15.5/terraform_1.15.5_${terraformPlatform.platform}.zip";
-                hash = terraformPlatform.hash;
+                url = "https://releases.hashicorp.com/terraform/1.15.5/terraform_1.15.5_${target.platform}.zip";
+                hash = target.hash;
               };
             } ''
               mkdir -p "$out/bin"

--- a/flake.nix
+++ b/flake.nix
@@ -149,14 +149,39 @@
         };
 
         # Keep Terraform aligned with provisioner/terraform/testdata/version.txt
-        # so `make gen` remains deterministic in Nix shells.
+        # so `make gen` remains deterministic across platforms.
         terraform_1_15_5 =
-          if pkgs.stdenv.isLinux && pkgs.stdenv.hostPlatform.isx86_64 then
+          let
+            terraformPlatform =
+              if pkgs.stdenv.isLinux && pkgs.stdenv.hostPlatform.isx86_64 then
+                {
+                  platform = "linux_amd64";
+                  hash = "sha256-cCshNq9nKMj/A3+EPdLbzit62IeGtzgdHXKu+iUPYBw=";
+                }
+              else if pkgs.stdenv.isLinux && pkgs.stdenv.hostPlatform.isAarch64 then
+                {
+                  platform = "linux_arm64";
+                  hash = "sha256-Bue0jegmFGxtkzG6NbE9oSMy2Dkr4w0d1reJukcT//A=";
+                }
+              else if pkgs.stdenv.isDarwin && pkgs.stdenv.hostPlatform.isAarch64 then
+                {
+                  platform = "darwin_arm64";
+                  hash = "sha256-ARN2YFEABbkYu6ghVIZvvqxDkxY9gnfCq+hh37WELDw=";
+                }
+              else if pkgs.stdenv.isDarwin && pkgs.stdenv.hostPlatform.isx86_64 then
+                {
+                  platform = "darwin_amd64";
+                  hash = "sha256-NofQfANLPn3u1bByzYris0g1vLE5uuw/xPX9U02r9e0=";
+                }
+              else
+                null;
+          in
+          if terraformPlatform != null then
             pkgs.runCommand "terraform-1.15.5" {
               nativeBuildInputs = [ pkgs.unzip ];
               src = pkgs.fetchurl {
-                url = "https://releases.hashicorp.com/terraform/1.15.5/terraform_1.15.5_linux_amd64.zip";
-                hash = "sha256-cCshNq9nKMj/A3+EPdLbzit62IeGtzgdHXKu+iUPYBw=";
+                url = "https://releases.hashicorp.com/terraform/1.15.5/terraform_1.15.5_${terraformPlatform.platform}.zip";
+                hash = terraformPlatform.hash;
               };
             } ''
               mkdir -p "$out/bin"

--- a/flake.nix
+++ b/flake.nix
@@ -152,7 +152,7 @@
         # `make gen` across platforms.
         terraform_1_15_5 =
           let
-            hashes = {
+            releases = {
               x86_64-linux = {
                 platform = "linux_amd64";
                 hash = "sha256-cCshNq9nKMj/A3+EPdLbzit62IeGtzgdHXKu+iUPYBw=";
@@ -170,7 +170,7 @@
                 hash = "sha256-NofQfANLPn3u1bByzYris0g1vLE5uuw/xPX9U02r9e0=";
               };
             };
-            target = hashes.${system} or null;
+            target = releases.${system} or null;
           in
           if target != null then
             pkgs.runCommand "terraform-1.15.5" {

--- a/provisioner/terraform/testdata/generate.sh
+++ b/provisioner/terraform/testdata/generate.sh
@@ -140,10 +140,13 @@ if [[ " $* " == *" --check "* ]]; then
 	fi
 fi
 
-# The committed testdata encodes linux/amd64 values from the coder_provisioner
-# data source. Regenerating on a non-Linux host would bake in darwin/arm64 (or
-# similar) and dirty the tree. Guard here so local runs on macOS are safe.
+# Committed testdata encodes linux/amd64 values from coder_provisioner.
+# Regenerating elsewhere bakes in the host OS/arch.
 if [[ "$(uname)" != "Linux" ]]; then
+	if ((upgrade)); then
+		echo "ERROR: --upgrade is not supported on $(uname); run on Linux or via CI."
+		exit 1
+	fi
 	echo "Note: skipping testdata regeneration on $(uname); regenerate on Linux or via CI."
 	exit 0
 fi

--- a/provisioner/terraform/testdata/generate.sh
+++ b/provisioner/terraform/testdata/generate.sh
@@ -140,6 +140,14 @@ if [[ " $* " == *" --check "* ]]; then
 	fi
 fi
 
+# The committed testdata encodes linux/amd64 values from the coder_provisioner
+# data source. Regenerating on a non-Linux host would bake in darwin/arm64 (or
+# similar) and dirty the tree. Guard here so local runs on macOS are safe.
+if [[ "$(uname)" != "Linux" ]]; then
+	echo "Note: skipping testdata regeneration on $(uname); regenerate on Linux or via CI."
+	exit 0
+fi
+
 # Filter flags from positional args to get directory names.
 declare -a dirs=()
 for arg in "$@"; do

--- a/scripts/release/check_commit_metadata.sh
+++ b/scripts/release/check_commit_metadata.sh
@@ -78,7 +78,6 @@ main() {
 		[enterprise]="Enterprise"
 		[examples]="Examples"
 		[helm]="Helm"
-		[install.sh]="Installer"
 		[provisionersdk]="SDK"
 		[provisionerd]="Provisioner"
 		[provisioner]="Provisioner"
@@ -88,6 +87,9 @@ main() {
 		[support]="Support"
 		[tailnet]="Networking"
 	)
+	# shfmt (>=3.13) parses [install.sh] as floating-point arithmetic in array
+	# literals, so this entry is assigned after the declaration instead.
+	humanized_areas["install.sh"]="Installer"
 
 	# Get hashes for all cherry-picked commits between the selected ref
 	# and main. These are sorted by commit title so that we can group

--- a/scripts/release/check_commit_metadata.sh
+++ b/scripts/release/check_commit_metadata.sh
@@ -87,8 +87,7 @@ main() {
 		[support]="Support"
 		[tailnet]="Networking"
 	)
-	# shfmt (>=3.13) parses [install.sh] as floating-point arithmetic in array
-	# literals, so this entry is assigned after the declaration instead.
+	# shfmt (>=3.13) parses [install.sh] as floating-point arithmetic in array literals.
 	humanized_areas["install.sh"]="Installer"
 
 	# Get hashes for all cherry-picked commits between the selected ref


### PR DESCRIPTION
The terraform_1_15_5 derivation previously only handled linux/amd64, falling through to unstablePkgs.terraform on all other platforms. On macOS this meant a different Terraform version was used, which caused the version check in make pre-commit to trigger generate.sh, regenerating all testdata with the host platform's OS/arch (darwin/arm64) instead of the committed linux/amd64 values.

Three changes:

1. `flake.nix`: add explicit linux_arm64, darwin_arm64, and darwin_amd64 cases with SHA256 hashes from the official HashiCorp release. Unknown platforms still fall back to unstablePkgs.terraform.

2. `provisioner/terraform/testdata/generate.sh`: guard full regeneration behind a Linux-only check. The committed testdata encodes linux/amd64 values from the coder_provisioner data source, so regenerating on macOS would permanently bake in darwin/arm64. The --check path still runs on all platforms so the version target can detect provider mismatches. Regeneration via CI or an explicit Linux run is unchanged.

3. `scripts/release/check_commit_metadata.sh`: fix a shfmt (>=3.13) false positive. The [install.sh] key in an associative array literal was parsed as floating-point arithmetic (a zsh-only feature). Moving it to a post-declaration assignment satisfies the stricter parser without changing runtime behavior.

<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->



Linear: DOCS-279