### PR TITLE
fix(coderd): deflake TestWorkspaceBuildStatus audit log assertion

### DIFF
--- a/coderd/workspacebuilds_test.go
+++ b/coderd/workspacebuilds_test.go
@@ -1258,8 +1258,12 @@ func TestWorkspaceBuildStatus(t *testing.T) {
 
 	// assert an audit log has been created for workspace stopping
 	numLogs++ // add an audit log for workspace_build stop
-	require.Len(t, auditor.AuditLogs(), numLogs)
-	require.Equal(t, database.AuditActionStop, auditor.AuditLogs()[numLogs-1].Action)
+	// Audit logs are written asynchronously to build completion, so poll
+	// until the expected log appears.
+	require.Eventually(t, func() bool {
+		logs := auditor.AuditLogs()
+		return len(logs) == numLogs && logs[numLogs-1].Action == database.AuditActionStop
+	}, testutil.WaitShort, testutil.IntervalFast)
 
 	_ = closeDaemon.Close()
 	// after successful cancel is "canceled"

--- a/coderd/workspacebuilds_test.go
+++ b/coderd/workspacebuilds_test.go
@@ -1261,9 +1261,11 @@ func TestWorkspaceBuildStatus(t *testing.T) {
 	// Audit logs are written asynchronously to build completion, so poll
 	// until the expected log appears.
 	require.Eventually(t, func() bool {
-		logs := auditor.AuditLogs()
-		return len(logs) == numLogs &&
-			assert.Equal(t, database.AuditActionStop, logs[numLogs-1].Action)
+		return len(auditor.AuditLogs()) == numLogs &&
+			auditor.Contains(t, database.AuditLog{
+				Action:       database.AuditActionStop,
+				ResourceType: database.ResourceTypeWorkspaceBuild,
+			})
 	}, testutil.WaitShort, testutil.IntervalFast)
 
 	_ = closeDaemon.Close()

--- a/coderd/workspacebuilds_test.go
+++ b/coderd/workspacebuilds_test.go
@@ -1262,7 +1262,8 @@ func TestWorkspaceBuildStatus(t *testing.T) {
 	// until the expected log appears.
 	require.Eventually(t, func() bool {
 		logs := auditor.AuditLogs()
-		return len(logs) == numLogs && logs[numLogs-1].Action == database.AuditActionStop
+		return len(logs) == numLogs &&
+			assert.Equal(t, database.AuditActionStop, logs[numLogs-1].Action)
 	}, testutil.WaitShort, testutil.IntervalFast)
 
 	_ = closeDaemon.Close()

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -4614,16 +4614,16 @@ func TestWorkspaceDormant(t *testing.T) {
 		// start. Audit logs are written asynchronously to build completion,
 		// so poll until both appear.
 		require.Eventually(t, func() bool {
-			return len(auditor.AuditLogs()) == 2
+			return len(auditor.AuditLogs()) == 2 &&
+				auditor.Contains(t, database.AuditLog{
+					Action:       database.AuditActionWrite,
+					ResourceType: database.ResourceTypeWorkspace,
+				}) &&
+				auditor.Contains(t, database.AuditLog{
+					Action:       database.AuditActionStart,
+					ResourceType: database.ResourceTypeWorkspaceBuild,
+				})
 		}, testutil.WaitShort, testutil.IntervalFast)
-		require.True(t, auditor.Contains(t, database.AuditLog{
-			Action:       database.AuditActionWrite,
-			ResourceType: database.ResourceTypeWorkspace,
-		}))
-		require.True(t, auditor.Contains(t, database.AuditLog{
-			Action:       database.AuditActionStart,
-			ResourceType: database.ResourceTypeWorkspaceBuild,
-		}))
 	})
 }
 

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -4610,8 +4610,12 @@ func TestWorkspaceDormant(t *testing.T) {
 		require.NoError(t, err, "fetch updated workspace")
 		require.Nil(t, updatedWs.DormantAt)
 
-		// There should be an audit log for both the dormancy update and the start.
-		require.Len(t, auditor.AuditLogs(), 2)
+		// There should be an audit log for both the dormancy update and the
+		// start. Audit logs are written asynchronously to build completion,
+		// so poll until both appear.
+		require.Eventually(t, func() bool {
+			return len(auditor.AuditLogs()) == 2
+		}, testutil.WaitShort, testutil.IntervalFast)
 		require.True(t, auditor.Contains(t, database.AuditLog{
 			Action:       database.AuditActionWrite,
 			ResourceType: database.ResourceTypeWorkspace,


### PR DESCRIPTION
Fixes a flake in `TestWorkspaceBuildStatus` where the test asserted an exact audit log count immediately after the stop build completed:

```
workspacebuilds_test.go:1261: Error: "[...]" should have 7 item(s), but has 6
```

The audit log for a workspace build is exported asynchronously relative to what `AwaitWorkspaceBuildJobCompleted` observes, so the strict `require.Len` could run before the stop log was recorded. The assertion now polls with `require.Eventually` until the expected log count and stop action appear, matching the existing poll pattern in the file.

Also fixes the same race in `TestWorkspaceDormant/StartWakesUpDormantWorkspace` (`workspaces_test.go`), flagged during review as a sibling risk: its exact `require.Len(t, auditor.AuditLogs(), 2)` after build completion is now an equivalent `require.Eventually` poll.

Verified with `go test ./coderd -run TestWorkspaceBuildStatus -count=10` and `go test ./coderd -run 'TestWorkspaceDormant/StartWakesUpDormantWorkspace' -count=5`.

Closes https://github.com/coder/internal/issues/1565 (PLAT-304).

🤖 Generated by Coder Agents on behalf of @jscottmiller 