### PR TITLE
feat: add poolside as first-class AI Gateway provider type

### DIFF
--- a/cli/aibridged.go
+++ b/cli/aibridged.go
@@ -236,6 +236,7 @@ func buildAIProviderFromRow(
 		database.AiProviderTypeGoogle,
 		database.AiProviderTypeOpenaiCompat,
 		database.AiProviderTypeOpenrouter,
+		database.AiProviderTypePoolside,
 		database.AiProviderTypeVercel:
 		if len(keys) == 0 && !cfg.AllowBYOK.Value() {
 			return nil, xerrors.Errorf("%s provider has no api keys configured and BYOK is not enabled", row.Type)

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -15155,6 +15155,7 @@ const docTemplate = `{
                 "google",
                 "openai-compat",
                 "openrouter",
+                "poolside",
                 "vercel",
                 "bedrock",
                 "copilot"
@@ -15166,6 +15167,7 @@ const docTemplate = `{
                 "AIProviderTypeGoogle",
                 "AIProviderTypeOpenAICompat",
                 "AIProviderTypeOpenrouter",
+                "AIProviderTypePoolside",
                 "AIProviderTypeVercel",
                 "AIProviderTypeBedrock",
                 "AIProviderTypeCopilot"

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -13547,6 +13547,7 @@
 				"google",
 				"openai-compat",
 				"openrouter",
+				"poolside",
 				"vercel",
 				"bedrock",
 				"copilot"
@@ -13558,6 +13559,7 @@
 				"AIProviderTypeGoogle",
 				"AIProviderTypeOpenAICompat",
 				"AIProviderTypeOpenrouter",
+				"AIProviderTypePoolside",
 				"AIProviderTypeVercel",
 				"AIProviderTypeBedrock",
 				"AIProviderTypeCopilot"

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -19,7 +19,8 @@ CREATE TYPE ai_provider_type AS ENUM (
     'openai-compat',
     'openrouter',
     'vercel',
-    'copilot'
+    'copilot',
+    'poolside'
 );
 
 CREATE TYPE ai_seat_usage_reason AS ENUM (

--- a/coderd/database/migrations/000514_add_poolside_provider_type.down.sql
+++ b/coderd/database/migrations/000514_add_poolside_provider_type.down.sql
@@ -1,0 +1,21 @@
+-- Remove the 'poolside' value from ai_provider_type by recreating the enum
+-- without it. Any ai_providers rows that reference 'poolside' must be
+-- converted (or deleted) before running this migration.
+CREATE TYPE new_ai_provider_type AS ENUM (
+    'openai',
+    'anthropic',
+    'azure',
+    'bedrock',
+    'google',
+    'openai-compat',
+    'openrouter',
+    'vercel',
+    'copilot'
+);
+
+ALTER TABLE ai_providers
+    ALTER COLUMN type TYPE new_ai_provider_type USING (type::text::new_ai_provider_type);
+
+DROP TYPE ai_provider_type;
+
+ALTER TYPE new_ai_provider_type RENAME TO ai_provider_type;

--- a/coderd/database/migrations/000514_add_poolside_provider_type.up.sql
+++ b/coderd/database/migrations/000514_add_poolside_provider_type.up.sql
@@ -1,0 +1,1 @@
+ALTER TYPE ai_provider_type ADD VALUE IF NOT EXISTS 'poolside';

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -28,6 +28,7 @@ const (
 	AiProviderTypeOpenrouter   AIProviderType = "openrouter"
 	AiProviderTypeVercel       AIProviderType = "vercel"
 	AiProviderTypeCopilot      AIProviderType = "copilot"
+	AiProviderTypePoolside     AIProviderType = "poolside"
 )
 
 func (e *AIProviderType) Scan(src interface{}) error {
@@ -75,7 +76,8 @@ func (e AIProviderType) Valid() bool {
 		AiProviderTypeOpenaiCompat,
 		AiProviderTypeOpenrouter,
 		AiProviderTypeVercel,
-		AiProviderTypeCopilot:
+		AiProviderTypeCopilot,
+		AiProviderTypePoolside:
 		return true
 	}
 	return false
@@ -92,6 +94,7 @@ func AllAIProviderTypeValues() []AIProviderType {
 		AiProviderTypeOpenrouter,
 		AiProviderTypeVercel,
 		AiProviderTypeCopilot,
+		AiProviderTypePoolside,
 	}
 }
 

--- a/codersdk/aiproviders.go
+++ b/codersdk/aiproviders.go
@@ -28,7 +28,7 @@ const (
 	AIProviderTypeOpenAI    AIProviderType = "openai"
 	AIProviderTypeAnthropic AIProviderType = "anthropic"
 	// AIProviderTypeAzure, AIProviderTypeGoogle, AIProviderTypeOpenAICompat,
-	// AIProviderTypeOpenrouter, and AIProviderTypeVercel route through
+	// AIProviderTypeOpenrouter, AIProviderTypePoolside, and AIProviderTypeVercel route through
 	// aibridge's OpenAI client today because chatd configures these
 	// providers against their OpenAI-compatible endpoints. Native
 	// gateway-side support arrives later without an enum change.
@@ -36,6 +36,7 @@ const (
 	AIProviderTypeGoogle       AIProviderType = "google"
 	AIProviderTypeOpenAICompat AIProviderType = "openai-compat"
 	AIProviderTypeOpenrouter   AIProviderType = "openrouter"
+	AIProviderTypePoolside     AIProviderType = "poolside"
 	AIProviderTypeVercel       AIProviderType = "vercel"
 	// AIProviderTypeBedrock routes through aibridge's Anthropic client
 	// using the Bedrock discriminator in Settings; native support is
@@ -214,6 +215,7 @@ func (req CreateAIProviderRequest) Validate() []ValidationError {
 		AIProviderTypeGoogle,
 		AIProviderTypeOpenAICompat,
 		AIProviderTypeOpenrouter,
+		AIProviderTypePoolside,
 		AIProviderTypeVercel:
 	case "":
 		validations = append(validations, ValidationError{Field: "type", Detail: "type is required"})

--- a/docs/ai-coder/ai-gateway/providers.md
+++ b/docs/ai-coder/ai-gateway/providers.md
@@ -52,11 +52,12 @@ AI Gateway speaks two upstream API formats: the **OpenAI** format
 | `azure`         | OpenAI     | OpenAI-compatible endpoint only                                   |
 | `google`        | OpenAI     | OpenAI-compatible endpoint only                                   |
 | `openrouter`    | OpenAI     | OpenAI-compatible endpoint only                                   |
+| `poolside`      | OpenAI     | Poolside Laguna models; OpenAI-compatible endpoint                |
 | `vercel`        | OpenAI     | OpenAI-compatible endpoint only                                   |
 | `openai-compat` | OpenAI     | Generic OpenAI-compatible endpoint                                |
 
-`azure`, `google`, `openrouter`, `vercel`, and `openai-compat` are
-supported only as OpenAI-compatible endpoints: AI Gateway sends them
+`azure`, `google`, `openrouter`, `poolside`, `vercel`, and `openai-compat`
+are supported only as OpenAI-compatible endpoints: AI Gateway sends them
 OpenAI-format requests, so each must expose an OpenAI-compatible API at
 its base URL. They have no provider-specific integration beyond that.
 
@@ -125,7 +126,7 @@ certificates, IDE configuration), see
 
 ### OpenAI-compatible providers
 
-Azure-hosted OpenAI, Google, OpenRouter, Vercel, and any other
+Azure-hosted OpenAI, Google, OpenRouter, Poolside, Vercel, and any other
 OpenAI-compatible service are configured with the matching type (or the
 generic `openai-compat`), the provider's OpenAI-compatible base URL, and
 an API key.

--- a/docs/reference/api/aiproviders.md
+++ b/docs/reference/api/aiproviders.md
@@ -69,9 +69,9 @@ Status Code **200**
 
 #### Enumerated Values
 
-| Property | Value(s)                                                                                                |
-|----------|---------------------------------------------------------------------------------------------------------|
-| `type`   | `anthropic`, `azure`, `bedrock`, `copilot`, `google`, `openai`, `openai-compat`, `openrouter`, `vercel` |
+| Property | Value(s)                                                                                                            |
+|----------|---------------------------------------------------------------------------------------------------------------------|
+| `type`   | `anthropic`, `azure`, `bedrock`, `copilot`, `google`, `openai`, `openai-compat`, `openrouter`, `poolside`, `vercel` |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -1364,9 +1364,9 @@ None
 
 #### Enumerated Values
 
-| Value(s)                                                                                                |
-|---------------------------------------------------------------------------------------------------------|
-| `anthropic`, `azure`, `bedrock`, `copilot`, `google`, `openai`, `openai-compat`, `openrouter`, `vercel` |
+| Value(s)                                                                                                            |
+|---------------------------------------------------------------------------------------------------------------------|
+| `anthropic`, `azure`, `bedrock`, `copilot`, `google`, `openai`, `openai-compat`, `openrouter`, `poolside`, `vercel` |
 
 ## codersdk.APIAllowListTarget
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -472,6 +472,7 @@ export type AIProviderType =
 	| "openai"
 	| "openai-compat"
 	| "openrouter"
+	| "poolside"
 	| "vercel";
 
 export const AIProviderTypes: AIProviderType[] = [
@@ -483,6 +484,7 @@ export const AIProviderTypes: AIProviderType[] = [
 	"openai",
 	"openai-compat",
 	"openrouter",
+	"poolside",
 	"vercel",
 ];
 

--- a/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderForm.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderForm.tsx
@@ -91,6 +91,7 @@ const providerDefaults: Partial<
 	},
 	"openai-compat": { name: "openai-compat", baseUrl: "" },
 	openrouter: { name: "openrouter", baseUrl: "https://openrouter.ai/api/v1" },
+	poolside: { name: "poolside", baseUrl: "https://inference.poolside.ai/v1/" },
 	vercel: { name: "vercel", baseUrl: "https://ai-gateway.vercel.sh/v1" },
 };
 
@@ -104,6 +105,7 @@ const makeOpenAiAnthropicSchema = (editing: boolean) =>
 				"google",
 				"openai-compat",
 				"openrouter",
+				"poolside",
 				"vercel",
 			] as const)
 			.required(),
@@ -191,6 +193,7 @@ const getProviderFormSchema = (editing: boolean) =>
 			case "google":
 			case "openai-compat":
 			case "openrouter":
+			case "poolside":
 			case "vercel":
 				return makeOpenAiAnthropicSchema(editing);
 			case "bedrock":
@@ -209,6 +212,7 @@ const getProviderFormSchema = (editing: boolean) =>
 							"google",
 							"openai-compat",
 							"openrouter",
+							"poolside",
 							"vercel",
 						])
 						.required(),

--- a/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderIcon.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderIcon.tsx
@@ -44,6 +44,8 @@ const getProviderName = (provider: string): string => {
 			return "OpenAI-compatible";
 		case "openrouter":
 			return "OpenRouter";
+		case "poolside":
+			return "Poolside";
 		case "vercel":
 			return "Vercel";
 		default:

--- a/site/src/pages/AISettingsPage/ProvidersPage/components/addableProviderTypes.ts
+++ b/site/src/pages/AISettingsPage/ProvidersPage/components/addableProviderTypes.ts
@@ -14,5 +14,6 @@ export const addableProviders: readonly AddableProvider[] = [
 	{ value: "openai", label: "OpenAI" },
 	{ value: "openai-compat", label: "OpenAI-compatible" },
 	{ value: "openrouter", label: "OpenRouter" },
+	{ value: "poolside", label: "Poolside" },
 	{ value: "vercel", label: "Vercel" },
 ];

--- a/site/src/pages/AISettingsPage/ProvidersPage/components/providerFormApiMap.test.ts
+++ b/site/src/pages/AISettingsPage/ProvidersPage/components/providerFormApiMap.test.ts
@@ -196,6 +196,7 @@ describe("getProviderDisplayType", () => {
 		["azure", "https://YOUR-RESOURCE.openai.azure.com/openai/v1"],
 		["google", "https://generativelanguage.googleapis.com/v1beta/openai/"],
 		["openrouter", "https://openrouter.ai/api/v1"],
+		["poolside", "https://inference.poolside.ai/v1/"],
 		["vercel", "https://ai-gateway.vercel.sh/v1"],
 	])("recovers the %s preset from a canonical base_url", (expected, baseUrl) => {
 		const provider: AIProvider = {
@@ -279,6 +280,7 @@ describe("providerFormValuesToCreate", () => {
 			["google", "https://generativelanguage.googleapis.com/v1beta/openai/"],
 			["openai-compat", "https://compat.example.com/v1"],
 			["openrouter", "https://openrouter.ai/api/v1"],
+			["poolside", "https://inference.poolside.ai/v1/"],
 			["vercel", "https://ai-gateway.vercel.sh/v1"],
 		] as const)("collapses the %s UI type to type=openai on the wire", (type, baseUrl) => {
 			const req = providerFormValuesToCreate({

--- a/site/src/pages/AISettingsPage/ProvidersPage/components/providerFormApiMap.ts
+++ b/site/src/pages/AISettingsPage/ProvidersPage/components/providerFormApiMap.ts
@@ -80,13 +80,14 @@ const displayTypeHosts: ReadonlyArray<[string, AIProviderType]> = [
 	["openai.azure.com", "azure"],
 	["generativelanguage.googleapis.com", "google"],
 	["openrouter.ai", "openrouter"],
+	["inference.poolside.ai", "poolside"],
 	["ai-gateway.vercel.sh", "vercel"],
 ];
 
 const matchesHost = (host: string, suffix: string): boolean =>
 	host === suffix || host.endsWith(`.${suffix}`);
 
-// Wire `type` collapses azure/google/openrouter/vercel to `openai`, so
+// Wire `type` collapses azure/google/openrouter/poolside/vercel to `openai`, so
 // we recover the original choice from the saved host. Bedrock comes
 // through the settings discriminator. Unknown hosts fall back to wire.
 export const getProviderDisplayType = (


### PR DESCRIPTION
Add [Poolside](https://poolside.ai) to the `ai_provider_type` enum so it appears as a named option in the AI Gateway provider configuration UI and API.

Poolside's Laguna models expose an OpenAI-compatible `/v1/chat/completions` API, so the provider routes through the existing OpenAI provider implementation alongside `azure`, `google`, `openrouter`, and `vercel`. No new Go structs, interceptors, or provider implementations are needed.

**Changes:**

- DB migration adding `'poolside'` to the `ai_provider_type` enum
- `cli/aibridged.go`: add `AiProviderTypePoolside` to the OpenAI-compatible case in `buildAIProviderFromRow`
- `codersdk/aiproviders.go`: add `AIProviderTypePoolside` constant and include it in `Validate()`
- Frontend: add Poolside to the provider dropdown, form defaults (`https://inference.poolside.ai/v1/`), Yup schemas, icon display name, and host-based type recovery
- Docs: add Poolside row to the provider types table

<details><summary>Generated by Coder Agents</summary>

This PR was generated by Coder Agents on behalf of @jcjiang.
</details>