### PR TITLE
test(cli): scope retryWithInterval logger per subtest

### DIFF
--- a/cli/ssh_internal_test.go
+++ b/cli/ssh_internal_test.go
@@ -542,11 +542,11 @@ func TestRetryWithInterval(t *testing.T) {
 	const maxAttempts = 3
 
 	dnsErr := &net.DNSError{Err: "no such host", Name: "example.com", IsNotFound: true}
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 
 	t.Run("Succeeds_FirstTry", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitShort)
+		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 
 		attempts := 0
 		err := retryWithInterval(ctx, logger, interval, maxAttempts, func() error {
@@ -560,6 +560,7 @@ func TestRetryWithInterval(t *testing.T) {
 	t.Run("Succeeds_AfterTransientFailures", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitShort)
+		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 
 		attempts := 0
 		err := retryWithInterval(ctx, logger, interval, maxAttempts, func() error {
@@ -576,6 +577,7 @@ func TestRetryWithInterval(t *testing.T) {
 	t.Run("Stops_NonRetryableError", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitShort)
+		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 
 		attempts := 0
 		err := retryWithInterval(ctx, logger, interval, maxAttempts, func() error {
@@ -589,6 +591,7 @@ func TestRetryWithInterval(t *testing.T) {
 	t.Run("Stops_MaxAttemptsExhausted", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitShort)
+		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 
 		attempts := 0
 		err := retryWithInterval(ctx, logger, interval, maxAttempts, func() error {
@@ -602,6 +605,7 @@ func TestRetryWithInterval(t *testing.T) {
 	t.Run("Stops_ContextCanceled", func(t *testing.T) {
 		t.Parallel()
 		ctx, cancel := context.WithCancel(context.Background())
+		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 
 		attempts := 0
 		err := retryWithInterval(ctx, logger, interval, maxAttempts, func() error {


### PR DESCRIPTION
## Summary

Minor test hygiene: create the `slogtest` logger **inside each `TestRetryWithInterval` subtest** (bound to that subtest's own `*testing.T`) instead of sharing one logger bound to the parent test across parallel subtests.

### Why

The shared, parent-bound logger meant warnings emitted from parallel subtest goroutines were attributed to the parent test's output stream rather than the subtest that produced them. Binding each logger to its own subtest gives correct per-subtest log attribution and matches how the rest of the codebase uses `slogtest` in parallel subtests.

### This is not a flake fix

This does **not** fix coder/internal#1553, and intentionally does not close it. That report was a misattribution: `TestRetryWithInterval` actually passes. It was mislabeled `unknown` because raw stderr output from `cdr.dev/slog`'s `syncwriter` (the builtin `println` firing when a `sloghuman` sink's `io.Pipe` writer is closed, emitted by a concurrent `coder port-forward -v` test during teardown) interleaved into the `go test` output stream and corrupted the `--- PASS: TestRetryWithInterval` line, so `test2json`/`gotestsum` dropped its terminal action. The real, confirmed defect is tracked in **coder/slog#225**.

### Verification

- `go test ./cli -run TestRetryWithInterval -race -count=50` passes.
- Retry warnings are now attributed to the subtest that emitted them rather than the parent.

_Authored by Coder Agents on behalf of @EhabY._