### PR TITLE
fix(cli): bound Coder Connect SSH probe

### DIFF
--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -56,6 +56,10 @@ const (
 	// Retry transient errors during SSH connection establishment.
 	sshRetryInterval = 2 * time.Second
 	sshMaxAttempts   = 10 // initial + retries per step
+
+	// Coder Connect DNS should answer locally, so a slow probe should fall
+	// back to the normal SSH tunnel.
+	coderConnectProbeTimeout = 500 * time.Millisecond
 )
 
 var (
@@ -425,7 +429,11 @@ func (r *RootCmd) ssh() *serpent.Command {
 				// search domain expansion, which can add 20-30s of
 				// delay on corporate networks with search domains
 				// configured.
-				exists, ccErr := workspacesdk.ExistsViaCoderConnect(ctx, coderConnectHost+".")
+				// Some DNS paths blackhole absolute .coder. lookups instead of
+				// returning NXDOMAIN, so keep fallback fast.
+				coderConnectCtx, coderConnectCancel := context.WithTimeout(ctx, coderConnectProbeTimeout)
+				exists, ccErr := workspacesdk.ExistsViaCoderConnect(coderConnectCtx, coderConnectHost+".")
+				coderConnectCancel()
 				if ccErr != nil {
 					logger.Debug(ctx, "failed to check coder connect",
 						slog.F("hostname", coderConnectHost),

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -59,7 +59,7 @@ const (
 
 	// Coder Connect DNS should answer locally, so a slow probe should fall
 	// back to the normal SSH tunnel.
-	coderConnectProbeTimeout = 500 * time.Millisecond
+	coderConnectProbeTimeout = 100 * time.Millisecond
 )
 
 var (


### PR DESCRIPTION
Coder Connect DNS should answer from the local Coder Connect resolver, so `coder ssh --stdio` now gives the optional DNS availability probe a 100ms budget and falls back to the normal tunnel when DNS paths blackhole absolute `.coder.` lookups instead of answering NXDOMAIN. 

Closes https://github.com/coder/coder/issues/22581.
