### PR TITLE
fix(cli/ssh.go): pass TERM through to ssh session pty

### DIFF
--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -697,7 +697,12 @@ func (r *RootCmd) ssh() *serpent.Command {
 			sshSession.Stderr = inv.Stderr
 
 			if requestPTY {
-				err = sshSession.RequestPty("xterm-256color", 128, 128, gossh.TerminalModes{})
+				termType := os.Getenv("TERM")
+				if termType == "" {
+					termType = "xterm-256color"
+				}
+
+				err = sshSession.RequestPty(termType, 128, 128, gossh.TerminalModes{})
 				if err != nil {
 					return xerrors.Errorf("request pty: %w", err)
 				}


### PR DESCRIPTION
Pass an existing $TERM value from the current shell through to the new ssh session.

When running Claude Code via a `coder ssh my-workspace` session "shift+enter" (insert new line without submitting the prompt) wasn't working. When running Claude via `ssh coder.my-workspace` is _does_ work since all the env vars (including `TERM`) are passed through.
