### PR TITLE
fix: bypass pointer events check during UpdateUserRoleError story

### DIFF
--- a/site/src/pages/UsersPage/UsersPage.stories.tsx
+++ b/site/src/pages/UsersPage/UsersPage.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { PointerEventsCheckLevel } from "@testing-library/user-event";
 import { expect, screen, spyOn, userEvent, within } from "storybook/test";
 import { API } from "#/api/api";
 import { deploymentConfigQueryKey } from "#/api/queries/deployment";
@@ -385,7 +386,9 @@ export const UpdateUserRoleSuccess: Story = {
 export const UpdateUserRoleError: Story = {
 	parameters: UpdateUserRoleSuccess.parameters,
 	play: async ({ canvasElement }) => {
-		const user = userEvent.setup();
+		const user = userEvent.setup({
+			pointerEventsCheck: PointerEventsCheckLevel.Never,
+		});
 		const userRow = canvasElement.querySelector<HTMLElement>("tbody tr");
 		if (!userRow) {
 			throw new Error("No user row found");


### PR DESCRIPTION
fixes DEVEX-402

Fixes this test flake when testing UsersPage.stories.tsx locally:

```
FAIL  |storybook (chromium)| src/pages/UsersPage/UsersPage.stories.tsx > Update User Role Error
Unable to perform pointer interaction as the element has `pointer-events: none`:

BUTTON#radix-_r_163_(label=Open menu)
 ❯ play src/pages/UsersPage/UsersPage.stories.tsx:395:8
    393|   spyOn(API, "updateUserRoles").mockRejectedValue({});
    394|
    395|   await user.click(within(userRow).getByLabelText("Open menu"));
    396|   await user.click(screen.getByText("Edit roles"));
    397|   await user.click(screen.getByLabelText("Auditor", { exact: false }));
```