### PR TITLE
fix: correct user:* scope typo

### DIFF
--- a/coderd/rbac/scopes_catalog.go
+++ b/coderd/rbac/scopes_catalog.go
@@ -44,7 +44,7 @@ var externalLowLevel = map[ScopeName]struct{}{
 	"user:read":            {},
 	"user:read_personal":   {},
 	"user:update_personal": {},
-	"user.*":               {},
+	"user:*":               {},
 
 	// User secrets
 	"user_secret:read":   {},

--- a/codersdk/apikey_scopes_gen.go
+++ b/codersdk/apikey_scopes_gen.go
@@ -272,6 +272,7 @@ var PublicAPIKeyScopes = []APIKeyScope{
 	APIKeyScopeTemplateRead,
 	APIKeyScopeTemplateUpdate,
 	APIKeyScopeTemplateUse,
+	APIKeyScopeUserAll,
 	APIKeyScopeUserRead,
 	APIKeyScopeUserReadPersonal,
 	APIKeyScopeUserUpdatePersonal,


### PR DESCRIPTION
The wildcard entry in `externalLowLevel` was `"user.*"` (period) instead of `"user:*"` (colon). Every other entry uses the `resource:action` colon convention, and `parseLowLevelScope` rejects the period form, so the wildcard was silently dropped from `ExternalScopeNames()` and could not be requested via `coder tokens create --scope=user:*`.

Closes https://github.com/coder/coder/issues/25623