### PR TITLE
fix(agent/agentcontainers): forward execer args without shell interpretation

### DIFF
--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -3920,19 +3920,15 @@ func TestAPI(t *testing.T) {
 		// Call RefreshContainers directly to trigger CommandEnv usage.
 		_ = api.RefreshContainers(ctx) // Ignore error since docker commands will fail.
 
-		// Verify commands were executed through the custom shell and environment.
+		// Verify commands were executed through the custom environment.
 		require.NotEmpty(t, fakeExec.commands, "commands should be executed")
 
-		// Want: /bin/custom-shell -c '"docker" "ps" "--all" "--quiet" "--no-trunc"'
-		require.Equal(t, testShell, fakeExec.commands[0][0], "custom shell should be used")
-		if runtime.GOOS == "windows" {
-			require.Equal(t, "/c", fakeExec.commands[0][1], "shell should be called with /c on Windows")
-		} else {
-			require.Equal(t, "-c", fakeExec.commands[0][1], "shell should be called with -c")
-		}
-		require.Len(t, fakeExec.commands[0], 3, "command should have 3 arguments")
-		require.GreaterOrEqual(t, strings.Count(fakeExec.commands[0][2], " "), 2, "command/script should have multiple arguments")
-		require.True(t, strings.HasPrefix(fakeExec.commands[0][2], `"docker" "ps"`), "command should start with \"docker\" \"ps\"")
+		// Want: docker ps --all --quiet --no-trunc (no shell, no -c).
+		require.NotEqual(t, testShell, fakeExec.commands[0][0],
+			"commands must no longer be wrapped in the user shell")
+		require.Equal(t, []string{"docker", "ps", "--all", "--quiet", "--no-trunc"},
+			fakeExec.commands[0],
+			"argv must be forwarded verbatim, with no shell wrapper")
 
 		// Verify the environment was set on the command.
 		lastCmd := fakeExec.getLastCommand()

--- a/agent/agentcontainers/execer.go
+++ b/agent/agentcontainers/execer.go
@@ -2,8 +2,9 @@ package agentcontainers
 
 import (
 	"context"
-	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -19,10 +20,12 @@ import (
 // This signature matches agentssh.Server.CommandEnv.
 type CommandEnv func(ei usershell.EnvInfoer, addEnv []string) (shell, dir string, env []string, err error)
 
-// commandEnvExecer is an agentexec.Execer that uses a CommandEnv to
-// determine the shell, working directory, and environment variables
-// for commands. It wraps another agentexec.Execer to provide the
-// necessary context.
+// commandEnvExecer is an agentexec.Execer that uses a CommandEnv to determine
+// the working directory, environment, and PATH used when forwarding a command
+// to another agentexec.Execer.
+//
+// Commands are forwarded as discrete argv entries; the wrapper does not
+// interpolate arguments into a shell invocation.
 type commandEnvExecer struct {
 	logger     slog.Logger
 	commandEnv CommandEnv
@@ -44,23 +47,22 @@ func newCommandEnvExecer(
 // Ensure commandEnvExecer implements agentexec.Execer.
 var _ agentexec.Execer = (*commandEnvExecer)(nil)
 
+// prepare discards the shell returned by CommandEnv: this layer no longer
+// invokes a shell, so attacker-controlled argv elements cannot be
+// reinterpreted as shell syntax. To match what the user's shell would resolve,
+// the command name is resolved against the PATH in env rather than the agent
+// process's PATH. If lookup fails, the original name is forwarded so the
+// wrapped execer can surface a normal "executable not found" error.
 func (e *commandEnvExecer) prepare(ctx context.Context, inName string, inArgs ...string) (name string, args []string, dir string, env []string) {
-	shell, dir, env, err := e.commandEnv(nil, nil)
+	_, dir, env, err := e.commandEnv(nil, nil)
 	if err != nil {
-		e.logger.Error(ctx, "get command environment failed", slog.Error(err))
+		e.logger.Error(ctx, "get command environment failed", slog.F("cmd", inName), slog.Error(err))
 		return inName, inArgs, "", nil
 	}
-
-	caller := "-c"
-	if runtime.GOOS == "windows" {
-		caller = "/c"
+	if resolved, err := lookPathInEnv(inName, env); err == nil {
+		inName = resolved
 	}
-	name = shell
-	for _, arg := range append([]string{inName}, inArgs...) {
-		args = append(args, fmt.Sprintf("%q", arg))
-	}
-	args = []string{caller, strings.Join(args, " ")}
-	return name, args, dir, env
+	return inName, inArgs, dir, env
 }
 
 func (e *commandEnvExecer) CommandContext(ctx context.Context, cmd string, args ...string) *exec.Cmd {
@@ -77,4 +79,58 @@ func (e *commandEnvExecer) PTYCommandContext(ctx context.Context, cmd string, ar
 	c.Dir = dir
 	c.Env = env
 	return c
+}
+
+// lookPathInEnv resolves a command name against the PATH found in env so
+// resolution reflects the user's environment instead of the agent's.
+// Executability is determined from the file mode bits, not by an effective
+// access check, so a resolved file can still fail to exec with EACCES if the
+// agent lacks permission; the wrapped execer surfaces that error.
+//
+// Names containing a path separator are returned unchanged.
+//
+// On Windows, lookup falls back to exec.LookPath against the agent process's
+// PATH; the env-supplied PATH is ignored. Devcontainers are effectively
+// Linux-only, so this limitation is accepted rather than implementing
+// PATHEXT-aware scanning.
+func lookPathInEnv(name string, env []string) (string, error) {
+	if name == "" {
+		return "", &exec.Error{Name: name, Err: exec.ErrNotFound}
+	}
+	if strings.ContainsRune(name, filepath.Separator) {
+		return name, nil
+	}
+	if runtime.GOOS == "windows" {
+		return exec.LookPath(name)
+	}
+	var pathVar string
+	for _, kv := range env {
+		if k, v, ok := strings.Cut(kv, "="); ok && k == "PATH" {
+			pathVar = v // Go's exec.Cmd deduplicates env to last-wins; match that here.
+		}
+	}
+	for _, dir := range filepath.SplitList(pathVar) {
+		if dir == "" {
+			// POSIX: an empty PATH entry means the current directory.
+			dir = "."
+		}
+		full := filepath.Join(dir, name)
+		if isExecutable(full) {
+			return full, nil
+		}
+	}
+	return "", &exec.Error{Name: name, Err: exec.ErrNotFound}
+}
+
+// isExecutable reports whether path refers to a regular file with at least
+// one execute bit set. Only used on non-Windows platforms.
+func isExecutable(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	if !info.Mode().IsRegular() {
+		return false
+	}
+	return info.Mode().Perm()&0o111 != 0
 }

--- a/agent/agentcontainers/execer_internal_test.go
+++ b/agent/agentcontainers/execer_internal_test.go
@@ -1,0 +1,232 @@
+package agentcontainers
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"cdr.dev/slog/v3"
+	"cdr.dev/slog/v3/sloggers/slogtest"
+	"github.com/coder/coder/v2/agent/usershell"
+	"github.com/coder/coder/v2/pty"
+)
+
+// recordingExecer captures each forwarded argv tuple so internal tests can
+// assert on what commandEnvExecer hands to its inner Execer.
+type recordingExecer struct {
+	commands [][]string
+}
+
+func (r *recordingExecer) CommandContext(ctx context.Context, cmd string, args ...string) *exec.Cmd {
+	r.commands = append(r.commands, append([]string{cmd}, args...))
+	// Return a no-op command; tests never call Run.
+	return exec.CommandContext(ctx, "true")
+}
+
+func (r *recordingExecer) PTYCommandContext(ctx context.Context, cmd string, args ...string) *pty.Cmd {
+	r.commands = append(r.commands, append([]string{cmd}, args...))
+	return &pty.Cmd{Context: ctx, Path: cmd, Args: append([]string{cmd}, args...)}
+}
+
+// TestCommandEnvExecer_NoShellInterpolation asserts that arguments forwarded
+// through commandEnvExecer reach the wrapped execer as separate argv entries.
+func TestCommandEnvExecer_NoShellInterpolation(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows PATH resolution uses exec.LookPath; not tested here.")
+	}
+
+	tempDir := t.TempDir()
+	dockerPath := filepath.Join(tempDir, "docker")
+	require.NoError(t, os.WriteFile(dockerPath, []byte("#!/bin/sh\nexit 0\n"), 0o600))
+	require.NoError(t, os.Chmod(dockerPath, 0o755))
+
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	commandEnv := func(usershell.EnvInfoer, []string) (string, string, []string, error) {
+		return "/bin/bash", "/tmp", []string{"PATH=" + tempDir, "CUSTOM=value"}, nil
+	}
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{name: "CommandSubstitution", args: []string{"exec", "--env", `FOO=$(touch /tmp/pwn)`, "ctr"}},
+		{name: "Backticks", args: []string{"exec", "--env", "FOO=`id`", "ctr"}},
+		{name: "VariableExpansion", args: []string{"exec", "--env", "FOO=$HOME", "ctr"}},
+		{name: "Semicolon", args: []string{"inspect", "ctr; rm -rf /"}},
+		{name: "Pipe", args: []string{"inspect", "ctr | curl evil"}},
+		{name: "SingleQuotes", args: []string{"inspect", `it's`}},
+		{name: "DoubleQuotes", args: []string{"inspect", `"quoted"`}},
+		{name: "DockerTemplate", args: []string{"inspect", "--format", "{{.Config.Image}}", "ctr"}},
+		{name: "EmptyArg", args: []string{"inspect", "", "ctr"}},
+		{name: "Newline", args: []string{"inspect", "line1\nline2"}},
+	}
+
+	ctx := t.Context()
+	for _, tc := range cases {
+		t.Run("CommandContext/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			rec := &recordingExecer{}
+			e := newCommandEnvExecer(logger, commandEnv, rec)
+			_ = e.CommandContext(ctx, "docker", tc.args...)
+			require.Len(t, rec.commands, 1)
+			got := rec.commands[0]
+			require.Equal(t, dockerPath, got[0],
+				"first forwarded element must be the resolved docker path, never /bin/bash or a shell flag")
+			require.Equal(t, tc.args, got[1:],
+				"remaining argv must equal the original args verbatim")
+		})
+		t.Run("PTYCommandContext/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			rec := &recordingExecer{}
+			e := newCommandEnvExecer(logger, commandEnv, rec)
+			_ = e.PTYCommandContext(ctx, "docker", tc.args...)
+			require.Len(t, rec.commands, 1)
+			got := rec.commands[0]
+			require.Equal(t, dockerPath, got[0])
+			require.Equal(t, tc.args, got[1:])
+		})
+	}
+}
+
+// TestCommandEnvExecer_SetsEnvAndDir asserts that env and dir from CommandEnv
+// are applied to the returned command unchanged.
+func TestCommandEnvExecer_SetsEnvAndDir(t *testing.T) {
+	t.Parallel()
+
+	wantEnv := []string{"PATH=/nonexistent", "FOO=bar"}
+	wantDir := t.TempDir()
+	commandEnv := func(usershell.EnvInfoer, []string) (string, string, []string, error) {
+		return "/bin/bash", wantDir, wantEnv, nil
+	}
+	rec := &recordingExecer{}
+	e := newCommandEnvExecer(slogtest.Make(t, nil), commandEnv, rec)
+
+	c := e.CommandContext(t.Context(), "docker", "ps")
+	require.Equal(t, wantEnv, c.Env)
+	require.Equal(t, wantDir, c.Dir)
+}
+
+// TestCommandEnvExecer_CommandEnvError ensures the original cmd/args are
+// forwarded with empty dir and nil env when CommandEnv fails.
+func TestCommandEnvExecer_CommandEnvError(t *testing.T) {
+	t.Parallel()
+
+	commandEnv := func(usershell.EnvInfoer, []string) (string, string, []string, error) {
+		return "", "", nil, errBoom
+	}
+	rec := &recordingExecer{}
+	e := newCommandEnvExecer(slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}), commandEnv, rec)
+
+	c := e.CommandContext(t.Context(), "docker", "ps", "--all")
+	require.Len(t, rec.commands, 1)
+	require.Equal(t, []string{"docker", "ps", "--all"}, rec.commands[0])
+	require.Equal(t, "", c.Dir)
+	require.Nil(t, c.Env)
+}
+
+var errBoom = &exec.Error{Name: "commandEnv", Err: exec.ErrNotFound}
+
+func TestLookPathInEnv(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows PATH resolution uses exec.LookPath; not tested here.")
+	}
+
+	noExecDir := t.TempDir()
+	execDir := t.TempDir()
+	// noExecDir contains: a non-executable "tool", a directory named "alsotool".
+	// execDir contains: an executable "tool" and an executable "alsotool".
+	require.NoError(t, os.WriteFile(filepath.Join(noExecDir, "tool"), []byte("not exec"), 0o600))
+	require.NoError(t, os.Mkdir(filepath.Join(noExecDir, "alsotool"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(execDir, "tool"), []byte("#!/bin/sh\nexit 0\n"), 0o600))
+	require.NoError(t, os.Chmod(filepath.Join(execDir, "tool"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(execDir, "alsotool"), []byte("#!/bin/sh\nexit 0\n"), 0o600))
+	require.NoError(t, os.Chmod(filepath.Join(execDir, "alsotool"), 0o755))
+
+	tests := []struct {
+		name    string
+		nameArg string
+		env     []string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "AbsolutePathPassThrough",
+			nameArg: "/usr/bin/whatever",
+			env:     []string{"PATH=/nonexistent"},
+			want:    "/usr/bin/whatever",
+		},
+		{
+			name:    "RelativePathPassThrough",
+			nameArg: "./tool",
+			env:     []string{"PATH=" + execDir},
+			want:    "./tool",
+		},
+		{
+			name:    "FoundInLaterPATHEntry",
+			nameArg: "tool",
+			env:     []string{"PATH=" + noExecDir + string(os.PathListSeparator) + execDir},
+			want:    filepath.Join(execDir, "tool"),
+		},
+		{
+			name:    "SkipsNonExecutable",
+			nameArg: "tool",
+			env:     []string{"PATH=" + noExecDir},
+			wantErr: true,
+		},
+		{
+			name:    "SkipsDirectory",
+			nameArg: "alsotool",
+			env:     []string{"PATH=" + noExecDir + string(os.PathListSeparator) + execDir},
+			want:    filepath.Join(execDir, "alsotool"),
+		},
+		{
+			name:    "MissingPATH",
+			nameArg: "tool",
+			env:     []string{"OTHER=value"},
+			wantErr: true,
+		},
+		{
+			name:    "EmptyPATH",
+			nameArg: "tool",
+			env:     []string{"PATH="},
+			wantErr: true,
+		},
+		{
+			name:    "EmptyPATHEntry",
+			nameArg: "tool",
+			env:     []string{"PATH=" + string(os.PathListSeparator) + execDir},
+			want:    filepath.Join(execDir, "tool"),
+		},
+		{
+			name:    "PATHLastDefinitionWins",
+			nameArg: "tool",
+			env:     []string{"PATH=/nonexistent", "PATH=" + execDir},
+			want:    filepath.Join(execDir, "tool"),
+		},
+		{
+			name:    "EmptyName",
+			nameArg: "",
+			env:     []string{"PATH=" + execDir},
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := lookPathInEnv(tc.nameArg, tc.env)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
commandEnvExecer previously assembled an `sh -c` script by wrapping each argument in fmt.Sprintf("%q", arg). Go's %q produces double-quoted Go syntax, and POSIX shells still perform $(...), backtick, and $VAR expansion inside double quotes, so attacker-controlled values such as Docker container labels could be evaluated by the agent's shell as a container-to-host escape.

Drop the shell wrapper entirely and forward the cmd and args to the inner Execer as discrete argv entries. The PATH from CommandEnv is now honored by a small env-aware lookup (lookPathInEnv) so user-installed binaries (devcontainer, custom docker) continue to resolve as they did under the shell.

Authored with assistance from Coder Agents.
