### PR TITLE
fix(cli): sort external auth env vars by numeric index

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -2904,11 +2904,22 @@ func ReadExternalAuthProvidersFromEnv(environ []string) ([]codersdk.ExternalAuth
 // external auth providers. A prefix is provided to support the legacy
 // parsing of `GITAUTH` environment variables.
 func parseExternalAuthProvidersFromEnv(prefix string, environ []string) ([]codersdk.ExternalAuthConfig, error) {
-	// The index numbers must be in-order.
-	slices.Sort(environ)
+	parsed := serpent.ParseEnviron(environ, prefix)
+
+	// Sort by numeric index so that PROVIDER_2 comes before PROVIDER_10.
+	// A lexicographic sort would order PROVIDER_10 between PROVIDER_1 and
+	// PROVIDER_2 and trip the "provider num skipped" check below.
+	slices.SortFunc(parsed, func(a, b serpent.EnvVar) int {
+		aIdx, _ := strconv.Atoi(strings.SplitN(a.Name, "_", 2)[0])
+		bIdx, _ := strconv.Atoi(strings.SplitN(b.Name, "_", 2)[0])
+		if aIdx != bIdx {
+			return aIdx - bIdx
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
 
 	var providers []codersdk.ExternalAuthConfig
-	for _, v := range serpent.ParseEnviron(environ, prefix) {
+	for _, v := range parsed {
 		tokens := strings.SplitN(v.Name, "_", 2)
 		if len(tokens) != 2 {
 			return nil, xerrors.Errorf("invalid env var: %s", v.Name)

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -107,6 +107,28 @@ func TestReadExternalAuthProvidersFromEnv(t *testing.T) {
 		assert.Equal(t, "Google", providers[1].DisplayName)
 		assert.Equal(t, "/icon/google.svg", providers[1].DisplayIcon)
 	})
+
+	// Regression test: when more than 10 providers are configured the
+	// previous lexicographic sort placed PROVIDER_10 between PROVIDER_1
+	// and PROVIDER_2 and the parser failed with "provider num skipped".
+	t.Run("MoreThan10Providers", func(t *testing.T) {
+		t.Parallel()
+		const count = 12
+		environ := make([]string, 0, count*2)
+		for i := 0; i < count; i++ {
+			environ = append(environ,
+				fmt.Sprintf("CODER_EXTERNAL_AUTH_%d_ID=id-%d", i, i),
+				fmt.Sprintf("CODER_EXTERNAL_AUTH_%d_TYPE=type-%d", i, i),
+			)
+		}
+		providers, err := cli.ReadExternalAuthProvidersFromEnv(environ)
+		require.NoError(t, err)
+		require.Len(t, providers, count)
+		for i := 0; i < count; i++ {
+			assert.Equal(t, fmt.Sprintf("id-%d", i), providers[i].ID)
+			assert.Equal(t, fmt.Sprintf("type-%d", i), providers[i].Type)
+		}
+	})
 }
 
 func TestReadExternalAuthProvidersFromEnv_APIBaseURL(t *testing.T) {


### PR DESCRIPTION
When more than 10 external auth providers were configured via env vars without zero-padding (e.g. `CODER_EXTERNAL_AUTH_0_*` ... `CODER_EXTERNAL_AUTH_10_*`), `coder server` failed to start with an error like:

```
provider num 1 skipped: 10_ID
```

## Root cause

`parseExternalAuthProvidersFromEnv` sorted env vars lexicographically with `slices.Sort(environ)`. That ordering placed `CODER_EXTERNAL_AUTH_10_*` between `CODER_EXTERNAL_AUTH_1_*` and `CODER_EXTERNAL_AUTH_2_*`, so by the time the parser saw index `10` only one provider had been appended, triggering the "provider num skipped" guard.

The analogous AI-provider parser (`readAIProvidersForPrefix`) already sorts by numeric index. This change ports the same approach to the external-auth parser. Zero-padded indices continue to work.

## Change

- Sort the parsed `serpent.EnvVar`s by their numeric provider index (ties broken by name) before consumption.
- Add a regression test that configures 12 providers without zero-padding and verifies they are all parsed in order. Without the fix the new test reproduces the customer's error; with the fix it passes.

## Verification

- `go test ./cli -run 'TestReadExternalAuthProvidersFromEnv|TestReadGitAuthProvidersFromEnv' -count=1` passes.
- Reverting the production change makes `TestReadExternalAuthProvidersFromEnv/MoreThan10Providers` fail with `provider num 1 skipped: 10_ID`, matching the customer's report.
- `go vet ./cli/...`, `gofmt`, and `scripts/check_emdash.sh` are clean.

---

_This PR was opened on a customer's behalf by Coder Agents._