### PR TITLE
fix: update scaletest chat provider bootstrap

### DIFF
--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -396,6 +396,7 @@ type workspaceTargetFlags struct {
 	template         string
 	targetWorkspaces string
 	useHostLogin     bool
+	allowEmpty       bool
 }
 
 // attach adds the workspace target flags to the given options set.
@@ -463,6 +464,9 @@ func (f *workspaceTargetFlags) getTargetedWorkspaces(ctx context.Context, client
 
 	// Validate range
 	if len(workspaces) == 0 {
+		if f.allowEmpty {
+			return nil, nil
+		}
 		return nil, xerrors.Errorf("no scaletest workspaces exist")
 	}
 	if targetEnd > len(workspaces) {

--- a/cli/exp_scaletest_chat.go
+++ b/cli/exp_scaletest_chat.go
@@ -27,7 +27,7 @@ func (r *RootCmd) scaletestChat() *serpent.Command {
 		turns             int64
 		turnStartDelay    time.Duration
 		llmMockURL        string
-		targetFlags       = &workspaceTargetFlags{}
+		targetFlags       = &workspaceTargetFlags{allowEmpty: true}
 		tracingFlags      = &scaletestTracingFlags{}
 		prometheusFlags   = &scaletestPrometheusFlags{}
 		timeoutStrategy   = &timeoutFlags{}
@@ -72,8 +72,13 @@ func (r *RootCmd) scaletestChat() *serpent.Command {
 				return err
 			}
 
+			if len(workspaces) == 0 {
+				workspaces = append(workspaces, codersdk.Workspace{OrganizationID: me.OrganizationIDs[0]})
+				_, _ = fmt.Fprintln(inv.Stderr, "No scaletest workspaces found; running chats without workspace context.")
+			}
+
 			logger := slog.Make(sloghuman.Sink(inv.Stderr)).Leveled(slog.LevelDebug)
-			modelConfigID, err := chat.EnsureScaletestModelConfig(ctx, client, logger, llmMockURL, workspaces[0].OrganizationID, workspaces[0].ID)
+			modelConfigID, err := chat.EnsureScaletestModelConfig(ctx, client, logger, llmMockURL, workspaces[0].OrganizationID)
 			if err != nil {
 				return err
 			}
@@ -154,7 +159,7 @@ func (r *RootCmd) scaletestChat() *serpent.Command {
 			// Run the chat harness in the background so the CLI can release the
 			// follow-up turns after every runner finishes its initial turn.
 			totalChats := int64(len(workspaces)) * chatsPerWorkspace
-			_, _ = fmt.Fprintf(inv.Stderr, "Starting chat scale test with %d chats across %d workspaces...\n", totalChats, len(workspaces))
+			_, _ = fmt.Fprintf(inv.Stderr, "Starting chat scale test with %d chats across %d targets...\n", totalChats, len(workspaces))
 			testCtx, testCancel := timeoutStrategy.toContext(ctx)
 			defer testCancel()
 			testDone := make(chan error, 1)

--- a/cli/exp_scaletest_chat.go
+++ b/cli/exp_scaletest_chat.go
@@ -73,7 +73,7 @@ func (r *RootCmd) scaletestChat() *serpent.Command {
 			}
 
 			logger := slog.Make(sloghuman.Sink(inv.Stderr)).Leveled(slog.LevelDebug)
-			modelConfigID, err := chat.EnsureScaletestModelConfig(ctx, codersdk.NewExperimentalClient(client), logger, llmMockURL)
+			modelConfigID, err := chat.EnsureScaletestModelConfig(ctx, client, logger, llmMockURL, workspaces[0].OrganizationID, workspaces[0].ID)
 			if err != nil {
 				return err
 			}

--- a/cli/exp_scaletest_chat.go
+++ b/cli/exp_scaletest_chat.go
@@ -11,8 +11,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/xerrors"
 
-	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/sloghuman"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/scaletest/chat"
 	"github.com/coder/coder/v2/scaletest/harness"
@@ -77,7 +75,7 @@ func (r *RootCmd) scaletestChat() *serpent.Command {
 				_, _ = fmt.Fprintln(inv.Stderr, "No scaletest workspaces found; running chats without workspace context.")
 			}
 
-			logger := slog.Make(sloghuman.Sink(inv.Stderr)).Leveled(slog.LevelDebug)
+			logger := inv.Logger
 			modelConfigID, err := chat.EnsureScaletestModelConfig(ctx, client, logger, llmMockURL, workspaces[0].OrganizationID)
 			if err != nil {
 				return err

--- a/cli/exp_scaletest_chat.go
+++ b/cli/exp_scaletest_chat.go
@@ -20,17 +20,18 @@ import (
 
 func (r *RootCmd) scaletestChat() *serpent.Command {
 	var (
-		chatsPerWorkspace int64
-		prompt            string
-		turns             int64
-		turnStartDelay    time.Duration
-		llmMockURL        string
-		targetFlags       = &workspaceTargetFlags{allowEmpty: true}
-		tracingFlags      = &scaletestTracingFlags{}
-		prometheusFlags   = &scaletestPrometheusFlags{}
-		timeoutStrategy   = &timeoutFlags{}
-		cleanupStrategy   = newScaletestCleanupStrategy()
-		output            = &scaletestOutputFlags{}
+		chatsPerWorkspace       int64
+		prompt                  string
+		turns                   int64
+		turnStartDelay          time.Duration
+		llmMockURL              string
+		providerPropagationWait time.Duration
+		targetFlags             = &workspaceTargetFlags{allowEmpty: true}
+		tracingFlags            = &scaletestTracingFlags{}
+		prometheusFlags         = &scaletestPrometheusFlags{}
+		timeoutStrategy         = &timeoutFlags{}
+		cleanupStrategy         = newScaletestCleanupStrategy()
+		output                  = &scaletestOutputFlags{}
 	)
 
 	cmd := &serpent.Command{
@@ -76,7 +77,7 @@ func (r *RootCmd) scaletestChat() *serpent.Command {
 			}
 
 			logger := inv.Logger
-			modelConfigID, err := chat.EnsureScaletestModelConfig(ctx, client, logger, llmMockURL, workspaces[0].OrganizationID)
+			modelConfigID, err := chat.EnsureScaletestModelConfig(ctx, client, logger, llmMockURL, providerPropagationWait)
 			if err != nil {
 				return err
 			}
@@ -245,6 +246,13 @@ func (r *RootCmd) scaletestChat() *serpent.Command {
 			Description: "URL of the mock LLM server (e.g. http://127.0.0.1:8080/v1). Creates or updates the Scaletest LLM Mock openai-compat provider and model config to point at this URL.",
 			Value:       serpent.StringOf(&llmMockURL),
 			Required:    true,
+		},
+		{
+			Flag:        "provider-propagation-wait",
+			Description: "Time to wait after creating or updating the mock LLM provider so every coderd replica's cached provider config expires. The default exceeds the server-side cache TTL.",
+			Default:     chat.DefaultProviderPropagationWait.String(),
+			Value:       serpent.DurationOf(&providerPropagationWait),
+			Hidden:      true,
 		},
 	}
 	targetFlags.attach(&cmd.Options)

--- a/cli/exp_scaletest_chat_test.go
+++ b/cli/exp_scaletest_chat_test.go
@@ -59,6 +59,7 @@ func TestScaleTestChat(t *testing.T) {
 		"--cleanup-job-timeout", "30s",
 		"--scaletest-prometheus-address", "127.0.0.1:0",
 		"--scaletest-prometheus-wait", "0s",
+		"--provider-propagation-wait", "10ms",
 		"--llm-mock-url", mockURL,
 	)
 	//nolint:gocritic // The scaletest chat command requires an admin client.

--- a/cli/exp_scaletest_chat_test.go
+++ b/cli/exp_scaletest_chat_test.go
@@ -1,0 +1,152 @@
+//go:build !slim
+
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"cdr.dev/slog/v3"
+	"cdr.dev/slog/v3/sloggers/sloghuman"
+	"github.com/coder/coder/v2/agent/agenttest"
+	"github.com/coder/coder/v2/cli/clitest"
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbfake"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/scaletest/llmmock"
+	"github.com/coder/coder/v2/testutil"
+)
+
+const scaletestChatPrompt = "Reply with one short sentence from the scaletest."
+
+func TestScaleTestChat(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	values := coderdtest.DeploymentValues(t, func(dv *codersdk.DeploymentValues) {
+		require.NoError(t, dv.AI.BridgeConfig.Enabled.Set("true"))
+		// Keep AI Gateway routing disabled so the chat uses the direct model
+		// route to the mock provider, avoiding the need for an aibridged daemon.
+		require.NoError(t, dv.AI.Chat.AIGatewayRoutingEnabled.Set("false"))
+	})
+	client, _, api := coderdtest.NewWithAPI(t, &coderdtest.Options{
+		DeploymentValues: values,
+	})
+	db := api.Database
+	owner := coderdtest.CreateFirstUser(t, client)
+	workspaceBuild := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+		Name:           "scaletest-chat-e2e",
+		OrganizationID: owner.OrganizationID,
+		OwnerID:        owner.UserID,
+	}).WithAgent().Do()
+
+	_ = agenttest.New(t, client.URL, workspaceBuild.AgentToken)
+	coderdtest.NewWorkspaceAgentWaiter(t, client, workspaceBuild.Workspace.ID).WaitFor(coderdtest.AgentsReady)
+
+	firstServer := new(llmmock.Server)
+	require.NoError(t, firstServer.Start(context.Background(), llmmock.Config{
+		Address: "127.0.0.1:0",
+		Logger:  slog.Make(sloghuman.Sink(io.Discard)).Leveled(slog.LevelDebug),
+	}))
+	t.Cleanup(func() {
+		require.NoError(t, firstServer.Stop())
+	})
+	firstMockURL := firstServer.APIAddress() + "/v1"
+
+	firstInv, firstRoot := clitest.New(t,
+		"exp", "scaletest", "chat",
+		"--chats-per-workspace", "1",
+		"--turns", "1",
+		"--prompt", scaletestChatPrompt,
+		"--timeout", "30s",
+		"--job-timeout", "30s",
+		"--cleanup-timeout", "30s",
+		"--cleanup-job-timeout", "30s",
+		"--scaletest-prometheus-address", "127.0.0.1:0",
+		"--scaletest-prometheus-wait", "0s",
+		"--llm-mock-url", firstMockURL,
+	)
+	//nolint:gocritic // The scaletest chat command requires an admin client.
+	clitest.SetupConfig(t, client, firstRoot)
+
+	var firstStderr bytes.Buffer
+	firstInv.Stdout = io.Discard
+	firstInv.Stderr = &firstStderr
+
+	err := firstInv.WithContext(ctx).Run()
+	require.NoError(t, err, firstStderr.String())
+	require.Contains(t, firstStderr.String(), "Scale test passed: 1/1 runs succeeded")
+
+	provider, err := client.AIProvider(ctx, "coder-scaletest-mock")
+	require.NoError(t, err)
+	require.Equal(t, firstMockURL, provider.BaseURL)
+
+	expClient := codersdk.NewExperimentalClient(client)
+	configs, err := expClient.ListChatModelConfigs(ctx)
+	require.NoError(t, err)
+	matchingConfigs := scaletestModelConfigsForProvider(configs, provider.ID)
+	require.Len(t, matchingConfigs, 1)
+	require.True(t, matchingConfigs[0].Enabled)
+
+	chats, err := expClient.ListChats(ctx, &codersdk.ListChatsOptions{Query: "archived:true"})
+	require.NoError(t, err)
+
+	var scaletestMessages []codersdk.ChatMessage
+	for _, chat := range chats {
+		resp, err := expClient.GetChatMessages(ctx, chat.ID, nil)
+		require.NoError(t, err)
+		if userText, ok := chatMessageText(resp.Messages, codersdk.ChatMessageRoleUser); ok &&
+			strings.Contains(userText, scaletestChatPrompt) {
+			scaletestMessages = resp.Messages
+			break
+		}
+	}
+	require.NotEmpty(t, scaletestMessages)
+	assistantText, ok := chatMessageText(scaletestMessages, codersdk.ChatMessageRoleAssistant)
+	require.True(t, ok, "expected an assistant reply in the scaletest chat")
+	require.NotEmpty(t, assistantText)
+}
+
+// chatMessageText concatenates the text parts of every message with the given
+// role, reporting whether any such message was found. It aggregates across
+// messages because the API returns them newest-first and a turn can produce
+// more than one message per role.
+func chatMessageText(messages []codersdk.ChatMessage, role codersdk.ChatMessageRole) (string, bool) {
+	var (
+		b     strings.Builder
+		found bool
+	)
+	for _, msg := range messages {
+		if msg.Role != role {
+			continue
+		}
+		found = true
+		for _, part := range msg.Content {
+			if part.Type == codersdk.ChatMessagePartTypeText {
+				b.WriteString(part.Text)
+			}
+		}
+	}
+	return b.String(), found
+}
+
+func scaletestModelConfigsForProvider(configs []codersdk.ChatModelConfig, providerID uuid.UUID) []codersdk.ChatModelConfig {
+	matches := make([]codersdk.ChatModelConfig, 0, 1)
+	for _, config := range configs {
+		if config.AIProviderID == nil || *config.AIProviderID != providerID {
+			continue
+		}
+		if config.Model != "scaletest-model" {
+			continue
+		}
+		matches = append(matches, config)
+	}
+	return matches
+}

--- a/cli/exp_scaletest_chat_test.go
+++ b/cli/exp_scaletest_chat_test.go
@@ -130,7 +130,7 @@ func chatMessageText(messages []codersdk.ChatMessage, role codersdk.ChatMessageR
 		found = true
 		for _, part := range msg.Content {
 			if part.Type == codersdk.ChatMessagePartTypeText {
-				b.WriteString(part.Text)
+				_, _ = b.WriteString(part.Text)
 			}
 		}
 	}

--- a/cli/exp_scaletest_chat_test.go
+++ b/cli/exp_scaletest_chat_test.go
@@ -14,11 +14,8 @@ import (
 
 	"cdr.dev/slog/v3"
 	"cdr.dev/slog/v3/sloggers/sloghuman"
-	"github.com/coder/coder/v2/agent/agenttest"
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
-	"github.com/coder/coder/v2/coderd/database"
-	"github.com/coder/coder/v2/coderd/database/dbfake"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/scaletest/llmmock"
 	"github.com/coder/coder/v2/testutil"
@@ -36,31 +33,22 @@ func TestScaleTestChat(t *testing.T) {
 		// route to the mock provider, avoiding the need for an aibridged daemon.
 		require.NoError(t, dv.AI.Chat.AIGatewayRoutingEnabled.Set("false"))
 	})
-	client, _, api := coderdtest.NewWithAPI(t, &coderdtest.Options{
+	client := coderdtest.New(t, &coderdtest.Options{
 		DeploymentValues: values,
 	})
-	db := api.Database
-	owner := coderdtest.CreateFirstUser(t, client)
-	workspaceBuild := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
-		Name:           "scaletest-chat-e2e",
-		OrganizationID: owner.OrganizationID,
-		OwnerID:        owner.UserID,
-	}).WithAgent().Do()
+	coderdtest.CreateFirstUser(t, client)
 
-	_ = agenttest.New(t, client.URL, workspaceBuild.AgentToken)
-	coderdtest.NewWorkspaceAgentWaiter(t, client, workspaceBuild.Workspace.ID).WaitFor(coderdtest.AgentsReady)
-
-	firstServer := new(llmmock.Server)
-	require.NoError(t, firstServer.Start(context.Background(), llmmock.Config{
+	server := new(llmmock.Server)
+	require.NoError(t, server.Start(context.Background(), llmmock.Config{
 		Address: "127.0.0.1:0",
 		Logger:  slog.Make(sloghuman.Sink(io.Discard)).Leveled(slog.LevelDebug),
 	}))
 	t.Cleanup(func() {
-		require.NoError(t, firstServer.Stop())
+		require.NoError(t, server.Stop())
 	})
-	firstMockURL := firstServer.APIAddress() + "/v1"
+	mockURL := server.APIAddress() + "/v1"
 
-	firstInv, firstRoot := clitest.New(t,
+	inv, root := clitest.New(t,
 		"exp", "scaletest", "chat",
 		"--chats-per-workspace", "1",
 		"--turns", "1",
@@ -71,22 +59,22 @@ func TestScaleTestChat(t *testing.T) {
 		"--cleanup-job-timeout", "30s",
 		"--scaletest-prometheus-address", "127.0.0.1:0",
 		"--scaletest-prometheus-wait", "0s",
-		"--llm-mock-url", firstMockURL,
+		"--llm-mock-url", mockURL,
 	)
 	//nolint:gocritic // The scaletest chat command requires an admin client.
-	clitest.SetupConfig(t, client, firstRoot)
+	clitest.SetupConfig(t, client, root)
 
-	var firstStderr bytes.Buffer
-	firstInv.Stdout = io.Discard
-	firstInv.Stderr = &firstStderr
+	var stderr bytes.Buffer
+	inv.Stdout = io.Discard
+	inv.Stderr = &stderr
 
-	err := firstInv.WithContext(ctx).Run()
-	require.NoError(t, err, firstStderr.String())
-	require.Contains(t, firstStderr.String(), "Scale test passed: 1/1 runs succeeded")
+	err := inv.WithContext(ctx).Run()
+	require.NoError(t, err, stderr.String())
+	require.Contains(t, stderr.String(), "Scale test passed: 1/1 runs succeeded")
 
 	provider, err := client.AIProvider(ctx, "coder-scaletest-mock")
 	require.NoError(t, err)
-	require.Equal(t, firstMockURL, provider.BaseURL)
+	require.Equal(t, mockURL, provider.BaseURL)
 
 	expClient := codersdk.NewExperimentalClient(client)
 	configs, err := expClient.ListChatModelConfigs(ctx)

--- a/scaletest/chat/client.go
+++ b/scaletest/chat/client.go
@@ -19,36 +19,11 @@ type chatClient interface {
 	UpdateChat(ctx context.Context, chatID uuid.UUID, req codersdk.UpdateChatRequest) error
 }
 
-type sdkChatClient struct {
-	client *codersdk.ExperimentalClient
+var _ chatClient = (*codersdk.ExperimentalClient)(nil)
+
+type chatModelConfigClient interface {
+	ListChatModelConfigs(ctx context.Context) ([]codersdk.ChatModelConfig, error)
+	CreateChatModelConfig(ctx context.Context, req codersdk.CreateChatModelConfigRequest) (codersdk.ChatModelConfig, error)
 }
 
-func newChatClient(client *codersdk.Client) chatClient {
-	return &sdkChatClient{client: codersdk.NewExperimentalClient(client)}
-}
-
-func (c *sdkChatClient) SetLogger(logger slog.Logger) {
-	c.client.SetLogger(logger)
-}
-
-func (c *sdkChatClient) SetLogBodies(logBodies bool) {
-	c.client.SetLogBodies(logBodies)
-}
-
-func (c *sdkChatClient) CreateChat(ctx context.Context, req codersdk.CreateChatRequest) (codersdk.Chat, error) {
-	return c.client.CreateChat(ctx, req)
-}
-
-func (c *sdkChatClient) StreamChat(ctx context.Context, chatID uuid.UUID, opts *codersdk.StreamChatOptions) (<-chan codersdk.ChatStreamEvent, io.Closer, error) {
-	return c.client.StreamChat(ctx, chatID, opts)
-}
-
-func (c *sdkChatClient) CreateChatMessage(ctx context.Context, chatID uuid.UUID, req codersdk.CreateChatMessageRequest) (codersdk.CreateChatMessageResponse, error) {
-	return c.client.CreateChatMessage(ctx, chatID, req)
-}
-
-func (c *sdkChatClient) UpdateChat(ctx context.Context, chatID uuid.UUID, req codersdk.UpdateChatRequest) error {
-	return c.client.UpdateChat(ctx, chatID, req)
-}
-
-var _ chatClient = (*sdkChatClient)(nil)
+var _ chatModelConfigClient = (*codersdk.ExperimentalClient)(nil)

--- a/scaletest/chat/config.go
+++ b/scaletest/chat/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	OrganizationID uuid.UUID `json:"organization_id"`
 
 	// WorkspaceID is the pre-existing workspace to use for this chat run.
+	// When empty, the chat runs without workspace context.
 	WorkspaceID uuid.UUID `json:"workspace_id"`
 
 	// Prompt is the text content sent on every turn.
@@ -46,9 +47,6 @@ type Config struct {
 func (c Config) Validate() error {
 	if c.OrganizationID == uuid.Nil {
 		return xerrors.Errorf("validate organization_id: must not be empty")
-	}
-	if c.WorkspaceID == uuid.Nil {
-		return xerrors.Errorf("validate workspace_id: must not be empty")
 	}
 	if c.Prompt == "" {
 		return xerrors.Errorf("validate prompt: must not be empty")

--- a/scaletest/chat/provider.go
+++ b/scaletest/chat/provider.go
@@ -38,7 +38,7 @@ const (
 
 // EnsureScaletestModelConfig bootstraps the shared AI provider and model
 // config used by chat scaletests.
-func EnsureScaletestModelConfig(ctx context.Context, client *codersdk.Client, logger slog.Logger, llmMockURL string, organizationID uuid.UUID, workspaceID uuid.UUID) (uuid.UUID, error) {
+func EnsureScaletestModelConfig(ctx context.Context, client *codersdk.Client, logger slog.Logger, llmMockURL string, organizationID uuid.UUID) (uuid.UUID, error) {
 	expClient := codersdk.NewExperimentalClient(client)
 
 	logger.Info(ctx, "bootstrapping mock LLM provider", slog.F("llm_mock_url", llmMockURL))
@@ -74,7 +74,7 @@ func EnsureScaletestModelConfig(ctx context.Context, client *codersdk.Client, lo
 	}
 
 	if providerAction != scaletestAIProviderActionReused {
-		if err := waitForScaletestProviderReload(ctx, expClient, logger, modelConfigID, organizationID, workspaceID); err != nil {
+		if err := waitForScaletestProviderReload(ctx, expClient, logger, modelConfigID, organizationID); err != nil {
 			return uuid.Nil, xerrors.Errorf("wait for mock LLM provider reload: %w", err)
 		}
 	}
@@ -82,14 +82,14 @@ func EnsureScaletestModelConfig(ctx context.Context, client *codersdk.Client, lo
 	return modelConfigID, nil
 }
 
-func waitForScaletestProviderReload(ctx context.Context, client chatClient, logger slog.Logger, modelConfigID uuid.UUID, organizationID uuid.UUID, workspaceID uuid.UUID) error {
+func waitForScaletestProviderReload(ctx context.Context, client chatClient, logger slog.Logger, modelConfigID uuid.UUID, organizationID uuid.UUID) error {
 	logger.Info(ctx, "waiting for mock LLM provider reload", slog.F("provider_name", scaletestAIProviderName))
 	waitCtx, cancel := context.WithTimeout(ctx, scaletestAIProviderProbeWait)
 	defer cancel()
 
 	var lastErr error
 	for r := retry.New(scaletestAIProviderProbePeriod, scaletestAIProviderProbePeriod); r.Wait(waitCtx); {
-		if err := runScaletestProviderReloadProbe(waitCtx, client, logger, modelConfigID, organizationID, workspaceID); err != nil {
+		if err := runScaletestProviderReloadProbe(waitCtx, client, logger, modelConfigID, organizationID); err != nil {
 			lastErr = err
 			logger.Debug(ctx, "mock LLM provider probe failed", slog.Error(err))
 			continue
@@ -106,10 +106,9 @@ func waitForScaletestProviderReload(ctx context.Context, client chatClient, logg
 	return xerrors.New("timed out waiting for mock LLM provider reload")
 }
 
-func runScaletestProviderReloadProbe(ctx context.Context, client chatClient, logger slog.Logger, modelConfigID uuid.UUID, organizationID uuid.UUID, workspaceID uuid.UUID) error {
+func runScaletestProviderReloadProbe(ctx context.Context, client chatClient, logger slog.Logger, modelConfigID uuid.UUID, organizationID uuid.UUID) error {
 	chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
 		OrganizationID: organizationID,
-		WorkspaceID:    &workspaceID,
 		ModelConfigID:  &modelConfigID,
 		Content: []codersdk.ChatInputPart{{
 			Type: codersdk.ChatInputPartTypeText,

--- a/scaletest/chat/provider.go
+++ b/scaletest/chat/provider.go
@@ -10,23 +10,25 @@ import (
 
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/codersdk"
-	"github.com/coder/retry"
 )
 
 const (
-	scaletestAIProviderType           = codersdk.AIProviderTypeOpenAICompat
-	scaletestAIProviderName           = "coder-scaletest-mock"
-	scaletestAIProviderDisplayName    = "Scaletest LLM Mock"
-	scaletestAIProviderAPIKey         = "coder-scaletest"
-	scaletestModelName                = "scaletest-model"
-	scaletestModelDisplayName         = "Scaletest Model"
-	scaletestModelContextLimit        = int64(4096)
-	scaletestAIProviderProbeWait      = 15 * time.Second
-	scaletestAIProviderProbePeriod    = 500 * time.Millisecond
-	scaletestAIProviderArchiveTimeout = 5 * time.Second
-
-	scaletestProviderReloadProbePrompt = "Reply with one short sentence."
+	scaletestAIProviderType        = codersdk.AIProviderTypeOpenAICompat
+	scaletestAIProviderName        = "coder-scaletest-mock"
+	scaletestAIProviderDisplayName = "Scaletest LLM Mock"
+	scaletestAIProviderAPIKey      = "coder-scaletest"
+	scaletestModelName             = "scaletest-model"
+	scaletestModelDisplayName      = "Scaletest Model"
+	scaletestModelContextLimit     = int64(4096)
 )
+
+// DefaultProviderPropagationWait is how long to wait after creating or
+// updating the mock LLM provider before starting chats. Provider config is
+// cached per coderd replica with a 10 second TTL (see
+// coderd/x/chatd/configcache.go), and a change is only guaranteed to be
+// visible everywhere once every replica's cached entry has expired. 15
+// seconds comfortably exceeds that TTL.
+const DefaultProviderPropagationWait = 15 * time.Second
 
 type scaletestAIProviderAction string
 
@@ -37,8 +39,10 @@ const (
 )
 
 // EnsureScaletestModelConfig bootstraps the shared AI provider and model
-// config used by chat scaletests.
-func EnsureScaletestModelConfig(ctx context.Context, client *codersdk.Client, logger slog.Logger, llmMockURL string, organizationID uuid.UUID) (uuid.UUID, error) {
+// config used by chat scaletests. When the provider was created or updated,
+// it sleeps for propagationWait so every coderd replica's cached provider
+// config expires before chats start.
+func EnsureScaletestModelConfig(ctx context.Context, client *codersdk.Client, logger slog.Logger, llmMockURL string, propagationWait time.Duration) (uuid.UUID, error) {
 	expClient := codersdk.NewExperimentalClient(client)
 
 	logger.Info(ctx, "bootstrapping mock LLM provider", slog.F("llm_mock_url", llmMockURL))
@@ -73,85 +77,19 @@ func EnsureScaletestModelConfig(ctx context.Context, client *codersdk.Client, lo
 		return uuid.Nil, err
 	}
 
-	if providerAction != scaletestAIProviderActionReused {
-		if err := waitForScaletestProviderReload(ctx, expClient, logger, modelConfigID, organizationID); err != nil {
-			return uuid.Nil, xerrors.Errorf("wait for mock LLM provider reload: %w", err)
+	if providerAction != scaletestAIProviderActionReused && propagationWait > 0 {
+		logger.Info(ctx, "waiting for mock LLM provider propagation",
+			slog.F("provider_name", provider.Name),
+			slog.F("wait", propagationWait),
+		)
+		select {
+		case <-ctx.Done():
+			return uuid.Nil, ctx.Err()
+		case <-time.After(propagationWait):
 		}
 	}
 
 	return modelConfigID, nil
-}
-
-func waitForScaletestProviderReload(ctx context.Context, client chatClient, logger slog.Logger, modelConfigID uuid.UUID, organizationID uuid.UUID) error {
-	logger.Info(ctx, "waiting for mock LLM provider reload", slog.F("provider_name", scaletestAIProviderName))
-	waitCtx, cancel := context.WithTimeout(ctx, scaletestAIProviderProbeWait)
-	defer cancel()
-
-	var lastErr error
-	for r := retry.New(scaletestAIProviderProbePeriod, scaletestAIProviderProbePeriod); r.Wait(waitCtx); {
-		if err := runScaletestProviderReloadProbe(waitCtx, client, logger, modelConfigID, organizationID); err != nil {
-			lastErr = err
-			logger.Debug(ctx, "mock LLM provider probe failed", slog.Error(err))
-			continue
-		}
-		return nil
-	}
-
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	if lastErr != nil {
-		return xerrors.Errorf("timed out waiting for mock LLM provider reload: %w", lastErr)
-	}
-	return xerrors.New("timed out waiting for mock LLM provider reload")
-}
-
-func runScaletestProviderReloadProbe(ctx context.Context, client chatClient, logger slog.Logger, modelConfigID uuid.UUID, organizationID uuid.UUID) error {
-	chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
-		OrganizationID: organizationID,
-		ModelConfigID:  &modelConfigID,
-		Content: []codersdk.ChatInputPart{{
-			Type: codersdk.ChatInputPartTypeText,
-			Text: scaletestProviderReloadProbePrompt,
-		}},
-	})
-	if err != nil {
-		return xerrors.Errorf("create probe chat: %w", err)
-	}
-	defer archiveScaletestProbeChat(ctx, client, logger, chat.ID)
-
-	events, closer, err := client.StreamChat(ctx, chat.ID, nil)
-	if err != nil {
-		return xerrors.Errorf("stream probe chat: %w", err)
-	}
-	defer closer.Close()
-
-	for event := range events {
-		switch event.Type {
-		case codersdk.ChatStreamEventTypeStatus:
-			if event.Status != nil && event.Status.Status == codersdk.ChatStatusWaiting {
-				return nil
-			}
-		case codersdk.ChatStreamEventTypeError:
-			if event.Error != nil {
-				return xerrors.Errorf("probe chat failed: %s", event.Error.Message)
-			}
-		}
-	}
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
-	return xerrors.New("probe chat stream ended before waiting status")
-}
-
-func archiveScaletestProbeChat(ctx context.Context, client chatClient, logger slog.Logger, chatID uuid.UUID) {
-	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), scaletestAIProviderArchiveTimeout)
-	defer cancel()
-
-	archived := true
-	if err := client.UpdateChat(cleanupCtx, chatID, codersdk.UpdateChatRequest{Archived: &archived}); err != nil {
-		logger.Warn(ctx, "failed to archive mock LLM provider probe chat", slog.Error(err))
-	}
 }
 
 func ensureScaletestChatModelConfig(ctx context.Context, client chatModelConfigClient, logger slog.Logger, provider codersdk.AIProvider) (uuid.UUID, error) {

--- a/scaletest/chat/provider.go
+++ b/scaletest/chat/provider.go
@@ -3,65 +3,168 @@ package chat
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/retry"
 )
 
 const (
-	scaletestProviderType        = "openai-compat"
-	scaletestProviderDisplayName = "Scaletest LLM Mock"
-	scaletestModelName           = "scaletest-model"
-	scaletestModelDisplayName    = "Scaletest Model"
+	scaletestAIProviderType           = codersdk.AIProviderTypeOpenAICompat
+	scaletestAIProviderName           = "coder-scaletest-mock"
+	scaletestAIProviderDisplayName    = "Scaletest LLM Mock"
+	scaletestAIProviderAPIKey         = "coder-scaletest"
+	scaletestModelName                = "scaletest-model"
+	scaletestModelDisplayName         = "Scaletest Model"
+	scaletestModelContextLimit        = int64(4096)
+	scaletestAIProviderProbeWait      = 15 * time.Second
+	scaletestAIProviderProbePeriod    = 500 * time.Millisecond
+	scaletestAIProviderArchiveTimeout = 5 * time.Second
+
+	scaletestProviderReloadProbePrompt = "Reply with one short sentence."
 )
 
-type scaletestProviderAction string
+type scaletestAIProviderAction string
 
 const (
-	scaletestProviderActionCreated scaletestProviderAction = "created"
-	scaletestProviderActionUpdated scaletestProviderAction = "updated"
-	scaletestProviderActionReused  scaletestProviderAction = "reused"
+	scaletestAIProviderActionCreated scaletestAIProviderAction = "created"
+	scaletestAIProviderActionUpdated scaletestAIProviderAction = "updated"
+	scaletestAIProviderActionReused  scaletestAIProviderAction = "reused"
 )
 
-// EnsureScaletestModelConfig bootstraps the shared chat provider and model
+// EnsureScaletestModelConfig bootstraps the shared AI provider and model
 // config used by chat scaletests.
-func EnsureScaletestModelConfig(ctx context.Context, client *codersdk.ExperimentalClient, logger slog.Logger, llmMockURL string) (uuid.UUID, error) {
+func EnsureScaletestModelConfig(ctx context.Context, client *codersdk.Client, logger slog.Logger, llmMockURL string, organizationID uuid.UUID, workspaceID uuid.UUID) (uuid.UUID, error) {
+	expClient := codersdk.NewExperimentalClient(client)
+
 	logger.Info(ctx, "bootstrapping mock LLM provider", slog.F("llm_mock_url", llmMockURL))
 
-	provider, providerAction, err := ensureScaletestProvider(ctx, client, llmMockURL)
+	provider, providerAction, err := ensureScaletestAIProvider(ctx, expClient, llmMockURL)
 	if err != nil {
 		return uuid.Nil, err
 	}
 
 	switch providerAction {
-	case scaletestProviderActionCreated:
+	case scaletestAIProviderActionCreated:
 		logger.Info(ctx, "created mock LLM provider",
-			slog.F("provider_type", scaletestProviderType),
-			slog.F("llm_mock_url", llmMockURL),
-		)
-	case scaletestProviderActionUpdated:
-		logger.Info(ctx, "updated mock LLM provider",
-			slog.F("provider_type", scaletestProviderType),
+			slog.F("provider_name", provider.Name),
 			slog.F("provider_id", provider.ID),
 			slog.F("llm_mock_url", llmMockURL),
 		)
-	case scaletestProviderActionReused:
+	case scaletestAIProviderActionUpdated:
+		logger.Info(ctx, "updated mock LLM provider",
+			slog.F("provider_name", provider.Name),
+			slog.F("provider_id", provider.ID),
+			slog.F("llm_mock_url", llmMockURL),
+		)
+	case scaletestAIProviderActionReused:
 		logger.Info(ctx, "reusing mock LLM provider",
-			slog.F("provider_type", scaletestProviderType),
+			slog.F("provider_name", provider.Name),
 			slog.F("provider_id", provider.ID),
 		)
 	}
 
+	modelConfigID, err := ensureScaletestChatModelConfig(ctx, expClient, logger, provider)
+	if err != nil {
+		return uuid.Nil, err
+	}
+
+	if providerAction != scaletestAIProviderActionReused {
+		if err := waitForScaletestProviderReload(ctx, expClient, logger, modelConfigID, organizationID, workspaceID); err != nil {
+			return uuid.Nil, xerrors.Errorf("wait for mock LLM provider reload: %w", err)
+		}
+	}
+
+	return modelConfigID, nil
+}
+
+func waitForScaletestProviderReload(ctx context.Context, client chatClient, logger slog.Logger, modelConfigID uuid.UUID, organizationID uuid.UUID, workspaceID uuid.UUID) error {
+	logger.Info(ctx, "waiting for mock LLM provider reload", slog.F("provider_name", scaletestAIProviderName))
+	waitCtx, cancel := context.WithTimeout(ctx, scaletestAIProviderProbeWait)
+	defer cancel()
+
+	var lastErr error
+	for r := retry.New(scaletestAIProviderProbePeriod, scaletestAIProviderProbePeriod); r.Wait(waitCtx); {
+		if err := runScaletestProviderReloadProbe(waitCtx, client, logger, modelConfigID, organizationID, workspaceID); err != nil {
+			lastErr = err
+			logger.Debug(ctx, "mock LLM provider probe failed", slog.Error(err))
+			continue
+		}
+		return nil
+	}
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if lastErr != nil {
+		return xerrors.Errorf("timed out waiting for mock LLM provider reload: %w", lastErr)
+	}
+	return xerrors.New("timed out waiting for mock LLM provider reload")
+}
+
+func runScaletestProviderReloadProbe(ctx context.Context, client chatClient, logger slog.Logger, modelConfigID uuid.UUID, organizationID uuid.UUID, workspaceID uuid.UUID) error {
+	chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
+		OrganizationID: organizationID,
+		WorkspaceID:    &workspaceID,
+		ModelConfigID:  &modelConfigID,
+		Content: []codersdk.ChatInputPart{{
+			Type: codersdk.ChatInputPartTypeText,
+			Text: scaletestProviderReloadProbePrompt,
+		}},
+	})
+	if err != nil {
+		return xerrors.Errorf("create probe chat: %w", err)
+	}
+	defer archiveScaletestProbeChat(ctx, client, logger, chat.ID)
+
+	events, closer, err := client.StreamChat(ctx, chat.ID, nil)
+	if err != nil {
+		return xerrors.Errorf("stream probe chat: %w", err)
+	}
+	defer closer.Close()
+
+	for event := range events {
+		switch event.Type {
+		case codersdk.ChatStreamEventTypeStatus:
+			if event.Status != nil && event.Status.Status == codersdk.ChatStatusWaiting {
+				return nil
+			}
+		case codersdk.ChatStreamEventTypeError:
+			if event.Error != nil {
+				return xerrors.Errorf("probe chat failed: %s", event.Error.Message)
+			}
+		}
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return xerrors.New("probe chat stream ended before waiting status")
+}
+
+func archiveScaletestProbeChat(ctx context.Context, client chatClient, logger slog.Logger, chatID uuid.UUID) {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), scaletestAIProviderArchiveTimeout)
+	defer cancel()
+
+	archived := true
+	if err := client.UpdateChat(cleanupCtx, chatID, codersdk.UpdateChatRequest{Archived: &archived}); err != nil {
+		logger.Warn(ctx, "failed to archive mock LLM provider probe chat", slog.Error(err))
+	}
+}
+
+func ensureScaletestChatModelConfig(ctx context.Context, client chatModelConfigClient, logger slog.Logger, provider codersdk.AIProvider) (uuid.UUID, error) {
 	modelConfigs, err := client.ListChatModelConfigs(ctx)
 	if err != nil {
 		return uuid.Nil, xerrors.Errorf("list chat model configs: %w", err)
 	}
 
 	for i := range modelConfigs {
-		if modelConfigs[i].Provider != provider.Provider || modelConfigs[i].Model != scaletestModelName {
+		matchesProvider := modelConfigs[i].AIProviderID != nil && *modelConfigs[i].AIProviderID == provider.ID
+		matchesModel := modelConfigs[i].Model == scaletestModelName
+		if !matchesProvider || !matchesModel {
 			continue
 		}
 		if !modelConfigs[i].Enabled {
@@ -74,9 +177,9 @@ func EnsureScaletestModelConfig(ctx context.Context, client *codersdk.Experiment
 
 	enabled := true
 	isDefault := false
-	contextLimit := int64(4096)
+	contextLimit := scaletestModelContextLimit
 	created, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
-		Provider:     provider.Provider,
+		AIProviderID: &provider.ID,
 		Model:        scaletestModelName,
 		DisplayName:  scaletestModelDisplayName,
 		Enabled:      &enabled,
@@ -90,59 +193,66 @@ func EnsureScaletestModelConfig(ctx context.Context, client *codersdk.Experiment
 	return created.ID, nil
 }
 
-func ensureScaletestProvider(ctx context.Context, client *codersdk.ExperimentalClient, llmMockURL string) (codersdk.ChatProviderConfig, scaletestProviderAction, error) {
-	enabled := true
-	mockProviderToken := uuid.NewString()
-	created, err := client.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
-		Provider:    scaletestProviderType,
-		DisplayName: scaletestProviderDisplayName,
-		APIKey:      mockProviderToken,
-		BaseURL:     llmMockURL,
-		Enabled:     &enabled,
-	})
-	if err == nil {
-		return created, scaletestProviderActionCreated, nil
-	}
-
-	var sdkErr *codersdk.Error
-	if !xerrors.As(err, &sdkErr) || sdkErr.StatusCode() != http.StatusConflict {
-		return codersdk.ChatProviderConfig{}, "", xerrors.Errorf("create scaletest chat provider: %w", err)
-	}
-
-	providers, err := client.ListChatProviders(ctx)
+func ensureScaletestAIProvider(ctx context.Context, client *codersdk.ExperimentalClient, llmMockURL string) (codersdk.AIProvider, scaletestAIProviderAction, error) {
+	provider, err := client.AIProvider(ctx, scaletestAIProviderName)
 	if err != nil {
-		return codersdk.ChatProviderConfig{}, "", xerrors.Errorf("list chat providers: %w", err)
-	}
+		var sdkErr *codersdk.Error
+		if !xerrors.As(err, &sdkErr) || sdkErr.StatusCode() != http.StatusNotFound {
+			return codersdk.AIProvider{}, "", xerrors.Errorf("look up scaletest AI provider: %w", err)
+		}
 
-	var existing *codersdk.ChatProviderConfig
-	for i := range providers {
-		if providers[i].Provider == scaletestProviderType {
-			existing = &providers[i]
-			break
+		created, err := client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+			Type:        scaletestAIProviderType,
+			Name:        scaletestAIProviderName,
+			DisplayName: scaletestAIProviderDisplayName,
+			Enabled:     true,
+			BaseURL:     llmMockURL,
+			APIKeys:     []string{scaletestAIProviderAPIKey},
+		})
+		if err == nil {
+			return created, scaletestAIProviderActionCreated, nil
+		}
+
+		sdkErr = nil
+		if !xerrors.As(err, &sdkErr) || sdkErr.StatusCode() != http.StatusConflict {
+			return codersdk.AIProvider{}, "", xerrors.Errorf("create scaletest AI provider: %w", err)
+		}
+
+		provider, err = client.AIProvider(ctx, scaletestAIProviderName)
+		if err != nil {
+			return codersdk.AIProvider{}, "", xerrors.Errorf("look up scaletest AI provider after conflict: %w", err)
 		}
 	}
-	if existing == nil {
-		return codersdk.ChatProviderConfig{}, "", xerrors.Errorf("find existing %s provider after conflict: not found", scaletestProviderType)
+
+	if provider.Type != scaletestAIProviderType {
+		return codersdk.AIProvider{}, "", xerrors.Errorf("refusing to use scaletest AI provider %s with type %q", provider.ID, provider.Type)
 	}
-	if existing.DisplayName != scaletestProviderDisplayName {
-		return codersdk.ChatProviderConfig{}, "", xerrors.Errorf("refusing to overwrite existing %s provider %s with display name %q", scaletestProviderType, existing.ID, existing.DisplayName)
+	if provider.DisplayName != scaletestAIProviderDisplayName {
+		return codersdk.AIProvider{}, "", xerrors.Errorf("refusing to use scaletest AI provider %s with display name %q", provider.ID, provider.DisplayName)
+	}
+	if !provider.Enabled {
+		return codersdk.AIProvider{}, "", xerrors.Errorf("existing scaletest AI provider %s is disabled; re-enable or delete it before running scaletests", provider.ID)
 	}
 
-	if !existing.Enabled {
-		return codersdk.ChatProviderConfig{}, "", xerrors.Errorf("existing scaletest chat provider %s is disabled; re-enable or delete it before running scaletests", existing.ID)
+	var update codersdk.UpdateAIProviderRequest
+	needsUpdate := false
+	if provider.BaseURL != llmMockURL {
+		update.BaseURL = &llmMockURL
+		needsUpdate = true
 	}
-	if existing.BaseURL == llmMockURL {
-		return *existing, scaletestProviderActionReused, nil
+	if len(provider.APIKeys) == 0 {
+		apiKey := scaletestAIProviderAPIKey
+		apiKeys := []codersdk.AIProviderKeyMutation{{APIKey: &apiKey}}
+		update.APIKeys = &apiKeys
+		needsUpdate = true
+	}
+	if !needsUpdate {
+		return provider, scaletestAIProviderActionReused, nil
 	}
 
-	updated, err := client.UpdateChatProvider(ctx, existing.ID, codersdk.UpdateChatProviderConfigRequest{
-		DisplayName: scaletestProviderDisplayName,
-		APIKey:      &mockProviderToken,
-		BaseURL:     &llmMockURL,
-		Enabled:     &enabled,
-	})
+	updated, err := client.UpdateAIProvider(ctx, scaletestAIProviderName, update)
 	if err != nil {
-		return codersdk.ChatProviderConfig{}, "", xerrors.Errorf("update scaletest chat provider: %w", err)
+		return codersdk.AIProvider{}, "", xerrors.Errorf("update scaletest AI provider: %w", err)
 	}
-	return updated, scaletestProviderActionUpdated, nil
+	return updated, scaletestAIProviderActionUpdated, nil
 }

--- a/scaletest/chat/run.go
+++ b/scaletest/chat/run.go
@@ -108,15 +108,18 @@ func (r *Runner) Run(ctx context.Context, id string, logs io.Writer) error {
 	r.resetConversation(time.Now(), markTurnStartReady)
 
 	createStartedAt := time.Now()
-	chat, err := r.client.CreateChat(ctx, codersdk.CreateChatRequest{
+	createReq := codersdk.CreateChatRequest{
 		OrganizationID: r.cfg.OrganizationID,
-		WorkspaceID:    &workspaceID,
 		ModelConfigID:  &modelConfigID,
 		Content: []codersdk.ChatInputPart{{
 			Type: codersdk.ChatInputPartTypeText,
 			Text: r.cfg.Prompt,
 		}},
-	})
+	}
+	if workspaceID != uuid.Nil {
+		createReq.WorkspaceID = &workspaceID
+	}
+	chat, err := r.client.CreateChat(ctx, createReq)
 	if err != nil {
 		r.result.failureStage = failureStageCreateChat
 		r.cfg.Metrics.ChatStageFailuresTotal.WithLabelValues(r.result.failureStage).Inc()

--- a/scaletest/chat/run.go
+++ b/scaletest/chat/run.go
@@ -54,7 +54,7 @@ var (
 
 func NewRunner(client *codersdk.Client, cfg Config) *Runner {
 	return &Runner{
-		client: newChatClient(client),
+		client: codersdk.NewExperimentalClient(client),
 		cfg:    cfg,
 	}
 }


### PR DESCRIPTION
`coder exp scaletest chat` now bootstraps its mock LLM using the, post-gateway unification, AI provider API instead of the removed experimental chat-provider API, and creates or reuses a chat model config linked to that provider. When the mock provider is created or updated, the command waits a flat, hidden `--provider-propagation-wait` (default 15s) before starting the scale run, since each coderd replica caches provider config with a 10s TTL and only expiry guarantees every replica sees the change. The command also runs without any scaletest workspaces, creating chats with no workspace context. The integration test covers the CLI path against `llmmock` with a near-zero propagation wait, verifies the provider/model config setup, and asserts the generated chat records user and assistant messages.



Relates to CODAGT-307

Relates to GRU-48
