### PR TITLE
fix(offlinedocs): use portable -r flag in copyImages.sh

### DIFF
--- a/offlinedocs/scripts/copyImages.sh
+++ b/offlinedocs/scripts/copyImages.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cp ../docs/images public/images --recursive
+cp -r ../docs/images/ public/images


### PR DESCRIPTION
## Summary

`cp --recursive` is GNU-specific and not recognized by BSD `cp` on macOS. BSD `cp` treats `--recursive` as a third path argument, producing `cp: --recursive: Not a directory`.

This replaces `--recursive` (placed after operands) with the POSIX-portable `-r` flag placed before operands, which works on both Linux and macOS.

---

> Generated by Coder Agents on behalf of @nickvigilante