### PR TITLE
fix(site): restrict pinned chats drag to vertical-only

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
@@ -3,6 +3,7 @@ import {
 	DndContext,
 	type DragEndEvent,
 	KeyboardSensor,
+	type Modifier,
 	MouseSensor,
 	TouchSensor,
 	useSensor,
@@ -519,6 +520,13 @@ export const ChatsPanel: FC<ChatsPanelProps> = ({
 															<DndContext
 																sensors={sensors}
 																collisionDetection={closestCenter}
+																modifiers={[
+																	// Restrict the drag to the y-axis only
+																	({ transform }) => ({
+																		...transform,
+																		x: 0,
+																	}),
+																]}
 																onDragEnd={handleDragEnd}
 															>
 																<SortableContext

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
@@ -3,7 +3,6 @@ import {
 	DndContext,
 	type DragEndEvent,
 	KeyboardSensor,
-	type Modifier,
 	MouseSensor,
 	TouchSensor,
 	useSensor,


### PR DESCRIPTION
This pull-request ensures that we aren't able to drag pinned chats horizontally. When doing so things would overflow poorly and break things. 

https://github.com/user-attachments/assets/3521bc81-8518-4609-9925-4dc25b31c127

https://github.com/user-attachments/assets/77e8301b-35bf-48f0-92d4-4d1eacf6b20e