### PR TITLE
feat(agent): unify session env via EnvInfoer

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -434,7 +434,7 @@ func (a *agent) init() {
 			return m.Directory
 		}
 		return ""
-	})
+	}, a.envInfo)
 	gitOpts := append([]agentgit.Option{agentgit.WithClock(a.clock)}, a.gitAPIOptions...)
 	a.gitAPI = agentgit.NewAPI(a.logger.Named("git"), pathStore, gitOpts...)
 	desktop := agentdesktop.NewPortableDesktop(

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -90,10 +90,8 @@ type Options struct {
 	Client                 Client
 	ReconnectingPTYTimeout time.Duration
 	EnvironmentVariables   map[string]string
-	// EnvInfo overrides how session command environments are resolved
-	// (user, shell, home directory, environment). Only tests should set
-	// this. Production leaves it nil so agentssh defaults to
-	// usershell.SystemEnvInfo.
+	// EnvInfo overrides the session command environment source. Only
+	// tests set this. Nil defaults to usershell.SystemEnvInfo.
 	EnvInfo usershell.EnvInfoer
 	Logger  slog.Logger
 	// IgnorePorts tells the api handler which ports to ignore when

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -52,6 +52,7 @@ import (
 	"github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/agent/proto/resourcesmonitor"
 	"github.com/coder/coder/v2/agent/reconnectingpty"
+	"github.com/coder/coder/v2/agent/usershell"
 	"github.com/coder/coder/v2/agent/x/agentdesktop"
 	"github.com/coder/coder/v2/agent/x/agentmcp"
 	"github.com/coder/coder/v2/buildinfo"
@@ -89,7 +90,12 @@ type Options struct {
 	Client                 Client
 	ReconnectingPTYTimeout time.Duration
 	EnvironmentVariables   map[string]string
-	Logger                 slog.Logger
+	// EnvInfo overrides how session command environments are resolved
+	// (user, shell, home directory, environment). Only tests should set
+	// this. Production leaves it nil so agentssh defaults to
+	// usershell.SystemEnvInfo.
+	EnvInfo usershell.EnvInfoer
+	Logger  slog.Logger
 	// IgnorePorts tells the api handler which ports to ignore when
 	// listing all listening ports. This is helpful to hide ports that
 	// are used by the agent, that the user does not care about.
@@ -226,6 +232,7 @@ func New(options Options) Agent {
 		statsReportInterval:                options.StatsReportInterval,
 		announcementBannersRefreshInterval: options.ServiceBannerRefreshInterval,
 		sshMaxTimeout:                      options.SSHMaxTimeout,
+		envInfo:                            options.EnvInfo,
 		subsystems:                         options.Subsystems,
 		logSender:                          agentsdk.NewLogSender(options.Logger),
 		blockFileTransfer:                  options.BlockFileTransfer,
@@ -303,6 +310,7 @@ type agent struct {
 	announcementBannersRefreshInterval time.Duration
 	sshServer                          *agentssh.Server
 	sshMaxTimeout                      time.Duration
+	envInfo                            usershell.EnvInfoer
 	blockFileTransfer                  bool
 	blockReversePortForwarding         bool
 	blockLocalPortForwarding           bool
@@ -365,6 +373,7 @@ func (a *agent) init() {
 		AnnouncementBanners:        func() *[]codersdk.BannerConfig { return a.announcementBanners.Load() },
 		UpdateEnv:                  a.updateCommandEnv,
 		WorkingDirectory:           func() string { return a.manifest.Load().Directory },
+		EnvInfo:                    a.envInfo,
 		BlockFileTransfer:          a.blockFileTransfer,
 		BlockReversePortForwarding: a.blockReversePortForwarding,
 		BlockLocalPortForwarding:   a.blockLocalPortForwarding,

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -429,12 +429,12 @@ func (a *agent) init() {
 
 	pathStore := agentgit.NewPathStore()
 	a.filesAPI = agentfiles.NewAPI(a.logger.Named("files"), a.filesystem, pathStore)
-	a.processAPI = agentproc.NewAPI(a.logger.Named("processes"), a.execer, a.updateCommandEnv, pathStore, func() string {
+	a.processAPI = agentproc.NewAPI(a.logger.Named("processes"), a.execer, pathStore, a.envInfo, a.updateCommandEnv, func() string {
 		if m := a.manifest.Load(); m != nil {
 			return m.Directory
 		}
 		return ""
-	}, a.envInfo)
+	})
 	gitOpts := append([]agentgit.Option{agentgit.WithClock(a.clock)}, a.gitAPIOptions...)
 	a.gitAPI = agentgit.NewAPI(a.logger.Named("git"), pathStore, gitOpts...)
 	desktop := agentdesktop.NewPortableDesktop(

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1741,6 +1741,43 @@ func TestAgent_SSHConnectionLoginVars(t *testing.T) {
 	}
 }
 
+// TestAgent_SSHEnvInfoShell verifies that an agent.Options.EnvInfo whose
+// Shell() reports a custom shell is piped through to the SSH session, so the
+// session command runs under that shell instead of the host default.
+func TestAgent_SSHEnvInfoShell(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("the fake shell is a POSIX script")
+	}
+
+	// A fake shell that ignores its arguments and prints a sentinel. The
+	// sentinel only appears in the session output if the injected Shell() was
+	// honored. Otherwise the command's own output ("should-not-run") appears.
+	const marker = "injected-shell-was-used"
+	shellPath := filepath.Join(t.TempDir(), "fakeshell")
+	//nolint:gosec // Executable test shell with test-controlled content.
+	err := os.WriteFile(shellPath, []byte("#!/bin/sh\necho "+marker+"\n"), 0o700)
+	require.NoError(t, err)
+
+	session := setupSSHSession(t, agentsdk.Manifest{}, codersdk.ServiceBannerConfig{}, nil, func(_ *agenttest.Client, o *agent.Options) {
+		o.EnvInfo = shellOverrideEnvInfo{shell: shellPath}
+	})
+
+	output, err := session.Output("echo should-not-run")
+	require.NoError(t, err)
+	require.Contains(t, string(output), marker)
+	require.NotContains(t, string(output), "should-not-run")
+}
+
+// shellOverrideEnvInfo is a usershell.EnvInfoer that delegates to the system
+// implementation but reports a custom shell.
+type shellOverrideEnvInfo struct {
+	usershell.SystemEnvInfo
+	shell string
+}
+
+func (e shellOverrideEnvInfo) Shell(string) (string, error) { return e.shell, nil }
+
 func TestAgent_Metadata(t *testing.T) {
 	t.Parallel()
 

--- a/agent/agentproc/api.go
+++ b/agent/agentproc/api.go
@@ -37,10 +37,10 @@ type API struct {
 }
 
 // NewAPI creates a new process API handler.
-func NewAPI(logger slog.Logger, execer agentexec.Execer, updateEnv func(current []string) (updated []string, err error), pathStore *agentgit.PathStore, workingDir func() string, envInfo usershell.EnvInfoer) *API {
+func NewAPI(logger slog.Logger, execer agentexec.Execer, pathStore *agentgit.PathStore, envInfo usershell.EnvInfoer, updateEnv func(current []string) (updated []string, err error), workingDir func() string) *API {
 	return &API{
 		logger:    logger,
-		manager:   newManager(logger, execer, updateEnv, workingDir, envInfo),
+		manager:   newManager(logger, execer, envInfo, updateEnv, workingDir),
 		pathStore: pathStore,
 	}
 }

--- a/agent/agentproc/api.go
+++ b/agent/agentproc/api.go
@@ -16,6 +16,7 @@ import (
 	"github.com/coder/coder/v2/agent/agentchat"
 	"github.com/coder/coder/v2/agent/agentexec"
 	"github.com/coder/coder/v2/agent/agentgit"
+	"github.com/coder/coder/v2/agent/usershell"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
@@ -36,10 +37,10 @@ type API struct {
 }
 
 // NewAPI creates a new process API handler.
-func NewAPI(logger slog.Logger, execer agentexec.Execer, updateEnv func(current []string) (updated []string, err error), pathStore *agentgit.PathStore, workingDir func() string) *API {
+func NewAPI(logger slog.Logger, execer agentexec.Execer, updateEnv func(current []string) (updated []string, err error), pathStore *agentgit.PathStore, workingDir func() string, envInfo usershell.EnvInfoer) *API {
 	return &API{
 		logger:    logger,
-		manager:   newManager(logger, execer, updateEnv, workingDir),
+		manager:   newManager(logger, execer, updateEnv, workingDir, envInfo),
 		pathStore: pathStore,
 	}
 }

--- a/agent/agentproc/api_test.go
+++ b/agent/agentproc/api_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -24,6 +25,7 @@ import (
 	"github.com/coder/coder/v2/agent/agentexec"
 	"github.com/coder/coder/v2/agent/agentgit"
 	"github.com/coder/coder/v2/agent/agentproc"
+	"github.com/coder/coder/v2/agent/usershell"
 	"github.com/coder/coder/v2/coderd/httpmw/loggermw"
 	"github.com/coder/coder/v2/coderd/tracing"
 	"github.com/coder/coder/v2/codersdk"
@@ -136,19 +138,43 @@ func newTestAPIWithOptions(t *testing.T, updateEnv func([]string) ([]string, err
 	logger := slogtest.Make(t, &slogtest.Options{
 		IgnoreErrors: true,
 	}).Leveled(slog.LevelDebug)
-	api := agentproc.NewAPI(logger, agentexec.DefaultExecer, updateEnv, nil, workingDir)
+	api := agentproc.NewAPI(logger, agentexec.DefaultExecer, updateEnv, nil, workingDir, nil)
 	t.Cleanup(func() {
 		_ = api.Close()
 	})
 	return agentchat.Middleware(api.Routes())
 }
 
+// newTestAPIWithEnvInfo creates a new API with an injected EnvInfoer
+// and an optional workingDir hook.
+func newTestAPIWithEnvInfo(t *testing.T, workingDir func() string, envInfo usershell.EnvInfoer) http.Handler {
+	t.Helper()
+
+	logger := slogtest.Make(t, &slogtest.Options{
+		IgnoreErrors: true,
+	}).Leveled(slog.LevelDebug)
+	api := agentproc.NewAPI(logger, agentexec.DefaultExecer, nil, nil, workingDir, envInfo)
+	t.Cleanup(func() {
+		_ = api.Close()
+	})
+	return agentchat.Middleware(api.Routes())
+}
+
+// homeOverrideEnvInfo is a usershell.EnvInfoer that delegates to the
+// system implementation but reports a custom home directory.
+type homeOverrideEnvInfo struct {
+	usershell.SystemEnvInfo
+	home string
+}
+
+func (e homeOverrideEnvInfo) HomeDir() (string, error) { return e.home, nil }
+
 func TestAccessLogIncludesChatID(t *testing.T) {
 	t.Parallel()
 
 	sink := testutil.NewFakeSink(t)
 	logger := sink.Logger()
-	api := agentproc.NewAPI(logger, agentexec.DefaultExecer, nil, nil, nil)
+	api := agentproc.NewAPI(logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 	t.Cleanup(func() {
 		_ = api.Close()
 	})
@@ -379,6 +405,40 @@ func TestStartProcess(t *testing.T) {
 
 		homeDir, err := os.UserHomeDir()
 		require.NoError(t, err)
+
+		id := startAndGetID(t, handler, workspacesdk.StartProcessRequest{
+			Command: "echo ok",
+		})
+
+		resp := waitForExit(t, handler, id)
+		require.NotNil(t, resp.ExitCode)
+		require.Equal(t, 0, *resp.ExitCode)
+
+		w := getList(t, handler)
+		require.Equal(t, http.StatusOK, w.Code)
+		var listResp workspacesdk.ListProcessesResponse
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&listResp))
+		var proc *workspacesdk.ProcessInfo
+		for i := range listResp.Processes {
+			if listResp.Processes[i].ID == id {
+				proc = &listResp.Processes[i]
+				break
+			}
+		}
+		require.NotNil(t, proc, "process not found in list")
+		require.Equal(t, homeDir, proc.WorkDir)
+	})
+
+	t.Run("DefaultWorkDirUsesInjectedEnvInfoHome", func(t *testing.T) {
+		t.Parallel()
+
+		// With no explicit or configured directory available,
+		// the home fallback must come from the injected EnvInfo
+		// rather than the real user home.
+		homeDir := t.TempDir()
+		handler := newTestAPIWithEnvInfo(t, func() string {
+			return filepath.Join(t.TempDir(), "nonexistent")
+		}, homeOverrideEnvInfo{home: homeDir})
 
 		id := startAndGetID(t, handler, workspacesdk.StartProcessRequest{
 			Command: "echo ok",
@@ -1086,7 +1146,7 @@ func TestHandleStartProcess_ChatHeaders_EmptyWorkDir_StillNotifies(t *testing.T)
 	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 	api := agentproc.NewAPI(logger, agentexec.DefaultExecer, func(current []string) ([]string, error) {
 		return current, nil
-	}, pathStore, nil)
+	}, pathStore, nil, nil)
 	defer api.Close()
 
 	routes := agentchat.Middleware(api.Routes())

--- a/agent/agentproc/api_test.go
+++ b/agent/agentproc/api_test.go
@@ -138,7 +138,7 @@ func newTestAPIWithOptions(t *testing.T, updateEnv func([]string) ([]string, err
 	logger := slogtest.Make(t, &slogtest.Options{
 		IgnoreErrors: true,
 	}).Leveled(slog.LevelDebug)
-	api := agentproc.NewAPI(logger, agentexec.DefaultExecer, updateEnv, nil, workingDir, nil)
+	api := agentproc.NewAPI(logger, agentexec.DefaultExecer, nil, nil, updateEnv, workingDir)
 	t.Cleanup(func() {
 		_ = api.Close()
 	})
@@ -153,7 +153,7 @@ func newTestAPIWithEnvInfo(t *testing.T, workingDir func() string, envInfo users
 	logger := slogtest.Make(t, &slogtest.Options{
 		IgnoreErrors: true,
 	}).Leveled(slog.LevelDebug)
-	api := agentproc.NewAPI(logger, agentexec.DefaultExecer, nil, nil, workingDir, envInfo)
+	api := agentproc.NewAPI(logger, agentexec.DefaultExecer, nil, envInfo, nil, workingDir)
 	t.Cleanup(func() {
 		_ = api.Close()
 	})
@@ -1144,9 +1144,9 @@ func TestHandleStartProcess_ChatHeaders_EmptyWorkDir_StillNotifies(t *testing.T)
 	defer unsub()
 
 	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
-	api := agentproc.NewAPI(logger, agentexec.DefaultExecer, func(current []string) ([]string, error) {
+	api := agentproc.NewAPI(logger, agentexec.DefaultExecer, pathStore, nil, func(current []string) ([]string, error) {
 		return current, nil
-	}, pathStore, nil, nil)
+	}, nil)
 	defer api.Close()
 
 	routes := agentchat.Middleware(api.Routes())

--- a/agent/agentproc/process.go
+++ b/agent/agentproc/process.go
@@ -84,7 +84,7 @@ type manager struct {
 }
 
 // newManager creates a new process manager.
-func newManager(logger slog.Logger, execer agentexec.Execer, updateEnv func(current []string) (updated []string, err error), workingDir func() string, envInfo usershell.EnvInfoer) *manager {
+func newManager(logger slog.Logger, execer agentexec.Execer, envInfo usershell.EnvInfoer, updateEnv func(current []string) (updated []string, err error), workingDir func() string) *manager {
 	if envInfo == nil {
 		envInfo = &usershell.SystemEnvInfo{}
 	}

--- a/agent/agentproc/process.go
+++ b/agent/agentproc/process.go
@@ -14,6 +14,7 @@ import (
 
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/agent/agentexec"
+	"github.com/coder/coder/v2/agent/usershell"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 	"github.com/coder/quartz"
 )
@@ -79,10 +80,14 @@ type manager struct {
 	closed     bool
 	updateEnv  func(current []string) (updated []string, err error)
 	workingDir func() string
+	envInfo    usershell.EnvInfoer
 }
 
 // newManager creates a new process manager.
-func newManager(logger slog.Logger, execer agentexec.Execer, updateEnv func(current []string) (updated []string, err error), workingDir func() string) *manager {
+func newManager(logger slog.Logger, execer agentexec.Execer, updateEnv func(current []string) (updated []string, err error), workingDir func() string, envInfo usershell.EnvInfoer) *manager {
+	if envInfo == nil {
+		envInfo = &usershell.SystemEnvInfo{}
+	}
 	return &manager{
 		logger:     logger,
 		execer:     execer,
@@ -90,6 +95,7 @@ func newManager(logger slog.Logger, execer agentexec.Execer, updateEnv func(curr
 		procs:      make(map[string]*process),
 		updateEnv:  updateEnv,
 		workingDir: workingDir,
+		envInfo:    envInfo,
 	}
 }
 
@@ -379,7 +385,7 @@ func (m *manager) resolveWorkDir(requested string) string {
 			}
 		}
 	}
-	if home, err := os.UserHomeDir(); err == nil {
+	if home, err := m.envInfo.HomeDir(); err == nil {
 		return home
 	}
 	return ""

--- a/agent/agentssh/agentssh.go
+++ b/agent/agentssh/agentssh.go
@@ -107,6 +107,12 @@ type Config struct {
 	// where users will land when they connect via SSH. Default is the home
 	// directory of the user.
 	WorkingDirectory func() string
+	// EnvInfo provides external information about the environment (user,
+	// shell, home directory, environment variables) used when creating
+	// session commands. Default is usershell.SystemEnvInfo, which reflects
+	// the host environment. A container override still applies per session
+	// when ExperimentalContainers is enabled.
+	EnvInfo usershell.EnvInfoer
 	// X11DisplayOffset is the offset to add to the X11 display number.
 	// Default is 10.
 	X11DisplayOffset *int
@@ -188,6 +194,9 @@ func NewServer(ctx context.Context, logger slog.Logger, prometheusRegistry *prom
 			}
 			return home
 		}
+	}
+	if config.EnvInfo == nil {
+		config.EnvInfo = &usershell.SystemEnvInfo{}
 	}
 	if config.ReportConnection == nil {
 		config.ReportConnection = func(uuid.UUID, MagicSessionType, string) func(int, string) { return func(int, string) {} }
@@ -619,7 +628,7 @@ func (s *Server) sessionStart(logger slog.Logger, session ssh.Session, env []str
 		ptyLabel = "yes"
 	}
 
-	var ei usershell.EnvInfoer
+	ei := s.config.EnvInfo
 	var err error
 	if s.config.ExperimentalContainers && container != "" {
 		ei, err = agentcontainers.EnvInfo(ctx, s.Execer, container, containerUser)

--- a/agent/agentssh/agentssh.go
+++ b/agent/agentssh/agentssh.go
@@ -107,11 +107,9 @@ type Config struct {
 	// where users will land when they connect via SSH. Default is the home
 	// directory of the user.
 	WorkingDirectory func() string
-	// EnvInfo provides external information about the environment (user,
-	// shell, home directory, environment variables) used when creating
-	// session commands. Default is usershell.SystemEnvInfo, which reflects
-	// the host environment. A container override still applies per session
-	// when ExperimentalContainers is enabled.
+	// EnvInfo sources the session command environment. Default is
+	// usershell.SystemEnvInfo. A container override still applies per
+	// session when ExperimentalContainers is enabled.
 	EnvInfo usershell.EnvInfoer
 	// X11DisplayOffset is the offset to add to the X11 display number.
 	// Default is 10.


### PR DESCRIPTION
SSH session tests lean on fragile `bufio.Scanner` and blind-write patterns against `NewSession`, which is the source of the flaky bare-EOF failures tracked in coder/internal#1560. The fix is a deterministic, protected test tool, landed in stages. This PR is stage one: the seam the tool depends on.

It adds an injectable `usershell.EnvInfoer` to `agent.Options` and `agentssh.Config`. `sessionStart` now sources the session's user, shell, home directory, and environment from it, and `NewServer` defaults it to `usershell.SystemEnvInfo`. Production never sets the field, so the resolved shell, environment, and working directory stay identical to before. The container override for `ExperimentalContainers` still takes precedence per session. The only new capability is that a test can force a deterministic shell.

The same `EnvInfoer` is threaded into the process API (`agentproc`), whose working-directory home fallback previously called `os.UserHomeDir` directly. `NewAPI` and `newManager` now take an `EnvInfoer` (nil defaults to `SystemEnvInfo`), and `resolveWorkDir` uses it for the home fallback. This keeps the seam consistent across SSH and the process API, and lets the stacked working-directory unification honor injected EnvInfo instead of hardcoding `SystemEnvInfo`. Production behavior is unchanged.

`TestAgent_SSHEnvInfoShell` covers the path from `agent.Options.EnvInfo` to the executed session command, and `TestStartProcess/DefaultWorkDirUsesInjectedEnvInfoHome` proves the injected home is honored as the process working-directory fallback.

<details>
<summary>Implementation plan and where this PR fits</summary>

The redesign replaces fragile `bufio.Scanner` and blind-write SSH session test patterns with a deterministic, protected, composable tool. It ships in stages:

- PR1 (this PR): EnvInfo seam in production, inert default. Covers both `agentssh` and the `agentproc` process API.
- PR2: `resolveWorkingDir` stat-validation bug fix, unifying SSH and process-API working-directory resolution.
- PR3: test tooling, an `agenttest` session driver plus `usershelltest.EnvInfo`, with a sentinel-prompt readiness mechanism validated on Linux and Windows.
- PR4+: migrate the ~32 `NewSession` sites and the cli `ptytest` path, by area.

Locked decisions relevant here:

- Test-only seam. Production behavior is unchanged.
- Injection goes through `usershell.EnvInfoer`. The default stays `SystemEnvInfo`.
- The per-session container override path is preserved.

PR1 scope: add `EnvInfo` to `agentssh.Config` and `agent.Options`, default it in `NewServer`, source it in `sessionStart`, thread it into `agentproc.NewAPI`, and assert that an injected `Shell()` changes the session shell and an injected `HomeDir()` changes the process working directory.
</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
