### PR TITLE
fix(site): stop sidebar scrollbar hit-area from covering chat row controls

### DIFF
--- a/site/src/components/ScrollArea/ScrollArea.stories.tsx
+++ b/site/src/components/ScrollArea/ScrollArea.stories.tsx
@@ -105,11 +105,8 @@ export const Accessibility: Story = {
 	},
 };
 
-// Verifies the scrollThumbClassName escape hatch used by the Agents chat list.
-// The sidebar passes `before:hidden` to remove the thumb's expanded 24px
-// hit-target (added in PR #26016) so it stops covering the per-row controls,
-// while leaving the visible thumb unchanged. type="always" guarantees the
-// thumb renders so the pseudo-element is measurable.
+// type="always" forces the thumb to render so its `::before` hit-target
+// pseudo-element is measurable.
 export const ThumbHitAreaOverride: Story = {
 	render: () => (
 		<div className="flex gap-4">
@@ -128,7 +125,9 @@ export const ThumbHitAreaOverride: Story = {
 				<ScrollArea
 					className="h-48"
 					type="always"
+					orientation="both"
 					scrollBarClassName="w-1.5"
+					horizontalScrollBarClassName="h-1.5"
 					scrollThumbClassName="before:hidden"
 				>
 					<OverflowingContent />
@@ -137,34 +136,40 @@ export const ThumbHitAreaOverride: Story = {
 		</div>
 	),
 	play: async ({ canvasElement }) => {
-		const getThumb = (testid: string) => {
+		const getThumb = (
+			testid: string,
+			orientation: "vertical" | "horizontal",
+		) => {
 			const area = canvasElement.querySelector(`[data-testid='${testid}']`);
-			return area?.querySelector('[data-orientation="vertical"]')
+			return area?.querySelector(`[data-orientation="${orientation}"]`)
 				?.firstElementChild as HTMLElement | null | undefined;
 		};
 
 		await waitFor(() => {
-			expect(getThumb("default-area")).toBeTruthy();
-			expect(getThumb("override-area")).toBeTruthy();
+			expect(getThumb("default-area", "vertical")).toBeTruthy();
+			expect(getThumb("override-area", "vertical")).toBeTruthy();
+			expect(getThumb("override-area", "horizontal")).toBeTruthy();
 		});
 
-		const defaultThumb = getThumb("default-area");
-		const overrideThumb = getThumb("override-area");
-		if (!defaultThumb || !overrideThumb) {
+		const defaultThumb = getThumb("default-area", "vertical");
+		const overrideThumb = getThumb("override-area", "vertical");
+		const overrideHorizontalThumb = getThumb("override-area", "horizontal");
+		if (!defaultThumb || !overrideThumb || !overrideHorizontalThumb) {
 			throw new Error("scrollbar thumbs not found");
 		}
 
-		// By default the thumb keeps its expanded 24px hit-target pseudo-element.
 		const defaultBefore = getComputedStyle(defaultThumb, "::before");
 		await expect(defaultBefore.display).not.toBe("none");
 		await expect(Number.parseFloat(defaultBefore.width)).toBeGreaterThanOrEqual(
 			24,
 		);
 
-		// scrollThumbClassName="before:hidden" removes that expanded hit-target...
-		const overrideBefore = getComputedStyle(overrideThumb, "::before");
-		await expect(overrideBefore.display).toBe("none");
-		// ...while the visible thumb itself stays intact and draggable.
+		await expect(getComputedStyle(overrideThumb, "::before").display).toBe(
+			"none",
+		);
+		await expect(
+			getComputedStyle(overrideHorizontalThumb, "::before").display,
+		).toBe("none");
 		await expect(overrideThumb.getBoundingClientRect().width).toBeGreaterThan(
 			0,
 		);

--- a/site/src/components/ScrollArea/ScrollArea.stories.tsx
+++ b/site/src/components/ScrollArea/ScrollArea.stories.tsx
@@ -104,3 +104,69 @@ export const Accessibility: Story = {
 		).toBeGreaterThanOrEqual(3);
 	},
 };
+
+// Verifies the scrollThumbClassName escape hatch used by the Agents chat list.
+// The sidebar passes `before:hidden` to remove the thumb's expanded 24px
+// hit-target (added in PR #26016) so it stops covering the per-row controls,
+// while leaving the visible thumb unchanged. type="always" guarantees the
+// thumb renders so the pseudo-element is measurable.
+export const ThumbHitAreaOverride: Story = {
+	render: () => (
+		<div className="flex gap-4">
+			<div
+				data-testid="default-area"
+				className="w-48 rounded-md border border-solid border-border-default bg-surface-primary"
+			>
+				<ScrollArea className="h-48" type="always" scrollBarClassName="w-1.5">
+					<OverflowingContent />
+				</ScrollArea>
+			</div>
+			<div
+				data-testid="override-area"
+				className="w-48 rounded-md border border-solid border-border-default bg-surface-primary"
+			>
+				<ScrollArea
+					className="h-48"
+					type="always"
+					scrollBarClassName="w-1.5"
+					scrollThumbClassName="before:hidden"
+				>
+					<OverflowingContent />
+				</ScrollArea>
+			</div>
+		</div>
+	),
+	play: async ({ canvasElement }) => {
+		const getThumb = (testid: string) => {
+			const area = canvasElement.querySelector(`[data-testid='${testid}']`);
+			return area?.querySelector('[data-orientation="vertical"]')
+				?.firstElementChild as HTMLElement | null | undefined;
+		};
+
+		await waitFor(() => {
+			expect(getThumb("default-area")).toBeTruthy();
+			expect(getThumb("override-area")).toBeTruthy();
+		});
+
+		const defaultThumb = getThumb("default-area");
+		const overrideThumb = getThumb("override-area");
+		if (!defaultThumb || !overrideThumb) {
+			throw new Error("scrollbar thumbs not found");
+		}
+
+		// By default the thumb keeps its expanded 24px hit-target pseudo-element.
+		const defaultBefore = getComputedStyle(defaultThumb, "::before");
+		await expect(defaultBefore.display).not.toBe("none");
+		await expect(Number.parseFloat(defaultBefore.width)).toBeGreaterThanOrEqual(
+			24,
+		);
+
+		// scrollThumbClassName="before:hidden" removes that expanded hit-target...
+		const overrideBefore = getComputedStyle(overrideThumb, "::before");
+		await expect(overrideBefore.display).toBe("none");
+		// ...while the visible thumb itself stays intact and draggable.
+		await expect(overrideThumb.getBoundingClientRect().width).toBeGreaterThan(
+			0,
+		);
+	},
+};

--- a/site/src/components/ScrollArea/ScrollArea.tsx
+++ b/site/src/components/ScrollArea/ScrollArea.tsx
@@ -10,11 +10,7 @@ interface ScrollAreaProps
 	extends React.ComponentPropsWithRef<typeof ScrollAreaPrimitive.Root> {
 	scrollBarClassName?: string;
 	horizontalScrollBarClassName?: string;
-	/**
-	 * Extra classes for the scrollbar thumb, including its expanded `before`
-	 * hit-target pseudo-element. Use to scope hit-area overrides to a single
-	 * instance without affecting other scrollbars.
-	 */
+	/** Extra thumb classes; also reaches the thumb's `::before` hit-target. */
 	scrollThumbClassName?: string;
 	viewportClassName?: string;
 	viewportTabIndex?: number;

--- a/site/src/components/ScrollArea/ScrollArea.tsx
+++ b/site/src/components/ScrollArea/ScrollArea.tsx
@@ -10,6 +10,12 @@ interface ScrollAreaProps
 	extends React.ComponentPropsWithRef<typeof ScrollAreaPrimitive.Root> {
 	scrollBarClassName?: string;
 	horizontalScrollBarClassName?: string;
+	/**
+	 * Extra classes for the scrollbar thumb, including its expanded `before`
+	 * hit-target pseudo-element. Use to scope hit-area overrides to a single
+	 * instance without affecting other scrollbars.
+	 */
+	scrollThumbClassName?: string;
 	viewportClassName?: string;
 	viewportTabIndex?: number;
 	/** Which scrollbar(s) to show. Defaults to "vertical". */
@@ -20,6 +26,7 @@ export const ScrollArea: React.FC<ScrollAreaProps> = ({
 	className,
 	scrollBarClassName,
 	horizontalScrollBarClassName,
+	scrollThumbClassName,
 	viewportClassName,
 	viewportTabIndex,
 	orientation = "vertical",
@@ -61,6 +68,7 @@ export const ScrollArea: React.FC<ScrollAreaProps> = ({
 				<ScrollBar
 					orientation="vertical"
 					className={cn("z-10", scrollBarClassName)}
+					thumbClassName={scrollThumbClassName}
 				/>
 			)}
 			{(orientation === "horizontal" || orientation === "both") && (
@@ -72,6 +80,7 @@ export const ScrollArea: React.FC<ScrollAreaProps> = ({
 							? horizontalScrollBarClassName
 							: (horizontalScrollBarClassName ?? scrollBarClassName),
 					)}
+					thumbClassName={scrollThumbClassName}
 				/>
 			)}
 			<ScrollAreaPrimitive.Corner />
@@ -80,8 +89,12 @@ export const ScrollArea: React.FC<ScrollAreaProps> = ({
 };
 
 export const ScrollBar: React.FC<
-	React.ComponentPropsWithRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
-> = ({ className, orientation = "vertical", ...props }) => {
+	React.ComponentPropsWithRef<
+		typeof ScrollAreaPrimitive.ScrollAreaScrollbar
+	> & {
+		thumbClassName?: string;
+	}
+> = ({ className, orientation = "vertical", thumbClassName, ...props }) => {
 	return (
 		<ScrollAreaPrimitive.ScrollAreaScrollbar
 			orientation={orientation}
@@ -102,6 +115,7 @@ export const ScrollBar: React.FC<
 					orientation === "vertical"
 						? "before:right-0 before:top-1/2 before:h-full before:min-h-6 before:w-6 before:-translate-y-1/2"
 						: "before:bottom-0 before:left-1/2 before:w-full before:min-w-6 before:h-6 before:-translate-x-1/2",
+					thumbClassName,
 				)}
 			/>
 		</ScrollAreaPrimitive.ScrollAreaScrollbar>

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
@@ -447,6 +447,11 @@ export const ChatsPanel: FC<ChatsPanelProps> = ({
 				<ScrollArea
 					className="min-h-0 flex-1 [&_[data-radix-scroll-area-viewport]>div]:!block"
 					scrollBarClassName="w-1.5"
+					// Disable the thumb's expanded hit-target. It extends ~18px left
+					// of this thin scrollbar and would otherwise sit on top of the
+					// row controls (actions menu, timestamp, indicators). The 6px
+					// thumb stays draggable and the visible scrollbar is unchanged.
+					scrollThumbClassName="before:hidden"
 					viewportClassName={cn(
 						"[mask-image:linear-gradient(to_bottom,transparent_0,black_20px,black_calc(100%-20px),transparent_100%)]",
 						"[-webkit-mask-image:linear-gradient(to_bottom,transparent_0,black_20px,black_calc(100%-20px),transparent_100%)]",

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
@@ -447,10 +447,9 @@ export const ChatsPanel: FC<ChatsPanelProps> = ({
 				<ScrollArea
 					className="min-h-0 flex-1 [&_[data-radix-scroll-area-viewport]>div]:!block"
 					scrollBarClassName="w-1.5"
-					// Disable the thumb's expanded hit-target. It extends ~18px left
-					// of this thin scrollbar and would otherwise sit on top of the
-					// row controls (actions menu, timestamp, indicators). The 6px
-					// thumb stays draggable and the visible scrollbar is unchanged.
+					// The default 24px hit-target extends ~18px left of this narrow
+					// scrollbar, onto the row controls (actions menu, timestamp,
+					// indicators). Disable it so those controls stay clickable.
 					scrollThumbClassName="before:hidden"
 					viewportClassName={cn(
 						"[mask-image:linear-gradient(to_bottom,transparent_0,black_20px,black_calc(100%-20px),transparent_100%)]",


### PR DESCRIPTION
The Agents chat list scrollbar swallowed clicks on the per-row controls (the actions menu, timestamp, and unread/shared indicators). PR #26016 added a 24px invisible hit-target to the shared `ScrollArea` thumb, anchored to the thumb's right edge and extending left. On this sidebar the visible scrollbar is only ~6px wide (`w-1.5`), so the hit-target reached ~18px left of it, on top of the controls just inside the edge.

This adds an optional, default-preserving `scrollThumbClassName` prop to the shared `ScrollArea`, threaded through `ScrollBar` to the thumb the same way `scrollBarClassName` already is. When the prop is omitted the output is byte-for-byte unchanged, so every other scrollbar keeps the 24px target. The Agents chat list passes `before:hidden` to drop only the expanded hit-target: the visible 6px thumb stays draggable and the scrollbar looks identical, so there is no visible change while the controls beside it become clickable again.

A new `ScrollArea` story (`ThumbHitAreaOverride`) uses `type="always"` so the thumb is guaranteed to render, then asserts the default keeps the 24px `::before` target while the override sets `display: none`.

Refs #26016
