### PR TITLE
fix(site): add openai-compatible endpoint placeholder

### DIFF
--- a/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderForm.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderForm.tsx
@@ -89,7 +89,10 @@ const providerDefaults: Partial<
 		name: "google",
 		baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai/",
 	},
-	"openai-compat": { name: "openai-compat", baseUrl: "" },
+	"openai-compat": {
+		name: "openai-compat",
+		baseUrl: "https://provider.example.com/v1",
+	},
 	openrouter: { name: "openrouter", baseUrl: "https://openrouter.ai/api/v1" },
 	vercel: { name: "vercel", baseUrl: "https://ai-gateway.vercel.sh/v1" },
 };

--- a/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderForm.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderForm.tsx
@@ -89,12 +89,13 @@ const providerDefaults: Partial<
 		name: "google",
 		baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai/",
 	},
-	"openai-compat": {
-		name: "openai-compat",
-		baseUrl: "https://provider.example.com/v1",
-	},
+	"openai-compat": { name: "openai-compat", baseUrl: "" },
 	openrouter: { name: "openrouter", baseUrl: "https://openrouter.ai/api/v1" },
 	vercel: { name: "vercel", baseUrl: "https://ai-gateway.vercel.sh/v1" },
+};
+
+const baseUrlPlaceholders: Partial<Record<AIProviderType, string>> = {
+	"openai-compat": "https://provider.example.com/v1",
 };
 
 const makeOpenAiAnthropicSchema = (editing: boolean) =>
@@ -246,6 +247,7 @@ const apiKeyPlaceholder = (provider: string) => {
 };
 
 const baseUrlPlaceholder = (provider: string) =>
+	baseUrlPlaceholders[provider as keyof typeof baseUrlPlaceholders] ??
 	providerDefaults[provider as keyof typeof providerDefaults]?.baseUrl;
 
 export const ProviderForm: FC<ProviderFormProps> = ({

--- a/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderForm.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderForm.tsx
@@ -94,10 +94,6 @@ const providerDefaults: Partial<
 	vercel: { name: "vercel", baseUrl: "https://ai-gateway.vercel.sh/v1" },
 };
 
-const baseUrlPlaceholders: Partial<Record<AIProviderType, string>> = {
-	"openai-compat": "https://provider.example.com/v1",
-};
-
 const makeOpenAiAnthropicSchema = (editing: boolean) =>
 	Yup.object({
 		type: Yup.string()
@@ -247,8 +243,9 @@ const apiKeyPlaceholder = (provider: string) => {
 };
 
 const baseUrlPlaceholder = (provider: string) =>
-	baseUrlPlaceholders[provider as keyof typeof baseUrlPlaceholders] ??
-	providerDefaults[provider as keyof typeof providerDefaults]?.baseUrl;
+	provider === "openai-compat"
+		? "https://provider.example.com/v1"
+		: providerDefaults[provider as keyof typeof providerDefaults]?.baseUrl;
 
 export const ProviderForm: FC<ProviderFormProps> = ({
 	editing = false,

--- a/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderForm.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderForm.tsx
@@ -94,6 +94,10 @@ const providerDefaults: Partial<
 	vercel: { name: "vercel", baseUrl: "https://ai-gateway.vercel.sh/v1" },
 };
 
+const baseUrlPlaceholders: Partial<Record<AIProviderType, string>> = {
+	"openai-compat": "https://provider.example.com/v1",
+};
+
 const makeOpenAiAnthropicSchema = (editing: boolean) =>
 	Yup.object({
 		type: Yup.string()
@@ -243,9 +247,8 @@ const apiKeyPlaceholder = (provider: string) => {
 };
 
 const baseUrlPlaceholder = (provider: string) =>
-	provider === "openai-compat"
-		? "https://provider.example.com/v1"
-		: providerDefaults[provider as keyof typeof providerDefaults]?.baseUrl;
+	baseUrlPlaceholders[provider as keyof typeof baseUrlPlaceholders] ??
+	providerDefaults[provider as keyof typeof providerDefaults]?.baseUrl;
 
 export const ProviderForm: FC<ProviderFormProps> = ({
 	editing = false,


### PR DESCRIPTION
OpenAI-compatible provider endpoints need to include the upstream OpenAI-compatible prefix, typically `/v1`, because Coder appends request suffixes such as `/chat/completions`, `/responses`, and `/models`. The generic OpenAI-compatible provider form did not show an example endpoint, so it was easy to save a host-only URL that looked valid but would fail when used.

Add `https://provider.example.com/v1` as the Endpoint placeholder for the OpenAI-compatible provider, matching the documented example URL shape.
