### PR TITLE
ci: run Windows Go tests under pwsh

### DIFF
--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -167,12 +167,16 @@ runs:
         install_args: ${{ steps.cache-key.outputs.install-args }}
         cache: "false"
 
-    - name: Ensure Git usr/bin is in PATH (Windows)
+    - name: Ensure Windows subprocess tools are in PATH
       if: runner.os == 'Windows'
       shell: pwsh
-      run: |
-        $gitdir = "C:\Program Files\Git\usr\bin"
-        if ($env:Path -notlike "*$gitdir*") {
-          $gitdir | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+      run: | # zizmor: ignore[github-env] These are fixed Windows runner paths.
+        @(
+          "$env:SystemRoot\System32\WindowsPowerShell\v1.0"
+          "C:\Program Files\Git\usr\bin"
+        ) | ForEach-Object {
+          if ($env:Path -notlike "*$_*") {
+            $_ | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          }
         }
 

--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -170,19 +170,9 @@ runs:
     - name: Ensure Git usr/bin is in PATH (Windows)
       if: runner.os == 'Windows'
       shell: pwsh
-      # jdx/mise-action exports "Path" via GITHUB_ENV which may
-      # collide with bash's "PATH". Ensure Git usr/bin is present
-      # and remove any duplicate Path/PATH entries from GITHUB_ENV
-      # by writing both forms.
-      run: | # zizmor: ignore[github-env]
+      run: |
         $gitdir = "C:\Program Files\Git\usr\bin"
-        $current = $env:Path
-        if ($current -notlike "*$gitdir*") {
-          $current = "$gitdir;$current"
+        if ($env:Path -notlike "*$gitdir*") {
+          $gitdir | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
         }
-        # Write both Path and PATH to GITHUB_ENV so that both
-        # cmd.exe (uses Path) and bash/Go (uses PATH) see the
-        # same value including Git usr/bin.
-        "Path=$current" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
-        "PATH=$current" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
 

--- a/.github/actions/test-go-pg/action.yaml
+++ b/.github/actions/test-go-pg/action.yaml
@@ -174,6 +174,27 @@ runs:
           $goTestArgs += "-shuffle=$env:TEST_SHUFFLE"
         }
 
+        $nativePathParts = @(
+          "$env:SystemRoot\System32"
+          "$env:SystemRoot\System32\WindowsPowerShell\v1.0"
+          "$env:SystemRoot\System32\OpenSSH"
+          "C:\Program Files\Git\usr\bin"
+          "C:\Program Files\Git\cmd"
+        )
+        $nativePathParts += $env:Path -split ";"
+        $dedupedNativePathParts = @()
+        $seenNativePathParts = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        foreach ($part in $nativePathParts) {
+          if ([string]::IsNullOrWhiteSpace($part)) {
+            continue
+          }
+          if ($seenNativePathParts.Add($part)) {
+            $dedupedNativePathParts += $part
+          }
+        }
+        $nativePath = $dedupedNativePathParts -join ";"
+        $env:Path = $nativePath
+
         $gotestsum = (mise which gotestsum).Trim()
         $envBlock = [Environment]::GetEnvironmentVariables()
         $process = [System.Diagnostics.ProcessStartInfo]::new()
@@ -186,7 +207,7 @@ runs:
             $process.Environment[$entry.Key] = [string]$entry.Value
           }
         }
-        $process.Environment["Path"] = $env:Path
+        $process.Environment["Path"] = $nativePath
         foreach ($arg in ($gotestsumArgs + $goTestArgs)) {
           $process.ArgumentList.Add($arg) | Out-Null
         }

--- a/.github/actions/test-go-pg/action.yaml
+++ b/.github/actions/test-go-pg/action.yaml
@@ -208,7 +208,6 @@ runs:
             $process.Environment[$entry.Key] = [string]$entry.Value
           }
         }
-        $process.Environment["Path"] = $nativePath
         $process.Environment["PATH"] = $nativePath
         foreach ($arg in ($gotestsumArgs + $goTestArgs)) {
           $process.ArgumentList.Add($arg) | Out-Null

--- a/.github/actions/test-go-pg/action.yaml
+++ b/.github/actions/test-go-pg/action.yaml
@@ -144,10 +144,6 @@ runs:
         $env:GIT_CONFIG_GLOBAL = $emptyGitConfig
         $env:GIT_CONFIG_SYSTEM = $emptyGitConfig
 
-        # Go deduplicates environment keys case-insensitively on Windows and keeps the last value.
-        # Keep both common spellings native before gotestsum starts test subprocesses.
-        $env:PATH = $env:Path
-
         $gotestsumArgs = @("--format", "standard-quiet")
         if ($env:RACE_DETECTION -eq "true") {
           $gotestsumArgs += "--junitfile=gotests.xml"
@@ -178,4 +174,23 @@ runs:
           $goTestArgs += "-shuffle=$env:TEST_SHUFFLE"
         }
 
-        gotestsum @gotestsumArgs @goTestArgs
+        $gotestsum = (mise which gotestsum).Trim()
+        $envBlock = [Environment]::GetEnvironmentVariables()
+        $process = [System.Diagnostics.ProcessStartInfo]::new()
+        $process.FileName = $gotestsum
+        $process.UseShellExecute = $false
+        $process.WorkingDirectory = (Get-Location).ProviderPath
+        $process.Environment.Clear()
+        foreach ($entry in $envBlock.GetEnumerator()) {
+          if ($entry.Key -ine "Path") {
+            $process.Environment[$entry.Key] = [string]$entry.Value
+          }
+        }
+        $process.Environment["Path"] = $env:Path
+        foreach ($arg in ($gotestsumArgs + $goTestArgs)) {
+          $process.ArgumentList.Add($arg) | Out-Null
+        }
+
+        $child = [System.Diagnostics.Process]::Start($process)
+        $child.WaitForExit()
+        exit $child.ExitCode

--- a/.github/actions/test-go-pg/action.yaml
+++ b/.github/actions/test-go-pg/action.yaml
@@ -57,8 +57,8 @@ runs:
         POSTGRES_VERSION: ${{ inputs.postgres-version }}
       run: make test-postgres-docker
 
-    - name: Setup Embedded Postgres (Windows/macOS)
-      if: runner.os != 'Linux'
+    - name: Setup Embedded Postgres (macOS)
+      if: runner.os == 'macOS'
       shell: bash
       env:
         POSTGRES_VERSION: ${{ inputs.postgres-version }}
@@ -67,7 +67,18 @@ runs:
       run: |
         go run scripts/embedded-pg/main.go -path "${EMBEDDED_PG_PATH}" -cache "${EMBEDDED_PG_CACHE_DIR}"
 
+    - name: Setup Embedded Postgres (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        POSTGRES_VERSION: ${{ inputs.postgres-version }}
+        EMBEDDED_PG_PATH: ${{ inputs.embedded-pg-path }}
+        EMBEDDED_PG_CACHE_DIR: ${{ inputs.embedded-pg-cache }}
+      run: |
+        go run scripts/embedded-pg/main.go -path "$env:EMBEDDED_PG_PATH" -cache "$env:EMBEDDED_PG_CACHE_DIR"
+
     - name: Run tests
+      if: runner.os != 'Windows'
       shell: bash
       env:
         TEST_NUM_PARALLEL_PACKAGES: ${{ inputs.test-parallelism-packages }}
@@ -102,3 +113,65 @@ runs:
         else
           make test
         fi
+
+    - name: Run tests (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        TEST_NUM_PARALLEL_PACKAGES: ${{ inputs.test-parallelism-packages }}
+        TEST_NUM_PARALLEL_TESTS: ${{ inputs.test-parallelism-tests }}
+        TEST_COUNT: ${{ inputs.test-count }}
+        RUN: ${{ inputs.run-regex }}
+        TEST_SHUFFLE: ${{ inputs.test-shuffle }}
+        TEST_PACKAGES: ${{ inputs.test-packages }}
+        RACE_DETECTION: ${{ inputs.race-detection }}
+        GOTESTSUM_JSONFILE_INPUT: ${{ inputs.gotestsum-json-file }}
+        TS_DEBUG_DISCO: "true"
+        TS_DEBUG_DERP: "true"
+      run: |
+        $ErrorActionPreference = "Stop"
+
+        if ($env:GOTESTSUM_JSONFILE_INPUT) {
+          if ($env:GOTESTSUM_JSONFILE_INPUT -eq "default") {
+            $env:GOTESTSUM_JSONFILE = Join-Path $env:RUNNER_TEMP "go-test.json"
+          } else {
+            $env:GOTESTSUM_JSONFILE = $env:GOTESTSUM_JSONFILE_INPUT
+          }
+        }
+
+        $emptyGitConfig = Join-Path $env:RUNNER_TEMP "empty-gitconfig"
+        New-Item -ItemType File -Path $emptyGitConfig -Force | Out-Null
+        $env:GIT_CONFIG_GLOBAL = $emptyGitConfig
+        $env:GIT_CONFIG_SYSTEM = $emptyGitConfig
+
+        $gotestsumArgs = @("--format", "standard-quiet")
+        if ($env:RACE_DETECTION -eq "true") {
+          $gotestsumArgs += "--junitfile=gotests.xml"
+        }
+        if ($env:TEST_RETRIES) {
+          $gotestsumArgs += "--rerun-fails=$env:TEST_RETRIES"
+        }
+        $gotestsumArgs += "--packages=$env:TEST_PACKAGES"
+        $gotestsumArgs += "--"
+
+        $goTestArgs = @(
+          "-tags=testsmallbatch",
+          "-v",
+          "-timeout", "20m",
+          "-p", $env:TEST_NUM_PARALLEL_PACKAGES,
+          "-parallel=$env:TEST_NUM_PARALLEL_TESTS"
+        )
+        if ($env:RACE_DETECTION -eq "true") {
+          $goTestArgs += "-race"
+        }
+        if ($env:TEST_COUNT) {
+          $goTestArgs += "-count=$env:TEST_COUNT"
+        }
+        if ($env:RUN) {
+          $goTestArgs += @("-run", $env:RUN)
+        }
+        if ($env:TEST_SHUFFLE) {
+          $goTestArgs += "-shuffle=$env:TEST_SHUFFLE"
+        }
+
+        gotestsum @gotestsumArgs @goTestArgs

--- a/.github/actions/test-go-pg/action.yaml
+++ b/.github/actions/test-go-pg/action.yaml
@@ -144,6 +144,10 @@ runs:
         $env:GIT_CONFIG_GLOBAL = $emptyGitConfig
         $env:GIT_CONFIG_SYSTEM = $emptyGitConfig
 
+        # Go deduplicates environment keys case-insensitively on Windows and keeps the last value.
+        # Keep both common spellings native before gotestsum starts test subprocesses.
+        $env:PATH = $env:Path
+
         $gotestsumArgs = @("--format", "standard-quiet")
         if ($env:RACE_DETECTION -eq "true") {
           $gotestsumArgs += "--junitfile=gotests.xml"

--- a/.github/actions/test-go-pg/action.yaml
+++ b/.github/actions/test-go-pg/action.yaml
@@ -196,23 +196,7 @@ runs:
         $env:Path = $nativePath
         $env:PATH = $nativePath
 
-        $gotestsum = (mise which gotestsum).Trim()
-        $envBlock = [Environment]::GetEnvironmentVariables()
-        $process = [System.Diagnostics.ProcessStartInfo]::new()
-        $process.FileName = $gotestsum
-        $process.UseShellExecute = $false
-        $process.WorkingDirectory = (Get-Location).ProviderPath
-        $process.Environment.Clear()
-        foreach ($entry in $envBlock.GetEnumerator()) {
-          if ($entry.Key -ine "Path") {
-            $process.Environment[$entry.Key] = [string]$entry.Value
-          }
-        }
-        $process.Environment["PATH"] = $nativePath
-        foreach ($arg in ($gotestsumArgs + $goTestArgs)) {
-          $process.ArgumentList.Add($arg) | Out-Null
-        }
+        cmd.exe /d /c "where powershell.exe && where printf.exe && where ssh.exe"
 
-        $child = [System.Diagnostics.Process]::Start($process)
-        $child.WaitForExit()
-        exit $child.ExitCode
+        $gotestsum = (mise which gotestsum).Trim()
+        & $gotestsum @gotestsumArgs @goTestArgs

--- a/.github/actions/test-go-pg/action.yaml
+++ b/.github/actions/test-go-pg/action.yaml
@@ -177,9 +177,9 @@ runs:
         $nativePathParts = @(
           "$env:SystemRoot\System32"
           "$env:SystemRoot\System32\WindowsPowerShell\v1.0"
-          "$env:SystemRoot\System32\OpenSSH"
           "C:\Program Files\Git\usr\bin"
           "C:\Program Files\Git\cmd"
+          "$env:SystemRoot\System32\OpenSSH"
         )
         $nativePathParts += $env:Path -split ";"
         $dedupedNativePathParts = @()
@@ -194,6 +194,7 @@ runs:
         }
         $nativePath = $dedupedNativePathParts -join ";"
         $env:Path = $nativePath
+        $env:PATH = $nativePath
 
         $gotestsum = (mise which gotestsum).Trim()
         $envBlock = [Environment]::GetEnvironmentVariables()
@@ -208,6 +209,7 @@ runs:
           }
         }
         $process.Environment["Path"] = $nativePath
+        $process.Environment["PATH"] = $nativePath
         foreach ($arg in ($gotestsumArgs + $goTestArgs)) {
           $process.ArgumentList.Add($arg) | Out-Null
         }

--- a/Makefile
+++ b/Makefile
@@ -1410,6 +1410,13 @@ else
 GOTESTSUM_RETRY_FLAGS :=
 endif
 
+GOTESTSUM := gotestsum
+ifeq ($(GOOS),windows)
+# Git Bash adds a POSIX PATH alongside native Path. Launch native gotestsum
+# without PATH so Go tests inherit only the native Path from the runner.
+GOTESTSUM := env -u PATH "$$(command -v gotestsum)"
+endif
+
 # Default to 8x8 parallelism to avoid overwhelming our workspaces.
 # Race detection defaults to 4x4 because the detector adds significant
 # CPU overhead. Override via TEST_NUM_PARALLEL_PACKAGES /
@@ -1459,7 +1466,7 @@ endif
 TEST_PACKAGES ?= ./...
 
 test:
-	$(GIT_FLAGS) gotestsum --format standard-quiet \
+	$(GIT_FLAGS) $(GOTESTSUM) --format standard-quiet \
 		$(GOTESTSUM_RETRY_FLAGS) \
 		--packages="$(TEST_PACKAGES)" \
 		-- \
@@ -1469,7 +1476,7 @@ test:
 test-race: TEST_PARALLEL_PACKAGES := $(RACE_PARALLEL_PACKAGES)
 test-race: TEST_PARALLEL_TESTS := $(RACE_PARALLEL_TESTS)
 test-race:
-	$(GIT_FLAGS) gotestsum --format standard-quiet \
+	$(GIT_FLAGS) $(GOTESTSUM) --format standard-quiet \
 		--junitfile="gotests.xml" \
 		$(GOTESTSUM_RETRY_FLAGS) \
 		--packages="$(TEST_PACKAGES)" \

--- a/Makefile
+++ b/Makefile
@@ -1413,8 +1413,8 @@ endif
 GOTESTSUM := gotestsum
 ifeq ($(GOOS),windows)
 # Resolve gotestsum before dropping PATH. The shim needs mise in PATH, but
-# native test subprocesses should not inherit Git Bash's POSIX PATH.
-GOTESTSUM := env -u PATH "$$(cygpath -u "$$(mise which gotestsum)")"
+# native test subprocesses should inherit only the GitHub runner's native Path.
+GOTESTSUM := env -u PATH Path="$${Path}" "$$(cygpath -u "$$(mise which gotestsum)")"
 endif
 
 # Default to 8x8 parallelism to avoid overwhelming our workspaces.

--- a/Makefile
+++ b/Makefile
@@ -1412,9 +1412,9 @@ endif
 
 GOTESTSUM := gotestsum
 ifeq ($(GOOS),windows)
-# Git Bash adds a POSIX PATH alongside native Path. Launch native gotestsum
-# without PATH so Go tests inherit only the native Path from the runner.
-GOTESTSUM := env -u PATH "$$(command -v gotestsum)"
+# Resolve gotestsum before dropping PATH. The shim needs mise in PATH, but
+# native test subprocesses should not inherit Git Bash's POSIX PATH.
+GOTESTSUM := env -u PATH "$$(cygpath -u "$$(mise which gotestsum)")"
 endif
 
 # Default to 8x8 parallelism to avoid overwhelming our workspaces.

--- a/Makefile
+++ b/Makefile
@@ -1410,13 +1410,6 @@ else
 GOTESTSUM_RETRY_FLAGS :=
 endif
 
-GOTESTSUM := gotestsum
-ifeq ($(GOOS),windows)
-# Resolve gotestsum before dropping PATH. The shim needs mise in PATH, but
-# native test subprocesses should inherit only the GitHub runner's native Path.
-GOTESTSUM := env -u PATH Path="$${Path}" "$$(cygpath -u "$$(mise which gotestsum)")"
-endif
-
 # Default to 8x8 parallelism to avoid overwhelming our workspaces.
 # Race detection defaults to 4x4 because the detector adds significant
 # CPU overhead. Override via TEST_NUM_PARALLEL_PACKAGES /
@@ -1466,7 +1459,7 @@ endif
 TEST_PACKAGES ?= ./...
 
 test:
-	$(GIT_FLAGS) $(GOTESTSUM) --format standard-quiet \
+	$(GIT_FLAGS) gotestsum --format standard-quiet \
 		$(GOTESTSUM_RETRY_FLAGS) \
 		--packages="$(TEST_PACKAGES)" \
 		-- \
@@ -1476,7 +1469,7 @@ test:
 test-race: TEST_PARALLEL_PACKAGES := $(RACE_PARALLEL_PACKAGES)
 test-race: TEST_PARALLEL_TESTS := $(RACE_PARALLEL_TESTS)
 test-race:
-	$(GIT_FLAGS) $(GOTESTSUM) --format standard-quiet \
+	$(GIT_FLAGS) gotestsum --format standard-quiet \
 		--junitfile="gotests.xml" \
 		$(GOTESTSUM_RETRY_FLAGS) \
 		--packages="$(TEST_PACKAGES)" \

--- a/cli/agent_test.go
+++ b/cli/agent_test.go
@@ -146,10 +146,8 @@ func TestWorkspaceAgent(t *testing.T) {
 		}).WithAgent().Do()
 
 		coderURLEnv := "$CODER_URL"
-		headerCmd := "printf X-Process-Testing=very-wow-" + coderURLEnv + "'\\r\\n'X-Process-Testing2=more-wow"
 		if runtime.GOOS == "windows" {
 			coderURLEnv = "%CODER_URL%"
-			headerCmd = "echo X-Process-Testing=very-wow-" + coderURLEnv + "& echo X-Process-Testing2=more-wow"
 		}
 
 		logDir := t.TempDir()
@@ -161,7 +159,7 @@ func TestWorkspaceAgent(t *testing.T) {
 			"--log-dir", logDir,
 			"--agent-header", "X-Testing=agent",
 			"--agent-header", "Cool-Header=Ethan was Here!",
-			"--agent-header-command", headerCmd,
+			"--agent-header-command", "printf X-Process-Testing=very-wow-"+coderURLEnv+"'\\r\\n'X-Process-Testing2=more-wow",
 			"--socket-path", testutil.AgentSocketPath(t),
 		)
 		clitest.Start(t, agentInv)

--- a/cli/configssh_internal_test.go
+++ b/cli/configssh_internal_test.go
@@ -229,14 +229,7 @@ func Test_sshConfigMatchExecEscape(t *testing.T) {
 
 			// OpenSSH processes %% escape sequences into %
 			escaped = strings.ReplaceAll(escaped, "%%", "%")
-			c := exec.Command(cmd, arg, escaped) //nolint:gosec
-			if runtime.GOOS == "windows" {
-				// Deduplicate Path/PATH env vars so cmd.exe
-				// subprocesses (like powershell.exe used for
-				// paths with spaces) resolve correctly.
-				c.Env = appendAndDedupEnv(os.Environ())
-			}
-			b, err := c.CombinedOutput()
+			b, err := exec.Command(cmd, arg, escaped).CombinedOutput() //nolint:gosec
 			require.NoError(t, err, "command output: %s", string(b))
 			got := strings.TrimSpace(string(b))
 			require.Equal(t, "yay", got)

--- a/cli/configssh_windows.go
+++ b/cli/configssh_windows.go
@@ -4,8 +4,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"golang.org/x/xerrors"
@@ -52,13 +50,7 @@ func sshConfigMatchExecEscape(path string) (string, error) {
 
 	if strings.ContainsAny(path, " ") {
 		// c.f. function comment for how this works.
-		// Use absolute paths for powershell.exe and cmd.exe
-		// to avoid PATH resolution issues when both Path and
-		// PATH (MSYS-translated) exist in the environment.
-		sysRoot := os.Getenv("SYSTEMROOT")
-		pwsh := filepath.Join(sysRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
-		cmd := filepath.Join(sysRoot, "System32", "cmd.exe")
-		path = fmt.Sprintf("for /f %%%%a in ('%s -Command [char]34') do @%s /c %%%%a%s%%%%a", pwsh, cmd, path) //nolint:gocritic // We don't want %q here.
+		path = fmt.Sprintf("for /f %%%%a in ('powershell.exe -Command [char]34') do @cmd.exe /c %%%%a%s%%%%a", path) //nolint:gocritic // We don't want %q here.
 	}
 	return path, nil
 }

--- a/cli/root.go
+++ b/cli/root.go
@@ -1701,43 +1701,6 @@ func (r roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return r(req)
 }
 
-// appendAndDedupEnv appends extra environment variables and
-// deduplicates entries with the same key (case-insensitive on
-// Windows). For the PATH variable specifically, it prefers the
-// value that contains native Windows paths (with backslashes)
-// over MSYS-translated paths (with forward slashes). For all
-// other variables, the last value wins.
-func appendAndDedupEnv(env []string, extra ...string) []string {
-	env = append(env, extra...)
-	if runtime.GOOS != "windows" {
-		return env
-	}
-	seen := make(map[string]int, len(env))
-	result := make([]string, 0, len(env))
-	for _, e := range env {
-		key, val, ok := strings.Cut(e, "=")
-		if !ok {
-			result = append(result, e)
-			continue
-		}
-		upper := strings.ToUpper(key)
-		if idx, exists := seen[upper]; exists {
-			if upper == "PATH" {
-				// Prefer the value with native Windows paths.
-				existingVal := result[idx][len(key)+1:]
-				if strings.Contains(existingVal, "\\") && !strings.Contains(val, "\\") {
-					continue
-				}
-			}
-			result[idx] = e
-			continue
-		}
-		seen[upper] = len(result)
-		result = append(result, e)
-	}
-	return result
-}
-
 // headerTransport creates a new transport that executes `--header-command`
 // if it is set to add headers for all outbound requests.
 func headerTransport(ctx context.Context, serverURL *url.URL, header []string, headerCommand string) (*codersdk.HeaderTransport, error) {
@@ -1756,7 +1719,7 @@ func headerTransport(ctx context.Context, serverURL *url.URL, header []string, h
 		var outBuf bytes.Buffer
 		// #nosec
 		cmd := exec.CommandContext(ctx, shell, caller, headerCommand)
-		cmd.Env = appendAndDedupEnv(os.Environ(), "CODER_URL="+serverURL.String())
+		cmd.Env = append(os.Environ(), "CODER_URL="+serverURL.String())
 		cmd.Stdout = &outBuf
 		cmd.Stderr = io.Discard
 		err := cmd.Run()

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -177,17 +177,15 @@ func TestRoot(t *testing.T) {
 		url = srv.URL
 		buf := new(bytes.Buffer)
 		coderURLEnv := "$CODER_URL"
-		headerCmd := "printf X-Process-Testing=very-wow-" + coderURLEnv + "'\\r\\n'X-Process-Testing2=more-wow"
 		if runtime.GOOS == "windows" {
 			coderURLEnv = "%CODER_URL%"
-			headerCmd = "echo X-Process-Testing=very-wow-" + coderURLEnv + "& echo X-Process-Testing2=more-wow"
 		}
 		inv, _ := clitest.New(t,
 			"--no-feature-warning",
 			"--no-version-warning",
 			"--header", "X-Testing=wow",
 			"--header", "Cool-Header=Dean was Here!",
-			"--header-command", headerCmd,
+			"--header-command", "printf X-Process-Testing=very-wow-"+coderURLEnv+"'\\r\\n'X-Process-Testing2=more-wow",
 			"login", srv.URL,
 		)
 		inv.Stdout = buf
@@ -268,7 +266,7 @@ func TestDERPHeaders(t *testing.T) {
 		"--no-version-warning",
 		"ping", workspace.Name,
 		"-n", "1",
-		"--header-command", "echo X-Process-Testing=very-wow",
+		"--header-command", "printf X-Process-Testing=very-wow",
 	}
 	for k, v := range expectedHeaders {
 		if k != "X-Process-Testing" {

--- a/enterprise/cli/proxyserver_test.go
+++ b/enterprise/cli/proxyserver_test.go
@@ -48,7 +48,7 @@ func Test_ProxyServer_Headers(t *testing.T) {
 		"--access-url", "http://localhost:8080",
 		"--http-address", ":0",
 		"--header", fmt.Sprintf("%s=%s", headerName1, headerVal1),
-		"--header-command", fmt.Sprintf("echo %s=%s", headerName2, headerVal2),
+		"--header-command", fmt.Sprintf("printf %s=%s", headerName2, headerVal2),
 	)
 	pty := ptytest.New(t)
 	inv.Stdout = pty.Output()


### PR DESCRIPTION
Windows Go tests were running through Git Bash twice: the action used `shell: bash`, and `make test` runs recipes with `SHELL := bash`. On Windows, that introduces an MSYS `PATH` alongside the native `Path`, so Go subprocesses can inherit a path form that native Windows commands cannot use.

This fixes the shell boundary in CI instead of carrying CI-specific workarounds in product code. Linux and macOS still use `make test`; Windows sets up embedded Postgres and invokes `gotestsum` directly from `pwsh` with an explicit environment that contains one native `Path`. `setup-mise` adds the fixed Windows subprocess tool directories through `$GITHUB_PATH`.

This also deliberately undoes some changes from #25939: the Go env dedupe helper, absolute `cmd.exe`/`powershell.exe` paths, and `echo` substitutions in header-command tests. Those made CI pass by adapting product code and tests to a runner-specific Git Bash environment. Keeping the fix in the action is narrower and keeps the Makefile independent of `mise` and Git Bash internals.
