### PR TITLE
feat(site): add Opus 4.8 known model

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.stories.tsx
@@ -1374,9 +1374,9 @@ export const AnthropicKnownModelHappyPath: Story = {
 
 		await openKnownModelPopover(body);
 		const options = await body.findAllByRole("option");
-		await userEvent.click(findOptionByText(options, "claude-opus-4-7"));
+		await userEvent.click(findOptionByText(options, "claude-opus-4-8"));
 
-		await expectModelIdentifierValue(body, "claude-opus-4-7");
+		await expectModelIdentifierValue(body, "claude-opus-4-8");
 		await expect(body.getByLabelText(/Context limit/i)).toHaveValue("1000000");
 
 		await expandSection(body, "Advanced");
@@ -1858,7 +1858,7 @@ export const KnownModelAutoHidePopoverWhenNoMatches: Story = {
 			name: /Model Identifier/i,
 		});
 		await userEvent.click(input);
-		await expect(await body.findByText("Claude Opus 4.7")).toBeInTheDocument();
+		await expect(await body.findByText("Claude Opus 4.8")).toBeInTheDocument();
 
 		await userEvent.clear(input);
 		await userEvent.type(input, "claude-opus-4-5");

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/anthropic.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/anthropic.test.ts
@@ -22,6 +22,7 @@ describe("anthropicKnownModels", () => {
 				(knownModel) => knownModel.modelIdentifier,
 			),
 		).toEqual([
+			"claude-opus-4-8",
 			"claude-opus-4-7",
 			"claude-opus-4-6",
 			"claude-sonnet-4-6",
@@ -31,7 +32,11 @@ describe("anthropicKnownModels", () => {
 	});
 
 	it("declares Anthropic reasoning defaults by API support", () => {
-		for (const modelIdentifier of ["claude-opus-4-7", "claude-opus-4-6"]) {
+		for (const modelIdentifier of [
+			"claude-opus-4-8",
+			"claude-opus-4-7",
+			"claude-opus-4-6",
+		]) {
 			const knownModel = requireAnthropicKnownModel(modelIdentifier);
 
 			expect(knownModel.reasoningEffort).toBe("high");
@@ -54,6 +59,7 @@ describe("anthropicKnownModels", () => {
 		expect(
 			anthropicKnownModels.map((knownModel) => knownModel.modelIdentifier),
 		).toEqual([
+			"claude-opus-4-8",
 			"claude-opus-4-7",
 			"claude-opus-4-6",
 			"claude-sonnet-4-6",
@@ -64,8 +70,16 @@ describe("anthropicKnownModels", () => {
 		for (const knownModel of anthropicKnownModels) {
 			expect(knownModel.provider).toBe("anthropic");
 			expect(knownModel.sourceMetadata.sourceName).toBe("models.dev");
-			expect(knownModel.sourceMetadata.sourceRetrievedAt).toBe("2026-04-30");
+			expect(knownModel.sourceMetadata.sourceRetrievedAt).not.toBe("");
 			expect(knownModel.sourceMetadata.lastUpdated).not.toBe("");
 		}
+
+		expect(
+			requireAnthropicKnownModel("claude-opus-4-8").sourceMetadata,
+		).toEqual({
+			sourceName: "models.dev",
+			sourceRetrievedAt: "2026-05-29",
+			lastUpdated: "2026-05-28",
+		});
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/anthropic.ts
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/anthropic.ts
@@ -10,14 +10,33 @@ import type { KnownModel } from "./types";
 // catalog and should be reviewed when the catalog is refreshed.
 //
 // Reasoning configuration is split per model based on Anthropic API support:
-// models that support adaptive thinking (Opus 4.7, Opus 4.6, Sonnet 4.6)
-// carry `reasoningEffort`, which Coder maps to `thinking.type: "adaptive"`
-// with the `effort` parameter. Models that do not (Haiku 4.5, Sonnet 4.5)
+// models that support adaptive thinking (Opus 4.8, Opus 4.7, Opus 4.6,
+// Sonnet 4.6) carry `reasoningEffort`, which Coder maps to
+// `thinking.type: "adaptive"` with the `effort` parameter. Models that do not
+// (Haiku 4.5, Sonnet 4.5)
 // carry `thinkingBudgetTokens` instead, which Coder maps to the legacy
 // `thinking.type: "enabled"` path with `budget_tokens`. Setting `effort` on
 // the legacy path produces an "adaptive thinking is not supported on this
 // model" HTTP 400 from Anthropic.
 export const anthropicKnownModels = [
+	{
+		provider: "anthropic",
+		modelIdentifier: "claude-opus-4-8",
+		displayName: "Claude Opus 4.8",
+		aliases: [],
+		contextLimit: 1_000_000,
+		maxOutputTokens: 128_000,
+		reasoningEffort: "high",
+		inputCost: 5,
+		outputCost: 25,
+		cacheReadCost: 0.5,
+		cacheWriteCost: 6.25,
+		sourceMetadata: {
+			sourceName: "models.dev",
+			sourceRetrievedAt: "2026-05-29",
+			lastUpdated: "2026-05-28",
+		},
+	},
 	{
 		provider: "anthropic",
 		modelIdentifier: "claude-opus-4-7",

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/applyKnownModelDefaults.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/applyKnownModelDefaults.test.ts
@@ -294,7 +294,7 @@ describe("applyKnownModelDefaults", () => {
 			values: buildInitialModelFormValues(),
 			initialValues: buildInitialModelFormValues(),
 			provider: "anthropic",
-			knownModel: requireKnownModel("anthropic", "claude-opus-4-7"),
+			knownModel: requireKnownModel("anthropic", "claude-opus-4-8"),
 		});
 
 		expect(getPath(result.values, "config.anthropic.effort")).toBe("high");
@@ -327,7 +327,7 @@ describe("applyKnownModelDefaults", () => {
 			values: buildInitialModelFormValues(),
 			initialValues: buildInitialModelFormValues(),
 			provider: "anthropic",
-			knownModel: requireKnownModel("anthropic", "claude-opus-4-7"),
+			knownModel: requireKnownModel("anthropic", "claude-opus-4-8"),
 		});
 
 		expect(getPath(result.values, "config.anthropic.sendReasoning")).toBe("");


### PR DESCRIPTION
Adds Claude Opus 4.8 to the Anthropic known model suggestions in the `/agents` model settings panel. The new entry uses the latest models.dev metadata for context, output limits, pricing, and adaptive reasoning defaults, and is ordered before Opus 4.7.

Updates the known-model unit tests and Storybook interaction coverage so the Anthropic happy path and popover ordering validate Opus 4.8.

Refs CODAGT-521.

<details>
<summary>Coder Agent context</summary>

Generated by Coder Agents on behalf of @ThomasK33.

Prior history checked:
- PR #24842, commit `69610cca75`, introduced the `/agents` Known Model catalog and added Opus 4.6 and Opus 4.7 together.
- PR #24932 added AI Gateway model price seeding and was not required for this `/agents` suggested-settings scope.
- PR #25335 added Bedrock Opus 4.7 adaptive-thinking handling and was not required for this `/agents` suggested-settings scope.

Validation run:
- `pnpm --dir site exec biome check --error-on-warnings src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/anthropic.ts src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/anthropic.test.ts src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/applyKnownModelDefaults.test.ts src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.stories.tsx`
- `pnpm --dir site exec vitest run --project=unit src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/anthropic.test.ts src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/applyKnownModelDefaults.test.ts`
- `pnpm --dir site test:storybook src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.stories.tsx --run --testNamePattern='Anthropic Known Model Happy Path|popover auto-hides when search has no matches'`
- `git commit` pre-commit hook passed.

</details>
