### PR TITLE
feat: classify provider_disabled 503 as non-retryable

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -16490,7 +16490,8 @@ const docTemplate = `{
                 "auth",
                 "config",
                 "usage_limit",
-                "missing_key"
+                "missing_key",
+                "provider_disabled"
             ],
             "x-enum-varnames": [
                 "ChatErrorKindGeneric",
@@ -16501,7 +16502,8 @@ const docTemplate = `{
                 "ChatErrorKindAuth",
                 "ChatErrorKindConfig",
                 "ChatErrorKindUsageLimit",
-                "ChatErrorKindMissingKey"
+                "ChatErrorKindMissingKey",
+                "ChatErrorKindProviderDisabled"
             ]
         },
         "codersdk.ChatFileMetadata": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -14840,7 +14840,8 @@
 				"auth",
 				"config",
 				"usage_limit",
-				"missing_key"
+				"missing_key",
+				"provider_disabled"
 			],
 			"x-enum-varnames": [
 				"ChatErrorKindGeneric",
@@ -14851,7 +14852,8 @@
 				"ChatErrorKindAuth",
 				"ChatErrorKindConfig",
 				"ChatErrorKindUsageLimit",
-				"ChatErrorKindMissingKey"
+				"ChatErrorKindMissingKey",
+				"ChatErrorKindProviderDisabled"
 			]
 		},
 		"codersdk.ChatFileMetadata": {

--- a/coderd/x/chatd/chaterror/classify.go
+++ b/coderd/x/chatd/chaterror/classify.go
@@ -195,6 +195,7 @@ func Classify(err error) ClassifiedError {
 	}
 
 	retryableHTTP2StreamReset, hasHTTP2StreamReset := classifyHTTP2StreamReset(err)
+	providerDisabledMatch := containsAny(lower, providerDisabledPatterns...)
 	deadline := errors.Is(err, context.DeadlineExceeded) || strings.Contains(lower, "context deadline exceeded")
 	overloadedMatch := statusCode == 529 || containsAny(lower, overloadedPatterns...)
 	usageLimitMatch := containsAny(lower, usageLimitPatterns...)
@@ -250,6 +251,11 @@ func Classify(err error) ClassifiedError {
 			match:     rateLimitMatch && !configMatch,
 			kind:      codersdk.ChatErrorKindRateLimit,
 			retryable: true,
+		},
+		{
+			match:     providerDisabledMatch,
+			kind:      codersdk.ChatErrorKindProviderDisabled,
+			retryable: false,
 		},
 		{
 			match:     timeoutMatch && !configMatch,

--- a/coderd/x/chatd/chaterror/classify.go
+++ b/coderd/x/chatd/chaterror/classify.go
@@ -222,6 +222,8 @@ func Classify(err error) ClassifiedError {
 	// over whatever HTTP status code the provider happened to use.
 	// Strong auth still stays above config because bad credentials are
 	// the root cause when both signals appear.
+	// Provider-disabled must precede timeout because disabled providers
+	// return 503, which matches the timeout rule.
 	rules := []struct {
 		match     bool
 		kind      codersdk.ChatErrorKind

--- a/coderd/x/chatd/chaterror/classify_test.go
+++ b/coderd/x/chatd/chaterror/classify_test.go
@@ -2,6 +2,7 @@ package chaterror_test
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/xerrors"
 
+	"github.com/coder/coder/v2/aibridge"
 	"github.com/coder/coder/v2/coderd/x/chatd/chaterror"
 	"github.com/coder/coder/v2/codersdk"
 )
@@ -218,15 +220,21 @@ func TestClassify(t *testing.T) {
 				StatusCode: 0,
 			},
 		},
+		// The next three cases model the error that fantasy produces
+		// when aibridge's disabledProviderHandler returns a 503
+		// plain-text sentinel. Fantasy sets Title from the HTTP
+		// status text and Message from the response body (including
+		// the trailing newline written by http.Error).
 		{
 			name: "ProviderDisabled503ClassifiesAsProviderDisabled",
 			err: &fantasy.ProviderError{
-				Message:    `provider_disabled: AI provider "openai" is disabled`,
-				StatusCode: 503,
+				Title:      fantasy.ErrorTitleForStatusCode(http.StatusServiceUnavailable),
+				Message:    fmt.Sprintf("%s: AI provider %q is disabled\n", aibridge.ErrorCodeProviderDisabled, "openai"),
+				StatusCode: http.StatusServiceUnavailable,
 			},
 			want: chaterror.ClassifiedError{
 				Message:    "The OpenAI provider has been disabled by an administrator.",
-				Detail:     `provider_disabled: AI provider "openai" is disabled`,
+				Detail:     fmt.Sprintf("%s: AI provider %q is disabled", aibridge.ErrorCodeProviderDisabled, "openai"),
 				Kind:       codersdk.ChatErrorKindProviderDisabled,
 				Provider:   "openai",
 				Retryable:  false,
@@ -235,7 +243,7 @@ func TestClassify(t *testing.T) {
 		},
 		{
 			name: "ProviderDisabledPlainErrorString",
-			err:  xerrors.New(`provider_disabled: AI provider "anthropic" is disabled`),
+			err:  xerrors.New(fmt.Sprintf("%s: AI provider %q is disabled", aibridge.ErrorCodeProviderDisabled, "anthropic")),
 			want: chaterror.ClassifiedError{
 				Message:    "The Anthropic provider has been disabled by an administrator.",
 				Kind:       codersdk.ChatErrorKindProviderDisabled,
@@ -247,12 +255,13 @@ func TestClassify(t *testing.T) {
 		{
 			name: "ProviderDisabledBeatsTimeout503",
 			err: &fantasy.ProviderError{
-				Message:    "provider_disabled: AI provider \"google\" is disabled",
-				StatusCode: 503,
+				Title:      fantasy.ErrorTitleForStatusCode(http.StatusServiceUnavailable),
+				Message:    fmt.Sprintf("%s: AI provider %q is disabled\n", aibridge.ErrorCodeProviderDisabled, "google"),
+				StatusCode: http.StatusServiceUnavailable,
 			},
 			want: chaterror.ClassifiedError{
 				Message:    "The Google provider has been disabled by an administrator.",
-				Detail:     `provider_disabled: AI provider "google" is disabled`,
+				Detail:     fmt.Sprintf("%s: AI provider %q is disabled", aibridge.ErrorCodeProviderDisabled, "google"),
 				Kind:       codersdk.ChatErrorKindProviderDisabled,
 				Provider:   "google",
 				Retryable:  false,

--- a/coderd/x/chatd/chaterror/classify_test.go
+++ b/coderd/x/chatd/chaterror/classify_test.go
@@ -444,6 +444,7 @@ func TestClassify_PatternCoverage(t *testing.T) {
 		{name: "OperationInterruptedLiteral", err: "operation interrupted", wantKind: codersdk.ChatErrorKindGeneric, wantRetry: false},
 		{name: "Status408", err: "status 408", wantKind: codersdk.ChatErrorKindTimeout, wantRetry: true},
 		{name: "Status500", err: "status 500", wantKind: codersdk.ChatErrorKindGeneric, wantRetry: true},
+		{name: "ProviderDisabledLiteral", err: "provider_disabled", wantKind: codersdk.ChatErrorKindProviderDisabled, wantRetry: false},
 	}
 
 	for _, tt := range tests {

--- a/coderd/x/chatd/chaterror/classify_test.go
+++ b/coderd/x/chatd/chaterror/classify_test.go
@@ -218,6 +218,62 @@ func TestClassify(t *testing.T) {
 				StatusCode: 0,
 			},
 		},
+		{
+			name: "ProviderDisabled503ClassifiesAsProviderDisabled",
+			err: &fantasy.ProviderError{
+				Message:    `provider_disabled: AI provider "openai" is disabled`,
+				StatusCode: 503,
+			},
+			want: chaterror.ClassifiedError{
+				Message:    "The OpenAI provider has been disabled by an administrator.",
+				Detail:     `provider_disabled: AI provider "openai" is disabled`,
+				Kind:       codersdk.ChatErrorKindProviderDisabled,
+				Provider:   "openai",
+				Retryable:  false,
+				StatusCode: 503,
+			},
+		},
+		{
+			name: "ProviderDisabledPlainErrorString",
+			err:  xerrors.New(`provider_disabled: AI provider "anthropic" is disabled`),
+			want: chaterror.ClassifiedError{
+				Message:    "The Anthropic provider has been disabled by an administrator.",
+				Kind:       codersdk.ChatErrorKindProviderDisabled,
+				Provider:   "anthropic",
+				Retryable:  false,
+				StatusCode: 0,
+			},
+		},
+		{
+			name: "ProviderDisabledBeatsTimeout503",
+			err: &fantasy.ProviderError{
+				Message:    "provider_disabled: AI provider \"google\" is disabled",
+				StatusCode: 503,
+			},
+			want: chaterror.ClassifiedError{
+				Message:    "The Google provider has been disabled by an administrator.",
+				Detail:     `provider_disabled: AI provider "google" is disabled`,
+				Kind:       codersdk.ChatErrorKindProviderDisabled,
+				Provider:   "google",
+				Retryable:  false,
+				StatusCode: 503,
+			},
+		},
+		{
+			name: "Generic503StillClassifiesAsTimeout",
+			err: &fantasy.ProviderError{
+				Message:    "service unavailable",
+				StatusCode: 503,
+			},
+			want: chaterror.ClassifiedError{
+				Message:    "The AI provider is temporarily unavailable.",
+				Detail:     "service unavailable",
+				Kind:       codersdk.ChatErrorKindTimeout,
+				Provider:   "",
+				Retryable:  true,
+				StatusCode: 503,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/coderd/x/chatd/chaterror/classify_test.go
+++ b/coderd/x/chatd/chaterror/classify_test.go
@@ -242,6 +242,22 @@ func TestClassify(t *testing.T) {
 			},
 		},
 		{
+			name: "ProviderDisabled503UnknownProvider",
+			err: &fantasy.ProviderError{
+				Title:      fantasy.ErrorTitleForStatusCode(http.StatusServiceUnavailable),
+				Message:    fmt.Sprintf("%s: AI provider %q is disabled\n", aibridge.ErrorCodeProviderDisabled, "mycustomprovider"),
+				StatusCode: http.StatusServiceUnavailable,
+			},
+			want: chaterror.ClassifiedError{
+				Message:    "The AI provider has been disabled by an administrator.",
+				Detail:     fmt.Sprintf("%s: AI provider %q is disabled", aibridge.ErrorCodeProviderDisabled, "mycustomprovider"),
+				Kind:       codersdk.ChatErrorKindProviderDisabled,
+				Provider:   "",
+				Retryable:  false,
+				StatusCode: 503,
+			},
+		},
+		{
 			name: "ProviderDisabledPlainErrorString",
 			err:  xerrors.New(fmt.Sprintf("%s: AI provider %q is disabled", aibridge.ErrorCodeProviderDisabled, "anthropic")),
 			want: chaterror.ClassifiedError{

--- a/coderd/x/chatd/chaterror/classify_test.go
+++ b/coderd/x/chatd/chaterror/classify_test.go
@@ -220,7 +220,7 @@ func TestClassify(t *testing.T) {
 				StatusCode: 0,
 			},
 		},
-		// The next three cases model the error that fantasy produces
+		// The next cases model the error that fantasy produces
 		// when aibridge's disabledProviderHandler returns a 503
 		// plain-text sentinel. Fantasy sets Title from the HTTP
 		// status text and Message from the response body (including

--- a/coderd/x/chatd/chaterror/classify_test.go
+++ b/coderd/x/chatd/chaterror/classify_test.go
@@ -14,7 +14,6 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/xerrors"
 
-	"github.com/coder/coder/v2/aibridge"
 	"github.com/coder/coder/v2/coderd/x/chatd/chaterror"
 	"github.com/coder/coder/v2/codersdk"
 )
@@ -229,12 +228,12 @@ func TestClassify(t *testing.T) {
 			name: "ProviderDisabled503ClassifiesAsProviderDisabled",
 			err: &fantasy.ProviderError{
 				Title:      fantasy.ErrorTitleForStatusCode(http.StatusServiceUnavailable),
-				Message:    fmt.Sprintf("%s: AI provider %q is disabled\n", aibridge.ErrorCodeProviderDisabled, "openai"),
+				Message:    fmt.Sprintf("%s: AI provider %q is disabled\n", codersdk.ChatErrorKindProviderDisabled, "openai"),
 				StatusCode: http.StatusServiceUnavailable,
 			},
 			want: chaterror.ClassifiedError{
 				Message:    "The OpenAI provider has been disabled. Contact your Coder administrator.",
-				Detail:     fmt.Sprintf("%s: AI provider %q is disabled", aibridge.ErrorCodeProviderDisabled, "openai"),
+				Detail:     fmt.Sprintf("%s: AI provider %q is disabled", codersdk.ChatErrorKindProviderDisabled, "openai"),
 				Kind:       codersdk.ChatErrorKindProviderDisabled,
 				Provider:   "openai",
 				Retryable:  false,
@@ -245,12 +244,12 @@ func TestClassify(t *testing.T) {
 			name: "ProviderDisabled503UnknownProvider",
 			err: &fantasy.ProviderError{
 				Title:      fantasy.ErrorTitleForStatusCode(http.StatusServiceUnavailable),
-				Message:    fmt.Sprintf("%s: AI provider %q is disabled\n", aibridge.ErrorCodeProviderDisabled, "mycustomprovider"),
+				Message:    fmt.Sprintf("%s: AI provider %q is disabled\n", codersdk.ChatErrorKindProviderDisabled, "mycustomprovider"),
 				StatusCode: http.StatusServiceUnavailable,
 			},
 			want: chaterror.ClassifiedError{
 				Message:    "The AI provider has been disabled. Contact your Coder administrator.",
-				Detail:     fmt.Sprintf("%s: AI provider %q is disabled", aibridge.ErrorCodeProviderDisabled, "mycustomprovider"),
+				Detail:     fmt.Sprintf("%s: AI provider %q is disabled", codersdk.ChatErrorKindProviderDisabled, "mycustomprovider"),
 				Kind:       codersdk.ChatErrorKindProviderDisabled,
 				Provider:   "",
 				Retryable:  false,
@@ -259,7 +258,7 @@ func TestClassify(t *testing.T) {
 		},
 		{
 			name: "ProviderDisabledPlainErrorString",
-			err:  xerrors.New(fmt.Sprintf("%s: AI provider %q is disabled", aibridge.ErrorCodeProviderDisabled, "anthropic")),
+			err:  xerrors.New(fmt.Sprintf("%s: AI provider %q is disabled", codersdk.ChatErrorKindProviderDisabled, "anthropic")),
 			want: chaterror.ClassifiedError{
 				Message:    "The Anthropic provider has been disabled. Contact your Coder administrator.",
 				Kind:       codersdk.ChatErrorKindProviderDisabled,
@@ -272,12 +271,12 @@ func TestClassify(t *testing.T) {
 			name: "ProviderDisabledBeatsTimeout503",
 			err: &fantasy.ProviderError{
 				Title:      fantasy.ErrorTitleForStatusCode(http.StatusServiceUnavailable),
-				Message:    fmt.Sprintf("%s: AI provider %q is disabled\n", aibridge.ErrorCodeProviderDisabled, "google"),
+				Message:    fmt.Sprintf("%s: AI provider %q is disabled\n", codersdk.ChatErrorKindProviderDisabled, "google"),
 				StatusCode: http.StatusServiceUnavailable,
 			},
 			want: chaterror.ClassifiedError{
 				Message:    "The Google provider has been disabled. Contact your Coder administrator.",
-				Detail:     fmt.Sprintf("%s: AI provider %q is disabled", aibridge.ErrorCodeProviderDisabled, "google"),
+				Detail:     fmt.Sprintf("%s: AI provider %q is disabled", codersdk.ChatErrorKindProviderDisabled, "google"),
 				Kind:       codersdk.ChatErrorKindProviderDisabled,
 				Provider:   "google",
 				Retryable:  false,

--- a/coderd/x/chatd/chaterror/classify_test.go
+++ b/coderd/x/chatd/chaterror/classify_test.go
@@ -233,7 +233,7 @@ func TestClassify(t *testing.T) {
 				StatusCode: http.StatusServiceUnavailable,
 			},
 			want: chaterror.ClassifiedError{
-				Message:    "The OpenAI provider has been disabled by an administrator.",
+				Message:    "The OpenAI provider has been disabled. Contact your Coder administrator.",
 				Detail:     fmt.Sprintf("%s: AI provider %q is disabled", aibridge.ErrorCodeProviderDisabled, "openai"),
 				Kind:       codersdk.ChatErrorKindProviderDisabled,
 				Provider:   "openai",
@@ -249,7 +249,7 @@ func TestClassify(t *testing.T) {
 				StatusCode: http.StatusServiceUnavailable,
 			},
 			want: chaterror.ClassifiedError{
-				Message:    "The AI provider has been disabled by an administrator.",
+				Message:    "The AI provider has been disabled. Contact your Coder administrator.",
 				Detail:     fmt.Sprintf("%s: AI provider %q is disabled", aibridge.ErrorCodeProviderDisabled, "mycustomprovider"),
 				Kind:       codersdk.ChatErrorKindProviderDisabled,
 				Provider:   "",
@@ -261,7 +261,7 @@ func TestClassify(t *testing.T) {
 			name: "ProviderDisabledPlainErrorString",
 			err:  xerrors.New(fmt.Sprintf("%s: AI provider %q is disabled", aibridge.ErrorCodeProviderDisabled, "anthropic")),
 			want: chaterror.ClassifiedError{
-				Message:    "The Anthropic provider has been disabled by an administrator.",
+				Message:    "The Anthropic provider has been disabled. Contact your Coder administrator.",
 				Kind:       codersdk.ChatErrorKindProviderDisabled,
 				Provider:   "anthropic",
 				Retryable:  false,
@@ -276,7 +276,7 @@ func TestClassify(t *testing.T) {
 				StatusCode: http.StatusServiceUnavailable,
 			},
 			want: chaterror.ClassifiedError{
-				Message:    "The Google provider has been disabled by an administrator.",
+				Message:    "The Google provider has been disabled. Contact your Coder administrator.",
 				Detail:     fmt.Sprintf("%s: AI provider %q is disabled", aibridge.ErrorCodeProviderDisabled, "google"),
 				Kind:       codersdk.ChatErrorKindProviderDisabled,
 				Provider:   "google",

--- a/coderd/x/chatd/chaterror/message.go
+++ b/coderd/x/chatd/chaterror/message.go
@@ -70,7 +70,8 @@ func terminalMessage(classified ClassifiedError) string {
 			displayName = "AI"
 		}
 		return fmt.Sprintf(
-			"The %s provider has been disabled by an administrator.",
+			"The %s provider has been disabled."+
+				" Contact your Coder administrator.",
 			displayName,
 		)
 	default:

--- a/coderd/x/chatd/chaterror/message.go
+++ b/coderd/x/chatd/chaterror/message.go
@@ -64,7 +64,15 @@ func terminalMessage(classified ClassifiedError) string {
 	case codersdk.ChatErrorKindMissingKey:
 		return "This conversation was started with an API key that is no longer available." +
 			" Send your message again to continue."
-
+	case codersdk.ChatErrorKindProviderDisabled:
+		displayName := providerDisplayName(classified.Provider)
+		if displayName == "" {
+			displayName = "AI"
+		}
+		return fmt.Sprintf(
+			"The %s provider has been disabled by an administrator.",
+			displayName,
+		)
 	default:
 		if !classified.Retryable && classified.StatusCode == 0 {
 			return "The chat request failed unexpectedly."
@@ -108,6 +116,15 @@ func retryMessage(classified ClassifiedError) string {
 		)
 	case codersdk.ChatErrorKindMissingKey:
 		return "The API key for this conversation is no longer available."
+	case codersdk.ChatErrorKindProviderDisabled:
+		displayName := providerDisplayName(classified.Provider)
+		if displayName == "" {
+			displayName = "AI"
+		}
+		return fmt.Sprintf(
+			"The %s provider has been disabled by an administrator.",
+			displayName,
+		)
 	default:
 		return fmt.Sprintf(
 			"%s returned an unexpected error.", subject,

--- a/coderd/x/chatd/chaterror/message.go
+++ b/coderd/x/chatd/chaterror/message.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	stringutil "github.com/coder/coder/v2/coderd/util/strings"
 	"github.com/coder/coder/v2/codersdk"
 )
 
@@ -16,69 +17,58 @@ func terminalMessage(classified ClassifiedError) string {
 	subject := providerSubject(classified.Provider)
 	switch classified.Kind {
 	case codersdk.ChatErrorKindOverloaded:
-		return fmt.Sprintf("%s is temporarily overloaded.", subject)
+		return stringutil.Capitalize(fmt.Sprintf("%s is temporarily overloaded.", subject))
 
 	case codersdk.ChatErrorKindRateLimit:
-		return fmt.Sprintf("%s is rate limiting requests.", subject)
+		return stringutil.Capitalize(fmt.Sprintf("%s is rate limiting requests.", subject))
 
 	case codersdk.ChatErrorKindTimeout:
 		if !classified.Retryable && classified.StatusCode == 0 {
 			return "The request timed out before it completed."
 		}
-		return fmt.Sprintf("%s is temporarily unavailable.", subject)
+		return stringutil.Capitalize(fmt.Sprintf("%s is temporarily unavailable.", subject))
 
 	case codersdk.ChatErrorKindStartupTimeout:
-		return fmt.Sprintf(
+		return stringutil.Capitalize(fmt.Sprintf(
 			"%s did not start responding in time.", subject,
-		)
+		))
 
 	case codersdk.ChatErrorKindUsageLimit:
-		displayName := providerDisplayName(classified.Provider)
-		if displayName == "" {
-			displayName = "the AI provider"
-		}
-		return fmt.Sprintf(
+		return stringutil.Capitalize(fmt.Sprintf(
 			"The usage quota for %s has been exceeded."+
 				" Check the billing and quota settings for the provider account.",
-			displayName,
-		)
+			subject,
+		))
 
 	case codersdk.ChatErrorKindAuth:
-		displayName := providerDisplayName(classified.Provider)
-		if displayName == "" {
-			displayName = "the AI provider"
-		}
 		return fmt.Sprintf(
 			"Authentication with %s failed."+
 				" Check the API key and permissions.",
-			displayName,
+			subject,
 		)
 
 	case codersdk.ChatErrorKindConfig:
-		return fmt.Sprintf(
+		return stringutil.Capitalize(fmt.Sprintf(
 			"%s rejected the model configuration."+
 				" Check the selected model and provider settings.",
 			subject,
-		)
+		))
 
 	case codersdk.ChatErrorKindMissingKey:
 		return "This conversation was started with an API key that is no longer available." +
 			" Send your message again to continue."
 	case codersdk.ChatErrorKindProviderDisabled:
 		displayName := providerDisplayName(classified.Provider)
-		if displayName == "" {
-			displayName = "AI"
-		}
-		return fmt.Sprintf(
+		return stringutil.Capitalize(fmt.Sprintf(
 			"The %s provider has been disabled."+
 				" Contact your Coder administrator.",
 			displayName,
-		)
+		))
 	default:
 		if !classified.Retryable && classified.StatusCode == 0 {
 			return "The chat request failed unexpectedly."
 		}
-		return fmt.Sprintf("%s returned an unexpected error.", subject)
+		return stringutil.Capitalize(fmt.Sprintf("%s returned an unexpected error.", subject))
 	}
 }
 
@@ -94,50 +84,43 @@ func retryMessage(classified ClassifiedError) string {
 	subject := providerSubject(classified.Provider)
 	switch classified.Kind {
 	case codersdk.ChatErrorKindOverloaded:
-		return fmt.Sprintf("%s is temporarily overloaded.", subject)
+		return stringutil.Capitalize(fmt.Sprintf("%s is temporarily overloaded.", subject))
 	case codersdk.ChatErrorKindRateLimit:
-		return fmt.Sprintf("%s is rate limiting requests.", subject)
+		return stringutil.Capitalize(fmt.Sprintf("%s is rate limiting requests.", subject))
 	case codersdk.ChatErrorKindTimeout:
-		return fmt.Sprintf("%s is temporarily unavailable.", subject)
+		return stringutil.Capitalize(fmt.Sprintf("%s is temporarily unavailable.", subject))
 	case codersdk.ChatErrorKindStartupTimeout:
-		return fmt.Sprintf(
+		return stringutil.Capitalize(fmt.Sprintf(
 			"%s did not start responding in time.", subject,
-		)
+		))
 	case codersdk.ChatErrorKindAuth:
-		displayName := providerDisplayName(classified.Provider)
-		if displayName == "" {
-			displayName = "the AI provider"
-		}
 		return fmt.Sprintf(
-			"Authentication with %s failed.", displayName,
+			"Authentication with %s failed.", subject,
 		)
 	case codersdk.ChatErrorKindConfig:
-		return fmt.Sprintf(
+		return stringutil.Capitalize(fmt.Sprintf(
 			"%s rejected the model configuration.", subject,
-		)
+		))
 	case codersdk.ChatErrorKindMissingKey:
 		return "The API key for this conversation is no longer available."
 	case codersdk.ChatErrorKindProviderDisabled:
 		displayName := providerDisplayName(classified.Provider)
-		if displayName == "" {
-			displayName = "AI"
-		}
 		return fmt.Sprintf(
 			"The %s provider has been disabled by an administrator.",
 			displayName,
 		)
 	default:
-		return fmt.Sprintf(
+		return stringutil.Capitalize(fmt.Sprintf(
 			"%s returned an unexpected error.", subject,
-		)
+		))
 	}
 }
 
 func providerSubject(provider string) string {
-	if displayName := providerDisplayName(provider); displayName != "" {
+	if displayName := providerDisplayName(provider); displayName != "AI" && displayName != "" {
 		return displayName
 	}
-	return "The AI provider"
+	return "the AI provider"
 }
 
 func providerDisplayName(provider string) string {
@@ -159,7 +142,7 @@ func providerDisplayName(provider string) string {
 	case "vercel":
 		return "Vercel AI Gateway"
 	default:
-		return ""
+		return "AI"
 	}
 }
 

--- a/coderd/x/chatd/chaterror/message.go
+++ b/coderd/x/chatd/chaterror/message.go
@@ -59,11 +59,11 @@ func terminalMessage(classified ClassifiedError) string {
 			" Send your message again to continue."
 	case codersdk.ChatErrorKindProviderDisabled:
 		displayName := providerDisplayName(classified.Provider)
-		return stringutil.Capitalize(fmt.Sprintf(
+		return fmt.Sprintf(
 			"The %s provider has been disabled."+
 				" Contact your Coder administrator.",
 			displayName,
-		))
+		)
 	default:
 		if !classified.Retryable && classified.StatusCode == 0 {
 			return "The chat request failed unexpectedly."

--- a/coderd/x/chatd/chaterror/signals.go
+++ b/coderd/x/chatd/chaterror/signals.go
@@ -83,6 +83,7 @@ var (
 	}
 	genericRetryablePatterns = []string{"server error", "internal server error"}
 	interruptedPatterns      = []string{"chat interrupted", "request interrupted", "operation interrupted"}
+	providerDisabledPatterns = []string{"provider_disabled"}
 )
 
 func extractStatusCode(lower string) int {

--- a/coderd/x/chatd/chaterror/signals.go
+++ b/coderd/x/chatd/chaterror/signals.go
@@ -4,6 +4,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/coder/coder/v2/aibridge"
 )
 
 type providerHint struct {
@@ -83,7 +85,7 @@ var (
 	}
 	genericRetryablePatterns = []string{"server error", "internal server error"}
 	interruptedPatterns      = []string{"chat interrupted", "request interrupted", "operation interrupted"}
-	providerDisabledPatterns = []string{"provider_disabled"}
+	providerDisabledPatterns = []string{aibridge.ErrorCodeProviderDisabled}
 )
 
 func extractStatusCode(lower string) int {

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -1525,15 +1525,16 @@ type ChatStreamStatus struct {
 type ChatErrorKind string
 
 const (
-	ChatErrorKindGeneric        ChatErrorKind = "generic"
-	ChatErrorKindOverloaded     ChatErrorKind = "overloaded"
-	ChatErrorKindRateLimit      ChatErrorKind = "rate_limit"
-	ChatErrorKindTimeout        ChatErrorKind = "timeout"
-	ChatErrorKindStartupTimeout ChatErrorKind = "startup_timeout"
-	ChatErrorKindAuth           ChatErrorKind = "auth"
-	ChatErrorKindConfig         ChatErrorKind = "config"
-	ChatErrorKindUsageLimit     ChatErrorKind = "usage_limit"
-	ChatErrorKindMissingKey     ChatErrorKind = "missing_key"
+	ChatErrorKindGeneric          ChatErrorKind = "generic"
+	ChatErrorKindOverloaded       ChatErrorKind = "overloaded"
+	ChatErrorKindRateLimit        ChatErrorKind = "rate_limit"
+	ChatErrorKindTimeout          ChatErrorKind = "timeout"
+	ChatErrorKindStartupTimeout   ChatErrorKind = "startup_timeout"
+	ChatErrorKindAuth             ChatErrorKind = "auth"
+	ChatErrorKindConfig           ChatErrorKind = "config"
+	ChatErrorKindUsageLimit       ChatErrorKind = "usage_limit"
+	ChatErrorKindMissingKey       ChatErrorKind = "missing_key"
+	ChatErrorKindProviderDisabled ChatErrorKind = "provider_disabled"
 )
 
 // AllChatErrorKinds contains every ChatErrorKind value.
@@ -1548,6 +1549,7 @@ var AllChatErrorKinds = []ChatErrorKind{
 	ChatErrorKindConfig,
 	ChatErrorKindUsageLimit,
 	ChatErrorKindMissingKey,
+	ChatErrorKindProviderDisabled,
 }
 
 // ChatError represents a terminal chat error in persisted chat state or the

--- a/docs/reference/api/chats.md
+++ b/docs/reference/api/chats.md
@@ -292,13 +292,13 @@ Status Code **200**
 
 #### Enumerated Values
 
-| Property      | Value(s)                                                                                                            |
-|---------------|---------------------------------------------------------------------------------------------------------------------|
-| `client_type` | `api`, `ui`                                                                                                         |
-| `kind`        | `auth`, `config`, `generic`, `missing_key`, `overloaded`, `rate_limit`, `startup_timeout`, `timeout`, `usage_limit` |
-| `type`        | `context-file`, `file`, `file-reference`, `reasoning`, `skill`, `source`, `text`, `tool-call`, `tool-result`        |
-| `plan_mode`   | `plan`                                                                                                              |
-| `status`      | `completed`, `error`, `paused`, `pending`, `requires_action`, `running`, `waiting`                                  |
+| Property      | Value(s)                                                                                                                                 |
+|---------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| `client_type` | `api`, `ui`                                                                                                                              |
+| `kind`        | `auth`, `config`, `generic`, `missing_key`, `overloaded`, `provider_disabled`, `rate_limit`, `startup_timeout`, `timeout`, `usage_limit` |
+| `type`        | `context-file`, `file`, `file-reference`, `reasoning`, `skill`, `source`, `text`, `tool-call`, `tool-result`                             |
+| `plan_mode`   | `plan`                                                                                                                                   |
+| `status`      | `completed`, `error`, `paused`, `pending`, `requires_action`, `running`, `waiting`                                                       |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2681,9 +2681,9 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 #### Enumerated Values
 
-| Value(s)                                                                                                            |
-|---------------------------------------------------------------------------------------------------------------------|
-| `auth`, `config`, `generic`, `missing_key`, `overloaded`, `rate_limit`, `startup_timeout`, `timeout`, `usage_limit` |
+| Value(s)                                                                                                                                 |
+|------------------------------------------------------------------------------------------------------------------------------------------|
+| `auth`, `config`, `generic`, `missing_key`, `overloaded`, `provider_disabled`, `rate_limit`, `startup_timeout`, `timeout`, `usage_limit` |
 
 ## codersdk.ChatFileMetadata
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1961,6 +1961,7 @@ export type ChatErrorKind =
 	| "generic"
 	| "missing_key"
 	| "overloaded"
+	| "provider_disabled"
 	| "rate_limit"
 	| "startup_timeout"
 	| "timeout"
@@ -1972,6 +1973,7 @@ export const ChatErrorKinds: ChatErrorKind[] = [
 	"generic",
 	"missing_key",
 	"overloaded",
+	"provider_disabled",
 	"rate_limit",
 	"startup_timeout",
 	"timeout",

--- a/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.stories.tsx
@@ -295,7 +295,7 @@ export const TerminalProviderDisabledError: Story = {
 		liveStatus: buildLiveStatus({
 			streamError: {
 				kind: "provider_disabled",
-				message: "The OpenAI provider has been disabled by an administrator.",
+				message: "The OpenAI provider has been disabled. Contact your Coder administrator.",
 				provider: "openai",
 				retryable: false,
 				statusCode: 503,
@@ -309,7 +309,7 @@ export const TerminalProviderDisabledError: Story = {
 		).toBeVisible();
 		expect(
 			canvas.getByText(
-				/the openai provider has been disabled by an administrator/i,
+				/the openai provider has been disabled.*contact your coder administrator/i,
 			),
 		).toBeVisible();
 		expect(canvas.getByText(/^HTTP 503$/)).toBeVisible();

--- a/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.stories.tsx
@@ -295,7 +295,8 @@ export const TerminalProviderDisabledError: Story = {
 		liveStatus: buildLiveStatus({
 			streamError: {
 				kind: "provider_disabled",
-				message: "The OpenAI provider has been disabled. Contact your Coder administrator.",
+				message:
+					"The OpenAI provider has been disabled. Contact your Coder administrator.",
 				provider: "openai",
 				retryable: false,
 				statusCode: 503,

--- a/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.stories.tsx
@@ -288,6 +288,39 @@ export const TerminalStartupTimeoutError: Story = {
 	},
 };
 
+/** Disabled provider errors render an admin-oriented message without retry. */
+export const TerminalProviderDisabledError: Story = {
+	args: {
+		...defaultArgs,
+		liveStatus: buildLiveStatus({
+			streamError: {
+				kind: "provider_disabled",
+				message: "The OpenAI provider has been disabled by an administrator.",
+				provider: "openai",
+				retryable: false,
+				statusCode: 503,
+			},
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByRole("heading", { name: /provider disabled/i }),
+		).toBeVisible();
+		expect(
+			canvas.getByText(
+				/the openai provider has been disabled by an administrator/i,
+			),
+		).toBeVisible();
+		expect(canvas.getByText(/^HTTP 503$/)).toBeVisible();
+		// No retry or status link for administrative disablement.
+		expect(canvas.queryByText(/retrying/i)).not.toBeInTheDocument();
+		expect(
+			canvas.queryByRole("link", { name: /status/i }),
+		).not.toBeInTheDocument();
+	},
+};
+
 /** Generic failures do not show usage or provider CTAs. */
 export const GenericErrorDoesNotShowUsageAction: Story = {
 	args: {

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStatusHelpers.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStatusHelpers.ts
@@ -44,6 +44,8 @@ export const getErrorTitle = (
 			return "Usage limit reached";
 		case "missing_key":
 			return "Chat interrupted";
+		case "provider_disabled":
+			return "Provider disabled";
 		default:
 			return mode === "retry" ? "Retrying request" : "Request failed";
 	}

--- a/site/src/pages/AgentsPage/utils/usageLimitMessage.ts
+++ b/site/src/pages/AgentsPage/utils/usageLimitMessage.ts
@@ -11,9 +11,8 @@ type UsageLimitData = Partial<
 /**
  * Typed classification for errors surfaced in the agent detail view.
  * - "usage_limit": the user hit a spending cap (409 + valid usage data).
- * - other kinds come from normalized stream/provider failures such as
- *   "generic", "overloaded", "rate_limit", "timeout",
- *   "startup_timeout", "auth", "config", and "provider_disabled".
+ * - other kinds come from normalized stream/provider failures.
+ *   See ChatErrorKind for the full set.
  */
 export type ChatDetailError = {
 	message: string;

--- a/site/src/pages/AgentsPage/utils/usageLimitMessage.ts
+++ b/site/src/pages/AgentsPage/utils/usageLimitMessage.ts
@@ -13,7 +13,7 @@ type UsageLimitData = Partial<
  * - "usage_limit": the user hit a spending cap (409 + valid usage data).
  * - other kinds come from normalized stream/provider failures such as
  *   "generic", "overloaded", "rate_limit", "timeout",
- *   "startup_timeout", "auth", and "config".
+ *   "startup_timeout", "auth", "config", and "provider_disabled".
  */
 export type ChatDetailError = {
 	message: string;


### PR DESCRIPTION
Builds on top of https://github.com/coder/coder/pull/25794

Adds a new `provider_disabled` error classification in `chatd` with the corresponding plumbing to classify it as non-retryable. Also adds a story for how this particular error kind is displayed in the UI.