### PR TITLE
fix(coderd/x/chatd/chattool): list directories in read_file

### DIFF
--- a/agent/agentfiles/files.go
+++ b/agent/agentfiles/files.go
@@ -196,7 +196,7 @@ func (api *API) readFileLines(_ context.Context, path string, offset, limit int6
 	}
 
 	if stat.IsDir() {
-		return errResp(fmt.Sprintf("not a file: %s", path))
+		return errResp(fmt.Sprintf("%s %s", workspacesdk.ReadFileLinesNotFileErrorPrefix, path))
 	}
 
 	fileSize := stat.Size()

--- a/coderd/x/chatd/chattool/readfile.go
+++ b/coderd/x/chatd/chattool/readfile.go
@@ -24,8 +24,9 @@ type ReadFileArgs struct {
 func ReadFile(options ReadFileOptions) fantasy.AgentTool {
 	return fantasy.NewAgentTool(
 		"read_file",
-		"Read a file from the workspace. Returns line-numbered content. "+
-			"When reading a directory, returns a non-recursive directory listing. "+
+		"Read a file or list a directory in the workspace. "+
+			"For files, returns line-numbered content. "+
+			"For directories, returns a non-recursive listing. "+
 			"The offset parameter is a 1-based line number or directory entry (default: 1). "+
 			"The limit parameter is the number of lines or directory entries to return (default: 2000). "+
 			"For large files and directories, use offset and limit to paginate.",
@@ -80,10 +81,15 @@ func executeReadFileTool(
 	}), nil
 }
 
+// readFileLinesErrorIsDirectory returns true when the ReadFileLines error
+// indicates that the path is a directory. The workspace agent's file-read
+// handler emits this prefix for directories.
 func readFileLinesErrorIsDirectory(err string) bool {
-	return strings.HasPrefix(strings.TrimSpace(err), "not a file:")
+	return strings.HasPrefix(strings.TrimSpace(err), workspacesdk.ReadFileLinesNotFileErrorPrefix)
 }
 
+// executeReadFileDirectoryListing falls back to the agent's directory-list
+// endpoint after ReadFileLines reports that the path is a directory.
 func executeReadFileDirectoryListing(
 	ctx context.Context,
 	conn workspacesdk.AgentConn,
@@ -111,7 +117,6 @@ func executeReadFileDirectoryListing(
 		"is_directory":         true,
 		"absolute_path":        resp.AbsolutePath,
 		"absolute_path_string": resp.AbsolutePathString,
-		"entries":              listing.entries,
 		"entries_read":         listing.entriesRead,
 		"total_entries":        len(resp.Contents),
 		"truncated":            listing.truncated,
@@ -120,11 +125,12 @@ func executeReadFileDirectoryListing(
 
 type directoryListing struct {
 	content     string
-	entries     []workspacesdk.LSFile
 	entriesRead int
 	truncated   bool
 }
 
+// directoryListingResult applies read_file pagination semantics to an LS
+// response and keeps the formatted listing within the tool output budget.
 func directoryListingResult(resp workspacesdk.LSResponse, offset, limit int64) (directoryListing, error) {
 	if offset < 1 {
 		offset = 1
@@ -138,7 +144,7 @@ func directoryListingResult(resp workspacesdk.LSResponse, offset, limit int64) (
 		return directoryListing{}, nil
 	}
 	if offset > int64(totalEntries) {
-		return directoryListing{}, xerrors.Errorf("offset %d is beyond the directory length of %d entries", offset, totalEntries)
+		return directoryListing{}, xerrors.Errorf("offset %d exceeds directory entry count %d", offset, totalEntries)
 	}
 
 	start := int(offset - 1)
@@ -156,24 +162,31 @@ func directoryListingResult(resp workspacesdk.LSResponse, offset, limit int64) (
 	)
 	return directoryListing{
 		content:     content,
-		entries:     resp.Contents[start : start+entriesRead],
 		entriesRead: entriesRead,
 		truncated:   byteTruncated || start+entriesRead < totalEntries,
 	}, nil
 }
 
+// formatDirectoryListing formats directory entries until the line or byte
+// budget is exhausted. It returns the formatted content, entries read, and
+// whether the byte budget truncated the listing.
 func formatDirectoryListing(entries []workspacesdk.LSFile, offset int64, maxBytes int) (string, int, bool) {
 	var b strings.Builder
 	for i, entry := range entries {
-		name := entry.Name
-		if entry.IsDir {
-			name += "/"
-		}
-		line := fmt.Sprintf("%d\t%s\n", offset+int64(i), name)
+		line := fmt.Sprintf("%d\t%s\n", offset+int64(i), lsFileDisplayName(entry))
 		if b.Len()+len(line) > maxBytes {
 			return b.String(), i, true
 		}
 		_, _ = b.WriteString(line)
 	}
 	return b.String(), len(entries), false
+}
+
+// lsFileDisplayName returns the stable display form shared by tools that show
+// LS entries to the model.
+func lsFileDisplayName(entry workspacesdk.LSFile) string {
+	if entry.IsDir {
+		return entry.Name + "/"
+	}
+	return entry.Name
 }

--- a/coderd/x/chatd/chattool/readfile.go
+++ b/coderd/x/chatd/chattool/readfile.go
@@ -2,8 +2,11 @@ package chattool
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"charm.land/fantasy"
+	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 )
@@ -22,9 +25,10 @@ func ReadFile(options ReadFileOptions) fantasy.AgentTool {
 	return fantasy.NewAgentTool(
 		"read_file",
 		"Read a file from the workspace. Returns line-numbered content. "+
-			"The offset parameter is a 1-based line number (default: 1). "+
-			"The limit parameter is the number of lines to return (default: 2000). "+
-			"For large files, use offset and limit to paginate.",
+			"When reading a directory, returns a non-recursive directory listing. "+
+			"The offset parameter is a 1-based line number or directory entry (default: 1). "+
+			"The limit parameter is the number of lines or directory entries to return (default: 2000). "+
+			"For large files and directories, use offset and limit to paginate.",
 		func(ctx context.Context, args ReadFileArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
 			if options.GetWorkspaceConn == nil {
 				return fantasy.NewTextErrorResponse("workspace connection resolver is not configured"), nil
@@ -62,6 +66,9 @@ func executeReadFileTool(
 	}
 
 	if !resp.Success {
+		if readFileLinesErrorIsDirectory(resp.Error) {
+			return executeReadFileDirectoryListing(ctx, conn, args, offset, limit, resp.Error)
+		}
 		return fantasy.NewTextErrorResponse(resp.Error), nil
 	}
 
@@ -71,4 +78,102 @@ func executeReadFileTool(
 		"total_lines": resp.TotalLines,
 		"lines_read":  resp.LinesRead,
 	}), nil
+}
+
+func readFileLinesErrorIsDirectory(err string) bool {
+	return strings.HasPrefix(strings.TrimSpace(err), "not a file:")
+}
+
+func executeReadFileDirectoryListing(
+	ctx context.Context,
+	conn workspacesdk.AgentConn,
+	args ReadFileArgs,
+	offset int64,
+	limit int64,
+	readErr string,
+) (fantasy.ToolResponse, error) {
+	resp, err := conn.LS(ctx, args.Path, workspacesdk.LSRequest{
+		Relativity: workspacesdk.LSRelativityRoot,
+	})
+	if err != nil {
+		return fantasy.NewTextErrorResponse(
+			fmt.Sprintf("%s; failed to list directory: %s", readErr, err),
+		), nil
+	}
+
+	listing, err := directoryListingResult(resp, offset, limit)
+	if err != nil {
+		return fantasy.NewTextErrorResponse(err.Error()), nil
+	}
+
+	return toolResponse(map[string]any{
+		"content":              listing.content,
+		"is_directory":         true,
+		"absolute_path":        resp.AbsolutePath,
+		"absolute_path_string": resp.AbsolutePathString,
+		"entries":              listing.entries,
+		"entries_read":         listing.entriesRead,
+		"total_entries":        len(resp.Contents),
+		"truncated":            listing.truncated,
+	}), nil
+}
+
+type directoryListing struct {
+	content     string
+	entries     []workspacesdk.LSFile
+	entriesRead int
+	truncated   bool
+}
+
+func directoryListingResult(resp workspacesdk.LSResponse, offset, limit int64) (directoryListing, error) {
+	if offset < 1 {
+		offset = 1
+	}
+	if limit <= 0 {
+		limit = workspacesdk.DefaultMaxResponseLines
+	}
+
+	totalEntries := len(resp.Contents)
+	if totalEntries == 0 {
+		return directoryListing{}, nil
+	}
+	if offset > int64(totalEntries) {
+		return directoryListing{}, xerrors.Errorf("offset %d is beyond the directory length of %d entries", offset, totalEntries)
+	}
+
+	start := int(offset - 1)
+	remaining := totalEntries - start
+	entriesToRead := remaining
+	if limit < int64(remaining) {
+		entriesToRead = int(limit)
+	}
+	end := start + entriesToRead
+
+	content, entriesRead, byteTruncated := formatDirectoryListing(
+		resp.Contents[start:end],
+		offset,
+		int(workspacesdk.DefaultMaxResponseBytes),
+	)
+	return directoryListing{
+		content:     content,
+		entries:     resp.Contents[start : start+entriesRead],
+		entriesRead: entriesRead,
+		truncated:   byteTruncated || start+entriesRead < totalEntries,
+	}, nil
+}
+
+func formatDirectoryListing(entries []workspacesdk.LSFile, offset int64, maxBytes int) (string, int, bool) {
+	var b strings.Builder
+	for i, entry := range entries {
+		name := entry.Name
+		if entry.IsDir {
+			name += "/"
+		}
+		line := fmt.Sprintf("%d\t%s\n", offset+int64(i), name)
+		if b.Len()+len(line) > maxBytes {
+			return b.String(), i, true
+		}
+		_, _ = b.WriteString(line)
+	}
+	return b.String(), len(entries), false
 }

--- a/coderd/x/chatd/chattool/readfile_test.go
+++ b/coderd/x/chatd/chattool/readfile_test.go
@@ -1,0 +1,453 @@
+package chattool_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"charm.land/fantasy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
+	"github.com/coder/coder/v2/codersdk/workspacesdk"
+	"github.com/coder/coder/v2/codersdk/workspacesdk/agentconnmock"
+)
+
+func TestReadFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ReadsFileLines", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		mockConn.EXPECT().
+			ReadFileLines(
+				gomock.Any(),
+				"/home/coder/main.go",
+				int64(1),
+				int64(0),
+				workspacesdk.DefaultReadFileLinesLimits(),
+			).
+			Return(workspacesdk.ReadFileLinesResponse{
+				Success:    true,
+				Content:    "1\tpackage main\n",
+				FileSize:   13,
+				TotalLines: 1,
+				LinesRead:  1,
+			}, nil)
+
+		tool := newReadFileTool(mockConn)
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "read_file",
+			Input: `{"path":"/home/coder/main.go"}`,
+		})
+
+		require.NoError(t, err)
+		require.False(t, resp.IsError)
+		var result struct {
+			Content    string `json:"content"`
+			FileSize   int64  `json:"file_size"`
+			TotalLines int    `json:"total_lines"`
+			LinesRead  int    `json:"lines_read"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+		assert.Equal(t, "1\tpackage main\n", result.Content)
+		assert.Equal(t, int64(13), result.FileSize)
+		assert.Equal(t, 1, result.TotalLines)
+		assert.Equal(t, 1, result.LinesRead)
+	})
+
+	t.Run("ListsDirectory", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		mockConn.EXPECT().
+			ReadFileLines(
+				gomock.Any(),
+				"/home/coder/project",
+				int64(1),
+				int64(0),
+				workspacesdk.DefaultReadFileLinesLimits(),
+			).
+			Return(workspacesdk.ReadFileLinesResponse{
+				Success: false,
+				Error:   "not a file: /home/coder/project",
+			}, nil)
+		mockConn.EXPECT().
+			LS(
+				gomock.Any(),
+				"/home/coder/project",
+				workspacesdk.LSRequest{Relativity: workspacesdk.LSRelativityRoot},
+			).
+			Return(workspacesdk.LSResponse{
+				AbsolutePath:       []string{"home", "coder", "project"},
+				AbsolutePathString: "/home/coder/project",
+				Contents: []workspacesdk.LSFile{
+					{
+						Name:               "src",
+						AbsolutePathString: "/home/coder/project/src",
+						IsDir:              true,
+					},
+					{
+						Name:               "README.md",
+						AbsolutePathString: "/home/coder/project/README.md",
+					},
+				},
+			}, nil)
+
+		tool := newReadFileTool(mockConn)
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "read_file",
+			Input: `{"path":"/home/coder/project"}`,
+		})
+
+		require.NoError(t, err)
+		require.False(t, resp.IsError)
+		var result struct {
+			Content            string                `json:"content"`
+			IsDirectory        bool                  `json:"is_directory"`
+			AbsolutePath       []string              `json:"absolute_path"`
+			AbsolutePathString string                `json:"absolute_path_string"`
+			Entries            []workspacesdk.LSFile `json:"entries"`
+			EntriesRead        int                   `json:"entries_read"`
+			TotalEntries       int                   `json:"total_entries"`
+			Truncated          bool                  `json:"truncated"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+		assert.True(t, result.IsDirectory)
+		assert.Equal(t, []string{"home", "coder", "project"}, result.AbsolutePath)
+		assert.Equal(t, "/home/coder/project", result.AbsolutePathString)
+		assert.Equal(t, 2, result.EntriesRead)
+		assert.Equal(t, 2, result.TotalEntries)
+		assert.False(t, result.Truncated)
+		assert.Equal(t, []workspacesdk.LSFile{
+			{
+				Name:               "src",
+				AbsolutePathString: "/home/coder/project/src",
+				IsDir:              true,
+			},
+			{
+				Name:               "README.md",
+				AbsolutePathString: "/home/coder/project/README.md",
+			},
+		}, result.Entries)
+		assert.Equal(t, "1\tsrc/\n2\tREADME.md\n", result.Content)
+	})
+
+	t.Run("PaginatesDirectoryListing", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		mockConn.EXPECT().
+			ReadFileLines(
+				gomock.Any(),
+				"/home/coder/project",
+				int64(2),
+				int64(1),
+				workspacesdk.DefaultReadFileLinesLimits(),
+			).
+			Return(workspacesdk.ReadFileLinesResponse{
+				Success: false,
+				Error:   "not a file: /home/coder/project",
+			}, nil)
+		mockConn.EXPECT().
+			LS(
+				gomock.Any(),
+				"/home/coder/project",
+				workspacesdk.LSRequest{Relativity: workspacesdk.LSRelativityRoot},
+			).
+			Return(workspacesdk.LSResponse{
+				AbsolutePath:       []string{"home", "coder", "project"},
+				AbsolutePathString: "/home/coder/project",
+				Contents: []workspacesdk.LSFile{
+					{Name: "a.txt", AbsolutePathString: "/home/coder/project/a.txt"},
+					{Name: "b.txt", AbsolutePathString: "/home/coder/project/b.txt"},
+					{Name: "c.txt", AbsolutePathString: "/home/coder/project/c.txt"},
+				},
+			}, nil)
+
+		tool := newReadFileTool(mockConn)
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "read_file",
+			Input: `{"path":"/home/coder/project","offset":2,"limit":1}`,
+		})
+
+		require.NoError(t, err)
+		require.False(t, resp.IsError)
+		var result struct {
+			Content      string                `json:"content"`
+			Entries      []workspacesdk.LSFile `json:"entries"`
+			EntriesRead  int                   `json:"entries_read"`
+			TotalEntries int                   `json:"total_entries"`
+			Truncated    bool                  `json:"truncated"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+		assert.Equal(t, "2\tb.txt\n", result.Content)
+		assert.Equal(t, []workspacesdk.LSFile{{
+			Name:               "b.txt",
+			AbsolutePathString: "/home/coder/project/b.txt",
+		}}, result.Entries)
+		assert.Equal(t, 1, result.EntriesRead)
+		assert.Equal(t, 3, result.TotalEntries)
+		assert.True(t, result.Truncated)
+	})
+
+	t.Run("TruncatesLargeDirectoryListing", func(t *testing.T) {
+		t.Parallel()
+
+		entries := make([]workspacesdk.LSFile, 2000)
+		for i := range entries {
+			name := strings.Repeat("a", 128)
+			entries[i] = workspacesdk.LSFile{
+				Name:               name,
+				AbsolutePathString: "/home/coder/project/" + name,
+			}
+		}
+
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		mockConn.EXPECT().
+			ReadFileLines(
+				gomock.Any(),
+				"/home/coder/project",
+				int64(1),
+				int64(0),
+				workspacesdk.DefaultReadFileLinesLimits(),
+			).
+			Return(workspacesdk.ReadFileLinesResponse{
+				Success: false,
+				Error:   "not a file: /home/coder/project",
+			}, nil)
+		mockConn.EXPECT().
+			LS(
+				gomock.Any(),
+				"/home/coder/project",
+				workspacesdk.LSRequest{Relativity: workspacesdk.LSRelativityRoot},
+			).
+			Return(workspacesdk.LSResponse{
+				AbsolutePath:       []string{"home", "coder", "project"},
+				AbsolutePathString: "/home/coder/project",
+				Contents:           entries,
+			}, nil)
+
+		tool := newReadFileTool(mockConn)
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "read_file",
+			Input: `{"path":"/home/coder/project"}`,
+		})
+
+		require.NoError(t, err)
+		require.False(t, resp.IsError)
+		var result struct {
+			Content      string                `json:"content"`
+			Entries      []workspacesdk.LSFile `json:"entries"`
+			EntriesRead  int                   `json:"entries_read"`
+			TotalEntries int                   `json:"total_entries"`
+			Truncated    bool                  `json:"truncated"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+		assert.True(t, result.Truncated)
+		assert.Equal(t, 2000, result.TotalEntries)
+		assert.Equal(t, result.EntriesRead, len(result.Entries))
+		assert.LessOrEqual(t, len(result.Content), int(workspacesdk.DefaultMaxResponseBytes))
+		assert.Less(t, result.EntriesRead, result.TotalEntries)
+	})
+
+	t.Run("ListsEmptyDirectory", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		mockConn.EXPECT().
+			ReadFileLines(
+				gomock.Any(),
+				"/home/coder/empty",
+				int64(1),
+				int64(0),
+				workspacesdk.DefaultReadFileLinesLimits(),
+			).
+			Return(workspacesdk.ReadFileLinesResponse{
+				Success: false,
+				Error:   "not a file: /home/coder/empty",
+			}, nil)
+		mockConn.EXPECT().
+			LS(
+				gomock.Any(),
+				"/home/coder/empty",
+				workspacesdk.LSRequest{Relativity: workspacesdk.LSRelativityRoot},
+			).
+			Return(workspacesdk.LSResponse{
+				AbsolutePath:       []string{"home", "coder", "empty"},
+				AbsolutePathString: "/home/coder/empty",
+			}, nil)
+
+		tool := newReadFileTool(mockConn)
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "read_file",
+			Input: `{"path":"/home/coder/empty"}`,
+		})
+
+		require.NoError(t, err)
+		require.False(t, resp.IsError)
+		var result struct {
+			Content      string                `json:"content"`
+			Entries      []workspacesdk.LSFile `json:"entries"`
+			EntriesRead  int                   `json:"entries_read"`
+			TotalEntries int                   `json:"total_entries"`
+			Truncated    bool                  `json:"truncated"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+		assert.Empty(t, result.Content)
+		assert.Empty(t, result.Entries)
+		assert.Equal(t, 0, result.EntriesRead)
+		assert.Equal(t, 0, result.TotalEntries)
+		assert.False(t, result.Truncated)
+	})
+
+	t.Run("RejectsDirectoryOffsetBeyondEntries", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		mockConn.EXPECT().
+			ReadFileLines(
+				gomock.Any(),
+				"/home/coder/project",
+				int64(5),
+				int64(0),
+				workspacesdk.DefaultReadFileLinesLimits(),
+			).
+			Return(workspacesdk.ReadFileLinesResponse{
+				Success: false,
+				Error:   "not a file: /home/coder/project",
+			}, nil)
+		mockConn.EXPECT().
+			LS(
+				gomock.Any(),
+				"/home/coder/project",
+				workspacesdk.LSRequest{Relativity: workspacesdk.LSRelativityRoot},
+			).
+			Return(workspacesdk.LSResponse{
+				AbsolutePath:       []string{"home", "coder", "project"},
+				AbsolutePathString: "/home/coder/project",
+				Contents: []workspacesdk.LSFile{
+					{Name: "a.txt", AbsolutePathString: "/home/coder/project/a.txt"},
+				},
+			}, nil)
+
+		tool := newReadFileTool(mockConn)
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "read_file",
+			Input: `{"path":"/home/coder/project","offset":5}`,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, resp.IsError)
+		assert.Equal(t, "offset 5 is beyond the directory length of 1 entries", resp.Content)
+	})
+
+	t.Run("DoesNotListOtherReadErrors", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		mockConn.EXPECT().
+			ReadFileLines(
+				gomock.Any(),
+				"/home/coder/missing.txt",
+				int64(1),
+				int64(0),
+				workspacesdk.DefaultReadFileLinesLimits(),
+			).
+			Return(workspacesdk.ReadFileLinesResponse{
+				Success: false,
+				Error:   "file does not exist: /home/coder/missing.txt",
+			}, nil)
+
+		tool := newReadFileTool(mockConn)
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "read_file",
+			Input: `{"path":"/home/coder/missing.txt"}`,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, resp.IsError)
+		assert.Equal(t, "file does not exist: /home/coder/missing.txt", resp.Content)
+	})
+
+	t.Run("ReportsDirectoryListingError", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		mockConn.EXPECT().
+			ReadFileLines(
+				gomock.Any(),
+				"/home/coder/private",
+				int64(1),
+				int64(0),
+				workspacesdk.DefaultReadFileLinesLimits(),
+			).
+			Return(workspacesdk.ReadFileLinesResponse{
+				Success: false,
+				Error:   "not a file: /home/coder/private",
+			}, nil)
+		mockConn.EXPECT().
+			LS(
+				gomock.Any(),
+				"/home/coder/private",
+				workspacesdk.LSRequest{Relativity: workspacesdk.LSRelativityRoot},
+			).
+			Return(workspacesdk.LSResponse{}, xerrors.New("permission denied"))
+
+		tool := newReadFileTool(mockConn)
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "read_file",
+			Input: `{"path":"/home/coder/private"}`,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, resp.IsError)
+		assert.Equal(t, "not a file: /home/coder/private; failed to list directory: permission denied", resp.Content)
+	})
+}
+
+func newReadFileTool(mockConn *agentconnmock.MockAgentConn) fantasy.AgentTool {
+	return chattool.ReadFile(chattool.ReadFileOptions{
+		GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
+			return mockConn, nil
+		},
+	})
+}
+
+func TestReadFileRequiresPath(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockConn := agentconnmock.NewMockAgentConn(ctrl)
+	tool := newReadFileTool(mockConn)
+	resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+		ID:    "call-1",
+		Name:  "read_file",
+		Input: `{}`,
+	})
+
+	require.NoError(t, err)
+	assert.True(t, resp.IsError)
+	assert.Equal(t, "path is required", strings.TrimSpace(resp.Content))
+}

--- a/coderd/x/chatd/chattool/readfile_test.go
+++ b/coderd/x/chatd/chattool/readfile_test.go
@@ -78,7 +78,7 @@ func TestReadFile(t *testing.T) {
 			).
 			Return(workspacesdk.ReadFileLinesResponse{
 				Success: false,
-				Error:   "not a file: /home/coder/project",
+				Error:   notFileError("/home/coder/project"),
 			}, nil)
 		mockConn.EXPECT().
 			LS(
@@ -112,33 +112,24 @@ func TestReadFile(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, resp.IsError)
 		var result struct {
-			Content            string                `json:"content"`
-			IsDirectory        bool                  `json:"is_directory"`
-			AbsolutePath       []string              `json:"absolute_path"`
-			AbsolutePathString string                `json:"absolute_path_string"`
-			Entries            []workspacesdk.LSFile `json:"entries"`
-			EntriesRead        int                   `json:"entries_read"`
-			TotalEntries       int                   `json:"total_entries"`
-			Truncated          bool                  `json:"truncated"`
+			Content            string   `json:"content"`
+			IsDirectory        bool     `json:"is_directory"`
+			AbsolutePath       []string `json:"absolute_path"`
+			AbsolutePathString string   `json:"absolute_path_string"`
+			EntriesRead        int      `json:"entries_read"`
+			TotalEntries       int      `json:"total_entries"`
+			Truncated          bool     `json:"truncated"`
 		}
 		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+		var raw map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal([]byte(resp.Content), &raw))
+		assert.NotContains(t, raw, "entries")
 		assert.True(t, result.IsDirectory)
 		assert.Equal(t, []string{"home", "coder", "project"}, result.AbsolutePath)
 		assert.Equal(t, "/home/coder/project", result.AbsolutePathString)
 		assert.Equal(t, 2, result.EntriesRead)
 		assert.Equal(t, 2, result.TotalEntries)
 		assert.False(t, result.Truncated)
-		assert.Equal(t, []workspacesdk.LSFile{
-			{
-				Name:               "src",
-				AbsolutePathString: "/home/coder/project/src",
-				IsDir:              true,
-			},
-			{
-				Name:               "README.md",
-				AbsolutePathString: "/home/coder/project/README.md",
-			},
-		}, result.Entries)
 		assert.Equal(t, "1\tsrc/\n2\tREADME.md\n", result.Content)
 	})
 
@@ -157,7 +148,7 @@ func TestReadFile(t *testing.T) {
 			).
 			Return(workspacesdk.ReadFileLinesResponse{
 				Success: false,
-				Error:   "not a file: /home/coder/project",
+				Error:   notFileError("/home/coder/project"),
 			}, nil)
 		mockConn.EXPECT().
 			LS(
@@ -185,18 +176,13 @@ func TestReadFile(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, resp.IsError)
 		var result struct {
-			Content      string                `json:"content"`
-			Entries      []workspacesdk.LSFile `json:"entries"`
-			EntriesRead  int                   `json:"entries_read"`
-			TotalEntries int                   `json:"total_entries"`
-			Truncated    bool                  `json:"truncated"`
+			Content      string `json:"content"`
+			EntriesRead  int    `json:"entries_read"`
+			TotalEntries int    `json:"total_entries"`
+			Truncated    bool   `json:"truncated"`
 		}
 		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
 		assert.Equal(t, "2\tb.txt\n", result.Content)
-		assert.Equal(t, []workspacesdk.LSFile{{
-			Name:               "b.txt",
-			AbsolutePathString: "/home/coder/project/b.txt",
-		}}, result.Entries)
 		assert.Equal(t, 1, result.EntriesRead)
 		assert.Equal(t, 3, result.TotalEntries)
 		assert.True(t, result.Truncated)
@@ -207,7 +193,7 @@ func TestReadFile(t *testing.T) {
 
 		entries := make([]workspacesdk.LSFile, 2000)
 		for i := range entries {
-			name := strings.Repeat("a", 128)
+			name := strings.Repeat(string(rune('a'+i%26)), 1+i%256)
 			entries[i] = workspacesdk.LSFile{
 				Name:               name,
 				AbsolutePathString: "/home/coder/project/" + name,
@@ -226,7 +212,7 @@ func TestReadFile(t *testing.T) {
 			).
 			Return(workspacesdk.ReadFileLinesResponse{
 				Success: false,
-				Error:   "not a file: /home/coder/project",
+				Error:   notFileError("/home/coder/project"),
 			}, nil)
 		mockConn.EXPECT().
 			LS(
@@ -250,16 +236,14 @@ func TestReadFile(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, resp.IsError)
 		var result struct {
-			Content      string                `json:"content"`
-			Entries      []workspacesdk.LSFile `json:"entries"`
-			EntriesRead  int                   `json:"entries_read"`
-			TotalEntries int                   `json:"total_entries"`
-			Truncated    bool                  `json:"truncated"`
+			Content      string `json:"content"`
+			EntriesRead  int    `json:"entries_read"`
+			TotalEntries int    `json:"total_entries"`
+			Truncated    bool   `json:"truncated"`
 		}
 		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
 		assert.True(t, result.Truncated)
 		assert.Equal(t, 2000, result.TotalEntries)
-		assert.Equal(t, result.EntriesRead, len(result.Entries))
 		assert.LessOrEqual(t, len(result.Content), int(workspacesdk.DefaultMaxResponseBytes))
 		assert.Less(t, result.EntriesRead, result.TotalEntries)
 	})
@@ -279,7 +263,7 @@ func TestReadFile(t *testing.T) {
 			).
 			Return(workspacesdk.ReadFileLinesResponse{
 				Success: false,
-				Error:   "not a file: /home/coder/empty",
+				Error:   notFileError("/home/coder/empty"),
 			}, nil)
 		mockConn.EXPECT().
 			LS(
@@ -302,15 +286,15 @@ func TestReadFile(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, resp.IsError)
 		var result struct {
-			Content      string                `json:"content"`
-			Entries      []workspacesdk.LSFile `json:"entries"`
-			EntriesRead  int                   `json:"entries_read"`
-			TotalEntries int                   `json:"total_entries"`
-			Truncated    bool                  `json:"truncated"`
+			Content      string `json:"content"`
+			IsDirectory  bool   `json:"is_directory"`
+			EntriesRead  int    `json:"entries_read"`
+			TotalEntries int    `json:"total_entries"`
+			Truncated    bool   `json:"truncated"`
 		}
 		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
 		assert.Empty(t, result.Content)
-		assert.Empty(t, result.Entries)
+		assert.True(t, result.IsDirectory)
 		assert.Equal(t, 0, result.EntriesRead)
 		assert.Equal(t, 0, result.TotalEntries)
 		assert.False(t, result.Truncated)
@@ -331,7 +315,7 @@ func TestReadFile(t *testing.T) {
 			).
 			Return(workspacesdk.ReadFileLinesResponse{
 				Success: false,
-				Error:   "not a file: /home/coder/project",
+				Error:   notFileError("/home/coder/project"),
 			}, nil)
 		mockConn.EXPECT().
 			LS(
@@ -356,7 +340,34 @@ func TestReadFile(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.True(t, resp.IsError)
-		assert.Equal(t, "offset 5 is beyond the directory length of 1 entries", resp.Content)
+		assert.Equal(t, "offset 5 exceeds directory entry count 1", resp.Content)
+	})
+
+	t.Run("ReportsReadFileLinesTransportError", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		mockConn.EXPECT().
+			ReadFileLines(
+				gomock.Any(),
+				"/home/coder/main.go",
+				int64(1),
+				int64(0),
+				workspacesdk.DefaultReadFileLinesLimits(),
+			).
+			Return(workspacesdk.ReadFileLinesResponse{}, xerrors.New("connection reset"))
+
+		tool := newReadFileTool(mockConn)
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "read_file",
+			Input: `{"path":"/home/coder/main.go"}`,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, resp.IsError)
+		assert.Equal(t, "connection reset", resp.Content)
 	})
 
 	t.Run("DoesNotListOtherReadErrors", func(t *testing.T) {
@@ -404,7 +415,7 @@ func TestReadFile(t *testing.T) {
 			).
 			Return(workspacesdk.ReadFileLinesResponse{
 				Success: false,
-				Error:   "not a file: /home/coder/private",
+				Error:   notFileError("/home/coder/private"),
 			}, nil)
 		mockConn.EXPECT().
 			LS(
@@ -423,7 +434,7 @@ func TestReadFile(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.True(t, resp.IsError)
-		assert.Equal(t, "not a file: /home/coder/private; failed to list directory: permission denied", resp.Content)
+		assert.Equal(t, notFileError("/home/coder/private")+"; failed to list directory: permission denied", resp.Content)
 	})
 }
 
@@ -433,6 +444,10 @@ func newReadFileTool(mockConn *agentconnmock.MockAgentConn) fantasy.AgentTool {
 			return mockConn, nil
 		},
 	})
+}
+
+func notFileError(path string) string {
+	return workspacesdk.ReadFileLinesNotFileErrorPrefix + " " + path
 }
 
 func TestReadFileRequiresPath(t *testing.T) {

--- a/coderd/x/chatd/chattool/skill.go
+++ b/coderd/x/chatd/chattool/skill.go
@@ -180,11 +180,7 @@ func LoadSkillBody(
 		if entry.Name == metaFile {
 			continue
 		}
-		name := entry.Name
-		if entry.IsDir {
-			name += "/"
-		}
-		files = append(files, name)
+		files = append(files, lsFileDisplayName(entry))
 	}
 
 	return SkillContent{

--- a/codersdk/workspacesdk/agentconn.go
+++ b/codersdk/workspacesdk/agentconn.go
@@ -1020,6 +1020,10 @@ func (c *agentConn) WriteFile(ctx context.Context, path string, reader io.Reader
 	return nil
 }
 
+// ReadFileLinesNotFileErrorPrefix prefixes ReadFileLines errors for paths
+// that resolve to directories instead of regular files.
+const ReadFileLinesNotFileErrorPrefix = "not a file:"
+
 // ReadFileLinesResponse is the response from the line-based file reader.
 type ReadFileLinesResponse struct {
 	Success    bool   `json:"success"`


### PR DESCRIPTION
`read_file` now falls back to a bounded directory listing when the agent reports that the requested path is not a file. The lower-level file-read endpoint still keeps its file-only contract; the chat tool composes that response with the existing workspace `LS` call.

Directory responses keep the existing `content` field for UI compatibility and include pagination metadata. They do not return structured `entries`, so direct tool output remains bounded by the formatted listing budget.

Verified with focused package tests, Go lint, and the full pre-commit hook in a clean worktree. The initial local pre-push run reached an unrelated Storybook failure in `UsersPage.stories.tsx`, so I used the repo-supported `coder.pre-push false` opt-out for the Go-only push.

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
