### PR TITLE
fix(site/src/pages/AgentsPage/components/ChatElements/tools): special-case Notion block logo in ToolIcon

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -1366,6 +1366,42 @@ export const MCPToolFigmaIcon: Story = {
 	},
 };
 
+// Notion advertises its MCP icon as a "block" logo: a coloured backdrop
+// with the glyph overlaid in the same SVG. The default monochrome filter
+// path would collapse that into a featureless square, so ToolIcon must
+// route composite block logos through the natural-colour badge branch.
+export const MCPToolNotionIcon: Story = {
+	args: {
+		name: "notion__fetch",
+		status: "completed",
+		result: { ok: true },
+		mcpServerConfigId: "mcp-server-1",
+		mcpServers: [
+			{
+				...sampleMCPServers[0],
+				slug: "notion",
+				display_name: "Notion",
+				icon_url: "https://www.notion.com/images/notion-logo-block-main.svg",
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const icon = await canvas.findByAltText("notion__fetch icon");
+		expect(icon).toBeInTheDocument();
+		expect(icon.getAttribute("src") ?? "").toContain(
+			"notion-logo-block-main.svg",
+		);
+		// Composite block logos must not get the silhouette filter.
+		expect(icon.className).not.toMatch(/brightness-0/);
+		expect(icon.className).not.toMatch(/dark:invert/);
+		// They render inside a rounded badge frame for the coloured backdrop.
+		const frame = icon.parentElement;
+		expect(frame).not.toBeNull();
+		expect(frame?.className ?? "").toMatch(/rounded-sm/);
+	},
+};
+
 export const MCPToolNoServer: Story = {
 	args: {
 		name: "some_custom_tool",

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolIcon.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolIcon.tsx
@@ -27,6 +27,19 @@ import {
 	type SubagentIconKind,
 } from "./subagentDescriptor";
 
+// Some MCP servers advertise composite "block" brand logos that
+// layer a colored backdrop and an overlaid glyph in the same SVG
+// (e.g. Notion's `notion-logo-block-*.svg`). A `brightness-0`
+// silhouette filter collapses both layers into a featureless square,
+// so those URLs render in their natural colors inside a small badge
+// frame instead. Extend the pattern when other vendors are found to
+// ship block-style logos via their MCP advertisement.
+const COMPOSITE_BLOCK_LOGO_RE = /notion-logo-block/i;
+
+function isCompositeBlockBrandLogo(url: string): boolean {
+	return COMPOSITE_BLOCK_LOGO_RE.test(url);
+}
+
 export const ToolIcon: React.FC<{
 	name: string;
 	isError: boolean;
@@ -49,8 +62,29 @@ export const ToolIcon: React.FC<{
 	// style. brightness-0 forces every pixel to black, then in dark
 	// mode we invert to white and tune opacity to approximate
 	// content-secondary (light ≈ 34% lightness, dark ≈ 65%).
+	//
+	// Exception: composite "block" brand logos (e.g. Notion) ship a
+	// coloured backdrop with an overlaid glyph in the same SVG. A
+	// silhouette filter would collapse both layers into a featureless
+	// square, so those render in their natural colours inside a small
+	// rounded badge frame.
 	if (iconUrl && !imgError) {
-		const img = (
+		const img = isCompositeBlockBrandLogo(iconUrl) ? (
+			<div
+				className={cn(
+					"flex size-4 shrink-0 items-center justify-center",
+					"overflow-hidden rounded-sm",
+					isRunning && "grayscale",
+				)}
+			>
+				<ExternalImage
+					src={iconUrl}
+					alt={`${name} icon`}
+					className="block size-4 object-contain"
+					onError={() => setImgError(true)}
+				/>
+			</div>
+		) : (
 			<div className="size-4 shrink-0 overflow-hidden">
 				<ExternalImage
 					src={iconUrl}


### PR DESCRIPTION
## What

Minimal fix for the Notion MCP tool icon rendering as a featureless square in the agent chat timeline.

`ToolIcon` applies a `brightness-0 dark:invert` filter to every advertised MCP icon so external brand glyphs match the monochrome lucide style of the built-in tools. Notion advertises a "block" logo (`notion-logo-block-*.svg`) that ships a coloured backdrop with the glyph overlaid in the same SVG, so the silhouette filter collapses both layers into a solid square.

This PR routes URLs matching `/notion-logo-block/i` through a separate branch that renders the SVG in its natural colours inside a small rounded badge frame. Everything else keeps the existing monochrome path.

## Why a comparison PR

This is intentionally the smallest possible change so the team can compare it against the broader architectural fix in #26228 before picking a direction.

| | This PR | #26228 |
|---|---|---|
| Scope | `ToolIcon` only | `ToolIcon`, `ExternalImage` defaults, MCP admin form, bundled icons, known-server registry |
| Files changed | 2 | 11 |
| Notion fix | regex special case in `ToolIcon` | bundled `notion.svg` registered as `monochrome` + unified `ExternalImage` pipeline |
| Linear / Figma washout in dark mode | unchanged | fixed via bundled icons and `defaultParametersForBuiltinIcons` |
| Admin UX | unchanged | URL prefills `displayName`, `slug`, `iconURL` for known MCP hosts; clearing the icon restores the bundled default |
| New regression coverage | 1 story (`MCPToolNotionIcon`) | 4 stories across `Tool.stories.tsx` and `MCPServerAdminPanel.stories.tsx` |

The regex approach is brittle (every new vendor that ships a composite block logo needs another entry), but it lands the Notion-only fix immediately without touching the form or shipping new assets. Land whichever direction the team prefers; close the other.

## Test plan

- `pnpm exec biome check` clean on the changed files.
- `pnpm exec tsc --noEmit -p tsconfig.json` clean.
- `pnpm test:storybook run src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx` -> 114 / 114 passing, including the new `MCPToolNotionIcon` story that asserts the rendered `<img>` keeps the block-logo URL, drops `brightness-0` and `dark:invert`, and sits inside a `rounded-sm` frame.

<details>
<summary>Decision log</summary>

- Started with the regex special case but rejected it as the primary fix in #26228 after pushback ("is special casing it the right solution?"). #26228 instead bundles `notion.svg`, `linear.svg`, and two Figma variants in `site/static/icon/`, registers the monochrome variants in `defaultParametersForBuiltinIcons`, drops the class-based filter in `ToolIcon`, and adds a URL-host `knownMcpServers` registry that prefills the MCP admin form.
- Reopened the regex approach in this PR specifically so the team can review both side by side before merging either.
- The regression story uses `findByAltText("notion__fetch icon")` rather than `getByRole("img")` so it survives sibling icons in the row, and asserts on the parent's `rounded-sm` class to lock in the badge frame.

</details>

<sub>This PR was generated by Coder Agents.</sub>
