### PR TITLE
feat(agent): add SSH session test driver

### DIFF
--- a/agent/agenttest/envinfo.go
+++ b/agent/agenttest/envinfo.go
@@ -1,0 +1,135 @@
+package agenttest
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/agent/usershell"
+)
+
+// PromptMarker is the sentinel a deterministic test shell prints as its
+// prompt once it is ready for input. It contains no ANSI and is matched as a
+// substring, so a terminal wrapping it in control sequences does not defeat
+// detection.
+const PromptMarker = "::coder-shell-ready::"
+
+type shellEnvInfoConfig struct {
+	shell   string
+	homeDir string
+}
+
+// ShellEnvInfoOption configures ShellEnvInfo.
+type ShellEnvInfoOption func(*shellEnvInfoConfig)
+
+// WithShell forces a named shell instead of the platform default. The name is
+// resolved against PATH unless it is already an absolute path.
+func WithShell(shell string) ShellEnvInfoOption {
+	return func(c *shellEnvInfoConfig) { c.shell = shell }
+}
+
+// WithHomeDir overrides the isolated HOME directory. By default ShellEnvInfo
+// uses t.TempDir().
+func WithHomeDir(dir string) ShellEnvInfoOption {
+	return func(c *shellEnvInfoConfig) { c.homeDir = dir }
+}
+
+// shellEnvInfo wraps usershell.SystemEnvInfo, overriding the shell, home
+// directory, and environment so an SSH session runs a deterministic shell
+// whose prompt is the PromptMarker.
+type shellEnvInfo struct {
+	usershell.SystemEnvInfo
+	shell string
+	home  string
+	env   []string
+}
+
+func (e *shellEnvInfo) Shell(string) (string, error) { return e.shell, nil }
+func (e *shellEnvInfo) HomeDir() (string, error)     { return e.home, nil }
+func (e *shellEnvInfo) Environ() []string            { return slices.Clone(e.env) }
+
+// ShellEnvInfo returns a usershell.EnvInfoer that forces a deterministic
+// shell with the PromptMarker as its prompt, an isolated temp HOME, and the
+// environment wired so the marker appears once the shell is ready for input.
+//
+// On POSIX the home directory's .profile sets PS1 to the marker framed by real
+// newlines (dash does not interpret \n). On Windows the PROMPT environment
+// variable carries the marker (cmd.exe renders PROMPT, $_ expands to CRLF).
+func ShellEnvInfo(t testing.TB, opts ...ShellEnvInfoOption) usershell.EnvInfoer {
+	t.Helper()
+
+	var c shellEnvInfoConfig
+	for _, opt := range opts {
+		opt(&c)
+	}
+
+	home := c.homeDir
+	if home == "" {
+		home = t.TempDir()
+	}
+
+	shell, err := resolveShell(c.shell)
+	require.NoError(t, err, "resolve shell")
+
+	env := usershell.SystemEnvInfo{}.Environ()
+	if runtime.GOOS == "windows" {
+		env = setEnv(env, "PROMPT", PromptMarker+"$_")
+	} else {
+		env = setEnv(env, "HOME", home)
+		writeProfile(t, home, shell)
+	}
+
+	return &shellEnvInfo{shell: shell, home: home, env: env}
+}
+
+// resolveShell returns the platform default when name is empty, the path
+// unchanged when it is absolute, otherwise the PATH lookup of name.
+func resolveShell(name string) (string, error) {
+	if name == "" {
+		if runtime.GOOS == "windows" {
+			return "cmd.exe", nil
+		}
+		return "/bin/sh", nil
+	}
+	if filepath.IsAbs(name) {
+		return name, nil
+	}
+	return exec.LookPath(name)
+}
+
+// writeProfile drops the login profile(s) that set the marker prompt. The PS1
+// value is framed by real newline bytes because dash does not interpret \n.
+// bash reads .bash_profile in preference to .profile, so it gets its own copy.
+func writeProfile(t testing.TB, home, shell string) {
+	t.Helper()
+
+	profile := "PS1='\n" + PromptMarker + "\n'\n"
+	err := os.WriteFile(filepath.Join(home, ".profile"), []byte(profile), 0o600)
+	require.NoError(t, err, "write .profile")
+
+	if strings.HasPrefix(filepath.Base(shell), "bash") {
+		err = os.WriteFile(filepath.Join(home, ".bash_profile"), []byte(profile), 0o600)
+		require.NoError(t, err, "write .bash_profile")
+	}
+}
+
+// setEnv returns env with any existing key entry removed and key=value
+// appended, so the value is unambiguous regardless of how the OS resolves
+// duplicate keys.
+func setEnv(env []string, key, value string) []string {
+	prefix := key + "="
+	out := make([]string, 0, len(env)+1)
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			continue
+		}
+		out = append(out, e)
+	}
+	return append(out, prefix+value)
+}

--- a/agent/agenttest/envinfo_test.go
+++ b/agent/agenttest/envinfo_test.go
@@ -1,0 +1,89 @@
+package agenttest_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/agent/agenttest"
+)
+
+// TestShellEnvInfo asserts the deterministic-shell EnvInfoer forces a known
+// shell, isolates HOME to a temp dir, and wires the sentinel prompt so the
+// marker appears once the shell is ready for input.
+func TestShellEnvInfo(t *testing.T) {
+	t.Parallel()
+
+	ei := agenttest.ShellEnvInfo(t)
+
+	// HOME is an isolated, existing directory.
+	home, err := ei.HomeDir()
+	require.NoError(t, err)
+	fi, err := os.Stat(home)
+	require.NoError(t, err)
+	require.True(t, fi.IsDir(), "home dir should exist")
+
+	// The forced shell is deterministic per platform.
+	shell, err := ei.Shell("")
+	require.NoError(t, err)
+	if runtime.GOOS == "windows" {
+		require.Equal(t, "cmd.exe", shell)
+	} else {
+		require.Equal(t, "/bin/sh", shell)
+	}
+
+	// The prompt is wired so the marker frames the prompt.
+	env := ei.Environ()
+	if runtime.GOOS == "windows" {
+		// cmd.exe renders PROMPT; $_ expands to CRLF.
+		require.Contains(t, env, "PROMPT="+agenttest.PromptMarker+"$_")
+	} else {
+		// HOME is exported so the login shell sources our .profile.
+		require.Contains(t, env, "HOME="+home)
+		// dash does not interpret \n in PS1, so the marker is framed by
+		// real newline bytes.
+		b, err := os.ReadFile(filepath.Join(home, ".profile"))
+		require.NoError(t, err)
+		require.Contains(t, string(b), "\n"+agenttest.PromptMarker+"\n")
+	}
+}
+
+// TestShellEnvInfo_WithHomeDir asserts the HOME override is honored.
+func TestShellEnvInfo_WithHomeDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	ei := agenttest.ShellEnvInfo(t, agenttest.WithHomeDir(dir))
+	home, err := ei.HomeDir()
+	require.NoError(t, err)
+	require.Equal(t, dir, home)
+}
+
+// TestShellEnvInfo_WithShellBash asserts a named shell is resolved and that
+// bash gets a .bash_profile, which it reads in preference to .profile.
+func TestShellEnvInfo_WithShellBash(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("bash login profile is POSIX")
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not installed")
+	}
+
+	ei := agenttest.ShellEnvInfo(t, agenttest.WithShell("bash"))
+	shell, err := ei.Shell("")
+	require.NoError(t, err)
+	require.True(t, strings.HasSuffix(shell, "bash"), "shell %q should be bash", shell)
+
+	home, err := ei.HomeDir()
+	require.NoError(t, err)
+	b, err := os.ReadFile(filepath.Join(home, ".bash_profile"))
+	require.NoError(t, err)
+	require.Contains(t, string(b), agenttest.PromptMarker)
+}

--- a/agent/agenttest/session.go
+++ b/agent/agenttest/session.go
@@ -1,0 +1,375 @@
+package agenttest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/acarl005/stripansi"
+	gossh "golang.org/x/crypto/ssh"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/testutil"
+)
+
+// Session adapts a single-use *gossh.Session (the caller did any native
+// Setenv/SendRequest first) into the protected test driver. Pre-start
+// configuration is chained, e.g. WrapSession(t, s).PTY().Command(ctx, cmd).
+type Session struct {
+	t   testing.TB
+	s   *gossh.Session
+	pty bool
+}
+
+// WrapSession wraps a fresh, unstarted *gossh.Session.
+func WrapSession(t testing.TB, s *gossh.Session) *Session {
+	return &Session{t: t, s: s}
+}
+
+// PTY requests a wide PTY before start so a prompt marker cannot wrap.
+func (s *Session) PTY() *Session {
+	s.pty = true
+	return s
+}
+
+// Command starts an arbitrary command and returns the protected stream
+// driver. The command runs under the session's shell (shell -c cmd).
+func (s *Session) Command(ctx context.Context, cmd string) (*Process, error) {
+	return s.start(ctx, cmd)
+}
+
+// Shell starts a login shell over a PTY and returns after the first prompt.
+// The consumed login output is available via Banner.
+func (s *Session) Shell(ctx context.Context) (*Shell, error) {
+	s.pty = true
+	p, err := s.start(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+	sh := &Shell{Process: p}
+	sh.banner = p.ReadUntil(ctx, PromptMarker)
+	return sh, nil
+}
+
+func (s *Session) start(ctx context.Context, cmd string) (*Process, error) {
+	s.t.Helper()
+
+	stdin, err := s.s.StdinPipe()
+	if err != nil {
+		return nil, xerrors.Errorf("stdin pipe: %w", err)
+	}
+
+	runCtx, runCancel := context.WithCancel(context.Background())
+	p := &Process{
+		t:         s.t,
+		s:         s.s,
+		stdin:     stdin,
+		out:       testutil.NewWaitBuffer(),
+		waited:    make(chan struct{}),
+		runCtx:    runCtx,
+		runCancel: runCancel,
+	}
+	// gossh copies the channel streams into these writers and Wait() waits for
+	// the copies to finish, so the driver owns no stdout/stderr copy
+	// goroutines. Under a PTY the server folds stderr into the single terminal
+	// stream, so stderr is captured separately only for non-PTY commands.
+	s.s.Stdout = p.out
+	if !s.pty {
+		p.errBuf = testutil.NewWaitBuffer()
+		s.s.Stderr = p.errBuf
+	}
+
+	// Enforce goroutine lifetimes: closing the session unblocks Wait and the
+	// gossh copies, then wg.Wait confirms every goroutine we spawned has ended
+	// before the test finishes. Registered before any goroutine starts so the
+	// error paths below drain just as well as the success path.
+	s.t.Cleanup(func() {
+		_ = p.s.Close()
+		p.runCancel()
+		p.wg.Wait()
+		p.t.Logf("ssh out:\n%s", clean(p.out.String()))
+		if e := p.capturedStderr(); e != "" {
+			p.t.Logf("ssh err:\n%s", clean(e))
+		}
+	})
+
+	// Bound the start handshake (a wide PTY request keeps a prompt marker on
+	// one line) on ctx so a stuck connection fails fast. The goroutine is
+	// tracked by wg; the cleanup's session Close unblocks it on the ctx path.
+	startErr := make(chan error, 1)
+	p.wg.Go(func() {
+		if s.pty {
+			if err := s.s.RequestPty("xterm", 50, 200, gossh.TerminalModes{}); err != nil {
+				startErr <- xerrors.Errorf("request pty: %w", err)
+				return
+			}
+		}
+		if cmd == "" {
+			startErr <- s.s.Shell()
+		} else {
+			startErr <- s.s.Start(cmd)
+		}
+	})
+	select {
+	case err := <-startErr:
+		if err != nil {
+			return nil, xerrors.Errorf("start: %w", err)
+		}
+	case <-ctx.Done():
+		return nil, xerrors.Errorf("start: %w", ctx.Err())
+	}
+
+	p.mu.Lock()
+	p.status.Started = true
+	p.mu.Unlock()
+	p.wg.Go(p.waitLoop)
+
+	return p, nil
+}
+
+// Process is the protected I/O core. It implements io.ReadWriteCloser over the
+// remote process: Write feeds stdin, Read consumes stdout, Close closes stdin.
+// Reads also have a token matcher (ReadUntil). Writes are logged. A write to a
+// process that already exited returns a *ProcessError carrying the exit code
+// and captured stderr, never a bare EOF, which is the diagnosable form of the
+// #1560 bug.
+type Process struct {
+	t     testing.TB
+	s     *gossh.Session
+	stdin io.WriteCloser
+	// out captures stdout (and merged stderr under a PTY); errBuf captures
+	// stderr for non-PTY commands and is nil otherwise. Both are thread-safe.
+	out    *testutil.WaitBuffer
+	errBuf *testutil.WaitBuffer
+	// readOff is the number of stdout bytes already consumed by Read/ReadUntil.
+	// Reads are sequential, so it needs no lock.
+	readOff int
+
+	// waited is closed once the process has exited and status is final.
+	waited chan struct{}
+	// runCtx is canceled when the process exits (or on cleanup), so a Read
+	// blocked for more stdout unblocks and returns io.EOF.
+	runCtx    context.Context
+	runCancel context.CancelFunc
+	// wg tracks the goroutines this driver spawns so the cleanup can confirm
+	// they have all ended.
+	wg sync.WaitGroup
+
+	mu     sync.Mutex
+	status Status
+}
+
+var _ io.ReadWriteCloser = (*Process)(nil)
+
+// waitLoop observes the process exit on the single allowed gossh Wait call.
+// gossh's Wait returns only after the stdout/stderr copies finish, so the
+// captured buffers are complete once status is final.
+func (p *Process) waitLoop() {
+	code, sig := exitInfo(p.s.Wait())
+	p.mu.Lock()
+	p.status.Done = true
+	p.status.ExitCode = code
+	p.status.Signal = sig
+	p.mu.Unlock()
+	close(p.waited)
+	p.runCancel()
+}
+
+// exitInfo extracts the exit code and signal from a *gossh.Session.Wait error.
+// It returns -1 when the code is unavailable.
+func exitInfo(err error) (int, gossh.Signal) {
+	if err == nil {
+		return 0, ""
+	}
+	var ee *gossh.ExitError
+	if errors.As(err, &ee) {
+		return ee.ExitStatus(), gossh.Signal(ee.Signal())
+	}
+	return -1, ""
+}
+
+// Write implements io.Writer, feeding stdin. The bytes are logged. A write to
+// an exited process returns a *ProcessError with the exit code and stderr.
+func (p *Process) Write(b []byte) (int, error) {
+	p.t.Logf("ssh in: %q", b)
+	n, err := p.stdin.Write(b)
+	if err != nil {
+		return n, p.processError("write", err)
+	}
+	return n, nil
+}
+
+// Close implements io.Closer, closing stdin (signaling EOF to the process).
+func (p *Process) Close() error {
+	if err := p.stdin.Close(); err != nil {
+		return p.processError("close", err)
+	}
+	return nil
+}
+
+// WriteLine writes a line terminated for the local shell.
+func (p *Process) WriteLine(line string) error {
+	_, err := io.WriteString(p, line+lineEnding)
+	return err
+}
+
+// lineEnding submits a line to the local shell. cmd.exe under ConPTY treats CR
+// as Enter and ignores a bare LF, so a stray LF would inject an empty-line
+// prompt and desync later reads. POSIX shells accept LF.
+var lineEnding = func() string {
+	if runtime.GOOS == "windows" {
+		return "\r"
+	}
+	return "\n"
+}()
+
+// Read implements io.Reader over stdout. It blocks until stdout has unread
+// bytes, returning io.EOF once the process has exited and stdout is drained.
+// Read shares its cursor with ReadUntil and is not safe for concurrent use.
+func (p *Process) Read(b []byte) (int, error) {
+	_ = p.out.WaitForCond(p.runCtx, func(s string) bool { return len(s) > p.readOff })
+	data := p.out.Bytes()
+	if p.readOff >= len(data) {
+		return 0, io.EOF
+	}
+	n := copy(b, data[p.readOff:])
+	p.readOff += n
+	return n, nil
+}
+
+// ReadUntil reads until token appears and returns the text before it, with the
+// token consumed. ANSI control sequences are stripped from the returned text.
+// A token that never arrives fails the test once ctx expires, logging the
+// output captured so far. Not safe for concurrent use.
+func (p *Process) ReadUntil(ctx context.Context, token string) string {
+	p.t.Helper()
+	off := p.readOff
+	err := p.out.WaitForCond(ctx, func(s string) bool {
+		return strings.Contains(s[off:], token)
+	})
+	if err != nil {
+		p.t.Fatalf("ReadUntil %q: %v\noutput so far:\n%s", token, err, p.out.String())
+		return ""
+	}
+	rest := p.out.String()[off:]
+	idx := strings.Index(rest, token)
+	p.readOff = off + idx + len(token)
+	return clean(rest[:idx])
+}
+
+// Signal sends an SSH signal to the process.
+func (p *Process) Signal(sig gossh.Signal) error {
+	if err := p.s.Signal(sig); err != nil {
+		return p.processError("signal", err)
+	}
+	return nil
+}
+
+// Wait blocks until the process exits or ctx is done.
+func (p *Process) Wait(ctx context.Context) (Status, error) {
+	select {
+	case <-p.waited:
+		return p.Status(), nil
+	case <-ctx.Done():
+		return p.Status(), xerrors.Errorf("wait: %w", ctx.Err())
+	}
+}
+
+// Status returns a snapshot of the process lifecycle and exit disposition.
+func (p *Process) Status() Status {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	st := p.status
+	st.Stderr = p.capturedStderr()
+	return st
+}
+
+// Stderr returns the stderr captured so far.
+func (p *Process) Stderr() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.capturedStderr()
+}
+
+func (p *Process) capturedStderr() string {
+	if p.errBuf == nil {
+		return ""
+	}
+	return p.errBuf.String()
+}
+
+// processError attaches the process exit status to a failed stdin operation.
+// It waits briefly for an in-flight exit to land so the returned status carries
+// the exit code, bounded so a still-live process does not stall the test.
+func (p *Process) processError(op string, err error) error {
+	select {
+	case <-p.waited:
+	case <-time.After(testutil.WaitShort):
+	}
+	return &ProcessError{Op: op, Err: err, Status: p.Status()}
+}
+
+func clean(s string) string { return stripansi.Strip(s) }
+
+// Shell is a Process plus prompt policy. Shell(ctx) has already blocked until
+// the first prompt, so the consumed login output is available via Banner.
+type Shell struct {
+	*Process
+	banner string
+}
+
+// Banner returns the login/MOTD output printed before the first prompt.
+func (sh *Shell) Banner() string { return sh.banner }
+
+// ReadPrompt reads to the next prompt and returns the text before it.
+func (sh *Shell) ReadPrompt(ctx context.Context) string {
+	return sh.ReadUntil(ctx, PromptMarker)
+}
+
+// Run writes a line and reads to the next prompt. It is not a one-shot exec;
+// it drives the interactive shell.
+func (sh *Shell) Run(ctx context.Context, line string) (string, error) {
+	if err := sh.WriteLine(line); err != nil {
+		return "", err
+	}
+	return sh.ReadPrompt(ctx), nil
+}
+
+// Status reports the lifecycle and exit disposition of a Process.
+type Status struct {
+	Started, Done bool
+	ExitCode      int // -1 if unavailable
+	Signal        gossh.Signal
+	Stderr        string
+}
+
+// ProcessError is returned when a stdin operation targets a process that
+// already exited. It carries the exit code and captured stderr so the failure
+// is diagnosable instead of a bare EOF.
+type ProcessError struct {
+	Op     string
+	Err    error
+	Status Status
+}
+
+func (e *ProcessError) Error() string {
+	// Surface the exit code and stderr so the failure is diagnosable, which is
+	// the point of #1560. A bare EOF told you nothing about why the process
+	// was gone.
+	if e.Status.Done {
+		msg := fmt.Sprintf("%s: process exited code %d", e.Op, e.Status.ExitCode)
+		if stderr := strings.TrimSpace(e.Status.Stderr); stderr != "" {
+			msg += ": " + stderr
+		}
+		return msg
+	}
+	return e.Op + ": " + e.Err.Error()
+}
+
+func (e *ProcessError) Unwrap() error { return e.Err }

--- a/agent/wrapsession_test.go
+++ b/agent/wrapsession_test.go
@@ -1,0 +1,232 @@
+package agent_test
+
+import (
+	"io"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/coder/coder/v2/agent"
+	"github.com/coder/coder/v2/agent/agenttest"
+	"github.com/coder/coder/v2/codersdk/agentsdk"
+	"github.com/coder/coder/v2/testutil"
+)
+
+// driverSSHClient builds an agent whose sessions run the deterministic test
+// shell, and returns an SSH client. Each test opens its own session from it.
+func driverSSHClient(t *testing.T, opts ...func(*agenttest.Client, *agent.Options)) *ssh.Client {
+	t.Helper()
+	ctx := testutil.Context(t, testutil.WaitLong)
+	opts = append([]func(*agenttest.Client, *agent.Options){
+		func(_ *agenttest.Client, o *agent.Options) {
+			o.EnvInfo = agenttest.ShellEnvInfo(t)
+		},
+	}, opts...)
+	//nolint:dogsled
+	conn, _, _, _, _ := setupAgent(t, agentsdk.Manifest{}, 0, opts...)
+	client, err := conn.SSHClient(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+func driverSession(t *testing.T, client *ssh.Client) *ssh.Session {
+	t.Helper()
+	sess, err := client.NewSession()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sess.Close() })
+	return sess
+}
+
+// TestWrapSession_CommandExitCode asserts Wait surfaces the real exit code.
+func TestWrapSession_CommandExitCode(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client := driverSSHClient(t)
+
+	p, err := agenttest.WrapSession(t, driverSession(t, client)).Command(ctx, "exit 3")
+	require.NoError(t, err)
+
+	st, err := p.Wait(ctx)
+	require.NoError(t, err)
+	require.True(t, st.Done)
+	require.Equal(t, 3, st.ExitCode)
+}
+
+// TestWrapSession_CommandProcessErrorOnDeadWrite is the #1560 repro: writing
+// to a process that already exited yields a diagnosable *ProcessError with the
+// exit code, not a bare EOF.
+func TestWrapSession_CommandProcessErrorOnDeadWrite(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client := driverSSHClient(t)
+
+	p, err := agenttest.WrapSession(t, driverSession(t, client)).Command(ctx, "exit 3")
+	require.NoError(t, err)
+	_, err = p.Wait(ctx)
+	require.NoError(t, err)
+
+	err = p.WriteLine("too late")
+	var pe *agenttest.ProcessError
+	require.ErrorAs(t, err, &pe)
+	require.Equal(t, "write", pe.Op)
+	require.Equal(t, 3, pe.Status.ExitCode)
+	require.Contains(t, pe.Error(), "exited code 3", "the error message is diagnosable, not a bare EOF")
+}
+
+// TestWrapSession_CommandStderr asserts stderr is captured continuously and
+// surfaced on Wait and via Stderr().
+func TestWrapSession_CommandStderr(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client := driverSSHClient(t)
+
+	p, err := agenttest.WrapSession(t, driverSession(t, client)).Command(ctx, "echo oops 1>&2")
+	require.NoError(t, err)
+
+	st, err := p.Wait(ctx)
+	require.NoError(t, err)
+	require.Contains(t, st.Stderr, "oops")
+	require.Contains(t, p.Stderr(), "oops")
+}
+
+// TestWrapSession_CommandReadFromLiveProcess reads output from a process that
+// is still running (the streaming-readiness case, e.g. a server logging
+// "listening on ..."), then confirms a clean exit. Cross-platform.
+func TestWrapSession_CommandReadFromLiveProcess(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client := driverSSHClient(t)
+
+	// Print a marker, then stay alive briefly so the read happens while the
+	// process is running rather than after it exits.
+	cmd := "echo ready; sleep 1"
+	if runtime.GOOS == "windows" {
+		// ping is the Windows sleep that tolerates redirected stdin; timeout
+		// and findstr reject it ("Input redirection is not supported").
+		cmd = "echo ready& ping -n 2 127.0.0.1 >nul"
+	}
+	p, err := agenttest.WrapSession(t, driverSession(t, client)).Command(ctx, cmd)
+	require.NoError(t, err)
+
+	out := p.ReadUntil(ctx, "ready")
+	require.NotContains(t, out, "ready", "ReadUntil returns the text before the token")
+
+	st, err := p.Wait(ctx)
+	require.NoError(t, err)
+	require.True(t, st.Done)
+	require.Equal(t, 0, st.ExitCode)
+}
+
+// TestWrapSession_CommandStdinEcho drives a bidirectional stdin->stdout echo:
+// write a line, read it back while the process runs, close stdin, confirm a
+// clean exit. This is the netcat/cat streaming case. It is POSIX-only: there
+// is no reliable non-PTY line echo on Windows (findstr rejects piped input),
+// so Windows interactive stdin is covered by the PTY Shell test instead.
+func TestWrapSession_CommandStdinEcho(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("no reliable non-PTY line echo on Windows; see the Shell PTY test")
+	}
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client := driverSSHClient(t)
+
+	p, err := agenttest.WrapSession(t, driverSession(t, client)).Command(ctx, "cat")
+	require.NoError(t, err)
+
+	require.NoError(t, p.WriteLine("ping"))
+	out := p.ReadUntil(ctx, "ping")
+	require.NotContains(t, out, "ping", "ReadUntil returns the text before the token")
+
+	require.NoError(t, p.Close())
+	st, err := p.Wait(ctx)
+	require.NoError(t, err)
+	require.True(t, st.Done)
+	require.Equal(t, 0, st.ExitCode)
+}
+
+// TestWrapSession_CommandReadStream consumes stdout through the io.Reader
+// interface (io.ReadAll), proving the driver composes with the stdlib and
+// returns io.EOF once the process exits.
+func TestWrapSession_CommandReadStream(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client := driverSSHClient(t)
+
+	p, err := agenttest.WrapSession(t, driverSession(t, client)).Command(ctx, "echo hello")
+	require.NoError(t, err)
+
+	out, err := io.ReadAll(p)
+	require.NoError(t, err)
+	require.Contains(t, string(out), "hello")
+}
+
+// TestWrapSession_Shell starts a login shell over a PTY and confirms it returns
+// after the first prompt (no Ready() footgun), then drives sequential commands
+// through the prompt cycle. The prompt marker must be matched as a substring
+// despite terminal control sequences.
+func TestWrapSession_Shell(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client := driverSSHClient(t)
+
+	sh, err := agenttest.WrapSession(t, driverSession(t, client)).Shell(ctx)
+	require.NoError(t, err)
+
+	out, err := sh.Run(ctx, "echo hello-shell")
+	require.NoError(t, err)
+	require.Contains(t, out, "hello-shell")
+
+	// A second command cycles the prompt and does not bleed the first
+	// command's output.
+	out2, err := sh.Run(ctx, "echo second-line")
+	require.NoError(t, err)
+	require.Contains(t, out2, "second-line")
+	require.NotContains(t, out2, "hello-shell")
+}
+
+// TestWrapSession_Signal signals a running process and confirms Wait reports it
+// as terminated rather than a clean exit. POSIX-only: SSH signal delivery to
+// Windows processes is not supported by the agent.
+func TestWrapSession_Signal(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX signals")
+	}
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client := driverSSHClient(t)
+
+	p, err := agenttest.WrapSession(t, driverSession(t, client)).Command(ctx, "echo started; exec sleep 60")
+	require.NoError(t, err)
+
+	// exec replaces the shell with sleep so the signal targets the actual
+	// long-running process. Without exec the shell stays resident and the
+	// orphaned sleep keeps stdout open, so the agent (which signals only the
+	// shell, matching OpenSSH) would not tear the command down.
+	p.ReadUntil(ctx, "started")
+
+	require.NoError(t, p.Signal(ssh.SIGKILL))
+
+	st, err := p.Wait(ctx)
+	require.NoError(t, err)
+	require.True(t, st.Done)
+	require.NotEqual(t, 0, st.ExitCode, "a killed process is not a clean exit")
+}
+
+// TestWrapSession_ShellBanner confirms the login output before the first prompt
+// is captured as the banner and the consumed prompt marker is not in it.
+func TestWrapSession_ShellBanner(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client := driverSSHClient(t)
+
+	sh, err := agenttest.WrapSession(t, driverSession(t, client)).Shell(ctx)
+	require.NoError(t, err)
+
+	require.NotContains(t, sh.Banner(), agenttest.PromptMarker, "the marker is consumed, not part of the banner")
+	if runtime.GOOS == "windows" {
+		require.Contains(t, sh.Banner(), "Microsoft Windows")
+	}
+}


### PR DESCRIPTION
## Summary

PR 3 of the SSH session test redesign (issue coder/internal#1560), following
[#26102](https://github.com/coder/coder/pull/26102) (merged). Test-only; no
production change.

`#1560` is the class of flaky SSH session tests that drive a session with a
`bufio.Scanner` read loop and blind `Fprintf` writes. When the remote process
dies, the write surfaces a bare `io.EOF` with no exit code or stderr, so the
failure is undiagnosable, and unbounded reads hang.

This adds a deterministic, composable replacement in `agent/agenttest`.

## API

`agenttest.WrapSession(t, *gossh.Session)` returns a `Session`; chain `.PTY()`
then `.Command(ctx, cmd)` or `.Shell(ctx)`.

- `Process` implements `io.ReadWriteCloser`: `Write` feeds stdin (logged to
  `t`), `Read` consumes stdout (`io.EOF` on exit), `Close` closes stdin. Plus
  `ReadUntil(ctx, token)`, `Signal`, `Wait`, `Status`, `Stderr`.
- A stdin op against an exited process returns a `*ProcessError` carrying the
  exit code and captured stderr, never a bare EOF.
- `Shell` adds prompt policy: `Shell(ctx)` returns after the first prompt;
  `Run`/`ReadPrompt`/`Banner`.
- `agenttest.ShellEnvInfo(t, ...)` forces a deterministic shell (`/bin/sh`,
  `cmd.exe`) whose prompt is `PromptMarker`, so interactive tests stop
  depending on the host shell or hand-rolled prompt detection.

Reads use `testutil.WaitBuffer` for ctx-bounded matching; `gossh` does the
stream copying (`session.Stdout`/`Stderr`), so the driver carries no copy
goroutines of its own.

## Testing

Verified on Linux and Windows (a live `windows-2022`-class host). Windows skips
are deliberate and documented: no reliable non-PTY line echo (`findstr` rejects
piped stdin), and the agent does not deliver SSH signals to Windows processes.
The PTY `Shell` path is verified against ConPTY/`cmd.exe`.

<details>
<summary>Design decisions</summary>

- **No `usershelltest` package.** The test `EnvInfoer` lives in `agenttest`
  because all consumers (`agent_test`, `agentssh_test`, `cli/ssh_test`) are
  external `_test` packages, so importing `agenttest` causes no cycle. A
  separate package was unjustified structure.
- **`Process` is an `io.ReadWriteCloser`.** Earlier drafts took `ctx` on
  `Write`/`Close`/`Signal` and hand-rolled stdin/stdout copy goroutines. This
  version conforms to the stdlib interfaces (composes with `io.Copy`,
  `io.WriteString`, `io.ReadAll`), logs writes, and keeps `ctx` only where it
  is honored (`Wait`, `ReadUntil`, `Run`).
- **Reads fail the test on timeout** (with the captured output) rather than
  returning an error, matching the test-helper contract. `*ProcessError` is
  reserved for the stdin path, which is the actual #1560 scenario.
- **Default wiring deferred.** Defaulting `agenttest.New`'s `EnvInfo` (and the
  migration of existing tests) is left to PR 4 so it lands with the consumers
  it serves; PR 3 is opt-in via `o.EnvInfo = agenttest.ShellEnvInfo(t)`.
- **Platform mechanics (validated, not assumed):** `cmd.exe` under ConPTY
  takes `CR` (not `LF`) to submit a line; the marker is matched as a substring
  on a wide PTY with ANSI stripped from returned text; the `Signal` test uses
  `exec sleep` so the signal targets the long-running process rather than a
  resident shell with an orphaned child.

</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
