### PR TITLE
fix(site): delink agent health from script failures

### DIFF
--- a/site/src/modules/resources/AgentRow.stories.tsx
+++ b/site/src/modules/resources/AgentRow.stories.tsx
@@ -216,7 +216,7 @@ export const ConnectingWithStartupLogs: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 
-		// Agent is connecting (hasAgentIssues=true) but no script has failed.
+		// Agent is connecting (hasConnectivityIssues=true) but no script has failed.
 		// Old code snapped to the Startup Script tab; the fix keeps us on All Logs.
 		const allLogsTab = await canvas.findByRole("tab", { name: "All Logs" });
 		await waitFor(() =>

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -58,10 +58,7 @@ import {
 import { useProxy } from "#/contexts/ProxyContext";
 import { useClipboard } from "#/hooks/useClipboard";
 import { useFeatureVisibility } from "#/modules/dashboard/useFeatureVisibility";
-import {
-	getAgentConnectivityIssues,
-	getAgentHealthIssues,
-} from "#/modules/workspaces/health";
+import { getAgentConnectivityIssues } from "#/modules/workspaces/health";
 import { AgentAlert } from "#/pages/WorkspacePage/AgentAlert";
 import { AppStatuses } from "#/pages/WorkspacePage/AppStatuses";
 import { cn } from "#/utils/cn";
@@ -107,9 +104,9 @@ const statusBorderClassByLifecycle: Partial<
 	starting: "border-border-pending",
 	shutting_down: "border-border-pending",
 	ready: "border-border-success",
-	start_timeout: "border-border-warning",
+	start_timeout: "border-border-success",
 	shutdown_timeout: "border-border-warning",
-	start_error: "border-border-warning",
+	start_error: "border-border-success",
 	shutdown_error: "border-border-warning",
 	off: "border-border",
 };
@@ -171,8 +168,6 @@ export const AgentRow: FC<AgentRowProps> = ({
 	const hasWarningConnectivityIssues = connectivityIssues.some(
 		(i) => i.severity === "warning",
 	);
-	// Get all issues (connectivity + script) for the logs panel alerts.
-	const healthIssues = getAgentHealthIssues(agent);
 	const { proxy } = useProxy();
 	const [showLogs, setShowLogs] = useState(
 		(["starting", "start_timeout"].includes(agent.lifecycle_state) ||
@@ -340,7 +335,8 @@ export const AgentRow: FC<AgentRowProps> = ({
 		...sortedSourceLogTabs,
 	];
 	const hasAnyLogs = agentLogs.length > 0;
-	const shouldExpandLogs = showLogs || (!hasStartupFeatures && hasAgentIssues);
+	const shouldExpandLogs =
+		showLogs || (!hasStartupFeatures && hasConnectivityIssues);
 	const shouldShowLogsTabs = hasStartupFeatures && hasAnyLogs;
 	const logTabsMeasureEnabled = shouldShowLogsTabs && showLogs;
 	const {

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -104,6 +104,8 @@ const statusBorderClassByLifecycle: Partial<
 	starting: "border-border-pending",
 	shutting_down: "border-border-pending",
 	ready: "border-border-success",
+	// Script errors and timeouts do not affect agent connectivity; they are
+	// surfaced in the per-script log tabs instead.
 	start_timeout: "border-border-success",
 	shutdown_timeout: "border-border-warning",
 	start_error: "border-border-success",
@@ -170,8 +172,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 	);
 	const { proxy } = useProxy();
 	const [showLogs, setShowLogs] = useState(
-		(["starting", "start_timeout"].includes(agent.lifecycle_state) ||
-			hasConnectivityIssues) &&
+		(agent.lifecycle_state !== "ready" || hasConnectivityIssues) &&
 			hasStartupFeatures,
 	);
 	const agentLogs = useAgentLogs({ agentId: agent.id, enabled: showLogs });

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -58,7 +58,10 @@ import {
 import { useProxy } from "#/contexts/ProxyContext";
 import { useClipboard } from "#/hooks/useClipboard";
 import { useFeatureVisibility } from "#/modules/dashboard/useFeatureVisibility";
-import { getAgentHealthIssues } from "#/modules/workspaces/health";
+import {
+	getAgentConnectivityIssues,
+	getAgentHealthIssues,
+} from "#/modules/workspaces/health";
 import { AgentAlert } from "#/pages/WorkspacePage/AgentAlert";
 import { AppStatuses } from "#/pages/WorkspacePage/AppStatuses";
 import { cn } from "#/utils/cn";
@@ -161,13 +164,19 @@ export const AgentRow: FC<AgentRowProps> = ({
 	const runningScriptsCount = agent.scripts.filter(
 		(s) => s.run_on_start && !s.status,
 	).length;
+	// Use connectivity issues for agent panel styling and visibility decisions.
+	// Script issues are handled separately in the log tabs.
+	const connectivityIssues = getAgentConnectivityIssues(agent);
+	const hasConnectivityIssues = connectivityIssues.length > 0;
+	const hasWarningConnectivityIssues = connectivityIssues.some(
+		(i) => i.severity === "warning",
+	);
+	// Get all issues (connectivity + script) for the logs panel alerts.
 	const healthIssues = getAgentHealthIssues(agent);
-	const hasAgentIssues = healthIssues.length > 0;
-	const hasWarningIssues = healthIssues.some((i) => i.severity === "warning");
 	const { proxy } = useProxy();
 	const [showLogs, setShowLogs] = useState(
 		(["starting", "start_timeout"].includes(agent.lifecycle_state) ||
-			hasAgentIssues) &&
+			hasConnectivityIssues) &&
 			hasStartupFeatures,
 	);
 	const agentLogs = useAgentLogs({ agentId: agent.id, enabled: showLogs });
@@ -177,10 +186,10 @@ export const AgentRow: FC<AgentRowProps> = ({
 
 	useEffect(() => {
 		setShowLogs(
-			(agent.lifecycle_state !== "ready" || hasAgentIssues) &&
+			(agent.lifecycle_state !== "ready" || hasConnectivityIssues) &&
 				hasStartupFeatures,
 		);
-	}, [agent.lifecycle_state, hasAgentIssues, hasStartupFeatures]);
+	}, [agent.lifecycle_state, hasConnectivityIssues, hasStartupFeatures]);
 
 	// This is a layout effect to remove flicker when we're scrolling to the bottom.
 	// biome-ignore lint/correctness/useExhaustiveDependencies: consider refactoring
@@ -542,7 +551,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 						<span>Logs</span>
 						{agent.lifecycle_state === "starting" &&
 							runningScriptsCount > 0 &&
-							healthIssues.length === 0 && (
+							connectivityIssues.length === 0 && (
 								<Badge
 									variant="default"
 									size="xs"
@@ -557,18 +566,18 @@ export const AgentRow: FC<AgentRowProps> = ({
 									<span>{runningScriptsCount}</span>
 								</Badge>
 							)}
-						{hasAgentIssues && (
+						{hasConnectivityIssues && (
 							<Badge
-								variant={hasWarningIssues ? "warning" : "info"}
+								variant={hasWarningConnectivityIssues ? "warning" : "info"}
 								size="xs"
 								className="ml-1.5"
 							>
-								{hasWarningIssues ? (
+								{hasWarningConnectivityIssues ? (
 									<TriangleAlertIcon className="-ml-0.5" />
 								) : (
 									<InfoIcon className="-ml-0.5" />
 								)}
-								<span>{healthIssues.length}</span>
+								<span>{connectivityIssues.length}</span>
 							</Badge>
 						)}
 					</Button>
@@ -579,12 +588,13 @@ export const AgentRow: FC<AgentRowProps> = ({
 						  Collapse's `in` condition is needed here,
 							or else the Spinner will also show as Collapse is closing
 						*/}
-						{shouldExpandLogs && !(hasAgentIssues || shouldShowLogsTabs) && (
-							<Spinner size="lg" loading className="block mx-auto" />
-						)}
-						{hasAgentIssues && (
+						{shouldExpandLogs &&
+							!(hasConnectivityIssues || shouldShowLogsTabs) && (
+								<Spinner size="lg" loading className="block mx-auto" />
+							)}
+						{hasConnectivityIssues && (
 							<div className="mb-4 flex flex-col gap-3">
-								{healthIssues.map((issue) => (
+								{connectivityIssues.map((issue) => (
 									<AgentAlert
 										key={`${issue.title}-${issue.detail}`}
 										{...issue}

--- a/site/src/modules/resources/AgentStatus.stories.tsx
+++ b/site/src/modules/resources/AgentStatus.stories.tsx
@@ -54,6 +54,8 @@ export const Ready: Story = {
 	},
 };
 
+// start_error no longer affects the status dot; the agent shows as Ready
+// because the error is surfaced in the per-script log tabs instead.
 export const StartupScriptFailed: Story = {
 	args: {
 		agent: {
@@ -63,15 +65,12 @@ export const StartupScriptFailed: Story = {
 		},
 	},
 	play: async () => {
-		await expectTooltip(
-			"Startup script failed",
-			agentScriptMessages.start_error.title,
-			agentScriptMessages.start_error.detail,
-			true,
-		);
+		expect(screen.getByRole("status", { name: "Ready" })).toBeInTheDocument();
 	},
 };
 
+// start_timeout no longer affects the status dot; the agent shows as Ready
+// because the timeout is surfaced in the per-script log tabs instead.
 export const StartupScriptTimeout: Story = {
 	args: {
 		agent: {
@@ -81,12 +80,7 @@ export const StartupScriptTimeout: Story = {
 		},
 	},
 	play: async () => {
-		await expectTooltip(
-			"Startup script timeout",
-			agentScriptMessages.start_timeout.title,
-			agentScriptMessages.start_timeout.detail,
-			true,
-		);
+		expect(screen.getByRole("status", { name: "Ready" })).toBeInTheDocument();
 	},
 };
 
@@ -143,6 +137,8 @@ export const ConnectionTimeout: Story = {
 	},
 };
 
+// start_error renders as Ready regardless of whether a troubleshoot URL is
+// provided, because script errors are surfaced in the per-script log tabs.
 export const StartupScriptFailedNoTroubleshootURL: Story = {
 	args: {
 		agent: {
@@ -153,12 +149,7 @@ export const StartupScriptFailedNoTroubleshootURL: Story = {
 		},
 	},
 	play: async () => {
-		await expectTooltip(
-			"Startup script failed",
-			agentScriptMessages.start_error.title,
-			agentScriptMessages.start_error.detail,
-			false,
-		);
+		expect(screen.getByRole("status", { name: "Ready" })).toBeInTheDocument();
 	},
 };
 

--- a/site/src/modules/resources/AgentStatus.tsx
+++ b/site/src/modules/resources/AgentStatus.tsx
@@ -126,25 +126,6 @@ interface DevcontainerStatusProps {
 	agent?: WorkspaceAgent;
 }
 
-const StartTimeoutLifecycle: FC<AgentStatusProps> = ({ agent }) => (
-	<AgentWarningTooltip
-		ariaLabel="Startup script timeout"
-		title={agentScriptMessages.start_timeout.title}
-		detail={agentScriptMessages.start_timeout.detail}
-		troubleshootingURL={agent.troubleshooting_url}
-	/>
-);
-
-const StartErrorLifecycle: FC<AgentStatusProps> = ({ agent }) => (
-	<AgentWarningTooltip
-		ariaLabel="Startup script failed"
-		title={agentScriptMessages.start_error.title}
-		detail={agentScriptMessages.start_error.detail}
-		troubleshootingURL={agent.troubleshooting_url}
-		variant="warning"
-	/>
-);
-
 const ShuttingDownLifecycle: FC = () => {
 	return (
 		<Tooltip>
@@ -203,11 +184,13 @@ const ConnectedStatus: FC<AgentStatusProps> = ({ agent }) => {
 	if (agent.lifecycle_state === "ready") {
 		return <ReadyLifecycle />;
 	}
-	if (agent.lifecycle_state === "start_timeout") {
-		return <StartTimeoutLifecycle agent={agent} />;
-	}
-	if (agent.lifecycle_state === "start_error") {
-		return <StartErrorLifecycle agent={agent} />;
+	// Script errors and timeouts do not affect agent connectivity.
+	// These states are surfaced in the per-script log tabs instead.
+	if (
+		agent.lifecycle_state === "start_timeout" ||
+		agent.lifecycle_state === "start_error"
+	) {
+		return <ReadyLifecycle />;
 	}
 	if (agent.lifecycle_state === "shutting_down") {
 		return <ShuttingDownLifecycle />;

--- a/site/src/modules/workspaces/health.test.ts
+++ b/site/src/modules/workspaces/health.test.ts
@@ -71,6 +71,37 @@ describe("getAgentConnectivityIssues", () => {
 			),
 		).toEqual([]);
 	});
+
+	it("returns connecting issue for a connecting agent", () => {
+		expect(
+			getAgentConnectivityIssues(
+				buildAgent({ status: "connecting", lifecycle_state: "starting" }),
+			),
+		).toContainEqual(
+			expect.objectContaining({
+				title: "Workspace agent is connecting",
+				severity: "info",
+				prominent: false,
+			}),
+		);
+	});
+
+	it("returns shutdown issue for shutdown lifecycle states", () => {
+		for (const lifecycle_state of [
+			"shutting_down",
+			"shutdown_error",
+			"shutdown_timeout",
+		] as const) {
+			expect(
+				getAgentConnectivityIssues(buildAgent({ lifecycle_state })),
+			).toContainEqual(
+				expect.objectContaining({
+					title: "Workspace agent is shutting down",
+					severity: "info",
+				}),
+			);
+		}
+	});
 });
 
 describe("getAgentScriptIssues", () => {

--- a/site/src/modules/workspaces/health.test.ts
+++ b/site/src/modules/workspaces/health.test.ts
@@ -9,7 +9,11 @@ import {
 	MockWorkspaceAgentStartError,
 	MockWorkspaceAgentStartTimeout,
 } from "#/testHelpers/entities";
-import { getAgentHealthIssues } from "./health";
+import {
+	getAgentConnectivityIssues,
+	getAgentHealthIssues,
+	getAgentScriptIssues,
+} from "./health";
 
 interface AgentOverrides {
 	status?: WorkspaceAgentStatus;
@@ -23,6 +27,97 @@ function buildAgent(overrides: AgentOverrides): WorkspaceAgent {
 		...overrides,
 	};
 }
+
+describe("getAgentConnectivityIssues", () => {
+	it("returns disconnected issue for a disconnected agent", () => {
+		expect(
+			getAgentConnectivityIssues(buildAgent({ status: "disconnected" })),
+		).toContainEqual(
+			expect.objectContaining({
+				title: "Workspace agent has disconnected",
+				severity: "warning",
+				prominent: false,
+			}),
+		);
+	});
+
+	it("returns timeout issue for a timed-out agent", () => {
+		expect(
+			getAgentConnectivityIssues(buildAgent({ status: "timeout" })),
+		).toContainEqual(
+			expect.objectContaining({
+				title: "Agent is taking longer than expected to connect",
+				severity: "warning",
+				prominent: false,
+			}),
+		);
+	});
+
+	it("does not return script issues", () => {
+		const issues = getAgentConnectivityIssues(
+			buildAgent(MockWorkspaceAgentStartError),
+		);
+		expect(issues).not.toContainEqual(
+			expect.objectContaining({
+				title: `"Startup Script" failed`,
+			}),
+		);
+	});
+
+	it("returns empty list for healthy ready connected agent", () => {
+		expect(
+			getAgentConnectivityIssues(
+				buildAgent({ status: "connected", lifecycle_state: "ready" }),
+			),
+		).toEqual([]);
+	});
+});
+
+describe("getAgentScriptIssues", () => {
+	it("returns script issues", () => {
+		const issues = getAgentScriptIssues(
+			buildAgent(MockWorkspaceAgentStartError),
+		);
+		expect(issues).toContainEqual(
+			expect.objectContaining({
+				title: `"Startup Script" failed`,
+				severity: "warning",
+				prominent: false,
+			}),
+		);
+		expect(issues).toContainEqual(
+			expect.objectContaining({
+				title: `"time" is taking longer than expected`,
+				severity: "warning",
+				prominent: false,
+			}),
+		);
+		expect(issues).toContainEqual(
+			expect.objectContaining({
+				title: `"pipe" left pipes open`,
+				severity: "warning",
+				prominent: false,
+			}),
+		);
+	});
+
+	it("does not return connectivity issues", () => {
+		const issues = getAgentScriptIssues(buildAgent({ status: "disconnected" }));
+		expect(issues).not.toContainEqual(
+			expect.objectContaining({
+				title: "Workspace agent has disconnected",
+			}),
+		);
+	});
+
+	it("returns empty list when no scripts failed", () => {
+		expect(
+			getAgentScriptIssues(
+				buildAgent({ status: "connected", lifecycle_state: "ready" }),
+			),
+		).toEqual([]);
+	});
+});
 
 describe("getAgentHealthIssues", () => {
 	it("returns disconnected issue for a disconnected agent", () => {

--- a/site/src/modules/workspaces/health.ts
+++ b/site/src/modules/workspaces/health.ts
@@ -62,9 +62,12 @@ interface AgentHealthIssue {
 }
 
 /**
- * Classifies all health issues for an individual agent.
+ * Classifies connectivity-related health issues for an individual agent.
+ * These issues affect the agent panel border color and warning visibility.
+ * Script failures are excluded from this function to prevent them from
+ * incorrectly suggesting agent connectivity problems.
  */
-export function getAgentHealthIssues(
+export function getAgentConnectivityIssues(
 	agent: WorkspaceAgent,
 ): AgentHealthIssue[] {
 	const issues: AgentHealthIssue[] = [];
@@ -100,9 +103,28 @@ export function getAgentHealthIssues(
 		});
 	}
 
-	// Ignore `start_error` and `start_timeout`, as these will eventually be
-	// removed from agent health.  Instead, figure out if a script failed to start
-	// by looking directly at the scripts.
+	if (agent.status === "connecting") {
+		issues.push({
+			title: agentConnectionMessages.connecting.title,
+			detail: agentConnectionMessages.connecting.detail,
+			severity: "info",
+			prominent: false,
+		});
+	}
+
+	return issues;
+}
+
+/**
+ * Classifies script-related health issues for an individual agent.
+ * These issues are shown only in the script tabs, not in the agent panel header.
+ */
+export function getAgentScriptIssues(
+	agent: WorkspaceAgent,
+): AgentHealthIssue[] {
+	const issues: AgentHealthIssue[] = [];
+
+	// Check for script failures directly from the scripts array.
 	for (const script of agent.scripts) {
 		switch (script.status) {
 			case "timed_out":
@@ -141,14 +163,15 @@ export function getAgentHealthIssues(
 		}
 	}
 
-	if (agent.status === "connecting") {
-		issues.push({
-			title: agentConnectionMessages.connecting.title,
-			detail: agentConnectionMessages.connecting.detail,
-			severity: "info",
-			prominent: false,
-		});
-	}
-
 	return issues;
+}
+
+/**
+ * Classifies all health issues for an individual agent, combining both
+ * connectivity and script issues.
+ */
+export function getAgentHealthIssues(
+	agent: WorkspaceAgent,
+): AgentHealthIssue[] {
+	return [...getAgentConnectivityIssues(agent), ...getAgentScriptIssues(agent)];
 }

--- a/site/src/modules/workspaces/health.ts
+++ b/site/src/modules/workspaces/health.ts
@@ -4,7 +4,7 @@ import type { WorkspaceAgent } from "#/api/typesGenerated";
  * Canonical messages for startup and shutdown script issues.
  * Used by the per-agent-row tooltips in AgentStatus; the
  * start-related entries are also shared with per-agent health
- * classification in getAgentHealthIssues.
+ * classification in getAgentScriptIssues.
  */
 export const agentScriptMessages = {
 	start_error: {
@@ -90,6 +90,10 @@ export function getAgentConnectivityIssues(
 		});
 	}
 
+	// Shutdown lifecycle states are treated as connectivity concerns rather than
+	// script concerns because the workspace is actively becoming unavailable;
+	// unlike startup script failures, the agent is no longer reachable once
+	// shutdown begins.
 	if (
 		agent.lifecycle_state === "shutting_down" ||
 		agent.lifecycle_state === "shutdown_error" ||


### PR DESCRIPTION
## Summary

Agent connectivity status should be separate from script execution failures.

Previously, when any startup or shutdown scripts failed, the entire agent panel would show warning badges and border colors, incorrectly suggesting agent connectivity issues.

Fixes #26025
Closes DEVEX-437

## Changes

### `site/src/modules/workspaces/health.ts`
- Added `getAgentConnectivityIssues()` returning only connection-related issues (disconnected, timeout, shutting down, connecting)
- Added `getAgentScriptIssues()` returning only script-related issues (exit failure, timed out, pipes left open)
- Refactored `getAgentHealthIssues()` to combine both for backward compatibility

### `site/src/modules/resources/AgentRow.tsx`
- Updated panel border color, warning badge, and alert rendering to use connectivity issues only
- Script failures remain visible in their dedicated log tabs with error indicators

### `site/src/modules/workspaces/health.test.ts`
- Added tests for `getAgentConnectivityIssues` and `getAgentScriptIssues`
- Verified separation: connectivity function excludes scripts, script function excludes connectivity
- Maintained existing `getAgentHealthIssues` tests

## Behavior after fix

| Scenario | Agent Border | Warning Badge | Auto-Open Logs | Alerts |
|----------|-------------|---------------|----------------|--------|
| Connected, script fails | Normal (green) | None | Yes (starts on All Logs, then jumps to first failed script tab) | None (tabs show error) |
| Agent timeout | Warning | Yes | Yes | Yes |
| Agent disconnected | Warning | Yes | Yes | Yes |
| Connected, all scripts OK | Normal (green) | None | Yes (All Logs tab) | None |

<details>
<summary>Implementation details</summary>

The core change splits `getAgentHealthIssues()` into two focused functions:
- `getAgentConnectivityIssues()` for agent panel border/badge/alert decisions
- `getAgentScriptIssues()` for script tab error indicators

`getAgentHealthIssues()` remains as a composition of both for any callers needing the full picture.

Logs auto-open whenever `lifecycle_state !== "ready"` (including `start_error`). The default tab is "All Logs"; a separate effect auto-selects the first failed script tab once its output is available.

</details>

> Generated by Coder Agents