### PR TITLE
chore(dogfood): add Firefox to base images

### DIFF
--- a/dogfood/coder/ubuntu-22.04/Dockerfile.base
+++ b/dogfood/coder/ubuntu-22.04/Dockerfile.base
@@ -121,6 +121,20 @@ RUN chmod a+x /usr/local/bin/configure-chrome-flags.sh && \
 	apt-get install --yes ./google-chrome-stable_current_amd64.deb && \
 	rm google-chrome-stable_current_amd64.deb
 
+# Install Firefox from Mozilla's official APT repository.
+# Ubuntu 22.04 only ships Firefox as a snap, which does not work in
+# Docker containers.
+RUN install -d -m 0755 /etc/apt/keyrings && \
+	wget -q https://packages.mozilla.org/apt/repo-signing-key.gpg \
+		-O /etc/apt/keyrings/packages.mozilla.org.asc && \
+	echo "deb [signed-by=/etc/apt/keyrings/packages.mozilla.org.asc] https://packages.mozilla.org/apt mozilla main" \
+		> /etc/apt/sources.list.d/mozilla.list && \
+	printf 'Package: *\nPin: origin packages.mozilla.org\nPin-Priority: 1000\n' \
+		> /etc/apt/preferences.d/mozilla && \
+	apt-get update --quiet && \
+	apt-get install --yes --allow-downgrades firefox && \
+	apt-get clean
+
 # Install Rust via rustup. Using rustup ensures we get a current stable
 # toolchain.
 ENV RUSTUP_HOME=/usr/local/rustup \

--- a/dogfood/coder/ubuntu-26.04/Dockerfile.base
+++ b/dogfood/coder/ubuntu-26.04/Dockerfile.base
@@ -128,6 +128,20 @@ RUN chmod a+x /opt/configure-chrome-flags.sh && \
 	apt-get install --yes ./google-chrome-stable_current_amd64.deb && \
 	rm google-chrome-stable_current_amd64.deb
 
+# Install Firefox from Mozilla's official APT repository.
+# Ubuntu 26.04 only ships Firefox as a snap, which does not work in
+# Docker containers.
+RUN install -d -m 0755 /etc/apt/keyrings && \
+	wget -q https://packages.mozilla.org/apt/repo-signing-key.gpg \
+		-O /etc/apt/keyrings/packages.mozilla.org.asc && \
+	echo "deb [signed-by=/etc/apt/keyrings/packages.mozilla.org.asc] https://packages.mozilla.org/apt mozilla main" \
+		> /etc/apt/sources.list.d/mozilla.list && \
+	printf 'Package: *\nPin: origin packages.mozilla.org\nPin-Priority: 1000\n' \
+		> /etc/apt/preferences.d/mozilla && \
+	apt-get update --quiet && \
+	apt-get install --yes --allow-downgrades firefox && \
+	apt-get clean
+
 # Install Rust via rustup. Using rustup ensures we get a current stable
 # toolchain.
 ENV RUSTUP_HOME=/usr/local/rustup \


### PR DESCRIPTION
Chrome 148 crashes with `Trace/breakpoint trap` (exit code 133) inside
the dogfood container environment, making it unusable for AI agents and
the portabledesktop browser preview. Firefox provides a working
alternative.

This PR installs Firefox from Mozilla's official APT repository in both
the ubuntu-22.04 and ubuntu-26.04 dogfood base images. Both Ubuntu
versions only ship Firefox as a snap, which does not work in Docker
containers.

- Adds Mozilla APT repo with signing key, pinned at priority 1000 to
  ensure it wins over the snap transitional package
- Uses `--allow-downgrades` in case the snap transitional package is
  already present
- Tested on the current dogfood image: installs Firefox 151.0.3 and
  creates `/usr/share/applications/firefox.desktop`

The portabledesktop dock already has `firefox.desktop` in its curated
priority list (#2 after Chrome), so Firefox will automatically appear
in the taskbar once the image is rebuilt.

---

**Closing:** Chrome works fine when launched via `portabledesktop open -- google-chrome-stable` instead of directly. The crashpad/ptrace issue is handled internally by portabledesktop. No need for Firefox as a workaround.