### PR TITLE
feat(site): show org default roles in member role editor

### DIFF
--- a/site/src/modules/roles/RoleSelector.stories.tsx
+++ b/site/src/modules/roles/RoleSelector.stories.tsx
@@ -89,3 +89,13 @@ export const OrganizationMemberRoles: Story = {
 		availableRoles: orgMemberRoles,
 	},
 };
+
+export const WithAdditionalImpliedRoles: Story = {
+	args: {
+		availableRoles: orgMemberRoles,
+		additionalImpliedRoles: [
+			assignableRole(MockAgentsAccessRole, true),
+			assignableRole(MockOrganizationAuditorRole, true),
+		],
+	},
+};

--- a/site/src/modules/roles/RoleSelector.tsx
+++ b/site/src/modules/roles/RoleSelector.tsx
@@ -16,6 +16,14 @@ type RoleSelectorProps = {
 	loading?: boolean;
 	error?: unknown;
 	availableRoles?: AssignableRoles[];
+	/**
+	 * Extra roles to display below `Member` as always-granted (implied)
+	 * rows. Used by the org members editor to surface the organization's
+	 * `default_org_member_roles` alongside the built-in `member` role.
+	 * Roles listed here are filtered out of the selectable list because
+	 * users cannot toggle implied roles.
+	 */
+	additionalImpliedRoles?: AssignableRoles[];
 	selectedRoles: Set<string>;
 	onChange: (roles: Set<string>) => void;
 };
@@ -25,6 +33,7 @@ export const RoleSelector: FC<RoleSelectorProps> = ({
 	loading,
 	error,
 	availableRoles = [],
+	additionalImpliedRoles = [],
 	selectedRoles,
 	onChange,
 }) => {
@@ -32,7 +41,7 @@ export const RoleSelector: FC<RoleSelectorProps> = ({
 		return (
 			<RoleSelectorLayout>
 				<RoleSelectorSkeleton />
-				<MemberRole />
+				<ImpliedRolesList additionalImpliedRoles={additionalImpliedRoles} />
 			</RoleSelectorLayout>
 		);
 	}
@@ -49,8 +58,11 @@ export const RoleSelector: FC<RoleSelectorProps> = ({
 		);
 	}
 
+	const impliedRoleNames = new Set(additionalImpliedRoles.map((r) => r.name));
 	const { selectableRoles = [], advancedRoles = [] } = Object.groupBy(
-		availableRoles.filter((r) => r.name !== "member"),
+		availableRoles.filter(
+			(r) => r.name !== "member" && !impliedRoleNames.has(r.name),
+		),
 		(it) =>
 			advancedRoleNames.includes(it.name) ? "advancedRoles" : "selectableRoles",
 	);
@@ -80,7 +92,7 @@ export const RoleSelector: FC<RoleSelectorProps> = ({
 				/>
 			)}
 
-			<MemberRole />
+			<ImpliedRolesList additionalImpliedRoles={additionalImpliedRoles} />
 		</RoleSelectorLayout>
 	);
 };
@@ -182,13 +194,42 @@ const RoleSelectorLayout: React.FC<RoleSelectorLayoutProps> = ({
 	);
 };
 
-const MemberRole: React.FC = () => {
+type ImpliedRolesListProps = {
+	additionalImpliedRoles: AssignableRoles[];
+};
+
+const ImpliedRolesList: React.FC<ImpliedRolesListProps> = ({
+	additionalImpliedRoles,
+}) => {
+	return (
+		<>
+			<ImpliedRoleRow title="Member" description={roleDescriptions.member} />
+			{additionalImpliedRoles.map((role) => (
+				<ImpliedRoleRow
+					key={role.name}
+					title={role.display_name || role.name}
+					description={roleDescriptions[role.name] ?? ""}
+				/>
+			))}
+		</>
+	);
+};
+
+type ImpliedRoleRowProps = {
+	title: string;
+	description: string;
+};
+
+const ImpliedRoleRow: React.FC<ImpliedRoleRowProps> = ({
+	title,
+	description,
+}) => {
 	return (
 		<div className="border-t border-border py-2 flex items-start gap-2 text-content-disabled">
 			<UserIcon className="size-4 mt-1 shrink-0" />
 			<div className="flex flex-col">
-				<span className="text-sm font-medium">Member</span>
-				<span className="text-sm">{roleDescriptions.member}</span>
+				<span className="text-sm font-medium">{title}</span>
+				{description && <span className="text-sm">{description}</span>}
 			</div>
 		</div>
 	);

--- a/site/src/modules/roles/RoleSelector.tsx
+++ b/site/src/modules/roles/RoleSelector.tsx
@@ -16,13 +16,6 @@ type RoleSelectorProps = {
 	loading?: boolean;
 	error?: unknown;
 	availableRoles?: AssignableRoles[];
-	/**
-	 * Extra roles to display below `Member` as always-granted (implied)
-	 * rows. Used by the org members editor to surface the organization's
-	 * `default_org_member_roles` alongside the built-in `member` role.
-	 * Roles listed here are filtered out of the selectable list because
-	 * users cannot toggle implied roles.
-	 */
 	additionalImpliedRoles?: AssignableRoles[];
 	selectedRoles: Set<string>;
 	onChange: (roles: Set<string>) => void;

--- a/site/src/modules/roles/RoleSelector.tsx
+++ b/site/src/modules/roles/RoleSelector.tsx
@@ -209,6 +209,7 @@ const ImpliedRolesList: React.FC<ImpliedRolesListProps> = ({
 					key={role.name}
 					title={role.display_name || role.name}
 					description={roleDescriptions[role.name] ?? ""}
+					caption="Sourced from organization default roles"
 				/>
 			))}
 		</>
@@ -218,11 +219,13 @@ const ImpliedRolesList: React.FC<ImpliedRolesListProps> = ({
 type ImpliedRoleRowProps = {
 	title: string;
 	description: string;
+	caption?: string;
 };
 
 const ImpliedRoleRow: React.FC<ImpliedRoleRowProps> = ({
 	title,
 	description,
+	caption,
 }) => {
 	return (
 		<div className="border-t border-border py-2 flex items-start gap-2 text-content-disabled">
@@ -230,6 +233,7 @@ const ImpliedRoleRow: React.FC<ImpliedRoleRowProps> = ({
 			<div className="flex flex-col">
 				<span className="text-sm font-medium">{title}</span>
 				{description && <span className="text-sm">{description}</span>}
+				{caption && <span className="text-xs italic">{caption}</span>}
 			</div>
 		</div>
 	);

--- a/site/src/modules/roles/RoleSelectorDialog.tsx
+++ b/site/src/modules/roles/RoleSelectorDialog.tsx
@@ -20,6 +20,12 @@ type RoleSelectorDialogProps = {
 	user?: ThingWithRoles;
 	/** The roles available in this context that can be given or removed from the user */
 	availableRoles?: AssignableRoles[];
+	/**
+	 * Extra roles to display as always-granted (implied) below `Member`.
+	 * Pass through to the underlying selector. Used on the org members
+	 * editor to surface the org's `default_org_member_roles`.
+	 */
+	additionalImpliedRoles?: AssignableRoles[];
 
 	onCancel: () => void;
 	onUpdateRoles: (roles: string[]) => Promise<void>;
@@ -36,6 +42,7 @@ type ThingWithRoles = {
 export const RoleSelectorDialog: React.FC<RoleSelectorDialogProps> = ({
 	user,
 	availableRoles = [],
+	additionalImpliedRoles = [],
 	onCancel,
 	onUpdateRoles,
 	isUpdatingRoles,
@@ -48,6 +55,7 @@ export const RoleSelectorDialog: React.FC<RoleSelectorDialogProps> = ({
 		<ActiveRoleSelectorDialog
 			user={user}
 			availableRoles={availableRoles}
+			additionalImpliedRoles={additionalImpliedRoles}
 			onCancel={onCancel}
 			onUpdateRoles={onUpdateRoles}
 			isUpdatingRoles={isUpdatingRoles}
@@ -58,6 +66,7 @@ export const RoleSelectorDialog: React.FC<RoleSelectorDialogProps> = ({
 const ActiveRoleSelectorDialog: React.FC<Required<RoleSelectorDialogProps>> = ({
 	user,
 	availableRoles,
+	additionalImpliedRoles,
 	onCancel,
 	onUpdateRoles,
 	isUpdatingRoles,
@@ -89,6 +98,7 @@ const ActiveRoleSelectorDialog: React.FC<Required<RoleSelectorDialogProps>> = ({
 				<RoleSelector
 					hideLabel
 					availableRoles={availableRoles}
+					additionalImpliedRoles={additionalImpliedRoles}
 					selectedRoles={selectedRoles}
 					onChange={setSelectedRoles}
 				/>

--- a/site/src/modules/roles/RoleSelectorDialog.tsx
+++ b/site/src/modules/roles/RoleSelectorDialog.tsx
@@ -20,11 +20,6 @@ type RoleSelectorDialogProps = {
 	user?: ThingWithRoles;
 	/** The roles available in this context that can be given or removed from the user */
 	availableRoles?: AssignableRoles[];
-	/**
-	 * Extra roles to display as always-granted (implied) below `Member`.
-	 * Pass through to the underlying selector. Used on the org members
-	 * editor to surface the org's `default_org_member_roles`.
-	 */
 	additionalImpliedRoles?: AssignableRoles[];
 
 	onCancel: () => void;

--- a/site/src/pages/OrganizationSettingsPage/OrganizationMembersPage.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationMembersPage.tsx
@@ -1,4 +1,4 @@
-import { type FC, useState } from "react";
+import { type FC, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { useParams, useSearchParams } from "react-router";
 import { toast } from "sonner";
@@ -12,6 +12,7 @@ import {
 } from "#/api/queries/organizations";
 import { organizationRoles } from "#/api/queries/roles";
 import type {
+	AssignableRoles,
 	OrganizationMemberWithUserData,
 	User,
 } from "#/api/typesGenerated";
@@ -35,9 +36,10 @@ const OrganizationMembersPage: FC = () => {
 		organization: string;
 	};
 	const { organization, organizationPermissions } = useOrganizationSettings();
-	const { entitlements } = useDashboard();
+	const { entitlements, experiments } = useDashboard();
 	const searchParamsResult = useSearchParams();
 	const showAISeatColumn = shouldShowAISeatColumn(entitlements);
+	const defaultRolesEnabled = experiments.includes("minimum-implicit-member");
 
 	const organizationRolesQuery = useQuery(organizationRoles(organizationName));
 	const groupsByUserIdQuery = useQuery(
@@ -75,6 +77,25 @@ const OrganizationMembersPage: FC = () => {
 	const removeMemberMutation = useMutation(
 		removeOrganizationMember(queryClient, organizationName),
 	);
+
+	// Resolve the org's default member role names against the assignable
+	// roles list so the dialog can show full display names + descriptions.
+	const defaultMemberImpliedRoles = useMemo<AssignableRoles[]>(() => {
+		if (!defaultRolesEnabled) {
+			return [];
+		}
+		const available = organizationRolesQuery.data;
+		if (!available) {
+			return [];
+		}
+		return (organization?.default_org_member_roles ?? [])
+			.map((name) => available.find((r) => r.name === name))
+			.filter((r): r is AssignableRoles => r !== undefined);
+	}, [
+		defaultRolesEnabled,
+		organization?.default_org_member_roles,
+		organizationRolesQuery.data,
+	]);
 
 	if (!organization) {
 		return <EmptyState message="Organization not found" />;
@@ -133,6 +154,7 @@ const OrganizationMembersPage: FC = () => {
 				key={memberToEditRoles?.username}
 				user={memberToEditRoles}
 				availableRoles={organizationRolesQuery.data}
+				additionalImpliedRoles={defaultMemberImpliedRoles}
 				onCancel={() => setMemberToEditRoles(undefined)}
 				onUpdateRoles={async (roles) => {
 					try {


### PR DESCRIPTION
<!-- Authored with Coder Agents on behalf of @Emyrk -->

Refs #25936. Stacks on #26028.

Surfaces the org's `default_org_member_roles` inside the org members role editor. These roles are implied, not physically assigned to any member. Just like the `member` role. 

Configured in the org settings.


<img width="545" height="666" alt="Screenshot From 2026-06-05 12-41-39" src="https://github.com/user-attachments/assets/2545059f-fc7e-4d39-abd6-ee32c044922c" />



<details><summary>Implementation notes</summary>

- The previous `MemberRole` row was generalized into a small `ImpliedRoleRow`. `Member` is the first row; any `additionalImpliedRoles` follow in order. Both share the same disabled style.
- The Roles page's `DefaultRolesDialog` deliberately does not pass `additionalImpliedRoles`. That editor is where defaults are configured, so showing them as implied there would be circular.
- If a role is both explicitly assigned to a user and listed as a default, the existing assignment stays in the selected set on save (the checkbox just isn't visible). The set sent to the PATCH is unchanged, which keeps the backend authoritative for "default ∪ explicit".

</details>

<sub>Coder Agents on behalf of @Emyrk.</sub>
