### PR TITLE
docs(docs/ai-coder/agents/platform-controls/mcp-servers): document user-set custom_headers

### DIFF
--- a/docs/ai-coder/agents/platform-controls/mcp-servers.md
+++ b/docs/ai-coder/agents/platform-controls/mcp-servers.md
@@ -106,6 +106,32 @@ A static key sent as a header on every request.
 Arbitrary key-value header pairs sent on every request. At least one header
 is required when this mode is selected.
 
+#### User-set custom headers
+
+Individual header keys can be marked as **user-set** in the admin form. Coder
+stops storing an admin value for those keys and lists them in
+`custom_headers_user_keys`. Each user then supplies their own value in
+`Agents` > `Settings` > `MCP Servers`. At request time Coder merges the
+user's stored value with the admin-set headers and sends the combined map
+to the MCP server.
+
+Admins can attach an optional **description** to each user-set key (for
+example "Personal access token from your Honcho profile"). Descriptions are
+stored alongside the keys in `custom_headers_user_key_descriptions` and
+rendered above the corresponding input on the user's settings page.
+Descriptions for keys that are not in `custom_headers_user_keys` are
+rejected, and orphaned descriptions are dropped automatically when the
+key list changes.
+
+The values are encrypted at rest with the same key set as the rest of the
+MCP server config. Admins cannot read or list per-user values; clearing a
+user's values is a per-user action from the same settings page or through
+`DELETE /api/experimental/mcp/servers/{id}/user-headers`.
+
+Use this mode when the MCP server identifies callers by a stable header
+name but expects each user to present their own credential (for example,
+a long-lived per-user JWT).
+
 ### User OIDC Identity
 
 Forwards the calling user's OIDC access token (stored in


### PR DESCRIPTION
<!--

This pull request was generated by Coder Agents on behalf of @Emyrk.

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->

## Stack Context

Tracking issue: #25921

Slice of #25823 (per-user MCP `custom_headers`) into a 6-PR Graphite stack so each part can be reviewed in isolation. The original PR will be marked superseded once this stack lands.

Stack order:

1. #25913 db foundation
2. #25914 dbcrypt CLI rotate / decrypt / delete coverage
3. #25915 backend API + SDK
4. #25916 chatd runtime overlay
5. #25917 frontend
6. **#25918 docs** _(this PR)_

## What?

Adds a "User-set custom headers" subsection to the MCP servers admin guide under the existing `custom_headers` auth mode. Covers:

- How an admin marks keys as user-set (`custom_headers_user_keys`) and attaches optional descriptions (`custom_headers_user_key_descriptions`).
- Where the user supplies their value (`Agents > Settings > MCP Servers`) and how Coder merges it with admin static headers at request time.
- Encryption at rest (same key set as the rest of the MCP server config) and that admin cannot read or list per-user values.
- The DELETE endpoint for clearing a user's values, and when to choose this mode vs the alternatives.

## Why?

The runtime behavior shipping in #25916 introduces a new authentication shape that admins and users will need to understand before they can configure or troubleshoot it. Keeping the docs in their own PR makes them easy to review independently of the code changes and easy to backport / cherry-pick if needed.
