### PR TITLE
chore(site): extend sentence-case label lint to the whole frontend

### DIFF
--- a/site/AGENTS.md
+++ b/site/AGENTS.md
@@ -119,9 +119,8 @@ Debug logs and pprof dumps use the same job name and commit SHA convention.
   equivalent; the shorthand is the React convention and reduces noise.
 - Use **sentence case** for user-facing UI labels: capitalize only the
   first word and proper nouns (`Personal instructions`, `API key`), not
-  Title Case (`Personal Instructions`, `API Key`). Under
-  `src/pages/AgentsPage`, a Biome GritQL plugin
-  (`biome-rules/use-sentence-case-labels.grit`) enforces this for
+  Title Case (`Personal Instructions`, `API Key`). A Biome GritQL
+  plugin (`biome-rules/use-sentence-case-labels.grit`) enforces this for
   `label`/`title`/`sectionLabel`/`aria-label` attributes and `label:`/
   `title:` object properties. It cannot see labels rendered as JSX text
   or built from variables, so those still need a human eye. Add genuine

--- a/site/biome-rules/use-sentence-case-labels.grit
+++ b/site/biome-rules/use-sentence-case-labels.grit
@@ -25,8 +25,12 @@ or {
 	}
 } where {
 	$value <: r".* [A-Z][a-z].*",
-	// Allowlist: proper nouns / product names that are correctly multi-cap.
-	not $value <: r".*(?:VS Code|Coder Agents|GitHub Actions|JetBrains Fleet|Cmd/Ctrl).*",
+	// Skip multi-sentence prose (descriptions, tooltips): a period followed
+	// by a space signals sentence text, not a label.
+	not $value <: r".*\. .*",
+	// Allowlist: proper nouns, product names, and key combos that are
+	// correctly multi-capitalized. Extend as needed.
+	not $value <: r".*(?:VS Code|VSCode Insiders|Coder Agents|AI Bridge|AI Governance|GitHub Copilot|GitHub Actions|AWS Bedrock|Azure OpenAI|OpenID Connect|JetBrains Fleet|Cmd/Ctrl|Ctrl \+ Enter).*",
 	register_diagnostic(
 		span = $value,
 		message = "Use sentence case for UI labels (e.g. \"Personal instructions\"), not Title Case. If this is a proper noun, add it to the allowlist in use-sentence-case-labels.grit.",

--- a/site/biome.jsonc
+++ b/site/biome.jsonc
@@ -6,9 +6,10 @@
 	"overrides": [
 		{
 			"includes": [
-				"src/pages/AgentsPage/**/*.ts",
-				"src/pages/AgentsPage/**/*.tsx",
+				"src/**/*.ts",
+				"src/**/*.tsx",
 				"!**/*.stories.tsx",
+				"!**/*.test.ts",
 				"!**/*.test.tsx"
 			],
 			"plugins": ["./biome-rules/use-sentence-case-labels.grit"]

--- a/site/src/components/ActiveUserChart/ActiveUserChart.tsx
+++ b/site/src/components/ActiveUserChart/ActiveUserChart.tsx
@@ -17,7 +17,7 @@ import { formatDate } from "#/utils/time";
 
 const chartConfig = {
 	amount: {
-		label: "Active Users",
+		label: "Active users",
 		color: "hsl(var(--highlight-purple))",
 	},
 } satisfies ChartConfig;

--- a/site/src/modules/dashboard/Navbar/ProxyMenu.tsx
+++ b/site/src/modules/dashboard/Navbar/ProxyMenu.tsx
@@ -110,7 +110,7 @@ export const ProxyMenu: FC<ProxyMenuProps> = ({ proxyContextValue }) => {
 						</div>
 						<div className="text-xs text-content-secondary leading-relaxed">
 							Workspace proxies improve terminal and web app connections.{" "}
-							<Abbr title="Command-Line Interface" pronunciation="initialism">
+							<Abbr title="Command-line interface" pronunciation="initialism">
 								CLI
 							</Abbr>{" "}
 							connections are unaffected. If no region is selected, the primary

--- a/site/src/modules/resources/AgentDevcontainerMoreActions.tsx
+++ b/site/src/modules/resources/AgentDevcontainerMoreActions.tsx
@@ -67,7 +67,7 @@ const DevcontainerDeleteDialog: FC<DevcontainerDeleteDialogProps> = ({
 		<ConfirmDialog
 			type="delete"
 			open={isOpen}
-			title="Delete Dev Container"
+			title="Delete dev container"
 			onConfirm={onConfirm}
 			onClose={onCancel}
 			description={

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -297,7 +297,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 		error: boolean;
 	}[] = [
 		{
-			title: "All Logs",
+			title: "All logs",
 			value: "all",
 			startIcon: <PackageIcon className="size-icon-xs shrink-0" />,
 			error: false,

--- a/site/src/modules/resources/PortForwardButton.tsx
+++ b/site/src/modules/resources/PortForwardButton.tsx
@@ -560,7 +560,7 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
 									fullWidth
 									select
 									value={form.values.share_level}
-									label="Sharing Level"
+									label="Sharing level"
 								>
 									<MenuItem value="organization">Organization</MenuItem>
 									{canSharePortsAuthenticated ? (

--- a/site/src/modules/resources/PortForwardPopoverView.stories.tsx
+++ b/site/src/modules/resources/PortForwardPopoverView.stories.tsx
@@ -104,7 +104,7 @@ export const DisabledOptions: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		const dropdown = canvas.getByLabelText("Sharing Level");
+		const dropdown = canvas.getByLabelText("Sharing level");
 		await userEvent.click(dropdown);
 	},
 };

--- a/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceDeleteDialog.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceDeleteDialog.tsx
@@ -63,7 +63,7 @@ export const WorkspaceDeleteDialog: FC<WorkspaceDeleteDialogProps> = ({
 			type="delete"
 			hideCancel={false}
 			open={isOpen}
-			title="Delete Workspace"
+			title="Delete workspace"
 			onConfirm={() => onConfirm(orphanWorkspace)}
 			onClose={onCancel}
 			disabled={!deletionConfirmed}

--- a/site/src/pages/CreateTemplatePage/CreateTemplatePage.tsx
+++ b/site/src/pages/CreateTemplatePage/CreateTemplatePage.tsx
@@ -46,7 +46,7 @@ const CreateTemplatePage: FC = () => {
 		<>
 			<title>{pageTitle("Create Template")}</title>
 
-			<FullPageHorizontalForm title="Create Template">
+			<FullPageHorizontalForm title="Create template">
 				{searchParams.has("fromTemplate") ? (
 					<DuplicateTemplateView {...pageViewProps} />
 				) : searchParams.has("exampleId") ? (

--- a/site/src/pages/CreateTokenPage/CreateTokenPage.tsx
+++ b/site/src/pages/CreateTokenPage/CreateTokenPage.tsx
@@ -94,7 +94,7 @@ const CreateTokenPage: FC<CreateTokenPageProps> = ({ now }) => {
 
 			{tokenFetchFailed && <ErrorAlert error={tokenFetchError} />}
 			<FullPageHorizontalForm
-				title="Create Token"
+				title="Create token"
 				detail="All tokens are unscoped and therefore have full resource access."
 			>
 				<CreateTokenForm

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/AddNewLicensePageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/AddNewLicensePageView.tsx
@@ -73,7 +73,7 @@ export const AddNewLicensePageView: FC<AddNewLicenseProps> = ({
 				isUploading={isUploading}
 				onUpload={onUpload}
 				removeLabel="Remove File"
-				title="Upload Your License"
+				title="Upload your license"
 				description="Select a text file that contains your license key."
 			/>
 
@@ -81,7 +81,7 @@ export const AddNewLicensePageView: FC<AddNewLicenseProps> = ({
 				<DividerWithText>or</DividerWithText>
 
 				<Fieldset
-					title="Paste Your License"
+					title="Paste your license"
 					onSubmit={(e) => {
 						e.preventDefault();
 

--- a/site/src/pages/HealthPage/DERPPage.tsx
+++ b/site/src/pages/HealthPage/DERPPage.tsx
@@ -53,29 +53,29 @@ const flagDescriptions: Record<BooleanKeys<NetcheckReport>, FlagInfo> = {
 		description: "Whether an IPv4 STUN round trip completed successfully.",
 	},
 	IPv6CanSend: {
-		label: "IPv6 Send",
+		label: "IPv6 send",
 		description: "Whether this server can send IPv6 packets.",
 	},
 	IPv4CanSend: {
-		label: "IPv4 Send",
+		label: "IPv4 send",
 		description: "Whether this server can send IPv4 packets.",
 	},
 	OSHasIPv6: {
-		label: "OS IPv6 Support",
+		label: "OS IPv6 support",
 		description: "Whether the operating system supports IPv6.",
 	},
 	ICMPv4: {
-		label: "ICMP Ping",
+		label: "ICMP ping",
 		description: "Whether an ICMPv4 round trip completed successfully.",
 	},
 	MappingVariesByDestIP: {
-		label: "No Symmetric NAT",
+		label: "No symmetric NAT",
 		description:
 			"Whether STUN results are consistent across destinations. Symmetric NAT may degrade peer-to-peer connectivity.",
 		invert: true,
 	},
 	HairPinning: {
-		label: "NAT Hairpinning",
+		label: "NAT hairpinning",
 		description:
 			"Whether the router supports communication between local devices through the public IP address.",
 	},
@@ -92,7 +92,7 @@ const flagDescriptions: Record<BooleanKeys<NetcheckReport>, FlagInfo> = {
 		description: "Whether Port Control Protocol was detected on the LAN.",
 	},
 	CaptivePortal: {
-		label: "No Captive Portal",
+		label: "No captive portal",
 		description:
 			"Whether HTTP traffic is free from captive portal interception.",
 		invert: true,
@@ -110,15 +110,15 @@ const flagGroups: FlagGroup[] = [
 		flags: ["UDP", "IPv4", "IPv6", "ICMPv4", "CaptivePortal"],
 	},
 	{
-		title: "IPv6 Support",
+		title: "IPv6 support",
 		flags: ["OSHasIPv6", "IPv4CanSend", "IPv6CanSend"],
 	},
 	{
-		title: "NAT Traversal",
+		title: "NAT traversal",
 		flags: ["MappingVariesByDestIP", "HairPinning"],
 	},
 	{
-		title: "Port Mapping",
+		title: "Port mapping",
 		flags: ["UPnP", "PMP", "PCP"],
 	},
 ];

--- a/site/src/pages/HealthPage/DERPRegionPage.tsx
+++ b/site/src/pages/HealthPage/DERPRegionPage.tsx
@@ -138,24 +138,24 @@ const DERPRegionPage: FC = () => {
 					);
 					const checks: NodeCheckRow[] = [
 						{
-							label: "Exchange Messages",
+							label: "Exchange messages",
 							description:
 								"Whether DERP clients can relay messages through this node.",
 							value: report.can_exchange_messages,
 						},
 						{
-							label: "Direct HTTP Upgrade",
+							label: "Direct HTTP upgrade",
 							description:
 								"Whether the connection used a direct HTTP upgrade instead of falling back to WebSocket. Fallback may indicate the DERP upgrade header is being blocked.",
 							value: !report.uses_websocket,
 						},
 						{
-							label: "STUN Enabled",
+							label: "STUN enabled",
 							description: "Whether STUN is enabled on this node.",
 							value: report.stun.Enabled,
 						},
 						{
-							label: "STUN Reachable",
+							label: "STUN reachable",
 							description:
 								"Whether this node responded to a STUN request successfully.",
 							value: report.stun.CanSTUN,

--- a/site/src/pages/OrganizationSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
@@ -129,7 +129,7 @@ const CreateEditRolePageView: FC<CreateEditRolePageViewProps> = ({
 							helperText: "Optional: keep empty to default to the name.",
 						})}
 						fullWidth
-						label="Display Name"
+						label="Display name"
 					/>
 					<ActionCheckboxes
 						permissions={role?.organization_permissions || []}

--- a/site/src/pages/OrganizationSettingsPage/OrganizationSettingsPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationSettingsPageView.tsx
@@ -152,7 +152,7 @@ export const OrganizationSettingsPageView: FC<
 			{onChangeShareableOwners && (
 				<HorizontalContainer className="mt-12">
 					<HorizontalSection
-						title="Workspace Sharing"
+						title="Workspace sharing"
 						description="Control whether workspace owners can share their workspaces."
 					>
 						<div className="flex flex-col gap-2">
@@ -262,7 +262,7 @@ export const OrganizationSettingsPageView: FC<
 			{!organization.is_default && (
 				<HorizontalContainer className="mt-12">
 					<HorizontalSection
-						title="Delete Organization"
+						title="Delete organization"
 						description="Delete your organization permanently."
 					>
 						<div className="flex flex-col gap-4 flex-grow">

--- a/site/src/pages/TaskPage/TaskStartupWarningButton.tsx
+++ b/site/src/pages/TaskPage/TaskStartupWarningButton.tsx
@@ -93,7 +93,7 @@ const StartupWarningButtonBase: FC<StartupWarningButtonBaseProps> = ({
 const ErrorScriptButton: FC = () => {
 	return (
 		<StartupWarningButtonBase
-			label="Startup Error"
+			label="Startup error"
 			errorMessage="startup script has exited with an error"
 		/>
 	);
@@ -102,7 +102,7 @@ const ErrorScriptButton: FC = () => {
 const TimeoutScriptButton: FC = () => {
 	return (
 		<StartupWarningButtonBase
-			label="Startup Timeout"
+			label="Startup timeout"
 			errorMessage="startup script has timed out"
 		/>
 	);

--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
@@ -308,7 +308,7 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
 							isSubmitting || (!template.deprecated && !accessControlEnabled)
 						}
 						fullWidth
-						label="Deprecation Message"
+						label="Deprecation message"
 					/>
 					{!accessControlEnabled && (
 						<div className="flex flex-row gap-4 items-center">
@@ -324,7 +324,7 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
 			</FormSection>
 
 			<FormSection
-				title="Port Sharing"
+				title="Port sharing"
 				description="Shared ports with the Public sharing level can be accessed by anyone,
           while ports with the Authenticated sharing level can only be accessed
           by authenticated Coder users. Ports with the Owner sharing level can
@@ -344,7 +344,7 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
 								? form.values.max_port_share_level
 								: "public"
 						}
-						label="Maximum Port Sharing Level"
+						label="Maximum port sharing level"
 					>
 						<MenuItem value="owner">Owner</MenuItem>
 						<MenuItem value="organization">Organization</MenuItem>
@@ -363,7 +363,7 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
 			</FormSection>
 
 			<FormSection
-				title="CORS Behavior"
+				title="CORS behavior"
 				description="Control how Cross-Origin Resource Sharing (CORS) requests are handled for all shared ports."
 			>
 				<FormFields>
@@ -376,7 +376,7 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
 						fullWidth
 						select
 						value={form.values.cors_behavior}
-						label="CORS Behavior"
+						label="CORS behavior"
 					>
 						<MenuItem value="simple">Simple (recommended)</MenuItem>
 						<MenuItem value="passthru">Passthru</MenuItem>

--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsPage.test.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsPage.test.tsx
@@ -222,7 +222,7 @@ describe("TemplateSettingsPage", { timeout: 20_000 }, () => {
 });
 
 async function deprecateTemplate(message: string) {
-	const deprecationField = screen.getByLabelText("Deprecation Message");
+	const deprecationField = screen.getByLabelText("Deprecation message");
 	await userEvent.type(deprecationField, message);
 	const submitButton = await screen.findByRole("button", { name: /save/i });
 	await userEvent.click(submitButton);

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/ScheduleDialog.stories.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/ScheduleDialog.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof ScheduleDialog> = {
 		onConfirm: action("onConfirm"),
 		onClose: action("onClose"),
 		open: true,
-		title: "Workspace Scheduling",
+		title: "Workspace scheduling",
 	},
 };
 

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/ScheduleDialog.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/ScheduleDialog.tsx
@@ -88,7 +88,7 @@ export const ScheduleDialog: FC<ScheduleDialogProps> = ({
 									}}
 								/>
 							}
-							label="Prevent Dormancy - Reset all workspace inactivity periods"
+							label="Prevent dormancy - reset all workspace inactivity periods"
 						/>
 					</>
 				)}
@@ -118,7 +118,7 @@ export const ScheduleDialog: FC<ScheduleDialogProps> = ({
 									}}
 								/>
 							}
-							label="Prevent Deletion - Reset all workspace dormancy periods"
+							label="Prevent deletion - reset all workspace dormancy periods"
 						/>
 					</>
 				)}

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
@@ -578,7 +578,7 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 					onClose={() => {
 						setIsScheduleDialogOpen(false);
 					}}
-					title="Workspace Scheduling"
+					title="Workspace scheduling"
 					updateDormantWorkspaces={(update: boolean) =>
 						form.setFieldValue("update_workspace_dormant_at", update)
 					}

--- a/site/src/pages/TemplateVersionEditorPage/FileDialog.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/FileDialog.tsx
@@ -56,7 +56,7 @@ export const CreateFileDialog: FC<CreateFileDialogProps> = ({
 			type="success"
 			cancelText="Cancel"
 			confirmText="Create"
-			title="Create File"
+			title="Create file"
 			description={
 				<div className="flex flex-col gap-8">
 					<p>
@@ -78,7 +78,7 @@ export const CreateFileDialog: FC<CreateFileDialogProps> = ({
 						placeholder="example.tf"
 						value={pathValue}
 						onChange={handleChange}
-						label="File Path"
+						label="File path"
 					/>
 				</div>
 			}
@@ -105,7 +105,7 @@ export const DeleteFileDialog: FC<DeleteFileDialogProps> = ({
 			onClose={onClose}
 			open={open}
 			onConfirm={onConfirm}
-			title="Delete File"
+			title="Delete file"
 			description={
 				<>
 					Are you sure you want to delete <strong>{filename}</strong>? It will
@@ -177,7 +177,7 @@ export const RenameFileDialog: FC<RenameFileDialogProps> = ({
 			type="success"
 			cancelText="Cancel"
 			confirmText="Rename"
-			title="Rename File"
+			title="Rename file"
 			description={
 				<div className="flex flex-col gap-4">
 					<p>
@@ -199,7 +199,7 @@ export const RenameFileDialog: FC<RenameFileDialogProps> = ({
 						placeholder={filename}
 						value={pathValue}
 						onChange={handleChange}
-						label="File Path"
+						label="File path"
 					/>
 				</div>
 			}

--- a/site/src/pages/TemplateVersionEditorPage/ProvisionerTagsPopover.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ProvisionerTagsPopover.tsx
@@ -50,7 +50,7 @@ export const ProvisionerTagsPopover: FC<ProvisionerTagsPopoverProps> = ({
 							// direction ("horizontal") which adds lg:flex-row.
 							root: "flex-col lg:flex-col gap-4 lg:gap-4",
 						}}
-						title="Provisioner Tags"
+						title="Provisioner tags"
 						description={
 							<>
 								Tags are a way to control which provisioner daemons complete

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
@@ -331,7 +331,7 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 										<Button
 											size="icon"
 											variant="subtle"
-											aria-label="Create File"
+											aria-label="Create file"
 											onClick={(event) => {
 												setCreateFileOpen(true);
 												event.currentTarget.blur();

--- a/site/src/pages/UserSettingsPage/ExternalAuthPage/ExternalAuthPage.tsx
+++ b/site/src/pages/UserSettingsPage/ExternalAuthPage/ExternalAuthPage.tsx
@@ -62,7 +62,7 @@ const ExternalAuthPage: FC = () => {
 			/>
 			<DeleteDialog
 				key={appToUnlink?.id}
-				title="Unlink Application"
+				title="Unlink application"
 				verb="Unlinking"
 				info={
 					appToUnlink?.supports_revocation

--- a/site/src/pages/UserSettingsPage/OAuth2ProviderPage/OAuth2ProviderPage.tsx
+++ b/site/src/pages/UserSettingsPage/OAuth2ProviderPage/OAuth2ProviderPage.tsx
@@ -36,7 +36,7 @@ const OAuth2ProviderPage: FC = () => {
 			/>
 			{appToRevoke !== undefined && (
 				<DeleteDialog
-					title="Revoke Application"
+					title="Revoke application"
 					verb="Revoking"
 					info={`This will invalidate any tokens created by the OAuth2 application "${appToRevoke.name}".`}
 					label="Name of the application to revoke"

--- a/site/src/pages/UserSettingsPage/SecurityPage/SecurityForm.tsx
+++ b/site/src/pages/UserSettingsPage/SecurityPage/SecurityForm.tsx
@@ -83,18 +83,18 @@ export const SecurityForm: FC<SecurityFormProps> = ({
 					{Boolean(error) && <ErrorAlert error={error} />}
 					<FormField
 						field={getFieldHelpers("old_password")}
-						label="Old Password"
+						label="Old password"
 						type="password"
 						autoComplete="current-password"
 					/>
 					<PasswordField
 						field={getFieldHelpers("password")}
-						label="New Password"
+						label="New password"
 						autoComplete="new-password"
 					/>
 					<FormField
 						field={getFieldHelpers("confirm_password")}
-						label="Confirm Password"
+						label="Confirm password"
 						type="password"
 						autoComplete="new-password"
 					/>

--- a/site/src/pages/UserSettingsPage/SecurityPage/SecurityPage.test.tsx
+++ b/site/src/pages/UserSettingsPage/SecurityPage/SecurityPage.test.tsx
@@ -23,13 +23,13 @@ const newSecurityFormValues = {
 };
 
 const fillAndSubmitSecurityForm = () => {
-	fireEvent.change(screen.getByLabelText("Old Password"), {
+	fireEvent.change(screen.getByLabelText("Old password"), {
 		target: { value: newSecurityFormValues.old_password },
 	});
-	fireEvent.change(screen.getByLabelText("New Password"), {
+	fireEvent.change(screen.getByLabelText("New password"), {
 		target: { value: newSecurityFormValues.password },
 	});
-	fireEvent.change(screen.getByLabelText("Confirm Password"), {
+	fireEvent.change(screen.getByLabelText("Confirm password"), {
 		target: { value: newSecurityFormValues.confirm_password },
 	});
 	fireEvent.click(screen.getByText("Update password"));

--- a/site/src/pages/UserSettingsPage/TokensPage/ConfirmDeleteDialog.tsx
+++ b/site/src/pages/UserSettingsPage/TokensPage/ConfirmDeleteDialog.tsx
@@ -37,7 +37,7 @@ export const ConfirmDeleteDialog: FC<ConfirmDeleteDialogProps> = ({
 	return (
 		<ConfirmDialog
 			type="delete"
-			title="Delete Token"
+			title="Delete token"
 			description={
 				<>
 					Are you sure you want to permanently delete token{" "}

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersForm.tsx
@@ -131,7 +131,7 @@ export const WorkspaceParametersForm: FC<WorkspaceParameterFormProps> = ({
 				)}
 				{hasEphemeralParameters && (
 					<FormSection
-						title="Ephemeral Parameters"
+						title="Ephemeral parameters"
 						description="These parameters only apply for a single workspace start."
 					>
 						<FormFields>

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.tsx
@@ -95,7 +95,7 @@ const WorkspaceSchedulePage: FC = () => {
 						Prebuilt workspaces ignore workspace-level scheduling until they are
 						claimed. For prebuilt workspace specific scheduling refer to the{" "}
 						<Link
-							title="Prebuilt Workspaces Scheduling"
+							title="Prebuilt workspaces scheduling"
 							href={docs(
 								"/admin/templates/extending-templates/prebuilt-workspaces#scheduling",
 							)}

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
@@ -64,7 +64,7 @@ export const WorkspaceSettingsForm: FC<WorkspaceSettingsFormProps> = ({
 	return (
 		<HorizontalForm onSubmit={form.handleSubmit} data-testid="form">
 			<FormSection
-				title="Workspace Name"
+				title="Workspace name"
 				description="Update the name of your workspace."
 			>
 				<FormFields>
@@ -86,14 +86,14 @@ export const WorkspaceSettingsForm: FC<WorkspaceSettingsFormProps> = ({
 				</FormFields>
 			</FormSection>
 			<FormSection
-				title="Automatic Updates"
+				title="Automatic updates"
 				description="Configure your workspace to automatically update when started."
 			>
 				<FormFields>
 					<TextField
 						{...getFieldHelpers("automatic_updates")}
 						id="automatic_updates"
-						label="Update Policy"
+						label="Update policy"
 						value={
 							workspace.template_require_active_version
 								? "always"

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -739,7 +739,7 @@ const WorkspaceApps: FC<WorkspaceAppsProps> = ({ workspace }) => {
 					e.preventDefault();
 					openAppInNewWindow(href);
 				}}
-				label="Open Terminal"
+				label="Open terminal"
 			>
 				<SquareTerminalIcon className="!size-7" />
 			</BaseIconLink>,


### PR DESCRIPTION
## Summary

Builds on #26000 (the AgentsPage gate) and extends the sentence-case label lint to the **entire frontend**. The Biome GritQL plugin now runs across all of `src` (minus `*.stories`/`*.test`), and this PR fixes every Title Case label it surfaces so CI is green.

> [!NOTE]
> Stacked on #26000 — review/merge that first; this PR targets its branch, so the diff here is only the widening + fixes. Same scope caveat applies: the gate covers `label`/`title`/`sectionLabel`/`aria-label` attributes and `label:`/`title:` object properties, not labels rendered as JSX text or built from variables.

## Changes

**Rule / config**
- Widen the `overrides` glob from `src/pages/AgentsPage/**` to all of `src` (and fix the exclusion to also skip `*.test.ts`, not just `*.test.tsx`).
- Harden `use-sentence-case-labels.grit`:
  - Skip multi-sentence prose (a `. ` inside the string signals a description/tooltip, not a label) — removes false positives like two-sentence button tooltips.
  - Allowlist product names and key combos: `AWS Bedrock`, `Azure OpenAI`, `GitHub Copilot`, `OpenID Connect`, `AI Bridge`, `AI Governance`, `VSCode Insiders`, `Ctrl + Enter`.

**Label fixes (56 across ~12 areas)**

| Area | Examples |
|---|---|
| modules (resources, dashboard, workspaces) | `All Logs`→`All logs`, `Sharing Level`→`Sharing level`, `Delete Workspace`→`Delete workspace`, `Command-Line Interface`→`Command-line interface` |
| HealthPage (DERP) | `ICMP Ping`→`ICMP ping`, `NAT Hairpinning`→`NAT hairpinning`, `IPv6 Support`→`IPv6 support` (acronyms preserved) |
| Template settings / version editor | `CORS Behavior`→`CORS behavior`, `Create File`→`Create file`, `Provisioner Tags`→`Provisioner tags` |
| User / Org settings | `Old/New/Confirm Password`, `Display Name`→`Display name`, `Unlink/Revoke Application`, `Delete Organization` |
| Workspace settings / create pages | `Workspace Name`, `Automatic Updates`, `Update Policy`, `Create Template`/`Create Token` (visible heading only; browser `<title>` left as-is) |

- Updated 4 stale story/test assertions for the components changed (SecurityPage, TemplateSettingsPage, PortForwardPopoverView, ScheduleDialog). Independent fixtures for other components (Abbr, useKebabMenu, CreateWorkspace, Form) were intentionally left alone.

## Validation

| Check | Result |
|---|---|
| `biome lint --error-on-warnings src` (whole frontend) | passes, 0 plugin hits |
| `biome check` on all changed files | passes |
| `tsc -p .` | passes |
| Widening hit-count | 72 raw → 13 cleared by allowlist/prose exclusion → 56 fixed |

<details>
<summary>Judgment calls flagged for review</summary>

These were converted to sentence case but are debatable — easy to allowlist instead if you prefer:
- **HealthPage networking labels** (`No symmetric NAT`, `NAT traversal`, `STUN reachable`, `OS IPv6 support`, etc.). Acronyms kept uppercase; only the trailing words were lowercased.
- **`Delete dev container`** ("Dev Container" is a spec term; lowercased here).
- **Product names left capitalized** via allowlist: `AWS Bedrock`, `Azure OpenAI`, `GitHub Copilot`, `OpenID Connect`, `AI Bridge`, `AI Governance`, `VSCode Insiders`. If any of these should be sentence case (e.g. `AI governance`), say so and I'll adjust.

**Known out-of-scope (not fixed):** labels rendered as JSX text (e.g. `<label>API Key</label>` in `AgentSettingsAPIKeysPageView`) or via `removeLabel`-style props the rule doesn't target. These need the broader approaches discussed on #26000.

</details>

## Test plan

- [ ] CI green (lint, types, story/unit suites)
- [ ] Spot-check a few converted screens (Template settings, User security, Health) render the sentence-case labels
- [ ] Add a Title Case `label="Foo Bar"` anywhere under `src` and confirm `biome lint` flags it

Related to #25941. Stacked on #26000.

> 🤖 This PR was created with the help of Coder Agents, and needs a human review. 🧑‍💻