### PR TITLE
ci: extend flake-go timeout and bump test-count to 35

### DIFF
--- a/.github/workflows/flake-go.yaml
+++ b/.github/workflows/flake-go.yaml
@@ -24,7 +24,10 @@ jobs:
   flake_go:
     name: Flake Check
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-4' || 'ubuntu-latest' }}
-    timeout-minutes: 20
+    # This timeout must be greater than the Go test timeout set in `make test`
+    # (-timeout 20m) so we receive a goroutine trace before the runner kills
+    # the job. Mirrors the test-go-pg job in ci.yaml.
+    timeout-minutes: 25
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
@@ -75,7 +78,7 @@ jobs:
           postgres-version: "13"
           test-parallelism-packages: "4"
           test-parallelism-tests: "16"
-          test-count: "25"
+          test-count: "35"
           test-packages: ${{ fromJSON(steps.selector.outputs.matrix).include[0].package }}
           run-regex: ${{ fromJSON(steps.selector.outputs.matrix).include[0].run_regex }}
           test-shuffle: "on"


### PR DESCRIPTION
Two changes to make the `flake-go` workflow produce better signal when something hangs or flakes at low rates.

**Job timeout (20m → 25m).** The Go-level `-timeout 20m` baked into `make test` (`Makefile:1428`) currently raced the runner's 20m hard-kill, so a hanging test got SIGTERM'd by Actions instead of SIGQUIT'd by Go, and we never got the goroutine dump. Bumping the workflow job to 25m mirrors the layering already used by `test-go-pg` in `ci.yaml:409` and gives Go's timeout the 5m head start it expects.

**Test count (25 → 35).** Catches lower-frequency flakes that 25 attempts miss too often. For a 5% per-run flake, detection probability goes from ~72% at n=25 to ~83% at n=35; for 1–2% flakes the lift is larger. The longest successful flake-go run to date was 11m49s at n=25, so n=35 should peak around ~16–17m and stay well inside the new 25m budget.
