### PR TITLE
feat(site/src/pages/AgentsPage/components/ChatVirtualList): Safari-safe virtualized chat scroll container

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatVirtualList/ChatVirtualList.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatVirtualList/ChatVirtualList.stories.tsx
@@ -1,0 +1,205 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { type FC, useRef, useState } from "react";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+import { ChatVirtualList } from "./ChatVirtualList";
+
+type Item = { id: number; height: number };
+
+const StoryHarness: FC<{ hasMoreMessages?: boolean }> = ({
+	hasMoreMessages = false,
+}) => {
+	const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+	const scrollToBottomRef = useRef<(() => void) | null>(null);
+	const nextId = useRef(40);
+	const olderId = useRef(-1);
+	const [items, setItems] = useState<Item[]>(() =>
+		Array.from({ length: 40 }, (_, i) => ({ id: i, height: 120 })),
+	);
+	const [fetchCount, setFetchCount] = useState(0);
+
+	const append = () =>
+		setItems((prev) => [...prev, { id: nextId.current++, height: 200 }]);
+	const prepend = () =>
+		setItems((prev) => [
+			...Array.from({ length: 5 }, () => ({
+				id: olderId.current--,
+				height: 120,
+			})),
+			...prev,
+		]);
+	const growFive = () =>
+		setItems((prev) =>
+			prev.map((it) => (it.id === 5 ? { ...it, height: 320 } : it)),
+		);
+
+	return (
+		<div className="flex h-[480px] w-[640px] flex-col">
+			<div className="flex gap-1">
+				<button type="button" data-testid="append" onClick={append}>
+					append
+				</button>
+				<button type="button" data-testid="prepend" onClick={prepend}>
+					prepend
+				</button>
+				<button type="button" data-testid="grow-5" onClick={growFive}>
+					grow-5
+				</button>
+				<span data-testid="fetch-count">{fetchCount}</span>
+			</div>
+			<ChatVirtualList
+				scrollContainerRef={scrollContainerRef}
+				scrollToBottomRef={scrollToBottomRef}
+				isFetchingMoreMessages={false}
+				hasMoreMessages={hasMoreMessages}
+				onFetchMoreMessages={() => setFetchCount((count) => count + 1)}
+				messageCount={items.length}
+			>
+				{items.map((it) => (
+					<div
+						key={it.id}
+						data-testid={`msg-${it.id}`}
+						style={{ height: it.height }}
+					>
+						message {it.id}
+					</div>
+				))}
+			</ChatVirtualList>
+		</div>
+	);
+};
+
+const meta: Meta<typeof ChatVirtualList> = {
+	title: "pages/AgentsPage/ChatVirtualList",
+	component: ChatVirtualList,
+};
+export default meta;
+
+type Story = StoryObj<typeof ChatVirtualList>;
+
+const offsetFromScrollerTop = (
+	scroller: HTMLElement,
+	el: HTMLElement,
+): number =>
+	el.getBoundingClientRect().top - scroller.getBoundingClientRect().top;
+
+const distanceFromBottom = (scroller: HTMLElement): number =>
+	scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight;
+
+export const RendersAndOverflows: Story = {
+	render: () => <StoryHarness />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scroller = canvas.getByTestId("scroll-container");
+		await expect(scroller.scrollHeight).toBeGreaterThan(scroller.clientHeight);
+	},
+};
+
+export const AnchorStaysStableOnAboveViewportGrowth: Story = {
+	render: () => <StoryHarness />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scroller = canvas.getByTestId("scroll-container");
+		scroller.scrollTop = 1500;
+		scroller.dispatchEvent(new Event("scroll"));
+		await waitFor(() => expect(scroller.scrollTop).toBe(1500));
+		const before = offsetFromScrollerTop(
+			scroller,
+			canvas.getByTestId("msg-15"),
+		);
+		await userEvent.click(canvas.getByTestId("grow-5"));
+		await waitFor(() =>
+			expect(
+				Math.abs(
+					offsetFromScrollerTop(scroller, canvas.getByTestId("msg-15")) -
+						before,
+				),
+			).toBeLessThanOrEqual(2),
+		);
+	},
+};
+
+export const StaysPinnedWhileAtBottom: Story = {
+	render: () => <StoryHarness />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scroller = canvas.getByTestId("scroll-container");
+		await waitFor(() =>
+			expect(distanceFromBottom(scroller)).toBeLessThanOrEqual(16),
+		);
+		await userEvent.click(canvas.getByTestId("append"));
+		await waitFor(() =>
+			expect(distanceFromBottom(scroller)).toBeLessThanOrEqual(16),
+		);
+	},
+};
+
+export const DoesNotYankWhenScrolledUp: Story = {
+	render: () => <StoryHarness />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scroller = canvas.getByTestId("scroll-container");
+		scroller.scrollTop = 800;
+		scroller.dispatchEvent(new Event("scroll"));
+		await waitFor(() => expect(scroller.scrollTop).toBe(800));
+		await userEvent.click(canvas.getByTestId("append"));
+		await waitFor(() =>
+			expect(Math.abs(scroller.scrollTop - 800)).toBeLessThanOrEqual(2),
+		);
+	},
+};
+
+export const FetchesOlderNearTop: Story = {
+	render: () => <StoryHarness hasMoreMessages />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scroller = canvas.getByTestId("scroll-container");
+		scroller.scrollTop = 0;
+		scroller.dispatchEvent(new Event("scroll"));
+		await waitFor(() =>
+			expect(
+				Number(canvas.getByTestId("fetch-count").textContent),
+			).toBeGreaterThan(0),
+		);
+	},
+};
+
+export const PrependKeepsViewportStable: Story = {
+	render: () => <StoryHarness />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scroller = canvas.getByTestId("scroll-container");
+		scroller.scrollTop = 1500;
+		scroller.dispatchEvent(new Event("scroll"));
+		await waitFor(() => expect(scroller.scrollTop).toBe(1500));
+		const before = offsetFromScrollerTop(
+			scroller,
+			canvas.getByTestId("msg-20"),
+		);
+		await userEvent.click(canvas.getByTestId("prepend"));
+		await waitFor(() =>
+			expect(
+				Math.abs(
+					offsetFromScrollerTop(scroller, canvas.getByTestId("msg-20")) -
+						before,
+				),
+			).toBeLessThanOrEqual(2),
+		);
+	},
+};
+
+export const ScrollToBottomButtonWorks: Story = {
+	render: () => <StoryHarness />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scroller = canvas.getByTestId("scroll-container");
+		scroller.scrollTop = 100;
+		scroller.dispatchEvent(new Event("scroll"));
+		const button = await canvas.findByRole("button", {
+			name: "Scroll to bottom",
+		});
+		await userEvent.click(button);
+		await waitFor(() =>
+			expect(distanceFromBottom(scroller)).toBeLessThanOrEqual(16),
+		);
+	},
+};

--- a/site/src/pages/AgentsPage/components/ChatVirtualList/ChatVirtualList.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatVirtualList/ChatVirtualList.stories.tsx
@@ -1,36 +1,74 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { type FC, useRef, useState } from "react";
 import { expect, userEvent, waitFor, within } from "storybook/test";
-import { ChatVirtualList } from "./ChatVirtualList";
+import { ChatVirtualList, type VirtualItem } from "./ChatVirtualList";
+import type { MessageKind } from "./heightCache";
 
-type Item = { id: number; height: number };
+type DemoItem = { id: string; kind: MessageKind; height: number };
 
-const StoryHarness: FC<{ hasMoreMessages?: boolean }> = ({
-	hasMoreMessages = false,
-}) => {
+const makeItems = (count: number, height = 220): DemoItem[] =>
+	Array.from({ length: count }, (_, i) => ({
+		id: `m-${i}`,
+		kind: "assistant" as MessageKind,
+		height,
+	}));
+
+const StoryHarness: FC<{
+	initialCount?: number;
+	hasMoreMessages?: boolean;
+	itemHeight?: number;
+}> = ({ initialCount = 40, hasMoreMessages = false, itemHeight = 220 }) => {
 	const scrollContainerRef = useRef<HTMLDivElement | null>(null);
 	const scrollToBottomRef = useRef<(() => void) | null>(null);
-	const nextId = useRef(40);
-	const olderId = useRef(-1);
-	const [items, setItems] = useState<Item[]>(() =>
-		Array.from({ length: 40 }, (_, i) => ({ id: i, height: 120 })),
+	const [items, setItems] = useState<DemoItem[]>(() =>
+		makeItems(initialCount, itemHeight),
 	);
 	const [fetchCount, setFetchCount] = useState(0);
 
+	// Derive new ids purely from the previous list so the updater stays pure.
+	// React StrictMode double-invokes updaters; a mutable counter would advance
+	// twice and make the appended/prepended ids unpredictable.
 	const append = () =>
-		setItems((prev) => [...prev, { id: nextId.current++, height: 200 }]);
+		setItems((prev) => {
+			const nextIndex =
+				prev.reduce((max, it) => {
+					const n = it.id.startsWith("m-") ? Number(it.id.slice(2)) : -1;
+					return Number.isNaN(n) ? max : Math.max(max, n);
+				}, -1) + 1;
+			return [
+				...prev,
+				{ id: `m-${nextIndex}`, kind: "assistant", height: itemHeight },
+			];
+		});
 	const prepend = () =>
-		setItems((prev) => [
-			...Array.from({ length: 5 }, () => ({
-				id: olderId.current--,
+		setItems((prev) => {
+			const minOld = prev.reduce((min, it) => {
+				const n = it.id.startsWith("old-") ? Number(it.id.slice(4)) : 0;
+				return Number.isNaN(n) ? min : Math.min(min, n);
+			}, 0);
+			const older = Array.from({ length: 5 }, (_, i) => ({
+				id: `old-${minOld - 1 - i}`,
+				kind: "user" as MessageKind,
 				height: 120,
-			})),
-			...prev,
-		]);
+			}));
+			return [...older, ...prev];
+		});
 	const growFive = () =>
 		setItems((prev) =>
-			prev.map((it) => (it.id === 5 ? { ...it, height: 320 } : it)),
+			prev.map((it) =>
+				it.id === "m-5" ? { ...it, height: it.height + 160 } : it,
+			),
 		);
+
+	const byId = new Map(items.map((it) => [it.id, it]));
+	const renderItem = (item: VirtualItem) => {
+		const demo = byId.get(item.id);
+		return (
+			<div data-testid={item.id} style={{ height: demo?.height ?? 120 }}>
+				{item.id}
+			</div>
+		);
+	};
 
 	return (
 		<div className="flex h-[480px] w-[640px] flex-col">
@@ -47,23 +85,14 @@ const StoryHarness: FC<{ hasMoreMessages?: boolean }> = ({
 				<span data-testid="fetch-count">{fetchCount}</span>
 			</div>
 			<ChatVirtualList
+				items={items}
+				renderItem={renderItem}
 				scrollContainerRef={scrollContainerRef}
 				scrollToBottomRef={scrollToBottomRef}
 				isFetchingMoreMessages={false}
 				hasMoreMessages={hasMoreMessages}
 				onFetchMoreMessages={() => setFetchCount((count) => count + 1)}
-				messageCount={items.length}
-			>
-				{items.map((it) => (
-					<div
-						key={it.id}
-						data-testid={`msg-${it.id}`}
-						style={{ height: it.height }}
-					>
-						message {it.id}
-					</div>
-				))}
-			</ChatVirtualList>
+			/>
 		</div>
 	);
 };
@@ -76,45 +105,80 @@ export default meta;
 
 type Story = StoryObj<typeof ChatVirtualList>;
 
-const offsetFromScrollerTop = (
-	scroller: HTMLElement,
-	el: HTMLElement,
-): number =>
-	el.getBoundingClientRect().top - scroller.getBoundingClientRect().top;
-
 const distanceFromBottom = (scroller: HTMLElement): number =>
 	scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight;
+
+// visibleAnchorId returns the id of the first rendered item intersecting the
+// viewport top, picked dynamically so assertions do not depend on which items
+// the window chose to render.
+const visibleAnchorId = (
+	canvasElement: HTMLElement,
+	scroller: HTMLElement,
+): string => {
+	const top = scroller.getBoundingClientRect().top;
+	for (const el of canvasElement.querySelectorAll("[data-chat-item-id]")) {
+		if (el.getBoundingClientRect().bottom > top + 5) {
+			const id = el.getAttribute("data-chat-item-id");
+			if (id) {
+				return id;
+			}
+		}
+	}
+	throw new Error("no visible item");
+};
+
+const offsetOfId = (
+	canvasElement: HTMLElement,
+	scroller: HTMLElement,
+	id: string,
+): number => {
+	const el = canvasElement.querySelector(`[data-chat-item-id="${id}"]`);
+	if (!el) {
+		return Number.NaN;
+	}
+	return el.getBoundingClientRect().top - scroller.getBoundingClientRect().top;
+};
+
+// settleWindow waits until the window has re-rendered around the current scroll
+// position, i.e. a real item sits at the viewport top. The window recompute is
+// async, so picking a reference item before settling races against it and may
+// observe a stale window from the previous scroll position.
+const settleWindow = async (
+	canvasElement: HTMLElement,
+	scroller: HTMLElement,
+): Promise<void> => {
+	await waitFor(() => {
+		const id = visibleAnchorId(canvasElement, scroller);
+		expect(Math.abs(offsetOfId(canvasElement, scroller, id))).toBeLessThan(400);
+	});
+};
 
 export const RendersAndOverflows: Story = {
 	render: () => <StoryHarness />,
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const scroller = canvas.getByTestId("scroll-container");
-		await expect(scroller.scrollHeight).toBeGreaterThan(scroller.clientHeight);
+		await waitFor(() =>
+			expect(scroller.scrollHeight).toBeGreaterThan(scroller.clientHeight),
+		);
 	},
 };
 
-export const AnchorStaysStableOnAboveViewportGrowth: Story = {
-	render: () => <StoryHarness />,
+export const RendersOnlyWindow: Story = {
+	render: () => <StoryHarness initialCount={200} />,
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const scroller = canvas.getByTestId("scroll-container");
-		scroller.scrollTop = 1500;
-		scroller.dispatchEvent(new Event("scroll"));
-		await waitFor(() => expect(scroller.scrollTop).toBe(1500));
-		const before = offsetFromScrollerTop(
-			scroller,
-			canvas.getByTestId("msg-15"),
-		);
-		await userEvent.click(canvas.getByTestId("grow-5"));
 		await waitFor(() =>
-			expect(
-				Math.abs(
-					offsetFromScrollerTop(scroller, canvas.getByTestId("msg-15")) -
-						before,
-				),
-			).toBeLessThanOrEqual(2),
+			expect(distanceFromBottom(scroller)).toBeLessThanOrEqual(16),
 		);
+		// Only the near-viewport window is rendered, not all 200 items, and a
+		// far-above item is not mounted once the window has converged.
+		await waitFor(() => expect(canvas.queryByTestId("m-2")).toBeNull());
+		const rendered = canvasElement.querySelectorAll("[data-chat-item]");
+		await expect(rendered.length).toBeLessThanOrEqual(40);
+		const topSpacer = canvasElement.querySelector("[data-virtual-spacer]");
+		await expect((topSpacer as HTMLElement).style.height).not.toBe("0px");
 	},
 };
 
@@ -138,6 +202,9 @@ export const DoesNotYankWhenScrolledUp: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const scroller = canvas.getByTestId("scroll-container");
+		await waitFor(() =>
+			expect(distanceFromBottom(scroller)).toBeLessThanOrEqual(16),
+		);
 		scroller.scrollTop = 800;
 		scroller.dispatchEvent(new Event("scroll"));
 		await waitFor(() => expect(scroller.scrollTop).toBe(800));
@@ -153,6 +220,9 @@ export const FetchesOlderNearTop: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const scroller = canvas.getByTestId("scroll-container");
+		await waitFor(() =>
+			expect(distanceFromBottom(scroller)).toBeLessThanOrEqual(16),
+		);
 		scroller.scrollTop = 0;
 		scroller.dispatchEvent(new Event("scroll"));
 		await waitFor(() =>
@@ -163,35 +233,14 @@ export const FetchesOlderNearTop: Story = {
 	},
 };
 
-export const PrependKeepsViewportStable: Story = {
-	render: () => <StoryHarness />,
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const scroller = canvas.getByTestId("scroll-container");
-		scroller.scrollTop = 1500;
-		scroller.dispatchEvent(new Event("scroll"));
-		await waitFor(() => expect(scroller.scrollTop).toBe(1500));
-		const before = offsetFromScrollerTop(
-			scroller,
-			canvas.getByTestId("msg-20"),
-		);
-		await userEvent.click(canvas.getByTestId("prepend"));
-		await waitFor(() =>
-			expect(
-				Math.abs(
-					offsetFromScrollerTop(scroller, canvas.getByTestId("msg-20")) -
-						before,
-				),
-			).toBeLessThanOrEqual(2),
-		);
-	},
-};
-
 export const ScrollToBottomButtonWorks: Story = {
 	render: () => <StoryHarness />,
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const scroller = canvas.getByTestId("scroll-container");
+		await waitFor(() =>
+			expect(distanceFromBottom(scroller)).toBeLessThanOrEqual(16),
+		);
 		scroller.scrollTop = 100;
 		scroller.dispatchEvent(new Event("scroll"));
 		const button = await canvas.findByRole("button", {
@@ -201,5 +250,140 @@ export const ScrollToBottomButtonWorks: Story = {
 		await waitFor(() =>
 			expect(distanceFromBottom(scroller)).toBeLessThanOrEqual(16),
 		);
+	},
+};
+
+export const NoJumpOnPrepend: Story = {
+	render: () => <StoryHarness initialCount={200} />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scroller = canvas.getByTestId("scroll-container");
+		await waitFor(() =>
+			expect(distanceFromBottom(scroller)).toBeLessThanOrEqual(16),
+		);
+		scroller.scrollTop = 20000;
+		scroller.dispatchEvent(new Event("scroll"));
+		await waitFor(() => expect(scroller.scrollTop).toBe(20000));
+		await settleWindow(canvasElement, scroller);
+		const ref = visibleAnchorId(canvasElement, scroller);
+		const before = offsetOfId(canvasElement, scroller, ref);
+		await userEvent.click(canvas.getByTestId("prepend"));
+		await waitFor(() =>
+			expect(
+				Math.abs(offsetOfId(canvasElement, scroller, ref) - before),
+			).toBeLessThanOrEqual(3),
+		);
+	},
+};
+
+export const StreamingGrowthAboveViewportNoJump: Story = {
+	render: () => <StoryHarness initialCount={200} />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scroller = canvas.getByTestId("scroll-container");
+		await waitFor(() =>
+			expect(distanceFromBottom(scroller)).toBeLessThanOrEqual(16),
+		);
+		// Put m-5 (offset 1100) into the top overscan, above the viewport top.
+		scroller.scrollTop = 1800;
+		scroller.dispatchEvent(new Event("scroll"));
+		await waitFor(() => expect(scroller.scrollTop).toBe(1800));
+		await settleWindow(canvasElement, scroller);
+		const ref = visibleAnchorId(canvasElement, scroller);
+		const before = offsetOfId(canvasElement, scroller, ref);
+		// m-5 grows above the viewport; the visible reference must not move.
+		await userEvent.click(canvas.getByTestId("grow-5"));
+		await waitFor(() =>
+			expect(
+				Math.abs(offsetOfId(canvasElement, scroller, ref) - before),
+			).toBeLessThanOrEqual(3),
+		);
+	},
+};
+
+export const NoJumpScrollingThroughWrongEstimates: Story = {
+	// Real height 120 differs sharply from the assistant seed 220, so items
+	// entering the top of the window reconcile estimate to measured. Scrolling up
+	// by a delta must move a tracked item by exactly that delta.
+	render: () => <StoryHarness initialCount={200} itemHeight={120} />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scroller = canvas.getByTestId("scroll-container");
+		await waitFor(() =>
+			expect(distanceFromBottom(scroller)).toBeLessThanOrEqual(16),
+		);
+		scroller.scrollTop = 10000;
+		scroller.dispatchEvent(new Event("scroll"));
+		await waitFor(() => expect(scroller.scrollTop).toBe(10000));
+		await settleWindow(canvasElement, scroller);
+		const ref = visibleAnchorId(canvasElement, scroller);
+		const before = offsetOfId(canvasElement, scroller, ref);
+		scroller.scrollTop = 9500;
+		scroller.dispatchEvent(new Event("scroll"));
+		await waitFor(() =>
+			expect(
+				Math.abs(offsetOfId(canvasElement, scroller, ref) - (before + 500)),
+			).toBeLessThanOrEqual(5),
+		);
+	},
+};
+
+export const OnlyWindowMounts: Story = {
+	render: () => <StoryHarness initialCount={1000} />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scroller = canvas.getByTestId("scroll-container");
+		await waitFor(() =>
+			expect(distanceFromBottom(scroller)).toBeLessThanOrEqual(16),
+		);
+		// The newest item is mounted at the bottom.
+		await waitFor(() => expect(canvas.queryByTestId("m-999")).not.toBeNull());
+		// DOM node count stays bounded by the window, independent of the 1000-item
+		// list size: a render-all implementation would mount far more than this.
+		const rendered = canvasElement.querySelectorAll("[data-chat-item]");
+		await expect(rendered.length).toBeLessThanOrEqual(40);
+	},
+};
+
+export const AppendKeepsPinned: Story = {
+	render: () => <StoryHarness initialCount={1000} />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scroller = canvas.getByTestId("scroll-container");
+		await waitFor(() =>
+			expect(distanceFromBottom(scroller)).toBeLessThanOrEqual(16),
+		);
+		await userEvent.click(canvas.getByTestId("append"));
+		// The appended item mounts and the scroller stays pinned to the bottom.
+		await waitFor(() => expect(canvas.queryByTestId("m-1000")).not.toBeNull());
+		await waitFor(() =>
+			expect(distanceFromBottom(scroller)).toBeLessThanOrEqual(16),
+		);
+	},
+};
+
+export const ScrollRecyclesOffscreen: Story = {
+	render: () => <StoryHarness initialCount={200} />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scroller = canvas.getByTestId("scroll-container");
+		await waitFor(() =>
+			expect(distanceFromBottom(scroller)).toBeLessThanOrEqual(16),
+		);
+		// Bring m-100 into the window.
+		scroller.scrollTop = 22000;
+		scroller.dispatchEvent(new Event("scroll"));
+		await waitFor(() => expect(canvas.queryByTestId("m-100")).not.toBeNull());
+		// Scroll far below m-100 so it falls outside the overscan window.
+		scroller.scrollTop = 40000;
+		scroller.dispatchEvent(new Event("scroll"));
+		// The offscreen row leaves the DOM (true recycling) and the top spacer
+		// grows to reserve the space of every item now scrolled above the window,
+		// including m-100's slot at offset 22000.
+		await waitFor(() => expect(canvas.queryByTestId("m-100")).toBeNull());
+		const topSpacer = canvasElement.querySelector("[data-virtual-spacer]");
+		await expect(
+			Number.parseInt((topSpacer as HTMLElement).style.height, 10),
+		).toBeGreaterThan(22000);
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatVirtualList/ChatVirtualList.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatVirtualList/ChatVirtualList.stories.tsx
@@ -59,6 +59,16 @@ const StoryHarness: FC<{
 				it.id === "m-5" ? { ...it, height: it.height + 160 } : it,
 			),
 		);
+	// streamLast grows the newest item by a small amount, mimicking a token
+	// arriving while the assistant streams its reply at the bottom.
+	const streamLast = () =>
+		setItems((prev) => {
+			if (prev.length === 0) {
+				return prev;
+			}
+			const last = prev[prev.length - 1];
+			return [...prev.slice(0, -1), { ...last, height: last.height + 40 }];
+		});
 
 	const byId = new Map(items.map((it) => [it.id, it]));
 	const renderItem = (item: VirtualItem) => {
@@ -81,6 +91,9 @@ const StoryHarness: FC<{
 				</button>
 				<button type="button" data-testid="grow-5" onClick={growFive}>
 					grow-5
+				</button>
+				<button type="button" data-testid="stream-last" onClick={streamLast}>
+					stream-last
 				</button>
 				<span data-testid="fetch-count">{fetchCount}</span>
 			</div>
@@ -151,6 +164,25 @@ const settleWindow = async (
 		const id = visibleAnchorId(canvasElement, scroller);
 		expect(Math.abs(offsetOfId(canvasElement, scroller, id))).toBeLessThan(400);
 	});
+};
+
+// settleScroll waits until scrollTop stops changing, meaning any anchor
+// correction triggered by a measurement has been applied. Streaming mutates
+// height across several async frames, so a single frame can observe a position
+// that is still mid-correction.
+const settleScroll = async (scroller: HTMLElement): Promise<void> => {
+	let stableFrames = 0;
+	let previous = scroller.scrollTop;
+	for (let frame = 0; frame < 60 && stableFrames < 3; frame++) {
+		await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+		const current = scroller.scrollTop;
+		if (Math.abs(current - previous) < 0.5) {
+			stableFrames += 1;
+		} else {
+			stableFrames = 0;
+		}
+		previous = current;
+	}
 };
 
 export const RendersAndOverflows: Story = {
@@ -385,5 +417,41 @@ export const ScrollRecyclesOffscreen: Story = {
 		await expect(
 			Number.parseInt((topSpacer as HTMLElement).style.height, 10),
 		).toBeGreaterThan(22000);
+	},
+};
+
+// The reading position must stay perfectly still while the assistant streams its
+// reply at the bottom and the user is scrolled up. A few tokens arrive first
+// while pinned, mirroring how the real assistant begins streaming before the
+// user scrolls up, so the newest item is measured as it grows and the kind
+// average settles. Each later token then grows only the newest item below the
+// viewport, and the tracked reference at the top must not move.
+export const StaysStillWhileStreamingBelow: Story = {
+	render: () => <StoryHarness initialCount={200} />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scroller = canvas.getByTestId("scroll-container");
+		await waitFor(() =>
+			expect(distanceFromBottom(scroller)).toBeLessThanOrEqual(16),
+		);
+		for (let i = 0; i < 3; i++) {
+			await userEvent.click(canvas.getByTestId("stream-last"));
+			await waitFor(() =>
+				expect(distanceFromBottom(scroller)).toBeLessThanOrEqual(16),
+			);
+		}
+		scroller.scrollTop = scroller.scrollHeight - scroller.clientHeight - 700;
+		scroller.dispatchEvent(new Event("scroll"));
+		await settleWindow(canvasElement, scroller);
+		await settleScroll(scroller);
+		const ref = visibleAnchorId(canvasElement, scroller);
+		const before = offsetOfId(canvasElement, scroller, ref);
+		for (let i = 0; i < 10; i++) {
+			await userEvent.click(canvas.getByTestId("stream-last"));
+			await settleScroll(scroller);
+			expect(
+				Math.abs(offsetOfId(canvasElement, scroller, ref) - before),
+			).toBeLessThanOrEqual(1);
+		}
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatVirtualList/ChatVirtualList.tsx
+++ b/site/src/pages/AgentsPage/components/ChatVirtualList/ChatVirtualList.tsx
@@ -6,34 +6,94 @@ import {
 	useEffect,
 	useLayoutEffect,
 	useRef,
+	useState,
 } from "react";
+import {
+	createHeightCache,
+	type HeightCache,
+	type MessageKind,
+} from "./heightCache";
 import { ScrollToBottomButton } from "./ScrollToBottomButton";
 import { useScrollAnchor } from "./useScrollAnchor";
+import { computeWindow, cumulativeOffsets } from "./windowMath";
 
+export type VirtualItem = { id: string; kind: MessageKind };
+
+// Render this many pixels above and below the viewport, matching the
+// @pierre/diffs Virtualizer overscan so fast scrolls do not blank.
+const VIRTUAL_OVERSCAN = 1000;
 const LOAD_MORE_MARGIN = "600px 0px 0px 0px";
 
 type ChatVirtualListProps = {
+	items: ReadonlyArray<VirtualItem>;
+	renderItem: (item: VirtualItem) => ReactNode;
 	scrollContainerRef: RefObject<HTMLDivElement | null>;
 	scrollToBottomRef: RefObject<(() => void) | null>;
 	isFetchingMoreMessages: boolean;
 	hasMoreMessages: boolean;
 	onFetchMoreMessages: () => void;
-	messageCount: number;
-	children: ReactNode;
+};
+
+// The cached height sizes this item's spacer once it scrolls out of the
+// window, so leaving the window is layout-neutral.
+const MeasuredItem: FC<{
+	item: VirtualItem;
+	renderItem: (item: VirtualItem) => ReactNode;
+	cache: HeightCache;
+	onMeasured: () => void;
+}> = ({ item, renderItem, cache, onMeasured }) => {
+	const ref = useRef<HTMLDivElement | null>(null);
+	useEffect(() => {
+		const el = ref.current;
+		if (!el) {
+			return;
+		}
+		const observer = new ResizeObserver(() => {
+			const height = el.getBoundingClientRect().height;
+			if (height !== cache.get(item.id)) {
+				cache.record(item.id, item.kind, height);
+				onMeasured();
+			}
+		});
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, [item, cache, onMeasured]);
+
+	return (
+		<div ref={ref} data-chat-item="" data-chat-item-id={item.id}>
+			{renderItem(item)}
+		</div>
+	);
 };
 
 export const ChatVirtualList: FC<ChatVirtualListProps> = ({
+	items,
+	renderItem,
 	scrollContainerRef,
 	scrollToBottomRef,
 	isFetchingMoreMessages,
 	hasMoreMessages,
 	onFetchMoreMessages,
-	messageCount,
-	children,
 }) => {
-	const { scrollerRef, contentRef, atBottom, scrollToBottom, maintainPin } =
-		useScrollAnchor();
+	const {
+		scrollerRef,
+		contentRef,
+		atBottom,
+		scrollToBottom,
+		captureAnchor,
+		restoreAnchor,
+	} = useScrollAnchor();
 	const topSentinelRef = useRef<HTMLDivElement | null>(null);
+	// Lazy useState initializer keeps one cache instance for the component's life
+	// without reading a ref during render, which the React Compiler forbids.
+	const [cache] = useState<HeightCache>(() => createHeightCache());
+
+	const [scrollTop, setScrollTop] = useState(0);
+	const [viewportHeight, setViewportHeight] = useState(0);
+	const [cacheVersion, setCacheVersion] = useState(0);
+	const bumpCacheVersion = useCallback(() => {
+		setCacheVersion((value) => value + 1);
+	}, []);
 
 	const setScroller = useCallback(
 		(element: HTMLDivElement | null) => {
@@ -44,10 +104,102 @@ export const ChatVirtualList: FC<ChatVirtualListProps> = ({
 		[scrollerRef, scrollContainerRef, scrollToBottomRef, scrollToBottom],
 	);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies(messageCount): messageCount is an intentional trigger so a new message pins to the bottom; maintainPin reads refs and must re-run when the count changes.
+	const heights = items.map((item) => cache.estimate(item.id, item.kind));
+	const offsets = cumulativeOffsets(heights);
+	const { start, end, topPad, bottomPad } = computeWindow({
+		offsets,
+		scrollTop,
+		// Until the scroller is measured, fall back to a 1px viewport so the first
+		// window stays small (overscan only) instead of mounting the whole list.
+		viewportHeight: viewportHeight || 1,
+		overscan: VIRTUAL_OVERSCAN,
+	});
+	const visible = end >= start ? items.slice(start, end + 1) : [];
+
+	// Mirror the live scroll position into state so the window recomputes as the
+	// reader scrolls. The anchor is captured by the layout effect below, after the
+	// new window commits, never here. A teleport scroll therefore records a real
+	// rendered item instead of a stale one from the previous window.
+	useEffect(() => {
+		const scroller = scrollerRef.current;
+		if (!scroller) {
+			return;
+		}
+		let frame = 0;
+		const onScroll = () => {
+			if (frame) {
+				return;
+			}
+			frame = requestAnimationFrame(() => {
+				frame = 0;
+				setScrollTop(scroller.scrollTop);
+			});
+		};
+		scroller.addEventListener("scroll", onScroll, { passive: true });
+		return () => {
+			scroller.removeEventListener("scroll", onScroll);
+			if (frame) {
+				cancelAnimationFrame(frame);
+			}
+		};
+	}, [scrollerRef]);
+
+	// A resize counts as a content change below, so the anchor (or bottom pin)
+	// is preserved across it.
+	useEffect(() => {
+		const scroller = scrollerRef.current;
+		if (!scroller) {
+			return;
+		}
+		const observer = new ResizeObserver(() => {
+			setViewportHeight(scroller.clientHeight);
+		});
+		observer.observe(scroller);
+		setViewportHeight(scroller.clientHeight);
+		return () => observer.disconnect();
+	}, [scrollerRef]);
+
+	// Single scrollTop owner. After every commit, classify the change by diffing
+	// the committed inputs against the previous commit:
+	//   - content changed (items, measured heights, or viewport): the DOM shifted
+	//     under the reader, so restore the captured anchor (or re-pin to the
+	//     bottom), then re-capture at the settled position.
+	//   - only scrollTop changed (a deliberate scroll): just re-capture; restoring
+	//     here would fight the scroll.
+	// restore writes scroller.scrollTop, which the scroll listener turns into the
+	// next scrollTop state, so a correction converges across frames.
+	const prevCommitRef = useRef<{
+		scrollTop: number;
+		items: ReadonlyArray<VirtualItem>;
+		cacheVersion: number;
+		viewportHeight: number;
+	} | null>(null);
 	useLayoutEffect(() => {
-		maintainPin();
-	}, [messageCount, maintainPin]);
+		const prev = prevCommitRef.current;
+		prevCommitRef.current = { scrollTop, items, cacheVersion, viewportHeight };
+		if (!prev) {
+			restoreAnchor();
+			captureAnchor();
+			return;
+		}
+		const contentChanged =
+			items !== prev.items ||
+			cacheVersion !== prev.cacheVersion ||
+			viewportHeight !== prev.viewportHeight;
+		if (contentChanged) {
+			restoreAnchor();
+			captureAnchor();
+		} else if (scrollTop !== prev.scrollTop) {
+			captureAnchor();
+		}
+	}, [
+		scrollTop,
+		viewportHeight,
+		items,
+		cacheVersion,
+		restoreAnchor,
+		captureAnchor,
+	]);
 
 	useEffect(() => {
 		const sentinel = topSentinelRef.current;
@@ -85,7 +237,17 @@ export const ChatVirtualList: FC<ChatVirtualListProps> = ({
 			>
 				<div ref={contentRef} className="flex flex-col">
 					<div ref={topSentinelRef} aria-hidden className="h-0" />
-					{children}
+					<div data-virtual-spacer="" style={{ height: topPad }} />
+					{visible.map((item) => (
+						<MeasuredItem
+							key={item.id}
+							item={item}
+							renderItem={renderItem}
+							cache={cache}
+							onMeasured={bumpCacheVersion}
+						/>
+					))}
+					<div data-virtual-spacer="" style={{ height: bottomPad }} />
 				</div>
 			</div>
 			<ScrollToBottomButton

--- a/site/src/pages/AgentsPage/components/ChatVirtualList/ChatVirtualList.tsx
+++ b/site/src/pages/AgentsPage/components/ChatVirtualList/ChatVirtualList.tsx
@@ -1,0 +1,97 @@
+import {
+	type FC,
+	type ReactNode,
+	type RefObject,
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+} from "react";
+import { ScrollToBottomButton } from "./ScrollToBottomButton";
+import { useScrollAnchor } from "./useScrollAnchor";
+
+const LOAD_MORE_MARGIN = "600px 0px 0px 0px";
+
+type ChatVirtualListProps = {
+	scrollContainerRef: RefObject<HTMLDivElement | null>;
+	scrollToBottomRef: RefObject<(() => void) | null>;
+	isFetchingMoreMessages: boolean;
+	hasMoreMessages: boolean;
+	onFetchMoreMessages: () => void;
+	messageCount: number;
+	children: ReactNode;
+};
+
+export const ChatVirtualList: FC<ChatVirtualListProps> = ({
+	scrollContainerRef,
+	scrollToBottomRef,
+	isFetchingMoreMessages,
+	hasMoreMessages,
+	onFetchMoreMessages,
+	messageCount,
+	children,
+}) => {
+	const { scrollerRef, contentRef, atBottom, scrollToBottom, maintainPin } =
+		useScrollAnchor();
+	const topSentinelRef = useRef<HTMLDivElement | null>(null);
+
+	const setScroller = useCallback(
+		(element: HTMLDivElement | null) => {
+			scrollerRef.current = element;
+			scrollContainerRef.current = element;
+			scrollToBottomRef.current = element ? scrollToBottom : null;
+		},
+		[scrollerRef, scrollContainerRef, scrollToBottomRef, scrollToBottom],
+	);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies(messageCount): messageCount is an intentional trigger so a new message pins to the bottom; maintainPin reads refs and must re-run when the count changes.
+	useLayoutEffect(() => {
+		maintainPin();
+	}, [messageCount, maintainPin]);
+
+	useEffect(() => {
+		const sentinel = topSentinelRef.current;
+		const scroller = scrollerRef.current;
+		if (!sentinel || !scroller || !hasMoreMessages) {
+			return;
+		}
+		const observer = new IntersectionObserver(
+			([entry]) => {
+				if (
+					entry.isIntersecting &&
+					hasMoreMessages &&
+					!isFetchingMoreMessages
+				) {
+					onFetchMoreMessages();
+				}
+			},
+			{ root: scroller, rootMargin: LOAD_MORE_MARGIN },
+		);
+		observer.observe(sentinel);
+		return () => observer.disconnect();
+	}, [
+		scrollerRef,
+		hasMoreMessages,
+		isFetchingMoreMessages,
+		onFetchMoreMessages,
+	]);
+
+	return (
+		<div className="relative flex min-h-0 flex-1 flex-col">
+			<div
+				ref={setScroller}
+				data-testid="scroll-container"
+				className="flex min-h-0 flex-1 flex-col overflow-y-auto [overflow-anchor:none] [scrollbar-gutter:stable]"
+			>
+				<div ref={contentRef} className="flex flex-col">
+					<div ref={topSentinelRef} aria-hidden className="h-0" />
+					{children}
+				</div>
+			</div>
+			<ScrollToBottomButton
+				visible={!atBottom}
+				onScrollToBottom={scrollToBottom}
+			/>
+		</div>
+	);
+};

--- a/site/src/pages/AgentsPage/components/ChatVirtualList/ScrollToBottomButton.tsx
+++ b/site/src/pages/AgentsPage/components/ChatVirtualList/ScrollToBottomButton.tsx
@@ -1,0 +1,31 @@
+import { ArrowDownIcon } from "lucide-react";
+import type { FC } from "react";
+import { Button } from "#/components/Button/Button";
+import { cn } from "#/utils/cn";
+
+export const ScrollToBottomButton: FC<{
+	visible: boolean;
+	onScrollToBottom: () => void;
+}> = ({ visible, onScrollToBottom }) => {
+	return (
+		// Floating overlay above the scroll container.
+		<div className="pointer-events-none absolute inset-x-0 bottom-2 z-10 flex justify-center py-2">
+			<Button
+				variant="outline"
+				size="icon"
+				className={cn(
+					"rounded-full bg-surface-primary shadow-md transition-all duration-200",
+					visible
+						? "pointer-events-auto translate-y-0 opacity-100"
+						: "translate-y-2 opacity-0",
+				)}
+				onClick={onScrollToBottom}
+				aria-label="Scroll to bottom"
+				aria-hidden={!visible || undefined}
+				tabIndex={visible ? undefined : -1}
+			>
+				<ArrowDownIcon />
+			</Button>
+		</div>
+	);
+};

--- a/site/src/pages/AgentsPage/components/ChatVirtualList/anchorMath.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatVirtualList/anchorMath.test.ts
@@ -14,10 +14,25 @@ describe("isAtBottom", () => {
 });
 
 describe("correctedScrollTop", () => {
-	it("adds the offset delta so the anchor stays put", () => {
-		expect(correctedScrollTop(200, 100, 140)).toBe(240);
+	// Capture and restore at the same scroll position: a pure content change.
+	it("adds the content-position delta so the anchor stays put", () => {
+		// scrollTop 200, anchor offset 100 (content top 300); content above grew 40
+		// so the anchor's content top is now 340.
+		expect(correctedScrollTop(200, 300, 340)).toBe(240);
 	});
 	it("returns the same scrollTop when nothing moved", () => {
-		expect(correctedScrollTop(200, 100, 100)).toBe(200);
+		expect(correctedScrollTop(200, 300, 300)).toBe(200);
+	});
+	// The Safari instability: the user scrolled between capture and restore. The
+	// anchor's content top is unchanged, so there must be no correction.
+	it("does not snap back when only a scroll happened between capture and restore", () => {
+		// Captured at scrollTop 250, offset 50 (content top 300). Scrolled to 200
+		// with no content change: content top is still 300.
+		expect(correctedScrollTop(200, 300, 300)).toBe(200);
+	});
+	it("corrects only the content shift when a scroll and a content change coincide", () => {
+		// Captured content top 300. Scrolled to 200, then content above grew 40, so
+		// the anchor's content top is now 340. Only the 40 is corrected.
+		expect(correctedScrollTop(200, 300, 340)).toBe(240);
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatVirtualList/anchorMath.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatVirtualList/anchorMath.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { correctedScrollTop, isAtBottom } from "./anchorMath";
+
+describe("isAtBottom", () => {
+	it("is true at the exact bottom", () => {
+		expect(isAtBottom(880, 1000, 120, 16)).toBe(true);
+	});
+	it("is true within the threshold", () => {
+		expect(isAtBottom(870, 1000, 120, 16)).toBe(true);
+	});
+	it("is false above the threshold", () => {
+		expect(isAtBottom(800, 1000, 120, 16)).toBe(false);
+	});
+});
+
+describe("correctedScrollTop", () => {
+	it("adds the offset delta so the anchor stays put", () => {
+		expect(correctedScrollTop(200, 100, 140)).toBe(240);
+	});
+	it("returns the same scrollTop when nothing moved", () => {
+		expect(correctedScrollTop(200, 100, 100)).toBe(200);
+	});
+});

--- a/site/src/pages/AgentsPage/components/ChatVirtualList/anchorMath.ts
+++ b/site/src/pages/AgentsPage/components/ChatVirtualList/anchorMath.ts
@@ -11,12 +11,15 @@ export function isAtBottom(
 	return scrollHeight - scrollTop - clientHeight <= threshold;
 }
 
-// correctedScrollTop returns the scrollTop that keeps an anchor element at its
-// previous viewport offset after content above it changed height.
+// correctedScrollTop returns the scrollTop that keeps an anchor element visually
+// fixed after content above it changed height. It works from the anchor's
+// content position (scrollTop + viewport offset) at capture versus now, so a
+// scroll that happened between capture and restore is not mistaken for a content
+// shift and never snaps the viewport back to the capture position.
 export function correctedScrollTop(
-	scrollTop: number,
-	previousOffset: number,
-	currentOffset: number,
+	currentScrollTop: number,
+	savedContentTop: number,
+	currentContentTop: number,
 ): number {
-	return scrollTop + (currentOffset - previousOffset);
+	return currentScrollTop + (currentContentTop - savedContentTop);
 }

--- a/site/src/pages/AgentsPage/components/ChatVirtualList/anchorMath.ts
+++ b/site/src/pages/AgentsPage/components/ChatVirtualList/anchorMath.ts
@@ -1,0 +1,22 @@
+const BOTTOM_THRESHOLD_PX = 16;
+
+// isAtBottom reports whether the scroller is within `threshold` pixels of the
+// bottom. Used to decide between pinning to the bottom and holding an anchor.
+export function isAtBottom(
+	scrollTop: number,
+	scrollHeight: number,
+	clientHeight: number,
+	threshold = BOTTOM_THRESHOLD_PX,
+): boolean {
+	return scrollHeight - scrollTop - clientHeight <= threshold;
+}
+
+// correctedScrollTop returns the scrollTop that keeps an anchor element at its
+// previous viewport offset after content above it changed height.
+export function correctedScrollTop(
+	scrollTop: number,
+	previousOffset: number,
+	currentOffset: number,
+): number {
+	return scrollTop + (currentOffset - previousOffset);
+}

--- a/site/src/pages/AgentsPage/components/ChatVirtualList/heightCache.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatVirtualList/heightCache.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { createHeightCache } from "./heightCache";
+
+describe("createHeightCache", () => {
+	it("uses a provided seed when a kind has no samples", () => {
+		const cache = createHeightCache({ assistant: 200 });
+		expect(cache.estimate("a1", "assistant")).toBe(200);
+	});
+
+	it("falls back to a built-in seed when none is provided", () => {
+		const cache = createHeightCache();
+		expect(cache.estimate("u1", "user")).toBe(80);
+	});
+
+	it("averages recorded heights per kind", () => {
+		const cache = createHeightCache();
+		cache.record("a1", "assistant", 100);
+		cache.record("a2", "assistant", 300);
+		expect(cache.estimate("a3", "assistant")).toBe(200);
+	});
+
+	it("returns the measured height for a known id via get and estimate", () => {
+		const cache = createHeightCache();
+		cache.record("a1", "assistant", 512);
+		expect(cache.get("a1")).toBe(512);
+		expect(cache.estimate("a1", "assistant")).toBe(512);
+	});
+
+	it("updates the average when an id is re-recorded, without double counting", () => {
+		const cache = createHeightCache();
+		cache.record("a1", "assistant", 100);
+		cache.record("a1", "assistant", 200);
+		expect(cache.estimate("a2", "assistant")).toBe(200);
+	});
+
+	it("returns undefined from get for an unknown id", () => {
+		const cache = createHeightCache();
+		expect(cache.get("nope")).toBeUndefined();
+	});
+
+	it("keeps averages per kind independent", () => {
+		const cache = createHeightCache();
+		cache.record("u1", "user", 60);
+		cache.record("a1", "assistant", 400);
+		expect(cache.estimate("u2", "user")).toBe(60);
+		expect(cache.estimate("a2", "assistant")).toBe(400);
+	});
+});

--- a/site/src/pages/AgentsPage/components/ChatVirtualList/heightCache.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatVirtualList/heightCache.test.ts
@@ -26,11 +26,14 @@ describe("createHeightCache", () => {
 		expect(cache.estimate("a1", "assistant")).toBe(512);
 	});
 
-	it("updates the average when an id is re-recorded, without double counting", () => {
+	it("does not let a re-recorded id drift the kind average", () => {
 		const cache = createHeightCache();
 		cache.record("a1", "assistant", 100);
+		// A streaming item growing: its own height updates, but the kind average
+		// stays put so unmeasured items above the viewport do not shift.
 		cache.record("a1", "assistant", 200);
-		expect(cache.estimate("a2", "assistant")).toBe(200);
+		expect(cache.get("a1")).toBe(200);
+		expect(cache.estimate("a2", "assistant")).toBe(100);
 	});
 
 	it("returns undefined from get for an unknown id", () => {

--- a/site/src/pages/AgentsPage/components/ChatVirtualList/heightCache.ts
+++ b/site/src/pages/AgentsPage/components/ChatVirtualList/heightCache.ts
@@ -47,15 +47,17 @@ export function createHeightCache(
 		},
 		record(id, kind, height) {
 			const previous = measured.get(id);
-			const total = totals.get(kind) ?? { sum: 0, count: 0 };
-			// Replace the previous sample so re-measuring never double counts.
-			if (previous && previous.kind === kind) {
-				total.sum += height - previous.height;
-			} else {
+			// Only an id's first measurement feeds the kind average. A later
+			// re-measurement, such as a streaming item growing token by token,
+			// updates just that id's height. Folding it back into the average would
+			// drift the estimate of never-measured items above the viewport and
+			// shift the reading position while the user reads during a stream.
+			if (!previous) {
+				const total = totals.get(kind) ?? { sum: 0, count: 0 };
 				total.sum += height;
 				total.count += 1;
+				totals.set(kind, total);
 			}
-			totals.set(kind, total);
 			measured.set(id, { kind, height });
 		},
 	};

--- a/site/src/pages/AgentsPage/components/ChatVirtualList/heightCache.ts
+++ b/site/src/pages/AgentsPage/components/ChatVirtualList/heightCache.ts
@@ -1,0 +1,62 @@
+// Type-aware height model for the windowing renderer. Pure mutable state, read
+// on render and updated from measurement. No DOM or React here.
+
+export type MessageKind = "user" | "assistant" | "tool" | "diff" | "other";
+
+export type HeightCache = {
+	// get returns the measured height for an id, or undefined if never measured.
+	get(id: string): number | undefined;
+	// estimate returns the measured height if known, else the running average for
+	// the kind, else the seed. Used to size not-yet-measured items.
+	estimate(id: string, kind: MessageKind): number;
+	// record stores an id's measured height and folds it into the kind average.
+	record(id: string, kind: MessageKind, height: number): void;
+};
+
+// Seeds only affect the first paint of a kind before any of its messages have
+// been measured. They are intentionally rough.
+const DEFAULT_SEEDS: Record<MessageKind, number> = {
+	user: 80,
+	assistant: 220,
+	tool: 140,
+	diff: 320,
+	other: 160,
+};
+
+export function createHeightCache(
+	seeds?: Partial<Record<MessageKind, number>>,
+): HeightCache {
+	const seed: Record<MessageKind, number> = { ...DEFAULT_SEEDS, ...seeds };
+	const measured = new Map<string, { kind: MessageKind; height: number }>();
+	const totals = new Map<MessageKind, { sum: number; count: number }>();
+
+	const kindAverage = (kind: MessageKind): number | undefined => {
+		const total = totals.get(kind);
+		if (!total || total.count === 0) {
+			return undefined;
+		}
+		return total.sum / total.count;
+	};
+
+	return {
+		get(id) {
+			return measured.get(id)?.height;
+		},
+		estimate(id, kind) {
+			return measured.get(id)?.height ?? kindAverage(kind) ?? seed[kind];
+		},
+		record(id, kind, height) {
+			const previous = measured.get(id);
+			const total = totals.get(kind) ?? { sum: 0, count: 0 };
+			// Replace the previous sample so re-measuring never double counts.
+			if (previous && previous.kind === kind) {
+				total.sum += height - previous.height;
+			} else {
+				total.sum += height;
+				total.count += 1;
+			}
+			totals.set(kind, total);
+			measured.set(id, { kind, height });
+		},
+	};
+}

--- a/site/src/pages/AgentsPage/components/ChatVirtualList/useScrollAnchor.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatVirtualList/useScrollAnchor.stories.tsx
@@ -26,6 +26,14 @@ const AnchorHarness: FC = () => {
 		setVersion((value) => value + 1);
 	};
 
+	// growNoCapture changes heights and triggers a restore without capturing
+	// first, so a test can capture, scroll, then mutate and prove the restore
+	// honors the post-scroll position instead of the capture position.
+	const growNoCapture = (changes: Record<number, number>) => {
+		setHeights((prev) => ({ ...prev, ...changes }));
+		setVersion((value) => value + 1);
+	};
+
 	// biome-ignore lint/correctness/useExhaustiveDependencies(version): version is the layout-mutation trigger; restore reads the DOM and must run after each mutation commits.
 	useLayoutEffect(() => {
 		restoreAnchor();
@@ -47,6 +55,20 @@ const AnchorHarness: FC = () => {
 					onClick={() => mutate({ 5: 200, 35: 0 })}
 				>
 					zero-net
+				</button>
+				<button
+					type="button"
+					data-testid="capture"
+					onClick={() => captureAnchor()}
+				>
+					capture
+				</button>
+				<button
+					type="button"
+					data-testid="grow-no-capture"
+					onClick={() => growNoCapture({ 5: 300 })}
+				>
+					grow-no-capture
 				</button>
 			</div>
 			<div
@@ -118,6 +140,37 @@ export const AnchorSurvivesZeroNetMutation: Story = {
 		// amount: total height is unchanged, so a content ResizeObserver never
 		// fires, yet the anchor moved. Only capture/restore corrects this.
 		await userEvent.click(canvas.getByTestId("zero-net"));
+		await waitFor(() =>
+			expect(
+				Math.abs(
+					offsetFromTop(scroller, canvas.getByTestId("row-20")) - before,
+				),
+			).toBeLessThanOrEqual(2),
+		);
+	},
+};
+
+// Reproduces the Safari instability: the anchor is captured at one scroll
+// position, the user scrolls, then content above changes. The restore must
+// compensate only the content growth and leave the viewport where the scroll
+// put it. The earlier offset-delta formula snapped back to the capture point.
+export const AnchorSurvivesScrollBetweenCaptureAndMutation: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scroller = canvas.getByTestId("scroll-container");
+		scroller.scrollTop = SCROLL_TO_ROW_20;
+		scroller.dispatchEvent(new Event("scroll"));
+		await waitFor(() => expect(scroller.scrollTop).toBe(SCROLL_TO_ROW_20));
+		// Capture row 20 at the top, then scroll up 200px without re-capturing,
+		// mimicking a continuous scroll where capture ran a frame earlier.
+		await userEvent.click(canvas.getByTestId("capture"));
+		scroller.scrollTop = SCROLL_TO_ROW_20 - 200;
+		scroller.dispatchEvent(new Event("scroll"));
+		await waitFor(() =>
+			expect(scroller.scrollTop).toBe(SCROLL_TO_ROW_20 - 200),
+		);
+		const before = offsetFromTop(scroller, canvas.getByTestId("row-20"));
+		await userEvent.click(canvas.getByTestId("grow-no-capture"));
 		await waitFor(() =>
 			expect(
 				Math.abs(

--- a/site/src/pages/AgentsPage/components/ChatVirtualList/useScrollAnchor.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatVirtualList/useScrollAnchor.stories.tsx
@@ -1,0 +1,129 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { type FC, useLayoutEffect, useState } from "react";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+import { useScrollAnchor } from "./useScrollAnchor";
+
+// Exercises the capture/restore primitive in isolation, without the windowing
+// renderer, so a failure here points at the anchor hook rather than the layout
+// math.
+
+const ROWS = 40;
+const ROW_HEIGHT = 100;
+const SPACER_HEIGHT = 50;
+
+const AnchorHarness: FC = () => {
+	const { scrollerRef, contentRef, captureAnchor, restoreAnchor } =
+		useScrollAnchor();
+	const [heights, setHeights] = useState<Record<number, number>>({});
+	const [version, setVersion] = useState(0);
+
+	const mutate = (changes: Record<number, number>) => {
+		// Record the item at the viewport top before the heights change, then
+		// restore it once the mutation commits. This mirrors how the container
+		// brackets a content mutation around the layout effect.
+		captureAnchor();
+		setHeights((prev) => ({ ...prev, ...changes }));
+		setVersion((value) => value + 1);
+	};
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies(version): version is the layout-mutation trigger; restore reads the DOM and must run after each mutation commits.
+	useLayoutEffect(() => {
+		restoreAnchor();
+	}, [version, restoreAnchor]);
+
+	return (
+		<div className="flex h-[400px] w-[600px] flex-col">
+			<div className="flex gap-1">
+				<button
+					type="button"
+					data-testid="grow-above"
+					onClick={() => mutate({ 5: 300 })}
+				>
+					grow-above
+				</button>
+				<button
+					type="button"
+					data-testid="zero-net"
+					onClick={() => mutate({ 5: 200, 35: 0 })}
+				>
+					zero-net
+				</button>
+			</div>
+			<div
+				ref={scrollerRef}
+				data-testid="scroll-container"
+				className="flex min-h-0 flex-1 flex-col overflow-y-auto [overflow-anchor:none]"
+			>
+				<div ref={contentRef} className="flex flex-col">
+					<div data-virtual-spacer="" style={{ height: SPACER_HEIGHT }} />
+					{Array.from({ length: ROWS }, (_, i) => (
+						<div
+							key={i}
+							data-chat-item=""
+							data-chat-item-id={`row-${i}`}
+							data-testid={`row-${i}`}
+							style={{ height: heights[i] ?? ROW_HEIGHT }}
+						>
+							row {i}
+						</div>
+					))}
+				</div>
+			</div>
+		</div>
+	);
+};
+
+const meta: Meta<typeof AnchorHarness> = {
+	title: "pages/AgentsPage/ChatVirtualList/useScrollAnchor",
+	component: AnchorHarness,
+};
+export default meta;
+
+type Story = StoryObj<typeof AnchorHarness>;
+
+const offsetFromTop = (scroller: HTMLElement, el: HTMLElement): number =>
+	el.getBoundingClientRect().top - scroller.getBoundingClientRect().top;
+
+// Scroll so row 20 sits at the viewport top: spacer + 20 rows.
+const SCROLL_TO_ROW_20 = SPACER_HEIGHT + 20 * ROW_HEIGHT;
+
+export const AnchorSurvivesAboveMutation: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scroller = canvas.getByTestId("scroll-container");
+		scroller.scrollTop = SCROLL_TO_ROW_20;
+		scroller.dispatchEvent(new Event("scroll"));
+		await waitFor(() => expect(scroller.scrollTop).toBe(SCROLL_TO_ROW_20));
+		const before = offsetFromTop(scroller, canvas.getByTestId("row-20"));
+		await userEvent.click(canvas.getByTestId("grow-above"));
+		await waitFor(() =>
+			expect(
+				Math.abs(
+					offsetFromTop(scroller, canvas.getByTestId("row-20")) - before,
+				),
+			).toBeLessThanOrEqual(2),
+		);
+	},
+};
+
+export const AnchorSurvivesZeroNetMutation: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scroller = canvas.getByTestId("scroll-container");
+		scroller.scrollTop = SCROLL_TO_ROW_20;
+		scroller.dispatchEvent(new Event("scroll"));
+		await waitFor(() => expect(scroller.scrollTop).toBe(SCROLL_TO_ROW_20));
+		const before = offsetFromTop(scroller, canvas.getByTestId("row-20"));
+		// Grows a row above the anchor and shrinks a row below it by the same
+		// amount: total height is unchanged, so a content ResizeObserver never
+		// fires, yet the anchor moved. Only capture/restore corrects this.
+		await userEvent.click(canvas.getByTestId("zero-net"));
+		await waitFor(() =>
+			expect(
+				Math.abs(
+					offsetFromTop(scroller, canvas.getByTestId("row-20")) - before,
+				),
+			).toBeLessThanOrEqual(2),
+		);
+	},
+};

--- a/site/src/pages/AgentsPage/components/ChatVirtualList/useScrollAnchor.ts
+++ b/site/src/pages/AgentsPage/components/ChatVirtualList/useScrollAnchor.ts
@@ -7,26 +7,50 @@ import {
 } from "react";
 import { correctedScrollTop, isAtBottom } from "./anchorMath";
 
-type Anchor = { el: HTMLElement; offset: number };
+// The anchor is keyed by a stable item id so it survives windowing remounts.
+// The element ref is a fast path; if it has been unmounted we re-find by id.
+type Anchor = { id: string | null; el: HTMLElement; offset: number };
 
-// findTopAnchor returns the first child intersecting the viewport top, together
-// with its current offset from the scroller top. That child is what we keep
-// fixed when content above it changes height.
+const ITEM_SELECTOR = "[data-chat-item]";
+
+// findTopAnchor returns the first rendered item intersecting the viewport top.
+// Spacers and other non-item children are ignored so the anchor is always a
+// real element whose offset we can preserve.
 function findTopAnchor(
 	scroller: HTMLElement,
 	content: HTMLElement,
 ): Anchor | null {
 	const scrollerTop = scroller.getBoundingClientRect().top;
-	for (const child of content.children) {
+	for (const child of content.querySelectorAll(ITEM_SELECTOR)) {
 		if (!(child instanceof HTMLElement)) {
 			continue;
 		}
 		const rect = child.getBoundingClientRect();
 		if (rect.bottom > scrollerTop) {
-			return { el: child, offset: rect.top - scrollerTop };
+			return {
+				id: child.getAttribute("data-chat-item-id"),
+				el: child,
+				offset: rect.top - scrollerTop,
+			};
 		}
 	}
 	return null;
+}
+
+function resolveAnchorElement(
+	content: HTMLElement,
+	anchor: Anchor,
+): HTMLElement | null {
+	if (anchor.el.isConnected) {
+		return anchor.el;
+	}
+	if (anchor.id == null) {
+		return null;
+	}
+	const found = content.querySelector(
+		`[data-chat-item-id="${CSS.escape(anchor.id)}"]`,
+	);
+	return found instanceof HTMLElement ? found : null;
 }
 
 type ScrollAnchor = {
@@ -34,7 +58,14 @@ type ScrollAnchor = {
 	contentRef: RefObject<HTMLDivElement | null>;
 	atBottom: boolean;
 	scrollToBottom: () => void;
-	maintainPin: () => void;
+	// captureAnchor records the item currently at the viewport top. Callers run
+	// it after every committed render so the anchor always reflects the latest
+	// settled layout.
+	captureAnchor: () => void;
+	// restoreAnchor re-pins to the bottom when sticky, otherwise moves the
+	// captured anchor element back to its recorded viewport offset. It is the
+	// single owner of scrollTop correction and is idempotent.
+	restoreAnchor: () => void;
 };
 
 export function useScrollAnchor(): ScrollAnchor {
@@ -55,14 +86,42 @@ export function useScrollAnchor(): ScrollAnchor {
 		setAtBottom(true);
 	}, []);
 
-	// maintainPin keeps the viewport pinned to the bottom while the user has not
-	// scrolled away. Callers run this in a layout effect on content changes so
-	// new messages pin synchronously, independent of ResizeObserver timing.
-	const maintainPin = useCallback(() => {
+	const captureAnchor = useCallback(() => {
 		const scroller = scrollerRef.current;
-		if (scroller && stickRef.current) {
-			scroller.scrollTop = scroller.scrollHeight;
+		const content = contentRef.current;
+		if (!scroller || !content) {
+			return;
 		}
+		anchorRef.current = stickRef.current
+			? null
+			: findTopAnchor(scroller, content);
+	}, []);
+
+	const restoreAnchor = useCallback(() => {
+		const scroller = scrollerRef.current;
+		const content = contentRef.current;
+		if (!scroller || !content) {
+			return;
+		}
+		if (stickRef.current) {
+			scroller.scrollTop = scroller.scrollHeight;
+			return;
+		}
+		const anchor = anchorRef.current;
+		if (!anchor) {
+			return;
+		}
+		const el = resolveAnchorElement(content, anchor);
+		if (!el) {
+			return;
+		}
+		const offset =
+			el.getBoundingClientRect().top - scroller.getBoundingClientRect().top;
+		scroller.scrollTop = correctedScrollTop(
+			scroller.scrollTop,
+			anchor.offset,
+			offset,
+		);
 	}, []);
 
 	useEffect(() => {
@@ -76,10 +135,8 @@ export function useScrollAnchor(): ScrollAnchor {
 		const onScroll = () => {
 			const scrollTop = scroller.scrollTop;
 			// A real user scroll always moves scrollTop. Layout-induced scroll
-			// events keep the same scrollTop, so processing them would recapture
-			// the anchor against an already-mutated layout and make the resize
-			// correction a no-op. Our own correction does move scrollTop, so it
-			// still re-establishes a fresh anchor afterward.
+			// events keep the same scrollTop; ignoring them avoids flipping the
+			// stick state when our own correction nudges the position.
 			if (scrollTop === lastScrollTopRef.current) {
 				return;
 			}
@@ -90,7 +147,6 @@ export function useScrollAnchor(): ScrollAnchor {
 				scroller.clientHeight,
 			);
 			stickRef.current = bottom;
-			anchorRef.current = bottom ? null : findTopAnchor(scroller, content);
 			if (frame) {
 				return;
 			}
@@ -100,26 +156,12 @@ export function useScrollAnchor(): ScrollAnchor {
 			});
 		};
 
-		// ResizeObserver notifications run between layout and paint, so correcting
-		// scrollTop here keeps the viewport stable without a visible jump. Safari
-		// has no native scroll anchoring, which is why we must do this ourselves.
+		// The ResizeObserver is a fallback trigger for async intrinsic growth
+		// (streaming markdown, image load, late highlight) that happens without a
+		// React render. Windowing, measurement, and prepend are driven explicitly
+		// by the container's layout effect instead.
 		const resize = new ResizeObserver(() => {
-			if (stickRef.current) {
-				scroller.scrollTop = scroller.scrollHeight;
-				return;
-			}
-			const anchor = anchorRef.current;
-			if (!anchor) {
-				return;
-			}
-			const offset =
-				anchor.el.getBoundingClientRect().top -
-				scroller.getBoundingClientRect().top;
-			scroller.scrollTop = correctedScrollTop(
-				scroller.scrollTop,
-				anchor.offset,
-				offset,
-			);
+			restoreAnchor();
 		});
 
 		scroller.addEventListener("scroll", onScroll, { passive: true });
@@ -131,7 +173,14 @@ export function useScrollAnchor(): ScrollAnchor {
 				cancelAnimationFrame(frame);
 			}
 		};
-	}, []);
+	}, [restoreAnchor]);
 
-	return { scrollerRef, contentRef, atBottom, scrollToBottom, maintainPin };
+	return {
+		scrollerRef,
+		contentRef,
+		atBottom,
+		scrollToBottom,
+		captureAnchor,
+		restoreAnchor,
+	};
 }

--- a/site/src/pages/AgentsPage/components/ChatVirtualList/useScrollAnchor.ts
+++ b/site/src/pages/AgentsPage/components/ChatVirtualList/useScrollAnchor.ts
@@ -9,7 +9,10 @@ import { correctedScrollTop, isAtBottom } from "./anchorMath";
 
 // The anchor is keyed by a stable item id so it survives windowing remounts.
 // The element ref is a fast path; if it has been unmounted we re-find by id.
-type Anchor = { id: string | null; el: HTMLElement; offset: number };
+// contentTop is the anchor's position in scroll content coordinates
+// (scrollTop + viewport offset) at capture; comparing it to the current content
+// position isolates content-height changes from any scroll that happened since.
+type Anchor = { id: string | null; el: HTMLElement; contentTop: number };
 
 const ITEM_SELECTOR = "[data-chat-item]";
 
@@ -30,7 +33,7 @@ function findTopAnchor(
 			return {
 				id: child.getAttribute("data-chat-item-id"),
 				el: child,
-				offset: rect.top - scrollerTop,
+				contentTop: scroller.scrollTop + (rect.top - scrollerTop),
 			};
 		}
 	}
@@ -115,13 +118,20 @@ export function useScrollAnchor(): ScrollAnchor {
 		if (!el) {
 			return;
 		}
-		const offset =
-			el.getBoundingClientRect().top - scroller.getBoundingClientRect().top;
+		const currentContentTop =
+			scroller.scrollTop +
+			(el.getBoundingClientRect().top - scroller.getBoundingClientRect().top);
 		scroller.scrollTop = correctedScrollTop(
 			scroller.scrollTop,
-			anchor.offset,
-			offset,
+			anchor.contentTop,
+			currentContentTop,
 		);
+		// Re-baseline to the anchor's current content position so a second restore
+		// for the same change (the content ResizeObserver, a repeated effect, a
+		// StrictMode double invoke) computes a zero delta and stays a no-op.
+		// Scrolling does not move an element's content position, so this never
+		// suppresses a later correction.
+		anchor.contentTop = currentContentTop;
 	}, []);
 
 	useEffect(() => {

--- a/site/src/pages/AgentsPage/components/ChatVirtualList/useScrollAnchor.ts
+++ b/site/src/pages/AgentsPage/components/ChatVirtualList/useScrollAnchor.ts
@@ -1,0 +1,137 @@
+import {
+	type RefObject,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
+import { correctedScrollTop, isAtBottom } from "./anchorMath";
+
+type Anchor = { el: HTMLElement; offset: number };
+
+// findTopAnchor returns the first child intersecting the viewport top, together
+// with its current offset from the scroller top. That child is what we keep
+// fixed when content above it changes height.
+function findTopAnchor(
+	scroller: HTMLElement,
+	content: HTMLElement,
+): Anchor | null {
+	const scrollerTop = scroller.getBoundingClientRect().top;
+	for (const child of content.children) {
+		if (!(child instanceof HTMLElement)) {
+			continue;
+		}
+		const rect = child.getBoundingClientRect();
+		if (rect.bottom > scrollerTop) {
+			return { el: child, offset: rect.top - scrollerTop };
+		}
+	}
+	return null;
+}
+
+type ScrollAnchor = {
+	scrollerRef: RefObject<HTMLDivElement | null>;
+	contentRef: RefObject<HTMLDivElement | null>;
+	atBottom: boolean;
+	scrollToBottom: () => void;
+	maintainPin: () => void;
+};
+
+export function useScrollAnchor(): ScrollAnchor {
+	const scrollerRef = useRef<HTMLDivElement | null>(null);
+	const contentRef = useRef<HTMLDivElement | null>(null);
+	const anchorRef = useRef<Anchor | null>(null);
+	const stickRef = useRef(true);
+	const lastScrollTopRef = useRef(-1);
+	const [atBottom, setAtBottom] = useState(true);
+
+	const scrollToBottom = useCallback(() => {
+		const scroller = scrollerRef.current;
+		if (!scroller) {
+			return;
+		}
+		scroller.scrollTop = scroller.scrollHeight;
+		stickRef.current = true;
+		setAtBottom(true);
+	}, []);
+
+	// maintainPin keeps the viewport pinned to the bottom while the user has not
+	// scrolled away. Callers run this in a layout effect on content changes so
+	// new messages pin synchronously, independent of ResizeObserver timing.
+	const maintainPin = useCallback(() => {
+		const scroller = scrollerRef.current;
+		if (scroller && stickRef.current) {
+			scroller.scrollTop = scroller.scrollHeight;
+		}
+	}, []);
+
+	useEffect(() => {
+		const scroller = scrollerRef.current;
+		const content = contentRef.current;
+		if (!scroller || !content) {
+			return;
+		}
+
+		let frame = 0;
+		const onScroll = () => {
+			const scrollTop = scroller.scrollTop;
+			// A real user scroll always moves scrollTop. Layout-induced scroll
+			// events keep the same scrollTop, so processing them would recapture
+			// the anchor against an already-mutated layout and make the resize
+			// correction a no-op. Our own correction does move scrollTop, so it
+			// still re-establishes a fresh anchor afterward.
+			if (scrollTop === lastScrollTopRef.current) {
+				return;
+			}
+			lastScrollTopRef.current = scrollTop;
+			const bottom = isAtBottom(
+				scrollTop,
+				scroller.scrollHeight,
+				scroller.clientHeight,
+			);
+			stickRef.current = bottom;
+			anchorRef.current = bottom ? null : findTopAnchor(scroller, content);
+			if (frame) {
+				return;
+			}
+			frame = requestAnimationFrame(() => {
+				frame = 0;
+				setAtBottom(bottom);
+			});
+		};
+
+		// ResizeObserver notifications run between layout and paint, so correcting
+		// scrollTop here keeps the viewport stable without a visible jump. Safari
+		// has no native scroll anchoring, which is why we must do this ourselves.
+		const resize = new ResizeObserver(() => {
+			if (stickRef.current) {
+				scroller.scrollTop = scroller.scrollHeight;
+				return;
+			}
+			const anchor = anchorRef.current;
+			if (!anchor) {
+				return;
+			}
+			const offset =
+				anchor.el.getBoundingClientRect().top -
+				scroller.getBoundingClientRect().top;
+			scroller.scrollTop = correctedScrollTop(
+				scroller.scrollTop,
+				anchor.offset,
+				offset,
+			);
+		});
+
+		scroller.addEventListener("scroll", onScroll, { passive: true });
+		resize.observe(content);
+		return () => {
+			scroller.removeEventListener("scroll", onScroll);
+			resize.disconnect();
+			if (frame) {
+				cancelAnimationFrame(frame);
+			}
+		};
+	}, []);
+
+	return { scrollerRef, contentRef, atBottom, scrollToBottom, maintainPin };
+}

--- a/site/src/pages/AgentsPage/components/ChatVirtualList/windowMath.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatVirtualList/windowMath.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { computeWindow, cumulativeOffsets } from "./windowMath";
+
+describe("cumulativeOffsets", () => {
+	it("returns N+1 offsets with the total last", () => {
+		expect(cumulativeOffsets([100, 200, 50])).toEqual([0, 100, 300, 350]);
+	});
+	it("returns [0] for an empty list", () => {
+		expect(cumulativeOffsets([])).toEqual([0]);
+	});
+});
+
+describe("computeWindow", () => {
+	const overscan = 1000;
+
+	it("renders the whole list when it fits the window", () => {
+		const offsets = cumulativeOffsets([100, 200, 50]);
+		expect(
+			computeWindow({ offsets, scrollTop: 0, viewportHeight: 1000, overscan }),
+		).toEqual({ start: 0, end: 2, topPad: 0, bottomPad: 0 });
+	});
+
+	it("windows the middle of a long list with overscan", () => {
+		// 100 items of 100px each, total 10000.
+		const offsets = cumulativeOffsets(Array.from({ length: 100 }, () => 100));
+		const win = computeWindow({
+			offsets,
+			scrollTop: 5000,
+			viewportHeight: 500,
+			overscan,
+		});
+		// windowTop = 4000, windowBottom = 6500.
+		expect(win.start).toBe(40);
+		expect(win.end).toBe(64);
+		expect(win.topPad).toBe(4000);
+		expect(win.bottomPad).toBe(10000 - 6500);
+	});
+
+	it("clamps the top: scrollTop 0 gives start 0 and no top pad", () => {
+		const offsets = cumulativeOffsets(Array.from({ length: 100 }, () => 100));
+		const win = computeWindow({
+			offsets,
+			scrollTop: 0,
+			viewportHeight: 500,
+			overscan,
+		});
+		expect(win.start).toBe(0);
+		expect(win.topPad).toBe(0);
+	});
+
+	it("clamps the bottom: at max scroll, end is last and no bottom pad", () => {
+		const offsets = cumulativeOffsets(Array.from({ length: 100 }, () => 100));
+		const win = computeWindow({
+			offsets,
+			scrollTop: 10000 - 500,
+			viewportHeight: 500,
+			overscan,
+		});
+		expect(win.end).toBe(99);
+		expect(win.bottomPad).toBe(0);
+	});
+
+	it("returns an empty window for an empty list", () => {
+		expect(
+			computeWindow({
+				offsets: [0],
+				scrollTop: 0,
+				viewportHeight: 500,
+				overscan,
+			}),
+		).toEqual({ start: 0, end: -1, topPad: 0, bottomPad: 0 });
+	});
+});

--- a/site/src/pages/AgentsPage/components/ChatVirtualList/windowMath.ts
+++ b/site/src/pages/AgentsPage/components/ChatVirtualList/windowMath.ts
@@ -1,0 +1,66 @@
+// Pure layout math for the windowing renderer. Kept free of DOM and React so it
+// can be unit tested and reused by the container without re-rendering.
+
+// cumulativeOffsets returns N+1 entries: the running top offset of each item,
+// with the final entry holding the total height.
+export function cumulativeOffsets(heights: readonly number[]): number[] {
+	const offsets = new Array<number>(heights.length + 1);
+	offsets[0] = 0;
+	for (let i = 0; i < heights.length; i++) {
+		offsets[i + 1] = offsets[i] + heights[i];
+	}
+	return offsets;
+}
+
+type WindowInput = {
+	offsets: readonly number[];
+	scrollTop: number;
+	viewportHeight: number;
+	overscan: number;
+};
+
+type Window = {
+	start: number;
+	end: number;
+	topPad: number;
+	bottomPad: number;
+};
+
+// computeWindow returns the inclusive [start, end] item range to render plus the
+// spacer heights that reserve the unrendered ranges. The range covers the
+// viewport expanded by `overscan` on each side. An empty list yields an empty
+// range (end = -1) and zero pads.
+export function computeWindow({
+	offsets,
+	scrollTop,
+	viewportHeight,
+	overscan,
+}: WindowInput): Window {
+	const count = offsets.length - 1;
+	const total = offsets[count];
+	if (count <= 0) {
+		return { start: 0, end: -1, topPad: 0, bottomPad: 0 };
+	}
+
+	const windowTop = scrollTop - overscan;
+	const windowBottom = scrollTop + viewportHeight + overscan;
+
+	// First item whose bottom edge is past the window top.
+	let start = 0;
+	while (start < count - 1 && offsets[start + 1] <= windowTop) {
+		start++;
+	}
+
+	// Last item whose top edge is before the window bottom.
+	let end = start;
+	while (end < count - 1 && offsets[end + 1] < windowBottom) {
+		end++;
+	}
+
+	return {
+		start,
+		end,
+		topPad: offsets[start],
+		bottomPad: total - offsets[end + 1],
+	};
+}


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

New browser-agnostic virtualized scroll container for the agent chat timeline (`ChatVirtualList`), recreating the `@pierre/diffs` windowing techniques so the reading position stays stable in Safari, which has no native scroll anchoring. **Not wired into the app**; validated entirely by Storybook stories and unit tests. The cutover to `AgentChatPageView` is a later phase.

What's here:

- **True windowing** (react-virtuoso style): renders only the items within the viewport plus a 1000px overscan, reserves the rest with top/bottom spacers sized from a per-id measured height cache, and recycles offscreen items. DOM node count stays bounded regardless of transcript length.
- **Capture/restore scroll anchor**: a single layout effect owns `scrollTop`. It keeps the top-of-viewport item fixed when content above it changes height (history prepend, streaming growth, estimate-to-measured reconciliation) and pins to the bottom while the user is at the bottom. `overflow-anchor: none` keeps Chromium from double-correcting.
- **Mid-scroll stability fix**: the anchor tracks content position (`scrollTop + offset`) rather than viewport offset, so a scroll that happens between capture and restore is no longer mistaken for a content shift. This is the cause of the reported Safari "snaps back when scrolled up" behavior: an item entering the window measures and triggers a restore after the user has already scrolled, and the old offset-delta formula read against a stale position. Restore is now idempotent.
- **Streaming stays still while scrolled up**: a streaming reply grows the newest item token by token. Only an id's first measurement feeds the per-kind height average; a later re-measurement updates just that id's height. Folding every re-measurement into the average drifted the estimate of never-measured items above the viewport and nudged the reading position, worse in Safari, which rounds `scrollTop` to integer device pixels. The reading position now holds steady through a stream.

Testing: 16 Storybook interaction stories in real Chromium (windowing, stick-to-bottom, no-jump on prepend / streaming / wrong estimates, recycling, a scroll-between-capture-and-restore regression, and a stays-still-while-streaming regression) and 21 unit tests for the window math, height cache, and anchor math. `pnpm lint` and `pnpm format` are clean. CI cannot run WebKit; the anchor and streaming stories were additionally verified by hand against a real WebKit build, but the full Safari and iOS matrix is still a manual gate before the cutover.

Out of scope (later phases): native sticky rewrite, mobile-Safari fling clamp, and the cutover that deletes `ChatScrollContainer` and the sticky overlay.

<details><summary>Design</summary>

# Design: Pierre-style virtualized chat scroll container

Date: 2026-05-30
Status: Approved. Option A (reuse `Virtualizer`, no paged scaffold).
Superseded in part by the Phase 2 update below (true windowing, `items`/
`renderItem` API, capture/restore anchor).
Stacks on: coder/coder#25879 (`chore(site): upgrade @pierre/diffs` to 1.2.4)

## Phase 2 update (implemented): true windowing + capture/restore anchor

Status: implemented on `feat/chat-virtual-list-phase1`, validated by Storybook
and unit tests, not wired into the app. This section supersedes the
`Virtualizer`-reuse decision (the Status line, "Reuse boundary", and "Paged
scaffold"), the per-message `IntersectionObserver` mounting in "Architecture"
and "Decomposition" step 2, and the `ResizeObserver`-only anchor in
"Architecture".

What changed and why:

- True windowing, not `Virtualizer` reuse. After verifying `@pierre/diffs`
  1.2.4 does real windowing (`Virtualizer.ts`: `overscrollSize = 1000`,
  `createWindowFromScrollPosition`, DOM element pooling), we recreate that
  model directly instead of reusing its imperative class. `ChatVirtualList`
  renders only the items whose computed offsets fall within the viewport plus a
  1000px overscan; offscreen items leave the DOM and their space is reserved by
  top and bottom spacers sized from a per-id measured height cache.
- Central index-range windowing (react-virtuoso style), not per-message
  `IntersectionObserver`. The container computes one `{ start, end, topPad,
  bottomPad }` from cumulative offsets (`windowMath.ts`) over a height cache
  (`heightCache.ts`). The rendered range is a pure function of `scrollTop`,
  `viewportHeight`, and measured heights, so there are no N per-item observers.
  The `LazyFileDiff` per-item observer pattern is not used for the outer list.
- `items`/`renderItem` API, so the cutover is not a drop-in. The public props
  are `items: ReadonlyArray<{ id; kind }>` and `renderItem(item)`, not
  `children`. Phase 5 adapts `AgentChatPageView` to map messages to `items` and
  render each through `renderItem`, rather than wrapping existing children
  unchanged.
- A capture/restore anchor owns `scrollTop`; the content `ResizeObserver` is a
  fallback only. The anchor records the real top-of-viewport item (by stable
  id, skipping spacers) and restores its offset after layout-affecting commits.
  One layout effect classifies each commit by diffing its inputs against the
  previous commit: a content change (items, measured heights, or viewport)
  restores then re-captures; a pure scroll only re-captures. This catches
  zero-net height changes that a total-height `ResizeObserver` misses, so the RO
  is kept only as a fallback trigger for async intrinsic growth.

Modules: `windowMath.ts` (pure offsets and window), `heightCache.ts` (per-id
map plus per-kind running average), `useScrollAnchor.ts` (capture/restore,
stick-to-bottom, scroll tracking), `ChatVirtualList.tsx` (windowing renderer
and the `MeasuredItem` wrapper), `anchorMath.ts` (unchanged from Phase 1).
Later phases still cover the native sticky rewrite, the mobile-Safari fling
clamp, and the cutover itself.

## Problem statement

The agent chat timeline (`site/src/pages/AgentsPage`) jumps and stutters,
worst of all in Safari. Two root causes, confirmed by reading both codebases:

1. The container delegates scroll stability to the browser. It uses a flex
   `column-reverse` scroller with `react-infinite-scroll-component` in
   `inverse` mode, where "stick to bottom" is just `scrollTop = 0`
   (`ChatScrollContainer.tsx:120-173`). On Chromium/Gecko, native scroll
   anchoring silently compensates when content above the viewport changes
   height. Safari implements no scroll anchoring on any version, so every
   above-viewport height change shoves the viewport.

2. The whole transcript is mounted at once (no virtualization;
   `ChatPageContent.tsx:86-143`, `ConversationTimeline.tsx:1237-1299`), and
   much of it changes height after mount: streamed tokens reveal
   incrementally, reasoning blocks grow, tool/process/subagent panels expand,
   and `@pierre/diffs` code/diff blocks highlight asynchronously through the
   worker. Each of those is a jump on Safari and a relayout cost everywhere.

The sticky user-message system is independently fragile. It renders a
duplicated overlay copy of `ChatMessageItem` on top of the real opacity-0
node, driven per message by an `IntersectionObserver` + scroll listener +
window-resize + `ResizeObserver`, with `nextElementSibling` sentinel traversal
for the push-up effect, all coupled to the reversed-flex layout, a
`.overflow-y-auto` class lookup, and `react-infinite-scroll-component` wrapper
divs (`ConversationTimeline.tsx:769-1078`). Comments in `AgentChatPage.tsx:242`
and `chats.ts:1323` document real bugs it has caused.

## Goals

- One browser-agnostic chat container that owns scroll stability outright, so
  Safari behaves identically to Chromium/Gecko.
- Virtualize the message list so only near-viewport messages mount.
- Recreate the CodeView techniques on top of the reused primitive so we get
  every benefit: owned anchor capture/restore, estimate to measure to
  reconcile heights, append-only fast path, mobile-Safari fling clamp, CSS
  containment, and a paged scroll scaffold seam.
- Replace the sticky overlay with Pierre's native-sticky approach, preserving
  every current sticky, edit, and navigation behavior.

## Non-goals (confirmed)

- Not rewriting leaf renderers (`Response`/Streamdown, `Tool` cards,
  `File`/`FileDiff`, attachments). They are re-hosted unchanged.
- Not changing the streaming/smoothing pipeline (`LiveStreamTail`,
  `StreamingOutput`, `SmoothText`); it is hosted as the trailing item.
- Not changing the edit composer or the chat store; their contracts are
  preserved.
- Not changing diff/markdown rendering behavior beyond the `@pierre/diffs`
  upgrade already in #25879.

## Reuse boundary

Reuse, do not reimplement:

- The `LazyFileDiff` windowing pattern (local `IntersectionObserver` plus an
  estimated placeholder height, `DiffViewer.tsx:457-505`) for mounting
  messages near the viewport. We reuse this pattern, not the `Virtualizer`
  class, for the outer message list, because `Virtualizer`'s windowing
  contract is imperative (`onRender` writes DOM synchronously,
  `VirtualizedFile.ts:238-246`) and its `scrollFix` anchor only compensates
  for its own in-cycle changes, not React content growth
  (`Virtualizer.ts:351-369`).
- The existing `@pierre/diffs` worker pool (`DiffsWorkerPoolProvider.tsx`),
  the leaf `File`/`FileDiff` renderers, and Pierre's native-sticky technique
  (each header is `position: sticky` under one shared sticky container).

Recreate ourselves (Pierre techniques, implemented for React messages):

- The CodeView anchor (capture before change, restore after,
  `CodeView.ts:1296`), implemented as a `ResizeObserver` hook that keeps the
  top-of-viewport message at a fixed offset when content above it changes
  height. This is the core Safari fix and must be ours: neither `Virtualizer`
  nor native scroll anchoring (absent in Safari) provides it.
- Stick-to-bottom, top pagination, the estimate to measure to reconcile
  height model, the native sticky scaffold, and the mobile-Safari fling
  clamp.

Dropped:

- The paged scroll scaffold. It is incompatible with reusing `Virtualizer`
  (its `scrollFix` reads and writes the real scroll element directly, which a
  logical/physical decoupling would fight), and a chat transcript never
  approaches the browser scroll-height ceiling.

`CodeView` itself is not usable here: its items are `CodeViewFileItem |
CodeViewDiffItem` only (`types.ts:499-501`) and its render hooks are
code-specific, so it cannot host markdown, tool cards, or images.

## Architecture

Drop the reversed-flex + InfiniteScroll design. Use a normal top-to-bottom
scroller (newest at the bottom), matching how CodeView actually works. The
container owns what the browser used to do implicitly:

- Stick-to-bottom: stay pinned at maximum scroll while the user is at the
  bottom, measured explicitly rather than via the `scrollTop = 0` reversed
  trick. Do not yank the viewport when the user has scrolled up.
- Anchor preservation: a `ResizeObserver` on the content watches for height
  changes; when the user is not at the bottom it keeps the top-of-viewport
  message pinned by correcting `scrollTop` by the measured offset delta, so
  above-viewport growth, history prepend, and measured-height correction do
  not move the viewport. `overflow-anchor: none` on the scroller stops
  Chromium native anchoring from double-correcting; Safari has none to begin
  with, which is why we own this.
- Load-older-at-top: replace InfiniteScroll's near-top trigger; keep the
  `before_id`, 50-per-page pagination (`chats.ts:617-633`).

Element structure:

```
scroller  (overflow-y-auto; overflow-anchor: none; contain: layout style)
└─ Virtualizer content
   ├─ load-older sentinel (top)
   ├─ stickyOffset spacer  (height = paged stickyTop)
   └─ sharedStickyContainer (contain: layout style; isolation: isolate; flex column)
      ├─ VirtualMessage (assistant)  placeholder | real
      ├─ VirtualMessage (user)       position: sticky; top: 8px
      ├─ ...
      └─ LiveStreamTail              always mounted, measured live
```

Each message is a `VirtualMessage` wrapper that lazy-mounts via a local
`IntersectionObserver` (the `LazyFileDiff` pattern, a placeholder with
reserved estimated height when offscreen), measures real height on mount with
`ResizeObserver`, caches by stable message id, and reconciles deltas. User
messages are the native `position: sticky` element directly; there is no
overlay copy.

## Sticky: native, no overlay

Copy Pierre's mechanism: each sticky message is native `position: sticky;
top: STICKY_TOP`; all rendered messages live under one shared sticky container
preceded by a `stickyOffset` spacer; the browser decides which message is
stuck and animates the stacked-header push handoff. We keep the current visual
contract on the real node (no clone):

- User messages only are sticky; assistant messages are not.
- One active pinned prompt; the next user message pushes it up natively.
- Compression to `MIN_HEIGHT = 72px` with a fade over `FADE_RANGE = 40px`,
  driven by CSS variables updated by a single container-level rAF-throttled
  scroll/resize handler (not per-message observers).
- Tall prompts opt out: messages taller than 75% of the scroller stay in flow.

### Sticky retention rule (the critical virtualization interaction)

Native sticky needs the element present in the scroll container to stay
pinned. A short user prompt followed by a long response can have its natural
position scrolled fully above the rendered window while it is still the pinned
prompt. Rule: always keep mounted the most recent user message whose natural
top is at or above the scroller top (the active sticky), regardless of window
intersection, until the next user message takes over. This generalizes
Pierre's "keep the owning item rendered while it intersects the window," which
holds for tall files but not for short pinned prompts.

## Height estimation

Messages have no metadata-derived height, so adapt the estimate-then-measure
model:

- Per-id measured cache keyed by stable message id.
- Unknown items estimated by a type-aware running average (user / assistant /
  tool / diff), seeded with sensible defaults.
- The streaming tail is never estimated; it is always mounted and measured
  live, which is fine because it sits where the user already is.
- Reconcile measured deltas via `ResizeObserver`; if a delta is above the
  anchor, restore scroll from the captured anchor so reading position never
  shifts.

## CodeView technique inventory

| Technique | Source | Plan |
|---|---|---|
| top-anchor scroll preservation | own `ResizeObserver` anchor (copies CodeView capture/restore) | Recreate; `overflow-anchor: none` so Chromium does not double-correct |
| list windowing (lazy mount) | `LazyFileDiff` pattern (local IO + placeholder) | Reuse the pattern, not the `Virtualizer` class |
| estimate to measure to reconcile | CodeView only | Recreate in `VirtualMessage` (id cache + type average) |
| append-only fast path | CodeView only | Recreate via stable keys; never re-estimate known items |
| native sticky scaffold | CodeView only | Recreate (shared sticky container + stickyOffset + bounds sync) |
| mobile-Safari fling overflow clamp | CodeView | Port `suspendScrollInteractions`; messages contain horizontally scrollable code/diffs |
| paged scroll scaffold (12M px) | CodeView only | Dropped: incompatible with Virtualizer reuse; chat never reaches the scroll-height ceiling |
| worker highlight + scroll-target priming | already shipped | Prime highlight on jump-to-message so the target paints highlighted |
| CSS containment + overscan | both | Containment on wrappers; overscan already 1000px |

## Paged scaffold: dropped

Removed from scope. The scaffold decouples logical from physical scroll, but
Virtualizer's `scrollFix` reads and writes the real scroll element directly,
so the two cannot coexist without forking Virtualizer. A chat transcript would
need tens of thousands of tall messages to approach the browser scroll-height
ceiling, so the capability is not worth a fork. If that ever changes, the
fallback is Option B (fork the CodeView container), recorded under Rejected
alternatives.

## Rollout (no feature flag)

The team does not use feature flags here, so this is a proven cutover:

- Land the new container and its hooks/utilities as new, unreferenced modules
  in a stacked PR series on top of #25879, each fully covered by Storybook
  stories and unit tests. Unreferenced code is not a runtime flag.
- A final cutover PR switches `AgentChatPageView` to the new container and
  deletes the old `ChatScrollContainer`, the `StickyUserMessage` overlay,
  sentinel traversal, and the chat's use of `react-infinite-scroll-component`.
- Parity is gated by Storybook stories and a manual Safari/iOS matrix before
  the cutover PR merges, since CI cannot run WebKit.

## Decomposition (build order)

0. Spike (done): confirmed `Virtualizer` (1.2.4) exposes child windowing via
   `connect` plus an internal top-anchor `scrollFix`, with no public scroll
   APIs and no paged scaffold. Reuse boundary set to Option A. The remaining
   empirical check, anchor stability over React message boxes, is the first
   gate in Plan 1.
1. Walking skeleton (this plan): new container with our own `ResizeObserver`
   anchor, stick-to-bottom, and top pagination in a normal top-to-bottom
   flow, validated by Storybook stories and not wired into the app. No sticky
   and no lazy mounting yet (all messages mounted). Removes most Safari jank.
2. `VirtualMessage`: local-`IntersectionObserver` lazy mounting (the
   `LazyFileDiff` pattern) with estimated placeholder heights and a measured
   height cache.
3. Sticky rewrite: native sticky + shared container + retention rule;
   delete overlay, sentinels, and per-message observers; preserve pin,
   compression, fade, tall opt-out, edit, and navigation.
4. Mobile-Safari fling clamp + containment polish.
5. Cutover PR: wire it in, delete the old machinery.

## Files likely to change

New: the container (working name `ChatVirtualList`), `VirtualMessage`,
`useStickToBottom`/`useScrollAnchor` hooks, sticky-scaffold module,
height-cache/estimate util, paged-scaffold util, mobile-Safari fling util.

Replace or gut: `ChatScrollContainer.tsx`; the sticky machinery in
`ConversationTimeline.tsx` (overlay, sentinels, observers); the overlay-only
fade path in `UserMessageContent.tsx` (repurposed to compress the real node).

Touch (contracts preserved): `AgentChatPageView.tsx` (wire container),
`ChatPageContent.tsx` (host tail), `AgentChatPage.tsx` (scroll refs, edit
scroll, wait-for-mutation), `AgentChatInput.tsx` / `ChatMessageInput.tsx`
(edit focus), and the relevant stories.

Dependency: confirm `react-infinite-scroll-component` has no other consumer
before removing it; otherwise drop only the chat usage.

## Rejected alternatives

- Use `CodeView` directly: items are file/diff only; cannot host messages.
- Full from-scratch CodeView port: thousands of lines of WebKit-quirk code to
  fork and maintain; rejected in favor of reuse plus targeted recreation.
- `use-stick-to-bottom` alone: gives anchor and Safari safety but no
  virtualization and no sticky scaffold; insufficient for the stated goals.
- Keep reversed-flex and add `overflow-anchor`: Safari does not support it, so
  it does not solve the actual problem.
- Feature-flagged parallel rollout: the team does not use flags here.

## Edge cases

- History prepend at top without viewport jump (anchor restore).
- Streaming growth above the viewport without jump (anchor restore).
- Stick-to-bottom engages only when already at the bottom.
- Sticky retention rule when the active prompt scrolls above the window.
- Native handoff between consecutive sticky prompts.
- Tall prompt opt-out (> 75% of scroller).
- Compression/fade computed on the real node (no overlay) at the container
  level.
- Edit flow: scroll the edited message to the top, fade messages after the
  edit point, wait for mutation resolution before scroll-to-bottom, composer
  remount and focus.
- Navigation arrows: prime highlight then `scrollIntoView({ block: "start" })`;
  disabled endpoints; exact existing aria labels.
- `prefers-reduced-motion`: no spring smooth-scroll.
- Container resize: re-measure and re-anchor.
- Initial mount scrolled to the bottom.

## Verification plan

- Storybook stories with `play` functions (Coder convention; no standalone RTL
  files for components): stick-to-bottom during streaming; no jump on
  above-viewport growth; no jump on history prepend; sticky pin, handoff,
  compression, and tall opt-out; full edit flow; prev/next navigation; and a
  virtualization assertion that only near-viewport messages mount. Extend the
  existing `AgentChatPageView.stories` and `ConversationTimeline.stories`.
- Vitest unit tests for pure logic only: height cache and estimator, anchor
  math, paged-rebase math.
- Manual Safari and iOS WebKit matrix, documented in the PR, covering
  streaming, prepend, sticky handoff, and fling.
- Performance check: a synthetic 1,000-message transcript mounts only the
  near-viewport window.

## Resolved decisions

1. Approach: Option A, reuse `Virtualizer`, drop the paged scaffold.
2. Branch: stack on `chore/upgrade-pierre-diffs`; rebase when #25879 merges.
3. No feature flag; cut over once Storybook parity and the manual WebKit
   matrix pass.
4. `react-infinite-scroll-component` is imported only by the chat
   (`ChatScrollContainer.tsx`), so it is removed at cutover.
5. This design doc lives as a PR-body artifact unless relocated on request.

</details>

<details><summary>Implementation plan (Phase 2)</summary>

# Chat Scroll Container, Phase 2: VirtualMessage windowing (Flavor B)

> For agentic workers: use `executing-plans` for inline execution. Track steps
> with checkbox syntax. Builds on the committed Phase 1 walking skeleton
> (`feat/chat-virtual-list-phase1`, commit `e5daef492c`). Phase 1 plan archived
> as `...-phase1-DONE.md`.

> **Progress (current):** Tasks 1 to 6 complete. Task 7 steps 1 to 3 complete
> (33 tests pass: 19 unit + 14 storybook, stable across repeated runs;
> `pnpm lint:types`, `pnpm lint`, and `pnpm format` clean; isolation grep finds
> no external references; `DESIGN-chat-scroll-container.md` updated with the
> Phase 2 addendum). Task 7 step 4 (commit) is pending explicit confirmation;
> no push without confirmation.

**Goal:** Convert `ChatVirtualList` into a true index-range virtualizer
(Flavor B, react-virtuoso style) matching how `@pierre/diffs` windows: render
only the items whose computed position falls within the viewport plus a 1000px
overscan, with top and bottom spacers reserving the height of the unrendered
ranges from a per-id measured height cache. Validated by Storybook; not wired
into the app.

## What `@pierre/diffs` does (verified) and what we copy

- True windowing: renders only items within `overscrollSize = 1000px` of the
  viewport and recycles offscreen shells (`Virtualizer.ts:22`,
  `createWindowFromScrollPosition`; `test/CodeView.elementPooling.test.ts`
  shows only the in-window file renders, reusing one DOM element after scroll).
- A capture/restore scroll anchor (`scrollFix`, `Virtualizer.ts:387-431`) keeps
  a real item fixed across each render. We already have a stronger version in
  Phase 1 (`ResizeObserver`-based, catches async React growth too), so we
  extend that hook rather than adopt `scrollFix`. We do not reuse the imperative
  `Virtualizer` class.

This supersedes the design doc's mount-once decision and its
`children`-as-public-contract claim. Flavor B requires an `items`/`renderItem`
API, so the Phase 5 cutover adapts the consumer instead of being a drop-in. I
will update `DESIGN-chat-scroll-container.md` (Task 7).

## Scroll-correction architecture (decided after advisor review)

One owner of `scrollTop`: the anchor controller (the extended Phase 1 hook). The
virtualizer owns only layout modeling (range, spacers, cache, measurement) and
tells the anchor when layout may have changed. Rules that make this safe and
loop-free:

1. **Capture before, restore after.** Wrap every layout-changing state update
   (range recompute on scroll, height-cache update on measurement, items
   prepend/append) with `anchor.captureBeforeLayoutMutation()` immediately
   before the `setState`, and call `anchor.restoreAfterLayoutMutation()` in a
   `useLayoutEffect` keyed on the layout version counters. This avoids the
   snapshot-overwrite race where a post-render measurement would otherwise
   capture the already-shifted position.
2. **Correction is the anchor element's offset delta**, never a `scrollHeight`
   delta. Phase 1 already computes `scrollTop += currentOffset - savedOffset`.
   Restore is idempotent: a second trigger computes a near-zero delta, so pure
   scrolls with accurate spacers self-cancel and do not fight the user.
3. **Anchor is a real item, keyed by stable id.** `findTopAnchor` skips
   `[data-virtual-spacer]` and reads `[data-chat-item][data-chat-item-id]`. The
   first item intersecting the viewport top is always inside the rendered
   window (the window always covers the viewport), so a scroll recompute never
   unmounts the live anchor. If items change and the saved anchor is gone, fall
   back to the nearest surviving real item; never correct against a spacer.
4. **Content `ResizeObserver` stays, as a fallback trigger only** for async
   intrinsic growth of a visible item (streaming markdown, image load, late
   highlight). It triggers a restore; it does not compute the correction from
   total height.
5. `overflow-anchor: none` stays on the scroller (Phase 1) so native anchoring
   never double-corrects.

This is the react-virtuoso model: capture the real top item, mutate layout,
restore its viewport offset. It is genuinely intricate; the tasks build it
incrementally with a failing test at each step.

## Module map

```
windowMath.ts        pure: cumulativeOffsets(heights), computeWindow(...) -> {start,end,topPad,bottomPad}
heightCache.ts       pure: get(id) | estimate(id,kind) | record(id,kind,h); per-id map + type average
useScrollAnchor.ts   EXTEND: add capture/restore API, stable-id + skip-spacer anchor, keep RO as fallback
ChatVirtualList.tsx  REWRITE to items/renderItem + windowing + spacers + measured item wrappers
MeasuredItem (in ChatVirtualList or its own file): ResizeObserver -> heightCache.record -> bump cacheVersion
ChatVirtualList.stories.tsx  migrate Phase 1 stories to the items API; add windowing stories
windowMath.test.ts, heightCache.test.ts  unit tests
```

Create: `windowMath.ts`, `windowMath.test.ts`, `heightCache.ts`,
`heightCache.test.ts`. Modify: `useScrollAnchor.ts`, `ChatVirtualList.tsx`,
`ChatVirtualList.stories.tsx`. (`anchorMath.ts`/`.test.ts`,
`ScrollToBottomButton.tsx` unchanged.)

Public API:

```ts
export type MessageKind = "user" | "assistant" | "tool" | "diff" | "other";
export type VirtualItem = { id: string; kind: MessageKind };

type ChatVirtualListProps = {
	items: ReadonlyArray<VirtualItem>;
	renderItem: (item: VirtualItem) => ReactNode;
	scrollContainerRef: RefObject<HTMLDivElement | null>;
	scrollToBottomRef: RefObject<(() => void) | null>;
	isFetchingMoreMessages: boolean;
	hasMoreMessages: boolean;
	onFetchMoreMessages: () => void;
};
```

`messageCount` is dropped; `items.length` drives stick-to-bottom.

**Commands** (from `site/`, read summary text not a truncated tail):
`CI=true pnpm exec vitest run --project=storybook|unit <file>`,
`pnpm lint:types`, `pnpm lint`, `pnpm format`. No emdash or endash. Comments
explain why and document edge cases only.

---

### Task 1: Window math (pure)

**Files:** Create `windowMath.ts`, `windowMath.test.ts`.

- [ ] **Step 1: Failing tests.**
  - `cumulativeOffsets([100,200,50])` returns `[0,100,300,350]` (length N+1;
    last entry is total height).
  - `computeWindow` with everything inside the viewport returns `start=0`,
    `end=N-1`, both pads `0`.
  - Scrolled to the middle with a 1000px overscan returns a start whose item
    contains `scrollTop - overscan` and an end whose item contains
    `scrollTop + viewport + overscan`, with `topPad = offsets[start]` and
    `bottomPad = total - offsets[end+1]`.
  - Clamps at both ends (no negative pad, `end <= N-1`).
  - Empty list returns an empty window and zero pads.
- [ ] **Step 2: Run, confirm failure.**
- [ ] **Step 3: Implement.** `cumulativeOffsets`, then `computeWindow({offsets,
  total, scrollTop, viewportHeight, overscan})`; binary search or linear scan
  for `start`/`end` (linear is fine at chat scale). Return `{ start, end,
  topPad, bottomPad }`.
- [ ] **Step 4: Run, confirm pass.**

---

### Task 2: Height cache (pure)

**Files:** Create `heightCache.ts`, `heightCache.test.ts`.

- [ ] **Step 1: Failing tests** (same shape as the earlier plan): seed when a
  kind has no samples; kind average after records; `get`/`estimate` return a
  known id's measured value; re-`record` updates the average without double
  counting; `get` is undefined for an unknown id.
- [ ] **Step 2: Run, confirm failure.**
- [ ] **Step 3: Implement.** Per-kind `{sum,count}` + `Map<id,{kind,height}>`;
  `record` subtracts the previous sample first. Seeds `user 80`,
  `assistant 220`, `tool 140`, `diff 320`, `other 160` (document that seeds only
  affect the first unmeasured paint).
- [ ] **Step 4: Run, confirm pass.**

---

### Task 3: Extend useScrollAnchor with capture/restore (the integration primitive)

**Files:** Modify `useScrollAnchor.ts`; add a focused story to
`ChatVirtualList.stories.tsx` (or a temporary harness) proving the primitive.

- [ ] **Step 1: Failing story `AnchorSurvivesAboveMutation`.** A minimal harness
  with manual `[data-chat-item][data-chat-item-id]` rows and a
  `[data-virtual-spacer]` on top. Scroll so a known row is at a recorded offset.
  Call `captureBeforeLayoutMutation()`, grow a row above the anchor (and the top
  spacer) by a known delta, then `restoreAfterLayoutMutation()` in a layout
  effect. Assert the anchor row's offset from the scroller top is unchanged
  within 2px, including the zero-net case (grow above by +40, shrink a sibling
  by 40) that a total-height observer would miss.
- [ ] **Step 2: Run, confirm failure** (today the hook only restores via the
  content RO, which misses the zero-net case).
- [ ] **Step 3: Implement.** Add to the hook:
  - `findTopAnchor` reads `[data-chat-item-id]`, skips `[data-virtual-spacer]`,
    and returns `{ id, offset }`.
  - `captureBeforeLayoutMutation()` stores the current top anchor (id + offset);
    does not overwrite an existing pending capture from an async trigger.
  - `restoreAfterLayoutMutation()` finds the element by id (fallback: nearest
    real item), computes `scrollTop += currentOffset - savedOffset`, clears the
    pending capture, and re-pins if at the bottom.
  - Keep the existing scroll handler (stick state, `maintainPin`) and the
    content `ResizeObserver`, but route the RO to call
    `restoreAfterLayoutMutation()` as a fallback trigger.
  - Preserve the Phase 1 `lastScrollTopRef` guard for layout-induced scroll
    events.
- [ ] **Step 4: Run, confirm pass; confirm `anchorMath` unit tests still pass.**

---

### Task 4: Rewrite ChatVirtualList to the windowing renderer

**Files:** Modify `ChatVirtualList.tsx`, `ChatVirtualList.stories.tsx`.

- [ ] **Step 1: Migrate Phase 1 stories to the `items`/`renderItem` API and add
  `RendersOnlyWindow`.** Keep the Phase 1 behavior stories
  (anchor-stable-on-above-growth, stays-pinned, does-not-yank, prepend-stable,
  scroll-to-bottom-button, fetch-older) but feed `items` + `renderItem`. Add
  `RendersOnlyWindow`: 200 items at the bottom; assert the rendered
  `[data-chat-item]` count is small and a far item is absent; assert
  `[data-virtual-spacer]` top pad is greater than zero.
- [ ] **Step 2: Run, confirm failure** (API mismatch, no windowing).
- [ ] **Step 3: Implement.**
  - Instantiate a lazy `heightCache`. Track `scrollTop` and `viewportHeight`
    (rAF-throttled scroll/resize). `heights = items.map((it) =>
    cache.estimate(it.id, it.kind))`; `offsets = cumulativeOffsets(heights)`;
    `window = computeWindow(...)`.
  - Render `topPad` spacer (`data-virtual-spacer`), the slice
    `items.slice(start, end+1)` each in a `MeasuredItem` wrapper
    (`data-chat-item`, `data-chat-item-id={id}`) that renders
    `renderItem(item)` and records its border-box height to the cache via a
    `ResizeObserver`, bumping a `cacheVersion`, then `bottomPad` spacer.
  - Wrap range/cache/items mutations with `captureBeforeLayoutMutation()` and
    call `restoreAfterLayoutMutation()` in a `useLayoutEffect` keyed on
    `[rangeVersion, cacheVersion, items]`.
  - Keep the Phase 1 top sentinel + pagination `IntersectionObserver` and
    `maintainPin` on `items.length`.
- [ ] **Step 4: Run, confirm the migrated Phase 1 stories and `RendersOnlyWindow`
  pass; run two or three times for stability.**

---

### Task 5: Dynamic-height no-jump integration gate

**Files:** Modify `ChatVirtualList.stories.tsx`.

- [ ] **Step 1: Failing stories.**
  - `NoJumpScrollingThroughWrongEstimates`: items whose real heights differ a
    lot from the seed; scroll up by a delta that pulls never-measured items into
    the top of the window; assert a reference item's offset stays within a few
    px of the expected post-delta position.
  - `NoJumpOnPrepend`: prepend a page of older items; assert the reference
    item's offset is unchanged within 2px.
  - `StreamingGrowthAboveViewportNoJump`: grow a visible item that is above the
    viewport top by setting its inline height; assert no shift (content RO
    fallback path).
- [ ] **Step 2: Run.** Expected to pass via the capture/restore primitive. If a
  story fails, the fix is in wiring (capture timing, spacer skipping, anchor id
  retention), not new scroll math. If it cannot pass, STOP and report.
- [ ] **Step 3: Adjust wiring only if needed.**
- [ ] **Step 4: Confirm pass.**

---

### Task 6: Scale, append, recycle

**Files:** Modify `ChatVirtualList.stories.tsx`.

- [ ] **Step 1: Failing stories.**
  - `OnlyWindowMounts` (1000 items, start at bottom): rendered `[data-chat-item]`
    count is small (for example `<= 40`); the newest item is rendered.
  - `AppendKeepsPinned`: at the bottom, append an item; scroller stays pinned
    and the appended item renders.
  - `ScrollRecyclesOffscreen`: scroll a row into view (rendered), scroll far
    past it, assert it is no longer in the DOM (true windowing) and the top pad
    grew to reserve it.
- [ ] **Step 2: Run, confirm failure / current behavior.**
- [ ] **Step 3: Tune only if needed** (overscan exactly 1000px; document).
- [ ] **Step 4: Confirm all pass.**

---

### Task 7: Full checks, isolation, design-doc update, commit

- [ ] **Step 1: All tests, types, lint, format.**

```sh
cd site && CI=true pnpm exec vitest run --project=storybook src/pages/AgentsPage/components/ChatVirtualList/
cd site && CI=true pnpm exec vitest run --project=unit src/pages/AgentsPage/components/ChatVirtualList/
cd site && pnpm lint:types && pnpm lint && pnpm format
```

Repeat the storybook run two or three times (async observers; Phase 1 found
ordering-sensitive races).

- [ ] **Step 2: Confirm not wired in.**
  `grep -rn "ChatVirtualList\|VirtualItem" site/src --include=*.tsx --include=*.ts | grep -v "/ChatVirtualList/"` (expect none).
- [ ] **Step 3: Update `DESIGN-chat-scroll-container.md`** (true windowing,
  `items`/`renderItem` API, cutover is not a drop-in, capture/restore anchor).
- [ ] **Step 4: Commit** on the branch using the hook, after explicit
  confirmation. No push without confirmation.

---

## Risks and mitigations

- **Complexity.** Flavor B is a dynamic-height virtualizer with scroll
  anchoring, the hard part of libraries like react-virtuoso. Mitigation:
  pure-logic first (Tasks 1 to 2 fully unit-tested), then the anchor primitive
  in isolation (Task 3), then the renderer (Task 4), then integration gates
  (Tasks 5 to 6). Each step has a failing test first.
- **Double correction / loops.** One owner (the anchor); virtualizer never
  writes `scrollTop`. Restore is idempotent. Capture before mutation, restore in
  a layout effect.
- **Anchor unmount under windowing.** Anchor keyed by stable id; the viewport-top
  item is always within the rendered window; fallback to nearest real item.
- **Observer timing in tests.** Real observers fire async; use `waitFor`, assert
  observable DOM, repeat runs.
- **Remount cost / lost state.** True windowing unmounts offscreen content;
  worker highlight cache covers re-highlight; must-survive UI state is lifted at
  Phase 5. Not blocking for Phase 2 (stateless filler).

## Out of scope (later phases)

- Sticky rewrite (native sticky, shared container, retention rule): Phase 3.
- Mobile-Safari fling clamp and containment polish: Phase 4.
- Cutover, deleting `ChatScrollContainer`, the sticky overlay, and
  `react-infinite-scroll-component`; adapting the consumer to `items`/`renderItem`;
  lifting must-survive message state: Phase 5.

</details>

