### PR TITLE
feat(coderd/mcp): add per-user custom_headers MCP API

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1367,6 +1367,10 @@ func New(options *Options) *API {
 					r.Get("/oauth2/connect", api.mcpServerOAuth2Connect)
 					r.Get("/oauth2/callback", api.mcpServerOAuth2Callback)
 					r.Delete("/oauth2/disconnect", api.mcpServerOAuth2Disconnect)
+					// Per-user custom header values for admin-marked keys.
+					r.Get("/user-headers", api.getMCPServerUserHeaderValues)
+					r.Put("/user-headers", api.updateMCPServerUserHeaderValues)
+					r.Delete("/user-headers", api.deleteMCPServerUserHeaderValues)
 				})
 			})
 			// MCP HTTP transport endpoint with mandatory authentication

--- a/coderd/mcp.go
+++ b/coderd/mcp.go
@@ -183,6 +183,26 @@ func (api *API) listMCPServerConfigs(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Look up the calling user's custom_headers user-set values so
+	// auth_connected can reflect whether the user has supplied every
+	// required header.
+	userHeaderValues, err := api.Database.GetMCPServerUserHeaderValuesByUserID(ctx, apiKey.UserID)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to get user header values.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+	headerValuesByConfigID, err := decodeMCPUserHeaderValues(userHeaderValues)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to decode user header values.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
 	// Build a config lookup for the refresh helper.
 	configByID := make(map[uuid.UUID]database.MCPServerConfig, len(configs))
 	for _, c := range configs {
@@ -202,13 +222,19 @@ func (api *API) listMCPServerConfigs(rw http.ResponseWriter, r *http.Request) {
 	for _, config := range configs {
 		var sdkConfig codersdk.MCPServerConfig
 		if isAdmin {
-			sdkConfig = convertMCPServerConfig(config)
+			sdkConfig = convertMCPServerConfig(ctx, api.Logger, config)
 		} else {
-			sdkConfig = convertMCPServerConfigRedacted(config)
+			sdkConfig = convertMCPServerConfigRedacted(ctx, api.Logger, config)
 		}
-		if config.AuthType == "oauth2" {
+		switch config.AuthType {
+		case "oauth2":
 			sdkConfig.AuthConnected = tokenMap[config.ID]
-		} else {
+		case "custom_headers":
+			sdkConfig.AuthConnected = mcpCustomHeadersConnected(
+				headerValuesByConfigID[config.ID],
+				config.CustomHeadersUserKeys,
+			)
+		default:
 			sdkConfig.AuthConnected = true
 		}
 		resp = append(resp, sdkConfig)
@@ -236,6 +262,38 @@ func (api *API) createMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	// Validate auth-type-dependent fields.
+	// Reject custom_headers_user_keys for auth types that do not use
+	// custom headers, and validate the user-key set against the
+	// admin-set headers.
+	if len(req.CustomHeadersUserKeys) > 0 && req.AuthType != "custom_headers" {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "custom_headers_user_keys is only valid when auth_type is custom_headers.",
+		})
+		return
+	}
+	if len(req.CustomHeadersUserKeyDescriptions) > 0 && req.AuthType != "custom_headers" {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "custom_headers_user_key_descriptions is only valid when auth_type is custom_headers.",
+		})
+		return
+	}
+	customHeadersUserKeys, customHeadersUserKeyDescriptions, err := validateCustomHeaderUserKeys(req.CustomHeadersUserKeys, req.CustomHeaders, req.CustomHeadersUserKeyDescriptions)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Invalid custom_headers_user_keys.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+	customHeadersUserKeyDescriptionsJSON, err := marshalCustomHeaderUserKeyDescriptions(customHeadersUserKeyDescriptions)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Invalid custom_headers_user_key_descriptions.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
 	switch req.AuthType {
 	case "oauth2":
 		// When the admin does not provide OAuth2 credentials, attempt
@@ -277,8 +335,8 @@ func (api *API) createMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 				APIKeyValueKeyID:                 sql.NullString{},
 				CustomHeaders:                    customHeadersJSON,
 				CustomHeadersKeyID:               sql.NullString{},
-				CustomHeadersUserKeys:            nil,
-				CustomHeadersUserKeyDescriptions: nil,
+				CustomHeadersUserKeys:            customHeadersUserKeys,
+				CustomHeadersUserKeyDescriptions: customHeadersUserKeyDescriptionsJSON,
 				ToolAllowList:                    coalesceStringSlice(trimStringSlice(req.ToolAllowList)),
 				ToolDenyList:                     coalesceStringSlice(trimStringSlice(req.ToolDenyList)),
 				Availability:                     strings.TrimSpace(req.Availability),
@@ -387,7 +445,7 @@ func (api *API) createMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			httpapi.Write(ctx, rw, http.StatusCreated, convertMCPServerConfig(updated))
+			httpapi.Write(ctx, rw, http.StatusCreated, convertMCPServerConfig(ctx, api.Logger, updated))
 			return
 		} else if req.OAuth2ClientID == "" || req.OAuth2AuthURL == "" || req.OAuth2TokenURL == "" {
 			// Partial manual config: all three fields are required together.
@@ -404,9 +462,9 @@ func (api *API) createMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 			return
 		}
 	case "custom_headers":
-		if len(req.CustomHeaders) == 0 {
+		if len(req.CustomHeaders)+len(req.CustomHeadersUserKeys) == 0 {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-				Message: "Custom headers auth type requires at least one custom header.",
+				Message: "Custom headers auth type requires at least one custom header or custom_headers_user_keys entry.",
 			})
 			return
 		}
@@ -440,8 +498,8 @@ func (api *API) createMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 		APIKeyValueKeyID:                 sql.NullString{},
 		CustomHeaders:                    customHeadersJSON,
 		CustomHeadersKeyID:               sql.NullString{},
-		CustomHeadersUserKeys:            nil,
-		CustomHeadersUserKeyDescriptions: nil,
+		CustomHeadersUserKeys:            customHeadersUserKeys,
+		CustomHeadersUserKeyDescriptions: customHeadersUserKeyDescriptionsJSON,
 		ToolAllowList:                    coalesceStringSlice(trimStringSlice(req.ToolAllowList)),
 		ToolDenyList:                     coalesceStringSlice(trimStringSlice(req.ToolDenyList)),
 		Availability:                     strings.TrimSpace(req.Availability),
@@ -475,7 +533,7 @@ func (api *API) createMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	httpapi.Write(ctx, rw, http.StatusCreated, convertMCPServerConfig(inserted))
+	httpapi.Write(ctx, rw, http.StatusCreated, convertMCPServerConfig(ctx, api.Logger, inserted))
 }
 
 // @Summary Get MCP server config
@@ -520,14 +578,15 @@ func (api *API) getMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 
 	var sdkConfig codersdk.MCPServerConfig
 	if isAdmin {
-		sdkConfig = convertMCPServerConfig(config)
+		sdkConfig = convertMCPServerConfig(ctx, api.Logger, config)
 	} else {
-		sdkConfig = convertMCPServerConfigRedacted(config)
+		sdkConfig = convertMCPServerConfigRedacted(ctx, api.Logger, config)
 	}
 
 	// Populate AuthConnected for the calling user. Attempt to
 	// refresh the token so the status is accurate.
-	if config.AuthType == "oauth2" {
+	switch config.AuthType {
+	case "oauth2":
 		//nolint:gocritic // Need to check user token for this server.
 		userTokens, err := api.Database.GetMCPServerUserTokensByUserID(dbauthz.AsSystemRestricted(ctx), apiKey.UserID)
 		if err != nil {
@@ -543,7 +602,34 @@ func (api *API) getMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 				break
 			}
 		}
-	} else {
+	case "custom_headers":
+		stored := map[string]string{}
+		if len(config.CustomHeadersUserKeys) > 0 {
+			row, hvErr := api.Database.GetMCPServerUserHeaderValues(ctx, database.GetMCPServerUserHeaderValuesParams{
+				MCPServerConfigID: config.ID,
+				UserID:            apiKey.UserID,
+			})
+			if hvErr != nil && !errors.Is(hvErr, sql.ErrNoRows) {
+				httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+					Message: "Failed to get user header values.",
+					Detail:  hvErr.Error(),
+				})
+				return
+			}
+			if hvErr == nil {
+				decoded, decErr := decodeHeaderValuesJSON(row.HeaderValues)
+				if decErr != nil {
+					httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+						Message: "Failed to decode stored user header values.",
+						Detail:  decErr.Error(),
+					})
+					return
+				}
+				stored = decoded
+			}
+		}
+		sdkConfig.AuthConnected = mcpCustomHeadersConnected(stored, config.CustomHeadersUserKeys)
+	default:
 		sdkConfig.AuthConnected = true
 	}
 
@@ -678,6 +764,67 @@ func (api *API) updateMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 			customHeadersKeyID = sql.NullString{}
 		}
 
+		// Compute the final admin headers map for disjointness
+		// validation against custom_headers_user_keys.
+		var finalAdminHeaders map[string]string
+		if req.CustomHeaders != nil {
+			finalAdminHeaders = *req.CustomHeaders
+		} else {
+			decoded, decErr := decodeCustomHeaders(existing.CustomHeaders)
+			if decErr != nil {
+				return decErr
+			}
+			finalAdminHeaders = decoded
+		}
+
+		customHeadersUserKeys := existing.CustomHeadersUserKeys
+		existingDescriptions, descErr := decodeCustomHeaderUserKeyDescriptions(existing.CustomHeadersUserKeyDescriptions)
+		if descErr != nil {
+			return descErr
+		}
+		customHeadersUserKeyDescriptions := existingDescriptions
+		switch {
+		case req.CustomHeadersUserKeys != nil:
+			if authType != "custom_headers" && len(*req.CustomHeadersUserKeys) > 0 {
+				return &mcpValidationError{msg: "custom_headers_user_keys is only valid when auth_type is custom_headers."}
+			}
+			// When the caller didn't send descriptions, carry over
+			// the existing map but silently drop entries whose key
+			// is no longer in the new key set; the validator would
+			// otherwise reject this routine refresh.
+			var descriptionsInput map[string]string
+			if req.CustomHeadersUserKeyDescriptions != nil {
+				if authType != "custom_headers" && len(*req.CustomHeadersUserKeyDescriptions) > 0 {
+					return &mcpValidationError{msg: "custom_headers_user_key_descriptions is only valid when auth_type is custom_headers."}
+				}
+				descriptionsInput = *req.CustomHeadersUserKeyDescriptions
+			} else {
+				descriptionsInput = filterDescriptionsToKeys(existingDescriptions, *req.CustomHeadersUserKeys)
+			}
+			cleanedKeys, cleanedDescriptions, vErr := validateCustomHeaderUserKeys(*req.CustomHeadersUserKeys, finalAdminHeaders, descriptionsInput)
+			if vErr != nil {
+				return &mcpValidationError{msg: vErr.Error()}
+			}
+			customHeadersUserKeys = cleanedKeys
+			customHeadersUserKeyDescriptions = cleanedDescriptions
+		case req.CustomHeadersUserKeyDescriptions != nil:
+			// Keys unchanged; descriptions are being replaced.
+			if authType != "custom_headers" && len(*req.CustomHeadersUserKeyDescriptions) > 0 {
+				return &mcpValidationError{msg: "custom_headers_user_key_descriptions is only valid when auth_type is custom_headers."}
+			}
+			_, cleanedDescriptions, vErr := validateCustomHeaderUserKeys(existing.CustomHeadersUserKeys, finalAdminHeaders, *req.CustomHeadersUserKeyDescriptions)
+			if vErr != nil {
+				return &mcpValidationError{msg: vErr.Error()}
+			}
+			customHeadersUserKeyDescriptions = cleanedDescriptions
+		case req.CustomHeaders != nil && len(existing.CustomHeadersUserKeys) > 0:
+			// Admin headers changed but user keys did not; re-validate
+			// the unchanged user keys against the new admin map.
+			if _, _, vErr := validateCustomHeaderUserKeys(existing.CustomHeadersUserKeys, finalAdminHeaders, existingDescriptions); vErr != nil {
+				return &mcpValidationError{msg: vErr.Error()}
+			}
+		}
+
 		toolAllowList := existing.ToolAllowList
 		if req.ToolAllowList != nil {
 			toolAllowList = coalesceStringSlice(trimStringSlice(*req.ToolAllowList))
@@ -729,12 +876,16 @@ func (api *API) updateMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 				apiKeyValueKeyID = sql.NullString{}
 				customHeaders = "{}"
 				customHeadersKeyID = sql.NullString{}
+				customHeadersUserKeys = nil
+				customHeadersUserKeyDescriptions = nil
 			case "oauth2":
 				apiKeyHeader = ""
 				apiKeyValue = ""
 				apiKeyValueKeyID = sql.NullString{}
 				customHeaders = "{}"
 				customHeadersKeyID = sql.NullString{}
+				customHeadersUserKeys = nil
+				customHeadersUserKeyDescriptions = nil
 			case "api_key":
 				oauth2ClientID = ""
 				oauth2ClientSecret = ""
@@ -744,6 +895,8 @@ func (api *API) updateMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 				oauth2Scopes = ""
 				customHeaders = "{}"
 				customHeadersKeyID = sql.NullString{}
+				customHeadersUserKeys = nil
+				customHeadersUserKeyDescriptions = nil
 			case "custom_headers":
 				oauth2ClientID = ""
 				oauth2ClientSecret = ""
@@ -769,7 +922,34 @@ func (api *API) updateMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 				apiKeyValueKeyID = sql.NullString{}
 				customHeaders = "{}"
 				customHeadersKeyID = sql.NullString{}
+				customHeadersUserKeys = nil
+				customHeadersUserKeyDescriptions = nil
 			}
+		}
+
+		// Post-merge validation: when staying on or moving to
+		// custom_headers, at least one admin header or one
+		// user-set key is required. Mirrors the create handler.
+		if authType == "custom_headers" && len(finalAdminHeaders)+len(customHeadersUserKeys) == 0 {
+			return &mcpValidationError{msg: "Custom headers auth type requires at least one custom header or custom_headers_user_keys entry."}
+		}
+
+		// When auth_type changes away from custom_headers or the
+		// admin alters the user-set key list, clear every user's
+		// stored header values for this config so stale
+		// credentials do not silently reactivate if the previous
+		// key set is later restored. Equal slices (order-insensitive,
+		// case-sensitive) skip the delete so a no-op update keeps
+		// each user's values intact.
+		if !mcpUserKeySetsEqual(existing.CustomHeadersUserKeys, customHeadersUserKeys) {
+			if dErr := tx.DeleteMCPServerUserHeaderValuesByConfigID(ctx, existing.ID); dErr != nil {
+				return xerrors.Errorf("clear orphaned user header values: %w", dErr)
+			}
+		}
+
+		customHeadersUserKeyDescriptionsJSON, mErr := marshalCustomHeaderUserKeyDescriptions(customHeadersUserKeyDescriptions)
+		if mErr != nil {
+			return mErr
 		}
 
 		updated, err = tx.UpdateMCPServerConfig(ctx, database.UpdateMCPServerConfigParams{
@@ -791,8 +971,8 @@ func (api *API) updateMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 			APIKeyValueKeyID:                 apiKeyValueKeyID,
 			CustomHeaders:                    customHeaders,
 			CustomHeadersKeyID:               customHeadersKeyID,
-			CustomHeadersUserKeys:            existing.CustomHeadersUserKeys,
-			CustomHeadersUserKeyDescriptions: existing.CustomHeadersUserKeyDescriptions,
+			CustomHeadersUserKeys:            coalesceStringSlice(customHeadersUserKeys),
+			CustomHeadersUserKeyDescriptions: customHeadersUserKeyDescriptionsJSON,
 			ToolAllowList:                    toolAllowList,
 			ToolDenyList:                     toolDenyList,
 			Availability:                     availability,
@@ -806,6 +986,14 @@ func (api *API) updateMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 		return err
 	}, nil)
 	if err != nil {
+		var vErr *mcpValidationError
+		if errors.As(err, &vErr) {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "Invalid MCP server config update.",
+				Detail:  vErr.Error(),
+			})
+			return
+		}
 		switch {
 		case httpapi.Is404Error(err):
 			httpapi.ResourceNotFound(rw)
@@ -831,7 +1019,7 @@ func (api *API) updateMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	httpapi.Write(ctx, rw, http.StatusOK, convertMCPServerConfig(updated))
+	httpapi.Write(ctx, rw, http.StatusOK, convertMCPServerConfig(ctx, api.Logger, updated))
 }
 
 // @Summary Delete MCP server config
@@ -1175,8 +1363,266 @@ func (api *API) mcpServerOAuth2Disconnect(rw http.ResponseWriter, r *http.Reques
 	rw.WriteHeader(http.StatusNoContent)
 }
 
-// parseMCPServerConfigID extracts the MCP server config UUID from the
-// "mcpServer" path parameter.
+// @Summary Get MCP user-set custom header values
+// @x-apidocgen {"skip": true}
+// EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+//nolint:revive // HTTP handler writes to ResponseWriter.
+func (api *API) getMCPServerUserHeaderValues(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	apiKey := httpmw.APIKey(r)
+
+	mcpServerID, ok := parseMCPServerConfigID(rw, r)
+	if !ok {
+		return
+	}
+
+	// Load the config to know which keys the admin has marked as
+	// user-set. We use system context because the user can't
+	// authorize a direct ResourceDeploymentConfig read.
+	//nolint:gocritic // Users read their own header values; need config metadata to bound the response.
+	cfg, err := api.Database.GetMCPServerConfigByID(dbauthz.AsSystemRestricted(ctx), mcpServerID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			httpapi.ResourceNotFound(rw)
+			return
+		}
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to get MCP server config.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+	if !cfg.Enabled {
+		httpapi.ResourceNotFound(rw)
+		return
+	}
+	if cfg.AuthType != "custom_headers" || len(cfg.CustomHeadersUserKeys) == 0 {
+		// No user-set keys; respond with an empty has_values map.
+		httpapi.Write(ctx, rw, http.StatusOK, codersdk.MCPServerUserHeaderValues{
+			MCPServerConfigID: cfg.ID,
+			HasValues:         map[string]bool{},
+		})
+		return
+	}
+
+	row, err := api.Database.GetMCPServerUserHeaderValues(ctx, database.GetMCPServerUserHeaderValuesParams{
+		MCPServerConfigID: mcpServerID,
+		UserID:            apiKey.UserID,
+	})
+	stored := map[string]string{}
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to get user header values.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+	if err == nil {
+		decoded, decErr := decodeHeaderValuesJSON(row.HeaderValues)
+		if decErr != nil {
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Failed to decode stored user header values.",
+				Detail:  decErr.Error(),
+			})
+			return
+		}
+		stored = decoded
+	}
+
+	hasValues := make(map[string]bool, len(cfg.CustomHeadersUserKeys))
+	for _, key := range cfg.CustomHeadersUserKeys {
+		v, _ := headerValueForKey(stored, key)
+		hasValues[key] = v != ""
+	}
+	httpapi.Write(ctx, rw, http.StatusOK, codersdk.MCPServerUserHeaderValues{
+		MCPServerConfigID: cfg.ID,
+		HasValues:         hasValues,
+	})
+}
+
+// @Summary Update MCP user-set custom header values
+// @x-apidocgen {"skip": true}
+// EXPERIMENTAL: this endpoint is experimental and is subject to change.
+func (api *API) updateMCPServerUserHeaderValues(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	apiKey := httpmw.APIKey(r)
+
+	mcpServerID, ok := parseMCPServerConfigID(rw, r)
+	if !ok {
+		return
+	}
+
+	var req codersdk.UpdateMCPServerUserHeaderValuesRequest
+	if !httpapi.Read(ctx, rw, r, &req) {
+		return
+	}
+
+	//nolint:gocritic // Users update their own header values; need config metadata to validate the request.
+	cfg, err := api.Database.GetMCPServerConfigByID(dbauthz.AsSystemRestricted(ctx), mcpServerID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			httpapi.ResourceNotFound(rw)
+			return
+		}
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to get MCP server config.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+	if !cfg.Enabled {
+		httpapi.ResourceNotFound(rw)
+		return
+	}
+	if cfg.AuthType != "custom_headers" {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "This MCP server does not support user-set headers. Contact your Coder administrator if you believe this is unexpected.",
+		})
+		return
+	}
+	if len(cfg.CustomHeadersUserKeys) == 0 {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "This MCP server has no user-set headers configured. Contact your Coder administrator to add one.",
+		})
+		return
+	}
+
+	// Build a case-insensitive lookup of allowed user keys, preserving
+	// the admin's casing for storage.
+	allowed := make(map[string]string, len(cfg.CustomHeadersUserKeys))
+	for _, k := range cfg.CustomHeadersUserKeys {
+		allowed[strings.ToLower(k)] = k
+	}
+
+	// Validate every key in the request matches an allowed user key.
+	normalized := make(map[string]string, len(req.Values))
+	for reqKey, reqVal := range req.Values {
+		canonical, ok := allowed[strings.ToLower(strings.TrimSpace(reqKey))]
+		if !ok {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: fmt.Sprintf("Header %q is not in the MCP server's user-set custom header keys.", reqKey),
+			})
+			return
+		}
+		// Reject control characters that would enable CRLF/null injection
+		// into the outgoing MCP request headers.
+		if strings.ContainsAny(reqVal, "\r\n\x00") {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: fmt.Sprintf("Header %q value contains disallowed control characters (CR, LF, or NUL).", reqKey),
+			})
+			return
+		}
+		if strings.TrimSpace(reqVal) != "" {
+			normalized[canonical] = reqVal
+		}
+	}
+
+	// Merge with any existing stored values so a partial update only
+	// overwrites the keys it touches. A user can clear a single value
+	// by sending an empty string for that key.
+	merged := map[string]string{}
+	existing, err := api.Database.GetMCPServerUserHeaderValues(ctx, database.GetMCPServerUserHeaderValuesParams{
+		MCPServerConfigID: mcpServerID,
+		UserID:            apiKey.UserID,
+	})
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to get existing user header values.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+	if err == nil {
+		decoded, decErr := decodeHeaderValuesJSON(existing.HeaderValues)
+		if decErr != nil {
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Failed to decode existing user header values.",
+				Detail:  decErr.Error(),
+			})
+			return
+		}
+		merged = decoded
+	}
+	for _, k := range cfg.CustomHeadersUserKeys {
+		if _, sent := req.Values[k]; !sent {
+			// Case-insensitive check for the canonical key.
+			alreadyInRequest := false
+			for reqKey := range req.Values {
+				if strings.EqualFold(strings.TrimSpace(reqKey), k) {
+					alreadyInRequest = true
+					break
+				}
+			}
+			if alreadyInRequest {
+				continue
+			}
+			// Preserve existing stored value if any (case-insensitive lookup
+			// so a case-only admin rename does not silently drop the value).
+			if v, has := headerValueForKey(merged, k); has && v != "" {
+				normalized[k] = v
+			}
+		}
+	}
+
+	encoded, err := json.Marshal(normalized)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to encode user header values.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	if _, err := api.Database.UpsertMCPServerUserHeaderValues(ctx, database.UpsertMCPServerUserHeaderValuesParams{
+		MCPServerConfigID: mcpServerID,
+		UserID:            apiKey.UserID,
+		HeaderValues:      string(encoded),
+		HeaderValuesKeyID: sql.NullString{},
+	}); err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to save user header values.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	hasValues := make(map[string]bool, len(cfg.CustomHeadersUserKeys))
+	for _, k := range cfg.CustomHeadersUserKeys {
+		hasValues[k] = normalized[k] != ""
+	}
+	httpapi.Write(ctx, rw, http.StatusOK, codersdk.MCPServerUserHeaderValues{
+		MCPServerConfigID: cfg.ID,
+		HasValues:         hasValues,
+	})
+}
+
+// @Summary Delete MCP user-set custom header values
+// @x-apidocgen {"skip": true}
+// EXPERIMENTAL: this endpoint is experimental and is subject to change.
+func (api *API) deleteMCPServerUserHeaderValues(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	apiKey := httpmw.APIKey(r)
+
+	mcpServerID, ok := parseMCPServerConfigID(rw, r)
+	if !ok {
+		return
+	}
+
+	err := api.Database.DeleteMCPServerUserHeaderValues(ctx, database.DeleteMCPServerUserHeaderValuesParams{
+		MCPServerConfigID: mcpServerID,
+		UserID:            apiKey.UserID,
+	})
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to delete user header values.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+	rw.WriteHeader(http.StatusNoContent)
+}
+
 // refreshMCPUserToken attempts to refresh an expired OAuth2 token
 // for the given MCP server config. Returns true when the token is
 // valid (either still fresh or successfully refreshed), false when
@@ -1238,6 +1684,8 @@ func (api *API) refreshMCPUserToken(
 	return true
 }
 
+// parseMCPServerConfigID extracts the MCP server config UUID from the
+// "mcpServer" path parameter.
 func parseMCPServerConfigID(rw http.ResponseWriter, r *http.Request) (uuid.UUID, bool) {
 	mcpServerID, err := uuid.Parse(chi.URLParam(r, "mcpServer"))
 	if err != nil {
@@ -1253,7 +1701,19 @@ func parseMCPServerConfigID(rw http.ResponseWriter, r *http.Request) (uuid.UUID,
 // convertMCPServerConfig converts a database MCP server config to the
 // SDK type. Secrets are never returned; only has_* booleans are set.
 // Admin-only fields (OAuth2 client ID, auth URLs, etc.) are included.
-func convertMCPServerConfig(config database.MCPServerConfig) codersdk.MCPServerConfig {
+// A malformed custom_headers_user_key_descriptions payload is logged
+// and defaulted to an empty map so a single corrupt row does not
+// break the entire list endpoint.
+func convertMCPServerConfig(ctx context.Context, logger slog.Logger, config database.MCPServerConfig) codersdk.MCPServerConfig {
+	descriptions, err := decodeCustomHeaderUserKeyDescriptions(config.CustomHeadersUserKeyDescriptions)
+	if err != nil {
+		logger.Warn(ctx,
+			"failed to decode mcp_server_configs.custom_headers_user_key_descriptions; defaulting to empty map",
+			slog.F("mcp_server_config_id", config.ID),
+			slog.Error(err),
+		)
+		descriptions = map[string]string{}
+	}
 	return codersdk.MCPServerConfig{
 		ID:          config.ID,
 		DisplayName: config.DisplayName,
@@ -1276,6 +1736,9 @@ func convertMCPServerConfig(config database.MCPServerConfig) codersdk.MCPServerC
 
 		HasCustomHeaders: len(config.CustomHeaders) > 0 && config.CustomHeaders != "{}",
 
+		CustomHeadersUserKeys:            coalesceStringSlice(config.CustomHeadersUserKeys),
+		CustomHeadersUserKeyDescriptions: descriptions,
+
 		ToolAllowList: coalesceStringSlice(config.ToolAllowList),
 		ToolDenyList:  coalesceStringSlice(config.ToolDenyList),
 
@@ -1290,11 +1753,15 @@ func convertMCPServerConfig(config database.MCPServerConfig) codersdk.MCPServerC
 	}
 }
 
-// convertMCPServerConfigRedacted is the same as convertMCPServerConfig
-// but strips admin-only fields (OAuth2 details, API key header) for
-// non-admin callers.
-func convertMCPServerConfigRedacted(config database.MCPServerConfig) codersdk.MCPServerConfig {
-	c := convertMCPServerConfig(config)
+// convertMCPServerConfigRedacted returns the same SDK config as
+// convertMCPServerConfig but strips admin-only fields (URL, transport,
+// OAuth2 client/auth/token URLs, scopes, API key header) so the
+// payload is safe to expose to non-admin callers. Non-secret
+// metadata such as auth_type, has_oauth2_secret, has_api_key,
+// has_custom_headers, and the user-set custom header key list is
+// retained because end users need it to wire up their own values.
+func convertMCPServerConfigRedacted(ctx context.Context, logger slog.Logger, config database.MCPServerConfig) codersdk.MCPServerConfig {
+	c := convertMCPServerConfig(ctx, logger, config)
 	c.URL = ""
 	c.Transport = ""
 	c.OAuth2ClientID = ""
@@ -1316,6 +1783,224 @@ func marshalCustomHeaders(headers map[string]string) (string, error) {
 		return "", err
 	}
 	return string(encoded), nil
+}
+
+// marshalCustomHeaderUserKeyDescriptions encodes the per-key
+// description map for storage in the JSONB column. A nil or empty
+// map produces an empty JSON object so the NOT NULL column never
+// receives SQL NULL.
+func marshalCustomHeaderUserKeyDescriptions(descriptions map[string]string) (json.RawMessage, error) {
+	if len(descriptions) == 0 {
+		return json.RawMessage("{}"), nil
+	}
+	encoded, err := json.Marshal(descriptions)
+	if err != nil {
+		return nil, err
+	}
+	return encoded, nil
+}
+
+// decodeCustomHeaderUserKeyDescriptions decodes the JSONB column
+// into a Go map. Empty or null payloads decode to an empty map.
+func decodeCustomHeaderUserKeyDescriptions(raw json.RawMessage) (map[string]string, error) {
+	if len(raw) == 0 || string(raw) == "{}" || string(raw) == "null" {
+		return map[string]string{}, nil
+	}
+	var out map[string]string
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, xerrors.Errorf("decode custom_headers_user_key_descriptions: %w", err)
+	}
+	if out == nil {
+		return map[string]string{}, nil
+	}
+	return out, nil
+}
+
+// mcpValidationError signals that the InTx update closure failed due
+// to a validation rule the caller should fix; the post-tx error
+// handler maps it to HTTP 400.
+type mcpValidationError struct{ msg string }
+
+func (e *mcpValidationError) Error() string { return e.msg }
+
+// decodeCustomHeaders decodes the database custom_headers JSON column
+// to a map. Returns an empty map when the column is empty or "{}".
+func decodeCustomHeaders(headers string) (map[string]string, error) {
+	if headers == "" || headers == "{}" {
+		return map[string]string{}, nil
+	}
+	var out map[string]string
+	if err := json.Unmarshal([]byte(headers), &out); err != nil {
+		return nil, xerrors.Errorf("decode custom_headers: %w", err)
+	}
+	return out, nil
+}
+
+// decodeMCPUserHeaderValues decodes each row's header_values JSON
+// into a per-config map for the calling user.
+func decodeMCPUserHeaderValues(rows []database.McpServerUserHeaderValue) (map[uuid.UUID]map[string]string, error) {
+	out := make(map[uuid.UUID]map[string]string, len(rows))
+	for _, row := range rows {
+		values, err := decodeHeaderValuesJSON(row.HeaderValues)
+		if err != nil {
+			return nil, xerrors.Errorf("decode mcp_server_user_header_values for config %s: %w", row.MCPServerConfigID, err)
+		}
+		out[row.MCPServerConfigID] = values
+	}
+	return out, nil
+}
+
+// decodeHeaderValuesJSON decodes the header_values text column from
+// mcp_server_user_header_values into a map. An empty or whitespace-only
+// payload decodes to an empty map; malformed JSON returns an error.
+func decodeHeaderValuesJSON(raw string) (map[string]string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return map[string]string{}, nil
+	}
+	var out map[string]string
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return nil, xerrors.Errorf("decode header_values: %w", err)
+	}
+	if out == nil {
+		return map[string]string{}, nil
+	}
+	return out, nil
+}
+
+// headerValueForKey returns the stored value for key using a
+// case-insensitive match. Admin-defined keys preserve their original
+// casing in storage, so a later case-only rename of a user-set key
+// would otherwise orphan the stored value until the user re-saves.
+func headerValueForKey(stored map[string]string, key string) (string, bool) {
+	if v, ok := stored[key]; ok {
+		return v, true
+	}
+	for k, v := range stored {
+		if strings.EqualFold(k, key) {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+// mcpUserKeySetsEqual returns true when a and b contain the same
+// keys, ignoring order. Comparison is case-sensitive, so a case-only
+// admin rename of a user-set key is treated as a change and triggers
+// orphaned-value cleanup.
+func mcpUserKeySetsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := make(map[string]struct{}, len(a))
+	for _, s := range a {
+		seen[s] = struct{}{}
+	}
+	for _, s := range b {
+		if _, ok := seen[s]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// mcpCustomHeadersConnected returns true when every key in
+// requiredKeys has a non-empty stored value. When requiredKeys is
+// empty the connection is considered fully configured (admin headers
+// alone are sufficient). The stored lookup is case-insensitive so a
+// case-only admin rename does not flip a configured server back to
+// disconnected until the user re-saves.
+func mcpCustomHeadersConnected(stored map[string]string, requiredKeys []string) bool {
+	for _, k := range requiredKeys {
+		v, _ := headerValueForKey(stored, k)
+		if strings.TrimSpace(v) == "" {
+			return false
+		}
+	}
+	return true
+}
+
+// filterDescriptionsToKeys returns a copy of descriptions that only
+// contains entries whose key matches (case-insensitively) an entry
+// in keys. This is used when an admin updates the user-key list
+// without explicitly providing descriptions, so orphaned
+// descriptions for removed keys are silently dropped.
+func filterDescriptionsToKeys(descriptions map[string]string, keys []string) map[string]string {
+	if len(descriptions) == 0 || len(keys) == 0 {
+		return map[string]string{}
+	}
+	allowed := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		allowed[strings.ToLower(strings.TrimSpace(k))] = struct{}{}
+	}
+	filtered := make(map[string]string, len(descriptions))
+	for k, v := range descriptions {
+		if _, ok := allowed[strings.ToLower(strings.TrimSpace(k))]; ok {
+			filtered[k] = v
+		}
+	}
+	return filtered
+}
+
+// validateCustomHeaderUserKeys returns the cleaned (trimmed, deduped)
+// list of user-set custom header names and the cleaned description
+// map. Header names are compared case-insensitively per RFC 7230, but
+// the original casing is preserved for storage.
+//
+// It rejects: empty entries (after trim), case-insensitive duplicates,
+// any name that collides (case-insensitively) with a key in
+// adminHeaders, and any description whose key does not match (case-
+// insensitively) one of the user keys.
+//
+// Empty-string description values are dropped. Description keys are
+// rewritten to use the canonical casing from cleaned user keys so
+// callers can index by exact match.
+//
+// An empty userKeys input returns an empty slice, an empty map, and
+// no error; the caller is responsible for any auth-type-specific
+// "at least one header" check.
+func validateCustomHeaderUserKeys(userKeys []string, adminHeaders map[string]string, descriptions map[string]string) ([]string, map[string]string, error) {
+	if len(userKeys) == 0 {
+		if len(descriptions) > 0 {
+			return nil, nil, xerrors.New("custom_headers_user_key_descriptions requires at least one entry in custom_headers_user_keys")
+		}
+		return []string{}, map[string]string{}, nil
+	}
+	seen := make(map[string]string, len(userKeys))
+	cleaned := make([]string, 0, len(userKeys))
+	for _, raw := range userKeys {
+		k := strings.TrimSpace(raw)
+		if k == "" {
+			return nil, nil, xerrors.New("custom_headers_user_keys entries must not be empty")
+		}
+		lk := strings.ToLower(k)
+		if _, dup := seen[lk]; dup {
+			return nil, nil, xerrors.Errorf("duplicate custom_headers_user_keys entry %q", k)
+		}
+		seen[lk] = k
+		cleaned = append(cleaned, k)
+	}
+	for adminKey := range adminHeaders {
+		if _, conflict := seen[strings.ToLower(strings.TrimSpace(adminKey))]; conflict {
+			return nil, nil, xerrors.Errorf("custom_headers_user_keys must be disjoint from custom_headers; %q is set by both", adminKey)
+		}
+	}
+	cleanedDescriptions := make(map[string]string, len(descriptions))
+	for rawKey, rawValue := range descriptions {
+		lk := strings.ToLower(strings.TrimSpace(rawKey))
+		canonical, ok := seen[lk]
+		if !ok {
+			return nil, nil, xerrors.Errorf("custom_headers_user_key_descriptions key %q is not in custom_headers_user_keys", rawKey)
+		}
+		if _, dup := cleanedDescriptions[canonical]; dup {
+			return nil, nil, xerrors.Errorf("duplicate custom_headers_user_key_descriptions entry %q", rawKey)
+		}
+		value := strings.TrimSpace(rawValue)
+		if value == "" {
+			continue
+		}
+		cleanedDescriptions[canonical] = value
+	}
+	return cleaned, cleanedDescriptions, nil
 }
 
 // trimStringSlice trims whitespace from each element and drops empty

--- a/coderd/mcp_test.go
+++ b/coderd/mcp_test.go
@@ -403,6 +403,398 @@ func TestMCPServerConfigsUserOIDCClearsFields(t *testing.T) {
 	require.Empty(t, updated.APIKeyHeader)
 }
 
+// TestMCPServerConfigsCustomHeadersUserKeys verifies create/update
+// validation and auth-type clearing for the user-set custom header
+// keys field.
+func TestMCPServerConfigsCustomHeadersUserKeys(t *testing.T) {
+	t.Parallel()
+
+	t.Run("CreateAcceptsValidUserKeys", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		created, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+			DisplayName:           "Honcho",
+			Slug:                  "honcho",
+			Transport:             "streamable_http",
+			URL:                   "https://mcp.example.com/v1",
+			AuthType:              "custom_headers",
+			CustomHeaders:         map[string]string{"X-Org-ID": "acme"},
+			CustomHeadersUserKeys: []string{"X-User-Token"},
+			Availability:          "default_on",
+			Enabled:               true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"X-User-Token"}, created.CustomHeadersUserKeys)
+		require.True(t, created.HasCustomHeaders)
+	})
+
+	t.Run("CreateAcceptsOnlyUserKeys", func(t *testing.T) {
+		// custom_headers with no admin-set headers and only user-set
+		// keys is valid (the honcho.dev use case).
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		created, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+			DisplayName:           "Honcho",
+			Slug:                  "honcho-user",
+			Transport:             "streamable_http",
+			URL:                   "https://mcp.example.com/v1",
+			AuthType:              "custom_headers",
+			CustomHeadersUserKeys: []string{"X-User-Token"},
+			Availability:          "default_on",
+			Enabled:               true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"X-User-Token"}, created.CustomHeadersUserKeys)
+		require.False(t, created.HasCustomHeaders)
+	})
+
+	t.Run("CreateRejectsOverlap", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		_, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+			DisplayName:           "Bad",
+			Slug:                  "bad-overlap",
+			Transport:             "streamable_http",
+			URL:                   "https://mcp.example.com/v1",
+			AuthType:              "custom_headers",
+			CustomHeaders:         map[string]string{"X-Token": "shared"},
+			CustomHeadersUserKeys: []string{"x-token"}, // case-insensitive collision
+			Availability:          "default_on",
+		})
+		require.Error(t, err)
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
+	})
+
+	t.Run("CreateRejectsUserKeysForOtherAuthType", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		_, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+			DisplayName:           "Bad",
+			Slug:                  "bad-authtype",
+			Transport:             "streamable_http",
+			URL:                   "https://mcp.example.com/v1",
+			AuthType:              "none",
+			CustomHeadersUserKeys: []string{"X-User-Token"},
+			Availability:          "default_on",
+		})
+		require.Error(t, err)
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
+	})
+
+	t.Run("CreateRejectsDuplicates", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		_, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+			DisplayName:           "Bad",
+			Slug:                  "bad-dup",
+			Transport:             "streamable_http",
+			URL:                   "https://mcp.example.com/v1",
+			AuthType:              "custom_headers",
+			CustomHeadersUserKeys: []string{"X-Token", "x-token"},
+			Availability:          "default_on",
+		})
+		require.Error(t, err)
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
+	})
+
+	t.Run("UpdateReplacesUserKeys", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		created, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+			DisplayName:           "Honcho",
+			Slug:                  "honcho-upd",
+			Transport:             "streamable_http",
+			URL:                   "https://mcp.example.com/v1",
+			AuthType:              "custom_headers",
+			CustomHeadersUserKeys: []string{"X-User-Token"},
+			Availability:          "default_on",
+			Enabled:               true,
+		})
+		require.NoError(t, err)
+
+		newKeys := []string{"X-Other-Token"}
+		updated, err := client.UpdateMCPServerConfig(ctx, created.ID, codersdk.UpdateMCPServerConfigRequest{
+			CustomHeadersUserKeys: &newKeys,
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"X-Other-Token"}, updated.CustomHeadersUserKeys)
+	})
+
+	t.Run("UpdateClearsUserKeysOnAuthTypeChange", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		created, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+			DisplayName:           "Honcho",
+			Slug:                  "honcho-clear",
+			Transport:             "streamable_http",
+			URL:                   "https://mcp.example.com/v1",
+			AuthType:              "custom_headers",
+			CustomHeadersUserKeys: []string{"X-User-Token"},
+			Availability:          "default_on",
+			Enabled:               true,
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, created.CustomHeadersUserKeys)
+
+		newAuthType := "none"
+		updated, err := client.UpdateMCPServerConfig(ctx, created.ID, codersdk.UpdateMCPServerConfigRequest{
+			AuthType: &newAuthType,
+		})
+		require.NoError(t, err)
+		require.Equal(t, "none", updated.AuthType)
+		require.Empty(t, updated.CustomHeadersUserKeys)
+	})
+
+	t.Run("UpdateRejectsOverlapWithNewAdminHeaders", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		created, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+			DisplayName:           "Honcho",
+			Slug:                  "honcho-collide",
+			Transport:             "streamable_http",
+			URL:                   "https://mcp.example.com/v1",
+			AuthType:              "custom_headers",
+			CustomHeadersUserKeys: []string{"X-User-Token"},
+			Availability:          "default_on",
+			Enabled:               true,
+		})
+		require.NoError(t, err)
+
+		// Existing user keys remain unchanged, but admin adds a header
+		// that collides.
+		newHeaders := map[string]string{"x-user-token": "clash"}
+		_, err = client.UpdateMCPServerConfig(ctx, created.ID, codersdk.UpdateMCPServerConfigRequest{
+			CustomHeaders: &newHeaders,
+		})
+		require.Error(t, err)
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
+	})
+
+	t.Run("CreateRoundTripsDescriptions", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		created, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+			DisplayName:           "Honcho",
+			Slug:                  "honcho-desc",
+			Transport:             "streamable_http",
+			URL:                   "https://mcp.example.com/v1",
+			AuthType:              "custom_headers",
+			CustomHeadersUserKeys: []string{"X-User-Token", "X-User-Email"},
+			CustomHeadersUserKeyDescriptions: map[string]string{
+				"X-User-Token": "Your personal access token.",
+				"x-user-email": "  Your email address.  ", // matched case-insensitively, value trimmed
+			},
+			Availability: "default_on",
+			Enabled:      true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"X-User-Token", "X-User-Email"}, created.CustomHeadersUserKeys)
+		require.Equal(t, map[string]string{
+			"X-User-Token": "Your personal access token.",
+			"X-User-Email": "Your email address.",
+		}, created.CustomHeadersUserKeyDescriptions)
+	})
+
+	t.Run("CreateRejectsDescriptionForUnknownKey", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		_, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+			DisplayName:                      "Bad",
+			Slug:                             "bad-desc-key",
+			Transport:                        "streamable_http",
+			URL:                              "https://mcp.example.com/v1",
+			AuthType:                         "custom_headers",
+			CustomHeadersUserKeys:            []string{"X-User-Token"},
+			CustomHeadersUserKeyDescriptions: map[string]string{"X-Stranger": "unused"},
+			Availability:                     "default_on",
+		})
+		require.Error(t, err)
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
+	})
+
+	t.Run("CreateRejectsDescriptionsForOtherAuthType", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		_, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+			DisplayName:                      "Bad",
+			Slug:                             "bad-desc-authtype",
+			Transport:                        "streamable_http",
+			URL:                              "https://mcp.example.com/v1",
+			AuthType:                         "none",
+			CustomHeadersUserKeyDescriptions: map[string]string{"X-Token": "nope"},
+			Availability:                     "default_on",
+		})
+		require.Error(t, err)
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
+	})
+
+	t.Run("UpdateReplacesDescriptionsOnly", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		created, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+			DisplayName:           "Honcho",
+			Slug:                  "honcho-desc-upd",
+			Transport:             "streamable_http",
+			URL:                   "https://mcp.example.com/v1",
+			AuthType:              "custom_headers",
+			CustomHeadersUserKeys: []string{"X-User-Token"},
+			CustomHeadersUserKeyDescriptions: map[string]string{
+				"X-User-Token": "Original description.",
+			},
+			Availability: "default_on",
+			Enabled:      true,
+		})
+		require.NoError(t, err)
+
+		newDescriptions := map[string]string{"X-User-Token": "Updated description."}
+		updated, err := client.UpdateMCPServerConfig(ctx, created.ID, codersdk.UpdateMCPServerConfigRequest{
+			CustomHeadersUserKeyDescriptions: &newDescriptions,
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"X-User-Token"}, updated.CustomHeadersUserKeys)
+		require.Equal(t, map[string]string{"X-User-Token": "Updated description."}, updated.CustomHeadersUserKeyDescriptions)
+	})
+
+	t.Run("UpdateClearsDescriptionsWithEmptyMap", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		created, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+			DisplayName:                      "Honcho",
+			Slug:                             "honcho-desc-clear",
+			Transport:                        "streamable_http",
+			URL:                              "https://mcp.example.com/v1",
+			AuthType:                         "custom_headers",
+			CustomHeadersUserKeys:            []string{"X-User-Token"},
+			CustomHeadersUserKeyDescriptions: map[string]string{"X-User-Token": "Will be cleared."},
+			Availability:                     "default_on",
+			Enabled:                          true,
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, created.CustomHeadersUserKeyDescriptions)
+
+		cleared := map[string]string{}
+		updated, err := client.UpdateMCPServerConfig(ctx, created.ID, codersdk.UpdateMCPServerConfigRequest{
+			CustomHeadersUserKeyDescriptions: &cleared,
+		})
+		require.NoError(t, err)
+		require.Empty(t, updated.CustomHeadersUserKeyDescriptions)
+	})
+
+	t.Run("UpdateDropsDescriptionsForRemovedKeys", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		created, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+			DisplayName:           "Honcho",
+			Slug:                  "honcho-desc-drop",
+			Transport:             "streamable_http",
+			URL:                   "https://mcp.example.com/v1",
+			AuthType:              "custom_headers",
+			CustomHeadersUserKeys: []string{"X-Old-Token", "X-Keep-Token"},
+			CustomHeadersUserKeyDescriptions: map[string]string{
+				"X-Old-Token":  "Old.",
+				"X-Keep-Token": "Keep.",
+			},
+			Availability: "default_on",
+			Enabled:      true,
+		})
+		require.NoError(t, err)
+
+		// Replace keys without explicitly sending descriptions; the
+		// orphaned X-Old-Token entry should be silently dropped, the
+		// X-Keep-Token entry preserved.
+		newKeys := []string{"X-Keep-Token"}
+		updated, err := client.UpdateMCPServerConfig(ctx, created.ID, codersdk.UpdateMCPServerConfigRequest{
+			CustomHeadersUserKeys: &newKeys,
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"X-Keep-Token"}, updated.CustomHeadersUserKeys)
+		require.Equal(t, map[string]string{"X-Keep-Token": "Keep."}, updated.CustomHeadersUserKeyDescriptions)
+	})
+
+	t.Run("UpdateClearsDescriptionsOnAuthTypeChange", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		created, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+			DisplayName:                      "Honcho",
+			Slug:                             "honcho-desc-authtype",
+			Transport:                        "streamable_http",
+			URL:                              "https://mcp.example.com/v1",
+			AuthType:                         "custom_headers",
+			CustomHeadersUserKeys:            []string{"X-User-Token"},
+			CustomHeadersUserKeyDescriptions: map[string]string{"X-User-Token": "To be cleared."},
+			Availability:                     "default_on",
+			Enabled:                          true,
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, created.CustomHeadersUserKeyDescriptions)
+
+		newAuthType := "none"
+		updated, err := client.UpdateMCPServerConfig(ctx, created.ID, codersdk.UpdateMCPServerConfigRequest{
+			AuthType: &newAuthType,
+		})
+		require.NoError(t, err)
+		require.Equal(t, "none", updated.AuthType)
+		require.Empty(t, updated.CustomHeadersUserKeyDescriptions)
+	})
+}
+
 func TestMCPServerConfigsUserOIDCDirect(t *testing.T) {
 	t.Parallel()
 
@@ -1942,5 +2334,381 @@ func TestMCPOAuth2DiscoveryEdgeCases(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "trailing-slash-client", created.OAuth2ClientID)
 		require.True(t, created.HasOAuth2Secret)
+	})
+}
+
+// TestMCPServerUserHeaderValuesEndpoints exercises the user-headers
+// GET/PUT/DELETE flow for the per-user custom header values.
+func TestMCPServerUserHeaderValuesEndpoints(t *testing.T) {
+	t.Parallel()
+
+	createHonchoConfig := func(t *testing.T, client *codersdk.Client) codersdk.MCPServerConfig {
+		t.Helper()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		cfg, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+			DisplayName:           "Honcho",
+			Slug:                  "honcho",
+			Transport:             "streamable_http",
+			URL:                   "https://mcp.example.com/v1",
+			AuthType:              "custom_headers",
+			CustomHeaders:         map[string]string{"X-Org-ID": "acme"},
+			CustomHeadersUserKeys: []string{"X-User-Token", "X-Workspace"},
+			Availability:          "default_on",
+			Enabled:               true,
+		})
+		require.NoError(t, err)
+		return cfg
+	}
+
+	t.Run("GetReturnsAllFalseWhenNoValuesStored", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+		cfg := createHonchoConfig(t, client)
+
+		resp, err := client.MCPServerUserHeaderValues(ctx, cfg.ID)
+		require.NoError(t, err)
+		require.Equal(t, cfg.ID, resp.MCPServerConfigID)
+		require.False(t, resp.HasValues["X-User-Token"])
+		require.False(t, resp.HasValues["X-Workspace"])
+	})
+
+	t.Run("GetReturnsEmptyForNonCustomHeadersConfig", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		cfg, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+			DisplayName:  "None",
+			Slug:         "none-cfg",
+			Transport:    "streamable_http",
+			URL:          "https://mcp.example.com/v1",
+			AuthType:     "none",
+			Availability: "default_on",
+			Enabled:      true,
+		})
+		require.NoError(t, err)
+
+		resp, err := client.MCPServerUserHeaderValues(ctx, cfg.ID)
+		require.NoError(t, err)
+		require.Empty(t, resp.HasValues)
+	})
+
+	t.Run("PutThenGetReportsHasValuesTrue", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+		cfg := createHonchoConfig(t, client)
+
+		putResp, err := client.UpdateMCPServerUserHeaderValues(ctx, cfg.ID, codersdk.UpdateMCPServerUserHeaderValuesRequest{
+			Values: map[string]string{"X-User-Token": "secret-jwt"},
+		})
+		require.NoError(t, err)
+		require.True(t, putResp.HasValues["X-User-Token"])
+		require.False(t, putResp.HasValues["X-Workspace"])
+
+		getResp, err := client.MCPServerUserHeaderValues(ctx, cfg.ID)
+		require.NoError(t, err)
+		require.True(t, getResp.HasValues["X-User-Token"])
+		require.False(t, getResp.HasValues["X-Workspace"])
+	})
+
+	t.Run("PutRejectsUnknownKey", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+		cfg := createHonchoConfig(t, client)
+
+		_, err := client.UpdateMCPServerUserHeaderValues(ctx, cfg.ID, codersdk.UpdateMCPServerUserHeaderValuesRequest{
+			Values: map[string]string{"X-Unknown": "oops"},
+		})
+		require.Error(t, err)
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
+	})
+
+	t.Run("PutPartialUpdatePreservesOtherKey", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+		cfg := createHonchoConfig(t, client)
+
+		_, err := client.UpdateMCPServerUserHeaderValues(ctx, cfg.ID, codersdk.UpdateMCPServerUserHeaderValuesRequest{
+			Values: map[string]string{"X-User-Token": "jwt-a", "X-Workspace": "main"},
+		})
+		require.NoError(t, err)
+
+		// Partial update touching only one key; the other must remain set.
+		putResp, err := client.UpdateMCPServerUserHeaderValues(ctx, cfg.ID, codersdk.UpdateMCPServerUserHeaderValuesRequest{
+			Values: map[string]string{"X-User-Token": "jwt-b"},
+		})
+		require.NoError(t, err)
+		require.True(t, putResp.HasValues["X-User-Token"])
+		require.True(t, putResp.HasValues["X-Workspace"])
+	})
+
+	t.Run("PutClearsSingleValueWithEmptyString", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+		cfg := createHonchoConfig(t, client)
+
+		_, err := client.UpdateMCPServerUserHeaderValues(ctx, cfg.ID, codersdk.UpdateMCPServerUserHeaderValuesRequest{
+			Values: map[string]string{"X-User-Token": "jwt-a"},
+		})
+		require.NoError(t, err)
+
+		putResp, err := client.UpdateMCPServerUserHeaderValues(ctx, cfg.ID, codersdk.UpdateMCPServerUserHeaderValuesRequest{
+			Values: map[string]string{"X-User-Token": ""},
+		})
+		require.NoError(t, err)
+		require.False(t, putResp.HasValues["X-User-Token"])
+	})
+
+	t.Run("DeleteRemovesAllValues", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+		cfg := createHonchoConfig(t, client)
+
+		_, err := client.UpdateMCPServerUserHeaderValues(ctx, cfg.ID, codersdk.UpdateMCPServerUserHeaderValuesRequest{
+			Values: map[string]string{"X-User-Token": "jwt-a", "X-Workspace": "main"},
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, client.DeleteMCPServerUserHeaderValues(ctx, cfg.ID))
+
+		getResp, err := client.MCPServerUserHeaderValues(ctx, cfg.ID)
+		require.NoError(t, err)
+		require.False(t, getResp.HasValues["X-User-Token"])
+		require.False(t, getResp.HasValues["X-Workspace"])
+	})
+
+	t.Run("DeleteIsIdempotent", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+		cfg := createHonchoConfig(t, client)
+
+		// Never set a value; delete should still return 204.
+		require.NoError(t, client.DeleteMCPServerUserHeaderValues(ctx, cfg.ID))
+	})
+
+	t.Run("PutAcceptsCaseInsensitiveKey", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+		cfg := createHonchoConfig(t, client)
+
+		// Request lowercases the canonical "X-User-Token".
+		putResp, err := client.UpdateMCPServerUserHeaderValues(ctx, cfg.ID, codersdk.UpdateMCPServerUserHeaderValuesRequest{
+			Values: map[string]string{"x-user-token": "jwt-a"},
+		})
+		require.NoError(t, err)
+		require.True(t, putResp.HasValues["X-User-Token"], "HasValues should report under the canonical key")
+	})
+
+	t.Run("ListAuthConnectedReflectsHeaderValues", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+		cfg := createHonchoConfig(t, client)
+
+		// Before any values stored: auth_connected=false.
+		list, err := client.MCPServerConfigs(ctx)
+		require.NoError(t, err)
+		require.Len(t, list, 1)
+		require.False(t, list[0].AuthConnected)
+
+		// Storing only one of two required keys keeps it false.
+		_, err = client.UpdateMCPServerUserHeaderValues(ctx, cfg.ID, codersdk.UpdateMCPServerUserHeaderValuesRequest{
+			Values: map[string]string{"X-User-Token": "jwt"},
+		})
+		require.NoError(t, err)
+		list, err = client.MCPServerConfigs(ctx)
+		require.NoError(t, err)
+		require.False(t, list[0].AuthConnected)
+
+		// Storing all required keys flips it to true.
+		_, err = client.UpdateMCPServerUserHeaderValues(ctx, cfg.ID, codersdk.UpdateMCPServerUserHeaderValuesRequest{
+			Values: map[string]string{"X-Workspace": "main"},
+		})
+		require.NoError(t, err)
+		list, err = client.MCPServerConfigs(ctx)
+		require.NoError(t, err)
+		require.True(t, list[0].AuthConnected)
+
+		// The single-config getter mirrors the list.
+		fetched, err := client.MCPServerConfigByID(ctx, cfg.ID)
+		require.NoError(t, err)
+		require.True(t, fetched.AuthConnected)
+	})
+
+	t.Run("AuthConnectedIsIsolatedPerUser", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		adminClient := newMCPClient(t)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient)
+		cfg := createHonchoConfig(t, adminClient)
+		memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
+
+		// User A (admin) stores all required user-set values.
+		_, err := adminClient.UpdateMCPServerUserHeaderValues(ctx, cfg.ID, codersdk.UpdateMCPServerUserHeaderValuesRequest{
+			Values: map[string]string{"X-User-Token": "jwt-a", "X-Workspace": "main"},
+		})
+		require.NoError(t, err)
+
+		// User A sees auth_connected=true via both list and get.
+		adminList, err := adminClient.MCPServerConfigs(ctx)
+		require.NoError(t, err)
+		require.Len(t, adminList, 1)
+		require.True(t, adminList[0].AuthConnected, "User A should see auth_connected=true")
+		adminGet, err := adminClient.MCPServerConfigByID(ctx, cfg.ID)
+		require.NoError(t, err)
+		require.True(t, adminGet.AuthConnected, "User A should see auth_connected=true on get")
+
+		// User B (different user, same org) must NOT see
+		// auth_connected=true; user-stored values are per-user and
+		// must not leak across accounts.
+		memberList, err := memberClient.MCPServerConfigs(ctx)
+		require.NoError(t, err)
+		require.Len(t, memberList, 1)
+		require.False(t, memberList[0].AuthConnected, "User B should NOT inherit User A's auth_connected")
+		memberGet, err := memberClient.MCPServerConfigByID(ctx, cfg.ID)
+		require.NoError(t, err)
+		require.False(t, memberGet.AuthConnected, "User B should NOT inherit User A's auth_connected on get")
+
+		// User B's own GET on user-header values reports the unset state.
+		memberHV, err := memberClient.MCPServerUserHeaderValues(ctx, cfg.ID)
+		require.NoError(t, err)
+		require.False(t, memberHV.HasValues["X-User-Token"], "User B HasValues must be false for X-User-Token")
+		require.False(t, memberHV.HasValues["X-Workspace"], "User B HasValues must be false for X-Workspace")
+	})
+
+	t.Run("PutRejectsControlCharsInValue", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+		cfg := createHonchoConfig(t, client)
+
+		for _, payload := range []string{
+			"jwt-a\r\nX-Injected: oops",
+			"jwt-a\nX-Injected: oops",
+			"jwt-a\x00",
+		} {
+			_, err := client.UpdateMCPServerUserHeaderValues(ctx, cfg.ID, codersdk.UpdateMCPServerUserHeaderValuesRequest{
+				Values: map[string]string{"X-User-Token": payload},
+			})
+			require.Error(t, err)
+			var sdkErr *codersdk.Error
+			require.ErrorAs(t, err, &sdkErr)
+			require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
+		}
+	})
+
+	t.Run("GetReturnsNotFoundWhenServerDisabled", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+		cfg := createHonchoConfig(t, client)
+
+		// Disable the config.
+		disabled := false
+		_, err := client.UpdateMCPServerConfig(ctx, cfg.ID, codersdk.UpdateMCPServerConfigRequest{
+			Enabled: &disabled,
+		})
+		require.NoError(t, err)
+
+		_, err = client.MCPServerUserHeaderValues(ctx, cfg.ID)
+		require.Error(t, err)
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusNotFound, sdkErr.StatusCode())
+
+		_, err = client.UpdateMCPServerUserHeaderValues(ctx, cfg.ID, codersdk.UpdateMCPServerUserHeaderValuesRequest{
+			Values: map[string]string{"X-User-Token": "jwt"},
+		})
+		require.Error(t, err)
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusNotFound, sdkErr.StatusCode())
+	})
+
+	t.Run("AdminUpdateClearsStoredValuesOnUserKeyChange", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+		cfg := createHonchoConfig(t, client)
+
+		// Store both values and confirm auth_connected flips.
+		_, err := client.UpdateMCPServerUserHeaderValues(ctx, cfg.ID, codersdk.UpdateMCPServerUserHeaderValuesRequest{
+			Values: map[string]string{"X-User-Token": "jwt-a", "X-Workspace": "main"},
+		})
+		require.NoError(t, err)
+		before, err := client.MCPServerConfigByID(ctx, cfg.ID)
+		require.NoError(t, err)
+		require.True(t, before.AuthConnected)
+
+		// Admin renames the user keys to a new disjoint set. Any
+		// orphaned stored values from the previous key set must be
+		// purged so the user is forced to re-supply credentials.
+		newKeys := []string{"X-Other-Token"}
+		_, err = client.UpdateMCPServerConfig(ctx, cfg.ID, codersdk.UpdateMCPServerConfigRequest{
+			CustomHeadersUserKeys: &newKeys,
+		})
+		require.NoError(t, err)
+
+		after, err := client.MCPServerConfigByID(ctx, cfg.ID)
+		require.NoError(t, err)
+		require.False(t, after.AuthConnected, "new key set must report disconnected")
+		hv, err := client.MCPServerUserHeaderValues(ctx, cfg.ID)
+		require.NoError(t, err)
+		require.False(t, hv.HasValues["X-Other-Token"], "orphan-clear should reset all values")
+
+		// Restoring the original key set must not silently reactivate
+		// the previously stored credentials.
+		originalKeys := []string{"X-User-Token", "X-Workspace"}
+		_, err = client.UpdateMCPServerConfig(ctx, cfg.ID, codersdk.UpdateMCPServerConfigRequest{
+			CustomHeadersUserKeys: &originalKeys,
+		})
+		require.NoError(t, err)
+		restored, err := client.MCPServerConfigByID(ctx, cfg.ID)
+		require.NoError(t, err)
+		require.False(t, restored.AuthConnected, "restoring key set must NOT reactivate orphaned values")
+	})
+
+	t.Run("AdminUpdateRejectsCustomHeadersWithoutAnyEntries", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+		cfg := createHonchoConfig(t, client)
+
+		// Try to drop both the admin custom_headers and the user keys
+		// while staying on custom_headers auth. This must be rejected
+		// so callers cannot leave the config in a degenerate state.
+		empty := map[string]string{}
+		emptyKeys := []string{}
+		_, err := client.UpdateMCPServerConfig(ctx, cfg.ID, codersdk.UpdateMCPServerConfigRequest{
+			CustomHeaders:         &empty,
+			CustomHeadersUserKeys: &emptyKeys,
+		})
+		require.Error(t, err)
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
 	})
 }

--- a/codersdk/mcp.go
+++ b/codersdk/mcp.go
@@ -57,6 +57,18 @@ type MCPServerConfig struct {
 
 	HasCustomHeaders bool `json:"has_custom_headers"`
 
+	// CustomHeadersUserKeys lists custom_headers entries whose values
+	// are supplied per-user. These are visible to all callers so the
+	// user settings UI can prompt for the corresponding values. The
+	// set must be disjoint from the admin-set CustomHeaders keys.
+	CustomHeadersUserKeys []string `json:"custom_headers_user_keys"`
+
+	// CustomHeadersUserKeyDescriptions maps a user-set custom header
+	// name to optional helper text the admin wrote to explain what
+	// the user should enter. Keys are case-insensitively a subset of
+	// CustomHeadersUserKeys. Missing entries mean "no description".
+	CustomHeadersUserKeyDescriptions map[string]string `json:"custom_headers_user_key_descriptions"`
+
 	// Tool governance.
 	ToolAllowList []string `json:"tool_allow_list"`
 	ToolDenyList  []string `json:"tool_deny_list"`
@@ -101,6 +113,17 @@ type CreateMCPServerConfigRequest struct {
 	APIKeyValue        string            `json:"api_key_value,omitempty"`
 	CustomHeaders      map[string]string `json:"custom_headers,omitempty"`
 
+	// CustomHeadersUserKeys, when AuthType is "custom_headers", marks
+	// these header names as user-supplied. Each entry must be disjoint
+	// from CustomHeaders keys and from each other (case-insensitive).
+	CustomHeadersUserKeys []string `json:"custom_headers_user_keys,omitempty"`
+
+	// CustomHeadersUserKeyDescriptions optionally provides helper text
+	// per user-set header key. Keys must be a (case-insensitive) subset
+	// of CustomHeadersUserKeys; descriptions for unknown keys are
+	// rejected. Empty strings are dropped.
+	CustomHeadersUserKeyDescriptions map[string]string `json:"custom_headers_user_key_descriptions,omitempty"`
+
 	ToolAllowList []string `json:"tool_allow_list,omitempty"`
 	ToolDenyList  []string `json:"tool_deny_list,omitempty"`
 
@@ -134,6 +157,15 @@ type UpdateMCPServerConfigRequest struct {
 	APIKeyValue        *string            `json:"api_key_value,omitempty"`
 	CustomHeaders      *map[string]string `json:"custom_headers,omitempty"`
 
+	// CustomHeadersUserKeys, when non-nil, replaces the set of
+	// user-supplied header names. See MCPServerConfig.CustomHeadersUserKeys.
+	CustomHeadersUserKeys *[]string `json:"custom_headers_user_keys,omitempty"`
+
+	// CustomHeadersUserKeyDescriptions, when non-nil, replaces the
+	// per-key description map. Pass an empty map to clear all
+	// descriptions. See MCPServerConfig.CustomHeadersUserKeyDescriptions.
+	CustomHeadersUserKeyDescriptions *map[string]string `json:"custom_headers_user_key_descriptions,omitempty"`
+
 	ToolAllowList *[]string `json:"tool_allow_list,omitempty"`
 	ToolDenyList  *[]string `json:"tool_deny_list,omitempty"`
 
@@ -145,6 +177,24 @@ type UpdateMCPServerConfigRequest struct {
 	// ForwardCoderHeaders, when set, updates whether Coder identity
 	// headers are forwarded on every outgoing MCP request.
 	ForwardCoderHeaders *bool `json:"forward_coder_headers,omitempty"`
+}
+
+// MCPServerUserHeaderValues represents the calling user's state for
+// an MCP server with admin-marked user-set custom headers. Values are
+// never returned; HasValues records which keys currently have a
+// non-empty user-supplied value.
+type MCPServerUserHeaderValues struct {
+	MCPServerConfigID uuid.UUID       `json:"mcp_server_config_id" format:"uuid"`
+	HasValues         map[string]bool `json:"has_values"`
+}
+
+// UpdateMCPServerUserHeaderValuesRequest upserts the calling user's
+// values for an MCP server's user-set custom headers. The set of keys
+// in Values must be a subset of the server's CustomHeadersUserKeys;
+// any keys not present are left unchanged. To clear a single value,
+// pass an empty string; to clear all values, use DeleteMCPServerUserHeaderValues.
+type UpdateMCPServerUserHeaderValuesRequest struct {
+	Values map[string]string `json:"values" validate:"required"`
 }
 
 func (c *Client) MCPServerConfigs(ctx context.Context) ([]MCPServerConfig, error) {
@@ -201,6 +251,51 @@ func (c *Client) UpdateMCPServerConfig(ctx context.Context, id uuid.UUID, req Up
 
 func (c *Client) DeleteMCPServerConfig(ctx context.Context, id uuid.UUID) error {
 	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/experimental/mcp/servers/%s", id), nil)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusNoContent {
+		return ReadBodyAsError(res)
+	}
+	return nil
+}
+
+// MCPServerUserHeaderValues returns the calling user's HasValues map
+// for the given MCP server. Returns an empty HasValues map when no
+// user-set values have been stored yet.
+func (c *Client) MCPServerUserHeaderValues(ctx context.Context, id uuid.UUID) (MCPServerUserHeaderValues, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/mcp/servers/%s/user-headers", id), nil)
+	if err != nil {
+		return MCPServerUserHeaderValues{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return MCPServerUserHeaderValues{}, ReadBodyAsError(res)
+	}
+	var resp MCPServerUserHeaderValues
+	return resp, json.NewDecoder(res.Body).Decode(&resp)
+}
+
+// UpdateMCPServerUserHeaderValues upserts the calling user's values
+// for the given MCP server's user-set custom headers.
+func (c *Client) UpdateMCPServerUserHeaderValues(ctx context.Context, id uuid.UUID, req UpdateMCPServerUserHeaderValuesRequest) (MCPServerUserHeaderValues, error) {
+	res, err := c.Request(ctx, http.MethodPut, fmt.Sprintf("/api/experimental/mcp/servers/%s/user-headers", id), req)
+	if err != nil {
+		return MCPServerUserHeaderValues{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return MCPServerUserHeaderValues{}, ReadBodyAsError(res)
+	}
+	var resp MCPServerUserHeaderValues
+	return resp, json.NewDecoder(res.Body).Decode(&resp)
+}
+
+// DeleteMCPServerUserHeaderValues removes the calling user's values
+// for the given MCP server's user-set custom headers.
+func (c *Client) DeleteMCPServerUserHeaderValues(ctx context.Context, id uuid.UUID) error {
+	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/experimental/mcp/servers/%s/user-headers", id), nil)
 	if err != nil {
 		return err
 	}

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -3403,6 +3403,19 @@ export interface CreateMCPServerConfigRequest {
 	readonly api_key_header?: string;
 	readonly api_key_value?: string;
 	readonly custom_headers?: Record<string, string>;
+	/**
+	 * CustomHeadersUserKeys, when AuthType is "custom_headers", marks
+	 * these header names as user-supplied. Each entry must be disjoint
+	 * from CustomHeaders keys and from each other (case-insensitive).
+	 */
+	readonly custom_headers_user_keys?: readonly string[];
+	/**
+	 * CustomHeadersUserKeyDescriptions optionally provides helper text
+	 * per user-set header key. Keys must be a (case-insensitive) subset
+	 * of CustomHeadersUserKeys; descriptions for unknown keys are
+	 * rejected. Empty strings are dropped.
+	 */
+	readonly custom_headers_user_key_descriptions?: Record<string, string>;
 	readonly tool_allow_list?: readonly string[];
 	readonly tool_deny_list?: readonly string[];
 	readonly availability: string;
@@ -5175,6 +5188,20 @@ export interface MCPServerConfig {
 	readonly has_api_key: boolean;
 	readonly has_custom_headers: boolean;
 	/**
+	 * CustomHeadersUserKeys lists custom_headers entries whose values
+	 * are supplied per-user. These are visible to all callers so the
+	 * user settings UI can prompt for the corresponding values. The
+	 * set must be disjoint from the admin-set CustomHeaders keys.
+	 */
+	readonly custom_headers_user_keys: readonly string[];
+	/**
+	 * CustomHeadersUserKeyDescriptions maps a user-set custom header
+	 * name to optional helper text the admin wrote to explain what
+	 * the user should enter. Keys are case-insensitively a subset of
+	 * CustomHeadersUserKeys. Missing entries mean "no description".
+	 */
+	readonly custom_headers_user_key_descriptions: Record<string, string>;
+	/**
 	 * Tool governance.
 	 */
 	readonly tool_allow_list: readonly string[];
@@ -5200,6 +5227,18 @@ export interface MCPServerConfig {
 	 * Per-user state (populated for non-admin requests).
 	 */
 	readonly auth_connected: boolean;
+}
+
+// From codersdk/mcp.go
+/**
+ * MCPServerUserHeaderValues represents the calling user's state for
+ * an MCP server with admin-marked user-set custom headers. Values are
+ * never returned; HasValues records which keys currently have a
+ * non-empty user-supplied value.
+ */
+export interface MCPServerUserHeaderValues {
+	readonly mcp_server_config_id: string;
+	readonly has_values: Record<string, boolean>;
 }
 
 // From codersdk/provisionerdaemons.go
@@ -8765,6 +8804,17 @@ export interface UpdateMCPServerConfigRequest {
 	readonly api_key_header?: string;
 	readonly api_key_value?: string;
 	readonly custom_headers?: Record<string, string>;
+	/**
+	 * CustomHeadersUserKeys, when non-nil, replaces the set of
+	 * user-supplied header names. See MCPServerConfig.CustomHeadersUserKeys.
+	 */
+	readonly custom_headers_user_keys?: string[];
+	/**
+	 * CustomHeadersUserKeyDescriptions, when non-nil, replaces the
+	 * per-key description map. Pass an empty map to clear all
+	 * descriptions. See MCPServerConfig.CustomHeadersUserKeyDescriptions.
+	 */
+	readonly custom_headers_user_key_descriptions?: Record<string, string>;
 	readonly tool_allow_list?: string[];
 	readonly tool_deny_list?: string[];
 	readonly availability?: string;
@@ -8776,6 +8826,18 @@ export interface UpdateMCPServerConfigRequest {
 	 * headers are forwarded on every outgoing MCP request.
 	 */
 	readonly forward_coder_headers?: boolean;
+}
+
+// From codersdk/mcp.go
+/**
+ * UpdateMCPServerUserHeaderValuesRequest upserts the calling user's
+ * values for an MCP server's user-set custom headers. The set of keys
+ * in Values must be a subset of the server's CustomHeadersUserKeys;
+ * any keys not present are left unchanged. To clear a single value,
+ * pass an empty string; to clear all values, use DeleteMCPServerUserHeaderValues.
+ */
+export interface UpdateMCPServerUserHeaderValuesRequest {
+	readonly values: Record<string, string>;
 }
 
 // From codersdk/notifications.go

--- a/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
@@ -703,6 +703,9 @@ const makeMCPServer = (
 	has_custom_headers: overrides.has_custom_headers ?? false,
 	tool_allow_list: overrides.tool_allow_list ?? [],
 	tool_deny_list: overrides.tool_deny_list ?? [],
+	custom_headers_user_keys: overrides.custom_headers_user_keys ?? [],
+	custom_headers_user_key_descriptions:
+		overrides.custom_headers_user_key_descriptions ?? {},
 	availability: overrides.availability ?? "default_on",
 	enabled: overrides.enabled ?? true,
 	model_intent: overrides.model_intent ?? false,

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -1250,6 +1250,8 @@ const sampleMCPServers = [
 		has_custom_headers: false,
 		tool_allow_list: [],
 		tool_deny_list: [],
+		custom_headers_user_keys: [],
+		custom_headers_user_key_descriptions: {},
 		availability: "default_on",
 		enabled: true,
 		model_intent: false,

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.stories.tsx
@@ -30,6 +30,9 @@ const createServerConfig = (
 	has_custom_headers: overrides.has_custom_headers ?? false,
 	tool_allow_list: overrides.tool_allow_list ?? [],
 	tool_deny_list: overrides.tool_deny_list ?? [],
+	custom_headers_user_keys: overrides.custom_headers_user_keys ?? [],
+	custom_headers_user_key_descriptions:
+		overrides.custom_headers_user_key_descriptions ?? {},
 	availability: overrides.availability ?? "default_on",
 	enabled: overrides.enabled ?? true,
 	model_intent: overrides.model_intent ?? false,

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -1210,6 +1210,9 @@ export const MCPServerAdminPanel: FC<MCPServerAdminPanelProps> = ({
 				tool_deny_list: req.tool_deny_list
 					? [...req.tool_deny_list]
 					: undefined,
+				custom_headers_user_keys: req.custom_headers_user_keys
+					? [...req.custom_headers_user_keys]
+					: undefined,
 			};
 			try {
 				await onUpdateServer({ id, req: updateReq });

--- a/site/src/pages/AgentsPage/components/MCPServerPicker.stories.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerPicker.stories.tsx
@@ -29,6 +29,9 @@ const createServerConfig = (
 	has_custom_headers: overrides.has_custom_headers ?? false,
 	tool_allow_list: overrides.tool_allow_list ?? [],
 	tool_deny_list: overrides.tool_deny_list ?? [],
+	custom_headers_user_keys: overrides.custom_headers_user_keys ?? [],
+	custom_headers_user_key_descriptions:
+		overrides.custom_headers_user_key_descriptions ?? {},
 	availability: overrides.availability ?? "default_on",
 	enabled: overrides.enabled ?? true,
 	model_intent: overrides.model_intent ?? false,


### PR DESCRIPTION
<!--

This pull request was generated by Coder Agents on behalf of @Emyrk.

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->

## Stack Context

Tracking issue: #25921

Slice of #25823 (per-user MCP `custom_headers`) into a 6-PR Graphite stack so each part can be reviewed in isolation. The original PR will be marked superseded once this stack lands.

Stack order:

1. #25913 db foundation
2. #25914 dbcrypt CLI rotate / decrypt / delete coverage
3. **#25915 backend API + SDK** _(this PR)_
4. #25916 chatd runtime overlay
5. #25917 frontend
6. #25918 docs

## What?

Surfaces the per-user `custom_headers` schema through the experimental MCP API and adds three new endpoints:

```
GET    /api/experimental/mcp/servers/{id}/user-headers
PUT    /api/experimental/mcp/servers/{id}/user-headers
DELETE /api/experimental/mcp/servers/{id}/user-headers
```

Admin-side changes (`coderd/mcp.go`):

- `CreateMCPServerConfig` / `UpdateMCPServerConfig` accept `custom_headers_user_keys` and `custom_headers_user_key_descriptions`.
- Validation: user-set keys must be disjoint from admin-set `CustomHeaders` (case-insensitive), unique among themselves, and only allowed when `AuthType` is `custom_headers`. Descriptions are bounded to declared keys; orphans are dropped automatically.
- `MCPServerConfig` list / get responses now expose the user-key list and descriptions so the settings UI can prompt the user without leaking admin-set `CustomHeaders` values.
- `auth_connected` on the list response also factors in per-user header state.

User-side changes:

- The three `/user-headers` endpoints accept partial updates, case-insensitive keys, and empty values to clear individual keys. `DELETE` clears all values for a server.
- Values are never returned; the response carries a `has_values` map only.

The endpoints are marked experimental and excluded from swagger via `@x-apidocgen skip`.

Frontend touch-ups in this PR are intentionally minimal — only the additions needed to keep `tsc` green now that `MCPServerConfig` and `UpdateMCPServerConfigRequest` carry the new fields. The full settings UI lands in stack PR #25917.

## Why?

This is the seam between the schema (#25913) and the runtime layer (#25916) — chatd needs `GetMCPServerUserHeaderValuesByUserID` plus the admin-declared key list to overlay per-user values at request time, and the frontend needs the API to render the settings page.

Splitting the API + SDK into its own PR keeps the (relatively large) `coderd/mcp.go` and `coderd/mcp_test.go` changes reviewable on their own and lets the chatd overlay PR focus only on the runtime behavior.
