### PR TITLE
fix: auto-reconnect dynamic parameters WebSocket and reduce idle timeout

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -176,6 +176,7 @@ type Options struct {
 	AgentConnectionUpdateFrequency time.Duration
 	AgentInactiveDisconnectTimeout time.Duration
 	ChatdInstructionLookupTimeout  time.Duration
+	DynamicParametersIdleTimeout   time.Duration
 	AWSCertificates                awsidentity.Certificates
 	Authorizer                     rbac.Authorizer
 	AzureCertificates              azureidentity.Options
@@ -401,6 +402,9 @@ func New(options *Options) *API {
 	}
 	if options.AgentConnectionUpdateFrequency == 0 {
 		options.AgentConnectionUpdateFrequency = 15 * time.Second
+	}
+	if options.DynamicParametersIdleTimeout == 0 {
+		options.DynamicParametersIdleTimeout = dynamicParameterIdleTimeout
 	}
 	if options.AgentInactiveDisconnectTimeout == 0 {
 		// Multiply the update by two to allow for some lag-time.

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -196,6 +196,7 @@ type Options struct {
 	OIDCConvertKeyCache                cryptokeys.SigningKeycache
 	Clock                              quartz.Clock
 	TelemetryReporter                  telemetry.Reporter
+	DynamicParametersIdleTimeout       time.Duration
 
 	ProvisionerdServerMetrics *provisionerdserver.Metrics
 	WorkspaceBuilderMetrics   *wsbuilder.Metrics
@@ -651,6 +652,7 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 			NotificationsEnqueuer:              options.NotificationsEnqueuer,
 			OneTimePasscodeValidityPeriod:      options.OneTimePasscodeValidityPeriod,
 			Clock:                              options.Clock,
+			DynamicParametersIdleTimeout:       options.DynamicParametersIdleTimeout,
 			AppEncryptionKeyCache:              options.APIKeyEncryptionCache,
 			OIDCConvertKeyCache:                options.OIDCConvertKeyCache,
 			ProvisionerdServerMetrics:          options.ProvisionerdServerMetrics,

--- a/coderd/parameters.go
+++ b/coderd/parameters.go
@@ -3,6 +3,7 @@ package coderd
 import (
 	"context"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -128,9 +129,25 @@ func (*API) handleParameterEvaluate(rw http.ResponseWriter, r *http.Request, ini
 	httpapi.Write(ctx, rw, http.StatusOK, response)
 }
 
+// dynamicParameterIdleTimeout is the default idle timeout for the dynamic
+// parameters WebSocket. The connection is closed if no messages are
+// received within this duration. Each client message resets the timer.
+// It can be overridden via Options.DynamicParametersIdleTimeout.
+const dynamicParameterIdleTimeout = 3 * time.Minute
+
 func (api *API) handleParameterWebsocket(rw http.ResponseWriter, r *http.Request, initial codersdk.DynamicParametersRequest, render dynamicparameters.Renderer) {
-	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Minute)
+	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
+
+	// idledOut records whether the connection is being torn down because the
+	// idle timer fired, so we can close with a distinct status code that the
+	// client treats as an expected idle close rather than an error.
+	var idledOut atomic.Bool
+	idleTimer := api.Clock.AfterFunc(api.DynamicParametersIdleTimeout, func() {
+		idledOut.Store(true)
+		cancel()
+	}, "dynamic-parameters-idle")
+	defer idleTimer.Stop()
 
 	conn, err := websocket.Accept(rw, r, nil)
 	if err != nil {
@@ -171,6 +188,12 @@ func (api *API) handleParameterWebsocket(rw http.ResponseWriter, r *http.Request
 	for {
 		select {
 		case <-ctx.Done():
+			if idledOut.Load() {
+				// Idle timeout closes normally so the client parks the
+				// connection and reconnects on focus or interaction.
+				stream.Close(websocket.StatusNormalClosure)
+				return
+			}
 			stream.Close(websocket.StatusGoingAway)
 			return
 		case update, ok := <-updates:
@@ -178,6 +201,8 @@ func (api *API) handleParameterWebsocket(rw http.ResponseWriter, r *http.Request
 				// The connection has been closed, so there is no one to write to
 				return
 			}
+
+			idleTimer.Reset(api.DynamicParametersIdleTimeout)
 
 			// Take a nil uuid to mean the previous owner ID.
 			// This just removes the need to constantly send who you are.

--- a/coderd/parameters_test.go
+++ b/coderd/parameters_test.go
@@ -2,9 +2,12 @@ package coderd_test
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"os"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -24,6 +27,7 @@ import (
 	provProto "github.com/coder/coder/v2/provisionerd/proto"
 	"github.com/coder/coder/v2/provisionersdk/proto"
 	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/quartz"
 	"github.com/coder/websocket"
 )
 
@@ -70,6 +74,100 @@ func TestDynamicParametersOwnerSSHPublicKey(t *testing.T) {
 	require.Equal(t, "public_key", preview.Parameters[0].Name)
 	require.True(t, preview.Parameters[0].Value.Valid)
 	require.Equal(t, sshKey.PublicKey, preview.Parameters[0].Value.Value)
+}
+
+// TestDynamicParametersWebsocketIdleTimeout verifies that the dynamic
+// parameters WebSocket closes after the idle timeout with a normal closure
+// status, and that each client message renews the timeout. A mock clock
+// drives the idle timer; the idle timeout is set below the WSWatcher
+// heartbeat interval so advancing past it never triggers a liveness probe.
+func TestDynamicParametersWebsocketIdleTimeout(t *testing.T) {
+	t.Parallel()
+
+	const idleTimeout = 5 * time.Second
+
+	mClock := quartz.NewMock(t)
+	ownerClient := coderdtest.New(t, &coderdtest.Options{
+		IncludeProvisionerDaemon:     true,
+		Clock:                        mClock,
+		DynamicParametersIdleTimeout: idleTimeout,
+	})
+	owner := coderdtest.CreateFirstUser(t, ownerClient)
+	templateAdmin, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID, rbac.RoleTemplateAdmin())
+
+	dynamicParametersTerraformSource, err := os.ReadFile("testdata/parameters/public_key/main.tf")
+	require.NoError(t, err)
+	dynamicParametersTerraformPlan, err := os.ReadFile("testdata/parameters/public_key/plan.json")
+	require.NoError(t, err)
+
+	files := echo.WithExtraFiles(map[string][]byte{
+		"main.tf": dynamicParametersTerraformSource,
+	})
+	files.ProvisionPlan = []*proto.Response{{
+		Type: &proto.Response_Plan{
+			Plan: &proto.PlanComplete{
+				Plan: dynamicParametersTerraformPlan,
+			},
+		},
+	}}
+
+	version := coderdtest.CreateTemplateVersion(t, templateAdmin, owner.OrganizationID, files)
+	coderdtest.AwaitTemplateVersionJobCompleted(t, templateAdmin, version.ID)
+	_ = coderdtest.CreateTemplate(t, templateAdmin, owner.OrganizationID, version.ID)
+
+	endpoint := fmt.Sprintf("/api/v2/templateversions/%s/dynamic-parameters", version.ID)
+
+	readResponse := func(ctx context.Context, conn *websocket.Conn) codersdk.DynamicParametersResponse {
+		t.Helper()
+		typ, data, err := conn.Read(ctx)
+		require.NoError(t, err)
+		require.Equal(t, websocket.MessageText, typ)
+		var resp codersdk.DynamicParametersResponse
+		require.NoError(t, json.Unmarshal(data, &resp))
+		return resp
+	}
+
+	sendRequest := func(ctx context.Context, conn *websocket.Conn, id int) {
+		t.Helper()
+		// A nil owner ID means "reuse the previous owner", which avoids
+		// needing to re-authorize against another user.
+		data, err := json.Marshal(codersdk.DynamicParametersRequest{
+			ID:      id,
+			OwnerID: uuid.Nil,
+			Inputs:  map[string]string{},
+		})
+		require.NoError(t, err)
+		require.NoError(t, conn.Write(ctx, websocket.MessageText, data))
+	}
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+
+	conn, err := templateAdmin.Dial(ctx, endpoint, nil)
+	require.NoError(t, err)
+	defer conn.Close(websocket.StatusGoingAway, "")
+
+	// The initial form state proves the idle timer has been armed.
+	initial := readResponse(ctx, conn)
+	require.EqualValues(t, -1, initial.ID)
+
+	// Advance to just before the deadline twice, sending a message each time.
+	// Each message resets the timer, so the connection survives well past a
+	// single idle window. The total advance stays below the WSWatcher
+	// heartbeat interval (15s) so no liveness probe fires.
+	for id := 1; id <= 2; id++ {
+		mClock.Advance(idleTimeout - time.Second).MustWait(ctx)
+		sendRequest(ctx, conn, id)
+		resp := readResponse(ctx, conn)
+		require.EqualValues(t, id, resp.ID)
+	}
+
+	// Stop sending. With no further messages, the connection closes after the
+	// idle timeout with a normal closure, distinct from an error close so the
+	// client treats it as an expected idle disconnect.
+	mClock.Advance(idleTimeout).MustWait(ctx)
+	_, _, err = conn.Read(ctx)
+	require.Error(t, err)
+	require.Equal(t, websocket.StatusNormalClosure, websocket.CloseStatus(err))
 }
 
 // TestDynamicParametersWithTerraformValues is for testing the websocket flow of

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1166,12 +1166,8 @@ class ApiMethods {
 		userId: string,
 		{
 			onMessage,
-			onError,
-			onClose,
 		}: {
 			onMessage: (response: TypesGen.DynamicParametersResponse) => void;
-			onError: (error: Error) => void;
-			onClose: () => void;
 		},
 	): WebSocket => {
 		const socket = createWebSocket(
@@ -1182,15 +1178,6 @@ class ApiMethods {
 		socket.addEventListener("message", (event) =>
 			onMessage(JSON.parse(event.data) as TypesGen.DynamicParametersResponse),
 		);
-
-		socket.addEventListener("error", () => {
-			onError(new Error("Connection for dynamic parameters failed."));
-			socket.close();
-		});
-
-		socket.addEventListener("close", () => {
-			onClose();
-		});
 
 		return socket;
 	};

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -814,7 +814,7 @@ const AgentChatPage: FC = () => {
 		if (!workspaceId) {
 			return;
 		}
-		return createReconnectingWebSocket({
+		const { dispose } = createReconnectingWebSocket({
 			connect() {
 				const socket = watchWorkspace(workspaceId);
 				socket.addEventListener("message", (event) => {
@@ -864,6 +864,7 @@ const AgentChatPage: FC = () => {
 				});
 			},
 		});
+		return dispose;
 	}, [workspaceId, queryClient]);
 	const sshConfigQuery = useQuery(deploymentSSHConfig());
 	const workspaceAgent = getWorkspaceAgent(workspace, undefined);

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -545,7 +545,7 @@ const AgentsPage: FC = () => {
 		void invalidateChatListQueries(queryClient);
 	}, [agentId, queryClient]);
 	useEffect(() => {
-		return createReconnectingWebSocket({
+		const { dispose } = createReconnectingWebSocket({
 			connect() {
 				const ws = watchChats();
 
@@ -650,6 +650,7 @@ const AgentsPage: FC = () => {
 				void invalidateChatListQueries(queryClient);
 			},
 		});
+		return dispose;
 	}, [queryClient]);
 
 	useAgentsPageKeybindings({

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -601,7 +601,7 @@ export const useChatStore = (
 				}
 			});
 		};
-		const disposeSocket = createReconnectingWebSocket({
+		const { dispose: disposeSocket } = createReconnectingWebSocket({
 			connect() {
 				// Use the latest known message ID so the server only
 				// sends events the client hasn't seen yet.

--- a/site/src/pages/AgentsPage/hooks/useGitWatcher.ts
+++ b/site/src/pages/AgentsPage/hooks/useGitWatcher.ts
@@ -86,7 +86,7 @@ export function useGitWatcher({
 
 		const activeChatId = chatId;
 
-		const dispose = createReconnectingWebSocket({
+		const { dispose } = createReconnectingWebSocket({
 			connect() {
 				const socket = watchChatGit(activeChatId);
 				socketRef.current = socket;

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
@@ -82,8 +82,6 @@ describe("CreateWorkspacePage", () => {
 				MockUserOwner.id,
 				expect.objectContaining({
 					onMessage: expect.any(Function),
-					onError: expect.any(Function),
-					onClose: expect.any(Function),
 				}),
 			);
 
@@ -133,7 +131,7 @@ describe("CreateWorkspacePage", () => {
 			vi.useRealTimers();
 		});
 
-		it("handles WebSocket error gracefully", async () => {
+		it("shows error when the WebSocket disconnects unexpectedly", async () => {
 			const [, mockPublisher] = mockDynamicParameterWebSocket([]);
 
 			renderCreateWorkspacePage();
@@ -142,29 +140,8 @@ describe("CreateWorkspacePage", () => {
 				expect(API.templateVersionDynamicParameters).toHaveBeenCalled();
 			});
 
-			await act(async () => {
-				mockPublisher.publishError(new Event("Connection failed"));
-			});
-
-			await waitFor(() => {
-				const alert = screen.getByRole("alert");
-				expect(
-					within(alert).getByRole("heading", {
-						name: /connection for dynamic parameters failed/i,
-					}),
-				).toBeInTheDocument();
-			});
-		});
-
-		it("handles WebSocket close event", async () => {
-			const [, mockPublisher] = mockDynamicParameterWebSocket([]);
-
-			renderCreateWorkspacePage();
-
-			await waitFor(() => {
-				expect(API.templateVersionDynamicParameters).toHaveBeenCalled();
-			});
-
+			// A close without a clean status is treated as an unexpected
+			// disconnect, so the error banner appears while it reconnects.
 			await act(async () => {
 				mockPublisher.publishClose(new Event("close") as CloseEvent);
 			});
@@ -173,10 +150,30 @@ describe("CreateWorkspacePage", () => {
 				const alert = screen.getByRole("alert");
 				expect(
 					within(alert).getByRole("heading", {
-						name: /websocket connection.*unexpectedly closed/i,
+						name: /dynamic parameters lost/i,
 					}),
 				).toBeInTheDocument();
 			});
+		});
+
+		it("does not show an error on a clean idle close", async () => {
+			const [, mockPublisher] = mockDynamicParameterWebSocket([]);
+
+			renderCreateWorkspacePage();
+			await waitForLoaderToBeRemoved();
+
+			// The backend closes idle connections with a normal closure. This
+			// is expected: the connection parks and resumes on focus or the
+			// next edit, so no error banner is shown.
+			await act(async () => {
+				mockPublisher.publishClose(
+					new CloseEvent("close", { code: 1000, wasClean: true }),
+				);
+			});
+
+			expect(
+				screen.queryByRole("heading", { name: /dynamic parameters lost/i }),
+			).not.toBeInTheDocument();
 		});
 
 		it("only parameters from latest response are displayed", async () => {

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
@@ -31,6 +31,10 @@ import { useAuthenticated } from "#/hooks/useAuthenticated";
 import { getInitialParameterValues } from "#/modules/workspaces/DynamicParameter/DynamicParameter";
 import { generateWorkspaceName } from "#/modules/workspaces/generateWorkspaceName";
 import { pageTitle } from "#/utils/page";
+import {
+	createReconnectingWebSocket,
+	isCleanClose,
+} from "#/utils/reconnectingWebSocket";
 import type { AutofillBuildParameter } from "#/utils/richParameters";
 import { AutoCreateConsentDialog } from "./AutoCreateConsentDialog";
 import { CreateWorkspacePageView } from "./CreateWorkspacePageView";
@@ -56,6 +60,11 @@ const CreateWorkspacePage: FC = () => {
 	const ws = useRef<WebSocket | null>(null);
 	const [wsError, setWsError] = useState<Error | null>(null);
 	const initialParamsSentRef = useRef(false);
+	// Reopens the dynamic-parameters socket after an idle (parked) close.
+	const reconnectWsRef = useRef<(() => void) | null>(null);
+	// The most recent inputs sent to the backend, re-sent on reconnect so the
+	// new connection renders against the user's current form state.
+	const lastSentInputsRef = useRef<Record<string, string> | null>(null);
 
 	const customVersionId = searchParams.get("version") ?? undefined;
 	const defaultName = searchParams.get("name");
@@ -160,6 +169,7 @@ const CreateWorkspacePage: FC = () => {
 		formValues: Record<string, string>,
 		ownerId?: string,
 	) => {
+		lastSentInputsRef.current = formValues;
 		const request: DynamicParametersRequest = {
 			id: wsResponseId.current + 1,
 			owner_id: ownerId ?? owner.id,
@@ -168,7 +178,11 @@ const CreateWorkspacePage: FC = () => {
 		if (ws.current && ws.current.readyState === WebSocket.OPEN) {
 			ws.current.send(JSON.stringify(request));
 			wsResponseId.current = wsResponseId.current + 1;
+			return;
 		}
+		// The socket is parked after an idle close. Reopen it; the onOpen
+		// handler re-sends the latest inputs once the connection is back.
+		reconnectWsRef.current?.();
 	};
 
 	// On page load, sends all initial parameter values to the websocket
@@ -213,37 +227,56 @@ const CreateWorkspacePage: FC = () => {
 		setLatestResponse(response);
 	});
 
+	// On (re)connect, re-send the latest inputs so the backend renders against
+	// the user's current form state. The first connection is seeded by
+	// sendInitialParameters via onMessage instead.
+	const resendCurrentInputs = useEffectEvent(() => {
+		if (lastSentInputsRef.current) {
+			sendMessage(lastSentInputsRef.current);
+		}
+	});
+
 	// Initialize the WebSocket connection when there is a valid template version ID
 	useEffect(() => {
 		if (!realizedVersionId) return;
 
-		const socket = API.templateVersionDynamicParameters(
-			realizedVersionId,
-			defaultOwner.id,
-			{
-				onMessage,
-				onError: (error) => {
-					if (ws.current === socket) {
-						setWsError(error);
-					}
-				},
-				onClose: () => {
-					if (ws.current === socket) {
-						setWsError(
-							new DetailedError(
-								"Websocket connection for dynamic parameters unexpectedly closed.",
-								"Refresh the page to reset the form.",
-							),
-						);
-					}
-				},
-			},
-		);
+		const handle = createReconnectingWebSocket({
+			connect() {
+				const socket = API.templateVersionDynamicParameters(
+					realizedVersionId,
+					defaultOwner.id,
+					{ onMessage },
+				);
 
-		ws.current = socket;
+				ws.current = socket;
+				return socket;
+			},
+			// An idle timeout is a clean close: park the connection instead of
+			// reconnecting in a loop, and resume on focus or the next edit.
+			shouldReconnect: (event) => !isCleanClose(event),
+			resumeOnVisible: true,
+			onOpen() {
+				setWsError(null);
+				resendCurrentInputs();
+			},
+			onParked() {
+				// Idle close is expected; surface no error while parked.
+				setWsError(null);
+			},
+			onDisconnect() {
+				setWsError(
+					new DetailedError(
+						"WebSocket connection for dynamic parameters lost.",
+						"Attempting to reconnect...",
+					),
+				);
+			},
+		});
+		reconnectWsRef.current = handle.reconnect;
 
 		return () => {
-			socket.close();
+			reconnectWsRef.current = null;
+			handle.dispose();
 		};
 	}, [realizedVersionId, defaultOwner.id]);
 

--- a/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPage.tsx
@@ -7,6 +7,10 @@ import type {
 } from "#/api/typesGenerated";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
 import { pageTitle } from "#/utils/page";
+import {
+	createReconnectingWebSocket,
+	isCleanClose,
+} from "#/utils/reconnectingWebSocket";
 import { useTemplateLayoutContext } from "../TemplateLayout";
 import { TemplateEmbedPageView } from "./TemplateEmbedPageView";
 
@@ -18,8 +22,14 @@ const TemplateEmbedPage: React.FC = () => {
 	const wsResponseId = useRef<number>(-1);
 	const ws = useRef<WebSocket | null>(null);
 	const [wsError, setWsError] = useState<Error | null>(null);
+	// Reopens the dynamic-parameters socket after an idle (parked) close.
+	const reconnectWsRef = useRef<(() => void) | null>(null);
+	// The most recent inputs sent to the backend, re-sent on reconnect so the
+	// new connection renders against the user's current form state.
+	const lastSentInputsRef = useRef<Record<string, string> | null>(null);
 
 	const sendMessage = (formValues: Record<string, string>) => {
+		lastSentInputsRef.current = formValues;
 		const request: DynamicParametersRequest = {
 			id: wsResponseId.current + 1,
 			owner_id: me.id,
@@ -28,7 +38,11 @@ const TemplateEmbedPage: React.FC = () => {
 		if (ws.current && ws.current.readyState === WebSocket.OPEN) {
 			ws.current.send(JSON.stringify(request));
 			wsResponseId.current = wsResponseId.current + 1;
+			return;
 		}
+		// The socket is parked after an idle close. Reopen it; the onOpen
+		// handler re-sends the latest inputs once the connection is back.
+		reconnectWsRef.current?.();
 	};
 
 	const onMessage = useEffectEvent((response: DynamicParametersResponse) => {
@@ -39,38 +53,56 @@ const TemplateEmbedPage: React.FC = () => {
 		setLatestResponse(response);
 	});
 
+	// On reconnect, re-send the latest inputs so the backend renders against
+	// the user's current form state.
+	const resendCurrentInputs = useEffectEvent(() => {
+		if (lastSentInputsRef.current) {
+			sendMessage(lastSentInputsRef.current);
+		}
+	});
+
 	useEffect(() => {
 		if (!template.active_version_id || !me) {
 			return;
 		}
 
-		const socket = API.templateVersionDynamicParameters(
-			template.active_version_id,
-			me.id,
-			{
-				onMessage,
-				onError: (error) => {
-					if (ws.current === socket) {
-						setWsError(error);
-					}
-				},
-				onClose: () => {
-					if (ws.current === socket) {
-						setWsError(
-							new DetailedError(
-								"Websocket connection for dynamic parameters unexpectedly closed.",
-								"Refresh the page to reset the form.",
-							),
-						);
-					}
-				},
-			},
-		);
+		const handle = createReconnectingWebSocket({
+			connect() {
+				const socket = API.templateVersionDynamicParameters(
+					template.active_version_id,
+					me.id,
+					{ onMessage },
+				);
 
-		ws.current = socket;
+				ws.current = socket;
+				return socket;
+			},
+			// An idle timeout is a clean close: park the connection instead of
+			// reconnecting in a loop, and resume on focus or the next edit.
+			shouldReconnect: (event) => !isCleanClose(event),
+			resumeOnVisible: true,
+			onOpen() {
+				setWsError(null);
+				resendCurrentInputs();
+			},
+			onParked() {
+				// Idle close is expected; surface no error while parked.
+				setWsError(null);
+			},
+			onDisconnect() {
+				setWsError(
+					new DetailedError(
+						"WebSocket connection for dynamic parameters lost.",
+						"Attempting to reconnect...",
+					),
+				);
+			},
+		});
+		reconnectWsRef.current = handle.reconnect;
 
 		return () => {
-			socket.close();
+			reconnectWsRef.current = null;
+			handle.dispose();
 		};
 	}, [template.active_version_id, me]);
 

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
@@ -23,6 +23,10 @@ import {
 } from "#/components/Tooltip/Tooltip";
 import { docs } from "#/utils/docs";
 import { pageTitle } from "#/utils/page";
+import {
+	createReconnectingWebSocket,
+	isCleanClose,
+} from "#/utils/reconnectingWebSocket";
 import type { AutofillBuildParameter } from "#/utils/richParameters";
 import { useWorkspaceSettings } from "../useWorkspaceSettings";
 import { WorkspaceParametersPageViewExperimental } from "./WorkspaceParametersPageViewExperimental";
@@ -53,6 +57,11 @@ const WorkspaceParametersPageExperimental: FC = () => {
 	const ws = useRef<WebSocket | null>(null);
 	const [wsError, setWsError] = useState<Error | null>(null);
 	const initialParamsSentRef = useRef(false);
+	// Reopens the dynamic-parameters socket after an idle (parked) close.
+	const reconnectWsRef = useRef<(() => void) | null>(null);
+	// The most recent inputs sent to the backend, re-sent on reconnect so the
+	// new connection renders against the user's current form state.
+	const lastSentInputsRef = useRef<Record<string, string> | null>(null);
 
 	const autofillParameters: AutofillBuildParameter[] =
 		latestBuildParameters?.map((p) => ({
@@ -61,6 +70,7 @@ const WorkspaceParametersPageExperimental: FC = () => {
 		})) ?? [];
 
 	const sendMessage = (formValues: Record<string, string>) => {
+		lastSentInputsRef.current = formValues;
 		const request: DynamicParametersRequest = {
 			id: wsResponseId.current + 1,
 			owner_id: workspace.owner_id,
@@ -69,7 +79,11 @@ const WorkspaceParametersPageExperimental: FC = () => {
 		if (ws.current && ws.current.readyState === WebSocket.OPEN) {
 			ws.current.send(JSON.stringify(request));
 			wsResponseId.current = wsResponseId.current + 1;
+			return;
 		}
+		// The socket is parked after an idle close. Reopen it; the onOpen
+		// handler re-sends the latest inputs once the connection is back.
+		reconnectWsRef.current?.();
 	};
 
 	// On page load, sends initial workspace build parameters to the websocket.
@@ -110,37 +124,59 @@ const WorkspaceParametersPageExperimental: FC = () => {
 		}
 	});
 
+	// On (re)connect, re-send the latest inputs so the backend renders against
+	// the user's current form state. The first connection is seeded by
+	// sendInitialParameters via onMessage instead.
+	const resendCurrentInputs = useEffectEvent(() => {
+		if (lastSentInputsRef.current) {
+			sendMessage(lastSentInputsRef.current);
+		}
+	});
+
 	useEffect(() => {
 		if (!templateVersionId && !workspace.latest_build.template_version_id)
 			return;
 
-		const socket = API.templateVersionDynamicParameters(
-			templateVersionId ?? workspace.latest_build.template_version_id,
-			workspace.owner_id,
-			{
-				onMessage,
-				onError: (error) => {
-					if (ws.current === socket) {
-						setWsError(error);
-					}
-				},
-				onClose: () => {
-					if (ws.current === socket) {
-						setWsError(
-							new DetailedError(
-								"Websocket connection for dynamic parameters unexpectedly closed.",
-								"Refresh the page to reset the form.",
-							),
-						);
-					}
-				},
-			},
-		);
+		const versionId =
+			templateVersionId ?? workspace.latest_build.template_version_id;
 
-		ws.current = socket;
+		const handle = createReconnectingWebSocket({
+			connect() {
+				const socket = API.templateVersionDynamicParameters(
+					versionId,
+					workspace.owner_id,
+					{ onMessage },
+				);
+
+				ws.current = socket;
+				return socket;
+			},
+			// An idle timeout is a clean close: park the connection instead of
+			// reconnecting in a loop, and resume on focus or the next edit.
+			shouldReconnect: (event) => !isCleanClose(event),
+			resumeOnVisible: true,
+			onOpen() {
+				setWsError(null);
+				resendCurrentInputs();
+			},
+			onParked() {
+				// Idle close is expected; surface no error while parked.
+				setWsError(null);
+			},
+			onDisconnect() {
+				setWsError(
+					new DetailedError(
+						"WebSocket connection for dynamic parameters lost.",
+						"Attempting to reconnect...",
+					),
+				);
+			},
+		});
+		reconnectWsRef.current = handle.reconnect;
 
 		return () => {
-			socket.close();
+			reconnectWsRef.current = null;
+			handle.dispose();
 		};
 	}, [
 		templateVersionId,

--- a/site/src/testHelpers/websockets.ts
+++ b/site/src/testHelpers/websockets.ts
@@ -186,14 +186,6 @@ export function mockDynamicParameterWebSocket(
 			mockWebSocket.addEventListener("message", (event) => {
 				callbacks.onMessage(JSON.parse(event.data));
 			});
-			mockWebSocket.addEventListener("error", () => {
-				callbacks.onError(
-					new Error("Connection for dynamic parameters failed."),
-				);
-			});
-			mockWebSocket.addEventListener("close", () => {
-				callbacks.onClose();
-			});
 			mockPublisher.publishOpen(new Event("open"));
 			mockPublisher.publishMessage(
 				new MessageEvent("message", { data: JSON.stringify(message) }),

--- a/site/src/utils/reconnectingWebSocket.test.ts
+++ b/site/src/utils/reconnectingWebSocket.test.ts
@@ -1,5 +1,6 @@
 import {
 	createReconnectingWebSocket,
+	isCleanClose,
 	type ReconnectSchedule,
 } from "./reconnectingWebSocket";
 
@@ -21,9 +22,9 @@ function createMockSocket() {
 		),
 		close: vi.fn(),
 		/** Fire all handlers registered for the given event type. */
-		emit(event: string) {
+		emit(event: string, payload?: unknown) {
 			for (const handler of listeners[event] ?? []) {
-				handler();
+				handler(payload);
 			}
 		},
 	};
@@ -480,7 +481,7 @@ describe("createReconnectingWebSocket", () => {
 		const socket = createMockSocket();
 		const connect = vi.fn(() => socket);
 
-		const dispose = createReconnectingWebSocket({ connect });
+		const { dispose } = createReconnectingWebSocket({ connect });
 
 		dispose();
 
@@ -500,7 +501,7 @@ describe("createReconnectingWebSocket", () => {
 			return activeSocket;
 		});
 
-		const dispose = createReconnectingWebSocket({ connect });
+		const { dispose } = createReconnectingWebSocket({ connect });
 
 		// Trigger a disconnect so a timer is scheduled.
 		activeSocket.emit("close");
@@ -518,7 +519,7 @@ describe("createReconnectingWebSocket", () => {
 		const socket = createMockSocket();
 		const connect = vi.fn(() => socket);
 
-		const dispose = createReconnectingWebSocket({ connect });
+		const { dispose } = createReconnectingWebSocket({ connect });
 
 		dispose();
 		dispose();
@@ -548,5 +549,90 @@ describe("createReconnectingWebSocket", () => {
 		expect(connect).toHaveBeenCalledTimes(1);
 		vi.advanceTimersByTime(1);
 		expect(connect).toHaveBeenCalledTimes(2);
+	});
+
+	it("parks instead of reconnecting when shouldReconnect returns false", () => {
+		let activeSocket = createMockSocket();
+		const connect = vi.fn(() => {
+			activeSocket = createMockSocket();
+			return activeSocket;
+		});
+		const onParked = vi.fn();
+		const onDisconnect = vi.fn();
+
+		createReconnectingWebSocket({
+			connect,
+			shouldReconnect: () => false,
+			onParked,
+			onDisconnect,
+		});
+		expect(connect).toHaveBeenCalledTimes(1);
+
+		activeSocket.emit("close");
+
+		expect(onParked).toHaveBeenCalledTimes(1);
+		expect(onDisconnect).not.toHaveBeenCalled();
+
+		// A parked connection schedules no reconnect timer.
+		vi.runAllTimers();
+		expect(connect).toHaveBeenCalledTimes(1);
+	});
+
+	it("reconnect() reopens a parked connection", () => {
+		let activeSocket = createMockSocket();
+		const connect = vi.fn(() => {
+			activeSocket = createMockSocket();
+			return activeSocket;
+		});
+
+		const { reconnect } = createReconnectingWebSocket({
+			connect,
+			shouldReconnect: () => false,
+		});
+		activeSocket.emit("close");
+		expect(connect).toHaveBeenCalledTimes(1);
+
+		reconnect();
+		expect(connect).toHaveBeenCalledTimes(2);
+	});
+
+	it("resumeOnVisible reconnects a parked connection on focus and stops after dispose", () => {
+		let activeSocket = createMockSocket();
+		const connect = vi.fn(() => {
+			activeSocket = createMockSocket();
+			return activeSocket;
+		});
+
+		const { dispose } = createReconnectingWebSocket({
+			connect,
+			shouldReconnect: () => false,
+			resumeOnVisible: true,
+		});
+		activeSocket.emit("close");
+		expect(connect).toHaveBeenCalledTimes(1);
+
+		window.dispatchEvent(new Event("focus"));
+		expect(connect).toHaveBeenCalledTimes(2);
+
+		// After dispose the resume listeners are removed.
+		dispose();
+		window.dispatchEvent(new Event("focus"));
+		expect(connect).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("isCleanClose", () => {
+	it("treats normal and going-away closes as clean", () => {
+		expect(
+			isCleanClose(new CloseEvent("close", { code: 1000, wasClean: true })),
+		).toBe(true);
+		expect(isCleanClose(new CloseEvent("close", { code: 1001 }))).toBe(true);
+	});
+
+	it("treats abnormal closes and non-close events as not clean", () => {
+		expect(
+			isCleanClose(new CloseEvent("close", { code: 1006, wasClean: false })),
+		).toBe(false);
+		expect(isCleanClose(new Event("error"))).toBe(false);
 	});
 });

--- a/site/src/utils/reconnectingWebSocket.ts
+++ b/site/src/utils/reconnectingWebSocket.ts
@@ -96,6 +96,29 @@ interface ReconnectingWebSocketOptions<TSocket extends Closable> {
 	 */
 	onDisconnect?: (reconnect: ReconnectSchedule) => void;
 
+	/**
+	 * Decides whether a disconnect should trigger an automatic reconnect.
+	 * Receives the `close` or `error` event. Defaults to always reconnecting.
+	 * Return `false` to "park" the connection instead: no reconnect is
+	 * scheduled and {@link onParked} fires. A parked connection can be resumed
+	 * by `resumeOnVisible` or by calling `reconnect()` on the returned handle.
+	 */
+	shouldReconnect?: (event: Event) => boolean;
+
+	/**
+	 * Called when a disconnect is parked, i.e. {@link shouldReconnect} returned
+	 * false. Fires at most once per socket instance, in place of
+	 * {@link onDisconnect}.
+	 */
+	onParked?: (event: Event) => void;
+
+	/**
+	 * When true, a parked connection reconnects automatically when the document
+	 * becomes visible or the window regains focus. Has no effect while the
+	 * connection is active or a reconnect is already scheduled.
+	 */
+	resumeOnVisible?: boolean;
+
 	/** Base delay in milliseconds. Defaults to {@link RECONNECT_BASE_MS}. */
 	baseMs?: number;
 
@@ -184,6 +207,20 @@ const getReconnectSchedule = ({
 };
 
 /**
+ * Returns true for a clean WebSocket close: the server sent a close frame
+ * with a normal status (`1000`) or going-away (`1001`), or the browser
+ * reported `wasClean`. Useful as a `shouldReconnect` predicate to park a
+ * connection on an expected close (e.g. an idle timeout) instead of
+ * reconnecting in a loop.
+ */
+export function isCleanClose(event: Event): boolean {
+	return (
+		event instanceof CloseEvent &&
+		(event.wasClean || event.code === 1000 || event.code === 1001)
+	);
+}
+
+/**
  * Creates a self-reconnecting WebSocket connection with capped
  * exponential backoff.
  *
@@ -203,15 +240,34 @@ const getReconnectSchedule = ({
  *
  * The reconnect attempt counter resets after a successful `open`.
  *
- * @returns A dispose function that tears down the connection.
+ * @returns A handle with `dispose` (tears down the connection) and
+ * `reconnect` (manually reopens a parked or closed connection).
  */
+export interface ReconnectingWebSocketHandle {
+	/**
+	 * Tears down the connection: closes the active socket, cancels any pending
+	 * reconnection timer, removes resume listeners, and prevents further
+	 * reconnection attempts. Safe to call more than once.
+	 */
+	dispose: () => void;
+	/**
+	 * Reopens the connection immediately. Cancels any pending reconnect timer,
+	 * clears the parked state, and resets the backoff counter. No-op after
+	 * dispose.
+	 */
+	reconnect: () => void;
+}
+
 export function createReconnectingWebSocket<TSocket extends Closable>(
 	options: ReconnectingWebSocketOptions<TSocket>,
-): () => void {
+): ReconnectingWebSocketHandle {
 	const {
 		connect: connectFn,
 		onOpen,
 		onDisconnect,
+		shouldReconnect = () => true,
+		onParked,
+		resumeOnVisible = false,
 		baseMs = RECONNECT_BASE_MS,
 		maxMs = RECONNECT_MAX_MS,
 		factor = RECONNECT_FACTOR,
@@ -220,19 +276,20 @@ export function createReconnectingWebSocket<TSocket extends Closable>(
 	} = options;
 
 	let disposed = false;
+	let parked = false;
 	let lastReconnectAttempt = 0;
 	let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 	let activeSocket: TSocket | null = null;
 
-	const scheduleReconnect = (reconnect: ReconnectSchedule) => {
+	const scheduleReconnect = (schedule: ReconnectSchedule) => {
 		if (disposed) {
 			return;
 		}
 		if (reconnectTimer !== null) {
 			clearTimeout(reconnectTimer);
 		}
-		lastReconnectAttempt = reconnect.attempt;
-		reconnectTimer = setTimeout(connect, reconnect.delayMs);
+		lastReconnectAttempt = schedule.attempt;
+		reconnectTimer = setTimeout(connect, schedule.delayMs);
 	};
 
 	function connect() {
@@ -240,6 +297,7 @@ export function createReconnectingWebSocket<TSocket extends Closable>(
 		if (disposed) {
 			return;
 		}
+		parked = false;
 		if (activeSocket) {
 			activeSocket.close();
 		}
@@ -248,12 +306,12 @@ export function createReconnectingWebSocket<TSocket extends Closable>(
 		activeSocket = socket;
 
 		const handleOpen = () => {
-			// Connection succeeded — reset backoff.
+			// Connection succeeded, reset backoff.
 			lastReconnectAttempt = 0;
 			onOpen?.(socket);
 		};
 
-		const handleDisconnect = () => {
+		const handleDisconnect = (event: Event) => {
 			// Guard against duplicate calls: browsers fire both "error"
 			// and "close" on a failed WebSocket, so we only process the
 			// first event per socket instance.
@@ -261,7 +319,16 @@ export function createReconnectingWebSocket<TSocket extends Closable>(
 				return;
 			}
 			activeSocket = null;
-			const reconnect = getReconnectSchedule({
+
+			if (!shouldReconnect(event)) {
+				// Park: leave the connection closed until something resumes it
+				// (resumeOnVisible or a manual reconnect call).
+				parked = true;
+				onParked?.(event);
+				return;
+			}
+
+			const schedule = getReconnectSchedule({
 				attempt: lastReconnectAttempt + 1,
 				baseMs,
 				maxMs,
@@ -269,26 +336,66 @@ export function createReconnectingWebSocket<TSocket extends Closable>(
 				jitter,
 				random,
 			});
-			onDisconnect?.(reconnect);
-			scheduleReconnect(reconnect);
+			onDisconnect?.(schedule);
+			scheduleReconnect(schedule);
 		};
 
 		socket.addEventListener("open", handleOpen);
-		socket.addEventListener("error", handleDisconnect);
-		socket.addEventListener("close", handleDisconnect);
+		socket.addEventListener("error", (event) =>
+			handleDisconnect(event as Event),
+		);
+		socket.addEventListener("close", (event) =>
+			handleDisconnect(event as Event),
+		);
+	}
+
+	const reconnect = () => {
+		if (disposed) {
+			return;
+		}
+		if (reconnectTimer !== null) {
+			clearTimeout(reconnectTimer);
+			reconnectTimer = null;
+		}
+		lastReconnectAttempt = 0;
+		connect();
+	};
+
+	// Resume a parked connection when the tab becomes visible or focused.
+	const handleResume = () => {
+		if (disposed || !parked) {
+			return;
+		}
+		if (
+			typeof document !== "undefined" &&
+			document.visibilityState !== "visible"
+		) {
+			return;
+		}
+		reconnect();
+	};
+	const resumeEnabled = resumeOnVisible && typeof window !== "undefined";
+	if (resumeEnabled) {
+		window.addEventListener("focus", handleResume);
+		document.addEventListener("visibilitychange", handleResume);
 	}
 
 	// Kick off the first connection.
 	connect();
 
-	// Return a dispose function that tears everything down.
-	return () => {
+	const dispose = () => {
 		disposed = true;
 		if (reconnectTimer !== null) {
 			clearTimeout(reconnectTimer);
+		}
+		if (resumeEnabled) {
+			window.removeEventListener("focus", handleResume);
+			document.removeEventListener("visibilitychange", handleResume);
 		}
 		if (activeSocket) {
 			activeSocket.close();
 		}
 	};
+
+	return { dispose, reconnect };
 }


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

Fixes #20846. Supersedes #22941 (the branch was rebased onto `main`, so the original PR could no longer be reopened).

## Problem

The dynamic parameters WebSocket used a hard 30-minute deadline and never reconnected. Long-lived forms (creating a workspace, editing parameters, embedding a template) would silently lose their connection, with no recovery and no way to resume.

## Changes

### Backend (`coderd`)

- Replace the hard 30-minute timeout with a renewable **3-minute idle timeout**. Each client message resets the timer, so active sessions stay alive and only abandoned connections are reaped.
- Close an idle connection with `StatusNormalClosure` (1000) so the client can tell an expected idle close apart from an abnormal disconnect, which uses `StatusGoingAway` (1001).
- Make the timeout injectable via `Options.DynamicParametersIdleTimeout` so it can be driven by a mock `quartz` clock in tests.

### Frontend (`site`)

- Extend `createReconnectingWebSocket` with opt-in `shouldReconnect`, `onParked`, and `resumeOnVisible` options, and return a `{ dispose, reconnect }` handle.
- On a **clean close** (idle timeout), the connection is *parked*: no error banner, no retry loop. It resumes on focus, visibility change, or the next interaction.
- On an **abnormal close** while the tab is visible, it reconnects with capped exponential backoff and shows an error banner.
- On reconnect, the error state is cleared and the last sent inputs are re-sent so the rendered parameters resync with the server.
- Wire this into all three dynamic-parameter pages: `CreateWorkspacePage`, `WorkspaceParametersPageExperimental`, and `TemplateEmbedPage`.
- Remove the now-unused `onError`/`onClose` callbacks from `templateVersionDynamicParameters`; lifecycle is owned by `createReconnectingWebSocket`. The four existing chat callers are updated for the new `{ dispose }` return shape.

## Testing

- `go test ./coderd/ -run TestDynamicParameters` — new `TestDynamicParametersWebsocketIdleTimeout` drives a mock clock to assert idle-timer renewal and the normal-closure status. Passes with `-race -count=3`.
- Frontend: extended `reconnectingWebSocket.test.ts` (park/reconnect/resume/`isCleanClose`) and `CreateWorkspacePage.test.tsx` (clean-close shows no banner; abnormal-close does). `tsc` and `biome check` clean.

<details>
<summary>Design decisions</summary>

- **Idle vs. hard timeout:** a renewable idle timeout keeps active sessions alive indefinitely while still reaping abandoned ones, instead of cutting off users mid-edit at 30 minutes.
- **Close-code discriminator:** an `idledOut` atomic flag set in the timer callback lets the same `ctx.Done()` path close with 1000 (idle) vs. 1001 (going away), so the client can choose park vs. retry without guessing.
- **Park instead of retry on clean close:** reconnecting in a loop against an intentional idle close wastes connections and flashes error UI. Parking + resume-on-visible matches user intent and reconnects exactly when the form is back in use.
- **Resync on reconnect:** re-sending the last inputs on `onOpen` guarantees the rendered parameters reflect the current form after any gap, replacing dead reset logic that never actually re-sent state.
- **Injectable timeout + mock clock:** the test clock is kept below the 15s heartbeat interval so advancing past the idle deadline never races a `WSWatcher` ping.

</details>
