### PR TITLE
fix(site/src/pages/AgentsPage): avoid stale live tail spacing

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
@@ -71,7 +71,13 @@ export const LiveStreamTailContent = ({
 	}
 
 	return (
-		<div className="mt-2 flex flex-col gap-2 empty:mt-0">
+		<div
+			className={
+				isTranscriptEmpty
+					? "flex flex-col gap-2"
+					: "mt-2 flex flex-col gap-2 empty:mt-0"
+			}
+		>
 			{shouldRenderEmptyState && (
 				<div className="py-12 text-center text-content-secondary">
 					<p className="text-sm">Start a conversation with your agent.</p>

--- a/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
@@ -71,7 +71,7 @@ export const LiveStreamTailContent = ({
 	}
 
 	return (
-		<div className="flex flex-col gap-2">
+		<div className="mt-2 flex flex-col gap-2 empty:mt-0">
 			{shouldRenderEmptyState && (
 				<div className="py-12 text-center text-content-secondary">
 					<p className="text-sm">Start a conversation with your agent.</p>

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -106,7 +106,7 @@ export const ChatPageTimeline: FC<ChatPageTimelineProps> = ({
 			<div
 				data-testid="chat-timeline-wrapper"
 				className={cn(
-					"mx-auto flex w-full flex-col gap-2 py-6",
+					"mx-auto flex w-full flex-col py-6",
 					chatWidthClass(chatFullWidth),
 				)}
 			>


### PR DESCRIPTION
When a chat message was promoted from the LiveTail to the durable messages, there would be layout shift due to funky margins.


A small diagram to demonstrate:
```
Durable Message 1    Durable Message 1
---                  Durable Message 2
Live Tail Message 1  ---
```

Where `---` is the bottom margin to the durable. You can see how the earlier messages aren't affected by this, but the live tail -> durable message gets an unwanted layout shift.

> Created by Coder Agents.