### PR TITLE
test(cli): eliminate race in PausedDuringWaitForReady test

### DIFF
--- a/cli/task_send_test.go
+++ b/cli/task_send_test.go
@@ -237,7 +237,10 @@ func Test_TaskSend(t *testing.T) {
 		t.Parallel()
 
 		// Given: An initializing task (workspace running, no agent
-		// connected).
+		// connected). Close the agent, pause, then resume so the
+		// workspace is started but no agent is connected. The
+		// command enters waitForTaskIdle directly (initializing
+		// path), where we verify it handles an external pause.
 		setupCtx := testutil.Context(t, testutil.WaitLong)
 		setup := setupCLITaskTest(setupCtx, t, nil)
 
@@ -246,8 +249,6 @@ func Test_TaskSend(t *testing.T) {
 		resumeTask(setupCtx, t, setup.userClient, setup.task)
 
 		// Set up mock clock and traps before starting the command.
-		// Without a mock clock the poll can race with the stop build
-		// and see a transient 'unknown' status instead of 'paused'.
 		mClock := quartz.NewMock(t)
 		tickTrap := mClock.Trap().NewTicker("task_send", "poll")
 		resetTrap := mClock.Trap().TickerReset("task_send", "poll")
@@ -271,23 +272,28 @@ func Test_TaskSend(t *testing.T) {
 		tickCall.MustRelease(ctx)
 		tickTrap.Close()
 
-		// Fire the immediate first poll (time.Nanosecond initial interval).
-		// This poll sees 'initializing' because no agent is connected.
+		// Fire the first poll. The goroutine calls ticker.Reset
+		// which the trap catches, freezing the goroutine BEFORE
+		// client.TaskByID runs. Release it so the first poll
+		// sees 'initializing' and continues.
 		mClock.Advance(time.Nanosecond).MustWait(ctx)
-
-		// Wait for Reset (confirms first poll completed).
 		resetCall := resetTrap.MustWait(ctx)
 		resetCall.MustRelease(ctx)
-		resetTrap.Close()
 
-		// Pause the task while waitForTaskIdle is polling. Since
-		// no agent is connected, the task stays initializing until
-		// we pause it, at which point the status becomes paused.
+		// Fire the second poll. The goroutine is again frozen at
+		// ticker.Reset by the trap.
+		mClock.Advance(5 * time.Second).MustWait(ctx)
+		resetCall = resetTrap.MustWait(ctx)
+
+		// While the goroutine is frozen (before client.TaskByID),
+		// pause the task. The stop build completes, so the DB has
+		// (stop, succeeded) = 'paused'.
 		pauseTask(ctx, t, setup.userClient, setup.task)
 
-		// Fire second poll at the regular 5s interval. The stop
-		// build has completed, so the poll sees 'paused'.
-		mClock.Advance(5 * time.Second).MustWait(ctx)
+		// Release the trap. The goroutine unfreezes and
+		// client.TaskByID deterministically sees 'paused'.
+		resetCall.MustRelease(ctx)
+		resetTrap.Close()
 
 		// Then: The command should fail because the task was paused.
 		err := w.Wait()
@@ -328,23 +334,31 @@ func Test_TaskSend(t *testing.T) {
 		tickCall.MustRelease(ctx)
 		tickTrap.Close()
 
-		// Fire the immediate first poll (time.Nanosecond initial interval).
+		// Fire the first poll. The goroutine calls ticker.Reset
+		// which the trap catches, freezing the goroutine BEFORE
+		// client.TaskByID runs. Release it so the first poll
+		// sees "working" and continues.
 		mClock.Advance(time.Nanosecond).MustWait(ctx)
-
-		// Wait for Reset (confirms first poll completed and saw "working").
 		resetCall := resetTrap.MustWait(ctx)
 		resetCall.MustRelease(ctx)
-		resetTrap.Close()
 
-		// Transition the app back to idle so waitForTaskIdle proceeds.
+		// Fire the second poll. The goroutine is again frozen
+		// at ticker.Reset by the trap.
+		mClock.Advance(5 * time.Second).MustWait(ctx)
+		resetCall = resetTrap.MustWait(ctx)
+
+		// While the goroutine is frozen (before client.TaskByID),
+		// transition the app to idle.
 		require.NoError(t, agentClient.PatchAppStatus(ctx, agentsdk.PatchAppStatus{
 			AppSlug: "task-sidebar",
 			State:   codersdk.WorkspaceAppStatusStateIdle,
 			Message: "ready",
 		}))
 
-		// Fire second poll at the regular 5s interval.
-		mClock.Advance(5 * time.Second).MustWait(ctx)
+		// Release the trap. The goroutine unfreezes and
+		// client.TaskByID deterministically sees "idle".
+		resetCall.MustRelease(ctx)
+		resetTrap.Close()
 
 		// Then: The command should complete successfully.
 		require.NoError(t, w.Wait())


### PR DESCRIPTION
`PausedDuringWaitForReady` and `WaitsForWorkingAppState` in `cli/task_send_test.go` flake because the quartz `TickerReset` trap synchronizes at `ticker.Reset` (line 174), but `client.TaskByID` runs one line later (line 175):

```go
// cli/task_send.go:173-175
case <-ticker.C:
    ticker.Reset(pollInterval, "task_send", "poll")  // <- trap fires here
    task, err := client.TaskByID(ctx, task.ID)        // <- runs AFTER release
```

The old test released the trap and closed it, then mutated state. This let `client.TaskByID` race with the mutation:

```go
// old test (origin/main, lines 279-286)
resetCall := resetTrap.MustWait(ctx)
resetCall.MustRelease(ctx)  // goroutine unfreezes, proceeds to TaskByID
resetTrap.Close()           // second poll not trapped
pauseTask(ctx, t, ...)     // RACES with TaskByID above
```

### Proof: the race fires on CI

Server logs from [CI run 26634123539](https://github.com/coder/coder/actions/runs/26634123539) (captured via `gh run view 26634123539 --log-failed`). The first poll's GET and the test's POST start from the same point (the trap release at m=+57.350) and execute concurrently:

```
# First poll's TaskByID and test's pauseTask, monotonic timestamps:
m=+57.350470 GET  /tasks/me/<uuid>  took=116ms   [runs +57.350 to +57.466]
m=+57.350526 POST /tasks/.../pause  took=29ms    [runs +57.350 to +57.380]
                                                  ^^^^^^^^^^^^^^^^^^^^^^^^
                                       OVERLAP: 30ms concurrent execution

# POST commits the stop build at +57.380.
# GET's DB query executes sometime in [+57.350, +57.466], sees (stop, pending).
# View returns "unknown". Result:
task entered unknown state while waiting for it to become idle
```

For comparison, local run (same test, PostgreSQL, `gh` not involved):

```
# /tmp/cli_test_old -test.run PausedDuringWaitForReady -test.v
m=+1.426088 GET  /tasks/me/<uuid>  took=32ms    [runs +1.426 to +1.458]
m=+1.459172 POST /tasks/.../pause  took=53ms    [runs +1.459 to +1.513]
                                                 no overlap (1ms gap)
```

Locally the GET completes before POST starts (fast DB), so the race doesn't fire. On macOS CI the GET takes 116ms (slow DB under load), creating the 30ms overlap window.

### Fix

Keep the `resetTrap` open across both polls. Release on the first poll (goroutine sees initial state, continues). On the second poll the trap freezes the goroutine at `ticker.Reset`; mutate state while frozen, then release. `client.TaskByID` cannot run while the goroutine is trapped, so the mutation always completes before the query.

Closes CODAGT-482

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻