### PR TITLE
fix(coderd)!: restrict OIDC email fallback to first-time account linking (#25712)

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -5390,7 +5390,7 @@ func (q *querier) UpdateUserLink(ctx context.Context, arg database.UpdateUserLin
 }
 
 func (q *querier) UpdateUserLinkedID(ctx context.Context, arg database.UpdateUserLinkedIDParams) (database.UserLink, error) {
-	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceUserObject(arg.UserID)); err != nil {
 		return database.UserLink{}, err
 	}
 	return q.db.UpdateUserLinkedID(ctx, arg)

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -1557,6 +1557,12 @@ func (s *MethodTestSuite) TestUser() {
 		dbm.EXPECT().UpdateUserLink(gomock.Any(), arg).Return(link, nil).AnyTimes()
 		check.Args(arg).Asserts(link, policy.ActionUpdatePersonal).Returns(link)
 	}))
+	s.Run("UpdateUserLinkedID", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		link := testutil.Fake(s.T(), faker, database.UserLink{})
+		arg := database.UpdateUserLinkedIDParams{LinkedID: link.LinkedID, UserID: link.UserID, LoginType: link.LoginType}
+		dbm.EXPECT().UpdateUserLinkedID(gomock.Any(), arg).Return(link, nil).AnyTimes()
+		check.Args(arg).Asserts(link, policy.ActionUpdate).Returns(link)
+	}))
 	s.Run("UpdateUserRoles", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		u := testutil.Fake(s.T(), faker, database.User{RBACRoles: []string{codersdk.RoleTemplateAdmin}})
 		o := u
@@ -2873,13 +2879,6 @@ func (s *MethodTestSuite) TestCryptoKeys() {
 }
 
 func (s *MethodTestSuite) TestSystemFunctions() {
-	s.Run("UpdateUserLinkedID", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
-		u := testutil.Fake(s.T(), faker, database.User{})
-		l := testutil.Fake(s.T(), faker, database.UserLink{UserID: u.ID})
-		arg := database.UpdateUserLinkedIDParams{UserID: u.ID, LinkedID: l.LinkedID, LoginType: database.LoginTypeGithub}
-		dbm.EXPECT().UpdateUserLinkedID(gomock.Any(), arg).Return(l, nil).AnyTimes()
-		check.Args(arg).Asserts(rbac.ResourceSystem, policy.ActionUpdate).Returns(l)
-	}))
 	s.Run("GetLatestWorkspaceAppStatusByAppID", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		appID := uuid.New()
 		dbm.EXPECT().GetLatestWorkspaceAppStatusByAppID(gomock.Any(), appID).Return(database.WorkspaceAppStatus{}, nil).AnyTimes()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -711,6 +711,9 @@ type sqlcQuerier interface {
 	UpdateUserHashedPassword(ctx context.Context, arg UpdateUserHashedPasswordParams) error
 	UpdateUserLastSeenAt(ctx context.Context, arg UpdateUserLastSeenAtParams) (User, error)
 	UpdateUserLink(ctx context.Context, arg UpdateUserLinkParams) (UserLink, error)
+	// Backfills linked_id for legacy user_links that were created before
+	// linked_id tracking was added. Only updates when linked_id is empty
+	// to avoid overwriting a valid binding.
 	UpdateUserLinkedID(ctx context.Context, arg UpdateUserLinkedIDParams) (UserLink, error)
 	UpdateUserLoginType(ctx context.Context, arg UpdateUserLoginTypeParams) (User, error)
 	UpdateUserNotificationPreferences(ctx context.Context, arg UpdateUserNotificationPreferencesParams) (int64, error)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -15925,7 +15925,7 @@ UPDATE
 SET
 	linked_id = $1
 WHERE
-	user_id = $2 AND login_type = $3 RETURNING user_id, login_type, linked_id, oauth_access_token, oauth_refresh_token, oauth_expiry, oauth_access_token_key_id, oauth_refresh_token_key_id, claims
+	user_id = $2 AND login_type = $3 AND linked_id = '' RETURNING user_id, login_type, linked_id, oauth_access_token, oauth_refresh_token, oauth_expiry, oauth_access_token_key_id, oauth_refresh_token_key_id, claims
 `
 
 type UpdateUserLinkedIDParams struct {
@@ -15934,6 +15934,9 @@ type UpdateUserLinkedIDParams struct {
 	LoginType LoginType `db:"login_type" json:"login_type"`
 }
 
+// Backfills linked_id for legacy user_links that were created before
+// linked_id tracking was added. Only updates when linked_id is empty
+// to avoid overwriting a valid binding.
 func (q *sqlQuerier) UpdateUserLinkedID(ctx context.Context, arg UpdateUserLinkedIDParams) (UserLink, error) {
 	row := q.db.QueryRowContext(ctx, updateUserLinkedID, arg.LinkedID, arg.UserID, arg.LoginType)
 	var i UserLink

--- a/coderd/database/queries/user_links.sql
+++ b/coderd/database/queries/user_links.sql
@@ -37,14 +37,6 @@ INSERT INTO
 VALUES
 	( $1, $2, $3, $4, $5, $6, $7, $8, $9 ) RETURNING *;
 
--- name: UpdateUserLinkedID :one
-UPDATE
-	user_links
-SET
-	linked_id = $1
-WHERE
-	user_id = $2 AND login_type = $3 RETURNING *;
-
 -- name: UpdateUserLink :one
 UPDATE
 	user_links
@@ -57,6 +49,17 @@ SET
 	claims = $6
 WHERE
 	user_id = $7 AND login_type = $8 RETURNING *;
+
+-- name: UpdateUserLinkedID :one
+-- Backfills linked_id for legacy user_links that were created before
+-- linked_id tracking was added. Only updates when linked_id is empty
+-- to avoid overwriting a valid binding.
+UPDATE
+	user_links
+SET
+	linked_id = @linked_id
+WHERE
+	user_id = @user_id AND login_type = @login_type AND linked_id = '' RETURNING *;
 
 -- name: OIDCClaimFields :many
 -- OIDCClaimFields returns a list of distinct keys in the the merged_claims fields.

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -45,6 +45,7 @@ import (
 	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/cryptorand"
+	"github.com/coder/coder/v2/site"
 )
 
 type MergedClaimsSource string
@@ -1031,7 +1032,16 @@ func (api *API) userOAuth2Github(rw http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	user, link, err := findLinkedUser(ctx, api.Database, githubLinkedID(ghUser), verifiedEmail.GetEmail())
+	user, link, err := findLinkedUser(ctx, api.Database, githubLinkedID(ghUser), database.LoginTypeGithub, verifiedEmail.GetEmail())
+	if errors.Is(err, errLinkedIDAlreadyBound) {
+		logger.Warn(ctx, "oauth2: blocked login, account already linked to different identity",
+			slog.F("email", verifiedEmail.GetEmail()),
+		)
+		httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
+			Message: "This account is already linked to a different identity provider subject.",
+		})
+		return
+	}
 	if err != nil {
 		logger.Error(ctx, "oauth2: unable to find linked user", slog.F("gh_user", ghUser.Name), slog.Error(err))
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
@@ -1396,7 +1406,21 @@ func (api *API) userOIDC(rw http.ResponseWriter, r *http.Request) {
 
 	ctx = slog.With(ctx, slog.F("email", email), slog.F("username", username), slog.F("name", name))
 
-	user, link, err := findLinkedUser(ctx, api.Database, oidcLinkedID(idToken), email)
+	user, link, err := findLinkedUser(ctx, api.Database, oidcLinkedID(idToken), database.LoginTypeOIDC, email)
+	if errors.Is(err, errLinkedIDAlreadyBound) {
+		logger.Warn(ctx, "oauth2: blocked login, account already linked to different identity",
+			slog.F("email", email),
+		)
+		site.RenderStaticErrorPage(rw, r, site.ErrorPageData{
+			Status:               http.StatusForbidden,
+			HideStatus:           true,
+			Title:                "Account already linked",
+			Description:          "This account is already linked to a different identity provider subject. Contact your administrator.",
+			AdditionalButtonLink: "/login",
+			AdditionalButtonText: "Back to login",
+		})
+		return
+	}
 	if err != nil {
 		logger.Error(ctx, "oauth2: unable to find linked user", slog.F("email", email), slog.Error(err))
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
@@ -1829,6 +1853,31 @@ func (api *API) oauthLogin(r *http.Request, params *oauthLoginParams) ([]*http.C
 			if err != nil {
 				return xerrors.Errorf("update user link: %w", err)
 			}
+
+			// Defense-in-depth: if a concurrent transaction backfilled
+			// linked_id between findLinkedUser and this point, reject the
+			// login with a 403 instead of letting it bubble up as a 500.
+			if link.LinkedID != "" && link.LinkedID != params.LinkedID {
+				return &idpsync.HTTPError{
+					Code:             http.StatusForbidden,
+					Msg:              "Account already linked",
+					Detail:           "This account is already linked to a different identity provider subject. Contact your administrator.",
+					RenderStaticPage: true,
+				}
+			}
+
+			// Backfill linked_id for legacy links.
+			if link.LinkedID == "" && params.LinkedID != "" {
+				//nolint:gocritic // System needs to update the user link.
+				link, err = tx.UpdateUserLinkedID(dbauthz.AsSystemRestricted(ctx), database.UpdateUserLinkedIDParams{
+					LinkedID:  params.LinkedID,
+					UserID:    user.ID,
+					LoginType: params.LoginType,
+				})
+				if err != nil {
+					return xerrors.Errorf("backfill user linked id: %w", err)
+				}
+			}
 		}
 
 		err = api.IDPSync.SyncOrganizations(ctx, tx, user, params.OrganizationSync)
@@ -2049,9 +2098,17 @@ func oidcLinkedID(tok *oidc.IDToken) string {
 	return strings.Join([]string{tok.Issuer, tok.Subject}, "||")
 }
 
+// errLinkedIDAlreadyBound is returned by findLinkedUser when the user
+// found by email already has a user_link with a different linked_id.
+var errLinkedIDAlreadyBound = xerrors.New("user account is already linked to a different identity provider subject")
+
 // findLinkedUser tries to find a user by their unique OAuth-linked ID.
-// If it doesn't not find it, it returns the user by their email.
-func findLinkedUser(ctx context.Context, db database.Store, linkedID string, emails ...string) (database.User, database.UserLink, error) {
+// If it does not find a match, it falls back to email-based lookup.
+// The email fallback is restricted to first-time account linking and
+// legacy links (empty linked_id) only. If the user found by email
+// already has a link with a different linked_id, errLinkedIDAlreadyBound
+// is returned to prevent account takeover via IdP email reuse.
+func findLinkedUser(ctx context.Context, db database.Store, linkedID string, loginType database.LoginType, emails ...string) (database.User, database.UserLink, error) {
 	var (
 		user database.User
 		link database.UserLink
@@ -2096,10 +2153,17 @@ func findLinkedUser(ctx context.Context, db database.Store, linkedID string, ema
 	// possible that a user_link exists without a populated 'linked_id'.
 	link, err = db.GetUserLinkByUserIDLoginType(ctx, database.GetUserLinkByUserIDLoginTypeParams{
 		UserID:    user.ID,
-		LoginType: user.LoginType,
+		LoginType: loginType,
 	})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return database.User{}, database.UserLink{}, xerrors.Errorf("get user link by user id and login type: %w", err)
+	}
+
+	// Block email fallback when an existing link has a different linked_id.
+	// Prevents account takeover via IdP email reuse; first-time and legacy
+	// (empty linked_id) links pass through.
+	if err == nil && link.LinkedID != "" && link.LinkedID != linkedID {
+		return database.User{}, database.UserLink{}, errLinkedIDAlreadyBound
 	}
 
 	return user, link, nil

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -386,6 +386,67 @@ func TestUserOAuth2Github(t *testing.T) {
 
 		require.Equal(t, http.StatusForbidden, resp.StatusCode)
 	})
+	t.Run("EmailFallbackBlockedByExistingLink", func(t *testing.T) {
+		t.Parallel()
+
+		// A victim already has a GitHub link bound to a specific GitHub user
+		// ID. An attacker authenticates with a different GitHub user ID but
+		// the victim's verified email. The email fallback must not hand the
+		// attacker the victim's account, even with signups enabled.
+		owner, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{
+			GithubOAuth2Config: &coderd.GithubOAuth2Config{
+				OAuth2Config:  &testutil.OAuth2Config{},
+				AllowSignups:  true,
+				AllowEveryone: true,
+				ListOrganizationMemberships: func(_ context.Context, _ *http.Client) ([]*github.Membership, error) {
+					return []*github.Membership{}, nil
+				},
+				TeamMembership: func(_ context.Context, _ *http.Client, _, _, _ string) (*github.Membership, error) {
+					return nil, xerrors.New("no teams")
+				},
+				AuthenticatedUser: func(_ context.Context, _ *http.Client) (*github.User, error) {
+					// Attacker's GitHub ID differs from the victim's link.
+					return &github.User{
+						ID:    github.Int64(200),
+						Login: github.String("attacker"),
+						Name:  github.String("Attacker"),
+					}, nil
+				},
+				ListEmails: func(_ context.Context, _ *http.Client) ([]*github.UserEmail, error) {
+					return []*github.UserEmail{{
+						Email:    github.String("victim@coder.com"),
+						Verified: github.Bool(true),
+						Primary:  github.Bool(true),
+					}}, nil
+				},
+			},
+		})
+
+		// Seed the victim with an existing GitHub link (a different linked_id).
+		victim := dbgen.User(t, db, database.User{
+			Email:     "victim@coder.com",
+			LoginType: database.LoginTypeGithub,
+		})
+		const victimLinkedID = "100"
+		dbgen.UserLink(t, db, database.UserLink{
+			UserID:    victim.ID,
+			LoginType: database.LoginTypeGithub,
+			LinkedID:  victimLinkedID,
+		})
+
+		resp := oauth2Callback(t, owner)
+		require.Equal(t, http.StatusForbidden, resp.StatusCode,
+			"attacker with a different GitHub ID must not authenticate as the victim")
+
+		// The victim's link must be untouched.
+		victimLink, err := db.GetUserLinkByUserIDLoginType(dbauthz.AsSystemRestricted(context.Background()), database.GetUserLinkByUserIDLoginTypeParams{
+			UserID:    victim.ID,
+			LoginType: database.LoginTypeGithub,
+		})
+		require.NoError(t, err)
+		require.Equal(t, victimLinkedID, victimLink.LinkedID,
+			"victim's linked_id must remain unchanged")
+	})
 	t.Run("Signup", func(t *testing.T) {
 		t.Parallel()
 		auditor := audit.NewMock()
@@ -1582,6 +1643,244 @@ func TestUserOIDC(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, codersdk.UserStatusActive, me.Status)
+	})
+
+	// Tests that an attacker with a different OIDC subject but the same
+	// email cannot hijack an existing linked account. The email fallback
+	// must be restricted to first-time linking only.
+	t.Run("OIDCEmailFallbackBlockedByExistingLink", func(t *testing.T) {
+		t.Parallel()
+
+		fake := oidctest.NewFakeIDP(t,
+			oidctest.WithRefresh(func(_ string) error {
+				return xerrors.New("refreshing token should never occur")
+			}),
+			oidctest.WithServing(),
+		)
+
+		for _, tc := range []struct {
+			name         string
+			allowSignups bool
+		}{
+			{"SignupsDisabled", false},
+			{"SignupsEnabled", true},
+		} {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				cfg := fake.OIDCConfig(t, nil, func(cfg *coderd.OIDCConfig) {
+					cfg.AllowSignups = tc.allowSignups
+				})
+
+				logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+				owner, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{
+					OIDCConfig: cfg,
+					Logger:     &logger,
+				})
+
+				// Create a victim user with an existing OIDC link.
+				// Use the fake IDP's issuer so the linked_id format is
+				// realistic (same issuer, different subject).
+				victim := dbgen.User(t, db, database.User{
+					LoginType: database.LoginTypeOIDC,
+				})
+				victimLinkedID := fake.IssuerURL().String() + "||" + "victim-subject"
+				dbgen.UserLink(t, db, database.UserLink{
+					UserID:    victim.ID,
+					LoginType: database.LoginTypeOIDC,
+					LinkedID:  victimLinkedID,
+				})
+
+				// Attacker tries to login with a different subject but the
+				// same email. The email fallback is blocked because the victim
+				// already has a user_link with a different linked_id.
+				_, resp := fake.AttemptLogin(t, owner, jwt.MapClaims{
+					"email": victim.Email,
+					"sub":   "attacker-subject",
+				})
+				require.Equal(t, http.StatusForbidden, resp.StatusCode,
+					"attacker must not authenticate as the victim")
+
+				// Verify the victim's link is unchanged.
+				victimLink, err := db.GetUserLinkByUserIDLoginType(dbauthz.AsSystemRestricted(context.Background()), database.GetUserLinkByUserIDLoginTypeParams{
+					UserID:    victim.ID,
+					LoginType: database.LoginTypeOIDC,
+				})
+				require.NoError(t, err)
+				require.Equal(t, victimLinkedID, victimLink.LinkedID,
+					"victim's linked_id must remain unchanged")
+			})
+		}
+	})
+
+	// Tests that a first-time OIDC user can still link via email when no
+	// user_link exists (e.g. a dormant OIDC user created via SCIM or API).
+	t.Run("OIDCFirstTimeLinkByEmailAllowed", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		fake := oidctest.NewFakeIDP(t,
+			oidctest.WithRefresh(func(_ string) error {
+				return xerrors.New("refreshing token should never occur")
+			}),
+			oidctest.WithServing(),
+		)
+		cfg := fake.OIDCConfig(t, nil, func(cfg *coderd.OIDCConfig) {
+			cfg.AllowSignups = true
+		})
+
+		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		owner, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{
+			OIDCConfig: cfg,
+			Logger:     &logger,
+		})
+
+		// Create a user with OIDC login type but NO user_link.
+		// This simulates a user created via SCIM or the API.
+		user := dbgen.User(t, db, database.User{
+			LoginType: database.LoginTypeOIDC,
+		})
+
+		// Login with a new OIDC subject and matching email.
+		// This should succeed because no user_link exists.
+		sub := uuid.NewString()
+		client, resp := fake.AttemptLogin(t, owner, jwt.MapClaims{
+			"email": user.Email,
+			"sub":   sub,
+		})
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		me, err := client.User(ctx, "me")
+		require.NoError(t, err)
+		require.Equal(t, user.ID, me.ID,
+			"should authenticate as the existing user")
+
+		// Verify the created link has a populated linked_id.
+		link, err := db.GetUserLinkByUserIDLoginType(
+			dbauthz.AsSystemRestricted(context.Background()),
+			database.GetUserLinkByUserIDLoginTypeParams{
+				UserID:    user.ID,
+				LoginType: database.LoginTypeOIDC,
+			})
+		require.NoError(t, err)
+		expectedLinkedID := fake.IssuerURL().String() + "||" + sub
+		require.Equal(t, expectedLinkedID, link.LinkedID,
+			"link should have the correct linked_id after first-time linking")
+	})
+
+	// Tests that a legacy user with an empty linked_id can still login
+	// and that their linked_id is backfilled with the correct value.
+	t.Run("OIDCLegacyLinkBackfill", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		fake := oidctest.NewFakeIDP(t,
+			oidctest.WithRefresh(func(_ string) error {
+				return xerrors.New("refreshing token should never occur")
+			}),
+			oidctest.WithServing(),
+		)
+		cfg := fake.OIDCConfig(t, nil, func(cfg *coderd.OIDCConfig) {
+			cfg.AllowSignups = true
+		})
+
+		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		owner, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{
+			OIDCConfig: cfg,
+			Logger:     &logger,
+		})
+
+		// Create a legacy user with an empty linked_id.
+		user := dbgen.User(t, db, database.User{
+			LoginType: database.LoginTypeOIDC,
+		})
+		dbgen.UserLink(t, db, database.UserLink{
+			UserID:    user.ID,
+			LoginType: database.LoginTypeOIDC,
+			LinkedID:  "", // Legacy: empty linked_id
+		})
+
+		sub := uuid.NewString()
+		client, resp := fake.AttemptLogin(t, owner, jwt.MapClaims{
+			"email": user.Email,
+			"sub":   sub,
+		})
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		me, err := client.User(ctx, "me")
+		require.NoError(t, err)
+		require.Equal(t, user.ID, me.ID,
+			"legacy user should still be able to login via email fallback")
+
+		// Verify the linked_id was backfilled with the correct value.
+		link, err := db.GetUserLinkByUserIDLoginType(
+			dbauthz.AsSystemRestricted(context.Background()),
+			database.GetUserLinkByUserIDLoginTypeParams{
+				UserID:    user.ID,
+				LoginType: database.LoginTypeOIDC,
+			})
+		require.NoError(t, err)
+		expectedLinkedID := fake.IssuerURL().String() + "||" + sub
+		require.Equal(t, expectedLinkedID, link.LinkedID,
+			"linked_id should be backfilled with the correct value after login")
+	})
+
+	// Tests that changing the OIDC issuer URL blocks an existing user whose
+	// linked_id was recorded under the old issuer. This is a deliberate
+	// breaking change: before this fix the email fallback silently rescued
+	// such users. Now the login is rejected because the existing link's
+	// linked_id (old issuer) differs from the newly computed one (new issuer).
+	t.Run("OIDCEmailFallbackBlockedByIssuerChange", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		fake := oidctest.NewFakeIDP(t,
+			oidctest.WithRefresh(func(_ string) error {
+				return xerrors.New("refreshing token should never occur")
+			}),
+			oidctest.WithServing(),
+		)
+		cfg := fake.OIDCConfig(t, nil, func(cfg *coderd.OIDCConfig) {
+			cfg.AllowSignups = true
+		})
+
+		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		owner, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{
+			OIDCConfig: cfg,
+			Logger:     &logger,
+		})
+
+		// Seed a user whose link was created under a different (old) issuer
+		// but with the same subject the IdP presents on login.
+		user := dbgen.User(t, db, database.User{
+			LoginType: database.LoginTypeOIDC,
+		})
+		const sub = "stable-subject"
+		oldLinkedID := "https://old-issuer.example.com||" + sub
+		dbgen.UserLink(t, db, database.UserLink{
+			UserID:    user.ID,
+			LoginType: database.LoginTypeOIDC,
+			LinkedID:  oldLinkedID,
+		})
+
+		// Login presents the same subject but the current issuer, so the
+		// computed linked_id differs from the stored one and is blocked.
+		_, resp := fake.AttemptLogin(t, owner, jwt.MapClaims{
+			"email": user.Email,
+			"sub":   sub,
+		})
+		require.Equal(t, http.StatusForbidden, resp.StatusCode,
+			"issuer change must block the email fallback for an existing link")
+
+		// The stored link must remain unchanged.
+		link, err := db.GetUserLinkByUserIDLoginType(dbauthz.AsSystemRestricted(ctx), database.GetUserLinkByUserIDLoginTypeParams{
+			UserID:    user.ID,
+			LoginType: database.LoginTypeOIDC,
+		})
+		require.NoError(t, err)
+		require.Equal(t, oldLinkedID, link.LinkedID,
+			"linked_id must not be modified when the login is blocked")
 	})
 
 	t.Run("OIDCConvert", func(t *testing.T) {


### PR DESCRIPTION
Backport of #25712 to `release/2.29`.

Cherry-picked with `git cherry-pick -x` (`53d287a139`); the commit message references the original PR.

> [!NOTE]
> Breaking change. See the original PR for the breaking-change details.

<details>
<summary>Cherry-pick conflict resolution</summary>

The core fix (`coderd/userauth.go`, `coderd/userauth_test.go`) applied cleanly. `release/2.29` required these adaptations:

- `coderd/userauth.go`: added the `site` import and rendered the new "account already linked" error using this branch's `ErrorPageData` API (`AdditionalButtonLink` / `AdditionalButtonText`), because the `Actions` field does not exist on this branch.
- `coderd/database/queries/user_links.sql` + generated code: this branch still carried an older, unused `UpdateUserLinkedID` query (unconditional update) that mainline had already removed. It was replaced with the backfill version from the original PR so the query name resolves to a single definition matching mainline. The `dbmetrics` and `dbmock` wrappers already existed on this branch (older templates) and were left untouched.
- `coderd/database/dbauthz/dbauthz.go` + test: authorization updated to `ActionUpdate` on the user object; the stale system-scoped test case was removed since the method is now covered by the user-scoped case.

Generated database code matches mainline output. Build, the new OIDC/GitHub tests, and the affected `dbauthz` authorization test pass.
</details>

_Generated by Coder Agents on behalf of @jdomeracki-coder._