### PR TITLE
docs(devcontainers): document Envbuilder lifecycle limitations and workarounds

### DIFF
--- a/docs/admin/integrations/devcontainers/envbuilder/add-envbuilder.md
+++ b/docs/admin/integrations/devcontainers/envbuilder/add-envbuilder.md
@@ -133,12 +133,64 @@ Your template can prompt the user for a repo URL with
 
 ## Dev container lifecycle scripts
 
-The `onCreateCommand`, `updateContentCommand`, `postCreateCommand`, and
-`postStartCommand` lifecycle scripts are run each time the container is started.
-This could be used, for example, to fetch or update project dependencies before
-a user begins using the workspace.
+Envbuilder supports the following lifecycle scripts: `onCreateCommand`,
+`updateContentCommand`, `postCreateCommand`, and `postStartCommand`. These can
+be used to fetch or update project dependencies before a user begins using the
+workspace.
 
 Lifecycle scripts are managed by project developers.
+
+> [!NOTE]
+> `onCreateCommand` runs only on the first start.
+> `updateContentCommand` and `postCreateCommand` run each time the container
+> is started. `postStartCommand` runs each time the container starts, but
+> may be deferred to the init command depending on configuration.
+
+### Unsupported lifecycle commands
+
+Envbuilder does not support the following lifecycle commands:
+
+- `initializeCommand`
+- `postAttachCommand`
+- `waitFor`
+
+For a complete list of supported and unsupported dev container features, see the
+[Envbuilder dev container spec support](https://github.com/coder/envbuilder/blob/main/docs/devcontainer-spec-support.md)
+documentation.
+
+### Custom Dockerfile ENTRYPOINT
+
+Envbuilder replaces the image `ENTRYPOINT` with its own binary during the build
+process. Custom `ENTRYPOINT` instructions in your Dockerfile will not execute.
+To run initialization commands, use lifecycle scripts such as
+`postCreateCommand` or `postStartCommand` instead.
+
+### SSH and Git credentials in lifecycle scripts
+
+Envbuilder runs lifecycle scripts during the container build phase, before the
+Coder agent starts. Because Coder-managed SSH keys and Git credentials are
+injected by the agent, they are not available during lifecycle script execution.
+
+This means operations that require SSH authentication, such as cloning private
+git submodules, will fail if placed in `postCreateCommand` or other lifecycle
+scripts.
+
+To run commands that depend on Coder-managed SSH or Git credentials, use the
+`coder_agent` startup script in your template instead:
+
+```hcl
+resource "coder_agent" "main" {
+  # ...
+  startup_script = <<-EOT
+    set -e
+    cd /workspaces/my-repo
+    git submodule update --init --recursive
+  EOT
+}
+```
+
+The startup script runs after the agent starts and credentials are available.
+It should be idempotent, as it runs each time the workspace starts.
 
 ## Next steps
 

--- a/docs/admin/integrations/devcontainers/envbuilder/envbuilder-releases-known-issues.md
+++ b/docs/admin/integrations/devcontainers/envbuilder/envbuilder-releases-known-issues.md
@@ -20,6 +20,19 @@ information and to submit feature requests or bug reports.
 
 ## Known issues
 
+Key limitations of Envbuilder include:
+
+- **Custom `ENTRYPOINT`**: Envbuilder replaces the image entrypoint with its
+  own binary. Custom `ENTRYPOINT` instructions in Dockerfiles are not executed.
+- **`postAttachCommand`**: Not supported. Use `postStartCommand` or the Coder
+  agent startup script instead.
+- **`initializeCommand`**: Not supported.
+- **SSH/Git credentials in lifecycle scripts**: Lifecycle scripts run before the
+  Coder agent starts, so Coder-managed SSH keys and Git credentials are not
+  available. Use the agent startup script for operations that require
+  authentication. See
+  [SSH and Git credentials in lifecycle scripts](./add-envbuilder.md#ssh-and-git-credentials-in-lifecycle-scripts).
+
 Visit the
 [Envbuilder repository](https://github.com/coder/envbuilder/blob/main/docs/devcontainer-spec-support.md)
 for a full list of supported features and known issues.

--- a/docs/user-guides/devcontainers/troubleshooting-dev-containers.md
+++ b/docs/user-guides/devcontainers/troubleshooting-dev-containers.md
@@ -106,6 +106,34 @@ If your dev container takes a long time to start:
    container start. Commands in `postCreateCommand` run once per build, so
    they execute again after each rebuild.
 
+## Git submodules or private repos failing in lifecycle scripts
+
+If `git submodule update --init` or other SSH-dependent commands fail when
+placed in `postCreateCommand` or `postStartCommand`:
+
+- **Cause**: Dev container lifecycle scripts run before the Coder agent starts.
+  Coder-managed SSH keys and Git credentials are not yet available during
+  lifecycle script execution.
+- **Fix**: Move SSH-dependent commands to the `coder_agent` startup script in
+  your template. The startup script runs after the agent initializes and
+  credentials become available. Ask your template administrator to add the
+  commands to the agent's `startup_script` block.
+
+For Envbuilder-based templates, see
+[SSH and Git credentials in lifecycle scripts](../../admin/integrations/devcontainers/envbuilder/add-envbuilder.md#ssh-and-git-credentials-in-lifecycle-scripts)
+for details and a template example.
+
+## Custom ENTRYPOINT not executing (Envbuilder)
+
+If your custom Dockerfile `ENTRYPOINT` does not run in an Envbuilder-based
+workspace:
+
+- **Cause**: Envbuilder replaces the image entrypoint with its own binary
+  during the build process.
+- **Fix**: Use dev container lifecycle scripts such as `postCreateCommand` or
+  `postStartCommand` for initialization logic instead. For commands that need
+  Coder-managed credentials, use the agent startup script as described above.
+
 ## Getting more help
 
 If you continue to experience issues:


### PR DESCRIPTION
Fixes #26071

Documents known Envbuilder limitations that cause confusion when users try to automate setup tasks in dev container lifecycle scripts:

- **Custom Dockerfile ENTRYPOINT**: Envbuilder replaces the image entrypoint with its own binary, so custom `ENTRYPOINT` instructions do not execute.
- **Unsupported lifecycle commands**: `postAttachCommand`, `initializeCommand`, and `waitFor` are not supported by Envbuilder.
- **SSH/Git credentials unavailable during lifecycle scripts**: Lifecycle scripts run before the Coder agent starts, so Coder-managed SSH keys and Git credentials are not yet available. This causes operations like `git submodule update --init --recursive` to fail.

Adds the recommended workaround: use the `coder_agent` startup script for operations that require Coder-managed credentials, with a Terraform example.

### Changes

- `docs/admin/integrations/devcontainers/envbuilder/add-envbuilder.md`: Expanded the lifecycle scripts section with supported/unsupported commands, ENTRYPOINT behavior, and SSH credentials guidance with a template code example.
- `docs/admin/integrations/devcontainers/envbuilder/envbuilder-releases-known-issues.md`: Added key limitations summary before the link to the full Envbuilder spec support matrix.
- `docs/user-guides/devcontainers/troubleshooting-dev-containers.md`: Added troubleshooting entries for git submodule/SSH failures in lifecycle scripts and custom ENTRYPOINT not executing.

> Generated by Coder Agents on behalf of @david-fraley