### PR TITLE
fix(provisionersdk/scripts): remove existing agent binary before download

### DIFF
--- a/provisionersdk/scripts/bootstrap_linux.sh
+++ b/provisionersdk/scripts/bootstrap_linux.sh
@@ -12,6 +12,14 @@ BINARY_DIR="${BINARY_DIR:-$(mktemp -d -t coder.XXXXXX)}"
 BINARY_NAME=coder
 BINARY_URL=${ACCESS_URL}bin/coder-linux-${ARCH}
 cd "$BINARY_DIR"
+# Remove any existing agent binary before downloading. When BINARY_DIR persists
+# across workspace restarts (e.g. envbox sets BINARY_DIR=$HOME/.coder) and a
+# previous agent process is still holding the executable open, writing to the
+# existing inode fails with ETXTBSY (text file busy) and curl/wget would loop
+# forever returning error 23. Unlinking the path is permitted while the file is
+# executing; any running process keeps its mapping to the old inode and the
+# next download creates a fresh one.
+rm -f "${BINARY_NAME}"
 # Attempt to download the coder agent.
 # This could fail for a number of reasons, many of which are likely transient.
 # So just keep trying!


### PR DESCRIPTION
On Linux, `bootstrap_linux.sh` writes the downloaded agent directly to `${BINARY_DIR}/coder`. When `BINARY_DIR` persists across workspace restarts (envbox sets it to `$HOME/.coder`) and a previous agent process is still holding the executable open, curl/wget cannot open the file for writing and fail with `curl: (23) Failure writing output to destination` (Linux ETXTBSY, "text file busy"). The bootstrap loop then retries forever and the workspace never recovers without manual `rm -f $HOME/.coder/coder`.

Unlink the existing binary before entering the download loop. `unlink(2)` is permitted while the file is being executed, the still-running process keeps its mapping to the old inode, and the next download creates a fresh inode that the new agent can exec. `bootstrap_darwin.sh` always creates a fresh `mktemp -d` directory, so it is unaffected.

Fixes #25975

<sub>Authored by Coder Agents on behalf of @ericpaulsen.</sub>