### PR TITLE
fix(coderd/x/chatd): preserve chat API key after compaction

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -6476,22 +6476,57 @@ func contextWithActiveTurnAPIKeyID(ctx context.Context, messages []database.Chat
 	return aibridge.WithDelegatedAPIKeyID(ctx, apiKeyID)
 }
 
+func contextWithPromptActiveTurnAPIKeyID(ctx context.Context, messages []database.ChatMessage) context.Context {
+	apiKeyID, ok := activeTurnAPIKeyIDFromPromptMessages(messages)
+	if !ok {
+		return ctx
+	}
+	return aibridge.WithDelegatedAPIKeyID(ctx, apiKeyID)
+}
+
 func activeTurnAPIKeyIDFromMessages(messages []database.ChatMessage) (string, bool) {
 	for i := len(messages) - 1; i >= 0; i-- {
 		message := messages[i]
 		if message.Role != database.ChatMessageRoleUser {
 			continue
 		}
-		if message.Visibility != database.ChatMessageVisibilityBoth &&
-			message.Visibility != database.ChatMessageVisibilityUser {
+		if !isUserVisibleChatMessage(message) {
 			continue
 		}
-		if !message.APIKeyID.Valid || message.APIKeyID.String == "" {
-			return "", false
-		}
-		return message.APIKeyID.String, true
+		return chatMessageAPIKeyID(message)
 	}
 	return "", false
+}
+
+// activeTurnAPIKeyIDFromPromptMessages falls back to the compressed
+// summary boundary because prompt queries omit the original visible user
+// turn after compaction.
+func activeTurnAPIKeyIDFromPromptMessages(messages []database.ChatMessage) (string, bool) {
+	for i := len(messages) - 1; i >= 0; i-- {
+		message := messages[i]
+		if message.Role != database.ChatMessageRoleUser {
+			continue
+		}
+		if isUserVisibleChatMessage(message) {
+			return chatMessageAPIKeyID(message)
+		}
+		if message.Visibility == database.ChatMessageVisibilityModel && message.Compressed {
+			return chatMessageAPIKeyID(message)
+		}
+	}
+	return "", false
+}
+
+func isUserVisibleChatMessage(message database.ChatMessage) bool {
+	return message.Visibility == database.ChatMessageVisibilityBoth ||
+		message.Visibility == database.ChatMessageVisibilityUser
+}
+
+func chatMessageAPIKeyID(message database.ChatMessage) (string, bool) {
+	if !message.APIKeyID.Valid || message.APIKeyID.String == "" {
+		return "", false
+	}
+	return message.APIKeyID.String, true
 }
 
 func allToolNames(allTools []fantasy.AgentTool) []string {
@@ -7123,8 +7158,10 @@ func (p *Server) runChat(
 	if err != nil {
 		return result, xerrors.Errorf("get chat messages: %w", err)
 	}
-	modelOpts := modelBuildOptionsFromMessages(messages)
-	ctx = contextWithActiveTurnAPIKeyID(ctx, messages)
+	modelOpts := modelBuildOptionsFromPromptMessages(messages)
+	if modelOpts.ActiveAPIKeyID != "" {
+		ctx = aibridge.WithDelegatedAPIKeyID(ctx, modelOpts.ActiveAPIKeyID)
+	}
 
 	// Load MCP server configs and user tokens in parallel with model
 	// resolution. These queries have no dependencies on each other and all
@@ -7831,6 +7868,7 @@ func (p *Server) runChat(
 				persistCtx,
 				chat.ID,
 				modelConfig.ID,
+				modelOpts.ActiveAPIKeyID,
 				compactionToolCallID,
 				result,
 			); err != nil {
@@ -8466,6 +8504,7 @@ func (p *Server) persistChatContextSummary(
 	ctx context.Context,
 	chatID uuid.UUID,
 	modelConfigID uuid.UUID,
+	activeAPIKeyID string,
 	toolCallID string,
 	result chatloop.CompactionResult,
 ) error {
@@ -8522,9 +8561,11 @@ func (p *Server) persistChatContextSummary(
 		}
 
 		// Hidden summary user message (not published to subscribers).
-		summaryAPIKeyID, _ := aibridge.DelegatedAPIKeyIDFromContext(ctx)
+		if activeAPIKeyID == "" {
+			activeAPIKeyID, _ = aibridge.DelegatedAPIKeyIDFromContext(ctx)
+		}
 		summaryUserMsg := newUserChatMessage(
-			summaryAPIKeyID,
+			activeAPIKeyID,
 			systemContent,
 			database.ChatMessageVisibilityModel,
 			modelConfigID,

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -8553,6 +8553,11 @@ func (p *Server) persistChatContextSummary(
 		return xerrors.Errorf("encode summary tool result: %w", err)
 	}
 
+	summaryAPIKeyID := activeAPIKeyID
+	if summaryAPIKeyID == "" {
+		summaryAPIKeyID, _ = aibridge.DelegatedAPIKeyIDFromContext(ctx)
+	}
+
 	var insertedMessages []database.ChatMessage
 
 	txErr := p.db.InTx(func(tx database.Store) error {
@@ -8561,11 +8566,8 @@ func (p *Server) persistChatContextSummary(
 		}
 
 		// Hidden summary user message (not published to subscribers).
-		if activeAPIKeyID == "" {
-			activeAPIKeyID, _ = aibridge.DelegatedAPIKeyIDFromContext(ctx)
-		}
 		summaryUserMsg := newUserChatMessage(
-			activeAPIKeyID,
+			summaryAPIKeyID,
 			systemContent,
 			database.ChatMessageVisibilityModel,
 			modelConfigID,

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -6482,9 +6482,9 @@ func activeTurnAPIKeyIDFromMessages(messages []database.ChatMessage) (string, bo
 	return "", false
 }
 
-// activeTurnAPIKeyIDFromPromptMessages falls back to the compressed
-// summary boundary because prompt queries omit the original visible user
-// turn after compaction.
+// activeTurnAPIKeyIDFromPromptMessages returns the API key ID from the most
+// recent user-role message. It prefers visible user turns. If none exist, it
+// falls back to compressed model-only summaries left by prompt compaction.
 func activeTurnAPIKeyIDFromPromptMessages(messages []database.ChatMessage) (string, bool) {
 	for i := len(messages) - 1; i >= 0; i-- {
 		message := messages[i]
@@ -8482,8 +8482,9 @@ func buildProviderTools(options *codersdk.ChatModelProviderOptions) []chatloop.P
 	return tools
 }
 
-// persistChatContextSummary persists a chat context summary to the database.
-// This is invoked via the chat loop's compaction callback.
+// persistChatContextSummary is called from the chat loop's compaction
+// callback. activeAPIKeyID is stamped onto the summary user message. When
+// empty, it falls back to the delegated key in ctx.
 func (p *Server) persistChatContextSummary(
 	ctx context.Context,
 	chatID uuid.UUID,

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -6468,22 +6468,6 @@ type runChatResult struct {
 	HistoryTipMessageID     int64
 }
 
-func contextWithActiveTurnAPIKeyID(ctx context.Context, messages []database.ChatMessage) context.Context {
-	apiKeyID, ok := activeTurnAPIKeyIDFromMessages(messages)
-	if !ok {
-		return ctx
-	}
-	return aibridge.WithDelegatedAPIKeyID(ctx, apiKeyID)
-}
-
-func contextWithPromptActiveTurnAPIKeyID(ctx context.Context, messages []database.ChatMessage) context.Context {
-	apiKeyID, ok := activeTurnAPIKeyIDFromPromptMessages(messages)
-	if !ok {
-		return ctx
-	}
-	return aibridge.WithDelegatedAPIKeyID(ctx, apiKeyID)
-}
-
 func activeTurnAPIKeyIDFromMessages(messages []database.ChatMessage) (string, bool) {
 	for i := len(messages) - 1; i >= 0; i-- {
 		message := messages[i]

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -6474,29 +6474,14 @@ func activeTurnAPIKeyIDFromMessages(messages []database.ChatMessage) (string, bo
 		if message.Role != database.ChatMessageRoleUser {
 			continue
 		}
-		if !isUserVisibleChatMessage(message) {
+		if !isUserVisibleChatMessage(message) &&
+			!(message.Visibility == database.ChatMessageVisibilityModel && message.Compressed) {
 			continue
 		}
-		return chatMessageAPIKeyID(message)
-	}
-	return "", false
-}
-
-// activeTurnAPIKeyIDFromPromptMessages returns the API key ID from the most
-// recent user-role message. It prefers visible user turns. If none exist, it
-// falls back to compressed model-only summaries left by prompt compaction.
-func activeTurnAPIKeyIDFromPromptMessages(messages []database.ChatMessage) (string, bool) {
-	for i := len(messages) - 1; i >= 0; i-- {
-		message := messages[i]
-		if message.Role != database.ChatMessageRoleUser {
-			continue
+		if !message.APIKeyID.Valid || message.APIKeyID.String == "" {
+			return "", false
 		}
-		if isUserVisibleChatMessage(message) {
-			return chatMessageAPIKeyID(message)
-		}
-		if message.Visibility == database.ChatMessageVisibilityModel && message.Compressed {
-			return chatMessageAPIKeyID(message)
-		}
+		return message.APIKeyID.String, true
 	}
 	return "", false
 }
@@ -6504,13 +6489,6 @@ func activeTurnAPIKeyIDFromPromptMessages(messages []database.ChatMessage) (stri
 func isUserVisibleChatMessage(message database.ChatMessage) bool {
 	return message.Visibility == database.ChatMessageVisibilityBoth ||
 		message.Visibility == database.ChatMessageVisibilityUser
-}
-
-func chatMessageAPIKeyID(message database.ChatMessage) (string, bool) {
-	if !message.APIKeyID.Valid || message.APIKeyID.String == "" {
-		return "", false
-	}
-	return message.APIKeyID.String, true
 }
 
 func allToolNames(allTools []fantasy.AgentTool) []string {
@@ -7142,7 +7120,7 @@ func (p *Server) runChat(
 	if err != nil {
 		return result, xerrors.Errorf("get chat messages: %w", err)
 	}
-	modelOpts := modelBuildOptionsFromPromptMessages(messages)
+	modelOpts := modelBuildOptionsFromMessages(messages)
 	if modelOpts.ActiveAPIKeyID != "" {
 		ctx = aibridge.WithDelegatedAPIKeyID(ctx, modelOpts.ActiveAPIKeyID)
 	}

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -6652,40 +6652,62 @@ func TestPersistChatContextSummarySetsAPIKeyID(t *testing.T) {
 	})
 
 	server := &Server{db: db}
+	persistAndAssertSummaryKey := func(
+		summaryCtx context.Context,
+		chatID uuid.UUID,
+		activeAPIKeyID string,
+		wantAPIKeyID string,
+		toolCallID string,
+	) {
+		t.Helper()
 
-	err := server.persistChatContextSummary(
-		ctx,
-		chat.ID,
-		modelConfig.ID,
-		apiKey.ID,
-		"tool-call-id-1",
-		chatloop.CompactionResult{
-			SystemSummary:    "summarized context",
-			SummaryReport:    "context was summarized",
-			ThresholdPercent: 70,
-			UsagePercent:     85.0,
-			ContextTokens:    8500,
-			ContextLimit:     10000,
-		},
-	)
-	require.NoError(t, err)
+		err := server.persistChatContextSummary(
+			summaryCtx,
+			chatID,
+			modelConfig.ID,
+			activeAPIKeyID,
+			toolCallID,
+			chatloop.CompactionResult{
+				SystemSummary:    "summarized context",
+				SummaryReport:    "context was summarized",
+				ThresholdPercent: 70,
+				UsagePercent:     85.0,
+				ContextTokens:    8500,
+				ContextLimit:     10000,
+			},
+		)
+		require.NoError(t, err)
 
-	msgs, err := db.GetChatMessagesForPromptByChatID(ctx, chat.ID)
-	require.NoError(t, err)
+		msgs, err := db.GetChatMessagesForPromptByChatID(ctx, chatID)
+		require.NoError(t, err)
 
-	// GetChatMessagesForPromptByChatID uses a compaction boundary CTE
-	// that selects compressed=true, visibility='model'. Only the user
-	// summary qualifies; the assistant (visibility=user) and tool
-	// result (visibility=both) are excluded by the CTE filter.
-	require.NotEmpty(t, msgs)
+		// GetChatMessagesForPromptByChatID uses a compaction boundary CTE
+		// that selects compressed=true, visibility='model'. Only the user
+		// summary qualifies; the assistant (visibility=user) and tool
+		// result (visibility=both) are excluded by the CTE filter.
+		require.NotEmpty(t, msgs)
 
-	var foundUserSummary bool
-	for _, msg := range msgs {
-		if msg.Role == database.ChatMessageRoleUser {
-			foundUserSummary = true
-			require.True(t, msg.APIKeyID.Valid, "summary user message must have APIKeyID set")
-			require.Equal(t, apiKey.ID, msg.APIKeyID.String, "summary user message APIKeyID must match")
+		var foundUserSummary bool
+		for _, msg := range msgs {
+			if msg.Role == database.ChatMessageRoleUser {
+				foundUserSummary = true
+				require.True(t, msg.APIKeyID.Valid, "summary user message must have APIKeyID set")
+				require.Equal(t, wantAPIKeyID, msg.APIKeyID.String, "summary user message APIKeyID must match")
+			}
 		}
+		require.True(t, foundUserSummary, "expected to find compressed user summary message")
 	}
-	require.True(t, foundUserSummary, "expected to find compressed user summary message")
+
+	persistAndAssertSummaryKey(ctx, chat.ID, apiKey.ID, apiKey.ID, "tool-call-id-1")
+
+	fallbackChat := dbgen.Chat(t, db, database.Chat{
+		OwnerID:           user.ID,
+		OrganizationID:    org.ID,
+		LastModelConfigID: modelConfig.ID,
+	})
+	fallbackKey, _ := dbgen.APIKey(t, db, database.APIKey{
+		UserID: user.ID,
+	})
+	fallbackCtx := aibridge.WithDelegatedAPIKeyID(ctx, fallbackKey.ID)
+	persistAndAssertSummaryKey(fallbackCtx, fallbackChat.ID, "", fallbackKey.ID, "tool-call-id-2")
 }

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -6651,14 +6651,13 @@ func TestPersistChatContextSummarySetsAPIKeyID(t *testing.T) {
 		UserID: user.ID,
 	})
 
-	ctx = aibridge.WithDelegatedAPIKeyID(ctx, apiKey.ID)
-
 	server := &Server{db: db}
 
 	err := server.persistChatContextSummary(
 		ctx,
 		chat.ID,
 		modelConfig.ID,
+		apiKey.ID,
 		"tool-call-id-1",
 		chatloop.CompactionResult{
 			SystemSummary:    "summarized context",

--- a/coderd/x/chatd/model_routing.go
+++ b/coderd/x/chatd/model_routing.go
@@ -29,11 +29,6 @@ func modelBuildOptionsFromMessages(messages []database.ChatMessage) modelBuildOp
 	return modelBuildOptions{ActiveAPIKeyID: apiKeyID}
 }
 
-func modelBuildOptionsFromPromptMessages(messages []database.ChatMessage) modelBuildOptions {
-	apiKeyID, _ := activeTurnAPIKeyIDFromPromptMessages(messages)
-	return modelBuildOptions{ActiveAPIKeyID: apiKeyID}
-}
-
 type modelRouteKind int
 
 const (

--- a/coderd/x/chatd/model_routing.go
+++ b/coderd/x/chatd/model_routing.go
@@ -29,6 +29,11 @@ func modelBuildOptionsFromMessages(messages []database.ChatMessage) modelBuildOp
 	return modelBuildOptions{ActiveAPIKeyID: apiKeyID}
 }
 
+func modelBuildOptionsFromPromptMessages(messages []database.ChatMessage) modelBuildOptions {
+	apiKeyID, _ := activeTurnAPIKeyIDFromPromptMessages(messages)
+	return modelBuildOptions{ActiveAPIKeyID: apiKeyID}
+}
+
 type modelRouteKind int
 
 const (

--- a/coderd/x/chatd/model_routing_internal_test.go
+++ b/coderd/x/chatd/model_routing_internal_test.go
@@ -495,7 +495,7 @@ func TestActiveTurnAPIKeyIDFromPromptMessages(t *testing.T) {
 	}
 }
 
-func TestActiveTurnAPIKeyIDUsesPromptMessages(t *testing.T) {
+func TestActiveTurnAPIKeyIDFromPromptMessagesWithVisibleUser(t *testing.T) {
 	t.Parallel()
 
 	db, _ := dbtestutil.NewDB(t)

--- a/coderd/x/chatd/model_routing_internal_test.go
+++ b/coderd/x/chatd/model_routing_internal_test.go
@@ -405,7 +405,7 @@ func TestActiveTurnAPIKeyIDFromMessages(t *testing.T) {
 			},
 		},
 		{
-			name: "SkipsModelOnlyUserMessages",
+			name: "SkipsUncompressedModelOnlyUserMessages",
 			messages: []database.ChatMessage{
 				{ID: 1, Role: database.ChatMessageRoleUser, Visibility: database.ChatMessageVisibilityBoth, APIKeyID: sqlNullString(oldKeyID)},
 				{ID: 2, Role: database.ChatMessageRoleUser, Visibility: database.ChatMessageVisibilityModel, APIKeyID: sqlNullString(currentKeyID)},
@@ -413,29 +413,6 @@ func TestActiveTurnAPIKeyIDFromMessages(t *testing.T) {
 			wantKey: oldKeyID,
 			wantOK:  true,
 		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			gotKey, gotOK := activeTurnAPIKeyIDFromMessages(tt.messages)
-			require.Equal(t, tt.wantOK, gotOK)
-			require.Equal(t, tt.wantKey, gotKey)
-		})
-	}
-}
-
-func TestActiveTurnAPIKeyIDFromPromptMessages(t *testing.T) {
-	t.Parallel()
-
-	oldKeyID := uuid.NewString()
-	currentKeyID := uuid.NewString()
-	tests := []struct {
-		name     string
-		messages []database.ChatMessage
-		wantKey  string
-		wantOK   bool
-	}{
 		{
 			name: "CompressedSummaryFallback",
 			messages: []database.ChatMessage{
@@ -465,7 +442,7 @@ func TestActiveTurnAPIKeyIDFromPromptMessages(t *testing.T) {
 			wantOK:  true,
 		},
 		{
-			name: "MissingVisibleUserKeyDoesNotFallBack",
+			name: "MissingVisibleUserKeyDoesNotFallBackToCompressedSummary",
 			messages: []database.ChatMessage{
 				{ID: 1, Role: database.ChatMessageRoleUser, Visibility: database.ChatMessageVisibilityModel, Compressed: true, APIKeyID: sqlNullString(oldKeyID)},
 				{ID: 2, Role: database.ChatMessageRoleUser, Visibility: database.ChatMessageVisibilityBoth},
@@ -478,9 +455,10 @@ func TestActiveTurnAPIKeyIDFromPromptMessages(t *testing.T) {
 			},
 		},
 		{
-			name: "CompressedSummaryMissingKeyFails",
+			name: "CompressedSummaryMissingKeyDoesNotFallBack",
 			messages: []database.ChatMessage{
-				{ID: 1, Role: database.ChatMessageRoleUser, Visibility: database.ChatMessageVisibilityModel, Compressed: true},
+				{ID: 1, Role: database.ChatMessageRoleUser, Visibility: database.ChatMessageVisibilityBoth, APIKeyID: sqlNullString(oldKeyID)},
+				{ID: 2, Role: database.ChatMessageRoleUser, Visibility: database.ChatMessageVisibilityModel, Compressed: true},
 			},
 		},
 	}
@@ -488,14 +466,14 @@ func TestActiveTurnAPIKeyIDFromPromptMessages(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			gotKey, gotOK := activeTurnAPIKeyIDFromPromptMessages(tt.messages)
+			gotKey, gotOK := activeTurnAPIKeyIDFromMessages(tt.messages)
 			require.Equal(t, tt.wantOK, gotOK)
 			require.Equal(t, tt.wantKey, gotKey)
 		})
 	}
 }
 
-func TestActiveTurnAPIKeyIDFromPromptMessagesWithVisibleUser(t *testing.T) {
+func TestPromptMessagesForVisibleUserPreserveActiveAPIKeyID(t *testing.T) {
 	t.Parallel()
 
 	db, _ := dbtestutil.NewDB(t)
@@ -543,12 +521,12 @@ func TestActiveTurnAPIKeyIDFromPromptMessagesWithVisibleUser(t *testing.T) {
 
 	messages, err := db.GetChatMessagesForPromptByChatID(ctx, chat.ID)
 	require.NoError(t, err)
-	gotKey, ok := activeTurnAPIKeyIDFromPromptMessages(messages)
+	gotKey, ok := activeTurnAPIKeyIDFromMessages(messages)
 	require.True(t, ok)
 	require.Equal(t, currentKey.ID, gotKey)
 }
 
-func TestActiveTurnAPIKeyIDFromPromptMessagesUsesCompressedSummary(t *testing.T) {
+func TestPromptMessagesForCompactedChatPreserveActiveAPIKeyID(t *testing.T) {
 	t.Parallel()
 
 	db, _ := dbtestutil.NewDB(t)
@@ -602,7 +580,7 @@ func TestActiveTurnAPIKeyIDFromPromptMessagesUsesCompressedSummary(t *testing.T)
 	_, hasAfterSummary := ids[afterSummary.ID]
 	require.True(t, hasAfterSummary)
 
-	gotKey, ok := activeTurnAPIKeyIDFromPromptMessages(messages)
+	gotKey, ok := activeTurnAPIKeyIDFromMessages(messages)
 	require.True(t, ok)
 	require.Equal(t, key.ID, gotKey)
 }

--- a/coderd/x/chatd/model_routing_internal_test.go
+++ b/coderd/x/chatd/model_routing_internal_test.go
@@ -446,6 +446,16 @@ func TestActiveTurnAPIKeyIDFromPromptMessages(t *testing.T) {
 			wantOK:  true,
 		},
 		{
+			name: "LatestCompressedSummaryWins",
+			messages: []database.ChatMessage{
+				{ID: 1, Role: database.ChatMessageRoleUser, Visibility: database.ChatMessageVisibilityModel, Compressed: true, APIKeyID: sqlNullString(oldKeyID)},
+				{ID: 2, Role: database.ChatMessageRoleUser, Visibility: database.ChatMessageVisibilityModel, Compressed: true, APIKeyID: sqlNullString(currentKeyID)},
+				{ID: 3, Role: database.ChatMessageRoleAssistant, Visibility: database.ChatMessageVisibilityBoth},
+			},
+			wantKey: currentKeyID,
+			wantOK:  true,
+		},
+		{
 			name: "VisibleUserWinsOverCompressedSummary",
 			messages: []database.ChatMessage{
 				{ID: 1, Role: database.ChatMessageRoleUser, Visibility: database.ChatMessageVisibilityModel, Compressed: true, APIKeyID: sqlNullString(oldKeyID)},
@@ -538,7 +548,7 @@ func TestActiveTurnAPIKeyIDUsesPromptMessages(t *testing.T) {
 	require.Equal(t, currentKey.ID, gotKey)
 }
 
-func TestPromptActiveTurnAPIKeyUsesCompressedSummary(t *testing.T) {
+func TestActiveTurnAPIKeyIDFromPromptMessagesUsesCompressedSummary(t *testing.T) {
 	t.Parallel()
 
 	db, _ := dbtestutil.NewDB(t)

--- a/coderd/x/chatd/model_routing_internal_test.go
+++ b/coderd/x/chatd/model_routing_internal_test.go
@@ -421,10 +421,6 @@ func TestActiveTurnAPIKeyIDFromMessages(t *testing.T) {
 			gotKey, gotOK := activeTurnAPIKeyIDFromMessages(tt.messages)
 			require.Equal(t, tt.wantOK, gotOK)
 			require.Equal(t, tt.wantKey, gotKey)
-			ctx := contextWithActiveTurnAPIKeyID(t.Context(), tt.messages)
-			ctxKey, ctxOK := aibridge.DelegatedAPIKeyIDFromContext(ctx)
-			require.Equal(t, tt.wantOK, ctxOK)
-			require.Equal(t, tt.wantKey, ctxKey)
 		})
 	}
 }
@@ -485,15 +481,11 @@ func TestActiveTurnAPIKeyIDFromPromptMessages(t *testing.T) {
 			gotKey, gotOK := activeTurnAPIKeyIDFromPromptMessages(tt.messages)
 			require.Equal(t, tt.wantOK, gotOK)
 			require.Equal(t, tt.wantKey, gotKey)
-			ctx := contextWithPromptActiveTurnAPIKeyID(t.Context(), tt.messages)
-			ctxKey, ctxOK := aibridge.DelegatedAPIKeyIDFromContext(ctx)
-			require.Equal(t, tt.wantOK, ctxOK)
-			require.Equal(t, tt.wantKey, ctxKey)
 		})
 	}
 }
 
-func TestActiveTurnContextUsesPromptMessages(t *testing.T) {
+func TestActiveTurnAPIKeyIDUsesPromptMessages(t *testing.T) {
 	t.Parallel()
 
 	db, _ := dbtestutil.NewDB(t)
@@ -541,8 +533,7 @@ func TestActiveTurnContextUsesPromptMessages(t *testing.T) {
 
 	messages, err := db.GetChatMessagesForPromptByChatID(ctx, chat.ID)
 	require.NoError(t, err)
-	ctx = contextWithPromptActiveTurnAPIKeyID(ctx, messages)
-	gotKey, ok := aibridge.DelegatedAPIKeyIDFromContext(ctx)
+	gotKey, ok := activeTurnAPIKeyIDFromPromptMessages(messages)
 	require.True(t, ok)
 	require.Equal(t, currentKey.ID, gotKey)
 }

--- a/coderd/x/chatd/model_routing_internal_test.go
+++ b/coderd/x/chatd/model_routing_internal_test.go
@@ -429,6 +429,70 @@ func TestActiveTurnAPIKeyIDFromMessages(t *testing.T) {
 	}
 }
 
+func TestActiveTurnAPIKeyIDFromPromptMessages(t *testing.T) {
+	t.Parallel()
+
+	oldKeyID := uuid.NewString()
+	currentKeyID := uuid.NewString()
+	tests := []struct {
+		name     string
+		messages []database.ChatMessage
+		wantKey  string
+		wantOK   bool
+	}{
+		{
+			name: "CompressedSummaryFallback",
+			messages: []database.ChatMessage{
+				{ID: 1, Role: database.ChatMessageRoleUser, Visibility: database.ChatMessageVisibilityModel, Compressed: true, APIKeyID: sqlNullString(currentKeyID)},
+				{ID: 2, Role: database.ChatMessageRoleAssistant, Visibility: database.ChatMessageVisibilityBoth},
+			},
+			wantKey: currentKeyID,
+			wantOK:  true,
+		},
+		{
+			name: "VisibleUserWinsOverCompressedSummary",
+			messages: []database.ChatMessage{
+				{ID: 1, Role: database.ChatMessageRoleUser, Visibility: database.ChatMessageVisibilityModel, Compressed: true, APIKeyID: sqlNullString(oldKeyID)},
+				{ID: 2, Role: database.ChatMessageRoleUser, Visibility: database.ChatMessageVisibilityBoth, APIKeyID: sqlNullString(currentKeyID)},
+			},
+			wantKey: currentKeyID,
+			wantOK:  true,
+		},
+		{
+			name: "MissingVisibleUserKeyDoesNotFallBack",
+			messages: []database.ChatMessage{
+				{ID: 1, Role: database.ChatMessageRoleUser, Visibility: database.ChatMessageVisibilityModel, Compressed: true, APIKeyID: sqlNullString(oldKeyID)},
+				{ID: 2, Role: database.ChatMessageRoleUser, Visibility: database.ChatMessageVisibilityBoth},
+			},
+		},
+		{
+			name: "UncompressedModelOnlyUserIgnored",
+			messages: []database.ChatMessage{
+				{ID: 1, Role: database.ChatMessageRoleUser, Visibility: database.ChatMessageVisibilityModel, APIKeyID: sqlNullString(currentKeyID)},
+			},
+		},
+		{
+			name: "CompressedSummaryMissingKeyFails",
+			messages: []database.ChatMessage{
+				{ID: 1, Role: database.ChatMessageRoleUser, Visibility: database.ChatMessageVisibilityModel, Compressed: true},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotKey, gotOK := activeTurnAPIKeyIDFromPromptMessages(tt.messages)
+			require.Equal(t, tt.wantOK, gotOK)
+			require.Equal(t, tt.wantKey, gotKey)
+			ctx := contextWithPromptActiveTurnAPIKeyID(t.Context(), tt.messages)
+			ctxKey, ctxOK := aibridge.DelegatedAPIKeyIDFromContext(ctx)
+			require.Equal(t, tt.wantOK, ctxOK)
+			require.Equal(t, tt.wantKey, ctxKey)
+		})
+	}
+}
+
 func TestActiveTurnContextUsesPromptMessages(t *testing.T) {
 	t.Parallel()
 
@@ -477,10 +541,69 @@ func TestActiveTurnContextUsesPromptMessages(t *testing.T) {
 
 	messages, err := db.GetChatMessagesForPromptByChatID(ctx, chat.ID)
 	require.NoError(t, err)
-	ctx = contextWithActiveTurnAPIKeyID(ctx, messages)
+	ctx = contextWithPromptActiveTurnAPIKeyID(ctx, messages)
 	gotKey, ok := aibridge.DelegatedAPIKeyIDFromContext(ctx)
 	require.True(t, ok)
 	require.Equal(t, currentKey.ID, gotKey)
+}
+
+func TestPromptActiveTurnAPIKeyUsesCompressedSummary(t *testing.T) {
+	t.Parallel()
+
+	db, _ := dbtestutil.NewDB(t)
+	ctx := t.Context()
+	user := dbgen.User(t, db, database.User{})
+	org := dbgen.Organization(t, db, database.Organization{})
+	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{})
+	chat := dbgen.Chat(t, db, database.Chat{OrganizationID: org.ID, OwnerID: user.ID, LastModelConfigID: model.ID})
+	key, _ := dbgen.APIKey(t, db, database.APIKey{UserID: user.ID})
+
+	visibleUser := dbgen.ChatMessage(t, db, database.ChatMessage{
+		ChatID:        chat.ID,
+		CreatedBy:     uuid.NullUUID{UUID: user.ID, Valid: true},
+		ModelConfigID: uuid.NullUUID{UUID: model.ID, Valid: true},
+		Role:          database.ChatMessageRoleUser,
+		Visibility:    database.ChatMessageVisibilityBoth,
+		APIKeyID:      sqlNullString(key.ID),
+	})
+	dbgen.ChatMessage(t, db, database.ChatMessage{
+		ChatID:        chat.ID,
+		ModelConfigID: uuid.NullUUID{UUID: model.ID, Valid: true},
+		Role:          database.ChatMessageRoleAssistant,
+		Visibility:    database.ChatMessageVisibilityBoth,
+	})
+	compressedSummary := dbgen.ChatMessage(t, db, database.ChatMessage{
+		ChatID:        chat.ID,
+		ModelConfigID: uuid.NullUUID{UUID: model.ID, Valid: true},
+		Role:          database.ChatMessageRoleUser,
+		Visibility:    database.ChatMessageVisibilityModel,
+		Compressed:    true,
+		APIKeyID:      sqlNullString(key.ID),
+	})
+	afterSummary := dbgen.ChatMessage(t, db, database.ChatMessage{
+		ChatID:        chat.ID,
+		ModelConfigID: uuid.NullUUID{UUID: model.ID, Valid: true},
+		Role:          database.ChatMessageRoleAssistant,
+		Visibility:    database.ChatMessageVisibilityBoth,
+	})
+
+	messages, err := db.GetChatMessagesForPromptByChatID(ctx, chat.ID)
+	require.NoError(t, err)
+
+	ids := make(map[int64]struct{}, len(messages))
+	for _, message := range messages {
+		ids[message.ID] = struct{}{}
+	}
+	_, hasVisibleUser := ids[visibleUser.ID]
+	require.False(t, hasVisibleUser)
+	_, hasSummary := ids[compressedSummary.ID]
+	require.True(t, hasSummary)
+	_, hasAfterSummary := ids[afterSummary.ID]
+	require.True(t, hasAfterSummary)
+
+	gotKey, ok := activeTurnAPIKeyIDFromPromptMessages(messages)
+	require.True(t, ok)
+	require.Equal(t, key.ID, gotKey)
 }
 
 func sqlNullString(value string) sql.NullString {


### PR DESCRIPTION
> Mux updated this PR on behalf of Mike.

AI Gateway chat retries after context compaction could lose active turn API key routing metadata because the prompt query keeps the compressed model-only summary but omits the original visible user turn.

Persist the active API key ID onto compaction summaries explicitly. Model construction now uses one active-turn lookup helper for visible user turns and compressed summary boundaries, so prompt model construction can recover the key when no later visible user turn exists. Added unit and DB-backed coverage for the compacted prompt path.
