### PR TITLE
feat: expand template abstract authoring

### DIFF
--- a/cli/templateedit.go
+++ b/cli/templateedit.go
@@ -20,6 +20,7 @@ func (r *RootCmd) templateEdit() *serpent.Command {
 		name                           string
 		displayName                    string
 		description                    string
+		abstract                       string
 		icon                           string
 		defaultTTL                     time.Duration
 		activityBump                   time.Duration
@@ -95,6 +96,10 @@ func (r *RootCmd) templateEdit() *serpent.Command {
 
 			if !userSetOption(inv, "description") {
 				description = template.Description
+			}
+
+			if !userSetOption(inv, "abstract") {
+				abstract = template.Abstract
 			}
 
 			if !userSetOption(inv, "icon") {
@@ -177,6 +182,7 @@ func (r *RootCmd) templateEdit() *serpent.Command {
 				Name:               &name,
 				DisplayName:        &displayName,
 				Description:        &description,
+				Abstract:           &abstract,
 				Icon:               &icon,
 				DefaultTTLMillis:   ptr.Ref(defaultTTL.Milliseconds()),
 				ActivityBumpMillis: ptr.Ref(activityBump.Milliseconds()),
@@ -226,6 +232,11 @@ func (r *RootCmd) templateEdit() *serpent.Command {
 			Flag:        "description",
 			Description: "Edit the template description.",
 			Value:       serpent.StringOf(&description),
+		},
+		{
+			Flag:        "abstract",
+			Description: "Edit the detailed template summary used by agents to choose a template.",
+			Value:       serpent.StringOf(&abstract),
 		},
 		{
 			Name:        deprecatedFlagName,

--- a/cli/templateedit_test.go
+++ b/cli/templateedit_test.go
@@ -42,6 +42,7 @@ func TestTemplateEdit(t *testing.T) {
 		name := "new-template-name"
 		displayName := "New Display Name 789"
 		desc := "lorem ipsum dolor sit amet et cetera"
+		abstract := "longer summary for agents"
 		icon := "/icon/new-icon.png"
 		defaultTTL := 12 * time.Hour
 		allowUserCancelWorkspaceJobs := false
@@ -53,6 +54,7 @@ func TestTemplateEdit(t *testing.T) {
 			"--name", name,
 			"--display-name", displayName,
 			"--description", desc,
+			"--abstract", abstract,
 			"--icon", icon,
 			"--default-ttl", defaultTTL.String(),
 			"--allow-user-cancel-workspace-jobs=" + strconv.FormatBool(allowUserCancelWorkspaceJobs),
@@ -71,6 +73,7 @@ func TestTemplateEdit(t *testing.T) {
 		assert.Equal(t, name, updated.Name)
 		assert.Equal(t, displayName, updated.DisplayName)
 		assert.Equal(t, desc, updated.Description)
+		assert.Equal(t, abstract, updated.Abstract)
 		assert.Equal(t, icon, updated.Icon)
 		assert.Equal(t, defaultTTL.Milliseconds(), updated.DefaultTTLMillis)
 		assert.Equal(t, allowUserCancelWorkspaceJobs, updated.AllowUserCancelWorkspaceJobs)
@@ -155,11 +158,13 @@ func TestTemplateEdit(t *testing.T) {
 
 		initialDisplayName := "This is a template"
 		initialDescription := "This is description"
+		initialAbstract := "This is an agent-facing summary"
 		initialIcon := "/img/icon.png"
 
 		template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID, func(ctr *codersdk.CreateTemplateRequest) {
 			ctr.DisplayName = initialDisplayName
 			ctr.Description = initialDescription
+			ctr.Abstract = initialAbstract
 			ctr.Icon = initialIcon
 		})
 
@@ -168,6 +173,7 @@ func TestTemplateEdit(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, initialDisplayName, created.DisplayName)
 		assert.Equal(t, initialDescription, created.Description)
+		assert.Equal(t, initialAbstract, created.Abstract)
 		assert.Equal(t, initialIcon, created.Icon)
 
 		// Test the cli command.
@@ -195,6 +201,7 @@ func TestTemplateEdit(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, template.Name, updated.Name) // doesn't change
 		assert.Equal(t, description, updated.Description)
+		assert.Equal(t, initialAbstract, updated.Abstract)
 		assert.Equal(t, displayName, updated.DisplayName)
 		assert.Equal(t, icon, updated.Icon)
 	})
@@ -208,11 +215,13 @@ func TestTemplateEdit(t *testing.T) {
 
 		initialDisplayName := "This is a template"
 		initialDescription := "This is description"
+		initialAbstract := "This is an agent-facing summary"
 		initialIcon := "/img/icon.png"
 
 		template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID, func(ctr *codersdk.CreateTemplateRequest) {
 			ctr.DisplayName = initialDisplayName
 			ctr.Description = initialDescription
+			ctr.Abstract = initialAbstract
 			ctr.Icon = initialIcon
 		})
 
@@ -221,6 +230,7 @@ func TestTemplateEdit(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, initialDisplayName, created.DisplayName)
 		assert.Equal(t, initialDescription, created.Description)
+		assert.Equal(t, initialAbstract, created.Abstract)
 		assert.Equal(t, initialIcon, created.Icon)
 
 		// Test the cli command.
@@ -229,6 +239,7 @@ func TestTemplateEdit(t *testing.T) {
 			"edit",
 			template.Name,
 			"--description", "",
+			"--abstract", "",
 			"--display-name", "",
 			"--icon", "",
 		}
@@ -248,6 +259,7 @@ func TestTemplateEdit(t *testing.T) {
 		// These properties are removed, as the API considers it as "delete" request
 		// See: https://github.com/coder/coder/issues/5066
 		assert.Equal(t, "", updated.Description)
+		assert.Equal(t, "", updated.Abstract)
 		assert.Equal(t, "", updated.Icon)
 		assert.Equal(t, "", updated.DisplayName)
 	})

--- a/cli/testdata/coder_templates_edit_--help.golden
+++ b/cli/testdata/coder_templates_edit_--help.golden
@@ -9,6 +9,10 @@ OPTIONS:
   -O, --org string, $CODER_ORGANIZATION
           Select which organization (uuid or name) to use.
 
+      --abstract string
+          Edit the detailed template summary used by agents to choose a
+          template.
+
       --activity-bump duration
           Edit the template activity bump - workspaces created from this
           template will have their shutdown time bumped by this value when

--- a/coderd/database/modelqueries.go
+++ b/coderd/database/modelqueries.go
@@ -83,6 +83,7 @@ func (q *sqlQuerier) GetAuthorizedTemplates(ctx context.Context, arg GetTemplate
 		arg.ExactDisplayName,
 		arg.FuzzyName,
 		arg.FuzzyDisplayName,
+		arg.FuzzySearch,
 		pq.Array(arg.IDs),
 		arg.Deprecated,
 		arg.HasAITask,

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -25000,17 +25000,28 @@ WHERE
 			END
 		ELSE true
 	END
+	-- Filter by general search text, matching on name, display name, description, or abstract
+	AND CASE
+		WHEN $7 :: text != '' THEN
+			(
+				lower(t.name) ILIKE '%' || REPLACE(REPLACE(REPLACE(REPLACE(lower($7), chr(92), chr(92) || chr(92)), '%', chr(92) || '%'), '_', chr(92) || '_'), ' ', '') || '%' ESCAPE '\'
+				OR lower(t.display_name) ILIKE '%' || REPLACE(REPLACE(REPLACE(lower($7), chr(92), chr(92) || chr(92)), '%', chr(92) || '%'), '_', chr(92) || '_') || '%' ESCAPE '\'
+				OR lower(t.description) ILIKE '%' || REPLACE(REPLACE(REPLACE(lower($7), chr(92), chr(92) || chr(92)), '%', chr(92) || '%'), '_', chr(92) || '_') || '%' ESCAPE '\'
+				OR lower(t.abstract) ILIKE '%' || REPLACE(REPLACE(REPLACE(lower($7), chr(92), chr(92) || chr(92)), '%', chr(92) || '%'), '_', chr(92) || '_') || '%' ESCAPE '\'
+			)
+		ELSE true
+	END
 	-- Filter by ids
 	AND CASE
-		WHEN array_length($7 :: uuid[], 1) > 0 THEN
-			t.id = ANY($7)
+		WHEN array_length($8 :: uuid[], 1) > 0 THEN
+			t.id = ANY($8)
 		ELSE true
 	END
 	-- Filter by deprecated
 	AND CASE
-		WHEN $8 :: boolean IS NOT NULL THEN
+		WHEN $9 :: boolean IS NOT NULL THEN
 			CASE
-				WHEN $8 :: boolean THEN
+				WHEN $9 :: boolean THEN
 					t.deprecated != ''
 				ELSE
 					t.deprecated = ''
@@ -25019,27 +25030,27 @@ WHERE
 	END
 	-- Filter by has_ai_task in latest version
 	AND CASE
-		WHEN $9 :: boolean IS NOT NULL THEN
-			tv.has_ai_task = $9 :: boolean
+		WHEN $10 :: boolean IS NOT NULL THEN
+			tv.has_ai_task = $10 :: boolean
 		ELSE true
 	END
 	-- Filter by author_id
 	AND CASE
-		  WHEN $10 :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN
-			  t.created_by = $10
+		  WHEN $11 :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN
+			  t.created_by = $11
 		  ELSE true
 	END
 	-- Filter by author_username
 	AND CASE
-		  WHEN $11 :: text != '' THEN
-			  t.created_by = (SELECT id FROM users WHERE lower(users.username) = lower($11) AND deleted = false)
+		  WHEN $12 :: text != '' THEN
+			  t.created_by = (SELECT id FROM users WHERE lower(users.username) = lower($12) AND deleted = false)
 		  ELSE true
 	END
 
 	-- Filter by has_external_agent in latest version
 	AND CASE
-		WHEN $12 :: boolean IS NOT NULL THEN
-			tv.has_external_agent = $12 :: boolean
+		WHEN $13 :: boolean IS NOT NULL THEN
+			tv.has_external_agent = $13 :: boolean
 		ELSE true
 	END
   -- Authorize Filter clause will be injected below in GetAuthorizedTemplates
@@ -25054,6 +25065,7 @@ type GetTemplatesWithFilterParams struct {
 	ExactDisplayName string       `db:"exact_display_name" json:"exact_display_name"`
 	FuzzyName        string       `db:"fuzzy_name" json:"fuzzy_name"`
 	FuzzyDisplayName string       `db:"fuzzy_display_name" json:"fuzzy_display_name"`
+	FuzzySearch      string       `db:"fuzzy_search" json:"fuzzy_search"`
 	IDs              []uuid.UUID  `db:"ids" json:"ids"`
 	Deprecated       sql.NullBool `db:"deprecated" json:"deprecated"`
 	HasAITask        sql.NullBool `db:"has_ai_task" json:"has_ai_task"`
@@ -25070,6 +25082,7 @@ func (q *sqlQuerier) GetTemplatesWithFilter(ctx context.Context, arg GetTemplate
 		arg.ExactDisplayName,
 		arg.FuzzyName,
 		arg.FuzzyDisplayName,
+		arg.FuzzySearch,
 		pq.Array(arg.IDs),
 		arg.Deprecated,
 		arg.HasAITask,

--- a/coderd/database/queries/templates.sql
+++ b/coderd/database/queries/templates.sql
@@ -54,6 +54,17 @@ WHERE
 			END
 		ELSE true
 	END
+	-- Filter by general search text, matching on name, display name, description, or abstract
+	AND CASE
+		WHEN @fuzzy_search :: text != '' THEN
+			(
+				lower(t.name) ILIKE '%' || REPLACE(REPLACE(REPLACE(REPLACE(lower(@fuzzy_search), chr(92), chr(92) || chr(92)), '%', chr(92) || '%'), '_', chr(92) || '_'), ' ', '') || '%' ESCAPE '\'
+				OR lower(t.display_name) ILIKE '%' || REPLACE(REPLACE(REPLACE(lower(@fuzzy_search), chr(92), chr(92) || chr(92)), '%', chr(92) || '%'), '_', chr(92) || '_') || '%' ESCAPE '\'
+				OR lower(t.description) ILIKE '%' || REPLACE(REPLACE(REPLACE(lower(@fuzzy_search), chr(92), chr(92) || chr(92)), '%', chr(92) || '%'), '_', chr(92) || '_') || '%' ESCAPE '\'
+				OR lower(t.abstract) ILIKE '%' || REPLACE(REPLACE(REPLACE(lower(@fuzzy_search), chr(92), chr(92) || chr(92)), '%', chr(92) || '%'), '_', chr(92) || '_') || '%' ESCAPE '\'
+			)
+		ELSE true
+	END
 	-- Filter by ids
 	AND CASE
 		WHEN array_length(@ids :: uuid[], 1) > 0 THEN

--- a/coderd/searchquery/search.go
+++ b/coderd/searchquery/search.go
@@ -328,7 +328,7 @@ func Templates(ctx context.Context, db database.Store, actorID uuid.UUID, query 
 	// Always lowercase for all searches.
 	query = strings.ToLower(query)
 	values, errors := searchTerms(query, func(term string, values url.Values) error {
-		// Default to the display name
+		// Bare terms preserve the existing template search behavior by matching display names.
 		values.Add("display_name", term)
 		return nil
 	})
@@ -344,6 +344,7 @@ func Templates(ctx context.Context, db database.Store, actorID uuid.UUID, query 
 		ExactDisplayName: parser.String(values, "", "exact_display_name"),
 		FuzzyName:        parser.String(values, "", "name"),
 		FuzzyDisplayName: parser.String(values, "", "display_name"),
+		FuzzySearch:      parser.String(values, "", "search"),
 		IDs:              parser.UUIDs(values, []uuid.UUID{}, "ids"),
 		Deprecated:       parser.NullableBoolean(values, sql.NullBool{}, "deprecated"),
 		HasAITask:        parser.NullableBoolean(values, sql.NullBool{}, "has-ai-task"),

--- a/coderd/searchquery/search_test.go
+++ b/coderd/searchquery/search_test.go
@@ -963,6 +963,20 @@ func TestSearchTemplates(t *testing.T) {
 			},
 		},
 		{
+			Name:  "SearchField",
+			Query: "search:rust",
+			Expected: database.GetTemplatesWithFilterParams{
+				FuzzySearch: "rust",
+			},
+		},
+		{
+			Name:  "SearchFieldQuoted",
+			Query: `search:"rust compiler"`,
+			Expected: database.GetTemplatesWithFilterParams{
+				FuzzySearch: "rust compiler",
+			},
+		},
+		{
 			Name:  "NameField",
 			Query: "name:testname",
 			Expected: database.GetTemplatesWithFilterParams{

--- a/coderd/templatepreview/templatepreview.go
+++ b/coderd/templatepreview/templatepreview.go
@@ -1,0 +1,10 @@
+package templatepreview
+
+const (
+	// ListDescriptionRunes limits short template descriptions in list responses.
+	ListDescriptionRunes = 200
+	// ListAbstractRunes limits agent-facing template abstracts in list responses.
+	ListAbstractRunes = 500
+	// ParameterDescriptionRunes limits parameter descriptions in template detail responses.
+	ParameterDescriptionRunes = 300
+)

--- a/coderd/x/chatd/chattool/chattool.go
+++ b/coderd/x/chatd/chattool/chattool.go
@@ -3,7 +3,6 @@ package chattool
 import (
 	"context"
 	"encoding/json"
-	"unicode/utf8"
 
 	"charm.land/fantasy"
 	"github.com/google/uuid"
@@ -115,21 +114,6 @@ func provisionerJobTerminal(status database.ProvisionerJobStatus) bool {
 	default:
 		return false
 	}
-}
-
-func truncateRunes(value string, maxLen int) string {
-	if maxLen <= 0 || value == "" {
-		return ""
-	}
-	if utf8.RuneCountInString(value) <= maxLen {
-		return value
-	}
-
-	runes := []rune(value)
-	if maxLen > len(runes) {
-		maxLen = len(runes)
-	}
-	return string(runes[:maxLen])
 }
 
 // buildErrorResult is a structured error response that preserves

--- a/coderd/x/chatd/chattool/listtemplates.go
+++ b/coderd/x/chatd/chattool/listtemplates.go
@@ -16,6 +16,8 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/templatepreview"
+	stringutil "github.com/coder/coder/v2/coderd/util/strings"
 )
 
 const listTemplatesPageSize = 10
@@ -27,7 +29,7 @@ type ListTemplatesOptions struct {
 }
 
 type listTemplatesArgs struct {
-	Query string `json:"query,omitempty" description:"Optional text to filter templates by name or description."`
+	Query string `json:"query,omitempty" description:"Optional text to filter templates by name, display name, description, or abstract."`
 	Page  int    `json:"page,omitempty" description:"Page number for pagination (starts at 1). Each page returns up to 10 templates."`
 }
 
@@ -40,8 +42,8 @@ func ListTemplates(db database.Store, organizationID uuid.UUID, options ListTemp
 	return fantasy.NewAgentTool(
 		"list_templates",
 		"List available workspace templates. Optionally filter by a "+
-			"search query matching template name or description. "+
-			"Results include short UI descriptions and agent-facing abstracts when present. "+
+			"search query matching template name, display name, description, or abstract. "+
+			"Description is short UI text; abstract is richer selection context. "+
 			"Results are ordered by number of active developers (most popular first). "+
 			"Returns 10 per page. Use the page parameter to paginate through results.",
 		func(ctx context.Context, args listTemplatesArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
@@ -58,9 +60,8 @@ func ListTemplates(db database.Store, organizationID uuid.UUID, options ListTemp
 					Valid: true,
 				},
 			}
-			query := strings.TrimSpace(args.Query)
-			if query != "" {
-				filterParams.FuzzyName = query
+			if query := strings.TrimSpace(args.Query); query != "" {
+				filterParams.FuzzySearch = query
 			}
 
 			var allowlist map[uuid.UUID]bool
@@ -126,10 +127,10 @@ func ListTemplates(db database.Store, organizationID uuid.UUID, options ListTemp
 					item["display_name"] = display
 				}
 				if desc := strings.TrimSpace(t.Description); desc != "" {
-					item["description"] = truncateRunes(desc, 200)
+					item["description"] = stringutil.Truncate(desc, templatepreview.ListDescriptionRunes, stringutil.TruncateWithEllipsis)
 				}
 				if abstract := strings.TrimSpace(t.Abstract); abstract != "" {
-					item["abstract"] = abstract
+					item["abstract"] = stringutil.Truncate(abstract, templatepreview.ListAbstractRunes, stringutil.TruncateWithEllipsis)
 				}
 				if count, ok := ownerCounts[t.ID]; ok && count > 0 {
 					item["active_developers"] = count

--- a/coderd/x/chatd/chattool/listtemplates_test.go
+++ b/coderd/x/chatd/chattool/listtemplates_test.go
@@ -132,13 +132,13 @@ func TestListTemplates_Abstract(t *testing.T) {
 		wantPresent bool
 	}{
 		{
-			name: "LongAbstract",
+			name: "TruncatesLongAbstract",
 			template: database.Template{
 				Name:        "with-abstract",
 				Description: "short description",
 				Abstract:    strings.Repeat("a", 1000),
 			},
-			want:        strings.Repeat("a", 1000),
+			want:        strings.Repeat("a", 499) + "…",
 			wantPresent: true,
 		},
 		{
@@ -189,6 +189,74 @@ func TestListTemplates_Abstract(t *testing.T) {
 			if tc.wantPresent {
 				require.Equal(t, tc.want, got.(string))
 			}
+		})
+	}
+}
+
+func TestListTemplates_Query(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		query              string
+		matchedDescription string
+		matchedAbstract    string
+		otherDescription   string
+		otherAbstract      string
+	}{
+		{
+			name:               "MatchesAbstract",
+			query:              "rust compiler",
+			matchedDescription: "Short card text.",
+			matchedAbstract:    "Use this template for Rust compiler work and systems debugging.",
+			otherDescription:   "Short card text.",
+			otherAbstract:      "Use this template for frontend and API work.",
+		},
+		{
+			name:               "MatchesDescription",
+			query:              "cuda toolkit",
+			matchedDescription: "Short card text for CUDA toolkit work.",
+			matchedAbstract:    "Use this template for systems debugging.",
+			otherDescription:   "Short card text.",
+			otherAbstract:      "Use this template for frontend and API work.",
+		},
+		{
+			name:               "EscapesLikeWildcards",
+			query:              "%",
+			matchedDescription: "Short card text.",
+			matchedAbstract:    "Use this template when the workload needs 100% GPU access.",
+			otherDescription:   "Short card text.",
+			otherAbstract:      "Use this template for frontend and API work.",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := newListTemplatesFixture(t)
+			matched := dbgen.Template(t, fixture.db, database.Template{
+				OrganizationID: fixture.org.ID,
+				CreatedBy:      fixture.user.ID,
+				Name:           "matched-dev",
+				DisplayName:    "Matched Dev",
+				Description:    tc.matchedDescription,
+				Abstract:       tc.matchedAbstract,
+			})
+			dbgen.Template(t, fixture.db, database.Template{
+				OrganizationID: fixture.org.ID,
+				CreatedBy:      fixture.user.ID,
+				Name:           "other-dev",
+				DisplayName:    "Other Dev",
+				Description:    tc.otherDescription,
+				Abstract:       tc.otherAbstract,
+			})
+
+			input, err := json.Marshal(map[string]string{"query": tc.query})
+			require.NoError(t, err)
+			items := fixture.listTemplates(t, string(input))
+			require.Len(t, items, 1)
+			require.Equal(t, matched.ID.String(), items[0]["id"].(string))
 		})
 	}
 }

--- a/coderd/x/chatd/chattool/readtemplate.go
+++ b/coderd/x/chatd/chattool/readtemplate.go
@@ -10,6 +10,8 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/templatepreview"
+	stringutil "github.com/coder/coder/v2/coderd/util/strings"
 )
 
 // ReadTemplateOptions configures the read_template tool.
@@ -103,7 +105,7 @@ func ReadTemplate(db database.Store, organizationID uuid.UUID, options ReadTempl
 					param["display_name"] = display
 				}
 				if desc := strings.TrimSpace(p.Description); desc != "" {
-					param["description"] = truncateRunes(desc, 300)
+					param["description"] = stringutil.Truncate(desc, templatepreview.ParameterDescriptionRunes, stringutil.TruncateWithEllipsis)
 				}
 				if p.DefaultValue != "" {
 					param["default"] = p.DefaultValue

--- a/codersdk/toolsdk/chatgpt.go
+++ b/codersdk/toolsdk/chatgpt.go
@@ -152,6 +152,7 @@ var ChatGPTSearch = Tool[SearchArgs, SearchResult]{
 To pick what you want to search for, use the following query formats:
 
 - ` + "`" + `templates/<template-query>` + "`" + `: List templates. The query accepts the following, optional parameters delineated by whitespace:
+	- "search:<text>" - Search by template name, display name, description, or abstract. Quote multi-word values. Examples: "search:rust" and search:"rust compiler"
 	- "name:<name>" - Fuzzy search by template name (substring matching). Example: "name:docker"
 	- "organization:<organization>" - Filter by organization ID or name. Example: "organization:coder"
 	- "deprecated:<true|false>" - Filter by deprecated status. Example: "deprecated:true"

--- a/codersdk/toolsdk/chatgpt_test.go
+++ b/codersdk/toolsdk/chatgpt_test.go
@@ -196,6 +196,39 @@ func TestChatGPTSearch_TemplateIncludesAbstract(t *testing.T) {
 	require.Equal(t, desc, byTitle["No Abstract"].Text)
 }
 
+func TestChatGPTSearch_TemplateSearchMatchesAbstract(t *testing.T) {
+	t.Parallel()
+
+	client, store := coderdtest.NewWithDatabase(t, nil)
+	owner := coderdtest.CreateFirstUser(t, client)
+
+	matched := dbgen.Template(t, store, database.Template{
+		OrganizationID: owner.OrganizationID,
+		CreatedBy:      owner.UserID,
+		Name:           "systems-dev",
+		DisplayName:    "Systems Dev",
+		Description:    "Short card text.",
+		Abstract:       "Use this template for rust compiler internals.",
+	})
+	dbgen.Template(t, store, database.Template{
+		OrganizationID: owner.OrganizationID,
+		CreatedBy:      owner.UserID,
+		Name:           "web-dev",
+		DisplayName:    "Web Dev",
+		Description:    "Short card text.",
+		Abstract:       "Use this template for frontend and API work.",
+	})
+
+	deps, err := toolsdk.NewDeps(client)
+	require.NoError(t, err)
+
+	result, err := testTool(t, toolsdk.ChatGPTSearch, deps, toolsdk.SearchArgs{Query: `templates/search:"rust compiler"`})
+	require.NoError(t, err)
+	require.Len(t, result.Results, 1)
+	require.Equal(t, "template:"+matched.ID.String(), result.Results[0].ID)
+	require.Contains(t, result.Results[0].Text, "rust compiler")
+}
+
 func TestChatGPTSearch_WorkspaceSearch(t *testing.T) {
 	t.Parallel()
 

--- a/codersdk/toolsdk/toolsdk.go
+++ b/codersdk/toolsdk/toolsdk.go
@@ -18,6 +18,8 @@ import (
 	"github.com/coder/aisdk-go"
 	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/cli/cliui"
+	"github.com/coder/coder/v2/coderd/templatepreview"
+	stringutil "github.com/coder/coder/v2/coderd/util/strings"
 	"github.com/coder/coder/v2/coderd/workspaceapps/appurl"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
@@ -635,15 +637,7 @@ var ListTemplates = Tool[NoArgs, []MinimalTemplate]{
 		}
 		minimalTemplates := make([]MinimalTemplate, len(templates))
 		for i, template := range templates {
-			minimalTemplates[i] = MinimalTemplate{
-				DisplayName:     template.DisplayName,
-				ID:              template.ID.String(),
-				Name:            template.Name,
-				Description:     template.Description,
-				Abstract:        template.Abstract,
-				ActiveVersionID: template.ActiveVersionID,
-				ActiveUserCount: template.ActiveUserCount,
-			}
+			minimalTemplates[i] = toMinimalTemplate(template, templatepreview.ListAbstractRunes)
 		}
 		return minimalTemplates, nil
 	},
@@ -773,16 +767,8 @@ When selecting a preset: if a preset is marked default and the user has not spec
 			return TemplateDetail{}, xerrors.Errorf("get template presets: %w", err)
 		}
 		detail := TemplateDetail{
-			MinimalTemplate: MinimalTemplate{
-				DisplayName:     template.DisplayName,
-				ID:              template.ID.String(),
-				Name:            template.Name,
-				Description:     template.Description,
-				Abstract:        template.Abstract,
-				ActiveVersionID: template.ActiveVersionID,
-				ActiveUserCount: template.ActiveUserCount,
-			},
-			Parameters: parameters,
+			MinimalTemplate: toMinimalTemplate(template, 0),
+			Parameters:      parameters,
 		}
 		for _, p := range presets {
 			detail.Presets = append(detail.Presets, toPresetView(p))
@@ -1724,6 +1710,22 @@ type MinimalTemplate struct {
 	Abstract        string    `json:"abstract,omitempty"`
 	ActiveVersionID uuid.UUID `json:"active_version_id"`
 	ActiveUserCount int       `json:"active_user_count"`
+}
+
+func toMinimalTemplate(t codersdk.Template, abstractMaxRunes int) MinimalTemplate {
+	abstract := strings.TrimSpace(t.Abstract)
+	if abstractMaxRunes > 0 {
+		abstract = stringutil.Truncate(abstract, abstractMaxRunes, stringutil.TruncateWithEllipsis)
+	}
+	return MinimalTemplate{
+		DisplayName:     t.DisplayName,
+		ID:              t.ID.String(),
+		Name:            t.Name,
+		Description:     t.Description,
+		Abstract:        abstract,
+		ActiveVersionID: t.ActiveVersionID,
+		ActiveUserCount: t.ActiveUserCount,
+	}
 }
 
 type WorkspaceLSArgs struct {

--- a/codersdk/toolsdk/toolsdk_test.go
+++ b/codersdk/toolsdk/toolsdk_test.go
@@ -314,6 +314,38 @@ func TestTools(t *testing.T) {
 		}
 	})
 
+	t.Run("ListTemplatesReturnsAbstractPreview", func(t *testing.T) {
+		ctx := testutil.Context(t, testutil.WaitShort)
+		abstract := strings.Repeat("a", 600)
+		_, err := client.UpdateTemplateMeta(ctx, r.Template.ID, codersdk.UpdateTemplateMeta{
+			Abstract: &abstract,
+		})
+		require.NoError(t, err)
+
+		originalAbstract := r.Template.Abstract
+		t.Cleanup(func() {
+			_, err := client.UpdateTemplateMeta(context.Background(), r.Template.ID, codersdk.UpdateTemplateMeta{
+				Abstract: &originalAbstract,
+			})
+			require.NoError(t, err)
+		})
+
+		tb, err := toolsdk.NewDeps(memberClient)
+		require.NoError(t, err)
+		result, err := testTool(t, toolsdk.ListTemplates, tb, toolsdk.NoArgs{})
+		require.NoError(t, err)
+
+		var found bool
+		for _, template := range result {
+			if template.ID == r.Template.ID.String() {
+				require.Equal(t, strings.Repeat("a", 499)+"…", template.Abstract)
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "expected fixture template in list response")
+	})
+
 	t.Run("Whoami", func(t *testing.T) {
 		tb, err := toolsdk.NewDeps(memberClient)
 		require.NoError(t, err)

--- a/docs/ai-coder/agents/getting-started.md
+++ b/docs/ai-coder/agents/getting-started.md
@@ -19,7 +19,7 @@ Before you begin, confirm the following:
 - **Network access** from the control plane to your LLM provider. Workspaces
   do not need LLM access — only the control plane does.
 - **At least one template** with a
-  [descriptive name and description](./platform-controls/template-optimization.md)
+  [descriptive name, description, and abstract](./platform-controls/template-optimization.md)
   for the agent to select when provisioning workspaces.
 - **Admin access** to the Coder deployment for configuring providers.
 - **Coder Agents User role** assigned to each user who needs to interact with Coder Agents.
@@ -125,11 +125,11 @@ immediately with no provisioning delay.
 
 ## Optimize your templates
 
-The agent selects templates based on their **name and description** — it does
-not read Terraform. Clear, specific descriptions are the most important factor
-in whether the agent picks the right template.
+The agent selects templates based on their **name, description, and abstract**.
+It does not read Terraform. Keep the description short for dashboard cards, and
+use the abstract for richer agent-facing routing details.
 
-Update your template descriptions to include:
+Update your template abstracts to include:
 
 - The language, framework, or stack the template targets.
 - Which repository or service it is for, if applicable.
@@ -137,15 +137,15 @@ Update your template descriptions to include:
 
 **Good examples:**
 
-| Description                                                                                 | Why it works                                 |
+| Abstract                                                                                    | Why it works                                 |
 |---------------------------------------------------------------------------------------------|----------------------------------------------|
 | Python backend services for the payments repo. Includes Poetry, Python 3.12, and PostgreSQL | Specific language, repo, and toolchain       |
 | React frontend development for the customer portal. Node 20, pnpm, Storybook pre-installed  | Clear stack, named project, key tools listed |
 | General-purpose Go development environment with Go 1.23, Docker, and common CLI tools       | Broad but descriptive                        |
 
-**Descriptions to avoid:**
+**Abstracts to avoid:**
 
-| Description        | Problem                                         |
+| Abstract           | Problem                                         |
 |--------------------|-------------------------------------------------|
 | Team A template v2 | No information about what the template is for   |
 | Dev environment    | Too generic to distinguish from other templates |

--- a/docs/ai-coder/agents/index.md
+++ b/docs/ai-coder/agents/index.md
@@ -83,13 +83,16 @@ This means:
 - **Lower infrastructure cost** — workspaces are only created when the agent
   needs to do real development work.
 
-When a workspace _is_ needed, the agent reads the templates available to that user —
-including their descriptions and parameters — selects the appropriate one, and
-creates a workspace automatically. Template visibility is scoped to the user's role and permissions, so the agent can only select templates the user is authorized to use. Users can also manually choose which workspace is used when starting a new chat.
+When a workspace _is_ needed, the agent reads the templates available to that user,
+including their descriptions, abstracts, and parameters. It selects the
+appropriate one and creates a workspace automatically. Template visibility is
+scoped to the user's role and permissions, so the agent can only select
+templates the user is authorized to use. Users can also manually choose which
+workspace is used when starting a new chat.
 
-Platform teams control template routing by writing clear template descriptions.
-For example, a description like "Use this template for Python backend services
-in the payments repo" helps the agent select the correct infrastructure.
+Platform teams control template routing by writing clear template abstracts.
+For example, an abstract like "Use this template for Python backend services in
+the payments repo" helps the agent select the correct infrastructure.
 
 **Examples of what triggers workspace creation:**
 

--- a/docs/ai-coder/agents/platform-controls/index.md
+++ b/docs/ai-coder/agents/platform-controls/index.md
@@ -75,12 +75,13 @@ The same value is exposed over the experimental chat configuration API:
 
 Platform teams control which templates are available to agents and how the agent
 selects them. When a developer describes a task, the agent reads template
-descriptions to determine which template to provision.
+names, descriptions, and abstracts to determine which template to provision.
 
-By writing clear template descriptions — for example, "Use this template for
-Python backend services in the payments repo" — platform teams can guide the
-agent toward the correct infrastructure without requiring developers to
-understand template selection at all.
+Descriptions are short dashboard card text. Abstracts are longer summaries for
+agent routing. By writing clear template abstracts, for example, "Use this
+template for Python backend services in the payments repo," platform teams can
+guide the agent toward the correct infrastructure without requiring developers
+to understand template selection at all.
 
 Administrators can also restrict which templates are available to agents
 using the template allowlist at **Agents** > **Settings** >
@@ -92,9 +93,9 @@ stricter policies to agent-created workspaces without affecting the manual
 workspace experience.
 
 See [Template Optimization](./template-optimization.md) for best practices on writing
-discoverable descriptions, restricting template visibility, configuring network
-boundaries, scoping credentials, and designing template parameters for agent
-use.
+discoverable template metadata, restricting template visibility, configuring
+network boundaries, scoping credentials, and designing template parameters for
+agent use.
 
 ### MCP servers
 

--- a/docs/ai-coder/agents/platform-controls/template-optimization.md
+++ b/docs/ai-coder/agents/platform-controls/template-optimization.md
@@ -5,9 +5,10 @@ agent decides it needs compute — to read files, write code, run commands, or
 execute builds.
 
 When a workspace is needed, the agent reads the available templates, selects
-the appropriate one based on its name and description, and provisions a
-workspace automatically. Administrators can restrict which templates the agent
-can see using the [template allowlist](#restrict-available-templates).
+the appropriate one based on its name, short description, and abstract, then
+provisions a workspace automatically. Administrators can restrict which
+templates the agent can see using the
+[template allowlist](#restrict-available-templates).
 
 This guide covers best practices for creating templates that are discoverable
 and useful to Coder Agents.
@@ -37,19 +38,20 @@ manually create workspaces from any template they have access to. This lets
 platform teams apply stricter policies to agent workloads without affecting
 the manual workspace experience.
 
-## Write discoverable template descriptions
+## Write discoverable template metadata
 
-The agent selects templates by reading their names and descriptions — the same
-metadata shown on the templates page in the Coder dashboard, sorted by number
-of active developers. It does not inspect the template's Terraform to
-understand what infrastructure is inside.
+The agent selects templates by reading their names, descriptions, and abstracts,
+sorted by number of active developers. It does not inspect the template's
+Terraform to understand what infrastructure is inside.
 
-This means the template description is the single most important factor in
-whether the agent picks the right template for a given task.
+Use the template description as short card text for the dashboard. Use the
+abstract for a longer agent-facing summary that explains when the agent should
+choose the template. The abstract is the best place for routing details that do
+not fit in the short description.
 
 ### What to include
 
-A good template description tells the agent:
+A good template abstract tells the agent:
 
 - What language, framework, or stack the template is for.
 - Which repository or service it targets, if applicable.
@@ -58,25 +60,25 @@ A good template description tells the agent:
 
 ### Examples
 
-| Description                                                                                 | Why it works                                                       |
-|---------------------------------------------------------------------------------------------|--------------------------------------------------------------------|
-| Python backend services for the payments repo. Includes Poetry, Python 3.12, and PostgreSQL | Specific language, repo, and toolchain                             |
-| React frontend development for the customer portal. Node 20, pnpm, Storybook pre-installed  | Clear stack, named project, key tools listed                       |
-| General-purpose Go development environment with Go 1.23, Docker, and common CLI tools       | Broad but descriptive — the agent can match it to Go-related tasks |
-| Java microservices for the order-processing pipeline. Maven, JDK 21, Kafka client libraries | Names the service domain and build tool                            |
+| Abstract                                                                                    | Why it works                                                      |
+|---------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
+| Python backend services for the payments repo. Includes Poetry, Python 3.12, and PostgreSQL | Specific language, repo, and toolchain                            |
+| React frontend development for the customer portal. Node 20, pnpm, Storybook pre-installed  | Clear stack, named project, key tools listed                      |
+| General-purpose Go development environment with Go 1.23, Docker, and common CLI tools       | Broad but descriptive, the agent can match it to Go-related tasks |
+| Java microservices for the order-processing pipeline. Maven, JDK 21, Kafka client libraries | Names the service domain and build tool                           |
 
-| Description        | Why it fails                                                            |
-|--------------------|-------------------------------------------------------------------------|
-| Team A template v2 | No information about what the template is for                           |
-| Dev environment    | Too generic — the agent cannot distinguish this from any other template |
-| k8s-prod-2024      | Internal shorthand that carries no meaning for the agent                |
-| Default            | Tells the agent nothing                                                 |
+| Abstract           | Why it fails                                                           |
+|--------------------|------------------------------------------------------------------------|
+| Team A template v2 | No information about what the template is for                          |
+| Dev environment    | Too generic, the agent cannot distinguish this from any other template |
+| k8s-prod-2024      | Internal shorthand that carries no meaning for the agent               |
+| Default            | Tells the agent nothing                                                |
 
 > [!TIP]
 > If many developers already use a template, the agent is more likely to
 > select it because templates are sorted by active developer count. A
-> well-written description on a popular template is the strongest routing
-> signal you can provide.
+> well-written abstract on a popular template is the strongest routing signal
+> you can provide.
 
 ### Template display names
 

--- a/docs/ai-coder/agents/tasks-to-chats-migration.md
+++ b/docs/ai-coder/agents/tasks-to-chats-migration.md
@@ -118,7 +118,7 @@ Key differences:
   `file`, and `file-reference` types) instead of a plain string.
 - `template_version_id` and `template_version_preset_id` are removed. The
   agent selects a template automatically based on the prompt and available
-  template descriptions. To pin to a specific workspace, pass
+  template descriptions and abstracts. To pin to a specific workspace, pass
   `workspace_id` instead.
 - Optionally pass `model_config_id` to override the default model, or
   `mcp_server_ids` to attach MCP servers.
@@ -378,10 +378,11 @@ unchanged. The reasons are different from Tasks, but the principle holds:
 <!-- TODO: Expand this section with concrete Terraform examples once
      template patterns stabilize. -->
 
-- **Clear descriptions.** The agent selects templates by reading names and
-  descriptions. Include the target language, framework, repository, and
-  type of work. For example: *"Python backend services for the payments
-  repo. Includes Poetry, Python 3.12, and PostgreSQL."*
+- **Clear template metadata.** The agent selects templates by reading names,
+  descriptions, and abstracts. Keep descriptions short for dashboard cards.
+  Use abstracts for the target language, framework, repository, and type of
+  work. For example: *"Python backend services for the payments repo.
+  Includes Poetry, Python 3.12, and PostgreSQL."*
 - **Pre-installed dependencies.** Language runtimes, build tools, `git`,
   and project-specific dependencies should be baked into the image. Time
   the agent spends installing tools is time not spent on the task.
@@ -445,7 +446,7 @@ unused when the chat is driven by the Chats API:
 
 See
 [Template Optimization](./platform-controls/template-optimization.md)
-for the full guide on writing discoverable descriptions, configuring
+for the full guide on writing discoverable template metadata, configuring
 network boundaries, scoping credentials, and pre-installing dependencies.
 
 ### Pre-creating a workspace for deterministic results

--- a/docs/reference/cli/templates_edit.md
+++ b/docs/reference/cli/templates_edit.md
@@ -35,6 +35,14 @@ Edit the template display name.
 
 Edit the template description.
 
+### --abstract
+
+|      |                     |
+|------|---------------------|
+| Type | <code>string</code> |
+
+Edit the detailed template summary used by agents to choose a template.
+
 ### --deprecated
 
 |      |                     |

--- a/site/src/modules/templates/validation.ts
+++ b/site/src/modules/templates/validation.ts
@@ -1,0 +1,4 @@
+export const MAX_TEMPLATE_DESCRIPTION_CHAR_LIMIT = 128;
+export const MAX_TEMPLATE_DESCRIPTION_MESSAGE = `Please enter a description that is no longer than ${MAX_TEMPLATE_DESCRIPTION_CHAR_LIMIT} characters.`;
+export const MAX_TEMPLATE_ABSTRACT_CHAR_LIMIT = 2048;
+export const MAX_TEMPLATE_ABSTRACT_MESSAGE = `Please enter an abstract that is no longer than ${MAX_TEMPLATE_ABSTRACT_CHAR_LIMIT} characters.`;

--- a/site/src/pages/CreateTemplatePage/CreateTemplateForm.stories.tsx
+++ b/site/src/pages/CreateTemplatePage/CreateTemplateForm.stories.tsx
@@ -131,3 +131,13 @@ export const DuplicateTemplateWithVariables: Story = {
 		],
 	},
 };
+
+export const DuplicateTemplateWithAbstract: Story = {
+	args: {
+		copiedTemplate: {
+			...MockTemplate,
+			abstract:
+				"This template provisions a remote VS Code environment backed by a Kubernetes pod. Agents should prefer it when the user mentions Kubernetes, k8s, or remote development.",
+		},
+	},
+};

--- a/site/src/pages/CreateTemplatePage/CreateTemplateForm.tsx
+++ b/site/src/pages/CreateTemplatePage/CreateTemplateForm.tsx
@@ -34,6 +34,12 @@ import { Label } from "#/components/Label/Label";
 import { OrganizationAutocomplete } from "#/components/OrganizationAutocomplete/OrganizationAutocomplete";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { ProvisionerTagsField } from "#/modules/provisioners/ProvisionerTagsField";
+import {
+	MAX_TEMPLATE_ABSTRACT_CHAR_LIMIT,
+	MAX_TEMPLATE_ABSTRACT_MESSAGE,
+	MAX_TEMPLATE_DESCRIPTION_CHAR_LIMIT,
+	MAX_TEMPLATE_DESCRIPTION_MESSAGE,
+} from "#/modules/templates/validation";
 import { SelectedTemplate } from "#/pages/CreateWorkspacePage/SelectedTemplate";
 import { docs } from "#/utils/docs";
 import {
@@ -50,12 +56,11 @@ import {
 import { TemplateUpload, type TemplateUploadProps } from "./TemplateUpload";
 import { VariableInput } from "./VariableInput";
 
-const MAX_DESCRIPTION_CHAR_LIMIT = 128;
-
 export interface CreateTemplateFormData {
 	name: string;
 	display_name: string;
 	description: string;
+	abstract: string;
 	icon: string;
 	default_ttl_hours: number;
 	autostart_requirement_days_of_week: TemplateAutostartRequirementDaysValue[];
@@ -76,8 +81,12 @@ const validationSchema = Yup.object({
 	name: nameValidator("Name"),
 	display_name: displayNameValidator("Display name"),
 	description: Yup.string().max(
-		MAX_DESCRIPTION_CHAR_LIMIT,
-		"Please enter a description that is less than or equal to 128 characters.",
+		MAX_TEMPLATE_DESCRIPTION_CHAR_LIMIT,
+		MAX_TEMPLATE_DESCRIPTION_MESSAGE,
+	),
+	abstract: Yup.string().max(
+		MAX_TEMPLATE_ABSTRACT_CHAR_LIMIT,
+		MAX_TEMPLATE_ABSTRACT_MESSAGE,
 	),
 	icon: Yup.string().optional(),
 });
@@ -86,6 +95,7 @@ const defaultInitialValues: CreateTemplateFormData = {
 	name: "",
 	display_name: "",
 	description: "",
+	abstract: "",
 	icon: "",
 	default_ttl_hours: 24,
 	// autostop_requirement is an enterprise-only feature, and the server ignores
@@ -344,13 +354,26 @@ export const CreateTemplateForm: FC<CreateTemplateFormProps> = (props) => {
 
 					<TextField
 						{...getFieldHelpers("description", {
-							maxLength: MAX_DESCRIPTION_CHAR_LIMIT,
+							maxLength: MAX_TEMPLATE_DESCRIPTION_CHAR_LIMIT,
 						})}
 						disabled={isSubmitting}
 						rows={5}
 						multiline
 						fullWidth
 						label="Description"
+					/>
+
+					<TextField
+						{...getFieldHelpers("abstract", {
+							helperText:
+								"Detailed summary for agents to help choose the right template.",
+							maxLength: MAX_TEMPLATE_ABSTRACT_CHAR_LIMIT,
+						})}
+						disabled={isSubmitting}
+						rows={5}
+						multiline
+						fullWidth
+						label="Abstract"
 					/>
 
 					<IconField

--- a/site/src/pages/CreateTemplatePage/utils.ts
+++ b/site/src/pages/CreateTemplatePage/utils.ts
@@ -21,6 +21,7 @@ export const newTemplate = (
 		cors_behavior: null,
 		display_name: formData.display_name,
 		description: formData.description,
+		abstract: formData.abstract,
 		icon: formData.icon,
 		allow_user_autostart: formData.allow_user_autostart,
 		allow_user_autostop: formData.allow_user_autostop,

--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
@@ -27,6 +27,12 @@ import {
 	StackLabel,
 	StackLabelHelperText,
 } from "#/components/StackLabel/StackLabel";
+import {
+	MAX_TEMPLATE_ABSTRACT_CHAR_LIMIT,
+	MAX_TEMPLATE_ABSTRACT_MESSAGE,
+	MAX_TEMPLATE_DESCRIPTION_CHAR_LIMIT,
+	MAX_TEMPLATE_DESCRIPTION_MESSAGE,
+} from "#/modules/templates/validation";
 import { docs } from "#/utils/docs";
 import {
 	displayNameValidator,
@@ -36,19 +42,17 @@ import {
 	onChangeTrimmed,
 } from "#/utils/formUtils";
 
-const MAX_DESCRIPTION_CHAR_LIMIT = 128;
-const MAX_DESCRIPTION_MESSAGE = `Please enter a description that is no longer than ${MAX_DESCRIPTION_CHAR_LIMIT} characters.`;
-const MAX_ABSTRACT_CHAR_LIMIT = 2048;
-const MAX_ABSTRACT_MESSAGE = `Please enter an abstract that is no longer than ${MAX_ABSTRACT_CHAR_LIMIT} characters.`;
-
 export const validationSchema = Yup.object({
 	name: nameValidator("Name"),
 	display_name: displayNameValidator("Display name"),
 	description: Yup.string().max(
-		MAX_DESCRIPTION_CHAR_LIMIT,
-		MAX_DESCRIPTION_MESSAGE,
+		MAX_TEMPLATE_DESCRIPTION_CHAR_LIMIT,
+		MAX_TEMPLATE_DESCRIPTION_MESSAGE,
 	),
-	abstract: Yup.string().max(MAX_ABSTRACT_CHAR_LIMIT, MAX_ABSTRACT_MESSAGE),
+	abstract: Yup.string().max(
+		MAX_TEMPLATE_ABSTRACT_CHAR_LIMIT,
+		MAX_TEMPLATE_ABSTRACT_MESSAGE,
+	),
 	allow_user_cancel_workspace_jobs: Yup.boolean(),
 	icon: iconValidator,
 	require_active_version: Yup.boolean(),
@@ -143,7 +147,7 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
 
 					<TextField
 						{...getFieldHelpers("description", {
-							maxLength: MAX_DESCRIPTION_CHAR_LIMIT,
+							maxLength: MAX_TEMPLATE_DESCRIPTION_CHAR_LIMIT,
 						})}
 						multiline
 						disabled={isSubmitting}
@@ -156,7 +160,7 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
 						{...getFieldHelpers("abstract", {
 							helperText:
 								"Detailed summary for agents to help choose the right template.",
-							maxLength: MAX_ABSTRACT_CHAR_LIMIT,
+							maxLength: MAX_TEMPLATE_ABSTRACT_CHAR_LIMIT,
 						})}
 						multiline
 						disabled={isSubmitting}


### PR DESCRIPTION
## Stack Context

This PR stacks on #25978. The base PR adds the `templates.abstract` field and exposes it to agents. This follow-up adds the authoring, search, and documentation pieces that were split out of the base PR.

## What?

- Adds `templates edit --abstract` for scripted updates and backfills.
- Adds the **Abstract** field to the create template form and copied-template story.
- Adds `search:` template filtering that matches name, display name, description, and abstract.
- Uses abstract-aware search from `list_templates` and documents it for the ChatGPT search tool.
- Updates agent docs to explain that `description` is short dashboard text and `abstract` is richer agent routing context.
- Keeps list responses token-conscious by truncating abstract previews while detail reads keep the full abstract.
- Centralizes template preview and frontend validation limits so agent tools and UI forms do not drift.

## Why?

The base PR is intentionally limited to the core field, template settings edit path, and agent payload plumbing. This PR restores the broader usability pieces in a separate reviewable change so admins can populate abstracts, agents can search them, and docs can explain how to use them.

## Validation

- `make fmt`
- `make test RUN='TestSearchTemplates|TestListTemplates_Query|TestReadTemplate|TestChatGPTSearch_TemplateSearchMatchesAbstract|TestTools/ListTemplatesReturnsAbstract'`
- `make test RUN='TestTools/ListTemplates|TestTools/ListTemplatesReturnsAbstractPreview'`
- `pnpm --dir site test -- CreateTemplatePage.test.tsx TemplateSettingsPage.test.tsx`
- `make lint`
- `make pre-commit`
- Commit hook pre-commit validation, including generation, formatting, linting, and slim build.

> Mux created this PR on behalf of Mike.
