### PR TITLE
fix(coderd): isolate OIDC fake IDP in parallel subtests

### DIFF
--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -1770,13 +1770,6 @@ func TestUserOIDC(t *testing.T) {
 	t.Run("OIDCEmailFallbackBlockedByExistingLink", func(t *testing.T) {
 		t.Parallel()
 
-		fake := oidctest.NewFakeIDP(t,
-			oidctest.WithRefresh(func(_ string) error {
-				return xerrors.New("refreshing token should never occur")
-			}),
-			oidctest.WithServing(),
-		)
-
 		for _, tc := range []struct {
 			name         string
 			allowSignups bool
@@ -1788,6 +1781,12 @@ func TestUserOIDC(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
+				fake := oidctest.NewFakeIDP(t,
+					oidctest.WithRefresh(func(_ string) error {
+						return xerrors.New("refreshing token should never occur")
+					}),
+					oidctest.WithServing(),
+				)
 				cfg := fake.OIDCConfig(t, nil, func(cfg *coderd.OIDCConfig) {
 					cfg.AllowSignups = tc.allowSignups
 				})


### PR DESCRIPTION
ENG-2833 reported `TestPatchChat/PlanMode/*` and `TestProvisionerJobs/ProvisionerJobs/Single/*` as race failures. Re-fetching the full job log showed those tests only had `testing.go:1712: race detected during execution of test` after the package-level race detector had already reported stacks from `TestUserOIDC/OIDCEmailFallbackBlockedByExistingLink`.

The race stack reads `oauth2.Config.AuthCodeURL` through `coderd/httpmw/oauth2.go` while another parallel OIDC subtest writes the same fake IDP redirect URL through `oidctest.FakeIDP.SetRedirect`. This moves the `oidctest.FakeIDP` setup into each parallel table subtest so plan chat and provisioner job tests are no longer collateral failures from the shared OIDC fake.

Closes ENG-2833

<details>
<summary>Coder Agents generated context</summary>

Generated by Coder Agents.

Relevant original CI log evidence:

- `WARNING: DATA RACE` at lines 1515, 1737, 1965, and 2193 of the fetched job log.
- Read side: `golang.org/x/oauth2.(*Config).AuthCodeURL()` through `coderd/httpmw/oauth2.go:156`.
- Write side: `coderd/coderdtest/oidctest.(*FakeIDP).SetRedirect()` from `LoginWithClient()` in `TestUserOIDC/OIDCEmailFallbackBlockedByExistingLink`.
- Later failures in `TestPatchChat/PlanMode/*` and `TestProvisionerJobs/ProvisionerJobs/Single/*` only contain `testing.go:1712: race detected during execution of test`.

Local validation:

- `go test -race ./coderd -run 'TestUserOIDC/OIDCEmailFallbackBlockedByExistingLink' -count=50 -failfast -v`
- `go test -race ./coderd -run '^(TestUserOIDC|TestPatchChat|TestProvisionerJobs)$/((OIDCEmailFallbackBlockedByExistingLink)|(PlanMode|Title)|(ProvisionerJobs))' -count=20 -failfast`
- `make lint`

</details>
