### PR TITLE
test: data race for TestAIGatewayKeysTableConstraints - shadowed error

### DIFF
--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -14828,7 +14828,7 @@ func TestAIGatewayKeysTableConstraints(t *testing.T) {
 
 			ctx := testutil.Context(t, testutil.WaitShort)
 
-			_, err = db.InsertAIGatewayKey(ctx, tc.params)
+			_, err := db.InsertAIGatewayKey(ctx, tc.params)
 			require.Error(t, err)
 			requireAIGatewayKeysViolation(t, err, tc.expectUniqueErr, tc.expectCheckErr)
 		})


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/25979

error is shadowed and shared by parallel subtests