### PR TITLE
fix!: reject OIDC login when email_verified claim is non-bool or absent (#25713)

### DIFF
--- a/coderd/coderdtest/oidctest/idp.go
+++ b/coderd/coderdtest/oidctest/idp.go
@@ -213,8 +213,9 @@ type FakeIDP struct {
 	hookAuthenticateClient func(t testing.TB, req *http.Request) (url.Values, error)
 	serve                  bool
 	// optional middlewares
-	middlewares   chi.Middlewares
-	defaultExpire time.Duration
+	middlewares              chi.Middlewares
+	defaultExpire            time.Duration
+	omitEmailVerifiedDefault bool
 }
 
 func StatusError(code int, err error) error {
@@ -366,6 +367,15 @@ func WithServing() func(*FakeIDP) {
 func WithIssuer(issuer string) func(*FakeIDP) {
 	return func(f *FakeIDP) {
 		f.locked.SetIssuer(issuer)
+	}
+}
+
+// WithOmitEmailVerifiedDefault suppresses the default email_verified=true
+// injection in encodeClaims. Use this for tests that exercise the handler's
+// absent-claim rejection path.
+func WithOmitEmailVerifiedDefault() func(*FakeIDP) {
+	return func(f *FakeIDP) {
+		f.omitEmailVerifiedDefault = true
 	}
 }
 
@@ -880,6 +890,17 @@ func (f *FakeIDP) encodeClaims(t testing.TB, claims jwt.MapClaims) string {
 
 	if _, ok := claims["iss"]; !ok {
 		claims["iss"] = f.locked.Issuer()
+	}
+
+	// Default email_verified to true so that tests that do not care
+	// about the email_verified flow are not forced to set it.
+	// Tests that need a different value can set it explicitly.
+	// Use WithOmitEmailVerifiedDefault() to suppress this default
+	// for tests that need to exercise the absent-claim path.
+	if !f.omitEmailVerifiedDefault {
+		if _, ok := claims["email_verified"]; !ok {
+			claims["email_verified"] = true
+		}
 	}
 
 	signed, err := jwt.NewWithClaims(jwt.SigningMethodRS256, claims).SignedString(f.locked.PrivateKey())

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -3,6 +3,7 @@ package coderd
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -45,6 +46,7 @@ import (
 	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/cryptorand"
+	"github.com/coder/coder/v2/site"
 )
 
 type MergedClaimsSource string
@@ -1325,18 +1327,38 @@ func (api *API) userOIDC(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	verifiedRaw, ok := mergedClaims["email_verified"]
-	if ok {
-		verified, ok := verifiedRaw.(bool)
-		if ok && !verified {
-			if !api.OIDCConfig.IgnoreEmailVerified {
-				httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
-					Message: fmt.Sprintf("Verify the %q email address on your OIDC provider to authenticate!", email),
-				})
-				return
-			}
-			logger.Warn(ctx, "allowing unverified oidc email %q")
+	// Determine whether the email is verified. Default to unverified
+	// so that a missing claim or an unrecognized type is fail-closed.
+	emailVerified := false
+	verifiedRaw, hasVerifiedClaim := mergedClaims["email_verified"]
+	if hasVerifiedClaim {
+		v, coerceOK := coerceEmailVerified(verifiedRaw)
+		if coerceOK {
+			emailVerified = v
+		} else {
+			logger.Warn(ctx, "unrecognized email_verified claim type, treating as unverified",
+				slog.F("type", fmt.Sprintf("%T", verifiedRaw)),
+				slog.F("value", verifiedRaw),
+			)
 		}
+	}
+
+	if !emailVerified {
+		if !api.OIDCConfig.IgnoreEmailVerified {
+			site.RenderStaticErrorPage(rw, r, site.ErrorPageData{
+				Status:     http.StatusForbidden,
+				HideStatus: true,
+				Title:      "Email not verified",
+				Description: fmt.Sprintf(
+					"Verify the %q email address on your OIDC provider to authenticate!",
+					email,
+				),
+				AdditionalButtonLink: "/login",
+				AdditionalButtonText: "Back to login",
+			})
+			return
+		}
+		logger.Warn(ctx, "allowing unverified oidc email", slog.F("email", email))
 	}
 
 	// The username is a required property in Coder. We make a best-effort
@@ -2128,5 +2150,41 @@ func wrongLoginTypeHTTPError(user database.LoginType, params database.LoginType)
 		Msg:              "Incorrect login type",
 		Detail: fmt.Sprintf("Attempting to use login type %q, but the user has the login type %q.%s",
 			params, user, addedMsg),
+	}
+}
+
+// coerceEmailVerified attempts to convert an OIDC email_verified claim to a
+// boolean. Some IdPs (e.g. SAML-to-OIDC bridges, certain Azure AD B2C
+// configurations) return email_verified as a string ("true"/"false") or a
+// number (1/0) rather than a native JSON boolean. This function handles
+// those variants so that non-bool representations cannot silently bypass
+// the verification check.
+//
+// Returns (value, true) on successful coercion, or (false, false) if the
+// value is nil or an unrecognized type.
+func coerceEmailVerified(v interface{}) (verified bool, ok bool) {
+	switch val := v.(type) {
+	case bool:
+		return val, true
+	case string:
+		b, err := strconv.ParseBool(val)
+		if err != nil {
+			return false, false
+		}
+		return b, true
+	case json.Number:
+		n, err := val.Int64()
+		if err != nil {
+			return false, false
+		}
+		return n != 0, true
+	case float64:
+		return val != 0, true
+	case int64:
+		return val != 0, true
+	case int:
+		return val != 0, true
+	default:
+		return false, false
 	}
 }

--- a/coderd/userauth_internal_test.go
+++ b/coderd/userauth_internal_test.go
@@ -1,0 +1,65 @@
+package coderd
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCoerceEmailVerified(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    interface{}
+		wantBool bool
+		wantOK   bool
+	}{
+		// Native booleans
+		{name: "BoolTrue", input: true, wantBool: true, wantOK: true},
+		{name: "BoolFalse", input: false, wantBool: false, wantOK: true},
+
+		// Strings
+		{name: "StringTrue", input: "true", wantBool: true, wantOK: true},
+		{name: "StringFalse", input: "false", wantBool: false, wantOK: true},
+		{name: "StringOne", input: "1", wantBool: true, wantOK: true},
+		{name: "StringZero", input: "0", wantBool: false, wantOK: true},
+		{name: "StringTRUE", input: "TRUE", wantBool: true, wantOK: true},
+		{name: "StringFALSE", input: "FALSE", wantBool: false, wantOK: true},
+		{name: "StringT", input: "t", wantBool: true, wantOK: true},
+		{name: "StringF", input: "f", wantBool: false, wantOK: true},
+		{name: "StringInvalid", input: "invalid", wantBool: false, wantOK: false},
+		{name: "StringEmpty", input: "", wantBool: false, wantOK: false},
+
+		// json.Number (when decoder uses UseNumber)
+		{name: "JSONNumberOne", input: json.Number("1"), wantBool: true, wantOK: true},
+		{name: "JSONNumberZero", input: json.Number("0"), wantBool: false, wantOK: true},
+		{name: "JSONNumberInvalid", input: json.Number("abc"), wantBool: false, wantOK: false},
+
+		// float64 (default JSON numeric type)
+		{name: "Float64One", input: float64(1), wantBool: true, wantOK: true},
+		{name: "Float64Zero", input: float64(0), wantBool: false, wantOK: true},
+
+		// Integer types
+		{name: "IntOne", input: int(1), wantBool: true, wantOK: true},
+		{name: "IntZero", input: int(0), wantBool: false, wantOK: true},
+		{name: "Int64One", input: int64(1), wantBool: true, wantOK: true},
+		{name: "Int64Zero", input: int64(0), wantBool: false, wantOK: true},
+
+		// Nil and unsupported types
+		{name: "Nil", input: nil, wantBool: false, wantOK: false},
+		{name: "Slice", input: []string{}, wantBool: false, wantOK: false},
+		{name: "Map", input: map[string]string{}, wantBool: false, wantOK: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotBool, gotOK := coerceEmailVerified(tc.input)
+			assert.Equal(t, tc.wantBool, gotBool, "bool value mismatch")
+			assert.Equal(t, tc.wantOK, gotOK, "ok value mismatch")
+		})
+	}
+}

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -1062,7 +1062,8 @@ func TestUserOIDC(t *testing.T) {
 				"sub": uuid.NewString(),
 			},
 			AccessTokenClaims: jwt.MapClaims{
-				"email": "kyle@kwc.io",
+				"email":          "kyle@kwc.io",
+				"email_verified": true,
 			},
 			IgnoreUserInfo: true,
 			AllowSignups:   true,
@@ -1085,14 +1086,38 @@ func TestUserOIDC(t *testing.T) {
 		{
 			Name: "EmailOnly",
 			IDTokenClaims: jwt.MapClaims{
-				"email": "kyle@kwc.io",
-				"sub":   uuid.NewString(),
+				"email":          "kyle@kwc.io",
+				"email_verified": true,
+				"sub":            uuid.NewString(),
 			},
 			AllowSignups: true,
 			StatusCode:   http.StatusOK,
 			AssertUser: func(t testing.TB, u codersdk.User) {
 				assert.Equal(t, "kyle", u.Username)
 			},
+		},
+		{
+			Name: "EmailVerifiedAsStringTrue",
+			IDTokenClaims: jwt.MapClaims{
+				"email":          "kyle@kwc.io",
+				"email_verified": "true",
+				"sub":            uuid.NewString(),
+			},
+			AllowSignups: true,
+			StatusCode:   http.StatusOK,
+			AssertUser: func(t testing.TB, u codersdk.User) {
+				assert.Equal(t, "kyle", u.Username)
+			},
+		},
+		{
+			Name: "EmailVerifiedAsStringFalse",
+			IDTokenClaims: jwt.MapClaims{
+				"email":          "kyle@kwc.io",
+				"email_verified": "false",
+				"sub":            uuid.NewString(),
+			},
+			AllowSignups: true,
+			StatusCode:   http.StatusForbidden,
 		},
 		{
 			Name: "EmailNotVerified",
@@ -1316,6 +1341,7 @@ func TestUserOIDC(t *testing.T) {
 			// See: https://github.com/coder/coder/issues/4472
 			Name: "UsernameIsEmail",
 			IDTokenClaims: jwt.MapClaims{
+				"email_verified":     true,
 				"preferred_username": "kyle@kwc.io",
 				"sub":                uuid.NewString(),
 			},
@@ -1365,9 +1391,10 @@ func TestUserOIDC(t *testing.T) {
 		{
 			Name: "GroupsDoesNothing",
 			IDTokenClaims: jwt.MapClaims{
-				"email":  "coolin@coder.com",
-				"groups": []string{"pingpong"},
-				"sub":    uuid.NewString(),
+				"email":          "coolin@coder.com",
+				"email_verified": true,
+				"groups":         []string{"pingpong"},
+				"sub":            uuid.NewString(),
 			},
 			AllowSignups: true,
 			StatusCode:   http.StatusOK,
@@ -1540,6 +1567,57 @@ func TestUserOIDC(t *testing.T) {
 		})
 	}
 
+	// Absent email_verified claim tests use a FakeIDP that suppresses the
+	// default email_verified=true injection so the handler's absent-claim
+	// branch is exercised end-to-end.
+	t.Run("EmailVerifiedMissing", func(t *testing.T) {
+		t.Parallel()
+		fake := oidctest.NewFakeIDP(t,
+			oidctest.WithRefresh(func(_ string) error {
+				return xerrors.New("refreshing token should never occur")
+			}),
+			oidctest.WithServing(),
+			oidctest.WithOmitEmailVerifiedDefault(),
+		)
+		cfg := fake.OIDCConfig(t, nil, func(cfg *coderd.OIDCConfig) {
+			cfg.AllowSignups = true
+		})
+		client := coderdtest.New(t, &coderdtest.Options{
+			OIDCConfig: cfg,
+		})
+		_, resp := fake.AttemptLogin(t, client, jwt.MapClaims{
+			"email": "kyle@kwc.io",
+			"sub":   uuid.NewString(),
+		})
+		require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("EmailVerifiedMissingIgnored", func(t *testing.T) {
+		t.Parallel()
+		fake := oidctest.NewFakeIDP(t,
+			oidctest.WithRefresh(func(_ string) error {
+				return xerrors.New("refreshing token should never occur")
+			}),
+			oidctest.WithServing(),
+			oidctest.WithOmitEmailVerifiedDefault(),
+		)
+		cfg := fake.OIDCConfig(t, nil, func(cfg *coderd.OIDCConfig) {
+			cfg.AllowSignups = true
+			cfg.IgnoreEmailVerified = true
+		})
+		client := coderdtest.New(t, &coderdtest.Options{
+			OIDCConfig: cfg,
+		})
+		userClient, _ := fake.Login(t, client, jwt.MapClaims{
+			"email": "kyle@kwc.io",
+			"sub":   uuid.NewString(),
+		})
+		ctx := testutil.Context(t, testutil.WaitShort)
+		user, err := userClient.User(ctx, "me")
+		require.NoError(t, err)
+		require.Equal(t, "kyle", user.Username)
+	})
+
 	t.Run("OIDCDormancy", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitShort)
@@ -1569,8 +1647,9 @@ func TestUserOIDC(t *testing.T) {
 		auditor.ResetLogs()
 
 		client, resp := fake.AttemptLogin(t, owner, jwt.MapClaims{
-			"email": user.Email,
-			"sub":   uuid.NewString(),
+			"email":          user.Email,
+			"email_verified": true,
+			"sub":            uuid.NewString(),
 		})
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 
@@ -1608,8 +1687,9 @@ func TestUserOIDC(t *testing.T) {
 		require.Equal(t, codersdk.LoginTypePassword, userData.LoginType)
 
 		claims := jwt.MapClaims{
-			"email": userData.Email,
-			"sub":   uuid.NewString(),
+			"email":          userData.Email,
+			"email_verified": true,
+			"sub":            uuid.NewString(),
 		}
 		var err error
 		user.HTTPClient.Jar, err = cookiejar.New(nil)
@@ -1679,8 +1759,9 @@ func TestUserOIDC(t *testing.T) {
 		user, userData := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
 
 		claims := jwt.MapClaims{
-			"email": userData.Email,
-			"sub":   uuid.NewString(),
+			"email":          userData.Email,
+			"email_verified": true,
+			"sub":            uuid.NewString(),
 		}
 		user.HTTPClient.Jar, err = cookiejar.New(nil)
 		require.NoError(t, err)
@@ -1750,8 +1831,9 @@ func TestUserOIDC(t *testing.T) {
 
 		numLogs := len(auditor.AuditLogs())
 		claims := jwt.MapClaims{
-			"email": "jon@coder.com",
-			"sub":   uuid.NewString(),
+			"email":          "jon@coder.com",
+			"email_verified": true,
+			"sub":            uuid.NewString(),
 		}
 
 		userClient, _ := fake.Login(t, client, claims)
@@ -1765,8 +1847,9 @@ func TestUserOIDC(t *testing.T) {
 		// Pass a different subject field so that we prompt creating a
 		// new user
 		userClient, _ = fake.Login(t, client, jwt.MapClaims{
-			"email": "jon@example2.com",
-			"sub":   "diff",
+			"email":          "jon@example2.com",
+			"email_verified": true,
+			"sub":            "diff",
 		})
 		numLogs++ // add an audit log for login
 
@@ -2117,9 +2200,10 @@ func TestOIDCSkipIssuer(t *testing.T) {
 	ctx := testutil.Context(t, testutil.WaitShort)
 	//nolint:bodyclose
 	userClient, _ := fake.Login(t, owner, jwt.MapClaims{
-		"iss":   secondaryURLString,
-		"email": "alice@coder.com",
-		"sub":   uuid.NewString(),
+		"iss":            secondaryURLString,
+		"email":          "alice@coder.com",
+		"email_verified": true,
+		"sub":            uuid.NewString(),
 	})
 	found, err := userClient.User(ctx, "me")
 	require.NoError(t, err)

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -875,8 +875,9 @@ func TestPostUsers(t *testing.T) {
 
 		// Try to log in with OIDC.
 		userClient, _ := fake.Login(t, client, jwt.MapClaims{
-			"email": email,
-			"sub":   uuid.NewString(),
+			"email":          email,
+			"email_verified": true,
+			"sub":            uuid.NewString(),
 		})
 
 		found, err := userClient.User(ctx, "me")

--- a/enterprise/coderd/userauth_test.go
+++ b/enterprise/coderd/userauth_test.go
@@ -173,7 +173,7 @@ func TestUserOIDC(t *testing.T) {
 			fields, err := runner.AdminClient.GetAvailableIDPSyncFields(ctx)
 			require.NoError(t, err)
 			require.ElementsMatch(t, []string{
-				"sub", "aud", "exp", "iss", // Always included from jwt
+				"sub", "aud", "exp", "iss", "email_verified", // Always included from jwt
 				"email", "organization",
 			}, fields)
 


### PR DESCRIPTION
Backport of #25713 to `release/2.29`.

Cherry-picked with `git cherry-pick -x` (`d5b0e93c6c`); the commit message references the original PR.

> [!NOTE]
> Breaking change. See the original PR for the breaking-change details.

<details>
<summary>Cherry-pick conflict resolution</summary>

The `coerceEmailVerified` helper, the FakeIDP default, and the new tests applied cleanly. `coderd/userauth.go` needed:

- the fail-closed `email_verified` check resolved in favor of the original PR (this branch previously used a bool type assertion with `httpapi.Write`);
- the `site` import added, and the "Email not verified" error rendered with this branch's `ErrorPageData` API (`AdditionalButtonLink` / `AdditionalButtonText`), because the `Actions` field does not exist on this branch.

Build, `TestCoerceEmailVerified`, and the OIDC integration cases pass.
</details>

_Generated by Coder Agents on behalf of @jdomeracki-coder._