### PR TITLE
fix: escape agent log HTML (#25808)

### DIFF
--- a/site/src/modules/resources/AgentLogs/AgentLogLine.test.tsx
+++ b/site/src/modules/resources/AgentLogs/AgentLogLine.test.tsx
@@ -1,0 +1,23 @@
+import { screen } from "@testing-library/react";
+import type { Line } from "#/components/Logs/LogLine";
+import { renderComponent } from "#/testHelpers/renderHelpers";
+import { AgentLogLine } from "./AgentLogLine";
+
+const line: Line = {
+	id: 1,
+	level: "info",
+	output: 'safe <span data-testid="agent-log-xss">xss</span>',
+	sourceId: "source-id",
+	time: "2024-03-14T11:31:04.090715Z",
+};
+
+describe("AgentLogLine", () => {
+	it("renders log HTML as escaped text", () => {
+		renderComponent(<AgentLogLine line={line} sourceIcon={null} style={{}} />);
+
+		expect(screen.queryByTestId("agent-log-xss")).not.toBeInTheDocument();
+		expect(
+			screen.getByText(/safe <span data-testid="agent-log-xss">xss<\/span>/),
+		).toBeInTheDocument();
+	});
+});

--- a/site/src/modules/resources/AgentLogs/AgentLogLine.tsx
+++ b/site/src/modules/resources/AgentLogs/AgentLogLine.tsx
@@ -5,7 +5,7 @@ import { type Line, LogLine, LogLinePrefix } from "#/components/Logs/LogLine";
 // Approximate height of a log line. Used to control virtualized list height.
 export const AGENT_LOG_LINE_HEIGHT = 20;
 
-const convert = new AnsiToHTML();
+const convert = new AnsiToHTML({ escapeXML: true });
 
 interface AgentLogLineProps {
 	line: Line;


### PR DESCRIPTION
Cherry-pick backport to `release/2.32`.