### PR TITLE
fix(site): don't block workspace updates on unchanged immutable parameters

### DIFF
--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.stories.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.stories.tsx
@@ -26,6 +26,7 @@ import {
 	MockWorkspaceBuildParameter1,
 	MockWorkspaceBuildParameter2,
 	MockWorkspaceBuildParameter3,
+	MockWorkspaceBuildParameter4,
 } from "#/testHelpers/entities";
 import {
 	withAuthProvider,
@@ -151,6 +152,129 @@ export const StartWorkspace: Story = {
 		await waitFor(() =>
 			expect(screen.getByText("would have started")).toBeInTheDocument(),
 		);
+	},
+};
+
+// Regression test for coder/coder#25822. When a new template version adds
+// stricter validation, conditional logic, or option changes that the
+// already-stored immutable value no longer satisfies, the parameters page
+// must not block the user from editing unrelated mutable parameters. The
+// existing immutable value is carried over by the backend resolver, so
+// surfacing diagnostics for an unchanged immutable parameter would block
+// legitimate updates.
+export const UnchangedImmutableParameterDoesNotBlock: Story = {
+	parameters: {
+		webSocket: [
+			{
+				event: "message",
+				data: JSON.stringify({
+					id: 0,
+					diagnostics: [],
+					parameters: [
+						{
+							...MockPreviewParameter,
+							name: MockWorkspaceBuildParameter1.name,
+							value: { valid: true, value: MockWorkspaceBuildParameter1.value },
+						},
+						{
+							...MockPreviewParameter,
+							name: MockWorkspaceBuildParameter4.name,
+							display_name: "Pre-existing immutable parameter",
+							mutable: false,
+							value: { valid: true, value: MockWorkspaceBuildParameter4.value },
+							diagnostics: [
+								{
+									severity: "error",
+									summary: "Value no longer matches updated options",
+									detail:
+										"The template version updated the allowed options for this parameter.",
+									extra: { code: "" },
+								},
+							],
+						},
+					],
+				}),
+			},
+		],
+		queries: [
+			...workspaceQueries(MockWorkspace).filter(
+				(q) =>
+					q.key[0] !==
+					workspaceBuildParametersKey(MockWorkspace.latest_build.id)[0],
+			),
+			{
+				key: workspaceBuildParametersKey(MockWorkspace.latest_build.id),
+				data: [MockWorkspaceBuildParameter1, MockWorkspaceBuildParameter4],
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// The blocking alert from #25822 must not appear when the only
+		// parameter with diagnostics is an unchanged immutable parameter.
+		await waitFor(() =>
+			expect(
+				canvas.queryByText("Workspace update blocked"),
+			).not.toBeInTheDocument(),
+		);
+		// The submit button stays enabled so the user can update mutable
+		// parameters; the backend resolver keeps the existing immutable
+		// value when nothing about it changed.
+		const submit = await canvas.findByRole("button", {
+			name: "Update and restart",
+		});
+		expect(submit).toBeEnabled();
+	},
+};
+
+// Companion to UnchangedImmutableParameterDoesNotBlock. When the immutable
+// parameter's rendered value differs from the autofill (e.g. the user did
+// try to change it, or the template substituted a different value), the
+// blocking alert is still required so the build doesn't fail with an
+// immutable-parameter error from the resolver.
+export const ChangedImmutableParameterStillBlocks: Story = {
+	parameters: {
+		webSocket: [
+			{
+				event: "message",
+				data: JSON.stringify({
+					id: 0,
+					diagnostics: [],
+					parameters: [
+						{
+							...MockPreviewParameter,
+							name: MockWorkspaceBuildParameter4.name,
+							display_name: "Pre-existing immutable parameter",
+							mutable: false,
+							value: { valid: true, value: "changed-value" },
+							diagnostics: [
+								{
+									severity: "error",
+									summary: "Immutable parameter changed",
+									detail: "Immutable parameters cannot change after creation.",
+									extra: { code: "" },
+								},
+							],
+						},
+					],
+				}),
+			},
+		],
+		queries: [
+			...workspaceQueries(MockWorkspace).filter(
+				(q) =>
+					q.key[0] !==
+					workspaceBuildParametersKey(MockWorkspace.latest_build.id)[0],
+			),
+			{
+				key: workspaceBuildParametersKey(MockWorkspace.latest_build.id),
+				data: [MockWorkspaceBuildParameter4],
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await canvas.findByText("Workspace update blocked");
 	},
 };
 

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageViewExperimental.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageViewExperimental.tsx
@@ -133,11 +133,29 @@ export const WorkspaceParametersPageViewExperimental: FC<
 		},
 	);
 
-	const hasIncompatibleParameters = parameters.some((parameter) => {
-		if (!parameter.mutable && parameter.diagnostics.length > 0) {
-			return true;
+	// An immutable parameter whose current rendered value already matches the
+	// previous workspace build value is not blocking. The form only submits
+	// mutable values, and the backend resolver reuses the previous value when
+	// an immutable parameter is unchanged, so diagnostics raised by stricter
+	// validations or new conditional logic on the new template version should
+	// not prevent the user from editing unrelated mutable parameters.
+	const isUnchangedImmutable = (parameter: PreviewParameter) => {
+		if (parameter.mutable) {
+			return false;
 		}
-		return false;
+		const autofill = autofillParameters.find((p) => p.name === parameter.name);
+		if (!autofill) {
+			return false;
+		}
+		const currentValue = parameter.value.valid ? parameter.value.value : "";
+		return autofill.value === currentValue;
+	};
+
+	const hasIncompatibleParameters = parameters.some((parameter) => {
+		if (parameter.mutable || parameter.diagnostics.length === 0) {
+			return false;
+		}
+		return !isUnchangedImmutable(parameter);
 	});
 
 	return (
@@ -287,10 +305,12 @@ export const WorkspaceParametersPageViewExperimental: FC<
 							diagnostics.some(
 								(diagnostic) => diagnostic.severity === "error",
 							) ||
-							parameters.some((parameter) =>
-								parameter.diagnostics.some(
-									(diagnostic) => diagnostic.severity === "error",
-								),
+							parameters.some(
+								(parameter) =>
+									!isUnchangedImmutable(parameter) &&
+									parameter.diagnostics.some(
+										(diagnostic) => diagnostic.severity === "error",
+									),
 							)
 						}
 					>


### PR DESCRIPTION
Fixes #25822.

## Problem

When a workspace was created on an older template version and the current version adds stricter validations, option changes, or new conditional logic that the already-stored immutable value no longer satisfies, the **Settings → Parameters** page surfaced diagnostics on the immutable parameter and showed a "Workspace update blocked" alert (plus disabled the submit button), preventing the user from editing **unrelated mutable parameters**.

Reproduces in 2.32.3; reporter notes 2.31.x was fine.

## Fix

`handleSubmit` only sends mutable parameter values, and `ResolveParameters` in `coderd/dynamicparameters/resolver.go` reuses the previous build value when an immutable parameter is unchanged. So a diagnostic on an immutable parameter whose **rendered value still matches the autofill from the latest build** is not actually going to break the build, and shouldn't gate the form.

This PR scopes both the blocking alert and the submit-button error check to skip immutable parameters in that state. New immutable parameters added by the template version (no autofill entry) and immutable parameters whose value differs from the previous build still block, matching backend behavior.

## Coverage

- `UnchangedImmutableParameterDoesNotBlock` story: immutable param with an error diagnostic but a value matching the previous build, asserts the alert is absent and the submit button is enabled.
- `ChangedImmutableParameterStillBlocks` story: immutable param whose rendered value differs from the previous build, asserts the alert remains.
- All existing `WorkspaceParametersPageExperimental` stories continue to pass.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm exec biome lint --error-on-warnings` on touched files
- `pnpm test src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental` (existing unit test still passes)
- `pnpm exec vitest run --project=storybook src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.stories.tsx` (8/8 pass)

<details>
<summary>Decision log</summary>

**Why frontend-only?** The backend resolver already does the right thing for unchanged immutable values; the bug is entirely the frontend treating any immutable-parameter diagnostic as fatal regardless of whether the user is actually changing the value. A backend change would need to suppress diagnostics in the WS render path conditionally on "previous build values", which is currently not plumbed into the WS handler in `coderd/parameters.go`. Frontend already has `autofillParameters` from `getWorkspaceBuildParameters(latest_build.id)`, so the equality check is local and cheap.

**Why compare against autofill value rather than ignore all immutable diagnostics?** Genuinely new immutable parameters introduced by a newer template version must still block from this page (the user can't set them here). The autofill check naturally distinguishes "this parameter existed on the previous build" from "this parameter is new".

**Edge case: `parameter.value.valid === false`.** The rest of this file already treats `valid: false` as an empty current value (`useSyncFormParameters` consumer above does the same). The compare uses the same convention so the behavior is consistent. In practice for the reported scenario the value is `valid: true` because the user previously supplied a real value that HCL still evaluates to a known string; validation failure is reported via diagnostics, not by clearing the value.

</details>

---

> 🤖 Generated with [Coder Agents](https://coder.com/agents) on behalf of @kylecarbs