### PR TITLE
ci(.github/workflows): label cherry-pick PRs with the target release

### DIFF
--- a/.github/workflows/cherry-pick.yaml
+++ b/.github/workflows/cherry-pick.yaml
@@ -11,6 +11,7 @@
 #   - Branch:  backport/<pr>-to-<version>
 #   - Title:   <original PR title> (#<pr>)
 #   - Body:    links back to the original PR and merge commit
+#   - Label:   cherry-pick/v<version> to identify the target release
 
 name: Cherry-pick to release
 on:
@@ -24,6 +25,8 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # Required to create the release-specific cherry-pick label if missing.
+  issues: write
 
 # Prevent duplicate runs for the same PR when both 'closed' and 'labeled'
 # fire in quick succession.
@@ -79,6 +82,10 @@ jobs:
           VERSION="${RELEASE_BRANCH#release/}"
           BACKPORT_BRANCH="backport/${PR_NUMBER}-to-${VERSION}"
 
+          # Label applied to the cherry-pick PR so PRs for a specific
+          # release can be filtered easily (e.g. cherry-pick/v2.31).
+          CHERRY_PICK_LABEL="cherry-pick/v${VERSION}"
+
           echo "Target branch: $RELEASE_BRANCH"
           echo "Backport branch: $BACKPORT_BRANCH"
 
@@ -131,6 +138,14 @@ jobs:
             TITLE="[CONFLICT] ${TITLE}"
           fi
 
+          # Ensure the release-specific label exists before applying it.
+          # --force updates the label in place if it already exists, so
+          # re-runs and concurrent runs stay idempotent.
+          gh label create "$CHERRY_PICK_LABEL" \
+            --description "Cherry-pick PR targeting ${RELEASE_BRANCH}" \
+            --color "D93F0B" \
+            --force
+
           # Check if a PR already exists for this branch (idempotency
           # for re-runs). Use --state all to catch closed/merged PRs too.
           EXISTING_PR=$(gh pr list --head "$BACKPORT_BRANCH" --base "$RELEASE_BRANCH" --state all --json number --jq '.[0].number // empty')
@@ -145,6 +160,7 @@ jobs:
               --head "$BACKPORT_BRANCH" \
               --title "$TITLE" \
               --body "$BODY" \
+              --label "$CHERRY_PICK_LABEL" \
               --assignee "$SENDER" \
               --reviewer "$SENDER"
           )


### PR DESCRIPTION
## Summary

Adds a `cherry-pick/v<version>` label to the cherry-pick PRs that the
`Cherry-pick to release` workflow creates automatically, so cherry-picks
for a specific release can be filtered and identified easily (for example
`cherry-pick/v2.31`).

## Changes

- Compute `CHERRY_PICK_LABEL="cherry-pick/v${VERSION}"` from the resolved
  release branch.
- Create the label on demand with `gh label create --force` so the
  workflow stays idempotent across re-runs and concurrent runs, and works
  even when the label does not exist yet.
- Apply the label at PR creation via `gh pr create --label`.
- Grant `issues: write` permission, required to create the label.
- Document the new label convention in the workflow header.

## Notes

The version is derived from the existing release-branch resolution
(`release/2.X` -> `2.X`), so no new configuration is required. The label
name uses a `v` prefix to match the requested `cherry-pick/vX.YZ` format.

<details>
<summary>Implementation context</summary>

The label is created before the existing-PR idempotency check and applied
in the same `gh pr create` call already used for assignees/reviewers, so it
fits the workflow's existing conventions (branch, title, body) without
changing control flow.

</details>

---

*This PR was created by Coder Agents on behalf of @dannykopping.*
