### PR TITLE
feat(aibridge): add interception_id to request log context

### DIFF
--- a/aibridge/bridge.go
+++ b/aibridge/bridge.go
@@ -236,6 +236,9 @@ func newInterceptionProcessor(p provider.Provider, cbs *circuitbreaker.ProviderC
 		traceAttrs := interceptor.TraceAttributes(r)
 		span.SetAttributes(traceAttrs...)
 		ctx = tracing.WithInterceptionAttributesInContext(ctx, traceAttrs)
+		// Attach the interception ID to the context so every log line
+		// emitted with this context can be correlated to the interception.
+		ctx = slog.With(ctx, slog.F("interception_id", interceptor.ID()))
 		r = r.WithContext(ctx)
 
 		// Record usage in the background to not block request flow.
@@ -272,7 +275,6 @@ func newInterceptionProcessor(p provider.Provider, cbs *circuitbreaker.ProviderC
 		log := logger.With(
 			slog.F("route", route),
 			slog.F("provider", p.Name()),
-			slog.F("interception_id", interceptor.ID()),
 			slog.F("user_agent", r.UserAgent()),
 			slog.F("streaming", interceptor.Streaming()),
 			slog.F("credential_kind", string(cred.Kind)),

--- a/aibridge/recorder/recorder.go
+++ b/aibridge/recorder/recorder.go
@@ -40,7 +40,7 @@ func (r *WrappedRecorder) RecordInterception(ctx context.Context, req *Intercept
 		return nil
 	}
 
-	r.logger.Warn(ctx, "failed to record interception", slog.Error(err), slog.F("interception_id", req.ID))
+	r.logger.Warn(ctx, "failed to record interception", slog.Error(err))
 	return err
 }
 
@@ -58,7 +58,7 @@ func (r *WrappedRecorder) RecordInterceptionEnded(ctx context.Context, req *Inte
 		return nil
 	}
 
-	r.logger.Warn(ctx, "failed to record that interception ended", slog.Error(err), slog.F("interception_id", req.ID))
+	r.logger.Warn(ctx, "failed to record that interception ended", slog.Error(err))
 	return err
 }
 
@@ -76,7 +76,7 @@ func (r *WrappedRecorder) RecordPromptUsage(ctx context.Context, req *PromptUsag
 		return nil
 	}
 
-	r.logger.Warn(ctx, "failed to record prompt usage", slog.Error(err), slog.F("interception_id", req.InterceptionID))
+	r.logger.Warn(ctx, "failed to record prompt usage", slog.Error(err))
 	return err
 }
 
@@ -94,7 +94,7 @@ func (r *WrappedRecorder) RecordTokenUsage(ctx context.Context, req *TokenUsageR
 		return nil
 	}
 
-	r.logger.Warn(ctx, "failed to record token usage", slog.Error(err), slog.F("interception_id", req.InterceptionID))
+	r.logger.Warn(ctx, "failed to record token usage", slog.Error(err))
 	return err
 }
 
@@ -112,7 +112,7 @@ func (r *WrappedRecorder) RecordToolUsage(ctx context.Context, req *ToolUsageRec
 		return nil
 	}
 
-	r.logger.Warn(ctx, "failed to record tool usage", slog.Error(err), slog.F("interception_id", req.InterceptionID))
+	r.logger.Warn(ctx, "failed to record tool usage", slog.Error(err))
 	return err
 }
 
@@ -130,7 +130,7 @@ func (r *WrappedRecorder) RecordModelThought(ctx context.Context, req *ModelThou
 		return nil
 	}
 
-	r.logger.Warn(ctx, "failed to record model thought", slog.Error(err), slog.F("interception_id", req.InterceptionID))
+	r.logger.Warn(ctx, "failed to record model thought", slog.Error(err))
 	return err
 }
 


### PR DESCRIPTION
Attach `interception_id` to the request context with `slog.With`, the same pattern already used for `request_id`, so every log emitted with that context carries it automatically. 
Remove the now-redundant explicit `interception_id` fields from the interception logger and the recorder warnings to avoid duplicate fields on those lines.

Related to https://github.com/coder/internal/issues/1447
Related to https://linear.app/codercom/issue/AIGOV-198/aibridge-key-failover-observability