### PR TITLE
feat(site/src/pages/AgentsPage/components/GitPanel): replace tab scrollbar with dropdown

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tabs/SidebarTabView.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tabs/SidebarTabView.tsx
@@ -104,6 +104,16 @@ function useTabScroll() {
 	return { ref, canScrollLeft, canScrollRight, scrollLeft, scrollRight };
 }
 
+/** Shared className fragments for underline-style tab triggers. */
+const tabTriggerBase = cn(
+	"inline-flex shrink-0 items-center gap-2 whitespace-nowrap",
+	"border-0 border-b border-solid border-transparent",
+	"bg-transparent px-1 py-2.5 text-sm text-content-secondary",
+	"cursor-pointer transition-colors -mb-px",
+	"hover:text-content-primary",
+);
+const tabTriggerActive = "border-b-content-primary text-content-primary";
+
 export const SidebarTabView: FC<SidebarTabViewProps> = ({
 	tabs,
 	isExpanded,
@@ -188,7 +198,7 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 		<div className="flex h-full min-w-0 flex-col overflow-hidden bg-surface-primary">
 			<div
 				role="tablist"
-				className="relative flex shrink-0 items-center gap-2 border-0 border-b border-solid border-border-default px-4 py-1.5 lg:px-3 lg:py-1"
+				className="relative flex shrink-0 items-stretch gap-2 border-0 border-b border-solid border-border-default px-4 lg:px-3"
 			>
 				{onClose && (
 					<Button
@@ -196,7 +206,7 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 						size="icon"
 						onClick={onClose}
 						aria-label="Close panel"
-						className="size-7 shrink-0 lg:hidden"
+						className="size-7 shrink-0 self-center lg:hidden"
 					>
 						<ArrowLeftIcon />
 					</Button>
@@ -207,12 +217,12 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 						size="icon"
 						onClick={onToggleSidebarCollapsed}
 						aria-label="Expand sidebar"
-						className="mr-1 size-7 shrink-0"
+						className="mr-1 size-7 shrink-0 self-center"
 					>
 						<PanelLeftIcon />
 					</Button>
 				)}
-				<div className="relative min-w-0 flex-1">
+				<div className="relative flex min-w-0 flex-1">
 					{canScrollLeft && (
 						<button
 							type="button"
@@ -225,24 +235,21 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 					)}
 					<div
 						ref={tabScrollRef}
-						className="flex w-full items-center gap-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+						className="flex w-full items-stretch gap-6 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
 					>
 						{tabs.map((tab) => {
 							const isActive = effectiveTabId === tab.id;
 							return (
-								<Button
+								<button
+									type="button"
 									key={tab.id}
 									id={`${tabIdPrefix}-tab-${tab.id}`}
 									role="tab"
 									aria-selected={isActive}
 									onClick={() => onActiveTabChange(tab.id)}
-									variant="outline"
-									size="lg"
 									className={cn(
-										"shrink-0 h-6 min-w-0 gap-1.5 px-2 py-0 bg-surface-primary",
-										isActive &&
-											"bg-surface-quaternary/25 text-content-primary hover:bg-surface-quaternary/50",
-										tab.badge && "pr-0",
+										tabTriggerBase,
+										isActive && tabTriggerActive,
 									)}
 								>
 									{tab.icon}
@@ -250,32 +257,30 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 									{tab.badge && (
 										<span
 											className={cn(
-												"flex -my-px items-center self-stretch transition-opacity",
-												!isActive && "opacity-50",
+												"flex items-center transition-opacity",
+												!isActive && "opacity-60",
 											)}
 										>
 											{tab.badge}
 										</span>
 									)}
-								</Button>
+								</button>
 							);
 						})}
 						{desktopChatId && (
-							<Button
+							<button
+								type="button"
 								id={`${tabIdPrefix}-tab-desktop`}
 								role="tab"
 								aria-selected={effectiveTabId === "desktop"}
 								onClick={() => onActiveTabChange("desktop")}
-								variant="outline"
-								size="lg"
 								className={cn(
-									"shrink-0 h-6 min-w-0 gap-1.5 px-2 py-0 bg-surface-primary",
-									effectiveTabId === "desktop" &&
-										"bg-surface-quaternary/25 text-content-primary hover:bg-surface-quaternary/50",
+									tabTriggerBase,
+									effectiveTabId === "desktop" && tabTriggerActive,
 								)}
 							>
 								Desktop
-							</Button>
+							</button>
 						)}
 					</div>
 					{canScrollRight && (
@@ -301,7 +306,7 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 					size="icon"
 					onClick={onToggleExpanded}
 					aria-label={isExpanded ? "Collapse panel" : "Expand panel"}
-					className="hidden size-7 shrink-0 text-content-secondary hover:text-content-primary lg:inline-flex"
+					className="hidden size-7 shrink-0 self-center text-content-secondary hover:text-content-primary lg:inline-flex"
 				>
 					{isExpanded ? <MinimizeIcon /> : <MaximizeIcon />}
 				</Button>

--- a/site/src/pages/AgentsPage/components/GitPanel/GitPanel.tsx
+++ b/site/src/pages/AgentsPage/components/GitPanel/GitPanel.tsx
@@ -1,5 +1,6 @@
 import {
 	CheckIcon,
+	ChevronDownIcon,
 	CircleDotIcon,
 	ColumnsIcon,
 	GitBranchIcon,
@@ -18,7 +19,12 @@ import type {
 	WorkspaceAgentRepoChanges,
 } from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
-import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "#/components/DropdownMenu/DropdownMenu";
 import { cn } from "#/utils/cn";
 import type { ChatMessageInputRef } from "../AgentChatInput";
 import { DiffStatBadge } from "../DiffViewer/DiffStats";
@@ -77,6 +83,120 @@ function repoTabLabel(repoRoot: string): string {
 	const segments = repoRoot.split("/").filter(Boolean);
 	return segments[segments.length - 1] ?? repoRoot;
 }
+
+/** Builds the icon + label for a given view. */
+const viewLabel = (
+	view: GitView,
+	prTab: GitPanelProps["prTab"],
+	prTitle: string | undefined,
+	prState: string | undefined,
+	prDraft: boolean | undefined,
+): { icon: React.ReactNode; text: string } => {
+	if (view.type === "remote") {
+		if (prTab) {
+			return {
+				icon: (
+					<PrStateIcon
+						state={prState}
+						draft={prDraft}
+						className="!size-4 shrink-0"
+					/>
+				),
+				text: prTitle || `PR #${prTab.prNumber}`,
+			};
+		}
+		return {
+			icon: <GitBranchIcon className="!size-3.5 shrink-0" />,
+			text: "Branch",
+		};
+	}
+	return {
+		icon: <CircleDotIcon className="!size-3.5 shrink-0 text-content-warning" />,
+		text: `Working ${repoTabLabel(view.repoRoot)}`,
+	};
+};
+
+interface GitViewSelectorProps {
+	view: GitView;
+	setView: (view: GitView) => void;
+	showRemoteTab: boolean;
+	prTab: GitPanelProps["prTab"];
+	prTitle: string | undefined;
+	prState: string | undefined;
+	prDraft: boolean | undefined;
+	localRepos: string[];
+}
+
+const GitViewSelector: FC<GitViewSelectorProps> = ({
+	view,
+	setView,
+	showRemoteTab,
+	prTab,
+	prTitle,
+	prState,
+	prDraft,
+	localRepos,
+}) => {
+	const allViews: GitView[] = [
+		...(showRemoteTab ? [{ type: "remote" } as const] : []),
+		...localRepos.map((r) => ({ type: "local" as const, repoRoot: r })),
+	];
+
+	const active = viewLabel(view, prTab, prTitle, prState, prDraft);
+
+	// Single tab: just show the label inline, no dropdown.
+	if (allViews.length <= 1) {
+		return (
+			<div className="flex min-w-0 flex-1 items-center gap-1.5 py-1.5 text-xs font-medium text-content-primary">
+				{active.icon}
+				<span className="truncate">{active.text}</span>
+			</div>
+		);
+	}
+
+	// Multiple tabs: dropdown selector.
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<button
+					type="button"
+					className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 border-0 bg-transparent py-1.5 text-xs font-medium text-content-primary"
+				>
+					{active.icon}
+					<span className="truncate">{active.text}</span>
+					<ChevronDownIcon className="size-3.5 shrink-0 opacity-60" />
+				</button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="start" className="max-w-64">
+				{allViews.map((v) => {
+					const label = viewLabel(v, prTab, prTitle, prState, prDraft);
+					const isActive =
+						v.type === view.type &&
+						(v.type === "remote" ||
+							(v.type === "local" &&
+								view.type === "local" &&
+								v.repoRoot === view.repoRoot));
+					return (
+						<DropdownMenuItem
+							key={v.type === "remote" ? "remote" : v.repoRoot}
+							onClick={() => setView(v)}
+							className={cn(
+								"gap-1.5 text-xs",
+								isActive && "bg-surface-secondary text-content-primary",
+							)}
+						>
+							{label.icon}
+							<span className="truncate">{label.text}</span>
+							{isActive && (
+								<CheckIcon className="ml-auto size-3.5 shrink-0" />
+							)}
+						</DropdownMenuItem>
+					);
+				})}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+};
 
 export const GitPanel: FC<GitPanelProps> = ({
 	prTab,
@@ -195,75 +315,17 @@ export const GitPanel: FC<GitPanelProps> = ({
 		<div className="flex h-full flex-col">
 			{/* Toolbar */}
 			<div className="flex shrink-0 items-center gap-2 border-0 border-b border-solid border-border-default px-3">
-				{/* Tabs — scrollable when they overflow */}
-				<ScrollArea
-					className="min-w-0 flex-1"
-					orientation="horizontal"
-					scrollBarClassName="h-1.5"
-				>
-					<div className="flex items-center gap-0.5 py-1.5 text-xs">
-						{showRemoteTab && (
-							<Button
-								variant="outline"
-								size="lg"
-								onClick={() => setView({ type: "remote" })}
-								className={cn(
-									"shrink-0 h-6 min-w-0 gap-1.5 px-2 py-0 bg-surface-primary",
-									view.type === "remote" &&
-										"bg-surface-quaternary/25 text-content-primary hover:bg-surface-quaternary/50",
-								)}
-							>
-								{prTab ? (
-									<>
-										<PrStateIcon
-											state={prState}
-											draft={prDraft}
-											className="!size-4 shrink-0"
-										/>
-										<span className="truncate">
-											{prTitle || `PR #${prTab.prNumber}`}
-										</span>
-									</>
-								) : (
-									<>
-										<GitBranchIcon className="!size-3.5 shrink-0" />
-										<span className="truncate">Branch</span>
-									</>
-								)}
-							</Button>
-						)}
-						{localRepos.map((repoRoot) => {
-							const isActive =
-								view.type === "local" && view.repoRoot === repoRoot;
-							return (
-								<Button
-									key={repoRoot}
-									variant="outline"
-									size="lg"
-									onClick={() => setView({ type: "local", repoRoot })}
-									className={cn(
-										"shrink-0 h-6 min-w-0 gap-1.5 px-2 py-0 bg-surface-primary",
-										isActive &&
-											"bg-surface-quaternary/25 text-content-primary hover:bg-surface-quaternary/50",
-									)}
-								>
-									<CircleDotIcon
-										className={cn(
-											"!size-3.5 shrink-0",
-											isActive
-												? "text-content-warning"
-												: "text-content-warning/60",
-										)}
-									/>
-									<span className="truncate">
-										Working{" "}
-										<span className="opacity-50">{repoTabLabel(repoRoot)}</span>
-									</span>
-								</Button>
-							);
-						})}
-					</div>
-				</ScrollArea>
+				{/* Tab selector — dropdown when multiple tabs, inline label when single */}
+				<GitViewSelector
+					view={view}
+					setView={setView}
+					showRemoteTab={showRemoteTab}
+						prTab={prTab}
+					prTitle={prTitle}
+						prState={prState}
+						prDraft={prDraft}
+						localRepos={localRepos}
+					/>
 				{/* Controls */}
 				<div className="flex shrink-0 items-center gap-1 py-1.5">
 					<div className="flex h-6 items-stretch overflow-hidden rounded-md border border-solid border-border-default">

--- a/site/src/pages/AgentsPage/components/GitPanel/GitPanel.tsx
+++ b/site/src/pages/AgentsPage/components/GitPanel/GitPanel.tsx
@@ -38,24 +38,7 @@ import { RemoteDiffPanel } from "../DiffViewer/RemoteDiffPanel";
 
 type GitView =
 	| { type: "remote" }
-	| { type: "remote-extra"; index: number }
 	| { type: "local"; repoRoot: string };
-
-// Hardcoded extra PR tabs for demo purposes. In production these
-// would come from the backend when multi-PR support is added.
-const EXTRA_PR_TABS: readonly {
-	title: string;
-	state: string;
-	draft: boolean;
-	number: number;
-}[] = [
-	{
-		title: "fix: increase icon sizes for wcag 2.2 compliance",
-		state: "open",
-		draft: false,
-		number: 2,
-	},
-];
 
 const GIT_NOT_SETUP_TITLE = "Git is not set up for this chat";
 const GIT_NOT_SETUP_SENTENCE = "Git is not set up for this chat.";
@@ -129,21 +112,6 @@ const viewLabel = (
 			text: "Branch",
 		};
 	}
-	if (view.type === "remote-extra") {
-		const extra = EXTRA_PR_TABS[view.index];
-		if (extra) {
-			return {
-				icon: (
-					<PrStateIcon
-						state={extra.state}
-						draft={extra.draft}
-						className="!size-4 shrink-0"
-					/>
-				),
-				text: extra.title,
-			};
-		}
-	}
 	if (view.type === "local") {
 		return {
 			icon: <CircleDotIcon className="!size-3.5 shrink-0 text-content-warning" />,
@@ -179,7 +147,6 @@ const GitViewSelector: FC<GitViewSelectorProps> = ({
 }) => {
 	const allViews: GitView[] = [
 		...(showRemoteTab ? [{ type: "remote" } as const] : []),
-		...EXTRA_PR_TABS.map((_, i) => ({ type: "remote-extra" as const, index: i })),
 		...localRepos.map((r) => ({ type: "local" as const, repoRoot: r })),
 	];
 
@@ -214,18 +181,10 @@ const GitViewSelector: FC<GitViewSelectorProps> = ({
 					const isActive =
 						v.type === view.type &&
 						(v.type === "remote" ||
-							(v.type === "remote-extra" &&
-								view.type === "remote-extra" &&
-								v.index === view.index) ||
 							(v.type === "local" &&
 								view.type === "local" &&
 								v.repoRoot === view.repoRoot));
-					const key =
-						v.type === "remote"
-							? "remote"
-							: v.type === "remote-extra"
-								? `remote-extra-${v.index}`
-								: v.repoRoot;
+					const key = v.type === "remote" ? "remote" : v.repoRoot;
 					return (
 						<DropdownMenuItem
 							key={key}
@@ -437,7 +396,7 @@ export const GitPanel: FC<GitPanelProps> = ({
 			</div>
 			{/* Content */}
 			<div className="min-h-0 flex-1">
-				{view.type === "remote" || view.type === "remote-extra" ? (
+				{view.type === "remote" ? (
 					<RemoteContent
 						prTab={prTab}
 						hasGitContext={hasGitContext}

--- a/site/src/pages/AgentsPage/components/GitPanel/GitPanel.tsx
+++ b/site/src/pages/AgentsPage/components/GitPanel/GitPanel.tsx
@@ -36,7 +36,26 @@ import {
 import { LocalDiffPanel } from "../DiffViewer/LocalDiffPanel";
 import { RemoteDiffPanel } from "../DiffViewer/RemoteDiffPanel";
 
-type GitView = { type: "remote" } | { type: "local"; repoRoot: string };
+type GitView =
+	| { type: "remote" }
+	| { type: "remote-extra"; index: number }
+	| { type: "local"; repoRoot: string };
+
+// Hardcoded extra PR tabs for demo purposes. In production these
+// would come from the backend when multi-PR support is added.
+const EXTRA_PR_TABS: readonly {
+	title: string;
+	state: string;
+	draft: boolean;
+	number: number;
+}[] = [
+	{
+		title: "fix: increase icon sizes for wcag 2.2 compliance",
+		state: "open",
+		draft: false,
+		number: 2,
+	},
+];
 
 const GIT_NOT_SETUP_TITLE = "Git is not set up for this chat";
 const GIT_NOT_SETUP_SENTENCE = "Git is not set up for this chat.";
@@ -110,9 +129,30 @@ const viewLabel = (
 			text: "Branch",
 		};
 	}
+	if (view.type === "remote-extra") {
+		const extra = EXTRA_PR_TABS[view.index];
+		if (extra) {
+			return {
+				icon: (
+					<PrStateIcon
+						state={extra.state}
+						draft={extra.draft}
+						className="!size-4 shrink-0"
+					/>
+				),
+				text: extra.title,
+			};
+		}
+	}
+	if (view.type === "local") {
+		return {
+			icon: <CircleDotIcon className="!size-3.5 shrink-0 text-content-warning" />,
+			text: `Working ${repoTabLabel(view.repoRoot)}`,
+		};
+	}
 	return {
-		icon: <CircleDotIcon className="!size-3.5 shrink-0 text-content-warning" />,
-		text: `Working ${repoTabLabel(view.repoRoot)}`,
+		icon: <GitBranchIcon className="!size-3.5 shrink-0" />,
+		text: "Unknown",
 	};
 };
 
@@ -139,6 +179,7 @@ const GitViewSelector: FC<GitViewSelectorProps> = ({
 }) => {
 	const allViews: GitView[] = [
 		...(showRemoteTab ? [{ type: "remote" } as const] : []),
+		...EXTRA_PR_TABS.map((_, i) => ({ type: "remote-extra" as const, index: i })),
 		...localRepos.map((r) => ({ type: "local" as const, repoRoot: r })),
 	];
 
@@ -173,12 +214,21 @@ const GitViewSelector: FC<GitViewSelectorProps> = ({
 					const isActive =
 						v.type === view.type &&
 						(v.type === "remote" ||
+							(v.type === "remote-extra" &&
+								view.type === "remote-extra" &&
+								v.index === view.index) ||
 							(v.type === "local" &&
 								view.type === "local" &&
 								v.repoRoot === view.repoRoot));
+					const key =
+						v.type === "remote"
+							? "remote"
+							: v.type === "remote-extra"
+								? `remote-extra-${v.index}`
+								: v.repoRoot;
 					return (
 						<DropdownMenuItem
-							key={v.type === "remote" ? "remote" : v.repoRoot}
+							key={key}
 							onClick={() => setView(v)}
 							className={cn(
 								"gap-1.5 text-xs",
@@ -387,7 +437,7 @@ export const GitPanel: FC<GitPanelProps> = ({
 			</div>
 			{/* Content */}
 			<div className="min-h-0 flex-1">
-				{view.type === "remote" ? (
+				{view.type === "remote" || view.type === "remote-extra" ? (
 					<RemoteContent
 						prTab={prTab}
 						hasGitContext={hasGitContext}
@@ -397,7 +447,7 @@ export const GitPanel: FC<GitPanelProps> = ({
 						diffStyle={diffStyle}
 						diffStatus={remoteDiffStats}
 					/>
-				) : (
+				) : view.type === "local" ? (
 					<LocalRepoContent
 						repoRoot={view.repoRoot}
 						repo={repositories.get(view.repoRoot)}
@@ -409,7 +459,7 @@ export const GitPanel: FC<GitPanelProps> = ({
 						diffStyle={diffStyle}
 						chatInputRef={chatInputRef}
 					/>
-				)}
+				) : null}
 			</div>
 		</div>
 	);


### PR DESCRIPTION
Replaces the horizontal scrolling tab strip in the Git panel with a dropdown selector.

When only one view exists (single PR or single repo), it renders as an inline label with icon. When multiple views exist (PR + local repos), the active view shows as a truncated label with a chevron that opens a DropdownMenu to switch between views.

Removes the horizontal scrollbar that appeared when tab labels overflowed the panel width.

> Generated with [Coder Agents](https://coder.com/agents) by @tracyjohnsonux