### PR TITLE
fix(aibridge/intercept/chatcompletions): handle empty streams

### DIFF
--- a/aibridge/intercept/chatcompletions/sse_filter.go
+++ b/aibridge/intercept/chatcompletions/sse_filter.go
@@ -1,0 +1,188 @@
+package chatcompletions
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"mime"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+const maxSSELineSize = bufio.MaxScanTokenSize << 9 // 32 MB
+
+type sseStreamStats struct {
+	responseReceived atomic.Bool
+	statusCode       atomic.Int64
+	contentType      atomic.Value
+
+	rawBytes    atomic.Int64
+	dataEvents  atomic.Int64
+	comments    atomic.Int64
+	emptyEvents atomic.Int64
+	sawDone     atomic.Bool
+}
+
+func (s *sseStreamStats) wrapResponse(resp *http.Response) {
+	if resp == nil {
+		return
+	}
+	s.responseReceived.Store(true)
+	s.statusCode.Store(int64(resp.StatusCode))
+	s.contentType.Store(resp.Header.Get("Content-Type"))
+
+	if resp.Body == nil || !s.isSSEUpstream() {
+		return
+	}
+	resp.Body = newSSEFilteringBody(resp.Body, s)
+}
+
+func (s *sseStreamStats) isSSEUpstream() bool {
+	if !s.responseReceived.Load() {
+		return false
+	}
+	statusCode := int(s.statusCode.Load())
+	if statusCode < http.StatusOK || statusCode >= http.StatusMultipleChoices {
+		return false
+	}
+	return isEventStreamContentType(s.contentTypeString())
+}
+
+func (s *sseStreamStats) contentTypeString() string {
+	contentType, _ := s.contentType.Load().(string)
+	return contentType
+}
+
+func (s *sseStreamStats) statusCodeInt() int {
+	return int(s.statusCode.Load())
+}
+
+func (s *sseStreamStats) hasDataEvents() bool {
+	return s != nil && s.dataEvents.Load() > 0
+}
+
+func (s *sseStreamStats) isEmptyDataStream() bool {
+	return s != nil && s.isSSEUpstream() && s.dataEvents.Load() == 0
+}
+
+func isEventStreamContentType(contentType string) bool {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		mediaType, _, _ = strings.Cut(contentType, ";")
+		mediaType = strings.TrimSpace(mediaType)
+	}
+	return strings.EqualFold(mediaType, "text/event-stream")
+}
+
+type sseFilteringBody struct {
+	reader        *io.PipeReader
+	upstream      io.ReadCloser
+	closeUpstream func() error
+}
+
+func newSSEFilteringBody(upstream io.ReadCloser, stats *sseStreamStats) io.ReadCloser {
+	reader, writer := io.Pipe()
+	body := &sseFilteringBody{
+		reader:        reader,
+		upstream:      upstream,
+		closeUpstream: sync.OnceValue(upstream.Close),
+	}
+	go body.filter(writer, stats)
+	return body
+}
+
+func (b *sseFilteringBody) Read(p []byte) (int, error) {
+	return b.reader.Read(p)
+}
+
+func (b *sseFilteringBody) Close() error {
+	return errors.Join(b.reader.Close(), b.closeUpstream())
+}
+
+func (b *sseFilteringBody) filter(writer *io.PipeWriter, stats *sseStreamStats) {
+	defer func() {
+		_ = b.closeUpstream()
+	}()
+
+	scanner := bufio.NewScanner(b.upstream)
+	scanner.Buffer(nil, maxSSELineSize)
+
+	var event bytes.Buffer
+	var eventData bytes.Buffer
+	var eventHasData bool
+	var eventHadLine bool
+
+	resetEvent := func() {
+		event.Reset()
+		eventData.Reset()
+		eventHasData = false
+		eventHadLine = false
+	}
+	dispatchEvent := func() error {
+		defer resetEvent()
+		if !eventHasData {
+			if eventHadLine {
+				stats.emptyEvents.Add(1)
+			}
+			return nil
+		}
+
+		if bytes.HasPrefix(eventData.Bytes(), []byte("[DONE]")) {
+			stats.sawDone.Store(true)
+		} else {
+			stats.dataEvents.Add(1)
+		}
+
+		if _, err := writer.Write(event.Bytes()); err != nil {
+			return err
+		}
+		_, err := writer.Write([]byte("\n"))
+		return err
+	}
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		stats.rawBytes.Add(int64(len(line) + 1))
+
+		if len(line) == 0 {
+			if err := dispatchEvent(); err != nil {
+				_ = writer.CloseWithError(err)
+				return
+			}
+			continue
+		}
+
+		name, value, _ := bytes.Cut(line, []byte(":"))
+		if len(name) == 0 {
+			stats.comments.Add(1)
+			continue
+		}
+		eventHadLine = true
+		if len(value) > 0 && value[0] == ' ' {
+			value = value[1:]
+		}
+		if bytes.Equal(name, []byte("data")) {
+			eventHasData = true
+			_, _ = eventData.Write(value)
+			_, _ = eventData.WriteRune('\n')
+		}
+
+		_, _ = event.Write(line)
+		_ = event.WriteByte('\n')
+	}
+
+	if err := scanner.Err(); err != nil {
+		_ = writer.CloseWithError(err)
+		return
+	}
+	if eventHadLine {
+		if err := dispatchEvent(); err != nil {
+			_ = writer.CloseWithError(err)
+			return
+		}
+	}
+	_ = writer.Close()
+}

--- a/aibridge/intercept/chatcompletions/streaming.go
+++ b/aibridge/intercept/chatcompletions/streaming.go
@@ -397,20 +397,23 @@ func (i *StreamingInterception) ProcessRequest(w http.ResponseWriter, r *http.Re
 		i.req.Messages = append(i.req.Messages, openai.ToolMessage(out.String(), id))
 	}
 
-	// Send termination marker.
-	if err := events.SendRaw(streamCtx, i.encodeForStream([]byte("[DONE]"))); err != nil {
-		logger.Debug(ctx, "failed to send termination marker", slog.Error(err))
+	var shutdownErr error
+	if events.IsStreaming() {
+		// Send termination marker.
+		if err := events.SendRaw(streamCtx, i.encodeForStream([]byte("[DONE]"))); err != nil {
+			logger.Debug(ctx, "failed to send termination marker", slog.Error(err))
+		}
+
+		// Give the events stream 30 seconds (TODO: configurable) to gracefully shutdown.
+		shutdownCtx, shutdownCancel := context.WithTimeout(ctx, time.Second*30)
+		defer shutdownCancel()
+		if shutdownErr = events.Shutdown(shutdownCtx); shutdownErr != nil {
+			logger.Warn(ctx, "event stream shutdown", slog.Error(shutdownErr))
+		}
 	}
 
-	// Give the events stream 30 seconds (TODO: configurable) to gracefully shutdown.
-	shutdownCtx, shutdownCancel := context.WithTimeout(ctx, time.Second*30)
-	defer shutdownCancel()
-	if err = events.Shutdown(shutdownCtx); err != nil {
-		logger.Warn(ctx, "event stream shutdown", slog.Error(err))
-	}
-
-	if err != nil {
-		streamCancel(xerrors.Errorf("stream err: %w", err))
+	if shutdownErr != nil {
+		streamCancel(xerrors.Errorf("stream err: %w", shutdownErr))
 	} else {
 		streamCancel(xerrors.New("gracefully done"))
 	}

--- a/aibridge/intercept/chatcompletions/streaming.go
+++ b/aibridge/intercept/chatcompletions/streaming.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -28,6 +29,11 @@ import (
 	"github.com/coder/coder/v2/aibridge/recorder"
 	"github.com/coder/coder/v2/aibridge/tracing"
 	"github.com/coder/quartz"
+)
+
+const (
+	upstreamEmptyStreamMessage     = "The AI provider did not return a response. Try again or contact your administrator if this persists."
+	upstreamMalformedStreamMessage = "The AI provider returned an invalid response. Try again or contact your administrator if this persists."
 )
 
 type StreamingInterception struct {
@@ -192,6 +198,13 @@ func (i *StreamingInterception) ProcessRequest(w http.ResponseWriter, r *http.Re
 		opts = append(opts, option.WithRequestBody("application/json", body))
 		opts = append(opts, option.WithJSONSet("stream", true))
 
+		streamStats := &sseStreamStats{}
+		opts = append(opts, option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+			resp, err := next(req)
+			streamStats.wrapResponse(resp)
+			return resp, err
+		}))
+
 		stream = i.newStream(streamCtx, svc, opts)
 		processor := newStreamProcessor(streamCtx, i.logger.Named("stream-processor"), i.getInjectedToolByName)
 
@@ -234,6 +247,11 @@ func (i *StreamingInterception) ProcessRequest(w http.ResponseWriter, r *http.Re
 			}
 		}
 
+		streamErr := stream.Err()
+		if err := stream.Close(); err != nil {
+			logger.Debug(ctx, "failed to close upstream stream", slog.Error(err))
+		}
+
 		if toolCall != nil {
 			// Builtin tools are not intercepted.
 			if i.getInjectedToolByName(toolCall.Name) == nil {
@@ -247,7 +265,7 @@ func (i *StreamingInterception) ProcessRequest(w http.ResponseWriter, r *http.Re
 				})
 
 				toolCall = nil
-			} else if stream.Err() == nil {
+			} else if streamErr == nil {
 				// When the provider responds with only tool calls (no text content),
 				// no chunks are relayed to the client, so the stream is not yet
 				// initiated. Initiate it here so the SSE headers are sent and the
@@ -277,8 +295,7 @@ func (i *StreamingInterception) ProcessRequest(w http.ResponseWriter, r *http.Re
 			// Mid-stream error or logical error: events have
 			// already streamed for this iteration, so the
 			// error is relayed as an SSE event.
-			streamErr := stream.Err()
-			if respErr := i.mapStreamError(ctx, logger, streamErr, lastErr); respErr != nil {
+			if respErr := i.mapStreamError(ctx, logger, streamErr, lastErr, streamStats, true); respErr != nil {
 				interceptionErr = respErr
 				payload, err := i.marshalErr(respErr)
 				if err != nil {
@@ -296,14 +313,14 @@ func (i *StreamingInterception) ProcessRequest(w http.ResponseWriter, r *http.Re
 			// Pre-stream failure of this iteration. For
 			// centralized requests, mark the key and retry with
 			// the next one.
-			if currentPoolKey != nil && i.markKeyOnError(ctx, currentPoolKey, stream.Err()) {
+			if currentPoolKey != nil && i.markKeyOnError(ctx, currentPoolKey, streamErr) {
 				continue
 			}
 			// Non-key error: relay it. Use mapStreamError so that
 			// unknown upstream errors (TCP reset, DNS failure, TLS
 			// error, deadline exceeded) are wrapped in a generic
 			// response instead of producing a silent HTTP 200.
-			respErr := i.mapStreamError(ctx, logger, stream.Err(), lastErr)
+			respErr := i.mapStreamError(ctx, logger, streamErr, lastErr, streamStats, events.IsStreaming())
 			if respErr != nil {
 				interceptionErr = respErr
 				if events.IsStreaming() {
@@ -461,11 +478,20 @@ func (i *StreamingInterception) newStream(ctx context.Context, svc openai.ChatCo
 	return svc.NewStreaming(ctx, openai.ChatCompletionNewParams{}, opts...)
 }
 
-// mapStreamError converts a mid-stream upstream error or
-// processing error into a relayable ResponseError. Returns nil
-// when the error is unrecoverable, in which case nothing can be
-// relayed back.
-func (*StreamingInterception) mapStreamError(ctx context.Context, logger slog.Logger, streamErr, lastErr error) *intercept.ResponseError {
+// mapStreamError turns stream errors or empty-stream anomalies into
+// relayable ResponseErrors. Returns nil for unrecoverable errors that
+// cannot be relayed.
+func (i *StreamingInterception) mapStreamError(ctx context.Context, logger slog.Logger, streamErr, lastErr error, stats *sseStreamStats, downstreamStarted bool) *intercept.ResponseError {
+	if streamErr == nil && stats.isEmptyDataStream() {
+		i.logUpstreamStreamFailure(ctx, logger, "empty_stream", streamErr, stats, downstreamStarted)
+		return intercept.NewResponseError(
+			upstreamEmptyStreamMessage,
+			intercept.OpenAIErrTypeAPI,
+			intercept.OpenAIErrCodeServer,
+			http.StatusBadGateway,
+			0,
+		)
+	}
 	if streamErr != nil {
 		if eventstream.IsUnrecoverableError(streamErr) {
 			logger.Debug(ctx, "stream terminated", slog.Error(streamErr))
@@ -475,6 +501,16 @@ func (*StreamingInterception) mapStreamError(ctx context.Context, logger slog.Lo
 		if oaiErr := intercept.ResponseErrorFromAPIError(streamErr); oaiErr != nil {
 			logger.Warn(ctx, "openai stream error", slog.Error(streamErr))
 			return oaiErr
+		}
+		if stats != nil && stats.isSSEUpstream() && stats.hasDataEvents() && isJSONDecodeStreamError(streamErr) {
+			i.logUpstreamStreamFailure(ctx, logger, "malformed_json", streamErr, stats, downstreamStarted)
+			return intercept.NewResponseError(
+				upstreamMalformedStreamMessage,
+				intercept.OpenAIErrTypeAPI,
+				intercept.OpenAIErrCodeServer,
+				http.StatusBadGateway,
+				0,
+			)
 		}
 		logger.Warn(ctx, "unknown stream error", slog.Error(streamErr))
 		// Unfortunately, the OpenAI SDK does not support parsing errors received in the stream
@@ -488,6 +524,40 @@ func (*StreamingInterception) mapStreamError(ctx context.Context, logger slog.Lo
 		return intercept.NewResponseError(fmt.Sprintf("processing error: %s", lastErr), intercept.OpenAIErrTypeError, intercept.OpenAIErrTypeError, http.StatusBadGateway, 0)
 	}
 	return nil
+}
+
+func (i *StreamingInterception) logUpstreamStreamFailure(ctx context.Context, logger slog.Logger, kind string, err error, stats *sseStreamStats, downstreamStarted bool) {
+	fields := []slog.Field{
+		slog.F("stream_error_kind", kind),
+		slog.F("provider_name", i.cfg.ProviderName),
+		slog.F("model", i.Model()),
+		slog.F("endpoint", "/v1/chat/completions"),
+		slog.F("downstream_started", downstreamStarted),
+	}
+	if err != nil {
+		fields = append(fields, slog.Error(err))
+	}
+	if stats != nil {
+		fields = append(fields,
+			slog.F("upstream_status", stats.statusCodeInt()),
+			slog.F("upstream_content_type", stats.contentTypeString()),
+			slog.F("has_data_events", stats.hasDataEvents()),
+			slog.F("saw_done", stats.sawDone.Load()),
+			slog.F("data_event_count", stats.dataEvents.Load()),
+			slog.F("comment_count", stats.comments.Load()),
+			slog.F("empty_event_count", stats.emptyEvents.Load()),
+			slog.F("upstream_bytes_read", stats.rawBytes.Load()),
+		)
+	}
+	logger.Warn(ctx, "upstream stream failed", fields...)
+}
+
+func isJSONDecodeStreamError(err error) bool {
+	if _, ok := errors.AsType[*json.SyntaxError](err); ok {
+		return true
+	}
+	_, ok := errors.AsType[*json.UnmarshalTypeError](err)
+	return ok
 }
 
 type streamProcessor struct {

--- a/aibridge/intercept/chatcompletions/streaming_internal_test.go
+++ b/aibridge/intercept/chatcompletions/streaming_internal_test.go
@@ -111,8 +111,11 @@ func TestStreamingInterception_RelaysUpstreamErrorToClient(t *testing.T) {
 	}
 }
 
-// OpenAI-shaped SSE body for a successful streaming response.
-const streamingSuccessBody = `data: {"id":"chatcmpl-01","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"},"finish_reason":null}]}
+func TestStreamingInterception_HandlesUpstreamSSEEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	// OpenAI-shaped SSE body for a successful streaming response.
+	const streamingSuccessBody = `data: {"id":"chatcmpl-01","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"},"finish_reason":null}]}
 
 data: {"id":"chatcmpl-01","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4","choices":[{"index":0,"delta":{"content":"!"},"finish_reason":null}]}
 
@@ -121,9 +124,6 @@ data: {"id":"chatcmpl-01","object":"chat.completion.chunk","created":1234567890,
 data: [DONE]
 
 `
-
-func TestStreamingInterception_HandlesUpstreamSSEEdgeCases(t *testing.T) {
-	t.Parallel()
 
 	validChunkWithoutDone := `data: {"id":"chatcmpl-01","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"},"finish_reason":null}]}
 

--- a/aibridge/intercept/chatcompletions/streaming_internal_test.go
+++ b/aibridge/intercept/chatcompletions/streaming_internal_test.go
@@ -106,6 +106,7 @@ func TestStreamingInterception_RelaysUpstreamErrorToClient(t *testing.T) {
 			// Verify error body contains expected error info
 			body := w.Body.String()
 			assert.Contains(t, body, tc.expectedBody, "expected error type in response body")
+			assert.NotContains(t, body, "data: [DONE]", "direct JSON error response must not include SSE data")
 		})
 	}
 }
@@ -234,10 +235,14 @@ func TestStreamingInterception_HandlesUpstreamSSEEdgeCases(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+			body := w.Body.String()
 			assert.Equal(t, tc.expectedStatusCode, w.Code, "response status code")
-			assert.Contains(t, w.Body.String(), tc.expectedBody, "response body")
+			assert.Contains(t, body, tc.expectedBody, "response body")
+			if tc.expectErr {
+				assert.NotContains(t, body, "data: [DONE]", "direct JSON error response must not include SSE data")
+			}
 			if tc.unexpectedBody != "" {
-				assert.NotContains(t, w.Body.String(), tc.unexpectedBody, "response body")
+				assert.NotContains(t, body, tc.unexpectedBody, "response body")
 			}
 		})
 	}

--- a/aibridge/intercept/chatcompletions/streaming_internal_test.go
+++ b/aibridge/intercept/chatcompletions/streaming_internal_test.go
@@ -225,7 +225,8 @@ func TestStreamingInterception_HandlesUpstreamSSEEdgeCases(t *testing.T) {
 			}
 
 			interceptor := NewStreamingInterceptor(uuid.New(), params, cfg, cred, http.Header{}, otel.Tracer("streaming_test"))
-			interceptor.Setup(slog.Make(), &testutil.MockRecorder{}, nil)
+			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
+			interceptor.Setup(logger, &testutil.MockRecorder{}, nil)
 
 			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
 			w := httptest.NewRecorder()

--- a/aibridge/intercept/chatcompletions/streaming_internal_test.go
+++ b/aibridge/intercept/chatcompletions/streaming_internal_test.go
@@ -1,8 +1,10 @@
 package chatcompletions
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -104,6 +106,139 @@ func TestStreamingInterception_RelaysUpstreamErrorToClient(t *testing.T) {
 			// Verify error body contains expected error info
 			body := w.Body.String()
 			assert.Contains(t, body, tc.expectedBody, "expected error type in response body")
+		})
+	}
+}
+
+// OpenAI-shaped SSE body for a successful streaming response.
+const streamingSuccessBody = `data: {"id":"chatcmpl-01","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-01","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4","choices":[{"index":0,"delta":{"content":"!"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-01","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}
+
+data: [DONE]
+
+`
+
+func TestStreamingInterception_HandlesUpstreamSSEEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	validChunkWithoutDone := `data: {"id":"chatcmpl-01","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"},"finish_reason":null}]}
+
+`
+	largeContent := strings.Repeat("a", 70*1024)
+	largeChunk := `data: {"id":"chatcmpl-01","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4","choices":[{"index":0,"delta":{"role":"assistant","content":"` + largeContent + `"},"finish_reason":null}]}` + "\n\n"
+
+	tests := []struct {
+		name               string
+		body               string
+		expectErr          bool
+		expectedStatusCode int
+		expectedBody       string
+		unexpectedBody     string
+	}{
+		{
+			name:               "empty body",
+			body:               "",
+			expectErr:          true,
+			expectedStatusCode: http.StatusBadGateway,
+			expectedBody:       upstreamEmptyStreamMessage,
+			unexpectedBody:     "unexpected end of JSON input",
+		},
+		{
+			name:               "comment only event",
+			body:               ": OPENROUTER PROCESSING\n\n",
+			expectErr:          true,
+			expectedStatusCode: http.StatusBadGateway,
+			expectedBody:       upstreamEmptyStreamMessage,
+			unexpectedBody:     "unexpected end of JSON input",
+		},
+		{
+			name:               "comment only without final blank line",
+			body:               ": OPENROUTER PROCESSING\n",
+			expectErr:          true,
+			expectedStatusCode: http.StatusBadGateway,
+			expectedBody:       upstreamEmptyStreamMessage,
+			unexpectedBody:     "unexpected end of JSON input",
+		},
+		{
+			name:               "done marker only",
+			body:               "data: [DONE]\n\n",
+			expectErr:          true,
+			expectedStatusCode: http.StatusBadGateway,
+			expectedBody:       upstreamEmptyStreamMessage,
+		},
+		{
+			name:               "malformed data event",
+			body:               "data: {not-json}\n\n",
+			expectErr:          true,
+			expectedStatusCode: http.StatusBadGateway,
+			expectedBody:       upstreamMalformedStreamMessage,
+		},
+		{
+			name:               "valid chunk without done",
+			body:               validChunkWithoutDone,
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       "Hello",
+		},
+		{
+			name:               "large data event",
+			body:               largeChunk,
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       largeContent,
+		},
+		{
+			name:               "comments before valid chunks",
+			body:               ": OPENROUTER PROCESSING\n\n" + streamingSuccessBody,
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       "Hello",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = io.Copy(io.Discard, r.Body)
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			t.Cleanup(upstream.Close)
+
+			cfg := intercept.Config{
+				BaseURL: upstream.URL,
+			}
+			cred := intercept.BYOK{Secret: "test-key", Header: intercept.AuthHeaderAuthorization}
+
+			params := &ChatCompletionNewParamsWrapper{
+				ChatCompletionNewParams: openai.ChatCompletionNewParams{
+					Model: "gpt-4",
+					Messages: []openai.ChatCompletionMessageParamUnion{
+						openai.UserMessage("hello"),
+					},
+				},
+				Stream: true,
+			}
+
+			interceptor := NewStreamingInterceptor(uuid.New(), params, cfg, cred, http.Header{}, otel.Tracer("streaming_test"))
+			interceptor.Setup(slog.Make(), &testutil.MockRecorder{}, nil)
+
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+			w := httptest.NewRecorder()
+			err := interceptor.ProcessRequest(w, req)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.expectedStatusCode, w.Code, "response status code")
+			assert.Contains(t, w.Body.String(), tc.expectedBody, "response body")
+			if tc.unexpectedBody != "" {
+				assert.NotContains(t, w.Body.String(), tc.unexpectedBody, "response body")
+			}
 		})
 	}
 }


### PR DESCRIPTION
OpenRouter can return comment-only SSE heartbeats with no data frames, which previously surfaced as a generic JSON EOF error.

Add SSE stream accounting for chat completions so empty, comment-only, `[DONE]`-only, or malformed upstream streams become clear 502 responses instead of confusing client-side EOF failures.

The gateway canonical model-name fix was split into #26039.

> Mux updated this PR on behalf of Mike.
