### PR TITLE
feat: send connection logs from `agentfake` agents

### DIFF
--- a/enterprise/cli/exp_scaletest_agentfake.go
+++ b/enterprise/cli/exp_scaletest_agentfake.go
@@ -181,7 +181,7 @@ func (r *RootCmd) scaletestAgentFake() *serpent.Command {
 		{
 			Flag:        "connection-report-duration",
 			Env:         "CODER_SCALETEST_AGENTFAKE_CONNECTION_REPORT_DURATION",
-			Description: "Synthetic SSH session length per fake agent. Ignored when --connection-report-interval is zero.",
+			Description: "Synthetic SSH session length per fake agent. Zero disables connection reporting.",
 			Default:     "5s",
 			Value:       serpent.DurationOf(&connReportDuration),
 		},

--- a/enterprise/cli/exp_scaletest_agentfake.go
+++ b/enterprise/cli/exp_scaletest_agentfake.go
@@ -4,6 +4,7 @@ package cli
 
 import (
 	"os/signal"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -40,6 +41,8 @@ func (r *RootCmd) scaletestAgentFake() *serpent.Command {
 		expectedAgentsTolerance int64
 		postgresURL             string
 		postgresAuth            string
+		connReportInterval      time.Duration
+		connReportDuration      time.Duration
 	)
 
 	cmd := &serpent.Command{
@@ -117,11 +120,13 @@ func (r *RootCmd) scaletestAgentFake() *serpent.Command {
 			metrics := agentfake.NewMetrics(prometheus.DefaultRegisterer)
 
 			mgr := agentfake.NewManager(logger, client.URL, client, db, agentfake.ManagerOptions{
-				Template:                template,
-				Owner:                   owner,
-				Metrics:                 metrics,
-				ExpectedAgents:          expectedAgents,
-				ExpectedAgentsTolerance: expectedAgentsTolerance,
+				Template:                 template,
+				Owner:                    owner,
+				Metrics:                  metrics,
+				ExpectedAgents:           expectedAgents,
+				ExpectedAgentsTolerance:  expectedAgentsTolerance,
+				ConnectionReportInterval: connReportInterval,
+				ConnectionReportDuration: connReportDuration,
 			})
 			defer mgr.Close()
 
@@ -165,6 +170,20 @@ func (r *RootCmd) scaletestAgentFake() *serpent.Command {
 			Default:     "0",
 			Description: "Acceptable variance around --expected-agents. Ignored when --expected-agents is 0.",
 			Value:       serpent.Int64Of(&expectedAgentsTolerance),
+		},
+		{
+			Flag:        "connection-report-interval",
+			Env:         "CODER_SCALETEST_AGENTFAKE_CONNECTION_REPORT_INTERVAL",
+			Description: "Idle gap between synthetic SSH connect events per fake agent. Zero disables connection reporting.",
+			Default:     "30s",
+			Value:       serpent.DurationOf(&connReportInterval),
+		},
+		{
+			Flag:        "connection-report-duration",
+			Env:         "CODER_SCALETEST_AGENTFAKE_CONNECTION_REPORT_DURATION",
+			Description: "Synthetic SSH session length per fake agent. Ignored when --connection-report-interval is zero.",
+			Default:     "5s",
+			Value:       serpent.DurationOf(&connReportDuration),
 		},
 		{
 			Flag:        "postgres-url",

--- a/enterprise/scaletest/agentfake/agent.go
+++ b/enterprise/scaletest/agentfake/agent.go
@@ -365,6 +365,8 @@ func (a *Agent) runConnectionReports(ctx context.Context, rpc proto.DRPCAgentCli
 		now := a.clock.Now()
 		switch {
 		case openID != uuid.Nil && !now.Before(closeAt):
+			// A failed DISCONNECT send is non-fatal for scaletesting, so we
+			// ignore the result and always reset the session.
 			a.sendConnection(ctx, rpc, openID, proto.Connection_DISCONNECT, now)
 			openID = uuid.Nil
 			nextOpen = now.Add(a.connReportInterval)
@@ -390,6 +392,7 @@ func (a *Agent) sendConnection(ctx context.Context, rpc proto.DRPCAgentClient29,
 			Action:    action,
 			Type:      proto.Connection_SSH,
 			Timestamp: timestamppb.New(now),
+			Ip:        "127.0.0.1",
 		},
 	})
 	if err != nil && ctx.Err() == nil {

--- a/enterprise/scaletest/agentfake/agent.go
+++ b/enterprise/scaletest/agentfake/agent.go
@@ -361,9 +361,11 @@ func (a *Agent) runConnectionReports(ctx context.Context, rpc proto.DRPCAgentCli
 
 	// Wake often enough to honor both interval and duration. The branches
 	// inside the tick func gate which action (if any) fires on each tick.
+	// A zero duration (instant disconnect) is excluded from the min so the
+	// tick period stays the positive interval rather than collapsing to 0.
 	tick := a.connReportInterval
-	if a.connReportDuration > 0 && a.connReportDuration < tick {
-		tick = a.connReportDuration
+	if a.connReportDuration > 0 {
+		tick = min(tick, a.connReportDuration)
 	}
 
 	var (

--- a/enterprise/scaletest/agentfake/agent.go
+++ b/enterprise/scaletest/agentfake/agent.go
@@ -62,6 +62,12 @@ type Agent struct {
 	firstConnect   chan<- time.Duration
 	firstConnected atomic.Bool
 
+	// connReportInterval is the idle gap between synthetic SSH sessions.
+	// Zero disables connection reporting. connReportDuration is the length
+	// of each synthetic SSH session.
+	connReportInterval time.Duration
+	connReportDuration time.Duration
+
 	start time.Time
 
 	cancel context.CancelFunc
@@ -105,6 +111,16 @@ func WithMetrics(m *Metrics) Option {
 func WithFirstConnect(ch chan<- time.Duration) Option {
 	return func(a *Agent) {
 		a.firstConnect = ch
+	}
+}
+
+// WithConnectionReports enables periodic synthetic SSH connection reporting.
+// interval is the idle gap between sessions; a zero interval disables
+// reporting. duration is the length of each synthetic SSH session.
+func WithConnectionReports(interval, duration time.Duration) Option {
+	return func(a *Agent) {
+		a.connReportInterval = interval
+		a.connReportDuration = duration
 	}
 }
 
@@ -225,6 +241,11 @@ func (a *Agent) connectAndServe(ctx context.Context, client rpcDialer) error {
 		go a.runMetadata(connCtx, rpc, workspaceID, descs)
 	}
 
+	// Emit synthetic SSH connection events for the lifetime of this dRPC
+	// connection. Bound to connCtx so the goroutine exits on reconnect,
+	// matching runMetadata.
+	go a.runConnectionReports(connCtx, rpc)
+
 	select {
 	case <-ctx.Done():
 		return nil
@@ -324,6 +345,70 @@ func (a *Agent) runMetadata(ctx context.Context, rpc proto.DRPCAgentClient29, wo
 		}
 		return nil
 	}, "agentfake", "runMetadata").Wait()
+}
+
+// runConnectionReports emits a periodic synthetic SSH session (CONNECT then
+// DISCONNECT) via ReportConnection. Each session uses one connection_id so
+// coderd pairs the two halves onto a single connection_log row.
+//
+// The TickerFunc wakes every min(interval, duration) and the switch gates
+// which action (if any) fires on each tick; the goroutine is scoped to the
+// connection's ctx and exits cleanly on disconnect or shutdown.
+func (a *Agent) runConnectionReports(ctx context.Context, rpc proto.DRPCAgentClient29) {
+	if a.connReportInterval <= 0 {
+		return
+	}
+
+	// Wake often enough to honor both interval and duration. The branches
+	// inside the tick func gate which action (if any) fires on each tick.
+	tick := a.connReportInterval
+	if a.connReportDuration > 0 && a.connReportDuration < tick {
+		tick = a.connReportDuration
+	}
+
+	var (
+		openID   uuid.UUID
+		closeAt  time.Time
+		nextOpen = a.clock.Now().Add(a.connReportInterval)
+	)
+	_ = a.clock.TickerFunc(ctx, tick, func() error {
+		now := a.clock.Now()
+		switch {
+		case openID != uuid.Nil && !now.Before(closeAt):
+			a.sendConnection(ctx, rpc, openID, proto.Connection_DISCONNECT, now)
+			openID = uuid.Nil
+			nextOpen = now.Add(a.connReportInterval)
+		case openID == uuid.Nil && !now.Before(nextOpen):
+			id := uuid.New()
+			closeAt = now.Add(a.connReportDuration)
+			if a.sendConnection(ctx, rpc, id, proto.Connection_CONNECT, now) {
+				openID = id
+			} else {
+				// CONNECT failed; try again next interval. No dangling
+				// openID means we won't desync.
+				nextOpen = now.Add(a.connReportInterval)
+			}
+		}
+		return nil
+	}, "agentfake", "connectionReports").Wait()
+}
+
+func (a *Agent) sendConnection(ctx context.Context, rpc proto.DRPCAgentClient29, id uuid.UUID, action proto.Connection_Action, now time.Time) bool {
+	_, err := rpc.ReportConnection(ctx, &proto.ReportConnectionRequest{
+		Connection: &proto.Connection{
+			Id:        id[:],
+			Action:    action,
+			Type:      proto.Connection_SSH,
+			Timestamp: timestamppb.New(now),
+		},
+	})
+	if err != nil && ctx.Err() == nil {
+		a.logger.Debug(ctx, "report connection failed",
+			slog.F("action", action.String()),
+			slog.Error(err))
+		return false
+	}
+	return true
 }
 
 // Close stops the agent. Safe to call multiple times.

--- a/enterprise/scaletest/agentfake/agent.go
+++ b/enterprise/scaletest/agentfake/agent.go
@@ -62,7 +62,8 @@ type Agent struct {
 	firstConnect   chan<- time.Duration
 	firstConnected atomic.Bool
 
-	// Zero connReportInterval disables synthetic SSH connection reporting.
+	// A zero connReportInterval or connReportDuration disables synthetic SSH
+	// connection reporting.
 	connReportInterval time.Duration
 	connReportDuration time.Duration
 
@@ -113,7 +114,7 @@ func WithFirstConnect(ch chan<- time.Duration) Option {
 }
 
 // WithConnectionReports enables periodic synthetic SSH connection reporting.
-// A zero interval disables reporting.
+// A zero interval or duration disables reporting.
 func WithConnectionReports(interval, duration time.Duration) Option {
 	return func(a *Agent) {
 		a.connReportInterval = interval
@@ -346,16 +347,14 @@ func (a *Agent) runMetadata(ctx context.Context, rpc proto.DRPCAgentClient29, wo
 // DISCONNECT) via ReportConnection. Each session reuses one connection_id so
 // coderd pairs the two halves onto a single connection_log row.
 func (a *Agent) runConnectionReports(ctx context.Context, rpc proto.DRPCAgentClient29) {
-	if a.connReportInterval <= 0 {
+	// A zero-length session is meaningless, so a zero interval or duration
+	// disables reporting entirely.
+	if a.connReportInterval <= 0 || a.connReportDuration <= 0 {
 		return
 	}
 
-	// Tick at the smaller of the two so neither boundary is overshot. A zero
-	// duration is excluded so the tick period can't collapse to 0.
-	tick := a.connReportInterval
-	if a.connReportDuration > 0 {
-		tick = min(tick, a.connReportDuration)
-	}
+	// Tick at the smaller of the two so neither boundary is overshot.
+	tick := min(a.connReportInterval, a.connReportDuration)
 
 	var (
 		openID   uuid.UUID

--- a/enterprise/scaletest/agentfake/agent.go
+++ b/enterprise/scaletest/agentfake/agent.go
@@ -62,9 +62,7 @@ type Agent struct {
 	firstConnect   chan<- time.Duration
 	firstConnected atomic.Bool
 
-	// connReportInterval is the idle gap between synthetic SSH sessions.
-	// Zero disables connection reporting. connReportDuration is the length
-	// of each synthetic SSH session.
+	// Zero connReportInterval disables synthetic SSH connection reporting.
 	connReportInterval time.Duration
 	connReportDuration time.Duration
 
@@ -115,8 +113,7 @@ func WithFirstConnect(ch chan<- time.Duration) Option {
 }
 
 // WithConnectionReports enables periodic synthetic SSH connection reporting.
-// interval is the idle gap between sessions; a zero interval disables
-// reporting. duration is the length of each synthetic SSH session.
+// A zero interval disables reporting.
 func WithConnectionReports(interval, duration time.Duration) Option {
 	return func(a *Agent) {
 		a.connReportInterval = interval
@@ -241,9 +238,7 @@ func (a *Agent) connectAndServe(ctx context.Context, client rpcDialer) error {
 		go a.runMetadata(connCtx, rpc, workspaceID, descs)
 	}
 
-	// Emit synthetic SSH connection events for the lifetime of this dRPC
-	// connection. Bound to connCtx so the goroutine exits on reconnect,
-	// matching runMetadata.
+	// Bound to connCtx so the goroutine exits on reconnect, like runMetadata.
 	go a.runConnectionReports(connCtx, rpc)
 
 	select {
@@ -347,22 +342,16 @@ func (a *Agent) runMetadata(ctx context.Context, rpc proto.DRPCAgentClient29, wo
 	}, "agentfake", "runMetadata").Wait()
 }
 
-// runConnectionReports emits a periodic synthetic SSH session (CONNECT then
-// DISCONNECT) via ReportConnection. Each session uses one connection_id so
+// runConnectionReports emits periodic synthetic SSH sessions (CONNECT then
+// DISCONNECT) via ReportConnection. Each session reuses one connection_id so
 // coderd pairs the two halves onto a single connection_log row.
-//
-// The TickerFunc wakes every min(interval, duration) and the switch gates
-// which action (if any) fires on each tick; the goroutine is scoped to the
-// connection's ctx and exits cleanly on disconnect or shutdown.
 func (a *Agent) runConnectionReports(ctx context.Context, rpc proto.DRPCAgentClient29) {
 	if a.connReportInterval <= 0 {
 		return
 	}
 
-	// Wake often enough to honor both interval and duration. The branches
-	// inside the tick func gate which action (if any) fires on each tick.
-	// A zero duration (instant disconnect) is excluded from the min so the
-	// tick period stays the positive interval rather than collapsing to 0.
+	// Tick at the smaller of the two so neither boundary is overshot. A zero
+	// duration is excluded so the tick period can't collapse to 0.
 	tick := a.connReportInterval
 	if a.connReportDuration > 0 {
 		tick = min(tick, a.connReportDuration)
@@ -386,8 +375,8 @@ func (a *Agent) runConnectionReports(ctx context.Context, rpc proto.DRPCAgentCli
 			if a.sendConnection(ctx, rpc, id, proto.Connection_CONNECT, now) {
 				openID = id
 			} else {
-				// CONNECT failed; try again next interval. No dangling
-				// openID means we won't desync.
+				// Leave openID nil so a failed CONNECT retries next interval
+				// instead of desyncing the connect/disconnect pairing.
 				nextOpen = now.Add(a.connReportInterval)
 			}
 		}

--- a/enterprise/scaletest/agentfake/agent_test.go
+++ b/enterprise/scaletest/agentfake/agent_test.go
@@ -153,3 +153,147 @@ func TestAgent_SendsMetadata(t *testing.T) {
 		t.Fatalf("timed out waiting for Agent.Run to return: %v", ctx.Err())
 	}
 }
+
+// Assert that, when connection reporting is enabled, the fake agent emits a
+// repeating CONNECT/DISCONNECT SSH session via ReportConnection, with both
+// halves of a session sharing one connection id and successive sessions using
+// fresh ids. Driven against agent/agenttest.Client so the only quartz mock is
+// the agentfake clock backing the connectionReports ticker.
+func TestAgent_ReportsConnections(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitShort)
+
+	const (
+		interval = 30 * time.Second
+		duration = 5 * time.Second
+	)
+
+	mClock := quartz.NewMock(t)
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+
+	agentID := uuid.New()
+	manifest := agentsdk.Manifest{
+		AgentID:     agentID,
+		WorkspaceID: uuid.New(),
+	}
+	statsCh := make(chan *agentproto.Stats, 1)
+	coord := tailnet.NewCoordinator(logger)
+	t.Cleanup(func() { _ = coord.Close() })
+	dialer := agenttest.NewClient(t, logger, agentID, manifest, statsCh, coord)
+	t.Cleanup(dialer.Close)
+
+	a := agentfake.NewAgent(logger, nil, "",
+		agentfake.WithDialer(dialer),
+		agentfake.WithClock(mClock),
+		agentfake.WithConnectionReports(interval, duration),
+	)
+	t.Cleanup(a.Close)
+
+	// Trap the connectionReports TickerFunc registration so the goroutine
+	// is parked on the mock clock before we Advance; otherwise Advance
+	// could race goroutine startup and the first tick would be missed.
+	tickerTrap := mClock.Trap().TickerFunc("agentfake", "connectionReports")
+	defer tickerTrap.Close()
+
+	runCtx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+	runErr := make(chan error, 1)
+	go func() { runErr <- a.Run(runCtx) }()
+
+	tickerTrap.MustWait(ctx).Release(ctx)
+
+	// The ticker wakes every min(interval, duration) = 5s. Advance in 5s
+	// steps until the goroutine has emitted at least `want` reports.
+	advanceUntil := func(want int) {
+		t.Helper()
+		require.Eventually(t, func() bool {
+			mClock.Advance(duration).MustWait(ctx)
+			return len(dialer.GetConnectionReports()) >= want
+		}, testutil.WaitShort, testutil.IntervalFast,
+			"expected %d connection reports", want)
+	}
+
+	advanceUntil(1)
+	reports := dialer.GetConnectionReports()
+	require.GreaterOrEqual(t, len(reports), 1)
+	require.Equal(t, agentproto.Connection_SSH, reports[0].GetConnection().GetType())
+	require.Equal(t, agentproto.Connection_CONNECT, reports[0].GetConnection().GetAction())
+	firstID := reports[0].GetConnection().GetId()
+	require.NotEqual(t, uuid.Nil[:], firstID)
+
+	advanceUntil(2)
+	reports = dialer.GetConnectionReports()
+	require.Equal(t, agentproto.Connection_DISCONNECT, reports[1].GetConnection().GetAction())
+	require.Equal(t, firstID, reports[1].GetConnection().GetId())
+
+	advanceUntil(3)
+	reports = dialer.GetConnectionReports()
+	require.Equal(t, agentproto.Connection_CONNECT, reports[2].GetConnection().GetAction())
+	require.NotEqual(t, firstID, reports[2].GetConnection().GetId())
+
+	cancel()
+	select {
+	case err := <-runErr:
+		require.NoError(t, err, "Agent.Run returned unexpected error")
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for Agent.Run to return: %v", ctx.Err())
+	}
+}
+
+// Assert that a zero connection-report interval disables reporting entirely:
+// the goroutine registers no ticker and no ReportConnection calls are made.
+func TestAgent_ReportsConnections_Disabled(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitShort)
+
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+
+	agentID := uuid.New()
+	manifest := agentsdk.Manifest{
+		AgentID:     agentID,
+		WorkspaceID: uuid.New(),
+	}
+	statsCh := make(chan *agentproto.Stats, 1)
+	coord := tailnet.NewCoordinator(logger)
+	t.Cleanup(func() { _ = coord.Close() })
+	dialer := agenttest.NewClient(t, logger, agentID, manifest, statsCh, coord)
+	t.Cleanup(dialer.Close)
+
+	a := agentfake.NewAgent(logger, nil, "",
+		agentfake.WithDialer(dialer),
+		agentfake.WithConnectionReports(0, 0),
+	)
+	t.Cleanup(a.Close)
+
+	runCtx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+	runErr := make(chan error, 1)
+	go func() { runErr <- a.Run(runCtx) }()
+
+	// Wait for the connection to be established (lifecycle=READY) so the
+	// reporting goroutine has had its chance to start.
+	require.Eventually(t, func() bool {
+		for _, state := range dialer.GetLifecycleStates() {
+			if state == codersdk.WorkspaceAgentLifecycleReady {
+				return true
+			}
+		}
+		return false
+	}, testutil.WaitShort, testutil.IntervalFast,
+		"agent never reported Lifecycle=ready")
+
+	// Disabled means the goroutine returns immediately without registering a
+	// timer. Give any (buggy) reporting a brief window to leak through.
+	time.Sleep(testutil.IntervalSlow)
+
+	require.Empty(t, dialer.GetConnectionReports(),
+		"expected no ReportConnection calls when reporting is disabled")
+
+	cancel()
+	select {
+	case err := <-runErr:
+		require.NoError(t, err, "Agent.Run returned unexpected error")
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for Agent.Run to return: %v", ctx.Err())
+	}
+}

--- a/enterprise/scaletest/agentfake/agent_test.go
+++ b/enterprise/scaletest/agentfake/agent_test.go
@@ -154,11 +154,9 @@ func TestAgent_SendsMetadata(t *testing.T) {
 	}
 }
 
-// Assert that, when connection reporting is enabled, the fake agent emits a
-// repeating CONNECT/DISCONNECT SSH session via ReportConnection, with both
-// halves of a session sharing one connection id and successive sessions using
-// fresh ids. Driven against agent/agenttest.Client so the only quartz mock is
-// the agentfake clock backing the connectionReports ticker.
+// Assert that the fake agent emits repeating CONNECT/DISCONNECT SSH sessions,
+// pairing each session's halves under one connection id and using a fresh id
+// per session.
 func TestAgent_ReportsConnections(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)
@@ -189,9 +187,8 @@ func TestAgent_ReportsConnections(t *testing.T) {
 	)
 	t.Cleanup(a.Close)
 
-	// Trap the connectionReports TickerFunc registration so the goroutine
-	// is parked on the mock clock before we Advance; otherwise Advance
-	// could race goroutine startup and the first tick would be missed.
+	// Trap registration so the goroutine is parked on the mock clock before
+	// we Advance, otherwise Advance could race startup and miss the first tick.
 	tickerTrap := mClock.Trap().TickerFunc("agentfake", "connectionReports")
 	defer tickerTrap.Close()
 
@@ -202,8 +199,7 @@ func TestAgent_ReportsConnections(t *testing.T) {
 
 	tickerTrap.MustWait(ctx).Release(ctx)
 
-	// The ticker wakes every min(interval, duration) = 5s. Advance in 5s
-	// steps until the goroutine has emitted at least `want` reports.
+	// Advance one tick period (5s) per step until at least `want` reports land.
 	advanceUntil := func(want int) {
 		t.Helper()
 		require.Eventually(t, func() bool {
@@ -240,8 +236,7 @@ func TestAgent_ReportsConnections(t *testing.T) {
 	}
 }
 
-// Assert that a zero connection-report interval disables reporting entirely:
-// the goroutine registers no ticker and no ReportConnection calls are made.
+// Assert that a zero connection-report interval disables reporting entirely.
 func TestAgent_ReportsConnections_Disabled(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)
@@ -270,8 +265,8 @@ func TestAgent_ReportsConnections_Disabled(t *testing.T) {
 	runErr := make(chan error, 1)
 	go func() { runErr <- a.Run(runCtx) }()
 
-	// Wait for the connection to be established (lifecycle=READY) so the
-	// reporting goroutine has had its chance to start.
+	// Wait for lifecycle=READY so the reporting goroutine has had its chance
+	// to start before we assert it stayed silent.
 	require.Eventually(t, func() bool {
 		for _, state := range dialer.GetLifecycleStates() {
 			if state == codersdk.WorkspaceAgentLifecycleReady {
@@ -282,8 +277,7 @@ func TestAgent_ReportsConnections_Disabled(t *testing.T) {
 	}, testutil.WaitShort, testutil.IntervalFast,
 		"agent never reported Lifecycle=ready")
 
-	// Disabled means the goroutine returns immediately without registering a
-	// timer. Give any (buggy) reporting a brief window to leak through.
+	// Give any (buggy) reporting a brief window to leak through.
 	time.Sleep(testutil.IntervalSlow)
 
 	require.Empty(t, dialer.GetConnectionReports(),

--- a/enterprise/scaletest/agentfake/agent_test.go
+++ b/enterprise/scaletest/agentfake/agent_test.go
@@ -236,58 +236,72 @@ func TestAgent_ReportsConnections(t *testing.T) {
 	}
 }
 
-// Assert that a zero connection-report interval disables reporting entirely.
+// Assert that a zero interval or duration disables reporting entirely.
 func TestAgent_ReportsConnections_Disabled(t *testing.T) {
 	t.Parallel()
-	ctx := testutil.Context(t, testutil.WaitShort)
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	for _, tc := range []struct {
+		name     string
+		interval time.Duration
+		duration time.Duration
+	}{
+		{"BothZero", 0, 0},
+		{"ZeroInterval", 0, 5 * time.Second},
+		{"ZeroDuration", 30 * time.Second, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitShort)
 
-	agentID := uuid.New()
-	manifest := agentsdk.Manifest{
-		AgentID:     agentID,
-		WorkspaceID: uuid.New(),
-	}
-	statsCh := make(chan *agentproto.Stats, 1)
-	coord := tailnet.NewCoordinator(logger)
-	t.Cleanup(func() { _ = coord.Close() })
-	dialer := agenttest.NewClient(t, logger, agentID, manifest, statsCh, coord)
-	t.Cleanup(dialer.Close)
+			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
 
-	a := agentfake.NewAgent(logger, nil, "",
-		agentfake.WithDialer(dialer),
-		agentfake.WithConnectionReports(0, 0),
-	)
-	t.Cleanup(a.Close)
-
-	runCtx, cancel := context.WithCancel(ctx)
-	t.Cleanup(cancel)
-	runErr := make(chan error, 1)
-	go func() { runErr <- a.Run(runCtx) }()
-
-	// Wait for lifecycle=READY so the reporting goroutine has had its chance
-	// to start before we assert it stayed silent.
-	require.Eventually(t, func() bool {
-		for _, state := range dialer.GetLifecycleStates() {
-			if state == codersdk.WorkspaceAgentLifecycleReady {
-				return true
+			agentID := uuid.New()
+			manifest := agentsdk.Manifest{
+				AgentID:     agentID,
+				WorkspaceID: uuid.New(),
 			}
-		}
-		return false
-	}, testutil.WaitShort, testutil.IntervalFast,
-		"agent never reported Lifecycle=ready")
+			statsCh := make(chan *agentproto.Stats, 1)
+			coord := tailnet.NewCoordinator(logger)
+			t.Cleanup(func() { _ = coord.Close() })
+			dialer := agenttest.NewClient(t, logger, agentID, manifest, statsCh, coord)
+			t.Cleanup(dialer.Close)
 
-	// Give any (buggy) reporting a brief window to leak through.
-	time.Sleep(testutil.IntervalSlow)
+			a := agentfake.NewAgent(logger, nil, "",
+				agentfake.WithDialer(dialer),
+				agentfake.WithConnectionReports(tc.interval, tc.duration),
+			)
+			t.Cleanup(a.Close)
 
-	require.Empty(t, dialer.GetConnectionReports(),
-		"expected no ReportConnection calls when reporting is disabled")
+			runCtx, cancel := context.WithCancel(ctx)
+			t.Cleanup(cancel)
+			runErr := make(chan error, 1)
+			go func() { runErr <- a.Run(runCtx) }()
 
-	cancel()
-	select {
-	case err := <-runErr:
-		require.NoError(t, err, "Agent.Run returned unexpected error")
-	case <-ctx.Done():
-		t.Fatalf("timed out waiting for Agent.Run to return: %v", ctx.Err())
+			// Wait for lifecycle=READY so the reporting goroutine has had its
+			// chance to start before we assert it stayed silent.
+			require.Eventually(t, func() bool {
+				for _, state := range dialer.GetLifecycleStates() {
+					if state == codersdk.WorkspaceAgentLifecycleReady {
+						return true
+					}
+				}
+				return false
+			}, testutil.WaitShort, testutil.IntervalFast,
+				"agent never reported Lifecycle=ready")
+
+			// Give any (buggy) reporting a brief window to leak through.
+			time.Sleep(testutil.IntervalSlow)
+
+			require.Empty(t, dialer.GetConnectionReports(),
+				"expected no ReportConnection calls when reporting is disabled")
+
+			cancel()
+			select {
+			case err := <-runErr:
+				require.NoError(t, err, "Agent.Run returned unexpected error")
+			case <-ctx.Done():
+				t.Fatalf("timed out waiting for Agent.Run to return: %v", ctx.Err())
+			}
+		})
 	}
 }

--- a/enterprise/scaletest/agentfake/manager.go
+++ b/enterprise/scaletest/agentfake/manager.go
@@ -68,7 +68,8 @@ type ManagerOptions struct {
 	// before enumerating.
 	ExpectedAgents          int64
 	ExpectedAgentsTolerance int64
-	// Zero ConnectionReportInterval disables synthetic SSH connection reporting.
+	// A zero ConnectionReportInterval or ConnectionReportDuration disables
+	// synthetic SSH connection reporting.
 	ConnectionReportInterval time.Duration
 	ConnectionReportDuration time.Duration
 	// Clock is used for the workspace-count polling interval.

--- a/enterprise/scaletest/agentfake/manager.go
+++ b/enterprise/scaletest/agentfake/manager.go
@@ -68,6 +68,11 @@ type ManagerOptions struct {
 	// before enumerating.
 	ExpectedAgents          int64
 	ExpectedAgentsTolerance int64
+	// ConnectionReportInterval is the idle gap between synthetic SSH
+	// sessions per fake agent. Zero disables connection reporting.
+	ConnectionReportInterval time.Duration
+	// ConnectionReportDuration is the length of each synthetic SSH session.
+	ConnectionReportDuration time.Duration
 	// Clock is used for the workspace-count polling interval.
 	// Defaults to the real clock; override in tests with quartz.NewMock.
 	Clock quartz.Clock
@@ -149,7 +154,8 @@ func (m *Manager) Run(ctx context.Context) error {
 			m.logger.Named("agent-"+strconv.Itoa(i)),
 			m.coderURL, ti.Token,
 			WithMetrics(m.opts.Metrics),
-			WithFirstConnect(firstConnectCh)))
+			WithFirstConnect(firstConnectCh),
+			WithConnectionReports(m.opts.ConnectionReportInterval, m.opts.ConnectionReportDuration)))
 	}
 	m.mu.Lock()
 	m.agents = agents

--- a/enterprise/scaletest/agentfake/manager.go
+++ b/enterprise/scaletest/agentfake/manager.go
@@ -68,10 +68,8 @@ type ManagerOptions struct {
 	// before enumerating.
 	ExpectedAgents          int64
 	ExpectedAgentsTolerance int64
-	// ConnectionReportInterval is the idle gap between synthetic SSH
-	// sessions per fake agent. Zero disables connection reporting.
+	// Zero ConnectionReportInterval disables synthetic SSH connection reporting.
 	ConnectionReportInterval time.Duration
-	// ConnectionReportDuration is the length of each synthetic SSH session.
 	ConnectionReportDuration time.Duration
 	// Clock is used for the workspace-count polling interval.
 	// Defaults to the real clock; override in tests with quartz.NewMock.


### PR DESCRIPTION
This PR adds a basic routine to the `agentfake` `Agent` which will emit synthetic connection logs to coderd, simulating some basic amount of connection logging (connect/disconnect events) load for the coderd pods that would happen in normal deployments.
