### PR TITLE
feat: have fake agents subscribe to  derpmap updates

### DIFF
--- a/enterprise/scaletest/agentfake/agent.go
+++ b/enterprise/scaletest/agentfake/agent.go
@@ -15,6 +15,7 @@ import (
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
+	"github.com/coder/coder/v2/tailnet"
 	tailnetproto "github.com/coder/coder/v2/tailnet/proto"
 	"github.com/coder/quartz"
 )
@@ -179,7 +180,7 @@ func (a *Agent) Run(ctx context.Context) error {
 // continuing to issue RPCs against an already-closed rpc handle until the
 // outer ctx (the whole Agent's lifetime) eventually cancels.
 func (a *Agent) connectAndServe(ctx context.Context, client rpcDialer) error {
-	rpc, _, err := client.ConnectRPC29WithRole(ctx, "agent")
+	rpc, tailnetClient, err := client.ConnectRPC29WithRole(ctx, "agent")
 	if err != nil {
 		return xerrors.Errorf("connect dRPC: %w", err)
 	}
@@ -242,11 +243,47 @@ func (a *Agent) connectAndServe(ctx context.Context, client rpcDialer) error {
 	// Bound to connCtx so the goroutine exits on reconnect, like runMetadata.
 	go a.runConnectionReports(connCtx, rpc)
 
+	// Subscribe to DERP map updates like a real agent does. We have no
+	// tailnet.Conn to apply the map to, so we decode and discard each update;
+	// the point is to reproduce the load this places on coderd replicas (which
+	// stream the map to every connected agent) and the agent-side decode cost.
+	go a.runDERPMapSubscriber(connCtx, tailnetClient)
+
 	select {
 	case <-ctx.Done():
 		return nil
 	case <-conn.Closed():
 		return xerrors.New("dRPC connection closed by remote")
+	}
+}
+
+// runDERPMapSubscriber opens StreamDERPMaps and drains it for the lifetime of
+// the connection, decoding each update to reproduce the agent-side cost. Unlike
+// a real agent it has no tailnet.Conn, so the decoded map is discarded. The
+// loop exits when ctx is canceled or the stream/connection closes.
+func (a *Agent) runDERPMapSubscriber(ctx context.Context, tailnetClient tailnetproto.DRPCTailnetClient28) {
+	stream, err := tailnetClient.StreamDERPMaps(ctx, &tailnetproto.StreamDERPMapsRequest{})
+	if err != nil {
+		if ctx.Err() == nil {
+			a.logger.Warn(ctx, "open derp map stream", slog.Error(err))
+		}
+		return
+	}
+	defer func() {
+		_ = stream.Close()
+	}()
+	for {
+		dmp, err := stream.Recv()
+		if err != nil {
+			if ctx.Err() == nil {
+				a.logger.Debug(ctx, "derp map stream ended", slog.Error(err))
+			}
+			return
+		}
+		// Decode to reproduce agent-side cost; discard since there's no
+		// network to apply it to.
+		_ = tailnet.DERPMapFromProto(dmp)
+		a.metrics.incDERPMapsReceived()
 	}
 }
 

--- a/enterprise/scaletest/agentfake/agent.go
+++ b/enterprise/scaletest/agentfake/agent.go
@@ -216,6 +216,13 @@ func (a *Agent) connectAndServe(ctx context.Context, client rpcDialer) error {
 			slog.Error(err))
 	}
 
+	// fatalErr collects errors from routines that must reconnect the dRPC
+	// connection on failure, matching the real agent's managed subroutines
+	// (metadata and the derp subscriber). runConnectionReports is excluded: the
+	// real agent swallows connection-report failures (see
+	// agent.reportConnectionsLoop), so a blip there must not reconnect.
+	fatalErr := make(chan error, 2)
+
 	// Fetch the agent manifest so we know which metadata descriptions the
 	// template declared. We synthesize values for each declared key at the
 	// declared interval. Failure here is non-fatal: a manifest fetch
@@ -237,49 +244,31 @@ func (a *Agent) connectAndServe(ctx context.Context, client rpcDialer) error {
 				slog.Error(idErr))
 			workspaceID = uuid.Nil
 		}
-		go a.runMetadata(connCtx, rpc, workspaceID, descs)
+		go func() { fatalErr <- a.runMetadata(connCtx, rpc, workspaceID, descs) }()
 	}
 
-	// Bound to connCtx so the goroutine exits on reconnect, like runMetadata.
+	// Connection reporting is non-fatal, so it isn't wired into fatalErr. Bound
+	// to connCtx so it exits on reconnect, like the fatal routines.
 	go a.runConnectionReports(connCtx, rpc)
 
-	// The DERP map subscriber is the one routine whose failure is fatal to the
-	// connection. The point of subscribing is to keep coderd's per-agent
-	// StreamDERPMaps send goroutine alive; if our subscription silently died we
-	// would stop stimulating the control-plane DERP-push path. So a non-shutdown
-	// error tears the connection down and the outer loop reconnects, re-opening
-	// the stream and re-creating the server-side goroutine, matching the real
-	// agent (which reconnects when any managed subroutine errors).
-	derpErr := make(chan error, 1)
-	go func() {
-		derpErr <- a.runDERPMapSubscriber(connCtx, tailnetClient)
-	}()
+	go func() { fatalErr <- a.runDERPMapSubscriber(connCtx, tailnetClient) }()
 
 	select {
 	case <-ctx.Done():
 		return nil
 	case <-conn.Closed():
 		return xerrors.New("dRPC connection closed by remote")
-	case err := <-derpErr:
-		// nil means clean shutdown/cancel; a non-nil error reconnects. Either
-		// way the deferred cancelConn stops runMetadata and runConnectionReports.
-		if err != nil {
-			return xerrors.Errorf("derp map subscriber: %w", err)
-		}
-		return nil
+	case err := <-fatalErr:
+		// A non-nil error reconnects; nil is a clean shutdown. The routines
+		// wrap their own errors, so return as-is.
+		return err
 	}
 }
 
-// runDERPMapSubscriber drains the DERP map stream so coderd and the agent
-// exercise the cost of generating, sending, and receiving updates. The decoded
-// map is discarded because fake agents have no tailnet.Conn to apply it to.
-//
-// It returns the error that ended the stream so connectAndServe can tear down
-// and re-establish the dRPC connection, mirroring the real agent: any
-// non-shutdown subroutine error reconnects the whole connection, which re-opens
-// the stream and re-creates the server-side send goroutine. A subscription that
-// silently died would stop stimulating the control-plane DERP-push path. A
-// shutdown/reconnect cancellation (ctx canceled) returns nil so we don't churn.
+// runDERPMapSubscriber drains the DERP map stream, discarding each map since
+// fake agents have no tailnet.Conn. It returns the stream error so
+// connectAndServe can reconnect, re-creating coderd's send goroutine; ctx
+// cancellation (shutdown/reconnect) returns nil to avoid churn.
 func (a *Agent) runDERPMapSubscriber(ctx context.Context, tailnetClient tailnetproto.DRPCTailnetClient28) error {
 	stream, err := tailnetClient.StreamDERPMaps(ctx, &tailnetproto.StreamDERPMapsRequest{})
 	if err != nil {
@@ -304,24 +293,14 @@ func (a *Agent) runDERPMapSubscriber(ctx context.Context, tailnetClient tailnetp
 	}
 }
 
-// runMetadata sends synthetic values for every metadata description in the
-// agent manifest, batching per-tick into a single BatchUpdateMetadata call.
-//
-// One goroutine per agent (not per description): a 1s ticker pulses and we
-// track per-description next-due timestamps so each key reports at its own
-// declared interval. The goroutine is scoped to the connection's ctx; on
-// disconnect or shutdown it exits cleanly.
-//
-// The payload is a single fixed value, computed once: the workspace ID
-// prepended to a constant padding so each metadata row in scaletest logs
-// and the database is traceable back to the agent that emitted it. We
-// intentionally do not vary the value per key or per tick; if a future
-// scenario requires per-key/per-tick variation we can extend this then.
-//
-// Errors from BatchUpdateMetadata are logged and ignored. Tearing the
-// connection down over a metadata RPC blip would be wasteful; real agents
-// behave the same way (see agent.reportMetadata).
-func (a *Agent) runMetadata(ctx context.Context, rpc proto.DRPCAgentClient29, workspaceID uuid.UUID, descs []*proto.WorkspaceAgentMetadata_Description) {
+// runMetadata batches synthetic values for every manifest metadata description
+// into one BatchUpdateMetadata call per tick (a 1s ticker tracks per-key
+// next-due timestamps so each reports at its declared interval). The payload is
+// a fixed value computed once, the workspace ID plus padding, so rows are
+// traceable to the emitting agent. It returns a BatchUpdateMetadata error so
+// connectAndServe reconnects, matching the real agent (see
+// agent.reportMetadata); ctx cancellation returns nil to avoid churn.
+func (a *Agent) runMetadata(ctx context.Context, rpc proto.DRPCAgentClient29, workspaceID uuid.UUID, descs []*proto.WorkspaceAgentMetadata_Description) error {
 	// Resolve declared intervals once, applying a floor so a malformed
 	// manifest can't spin us. Initialize all keys as immediately due so
 	// the first tick fires every description.
@@ -360,15 +339,10 @@ func (a *Agent) runMetadata(ctx context.Context, rpc proto.DRPCAgentClient29, wo
 	}
 	value := base64.StdEncoding.EncodeToString([]byte(prefix + strings.Repeat("a", padLen)))
 
-	// TickerFunc spawns its own goroutine that ticks until ctx is
-	// done and then stops the underlying ticker. We Wait on the
-	// returned Waiter so that runMetadata (itself running in the
-	// goroutine spawned by connectAndServe) stays alive for the
-	// connection's lifetime, matching the pre-refactor for/select
-	// shape. The Wait error is discarded: ticker exits are expected
-	// (ctx cancellation), and our tick func never returns a non-nil
-	// error of its own.
-	_ = a.clock.TickerFunc(ctx, metadataTickInterval, func() error {
+	// TickerFunc ticks until ctx is done or the func errors; Wait
+	// returns that error. A BatchUpdateMetadata failure propagates so
+	// the connection reconnects, while ctx cancellation returns nil.
+	err := a.clock.TickerFunc(ctx, metadataTickInterval, func() error {
 		now := a.clock.Now()
 		var batch []*proto.Metadata
 		for i, d := range descs {
@@ -389,12 +363,18 @@ func (a *Agent) runMetadata(ctx context.Context, rpc proto.DRPCAgentClient29, wo
 		}
 		if _, err := rpc.BatchUpdateMetadata(ctx, &proto.BatchUpdateMetadataRequest{
 			Metadata: batch,
-		}); err != nil && ctx.Err() == nil {
-			a.logger.Debug(ctx, "batch update metadata failed",
-				slog.Error(err))
+		}); err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return xerrors.Errorf("batch update metadata: %w", err)
 		}
 		return nil
 	}, "agentfake", "runMetadata").Wait()
+	if ctx.Err() != nil {
+		return nil
+	}
+	return err
 }
 
 // runConnectionReports emits periodic synthetic SSH sessions (CONNECT then

--- a/enterprise/scaletest/agentfake/agent.go
+++ b/enterprise/scaletest/agentfake/agent.go
@@ -243,26 +243,50 @@ func (a *Agent) connectAndServe(ctx context.Context, client rpcDialer) error {
 	// Bound to connCtx so the goroutine exits on reconnect, like runMetadata.
 	go a.runConnectionReports(connCtx, rpc)
 
-	go a.runDERPMapSubscriber(connCtx, tailnetClient)
+	// The DERP map subscriber is the one routine whose failure is fatal to the
+	// connection. The point of subscribing is to keep coderd's per-agent
+	// StreamDERPMaps send goroutine alive; if our subscription silently died we
+	// would stop stimulating the control-plane DERP-push path. So a non-shutdown
+	// error tears the connection down and the outer loop reconnects, re-opening
+	// the stream and re-creating the server-side goroutine, matching the real
+	// agent (which reconnects when any managed subroutine errors).
+	derpErr := make(chan error, 1)
+	go func() {
+		derpErr <- a.runDERPMapSubscriber(connCtx, tailnetClient)
+	}()
 
 	select {
 	case <-ctx.Done():
 		return nil
 	case <-conn.Closed():
 		return xerrors.New("dRPC connection closed by remote")
+	case err := <-derpErr:
+		// nil means clean shutdown/cancel; a non-nil error reconnects. Either
+		// way the deferred cancelConn stops runMetadata and runConnectionReports.
+		if err != nil {
+			return xerrors.Errorf("derp map subscriber: %w", err)
+		}
+		return nil
 	}
 }
 
 // runDERPMapSubscriber drains the DERP map stream so coderd and the agent
 // exercise the cost of generating, sending, and receiving updates. The decoded
 // map is discarded because fake agents have no tailnet.Conn to apply it to.
-func (a *Agent) runDERPMapSubscriber(ctx context.Context, tailnetClient tailnetproto.DRPCTailnetClient28) {
+//
+// It returns the error that ended the stream so connectAndServe can tear down
+// and re-establish the dRPC connection, mirroring the real agent: any
+// non-shutdown subroutine error reconnects the whole connection, which re-opens
+// the stream and re-creates the server-side send goroutine. A subscription that
+// silently died would stop stimulating the control-plane DERP-push path. A
+// shutdown/reconnect cancellation (ctx canceled) returns nil so we don't churn.
+func (a *Agent) runDERPMapSubscriber(ctx context.Context, tailnetClient tailnetproto.DRPCTailnetClient28) error {
 	stream, err := tailnetClient.StreamDERPMaps(ctx, &tailnetproto.StreamDERPMapsRequest{})
 	if err != nil {
-		if ctx.Err() == nil {
-			a.logger.Warn(ctx, "open derp map stream", slog.Error(err))
+		if ctx.Err() != nil {
+			return nil
 		}
-		return
+		return xerrors.Errorf("open derp map stream: %w", err)
 	}
 	defer func() {
 		_ = stream.Close()
@@ -270,10 +294,10 @@ func (a *Agent) runDERPMapSubscriber(ctx context.Context, tailnetClient tailnetp
 	for {
 		dmp, err := stream.Recv()
 		if err != nil {
-			if ctx.Err() == nil {
-				a.logger.Debug(ctx, "derp map stream ended", slog.Error(err))
+			if ctx.Err() != nil {
+				return nil
 			}
-			return
+			return xerrors.Errorf("recv derp map: %w", err)
 		}
 		_ = tailnet.DERPMapFromProto(dmp)
 		a.metrics.incDERPMapsReceived()

--- a/enterprise/scaletest/agentfake/agent.go
+++ b/enterprise/scaletest/agentfake/agent.go
@@ -243,10 +243,6 @@ func (a *Agent) connectAndServe(ctx context.Context, client rpcDialer) error {
 	// Bound to connCtx so the goroutine exits on reconnect, like runMetadata.
 	go a.runConnectionReports(connCtx, rpc)
 
-	// Subscribe to DERP map updates like a real agent does. We have no
-	// tailnet.Conn to apply the map to, so we decode and discard each update;
-	// the point is to reproduce the load this places on coderd replicas (which
-	// stream the map to every connected agent) and the agent-side decode cost.
 	go a.runDERPMapSubscriber(connCtx, tailnetClient)
 
 	select {
@@ -257,10 +253,9 @@ func (a *Agent) connectAndServe(ctx context.Context, client rpcDialer) error {
 	}
 }
 
-// runDERPMapSubscriber opens StreamDERPMaps and drains it for the lifetime of
-// the connection, decoding each update to reproduce the agent-side cost. Unlike
-// a real agent it has no tailnet.Conn, so the decoded map is discarded. The
-// loop exits when ctx is canceled or the stream/connection closes.
+// runDERPMapSubscriber drains the DERP map stream so coderd and the agent
+// exercise the cost of generating, sending, and receiving updates. The decoded
+// map is discarded because fake agents have no tailnet.Conn to apply it to.
 func (a *Agent) runDERPMapSubscriber(ctx context.Context, tailnetClient tailnetproto.DRPCTailnetClient28) {
 	stream, err := tailnetClient.StreamDERPMaps(ctx, &tailnetproto.StreamDERPMapsRequest{})
 	if err != nil {
@@ -280,8 +275,6 @@ func (a *Agent) runDERPMapSubscriber(ctx context.Context, tailnetClient tailnetp
 			}
 			return
 		}
-		// Decode to reproduce agent-side cost; discard since there's no
-		// network to apply it to.
 		_ = tailnet.DERPMapFromProto(dmp)
 		a.metrics.incDERPMapsReceived()
 	}

--- a/enterprise/scaletest/agentfake/agent_test.go
+++ b/enterprise/scaletest/agentfake/agent_test.go
@@ -371,11 +371,8 @@ func TestAgent_ReportsConnections_Disabled(t *testing.T) {
 	}
 }
 
-// Assert that a transient error opening the DERP map stream tears the
-// connection down and the agent reconnects, re-opening the stream. This
-// mirrors the real agent: a failing subroutine reconnects the whole dRPC
-// connection, which re-creates coderd's per-agent send goroutine. A
-// subscriber that silently died would stop stimulating that path.
+// Assert that a transient DERP stream error tears the connection down and the
+// agent reconnects, re-opening the stream so coderd keeps pushing updates.
 func TestAgent_ReconnectsOnDERPStreamError(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)
@@ -481,4 +478,95 @@ func (c *derpFailingTailnetClient) StreamDERPMaps(ctx context.Context, in *tailn
 		return nil, xerrors.New("injected transient derp stream error")
 	}
 	return c.DRPCTailnetClient28.StreamDERPMaps(ctx, in)
+}
+
+// Assert that a transient BatchUpdateMetadata error tears the connection down
+// and the agent reconnects, matching the real agent (see agent.reportMetadata).
+func TestAgent_ReconnectsOnMetadataError(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitShort)
+
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	agentID := uuid.New()
+	manifest := agentsdk.Manifest{
+		AgentID:     agentID,
+		WorkspaceID: uuid.New(),
+		Metadata: []codersdk.WorkspaceAgentMetadataDescription{
+			{Key: "01_meta", DisplayName: "Meta 01", Script: "noop", Interval: 1, Timeout: 10},
+		},
+	}
+	statsCh := make(chan *agentproto.Stats, 1)
+	coord := tailnet.NewCoordinator(logger)
+	t.Cleanup(func() { _ = coord.Close() })
+	inner := agenttest.NewClient(t, logger, agentID, manifest, statsCh, coord)
+	t.Cleanup(inner.Close)
+
+	// Fail BatchUpdateMetadata exactly once so the first connection's metadata
+	// routine errors and forces a reconnect; the second connection succeeds.
+	dialer := &metadataFailingDialer{inner: inner}
+
+	a := agentfake.NewAgent(logger, nil, "",
+		agentfake.WithDialer(dialer),
+	)
+	t.Cleanup(a.Close)
+
+	runCtx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+	runErr := make(chan error, 1)
+	go func() { runErr <- a.Run(runCtx) }()
+
+	require.Eventually(t, func() bool {
+		return dialer.connects.Load() >= 2
+	}, testutil.WaitShort, testutil.IntervalFast,
+		"agent never reconnected after metadata error")
+
+	// On the (successful) second connection metadata is reported.
+	require.Eventually(t, func() bool {
+		return len(inner.GetMetadata()) >= 1
+	}, testutil.WaitShort, testutil.IntervalFast,
+		"fake agent never reported metadata after reconnect")
+
+	cancel()
+	select {
+	case err := <-runErr:
+		require.NoError(t, err, "Agent.Run returned unexpected error")
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for Agent.Run to return: %v", ctx.Err())
+	}
+}
+
+// metadataFailingDialer wraps an agenttest.Client, counts ConnectRPC calls, and
+// fails the first BatchUpdateMetadata call (across all connections).
+type metadataFailingDialer struct {
+	inner    *agenttest.Client
+	connects atomic.Int64
+	failed   atomic.Bool
+}
+
+func (d *metadataFailingDialer) ConnectRPC29WithRole(ctx context.Context, role string) (
+	agentproto.DRPCAgentClient29, tailnetproto.DRPCTailnetClient28, error,
+) {
+	d.connects.Add(1)
+	agentClient, tailnetClient, err := d.inner.ConnectRPC29WithRole(ctx, role)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &metadataFailingAgentClient{
+		DRPCAgentClient29: agentClient,
+		failed:            &d.failed,
+	}, tailnetClient, nil
+}
+
+// metadataFailingAgentClient embeds a real agent client and overrides only
+// BatchUpdateMetadata to fail once.
+type metadataFailingAgentClient struct {
+	agentproto.DRPCAgentClient29
+	failed *atomic.Bool
+}
+
+func (c *metadataFailingAgentClient) BatchUpdateMetadata(ctx context.Context, in *agentproto.BatchUpdateMetadataRequest) (*agentproto.BatchUpdateMetadataResponse, error) {
+	if c.failed.CompareAndSwap(false, true) {
+		return nil, xerrors.New("injected transient metadata error")
+	}
+	return c.DRPCAgentClient29.BatchUpdateMetadata(ctx, in)
 }

--- a/enterprise/scaletest/agentfake/agent_test.go
+++ b/enterprise/scaletest/agentfake/agent_test.go
@@ -3,6 +3,7 @@ package agentfake_test
 import (
 	"context"
 	"encoding/base64"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
 	"tailscale.com/tailcfg"
 
 	"cdr.dev/slog/v3"
@@ -20,6 +22,7 @@ import (
 	"github.com/coder/coder/v2/codersdk/agentsdk"
 	"github.com/coder/coder/v2/enterprise/scaletest/agentfake"
 	"github.com/coder/coder/v2/tailnet"
+	tailnetproto "github.com/coder/coder/v2/tailnet/proto"
 	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
 )
@@ -366,4 +369,116 @@ func TestAgent_ReportsConnections_Disabled(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Assert that a transient error opening the DERP map stream tears the
+// connection down and the agent reconnects, re-opening the stream. This
+// mirrors the real agent: a failing subroutine reconnects the whole dRPC
+// connection, which re-creates coderd's per-agent send goroutine. A
+// subscriber that silently died would stop stimulating that path.
+func TestAgent_ReconnectsOnDERPStreamError(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitShort)
+
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	agentID := uuid.New()
+	manifest := agentsdk.Manifest{
+		AgentID:     agentID,
+		WorkspaceID: uuid.New(),
+	}
+	statsCh := make(chan *agentproto.Stats, 1)
+	coord := tailnet.NewCoordinator(logger)
+	t.Cleanup(func() { _ = coord.Close() })
+	inner := agenttest.NewClient(t, logger, agentID, manifest, statsCh, coord)
+	t.Cleanup(inner.Close)
+
+	// Fail StreamDERPMaps exactly once so the first connection's subscriber
+	// errors and forces a reconnect; the second connection succeeds.
+	dialer := &derpFailingDialer{inner: inner}
+
+	metrics := agentfake.NewMetrics(prometheus.NewRegistry())
+	a := agentfake.NewAgent(logger, nil, "",
+		agentfake.WithDialer(dialer),
+		agentfake.WithMetrics(metrics),
+	)
+	t.Cleanup(a.Close)
+
+	runCtx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+	runErr := make(chan error, 1)
+	go func() { runErr <- a.Run(runCtx) }()
+
+	// The agent should reconnect after the injected failure, producing a second
+	// ConnectRPC call.
+	require.Eventually(t, func() bool {
+		return dialer.connects.Load() >= 2
+	}, testutil.WaitShort, testutil.IntervalFast,
+		"agent never reconnected after DERP stream error")
+
+	// On the (successful) second connection the subscription works, so a pushed
+	// map is received and counted.
+	derpMap := &tailcfg.DERPMap{
+		Regions: map[int]*tailcfg.DERPRegion{
+			1: {
+				RegionID:   1,
+				RegionCode: "test",
+				Nodes: []*tailcfg.DERPNode{{
+					Name:     "test",
+					RegionID: 1,
+					HostName: "localhost",
+				}},
+			},
+		},
+	}
+	require.NoError(t, inner.PushDERPMapUpdate(derpMap))
+
+	require.Eventually(t, func() bool {
+		return promtestutil.ToFloat64(metrics.DERPMapsReceived) >= 1
+	}, testutil.WaitShort, testutil.IntervalFast,
+		"fake agent never recorded a received DERP map after reconnect")
+
+	cancel()
+	select {
+	case err := <-runErr:
+		require.NoError(t, err, "Agent.Run returned unexpected error")
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for Agent.Run to return: %v", ctx.Err())
+	}
+}
+
+// derpFailingDialer wraps an agenttest.Client, counts ConnectRPC calls, and
+// makes the first StreamDERPMaps call (across all connections) return an error
+// so we can exercise the agent's reconnect-on-subscriber-error path.
+type derpFailingDialer struct {
+	inner    *agenttest.Client
+	connects atomic.Int64
+	failed   atomic.Bool
+}
+
+func (d *derpFailingDialer) ConnectRPC29WithRole(ctx context.Context, role string) (
+	agentproto.DRPCAgentClient29, tailnetproto.DRPCTailnetClient28, error,
+) {
+	d.connects.Add(1)
+	agentClient, tailnetClient, err := d.inner.ConnectRPC29WithRole(ctx, role)
+	if err != nil {
+		return nil, nil, err
+	}
+	return agentClient, &derpFailingTailnetClient{
+		DRPCTailnetClient28: tailnetClient,
+		failed:              &d.failed,
+	}, nil
+}
+
+// derpFailingTailnetClient embeds a real tailnet client and overrides only
+// StreamDERPMaps to fail once.
+type derpFailingTailnetClient struct {
+	tailnetproto.DRPCTailnetClient28
+	failed *atomic.Bool
+}
+
+func (c *derpFailingTailnetClient) StreamDERPMaps(ctx context.Context, in *tailnetproto.StreamDERPMapsRequest) (tailnetproto.DRPCTailnet_StreamDERPMapsClient, error) {
+	if c.failed.CompareAndSwap(false, true) {
+		return nil, xerrors.New("injected transient derp stream error")
+	}
+	return c.DRPCTailnetClient28.StreamDERPMaps(ctx, in)
 }

--- a/enterprise/scaletest/agentfake/agent_test.go
+++ b/enterprise/scaletest/agentfake/agent_test.go
@@ -238,11 +238,9 @@ func TestAgent_ReportsConnections(t *testing.T) {
 	}
 }
 
-// Assert that the fake agent subscribes to DERP map updates and records each
-// received map in its metrics. The agenttest.Client serves StreamDERPMaps and
-// only emits a map when one is pushed, so we push a minimal map and assert the
-// counter increments. This mirrors what agent/agent.go's runDERPMapSubscriber
-// does against a real coderd, but without a tailnet.Conn to apply the map to.
+// Assert that the fake agent subscribes to DERP map updates and counts each one
+// it receives. agenttest.Client only emits a map once pushed, so we push one and
+// assert the counter increments.
 func TestAgent_SubscribesToDERPMaps(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)
@@ -271,8 +269,6 @@ func TestAgent_SubscribesToDERPMaps(t *testing.T) {
 	runErr := make(chan error, 1)
 	go func() { runErr <- a.Run(runCtx) }()
 
-	// Push a minimal DERP map; the agent's subscriber decodes it (discarding
-	// the result, since there's no network) and increments the counter.
 	derpMap := &tailcfg.DERPMap{
 		Regions: map[int]*tailcfg.DERPRegion{
 			1: {

--- a/enterprise/scaletest/agentfake/agent_test.go
+++ b/enterprise/scaletest/agentfake/agent_test.go
@@ -7,7 +7,10 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
+	"tailscale.com/tailcfg"
 
 	"cdr.dev/slog/v3"
 	"cdr.dev/slog/v3/sloggers/slogtest"
@@ -168,7 +171,6 @@ func TestAgent_ReportsConnections(t *testing.T) {
 
 	mClock := quartz.NewMock(t)
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
-
 	agentID := uuid.New()
 	manifest := agentsdk.Manifest{
 		AgentID:     agentID,
@@ -226,6 +228,70 @@ func TestAgent_ReportsConnections(t *testing.T) {
 	reports = dialer.GetConnectionReports()
 	require.Equal(t, agentproto.Connection_CONNECT, reports[2].GetConnection().GetAction())
 	require.NotEqual(t, firstID, reports[2].GetConnection().GetId())
+
+	cancel()
+	select {
+	case err := <-runErr:
+		require.NoError(t, err, "Agent.Run returned unexpected error")
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for Agent.Run to return: %v", ctx.Err())
+	}
+}
+
+// Assert that the fake agent subscribes to DERP map updates and records each
+// received map in its metrics. The agenttest.Client serves StreamDERPMaps and
+// only emits a map when one is pushed, so we push a minimal map and assert the
+// counter increments. This mirrors what agent/agent.go's runDERPMapSubscriber
+// does against a real coderd, but without a tailnet.Conn to apply the map to.
+func TestAgent_SubscribesToDERPMaps(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitShort)
+
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	agentID := uuid.New()
+	manifest := agentsdk.Manifest{
+		AgentID:     agentID,
+		WorkspaceID: uuid.New(),
+	}
+	statsCh := make(chan *agentproto.Stats, 1)
+	coord := tailnet.NewCoordinator(logger)
+	t.Cleanup(func() { _ = coord.Close() })
+	dialer := agenttest.NewClient(t, logger, agentID, manifest, statsCh, coord)
+	t.Cleanup(dialer.Close)
+
+	metrics := agentfake.NewMetrics(prometheus.NewRegistry())
+	a := agentfake.NewAgent(logger, nil, "",
+		agentfake.WithDialer(dialer),
+		agentfake.WithMetrics(metrics),
+	)
+	t.Cleanup(a.Close)
+
+	runCtx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+	runErr := make(chan error, 1)
+	go func() { runErr <- a.Run(runCtx) }()
+
+	// Push a minimal DERP map; the agent's subscriber decodes it (discarding
+	// the result, since there's no network) and increments the counter.
+	derpMap := &tailcfg.DERPMap{
+		Regions: map[int]*tailcfg.DERPRegion{
+			1: {
+				RegionID:   1,
+				RegionCode: "test",
+				Nodes: []*tailcfg.DERPNode{{
+					Name:     "test",
+					RegionID: 1,
+					HostName: "localhost",
+				}},
+			},
+		},
+	}
+	require.NoError(t, dialer.PushDERPMapUpdate(derpMap))
+
+	require.Eventually(t, func() bool {
+		return promtestutil.ToFloat64(metrics.DERPMapsReceived) >= 1
+	}, testutil.WaitShort, testutil.IntervalFast,
+		"fake agent never recorded a received DERP map")
 
 	cancel()
 	select {

--- a/enterprise/scaletest/agentfake/metrics.go
+++ b/enterprise/scaletest/agentfake/metrics.go
@@ -6,8 +6,7 @@ import "github.com/prometheus/client_golang/prometheus"
 // A nil *Metrics is a valid no-op.
 type Metrics struct {
 	// ConnectedAgents is the number of fake agents with an established dRPC connection.
-	ConnectedAgents prometheus.Gauge
-	// DERPMapsReceived counts DERP map messages received across all fake agents.
+	ConnectedAgents  prometheus.Gauge
 	DERPMapsReceived prometheus.Counter
 }
 

--- a/enterprise/scaletest/agentfake/metrics.go
+++ b/enterprise/scaletest/agentfake/metrics.go
@@ -7,6 +7,8 @@ import "github.com/prometheus/client_golang/prometheus"
 type Metrics struct {
 	// ConnectedAgents is the number of fake agents with an established dRPC connection.
 	ConnectedAgents prometheus.Gauge
+	// DERPMapsReceived counts DERP map messages received across all fake agents.
+	DERPMapsReceived prometheus.Counter
 }
 
 // NewMetrics registers agentfake collectors on reg and returns the handle.
@@ -18,8 +20,14 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 			Name:      "connected_agents",
 			Help:      "Number of fake agents with an established dRPC connection to coderd.",
 		}),
+		DERPMapsReceived: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "coder",
+			Subsystem: "scaletest_agentfake",
+			Name:      "derp_maps_received_total",
+			Help:      "Total number of DERP map messages received by fake agents.",
+		}),
 	}
-	reg.MustRegister(m.ConnectedAgents)
+	reg.MustRegister(m.ConnectedAgents, m.DERPMapsReceived)
 	m.ConnectedAgents.Set(0) // ensure the metric appears before any agent connects
 	return m
 }
@@ -36,4 +44,11 @@ func (m *Metrics) decConnected() {
 		return
 	}
 	m.ConnectedAgents.Dec()
+}
+
+func (m *Metrics) incDERPMapsReceived() {
+	if m == nil {
+		return
+	}
+	m.DERPMapsReceived.Inc()
 }


### PR DESCRIPTION
This PR adds an additional routine per agentfake `Agent` which will subscribe to DERP map updates from coderd. The goal is to ensure the coderd replicas are doing any necessary processing work to keep the map up to date. It also adds the small amount of resource usage to both coderd and the agentfake `Manager` pods  for the network requests, which hopefully will allow the overall resource usage to more accurately reflect what customers will need to provision at a given concurrent workspace scale.

The results of this are not overly interesting at the moment, IIUC none of the existing scaletest load generators exercise behaviour that results in DERP map changes, and thus the only updates that actually get sent are during the initial cluster + workspaces deployment.

The manager will emit a new counter metric to expose a count of the # of DERP map updates it has received.
