### PR TITLE
chore(coderd/idpsync): remove stale TODO

### DIFF
--- a/coderd/idpsync/idpsync.go
+++ b/coderd/idpsync/idpsync.go
@@ -22,7 +22,6 @@ import (
 // and just swap the underlying implementation.
 // IDPSync exists to contain all the logic for mapping a user's external IDP
 // claims to the internal representation of a user in Coder.
-// TODO: Move group + role sync into this interface.
 type IDPSync interface {
 	OrganizationSyncEntitled() bool
 	OrganizationSyncSettings(ctx context.Context, db database.Store) (*OrganizationSyncSettings, error)


### PR DESCRIPTION
The `IDPSync` interface comment carried a TODO from #14432 to move group and role sync into the interface. That happened in #14578 and #14649, so the TODO is no longer applicable.

> [!NOTE]
> This PR was generated by a Coder agent on behalf of @aslilac.