### PR TITLE
fix(cli): serialize TestUseKeyring subtests to avoid OS keyring flakes

### DIFF
--- a/cli/keyring_test.go
+++ b/cli/keyring_test.go
@@ -55,14 +55,12 @@ func setupKeyringTestEnv(t *testing.T, clientURL string, args ...string) keyring
 	return keyringTestEnv{serviceName, backend, inv, cfg, parsedURL}
 }
 
+//nolint:paralleltest,tparallel // Windows OS keyring has intermittent failures with concurrent access
 func TestUseKeyring(t *testing.T) {
 	// Verify that the --use-keyring flag default opts into using a keyring backend
 	// for storing session tokens instead of plain text files.
-	t.Parallel()
 
 	t.Run("Login", func(t *testing.T) {
-		t.Parallel()
-
 		if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
 			t.Skip("keyring is not supported on this OS")
 		}
@@ -109,8 +107,6 @@ func TestUseKeyring(t *testing.T) {
 	})
 
 	t.Run("Logout", func(t *testing.T) {
-		t.Parallel()
-
 		if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
 			t.Skip("keyring is not supported on this OS")
 		}
@@ -174,8 +170,6 @@ func TestUseKeyring(t *testing.T) {
 	})
 
 	t.Run("DefaultFileStorage", func(t *testing.T) {
-		t.Parallel()
-
 		if runtime.GOOS != "linux" {
 			t.Skip("file storage is the default for Linux")
 		}
@@ -220,8 +214,6 @@ func TestUseKeyring(t *testing.T) {
 	})
 
 	t.Run("EnvironmentVariable", func(t *testing.T) {
-		t.Parallel()
-
 		logger := testutil.Logger(t)
 		ctx := testutil.Context(t, testutil.WaitMedium)
 		// Create a test server
@@ -265,8 +257,6 @@ func TestUseKeyring(t *testing.T) {
 	})
 
 	t.Run("DisableKeyringWithFlag", func(t *testing.T) {
-		t.Parallel()
-
 		logger := testutil.Logger(t)
 		ctx := testutil.Context(t, testutil.WaitMedium)
 		client := coderdtest.New(t, nil)


### PR DESCRIPTION
`TestUseKeyring/Logout` flaked on Windows in CI: after `coder logout` returned `nil`, `env.keyring.Read(env.clientURL)` still returned the credential instead of `os.ErrNotExist`. The CI logs showed the logout HTTP call succeeded and the keyring service name and server URL were correct.

The OS keyring is shared global state on Windows and macOS, and concurrent in-process access seems to produce intermittent failures on Windows (ERROR_NOT_FOUND, stale reads after delete). This change serializes TestUseKeyring subtests in an attempt to fix the intermittent failures, which was seen to have an impact for other Windows keyring tests. The root cause is unknown.

Closes coder/internal#1554

Generated with assistance by Coder Agents