### PR TITLE
fix: do not clobber dynamic parameters (backport #24645 to 2.29)

### DIFF
--- a/site/src/modules/hooks/useSyncFormParameters.ts
+++ b/site/src/modules/hooks/useSyncFormParameters.ts
@@ -5,6 +5,7 @@ import { useEffect, useRef } from "react";
 type UseSyncFormParametersProps = {
 	parameters: readonly PreviewParameter[];
 	formValues: readonly TypesGen.WorkspaceBuildParameter[];
+	protectedParameters?: ReadonlySet<string>;
 	setFieldValue: (
 		field: string,
 		value: TypesGen.WorkspaceBuildParameter[],
@@ -14,6 +15,7 @@ type UseSyncFormParametersProps = {
 export function useSyncFormParameters({
 	parameters,
 	formValues,
+	protectedParameters,
 	setFieldValue,
 }: UseSyncFormParametersProps) {
 	// Form values only needs to be updated when parameters change
@@ -32,13 +34,12 @@ export function useSyncFormParameters({
 		);
 
 		const newParameterValues = parameters.map((param) => {
-			// When the server value is not valid (e.g., the initial
-			// WebSocket response before any user input is sent),
-			// preserve the current form value. This prevents the sync
-			// hook from overwriting autofilled values (from the
-			// previous build) with empty strings before the server
-			// has had a chance to process them.
-			if (!param.value.valid) {
+			// Do not mess with values the user has changed (or were auto-filled).
+			// Otherwise based on timing web socket responses can undo changes, and it
+			// seems bad to change a user's inputs from under them anyway.
+			const isProtected =
+				!param.value.valid || protectedParameters?.has(param.name);
+			if (isProtected) {
 				const existingValue = currentFormValuesMap.get(param.name);
 				if (existingValue !== undefined) {
 					return { name: param.name, value: existingValue };
@@ -62,5 +63,5 @@ export function useSyncFormParameters({
 		if (isChanged) {
 			setFieldValue("rich_parameter_values", newParameterValues);
 		}
-	}, [parameters, setFieldValue]);
+	}, [parameters, protectedParameters, setFieldValue]);
 }

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.jest.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.jest.tsx
@@ -3,6 +3,7 @@ import {
 	MockDynamicParametersResponse,
 	MockDynamicParametersResponseWithError,
 	MockPermissions,
+	MockPreviewParameter,
 	MockSliderParameter,
 	MockTemplate,
 	MockTemplateVersionExternalAuthGithub,
@@ -15,8 +16,11 @@ import {
 	renderWithAuth,
 	waitForLoaderToBeRemoved,
 } from "testHelpers/renderHelpers";
-import { createMockWebSocket } from "testHelpers/websockets";
-import { screen, waitFor } from "@testing-library/react";
+import {
+	createMockWebSocket,
+	mockDynamicParameterWebSocket,
+} from "testHelpers/websockets";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { API } from "api/api";
 import type { DynamicParametersResponse } from "api/typesGenerated";
@@ -47,33 +51,7 @@ describe("CreateWorkspacePage", () => {
 		jest.spyOn(API, "getTemplateVersionPresets").mockResolvedValue([]);
 		jest.spyOn(API, "createWorkspace").mockResolvedValue(MockWorkspace);
 		jest.spyOn(API, "checkAuthorization").mockResolvedValue(MockPermissions);
-
-		jest
-			.spyOn(API, "templateVersionDynamicParameters")
-			.mockImplementation((_versionId, _ownerId, callbacks) => {
-				const [mockWebSocket, publisher] = createMockWebSocket("ws://test");
-
-				mockWebSocket.addEventListener("message", (event) => {
-					callbacks.onMessage(JSON.parse(event.data));
-				});
-				mockWebSocket.addEventListener("error", () => {
-					callbacks.onError(
-						new Error("Connection for dynamic parameters failed."),
-					);
-				});
-				mockWebSocket.addEventListener("close", () => {
-					callbacks.onClose();
-				});
-
-				publisher.publishOpen(new Event("open"));
-				publisher.publishMessage(
-					new MessageEvent("message", {
-						data: JSON.stringify(MockDynamicParametersResponse),
-					}),
-				);
-
-				return mockWebSocket;
-			});
+		mockDynamicParameterWebSocket(MockDynamicParametersResponse);
 	});
 
 	afterEach(() => {
@@ -105,32 +83,9 @@ describe("CreateWorkspacePage", () => {
 		});
 
 		it("sends parameter updates via WebSocket when form values change", async () => {
-			const [mockWebSocket, publisher] = createMockWebSocket("ws://test");
-
-			jest
-				.spyOn(API, "templateVersionDynamicParameters")
-				.mockImplementation((_versionId, _ownerId, callbacks) => {
-					mockWebSocket.addEventListener("message", (event) => {
-						callbacks.onMessage(JSON.parse(event.data));
-					});
-					mockWebSocket.addEventListener("error", () => {
-						callbacks.onError(
-							new Error("Connection for dynamic parameters failed."),
-						);
-					});
-					mockWebSocket.addEventListener("close", () => {
-						callbacks.onClose();
-					});
-
-					publisher.publishOpen(new Event("open"));
-					publisher.publishMessage(
-						new MessageEvent("message", {
-							data: JSON.stringify(MockDynamicParametersResponse),
-						}),
-					);
-
-					return mockWebSocket;
-				});
+			const [mockWebSocket] = mockDynamicParameterWebSocket(
+				MockDynamicParametersResponse,
+			);
 
 			renderCreateWorkspacePage();
 			await waitForLoaderToBeRemoved();
@@ -216,27 +171,9 @@ describe("CreateWorkspacePage", () => {
 		});
 
 		it("only parameters from latest response are displayed", async () => {
-			const [mockWebSocket, mockPublisher] = createMockWebSocket("ws://test");
-			jest
-				.spyOn(API, "templateVersionDynamicParameters")
-				.mockImplementation((_versionId, _ownerId, callbacks) => {
-					mockWebSocket.addEventListener("message", (event) => {
-						callbacks.onMessage(JSON.parse(event.data));
-					});
-
-					mockPublisher.publishOpen(new Event("open"));
-					mockPublisher.publishMessage(
-						new MessageEvent("message", {
-							data: JSON.stringify({
-								id: 0,
-								parameters: [MockDropdownParameter],
-								diagnostics: [],
-							}),
-						}),
-					);
-
-					return mockWebSocket;
-				});
+			const [, mockPublisher] = mockDynamicParameterWebSocket([
+				MockDropdownParameter,
+			]);
 
 			renderCreateWorkspacePage();
 			await waitForLoaderToBeRemoved();
@@ -265,27 +202,89 @@ describe("CreateWorkspacePage", () => {
 			expect(screen.queryByText("CPU Count")).toBeInTheDocument();
 			expect(screen.queryByText("Instance Type")).not.toBeInTheDocument();
 		});
+
+		it("does not clobber user values", async () => {
+			const [, mockPublisher] = mockDynamicParameterWebSocket([
+				MockPreviewParameter,
+			]);
+
+			renderCreateWorkspacePage();
+			await waitForLoaderToBeRemoved();
+
+			const form = screen.getByTestId("form");
+			const input = await within(form).findByRole("textbox", {
+				name: /parameter 1/i,
+			});
+			await userEvent.clear(input);
+			await userEvent.type(input, "hi there hello");
+
+			await waitFor(() => {
+				expect(
+					within(form).getByDisplayValue("hi there hello"),
+				).toBeInTheDocument();
+			});
+
+			// Simulate a stale response.
+			await act(async () => {
+				mockPublisher.publishMessage(
+					new MessageEvent("message", {
+						data: JSON.stringify({
+							id: 1,
+							parameters: [MockPreviewParameter, MockValidationParameter],
+						}),
+					}),
+				);
+			});
+
+			// Should have the new field, but keep the existing user-filled values.
+			await waitFor(() => {
+				expect(within(form).getByDisplayValue("50")).toBeInTheDocument();
+				expect(
+					within(form).getByDisplayValue("hi there hello"),
+				).toBeInTheDocument();
+			});
+		});
+
+		it("does not clobber auto-filled values", async () => {
+			const [, mockPublisher] = mockDynamicParameterWebSocket([
+				MockPreviewParameter,
+				MockSliderParameter,
+			]);
+
+			renderCreateWorkspacePage(
+				`/templates/${MockTemplate.name}/workspace?param.cpu_count=44&param.parameter1=auto`,
+			);
+			await waitForLoaderToBeRemoved();
+
+			// Simulate a stale response.
+			await act(async () => {
+				mockPublisher.publishMessage(
+					new MessageEvent("message", {
+						data: JSON.stringify({
+							id: 2,
+							parameters: [
+								MockPreviewParameter,
+								MockSliderParameter,
+								MockValidationParameter,
+							],
+						}),
+					}),
+				);
+			});
+
+			// Should have the new field, but keep the existing auto-filled values.
+			const form = screen.getByTestId("form");
+			await waitFor(() => {
+				expect(within(form).getByDisplayValue("50")).toBeInTheDocument();
+				expect(within(form).getByDisplayValue("44")).toBeInTheDocument();
+				expect(within(form).getByDisplayValue("auto")).toBeInTheDocument();
+			});
+		});
 	});
 
 	describe("Dynamic Parameter Types", () => {
 		it("displays parameter validation errors", async () => {
-			jest
-				.spyOn(API, "templateVersionDynamicParameters")
-				.mockImplementation((_versionId, _ownerId, callbacks) => {
-					const [mockWebSocket, publisher] = createMockWebSocket("ws://test");
-
-					mockWebSocket.addEventListener("message", (event) => {
-						callbacks.onMessage(JSON.parse(event.data));
-					});
-
-					publisher.publishMessage(
-						new MessageEvent("message", {
-							data: JSON.stringify(MockDynamicParametersResponseWithError),
-						}),
-					);
-
-					return mockWebSocket;
-				});
+			mockDynamicParameterWebSocket(MockDynamicParametersResponseWithError);
 
 			renderCreateWorkspacePage();
 			await waitForLoaderToBeRemoved();
@@ -329,38 +328,20 @@ describe("CreateWorkspacePage", () => {
 				diagnostics: [],
 			};
 
-			jest
-				.spyOn(API, "templateVersionDynamicParameters")
-				.mockImplementation((_versionId, _ownerId, callbacks) => {
-					const [mockWebSocket, publisher] = createMockWebSocket("ws://test");
+			const [mockWebSocket, publisher] =
+				mockDynamicParameterWebSocket(mockResponseInitial);
+			const originalSend = mockWebSocket.send;
+			mockWebSocket.send = jest.fn((data) => {
+				originalSend.call(mockWebSocket, data);
 
-					mockWebSocket.addEventListener("message", (event) => {
-						callbacks.onMessage(JSON.parse(event.data));
-					});
-
-					publisher.publishOpen(new Event("open"));
-
+				if (typeof data === "string" && data.includes('"200"')) {
 					publisher.publishMessage(
 						new MessageEvent("message", {
-							data: JSON.stringify(mockResponseInitial),
+							data: JSON.stringify(mockResponseWithError),
 						}),
 					);
-
-					const originalSend = mockWebSocket.send;
-					mockWebSocket.send = jest.fn((data) => {
-						originalSend.call(mockWebSocket, data);
-
-						if (typeof data === "string" && data.includes('"200"')) {
-							publisher.publishMessage(
-								new MessageEvent("message", {
-									data: JSON.stringify(mockResponseWithError),
-								}),
-							);
-						}
-					});
-
-					return mockWebSocket;
-				});
+				}
+			});
 
 			renderCreateWorkspacePage();
 			await waitForLoaderToBeRemoved();

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -114,17 +114,31 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 		autofillParameters.map((param) => [param.name, param]),
 	);
 
-	// Only touched fields are sent to the websocket
-	// Autofilled parameters are marked as touched since they have been modified
-	const initialTouched = Object.fromEntries(
-		parameters.filter((p) => autofillByName[p.name]).map((p) => [p.name, true]),
+	// Track which parameters are protected from websocket overwrites.
+	// Autofilled parameters start protected, and user changes add to the set.
+	const [protectedParameters, setProtectedParameters] = useState(
+		() =>
+			new Set(
+				parameters.filter((p) => autofillByName[p.name]).map((p) => p.name),
+			),
 	);
+
+	const protectParameter = useCallback((name: string) => {
+		setProtectedParameters((prev) => {
+			if (prev.has(name)) return prev;
+			const next = new Set(prev);
+			next.add(name);
+			return next;
+		});
+	}, []);
 
 	// The form parameters values hold the working state of the parameters that will be submitted when creating a workspace
 	// 1. The form parameter values are initialized from the websocket response when the form is mounted
 	// 2. Only touched form fields are sent to the websocket, a field is touched if edited by the user or set by autofill
 	// 3. The websocket response may add or remove parameters, these are added or removed from the form values in the useSyncFormParameters hook
-	// 4. All existing form parameters are updated to match the websocket response in the useSyncFormParameters hook
+	// 4. All existing form parameters are updated to match the websocket response
+	//    in the useSyncFormParameters hook, unless they have been touched by the
+	//    user or auto-filled.
 	const form: FormikContextType<TypesGen.CreateWorkspaceRequest> =
 		useFormik<TypesGen.CreateWorkspaceRequest>({
 			initialValues: {
@@ -135,7 +149,11 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 					autofillParameters,
 				),
 			},
-			initialTouched,
+			initialTouched: Object.fromEntries(
+				parameters
+					.filter((p) => autofillByName[p.name])
+					.map((p) => [p.name, true]),
+			),
 			validationSchema: Yup.object({
 				name: nameValidator("Workspace Name"),
 				rich_parameter_values:
@@ -285,6 +303,7 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 			for (const update of updates) {
 				form.setFieldValue(update.field, update.fieldValue);
 				form.setFieldTouched(update.parameter.name, true);
+				protectParameter(update.parameter.name);
 			}
 
 			sendDynamicParamsRequest(
@@ -300,6 +319,7 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 		presets,
 		form.setFieldValue,
 		form.setFieldTouched,
+		protectParameter,
 		parameters,
 		form.values.rich_parameter_values,
 		sendDynamicParamsRequest,
@@ -327,6 +347,7 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 		// Only send the request if the value has changed from the form value
 		if (currentFormValue !== value) {
 			form.setFieldTouched(parameter.name, true);
+			protectParameter(parameter.name);
 			sendDynamicParamsRequest([{ parameter, value }]);
 		}
 	};
@@ -334,6 +355,7 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 	useSyncFormParameters({
 		parameters,
 		formValues: form.values.rich_parameter_values ?? [],
+		protectedParameters,
 		setFieldValue: form.setFieldValue,
 	});
 
@@ -419,6 +441,7 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 					onSubmit={form.handleSubmit}
 					aria-label="Create workspace form"
 					className="flex flex-col gap-10 w-full border border-border-default border-solid rounded-lg p-6"
+					data-testid="form"
 				>
 					{Boolean(error) && <ErrorAlert error={error} />}
 

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.jest.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.jest.tsx
@@ -1,0 +1,107 @@
+import {
+	MockPreviewParameter,
+	MockTemplateVersionParameter1,
+	MockTemplateVersionParameter2,
+	MockTemplateVersionParameter4,
+	MockValidationParameter,
+	MockWorkspace,
+	MockWorkspaceBuildParameter1,
+	MockWorkspaceBuildParameter2,
+	MockWorkspaceBuildParameter4,
+} from "testHelpers/entities";
+import {
+	renderWithWorkspaceSettingsLayout,
+	waitForLoaderToBeRemoved,
+} from "testHelpers/renderHelpers";
+import { mockDynamicParameterWebSocket } from "testHelpers/websockets";
+import { screen, waitFor, within } from "@testing-library/react";
+import { API } from "api/api";
+import { act } from "react";
+import WorkspaceParametersPageExperimental from "./WorkspaceParametersPageExperimental";
+
+describe("WorkspaceParametersPageExperimental", () => {
+	const renderWorkspaceParametersPageExperimental = (
+		route = `/@${MockWorkspace.owner_name}/${MockWorkspace.name}/settings`,
+	) => {
+		return renderWithWorkspaceSettingsLayout(
+			<WorkspaceParametersPageExperimental />,
+			{
+				route,
+				path: "/:username/:workspace/settings",
+				extraRoutes: [
+					{
+						// Need this because after submit the user is redirected.
+						path: "/:username/:workspace",
+						element: <div>Workspace Page</div>,
+					},
+				],
+			},
+		);
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		jest
+			.spyOn(API, "getWorkspaceByOwnerAndName")
+			.mockResolvedValueOnce(MockWorkspace);
+		jest
+			.spyOn(API, "getTemplateVersionRichParameters")
+			.mockResolvedValueOnce([
+				MockTemplateVersionParameter1,
+				MockTemplateVersionParameter2,
+				MockTemplateVersionParameter4,
+			]);
+		jest
+			.spyOn(API, "getWorkspaceBuildParameters")
+			.mockResolvedValueOnce([
+				MockWorkspaceBuildParameter1,
+				MockWorkspaceBuildParameter2,
+				MockWorkspaceBuildParameter4,
+			]);
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+		jest.restoreAllMocks();
+	});
+
+	it("does not clobber touched parameters", async () => {
+		const [, mockPublisher] = mockDynamicParameterWebSocket([
+			{
+				...MockPreviewParameter,
+				name: MockWorkspaceBuildParameter1.name,
+			},
+		]);
+
+		renderWorkspaceParametersPageExperimental();
+		await waitForLoaderToBeRemoved();
+
+		// Simulate a stale response.
+		await act(async () => {
+			mockPublisher.publishMessage(
+				new MessageEvent("message", {
+					data: JSON.stringify({
+						id: 2,
+						diagnostics: [],
+						parameters: [
+							{
+								...MockPreviewParameter,
+								name: MockWorkspaceBuildParameter1.name,
+							},
+							MockValidationParameter,
+						],
+					}),
+				}),
+			);
+		});
+
+		// Should have the new field, but keep the existing auto-filled values.
+		const form = screen.getByTestId("form");
+		await waitFor(() => {
+			expect(within(form).getByDisplayValue("50")).toBeInTheDocument();
+			expect(
+				within(form).getByDisplayValue(MockWorkspaceBuildParameter1.value),
+			).toBeInTheDocument();
+		});
+	});
+});

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageViewExperimental.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageViewExperimental.tsx
@@ -15,7 +15,7 @@ import {
 	getInitialParameterValues,
 	useValidationSchemaForDynamicParameters,
 } from "modules/workspaces/DynamicParameter/DynamicParameter";
-import type { FC } from "react";
+import { type FC, useState } from "react";
 import { docs } from "utils/docs";
 import type { AutofillBuildParameter } from "utils/richParameters";
 
@@ -48,6 +48,10 @@ export const WorkspaceParametersPageViewExperimental: FC<
 	onCancel,
 	templateVersionId,
 }) => {
+	const [protectedParameters, setProtectedParameters] = useState(
+		() => new Set(autofillParameters.map((p) => p.name)),
+	);
+
 	const form = useFormik({
 		onSubmit,
 		initialValues: {
@@ -76,6 +80,12 @@ export const WorkspaceParametersPageViewExperimental: FC<
 			name: parameter.name,
 			value,
 		});
+		setProtectedParameters((prev: Set<string>) => {
+			if (prev.has(parameter.name)) return prev;
+			const next = new Set(prev);
+			next.add(parameter.name);
+			return next;
+		});
 		sendDynamicParamsRequest(parameter, value);
 	};
 
@@ -99,6 +109,7 @@ export const WorkspaceParametersPageViewExperimental: FC<
 	useSyncFormParameters({
 		parameters,
 		formValues: form.values.rich_parameter_values ?? [],
+		protectedParameters,
 		setFieldValue: form.setFieldValue,
 	});
 
@@ -182,7 +193,11 @@ export const WorkspaceParametersPageViewExperimental: FC<
 				</div>
 			)}
 
-			<form onSubmit={form.handleSubmit} className="flex flex-col gap-8">
+			<form
+				onSubmit={form.handleSubmit}
+				className="flex flex-col gap-8"
+				data-testid="form"
+			>
 				{parameters.length > 0 && (
 					<section className="flex flex-col gap-9">
 						<hgroup>

--- a/site/src/testHelpers/websockets.ts
+++ b/site/src/testHelpers/websockets.ts
@@ -1,3 +1,8 @@
+import { API } from "api/api";
+import type {
+	DynamicParametersResponse,
+	PreviewParameter,
+} from "api/typesGenerated";
 import type { WebSocketEventType } from "utils/OneWayWebSocket";
 
 type SocketSendData = Parameters<WebSocket["send"]>[0];
@@ -159,4 +164,42 @@ export function createMockWebSocket(
 	};
 
 	return [mockSocket, publisher] as const;
+}
+
+export function mockDynamicParameterWebSocket(
+	response: DynamicParametersResponse | readonly PreviewParameter[],
+): readonly [MockWebSocket, MockWebSocketServer] {
+	let message: DynamicParametersResponse;
+	if (Array.isArray(response)) {
+		message = {
+			id: 0,
+			parameters: response,
+			diagnostics: [],
+		};
+	} else {
+		message = response as DynamicParametersResponse;
+	}
+	const [mockWebSocket, mockPublisher] = createMockWebSocket("ws://test");
+	jest
+		.spyOn(API, "templateVersionDynamicParameters")
+		.mockImplementation((_versionId, _ownerId, callbacks) => {
+			mockWebSocket.addEventListener("message", (event) => {
+				callbacks.onMessage(JSON.parse(event.data));
+			});
+			mockWebSocket.addEventListener("error", () => {
+				callbacks.onError(
+					new Error("Connection for dynamic parameters failed."),
+				);
+			});
+			mockWebSocket.addEventListener("close", () => {
+				callbacks.onClose();
+			});
+			mockPublisher.publishOpen(new Event("open"));
+			mockPublisher.publishMessage(
+				new MessageEvent("message", { data: JSON.stringify(message) }),
+			);
+
+			return mockWebSocket;
+		});
+	return [mockWebSocket, mockPublisher];
 }


### PR DESCRIPTION
Backport of https://github.com/coder/coder/pull/24645 to `release/2.29`.

Once a user has touched a field, it is better to leave it alone and display explicit validation errors over silently overwriting their inputs. Same for auto-filled values (whether from query parameters or a previous build).

Original PR: #24645 — fix: do not clobber dynamic parameters
Merge commit: d958d89b6f8d2356bd597acd9df5bd6030e589eb

Closes #23418

<details>
<summary>Cherry-pick conflict resolution</summary>

Two conflicts resolved:

1. **`site/src/testHelpers/websockets.ts`**: Added new `mockDynamicParameterWebSocket` helper. Converted `vi.*` to `jest.*` and `#/` to bare import paths to match release branch conventions.

2. **`site/src/pages/CreateWorkspacePage/CreateWorkspacePage.jest.tsx`**: File is `.jest.tsx` on the release branch (`.test.tsx` on main). Applied the cherry-pick's structural changes (refactored inline websocket mocks, added two new test cases) while converting `vi.*` to `jest.*` and `#/` to bare import paths.

</details>

> [!NOTE]
> Generated with [Coder Agents](https://coder.com) by @rowansmithau