### PR TITLE
feat: cli: add support for supplying ephemeral parameters at workspace creation

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -271,6 +271,11 @@ func (r *RootCmd) Create(opts CreateOptions) *serpent.Command {
 				return xerrors.Errorf("can't parse given parameter defaults: %w", err)
 			}
 
+			cliEphemeralParameters, err := asWorkspaceBuildParameters(parameterFlags.ephemeralParameters)
+			if err != nil {
+				return xerrors.Errorf("can't parse given ephemeral parameter values: %w", err)
+			}
+
 			var sourceWorkspaceParameters []codersdk.WorkspaceBuildParameter
 			if copyParametersFrom != "" {
 				sourceWorkspaceParameters, err = client.WorkspaceBuildParameters(inv.Context(), sourceWorkspace.LatestBuild.ID)
@@ -329,6 +334,9 @@ func (r *RootCmd) Create(opts CreateOptions) *serpent.Command {
 				RichParameterFile:     parameterFlags.richParameterFile,
 				RichParameters:        cliBuildParameters,
 				RichParameterDefaults: cliBuildParameterDefaults,
+
+				PromptEphemeralParameters: parameterFlags.promptEphemeralParameters,
+				EphemeralParameters:       cliEphemeralParameters,
 
 				SourceWorkspaceParameters: sourceWorkspaceParameters,
 
@@ -455,9 +463,8 @@ func (r *RootCmd) Create(opts CreateOptions) *serpent.Command {
 		},
 		cliui.SkipPromptOption(),
 	)
-	cmd.Options = append(cmd.Options, parameterFlags.cliParameters()...)
-	cmd.Options = append(cmd.Options, parameterFlags.cliParameterDefaults()...)
-	cmd.Options = append(cmd.Options, parameterFlags.useParameterDefaultsOption())
+	cmd.Options = append(cmd.Options, parameterFlags.allOptions()...)
+
 	orgContext.AttachOptions(cmd)
 	return cmd
 }

--- a/cli/testdata/coder_create_--help.golden
+++ b/cli/testdata/coder_create_--help.golden
@@ -13,12 +13,28 @@ OPTIONS:
   -O, --org string, $CODER_ORGANIZATION
           Select which organization (uuid or name) to use.
 
+      --always-prompt bool
+          Always prompt all parameters. Does not pull parameter values from
+          existing workspace.
+
       --automatic-updates string, $CODER_WORKSPACE_AUTOMATIC_UPDATES (default: never)
           Specify automatic updates setting for the workspace (accepts 'always'
           or 'never').
 
+      --build-option string-array, $CODER_BUILD_OPTION
+          Build option value in the format "name=value".
+          DEPRECATED: Use --ephemeral-parameter instead.
+
+      --build-options bool
+          Prompt for one-time build options defined with ephemeral parameters.
+          DEPRECATED: Use --prompt-ephemeral-parameters instead.
+
       --copy-parameters-from string, $CODER_WORKSPACE_COPY_PARAMETERS_FROM
           Specify the source workspace name to copy parameters from.
+
+      --ephemeral-parameter string-array, $CODER_EPHEMERAL_PARAMETER
+          Set the value of ephemeral parameters defined in the template. The
+          format is "name=value".
 
       --no-wait bool, $CODER_CREATE_NO_WAIT
           Return immediately after creating the workspace. The build will run in
@@ -33,6 +49,11 @@ OPTIONS:
       --preset string, $CODER_PRESET_NAME
           Specify the name of a template version preset. Use 'none' to
           explicitly indicate that no preset should be used.
+
+      --prompt-ephemeral-parameters bool, $CODER_PROMPT_EPHEMERAL_PARAMETERS
+          Prompt to set values of ephemeral parameters defined in the template.
+          If a value has been set via --ephemeral-parameter, it will not be
+          prompted for.
 
       --rich-parameter-file string, $CODER_RICH_PARAMETER_FILE
           Specify a file path with values for rich parameters defined in the

--- a/docs/admin/templates/extending-templates/parameters.md
+++ b/docs/admin/templates/extending-templates/parameters.md
@@ -232,8 +232,8 @@ parameters, the **Create workspace** button is disabled until the issues are res
 Ephemeral parameters are introduced to users in order to model specific
 behaviors in a Coder workspace, such as reverting to a previous image, restoring
 from a volume snapshot, or building a project without using cache. These
-parameters are only settable when starting, updating, or restarting a workspace
-and do not persist after the workspace is stopped.
+parameters are settable when creating, starting, updating, or restarting a workspace
+but do not persist after the workspace is stopped.
 
 Since these parameters are ephemeral in nature, subsequent builds proceed in the
 standard manner:

--- a/docs/reference/cli/create.md
+++ b/docs/reference/cli/create.md
@@ -100,6 +100,41 @@ Return immediately after creating the workspace. The build will run in the backg
 
 Bypass confirmation prompts.
 
+### --build-option
+
+|             |                                  |
+|-------------|----------------------------------|
+| Type        | <code>string-array</code>        |
+| Environment | <code>$CODER_BUILD_OPTION</code> |
+
+Build option value in the format "name=value".
+
+### --build-options
+
+|      |                   |
+|------|-------------------|
+| Type | <code>bool</code> |
+
+Prompt for one-time build options defined with ephemeral parameters.
+
+### --ephemeral-parameter
+
+|             |                                         |
+|-------------|-----------------------------------------|
+| Type        | <code>string-array</code>               |
+| Environment | <code>$CODER_EPHEMERAL_PARAMETER</code> |
+
+Set the value of ephemeral parameters defined in the template. The format is "name=value".
+
+### --prompt-ephemeral-parameters
+
+|             |                                                 |
+|-------------|-------------------------------------------------|
+| Type        | <code>bool</code>                               |
+| Environment | <code>$CODER_PROMPT_EPHEMERAL_PARAMETERS</code> |
+
+Prompt to set values of ephemeral parameters defined in the template. If a value has been set via --ephemeral-parameter, it will not be prompted for.
+
 ### --parameter
 
 |             |                                    |
@@ -135,6 +170,14 @@ Rich parameter default values in the format "name=value".
 | Environment | <code>$CODER_WORKSPACE_USE_PARAMETER_DEFAULTS</code> |
 
 Automatically accept parameter defaults when no value is provided.
+
+### --always-prompt
+
+|      |                   |
+|------|-------------------|
+| Type | <code>bool</code> |
+
+Always prompt all parameters. Does not pull parameter values from existing workspace.
 
 ### -O, --org
 

--- a/docs/reference/cli/external-workspaces_create.md
+++ b/docs/reference/cli/external-workspaces_create.md
@@ -100,6 +100,41 @@ Return immediately after creating the workspace. The build will run in the backg
 
 Bypass confirmation prompts.
 
+### --build-option
+
+|             |                                  |
+|-------------|----------------------------------|
+| Type        | <code>string-array</code>        |
+| Environment | <code>$CODER_BUILD_OPTION</code> |
+
+Build option value in the format "name=value".
+
+### --build-options
+
+|      |                   |
+|------|-------------------|
+| Type | <code>bool</code> |
+
+Prompt for one-time build options defined with ephemeral parameters.
+
+### --ephemeral-parameter
+
+|             |                                         |
+|-------------|-----------------------------------------|
+| Type        | <code>string-array</code>               |
+| Environment | <code>$CODER_EPHEMERAL_PARAMETER</code> |
+
+Set the value of ephemeral parameters defined in the template. The format is "name=value".
+
+### --prompt-ephemeral-parameters
+
+|             |                                                 |
+|-------------|-------------------------------------------------|
+| Type        | <code>bool</code>                               |
+| Environment | <code>$CODER_PROMPT_EPHEMERAL_PARAMETERS</code> |
+
+Prompt to set values of ephemeral parameters defined in the template. If a value has been set via --ephemeral-parameter, it will not be prompted for.
+
 ### --parameter
 
 |             |                                    |
@@ -135,6 +170,14 @@ Rich parameter default values in the format "name=value".
 | Environment | <code>$CODER_WORKSPACE_USE_PARAMETER_DEFAULTS</code> |
 
 Automatically accept parameter defaults when no value is provided.
+
+### --always-prompt
+
+|      |                   |
+|------|-------------------|
+| Type | <code>bool</code> |
+
+Always prompt all parameters. Does not pull parameter values from existing workspace.
 
 ### -O, --org
 

--- a/enterprise/cli/testdata/coder_external-workspaces_create_--help.golden
+++ b/enterprise/cli/testdata/coder_external-workspaces_create_--help.golden
@@ -13,12 +13,28 @@ OPTIONS:
   -O, --org string, $CODER_ORGANIZATION
           Select which organization (uuid or name) to use.
 
+      --always-prompt bool
+          Always prompt all parameters. Does not pull parameter values from
+          existing workspace.
+
       --automatic-updates string, $CODER_WORKSPACE_AUTOMATIC_UPDATES (default: never)
           Specify automatic updates setting for the workspace (accepts 'always'
           or 'never').
 
+      --build-option string-array, $CODER_BUILD_OPTION
+          Build option value in the format "name=value".
+          DEPRECATED: Use --ephemeral-parameter instead.
+
+      --build-options bool
+          Prompt for one-time build options defined with ephemeral parameters.
+          DEPRECATED: Use --prompt-ephemeral-parameters instead.
+
       --copy-parameters-from string, $CODER_WORKSPACE_COPY_PARAMETERS_FROM
           Specify the source workspace name to copy parameters from.
+
+      --ephemeral-parameter string-array, $CODER_EPHEMERAL_PARAMETER
+          Set the value of ephemeral parameters defined in the template. The
+          format is "name=value".
 
       --no-wait bool, $CODER_CREATE_NO_WAIT
           Return immediately after creating the workspace. The build will run in
@@ -33,6 +49,11 @@ OPTIONS:
       --preset string, $CODER_PRESET_NAME
           Specify the name of a template version preset. Use 'none' to
           explicitly indicate that no preset should be used.
+
+      --prompt-ephemeral-parameters bool, $CODER_PROMPT_EPHEMERAL_PARAMETERS
+          Prompt to set values of ephemeral parameters defined in the template.
+          If a value has been set via --ephemeral-parameter, it will not be
+          prompted for.
 
       --rich-parameter-file string, $CODER_RICH_PARAMETER_FILE
           Specify a file path with values for rich parameters defined in the


### PR DESCRIPTION
Resolves the issue of `--prompt-ephemeral-parameters` and `--ephemeral-parameter` not being available for use in the `coder create` workspace creation command (they are only available in `coder start` command). Back when they were [added originally](https://github.com/coder/coder/pull/15030) it seems to have been an oversight that they were left out.

The problem this solves:

```
coder create --parameter my_ephemeral_parameter=foo
error: prepare build: ephemeral parameter "my_ephemeral_parameter" can be used only with --prompt-ephemeral-parameters or --ephemeral-parameter flag
```

```
coder create my-test-ws -t general --ephemeral-parameter my_ephemeral_parameter=foo
parsing flags ([create my-test-ws -t general --ephemeral-parameter my_ephemeral_parameter=foo]) for "coder create": unknown flag: --ephemeral-parameter
```

Tested on a template with the following:

```
data "coder_parameter" "my_ephemeral_parameter" {
  name         = "my_ephemeral_parameter"
  type         = "bool"
  description  = "true or false?"
  mutable      = true
  default      = false
  ephemeral    = true
}

resource "coder_env" "debug_ephemeral" {
  agent_id = coder_agent.main.id
  name     = "EPHEMERAL_TEST"
  value    = data.coder_parameter.my_ephemeral_parameter.value
}
```

By running:

```
➜  coder git:(rowan/coder-create-5495) ✗ go run cmd/coder/main.go create --ephemeral-parameter my_ephemeral_parameter=true
> Specify a name for your workspace: ws4
Select a template below to preview the provisioned infrastructure:
?  kasmvnc-ubuntu-coder-dev used by 1 active developer
Select a preset below:
?  Small (2 CPU / 4 GB)
....
...
The ws4 workspace has been created at Jun  3 12:36:38!

➜  coder git:(rowan/coder-create-5495) ✗ coder ssh ws4               
workspace-ws4-5d6994756f-qlwnl% echo $EPHEMERAL_TEST
true
workspace-ws4-5d6994756f-qlwnl% exit
```

