### PR TITLE
fix: upgrade Go to 1.26.4 (CVE-2026-27145, CVE-2026-42507)

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -4,7 +4,7 @@ description: |
 inputs:
   version:
     description: "The Go version to use."
-    default: "1.26.2"
+    default: "1.26.4"
   use-cache:
     description: "Whether to use the cache."
     default: "true"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coder/coder/v2
 
-go 1.26.2
+go 1.26.4
 
 // Required until a v3 of chroma is created to lazily initialize all XML files.
 // None of our dependencies seem to use the registries anyways, so this


### PR DESCRIPTION
## Summary

Upgrades Go toolchain from 1.26.2 to 1.26.4 on the `release/2.34` branch to address two low-severity CVEs:

- **CVE-2026-27145** (Low): `crypto/x509` `VerifyHostname` quadratic cost with large DNS SAN list (DoS on untrusted certs)
- **CVE-2026-42507** (Low): `net/textproto` attacker-controlled input included in errors without escaping (log injection)

## Changes

- `go.mod`: `go 1.26.2` -> `go 1.26.4`
- `.github/actions/setup-go/action.yaml`: default Go version `1.26.2` -> `1.26.4`

Resolves: [ENT-106](https://linear.app/codercom/issue/ENT-106)

> Generated with Coder Agents