### PR TITLE
fix(site/src/pages/AgentsPage): stabilize settings story

### DIFF
--- a/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
@@ -936,23 +936,7 @@ export const WithErrorReasons: Story = {
 
 const openSettingsView = async (canvasElement: HTMLElement) => {
 	const canvas = within(canvasElement);
-	const settingsLink = canvas.queryByRole("link", { name: "Settings" });
-	if (settingsLink) {
-		await userEvent.click(settingsLink);
-		return;
-	}
-
-	const mobileMoreOptionsButton = canvas
-		.getAllByRole("button", { name: "More options" })
-		.find((button) => button.getAttribute("aria-haspopup") === "menu");
-	if (!mobileMoreOptionsButton) {
-		throw new Error("Expected a mobile More options menu button.");
-	}
-	await userEvent.click(mobileMoreOptionsButton);
-	const body = within(canvasElement.ownerDocument.body);
-	await userEvent.click(
-		await body.findByRole("menuitem", { name: "Settings" }),
-	);
+	await userEvent.click(await canvas.findByRole("link", { name: "Settings" }));
 };
 
 export const OpensAnalyticsForAdmins: Story = {


### PR DESCRIPTION
I ran into the `SettingsViewResets` Storybook flake twice on my branch. The story reopens Agents settings immediately after clicking `Back to Agents`, but the helper was synchronously checking for the desktop `Settings` link before React Router had finished rendering `/agents`; on desktop it could then fall through to the mobile-only `More options` menu and fail.

Use `findByRole` for the desktop `Settings` link so the helper waits for the accessible sidebar link before clicking it, matching the existing Storybook interaction pattern used elsewhere in Agents stories.
