### PR TITLE
feat(site): FilterSearchField — unified chip-based filter component

### DIFF
--- a/FILTER_SEARCH_FIELD_PROMPT.md
+++ b/FILTER_SEARCH_FIELD_PROMPT.md
@@ -1,0 +1,675 @@
+# FilterSearchField Component — Reproduction Prompt
+
+Build a `FilterSearchField` component for the Coder frontend and wire it
+into the Workspaces page to replace the existing `<WorkspacesFilter>` +
+`<SelectFilter>` dropdown system. The component is an inline filter bar
+with chip tokens, a dropdown for selecting filter categories/values, and
+freeform text search that also searches actual resources (workspaces).
+
+## Environment & Tooling
+
+- Workspace is inside the Coder monorepo at `/home/coder/coder`
+- Frontend lives in `site/`; package manager is `pnpm`
+- Linter: `pnpm biome check --write <files>`
+- Type check: `npx tsc --noEmit --pretty`
+- Dev server: `./scripts/develop.sh` — backend on port 3000, Vite HMR on
+  port 8080
+- Use the project's existing UI primitives: `Badge`, `Spinner`, `Avatar`,
+  `StatusIndicatorDot`, `cn()` utility. Do NOT add new dependencies.
+- Icons come from `lucide-react`: `SearchIcon`, `ListFilter`, `XIcon`,
+  `User`, `LayoutPanelTop`, `CircleDot`, `Building2`.
+- Do NOT use Radix Popover. The dropdown is a plain `<div>` with absolute
+  positioning — see Part 7 for layout details.
+
+## Files to Create/Modify
+
+1. **`site/src/components/FilterSearchField/FilterSearchField.tsx`** — the
+   main component (~1450 lines)
+2. **`site/src/pages/WorkspacesPage/WorkspacesPageView.tsx`** — replace
+   `<WorkspacesFilter>` usage with `<FilterSearchField>`
+
+---
+
+## Part 1: Component Types (exported)
+
+```ts
+export type FilterOption = {
+  label: string;
+  value: string;
+  startIcon?: React.ReactNode;  // avatar/icon before the label
+  subtitle?: string;            // secondary text below label (e.g. email)
+};
+
+export type FilterCategory = {
+  key: string;                  // machine key used in query string (e.g. "owner")
+  label: string;                // human label shown in UI (e.g. "Owner")
+  getOptions: (query: string) => Promise<FilterOption[]>;
+  icon?: React.ReactNode;       // icon next to category button
+  /**
+   * When true, multiple values can be selected for this category
+   * (e.g. `status:running status:stopped`). Defaults to false
+   * (selecting a new value replaces the existing chip).
+   */
+  multiSelect?: boolean;
+};
+
+export type FilterChip = {
+  key: string;                  // the category key
+  value: string;                // selected value; empty string = incomplete
+};
+
+export type SearchResult = {
+  label: string;
+  value: string;
+  startIcon?: React.ReactNode;
+  subtitle?: string;
+};
+
+export type FilterSearchFieldProps = {
+  value: string;                // controlled: current query string "owner:me status:running"
+  onChange: (query: string) => void;
+  categories: FilterCategory[];
+  getSearchResults?: (query: string) => Promise<SearchResult[]>;
+  placeholder?: string;
+  className?: string;
+  autoFocus?: boolean;
+  ref?: Ref<HTMLInputElement>;
+  "aria-label"?: string;
+};
+```
+
+## Part 2: Helper Functions
+
+### `parseQuery(query, categories) → { chips: FilterChip[], freeform: string }`
+
+- Split on spaces. For each token, check if it matches `key:value` where
+  key is a known category.
+- Known `key:value` tokens become chips. Everything else becomes freeform
+  text.
+- Handles duplicate keys correctly (e.g. `"owner:me status:stopped"` → two
+  chips).
+
+### `serializeQuery(chips, freeform) → string`
+
+- Joins `key:value` pairs (only complete chips with non-empty value) then
+  appends freeform text.
+- Chips come first, freeform at the end.
+
+## Part 3: Sub-components
+
+### `ChipBadge` — renders a filter chip as a Badge
+
+- Complete chips show `CategoryLabel:value [X]` with an X button to remove.
+- Incomplete chips (value = "") show a dashed-border Badge with just
+  `CategoryLabel:`.
+- X button uses `onMouseDown={e.preventDefault()}` to prevent input blur,
+  then `onClick` to remove.
+
+### `CategoryButton` — pill-shaped div for "Filter by" mode
+
+- `<div role="option" tabIndex={-1}>` — NOT a `<button>` (nested inside a
+  listbox).
+- Rounded border, icon + label, hover/focus styles.
+- Uses `onMouseDown={e.preventDefault()}` to keep focus on the input.
+- `aria-selected` reflects highlighted state.
+
+### `OptionItem` — a single selectable option row
+
+- `<div role="option" tabIndex={-1}>` with `aria-selected`.
+- Icon (in a 24px container), label, optional subtitle, optional
+  `categoryLabel:` prefix.
+- Highlighted state: `bg-surface-secondary text-content-primary`.
+- Keyboard-highlighted state (when `showFocusRing`): adds `ring-2
+  ring-content-link`.
+- Uses `onMouseDown={e.preventDefault()}` to prevent blur.
+
+### `SearchResultsSection` — renders the "Workspaces" resource results section
+
+- Shows a `<Spinner>` while loading with no results yet.
+- Returns null if not ready or no results.
+- Section heading: `"Workspaces"` (`role="presentation"`, text-xs,
+  font-medium, text-content-secondary).
+
+## Part 4: Main Component State & Architecture
+
+### Dropdown modes (discriminated union)
+
+```ts
+type DropdownMode =
+  | { type: "categories" }
+  | { type: "options"; categoryKey: string }
+  | { type: "typeahead" }
+```
+
+### State variables
+
+- `chips: FilterChip[]` — local chip state synced from `value` prop via
+  useEffect
+- `freeformText: string` — the current free text in the input
+- `isOpen: boolean` — whether the dropdown is open
+- `dropdownMode: DropdownMode`
+- `highlightedIndex: number` — keyboard nav index, starts at **-1** (no
+  item highlighted)
+- `isKeyboardNav: boolean` — tracks whether the user is navigating via
+  keyboard (true) or mouse (false)
+- `categoryOptions: FilterOption[]` / `isLoadingOptions` — for options mode
+- `categorySearchText: string` — text typed while in options mode (filters
+  options)
+- `typeaheadMatches: FilterCategory[]` — categories whose key `startsWith`
+  input (for Tab completion, no visual indicator shown)
+- `globalResults: GlobalSearchResult[]` / `isLoadingGlobal` — suggestions
+  from all categories
+- `searchResults: SearchResult[]` / `isLoadingSearch` — resource search
+  results
+- `globalSearchReady` / `searchResultsReady` — booleans to prevent "no
+  results" flash while first request is in-flight
+- Three `useRef(0)` request ID counters (`categorySearchIdRef`,
+  `globalSearchIdRef`, `searchIdRef`) to discard stale async responses
+- `debounceRef` — `useRef<ReturnType<typeof setTimeout>>` for 300ms
+  debounce on global/search API calls
+
+### `highlightedIndex` semantics
+
+- **-1**: No item highlighted. Focus ring stays on the search box input.
+- **≥ 0**: An item in the dropdown is highlighted. `aria-activedescendant`
+  on the input points to `filter-option-${highlightedIndex}`.
+- ArrowDown from -1 → 0. ArrowUp from -1 → last item.
+- Typing resets to -1.
+- Mouse enter on items sets to their index.
+
+### `isKeyboardNav` semantics
+
+- ArrowDown/ArrowUp/ArrowRight/ArrowLeft set `isKeyboardNav = true`.
+- `onMouseEnter` handlers set `isKeyboardNav = false`.
+- Blue `ring-2 ring-content-link` only shows on highlighted items when
+  `isKeyboardNav === true`.
+- Mouse hover shows only `bg-surface-secondary` (no ring).
+- When `isKeyboardNav && highlightedIndex >= 0`, the input group's focus
+  ring is suppressed (one focus indicator at a time per WCAG).
+
+### Sync from external value
+
+```ts
+useEffect(() => {
+  const newParsed = parseQuery(value, categories);
+  setChips(newParsed.chips);
+  setFreeformText(newParsed.freeform);
+}, [value, categories]);
+```
+
+### `emitChange(nextChips, nextFreeform)`
+
+- Filters out incomplete chips (value = ""), serializes, calls `onChange`.
+
+### `showDropdown` and `hasDropdownContent`
+
+```ts
+const hasDropdownContent = useMemo(() => {
+  if (dropdownMode.type === "categories") return true;
+  if (dropdownMode.type === "options") return true;
+  return (
+    filteredCategories.length > 0 ||
+    globalResults.length > 0 ||
+    searchResults.length > 0 ||
+    isLoadingGlobal ||
+    isLoadingSearch
+  );
+}, [/* deps */]);
+
+const showDropdown = isOpen && hasDropdownContent;
+```
+
+`showDropdown` controls rendering of the dropdown div.
+
+## Part 5: Core Callbacks
+
+### `loadCategoryOptions(categoryKey, query)`
+
+- Looks up category from a `categoryMap` (useMemo Map), calls
+  `getOptions(query)`, sets `categoryOptions`. Uses request ID pattern to
+  discard stale responses.
+
+### `loadSearchResults(query)`
+
+- Calls `getSearchResults(query)` if provided. Sets `searchResults`. Uses
+  request ID pattern.
+
+### `loadGlobalResults(query)` — the "Filter suggestions" search
+
+- Queries **ALL** categories.
+- For each category, checks `categoryNameMatches` **first**:
+  - If the category name (key or label) contains the query → calls
+    `getOptions("")` (empty string) to fetch ALL options, includes all of
+    them.
+  - If the category name doesn't match → calls `getOptions(query)` and
+    filters locally by label/value containing the query.
+- This ensures: "ow" → owner category matches by name → shows ALL users
+  (including "member"); "test" → owner doesn't match by name, but
+  "testuser01" matches by value → shows that user.
+- Uses request ID + `Promise.allSettled` pattern.
+
+### Debounce (300ms)
+
+- `loadGlobalResults` and `loadSearchResults` in typeahead mode are
+  debounced 300ms via `debounceRef`.
+- `computeTypeahead` (local category name matching) remains immediate.
+- The debounce timer is cleared on dropdown close and on unmount.
+
+### `closeDropdown()`
+
+- Cancels pending debounce timer.
+- Removes incomplete chips, resets ALL state (dropdownMode to "categories",
+  clears all results/loading flags, bumps all request ID refs to cancel
+  in-flight requests).
+- Calls `emitChange` with the complete chips.
+
+### `selectCategory(categoryKey)`
+
+- For single-select categories: strips incomplete chips AND removes
+  existing chips with the same key. For multiSelect categories: only
+  strips incomplete chips.
+- Adds an incomplete chip `{key, value: ""}`.
+- Switches to options mode, loads options for that category.
+- Resets global/search results and bumps their request IDs.
+
+### `selectOption(option, categoryKey?)`
+
+- Two paths:
+  - **With `categoryKey`** (from global search suggestions): For
+    single-select, replaces existing chip of same key. For multiSelect,
+    appends. Creates complete chip.
+  - **Without `categoryKey`** (from options mode): Finds the incomplete
+    chip, fills in its value. For single-select, also removes any other
+    chip with the same key.
+- Resets ALL loading state, bumps all request ID refs.
+- Calls `emitChange`, keeps dropdown open (in categories mode), focuses
+  input.
+
+### `selectSearchResult(result)`
+
+- Removes incomplete chips, sets freeform text to `result.value`, closes
+  dropdown, emits change.
+
+### `removeChip(chipIndex)`
+
+- Removes by original array index, emits change, focuses input.
+
+### `computeTypeahead(text)`
+
+- Filters categories where key or label `startsWith` the trimmed lowercase
+  input (stricter than `includes` — this is for Tab completion).
+
+### `filteredCategories` (useMemo)
+
+- Categories where key or label `includes` the freeform text
+  (case-insensitive). Used for rendering the category list in typeahead
+  mode. Falls back to all categories when input is empty.
+
+### `checkForKeyColonPattern(text)`
+
+- Regex `/(\\S+):$/` — detects `"owner:"` → starts an incomplete chip,
+  switches to options mode. Respects `multiSelect` per category.
+- Regex `/(\\S+):(\\S+)\\s$/` — detects `"owner:me "` (trailing space) →
+  creates a complete chip immediately. Respects `multiSelect` per category.
+
+### `handleInputChange(e)`
+
+- In options mode: updates `categorySearchText`, reloads options.
+- Otherwise: checks for key:colon pattern, updates freeformText.
+- If empty: switches to categories mode, clears results.
+- If non-empty: computes typeahead (immediate), switches to typeahead mode,
+  debounces (300ms) global results + search results.
+- Clears globalResults before loading (`setGlobalResults([])`) and sets
+  `isLoadingGlobal(true)`.
+
+## Part 6: Keyboard Navigation
+
+### `navItems` (useMemo) — flat list for arrow key navigation
+
+- Categories mode: all categories.
+- Options mode: `categoryOptions`.
+- Typeahead mode: `filteredCategories` (as category items) + `globalResults`
+  (as global items) + `searchResults` (as search items, only if
+  `searchResultsReady`).
+
+### `handleKeyDown`
+
+- **Escape**: close dropdown, blur input.
+- **Backspace** (empty input, not in options mode): remove last chip.
+- **Backspace** (options mode, empty search text): cancel incomplete chip,
+  go back to categories.
+- **Tab** (typeahead mode, has typeahead matches): complete top match via
+  `selectCategory`. No visual Tab kbd badge in the dropdown.
+- **ArrowDown/ArrowUp**: cycle `highlightedIndex` through `navItems`. Sets
+  `isKeyboardNav = true`.
+- **ArrowRight/ArrowLeft** (categories mode only): also cycle
+  `highlightedIndex` for horizontal button layout. Sets `isKeyboardNav =
+  true`.
+- **Enter** (highlightedIndex < 0): closes dropdown, blurs input (submits
+  current freeform search).
+- **Enter** (highlightedIndex ≥ 0): activates the highlighted navItem
+  based on its `kind` (category/option/global/search).
+
+### Scroll into view
+
+```ts
+useEffect(() => {
+  if (!isOpen || highlightedIndex < 0) return;
+  const el = document.getElementById(`filter-option-${highlightedIndex}`);
+  if (el) el.scrollIntoView({ block: "nearest" });
+}, [highlightedIndex, isOpen]);
+```
+
+## Part 7: Layout & Render
+
+### Overall structure (NO Radix Popover)
+
+```
+<div ref={containerRef} className="relative rounded-md">
+  {/* Input group — has border, focus ring via has-[:focus] */}
+  <div className={cn(
+    "...border border-border...",
+    !(isKeyboardNav && highlightedIndex >= 0) &&
+      "has-[:focus]:ring-2 has-[:focus]:ring-content-link"
+  )}>
+    [SearchIcon] [Chips + Input (role="combobox")] [ListFilter icon]
+  </div>
+  {/* Dropdown — absolutely positioned, floats over page content */}
+  {showDropdown && (
+    <div id="filter-search-listbox" role="listbox"
+         className="absolute left-0 right-0 top-full z-50 max-h-80
+                    overflow-y-auto rounded-md border border-border
+                    bg-surface-primary shadow-lg mt-1.5">
+      {categories mode | options mode | typeahead mode}
+    </div>
+  )}
+</div>
+```
+
+Key layout decisions:
+- Dropdown is `absolute top-full mt-1.5` — floats over content, does NOT
+  push content down.
+- Dropdown has its own `border` + `shadow-lg` + `rounded-md` — visually
+  separate from search box.
+- Search box gets standard `has-[:focus]:ring-2 ring-content-link` focus
+  ring.
+- NO unified ring around both search + dropdown (too complex with absolute
+  positioning).
+- Focus ring on search box is suppressed when keyboard is highlighting a
+  dropdown item (one focus indicator at a time per WCAG).
+- Grey separator between search and dropdown comes from the dropdown's own
+  border-top.
+
+### Input group (the search bar)
+
+- `group/filter-search flex items-start w-full min-w-0 min-h-10 rounded-md
+  border border-solid border-border bg-transparent transition-colors`
+- Focus ring: `has-[:focus]:ring-2 has-[:focus]:ring-content-link` —
+  suppressed when `isKeyboardNav && highlightedIndex >= 0`.
+- onClick focuses the input and opens the dropdown.
+
+### Search icon (left)
+
+- `flex shrink-0 items-center justify-center h-10 pl-3 pr-2
+  text-content-secondary`
+
+### Chips + input area (center)
+
+- `flex flex-1 flex-wrap items-center gap-1.5 min-w-0 py-1.5 cursor-text`
+- Renders complete chips via `completeChipEntries` (a useMemo that maps
+  chips to `{chip, originalIndex}` — needed because `removeChip` needs the
+  original index, not the rendered index).
+- Renders incomplete chip indicator (dashed border Badge with
+  `CategoryLabel:`).
+- Text input: `flex-1 min-w-[40px] h-7 bg-transparent border-none
+  outline-none text-sm`
+  - Placeholder only shown when no chips exist.
+  - Value is `categorySearchText` in options mode, `freeformText`
+    otherwise.
+  - onFocus opens dropdown if not already open.
+  - onBlur closes dropdown unless focus moved within `containerRef`.
+
+### WCAG attributes on `<input>`
+
+```tsx
+role="combobox"
+aria-expanded={isOpen}
+aria-haspopup="listbox"
+aria-autocomplete="list"
+aria-controls={isOpen ? "filter-search-listbox" : undefined}
+aria-activedescendant={
+  isOpen && highlightedIndex >= 0 && navItems.length > 0
+    ? `filter-option-${highlightedIndex}`
+    : undefined
+}
+aria-label={ariaLabel ?? "Filter search"}
+```
+
+### ListFilter icon (right)
+
+- `flex shrink-0 items-center justify-center self-stretch pl-2 pr-3
+  border-0 border-l border-solid border-border text-content-secondary
+  hover:text-content-primary transition-colors cursor-pointer`
+- `self-stretch` so the left border extends full height when chips wrap.
+
+### Dropdown `<div>` (the listbox)
+
+- `id="filter-search-listbox"` with `role="listbox"` and
+  `aria-label="Filter options"`.
+- Single `role="listbox"` — no nested listbox elements.
+- Heading `<p>` tags inside ("Filter by", "Filter suggestions",
+  "Workspaces") use `role="presentation"` to avoid WCAG violations inside a
+  listbox.
+
+### Categories mode
+
+- Heading: "Filter by" (`role="presentation"`, text-xs, font-medium,
+  text-content-secondary, mb-2).
+- Flex-wrap grid of `CategoryButton` components (div role="option").
+
+### Options mode
+
+- Loading: centered `<Spinner>`.
+- Empty: "No results found" centered text.
+- Results: list of `OptionItem` components.
+
+### Typeahead mode (three sections)
+
+1. **Matching categories** (only if `filteredCategories.length > 0`):
+   - List of category rows with icon and label (div role="option").
+   - Highlighted state same as OptionItem.
+
+2. **Filter suggestions** (`globalResults`):
+   - Shows single spinner while `isLoadingGlobal && isLoadingSearch` and
+     both result arrays are empty (consolidated — no double spinner).
+   - Section heading: `"Filter suggestions"` (role="presentation").
+   - Each result rendered as `OptionItem` with `categoryLabel` prefix
+     (e.g. "Owner: testuser01").
+   - Nav index offset = `filteredCategories.length`.
+
+3. **Workspaces** (resource search results, only if `getSearchResults`
+   provided):
+   - Rendered by `SearchResultsSection` sub-component.
+   - Section heading: `"Workspaces"` (role="presentation").
+   - Nav index offset = `filteredCategories.length + globalResults.length`.
+
+### Section spacing
+
+- Categories mode container: `p-3`
+- Categories section in typeahead: `p-2`
+- Suggestions section: `px-2 pb-2 pt-1` with heading `px-2 pb-1`
+- Results section: `px-2 pb-2 pt-1` with heading `px-2 pb-1`
+- No `border-t` separators between sections.
+
+---
+
+## Part 8: Workspaces Page Integration
+
+### In `WorkspacesPageView.tsx`
+
+**Replace** the existing `<WorkspacesFilter>` (and its `<SelectFilter>`
+dropdowns) with a single `<FilterSearchField>`.
+
+### Categories (built via `useMemo` with deps `[me.username, me.avatar_url]`)
+
+1. **Owner** — `key: "owner"`, `icon: <User>`, `getOptions`: calls
+   `API.getUsers({q: query, limit: 25})`, maps to FilterOption with
+   avatar. Pins current user (`me`) first in the list. **No multiSelect**
+   — backend uses `parser.String` (single value only).
+
+2. **Template** — `key: "template"`, `icon: <LayoutPanelTop>`,
+   `getOptions`: calls `API.getTemplates()`, client-side filters by
+   name/display_name containing query. Uses template icon avatar. **No
+   multiSelect** — backend uses `parser.String`.
+
+3. **Status** — `key: "status"`, `icon: <CircleDot>`, `getOptions`:
+   returns static list `["running", "stopped", "failed", "pending"]`
+   mapped through `getDisplayWorkspaceStatus` for labels and
+   `StatusIndicatorDot` for icons. Create a `getStatusVariant` helper that
+   maps workspace status display types to StatusIndicatorDot variants:
+   `{active: "pending", inactive: "inactive", success: "success", error:
+   "failed", danger: "warning", warning: "warning"}`. **No multiSelect** —
+   backend uses `ParseCustom` (single enum).
+
+4. **Organization** — `key: "organization"`, `icon: <Building2>`,
+   `getOptions`: calls `API.getOrganizations()`, maps to FilterOption with
+   avatar. Always shown (no `showOrganizations` gate). **No multiSelect**.
+
+**Backend limitation:** All workspace filter fields (`owner`, `template`,
+`status`, `name`) use `parser.String` or single-enum parsing. None support
+multiple values. The `multiSelect` toggle exists on the `FilterCategory`
+type for future use, but no workspace category should set it to `true`
+until the backend is updated to use `parser.Strings` or `ParseCustomList`.
+
+### `getSearchResults` callback (via `useCallback`)
+
+- Calls `API.getWorkspaces({ q: query, limit: 5 })`.
+- Maps each workspace to `SearchResult` with template icon avatar,
+  workspace name, subtitle `"ownerName · statusText"`.
+
+### FilterSearchField usage
+
+```tsx
+<FilterSearchField
+  value={filterState.filter.query}
+  onChange={filterState.filter.update}
+  categories={categories}
+  getSearchResults={getSearchResults}
+  placeholder="Search workspaces..."
+  aria-label="Filter workspaces"
+  className="w-fit min-w-[min(550px,100%)] max-w-full"
+/>
+```
+
+### Critical: Use `filter.update` not `filter.debounceUpdate`
+
+The existing `useFilter` hook has a `debounceUpdate` (500ms delay). Using
+it causes a race condition: the sync effect (which re-parses the `value`
+prop) resets internal chips before the debounce fires, causing the table to
+get stuck in a loading state. Use `filter.update` (immediate) instead.
+
+---
+
+## Critical Implementation Details (Bug Prevention)
+
+These are subtle issues discovered during development. Getting them wrong
+causes visible bugs:
+
+### 1. Single-select vs multiSelect per category
+
+`FilterCategory` has an optional `multiSelect?: boolean` (defaults to
+false). When false, selecting a new value for the same category key
+**replaces** the existing chip. When true, multiple chips with the same key
+are allowed. All four chip-creation paths (`selectCategory`,
+`selectOption` with/without `categoryKey`, `checkForKeyColonPattern`)
+check `categoryMap.get(key)?.multiSelect` before deciding whether to strip
+existing chips of the same key.
+
+### 2. WCAG: `role="combobox"` on the `<input>`, not a wrapper
+
+The `<input>` element itself has `role="combobox"`, `aria-expanded`,
+`aria-haspopup`, `aria-controls`, and `aria-activedescendant`. NOT a
+wrapper `<div>`.
+
+### 3. WCAG: Single `role="listbox"` on the dropdown
+
+One `role="listbox"` on the outer dropdown `<div>`. No nested listbox
+elements. `CategoryButton` is a `<div role="option">`, not a `<button>`.
+Heading `<p>` tags inside the listbox use `role="presentation"`.
+
+### 4. WCAG: One focus indicator at a time
+
+When `isKeyboardNav && highlightedIndex >= 0`, the search box's focus ring
+is suppressed. Blue `ring-2 ring-content-link` shows only on the
+highlighted dropdown item. When `highlightedIndex < 0`, the search box
+shows its normal focus ring. Mouse hover only shows `bg-surface-secondary`
+on items (no blue ring).
+
+### 5. WCAG: `aria-controls` only when open
+
+`aria-controls="filter-search-listbox"` is set only when `isOpen` is true.
+When closed, it's `undefined`.
+
+### 6. Click focus management with `onMouseDown={e.preventDefault()}`
+
+Every interactive element inside the dropdown (X buttons on chips, category
+buttons, option items, search results) must use
+`onMouseDown={e.preventDefault()}` to prevent the input from losing focus.
+Without this, clicking triggers onBlur → closeDropdown before the click
+event fires.
+
+### 7. State cleanup on every transition
+
+`selectOption`, `selectCategory`, and `closeDropdown` must ALL: reset
+every loading flag to false, set `searchResultsReady`/`globalSearchReady`
+to true, and bump all three request ID refs to cancel in-flight requests.
+Without this, stale async responses can set loading states that never
+clear, causing permanent spinners.
+
+### 8. `loadGlobalResults` must call `getOptions("")` for matching categories
+
+When a category name matches the query (e.g. "ow" → "owner"), call
+`getOptions("")` to fetch ALL options — not `getOptions(query)` which
+would only return API results matching the partial text. Check
+`categoryNameMatches` BEFORE calling `getOptions`.
+
+### 9. Debounce only on API calls, not local matching
+
+`loadGlobalResults` and `loadSearchResults` are debounced 300ms via
+`debounceRef` in the `handleInputChange` handler. `computeTypeahead`
+(local category name matching) runs immediately — no debounce. The
+debounce timer is cancelled on close and on unmount.
+
+### 10. `completeChipEntries` index mapping
+
+The rendered chip list only shows complete chips, but `removeChip` needs
+the original index in the `chips` array (which includes incomplete chips).
+Use a useMemo to build `{chip, originalIndex}[]`.
+
+### 11. Chips wrapping behavior
+
+Use `flex-wrap` on the chips+input container, NOT horizontal scroll. Use
+`min-h-10` on the input group (not fixed `h-10`) so it grows when chips
+wrap. Use `items-start` so icons align to the top row. The ListFilter
+icon uses `self-stretch` so its left border extends the full height.
+
+### 12. Width behavior
+
+The component root has `className={cn("relative rounded-md", className)}`
+— no default `w-full`. The consumer controls width. The Workspaces page
+passes `className="w-fit min-w-[min(550px,100%)] max-w-full"` — prefers
+550px, grows with chip content, caps at page width, no horizontal scroll
+on narrow viewports.
+
+### 13. Dropdown positioning
+
+The dropdown is an inline `<div>` with `absolute left-0 right-0 top-full
+z-50 mt-1.5`. It is NOT rendered in a Radix portal — it lives inside
+`containerRef`. This means `onBlur` only needs to check
+`containerRef.current?.contains(related)` to decide whether to close.
+
+### 14. Enter key behavior
+
+When `highlightedIndex < 0` (no item highlighted), Enter closes the
+dropdown and blurs the input (submits the current freeform search). When
+`highlightedIndex >= 0`, Enter activates the highlighted item.

--- a/FILTER_SEARCH_FIELD_RFC.md
+++ b/FILTER_SEARCH_FIELD_RFC.md
@@ -1,0 +1,205 @@
+# RFC: Unified FilterSearchField Component
+
+> 🪐 RFC Process:
+>
+> 1. Start an RFC with a Problem Statement.
+> 2. Collaborate on a draft RFC. Customer-facing issues should include Ben. Most should include backend and frontend input.
+> 3. Announce the RFC in #dev and put an RFC Review meeting on the calendar. Invite Sprints & Releases so anyone can opt in, and invite any stakeholders individually.
+> 4. During review meetings, show reviewers what the RFC currently says and field questions and comments.
+> 5. Modify the RFC as needed based on feedback and schedule another review meeting. Repeat until stakeholders approve.
+> 6. Announce the RFC is approved in #dev.
+> 7. Write epics and tickets as needed for the work the RFC prescribes and put them in the Backlog.
+
+---
+
+# Stakeholders
+
+Who needs to approve this? Feel free to add others!
+
+- [ ] Product Lead:
+- [ ] Engineering DRI:
+- [ ] CTO:
+
+---
+
+# Problem Statement
+
+The current filtering system across Coder's dashboard (`<Filter>` + `<SelectFilter>` + page-specific wrappers like `<WorkspacesFilter>`) has several problems:
+
+1. **Fragmented UX** — Filters are split between a free-text search input and a row of separate dropdown buttons (Owner, Template, Status, etc.). Users must mentally map between the raw query string (`owner:me status:running`) shown in the text input and the dropdown selections. There's no unified interaction model.
+
+2. **High boilerplate per page** — Each filtered page (Workspaces, Audit, Connection Logs, AI Bridge) requires its own filter wrapper component, menu components, menu hook wiring, and skeleton states. The Workspaces filter alone spans 5 files and ~850 lines of glue code (`WorkspacesFilter.tsx`, `menus.tsx`, `Filter.tsx`, `SelectFilter.tsx`, `UserFilter.tsx`).
+
+3. **No typeahead or resource preview** — Typing `test` in the search bar gives no indication of what the query will match. Users can't see that `test` would match a workspace named `test-dev` or a user named `testuser01` until they press Enter and wait for results. There's no inline suggestion of which filter categories are relevant.
+
+4. **Discoverability** — New users don't know what filter keys are available. The dropdown buttons help, but they're visually disconnected from the text input and the `key:value` syntax is not taught anywhere in the UI.
+
+5. **Accessibility gaps** — The current system uses separate Radix popovers for each dropdown, resulting in multiple focus traps, inconsistent keyboard navigation, and no unified `combobox` ARIA pattern.
+
+We need a single, reusable filter component that combines chip-based structured filters with freeform search and live typeahead — reducing per-page boilerplate while improving discoverability, speed, and accessibility.
+
+---
+
+# UX & Design
+
+
+
+---
+
+# User Stories
+
+**As a workspace user**, I want to type partial text and immediately see matching filter categories, filter values, and workspaces so I can find what I need without memorizing `key:value` syntax.
+
+**As a workspace user**, I want selected filters to appear as removable chips in the search bar so I can see my active filters at a glance and modify them without editing raw text.
+
+**As a workspace user**, I want to press Tab to autocomplete a filter category (e.g., typing `ow` → Tab → `owner:`) so filtering is fast for keyboard-heavy workflows.
+
+**As a platform admin**, I want the same filter component on every filtered page (Workspaces, Audit, Connection Logs) so the interaction model is consistent across the dashboard.
+
+**As a frontend developer**, I want to add filtering to a new page by defining an array of `FilterCategory` objects and passing them as props — no menu hooks, skeleton wrappers, or per-page filter components required.
+
+**As a user relying on assistive technology**, I want the filter to follow the WCAG combobox pattern (`role="combobox"` with `aria-activedescendant`) so my screen reader correctly announces available options as I navigate.
+
+---
+
+# Requirements
+
+## Initial Functional Requirements
+
+- **Chip-based filter display** — Active filters render as `key:value` chips inside the search input. Each chip has an X button to remove it. Chips serialize to/from a standard query string (`owner:me status:running workspace-name`).
+- **Category picker** — On focus (empty input), a dropdown shows all available filter categories as pill buttons. Clicking or pressing Enter on a category starts a chip for that category and shows its available values.
+- **Options dropdown** — After selecting a category, the dropdown shows that category's options (fetched async via `getOptions`). The user can type to filter options, then click or press Enter to complete the chip.
+- **Typeahead mode** — When the user types freeform text, the dropdown shows three sections:
+    - **Matching categories** — categories whose name contains the typed text (e.g., `ow` → Owner).
+    - **Filter suggestions** — options across all categories that match the text (e.g., `test` → Owner: testuser01). When a category name matches, ALL its options are shown (fetched via `getOptions("")`).
+    - **Resource results** — actual matching resources (e.g., workspaces) so the user can preview what the query will return.
+- **Keyboard navigation** — Full arrow key navigation across all dropdown items. Tab completes the top matching category. Enter with no item highlighted submits the current search. Escape closes the dropdown.
+- **Single-select by default, opt-in multiSelect** — Each `FilterCategory` defaults to single-select (new value replaces existing chip of the same key). Categories can opt into `multiSelect: true` to allow multiple chips with the same key. This is a frontend-only toggle; backend support for multi-value filters is a separate concern.
+- **Controlled component** — Accepts `value` (query string) and `onChange` props. Syncs internal chip state from the external value. Compatible with the existing `useFilter` hook.
+- **300ms debounce** — API calls for global search and resource search are debounced. Local category matching is immediate.
+
+## Initial Non-functional Requirements
+
+- **WCAG 2.1 AA compliance** — `role="combobox"` on the input, single `role="listbox"` on the dropdown, `aria-activedescendant` for keyboard navigation, one focus indicator at a time, `role="presentation"` on non-interactive headings inside the listbox.
+- **No new dependencies** — Uses existing project primitives (`Badge`, `Spinner`, `Avatar`, `cn()`, `lucide-react` icons). No Radix Popover — the dropdown is a plain absolutely-positioned `<div>`.
+- **Performance** — Stale async responses are discarded via request ID counters. Debounce prevents excessive API calls during typing. `Promise.allSettled` ensures one slow category doesn't block others.
+- **Responsive** — Chips wrap (not scroll) when the input overflows. The component grows vertically. Width is consumer-controlled via `className`.
+
+## Eventual Requirements
+
+- **Multi-value backend support** — See "Backend Work Required for Multi-Select Filters" section below for full details. The frontend `multiSelect` toggle is already implemented and ready; the backend needs migration from single-value to multi-value parsing and SQL `ANY()` clauses.
+- **Preset filters** — The current `WorkspacesFilter` supports preset quick-filters ("My workspaces", "Running workspaces", "Failed workspaces", "Dormant workspaces"). These should be re-integrated as a companion feature — likely as a small button row or dropdown alongside `FilterSearchField`, not embedded inside it.
+- **Adoption on other pages** — Audit, Connection Logs, and AI Bridge pages all use the current `<Filter>` + `<SelectFilter>` system and are candidates for migration.
+- **Error display** — The current filter shows API validation errors inline. `FilterSearchField` does not yet handle error display; this should be added before full adoption.
+- **Dormant/outdated/shared filters** — These are boolean filters (`dormant:true`, `outdated:true`, `shared:true`) that don't fit the category → options model. They need a design decision: category with `true`/`false` options, toggle chips, or something else.
+
+---
+
+# Scope
+
+## In scope
+
+- `FilterSearchField` component implementation (complete — prototype exists at `site/src/components/FilterSearchField/FilterSearchField.tsx`, ~1450 lines)
+- Workspaces page integration (complete — prototype wired into `WorkspacesPageView.tsx`)
+- Storybook stories for the component
+- WCAG combobox compliance
+- Replacement of `<WorkspacesFilter>` on the Workspaces page
+
+## Not in scope
+
+- Migration of Audit, Connection Log, or AI Bridge pages (eventual)
+- Removal of the existing `<Filter>` / `<SelectFilter>` / `<UserFilter>` components (kept until all pages migrate)
+- Backend changes to support multi-value filters
+- Preset filter buttons (re-integration is a follow-up)
+- Mobile-specific design considerations
+- Unit/integration test coverage (follow-up)
+
+---
+
+# Phases
+
+## Phase 1: Component + Workspaces page (current prototype)
+
+Ship the `FilterSearchField` component and wire it into the Workspaces page, replacing `<WorkspacesFilter>`. This delivers the new UX for the highest-traffic filtered page.
+
+Deliverables:
+- `FilterSearchField.tsx` component
+- `FilterSearchField.stories.tsx` with Empty, WithDefaultValue, MultipleFilters, WithFreeformText, AutoFocused stories
+- `WorkspacesPageView.tsx` updated to use `FilterSearchField`
+- Categories: Owner, Template, Status, Organization
+- Resource search: live workspace preview in typeahead
+
+## Phase 2: Backend multi-select + preset filters + error handling
+
+Migrate workspace filter backend fields from single-value to multi-value parsing (see backend section below). Re-integrate preset quick-filters ("My workspaces", "Running workspaces", etc.) as a companion UI element. Add inline error display for invalid filter queries.
+
+## Phase 3: Migrate remaining pages
+
+Adopt `FilterSearchField` on Audit, Connection Logs, and AI Bridge pages. Each page defines its own `FilterCategory[]` array and optional `getSearchResults`. Remove per-page filter wrapper components as they're replaced.
+
+## Phase 4: Deprecate old filter system
+
+Once all pages are migrated, remove `Filter.tsx`, `SelectFilter.tsx`, `UserFilter.tsx`, and all page-specific menu/filter wrappers. Remove associated storybook stories and test helpers.
+
+---
+
+# Backend Work Required for Multi-Select Filters
+
+The frontend `FilterCategory` type supports an optional `multiSelect: boolean` toggle. When enabled, users can add multiple chips for the same category (e.g., `status:running status:stopped`). **No workspace category currently uses this because the backend doesn't support it.** Here's what would need to change.
+
+## Current state
+
+Workspace filter parsing lives in `coderd/searchquery/search.go`, function `Workspaces()`. The relevant fields in `GetWorkspacesParams` are all single-value:
+
+| Filter | Query param parser | Go struct field | SQL clause |
+|---|---|---|---|
+| Owner | `parser.String(values, "", "owner")` | `OwnerUsername string` | `WHERE owner_id = (SELECT id FROM users WHERE username = @owner_username)` |
+| Template | `parser.String(values, "", "template")` | `TemplateName string` | `WHERE template_id = ANY(SELECT id FROM templates WHERE name = @template_name)` |
+| Status | `httpapi.ParseCustom(... ParseEnum[WorkspaceStatus])` | `Status string` | Large `CASE/WHEN` block matching a single status |
+
+When the frontend sends `owner:admin owner:member`, the Go `url.Values` parser creates `{"owner": ["admin", "member"]}`, but `parser.String` silently takes only the first value. The second value is dropped.
+
+Note: `has-agent` already uses `parser.Strings` (multi-value), and the Users filter uses `ParseCustomList` for `status` and `login_type` — so the patterns exist in the codebase.
+
+## Changes needed per field
+
+### Owner (highest value for multi-select)
+
+1. **`coderd/searchquery/search.go`**: Change `parser.String(values, "", "owner")` → `parser.Strings(values, []string{}, "owner")`
+2. **`coderd/database/queries.sql.go`** / `GetWorkspacesParams`: Change `OwnerUsername string` → `OwnerUsernames []string`
+3. **`coderd/database/queries/workspaces.sql`**: Change the `WHERE` clause from single-user subquery to `owner_id = ANY(SELECT id FROM users WHERE lower(username) = ANY(@owner_usernames))`
+4. **`coderd/database/dbmem/dbmem.go`**: Update in-memory filter to iterate over the slice
+5. Run `make gen` to regenerate
+
+### Status
+
+1. Change `ParseCustom` → `ParseCustomList` (pattern already exists for user status filtering)
+2. Change `Status string` → `Statuses []database.WorkspaceStatus` in the params struct
+3. Update the SQL `CASE/WHEN` block to check membership in an array rather than equality to a single value
+4. This is the most complex change due to the large status `CASE/WHEN` in `workspaces.sql`
+
+### Template
+
+1. Change `parser.String` → `parser.Strings`
+2. Change `TemplateName string` → `TemplateNames []string`
+3. SQL already uses `ANY()` for `template_ids` — similar pattern for names
+
+## Recommended migration order
+
+Each field can be migrated independently:
+
+1. **Status** — highest user value for OR filtering ("show me running OR stopped"), and `ParseCustomList` pattern already exists for user status
+2. **Owner** — useful for admins viewing multiple users' workspaces
+3. **Template** — useful but lower priority
+
+Each migration requires: query parser change, struct field change, SQL change, in-memory DB change, `make gen`, and audit table update if the field touches audit logging.
+
+This same pattern applies to any future category added to `FilterSearchField` on other pages (e.g., AI governance filters for provider, model, client). If the backend field uses `parser.String` today and the UI wants multi-select, the migration is the same: `parser.String` → `parser.Strings`, scalar struct field → slice, single-match SQL → `ANY()` clause.
+
+## Frontend readiness
+
+Once a backend field supports multi-value, the only frontend change is adding `multiSelect: true` to that category's definition in `WorkspacesPageView.tsx`. The `FilterSearchField` component already handles:
+
+- Allowing multiple chips with the same key
+- Replace-on-select for single-select, append-on-select for multi-select
+- Correct serialization (`status:running status:stopped`)

--- a/site/src/components/FilterSearchField/FilterSearchField.stories.tsx
+++ b/site/src/components/FilterSearchField/FilterSearchField.stories.tsx
@@ -1,0 +1,154 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Avatar } from "components/Avatar/Avatar";
+import { useState } from "react";
+import {
+	type FilterCategory,
+	type FilterOption,
+	FilterSearchField,
+} from "./FilterSearchField";
+
+const mockUsers: FilterOption[] = [
+	{
+		label: "me",
+		value: "me",
+		subtitle: "yourself",
+		startIcon: <Avatar size="sm" src="" fallback="ME" />,
+	},
+	{
+		label: "alice",
+		value: "alice",
+		subtitle: "alice@example.com",
+		startIcon: <Avatar size="sm" src="" fallback="AL" />,
+	},
+	{
+		label: "bob",
+		value: "bob",
+		subtitle: "bob@example.com",
+		startIcon: <Avatar size="sm" src="" fallback="BO" />,
+	},
+	{
+		label: "charlie",
+		value: "charlie",
+		subtitle: "charlie@example.com",
+		startIcon: <Avatar size="sm" src="" fallback="CH" />,
+	},
+];
+
+const mockStatuses: FilterOption[] = [
+	{ label: "Running", value: "running" },
+	{ label: "Stopped", value: "stopped" },
+	{ label: "Failed", value: "failed" },
+	{ label: "Starting", value: "starting" },
+	{ label: "Deleting", value: "deleting" },
+];
+
+const mockTemplates: FilterOption[] = [
+	{ label: "Docker", value: "docker" },
+	{ label: "Kubernetes", value: "kubernetes" },
+	{ label: "AWS EC2", value: "aws-ec2" },
+	{ label: "Google Cloud", value: "gcp" },
+];
+
+const mockOrganizations: FilterOption[] = [
+	{ label: "Default", value: "default" },
+	{ label: "Engineering", value: "engineering" },
+	{ label: "Design", value: "design" },
+];
+
+const defaultCategories: FilterCategory[] = [
+	{
+		key: "owner",
+		label: "Owner",
+		getOptions: async (query) => {
+			await new Promise((r) => setTimeout(r, 200));
+			if (!query) return mockUsers;
+			return mockUsers.filter(
+				(u) =>
+					u.label.toLowerCase().includes(query.toLowerCase()) ||
+					(u.subtitle?.toLowerCase().includes(query.toLowerCase()) ?? false),
+			);
+		},
+	},
+	{
+		key: "status",
+		label: "Status",
+		getOptions: async (query) => {
+			await new Promise((r) => setTimeout(r, 100));
+			if (!query) return mockStatuses;
+			return mockStatuses.filter((s) =>
+				s.label.toLowerCase().includes(query.toLowerCase()),
+			);
+		},
+	},
+	{
+		key: "template",
+		label: "Template",
+		getOptions: async (query) => {
+			await new Promise((r) => setTimeout(r, 150));
+			if (!query) return mockTemplates;
+			return mockTemplates.filter((t) =>
+				t.label.toLowerCase().includes(query.toLowerCase()),
+			);
+		},
+	},
+	{
+		key: "organization",
+		label: "Organization",
+		getOptions: async (query) => {
+			await new Promise((r) => setTimeout(r, 100));
+			if (!query) return mockOrganizations;
+			return mockOrganizations.filter((o) =>
+				o.label.toLowerCase().includes(query.toLowerCase()),
+			);
+		},
+	},
+];
+
+const meta: Meta<typeof FilterSearchField> = {
+	title: "components/FilterSearchField",
+	component: FilterSearchField,
+	args: {
+		placeholder: "Search workspaces...",
+		categories: defaultCategories,
+	},
+	render: function StatefulWrapper(args) {
+		const [value, setValue] = useState(args.value ?? "");
+		return (
+			<div className="w-full max-w-3xl">
+				<FilterSearchField {...args} value={value} onChange={setValue} />
+				<pre className="mt-4 text-xs text-content-secondary bg-surface-secondary p-2 rounded">
+					query: "{value}"
+				</pre>
+			</div>
+		);
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof FilterSearchField>;
+
+export const Empty: Story = {};
+
+export const WithDefaultValue: Story = {
+	args: {
+		value: "owner:me",
+	},
+};
+
+export const MultipleFilters: Story = {
+	args: {
+		value: "owner:me status:running",
+	},
+};
+
+export const WithFreeformText: Story = {
+	args: {
+		value: "owner:me my-workspace",
+	},
+};
+
+export const AutoFocused: Story = {
+	args: {
+		autoFocus: true,
+	},
+};

--- a/site/src/components/FilterSearchField/FilterSearchField.tsx
+++ b/site/src/components/FilterSearchField/FilterSearchField.tsx
@@ -1,0 +1,1448 @@
+import { Badge } from "components/Badge/Badge";
+import { Spinner } from "components/Spinner/Spinner";
+import { useEffectEvent } from "hooks/hookPolyfills";
+import { ListFilter, SearchIcon, XIcon } from "lucide-react";
+import {
+	type KeyboardEvent,
+	type Ref,
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+import { cn } from "utils/cn";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Represents a single option in a filter category dropdown.
+ */
+export type FilterOption = {
+	label: string;
+	value: string;
+	/** Optional icon/avatar rendered before the label. */
+	startIcon?: React.ReactNode;
+	/** Optional secondary text (e.g. email) rendered below the label. */
+	subtitle?: string;
+};
+
+/**
+ * Describes a filter category (e.g. "Owner", "Status").  Consumers pass an
+ * array of these to configure which categories are available.
+ */
+export type FilterCategory = {
+	/** Machine-readable key used in the query string (e.g. "owner"). */
+	key: string;
+	/** Human-readable label shown in the UI (e.g. "Owner"). */
+	label: string;
+	/**
+	 * Async function that returns available options for this category.
+	 * Receives the current search text typed by the user inside the category
+	 * dropdown so the consumer can do server-side filtering.
+	 */
+	getOptions: (query: string) => Promise<FilterOption[]>;
+	/** Optional icon rendered next to the category button. */
+	icon?: React.ReactNode;
+	/**
+	 * When true, multiple values can be selected for this category
+	 * (e.g. `status:running status:stopped`). Defaults to false
+	 * (selecting a new value replaces the existing chip).
+	 */
+	multiSelect?: boolean;
+};
+
+/**
+ * A single active filter chip displayed in the input area.
+ */
+export type FilterChip = {
+	/** The category key (e.g. "owner"). */
+	key: string;
+	/** The selected value (e.g. "me"). Empty string means incomplete. */
+	value: string;
+};
+
+/**
+ * A search result representing an actual resource (e.g. a workspace) rather
+ * than a filter option. Displayed in a separate "Results" section.
+ */
+export type SearchResult = {
+	label: string;
+	value: string;
+	/** Optional icon/avatar rendered before the label. */
+	startIcon?: React.ReactNode;
+	/** Optional secondary text rendered below the label. */
+	subtitle?: string;
+};
+
+export type FilterSearchFieldProps = {
+	/** Current filter query string (e.g. "owner:me status:running"). */
+	value: string;
+	/** Called whenever the serialized query string changes. */
+	onChange: (query: string) => void;
+	/** Available filter categories. */
+	categories: FilterCategory[];
+	/**
+	 * Optional async function that returns matching resources (e.g.
+	 * workspaces) for the current freeform search text. Results are shown in
+	 * a dedicated section so the user can see what their query will match.
+	 */
+	getSearchResults?: (query: string) => Promise<SearchResult[]>;
+	placeholder?: string;
+	className?: string;
+	autoFocus?: boolean;
+	ref?: Ref<HTMLInputElement>;
+	"aria-label"?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a query string like "owner:me status:running my-workspace" into
+ * structured chips + freeform text.
+ */
+function parseQuery(
+	query: string,
+	categories: FilterCategory[],
+): { chips: FilterChip[]; freeform: string } {
+	if (!query.trim()) {
+		return { chips: [], freeform: "" };
+	}
+
+	const categoryKeys = new Set(categories.map((c) => c.key));
+	const chips: FilterChip[] = [];
+	const freeformParts: string[] = [];
+
+	for (const token of query.split(" ")) {
+		const colonIdx = token.indexOf(":");
+		if (colonIdx > 0) {
+			const key = token.slice(0, colonIdx);
+			const value = token.slice(colonIdx + 1);
+			if (categoryKeys.has(key) && value) {
+				chips.push({ key, value });
+				continue;
+			}
+		}
+		if (token) {
+			freeformParts.push(token);
+		}
+	}
+
+	return { chips, freeform: freeformParts.join(" ") };
+}
+
+/**
+ * Serialize chips + freeform text back into a query string.  Tags always
+ * come first, freeform text at the end.
+ */
+function serializeQuery(chips: FilterChip[], freeform: string): string {
+	const parts: string[] = [];
+	for (const chip of chips) {
+		if (chip.value) {
+			parts.push(`${chip.key}:${chip.value}`);
+		}
+	}
+	const trimmed = freeform.trim();
+	if (trimmed) {
+		parts.push(trimmed);
+	}
+	return parts.join(" ");
+}
+
+/** A single result from searching all categories. */
+type GlobalSearchResult = {
+	category: FilterCategory;
+	option: FilterOption;
+};
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+interface ChipBadgeProps {
+	chip: FilterChip;
+	categoryLabel: string;
+	onRemove: () => void;
+}
+
+const ChipBadge: React.FC<ChipBadgeProps> = ({
+	chip,
+	categoryLabel,
+	onRemove,
+}) => {
+	const isComplete = chip.value !== "";
+	return (
+		<Badge
+			variant="default"
+			size="md"
+			className={cn(
+				"shrink-0 gap-0.5 select-none text-content-secondary",
+				!isComplete && "border border-dashed border-border-default",
+			)}
+		>
+			<span>{categoryLabel}</span>
+			{isComplete && (
+				<>
+					<span>:</span>
+					<span>{chip.value}</span>
+					<button
+						type="button"
+						className="flex items-center rounded-sm p-0 text-content-secondary cursor-pointer bg-transparent border-none outline-none focus-visible:ring-2 focus-visible:ring-content-link"
+						onMouseDown={(e) => {
+							// Prevent the input from losing focus, which would
+							// trigger onBlur -> closeDropdown before the click
+							// event fires.
+							e.preventDefault();
+							e.stopPropagation();
+						}}
+						onClick={(e) => {
+							e.stopPropagation();
+							onRemove();
+						}}
+						aria-label={`Remove ${categoryLabel}:${chip.value} filter`}
+					>
+						<XIcon className="size-3.5" />
+					</button>
+				</>
+			)}
+		</Badge>
+	);
+};
+
+interface CategoryButtonProps {
+	category: FilterCategory;
+	onSelect: () => void;
+	id?: string;
+	isHighlighted?: boolean;
+	showFocusRing?: boolean;
+	onMouseEnter?: () => void;
+}
+
+const CategoryButton: React.FC<CategoryButtonProps> = ({
+	category,
+	onSelect,
+	id,
+	isHighlighted,
+	showFocusRing,
+	onMouseEnter,
+}) => {
+	return (
+		// biome-ignore lint/a11y/useKeyWithClickEvents: Keyboard navigation is handled by the parent input's onKeyDown handler.
+		<div
+			id={id}
+			role="option"
+			tabIndex={-1}
+			aria-selected={isHighlighted}
+			className={cn(
+				"inline-flex items-center gap-1.5 rounded-md border border-solid border-border-default",
+				"bg-transparent px-3 py-1.5 text-xs font-medium text-content-secondary",
+				"cursor-pointer transition-colors",
+				"hover:bg-surface-secondary hover:text-content-primary",
+				"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link",
+				isHighlighted && "bg-surface-secondary text-content-primary",
+				isHighlighted && showFocusRing && "ring-2 ring-content-link",
+			)}
+			onMouseDown={(e) => {
+				// Keep focus on the input so the popover doesn't close.
+				e.preventDefault();
+			}}
+			onClick={onSelect}
+			onMouseEnter={onMouseEnter}
+		>
+			{category.icon}
+			{category.label}
+		</div>
+	);
+};
+interface OptionItemProps {
+	option: FilterOption;
+	onSelect: () => void;
+	isHighlighted: boolean;
+	showFocusRing?: boolean;
+	id: string;
+	/** Optional category label prefix (used in global search results). */
+	categoryLabel?: string;
+	onMouseEnter?: () => void;
+}
+
+const OptionItem: React.FC<OptionItemProps> = ({
+	option,
+	onSelect,
+	isHighlighted,
+	showFocusRing,
+	id,
+	categoryLabel,
+	onMouseEnter,
+}) => {
+	return (
+		// biome-ignore lint/a11y/useKeyWithClickEvents: Keyboard navigation is handled by the parent input's onKeyDown handler.
+		<div
+			id={id}
+			role="option"
+			tabIndex={-1}
+			aria-selected={isHighlighted}
+			className={cn(
+				"flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm cursor-pointer",
+				"transition-colors",
+				isHighlighted
+					? "bg-surface-secondary text-content-primary"
+					: "text-content-secondary",
+				isHighlighted && showFocusRing && "ring-2 ring-content-link",
+			)}
+			onClick={onSelect}
+			onMouseEnter={onMouseEnter}
+			onMouseDown={(e) => {
+				// Prevent blur on the input when clicking an option.
+				e.preventDefault();
+			}}
+		>
+			{option.startIcon && (
+				<span className="flex shrink-0 items-center justify-center size-6">
+					{option.startIcon}
+				</span>
+			)}
+			<span className="flex flex-col min-w-0">
+				<span className="text-sm font-medium truncate text-content-primary">
+					{categoryLabel && (
+						<span className="text-content-secondary font-normal">
+							{categoryLabel}:{" "}
+						</span>
+					)}
+					{option.label}
+				</span>
+				{option.subtitle && (
+					<span className="text-xs text-content-secondary truncate">
+						{option.subtitle}
+					</span>
+				)}
+			</span>
+		</div>
+	);
+};
+
+interface SearchResultsSectionProps {
+	searchResults: SearchResult[];
+	isLoading: boolean;
+	isReady: boolean;
+	highlightedIndex: number;
+	showFocusRing: boolean;
+	/** The nav index offset for keyboard navigation. */
+	navIndexOffset: number;
+	/** Called when a search result is selected. */
+	onSelect: (result: SearchResult) => void;
+	/** Called when a search result is hovered. */
+	onHighlight: (index: number) => void;
+}
+
+const SearchResultsSection: React.FC<SearchResultsSectionProps> = ({
+	searchResults,
+	isLoading,
+	isReady,
+	highlightedIndex,
+	showFocusRing,
+	navIndexOffset,
+	onSelect,
+	onHighlight,
+}) => {
+	if (isLoading && searchResults.length === 0) {
+		return (
+			<div>
+				<div className="flex items-center justify-center py-4">
+					<Spinner size="sm" loading />
+				</div>
+			</div>
+		);
+	}
+
+	if (!isReady || searchResults.length === 0) {
+		return null;
+	}
+
+	return (
+		<div className="px-2 pb-2 pt-1">
+			<p
+				role="presentation"
+				className="text-xs font-medium text-content-secondary px-2 pb-1"
+			>
+				Workspaces
+			</p>
+			{searchResults.map((result, idx) => {
+				const navIdx = navIndexOffset + idx;
+				return (
+					// biome-ignore lint/a11y/useKeyWithClickEvents: Keyboard navigation is handled by the parent input's onKeyDown handler.
+					<div
+						key={result.value}
+						id={`filter-option-${navIdx}`}
+						role="option"
+						tabIndex={-1}
+						aria-selected={highlightedIndex === navIdx}
+						className={cn(
+							"flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm cursor-pointer",
+							"transition-colors",
+							highlightedIndex === navIdx
+								? "bg-surface-secondary text-content-primary"
+								: "text-content-secondary",
+							highlightedIndex === navIdx &&
+								showFocusRing &&
+								"ring-2 ring-content-link",
+						)}
+						onClick={() => onSelect(result)}
+						onMouseEnter={() => onHighlight(navIdx)}
+						onMouseDown={(e) => {
+							e.preventDefault();
+						}}
+					>
+						{result.startIcon && (
+							<span className="flex shrink-0 items-center justify-center size-6">
+								{result.startIcon}
+							</span>
+						)}
+						<span className="flex flex-col min-w-0">
+							<span className="text-sm font-medium truncate text-content-primary">
+								{result.label}
+							</span>
+							{result.subtitle && (
+								<span className="text-xs text-content-secondary truncate">
+									{result.subtitle}
+								</span>
+							)}
+						</span>
+					</div>
+				);
+			})}
+		</div>
+	);
+};
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+type DropdownMode =
+	| { type: "categories" }
+	| { type: "options"; categoryKey: string }
+	| { type: "typeahead" };
+
+export const FilterSearchField: React.FC<FilterSearchFieldProps> = ({
+	value = "",
+	onChange,
+	categories,
+	getSearchResults,
+	placeholder = "Search...",
+	className,
+	autoFocus = false,
+	ref,
+	...ariaProps
+}) => {
+	// ---- Refs ----
+	const internalRef = useRef<HTMLInputElement | null>(null);
+	const containerRef = useRef<HTMLDivElement | null>(null);
+
+	// ---- Derived state from the controlled value ----
+	const parsed = useMemo(
+		() => parseQuery(value, categories),
+		[value, categories],
+	);
+
+	// ---- Local state ----
+	const [chips, setChips] = useState<FilterChip[]>(parsed.chips);
+	const [freeformText, setFreeformText] = useState(parsed.freeform);
+	const [isOpen, setIsOpen] = useState(false);
+	const [dropdownMode, setDropdownMode] = useState<DropdownMode>({
+		type: "categories",
+	});
+	const [highlightedIndex, setHighlightedIndex] = useState(-1);
+	const [isKeyboardNav, setIsKeyboardNav] = useState(false);
+	const [categoryOptions, setCategoryOptions] = useState<FilterOption[]>([]);
+	const [isLoadingOptions, setIsLoadingOptions] = useState(false);
+	const [categorySearchText, setCategorySearchText] = useState("");
+
+	// Typeahead: categories whose keys start with the current input.
+	const [typeaheadMatches, setTypeaheadMatches] = useState<FilterCategory[]>(
+		[],
+	);
+
+	// Global search: results from searching all categories.
+	const [globalResults, setGlobalResults] = useState<GlobalSearchResult[]>([]);
+	const [isLoadingGlobal, setIsLoadingGlobal] = useState(false);
+
+	// Resource search results (e.g. matching workspaces).
+	const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+	const [isLoadingSearch, setIsLoadingSearch] = useState(false);
+	const searchIdRef = useRef(0);
+
+	// Track in-flight request IDs so stale responses are discarded.
+	const globalSearchIdRef = useRef(0);
+	const categorySearchIdRef = useRef(0);
+
+	// Debounce timer for freeform/typeahead API calls.
+	const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+		undefined,
+	);
+
+	// Tracks whether the current global search query has had at least one
+	// completed fetch.  This prevents a "No results found" flash while the
+	// very first request for a new query is still in-flight.
+	const [_globalSearchReady, setGlobalSearchReady] = useState(false);
+	const [searchResultsReady, setSearchResultsReady] = useState(false);
+
+	// ---- Category lookup ----
+	const categoryMap = useMemo(() => {
+		const map = new Map<string, FilterCategory>();
+		for (const cat of categories) {
+			map.set(cat.key, cat);
+		}
+		return map;
+	}, [categories]);
+
+	// ---- Sync from external value ----
+	useEffect(() => {
+		const newParsed = parseQuery(value, categories);
+		setChips(newParsed.chips);
+		setFreeformText(newParsed.freeform);
+	}, [value, categories]);
+
+	// Clean up debounce timer on unmount.
+	useEffect(() => {
+		return () => {
+			if (debounceRef.current) clearTimeout(debounceRef.current);
+		};
+	}, []);
+
+	// ---- Emit changes to parent ----
+	const emitChange = useCallback(
+		(nextChips: FilterChip[], nextFreeform: string) => {
+			const completeChips = nextChips.filter((c) => c.value !== "");
+			const serialized = serializeQuery(completeChips, nextFreeform);
+			onChange(serialized);
+		},
+		[onChange],
+	);
+
+	// ---- Auto-focus ----
+	const focusOnMount = useEffectEvent((): void => {
+		if (autoFocus) {
+			internalRef.current?.focus();
+		}
+	});
+	useLayoutEffect(() => {
+		focusOnMount();
+	}, [focusOnMount]);
+
+	// ---- Ref forwarding ----
+	const setRefs = useCallback(
+		(el: HTMLInputElement | null) => {
+			internalRef.current = el;
+			if (typeof ref === "function") {
+				ref(el);
+			} else if (ref) {
+				(ref as React.MutableRefObject<HTMLInputElement | null>).current = el;
+			}
+		},
+		[ref],
+	);
+
+	// ---- Load options for a category ----
+	const loadCategoryOptions = useCallback(
+		async (categoryKey: string, query: string) => {
+			const category = categoryMap.get(categoryKey);
+			if (!category) return;
+			const requestId = ++categorySearchIdRef.current;
+			setIsLoadingOptions(true);
+			try {
+				const options = await category.getOptions(query);
+				if (categorySearchIdRef.current === requestId) {
+					setCategoryOptions(options);
+				}
+			} finally {
+				if (categorySearchIdRef.current === requestId) {
+					setIsLoadingOptions(false);
+				}
+			}
+		},
+		[categoryMap],
+	);
+
+	// ---- Load resource search results (e.g. workspaces) ----
+	const loadSearchResults = useCallback(
+		async (query: string) => {
+			if (!getSearchResults) return;
+			const requestId = ++searchIdRef.current;
+			setIsLoadingSearch(true);
+			setSearchResultsReady(false);
+			try {
+				const results = await getSearchResults(query);
+				if (searchIdRef.current === requestId) {
+					setSearchResults(results);
+				}
+			} catch {
+				if (searchIdRef.current === requestId) {
+					setSearchResults([]);
+				}
+			} finally {
+				if (searchIdRef.current === requestId) {
+					setIsLoadingSearch(false);
+					setSearchResultsReady(true);
+				}
+			}
+		},
+		[getSearchResults],
+	);
+
+	// ---- Load global search results across all categories ----
+	const loadGlobalResults = useCallback(
+		async (query: string) => {
+			const requestId = ++globalSearchIdRef.current;
+			setIsLoadingGlobal(true);
+			setGlobalSearchReady(false);
+			try {
+				const allResults: GlobalSearchResult[] = [];
+				const lowerQuery = query.toLowerCase();
+				// Query every category, then decide what to keep:
+				// - Category name matches query (e.g. "sta" → "status"):
+				//   include ALL its options.
+				// - Category name doesn't match: include only options
+				//   whose label/value contains the query (e.g. "test" →
+				//   owner "testuser01").
+				const promises = categories.map(async (category) => {
+					const categoryNameMatches =
+						category.key.toLowerCase().includes(lowerQuery) ||
+						category.label.toLowerCase().includes(lowerQuery);
+					if (categoryNameMatches) {
+						const options = await category.getOptions("");
+						return options.map((option) => ({ category, option }));
+					}
+					const options = await category.getOptions(query);
+					const filtered = options.filter((option) => {
+						const haystack = [option.label, option.value]
+							.join(" ")
+							.toLowerCase();
+						return haystack.includes(lowerQuery);
+					});
+					return filtered.map((option) => ({ category, option }));
+				});
+				const settled = await Promise.allSettled(promises);
+				for (const result of settled) {
+					if (result.status === "fulfilled") {
+						allResults.push(...result.value);
+					}
+				}
+				if (globalSearchIdRef.current === requestId) {
+					setGlobalResults(allResults);
+				}
+			} finally {
+				if (globalSearchIdRef.current === requestId) {
+					setIsLoadingGlobal(false);
+					setGlobalSearchReady(true);
+				}
+			}
+		},
+		[categories],
+	);
+	// ---- Dropdown open/close ----
+	const openDropdown = useCallback(
+		(mode: DropdownMode = { type: "categories" }) => {
+			setIsOpen(true);
+			setDropdownMode(mode);
+			setHighlightedIndex(-1);
+			if (mode.type === "options") {
+				setCategorySearchText("");
+				loadCategoryOptions(mode.categoryKey, "");
+			}
+		},
+		[loadCategoryOptions],
+	);
+
+	const closeDropdown = useCallback(() => {
+		// Cancel any pending debounced API calls.
+		if (debounceRef.current) {
+			clearTimeout(debounceRef.current);
+		}
+		// Remove any incomplete chips on close.
+		const completeChips = chips.filter((c) => c.value !== "");
+		setChips(completeChips);
+		setIsOpen(false);
+		setDropdownMode({ type: "categories" });
+		setCategorySearchText("");
+		setCategoryOptions([]);
+		setHighlightedIndex(-1);
+		setTypeaheadMatches([]);
+		setGlobalResults([]);
+		setSearchResults([]);
+		setIsLoadingOptions(false);
+		setIsLoadingGlobal(false);
+		setIsLoadingSearch(false);
+		setSearchResultsReady(true);
+		setGlobalSearchReady(true);
+		// Cancel stale in-flight requests.
+		++categorySearchIdRef.current;
+		++globalSearchIdRef.current;
+		++searchIdRef.current;
+		emitChange(completeChips, freeformText);
+	}, [chips, freeformText, emitChange]);
+	// ---- Select a search result (e.g. a workspace) ----
+	const selectSearchResult = useCallback(
+		(result: SearchResult) => {
+			const completeChips = chips.filter((c) => c.value !== "");
+			setChips(completeChips);
+			setFreeformText(result.value);
+			setIsOpen(false);
+			setDropdownMode({ type: "categories" });
+			setCategorySearchText("");
+			setCategoryOptions([]);
+			setHighlightedIndex(-1);
+			setTypeaheadMatches([]);
+			setGlobalResults([]);
+			setSearchResults([]);
+			emitChange(completeChips, result.value);
+		},
+		[chips, emitChange],
+	);
+
+	// ---- Category selection (from default dropdown) ----
+	const selectCategory = useCallback(
+		(categoryKey: string) => {
+			const newChip: FilterChip = { key: categoryKey, value: "" };
+			const isMulti = categoryMap.get(categoryKey)?.multiSelect;
+			// Strip incomplete chips. For single-select categories also
+			// remove existing chips with the same key.
+			const nextChips = [
+				...chips.filter(
+					(c) => c.value !== "" && (isMulti || c.key !== categoryKey),
+				),
+				newChip,
+			];
+			setChips(nextChips);
+			setFreeformText("");
+			setDropdownMode({ type: "options", categoryKey });
+			setCategorySearchText("");
+			setHighlightedIndex(-1);
+			setTypeaheadMatches([]);
+			setGlobalResults([]);
+			setSearchResults([]);
+			setIsLoadingGlobal(false);
+			setIsLoadingSearch(false);
+			setSearchResultsReady(true);
+			setGlobalSearchReady(true);
+			// Cancel stale in-flight requests.
+			++globalSearchIdRef.current;
+			++searchIdRef.current;
+			loadCategoryOptions(categoryKey, "");
+			internalRef.current?.focus();
+		},
+		[chips, categoryMap, loadCategoryOptions],
+	);
+	// ---- Option selection (completes a chip) ----
+	const selectOption = useCallback(
+		(option: FilterOption, categoryKey?: string) => {
+			let nextChips: FilterChip[];
+			if (categoryKey) {
+				// Global search: add chip. For single-select categories
+				// replace any existing chip with the same key.
+				const isMulti = categoryMap.get(categoryKey)?.multiSelect;
+				nextChips = [
+					...chips.filter(
+						(c) => c.value !== "" && (isMulti || c.key !== categoryKey),
+					),
+					{ key: categoryKey, value: option.value },
+				];
+			} else {
+				// Options mode: fill the incomplete chip with the selected
+				// value. For single-select categories also remove any
+				// other chip with the same key.
+				const incompleteKey = chips.find((c) => c.value === "")?.key;
+				const isMulti = incompleteKey
+					? categoryMap.get(incompleteKey)?.multiSelect
+					: false;
+				nextChips = chips
+					.filter((c) => {
+						if (c.value === "") return true;
+						return isMulti || c.key !== incompleteKey;
+					})
+					.map((c) => (c.value === "" ? { ...c, value: option.value } : c));
+			}
+			setChips(nextChips);
+			setCategorySearchText("");
+			setFreeformText("");
+			setDropdownMode({ type: "categories" });
+			setHighlightedIndex(-1);
+			setTypeaheadMatches([]);
+			setGlobalResults([]);
+			setSearchResults([]);
+			setIsLoadingOptions(false);
+			setIsLoadingGlobal(false);
+			setIsLoadingSearch(false);
+			setSearchResultsReady(true);
+			setGlobalSearchReady(true);
+			setCategoryOptions([]);
+			// Cancel stale in-flight requests.
+			++categorySearchIdRef.current;
+			++globalSearchIdRef.current;
+			++searchIdRef.current;
+			emitChange(nextChips, "");
+			setIsOpen(true);
+			internalRef.current?.focus();
+		},
+		[chips, categoryMap, emitChange],
+	);
+	// ---- Remove a chip by its original index in the chips array ----
+	const removeChip = useCallback(
+		(chipIndex: number) => {
+			const nextChips = chips.filter((_, i) => i !== chipIndex);
+			setChips(nextChips);
+			emitChange(nextChips, freeformText);
+			internalRef.current?.focus();
+		},
+		[chips, freeformText, emitChange],
+	);
+
+	// ---- Compute typeahead matches ----
+	const computeTypeahead = useCallback(
+		(text: string) => {
+			const trimmed = text.trim().toLowerCase();
+			if (!trimmed) {
+				setTypeaheadMatches([]);
+				return [];
+			}
+			const matches = categories.filter(
+				(c) =>
+					c.key.toLowerCase().startsWith(trimmed) ||
+					c.label.toLowerCase().startsWith(trimmed),
+			);
+			setTypeaheadMatches(matches);
+			return matches;
+		},
+		[categories],
+	);
+
+	// Categories that contain the input text (for typeahead filtering).
+	const filteredCategories = useMemo(() => {
+		const trimmed = freeformText.trim().toLowerCase();
+		if (!trimmed) return categories;
+		return categories.filter(
+			(c) =>
+				c.key.toLowerCase().includes(trimmed) ||
+				c.label.toLowerCase().includes(trimmed),
+		);
+	}, [categories, freeformText]);
+	// ---- Check if user is typing a "key:" pattern ----
+	const checkForKeyColonPattern = useCallback(
+		(text: string) => {
+			// Match pattern like "owner:" at the end of input.
+			const match = text.match(/(\S+):$/);
+			if (match) {
+				const key = match[1];
+				const category = categoryMap.get(key);
+				if (category) {
+					// Remove the "key:" from freeform and start a chip.
+					const remaining = text.slice(0, text.length - match[0].length).trim();
+					setFreeformText(remaining);
+					const newChip: FilterChip = { key, value: "" };
+					const isMulti = categoryMap.get(key)?.multiSelect;
+					const nextChips = [
+						...chips.filter(
+							(c) => c.value !== "" && (isMulti || c.key !== key),
+						),
+						newChip,
+					];
+					setChips(nextChips);
+					setDropdownMode({ type: "options", categoryKey: key });
+					setCategorySearchText("");
+					setHighlightedIndex(-1);
+					setTypeaheadMatches([]);
+					setGlobalResults([]);
+					loadCategoryOptions(key, "");
+					return true;
+				}
+			}
+
+			// Match complete pattern like "owner:me " (trailing space).
+			const completeMatch = text.match(/(\S+):(\S+)\s$/);
+			if (completeMatch) {
+				const key = completeMatch[1];
+				const val = completeMatch[2];
+				const category = categoryMap.get(key);
+				if (category && val) {
+					const remaining = text
+						.slice(0, text.length - completeMatch[0].length)
+						.trim();
+					setFreeformText(remaining);
+					const newChip: FilterChip = { key, value: val };
+					const isMulti = categoryMap.get(key)?.multiSelect;
+					const nextChips = [
+						...chips.filter(
+							(c) => c.value !== "" && (isMulti || c.key !== key),
+						),
+						newChip,
+					];
+					setChips(nextChips);
+					emitChange(nextChips, remaining);
+					setDropdownMode({ type: "categories" });
+					return true;
+				}
+			}
+
+			return false;
+		},
+		[categoryMap, chips, loadCategoryOptions, emitChange],
+	);
+
+	// ---- Freeform input handling ----
+	const handleInputChange = useCallback(
+		(e: React.ChangeEvent<HTMLInputElement>) => {
+			const text = e.target.value;
+
+			// When in options mode, the input is used for searching options.
+			if (dropdownMode.type === "options") {
+				setCategorySearchText(text);
+				setHighlightedIndex(-1);
+				loadCategoryOptions(dropdownMode.categoryKey, text);
+				return;
+			}
+
+			if (checkForKeyColonPattern(text)) {
+				return;
+			}
+
+			setFreeformText(text);
+			const trimmed = text.trim();
+
+			if (!trimmed) {
+				// Empty input: show category buttons.
+				if (!isOpen) {
+					openDropdown({ type: "categories" });
+				} else {
+					setDropdownMode({ type: "categories" });
+					setTypeaheadMatches([]);
+					setGlobalResults([]);
+					setSearchResults([]);
+				}
+				return;
+			}
+
+			// Compute typeahead matches (e.g. "own" -> "owner").
+			computeTypeahead(trimmed);
+
+			if (!isOpen) {
+				setIsOpen(true);
+			}
+			setDropdownMode({ type: "typeahead" });
+			setHighlightedIndex(-1);
+			setGlobalResults([]);
+			setIsLoadingGlobal(true);
+			// Clear previous debounce timer.
+			if (debounceRef.current) {
+				clearTimeout(debounceRef.current);
+			}
+			// Debounce the API calls.
+			debounceRef.current = setTimeout(() => {
+				loadGlobalResults(trimmed);
+				loadSearchResults(trimmed);
+			}, 300);
+		},
+		[
+			dropdownMode,
+			isOpen,
+			openDropdown,
+			loadCategoryOptions,
+			checkForKeyColonPattern,
+			computeTypeahead,
+			loadGlobalResults,
+			loadSearchResults,
+		],
+	);
+
+	// ---- Flat list of items for keyboard nav in each mode ----
+	type NavItem =
+		| { kind: "category"; category: FilterCategory }
+		| { kind: "option"; option: FilterOption }
+		| { kind: "global"; result: GlobalSearchResult }
+		| { kind: "search"; result: SearchResult };
+
+	const navItems = useMemo((): NavItem[] => {
+		if (dropdownMode.type === "categories") {
+			return categories.map((c) => ({ kind: "category", category: c }));
+		}
+		if (dropdownMode.type === "options") {
+			return categoryOptions.map((o) => ({ kind: "option", option: o }));
+		}
+		if (dropdownMode.type === "typeahead") {
+			const items: NavItem[] = filteredCategories.map((c) => ({
+				kind: "category",
+				category: c,
+			}));
+			for (const r of globalResults) {
+				items.push({ kind: "global", result: r });
+			}
+			if (searchResultsReady) {
+				for (const r of searchResults) {
+					items.push({ kind: "search", result: r });
+				}
+			}
+			return items;
+		}
+		return [];
+	}, [
+		dropdownMode,
+		categories,
+		filteredCategories,
+		categoryOptions,
+		globalResults,
+		searchResults,
+		searchResultsReady,
+	]);
+	// ---- Keyboard navigation ----
+	const handleKeyDown = useCallback(
+		(e: KeyboardEvent<HTMLInputElement>) => {
+			if (e.key === "Escape") {
+				closeDropdown();
+				internalRef.current?.blur();
+				return;
+			}
+
+			if (
+				e.key === "Backspace" &&
+				dropdownMode.type !== "options" &&
+				freeformText === "" &&
+				chips.length > 0
+			) {
+				// Remove the last chip.
+				e.preventDefault();
+				removeChip(chips.length - 1);
+				return;
+			}
+
+			if (
+				e.key === "Backspace" &&
+				dropdownMode.type === "options" &&
+				categorySearchText === ""
+			) {
+				// Cancel the current incomplete chip selection.
+				e.preventDefault();
+				const nextChips = chips.filter((c) => c.value !== "");
+				setChips(nextChips);
+				setDropdownMode({ type: "categories" });
+				setCategorySearchText("");
+				return;
+			}
+
+			// Tab completion: fill in the top typeahead match.
+			if (
+				e.key === "Tab" &&
+				dropdownMode.type === "typeahead" &&
+				typeaheadMatches.length > 0
+			) {
+				e.preventDefault();
+				const match = typeaheadMatches[0];
+				selectCategory(match.key);
+				return;
+			}
+
+			if (!isOpen) {
+				if (e.key === "ArrowDown" || e.key === "Enter") {
+					e.preventDefault();
+					openDropdown();
+				}
+				return;
+			}
+
+			const itemCount = navItems.length;
+
+			// ArrowRight/ArrowLeft navigate horizontally in categories mode.
+			const isNext =
+				e.key === "ArrowDown" ||
+				(e.key === "ArrowRight" && dropdownMode.type === "categories");
+			const isPrev =
+				e.key === "ArrowUp" ||
+				(e.key === "ArrowLeft" && dropdownMode.type === "categories");
+
+			if (isNext) {
+				e.preventDefault();
+				if (itemCount === 0) return;
+				setIsKeyboardNav(true);
+				setHighlightedIndex((prev) => (prev < 0 ? 0 : (prev + 1) % itemCount));
+			} else if (isPrev) {
+				e.preventDefault();
+				if (itemCount === 0) return;
+				setIsKeyboardNav(true);
+				setHighlightedIndex((prev) =>
+					prev < 0 ? itemCount - 1 : (prev - 1 + itemCount) % itemCount,
+				);
+			} else if (e.key === "Enter") {
+				e.preventDefault();
+				if (highlightedIndex < 0) {
+					// No item highlighted — submit the current search.
+					closeDropdown();
+					internalRef.current?.blur();
+					return;
+				}
+				const item = navItems[highlightedIndex];
+				if (!item) return;
+				if (item.kind === "category") {
+					selectCategory(item.category.key);
+				} else if (item.kind === "option") {
+					selectOption(item.option);
+				} else if (item.kind === "global") {
+					selectOption(item.result.option, item.result.category.key);
+				} else if (item.kind === "search") {
+					selectSearchResult(item.result);
+				}
+			}
+		},
+		[
+			isOpen,
+			dropdownMode,
+			freeformText,
+			chips,
+			categorySearchText,
+			highlightedIndex,
+			typeaheadMatches,
+			closeDropdown,
+			openDropdown,
+			removeChip,
+			selectCategory,
+			selectOption,
+			selectSearchResult,
+			navItems,
+		],
+	);
+
+	// ---- Scroll highlighted item into view ----
+	useEffect(() => {
+		if (!isOpen || highlightedIndex < 0) return;
+		const el = document.getElementById(`filter-option-${highlightedIndex}`);
+		if (el) {
+			el.scrollIntoView({ block: "nearest" });
+		}
+	}, [highlightedIndex, isOpen]);
+
+	// ---- Active input value ----
+	const inputValue =
+		dropdownMode.type === "options" ? categorySearchText : freeformText;
+
+	// Whether the dropdown actually has visible content. When typing
+	// freeform text that doesn't match any categories and results
+	// haven't loaded yet, the Popover may be "open" but empty.
+	const hasDropdownContent = useMemo(() => {
+		if (dropdownMode.type === "categories") return true;
+		if (dropdownMode.type === "options") return true;
+		// Typeahead: has content if any section has items or is loading.
+		return (
+			filteredCategories.length > 0 ||
+			globalResults.length > 0 ||
+			searchResults.length > 0 ||
+			isLoadingGlobal ||
+			isLoadingSearch
+		);
+	}, [
+		dropdownMode,
+		filteredCategories,
+		globalResults,
+		searchResults,
+		isLoadingGlobal,
+		isLoadingSearch,
+	]);
+
+	// Whether to visually show the dropdown (suppress rounded corners
+	// and bottom border on the input group).
+	const showDropdown = isOpen && hasDropdownContent;
+
+	const activeIncompleteChip = chips.find((c) => c.value === "");
+	const activeCategoryLabel = activeIncompleteChip
+		? (categoryMap.get(activeIncompleteChip.key)?.label ??
+			activeIncompleteChip.key)
+		: undefined;
+
+	// Build the index mapping: rendered chip index -> original chips array
+	// index. We only render complete chips, but removeChip needs the original
+	// index.
+	const completeChipEntries = useMemo(() => {
+		const entries: Array<{ chip: FilterChip; originalIndex: number }> = [];
+		for (let i = 0; i < chips.length; i++) {
+			if (chips[i].value !== "") {
+				entries.push({ chip: chips[i], originalIndex: i });
+			}
+		}
+		return entries;
+	}, [chips]);
+
+	return (
+		<div ref={containerRef} className={cn("relative rounded-md", className)}>
+			{/* Input group */}
+			{/* biome-ignore lint/a11y/useKeyWithClickEvents: Keyboard handled via input's onKeyDown. */}
+			<div
+				className={cn(
+					"group/filter-search flex items-start w-full min-w-0 min-h-10 rounded-md border border-solid border-border bg-transparent transition-colors",
+					!(isKeyboardNav && highlightedIndex >= 0) &&
+						"has-[:focus]:ring-2 has-[:focus]:ring-content-link",
+				)}
+				onClick={() => {
+					internalRef.current?.focus();
+					if (!isOpen) {
+						openDropdown();
+					}
+				}}
+			>
+				{/* Search icon */}
+				<div className="flex shrink-0 items-center justify-center h-10 pl-3 pr-2 text-content-secondary">
+					<SearchIcon className="size-4" />
+				</div>
+				{/* Chips + input area */}
+				<div className="flex flex-1 flex-wrap items-center gap-1.5 min-w-0 py-1.5 cursor-text">
+					{completeChipEntries.map(({ chip, originalIndex }) => {
+						const cat = categoryMap.get(chip.key);
+						return (
+							<ChipBadge
+								key={`${chip.key}-${chip.value}-${originalIndex}`}
+								chip={chip}
+								categoryLabel={cat?.label ?? chip.key}
+								onRemove={() => removeChip(originalIndex)}
+							/>
+						);
+					})}
+
+					{/* Incomplete chip indicator */}
+					{activeIncompleteChip && (
+						<Badge
+							variant="default"
+							size="md"
+							className="shrink-0 border border-dashed border-border-default"
+						>
+							<span className="text-content-secondary">
+								{activeCategoryLabel}:
+							</span>
+						</Badge>
+					)}
+
+					{/* Text input */}
+					<input
+						ref={setRefs}
+						type="text"
+						tabIndex={0}
+						className="flex-1 min-w-[40px] h-7 bg-transparent border-none outline-none text-sm text-content-primary placeholder:text-content-secondary"
+						placeholder={chips.length === 0 ? placeholder : ""}
+						value={inputValue}
+						onChange={handleInputChange}
+						onFocus={() => {
+							if (!isOpen) {
+								openDropdown();
+							}
+						}}
+						onBlur={(e) => {
+							const related = e.relatedTarget;
+							if (containerRef.current?.contains(related)) {
+								return;
+							}
+							closeDropdown();
+						}}
+						onKeyDown={handleKeyDown}
+						role="combobox"
+						aria-expanded={isOpen}
+						aria-haspopup="listbox"
+						aria-autocomplete="list"
+						aria-controls={isOpen ? "filter-search-listbox" : undefined}
+						aria-activedescendant={
+							isOpen && highlightedIndex >= 0 && navItems.length > 0
+								? `filter-option-${highlightedIndex}`
+								: undefined
+						}
+						aria-label={ariaProps["aria-label"] ?? "Filter search"}
+					/>
+				</div>
+				{/* ListFilter icon with left border */}
+				<div
+					className="flex shrink-0 items-center justify-center self-stretch pl-2 pr-3 border-0 border-l border-solid border-border text-content-secondary hover:text-content-primary transition-colors cursor-pointer"
+					aria-hidden="true"
+				>
+					<ListFilter className="size-4" />
+				</div>
+			</div>
+
+			{/* Dropdown — absolutely positioned so it floats over page content */}
+			{showDropdown && (
+				<div
+					id="filter-search-listbox"
+					role="listbox"
+					aria-label="Filter options"
+					className="absolute left-0 right-0 top-full z-50 max-h-80 overflow-y-auto rounded-md border border-solid border-border bg-surface-primary shadow-lg mt-1.5"
+				>
+					{/* Categories mode: show "Filter by" + category buttons */}
+					{dropdownMode.type === "categories" && (
+						<div className="p-3">
+							<p
+								role="presentation"
+								className="text-xs font-medium text-content-secondary mb-2"
+							>
+								Filter by
+							</p>
+							<div className="flex flex-wrap gap-2">
+								{categories.map((category, index) => (
+									<CategoryButton
+										key={category.key}
+										category={category}
+										id={`filter-option-${index}`}
+										isHighlighted={highlightedIndex === index}
+										showFocusRing={isKeyboardNav}
+										onSelect={() => selectCategory(category.key)}
+										onMouseEnter={() => {
+											setHighlightedIndex(index);
+											setIsKeyboardNav(false);
+										}}
+									/>
+								))}
+							</div>
+						</div>
+					)}
+					{/* Options mode: show values for a selected category */}
+					{dropdownMode.type === "options" && (
+						<div>
+							{isLoadingOptions ? (
+								<div className="flex items-center justify-center py-6">
+									<Spinner size="sm" loading />
+								</div>
+							) : categoryOptions.length === 0 ? (
+								<p className="py-6 text-center text-sm text-content-secondary">
+									No results found
+								</p>
+							) : (
+								<div className="p-2">
+									{categoryOptions.map((option, index) => (
+										<OptionItem
+											key={option.value}
+											id={`filter-option-${index}`}
+											option={option}
+											isHighlighted={highlightedIndex === index}
+											showFocusRing={isKeyboardNav}
+											onSelect={() => selectOption(option)}
+											onMouseEnter={() => {
+												setHighlightedIndex(index);
+												setIsKeyboardNav(false);
+											}}
+										/>
+									))}
+								</div>
+							)}
+						</div>
+					)}
+					{/* Typeahead mode: show category list + suggestions + search results */}
+					{dropdownMode.type === "typeahead" && (
+						<div>
+							{/* Matching categories */}
+							{filteredCategories.length > 0 && (
+								<div className="p-2">
+									{filteredCategories.map((category) => {
+										const idx = navItems.findIndex(
+											(n) =>
+												n.kind === "category" &&
+												n.category.key === category.key,
+										);
+										return (
+											// biome-ignore lint/a11y/useKeyWithClickEvents: Keyboard navigation is handled by the parent input's onKeyDown handler.
+											<div
+												key={category.key}
+												id={`filter-option-${idx}`}
+												role="option"
+												tabIndex={-1}
+												aria-selected={highlightedIndex === idx}
+												className={cn(
+													"flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm cursor-pointer",
+													"transition-colors font-medium",
+													highlightedIndex === idx
+														? "bg-surface-secondary text-content-primary"
+														: "text-content-secondary",
+													highlightedIndex === idx &&
+														isKeyboardNav &&
+														"ring-2 ring-content-link",
+												)}
+												onClick={() => selectCategory(category.key)}
+												onMouseEnter={() => {
+													setHighlightedIndex(idx);
+													setIsKeyboardNav(false);
+												}}
+												onMouseDown={(e) => {
+													e.preventDefault();
+												}}
+											>
+												{category.icon && (
+													<span className="flex shrink-0 items-center justify-center size-6 text-content-secondary">
+														{category.icon}
+													</span>
+												)}
+												<span>{category.label}</span>
+											</div>
+										);
+									})}
+								</div>
+							)}
+							{/* Suggestions */}
+							{isLoadingGlobal &&
+							isLoadingSearch &&
+							globalResults.length === 0 &&
+							searchResults.length === 0 ? (
+								<div className="flex items-center justify-center py-4">
+									<Spinner size="sm" loading />
+								</div>
+							) : (
+								<>
+									{globalResults.length > 0 && (
+										<div className="px-2 pb-2 pt-1">
+											<p
+												id="filter-suggestions-label"
+												className="text-xs font-medium text-content-secondary px-2 pb-1"
+												role="presentation"
+											>
+												Filter suggestions
+											</p>
+											{globalResults.map((result, idx) => {
+												const navIdx = filteredCategories.length + idx;
+												return (
+													<OptionItem
+														key={`${result.category.key}-${result.option.value}`}
+														id={`filter-option-${navIdx}`}
+														option={result.option}
+														isHighlighted={highlightedIndex === navIdx}
+														showFocusRing={isKeyboardNav}
+														categoryLabel={result.category.label}
+														onSelect={() =>
+															selectOption(result.option, result.category.key)
+														}
+														onMouseEnter={() => {
+															setHighlightedIndex(navIdx);
+															setIsKeyboardNav(false);
+														}}
+													/>
+												);
+											})}
+										</div>
+									)}
+									{/* Resource search results */}
+									{getSearchResults && (
+										<SearchResultsSection
+											searchResults={searchResults}
+											isLoading={isLoadingSearch}
+											isReady={searchResultsReady}
+											highlightedIndex={highlightedIndex}
+											showFocusRing={isKeyboardNav}
+											navIndexOffset={
+												filteredCategories.length + globalResults.length
+											}
+											onSelect={selectSearchResult}
+											onHighlight={(idx) => {
+												setHighlightedIndex(idx);
+												setIsKeyboardNav(false);
+											}}
+										/>
+									)}
+								</>
+							)}
+						</div>
+					)}
+				</div>
+			)}
+		</div>
+	);
+};

--- a/site/src/components/FilterSearchField/FilterSearchField.tsx
+++ b/site/src/components/FilterSearchField/FilterSearchField.tsx
@@ -76,6 +76,8 @@ export type SearchResult = {
 	startIcon?: React.ReactNode;
 	/** Optional secondary text rendered below the label. */
 	subtitle?: string;
+	/** Optional URL to navigate to when this result is selected. */
+	url?: string;
 };
 
 export type FilterSearchFieldProps = {
@@ -91,6 +93,12 @@ export type FilterSearchFieldProps = {
 	 * a dedicated section so the user can see what their query will match.
 	 */
 	getSearchResults?: (query: string) => Promise<SearchResult[]>;
+	/**
+	 * Called when a search result is selected. Use this to navigate
+	 * to the result (e.g. a workspace page). If not provided, the
+	 * result value is placed into the freeform text.
+	 */
+	onSelectResult?: (result: SearchResult) => void;
 	placeholder?: string;
 	className?: string;
 	autoFocus?: boolean;
@@ -432,6 +440,7 @@ export const FilterSearchField: React.FC<FilterSearchFieldProps> = ({
 	onChange,
 	categories,
 	getSearchResults,
+	onSelectResult,
 	placeholder = "Search...",
 	className,
 	autoFocus = false,
@@ -687,6 +696,14 @@ export const FilterSearchField: React.FC<FilterSearchFieldProps> = ({
 	// ---- Select a search result (e.g. a workspace) ----
 	const selectSearchResult = useCallback(
 		(result: SearchResult) => {
+			if (onSelectResult) {
+				// Close dropdown and let the consumer handle navigation.
+				setIsOpen(false);
+				setDropdownMode({ type: "categories" });
+				setHighlightedIndex(-1);
+				onSelectResult(result);
+				return;
+			}
 			const completeChips = chips.filter((c) => c.value !== "");
 			setChips(completeChips);
 			setFreeformText(result.value);
@@ -700,7 +717,7 @@ export const FilterSearchField: React.FC<FilterSearchFieldProps> = ({
 			setSearchResults([]);
 			emitChange(completeChips, result.value);
 		},
-		[chips, emitChange],
+		[chips, emitChange, onSelectResult],
 	);
 
 	// ---- Category selection (from default dropdown) ----
@@ -1075,6 +1092,12 @@ export const FilterSearchField: React.FC<FilterSearchFieldProps> = ({
 			} else if (e.key === "Enter") {
 				e.preventDefault();
 				if (highlightedIndex < 0) {
+					// In options mode, select the first visible option
+					// instead of discarding the incomplete chip.
+					if (dropdownMode.type === "options" && categoryOptions.length > 0) {
+						selectOption(categoryOptions[0]);
+						return;
+					}
 					// No item highlighted — submit the current search.
 					closeDropdown();
 					internalRef.current?.blur();
@@ -1099,6 +1122,7 @@ export const FilterSearchField: React.FC<FilterSearchFieldProps> = ({
 			freeformText,
 			chips,
 			categorySearchText,
+			categoryOptions,
 			highlightedIndex,
 			typeaheadMatches,
 			closeDropdown,

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -245,7 +245,7 @@ const useWorkspacesFilter = ({
 	onFilterChange,
 }: UseWorkspacesFilterOptions) => {
 	const filter = useFilter({
-		fallbackFilter: "owner:me",
+		fallbackFilter: "",
 		searchParams,
 		onSearchParamsChange,
 		onUpdate: onFilterChange,

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -43,6 +43,7 @@ import {
 import { WorkspacesTable } from "pages/WorkspacesPage/WorkspacesTable";
 import { type FC, useCallback, useMemo } from "react";
 import type { UseQueryResult } from "react-query";
+import { useNavigate } from "react-router";
 import {
 	getDisplayWorkspaceStatus,
 	mustUpdateWorkspace,
@@ -112,6 +113,7 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 	const pageNumberIsInvalid = page !== 1 && workspaces?.length === 0;
 
 	const { user: me } = useAuthenticated();
+	const navigate = useNavigate();
 
 	const categories = useMemo<FilterCategory[]>(() => {
 		const cats: FilterCategory[] = [];
@@ -231,6 +233,7 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 				return {
 					label: ws.name,
 					value: ws.name,
+					url: `/@${ws.owner_name}/${ws.name}`,
 					startIcon: (
 						<Avatar
 							size="sm"
@@ -274,6 +277,11 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 					onChange={filterState.filter.update}
 					categories={categories}
 					getSearchResults={getSearchResults}
+					onSelectResult={(result) => {
+						if (result.url) {
+							navigate(result.url);
+						}
+					}}
 					placeholder="Search workspaces..."
 					aria-label="Filter workspaces"
 					className="w-fit min-w-[min(550px,100%)] max-w-full"

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -1,7 +1,9 @@
+import { API } from "api/api";
 import { hasError, isApiValidationError } from "api/errors";
-import type { Template, Workspace } from "api/typesGenerated";
+import type { Template, Workspace, WorkspaceStatus } from "api/typesGenerated";
 import { ErrorAlert } from "components/Alert/ErrorAlert";
 import { ChevronDownIcon } from "components/AnimatedIcons/ChevronDown";
+import { Avatar } from "components/Avatar/Avatar";
 import { Button } from "components/Button/Button";
 import {
 	DropdownMenu,
@@ -11,22 +13,41 @@ import {
 	DropdownMenuTrigger,
 } from "components/DropdownMenu/DropdownMenu";
 import { EmptyState } from "components/EmptyState/EmptyState";
+import {
+	type FilterCategory,
+	FilterSearchField,
+	type SearchResult,
+} from "components/FilterSearchField/FilterSearchField";
 import { Margins } from "components/Margins/Margins";
 import { PageHeader, PageHeaderTitle } from "components/PageHeader/PageHeader";
 import { PaginationAmount } from "components/PaginationWidget/PaginationAmount";
 import { PaginationWidgetBase } from "components/PaginationWidget/PaginationWidgetBase";
 import { Spinner } from "components/Spinner/Spinner";
 import { Stack } from "components/Stack/Stack";
-import { TableToolbar } from "components/TableToolbar/TableToolbar";
-import { CloudIcon, PlayIcon, SquareIcon, TrashIcon } from "lucide-react";
-import { WorkspacesTable } from "pages/WorkspacesPage/WorkspacesTable";
-import type { FC } from "react";
-import type { UseQueryResult } from "react-query";
-import { mustUpdateWorkspace } from "utils/workspace";
 import {
-	type WorkspaceFilterState,
-	WorkspacesFilter,
-} from "./filter/WorkspacesFilter";
+	StatusIndicatorDot,
+	type StatusIndicatorDotProps,
+} from "components/StatusIndicator/StatusIndicator";
+import { TableToolbar } from "components/TableToolbar/TableToolbar";
+import { useAuthenticated } from "hooks";
+import {
+	Building2,
+	CircleDot,
+	CloudIcon,
+	LayoutPanelTop,
+	PlayIcon,
+	SquareIcon,
+	TrashIcon,
+	User,
+} from "lucide-react";
+import { WorkspacesTable } from "pages/WorkspacesPage/WorkspacesTable";
+import { type FC, useCallback, useMemo } from "react";
+import type { UseQueryResult } from "react-query";
+import {
+	getDisplayWorkspaceStatus,
+	mustUpdateWorkspace,
+} from "utils/workspace";
+import type { WorkspaceFilterState } from "./filter/WorkspacesFilter";
 import { WorkspaceHelpTooltip } from "./WorkspaceHelpTooltip";
 import { WorkspacesButton } from "./WorkspacesButton";
 
@@ -90,6 +111,141 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 	// better error message.
 	const pageNumberIsInvalid = page !== 1 && workspaces?.length === 0;
 
+	const { user: me } = useAuthenticated();
+
+	const categories = useMemo<FilterCategory[]>(() => {
+		const cats: FilterCategory[] = [];
+
+		// Owner category.
+		cats.push({
+			key: "owner",
+			label: "Owner",
+			icon: <User className="size-4" />,
+			getOptions: async (query) => {
+				const usersRes = await API.getUsers({ q: query, limit: 25 });
+				const options = usersRes.users.map((user) => ({
+					label: user.username,
+					value: user.username,
+					startIcon: (
+						<Avatar fallback={user.username} src={user.avatar_url} size="sm" />
+					),
+				}));
+				// Pin the current user first.
+				const filtered = options.filter((o) => o.value !== me.username);
+				return [
+					{
+						label: me.username,
+						value: me.username,
+						startIcon: (
+							<Avatar fallback={me.username} src={me.avatar_url} size="sm" />
+						),
+					},
+					...filtered,
+				];
+			},
+		});
+
+		// Template category.
+		cats.push({
+			key: "template",
+			label: "Template",
+			icon: <LayoutPanelTop className="size-4" />,
+			getOptions: async (query) => {
+				const templates = await API.getTemplates();
+				const filtered = templates.filter(
+					(t) =>
+						t.name.toLowerCase().includes(query.toLowerCase()) ||
+						t.display_name.toLowerCase().includes(query.toLowerCase()),
+				);
+				return filtered.map((t) => ({
+					label: t.display_name || t.name,
+					value: t.name,
+					startIcon: (
+						<Avatar
+							size="sm"
+							variant="icon"
+							src={t.icon}
+							fallback={t.display_name || t.name}
+						/>
+					),
+				}));
+			},
+		});
+
+		// Status category.
+		const statusesToFilter: WorkspaceStatus[] = [
+			"running",
+			"stopped",
+			"failed",
+			"pending",
+		];
+		cats.push({
+			key: "status",
+			label: "Status",
+			icon: <CircleDot className="size-4" />,
+			getOptions: async () => {
+				return statusesToFilter.map((status) => {
+					const display = getDisplayWorkspaceStatus(status);
+					return {
+						label: display.text,
+						value: status,
+						startIcon: (
+							<StatusIndicatorDot variant={getStatusVariant(status)} />
+						),
+					};
+				});
+			},
+		});
+
+		// Organization category.
+		cats.push({
+			key: "organization",
+			label: "Organization",
+			icon: <Building2 className="size-4" />,
+			getOptions: async () => {
+				const organizations = await API.getOrganizations();
+				return organizations.map((org) => ({
+					label: org.display_name || org.name,
+					value: org.name,
+					startIcon: (
+						<Avatar
+							size="sm"
+							fallback={org.display_name || org.name}
+							src={org.icon}
+						/>
+					),
+				}));
+			},
+		});
+		return cats;
+	}, [me.username, me.avatar_url]);
+
+	const getSearchResults = useCallback(
+		async (query: string): Promise<SearchResult[]> => {
+			const { workspaces } = await API.getWorkspaces({
+				q: query,
+				limit: 5,
+			});
+			return workspaces.map((ws) => {
+				const display = getDisplayWorkspaceStatus(ws.latest_build.status);
+				return {
+					label: ws.name,
+					value: ws.name,
+					startIcon: (
+						<Avatar
+							size="sm"
+							variant="icon"
+							src={ws.template_icon}
+							fallback={ws.name}
+						/>
+					),
+					subtitle: `${ws.owner_name} · ${display.text}`,
+				};
+			});
+		},
+		[],
+	);
+
 	return (
 		<Margins className="pb-12">
 			<PageHeader
@@ -109,96 +265,83 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 					</Stack>
 				</PageHeaderTitle>
 			</PageHeader>
-
 			<Stack>
 				{hasError(error) && !isApiValidationError(error) && (
 					<ErrorAlert error={error} />
 				)}
-				<WorkspacesFilter
-					filter={filterState.filter}
-					error={error}
-					statusMenu={filterState.menus.status}
-					templateMenu={filterState.menus.template}
-					userMenu={filterState.menus.user}
-					organizationsMenu={filterState.menus.organizations}
-				/>
+				<FilterSearchField
+					value={filterState.filter.query}
+					onChange={filterState.filter.update}
+					categories={categories}
+					getSearchResults={getSearchResults}
+					placeholder="Search workspaces..."
+					aria-label="Filter workspaces"
+					className="w-fit min-w-[min(550px,100%)] max-w-full"
+				/>{" "}
 			</Stack>
+			{checkedWorkspaces.length > 0 && (
+				<TableToolbar>
+					<div>
+						Selected <strong>{checkedWorkspaces.length}</strong> of{" "}
+						<strong>{workspaces?.length}</strong>{" "}
+						{workspaces?.length === 1 ? "workspace" : "workspaces"}
+					</div>
 
-			<TableToolbar>
-				{checkedWorkspaces.length > 0 ? (
-					<>
-						<div>
-							Selected <strong>{checkedWorkspaces.length}</strong> of{" "}
-							<strong>{workspaces?.length}</strong>{" "}
-							{workspaces?.length === 1 ? "workspace" : "workspaces"}
-						</div>
-
-						<DropdownMenu>
-							<DropdownMenuTrigger asChild>
-								<Button
-									disabled={isRunningBatchAction}
-									variant="outline"
-									size="sm"
-									className="ml-auto"
-								>
-									Bulk actions
-									<Spinner loading={isRunningBatchAction}>
-										<ChevronDownIcon />
-									</Spinner>
-								</Button>
-							</DropdownMenuTrigger>
-							<DropdownMenuContent align="end">
-								<DropdownMenuItem
-									disabled={
-										!checkedWorkspaces?.every(
-											(w) =>
-												w.latest_build.status === "stopped" &&
-												!mustUpdateWorkspace(w, canChangeVersions),
-										)
-									}
-									onClick={onBatchStartTransition}
-								>
-									<PlayIcon /> Start
-								</DropdownMenuItem>
-								<DropdownMenuItem
-									disabled={
-										!checkedWorkspaces?.every(
-											(w) => w.latest_build.status === "running",
-										)
-									}
-									onClick={onBatchStopTransition}
-								>
-									<SquareIcon /> Stop
-								</DropdownMenuItem>
-								<DropdownMenuSeparator />
-								<DropdownMenuItem onClick={onBatchUpdateTransition}>
-									<CloudIcon
-										className="size-icon-sm"
-										data-testid="bulk-action-update"
-									/>{" "}
-									Update&hellip;
-								</DropdownMenuItem>
-								<DropdownMenuItem
-									className="text-content-destructive focus:text-content-destructive"
-									onClick={onBatchDeleteTransition}
-								>
-									<TrashIcon /> Delete&hellip;
-								</DropdownMenuItem>
-							</DropdownMenuContent>
-						</DropdownMenu>
-					</>
-				) : (
-					!pageNumberIsInvalid && (
-						<PaginationAmount
-							paginationUnitLabel="workspaces"
-							limit={limit}
-							totalRecords={count}
-							currentOffsetStart={(page - 1) * limit + 1}
-						/>
-					)
-				)}
-			</TableToolbar>
-
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<Button
+								disabled={isRunningBatchAction}
+								variant="outline"
+								size="sm"
+								className="ml-auto"
+							>
+								Bulk actions
+								<Spinner loading={isRunningBatchAction}>
+									<ChevronDownIcon />
+								</Spinner>
+							</Button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="end">
+							<DropdownMenuItem
+								disabled={
+									!checkedWorkspaces?.every(
+										(w) =>
+											w.latest_build.status === "stopped" &&
+											!mustUpdateWorkspace(w, canChangeVersions),
+									)
+								}
+								onClick={onBatchStartTransition}
+							>
+								<PlayIcon /> Start
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								disabled={
+									!checkedWorkspaces?.every(
+										(w) => w.latest_build.status === "running",
+									)
+								}
+								onClick={onBatchStopTransition}
+							>
+								<SquareIcon /> Stop
+							</DropdownMenuItem>
+							<DropdownMenuSeparator />
+							<DropdownMenuItem onClick={onBatchUpdateTransition}>
+								<CloudIcon
+									className="size-icon-sm"
+									data-testid="bulk-action-update"
+								/>{" "}
+								Update&hellip;
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								className="text-content-destructive focus:text-content-destructive"
+								onClick={onBatchDeleteTransition}
+							>
+								<TrashIcon /> Delete&hellip;
+							</DropdownMenuItem>
+						</DropdownMenuContent>
+					</DropdownMenu>
+				</TableToolbar>
+			)}
 			{pageNumberIsInvalid ? (
 				<EmptyState
 					css={(theme) => ({
@@ -229,12 +372,15 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 					onActionError={onActionError}
 				/>
 			)}
-
-			{count !== undefined && (
-				// Temporary styling stopgap before component is migrated to using
-				// PaginationContainer (which renders PaginationWidgetBase using CSS
-				// flexbox gaps)
-				<div css={{ paddingTop: "16px" }}>
+			{!pageNumberIsInvalid && count !== undefined && (
+				<div className="flex flex-col gap-y-4 pt-4">
+					<PaginationAmount
+						paginationUnitLabel="workspaces"
+						limit={limit}
+						totalRecords={count}
+						currentOffsetStart={(page - 1) * limit + 1}
+						className="justify-end"
+					/>
 					<PaginationWidgetBase
 						totalRecords={count}
 						pageSize={limit}
@@ -242,7 +388,25 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 						currentPage={page}
 					/>
 				</div>
-			)}
+			)}{" "}
 		</Margins>
 	);
+};
+
+const getStatusVariant = (
+	status: WorkspaceStatus,
+): StatusIndicatorDotProps["variant"] => {
+	const display = getDisplayWorkspaceStatus(status);
+	const variantByStatusType: Record<
+		string,
+		StatusIndicatorDotProps["variant"]
+	> = {
+		active: "pending",
+		inactive: "inactive",
+		success: "success",
+		error: "failed",
+		danger: "warning",
+		warning: "warning",
+	};
+	return variantByStatusType[display.type] ?? "inactive";
 };


### PR DESCRIPTION
## What does this do?

Introduces a new `FilterSearchField` component that replaces the existing `<Filter>` + `<SelectFilter>` dropdown system with a unified inline filter bar. Currently wired into the Workspaces page as a prototype.

### How it works

- **Chip-based filters** — Active filters render as `key:value` chips inside the search input with X buttons to remove. Chips serialize to/from the standard query string (`owner:me status:running`).
- **Category picker** — On focus with empty input, a dropdown shows all available filter categories (Owner, Template, Status, Organization) as pill buttons.
- **Options dropdown** — After selecting a category, the dropdown shows that category's options fetched async. Type to filter, click or Enter to complete the chip.
- **Typeahead mode** — When typing freeform text, the dropdown shows matching categories, filter suggestions across all categories, and live workspace search results.
- **Workspace navigation** — Clicking a workspace in search results navigates directly to that workspace page.

### Keyboard navigation

- Arrow keys navigate dropdown items
- Tab autocompletes the top matching category (`ow` → Tab → `owner:`)
- Enter with no item highlighted submits current search
- Enter in options mode selects the first visible option
- Escape closes dropdown
- Backspace removes last chip when input is empty

### WCAG compliance

- `role="combobox"` on the `<input>` with `aria-activedescendant`
- Single `role="listbox"` on the dropdown
- One focus indicator at a time (search ring vs item ring)
- `role="presentation"` on non-interactive headings inside listbox

### Architecture

- ~1,460 lines, zero new dependencies
- Uses existing primitives: `Badge`, `Spinner`, `Avatar`, `cn()`, `lucide-react` icons
- Dropdown is a plain absolutely-positioned `<div>` (no Radix Popover)
- 300ms debounce on API calls; immediate local category matching
- Stale async responses discarded via request ID counters
- `multiSelect` per-category toggle (frontend-ready, no backend category uses it yet — backend uses `parser.String` single-value for all workspace filters)

### Files

| File | Lines | Description |
|---|---|---|
| `FilterSearchField.tsx` | 1,460 | Main component |
| `FilterSearchField.stories.tsx` | 155 | Storybook stories |
| `WorkspacesPageView.tsx` | +40 | Wiring into Workspaces page |
| `WorkspacesPage.tsx` | +1 | Default filter changed to empty |
| `FILTER_SEARCH_FIELD_PROMPT.md` | 675 | Reproduction prompt |
| `FILTER_SEARCH_FIELD_RFC.md` | 205 | Draft RFC with backend multi-select migration plan |

### Not yet implemented

- Preset quick-filter buttons ("My workspaces", "Running workspaces", etc.)
- Inline error display for invalid filter queries
- Migration of Audit / Connection Log / AI Bridge pages
- Backend multi-value filter support (see RFC for migration plan)
- Unit/integration tests

### How to test

```bash
./scripts/develop.sh
# Visit http://localhost:8080/workspaces
# Login: admin@coder.com / SomeSecurePassword!
```

Or view Storybook stories: `pnpm storybook` → components/FilterSearchField

### Screenshots

_TODO: Add screenshots of the component in action_