### PR TITLE
fix(coderd/x/chatd/chatloop): discourage doctrine in compaction summaries

### DIFF
--- a/coderd/x/chatd/chatloop/compaction.go
+++ b/coderd/x/chatd/chatloop/compaction.go
@@ -35,14 +35,22 @@ const (
 		"- Key decisions made and their rationale\n" +
 		"- Concrete technical details: file paths, function names, " +
 		"commands, APIs, and configurations\n" +
-		"- Errors encountered and how they were resolved\n" +
+		"- Errors encountered and how they were resolved. Keep error " +
+		"notes specific: name the file, the error, and the fix. Do not " +
+		"generalize from a specific failure to a blanket tool-avoidance " +
+		"rule (e.g. \"tool X is unreliable\" or \"always use Y instead " +
+		"of Z\")\n" +
 		"- Current state of the work: what is DONE, what is IN PROGRESS, " +
 		"and what REMAINS to be done\n" +
 		"- The specific action the assistant was performing or about to " +
 		"perform when this summary was triggered\n\n" +
 		"Be dense and factual. Every sentence should convey essential " +
 		"context for continuation. Do not include pleasantries or " +
-		"conversational filler."
+		"conversational filler. For content that can be reproduced " +
+		"(repo files, command output, API responses), reference how to " +
+		"obtain it (file path, command, URL) rather than inlining the " +
+		"full content. Include brief inline summaries when the content " +
+		"itself would exceed a few lines."
 	defaultCompactionSystemSummaryPrefix = "The following is a summary of " +
 		"the earlier conversation. The assistant was actively working when " +
 		"the context was compacted. Continue the work described below:"


### PR DESCRIPTION
## Summary

Two additive changes to the compaction summary prompt that address
measured problems in compaction output quality.

### 1. Error specificity

The "errors encountered" bullet now instructs the model to keep error
notes specific (name the file, the error, the fix) and not generalize
from a specific failure to a blanket tool-avoidance rule.

**Problem it solves**: doctrine crystallization, where a single tool
failure gets promoted to a standing "avoid tool X" rule that persists
across compactions and model swaps. 54 of 1,332 summaries (4.1%)
contained doctrine-style sections (`## Tool Quirks`, `## Working
Method`, etc.) including fabricated claims like "Unicode breaks
edit_files" or "`read_file` adds extra tabs".

### 2. Reproducibility

A new closing sentence instructs the model to reference reproducible
content by path, command, or URL rather than inlining it. Content
without a stable reproducer is still preserved inline.

**Problem it solves**: summary bloat from inlined code blocks. 37% of
summaries exceed 10k chars; the worst case was 34,754 chars with 76
code blocks reproducing Go struct definitions verbatim. GPT 5.5
averages 18k chars per summary (2x Opus).

### Verification

After shipping, re-run doctrine detection queries at 30 days:
- Doctrine section headers should stay near 0% of new summaries
- Average summary length should decrease (especially GPT 5.5)
- Useful error context should still be present

Addresses: CODAGT-331

<details><summary>Investigation data and analysis</summary>

### Data source
- 1,332 compaction summaries (March-May 2026)
- 111 post-rename (after 2026-05-26)
- Queries via Grafana Postgres datasource

### Pattern counts (all time, of 1,332)

| Pattern | Matches | Rate |
|---------|---------|------|
| Tool avoidance language | 63 | 4.7% |
| Frequency exaggeration | 50 | 3.8% |
| Technical claims about tool internals | 77 | 5.8% |
| Forward-looking methodology prescriptions | 78 | 5.9% |
| Workaround/fallback prescribed as method | 63 | 4.7% |
| Doctrine section headers | 54 | 4.1% |
| Blanket always/never prescriptions | 6 | 0.5% |

### Summary length by model (post-rename)

| Model | Avg length | Max |
|-------|-----------|-----|
| GPT 5.5 xhigh | 18,360 | 34,754 |
| Opus 4.7 Max | 8,203 | 10,203 |
| Opus 4.6 Max | 6,546 | 7,532 |
| Sonnet 4.6 | 6,482 | 14,482 |

</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻