### PR TITLE
test(coderd/coderdtest/oidctest): scope IDP NotFound errors to IDP paths

### DIFF
--- a/coderd/coderdtest/oidctest/idp.go
+++ b/coderd/coderdtest/oidctest/idp.go
@@ -1413,9 +1413,28 @@ func (f *FakeIDP) httpHandler(t testing.TB) http.Handler {
 		}.Encode())
 	}))
 
-	mux.NotFound(func(_ http.ResponseWriter, r *http.Request) {
-		f.logger.Error(r.Context(), "http call not found", slogRequestFields(r)...)
-		t.Errorf("unexpected request to IDP at path %q. Not supported", r.URL.Path)
+	mux.NotFound(func(rw http.ResponseWriter, r *http.Request) {
+		// When the IDP runs as a real HTTP server (WithServing), OS
+		// port reuse can route stale connections from other tests to
+		// this server. Only fail the test for paths that look like
+		// legitimate IDP requests (OIDC protocol paths). Non-IDP
+		// paths (e.g. /api/v2/.../provisionerdaemons/serve, /derp)
+		// are cross-test contamination; return an error to the caller
+		// so the offending test can be traced, but do not fail this
+		// test.
+		idpPath := strings.HasPrefix(r.URL.Path, "/oauth2/") ||
+			strings.HasPrefix(r.URL.Path, "/.well-known/") ||
+			strings.HasPrefix(r.URL.Path, "/login/") ||
+			strings.HasPrefix(r.URL.Path, "/external-auth-validate/")
+		if idpPath {
+			f.logger.Error(r.Context(), "unexpected IDP request at unhandled path", slogRequestFields(r)...)
+			t.Errorf("unexpected request to IDP at path %q. Not supported", r.URL.Path)
+			http.Error(rw, fmt.Sprintf("unexpected IDP request at path %q", r.URL.Path), http.StatusNotFound)
+		} else {
+			f.logger.Warn(r.Context(), "non-IDP request received, likely cross-test port reuse", slogRequestFields(r)...)
+			t.Logf("ignoring non-IDP request at path %q (likely cross-test port reuse)", r.URL.Path)
+			http.Error(rw, fmt.Sprintf("misdirected request to IDP at path %q", r.URL.Path), http.StatusMisdirectedRequest)
+		}
 	})
 
 	return mux


### PR DESCRIPTION
The FakeIDP `mux.NotFound` handler called `t.Errorf` for any unrecognized HTTP request path, failing the owning test. It also never wrote an HTTP response, so the stale caller got a 200 with an empty body, hiding the problem on the caller side.

When the IDP runs as a real HTTP server (`WithServing`), OS port reuse across concurrent test binaries can route stale connections to the IDP port. The source is enterprise provisionerd reconnects (`NewExternalProvisionerDaemon` -> `codersdk.ServeProvisionerDaemon`) and DERP clients from parallel tests whose coderd servers have shut down.

Flake: [test-go-pg-17](https://github.com/coder/coder/actions/runs/26645398613/job/78529513578?pr=25840). Same class as [#13788](https://github.com/coder/coder/issues/13788) (`/derp`) and [coder/internal#280](https://github.com/coder/internal/issues/280).

The NotFound handler now checks if the request path starts with a known IDP route prefix (`/oauth2/`, `/.well-known/`, `/login/`, `/external-auth-validate/`). Both branches return a proper HTTP error so the offending caller can be traced:

- **IDP paths**: `t.Errorf` + `logger.Error` + **404 Not Found** (real protocol violation)
- **Non-IDP paths**: `t.Logf` + `logger.Warn` + **421 Misdirected Request** (cross-test port reuse)

> 🤖 Generated by Coder Agents on behalf of @mafredri. This PR _will be_ reviewed by a human. 🏂🏻