### PR TITLE
fix(site): set external auth provider polling status individually

### DIFF
--- a/site/src/hooks/useExternalAuth.ts
+++ b/site/src/hooks/useExternalAuth.ts
@@ -46,7 +46,7 @@ export const useExternalAuth = (versionId: string | undefined) => {
 	// Per-provider 60-second timeout.
 	useEffect(() => {
 		const pollingIds = Object.entries(pollingState)
-			.filter(([, s]) => s === "polling")
+			.filter(([, authPollingState]) => authPollingState === "polling")
 			.map(([id]) => id);
 
 		if (pollingIds.length === 0) {

--- a/site/src/hooks/useExternalAuth.ts
+++ b/site/src/hooks/useExternalAuth.ts
@@ -13,9 +13,7 @@ export const useExternalAuth = (versionId: string | undefined) => {
 		setPollingState((prev) => ({ ...prev, [providerId]: "polling" }));
 	}, []);
 
-	const isAnyPolling = Object.values(pollingState).some(
-		(s) => s === "polling",
-	);
+	const isAnyPolling = Object.values(pollingState).some((s) => s === "polling");
 
 	const {
 		data: externalAuth,

--- a/site/src/hooks/useExternalAuth.ts
+++ b/site/src/hooks/useExternalAuth.ts
@@ -5,12 +5,17 @@ import { templateVersionExternalAuth } from "#/api/queries/templates";
 export type ExternalAuthPollingState = "idle" | "polling" | "abandoned";
 
 export const useExternalAuth = (versionId: string | undefined) => {
-	const [externalAuthPollingState, setExternalAuthPollingState] =
-		useState<ExternalAuthPollingState>("idle");
+	const [pollingState, setPollingState] = useState<
+		Record<string, ExternalAuthPollingState>
+	>({});
 
-	const startPollingExternalAuth = useCallback(() => {
-		setExternalAuthPollingState("polling");
+	const startPollingExternalAuth = useCallback((providerId: string) => {
+		setPollingState((prev) => ({ ...prev, [providerId]: "polling" }));
 	}, []);
+
+	const isAnyPolling = Object.values(pollingState).some(
+		(s) => s === "polling",
+	);
 
 	const {
 		data: externalAuth,
@@ -19,37 +24,58 @@ export const useExternalAuth = (versionId: string | undefined) => {
 	} = useQuery({
 		...templateVersionExternalAuth(versionId ?? ""),
 		enabled: Boolean(versionId),
-		refetchInterval: externalAuthPollingState === "polling" ? 1000 : false,
+		refetchInterval: isAnyPolling ? 1000 : false,
 	});
 
-	const allSignedIn = externalAuth?.every((it) => it.authenticated);
-
+	// Stop polling individual providers once they authenticate.
 	useEffect(() => {
-		if (allSignedIn) {
-			setExternalAuthPollingState("idle");
+		if (!externalAuth) {
+			return;
+		}
+		setPollingState((prev) => {
+			let changed = false;
+			const next = { ...prev };
+			for (const auth of externalAuth) {
+				if (auth.authenticated && next[auth.id] === "polling") {
+					next[auth.id] = "idle";
+					changed = true;
+				}
+			}
+			return changed ? next : prev;
+		});
+	}, [externalAuth]);
+
+	// Per-provider 60-second timeout.
+	useEffect(() => {
+		const pollingIds = Object.entries(pollingState)
+			.filter(([, s]) => s === "polling")
+			.map(([id]) => id);
+
+		if (pollingIds.length === 0) {
 			return;
 		}
 
-		if (externalAuthPollingState !== "polling") {
-			return;
-		}
-
-		// Poll for a maximum of one minute
-		const quitPolling = setTimeout(
-			() => setExternalAuthPollingState("abandoned"),
-			60_000,
+		const timers = pollingIds.map((id) =>
+			setTimeout(() => {
+				setPollingState((prev) =>
+					prev[id] === "polling" ? { ...prev, [id]: "abandoned" } : prev,
+				);
+			}, 60_000),
 		);
+
 		return () => {
-			clearTimeout(quitPolling);
+			for (const t of timers) {
+				clearTimeout(t);
+			}
 		};
-	}, [externalAuthPollingState, allSignedIn]);
+	}, [pollingState]);
 
 	return {
 		startPollingExternalAuth,
 		externalAuth,
-		externalAuthPollingState,
+		externalAuthPollingState: pollingState,
 		isLoadingExternalAuth,
 		externalAuthError: error,
-		isPollingExternalAuth: externalAuthPollingState === "polling",
+		isPollingExternalAuth: isAnyPolling,
 	};
 };

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.stories.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.stories.tsx
@@ -10,6 +10,7 @@ import {
 	MockTasks,
 	MockTemplate,
 	MockTemplateVersion,
+	MockTemplateVersionExternalAuthAzure,
 	MockTemplateVersionExternalAuthGithub,
 	MockTemplateVersionExternalAuthGithubAuthenticated,
 	MockUserOwner,
@@ -383,6 +384,39 @@ export const MissingExternalAuth: Story = {
 
 		await step("Renders external authentication", async () => {
 			await canvas.findByRole("button", { name: /connect to github/i });
+		});
+	},
+};
+
+export const MissingExternalAuthMultipleProviders: Story = {
+	beforeEach: () => {
+		spyOn(API, "getTasks")
+			.mockResolvedValueOnce(MockTasks)
+			.mockResolvedValue([MockNewTaskData, ...MockTasks]);
+		spyOn(API, "createTask").mockResolvedValue(MockTask);
+		spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([
+			MockTemplateVersionExternalAuthGithub,
+			MockTemplateVersionExternalAuthAzure,
+		]);
+		// Prevent the auth button from actually opening a popup.
+		spyOn(window, "open").mockReturnValue(null);
+	},
+	play: async ({ canvasElement, step }) => {
+		const canvas = within(canvasElement);
+
+		const githubButton = await canvas.findByRole("button", {
+			name: /connect to github/i,
+		});
+		const azureButton = await canvas.findByRole("button", {
+			name: /connect to azure/i,
+		});
+
+		await step("Click GitHub auth button", async () => {
+			await userEvent.click(githubButton);
+		});
+
+		await step("Azure button remains enabled", () => {
+			expect(azureButton).toBeEnabled();
 		});
 	},
 };

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -436,10 +436,8 @@ const ExternalAuthButtons: FC<ExternalAuthButtonProps> = ({
 	versionId,
 	missedExternalAuth,
 }) => {
-	const {
-		startPollingExternalAuth,
-		externalAuthPollingState,
-	} = useExternalAuth(versionId);
+	const { startPollingExternalAuth, externalAuthPollingState } =
+		useExternalAuth(versionId);
 
 	return missedExternalAuth.map((auth) => {
 		return (
@@ -447,7 +445,10 @@ const ExternalAuthButtons: FC<ExternalAuthButtonProps> = ({
 				<Button
 					className="bg-surface-tertiary hover:bg-surface-quaternary rounded-full text-content-primary"
 					size="sm"
-					disabled={externalAuthPollingState[auth.id] === "polling" || auth.authenticated}
+					disabled={
+						externalAuthPollingState[auth.id] === "polling" ||
+						auth.authenticated
+					}
 					onClick={() => {
 						window.open(
 							auth.authenticate_url,
@@ -463,23 +464,24 @@ const ExternalAuthButtons: FC<ExternalAuthButtonProps> = ({
 					Connect to {auth.display_name}
 				</Button>
 
-				{externalAuthPollingState[auth.id] === "abandoned" && !auth.authenticated && (
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								variant="outline"
-								size="icon"
-								onClick={() => startPollingExternalAuth(auth.id)}
-							>
-								<RedoIcon />
-								<span className="sr-only">Refresh external auth</span>
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>
-							Retry connecting to {auth.display_name}
-						</TooltipContent>
-					</Tooltip>
-				)}
+				{externalAuthPollingState[auth.id] === "abandoned" &&
+					!auth.authenticated && (
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									variant="outline"
+									size="icon"
+									onClick={() => startPollingExternalAuth(auth.id)}
+								>
+									<RedoIcon />
+									<span className="sr-only">Refresh external auth</span>
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent>
+								Retry connecting to {auth.display_name}
+							</TooltipContent>
+						</Tooltip>
+					)}
 			</div>
 		);
 	});

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -438,10 +438,8 @@ const ExternalAuthButtons: FC<ExternalAuthButtonProps> = ({
 }) => {
 	const {
 		startPollingExternalAuth,
-		isPollingExternalAuth,
 		externalAuthPollingState,
 	} = useExternalAuth(versionId);
-	const shouldRetry = externalAuthPollingState === "abandoned";
 
 	return missedExternalAuth.map((auth) => {
 		return (
@@ -449,29 +447,29 @@ const ExternalAuthButtons: FC<ExternalAuthButtonProps> = ({
 				<Button
 					className="bg-surface-tertiary hover:bg-surface-quaternary rounded-full text-content-primary"
 					size="sm"
-					disabled={isPollingExternalAuth || auth.authenticated}
+					disabled={externalAuthPollingState[auth.id] === "polling" || auth.authenticated}
 					onClick={() => {
 						window.open(
 							auth.authenticate_url,
 							"_blank",
 							"width=900,height=600",
 						);
-						startPollingExternalAuth();
+						startPollingExternalAuth(auth.id);
 					}}
 				>
-					<Spinner loading={isPollingExternalAuth}>
+					<Spinner loading={externalAuthPollingState[auth.id] === "polling"}>
 						<ExternalImage src={auth.display_icon} />
 					</Spinner>
 					Connect to {auth.display_name}
 				</Button>
 
-				{shouldRetry && !auth.authenticated && (
+				{externalAuthPollingState[auth.id] === "abandoned" && !auth.authenticated && (
 					<Tooltip>
 						<TooltipTrigger asChild>
 							<Button
 								variant="outline"
 								size="icon"
-								onClick={startPollingExternalAuth}
+								onClick={() => startPollingExternalAuth(auth.id)}
 							>
 								<RedoIcon />
 								<span className="sr-only">Refresh external auth</span>

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -440,15 +440,16 @@ const ExternalAuthButtons: FC<ExternalAuthButtonProps> = ({
 		useExternalAuth(versionId);
 
 	return missedExternalAuth.map((auth) => {
+		const isPollingExternalAuth =
+			externalAuthPollingState[auth.id] === "polling";
+		const shouldRetry = externalAuthPollingState[auth.id] === "abandoned";
+
 		return (
 			<div className="flex items-center gap-2" key={auth.id}>
 				<Button
 					className="bg-surface-tertiary hover:bg-surface-quaternary rounded-full text-content-primary"
 					size="sm"
-					disabled={
-						externalAuthPollingState[auth.id] === "polling" ||
-						auth.authenticated
-					}
+					disabled={isPollingExternalAuth || auth.authenticated}
 					onClick={() => {
 						window.open(
 							auth.authenticate_url,
@@ -458,30 +459,29 @@ const ExternalAuthButtons: FC<ExternalAuthButtonProps> = ({
 						startPollingExternalAuth(auth.id);
 					}}
 				>
-					<Spinner loading={externalAuthPollingState[auth.id] === "polling"}>
+					<Spinner loading={isPollingExternalAuth}>
 						<ExternalImage src={auth.display_icon} />
 					</Spinner>
 					Connect to {auth.display_name}
 				</Button>
 
-				{externalAuthPollingState[auth.id] === "abandoned" &&
-					!auth.authenticated && (
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									variant="outline"
-									size="icon"
-									onClick={() => startPollingExternalAuth(auth.id)}
-								>
-									<RedoIcon />
-									<span className="sr-only">Refresh external auth</span>
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>
-								Retry connecting to {auth.display_name}
-							</TooltipContent>
-						</Tooltip>
-					)}
+				{shouldRetry && !auth.authenticated && (
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								variant="outline"
+								size="icon"
+								onClick={() => startPollingExternalAuth(auth.id)}
+							>
+								<RedoIcon />
+								<span className="sr-only">Refresh external auth</span>
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>
+							Retry connecting to {auth.display_name}
+						</TooltipContent>
+					</Tooltip>
+				)}
 			</div>
 		);
 	});

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.stories.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.stories.tsx
@@ -2,10 +2,10 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import { API } from "#/api/api";
-import type { TemplateVersionExternalAuth } from "#/api/typesGenerated";
 import {
 	MockTemplate,
 	MockTemplateVersion,
+	MockTemplateVersionExternalAuthAzure,
 	MockTemplateVersionExternalAuthGithub,
 	MockTemplateVersionExternalAuthGithubAuthenticated,
 	MockUserOwner,
@@ -15,20 +15,6 @@ import {
 	withDashboardProvider,
 } from "#/testHelpers/storybook";
 import CreateWorkspacePage from "./CreateWorkspacePage";
-
-const MockGitLabExternalAuth: TemplateVersionExternalAuth = {
-	id: "gitlab",
-	type: "gitlab",
-	authenticate_url: "https://example.com/external-auth/gitlab",
-	authenticated: false,
-	display_icon: "/icon/gitlab.svg",
-	display_name: "GitLab",
-};
-
-const MockGitLabExternalAuthAuthenticated: TemplateVersionExternalAuth = {
-	...MockGitLabExternalAuth,
-	authenticated: true,
-};
 
 /**
  * Mocks API.templateVersionDynamicParameters to immediately send an empty
@@ -100,7 +86,7 @@ export const MultipleExternalAuth: Story = {
 	beforeEach: () => {
 		spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([
 			MockTemplateVersionExternalAuthGithub,
-			MockGitLabExternalAuth,
+			MockTemplateVersionExternalAuthAzure,
 		]);
 	},
 	play: async ({ canvasElement }) => {
@@ -129,7 +115,7 @@ export const ClickingOneAuthDoesNotDisableOthers: Story = {
 	beforeEach: () => {
 		spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([
 			MockTemplateVersionExternalAuthGithub,
-			MockGitLabExternalAuth,
+			MockTemplateVersionExternalAuthAzure,
 		]);
 	},
 	play: async ({ canvasElement, step }) => {
@@ -166,7 +152,7 @@ export const OneProviderAuthenticated: Story = {
 	beforeEach: () => {
 		spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([
 			MockTemplateVersionExternalAuthGithubAuthenticated,
-			MockGitLabExternalAuth,
+			MockTemplateVersionExternalAuthAzure,
 		]);
 	},
 	play: async ({ canvasElement, step }) => {
@@ -198,11 +184,11 @@ export const SequentialAuthFlow: Story = {
 		spyOn(API, "getTemplateVersionExternalAuth")
 			.mockResolvedValueOnce([
 				MockTemplateVersionExternalAuthGithub,
-				MockGitLabExternalAuth,
+				MockTemplateVersionExternalAuthAzure,
 			])
 			.mockResolvedValue([
 				MockTemplateVersionExternalAuthGithubAuthenticated,
-				MockGitLabExternalAuth,
+				MockTemplateVersionExternalAuthAzure,
 			]);
 	},
 	play: async ({ canvasElement, step }) => {

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.stories.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.stories.tsx
@@ -10,7 +10,10 @@ import {
 	MockTemplateVersionExternalAuthGithubAuthenticated,
 	MockUserOwner,
 } from "#/testHelpers/entities";
-import { withAuthProvider, withDashboardProvider } from "#/testHelpers/storybook";
+import {
+	withAuthProvider,
+	withDashboardProvider,
+} from "#/testHelpers/storybook";
 import CreateWorkspacePage from "./CreateWorkspacePage";
 
 const MockGitLabExternalAuth: TemplateVersionExternalAuth = {
@@ -219,8 +222,9 @@ export const SequentialAuthFlow: Story = {
 			// Polling picks up the updated mock that returns GitHub as
 			// authenticated. The "Authenticated" text replaces the button.
 			await waitFor(() => {
-				expect(canvas.queryByRole("button", { name: /login with github/i }))
-					.not.toBeInTheDocument();
+				expect(
+					canvas.queryByRole("button", { name: /login with github/i }),
+				).not.toBeInTheDocument();
 			});
 		});
 

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.stories.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.stories.tsx
@@ -132,12 +132,8 @@ export const ClickingOneAuthDoesNotDisableOthers: Story = {
 			await userEvent.click(githubButton);
 		});
 
-		await step("Azure button remains enabled", async () => {
-			// After the fix, each provider tracks its own polling state so
-			// only the clicked provider shows a loading spinner.
-			await waitFor(() => {
-				expect(azureButton).toBeEnabled();
-			});
+		await step("Azure button remains enabled", () => {
+			expect(azureButton).toBeEnabled();
 		});
 	},
 };

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.stories.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.stories.tsx
@@ -95,12 +95,12 @@ export const MultipleExternalAuth: Story = {
 		const githubButton = await canvas.findByRole("button", {
 			name: /login with github/i,
 		});
-		const gitlabButton = await canvas.findByRole("button", {
-			name: /login with gitlab/i,
+		const azureButton = await canvas.findByRole("button", {
+			name: /login with azure/i,
 		});
 
 		expect(githubButton).toBeEnabled();
-		expect(gitlabButton).toBeEnabled();
+		expect(azureButton).toBeEnabled();
 	},
 };
 
@@ -124,19 +124,19 @@ export const ClickingOneAuthDoesNotDisableOthers: Story = {
 		const githubButton = await canvas.findByRole("button", {
 			name: /login with github/i,
 		});
-		const gitlabButton = await canvas.findByRole("button", {
-			name: /login with gitlab/i,
+		const azureButton = await canvas.findByRole("button", {
+			name: /login with azure/i,
 		});
 
 		await step("Click GitHub auth button", async () => {
 			await userEvent.click(githubButton);
 		});
 
-		await step("GitLab button remains enabled", async () => {
+		await step("Azure button remains enabled", async () => {
 			// After the fix, each provider tracks its own polling state so
 			// only the clicked provider shows a loading spinner.
 			await waitFor(() => {
-				expect(gitlabButton).toBeEnabled();
+				expect(azureButton).toBeEnabled();
 			});
 		});
 	},
@@ -162,11 +162,11 @@ export const OneProviderAuthenticated: Story = {
 			await canvas.findByText("Authenticated");
 		});
 
-		await step("GitLab login button is still enabled", async () => {
-			const gitlabButton = await canvas.findByRole("button", {
-				name: /login with gitlab/i,
+		await step("Azure login button is still enabled", async () => {
+			const azureButton = await canvas.findByRole("button", {
+				name: /login with azure/i,
 			});
-			expect(gitlabButton).toBeEnabled();
+			expect(azureButton).toBeEnabled();
 		});
 	},
 };
@@ -196,7 +196,7 @@ export const SequentialAuthFlow: Story = {
 
 		await step("Both buttons render initially", async () => {
 			await canvas.findByRole("button", { name: /login with github/i });
-			await canvas.findByRole("button", { name: /login with gitlab/i });
+			await canvas.findByRole("button", { name: /login with azure/i });
 		});
 
 		await step("Click GitHub and wait for it to authenticate", async () => {
@@ -214,11 +214,11 @@ export const SequentialAuthFlow: Story = {
 			});
 		});
 
-		await step("GitLab button is still clickable", async () => {
-			const gitlabButton = await canvas.findByRole("button", {
-				name: /login with gitlab/i,
+		await step("Azure button is still clickable", async () => {
+			const azureButton = await canvas.findByRole("button", {
+				name: /login with azure/i,
 			});
-			expect(gitlabButton).toBeEnabled();
+			expect(azureButton).toBeEnabled();
 		});
 	},
 };

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.stories.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.stories.tsx
@@ -1,0 +1,234 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
+import { reactRouterParameters } from "storybook-addon-remix-react-router";
+import { API } from "#/api/api";
+import type { TemplateVersionExternalAuth } from "#/api/typesGenerated";
+import {
+	MockTemplate,
+	MockTemplateVersion,
+	MockTemplateVersionExternalAuthGithub,
+	MockTemplateVersionExternalAuthGithubAuthenticated,
+	MockUserOwner,
+} from "#/testHelpers/entities";
+import { withAuthProvider, withDashboardProvider } from "#/testHelpers/storybook";
+import CreateWorkspacePage from "./CreateWorkspacePage";
+
+const MockGitLabExternalAuth: TemplateVersionExternalAuth = {
+	id: "gitlab",
+	type: "gitlab",
+	authenticate_url: "https://example.com/external-auth/gitlab",
+	authenticated: false,
+	display_icon: "/icon/gitlab.svg",
+	display_name: "GitLab",
+};
+
+const MockGitLabExternalAuthAuthenticated: TemplateVersionExternalAuth = {
+	...MockGitLabExternalAuth,
+	authenticated: true,
+};
+
+/**
+ * Mocks API.templateVersionDynamicParameters to immediately send an empty
+ * DynamicParametersResponse so the page renders the form instead of the
+ * loader.
+ */
+function mockDynamicParameters() {
+	spyOn(API, "templateVersionDynamicParameters").mockImplementation(
+		(_versionId, _ownerId, callbacks) => {
+			// Fire asynchronously so the component mounts before the message
+			// arrives, matching real WebSocket behavior.
+			setTimeout(() => {
+				callbacks.onMessage({ id: 0, parameters: [], diagnostics: [] });
+			}, 0);
+
+			return { close: () => {} } as unknown as WebSocket;
+		},
+	);
+}
+
+const meta: Meta<typeof CreateWorkspacePage> = {
+	title: "pages/CreateWorkspacePage",
+	component: CreateWorkspacePage,
+	decorators: [withAuthProvider, withDashboardProvider],
+	parameters: {
+		layout: "fullscreen",
+		user: MockUserOwner,
+		reactRouter: reactRouterParameters({
+			location: {
+				pathParams: {
+					organization: MockTemplate.organization_name,
+					template: MockTemplate.name,
+				},
+			},
+			routing: {
+				path: "/templates/:organization/:template/workspace",
+			},
+		}),
+	},
+	beforeEach: () => {
+		// Prevent the auth button from actually opening a popup.
+		spyOn(window, "open").mockReturnValue(null);
+
+		// Template, version, and preset queries.
+		spyOn(API, "getTemplateByName").mockResolvedValue(MockTemplate);
+		spyOn(API, "getTemplateVersion").mockResolvedValue(MockTemplateVersion);
+		spyOn(API, "getTemplateVersionPresets").mockResolvedValue(null);
+		spyOn(API, "checkAuthorization").mockResolvedValue({
+			createWorkspaceForAny: true,
+			canUpdateTemplate: false,
+		});
+
+		// Dynamic parameters over WebSocket.
+		mockDynamicParameters();
+
+		// Default: no external auth required.
+		spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([]);
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof CreateWorkspacePage>;
+
+/**
+ * Renders two unauthenticated external auth providers. Both "Login with"
+ * buttons should be visible and enabled.
+ */
+export const MultipleExternalAuth: Story = {
+	beforeEach: () => {
+		spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([
+			MockTemplateVersionExternalAuthGithub,
+			MockGitLabExternalAuth,
+		]);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		const githubButton = await canvas.findByRole("button", {
+			name: /login with github/i,
+		});
+		const gitlabButton = await canvas.findByRole("button", {
+			name: /login with gitlab/i,
+		});
+
+		expect(githubButton).toBeEnabled();
+		expect(gitlabButton).toBeEnabled();
+	},
+};
+
+/**
+ * Clicking one external auth button should only show a loading spinner on
+ * that button. The other provider's button must remain enabled so the user
+ * can authenticate with both without a page refresh.
+ *
+ * This is the regression test for coder/coder#22420.
+ */
+export const ClickingOneAuthDoesNotDisableOthers: Story = {
+	beforeEach: () => {
+		spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([
+			MockTemplateVersionExternalAuthGithub,
+			MockGitLabExternalAuth,
+		]);
+	},
+	play: async ({ canvasElement, step }) => {
+		const canvas = within(canvasElement);
+
+		const githubButton = await canvas.findByRole("button", {
+			name: /login with github/i,
+		});
+		const gitlabButton = await canvas.findByRole("button", {
+			name: /login with gitlab/i,
+		});
+
+		await step("Click GitHub auth button", async () => {
+			await userEvent.click(githubButton);
+		});
+
+		await step("GitLab button remains enabled", async () => {
+			// After the fix, each provider tracks its own polling state so
+			// only the clicked provider shows a loading spinner.
+			await waitFor(() => {
+				expect(gitlabButton).toBeEnabled();
+			});
+		});
+	},
+};
+
+/**
+ * After the first provider completes authentication and the API starts
+ * returning it as authenticated, its button should be replaced with the
+ * "Authenticated" badge. The second provider's button should still be
+ * clickable.
+ */
+export const OneProviderAuthenticated: Story = {
+	beforeEach: () => {
+		spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([
+			MockTemplateVersionExternalAuthGithubAuthenticated,
+			MockGitLabExternalAuth,
+		]);
+	},
+	play: async ({ canvasElement, step }) => {
+		const canvas = within(canvasElement);
+
+		await step("GitHub shows authenticated", async () => {
+			await canvas.findByText("Authenticated");
+		});
+
+		await step("GitLab login button is still enabled", async () => {
+			const gitlabButton = await canvas.findByRole("button", {
+				name: /login with gitlab/i,
+			});
+			expect(gitlabButton).toBeEnabled();
+		});
+	},
+};
+
+/**
+ * Simulates the full two-provider authentication flow: click the first
+ * provider, have polling return it as authenticated, then click the second
+ * provider.
+ */
+export const SequentialAuthFlow: Story = {
+	beforeEach: () => {
+		// First call: both unauthenticated.
+		// Subsequent calls: GitHub authenticated (simulating a successful login
+		// during the polling interval).
+		spyOn(API, "getTemplateVersionExternalAuth")
+			.mockResolvedValueOnce([
+				MockTemplateVersionExternalAuthGithub,
+				MockGitLabExternalAuth,
+			])
+			.mockResolvedValue([
+				MockTemplateVersionExternalAuthGithubAuthenticated,
+				MockGitLabExternalAuth,
+			]);
+	},
+	play: async ({ canvasElement, step }) => {
+		const canvas = within(canvasElement);
+
+		await step("Both buttons render initially", async () => {
+			await canvas.findByRole("button", { name: /login with github/i });
+			await canvas.findByRole("button", { name: /login with gitlab/i });
+		});
+
+		await step("Click GitHub and wait for it to authenticate", async () => {
+			const githubButton = await canvas.findByRole("button", {
+				name: /login with github/i,
+			});
+			await userEvent.click(githubButton);
+
+			// Polling picks up the updated mock that returns GitHub as
+			// authenticated. The "Authenticated" text replaces the button.
+			await waitFor(() => {
+				expect(canvas.queryByRole("button", { name: /login with github/i }))
+					.not.toBeInTheDocument();
+			});
+		});
+
+		await step("GitLab button is still clickable", async () => {
+			const gitlabButton = await canvas.findByRole("button", {
+				name: /login with gitlab/i,
+			});
+			expect(gitlabButton).toBeEnabled();
+		});
+	},
+};

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
@@ -462,45 +462,71 @@ const CreateWorkspacePage: FC = () => {
 };
 
 const useExternalAuth = (versionId: string | undefined) => {
-	const [externalAuthPollingState, setExternalAuthPollingState] =
-		useState<ExternalAuthPollingState>("idle");
+	const [pollingState, setPollingState] = useState<
+		Record<string, ExternalAuthPollingState>
+	>({});
 
-	const startPollingExternalAuth = useCallback(() => {
-		setExternalAuthPollingState("polling");
+	const startPollingExternalAuth = useCallback((providerId: string) => {
+		setPollingState((prev) => ({ ...prev, [providerId]: "polling" }));
 	}, []);
+
+	const isAnyPolling = Object.values(pollingState).some(
+		(s) => s === "polling",
+	);
 
 	const { data: externalAuth, isLoading: isLoadingExternalAuth } = useQuery({
 		...templateVersionExternalAuth(versionId ?? ""),
 		enabled: Boolean(versionId),
-		refetchInterval: externalAuthPollingState === "polling" ? 1000 : false,
+		refetchInterval: isAnyPolling ? 1000 : false,
 	});
 
-	const allSignedIn = externalAuth?.every((it) => it.authenticated);
-
+	// Stop polling individual providers once they authenticate.
 	useEffect(() => {
-		if (allSignedIn) {
-			setExternalAuthPollingState("idle");
+		if (!externalAuth) {
+			return;
+		}
+		setPollingState((prev) => {
+			let changed = false;
+			const next = { ...prev };
+			for (const auth of externalAuth) {
+				if (auth.authenticated && next[auth.id] === "polling") {
+					next[auth.id] = "idle";
+					changed = true;
+				}
+			}
+			return changed ? next : prev;
+		});
+	}, [externalAuth]);
+
+	// Per-provider 60-second timeout.
+	useEffect(() => {
+		const pollingIds = Object.entries(pollingState)
+			.filter(([, s]) => s === "polling")
+			.map(([id]) => id);
+
+		if (pollingIds.length === 0) {
 			return;
 		}
 
-		if (externalAuthPollingState !== "polling") {
-			return;
-		}
-
-		// Poll for a maximum of one minute
-		const quitPolling = setTimeout(
-			() => setExternalAuthPollingState("abandoned"),
-			60_000,
+		const timers = pollingIds.map((id) =>
+			setTimeout(() => {
+				setPollingState((prev) =>
+					prev[id] === "polling" ? { ...prev, [id]: "abandoned" } : prev,
+				);
+			}, 60_000),
 		);
+
 		return () => {
-			clearTimeout(quitPolling);
+			for (const t of timers) {
+				clearTimeout(t);
+			}
 		};
-	}, [externalAuthPollingState, allSignedIn]);
+	}, [pollingState]);
 
 	return {
 		startPollingExternalAuth,
 		externalAuth,
-		externalAuthPollingState,
+		externalAuthPollingState: pollingState,
 		isLoadingExternalAuth,
 	};
 };

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
@@ -470,9 +470,7 @@ const useExternalAuth = (versionId: string | undefined) => {
 		setPollingState((prev) => ({ ...prev, [providerId]: "polling" }));
 	}, []);
 
-	const isAnyPolling = Object.values(pollingState).some(
-		(s) => s === "polling",
-	);
+	const isAnyPolling = Object.values(pollingState).some((s) => s === "polling");
 
 	const { data: externalAuth, isLoading: isLoadingExternalAuth } = useQuery({
 		...templateVersionExternalAuth(versionId ?? ""),

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
@@ -15,7 +15,6 @@ import { checkAuthorization } from "#/api/queries/authCheck";
 import {
 	templateByName,
 	templateVersion,
-	templateVersionExternalAuth,
 	templateVersionPresets,
 } from "#/api/queries/templates";
 import { autoCreateWorkspace, createWorkspace } from "#/api/queries/workspaces";
@@ -28,6 +27,7 @@ import type {
 } from "#/api/typesGenerated";
 import { Loader } from "#/components/Loader/Loader";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
+import { useExternalAuth } from "#/hooks/useExternalAuth";
 import { getInitialParameterValues } from "#/modules/workspaces/DynamicParameter/DynamicParameter";
 import { generateWorkspaceName } from "#/modules/workspaces/generateWorkspaceName";
 import { pageTitle } from "#/utils/page";
@@ -41,7 +41,6 @@ import {
 
 const createWorkspaceModes = ["form", "auto", "duplicate"] as const;
 export type CreateWorkspaceMode = (typeof createWorkspaceModes)[number];
-type ExternalAuthPollingState = "idle" | "polling" | "abandoned";
 
 const CreateWorkspacePage: FC = () => {
 	const { organization: organizationName = "default", template: templateName } =
@@ -459,74 +458,6 @@ const CreateWorkspacePage: FC = () => {
 			)}
 		</>
 	);
-};
-
-const useExternalAuth = (versionId: string | undefined) => {
-	const [pollingState, setPollingState] = useState<
-		Record<string, ExternalAuthPollingState>
-	>({});
-
-	const startPollingExternalAuth = useCallback((providerId: string) => {
-		setPollingState((prev) => ({ ...prev, [providerId]: "polling" }));
-	}, []);
-
-	const isAnyPolling = Object.values(pollingState).some((s) => s === "polling");
-
-	const { data: externalAuth, isLoading: isLoadingExternalAuth } = useQuery({
-		...templateVersionExternalAuth(versionId ?? ""),
-		enabled: Boolean(versionId),
-		refetchInterval: isAnyPolling ? 1000 : false,
-	});
-
-	// Stop polling individual providers once they authenticate.
-	useEffect(() => {
-		if (!externalAuth) {
-			return;
-		}
-		setPollingState((prev) => {
-			let changed = false;
-			const next = { ...prev };
-			for (const auth of externalAuth) {
-				if (auth.authenticated && next[auth.id] === "polling") {
-					next[auth.id] = "idle";
-					changed = true;
-				}
-			}
-			return changed ? next : prev;
-		});
-	}, [externalAuth]);
-
-	// Per-provider 60-second timeout.
-	useEffect(() => {
-		const pollingIds = Object.entries(pollingState)
-			.filter(([, s]) => s === "polling")
-			.map(([id]) => id);
-
-		if (pollingIds.length === 0) {
-			return;
-		}
-
-		const timers = pollingIds.map((id) =>
-			setTimeout(() => {
-				setPollingState((prev) =>
-					prev[id] === "polling" ? { ...prev, [id]: "abandoned" } : prev,
-				);
-			}, 60_000),
-		);
-
-		return () => {
-			for (const t of timers) {
-				clearTimeout(t);
-			}
-		};
-	}, [pollingState]);
-
-	return {
-		startPollingExternalAuth,
-		externalAuth,
-		externalAuthPollingState: pollingState,
-		isLoadingExternalAuth,
-	};
 };
 
 const getAutofillParameters = (

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<typeof CreateWorkspacePageView> = {
 		defaultName: "",
 		defaultOwner: MockUserOwner,
 		externalAuth: [],
-		externalAuthPollingState: "idle",
+		externalAuthPollingState: {},
 		hasAllRequiredExternalAuth: true,
 		mode: "form",
 		parameters: [],

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -66,7 +66,7 @@ interface CreateWorkspacePageViewProps {
 	disabledParams?: string[];
 	error: unknown;
 	externalAuth: TypesGen.TemplateVersionExternalAuth[];
-	externalAuthPollingState: ExternalAuthPollingState;
+	externalAuthPollingState: Record<string, ExternalAuthPollingState>;
 	hasAllRequiredExternalAuth: boolean;
 	hasIgnoredUrlParams?: boolean;
 	mode: CreateWorkspaceMode;
@@ -85,7 +85,7 @@ interface CreateWorkspacePageViewProps {
 	) => void;
 	resetMutation: () => void;
 	sendMessage: (message: Record<string, string>, ownerId?: string) => void;
-	startPollingExternalAuth: () => void;
+	startPollingExternalAuth: (providerId: string) => void;
 	owner: TypesGen.MinimalUser;
 	setOwner: (user: TypesGen.MinimalUser) => void;
 }
@@ -588,9 +588,9 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 										key={auth.id}
 										error={error}
 										auth={auth}
-										isLoading={externalAuthPollingState === "polling"}
-										onStartPolling={startPollingExternalAuth}
-										displayRetry={externalAuthPollingState === "abandoned"}
+										isLoading={externalAuthPollingState[auth.id] === "polling"}
+										onStartPolling={() => startPollingExternalAuth(auth.id)}
+										displayRetry={externalAuthPollingState[auth.id] === "abandoned"}
 									/>
 								))}
 							</div>

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -590,7 +590,9 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 										auth={auth}
 										isLoading={externalAuthPollingState[auth.id] === "polling"}
 										onStartPolling={() => startPollingExternalAuth(auth.id)}
-										displayRetry={externalAuthPollingState[auth.id] === "abandoned"}
+										displayRetry={
+											externalAuthPollingState[auth.id] === "abandoned"
+										}
 									/>
 								))}
 							</div>

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -3638,6 +3638,16 @@ export const MockTemplateVersionExternalAuthGithubAuthenticated: TypesGen.Templa
 		display_name: "GitHub",
 	};
 
+export const MockTemplateVersionExternalAuthAzure: TypesGen.TemplateVersionExternalAuth =
+	{
+		id: "azure",
+		type: "azure",
+		authenticate_url: "https://example.com/external-auth/azure",
+		authenticated: false,
+		display_icon: "/icon/azure.svg",
+		display_name: "Azure",
+	};
+
 export const MockDeploymentStats: TypesGen.DeploymentStats = {
 	aggregated_from: "2023-03-06T19:08:55.211625Z",
 	collected_at: "2023-03-06T19:12:55.211625Z",


### PR DESCRIPTION
fixes #22420
ref DEVEX-369
ref DEVEX-269

The bug on `CreateWorkspacePage`, where clicking one external auth provider login button disabled all providers' login buttons, was caused by providers all sharing a single polling status (`"idle" | "polling" | "abandoned"`) in the `useExternalAuth` hook.

## changes

- Instead of setting one status across all providers, the polling status in `useExternalAuth` is now tracked for each provider in a record whose keys are the providers' IDs.
- The biggest diff is a new Storybook file CreateWorkspacePage.stories.tsx which reproduces the bug behavior from the issue.
  - Until now we've only had CreateWorkspacePageView.stories.tsx, which isn't able to model the user interactions / API responses needed to verify the bugfix. This file is unchanged.
- Also deletes `CreateWorkspacePage`'s `useExternalAuth` hook in favor of the global `useExternalAuth` hook (see #26310)

(co-written with Coder Agents)