### PR TITLE
ci: reduce flake-go parallelism to fit 4-vCPU runner

### DIFF
--- a/.github/workflows/flake-go.yaml
+++ b/.github/workflows/flake-go.yaml
@@ -76,8 +76,8 @@ jobs:
         uses: ./.github/actions/test-go-pg
         with:
           postgres-version: "13"
-          test-parallelism-packages: "2"
-          test-parallelism-tests: "8"
+          test-parallelism-packages: "4"
+          test-parallelism-tests: "12"
           test-count: "35"
           test-packages: ${{ fromJSON(steps.selector.outputs.matrix).include[0].package }}
           run-regex: ${{ fromJSON(steps.selector.outputs.matrix).include[0].run_regex }}

--- a/.github/workflows/flake-go.yaml
+++ b/.github/workflows/flake-go.yaml
@@ -76,8 +76,8 @@ jobs:
         uses: ./.github/actions/test-go-pg
         with:
           postgres-version: "13"
-          test-parallelism-packages: "4"
-          test-parallelism-tests: "16"
+          test-parallelism-packages: "2"
+          test-parallelism-tests: "8"
           test-count: "35"
           test-packages: ${{ fromJSON(steps.selector.outputs.matrix).include[0].package }}
           run-regex: ${{ fromJSON(steps.selector.outputs.matrix).include[0].run_regex }}


### PR DESCRIPTION
The flake-go workflow runs on `depot-ubuntu-22.04-4` (4 vCPU, 16 GB). With `test-parallelism-packages=4` and `test-parallelism-tests=16`, the worst-case concurrency is 64 in-flight subtests, which OOMed the runner on PRs whose `whichtests` selection covered `./cli` and `./enterprise/cli` at the same time.

Concrete example: run [26845700051](https://github.com/coder/coder/actions/runs/26845700051) peaked at 14.8 / 16 GB and the kernel SIGKILLed `cli.test` at 1m12s into the step. `gotestsum` correctly recorded `FAIL ./cli signal: killed` and then kept running `./enterprise/cli` (the heaviest remaining package) until the job-level `timeout-minutes: 20` fired.

Keep package parallelism at 4 to match the runner vCPU count, but reduce intra-package test parallelism from 16 to 12. That lowers the worst-case concurrency from `4 x 16 = 64` to `4 x 12 = 48` in-flight subtests. Using the observed OOM run as a rough model, this lands around an 11 GB peak on a 16 GB runner, leaving about 5 GB of headroom while avoiding the overly conservative 16-slot first pass.

`test-count` stays at 35 to preserve the flake-detection probability bumped in #25981. The detection math (catching 5%-rate flakes goes from 72% at count=25 to 83% at count=35) was a deliberate choice and this PR does not roll it back.

Trade-offs:
- Median run gets somewhat slower wall-clock. The median selection is small (often empty), so the absolute difference should be seconds, not minutes.
- Large selections that previously OOMed may now run longer instead of OOMing. They may still hit the 20-minute job timeout if the selection is genuinely pathological (e.g. PRs touching dozens of `./cli` test files). That class of failure is a separate problem and needs a selection-size cap in `whichtests` rather than another parallelism cut.
