### PR TITLE
fix: render Bedrock agents models with Bedrock identity

### DIFF
--- a/coderd/ai_providers.go
+++ b/coderd/ai_providers.go
@@ -188,6 +188,11 @@ func (api *API) aiProvidersCreate(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	providerType := database.AIProviderType(req.Type)
+	if providerType == database.AiProviderTypeAnthropic && req.Settings.Bedrock != nil {
+		providerType = database.AiProviderTypeBedrock
+	}
+
 	var (
 		row  database.AIProvider
 		keys []database.AIProviderKey
@@ -196,7 +201,7 @@ func (api *API) aiProvidersCreate(rw http.ResponseWriter, r *http.Request) {
 		var txErr error
 		row, txErr = tx.InsertAIProvider(ctx, database.InsertAIProviderParams{
 			ID:          uuid.New(),
-			Type:        database.AIProviderType(req.Type),
+			Type:        providerType,
 			Name:        req.Name,
 			DisplayName: sql.NullString{String: req.DisplayName, Valid: req.DisplayName != ""},
 			Enabled:     req.Enabled,

--- a/coderd/ai_providers_migrate.go
+++ b/coderd/ai_providers_migrate.go
@@ -126,8 +126,12 @@ func SeedAIProvidersFromEnv(
 				for _, k := range existingKeyRows {
 					existingKeys = append(existingKeys, k.APIKey)
 				}
+				effectiveType, err := db2sdk.EffectiveAIProviderType(existing)
+				if err != nil {
+					return xerrors.Errorf("resolve existing provider type for %q: %w", dp.Name, err)
+				}
 				existingDP := desiredAIProvider{
-					Type:    existing.Type,
+					Type:    database.AIProviderType(effectiveType),
 					BaseURL: existing.BaseUrl,
 					Bedrock: existingSettings.Bedrock,
 					Keys:    existingKeys,
@@ -139,11 +143,15 @@ func SeedAIProvidersFromEnv(
 				return xerrors.Errorf("AI provider %q already exists in the database and differs from the current environment configuration; update the provider through the API or remove the CODER_AIBRIDGE_* env vars to stop seeding it", dp.Name)
 			}
 
+			displayName := dp.Name
+			if dp.DisplayName != "" {
+				displayName = dp.DisplayName
+			}
 			row, err := tx.InsertAIProvider(sysCtx, database.InsertAIProviderParams{
 				ID:            uuid.New(),
 				Type:          dp.Type,
 				Name:          dp.Name,
-				DisplayName:   sql.NullString{String: dp.Name, Valid: true},
+				DisplayName:   sql.NullString{String: displayName, Valid: true},
 				Enabled:       true,
 				BaseUrl:       dp.BaseURL,
 				Settings:      settings,
@@ -221,8 +229,9 @@ type canonicalAIProvider struct {
 // desiredAIProvider is a normalized provider description sourced from
 // environment configuration that we want to materialize as a row.
 type desiredAIProvider struct {
-	Name string
-	Type database.AIProviderType
+	Name        string
+	DisplayName string
+	Type        database.AIProviderType
 	// BaseURL is the upstream provider's HTTP endpoint.
 	BaseURL string
 	// Keys is the list of API keys to seed into ai_provider_keys for
@@ -310,11 +319,8 @@ func providersFromEnv(ctx context.Context, cfg codersdk.AIBridgeConfig, logger s
 		addLegacy(aibridge.ProviderOpenAI, dp)
 	}
 
-	// Legacy Anthropic + Bedrock. Anthropic is enabled if either an
-	// Anthropic key OR any Bedrock setting is explicitly configured.
-	// Detection goes through AIProviderBedrockSettings.IsConfigured()
-	// so the legacy and indexed paths agree on what counts as a
-	// Bedrock provider.
+	// Legacy Anthropic + Bedrock. The legacy route name stays
+	// "anthropic" for backward compatibility.
 	bedrock := codersdk.NewAIProviderBedrockSettings(
 		cfg.LegacyBedrock.Region.String(),
 		cfg.LegacyBedrock.AccessKey.String(),
@@ -337,6 +343,8 @@ func providersFromEnv(ctx context.Context, cfg codersdk.AIBridgeConfig, logger s
 			}
 			// Bedrock-only deployments use CODER_AIBRIDGE_BEDROCK_BASE_URL
 			// for custom VPC, FIPS, or proxy endpoints.
+			dp.Type = database.AiProviderTypeBedrock
+			dp.DisplayName = codersdk.AIProviderDisplayNameBedrock
 			dp.BaseURL = cfg.LegacyBedrock.BaseURL.String()
 			dp.Bedrock = &bedrock
 		} else {
@@ -404,6 +412,9 @@ func providersFromEnv(ctx context.Context, cfg codersdk.AIBridgeConfig, logger s
 				// the runtime derives the endpoint from the region.
 				dp.BaseURL = p.BedrockBaseURL
 			}
+		}
+		if isBedrock {
+			dp.Type = database.AiProviderTypeBedrock
 		}
 		// Non-Bedrock, non-Copilot providers carry their bearer keys in
 		// ai_provider_keys. Bedrock providers authenticate via the

--- a/coderd/ai_providers_migrate_test.go
+++ b/coderd/ai_providers_migrate_test.go
@@ -145,8 +145,8 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 		db, _ := dbtestutil.NewDB(t)
 		ctx := testutil.Context(t, testutil.WaitShort)
 
-		// Bedrock fields without an Anthropic key produce a Bedrock-
-		// authenticated Anthropic provider with no bearer keys.
+		// Bedrock fields without an Anthropic key produce a Bedrock
+		// provider with no bearer keys.
 		cfg := codersdk.AIBridgeConfig{
 			LegacyBedrock: codersdk.AIBridgeBedrockConfig{
 				Region:          serpent.String("us-west-2"),
@@ -160,7 +160,7 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 
 		row, err := db.GetAIProviderByName(ctx, "anthropic")
 		require.NoError(t, err)
-		require.Equal(t, database.AiProviderTypeAnthropic, row.Type)
+		require.Equal(t, database.AiProviderTypeBedrock, row.Type)
 		require.Contains(t, row.Settings.String, "us-west-2")
 		require.Contains(t, row.Settings.String, "anthropic.claude-3-5-sonnet")
 		require.Contains(t, row.Settings.String, "anthropic.claude-3-5-haiku")
@@ -220,6 +220,7 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 
 		row, err := db.GetAIProviderByName(ctx, "anthropic")
 		require.NoError(t, err)
+		require.Equal(t, database.AiProviderTypeBedrock, row.Type)
 		require.True(t, row.Settings.Valid, "Bedrock metadata must produce a settings blob")
 		require.Contains(t, row.Settings.String, "us-east-1")
 		require.Contains(t, row.Settings.String, "anthropic.claude-3-5-sonnet")
@@ -228,7 +229,7 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 		require.Empty(t, keys, "Bedrock provider must not seed bearer keys")
 	})
 
-	t.Run("BedrockOnlyAnthropic", func(t *testing.T) {
+	t.Run("BedrockOnlyProvider", func(t *testing.T) {
 		t.Parallel()
 		db, _ := dbtestutil.NewDB(t)
 		ctx := testutil.Context(t, testutil.WaitShort)
@@ -244,11 +245,11 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 		require.NoError(t, coderd.SeedAIProvidersFromEnv(ctx, db, cfg, testLogger(t)))
 		row, err := db.GetAIProviderByName(ctx, "anthropic")
 		require.NoError(t, err)
+		require.Equal(t, database.AiProviderTypeBedrock, row.Type)
 		require.Contains(t, row.Settings.String, "us-east-1")
 		require.Contains(t, row.Settings.String, "AKIAONLY")
 		require.Contains(t, row.Settings.String, "secretonly")
-		// Bedrock-only Anthropic has zero ai_provider_keys: it
-		// authenticates via the settings blob.
+		// Bedrock authenticates via the settings blob.
 		keys, err := db.GetAIProviderKeysByProviderID(ctx, row.ID)
 		require.NoError(t, err)
 		require.Empty(t, keys)
@@ -371,6 +372,7 @@ func TestSeedAIProvidersFromEnv(t *testing.T) {
 
 		row, err := db.GetAIProviderByName(ctx, "bedrock-anthropic")
 		require.NoError(t, err)
+		require.Equal(t, database.AiProviderTypeBedrock, row.Type)
 		require.Contains(t, row.Settings.String, "AKIA-indexed")
 		require.Contains(t, row.Settings.String, "indexed-secret")
 		// Crucially, no ai_provider_keys rows for Bedrock providers.

--- a/coderd/ai_providers_test.go
+++ b/coderd/ai_providers_test.go
@@ -102,7 +102,7 @@ func TestAIProvidersCRUD(t *testing.T) {
 		created, err := client.CreateAIProvider(ctx, req)
 		require.NoError(t, err)
 		require.NotEqual(t, [16]byte{}, created.ID)
-		require.Equal(t, req.Type, created.Type)
+		require.Equal(t, codersdk.AIProviderTypeBedrock, created.Type)
 		require.Equal(t, req.Name, created.Name)
 		require.Equal(t, req.DisplayName, created.DisplayName)
 		require.Equal(t, req.Enabled, created.Enabled)
@@ -535,7 +535,7 @@ func TestAIProvidersCRUD(t *testing.T) {
 		require.NotEmpty(t, sdkErr.Message)
 	})
 
-	t.Run("BedrockSettingsRequireAnthropic", func(t *testing.T) {
+	t.Run("BedrockSettingsRequireAnthropicOrBedrock", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, nil)
 		_ = coderdtest.CreateFirstUser(t, client)
@@ -565,7 +565,7 @@ func TestAIProvidersCRUD(t *testing.T) {
 		require.Contains(t, sdkErr.Message, "Invalid AI provider request")
 		require.NotEmpty(t, sdkErr.Validations)
 		require.Equal(t, "settings", sdkErr.Validations[0].Field)
-		require.Contains(t, sdkErr.Validations[0].Detail, "bedrock settings are only valid for type=anthropic")
+		require.Contains(t, sdkErr.Validations[0].Detail, "bedrock settings are only valid for type=anthropic or type=bedrock")
 
 		// Update: existing OpenAI provider patched with Bedrock settings
 		// must also be rejected.
@@ -584,7 +584,7 @@ func TestAIProvidersCRUD(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorAs(t, err, &sdkErr)
 		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
-		require.Contains(t, sdkErr.Message, "Bedrock settings are only valid for type=anthropic")
+		require.Contains(t, sdkErr.Message, "Bedrock settings are only valid for type=anthropic or type=bedrock")
 	})
 
 	t.Run("BedrockSecretsHidden", func(t *testing.T) {

--- a/coderd/database/db2sdk/db2sdk.go
+++ b/coderd/database/db2sdk/db2sdk.go
@@ -50,27 +50,58 @@ func APIAllowListTarget(entry rbac.AllowListElement) codersdk.APIAllowListTarget
 // write-only fields on Settings are stripped, so the result is safe
 // to echo back in API responses.
 func AIProvider(row database.AIProvider, keys []database.AIProviderKey) (codersdk.AIProvider, error) {
-	display := row.Name
-	if row.DisplayName.Valid && row.DisplayName.String != "" {
-		display = row.DisplayName.String
+	s, err := AIProviderSettings(row.Settings)
+	if err != nil {
+		return codersdk.AIProvider{}, xerrors.Errorf("decode settings: %w", err)
 	}
+	effectiveType := resolveAIProviderType(row.Type, s)
 	out := codersdk.AIProvider{
 		ID:          row.ID,
-		Type:        codersdk.AIProviderType(row.Type),
+		Type:        effectiveType,
 		Name:        row.Name,
-		DisplayName: display,
+		DisplayName: AIProviderDisplayName(row, effectiveType),
 		Enabled:     row.Enabled,
 		BaseURL:     row.BaseUrl,
 		APIKeys:     maskAIProviderKeys(keys),
 		CreatedAt:   row.CreatedAt,
 		UpdatedAt:   row.UpdatedAt,
 	}
-	s, err := AIProviderSettings(row.Settings)
-	if err != nil {
-		return codersdk.AIProvider{}, xerrors.Errorf("decode settings: %w", err)
-	}
 	out.Settings = redactAIProviderSettings(s)
 	return out, nil
+}
+
+// EffectiveAIProviderType reports the provider identity callers should
+// use for routing and presentation.
+func EffectiveAIProviderType(row database.AIProvider) (codersdk.AIProviderType, error) {
+	s, err := AIProviderSettings(row.Settings)
+	if err != nil {
+		return "", err
+	}
+	return resolveAIProviderType(row.Type, s), nil
+}
+
+func resolveAIProviderType(
+	providerType database.AIProviderType,
+	settings codersdk.AIProviderSettings,
+) codersdk.AIProviderType {
+	if providerType == database.AiProviderTypeAnthropic && settings.Bedrock != nil {
+		return codersdk.AIProviderTypeBedrock
+	}
+	return codersdk.AIProviderType(providerType)
+}
+
+// AIProviderDisplayName uses effectiveType to override generic names for Bedrock providers.
+func AIProviderDisplayName(row database.AIProvider, effectiveType codersdk.AIProviderType) string {
+	display := row.Name
+	if row.DisplayName.Valid && row.DisplayName.String != "" {
+		display = row.DisplayName.String
+	}
+	if effectiveType == codersdk.AIProviderTypeBedrock &&
+		(strings.EqualFold(display, string(codersdk.AIProviderTypeAnthropic)) ||
+			strings.EqualFold(display, string(codersdk.AIProviderTypeBedrock))) {
+		return codersdk.AIProviderDisplayNameBedrock
+	}
+	return display
 }
 
 // AIProviderSettings parses the on-disk JSON form back into a codersdk

--- a/coderd/database/db2sdk/db2sdk_test.go
+++ b/coderd/database/db2sdk/db2sdk_test.go
@@ -23,6 +23,92 @@ import (
 	"github.com/coder/coder/v2/provisionersdk/proto"
 )
 
+func TestAIProviderEffectiveTypeAndDisplayName(t *testing.T) {
+	t.Parallel()
+
+	bedrockSettings := marshalAIProviderSettings(t, codersdk.AIProviderSettings{
+		Bedrock: &codersdk.AIProviderBedrockSettings{Region: "us-east-1"},
+	})
+
+	cases := []struct {
+		name        string
+		row         database.AIProvider
+		wantType    codersdk.AIProviderType
+		wantDisplay string
+	}{
+		{
+			name: "anthropic without bedrock stays anthropic",
+			row: database.AIProvider{
+				Type: database.AiProviderTypeAnthropic,
+				Name: "anthropic",
+			},
+			wantType:    codersdk.AIProviderTypeAnthropic,
+			wantDisplay: "anthropic",
+		},
+		{
+			name: "anthropic with bedrock promotes to bedrock",
+			row: database.AIProvider{
+				Type:     database.AiProviderTypeAnthropic,
+				Name:     "anthropic",
+				Settings: bedrockSettings,
+			},
+			wantType:    codersdk.AIProviderTypeBedrock,
+			wantDisplay: codersdk.AIProviderDisplayNameBedrock,
+		},
+		{
+			name: "bedrock type passes through",
+			row: database.AIProvider{
+				Type:        database.AiProviderTypeBedrock,
+				Name:        "bedrock",
+				DisplayName: sql.NullString{String: "bedrock", Valid: true},
+				Settings:    bedrockSettings,
+			},
+			wantType:    codersdk.AIProviderTypeBedrock,
+			wantDisplay: codersdk.AIProviderDisplayNameBedrock,
+		},
+		{
+			name: "other types ignore bedrock settings",
+			row: database.AIProvider{
+				Type:     database.AiProviderTypeOpenai,
+				Name:     "openai",
+				Settings: bedrockSettings,
+			},
+			wantType:    codersdk.AIProviderTypeOpenAI,
+			wantDisplay: "openai",
+		},
+		{
+			name: "custom bedrock display name is preserved",
+			row: database.AIProvider{
+				Type:        database.AiProviderTypeAnthropic,
+				Name:        "anthropic",
+				DisplayName: sql.NullString{String: "Claude in AWS", Valid: true},
+				Settings:    bedrockSettings,
+			},
+			wantType:    codersdk.AIProviderTypeBedrock,
+			wantDisplay: "Claude in AWS",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotType, err := db2sdk.EffectiveAIProviderType(tt.row)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantType, gotType)
+			require.Equal(t, tt.wantDisplay, db2sdk.AIProviderDisplayName(tt.row, gotType))
+		})
+	}
+}
+
+func marshalAIProviderSettings(t *testing.T, settings codersdk.AIProviderSettings) sql.NullString {
+	t.Helper()
+
+	raw, err := json.Marshal(settings)
+	require.NoError(t, err)
+	return sql.NullString{String: string(raw), Valid: true}
+}
+
 func TestProvisionerJobStatus(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -6530,11 +6530,8 @@ func parseUserAIProviderID(r *http.Request) (uuid.UUID, error) {
 	return uuid.Parse(chi.URLParam(r, "aiProvider"))
 }
 
-func convertAIProviderSummary(provider database.AIProvider) (codersdk.AIProviderSummary, error) {
-	effectiveType, err := db2sdk.EffectiveAIProviderType(provider)
-	if err != nil {
-		return codersdk.AIProviderSummary{}, xerrors.Errorf("effective AI provider type: %w", err)
-	}
+func (api *API) convertAIProviderSummary(ctx context.Context, provider database.AIProvider) codersdk.AIProviderSummary {
+	effectiveType := api.effectiveAIProviderTypeOrRaw(ctx, provider)
 	return codersdk.AIProviderSummary{
 		ID:          provider.ID,
 		Type:        effectiveType,
@@ -6542,7 +6539,7 @@ func convertAIProviderSummary(provider database.AIProvider) (codersdk.AIProvider
 		DisplayName: db2sdk.AIProviderDisplayName(provider, effectiveType),
 		Enabled:     provider.Enabled,
 		Deleted:     provider.Deleted,
-	}, nil
+	}
 }
 
 func (api *API) listUserAIProviderKeyConfigs(rw http.ResponseWriter, r *http.Request) {
@@ -6597,15 +6594,7 @@ func (api *API) listUserAIProviderKeyConfigs(rw http.ResponseWriter, r *http.Req
 	for _, provider := range visibleProviders {
 		_, hasUserKey := keysByProviderID[provider.ID]
 		_, hasProviderKey := providerKeysByProviderID[provider.ID]
-		providerSummary, err := convertAIProviderSummary(provider)
-		if err != nil {
-			api.Logger.Error(ctx, "convert AI provider summary", slog.F("provider_id", provider.ID), slog.Error(err))
-			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-				Message: "AI provider settings could not be parsed.",
-				Detail:  err.Error(),
-			})
-			return
-		}
+		providerSummary := api.convertAIProviderSummary(ctx, provider)
 		configs = append(configs, codersdk.UserAIProviderKeyConfig{
 			Provider:          providerSummary,
 			HasUserAPIKey:     hasUserKey,
@@ -6684,15 +6673,7 @@ func (api *API) upsertUserAIProviderKey(rw http.ResponseWriter, r *http.Request)
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{Message: "Failed to update user AI provider key."})
 		return
 	}
-	providerSummary, err := convertAIProviderSummary(provider)
-	if err != nil {
-		api.Logger.Error(ctx, "convert AI provider summary", slog.F("provider_id", provider.ID), slog.Error(err))
-		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "AI provider settings could not be parsed.",
-			Detail:  err.Error(),
-		})
-		return
-	}
+	providerSummary := api.convertAIProviderSummary(ctx, provider)
 	httpapi.Write(ctx, rw, http.StatusOK, codersdk.UserAIProviderKeyConfig{
 		Provider:          providerSummary,
 		HasUserAPIKey:     true,

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -827,6 +827,7 @@ func (api *API) getUserChatProviderAvailability(
 		enabledProviderIDs:   make(map[uuid.UUID]struct{}, len(enabledProviders)),
 		providerStatusByID:   make(map[uuid.UUID]chatprovider.ProviderAvailability, len(enabledProviders)),
 	}
+	normalizedProviderByID := make(map[uuid.UUID]string, len(configuredProviders))
 	for _, configuredProvider := range configuredProviders {
 		normalizedProvider := chatprovider.NormalizeProvider(configuredProvider.Provider)
 		if normalizedProvider != "" {
@@ -834,6 +835,9 @@ func (api *API) getUserChatProviderAvailability(
 		}
 		if configuredProvider.ProviderID != uuid.Nil {
 			availability.enabledProviderIDs[configuredProvider.ProviderID] = struct{}{}
+			if normalizedProvider != "" {
+				normalizedProviderByID[configuredProvider.ProviderID] = normalizedProvider
+			}
 		}
 	}
 	userKeys := []chatprovider.UserProviderKey{}
@@ -884,9 +888,18 @@ func (api *API) getUserChatProviderAvailability(
 		mergeProviderStatus(providerStatusByType, normalizedProvider, status)
 	}
 
+	modelProviderType := func(model database.ChatModelConfig) string {
+		if model.AIProviderID.Valid {
+			if providerType := normalizedProviderByID[model.AIProviderID.UUID]; providerType != "" {
+				return providerType
+			}
+		}
+		return model.Provider
+	}
+
 	modelStatusByType := make(map[string]chatprovider.ProviderAvailability, len(enabledModels))
 	for _, model := range enabledModels {
-		normalizedProvider := chatprovider.NormalizeProvider(model.Provider)
+		normalizedProvider := chatprovider.NormalizeProvider(modelProviderType(model))
 		if normalizedProvider == "" {
 			continue
 		}
@@ -907,7 +920,8 @@ func (api *API) getUserChatProviderAvailability(
 	}
 
 	for _, model := range enabledModels {
-		normalizedProvider := chatprovider.NormalizeProvider(model.Provider)
+		providerType := modelProviderType(model)
+		normalizedProvider := chatprovider.NormalizeProvider(providerType)
 		if model.AIProviderID.Valid {
 			status, ok := availability.providerStatusByID[model.AIProviderID.UUID]
 			if !ok {
@@ -918,7 +932,7 @@ func (api *API) getUserChatProviderAvailability(
 			}
 		}
 		availability.configuredModels = append(availability.configuredModels, chatprovider.ConfiguredModel{
-			Provider:    model.Provider,
+			Provider:    providerType,
 			Model:       model.Model,
 			DisplayName: model.DisplayName,
 		})
@@ -6516,19 +6530,19 @@ func parseUserAIProviderID(r *http.Request) (uuid.UUID, error) {
 	return uuid.Parse(chi.URLParam(r, "aiProvider"))
 }
 
-func convertAIProviderSummary(provider database.AIProvider) codersdk.AIProviderSummary {
-	displayName := provider.Name
-	if provider.DisplayName.Valid && provider.DisplayName.String != "" {
-		displayName = provider.DisplayName.String
+func convertAIProviderSummary(provider database.AIProvider) (codersdk.AIProviderSummary, error) {
+	effectiveType, err := db2sdk.EffectiveAIProviderType(provider)
+	if err != nil {
+		return codersdk.AIProviderSummary{}, xerrors.Errorf("effective AI provider type: %w", err)
 	}
 	return codersdk.AIProviderSummary{
 		ID:          provider.ID,
-		Type:        codersdk.AIProviderType(provider.Type),
+		Type:        effectiveType,
 		Name:        provider.Name,
-		DisplayName: displayName,
+		DisplayName: db2sdk.AIProviderDisplayName(provider, effectiveType),
 		Enabled:     provider.Enabled,
 		Deleted:     provider.Deleted,
-	}
+	}, nil
 }
 
 func (api *API) listUserAIProviderKeyConfigs(rw http.ResponseWriter, r *http.Request) {
@@ -6583,8 +6597,17 @@ func (api *API) listUserAIProviderKeyConfigs(rw http.ResponseWriter, r *http.Req
 	for _, provider := range visibleProviders {
 		_, hasUserKey := keysByProviderID[provider.ID]
 		_, hasProviderKey := providerKeysByProviderID[provider.ID]
+		providerSummary, err := convertAIProviderSummary(provider)
+		if err != nil {
+			api.Logger.Error(ctx, "convert AI provider summary", slog.F("provider_id", provider.ID), slog.Error(err))
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "AI provider settings could not be parsed.",
+				Detail:  err.Error(),
+			})
+			return
+		}
 		configs = append(configs, codersdk.UserAIProviderKeyConfig{
-			Provider:          convertAIProviderSummary(provider),
+			Provider:          providerSummary,
 			HasUserAPIKey:     hasUserKey,
 			HasProviderAPIKey: hasProviderKey,
 			BYOKEnabled:       byokEnabled,
@@ -6661,8 +6684,17 @@ func (api *API) upsertUserAIProviderKey(rw http.ResponseWriter, r *http.Request)
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{Message: "Failed to update user AI provider key."})
 		return
 	}
+	providerSummary, err := convertAIProviderSummary(provider)
+	if err != nil {
+		api.Logger.Error(ctx, "convert AI provider summary", slog.F("provider_id", provider.ID), slog.Error(err))
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "AI provider settings could not be parsed.",
+			Detail:  err.Error(),
+		})
+		return
+	}
 	httpapi.Write(ctx, rw, http.StatusOK, codersdk.UserAIProviderKeyConfig{
-		Provider:          convertAIProviderSummary(provider),
+		Provider:          providerSummary,
 		HasUserAPIKey:     true,
 		HasProviderAPIKey: len(providerKeys) > 0,
 		BYOKEnabled:       true,
@@ -6703,12 +6735,12 @@ func (api *API) configuredProvidersFromAIProviders(ctx context.Context, provider
 	}
 	configuredProviders := make([]chatprovider.ConfiguredProvider, 0, len(providers))
 	for _, provider := range providers {
-		configuredProviders = append(configuredProviders, api.configuredProviderFromAIProviderKeys(provider, keysByProviderID[provider.ID]))
+		configuredProviders = append(configuredProviders, api.configuredProviderFromAIProviderKeys(ctx, provider, keysByProviderID[provider.ID]))
 	}
 	return configuredProviders, nil
 }
 
-func (api *API) configuredProviderFromAIProviderKeys(provider database.AIProvider, keys []database.AIProviderKey) chatprovider.ConfiguredProvider {
+func (api *API) configuredProviderFromAIProviderKeys(ctx context.Context, provider database.AIProvider, keys []database.AIProviderKey) chatprovider.ConfiguredProvider {
 	apiKey := ""
 	for _, key := range keys {
 		if key.APIKey != "" {
@@ -6716,9 +6748,10 @@ func (api *API) configuredProviderFromAIProviderKeys(provider database.AIProvide
 			break
 		}
 	}
+	effectiveType := api.effectiveAIProviderTypeOrRaw(ctx, provider)
 	return chatprovider.ConfiguredProvider{
 		ProviderID:                 provider.ID,
-		Provider:                   string(provider.Type),
+		Provider:                   string(effectiveType),
 		APIKey:                     apiKey,
 		BaseURL:                    provider.BaseUrl,
 		CentralAPIKeyEnabled:       true,
@@ -6786,12 +6819,68 @@ func (api *API) listChatModelConfigs(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	providerTypesByID, err := effectiveAIProviderTypesByID(ctx, api.Database, configs, api.Logger)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to load AI providers.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
 	resp := make([]codersdk.ChatModelConfig, 0, len(configs))
 	for _, config := range configs {
-		resp = append(resp, convertChatModelConfig(config))
+		provider := config.Provider
+		if config.AIProviderID.Valid {
+			if effectiveType, ok := providerTypesByID[config.AIProviderID.UUID]; ok {
+				provider = string(effectiveType)
+			}
+		}
+		resp = append(resp, convertChatModelConfigWithProvider(config, provider))
 	}
 
 	httpapi.Write(ctx, rw, http.StatusOK, resp)
+}
+
+func effectiveAIProviderTypesByID(
+	ctx context.Context,
+	db database.Store,
+	configs []database.ChatModelConfig,
+	logger slog.Logger,
+) (map[uuid.UUID]codersdk.AIProviderType, error) {
+	providerIDs := make(map[uuid.UUID]struct{})
+	for _, config := range configs {
+		if config.AIProviderID.Valid {
+			providerIDs[config.AIProviderID.UUID] = struct{}{}
+		}
+	}
+	providerTypesByID := make(map[uuid.UUID]codersdk.AIProviderType, len(providerIDs))
+	for providerID := range providerIDs {
+		//nolint:gocritic // Chatd context is required to include provider metadata for model config presentation.
+		provider, err := db.GetAIProviderByID(dbauthz.AsChatd(ctx), providerID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				continue
+			}
+			return nil, xerrors.Errorf("get AI provider %s: %w", providerID, err)
+		}
+		effectiveType, err := db2sdk.EffectiveAIProviderType(provider)
+		if err != nil {
+			logger.Warn(ctx, "parse AI provider settings for chat model config", slog.F("provider_id", providerID), slog.Error(err))
+			continue
+		}
+		providerTypesByID[provider.ID] = effectiveType
+	}
+	return providerTypesByID, nil
+}
+
+func (api *API) effectiveAIProviderTypeOrRaw(ctx context.Context, provider database.AIProvider) codersdk.AIProviderType {
+	effectiveType, err := db2sdk.EffectiveAIProviderType(provider)
+	if err != nil {
+		api.Logger.Warn(ctx, "parse AI provider settings", slog.F("provider_id", provider.ID), slog.Error(err))
+		return codersdk.AIProviderType(provider.Type)
+	}
+	return effectiveType
 }
 
 func (api *API) createChatModelConfig(rw http.ResponseWriter, r *http.Request) {
@@ -6828,7 +6917,7 @@ func (api *API) createChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 		httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{Message: "AI provider is disabled."})
 		return
 	}
-	provider := string(aiProvider.Type)
+	provider := string(api.effectiveAIProviderTypeOrRaw(ctx, aiProvider))
 	aiProviderID := uuid.NullUUID{UUID: aiProvider.ID, Valid: true}
 
 	model := strings.TrimSpace(req.Model)
@@ -6905,7 +6994,7 @@ func (api *API) createChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 		if !lockedAIProvider.Enabled {
 			return errChatProviderNotConfigured
 		}
-		insertParams.Provider = string(lockedAIProvider.Type)
+		insertParams.Provider = string(api.effectiveAIProviderTypeOrRaw(ctx, lockedAIProvider))
 
 		insertAsDefault := isDefault
 		if !insertAsDefault {
@@ -7003,20 +7092,40 @@ func (api *API) updateChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	provider := existing.Provider
+	aiProviderID := existing.AIProviderID
+	linkedProviderMissing := false
+	if req.AIProviderID == nil && existing.AIProviderID.Valid {
+		//nolint:gocritic // The route already authorized chat model config updates.
+		aiProvider, err := api.Database.GetAIProviderByID(dbauthz.AsChatd(ctx), existing.AIProviderID.UUID)
+		if err != nil {
+			linkedProviderMissing = true
+			if !httpapi.Is404Error(err) {
+				httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+					Message: "Failed to get AI provider.",
+					Detail:  err.Error(),
+				})
+				return
+			}
+		} else {
+			provider = string(api.effectiveAIProviderTypeOrRaw(ctx, aiProvider))
+		}
+	}
+
 	if strings.TrimSpace(req.Provider) != "" && req.AIProviderID == nil {
 		requestedProvider := chatprovider.NormalizeProvider(req.Provider)
 		if requestedProvider == "" {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{Message: "Invalid provider."})
 			return
 		}
-		if requestedProvider != existing.Provider {
+		if linkedProviderMissing {
+			provider = requestedProvider
+		} else if requestedProvider != chatprovider.NormalizeProvider(provider) {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{Message: "AI provider ID is required when updating provider."})
 			return
 		}
 	}
 
-	provider := existing.Provider
-	aiProviderID := existing.AIProviderID
 	if req.AIProviderID != nil {
 		//nolint:gocritic // The route already authorized chat model config updates.
 		aiProvider, err := api.Database.GetAIProviderByID(dbauthz.AsChatd(ctx), *req.AIProviderID)
@@ -7035,7 +7144,7 @@ func (api *API) updateChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 			httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{Message: "AI provider is disabled."})
 			return
 		}
-		provider = string(aiProvider.Type)
+		provider = string(api.effectiveAIProviderTypeOrRaw(ctx, aiProvider))
 		aiProviderID = uuid.NullUUID{UUID: aiProvider.ID, Valid: true}
 	}
 
@@ -7122,7 +7231,7 @@ func (api *API) updateChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 			if !aiProvider.Enabled {
 				return errChatProviderNotConfigured
 			}
-			updateParams.Provider = string(aiProvider.Type)
+			updateParams.Provider = string(api.effectiveAIProviderTypeOrRaw(ctx, aiProvider))
 		}
 
 		setAsDefault := updateParams.IsDefault && !existing.IsDefault
@@ -7365,13 +7474,17 @@ func parseChatModelConfigID(rw http.ResponseWriter, r *http.Request) (uuid.UUID,
 }
 
 func convertChatModelConfig(config database.ChatModelConfig) codersdk.ChatModelConfig {
+	return convertChatModelConfigWithProvider(config, config.Provider)
+}
+
+func convertChatModelConfigWithProvider(config database.ChatModelConfig, provider string) codersdk.ChatModelConfig {
 	var aiProviderID *uuid.UUID
 	if config.AIProviderID.Valid {
 		aiProviderID = &config.AIProviderID.UUID
 	}
 	return codersdk.ChatModelConfig{
 		ID:                   config.ID,
-		Provider:             config.Provider,
+		Provider:             provider,
 		AIProviderID:         aiProviderID,
 		Model:                config.Model,
 		DisplayName:          config.DisplayName,

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -3494,6 +3494,68 @@ func TestListChatModelConfigs(t *testing.T) {
 		})
 	})
 
+	t.Run("LinkedBedrockProviderUsesBedrockIdentity", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client, db := newChatClientWithDatabase(t)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
+
+		provider, err := client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+			Type:    codersdk.AIProviderTypeAnthropic,
+			Name:    "anthropic-bedrock-" + uuid.NewString(),
+			Enabled: true,
+			BaseURL: "https://bedrock-runtime.us-east-1.amazonaws.com/",
+			Settings: codersdk.AIProviderSettings{
+				Bedrock: &codersdk.AIProviderBedrockSettings{Region: "us-east-1"},
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, codersdk.AIProviderTypeBedrock, provider.Type)
+
+		contextLimit := int64(4096)
+		createdConfig, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+			Provider:     "anthropic",
+			AIProviderID: &provider.ID,
+			Model:        "anthropic.claude-3-5-haiku",
+			DisplayName:  "Created Claude on Bedrock",
+			ContextLimit: &contextLimit,
+		})
+		require.NoError(t, err)
+		require.Equal(t, "bedrock", createdConfig.Provider)
+
+		storedCreatedConfig, err := db.GetChatModelConfigByID(ctx, createdConfig.ID)
+		require.NoError(t, err)
+		require.Equal(t, "bedrock", storedCreatedConfig.Provider)
+
+		updatedConfig, err := client.UpdateChatModelConfig(ctx, createdConfig.ID, codersdk.UpdateChatModelConfigRequest{
+			DisplayName: "Updated Claude on Bedrock",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "bedrock", updatedConfig.Provider)
+
+		storedConfig := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
+			Provider:             "anthropic",
+			AIProviderID:         uuid.NullUUID{UUID: provider.ID, Valid: true},
+			Model:                "anthropic.claude-3-5-sonnet",
+			DisplayName:          "Claude on Bedrock",
+			CreatedBy:            uuid.NullUUID{UUID: firstUser.UserID, Valid: true},
+			UpdatedBy:            uuid.NullUUID{UUID: firstUser.UserID, Valid: true},
+			ContextLimit:         4096,
+			CompressionThreshold: 80,
+		})
+
+		configs, err := client.ListChatModelConfigs(ctx)
+		require.NoError(t, err)
+		for _, config := range configs {
+			if config.ID == storedConfig.ID {
+				require.Equal(t, "bedrock", config.Provider)
+				return
+			}
+		}
+		t.Fatal("bedrock model config not found")
+	})
+
 	t.Run("SuccessForOrganizationMember", func(t *testing.T) {
 		t.Parallel()
 

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -2133,6 +2133,35 @@ func TestUserAIProviderKeys(t *testing.T) {
 		require.False(t, cfg.HasUserAPIKey)
 	})
 
+	t.Run("CorruptProviderSettingsUseRawType", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		adminClient, db := newChatClientWithDatabase(t)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
+		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
+		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
+
+		provider := dbgen.AIProvider(t, db, database.AIProvider{
+			Type:        database.AiProviderTypeAnthropic,
+			Name:        "test-corrupt-settings-" + uuid.NewString(),
+			DisplayName: sql.NullString{String: "Corrupt Settings", Valid: true},
+			Settings:    sql.NullString{String: "{", Valid: true},
+		})
+
+		cfgValue, err := memberClient.UpsertUserAIProviderKey(ctx, "me", provider.ID, codersdk.CreateUserAIProviderKeyRequest{APIKey: "test-user-api-key"})
+		require.NoError(t, err)
+		require.Equal(t, provider.ID, cfgValue.Provider.ID)
+		require.Equal(t, codersdk.AIProviderTypeAnthropic, cfgValue.Provider.Type)
+
+		configs, err := memberClient.ListUserAIProviderKeyConfigs(ctx, "me")
+		require.NoError(t, err)
+		cfg := findUserAIProviderKeyConfig(t, configs, provider.ID)
+		require.NotNil(t, cfg)
+		require.Equal(t, codersdk.AIProviderTypeAnthropic, cfg.Provider.Type)
+		require.True(t, cfg.HasUserAPIKey)
+	})
+
 	t.Run("ListsDisabledProviderWithSavedUserKey", func(t *testing.T) {
 		t.Parallel()
 
@@ -3524,7 +3553,7 @@ func TestListChatModelConfigs(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "bedrock", createdConfig.Provider)
 
-		storedCreatedConfig, err := db.GetChatModelConfigByID(ctx, createdConfig.ID)
+		storedCreatedConfig, err := db.GetChatModelConfigByID(dbauthz.AsSystemRestricted(ctx), createdConfig.ID)
 		require.NoError(t, err)
 		require.Equal(t, "bedrock", storedCreatedConfig.Provider)
 

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -8774,15 +8774,16 @@ func (p *Server) resolveUserProviderAPIKeysAndProviderForProviderType(
 		return chatprovider.ProviderAPIKeys{}, nil, nil
 	}
 	for _, provider := range providers {
-		matches, err := aiProviderMatchesEffectiveType(provider, normalizedProviderType)
+		effectiveProviderType, err := effectiveAIProviderTypeString(provider)
 		if err != nil {
 			p.logger.Warn(ctx, "parse AI provider settings", slog.F("provider_id", provider.ID), slog.Error(err))
 			continue
 		}
-		if !matches {
+		providerKeysType := chatprovider.NormalizeProvider(effectiveProviderType)
+		if !aiProviderTypeCanSatisfyRequest(providerKeysType, normalizedProviderType) {
 			continue
 		}
-		keys, matchedProvider, err := keysForProvider(provider, normalizedProviderType)
+		keys, matchedProvider, err := keysForProvider(provider, providerKeysType)
 		if err != nil || matchedProvider != nil {
 			return keys, matchedProvider, err
 		}

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -8660,7 +8660,7 @@ func (p *Server) aiProviderConfigFromKeys(provider database.AIProvider, keys []d
 	}
 	return chatprovider.ConfiguredProvider{
 		ProviderID:                 provider.ID,
-		Provider:                   string(provider.Type),
+		Provider:                   bestEffortAIProviderTypeString(provider),
 		APIKey:                     apiKey,
 		BaseURL:                    provider.BaseUrl,
 		CentralAPIKeyEnabled:       true,
@@ -8763,16 +8763,34 @@ func (p *Server) resolveUserProviderAPIKeysAndProviderForProviderType(
 		return chatprovider.ProviderAPIKeys{}, nil, xerrors.Errorf("get enabled AI providers: %w", err)
 	}
 	normalizedProviderType := chatprovider.NormalizeProvider(providerType)
-	for _, provider := range providers {
-		if chatprovider.NormalizeProvider(string(provider.Type)) != normalizedProviderType {
-			continue
-		}
+	keysForProvider := func(provider database.AIProvider, providerKeysType string) (chatprovider.ProviderAPIKeys, *database.AIProvider, error) {
 		keys, err := p.resolveUserProviderAPIKeysForProvider(ctx, ownerID, provider)
 		if err != nil {
 			return chatprovider.ProviderAPIKeys{}, nil, err
 		}
-		if userCanUseProviderKeys(keys, normalizedProviderType) {
+		if userCanUseProviderKeys(keys, providerKeysType) {
 			return keys, &provider, nil
+		}
+		return chatprovider.ProviderAPIKeys{}, nil, nil
+	}
+	for _, provider := range providers {
+		matches, err := aiProviderMatchesEffectiveType(provider, normalizedProviderType)
+		if err != nil || !matches {
+			continue
+		}
+		keys, matchedProvider, err := keysForProvider(provider, normalizedProviderType)
+		if err != nil || matchedProvider != nil {
+			return keys, matchedProvider, err
+		}
+	}
+	for _, provider := range providers {
+		if !aiProviderMatchesRawType(provider, normalizedProviderType) {
+			continue
+		}
+		providerKeysType := chatprovider.NormalizeProvider(bestEffortAIProviderTypeString(provider))
+		keys, matchedProvider, err := keysForProvider(provider, providerKeysType)
+		if err != nil || matchedProvider != nil {
+			return keys, matchedProvider, err
 		}
 	}
 	keys, err := p.resolveUserProviderAPIKeys(ctx, ownerID, uuid.Nil)

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -8642,10 +8642,10 @@ func (p *Server) aiProviderConfig(ctx context.Context, provider database.AIProvi
 	if err != nil {
 		return chatprovider.ConfiguredProvider{}, xerrors.Errorf("get AI provider keys: %w", err)
 	}
-	return p.aiProviderConfigFromKeys(provider, keys)
+	return p.aiProviderConfigFromKeys(ctx, provider, keys)
 }
 
-func (p *Server) aiProviderConfigFromKeys(provider database.AIProvider, keys []database.AIProviderKey) (chatprovider.ConfiguredProvider, error) {
+func (p *Server) aiProviderConfigFromKeys(ctx context.Context, provider database.AIProvider, keys []database.AIProviderKey) (chatprovider.ConfiguredProvider, error) {
 	if !provider.Enabled {
 		return chatprovider.ConfiguredProvider{}, xerrors.Errorf("AI provider %s is disabled", provider.ID)
 	}
@@ -8660,7 +8660,7 @@ func (p *Server) aiProviderConfigFromKeys(provider database.AIProvider, keys []d
 	}
 	return chatprovider.ConfiguredProvider{
 		ProviderID:                 provider.ID,
-		Provider:                   bestEffortAIProviderTypeString(provider),
+		Provider:                   bestEffortAIProviderTypeString(ctx, p.logger, provider),
 		APIKey:                     apiKey,
 		BaseURL:                    provider.BaseUrl,
 		CentralAPIKeyEnabled:       true,
@@ -8687,7 +8687,7 @@ func (p *Server) aiProviderConfigs(ctx context.Context, providers []database.AIP
 	}
 	configuredProviders := make([]chatprovider.ConfiguredProvider, 0, len(providers))
 	for _, provider := range providers {
-		configuredProvider, err := p.aiProviderConfigFromKeys(provider, keysByProviderID[provider.ID])
+		configuredProvider, err := p.aiProviderConfigFromKeys(ctx, provider, keysByProviderID[provider.ID])
 		if err != nil {
 			return nil, err
 		}
@@ -8775,7 +8775,11 @@ func (p *Server) resolveUserProviderAPIKeysAndProviderForProviderType(
 	}
 	for _, provider := range providers {
 		matches, err := aiProviderMatchesEffectiveType(provider, normalizedProviderType)
-		if err != nil || !matches {
+		if err != nil {
+			p.logger.Warn(ctx, "parse AI provider settings", slog.F("provider_id", provider.ID), slog.Error(err))
+			continue
+		}
+		if !matches {
 			continue
 		}
 		keys, matchedProvider, err := keysForProvider(provider, normalizedProviderType)
@@ -8787,7 +8791,7 @@ func (p *Server) resolveUserProviderAPIKeysAndProviderForProviderType(
 		if !aiProviderMatchesRawType(provider, normalizedProviderType) {
 			continue
 		}
-		providerKeysType := chatprovider.NormalizeProvider(bestEffortAIProviderTypeString(provider))
+		providerKeysType := chatprovider.NormalizeProvider(bestEffortAIProviderTypeString(ctx, p.logger, provider))
 		keys, matchedProvider, err := keysForProvider(provider, providerKeysType)
 		if err != nil || matchedProvider != nil {
 			return keys, matchedProvider, err

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -202,6 +202,43 @@ func TestResolveUserProviderAPIKeysAndProviderForProviderTypeProviderMatch(t *te
 	require.Equal(t, database.AiProviderTypeOpenai, aiProvider.Type)
 }
 
+func TestResolveDirectModelRouteForProviderTypeFallsBackToRawTypeForBedrock(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+	ownerID := uuid.New()
+	providerID := uuid.New()
+
+	rawSettings, err := json.Marshal(codersdk.AIProviderSettings{
+		Bedrock: &codersdk.AIProviderBedrockSettings{Region: "us-east-1"},
+	})
+	require.NoError(t, err)
+	provider := database.AIProvider{
+		ID:       providerID,
+		Type:     database.AiProviderTypeAnthropic,
+		Enabled:  true,
+		Settings: sql.NullString{String: string(rawSettings), Valid: true},
+	}
+
+	db.EXPECT().GetAIProviders(gomock.Any(), database.GetAIProvidersParams{}).Return([]database.AIProvider{provider}, nil)
+	db.EXPECT().GetAIProviderKeysByProviderID(gomock.Any(), providerID).Return(nil, nil)
+
+	server := &Server{db: db}
+	route, err := server.resolveDirectModelRouteForProviderType(
+		ctx,
+		ownerID,
+		chattool.ComputerUseProviderAnthropic,
+	)
+	require.NoError(t, err)
+
+	providerHint, err := route.providerHint()
+	require.NoError(t, err)
+	require.Equal(t, "bedrock", providerHint)
+	require.True(t, route.directProviderKeys().HasProvider("bedrock"))
+}
+
 func TestResolveModelRouteForProviderTypeAIGatewayRequiresProvider(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -239,6 +239,38 @@ func TestResolveDirectModelRouteForProviderTypeFallsBackToRawTypeForBedrock(t *t
 	require.True(t, route.directProviderKeys().HasProvider("bedrock"))
 }
 
+func TestResolveDirectModelRouteForProviderTypeUsesBedrockProviderForAnthropicComputerUse(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+	ownerID := uuid.New()
+	providerID := uuid.New()
+
+	provider := database.AIProvider{
+		ID:      providerID,
+		Type:    database.AiProviderTypeBedrock,
+		Enabled: true,
+	}
+
+	db.EXPECT().GetAIProviders(gomock.Any(), database.GetAIProvidersParams{}).Return([]database.AIProvider{provider}, nil)
+	db.EXPECT().GetAIProviderKeysByProviderID(gomock.Any(), providerID).Return(nil, nil)
+
+	server := &Server{db: db}
+	route, err := server.resolveDirectModelRouteForProviderType(
+		ctx,
+		ownerID,
+		chattool.ComputerUseProviderAnthropic,
+	)
+	require.NoError(t, err)
+
+	providerHint, err := route.providerHint()
+	require.NoError(t, err)
+	require.Equal(t, "bedrock", providerHint)
+	require.True(t, route.directProviderKeys().HasProvider("bedrock"))
+}
+
 func TestResolveModelRouteForProviderTypeAIGatewayRequiresProvider(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -202,7 +202,7 @@ func TestResolveUserProviderAPIKeysAndProviderForProviderTypeProviderMatch(t *te
 	require.Equal(t, database.AiProviderTypeOpenai, aiProvider.Type)
 }
 
-func TestResolveDirectModelRouteForProviderTypeFallsBackToRawTypeForBedrock(t *testing.T) {
+func TestResolveDirectModelRouteForProviderTypeMatchesEffectiveBedrockForAnthropicRequest(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitShort)

--- a/coderd/x/chatd/chaterror/message.go
+++ b/coderd/x/chatd/chaterror/message.go
@@ -130,7 +130,7 @@ func providerDisplayName(provider string) string {
 	case "azure":
 		return "Azure OpenAI"
 	case "bedrock":
-		return "AWS Bedrock"
+		return codersdk.AIProviderDisplayNameBedrock
 	case "google":
 		return "Google"
 	case "openai":

--- a/coderd/x/chatd/chatprovider/chatprovider.go
+++ b/coderd/x/chatd/chatprovider/chatprovider.go
@@ -43,7 +43,7 @@ var envPresetProviderNames = []string{
 var providerDisplayNameByName = map[string]string{
 	fantasyanthropic.Name:    "Anthropic",
 	fantasyazure.Name:        "Azure OpenAI",
-	fantasybedrock.Name:      "AWS Bedrock",
+	fantasybedrock.Name:      codersdk.AIProviderDisplayNameBedrock,
 	fantasygoogle.Name:       "Google",
 	fantasyopenai.Name:       "OpenAI",
 	fantasyopenaicompat.Name: "OpenAI Compatible",

--- a/coderd/x/chatd/model_routing_aibridge.go
+++ b/coderd/x/chatd/model_routing_aibridge.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
+	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/coderd/aibridge"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatdebug"
@@ -88,7 +89,7 @@ func (t *aiGatewayRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 }
 
 func (p *Server) newAIGatewayModel(
-	_ context.Context,
+	ctx context.Context,
 	req modelClientRequest,
 	route aiGatewayModelRoute,
 	opts modelBuildOptions,
@@ -131,7 +132,7 @@ func (p *Server) newAIGatewayModel(
 		baseRT = &chatdebug.RecordingTransport{Base: baseRT}
 	}
 
-	config := fantasyConfigForAIBridge(bestEffortAIProviderType(route.Provider))
+	config := fantasyConfigForAIBridge(bestEffortAIProviderType(ctx, p.logger, route.Provider))
 	return newLanguageModel(
 		config.ProviderHint,
 		req.ModelName,
@@ -225,7 +226,7 @@ func (p *Server) resolveAIGatewayRoute(
 		ctx,
 		ownerID,
 		provider,
-		aiGatewayRequestFormatForProviderType(bestEffortAIProviderType(provider)),
+		aiGatewayRequestFormatForProviderType(bestEffortAIProviderType(ctx, p.logger, provider)),
 	)
 	if err != nil {
 		return resolvedModelRoute{}, xerrors.Errorf("resolve AI Gateway provider auth: %w", err)
@@ -242,7 +243,7 @@ func (p *Server) resolveAIGatewayModelRouteForConfig(
 	if err != nil {
 		return resolvedModelRoute{}, err
 	}
-	return p.resolveAIGatewayRoute(ctx, ownerID, provider, bestEffortAIProviderTypeString(provider))
+	return p.resolveAIGatewayRoute(ctx, ownerID, provider, bestEffortAIProviderTypeString(ctx, p.logger, provider))
 }
 
 func (p *Server) resolveAIGatewayModelRouteForProviderType(
@@ -258,7 +259,7 @@ func (p *Server) resolveAIGatewayModelRouteForProviderType(
 		ctx,
 		ownerID,
 		provider,
-		bestEffortAIProviderTypeString(provider),
+		bestEffortAIProviderTypeString(ctx, p.logger, provider),
 	)
 }
 
@@ -290,7 +291,11 @@ func (p *Server) aiProviderForProviderType(
 			continue
 		}
 		matches, err := aiProviderMatchesEffectiveType(provider, normalizedProviderType)
-		if err != nil || !matches {
+		if err != nil {
+			p.logger.Warn(ctx, "parse AI provider settings", slog.F("provider_id", provider.ID), slog.Error(err))
+			continue
+		}
+		if !matches {
 			continue
 		}
 		return provider, nil

--- a/coderd/x/chatd/model_routing_aibridge.go
+++ b/coderd/x/chatd/model_routing_aibridge.go
@@ -131,7 +131,7 @@ func (p *Server) newAIGatewayModel(
 		baseRT = &chatdebug.RecordingTransport{Base: baseRT}
 	}
 
-	config := fantasyConfigForAIBridge(route.Provider.Type)
+	config := fantasyConfigForAIBridge(bestEffortAIProviderType(route.Provider))
 	return newLanguageModel(
 		config.ProviderHint,
 		req.ModelName,
@@ -225,7 +225,7 @@ func (p *Server) resolveAIGatewayRoute(
 		ctx,
 		ownerID,
 		provider,
-		aiGatewayRequestFormatForProviderType(provider.Type),
+		aiGatewayRequestFormatForProviderType(bestEffortAIProviderType(provider)),
 	)
 	if err != nil {
 		return resolvedModelRoute{}, xerrors.Errorf("resolve AI Gateway provider auth: %w", err)
@@ -242,7 +242,7 @@ func (p *Server) resolveAIGatewayModelRouteForConfig(
 	if err != nil {
 		return resolvedModelRoute{}, err
 	}
-	return p.resolveAIGatewayRoute(ctx, ownerID, provider, string(provider.Type))
+	return p.resolveAIGatewayRoute(ctx, ownerID, provider, bestEffortAIProviderTypeString(provider))
 }
 
 func (p *Server) resolveAIGatewayModelRouteForProviderType(
@@ -258,7 +258,7 @@ func (p *Server) resolveAIGatewayModelRouteForProviderType(
 		ctx,
 		ownerID,
 		provider,
-		chatprovider.NormalizeProvider(providerType),
+		bestEffortAIProviderTypeString(provider),
 	)
 }
 
@@ -289,7 +289,14 @@ func (p *Server) aiProviderForProviderType(
 		if !provider.Enabled {
 			continue
 		}
-		if chatprovider.NormalizeProvider(string(provider.Type)) != normalizedProviderType {
+		matches, err := aiProviderMatchesEffectiveType(provider, normalizedProviderType)
+		if err != nil || !matches {
+			continue
+		}
+		return provider, nil
+	}
+	for _, provider := range providers {
+		if !provider.Enabled || !aiProviderMatchesRawType(provider, normalizedProviderType) {
 			continue
 		}
 		return provider, nil

--- a/coderd/x/chatd/model_routing_direct.go
+++ b/coderd/x/chatd/model_routing_direct.go
@@ -77,7 +77,7 @@ func (p *Server) resolveDirectModelRouteForProviderType(
 	}
 	providerHint := normalizedProviderType
 	if provider != nil {
-		providerHint = chatprovider.NormalizeProvider(bestEffortAIProviderTypeString(*provider))
+		providerHint = chatprovider.NormalizeProvider(bestEffortAIProviderTypeString(ctx, p.logger, *provider))
 	}
 	return newDirectModelRoute(providerHint, keys), nil
 }
@@ -93,5 +93,5 @@ func (p *Server) directProviderHintAndProviderForConfig(
 	if err != nil {
 		return "", nil, err
 	}
-	return bestEffortAIProviderTypeString(provider), &provider, nil
+	return bestEffortAIProviderTypeString(ctx, p.logger, provider), &provider, nil
 }

--- a/coderd/x/chatd/model_routing_direct.go
+++ b/coderd/x/chatd/model_routing_direct.go
@@ -71,11 +71,15 @@ func (p *Server) resolveDirectModelRouteForProviderType(
 	providerType string,
 ) (resolvedModelRoute, error) {
 	normalizedProviderType := chatprovider.NormalizeProvider(providerType)
-	keys, _, err := p.resolveUserProviderAPIKeysAndProviderForProviderType(ctx, ownerID, providerType)
+	keys, provider, err := p.resolveUserProviderAPIKeysAndProviderForProviderType(ctx, ownerID, providerType)
 	if err != nil {
 		return resolvedModelRoute{}, err
 	}
-	return newDirectModelRoute(normalizedProviderType, keys), nil
+	providerHint := normalizedProviderType
+	if provider != nil {
+		providerHint = chatprovider.NormalizeProvider(bestEffortAIProviderTypeString(*provider))
+	}
+	return newDirectModelRoute(providerHint, keys), nil
 }
 
 func (p *Server) directProviderHintAndProviderForConfig(
@@ -89,5 +93,5 @@ func (p *Server) directProviderHintAndProviderForConfig(
 	if err != nil {
 		return "", nil, err
 	}
-	return string(provider.Type), &provider, nil
+	return bestEffortAIProviderTypeString(provider), &provider, nil
 }

--- a/coderd/x/chatd/provider_identity.go
+++ b/coderd/x/chatd/provider_identity.go
@@ -38,14 +38,22 @@ func bestEffortAIProviderTypeString(ctx context.Context, logger slog.Logger, pro
 	return string(bestEffortAIProviderType(ctx, logger, provider))
 }
 
+func aiProviderTypeCanSatisfyRequest(candidateProviderType string, requestedProviderType string) bool {
+	if candidateProviderType == requestedProviderType {
+		return true
+	}
+	return requestedProviderType == string(database.AiProviderTypeAnthropic) &&
+		candidateProviderType == string(database.AiProviderTypeBedrock)
+}
+
 func aiProviderMatchesEffectiveType(provider database.AIProvider, normalizedProviderType string) (bool, error) {
 	effectiveType, err := effectiveAIProviderTypeString(provider)
 	if err != nil {
 		return false, err
 	}
-	return chatprovider.NormalizeProvider(effectiveType) == normalizedProviderType, nil
+	return aiProviderTypeCanSatisfyRequest(chatprovider.NormalizeProvider(effectiveType), normalizedProviderType), nil
 }
 
 func aiProviderMatchesRawType(provider database.AIProvider, normalizedProviderType string) bool {
-	return chatprovider.NormalizeProvider(string(provider.Type)) == normalizedProviderType
+	return aiProviderTypeCanSatisfyRequest(chatprovider.NormalizeProvider(string(provider.Type)), normalizedProviderType)
 }

--- a/coderd/x/chatd/provider_identity.go
+++ b/coderd/x/chatd/provider_identity.go
@@ -1,0 +1,47 @@
+package chatd
+
+import (
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/db2sdk"
+	"github.com/coder/coder/v2/coderd/x/chatd/chatprovider"
+)
+
+func effectiveAIProviderType(provider database.AIProvider) (database.AIProviderType, error) {
+	effectiveType, err := db2sdk.EffectiveAIProviderType(provider)
+	if err != nil {
+		return "", err
+	}
+	return database.AIProviderType(effectiveType), nil
+}
+
+func effectiveAIProviderTypeString(provider database.AIProvider) (string, error) {
+	effectiveType, err := effectiveAIProviderType(provider)
+	if err != nil {
+		return "", err
+	}
+	return string(effectiveType), nil
+}
+
+func bestEffortAIProviderType(provider database.AIProvider) database.AIProviderType {
+	effectiveType, err := effectiveAIProviderType(provider)
+	if err != nil {
+		return provider.Type
+	}
+	return effectiveType
+}
+
+func bestEffortAIProviderTypeString(provider database.AIProvider) string {
+	return string(bestEffortAIProviderType(provider))
+}
+
+func aiProviderMatchesEffectiveType(provider database.AIProvider, normalizedProviderType string) (bool, error) {
+	effectiveType, err := effectiveAIProviderTypeString(provider)
+	if err != nil {
+		return false, err
+	}
+	return chatprovider.NormalizeProvider(effectiveType) == normalizedProviderType, nil
+}
+
+func aiProviderMatchesRawType(provider database.AIProvider, normalizedProviderType string) bool {
+	return chatprovider.NormalizeProvider(string(provider.Type)) == normalizedProviderType
+}

--- a/coderd/x/chatd/provider_identity.go
+++ b/coderd/x/chatd/provider_identity.go
@@ -1,6 +1,9 @@
 package chatd
 
 import (
+	"context"
+
+	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprovider"
@@ -22,16 +25,17 @@ func effectiveAIProviderTypeString(provider database.AIProvider) (string, error)
 	return string(effectiveType), nil
 }
 
-func bestEffortAIProviderType(provider database.AIProvider) database.AIProviderType {
+func bestEffortAIProviderType(ctx context.Context, logger slog.Logger, provider database.AIProvider) database.AIProviderType {
 	effectiveType, err := effectiveAIProviderType(provider)
 	if err != nil {
+		logger.Warn(ctx, "parse AI provider settings", slog.F("provider_id", provider.ID), slog.Error(err))
 		return provider.Type
 	}
 	return effectiveType
 }
 
-func bestEffortAIProviderTypeString(provider database.AIProvider) string {
-	return string(bestEffortAIProviderType(provider))
+func bestEffortAIProviderTypeString(ctx context.Context, logger slog.Logger, provider database.AIProvider) string {
+	return string(bestEffortAIProviderType(ctx, logger, provider))
 }
 
 func aiProviderMatchesEffectiveType(provider database.AIProvider, normalizedProviderType string) (bool, error) {

--- a/coderd/x/chatd/subagent.go
+++ b/coderd/x/chatd/subagent.go
@@ -155,13 +155,19 @@ func validateModelConfigAndResolveProvider(
 }
 
 func enabledProviderContainsName(
+	ctx context.Context,
+	logger slog.Logger,
 	providers []database.AIProvider,
 	providerName string,
 ) bool {
 	normalizedProviderName := chatprovider.NormalizeProvider(providerName)
 	for _, provider := range providers {
 		matches, err := aiProviderMatchesEffectiveType(provider, normalizedProviderName)
-		if err == nil && matches {
+		if err != nil {
+			logger.Warn(ctx, "parse AI provider settings", slog.F("provider_id", provider.ID), slog.Error(err))
+			continue
+		}
+		if matches {
 			return true
 		}
 	}
@@ -512,7 +518,7 @@ func (p *Server) resolveModelConfigAndNormalizedProvider(
 		if !provider.Enabled {
 			return database.ChatModelConfig{}, "", sql.ErrNoRows
 		}
-		providerName := chatprovider.NormalizeProvider(bestEffortAIProviderTypeString(provider))
+		providerName := chatprovider.NormalizeProvider(bestEffortAIProviderTypeString(ctx, p.logger, provider))
 		if providerName == "" {
 			return database.ChatModelConfig{}, "", errInvalidModelOverrideMetadata
 		}
@@ -529,7 +535,7 @@ func (p *Server) resolveModelConfigAndNormalizedProvider(
 	if err != nil {
 		return database.ChatModelConfig{}, "", err
 	}
-	if !enabledProviderContainsName(enabledProviders, providerName) {
+	if !enabledProviderContainsName(ctx, p.logger, enabledProviders, providerName) {
 		return database.ChatModelConfig{}, "", sql.ErrNoRows
 	}
 	return modelConfig, providerName, nil

--- a/coderd/x/chatd/subagent.go
+++ b/coderd/x/chatd/subagent.go
@@ -160,7 +160,13 @@ func enabledProviderContainsName(
 ) bool {
 	normalizedProviderName := chatprovider.NormalizeProvider(providerName)
 	for _, provider := range providers {
-		if chatprovider.NormalizeProvider(string(provider.Type)) == normalizedProviderName {
+		matches, err := aiProviderMatchesEffectiveType(provider, normalizedProviderName)
+		if err == nil && matches {
+			return true
+		}
+	}
+	for _, provider := range providers {
+		if aiProviderMatchesRawType(provider, normalizedProviderName) {
 			return true
 		}
 	}
@@ -506,7 +512,7 @@ func (p *Server) resolveModelConfigAndNormalizedProvider(
 		if !provider.Enabled {
 			return database.ChatModelConfig{}, "", sql.ErrNoRows
 		}
-		providerName := chatprovider.NormalizeProvider(string(provider.Type))
+		providerName := chatprovider.NormalizeProvider(bestEffortAIProviderTypeString(provider))
 		if providerName == "" {
 			return database.ChatModelConfig{}, "", errInvalidModelOverrideMetadata
 		}

--- a/codersdk/aiproviders.go
+++ b/codersdk/aiproviders.go
@@ -47,6 +47,9 @@ const (
 	AIProviderTypeCopilot AIProviderType = "copilot"
 )
 
+// AIProviderDisplayNameBedrock is the default display name for AWS Bedrock providers.
+const AIProviderDisplayNameBedrock = "AWS Bedrock"
+
 // AIProviderSettings is the discriminated container for type-specific
 // provider settings stored in ai_providers.settings. Providers that
 // need no type-specific configuration (current OpenAI and standard
@@ -60,8 +63,8 @@ const (
 // concrete settings struct directly.
 type AIProviderSettings struct {
 	// Bedrock, when set, indicates this provider authenticates against
-	// AWS Bedrock instead of api.anthropic.com. Only meaningful for
-	// AIProviderTypeAnthropic.
+	// AWS Bedrock instead of api.anthropic.com. It is meaningful for
+	// AIProviderTypeAnthropic and AIProviderTypeBedrock.
 	Bedrock *AIProviderBedrockSettings `json:"-"`
 }
 

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -4710,7 +4710,7 @@ type AIProviderConfig struct {
 	// BaseURL is the base URL of the upstream provider API.
 	BaseURL string `json:"base_url"`
 
-	// Bedrock fields (only applicable when Type == "anthropic").
+	// Bedrock fields apply when Type is "anthropic" or "bedrock".
 	BedrockBaseURL string `json:"-"`
 	BedrockRegion  string `json:"bedrock_region,omitempty"`
 	// BedrockAccessKeys and BedrockAccessKeySecrets hold one or

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -412,6 +412,12 @@ export interface AIProviderConfig {
 
 // From codersdk/aiproviders.go
 /**
+ * AIProviderDisplayNameBedrock is the default display name for AWS Bedrock providers.
+ */
+export const AIProviderDisplayNameBedrock = "AWS Bedrock";
+
+// From codersdk/aiproviders.go
+/**
  * AIProviderKey is a single API key registered on a provider. The
  * plaintext is never returned; Masked is a one-way rendering safe for
  * display (see aibridge utils MaskSecret). ID lets clients reference

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.stories.tsx
@@ -2092,6 +2092,41 @@ export const ModelFormBedrock: Story = {
 	},
 };
 
+export const ModelListUsesLinkedProviderPresentation: Story = {
+	args: {
+		section: "models" as ChatModelAdminSection,
+		providerConfigsData: [
+			createProviderConfig({
+				id: "provider-bedrock-linked",
+				provider: "bedrock",
+				display_name: "AWS Bedrock",
+				source: "database",
+				has_api_key: false,
+				central_api_key_enabled: true,
+			}),
+		],
+		modelConfigsData: [
+			createModelConfig({
+				id: "model-bedrock-linked",
+				provider: "bedrock",
+				ai_provider_id: "provider-bedrock-linked",
+				model: "anthropic.claude-3-5-sonnet",
+				display_name: "Claude on Bedrock",
+			}),
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const body = within(canvasElement.ownerDocument.body);
+		await expect(
+			await body.findByText("Claude on Bedrock"),
+		).toBeInTheDocument();
+		await expect(
+			await body.findByAltText("AWS Bedrock logo"),
+		).toBeInTheDocument();
+		expect(body.queryByAltText("Anthropic logo")).not.toBeInTheDocument();
+	},
+};
+
 export const ModelPricingWarningInList: Story = {
 	args: {
 		section: "models" as ChatModelAdminSection,

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.tsx
@@ -336,6 +336,8 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 							(ps) =>
 								ps.key === modelConfigProviderKey(modelConfig, providerStates),
 						);
+						const displayProvider =
+							providerState?.provider ?? modelConfig.provider;
 						const duplicateUnavailable = Boolean(
 							providerState && !canManageProviderModels(providerState),
 						);
@@ -355,7 +357,7 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 									className="flex min-w-0 flex-1 cursor-pointer items-center gap-3.5 border-0 bg-transparent p-0 text-left"
 								>
 									<ProviderIcon
-										provider={modelConfig.provider}
+										provider={displayProvider}
 										className="size-8 shrink-0"
 									/>
 									<div className="min-w-0 flex-1">


### PR DESCRIPTION
Bedrock-backed Agents model configs were still serialized and rendered with Anthropic provider identity when the linked AI provider stored Bedrock settings.

This PR resolves effective Bedrock provider identity on the backend for API summaries, chat model configs, availability, and chatd routing while keeping Bedrock runtime calls on the Anthropic-compatible schema. It also lets Anthropic computer use requests use first-class Bedrock providers, updates the Agents model admin list to render linked provider presentation, adds graceful fallback logging for unreadable provider settings, and adds regression coverage.

Refs CODAGT-549

> Mux updated this PR on behalf of Mike.
