### PR TITLE
feat: add OpenCode AI Bridge client support

### DIFF
--- a/aibridge/client.go
+++ b/aibridge/client.go
@@ -21,6 +21,7 @@ const (
 	ClientMux         Client = "Mux"
 	ClientRoo         Client = "Roo Code"
 	ClientCursor      Client = "Cursor"
+	ClientOpenCode    Client = "OpenCode"
 	ClientUnknown     Client = "Unknown"
 )
 
@@ -55,6 +56,8 @@ func GuessClient(r *http.Request) Client {
 		return ClientCrush
 	case r.Header.Get("x-cursor-client-version") != "":
 		return ClientCursor
+	case strings.HasPrefix(userAgent, "opencode/"):
+		return ClientOpenCode
 	}
 	return ClientUnknown
 }

--- a/aibridge/client_test.go
+++ b/aibridge/client_test.go
@@ -100,6 +100,11 @@ func TestGuessClient(t *testing.T) {
 			wantClient: aibridge.ClientCursor,
 		},
 		{
+			name:       "opencode",
+			userAgent:  "opencode/1.16.0 ai-sdk/provider-utils/4.0.23 runtime/bun/1.3.14",
+			wantClient: aibridge.ClientOpenCode,
+		},
+		{
 			name:       "unknown_client",
 			userAgent:  "ccclaude-cli/calude-with-wrong-prefix",
 			wantClient: aibridge.ClientUnknown,

--- a/aibridge/internal/integrationtest/bridge_internal_test.go
+++ b/aibridge/internal/integrationtest/bridge_internal_test.go
@@ -906,6 +906,17 @@ func TestSimple(t *testing.T) {
 			expectedClient:    aibridge.ClientCodex,
 		},
 		{
+			name:              config.ProviderOpenAI + "_opencode",
+			fixture:           fixtures.OaiChatSimple,
+			basePath:          "",
+			expectedPath:      "/chat/completions",
+			getResponseIDFunc: getOpenAIResponseID,
+			path:              pathOpenAIChatCompletions,
+			expectedMsgID:     "chatcmpl-BwoiPTGRbKkY5rncfaM0s9KtWrq5N",
+			userAgent:         "opencode/1.16.0 ai-sdk/provider-utils/4.0.23 runtime/bun/1.3.14",
+			expectedClient:    aibridge.ClientOpenCode,
+		},
+		{
 			name:              config.ProviderAnthropic + "_baseURL_path",
 			fixture:           fixtures.AntSimple,
 			basePath:          "/api",

--- a/docs/ai-coder/ai-gateway/monitoring.md
+++ b/docs/ai-coder/ai-gateway/monitoring.md
@@ -94,6 +94,7 @@ Available query filters:
   - `Coder Agents`
   - `Mux`
   - `Cursor`
+  - `OpenCode`
   - `Unknown`
 
   </details><br>

--- a/site/src/pages/AIBridgePage/RequestLogsPage/icons/AIBridgeClientIcon.stories.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/icons/AIBridgeClientIcon.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AIBridgeClientIcon } from "./AIBridgeClientIcon";
+
+const meta: Meta<typeof AIBridgeClientIcon> = {
+	title: "pages/AIBridgePage/AIBridgeClientIcon",
+	component: AIBridgeClientIcon,
+	args: {
+		className: "size-8",
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof AIBridgeClientIcon>;
+
+export const OpenCode: Story = {
+	args: {
+		client: "OpenCode",
+	},
+};
+
+export const ClaudeCode: Story = {
+	args: {
+		client: "Claude Code",
+	},
+};
+
+export const Unknown: Story = {
+	args: {
+		client: "Unknown",
+	},
+};

--- a/site/src/pages/AIBridgePage/RequestLogsPage/icons/AIBridgeClientIcon.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/icons/AIBridgeClientIcon.tsx
@@ -71,6 +71,13 @@ export const AIBridgeClientIcon = ({
 					className={cn(iconClassName, className)}
 				/>
 			);
+		case "OpenCode":
+			return (
+				<ExternalImage
+					src="/icon/opencode.svg"
+					className={cn(iconClassName, className)}
+				/>
+			);
 		case "Charm Crush":
 			return (
 				<ExternalImage


### PR DESCRIPTION
Adds OpenCode to AI Bridge client detection so requests with user agents like `opencode/1.16.0 ai-sdk/provider-utils/4.0.23 runtime/bun/1.3.14` show up as a first-class client instead of `Unknown`.

This also wires the existing OpenCode frontend asset into the AIBridge UI, adds a Storybook story for the client icon, and updates the monitoring docs list of supported client values.

<details>
<summary>Coder Agents generated</summary>

This pull request was generated by Coder Agents.

</details>
