### PR TITLE
fix(site/src/pages/AgentsPage): drop misleading response-startup warning

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -531,7 +531,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 						>
 							<div className="px-4">
 								<ChatPageTimeline
-									chatID={agentId}
 									store={store}
 									persistedError={persistedError}
 									onEditUserMessage={

--- a/site/src/pages/AgentsPage/components/ChatConversation/ChatStatusCallout.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ChatStatusCallout.tsx
@@ -7,8 +7,6 @@ import { ToolIcon } from "../ChatElements/tools/ToolIcon";
 import { getProviderStatusURL } from "./chatStatusHelpers";
 import type { LiveStatusModel } from "./liveStatusModel";
 
-const RESPONSE_STARTUP_GRACE_MS = 15_000;
-const DELAYED_STARTUP_TEXT = "Response startup is taking longer than expected";
 const THINKING_TEXT = "Thinking...";
 
 type RetryOrFailedStatus = Extract<
@@ -35,25 +33,6 @@ const StatusPlaceholder: FC<{
 				</span>
 			)}
 		</TranscriptRow>
-	);
-};
-
-const StartingPlaceholder: FC = () => {
-	const [isDelayed, setIsDelayed] = useState(false);
-
-	useEffect(() => {
-		const timeout = window.setTimeout(() => {
-			setIsDelayed(true);
-		}, RESPONSE_STARTUP_GRACE_MS);
-		return () => window.clearTimeout(timeout);
-	}, []);
-
-	return (
-		<StatusPlaceholder
-			text={isDelayed ? DELAYED_STARTUP_TEXT : THINKING_TEXT}
-			shimmer={!isDelayed}
-			showThinkingIcon={!isDelayed}
-		/>
 	);
 };
 
@@ -195,14 +174,15 @@ const ReconnectingAlert: FC<{ status: ReconnectingStatus }> = ({ status }) => {
 
 export const ChatStatusCallout: FC<{
 	status: LiveStatusModel;
-	startingResetKey?: string;
-}> = ({ status, startingResetKey }) => {
+}> = ({ status }) => {
 	switch (status.phase) {
 		case "idle":
 		case "streaming":
 			return null;
 		case "starting":
-			return <StartingPlaceholder key={startingResetKey ?? "starting"} />;
+			return (
+				<StatusPlaceholder text={THINKING_TEXT} shimmer showThinkingIcon />
+			);
 		case "retrying":
 			return (
 				<>

--- a/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
@@ -35,7 +35,6 @@ interface LiveStreamTailContentProps {
 	streamState: StreamState | null;
 	streamTools: readonly MergedTool[];
 	liveStatus: LiveStatusModel;
-	startingResetKey?: string;
 	subagentTitles: Map<string, string>;
 	subagentVariants?: Map<string, SubagentVariant>;
 	subagentStatusOverrides: Map<string, TypesGen.ChatStatus>;
@@ -48,7 +47,6 @@ export const LiveStreamTailContent = ({
 	streamState,
 	streamTools,
 	liveStatus,
-	startingResetKey,
 	subagentTitles,
 	subagentVariants,
 	subagentStatusOverrides,
@@ -88,7 +86,6 @@ export const LiveStreamTailContent = ({
 					streamState={streamState}
 					streamTools={streamTools}
 					liveStatus={liveStatus}
-					startingResetKey={startingResetKey}
 					subagentTitles={subagentTitles}
 					subagentVariants={subagentVariants}
 					subagentStatusOverrides={subagentStatusOverrides}
@@ -118,7 +115,6 @@ interface LiveStreamTailProps {
 	store: ChatStoreHandle;
 	persistedError: ChatDetailError | undefined;
 	isTranscriptEmpty: boolean;
-	startingResetKey?: string;
 	subagentTitles: Map<string, string>;
 	subagentVariants?: Map<string, SubagentVariant>;
 	urlTransform?: UrlTransform;
@@ -129,7 +125,6 @@ export const LiveStreamTail = ({
 	store,
 	persistedError,
 	isTranscriptEmpty,
-	startingResetKey,
 	subagentTitles,
 	subagentVariants,
 	urlTransform,
@@ -166,7 +161,6 @@ export const LiveStreamTail = ({
 			streamState={streamState}
 			streamTools={streamTools}
 			liveStatus={liveStatus}
-			startingResetKey={startingResetKey}
 			subagentTitles={subagentTitles}
 			subagentVariants={subagentVariants}
 			subagentStatusOverrides={subagentStatusOverrides}

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -52,7 +52,6 @@ export const StreamingOutput: FC<{
 	subagentVariants?: Map<string, SubagentVariant>;
 	subagentStatusOverrides?: Map<string, TypesGen.ChatStatus>;
 	liveStatus: LiveStatusModel;
-	startingResetKey?: string;
 	urlTransform?: UrlTransform;
 	mcpServers?: readonly TypesGen.MCPServerConfig[];
 }> = ({
@@ -62,7 +61,6 @@ export const StreamingOutput: FC<{
 	subagentVariants,
 	subagentStatusOverrides,
 	liveStatus,
-	startingResetKey,
 	urlTransform,
 	mcpServers,
 }) => {
@@ -113,10 +111,7 @@ export const StreamingOutput: FC<{
 						)}
 						{needsStreamingThinking && <StreamingThinkingPlaceholder />}
 						{!needsStreamingThinking && hasTransientLiveStatus(liveStatus) && (
-							<ChatStatusCallout
-								status={liveStatus}
-								startingResetKey={startingResetKey}
-							/>
+							<ChatStatusCallout status={liveStatus} />
 						)}
 					</div>
 				</MessageContent>

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -101,13 +101,7 @@ export const StreamingToolCallGapRegression: Story = {
 		store.setStreamState(streamState);
 		store.setChatStatus("pending");
 
-		return (
-			<ChatPageTimeline
-				chatID={CHAT_ID}
-				store={store}
-				persistedError={undefined}
-			/>
-		);
+		return <ChatPageTimeline store={store} persistedError={undefined} />;
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -120,13 +114,7 @@ export const StartingPhaseToolCallGapRegression: Story = {
 		const store = buildRegressionStore();
 		store.setChatStatus("running");
 
-		return (
-			<ChatPageTimeline
-				chatID={CHAT_ID}
-				store={store}
-				persistedError={undefined}
-			/>
-		);
+		return <ChatPageTimeline store={store} persistedError={undefined} />;
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -139,13 +127,7 @@ export const SpacerVisibleWhenNotStreaming: Story = {
 	render: () => {
 		const store = buildThinkingSpacerStore();
 
-		return (
-			<ChatPageTimeline
-				chatID={CHAT_ID}
-				store={store}
-				persistedError={undefined}
-			/>
-		);
+		return <ChatPageTimeline store={store} persistedError={undefined} />;
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -165,13 +147,7 @@ export const HiddenAssistantPlaceholderDoesNotRender: Story = {
 			buildMessage(4, "user", [{ type: "text", text: "Thanks!" }]),
 		]);
 
-		return (
-			<ChatPageTimeline
-				chatID={CHAT_ID}
-				store={store}
-				persistedError={undefined}
-			/>
-		);
+		return <ChatPageTimeline store={store} persistedError={undefined} />;
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -46,7 +46,6 @@ const isChatMessage = (
 ): message is TypesGen.ChatMessage => Boolean(message);
 
 interface ChatPageTimelineProps {
-	chatID?: string;
 	store: ChatStoreHandle;
 	persistedError: ChatDetailError | undefined;
 	onEditUserMessage?: (
@@ -62,7 +61,6 @@ interface ChatPageTimelineProps {
 }
 
 export const ChatPageTimeline: FC<ChatPageTimelineProps> = ({
-	chatID,
 	store,
 	persistedError,
 	onEditUserMessage,
@@ -133,7 +131,6 @@ export const ChatPageTimeline: FC<ChatPageTimelineProps> = ({
 				<LiveStreamTail
 					store={store}
 					persistedError={persistedError}
-					startingResetKey={chatID}
 					isTranscriptEmpty={parsedMessages.length === 0}
 					subagentTitles={subagentTitles}
 					subagentVariants={subagentVariants}


### PR DESCRIPTION
The agents UI showed "Response startup is taking longer than expected" after a 15s grace period while waiting on the LLM provider. The message implied a problem was about to occur, but it does not actually lead to a timeout. The typical underlying cause is provider slowness rather than a client-side issue, so the warning is alarmist and unhelpful.

Drop the delayed message and its timer entirely. The `starting` phase now keeps showing the shimmering "Thinking..." indicator until the first stream chunk arrives. Also remove the now-dead `startingResetKey` / `chatID` plumbing that only existed to remount the placeholder and reset the delayed-message timer when switching chats.

Closes CODAGT-536
