### PR TITLE
fix(site): update models settings page description text

### DIFF
--- a/site/src/pages/AgentsPage/AgentSettingsModelsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsModelsPage.tsx
@@ -47,7 +47,7 @@ const AgentSettingsModelsPage: FC = () => {
 			<ChatModelAdminPanel
 				section="models"
 				sectionLabel="Models"
-				sectionDescription="Choose which models from your configured providers are available for users to select. You can set a default and adjust context limits."
+				sectionDescription="Choose which models from your configured providers are available for Coder Agents. Set a default and adjust context limits."
 				providerConfigsData={providerConfigsQuery.data}
 				modelConfigsData={modelConfigsQuery.data}
 				modelCatalogData={modelCatalogQuery.data}


### PR DESCRIPTION
Updates the description text on the Agent Settings > Models page (`/agents/settings/models`).

**Before:** "Choose which models from your configured providers are available for users to select. You can set a default and adjust context limits."

**After:** "Choose which models from your configured providers are available for Coder Agents. Set a default and adjust context limits."

> Generated by Coder Agents on behalf of @tracyjohnsonux