### PR TITLE
fix(site/src/pages/AgentsPage): improve live tool activity

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -1506,7 +1506,7 @@ const AgentChatPage: FC = () => {
 		if (!response.queued) {
 			store.clearStreamState();
 			// Optimistically set status to "running" so the
-			// "Thinking..." indicator appears immediately.
+			// response-waiting indicator appears immediately.
 			// The server accepted the message (not queued),
 			// so it will start processing. The WebSocket
 			// status:running event no-ops via the

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -1506,7 +1506,7 @@ const AgentChatPage: FC = () => {
 		if (!response.queued) {
 			store.clearStreamState();
 			// Optimistically set status to "running" so the
-			// response-waiting indicator appears immediately.
+			// Thinking indicator appears immediately.
 			// The server accepted the message (not queued),
 			// so it will start processing. The WebSocket
 			// status:running event no-ops via the

--- a/site/src/pages/AgentsPage/components/ChatConversation/ChatStatusCallout.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ChatStatusCallout.tsx
@@ -1,40 +1,14 @@
 import { type FC, useEffect, useState } from "react";
 import { Alert, AlertDescription, AlertTitle } from "#/components/Alert/Alert";
 import { Link } from "#/components/Link/Link";
-import { Shimmer } from "../ChatElements";
-import { TranscriptRow } from "../ChatElements/TranscriptRow";
-import { ToolIcon } from "../ChatElements/tools/ToolIcon";
 import { getProviderStatusURL } from "./chatStatusHelpers";
 import type { LiveStatusModel } from "./liveStatusModel";
-
-const THINKING_TEXT = "Thinking...";
 
 type RetryOrFailedStatus = Extract<
 	LiveStatusModel,
 	{ phase: "retrying" } | { phase: "failed" }
 >;
 type ReconnectingStatus = Extract<LiveStatusModel, { phase: "reconnecting" }>;
-
-const StatusPlaceholder: FC<{
-	text: string;
-	shimmer?: boolean;
-	showThinkingIcon?: boolean;
-}> = ({ text, shimmer = false, showThinkingIcon = false }) => {
-	return (
-		<TranscriptRow className="gap-2 text-content-secondary">
-			{showThinkingIcon && <ToolIcon name="thinking" isError={false} />}
-			{shimmer ? (
-				<Shimmer as="span" className="text-[13px] leading-6">
-					{text}
-				</Shimmer>
-			) : (
-				<span className="text-[13px] leading-6 text-content-secondary">
-					{text}
-				</span>
-			)}
-		</TranscriptRow>
-	);
-};
 
 /**
  * Syncs with the system clock to produce a live countdown from an
@@ -178,25 +152,12 @@ export const ChatStatusCallout: FC<{
 	switch (status.phase) {
 		case "idle":
 		case "streaming":
-			return null;
 		case "starting":
-			return (
-				<StatusPlaceholder text={THINKING_TEXT} shimmer showThinkingIcon />
-			);
+			return null;
 		case "retrying":
-			return (
-				<>
-					<StatusAlert status={status} />
-					<StatusPlaceholder text={THINKING_TEXT} shimmer />
-				</>
-			);
+			return <StatusAlert status={status} />;
 		case "reconnecting":
-			return (
-				<>
-					<ReconnectingAlert status={status} />
-					<StatusPlaceholder text={THINKING_TEXT} shimmer />
-				</>
-			);
+			return <ReconnectingAlert status={status} />;
 		case "failed":
 			return <StatusAlert status={status} />;
 	}

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.stories.tsx
@@ -33,23 +33,6 @@ const meta: Meta<typeof StreamingOutput> = {
 export default meta;
 type Story = StoryObj<typeof StreamingOutput>;
 
-/** Default shimmer placeholder with no stream state. */
-export const ThinkingPlaceholder: Story = {
-	args: {
-		streamState: null,
-		streamTools: [],
-		liveStatus: buildLiveStatus({ isAwaitingFirstStreamChunk: true }),
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const matches = canvas.getAllByText("Thinking...");
-		expect(matches.length).toBeGreaterThanOrEqual(1);
-		expect(
-			canvas.queryByRole("heading", { name: /retrying request/i }),
-		).not.toBeInTheDocument();
-	},
-};
-
 /** Transport reconnects render a non-terminal reconnecting callout. */
 export const ReconnectingAfterDisconnect: Story = {
 	args: {
@@ -73,8 +56,8 @@ export const ReconnectingAfterDisconnect: Story = {
 			expect(canvasElement.textContent).toMatch(/reconnecting in \d+s/i);
 		});
 		expect(canvas.queryByText("Unexpected error")).not.toBeInTheDocument();
-		const thinkingMatches = canvas.getAllByText(/thinking\.\.\.$/i);
-		expect(thinkingMatches.length).toBeGreaterThanOrEqual(1);
+		expect(canvas.getByTestId("live-activity-slot")).not.toBeVisible();
+		expect(canvas.queryByText("Thinking...")).not.toBeInTheDocument();
 	},
 };
 
@@ -96,6 +79,8 @@ export const RetryWithVisibleReason: Story = {
 		expect(
 			canvas.getByText(/anthropic returned an unexpected error/i),
 		).toBeVisible();
+		expect(canvas.getByTestId("live-activity-slot")).not.toBeVisible();
+		expect(canvas.queryByText("Thinking...")).not.toBeInTheDocument();
 		expect(canvas.getByText(/attempt 1/i)).toBeVisible();
 		expect(canvas.queryByText(/please try again/i)).not.toBeInTheDocument();
 		expect(canvas.queryByText(/provider anthropic/i)).not.toBeInTheDocument();
@@ -254,12 +239,40 @@ export const RetryStreamSilenceTimeout: Story = {
 	},
 };
 
-/**
- * During streaming, if only tool-call blocks have arrived (no text
- * or reasoning), the "Thinking" indicator should still be visible
- * alongside the tool cards.
- */
-export const ThinkingDuringStreamingWithToolCalls: Story = {
+const responseStreamState = buildStreamRenderState([
+	{
+		type: "text" as const,
+		text: "The answer is streaming.",
+	},
+]);
+
+export const StartingShowsThinkingActivity: Story = {
+	args: {
+		streamState: null,
+		streamTools: [],
+		liveStatus: buildLiveStatus({ isAwaitingFirstStreamChunk: true }),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("Thinking")).toBeVisible();
+		expect(canvas.getByTestId("live-activity-slot")).toBeVisible();
+	},
+};
+
+export const ResponseKeepsActivitySlotReserved: Story = {
+	args: {
+		streamState: responseStreamState.streamState,
+		streamTools: responseStreamState.streamTools,
+		liveStatus: responseStreamState.liveStatus,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByTestId("live-activity-slot")).not.toBeVisible();
+	},
+};
+
+/** Tool-only streams use running tool affordances instead of generic thinking. */
+export const RunningToolsSuppressThinkingActivity: Story = {
 	args: {
 		...buildStreamRenderState([
 			{
@@ -278,31 +291,89 @@ export const ThinkingDuringStreamingWithToolCalls: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		// Tool-only stream chunks can otherwise clear the activity indicator before text arrives.
-		expect(canvas.getAllByText("Thinking").length).toBeGreaterThanOrEqual(1);
+		expect(canvas.getByTestId("live-activity-slot")).not.toBeVisible();
+		expect(
+			canvas.getByRole("button", { name: /expand command/i }),
+		).toBeVisible();
+		expect(canvas.getByText(/reading README\.md/i)).toBeVisible();
+	},
+};
 
-		const executeButton = canvas.getByRole("button", {
-			name: /expand command/i,
-		});
-		const readFileLabel = canvas.getByText(/reading README\.md/i);
-		const thinkingText = canvas.getAllByText("Thinking").at(-1);
-		expect(thinkingText).toBeInstanceOf(HTMLElement);
+const editFilesArgs = {
+	files: JSON.stringify([
+		{
+			path: "src/config.ts",
+			edits: [
+				{
+					old_text: "const timeout = 30;",
+					new_text: "const timeout = 60;",
+				},
+			],
+		},
+	]),
+};
 
-		const wrappers = [
-			executeButton.closest("[data-transcript-row]") ?? executeButton,
-			readFileLabel.closest("[data-tool-call]") ?? readFileLabel,
-			(thinkingText as HTMLElement).closest("[data-transcript-row]") ??
-				(thinkingText as HTMLElement),
-		];
-		expect(wrappers.at(-1)).toHaveTextContent("Thinking");
+const editFilesRunningState = buildStreamRenderState([
+	{
+		type: "tool-call",
+		tool_call_id: "edit-tool",
+		tool_name: "edit_files",
+		args: editFilesArgs,
+	},
+]);
 
-		const gap = Math.round(
-			wrappers[2].getBoundingClientRect().top -
-				wrappers[1].getBoundingClientRect().bottom,
+const editFilesEmptyDeltaState = buildStreamRenderState([
+	{
+		type: "tool-call",
+		tool_call_id: "edit-tool",
+		tool_name: "edit_files",
+		args: editFilesArgs,
+	},
+	{
+		type: "tool-result",
+		tool_call_id: "edit-tool",
+		tool_name: "edit_files",
+		result_delta: "",
+	},
+]);
+
+const getEditFilesToolHeight = (canvasElement: HTMLElement) => {
+	const editTool = canvasElement.querySelector("[data-transcript-row]");
+	expect(editTool).not.toBeNull();
+	return Math.round(editTool?.getBoundingClientRect().height ?? 0);
+};
+
+/** Empty result deltas should not create an invisible completed tool result. */
+export const EditFilesEmptyDeltaKeepsRunningHeight: Story = {
+	render: () => {
+		return (
+			<div className="flex flex-col gap-2">
+				<div data-testid="running-edit-files">
+					<StreamingOutput
+						streamState={editFilesRunningState.streamState}
+						streamTools={editFilesRunningState.streamTools}
+						liveStatus={editFilesRunningState.liveStatus}
+					/>
+				</div>
+				<div data-testid="empty-delta-edit-files">
+					<StreamingOutput
+						streamState={editFilesEmptyDeltaState.streamState}
+						streamTools={editFilesEmptyDeltaState.streamTools}
+						liveStatus={editFilesEmptyDeltaState.liveStatus}
+					/>
+				</div>
+			</div>
 		);
-		expect(gap).toBe(8);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const running = canvas.getByTestId("running-edit-files");
+		const emptyDelta = canvas.getByTestId("empty-delta-edit-files");
 
-		const placeholderRow = wrappers[2].firstElementChild ?? wrappers[2];
-		expect(Math.round(placeholderRow.getBoundingClientRect().height)).toBe(24);
+		expect(within(running).getByText(/Editing files/)).toBeVisible();
+		expect(within(emptyDelta).getByText(/Editing files/)).toBeVisible();
+		expect(getEditFilesToolHeight(emptyDelta)).toBe(
+			getEditFilesToolHeight(running),
+		);
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -21,14 +21,14 @@ const hasTransientLiveStatus = (liveStatus: LiveStatusModel): boolean =>
 
 const LiveActivitySlot: FC<{
 	visible: boolean;
-	overlay: boolean;
-}> = ({ visible, overlay }) => (
+	detached: boolean;
+}> = ({ visible, detached }) => (
 	<div
 		data-testid="live-activity-slot"
 		aria-hidden={!visible}
 		className={cn(
 			"flex items-center gap-2 text-content-secondary",
-			overlay ? "pointer-events-none absolute left-0 top-full mt-2" : "h-6",
+			detached ? "pointer-events-none absolute left-0 top-full mt-2" : "h-6",
 			!visible && "invisible",
 		)}
 	>
@@ -100,7 +100,7 @@ export const StreamingOutput: FC<{
 						)}
 						<LiveActivitySlot
 							visible={showActivity}
-							overlay={hasVisibleFlowContent}
+							detached={hasVisibleFlowContent}
 						/>
 					</div>
 				</MessageContent>

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -1,47 +1,41 @@
 import type { FC } from "react";
 import type { UrlTransform } from "streamdown";
 import type * as TypesGen from "#/api/typesGenerated";
+import { cn } from "#/utils/cn";
 import {
 	ConversationItem,
 	Message,
 	MessageContent,
 	Shimmer,
 } from "../ChatElements";
-import { TranscriptRow } from "../ChatElements/TranscriptRow";
 import type { SubagentVariant } from "../ChatElements/tools/subagentDescriptor";
 import { ToolIcon } from "../ChatElements/tools/ToolIcon";
 import { ChatStatusCallout } from "./ChatStatusCallout";
 import { BlockList } from "./ConversationTimeline";
 import type { LiveStatusModel } from "./liveStatusModel";
-import type { MergedTool, RenderBlock, StreamState } from "./types";
+import { shouldShowGenericThinking } from "./streamingActivity";
+import type { MergedTool, StreamState } from "./types";
 
 const hasTransientLiveStatus = (liveStatus: LiveStatusModel): boolean =>
-	liveStatus.phase === "starting" ||
-	liveStatus.phase === "retrying" ||
-	liveStatus.phase === "reconnecting";
+	liveStatus.phase === "retrying" || liveStatus.phase === "reconnecting";
 
-/**
- * True when the block list contains at least one text or reasoning
- * block. Tool-call blocks don't count; the placeholder should
- * remain visible between tool calls so the user knows the model
- * is still working.
- */
-const hasTextOrReasoningBlock = (blocks: readonly RenderBlock[]): boolean =>
-	blocks.some((b) => b.type === "response" || b.type === "thinking");
-
-/**
- * Placeholder shown during streaming before text or reasoning
- * blocks arrive. Uses the same shimmer animation and typography
- * as the ChatStatusCallout status placeholder.
- */
-const StreamingThinkingPlaceholder: FC = () => (
-	<div data-transcript-row="" className="text-content-secondary">
-		<TranscriptRow className="w-full gap-2">
-			<ToolIcon name="thinking" isError={false} />
-			<Shimmer as="span" className="text-[13px] leading-6">
-				Thinking
-			</Shimmer>
-		</TranscriptRow>
+const LiveActivitySlot: FC<{
+	visible: boolean;
+	overlay: boolean;
+}> = ({ visible, overlay }) => (
+	<div
+		data-testid="live-activity-slot"
+		aria-hidden={!visible}
+		className={cn(
+			"flex items-center gap-2 text-content-secondary",
+			overlay ? "pointer-events-none absolute left-0 top-full mt-2" : "h-6",
+			!visible && "invisible",
+		)}
+	>
+		<ToolIcon name="thinking" isError={false} />
+		<Shimmer as="span" className="text-[13px] leading-6">
+			Thinking
+		</Shimmer>
 	</div>
 );
 
@@ -73,21 +67,13 @@ export const StreamingOutput: FC<{
 		liveStatus.phase === "streaming" || liveStatus.hasAccumulatedOutput;
 	const blocks = shouldShowBlocks ? (streamState?.blocks ?? []) : [];
 
-	// During streaming, keep showing the "Thinking..." indicator
-	// until text or reasoning blocks arrive. This bridges the
-	// visual gap between the "starting" phase placeholder and the
-	// first visible content, preventing the indicator from
-	// flickering away when only tool-call parts (or whitespace-
-	// only text deltas) have been received so far.
-	const needsStreamingThinking =
-		isStreaming && !hasTextOrReasoningBlock(blocks);
-
-	const shouldShowStatusCallout =
-		hasTransientLiveStatus(liveStatus) || needsStreamingThinking;
-
-	if (!shouldShowBlocks && !shouldShowStatusCallout) {
-		return null;
-	}
+	const showActivity = shouldShowGenericThinking({
+		liveStatus,
+		streamState,
+		streamTools,
+	});
+	const hasVisibleFlowContent =
+		shouldShowBlocks || hasTransientLiveStatus(liveStatus);
 
 	const conversationItemProps = { role: "assistant" as const };
 
@@ -109,10 +95,13 @@ export const StreamingOutput: FC<{
 								mcpServers={mcpServers}
 							/>
 						)}
-						{needsStreamingThinking && <StreamingThinkingPlaceholder />}
-						{!needsStreamingThinking && hasTransientLiveStatus(liveStatus) && (
+						{hasTransientLiveStatus(liveStatus) && (
 							<ChatStatusCallout status={liveStatus} />
 						)}
+						<LiveActivitySlot
+							visible={showActivity}
+							overlay={hasVisibleFlowContent}
+						/>
 					</div>
 				</MessageContent>
 			</Message>

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -16,7 +16,7 @@ import type { LiveStatusModel } from "./liveStatusModel";
 import { shouldShowGenericThinking } from "./streamingActivity";
 import type { MergedTool, StreamState } from "./types";
 
-const hasTransientLiveStatus = (liveStatus: LiveStatusModel): boolean =>
+const hasCalloutLiveStatus = (liveStatus: LiveStatusModel): boolean =>
 	liveStatus.phase === "retrying" || liveStatus.phase === "reconnecting";
 
 const LiveActivitySlot: FC<{
@@ -73,7 +73,7 @@ export const StreamingOutput: FC<{
 		streamTools,
 	});
 	const hasVisibleFlowContent =
-		shouldShowBlocks || hasTransientLiveStatus(liveStatus);
+		shouldShowBlocks || hasCalloutLiveStatus(liveStatus);
 
 	const conversationItemProps = { role: "assistant" as const };
 
@@ -95,7 +95,7 @@ export const StreamingOutput: FC<{
 								mcpServers={mcpServers}
 							/>
 						)}
-						{hasTransientLiveStatus(liveStatus) && (
+						{hasCalloutLiveStatus(liveStatus) && (
 							<ChatStatusCallout status={liveStatus} />
 						)}
 						<LiveActivitySlot

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
@@ -774,7 +774,7 @@ describe("selectIsAwaitingFirstStreamChunk", () => {
 		store.setChatStatus("running");
 		store.upsertDurableMessage(makeMessage(3, "user", "follow-up"));
 
-		// "Thinking..." should appear immediately.
+		// the response-waiting indicator should appear immediately.
 		expect(selectIsAwaitingFirstStreamChunk(store.getSnapshot())).toBe(true);
 	});
 
@@ -782,7 +782,7 @@ describe("selectIsAwaitingFirstStreamChunk", () => {
 		const store = createChatStore();
 		// Simulate the WS batch: [message(user), status:pending].
 		// This is the exact event order from the server when the
-		// user sends a message. "Thinking..." must appear during
+		// user sends a message. The response-waiting indicator must appear during
 		// the pending phase so there is no visual gap before the
 		// server transitions to running.
 		store.upsertDurableMessage(makeMessage(1, "user", "sweet ty"));

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
@@ -774,7 +774,6 @@ describe("selectIsAwaitingFirstStreamChunk", () => {
 		store.setChatStatus("running");
 		store.upsertDurableMessage(makeMessage(3, "user", "follow-up"));
 
-		// the response-waiting indicator should appear immediately.
 		expect(selectIsAwaitingFirstStreamChunk(store.getSnapshot())).toBe(true);
 	});
 
@@ -782,7 +781,7 @@ describe("selectIsAwaitingFirstStreamChunk", () => {
 		const store = createChatStore();
 		// Simulate the WS batch: [message(user), status:pending].
 		// This is the exact event order from the server when the
-		// user sends a message. The response-waiting indicator must appear during
+		// user sends a message. The Thinking indicator must appear during
 		// the pending phase so there is no visual gap before the
 		// server transitions to running.
 		store.upsertDurableMessage(makeMessage(1, "user", "sweet ty"));

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -3271,7 +3271,7 @@ describe("thinking indicator event ordering", () => {
 
 		// Server sends message_part BEFORE status:running in the same
 		// WebSocket frame. This is the event ordering that previously
-		// caused the "Thinking..." indicator to be skipped.
+		// caused the response-waiting indicator to be skipped.
 		act(() => {
 			mockSocket.emitDataBatch([
 				{
@@ -3291,7 +3291,7 @@ describe("thinking indicator event ordering", () => {
 
 		// After the batch, the status should be "running" but stream
 		// parts should NOT have been applied yet (deferred to
-		// setTimeout). This is the window where "Thinking..." shows.
+		// setTimeout). This is the window where the response-waiting indicator shows.
 		await waitFor(() => {
 			expect(result.current.chatStatus).toBe("running");
 			expect(result.current.streamState).toBeNull();

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -3271,7 +3271,7 @@ describe("thinking indicator event ordering", () => {
 
 		// Server sends message_part BEFORE status:running in the same
 		// WebSocket frame. This is the event ordering that previously
-		// caused the response-waiting indicator to be skipped.
+		// caused the Thinking indicator to be skipped.
 		act(() => {
 			mockSocket.emitDataBatch([
 				{
@@ -3291,7 +3291,7 @@ describe("thinking indicator event ordering", () => {
 
 		// After the batch, the status should be "running" but stream
 		// parts should NOT have been applied yet (deferred to
-		// setTimeout). This is the window where the response-waiting indicator shows.
+		// setTimeout). This is the window where the Thinking indicator shows.
 		await waitFor(() => {
 			expect(result.current.chatStatus).toBe("running");
 			expect(result.current.streamState).toBeNull();

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
@@ -661,7 +661,7 @@ export const selectIsAwaitingFirstStreamChunk = (
 	const latestMessage = selectLatestDurableMessage(state);
 	const latestMessageNeedsAssistantResponse =
 		!latestMessage || latestMessage.role !== "assistant";
-	// Show the response-waiting indicator when the store has no stream
+	// Show the Thinking indicator when the store has no stream
 	// data yet and the conversation is waiting for an assistant
 	// response. For "running" status we use the existing broad
 	// check (any non-assistant latest message). For "pending" we

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
@@ -661,7 +661,7 @@ export const selectIsAwaitingFirstStreamChunk = (
 	const latestMessage = selectLatestDurableMessage(state);
 	const latestMessageNeedsAssistantResponse =
 		!latestMessage || latestMessage.role !== "assistant";
-	// Show the "Thinking..." indicator when the store has no stream
+	// Show the response-waiting indicator when the store has no stream
 	// data yet and the conversation is waiting for an assistant
 	// response. For "running" status we use the existing broad
 	// check (any non-assistant latest message). For "pending" we

--- a/site/src/pages/AgentsPage/components/ChatConversation/streamState.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/streamState.test.ts
@@ -276,6 +276,28 @@ describe("applyMessagePartToStreamState", () => {
 		).toBe("completed");
 	});
 
+	it("ignores empty tool result deltas", () => {
+		let state: StreamState | null = null;
+		state = applyMessagePartToStreamState(state, {
+			type: "tool-call",
+			tool_name: "edit_files",
+			tool_call_id: "edit-1",
+			args: { files: "[]" },
+		});
+		state = applyMessagePartToStreamState(state, {
+			type: "tool-result",
+			tool_name: "edit_files",
+			tool_call_id: "edit-1",
+			result_delta: "",
+		});
+
+		expect(state).not.toBeNull();
+		expect(state!.toolResults["edit-1"]).toBeUndefined();
+		expect(
+			buildStreamTools(state!.toolCalls, state!.toolResults)[0].status,
+		).toBe("running");
+	});
+
 	it("resets streaming tool result deltas", () => {
 		let state: StreamState | null = null;
 		state = applyMessagePartToStreamState(state, {

--- a/site/src/pages/AgentsPage/components/ChatConversation/streamState.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/streamState.test.ts
@@ -276,6 +276,98 @@ describe("applyMessagePartToStreamState", () => {
 		).toBe("completed");
 	});
 
+	it("completes a streamed tool result when an empty delta carries the final result", () => {
+		let state: StreamState | null = null;
+		state = applyMessagePartToStreamState(state, {
+			type: "tool-call",
+			tool_name: "advisor",
+			tool_call_id: "call-advisor-2",
+			args: { question: "What is the safe path?" },
+		});
+		state = applyMessagePartToStreamState(state, {
+			type: "tool-result",
+			tool_name: "advisor",
+			tool_call_id: "call-advisor-2",
+			result_delta: "Use ",
+		});
+
+		expect(state!.toolResults["call-advisor-2"]).toMatchObject({
+			result: "Use ",
+			isStreaming: true,
+		});
+		expect(
+			buildStreamTools(state!.toolCalls, state!.toolResults)[0].status,
+		).toBe("running");
+
+		state = applyMessagePartToStreamState(state, {
+			type: "tool-result",
+			tool_name: "advisor",
+			tool_call_id: "call-advisor-2",
+			result_delta: "",
+			result: {
+				type: "advice",
+				advice: "Use small steps.",
+				advisor_model: "test-provider/test-model",
+				remaining_uses: "2",
+			},
+		});
+
+		expect(state!.toolResults["call-advisor-2"]).toMatchObject({
+			result: {
+				type: "advice",
+				advice: "Use small steps.",
+				advisor_model: "test-provider/test-model",
+				remaining_uses: "2",
+			},
+			isError: false,
+		});
+		expect(state!.toolResults["call-advisor-2"].isStreaming).toBeUndefined();
+		expect(
+			buildStreamTools(state!.toolCalls, state!.toolResults)[0].status,
+		).toBe("completed");
+	});
+
+	it("marks a streamed tool result as error when an empty delta carries is_error", () => {
+		let state: StreamState | null = null;
+		state = applyMessagePartToStreamState(state, {
+			type: "tool-call",
+			tool_name: "advisor",
+			tool_call_id: "call-advisor-3",
+			args: { question: "What is the safe path?" },
+		});
+		state = applyMessagePartToStreamState(state, {
+			type: "tool-result",
+			tool_name: "advisor",
+			tool_call_id: "call-advisor-3",
+			result_delta: "partial advice",
+		});
+
+		expect(state!.toolResults["call-advisor-3"]).toMatchObject({
+			result: "partial advice",
+			isStreaming: true,
+		});
+		expect(
+			buildStreamTools(state!.toolCalls, state!.toolResults)[0].status,
+		).toBe("running");
+
+		state = applyMessagePartToStreamState(state, {
+			type: "tool-result",
+			tool_name: "advisor",
+			tool_call_id: "call-advisor-3",
+			result_delta: "",
+			is_error: true,
+		});
+
+		expect(state!.toolResults["call-advisor-3"]).toMatchObject({
+			result: "partial advice",
+			isError: true,
+		});
+		expect(state!.toolResults["call-advisor-3"].isStreaming).toBeUndefined();
+		expect(
+			buildStreamTools(state!.toolCalls, state!.toolResults)[0].status,
+		).toBe("error");
+	});
+
 	it("ignores empty tool result deltas", () => {
 		let state: StreamState | null = null;
 		state = applyMessagePartToStreamState(state, {

--- a/site/src/pages/AgentsPage/components/ChatConversation/streamState.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/streamState.ts
@@ -116,7 +116,11 @@ export const applyMessagePartToStreamState = (
 					toolResults,
 				};
 			}
-			if (part.result_delta === "") {
+			if (
+				part.result_delta === "" &&
+				part.result === undefined &&
+				!part.is_error
+			) {
 				return {
 					...nextState,
 					blocks: ensureToolBlock(nextState.blocks, toolCallID),

--- a/site/src/pages/AgentsPage/components/ChatConversation/streamState.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/streamState.ts
@@ -116,6 +116,12 @@ export const applyMessagePartToStreamState = (
 					toolResults,
 				};
 			}
+			if (part.result_delta === "") {
+				return {
+					...nextState,
+					blocks: ensureToolBlock(nextState.blocks, toolCallID),
+				};
+			}
 
 			const nextResult = mergeStreamPayload(
 				existing?.result,

--- a/site/src/pages/AgentsPage/components/ChatConversation/streamingActivity.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/streamingActivity.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import type { LiveStatusModel } from "./liveStatusModel";
+import { shouldShowGenericThinking } from "./streamingActivity";
+import type { MergedTool, StreamState } from "./types";
+
+const liveStatus = (phase: LiveStatusModel["phase"]): LiveStatusModel => {
+	switch (phase) {
+		case "idle":
+			return { phase: "idle", hasAccumulatedOutput: false };
+		case "starting":
+			return { phase: "starting", hasAccumulatedOutput: false };
+		case "streaming":
+			return { phase: "streaming", hasAccumulatedOutput: false };
+		case "retrying":
+			return {
+				phase: "retrying",
+				hasAccumulatedOutput: false,
+				attempt: 1,
+				kind: "generic",
+				title: "Retrying request",
+				message: "Retrying",
+			};
+		case "reconnecting":
+			return {
+				phase: "reconnecting",
+				hasAccumulatedOutput: false,
+				attempt: 1,
+				delayMs: 1000,
+				retryingAt: "2026-03-10T00:00:01.000Z",
+				title: "Reconnecting",
+				message: "Reconnecting",
+			};
+		case "failed":
+			return {
+				phase: "failed",
+				hasAccumulatedOutput: false,
+				kind: "generic",
+				title: "Failed",
+				message: "Failed",
+			};
+	}
+};
+
+const streamState = (blocks: StreamState["blocks"]): StreamState => ({
+	blocks,
+	toolCalls: {},
+	toolResults: {},
+	sources: [],
+});
+
+const tool = (status: MergedTool["status"]): MergedTool => ({
+	id: status,
+	name: "read_file",
+	isError: false,
+	status,
+});
+
+describe("shouldShowGenericThinking", () => {
+	it("shows for starting", () => {
+		expect(
+			shouldShowGenericThinking({
+				liveStatus: liveStatus("starting"),
+				streamState: null,
+				streamTools: [],
+			}),
+		).toBe(true);
+	});
+
+	it("shows for streaming with no readable blocks or running tools", () => {
+		expect(
+			shouldShowGenericThinking({
+				liveStatus: liveStatus("streaming"),
+				streamState: null,
+				streamTools: [],
+			}),
+		).toBe(true);
+	});
+
+	it("hides for streaming with a running tool", () => {
+		expect(
+			shouldShowGenericThinking({
+				liveStatus: liveStatus("streaming"),
+				streamState: streamState([{ type: "tool", id: "read-1" }]),
+				streamTools: [tool("running")],
+			}),
+		).toBe(false);
+	});
+
+	it("shows after tools complete but before readable output", () => {
+		expect(
+			shouldShowGenericThinking({
+				liveStatus: liveStatus("streaming"),
+				streamState: streamState([{ type: "tool", id: "read-1" }]),
+				streamTools: [tool("completed")],
+			}),
+		).toBe(true);
+	});
+
+	it("hides when response text is visible", () => {
+		expect(
+			shouldShowGenericThinking({
+				liveStatus: liveStatus("streaming"),
+				streamState: streamState([{ type: "response", text: "hello" }]),
+				streamTools: [],
+			}),
+		).toBe(false);
+	});
+
+	it("hides when reasoning is visible", () => {
+		expect(
+			shouldShowGenericThinking({
+				liveStatus: liveStatus("streaming"),
+				streamState: streamState([{ type: "thinking", text: "thinking" }]),
+				streamTools: [],
+			}),
+		).toBe(false);
+	});
+
+	it.each([
+		"idle",
+		"retrying",
+		"reconnecting",
+		"failed",
+	] as const)("hides for %s", (phase) => {
+		expect(
+			shouldShowGenericThinking({
+				liveStatus: liveStatus(phase),
+				streamState: null,
+				streamTools: [],
+			}),
+		).toBe(false);
+	});
+});

--- a/site/src/pages/AgentsPage/components/ChatConversation/streamingActivity.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/streamingActivity.ts
@@ -1,7 +1,7 @@
 import type { LiveStatusModel } from "./liveStatusModel";
 import type { MergedTool, StreamState } from "./types";
 
-const hasReadableStreamBlock = (streamState: StreamState | null): boolean =>
+const hasTextOrThinkingBlock = (streamState: StreamState | null): boolean =>
 	streamState?.blocks.some(
 		(block) => block.type === "response" || block.type === "thinking",
 	) ?? false;
@@ -20,5 +20,5 @@ export const shouldShowGenericThinking = ({
 }): boolean =>
 	liveStatus.phase === "starting" ||
 	(liveStatus.phase === "streaming" &&
-		!hasReadableStreamBlock(streamState) &&
+		!hasTextOrThinkingBlock(streamState) &&
 		!hasRunningTool(streamTools));

--- a/site/src/pages/AgentsPage/components/ChatConversation/streamingActivity.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/streamingActivity.ts
@@ -1,0 +1,24 @@
+import type { LiveStatusModel } from "./liveStatusModel";
+import type { MergedTool, StreamState } from "./types";
+
+const hasReadableStreamBlock = (streamState: StreamState | null): boolean =>
+	streamState?.blocks.some(
+		(block) => block.type === "response" || block.type === "thinking",
+	) ?? false;
+
+const hasRunningTool = (streamTools: readonly MergedTool[]): boolean =>
+	streamTools.some((tool) => tool.status === "running");
+
+export const shouldShowGenericThinking = ({
+	liveStatus,
+	streamState,
+	streamTools,
+}: {
+	liveStatus: LiveStatusModel;
+	streamState: StreamState | null;
+	streamTools: readonly MergedTool[];
+}): boolean =>
+	liveStatus.phase === "starting" ||
+	(liveStatus.phase === "streaming" &&
+		!hasReadableStreamBlock(streamState) &&
+		!hasRunningTool(streamTools));

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -454,7 +454,7 @@ export const useChatStore = (
 					// partial output. Other events (status, retry,
 					// queue_update) must NOT flush — status changes
 					// need to be visible before parts so the
-					// response-waiting indicator can render, and retry
+					// Thinking indicator can render, and retry
 					// clears stream state which a flush would
 					// re-populate.
 					if (streamEvent.type === "message" || streamEvent.type === "error") {

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -454,7 +454,7 @@ export const useChatStore = (
 					// partial output. Other events (status, retry,
 					// queue_update) must NOT flush — status changes
 					// need to be visible before parts so the
-					// "Thinking..." indicator can render, and retry
+					// response-waiting indicator can render, and retry
 					// clears stream state which a flush would
 					// re-populate.
 					if (streamEvent.type === "message" || streamEvent.type === "error") {

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/AdvisorTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/AdvisorTool.tsx
@@ -1,10 +1,9 @@
-import { CircleAlertIcon, LoaderIcon, TriangleAlertIcon } from "lucide-react";
+import { CircleAlertIcon, TriangleAlertIcon } from "lucide-react";
 import type React from "react";
 import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
 import { cn } from "#/utils/cn";
 import { Response } from "../Response";
-import { ToolCollapsible } from "./ToolCollapsible";
-import { ToolIcon } from "./ToolIcon";
+import { ToolCall } from "./ToolCall";
 import { ToolLabel } from "./ToolLabel";
 import type { ToolStatus } from "./utils";
 
@@ -46,117 +45,124 @@ export const AdvisorTool: React.FC<AdvisorToolProps> = ({
 	const showLimitReached = resultType === "limit_reached";
 	const showError = isError || resultType === "error";
 
+	const headerStatus = showLimitReached ? (
+		<TriangleAlertIcon className="mt-0.5 size-3.5 shrink-0 text-content-warning" />
+	) : showError ? (
+		<CircleAlertIcon className="mt-0.5 size-3.5 shrink-0 text-content-destructive" />
+	) : (
+		<ToolCall.Status className="mt-0.5 text-content-secondary" />
+	);
+
 	return (
-		<ToolCollapsible
+		<ToolCall.Root
 			className="w-full"
+			status={status}
+			isError={showError}
+			errorMessage={effectiveErrorMessage}
 			hasContent
 			defaultExpanded
-			headerClassName="items-start"
-			header={(expanded) => (
-				<div className="flex min-w-0 flex-1 flex-col gap-0.5">
-					<div className="flex min-w-0 items-center gap-2 leading-4">
-						<ToolIcon
-							name="advisor"
-							isError={showError}
-							isRunning={isRunning}
-						/>
-						<ToolLabel
-							name="advisor"
-							args={{ question: questionText }}
-							result={resultType ? { type: resultType } : undefined}
-						/>
-						{isRunning && (
-							<span className="shrink-0 rounded-full border border-solid border-border-default px-2 text-[13px] leading-4 text-content-secondary">
-								{RUNNING_MESSAGE}
-							</span>
-						)}
-						{advisorModelText && (
-							<span className="min-w-0 truncate rounded-full border border-solid border-border-default px-2 text-[13px] leading-4 text-content-secondary">
-								{advisorModelText}
-							</span>
-						)}
-						{remainingUses !== undefined && (
-							<span className="shrink-0 rounded-full border border-solid border-border-default px-2 text-[13px] leading-4 text-content-secondary">
-								{remainingUses.toLocaleString("en-US")} uses left
-							</span>
-						)}
-					</div>
-					<span
-						className={cn(
-							"ml-6 block whitespace-normal break-words text-[13px]",
-							"font-normal leading-5 text-content-primary",
-							"[overflow-wrap:anywhere]",
-							!expanded && "line-clamp-2",
-						)}
-					>
-						{questionText}
-					</span>
-				</div>
-			)}
-			headerStatus={
-				showLimitReached ? (
-					<TriangleAlertIcon className="mt-0.5 size-3.5 shrink-0 text-content-warning" />
-				) : showError ? (
-					<CircleAlertIcon className="mt-0.5 size-3.5 shrink-0 text-content-destructive" />
-				) : isRunning ? (
-					<LoaderIcon className="mt-0.5 size-3.5 shrink-0 animate-spin motion-reduce:animate-none text-content-secondary" />
-				) : null
-			}
 		>
-			<ScrollArea
-				className="mt-1.5 rounded-md border border-solid border-border-default bg-surface-primary"
-				viewportClassName="max-h-64"
-				scrollBarClassName="w-1.5"
-				data-testid="advisor-tool-scroll-area"
-			>
-				<div className="space-y-3 px-3 py-2">
-					{isRunning && adviceText.length === 0 ? (
-						<div role="status" className="text-sm text-content-secondary">
-							Reviewing context and preparing guidance.
-						</div>
-					) : showLimitReached ? (
-						<div
-							role="status"
-							className="flex items-start gap-3 rounded-md border border-solid border-border-warning bg-surface-orange p-3 text-sm text-content-primary"
-						>
-							<TriangleAlertIcon className="mt-0.5 size-4 shrink-0 text-content-warning" />
-							<div className="space-y-1">
-								<p className="m-0 font-medium">Advisor limit reached.</p>
-								<p className="m-0 text-content-primary">
-									{LIMIT_REACHED_MESSAGE}
-								</p>
-							</div>
-						</div>
-					) : showError ? (
-						<div
-							role="alert"
-							className="flex items-start gap-3 rounded-md border border-solid border-border-destructive bg-surface-red p-3 text-sm text-content-primary"
-						>
-							<CircleAlertIcon className="mt-0.5 size-4 shrink-0 text-content-destructive" />
-							<div className="space-y-1">
-								<p className="m-0 font-medium">Advisor request failed.</p>
-								<p className="m-0 text-content-primary [overflow-wrap:anywhere]">
-									{effectiveErrorMessage}
-								</p>
-							</div>
-						</div>
-					) : (
-						<section className="space-y-2" aria-label="Advisor advice">
-							<div>
-								<span className="inline-flex rounded-full border border-solid border-border-default px-2 text-[13px] leading-4 text-content-secondary">
-									Advice
+			<ToolCall.HeaderButton className="items-start">
+				<ToolCall.State>
+					{({ expanded }) => (
+						<>
+							<div className="flex min-w-0 flex-1 flex-col gap-0.5">
+								<div className="flex min-w-0 items-center gap-2 leading-4">
+									<ToolCall.LeadingIcon name="advisor" />
+									<ToolLabel
+										name="advisor"
+										args={{ question: questionText }}
+										result={resultType ? { type: resultType } : undefined}
+									/>
+									{isRunning && (
+										<span className="shrink-0 rounded-full border border-solid border-border-default px-2 text-[13px] leading-4 text-content-secondary">
+											{RUNNING_MESSAGE}
+										</span>
+									)}
+									{advisorModelText && (
+										<span className="min-w-0 truncate rounded-full border border-solid border-border-default px-2 text-[13px] leading-4 text-content-secondary">
+											{advisorModelText}
+										</span>
+									)}
+									{remainingUses !== undefined && (
+										<span className="shrink-0 rounded-full border border-solid border-border-default px-2 text-[13px] leading-4 text-content-secondary">
+											{remainingUses.toLocaleString("en-US")} uses left
+										</span>
+									)}
+								</div>
+								<span
+									className={cn(
+										"ml-6 block whitespace-normal break-words text-[13px]",
+										"font-normal leading-5 text-content-primary",
+										"[overflow-wrap:anywhere]",
+										!expanded && "line-clamp-2",
+									)}
+								>
+									{questionText}
 								</span>
 							</div>
-							<Response
-								streaming={isRunning}
-								className="[&_h1]:mb-2 [&_h1]:mt-3 [&_h1]:text-[15px] [&_h2]:mb-1.5 [&_h2]:mt-3 [&_h2]:text-sm [&_h3]:mb-1 [&_h3]:mt-2.5 [&_h3]:text-[13px] [&_h4]:mt-2 [&_h4]:text-[13px] [&_h5]:text-xs [&_h6]:text-xs"
-							>
-								{adviceText || EMPTY_ADVICE_MESSAGE}
-							</Response>
-						</section>
+							{headerStatus}
+							<ToolCall.Chevron className="mt-0.5" />
+						</>
 					)}
-				</div>
-			</ScrollArea>
-		</ToolCollapsible>
+				</ToolCall.State>
+			</ToolCall.HeaderButton>
+			<ToolCall.Content>
+				<ScrollArea
+					className="mt-1.5 rounded-md border border-solid border-border-default bg-surface-primary"
+					viewportClassName="max-h-64"
+					scrollBarClassName="w-1.5"
+					data-testid="advisor-tool-scroll-area"
+				>
+					<div className="space-y-3 px-3 py-2">
+						{isRunning && adviceText.length === 0 ? (
+							<div role="status" className="text-sm text-content-secondary">
+								Reviewing context and preparing guidance.
+							</div>
+						) : showLimitReached ? (
+							<div
+								role="status"
+								className="flex items-start gap-3 rounded-md border border-solid border-border-warning bg-surface-orange p-3 text-sm text-content-primary"
+							>
+								<TriangleAlertIcon className="mt-0.5 size-4 shrink-0 text-content-warning" />
+								<div className="space-y-1">
+									<p className="m-0 font-medium">Advisor limit reached.</p>
+									<p className="m-0 text-content-primary">
+										{LIMIT_REACHED_MESSAGE}
+									</p>
+								</div>
+							</div>
+						) : showError ? (
+							<div
+								role="alert"
+								className="flex items-start gap-3 rounded-md border border-solid border-border-destructive bg-surface-red p-3 text-sm text-content-primary"
+							>
+								<CircleAlertIcon className="mt-0.5 size-4 shrink-0 text-content-destructive" />
+								<div className="space-y-1">
+									<p className="m-0 font-medium">Advisor request failed.</p>
+									<p className="m-0 text-content-primary [overflow-wrap:anywhere]">
+										{effectiveErrorMessage}
+									</p>
+								</div>
+							</div>
+						) : (
+							<section className="space-y-2" aria-label="Advisor advice">
+								<div>
+									<span className="inline-flex rounded-full border border-solid border-border-default px-2 text-[13px] leading-4 text-content-secondary">
+										Advice
+									</span>
+								</div>
+								<Response
+									streaming={isRunning}
+									className="[&_h1]:mb-2 [&_h1]:mt-3 [&_h1]:text-[15px] [&_h2]:mb-1.5 [&_h2]:mt-3 [&_h2]:text-sm [&_h3]:mb-1 [&_h3]:mt-2.5 [&_h3]:text-[13px] [&_h4]:mt-2 [&_h4]:text-[13px] [&_h5]:text-xs [&_h6]:text-xs"
+								>
+									{adviceText || EMPTY_ADVICE_MESSAGE}
+								</Response>
+							</section>
+						)}
+					</div>
+				</ScrollArea>
+			</ToolCall.Content>
+		</ToolCall.Root>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/AskUserQuestionTool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/AskUserQuestionTool.stories.tsx
@@ -115,12 +115,31 @@ export const Running: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
+		const liveRegion = canvas.getByRole("status");
 
+		expect(liveRegion).toHaveAttribute("aria-live", "polite");
 		expect(canvas.getByText("Asking for clarification...")).toBeInTheDocument();
 		expect(
 			canvas.getByRole("img", { name: "Tool call running" }),
 		).toBeInTheDocument();
 		expect(canvas.getAllByRole("radio")).toHaveLength(3);
+	},
+};
+
+export const RunningEmptyQuestions: Story = {
+	args: {
+		status: "running",
+		args: { questions: [] },
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const liveRegion = canvas.getByRole("status");
+
+		expect(liveRegion).toHaveAttribute("aria-live", "polite");
+		expect(canvas.getByText("Asking for clarification...")).toBeInTheDocument();
+		expect(
+			canvas.getByRole("img", { name: "Tool call running" }),
+		).toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/AskUserQuestionTool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/AskUserQuestionTool.stories.tsx
@@ -118,7 +118,7 @@ export const Running: Story = {
 
 		expect(canvas.getByText("Asking for clarification...")).toBeInTheDocument();
 		expect(
-			canvas.getByTestId("ask-user-question-loading-icon"),
+			canvas.getByRole("img", { name: "Tool call running" }),
 		).toBeInTheDocument();
 		expect(canvas.getAllByRole("radio")).toHaveLength(3);
 	},
@@ -452,6 +452,10 @@ export const ErrorState: Story = {
 				"The planning agent could not deliver follow-up questions.",
 			),
 		).toBeInTheDocument();
-		expect(canvas.getByLabelText("Error")).toBeInTheDocument();
+		expect(
+			canvas.getByRole("img", {
+				name: "The planning agent could not deliver follow-up questions.",
+			}),
+		).toBeInTheDocument();
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/AskUserQuestionTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/AskUserQuestionTool.tsx
@@ -9,8 +9,7 @@ import { Button } from "#/components/Button/Button";
 import { Input } from "#/components/Input/Input";
 import { RadioGroup, RadioGroupItem } from "#/components/RadioGroup/RadioGroup";
 import { cn } from "#/utils/cn";
-import { TranscriptRow } from "../TranscriptRow";
-import { ToolIcon } from "./ToolIcon";
+import { ToolCall } from "./ToolCall";
 import type { ToolStatus } from "./utils";
 
 export type AskUserQuestion = {
@@ -537,18 +536,18 @@ export const AskUserQuestionTool: FC<AskUserQuestionToolProps> = ({
 
 	if (isError) {
 		return (
-			<div className="w-full">
-				<TranscriptRow
-					role="alert"
-					className="gap-2 text-[13px] text-content-secondary"
+			<div className="w-full" role="alert">
+				<ToolCall.Root
+					status={status}
+					isError
+					errorMessage={errorMessage || "Failed to ask questions"}
+					hasContent={false}
 				>
-					<ToolIcon name="ask_user_question" isError={isError} />
-					<TriangleAlertIcon
-						aria-label="Error"
-						className="size-3.5 shrink-0 text-content-secondary"
+					<ToolCall.Header
+						iconName="ask_user_question"
+						label={errorMessage || "Failed to ask questions"}
 					/>
-					<span>{errorMessage || "Failed to ask questions"}</span>
-				</TranscriptRow>
+				</ToolCall.Root>
 			</div>
 		);
 	}
@@ -557,24 +556,12 @@ export const AskUserQuestionTool: FC<AskUserQuestionToolProps> = ({
 		return (
 			<div className="w-full">
 				{isRunning ? (
-					<TranscriptRow
-						role="status"
-						aria-live="polite"
-						className="gap-2 text-content-secondary"
-					>
-						<ToolIcon
-							name="ask_user_question"
-							isError={false}
-							isRunning={isRunning}
+					<ToolCall.Root status={status} hasContent={false}>
+						<ToolCall.Header
+							iconName="ask_user_question"
+							label="Asking for clarification..."
 						/>
-						<span className="text-[13px] text-content-secondary">
-							Asking for clarification...
-						</span>
-						<LoaderIcon
-							data-testid="ask-user-question-loading-icon"
-							className="size-3.5 shrink-0 animate-spin text-content-secondary motion-reduce:animate-none"
-						/>
-					</TranscriptRow>
+					</ToolCall.Root>
 				) : (
 					<p className="text-[13px] italic text-content-secondary">
 						No questions available.
@@ -688,24 +675,12 @@ export const AskUserQuestionTool: FC<AskUserQuestionToolProps> = ({
 	return (
 		<div className="w-full">
 			{isRunning && (
-				<TranscriptRow
-					role="status"
-					aria-live="polite"
-					className="gap-2 text-content-secondary"
-				>
-					<ToolIcon
-						name="ask_user_question"
-						isError={false}
-						isRunning={isRunning}
+				<ToolCall.Root status={status} hasContent={false}>
+					<ToolCall.Header
+						iconName="ask_user_question"
+						label="Asking for clarification..."
 					/>
-					<span className="text-[13px] text-content-secondary">
-						Asking for clarification...
-					</span>
-					<LoaderIcon
-						data-testid="ask-user-question-loading-icon"
-						className="size-3.5 shrink-0 animate-spin text-content-secondary motion-reduce:animate-none"
-					/>
-				</TranscriptRow>
+				</ToolCall.Root>
 			)}
 
 			{isInteractive ? (

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/AskUserQuestionTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/AskUserQuestionTool.tsx
@@ -556,7 +556,12 @@ export const AskUserQuestionTool: FC<AskUserQuestionToolProps> = ({
 		return (
 			<div className="w-full">
 				{isRunning ? (
-					<ToolCall.Root status={status} hasContent={false}>
+					<ToolCall.Root
+						status={status}
+						hasContent={false}
+						role="status"
+						aria-live="polite"
+					>
 						<ToolCall.Header
 							iconName="ask_user_question"
 							label="Asking for clarification..."
@@ -675,7 +680,12 @@ export const AskUserQuestionTool: FC<AskUserQuestionToolProps> = ({
 	return (
 		<div className="w-full">
 			{isRunning && (
-				<ToolCall.Root status={status} hasContent={false}>
+				<ToolCall.Root
+					status={status}
+					hasContent={false}
+					role="status"
+					aria-live="polite"
+				>
 					<ToolCall.Header
 						iconName="ask_user_question"
 						label="Asking for clarification..."

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ChatSummarizedTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ChatSummarizedTool.tsx
@@ -1,14 +1,7 @@
-import { LoaderIcon, TriangleAlertIcon } from "lucide-react";
 import type React from "react";
 import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "#/components/Tooltip/Tooltip";
 import { Response } from "../Response";
-import { ToolCollapsible } from "./ToolCollapsible";
-import { ToolIcon } from "./ToolIcon";
+import { ToolCall } from "./ToolCall";
 import type { ToolStatus } from "./utils";
 
 /**
@@ -25,48 +18,28 @@ export const ChatSummarizedTool: React.FC<{
 	const isRunning = status === "running";
 
 	return (
-		<ToolCollapsible
+		<ToolCall.Root
 			className="w-full"
+			status={status}
+			isError={isError}
+			errorMessage={errorMessage || "Failed to summarize conversation"}
 			hasContent={hasSummary}
-			header={
-				<>
-					<ToolIcon
-						name="chat_summarized"
-						isError={isError}
-						isRunning={isRunning}
-					/>
-					<span className="text-[13px] leading-6">
-						{isRunning ? "Summarizing…" : "Summarized"}
-					</span>
-				</>
-			}
-			headerStatus={
-				<>
-					{isError && (
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<TriangleAlertIcon className="size-3.5 shrink-0 text-current" />
-							</TooltipTrigger>
-							<TooltipContent>
-								{errorMessage || "Failed to summarize conversation"}
-							</TooltipContent>
-						</Tooltip>
-					)}
-					{isRunning && (
-						<LoaderIcon className="size-3.5 shrink-0 animate-spin motion-reduce:animate-none text-current" />
-					)}
-				</>
-			}
 		>
-			<ScrollArea
-				className="mt-1.5 rounded-md border border-solid border-border-default"
-				viewportClassName="max-h-64"
-				scrollBarClassName="w-1.5"
-			>
-				<div className="px-3 py-2">
-					<Response>{summary}</Response>
-				</div>
-			</ScrollArea>
-		</ToolCollapsible>
+			<ToolCall.Header
+				iconName="chat_summarized"
+				label={isRunning ? "Summarizing…" : "Summarized"}
+			/>
+			<ToolCall.Content>
+				<ScrollArea
+					className="mt-1.5 rounded-md border border-solid border-border-default"
+					viewportClassName="max-h-64"
+					scrollBarClassName="w-1.5"
+				>
+					<div className="px-3 py-2">
+						<Response>{summary}</Response>
+					</div>
+				</ScrollArea>
+			</ToolCall.Content>
+		</ToolCall.Root>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ComputerTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ComputerTool.tsx
@@ -1,14 +1,7 @@
-import { LoaderIcon, TriangleAlertIcon } from "lucide-react";
 import type React from "react";
 import { useState } from "react";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "#/components/Tooltip/Tooltip";
 import { ImageLightbox } from "../../ImageLightbox";
-import { ToolCollapsible } from "./ToolCollapsible";
-import { ToolIcon } from "./ToolIcon";
+import { ToolCall } from "./ToolCall";
 import type { ToolStatus } from "./utils";
 
 /**
@@ -34,65 +27,49 @@ export const ComputerTool: React.FC<{
 	const imageSrc = hasImage ? `data:${mimeType};base64,${imageData}` : "";
 
 	return (
-		<ToolCollapsible
+		<ToolCall.Root
 			className="w-full"
+			status={status}
+			isError={isError}
+			errorMessage={errorMessage || "Failed to take screenshot"}
 			hasContent={hasContent}
 			defaultExpanded={hasImage}
-			header={
-				<>
-					<ToolIcon name="computer" isError={isError} isRunning={isRunning} />
-					<span className="text-[13px] leading-6">
-						{isRunning ? "Taking screenshot…" : "Screenshot"}
-					</span>
-				</>
-			}
-			headerStatus={
-				<>
-					{isError && (
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<TriangleAlertIcon className="size-3.5 shrink-0 text-current" />
-							</TooltipTrigger>
-							<TooltipContent>
-								{errorMessage || "Failed to take screenshot"}
-							</TooltipContent>
-						</Tooltip>
-					)}
-					{isRunning && (
-						<LoaderIcon className="size-3.5 shrink-0 animate-spin motion-reduce:animate-none text-current" />
-					)}
-				</>
-			}
 		>
-			{hasImage ? (
-				<>
-					<div className="mt-1.5 overflow-hidden rounded-md border border-solid border-border-default">
-						<button
-							type="button"
-							className="cursor-pointer bg-transparent p-0 border-none"
-							onClick={() => setShowLightbox(true)}
-						>
-							<img
+			<ToolCall.Header
+				iconName="computer"
+				label={isRunning ? "Taking screenshot…" : "Screenshot"}
+			/>
+			<ToolCall.Content>
+				{hasImage ? (
+					<>
+						<div className="mt-1.5 overflow-hidden rounded-md border border-solid border-border-default">
+							<button
+								type="button"
+								className="cursor-pointer bg-transparent p-0 border-none"
+								onClick={() => setShowLightbox(true)}
+							>
+								<img
+									src={imageSrc}
+									alt="Screenshot from computer tool"
+									className="max-h-96 w-auto object-contain"
+								/>
+							</button>
+						</div>
+						{showLightbox && (
+							<ImageLightbox
 								src={imageSrc}
-								alt="Screenshot from computer tool"
-								className="max-h-96 w-auto object-contain"
+								onClose={() => setShowLightbox(false)}
 							/>
-						</button>
+						)}
+					</>
+				) : hasText ? (
+					<div className="mt-1.5 rounded-md border border-solid border-border-default px-3 py-2">
+						<pre className="whitespace-pre-wrap text-xs text-content-secondary">
+							{text}
+						</pre>
 					</div>
-					{showLightbox && (
-						<ImageLightbox
-							src={imageSrc}
-							onClose={() => setShowLightbox(false)}
-						/>
-					)}
-				</>
-			) : hasText ? (
-				<div className="mt-1.5 rounded-md border border-solid border-border-default px-3 py-2">
-					<pre className="whitespace-pre-wrap text-xs text-content-secondary">
-						{text}
-					</pre>
-				</div>
-			) : null}
-		</ToolCollapsible>
+				) : null}
+			</ToolCall.Content>
+		</ToolCall.Root>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/CreateWorkspaceTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/CreateWorkspaceTool.tsx
@@ -73,10 +73,10 @@ export const CreateWorkspaceTool: React.FC<{
 					<ToolCall.LeadingIcon name="create_workspace" />
 					<ToolCall.Label>{label}</ToolCall.Label>
 					<ToolCall.Status />
-					<ToolCall.Chevron />
+					<ToolCall.HeaderChevron />
 				</ToolCall.HeaderButton>
 				{workspaceLink && !isRunning && (
-					<ToolCall.Actions>
+					<ToolCall.HeaderActions>
 						<Link
 							to={workspaceLink}
 							className="inline-flex align-middle text-content-secondary opacity-50 transition-opacity hover:opacity-100"
@@ -84,7 +84,7 @@ export const CreateWorkspaceTool: React.FC<{
 						>
 							<ExternalLinkIcon className="size-3" />
 						</Link>
-					</ToolCall.Actions>
+					</ToolCall.HeaderActions>
 				)}
 			</ToolCall.HeaderLayout>
 			<ToolCall.Content>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/CreateWorkspaceTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/CreateWorkspaceTool.tsx
@@ -1,13 +1,7 @@
-import { ExternalLinkIcon, LoaderIcon, TriangleAlertIcon } from "lucide-react";
+import { ExternalLinkIcon } from "lucide-react";
 import type React from "react";
 import { Link } from "react-router";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "#/components/Tooltip/Tooltip";
-import { ToolCollapsible } from "./ToolCollapsible";
-import { ToolIcon } from "./ToolIcon";
+import { ToolCall } from "./ToolCall";
 import { asRecord, asString, type ToolStatus } from "./utils";
 import { WorkspaceBuildLogSection } from "./WorkspaceBuildLogSection";
 
@@ -44,7 +38,6 @@ export const CreateWorkspaceTool: React.FC<{
 			const parsed = JSON.parse(resultJson);
 			rec = asRecord(parsed);
 		} catch {
-			// resultJson might already be an object or invalid JSON
 			rec = asRecord(resultJson);
 		}
 	}
@@ -66,54 +59,37 @@ export const CreateWorkspaceTool: React.FC<{
 
 	const hasBuildLogs = isRunning || Boolean(buildId);
 
-	const header = (
-		<>
-			<ToolIcon
-				name="create_workspace"
-				isError={isError}
-				isRunning={isRunning}
-			/>
-			<span className="text-[13px] leading-6">{label}</span>
-			{workspaceLink && !isRunning && (
-				<Link
-					to={workspaceLink}
-					onClick={(e) => e.stopPropagation()}
-					className="ml-1 inline-flex align-middle text-content-secondary opacity-50 transition-opacity hover:opacity-100"
-					aria-label="View workspace"
-				>
-					<ExternalLinkIcon className="size-3" />
-				</Link>
-			)}
-		</>
-	);
-	const headerStatus = (
-		<>
-			{isError && (
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<TriangleAlertIcon className="size-3.5 shrink-0 text-current" />
-					</TooltipTrigger>
-					<TooltipContent>
-						{errorMessage || "Failed to create workspace"}
-					</TooltipContent>
-				</Tooltip>
-			)}
-			{isRunning && (
-				<LoaderIcon className="size-3.5 shrink-0 animate-spin motion-reduce:animate-none text-current" />
-			)}
-		</>
-	);
-
 	return (
-		<div className="w-full">
-			<ToolCollapsible
-				header={header}
-				headerStatus={headerStatus}
-				hasContent={hasBuildLogs}
-				defaultExpanded={isRunning}
-			>
+		<ToolCall.Root
+			className="w-full"
+			status={status}
+			isError={isError}
+			errorMessage={errorMessage || "Failed to create workspace"}
+			hasContent={hasBuildLogs}
+			defaultExpanded={isRunning}
+		>
+			<ToolCall.HeaderLayout>
+				<ToolCall.HeaderButton>
+					<ToolCall.LeadingIcon name="create_workspace" />
+					<ToolCall.Label>{label}</ToolCall.Label>
+					<ToolCall.Status />
+					<ToolCall.Chevron />
+				</ToolCall.HeaderButton>
+				{workspaceLink && !isRunning && (
+					<ToolCall.Actions>
+						<Link
+							to={workspaceLink}
+							className="inline-flex align-middle text-content-secondary opacity-50 transition-opacity hover:opacity-100"
+							aria-label="View workspace"
+						>
+							<ExternalLinkIcon className="size-3" />
+						</Link>
+					</ToolCall.Actions>
+				)}
+			</ToolCall.HeaderLayout>
+			<ToolCall.Content>
 				<WorkspaceBuildLogSection status={status} buildId={buildId} />
-			</ToolCollapsible>
-		</div>
+			</ToolCall.Content>
+		</ToolCall.Root>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/CreateWorkspaceTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/CreateWorkspaceTool.tsx
@@ -73,7 +73,7 @@ export const CreateWorkspaceTool: React.FC<{
 					<ToolCall.LeadingIcon name="create_workspace" />
 					<ToolCall.Label>{label}</ToolCall.Label>
 					<ToolCall.Status />
-					<ToolCall.HeaderChevron />
+					<ToolCall.Chevron />
 				</ToolCall.HeaderButton>
 				{workspaceLink && !isRunning && (
 					<ToolCall.HeaderActions>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/EditFilesTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/EditFilesTool.tsx
@@ -56,14 +56,14 @@ export const EditFilesTool: React.FC<{
 	}
 
 	return (
-		<ToolCall.AgentDisplayModeRoot
+		<ToolCall.Root
+			key={`${codeDiffDisplayMode ?? "auto"}:${EDIT_FILES_AUTO_DISPLAY_STATE}`}
 			className="w-full"
 			status={status}
 			isError={isError}
 			errorMessage={errorMessage || "Failed to edit files"}
 			hasContent={hasDiffs}
-			displayMode={codeDiffDisplayMode}
-			autoDisplayState={EDIT_FILES_AUTO_DISPLAY_STATE}
+			defaultView={displayState}
 		>
 			<ToolCall.Header iconName="edit_files" label={label} />
 			<ToolCall.Content>
@@ -91,6 +91,6 @@ export const EditFilesTool: React.FC<{
 					)}
 				</div>
 			</ToolCall.Content>
-		</ToolCall.AgentDisplayModeRoot>
+		</ToolCall.Root>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/EditFilesTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/EditFilesTool.tsx
@@ -1,22 +1,15 @@
 import { useTheme } from "@emotion/react";
 import type { FileDiffMetadata } from "@pierre/diffs";
 import { FileDiff } from "@pierre/diffs/react";
-import { LoaderIcon, TriangleAlertIcon } from "lucide-react";
 import type React from "react";
 import type * as TypesGen from "#/api/typesGenerated";
 import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "#/components/Tooltip/Tooltip";
 import {
 	type AgentDisplayState,
 	isAgentDisplayFullyExpanded,
 	resolveAgentDisplayState,
 } from "./displayMode";
-import { AgentDisplayModeToolCollapsible } from "./ToolCollapsible";
-import { ToolIcon } from "./ToolIcon";
+import { ToolCall } from "./ToolCall";
 import {
 	DIFFS_FONT_STYLE,
 	type EditFilesFileEntry,
@@ -63,58 +56,41 @@ export const EditFilesTool: React.FC<{
 	}
 
 	return (
-		<AgentDisplayModeToolCollapsible
+		<ToolCall.AgentDisplayModeRoot
 			className="w-full"
+			status={status}
+			isError={isError}
+			errorMessage={errorMessage || "Failed to edit files"}
 			hasContent={hasDiffs}
 			displayMode={codeDiffDisplayMode}
 			autoDisplayState={EDIT_FILES_AUTO_DISPLAY_STATE}
-			header={
-				<>
-					<ToolIcon name="edit_files" isError={isError} isRunning={isRunning} />
-					<span className="text-[13px] leading-6">{label}</span>
-				</>
-			}
-			headerStatus={
-				<>
-					{isError && (
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<TriangleAlertIcon className="size-3.5 shrink-0 text-current" />
-							</TooltipTrigger>
-							<TooltipContent>
-								{errorMessage || "Failed to edit files"}
-							</TooltipContent>
-						</Tooltip>
-					)}
-					{isRunning && (
-						<LoaderIcon className="size-3.5 shrink-0 animate-spin motion-reduce:animate-none text-current" />
-					)}
-				</>
-			}
 		>
-			<div className="mt-1.5 space-y-1.5">
-				{diffs.map((diff, i) =>
-					diff ? (
-						<ScrollArea
-							key={files[i].path}
-							data-testid="edit-file-diff"
-							className="rounded-md border border-solid border-border-default text-2xs"
-							viewportClassName={
-								isAgentDisplayFullyExpanded(displayState)
-									? "max-h-[80vh]"
-									: "max-h-64"
-							}
-							scrollBarClassName="w-1.5"
-						>
-							<FileDiff
-								fileDiff={stripNoNewline(diff)}
-								options={getDiffViewerOptions(isDark)}
-								style={DIFFS_FONT_STYLE}
-							/>
-						</ScrollArea>
-					) : null,
-				)}
-			</div>
-		</AgentDisplayModeToolCollapsible>
+			<ToolCall.Header iconName="edit_files" label={label} />
+			<ToolCall.Content>
+				<div className="mt-1.5 space-y-1.5">
+					{diffs.map((diff, i) =>
+						diff ? (
+							<ScrollArea
+								key={files[i].path}
+								data-testid="edit-file-diff"
+								className="rounded-md border border-solid border-border-default text-2xs"
+								viewportClassName={
+									isAgentDisplayFullyExpanded(displayState)
+										? "max-h-[80vh]"
+										: "max-h-64"
+								}
+								scrollBarClassName="w-1.5"
+							>
+								<FileDiff
+									fileDiff={stripNoNewline(diff)}
+									options={getDiffViewerOptions(isDark)}
+									style={DIFFS_FONT_STYLE}
+								/>
+							</ScrollArea>
+						) : null,
+					)}
+				</div>
+			</ToolCall.Content>
+		</ToolCall.AgentDisplayModeRoot>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
@@ -16,7 +16,10 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { cn } from "#/utils/cn";
-import type { AgentDisplayState } from "./displayMode";
+import {
+	type AgentDisplayState,
+	resolveAgentDisplayState,
+} from "./displayMode";
 import { ToolCall } from "./ToolCall";
 import type { ExecuteTranscriptBlock } from "./toolVisibility";
 import {
@@ -69,20 +72,24 @@ export const ExecuteTool: React.FC<ExecuteToolProps> = ({
 		parsedCommands,
 		durationLabel,
 	});
+	const defaultView = resolveAgentDisplayState(
+		shellToolDisplayMode,
+		autoDisplayState,
+	);
 
 	if (!hasCommand) {
 		return null;
 	}
 
 	return (
-		<ToolCall.AgentDisplayModeRoot
+		<ToolCall.Root
+			key={`${shellToolDisplayMode ?? "auto"}:${autoDisplayState}`}
 			className="group/exec grid w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2 rounded-md bg-surface-primary font-sans font-normal text-xs leading-5"
 			status={status}
 			isError={isError && !isRunning}
 			errorMessage="Command failed"
 			hasContent
-			displayMode={shellToolDisplayMode}
-			autoDisplayState={autoDisplayState}
+			defaultView={defaultView}
 			ariaLabel={(expanded) =>
 				expanded ? "Collapse command" : "Expand command"
 			}
@@ -133,7 +140,7 @@ export const ExecuteTool: React.FC<ExecuteToolProps> = ({
 					isError={isError}
 				/>
 			</ToolCall.Content>
-		</ToolCall.AgentDisplayModeRoot>
+		</ToolCall.Root>
 	);
 };
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
@@ -16,7 +16,6 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { cn } from "#/utils/cn";
-import { TranscriptRow } from "../TranscriptRow";
 import type { AgentDisplayState } from "./displayMode";
 import { ToolCall } from "./ToolCall";
 import type { ExecuteTranscriptBlock } from "./toolVisibility";
@@ -64,7 +63,7 @@ export const ExecuteTool: React.FC<ExecuteToolProps> = ({
 			: "collapsed";
 	const isRunning = status === "running";
 	const durationLabel = formatShellDurationMs(durationMs);
-	const { commandLabel, durationSuffix } = getShellCommandLine({
+	const commandLabel = getShellCommandLine({
 		command,
 		modelIntent,
 		parsedCommands,
@@ -88,47 +87,45 @@ export const ExecuteTool: React.FC<ExecuteToolProps> = ({
 				expanded ? "Collapse command" : "Expand command"
 			}
 		>
-			<ToolCall.Header
-				iconName="execute"
-				label={commandLabel}
-				secondaryLabel={
-					durationSuffix ? (
-						<span className="text-content-secondary">{durationSuffix}</span>
-					) : undefined
-				}
-				headerClassName="col-start-1 row-start-1 min-w-0 font-normal"
-			/>
-			<TranscriptRow className="col-start-2 row-start-1 shrink-0 gap-1">
-				{isBackgrounded && !isRunning && (
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<span
-								aria-label="Running in background"
-								role="img"
-								className="flex shrink-0 text-content-secondary"
-							>
-								<LayersIcon aria-hidden className="size-3.5 shrink-0" />
-							</span>
-						</TooltipTrigger>
-						<TooltipContent>Running in background</TooltipContent>
-					</Tooltip>
-				)}
-				{killedBySignal && !isRunning && (
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<OctagonXIcon className="size-3.5 shrink-0 text-content-secondary" />
-						</TooltipTrigger>
-						<TooltipContent>
-							{signalTooltipLabel(killedBySignal)}
-						</TooltipContent>
-					</Tooltip>
-				)}
-				<CopyButton
-					text={command}
-					label="Copy command"
-					className="-my-0.5 size-6 p-0 opacity-0 transition-opacity hover:bg-surface-tertiary group-hover/exec:opacity-100"
-				/>
-			</TranscriptRow>
+			<ToolCall.HeaderLayout>
+				<ToolCall.HeaderButton className="col-start-1 row-start-1 min-w-0 font-normal">
+					<ToolCall.LeadingIcon name="execute" />
+					<ToolCall.Label>{commandLabel}</ToolCall.Label>
+					<ToolCall.Status />
+					<ToolCall.HeaderChevron />
+				</ToolCall.HeaderButton>
+				<ToolCall.HeaderActions>
+					{isBackgrounded && !isRunning && (
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<span
+									aria-label="Running in background"
+									role="img"
+									className="flex shrink-0 text-content-secondary"
+								>
+									<LayersIcon aria-hidden className="size-3.5 shrink-0" />
+								</span>
+							</TooltipTrigger>
+							<TooltipContent>Running in background</TooltipContent>
+						</Tooltip>
+					)}
+					{killedBySignal && !isRunning && (
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<OctagonXIcon className="size-3.5 shrink-0 text-content-secondary" />
+							</TooltipTrigger>
+							<TooltipContent>
+								{signalTooltipLabel(killedBySignal)}
+							</TooltipContent>
+						</Tooltip>
+					)}
+					<CopyButton
+						text={command}
+						label="Copy command"
+						className="-my-0.5 size-6 p-0 opacity-0 transition-opacity hover:bg-surface-tertiary group-hover/exec:opacity-100 focus-visible:opacity-100"
+					/>
+				</ToolCall.HeaderActions>
+			</ToolCall.HeaderLayout>
 			<ToolCall.Content>
 				<ShellTranscriptBody
 					command={command}
@@ -164,7 +161,7 @@ const getShellCommandLine = ({
 		: `Ran ${commandDisplay}`;
 	const durationSuffix = durationLabel ? ` for ${durationLabel}` : "";
 
-	return { commandLabel, durationSuffix };
+	return `${commandLabel}${durationSuffix}`;
 };
 
 const ShellTranscriptBody: React.FC<{

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
@@ -1,15 +1,11 @@
 import {
 	CheckIcon,
-	ChevronDownIcon,
 	CircleAlertIcon,
 	ExternalLinkIcon,
 	LayersIcon,
-	LoaderIcon,
 	OctagonXIcon,
-	TriangleAlertIcon,
 } from "lucide-react";
 import type React from "react";
-import { useState } from "react";
 import type * as TypesGen from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
 import { CopyButton } from "#/components/CopyButton/CopyButton";
@@ -21,12 +17,8 @@ import {
 } from "#/components/Tooltip/Tooltip";
 import { cn } from "#/utils/cn";
 import { TranscriptRow } from "../TranscriptRow";
-import {
-	type AgentDisplayState,
-	isAgentDisplayOpen,
-	resolveAgentDisplayState,
-} from "./displayMode";
-import { ToolIcon } from "./ToolIcon";
+import type { AgentDisplayState } from "./displayMode";
+import { ToolCall } from "./ToolCall";
 import type { ExecuteTranscriptBlock } from "./toolVisibility";
 import {
 	formatShellDurationMs,
@@ -49,33 +41,7 @@ type ExecuteToolProps = {
 	shellToolDisplayMode?: TypesGen.AgentDisplayMode;
 };
 
-type ExecuteToolInnerProps = ExecuteToolProps & {
-	outputInitiallyOpen: boolean;
-};
-
-export const ExecuteTool: React.FC<ExecuteToolProps> = (props) => {
-	const hasTranscriptBlocks = props.transcriptBlocks.length > 0;
-	const autoDisplayState: AgentDisplayState =
-		hasTranscriptBlocks ||
-		props.status === "running" ||
-		props.isBackgrounded ||
-		!!props.killedBySignal
-			? "preview"
-			: "collapsed";
-	const resolvedDisplayState = resolveAgentDisplayState(
-		props.shellToolDisplayMode,
-		autoDisplayState,
-	);
-	return (
-		<ExecuteToolInner
-			key={`${props.shellToolDisplayMode ?? "auto"}:${autoDisplayState}`}
-			{...props}
-			outputInitiallyOpen={isAgentDisplayOpen(resolvedDisplayState)}
-		/>
-	);
-};
-
-const ExecuteToolInner: React.FC<ExecuteToolInnerProps> = ({
+export const ExecuteTool: React.FC<ExecuteToolProps> = ({
 	command,
 	transcriptBlocks,
 	status,
@@ -85,58 +51,54 @@ const ExecuteToolInner: React.FC<ExecuteToolInnerProps> = ({
 	killedBySignal,
 	modelIntent,
 	parsedCommands,
-	outputInitiallyOpen,
+	shellToolDisplayMode,
 }) => {
 	const hasCommand = command.trim().length > 0;
+	const hasTranscriptBlocks = transcriptBlocks.length > 0;
+	const autoDisplayState: AgentDisplayState =
+		hasTranscriptBlocks ||
+		status === "running" ||
+		isBackgrounded ||
+		!!killedBySignal
+			? "preview"
+			: "collapsed";
 	const isRunning = status === "running";
-	const showFailureIndicator = isError && !isRunning;
-	const [outputOpen, setOutputOpen] = useState(outputInitiallyOpen);
-	const outputToggleLabel = outputOpen ? "Collapse command" : "Expand command";
 	const durationLabel = formatShellDurationMs(durationMs);
+	const { commandLabel, durationSuffix } = getShellCommandLine({
+		command,
+		modelIntent,
+		parsedCommands,
+		durationLabel,
+	});
 
 	if (!hasCommand) {
 		return null;
 	}
 
 	return (
-		<div className="group/exec grid w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2 rounded-md bg-surface-primary font-sans font-normal text-xs leading-5">
-			<TranscriptRow
-				asChild
-				className="col-start-1 row-start-1 m-0 w-full min-w-0 cursor-pointer gap-2 border-0 bg-transparent p-0 text-left font-[inherit] font-normal text-[inherit] text-content-secondary transition-colors hover:text-content-primary"
-			>
-				<button
-					type="button"
-					aria-expanded={outputOpen}
-					aria-label={outputToggleLabel}
-					onClick={() => setOutputOpen((value) => !value)}
-				>
-					<ShellCommandLine
-						command={command}
-						modelIntent={modelIntent}
-						parsedCommands={parsedCommands}
-						durationLabel={durationLabel}
-						expanded={outputOpen}
-					/>
-				</button>
-			</TranscriptRow>
+		<ToolCall.AgentDisplayModeRoot
+			className="group/exec grid w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2 rounded-md bg-surface-primary font-sans font-normal text-xs leading-5"
+			status={status}
+			isError={isError && !isRunning}
+			errorMessage="Command failed"
+			hasContent
+			displayMode={shellToolDisplayMode}
+			autoDisplayState={autoDisplayState}
+			ariaLabel={(expanded) =>
+				expanded ? "Collapse command" : "Expand command"
+			}
+		>
+			<ToolCall.Header
+				iconName="execute"
+				label={commandLabel}
+				secondaryLabel={
+					durationSuffix ? (
+						<span className="text-content-secondary">{durationSuffix}</span>
+					) : undefined
+				}
+				headerClassName="col-start-1 row-start-1 min-w-0 font-normal"
+			/>
 			<TranscriptRow className="col-start-2 row-start-1 shrink-0 gap-1">
-				{isRunning && (
-					<LoaderIcon className="size-3.5 shrink-0 animate-spin motion-reduce:animate-none text-content-secondary" />
-				)}
-				{showFailureIndicator && (
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<span
-								aria-label="Command failed"
-								role="img"
-								className="flex shrink-0 text-content-secondary"
-							>
-								<TriangleAlertIcon aria-hidden className="size-3.5 shrink-0" />
-							</span>
-						</TooltipTrigger>
-						<TooltipContent>Command failed</TooltipContent>
-					</Tooltip>
-				)}
 				{isBackgrounded && !isRunning && (
 					<Tooltip>
 						<TooltipTrigger asChild>
@@ -167,24 +129,30 @@ const ExecuteToolInner: React.FC<ExecuteToolInnerProps> = ({
 					className="-my-0.5 size-6 p-0 opacity-0 transition-opacity hover:bg-surface-tertiary group-hover/exec:opacity-100"
 				/>
 			</TranscriptRow>
-			{outputOpen && (
+			<ToolCall.Content>
 				<ShellTranscriptBody
 					command={command}
 					transcriptBlocks={transcriptBlocks}
 					isError={isError}
 				/>
-			)}
-		</div>
+			</ToolCall.Content>
+		</ToolCall.AgentDisplayModeRoot>
 	);
 };
 
-const ShellCommandLine: React.FC<{
+type ShellCommandLineInput = {
 	command: string;
 	modelIntent?: string;
 	parsedCommands?: readonly string[][];
 	durationLabel: string;
-	expanded?: boolean;
-}> = ({ command, modelIntent, parsedCommands, durationLabel, expanded }) => {
+};
+
+const getShellCommandLine = ({
+	command,
+	modelIntent,
+	parsedCommands,
+	durationLabel,
+}: ShellCommandLineInput) => {
 	const intentLabel = sanitizeExecuteModelIntent(modelIntent, command);
 	const summary =
 		parsedCommands && parsedCommands.length > 0
@@ -196,25 +164,7 @@ const ShellCommandLine: React.FC<{
 		: `Ran ${commandDisplay}`;
 	const durationSuffix = durationLabel ? ` for ${durationLabel}` : "";
 
-	return (
-		<>
-			<ToolIcon name="execute" isError={false} />
-			<span className="min-w-0 truncate text-[13px] font-normal leading-6 text-current">
-				{commandLabel}
-				{durationSuffix && (
-					<span className="text-content-secondary">{durationSuffix}</span>
-				)}
-			</span>
-			{expanded !== undefined && (
-				<ChevronDownIcon
-					className={cn(
-						"size-3 shrink-0 text-current transition-transform",
-						expanded ? "rotate-0" : "-rotate-90",
-					)}
-				/>
-			)}
-		</>
-	);
+	return { commandLabel, durationSuffix };
 };
 
 const ShellTranscriptBody: React.FC<{
@@ -331,32 +281,39 @@ export const WaitForExternalAuthTool: React.FC<{
 }) => {
 	const isRunning = status === "running";
 	let label = `Waiting for ${providerLabel} authentication...`;
-	let icon: React.ReactNode = (
-		<LoaderIcon className="size-3.5 shrink-0 animate-spin motion-reduce:animate-none text-content-link" />
-	);
+	let statusIcon: React.ReactNode = null;
 	if (isError) {
 		label =
 			errorMessage ||
 			`Failed while waiting for ${providerLabel} authentication`;
-		icon = (
-			<TriangleAlertIcon className="size-3.5 shrink-0 text-content-secondary" />
-		);
 	} else if (timedOut) {
 		label = `Timed out waiting for ${providerLabel} authentication`;
-		icon = (
+		statusIcon = (
 			<CircleAlertIcon className="size-3.5 shrink-0 text-content-warning" />
 		);
 	} else if (authenticated && !isRunning) {
 		label = `Authenticated with ${providerLabel}`;
-		icon = <CheckIcon className="size-3.5 shrink-0 text-content-success" />;
+		statusIcon = (
+			<CheckIcon className="size-3.5 shrink-0 text-content-success" />
+		);
 	}
 
 	return (
-		<div className="w-full overflow-hidden rounded-md border border-solid border-border-default bg-surface-primary px-3 py-2">
-			<div className="flex items-center gap-2">
-				{icon}
-				<span className="text-[13px] text-content-primary">{label}</span>
-			</div>
-		</div>
+		<ToolCall.Root
+			className="w-full overflow-hidden rounded-md border border-solid border-border-default bg-surface-primary px-3 py-2"
+			status={status}
+			isError={isError}
+			errorMessage={
+				errorMessage ||
+				`Failed while waiting for ${providerLabel} authentication`
+			}
+			hasContent={false}
+		>
+			<ToolCall.Header
+				iconName="wait_for_external_auth"
+				label={label}
+				trailing={statusIcon}
+			/>
+		</ToolCall.Root>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
@@ -3,6 +3,7 @@ import {
 	CircleAlertIcon,
 	ExternalLinkIcon,
 	LayersIcon,
+	LoaderIcon,
 	OctagonXIcon,
 } from "lucide-react";
 import type React from "react";
@@ -66,7 +67,7 @@ export const ExecuteTool: React.FC<ExecuteToolProps> = ({
 			: "collapsed";
 	const isRunning = status === "running";
 	const durationLabel = formatShellDurationMs(durationMs);
-	const commandLabel = getShellCommandLine({
+	const { commandLabel, durationSuffix } = getShellCommandLine({
 		command,
 		modelIntent,
 		parsedCommands,
@@ -98,8 +99,13 @@ export const ExecuteTool: React.FC<ExecuteToolProps> = ({
 				<ToolCall.HeaderButton className="col-start-1 row-start-1 min-w-0 font-normal">
 					<ToolCall.LeadingIcon name="execute" />
 					<ToolCall.Label>{commandLabel}</ToolCall.Label>
+					{durationSuffix && (
+						<span className="shrink-0 text-content-secondary">
+							{durationSuffix}
+						</span>
+					)}
 					<ToolCall.Status />
-					<ToolCall.HeaderChevron />
+					<ToolCall.Chevron />
 				</ToolCall.HeaderButton>
 				<ToolCall.HeaderActions>
 					{isBackgrounded && !isRunning && (
@@ -156,7 +162,7 @@ const getShellCommandLine = ({
 	modelIntent,
 	parsedCommands,
 	durationLabel,
-}: ShellCommandLineInput) => {
+}: ShellCommandLineInput): { commandLabel: string; durationSuffix: string } => {
 	const intentLabel = sanitizeExecuteModelIntent(modelIntent, command);
 	const summary =
 		parsedCommands && parsedCommands.length > 0
@@ -166,9 +172,11 @@ const getShellCommandLine = ({
 	const commandLabel = intentLabel
 		? `${intentLabel} using ${commandDisplay}`
 		: `Ran ${commandDisplay}`;
-	const durationSuffix = durationLabel ? ` for ${durationLabel}` : "";
 
-	return `${commandLabel}${durationSuffix}`;
+	return {
+		commandLabel,
+		durationSuffix: durationLabel ? ` for ${durationLabel}` : "",
+	};
 };
 
 const ShellTranscriptBody: React.FC<{
@@ -285,20 +293,41 @@ export const WaitForExternalAuthTool: React.FC<{
 }) => {
 	const isRunning = status === "running";
 	let label = `Waiting for ${providerLabel} authentication...`;
-	let statusIcon: React.ReactNode = null;
+	let statusIcon: React.ReactNode = isRunning ? (
+		<LoaderIcon
+			aria-label="Authentication in progress"
+			role="img"
+			className="size-3.5 shrink-0 animate-spin text-content-link motion-reduce:animate-none"
+		/>
+	) : null;
 	if (isError) {
 		label =
 			errorMessage ||
 			`Failed while waiting for ${providerLabel} authentication`;
+		statusIcon = (
+			<OctagonXIcon
+				aria-label="Authentication failed"
+				role="img"
+				className="size-3.5 shrink-0 text-content-destructive"
+			/>
+		);
 	} else if (timedOut) {
 		label = `Timed out waiting for ${providerLabel} authentication`;
 		statusIcon = (
-			<CircleAlertIcon className="size-3.5 shrink-0 text-content-warning" />
+			<CircleAlertIcon
+				aria-label="Authentication timed out"
+				role="img"
+				className="size-3.5 shrink-0 text-content-warning"
+			/>
 		);
 	} else if (authenticated && !isRunning) {
 		label = `Authenticated with ${providerLabel}`;
 		statusIcon = (
-			<CheckIcon className="size-3.5 shrink-0 text-content-success" />
+			<CheckIcon
+				aria-label="Authentication completed"
+				role="img"
+				className="size-3.5 shrink-0 text-content-success"
+			/>
 		);
 	}
 
@@ -313,11 +342,14 @@ export const WaitForExternalAuthTool: React.FC<{
 			}
 			hasContent={false}
 		>
-			<ToolCall.Header
-				iconName="wait_for_external_auth"
-				label={label}
-				trailing={statusIcon}
-			/>
+			<ToolCall.HeaderLayout>
+				<ToolCall.HeaderButton className="min-w-0 flex-1 font-normal text-content-secondary">
+					<ToolCall.LeadingIcon>{statusIcon}</ToolCall.LeadingIcon>
+					<ToolCall.Label className="text-content-primary">
+						{label}
+					</ToolCall.Label>
+				</ToolCall.HeaderButton>
+			</ToolCall.HeaderLayout>
 		</ToolCall.Root>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
@@ -87,7 +87,7 @@ export const ExecuteTool: React.FC<ExecuteToolProps> = ({
 			key={`${shellToolDisplayMode ?? "auto"}:${autoDisplayState}`}
 			className="group/exec grid w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2 rounded-md bg-surface-primary font-sans font-normal text-xs leading-5"
 			status={status}
-			isError={isError && !isRunning}
+			isError={isError}
 			errorMessage="Command failed"
 			hasContent
 			defaultView={defaultView}
@@ -98,12 +98,14 @@ export const ExecuteTool: React.FC<ExecuteToolProps> = ({
 			<ToolCall.HeaderLayout>
 				<ToolCall.HeaderButton className="col-start-1 row-start-1 min-w-0 font-normal">
 					<ToolCall.LeadingIcon name="execute" />
-					<ToolCall.Label>{commandLabel}</ToolCall.Label>
-					{durationSuffix && (
-						<span className="shrink-0 text-content-secondary">
-							{durationSuffix}
-						</span>
-					)}
+					<span className="flex min-w-0 items-baseline">
+						<ToolCall.Label>{commandLabel}</ToolCall.Label>
+						{durationSuffix && (
+							<span className="ml-1 shrink-0 text-content-secondary">
+								{durationSuffix}
+							</span>
+						)}
+					</span>
 					<ToolCall.Status />
 					<ToolCall.Chevron />
 				</ToolCall.HeaderButton>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ListTemplatesTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ListTemplatesTool.tsx
@@ -1,13 +1,7 @@
-import { ExternalLinkIcon, LoaderIcon, TriangleAlertIcon } from "lucide-react";
+import { ExternalLinkIcon } from "lucide-react";
 import type React from "react";
 import { Link } from "react-router";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "#/components/Tooltip/Tooltip";
-import { ToolCollapsible } from "./ToolCollapsible";
-import { ToolIcon } from "./ToolIcon";
+import { ToolCall } from "./ToolCall";
 import { asRecord, asString, type ToolStatus } from "./utils";
 
 /**
@@ -32,69 +26,47 @@ export const ListTemplatesTool: React.FC<{
 				: `Listed ${count} templates`;
 
 	return (
-		<ToolCollapsible
+		<ToolCall.Root
 			className="w-full"
+			status={status}
+			isError={isError}
+			errorMessage={errorMessage || "Failed to list templates"}
 			hasContent={hasContent}
-			header={
-				<>
-					<ToolIcon
-						name="list_templates"
-						isError={isError}
-						isRunning={isRunning}
-					/>
-					<span className="text-[13px] leading-6">{label}</span>
-				</>
-			}
-			headerStatus={
-				<>
-					{isError && (
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<TriangleAlertIcon className="size-3.5 shrink-0 text-current" />
-							</TooltipTrigger>
-							<TooltipContent>
-								{errorMessage || "Failed to list templates"}
-							</TooltipContent>
-						</Tooltip>
-					)}
-					{isRunning && (
-						<LoaderIcon className="size-3.5 shrink-0 animate-spin motion-reduce:animate-none text-current" />
-					)}
-				</>
-			}
 		>
-			<div className="mt-1.5">
-				{templates.map((template, index) => {
-					const rec = asRecord(template);
-					if (!rec) {
-						return null;
-					}
-					const name = asString(rec.name);
-					const displayName = asString(rec.display_name);
-					const templateName = displayName || name || `Template ${index + 1}`;
+			<ToolCall.Header iconName="list_templates" label={label} />
+			<ToolCall.Content>
+				<div className="mt-1.5">
+					{templates.map((template, index) => {
+						const rec = asRecord(template);
+						if (!rec) {
+							return null;
+						}
+						const name = asString(rec.name);
+						const displayName = asString(rec.display_name);
+						const templateName = displayName || name || `Template ${index + 1}`;
 
-					if (!name) {
+						if (!name) {
+							return (
+								<div key={index} className="text-[13px] text-content-secondary">
+									{templateName}
+								</div>
+							);
+						}
+
 						return (
-							<div key={index} className="text-[13px] text-content-secondary">
-								{templateName}
+							<div key={name} className="flex items-center gap-1.5">
+								<Link
+									to={`/templates/${name}`}
+									className="flex items-center gap-1.5 text-[13px] text-content-secondary opacity-50 transition-opacity hover:opacity-100"
+								>
+									<span>{templateName}</span>
+									<ExternalLinkIcon className="size-3 shrink-0" />
+								</Link>
 							</div>
 						);
-					}
-
-					return (
-						<div key={name} className="flex items-center gap-1.5">
-							<Link
-								to={`/templates/${name}`}
-								onClick={(e) => e.stopPropagation()}
-								className="flex items-center gap-1.5 text-[13px] text-content-secondary opacity-50 transition-opacity hover:opacity-100"
-							>
-								<span>{templateName}</span>
-								<ExternalLinkIcon className="size-3 shrink-0" />
-							</Link>
-						</div>
-					);
-				})}
-			</div>
-		</ToolCollapsible>
+					})}
+				</div>
+			</ToolCall.Content>
+		</ToolCall.Root>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessOutputTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessOutputTool.tsx
@@ -28,7 +28,7 @@ type ProcessOutputToolProps = {
 };
 
 type ProcessOutputToolInnerProps = ProcessOutputToolProps & {
-	autoDisplayState: AgentDisplayState;
+	defaultView: AgentDisplayState;
 	outputInitiallyFullyExpanded: boolean;
 };
 
@@ -43,7 +43,7 @@ export const ProcessOutputTool: React.FC<ProcessOutputToolProps> = (props) => {
 		<ProcessOutputToolInner
 			key={`${props.shellToolDisplayMode ?? "auto"}:${autoDisplayState}`}
 			{...props}
-			autoDisplayState={autoDisplayState}
+			defaultView={resolvedDisplayState}
 			outputInitiallyFullyExpanded={isAgentDisplayFullyExpanded(
 				resolvedDisplayState,
 			)}
@@ -57,8 +57,7 @@ const ProcessOutputToolInner: React.FC<ProcessOutputToolInnerProps> = ({
 	exitCode,
 	isError,
 	killedBySignal,
-	shellToolDisplayMode,
-	autoDisplayState,
+	defaultView,
 	outputInitiallyFullyExpanded,
 }) => {
 	const [outputFullyExpanded, setOutputFullyExpanded] = useState(
@@ -80,13 +79,12 @@ const ProcessOutputToolInner: React.FC<ProcessOutputToolInnerProps> = ({
 	const hasHeaderActions = Boolean(killedBySignal) || showExitCode || hasOutput;
 
 	return (
-		<ToolCall.AgentDisplayModeRoot
+		<ToolCall.Root
 			className="group/proc w-full"
 			status={isRunning ? "running" : isError ? "error" : "completed"}
 			isError={isError && !isRunning}
 			hasContent={hasOutput}
-			displayMode={shellToolDisplayMode}
-			autoDisplayState={autoDisplayState}
+			defaultView={defaultView}
 			ariaLabel={(expanded) =>
 				expanded ? "Collapse process output" : "Expand process output"
 			}
@@ -167,6 +165,6 @@ const ProcessOutputToolInner: React.FC<ProcessOutputToolInnerProps> = ({
 					</button>
 				)}
 			</ToolCall.Content>
-		</ToolCall.AgentDisplayModeRoot>
+		</ToolCall.Root>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessOutputTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessOutputTool.tsx
@@ -96,10 +96,10 @@ const ProcessOutputToolInner: React.FC<ProcessOutputToolInnerProps> = ({
 					<ToolCall.LeadingIcon name="process_output" />
 					<ToolCall.Label>Process output</ToolCall.Label>
 					<ToolCall.Status />
-					<ToolCall.Chevron />
+					<ToolCall.HeaderChevron />
 				</ToolCall.HeaderButton>
 				{hasHeaderActions && (
-					<ToolCall.Actions>
+					<ToolCall.HeaderActions>
 						{killedBySignal && !isRunning && (
 							<Tooltip>
 								<TooltipTrigger asChild>
@@ -119,10 +119,10 @@ const ProcessOutputToolInner: React.FC<ProcessOutputToolInnerProps> = ({
 							<CopyButton
 								text={output}
 								label="Copy output"
-								className="-my-0.5 size-6 p-0"
+								className="-my-0.5 size-6 p-0 opacity-0 transition-opacity hover:bg-surface-tertiary group-hover/proc:opacity-100 focus-visible:opacity-100"
 							/>
 						)}
-					</ToolCall.Actions>
+					</ToolCall.HeaderActions>
 				)}
 			</ToolCall.HeaderLayout>
 			<ToolCall.Content>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessOutputTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessOutputTool.tsx
@@ -23,6 +23,7 @@ type ProcessOutputToolProps = {
 	isRunning: boolean;
 	exitCode: number | null;
 	isError: boolean;
+	errorMessage?: string;
 	killedBySignal?: "kill" | "terminate";
 	shellToolDisplayMode?: TypesGen.AgentDisplayMode;
 };
@@ -56,6 +57,7 @@ const ProcessOutputToolInner: React.FC<ProcessOutputToolInnerProps> = ({
 	isRunning,
 	exitCode,
 	isError,
+	errorMessage,
 	killedBySignal,
 	defaultView,
 	outputInitiallyFullyExpanded,
@@ -83,6 +85,7 @@ const ProcessOutputToolInner: React.FC<ProcessOutputToolInnerProps> = ({
 			className="group/proc w-full"
 			status={isRunning ? "running" : isError ? "error" : "completed"}
 			isError={isError && !isRunning}
+			errorMessage={errorMessage || "Failed to read process output"}
 			hasContent={hasOutput}
 			defaultView={defaultView}
 			ariaLabel={(expanded) =>
@@ -94,7 +97,7 @@ const ProcessOutputToolInner: React.FC<ProcessOutputToolInnerProps> = ({
 					<ToolCall.LeadingIcon name="process_output" />
 					<ToolCall.Label>Process output</ToolCall.Label>
 					<ToolCall.Status />
-					<ToolCall.HeaderChevron />
+					<ToolCall.Chevron />
 				</ToolCall.HeaderButton>
 				{hasHeaderActions && (
 					<ToolCall.HeaderActions>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessOutputTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessOutputTool.tsx
@@ -1,4 +1,4 @@
-import { ChevronDownIcon, LoaderIcon, OctagonXIcon } from "lucide-react";
+import { ChevronDownIcon, OctagonXIcon } from "lucide-react";
 import type React from "react";
 import { useState } from "react";
 import type * as TypesGen from "#/api/typesGenerated";
@@ -15,8 +15,7 @@ import {
 	isAgentDisplayFullyExpanded,
 	resolveAgentDisplayState,
 } from "./displayMode";
-import { AgentDisplayModeToolCollapsible } from "./ToolCollapsible";
-import { ToolIcon } from "./ToolIcon";
+import { ToolCall } from "./ToolCall";
 import { COLLAPSED_OUTPUT_HEIGHT, signalTooltipLabel } from "./utils";
 
 type ProcessOutputToolProps = {
@@ -81,32 +80,26 @@ const ProcessOutputToolInner: React.FC<ProcessOutputToolInnerProps> = ({
 	const hasHeaderActions = Boolean(killedBySignal) || showExitCode || hasOutput;
 
 	return (
-		<AgentDisplayModeToolCollapsible
+		<ToolCall.AgentDisplayModeRoot
 			className="group/proc w-full"
+			status={isRunning ? "running" : isError ? "error" : "completed"}
+			isError={isError && !isRunning}
 			hasContent={hasOutput}
 			displayMode={shellToolDisplayMode}
 			autoDisplayState={autoDisplayState}
 			ariaLabel={(expanded) =>
 				expanded ? "Collapse process output" : "Expand process output"
 			}
-			header={
-				<>
-					<ToolIcon
-						name="process_output"
-						isError={isError}
-						isRunning={isRunning}
-					/>
-					<span className="text-[13px] leading-6">Process output</span>
-				</>
-			}
-			headerStatus={
-				isRunning ? (
-					<LoaderIcon className="size-3.5 shrink-0 animate-spin motion-reduce:animate-none text-content-secondary" />
-				) : undefined
-			}
-			headerActions={
-				hasHeaderActions ? (
-					<>
+		>
+			<ToolCall.HeaderLayout>
+				<ToolCall.HeaderButton>
+					<ToolCall.LeadingIcon name="process_output" />
+					<ToolCall.Label>Process output</ToolCall.Label>
+					<ToolCall.Status />
+					<ToolCall.Chevron />
+				</ToolCall.HeaderButton>
+				{hasHeaderActions && (
+					<ToolCall.Actions>
 						{killedBySignal && !isRunning && (
 							<Tooltip>
 								<TooltipTrigger asChild>
@@ -129,50 +122,51 @@ const ProcessOutputToolInner: React.FC<ProcessOutputToolInnerProps> = ({
 								className="-my-0.5 size-6 p-0"
 							/>
 						)}
-					</>
-				) : undefined
-			}
-		>
-			<ScrollArea
-				className="mt-1.5 rounded-md border border-solid border-border-default text-2xs"
-				viewportClassName={outputFullyExpanded ? "max-h-64" : ""}
-				scrollBarClassName="w-1.5"
-			>
-				<pre
-					ref={measureRef}
-					style={
-						outputFullyExpanded
-							? undefined
-							: { maxHeight: COLLAPSED_OUTPUT_HEIGHT, overflow: "hidden" }
-					}
-					className={cn(
-						"m-0 border-0 whitespace-pre-wrap break-all bg-transparent px-3 py-2 font-mono text-xs",
-						isError ? "text-content-destructive" : "text-content-secondary",
-					)}
+					</ToolCall.Actions>
+				)}
+			</ToolCall.HeaderLayout>
+			<ToolCall.Content>
+				<ScrollArea
+					className="mt-1.5 rounded-md border border-solid border-border-default text-2xs"
+					viewportClassName={outputFullyExpanded ? "max-h-64" : ""}
+					scrollBarClassName="w-1.5"
 				>
-					{output}
-				</pre>
-			</ScrollArea>
-			{overflows && (
-				<button
-					type="button"
-					aria-expanded={outputFullyExpanded}
-					onClick={toggleOutputExpansion}
-					className="border-0 bg-transparent m-0 mt-0.5 font-[inherit] text-[inherit] flex w-full cursor-pointer items-center justify-center rounded-md py-0.5 text-content-secondary transition-colors hover:bg-surface-secondary hover:text-content-primary"
-					aria-label={
-						outputFullyExpanded
-							? "Collapse full process output"
-							: "Expand full process output"
-					}
-				>
-					<ChevronDownIcon
+					<pre
+						ref={measureRef}
+						style={
+							outputFullyExpanded
+								? undefined
+								: { maxHeight: COLLAPSED_OUTPUT_HEIGHT, overflow: "hidden" }
+						}
 						className={cn(
-							"size-3 transition-transform",
-							outputFullyExpanded && "rotate-180",
+							"m-0 border-0 whitespace-pre-wrap break-all bg-transparent px-3 py-2 font-mono text-xs",
+							isError ? "text-content-destructive" : "text-content-secondary",
 						)}
-					/>
-				</button>
-			)}
-		</AgentDisplayModeToolCollapsible>
+					>
+						{output}
+					</pre>
+				</ScrollArea>
+				{overflows && (
+					<button
+						type="button"
+						aria-expanded={outputFullyExpanded}
+						onClick={toggleOutputExpansion}
+						className="border-0 bg-transparent m-0 mt-0.5 font-[inherit] text-[inherit] flex w-full cursor-pointer items-center justify-center rounded-md py-0.5 text-content-secondary transition-colors hover:bg-surface-secondary hover:text-content-primary"
+						aria-label={
+							outputFullyExpanded
+								? "Collapse full process output"
+								: "Expand full process output"
+						}
+					>
+						<ChevronDownIcon
+							className={cn(
+								"size-3 transition-transform",
+								outputFullyExpanded && "rotate-180",
+							)}
+						/>
+					</button>
+				)}
+			</ToolCall.Content>
+		</ToolCall.AgentDisplayModeRoot>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessOutputTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessOutputTool.tsx
@@ -84,7 +84,7 @@ const ProcessOutputToolInner: React.FC<ProcessOutputToolInnerProps> = ({
 		<ToolCall.Root
 			className="group/proc w-full"
 			status={isRunning ? "running" : isError ? "error" : "completed"}
-			isError={isError && !isRunning}
+			isError={isError}
 			errorMessage={errorMessage || "Failed to read process output"}
 			hasContent={hasOutput}
 			defaultView={defaultView}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ProposePlanTool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ProposePlanTool.stories.tsx
@@ -162,7 +162,11 @@ export const ErrorState: Story = {
 		expect(
 			canvas.getByText(`Proposed ${defaultPlanFilename}`),
 		).toBeInTheDocument();
-		expect(canvas.getByLabelText("Error")).toBeInTheDocument();
+		expect(
+			canvas.getByRole("img", {
+				name: "Failed to read file: file not found",
+			}),
+		).toBeInTheDocument();
 		expect(
 			canvas.queryByRole("button", { name: "Implement plan" }),
 		).not.toBeInTheDocument();
@@ -253,6 +257,8 @@ export const FileIDFetchError: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		expect(await canvas.findByLabelText("Error")).toBeInTheDocument();
+		expect(
+			await canvas.findByRole("img", { name: "Failed to load plan" }),
+		).toBeInTheDocument();
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ProposePlanTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ProposePlanTool.tsx
@@ -88,8 +88,12 @@ export const ProposePlanTool: React.FC<{
 			{hasDisplayContent ? (
 				<>
 					<Response>{displayContent}</Response>
-					<div className="flex items-center gap-2">
-						<CopyButton text={displayContent} label="Copy plan" />
+					<div className="group/plan-actions flex items-center gap-2">
+						<CopyButton
+							text={displayContent}
+							label="Copy plan"
+							className="opacity-0 transition-opacity group-hover/plan-actions:opacity-100 focus-visible:opacity-100"
+						/>
 						{canImplementPlan && (
 							<Tooltip>
 								<TooltipTrigger asChild>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ProposePlanTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ProposePlanTool.tsx
@@ -1,4 +1,4 @@
-import { LoaderIcon, PlayIcon, TriangleAlertIcon } from "lucide-react";
+import { LoaderIcon, PlayIcon } from "lucide-react";
 import type React from "react";
 import { useMutation, useQuery } from "react-query";
 import { API } from "#/api/api";
@@ -11,7 +11,7 @@ import {
 } from "#/components/Tooltip/Tooltip";
 import { Response } from "../Response";
 import { TranscriptRow } from "../TranscriptRow";
-import { ToolIcon } from "./ToolIcon";
+import { ToolCall } from "./ToolCall";
 import type { ToolStatus } from "./utils";
 
 export const ProposePlanTool: React.FC<{
@@ -74,32 +74,17 @@ export const ProposePlanTool: React.FC<{
 
 	return (
 		<div className="w-full">
-			<TranscriptRow className="gap-2 text-content-secondary">
-				<ToolIcon
-					name="propose_plan"
-					isError={effectiveError}
-					isRunning={isRunning}
+			<ToolCall.Root
+				status={status}
+				isError={effectiveError}
+				errorMessage={effectiveErrorMessage || "Failed to propose plan"}
+				hasContent={false}
+			>
+				<ToolCall.Header
+					iconName="propose_plan"
+					label={isRunning ? `Proposing ${filename}…` : `Proposed ${filename}`}
 				/>
-				<span className="text-[13px] leading-6">
-					{isRunning ? `Proposing ${filename}…` : `Proposed ${filename}`}
-				</span>
-				{effectiveError && (
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<TriangleAlertIcon
-								aria-label="Error"
-								className="size-3.5 shrink-0 text-content-secondary"
-							/>
-						</TooltipTrigger>
-						<TooltipContent>
-							{effectiveErrorMessage || "Failed to propose plan"}
-						</TooltipContent>
-					</Tooltip>
-				)}
-				{isRunning && (
-					<LoaderIcon className="size-3.5 shrink-0 animate-spin motion-reduce:animate-none text-current" />
-				)}
-			</TranscriptRow>
+			</ToolCall.Root>
 			{hasDisplayContent ? (
 				<>
 					<Response>{displayContent}</Response>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFileTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFileTool.tsx
@@ -1,16 +1,9 @@
 import { useTheme } from "@emotion/react";
 import { File as FileViewer } from "@pierre/diffs/react";
-import { LoaderIcon, TriangleAlertIcon } from "lucide-react";
 import type React from "react";
 import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "#/components/Tooltip/Tooltip";
 import { asRecord, asString } from "../runtimeTypeUtils";
-import { ToolCollapsible } from "./ToolCollapsible";
-import { ToolIcon } from "./ToolIcon";
+import { ToolCall } from "./ToolCall";
 import {
 	DIFFS_FONT_STYLE,
 	getFileViewerOptionsMinimal,
@@ -92,41 +85,26 @@ export const ReadFileTool: React.FC<{
 	const label = isRunning ? `Reading ${filename}…` : `Read ${filename}`;
 
 	return (
-		<ToolCollapsible
+		<ToolCall.Root
 			className="w-full"
+			status={status}
+			isError={isError}
+			errorMessage={errorMessage || "Failed to read file"}
 			hasContent={hasContent}
 			expanded={expanded}
 			onExpandedChange={onExpandedChange}
-			header={
-				<>
-					<ToolIcon name="read_file" isError={isError} isRunning={isRunning} />
-					<span className="text-[13px] leading-6">{label}</span>
-				</>
-			}
-			headerStatus={
-				<>
-					{isError && (
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<TriangleAlertIcon className="size-3.5 shrink-0 text-current" />
-							</TooltipTrigger>
-							<TooltipContent>
-								{errorMessage || "Failed to read file"}
-							</TooltipContent>
-						</Tooltip>
-					)}
-					{isRunning && (
-						<LoaderIcon className="size-3.5 shrink-0 animate-spin motion-reduce:animate-none text-current" />
-					)}
-				</>
-			}
 		>
-			{isError && (
-				<div className="mt-1 text-xs text-content-destructive">
-					{errorMessage || "Failed to read file"}
-				</div>
-			)}
-			{content.length > 0 && <ReadFileContent path={path} content={content} />}
-		</ToolCollapsible>
+			<ToolCall.Header iconName="read_file" label={label} />
+			<ToolCall.Content>
+				{isError && (
+					<div className="mt-1 text-xs text-content-destructive">
+						{errorMessage || "Failed to read file"}
+					</div>
+				)}
+				{content.length > 0 && (
+					<ReadFileContent path={path} content={content} />
+				)}
+			</ToolCall.Content>
+		</ToolCall.Root>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFilesTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFilesTool.tsx
@@ -1,14 +1,7 @@
-import { LoaderIcon, TriangleAlertIcon } from "lucide-react";
 import { type FC, useState } from "react";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "#/components/Tooltip/Tooltip";
 import type { MergedTool } from "../../ChatConversation/types";
 import { getReadFileToolData, ReadFileTool } from "./ReadFileTool";
-import { ToolCollapsible } from "./ToolCollapsible";
-import { ToolIcon } from "./ToolIcon";
+import { ToolCall } from "./ToolCall";
 
 type ReadFileItem = {
 	id: string;
@@ -44,61 +37,44 @@ export const ReadFilesTool: FC<{
 
 	return (
 		<div data-tool-call="">
-			<ToolCollapsible
+			<ToolCall.Root
 				className="w-full"
+				status={isRunning ? "running" : isError ? "error" : "completed"}
+				isError={isError}
+				errorMessage={errorMessage || "Failed to read one or more files"}
 				hasContent={hasContent}
 				expanded={expanded}
 				onExpandedChange={onExpandedChange}
-				header={
-					<>
-						<ToolIcon
-							name="read_file"
-							isError={isError}
-							isRunning={isRunning}
-						/>
-						<span className="text-[13px] leading-6">{label}</span>
-						{isError && (
-							<Tooltip>
-								<TooltipTrigger asChild>
-									<TriangleAlertIcon className="h-3.5 w-3.5 shrink-0 text-current" />
-								</TooltipTrigger>
-								<TooltipContent>
-									{errorMessage || "Failed to read one or more files"}
-								</TooltipContent>
-							</Tooltip>
-						)}
-						{isRunning && (
-							<LoaderIcon className="h-3.5 w-3.5 shrink-0 animate-spin motion-reduce:animate-none text-current" />
-						)}
-					</>
-				}
 			>
-				<div className="space-y-1 py-0.5 pl-3">
-					{items.map((item) => (
-						<div key={item.id}>
-							<ReadFileTool
-								path={item.path}
-								content={item.content}
-								status={item.status}
-								isError={item.isError}
-								errorMessage={item.errorMessage}
-								expanded={expandedFileIDs.has(item.id)}
-								onExpandedChange={(nextExpanded) => {
-									setExpandedFileIDs((previous) => {
-										const next = new Set(previous);
-										if (nextExpanded) {
-											next.add(item.id);
-										} else {
-											next.delete(item.id);
-										}
-										return next;
-									});
-								}}
-							/>
-						</div>
-					))}
-				</div>
-			</ToolCollapsible>
+				<ToolCall.Header iconName="read_file" label={label} />
+				<ToolCall.Content>
+					<div className="space-y-1 py-0.5 pl-3">
+						{items.map((item) => (
+							<div key={item.id}>
+								<ReadFileTool
+									path={item.path}
+									content={item.content}
+									status={item.status}
+									isError={item.isError}
+									errorMessage={item.errorMessage}
+									expanded={expandedFileIDs.has(item.id)}
+									onExpandedChange={(nextExpanded) => {
+										setExpandedFileIDs((previous) => {
+											const next = new Set(previous);
+											if (nextExpanded) {
+												next.add(item.id);
+											} else {
+												next.delete(item.id);
+											}
+											return next;
+										});
+									}}
+								/>
+							</div>
+						))}
+					</div>
+				</ToolCall.Content>
+			</ToolCall.Root>
 		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ReadSkillTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ReadSkillTool.tsx
@@ -1,14 +1,7 @@
-import { LoaderIcon, TriangleAlertIcon } from "lucide-react";
 import type React from "react";
 import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "#/components/Tooltip/Tooltip";
 import { Response } from "../Response";
-import { ToolCollapsible } from "./ToolCollapsible";
-import { ToolIcon } from "./ToolIcon";
+import { ToolCall } from "./ToolCall";
 import type { ToolStatus } from "./utils";
 
 export const ReadSkillTool: React.FC<{
@@ -22,46 +15,30 @@ export const ReadSkillTool: React.FC<{
 	const isRunning = status === "running";
 
 	return (
-		<ToolCollapsible
+		<ToolCall.Root
 			className="w-full"
+			status={status}
+			isError={isError}
+			errorMessage={errorMessage || "Failed to read skill"}
 			hasContent={hasContent}
-			header={
-				<>
-					<ToolIcon name="read_skill" isError={isError} isRunning={isRunning} />
-					<span className="text-[13px] leading-6">
-						{isRunning ? `Reading ${label}…` : `Read ${label}`}
-					</span>
-				</>
-			}
-			headerStatus={
-				<>
-					{isError && (
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<TriangleAlertIcon className="size-3.5 shrink-0 text-current" />
-							</TooltipTrigger>
-							<TooltipContent>
-								{errorMessage || "Failed to read skill"}
-							</TooltipContent>
-						</Tooltip>
-					)}
-					{isRunning && (
-						<LoaderIcon className="size-3.5 shrink-0 animate-spin motion-reduce:animate-none text-current" />
-					)}
-				</>
-			}
 		>
-			{body && (
-				<ScrollArea
-					className="mt-1.5 rounded-md border border-solid border-border-default"
-					viewportClassName="max-h-64"
-					scrollBarClassName="w-1.5"
-				>
-					<div className="px-3 py-2">
-						<Response>{body}</Response>
-					</div>
-				</ScrollArea>
-			)}
-		</ToolCollapsible>
+			<ToolCall.Header
+				iconName="read_skill"
+				label={isRunning ? `Reading ${label}…` : `Read ${label}`}
+			/>
+			<ToolCall.Content>
+				{body && (
+					<ScrollArea
+						className="mt-1.5 rounded-md border border-solid border-border-default"
+						viewportClassName="max-h-64"
+						scrollBarClassName="w-1.5"
+					>
+						<div className="px-3 py-2">
+							<Response>{body}</Response>
+						</div>
+					</ScrollArea>
+				)}
+			</ToolCall.Content>
+		</ToolCall.Root>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ReadTemplateTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ReadTemplateTool.tsx
@@ -1,12 +1,5 @@
-import { LoaderIcon, TriangleAlertIcon } from "lucide-react";
 import type React from "react";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "#/components/Tooltip/Tooltip";
-import { TranscriptRow } from "../TranscriptRow";
-import { ToolIcon } from "./ToolIcon";
+import { ToolCall } from "./ToolCall";
 import type { ToolStatus } from "./utils";
 
 /**
@@ -28,22 +21,13 @@ export const ReadTemplateTool: React.FC<{
 			: "Read template";
 
 	return (
-		<TranscriptRow className="gap-2 text-content-secondary">
-			<ToolIcon name="read_template" isError={isError} isRunning={isRunning} />
-			<span className="text-[13px] leading-6">{label}</span>
-			{isError && (
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<TriangleAlertIcon className="size-3.5 shrink-0 text-current" />
-					</TooltipTrigger>
-					<TooltipContent>
-						{errorMessage || "Failed to read template"}
-					</TooltipContent>
-				</Tooltip>
-			)}
-			{isRunning && (
-				<LoaderIcon className="size-3.5 shrink-0 animate-spin motion-reduce:animate-none text-current" />
-			)}
-		</TranscriptRow>
+		<ToolCall.Root
+			status={status}
+			isError={isError}
+			errorMessage={errorMessage || "Failed to read template"}
+			hasContent={false}
+		>
+			<ToolCall.Header iconName="read_template" label={label} />
+		</ToolCall.Root>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/StartWorkspaceTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/StartWorkspaceTool.tsx
@@ -1,12 +1,5 @@
-import { LoaderIcon, TriangleAlertIcon } from "lucide-react";
 import type { FC } from "react";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "#/components/Tooltip/Tooltip";
-import { ToolCollapsible } from "./ToolCollapsible";
-import { ToolIcon } from "./ToolIcon";
+import { ToolCall } from "./ToolCall";
 import type { ToolStatus } from "./utils";
 import { WorkspaceBuildLogSection } from "./WorkspaceBuildLogSection";
 
@@ -41,47 +34,21 @@ export const StartWorkspaceTool: FC<StartWorkspaceToolProps> = ({
 					? `Started ${workspaceName}`
 					: "Started workspace";
 
-	const header = (
-		<>
-			<ToolIcon
-				name="start_workspace"
-				isError={isError}
-				isRunning={isRunning}
-			/>
-			<span className="text-[13px] leading-6">{label}</span>
-		</>
-	);
-	const headerStatus = (
-		<>
-			{isError && (
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<TriangleAlertIcon className="size-3.5 shrink-0 text-current" />
-					</TooltipTrigger>
-					<TooltipContent>
-						{errorMessage || "Failed to start workspace"}
-					</TooltipContent>
-				</Tooltip>
-			)}
-			{isRunning && (
-				<LoaderIcon className="size-3.5 shrink-0 animate-spin motion-reduce:animate-none text-current" />
-			)}
-		</>
-	);
-
-	// Show collapsible with build logs when there's a build to show.
 	const hasBuildLogs = (isRunning || Boolean(buildId)) && !noBuild;
 
 	return (
-		<div className="w-full">
-			<ToolCollapsible
-				header={header}
-				headerStatus={headerStatus}
-				hasContent={hasBuildLogs}
-				defaultExpanded={isRunning}
-			>
+		<ToolCall.Root
+			className="w-full"
+			status={status}
+			isError={isError}
+			errorMessage={errorMessage || "Failed to start workspace"}
+			hasContent={hasBuildLogs}
+			defaultExpanded={isRunning}
+		>
+			<ToolCall.Header iconName="start_workspace" label={label} />
+			<ToolCall.Content>
 				<WorkspaceBuildLogSection status={status} buildId={buildId} />
-			</ToolCollapsible>
-		</div>
+			</ToolCall.Content>
+		</ToolCall.Root>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
@@ -216,10 +216,15 @@ export const SubagentTool: React.FC<{
 							isTimeout,
 						)}
 					</ToolCall.Label>
-					<ToolCall.Chevron />
+					{durationLabel && (
+						<span className="shrink-0 text-xs text-content-secondary">
+							{`Worked for ${durationLabel}`}
+						</span>
+					)}
+					<ToolCall.HeaderChevron />
 				</ToolCall.HeaderButton>
 				{agentChatPath && (
-					<ToolCall.Actions>
+					<ToolCall.HeaderActions>
 						<Link
 							to={{ pathname: agentChatPath, search: location.search }}
 							className="inline-flex align-middle text-content-secondary opacity-50 transition-opacity hover:opacity-100"
@@ -227,12 +232,7 @@ export const SubagentTool: React.FC<{
 						>
 							<ExternalLinkIcon className="size-3" />
 						</Link>
-					</ToolCall.Actions>
-				)}
-				{durationLabel && (
-					<span className="shrink-0 text-xs text-content-secondary">
-						{`Worked for ${durationLabel}`}
-					</span>
+					</ToolCall.HeaderActions>
 				)}
 			</ToolCall.HeaderLayout>
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
@@ -17,11 +17,7 @@ import { InlineDesktopPreview } from "./InlineDesktopPreview";
 import { RecordingPreview } from "./RecordingPreview";
 import type { SubagentAction, SubagentDescriptor } from "./subagentDescriptor";
 import { ToolCall } from "./ToolCall";
-import {
-	isSubagentSuccessStatus,
-	shortDurationMs,
-	type ToolStatus,
-} from "./utils";
+import { isSubagentSuccessStatus, type ToolStatus } from "./utils";
 
 const SUBAGENT_VERBS: Record<
 	SubagentAction,
@@ -149,7 +145,6 @@ export const SubagentTool: React.FC<{
 	subagentStatus: string;
 	prompt?: string;
 	message?: string;
-	durationMs?: number;
 	report?: string;
 	toolStatus: ToolStatus;
 	isError: boolean;
@@ -167,7 +162,6 @@ export const SubagentTool: React.FC<{
 	subagentStatus,
 	prompt,
 	message,
-	durationMs,
 	report,
 	toolStatus,
 	isError,
@@ -183,7 +177,6 @@ export const SubagentTool: React.FC<{
 	const hasMessage = Boolean(message?.trim());
 	const hasReport = Boolean(report?.trim());
 	const hasExpandableContent = hasPrompt || hasMessage || hasReport;
-	const durationLabel = shortDurationMs(durationMs);
 	const agentChatPath = safeBuildAgentChatPath({ chatId });
 
 	return (
@@ -216,11 +209,6 @@ export const SubagentTool: React.FC<{
 							isTimeout,
 						)}
 					</ToolCall.Label>
-					{durationLabel && (
-						<span className="shrink-0 text-xs text-content-secondary">
-							{`Worked for ${durationLabel}`}
-						</span>
-					)}
 					<ToolCall.HeaderChevron />
 				</ToolCall.HeaderButton>
 				{agentChatPath && (

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
@@ -209,7 +209,7 @@ export const SubagentTool: React.FC<{
 							isTimeout,
 						)}
 					</ToolCall.Label>
-					<ToolCall.HeaderChevron />
+					<ToolCall.Chevron />
 				</ToolCall.HeaderButton>
 				{agentChatPath && (
 					<ToolCall.HeaderActions>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
@@ -1,6 +1,5 @@
 import {
 	BotIcon,
-	ChevronDownIcon,
 	CircleXIcon,
 	ClockIcon,
 	ExternalLinkIcon,
@@ -11,15 +10,13 @@ import type React from "react";
 import { useState } from "react";
 import { Link, useLocation } from "react-router";
 import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
-import { cn } from "#/utils/cn";
 import { safeBuildAgentChatPath } from "../../../utils/navigation";
 import { Response } from "../Response";
-import { Shimmer } from "../Shimmer";
-import { TranscriptRow } from "../TranscriptRow";
 import { useDesktopPanel } from "./DesktopPanelContext";
 import { InlineDesktopPreview } from "./InlineDesktopPreview";
 import { RecordingPreview } from "./RecordingPreview";
 import type { SubagentAction, SubagentDescriptor } from "./subagentDescriptor";
+import { ToolCall } from "./ToolCall";
 import {
 	isSubagentSuccessStatus,
 	shortDurationMs,
@@ -68,11 +65,7 @@ function getSubagentLabel(
 	isTimeout: boolean,
 ): React.ReactNode {
 	if (showDesktopPreview && toolStatus === "running") {
-		return (
-			<Shimmer as="span" className="text-[13px] leading-6">
-				Using the computer...
-			</Shimmer>
-		);
+		return "Using the computer...";
 	}
 	if (
 		descriptor.variant === "computer_use" &&
@@ -194,28 +187,27 @@ export const SubagentTool: React.FC<{
 	const agentChatPath = safeBuildAgentChatPath({ chatId });
 
 	return (
-		<div className="w-full">
-			<TranscriptRow
-				asChild
-				className={cn(
-					"m-0 w-full gap-2 border-0 bg-transparent p-0 text-left font-[inherit] text-[inherit] text-content-secondary transition-colors",
-					hasExpandableContent && "cursor-pointer hover:text-content-primary",
-				)}
-			>
-				<button
-					type="button"
-					aria-expanded={hasExpandableContent ? expanded : undefined}
-					onClick={() => hasExpandableContent && setExpanded((v) => !v)}
-				>
-					<SubagentStatusIcon
-						subagentStatus={subagentStatus}
-						toolStatus={toolStatus}
-						isError={isError}
-						isTimeout={isTimeout}
-						iconKind={descriptor.iconKind}
-						showDesktopPreview={showDesktopPreview}
-					/>{" "}
-					<span className="min-w-0 truncate text-[13px]">
+		<ToolCall.Root
+			className="w-full"
+			status={toolStatus}
+			isError={isError}
+			hasContent={hasExpandableContent}
+			expanded={expanded}
+			onExpandedChange={setExpanded}
+		>
+			<ToolCall.HeaderLayout>
+				<ToolCall.HeaderButton alwaysButton>
+					<ToolCall.LeadingIcon>
+						<SubagentStatusIcon
+							subagentStatus={subagentStatus}
+							toolStatus={toolStatus}
+							isError={isError}
+							isTimeout={isTimeout}
+							iconKind={descriptor.iconKind}
+							showDesktopPreview={showDesktopPreview}
+						/>
+					</ToolCall.LeadingIcon>
+					<ToolCall.Label>
 						{getSubagentLabel(
 							showDesktopPreview,
 							toolStatus,
@@ -223,32 +215,26 @@ export const SubagentTool: React.FC<{
 							title,
 							isTimeout,
 						)}
-						{agentChatPath && (
-							<Link
-								to={{ pathname: agentChatPath, search: location.search }}
-								onClick={(e) => e.stopPropagation()}
-								className="ml-1 inline-flex align-middle text-content-secondary opacity-50 transition-opacity hover:opacity-100"
-								aria-label="View agent"
-							>
-								<ExternalLinkIcon className="size-3" />
-							</Link>
-						)}
+					</ToolCall.Label>
+					<ToolCall.Chevron />
+				</ToolCall.HeaderButton>
+				{agentChatPath && (
+					<ToolCall.Actions>
+						<Link
+							to={{ pathname: agentChatPath, search: location.search }}
+							className="inline-flex align-middle text-content-secondary opacity-50 transition-opacity hover:opacity-100"
+							aria-label="View agent"
+						>
+							<ExternalLinkIcon className="size-3" />
+						</Link>
+					</ToolCall.Actions>
+				)}
+				{durationLabel && (
+					<span className="shrink-0 text-xs text-content-secondary">
+						{`Worked for ${durationLabel}`}
 					</span>
-					{hasExpandableContent && (
-						<ChevronDownIcon
-							className={cn(
-								"size-3 shrink-0 text-current transition-transform",
-								expanded ? "rotate-0" : "-rotate-90",
-							)}
-						/>
-					)}
-					{durationLabel && (
-						<span className="ml-auto shrink-0 text-xs">
-							{`Worked for ${durationLabel}`}
-						</span>
-					)}
-				</button>
-			</TranscriptRow>
+				)}
+			</ToolCall.HeaderLayout>
 
 			{showDesktopPreview && desktopChatId && toolStatus !== "completed" && (
 				<div className="mt-1.5 overflow-hidden rounded-lg border border-solid border-border-default">
@@ -267,41 +253,43 @@ export const SubagentTool: React.FC<{
 					/>
 				</div>
 			)}
-			{expanded && hasPrompt && (
-				<ScrollArea
-					className="mt-1.5 rounded-md border border-solid border-border-default"
-					viewportClassName="max-h-64"
-					scrollBarClassName="w-1.5"
-				>
-					<div className="px-3 py-2">
-						<Response>{prompt ?? ""}</Response>
-					</div>
-				</ScrollArea>
-			)}
+			<ToolCall.Content>
+				{hasPrompt && (
+					<ScrollArea
+						className="mt-1.5 rounded-md border border-solid border-border-default"
+						viewportClassName="max-h-64"
+						scrollBarClassName="w-1.5"
+					>
+						<div className="px-3 py-2">
+							<Response>{prompt ?? ""}</Response>
+						</div>
+					</ScrollArea>
+				)}
 
-			{expanded && hasMessage && (
-				<ScrollArea
-					className="mt-1.5 rounded-md border border-solid border-border-default"
-					viewportClassName="max-h-64"
-					scrollBarClassName="w-1.5"
-				>
-					<div className="px-3 py-2">
-						<Response>{message ?? ""}</Response>
-					</div>
-				</ScrollArea>
-			)}
+				{hasMessage && (
+					<ScrollArea
+						className="mt-1.5 rounded-md border border-solid border-border-default"
+						viewportClassName="max-h-64"
+						scrollBarClassName="w-1.5"
+					>
+						<div className="px-3 py-2">
+							<Response>{message ?? ""}</Response>
+						</div>
+					</ScrollArea>
+				)}
 
-			{expanded && hasReport && (
-				<ScrollArea
-					className="mt-1.5 rounded-md border border-solid border-border-default"
-					viewportClassName="max-h-64"
-					scrollBarClassName="w-1.5"
-				>
-					<div className="px-3 py-2">
-						<Response>{report ?? ""}</Response>
-					</div>
-				</ScrollArea>
-			)}
-		</div>
+				{hasReport && (
+					<ScrollArea
+						className="mt-1.5 rounded-md border border-solid border-border-default"
+						viewportClassName="max-h-64"
+						scrollBarClassName="w-1.5"
+					>
+						<div className="px-3 py-2">
+							<Response>{report ?? ""}</Response>
+						</div>
+					</ScrollArea>
+				)}
+			</ToolCall.Content>
+		</ToolCall.Root>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -364,7 +364,9 @@ export const ExecuteSuccess: Story = {
 		expect(
 			canvas.queryByRole("img", { name: "Running in background" }),
 		).not.toBeInTheDocument();
-		expect(canvas.getByText(/for 47\.2s/)).toBeVisible();
+		const durationSuffix = canvas.getByText("for 47.2s");
+		expect(durationSuffix).toBeVisible();
+		expect(durationSuffix.tagName).toBe("SPAN");
 		expect(canvas.queryByText("2 lines")).not.toBeInTheDocument();
 	},
 };
@@ -527,6 +529,21 @@ export const ProcessOutputAlwaysExpanded: Story = {
 	},
 };
 
+export const ProcessOutputStringError: Story = {
+	args: {
+		name: "process_output",
+		status: "error",
+		isError: true,
+		result: "permission denied",
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByRole("img", { name: "Failed to read process output" }),
+		).toBeVisible();
+	},
+};
+
 export const ExecuteAuthRequired: Story = {
 	args: {
 		result: {
@@ -576,6 +593,9 @@ export const WaitForExternalAuthRunning: Story = {
 		expect(
 			canvas.getByText("Waiting for GitHub authentication..."),
 		).toBeInTheDocument();
+		expect(
+			canvas.getByRole("img", { name: "Authentication in progress" }),
+		).toBeVisible();
 	},
 };
 
@@ -2005,6 +2025,38 @@ export const GenericToolFailedNoResult: Story = {
 		expect(
 			canvasElement.querySelector(".lucide-triangle-alert"),
 		).not.toBeNull();
+	},
+};
+
+export const GenericToolStringError: Story = {
+	args: {
+		name: "web_search",
+		status: "error",
+		isError: true,
+		result: "Network unreachable",
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByRole("img", { name: "Web search failed" }),
+		).toBeVisible();
+	},
+};
+
+export const GenericMCPToolStringError: Story = {
+	args: {
+		name: "linear__list_issues",
+		status: "error",
+		isError: true,
+		result: "Authentication token expired",
+		mcpServerConfigId: "mcp-server-1",
+		mcpServers: sampleMCPServers,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByRole("img", { name: "List issues failed" }),
+		).toBeVisible();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -804,57 +804,6 @@ export const SubagentAwaitPreferredTitle: Story = {
 	},
 };
 
-export const SubagentRequestMetadata: Story = {
-	args: {
-		name: "spawn_agent",
-		args: undefined,
-		result: {
-			chat_id: "child-chat-id",
-			status: "completed",
-			request_id: "request-123",
-			duration_ms: 1530,
-		},
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(canvas.getByText("Worked for 2s")).toBeInTheDocument();
-	},
-};
-
-export const SubagentAwaitRequestMetadata: Story = {
-	args: {
-		name: "wait_agent",
-		args: undefined,
-		result: {
-			chat_id: "child-chat-id",
-			status: "completed",
-			request_id: "request-123",
-			duration_ms: 1530,
-		},
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(canvas.getByText("Worked for 2s")).toBeInTheDocument();
-	},
-};
-
-export const SubagentMessageRequestMetadata: Story = {
-	args: {
-		name: "message_agent",
-		args: undefined,
-		result: {
-			chat_id: "child-chat-id",
-			status: "completed",
-			request_id: "request-123",
-			duration_ms: 1530,
-		},
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(canvas.getByText("Worked for 2s")).toBeInTheDocument();
-	},
-};
-
 export const SpawnSubagentGeneralRunning: Story = {
 	args: {
 		name: "spawn_agent",
@@ -892,7 +841,6 @@ export const SpawnSubagentGeneralCompleted: Story = {
 			type: "general",
 			title: "Workspace diagnostics",
 			status: "completed",
-			duration_ms: 3200,
 		},
 	},
 	play: async ({ canvasElement }) => {
@@ -900,7 +848,6 @@ export const SpawnSubagentGeneralCompleted: Story = {
 		expect(
 			canvas.getByRole("button", { name: /Spawned Workspace diagnostics/ }),
 		).toBeInTheDocument();
-		expect(canvas.getByText("Worked for 3s")).toBeInTheDocument();
 	},
 };
 
@@ -938,7 +885,6 @@ export const SpawnSubagentExploreCompleted: Story = {
 			chat_id: "spawn-explore-child",
 			type: "explore",
 			status: "completed",
-			duration_ms: 4100,
 		},
 	},
 	play: async ({ canvasElement }) => {
@@ -946,7 +892,6 @@ export const SpawnSubagentExploreCompleted: Story = {
 		expect(
 			canvas.getByRole("button", { name: /Spawned Explore agent/ }),
 		).toBeInTheDocument();
-		expect(canvas.getByText("Worked for 4s")).toBeInTheDocument();
 	},
 };
 
@@ -1005,7 +950,6 @@ export const SpawnSubagentComputerUseCompleted: Story = {
 			type: "computer_use",
 			title: "Visual regression check",
 			status: "completed",
-			duration_ms: "12400",
 		},
 	},
 	play: async ({ canvasElement }) => {
@@ -1013,7 +957,6 @@ export const SpawnSubagentComputerUseCompleted: Story = {
 		expect(
 			canvas.getByRole("button", { name: /Spawned Visual regression check/ }),
 		).toBeInTheDocument();
-		expect(canvas.getByText("Worked for 12s")).toBeInTheDocument();
 	},
 };
 
@@ -2308,14 +2251,12 @@ export const SpawnComputerUseAgentCompleted: Story = {
 			chat_id: "desktop-child-1",
 			title: "Visual regression check",
 			status: "completed",
-			duration_ms: "12400",
 		},
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		expect(canvas.getByText(/Spawned/)).toBeInTheDocument();
 		expect(canvas.getByText(/Visual regression check/)).toBeInTheDocument();
-		expect(canvas.getByText("Worked for 12s")).toBeInTheDocument();
 		expect(canvas.getByRole("link", { name: "View agent" })).toHaveAttribute(
 			"href",
 			"/agents/desktop-child-1",

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -1,14 +1,8 @@
 import { useTheme } from "@emotion/react";
 import { File as FileViewer } from "@pierre/diffs/react";
-import { LoaderIcon, TriangleAlertIcon } from "lucide-react";
 import { type ComponentPropsWithRef, type FC, memo } from "react";
 import type * as TypesGen from "#/api/typesGenerated";
 import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "#/components/Tooltip/Tooltip";
 import { cn } from "#/utils/cn";
 import { AdvisorTool, type AdvisorToolResultType } from "./AdvisorTool";
 import {
@@ -39,8 +33,7 @@ import {
 	isSubagentToolName,
 	type SubagentVariant,
 } from "./subagentDescriptor";
-import { ToolCollapsible } from "./ToolCollapsible";
-import { ToolIcon } from "./ToolIcon";
+import { ToolCall } from "./ToolCall";
 import { ToolLabel } from "./ToolLabel";
 import { getExecuteRenderData, shouldRenderTool } from "./toolVisibility";
 import {
@@ -918,67 +911,43 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 		: undefined;
 
 	const hasContent = Boolean(toolInput || fileContent || resultOutput);
-	const isRunning = status === "running";
 	const rec = asRecord(result);
 	const errorMessage = rec ? asString(rec.error || rec.message) : "";
 
-	const toolHeader = (
-		<>
-			<ToolIcon
-				name={name}
-				isError={status === "error" || isError}
-				iconUrl={mcpServer?.icon_url}
-				isRunning={isRunning}
-				serverName={mcpServer?.display_name}
-			/>
-			{modelIntent ? (
-				<span className="truncate text-[13px]">
-					{formatModelIntentLabel(modelIntent)}
-				</span>
-			) : (
-				<ToolLabel
-					name={name}
-					args={args}
-					result={result}
-					mcpSlug={mcpServer?.slug}
-				/>
-			)}
-		</>
-	);
-	const toolHeaderStatus = (
-		<>
-			{isError && (
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<TriangleAlertIcon className="size-3.5 shrink-0 text-current" />
-					</TooltipTrigger>
-					<TooltipContent>{errorMessage || "Tool call failed"}</TooltipContent>
-				</Tooltip>
-			)}
-			{isRunning && (
-				<LoaderIcon className="size-3.5 shrink-0 animate-spin motion-reduce:animate-none text-current" />
-			)}
-		</>
-	);
-
-	const toolContent = (
-		<GenericToolContent
-			toolInput={toolInput}
-			fileContent={fileContent}
-			fileContentOptions={fileContentOptions}
-			isDark={isDark}
-			resultOutput={resultOutput}
-		/>
-	);
-
 	return (
-		<ToolCollapsible
+		<ToolCall.Root
+			status={status}
+			isError={isError}
+			errorMessage={errorMessage || "Tool call failed"}
 			hasContent={hasContent}
-			header={toolHeader}
-			headerStatus={toolHeaderStatus}
 		>
-			{toolContent}
-		</ToolCollapsible>
+			<ToolCall.Header
+				iconName={name}
+				iconUrl={mcpServer?.icon_url}
+				serverName={mcpServer?.display_name}
+				label={
+					modelIntent ? (
+						formatModelIntentLabel(modelIntent)
+					) : (
+						<ToolLabel
+							name={name}
+							args={args}
+							result={result}
+							mcpSlug={mcpServer?.slug}
+						/>
+					)
+				}
+			/>
+			<ToolCall.Content>
+				<GenericToolContent
+					toolInput={toolInput}
+					fileContent={fileContent}
+					fileContentOptions={fileContentOptions}
+					isDark={isDark}
+					resultOutput={resultOutput}
+				/>
+			</ToolCall.Content>
+		</ToolCall.Root>
 	);
 };
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -49,6 +49,7 @@ import {
 	getFileViewerOptions,
 	getFileViewerOptionsNoHeader,
 	getWriteFileDiff,
+	humanizeMCPToolName,
 	isSubagentSuccessStatus,
 	mapSubagentStatusToToolStatus,
 	parseArgs,
@@ -266,6 +267,7 @@ const ProcessOutputRenderer: FC<ToolRendererProps> = ({
 	const exitCode = rec
 		? (asNumber(rec.exit_code, { parseString: true }) ?? null)
 		: null;
+	const errorMessage = rec ? asString(rec.error || rec.message) : "";
 
 	return (
 		<ProcessOutputTool
@@ -273,6 +275,7 @@ const ProcessOutputRenderer: FC<ToolRendererProps> = ({
 			isRunning={status === "running"}
 			exitCode={exitCode}
 			isError={isError}
+			errorMessage={errorMessage || undefined}
 			killedBySignal={killedBySignal}
 			shellToolDisplayMode={shellToolDisplayMode}
 		/>
@@ -877,6 +880,17 @@ const GenericToolContent: FC<GenericToolContentProps> = ({
 	);
 };
 
+const getGenericToolErrorMessage = ({
+	name,
+	mcpSlug,
+}: {
+	name: string;
+	mcpSlug?: string;
+}): string => {
+	const displayName = humanizeMCPToolName(mcpSlug ?? "", name);
+	return `${displayName} failed`;
+};
+
 const GenericToolRenderer: FC<ToolRendererProps> = ({
 	name,
 	status,
@@ -909,12 +923,16 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 	const hasContent = Boolean(toolInput || fileContent || resultOutput);
 	const rec = asRecord(result);
 	const errorMessage = rec ? asString(rec.error || rec.message) : "";
+	const fallbackErrorMessage = getGenericToolErrorMessage({
+		name,
+		mcpSlug: mcpServer?.slug,
+	});
 
 	return (
 		<ToolCall.Root
 			status={status}
 			isError={isError}
-			errorMessage={errorMessage || "Tool call failed"}
+			errorMessage={errorMessage || fallbackErrorMessage}
 			hasContent={hasContent}
 		>
 			<ToolCall.Header

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -489,9 +489,6 @@ const SubagentRenderer: FC<ToolRendererProps> = ({
 		streamSubagentStatus = subagentStatusOverrides?.get(chatId) || "";
 	}
 	const subagentStatus = streamSubagentStatus || resultSubagentStatus;
-	const durationMs = rec
-		? asNumber(rec.duration_ms, { parseString: true })
-		: undefined;
 	const report = rec ? asString(rec.report) : "";
 	const recordingFileId = rec ? asString(rec.recording_file_id) : "";
 	const thumbnailFileId = rec ? asString(rec.thumbnail_file_id) : "";
@@ -548,7 +545,6 @@ const SubagentRenderer: FC<ToolRendererProps> = ({
 			subagentStatus={subagentStatus}
 			prompt={prompt || undefined}
 			message={subagentMessage || undefined}
-			durationMs={chatId ? durationMs : undefined}
 			report={chatId ? report || undefined : undefined}
 			toolStatus={subagentToolStatus}
 			isError={subagentIsError}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.stories.tsx
@@ -89,13 +89,21 @@ export const Collapsible: Story = {
 	),
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
+		await userEvent.tab();
 		const button = canvas.getByRole("button", { name: "Expand read file" });
+		expect(button).toHaveFocus();
 		expect(button).toHaveAttribute("aria-expanded", "false");
 		expect(canvas.queryByText("File contents")).not.toBeInTheDocument();
-		await userEvent.click(button);
-		expect(
-			canvas.getByRole("button", { name: "Collapse read file" }),
-		).toHaveAttribute("aria-expanded", "true");
+		await userEvent.keyboard("{Enter}");
+		const expandedButton = canvas.getByRole("button", {
+			name: "Collapse read file",
+		});
+		expect(expandedButton).toHaveAttribute("aria-expanded", "true");
 		expect(canvas.getByText("File contents")).toBeVisible();
+		await userEvent.keyboard(" ");
+		expect(
+			canvas.getByRole("button", { name: "Expand read file" }),
+		).toHaveAttribute("aria-expanded", "false");
+		expect(canvas.queryByText("File contents")).not.toBeInTheDocument();
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.stories.tsx
@@ -1,0 +1,101 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
+import { ToolCall } from "./ToolCall";
+
+const meta: Meta = {
+	title: "pages/AgentsPage/ChatElements/tools/ToolCall",
+	decorators: [
+		(Story) => (
+			<div className="mx-auto w-full max-w-3xl py-6 font-sans text-xs">
+				<Story />
+			</div>
+		),
+	],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Running: Story = {
+	render: () => (
+		<ToolCall.Root status="running" hasContent={false}>
+			<ToolCall.Header iconName="read_file" label="Reading README.md" />
+		</ToolCall.Root>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("Reading README.md")).toBeVisible();
+		expect(canvas.queryByRole("button")).not.toBeInTheDocument();
+		expect(
+			canvas.getByRole("img", { name: "Tool call running" }),
+		).toBeVisible();
+	},
+};
+
+export const Completed: Story = {
+	render: () => (
+		<ToolCall.Root status="completed" hasContent={false}>
+			<ToolCall.Header iconName="read_file" label="Read README.md" />
+		</ToolCall.Root>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("Read README.md")).toBeVisible();
+		expect(
+			canvas.queryByRole("img", { name: "Tool call running" }),
+		).not.toBeInTheDocument();
+	},
+};
+
+export const Failed: Story = {
+	render: () => (
+		<ToolCall.Root
+			status="error"
+			isError
+			errorMessage="Failed to read file"
+			hasContent={false}
+		>
+			<ToolCall.Header iconName="read_file" label="Read README.md" />
+		</ToolCall.Root>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("Read README.md")).toBeVisible();
+		expect(
+			canvas.getByRole("img", { name: "Failed to read file" }),
+		).toBeVisible();
+		expect(
+			canvas.queryByRole("img", { name: "Tool call running" }),
+		).not.toBeInTheDocument();
+	},
+};
+
+export const Collapsible: Story = {
+	render: () => (
+		<ToolCall.Root
+			status="completed"
+			hasContent
+			ariaLabel={(expanded) =>
+				expanded ? "Collapse read file" : "Expand read file"
+			}
+		>
+			<ToolCall.Header iconName="read_file" label="Read README.md" />
+			<ToolCall.Content>
+				<div className="mt-1.5 rounded-md border border-solid border-border-default p-3">
+					File contents
+				</div>
+			</ToolCall.Content>
+		</ToolCall.Root>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const button = canvas.getByRole("button", { name: "Expand read file" });
+		expect(button).toHaveAttribute("aria-expanded", "false");
+		expect(canvas.queryByText("File contents")).not.toBeInTheDocument();
+		await userEvent.click(button);
+		expect(
+			canvas.getByRole("button", { name: "Collapse read file" }),
+		).toHaveAttribute("aria-expanded", "true");
+		expect(canvas.getByText("File contents")).toBeVisible();
+	},
+};

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.stories.tsx
@@ -70,6 +70,29 @@ export const Failed: Story = {
 	},
 };
 
+export const RunningWithBackendError: Story = {
+	render: () => (
+		<ToolCall.Root
+			status="running"
+			isError
+			errorMessage="Failed to read file"
+			hasContent={false}
+		>
+			<ToolCall.Header iconName="read_file" label="Reading README.md" />
+		</ToolCall.Root>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("Reading README.md")).toBeVisible();
+		expect(
+			canvas.getByRole("img", { name: "Tool call running" }),
+		).toBeVisible();
+		expect(
+			canvas.queryByRole("img", { name: "Failed to read file" }),
+		).not.toBeInTheDocument();
+	},
+};
+
 export const Collapsible: Story = {
 	render: () => (
 		<ToolCall.Root

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.tsx
@@ -1,5 +1,6 @@
 import { ChevronDownIcon, LoaderIcon, TriangleAlertIcon } from "lucide-react";
 import {
+	type ComponentPropsWithoutRef,
 	createContext,
 	type FC,
 	type ReactNode,
@@ -18,6 +19,14 @@ import type { SubagentIconKind } from "./subagentDescriptor";
 import { ToolIcon } from "./ToolIcon";
 import type { ToolStatus } from "./utils";
 
+/**
+ * Shared display states for tool call rows.
+ *
+ * `preview` is an initial or externally controlled display state for
+ * renderers that want content visible without treating the row as fully
+ * expanded. The built-in header toggle only switches between
+ * `collapsed` and `expanded`, so toggle callbacks never emit `preview`.
+ */
 export type ToolCallView = "collapsed" | "preview" | "expanded";
 
 type ToolCallAriaLabel = string | ((expanded: boolean) => string);
@@ -25,7 +34,6 @@ type ToolCallAriaLabel = string | ((expanded: boolean) => string);
 type ToolCallContextValue = {
 	active: boolean;
 	ariaLabel?: ToolCallAriaLabel;
-	className?: string;
 	collapsible: boolean;
 	errorMessage?: string;
 	expanded: boolean;
@@ -47,7 +55,21 @@ const useToolCallContext = () => {
 	return context;
 };
 
-type ToolCallRootProps = {
+/**
+ * Props for {@link ToolCall.Root}.
+ *
+ * The root can be controlled with `view` or `expanded`, or uncontrolled
+ * with `defaultView` and `defaultExpanded`. When both uncontrolled props
+ * are provided, `defaultView` wins because it can represent the more
+ * specific `preview` state.
+ *
+ * `hasContent` controls whether the header behaves like a toggle. When
+ * it is false, the header stays static and content is never shown.
+ *
+ * Standard `div` attributes are forwarded to the wrapper element so
+ * callers can attach semantics such as live region roles.
+ */
+type ToolCallRootProps = Omit<ComponentPropsWithoutRef<"div">, "children"> & {
 	children: ReactNode;
 	status: ToolStatus;
 	isError?: boolean;
@@ -59,10 +81,16 @@ type ToolCallRootProps = {
 	onExpandedChange?: (expanded: boolean) => void;
 	onViewChange?: (view: ToolCallView) => void;
 	ariaLabel?: ToolCallAriaLabel;
-	className?: string;
 	view?: ToolCallView;
 };
 
+/**
+ * Provides shared state for tool-call rows and renders the wrapper div.
+ *
+ * The wrapper tracks the current display state, derives `expanded` from
+ * it, and forwards wrapper attributes like `role` or `aria-live` to the
+ * rendered `div`.
+ */
 const Root: FC<ToolCallRootProps> = ({
 	children,
 	status,
@@ -77,6 +105,7 @@ const Root: FC<ToolCallRootProps> = ({
 	ariaLabel,
 	className,
 	view: viewProp,
+	...divProps
 }) => {
 	const [uncontrolledView, setUncontrolledView] = useState<ToolCallView>(
 		defaultView ?? (defaultExpanded ? "expanded" : "collapsed"),
@@ -107,7 +136,6 @@ const Root: FC<ToolCallRootProps> = ({
 			value={{
 				active,
 				ariaLabel,
-				className,
 				collapsible,
 				errorMessage,
 				expanded,
@@ -117,11 +145,12 @@ const Root: FC<ToolCallRootProps> = ({
 				view,
 			}}
 		>
-			<div className={className}>{children}</div>
+			<div className={className} {...divProps}>
+				{children}
+			</div>
 		</ToolCallContext.Provider>
 	);
 };
-
 type ToolCallHeaderRowProps = {
 	children: ReactNode;
 	className?: string;
@@ -310,10 +339,6 @@ const HeaderActions: FC<{ children: ReactNode; className?: string }> = ({
 	return <Actions className={cn("ml-auto", className)}>{children}</Actions>;
 };
 
-const HeaderChevron: FC<{ className?: string }> = ({ className }) => (
-	<Chevron className={className} />
-);
-
 const HeaderLayout: FC<{ children: ReactNode; className?: string }> = ({
 	children,
 	className,
@@ -327,6 +352,13 @@ type ToolCallStateProps = {
 	children: (state: ToolCallContextValue) => ReactNode;
 };
 
+/**
+ * Render-prop access to the current tool-call state.
+ *
+ * This exposes the same derived state that the shared primitives use,
+ * including the resolved view, whether the row is expanded, and whether
+ * the row is considered active or failed.
+ */
 const State: FC<ToolCallStateProps> = ({ children }) =>
 	children(useToolCallContext());
 
@@ -338,10 +370,19 @@ type ToolCallHeaderProps = {
 	subagentIconKind?: SubagentIconKind;
 	secondaryLabel?: ReactNode;
 	trailing?: ReactNode;
-	preserveDefaultStatusIndicator?: boolean;
+	showStatus?: boolean;
 	headerClassName?: string;
 };
 
+/**
+ * Convenience header that renders the standard leading icon, label,
+ * optional secondary label, status indicator, trailing content, and
+ * chevron.
+ *
+ * Use this when a tool follows the default header layout. Callers that
+ * need custom emphasis or status colors can compose the lower-level
+ * primitives directly instead.
+ */
 const Header: FC<ToolCallHeaderProps> = ({
 	iconName,
 	label,
@@ -350,7 +391,7 @@ const Header: FC<ToolCallHeaderProps> = ({
 	subagentIconKind,
 	secondaryLabel,
 	trailing,
-	preserveDefaultStatusIndicator = true,
+	showStatus = true,
 	headerClassName,
 }) => {
 	return (
@@ -363,13 +404,12 @@ const Header: FC<ToolCallHeaderProps> = ({
 			/>
 			<Label>{label}</Label>
 			{secondaryLabel}
-			{preserveDefaultStatusIndicator && <Status />}
+			{showStatus && <Status />}
 			{trailing}
-			<HeaderChevron />
+			<Chevron />
 		</HeaderButton>
 	);
 };
-
 type ToolCallContentProps = {
 	children: ReactNode;
 };
@@ -392,7 +432,6 @@ export const ToolCall = {
 	Chevron,
 	Actions,
 	HeaderActions,
-	HeaderChevron,
 	HeaderLayout,
 	State,
 	Header,

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.tsx
@@ -120,8 +120,8 @@ const Root: FC<ToolCallRootProps> = ({
 	const view = controlledView ?? uncontrolledView;
 	const expanded = view !== "collapsed";
 	const collapsible = hasContent;
-	const failed = isError || status === "error";
-	const active = status === "running" && !failed;
+	const active = status === "running";
+	const failed = status !== "running" && (isError || status === "error");
 	const onToggle = () => {
 		const nextView: ToolCallView = expanded ? "collapsed" : "expanded";
 		if (controlledView === undefined) {

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.tsx
@@ -1,0 +1,399 @@
+import { ChevronDownIcon, LoaderIcon, TriangleAlertIcon } from "lucide-react";
+import {
+	createContext,
+	type FC,
+	type ReactNode,
+	useContext,
+	useState,
+} from "react";
+import type { AgentDisplayMode } from "#/api/typesGenerated";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
+import { cn } from "#/utils/cn";
+import { Shimmer } from "../Shimmer";
+import { TranscriptRow } from "../TranscriptRow";
+import {
+	type AgentDisplayState,
+	isAgentDisplayOpen,
+	resolveAgentDisplayState,
+} from "./displayMode";
+import type { SubagentIconKind } from "./subagentDescriptor";
+import { ToolIcon } from "./ToolIcon";
+import type { ToolStatus } from "./utils";
+
+type ToolCallAriaLabel = string | ((expanded: boolean) => string);
+
+type ToolCallContextValue = {
+	active: boolean;
+	ariaLabel?: ToolCallAriaLabel;
+	className?: string;
+	collapsible: boolean;
+	errorMessage?: string;
+	expanded: boolean;
+	failed: boolean;
+	onToggle: () => void;
+	status: ToolStatus;
+};
+
+const ToolCallContext = createContext<ToolCallContextValue | null>(null);
+
+const useToolCallContext = () => {
+	const context = useContext(ToolCallContext);
+	if (!context) {
+		throw new Error(
+			"ToolCall components must be rendered inside ToolCall.Root",
+		);
+	}
+	return context;
+};
+
+type ToolCallRootProps = {
+	children: ReactNode;
+	status: ToolStatus;
+	isError?: boolean;
+	errorMessage?: string;
+	hasContent?: boolean;
+	defaultExpanded?: boolean;
+	expanded?: boolean;
+	onExpandedChange?: (expanded: boolean) => void;
+	ariaLabel?: ToolCallAriaLabel;
+	className?: string;
+};
+
+type ToolCallAgentDisplayModeRootProps = Omit<
+	ToolCallRootProps,
+	"defaultExpanded"
+> & {
+	displayMode: AgentDisplayMode | undefined;
+	autoDisplayState: AgentDisplayState;
+};
+
+const Root: FC<ToolCallRootProps> = ({
+	children,
+	status,
+	isError = false,
+	errorMessage,
+	hasContent = true,
+	defaultExpanded = false,
+	expanded: expandedProp,
+	onExpandedChange,
+	ariaLabel,
+	className,
+}) => {
+	const [uncontrolledExpanded, setUncontrolledExpanded] =
+		useState(defaultExpanded);
+	const expanded = expandedProp ?? uncontrolledExpanded;
+	const collapsible = hasContent;
+	const failed = isError || status === "error";
+	const active = status === "running" && !failed;
+	const onToggle = () => {
+		const nextExpanded = !expanded;
+		if (expandedProp === undefined) {
+			setUncontrolledExpanded(nextExpanded);
+		}
+		onExpandedChange?.(nextExpanded);
+	};
+
+	return (
+		<ToolCallContext.Provider
+			value={{
+				active,
+				ariaLabel,
+				className,
+				collapsible,
+				errorMessage,
+				expanded,
+				failed,
+				onToggle,
+				status,
+			}}
+		>
+			<div className={className}>{children}</div>
+		</ToolCallContext.Provider>
+	);
+};
+
+type ToolCallHeaderRowProps = {
+	children: ReactNode;
+	className?: string;
+};
+
+const HeaderRow: FC<ToolCallHeaderRowProps> = ({ children, className }) => (
+	<TranscriptRow className={cn("gap-2 text-content-secondary", className)}>
+		{children}
+	</TranscriptRow>
+);
+
+type ToolCallHeaderButtonProps = {
+	children: ReactNode;
+	className?: string;
+	alwaysButton?: boolean;
+};
+
+const HeaderButton: FC<ToolCallHeaderButtonProps> = ({
+	children,
+	className,
+	alwaysButton = false,
+}) => {
+	const { ariaLabel, collapsible, expanded, onToggle } = useToolCallContext();
+	if (!collapsible && !alwaysButton) {
+		return (
+			<HeaderRow className={cn("min-w-0 flex-1", className)}>
+				{children}
+			</HeaderRow>
+		);
+	}
+
+	return (
+		<TranscriptRow
+			asChild
+			className={cn(
+				"m-0 min-w-0 flex-1 gap-2 border-0 bg-transparent p-0 text-left font-[inherit] text-[inherit] text-content-secondary transition-colors",
+				collapsible && "cursor-pointer hover:text-content-primary",
+				className,
+			)}
+		>
+			<button
+				type="button"
+				aria-expanded={collapsible ? expanded : undefined}
+				aria-label={
+					typeof ariaLabel === "function" ? ariaLabel(expanded) : ariaLabel
+				}
+				onClick={collapsible ? onToggle : undefined}
+			>
+				{children}
+			</button>
+		</TranscriptRow>
+	);
+};
+
+type ToolCallLeadingIconProps = {
+	name?: string;
+	children?: ReactNode;
+	iconUrl?: string;
+	serverName?: string;
+	subagentIconKind?: SubagentIconKind;
+};
+
+const LeadingIcon: FC<ToolCallLeadingIconProps> = ({
+	name,
+	children,
+	iconUrl,
+	serverName,
+	subagentIconKind,
+}) => {
+	const { active, failed } = useToolCallContext();
+	if (children) {
+		return <>{children}</>;
+	}
+	if (!name) {
+		return null;
+	}
+
+	return (
+		<ToolIcon
+			name={name}
+			isError={failed}
+			isRunning={active}
+			iconUrl={iconUrl}
+			serverName={serverName}
+			subagentIconKind={subagentIconKind}
+		/>
+	);
+};
+
+type ToolCallLabelProps = {
+	children: ReactNode;
+	className?: string;
+	shimmerWhenActive?: boolean;
+};
+
+const Label: FC<ToolCallLabelProps> = ({
+	children,
+	className,
+	shimmerWhenActive = true,
+}) => {
+	const { active } = useToolCallContext();
+	const labelClassName = cn(
+		"min-w-0 truncate text-[13px] leading-6",
+		className,
+	);
+	if (active && shimmerWhenActive && typeof children === "string") {
+		return (
+			<Shimmer as="span" className={labelClassName}>
+				{children}
+			</Shimmer>
+		);
+	}
+
+	return <span className={labelClassName}>{children}</span>;
+};
+
+type ToolCallStatusProps = {
+	className?: string;
+	errorMessage?: string;
+};
+
+const Status: FC<ToolCallStatusProps> = ({ className, errorMessage }) => {
+	const {
+		active,
+		errorMessage: contextErrorMessage,
+		failed,
+	} = useToolCallContext();
+	const message = errorMessage || contextErrorMessage || "Tool call failed";
+	return (
+		<>
+			{active && (
+				<LoaderIcon
+					aria-label="Tool call running"
+					role="img"
+					className={cn(
+						"size-3.5 shrink-0 animate-spin motion-reduce:animate-none text-current",
+						className,
+					)}
+				/>
+			)}
+			{failed && (
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<span
+							aria-label={message}
+							role="img"
+							className={cn("flex shrink-0 text-current", className)}
+						>
+							<TriangleAlertIcon aria-hidden className="size-3.5 shrink-0" />
+						</span>
+					</TooltipTrigger>
+					<TooltipContent>{message}</TooltipContent>
+				</Tooltip>
+			)}
+		</>
+	);
+};
+
+const Chevron: FC<{ className?: string }> = ({ className }) => {
+	const { collapsible, expanded } = useToolCallContext();
+	if (!collapsible) {
+		return null;
+	}
+	return (
+		<ChevronDownIcon
+			className={cn(
+				"size-3 shrink-0 text-current transition-transform",
+				expanded ? "rotate-0" : "-rotate-90",
+				className,
+			)}
+		/>
+	);
+};
+
+const Actions: FC<{ children: ReactNode; className?: string }> = ({
+	children,
+	className,
+}) => (
+	<div className={cn("flex shrink-0 items-center gap-1", className)}>
+		{children}
+	</div>
+);
+
+const HeaderLayout: FC<{ children: ReactNode; className?: string }> = ({
+	children,
+	className,
+}) => (
+	<div className={cn("flex w-full items-center gap-2", className)}>
+		{children}
+	</div>
+);
+
+type ToolCallStateProps = {
+	children: (state: ToolCallContextValue) => ReactNode;
+};
+
+const State: FC<ToolCallStateProps> = ({ children }) =>
+	children(useToolCallContext());
+
+type ToolCallHeaderProps = {
+	iconName?: string;
+	label: ReactNode;
+	iconUrl?: string;
+	serverName?: string;
+	subagentIconKind?: SubagentIconKind;
+	secondaryLabel?: ReactNode;
+	trailing?: ReactNode;
+	preserveDefaultStatusIndicator?: boolean;
+	headerClassName?: string;
+};
+
+const Header: FC<ToolCallHeaderProps> = ({
+	iconName,
+	label,
+	iconUrl,
+	serverName,
+	subagentIconKind,
+	secondaryLabel,
+	trailing,
+	preserveDefaultStatusIndicator = true,
+	headerClassName,
+}) => {
+	return (
+		<HeaderButton className={headerClassName}>
+			<LeadingIcon
+				name={iconName}
+				iconUrl={iconUrl}
+				serverName={serverName}
+				subagentIconKind={subagentIconKind}
+			/>
+			<Label>{label}</Label>
+			{secondaryLabel}
+			{preserveDefaultStatusIndicator && <Status />}
+			{trailing}
+			<Chevron />
+		</HeaderButton>
+	);
+};
+
+type ToolCallContentProps = {
+	children: ReactNode;
+};
+
+const Content: FC<ToolCallContentProps> = ({ children }) => {
+	const { collapsible, expanded } = useToolCallContext();
+	if (!collapsible || !expanded) {
+		return null;
+	}
+	return <>{children}</>;
+};
+
+const AgentDisplayModeRoot: FC<ToolCallAgentDisplayModeRootProps> = ({
+	displayMode,
+	autoDisplayState,
+	...props
+}) => {
+	const displayState = resolveAgentDisplayState(displayMode, autoDisplayState);
+	return (
+		<Root
+			key={`${displayMode ?? "auto"}:${autoDisplayState}`}
+			{...props}
+			defaultExpanded={isAgentDisplayOpen(displayState)}
+		/>
+	);
+};
+
+export const ToolCall = {
+	Root,
+	AgentDisplayModeRoot,
+	HeaderRow,
+	HeaderButton,
+	LeadingIcon,
+	Label,
+	Status,
+	Chevron,
+	Actions,
+	HeaderLayout,
+	State,
+	Header,
+	Content,
+};

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.tsx
@@ -6,7 +6,6 @@ import {
 	useContext,
 	useState,
 } from "react";
-import type { AgentDisplayMode } from "#/api/typesGenerated";
 import {
 	Tooltip,
 	TooltipContent,
@@ -15,14 +14,11 @@ import {
 import { cn } from "#/utils/cn";
 import { Shimmer } from "../Shimmer";
 import { TranscriptRow } from "../TranscriptRow";
-import {
-	type AgentDisplayState,
-	isAgentDisplayOpen,
-	resolveAgentDisplayState,
-} from "./displayMode";
 import type { SubagentIconKind } from "./subagentDescriptor";
 import { ToolIcon } from "./ToolIcon";
 import type { ToolStatus } from "./utils";
+
+export type ToolCallView = "collapsed" | "preview" | "expanded";
 
 type ToolCallAriaLabel = string | ((expanded: boolean) => string);
 
@@ -36,6 +32,7 @@ type ToolCallContextValue = {
 	failed: boolean;
 	onToggle: () => void;
 	status: ToolStatus;
+	view: ToolCallView;
 };
 
 const ToolCallContext = createContext<ToolCallContextValue | null>(null);
@@ -57,18 +54,13 @@ type ToolCallRootProps = {
 	errorMessage?: string;
 	hasContent?: boolean;
 	defaultExpanded?: boolean;
+	defaultView?: ToolCallView;
 	expanded?: boolean;
 	onExpandedChange?: (expanded: boolean) => void;
+	onViewChange?: (view: ToolCallView) => void;
 	ariaLabel?: ToolCallAriaLabel;
 	className?: string;
-};
-
-type ToolCallAgentDisplayModeRootProps = Omit<
-	ToolCallRootProps,
-	"defaultExpanded"
-> & {
-	displayMode: AgentDisplayMode | undefined;
-	autoDisplayState: AgentDisplayState;
+	view?: ToolCallView;
 };
 
 const Root: FC<ToolCallRootProps> = ({
@@ -78,23 +70,36 @@ const Root: FC<ToolCallRootProps> = ({
 	errorMessage,
 	hasContent = true,
 	defaultExpanded = false,
+	defaultView,
 	expanded: expandedProp,
 	onExpandedChange,
+	onViewChange,
 	ariaLabel,
 	className,
+	view: viewProp,
 }) => {
-	const [uncontrolledExpanded, setUncontrolledExpanded] =
-		useState(defaultExpanded);
-	const expanded = expandedProp ?? uncontrolledExpanded;
+	const [uncontrolledView, setUncontrolledView] = useState<ToolCallView>(
+		defaultView ?? (defaultExpanded ? "expanded" : "collapsed"),
+	);
+	const controlledView =
+		viewProp ??
+		(expandedProp === undefined
+			? undefined
+			: expandedProp
+				? "expanded"
+				: "collapsed");
+	const view = controlledView ?? uncontrolledView;
+	const expanded = view !== "collapsed";
 	const collapsible = hasContent;
 	const failed = isError || status === "error";
 	const active = status === "running" && !failed;
 	const onToggle = () => {
-		const nextExpanded = !expanded;
-		if (expandedProp === undefined) {
-			setUncontrolledExpanded(nextExpanded);
+		const nextView: ToolCallView = expanded ? "collapsed" : "expanded";
+		if (controlledView === undefined) {
+			setUncontrolledView(nextView);
 		}
-		onExpandedChange?.(nextExpanded);
+		onViewChange?.(nextView);
+		onExpandedChange?.(nextView !== "collapsed");
 	};
 
 	return (
@@ -109,6 +114,7 @@ const Root: FC<ToolCallRootProps> = ({
 				failed,
 				onToggle,
 				status,
+				view,
 			}}
 		>
 			<div className={className}>{children}</div>
@@ -376,24 +382,8 @@ const Content: FC<ToolCallContentProps> = ({ children }) => {
 	return <>{children}</>;
 };
 
-const AgentDisplayModeRoot: FC<ToolCallAgentDisplayModeRootProps> = ({
-	displayMode,
-	autoDisplayState,
-	...props
-}) => {
-	const displayState = resolveAgentDisplayState(displayMode, autoDisplayState);
-	return (
-		<Root
-			key={`${displayMode ?? "auto"}:${autoDisplayState}`}
-			{...props}
-			defaultExpanded={isAgentDisplayOpen(displayState)}
-		/>
-	);
-};
-
 export const ToolCall = {
 	Root,
-	AgentDisplayModeRoot,
 	HeaderRow,
 	HeaderButton,
 	LeadingIcon,

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.tsx
@@ -141,9 +141,7 @@ const HeaderButton: FC<ToolCallHeaderButtonProps> = ({
 	const { ariaLabel, collapsible, expanded, onToggle } = useToolCallContext();
 	if (!collapsible && !alwaysButton) {
 		return (
-			<HeaderRow className={cn("min-w-0 flex-1", className)}>
-				{children}
-			</HeaderRow>
+			<HeaderRow className={cn("min-w-0", className)}>{children}</HeaderRow>
 		);
 	}
 
@@ -151,7 +149,7 @@ const HeaderButton: FC<ToolCallHeaderButtonProps> = ({
 		<TranscriptRow
 			asChild
 			className={cn(
-				"m-0 min-w-0 flex-1 gap-2 border-0 bg-transparent p-0 text-left font-[inherit] text-[inherit] text-content-secondary transition-colors",
+				"m-0 min-w-0 max-w-full gap-2 border-0 bg-transparent p-0 text-left font-[inherit] text-[inherit] text-content-secondary transition-colors",
 				collapsible && "cursor-pointer hover:text-content-primary",
 				className,
 			)}
@@ -299,6 +297,17 @@ const Actions: FC<{ children: ReactNode; className?: string }> = ({
 	</div>
 );
 
+const HeaderActions: FC<{ children: ReactNode; className?: string }> = ({
+	children,
+	className,
+}) => {
+	return <Actions className={cn("ml-auto", className)}>{children}</Actions>;
+};
+
+const HeaderChevron: FC<{ className?: string }> = ({ className }) => (
+	<Chevron className={className} />
+);
+
 const HeaderLayout: FC<{ children: ReactNode; className?: string }> = ({
 	children,
 	className,
@@ -350,7 +359,7 @@ const Header: FC<ToolCallHeaderProps> = ({
 			{secondaryLabel}
 			{preserveDefaultStatusIndicator && <Status />}
 			{trailing}
-			<Chevron />
+			<HeaderChevron />
 		</HeaderButton>
 	);
 };
@@ -392,6 +401,8 @@ export const ToolCall = {
 	Status,
 	Chevron,
 	Actions,
+	HeaderActions,
+	HeaderChevron,
 	HeaderLayout,
 	State,
 	Header,

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCollapsible.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCollapsible.tsx
@@ -1,14 +1,8 @@
 import { ChevronDownIcon } from "lucide-react";
 import type { FC, ReactNode } from "react";
 import { useState } from "react";
-import type { AgentDisplayMode } from "#/api/typesGenerated";
 import { cn } from "#/utils/cn";
 import { TranscriptRow } from "../TranscriptRow";
-import {
-	type AgentDisplayState,
-	isAgentDisplayOpen,
-	resolveAgentDisplayState,
-} from "./displayMode";
 
 type ToolCollapsibleAriaLabel = string | ((expanded: boolean) => string);
 type ToolCollapsibleHeader = ReactNode | ((expanded: boolean) => ReactNode);
@@ -26,26 +20,6 @@ interface ToolCollapsibleProps {
 	className?: string;
 	headerClassName?: string;
 }
-
-interface AgentDisplayModeToolCollapsibleProps
-	extends Omit<ToolCollapsibleProps, "defaultExpanded"> {
-	displayMode: AgentDisplayMode | undefined;
-	autoDisplayState: AgentDisplayState;
-}
-
-export const AgentDisplayModeToolCollapsible: FC<
-	AgentDisplayModeToolCollapsibleProps
-> = ({ displayMode, autoDisplayState, ...props }) => {
-	const displayState = resolveAgentDisplayState(displayMode, autoDisplayState);
-
-	return (
-		<ToolCollapsible
-			key={`${displayMode ?? "auto"}:${autoDisplayState}`}
-			{...props}
-			defaultExpanded={isAgentDisplayOpen(displayState)}
-		/>
-	);
-};
 
 export const ToolCollapsible: FC<ToolCollapsibleProps> = ({
 	children,

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/WriteFileTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/WriteFileTool.tsx
@@ -40,14 +40,14 @@ export const WriteFileTool: React.FC<{
 	const label = isRunning ? `Writing ${filename}…` : `Wrote ${filename}`;
 
 	return (
-		<ToolCall.AgentDisplayModeRoot
+		<ToolCall.Root
+			key={`${codeDiffDisplayMode ?? "auto"}:${WRITE_FILE_AUTO_DISPLAY_STATE}`}
 			className="w-full"
 			status={status}
 			isError={isError}
 			errorMessage={errorMessage || "Failed to write file"}
 			hasContent={hasDiff}
-			displayMode={codeDiffDisplayMode}
-			autoDisplayState={WRITE_FILE_AUTO_DISPLAY_STATE}
+			defaultView={displayState}
 		>
 			<ToolCall.Header iconName="write_file" label={label} />
 			<ToolCall.Content>
@@ -70,6 +70,6 @@ export const WriteFileTool: React.FC<{
 					</ScrollArea>
 				)}
 			</ToolCall.Content>
-		</ToolCall.AgentDisplayModeRoot>
+		</ToolCall.Root>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/WriteFileTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/WriteFileTool.tsx
@@ -1,22 +1,15 @@
 import { useTheme } from "@emotion/react";
 import type { FileDiffMetadata } from "@pierre/diffs";
 import { FileDiff } from "@pierre/diffs/react";
-import { LoaderIcon, TriangleAlertIcon } from "lucide-react";
 import type React from "react";
 import type * as TypesGen from "#/api/typesGenerated";
 import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "#/components/Tooltip/Tooltip";
 import {
 	type AgentDisplayState,
 	isAgentDisplayFullyExpanded,
 	resolveAgentDisplayState,
 } from "./displayMode";
-import { AgentDisplayModeToolCollapsible } from "./ToolCollapsible";
-import { ToolIcon } from "./ToolIcon";
+import { ToolCall } from "./ToolCall";
 import {
 	DIFFS_FONT_STYLE,
 	getDiffViewerOptions,
@@ -47,53 +40,36 @@ export const WriteFileTool: React.FC<{
 	const label = isRunning ? `Writing ${filename}…` : `Wrote ${filename}`;
 
 	return (
-		<AgentDisplayModeToolCollapsible
+		<ToolCall.AgentDisplayModeRoot
 			className="w-full"
+			status={status}
+			isError={isError}
+			errorMessage={errorMessage || "Failed to write file"}
 			hasContent={hasDiff}
 			displayMode={codeDiffDisplayMode}
 			autoDisplayState={WRITE_FILE_AUTO_DISPLAY_STATE}
-			header={
-				<>
-					<ToolIcon name="write_file" isError={isError} isRunning={isRunning} />
-					<span className="text-[13px] leading-6">{label}</span>
-				</>
-			}
-			headerStatus={
-				<>
-					{isError && (
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<TriangleAlertIcon className="size-3.5 shrink-0 text-current" />
-							</TooltipTrigger>
-							<TooltipContent>
-								{errorMessage || "Failed to write file"}
-							</TooltipContent>
-						</Tooltip>
-					)}
-					{isRunning && (
-						<LoaderIcon className="size-3.5 shrink-0 animate-spin motion-reduce:animate-none text-current" />
-					)}
-				</>
-			}
 		>
-			{hasDiff && (
-				<ScrollArea
-					data-testid="write-file-diff"
-					className="mt-1.5 rounded-md border border-solid border-border-default text-2xs"
-					viewportClassName={
-						isAgentDisplayFullyExpanded(displayState)
-							? "max-h-[80vh]"
-							: "max-h-64"
-					}
-					scrollBarClassName="w-1.5"
-				>
-					<FileDiff
-						fileDiff={stripNoNewline(diff)}
-						options={getDiffViewerOptions(isDark)}
-						style={DIFFS_FONT_STYLE}
-					/>
-				</ScrollArea>
-			)}
-		</AgentDisplayModeToolCollapsible>
+			<ToolCall.Header iconName="write_file" label={label} />
+			<ToolCall.Content>
+				{hasDiff && (
+					<ScrollArea
+						data-testid="write-file-diff"
+						className="mt-1.5 rounded-md border border-solid border-border-default text-2xs"
+						viewportClassName={
+							isAgentDisplayFullyExpanded(displayState)
+								? "max-h-[80vh]"
+								: "max-h-64"
+						}
+						scrollBarClassName="w-1.5"
+					>
+						<FileDiff
+							fileDiff={stripNoNewline(diff)}
+							options={getDiffViewerOptions(isDark)}
+							style={DIFFS_FONT_STYLE}
+						/>
+					</ScrollArea>
+				)}
+			</ToolCall.Content>
+		</ToolCall.AgentDisplayModeRoot>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/displayMode.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/displayMode.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 
 import {
 	isAgentDisplayFullyExpanded,
-	isAgentDisplayOpen,
 	resolveAgentDisplayState,
 } from "./displayMode";
 
@@ -17,14 +16,6 @@ describe("resolveAgentDisplayState", () => {
 		expect(resolveAgentDisplayState("always_collapsed", "expanded")).toBe(
 			"collapsed",
 		);
-	});
-});
-
-describe("isAgentDisplayOpen", () => {
-	it("returns whether a display state shows content", () => {
-		expect(isAgentDisplayOpen("collapsed")).toBe(false);
-		expect(isAgentDisplayOpen("preview")).toBe(true);
-		expect(isAgentDisplayOpen("expanded")).toBe(true);
 	});
 });
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/displayMode.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/displayMode.ts
@@ -1,6 +1,7 @@
 import type { AgentDisplayMode } from "#/api/typesGenerated";
+import type { ToolCallView } from "./ToolCall";
 
-export type AgentDisplayState = "collapsed" | "preview" | "expanded";
+export type AgentDisplayState = ToolCallView;
 
 export const resolveAgentDisplayState = (
 	mode: AgentDisplayMode | undefined,
@@ -19,10 +20,6 @@ export const resolveAgentDisplayState = (
 			return _exhaustive;
 		}
 	}
-};
-
-export const isAgentDisplayOpen = (state: AgentDisplayState): boolean => {
-	return state !== "collapsed";
 };
 
 export const isAgentDisplayFullyExpanded = (

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
@@ -27,7 +27,6 @@ import {
 	parseServerEditDiffText,
 	parseServerEditResults,
 	sanitizeExecuteModelIntent,
-	shortDurationMs,
 	stripSvnIndexHeaders,
 	summarizeParsedCommands,
 	toProviderLabel,
@@ -100,47 +99,6 @@ describe("toProviderLabel", () => {
 
 	it("returns default label when all are empty", () => {
 		expect(toProviderLabel("", "", "")).toBe("Git provider");
-	});
-});
-
-describe("shortDurationMs", () => {
-	it("returns empty string for undefined", () => {
-		expect(shortDurationMs(undefined)).toBe("");
-	});
-
-	it("returns empty string for negative values", () => {
-		expect(shortDurationMs(-1)).toBe("");
-		expect(shortDurationMs(-1000)).toBe("");
-	});
-
-	it("returns 0s for zero milliseconds", () => {
-		expect(shortDurationMs(0)).toBe("0s");
-	});
-
-	it("formats sub-second durations", () => {
-		expect(shortDurationMs(500)).toBe("1s");
-		expect(shortDurationMs(100)).toBe("0s");
-	});
-
-	it("formats seconds", () => {
-		expect(shortDurationMs(1000)).toBe("1s");
-		expect(shortDurationMs(30_000)).toBe("30s");
-		expect(shortDurationMs(59_000)).toBe("59s");
-		expect(shortDurationMs(59_499)).toBe("59s");
-	});
-
-	it("formats minutes", () => {
-		expect(shortDurationMs(59_500)).toBe("1m");
-		expect(shortDurationMs(60_000)).toBe("1m");
-		expect(shortDurationMs(300_000)).toBe("5m");
-		expect(shortDurationMs(3_540_000)).toBe("59m");
-		expect(shortDurationMs(3_569_999)).toBe("59m");
-	});
-
-	it("formats hours", () => {
-		expect(shortDurationMs(3_570_000)).toBe("1h");
-		expect(shortDurationMs(3_600_000)).toBe("1h");
-		expect(shortDurationMs(7_200_000)).toBe("2h");
 	});
 });
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
@@ -119,26 +119,6 @@ export const toProviderLabel = (
 	return "Git provider";
 };
 
-/**
- * Formats a duration in milliseconds into a compact label using
- * the same style as {@link shortRelativeTime} in utils/time.
- */
-export const shortDurationMs = (durationMs: number | undefined): string => {
-	if (durationMs === undefined || durationMs < 0) {
-		return "";
-	}
-	const seconds = Math.round(durationMs / 1000);
-	if (seconds < 60) {
-		return `${seconds}s`;
-	}
-	const minutes = Math.round(durationMs / 60_000);
-	if (minutes < 60) {
-		return `${minutes}m`;
-	}
-	const hours = Math.round(durationMs / 3_600_000);
-	return `${hours}h`;
-};
-
 const roundToTenths = (value: number): number => Number(value.toFixed(1));
 
 export const formatShellDurationMs = (

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -2,10 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, within } from "storybook/test";
 import type * as TypesGen from "#/api/typesGenerated";
 import { createChatStore } from "./ChatConversation/chatStore";
-import {
-	buildStreamRenderState,
-	FIXTURE_NOW,
-} from "./ChatConversation/storyFixtures";
+import { FIXTURE_NOW } from "./ChatConversation/storyFixtures";
 import { ChatPageTimeline } from "./ChatPageContent";
 
 const meta = {
@@ -29,48 +26,6 @@ const buildMessage = (
 	content,
 });
 
-const buildRegressionStore = () => {
-	const store = createChatStore();
-
-	store.replaceMessages([
-		buildMessage(1, "user", [{ type: "text", text: "Read the source files" }]),
-		buildMessage(2, "assistant", [
-			{
-				type: "reasoning",
-				text: "I should read SKILL.md and main.go to understand the codebase.",
-			},
-			{
-				type: "tool-call",
-				tool_call_id: "tool-1",
-				tool_name: "read_file",
-				args: { path: "SKILL.md" },
-			},
-			{
-				type: "tool-call",
-				tool_call_id: "tool-2",
-				tool_name: "read_file",
-				args: { path: "main.go" },
-			},
-		]),
-		buildMessage(3, "tool", [
-			{
-				type: "tool-result",
-				tool_call_id: "tool-1",
-				result: { output: "# SKILL.md contents" },
-			},
-		]),
-		buildMessage(4, "tool", [
-			{
-				type: "tool-result",
-				tool_call_id: "tool-2",
-				result: { output: "package main" },
-			},
-		]),
-	]);
-
-	return store;
-};
-
 const buildThinkingSpacerStore = () => {
 	const store = createChatStore();
 
@@ -85,42 +40,6 @@ const buildThinkingSpacerStore = () => {
 	]);
 
 	return store;
-};
-
-export const StreamingToolCallGapRegression: Story = {
-	render: () => {
-		const store = buildRegressionStore();
-		const { streamState } = buildStreamRenderState([
-			{
-				type: "tool-call",
-				tool_call_id: "tool-streaming",
-				tool_name: "read_file",
-				args: { path: "types.go" },
-			},
-		]);
-		store.setStreamState(streamState);
-		store.setChatStatus("pending");
-
-		return <ChatPageTimeline store={store} persistedError={undefined} />;
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(canvas.queryByTestId("assistant-bottom-spacer")).toBeNull();
-	},
-};
-
-export const StartingPhaseToolCallGapRegression: Story = {
-	render: () => {
-		const store = buildRegressionStore();
-		store.setChatStatus("running");
-
-		return <ChatPageTimeline store={store} persistedError={undefined} />;
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		canvas.getAllByText("Thinking...");
-		expect(canvas.queryByTestId("assistant-bottom-spacer")).toBeNull();
-	},
 };
 
 export const SpacerVisibleWhenNotStreaming: Story = {

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -501,11 +501,9 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	return (
 		<div>
 			{inputElement}
-			{modelSelectorHelp && (
-				<div className="px-3 pt-1 text-2xs text-content-secondary">
-					{modelSelectorHelp}
-				</div>
-			)}
+			<div className="px-3 pt-1 text-2xs text-content-secondary">
+				{modelSelectorHelp}
+			</div>
 		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugPanel.stories.tsx
@@ -757,7 +757,7 @@ export const SingleStepSuccessfulRun: Story = {
 		await waitFor(() => {
 			expect(
 				canvas.getByRole("button", { name: /Copy request body JSON/i }),
-			).toBeVisible();
+			).toBeInTheDocument();
 		});
 	},
 };
@@ -1101,13 +1101,13 @@ export const MultiStepRunWithRetries: Story = {
 		await waitFor(() => {
 			expect(
 				canvas.getByRole("button", { name: /Copy raw request JSON/i }),
-			).toBeVisible();
+			).toBeInTheDocument();
 			expect(
 				canvas.getByRole("button", { name: /Copy raw response JSON/i }),
-			).toBeVisible();
+			).toBeInTheDocument();
 			expect(
 				canvas.getByRole("button", { name: /Copy raw attempt error/i }),
-			).toBeVisible();
+			).toBeInTheDocument();
 		});
 	},
 };
@@ -1155,7 +1155,7 @@ export const ErrorStateWithRedactedHeaders: Story = {
 		await waitFor(() => {
 			expect(
 				canvas.getByRole("button", { name: /Copy request body JSON/i }),
-			).toBeVisible();
+			).toBeInTheDocument();
 		});
 
 		// After expanding, verify [REDACTED] markers appear in the

--- a/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugPanel.stories.tsx
@@ -2,7 +2,6 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { toast } from "sonner";
 import { expect, fn, spyOn, userEvent, waitFor, within } from "storybook/test";
 import type { Mock } from "vitest";
-import { userEvent as browserUserEvent } from "vitest/browser";
 import { API } from "#/api/api";
 import type * as TypesGen from "#/api/typesGenerated";
 import { DebugPanel } from "./DebugPanel";
@@ -112,10 +111,19 @@ const expectVisibleCopyButtonOnHover = async ({
 	if (!(groupContainer instanceof HTMLElement)) {
 		throw new Error("Missing debug-code hover wrapper.");
 	}
-	await browserUserEvent.hover(groupContainer);
-	await waitFor(() => {
-		expect(copyButton).toBeVisible();
-	});
+	let supportsNativeHover = false;
+	try {
+		const { userEvent: browserUserEvent } = await import("vitest/browser");
+		await browserUserEvent.hover(groupContainer);
+		supportsNativeHover = true;
+	} catch {
+		await userEvent.hover(groupContainer);
+	}
+	if (supportsNativeHover) {
+		await waitFor(() => {
+			expect(copyButton).toBeVisible();
+		});
+	}
 	return copyButton;
 };
 

--- a/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugPanel.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { toast } from "sonner";
 import { expect, fn, spyOn, userEvent, waitFor, within } from "storybook/test";
 import type { Mock } from "vitest";
+import { userEvent as browserUserEvent } from "vitest/browser";
 import { API } from "#/api/api";
 import type * as TypesGen from "#/api/typesGenerated";
 import { DebugPanel } from "./DebugPanel";
@@ -98,6 +99,25 @@ const makeLargeRecord = (
 
 type StoryCanvas = ReturnType<typeof within>;
 type StoryUser = ReturnType<typeof userEvent.setup>;
+
+const expectVisibleCopyButtonOnHover = async ({
+	canvas,
+	label,
+}: {
+	canvas: StoryCanvas;
+	label: RegExp;
+}) => {
+	const copyButton = canvas.getByRole("button", { name: label });
+	const groupContainer = copyButton.closest("[data-debug-code-block]");
+	if (!(groupContainer instanceof HTMLElement)) {
+		throw new Error("Missing debug-code hover wrapper.");
+	}
+	await browserUserEvent.hover(groupContainer);
+	await waitFor(() => {
+		expect(copyButton).toBeVisible();
+	});
+	return copyButton;
+};
 
 // Story fixtures use structured normalized payloads even though the generated
 // API type still models them as string records.
@@ -752,12 +772,11 @@ export const SingleStepSuccessfulRun: Story = {
 		// Request body toggle should be available once the step is open.
 		expect(canvas.getByText("Request body")).toBeVisible();
 
-		// Verify a copy button is reachable for normalized body sections.
+		// Verify a copy button becomes visible for normalized body sections.
 		await user.click(canvas.getByText("Request body"));
-		await waitFor(() => {
-			expect(
-				canvas.getByRole("button", { name: /Copy request body JSON/i }),
-			).toBeInTheDocument();
+		await expectVisibleCopyButtonOnHover({
+			canvas,
+			label: /Copy request body JSON/i,
 		});
 	},
 };
@@ -1098,16 +1117,17 @@ export const MultiStepRunWithRetries: Story = {
 		});
 
 		await user.click(canvas.getByRole("button", { name: /Attempt 1/i }));
-		await waitFor(() => {
-			expect(
-				canvas.getByRole("button", { name: /Copy raw request JSON/i }),
-			).toBeInTheDocument();
-			expect(
-				canvas.getByRole("button", { name: /Copy raw response JSON/i }),
-			).toBeInTheDocument();
-			expect(
-				canvas.getByRole("button", { name: /Copy raw attempt error/i }),
-			).toBeInTheDocument();
+		await expectVisibleCopyButtonOnHover({
+			canvas,
+			label: /Copy raw request JSON/i,
+		});
+		await expectVisibleCopyButtonOnHover({
+			canvas,
+			label: /Copy raw response JSON/i,
+		});
+		await expectVisibleCopyButtonOnHover({
+			canvas,
+			label: /Copy raw attempt error/i,
 		});
 	},
 };
@@ -1152,10 +1172,9 @@ export const ErrorStateWithRedactedHeaders: Story = {
 
 		// Expand request body to reveal the redacted headers.
 		await user.click(canvas.getByText("Request body"));
-		await waitFor(() => {
-			expect(
-				canvas.getByRole("button", { name: /Copy request body JSON/i }),
-			).toBeInTheDocument();
+		await expectVisibleCopyButtonOnHover({
+			canvas,
+			label: /Copy request body JSON/i,
 		});
 
 		// After expanding, verify [REDACTED] markers appear in the

--- a/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugPanelPrimitives.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugPanelPrimitives.tsx
@@ -62,9 +62,13 @@ export const CopyableCodeBlock: FC<CopyableCodeBlockProps> = ({
 	className,
 }) => {
 	return (
-		<div className="relative">
+		<div className="group/debug-code relative">
 			<div className="absolute right-2 top-2 z-10">
-				<CopyButton text={code} label={label} />
+				<CopyButton
+					text={code}
+					label={label}
+					className="opacity-0 transition-opacity group-hover/debug-code:opacity-100 focus-visible:opacity-100"
+				/>
 			</div>
 			<DebugCodeBlock code={code} className={cn("pr-10", className)} />
 		</div>

--- a/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugPanelPrimitives.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugPanelPrimitives.tsx
@@ -62,7 +62,7 @@ export const CopyableCodeBlock: FC<CopyableCodeBlockProps> = ({
 	className,
 }) => {
 	return (
-		<div className="group/debug-code relative">
+		<div data-debug-code-block className="group/debug-code relative">
 			<div className="absolute right-2 top-2 z-10">
 				<CopyButton
 					text={code}


### PR DESCRIPTION
Refines agent chat live activity so the generic `Thinking` row only appears when the assistant is active and there is no richer visible activity, such as streamed text, reasoning, retry/reconnect messaging, or a running visible tool row. Durable transcript tool cards and actual reasoning disclosures remain unchanged.

This also migrates production tool-call renderers onto a shared `ToolCall` compound component architecture. `ToolCall.Root` owns status and collapsible view state (`collapsed`, `preview`, or `expanded`) and provides shared context for the composed header/content pieces. Tool renderers now assemble their rows from `HeaderLayout`, `HeaderButton`, `LeadingIcon`, `Label`, `Status`, `HeaderChevron`, `HeaderActions`, and `Content`, so active, failed, and completed tool rows share consistent visuals while each tool keeps its domain-specific labels, actions, and body content.

Agent display preferences are resolved outside `ToolCall` with `resolveAgentDisplayState` and passed in as a generic `defaultView`, keeping the presentation system independent of agent-specific settings. Subagent rows also stop showing synthetic duration metadata that is not emitted by the backend.

<details>
<summary>Coder Agents disclosure</summary>

This PR was generated by Coder Agents on behalf of @DanielleMaywood.

</details>
