### PR TITLE
ci: install Chrome for puppeteer before linkspector to fix check-docs

### DIFF
--- a/.github/workflows/weekly-docs.yaml
+++ b/.github/workflows/weekly-docs.yaml
@@ -9,6 +9,7 @@ on:
       - main
     paths:
       - "docs/**"
+      - ".github/workflows/weekly-docs.yaml"
 
 permissions:
   contents: read

--- a/.github/workflows/weekly-docs.yaml
+++ b/.github/workflows/weekly-docs.yaml
@@ -54,6 +54,16 @@ jobs:
           corepack enable pnpm
           mkdir -p "$(pnpm store path --silent)"
 
+      # TODO: Remove this workaround once action-linkspector handles
+      # puppeteer's Chrome install on its own. As of Chrome 148
+      # (released ~2026-05-27), puppeteer no longer auto-downloads
+      # Chrome via npm postinstall, so the bundled linkspector cannot
+      # find a Chrome binary and exits with "Could not find Chrome".
+      # See: https://github.com/UmbrellaDocs/action-linkspector/issues/62
+      - name: Install Chrome for puppeteer
+        shell: bash
+        run: npx --yes puppeteer browsers install chrome
+
       - name: Check Markdown links
         uses: umbrelladocs/action-linkspector@37c85bcde51b30bf929936502bac6bfb7e8f0a4d # v1.4.1
         id: markdown-link-check

--- a/.github/workflows/weekly-docs.yaml
+++ b/.github/workflows/weekly-docs.yaml
@@ -60,10 +60,14 @@ jobs:
       # (released ~2026-05-27), puppeteer no longer auto-downloads
       # Chrome via npm postinstall, so the bundled linkspector cannot
       # find a Chrome binary and exits with "Could not find Chrome".
+      # Pin to puppeteer ^24 because linkspector 0.4.7 (what
+      # action-linkspector v1.4.1 installs) depends on
+      # puppeteer ^24.14.0; the latest standalone puppeteer is on a
+      # newer Chrome pin and would cache the wrong version.
       # See: https://github.com/UmbrellaDocs/action-linkspector/issues/62
       - name: Install Chrome for puppeteer
         shell: bash
-        run: npx --yes puppeteer browsers install chrome
+        run: npx --yes puppeteer@^24 browsers install chrome
 
       - name: Check Markdown links
         uses: umbrelladocs/action-linkspector@37c85bcde51b30bf929936502bac6bfb7e8f0a4d # v1.4.1


### PR DESCRIPTION
Fixes the `check-docs` job that has been failing on every PR touching `docs/**` since 2026-05-28 ~12:30 UTC.

## Symptom

```
🔗💀 Installing linkspector ... https://github.com/UmbrellaDocs/linkspector
🔗💀 Setting up Chrome Linux Sandbox
 Running linkspector with reviewdog 🐶 ...
  💥 Main error: Could not find Chrome (ver. 148.0.7778.97).
  reviewdog: parse error: failed to unmarshal rdjson (DiagnosticResult): proto: syntax error (line 1:1): unexpected token
  Error: Process completed with exit code 1.
```

## Root cause

Chrome 148 was released around 2026-05-27. Recent versions of puppeteer no longer auto-download Chrome via the npm postinstall hook; consumers must run `npx puppeteer browsers install chrome` explicitly. `umbrelladocs/action-linkspector@v1.4.1` does not do this in its setup, so the bundled linkspector starts and immediately fails when it cannot find a matching Chrome binary in `/home/runner/.cache/puppeteer`.

Tracked upstream as [UmbrellaDocs/action-linkspector#62](https://github.com/UmbrellaDocs/action-linkspector/issues/62). Affects every PR touching `docs/**` in this repo since 2026-05-28; scheduled `main` runs still pass because they hit a different cache state.

## Fix

Add an explicit `npx --yes puppeteer browsers install chrome` step before the linkspector action so the puppeteer cache at the default location (`~/.cache/puppeteer`) is populated with a usable Chrome binary by the time the action runs.

Remove this workaround once the upstream action handles puppeteer browser installation on its own.

## Verification

Watch the `check-docs` job on this PR. It should reach the link-check stage and either pass or fail on actual link content rather than on Chrome missing.

---

Generated with Coder Agents.