### PR TITLE
chore: bump Go to 1.26.4 on release/2.34

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -4,7 +4,7 @@ description: |
 inputs:
   version:
     description: "The Go version to use."
-    default: "1.26.2"
+    default: "1.26.4"
   use-cache:
     description: "Whether to use the cache."
     default: "true"


### PR DESCRIPTION
Backports the Go toolchain security update to `release/2.34`.

`release/2.34` is already on Go `1.26.4` in `go.mod`/`mise.toml`, but the `setup-go` composite action still defaulted to `1.26.2`. This updates the action default to `1.26.4` so CI uses the patched toolchain, addressing:

- **CVE-2026-27145** (Low): `crypto/x509` `VerifyHostname` quadratic cost with large DNS SAN lists.
- **CVE-2026-42507** (Low): `net/textproto` unescaped attacker-controlled input in errors (log injection).

Related to the upstream upgrade in #26066 (`61a35185cf`).

<details>
<summary>Why this differs from a direct cherry-pick of 61a35185cf</summary>

Commit `61a35185cf` bumps `go.mod`/`mise.toml`/`mise.lock` from `1.26.2` to `1.26.4`. On `release/2.34` those files are already at `1.26.4`, so a cherry-pick is a no-op there. The only remaining `1.26.2` reference was the `setup-go` action default, which this PR updates directly.
</details>

> Generated by Coder Agents on behalf of @sreya
