### PR TITLE
feat: warn instead of fail on ineffective deprecated AI provider env config

### DIFF
--- a/cli/aibridged_internal_test.go
+++ b/cli/aibridged_internal_test.go
@@ -33,7 +33,7 @@ func buildFromEnv(t *testing.T, cfg codersdk.AIBridgeConfig) ([]aibridge.Provide
 	db, _ := dbtestutil.NewDB(t)
 	ctx := testutil.Context(t, testutil.WaitShort)
 	logger := slogtest.Make(t, nil)
-	if err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, logger); err != nil {
+	if _, err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, logger); err != nil {
 		return nil, err
 	}
 	providers, _, err := BuildProviders(ctx, db, cfg, logger)

--- a/cli/server.go
+++ b/cli/server.go
@@ -1024,14 +1024,19 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 			//nolint:gocritic // Production timeout, not a test wait.
 			aibridgeInitCtx, aibridgeInitCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 			defer aibridgeInitCancel()
-			if err := coderd.SeedAIProvidersFromEnv(
+			ineffective, err := coderd.SeedAIProvidersFromEnv(
 				aibridgeInitCtx,
 				options.Database,
 				vals.AI.BridgeConfig,
 				logger.Named("aibridge.envseed"),
-			); err != nil {
+			)
+			if err != nil {
 				return xerrors.Errorf("seed ai providers from env: %w", err)
 			}
+			// This runs unconditionally for both editions (enterprise
+			// reuses this AGPL server runner), so it is the authoritative
+			// setter for the deprecated-env-drift warning banner.
+			coderAPI.AIProvidersEnvDrift.Store(ineffective)
 
 			// In-memory aibridge daemon. Registered on coderd so chatd can
 			// dispatch LLM requests via the in-process transport without

--- a/coderd/ai_providers_migrate.go
+++ b/coderd/ai_providers_migrate.go
@@ -26,9 +26,16 @@ import (
 // derived AI provider configuration with rows in the ai_providers
 // table at server startup. Concurrent server starts are serialized via a
 // Postgres advisory lock; rows that already exist with a matching
-// canonical hash are left alone, missing rows are inserted, and rows
-// whose hash differs from the env-derived value cause startup to fail
-// with a descriptive error.
+// canonical hash are left alone and missing rows are inserted.
+//
+// AI-provider configuration via CODER_AIBRIDGE_* env vars is deprecated
+// in favor of managing providers through the API/UI, where the database
+// is the source of truth. When an env-derived provider differs from the
+// row already stored in the database ("drift"), startup does NOT fail:
+// the env change is ineffective, so the existing row is left untouched, a
+// warning is logged, and the returned ineffective flag is set to true so
+// callers can surface a banner to admins. Other missing providers in the
+// same config are still inserted.
 //
 // API keys derived from env vars are inserted into ai_provider_keys at
 // the time the provider row is first created. We do NOT add env-sourced
@@ -45,13 +52,13 @@ func SeedAIProvidersFromEnv(
 	db database.Store,
 	cfg codersdk.AIBridgeConfig,
 	logger slog.Logger,
-) error {
+) (ineffective bool, err error) {
 	desired, err := providersFromEnv(ctx, cfg, logger)
 	if err != nil {
-		return xerrors.Errorf("compute providers from env: %w", err)
+		return false, xerrors.Errorf("compute providers from env: %w", err)
 	}
 	if len(desired) == 0 {
-		return nil
+		return false, nil
 	}
 
 	// Audit entries are attributed to the deployment rather than a user.
@@ -65,11 +72,19 @@ func SeedAIProvidersFromEnv(
 	var (
 		insertedProviders []database.AIProvider
 		insertedKeys      []database.AIProviderKey
+		// drift records whether any env-derived provider differs from a
+		// row already in the database. driftedNames collects the affected
+		// provider names for the warning log. Both are reset at the top of
+		// the InTx closure so a transaction retry recomputes them cleanly.
+		drift        bool
+		driftedNames []string
 	)
 
 	err = db.InTx(func(tx database.Store) error {
 		insertedProviders = insertedProviders[:0]
 		insertedKeys = insertedKeys[:0]
+		drift = false
+		driftedNames = driftedNames[:0]
 
 		// Acquire the advisory lock. The lock is released when the
 		// transaction ends.
@@ -136,7 +151,16 @@ func SeedAIProvidersFromEnv(
 				if existingHash == dp.Hash {
 					continue
 				}
-				return xerrors.Errorf("AI provider %q already exists in the database and differs from the current environment configuration; update the provider through the API or remove the CODER_AIBRIDGE_* env vars to stop seeding it", dp.Name)
+				// The env-derived config drifted from the stored row.
+				// CODER_AIBRIDGE_* env config is deprecated, so this is
+				// not fatal: the database is the source of truth, the
+				// existing row is left untouched, and the env change is
+				// ineffective. Flag it (the warning is emitted after the
+				// transaction commits, like the insert logs below) and keep
+				// reconciling the remaining providers.
+				drift = true
+				driftedNames = append(driftedNames, dp.Name)
+				continue
 			}
 
 			row, err := tx.InsertAIProvider(sysCtx, database.InsertAIProviderParams{
@@ -183,7 +207,7 @@ func SeedAIProvidersFromEnv(
 		return nil
 	}, nil)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	for _, row := range insertedProviders {
@@ -201,7 +225,12 @@ func SeedAIProvidersFromEnv(
 			slog.F("api_key", aibridgeutils.MaskSecret(keyRow.APIKey)),
 		)
 	}
-	return nil
+	if drift {
+		logger.Warn(sysCtx, "deprecated AI provider env configuration is ineffective; the database is the source of truth, so update these providers through the API or remove their CODER_AIBRIDGE_* env vars",
+			slog.F("providers", driftedNames),
+		)
+	}
+	return drift, nil
 }
 
 // canonicalAIProvider is the shape we hash to detect drift between the

--- a/coderd/ai_providers_migrate_test.go
+++ b/coderd/ai_providers_migrate_test.go
@@ -24,8 +24,9 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 		t.Parallel()
 		db, _ := dbtestutil.NewDB(t)
 		ctx := testutil.Context(t, testutil.WaitShort)
-		err := coderd.SeedAIProvidersFromEnv(ctx, db, codersdk.AIBridgeConfig{}, testLogger(t))
+		ineffective, err := coderd.SeedAIProvidersFromEnv(ctx, db, codersdk.AIBridgeConfig{}, testLogger(t))
 		require.NoError(t, err)
+		require.False(t, ineffective)
 	})
 
 	t.Run("LegacyOpenAI", func(t *testing.T) {
@@ -40,7 +41,7 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 			},
 		}
 		var firstSeedLogs bytes.Buffer
-		err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, capturedLogger(&firstSeedLogs))
+		_, err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, capturedLogger(&firstSeedLogs))
 		require.NoError(t, err)
 
 		// One row exists for "openai".
@@ -65,7 +66,7 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 		// Re-running with the same config is a no-op and emits no new
 		// env-seed log lines.
 		var rerunLogs bytes.Buffer
-		err = coderd.SeedAIProvidersFromEnv(ctx, db, cfg, capturedLogger(&rerunLogs))
+		_, err = coderd.SeedAIProvidersFromEnv(ctx, db, cfg, capturedLogger(&rerunLogs))
 		require.NoError(t, err)
 		require.NotContains(t, rerunLogs.String(), "env-seeded ai provider")
 
@@ -78,7 +79,7 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 		require.Len(t, keys, 1)
 	})
 
-	t.Run("DriftFailsStartup", func(t *testing.T) {
+	t.Run("DriftIsNonFatalAndFlagged", func(t *testing.T) {
 		t.Parallel()
 		db, _ := dbtestutil.NewDB(t)
 		ctx := testutil.Context(t, testutil.WaitShort)
@@ -89,22 +90,38 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 				Key:     serpent.String("sk-original"),
 			},
 		}
-		require.NoError(t, coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t)))
+		ineffective, err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
+		require.NoError(t, err)
+		require.False(t, ineffective)
 
-		// Changing the API key counts as drift: keys are included
-		// in the canonical hash so operators notice when env-var
-		// credential changes are ignored by an existing provider.
+		// Changing the API key counts as drift: keys are included in the
+		// canonical hash. Because CODER_AIBRIDGE_* config is deprecated,
+		// drift no longer fails startup; the env change is ineffective,
+		// the stored row is left untouched, and the call reports it.
 		cfg.LegacyOpenAI.Key = serpent.String("sk-rotated")
-		err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "differs from the current environment configuration")
+		ineffective, err = coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
+		require.NoError(t, err)
+		require.True(t, ineffective)
 
-		// Changing the base URL is also real drift.
+		// The database still holds the original key.
+		row, err := db.GetAIProviderByName(ctx, "openai")
+		require.NoError(t, err)
+		keys, err := db.GetAIProviderKeysByProviderID(ctx, row.ID)
+		require.NoError(t, err)
+		require.Len(t, keys, 1)
+		require.Equal(t, "sk-original", keys[0].APIKey)
+
+		// Changing the base URL is also drift, and also non-fatal.
 		cfg.LegacyOpenAI.Key = serpent.String("sk-original")
 		cfg.LegacyOpenAI.BaseURL = serpent.String("https://api.openai.com/v2")
-		err = coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "differs from the current environment configuration")
+		ineffective, err = coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
+		require.NoError(t, err)
+		require.True(t, ineffective)
+
+		// The stored base URL is unchanged.
+		row, err = db.GetAIProviderByName(ctx, "openai")
+		require.NoError(t, err)
+		require.Equal(t, "https://api.openai.com/v1", row.BaseUrl)
 	})
 
 	t.Run("BedrockCredentialChangeIsDrift", func(t *testing.T) {
@@ -120,24 +137,35 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 				Model:           serpent.String("anthropic.claude-3-5-sonnet"),
 			},
 		}
-		require.NoError(t, coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t)))
+		_, err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
+		require.NoError(t, err)
 
-		// Rotating the Bedrock access key in env trips the drift
-		// check so operators know the change did not take effect.
+		// Rotating the Bedrock access key in env is drift. It is
+		// non-fatal for the deprecated env path: the call reports the
+		// change is ineffective and the stored credentials are unchanged.
 		cfg.LegacyBedrock.AccessKey = serpent.String("AKIA-rotated")
 		cfg.LegacyBedrock.AccessKeySecret = serpent.String("secret-rotated")
-		err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "differs from the current environment configuration")
+		ineffective, err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
+		require.NoError(t, err)
+		require.True(t, ineffective)
 
-		// Changing the Bedrock region (a non-credential field) is
-		// also real drift.
+		row, err := db.GetAIProviderByName(ctx, "anthropic")
+		require.NoError(t, err)
+		require.Contains(t, row.Settings.String, "AKIA-original")
+		require.Contains(t, row.Settings.String, "secret-original")
+
+		// Changing the Bedrock region (a non-credential field) is also
+		// drift, and also non-fatal.
 		cfg.LegacyBedrock.AccessKey = serpent.String("AKIA-original")
 		cfg.LegacyBedrock.AccessKeySecret = serpent.String("secret-original")
 		cfg.LegacyBedrock.Region = serpent.String("us-west-2")
-		err = coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "differs from the current environment configuration")
+		ineffective, err = coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
+		require.NoError(t, err)
+		require.True(t, ineffective)
+
+		row, err = db.GetAIProviderByName(ctx, "anthropic")
+		require.NoError(t, err)
+		require.Contains(t, row.Settings.String, "us-east-1")
 	})
 
 	t.Run("LegacyBedrockOnlyKeepsBedrockSettings", func(t *testing.T) {
@@ -156,7 +184,8 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 				SmallFastModel:  serpent.String("anthropic.claude-3-5-haiku"),
 			},
 		}
-		require.NoError(t, coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t)))
+		_, err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
+		require.NoError(t, err)
 
 		row, err := db.GetAIProviderByName(ctx, "anthropic")
 		require.NoError(t, err)
@@ -191,7 +220,8 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 
 		cfg := dv.AI.BridgeConfig
 		cfg.LegacyAnthropic.Key = serpent.String("sk-ant-only")
-		require.NoError(t, coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t)))
+		_, err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
+		require.NoError(t, err)
 
 		row, err := db.GetAIProviderByName(ctx, "anthropic")
 		require.NoError(t, err)
@@ -216,7 +246,8 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 				Model:  serpent.String("anthropic.claude-3-5-sonnet"),
 			},
 		}
-		require.NoError(t, coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t)))
+		_, err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
+		require.NoError(t, err)
 
 		row, err := db.GetAIProviderByName(ctx, "anthropic")
 		require.NoError(t, err)
@@ -241,7 +272,8 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 				Model:           serpent.String("anthropic.claude-3-5-sonnet"),
 			},
 		}
-		require.NoError(t, coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t)))
+		_, err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
+		require.NoError(t, err)
 		row, err := db.GetAIProviderByName(ctx, "anthropic")
 		require.NoError(t, err)
 		require.Contains(t, row.Settings.String, "us-east-1")
@@ -275,7 +307,8 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 				},
 			},
 		}
-		require.NoError(t, coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t)))
+		_, err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
+		require.NoError(t, err)
 
 		oa, err := db.GetAIProviderByName(ctx, "primary-openai")
 		require.NoError(t, err)
@@ -319,34 +352,55 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 				},
 			},
 		}
-		require.NoError(t, coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t)))
+		_, err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
+		require.NoError(t, err)
 
 		// Reordering keys must not count as drift. The canonical hash
 		// sorts keys before hashing, so equivalent key sets remain
 		// stable across restarts.
 		cfg.Providers[0].Keys = []string{"sk-openai-2", "sk-openai-1"}
 		cfg.Providers[1].Keys = []string{"sk-ant-2", "sk-ant-1"}
-		require.NoError(t, coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t)))
+		ineffective, err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
+		require.NoError(t, err)
+		require.False(t, ineffective)
 
-		// Changing one key on one provider must block startup even
-		// when multiple providers are configured.
+		// Changing one key on one provider is drift even when multiple
+		// providers are configured. Drift is non-fatal: it must not block
+		// a brand-new provider in the same config from being inserted,
+		// which exercises the continue-after-drift path.
 		cfg.Providers[1].Keys = []string{"sk-ant-2", "sk-ant-rotated"}
-		err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "differs from the current environment configuration")
-		require.Contains(t, err.Error(), `"primary-anthropic"`)
+		cfg.Providers = append(cfg.Providers, codersdk.AIProviderConfig{
+			Type:    "openai",
+			Name:    "secondary-openai",
+			BaseURL: "https://api.openai.com/v1",
+			Keys:    []string{"sk-new"},
+		})
+		ineffective, err = coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
+		require.NoError(t, err)
+		require.True(t, ineffective)
 
+		// The non-drifting provider is still present with its original keys.
 		oa, err := db.GetAIProviderByName(ctx, "primary-openai")
 		require.NoError(t, err)
 		oaKeys, err := db.GetAIProviderKeysByProviderID(ctx, oa.ID)
 		require.NoError(t, err)
 		require.ElementsMatch(t, []string{"sk-openai-1", "sk-openai-2"}, []string{oaKeys[0].APIKey, oaKeys[1].APIKey})
 
+		// The drifted provider keeps its original keys; the env change
+		// was ignored.
 		an, err := db.GetAIProviderByName(ctx, "primary-anthropic")
 		require.NoError(t, err)
 		anKeys, err := db.GetAIProviderKeysByProviderID(ctx, an.ID)
 		require.NoError(t, err)
 		require.ElementsMatch(t, []string{"sk-ant-1", "sk-ant-2"}, []string{anKeys[0].APIKey, anKeys[1].APIKey})
+
+		// The new provider was inserted despite the drift on another row.
+		sec, err := db.GetAIProviderByName(ctx, "secondary-openai")
+		require.NoError(t, err)
+		secKeys, err := db.GetAIProviderKeysByProviderID(ctx, sec.ID)
+		require.NoError(t, err)
+		require.Len(t, secKeys, 1)
+		require.Equal(t, "sk-new", secKeys[0].APIKey)
 	})
 
 	t.Run("BedrockIndexedProviderHasNoKeys", func(t *testing.T) {
@@ -367,7 +421,8 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 				},
 			},
 		}
-		require.NoError(t, coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t)))
+		_, err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
+		require.NoError(t, err)
 
 		row, err := db.GetAIProviderByName(ctx, "bedrock-anthropic")
 		require.NoError(t, err)
@@ -398,7 +453,9 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 				},
 			},
 		}
-		err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
+		// Pre-transaction validation: a legacy/indexed name conflict is
+		// still fatal.
+		_, err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "conflicts")
 	})
@@ -417,7 +474,8 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 				},
 			},
 		}
-		err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
+		// Pre-transaction validation: an invalid name is still fatal.
+		_, err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid AI provider name")
 	})
@@ -446,7 +504,8 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 				},
 			},
 		}
-		require.NoError(t, coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t)))
+		_, err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
+		require.NoError(t, err)
 
 		all, err := db.GetAIProviders(ctx, database.GetAIProvidersParams{})
 		require.NoError(t, err)
@@ -465,7 +524,8 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 				Key:     serpent.String("sk-original"),
 			},
 		}
-		require.NoError(t, coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t)))
+		_, err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
+		require.NoError(t, err)
 
 		row, err := db.GetAIProviderByName(ctx, "openai")
 		require.NoError(t, err)
@@ -473,14 +533,15 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 
 		// Re-run seed; the soft-deleted row should remain soft-deleted
 		// and no new row should be created.
-		require.NoError(t, coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t)))
+		_, err = coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
+		require.NoError(t, err)
 
 		all, err := db.GetAIProviders(ctx, database.GetAIProvidersParams{})
 		require.NoError(t, err)
 		require.Empty(t, all, "expected no active rows after soft-delete + re-seed")
 	})
 
-	t.Run("ExistingKeysBlockOnDrift", func(t *testing.T) {
+	t.Run("ExistingKeysDriftKeepsOriginalKeys", func(t *testing.T) {
 		t.Parallel()
 		db, _ := dbtestutil.NewDB(t)
 		ctx := testutil.Context(t, testutil.WaitShort)
@@ -491,17 +552,19 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 				Key:     serpent.String("sk-original"),
 			},
 		}
-		require.NoError(t, coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t)))
+		_, err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
+		require.NoError(t, err)
 
 		row, err := db.GetAIProviderByName(ctx, "openai")
 		require.NoError(t, err)
 
-		// Operator rotates the env key. The seed now blocks startup
-		// because the keys differ, alerting the operator.
+		// Operator rotates the env key. The seed reports the change is
+		// ineffective rather than blocking startup, and the database row
+		// is left untouched.
 		cfg.LegacyOpenAI.Key = serpent.String("sk-rotated")
-		err = coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "differs from the current environment configuration")
+		ineffective, err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
+		require.NoError(t, err)
+		require.True(t, ineffective)
 
 		// The original key is still in the database.
 		keys, err := db.GetAIProviderKeysByProviderID(ctx, row.ID)
@@ -533,7 +596,8 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 				},
 			},
 		}
-		require.NoError(t, coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t)))
+		_, err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
+		require.NoError(t, err)
 
 		all, err := db.GetAIProviders(ctx, database.GetAIProvidersParams{})
 		require.NoError(t, err)
@@ -563,7 +627,8 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 				},
 			},
 		}
-		require.NoError(t, coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t)))
+		_, err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
+		require.NoError(t, err)
 
 		all, err := db.GetAIProviders(ctx, database.GetAIProvidersParams{})
 		require.NoError(t, err)
@@ -579,7 +644,8 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 		db, _ := dbtestutil.NewDB(t)
 		ctx := testutil.Context(t, testutil.WaitShort)
 
-		// Same name, different canonical fields: must be rejected.
+		// Same name, different canonical fields: pre-transaction
+		// validation rejects this, so it is still fatal.
 		cfg := codersdk.AIBridgeConfig{
 			Providers: []codersdk.AIProviderConfig{
 				{
@@ -596,7 +662,7 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 				},
 			},
 		}
-		err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
+		_, err := coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "conflicting fields")
 	})

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -15840,6 +15840,10 @@ const docTemplate = `{
         "codersdk.AppearanceConfig": {
             "type": "object",
             "properties": {
+                "ai_providers_env_drift_detected": {
+                    "description": "AIProvidersEnvDriftDetected is true when deprecated CODER_AIBRIDGE_*\nenv configuration differs from the AI provider rows already stored in\nthe database, meaning those env changes are ineffective. It is\noutput-only and is not part of UpdateAppearanceConfig.",
+                    "type": "boolean"
+                },
                 "announcement_banners": {
                     "type": "array",
                     "items": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -14211,6 +14211,10 @@
 		"codersdk.AppearanceConfig": {
 			"type": "object",
 			"properties": {
+				"ai_providers_env_drift_detected": {
+					"description": "AIProvidersEnvDriftDetected is true when deprecated CODER_AIBRIDGE_*\nenv configuration differs from the AI provider rows already stored in\nthe database, meaning those env changes are ineffective. It is\noutput-only and is not part of UpdateAppearanceConfig.",
+					"type": "boolean"
+				},
 				"announcement_banners": {
 					"type": "array",
 					"items": {

--- a/coderd/appearance/appearance.go
+++ b/coderd/appearance/appearance.go
@@ -2,6 +2,7 @@ package appearance
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/coder/coder/v2/codersdk"
 )
@@ -12,21 +13,27 @@ type Fetcher interface {
 
 type AGPLFetcher struct {
 	docsURL string
+	// aiProvidersEnvDrift reports whether deprecated CODER_AIBRIDGE_* env
+	// configuration is ineffective because it differs from the database.
+	// It may be nil when no source is wired in.
+	aiProvidersEnvDrift *atomic.Bool
 }
 
 func (f AGPLFetcher) Fetch(context.Context) (codersdk.AppearanceConfig, error) {
 	return codersdk.AppearanceConfig{
-		AnnouncementBanners: []codersdk.BannerConfig{},
-		SupportLinks:        codersdk.DefaultSupportLinks(f.docsURL),
-		DocsURL:             f.docsURL,
+		AnnouncementBanners:         []codersdk.BannerConfig{},
+		SupportLinks:                codersdk.DefaultSupportLinks(f.docsURL),
+		DocsURL:                     f.docsURL,
+		AIProvidersEnvDriftDetected: f.aiProvidersEnvDrift != nil && f.aiProvidersEnvDrift.Load(),
 	}, nil
 }
 
-func NewDefaultFetcher(docsURL string) Fetcher {
+func NewDefaultFetcher(docsURL string, aiProvidersEnvDrift *atomic.Bool) Fetcher {
 	if docsURL == "" {
 		docsURL = codersdk.DefaultDocsURL()
 	}
 	return &AGPLFetcher{
-		docsURL: docsURL,
+		docsURL:             docsURL,
+		aiProvidersEnvDrift: aiProvidersEnvDrift,
 	}
 }

--- a/coderd/appearance/appearance.go
+++ b/coderd/appearance/appearance.go
@@ -2,7 +2,6 @@ package appearance
 
 import (
 	"context"
-	"sync/atomic"
 
 	"github.com/coder/coder/v2/codersdk"
 )
@@ -11,29 +10,36 @@ type Fetcher interface {
 	Fetch(ctx context.Context) (codersdk.AppearanceConfig, error)
 }
 
+// Option overlays process-local, deployment-derived values onto a
+// resolved AppearanceConfig. Options run at fetch time, so they may read
+// values that change after startup (such as atomics). They let callers
+// surface dynamic fields without adding parameters to fetcher
+// constructors, and keep this package agnostic of those fields.
+type Option func(*codersdk.AppearanceConfig)
+
 type AGPLFetcher struct {
 	docsURL string
-	// aiProvidersEnvDrift reports whether deprecated CODER_AIBRIDGE_* env
-	// configuration is ineffective because it differs from the database.
-	// It may be nil when no source is wired in.
-	aiProvidersEnvDrift *atomic.Bool
+	options []Option
 }
 
 func (f AGPLFetcher) Fetch(context.Context) (codersdk.AppearanceConfig, error) {
-	return codersdk.AppearanceConfig{
-		AnnouncementBanners:         []codersdk.BannerConfig{},
-		SupportLinks:                codersdk.DefaultSupportLinks(f.docsURL),
-		DocsURL:                     f.docsURL,
-		AIProvidersEnvDriftDetected: f.aiProvidersEnvDrift != nil && f.aiProvidersEnvDrift.Load(),
-	}, nil
+	cfg := codersdk.AppearanceConfig{
+		AnnouncementBanners: []codersdk.BannerConfig{},
+		SupportLinks:        codersdk.DefaultSupportLinks(f.docsURL),
+		DocsURL:             f.docsURL,
+	}
+	for _, opt := range f.options {
+		opt(&cfg)
+	}
+	return cfg, nil
 }
 
-func NewDefaultFetcher(docsURL string, aiProvidersEnvDrift *atomic.Bool) Fetcher {
+func NewDefaultFetcher(docsURL string, opts ...Option) Fetcher {
 	if docsURL == "" {
 		docsURL = codersdk.DefaultDocsURL()
 	}
 	return &AGPLFetcher{
-		docsURL:             docsURL,
-		aiProvidersEnvDrift: aiProvidersEnvDrift,
+		docsURL: docsURL,
+		options: opts,
 	}
 }

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -666,7 +666,12 @@ func New(options *Options) *API {
 		options.AppSigningKeyCache,
 	)
 
-	f := appearance.NewDefaultFetcher(api.DeploymentValues.DocsURL.String(), &api.AIProvidersEnvDrift)
+	f := appearance.NewDefaultFetcher(
+		api.DeploymentValues.DocsURL.String(),
+		func(cfg *codersdk.AppearanceConfig) {
+			cfg.AIProvidersEnvDriftDetected = api.AIProvidersEnvDrift.Load()
+		},
+	)
 	api.AppearanceFetcher.Store(&f)
 	api.PortSharer.Store(&portsharing.DefaultPortSharer)
 	api.PrebuildsClaimer.Store(&prebuilds.DefaultClaimer)

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -2180,6 +2180,12 @@ type API struct {
 	WebpushDispatcher webpush.Dispatcher
 	QuotaCommitter    atomic.Pointer[proto.QuotaCommitter]
 	AppearanceFetcher atomic.Pointer[appearance.Fetcher]
+	// AIProvidersEnvDrift is set to true at startup when deprecated
+	// CODER_AIBRIDGE_* env configuration differs from the AI provider rows
+	// already stored in the database. The appearance fetchers read it to
+	// warn admins that their env changes are ineffective. The zero value
+	// (false) needs no initialization.
+	AIProvidersEnvDrift atomic.Bool
 	// WorkspaceProxyHostsFn returns the hosts of healthy workspace proxies
 	// for header reasons.
 	WorkspaceProxyHostsFn atomic.Pointer[func() []*proxyhealth.ProxyHost]

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -666,7 +666,7 @@ func New(options *Options) *API {
 		options.AppSigningKeyCache,
 	)
 
-	f := appearance.NewDefaultFetcher(api.DeploymentValues.DocsURL.String())
+	f := appearance.NewDefaultFetcher(api.DeploymentValues.DocsURL.String(), &api.AIProvidersEnvDrift)
 	api.AppearanceFetcher.Store(&f)
 	api.PortSharer.Store(&portsharing.DefaultPortSharer)
 	api.PrebuildsClaimer.Store(&prebuilds.DefaultClaimer)

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -4882,6 +4882,11 @@ type AppearanceConfig struct {
 	ServiceBanner       BannerConfig   `json:"service_banner"`
 	AnnouncementBanners []BannerConfig `json:"announcement_banners"`
 	SupportLinks        []LinkConfig   `json:"support_links,omitempty"`
+	// AIProvidersEnvDriftDetected is true when deprecated CODER_AIBRIDGE_*
+	// env configuration differs from the AI provider rows already stored in
+	// the database, meaning those env changes are ineffective. It is
+	// output-only and is not part of UpdateAppearanceConfig.
+	AIProvidersEnvDriftDetected bool `json:"ai_providers_env_drift_detected"`
 }
 
 type UpdateAppearanceConfig struct {

--- a/docs/reference/api/enterprise.md
+++ b/docs/reference/api/enterprise.md
@@ -103,6 +103,7 @@ curl -X GET http://coder-server:8080/api/v2/appearance \
 
 ```json
 {
+  "ai_providers_env_drift_detected": true,
   "announcement_banners": [
     {
       "background_color": "string",

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -1572,6 +1572,7 @@ None
 
 ```json
 {
+  "ai_providers_env_drift_detected": true,
   "announcement_banners": [
     {
       "background_color": "string",
@@ -1600,14 +1601,15 @@ None
 
 ### Properties
 
-| Name                   | Type                                                    | Required | Restrictions | Description                                                         |
-|------------------------|---------------------------------------------------------|----------|--------------|---------------------------------------------------------------------|
-| `announcement_banners` | array of [codersdk.BannerConfig](#codersdkbannerconfig) | false    |              |                                                                     |
-| `application_name`     | string                                                  | false    |              |                                                                     |
-| `docs_url`             | string                                                  | false    |              |                                                                     |
-| `logo_url`             | string                                                  | false    |              |                                                                     |
-| `service_banner`       | [codersdk.BannerConfig](#codersdkbannerconfig)          | false    |              | Deprecated: ServiceBanner has been replaced by AnnouncementBanners. |
-| `support_links`        | array of [codersdk.LinkConfig](#codersdklinkconfig)     | false    |              |                                                                     |
+| Name                              | Type                                                    | Required | Restrictions | Description                                                                                                                                                                                                                                                          |
+|-----------------------------------|---------------------------------------------------------|----------|--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `ai_providers_env_drift_detected` | boolean                                                 | false    |              | Ai providers env drift detected is true when deprecated CODER_AIBRIDGE_* env configuration differs from the AI provider rows already stored in the database, meaning those env changes are ineffective. It is output-only and is not part of UpdateAppearanceConfig. |
+| `announcement_banners`            | array of [codersdk.BannerConfig](#codersdkbannerconfig) | false    |              |                                                                                                                                                                                                                                                                      |
+| `application_name`                | string                                                  | false    |              |                                                                                                                                                                                                                                                                      |
+| `docs_url`                        | string                                                  | false    |              |                                                                                                                                                                                                                                                                      |
+| `logo_url`                        | string                                                  | false    |              |                                                                                                                                                                                                                                                                      |
+| `service_banner`                  | [codersdk.BannerConfig](#codersdkbannerconfig)          | false    |              | Deprecated: ServiceBanner has been replaced by AnnouncementBanners.                                                                                                                                                                                                  |
+| `support_links`                   | array of [codersdk.LinkConfig](#codersdklinkconfig)     | false    |              |                                                                                                                                                                                                                                                                      |
 
 ## codersdk.ArchiveTemplateVersionsRequest
 

--- a/enterprise/cli/server.go
+++ b/enterprise/cli/server.go
@@ -178,14 +178,19 @@ func (r *RootCmd) Server(_ func()) *serpent.Command {
 			//nolint:gocritic // Production timeout, not a test wait.
 			aibridgeInitCtx, aibridgeInitCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 			defer aibridgeInitCancel()
-			if err := agplcoderd.SeedAIProvidersFromEnv(
+			ineffective, err := agplcoderd.SeedAIProvidersFromEnv(
 				aibridgeInitCtx,
 				options.Database,
 				options.DeploymentValues.AI.BridgeConfig,
 				options.Logger.Named("aibridge.envseed"),
-			); err != nil {
+			)
+			if err != nil {
 				return nil, nil, xerrors.Errorf("seed ai providers from env: %w", err)
 			}
+			// Belt-and-suspenders: the agplcli re-seed after newAPI
+			// overwrites this with the same deterministic value. Use the
+			// computed flag rather than a hardcoded true.
+			api.AGPL.AIProvidersEnvDrift.Store(ineffective)
 			aiBridgeProxyCloser, err := newAIBridgeProxyDaemon(api)
 			if err != nil {
 				_ = closers.Close()

--- a/enterprise/coderd/appearance.go
+++ b/enterprise/coderd/appearance.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"sync/atomic"
 
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/xerrors"
@@ -43,23 +42,23 @@ func (api *API) appearance(rw http.ResponseWriter, r *http.Request) {
 }
 
 type appearanceFetcher struct {
-	database            database.Store
-	supportLinks        []codersdk.LinkConfig
-	docsURL             string
-	coderVersion        string
-	aiProvidersEnvDrift *atomic.Bool
+	database     database.Store
+	supportLinks []codersdk.LinkConfig
+	docsURL      string
+	coderVersion string
+	options      []agpl.Option
 }
 
-func newAppearanceFetcher(store database.Store, links []codersdk.LinkConfig, docsURL, coderVersion string, aiProvidersEnvDrift *atomic.Bool) agpl.Fetcher {
+func newAppearanceFetcher(store database.Store, links []codersdk.LinkConfig, docsURL, coderVersion string, opts ...agpl.Option) agpl.Fetcher {
 	if docsURL == "" {
 		docsURL = codersdk.DefaultDocsURL()
 	}
 	return &appearanceFetcher{
-		database:            store,
-		supportLinks:        links,
-		docsURL:             docsURL,
-		coderVersion:        coderVersion,
-		aiProvidersEnvDrift: aiProvidersEnvDrift,
+		database:     store,
+		supportLinks: links,
+		docsURL:      docsURL,
+		coderVersion: coderVersion,
+		options:      opts,
 	}
 }
 
@@ -97,12 +96,11 @@ func (f *appearanceFetcher) Fetch(ctx context.Context) (codersdk.AppearanceConfi
 	}
 
 	cfg := codersdk.AppearanceConfig{
-		ApplicationName:             applicationName,
-		LogoURL:                     logoURL,
-		AnnouncementBanners:         []codersdk.BannerConfig{},
-		SupportLinks:                codersdk.DefaultSupportLinks(f.docsURL),
-		DocsURL:                     f.docsURL,
-		AIProvidersEnvDriftDetected: f.aiProvidersEnvDrift != nil && f.aiProvidersEnvDrift.Load(),
+		ApplicationName:     applicationName,
+		LogoURL:             logoURL,
+		AnnouncementBanners: []codersdk.BannerConfig{},
+		SupportLinks:        codersdk.DefaultSupportLinks(f.docsURL),
+		DocsURL:             f.docsURL,
 	}
 
 	if announcementBannersJSON != "" {
@@ -121,6 +119,9 @@ func (f *appearanceFetcher) Fetch(ctx context.Context) (codersdk.AppearanceConfi
 	}
 	if len(f.supportLinks) > 0 {
 		cfg.SupportLinks = f.supportLinks
+	}
+	for _, opt := range f.options {
+		opt(&cfg)
 	}
 
 	return cfg, nil

--- a/enterprise/coderd/appearance.go
+++ b/enterprise/coderd/appearance.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync/atomic"
 
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/xerrors"
@@ -42,21 +43,23 @@ func (api *API) appearance(rw http.ResponseWriter, r *http.Request) {
 }
 
 type appearanceFetcher struct {
-	database     database.Store
-	supportLinks []codersdk.LinkConfig
-	docsURL      string
-	coderVersion string
+	database            database.Store
+	supportLinks        []codersdk.LinkConfig
+	docsURL             string
+	coderVersion        string
+	aiProvidersEnvDrift *atomic.Bool
 }
 
-func newAppearanceFetcher(store database.Store, links []codersdk.LinkConfig, docsURL, coderVersion string) agpl.Fetcher {
+func newAppearanceFetcher(store database.Store, links []codersdk.LinkConfig, docsURL, coderVersion string, aiProvidersEnvDrift *atomic.Bool) agpl.Fetcher {
 	if docsURL == "" {
 		docsURL = codersdk.DefaultDocsURL()
 	}
 	return &appearanceFetcher{
-		database:     store,
-		supportLinks: links,
-		docsURL:      docsURL,
-		coderVersion: coderVersion,
+		database:            store,
+		supportLinks:        links,
+		docsURL:             docsURL,
+		coderVersion:        coderVersion,
+		aiProvidersEnvDrift: aiProvidersEnvDrift,
 	}
 }
 
@@ -94,11 +97,12 @@ func (f *appearanceFetcher) Fetch(ctx context.Context) (codersdk.AppearanceConfi
 	}
 
 	cfg := codersdk.AppearanceConfig{
-		ApplicationName:     applicationName,
-		LogoURL:             logoURL,
-		AnnouncementBanners: []codersdk.BannerConfig{},
-		SupportLinks:        codersdk.DefaultSupportLinks(f.docsURL),
-		DocsURL:             f.docsURL,
+		ApplicationName:             applicationName,
+		LogoURL:                     logoURL,
+		AnnouncementBanners:         []codersdk.BannerConfig{},
+		SupportLinks:                codersdk.DefaultSupportLinks(f.docsURL),
+		DocsURL:                     f.docsURL,
+		AIProvidersEnvDriftDetected: f.aiProvidersEnvDrift != nil && f.aiProvidersEnvDrift.Load(),
 	}
 
 	if announcementBannersJSON != "" {

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -1008,17 +1008,20 @@ func (api *API) updateEntitlements(ctx context.Context) error {
 		}
 
 		if initial, changed, enabled := featureChanged(codersdk.FeatureAppearance); shouldUpdate(initial, changed, enabled) {
+			withAIProvidersEnvDrift := func(cfg *codersdk.AppearanceConfig) {
+				cfg.AIProvidersEnvDriftDetected = api.AGPL.AIProvidersEnvDrift.Load()
+			}
 			if enabled {
 				f := newAppearanceFetcher(
 					api.Database,
 					api.DeploymentValues.Support.Links.Value,
 					api.DeploymentValues.DocsURL.String(),
 					buildinfo.Version(),
-					&api.AGPL.AIProvidersEnvDrift,
+					withAIProvidersEnvDrift,
 				)
 				api.AGPL.AppearanceFetcher.Store(&f)
 			} else {
-				f := appearance.NewDefaultFetcher(api.DeploymentValues.DocsURL.String(), &api.AGPL.AIProvidersEnvDrift)
+				f := appearance.NewDefaultFetcher(api.DeploymentValues.DocsURL.String(), withAIProvidersEnvDrift)
 				api.AGPL.AppearanceFetcher.Store(&f)
 			}
 		}

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -1014,10 +1014,11 @@ func (api *API) updateEntitlements(ctx context.Context) error {
 					api.DeploymentValues.Support.Links.Value,
 					api.DeploymentValues.DocsURL.String(),
 					buildinfo.Version(),
+					&api.AGPL.AIProvidersEnvDrift,
 				)
 				api.AGPL.AppearanceFetcher.Store(&f)
 			} else {
-				f := appearance.NewDefaultFetcher(api.DeploymentValues.DocsURL.String())
+				f := appearance.NewDefaultFetcher(api.DeploymentValues.DocsURL.String(), &api.AGPL.AIProvidersEnvDrift)
 				api.AGPL.AppearanceFetcher.Store(&f)
 			}
 		}

--- a/site/site.go
+++ b/site/site.go
@@ -88,7 +88,7 @@ type Options struct {
 func New(opts *Options) (*Handler, error) {
 	if opts.AppearanceFetcher == nil {
 		daf := atomic.Pointer[appearance.Fetcher]{}
-		f := appearance.NewDefaultFetcher(opts.DocsURL, nil)
+		f := appearance.NewDefaultFetcher(opts.DocsURL)
 		daf.Store(&f)
 		opts.AppearanceFetcher = &daf
 	}

--- a/site/site.go
+++ b/site/site.go
@@ -88,7 +88,7 @@ type Options struct {
 func New(opts *Options) (*Handler, error) {
 	if opts.AppearanceFetcher == nil {
 		daf := atomic.Pointer[appearance.Fetcher]{}
-		f := appearance.NewDefaultFetcher(opts.DocsURL)
+		f := appearance.NewDefaultFetcher(opts.DocsURL, nil)
 		daf.Store(&f)
 		opts.AppearanceFetcher = &daf
 	}

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2393,6 +2393,7 @@ class ApiMethods {
 					service_banner: {
 						enabled: false,
 					},
+					ai_providers_env_drift_detected: false,
 				};
 			}
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1132,6 +1132,13 @@ export interface AppearanceConfig {
 	readonly service_banner: BannerConfig;
 	readonly announcement_banners: readonly BannerConfig[];
 	readonly support_links?: readonly LinkConfig[];
+	/**
+	 * AIProvidersEnvDriftDetected is true when deprecated CODER_AIBRIDGE_*
+	 * env configuration differs from the AI provider rows already stored in
+	 * the database, meaning those env changes are ineffective. It is
+	 * output-only and is not part of UpdateAppearanceConfig.
+	 */
+	readonly ai_providers_env_drift_detected: boolean;
 }
 
 // From codersdk/templates.go

--- a/site/src/modules/dashboard/AIProviderEnvDriftBanner/AIProviderEnvDriftBanner.stories.tsx
+++ b/site/src/modules/dashboard/AIProviderEnvDriftBanner/AIProviderEnvDriftBanner.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
+import { chromatic } from "#/testHelpers/chromatic";
+import {
+	MockAppearanceConfig,
+	MockBuildInfo,
+	MockDefaultOrganization,
+	MockEntitlements,
+	MockExperiments,
+} from "#/testHelpers/entities";
+import { docs } from "#/utils/docs";
+import { DashboardContext, type DashboardValue } from "../DashboardProvider";
+import {
+	AIProviderEnvDriftBanner,
+	AIProviderEnvDriftBannerView,
+} from "./AIProviderEnvDriftBanner";
+
+const meta: Meta<typeof AIProviderEnvDriftBannerView> = {
+	title: "modules/dashboard/AIProviderEnvDriftBanner",
+	parameters: { chromatic },
+	component: AIProviderEnvDriftBannerView,
+};
+
+export default meta;
+type Story = StoryObj<typeof AIProviderEnvDriftBannerView>;
+
+export const Default: Story = {
+	args: {
+		docsHref: docs("/ai-coder/ai-gateway/setup"),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByRole("status")).toBeInTheDocument();
+		await expect(
+			canvas.getByRole("link", { name: /View setup docs/i }),
+		).toHaveAttribute("href", docs("/ai-coder/ai-gateway/setup"));
+	},
+};
+
+const renderBannerWithDrift = (driftDetected: boolean) => {
+	const value: DashboardValue = {
+		entitlements: MockEntitlements,
+		experiments: MockExperiments,
+		appearance: {
+			...MockAppearanceConfig,
+			ai_providers_env_drift_detected: driftDetected,
+		},
+		buildInfo: MockBuildInfo,
+		organizations: [MockDefaultOrganization],
+		showOrganizations: false,
+		canViewOrganizationSettings: false,
+	};
+	return (
+		<DashboardContext.Provider value={value}>
+			<AIProviderEnvDriftBanner />
+		</DashboardContext.Provider>
+	);
+};
+
+export const DriftDetected: Story = {
+	render: () => renderBannerWithDrift(true),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByRole("status")).toBeInTheDocument();
+		await expect(
+			canvas.getByRole("link", { name: /View setup docs/i }),
+		).toHaveAttribute("href", docs("/ai-coder/ai-gateway/setup"));
+	},
+};
+
+export const NoDrift: Story = {
+	render: () => renderBannerWithDrift(false),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.queryByRole("status")).not.toBeInTheDocument();
+	},
+};

--- a/site/src/modules/dashboard/AIProviderEnvDriftBanner/AIProviderEnvDriftBanner.tsx
+++ b/site/src/modules/dashboard/AIProviderEnvDriftBanner/AIProviderEnvDriftBanner.tsx
@@ -1,0 +1,63 @@
+import { TriangleAlertIcon } from "lucide-react";
+import type { FC } from "react";
+import { Link } from "#/components/Link/Link";
+import { useDashboard } from "#/modules/dashboard/useDashboard";
+import { docs } from "#/utils/docs";
+
+interface AIProviderEnvDriftBannerViewProps {
+	docsHref: string;
+}
+
+/**
+ * AIProviderEnvDriftBannerView is the presentational banner. It is pure
+ * (props only) so it can be exercised in Storybook without dashboard
+ * context. Styling mirrors the single-message LicenseBannerView so the
+ * two banners stack consistently.
+ */
+export const AIProviderEnvDriftBannerView: FC<
+	AIProviderEnvDriftBannerViewProps
+> = ({ docsHref }) => {
+	return (
+		<div role="status" className="flex items-center p-3 bg-surface-secondary">
+			<div className="flex min-w-0 flex-1 items-start gap-2">
+				<div className="flex h-6 items-center">
+					<TriangleAlertIcon className="size-4 text-content-warning" />
+				</div>
+				<div className="flex min-h-6 min-w-0 flex-1 items-center text-xs leading-4 text-content-primary">
+					<span>
+						Changes to the deprecated AI provider environment variables
+						(CODER_AIBRIDGE_*) are ineffective. Manage AI providers through the
+						dashboard, which is the source of truth.{" "}
+						<Link
+							className="text-xs font-medium !text-content-link"
+							href={docsHref}
+							target="_blank"
+						>
+							View setup docs
+						</Link>
+					</span>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+/**
+ * AIProviderEnvDriftBanner warns admins when deprecated CODER_AIBRIDGE_*
+ * env configuration drifts from the AI provider rows in the database,
+ * which makes those env changes ineffective. It renders nothing when no
+ * drift was detected at startup.
+ */
+export const AIProviderEnvDriftBanner: FC = () => {
+	const { appearance } = useDashboard();
+
+	if (!appearance.ai_providers_env_drift_detected) {
+		return null;
+	}
+
+	return (
+		<AIProviderEnvDriftBannerView
+			docsHref={docs("/ai-coder/ai-gateway/setup")}
+		/>
+	);
+};

--- a/site/src/modules/dashboard/DashboardLayout.tsx
+++ b/site/src/modules/dashboard/DashboardLayout.tsx
@@ -6,6 +6,7 @@ import { Outlet } from "react-router";
 import { Button } from "#/components/Button/Button";
 import { Loader } from "#/components/Loader/Loader";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
+import { AIProviderEnvDriftBanner } from "#/modules/dashboard/AIProviderEnvDriftBanner/AIProviderEnvDriftBanner";
 import { AnnouncementBanners } from "#/modules/dashboard/AnnouncementBanners/AnnouncementBanners";
 import { LicenseBanner } from "#/modules/dashboard/LicenseBanner/LicenseBanner";
 import { cn } from "#/utils/cn";
@@ -22,6 +23,7 @@ export const DashboardLayout: FC = () => {
 	return (
 		<>
 			{canViewDeployment && <LicenseBanner />}
+			{canViewDeployment && <AIProviderEnvDriftBanner />}
 			<AnnouncementBanners />
 
 			<div className="flex flex-col min-h-screen justify-between">

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -3392,6 +3392,7 @@ export const MockAppearanceConfig: TypesGen.AppearanceConfig = {
 	},
 	announcement_banners: [],
 	docs_url: "https://coder.com/docs/@main/",
+	ai_providers_env_drift_detected: false,
 };
 
 export const MockWorkspaceBuildParameter1: TypesGen.WorkspaceBuildParameter = {


### PR DESCRIPTION
AI-provider configuration via `CODER_AIBRIDGE_*` env vars is deprecated in favor of managing providers through the API/UI, where the database is the source of truth. Previously, if an env-derived provider differed from an already-seeded `ai_providers` row ("drift"), the server **failed to start**. For a deprecated mechanism that is too strict.

Now drift is non-fatal: `SeedAIProvidersFromEnv` leaves the existing row untouched, logs a warning, still inserts any other missing providers, and reports an `ineffective` flag. That flag is stored on a process-local atomic and surfaced (output-only) via `AppearanceConfig.ai_providers_env_drift_detected`. The dashboard renders an admin-only warning banner that stacks beneath the license banner and links to the AI gateway setup docs. Pre-transaction validation errors (name conflicts, invalid names, conflicting hashes) stay fatal.

The banner is gated on `viewDeploymentConfig` (admins only), mirroring `LicenseBanner`, and its presentation lives in a pure subcomponent covered by a Storybook story.

The appearance fetchers expose dynamic, deployment-derived fields through a general-purpose variadic `appearance.Option` (`func(*codersdk.AppearanceConfig)`) applied at fetch time, rather than a per-field constructor parameter. Callers that need nothing dynamic stay on `NewDefaultFetcher(docsURL)`; the env-drift value is injected as a closure from `coderd`/`enterprise/coderd`, so the `appearance` package stays agnostic and future live fields add no constructor churn.

<details>
<summary>Implementation plan (original)</summary>

> Note: section 3 below described threading a `*atomic.Bool` parameter through the fetcher constructors. That was generalized during review into the variadic `appearance.Option` mechanism described above.

# Plan: Warn (don't fail) on ineffective deprecated AI-provider env config

## Context

AI-provider configuration via `CODER_AIBRIDGE_*` env vars is deprecated in favor of managing providers through the API/UI. At startup, `SeedAIProvidersFromEnv` (`coderd/ai_providers_migrate.go`) reconciles env-derived providers with the `ai_providers` table. Today, when an env-derived provider differs from the existing DB row ("drift", detected via `computeProviderHash`), the server **fails to start** with a hard error.

For a deprecated mechanism this is too strict: operators who tweak the old env vars after the provider was already seeded should not be blocked from booting. Instead, startup should succeed and surface a **non-dismissable warning banner** to admins, telling them their env changes are ineffective (the DB is the source of truth) and linking to the setup docs. The banner must **stack** with any other active banners.

Decisions already made with the user:
- Trigger: the existing drift condition (env config differs from DB row).
- Audience: **admins only** (gate on `viewDeploymentConfig`, like `LicenseBanner`).
- Exposure: an **output-only boolean on `AppearanceConfig`** (no new endpoint), populated live by the appearance fetchers from a process-local atomic.
- Banner text/link live in the frontend; backend exposes only the boolean.

## Backend

### 1. Make drift non-fatal + return a flag
- `SeedAIProvidersFromEnv(...) (ineffective bool, err error)`.
- Closure-captured `drift`/`driftedNames`, reset at the top of the `InTx` closure for retry safety.
- Replace the drift `return xerrors.Errorf(...)` with `drift = true`, collect the name, and `continue` so other missing providers still insert and the tx commits. Emit a single consolidated `logger.Warn` after commit.
- Pre-transaction validation errors stay fatal.

### 2. Process-local atomic on the API
- `AIProvidersEnvDrift atomic.Bool` on the `API` struct.
- `cli/server.go` (authoritative, both editions) and `enterprise/cli/server.go` (early proxy-gated seed) capture the bool and `Store(ineffective)`.

### 3. Surface via AppearanceConfig (live fetch)
- `codersdk` `AppearanceConfig.AIProvidersEnvDriftDetected` (output-only, not on `UpdateAppearanceConfig`).
- AGPL + enterprise fetchers read the atomic (nil-guarded) and set the field; all four constructor callers updated.

### 4. Generate
- `make gen` for `typesGenerated.ts` + swagger.

## Frontend
- `AIProviderEnvDriftBanner` reads `useDashboard().appearance.ai_providers_env_drift_detected`, returns null when false, renders a warning banner (visual parity with single-message `LicenseBannerView`) linking to `docs("/ai-coder/ai-gateway/setup")`. Presentation kept in a pure subcomponent.
- `DashboardLayout.tsx` renders it inside the `canViewDeployment` gate next to `<LicenseBanner />` so it stacks and is admin-only.
- Storybook story covers shown/hidden states and the link.

## Tests
- `TestSeedAIProvidersFromEnv` callers capture two return values; the four drift subtests flip from asserting an error to asserting `ineffective == true` + the DB row retaining original values. The multi-provider case also asserts a brand-new provider is still inserted (exercising `continue`). Validation subtests stay fatal.

</details>

---

> [!NOTE]
> This PR was generated by Coder Agents on behalf of @dannykopping.
