### PR TITLE
docs(reference/api): add chat context endpoints to API reference

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -11200,6 +11200,83 @@ const docTemplate = `{
                 ]
             }
         },
+        "/api/v2/workspaceagents/me/experimental/chat-context": {
+            "post": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Add chat context from a workspace agent",
+                "operationId": "add-chat-context-from-a-workspace-agent",
+                "parameters": [
+                    {
+                        "description": "Add chat context request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/agentsdk.AddChatContextRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/agentsdk.AddChatContextResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "delete": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Clear chat context from a workspace agent",
+                "operationId": "clear-chat-context-from-a-workspace-agent",
+                "parameters": [
+                    {
+                        "description": "Clear chat context request",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/agentsdk.ClearChatContextRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/agentsdk.ClearChatContextResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
         "/api/v2/workspaceagents/me/external-auth": {
             "get": {
                 "produces": [
@@ -14315,6 +14392,33 @@ const docTemplate = `{
                 }
             }
         },
+        "agentsdk.AddChatContextRequest": {
+            "type": "object",
+            "properties": {
+                "chat_id": {
+                    "description": "ChatID optionally identifies the chat to add context to.\nIf empty, auto-detection is used (CODER_CHAT_ID env, the\nonly active chat, or the only top-level active chat for this\nagent).",
+                    "type": "string"
+                },
+                "parts": {
+                    "description": "Parts are the context-file and skill parts to add.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.ChatMessagePart"
+                    }
+                }
+            }
+        },
+        "agentsdk.AddChatContextResponse": {
+            "type": "object",
+            "properties": {
+                "chat_id": {
+                    "type": "string"
+                },
+                "count": {
+                    "type": "integer"
+                }
+            }
+        },
         "agentsdk.AuthenticateResponse": {
             "type": "object",
             "properties": {
@@ -14338,6 +14442,23 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "signature": {
+                    "type": "string"
+                }
+            }
+        },
+        "agentsdk.ClearChatContextRequest": {
+            "type": "object",
+            "properties": {
+                "chat_id": {
+                    "description": "ChatID optionally identifies the chat to clear context from.\nIf empty, auto-detection is used (CODER_CHAT_ID env, the\nonly active chat, or the only top-level active chat for this\nagent).",
+                    "type": "string"
+                }
+            }
+        },
+        "agentsdk.ClearChatContextResponse": {
+            "type": "object",
+            "properties": {
+                "chat_id": {
                     "type": "string"
                 }
             }

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -9931,6 +9931,71 @@
 				]
 			}
 		},
+		"/api/v2/workspaceagents/me/experimental/chat-context": {
+			"post": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Add chat context from a workspace agent",
+				"operationId": "add-chat-context-from-a-workspace-agent",
+				"parameters": [
+					{
+						"description": "Add chat context request",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/agentsdk.AddChatContextRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/agentsdk.AddChatContextResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"delete": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Clear chat context from a workspace agent",
+				"operationId": "clear-chat-context-from-a-workspace-agent",
+				"parameters": [
+					{
+						"description": "Clear chat context request",
+						"name": "request",
+						"in": "body",
+						"schema": {
+							"$ref": "#/definitions/agentsdk.ClearChatContextRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/agentsdk.ClearChatContextResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
 		"/api/v2/workspaceagents/me/external-auth": {
 			"get": {
 				"produces": ["application/json"],
@@ -12704,6 +12769,33 @@
 				}
 			}
 		},
+		"agentsdk.AddChatContextRequest": {
+			"type": "object",
+			"properties": {
+				"chat_id": {
+					"description": "ChatID optionally identifies the chat to add context to.\nIf empty, auto-detection is used (CODER_CHAT_ID env, the\nonly active chat, or the only top-level active chat for this\nagent).",
+					"type": "string"
+				},
+				"parts": {
+					"description": "Parts are the context-file and skill parts to add.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.ChatMessagePart"
+					}
+				}
+			}
+		},
+		"agentsdk.AddChatContextResponse": {
+			"type": "object",
+			"properties": {
+				"chat_id": {
+					"type": "string"
+				},
+				"count": {
+					"type": "integer"
+				}
+			}
+		},
 		"agentsdk.AuthenticateResponse": {
 			"type": "object",
 			"properties": {
@@ -12724,6 +12816,23 @@
 					"type": "string"
 				},
 				"signature": {
+					"type": "string"
+				}
+			}
+		},
+		"agentsdk.ClearChatContextRequest": {
+			"type": "object",
+			"properties": {
+				"chat_id": {
+					"description": "ChatID optionally identifies the chat to clear context from.\nIf empty, auto-detection is used (CODER_CHAT_ID env, the\nonly active chat, or the only top-level active chat for this\nagent).",
+					"type": "string"
+				}
+			}
+		},
+		"agentsdk.ClearChatContextResponse": {
+			"type": "object",
+			"properties": {
+				"chat_id": {
 					"type": "string"
 				}
 			}

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -2448,7 +2448,18 @@ func readChatContextBody(ctx context.Context, rw http.ResponseWriter, r *http.Re
 	return httpapi.Read(ctx, rw, r, dst)
 }
 
-// @x-apidocgen {"skip": true}
+// Add context to a chat from a workspace agent.
+//
+// @Summary Add chat context from a workspace agent
+// @ID add-chat-context-from-a-workspace-agent
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Produce json
+// @Param request body agentsdk.AddChatContextRequest true "Add chat context request"
+// @Success 200 {object} agentsdk.AddChatContextResponse
+// @Router /api/v2/workspaceagents/me/experimental/chat-context [post]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) workspaceAgentAddChatContext(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	workspaceAgent := httpmw.WorkspaceAgent(r)
@@ -2599,7 +2610,18 @@ func (api *API) workspaceAgentAddChatContext(rw http.ResponseWriter, r *http.Req
 	})
 }
 
-// @x-apidocgen {"skip": true}
+// Clear context from a chat via a workspace agent.
+//
+// @Summary Clear chat context from a workspace agent
+// @ID clear-chat-context-from-a-workspace-agent
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Produce json
+// @Param request body agentsdk.ClearChatContextRequest false "Clear chat context request"
+// @Success 200 {object} agentsdk.ClearChatContextResponse
+// @Router /api/v2/workspaceagents/me/experimental/chat-context [delete]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) workspaceAgentClearChatContext(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	workspaceAgent := httpmw.WorkspaceAgent(r)

--- a/docs/reference/api/chats.md
+++ b/docs/reference/api/chats.md
@@ -2957,3 +2957,164 @@ Experimental: this endpoint is subject to change.
 | 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.Chat](schemas.md#codersdkchat) |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Add chat context from a workspace agent
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X POST http://coder-server:8080/api/v2/workspaceagents/me/experimental/chat-context \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`POST /api/v2/workspaceagents/me/experimental/chat-context`
+
+Experimental: this endpoint is subject to change.
+
+> Body parameter
+
+```json
+{
+  "chat_id": "string",
+  "parts": [
+    {
+      "args": [
+        0
+      ],
+      "args_delta": "string",
+      "completed_at": "2019-08-24T14:15:22Z",
+      "content": "string",
+      "context_file_agent_id": {
+        "uuid": "string",
+        "valid": true
+      },
+      "context_file_content": "string",
+      "context_file_directory": "string",
+      "context_file_os": "string",
+      "context_file_path": "string",
+      "context_file_skill_meta_file": "string",
+      "context_file_truncated": true,
+      "created_at": "2019-08-24T14:15:22Z",
+      "data": [
+        0
+      ],
+      "end_line": 0,
+      "file_id": {
+        "uuid": "string",
+        "valid": true
+      },
+      "file_name": "string",
+      "is_error": true,
+      "is_media": true,
+      "mcp_server_config_id": {
+        "uuid": "string",
+        "valid": true
+      },
+      "media_type": "string",
+      "name": "string",
+      "parsed_commands": [
+        [
+          "string"
+        ]
+      ],
+      "provider_executed": true,
+      "provider_metadata": [
+        0
+      ],
+      "result": [
+        0
+      ],
+      "result_delta": "string",
+      "result_reset": true,
+      "signature": "string",
+      "skill_description": "string",
+      "skill_dir": "string",
+      "skill_name": "string",
+      "source_id": "string",
+      "start_line": 0,
+      "text": "string",
+      "title": "string",
+      "tool_call_id": "string",
+      "tool_name": "string",
+      "type": "text",
+      "url": "string"
+    }
+  ]
+}
+```
+
+### Parameters
+
+| Name   | In   | Type                                                                       | Required | Description              |
+|--------|------|----------------------------------------------------------------------------|----------|--------------------------|
+| `body` | body | [agentsdk.AddChatContextRequest](schemas.md#agentsdkaddchatcontextrequest) | true     | Add chat context request |
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "chat_id": "string",
+  "count": 0
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                       |
+|--------|---------------------------------------------------------|-------------|------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [agentsdk.AddChatContextResponse](schemas.md#agentsdkaddchatcontextresponse) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Clear chat context from a workspace agent
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X DELETE http://coder-server:8080/api/v2/workspaceagents/me/experimental/chat-context \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`DELETE /api/v2/workspaceagents/me/experimental/chat-context`
+
+Experimental: this endpoint is subject to change.
+
+> Body parameter
+
+```json
+{
+  "chat_id": "string"
+}
+```
+
+### Parameters
+
+| Name   | In   | Type                                                                           | Required | Description                |
+|--------|------|--------------------------------------------------------------------------------|----------|----------------------------|
+| `body` | body | [agentsdk.ClearChatContextRequest](schemas.md#agentsdkclearchatcontextrequest) | false    | Clear chat context request |
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "chat_id": "string"
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                           |
+|--------|---------------------------------------------------------|-------------|----------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [agentsdk.ClearChatContextResponse](schemas.md#agentsdkclearchatcontextresponse) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -18,6 +18,101 @@
 | `document`   | string | true     |              |                                                                                                                                                  |
 | `signature`  | string | true     |              |                                                                                                                                                  |
 
+## agentsdk.AddChatContextRequest
+
+```json
+{
+  "chat_id": "string",
+  "parts": [
+    {
+      "args": [
+        0
+      ],
+      "args_delta": "string",
+      "completed_at": "2019-08-24T14:15:22Z",
+      "content": "string",
+      "context_file_agent_id": {
+        "uuid": "string",
+        "valid": true
+      },
+      "context_file_content": "string",
+      "context_file_directory": "string",
+      "context_file_os": "string",
+      "context_file_path": "string",
+      "context_file_skill_meta_file": "string",
+      "context_file_truncated": true,
+      "created_at": "2019-08-24T14:15:22Z",
+      "data": [
+        0
+      ],
+      "end_line": 0,
+      "file_id": {
+        "uuid": "string",
+        "valid": true
+      },
+      "file_name": "string",
+      "is_error": true,
+      "is_media": true,
+      "mcp_server_config_id": {
+        "uuid": "string",
+        "valid": true
+      },
+      "media_type": "string",
+      "name": "string",
+      "parsed_commands": [
+        [
+          "string"
+        ]
+      ],
+      "provider_executed": true,
+      "provider_metadata": [
+        0
+      ],
+      "result": [
+        0
+      ],
+      "result_delta": "string",
+      "result_reset": true,
+      "signature": "string",
+      "skill_description": "string",
+      "skill_dir": "string",
+      "skill_name": "string",
+      "source_id": "string",
+      "start_line": 0,
+      "text": "string",
+      "title": "string",
+      "tool_call_id": "string",
+      "tool_name": "string",
+      "type": "text",
+      "url": "string"
+    }
+  ]
+}
+```
+
+### Properties
+
+| Name      | Type                                                          | Required | Restrictions | Description                                                                                                                                                                             |
+|-----------|---------------------------------------------------------------|----------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `chat_id` | string                                                        | false    |              | Chat ID optionally identifies the chat to add context to. If empty, auto-detection is used (CODER_CHAT_ID env, the only active chat, or the only top-level active chat for this agent). |
+| `parts`   | array of [codersdk.ChatMessagePart](#codersdkchatmessagepart) | false    |              | Parts are the context-file and skill parts to add.                                                                                                                                      |
+
+## agentsdk.AddChatContextResponse
+
+```json
+{
+  "chat_id": "string",
+  "count": 0
+}
+```
+
+### Properties
+
+| Name      | Type    | Required | Restrictions | Description |
+|-----------|---------|----------|--------------|-------------|
+| `chat_id` | string  | false    |              |             |
+| `count`   | integer | false    |              |             |
+
 ## agentsdk.AuthenticateResponse
 
 ```json
@@ -49,6 +144,34 @@
 | `agent_name` | string | false    |              | Agent name optionally selects a specific agent when multiple agents share the same instance identity. An empty string is treated as unspecified. |
 | `encoding`   | string | true     |              |                                                                                                                                                  |
 | `signature`  | string | true     |              |                                                                                                                                                  |
+
+## agentsdk.ClearChatContextRequest
+
+```json
+{
+  "chat_id": "string"
+}
+```
+
+### Properties
+
+| Name      | Type   | Required | Restrictions | Description                                                                                                                                                                                 |
+|-----------|--------|----------|--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `chat_id` | string | false    |              | Chat ID optionally identifies the chat to clear context from. If empty, auto-detection is used (CODER_CHAT_ID env, the only active chat, or the only top-level active chat for this agent). |
+
+## agentsdk.ClearChatContextResponse
+
+```json
+{
+  "chat_id": "string"
+}
+```
+
+### Properties
+
+| Name      | Type   | Required | Restrictions | Description |
+|-----------|--------|----------|--------------|-------------|
+| `chat_id` | string | false    |              |             |
 
 ## agentsdk.ExternalAuthResponse
 


### PR DESCRIPTION
## Summary

Add the `POST` and `DELETE` chat context endpoints to the auto-generated Chats API reference page at [coder.com/docs/reference/api/chats](https://coder.com/docs/reference/api/chats).

These endpoints (introduced in #24105) allow workspace agents to inject instruction files and skills into an active chat session. The injected content is model-only visible, acting as a hidden prompt mechanism for startup scripts, CI/CD integrations, and custom agents.

## Changes

- Replace `@x-apidocgen {"skip": true}` on `workspaceAgentAddChatContext` and `workspaceAgentClearChatContext` with proper swagger annotations tagged as `Chats`.
- Regenerate API docs via `make coderd/apidoc/.gen`.

New endpoints on the Chats page:
- **Add chat context from a workspace agent** (`POST /api/v2/workspaceagents/me/experimental/chat-context`)
- **Clear chat context from a workspace agent** (`DELETE /api/v2/workspaceagents/me/experimental/chat-context`)

> Generated by Coder Agents on behalf of @david-fraley