### PR TITLE
chore(site): enforce sentence-case UI labels in AgentsPage via Biome plugin

### DIFF
--- a/site/AGENTS.md
+++ b/site/AGENTS.md
@@ -117,6 +117,15 @@ Debug logs and pprof dumps use the same job name and commit SHA convention.
 - For JSX boolean props that are `true`, use the shorthand form
   (`<Foo prop />`) instead of `<Foo prop={true} />`. The two are
   equivalent; the shorthand is the React convention and reduces noise.
+- Use **sentence case** for user-facing UI labels: capitalize only the
+  first word and proper nouns (`Personal instructions`, `API key`), not
+  Title Case (`Personal Instructions`, `API Key`). Under
+  `src/pages/AgentsPage`, a Biome GritQL plugin
+  (`biome-rules/use-sentence-case-labels.grit`) enforces this for
+  `label`/`title`/`sectionLabel`/`aria-label` attributes and `label:`/
+  `title:` object properties. It cannot see labels rendered as JSX text
+  or built from variables, so those still need a human eye. Add genuine
+  proper nouns to the allowlist in that file.
 - **Avoid unnecessary indirection.** Inline single-use module-level
   constants, single-use aliases, and one-line helpers that just return a
   single field at the call site. Do not create wrapper hooks that only

--- a/site/biome-rules/use-sentence-case-labels.grit
+++ b/site/biome-rules/use-sentence-case-labels.grit
@@ -1,0 +1,35 @@
+// Enforce sentence case for user-facing UI labels.
+//
+// Flags Title Case in label-bearing JSX attributes (label, title,
+// sectionLabel, aria-label) and object-property labels (label:, title:,
+// sectionLabel:). Sentence case capitalizes only the first word and
+// proper nouns: "Personal instructions", not "Personal Instructions".
+//
+// Heuristic: a space followed by a capitalized word ([A-Z][a-z]). This
+// also catches acronym-prefixed Title Case like "MCP Servers". Genuine
+// multi-word proper nouns (e.g. "VS Code") are false positives and must
+// be added to the allowlist below.
+//
+// Diagnostic-only: Biome GritQL plugins cannot autofix yet.
+language js
+
+or {
+	JsxAttribute(name = $name) as $node where {
+		$name <: r"^(?:label|title|sectionLabel|aria-label)$",
+		$node <: contains JsxString() as $value
+	},
+	JsPropertyObjectMember() as $node where {
+		$node <: contains JsLiteralMemberName() as $key,
+		$key <: r"^(?:label|title|sectionLabel)$",
+		$node <: contains JsStringLiteralExpression() as $value
+	}
+} where {
+	$value <: r".* [A-Z][a-z].*",
+	// Allowlist: proper nouns / product names that are correctly multi-cap.
+	not $value <: r".*(?:VS Code|Coder Agents|GitHub Actions|JetBrains Fleet|Cmd/Ctrl).*",
+	register_diagnostic(
+		span = $value,
+		message = "Use sentence case for UI labels (e.g. \"Personal instructions\"), not Title Case. If this is a proper noun, add it to the allowlist in use-sentence-case-labels.grit.",
+		severity = "warn"
+	)
+}

--- a/site/biome.jsonc
+++ b/site/biome.jsonc
@@ -3,5 +3,16 @@
 	"files": {
 		"includes": ["!e2e/**/*Generated.ts", "!scripts/*.mjs"]
 	},
+	"overrides": [
+		{
+			"includes": [
+				"src/pages/AgentsPage/**/*.ts",
+				"src/pages/AgentsPage/**/*.tsx",
+				"!**/*.stories.tsx",
+				"!**/*.test.tsx"
+			],
+			"plugins": ["./biome-rules/use-sentence-case-labels.grit"]
+		}
+	],
 	"$schema": "./node_modules/@biomejs/biome/configuration_schema.json"
 }

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ProviderForm.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ProviderForm.tsx
@@ -256,7 +256,7 @@ export const ProviderForm: FC<ProviderFormProps> = ({
 				>
 					<div className="space-y-5">
 						<ProviderField
-							label="API Key"
+							label="API key"
 							htmlFor={apiKeyInputId}
 							required={requiresAPIKey}
 							description={apiKeyDescription}

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -67,25 +67,25 @@ const TRANSPORT_OPTIONS = [
 const AUTH_TYPE_OPTIONS = [
 	{ value: "none", label: "None" },
 	{ value: "oauth2", label: "OAuth2" },
-	{ value: "api_key", label: "API Key" },
-	{ value: "custom_headers", label: "Custom Headers" },
-	{ value: "user_oidc", label: "User OIDC Identity" },
+	{ value: "api_key", label: "API key" },
+	{ value: "custom_headers", label: "Custom headers" },
+	{ value: "user_oidc", label: "User OIDC identity" },
 ] as const;
 
 const AVAILABILITY_OPTIONS = [
 	{
 		value: "force_on",
-		label: "Force On",
+		label: "Force on",
 		description: "Always injected into every conversation.",
 	},
 	{
 		value: "default_on",
-		label: "Default On",
+		label: "Default on",
 		description: "Pre-selected but users can opt out.",
 	},
 	{
 		value: "default_off",
-		label: "Default Off",
+		label: "Default off",
 		description: "Available but users must opt in.",
 	},
 ] as const;
@@ -784,7 +784,7 @@ const ServerForm: FC<ServerFormProps> = ({
 												disabled={isDisabled}
 											/>
 										</Field>
-										<Field label="API Key" htmlFor={`${formId}-apikey-value`}>
+										<Field label="API key" htmlFor={`${formId}-apikey-value`}>
 											<Input
 												id={`${formId}-apikey-value`}
 												className="h-9 font-mono text-[13px] [-webkit-text-security:disc]"


### PR DESCRIPTION
## Summary

[#25941](https://github.com/coder/coder/pull/25941) converted AgentsPage UI labels to sentence case by hand. Nothing stops Title Case from creeping back in. This adds a lint **gate** so the linter catches it instead of reviewers.

It's a Biome GritQL plugin scoped to `src/pages/AgentsPage` (non-test files) that flags Title Case in label-bearing JSX attributes (`label`/`title`/`sectionLabel`/`aria-label`) and `label:`/`title:` object properties. It rides the existing `biome lint`, so there's no new lint step or dependency, and it shows up in-editor too.

> [!NOTE]
> This is a deliberate **gate, not full coverage.** It catches the attribute/property-shaped labels (~75% of what #25941 fixed) with near-zero false positives. Labels rendered as JSX text (`<label>API Key</label>`) or built from variables/ternaries are **not** caught: distinguishing those from ordinary prose needs matching all text, which floods false positives (measured below). Treat it as defense-in-depth, not a guarantee.

## Changes

- Add `site/biome-rules/use-sentence-case-labels.grit` (diagnostic-only; Biome plugins can't autofix yet).
- Wire it into `site/biome.jsonc` via `overrides`, scoped to AgentsPage non-test files (verified: 0 leakage elsewhere).
- Fix the residual violations the gate surfaces:

  | Before | After | Where |
  |---|---|---|
  | API Key | API key | `ProviderForm`, `MCPServerAdminPanel` (×2) |
  | Custom Headers | Custom headers | `MCPServerAdminPanel` |
  | User OIDC Identity | User OIDC identity | `MCPServerAdminPanel` |
  | Force On / Default On / Default Off | Force on / Default on / Default off | `MCPServerAdminPanel` |

- Allowlist one false positive (the `Cmd/Ctrl+Enter` shortcut label).
- Document the convention in `site/AGENTS.md`.

Labels are display-only (`value`/`htmlFor` are separate), and no story/test asserts the changed strings, so nothing downstream breaks.

## Validation

Ran the rule against the exact before/after commits of #25941:

| Check | Result |
|---|---|
| Labels #25941 converted, caught at the pre-PR commit | 18 / 24 source labels |
| Of those caught, still flagged after #25941 | 0 (rule agrees with the manual fix) |
| Scope leakage (non-AgentsPage or test files) | 0 |
| `biome lint --error-on-warnings src/pages/AgentsPage` | passes |
| `tsc -p .` | passes |

<details>
<summary>Decision log: why gate-only, and what full coverage would cost</summary>

I prototyped both the scoped structural rule and a max-coverage variant and measured them against #25941's before/after commits.

**Coverage vs. noise**

| | Scoped rule (this PR) | Max-coverage (all strings + JSX text) |
|---|---|---|
| Labels from #25941 caught | 18 / 24 (75%) | 26 / 26 (100%) |
| Source false positives on already-correct code | ~0 (after fixes) | **94** |
| Test/story false positives | 0 (excluded) | **732** |

The casing regex looks at characters, not meaning, so it can't tell a UI label from a sentence that legitimately contains a proper noun (`OpenAI`, `WebSocket`), a CSS `font-family` value, or an error message. Pushing to 100% recall means gating CI on legitimate prose and maintaining an allowlist of most English sentences. That's a precision-vs-recall wall, so this PR picks precision.

**The 6 misses** are all JSX children text (`<TableHead>Cache read</TableHead>`) or computed strings (`cond ? "Edit model" : "Add model"`) — shapes a cheap structural rule can't target without matching all text.

**Perf** (`--profile-rules`): the GritQL plugin is the single most expensive rule (~5.1s summed across 1733 files vs ~176ms for the next rule). Scoping it to AgentsPage keeps the real cost small; it's diagnostic-only and beta, so scope matters. Note: capturing-group regex `(a|b)` silently matches nothing in Biome's GritQL; non-capturing `(?:a|b)` is required.

**Follow-ups (not in this PR):**
- Widen the gate beyond AgentsPage (~106 codebase-wide hits to fix first).
- A targeted JSX-text tier for known label components (`TableHead`, `TooltipContent`, `SettingsHeader`) to lift coverage toward ~90%.
- For genuine 100% enforcement, route labels through a centralized/typed strings layer so labels are distinguishable from prose.

</details>

## Test plan

- [ ] `cd site && pnpm exec biome lint --error-on-warnings src/pages/AgentsPage` is clean
- [ ] Introduce a Title Case `label="Foo Bar"` under AgentsPage and confirm `biome lint` flags it
- [ ] Confirm no diagnostics outside AgentsPage / in `*.stories.tsx` / `*.test.tsx`

Related to #25941.

> 🤖 This PR was created with the help of Coder Agents, and needs a human review. 🧑‍💻