### PR TITLE
fix(coderd/x/chatd): disclose execute shell

### DIFF
--- a/coderd/x/chatd/chattool/execute.go
+++ b/coderd/x/chatd/chattool/execute.go
@@ -77,7 +77,7 @@ type ProcessToolOptions struct {
 
 // ExecuteArgs are the parameters accepted by the execute tool.
 type ExecuteArgs struct {
-	Command         string  `json:"command" description:"The shell command to execute."`
+	Command         string  `json:"command" description:"The shell command to execute. Runs under \"sh -c\" (POSIX)."`
 	ModelIntent     *string `json:"model_intent,omitempty" description:"A short, natural-language, present-participle phrase describing what you are doing. This is shown to the user alongside the command. Use plain English with no underscores or technical jargon. The UI appends \"using <command>\" and \"for <duration>\" automatically, so do not repeat the command or include a duration. Keep it under 100 characters. Good examples: \"Running the unit tests\", \"Checking repository state\", \"Inspecting build output\"."`
 	Timeout         *string `json:"timeout,omitempty" description:"How long to wait for completion (e.g. '30s', '5m'). Default is 10s. The process keeps running if this expires and you get a background_process_id to re-attach. Only applies to foreground commands."`
 	WorkDir         *string `json:"workdir,omitempty" description:"Working directory for the command."`
@@ -92,7 +92,7 @@ const ExecuteToolName = "execute"
 func Execute(options ExecuteOptions) fantasy.AgentTool {
 	return fantasy.NewAgentTool(
 		ExecuteToolName,
-		"Execute a shell command in the workspace. Runs the command and waits for completion up to the timeout (default 10s, override with the timeout parameter e.g. '30s', '5m'). If the command exceeds the timeout, the response includes a background_process_id; use process_output with that ID to re-attach and wait for the result. Use run_in_background=true for persistent processes (dev servers, file watchers) or when you want to continue other work while the command runs. Never use shell '&' for backgrounding.",
+		"Execute a shell command in the workspace. Runs under \"sh -c\" (POSIX). Waits for completion up to the timeout (default 10s, override with the timeout parameter e.g. '30s', '5m'). If the command exceeds the timeout, the response includes a background_process_id; use process_output with that ID to re-attach and wait for the result. Use run_in_background=true for persistent processes (dev servers, file watchers) or when you want to continue other work while the command runs. Never use shell '&' for backgrounding.",
 		func(ctx context.Context, args ExecuteArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
 			if options.GetWorkspaceConn == nil {
 				return fantasy.NewTextErrorResponse("workspace connection resolver is not configured"), nil

--- a/coderd/x/chatd/chattool/execute_test.go
+++ b/coderd/x/chatd/chattool/execute_test.go
@@ -34,6 +34,19 @@ func TestExecuteTool(t *testing.T) {
 		assert.NotContains(t, info.Required, "model_intent")
 	})
 
+	t.Run("SchemaDisclosesShell", func(t *testing.T) {
+		t.Parallel()
+
+		tool := chattool.Execute(chattool.ExecuteOptions{})
+		info := tool.Info()
+		assert.Contains(t, info.Description, `Runs under "sh -c" (POSIX)`)
+
+		commandParam, ok := info.Parameters["command"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "string", commandParam["type"])
+		assert.Contains(t, commandParam["description"], `Runs under "sh -c" (POSIX)`)
+	})
+
 	t.Run("EmptyCommand", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)


### PR DESCRIPTION
The execute tool already runs commands through `sh -c`, but the LLM-facing metadata only described a generic shell command.

This updates the tool and `command` parameter descriptions to disclose `"sh -c" (POSIX)`. A regression test covers both places the model sees the contract.

Verification:
- `go test ./coderd/x/chatd/chattool -run 'TestExecuteTool/SchemaDisclosesShell' -count=1`
- pre-commit hook passed

Pre-push was explicitly opted out after `test-storybook` failed twice in unrelated stories:
- `src/pages/AgentsPage/AgentChatPageView.stories.tsx:1197`
- `src/pages/UsersPage/UsersPage.stories.tsx:395`

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
