### PR TITLE
fix(aibridge): check x-session-affinity header for OpenCode sessions

### DIFF
--- a/aibridge/session.go
+++ b/aibridge/session.go
@@ -76,7 +76,12 @@ func GuessSessionID(client Client, r *http.Request) *string {
 	case ClientCoderAgents:
 		return cleanRef(r.Header.Get("X-Coder-Chat-Id"))
 	case ClientOpenCode:
-		return cleanRef(r.Header.Get("X-OpenCode-Session"))
+		// Prefer X-OpenCode-Session (set by the OpenCode "Zen" provider).
+		if sid := cleanRef(r.Header.Get("X-OpenCode-Session")); sid != nil {
+			return sid
+		}
+		// Fall back to x-session-affinity (set by other providers).
+		return cleanRef(r.Header.Get("x-session-affinity"))
 	case ClientCrush:
 		return nil // Crush does not send a session ID header.
 	case ClientRoo:

--- a/aibridge/session_test.go
+++ b/aibridge/session_test.go
@@ -196,6 +196,18 @@ func TestGuessSessionID(t *testing.T) {
 			sessionID: utils.PtrTo("ses_15a48edefffe7oY0YcIHRv29dD"),
 		},
 		{
+			name:      "opencode_zen_header_takes_precedence_over_session_affinity",
+			client:    aibridge.ClientOpenCode,
+			headers:   map[string]string{"X-OpenCode-Session": "zen-session", "x-session-affinity": "other-session"},
+			sessionID: utils.PtrTo("zen-session"),
+		},
+		{
+			name:      "opencode_session_affinity_fallback",
+			client:    aibridge.ClientOpenCode,
+			headers:   map[string]string{"x-session-affinity": "affinity-session-123"},
+			sessionID: utils.PtrTo("affinity-session-123"),
+		},
+		{
 			name:   "opencode_without_session_header",
 			client: aibridge.ClientOpenCode,
 		},


### PR DESCRIPTION
## Summary

`X-OpenCode-Session` is only set by the OpenCode "Zen" provider. Other providers use `x-session-affinity` instead. This change falls back to `x-session-affinity` when `X-OpenCode-Session` is not present, so sessions are correctly identified regardless of the provider used.

Ref: https://github.com/coder/coder/pull/26128

## Changes

- `aibridge/session.go`: Prefer `X-OpenCode-Session` (Zen), fall back to `x-session-affinity` (other providers).
- `aibridge/session_test.go`: Add tests for precedence and fallback behavior.

> Generated with [Coder Agents](https://coder.com) by @dannykopping