### PR TITLE
feat(coderd): support Slack user-token OAuth flow for MCP

### DIFF
--- a/coderd/mcp.go
+++ b/coderd/mcp.go
@@ -953,8 +953,25 @@ func (api *API) mcpServerOAuth2Connect(rw http.ResponseWriter, r *http.Request) 
 	if config.OAuth2Scopes != "" {
 		scopes = strings.Split(config.OAuth2Scopes, " ")
 	}
-	oauth2Config.Scopes = scopes
-	authURL := oauth2Config.AuthCodeURL(state, oauth2.S256ChallengeOption(verifier))
+
+	authCodeOpts := []oauth2.AuthCodeOption{oauth2.S256ChallengeOption(verifier)}
+	if isSlackUserTokenAuthURL(config.OAuth2AuthURL) {
+		// Slack's user-token OAuth flow (oauth.v2; the
+		// /oauth/v2_user/authorize endpoint) expects the
+		// requested scopes in the "user_scope" parameter, NOT
+		// the standard "scope" parameter. "scope" is reserved
+		// for bot-token scopes. If we send our scopes as
+		// "scope" (the default for oauth2.Config), Slack mints a
+		// user token with zero user scopes and every subsequent
+		// API call fails. So move the scopes to "user_scope"
+		// and leave the library's "scope" empty.
+		oauth2Config.Scopes = nil
+		authCodeOpts = append(authCodeOpts,
+			oauth2.SetAuthURLParam("user_scope", strings.Join(scopes, " ")))
+	} else {
+		oauth2Config.Scopes = scopes
+	}
+	authURL := oauth2Config.AuthCodeURL(state, authCodeOpts...)
 	http.Redirect(rw, r, authURL, http.StatusTemporaryRedirect)
 }
 
@@ -1048,7 +1065,9 @@ func (api *API) mcpServerOAuth2Callback(rw http.ResponseWriter, r *http.Request)
 
 	// Recover the PKCE code_verifier set during the connect step.
 	var exchangeOpts []oauth2.AuthCodeOption
+	var pkceVerifier string
 	if verifierCookie, err := r.Cookie("mcp_oauth2_verifier_" + config.ID.String()); err == nil {
+		pkceVerifier = verifierCookie.Value
 		exchangeOpts = append(exchangeOpts, oauth2.VerifierOption(verifierCookie.Value))
 	}
 	// Clear the verifier cookie regardless of whether it was present.
@@ -1085,7 +1104,18 @@ func (api *API) mcpServerOAuth2Callback(rw http.ResponseWriter, r *http.Request)
 	if api.HTTPClient != nil {
 		exchangeCtx = context.WithValue(ctx, oauth2.HTTPClient, api.HTTPClient)
 	}
-	token, err := oauth2Config.Exchange(exchangeCtx, code, exchangeOpts...)
+	var token *oauth2.Token
+	if isSlackUserTokenAuthURL(config.OAuth2AuthURL) {
+		// Slack's oauth.v2.user.access response is non-standard:
+		// it returns HTTP 200 with {"ok": false, "error": ...} on
+		// failure, and nests the user access token under
+		// "authed_user.access_token" rather than the top-level
+		// "access_token" the stdlib oauth2 library reads. Exchange
+		// via a Slack-aware helper so we capture the right token.
+		token, err = exchangeSlackUserToken(exchangeCtx, api.HTTPClient, oauth2Config, code, pkceVerifier)
+	} else {
+		token, err = oauth2Config.Exchange(exchangeCtx, code, exchangeOpts...)
+	}
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusBadGateway, codersdk.Response{
 			Message: "Failed to exchange authorization code for token.",
@@ -1240,6 +1270,106 @@ func parseMCPServerConfigID(rw http.ResponseWriter, r *http.Request) (uuid.UUID,
 		return uuid.Nil, false
 	}
 	return mcpServerID, true
+}
+
+// isSlackUserTokenAuthURL reports whether the given OAuth2 authorization
+// URL is Slack's user-token authorize endpoint. Slack's user-token flow
+// (oauth.v2) is non-standard in two ways that require special handling:
+// requested scopes must be sent in the "user_scope" parameter instead of
+// "scope", and the token-exchange response nests the user access token
+// under "authed_user.access_token". We key off the host + path so that
+// only Slack's user-token endpoint triggers the workarounds; Slack's
+// bot-token endpoint (/oauth/v2/authorize) and all other providers use
+// the standard path.
+func isSlackUserTokenAuthURL(authURL string) bool {
+	u, err := url.Parse(authURL)
+	if err != nil {
+		return false
+	}
+	if !strings.EqualFold(u.Host, "slack.com") {
+		return false
+	}
+	return strings.HasPrefix(u.Path, "/oauth/v2_user/")
+}
+
+// slackUserTokenResponse models the relevant fields of Slack's
+// oauth.v2.user.access response. Slack returns HTTP 200 even on failure,
+// signalling errors via "ok": false, and places the per-user access token
+// under "authed_user" rather than at the top level.
+type slackUserTokenResponse struct {
+	OK         bool   `json:"ok"`
+	Error      string `json:"error"`
+	AuthedUser struct {
+		AccessToken  string `json:"access_token"`
+		TokenType    string `json:"token_type"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int64  `json:"expires_in"`
+	} `json:"authed_user"`
+}
+
+// exchangeSlackUserToken performs the authorization-code exchange against
+// Slack's oauth.v2.user.access endpoint and returns an *oauth2.Token built
+// from the nested "authed_user" object. It is used instead of the stdlib
+// oauth2.Config.Exchange, which reads the (empty) top-level access_token
+// and does not treat Slack's {"ok": false} as an error. The PKCE
+// code_verifier (when present) is forwarded as a form value.
+func exchangeSlackUserToken(ctx context.Context, httpClient *http.Client, cfg *oauth2.Config, code, pkceVerifier string) (*oauth2.Token, error) {
+	v := url.Values{}
+	v.Set("client_id", cfg.ClientID)
+	v.Set("client_secret", cfg.ClientSecret)
+	v.Set("code", code)
+	v.Set("grant_type", "authorization_code")
+	if cfg.RedirectURL != "" {
+		v.Set("redirect_uri", cfg.RedirectURL)
+	}
+	if pkceVerifier != "" {
+		v.Set("code_verifier", pkceVerifier)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.Endpoint.TokenURL, strings.NewReader(v.Encode()))
+	if err != nil {
+		return nil, xerrors.Errorf("build slack token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	client := httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, xerrors.Errorf("slack token exchange request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var body slackUserTokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, xerrors.Errorf("decode slack token response: %w", err)
+	}
+	if !body.OK {
+		if body.Error == "" {
+			body.Error = "unknown error"
+		}
+		return nil, xerrors.Errorf("slack token exchange failed: %s", body.Error)
+	}
+	if body.AuthedUser.AccessToken == "" {
+		return nil, xerrors.New("slack token exchange returned no user access token")
+	}
+
+	tokenType := body.AuthedUser.TokenType
+	if tokenType == "" {
+		tokenType = "Bearer"
+	}
+	tok := &oauth2.Token{
+		AccessToken:  body.AuthedUser.AccessToken,
+		TokenType:    tokenType,
+		RefreshToken: body.AuthedUser.RefreshToken,
+	}
+	if body.AuthedUser.ExpiresIn > 0 {
+		tok.Expiry = time.Now().Add(time.Duration(body.AuthedUser.ExpiresIn) * time.Second)
+	}
+	return tok, nil
 }
 
 // convertMCPServerConfig converts a database MCP server config to the

--- a/coderd/mcp_internal_test.go
+++ b/coderd/mcp_internal_test.go
@@ -2,6 +2,8 @@ package coderd
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -212,5 +214,100 @@ func TestOIDCMCPTokenSource(t *testing.T) {
 		tok, err := src.OIDCAccessToken(ctx, user.ID)
 		require.NoError(t, err)
 		require.Empty(t, tok)
+	})
+}
+
+func TestIsSlackUserTokenAuthURL(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		authURL string
+		want    bool
+	}{
+		{"slack user-token endpoint", "https://slack.com/oauth/v2_user/authorize", true},
+		{"slack bot-token endpoint", "https://slack.com/oauth/v2/authorize", false},
+		{"slack legacy endpoint", "https://slack.com/oauth/authorize", false},
+		{"other provider", "https://github.com/login/oauth/authorize", false},
+		{"empty", "", false},
+		{"not a url", "://bogus", false},
+		{"lookalike host", "https://notslack.com/oauth/v2_user/authorize", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, isSlackUserTokenAuthURL(tc.authURL))
+		})
+	}
+}
+
+func TestExchangeSlackUserToken(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+
+		var gotForm string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.NoError(t, r.ParseForm())
+			gotForm = r.Form.Encode()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"ok": true,
+				"authed_user": {
+					"id": "U123",
+					"access_token": "xoxp-user-token",
+					"token_type": "Bearer"
+				}
+			}`))
+		}))
+		defer srv.Close()
+
+		cfg := &oauth2.Config{
+			ClientID:     "cid",
+			ClientSecret: "secret",
+			Endpoint:     oauth2.Endpoint{TokenURL: srv.URL},
+			RedirectURL:  "https://coder.example.com/callback",
+		}
+		tok, err := exchangeSlackUserToken(context.Background(), srv.Client(), cfg, "the-code", "the-verifier")
+		require.NoError(t, err)
+		require.Equal(t, "xoxp-user-token", tok.AccessToken)
+		require.Equal(t, "Bearer", tok.TokenType)
+		// The user token (not a bot token) must be the one stored.
+		require.Contains(t, gotForm, "code=the-code")
+		require.Contains(t, gotForm, "code_verifier=the-verifier")
+		require.Contains(t, gotForm, "grant_type=authorization_code")
+	})
+
+	t.Run("SlackErrorOnHTTP200", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			// Slack signals failures with HTTP 200 + ok:false.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok": false, "error": "invalid_code"}`))
+		}))
+		defer srv.Close()
+
+		cfg := &oauth2.Config{Endpoint: oauth2.Endpoint{TokenURL: srv.URL}}
+		_, err := exchangeSlackUserToken(context.Background(), srv.Client(), cfg, "bad", "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid_code")
+	})
+
+	t.Run("MissingUserToken", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			// ok:true but no authed_user.access_token (e.g. only a bot token).
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok": true, "access_token": "xoxb-bot-only"}`))
+		}))
+		defer srv.Close()
+
+		cfg := &oauth2.Config{Endpoint: oauth2.Endpoint{TokenURL: srv.URL}}
+		_, err := exchangeSlackUserToken(context.Background(), srv.Client(), cfg, "code", "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no user access token")
 	})
 }


### PR DESCRIPTION
### Problem

Connecting a Slack MCP server via Coder's admin-configured MCP OAuth2 flow yields a
token that has **no usable scopes**, so every Slack tool call fails (returns empty /
unauthorized) even though the server shows `auth_connected: true`.

Slack's **user-token** OAuth flow — the `https://slack.com/oauth/v2_user/authorize`
authorize endpoint paired with the `https://slack.com/api/oauth.v2.user.access` token
endpoint — is non-standard in two ways that `golang.org/x/oauth2` (used by
`coderd/mcp.go`) does not handle:

1. **Authorize:** requested scopes must be sent in a **`user_scope`** query parameter,
   not the standard **`scope`** parameter. `scope` is reserved for *bot*-token scopes.
   `oauth2.Config.AuthCodeURL` always writes `scope`, so Slack receives the scopes as
   bot scopes, `user_scope` is empty, and it mints a **user token with zero user
   scopes**.
2. **Token exchange:** Slack returns **HTTP 200 with `{"ok": false, "error": ...}`** on
   failure (which the stdlib does not treat as an error), and nests the user access
   token under **`authed_user.access_token`** rather than the top-level `access_token`
   the library reads. So even with scopes fixed, `oauth2.Config.Exchange` stores an
   empty/incorrect token.

This blocks using Slack as a control-plane MCP provider (e.g. searching/reading the
connecting user's own Slack messages, which requires a user token — Slack's
`search.messages` is user-token-only).

### Fix

Detect Slack's user-token authorize URL by host + path (`slack.com` +
`/oauth/v2_user/`) and, **only for it**:

- send the configured scopes via `user_scope` (leaving the library's `scope` empty), and
- perform the code exchange through a small Slack-aware helper that reads
  `authed_user.access_token` and surfaces `ok:false` errors.

Everything else — all other providers, and Slack's *bot*-token endpoint
(`/oauth/v2/authorize`) — is unaffected and continues through the standard path. No DB
schema, API, or config-shape changes; the behavior keys purely off the provider's
existing `oauth2_auth_url`.

### Testing

- `go build ./coderd/` — passes
- `go vet ./coderd/` — passes
- `gofmt` — clean
- New unit tests (`coderd/mcp_internal_test.go`):
  - `TestIsSlackUserTokenAuthURL` — table-driven: user-token vs bot-token vs legacy vs
    other providers vs lookalike host vs empty/invalid.
  - `TestExchangeSlackUserToken` — success (reads nested `authed_user.access_token`,
    forwards `code`/`code_verifier`/`grant_type`); `ok:false`-on-HTTP-200 surfaces an
    error; `ok:true` with no user token is rejected.

### Notes / open questions for maintainers

- Detection is provider-specific (Slack) keyed on the auth URL. An alternative would be
  a generic per-MCP-server "scope parameter name" / "user-token mode" config field; I
  kept this minimal and self-contained to match the existing per-provider handling in
  `coderd/externalauth/externalauth.go`. Happy to generalize if preferred.
- Refresh-token handling for Slack user tokens uses the same nested shape; this PR wires
  the initial exchange. If `refreshMCPUserToken` needs the same treatment for Slack, I
  can follow up.
