### PR TITLE
docs: document VS Code local telemetry

### DIFF
--- a/docs/support/support-bundle.md
+++ b/docs/support/support-bundle.md
@@ -53,7 +53,7 @@ A brief overview of all files contained in the bundle is provided below:
 | `workspace/template.json`         | The template currently in use by the selected workspace.                                                                          |
 | `workspace/template_file.zip`     | The source code of the template currently in use by the selected workspace.                                                       |
 | `workspace/template_version.json` | The template version currently in use by the selected workspace.                                                                  |
-| `vscode-logs/`                    | Recent diagnostics from the Coder Remote extension, including logs, redacted settings, and local telemetry files.                 |
+| `vscode-logs/`                    | Only present when generated from the Coder Remote extension. Includes logs, redacted settings, and local telemetry files.         |
 
 ## How do I generate a Support Bundle?
 
@@ -79,7 +79,8 @@ A brief overview of all files contained in the bundle is provided below:
 
    If you use VS Code, you can also run **Coder: Create Support Bundle** from
    the Command Palette. The extension runs `coder support bundle` and appends
-   recent VS Code diagnostics to the generated archive. Learn more about
+   recent VS Code diagnostics to the generated archive. Bundles created with
+   the CLI alone do not include `vscode-logs/`. Learn more about
    [VS Code diagnostics](../user-guides/workspace-access/vscode.md#diagnostics-and-support-bundles).
 
    > [!NOTE]

--- a/docs/support/support-bundle.md
+++ b/docs/support/support-bundle.md
@@ -53,7 +53,7 @@ A brief overview of all files contained in the bundle is provided below:
 | `workspace/template.json`         | The template currently in use by the selected workspace.                                                                          |
 | `workspace/template_file.zip`     | The source code of the template currently in use by the selected workspace.                                                       |
 | `workspace/template_version.json` | The template version currently in use by the selected workspace.                                                                  |
-| `vscode-logs/`                    | Only present when generated from the Coder Remote extension. Includes logs, redacted settings, and local telemetry files.         |
+| `vscode-logs/`                    | Only present when generated from the VS Code Coder Remote extension. Includes logs, redacted settings, and local telemetry files. |
 
 ## How do I generate a Support Bundle?
 
@@ -78,9 +78,10 @@ A brief overview of all files contained in the bundle is provided below:
    the filename `coder-support-$TIMESTAMP.zip`.
 
    If you use VS Code, you can also run **Coder: Create Support Bundle** from
-   the Command Palette. The extension runs `coder support bundle` and appends
-   recent VS Code diagnostics to the generated archive. Bundles created with
-   the CLI alone do not include `vscode-logs/`. Learn more about
+   the Command Palette. The VS Code Coder Remote extension runs
+   `coder support bundle` and appends recent VS Code diagnostics to the
+   generated archive. Bundles created with the CLI alone do not include
+   `vscode-logs/`. Learn more about
    [VS Code diagnostics](../user-guides/workspace-access/vscode.md#diagnostics-and-support-bundles).
 
    > [!NOTE]

--- a/docs/support/support-bundle.md
+++ b/docs/support/support-bundle.md
@@ -53,6 +53,7 @@ A brief overview of all files contained in the bundle is provided below:
 | `workspace/template.json`         | The template currently in use by the selected workspace.                                                                          |
 | `workspace/template_file.zip`     | The source code of the template currently in use by the selected workspace.                                                       |
 | `workspace/template_version.json` | The template version currently in use by the selected workspace.                                                                  |
+| `vscode-logs/`                    | Recent diagnostics from the Coder Remote extension, including logs, redacted settings, and local telemetry files.                 |
 
 ## How do I generate a Support Bundle?
 
@@ -75,6 +76,11 @@ A brief overview of all files contained in the bundle is provided below:
 4. Run `coder support bundle [owner/workspace]`, and respond `yes` to the
    prompt. The support bundle will be generated in the current directory with
    the filename `coder-support-$TIMESTAMP.zip`.
+
+   If you use VS Code, you can also run **Coder: Create Support Bundle** from
+   the Command Palette. The extension runs `coder support bundle` and appends
+   recent VS Code diagnostics to the generated archive. Learn more about
+   [VS Code diagnostics](../user-guides/workspace-access/vscode.md#diagnostics-and-support-bundles).
 
    > [!NOTE]
    > While support bundles can be generated without a running workspace, it is

--- a/docs/user-guides/workspace-access/vscode.md
+++ b/docs/user-guides/workspace-access/vscode.md
@@ -88,9 +88,12 @@ The extension includes commands for collecting diagnostics from VS Code:
 
 - **Coder: Export Telemetry** exports only local telemetry. Choose a date range
   and JSON or OTLP JSON zip format, then review the file before sharing it.
-- **Coder: Create Support Bundle** runs `coder support bundle` and adds recent
-  VS Code extension diagnostics, including extension logs, proxy and Remote-SSH
-  logs, redacted VS Code settings, and local telemetry files when available.
+- **Coder: Create Support Bundle** runs `coder support bundle` and adds a
+  `vscode-logs/` directory with recent VS Code extension diagnostics, including
+  extension logs, proxy and Remote-SSH logs, redacted VS Code settings, and
+  local telemetry files when available. The `vscode-logs/` directory is only
+  added when the bundle is created from the Coder Remote extension; bundles
+  created with the CLI alone do not include it.
 - **Coder: View Logs** opens the extension output logs in VS Code.
 
 Support bundles can contain sensitive diagnostic data. Review the generated

--- a/docs/user-guides/workspace-access/vscode.md
+++ b/docs/user-guides/workspace-access/vscode.md
@@ -60,7 +60,7 @@ terminal contents, tokens, or credentials.
 
 The exact events vary by extension version. For a comprehensive list of current
 events, properties, and attributes, see the
-[extension event reference](https://github.com/coder/vscode-coder/blob/b75c5e49b1c253373fb1128312918c1649e79281/src/instrumentation/EVENTS.md).
+[extension event reference](https://github.com/coder/vscode-coder/blob/main/src/instrumentation/EVENTS.md).
 The following categories summarize the diagnostic signals the extension may
 record:
 

--- a/docs/user-guides/workspace-access/vscode.md
+++ b/docs/user-guides/workspace-access/vscode.md
@@ -56,6 +56,23 @@ workspace and agent names, command outcomes, connection state, request routes,
 timing, and error details. It does not intentionally collect source code,
 terminal contents, tokens, or credentials.
 
+### Tracked activity
+
+The exact events vary by extension version. They focus on support and debugging
+signals such as:
+
+- extension activation and deployment initialization
+- authentication, token refresh, logout, credential storage, and deployment
+  recovery
+- command execution and diagnostic workflows, such as telemetry export, support
+  bundles, ping, and speed tests
+- workspace selection, open, dev container handoff, start, and update prompts
+- CLI binary resolution, download, verification, and configuration
+- remote setup phases from workspace lookup through SSH handoff
+- workspace and agent state transitions
+- connection lifecycle, reconnects, SSH process health, and network samples
+- HTTP request rollups by normalized route, status class, and latency
+
 ### Storage and retention
 
 The extension stores telemetry as JSON Lines files in its VS Code global storage

--- a/docs/user-guides/workspace-access/vscode.md
+++ b/docs/user-guides/workspace-access/vscode.md
@@ -34,6 +34,56 @@ ext install coder.coder-remote
 Alternatively, manually install the VSIX from the
 [latest release](https://github.com/coder/vscode-coder/releases/latest).
 
+## Local telemetry
+
+The Coder Remote extension records local telemetry to help diagnose extension
+and workspace connection issues. Telemetry is stored on your machine. It is not
+sent to Coder unless you export it or include it in a support bundle and share
+that file.
+
+Local telemetry is controlled by the VS Code setting `coder.telemetry.level`:
+
+| Value   | Behavior                                                      |
+|---------|---------------------------------------------------------------|
+| `local` | Record telemetry events on this machine. This is the default. |
+| `off`   | Disable extension telemetry collection.                       |
+
+### Stored data
+
+Telemetry can include diagnostic details such as extension version, VS Code
+version, operating system, machine and session identifiers, deployment URL,
+workspace and agent names, command outcomes, connection state, request routes,
+timing, and error details. It does not intentionally collect source code,
+terminal contents, tokens, or credentials.
+
+### Storage and retention
+
+The extension stores telemetry as JSON Lines files in its VS Code global storage
+under a `telemetry` directory. Files rotate at 5 MiB, are kept for up to 30 days,
+and are capped at 100 MiB total by default.
+
+You can tune local retention with the advanced `coder.telemetry.local` setting.
+Most users should keep the default values.
+
+### Export telemetry
+
+To review or share telemetry:
+
+1. Open the VS Code Command Palette.
+1. Run **Coder: Export Telemetry**.
+1. Choose a date range and export format.
+1. Save the export, then review the file before sharing it.
+
+The extension supports JSON and OTLP JSON zip exports. Exports may contain the
+same diagnostic identifiers listed above, so only share them with people you
+trust.
+
+### Support bundles
+
+Coder support bundles include recent VS Code extension diagnostics, including
+local telemetry files, when available. Review the generated support bundle before
+sharing it.
+
 ## VS Code extensions
 
 There are multiple ways to add extensions to VS Code Desktop:

--- a/docs/user-guides/workspace-access/vscode.md
+++ b/docs/user-guides/workspace-access/vscode.md
@@ -45,8 +45,8 @@ Local telemetry is controlled by the VS Code setting `coder.telemetry.level`:
 
 | Value   | Behavior                                                      |
 |---------|---------------------------------------------------------------|
-| `local` | Record telemetry events on this machine. This is the default. |
 | `off`   | Disable extension telemetry collection.                       |
+| `local` | Record telemetry events on this machine. This is the default. |
 
 ### Stored data
 
@@ -58,20 +58,18 @@ terminal contents, tokens, or credentials.
 
 ### Tracked activity
 
-The exact events vary by extension version. They focus on support and debugging
-signals such as:
+The exact events vary by extension version. The following categories summarize
+the diagnostic signals the extension may record:
 
-- extension activation and deployment initialization
-- authentication, token refresh, logout, credential storage, and deployment
-  recovery
-- command execution and diagnostic workflows, such as telemetry export, support
-  bundles, ping, and speed tests
-- workspace selection, open, dev container handoff, start, and update prompts
-- CLI binary resolution, download, verification, and configuration
-- remote setup phases from workspace lookup through SSH handoff
-- workspace and agent state transitions
-- connection lifecycle, reconnects, SSH process health, and network samples
-- HTTP request rollups by normalized route, status class, and latency
+| Area                           | Examples                                                                                     |
+|--------------------------------|----------------------------------------------------------------------------------------------|
+| Extension lifecycle            | Activation, deployment initialization, and configuration loading.                            |
+| Authentication and credentials | Sign-in state, token refresh, logout, credential storage, and deployment recovery.           |
+| Commands and diagnostics       | Command outcomes, telemetry exports, support bundle creation, ping, and speed tests.         |
+| Workspace workflows            | Workspace selection, open attempts, dev container handoff, start, and update prompts.        |
+| CLI and remote setup           | CLI binary resolution, download, verification, configuration, and setup through SSH handoff. |
+| Connection health              | Workspace and agent state transitions, reconnects, SSH process health, and network samples.  |
+| HTTP diagnostics               | Normalized routes, status classes, and latency rollups.                                      |
 
 ### Storage and retention
 
@@ -92,8 +90,8 @@ The extension includes commands for collecting diagnostics from VS Code:
   `vscode-logs/` directory with recent VS Code extension diagnostics, including
   extension logs, proxy and Remote-SSH logs, redacted VS Code settings, and
   local telemetry files when available. The `vscode-logs/` directory is only
-  added when the bundle is created from the Coder Remote extension; bundles
-  created with the CLI alone do not include it.
+  added when the bundle is created from the VS Code Coder Remote extension;
+  bundles created with the CLI alone do not include it.
 - **Coder: View Logs** opens the extension output logs in VS Code.
 
 Support bundles can contain sensitive diagnostic data. Review the generated

--- a/docs/user-guides/workspace-access/vscode.md
+++ b/docs/user-guides/workspace-access/vscode.md
@@ -82,24 +82,20 @@ and are capped at 100 MiB total by default.
 You can tune local retention with the advanced `coder.telemetry.local` setting.
 Most users should keep the default values.
 
-### Export telemetry
+### Diagnostics and support bundles
 
-To review or share telemetry:
+The extension includes commands for collecting diagnostics from VS Code:
 
-1. Open the VS Code Command Palette.
-1. Run **Coder: Export Telemetry**.
-1. Choose a date range and export format.
-1. Save the export, then review the file before sharing it.
+- **Coder: Export Telemetry** exports only local telemetry. Choose a date range
+  and JSON or OTLP JSON zip format, then review the file before sharing it.
+- **Coder: Create Support Bundle** runs `coder support bundle` and adds recent
+  VS Code extension diagnostics, including extension logs, proxy and Remote-SSH
+  logs, redacted VS Code settings, and local telemetry files when available.
+- **Coder: View Logs** opens the extension output logs in VS Code.
 
-The extension supports JSON and OTLP JSON zip exports. Exports may contain the
-same diagnostic identifiers listed above, so only share them with people you
-trust.
-
-### Support bundles
-
-Coder support bundles include recent VS Code extension diagnostics, including
-local telemetry files, when available. Review the generated support bundle before
-sharing it.
+Support bundles can contain sensitive diagnostic data. Review the generated
+bundle before sharing it. Learn more about
+[support bundles](../../support/support-bundle.md).
 
 ## VS Code extensions
 

--- a/docs/user-guides/workspace-access/vscode.md
+++ b/docs/user-guides/workspace-access/vscode.md
@@ -58,8 +58,11 @@ terminal contents, tokens, or credentials.
 
 ### Tracked activity
 
-The exact events vary by extension version. The following categories summarize
-the diagnostic signals the extension may record:
+The exact events vary by extension version. For a comprehensive list of current
+events, properties, and attributes, see the
+[extension event reference](https://github.com/coder/vscode-coder/blob/b75c5e49b1c253373fb1128312918c1649e79281/src/instrumentation/EVENTS.md).
+The following categories summarize the diagnostic signals the extension may
+record:
 
 | Area                           | Examples                                                                                     |
 |--------------------------------|----------------------------------------------------------------------------------------------|


### PR DESCRIPTION
## Summary

Documents VS Code extension local telemetry in the VS Code workspace access guide.

Covers:
- local-only collection behavior and the `coder.telemetry.level` setting
- the kinds of diagnostic data that may be stored/exported
- storage and retention defaults
- the **Coder: Export Telemetry** flow
- support bundle behavior

Related:
- coder/vscode-coder#987
- coder/vscode-coder#996 covers the repo-side contributor guidance

## Testing

- `pnpm run check-docs`

<details>
<summary>Coder Agent disclosure</summary>

This PR was generated by Coder Agent from the local telemetry documentation follow-up.

</details>
