### PR TITLE
chore(site): restore diff file tree

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -61,6 +61,7 @@
 		"@mui/system": "5.18.0",
 		"@novnc/novnc": "^1.5.0",
 		"@pierre/diffs": "1.2.4",
+		"@pierre/trees": "1.0.0-beta.4",
 		"@tanstack/react-query-devtools": "5.77.0",
 		"@xterm/addon-canvas": "0.7.0",
 		"@xterm/addon-fit": "0.11.0",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@pierre/diffs':
         specifier: 1.2.4
         version: 1.2.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@pierre/trees':
+        specifier: 1.0.0-beta.4
+        version: 1.0.0-beta.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-query-devtools':
         specifier: 5.77.0
         version: 5.77.0(@tanstack/react-query@5.77.0(react@19.2.6))(react@19.2.6)
@@ -1423,6 +1426,12 @@ packages:
   '@pierre/theme@1.0.3':
     resolution: {integrity: sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA==, tarball: https://registry.npmjs.org/@pierre/theme/-/theme-1.0.3.tgz}
     engines: {vscode: ^1.0.0}
+
+  '@pierre/trees@1.0.0-beta.4':
+    resolution: {integrity: sha512-OfT1yk9ne8Te5+GB5zUY8yqE6B8BqjBHQJleH4lu8ltwNpoocZl4vXt1AzlEExpxI/pp+AFX5QG+lR3JjtTEag==, tarball: https://registry.npmjs.org/@pierre/trees/-/trees-1.0.0-beta.4.tgz}
+    peerDependencies:
+      react: ^18.3.1 || ^19.0.0
+      react-dom: ^18.3.1 || ^19.0.0
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==, tarball: https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz}
@@ -5179,6 +5188,14 @@ packages:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==, tarball: https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz}
     engines: {node: '>=20'}
 
+  preact-render-to-string@6.6.5:
+    resolution: {integrity: sha512-O6MHzYNIKYaiSX3bOw0gGZfEbOmlIDtDfWwN1JJdc/T3ihzRT6tGGSEWE088dWrEDGa1u7101q+6fzQnO9XCPA==, tarball: https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.6.5.tgz}
+    peerDependencies:
+      preact: '>=10 || >= 11.0.0-0'
+
+  preact@11.0.0-beta.0:
+    resolution: {integrity: sha512-IcODoASASYwJ9kxz7+MJeiJhvLriwSb4y4mHIyxdgaRZp6kPUud7xytrk/6GZw8U3y6EFJaRb5wi9SrEK+8+lg==, tarball: https://registry.npmjs.org/preact/-/preact-11.0.0-beta.0.tgz}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==, tarball: https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz}
     engines: {node: '>= 0.8.0'}
@@ -7503,6 +7520,13 @@ snapshots:
       shiki: 3.23.0
 
   '@pierre/theme@1.0.3': {}
+
+  '@pierre/trees@1.0.0-beta.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      preact: 11.0.0-beta.0
+      preact-render-to-string: 6.6.5(preact@11.0.0-beta.0)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -11611,6 +11635,12 @@ snapshots:
       source-map-js: 1.2.1
 
   powershell-utils@0.1.0: {}
+
+  preact-render-to-string@6.6.5(preact@11.0.0-beta.0):
+    dependencies:
+      preact: 11.0.0-beta.0
+
+  preact@11.0.0-beta.0: {}
 
   prelude-ls@1.2.1:
     optional: true

--- a/site/src/pages/AgentsPage/components/DiffViewer/DiffViewer.tsx
+++ b/site/src/pages/AgentsPage/components/DiffViewer/DiffViewer.tsx
@@ -8,6 +8,8 @@ import type {
 	VirtualFileMetrics,
 } from "@pierre/diffs/react";
 import { CodeView } from "@pierre/diffs/react";
+import type { GitStatusEntry } from "@pierre/trees";
+import { FileTree, useFileTree } from "@pierre/trees/react";
 import {
 	type ComponentProps,
 	type CSSProperties,
@@ -92,6 +94,16 @@ const diffViewerSeparatorCSS = [
 	"}",
 ].join(" ");
 
+const fileTreeStyle = {
+	height: "100%",
+	"--trees-font-family-override": '"Geist Variable", system-ui, sans-serif',
+	"--trees-font-size-override": "13px",
+	"--trees-border-color-override": "hsl(var(--border-default))",
+	"--trees-fg-override": "hsl(var(--content-primary))",
+	"--trees-muted-fg-override": "hsl(var(--content-secondary))",
+	"--trees-selected-bg-override": "hsl(var(--surface-secondary))",
+} satisfies CSSProperties;
+
 function countChangedLines(fileDiff: FileDiffMetadata) {
 	let additions = 0;
 	let deletions = 0;
@@ -100,6 +112,22 @@ function countChangedLines(fileDiff: FileDiffMetadata) {
 		deletions += hunk.deletionLines;
 	}
 	return { additions, deletions };
+}
+
+function gitStatusForFile(
+	fileDiff: FileDiffMetadata,
+): GitStatusEntry["status"] {
+	switch (fileDiff.type) {
+		case "new":
+			return "added";
+		case "deleted":
+			return "deleted";
+		case "rename-pure":
+		case "rename-changed":
+			return "renamed";
+		default:
+			return "modified";
+	}
 }
 
 function HeaderContent({ fileDiff }: { fileDiff: FileDiffMetadata }) {
@@ -139,6 +167,45 @@ function HeaderContent({ fileDiff }: { fileDiff: FileDiffMetadata }) {
 				</span>
 			)}
 		</div>
+	);
+}
+
+function DiffFileTree({
+	files,
+	onSelectFile,
+}: {
+	files: readonly FileDiffMetadata[];
+	onSelectFile: (fileName: string) => void;
+}) {
+	const paths = files.map((file) => file.name);
+	const gitStatus = files.map((file) => ({
+		path: file.name,
+		status: gitStatusForFile(file),
+	}));
+	const { model } = useFileTree({
+		flattenEmptyDirectories: true,
+		gitStatus,
+		initialExpansion: "open",
+		onSelectionChange: (selectedPaths) => {
+			const selectedPath = selectedPaths.at(-1);
+			if (selectedPath) {
+				onSelectFile(selectedPath);
+			}
+		},
+		paths,
+	});
+
+	useEffect(() => {
+		model.resetPaths(paths);
+		model.setGitStatus(gitStatus);
+	}, [gitStatus, model, paths]);
+
+	return (
+		<FileTree
+			model={model}
+			className="block h-full min-h-0 w-full"
+			style={fileTreeStyle}
+		/>
 	);
 }
 
@@ -323,19 +390,36 @@ export const DiffViewer: FC<DiffViewerProps> = ({
 	}
 
 	return (
-		<CodeView
-			ref={codeViewRef}
-			items={items}
-			options={options}
-			selectedLines={selectedLines}
-			className="h-full min-h-0 min-w-0 overflow-auto"
-			style={diffViewerStyle}
-			renderCustomHeader={(item) =>
-				item.type === "diff" ? <HeaderContent fileDiff={item.fileDiff} /> : null
-			}
-			renderAnnotation={(annotation) =>
-				"side" in annotation ? renderAnnotation?.(annotation) : null
-			}
-		/>
+		<div className="flex h-full min-h-0 min-w-0 overflow-hidden">
+			<aside className="hidden h-full min-h-0 w-72 shrink-0 border-0 border-r border-solid border-border-default xl:block">
+				<DiffFileTree
+					files={parsedFiles}
+					onSelectFile={(fileName) => {
+						codeViewRef.current?.scrollTo({
+							type: "item",
+							id: fileName,
+							align: "start",
+							behavior: "instant",
+						});
+					}}
+				/>
+			</aside>
+			<CodeView
+				ref={codeViewRef}
+				items={items}
+				options={options}
+				selectedLines={selectedLines}
+				className="h-full min-h-0 min-w-0 flex-1 overflow-auto"
+				style={diffViewerStyle}
+				renderCustomHeader={(item) =>
+					item.type === "diff" ? (
+						<HeaderContent fileDiff={item.fileDiff} />
+					) : null
+				}
+				renderAnnotation={(annotation) =>
+					"side" in annotation ? renderAnnotation?.(annotation) : null
+				}
+			/>
+		</div>
 	);
 };


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

## Summary

- Restores the agents diff file tree as a stacked follow-up to #25879.
- Uses `@pierre/trees` for the sidebar instead of restoring the old custom recursive tree.
- Wires file selection to `CodeView.scrollTo`, keeping the diff renderer as the source of truth.

## Notes

- This intentionally does not restore the old active-file scroll observer. The first pass keeps the integration simple: tree click navigates to the file.
- Styling uses supported host CSS variables and avoids `unsafeCSS`.

## Validation

- `cd site && pnpm lint:types`
- `cd site && pnpm format`
- `make pre-commit` via git commit hook
