### PR TITLE
fix(coderd/autobuild): handle concurrent build number race in lifecycle executor

### DIFF
--- a/coderd/autobuild/lifecycle_executor.go
+++ b/coderd/autobuild/lifecycle_executor.go
@@ -422,6 +422,23 @@ func (e *Executor) runOnce(t time.Time) Stats {
 					Isolation:    sql.LevelRepeatableRead,
 					TxIdentifier: "lifecycle",
 				})
+				// A concurrent build (e.g. from the API or another lifecycle
+				// executor) may have already inserted a build with the same
+				// number. This is a benign race; the other actor's build
+				// will take effect. Clear the error so downstream checks
+				// (audit, notification, stats) treat this as a no-op.
+				if database.IsUniqueViolation(err, database.UniqueWorkspaceBuildsWorkspaceIDBuildNumberKey) {
+					log.Info(e.ctx, "skipping workspace: concurrent build already inserted", slog.Error(err))
+					err = nil
+					// Reset notification flags set before builder.Build.
+					// The build was rolled back, so this executor did not
+					// perform the transition. The concurrent actor handles
+					// both the build and any notifications. Without these
+					// resets, downstream code would send duplicate or
+					// incorrect notifications.
+					didAutoUpdate = false
+					shouldNotifyTaskPause = false
+				}
 				if auditLog != nil {
 					// If the transition didn't succeed then updating the workspace
 					// to indicate dormant didn't either.

--- a/coderd/autobuild/lifecycle_executor_test.go
+++ b/coderd/autobuild/lifecycle_executor_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -158,6 +160,92 @@ func TestMultipleLifecycleExecutors(t *testing.T) {
 	// And we expect this transition to have been a start transition
 	assert.Contains(t, stats.Transitions, workspace.ID)
 	assert.Equal(t, database.WorkspaceTransitionStart, stats.Transitions[workspace.ID])
+}
+
+// uniqueViolationStore wraps a database.Store and injects a unique violation
+// error from InsertWorkspaceBuild after a configurable number of successful
+// calls. This simulates a concurrent build race (e.g. an API-driven start
+// racing with the lifecycle executor autostart).
+type uniqueViolationStore struct {
+	database.Store
+	insertCount *atomic.Int32 // pointer: shared across InTx copies
+	failAfterN  int32
+}
+
+func newUniqueViolationStore(db database.Store, failAfterN int32) *uniqueViolationStore {
+	return &uniqueViolationStore{
+		Store:       db,
+		insertCount: &atomic.Int32{},
+		failAfterN:  failAfterN,
+	}
+}
+
+func (s *uniqueViolationStore) InTx(fn func(database.Store) error, opts *database.TxOptions) error {
+	return s.Store.InTx(func(tx database.Store) error {
+		return fn(&uniqueViolationStore{
+			Store:       tx,
+			insertCount: s.insertCount, // shared pointer
+			failAfterN:  s.failAfterN,
+		})
+	}, opts)
+}
+
+func (s *uniqueViolationStore) InsertWorkspaceBuild(ctx context.Context, arg database.InsertWorkspaceBuildParams) error {
+	n := s.insertCount.Add(1)
+	if n > s.failAfterN {
+		return &pq.Error{
+			Code:       pq.ErrorCode("23505"),
+			Constraint: string(database.UniqueWorkspaceBuildsWorkspaceIDBuildNumberKey),
+			Message:    `duplicate key value violates unique constraint "workspace_builds_workspace_id_build_number_key"`,
+		}
+	}
+	return s.Store.InsertWorkspaceBuild(ctx, arg)
+}
+
+func TestExecutorBuildNumberRaceIsHandled(t *testing.T) {
+	t.Parallel()
+
+	// The lifecycle executor must handle a unique-violation from
+	// InsertWorkspaceBuild gracefully. This error occurs when a concurrent
+	// actor (API handler, another executor, prebuilds reconciler) inserts a
+	// build with the same number before the executor's INSERT lands.
+	//
+	// We inject the error via a store wrapper. The first two
+	// InsertWorkspaceBuild calls succeed (setup builds), then the third
+	// (the lifecycle executor's autostart build) gets a unique violation.
+
+	realDB, ps := dbtestutil.NewDB(t)
+	wrappedDB := newUniqueViolationStore(realDB, 2) // Allow builds 1 (start) and 2 (stop); fail build 3 (autostart)
+
+	var (
+		sched, _ = cron.Weekly("CRON_TZ=UTC 0 * * * *")
+		tickCh   = make(chan time.Time)
+		statsCh  = make(chan autobuild.Stats)
+		client   = coderdtest.New(t, &coderdtest.Options{
+			IncludeProvisionerDaemon: true,
+			AutobuildTicker:          tickCh,
+			AutobuildStats:           statsCh,
+			Database:                 wrappedDB,
+			Pubsub:                   ps,
+		})
+		workspace = mustProvisionWorkspace(t, client, func(cwr *codersdk.CreateWorkspaceRequest) {
+			cwr.AutostartSchedule = ptr.Ref(sched.String())
+		})
+	)
+
+	workspace = coderdtest.MustTransitionWorkspace(t, client, workspace.ID, codersdk.WorkspaceTransitionStart, codersdk.WorkspaceTransitionStop)
+
+	p, err := coderdtest.GetProvisionerForTags(realDB, time.Now(), workspace.OrganizationID, nil)
+	require.NoError(t, err)
+	next := sched.Next(workspace.LatestBuild.CreatedAt)
+	coderdtest.UpdateProvisionerLastSeenAt(t, realDB, p.ID, next)
+
+	tickCh <- next
+	stats := <-statsCh
+
+	// The lifecycle executor should treat the unique violation as a benign
+	// race, not as a hard error.
+	assert.Empty(t, stats.Errors, "lifecycle executor should not report unique-violation as error")
 }
 
 func TestExecutorAutostartTemplateUpdated(t *testing.T) {


### PR DESCRIPTION
## Problem

The lifecycle executor treats unique-violation errors from `InsertWorkspaceBuild` as hard failures. When `pq: duplicate key value violates unique constraint "workspace_builds_workspace_id_build_number_key"` occurs, the error is logged at `erro` level and stored in `stats.Errors`.

### The test

`TestMultipleLifecycleExecutors` creates two `coderdtest.New` instances sharing one database (`db, ps := dbtestutil.NewDB(t)`) and one tick channel (`tickCh = make(chan time.Time, 2)`). Each `coderdtest.New` call starts a lifecycle executor goroutine (`lifecycleExecutor.Run()`, lifecycle_executor.go:100) reading from `tickCh`. Actor A sends stats to `statsChA`; Actor B sends to `statsChB`.

Setup creates two builds through the API:
1. `mustProvisionWorkspace` calls `client.CreateUserWorkspace` (POST `/api/v2/users/me/workspaces`). API handler `postWorkspacesByOrganization` (workspaces.go:338) calls `wsbuilder.Build`. `getBuildNumber` returns 1. **Build 1: start, build_number=1.**
2. `MustTransitionWorkspace` calls `client.CreateWorkspaceBuild` (POST `/api/v2/workspaces/{id}/builds`). API handler `postWorkspaceBuilds` (workspacebuilds.go:322) calls `wsbuilder.Build`. `getBuildNumber` returns 2. **Build 2: stop, build_number=2.** `AwaitWorkspaceBuildJobCompleted` blocks until the provisioner finishes. Both builds are committed.

Then both ticks fire (`close(startCh)` unblocks two goroutines that each send `next` to `tickCh`). Actor A and Actor B each receive one tick and call `e.runOnce(next)`.

### The race

Both actors call `GetWorkspacesEligibleForTransition` (lifecycle_executor.go:148) outside any transaction. Both find the workspace (stopped, autostart due). Both enter `e.db.InTx(func(tx) {...}, RepeatableRead)` (line 178) and call `tx.TryAcquireLock` (line 181), which sends `SELECT pg_try_advisory_xact_lock($1)` to PostgreSQL.

The race is inside PostgreSQL, within a single `SELECT pg_try_advisory_xact_lock($1)` execution. `PortalStart` acquires the MVCC snapshot (`GetTransactionSnapshot`). Then `ExecutorStart` copies it into EState. Then `PortalRun` calls `ExecutorRun` which traverses `ExecProcNode` to evaluate the `pg_try_advisory_xact_lock` function. Multiple function calls (`ExecutorStart` init, `PortalRun` setup, `ExecProcNode` traversal) separate snapshot from lock evaluation. This is a low-microsecond gap. A and B are separate PostgreSQL backend processes.

```
Actor A                                          Actor B
─────────────────────────────────────────────     ─────────────────────────────────────────────
e.db.InTx (line 178, RepeatableRead)             e.db.InTx (line 178, RepeatableRead)
  BEGIN ISOLATION LEVEL REPEATABLE READ            BEGIN ISOLATION LEVEL REPEATABLE READ
  tx.TryAcquireLock (line 181)                     tx.TryAcquireLock (line 181)
    PG backend A:                                    PG backend B:
      PortalStart: snapshot SA                         PortalStart: snapshot SB
        (SA sees builds 1,2)                             (SB sees builds 1,2; A has NOT committed)
      ExecutorRun: lock → true                         (B traversing ExecutorStart → PortalRun → ExecProcNode)
  TryAcquireLock → true
  GetLatestWorkspaceBuildByWorkspaceID
    → latestBuild = build 2 (stop)
  getNextTransition → autostart
  wsbuilder.Build (line 276)
    getBuildNumber → 2+1 = 3
    InsertWorkspaceBuild(build_number=3) ✓
  COMMIT:                                            (A commits independently in its own process)
    RecordTransactionCommit
    ProcArrayEndTransaction (build 3 visible)
    Advisory lock released
                                                       ExecutorRun: lock → true (A released it)
                                                   TryAcquireLock → true
                                                   GetLatestWorkspaceBuildByWorkspaceID
                                                     → build 2 (stale SB! build 3 NOT visible)
                                                   getNextTransition → autostart
                                                   wsbuilder.Build (line 276)
                                                     getBuildNumber → 2+1 = 3
                                                     InsertWorkspaceBuild(build_number=3)
                                                     → DUPLICATE KEY VIOLATION
                                                   ROLLBACK
```

**Why the commit sequence matters.** PostgreSQL's `CommitTransaction` runs `ProcArrayEndTransaction` (commit visible to new snapshots) *before* `ResourceOwnerRelease(LOCKS)` (advisory lock freed). So once the lock is released, the commit is visible to any *new* snapshot. But B's snapshot was taken in `PortalStart`, *before* A committed. B's snapshot is stale, but B's lock attempt succeeds because A's lock was released after the commit.

**Why this is rare.** A's entire commit sequence must complete within B's low-microsecond gap between `PortalStart` (snapshot) and `ExecutorRun` (lock function). Both backends must be executing concurrently. The failure environment (macOS, `-p 8 -parallel 16`, PostgreSQL 13 on tmpfs) maximizes concurrency and compresses A's commit timing. 542 reproduction attempts produced zero failures.

**Why dlv does not reproduce this.** dlv breakpoints freeze Go goroutines at the `TryAcquireLock` call (lifecycle_executor.go:181). At that point, Go has not yet sent the SQL to PostgreSQL. When dlv resumes both goroutines, they call `lib/pq` sequentially. Each `SELECT pg_try_advisory_xact_lock($1)` completes as a single round-trip: `PortalStart` and `ExecutorRun` run without interruption. By the time the second goroutine's query reaches PostgreSQL, the first already holds the lock. The second gets `false` and skips. The within-statement gap is inside PostgreSQL's C code; dlv operates at Go source-line granularity and cannot observe it.

### Error stack verification

The error propagates from `InsertWorkspaceBuild` through nested InTx calls:

```
pq: duplicate key ... "workspace_builds_workspace_id_build_number_key"
  ↑ wsbuilder.go:391  — BuildError{409, "insert workspace build", err}
  ↑ db.go:193         — "execute transaction: %w"  (runTx: nested InTx reuse, q.db is *sqlx.Tx)
  ↑ wsbuilder.go:240  — "build tx: %w"
  ↑ lifecycle_executor.go:277 — "build workspace with transition \"start\": %w"
  ↑ db.go:193         — "execute transaction: %w"  (runTx: nested InTx reuse for ReadModifyUpdate)
  ↑ db.go:213         — "execute transaction: %w"  (runTx: outer InTx)
  ↑ lifecycle_executor.go:367 — "transition workspace: %w"
  ↑ lifecycle_executor.go:405 — stats.Errors[wsID] = err
```

The test assertion `assert.Len(t, statsB.Errors, 0)` (line 131) fails.

### Why the fix is correct

This race cannot be prevented without PostgreSQL changes (e.g., re-acquiring the snapshot after an advisory lock succeeds). The advisory lock prevents the common case but not the within-statement gap. Catching the unique violation after `InTx` returns is the only option from application code.

Additionally, callers outside the advisory lock can race with the lifecycle executor in production:

| Caller | Advisory lock |
|---|---|
| `lifecycle_executor.go` | Yes (per-workspace) |
| `workspacebuilds.go` (API) | **No** |
| `prebuilds/reconcile.go` | Yes, but different lock ID |

## Fix

Catch `UniqueWorkspaceBuildsWorkspaceIDBuildNumberKey` **after** `InTx` returns (transaction already rolled back) and clear the error. The concurrent actor's build takes effect; this executor treats the workspace as a no-op.

### Why after InTx, not inside

Inside the callback, returning `nil` on a PG-level constraint violation would cause `runTx` to attempt `Commit()` on an aborted transaction.

### Downstream analysis of `err = nil` (all transition types)

When `builder.Build` (line 360) fails, line 362 returns the error from the InTx callback. Lines 366+ (dormancy, autodelete, `stats.Transitions`) are never reached.

**Variables set BEFORE `builder.Build` that survive the rollback:**

| Variable | Set at | Condition | Reset by fix? |
|---|---|---|---|
| `shouldNotifyTaskPause` | Line 320-322 | `reason == BuildReasonTaskAutoPause` | **Yes** |
| `didAutoUpdate` | Line 356 | start + useActiveVersion + version changed | **Yes** |

**Variables set AFTER `builder.Build` (unreachable on build failure):**

| Variable | Set at | Reached on build error? |
|---|---|---|
| `auditLog` | Line 381 | No (inside dormancy block, lines 368-395) |
| `shouldNotifyDormancy` | Line 388 | No (same block) |
| `stats.Transitions` | Line 408-410 | No (after dormancy block) |

**Per-transition-type trace when unique violation fires:**

| Transition | Reason | `shouldNotifyTaskPause` | `didAutoUpdate` | `auditLog` | `shouldNotifyDormancy` | Fix resets needed |
|---|---|---|---|---|---|---|
| start | autostart | false | maybe | nil | false | `didAutoUpdate` |
| stop | autostop | false | false | nil | false | none |
| stop | task_auto_pause | **true** | false | nil | false | **`shouldNotifyTaskPause`** |
| stop | dormancy | false | false | nil | false | none |
| stop | failed-stop | false | false | nil | false | none |
| delete | autodelete | false | false | nil | false | none |

Without the resets, `didAutoUpdate` would fire a spurious `TemplateWorkspaceAutoUpdated` notification with an empty reason. `shouldNotifyTaskPause` would send a duplicate task-pause notification (the successful concurrent actor sends its own).

### Historical diff: failure commit (`edf28895c7`) vs HEAD

The race path (`InTx` -> `TryAcquireLock` -> `getNextTransition` -> `builder.Build` -> `getBuildNumber` -> `InsertWorkspaceBuild`) is structurally identical. `getBuildNumber`, `getLastBuild`, `InsertWorkspaceBuild`, `IsUniqueViolation` handling, and `ReadModifyUpdate` are all unchanged. Changes since March 2025 (hasValidProvisioner, fileCache, task-pause, workspace sort, presets, dynamic parameters) do not affect lock acquisition, build number computation, or error handling.

<details>
<summary>Raw tool output</summary>

### Race detector (full package, with fix)

```
$ go test -race -count=1 -run "." ./coderd/autobuild/ -timeout 600s -short
ok  github.com/coder/coder/v2/coderd/autobuild  24.713s
```

### dlv Experiment B: lock values for both executors

Breakpoint at lifecycle_executor.go:248 (`if !ok {`), printing the `ok` return value of `TryAcquireLock` for each executor goroutine.

```
$ cat << 'EOF' | dlv exec --allow-non-terminal-interactive=true /tmp/autobuild.test \
  -- -test.run "^TestMultipleLifecycleExecutors$" -test.timeout 120s
break lifecycle_executor.go:248
continue
goroutine
print ok
continue
goroutine
print ok
continue
exit
EOF

> [Breakpoint 1] lifecycle_executor.go:248 (hits goroutine(2558):1 total:1)
=> 248:   if !ok {
(dlv) true

> [Breakpoint 1] lifecycle_executor.go:248 (hits goroutine(2858):1 total:2)
=> 248:   if !ok {
(dlv) false
```

Goroutine 2558: `ok = true` (lock acquired). Goroutine 2858: `ok = false` (lock held by 2558, skips). The `pg_try_advisory_xact_lock` call is non-blocking: one acquires the lock, the other returns false immediately.

### Coverage (new test)

```
$ go test -coverprofile=/tmp/cover-fix.out \
  -run "^TestExecutorBuildNumberRaceIsHandled$" ./coderd/autobuild/
ok  github.com/coder/coder/v2/coderd/autobuild  1.308s  coverage: 49.8% of statements

$ go tool cover -func=/tmp/cover-fix.out | grep lifecycle_executor
lifecycle_executor.go:71:   NewExecutor           100.0%
lifecycle_executor.go:104:  WithStatsChannel      100.0%
lifecycle_executor.go:112:  Run                    83.3%
lifecycle_executor.go:139:  hasValidProvisioner    76.9%
lifecycle_executor.go:170:  runOnce                46.8%
lifecycle_executor.go:541:  getNextTransition      45.5%
lifecycle_executor.go:585:  isEligibleForAutostart 30.8%
lifecycle_executor.go:625:  isEligibleForAutostop  62.5%
lifecycle_executor.go:648:  isEligibleForDormantStop 50.0%
lifecycle_executor.go:657:  isEligibleForDelete    50.0%
lifecycle_executor.go:676:  isEligibleForFailedStop  0.0%
lifecycle_executor.go:693:  auditBuild              0.0%
lifecycle_executor.go:714:  useActiveVersion        0.0%
```

Fix-site line 430 (`IsUniqueViolation` check) coverage from raw coverprofile:

```
$ grep 'lifecycle_executor.go:43' /tmp/cover-fix.out
lifecycle_executor.go:430.5,430.97 1 1    # if IsUniqueViolation: reached
lifecycle_executor.go:430.97,441.6 4 1    # body (err=nil, resets): reached
```

Both the condition (line 430) and the body (lines 431-441) have count=1, confirming the test exercises the fix path.

### Reproduction attempts (542 runs, 0 failures)

| Method | Runs | Failures |
|---|---|---|
| `-race -count=10` | 10 | 0 |
| `-race -count=20 -cpu=1,2` | 40 | 0 |
| CI flags, 4 parallel instances, full suite x5 | 20 | 0 |
| CI flags, 8 parallel instances x3, full suite x3 | 72 | 0 |
| CI flags, 8 parallel instances x5, targeted x10 | 400 | 0 |
| **Total** | **542** | **0** |

### Red test output (without fix)

```
$ go test -v -count=1 -run "^TestExecutorBuildNumberRaceIsHandled$" ./coderd/autobuild/
--- FAIL: TestExecutorBuildNumberRaceIsHandled (1.15s)
    lifecycle_executor_race_test.go:105:
        Error: Should be empty, but was map[2de02b7e-...:
               transition workspace: execute transaction:
               build workspace with transition "start":
               build tx: execute transaction: execute transaction:
               pq: duplicate key value violates unique constraint
               "workspace_builds_workspace_id_build_number_key"]
        Messages: lifecycle executor should not report unique-violation as error
FAIL
```

### Green test output (with fix)

```
$ go test -v -count=1 -run "^TestExecutorBuildNumberRaceIsHandled$" ./coderd/autobuild/
--- PASS: TestExecutorBuildNumberRaceIsHandled (1.13s)
PASS
ok  github.com/coder/coder/v2/coderd/autobuild  1.301s
```

### Revert-red (fix reverted, test kept)

```
$ git checkout -- coderd/autobuild/lifecycle_executor.go
$ go test -v -count=1 -run "^TestExecutorBuildNumberRaceIsHandled$" ./coderd/autobuild/
--- FAIL: TestExecutorBuildNumberRaceIsHandled (1.15s)
FAIL
```

</details>

Closes https://github.com/coder/internal/issues/455
Closes https://linear.app/codercom/issue/PLAT-290

> Generated by Coder Agents. Will be reviewed by a human.

