### PR TITLE
fix: isolate MCP HTTP transports from DefaultTransport in tests

### DIFF
--- a/agent/x/agentmcp/manager.go
+++ b/agent/x/agentmcp/manager.go
@@ -975,15 +975,19 @@ func (m *Manager) createTransport(ctx context.Context, cfg ServerConfig) (transp
 			}),
 		), nil
 	case "http", "":
-		return transport.NewStreamableHTTP(
-			cfg.URL,
-			transport.WithHTTPHeaders(cfg.Headers),
-		)
+		var opts []transport.StreamableHTTPCOption
+		opts = append(opts, transport.WithHTTPHeaders(cfg.Headers))
+		if c := mcpHTTPClient(); c != nil {
+			opts = append(opts, transport.WithHTTPBasicClient(c))
+		}
+		return transport.NewStreamableHTTP(cfg.URL, opts...)
 	case "sse":
-		return transport.NewSSE(
-			cfg.URL,
-			transport.WithHeaders(cfg.Headers),
-		)
+		var sseOpts []transport.ClientOption
+		sseOpts = append(sseOpts, transport.WithHeaders(cfg.Headers))
+		if c := mcpHTTPClient(); c != nil {
+			sseOpts = append(sseOpts, transport.WithHTTPClient(c))
+		}
+		return transport.NewSSE(cfg.URL, sseOpts...)
 	default:
 		return nil, xerrors.Errorf("unsupported transport %q", cfg.Transport)
 	}

--- a/agent/x/agentmcp/mcphttpclient.go
+++ b/agent/x/agentmcp/mcphttpclient.go
@@ -1,0 +1,25 @@
+package agentmcp
+
+import (
+	"net/http"
+	"testing"
+)
+
+// mcpHTTPClient returns an isolated *http.Client when running
+// inside tests, or nil for production. During tests,
+// httptest.Server.Close() calls
+// http.DefaultTransport.CloseIdleConnections(), which disrupts
+// any MCP client sharing that transport. When DefaultTransport
+// is a *http.Transport it is cloned; otherwise a minimal
+// transport with ProxyFromEnvironment is created as a fallback.
+func mcpHTTPClient() *http.Client {
+	if !testing.Testing() {
+		return nil
+	}
+	if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+		return &http.Client{Transport: dt.Clone()}
+	}
+	return &http.Client{Transport: &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+	}}
+}

--- a/aibridge/mcp/mcphttpclient.go
+++ b/aibridge/mcp/mcphttpclient.go
@@ -1,0 +1,25 @@
+package mcp
+
+import (
+	"net/http"
+	"testing"
+)
+
+// mcpHTTPClient returns an isolated *http.Client when running
+// inside tests, or nil for production. During tests,
+// httptest.Server.Close() calls
+// http.DefaultTransport.CloseIdleConnections(), which disrupts
+// any MCP client sharing that transport. When DefaultTransport
+// is a *http.Transport it is cloned; otherwise a minimal
+// transport with ProxyFromEnvironment is created as a fallback.
+func mcpHTTPClient() *http.Client {
+	if !testing.Testing() {
+		return nil
+	}
+	if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+		return &http.Client{Transport: dt.Clone()}
+	}
+	return &http.Client{Transport: &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+	}}
+}

--- a/aibridge/mcp/proxy_streamable_http.go
+++ b/aibridge/mcp/proxy_streamable_http.go
@@ -39,6 +39,17 @@ func NewStreamableHTTPServerProxy(serverName, serverURL string, headers map[stri
 		opts = append(opts, transport.WithHTTPHeaders(headers))
 	}
 
+	// Prepend an isolated HTTP client when running in tests so
+	// httptest.Server.Close() does not disrupt this proxy's
+	// connections via http.DefaultTransport.CloseIdleConnections().
+	// Caller-provided WithHTTPBasicClient in opts overrides this
+	// (last-wins).
+	if c := mcpHTTPClient(); c != nil {
+		opts = append([]transport.StreamableHTTPCOption{
+			transport.WithHTTPBasicClient(c),
+		}, opts...)
+	}
+
 	mcpClient, err := client.NewStreamableHttpClient(serverURL, opts...)
 	if err != nil {
 		return nil, xerrors.Errorf("create streamable http client: %w", err)

--- a/coderd/mcp/mcp_e2e_test.go
+++ b/coderd/mcp/mcp_e2e_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/uuid"
@@ -57,11 +58,10 @@ func TestMCPHTTP_E2E_ClientIntegration(t *testing.T) {
 	mcpURL := api.AccessURL.String() + mcpserver.MCPEndpoint
 
 	// Configure client with authentication headers using RFC 6750 Bearer token
-	mcpClient, err := mcpclient.NewStreamableHttpClient(mcpURL,
+	mcpClient := newIsolatedMCPClient(t, mcpURL,
 		transport.WithHTTPHeaders(map[string]string{
 			"Authorization": "Bearer " + coderClient.SessionToken(),
 		}))
-	require.NoError(t, err)
 	defer func() {
 		if closeErr := mcpClient.Close(); closeErr != nil {
 			t.Logf("Failed to close MCP client: %v", closeErr)
@@ -72,7 +72,7 @@ func TestMCPHTTP_E2E_ClientIntegration(t *testing.T) {
 	defer cancel()
 
 	// Start client
-	err = mcpClient.Start(ctx)
+	err := mcpClient.Start(ctx)
 	require.NoError(t, err)
 
 	// Initialize connection
@@ -190,8 +190,7 @@ func TestMCPHTTP_E2E_UnauthenticatedAccess(t *testing.T) {
 	require.Equal(t, http.StatusUnauthorized, resp.StatusCode, "Should get HTTP 401 for unauthenticated access")
 
 	// Also test with MCP client to ensure it handles the error gracefully
-	mcpClient, err := mcpclient.NewStreamableHttpClient(mcpURL)
-	require.NoError(t, err, "Should be able to create MCP client without authentication")
+	mcpClient := newIsolatedMCPClient(t, mcpURL)
 	defer func() {
 		if closeErr := mcpClient.Close(); closeErr != nil {
 			t.Logf("Failed to close MCP client: %v", closeErr)
@@ -245,11 +244,10 @@ func TestMCPHTTP_E2E_ToolWithWorkspace(t *testing.T) {
 	coderdtest.NewWorkspaceAgentWaiter(t, coderClient, r.Workspace.ID).Wait()
 
 	mcpURL := api.AccessURL.String() + mcpserver.MCPEndpoint
-	mcpClient, err := mcpclient.NewStreamableHttpClient(mcpURL,
+	mcpClient := newIsolatedMCPClient(t, mcpURL,
 		transport.WithHTTPHeaders(map[string]string{
 			"Authorization": "Bearer " + coderClient.SessionToken(),
 		}))
-	require.NoError(t, err)
 	defer func() {
 		if closeErr := mcpClient.Close(); closeErr != nil {
 			t.Logf("Failed to close MCP client: %v", closeErr)
@@ -260,7 +258,7 @@ func TestMCPHTTP_E2E_ToolWithWorkspace(t *testing.T) {
 	defer cancel()
 
 	require.NoError(t, mcpClient.Start(ctx))
-	_, err = mcpClient.Initialize(ctx, mcp.InitializeRequest{
+	_, err := mcpClient.Initialize(ctx, mcp.InitializeRequest{
 		Params: mcp.InitializeParams{
 			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
 			ClientInfo: mcp.Implementation{
@@ -307,11 +305,10 @@ func TestMCPHTTP_E2E_ErrorHandling(t *testing.T) {
 
 	// Create MCP client
 	mcpURL := api.AccessURL.String() + mcpserver.MCPEndpoint
-	mcpClient, err := mcpclient.NewStreamableHttpClient(mcpURL,
+	mcpClient := newIsolatedMCPClient(t, mcpURL,
 		transport.WithHTTPHeaders(map[string]string{
 			"Authorization": "Bearer " + coderClient.SessionToken(),
 		}))
-	require.NoError(t, err)
 	defer func() {
 		if closeErr := mcpClient.Close(); closeErr != nil {
 			t.Logf("Failed to close MCP client: %v", closeErr)
@@ -322,7 +319,7 @@ func TestMCPHTTP_E2E_ErrorHandling(t *testing.T) {
 	defer cancel()
 
 	// Start and initialize client
-	err = mcpClient.Start(ctx)
+	err := mcpClient.Start(ctx)
 	require.NoError(t, err)
 
 	initReq := mcp.InitializeRequest{
@@ -366,11 +363,10 @@ func TestMCPHTTP_E2E_ConcurrentRequests(t *testing.T) {
 
 	// Create MCP client
 	mcpURL := api.AccessURL.String() + mcpserver.MCPEndpoint
-	mcpClient, err := mcpclient.NewStreamableHttpClient(mcpURL,
+	mcpClient := newIsolatedMCPClient(t, mcpURL,
 		transport.WithHTTPHeaders(map[string]string{
 			"Authorization": "Bearer " + coderClient.SessionToken(),
 		}))
-	require.NoError(t, err)
 	defer func() {
 		if closeErr := mcpClient.Close(); closeErr != nil {
 			t.Logf("Failed to close MCP client: %v", closeErr)
@@ -381,7 +377,7 @@ func TestMCPHTTP_E2E_ConcurrentRequests(t *testing.T) {
 	defer cancel()
 
 	// Start and initialize client
-	err = mcpClient.Start(ctx)
+	err := mcpClient.Start(ctx)
 	require.NoError(t, err)
 
 	initReq := mcp.InitializeRequest{
@@ -520,11 +516,10 @@ func TestMCPHTTP_E2E_OAuth2_EndToEnd(t *testing.T) {
 		sessionToken := coderClient.SessionToken()
 
 		mcpURL := api.AccessURL.String() + mcpserver.MCPEndpoint
-		mcpClient, err := mcpclient.NewStreamableHttpClient(mcpURL,
+		mcpClient := newIsolatedMCPClient(t, mcpURL,
 			transport.WithHTTPHeaders(map[string]string{
 				"Authorization": "Bearer " + sessionToken,
 			}))
-		require.NoError(t, err)
 		defer func() {
 			if closeErr := mcpClient.Close(); closeErr != nil {
 				t.Logf("Failed to close MCP client: %v", closeErr)
@@ -669,11 +664,10 @@ func TestMCPHTTP_E2E_OAuth2_EndToEnd(t *testing.T) {
 
 		// Step 3: Use access token to authenticate with MCP endpoint
 		mcpURL := api.AccessURL.String() + mcpserver.MCPEndpoint
-		mcpClient, err := mcpclient.NewStreamableHttpClient(mcpURL,
+		mcpClient := newIsolatedMCPClient(t, mcpURL,
 			transport.WithHTTPHeaders(map[string]string{
 				"Authorization": "Bearer " + accessToken,
 			}))
-		require.NoError(t, err)
 		defer func() {
 			if closeErr := mcpClient.Close(); closeErr != nil {
 				t.Logf("Failed to close MCP client: %v", closeErr)
@@ -762,11 +756,10 @@ func TestMCPHTTP_E2E_OAuth2_EndToEnd(t *testing.T) {
 		t.Logf("Successfully refreshed token: %s...", newAccessToken[:10])
 
 		// Step 5: Use new access token to create another MCP connection
-		newMcpClient, err := mcpclient.NewStreamableHttpClient(mcpURL,
+		newMcpClient := newIsolatedMCPClient(t, mcpURL,
 			transport.WithHTTPHeaders(map[string]string{
 				"Authorization": "Bearer " + newAccessToken,
 			}))
-		require.NoError(t, err)
 		defer func() {
 			if closeErr := newMcpClient.Close(); closeErr != nil {
 				t.Logf("Failed to close new MCP client: %v", closeErr)
@@ -990,11 +983,10 @@ func TestMCPHTTP_E2E_OAuth2_EndToEnd(t *testing.T) {
 		t.Logf("Successfully obtained access token: %s...", accessToken[:10])
 
 		// Step 5: Use access token to get user information via MCP
-		mcpClient, err := mcpclient.NewStreamableHttpClient(mcpURL,
+		mcpClient := newIsolatedMCPClient(t, mcpURL,
 			transport.WithHTTPHeaders(map[string]string{
 				"Authorization": "Bearer " + accessToken,
 			}))
-		require.NoError(t, err)
 		defer func() {
 			if closeErr := mcpClient.Close(); closeErr != nil {
 				t.Logf("Failed to close MCP client: %v", closeErr)
@@ -1088,11 +1080,10 @@ func TestMCPHTTP_E2E_OAuth2_EndToEnd(t *testing.T) {
 		t.Logf("Successfully refreshed token: %s...", newAccessToken[:10])
 
 		// Step 7: Use refreshed token to get user information again via MCP
-		newMcpClient, err := mcpclient.NewStreamableHttpClient(mcpURL,
+		newMcpClient := newIsolatedMCPClient(t, mcpURL,
 			transport.WithHTTPHeaders(map[string]string{
 				"Authorization": "Bearer " + newAccessToken,
 			}))
-		require.NoError(t, err)
 		defer func() {
 			if closeErr := newMcpClient.Close(); closeErr != nil {
 				t.Logf("Failed to close new MCP client: %v", closeErr)
@@ -1268,11 +1259,10 @@ func TestMCPHTTP_E2E_ChatGPTEndpoint(t *testing.T) {
 	mcpURL := api.AccessURL.String() + mcpserver.MCPEndpoint + "?toolset=chatgpt"
 
 	// Configure client with authentication headers using RFC 6750 Bearer token
-	mcpClient, err := mcpclient.NewStreamableHttpClient(mcpURL,
+	mcpClient := newIsolatedMCPClient(t, mcpURL,
 		transport.WithHTTPHeaders(map[string]string{
 			"Authorization": "Bearer " + coderClient.SessionToken(),
 		}))
-	require.NoError(t, err)
 	t.Cleanup(func() {
 		if closeErr := mcpClient.Close(); closeErr != nil {
 			t.Logf("Failed to close MCP client: %v", closeErr)
@@ -1283,7 +1273,7 @@ func TestMCPHTTP_E2E_ChatGPTEndpoint(t *testing.T) {
 	defer cancel()
 
 	// Start client
-	err = mcpClient.Start(ctx)
+	err := mcpClient.Start(ctx)
 	require.NoError(t, err)
 
 	// Initialize connection
@@ -1433,11 +1423,10 @@ func TestMCPHTTP_E2E_WorkspaceSSHAuthz(t *testing.T) {
 
 	// Connect with the template-admin user.
 	mcpURL := api.AccessURL.String() + mcpserver.MCPEndpoint
-	mcpClient, err := mcpclient.NewStreamableHttpClient(mcpURL,
+	mcpClient := newIsolatedMCPClient(t, mcpURL,
 		transport.WithHTTPHeaders(map[string]string{
 			"Authorization": "Bearer " + tmplAdminClient.SessionToken(),
 		}))
-	require.NoError(t, err)
 	defer func() {
 		_ = mcpClient.Close()
 	}()
@@ -1446,7 +1435,7 @@ func TestMCPHTTP_E2E_WorkspaceSSHAuthz(t *testing.T) {
 	defer cancel()
 
 	require.NoError(t, mcpClient.Start(ctx))
-	_, err = mcpClient.Initialize(ctx, mcp.InitializeRequest{
+	_, err := mcpClient.Initialize(ctx, mcp.InitializeRequest{
 		Params: mcp.InitializeParams{
 			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
 			ClientInfo: mcp.Implementation{
@@ -1488,4 +1477,92 @@ func mustParseURL(t *testing.T, rawURL string) *url.URL {
 	u, err := url.Parse(rawURL)
 	require.NoError(t, err, "Failed to parse URL %q", rawURL)
 	return u
+}
+
+// newIsolatedMCPClient creates a streamable HTTP MCP client that uses
+// an isolated http.Transport cloned from http.DefaultTransport.
+// This prevents httptest.Server.Close() (which calls
+// http.DefaultTransport.CloseIdleConnections()) from disrupting the
+// client's connections during parallel tests.
+func newIsolatedMCPClient(t *testing.T, mcpURL string, opts ...transport.StreamableHTTPCOption) *mcpclient.Client {
+	t.Helper()
+	isolated := coderdtest.NewIsolatedHTTPClient(nil)
+	opts = append([]transport.StreamableHTTPCOption{transport.WithHTTPBasicClient(isolated)}, opts...)
+	client, err := mcpclient.NewStreamableHttpClient(mcpURL, opts...)
+	require.NoError(t, err)
+	return client
+}
+
+// sentinelTransport wraps an http.RoundTripper and counts how many
+// requests flow through it. Used as a test sentinel to verify
+// whether a client is (or is not) using http.DefaultTransport.
+type sentinelTransport struct {
+	inner http.RoundTripper
+	hits  atomic.Int64
+}
+
+func (s *sentinelTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	s.hits.Add(1)
+	return s.inner.RoundTrip(req)
+}
+
+// TestMCPHTTP_E2E_TransportIsolation verifies that the
+// newIsolatedMCPClient helper creates clients that do NOT route
+// requests through http.DefaultTransport, while raw
+// mcpclient.NewStreamableHttpClient (without explicit
+// WithHTTPBasicClient) does use it.
+//
+//nolint:paralleltest // Mutates http.DefaultTransport.
+func TestMCPHTTP_E2E_TransportIsolation(t *testing.T) {
+	// Replace DefaultTransport with a counting sentinel.
+	original := http.DefaultTransport
+	sentinel := &sentinelTransport{inner: original}
+	http.DefaultTransport = sentinel
+	t.Cleanup(func() { http.DefaultTransport = original })
+
+	coderClient, closer, api := coderdtest.NewWithAPI(t, nil)
+	t.Cleanup(func() { closer.Close() })
+	_ = coderdtest.CreateFirstUser(t, coderClient)
+
+	mcpURL := api.AccessURL.String() + mcpserver.MCPEndpoint
+	authOpt := transport.WithHTTPHeaders(map[string]string{
+		"Authorization": "Bearer " + coderClient.SessionToken(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	defer cancel()
+
+	initReq := mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+			ClientInfo:      mcp.Implementation{Name: "sentinel-test", Version: "1.0.0"},
+		},
+	}
+
+	t.Run("RawClientUsesDefaultTransport", func(t *testing.T) {
+		sentinel.hits.Store(0)
+		rawClient, err := mcpclient.NewStreamableHttpClient(mcpURL, authOpt)
+		require.NoError(t, err)
+		defer func() { _ = rawClient.Close() }()
+
+		require.NoError(t, rawClient.Start(ctx))
+		_, err = rawClient.Initialize(ctx, initReq)
+		require.NoError(t, err)
+
+		require.Greater(t, sentinel.hits.Load(), int64(0),
+			"raw client should route requests through http.DefaultTransport")
+	})
+
+	t.Run("IsolatedClientBypassesDefaultTransport", func(t *testing.T) {
+		sentinel.hits.Store(0)
+		isoClient := newIsolatedMCPClient(t, mcpURL, authOpt)
+		defer func() { _ = isoClient.Close() }()
+
+		require.NoError(t, isoClient.Start(ctx))
+		_, err := isoClient.Initialize(ctx, initReq)
+		require.NoError(t, err)
+
+		require.Equal(t, int64(0), sentinel.hits.Load(),
+			"isolated client must NOT route requests through http.DefaultTransport")
+	})
 }

--- a/coderd/x/chatd/mcpclient/mcpclient.go
+++ b/coderd/x/chatd/mcpclient/mcpclient.go
@@ -285,31 +285,24 @@ func createTransport(
 	cfg database.MCPServerConfig,
 	headers map[string]string,
 ) (transport.Interface, error) {
-	// Each connection gets its own HTTP client with a dedicated
-	// transport so that httptest.Server.Close() (which calls
-	// CloseIdleConnections on http.DefaultTransport) does not
-	// disrupt unrelated connections during parallel tests.
-	var httpClient *http.Client
-	if dt, ok := http.DefaultTransport.(*http.Transport); ok {
-		httpClient = &http.Client{Transport: dt.Clone()}
-	} else {
-		httpClient = &http.Client{}
-	}
+	httpClient := mcpHTTPClient()
 
 	switch cfg.Transport {
 	case "sse":
-		return transport.NewSSE(
-			cfg.Url,
-			transport.WithHeaders(headers),
-			transport.WithHTTPClient(httpClient),
-		)
+		var opts []transport.ClientOption
+		opts = append(opts, transport.WithHeaders(headers))
+		if httpClient != nil {
+			opts = append(opts, transport.WithHTTPClient(httpClient))
+		}
+		return transport.NewSSE(cfg.Url, opts...)
 	case "", "streamable_http":
 		// Default to streamable HTTP, the newer transport.
-		return transport.NewStreamableHTTP(
-			cfg.Url,
-			transport.WithHTTPHeaders(headers),
-			transport.WithHTTPBasicClient(httpClient),
-		)
+		var opts []transport.StreamableHTTPCOption
+		opts = append(opts, transport.WithHTTPHeaders(headers))
+		if httpClient != nil {
+			opts = append(opts, transport.WithHTTPBasicClient(httpClient))
+		}
+		return transport.NewStreamableHTTP(cfg.Url, opts...)
 	default:
 		return nil, xerrors.Errorf(
 			"unsupported transport %q", cfg.Transport,

--- a/coderd/x/chatd/mcpclient/mcphttpclient.go
+++ b/coderd/x/chatd/mcpclient/mcphttpclient.go
@@ -1,0 +1,25 @@
+package mcpclient
+
+import (
+	"net/http"
+	"testing"
+)
+
+// mcpHTTPClient returns an isolated *http.Client when running
+// inside tests, or nil for production. During tests,
+// httptest.Server.Close() calls
+// http.DefaultTransport.CloseIdleConnections(), which disrupts
+// any MCP client sharing that transport. When DefaultTransport
+// is a *http.Transport it is cloned; otherwise a minimal
+// transport with ProxyFromEnvironment is created as a fallback.
+func mcpHTTPClient() *http.Client {
+	if !testing.Testing() {
+		return nil
+	}
+	if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+		return &http.Client{Transport: dt.Clone()}
+	}
+	return &http.Client{Transport: &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+	}}
+}


### PR DESCRIPTION
## Problem

`mcp-go` v0.38.0 transports default to `&http.Client{}` with nil Transport, falling through to `http.DefaultTransport`. `httptest.Server.Close()` calls `http.DefaultTransport.CloseIdleConnections()`, breaking in-flight MCP requests with `"net/http: HTTP/1.x transport connection broken: http: CloseIdleConnections called"`. Same class as PR #23494, tracked at coder/internal#1020.

## Fix

New `mcpHTTPClient()` helper in each MCP package uses `testing.Testing()` to auto-detect test context. In tests, it clones `http.DefaultTransport` so MCP connections are immune to `CloseIdleConnections`. In production, it returns nil and mcp-go uses `DefaultTransport` as-is, preserving connection pooling.

Each package's `createTransport` (or constructor) calls `mcpHTTPClient()` internally. No signature changes, no new parameters, no caller changes needed. The function is duplicated across three packages (`agent/x/agentmcp`, `coderd/x/chatd/mcpclient`, `aibridge/mcp`) to avoid cross-module coupling between agent, coderd, and aibridge subtrees. The `testing` import is isolated in its own `mcphttpclient.go` file per package to avoid triggering gocritic lint rules in the main source files.

Replaces the unconditional `dt.Clone()` from PR #23494 in `coderd/x/chatd/mcpclient` (which cloned in production too) with the conditional approach. Also fixes `aibridge/mcp/proxy_streamable_http.go` which called `client.NewStreamableHttpClient` directly without isolation.

Closes https://github.com/coder/internal/issues/1016

<details><summary>Sentinel test evidence</summary>

`TestMCPHTTP_E2E_TransportIsolation` replaces `http.DefaultTransport` with a counting wrapper, then verifies `newIsolatedMCPClient` clients do not route through it.

**Red (helper reverted to raw `NewStreamableHttpClient`, no isolation):**

```
$ GOFLAGS="" go test -run "TestMCPHTTP_E2E_TransportIsolation" -v -count=5 -timeout=2m ./coderd/mcp/
--- FAIL: TestMCPHTTP_E2E_TransportIsolation (0.37s)
    --- PASS: .../RawClientUsesDefaultTransport (0.01s)
    --- FAIL: .../IsolatedClientBypassesDefaultTransport (0.01s)
        Error: Not equal:
               expected: 0
               actual  : 2
--- FAIL: TestMCPHTTP_E2E_TransportIsolation (0.32s)
--- FAIL: TestMCPHTTP_E2E_TransportIsolation (0.31s)
--- FAIL: TestMCPHTTP_E2E_TransportIsolation (0.34s)
--- FAIL: TestMCPHTTP_E2E_TransportIsolation (0.21s)
FAIL
```

**Green (with fix):**

```
$ GOFLAGS="" go test -run "TestMCPHTTP_E2E_TransportIsolation" -v -count=1 -timeout=2m ./coderd/mcp/
--- PASS: TestMCPHTTP_E2E_TransportIsolation (0.23s)
    --- PASS: .../RawClientUsesDefaultTransport (0.01s)
    --- PASS: .../IsolatedClientBypassesDefaultTransport (0.00s)
PASS
```

**Race tests on all affected packages:**

```
$ GOFLAGS="" go test -race -count=1 -timeout=5m \
    ./coderd/mcp/ ./agent/x/agentmcp/ ./coderd/x/chatd/mcpclient/ ./aibridge/mcp/
ok  github.com/coder/coder/v2/coderd/mcp              8.021s
ok  github.com/coder/coder/v2/agent/x/agentmcp        4.315s
ok  github.com/coder/coder/v2/coderd/x/chatd/mcpclient 1.175s
ok  github.com/coder/coder/v2/aibridge/mcp            1.050s
```

</details>

> Generated by Coder Agents, operated by @mafredri