### PR TITLE
style(site): use lightbulb icon for thinking

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolIcon.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolIcon.tsx
@@ -4,12 +4,12 @@ import {
 	CompassIcon,
 	FilePenLineIcon,
 	FileTextIcon,
+	LightbulbIcon,
 	LogInIcon,
 	MonitorIcon,
 	PowerIcon,
 	RouteIcon,
 	ServerIcon,
-	SparklesIcon,
 	TerminalIcon,
 	WrenchIcon,
 } from "lucide-react";
@@ -118,7 +118,7 @@ export const ToolIcon: React.FC<{
 		case "chat_summarized":
 			return <BotIcon className={base} />;
 		case "thinking":
-			return <SparklesIcon className={base} />;
+			return <LightbulbIcon className={base} />;
 		case "propose_plan":
 			return <RouteIcon className={base} />;
 		case "ask_user_question":


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

Replaces the Agents UI thinking tool sparkles icon with a lightbulb icon.

This updates only the `thinking` tool icon to use `LightbulbIcon` from `lucide-react`.
