### PR TITLE
fix(cli): use quartz mock clock in PausedDuringWaitForReady test

### DIFF
--- a/cli/task_send_test.go
+++ b/cli/task_send_test.go
@@ -245,8 +245,15 @@ func Test_TaskSend(t *testing.T) {
 		pauseTask(setupCtx, t, setup.userClient, setup.task)
 		resumeTask(setupCtx, t, setup.userClient, setup.task)
 
+		// Set up mock clock and traps before starting the command.
+		// Without a mock clock the poll can race with the stop build
+		// and see a transient 'unknown' status instead of 'paused'.
+		mClock := quartz.NewMock(t)
+		tickTrap := mClock.Trap().NewTicker("task_send", "poll")
+		resetTrap := mClock.Trap().TickerReset("task_send", "poll")
+
 		// When: We attempt to send input to the initializing task.
-		inv, root := clitest.New(t, "task", "send", setup.task.Name, "some task input")
+		inv, root := clitest.NewWithClock(t, mClock, "task", "send", setup.task.Name, "some task input")
 		clitest.SetupConfig(t, setup.userClient, root)
 
 		ctx := testutil.Context(t, testutil.WaitLong)
@@ -259,10 +266,28 @@ func Test_TaskSend(t *testing.T) {
 		// of waitForTaskIdle.
 		pty.ExpectMatchContext(ctx, "Waiting for task to become idle")
 
+		// Wait for ticker creation and release it.
+		tickCall := tickTrap.MustWait(ctx)
+		tickCall.MustRelease(ctx)
+		tickTrap.Close()
+
+		// Fire the immediate first poll (time.Nanosecond initial interval).
+		// This poll sees 'initializing' because no agent is connected.
+		mClock.Advance(time.Nanosecond).MustWait(ctx)
+
+		// Wait for Reset (confirms first poll completed).
+		resetCall := resetTrap.MustWait(ctx)
+		resetCall.MustRelease(ctx)
+		resetTrap.Close()
+
 		// Pause the task while waitForTaskIdle is polling. Since
 		// no agent is connected, the task stays initializing until
 		// we pause it, at which point the status becomes paused.
 		pauseTask(ctx, t, setup.userClient, setup.task)
+
+		// Fire second poll at the regular 5s interval. The stop
+		// build has completed, so the poll sees 'paused'.
+		mClock.Advance(5 * time.Second).MustWait(ctx)
 
 		// Then: The command should fail because the task was paused.
 		err := w.Wait()


### PR DESCRIPTION
`PausedDuringWaitForReady` used the real clock, so the 5s poll in `waitForTaskIdle` could race with an in-flight stop build. The SQL view (`tasks_with_status`) returns `unknown` for stop builds with `job_status != 'succeeded'` because the `build_status` CASE has no branch for `(stop, pending)` or `(stop, running)`. On macOS CI, the poll fires during this transient window and hits `TaskStatusUnknown` instead of `TaskStatusPaused`.

Convert to the same quartz mock clock pattern that PR #25648 applied to `WaitsForWorkingAppState`: inject a mock clock via `NewWithClock`, trap ticker creation and reset, then advance time deterministically so the poll fires after the stop build completes.

Closes CODAGT-482

<details><summary>Investigation evidence</summary>

### Mechanism: transient `unknown` during stop builds

The `build_status` CASE expression in the `tasks_with_status` view only maps `(stop, succeeded)` to `paused`. In-flight stop builds (`stop, pending` / `stop, running`) fall to `ELSE 'unknown'`:

```sql
WHEN latest_build_raw.transition IN ('stop', 'delete')
     AND latest_build_raw.job_status = 'succeeded' THEN 'paused'
-- No branch for (stop, pending) or (stop, running)
ELSE 'unknown'
```

### Debugger session (dlv)

Breakpoint at `switch task.Status` (task_send.go:180), two hits in the same goroutine:

```
> [Breakpoint 1] cli.waitForTaskIdle() ./cli/task_send.go:180 (hits goroutine(3724):1 total:1)
=> 180:            switch task.Status {
(dlv) "initializing"

> [Breakpoint 1] cli.waitForTaskIdle() ./cli/task_send.go:180 (hits goroutine(3724):2 total:2)
=> 180:            switch task.Status {
(dlv) "unknown"
```

Poll 1 sees `initializing` (no agent), then `PauseTask` creates a stop build, and poll 2 sees `unknown` (stop build in flight).

### Coverage at bug site (pre-fix, single test)

```
COV   task_send.go:182   case TaskStatusInitializing: continue
COV   task_send.go:215   case TaskStatusPaused: return "was paused..."
UNCOV task_send.go:217   case TaskStatusUnknown: return "unknown state..."
```

The `Unknown` branch is never exercised when the test passes; it only fires when the poll races with the stop build.

### Race detector

All 13 `Test_TaskSend` subtests pass with `-race -count=1`.

</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻