### PR TITLE
feat(agent/agentcontextconfig): fall back to AGENT.md and CLAUDE.md

### DIFF
--- a/agent/agentcontextconfig/api.go
+++ b/agent/agentcontextconfig/api.go
@@ -19,11 +19,11 @@ import (
 // Env var names for context configuration. Prefixed with EXP_
 // to indicate these are experimental and may change.
 const (
-	EnvInstructionsDirs = "CODER_AGENT_EXP_INSTRUCTIONS_DIRS"
-	EnvInstructionsFile = "CODER_AGENT_EXP_INSTRUCTIONS_FILE"
-	EnvSkillsDirs       = "CODER_AGENT_EXP_SKILLS_DIRS"
-	EnvSkillMetaFile    = "CODER_AGENT_EXP_SKILL_META_FILE"
-	EnvMCPConfigFiles   = "CODER_AGENT_EXP_MCP_CONFIG_FILES"
+	EnvInstructionsDirs  = "CODER_AGENT_EXP_INSTRUCTIONS_DIRS"
+	EnvInstructionsFiles = "CODER_AGENT_EXP_INSTRUCTIONS_FILES"
+	EnvSkillsDirs        = "CODER_AGENT_EXP_SKILLS_DIRS"
+	EnvSkillMetaFile     = "CODER_AGENT_EXP_SKILL_META_FILE"
+	EnvMCPConfigFiles    = "CODER_AGENT_EXP_MCP_CONFIG_FILES"
 )
 
 const (
@@ -56,31 +56,36 @@ var invisibleRunePattern = regexp.MustCompile(
 // Default values for agent-internal configuration. These are
 // used when the corresponding env vars are unset.
 //
+// DefaultInstructionsFiles is a comma-separated, priority-ordered
+// list of instruction filenames. Per directory, the first existing
+// file wins; files that are empty after sanitization fall through
+// to the next candidate.
+//
 // DefaultSkillsDir is a comma-separated list so home-scoped
 // skills override project-scoped ones with the same name
 // (discoverSkills picks the first occurrence per skill name).
 const (
-	DefaultInstructionsDir  = "~/.coder"
-	DefaultInstructionsFile = "AGENTS.md"
-	DefaultSkillsDir        = "~/.coder/skills,.agents/skills"
-	DefaultSkillMetaFile    = "SKILL.md"
-	DefaultMCPConfigFile    = ".mcp.json"
+	DefaultInstructionsDir   = "~/.coder"
+	DefaultInstructionsFiles = "AGENTS.md,AGENT.md,CLAUDE.md"
+	DefaultSkillsDir         = "~/.coder/skills,.agents/skills"
+	DefaultSkillMetaFile     = "SKILL.md"
+	DefaultMCPConfigFile     = ".mcp.json"
 )
 
 // Config holds the agent's context configuration.
 // Defaults are applied by NewAPI, not by the zero value.
 type Config struct {
-	InstructionsDirs string
-	InstructionsFile string
-	SkillsDirs       string
-	SkillMetaFile    string
-	MCPConfigFiles   string
+	InstructionsDirs  string
+	InstructionsFiles string
+	SkillsDirs        string
+	SkillMetaFile     string
+	MCPConfigFiles    string
 }
 
 // applyDefaults fills zero-valued fields with their defaults.
 func (c Config) applyDefaults() Config {
 	c.InstructionsDirs = cmp.Or(c.InstructionsDirs, DefaultInstructionsDir)
-	c.InstructionsFile = cmp.Or(c.InstructionsFile, DefaultInstructionsFile)
+	c.InstructionsFiles = cmp.Or(c.InstructionsFiles, DefaultInstructionsFiles)
 	c.SkillsDirs = cmp.Or(c.SkillsDirs, DefaultSkillsDir)
 	c.SkillMetaFile = cmp.Or(c.SkillMetaFile, DefaultSkillMetaFile)
 	c.MCPConfigFiles = cmp.Or(c.MCPConfigFiles, DefaultMCPConfigFile)
@@ -91,11 +96,11 @@ func (c Config) applyDefaults() Config {
 // variables, falling back to defaults for unset values.
 func ReadEnvConfig() Config {
 	return Config{
-		InstructionsDirs: strings.TrimSpace(os.Getenv(EnvInstructionsDirs)),
-		InstructionsFile: strings.TrimSpace(os.Getenv(EnvInstructionsFile)),
-		SkillsDirs:       strings.TrimSpace(os.Getenv(EnvSkillsDirs)),
-		SkillMetaFile:    strings.TrimSpace(os.Getenv(EnvSkillMetaFile)),
-		MCPConfigFiles:   strings.TrimSpace(os.Getenv(EnvMCPConfigFiles)),
+		InstructionsDirs:  strings.TrimSpace(os.Getenv(EnvInstructionsDirs)),
+		InstructionsFiles: strings.TrimSpace(os.Getenv(EnvInstructionsFiles)),
+		SkillsDirs:        strings.TrimSpace(os.Getenv(EnvSkillsDirs)),
+		SkillMetaFile:     strings.TrimSpace(os.Getenv(EnvSkillMetaFile)),
+		MCPConfigFiles:    strings.TrimSpace(os.Getenv(EnvMCPConfigFiles)),
 	}.applyDefaults()
 }
 
@@ -103,7 +108,7 @@ func ReadEnvConfig() Config {
 // used by the context configuration subsystem.
 func envVarKeys() []string {
 	return []string{
-		EnvInstructionsDirs, EnvInstructionsFile,
+		EnvInstructionsDirs, EnvInstructionsFiles,
 		EnvSkillsDirs, EnvSkillMetaFile, EnvMCPConfigFiles,
 	}
 }
@@ -139,11 +144,12 @@ func NewAPI(workingDir func() string, cfg Config) *API {
 func Resolve(workingDir string, cfg Config) (workspacesdk.ContextConfigResponse, []string) {
 	resolvedInstructionsDirs := ResolvePaths(cfg.InstructionsDirs, workingDir)
 	resolvedSkillsDirs := ResolvePaths(cfg.SkillsDirs, workingDir)
+	instructionsFileNames := parseFileNames(cfg.InstructionsFiles)
 
 	// Read instruction files from each configured directory.
-	parts := readInstructionFiles(resolvedInstructionsDirs, cfg.InstructionsFile)
+	parts := readInstructionFiles(resolvedInstructionsDirs, instructionsFileNames)
 
-	// Also check the working directory for the instruction file,
+	// Also check the working directory for an instruction file,
 	// unless it was already covered by InstructionsDirs.
 	if workingDir != "" {
 		seenDirs := make(map[string]struct{}, len(resolvedInstructionsDirs))
@@ -151,7 +157,7 @@ func Resolve(workingDir string, cfg Config) (workspacesdk.ContextConfigResponse,
 			seenDirs[d] = struct{}{}
 		}
 		if _, ok := seenDirs[workingDir]; !ok {
-			if entry, found := readInstructionFileFromDir(workingDir, cfg.InstructionsFile); found {
+			if entry, found := readInstructionFileFromDir(workingDir, instructionsFileNames); found {
 				parts = append(parts, entry)
 			}
 		}
@@ -178,7 +184,7 @@ func Resolve(workingDir string, cfg Config) (workspacesdk.ContextConfigResponse,
 func ContextPartsFromDir(dir string) []codersdk.ChatMessagePart {
 	var parts []codersdk.ChatMessagePart
 
-	if entry, found := readInstructionFileFromDir(dir, DefaultInstructionsFile); found {
+	if entry, found := readInstructionFileFromDir(dir, parseFileNames(DefaultInstructionsFiles)); found {
 		parts = append(parts, entry)
 	}
 
@@ -218,10 +224,27 @@ func (api *API) handleGet(rw http.ResponseWriter, r *http.Request) {
 	httpapi.Write(r.Context(), rw, http.StatusOK, response)
 }
 
+// parseFileNames splits a comma-separated list of instruction
+// filenames, trims whitespace, and drops empty entries. Order is
+// preserved so callers can use the result as a priority list.
+func parseFileNames(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
 // readInstructionFiles reads instruction files from each given
 // directory. Missing directories are silently skipped. Duplicate
 // directories are deduplicated.
-func readInstructionFiles(dirs []string, fileName string) []codersdk.ChatMessagePart {
+func readInstructionFiles(dirs []string, fileNames []string) []codersdk.ChatMessagePart {
 	var parts []codersdk.ChatMessagePart
 	seen := make(map[string]struct{}, len(dirs))
 	for _, dir := range dirs {
@@ -229,33 +252,38 @@ func readInstructionFiles(dirs []string, fileName string) []codersdk.ChatMessage
 			continue
 		}
 		seen[dir] = struct{}{}
-		if part, found := readInstructionFileFromDir(dir, fileName); found {
+		if part, found := readInstructionFileFromDir(dir, fileNames); found {
 			parts = append(parts, part)
 		}
 	}
 	return parts
 }
 
-// readInstructionFileFromDir scans a directory for a file matching
-// fileName (case-insensitive) and reads its contents.
-func readInstructionFileFromDir(dir, fileName string) (codersdk.ChatMessagePart, bool) {
+// readInstructionFileFromDir scans a directory for the first file
+// matching one of fileNames (case-insensitive) in priority order
+// and reads its contents. A candidate that is unreadable or empty
+// after sanitization falls through to the next candidate.
+func readInstructionFileFromDir(dir string, fileNames []string) (codersdk.ChatMessagePart, bool) {
 	dirEntries, err := os.ReadDir(dir)
 	if err != nil {
 		return codersdk.ChatMessagePart{}, false
 	}
 
-	for _, e := range dirEntries {
-		if e.IsDir() {
-			continue
-		}
-		if strings.EqualFold(strings.TrimSpace(e.Name()), fileName) {
+	for _, fileName := range fileNames {
+		for _, e := range dirEntries {
+			if e.IsDir() {
+				continue
+			}
+			if !strings.EqualFold(strings.TrimSpace(e.Name()), fileName) {
+				continue
+			}
 			filePath := filepath.Join(dir, e.Name())
 			content, truncated, ok := readAndSanitizeFile(filePath, maxInstructionFileBytes)
-			if !ok {
-				return codersdk.ChatMessagePart{}, false
-			}
-			if content == "" {
-				return codersdk.ChatMessagePart{}, false
+			if !ok || content == "" {
+				// Unreadable or empty after sanitization. Stop
+				// scanning this candidate name and fall through
+				// to the next one in priority order.
+				break
 			}
 			return codersdk.ChatMessagePart{
 				Type:                 codersdk.ChatMessagePartTypeContextFile,

--- a/agent/agentcontextconfig/api_test.go
+++ b/agent/agentcontextconfig/api_test.go
@@ -148,7 +148,7 @@ func setupConfigTestEnv(t *testing.T, overrides map[string]string) string {
 	t.Setenv("HOME", fakeHome)
 	t.Setenv("USERPROFILE", fakeHome)
 	t.Setenv(agentcontextconfig.EnvInstructionsDirs, "")
-	t.Setenv(agentcontextconfig.EnvInstructionsFile, "")
+	t.Setenv(agentcontextconfig.EnvInstructionsFiles, "")
 	t.Setenv(agentcontextconfig.EnvSkillsDirs, "")
 	t.Setenv(agentcontextconfig.EnvSkillMetaFile, "")
 	t.Setenv(agentcontextconfig.EnvMCPConfigFiles, "")
@@ -181,11 +181,11 @@ func TestResolve(t *testing.T) {
 		optSkills := t.TempDir()
 		optMCP := platformAbsPath("opt", "mcp.json")
 		setupConfigTestEnv(t, map[string]string{
-			agentcontextconfig.EnvInstructionsDirs: optInstructions,
-			agentcontextconfig.EnvInstructionsFile: "CUSTOM.md",
-			agentcontextconfig.EnvSkillsDirs:       optSkills,
-			agentcontextconfig.EnvSkillMetaFile:    "META.yaml",
-			agentcontextconfig.EnvMCPConfigFiles:   optMCP,
+			agentcontextconfig.EnvInstructionsDirs:  optInstructions,
+			agentcontextconfig.EnvInstructionsFiles: "CUSTOM.md",
+			agentcontextconfig.EnvSkillsDirs:        optSkills,
+			agentcontextconfig.EnvSkillMetaFile:     "META.yaml",
+			agentcontextconfig.EnvMCPConfigFiles:    optMCP,
 		})
 
 		// Create files matching the custom names so we can
@@ -215,7 +215,7 @@ func TestResolve(t *testing.T) {
 	//nolint:paralleltest // Uses t.Setenv to mutate process-wide environment.
 	t.Run("WhitespaceInFileNames", func(t *testing.T) {
 		fakeHome := setupConfigTestEnv(t, map[string]string{
-			agentcontextconfig.EnvInstructionsFile: "  CLAUDE.md  ",
+			agentcontextconfig.EnvInstructionsFiles: "  CLAUDE.md  ",
 		})
 		t.Setenv(agentcontextconfig.EnvInstructionsDirs, fakeHome)
 
@@ -248,6 +248,125 @@ func TestResolve(t *testing.T) {
 		ctxFiles := filterParts(cfg.Parts, codersdk.ChatMessagePartTypeContextFile)
 		require.Len(t, ctxFiles, 2)
 		require.Equal(t, "from a", ctxFiles[0].ContextFileContent)
+		require.Equal(t, "from b", ctxFiles[1].ContextFileContent)
+	})
+
+	//nolint:paralleltest // Uses t.Setenv to mutate process-wide environment.
+	t.Run("AgentsMdWinsOverFallbackNames", func(t *testing.T) {
+		// AGENTS.md, AGENT.md, and CLAUDE.md all exist in the same
+		// directory. AGENTS.md (highest priority in the default list)
+		// must win and the other candidates must be ignored.
+		setupConfigTestEnv(t, nil)
+		workDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(workDir, "AGENTS.md"), []byte("from agents"), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(workDir, "AGENT.md"), []byte("from agent"), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(workDir, "CLAUDE.md"), []byte("from claude"), 0o600))
+
+		cfg, _ := agentcontextconfig.Resolve(workDir, agentcontextconfig.ReadEnvConfig())
+
+		ctxFiles := filterParts(cfg.Parts, codersdk.ChatMessagePartTypeContextFile)
+		require.Len(t, ctxFiles, 1)
+		require.Equal(t, filepath.Join(workDir, "AGENTS.md"), ctxFiles[0].ContextFilePath)
+		require.Equal(t, "from agents", ctxFiles[0].ContextFileContent)
+	})
+
+	//nolint:paralleltest // Uses t.Setenv to mutate process-wide environment.
+	t.Run("AgentMdWinsOverClaudeMd", func(t *testing.T) {
+		// Only AGENT.md (singular) and CLAUDE.md exist. AGENT.md
+		// is higher priority and must win.
+		setupConfigTestEnv(t, nil)
+		workDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(workDir, "AGENT.md"), []byte("from agent"), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(workDir, "CLAUDE.md"), []byte("from claude"), 0o600))
+
+		cfg, _ := agentcontextconfig.Resolve(workDir, agentcontextconfig.ReadEnvConfig())
+
+		ctxFiles := filterParts(cfg.Parts, codersdk.ChatMessagePartTypeContextFile)
+		require.Len(t, ctxFiles, 1)
+		require.Equal(t, filepath.Join(workDir, "AGENT.md"), ctxFiles[0].ContextFilePath)
+		require.Equal(t, "from agent", ctxFiles[0].ContextFileContent)
+	})
+
+	//nolint:paralleltest // Uses t.Setenv to mutate process-wide environment.
+	t.Run("FallsBackToClaudeMd", func(t *testing.T) {
+		// Only CLAUDE.md exists. With the default fallback list it
+		// must be picked up.
+		setupConfigTestEnv(t, nil)
+		workDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(workDir, "CLAUDE.md"), []byte("from claude"), 0o600))
+
+		cfg, _ := agentcontextconfig.Resolve(workDir, agentcontextconfig.ReadEnvConfig())
+
+		ctxFiles := filterParts(cfg.Parts, codersdk.ChatMessagePartTypeContextFile)
+		require.Len(t, ctxFiles, 1)
+		require.Equal(t, filepath.Join(workDir, "CLAUDE.md"), ctxFiles[0].ContextFilePath)
+		require.Equal(t, "from claude", ctxFiles[0].ContextFileContent)
+	})
+
+	//nolint:paralleltest // Uses t.Setenv to mutate process-wide environment.
+	t.Run("EmptyAgentsMdFallsThroughToClaudeMd", func(t *testing.T) {
+		// AGENTS.md exists but sanitizes to empty (HTML-comment-only
+		// content). Coder treats empty-after-sanitization as not
+		// found, so the search must fall through to CLAUDE.md.
+		setupConfigTestEnv(t, nil)
+		workDir := t.TempDir()
+		require.NoError(t, os.WriteFile(
+			filepath.Join(workDir, "AGENTS.md"),
+			[]byte("<!-- only a comment -->"),
+			0o600,
+		))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(workDir, "CLAUDE.md"),
+			[]byte("from claude"),
+			0o600,
+		))
+
+		cfg, _ := agentcontextconfig.Resolve(workDir, agentcontextconfig.ReadEnvConfig())
+
+		ctxFiles := filterParts(cfg.Parts, codersdk.ChatMessagePartTypeContextFile)
+		require.Len(t, ctxFiles, 1)
+		require.Equal(t, filepath.Join(workDir, "CLAUDE.md"), ctxFiles[0].ContextFilePath)
+		require.Equal(t, "from claude", ctxFiles[0].ContextFileContent)
+	})
+
+	//nolint:paralleltest // Uses t.Setenv to mutate process-wide environment.
+	t.Run("CustomEnvVarDisablesDefaultFallback", func(t *testing.T) {
+		// Setting EnvInstructionsFiles to a single name overrides
+		// the default list. AGENTS.md must NOT be picked up when
+		// only CLAUDE.md is configured.
+		setupConfigTestEnv(t, map[string]string{
+			agentcontextconfig.EnvInstructionsFiles: "CLAUDE.md",
+		})
+		workDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(workDir, "AGENTS.md"), []byte("from agents"), 0o600))
+
+		cfg, _ := agentcontextconfig.Resolve(workDir, agentcontextconfig.ReadEnvConfig())
+
+		ctxFiles := filterParts(cfg.Parts, codersdk.ChatMessagePartTypeContextFile)
+		require.Empty(t, ctxFiles)
+	})
+
+	//nolint:paralleltest // Uses t.Setenv to mutate process-wide environment.
+	t.Run("PerDirectoryFallbackIsIndependent", func(t *testing.T) {
+		// One configured directory has AGENTS.md, another has only
+		// CLAUDE.md. Each directory falls back independently and
+		// both files are emitted in configured-directory order.
+		a := t.TempDir()
+		b := t.TempDir()
+		setupConfigTestEnv(t, map[string]string{
+			agentcontextconfig.EnvInstructionsDirs: a + "," + b,
+		})
+		require.NoError(t, os.WriteFile(filepath.Join(a, "AGENTS.md"), []byte("from a"), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(b, "CLAUDE.md"), []byte("from b"), 0o600))
+
+		workDir := t.TempDir()
+		cfg, _ := agentcontextconfig.Resolve(workDir, agentcontextconfig.ReadEnvConfig())
+
+		ctxFiles := filterParts(cfg.Parts, codersdk.ChatMessagePartTypeContextFile)
+		require.Len(t, ctxFiles, 2)
+		require.Equal(t, filepath.Join(a, "AGENTS.md"), ctxFiles[0].ContextFilePath)
+		require.Equal(t, "from a", ctxFiles[0].ContextFileContent)
+		require.Equal(t, filepath.Join(b, "CLAUDE.md"), ctxFiles[1].ContextFilePath)
 		require.Equal(t, "from b", ctxFiles[1].ContextFileContent)
 	})
 
@@ -358,7 +477,7 @@ func TestResolve(t *testing.T) {
 		t.Setenv("HOME", fakeHome)
 		t.Setenv("USERPROFILE", fakeHome)
 		t.Setenv(agentcontextconfig.EnvInstructionsDirs, fakeHome)
-		t.Setenv(agentcontextconfig.EnvInstructionsFile, "")
+		t.Setenv(agentcontextconfig.EnvInstructionsFiles, "")
 		t.Setenv(agentcontextconfig.EnvSkillMetaFile, "")
 		t.Setenv(agentcontextconfig.EnvMCPConfigFiles, "")
 
@@ -499,7 +618,7 @@ func TestResolve(t *testing.T) {
 
 func TestNewAPI_LazyDirectory(t *testing.T) {
 	t.Setenv(agentcontextconfig.EnvInstructionsDirs, "")
-	t.Setenv(agentcontextconfig.EnvInstructionsFile, "")
+	t.Setenv(agentcontextconfig.EnvInstructionsFiles, "")
 	t.Setenv(agentcontextconfig.EnvSkillsDirs, "")
 	t.Setenv(agentcontextconfig.EnvSkillMetaFile, "")
 	t.Setenv(agentcontextconfig.EnvMCPConfigFiles, "")
@@ -526,7 +645,7 @@ func TestClearEnvVars(t *testing.T) {
 	// Set every context config env var.
 	for _, key := range []string{
 		agentcontextconfig.EnvInstructionsDirs,
-		agentcontextconfig.EnvInstructionsFile,
+		agentcontextconfig.EnvInstructionsFiles,
 		agentcontextconfig.EnvSkillsDirs,
 		agentcontextconfig.EnvSkillMetaFile,
 		agentcontextconfig.EnvMCPConfigFiles,
@@ -539,7 +658,7 @@ func TestClearEnvVars(t *testing.T) {
 	// Every env var should be absent.
 	for _, key := range []string{
 		agentcontextconfig.EnvInstructionsDirs,
-		agentcontextconfig.EnvInstructionsFile,
+		agentcontextconfig.EnvInstructionsFiles,
 		agentcontextconfig.EnvSkillsDirs,
 		agentcontextconfig.EnvSkillMetaFile,
 		agentcontextconfig.EnvMCPConfigFiles,

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -8733,7 +8733,7 @@ func TestAgentContextFilesAndSkillsLoadedIntoChat(t *testing.T) {
 	require.NoError(t, os.MkdirAll(skillsDir, 0o755))
 
 	t.Setenv(agentcontextconfig.EnvInstructionsDirs, instructionsDir)
-	t.Setenv(agentcontextconfig.EnvInstructionsFile, "AGENTS.md")
+	t.Setenv(agentcontextconfig.EnvInstructionsFiles, "AGENTS.md")
 	t.Setenv(agentcontextconfig.EnvSkillsDirs, skillsDir)
 	t.Setenv(agentcontextconfig.EnvSkillMetaFile, "SKILL.md")
 	t.Setenv(agentcontextconfig.EnvMCPConfigFiles, filepath.Join(fakeHome, "nonexistent-mcp.json"))


### PR DESCRIPTION
Adds an ordered fallback chain so Coder Agents picks up `AGENTS.md`, then `AGENT.md`, then `CLAUDE.md` per directory. The first existing file wins; a file that sanitizes to empty falls through to the next candidate, matching Coder's existing empty-file semantics.

The configuration env var is renamed to follow the rest of the package convention (`*_DIRS`, `*_FILES` for comma-separated lists):

- `CODER_AGENT_EXP_INSTRUCTIONS_FILE` → `CODER_AGENT_EXP_INSTRUCTIONS_FILES`

The var is experimental, so the rename is a straight swap with no backcompat alias. Setting it to a single name still works and disables the default fallback, preserving the behavior of any user who pinned the old single-name override.

Refs https://linear.app/codercom/issue/CODAGT-338

<details>
<summary>Design plan and decision log</summary>

### Behavior

- Per directory, the package searches a comma-separated, priority-ordered list of filenames (`AGENTS.md,AGENT.md,CLAUDE.md` by default).
- First existing, non-empty file wins per directory. No concatenation across candidate names in the same folder.
- A file that exists but sanitizes to empty (HTML-comment-only, whitespace, etc.) is treated as "not found" and falls through to the next candidate, matching Coder's existing single-filename behavior.
- Sanitization, the 64 KiB truncation cap, and the case-insensitive name match are unchanged.

### Env var

One env var, pluralized to match `CODER_AGENT_EXP_INSTRUCTIONS_DIRS`, `CODER_AGENT_EXP_SKILLS_DIRS`, and `CODER_AGENT_EXP_MCP_CONFIG_FILES`. The closest precedent is `CODER_AGENT_EXP_MCP_CONFIG_FILES`, which already takes a comma-separated list in dogfood (`~/.mcp.json,.mcp.json`).

### Divergences from Mux

Mux already has comparable fallback behavior. We adopt the same priority list but deliberately diverge on two points:

- Mux uses pre-sanitization existence to pick the base file. Coder keeps its "empty-after-sanitization is not found" rule for consistency with prior single-filename behavior, which means an empty `AGENTS.md` falls through to `CLAUDE.md`.
- Mux also overlays `AGENTS.local.md` from the same directory. Not in scope for this change.

### Scope

- `agent/agentcontextconfig/api.go` — env var rename, `Config` field rename, default fallback list, `Resolve` and `ContextPartsFromDir` parse the list and pass a `[]string` of candidate filenames to `readInstructionFileFromDir`, which iterates in priority order.
- `agent/agentcontextconfig/api_test.go` — six new subtests covering `AGENTS.md > AGENT.md > CLAUDE.md` precedence, fallback when only `CLAUDE.md` exists, `AGENT.md > CLAUDE.md`, empty `AGENTS.md` falls through, single-name env var disables the default fallback, and per-directory fallback is independent.
- `coderd/x/chatd/chatd_test.go` — env var identifier rename only.

No downstream changes. `agent/proto`, `coderd/x/chatd/chatd.go`, and `codersdk` treat the instruction file as opaque path + content.

</details>

---

_Authored by Coder Agents on behalf of @tracyjohnsonux._
