### PR TITLE
fix(site): allow tabbing through chat search results

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchDialog.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchDialog.stories.tsx
@@ -295,8 +295,8 @@ export const KeyboardNavigation: Story = {
 		}
 
 		await expect(resultsViewport).toHaveAttribute("tabindex", "-1");
-		await expect(firstResult).toHaveAttribute("tabindex", "-1");
-		await expect(secondResult).toHaveAttribute("tabindex", "-1");
+		await expect(firstResult).toHaveAttribute("tabindex", "0");
+		await expect(secondResult).toHaveAttribute("tabindex", "0");
 
 		await userEvent.keyboard("{ArrowUp}");
 		await expect(secondResult).toHaveAttribute("aria-selected", "true");
@@ -429,6 +429,30 @@ export const BooleanFilterPill: Story = {
 				q: "has_unread:true",
 			});
 		});
+	},
+};
+
+export const SearchResultsAreTabbable: Story = {
+	play: async () => {
+		const body = within(document.body);
+		const searchInput = body.getByRole("combobox", { name: "Search chats" });
+
+		await userEvent.type(searchInput, "Fix");
+		const firstResult = await body.findByRole("option", {
+			name: /Fix race condition in auth middleware/,
+		});
+		const secondResult = await body.findByRole("option", {
+			name: /Fix flaky workspace search story/,
+		});
+		await expect(firstResult).toHaveAttribute("tabindex", "0");
+		await expect(secondResult).toHaveAttribute("tabindex", "0");
+
+		await userEvent.tab();
+		await userEvent.tab();
+		await expect(firstResult).toHaveFocus();
+
+		await userEvent.tab();
+		await expect(secondResult).toHaveFocus();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchResults.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchResults.tsx
@@ -263,11 +263,11 @@ const ChatSearchResultRow: FC<ChatSearchResultRowProps> = ({
 			id={id}
 			role="option"
 			aria-selected={isSelected}
-			tabIndex={-1}
+			tabIndex={0}
 			to={{ pathname: `/agents/${chat.id}`, search: location.search }}
 			onClick={onSelect}
 			className={cn(
-				"grid w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-2 rounded-md px-1.5 py-1 text-content-secondary no-underline hover:bg-surface-tertiary/40 hover:text-content-primary",
+				"grid w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-2 rounded-md px-1.5 py-1 text-content-secondary no-underline hover:bg-surface-tertiary/40 hover:text-content-primary focus-visible:outline focus-visible:-outline-offset-2 focus-visible:outline-2 focus-visible:outline-content-link",
 				isSelected && "bg-surface-tertiary/40 text-content-primary",
 			)}
 		>


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

Fixes keyboard tab navigation in the AgentsPage chat search dialog by keeping result links in the browser's normal tab order. The search results still support arrow-key selection, but `Tab` can now move from the search input through the filter toggle and each result link.

Also updates the Storybook interaction coverage to assert that search results are tabbable and no longer explicitly removed from sequential keyboard navigation.

<details><summary>Research</summary>

Root cause: `ChatSearchResultRow` rendered each result as a React Router `Link`, but also set `tabIndex={-1}`. That removed semantic anchor links from sequential keyboard navigation, so users could not tab through search results even though the rows were otherwise interactive.

The scroll viewport's `viewportTabIndex: -1` was not the blocker. That only keeps the scroll container itself out of tab order. Removing `tabIndex={-1}` from the result link is the minimal fix, and it applies to both live search results and recent chats because both paths share `ChatSearchResultRow`.

Reviewed by a Coder sub agent with no blocking findings.

</details>

## Testing

- `pnpm --dir site test:storybook src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchDialog.stories.tsx`
- `pnpm --dir site check src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchResults.tsx src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchDialog.stories.tsx`

Note: an initial run with `--runInBand` failed because Vitest does not support that option here. The focused Storybook suite was rerun without it and passed.