### PR TITLE
fix(dogfood/coder): disable gh terminal color probes

### DIFF
--- a/dogfood/coder/ubuntu-22.04/files/usr/local/bin/gh
+++ b/dogfood/coder/ubuntu-22.04/files/usr/local/bin/gh
@@ -10,6 +10,11 @@
 
 REAL_GH="/usr/bin/gh"
 
+# ENG-2842: prevent gh from probing terminal colors before interactive prompts.
+if [ -z "${NO_COLOR+x}" ]; then
+  export NO_COLOR=1
+fi
+
 # If GH_TOKEN or GITHUB_TOKEN is already set, defer to the real gh.
 if [ -n "${GH_TOKEN:-}" ] || [ -n "${GITHUB_TOKEN:-}" ]; then
   exec "$REAL_GH" "$@"

--- a/dogfood/coder/ubuntu-26.04/files/usr/local/bin/gh
+++ b/dogfood/coder/ubuntu-26.04/files/usr/local/bin/gh
@@ -10,6 +10,11 @@
 
 REAL_GH="/usr/bin/gh"
 
+# ENG-2842: prevent gh from probing terminal colors before interactive prompts.
+if [ -z "${NO_COLOR+x}" ]; then
+  export NO_COLOR=1
+fi
+
 # If GH_TOKEN or GITHUB_TOKEN is already set, defer to the real gh.
 if [ -n "${GH_TOKEN:-}" ] || [ -n "${GITHUB_TOKEN:-}" ]; then
   exec "$REAL_GH" "$@"


### PR DESCRIPTION
Newer GitHub CLI versions probe terminal colors before interactive prompts, which can leave OSC responses in dogfood web terminal stdin and break `gh auth login`.

Default `NO_COLOR=1` inside the dogfood `/usr/local/bin/gh` wrappers when callers have not set it themselves. This avoids the color probe without pinning or downgrading `gh`, and keeps the existing Coder external-auth wrapper behavior intact.

Refs ENG-2842.

<details>
<summary>Coder Agents disclosure</summary>

This PR was generated by Coder Agents on behalf of @johnstcn.

</details>
