### PR TITLE
fix: do not clobber dynamic parameters (backport #24645 to 2.32)

### DIFF
--- a/site/src/modules/hooks/useSyncFormParameters.ts
+++ b/site/src/modules/hooks/useSyncFormParameters.ts
@@ -1,3 +1,4 @@
+import type { FormikTouched } from "formik";
 import { useEffect, useRef } from "react";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { PreviewParameter } from "#/api/typesGenerated";
@@ -5,6 +6,9 @@ import type { PreviewParameter } from "#/api/typesGenerated";
 type UseSyncFormParametersProps = {
 	parameters: readonly PreviewParameter[];
 	formValues: readonly TypesGen.WorkspaceBuildParameter[];
+	touched: FormikTouched<{
+		rich_parameter_values?: readonly TypesGen.WorkspaceBuildParameter[];
+	}>;
 	setFieldValue: (
 		field: string,
 		value: TypesGen.WorkspaceBuildParameter[],
@@ -14,6 +18,7 @@ type UseSyncFormParametersProps = {
 export function useSyncFormParameters({
 	parameters,
 	formValues,
+	touched,
 	setFieldValue,
 }: UseSyncFormParametersProps) {
 	// Form values only needs to be updated when parameters change
@@ -30,13 +35,16 @@ export function useSyncFormParameters({
 		);
 
 		const newParameterValues = parameters.map((param) => {
-			// When the server value is not valid (e.g., the initial
-			// WebSocket response before any user input is sent),
-			// preserve the current form value. This prevents the sync
-			// hook from overwriting autofilled values (from the
-			// previous build) with empty strings before the server
-			// has had a chance to process them.
-			if (!param.value.valid) {
+			// Do not mess with values the user has changed (or were auto-filled).
+			// Otherwise based on timing web socket responses can undo changes, and it
+			// seems bad to change a user's inputs from under them anyway.
+			if (
+				touched[
+					param.name as keyof {
+						rich_parameter_values?: readonly TypesGen.WorkspaceBuildParameter[];
+					}
+				]
+			) {
 				const existingValue = currentFormValuesMap.get(param.name);
 				if (existingValue !== undefined) {
 					return { name: param.name, value: existingValue };
@@ -60,5 +68,5 @@ export function useSyncFormParameters({
 		if (isChanged) {
 			setFieldValue("rich_parameter_values", newParameterValues);
 		}
-	}, [parameters, setFieldValue]);
+	}, [parameters, touched, setFieldValue]);
 }

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.jest.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.jest.tsx
@@ -8,6 +8,7 @@ import {
 	MockDynamicParametersResponse,
 	MockDynamicParametersResponseWithError,
 	MockPermissions,
+	MockPreviewParameter,
 	MockSliderParameter,
 	MockTemplate,
 	MockTemplateVersionExternalAuthGithub,
@@ -20,7 +21,7 @@ import {
 	renderWithAuth,
 	waitForLoaderToBeRemoved,
 } from "#/testHelpers/renderHelpers";
-import { createMockWebSocket } from "#/testHelpers/websockets";
+import { mockDynamicParameterWebSocket } from "#/testHelpers/websockets";
 import CreateWorkspacePage from "./CreateWorkspacePage";
 
 describe("CreateWorkspacePage", () => {
@@ -47,36 +48,11 @@ describe("CreateWorkspacePage", () => {
 		jest.spyOn(API, "getTemplateVersionPresets").mockResolvedValue([]);
 		jest.spyOn(API, "createWorkspace").mockResolvedValue(MockWorkspace);
 		jest.spyOn(API, "checkAuthorization").mockResolvedValue(MockPermissions);
-
-		jest
-			.spyOn(API, "templateVersionDynamicParameters")
-			.mockImplementation((_versionId, _ownerId, callbacks) => {
-				const [mockWebSocket, publisher] = createMockWebSocket("ws://test");
-
-				mockWebSocket.addEventListener("message", (event) => {
-					callbacks.onMessage(JSON.parse(event.data));
-				});
-				mockWebSocket.addEventListener("error", () => {
-					callbacks.onError(
-						new Error("Connection for dynamic parameters failed."),
-					);
-				});
-				mockWebSocket.addEventListener("close", () => {
-					callbacks.onClose();
-				});
-
-				publisher.publishOpen(new Event("open"));
-				publisher.publishMessage(
-					new MessageEvent("message", {
-						data: JSON.stringify(MockDynamicParametersResponse),
-					}),
-				);
-
-				return mockWebSocket;
-			});
+		mockDynamicParameterWebSocket(MockDynamicParametersResponse);
 	});
 
 	afterEach(() => {
+		jest.useRealTimers();
 		jest.restoreAllMocks();
 	});
 
@@ -105,32 +81,9 @@ describe("CreateWorkspacePage", () => {
 		});
 
 		it("sends parameter updates via WebSocket when form values change", async () => {
-			const [mockWebSocket, publisher] = createMockWebSocket("ws://test");
-
-			jest
-				.spyOn(API, "templateVersionDynamicParameters")
-				.mockImplementation((_versionId, _ownerId, callbacks) => {
-					mockWebSocket.addEventListener("message", (event) => {
-						callbacks.onMessage(JSON.parse(event.data));
-					});
-					mockWebSocket.addEventListener("error", () => {
-						callbacks.onError(
-							new Error("Connection for dynamic parameters failed."),
-						);
-					});
-					mockWebSocket.addEventListener("close", () => {
-						callbacks.onClose();
-					});
-
-					publisher.publishOpen(new Event("open"));
-					publisher.publishMessage(
-						new MessageEvent("message", {
-							data: JSON.stringify(MockDynamicParametersResponse),
-						}),
-					);
-
-					return mockWebSocket;
-				});
+			const [mockWebSocket] = mockDynamicParameterWebSocket(
+				MockDynamicParametersResponse,
+			);
 
 			renderCreateWorkspacePage();
 			await waitForLoaderToBeRemoved();
@@ -144,24 +97,18 @@ describe("CreateWorkspacePage", () => {
 				within(instanceTypeField).getByRole("combobox");
 			expect(instanceTypeSelect).toBeInTheDocument();
 
-			jest.useFakeTimers();
+			jest.useFakeTimers({ shouldAdvanceTime: true });
 
-			await waitFor(async () => {
-				await userEvent.click(instanceTypeSelect);
+			await userEvent.click(instanceTypeSelect);
+
+			const mediumOption = await screen.findByRole("option", {
+				name: /t3\.medium/i,
 			});
 
-			let mediumOption: Element | null = null;
-			await waitFor(() => {
-				mediumOption = screen.queryByRole("option", { name: /t3\.medium/i });
-				expect(mediumOption).toBeTruthy();
-			});
+			await userEvent.click(mediumOption);
 
-			await waitFor(async () => {
-				await userEvent.click(mediumOption!);
-			});
-
-			act(() => {
-				jest.runAllTimers();
+			await act(async () => {
+				await jest.runAllTimersAsync();
 			});
 
 			expect(mockWebSocket.send).toHaveBeenCalledWith(
@@ -172,48 +119,42 @@ describe("CreateWorkspacePage", () => {
 		});
 
 		it("handles WebSocket error gracefully", async () => {
-			const [mockWebSocket, mockPublisher] = createMockWebSocket("ws://test");
-
-			jest
-				.spyOn(API, "templateVersionDynamicParameters")
-				.mockImplementation((_versionId, _ownerId, callbacks) => {
-					mockWebSocket.addEventListener("error", () => {
-						callbacks.onError(new Error("Connection failed"));
-					});
-
-					return mockWebSocket;
-				});
+			const [, mockPublisher] = mockDynamicParameterWebSocket([]);
 
 			renderCreateWorkspacePage();
 
 			await waitFor(() => {
-				expect(mockPublisher).toBeDefined();
+				expect(API.templateVersionDynamicParameters).toHaveBeenCalled();
+			});
+
+			await act(async () => {
 				mockPublisher.publishError(new Event("Connection failed"));
+			});
+
+			await waitFor(() => {
 				const alert = screen.getByRole("alert");
 				expect(
-					within(alert).getByRole("heading", { name: /connection failed/i }),
+					within(alert).getByRole("heading", {
+						name: /connection for dynamic parameters failed/i,
+					}),
 				).toBeInTheDocument();
 			});
 		});
 
 		it("handles WebSocket close event", async () => {
-			const [mockWebSocket, mockPublisher] = createMockWebSocket("ws://test");
-
-			jest
-				.spyOn(API, "templateVersionDynamicParameters")
-				.mockImplementation((_versionId, _ownerId, callbacks) => {
-					mockWebSocket.addEventListener("close", () => {
-						callbacks.onClose();
-					});
-
-					return mockWebSocket;
-				});
+			const [, mockPublisher] = mockDynamicParameterWebSocket([]);
 
 			renderCreateWorkspacePage();
 
 			await waitFor(() => {
-				expect(mockPublisher).toBeDefined();
+				expect(API.templateVersionDynamicParameters).toHaveBeenCalled();
+			});
+
+			await act(async () => {
 				mockPublisher.publishClose(new Event("close") as CloseEvent);
+			});
+
+			await waitFor(() => {
 				const alert = screen.getByRole("alert");
 				expect(
 					within(alert).getByRole("heading", {
@@ -224,27 +165,9 @@ describe("CreateWorkspacePage", () => {
 		});
 
 		it("only parameters from latest response are displayed", async () => {
-			const [mockWebSocket, mockPublisher] = createMockWebSocket("ws://test");
-			jest
-				.spyOn(API, "templateVersionDynamicParameters")
-				.mockImplementation((_versionId, _ownerId, callbacks) => {
-					mockWebSocket.addEventListener("message", (event) => {
-						callbacks.onMessage(JSON.parse(event.data));
-					});
-
-					mockPublisher.publishOpen(new Event("open"));
-					mockPublisher.publishMessage(
-						new MessageEvent("message", {
-							data: JSON.stringify({
-								id: 0,
-								parameters: [MockDropdownParameter],
-								diagnostics: [],
-							}),
-						}),
-					);
-
-					return mockWebSocket;
-				});
+			const [, mockPublisher] = mockDynamicParameterWebSocket([
+				MockDropdownParameter,
+			]);
 
 			renderCreateWorkspacePage();
 			await waitForLoaderToBeRemoved();
@@ -260,7 +183,7 @@ describe("CreateWorkspacePage", () => {
 				diagnostics: [],
 			};
 
-			await waitFor(() => {
+			await act(async () => {
 				mockPublisher.publishMessage(
 					new MessageEvent("message", { data: JSON.stringify(response1) }),
 				);
@@ -270,30 +193,94 @@ describe("CreateWorkspacePage", () => {
 				);
 			});
 
-			expect(screen.queryByText("CPU Count")).toBeInTheDocument();
-			expect(screen.queryByText("Instance Type")).not.toBeInTheDocument();
+			await waitFor(() => {
+				expect(screen.queryByText("CPU Count")).toBeInTheDocument();
+				expect(screen.queryByText("Instance Type")).not.toBeInTheDocument();
+			});
+		});
+
+		it("does not clobber user values", async () => {
+			const [, mockPublisher] = mockDynamicParameterWebSocket([
+				MockPreviewParameter,
+			]);
+
+			renderCreateWorkspacePage();
+			await waitForLoaderToBeRemoved();
+
+			const form = screen.getByTestId("form");
+			const input = await within(form).findByRole("textbox", {
+				name: /parameter 1/i,
+			});
+			await userEvent.clear(input);
+			await userEvent.type(input, "hi there hello");
+
+			await waitFor(() => {
+				expect(
+					within(form).getByDisplayValue("hi there hello"),
+				).toBeInTheDocument();
+			});
+
+			// Simulate a stale response.
+			await act(async () => {
+				mockPublisher.publishMessage(
+					new MessageEvent("message", {
+						data: JSON.stringify({
+							id: 1,
+							parameters: [MockPreviewParameter, MockValidationParameter],
+						}),
+					}),
+				);
+			});
+
+			// Should have the new field, but keep the existing user-filled values.
+			await waitFor(() => {
+				expect(within(form).getByDisplayValue("50")).toBeInTheDocument();
+				expect(
+					within(form).getByDisplayValue("hi there hello"),
+				).toBeInTheDocument();
+			});
+		});
+
+		it("does not clobber auto-filled values", async () => {
+			const [, mockPublisher] = mockDynamicParameterWebSocket([
+				MockPreviewParameter,
+				MockSliderParameter,
+			]);
+
+			renderCreateWorkspacePage(
+				`/templates/${MockTemplate.name}/workspace?param.cpu_count=44&param.parameter1=auto`,
+			);
+			await waitForLoaderToBeRemoved();
+
+			// Simulate a stale response.
+			await act(async () => {
+				mockPublisher.publishMessage(
+					new MessageEvent("message", {
+						data: JSON.stringify({
+							id: 2,
+							parameters: [
+								MockPreviewParameter,
+								MockSliderParameter,
+								MockValidationParameter,
+							],
+						}),
+					}),
+				);
+			});
+
+			// Should have the new field, but keep the existing auto-filled values.
+			const form = screen.getByTestId("form");
+			await waitFor(() => {
+				expect(within(form).getByDisplayValue("50")).toBeInTheDocument();
+				expect(within(form).getByDisplayValue("44")).toBeInTheDocument();
+				expect(within(form).getByDisplayValue("auto")).toBeInTheDocument();
+			});
 		});
 	});
 
 	describe("Dynamic Parameter Types", () => {
 		it("displays parameter validation errors", async () => {
-			jest
-				.spyOn(API, "templateVersionDynamicParameters")
-				.mockImplementation((_versionId, _ownerId, callbacks) => {
-					const [mockWebSocket, publisher] = createMockWebSocket("ws://test");
-
-					mockWebSocket.addEventListener("message", (event) => {
-						callbacks.onMessage(JSON.parse(event.data));
-					});
-
-					publisher.publishMessage(
-						new MessageEvent("message", {
-							data: JSON.stringify(MockDynamicParametersResponseWithError),
-						}),
-					);
-
-					return mockWebSocket;
-				});
+			mockDynamicParameterWebSocket(MockDynamicParametersResponseWithError);
 
 			renderCreateWorkspacePage();
 			await waitForLoaderToBeRemoved();
@@ -337,38 +324,20 @@ describe("CreateWorkspacePage", () => {
 				diagnostics: [],
 			};
 
-			jest
-				.spyOn(API, "templateVersionDynamicParameters")
-				.mockImplementation((_versionId, _ownerId, callbacks) => {
-					const [mockWebSocket, publisher] = createMockWebSocket("ws://test");
+			const [mockWebSocket, publisher] =
+				mockDynamicParameterWebSocket(mockResponseInitial);
+			const originalSend = mockWebSocket.send;
+			mockWebSocket.send = jest.fn((data) => {
+				originalSend.call(mockWebSocket, data);
 
-					mockWebSocket.addEventListener("message", (event) => {
-						callbacks.onMessage(JSON.parse(event.data));
-					});
-
-					publisher.publishOpen(new Event("open"));
-
+				if (typeof data === "string" && data.includes('"200"')) {
 					publisher.publishMessage(
 						new MessageEvent("message", {
-							data: JSON.stringify(mockResponseInitial),
+							data: JSON.stringify(mockResponseWithError),
 						}),
 					);
-
-					const originalSend = mockWebSocket.send;
-					mockWebSocket.send = jest.fn((data) => {
-						originalSend.call(mockWebSocket, data);
-
-						if (typeof data === "string" && data.includes('"200"')) {
-							publisher.publishMessage(
-								new MessageEvent("message", {
-									data: JSON.stringify(mockResponseWithError),
-								}),
-							);
-						}
-					});
-
-					return mockWebSocket;
-				});
+				}
+			});
 
 			renderCreateWorkspacePage();
 			await waitForLoaderToBeRemoved();
@@ -380,10 +349,8 @@ describe("CreateWorkspacePage", () => {
 			const numberInput = screen.getByDisplayValue("50");
 			expect(numberInput).toBeInTheDocument();
 
-			await waitFor(async () => {
-				await userEvent.clear(numberInput);
-				await userEvent.type(numberInput, "200");
-			});
+			await userEvent.clear(numberInput);
+			await userEvent.type(numberInput, "200");
 
 			await waitFor(() => {
 				expect(screen.getByDisplayValue("200")).toBeInTheDocument();
@@ -414,9 +381,9 @@ describe("CreateWorkspacePage", () => {
 
 	describe("External Authentication", () => {
 		it("displays external auth providers", async () => {
-			jest
-				.spyOn(API, "getTemplateVersionExternalAuth")
-				.mockResolvedValue([MockTemplateVersionExternalAuthGithub]);
+			jest.spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([
+				MockTemplateVersionExternalAuthGithub,
+			]);
 
 			renderCreateWorkspacePage();
 			await waitForLoaderToBeRemoved();
@@ -430,11 +397,9 @@ describe("CreateWorkspacePage", () => {
 		});
 
 		it("shows authenticated state for connected providers", async () => {
-			jest
-				.spyOn(API, "getTemplateVersionExternalAuth")
-				.mockResolvedValue([
-					MockTemplateVersionExternalAuthGithubAuthenticated,
-				]);
+			jest.spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([
+				MockTemplateVersionExternalAuthGithubAuthenticated,
+			]);
 
 			renderCreateWorkspacePage();
 			await waitForLoaderToBeRemoved();
@@ -446,9 +411,9 @@ describe("CreateWorkspacePage", () => {
 		});
 
 		it("prevents auto-creation when required external auth is missing", async () => {
-			jest
-				.spyOn(API, "getTemplateVersionExternalAuth")
-				.mockResolvedValue([MockTemplateVersionExternalAuthGithub]);
+			jest.spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([
+				MockTemplateVersionExternalAuthGithub,
+			]);
 
 			renderCreateWorkspacePage(
 				`/templates/${MockTemplate.name}/workspace?mode=auto&version=${MockTemplate.id}`,
@@ -470,14 +435,12 @@ describe("CreateWorkspacePage", () => {
 
 	describe("Auto-creation Mode", () => {
 		it("falls back to form mode when auto-creation fails", async () => {
-			jest
-				.spyOn(API, "getTemplateVersionExternalAuth")
-				.mockResolvedValue([
-					MockTemplateVersionExternalAuthGithubAuthenticated,
-				]);
-			jest
-				.spyOn(API, "createWorkspace")
-				.mockRejectedValue(new Error("Auto-creation failed"));
+			jest.spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([
+				MockTemplateVersionExternalAuthGithubAuthenticated,
+			]);
+			jest.spyOn(API, "createWorkspace").mockRejectedValue(
+				new Error("Auto-creation failed"),
+			);
 
 			renderCreateWorkspacePage(
 				`/templates/${MockTemplate.name}/workspace?mode=auto`,
@@ -512,17 +475,13 @@ describe("CreateWorkspacePage", () => {
 			const nameInput = screen.getByRole("textbox", {
 				name: /workspace name/i,
 			});
-			await waitFor(async () => {
-				await userEvent.clear(nameInput);
-				await userEvent.type(nameInput, "my-test-workspace");
-			});
+			await userEvent.clear(nameInput);
+			await userEvent.type(nameInput, "my-test-workspace");
 
 			const createButton = screen.getByRole("button", {
 				name: /create workspace/i,
 			});
-			await waitFor(async () => {
-				await userEvent.click(createButton);
-			});
+			await userEvent.click(createButton);
 
 			await waitFor(() => {
 				expect(API.createWorkspace).toHaveBeenCalledWith(
@@ -600,18 +559,13 @@ describe("CreateWorkspacePage", () => {
 				name: /workspace name/i,
 			});
 
-			await waitFor(async () => {
-				await userEvent.clear(nameInput);
-				await userEvent.type(nameInput, "my-test-workspace");
-			});
+			await userEvent.clear(nameInput);
+			await userEvent.type(nameInput, "my-test-workspace");
 
-			// Submit form
 			const createButton = screen.getByRole("button", {
 				name: /create workspace/i,
 			});
-			await waitFor(async () => {
-				await userEvent.click(createButton);
-			});
+			await userEvent.click(createButton);
 
 			await waitFor(() => {
 				expect(router.state.location.pathname).toBe(

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.jest.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.jest.tsx
@@ -97,15 +97,19 @@ describe("CreateWorkspacePage", () => {
 				within(instanceTypeField).getByRole("combobox");
 			expect(instanceTypeSelect).toBeInTheDocument();
 
-			jest.useFakeTimers({ shouldAdvanceTime: true });
+			jest.useFakeTimers();
 
-			await userEvent.click(instanceTypeSelect);
+			await waitFor(async () => {
+				await userEvent.click(instanceTypeSelect);
+			});
 
 			const mediumOption = await screen.findByRole("option", {
 				name: /t3\.medium/i,
 			});
 
-			await userEvent.click(mediumOption);
+			await waitFor(async () => {
+				await userEvent.click(mediumOption);
+			});
 
 			await act(async () => {
 				await jest.runAllTimersAsync();

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.jest.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.jest.tsx
@@ -385,9 +385,9 @@ describe("CreateWorkspacePage", () => {
 
 	describe("External Authentication", () => {
 		it("displays external auth providers", async () => {
-			jest.spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([
-				MockTemplateVersionExternalAuthGithub,
-			]);
+			jest
+				.spyOn(API, "getTemplateVersionExternalAuth")
+				.mockResolvedValue([MockTemplateVersionExternalAuthGithub]);
 
 			renderCreateWorkspacePage();
 			await waitForLoaderToBeRemoved();
@@ -401,9 +401,11 @@ describe("CreateWorkspacePage", () => {
 		});
 
 		it("shows authenticated state for connected providers", async () => {
-			jest.spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([
-				MockTemplateVersionExternalAuthGithubAuthenticated,
-			]);
+			jest
+				.spyOn(API, "getTemplateVersionExternalAuth")
+				.mockResolvedValue([
+					MockTemplateVersionExternalAuthGithubAuthenticated,
+				]);
 
 			renderCreateWorkspacePage();
 			await waitForLoaderToBeRemoved();
@@ -415,9 +417,9 @@ describe("CreateWorkspacePage", () => {
 		});
 
 		it("prevents auto-creation when required external auth is missing", async () => {
-			jest.spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([
-				MockTemplateVersionExternalAuthGithub,
-			]);
+			jest
+				.spyOn(API, "getTemplateVersionExternalAuth")
+				.mockResolvedValue([MockTemplateVersionExternalAuthGithub]);
 
 			renderCreateWorkspacePage(
 				`/templates/${MockTemplate.name}/workspace?mode=auto&version=${MockTemplate.id}`,
@@ -439,12 +441,14 @@ describe("CreateWorkspacePage", () => {
 
 	describe("Auto-creation Mode", () => {
 		it("falls back to form mode when auto-creation fails", async () => {
-			jest.spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([
-				MockTemplateVersionExternalAuthGithubAuthenticated,
-			]);
-			jest.spyOn(API, "createWorkspace").mockRejectedValue(
-				new Error("Auto-creation failed"),
-			);
+			jest
+				.spyOn(API, "getTemplateVersionExternalAuth")
+				.mockResolvedValue([
+					MockTemplateVersionExternalAuthGithubAuthenticated,
+				]);
+			jest
+				.spyOn(API, "createWorkspace")
+				.mockRejectedValue(new Error("Auto-creation failed"));
 
 			renderCreateWorkspacePage(
 				`/templates/${MockTemplate.name}/workspace?mode=auto`,

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -138,7 +138,9 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 	// 1. The form parameter values are initialized from the websocket response when the form is mounted
 	// 2. Only touched form fields are sent to the websocket, a field is touched if edited by the user or set by autofill
 	// 3. The websocket response may add or remove parameters, these are added or removed from the form values in the useSyncFormParameters hook
-	// 4. All existing form parameters are updated to match the websocket response in the useSyncFormParameters hook
+	// 4. All existing form parameters are updated to match the websocket response
+	//    in the useSyncFormParameters hook, unless they have been touched by the
+	//    user or auto-filled.
 	const form: FormikContextType<TypesGen.CreateWorkspaceRequest> =
 		useFormik<TypesGen.CreateWorkspaceRequest>({
 			initialValues: {
@@ -360,6 +362,7 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 	useSyncFormParameters({
 		parameters,
 		formValues: form.values.rich_parameter_values ?? [],
+		touched: form.touched,
 		setFieldValue: form.setFieldValue,
 	});
 
@@ -445,6 +448,7 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 					onSubmit={form.handleSubmit}
 					aria-label="Create workspace form"
 					className="flex flex-col gap-10 w-full border border-border-default border-solid rounded-lg p-6"
+					data-testid="form"
 				>
 					{Boolean(error) && <ErrorAlert error={error} />}
 

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.jest.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.jest.tsx
@@ -55,12 +55,11 @@ function setupDynamicParameterWebSocket(
 		},
 	};
 
-	jest.spyOn(API, "templateVersionDynamicParameters").mockImplementation(
-		(_versionId, _ownerId, callbacks) => {
+	jest
+		.spyOn(API, "templateVersionDynamicParameters")
+		.mockImplementation((_versionId, _ownerId, callbacks) => {
 			fakeSocket.addEventListener("message", (event) => {
-				callbacks.onMessage(
-					JSON.parse((event as MessageEvent<string>).data),
-				);
+				callbacks.onMessage(JSON.parse((event as MessageEvent<string>).data));
 			});
 			fakeSocket.addEventListener("error", () => {
 				callbacks.onError(
@@ -77,8 +76,7 @@ function setupDynamicParameterWebSocket(
 				}),
 			);
 			return fakeSocket as unknown as WebSocket;
-		},
-	);
+		});
 
 	return publisher;
 }
@@ -105,19 +103,23 @@ describe("WorkspaceParametersPageExperimental", () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks();
-		jest.spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValueOnce(
-			MockWorkspace,
-		);
-		jest.spyOn(API, "getTemplateVersionRichParameters").mockResolvedValueOnce([
-			MockTemplateVersionParameter1,
-			MockTemplateVersionParameter2,
-			MockTemplateVersionParameter4,
-		]);
-		jest.spyOn(API, "getWorkspaceBuildParameters").mockResolvedValueOnce([
-			MockWorkspaceBuildParameter1,
-			MockWorkspaceBuildParameter2,
-			MockWorkspaceBuildParameter4,
-		]);
+		jest
+			.spyOn(API, "getWorkspaceByOwnerAndName")
+			.mockResolvedValueOnce(MockWorkspace);
+		jest
+			.spyOn(API, "getTemplateVersionRichParameters")
+			.mockResolvedValueOnce([
+				MockTemplateVersionParameter1,
+				MockTemplateVersionParameter2,
+				MockTemplateVersionParameter4,
+			]);
+		jest
+			.spyOn(API, "getWorkspaceBuildParameters")
+			.mockResolvedValueOnce([
+				MockWorkspaceBuildParameter1,
+				MockWorkspaceBuildParameter2,
+				MockWorkspaceBuildParameter4,
+			]);
 	});
 
 	afterEach(() => {

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.jest.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.jest.tsx
@@ -43,7 +43,7 @@ function setupDynamicParameterWebSocket(
 		removeEventListener: (type: string, cb: (e: unknown) => void) => {
 			subs[type]?.delete(cb);
 		},
-		close: vi.fn(),
+		close: jest.fn(),
 	};
 
 	const publisher: Publisher = {
@@ -55,7 +55,7 @@ function setupDynamicParameterWebSocket(
 		},
 	};
 
-	vi.spyOn(API, "templateVersionDynamicParameters").mockImplementation(
+	jest.spyOn(API, "templateVersionDynamicParameters").mockImplementation(
 		(_versionId, _ownerId, callbacks) => {
 			fakeSocket.addEventListener("message", (event) => {
 				callbacks.onMessage(
@@ -104,16 +104,16 @@ describe("WorkspaceParametersPageExperimental", () => {
 	};
 
 	beforeEach(() => {
-		vi.clearAllMocks();
-		vi.spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValueOnce(
+		jest.clearAllMocks();
+		jest.spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValueOnce(
 			MockWorkspace,
 		);
-		vi.spyOn(API, "getTemplateVersionRichParameters").mockResolvedValueOnce([
+		jest.spyOn(API, "getTemplateVersionRichParameters").mockResolvedValueOnce([
 			MockTemplateVersionParameter1,
 			MockTemplateVersionParameter2,
 			MockTemplateVersionParameter4,
 		]);
-		vi.spyOn(API, "getWorkspaceBuildParameters").mockResolvedValueOnce([
+		jest.spyOn(API, "getWorkspaceBuildParameters").mockResolvedValueOnce([
 			MockWorkspaceBuildParameter1,
 			MockWorkspaceBuildParameter2,
 			MockWorkspaceBuildParameter4,
@@ -121,8 +121,8 @@ describe("WorkspaceParametersPageExperimental", () => {
 	});
 
 	afterEach(() => {
-		vi.useRealTimers();
-		vi.restoreAllMocks();
+		jest.useRealTimers();
+		jest.restoreAllMocks();
 	});
 
 	it("does not clobber touched parameters", async () => {

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.test.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.test.tsx
@@ -1,0 +1,170 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import { act } from "react";
+import { API } from "#/api/api";
+import type { DynamicParametersResponse } from "#/api/typesGenerated";
+import {
+	MockPreviewParameter,
+	MockTemplateVersionParameter1,
+	MockTemplateVersionParameter2,
+	MockTemplateVersionParameter4,
+	MockValidationParameter,
+	MockWorkspace,
+	MockWorkspaceBuildParameter1,
+	MockWorkspaceBuildParameter2,
+	MockWorkspaceBuildParameter4,
+} from "#/testHelpers/entities";
+import {
+	renderWithWorkspaceSettingsLayout,
+	waitForLoaderToBeRemoved,
+} from "#/testHelpers/renderHelpers";
+import WorkspaceParametersPageExperimental from "./WorkspaceParametersPageExperimental";
+
+// Minimal inline publisher for vitest. The shared websockets.ts helper
+// uses jest globals and cannot be imported from vitest on this branch.
+type Publisher = {
+	publishMessage: (event: MessageEvent<string>) => void;
+	publishOpen: (event: Event) => void;
+};
+
+function setupDynamicParameterWebSocket(
+	response: DynamicParametersResponse,
+): Publisher {
+	const subs: Record<string, Set<(e: unknown) => void>> = {
+		message: new Set(),
+		error: new Set(),
+		close: new Set(),
+		open: new Set(),
+	};
+
+	const fakeSocket = {
+		addEventListener: (type: string, cb: (e: unknown) => void) => {
+			subs[type]?.add(cb);
+		},
+		removeEventListener: (type: string, cb: (e: unknown) => void) => {
+			subs[type]?.delete(cb);
+		},
+		close: vi.fn(),
+	};
+
+	const publisher: Publisher = {
+		publishOpen: (event) => {
+			for (const sub of subs.open) sub(event);
+		},
+		publishMessage: (event) => {
+			for (const sub of subs.message) sub(event);
+		},
+	};
+
+	vi.spyOn(API, "templateVersionDynamicParameters").mockImplementation(
+		(_versionId, _ownerId, callbacks) => {
+			fakeSocket.addEventListener("message", (event) => {
+				callbacks.onMessage(
+					JSON.parse((event as MessageEvent<string>).data),
+				);
+			});
+			fakeSocket.addEventListener("error", () => {
+				callbacks.onError(
+					new Error("Connection for dynamic parameters failed."),
+				);
+			});
+			fakeSocket.addEventListener("close", () => {
+				callbacks.onClose();
+			});
+			publisher.publishOpen(new Event("open"));
+			publisher.publishMessage(
+				new MessageEvent("message", {
+					data: JSON.stringify(response),
+				}),
+			);
+			return fakeSocket as unknown as WebSocket;
+		},
+	);
+
+	return publisher;
+}
+
+describe("WorkspaceParametersPageExperimental", () => {
+	const renderWorkspaceParametersPageExperimental = (
+		route = `/@${MockWorkspace.owner_name}/${MockWorkspace.name}/settings`,
+	) => {
+		return renderWithWorkspaceSettingsLayout(
+			<WorkspaceParametersPageExperimental />,
+			{
+				route,
+				path: "/:username/:workspace/settings",
+				extraRoutes: [
+					{
+						// Need this because after submit the user is redirected.
+						path: "/:username/:workspace",
+						element: <div>Workspace Page</div>,
+					},
+				],
+			},
+		);
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValueOnce(
+			MockWorkspace,
+		);
+		vi.spyOn(API, "getTemplateVersionRichParameters").mockResolvedValueOnce([
+			MockTemplateVersionParameter1,
+			MockTemplateVersionParameter2,
+			MockTemplateVersionParameter4,
+		]);
+		vi.spyOn(API, "getWorkspaceBuildParameters").mockResolvedValueOnce([
+			MockWorkspaceBuildParameter1,
+			MockWorkspaceBuildParameter2,
+			MockWorkspaceBuildParameter4,
+		]);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("does not clobber touched parameters", async () => {
+		const publisher = setupDynamicParameterWebSocket({
+			id: 0,
+			parameters: [
+				{
+					...MockPreviewParameter,
+					name: MockWorkspaceBuildParameter1.name,
+				},
+			],
+			diagnostics: [],
+		});
+
+		renderWorkspaceParametersPageExperimental();
+		await waitForLoaderToBeRemoved();
+
+		// Simulate a stale response.
+		await act(async () => {
+			publisher.publishMessage(
+				new MessageEvent("message", {
+					data: JSON.stringify({
+						id: 2,
+						parameters: [
+							{
+								...MockPreviewParameter,
+								name: MockWorkspaceBuildParameter1.name,
+							},
+							MockValidationParameter,
+						],
+					}),
+				}),
+			);
+		});
+
+		// Should have the new field, but keep the existing auto-filled values.
+		const form = screen.getByTestId("form");
+		await waitFor(() => {
+			expect(within(form).getByDisplayValue("50")).toBeInTheDocument();
+			expect(
+				within(form).getByDisplayValue(MockWorkspaceBuildParameter1.value),
+			).toBeInTheDocument();
+		});
+	});
+});

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageViewExperimental.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageViewExperimental.tsx
@@ -60,6 +60,9 @@ export const WorkspaceParametersPageViewExperimental: FC<
 				autofillParameters,
 			),
 		},
+		initialTouched: Object.fromEntries(
+			autofillParameters.map((p) => [p.name, true]),
+		),
 		validationSchema: useValidationSchemaForDynamicParameters(parameters),
 		enableReinitialize: false,
 		validateOnChange: true,
@@ -97,12 +100,14 @@ export const WorkspaceParametersPageViewExperimental: FC<
 			name: parameter.name,
 			value,
 		});
+		form.setFieldTouched(parameter.name, true);
 		sendDynamicParamsRequest(parameter, value);
 	};
 
 	useSyncFormParameters({
 		parameters,
 		formValues: form.values.rich_parameter_values ?? [],
+		touched: form.touched,
 		setFieldValue: form.setFieldValue,
 	});
 
@@ -201,7 +206,11 @@ export const WorkspaceParametersPageViewExperimental: FC<
 				</div>
 			)}
 
-			<form onSubmit={form.handleSubmit} className="flex flex-col gap-8">
+			<form
+				onSubmit={form.handleSubmit}
+				className="flex flex-col gap-8"
+				data-testid="form"
+			>
 				{parameters.length > 0 && (
 					<section className="flex flex-col gap-9">
 						<hgroup>

--- a/site/src/testHelpers/websockets.ts
+++ b/site/src/testHelpers/websockets.ts
@@ -1,3 +1,9 @@
+import type { Mock } from "vitest";
+import { API } from "#/api/api";
+import type {
+	DynamicParametersResponse,
+	PreviewParameter,
+} from "#/api/typesGenerated";
 import type { WebSocketEventType } from "#/utils/OneWayWebSocket";
 
 type SocketSendData = Parameters<WebSocket["send"]>[0];
@@ -19,15 +25,15 @@ type CallbackStore = {
 type MockWebSocket = Omit<WebSocket, "send"> & {
 	/**
 	 * A version of the WebSocket `send` method that has been pre-wrapped inside
-	 * a Jest mock.
+	 * a vitest mock.
 	 *
-	 * The Jest mock functionality should be used at a minimum. Basically:
+	 * The vitest mock functionality should be used at a minimum. Basically:
 	 * 1. If you want to check that the mock socket sent something to the mock
 	 *    server: call the `send` method as a function, and then check the
 	 *    `clientSentData` on `MockWebSocketServer` to see what data got
 	 *    received.
 	 * 2. If you need to make sure that the client-side `send` method got called
-	 *    at all: you can use the Jest mock functionality, but you should
+	 *    at all: you can use the vitest mock functionality, but you should
 	 *    probably also be checking `clientSentData` still and making additional
 	 *    assertions with it.
 	 *
@@ -35,7 +41,7 @@ type MockWebSocket = Omit<WebSocket, "send"> & {
 	 * communication was successful, not whether the client-side method was
 	 * called.
 	 */
-	send: jest.Mock<void, [SocketSendData], unknown>;
+	send: Mock<(data: SocketSendData) => void>;
 };
 
 export function createMockWebSocket(
@@ -159,4 +165,42 @@ export function createMockWebSocket(
 	};
 
 	return [mockSocket, publisher] as const;
+}
+
+export function mockDynamicParameterWebSocket(
+	response: DynamicParametersResponse | readonly PreviewParameter[],
+): readonly [MockWebSocket, MockWebSocketServer] {
+	let message: DynamicParametersResponse;
+	if (Array.isArray(response)) {
+		message = {
+			id: 0,
+			parameters: response,
+			diagnostics: [],
+		};
+	} else {
+		message = response as DynamicParametersResponse;
+	}
+	const [mockWebSocket, mockPublisher] = createMockWebSocket("ws://test");
+	jest.spyOn(API, "templateVersionDynamicParameters").mockImplementation(
+		(_versionId, _ownerId, callbacks) => {
+			mockWebSocket.addEventListener("message", (event) => {
+				callbacks.onMessage(JSON.parse(event.data));
+			});
+			mockWebSocket.addEventListener("error", () => {
+				callbacks.onError(
+					new Error("Connection for dynamic parameters failed."),
+				);
+			});
+			mockWebSocket.addEventListener("close", () => {
+				callbacks.onClose();
+			});
+			mockPublisher.publishOpen(new Event("open"));
+			mockPublisher.publishMessage(
+				new MessageEvent("message", { data: JSON.stringify(message) }),
+			);
+
+			return mockWebSocket;
+		},
+	);
+	return [mockWebSocket, mockPublisher];
 }

--- a/site/src/testHelpers/websockets.ts
+++ b/site/src/testHelpers/websockets.ts
@@ -180,8 +180,9 @@ export function mockDynamicParameterWebSocket(
 		message = response as DynamicParametersResponse;
 	}
 	const [mockWebSocket, mockPublisher] = createMockWebSocket("ws://test");
-	jest.spyOn(API, "templateVersionDynamicParameters").mockImplementation(
-		(_versionId, _ownerId, callbacks) => {
+	jest
+		.spyOn(API, "templateVersionDynamicParameters")
+		.mockImplementation((_versionId, _ownerId, callbacks) => {
 			mockWebSocket.addEventListener("message", (event) => {
 				callbacks.onMessage(JSON.parse(event.data));
 			});
@@ -199,7 +200,6 @@ export function mockDynamicParameterWebSocket(
 			);
 
 			return mockWebSocket;
-		},
-	);
+		});
 	return [mockWebSocket, mockPublisher];
 }

--- a/site/src/testHelpers/websockets.ts
+++ b/site/src/testHelpers/websockets.ts
@@ -1,4 +1,3 @@
-import type { Mock } from "vitest";
 import { API } from "#/api/api";
 import type {
 	DynamicParametersResponse,
@@ -25,15 +24,15 @@ type CallbackStore = {
 type MockWebSocket = Omit<WebSocket, "send"> & {
 	/**
 	 * A version of the WebSocket `send` method that has been pre-wrapped inside
-	 * a vitest mock.
+	 * a Jest mock.
 	 *
-	 * The vitest mock functionality should be used at a minimum. Basically:
+	 * The Jest mock functionality should be used at a minimum. Basically:
 	 * 1. If you want to check that the mock socket sent something to the mock
 	 *    server: call the `send` method as a function, and then check the
 	 *    `clientSentData` on `MockWebSocketServer` to see what data got
 	 *    received.
 	 * 2. If you need to make sure that the client-side `send` method got called
-	 *    at all: you can use the vitest mock functionality, but you should
+	 *    at all: you can use the Jest mock functionality, but you should
 	 *    probably also be checking `clientSentData` still and making additional
 	 *    assertions with it.
 	 *
@@ -41,7 +40,7 @@ type MockWebSocket = Omit<WebSocket, "send"> & {
 	 * communication was successful, not whether the client-side method was
 	 * called.
 	 */
-	send: Mock<(data: SocketSendData) => void>;
+	send: jest.Mock<void, [SocketSendData], unknown>;
 };
 
 export function createMockWebSocket(


### PR DESCRIPTION
Backport of https://github.com/coder/coder/pull/24645 to `release/2.32`.

Once a user has touched a field, it is better to leave it alone and display explicit validation errors over silently overwriting their inputs. Same for auto-filled values (whether from query parameters or a previous build).

Original PR: #24645 — fix: do not clobber dynamic parameters
Merge commit: d958d89b6f8d2356bd597acd9df5bd6030e589eb

Closes #23418

<details>
<summary>Cherry-pick conflict resolution</summary>

Two conflicts resolved:

1. **`site/src/testHelpers/websockets.ts`**: File was empty on release/2.32. Took the incoming version with the new `mockDynamicParameterWebSocket` helper.

2. **`site/src/pages/CreateWorkspacePage/CreateWorkspacePage.jest.tsx`**: File is `.jest.tsx` on the release branch (`.test.tsx` on main). Applied the incoming content (refactored websocket mocking, modernized test calls) to the existing `.jest.tsx` filename.

</details>

> [!NOTE]
> Generated with [Coder Agents](https://coder.com) by @rowansmithau