### PR TITLE
fix(site): search box mishandles diff URLs and error overflow

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchDialog.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchDialog.stories.tsx
@@ -156,7 +156,7 @@ export const Results: Story = {
 		await waitFor(() => {
 			expect(API.experimental.getChats).toHaveBeenCalledWith({
 				limit: CHAT_SEARCH_LIMIT,
-				q: 'title:"Fix"',
+				q: "title:Fix",
 			});
 		});
 		await expect(
@@ -224,7 +224,7 @@ export const OverflowResults: Story = {
 		await waitFor(() => {
 			expect(API.experimental.getChats).toHaveBeenCalledWith({
 				limit: CHAT_SEARCH_LIMIT,
-				q: 'title:"review"',
+				q: "title:review",
 			});
 		});
 
@@ -260,7 +260,7 @@ export const CappedResults: Story = {
 		await waitFor(() => {
 			expect(API.experimental.getChats).toHaveBeenCalledWith({
 				limit: CHAT_SEARCH_LIMIT,
-				q: 'title:"Fix"',
+				q: "title:Fix",
 			});
 		});
 		await expect(
@@ -379,6 +379,36 @@ export const ErrorStateWithStackTrace: Story = {
 		const details = body.getByText("Stack Trace");
 		await userEvent.click(details);
 		await expect(body.getByText(/fetchChats/)).toBeInTheDocument();
+	},
+};
+
+// Regression coverage for CODAGT-556: a backend validation error echoing a
+// long diff URL must wrap inside the 560px dialog instead of spilling out the
+// right side. The story renders the dialog with the offending alert pre-shown
+// so visual regression tooling and reviewers can verify the wrap behavior.
+export const ErrorStateWithLongURL: Story = {
+	beforeEach: () => {
+		const err = new Error(
+			"Query element \"diff_url:https://github.com/coder/coder/pull/25391\" can only contain 1 ':'",
+		);
+		spyOn(API.experimental, "getChats").mockRejectedValue(err);
+	},
+	play: async () => {
+		const body = within(document.body);
+		await userEvent.type(
+			body.getByRole("combobox", { name: "Search chats" }),
+			"title:x",
+		);
+		const alert = await body.findByRole("alert");
+		await expect(alert).toBeInTheDocument();
+
+		// The alert must not exceed the dialog content width (max 560px).
+		const dialog = body.getByRole("dialog");
+		await waitFor(() => {
+			expect(alert.getBoundingClientRect().right).toBeLessThanOrEqual(
+				dialog.getBoundingClientRect().right + 1,
+			);
+		});
 	},
 };
 
@@ -537,7 +567,68 @@ export const CombinedFilterAndText: Story = {
 		await waitFor(() => {
 			expect(API.experimental.getChats).toHaveBeenCalledWith({
 				limit: CHAT_SEARCH_LIMIT,
-				q: 'has_unread:true title:"Fix"',
+				q: "has_unread:true title:Fix",
+			});
+		});
+	},
+};
+
+// Regression coverage for CODAGT-556: pasting a diff URL into a `diff_url:`
+// pill must quote the value so the backend doesn't reject it with
+// "can only contain 1 ':'". A scheme-less URL must also be sent to the
+// backend with `https://` prepended so it passes the URL validator.
+export const DiffURLFilterPill: Story = {
+	beforeEach: () => {
+		spyOn(API.experimental, "getChats").mockResolvedValue(mockChats);
+	},
+	play: async () => {
+		const body = within(document.body);
+		const searchInput = body.getByRole("combobox", { name: "Search chats" });
+		const toggleButton = body.getByRole("button", { name: "Toggle filters" });
+
+		await userEvent.click(toggleButton);
+		await userEvent.click(await body.findByText("Diff URL"));
+		await userEvent.click(searchInput);
+		await userEvent.type(
+			searchInput,
+			"https://github.com/coder/coder/pull/25391{Enter}",
+		);
+
+		await expect(
+			await body.findByText(
+				"diff_url:https://github.com/coder/coder/pull/25391",
+			),
+		).toBeInTheDocument();
+
+		await waitFor(() => {
+			expect(API.experimental.getChats).toHaveBeenCalledWith({
+				limit: CHAT_SEARCH_LIMIT,
+				q: 'diff_url:"https://github.com/coder/coder/pull/25391"',
+			});
+		});
+	},
+};
+
+// Regression coverage for CODAGT-556: a bare URL pasted into the input
+// should be auto-routed to a `diff_url:` filter pill instead of falling
+// through as a title search (which would never match).
+export const BareURLAutoRoutesToDiffURL: Story = {
+	beforeEach: () => {
+		spyOn(API.experimental, "getChats").mockResolvedValue(mockChats);
+	},
+	play: async () => {
+		const body = within(document.body);
+		const searchInput = body.getByRole("combobox", { name: "Search chats" });
+
+		await userEvent.type(
+			searchInput,
+			"https://github.com/coder/coder/pull/25391{Enter}",
+		);
+
+		await waitFor(() => {
+			expect(API.experimental.getChats).toHaveBeenCalledWith({
+				limit: CHAT_SEARCH_LIMIT,
+				q: 'diff_url:"https://github.com/coder/coder/pull/25391"',
 			});
 		});
 	},

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchDialog.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchDialog.stories.tsx
@@ -625,6 +625,15 @@ export const BareURLAutoRoutesToDiffURL: Story = {
 			"https://github.com/coder/coder/pull/25391{Enter}",
 		);
 
+		// The pill must render so a regression in `handleInputKeyDown`'s
+		// URL detection cannot hide behind the normalizer producing the
+		// same `q` value from freeText.
+		await expect(
+			await body.findByText(
+				"diff_url:https://github.com/coder/coder/pull/25391",
+			),
+		).toBeInTheDocument();
+
 		await waitFor(() => {
 			expect(API.experimental.getChats).toHaveBeenCalledWith({
 				limit: CHAT_SEARCH_LIMIT,

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchDialog.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchDialog.tsx
@@ -26,6 +26,7 @@ import {
 	looksLikeChatDiffURL,
 	normalizeChatDiffURLValue,
 	normalizeChatSearchInput,
+	resolveChatSearchFilterAlias,
 } from "./searchQuery";
 
 // Filter definitions. Filters with a defaultValue are inserted as complete
@@ -333,7 +334,7 @@ const ChatSearchDialogContent: FC<ChatSearchDialogContentProps> = ({
 			for (const token of tokens) {
 				const colonIndex = token.indexOf(":");
 				if (colonIndex > 0 && colonIndex < token.length - 1) {
-					const key = token.slice(0, colonIndex);
+					const key = resolveChatSearchFilterAlias(token.slice(0, colonIndex));
 					const val = token.slice(colonIndex + 1);
 					if (KNOWN_FILTER_KEYS.has(key)) {
 						// Drop duplicate filter keys silently instead of
@@ -424,7 +425,10 @@ const ChatSearchDialogContent: FC<ChatSearchDialogContentProps> = ({
 				   the dropdown, but clicks within the dropdown (which is
 				   inside the same container) don't trigger blur. */}
 			<div
-				className="relative"
+				// `min-w-0` keeps this column flex item from expanding past the
+				// dialog's max-width when its content (filter pills, dropdown)
+				// would otherwise demand a larger intrinsic width.
+				className="relative min-w-0"
 				onBlur={(e) => {
 					if (!e.currentTarget.contains(e.relatedTarget)) {
 						setIsDropdownOpen(false);

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchDialog.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchDialog.tsx
@@ -22,6 +22,8 @@ import { useDebouncedValue } from "#/hooks/debounce";
 import { ChatSearchInput, type SearchFilter } from "./ChatSearchInput";
 import { ChatSearchResults } from "./ChatSearchResults";
 import {
+	CHAT_SEARCH_FILTER_KEYS,
+	type ChatSearchFilterKey,
 	formatChatSearchFilterToken,
 	looksLikeChatDiffURL,
 	normalizeChatDiffURLValue,
@@ -33,7 +35,7 @@ import {
 // pills (e.g. has_unread:true). Filters without one are inserted as
 // incomplete pills so the user can type the value.
 type FilterDefinition = {
-	readonly key: string;
+	readonly key: ChatSearchFilterKey;
 	readonly label: string;
 	readonly icon: FC<{ className?: string }>;
 	readonly defaultValue: string | null;
@@ -62,10 +64,10 @@ const FILTER_DEFINITIONS: readonly FilterDefinition[] = [
 ];
 
 // Set of recognized filter keys for detecting typed filter patterns
-// (e.g. "has_unread:true" typed directly into the input). Derived from
-// FILTER_DEFINITIONS; the backend equivalent lives in searchQuery.ts as
-// passthroughChatSearchFilterKeys.
-const KNOWN_FILTER_KEYS = new Set(FILTER_DEFINITIONS.map((def) => def.key));
+// (e.g. "has_unread:true" typed directly into the input). Derived from the
+// shared {@link CHAT_SEARCH_FILTER_KEYS} so the dialog and the normalizer
+// stay in sync when a new filter is added.
+const KNOWN_FILTER_KEYS = new Set<string>(CHAT_SEARCH_FILTER_KEYS);
 
 type ChatSearchDialogProps = {
 	readonly open: boolean;
@@ -139,10 +141,6 @@ type ChatSearchDialogContentProps = Omit<
 
 // Build a raw query string from structured filters + freeform text, then
 // normalize it through the existing parser that the backend expects.
-// formatChatSearchFilterToken handles quoting (including for values that
-// contain `:` like diff URLs) and prepends `https://` for scheme-less
-// diff_url values, both of which the raw backend parser would otherwise
-// reject with "can only contain 1 ':'" or "http or https scheme" errors.
 const buildQuery = (
 	filters: readonly SearchFilter[],
 	freeText: string,
@@ -335,7 +333,10 @@ const ChatSearchDialogContent: FC<ChatSearchDialogContentProps> = ({
 				const colonIndex = token.indexOf(":");
 				if (colonIndex > 0 && colonIndex < token.length - 1) {
 					const key = resolveChatSearchFilterAlias(token.slice(0, colonIndex));
-					const val = token.slice(colonIndex + 1);
+					// Match `getKeyValuePair` in searchQuery.ts so a manually
+					// quoted value (e.g. pasted from JSON) does not surface in
+					// the pill with literal quotes.
+					const val = token.slice(colonIndex + 1).replace(/^"|"$/g, "");
 					if (KNOWN_FILTER_KEYS.has(key)) {
 						// Drop duplicate filter keys silently instead of
 						// letting them fall through to freeform text.

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchDialog.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchDialog.tsx
@@ -21,7 +21,12 @@ import { Dialog, DialogContent, DialogTitle } from "#/components/Dialog/Dialog";
 import { useDebouncedValue } from "#/hooks/debounce";
 import { ChatSearchInput, type SearchFilter } from "./ChatSearchInput";
 import { ChatSearchResults } from "./ChatSearchResults";
-import { normalizeChatSearchInput } from "./searchQuery";
+import {
+	formatChatSearchFilterToken,
+	looksLikeChatDiffURL,
+	normalizeChatDiffURLValue,
+	normalizeChatSearchInput,
+} from "./searchQuery";
 
 // Filter definitions. Filters with a defaultValue are inserted as complete
 // pills (e.g. has_unread:true). Filters without one are inserted as
@@ -133,6 +138,10 @@ type ChatSearchDialogContentProps = Omit<
 
 // Build a raw query string from structured filters + freeform text, then
 // normalize it through the existing parser that the backend expects.
+// formatChatSearchFilterToken handles quoting (including for values that
+// contain `:` like diff URLs) and prepends `https://` for scheme-less
+// diff_url values, both of which the raw backend parser would otherwise
+// reject with "can only contain 1 ':'" or "http or https scheme" errors.
 const buildQuery = (
 	filters: readonly SearchFilter[],
 	freeText: string,
@@ -140,11 +149,7 @@ const buildQuery = (
 	const parts: string[] = [];
 	for (const f of filters) {
 		if (f.value !== null && f.value !== "") {
-			// Strip internal quotes before wrapping so the resulting
-			// key:"value" token stays well-formed for the backend.
-			const stripped = f.value.replaceAll('"', "");
-			const v = stripped.includes(" ") ? `"${stripped}"` : stripped;
-			parts.push(`${f.key}:${v}`);
+			parts.push(formatChatSearchFilterToken(f.key, f.value));
 		}
 	}
 	if (freeText.trim()) {
@@ -242,10 +247,16 @@ const ChatSearchDialogContent: FC<ChatSearchDialogContentProps> = ({
 
 	const commitIncompleteFilter = () => {
 		if (incompleteFilterKey && freeText.trim()) {
-			setFilters((prev) => [
-				...prev,
-				{ key: incompleteFilterKey, value: freeText.trim() },
-			]);
+			const rawValue = freeText.trim();
+			// `diff_url` pills accept URLs without a scheme as a convenience
+			// (so the user can paste `github.com/...` and have it work). The
+			// backend's validator rejects scheme-less URLs, so normalize the
+			// value into the committed pill rather than only at query time.
+			const value =
+				incompleteFilterKey === "diff_url"
+					? normalizeChatDiffURLValue(rawValue)
+					: rawValue;
+			setFilters((prev) => [...prev, { key: incompleteFilterKey, value }]);
 			setFreeText("");
 			setIncompleteFilterKey(null);
 		}
@@ -328,11 +339,24 @@ const ChatSearchDialogContent: FC<ChatSearchDialogContentProps> = ({
 						// Drop duplicate filter keys silently instead of
 						// letting them fall through to freeform text.
 						if (!activeKeys.has(key)) {
-							newFilters.push({ key, value: val });
+							const normalizedVal =
+								key === "diff_url" ? normalizeChatDiffURLValue(val) : val;
+							newFilters.push({ key, value: normalizedVal });
 							activeKeys.add(key);
 						}
 						continue;
 					}
+				}
+				// A bare URL paste is almost always a diff link; promote it to a
+				// `diff_url` pill instead of running an always-empty title
+				// search on the URL string.
+				if (!activeKeys.has("diff_url") && looksLikeChatDiffURL(token)) {
+					newFilters.push({
+						key: "diff_url",
+						value: normalizeChatDiffURLValue(token),
+					});
+					activeKeys.add("diff_url");
+					continue;
 				}
 				remaining.push(token);
 			}

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchInput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchInput.tsx
@@ -45,32 +45,45 @@ export const ChatSearchInput: FC<ChatSearchInputProps> = ({
 	return (
 		<div
 			className={cn(
-				"flex min-h-10 w-full items-center gap-1.5 rounded-md border border-solid border-border-default bg-surface-primary px-3",
+				// `flex-wrap` lets the pills + input flow onto additional rows
+				// when there are too many filters to fit on one line, instead
+				// of expanding the row past the dialog's max-width. With a
+				// wrapping flex container, `items-center` aligns items within
+				// each wrap line so a single-row layout stays vertically
+				// centered while a multi-row layout still pins the icons to
+				// the first row of pills.
+				"flex min-h-10 w-full min-w-0 flex-wrap items-center gap-1.5 rounded-md border border-solid border-border-default bg-surface-primary px-3 py-1.5",
 				"focus-within:ring-2 focus-within:ring-content-link",
 			)}
 		>
 			<SearchIcon className="size-4 shrink-0 text-content-secondary" />
-			{completedFilters.map((f) => (
-				<span
-					key={f.key}
-					className="inline-flex shrink-0 items-center gap-1 rounded-md border border-solid border-border bg-surface-secondary px-2 py-0.5 text-xs text-content-secondary"
-				>
-					<span>
-						{f.key}:{f.value}
-					</span>
-					<button
-						type="button"
-						onClick={(e) => {
-							e.stopPropagation();
-							onRemoveFilter(f.key);
-						}}
-						className="inline-flex cursor-pointer items-center border-none bg-transparent p-0 text-content-secondary hover:text-content-primary"
-						aria-label={`Remove ${f.key} filter`}
+			{completedFilters.map((f) => {
+				const tokenText = `${f.key}:${f.value}`;
+				return (
+					<span
+						key={f.key}
+						// `max-w-full` plus `truncate` on the inner text keeps a
+						// single very long pill (e.g. a diff URL) from blowing
+						// past the dialog edge even with wrapping enabled.
+						className="inline-flex max-w-full shrink items-center gap-1 rounded-md border border-solid border-border bg-surface-secondary px-2 py-0.5 text-xs text-content-secondary"
 					>
-						<XIcon className="size-3" />
-					</button>
-				</span>
-			))}
+						<span className="min-w-0 truncate" title={tokenText}>
+							{tokenText}
+						</span>
+						<button
+							type="button"
+							onClick={(e) => {
+								e.stopPropagation();
+								onRemoveFilter(f.key);
+							}}
+							className="inline-flex shrink-0 cursor-pointer items-center border-none bg-transparent p-0 text-content-secondary hover:text-content-primary"
+							aria-label={`Remove ${f.key} filter`}
+						>
+							<XIcon className="size-3" />
+						</button>
+					</span>
+				);
+			})}
 			{incompleteFilter && (
 				<span className="inline-flex shrink-0 items-center rounded-md border border-dashed border-border bg-surface-secondary px-2 py-0.5 text-xs text-content-secondary">
 					{incompleteFilter.key}:
@@ -82,7 +95,7 @@ export const ChatSearchInput: FC<ChatSearchInputProps> = ({
 				onChange={onChange}
 				onKeyDown={onKeyDown}
 				placeholder={filters.length > 0 ? "" : "Search chats..."}
-				className="min-w-[60px] flex-1 border-none bg-transparent py-2 text-sm text-content-primary outline-none placeholder:text-content-disabled"
+				className="min-w-[60px] flex-1 border-none bg-transparent py-0.5 text-sm text-content-primary outline-none placeholder:text-content-disabled"
 				aria-label="Search chats"
 				role="combobox"
 				aria-controls={hasResults ? listboxId : undefined}

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchResults.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchResults.tsx
@@ -51,7 +51,12 @@ export const ChatSearchResults: FC<ChatSearchResultsProps> = ({
 			<div className="min-h-[260px]">
 				<ErrorAlert
 					error={error}
-					className="max-h-[340px] overflow-y-auto [&_pre]:whitespace-pre-wrap [&_pre]:break-all [&_pre]:w-auto [&_pre]:min-w-0"
+					// `[overflow-wrap:anywhere]` on the alert title/description
+					// keeps long unbreakable strings (URLs, raw error tokens)
+					// from overflowing the dialog's 560px max width. Backend
+					// validation errors echo the offending query element, which
+					// is often a diff URL with no spaces.
+					className="max-h-[340px] overflow-y-auto [&_h2]:[overflow-wrap:anywhere] [&_span]:[overflow-wrap:anywhere] [&_pre]:whitespace-pre-wrap [&_pre]:break-all [&_pre]:w-auto [&_pre]:min-w-0"
 				/>
 			</div>
 		);

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/searchQuery.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/searchQuery.test.ts
@@ -3,6 +3,7 @@ import {
 	looksLikeChatDiffURL,
 	normalizeChatDiffURLValue,
 	normalizeChatSearchInput,
+	resolveChatSearchFilterAlias,
 } from "./searchQuery";
 
 describe("normalizeChatSearchInput", () => {
@@ -124,6 +125,36 @@ describe("normalizeChatSearchInput", () => {
 				"archived:true https://github.com/coder/coder/pull/1",
 			),
 		).toBe('archived:true diff_url:"https://github.com/coder/coder/pull/1"');
+	});
+
+	it("resolves common filter-key aliases to their canonical form", () => {
+		// User typos / shorthand land on the right filter instead of falling
+		// through to an always-empty title search.
+		expect(normalizeChatSearchInput("archive:true")).toBe("archived:true");
+		expect(normalizeChatSearchInput("unread:true")).toBe("has_unread:true");
+		expect(
+			normalizeChatSearchInput('diff:"https://github.com/coder/coder/pull/1"'),
+		).toBe('diff_url:"https://github.com/coder/coder/pull/1"');
+		expect(normalizeChatSearchInput("prstatus:open")).toBe("pr_status:open");
+		expect(normalizeChatSearchInput("pr-status:open")).toBe("pr_status:open");
+	});
+});
+
+describe("resolveChatSearchFilterAlias", () => {
+	it.each([
+		["archive", "archived"],
+		["unread", "has_unread"],
+		["diff", "diff_url"],
+		["diffurl", "diff_url"],
+		["diff-url", "diff_url"],
+		["prstatus", "pr_status"],
+		["pr-status", "pr_status"],
+		["ARCHIVE", "archived"],
+		["archived", "archived"],
+		["title", "title"],
+		["unknown", "unknown"],
+	])("%s -> %s", (input, expected) => {
+		expect(resolveChatSearchFilterAlias(input)).toBe(expected);
 	});
 });
 

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/searchQuery.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/searchQuery.test.ts
@@ -1,4 +1,6 @@
+import { describe, expect, it } from "vitest";
 import {
+	CHAT_SEARCH_FILTER_KEYS,
 	formatChatSearchFilterToken,
 	looksLikeChatDiffURL,
 	normalizeChatDiffURLValue,
@@ -80,6 +82,23 @@ describe("normalizeChatSearchInput", () => {
 		).toBe('diff_url:"https://gitlab.com/foo/bar/-/merge_requests/9"');
 	});
 
+	it("routes a scheme-less URL with a port into a diff_url filter", () => {
+		// The token's first `:` belongs to the host:port, so the splitter sees
+		// a key of `gitlab.com`. The normalizer must still recognize the whole
+		// token as a URL.
+		expect(
+			normalizeChatSearchInput("gitlab.com:8080/foo/bar/-/merge_requests/9"),
+		).toBe('diff_url:"https://gitlab.com:8080/foo/bar/-/merge_requests/9"');
+	});
+
+	it("routes a quote-wrapped URL into a diff_url filter", () => {
+		// Pasting a URL from JSON, a CI log, or Slack often wraps it in
+		// quotes; the result must still land on diff_url:.
+		expect(
+			normalizeChatSearchInput('"https://github.com/coder/coder/pull/1"'),
+		).toBe('diff_url:"https://github.com/coder/coder/pull/1"');
+	});
+
 	it("routes a scheme-less URL into a diff_url filter with https://", () => {
 		expect(normalizeChatSearchInput("github.com/coder/coder/pull/25391")).toBe(
 			'diff_url:"https://github.com/coder/coder/pull/25391"',
@@ -137,6 +156,14 @@ describe("normalizeChatSearchInput", () => {
 		).toBe('diff_url:"https://github.com/coder/coder/pull/1"');
 		expect(normalizeChatSearchInput("prstatus:open")).toBe("pr_status:open");
 		expect(normalizeChatSearchInput("pr-status:open")).toBe("pr_status:open");
+	});
+});
+
+describe("CHAT_SEARCH_FILTER_KEYS", () => {
+	it("exposes the recognized filter keys", () => {
+		expect(new Set(CHAT_SEARCH_FILTER_KEYS)).toEqual(
+			new Set(["archived", "diff_url", "has_unread", "pr_status"]),
+		);
 	});
 });
 

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/searchQuery.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/searchQuery.test.ts
@@ -157,6 +157,18 @@ describe("normalizeChatSearchInput", () => {
 		expect(normalizeChatSearchInput("prstatus:open")).toBe("pr_status:open");
 		expect(normalizeChatSearchInput("pr-status:open")).toBe("pr_status:open");
 	});
+
+	it("deduplicates repeated non-title filters first-wins", () => {
+		// The backend rejects a parameter that appears more than once, so the
+		// later token is dropped instead of producing a query the API will
+		// reject.
+		expect(normalizeChatSearchInput("has_unread:true has_unread:false")).toBe(
+			"has_unread:true",
+		);
+		expect(normalizeChatSearchInput("archived:true archived:false")).toBe(
+			"archived:true",
+		);
+	});
 });
 
 describe("CHAT_SEARCH_FILTER_KEYS", () => {
@@ -197,6 +209,10 @@ describe("looksLikeChatDiffURL", () => {
 		["1.2.3", false],
 		["", false],
 		["title:foo", false],
+		// Short title text that ends in a TLD-like suffix followed by a single
+		// slug should not be misread as a URL.
+		["fix.lint/issue", false],
+		["v2.api/endpoints", false],
 	])("%s -> %s", (input, expected) => {
 		expect(looksLikeChatDiffURL(input)).toBe(expected);
 	});

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/searchQuery.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/searchQuery.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
-import { normalizeChatSearchInput } from "./searchQuery";
+import {
+	formatChatSearchFilterToken,
+	looksLikeChatDiffURL,
+	normalizeChatDiffURLValue,
+	normalizeChatSearchInput,
+} from "./searchQuery";
 
 describe("normalizeChatSearchInput", () => {
 	it("returns undefined for empty input", () => {
@@ -23,7 +27,7 @@ describe("normalizeChatSearchInput", () => {
 	});
 
 	it("converts bare search text into a title filter", () => {
-		expect(normalizeChatSearchInput("Fix")).toBe('title:"Fix"');
+		expect(normalizeChatSearchInput("Fix")).toBe("title:Fix");
 		expect(normalizeChatSearchInput("fix auth middleware")).toBe(
 			'title:"fix auth middleware"',
 		);
@@ -38,7 +42,7 @@ describe("normalizeChatSearchInput", () => {
 			'archived:true title:"fix:lint"',
 		);
 		expect(normalizeChatSearchInput("fix has_unread:true auth")).toBe(
-			'has_unread:true title:"fix auth"',
+			'title:"fix auth" has_unread:true',
 		);
 		expect(
 			normalizeChatSearchInput('archived:true title:"chat title" fix'),
@@ -64,5 +68,144 @@ describe("normalizeChatSearchInput", () => {
 		// `title:` is not a well-formed key:value pair, so it should be searched
 		// for as a literal title substring.
 		expect(normalizeChatSearchInput("title:")).toBe('title:"title:"');
+	});
+
+	it("routes a bare HTTPS URL into a diff_url filter", () => {
+		expect(
+			normalizeChatSearchInput("https://github.com/coder/coder/pull/25391"),
+		).toBe('diff_url:"https://github.com/coder/coder/pull/25391"');
+		expect(
+			normalizeChatSearchInput("https://gitlab.com/foo/bar/-/merge_requests/9"),
+		).toBe('diff_url:"https://gitlab.com/foo/bar/-/merge_requests/9"');
+	});
+
+	it("routes a scheme-less URL into a diff_url filter with https://", () => {
+		expect(normalizeChatSearchInput("github.com/coder/coder/pull/25391")).toBe(
+			'diff_url:"https://github.com/coder/coder/pull/25391"',
+		);
+	});
+
+	it("does not mistake plain title text for a URL", () => {
+		expect(normalizeChatSearchInput("coder.com")).toBe("title:coder.com");
+		expect(normalizeChatSearchInput("1.2.3")).toBe("title:1.2.3");
+		expect(normalizeChatSearchInput("coder/coder")).toBe("title:coder/coder");
+	});
+
+	it("quotes diff_url values that contain colons", () => {
+		// The original bug: a `diff_url:` filter pill with a URL value lost its
+		// quotes and produced `diff_url:https://...`, which the backend
+		// rejected with a "can only contain 1 ':'" error.
+		expect(
+			normalizeChatSearchInput(
+				"diff_url:https://github.com/coder/coder/pull/1",
+			),
+		).toBe('diff_url:"https://github.com/coder/coder/pull/1"');
+	});
+
+	it("auto-prepends https:// to diff_url values missing a scheme", () => {
+		expect(
+			normalizeChatSearchInput("diff_url:github.com/coder/coder/pull/1"),
+		).toBe('diff_url:"https://github.com/coder/coder/pull/1"');
+	});
+
+	it("treats a second URL after a diff_url as title text", () => {
+		expect(
+			normalizeChatSearchInput(
+				"https://example.com/a/1 https://example.com/b/2",
+			),
+		).toBe(
+			'diff_url:"https://example.com/a/1" title:"https://example.com/b/2"',
+		);
+	});
+
+	it("combines bare URL with other filters", () => {
+		expect(
+			normalizeChatSearchInput(
+				"archived:true https://github.com/coder/coder/pull/1",
+			),
+		).toBe('archived:true diff_url:"https://github.com/coder/coder/pull/1"');
+	});
+});
+
+describe("looksLikeChatDiffURL", () => {
+	it.each([
+		["https://github.com/coder/coder/pull/1", true],
+		["http://example.com/foo", true],
+		["github.com/coder/coder/pull/1", true],
+		["gitlab.com:8080/foo/bar/-/merge_requests/9", true],
+		["plain text", false],
+		["coder/coder", false],
+		["coder.com", false],
+		["1.2.3", false],
+		["", false],
+		["title:foo", false],
+	])("%s -> %s", (input, expected) => {
+		expect(looksLikeChatDiffURL(input)).toBe(expected);
+	});
+});
+
+describe("normalizeChatDiffURLValue", () => {
+	it("returns http(s) URLs unchanged", () => {
+		expect(
+			normalizeChatDiffURLValue("https://github.com/coder/coder/pull/1"),
+		).toBe("https://github.com/coder/coder/pull/1");
+		expect(normalizeChatDiffURLValue("http://example.com/foo")).toBe(
+			"http://example.com/foo",
+		);
+	});
+
+	it("returns non-http schemed URLs unchanged so the backend can reject them", () => {
+		expect(normalizeChatDiffURLValue("ftp://example.com/x")).toBe(
+			"ftp://example.com/x",
+		);
+	});
+
+	it("prepends https:// to scheme-less host/path values", () => {
+		expect(normalizeChatDiffURLValue("github.com/coder/coder/pull/1")).toBe(
+			"https://github.com/coder/coder/pull/1",
+		);
+	});
+
+	it("leaves non-URL values alone", () => {
+		expect(normalizeChatDiffURLValue("plain")).toBe("plain");
+		expect(normalizeChatDiffURLValue("")).toBe("");
+	});
+});
+
+describe("formatChatSearchFilterToken", () => {
+	it("does not quote simple values", () => {
+		expect(formatChatSearchFilterToken("has_unread", "true")).toBe(
+			"has_unread:true",
+		);
+		expect(formatChatSearchFilterToken("pr_status", "open,merged")).toBe(
+			"pr_status:open,merged",
+		);
+	});
+
+	it("quotes values that contain colons", () => {
+		expect(
+			formatChatSearchFilterToken(
+				"diff_url",
+				"https://github.com/coder/coder/pull/1",
+			),
+		).toBe('diff_url:"https://github.com/coder/coder/pull/1"');
+	});
+
+	it("quotes values that contain whitespace", () => {
+		expect(formatChatSearchFilterToken("title", "chat title")).toBe(
+			'title:"chat title"',
+		);
+	});
+
+	it("strips internal quotes before wrapping", () => {
+		expect(formatChatSearchFilterToken("title", 'a "b" c')).toBe(
+			'title:"a b c"',
+		);
+	});
+
+	it("auto-prepends https:// for scheme-less diff_url values", () => {
+		expect(
+			formatChatSearchFilterToken("diff_url", "github.com/coder/coder/pull/1"),
+		).toBe('diff_url:"https://github.com/coder/coder/pull/1"');
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/searchQuery.ts
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/searchQuery.ts
@@ -6,15 +6,28 @@ const sanitizeChatSearchValue = (value: string): string => {
 	return value.replaceAll('"', "");
 };
 
-// Filter keys that may pass through to the backend unchanged. `title` is not
-// listed here because bare text and `title:` filters are merged into a single
-// title filter; see the title-handling branch in normalizeChatSearchInput.
-const passthroughChatSearchFilterKeys = new Set([
+// Strips surrounding double quotes so URL detection and value normalization
+// stay resilient to inputs pasted from JSON, CI logs, or Slack code blocks.
+const stripSurroundingQuotes = (value: string): string =>
+	value.replace(/^"+|"+$/g, "");
+
+/**
+ * Filter keys the chat search backend accepts as `key:value` pairs (besides
+ * `title`, which has its own merging logic). The dialog's filter pill list
+ * is derived from this so the two stay in sync.
+ */
+export const CHAT_SEARCH_FILTER_KEYS = [
 	"archived",
 	"diff_url",
 	"has_unread",
 	"pr_status",
-]);
+] as const;
+
+export type ChatSearchFilterKey = (typeof CHAT_SEARCH_FILTER_KEYS)[number];
+
+const passthroughChatSearchFilterKeys = new Set<string>(
+	CHAT_SEARCH_FILTER_KEYS,
+);
 
 // Common close-typo or shorthand spellings users reach for, mapped to the
 // canonical backend keys. Resolving aliases early means a user typing
@@ -53,7 +66,7 @@ const ANY_SCHEME_PATTERN = /^[a-z][a-z0-9+.-]*:\/\//i;
  * "fix lint" are never mistaken for URLs.
  */
 export const looksLikeChatDiffURL = (value: string): boolean => {
-	const trimmed = value.trim();
+	const trimmed = stripSurroundingQuotes(value.trim());
 	if (trimmed === "") {
 		return false;
 	}
@@ -71,7 +84,7 @@ export const looksLikeChatDiffURL = (value: string): boolean => {
  * its usual validation error.
  */
 export const normalizeChatDiffURLValue = (value: string): string => {
-	const trimmed = value.trim();
+	const trimmed = stripSurroundingQuotes(value.trim());
 	if (trimmed === "") {
 		return trimmed;
 	}
@@ -103,7 +116,7 @@ export const formatChatSearchFilterToken = (
 	if (key === "diff_url") {
 		value = normalizeChatDiffURLValue(value);
 	}
-	if (/[\s:"]/.test(value)) {
+	if (/[\s:]/.test(value)) {
 		return `${key}:"${value}"`;
 	}
 	return `${key}:${value}`;
@@ -191,6 +204,9 @@ const TITLE_PLACEHOLDER = "\u0000__TITLE__\u0000";
  *   - Bare tokens that look like HTTP(S) URLs are routed to `diff_url:` so a
  *     pasted diff link finds the matching chat instead of running an
  *     always-empty title search on the URL string.
+ *   - Filter keys are resolved through {@link resolveChatSearchFilterAlias}
+ *     so common aliases and near-miss typos land on the canonical backend
+ *     key.
  *   - Recognized `key:value` filters are re-serialized through
  *     {@link formatChatSearchFilterToken} so values containing `:` are quoted
  *     and `diff_url` values without a scheme get `https://` prepended.
@@ -256,15 +272,13 @@ export const normalizeChatSearchInput = (
 		}
 
 		if (!passthroughChatSearchFilterKeys.has(keyValuePair.key)) {
-			// Unknown key. Most often this is a bare URL like
+			// Unknown key. The most common shape is a bare URL like
 			// `https://github.com/...` whose first `:` makes the splitter
-			// think it has a key of `https`. Route those to `diff_url:`
-			// instead of letting them fall through to a title search that
-			// will never match.
-			if (
-				(keyValuePair.key === "http" || keyValuePair.key === "https") &&
-				looksLikeChatDiffURL(token)
-			) {
+			// think it has a key (`https`, `gitlab.com`, etc.). Route any
+			// token that still looks like a URL to `diff_url:` instead of
+			// letting it fall through to a title search that will never
+			// match.
+			if (looksLikeChatDiffURL(token)) {
 				collectDiffURL(token);
 				continue;
 			}

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/searchQuery.ts
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/searchQuery.ts
@@ -16,6 +16,30 @@ const passthroughChatSearchFilterKeys = new Set([
 	"pr_status",
 ]);
 
+// Common close-typo or shorthand spellings users reach for, mapped to the
+// canonical backend keys. Resolving aliases early means a user typing
+// `archive:true` or `unread:true` lands on the right filter instead of
+// falling through to an always-empty title search.
+const chatSearchFilterKeyAliases: Record<string, string> = {
+	archive: "archived",
+	unread: "has_unread",
+	diff: "diff_url",
+	diffurl: "diff_url",
+	"diff-url": "diff_url",
+	prstatus: "pr_status",
+	"pr-status": "pr_status",
+};
+
+/**
+ * Maps a user-typed filter key to its canonical backend equivalent. Unknown
+ * keys are returned lowercased so callers can still distinguish recognized
+ * filters from free-form text.
+ */
+export const resolveChatSearchFilterAlias = (key: string): string => {
+	const lower = key.toLowerCase();
+	return chatSearchFilterKeyAliases[lower] ?? lower;
+};
+
 // Matches a host that looks like a URL (e.g. `github.com`, `example.co.uk`).
 // Used to detect bare URL-like input so it can be routed to the `diff_url:`
 // filter instead of falling back to a useless title search on the URL string.
@@ -142,7 +166,9 @@ const getKeyValuePair = (
 	}
 
 	return {
-		key: token.slice(0, delimiterIndex).replaceAll('"', "").toLowerCase(),
+		key: resolveChatSearchFilterAlias(
+			token.slice(0, delimiterIndex).replaceAll('"', ""),
+		),
 		value: token.slice(delimiterIndex + 1).replace(/^"|"$/g, ""),
 	};
 };

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/searchQuery.ts
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/searchQuery.ts
@@ -56,7 +56,11 @@ export const resolveChatSearchFilterAlias = (key: string): string => {
 // Matches a host that looks like a URL (e.g. `github.com`, `example.co.uk`).
 // Used to detect bare URL-like input so it can be routed to the `diff_url:`
 // filter instead of falling back to a useless title search on the URL string.
-const HOST_WITH_PATH_PATTERN = /^[a-z0-9][a-z0-9.-]*\.[a-z]{2,}(:\d+)?\/\S*$/i;
+// Requires at least two path segments so values like `fix.lint/issue` or
+// `v2.api/endpoints` (a short word ending in a TLD-like suffix followed by a
+// single slug) stay treated as title text.
+const HOST_WITH_PATH_PATTERN =
+	/^[a-z0-9][a-z0-9.-]*\.[a-z]{2,}(:\d+)?\/[^\s/]+\/\S*$/i;
 const SCHEMED_URL_PATTERN = /^https?:\/\/\S+$/i;
 const ANY_SCHEME_PATTERN = /^[a-z][a-z0-9+.-]*:\/\//i;
 
@@ -101,7 +105,7 @@ export const normalizeChatDiffURLValue = (value: string): string => {
  * Serializes a single `key:value` filter token for the chat search backend.
  *
  * Values containing characters that the backend's parser treats specially
- * (`:`, `"`, or whitespace) are wrapped in double quotes after stripping any
+ * (`:` or whitespace) are wrapped in double quotes after stripping any
  * internal quotes. Without this, a value like `https://github.com/...` would
  * be split on its `:` and rejected with a "can only contain 1 ':'" error.
  *
@@ -210,6 +214,9 @@ const TITLE_PLACEHOLDER = "\u0000__TITLE__\u0000";
  *   - Recognized `key:value` filters are re-serialized through
  *     {@link formatChatSearchFilterToken} so values containing `:` are quoted
  *     and `diff_url` values without a scheme get `https://` prepended.
+ *   - Duplicate non-title filters (e.g. two `has_unread:` tokens) are
+ *     deduplicated first-wins because the backend rejects a parameter that
+ *     appears more than once.
  */
 export const normalizeChatSearchInput = (
 	rawInput: string,

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/searchQuery.ts
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/searchQuery.ts
@@ -16,6 +16,75 @@ const passthroughChatSearchFilterKeys = new Set([
 	"pr_status",
 ]);
 
+// Matches a host that looks like a URL (e.g. `github.com`, `example.co.uk`).
+// Used to detect bare URL-like input so it can be routed to the `diff_url:`
+// filter instead of falling back to a useless title search on the URL string.
+const HOST_WITH_PATH_PATTERN = /^[a-z0-9][a-z0-9.-]*\.[a-z]{2,}(:\d+)?\/\S*$/i;
+const SCHEMED_URL_PATTERN = /^https?:\/\/\S+$/i;
+const ANY_SCHEME_PATTERN = /^[a-z][a-z0-9+.-]*:\/\//i;
+
+/**
+ * Returns true when the value looks like an HTTP(S) URL or a scheme-less host
+ * with a path segment. Conservative on purpose so plain title searches like
+ * "fix lint" are never mistaken for URLs.
+ */
+export const looksLikeChatDiffURL = (value: string): boolean => {
+	const trimmed = value.trim();
+	if (trimmed === "") {
+		return false;
+	}
+	if (SCHEMED_URL_PATTERN.test(trimmed)) {
+		return true;
+	}
+	return HOST_WITH_PATH_PATTERN.test(trimmed);
+};
+
+/**
+ * Normalizes a diff URL value for the backend. The backend's `validateDiffURL`
+ * rejects values without an `http`/`https` scheme, so any scheme-less URL-like
+ * value gets `https://` prepended. Values that already carry a scheme
+ * (including non-http ones) are returned unchanged so the backend can produce
+ * its usual validation error.
+ */
+export const normalizeChatDiffURLValue = (value: string): string => {
+	const trimmed = value.trim();
+	if (trimmed === "") {
+		return trimmed;
+	}
+	if (ANY_SCHEME_PATTERN.test(trimmed)) {
+		return trimmed;
+	}
+	if (HOST_WITH_PATH_PATTERN.test(trimmed)) {
+		return `https://${trimmed}`;
+	}
+	return trimmed;
+};
+
+/**
+ * Serializes a single `key:value` filter token for the chat search backend.
+ *
+ * Values containing characters that the backend's parser treats specially
+ * (`:`, `"`, or whitespace) are wrapped in double quotes after stripping any
+ * internal quotes. Without this, a value like `https://github.com/...` would
+ * be split on its `:` and rejected with a "can only contain 1 ':'" error.
+ *
+ * For `diff_url`, scheme-less URL-like values get `https://` auto-prepended
+ * because the backend rejects URLs without a scheme.
+ */
+export const formatChatSearchFilterToken = (
+	key: string,
+	rawValue: string,
+): string => {
+	let value = sanitizeChatSearchValue(rawValue);
+	if (key === "diff_url") {
+		value = normalizeChatDiffURLValue(value);
+	}
+	if (/[\s:"]/.test(value)) {
+		return `${key}:"${value}"`;
+	}
+	return `${key}:${value}`;
+};
+
 const splitSearchInput = (input: string): string[] => {
 	const tokens: string[] = [];
 	let token = "";
@@ -78,12 +147,27 @@ const getKeyValuePair = (
 	};
 };
 
+// Sentinel placeholder so we can reserve the position of the merged title
+// filter in the output while still collecting title terms from the rest of
+// the input. The placeholder is replaced with the formatted `title:"..."`
+// token (or removed) at the end of normalization.
+const TITLE_PLACEHOLDER = "\u0000__TITLE__\u0000";
+
 /**
  * Normalizes raw search input into a query string the chat search API accepts.
  *
- * Bare text and `title:` filters are merged into a single `title:"..."`
- * filter (the backend rejects a parameter that appears more than once).
- * Recognized `key:value` filters pass through unchanged.
+ * Behaviors:
+ *   - Bare text and `title:` filters merge into a single `title:"..."` filter
+ *     because the backend rejects a parameter that appears more than once.
+ *     The merged title takes the position of the first title-like token so
+ *     callers that pass an already-well-formed query get a stable string
+ *     back.
+ *   - Bare tokens that look like HTTP(S) URLs are routed to `diff_url:` so a
+ *     pasted diff link finds the matching chat instead of running an
+ *     always-empty title search on the URL string.
+ *   - Recognized `key:value` filters are re-serialized through
+ *     {@link formatChatSearchFilterToken} so values containing `:` are quoted
+ *     and `diff_url` values without a scheme get `https://` prepended.
  */
 export const normalizeChatSearchInput = (
 	rawInput: string,
@@ -94,44 +178,105 @@ export const normalizeChatSearchInput = (
 	}
 
 	const tokens = splitSearchInput(trimmedInput);
-	const keyValuePairs: string[] = [];
+	const outputTokens: string[] = [];
+	const filterKeys = new Set<string>();
 	const titleTerms: string[] = [];
-	let hasBareTitleText = false;
+	let diffURLValue: string | undefined;
+	let diffURLIndex: number | undefined;
+
+	const reserveTitlePlaceholder = (): void => {
+		if (!outputTokens.includes(TITLE_PLACEHOLDER)) {
+			outputTokens.push(TITLE_PLACEHOLDER);
+		}
+	};
+
+	const collectTitleTerm = (value: string): void => {
+		const sanitized = sanitizeChatSearchValue(value);
+		if (sanitized === "") {
+			return;
+		}
+		titleTerms.push(sanitized);
+		reserveTitlePlaceholder();
+	};
+
+	const collectDiffURL = (value: string): void => {
+		// The backend rejects a repeated parameter, so only the first diff_url
+		// survives; later URL-like tokens fall back to title text.
+		if (diffURLValue !== undefined) {
+			collectTitleTerm(value);
+			return;
+		}
+		diffURLValue = value;
+		diffURLIndex = outputTokens.length;
+		outputTokens.push("");
+		filterKeys.add("diff_url");
+	};
 
 	for (const token of tokens) {
 		const keyValuePair = getKeyValuePair(token);
+
 		if (!keyValuePair) {
-			titleTerms.push(token);
-			hasBareTitleText = true;
+			if (looksLikeChatDiffURL(token)) {
+				collectDiffURL(token);
+				continue;
+			}
+			collectTitleTerm(token);
 			continue;
 		}
 
 		if (keyValuePair.key === "title") {
-			titleTerms.push(keyValuePair.value);
+			collectTitleTerm(keyValuePair.value);
 			continue;
 		}
 
 		if (!passthroughChatSearchFilterKeys.has(keyValuePair.key)) {
-			titleTerms.push(token);
-			hasBareTitleText = true;
+			// Unknown key. Most often this is a bare URL like
+			// `https://github.com/...` whose first `:` makes the splitter
+			// think it has a key of `https`. Route those to `diff_url:`
+			// instead of letting them fall through to a title search that
+			// will never match.
+			if (
+				(keyValuePair.key === "http" || keyValuePair.key === "https") &&
+				looksLikeChatDiffURL(token)
+			) {
+				collectDiffURL(token);
+				continue;
+			}
+			collectTitleTerm(token);
 			continue;
 		}
 
-		keyValuePairs.push(token);
+		if (keyValuePair.key === "diff_url") {
+			collectDiffURL(keyValuePair.value);
+			continue;
+		}
+
+		if (filterKeys.has(keyValuePair.key)) {
+			continue;
+		}
+		filterKeys.add(keyValuePair.key);
+		outputTokens.push(
+			formatChatSearchFilterToken(keyValuePair.key, keyValuePair.value),
+		);
 	}
 
-	// Multiple title values must be merged into a single title filter because
-	// the backend's query parser rejects the same key appearing more than once.
-	if (titleTerms.length > 1) {
-		hasBareTitleText = true;
+	if (diffURLValue !== undefined && diffURLIndex !== undefined) {
+		outputTokens[diffURLIndex] = formatChatSearchFilterToken(
+			"diff_url",
+			diffURLValue,
+		);
 	}
 
-	if (!hasBareTitleText) {
-		return trimmedInput;
-	}
+	const titleTerm = titleTerms.join(" ").trim();
+	const titleToken =
+		titleTerm === "" ? "" : formatChatSearchFilterToken("title", titleTerm);
 
-	return [
-		...keyValuePairs,
-		`title:"${sanitizeChatSearchValue(titleTerms.join(" "))}"`,
-	].join(" ");
+	const finalTokens = outputTokens
+		.map((token) => (token === TITLE_PLACEHOLDER ? titleToken : token))
+		.filter((token) => token !== "");
+
+	if (finalTokens.length === 0) {
+		return undefined;
+	}
+	return finalTokens.join(" ");
 };


### PR DESCRIPTION
The chat search dialog had three related bugs around diff URLs (CODAGT-556):

1. Pasting a diff URL into a `diff_url:` filter pill produced a backend error `query element ... can only contain 1 ':'`. `buildQuery` only quoted values containing spaces, so `diff_url:https://github.com/owner/repo/pull/123` was sent unquoted and the backend's `splitQueryParameterByDelimiter` split it on every `:`.
2. Removing `https` to dodge that error left a scheme-less URL the backend rejects in `validateDiffURL` with `must use http or https scheme`.
3. Long backend validation errors (which echo the offending query element) ran past the dialog's 560px max-width because `AlertTitle`/`AlertDescription` have no `break-words` and a URL has no spaces to wrap on.

The fix centralizes filter-token formatting in `searchQuery.ts`:

- `formatChatSearchFilterToken` quotes values containing whitespace, `:`, or `"` so a URL filter token round-trips through the backend parser cleanly.
- `normalizeChatDiffURLValue` auto-prepends `https://` to scheme-less host/path values, applied both at filter-pill commit time and inside the normalizer so the pasted URL keeps working even if the user removes the scheme.
- `looksLikeChatDiffURL` detects bare URL paste (e.g. `https://github.com/coder/coder/pull/1` typed directly into the input with no `diff_url:` pill) and routes it to `diff_url:` instead of falling through to an always-empty title search on the URL string.

`ChatSearchResults` adds `[overflow-wrap:anywhere]` to the error alert's title/description so a long URL inside a backend error wraps inside the dialog instead of overflowing it.

Refs https://linear.app/codercom/issue/CODAGT-556

<details>
<summary>Test coverage</summary>

- `searchQuery.test.ts` gains 17 new cases covering URL detection, scheme-less normalization, quoting, duplicate diff_url handling, and the `looksLikeChatDiffURL`/`normalizeChatDiffURLValue`/`formatChatSearchFilterToken` helpers individually.
- `ChatSearchDialog.stories.tsx` gains three regression stories (`ErrorStateWithLongURL`, `DiffURLFilterPill`, `BareURLAutoRoutesToDiffURL`) that exercise the failing flows end to end through the dialog.

Local `make pre-commit` (gen, lint, build) and the storybook + vitest suites for these files all pass.

</details>

> Generated with [Coder Agents](https://coder.com/agents)