### PR TITLE
fix(site/src/modules/resources): restore log auto-expand on script failure

### DIFF
--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -58,7 +58,10 @@ import {
 import { useProxy } from "#/contexts/ProxyContext";
 import { useClipboard } from "#/hooks/useClipboard";
 import { useFeatureVisibility } from "#/modules/dashboard/useFeatureVisibility";
-import { getAgentConnectivityIssues } from "#/modules/workspaces/health";
+import {
+	getAgentConnectivityIssues,
+	getAgentScriptIssues,
+} from "#/modules/workspaces/health";
 import { AgentAlert } from "#/pages/WorkspacePage/AgentAlert";
 import { AppStatuses } from "#/pages/WorkspacePage/AppStatuses";
 import { cn } from "#/utils/cn";
@@ -163,16 +166,21 @@ export const AgentRow: FC<AgentRowProps> = ({
 	const runningScriptsCount = agent.scripts.filter(
 		(s) => s.run_on_start && !s.status,
 	).length;
-	// Use connectivity issues for agent panel styling and visibility decisions.
-	// Script issues are handled separately in the log tabs.
+	// Connectivity issues drive agent panel styling (border color, warning
+	// badge). Script issues are kept out of that styling so a failed script
+	// does not imply a connectivity problem, but they still auto-expand the
+	// logs so the failing script's tab surfaces on its own.
 	const connectivityIssues = getAgentConnectivityIssues(agent);
 	const hasConnectivityIssues = connectivityIssues.length > 0;
 	const hasWarningConnectivityIssues = connectivityIssues.some(
 		(i) => i.severity === "warning",
 	);
+	const hasScriptIssues = getAgentScriptIssues(agent).length > 0;
 	const { proxy } = useProxy();
 	const [showLogs, setShowLogs] = useState(
-		(agent.lifecycle_state !== "ready" || hasConnectivityIssues) &&
+		(agent.lifecycle_state !== "ready" ||
+			hasConnectivityIssues ||
+			hasScriptIssues) &&
 			hasStartupFeatures,
 	);
 	const agentLogs = useAgentLogs({ agentId: agent.id, enabled: showLogs });
@@ -182,10 +190,17 @@ export const AgentRow: FC<AgentRowProps> = ({
 
 	useEffect(() => {
 		setShowLogs(
-			(agent.lifecycle_state !== "ready" || hasConnectivityIssues) &&
+			(agent.lifecycle_state !== "ready" ||
+				hasConnectivityIssues ||
+				hasScriptIssues) &&
 				hasStartupFeatures,
 		);
-	}, [agent.lifecycle_state, hasConnectivityIssues, hasStartupFeatures]);
+	}, [
+		agent.lifecycle_state,
+		hasConnectivityIssues,
+		hasScriptIssues,
+		hasStartupFeatures,
+	]);
 
 	// This is a layout effect to remove flicker when we're scrolling to the bottom.
 	// biome-ignore lint/correctness/useExhaustiveDependencies: consider refactoring


### PR DESCRIPTION
#26124 introduced a regression on `main`: `AgentRow › NonStartupScriptError` fails because the refactor replaced `hasAgentIssues` (which covered both connectivity and script issues) with `hasConnectivityIssues` only in the `showLogs` condition. For a `ready` agent with a failed script but no connectivity issues, `showLogs` becomes false, logs never load, and the failed script tab never renders. The PR's own behavior table said logs should still auto-open in this case — it was an implementation oversight, not an intentional change.

Fix by including `hasScriptIssues` in the `showLogs` condition alongside `hasConnectivityIssues`, restoring the auto-expand behavior from #25442 without touching connectivity badge styling.

> **Note:** This reached `main` undetected because `test-js` in CI only runs `--project=unit`; the Storybook interaction tests (`--project=storybook`) that caught this are not a required check. When Chromatic is switched off, `--project=storybook` should be added to the required gate.

Refs #26124, #25442