### PR TITLE
feat: surface model content-filter refusals as a blocked chat error

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -16732,7 +16732,8 @@ const docTemplate = `{
                 "config",
                 "usage_limit",
                 "missing_key",
-                "provider_disabled"
+                "provider_disabled",
+                "content_filter"
             ],
             "x-enum-varnames": [
                 "ChatErrorKindGeneric",
@@ -16744,7 +16745,8 @@ const docTemplate = `{
                 "ChatErrorKindConfig",
                 "ChatErrorKindUsageLimit",
                 "ChatErrorKindMissingKey",
-                "ChatErrorKindProviderDisabled"
+                "ChatErrorKindProviderDisabled",
+                "ChatErrorKindContentFilter"
             ]
         },
         "codersdk.ChatFileMetadata": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -15058,7 +15058,8 @@
 				"config",
 				"usage_limit",
 				"missing_key",
-				"provider_disabled"
+				"provider_disabled",
+				"content_filter"
 			],
 			"x-enum-varnames": [
 				"ChatErrorKindGeneric",
@@ -15070,7 +15071,8 @@
 				"ChatErrorKindConfig",
 				"ChatErrorKindUsageLimit",
 				"ChatErrorKindMissingKey",
-				"ChatErrorKindProviderDisabled"
+				"ChatErrorKindProviderDisabled",
+				"ChatErrorKindContentFilter"
 			]
 		},
 		"codersdk.ChatFileMetadata": {

--- a/coderd/x/chatd/chaterror/message.go
+++ b/coderd/x/chatd/chaterror/message.go
@@ -64,6 +64,10 @@ func terminalMessage(classified ClassifiedError) string {
 				" Contact your Coder administrator.",
 			displayName,
 		)
+	case codersdk.ChatErrorKindContentFilter:
+		return stringutil.Capitalize(fmt.Sprintf(
+			"%s blocked this response under its content policy.", subject,
+		))
 	default:
 		if !classified.Retryable && classified.StatusCode == 0 {
 			return "The chat request failed unexpectedly."

--- a/coderd/x/chatd/chaterror/message_test.go
+++ b/coderd/x/chatd/chaterror/message_test.go
@@ -97,6 +97,20 @@ func TestTerminalMessage(t *testing.T) {
 			retryable: false,
 			want:      "This conversation was started with an API key that is no longer available. Send your message again to continue.",
 		},
+		{
+			name:      "ContentFilter_Anthropic",
+			kind:      codersdk.ChatErrorKindContentFilter,
+			provider:  "anthropic",
+			retryable: false,
+			want:      "Anthropic blocked this response under its content policy.",
+		},
+		{
+			name:      "ContentFilter_UnknownProvider",
+			kind:      codersdk.ChatErrorKindContentFilter,
+			provider:  "",
+			retryable: false,
+			want:      "The AI provider blocked this response under its content policy.",
+		},
 	}
 
 	for _, tt := range tests {

--- a/coderd/x/chatd/chatloop/chatloop.go
+++ b/coderd/x/chatd/chatloop/chatloop.go
@@ -54,10 +54,8 @@ var (
 	// the run should terminate cleanly after persistence.
 	ErrStopAfterTool = xerrors.New("stop after tool")
 
-	// ErrContentFiltered is returned when the model produced no content and
-	// finished with a content-filter reason (e.g. Anthropic's "refusal"
-	// stop reason). It carries a classification so the turn ends as a
-	// user-visible blocked error instead of a silent empty turn.
+	// ErrContentFiltered is returned when the model finishes with
+	// FinishReasonContentFilter and produces no content.
 	ErrContentFiltered = xerrors.New("model response blocked by content filter")
 
 	errStreamSilenceTimeout = xerrors.New(
@@ -65,9 +63,8 @@ var (
 	)
 )
 
-// contentFilterError builds a classified, user-visible error for a turn that
-// produced no content because the provider blocked it. When Anthropic refusal
-// metadata is present, its explanation and category are surfaced.
+// contentFilterError builds a classified error from a content-filter finish.
+// Anthropic refusal metadata is surfaced when present.
 func contentFilterError(provider string, metadata fantasy.ProviderMetadata) error {
 	classified := chaterror.ClassifiedError{
 		Kind:      codersdk.ChatErrorKindContentFilter,
@@ -599,9 +596,8 @@ func Run(ctx context.Context, opts RunOptions) error {
 				"normal_persist", step, result.finishReason, result.content,
 			)
 			if len(result.content) == 0 {
-				// A content-filter finish with no content is a provider
-				// block (e.g. Anthropic refusal), not a normal stop. End the
-				// turn as a user-visible error instead of silently.
+				// A content-filter finish with empty content is a provider
+				// block, not a normal empty stop.
 				if result.finishReason == fantasy.FinishReasonContentFilter {
 					return contentFilterError(provider, result.providerMetadata)
 				}

--- a/coderd/x/chatd/chatloop/chatloop.go
+++ b/coderd/x/chatd/chatloop/chatloop.go
@@ -54,10 +54,31 @@ var (
 	// the run should terminate cleanly after persistence.
 	ErrStopAfterTool = xerrors.New("stop after tool")
 
+	// ErrContentFiltered is returned when the model produced no content and
+	// finished with a content-filter reason (e.g. Anthropic's "refusal"
+	// stop reason). It carries a classification so the turn ends as a
+	// user-visible blocked error instead of a silent empty turn.
+	ErrContentFiltered = xerrors.New("model response blocked by content filter")
+
 	errStreamSilenceTimeout = xerrors.New(
 		"chat stream was silent for longer than the configured timeout",
 	)
 )
+
+// contentFilterError builds a classified, user-visible error for a turn that
+// produced no content because the provider blocked it. When Anthropic refusal
+// metadata is present, its explanation and category are surfaced.
+func contentFilterError(provider string, metadata fantasy.ProviderMetadata) error {
+	classified := chaterror.ClassifiedError{
+		Kind:     codersdk.ChatErrorKindContentFilter,
+		Provider: provider,
+	}
+	if refusal := fantasyanthropic.GetRefusalMetadata(metadata); refusal != nil {
+		classified.Message = refusal.Explanation
+		classified.Detail = refusal.Category
+	}
+	return chaterror.WithClassification(ErrContentFiltered, classified)
+}
 
 // PendingToolCall describes a tool call that targets a dynamic
 // tool. These calls are not executed by the chatloop; instead
@@ -579,6 +600,12 @@ func Run(ctx context.Context, opts RunOptions) error {
 			if len(result.content) == 0 {
 				lastUsage = result.usage
 				lastProviderMetadata = result.providerMetadata
+				// A content-filter finish with no content is a provider
+				// block (e.g. Anthropic refusal), not a normal stop. End the
+				// turn as a user-visible error instead of silently.
+				if result.finishReason == fantasy.FinishReasonContentFilter {
+					return contentFilterError(provider, result.providerMetadata)
+				}
 				stoppedByModel = true
 				break
 			}

--- a/coderd/x/chatd/chatloop/chatloop.go
+++ b/coderd/x/chatd/chatloop/chatloop.go
@@ -70,8 +70,9 @@ var (
 // metadata is present, its explanation and category are surfaced.
 func contentFilterError(provider string, metadata fantasy.ProviderMetadata) error {
 	classified := chaterror.ClassifiedError{
-		Kind:     codersdk.ChatErrorKindContentFilter,
-		Provider: provider,
+		Kind:      codersdk.ChatErrorKindContentFilter,
+		Provider:  provider,
+		Retryable: false,
 	}
 	if refusal := fantasyanthropic.GetRefusalMetadata(metadata); refusal != nil {
 		classified.Message = refusal.Explanation

--- a/coderd/x/chatd/chatloop/chatloop.go
+++ b/coderd/x/chatd/chatloop/chatloop.go
@@ -598,14 +598,14 @@ func Run(ctx context.Context, opts RunOptions) error {
 				"normal_persist", step, result.finishReason, result.content,
 			)
 			if len(result.content) == 0 {
-				lastUsage = result.usage
-				lastProviderMetadata = result.providerMetadata
 				// A content-filter finish with no content is a provider
 				// block (e.g. Anthropic refusal), not a normal stop. End the
 				// turn as a user-visible error instead of silently.
 				if result.finishReason == fantasy.FinishReasonContentFilter {
 					return contentFilterError(provider, result.providerMetadata)
 				}
+				lastUsage = result.usage
+				lastProviderMetadata = result.providerMetadata
 				stoppedByModel = true
 				break
 			}

--- a/coderd/x/chatd/chatloop/contentfilter_internal_test.go
+++ b/coderd/x/chatd/chatloop/contentfilter_internal_test.go
@@ -1,0 +1,45 @@
+package chatloop
+
+import (
+	"testing"
+
+	fantasy "charm.land/fantasy"
+	fantasyanthropic "charm.land/fantasy/providers/anthropic"
+
+	"github.com/coder/coder/v2/coderd/x/chatd/chaterror"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func TestContentFilterError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WithRefusalMetadata", func(t *testing.T) {
+		t.Parallel()
+		meta := fantasy.ProviderMetadata{
+			fantasyanthropic.Name: &fantasyanthropic.RefusalMetadata{
+				Category:    "cyber",
+				Explanation: "blocked under policy",
+			},
+		}
+		err := contentFilterError("anthropic", meta)
+		classified := chaterror.Classify(err)
+		if classified.Kind != codersdk.ChatErrorKindContentFilter {
+			t.Errorf("kind = %q, want content_filter", classified.Kind)
+		}
+		if classified.Message != "blocked under policy" {
+			t.Errorf("message = %q, want explanation", classified.Message)
+		}
+	})
+
+	t.Run("WithoutMetadataUsesDefault", func(t *testing.T) {
+		t.Parallel()
+		err := contentFilterError("anthropic", nil)
+		classified := chaterror.Classify(err)
+		if classified.Kind != codersdk.ChatErrorKindContentFilter {
+			t.Errorf("kind = %q, want content_filter", classified.Kind)
+		}
+		if classified.Message == "" {
+			t.Error("expected a default message, got empty")
+		}
+	})
+}

--- a/coderd/x/chatd/chatloop/contentfilter_internal_test.go
+++ b/coderd/x/chatd/chatloop/contentfilter_internal_test.go
@@ -1,12 +1,15 @@
 package chatloop
 
 import (
+	"context"
 	"testing"
 
 	fantasy "charm.land/fantasy"
 	fantasyanthropic "charm.land/fantasy/providers/anthropic"
+	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/x/chatd/chaterror"
+	"github.com/coder/coder/v2/coderd/x/chatd/chattest"
 	"github.com/coder/coder/v2/codersdk"
 )
 
@@ -27,7 +30,10 @@ func TestContentFilterError(t *testing.T) {
 			t.Errorf("kind = %q, want content_filter", classified.Kind)
 		}
 		if classified.Message != "blocked under policy" {
-			t.Errorf("message = %q, want explanation", classified.Message)
+			t.Errorf("message = %q, want %q", classified.Message, "blocked under policy")
+		}
+		if classified.Detail != "cyber" {
+			t.Errorf("detail = %q, want %q", classified.Detail, "cyber")
 		}
 	})
 
@@ -38,8 +44,54 @@ func TestContentFilterError(t *testing.T) {
 		if classified.Kind != codersdk.ChatErrorKindContentFilter {
 			t.Errorf("kind = %q, want content_filter", classified.Kind)
 		}
-		if classified.Message == "" {
-			t.Error("expected a default message, got empty")
+		want := "Anthropic blocked this response under its content policy."
+		if classified.Message != want {
+			t.Errorf("message = %q, want %q", classified.Message, want)
 		}
 	})
+}
+
+// TestRun_ContentFilterEmptyTurn exercises the branch in Run that converts
+// a content-filter finish with no content into a terminal classified error
+// instead of a silent empty turn. Nothing is persisted for the blocked step.
+func TestRun_ContentFilterEmptyTurn(t *testing.T) {
+	t.Parallel()
+
+	model := &chattest.FakeModel{
+		ProviderName: fantasyanthropic.Name,
+		StreamFn: func(_ context.Context, _ fantasy.Call) (fantasy.StreamResponse, error) {
+			return streamFromParts([]fantasy.StreamPart{{
+				Type:         fantasy.StreamPartTypeFinish,
+				FinishReason: fantasy.FinishReasonContentFilter,
+				ProviderMetadata: fantasy.ProviderMetadata{
+					fantasyanthropic.Name: &fantasyanthropic.RefusalMetadata{
+						Category:    "cyber",
+						Explanation: "blocked under policy",
+					},
+				},
+			}}), nil
+		},
+	}
+
+	persisted := false
+	err := Run(context.Background(), RunOptions{
+		Model: model,
+		Messages: []fantasy.Message{
+			textMessage(fantasy.MessageRoleUser, "hello"),
+		},
+		MaxSteps:             1,
+		ContextLimitFallback: 4096,
+		PersistStep: func(_ context.Context, _ PersistedStep) error {
+			persisted = true
+			return nil
+		},
+	})
+	require.ErrorIs(t, err, ErrContentFiltered)
+
+	classified := chaterror.Classify(err)
+	require.Equal(t, codersdk.ChatErrorKindContentFilter, classified.Kind)
+	require.Equal(t, "blocked under policy", classified.Message)
+	require.Equal(t, "cyber", classified.Detail)
+	require.False(t, classified.Retryable)
+	require.False(t, persisted, "blocked turn must not persist a step")
 }

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -1538,6 +1538,7 @@ const (
 	ChatErrorKindUsageLimit           ChatErrorKind = "usage_limit"
 	ChatErrorKindMissingKey           ChatErrorKind = "missing_key"
 	ChatErrorKindProviderDisabled     ChatErrorKind = "provider_disabled"
+	ChatErrorKindContentFilter        ChatErrorKind = "content_filter"
 )
 
 // AllChatErrorKinds contains every ChatErrorKind value.
@@ -1553,6 +1554,7 @@ var AllChatErrorKinds = []ChatErrorKind{
 	ChatErrorKindUsageLimit,
 	ChatErrorKindMissingKey,
 	ChatErrorKindProviderDisabled,
+	ChatErrorKindContentFilter,
 }
 
 // ChatError represents a terminal chat error in persisted chat state or the

--- a/docs/reference/api/chats.md
+++ b/docs/reference/api/chats.md
@@ -294,13 +294,13 @@ Status Code **200**
 
 #### Enumerated Values
 
-| Property      | Value(s)                                                                                                                                        |
-|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
-| `client_type` | `api`, `ui`                                                                                                                                     |
-| `kind`        | `auth`, `config`, `generic`, `missing_key`, `overloaded`, `provider_disabled`, `rate_limit`, `stream_silence_timeout`, `timeout`, `usage_limit` |
-| `type`        | `context-file`, `file`, `file-reference`, `reasoning`, `skill`, `source`, `text`, `tool-call`, `tool-result`                                    |
-| `plan_mode`   | `plan`                                                                                                                                          |
-| `status`      | `completed`, `error`, `paused`, `pending`, `requires_action`, `running`, `waiting`                                                              |
+| Property      | Value(s)                                                                                                                                                          |
+|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `client_type` | `api`, `ui`                                                                                                                                                       |
+| `kind`        | `auth`, `config`, `content_filter`, `generic`, `missing_key`, `overloaded`, `provider_disabled`, `rate_limit`, `stream_silence_timeout`, `timeout`, `usage_limit` |
+| `type`        | `context-file`, `file`, `file-reference`, `reasoning`, `skill`, `source`, `text`, `tool-call`, `tool-result`                                                      |
+| `plan_mode`   | `plan`                                                                                                                                                            |
+| `status`      | `completed`, `error`, `paused`, `pending`, `requires_action`, `running`, `waiting`                                                                                |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2706,9 +2706,9 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 #### Enumerated Values
 
-| Value(s)                                                                                                                                        |
-|-------------------------------------------------------------------------------------------------------------------------------------------------|
-| `auth`, `config`, `generic`, `missing_key`, `overloaded`, `provider_disabled`, `rate_limit`, `stream_silence_timeout`, `timeout`, `usage_limit` |
+| Value(s)                                                                                                                                                          |
+|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `auth`, `config`, `content_filter`, `generic`, `missing_key`, `overloaded`, `provider_disabled`, `rate_limit`, `stream_silence_timeout`, `timeout`, `usage_limit` |
 
 ## codersdk.ChatFileMetadata
 

--- a/go.mod
+++ b/go.mod
@@ -99,8 +99,11 @@ replace github.com/spf13/afero => github.com/aslilac/afero v0.0.0-20250403163713
 //     name, and warn on unsupported FilePart media types instead of
 //     silently dropping them.
 // 12) coder/fantasy#39, support Anthropic thinking_display natively.
-// See: https://github.com/coder/fantasy/commits/a2a3f2171ec8
-replace charm.land/fantasy => github.com/coder/fantasy v0.0.0-20260604204802-a2a3f2171ec8
+// 13) coder/fantasy scott/anthropic-refusal-content-filter, map Anthropic's
+//     "refusal" stop_reason to FinishReasonContentFilter and carry
+//     stop_details (category, explanation) in the finish ProviderMetadata.
+// See: https://github.com/coder/fantasy/commits/805f9dae1e20
+replace charm.land/fantasy => github.com/coder/fantasy v0.0.0-20260611184442-805f9dae1e20
 
 // coder/coder uses a fork of charmbracelet's fork of the Anthropic Go SDK
 // with performance improvements and Bedrock header cleanup.

--- a/go.sum
+++ b/go.sum
@@ -324,8 +324,8 @@ github.com/coder/bubbletea v1.2.2-0.20241212190825-007a1cdb2c41 h1:SBN/DA63+ZHwu
 github.com/coder/bubbletea v1.2.2-0.20241212190825-007a1cdb2c41/go.mod h1:I9ULxr64UaOSUv7hcb3nX4kowodJCVS7vt7VVJk/kW4=
 github.com/coder/clistat v1.2.1 h1:P9/10njXMyj5cWzIU5wkRsSy5LVQH49+tcGMsAgWX0w=
 github.com/coder/clistat v1.2.1/go.mod h1:m7SC0uj88eEERgvF8Kn6+w6XF21BeSr+15f7GoLAw0A=
-github.com/coder/fantasy v0.0.0-20260604204802-a2a3f2171ec8 h1:+8QmiW3qKSqS4pkEQQbK7Rg3UGWnD/c5BXp1tPpX1sU=
-github.com/coder/fantasy v0.0.0-20260604204802-a2a3f2171ec8/go.mod h1:RdKpE+blFnbGx4XmNc952AXAdBL1ZXg9iTnXHjdn9Bk=
+github.com/coder/fantasy v0.0.0-20260611184442-805f9dae1e20 h1:HcHzxj/UKFsu2BTh4L02+1/Ij8eqxvWGxy/ti/fzcmc=
+github.com/coder/fantasy v0.0.0-20260611184442-805f9dae1e20/go.mod h1:RdKpE+blFnbGx4XmNc952AXAdBL1ZXg9iTnXHjdn9Bk=
 github.com/coder/flog v1.1.0 h1:kbAes1ai8fIS5OeV+QAnKBQE22ty1jRF/mcAwHpLBa4=
 github.com/coder/flog v1.1.0/go.mod h1:UQlQvrkJBvnRGo69Le8E24Tcl5SJleAAR7gYEHzAmdQ=
 github.com/coder/go-httpstat v0.0.0-20230801153223-321c88088322 h1:m0lPZjlQ7vdVpRBPKfYIFlmgevoTkBxB10wv6l2gOaU=

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1991,6 +1991,7 @@ export interface ChatError {
 export type ChatErrorKind =
 	| "auth"
 	| "config"
+	| "content_filter"
 	| "generic"
 	| "missing_key"
 	| "overloaded"
@@ -2003,6 +2004,7 @@ export type ChatErrorKind =
 export const ChatErrorKinds: ChatErrorKind[] = [
 	"auth",
 	"config",
+	"content_filter",
 	"generic",
 	"missing_key",
 	"overloaded",

--- a/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.stories.tsx
@@ -321,6 +321,38 @@ export const TerminalProviderDisabledError: Story = {
 	},
 };
 
+/** Content-filter blocks render the refusal explanation and category without retry. */
+export const TerminalContentFilterError: Story = {
+	args: {
+		...defaultArgs,
+		liveStatus: buildLiveStatus({
+			persistedError: {
+				kind: "content_filter",
+				message:
+					"This response was blocked because it violated our usage policy.",
+				detail: "cyber",
+				provider: "anthropic",
+				retryable: false,
+			},
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByRole("heading", { name: /response blocked/i }),
+		).toBeVisible();
+		expect(
+			canvas.getByText(/blocked because it violated our usage policy/i),
+		).toBeVisible();
+		expect(canvas.getByText(/cyber/i)).toBeVisible();
+		// A provider block is terminal: no retry countdown or status link.
+		expect(canvas.queryByText(/retrying/i)).not.toBeInTheDocument();
+		expect(
+			canvas.queryByRole("link", { name: /status/i }),
+		).not.toBeInTheDocument();
+	},
+};
+
 /** Generic failures do not show usage or provider CTAs. */
 export const GenericErrorDoesNotShowUsageAction: Story = {
 	args: {

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStatusHelpers.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStatusHelpers.ts
@@ -46,6 +46,8 @@ export const getErrorTitle = (
 			return "Chat interrupted";
 		case "provider_disabled":
 			return "Provider disabled";
+		case "content_filter":
+			return "Response blocked";
 		default:
 			return mode === "retry" ? "Retrying request" : "Request failed";
 	}


### PR DESCRIPTION
## Summary

When a provider blocks a turn with a content-filter stop reason and produces no
content, the chat turn previously ended silently: the user saw the "Thinking"
spinner and then nothing. This adds detection and surfacing so the turn ends as
a terminal `content_filter` error with the provider's explanation, which the UI
renders as a clear "Response blocked" message.

Observed with Anthropic's real-time safety classifiers (`stop_reason: "refusal"`,
empty content), e.g. the Fable model on security-policy-violating prompts.

## Changes

- **codersdk**: add `ChatErrorKindContentFilter` (+ `AllChatErrorKinds`, generated TS).
- **chatloop**: when a step finishes with `FinishReasonContentFilter` and no
  content, return a classified `ErrContentFiltered` instead of breaking
  silently, surfacing the Anthropic refusal `category`/`explanation`.
- **chaterror**: default user-facing message for the new kind.
- **site**: render "Response blocked" as the error title.
- **go.mod**: point the fantasy fork at the refusal mapping change.

<img width="686" height="269" alt="image" src="https://github.com/user-attachments/assets/536b7656-4e88-42fd-8d32-335e0561b32d" />

## Dependency

Depends on coder/fantasy#41. The `go.mod` replace currently points at that PR's
branch commit (`805f9dae1e20`). Repoint it to the merged fantasy commit before
this merges.

## Testing

- `go test ./coderd/x/chatd/chatloop/ ./coderd/x/chatd/chaterror/ ./codersdk/`
  (new `contentfilter_internal_test.go`).
- End-to-end against a local `develop.sh` instance routed through the
  dev.coder.com AI gateway: a Fable refusal now ends the turn as
  `status=error`, `last_error.kind=content_filter` with Anthropic's explanation
  and `detail=cyber`. A normal text refusal (e.g. Opus 4.8 declining in prose)
  is unaffected, since content is non-empty.

<details>
<summary>Decision log</summary>

- Reproduced the silent turn and confirmed via the chat debug-run API that Fable
  returns HTTP 200 with `stop_reason: "refusal"` + `stop_details` and empty
  content; the fantasy SDK normalized it to `FinishReasonUnknown` and dropped
  the details, and chatloop's empty-content branch discarded it.
- Chose to model the block as `ChatStatusError` + a new `ChatErrorKind` to reuse
  the existing classified-error flow and frontend rendering, rather than a new
  terminal status or message-part type.
- Chose the precise path (carry Anthropic's `explanation`/`category` through
  `ProviderMetadata`) over a generic static message; the generic `unknown`
  signal is ambiguous and risks false positives on benign empty completions.
- Reused `FinishReasonContentFilter` for `refusal` rather than adding a new
  finish reason.

</details>

---
_Coder Agents generated._
