### PR TITLE
fix(dogfood/coder): install libx11-xcb1 for desktop Chrome

### DIFF
--- a/dogfood/coder/ubuntu-22.04/Dockerfile.base
+++ b/dogfood/coder/ubuntu-22.04/Dockerfile.base
@@ -71,6 +71,7 @@ RUN sed -i 's|http://archive.ubuntu.com/ubuntu/|http://mirrors.edge.kernel.org/u
 	libicu-dev \
 	libreadline-dev \
 	libssl-dev \
+	libx11-xcb1 \
 	lsb-release \
 	lsof \
 	man \

--- a/dogfood/coder/ubuntu-26.04/Dockerfile.base
+++ b/dogfood/coder/ubuntu-26.04/Dockerfile.base
@@ -70,6 +70,7 @@ RUN sed -i 's|http://archive.ubuntu.com/ubuntu/|http://mirrors.edge.kernel.org/u
 	libicu-dev \
 	libreadline-dev \
 	libssl-dev \
+	libx11-xcb1 \
 	lsb-release \
 	lsof \
 	man \


### PR DESCRIPTION
## Problem

Launching the system Google Chrome from the portabledesktop/VNC session in dogfood workspaces crashes immediately (SIGTRAP, exit 133). Headless Chrome and Playwright's bundled Chromium are unaffected, so it only shows up when a user opens Chrome in the desktop.

Root cause traced via `strace`: Chrome `dlopen`s `libX11-xcb.so.1` when it initializes the X11 GUI path and `IMMEDIATE_CRASH()`es when the library is missing:

```
openat(... "/usr/lib/x86_64-linux-gnu/libX11-xcb.so.1" ...) = -1 ENOENT
... --- SIGTRAP {si_signo=SIGTRAP, si_code=SI_KERNEL} ---
```

The Google Chrome `.deb` declares `libx11-6` and `libxcb1` but **not** `libx11-xcb1`, so apt never installs it.

## Why it regressed (~2 weeks ago)

`libx11-xcb1` used to be pulled in transitively by the build-time step:

```
pnpm dlx playwright@1.47.0 install --with-deps chromium
```

`--with-deps` makes Playwright `apt-get install` Chromium's full system-library set, which on Ubuntu includes `libx11-xcb1`.

#25448 ("refactor: build dogfood image as base + mise oci layers") removed that build step from both Ubuntu Dockerfiles and moved the install to the workspace-start `install-deps` script, which runs `playwright install chromium` / `playwright-core install --no-shell chromium` **without** `--with-deps`. Those download only the browser binaries, not the apt system libraries, so `libx11-xcb1` disappeared from the image.

## Fix

Install `libx11-xcb1` explicitly in both `ubuntu-22.04` and `ubuntu-26.04` `Dockerfile.base` apt lists, decoupling desktop Chrome's X libraries from the Playwright install so it can't silently regress again.

## Testing

Reproduced and verified on a running dogfood workspace (Ubuntu 22.04): before the fix, `DISPLAY=:1 google-chrome` crashed with SIGTRAP on the missing `libX11-xcb.so.1`; after `apt-get install -y libx11-xcb1`, a vanilla `google-chrome` launch (as the desktop menu invokes it) starts and stays running with a renderer process. Remaining EGL/GPU warnings are expected (software rendering under VNC) and non-fatal.

<details>
<summary>Investigation notes</summary>

- headless Chrome and `--screenshot` worked, isolating the failure to the X11/Ozone GUI path.
- The earlier `crashpad ... format error / Unknown ptrace scope` messages were a red herring; the real crash was the missing-library `dlopen`.
- `portabledesktop` ships a self-contained Xvnc server + WM runtime (its own glibc closure) and does not provide libraries to system apps like Chrome, so the fix belongs in the dogfood image.

</details>

---
Generated with Coder Agents.
