### PR TITLE
ci(.github/workflows): bump action-linkspector to v1.5.2

### DIFF
--- a/.github/workflows/weekly-docs.yaml
+++ b/.github/workflows/weekly-docs.yaml
@@ -58,6 +58,11 @@ jobs:
         uses: umbrelladocs/action-linkspector@036f295d12b67b0c4b445bc83db0538afb78db69 # v1.5.2
         id: markdown-link-check
         # checks all markdown files from /docs including all subfolders
+        env:
+          # Use the runner-provided Chrome instead of letting linkspector's
+          # puppeteer download a specific version that may not match the
+          # runner's puppeteer cache. See: https://github.com/UmbrellaDocs/action-linkspector/issues/62
+          PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
         with:
           reporter: github-pr-review
           config_file: ".github/.linkspector.yml"

--- a/.github/workflows/weekly-docs.yaml
+++ b/.github/workflows/weekly-docs.yaml
@@ -55,7 +55,7 @@ jobs:
           mkdir -p "$(pnpm store path --silent)"
 
       - name: Check Markdown links
-        uses: umbrelladocs/action-linkspector@37c85bcde51b30bf929936502bac6bfb7e8f0a4d # v1.4.1
+        uses: umbrelladocs/action-linkspector@036f295d12b67b0c4b445bc83db0538afb78db69 # v1.5.2
         id: markdown-link-check
         # checks all markdown files from /docs including all subfolders
         with:


### PR DESCRIPTION
The `check-docs` job has been failing on every PR touching `docs/**` since 2026-05-29. `umbrelladocs/action-linkspector` runs linkspector under puppeteer, which expects an exact Chrome build (e.g. `148.0.7778.97`) in `/home/runner/.cache/puppeteer`. When that build isn't present on the hosted runner, linkspector crashes with `Could not find Chrome` and reviewdog then fails parsing the empty rdjson output with `proto: syntax error`.

The pinned `v1.4.1` of the action was installing linkspector `0.4.7`, whose puppeteer requires `148.0.7778.97`; that build is no longer in the runner cache. Upstream `v1.5.2` upgrades linkspector to `0.5.3` and adds Chromium fallback logic, but on `ubuntu-22.04` x86_64 none of its new code paths fire (the AppArmor branch is gated on `lsb_release -rs == "24.04"`, the system-Chromium branch on aarch64 or missing 24.04 sysctl), so the bump alone leaves the same Chrome error in place.

This PR:

- Bumps the action to `v1.5.2` (linkspector `0.5.3`).
- Sets `PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome` on the action step. The hosted `ubuntu-22.04` image ships Google Chrome at that path. `v1.5.2`'s `script.sh` short-circuits Chromium setup when this env is set, so puppeteer skips the cache lookup and uses the runner binary directly.

End-to-end verified by temporarily perturbing `docs/**` on this branch so the workflow's `pull_request` trigger would fire: https://github.com/coder/coder/actions/runs/26732938434. `check-docs` ran linkspector against `docs/**` for ~2m30s and exited 0, with no `Could not find Chrome` or reviewdog parse errors in the log. That perturbation has been removed from the branch.

Refs UmbrellaDocs/action-linkspector#62, UmbrellaDocs/action-linkspector#61
