### PR TITLE
fix: deprecate ai provider seeding env config

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -2979,6 +2979,11 @@ func parseExternalAuthProvidersFromEnv(prefix string, environ []string) ([]coder
 	return providers, nil
 }
 
+const (
+	aiGatewayProviderEnvPrefix = "CODER_AI_GATEWAY_PROVIDER_"
+	aiBridgeProviderEnvPrefix  = "CODER_AIBRIDGE_PROVIDER_"
+)
+
 // ReadAIProvidersFromEnv parses CODER_AI_GATEWAY_PROVIDER_<N>_<KEY>
 // environment variables into a slice of AIProviderConfig.
 // Deprecated alias env vars with the CODER_AIBRIDGE_PROVIDER_<N>_<KEY>
@@ -2986,18 +2991,19 @@ func parseExternalAuthProvidersFromEnv(prefix string, environ []string) ([]coder
 //
 // This follows the same indexed pattern as ReadExternalAuthProvidersFromEnv.
 func ReadAIProvidersFromEnv(logger slog.Logger, environ []string) ([]codersdk.AIProviderConfig, error) {
-	providers, err := readAIProvidersForPrefix(logger, environ, "CODER_AIBRIDGE_PROVIDER_")
+	providers, err := readAIProvidersForPrefix(logger, environ, aiBridgeProviderEnvPrefix)
 	if err != nil {
 		return nil, err
 	}
-	gatewayProviders, err := readAIProvidersForPrefix(logger, environ, "CODER_AI_GATEWAY_PROVIDER_")
+	gatewayProviders, err := readAIProvidersForPrefix(logger, environ, aiGatewayProviderEnvPrefix)
 	if err != nil {
 		return nil, err
 	}
 	if len(providers) > 0 && len(gatewayProviders) > 0 {
-		return nil, xerrors.New("cannot mix CODER_AIBRIDGE_PROVIDER_* and CODER_AI_GATEWAY_PROVIDER_* environment variables, please consolidate onto CODER_AI_GATEWAY_PROVIDER_*")
+		return nil, xerrors.Errorf("cannot mix %s* and %s* environment variables, please consolidate onto %s*", aiBridgeProviderEnvPrefix, aiGatewayProviderEnvPrefix, aiGatewayProviderEnvPrefix)
 	}
 	providers = append(providers, gatewayProviders...)
+	warnIfAIProvidersConfiguredFromEnv(context.Background(), logger, environ, providers)
 
 	// Post-parse validation.
 	names := make(map[string]int, len(providers))
@@ -3078,6 +3084,40 @@ func ReadAIProvidersFromEnv(logger slog.Logger, environ []string) ([]codersdk.AI
 	}
 
 	return providers, nil
+}
+
+func warnIfAIProvidersConfiguredFromEnv(ctx context.Context, logger slog.Logger, environ []string, providers []codersdk.AIProviderConfig) {
+	if len(providers) == 0 {
+		return
+	}
+
+	prefix := aiProviderEnvPrefix(environ)
+	if prefix == "" {
+		return
+	}
+
+	logger.Warn(ctx,
+		"ai provider environment variables are deprecated for provider management and only seed provider rows at startup",
+		slog.F("env_prefix", prefix),
+		slog.F("replacement", "Manage AI Providers from the Coder UI or HTTP API."),
+	)
+}
+
+func aiProviderEnvPrefix(environ []string) string {
+	for _, raw := range environ {
+		name, _, found := strings.Cut(raw, "=")
+		if !found {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(name, aiBridgeProviderEnvPrefix):
+			return aiBridgeProviderEnvPrefix
+		case strings.HasPrefix(name, aiGatewayProviderEnvPrefix):
+			return aiGatewayProviderEnvPrefix
+		}
+	}
+
+	return ""
 }
 
 // readAIProvidersForPrefix parses provider env vars under a single

--- a/cli/server.go
+++ b/cli/server.go
@@ -3002,8 +3002,13 @@ func ReadAIProvidersFromEnv(logger slog.Logger, environ []string) ([]codersdk.AI
 	if len(providers) > 0 && len(gatewayProviders) > 0 {
 		return nil, xerrors.Errorf("cannot mix %s* and %s* environment variables, please consolidate onto %s*", aiBridgeProviderEnvPrefix, aiGatewayProviderEnvPrefix, aiGatewayProviderEnvPrefix)
 	}
+	var activePrefix string
+	if len(providers) > 0 {
+		activePrefix = aiBridgeProviderEnvPrefix
+	} else if len(gatewayProviders) > 0 {
+		activePrefix = aiGatewayProviderEnvPrefix
+	}
 	providers = append(providers, gatewayProviders...)
-	warnIfAIProvidersConfiguredFromEnv(context.Background(), logger, environ, providers)
 
 	// Post-parse validation.
 	names := make(map[string]int, len(providers))
@@ -3083,41 +3088,25 @@ func ReadAIProvidersFromEnv(logger slog.Logger, environ []string) ([]codersdk.AI
 		names[p.Name] = i
 	}
 
+	warnIfAIProvidersConfiguredFromEnv(context.Background(), logger, activePrefix, providers)
+
 	return providers, nil
 }
 
-func warnIfAIProvidersConfiguredFromEnv(ctx context.Context, logger slog.Logger, environ []string, providers []codersdk.AIProviderConfig) {
+func warnIfAIProvidersConfiguredFromEnv(ctx context.Context, logger slog.Logger, prefix string, providers []codersdk.AIProviderConfig) {
 	if len(providers) == 0 {
 		return
 	}
 
-	prefix := aiProviderEnvPrefix(environ)
 	if prefix == "" {
 		return
 	}
 
 	logger.Warn(ctx,
-		"ai provider environment variables are deprecated for provider management and only seed provider rows at startup",
+		"ai provider environment variables are deprecated for provider management and only seed provider configuration at startup",
 		slog.F("env_prefix", prefix),
 		slog.F("replacement", "Manage AI Providers from the Coder UI or HTTP API."),
 	)
-}
-
-func aiProviderEnvPrefix(environ []string) string {
-	for _, raw := range environ {
-		name, _, found := strings.Cut(raw, "=")
-		if !found {
-			continue
-		}
-		switch {
-		case strings.HasPrefix(name, aiBridgeProviderEnvPrefix):
-			return aiBridgeProviderEnvPrefix
-		case strings.HasPrefix(name, aiGatewayProviderEnvPrefix):
-			return aiGatewayProviderEnvPrefix
-		}
-	}
-
-	return ""
 }
 
 // readAIProvidersForPrefix parses provider env vars under a single

--- a/cli/server_aibridge_internal_test.go
+++ b/cli/server_aibridge_internal_test.go
@@ -583,56 +583,48 @@ func TestWarnIfAIProvidersConfiguredFromEnv(t *testing.T) {
 		t.Parallel()
 
 		sink := testutil.NewFakeSink(t)
-		warnIfAIProvidersConfiguredFromEnv(context.Background(), sink.Logger(), []string{
-			"CODER_AI_GATEWAY_PROVIDER_0_TYPE=openai",
-		}, nil)
+		warnIfAIProvidersConfiguredFromEnv(context.Background(), sink.Logger(), aiGatewayProviderEnvPrefix, nil)
 
-		require.Empty(t, sink.Entries(nil))
+		require.Empty(t, sink.Entries())
 	})
 
-	t.Run("NoProviderEnv", func(t *testing.T) {
+	t.Run("EmptyPrefix", func(t *testing.T) {
 		t.Parallel()
 
 		sink := testutil.NewFakeSink(t)
-		warnIfAIProvidersConfiguredFromEnv(context.Background(), sink.Logger(), []string{
-			"HOME=/home/coder",
-		}, []codersdk.AIProviderConfig{{Type: "openai", Name: "openai"}})
+		warnIfAIProvidersConfiguredFromEnv(context.Background(), sink.Logger(), "", []codersdk.AIProviderConfig{{Type: "openai", Name: "openai"}})
 
-		require.Empty(t, sink.Entries(nil))
+		require.Empty(t, sink.Entries())
 	})
 
 	t.Run("AIGatewayPrefix", func(t *testing.T) {
 		t.Parallel()
 
 		sink := testutil.NewFakeSink(t)
-		warnIfAIProvidersConfiguredFromEnv(context.Background(), sink.Logger(), []string{
-			"CODER_AI_GATEWAY_PROVIDER_0_TYPE=openai",
-		}, []codersdk.AIProviderConfig{{Type: "openai", Name: "openai"}})
+		warnIfAIProvidersConfiguredFromEnv(context.Background(), sink.Logger(), aiGatewayProviderEnvPrefix, []codersdk.AIProviderConfig{{Type: "openai", Name: "openai"}})
 
 		entries := sink.Entries(func(e slog.SinkEntry) bool {
-			return e.Message == "ai provider environment variables are deprecated for provider management and only seed provider rows at startup"
+			return e.Message == "ai provider environment variables are deprecated for provider management and only seed provider configuration at startup"
 		})
 		require.Len(t, entries, 1)
 		require.Len(t, entries[0].Fields, 2)
-		assert.Equal(t, aiGatewayProviderEnvPrefix, entries[0].Fields[0].Value)
-		assert.Equal(t, "Manage AI Providers from the Coder UI or HTTP API.", entries[0].Fields[1].Value)
+		assertFieldValue(t, entries[0].Fields, "env_prefix", aiGatewayProviderEnvPrefix)
+		assertFieldValue(t, entries[0].Fields, "replacement", "Manage AI Providers from the Coder UI or HTTP API.")
 	})
 
 	t.Run("AIBridgePrefix", func(t *testing.T) {
 		t.Parallel()
 
 		sink := testutil.NewFakeSink(t)
-		warnIfAIProvidersConfiguredFromEnv(context.Background(), sink.Logger(), []string{
-			"CODER_AIBRIDGE_PROVIDER_0_TYPE=openai",
-		}, []codersdk.AIProviderConfig{{Type: "openai", Name: "openai"}})
+		warnIfAIProvidersConfiguredFromEnv(context.Background(), sink.Logger(), aiBridgeProviderEnvPrefix, []codersdk.AIProviderConfig{{Type: "openai", Name: "openai"}})
 
 		entries := sink.Entries(func(e slog.SinkEntry) bool {
-			return e.Message == "ai provider environment variables are deprecated for provider management and only seed provider rows at startup"
+			return e.Message == "ai provider environment variables are deprecated for provider management and only seed provider configuration at startup"
 		})
 		require.Len(t, entries, 1)
 		require.Len(t, entries[0].Fields, 2)
-		assert.Equal(t, aiBridgeProviderEnvPrefix, entries[0].Fields[0].Value)
-		assert.Equal(t, "Manage AI Providers from the Coder UI or HTTP API.", entries[0].Fields[1].Value)
+		assertFieldValue(t, entries[0].Fields, "env_prefix", aiBridgeProviderEnvPrefix)
+		assertFieldValue(t, entries[0].Fields, "replacement", "Manage AI Providers from the Coder UI or HTTP API.")
 	})
 }
 
@@ -781,4 +773,15 @@ func mustMarshalSettings(s codersdk.AIProviderSettings) sql.NullString {
 		panic(err)
 	}
 	return sql.NullString{String: string(data), Valid: true}
+}
+
+func assertFieldValue(t *testing.T, fields slog.Map, name string, expected interface{}) {
+	t.Helper()
+	for _, f := range fields {
+		if f.Name == name {
+			assert.Equal(t, expected, f.Value)
+			return
+		}
+	}
+	t.Errorf("field %q not found", name)
 }

--- a/cli/server_aibridge_internal_test.go
+++ b/cli/server_aibridge_internal_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -573,6 +574,66 @@ func TestValidateLegacyAIBridgeConfig(t *testing.T) {
 			require.Contains(t, err.Error(), tt.errContains)
 		})
 	}
+}
+
+func TestWarnIfAIProvidersConfiguredFromEnv(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NoProviders", func(t *testing.T) {
+		t.Parallel()
+
+		sink := testutil.NewFakeSink(t)
+		warnIfAIProvidersConfiguredFromEnv(context.Background(), sink.Logger(), []string{
+			"CODER_AI_GATEWAY_PROVIDER_0_TYPE=openai",
+		}, nil)
+
+		require.Empty(t, sink.Entries(nil))
+	})
+
+	t.Run("NoProviderEnv", func(t *testing.T) {
+		t.Parallel()
+
+		sink := testutil.NewFakeSink(t)
+		warnIfAIProvidersConfiguredFromEnv(context.Background(), sink.Logger(), []string{
+			"HOME=/home/coder",
+		}, []codersdk.AIProviderConfig{{Type: "openai", Name: "openai"}})
+
+		require.Empty(t, sink.Entries(nil))
+	})
+
+	t.Run("AIGatewayPrefix", func(t *testing.T) {
+		t.Parallel()
+
+		sink := testutil.NewFakeSink(t)
+		warnIfAIProvidersConfiguredFromEnv(context.Background(), sink.Logger(), []string{
+			"CODER_AI_GATEWAY_PROVIDER_0_TYPE=openai",
+		}, []codersdk.AIProviderConfig{{Type: "openai", Name: "openai"}})
+
+		entries := sink.Entries(func(e slog.SinkEntry) bool {
+			return e.Message == "ai provider environment variables are deprecated for provider management and only seed provider rows at startup"
+		})
+		require.Len(t, entries, 1)
+		require.Len(t, entries[0].Fields, 2)
+		assert.Equal(t, aiGatewayProviderEnvPrefix, entries[0].Fields[0].Value)
+		assert.Equal(t, "Manage AI Providers from the Coder UI or HTTP API.", entries[0].Fields[1].Value)
+	})
+
+	t.Run("AIBridgePrefix", func(t *testing.T) {
+		t.Parallel()
+
+		sink := testutil.NewFakeSink(t)
+		warnIfAIProvidersConfiguredFromEnv(context.Background(), sink.Logger(), []string{
+			"CODER_AIBRIDGE_PROVIDER_0_TYPE=openai",
+		}, []codersdk.AIProviderConfig{{Type: "openai", Name: "openai"}})
+
+		entries := sink.Entries(func(e slog.SinkEntry) bool {
+			return e.Message == "ai provider environment variables are deprecated for provider management and only seed provider rows at startup"
+		})
+		require.Len(t, entries, 1)
+		require.Len(t, entries[0].Fields, 2)
+		assert.Equal(t, aiBridgeProviderEnvPrefix, entries[0].Fields[0].Value)
+		assert.Equal(t, "Manage AI Providers from the Coder UI or HTTP API.", entries[0].Fields[1].Value)
+	})
 }
 
 func TestBuildAIProviderFromRowSetsAPIDumpDir(t *testing.T) {

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -124,51 +124,55 @@ AI GATEWAY OPTIONS:
           disabled, only centralized key authentication is permitted.
 
       --ai-gateway-anthropic-base-url string, $CODER_AI_GATEWAY_ANTHROPIC_BASE_URL (default: https://api.anthropic.com/)
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if set.
-          The base URL of the Anthropic API.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The base URL of the Anthropic
+          API.
 
       --ai-gateway-anthropic-key string, $CODER_AI_GATEWAY_ANTHROPIC_KEY
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if set.
-          The key to authenticate against the Anthropic API.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The key to authenticate
+          against the Anthropic API.
 
       --ai-gateway-bedrock-access-key string, $CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if set.
-          The access key to authenticate against the AWS Bedrock API.
-
-      --ai-gateway-bedrock-access-key-secret string, $CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY_SECRET
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if set.
-          The access key secret to use with the access key to authenticate
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The access key to authenticate
           against the AWS Bedrock API.
 
+      --ai-gateway-bedrock-access-key-secret string, $CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY_SECRET
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The access key secret to use
+          with the access key to authenticate against the AWS Bedrock API.
+
       --ai-gateway-bedrock-base-url string, $CODER_AI_GATEWAY_BEDROCK_BASE_URL
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if set.
-          The base URL to use for the AWS Bedrock API. Use this setting to
-          specify an exact URL to use. Takes precedence over
-          CODER_AI_GATEWAY_BEDROCK_REGION.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The base URL to use for the
+          AWS Bedrock API. Use this setting to specify an exact URL to use.
+          Takes precedence over CODER_AI_GATEWAY_BEDROCK_REGION.
 
       --ai-gateway-bedrock-model string, $CODER_AI_GATEWAY_BEDROCK_MODEL (default: global.anthropic.claude-sonnet-4-5-20250929-v1:0)
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if set.
-          The model to use when making requests to the AWS Bedrock API.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The model to use when making
+          requests to the AWS Bedrock API.
 
       --ai-gateway-bedrock-region string, $CODER_AI_GATEWAY_BEDROCK_REGION
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if set.
-          The AWS Bedrock API region to use. Constructs a base URL to use for
-          the AWS Bedrock API in the form of
-          'https://bedrock-runtime.<region>.amazonaws.com'.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The AWS Bedrock API region to
+          use. Constructs a base URL to use for the AWS Bedrock API in the form
+          of 'https://bedrock-runtime.<region>.amazonaws.com'.
 
       --ai-gateway-bedrock-small-fastmodel string, $CODER_AI_GATEWAY_BEDROCK_SMALL_FAST_MODEL (default: global.anthropic.claude-haiku-4-5-20251001-v1:0)
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if set.
-          The small fast model to use when making requests to the AWS Bedrock
-          API. Claude Code uses Haiku-class models to perform background tasks.
-          See
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The small fast model to use
+          when making requests to the AWS Bedrock API. Claude Code uses
+          Haiku-class models to perform background tasks. See
           https://docs.claude.com/en/docs/claude-code/settings#environment-variables.
 
       --ai-gateway-circuit-breaker-enabled bool, $CODER_AI_GATEWAY_CIRCUIT_BREAKER_ENABLED (default: false)
@@ -187,14 +191,16 @@ AI GATEWAY OPTIONS:
           to disable (unlimited).
 
       --ai-gateway-openai-base-url string, $CODER_AI_GATEWAY_OPENAI_BASE_URL (default: https://api.openai.com/v1/)
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if set.
-          The base URL of the OpenAI API.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The base URL of the OpenAI
+          API.
 
       --ai-gateway-openai-key string, $CODER_AI_GATEWAY_OPENAI_KEY
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if set.
-          The key to authenticate against the OpenAI API.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The key to authenticate
+          against the OpenAI API.
 
       --ai-gateway-rate-limit int, $CODER_AI_GATEWAY_RATE_LIMIT (default: 0)
           Maximum number of AI Gateway requests per second per replica. Set to 0

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -124,36 +124,44 @@ AI GATEWAY OPTIONS:
           disabled, only centralized key authentication is permitted.
 
       --ai-gateway-anthropic-base-url string, $CODER_AI_GATEWAY_ANTHROPIC_BASE_URL (default: https://api.anthropic.com/)
-          The base URL of the Anthropic API.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
+          option only seeds provider configuration at startup once-off, if
+          configured.
 
       --ai-gateway-anthropic-key string, $CODER_AI_GATEWAY_ANTHROPIC_KEY
-          The key to authenticate against the Anthropic API.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
+          option only seeds provider configuration at startup once-off, if
+          configured.
 
       --ai-gateway-bedrock-access-key string, $CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY
-          The access key to authenticate against the AWS Bedrock API.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
+          option only seeds provider configuration at startup once-off, if
+          configured.
 
       --ai-gateway-bedrock-access-key-secret string, $CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY_SECRET
-          The access key secret to use with the access key to authenticate
-          against the AWS Bedrock API.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
+          option only seeds provider configuration at startup once-off, if
+          configured.
 
       --ai-gateway-bedrock-base-url string, $CODER_AI_GATEWAY_BEDROCK_BASE_URL
-          The base URL to use for the AWS Bedrock API. Use this setting to
-          specify an exact URL to use. Takes precedence over
-          CODER_AI_GATEWAY_BEDROCK_REGION.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
+          option only seeds provider configuration at startup once-off, if
+          configured.
 
       --ai-gateway-bedrock-model string, $CODER_AI_GATEWAY_BEDROCK_MODEL (default: global.anthropic.claude-sonnet-4-5-20250929-v1:0)
-          The model to use when making requests to the AWS Bedrock API.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
+          option only seeds provider configuration at startup once-off, if
+          configured.
 
       --ai-gateway-bedrock-region string, $CODER_AI_GATEWAY_BEDROCK_REGION
-          The AWS Bedrock API region to use. Constructs a base URL to use for
-          the AWS Bedrock API in the form of
-          'https://bedrock-runtime.<region>.amazonaws.com'.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
+          option only seeds provider configuration at startup once-off, if
+          configured.
 
       --ai-gateway-bedrock-small-fastmodel string, $CODER_AI_GATEWAY_BEDROCK_SMALL_FAST_MODEL (default: global.anthropic.claude-haiku-4-5-20251001-v1:0)
-          The small fast model to use when making requests to the AWS Bedrock
-          API. Claude Code uses Haiku-class models to perform background tasks.
-          See
-          https://docs.claude.com/en/docs/claude-code/settings#environment-variables.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
+          option only seeds provider configuration at startup once-off, if
+          configured.
 
       --ai-gateway-circuit-breaker-enabled bool, $CODER_AI_GATEWAY_CIRCUIT_BREAKER_ENABLED (default: false)
           Enable the circuit breaker to protect against cascading failures from
@@ -171,10 +179,14 @@ AI GATEWAY OPTIONS:
           to disable (unlimited).
 
       --ai-gateway-openai-base-url string, $CODER_AI_GATEWAY_OPENAI_BASE_URL (default: https://api.openai.com/v1/)
-          The base URL of the OpenAI API.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
+          option only seeds provider configuration at startup once-off, if
+          configured.
 
       --ai-gateway-openai-key string, $CODER_AI_GATEWAY_OPENAI_KEY
-          The key to authenticate against the OpenAI API.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
+          option only seeds provider configuration at startup once-off, if
+          configured.
 
       --ai-gateway-rate-limit int, $CODER_AI_GATEWAY_RATE_LIMIT (default: 0)
           Maximum number of AI Gateway requests per second per replica. Set to 0

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -125,47 +125,47 @@ AI GATEWAY OPTIONS:
 
       --ai-gateway-anthropic-base-url string, $CODER_AI_GATEWAY_ANTHROPIC_BASE_URL (default: https://api.anthropic.com/)
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup one-off, if set.
+          option only seeds provider configuration at startup once-off, if set.
           The base URL of the Anthropic API.
 
       --ai-gateway-anthropic-key string, $CODER_AI_GATEWAY_ANTHROPIC_KEY
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup one-off, if set.
+          option only seeds provider configuration at startup once-off, if set.
           The key to authenticate against the Anthropic API.
 
       --ai-gateway-bedrock-access-key string, $CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup one-off, if set.
+          option only seeds provider configuration at startup once-off, if set.
           The access key to authenticate against the AWS Bedrock API.
 
       --ai-gateway-bedrock-access-key-secret string, $CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY_SECRET
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup one-off, if set.
+          option only seeds provider configuration at startup once-off, if set.
           The access key secret to use with the access key to authenticate
           against the AWS Bedrock API.
 
       --ai-gateway-bedrock-base-url string, $CODER_AI_GATEWAY_BEDROCK_BASE_URL
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup one-off, if set.
+          option only seeds provider configuration at startup once-off, if set.
           The base URL to use for the AWS Bedrock API. Use this setting to
           specify an exact URL to use. Takes precedence over
           CODER_AI_GATEWAY_BEDROCK_REGION.
 
       --ai-gateway-bedrock-model string, $CODER_AI_GATEWAY_BEDROCK_MODEL (default: global.anthropic.claude-sonnet-4-5-20250929-v1:0)
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup one-off, if set.
+          option only seeds provider configuration at startup once-off, if set.
           The model to use when making requests to the AWS Bedrock API.
 
       --ai-gateway-bedrock-region string, $CODER_AI_GATEWAY_BEDROCK_REGION
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup one-off, if set.
+          option only seeds provider configuration at startup once-off, if set.
           The AWS Bedrock API region to use. Constructs a base URL to use for
           the AWS Bedrock API in the form of
           'https://bedrock-runtime.<region>.amazonaws.com'.
 
       --ai-gateway-bedrock-small-fastmodel string, $CODER_AI_GATEWAY_BEDROCK_SMALL_FAST_MODEL (default: global.anthropic.claude-haiku-4-5-20251001-v1:0)
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup one-off, if set.
+          option only seeds provider configuration at startup once-off, if set.
           The small fast model to use when making requests to the AWS Bedrock
           API. Claude Code uses Haiku-class models to perform background tasks.
           See
@@ -188,12 +188,12 @@ AI GATEWAY OPTIONS:
 
       --ai-gateway-openai-base-url string, $CODER_AI_GATEWAY_OPENAI_BASE_URL (default: https://api.openai.com/v1/)
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup one-off, if set.
+          option only seeds provider configuration at startup once-off, if set.
           The base URL of the OpenAI API.
 
       --ai-gateway-openai-key string, $CODER_AI_GATEWAY_OPENAI_KEY
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup one-off, if set.
+          option only seeds provider configuration at startup once-off, if set.
           The key to authenticate against the OpenAI API.
 
       --ai-gateway-rate-limit int, $CODER_AI_GATEWAY_RATE_LIMIT (default: 0)

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -125,43 +125,51 @@ AI GATEWAY OPTIONS:
 
       --ai-gateway-anthropic-base-url string, $CODER_AI_GATEWAY_ANTHROPIC_BASE_URL (default: https://api.anthropic.com/)
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if
-          configured.
+          option only seeds provider configuration at startup one-off, if set.
+          The base URL of the Anthropic API.
 
       --ai-gateway-anthropic-key string, $CODER_AI_GATEWAY_ANTHROPIC_KEY
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if
-          configured.
+          option only seeds provider configuration at startup one-off, if set.
+          The key to authenticate against the Anthropic API.
 
       --ai-gateway-bedrock-access-key string, $CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if
-          configured.
+          option only seeds provider configuration at startup one-off, if set.
+          The access key to authenticate against the AWS Bedrock API.
 
       --ai-gateway-bedrock-access-key-secret string, $CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY_SECRET
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if
-          configured.
+          option only seeds provider configuration at startup one-off, if set.
+          The access key secret to use with the access key to authenticate
+          against the AWS Bedrock API.
 
       --ai-gateway-bedrock-base-url string, $CODER_AI_GATEWAY_BEDROCK_BASE_URL
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if
-          configured.
+          option only seeds provider configuration at startup one-off, if set.
+          The base URL to use for the AWS Bedrock API. Use this setting to
+          specify an exact URL to use. Takes precedence over
+          CODER_AI_GATEWAY_BEDROCK_REGION.
 
       --ai-gateway-bedrock-model string, $CODER_AI_GATEWAY_BEDROCK_MODEL (default: global.anthropic.claude-sonnet-4-5-20250929-v1:0)
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if
-          configured.
+          option only seeds provider configuration at startup one-off, if set.
+          The model to use when making requests to the AWS Bedrock API.
 
       --ai-gateway-bedrock-region string, $CODER_AI_GATEWAY_BEDROCK_REGION
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if
-          configured.
+          option only seeds provider configuration at startup one-off, if set.
+          The AWS Bedrock API region to use. Constructs a base URL to use for
+          the AWS Bedrock API in the form of
+          'https://bedrock-runtime.<region>.amazonaws.com'.
 
       --ai-gateway-bedrock-small-fastmodel string, $CODER_AI_GATEWAY_BEDROCK_SMALL_FAST_MODEL (default: global.anthropic.claude-haiku-4-5-20251001-v1:0)
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if
-          configured.
+          option only seeds provider configuration at startup one-off, if set.
+          The small fast model to use when making requests to the AWS Bedrock
+          API. Claude Code uses Haiku-class models to perform background tasks.
+          See
+          https://docs.claude.com/en/docs/claude-code/settings#environment-variables.
 
       --ai-gateway-circuit-breaker-enabled bool, $CODER_AI_GATEWAY_CIRCUIT_BREAKER_ENABLED (default: false)
           Enable the circuit breaker to protect against cascading failures from
@@ -180,13 +188,13 @@ AI GATEWAY OPTIONS:
 
       --ai-gateway-openai-base-url string, $CODER_AI_GATEWAY_OPENAI_BASE_URL (default: https://api.openai.com/v1/)
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if
-          configured.
+          option only seeds provider configuration at startup one-off, if set.
+          The base URL of the OpenAI API.
 
       --ai-gateway-openai-key string, $CODER_AI_GATEWAY_OPENAI_KEY
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if
-          configured.
+          option only seeds provider configuration at startup one-off, if set.
+          The key to authenticate against the OpenAI API.
 
       --ai-gateway-rate-limit int, $CODER_AI_GATEWAY_RATE_LIMIT (default: 0)
           Maximum number of AI Gateway requests per second per replica. Set to 0

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -874,26 +874,28 @@ ai_gateway:
   # Whether to start an in-memory AI Gateway instance.
   # (default: true, type: bool)
   enabled: true
-  # The base URL of the OpenAI API.
+  # Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only
+  # seeds provider configuration at startup once-off, if configured.
   # (default: https://api.openai.com/v1/, type: string)
   openai_base_url: https://api.openai.com/v1/
-  # The base URL of the Anthropic API.
+  # Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only
+  # seeds provider configuration at startup once-off, if configured.
   # (default: https://api.anthropic.com/, type: string)
   anthropic_base_url: https://api.anthropic.com/
-  # The base URL to use for the AWS Bedrock API. Use this setting to specify an
-  # exact URL to use. Takes precedence over CODER_AI_GATEWAY_BEDROCK_REGION.
+  # Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only
+  # seeds provider configuration at startup once-off, if configured.
   # (default: <unset>, type: string)
   bedrock_base_url: ""
-  # The AWS Bedrock API region to use. Constructs a base URL to use for the AWS
-  # Bedrock API in the form of 'https://bedrock-runtime.<region>.amazonaws.com'.
+  # Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only
+  # seeds provider configuration at startup once-off, if configured.
   # (default: <unset>, type: string)
   bedrock_region: ""
-  # The model to use when making requests to the AWS Bedrock API.
+  # Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only
+  # seeds provider configuration at startup once-off, if configured.
   # (default: global.anthropic.claude-sonnet-4-5-20250929-v1:0, type: string)
   bedrock_model: global.anthropic.claude-sonnet-4-5-20250929-v1:0
-  # The small fast model to use when making requests to the AWS Bedrock API. Claude
-  # Code uses Haiku-class models to perform background tasks. See
-  # https://docs.claude.com/en/docs/claude-code/settings#environment-variables.
+  # Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only
+  # seeds provider configuration at startup once-off, if configured.
   # (default: global.anthropic.claude-haiku-4-5-20251001-v1:0, type: string)
   bedrock_small_fast_model: global.anthropic.claude-haiku-4-5-20251001-v1:0
   # Deprecated: Injected MCP in AI Gateway is deprecated and will be removed in a

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -875,27 +875,37 @@ ai_gateway:
   # (default: true, type: bool)
   enabled: true
   # Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only
-  # seeds provider configuration at startup once-off, if configured.
+  # seeds provider configuration at startup one-off, if set. The base URL of the
+  # OpenAI API.
   # (default: https://api.openai.com/v1/, type: string)
   openai_base_url: https://api.openai.com/v1/
   # Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only
-  # seeds provider configuration at startup once-off, if configured.
+  # seeds provider configuration at startup one-off, if set. The base URL of the
+  # Anthropic API.
   # (default: https://api.anthropic.com/, type: string)
   anthropic_base_url: https://api.anthropic.com/
   # Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only
-  # seeds provider configuration at startup once-off, if configured.
+  # seeds provider configuration at startup one-off, if set. The base URL to use for
+  # the AWS Bedrock API. Use this setting to specify an exact URL to use. Takes
+  # precedence over CODER_AI_GATEWAY_BEDROCK_REGION.
   # (default: <unset>, type: string)
   bedrock_base_url: ""
   # Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only
-  # seeds provider configuration at startup once-off, if configured.
+  # seeds provider configuration at startup one-off, if set. The AWS Bedrock API
+  # region to use. Constructs a base URL to use for the AWS Bedrock API in the form
+  # of 'https://bedrock-runtime.<region>.amazonaws.com'.
   # (default: <unset>, type: string)
   bedrock_region: ""
   # Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only
-  # seeds provider configuration at startup once-off, if configured.
+  # seeds provider configuration at startup one-off, if set. The model to use when
+  # making requests to the AWS Bedrock API.
   # (default: global.anthropic.claude-sonnet-4-5-20250929-v1:0, type: string)
   bedrock_model: global.anthropic.claude-sonnet-4-5-20250929-v1:0
   # Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only
-  # seeds provider configuration at startup once-off, if configured.
+  # seeds provider configuration at startup one-off, if set. The small fast model to
+  # use when making requests to the AWS Bedrock API. Claude Code uses Haiku-class
+  # models to perform background tasks. See
+  # https://docs.claude.com/en/docs/claude-code/settings#environment-variables.
   # (default: global.anthropic.claude-haiku-4-5-20251001-v1:0, type: string)
   bedrock_small_fast_model: global.anthropic.claude-haiku-4-5-20251001-v1:0
   # Deprecated: Injected MCP in AI Gateway is deprecated and will be removed in a

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -874,37 +874,41 @@ ai_gateway:
   # Whether to start an in-memory AI Gateway instance.
   # (default: true, type: bool)
   enabled: true
-  # Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only
-  # seeds provider configuration at startup once-off, if set. The base URL of the
-  # OpenAI API.
+  # Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this
+  # option seeds provider configuration at startup only exactly once. It will not be
+  # used in service runtime. The base URL of the OpenAI API.
   # (default: https://api.openai.com/v1/, type: string)
   openai_base_url: https://api.openai.com/v1/
-  # Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only
-  # seeds provider configuration at startup once-off, if set. The base URL of the
-  # Anthropic API.
+  # Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this
+  # option seeds provider configuration at startup only exactly once. It will not be
+  # used in service runtime. The base URL of the Anthropic API.
   # (default: https://api.anthropic.com/, type: string)
   anthropic_base_url: https://api.anthropic.com/
-  # Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only
-  # seeds provider configuration at startup once-off, if set. The base URL to use
-  # for the AWS Bedrock API. Use this setting to specify an exact URL to use. Takes
-  # precedence over CODER_AI_GATEWAY_BEDROCK_REGION.
+  # Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this
+  # option seeds provider configuration at startup only exactly once. It will not be
+  # used in service runtime. The base URL to use for the AWS Bedrock API. Use this
+  # setting to specify an exact URL to use. Takes precedence over
+  # CODER_AI_GATEWAY_BEDROCK_REGION.
   # (default: <unset>, type: string)
   bedrock_base_url: ""
-  # Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only
-  # seeds provider configuration at startup once-off, if set. The AWS Bedrock API
-  # region to use. Constructs a base URL to use for the AWS Bedrock API in the form
-  # of 'https://bedrock-runtime.<region>.amazonaws.com'.
+  # Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this
+  # option seeds provider configuration at startup only exactly once. It will not be
+  # used in service runtime. The AWS Bedrock API region to use. Constructs a base
+  # URL to use for the AWS Bedrock API in the form of
+  # 'https://bedrock-runtime.<region>.amazonaws.com'.
   # (default: <unset>, type: string)
   bedrock_region: ""
-  # Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only
-  # seeds provider configuration at startup once-off, if set. The model to use when
-  # making requests to the AWS Bedrock API.
+  # Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this
+  # option seeds provider configuration at startup only exactly once. It will not be
+  # used in service runtime. The model to use when making requests to the AWS
+  # Bedrock API.
   # (default: global.anthropic.claude-sonnet-4-5-20250929-v1:0, type: string)
   bedrock_model: global.anthropic.claude-sonnet-4-5-20250929-v1:0
-  # Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only
-  # seeds provider configuration at startup once-off, if set. The small fast model
-  # to use when making requests to the AWS Bedrock API. Claude Code uses Haiku-class
-  # models to perform background tasks. See
+  # Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this
+  # option seeds provider configuration at startup only exactly once. It will not be
+  # used in service runtime. The small fast model to use when making requests to the
+  # AWS Bedrock API. Claude Code uses Haiku-class models to perform background
+  # tasks. See
   # https://docs.claude.com/en/docs/claude-code/settings#environment-variables.
   # (default: global.anthropic.claude-haiku-4-5-20251001-v1:0, type: string)
   bedrock_small_fast_model: global.anthropic.claude-haiku-4-5-20251001-v1:0

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -875,35 +875,35 @@ ai_gateway:
   # (default: true, type: bool)
   enabled: true
   # Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only
-  # seeds provider configuration at startup one-off, if set. The base URL of the
+  # seeds provider configuration at startup once-off, if set. The base URL of the
   # OpenAI API.
   # (default: https://api.openai.com/v1/, type: string)
   openai_base_url: https://api.openai.com/v1/
   # Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only
-  # seeds provider configuration at startup one-off, if set. The base URL of the
+  # seeds provider configuration at startup once-off, if set. The base URL of the
   # Anthropic API.
   # (default: https://api.anthropic.com/, type: string)
   anthropic_base_url: https://api.anthropic.com/
   # Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only
-  # seeds provider configuration at startup one-off, if set. The base URL to use for
-  # the AWS Bedrock API. Use this setting to specify an exact URL to use. Takes
+  # seeds provider configuration at startup once-off, if set. The base URL to use
+  # for the AWS Bedrock API. Use this setting to specify an exact URL to use. Takes
   # precedence over CODER_AI_GATEWAY_BEDROCK_REGION.
   # (default: <unset>, type: string)
   bedrock_base_url: ""
   # Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only
-  # seeds provider configuration at startup one-off, if set. The AWS Bedrock API
+  # seeds provider configuration at startup once-off, if set. The AWS Bedrock API
   # region to use. Constructs a base URL to use for the AWS Bedrock API in the form
   # of 'https://bedrock-runtime.<region>.amazonaws.com'.
   # (default: <unset>, type: string)
   bedrock_region: ""
   # Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only
-  # seeds provider configuration at startup one-off, if set. The model to use when
+  # seeds provider configuration at startup once-off, if set. The model to use when
   # making requests to the AWS Bedrock API.
   # (default: global.anthropic.claude-sonnet-4-5-20250929-v1:0, type: string)
   bedrock_model: global.anthropic.claude-sonnet-4-5-20250929-v1:0
   # Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only
-  # seeds provider configuration at startup one-off, if set. The small fast model to
-  # use when making requests to the AWS Bedrock API. Claude Code uses Haiku-class
+  # seeds provider configuration at startup once-off, if set. The small fast model
+  # to use when making requests to the AWS Bedrock API. Claude Code uses Haiku-class
   # models to perform background tasks. See
   # https://docs.claude.com/en/docs/claude-code/settings#environment-variables.
   # (default: global.anthropic.claude-haiku-4-5-20251001-v1:0, type: string)

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -1700,7 +1700,7 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 	}
 
 	// AI Gateway options
-	aiGatewayProviderSeedingDeprecated := "Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if set. "
+	aiGatewayProviderSeedingDeprecated := "Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. "
 	aiGatewayEnabled := serpent.Option{
 		Name:        "AI Gateway Enabled",
 		Description: "Whether to start an in-memory AI Gateway instance.",

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -1700,7 +1700,7 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 	}
 
 	// AI Gateway options
-	aiGatewayProviderSeedingDeprecated := "Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup one-off, if set. "
+	aiGatewayProviderSeedingDeprecated := "Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if set. "
 	aiGatewayEnabled := serpent.Option{
 		Name:        "AI Gateway Enabled",
 		Description: "Whether to start an in-memory AI Gateway instance.",

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -1700,7 +1700,7 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 	}
 
 	// AI Gateway options
-	aiGatewayProviderSeedingDeprecated := "Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if configured."
+	aiGatewayProviderSeedingDeprecated := "Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup one-off, if set. "
 	aiGatewayEnabled := serpent.Option{
 		Name:        "AI Gateway Enabled",
 		Description: "Whether to start an in-memory AI Gateway instance.",
@@ -1711,10 +1711,9 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		Group:       &deploymentGroupAIGateway,
 		YAML:        "enabled",
 	}
-	// The base URL of the OpenAI API.
 	aiGatewayOpenAIBaseURL := serpent.Option{
 		Name:        "AI Gateway OpenAI Base URL",
-		Description: aiGatewayProviderSeedingDeprecated,
+		Description: aiGatewayProviderSeedingDeprecated + "The base URL of the OpenAI API.",
 		Flag:        "ai-gateway-openai-base-url",
 		Env:         "CODER_AI_GATEWAY_OPENAI_BASE_URL",
 		Value:       &c.AI.BridgeConfig.LegacyOpenAI.BaseURL,
@@ -1722,10 +1721,9 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		Group:       &deploymentGroupAIGateway,
 		YAML:        "openai_base_url",
 	}
-	// The key to authenticate against the OpenAI API.
 	aiGatewayOpenAIKey := serpent.Option{
 		Name:        "AI Gateway OpenAI Key",
-		Description: aiGatewayProviderSeedingDeprecated,
+		Description: aiGatewayProviderSeedingDeprecated + "The key to authenticate against the OpenAI API.",
 		Flag:        "ai-gateway-openai-key",
 		Env:         "CODER_AI_GATEWAY_OPENAI_KEY",
 		Value:       &c.AI.BridgeConfig.LegacyOpenAI.Key,
@@ -1733,10 +1731,9 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		Group:       &deploymentGroupAIGateway,
 		Annotations: serpent.Annotations{}.Mark(annotationSecretKey, "true"),
 	}
-	// The base URL of the Anthropic API.
 	aiGatewayAnthropicBaseURL := serpent.Option{
 		Name:        "AI Gateway Anthropic Base URL",
-		Description: aiGatewayProviderSeedingDeprecated,
+		Description: aiGatewayProviderSeedingDeprecated + "The base URL of the Anthropic API.",
 		Flag:        "ai-gateway-anthropic-base-url",
 		Env:         "CODER_AI_GATEWAY_ANTHROPIC_BASE_URL",
 		Value:       &c.AI.BridgeConfig.LegacyAnthropic.BaseURL,
@@ -1744,10 +1741,9 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		Group:       &deploymentGroupAIGateway,
 		YAML:        "anthropic_base_url",
 	}
-	// The key to authenticate against the Anthropic API.
 	aiGatewayAnthropicKey := serpent.Option{
 		Name:        "AI Gateway Anthropic Key",
-		Description: aiGatewayProviderSeedingDeprecated,
+		Description: aiGatewayProviderSeedingDeprecated + "The key to authenticate against the Anthropic API.",
 		Flag:        "ai-gateway-anthropic-key",
 		Env:         "CODER_AI_GATEWAY_ANTHROPIC_KEY",
 		Value:       &c.AI.BridgeConfig.LegacyAnthropic.Key,
@@ -1755,11 +1751,9 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		Group:       &deploymentGroupAIGateway,
 		Annotations: serpent.Annotations{}.Mark(annotationSecretKey, "true"),
 	}
-	// The base URL to use for the AWS Bedrock API. Use this setting to specify an exact URL to use.
-	// Takes precedence over CODER_AI_GATEWAY_BEDROCK_REGION.
 	aiGatewayBedrockBaseURL := serpent.Option{
 		Name:        "AI Gateway Bedrock Base URL",
-		Description: aiGatewayProviderSeedingDeprecated,
+		Description: aiGatewayProviderSeedingDeprecated + "The base URL to use for the AWS Bedrock API. Use this setting to specify an exact URL to use. Takes precedence over CODER_AI_GATEWAY_BEDROCK_REGION.",
 		Flag:        "ai-gateway-bedrock-base-url",
 		Env:         "CODER_AI_GATEWAY_BEDROCK_BASE_URL",
 		Value:       &c.AI.BridgeConfig.LegacyBedrock.BaseURL,
@@ -1767,11 +1761,9 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		Group:       &deploymentGroupAIGateway,
 		YAML:        "bedrock_base_url",
 	}
-	// The AWS Bedrock API region to use. Constructs a base URL to use for the AWS Bedrock API in the
-	// form of 'https://bedrock-runtime.<region>.amazonaws.com'.
 	aiGatewayBedrockRegion := serpent.Option{
 		Name:        "AI Gateway Bedrock Region",
-		Description: aiGatewayProviderSeedingDeprecated,
+		Description: aiGatewayProviderSeedingDeprecated + "The AWS Bedrock API region to use. Constructs a base URL to use for the AWS Bedrock API in the form of 'https://bedrock-runtime.<region>.amazonaws.com'.",
 		Flag:        "ai-gateway-bedrock-region",
 		Env:         "CODER_AI_GATEWAY_BEDROCK_REGION",
 		Value:       &c.AI.BridgeConfig.LegacyBedrock.Region,
@@ -1779,10 +1771,9 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		Group:       &deploymentGroupAIGateway,
 		YAML:        "bedrock_region",
 	}
-	// The access key to authenticate against the AWS Bedrock API.
 	aiGatewayBedrockAccessKey := serpent.Option{
 		Name:        "AI Gateway Bedrock Access Key",
-		Description: aiGatewayProviderSeedingDeprecated,
+		Description: aiGatewayProviderSeedingDeprecated + "The access key to authenticate against the AWS Bedrock API.",
 		Flag:        "ai-gateway-bedrock-access-key",
 		Env:         "CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY",
 		Value:       &c.AI.BridgeConfig.LegacyBedrock.AccessKey,
@@ -1790,10 +1781,9 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		Group:       &deploymentGroupAIGateway,
 		Annotations: serpent.Annotations{}.Mark(annotationSecretKey, "true"),
 	}
-	// The access key secret to use with the access key to authenticate against the AWS Bedrock API.
 	aiGatewayBedrockAccessKeySecret := serpent.Option{
 		Name:        "AI Gateway Bedrock Access Key Secret",
-		Description: aiGatewayProviderSeedingDeprecated,
+		Description: aiGatewayProviderSeedingDeprecated + "The access key secret to use with the access key to authenticate against the AWS Bedrock API.",
 		Flag:        "ai-gateway-bedrock-access-key-secret",
 		Env:         "CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY_SECRET",
 		Value:       &c.AI.BridgeConfig.LegacyBedrock.AccessKeySecret,
@@ -1801,10 +1791,9 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		Group:       &deploymentGroupAIGateway,
 		Annotations: serpent.Annotations{}.Mark(annotationSecretKey, "true"),
 	}
-	// The model to use when making requests to the AWS Bedrock API.
 	aiGatewayBedrockModel := serpent.Option{
 		Name:        "AI Gateway Bedrock Model",
-		Description: aiGatewayProviderSeedingDeprecated,
+		Description: aiGatewayProviderSeedingDeprecated + "The model to use when making requests to the AWS Bedrock API.",
 		Flag:        "ai-gateway-bedrock-model",
 		Env:         "CODER_AI_GATEWAY_BEDROCK_MODEL",
 		Value:       &c.AI.BridgeConfig.LegacyBedrock.Model,
@@ -1812,12 +1801,9 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		Group:       &deploymentGroupAIGateway,
 		YAML:        "bedrock_model",
 	}
-	// The small fast model to use when making requests to the AWS Bedrock API. Claude Code uses
-	// Haiku-class models to perform background tasks. See
-	// https://docs.claude.com/en/docs/claude-code/settings#environment-variables.
 	aiGatewayBedrockSmallFastModel := serpent.Option{
 		Name:        "AI Gateway Bedrock Small Fast Model",
-		Description: aiGatewayProviderSeedingDeprecated,
+		Description: aiGatewayProviderSeedingDeprecated + "The small fast model to use when making requests to the AWS Bedrock API. Claude Code uses Haiku-class models to perform background tasks. See https://docs.claude.com/en/docs/claude-code/settings#environment-variables.",
 		Flag:        "ai-gateway-bedrock-small-fastmodel",
 		Env:         "CODER_AI_GATEWAY_BEDROCK_SMALL_FAST_MODEL",
 		Value:       &c.AI.BridgeConfig.LegacyBedrock.SmallFastModel,

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -1700,6 +1700,7 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 	}
 
 	// AI Gateway options
+	aiGatewayProviderSeedingDeprecated := "Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if configured."
 	aiGatewayEnabled := serpent.Option{
 		Name:        "AI Gateway Enabled",
 		Description: "Whether to start an in-memory AI Gateway instance.",
@@ -1710,9 +1711,10 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		Group:       &deploymentGroupAIGateway,
 		YAML:        "enabled",
 	}
+	// The base URL of the OpenAI API.
 	aiGatewayOpenAIBaseURL := serpent.Option{
 		Name:        "AI Gateway OpenAI Base URL",
-		Description: "The base URL of the OpenAI API.",
+		Description: aiGatewayProviderSeedingDeprecated,
 		Flag:        "ai-gateway-openai-base-url",
 		Env:         "CODER_AI_GATEWAY_OPENAI_BASE_URL",
 		Value:       &c.AI.BridgeConfig.LegacyOpenAI.BaseURL,
@@ -1720,9 +1722,10 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		Group:       &deploymentGroupAIGateway,
 		YAML:        "openai_base_url",
 	}
+	// The key to authenticate against the OpenAI API.
 	aiGatewayOpenAIKey := serpent.Option{
 		Name:        "AI Gateway OpenAI Key",
-		Description: "The key to authenticate against the OpenAI API.",
+		Description: aiGatewayProviderSeedingDeprecated,
 		Flag:        "ai-gateway-openai-key",
 		Env:         "CODER_AI_GATEWAY_OPENAI_KEY",
 		Value:       &c.AI.BridgeConfig.LegacyOpenAI.Key,
@@ -1730,9 +1733,10 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		Group:       &deploymentGroupAIGateway,
 		Annotations: serpent.Annotations{}.Mark(annotationSecretKey, "true"),
 	}
+	// The base URL of the Anthropic API.
 	aiGatewayAnthropicBaseURL := serpent.Option{
 		Name:        "AI Gateway Anthropic Base URL",
-		Description: "The base URL of the Anthropic API.",
+		Description: aiGatewayProviderSeedingDeprecated,
 		Flag:        "ai-gateway-anthropic-base-url",
 		Env:         "CODER_AI_GATEWAY_ANTHROPIC_BASE_URL",
 		Value:       &c.AI.BridgeConfig.LegacyAnthropic.BaseURL,
@@ -1740,9 +1744,10 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		Group:       &deploymentGroupAIGateway,
 		YAML:        "anthropic_base_url",
 	}
+	// The key to authenticate against the Anthropic API.
 	aiGatewayAnthropicKey := serpent.Option{
 		Name:        "AI Gateway Anthropic Key",
-		Description: "The key to authenticate against the Anthropic API.",
+		Description: aiGatewayProviderSeedingDeprecated,
 		Flag:        "ai-gateway-anthropic-key",
 		Env:         "CODER_AI_GATEWAY_ANTHROPIC_KEY",
 		Value:       &c.AI.BridgeConfig.LegacyAnthropic.Key,
@@ -1750,31 +1755,34 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		Group:       &deploymentGroupAIGateway,
 		Annotations: serpent.Annotations{}.Mark(annotationSecretKey, "true"),
 	}
+	// The base URL to use for the AWS Bedrock API. Use this setting to specify an exact URL to use.
+	// Takes precedence over CODER_AI_GATEWAY_BEDROCK_REGION.
 	aiGatewayBedrockBaseURL := serpent.Option{
-		Name: "AI Gateway Bedrock Base URL",
-		Description: "The base URL to use for the AWS Bedrock API. Use this setting to specify an exact URL to use. Takes precedence " +
-			"over CODER_AI_GATEWAY_BEDROCK_REGION.",
-		Flag:    "ai-gateway-bedrock-base-url",
-		Env:     "CODER_AI_GATEWAY_BEDROCK_BASE_URL",
-		Value:   &c.AI.BridgeConfig.LegacyBedrock.BaseURL,
-		Default: "",
-		Group:   &deploymentGroupAIGateway,
-		YAML:    "bedrock_base_url",
+		Name:        "AI Gateway Bedrock Base URL",
+		Description: aiGatewayProviderSeedingDeprecated,
+		Flag:        "ai-gateway-bedrock-base-url",
+		Env:         "CODER_AI_GATEWAY_BEDROCK_BASE_URL",
+		Value:       &c.AI.BridgeConfig.LegacyBedrock.BaseURL,
+		Default:     "",
+		Group:       &deploymentGroupAIGateway,
+		YAML:        "bedrock_base_url",
 	}
+	// The AWS Bedrock API region to use. Constructs a base URL to use for the AWS Bedrock API in the
+	// form of 'https://bedrock-runtime.<region>.amazonaws.com'.
 	aiGatewayBedrockRegion := serpent.Option{
-		Name: "AI Gateway Bedrock Region",
-		Description: "The AWS Bedrock API region to use. Constructs a base URL to use for the AWS Bedrock API in the form of " +
-			"'https://bedrock-runtime.<region>.amazonaws.com'.",
-		Flag:    "ai-gateway-bedrock-region",
-		Env:     "CODER_AI_GATEWAY_BEDROCK_REGION",
-		Value:   &c.AI.BridgeConfig.LegacyBedrock.Region,
-		Default: "",
-		Group:   &deploymentGroupAIGateway,
-		YAML:    "bedrock_region",
+		Name:        "AI Gateway Bedrock Region",
+		Description: aiGatewayProviderSeedingDeprecated,
+		Flag:        "ai-gateway-bedrock-region",
+		Env:         "CODER_AI_GATEWAY_BEDROCK_REGION",
+		Value:       &c.AI.BridgeConfig.LegacyBedrock.Region,
+		Default:     "",
+		Group:       &deploymentGroupAIGateway,
+		YAML:        "bedrock_region",
 	}
+	// The access key to authenticate against the AWS Bedrock API.
 	aiGatewayBedrockAccessKey := serpent.Option{
 		Name:        "AI Gateway Bedrock Access Key",
-		Description: "The access key to authenticate against the AWS Bedrock API.",
+		Description: aiGatewayProviderSeedingDeprecated,
 		Flag:        "ai-gateway-bedrock-access-key",
 		Env:         "CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY",
 		Value:       &c.AI.BridgeConfig.LegacyBedrock.AccessKey,
@@ -1782,9 +1790,10 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		Group:       &deploymentGroupAIGateway,
 		Annotations: serpent.Annotations{}.Mark(annotationSecretKey, "true"),
 	}
+	// The access key secret to use with the access key to authenticate against the AWS Bedrock API.
 	aiGatewayBedrockAccessKeySecret := serpent.Option{
 		Name:        "AI Gateway Bedrock Access Key Secret",
-		Description: "The access key secret to use with the access key to authenticate against the AWS Bedrock API.",
+		Description: aiGatewayProviderSeedingDeprecated,
 		Flag:        "ai-gateway-bedrock-access-key-secret",
 		Env:         "CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY_SECRET",
 		Value:       &c.AI.BridgeConfig.LegacyBedrock.AccessKeySecret,
@@ -1792,9 +1801,10 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		Group:       &deploymentGroupAIGateway,
 		Annotations: serpent.Annotations{}.Mark(annotationSecretKey, "true"),
 	}
+	// The model to use when making requests to the AWS Bedrock API.
 	aiGatewayBedrockModel := serpent.Option{
 		Name:        "AI Gateway Bedrock Model",
-		Description: "The model to use when making requests to the AWS Bedrock API.",
+		Description: aiGatewayProviderSeedingDeprecated,
 		Flag:        "ai-gateway-bedrock-model",
 		Env:         "CODER_AI_GATEWAY_BEDROCK_MODEL",
 		Value:       &c.AI.BridgeConfig.LegacyBedrock.Model,
@@ -1802,9 +1812,12 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		Group:       &deploymentGroupAIGateway,
 		YAML:        "bedrock_model",
 	}
+	// The small fast model to use when making requests to the AWS Bedrock API. Claude Code uses
+	// Haiku-class models to perform background tasks. See
+	// https://docs.claude.com/en/docs/claude-code/settings#environment-variables.
 	aiGatewayBedrockSmallFastModel := serpent.Option{
 		Name:        "AI Gateway Bedrock Small Fast Model",
-		Description: "The small fast model to use when making requests to the AWS Bedrock API. Claude Code uses Haiku-class models to perform background tasks. See https://docs.claude.com/en/docs/claude-code/settings#environment-variables.",
+		Description: aiGatewayProviderSeedingDeprecated,
 		Flag:        "ai-gateway-bedrock-small-fastmodel",
 		Env:         "CODER_AI_GATEWAY_BEDROCK_SMALL_FAST_MODEL",
 		Value:       &c.AI.BridgeConfig.LegacyBedrock.SmallFastModel,

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1743,7 +1743,7 @@ Whether to start an in-memory AI Gateway instance.
 | YAML        | <code>ai_gateway.openai_base_url</code>        |
 | Default     | <code>https://api.openai.com/v1/</code>        |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if configured.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup one-off, if set. The base URL of the OpenAI API.
 
 ### --ai-gateway-openai-key
 
@@ -1752,7 +1752,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | Type        | <code>string</code>                       |
 | Environment | <code>$CODER_AI_GATEWAY_OPENAI_KEY</code> |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if configured.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup one-off, if set. The key to authenticate against the OpenAI API.
 
 ### --ai-gateway-anthropic-base-url
 
@@ -1763,7 +1763,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | YAML        | <code>ai_gateway.anthropic_base_url</code>        |
 | Default     | <code>https://api.anthropic.com/</code>           |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if configured.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup one-off, if set. The base URL of the Anthropic API.
 
 ### --ai-gateway-anthropic-key
 
@@ -1772,7 +1772,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | Type        | <code>string</code>                          |
 | Environment | <code>$CODER_AI_GATEWAY_ANTHROPIC_KEY</code> |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if configured.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup one-off, if set. The key to authenticate against the Anthropic API.
 
 ### --ai-gateway-bedrock-base-url
 
@@ -1782,7 +1782,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | Environment | <code>$CODER_AI_GATEWAY_BEDROCK_BASE_URL</code> |
 | YAML        | <code>ai_gateway.bedrock_base_url</code>        |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if configured.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup one-off, if set. The base URL to use for the AWS Bedrock API. Use this setting to specify an exact URL to use. Takes precedence over CODER_AI_GATEWAY_BEDROCK_REGION.
 
 ### --ai-gateway-bedrock-region
 
@@ -1792,7 +1792,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | Environment | <code>$CODER_AI_GATEWAY_BEDROCK_REGION</code> |
 | YAML        | <code>ai_gateway.bedrock_region</code>        |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if configured.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup one-off, if set. The AWS Bedrock API region to use. Constructs a base URL to use for the AWS Bedrock API in the form of 'https://bedrock-runtime.<region>.amazonaws.com'.
 
 ### --ai-gateway-bedrock-access-key
 
@@ -1801,7 +1801,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | Type        | <code>string</code>                               |
 | Environment | <code>$CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY</code> |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if configured.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup one-off, if set. The access key to authenticate against the AWS Bedrock API.
 
 ### --ai-gateway-bedrock-access-key-secret
 
@@ -1810,7 +1810,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | Type        | <code>string</code>                                      |
 | Environment | <code>$CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY_SECRET</code> |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if configured.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup one-off, if set. The access key secret to use with the access key to authenticate against the AWS Bedrock API.
 
 ### --ai-gateway-bedrock-model
 
@@ -1821,7 +1821,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | YAML        | <code>ai_gateway.bedrock_model</code>                         |
 | Default     | <code>global.anthropic.claude-sonnet-4-5-20250929-v1:0</code> |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if configured.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup one-off, if set. The model to use when making requests to the AWS Bedrock API.
 
 ### --ai-gateway-bedrock-small-fastmodel
 
@@ -1832,7 +1832,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | YAML        | <code>ai_gateway.bedrock_small_fast_model</code>             |
 | Default     | <code>global.anthropic.claude-haiku-4-5-20251001-v1:0</code> |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if configured.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup one-off, if set. The small fast model to use when making requests to the AWS Bedrock API. Claude Code uses Haiku-class models to perform background tasks. See https://docs.claude.com/en/docs/claude-code/settings#environment-variables.
 
 ### --ai-gateway-retention
 

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1743,7 +1743,7 @@ Whether to start an in-memory AI Gateway instance.
 | YAML        | <code>ai_gateway.openai_base_url</code>        |
 | Default     | <code>https://api.openai.com/v1/</code>        |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if set. The base URL of the OpenAI API.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The base URL of the OpenAI API.
 
 ### --ai-gateway-openai-key
 
@@ -1752,7 +1752,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | Type        | <code>string</code>                       |
 | Environment | <code>$CODER_AI_GATEWAY_OPENAI_KEY</code> |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if set. The key to authenticate against the OpenAI API.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The key to authenticate against the OpenAI API.
 
 ### --ai-gateway-anthropic-base-url
 
@@ -1763,7 +1763,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | YAML        | <code>ai_gateway.anthropic_base_url</code>        |
 | Default     | <code>https://api.anthropic.com/</code>           |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if set. The base URL of the Anthropic API.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The base URL of the Anthropic API.
 
 ### --ai-gateway-anthropic-key
 
@@ -1772,7 +1772,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | Type        | <code>string</code>                          |
 | Environment | <code>$CODER_AI_GATEWAY_ANTHROPIC_KEY</code> |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if set. The key to authenticate against the Anthropic API.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The key to authenticate against the Anthropic API.
 
 ### --ai-gateway-bedrock-base-url
 
@@ -1782,7 +1782,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | Environment | <code>$CODER_AI_GATEWAY_BEDROCK_BASE_URL</code> |
 | YAML        | <code>ai_gateway.bedrock_base_url</code>        |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if set. The base URL to use for the AWS Bedrock API. Use this setting to specify an exact URL to use. Takes precedence over CODER_AI_GATEWAY_BEDROCK_REGION.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The base URL to use for the AWS Bedrock API. Use this setting to specify an exact URL to use. Takes precedence over CODER_AI_GATEWAY_BEDROCK_REGION.
 
 ### --ai-gateway-bedrock-region
 
@@ -1792,7 +1792,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | Environment | <code>$CODER_AI_GATEWAY_BEDROCK_REGION</code> |
 | YAML        | <code>ai_gateway.bedrock_region</code>        |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if set. The AWS Bedrock API region to use. Constructs a base URL to use for the AWS Bedrock API in the form of 'https://bedrock-runtime.<region>.amazonaws.com'.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The AWS Bedrock API region to use. Constructs a base URL to use for the AWS Bedrock API in the form of 'https://bedrock-runtime.<region>.amazonaws.com'.
 
 ### --ai-gateway-bedrock-access-key
 
@@ -1801,7 +1801,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | Type        | <code>string</code>                               |
 | Environment | <code>$CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY</code> |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if set. The access key to authenticate against the AWS Bedrock API.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The access key to authenticate against the AWS Bedrock API.
 
 ### --ai-gateway-bedrock-access-key-secret
 
@@ -1810,7 +1810,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | Type        | <code>string</code>                                      |
 | Environment | <code>$CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY_SECRET</code> |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if set. The access key secret to use with the access key to authenticate against the AWS Bedrock API.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The access key secret to use with the access key to authenticate against the AWS Bedrock API.
 
 ### --ai-gateway-bedrock-model
 
@@ -1821,7 +1821,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | YAML        | <code>ai_gateway.bedrock_model</code>                         |
 | Default     | <code>global.anthropic.claude-sonnet-4-5-20250929-v1:0</code> |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if set. The model to use when making requests to the AWS Bedrock API.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The model to use when making requests to the AWS Bedrock API.
 
 ### --ai-gateway-bedrock-small-fastmodel
 
@@ -1832,7 +1832,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | YAML        | <code>ai_gateway.bedrock_small_fast_model</code>             |
 | Default     | <code>global.anthropic.claude-haiku-4-5-20251001-v1:0</code> |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if set. The small fast model to use when making requests to the AWS Bedrock API. Claude Code uses Haiku-class models to perform background tasks. See https://docs.claude.com/en/docs/claude-code/settings#environment-variables.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The small fast model to use when making requests to the AWS Bedrock API. Claude Code uses Haiku-class models to perform background tasks. See https://docs.claude.com/en/docs/claude-code/settings#environment-variables.
 
 ### --ai-gateway-retention
 

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1743,7 +1743,7 @@ Whether to start an in-memory AI Gateway instance.
 | YAML        | <code>ai_gateway.openai_base_url</code>        |
 | Default     | <code>https://api.openai.com/v1/</code>        |
 
-The base URL of the OpenAI API.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if configured.
 
 ### --ai-gateway-openai-key
 
@@ -1752,7 +1752,7 @@ The base URL of the OpenAI API.
 | Type        | <code>string</code>                       |
 | Environment | <code>$CODER_AI_GATEWAY_OPENAI_KEY</code> |
 
-The key to authenticate against the OpenAI API.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if configured.
 
 ### --ai-gateway-anthropic-base-url
 
@@ -1763,7 +1763,7 @@ The key to authenticate against the OpenAI API.
 | YAML        | <code>ai_gateway.anthropic_base_url</code>        |
 | Default     | <code>https://api.anthropic.com/</code>           |
 
-The base URL of the Anthropic API.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if configured.
 
 ### --ai-gateway-anthropic-key
 
@@ -1772,7 +1772,7 @@ The base URL of the Anthropic API.
 | Type        | <code>string</code>                          |
 | Environment | <code>$CODER_AI_GATEWAY_ANTHROPIC_KEY</code> |
 
-The key to authenticate against the Anthropic API.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if configured.
 
 ### --ai-gateway-bedrock-base-url
 
@@ -1782,7 +1782,7 @@ The key to authenticate against the Anthropic API.
 | Environment | <code>$CODER_AI_GATEWAY_BEDROCK_BASE_URL</code> |
 | YAML        | <code>ai_gateway.bedrock_base_url</code>        |
 
-The base URL to use for the AWS Bedrock API. Use this setting to specify an exact URL to use. Takes precedence over CODER_AI_GATEWAY_BEDROCK_REGION.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if configured.
 
 ### --ai-gateway-bedrock-region
 
@@ -1792,7 +1792,7 @@ The base URL to use for the AWS Bedrock API. Use this setting to specify an exac
 | Environment | <code>$CODER_AI_GATEWAY_BEDROCK_REGION</code> |
 | YAML        | <code>ai_gateway.bedrock_region</code>        |
 
-The AWS Bedrock API region to use. Constructs a base URL to use for the AWS Bedrock API in the form of 'https://bedrock-runtime.<region>.amazonaws.com'.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if configured.
 
 ### --ai-gateway-bedrock-access-key
 
@@ -1801,7 +1801,7 @@ The AWS Bedrock API region to use. Constructs a base URL to use for the AWS Bedr
 | Type        | <code>string</code>                               |
 | Environment | <code>$CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY</code> |
 
-The access key to authenticate against the AWS Bedrock API.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if configured.
 
 ### --ai-gateway-bedrock-access-key-secret
 
@@ -1810,7 +1810,7 @@ The access key to authenticate against the AWS Bedrock API.
 | Type        | <code>string</code>                                      |
 | Environment | <code>$CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY_SECRET</code> |
 
-The access key secret to use with the access key to authenticate against the AWS Bedrock API.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if configured.
 
 ### --ai-gateway-bedrock-model
 
@@ -1821,7 +1821,7 @@ The access key secret to use with the access key to authenticate against the AWS
 | YAML        | <code>ai_gateway.bedrock_model</code>                         |
 | Default     | <code>global.anthropic.claude-sonnet-4-5-20250929-v1:0</code> |
 
-The model to use when making requests to the AWS Bedrock API.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if configured.
 
 ### --ai-gateway-bedrock-small-fastmodel
 
@@ -1832,7 +1832,7 @@ The model to use when making requests to the AWS Bedrock API.
 | YAML        | <code>ai_gateway.bedrock_small_fast_model</code>             |
 | Default     | <code>global.anthropic.claude-haiku-4-5-20251001-v1:0</code> |
 
-The small fast model to use when making requests to the AWS Bedrock API. Claude Code uses Haiku-class models to perform background tasks. See https://docs.claude.com/en/docs/claude-code/settings#environment-variables.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if configured.
 
 ### --ai-gateway-retention
 

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1743,7 +1743,7 @@ Whether to start an in-memory AI Gateway instance.
 | YAML        | <code>ai_gateway.openai_base_url</code>        |
 | Default     | <code>https://api.openai.com/v1/</code>        |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup one-off, if set. The base URL of the OpenAI API.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if set. The base URL of the OpenAI API.
 
 ### --ai-gateway-openai-key
 
@@ -1752,7 +1752,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | Type        | <code>string</code>                       |
 | Environment | <code>$CODER_AI_GATEWAY_OPENAI_KEY</code> |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup one-off, if set. The key to authenticate against the OpenAI API.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if set. The key to authenticate against the OpenAI API.
 
 ### --ai-gateway-anthropic-base-url
 
@@ -1763,7 +1763,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | YAML        | <code>ai_gateway.anthropic_base_url</code>        |
 | Default     | <code>https://api.anthropic.com/</code>           |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup one-off, if set. The base URL of the Anthropic API.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if set. The base URL of the Anthropic API.
 
 ### --ai-gateway-anthropic-key
 
@@ -1772,7 +1772,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | Type        | <code>string</code>                          |
 | Environment | <code>$CODER_AI_GATEWAY_ANTHROPIC_KEY</code> |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup one-off, if set. The key to authenticate against the Anthropic API.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if set. The key to authenticate against the Anthropic API.
 
 ### --ai-gateway-bedrock-base-url
 
@@ -1782,7 +1782,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | Environment | <code>$CODER_AI_GATEWAY_BEDROCK_BASE_URL</code> |
 | YAML        | <code>ai_gateway.bedrock_base_url</code>        |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup one-off, if set. The base URL to use for the AWS Bedrock API. Use this setting to specify an exact URL to use. Takes precedence over CODER_AI_GATEWAY_BEDROCK_REGION.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if set. The base URL to use for the AWS Bedrock API. Use this setting to specify an exact URL to use. Takes precedence over CODER_AI_GATEWAY_BEDROCK_REGION.
 
 ### --ai-gateway-bedrock-region
 
@@ -1792,7 +1792,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | Environment | <code>$CODER_AI_GATEWAY_BEDROCK_REGION</code> |
 | YAML        | <code>ai_gateway.bedrock_region</code>        |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup one-off, if set. The AWS Bedrock API region to use. Constructs a base URL to use for the AWS Bedrock API in the form of 'https://bedrock-runtime.<region>.amazonaws.com'.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if set. The AWS Bedrock API region to use. Constructs a base URL to use for the AWS Bedrock API in the form of 'https://bedrock-runtime.<region>.amazonaws.com'.
 
 ### --ai-gateway-bedrock-access-key
 
@@ -1801,7 +1801,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | Type        | <code>string</code>                               |
 | Environment | <code>$CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY</code> |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup one-off, if set. The access key to authenticate against the AWS Bedrock API.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if set. The access key to authenticate against the AWS Bedrock API.
 
 ### --ai-gateway-bedrock-access-key-secret
 
@@ -1810,7 +1810,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | Type        | <code>string</code>                                      |
 | Environment | <code>$CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY_SECRET</code> |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup one-off, if set. The access key secret to use with the access key to authenticate against the AWS Bedrock API.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if set. The access key secret to use with the access key to authenticate against the AWS Bedrock API.
 
 ### --ai-gateway-bedrock-model
 
@@ -1821,7 +1821,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | YAML        | <code>ai_gateway.bedrock_model</code>                         |
 | Default     | <code>global.anthropic.claude-sonnet-4-5-20250929-v1:0</code> |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup one-off, if set. The model to use when making requests to the AWS Bedrock API.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if set. The model to use when making requests to the AWS Bedrock API.
 
 ### --ai-gateway-bedrock-small-fastmodel
 
@@ -1832,7 +1832,7 @@ Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only 
 | YAML        | <code>ai_gateway.bedrock_small_fast_model</code>             |
 | Default     | <code>global.anthropic.claude-haiku-4-5-20251001-v1:0</code> |
 
-Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup one-off, if set. The small fast model to use when making requests to the AWS Bedrock API. Claude Code uses Haiku-class models to perform background tasks. See https://docs.claude.com/en/docs/claude-code/settings#environment-variables.
+Deprecated: manage AI Providers from the Coder UI or HTTP API. This option only seeds provider configuration at startup once-off, if set. The small fast model to use when making requests to the AWS Bedrock API. Claude Code uses Haiku-class models to perform background tasks. See https://docs.claude.com/en/docs/claude-code/settings#environment-variables.
 
 ### --ai-gateway-retention
 

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -126,47 +126,47 @@ AI GATEWAY OPTIONS:
 
       --ai-gateway-anthropic-base-url string, $CODER_AI_GATEWAY_ANTHROPIC_BASE_URL (default: https://api.anthropic.com/)
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup one-off, if set.
+          option only seeds provider configuration at startup once-off, if set.
           The base URL of the Anthropic API.
 
       --ai-gateway-anthropic-key string, $CODER_AI_GATEWAY_ANTHROPIC_KEY
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup one-off, if set.
+          option only seeds provider configuration at startup once-off, if set.
           The key to authenticate against the Anthropic API.
 
       --ai-gateway-bedrock-access-key string, $CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup one-off, if set.
+          option only seeds provider configuration at startup once-off, if set.
           The access key to authenticate against the AWS Bedrock API.
 
       --ai-gateway-bedrock-access-key-secret string, $CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY_SECRET
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup one-off, if set.
+          option only seeds provider configuration at startup once-off, if set.
           The access key secret to use with the access key to authenticate
           against the AWS Bedrock API.
 
       --ai-gateway-bedrock-base-url string, $CODER_AI_GATEWAY_BEDROCK_BASE_URL
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup one-off, if set.
+          option only seeds provider configuration at startup once-off, if set.
           The base URL to use for the AWS Bedrock API. Use this setting to
           specify an exact URL to use. Takes precedence over
           CODER_AI_GATEWAY_BEDROCK_REGION.
 
       --ai-gateway-bedrock-model string, $CODER_AI_GATEWAY_BEDROCK_MODEL (default: global.anthropic.claude-sonnet-4-5-20250929-v1:0)
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup one-off, if set.
+          option only seeds provider configuration at startup once-off, if set.
           The model to use when making requests to the AWS Bedrock API.
 
       --ai-gateway-bedrock-region string, $CODER_AI_GATEWAY_BEDROCK_REGION
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup one-off, if set.
+          option only seeds provider configuration at startup once-off, if set.
           The AWS Bedrock API region to use. Constructs a base URL to use for
           the AWS Bedrock API in the form of
           'https://bedrock-runtime.<region>.amazonaws.com'.
 
       --ai-gateway-bedrock-small-fastmodel string, $CODER_AI_GATEWAY_BEDROCK_SMALL_FAST_MODEL (default: global.anthropic.claude-haiku-4-5-20251001-v1:0)
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup one-off, if set.
+          option only seeds provider configuration at startup once-off, if set.
           The small fast model to use when making requests to the AWS Bedrock
           API. Claude Code uses Haiku-class models to perform background tasks.
           See
@@ -189,12 +189,12 @@ AI GATEWAY OPTIONS:
 
       --ai-gateway-openai-base-url string, $CODER_AI_GATEWAY_OPENAI_BASE_URL (default: https://api.openai.com/v1/)
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup one-off, if set.
+          option only seeds provider configuration at startup once-off, if set.
           The base URL of the OpenAI API.
 
       --ai-gateway-openai-key string, $CODER_AI_GATEWAY_OPENAI_KEY
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup one-off, if set.
+          option only seeds provider configuration at startup once-off, if set.
           The key to authenticate against the OpenAI API.
 
       --ai-gateway-rate-limit int, $CODER_AI_GATEWAY_RATE_LIMIT (default: 0)

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -125,51 +125,55 @@ AI GATEWAY OPTIONS:
           disabled, only centralized key authentication is permitted.
 
       --ai-gateway-anthropic-base-url string, $CODER_AI_GATEWAY_ANTHROPIC_BASE_URL (default: https://api.anthropic.com/)
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if set.
-          The base URL of the Anthropic API.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The base URL of the Anthropic
+          API.
 
       --ai-gateway-anthropic-key string, $CODER_AI_GATEWAY_ANTHROPIC_KEY
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if set.
-          The key to authenticate against the Anthropic API.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The key to authenticate
+          against the Anthropic API.
 
       --ai-gateway-bedrock-access-key string, $CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if set.
-          The access key to authenticate against the AWS Bedrock API.
-
-      --ai-gateway-bedrock-access-key-secret string, $CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY_SECRET
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if set.
-          The access key secret to use with the access key to authenticate
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The access key to authenticate
           against the AWS Bedrock API.
 
+      --ai-gateway-bedrock-access-key-secret string, $CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY_SECRET
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The access key secret to use
+          with the access key to authenticate against the AWS Bedrock API.
+
       --ai-gateway-bedrock-base-url string, $CODER_AI_GATEWAY_BEDROCK_BASE_URL
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if set.
-          The base URL to use for the AWS Bedrock API. Use this setting to
-          specify an exact URL to use. Takes precedence over
-          CODER_AI_GATEWAY_BEDROCK_REGION.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The base URL to use for the
+          AWS Bedrock API. Use this setting to specify an exact URL to use.
+          Takes precedence over CODER_AI_GATEWAY_BEDROCK_REGION.
 
       --ai-gateway-bedrock-model string, $CODER_AI_GATEWAY_BEDROCK_MODEL (default: global.anthropic.claude-sonnet-4-5-20250929-v1:0)
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if set.
-          The model to use when making requests to the AWS Bedrock API.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The model to use when making
+          requests to the AWS Bedrock API.
 
       --ai-gateway-bedrock-region string, $CODER_AI_GATEWAY_BEDROCK_REGION
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if set.
-          The AWS Bedrock API region to use. Constructs a base URL to use for
-          the AWS Bedrock API in the form of
-          'https://bedrock-runtime.<region>.amazonaws.com'.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The AWS Bedrock API region to
+          use. Constructs a base URL to use for the AWS Bedrock API in the form
+          of 'https://bedrock-runtime.<region>.amazonaws.com'.
 
       --ai-gateway-bedrock-small-fastmodel string, $CODER_AI_GATEWAY_BEDROCK_SMALL_FAST_MODEL (default: global.anthropic.claude-haiku-4-5-20251001-v1:0)
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if set.
-          The small fast model to use when making requests to the AWS Bedrock
-          API. Claude Code uses Haiku-class models to perform background tasks.
-          See
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The small fast model to use
+          when making requests to the AWS Bedrock API. Claude Code uses
+          Haiku-class models to perform background tasks. See
           https://docs.claude.com/en/docs/claude-code/settings#environment-variables.
 
       --ai-gateway-circuit-breaker-enabled bool, $CODER_AI_GATEWAY_CIRCUIT_BREAKER_ENABLED (default: false)
@@ -188,14 +192,16 @@ AI GATEWAY OPTIONS:
           to disable (unlimited).
 
       --ai-gateway-openai-base-url string, $CODER_AI_GATEWAY_OPENAI_BASE_URL (default: https://api.openai.com/v1/)
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if set.
-          The base URL of the OpenAI API.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The base URL of the OpenAI
+          API.
 
       --ai-gateway-openai-key string, $CODER_AI_GATEWAY_OPENAI_KEY
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if set.
-          The key to authenticate against the OpenAI API.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The key to authenticate
+          against the OpenAI API.
 
       --ai-gateway-rate-limit int, $CODER_AI_GATEWAY_RATE_LIMIT (default: 0)
           Maximum number of AI Gateway requests per second per replica. Set to 0

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -126,43 +126,51 @@ AI GATEWAY OPTIONS:
 
       --ai-gateway-anthropic-base-url string, $CODER_AI_GATEWAY_ANTHROPIC_BASE_URL (default: https://api.anthropic.com/)
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if
-          configured.
+          option only seeds provider configuration at startup one-off, if set.
+          The base URL of the Anthropic API.
 
       --ai-gateway-anthropic-key string, $CODER_AI_GATEWAY_ANTHROPIC_KEY
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if
-          configured.
+          option only seeds provider configuration at startup one-off, if set.
+          The key to authenticate against the Anthropic API.
 
       --ai-gateway-bedrock-access-key string, $CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if
-          configured.
+          option only seeds provider configuration at startup one-off, if set.
+          The access key to authenticate against the AWS Bedrock API.
 
       --ai-gateway-bedrock-access-key-secret string, $CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY_SECRET
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if
-          configured.
+          option only seeds provider configuration at startup one-off, if set.
+          The access key secret to use with the access key to authenticate
+          against the AWS Bedrock API.
 
       --ai-gateway-bedrock-base-url string, $CODER_AI_GATEWAY_BEDROCK_BASE_URL
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if
-          configured.
+          option only seeds provider configuration at startup one-off, if set.
+          The base URL to use for the AWS Bedrock API. Use this setting to
+          specify an exact URL to use. Takes precedence over
+          CODER_AI_GATEWAY_BEDROCK_REGION.
 
       --ai-gateway-bedrock-model string, $CODER_AI_GATEWAY_BEDROCK_MODEL (default: global.anthropic.claude-sonnet-4-5-20250929-v1:0)
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if
-          configured.
+          option only seeds provider configuration at startup one-off, if set.
+          The model to use when making requests to the AWS Bedrock API.
 
       --ai-gateway-bedrock-region string, $CODER_AI_GATEWAY_BEDROCK_REGION
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if
-          configured.
+          option only seeds provider configuration at startup one-off, if set.
+          The AWS Bedrock API region to use. Constructs a base URL to use for
+          the AWS Bedrock API in the form of
+          'https://bedrock-runtime.<region>.amazonaws.com'.
 
       --ai-gateway-bedrock-small-fastmodel string, $CODER_AI_GATEWAY_BEDROCK_SMALL_FAST_MODEL (default: global.anthropic.claude-haiku-4-5-20251001-v1:0)
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if
-          configured.
+          option only seeds provider configuration at startup one-off, if set.
+          The small fast model to use when making requests to the AWS Bedrock
+          API. Claude Code uses Haiku-class models to perform background tasks.
+          See
+          https://docs.claude.com/en/docs/claude-code/settings#environment-variables.
 
       --ai-gateway-circuit-breaker-enabled bool, $CODER_AI_GATEWAY_CIRCUIT_BREAKER_ENABLED (default: false)
           Enable the circuit breaker to protect against cascading failures from
@@ -181,13 +189,13 @@ AI GATEWAY OPTIONS:
 
       --ai-gateway-openai-base-url string, $CODER_AI_GATEWAY_OPENAI_BASE_URL (default: https://api.openai.com/v1/)
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if
-          configured.
+          option only seeds provider configuration at startup one-off, if set.
+          The base URL of the OpenAI API.
 
       --ai-gateway-openai-key string, $CODER_AI_GATEWAY_OPENAI_KEY
           Deprecated: manage AI Providers from the Coder UI or HTTP API. This
-          option only seeds provider configuration at startup once-off, if
-          configured.
+          option only seeds provider configuration at startup one-off, if set.
+          The key to authenticate against the OpenAI API.
 
       --ai-gateway-rate-limit int, $CODER_AI_GATEWAY_RATE_LIMIT (default: 0)
           Maximum number of AI Gateway requests per second per replica. Set to 0

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -125,36 +125,44 @@ AI GATEWAY OPTIONS:
           disabled, only centralized key authentication is permitted.
 
       --ai-gateway-anthropic-base-url string, $CODER_AI_GATEWAY_ANTHROPIC_BASE_URL (default: https://api.anthropic.com/)
-          The base URL of the Anthropic API.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
+          option only seeds provider configuration at startup once-off, if
+          configured.
 
       --ai-gateway-anthropic-key string, $CODER_AI_GATEWAY_ANTHROPIC_KEY
-          The key to authenticate against the Anthropic API.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
+          option only seeds provider configuration at startup once-off, if
+          configured.
 
       --ai-gateway-bedrock-access-key string, $CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY
-          The access key to authenticate against the AWS Bedrock API.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
+          option only seeds provider configuration at startup once-off, if
+          configured.
 
       --ai-gateway-bedrock-access-key-secret string, $CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY_SECRET
-          The access key secret to use with the access key to authenticate
-          against the AWS Bedrock API.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
+          option only seeds provider configuration at startup once-off, if
+          configured.
 
       --ai-gateway-bedrock-base-url string, $CODER_AI_GATEWAY_BEDROCK_BASE_URL
-          The base URL to use for the AWS Bedrock API. Use this setting to
-          specify an exact URL to use. Takes precedence over
-          CODER_AI_GATEWAY_BEDROCK_REGION.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
+          option only seeds provider configuration at startup once-off, if
+          configured.
 
       --ai-gateway-bedrock-model string, $CODER_AI_GATEWAY_BEDROCK_MODEL (default: global.anthropic.claude-sonnet-4-5-20250929-v1:0)
-          The model to use when making requests to the AWS Bedrock API.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
+          option only seeds provider configuration at startup once-off, if
+          configured.
 
       --ai-gateway-bedrock-region string, $CODER_AI_GATEWAY_BEDROCK_REGION
-          The AWS Bedrock API region to use. Constructs a base URL to use for
-          the AWS Bedrock API in the form of
-          'https://bedrock-runtime.<region>.amazonaws.com'.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
+          option only seeds provider configuration at startup once-off, if
+          configured.
 
       --ai-gateway-bedrock-small-fastmodel string, $CODER_AI_GATEWAY_BEDROCK_SMALL_FAST_MODEL (default: global.anthropic.claude-haiku-4-5-20251001-v1:0)
-          The small fast model to use when making requests to the AWS Bedrock
-          API. Claude Code uses Haiku-class models to perform background tasks.
-          See
-          https://docs.claude.com/en/docs/claude-code/settings#environment-variables.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
+          option only seeds provider configuration at startup once-off, if
+          configured.
 
       --ai-gateway-circuit-breaker-enabled bool, $CODER_AI_GATEWAY_CIRCUIT_BREAKER_ENABLED (default: false)
           Enable the circuit breaker to protect against cascading failures from
@@ -172,10 +180,14 @@ AI GATEWAY OPTIONS:
           to disable (unlimited).
 
       --ai-gateway-openai-base-url string, $CODER_AI_GATEWAY_OPENAI_BASE_URL (default: https://api.openai.com/v1/)
-          The base URL of the OpenAI API.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
+          option only seeds provider configuration at startup once-off, if
+          configured.
 
       --ai-gateway-openai-key string, $CODER_AI_GATEWAY_OPENAI_KEY
-          The key to authenticate against the OpenAI API.
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. This
+          option only seeds provider configuration at startup once-off, if
+          configured.
 
       --ai-gateway-rate-limit int, $CODER_AI_GATEWAY_RATE_LIMIT (default: 0)
           Maximum number of AI Gateway requests per second per replica. Set to 0


### PR DESCRIPTION
Environment variables used to configure AI Gateway providers are now deprecated, and we need to reflect this as such.