### PR TITLE
fix: upgrade Go to 1.25.11 (CVE-2026-27145, CVE-2026-42507)

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -4,7 +4,7 @@ description: |
 inputs:
   version:
     description: "The Go version to use."
-    default: "1.25.10"
+    default: "1.25.11"
   use-cache:
     description: "Whether to use the cache."
     default: "true"

--- a/dogfood/coder/ubuntu-22.04/Dockerfile
+++ b/dogfood/coder/ubuntu-22.04/Dockerfile
@@ -11,8 +11,8 @@ RUN cargo install jj-cli typos-cli watchexec-cli
 FROM ubuntu:jammy@sha256:eb29ed27b0821dca09c2e28b39135e185fc1302036427d5f4d70a41ce8fd7659 AS go
 
 # Install Go manually, so that we can control the version
-ARG GO_VERSION=1.25.10
-ARG GO_CHECKSUM="42d4f7a32316aa66591eca7e89867256057a4264451aca10570a715b3637ba70"
+ARG GO_VERSION=1.25.11
+ARG GO_CHECKSUM="34f14304e856893f4ba30c2cacfe93906e9de7915c5f6aaaf3a81cdccd7ba30b"
 
 # Boring Go is needed to build FIPS-compliant binaries.
 RUN apt-get update && \

--- a/dogfood/coder/ubuntu-26.04/Dockerfile
+++ b/dogfood/coder/ubuntu-26.04/Dockerfile
@@ -11,8 +11,8 @@ RUN cargo install jj-cli typos-cli watchexec-cli
 FROM ubuntu:26.04@sha256:5e275723f82c67e387ba9e3c24baa0abdcb268917f276a0561c97bef9450d0b4 AS go
 
 # Install Go manually, so that we can control the version
-ARG GO_VERSION=1.25.10
-ARG GO_CHECKSUM="42d4f7a32316aa66591eca7e89867256057a4264451aca10570a715b3637ba70"
+ARG GO_VERSION=1.25.11
+ARG GO_CHECKSUM="34f14304e856893f4ba30c2cacfe93906e9de7915c5f6aaaf3a81cdccd7ba30b"
 
 # Boring Go is needed to build FIPS-compliant binaries.
 RUN apt-get update && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coder/coder/v2
 
-go 1.25.10
+go 1.25.11
 
 // Required until a v3 of chroma is created to lazily initialize all XML files.
 // None of our dependencies seem to use the registries anyways, so this


### PR DESCRIPTION
## Summary

Upgrades the Go toolchain from 1.25.10 to 1.25.11 on the `release/2.33` branch to address two low-severity CVEs:

- **CVE-2026-27145** (Low): `crypto/x509` `VerifyHostname` quadratic cost with large DNS SAN list (DoS on untrusted certs)
- **CVE-2026-42507** (Low): `net/textproto` attacker-controlled input included in errors without escaping (log injection)

## Changes

- `go.mod`: bump `go` directive from 1.25.10 to 1.25.11
- `.github/actions/setup-go/action.yaml`: update default Go version
- `dogfood/coder/ubuntu-26.04/Dockerfile`: update `GO_VERSION` and `GO_CHECKSUM`
- `dogfood/coder/ubuntu-22.04/Dockerfile`: update `GO_VERSION` and `GO_CHECKSUM`

Relates to: [ENT-107](https://linear.app/codercom/issue/ENT-107)

> Generated by Coder Agents