### PR TITLE
fix: deflake TestWorkspaceTagsTerraform with context-aware build waits

### DIFF
--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -1220,9 +1220,10 @@ func AwaitTemplateVersionJobRunning(t testing.TB, client *codersdk.Client, versi
 
 // AwaitTemplateVersionJobCompleted waits for the build to be completed. This may result
 // from cancelation, an error, or from completing successfully. The wait is bounded by
-// testutil.WaitLong, which is sized for fast in-memory provisioners such as echo. Tests
-// that run a real provisioner should use AwaitTemplateVersionJobCompletedCtx with a
-// deadline sized for real builds.
+// testutil.WaitLong, which is enough for the echo provisioner used by most tests, but
+// can be exceeded by a real provisioner such as terraform. Tests that run a real
+// provisioner should use AwaitTemplateVersionJobCompletedCtx with a deadline sized for
+// real builds.
 func AwaitTemplateVersionJobCompleted(t testing.TB, client *codersdk.Client, version uuid.UUID) codersdk.TemplateVersion {
 	t.Helper()
 
@@ -1257,8 +1258,9 @@ func AwaitTemplateVersionJobCompletedCtx(ctx context.Context, t testing.TB, clie
 }
 
 // AwaitWorkspaceBuildJobCompleted waits for a workspace provision job to reach completed
-// status. The wait is bounded by testutil.WaitMedium, which is sized for fast in-memory
-// provisioners such as echo. Tests that run a real provisioner should use
+// status. The wait is bounded by testutil.WaitMedium, which is enough for the echo
+// provisioner used by most tests, but can be exceeded by a real provisioner such as
+// terraform. Tests that run a real provisioner should use
 // AwaitWorkspaceBuildJobCompletedCtx with a deadline sized for real builds.
 func AwaitWorkspaceBuildJobCompleted(t testing.TB, client *codersdk.Client, build uuid.UUID) codersdk.WorkspaceBuild {
 	t.Helper()

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -1220,21 +1220,18 @@ func AwaitTemplateVersionJobRunning(t testing.TB, client *codersdk.Client, versi
 
 // AwaitTemplateVersionJobCompleted waits for the build to be completed. This may result
 // from cancelation, an error, or from completing successfully. The wait is bounded by
-// testutil.WaitLong; use AwaitTemplateVersionJobCompletedCtx to wait with a custom
-// deadline.
+// testutil.WaitLong; use AwaitTemplateVersionJobCompletedWithTimeout to wait longer.
 func AwaitTemplateVersionJobCompleted(t testing.TB, client *codersdk.Client, version uuid.UUID) codersdk.TemplateVersion {
 	t.Helper()
-
-	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
-	defer cancel()
-
-	return AwaitTemplateVersionJobCompletedCtx(ctx, t, client, version)
+	return AwaitTemplateVersionJobCompletedWithTimeout(t, client, version, testutil.WaitLong)
 }
 
-// AwaitTemplateVersionJobCompletedCtx is like AwaitTemplateVersionJobCompleted, but
-// polls until the deadline of the provided context, which must have a deadline set.
-func AwaitTemplateVersionJobCompletedCtx(ctx context.Context, t testing.TB, client *codersdk.Client, version uuid.UUID) codersdk.TemplateVersion {
+// AwaitTemplateVersionJobCompletedWithTimeout is like AwaitTemplateVersionJobCompleted
+// with a caller-provided wait bound.
+func AwaitTemplateVersionJobCompletedWithTimeout(t testing.TB, client *codersdk.Client, version uuid.UUID, timeout time.Duration) codersdk.TemplateVersion {
 	t.Helper()
+
+	ctx := testutil.Context(t, timeout)
 
 	t.Logf("waiting for template version %s build job to complete", version)
 	var templateVersion codersdk.TemplateVersion
@@ -1257,20 +1254,18 @@ func AwaitTemplateVersionJobCompletedCtx(ctx context.Context, t testing.TB, clie
 
 // AwaitWorkspaceBuildJobCompleted waits for a workspace provision job to reach completed
 // status. The wait is bounded by testutil.WaitMedium; use
-// AwaitWorkspaceBuildJobCompletedCtx to wait with a custom deadline.
+// AwaitWorkspaceBuildJobCompletedWithTimeout to wait longer.
 func AwaitWorkspaceBuildJobCompleted(t testing.TB, client *codersdk.Client, build uuid.UUID) codersdk.WorkspaceBuild {
 	t.Helper()
-
-	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
-	defer cancel()
-
-	return AwaitWorkspaceBuildJobCompletedCtx(ctx, t, client, build)
+	return AwaitWorkspaceBuildJobCompletedWithTimeout(t, client, build, testutil.WaitMedium)
 }
 
-// AwaitWorkspaceBuildJobCompletedCtx is like AwaitWorkspaceBuildJobCompleted, but
-// polls until the deadline of the provided context, which must have a deadline set.
-func AwaitWorkspaceBuildJobCompletedCtx(ctx context.Context, t testing.TB, client *codersdk.Client, build uuid.UUID) codersdk.WorkspaceBuild {
+// AwaitWorkspaceBuildJobCompletedWithTimeout is like AwaitWorkspaceBuildJobCompleted
+// with a caller-provided wait bound.
+func AwaitWorkspaceBuildJobCompletedWithTimeout(t testing.TB, client *codersdk.Client, build uuid.UUID, timeout time.Duration) codersdk.WorkspaceBuild {
 	t.Helper()
+
+	ctx := testutil.Context(t, timeout)
 
 	t.Logf("waiting for workspace build job %s", build)
 	var workspaceBuild codersdk.WorkspaceBuild

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -1220,10 +1220,8 @@ func AwaitTemplateVersionJobRunning(t testing.TB, client *codersdk.Client, versi
 
 // AwaitTemplateVersionJobCompleted waits for the build to be completed. This may result
 // from cancelation, an error, or from completing successfully. The wait is bounded by
-// testutil.WaitLong, which is enough for the echo provisioner used by most tests, but
-// can be exceeded by a real provisioner such as terraform. Tests that run a real
-// provisioner should use AwaitTemplateVersionJobCompletedCtx with a deadline sized for
-// real builds.
+// testutil.WaitLong; use AwaitTemplateVersionJobCompletedCtx to wait with a custom
+// deadline.
 func AwaitTemplateVersionJobCompleted(t testing.TB, client *codersdk.Client, version uuid.UUID) codersdk.TemplateVersion {
 	t.Helper()
 
@@ -1258,10 +1256,8 @@ func AwaitTemplateVersionJobCompletedCtx(ctx context.Context, t testing.TB, clie
 }
 
 // AwaitWorkspaceBuildJobCompleted waits for a workspace provision job to reach completed
-// status. The wait is bounded by testutil.WaitMedium, which is enough for the echo
-// provisioner used by most tests, but can be exceeded by a real provisioner such as
-// terraform. Tests that run a real provisioner should use
-// AwaitWorkspaceBuildJobCompletedCtx with a deadline sized for real builds.
+// status. The wait is bounded by testutil.WaitMedium; use
+// AwaitWorkspaceBuildJobCompletedCtx to wait with a custom deadline.
 func AwaitWorkspaceBuildJobCompleted(t testing.TB, client *codersdk.Client, build uuid.UUID) codersdk.WorkspaceBuild {
 	t.Helper()
 

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -1219,35 +1219,64 @@ func AwaitTemplateVersionJobRunning(t testing.TB, client *codersdk.Client, versi
 }
 
 // AwaitTemplateVersionJobCompleted waits for the build to be completed. This may result
-// from cancelation, an error, or from completing successfully.
+// from cancelation, an error, or from completing successfully. The wait is bounded by
+// testutil.WaitLong, which is sized for fast in-memory provisioners such as echo. Tests
+// that run a real provisioner should use AwaitTemplateVersionJobCompletedCtx with a
+// deadline sized for real builds.
 func AwaitTemplateVersionJobCompleted(t testing.TB, client *codersdk.Client, version uuid.UUID) codersdk.TemplateVersion {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
 
+	return AwaitTemplateVersionJobCompletedCtx(ctx, t, client, version)
+}
+
+// AwaitTemplateVersionJobCompletedCtx is like AwaitTemplateVersionJobCompleted, but
+// polls until the deadline of the provided context, which must have a deadline set.
+func AwaitTemplateVersionJobCompletedCtx(ctx context.Context, t testing.TB, client *codersdk.Client, version uuid.UUID) codersdk.TemplateVersion {
+	t.Helper()
+
 	t.Logf("waiting for template version %s build job to complete", version)
 	var templateVersion codersdk.TemplateVersion
-	require.Eventually(t, func() bool {
+	completed := testutil.Eventually(ctx, t, func(ctx context.Context) bool {
 		var err error
 		templateVersion, err = client.TemplateVersion(ctx, version)
+		if err != nil {
+			t.Logf("failed to get template version %s: %v", version, err)
+			return false
+		}
 		t.Logf("template version job status: %s", templateVersion.Job.Status)
-		return assert.NoError(t, err) && templateVersion.Job.CompletedAt != nil
-	}, testutil.WaitLong, testutil.IntervalFast, "make sure you set `IncludeProvisionerDaemon`!")
+		return templateVersion.Job.CompletedAt != nil
+	}, testutil.IntervalFast, "make sure you set `IncludeProvisionerDaemon`!")
+	if !completed {
+		t.FailNow()
+	}
 	t.Logf("template version %s job has completed", version)
 	return templateVersion
 }
 
-// AwaitWorkspaceBuildJobCompleted waits for a workspace provision job to reach completed status.
+// AwaitWorkspaceBuildJobCompleted waits for a workspace provision job to reach completed
+// status. The wait is bounded by testutil.WaitMedium, which is sized for fast in-memory
+// provisioners such as echo. Tests that run a real provisioner should use
+// AwaitWorkspaceBuildJobCompletedCtx with a deadline sized for real builds.
 func AwaitWorkspaceBuildJobCompleted(t testing.TB, client *codersdk.Client, build uuid.UUID) codersdk.WorkspaceBuild {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
 	defer cancel()
+
+	return AwaitWorkspaceBuildJobCompletedCtx(ctx, t, client, build)
+}
+
+// AwaitWorkspaceBuildJobCompletedCtx is like AwaitWorkspaceBuildJobCompleted, but
+// polls until the deadline of the provided context, which must have a deadline set.
+func AwaitWorkspaceBuildJobCompletedCtx(ctx context.Context, t testing.TB, client *codersdk.Client, build uuid.UUID) codersdk.WorkspaceBuild {
+	t.Helper()
 
 	t.Logf("waiting for workspace build job %s", build)
 	var workspaceBuild codersdk.WorkspaceBuild
-	require.Eventually(t, func() bool {
+	completed := testutil.Eventually(ctx, t, func(ctx context.Context) bool {
 		var err error
 		workspaceBuild, err = client.WorkspaceBuild(ctx, build)
 		if err != nil {
@@ -1259,7 +1288,10 @@ func AwaitWorkspaceBuildJobCompleted(t testing.TB, client *codersdk.Client, buil
 			return false
 		}
 		return true
-	}, testutil.WaitMedium, testutil.IntervalFast)
+	}, testutil.IntervalFast)
+	if !completed {
+		t.FailNow()
+	}
 	t.Logf("got workspace build job %s (status: %s)", build, workspaceBuild.Job.Status)
 	return workspaceBuild
 }

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -1226,8 +1226,9 @@ func AwaitTemplateVersionJobCompleted(t testing.TB, client *codersdk.Client, ver
 	return AwaitTemplateVersionJobCompletedWithTimeout(t, client, version, testutil.WaitLong)
 }
 
-// AwaitTemplateVersionJobCompletedWithTimeout is like AwaitTemplateVersionJobCompleted
-// with a caller-provided wait bound.
+// AwaitTemplateVersionJobCompletedWithTimeout waits up to timeout for the template
+// version build job to complete, polling at testutil.IntervalFast. Transient API errors
+// are logged and retried. Fails the test if the job does not complete in time.
 func AwaitTemplateVersionJobCompletedWithTimeout(t testing.TB, client *codersdk.Client, version uuid.UUID, timeout time.Duration) codersdk.TemplateVersion {
 	t.Helper()
 
@@ -1260,8 +1261,9 @@ func AwaitWorkspaceBuildJobCompleted(t testing.TB, client *codersdk.Client, buil
 	return AwaitWorkspaceBuildJobCompletedWithTimeout(t, client, build, testutil.WaitMedium)
 }
 
-// AwaitWorkspaceBuildJobCompletedWithTimeout is like AwaitWorkspaceBuildJobCompleted
-// with a caller-provided wait bound.
+// AwaitWorkspaceBuildJobCompletedWithTimeout waits up to timeout for a workspace
+// provision job to reach completed status, polling at testutil.IntervalFast. Transient
+// API errors are logged and retried. Fails the test if the job does not complete in time.
 func AwaitWorkspaceBuildJobCompletedWithTimeout(t testing.TB, client *codersdk.Client, build uuid.UUID, timeout time.Duration) codersdk.WorkspaceBuild {
 	t.Helper()
 
@@ -1281,7 +1283,7 @@ func AwaitWorkspaceBuildJobCompletedWithTimeout(t testing.TB, client *codersdk.C
 			return false
 		}
 		return true
-	}, testutil.IntervalFast)
+	}, testutil.IntervalFast, "workspace build %s did not complete", build)
 	if !completed {
 		t.FailNow()
 	}

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -3566,7 +3566,10 @@ func workspaceTagsTerraform(t *testing.T, tc testWorkspaceTagsTerraformCase, dyn
 		TemplateID:         tpl.ID,
 	})
 	require.NoError(t, err, "failed to create template version")
-	coderdtest.AwaitTemplateVersionJobCompleted(t, templateAdmin, tv.ID)
+	// Use the test's long context deadline. The default wait in
+	// AwaitTemplateVersionJobCompleted is too short for a real terraform
+	// build, especially on Windows where providers are not cached.
+	coderdtest.AwaitTemplateVersionJobCompletedCtx(ctx, t, templateAdmin, tv.ID)
 
 	err = templateAdmin.UpdateActiveTemplateVersion(ctx, tpl.ID, codersdk.UpdateActiveTemplateVersion{
 		ID: tv.ID,
@@ -3583,7 +3586,9 @@ func workspaceTagsTerraform(t *testing.T, tc testWorkspaceTagsTerraformCase, dyn
 		require.NoError(t, err, "failed to create workspace")
 		tagJSON, _ := json.Marshal(ws.LatestBuild.Job.Tags)
 		t.Logf("Created workspace build [%s] with tags: %s", ws.LatestBuild.Job.Type, tagJSON)
-		coderdtest.AwaitWorkspaceBuildJobCompleted(t, member, ws.LatestBuild.ID)
+		// As above, a real terraform workspace build can outlast the default
+		// wait in AwaitWorkspaceBuildJobCompleted.
+		coderdtest.AwaitWorkspaceBuildJobCompletedCtx(ctx, t, member, ws.LatestBuild.ID)
 	}
 }
 

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -3527,8 +3527,9 @@ func workspaceTagsTerraform(t *testing.T, tc testWorkspaceTagsTerraformCase, dyn
 	templateAdmin, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, rbac.RoleTemplateAdmin())
 	member, memberUser := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
 
-	// This can take a while, so set a relatively long timeout.
-	ctx := testutil.Context(t, 2*testutil.WaitSuperLong)
+	// This can take a while, so set a long timeout that outlasts both build
+	// awaits below.
+	ctx := testutil.Context(t, 4*testutil.WaitSuperLong)
 
 	emptyTar := testutil.CreateTar(t, map[string]string{"main.tf": ""})
 	emptyFi, err := templateAdmin.Upload(ctx, "application/x-tar", bytes.NewReader(emptyTar))
@@ -3566,9 +3567,8 @@ func workspaceTagsTerraform(t *testing.T, tc testWorkspaceTagsTerraformCase, dyn
 		TemplateID:         tpl.ID,
 	})
 	require.NoError(t, err, "failed to create template version")
-	// Allow a long wait. The default in AwaitTemplateVersionJobCompleted is
-	// too short for a real terraform build, especially on Windows where
-	// providers are not cached.
+	// Uncached Windows runners make real terraform builds much slower than
+	// the default await timeout.
 	coderdtest.AwaitTemplateVersionJobCompletedWithTimeout(t, templateAdmin, tv.ID, 2*testutil.WaitSuperLong)
 
 	err = templateAdmin.UpdateActiveTemplateVersion(ctx, tpl.ID, codersdk.UpdateActiveTemplateVersion{
@@ -3586,8 +3586,7 @@ func workspaceTagsTerraform(t *testing.T, tc testWorkspaceTagsTerraformCase, dyn
 		require.NoError(t, err, "failed to create workspace")
 		tagJSON, _ := json.Marshal(ws.LatestBuild.Job.Tags)
 		t.Logf("Created workspace build [%s] with tags: %s", ws.LatestBuild.Job.Type, tagJSON)
-		// As above, a real terraform workspace build can outlast the default
-		// wait in AwaitWorkspaceBuildJobCompleted.
+		// Same timeout reason as above.
 		coderdtest.AwaitWorkspaceBuildJobCompletedWithTimeout(t, member, ws.LatestBuild.ID, 2*testutil.WaitSuperLong)
 	}
 }

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -3233,8 +3233,9 @@ func TestWorkspaceTemplateParamsChange(t *testing.T) {
 
 	_ = coderdenttest.NewExternalProvisionerDaemonTerraform(t, client, owner.OrganizationID, nil)
 
-	// This can take a while, so set a relatively long timeout.
-	ctx := testutil.Context(t, 2*testutil.WaitSuperLong)
+	// This can take a while, so set a long timeout that outlasts the three
+	// build awaits below.
+	ctx := testutil.Context(t, 6*testutil.WaitSuperLong)
 
 	// Creating a template as a template admin must succeed
 	templateFiles := map[string]string{"main.tf": mainTfTemplate}
@@ -3250,7 +3251,9 @@ func TestWorkspaceTemplateParamsChange(t *testing.T) {
 		UserVariableValues: []codersdk.VariableValue{},
 	})
 	require.NoError(t, err, "failed to create template version")
-	coderdtest.AwaitTemplateVersionJobCompleted(t, templateAdmin, tv.ID)
+	// Uncached Windows runners make real terraform builds much slower than
+	// the default await timeout.
+	coderdtest.AwaitTemplateVersionJobCompletedWithTimeout(t, templateAdmin, tv.ID, 2*testutil.WaitSuperLong)
 	tpl := coderdtest.CreateTemplate(t, templateAdmin, owner.OrganizationID, tv.ID)
 
 	// Set to dynamic params
@@ -3281,7 +3284,8 @@ func TestWorkspaceTemplateParamsChange(t *testing.T) {
 	// Then: the build should succeed. The updated value of param_min should be
 	// used to validate param instead of the value defined in the temp
 	require.NoError(t, err, "failed to create workspace")
-	createBuild := coderdtest.AwaitWorkspaceBuildJobCompleted(t, member, ws.LatestBuild.ID)
+	// Same timeout reason as above.
+	createBuild := coderdtest.AwaitWorkspaceBuildJobCompletedWithTimeout(t, member, ws.LatestBuild.ID, 2*testutil.WaitSuperLong)
 	require.Equal(t, createBuild.Status, codersdk.WorkspaceStatusRunning)
 
 	// File should exist
@@ -3293,7 +3297,8 @@ func TestWorkspaceTemplateParamsChange(t *testing.T) {
 		Transition: codersdk.WorkspaceTransitionDelete,
 	})
 	require.NoError(t, err)
-	build = coderdtest.AwaitWorkspaceBuildJobCompleted(t, member, build.ID)
+	// Same timeout reason as above.
+	build = coderdtest.AwaitWorkspaceBuildJobCompletedWithTimeout(t, member, build.ID, 2*testutil.WaitSuperLong)
 	require.Equal(t, codersdk.WorkspaceStatusDeleted, build.Status)
 
 	logsCh, closeLogs, err := member.WorkspaceBuildLogsAfter(ctx, build.ID, 0)

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -3566,10 +3566,10 @@ func workspaceTagsTerraform(t *testing.T, tc testWorkspaceTagsTerraformCase, dyn
 		TemplateID:         tpl.ID,
 	})
 	require.NoError(t, err, "failed to create template version")
-	// Use the test's long context deadline. The default wait in
-	// AwaitTemplateVersionJobCompleted is too short for a real terraform
-	// build, especially on Windows where providers are not cached.
-	coderdtest.AwaitTemplateVersionJobCompletedCtx(ctx, t, templateAdmin, tv.ID)
+	// Allow a long wait. The default in AwaitTemplateVersionJobCompleted is
+	// too short for a real terraform build, especially on Windows where
+	// providers are not cached.
+	coderdtest.AwaitTemplateVersionJobCompletedWithTimeout(t, templateAdmin, tv.ID, 2*testutil.WaitSuperLong)
 
 	err = templateAdmin.UpdateActiveTemplateVersion(ctx, tpl.ID, codersdk.UpdateActiveTemplateVersion{
 		ID: tv.ID,
@@ -3588,7 +3588,7 @@ func workspaceTagsTerraform(t *testing.T, tc testWorkspaceTagsTerraformCase, dyn
 		t.Logf("Created workspace build [%s] with tags: %s", ws.LatestBuild.Job.Type, tagJSON)
 		// As above, a real terraform workspace build can outlast the default
 		// wait in AwaitWorkspaceBuildJobCompleted.
-		coderdtest.AwaitWorkspaceBuildJobCompletedCtx(ctx, t, member, ws.LatestBuild.ID)
+		coderdtest.AwaitWorkspaceBuildJobCompletedWithTimeout(t, member, ws.LatestBuild.ID, 2*testutil.WaitSuperLong)
 	}
 }
 


### PR DESCRIPTION
`TestWorkspaceTagsTerraform` runs a real terraform provisioner but waited on builds with `coderdtest` helpers whose deadlines are sized for the echo provisioner used by most tests, which replays canned responses and completes in well under a second. On Windows runners, where terraform providers are not cached and every `terraform init` downloads from the registry, template imports exceeded the 25s budget in `AwaitTemplateVersionJobCompleted` and workspace builds exceeded the 10s context in `AwaitWorkspaceBuildJobCompleted`, even though the test intends a 120s budget.

Add `AwaitTemplateVersionJobCompletedWithTimeout` and `AwaitWorkspaceBuildJobCompletedWithTimeout`, which take a caller-provided wait bound, and use them in the test with `2*testutil.WaitSuperLong` (120s). Also fix `AwaitWorkspaceBuildJobCompleted` creating a `WaitShort` (10s) context while polling for `WaitMedium` (15s), which guaranteed `context deadline exceeded` errors for the final five seconds of polling.

`TestWorkspaceTemplateParamsChange` has the same shape (real terraform provisioner, 120s test context, plain await helpers) and the same latent bug, so it gets the same fix.

Closes https://github.com/coder/internal/issues/1470 (Linear: PLAT-176)

<details>
<summary>Root cause analysis</summary>

Two CI failures, same mechanism:

- 2026-04-16 (run 24493089585, windows-2022): `overrides_with_dynamic_option_from_var/dynamic` failed at `coderdtest.AwaitTemplateVersionJobCompleted` with `Condition never satisfied ... make sure you set IncludeProvisionerDaemon!`. The template import job (real terraform init/plan, with network provider download) did not complete within `WaitLong` (25s).
- 2026-05-27 (run 26492817796, windows-2022): `tag_param/dynamic` failed at `coderdtest.AwaitWorkspaceBuildJobCompleted` with `failed to get workspace build ...: context deadline exceeded`. The helper's internal context was `WaitShort` (10s) while its polling window was `WaitMedium` (15s), so after 10s every poll could only fail. The logged `terraform apply: exit status 1` and the `TempDir RemoveAll ... Access is denied` cleanup error are consequences of test teardown canceling the in-flight job while the provider exe was still file-locked.

The test declares a 120s budget (`2*testutil.WaitSuperLong`, commented "This can take a while"), but the await helpers ignored it and applied their own 10-25s budgets. `testutil.CacheTFProviders` is a no-op on Windows, so real builds are much slower there.

This change raises the ceiling for the tests rather than making terraform faster; both observed failure signatures are eliminated. The default helper budgets are unchanged for the ~880 existing call sites. One small behavior change: `AwaitTemplateVersionJobCompleted` previously marked the test failed on any transient poll error via `assert.NoError`; it now logs and keeps polling, matching the workspace build helper, and still fails on timeout.

`TestWorkspaceTemplateParamsChange` is the sibling real-terraform test in the same file (also covered by the original provider-caching work in #20603). It runs three sequential real builds with the plain await helpers under a 120s context, so it is exposed to the same Windows slowness even though it has not produced its own issue yet. Its context is raised to `6*testutil.WaitSuperLong` to outlast three sequential await budgets.

API note: a context-taking variant was considered first, but a `time.Duration` parameter avoids an implicit "context must have a deadline" contract and matches how the existing helpers manage their own wait budgets.

</details>

---

🤖 This PR was generated by Coder Agents on behalf of @jscottmiller.
