### PR TITLE
fix(flake.nix): stop forcing musl biome binary in dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -295,14 +295,6 @@
               lib.optionalDrvAttr stdenv.isLinux "${glibcLocales}/lib/locale/locale-archive";
 
             NODE_OPTIONS = "--max-old-space-size=8192";
-            BIOME_BINARY =
-              if pkgs.stdenv.isLinux then
-                if pkgs.stdenv.hostPlatform.isAarch64 then
-                  "@biomejs/cli-linux-arm64-musl/biome"
-                else
-                  "@biomejs/cli-linux-x64-musl/biome"
-              else
-                "";
             GOPRIVATE = "coder.com,cdr.dev,go.coder.com,github.com/cdr,github.com/coder";
           };
         };


### PR DESCRIPTION
The nix-shell environment currently forces `BIOME_BINARY` to the musl Biome
package. On my Ubuntu 24.04 nix-shell, that breaks `pnpm exec biome` because
`pnpm install` only installs the host-matching glibc Biome package by default, so
the forced musl package path is missing even though the default glibc Biome
binary works when `BIOME_BINARY` is unset.

This change removes the unconditional musl override from `flake.nix` and lets
Biome use its normal platform resolution. I only verified this on Ubuntu 24.04 as
I do not have access to a Mac to test locally. I would appreciate a quick macOS
check by entering nix-shell and running `cd site && pnpm exec biome --version` to
confirm Biome still resolves and runs without any manual `BIOME_BINARY` override.

I considered the broader alternative of configuring pnpm to install both `current`
and `musl` libc variants. I rejected that for now because it widens install
behavior for the whole dependency graph, while the root cause here is Biome-
specific: only Biome is being forced to use the musl binary by `flake.nix`.
