### PR TITLE
fix: resolve user, CLI, docs, and app issues

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -261,6 +261,11 @@ func (r *RootCmd) Create(opts CreateOptions) *serpent.Command {
 				schedSpec = ptr.Ref(sched.String())
 			}
 
+			ephemeralParameters, err := asWorkspaceBuildParameters(parameterFlags.ephemeralParameters)
+			if err != nil {
+				return xerrors.Errorf("unable to parse ephemeral parameters: %w", err)
+			}
+
 			cliBuildParameters, err := asWorkspaceBuildParameters(parameterFlags.richParameters)
 			if err != nil {
 				return xerrors.Errorf("can't parse given parameter values: %w", err)
@@ -324,6 +329,9 @@ func (r *RootCmd) Create(opts CreateOptions) *serpent.Command {
 				TemplateVersionID: templateVersionID,
 				NewWorkspaceName:  workspaceName,
 				Owner:             workspaceOwner,
+
+				PromptEphemeralParameters: parameterFlags.promptEphemeralParameters,
+				EphemeralParameters:       ephemeralParameters,
 
 				PresetParameters:      presetParameters,
 				RichParameterFile:     parameterFlags.richParameterFile,
@@ -455,6 +463,7 @@ func (r *RootCmd) Create(opts CreateOptions) *serpent.Command {
 		},
 		cliui.SkipPromptOption(),
 	)
+	cmd.Options = append(cmd.Options, parameterFlags.cliEphemeralParameters()...)
 	cmd.Options = append(cmd.Options, parameterFlags.cliParameters()...)
 	cmd.Options = append(cmd.Options, parameterFlags.cliParameterDefaults()...)
 	cmd.Options = append(cmd.Options, parameterFlags.useParameterDefaultsOption())

--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -802,6 +802,13 @@ func TestCreateWithRichParameters(t *testing.T) {
 			mutable: false,
 		},
 	}
+	ephemeralParam := param{
+		name:    "ephemeral_param",
+		ptype:   "string",
+		value:   "one-time value",
+		mutable: true,
+	}
+	paramsWithEphemeral := append(append([]param{}, params...), ephemeralParam)
 
 	type testContext struct {
 		client        *codersdk.Client
@@ -903,6 +910,24 @@ func TestCreateWithRichParameters(t *testing.T) {
 				stdout.ExpectMatch(ctx, "Confirm create?")
 				stdin.WriteLine("yes")
 			},
+		},
+		{
+			name: "EphemeralParameterFlag",
+			setup: func() []string {
+				args := []string{}
+				for _, param := range params {
+					args = append(args, "--parameter", fmt.Sprintf("%s=%s", param.name, param.value))
+				}
+				args = append(args, "--ephemeral-parameter", fmt.Sprintf("%s=%s", ephemeralParam.name, ephemeralParam.value))
+				return args
+			},
+			handlePty: func(ctx context.Context, stdout *expecter.Expecter, stdin *testutil.Writer) {
+				// No prompts, we only need to confirm.
+				stdout.ExpectMatch(ctx, "Confirm create?")
+				stdin.WriteLine("yes")
+			},
+			inputParameters:    paramsWithEphemeral,
+			expectedParameters: paramsWithEphemeral,
 		},
 		{
 			name: "MisspelledParameter",
@@ -1112,6 +1137,7 @@ cli_param: from file`)
 					Name:         param.name,
 					Type:         param.ptype,
 					Mutable:      param.mutable,
+					Ephemeral:    param.name == ephemeralParam.name,
 					DefaultValue: defaultValue,
 					Order:        int32(i), //nolint:gosec
 				})

--- a/cli/testdata/coder_create_--help.golden
+++ b/cli/testdata/coder_create_--help.golden
@@ -17,8 +17,20 @@ OPTIONS:
           Specify automatic updates setting for the workspace (accepts 'always'
           or 'never').
 
+      --build-option string-array, $CODER_BUILD_OPTION
+          Build option value in the format "name=value".
+          DEPRECATED: Use --ephemeral-parameter instead.
+
+      --build-options bool
+          Prompt for one-time build options defined with ephemeral parameters.
+          DEPRECATED: Use --prompt-ephemeral-parameters instead.
+
       --copy-parameters-from string, $CODER_WORKSPACE_COPY_PARAMETERS_FROM
           Specify the source workspace name to copy parameters from.
+
+      --ephemeral-parameter string-array, $CODER_EPHEMERAL_PARAMETER
+          Set the value of ephemeral parameters defined in the template. The
+          format is "name=value".
 
       --no-wait bool, $CODER_CREATE_NO_WAIT
           Return immediately after creating the workspace. The build will run in
@@ -33,6 +45,11 @@ OPTIONS:
       --preset string, $CODER_PRESET_NAME
           Specify the name of a template version preset. Use 'none' to
           explicitly indicate that no preset should be used.
+
+      --prompt-ephemeral-parameters bool, $CODER_PROMPT_EPHEMERAL_PARAMETERS
+          Prompt to set values of ephemeral parameters defined in the template.
+          If a value has been set via --ephemeral-parameter, it will not be
+          prompted for.
 
       --rich-parameter-file string, $CODER_RICH_PARAMETER_FILE
           Specify a file path with values for rich parameters defined in the

--- a/cli/usereditroles.go
+++ b/cli/usereditroles.go
@@ -64,10 +64,13 @@ func (r *RootCmd) userEditRoles() *serpent.Command {
 
 				selectedRoles = givenRoles
 			} else {
+				defaultRoles := slices.DeleteFunc(slices.Clone(userRoles.Roles), func(role string) bool {
+					return !slices.Contains(siteRoleNames, role)
+				})
 				selectedRoles, err = cliui.MultiSelect(inv, cliui.MultiSelectOptions{
 					Message:  "Select the roles you'd like to assign to the user",
 					Options:  siteRoleNames,
-					Defaults: userRoles.Roles,
+					Defaults: defaultRoles,
 				})
 				if err != nil {
 					return xerrors.Errorf("selecting roles for user: %w", err)

--- a/cli/usereditroles_test.go
+++ b/cli/usereditroles_test.go
@@ -37,8 +37,9 @@ func TestUserEditRoles(t *testing.T) {
 
 		memberRoles, err := client.UserRoles(ctx, member.Username)
 		require.NoError(t, err)
+		expectedRoles := append([]string{rbac.RoleMember().String()}, roles...)
 
-		require.ElementsMatch(t, memberRoles.Roles, roles)
+		require.ElementsMatch(t, expectedRoles, memberRoles.Roles)
 	})
 
 	t.Run("UserNotFound", func(t *testing.T) {

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -10297,8 +10297,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "format": "uuid",
-                        "description": "User ID",
+                        "description": "User ID, name, or me",
                         "name": "user",
                         "in": "path",
                         "required": true
@@ -10336,8 +10335,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "format": "uuid",
-                        "description": "User ID",
+                        "description": "User ID, name, or me",
                         "name": "user",
                         "in": "path",
                         "required": true

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -9130,8 +9130,7 @@
 				"parameters": [
 					{
 						"type": "string",
-						"format": "uuid",
-						"description": "User ID",
+						"description": "User ID, name, or me",
 						"name": "user",
 						"in": "path",
 						"required": true
@@ -9163,8 +9162,7 @@
 				"parameters": [
 					{
 						"type": "string",
-						"format": "uuid",
-						"description": "User ID",
+						"description": "User ID, name, or me",
 						"name": "user",
 						"in": "path",
 						"required": true

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -1705,7 +1705,8 @@ func (api *API) putUserPassword(rw http.ResponseWriter, r *http.Request) {
 			return xerrors.Errorf("update user hashed password: %w", err)
 		}
 
-		err = tx.DeleteAPIKeysByUserID(ctx, user.ID)
+		//nolint:gocritic // The password update authorization check permits this session invalidation side effect.
+		err = tx.DeleteAPIKeysByUserID(dbauthz.AsSystemRestricted(ctx), user.ID)
 		if err != nil {
 			return xerrors.Errorf("delete api keys by user ID: %w", err)
 		}
@@ -1744,28 +1745,35 @@ func (api *API) userRoles(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: Replace this with "GetAuthorizationUserRoles"
-	resp := codersdk.UserRoles{
-		Roles:             user.RBACRoles,
-		OrganizationRoles: make(map[uuid.UUID][]string),
-	}
-
-	memberships, err := api.Database.OrganizationMembers(ctx, database.OrganizationMembersParams{
-		UserID:         user.ID,
-		OrganizationID: uuid.Nil,
-		IncludeSystem:  false,
-		GithubUserID:   0,
-	})
+	//nolint:gocritic // The handler already authorizes reading the target user before expanding effective roles.
+	authorizationRoles, err := api.Database.GetAuthorizationUserRoles(dbauthz.AsSystemRestricted(ctx), user.ID)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Internal error fetching user's organization memberships.",
+			Message: "Internal error fetching user's roles.",
 			Detail:  err.Error(),
 		})
 		return
 	}
 
-	for _, mem := range memberships {
-		resp.OrganizationRoles[mem.OrganizationMember.OrganizationID] = mem.OrganizationMember.Roles
+	roleNames, err := authorizationRoles.RoleNames()
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Internal error parsing user's roles.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	resp := codersdk.UserRoles{
+		Roles:             make([]string, 0, len(roleNames)),
+		OrganizationRoles: make(map[uuid.UUID][]string),
+	}
+	for _, role := range roleNames {
+		if role.OrganizationID == uuid.Nil {
+			resp.Roles = append(resp.Roles, role.Name)
+			continue
+		}
+		resp.OrganizationRoles[role.OrganizationID] = append(resp.OrganizationRoles[role.OrganizationID], role.Name)
 	}
 
 	httpapi.Write(ctx, rw, http.StatusOK, resp)

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -1326,6 +1326,34 @@ func TestUpdateUserPassword(t *testing.T) {
 		require.NoError(t, err, "member should login successfully with the new password")
 	})
 
+	t.Run("UserAdminCanUpdateMemberPassword", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		owner := coderdtest.CreateFirstUser(t, client)
+		userAdmin, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, rbac.RoleUserAdmin())
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		member, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
+			Email:           "member@coder.com",
+			Username:        "member",
+			Password:        "SomeStrongPassword!",
+			OrganizationIDs: []uuid.UUID{owner.OrganizationID},
+		})
+		require.NoError(t, err, "create member")
+		err = userAdmin.UpdateUserPassword(ctx, member.ID.String(), codersdk.UpdateUserPasswordRequest{
+			Password: "SomeNewStrongPassword!",
+		})
+		require.NoError(t, err, "user admin should be able to update member password")
+
+		_, err = client.LoginWithPassword(ctx, codersdk.LoginWithPasswordRequest{
+			Email:    "member@coder.com",
+			Password: "SomeNewStrongPassword!",
+		})
+		require.NoError(t, err, "member should login successfully with the new password")
+	})
+
 	t.Run("AuditorCantUpdateOtherUserPassword", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, nil)
@@ -1594,11 +1622,14 @@ func TestInitialRoles(t *testing.T) {
 
 	roles, err := client.UserRoles(ctx, codersdk.Me)
 	require.NoError(t, err)
-	require.ElementsMatch(t, roles.Roles, []string{
+	require.ElementsMatch(t, []string{
 		codersdk.RoleOwner,
-	}, "should be a member and admin")
+		codersdk.RoleMember,
+	}, roles.Roles, "should be a member and owner")
 
-	require.ElementsMatch(t, roles.OrganizationRoles[first.OrganizationID], []string{}, "should be a member")
+	require.ElementsMatch(t, []string{
+		rbac.RoleOrgMember(),
+	}, roles.OrganizationRoles[first.OrganizationID], "should be an organization member")
 }
 
 func TestPutUserSuspend(t *testing.T) {

--- a/docs/reference/api/enterprise.md
+++ b/docs/reference/api/enterprise.md
@@ -3678,9 +3678,9 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/quiet-hours \
 
 ### Parameters
 
-| Name   | In   | Type         | Required | Description |
-|--------|------|--------------|----------|-------------|
-| `user` | path | string(uuid) | true     | User ID     |
+| Name   | In   | Type   | Required | Description          |
+|--------|------|--------|----------|----------------------|
+| `user` | path | string | true     | User ID, name, or me |
 
 ### Example responses
 
@@ -3747,7 +3747,7 @@ curl -X PUT http://coder-server:8080/api/v2/users/{user}/quiet-hours \
 
 | Name   | In   | Type                                                                                                   | Required | Description             |
 |--------|------|--------------------------------------------------------------------------------------------------------|----------|-------------------------|
-| `user` | path | string(uuid)                                                                                           | true     | User ID                 |
+| `user` | path | string                                                                                                 | true     | User ID, name, or me    |
 | `body` | body | [codersdk.UpdateUserQuietHoursScheduleRequest](schemas.md#codersdkupdateuserquiethoursschedulerequest) | true     | Update schedule request |
 
 ### Example responses

--- a/docs/reference/cli/create.md
+++ b/docs/reference/cli/create.md
@@ -100,6 +100,41 @@ Return immediately after creating the workspace. The build will run in the backg
 
 Bypass confirmation prompts.
 
+### --build-option
+
+|             |                                  |
+|-------------|----------------------------------|
+| Type        | <code>string-array</code>        |
+| Environment | <code>$CODER_BUILD_OPTION</code> |
+
+Build option value in the format "name=value".
+
+### --build-options
+
+|      |                   |
+|------|-------------------|
+| Type | <code>bool</code> |
+
+Prompt for one-time build options defined with ephemeral parameters.
+
+### --ephemeral-parameter
+
+|             |                                         |
+|-------------|-----------------------------------------|
+| Type        | <code>string-array</code>               |
+| Environment | <code>$CODER_EPHEMERAL_PARAMETER</code> |
+
+Set the value of ephemeral parameters defined in the template. The format is "name=value".
+
+### --prompt-ephemeral-parameters
+
+|             |                                                 |
+|-------------|-------------------------------------------------|
+| Type        | <code>bool</code>                               |
+| Environment | <code>$CODER_PROMPT_EPHEMERAL_PARAMETERS</code> |
+
+Prompt to set values of ephemeral parameters defined in the template. If a value has been set via --ephemeral-parameter, it will not be prompted for.
+
 ### --parameter
 
 |             |                                    |

--- a/docs/reference/cli/external-workspaces_create.md
+++ b/docs/reference/cli/external-workspaces_create.md
@@ -100,6 +100,41 @@ Return immediately after creating the workspace. The build will run in the backg
 
 Bypass confirmation prompts.
 
+### --build-option
+
+|             |                                  |
+|-------------|----------------------------------|
+| Type        | <code>string-array</code>        |
+| Environment | <code>$CODER_BUILD_OPTION</code> |
+
+Build option value in the format "name=value".
+
+### --build-options
+
+|      |                   |
+|------|-------------------|
+| Type | <code>bool</code> |
+
+Prompt for one-time build options defined with ephemeral parameters.
+
+### --ephemeral-parameter
+
+|             |                                         |
+|-------------|-----------------------------------------|
+| Type        | <code>string-array</code>               |
+| Environment | <code>$CODER_EPHEMERAL_PARAMETER</code> |
+
+Set the value of ephemeral parameters defined in the template. The format is "name=value".
+
+### --prompt-ephemeral-parameters
+
+|             |                                                 |
+|-------------|-------------------------------------------------|
+| Type        | <code>bool</code>                               |
+| Environment | <code>$CODER_PROMPT_EPHEMERAL_PARAMETERS</code> |
+
+Prompt to set values of ephemeral parameters defined in the template. If a value has been set via --ephemeral-parameter, it will not be prompted for.
+
 ### --parameter
 
 |             |                                    |

--- a/enterprise/cli/testdata/coder_external-workspaces_create_--help.golden
+++ b/enterprise/cli/testdata/coder_external-workspaces_create_--help.golden
@@ -17,8 +17,20 @@ OPTIONS:
           Specify automatic updates setting for the workspace (accepts 'always'
           or 'never').
 
+      --build-option string-array, $CODER_BUILD_OPTION
+          Build option value in the format "name=value".
+          DEPRECATED: Use --ephemeral-parameter instead.
+
+      --build-options bool
+          Prompt for one-time build options defined with ephemeral parameters.
+          DEPRECATED: Use --prompt-ephemeral-parameters instead.
+
       --copy-parameters-from string, $CODER_WORKSPACE_COPY_PARAMETERS_FROM
           Specify the source workspace name to copy parameters from.
+
+      --ephemeral-parameter string-array, $CODER_EPHEMERAL_PARAMETER
+          Set the value of ephemeral parameters defined in the template. The
+          format is "name=value".
 
       --no-wait bool, $CODER_CREATE_NO_WAIT
           Return immediately after creating the workspace. The build will run in
@@ -33,6 +45,11 @@ OPTIONS:
       --preset string, $CODER_PRESET_NAME
           Specify the name of a template version preset. Use 'none' to
           explicitly indicate that no preset should be used.
+
+      --prompt-ephemeral-parameters bool, $CODER_PROMPT_EPHEMERAL_PARAMETERS
+          Prompt to set values of ephemeral parameters defined in the template.
+          If a value has been set via --ephemeral-parameter, it will not be
+          prompted for.
 
       --rich-parameter-file string, $CODER_RICH_PARAMETER_FILE
           Specify a file path with values for rich parameters defined in the

--- a/enterprise/coderd/users.go
+++ b/enterprise/coderd/users.go
@@ -41,7 +41,7 @@ func (api *API) autostopRequirementEnabledMW(next http.Handler) http.Handler {
 // @Security CoderSessionToken
 // @Produce json
 // @Tags Enterprise
-// @Param user path string true "User ID" format(uuid)
+// @Param user path string true "User ID, name, or me"
 // @Success 200 {array} codersdk.UserQuietHoursScheduleResponse
 // @Router /api/v2/users/{user}/quiet-hours [get]
 func (api *API) userQuietHoursSchedule(rw http.ResponseWriter, r *http.Request) {
@@ -76,7 +76,7 @@ func (api *API) userQuietHoursSchedule(rw http.ResponseWriter, r *http.Request) 
 // @Accept json
 // @Produce json
 // @Tags Enterprise
-// @Param user path string true "User ID" format(uuid)
+// @Param user path string true "User ID, name, or me"
 // @Param request body codersdk.UpdateUserQuietHoursScheduleRequest true "Update schedule request"
 // @Success 200 {array} codersdk.UserQuietHoursScheduleResponse
 // @Router /api/v2/users/{user}/quiet-hours [put]

--- a/site/src/modules/apps/apps.test.ts
+++ b/site/src/modules/apps/apps.test.ts
@@ -117,6 +117,25 @@ describe("getAppHref", () => {
 		expect(href).toBe(externalApp.url);
 	});
 
+	it("returns an invalid external app URL without throwing", () => {
+		const externalApp = {
+			...MockWorkspaceApp,
+			external: true,
+			url: `not-a-valid-url?token=${SESSION_TOKEN_PLACEHOLDER}`,
+		};
+		let href = "";
+		expect(() => {
+			href = getAppHref(externalApp, {
+				host: "*.apps-host.tld",
+				agent: MockWorkspaceAgent,
+				workspace: MockWorkspace,
+				path: "/path-base",
+				token: "user-session-token",
+			});
+		}).not.toThrow();
+		expect(href).toBe(externalApp.url);
+	});
+
 	it("returns a path when app doesn't use a subdomain", () => {
 		const app = {
 			...MockWorkspaceApp,

--- a/site/src/modules/apps/apps.ts
+++ b/site/src/modules/apps/apps.ts
@@ -117,7 +117,13 @@ export const getAppHref = (
 	{ path, token, workspace, agent, host }: GetAppHrefParams,
 ): string => {
 	if (isExternalApp(app)) {
-		const appProtocol = new URL(app.url).protocol;
+		let appProtocol: string;
+		try {
+			appProtocol = new URL(app.url).protocol;
+		} catch {
+			return app.url;
+		}
+
 		const isAllowedProtocol =
 			ALLOWED_EXTERNAL_APP_PROTOCOLS.includes(appProtocol);
 


### PR DESCRIPTION
Fixes several independent user-facing issues:

- Lets user admins reset another user's password by using system-restricted DB access only for API key invalidation after the handler authorizes the password update.
- Returns effective user roles from `/users/{user}/roles`, including implied site and organization roles, and filters implied roles out of the interactive role editor defaults.
- Adds `--ephemeral-parameter` and `--prompt-ephemeral-parameters` to `coder create`, with generated CLI docs and golden help updates.
- Prevents invalid external app URLs from crashing the frontend during app link rendering.
- Allows `me` in Swagger UI for enterprise quiet-hours endpoints by documenting the path parameter as a string instead of UUID-only.

Closes #25873
Closes #26002
Closes #25832
Closes #22349
Closes #24473

<details>
<summary>Coder Agents notes</summary>

This PR was generated by Coder Agents.

</details>
