### PR TITLE
test: batch 05 of refactoring CLI tests not to use PTY

### DIFF
--- a/enterprise/cli/create_test.go
+++ b/enterprise/cli/create_test.go
@@ -31,8 +31,8 @@ import (
 	"github.com/coder/coder/v2/enterprise/coderd/prebuilds"
 	"github.com/coder/coder/v2/provisioner/echo"
 	"github.com/coder/coder/v2/provisionersdk/proto"
-	"github.com/coder/coder/v2/pty/ptytest"
 	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/coder/v2/testutil/expecter"
 	"github.com/coder/quartz"
 )
 
@@ -124,7 +124,6 @@ func TestEnterpriseCreate(t *testing.T) {
 		}
 		inv, root := clitest.New(t, args...)
 		clitest.SetupConfig(t, member, root)
-		_ = ptytest.New(t).Attach(inv)
 		err := inv.Run()
 		require.NoError(t, err)
 
@@ -155,7 +154,6 @@ func TestEnterpriseCreate(t *testing.T) {
 		}
 		inv, root := clitest.New(t, args...)
 		clitest.SetupConfig(t, member, root)
-		_ = ptytest.New(t).Attach(inv)
 		err := inv.Run()
 		require.Error(t, err, "expected error due to ambiguous template name")
 		require.ErrorContains(t, err, "multiple templates found")
@@ -181,7 +179,6 @@ func TestEnterpriseCreate(t *testing.T) {
 		}
 		inv, root := clitest.New(t, args...)
 		clitest.SetupConfig(t, member, root)
-		_ = ptytest.New(t).Attach(inv)
 		err := inv.Run()
 		require.NoError(t, err)
 
@@ -216,7 +213,6 @@ func TestEnterpriseCreate(t *testing.T) {
 		}
 		inv, root := clitest.New(t, args...)
 		clitest.SetupConfig(t, newOwner, root)
-		_ = ptytest.New(t).Attach(inv)
 		err := inv.Run()
 		require.NoError(t, err)
 
@@ -247,7 +243,6 @@ func TestEnterpriseCreate(t *testing.T) {
 		}
 		inv, root := clitest.New(t, args...)
 		clitest.SetupConfig(t, member, root)
-		_ = ptytest.New(t).Attach(inv)
 		err := inv.Run()
 		require.Error(t, err)
 		// The error message should indicate the flag to fix the issue.
@@ -449,17 +444,15 @@ func TestEnterpriseCreateWithPreset(t *testing.T) {
 		workspaceName := "my-workspace"
 		inv, root := clitest.New(t, "create", workspaceName, "--template", template.Name, "-y", "--preset", preset.Name)
 		clitest.SetupConfig(t, member, root)
-		pty := ptytest.New(t).Attach(inv)
-		inv.Stdout = pty.Output()
-		inv.Stderr = pty.Output()
+		stdout := expecter.NewAttachedToInvocation(t, inv)
 		err = inv.Run()
 		require.NoError(t, err)
 
 		// Should: display the selected preset as well as its parameters
 		presetName := fmt.Sprintf("Preset '%s' applied:", preset.Name)
-		pty.ExpectMatch(presetName)
-		pty.ExpectMatch(fmt.Sprintf("%s: '%s'", firstParameterName, secondOptionalParameterValue))
-		pty.ExpectMatch(fmt.Sprintf("%s: '%s'", thirdParameterName, thirdParameterValue))
+		stdout.ExpectMatchContext(ctx, presetName)
+		stdout.ExpectMatchContext(ctx, fmt.Sprintf("%s: '%s'", firstParameterName, secondOptionalParameterValue))
+		stdout.ExpectMatchContext(ctx, fmt.Sprintf("%s: '%s'", thirdParameterName, thirdParameterValue))
 
 		// Verify if the new workspace uses expected parameters.
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
@@ -565,12 +558,10 @@ func TestEnterpriseCreateWithPreset(t *testing.T) {
 			"--parameter", fmt.Sprintf("%s=%s", firstParameterName, firstParameterValue),
 			"--parameter", fmt.Sprintf("%s=%s", thirdParameterName, thirdParameterValue))
 		clitest.SetupConfig(t, member, root)
-		pty := ptytest.New(t).Attach(inv)
-		inv.Stdout = pty.Output()
-		inv.Stderr = pty.Output()
+		stdout := expecter.NewAttachedToInvocation(t, inv)
 		err = inv.Run()
 		require.NoError(t, err)
-		pty.ExpectMatch("No preset applied.")
+		stdout.ExpectMatchContext(ctx, "No preset applied.")
 
 		// Verify if the new workspace uses expected parameters.
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)

--- a/enterprise/cli/externalworkspaces_test.go
+++ b/enterprise/cli/externalworkspaces_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/coder/coder/v2/enterprise/coderd/license"
 	"github.com/coder/coder/v2/provisioner/echo"
 	"github.com/coder/coder/v2/provisionersdk/proto"
-	"github.com/coder/coder/v2/pty/ptytest"
 	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/coder/v2/testutil/expecter"
 )
 
 // completeWithExternalAgent creates a template version with an external agent resource
@@ -82,6 +82,7 @@ func TestExternalWorkspaces(t *testing.T) {
 
 	t.Run("Create", func(t *testing.T) {
 		t.Parallel()
+		logger := testutil.Logger(t)
 		client, owner := coderdenttest.New(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				IncludeProvisionerDaemon: true,
@@ -106,7 +107,9 @@ func TestExternalWorkspaces(t *testing.T) {
 		inv, root := newCLI(t, args...)
 		clitest.SetupConfig(t, member, root)
 		doneChan := make(chan struct{})
-		pty := ptytest.New(t).Attach(inv)
+		stdout := expecter.NewAttachedToInvocation(t, inv)
+		stdin := testutil.NewWriterAttachedToInvocation(t, logger.Named("stdin"), inv)
+		ctx := testutil.Context(t, testutil.WaitLong)
 		go func() {
 			defer close(doneChan)
 			err := inv.Run()
@@ -114,16 +117,15 @@ func TestExternalWorkspaces(t *testing.T) {
 		}()
 
 		// Expect the workspace creation confirmation
-		pty.ExpectMatch("coder_external_agent.main")
-		pty.ExpectMatch("external-agent (linux, amd64)")
-		pty.ExpectMatch("Confirm create")
-		pty.WriteLine("yes")
+		stdout.ExpectMatchContext(ctx, "coder_external_agent.main")
+		stdout.ExpectMatchContext(ctx, "external-agent (linux, amd64)")
+		stdout.ExpectMatchContext(ctx, "Confirm create")
+		stdin.WriteLine("yes")
 
 		// Expect the external agent instructions
-		pty.ExpectMatch("Please run the following command to attach external agent")
-		pty.ExpectRegexMatch("curl -fsSL .* | CODER_AGENT_TOKEN=.* sh")
+		stdout.ExpectMatchContext(ctx, "Please run the following command to attach external agent")
+		stdout.ExpectRegexMatchContext(ctx, "curl -fsSL .* | CODER_AGENT_TOKEN=.* sh")
 
-		ctx := testutil.Context(t, testutil.WaitLong)
 		testutil.TryReceive(ctx, t, doneChan)
 
 		// Verify the workspace was created
@@ -217,7 +219,7 @@ func TestExternalWorkspaces(t *testing.T) {
 		}
 		inv, root := newCLI(t, args...)
 		clitest.SetupConfig(t, member, root)
-		pty := ptytest.New(t).Attach(inv)
+		stdout := expecter.NewAttachedToInvocation(t, inv)
 
 		ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancelFunc()
@@ -227,8 +229,8 @@ func TestExternalWorkspaces(t *testing.T) {
 			assert.NoError(t, errC)
 			close(done)
 		}()
-		pty.ExpectMatch(ws.Name)
-		pty.ExpectMatch(template.Name)
+		stdout.ExpectMatchContext(ctx, ws.Name)
+		stdout.ExpectMatchContext(ctx, template.Name)
 		cancelFunc()
 		<-done
 	})
@@ -296,7 +298,7 @@ func TestExternalWorkspaces(t *testing.T) {
 		}
 		inv, root := newCLI(t, args...)
 		clitest.SetupConfig(t, member, root)
-		pty := ptytest.New(t).Attach(inv)
+		stdout := expecter.NewAttachedToInvocation(t, inv)
 
 		ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancelFunc()
@@ -306,8 +308,8 @@ func TestExternalWorkspaces(t *testing.T) {
 			assert.NoError(t, errC)
 			close(done)
 		}()
-		pty.ExpectMatch("No workspaces found!")
-		pty.ExpectMatch("coder external-workspaces create")
+		stdout.ExpectMatchContext(ctx, "No workspaces found!")
+		stdout.ExpectMatchContext(ctx, "coder external-workspaces create")
 		cancelFunc()
 		<-done
 	})
@@ -340,7 +342,7 @@ func TestExternalWorkspaces(t *testing.T) {
 		}
 		inv, root := newCLI(t, args...)
 		clitest.SetupConfig(t, member, root)
-		pty := ptytest.New(t).Attach(inv)
+		stdout := expecter.NewAttachedToInvocation(t, inv)
 
 		ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancelFunc()
@@ -350,8 +352,8 @@ func TestExternalWorkspaces(t *testing.T) {
 			assert.NoError(t, errC)
 			close(done)
 		}()
-		pty.ExpectMatch("Please run the following command to attach external agent to the workspace")
-		pty.ExpectRegexMatch("curl -fsSL .* | CODER_AGENT_TOKEN=.* sh")
+		stdout.ExpectMatchContext(ctx, "Please run the following command to attach external agent to the workspace")
+		stdout.ExpectRegexMatchContext(ctx, "curl -fsSL .* | CODER_AGENT_TOKEN=.* sh")
 		cancelFunc()
 
 		ctx = testutil.Context(t, testutil.WaitLong)
@@ -492,7 +494,8 @@ func TestExternalWorkspaces(t *testing.T) {
 		inv, root := newCLI(t, args...)
 		clitest.SetupConfig(t, member, root)
 		doneChan := make(chan struct{})
-		pty := ptytest.New(t).Attach(inv)
+		stdout := expecter.NewAttachedToInvocation(t, inv)
+		ctx := testutil.Context(t, testutil.WaitLong)
 		go func() {
 			defer close(doneChan)
 			err := inv.Run()
@@ -500,14 +503,13 @@ func TestExternalWorkspaces(t *testing.T) {
 		}()
 
 		// Expect the workspace creation confirmation
-		pty.ExpectMatch("coder_external_agent.main")
-		pty.ExpectMatch("external-agent (linux, amd64)")
+		stdout.ExpectMatchContext(ctx, "coder_external_agent.main")
+		stdout.ExpectMatchContext(ctx, "external-agent (linux, amd64)")
 
 		// Expect the external agent instructions
-		pty.ExpectMatch("Please run the following command to attach external agent")
-		pty.ExpectRegexMatch("curl -fsSL .* | CODER_AGENT_TOKEN=.* sh")
+		stdout.ExpectMatchContext(ctx, "Please run the following command to attach external agent")
+		stdout.ExpectRegexMatchContext(ctx, "curl -fsSL .* | CODER_AGENT_TOKEN=.* sh")
 
-		ctx := testutil.Context(t, testutil.WaitLong)
 		testutil.TryReceive(ctx, t, doneChan)
 
 		// Verify the workspace was created

--- a/enterprise/cli/features_test.go
+++ b/enterprise/cli/features_test.go
@@ -12,21 +12,23 @@ import (
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
-	"github.com/coder/coder/v2/pty/ptytest"
+	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/coder/v2/testutil/expecter"
 )
 
 func TestFeaturesList(t *testing.T) {
 	t.Parallel()
 	t.Run("Table", func(t *testing.T) {
 		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitMedium)
 		client, admin := coderdenttest.New(t, &coderdenttest.Options{DontAddLicense: true})
 		anotherClient, _ := coderdtest.CreateAnotherUser(t, client, admin.OrganizationID)
 		inv, conf := newCLI(t, "features", "list")
 		clitest.SetupConfig(t, anotherClient, conf)
-		pty := ptytest.New(t).Attach(inv)
+		stdout := expecter.NewAttachedToInvocation(t, inv)
 		clitest.Start(t, inv)
-		pty.ExpectMatch("user_limit")
-		pty.ExpectMatch("not_entitled")
+		stdout.ExpectMatchContext(ctx, "user_limit")
+		stdout.ExpectMatchContext(ctx, "not_entitled")
 	})
 	t.Run("JSON", func(t *testing.T) {
 		t.Parallel()

--- a/enterprise/cli/organization_test.go
+++ b/enterprise/cli/organization_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
 	"github.com/coder/coder/v2/enterprise/coderd/license"
-	"github.com/coder/coder/v2/pty/ptytest"
 	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/coder/v2/testutil/expecter"
 )
 
 func TestCreateOrganizationRoles(t *testing.T) {
@@ -138,13 +138,13 @@ func TestShowOrganizations(t *testing.T) {
 
 		inv, root := clitest.New(t, "organizations", "show", "--only-id", "--org="+first.OrganizationID.String())
 		clitest.SetupConfig(t, client, root)
-		pty := ptytest.New(t).Attach(inv)
+		stdout := expecter.NewAttachedToInvocation(t, inv)
 		errC := make(chan error)
 		go func() {
 			errC <- inv.Run()
 		}()
 		require.NoError(t, <-errC)
-		pty.ExpectMatch(first.OrganizationID.String())
+		stdout.ExpectMatchContext(ctx, first.OrganizationID.String())
 	})
 
 	t.Run("UsingFlag", func(t *testing.T) {
@@ -179,13 +179,13 @@ func TestShowOrganizations(t *testing.T) {
 
 		inv, root := clitest.New(t, "organizations", "show", "selected", "--only-id", "-O=bar")
 		clitest.SetupConfig(t, client, root)
-		pty := ptytest.New(t).Attach(inv)
+		stdout := expecter.NewAttachedToInvocation(t, inv)
 		errC := make(chan error)
 		go func() {
 			errC <- inv.Run()
 		}()
 		require.NoError(t, <-errC)
-		pty.ExpectMatch(orgs["bar"].ID.String())
+		stdout.ExpectMatchContext(ctx, orgs["bar"].ID.String())
 	})
 }
 

--- a/enterprise/cli/prebuilds_test.go
+++ b/enterprise/cli/prebuilds_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
 	"github.com/coder/coder/v2/enterprise/coderd/license"
 	"github.com/coder/coder/v2/provisionersdk/proto"
-	"github.com/coder/coder/v2/pty/ptytest"
 	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/coder/v2/testutil/expecter"
 	"github.com/coder/quartz"
 )
 
@@ -448,7 +448,6 @@ func TestSchedulePrebuilds(t *testing.T) {
 			// When: running the schedule command over a prebuilt workspace
 			inv, root := clitest.New(t, tc.cmdArgs(prebuild.OwnerName+"/"+prebuild.Name)...)
 			clitest.SetupConfig(t, client, root)
-			ptytest.New(t).Attach(inv)
 			doneChan := make(chan struct{})
 			var runErr error
 			go func() {
@@ -480,11 +479,11 @@ func TestSchedulePrebuilds(t *testing.T) {
 			// When: running the schedule command over the claimed workspace
 			inv, root = clitest.New(t, tc.cmdArgs(workspace.OwnerName+"/"+workspace.Name)...)
 			clitest.SetupConfig(t, client, root)
-			pty := ptytest.New(t).Attach(inv)
+			stdout := expecter.NewAttachedToInvocation(t, inv)
 			require.NoError(t, inv.Run())
 
 			// Then: the updated schedule should be shown
-			pty.ExpectMatch(workspace.OwnerName + "/" + workspace.Name)
+			stdout.ExpectMatchContext(ctx, workspace.OwnerName+"/"+workspace.Name)
 		})
 	}
 }

--- a/enterprise/cli/provisionerdaemonstart_test.go
+++ b/enterprise/cli/provisionerdaemonstart_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/coder/coder/v2/enterprise/coderd/license"
 	"github.com/coder/coder/v2/provisionerd/proto"
 	"github.com/coder/coder/v2/provisionersdk"
-	"github.com/coder/coder/v2/pty/ptytest"
 	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/coder/v2/testutil/expecter"
 )
 
 func TestProvisionerDaemon_PSK(t *testing.T) {
@@ -42,12 +42,12 @@ func TestProvisionerDaemon_PSK(t *testing.T) {
 		inv, conf := newCLI(t, "provisionerd", "start", "--psk=provisionersftw", "--name=matt-daemon")
 		err := conf.URL().Write(client.URL.String())
 		require.NoError(t, err)
-		pty := ptytest.New(t).Attach(inv)
+		stdout := expecter.NewAttachedToInvocation(t, inv)
 		ctx, cancel := context.WithTimeout(inv.Context(), testutil.WaitLong)
 		defer cancel()
 		clitest.Start(t, inv)
-		pty.ExpectNoMatchBefore(ctx, "check entitlement", "starting provisioner daemon")
-		pty.ExpectMatchContext(ctx, "matt-daemon")
+		stdout.ExpectNoMatchBefore(ctx, "check entitlement", "starting provisioner daemon")
+		stdout.ExpectMatchContext(ctx, "matt-daemon")
 
 		var daemons []codersdk.ProvisionerDaemon
 		require.Eventually(t, func() bool {
@@ -78,11 +78,11 @@ func TestProvisionerDaemon_PSK(t *testing.T) {
 		anotherClient, _ := coderdtest.CreateAnotherUser(t, client, anotherOrg.ID, rbac.RoleTemplateAdmin())
 		inv, conf := newCLI(t, "provisionerd", "start", "--name", "org-daemon", "--org", anotherOrg.Name)
 		clitest.SetupConfig(t, anotherClient, conf)
-		pty := ptytest.New(t).Attach(inv)
+		stdout := expecter.NewAttachedToInvocation(t, inv)
 		ctx, cancel := context.WithTimeout(inv.Context(), testutil.WaitLong)
 		defer cancel()
 		clitest.Start(t, inv)
-		pty.ExpectMatchContext(ctx, "starting provisioner daemon")
+		stdout.ExpectMatchContext(ctx, "starting provisioner daemon")
 	})
 
 	t.Run("NoUserNoPSK", func(t *testing.T) {
@@ -120,11 +120,11 @@ func TestProvisionerDaemon_SessionToken(t *testing.T) {
 		anotherClient, anotherUser := coderdtest.CreateAnotherUser(t, client, admin.OrganizationID)
 		inv, conf := newCLI(t, "provisionerd", "start", "--tag", "scope=user", "--name", "my-daemon")
 		clitest.SetupConfig(t, anotherClient, conf)
-		pty := ptytest.New(t).Attach(inv)
+		stdout := expecter.NewAttachedToInvocation(t, inv)
 		ctx, cancel := context.WithTimeout(inv.Context(), testutil.WaitLong)
 		defer cancel()
 		clitest.Start(t, inv)
-		pty.ExpectMatchContext(ctx, "starting provisioner daemon")
+		stdout.ExpectMatchContext(ctx, "starting provisioner daemon")
 
 		var daemons []codersdk.ProvisionerDaemon
 		var err error
@@ -155,11 +155,11 @@ func TestProvisionerDaemon_SessionToken(t *testing.T) {
 		anotherClient, anotherUser := coderdtest.CreateAnotherUser(t, client, admin.OrganizationID)
 		inv, conf := newCLI(t, "provisionerd", "start", "--tag", "scope=user", "--tag", "owner="+admin.UserID.String(), "--name", "my-daemon")
 		clitest.SetupConfig(t, anotherClient, conf)
-		pty := ptytest.New(t).Attach(inv)
+		stdout := expecter.NewAttachedToInvocation(t, inv)
 		ctx, cancel := context.WithTimeout(inv.Context(), testutil.WaitLong)
 		defer cancel()
 		clitest.Start(t, inv)
-		pty.ExpectMatchContext(ctx, "starting provisioner daemon")
+		stdout.ExpectMatchContext(ctx, "starting provisioner daemon")
 
 		var daemons []codersdk.ProvisionerDaemon
 		var err error
@@ -191,11 +191,11 @@ func TestProvisionerDaemon_SessionToken(t *testing.T) {
 		anotherClient, _ := coderdtest.CreateAnotherUser(t, client, admin.OrganizationID, rbac.RoleTemplateAdmin())
 		inv, conf := newCLI(t, "provisionerd", "start", "--tag", "scope=organization", "--name", "org-daemon")
 		clitest.SetupConfig(t, anotherClient, conf)
-		pty := ptytest.New(t).Attach(inv)
+		stdout := expecter.NewAttachedToInvocation(t, inv)
 		ctx, cancel := context.WithTimeout(inv.Context(), testutil.WaitLong)
 		defer cancel()
 		clitest.Start(t, inv)
-		pty.ExpectMatchContext(ctx, "starting provisioner daemon")
+		stdout.ExpectMatchContext(ctx, "starting provisioner daemon")
 
 		var daemons []codersdk.ProvisionerDaemon
 		var err error
@@ -227,11 +227,11 @@ func TestProvisionerDaemon_SessionToken(t *testing.T) {
 		anotherClient, anotherUser := coderdtest.CreateAnotherUser(t, client, anotherOrg.ID, rbac.RoleTemplateAdmin())
 		inv, conf := newCLI(t, "provisionerd", "start", "--tag", "scope=user", "--name", "org-daemon", "--org", anotherOrg.ID.String())
 		clitest.SetupConfig(t, anotherClient, conf)
-		pty := ptytest.New(t).Attach(inv)
+		stdout := expecter.NewAttachedToInvocation(t, inv)
 		ctx, cancel := context.WithTimeout(inv.Context(), testutil.WaitLong)
 		defer cancel()
 		clitest.Start(t, inv)
-		pty.ExpectMatchContext(ctx, "starting provisioner daemon")
+		stdout.ExpectMatchContext(ctx, "starting provisioner daemon")
 
 		var daemons []codersdk.ProvisionerDaemon
 		var err error
@@ -275,10 +275,10 @@ func TestProvisionerDaemon_ProvisionerKey(t *testing.T) {
 		inv, conf := newCLI(t, "provisionerd", "start", "--key", res.Key, "--name=matt-daemon")
 		err = conf.URL().Write(client.URL.String())
 		require.NoError(t, err)
-		pty := ptytest.New(t).Attach(inv)
+		stdout := expecter.NewAttachedToInvocation(t, inv)
 		clitest.Start(t, inv)
-		pty.ExpectNoMatchBefore(ctx, "check entitlement", "starting provisioner daemon")
-		pty.ExpectMatchContext(ctx, "matt-daemon")
+		stdout.ExpectNoMatchBefore(ctx, "check entitlement", "starting provisioner daemon")
+		stdout.ExpectMatchContext(ctx, "matt-daemon")
 
 		var daemons []codersdk.ProvisionerDaemon
 		require.Eventually(t, func() bool {
@@ -320,10 +320,10 @@ func TestProvisionerDaemon_ProvisionerKey(t *testing.T) {
 		inv, conf := newCLI(t, "provisionerd", "start", "--key", res.Key, "--name=matt-daemon")
 		err = conf.URL().Write(client.URL.String())
 		require.NoError(t, err)
-		pty := ptytest.New(t).Attach(inv)
+		stdout := expecter.NewAttachedToInvocation(t, inv)
 		clitest.Start(t, inv)
-		pty.ExpectNoMatchBefore(ctx, "check entitlement", "starting provisioner daemon")
-		pty.ExpectMatchContext(ctx, `tags={"tag1":"value1","tag2":"value2"}`)
+		stdout.ExpectNoMatchBefore(ctx, "check entitlement", "starting provisioner daemon")
+		stdout.ExpectMatchContext(ctx, `tags={"tag1":"value1","tag2":"value2"}`)
 
 		var daemons []codersdk.ProvisionerDaemon
 		require.Eventually(t, func() bool {
@@ -436,10 +436,10 @@ func TestProvisionerDaemon_ProvisionerKey(t *testing.T) {
 		inv, conf := newCLI(t, "provisionerd", "start", "--key", res.Key, "--name=matt-daemon")
 		err = conf.URL().Write(client.URL.String())
 		require.NoError(t, err)
-		pty := ptytest.New(t).Attach(inv)
+		stdout := expecter.NewAttachedToInvocation(t, inv)
 		clitest.Start(t, inv)
-		pty.ExpectNoMatchBefore(ctx, "check entitlement", "starting provisioner daemon")
-		pty.ExpectMatchContext(ctx, "matt-daemon")
+		stdout.ExpectNoMatchBefore(ctx, "check entitlement", "starting provisioner daemon")
+		stdout.ExpectMatchContext(ctx, "matt-daemon")
 		var daemons []codersdk.ProvisionerDaemon
 		require.Eventually(t, func() bool {
 			daemons, err = client.OrganizationProvisionerDaemons(ctx, anotherOrg.ID, nil)
@@ -473,13 +473,13 @@ func TestProvisionerDaemon_PrometheusEnabled(t *testing.T) {
 	anotherClient, _ := coderdtest.CreateAnotherUser(t, client, admin.OrganizationID, rbac.RoleTemplateAdmin())
 	inv, conf := newCLI(t, "provisionerd", "start", "--name", "daemon-with-prometheus", "--prometheus-enable", "--prometheus-address", fmt.Sprintf("127.0.0.1:%d", prometheusPort))
 	clitest.SetupConfig(t, anotherClient, conf)
-	pty := ptytest.New(t).Attach(inv)
+	stdout := expecter.NewAttachedToInvocation(t, inv)
 	ctx, cancel := context.WithTimeout(inv.Context(), testutil.WaitLong)
 	defer cancel()
 
 	// Start "provisionerd" command
 	clitest.Start(t, inv)
-	pty.ExpectMatchContext(ctx, "starting provisioner daemon")
+	stdout.ExpectMatchContext(ctx, "starting provisioner daemon")
 
 	var daemons []codersdk.ProvisionerDaemon
 	var err error

--- a/enterprise/cli/proxyserver_test.go
+++ b/enterprise/cli/proxyserver_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/cli/clitest"
-	"github.com/coder/coder/v2/pty/ptytest"
 	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/coder/v2/testutil/expecter"
 )
 
 func Test_ProxyServer_Headers(t *testing.T) {
@@ -50,13 +50,9 @@ func Test_ProxyServer_Headers(t *testing.T) {
 		"--header", fmt.Sprintf("%s=%s", headerName1, headerVal1),
 		"--header-command", fmt.Sprintf("printf %s=%s", headerName2, headerVal2),
 	)
-	pty := ptytest.New(t)
-	inv.Stdout = pty.Output()
 	err := inv.Run()
 	require.Error(t, err)
 	require.ErrorContains(t, err, "unexpected status code 418")
-	require.NoError(t, pty.Close())
-
 	assert.EqualValues(t, 1, called.Load())
 }
 
@@ -102,7 +98,7 @@ func TestWorkspaceProxy_Server_PrometheusEnabled(t *testing.T) {
 		"--prometheus-enable",
 		"--prometheus-address", fmt.Sprintf("127.0.0.1:%d", prometheusPort),
 	)
-	pty := ptytest.New(t).Attach(inv)
+	stdout := expecter.NewAttachedToInvocation(t, inv)
 
 	ctx, cancel := context.WithTimeout(inv.Context(), testutil.WaitLong)
 	defer cancel()
@@ -111,7 +107,7 @@ func TestWorkspaceProxy_Server_PrometheusEnabled(t *testing.T) {
 	clitest.StartWithAssert(t, inv, func(t *testing.T, err error) {
 		// actually no assertions are needed as the test verifies only Prometheus endpoint
 	})
-	pty.ExpectMatchContext(ctx, "Started HTTP listener at")
+	stdout.ExpectMatchContext(ctx, "Started HTTP listener at")
 
 	// Fetch metrics from Prometheus endpoint
 	var res *http.Response


### PR DESCRIPTION
Part of [coder/internal#1400](https://github.com/coder/internal/issues/1400)

Batch of refactored CLI tests to avoid creating PTYs.