### PR TITLE
fix(agent/agentcontext): canonicalize scan root in symlink boundary check

### DIFF
--- a/agent/agentcontext/api_test.go
+++ b/agent/agentcontext/api_test.go
@@ -61,7 +61,7 @@ func TestAPI_ListSourcesEmpty(t *testing.T) {
 func TestAPI_AddAndListSource(t *testing.T) {
 	t.Parallel()
 	wd := t.TempDir()
-	src := t.TempDir()
+	src := testutil.TempDirResolved(t)
 
 	srv, _ := newAPITestServer(t, agentcontext.ManagerOptions{
 		WorkingDir:   func() string { return wd },
@@ -103,7 +103,7 @@ func TestAPI_AddSourceRejected(t *testing.T) {
 func TestAPI_GetAndDeleteSource(t *testing.T) {
 	t.Parallel()
 	wd := t.TempDir()
-	src := t.TempDir()
+	src := testutil.TempDirResolved(t)
 
 	srv, m := newAPITestServer(t, agentcontext.ManagerOptions{
 		WorkingDir:   func() string { return wd },

--- a/agent/agentcontext/manager_test.go
+++ b/agent/agentcontext/manager_test.go
@@ -67,8 +67,8 @@ func TestManager_InitialSnapshotIsPopulated(t *testing.T) {
 
 func TestManager_AddSourceTriggersResolve(t *testing.T) {
 	t.Parallel()
-	wd := t.TempDir()
-	src := t.TempDir()
+	wd := testutil.TempDirResolved(t)
+	src := testutil.TempDirResolved(t)
 	mustWriteFile(t, filepath.Join(src, "AGENTS.md"), "from source")
 
 	m := newTestManager(t, agentcontext.ManagerOptions{
@@ -194,7 +194,7 @@ func TestManager_RemoveSource(t *testing.T) {
 func TestManager_HasSource(t *testing.T) {
 	t.Parallel()
 	wd := t.TempDir()
-	src := t.TempDir()
+	src := testutil.TempDirResolved(t)
 
 	m := newTestManager(t, agentcontext.ManagerOptions{
 		WorkingDir:   func() string { return wd },
@@ -285,7 +285,7 @@ func TestManager_ResyncCanceledKeepsLiveSnapshot(t *testing.T) {
 func TestManager_InitialSourcesSeeded(t *testing.T) {
 	t.Parallel()
 	wd := t.TempDir()
-	src := t.TempDir()
+	src := testutil.TempDirResolved(t)
 	mustWriteFile(t, filepath.Join(src, "AGENTS.md"), "from initial")
 
 	m := newTestManager(t, agentcontext.ManagerOptions{
@@ -312,7 +312,7 @@ func TestManager_InitialSourcesSeeded(t *testing.T) {
 func TestManager_SeedSourcesLateBindsAfterManifest(t *testing.T) {
 	t.Parallel()
 	wd := t.TempDir()
-	late := t.TempDir()
+	late := testutil.TempDirResolved(t)
 	mustWriteFile(t, filepath.Join(late, "AGENTS.md"), "late binding")
 
 	// AllowedRoots intentionally omits `late` so AddSource

--- a/agent/agentcontext/paths_test.go
+++ b/agent/agentcontext/paths_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/agent/agentcontext"
+	"github.com/coder/coder/v2/testutil"
 )
 
 // switchHomeEnv overrides the platform-specific environment
@@ -99,7 +100,7 @@ func TestValidateSourcePath_RejectsParentSegments(t *testing.T) {
 
 func TestValidateSourcePath_AllowsInsideRoot(t *testing.T) {
 	t.Parallel()
-	dir := t.TempDir()
+	dir := testutil.TempDirResolved(t)
 	child := filepath.Join(dir, "child")
 	require.NoError(t, os.MkdirAll(child, 0o755))
 

--- a/agent/agentcontext/resolve.go
+++ b/agent/agentcontext/resolve.go
@@ -368,7 +368,16 @@ func resolveReadTarget(path string, info fs.FileInfo, scanRoot string) (readPath
 	if err != nil {
 		return "", nil, false, StatusUnreadable, fmt.Sprintf("symlink resolve: %v", err)
 	}
+	// Canonicalize scanRoot symmetrically with the target so the
+	// boundary check survives platform-level symlinks in the scan
+	// root prefix. macOS, for example, exposes /var as a symlink
+	// to /private/var; EvalSymlinks on the target produces a
+	// /private/var path while the caller's scanRoot may still be
+	// /var, which would incorrectly trip the prefix check.
 	rootClean := filepath.Clean(scanRoot)
+	if resolved, err := filepath.EvalSymlinks(rootClean); err == nil {
+		rootClean = resolved
+	}
 	if !pathHasPrefix(target, rootClean) {
 		return "", nil, false, StatusInvalid, fmt.Sprintf("symlink target %q escapes scan root %q", target, scanRoot)
 	}


### PR DESCRIPTION
## Summary

Fixes [coder/internal#1574](https://github.com/coder/internal/issues/1574): macOS test flakes in `agent/agentcontext` caused by `/var` being a symlink to `/private/var`.

## Root cause

On macOS, `t.TempDir()` returns paths under `/var/folders/...` while `filepath.EvalSymlinks` (and the package's `CanonicalizePath`) resolves them to `/private/var/folders/...`. Two distinct symptoms followed:

1. **Production bug in `resolveReadTarget`** (caused `TestResolver_SymlinkInsideScanRootAllowed`). The symlink boundary check resolved the target via `EvalSymlinks` but only `filepath.Clean`ed the scan root, so a `/private/var/.../target` was rejected as escaping a `/var/.../scanRoot`. This is a real production hazard: the working directory provided to the `Manager` is not canonicalized before being added to scan roots, so a workspace mounted under a symlinked prefix would have legitimate in-root symlinks rejected as `StatusInvalid`.
2. **Test-only path mismatch** (caused the rest). Tests compared the raw `t.TempDir()` against paths returned by `Manager.AddSource`, `Manager.HasSource`, `Manager.Sources`, `Manager.Snapshot`, and the HTTP API, all of which return canonical paths.

## Fix

- `resolveReadTarget` now applies `filepath.EvalSymlinks` to the scan root before the prefix check, symmetrically with the target. Escaping targets are still rejected. This mirrors the same lenient `EvalSymlinks` pattern already used in `agent/agentgit/agentgit.go` and `agent/x/agentmcp/configwatcher.go`.
- Tests now use the existing `testutil.TempDirResolved(t)` helper (already used by `agentmcp` and `agentgit` tests for exactly this macOS issue) for temp dirs whose paths are compared against `Manager`/API outputs.

The pre-existing security tests (`TestResolver_SymlinkOutsideScanRootRejected`, `TestValidateSourcePath_RejectsOutsideRoot`, etc.) still pass, so the symlink boundary remains enforced.

## Verification

Reproduced the macOS failure on Linux by constructing a temp tree where the scan root is reached through a synthetic symlinked prefix (mimicking `/var` -> `/private/var`). With only the production fix applied, the resolver case passes. With the test-side fixes applied, all previously-failing tests in the issue pass under `go test ./agent/agentcontext -count=5` and `go test -race ./agent/agentcontext -count=2`.

<details>
<summary>Failing tests covered</summary>

- `TestResolver_SymlinkInsideScanRootAllowed`
- `TestManager_HasSource`
- `TestManager_SeedSourcesLateBindsAfterManifest`
- `TestManager_InitialSourcesSeeded`
- `TestManager_AddSourceTriggersResolve`
- `TestValidateSourcePath_AllowsInsideRoot`
- `TestAPI_GetAndDeleteSource`
- `TestAPI_AddAndListSource`

</details>

---

_Authored by Coder Agents on behalf of @kylecarbs._