### PR TITLE
docs: rename "AI Bridge" to "AI Gateway"

### DIFF
--- a/docs/ai-coder/ai-gateway/ai-gateway-proxy/setup.md
+++ b/docs/ai-coder/ai-gateway/ai-gateway-proxy/setup.md
@@ -311,7 +311,7 @@ Consult the tool's documentation for specific instructions.
 Download the certificate:
 
 ```shell
-curl -o coder-aibridge-proxy-ca.pem \
+curl -o coder-ai-gateway-proxy-ca.pem \
   -H "Coder-Session-Token: ${CODER_SESSION_TOKEN}" \
   https://<coder-url>/api/v2/aibridge/proxy/ca-cert.pem
 ```
@@ -322,7 +322,7 @@ When [TLS is enabled](#proxy-tls-configuration) on the proxy, AI tools must trus
 Combine both certificates into a single PEM file:
 
 ```shell
-cat coder-aibridge-proxy-ca.pem listener.crt > combined-ca.pem
+cat coder-ai-gateway-proxy-ca.pem listener.crt > combined-ca.pem
 ```
 
 Use this combined file for any of the environment variables listed below.
@@ -342,10 +342,10 @@ Set the environment variables associated with the AI tool's runtime.
 If you're unsure which runtime the tool uses, or if you use multiple AI tools, the simplest approach is to set all of them:
 
 ```shell
-export NODE_EXTRA_CA_CERTS="/path/to/coder-aibridge-proxy-ca.pem"
-export SSL_CERT_FILE="/path/to/coder-aibridge-proxy-ca.pem"
-export REQUESTS_CA_BUNDLE="/path/to/coder-aibridge-proxy-ca.pem"
-export CURL_CA_BUNDLE="/path/to/coder-aibridge-proxy-ca.pem"
+export NODE_EXTRA_CA_CERTS="/path/to/coder-ai-gateway-proxy-ca.pem"
+export SSL_CERT_FILE="/path/to/coder-ai-gateway-proxy-ca.pem"
+export REQUESTS_CA_BUNDLE="/path/to/coder-ai-gateway-proxy-ca.pem"
+export CURL_CA_BUNDLE="/path/to/coder-ai-gateway-proxy-ca.pem"
 ```
 
 #### System trust store
@@ -356,7 +356,7 @@ This makes the certificate trusted by all applications on the system.
 On Linux:
 
 ```shell
-sudo cp coder-aibridge-proxy-ca.pem /usr/local/share/ca-certificates/
+sudo cp coder-ai-gateway-proxy-ca.pem /usr/local/share/ca-certificates/
 sudo update-ca-certificates
 ```
 

--- a/docs/ai-coder/ai-gateway/clients/codex.md
+++ b/docs/ai-coder/ai-gateway/clients/codex.md
@@ -12,10 +12,10 @@ Codex CLI can be configured to use AI Gateway by setting up a custom model provi
 To configure Codex CLI to use AI Gateway, set the following configuration options in your Codex configuration file (e.g., `~/.codex/config.toml`):
 
 ```toml
-model_provider = "aibridge"
+model_provider = "ai_gateway"
 
-[model_providers.aibridge]
-name = "AI Bridge"
+[model_providers.ai_gateway]
+name = "AI Gateway"
 base_url = "<your-deployment-url>/api/v2/aibridge/openai/v1"
 env_key = "OPENAI_API_KEY"
 wire_api = "responses"
@@ -27,17 +27,17 @@ To authenticate with AI Gateway, get your **[Coder API token](../../../admin/use
 export OPENAI_API_KEY="<your-coder-api-token>"
 ```
 
-Run Codex as usual. It will automatically use the `aibridge` model provider from your configuration.
+Run Codex as usual. It will automatically use the `ai_gateway` model provider from your configuration.
 
 ## BYOK (Personal API Key)
 
 Add the following to your Codex configuration file (e.g., `~/.codex/config.toml`):
 
 ```toml
-model_provider = "aibridge"
+model_provider = "ai_gateway"
 
-[model_providers.aibridge]
-name = "AI Bridge"
+[model_providers.ai_gateway]
+name = "AI Gateway"
 base_url = "<your-deployment-url>/api/v2/aibridge/openai/v1"
 wire_api = "responses"
 requires_openai_auth = true
@@ -59,10 +59,10 @@ export CODER_API_TOKEN="<your-coder-api-token>"
 Add the following to your Codex configuration file (e.g., `~/.codex/config.toml`):
 
 ```toml
-model_provider = "aibridge"
+model_provider = "ai_gateway"
 
-[model_providers.aibridge]
-name = "AI Bridge"
+[model_providers.ai_gateway]
+name = "AI Gateway"
 base_url = "<your-deployment-url>/api/v2/aibridge/chatgpt/v1"
 wire_api = "responses"
 requires_openai_auth = true

--- a/docs/ai-coder/ai-gateway/clients/copilot.md
+++ b/docs/ai-coder/ai-gateway/clients/copilot.md
@@ -40,7 +40,7 @@ Note: if [TLS is not enabled](../ai-gateway-proxy/setup.md#proxy-tls-configurati
 Copilot CLI is built on Node.js and uses the `NODE_EXTRA_CA_CERTS` environment variable for custom certificates:
 
 ```shell
-export NODE_EXTRA_CA_CERTS="/path/to/coder-aibridge-proxy-ca.pem"
+export NODE_EXTRA_CA_CERTS="/path/to/coder-ai-gateway-proxy-ca.pem"
 ```
 
 See [Client Configuration CA certificate trust](../ai-gateway-proxy/setup.md#trusting-the-ca-certificate) for details on how to obtain the certificate file.
@@ -48,7 +48,7 @@ See [Client Configuration CA certificate trust](../ai-gateway-proxy/setup.md#tru
 When [TLS is enabled](../ai-gateway-proxy/setup.md#proxy-tls-configuration) on the proxy, combine the MITM CA certificate and the TLS certificate into a single file:
 
 ```shell
-cat coder-aibridge-proxy-ca.pem listener.crt > combined-ca.pem
+cat coder-ai-gateway-proxy-ca.pem listener.crt > combined-ca.pem
 export NODE_EXTRA_CA_CERTS="/path/to/combined-ca.pem"
 ```
 

--- a/docs/ai-coder/ai-gateway/clients/copilot.md
+++ b/docs/ai-coder/ai-gateway/clients/copilot.md
@@ -17,7 +17,7 @@ For general information about GitHub Copilot, see the [GitHub Copilot documentat
 For general client configuration requirements, see [AI Gateway Proxy Client Configuration](../ai-gateway-proxy/setup.md#client-configuration).
 The sections below cover Copilot-specific setup for each client.
 
-For provider configuration (admin), see [GitHub Copilot provider setup](../setup.md#github-copilot).
+For provider configuration (admin), see [GitHub Copilot provider setup](../providers.md#github-copilot).
 
 ## Copilot CLI
 

--- a/docs/ai-coder/ai-gateway/clients/factory.md
+++ b/docs/ai-coder/ai-gateway/clients/factory.md
@@ -19,7 +19,7 @@ Factort's Droid agent can be configured to use AI Gateway by setting up custom m
   "customModels": [
     {
       "model": "claude-sonnet-4-5-20250929",
-      "displayName": "Claude (Coder AI Bridge)",
+      "displayName": "Claude (Coder AI Gateway)",
       "baseUrl": "https://coder.example.com/api/v2/aibridge/anthropic",
       "apiKey": "<your-coder-api-token>",
       "provider": "anthropic",
@@ -27,7 +27,7 @@ Factort's Droid agent can be configured to use AI Gateway by setting up custom m
     },
     {
       "model": "gpt-5.2-codex",
-      "displayName": "GPT (Coder AI Bridge)",
+      "displayName": "GPT (Coder AI Gateway)",
       "baseUrl": "https://coder.example.com/api/v2/aibridge/openai/v1",
       "apiKey": "<your-coder-api-token>",
       "provider": "openai",
@@ -40,7 +40,7 @@ Factort's Droid agent can be configured to use AI Gateway by setting up custom m
 ## BYOK (Personal API Key)
 
 1. Open `~/.factory/settings.json` (create it if it does not exist).
-2. Add a `customModels` entry for each provider you want to use with AI Bridge.
+2. Add a `customModels` entry for each provider you want to use with AI Gateway.
 3. Replace `coder.example.com` with your Coder deployment URL.
 4. Use your personal API key for `apiKey`.
 5. Set the `X-Coder-AI-Governance-Token` header to your **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.
@@ -50,7 +50,7 @@ Factort's Droid agent can be configured to use AI Gateway by setting up custom m
   "customModels": [
     {
       "model": "claude-sonnet-4-5-20250929",
-      "displayName": "Claude (Coder AI Bridge)",
+      "displayName": "Claude (Coder AI Gateway)",
       "baseUrl": "https://coder.example.com/api/v2/aibridge/anthropic",
       "apiKey": "<your-anthropic-api-key>",
       "provider": "anthropic",
@@ -61,7 +61,7 @@ Factort's Droid agent can be configured to use AI Gateway by setting up custom m
     },
     {
       "model": "gpt-5.2-codex",
-      "displayName": "GPT (Coder AI Bridge)",
+      "displayName": "GPT (Coder AI Gateway)",
       "baseUrl": "https://coder.example.com/api/v2/aibridge/openai/v1",
       "apiKey": "<your-openai-api-key>",
       "provider": "openai",

--- a/docs/ai-coder/ai-gateway/clients/index.md
+++ b/docs/ai-coder/ai-gateway/clients/index.md
@@ -110,7 +110,7 @@ For other clients setup [AI Gateway Proxy](../ai-gateway-proxy/index.md). Config
 
 ```sh
 export HTTPS_PROXY="https://coder:<your-coder-api-token>@<proxy-host>:8888"
-export SSL_CERT_FILE="/path/to/coder-aibridge-proxy-ca.pem"
+export SSL_CERT_FILE="/path/to/coder-ai-gateway-proxy-ca.pem"
 ```
 
 For proxy setup details, see [AI Gateway Proxy setup](../ai-gateway-proxy/setup.md).

--- a/docs/ai-coder/ai-gateway/monitoring.md
+++ b/docs/ai-coder/ai-gateway/monitoring.md
@@ -57,7 +57,7 @@ external proxy.
 
 ## Structured Logging
 
-AI Bridge can emit structured logs for every interception event to your
+AI Gateway can emit structured logs for every interception event to your
 existing log pipeline. This is useful for exporting data to external SIEM or
 observability platforms. See [Structured Logging](./setup.md#structured-logging)
 in the setup guide for configuration and a full list of record types.


### PR DESCRIPTION
Updates hand-written documentation to use "AI Gateway" instead of "AI Bridge" as a follow-up to the UI rename in https://github.com/coder/coder/pull/26161#issuecomment-4660014072.

Changed files:
- `docs/ai-coder/ai-gateway/clients/codex.md` — display name and config key (`aibridge` to `ai_gateway`) in TOML config examples
- `docs/ai-coder/ai-gateway/clients/factory.md` — display names in JSON config examples and prose
- `docs/ai-coder/ai-gateway/monitoring.md` — structured logging description
- `docs/ai-coder/ai-gateway/ai-gateway-proxy/setup.md` — CA cert example filenames (`coder-aibridge-proxy-ca.pem` to `coder-ai-gateway-proxy-ca.pem`)
- `docs/ai-coder/ai-gateway/clients/copilot.md` — CA cert example filenames
- `docs/ai-coder/ai-gateway/clients/index.md` — CA cert example filename

Generated reference docs (`docs/reference/cli/`, `docs/reference/api/`) and `docs/manifest.json` are generated from Go code and will update automatically via `make gen` in the context of AIGOV-230 (API swagger tags) and AIGOV-231 (CLI help). 

Refs https://linear.app/codercom/issue/AIGOV-233

> Generated by Coder Agents on behalf of @ssncferreira