### PR TITLE
fix: strip proxy headers from bridge requests to fix Bedrock SigV4 signing (coder#26019)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -494,7 +494,7 @@ require (
 	github.com/anthropics/anthropic-sdk-go v1.19.0
 	github.com/brianvoe/gofakeit/v7 v7.14.0
 	github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225
-	github.com/coder/aibridge v1.1.1-0.20260331154949-a011104f377d
+	github.com/coder/aibridge v1.1.1-0.20260605135544-d91a904c9ce3
 	github.com/coder/aisdk-go v0.0.9
 	github.com/coder/boundary v0.8.4-0.20260304164748-566aeea939ab
 	github.com/coder/preview v1.0.8

--- a/go.sum
+++ b/go.sum
@@ -312,8 +312,8 @@ github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2/go.mod h1:qwXFYgsP6T7XnJtbKlf1HP8AjxZZyzxMmc+Lq5GjlU4=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225 h1:tRIViZ5JRmzdOEo5wUWngaGEFBG8OaE1o2GIHN5ujJ8=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225/go.mod h1:rNLVpYgEVeu1Zk29K64z6Od8RBP9DwqCu9OfCzh8MR4=
-github.com/coder/aibridge v1.1.1-0.20260331154949-a011104f377d h1:yoDGndlvKP6fiKzivG7kYLYs7jDEt2phgGVagDmuAHY=
-github.com/coder/aibridge v1.1.1-0.20260331154949-a011104f377d/go.mod h1:u6WvGLMQQbk3ByeOw+LBdVgDNc/v/ujAtUc6MfvzQb4=
+github.com/coder/aibridge v1.1.1-0.20260605135544-d91a904c9ce3 h1:fqD6n7VfynUrich/l63LYtv5x4Tvx8QC86gu2JUI084=
+github.com/coder/aibridge v1.1.1-0.20260605135544-d91a904c9ce3/go.mod h1:lFf2RlWsN2hOYxqUplupkTqL/yWno6meGHYbTGlOErE=
 github.com/coder/aisdk-go v0.0.9 h1:Vzo/k2qwVGLTR10ESDeP2Ecek1SdPfZlEjtTfMveiVo=
 github.com/coder/aisdk-go v0.0.9/go.mod h1:KF6/Vkono0FJJOtWtveh5j7yfNrSctVTpwgweYWSp5M=
 github.com/coder/anthropic-sdk-go v0.0.0-20260409105508-5711db120546 h1:dYAA1uo93n9r/B4Gvx76pjaeS0kBTX1lO0WX0p0uqo8=


### PR DESCRIPTION
Backport of https://github.com/coder/coder/pull/26019

Original PR: #26019 — fix(aibridge): strip proxy headers from bridge requests to fix Bedrock SigV4 signing
aibridge PR: https://github.com/coder/aibridge/pull/283
Merge commit: https://github.com/coder/aibridge/commit/d91a904c9ce357d51d40b94a78414e6afd5a7a73
Requested by: @ssncferreira 