### PR TITLE
ci: install gotestsum in flake check workflow

### DIFF
--- a/.github/workflows/flake-go.yaml
+++ b/.github/workflows/flake-go.yaml
@@ -48,7 +48,7 @@ jobs:
         uses: ./.github/actions/go-cache
 
       - name: Install Go mise tools
-        run: ./.github/scripts/retry.sh -- mise install --locked go:github.com/coder/whichtests
+        run: ./.github/scripts/retry.sh -- mise install --locked go:github.com/coder/whichtests go:gotest.tools/gotestsum
 
       - name: Select changed tests
         id: selector


### PR DESCRIPTION
The Flake Check workflow runs `make test` through the `test-go-pg` action, which invokes `gotestsum`, but the workflow never installs it. The mise refactor (#25727) deleted the `setup-go` action that previously installed `gotestsum` implicitly, and added explicit `mise install ... go:gotest.tools/gotestsum` steps to every other Go test job. The flake check's `Install Go mise tools` step only listed `whichtests`, so the check fails with `gotestsum: command not found` whenever it selects changed tests to run.

Add `go:gotest.tools/gotestsum` to the flake check's install step, matching the other `test-go-pg` jobs in `ci.yaml` and `nightly-gauntlet.yaml`.

Refs #25727

🤖 Generated with [Claude Code](https://claude.com/claude-code)