### PR TITLE
fix(agent): install connstats callback at statsReporter creation

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -117,6 +117,9 @@ type Options struct {
 	ContextConfig                agentcontextconfig.Config
 	// DERPTLSConfig is an optional TLS config for DERP connections.
 	DERPTLSConfig *tls.Config
+	// StatsReportInterval is the interval for the connstats callback
+	// installed at statsReporter creation.
+	StatsReportInterval time.Duration
 }
 
 type Client interface {
@@ -183,6 +186,10 @@ func New(options Options) Agent {
 		options.Execer = agentexec.DefaultExecer
 	}
 
+	if options.StatsReportInterval == 0 {
+		options.StatsReportInterval = DefaultStatsReportInterval
+	}
+
 	if options.ListeningPortsGetter == nil {
 		options.ListeningPortsGetter = &osListeningPortsGetter{
 			cacheDuration: 1 * time.Second,
@@ -216,6 +223,7 @@ func New(options Options) Agent {
 			ignorePorts: maps.Clone(options.IgnorePorts),
 		},
 		reportMetadataInterval:             options.ReportMetadataInterval,
+		statsReportInterval:                options.StatsReportInterval,
 		announcementBannersRefreshInterval: options.ServiceBannerRefreshInterval,
 		sshMaxTimeout:                      options.SSHMaxTimeout,
 		subsystems:                         options.Subsystems,
@@ -289,6 +297,7 @@ type agent struct {
 	// values. Callers that need secrets must explicitly load this.
 	secrets                            atomic.Pointer[[]agentsdk.WorkspaceSecret]
 	reportMetadataInterval             time.Duration
+	statsReportInterval                time.Duration
 	scriptRunner                       *agentscripts.Runner
 	announcementBanners                atomic.Pointer[[]codersdk.BannerConfig] // announcementBanners is atomic because it is periodically updated.
 	announcementBannersRefreshInterval time.Duration
@@ -1500,7 +1509,7 @@ func (a *agent) createOrUpdateNetwork(manifestOK, networkOK *checkpoint) func(co
 			closing := a.closing
 			if !closing {
 				a.network = network
-				a.statsReporter = newStatsReporter(a.logger, network, a)
+				a.statsReporter = newStatsReporter(a.logger, network, a, a.statsReportInterval)
 			}
 			a.closeMutex.Unlock()
 			if closing {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -148,33 +148,11 @@ func TestAgent_Stats_SSH(t *testing.T) {
 			err = session.Shell()
 			require.NoError(t, err)
 
-			var s *proto.Stats
-			// We are looking for four different stats to be reported. They might not all
-			// arrive at the same time, so we loop until we've seen them all.
-			var connectionCountSeen, rxBytesSeen, txBytesSeen, sessionCountSSHSeen bool
-			require.Eventuallyf(t, func() bool {
-				var ok bool
-				s, ok = <-stats
-				if !ok {
-					return false
-				}
-				if s.ConnectionCount > 0 {
-					connectionCountSeen = true
-				}
-				if s.RxBytes > 0 {
-					rxBytesSeen = true
-				}
-				if s.TxBytes > 0 {
-					txBytesSeen = true
-				}
-				if s.SessionCountSsh == 1 {
-					sessionCountSSHSeen = true
-				}
-				return connectionCountSeen && rxBytesSeen && txBytesSeen && sessionCountSSHSeen
-			}, testutil.WaitLong, testutil.IntervalFast,
-				"never saw all stats: %+v, saw connectionCount: %t, rxBytes: %t, txBytes: %t, sessionCountSsh: %t",
-				s, connectionCountSeen, rxBytesSeen, txBytesSeen, sessionCountSSHSeen,
-			)
+			// Generate SSH traffic so the connstats window sees the session.
+			_, err = stdin.Write([]byte("echo test\n"))
+			require.NoError(t, err)
+
+			assertSSHStats(t, stats)
 			_, err = stdin.Write([]byte("exit 0\n"))
 			require.NoError(t, err, "writing exit to stdin")
 			_ = stdin.Close()
@@ -182,6 +160,92 @@ func TestAgent_Stats_SSH(t *testing.T) {
 			require.NoError(t, err, "waiting for session to exit")
 		})
 	}
+
+	// Regression test for CODAGT-517: the barrier blocks reportLoop's
+	// initial UpdateStats, so on unfixed code the connstats callback is
+	// never installed and handshake traffic is lost. On fixed code the
+	// callback is installed at creation, so traffic is captured.
+	t.Run("StatsCallbackRace", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		barrier := make(chan struct{})
+
+		//nolint:dogsled
+		conn, _, stats, _, _ := setupAgent(t, agentsdk.Manifest{}, 0,
+			func(c *agenttest.Client, _ *agent.Options) {
+				c.SetUpdateStatsOverride(func(
+					ctx context.Context,
+					req *proto.UpdateStatsRequest,
+					next func(context.Context, *proto.UpdateStatsRequest) (*proto.UpdateStatsResponse, error),
+				) (*proto.UpdateStatsResponse, error) {
+					if req.Stats == nil {
+						select {
+						case <-ctx.Done():
+							return nil, ctx.Err()
+						case <-barrier:
+						}
+					}
+					return next(ctx, req)
+				})
+			},
+		)
+
+		// Connect SSH while the barrier holds reportLoop blocked.
+		sshClient, err := conn.SSHClientOnPort(ctx, workspacesdk.AgentStandardSSHPort)
+		require.NoError(t, err)
+		defer sshClient.Close()
+		session, err := sshClient.NewSession()
+		require.NoError(t, err)
+		defer session.Close()
+		stdin, err := session.StdinPipe()
+		require.NoError(t, err)
+		err = session.Shell()
+		require.NoError(t, err)
+
+		// Shell must be idle so the only traffic is the SSH handshake.
+
+		close(barrier)
+
+		assertSSHStats(t, stats)
+		_, err = stdin.Write([]byte("exit 0\n"))
+		require.NoError(t, err, "writing exit to stdin")
+		_ = stdin.Close()
+		err = session.Wait()
+		require.NoError(t, err, "waiting for session to exit")
+	})
+}
+
+// assertSSHStats waits for ConnectionCount, RxBytes, TxBytes, and
+// SessionCountSsh to be nonzero on the stats channel.
+func assertSSHStats(t *testing.T, stats <-chan *proto.Stats) {
+	t.Helper()
+	var connectionCountSeen, rxBytesSeen, txBytesSeen, sessionCountSSHSeen bool
+	require.Eventuallyf(t, func() bool {
+		s, ok := <-stats
+		if !ok {
+			return false
+		}
+		t.Logf("got stats: ConnectionCount=%d, RxBytes=%d, TxBytes=%d, SessionCountSsh=%d",
+			s.ConnectionCount, s.RxBytes, s.TxBytes, s.SessionCountSsh)
+		if s.ConnectionCount > 0 {
+			connectionCountSeen = true
+		}
+		if s.RxBytes > 0 {
+			rxBytesSeen = true
+		}
+		if s.TxBytes > 0 {
+			txBytesSeen = true
+		}
+		if s.SessionCountSsh == 1 {
+			sessionCountSSHSeen = true
+		}
+		return connectionCountSeen && rxBytesSeen && txBytesSeen && sessionCountSSHSeen
+	}, testutil.WaitLong, testutil.IntervalFast,
+		"never saw all SSH stats",
+	)
 }
 
 func TestAgent_Stats_ReconnectingPTY(t *testing.T) {
@@ -3851,6 +3915,7 @@ func setupAgentWithSecrets(t testing.TB, metadata agentsdk.Manifest, secrets []a
 		Logger:                 logger.Named("agent"),
 		ReconnectingPTYTimeout: ptyTimeout,
 		EnvironmentVariables:   map[string]string{},
+		StatsReportInterval:    agenttest.StatsInterval,
 	}
 
 	for _, opt := range opts {

--- a/agent/agenttest/client.go
+++ b/agent/agenttest/client.go
@@ -32,7 +32,8 @@ import (
 	"github.com/coder/websocket"
 )
 
-const statsInterval = 500 * time.Millisecond
+// StatsInterval is the report interval returned by FakeAgentAPI.UpdateStats.
+const StatsInterval = 500 * time.Millisecond
 
 func NewClient(t testing.TB,
 	logger slog.Logger,
@@ -126,6 +127,17 @@ func (c *Client) RefreshToken(context.Context) error {
 	defer c.mu.Unlock()
 	c.refreshTokenCalls++
 	return nil
+}
+
+// SetUpdateStatsOverride sets a function that wraps UpdateStats calls.
+// The provided function receives a next callback for the default behavior.
+func (c *Client) SetUpdateStatsOverride(fn func(
+	ctx context.Context,
+	req *agentproto.UpdateStatsRequest,
+	next func(context.Context, *agentproto.UpdateStatsRequest) (*agentproto.UpdateStatsResponse, error),
+) (*agentproto.UpdateStatsResponse, error),
+) {
+	c.fakeAgentAPI.SetUpdateStatsOverride(fn)
 }
 
 func (c *Client) GetNumRefreshTokenCalls() int {
@@ -246,6 +258,11 @@ type FakeAgentAPI struct {
 	subAgentDisplayApps map[uuid.UUID][]agentproto.CreateSubAgentRequest_DisplayApp
 	subAgentApps        map[uuid.UUID][]*agentproto.CreateSubAgentRequest_App
 
+	updateStatsOverride func(
+		ctx context.Context,
+		req *agentproto.UpdateStatsRequest,
+		next func(context.Context, *agentproto.UpdateStatsRequest) (*agentproto.UpdateStatsResponse, error),
+	) (*agentproto.UpdateStatsResponse, error)
 	getAnnouncementBannersFunc              func() ([]codersdk.BannerConfig, error)
 	getResourcesMonitoringConfigurationFunc func() (*agentproto.GetResourcesMonitoringConfigurationResponse, error)
 	pushResourcesMonitoringUsageFunc        func(*agentproto.PushResourcesMonitoringUsageRequest) (*agentproto.PushResourcesMonitoringUsageResponse, error)
@@ -320,8 +337,26 @@ func (f *FakeAgentAPI) PushResourcesMonitoringUsage(_ context.Context, req *agen
 	return f.pushResourcesMonitoringUsageFunc(req)
 }
 
+func (f *FakeAgentAPI) SetUpdateStatsOverride(fn func(
+	ctx context.Context,
+	req *agentproto.UpdateStatsRequest,
+	next func(context.Context, *agentproto.UpdateStatsRequest) (*agentproto.UpdateStatsResponse, error),
+) (*agentproto.UpdateStatsResponse, error),
+) {
+	f.Lock()
+	defer f.Unlock()
+	f.updateStatsOverride = fn
+}
+
 func (f *FakeAgentAPI) UpdateStats(ctx context.Context, req *agentproto.UpdateStatsRequest) (*agentproto.UpdateStatsResponse, error) {
 	f.logger.Debug(ctx, "update stats called", slog.F("req", req))
+	if f.updateStatsOverride != nil {
+		return f.updateStatsOverride(ctx, req, f.updateStatsDefault)
+	}
+	return f.updateStatsDefault(ctx, req)
+}
+
+func (f *FakeAgentAPI) updateStatsDefault(ctx context.Context, req *agentproto.UpdateStatsRequest) (*agentproto.UpdateStatsResponse, error) {
 	// empty request is sent to get the interval; but our tests don't want empty stats requests
 	if req.Stats != nil {
 		select {
@@ -331,7 +366,7 @@ func (f *FakeAgentAPI) UpdateStats(ctx context.Context, req *agentproto.UpdateSt
 			// OK!
 		}
 	}
-	return &agentproto.UpdateStatsResponse{ReportInterval: durationpb.New(statsInterval)}, nil
+	return &agentproto.UpdateStatsResponse{ReportInterval: durationpb.New(StatsInterval)}, nil
 }
 
 func (f *FakeAgentAPI) GetLifecycleStates() []codersdk.WorkspaceAgentLifecycle {

--- a/agent/stats.go
+++ b/agent/stats.go
@@ -42,13 +42,22 @@ type statsReporter struct {
 	logger    slog.Logger
 }
 
-func newStatsReporter(logger slog.Logger, source networkStatsSource, collector statsCollector) *statsReporter {
-	return &statsReporter{
-		Cond:      sync.NewCond(&sync.Mutex{}),
-		logger:    logger,
-		source:    source,
-		collector: collector,
+// DefaultStatsReportInterval matches coderd.Options.AgentStatsRefreshInterval.
+const DefaultStatsReportInterval = 5 * time.Minute
+
+func newStatsReporter(logger slog.Logger, source networkStatsSource, collector statsCollector, interval time.Duration) *statsReporter {
+	s := &statsReporter{
+		Cond:         sync.NewCond(&sync.Mutex{}),
+		logger:       logger,
+		source:       source,
+		collector:    collector,
+		lastInterval: interval,
 	}
+	// Install the callback immediately so traffic is tracked before
+	// reportLoop starts. reportLoop replaces it only if the
+	// server-negotiated interval differs.
+	source.SetConnStatsCallback(interval, maxConns, s.callback)
+	return s
 }
 
 func (s *statsReporter) callback(_, _ time.Time, virtual, _ map[netlogtype.Connection]netlogtype.Counts) {
@@ -67,8 +76,10 @@ func (s *statsReporter) callback(_, _ time.Time, virtual, _ map[netlogtype.Conne
 	s.Broadcast()
 }
 
-// reportLoop programs the source (tailnet.Conn) to send it stats via the
-// callback, then reports them to the dest.
+// reportLoop reports collected stats to the server.
+//
+// The connstats callback is already installed by newStatsReporter;
+// reportLoop only replaces it if the server returns a different interval.
 //
 // It's intended to be called within the larger retry loop that establishes a
 // connection to the agent API, then passes that connection to go routines like
@@ -80,8 +91,11 @@ func (s *statsReporter) reportLoop(ctx context.Context, dest statsDest) error {
 	if err != nil {
 		return xerrors.Errorf("initial update: %w", err)
 	}
-	s.lastInterval = resp.ReportInterval.AsDuration()
-	s.source.SetConnStatsCallback(s.lastInterval, maxConns, s.callback)
+	interval := resp.ReportInterval.AsDuration()
+	if interval != s.lastInterval {
+		s.lastInterval = interval
+		s.source.SetConnStatsCallback(s.lastInterval, maxConns, s.callback)
+	}
 
 	// use a separate goroutine to monitor the context so that we notice immediately, rather than
 	// waiting for the next callback (which might never come if we are closing!)

--- a/agent/stats_internal_test.go
+++ b/agent/stats_internal_test.go
@@ -23,7 +23,9 @@ func TestStatsReporter(t *testing.T) {
 	fSource := newFakeNetworkStatsSource(ctx, t)
 	fCollector := newFakeCollector(t)
 	fDest := newFakeStatsDest()
-	uut := newStatsReporter(logger, fSource, fCollector)
+	uut := newStatsReporter(logger, fSource, fCollector, DefaultStatsReportInterval)
+
+	_ = testutil.TryReceive(ctx, t, fSource.period) // drain construction-time install
 
 	loopErr := make(chan error, 1)
 	loopCtx, loopCancel := context.WithCancel(ctx)
@@ -157,7 +159,7 @@ func newFakeNetworkStatsSource(ctx context.Context, t testing.TB) *fakeNetworkSt
 	f := &fakeNetworkStatsSource{
 		ctx:    ctx,
 		t:      t,
-		period: make(chan time.Duration),
+		period: make(chan time.Duration, 1),
 	}
 	return f
 }


### PR DESCRIPTION
## Problem

The stats reporter only installed the connstats callback on the TUN device after the report loop negotiated an interval with the server via `UpdateStats`. Traffic that flowed before that point (e.g. an SSH handshake) was silently dropped because the TUN wrapper's `stats.Load()` returned nil. On macOS CI under scheduler pressure, this window was wide enough for the entire SSH handshake to complete untracked, leaving `ConnectionCount`/`RxBytes`/`TxBytes` at zero permanently (disco pings from `Collect` use the physical layer, not the virtual TUN layer).

Controlled reproduction (barrier-blocked `UpdateStats`, SSH handshake completes before `SetConnStatsCallback`):

```
report 0: ConnectionCount=0 RxBytes=0 TxBytes=0 SessionCountSsh=1
report 1: ConnectionCount=0 RxBytes=0 TxBytes=0 SessionCountSsh=1
...
report 9: ConnectionCount=0 RxBytes=0 TxBytes=0 SessionCountSsh=1
never saw all four stats conditions met in 10 reports
```

Baseline (no barrier): `ConnectionCount=2 RxBytes=4068 TxBytes=4329 SessionCountSsh=1` on report 0.

## Fix

Two production changes in `agent/stats.go`:

**1. Install the connstats callback at construction (`newStatsReporter`), not in `reportLoop`.**

`newStatsReporter` now calls `source.SetConnStatsCallback(interval, maxConns, s.callback)` immediately, using the interval from `agent.Options.StatsReportInterval`. The default (`DefaultStatsReportInterval = 5 * time.Minute`) matches the server-side default (`coderd.Options.AgentStatsRefreshInterval`). This ensures the TUN device tracks traffic from the moment the network is created, before `reportLoop` even starts.

**2. `reportLoop` now only replaces the callback when the server-negotiated interval differs (`stats.go:99-102`).**

Previously, `reportLoop` unconditionally called `SetConnStatsCallback` on every connect. Now it compares the server's interval against `s.lastInterval` (set at construction) and skips the call when they match. This is safe because:

- The connstats tracker (`connstats.Statistics`) has no connection-specific state. It accumulates `netlogtype.Counts` keyed by `(proto, src, dst)` tuples, which are the same regardless of when the tracker was installed.
- Counts accumulate correctly across reconnections. The `callback` method (line 69) merges incoming virtual stats into `s.networkStats` using `Add()`, and `reportLocked` drains them on each report cycle. No data is lost if the tracker persists across a reconnect.
- When replacement does happen (server returns a different interval), `SetStatistics` in `tailnet/conn.go` atomically swaps the tracker. The old tracker's `Shutdown()` method calls `extract()` which calls `dump()` (the callback), flushing any accumulated data before the new tracker takes over. So even on interval mismatch, no data is lost.

On the common path (server default matches `DefaultStatsReportInterval`), this eliminates one unnecessary `SetConnStatsCallback` call per connect. Tests set `StatsReportInterval` to `agenttest.StatsInterval` (500ms) to match the fake server, also avoiding replacement.

## Test changes

- `TestAgent_Stats_SSH` port loop: added `echo test\n` write to generate traffic that survives across stats windows.
- `assertSSHStats` helper: extracted the SSH stats assertion loop (used by port tests and `StatsCallbackRace`).
- `StatsCallbackRace` subtest: uses a channel barrier to block `reportLoop`'s initial `UpdateStats` while SSH connects. On fixed code the callback is pre-installed (PASS). On unfixed code traffic is lost (FAIL).

```
# Red (production fix reverted, test kept):
$ go test ./agent -run 'TestAgent_Stats_SSH/StatsCallbackRace' -count=1 -timeout 60s
    Error:      Condition never satisfied
--- FAIL: TestAgent_Stats_SSH/StatsCallbackRace (25.60s)
FAIL

# Green (production fix applied):
$ go test -race ./agent -run 'TestAgent_Stats_SSH' -count=1 -timeout 120s
--- PASS: TestAgent_Stats_SSH/(:1) (2.54s)
--- PASS: TestAgent_Stats_SSH/(:22) (3.33s)
--- PASS: TestAgent_Stats_SSH/StatsCallbackRace (3.45s)
PASS
```

Fixes flaky `TestAgent_Stats_SSH`, `TestAgent_Stats_ReconnectingPTY`, and `TestAgent_Stats_Magic`.

Closes coder/internal#505
Closes CODAGT-517

<details><summary>Investigation evidence</summary>

dlv session at `tailnet/conn.go:832` (`SetStatistics` call) confirmed the state when the callback is first installed:

```
(dlv) locals
connStats = (*connstats.Statistics)(0x6b56d2ac420)
old = *connstats.Statistics nil    <-- no prior stats tracker

(dlv) print connStats
*connstats.Statistics {
    maxConns: 2048,
    connCnts: connCnts {
        virtual: map[...] nil,     <-- fresh, no data
        physical: map[...] nil,
    }, ...}
```

`old = nil` proves this is the first `SetStatistics` call. `virtual: nil` proves the new tracker starts with empty counters. All SSH handshake traffic that flowed before this point was silently dropped.

Single-test coverage showed the `callback` accumulation branch at 77.8% (never hit), confirming the test depends on the first stats window capturing all traffic with no recovery path.

All four reported CI failures were macOS-only (`/Users/runner/`): coder/internal #504, #505, #548, #953.

</details>

> 🤖 Generated by Coder Agents
