### PR TITLE
fix: upgrade Go to 1.25.11 (CVE-2026-27145, CVE-2026-42507)

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -4,7 +4,7 @@ description: |
 inputs:
   version:
     description: "The Go version to use."
-    default: "1.25.10"
+    default: "1.25.11"
   use-preinstalled-go:
     description: "Whether to use preinstalled Go."
     default: "false"

--- a/dogfood/coder/Dockerfile
+++ b/dogfood/coder/Dockerfile
@@ -12,7 +12,7 @@ FROM ubuntu:jammy@sha256:104ae83764a5119017b8e8d6218fa0832b09df65aae7d5a6de29a85
 
 # Install Go manually, so that we can control the version
 ARG GO_VERSION=1.25.11
-ARG GO_CHECKSUM="42d4f7a32316aa66591eca7e89867256057a4264451aca10570a715b3637ba70"
+ARG GO_CHECKSUM="34f14304e856893f4ba30c2cacfe93906e9de7915c5f6aaaf3a81cdccd7ba30b"
 
 # Boring Go is needed to build FIPS-compliant binaries.
 RUN apt-get update && \

--- a/dogfood/coder/Dockerfile
+++ b/dogfood/coder/Dockerfile
@@ -11,7 +11,7 @@ RUN cargo install jj-cli typos-cli watchexec-cli@2.3.2
 FROM ubuntu:jammy@sha256:104ae83764a5119017b8e8d6218fa0832b09df65aae7d5a6de29a85d813da2fb AS go
 
 # Install Go manually, so that we can control the version
-ARG GO_VERSION=1.25.10
+ARG GO_VERSION=1.25.11
 ARG GO_CHECKSUM="42d4f7a32316aa66591eca7e89867256057a4264451aca10570a715b3637ba70"
 
 # Boring Go is needed to build FIPS-compliant binaries.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coder/coder/v2
 
-go 1.25.10
+go 1.25.11
 
 // Required until a v3 of chroma is created to lazily initialize all XML files.
 // None of our dependencies seem to use the registries anyways, so this


### PR DESCRIPTION
## Summary

Upgrades Go from 1.25.10 to 1.25.11 on the `release/2.29` branch to address two low-severity CVEs:

- **CVE-2026-27145** (Low): `crypto/x509` `VerifyHostname` quadratic cost with large DNS SAN list (DoS on untrusted certs)
- **CVE-2026-42507** (Low): `net/textproto` attacker-controlled input included in errors without escaping (log injection)

## Changes

- `go.mod`: `go 1.25.10` -> `go 1.25.11`
- `.github/actions/setup-go/action.yaml`: default Go version -> `1.25.11`
- `dogfood/coder/Dockerfile`: `GO_VERSION` -> `1.25.11`

Relates to: [ENT-103](https://linear.app/codercom/issue/ENT-103)

> Generated by Coder Agents on behalf of @Shelnutt2