### PR TITLE
refactor: rename "AI Bridge" to "AI Gateway" in the UI

### DIFF
--- a/enterprise/coderd/license/license.go
+++ b/enterprise/coderd/license/license.go
@@ -566,7 +566,7 @@ func LicensesEntitlements(
 		aiBridgeFeature := entitlements.Features[codersdk.FeatureAIBridge]
 		if aiBridgeFeature.Enabled && aiBridgeFeature.Entitlement.Entitled() && !hasExplicitAIBridgeEntitlement {
 			entitlements.Warnings = append(entitlements.Warnings,
-				"The AI Governance add-on is required to use AI Bridge. Please reach out to your account team or sales@coder.com to learn more.")
+				"The AI Governance add-on is required to use AI Gateway. Please reach out to your account team or sales@coder.com to learn more.")
 		}
 	}
 

--- a/enterprise/coderd/license/license_test.go
+++ b/enterprise/coderd/license/license_test.go
@@ -1590,7 +1590,7 @@ func TestAIBridgeSoftWarning(t *testing.T) {
 		codersdk.FeatureAIBridge: false,
 	}
 
-	aiBridgeWarningMessage := "The AI Governance add-on is required to use AI Bridge. Please reach out to your account team or sales@coder.com to learn more."
+	aiBridgeWarningMessage := "The AI Governance add-on is required to use AI Gateway. Please reach out to your account team or sales@coder.com to learn more."
 
 	t.Run("NoAddon_AIBridgeOff", func(t *testing.T) {
 		t.Parallel()
@@ -2170,7 +2170,7 @@ func TestAIGovernanceAddon(t *testing.T) {
 		// AI Bridge should be enabled without warning when addon is present.
 		aibridgeFeature := entitlements.Features[codersdk.FeatureAIBridge]
 		require.True(t, aibridgeFeature.Enabled, "AI Bridge should be enabled when addon is present and enablements are set")
-		aiBridgeWarningMessage := "The AI Governance add-on is required to use AI Bridge. Please reach out to your account team or sales@coder.com to learn more."
+		aiBridgeWarningMessage := "The AI Governance add-on is required to use AI Gateway. Please reach out to your account team or sales@coder.com to learn more."
 		require.NotContains(t, entitlements.Warnings, aiBridgeWarningMessage, "AI Bridge warning should not appear when AI Governance addon is present")
 
 		// require.Equal(t, codersdk.EntitlementEntitled, aibridgeFeature.Entitlement, "AI Bridge should be entitled when addon is present")

--- a/site/src/modules/users/UserHelpPopovers.tsx
+++ b/site/src/modules/users/UserHelpPopovers.tsx
@@ -57,7 +57,7 @@ export const AiAddonHelpPopover: FC = () => {
 			<HelpPopoverContent>
 				<HelpPopoverTitle>What is the AI add-on?</HelpPopoverTitle>
 				<HelpPopoverText>
-					Users with access to AI features like AI Bridge or Tasks who are
+					Users with access to AI features like AI Gateway or Tasks who are
 					actively consuming a seat.
 				</HelpPopoverText>
 			</HelpPopoverContent>

--- a/site/src/pages/AIBridgePage/AIBridgeHelpPopover.tsx
+++ b/site/src/pages/AIBridgePage/AIBridgeHelpPopover.tsx
@@ -16,13 +16,13 @@ export const AIBridgeHelpPopover: FC = () => {
 			<HelpPopoverIconTrigger />
 
 			<HelpPopoverContent>
-				<HelpPopoverTitle>What is AI Bridge?</HelpPopoverTitle>
+				<HelpPopoverTitle>What is AI Gateway?</HelpPopoverTitle>
 				<HelpPopoverText>
-					AI Bridge is a smart gateway for AI that provides centralized
+					AI Gateway is a smart gateway for AI that provides centralized
 					management, auditing, and attribution for LLM usage.
 				</HelpPopoverText>
 				<HelpPopoverLinksGroup>
-					<HelpPopoverLink href={docs("/ai-coder/ai-bridge")}>
+					<HelpPopoverLink href={docs("/ai-coder/ai-gateway")}>
 						Read the docs
 					</HelpPopoverLink>
 				</HelpPopoverLinksGroup>

--- a/site/src/pages/AIBridgePage/AIBridgeLayout.tsx
+++ b/site/src/pages/AIBridgePage/AIBridgeLayout.tsx
@@ -14,7 +14,7 @@ const AIBridgeLayout: FC<PropsWithChildren> = () => {
 			<PageHeader>
 				<PageHeaderTitle>
 					<div className="flex items-center gap-2">
-						<span>AI Bridge Logs</span>
+						<span>AI Gateway Logs</span>
 						<AIBridgeHelpPopover />
 					</div>
 				</PageHeaderTitle>

--- a/site/src/pages/AIBridgePage/AIBridgeSetupAlert.tsx
+++ b/site/src/pages/AIBridgePage/AIBridgeSetupAlert.tsx
@@ -7,13 +7,13 @@ export const AIBridgeSetupAlert: FC = () => {
 	return (
 		<Alert className="mb-12" severity="warning" prominent>
 			<AlertTitle>
-				AI Bridge is included in your license, but not set up yet.
+				AI Gateway is included in your license, but not set up yet.
 			</AlertTitle>
 			<AlertDescription>
 				You have access to AI Governance, but it still needs to be setup. Check
 				out the{" "}
-				<Link href={docs("/ai-coder/ai-bridge")} target="_blank">
-					AI Bridge
+				<Link href={docs("/ai-coder/ai-gateway")} target="_blank">
+					AI Gateway
 				</Link>{" "}
 				documentation to get started.
 			</AlertDescription>

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsPage.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsPage.tsx
@@ -76,7 +76,7 @@ const AISessionListPage: FC = () => {
 
 	return (
 		<RequirePermission isFeatureVisible={hasPermission}>
-			<title>{pageTitle("Sessions", "AI Bridge")}</title>
+			<title>{pageTitle("Sessions", "AI Gateway")}</title>
 
 			<ListSessionsPageView
 				isLoading={sessionsQuery.isLoading}

--- a/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsPage.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsPage.tsx
@@ -74,7 +74,7 @@ const RequestLogsPage: FC = () => {
 
 	return (
 		<RequirePermission isFeatureVisible={hasPermission}>
-			<title>{pageTitle("Request Logs", "AI Bridge")}</title>
+			<title>{pageTitle("Request Logs", "AI Gateway")}</title>
 
 			<RequestLogsPageView
 				isLoading={interceptionsQuery.isLoading}

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionThreadsPage.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionThreadsPage.tsx
@@ -35,7 +35,7 @@ const SessionThreadsPage: FC = () => {
 
 	return (
 		<RequirePermission isFeatureVisible={hasPermission}>
-			<title>{pageTitle("Session Threads", "AI Bridge")}</title>
+			<title>{pageTitle("Session Threads", "AI Gateway")}</title>
 
 			<SessionThreadsPageView
 				session={firstPage}

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionThreadsPageView.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionThreadsPageView.tsx
@@ -82,7 +82,7 @@ export const SessionThreadsPageView: FC<SessionThreadsPageViewProps> = ({
 					asChild
 					variant="outline"
 					size="lg"
-					title="Back to AI Bridge sessions list"
+					title="Back to AI Gateway sessions list"
 					onClick={onBackClicked}
 				>
 					<span>


### PR DESCRIPTION
Renames all user-visible "AI Bridge" strings to "AI Gateway" in the browser UI as part of the AI Bridge to AI Gateway rebrand (AIGOV-233).

Changes:
- Page titles and headings ("AI Bridge Logs" to "AI Gateway Logs", `pageTitle` calls)
- Help popover title, description, and doc link
- Setup alert title, description, and doc link
- Back-link tooltip on session threads page
- AI add-on help popover text
- License entitlement warning shown in the dashboard banner

Doc links updated from `/ai-coder/ai-bridge` to `/ai-coder/ai-gateway` (directory already exists).

This PR intentionally does not rename internal identifiers, file/directory names, API endpoints, routes, CLI help, deployment config options, or generated types. Those will be tracked separately.

Related to: https://linear.app/codercom/issue/AIGOV-233

> Generated by Coder Agents on behalf of @ssncferreira