### PR TITLE
fix: only trust x-forwarded-host from configured trusted proxies (#26204)

### DIFF
--- a/agent/api.go
+++ b/agent/api.go
@@ -19,7 +19,7 @@ func (a *agent) apiHandler() http.Handler {
 	r.Use(
 		httpmw.Recover(a.logger),
 		tracing.StatusWriterMiddleware,
-		loggermw.Logger(a.logger),
+		loggermw.Logger(a.logger, nil),
 	)
 	r.Get("/", func(rw http.ResponseWriter, r *http.Request) {
 		httpapi.Write(r.Context(), rw, http.StatusOK, codersdk.Response{

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -295,8 +295,8 @@ NETWORKING OPTIONS:
           True-Client-Ip, X-Forwarded-For.
 
       --proxy-trusted-origins string-array, $CODER_PROXY_TRUSTED_ORIGINS
-          Origin addresses to respect "proxy-trusted-headers". e.g.
-          192.168.1.0/24.
+          Origin addresses to respect "proxy-trusted-headers" and
+          X-Forwarded-Host for subdomain app routing. e.g. 192.168.1.0/24.
 
       --redirect-to-access-url bool, $CODER_REDIRECT_TO_ACCESS_URL
           Specifies whether to redirect requests that do not match the access

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -172,7 +172,8 @@ networking:
   # True-Client-Ip, X-Forwarded-For.
   # (default: <unset>, type: string-array)
   proxyTrustedHeaders: []
-  # Origin addresses to respect "proxy-trusted-headers". e.g. 192.168.1.0/24.
+  # Origin addresses to respect "proxy-trusted-headers" and X-Forwarded-Host for
+  # subdomain app routing. e.g. 192.168.1.0/24.
   # (default: <unset>, type: string-array)
   proxyTrustedOrigins: []
   # Controls if the 'Secure' property is set on browser session cookies.

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -868,7 +868,9 @@ func New(options *Options) *API {
 		tracing.Middleware(api.TracerProvider),
 		httpmw.AttachRequestID,
 		httpmw.ExtractRealIP(api.RealIPConfig),
-		loggermw.Logger(api.Logger),
+		loggermw.Logger(api.Logger, func(r *http.Request) string {
+			return httpmw.EffectiveHost(api.RealIPConfig, r)
+		}),
 		singleSlashMW,
 		rolestore.CustomRoleMW,
 		prometheusMW,

--- a/coderd/httpapi/request.go
+++ b/coderd/httpapi/request.go
@@ -8,17 +8,6 @@ const (
 	XForwardedHostHeader = "X-Forwarded-Host"
 )
 
-// RequestHost returns the name of the host from the request.  It prioritizes
-// 'X-Forwarded-Host' over r.Host since most requests are being proxied.
-func RequestHost(r *http.Request) string {
-	host := r.Header.Get(XForwardedHostHeader)
-	if host != "" {
-		return host
-	}
-
-	return r.Host
-}
-
 func IsWebsocketUpgrade(r *http.Request) bool {
 	vs := r.Header.Values("Upgrade")
 	for _, v := range vs {

--- a/coderd/httpmw/loggermw/logger.go
+++ b/coderd/httpmw/loggermw/logger.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"cdr.dev/slog"
-	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/tracing"
 )
 
@@ -69,7 +68,7 @@ func safeQueryParams(params url.Values) []slog.Field {
 	return fields
 }
 
-func Logger(log slog.Logger) func(next http.Handler) http.Handler {
+func Logger(log slog.Logger, hostResolver func(*http.Request) string) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 			start := time.Now()
@@ -79,8 +78,14 @@ func Logger(log slog.Logger) func(next http.Handler) http.Handler {
 				panic(fmt.Sprintf("ResponseWriter not a *tracing.StatusWriter; got %T", rw))
 			}
 
+			host := r.Host
+			if hostResolver != nil {
+				host = hostResolver(r)
+			}
+
 			httplog := log.With(
-				slog.F("host", httpapi.RequestHost(r)),
+				slog.F("host", host),
+				slog.F("received_host", r.Host),
 				slog.F("path", r.URL.Path),
 				slog.F("proto", r.Proto),
 				slog.F("remote_addr", r.RemoteAddr),

--- a/coderd/httpmw/loggermw/logger_internal_test.go
+++ b/coderd/httpmw/loggermw/logger_internal_test.go
@@ -68,7 +68,7 @@ func TestLoggerMiddleware_SingleRequest(t *testing.T) {
 	})
 
 	// Wrap the test handler with the Logger middleware
-	loggerMiddleware := Logger(logger)
+	loggerMiddleware := Logger(logger, nil)
 	wrappedHandler := loggerMiddleware(testHandler)
 
 	// Create a test HTTP request
@@ -90,7 +90,7 @@ func TestLoggerMiddleware_SingleRequest(t *testing.T) {
 	}
 
 	// Check that the log contains the expected fields
-	requiredFields := []string{"host", "path", "proto", "remote_addr", "start", "took", "status_code", "latency_ms"}
+	requiredFields := []string{"host", "received_host", "path", "proto", "remote_addr", "start", "took", "status_code", "latency_ms"}
 	for _, field := range requiredFields {
 		_, exists := fieldsMap[field]
 		require.True(t, exists, "field %q is missing in log fields", field)
@@ -100,6 +100,38 @@ func TestLoggerMiddleware_SingleRequest(t *testing.T) {
 
 	// Check value of the status code
 	require.Equal(t, fieldsMap["status_code"], http.StatusOK)
+}
+
+func TestLoggerMiddleware_HostFields(t *testing.T) {
+	t.Parallel()
+
+	sink := &fakeSink{}
+	logger := slog.Make(sink)
+	logger = logger.Leveled(slog.LevelDebug)
+
+	testHandler := http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	})
+
+	loggerMiddleware := Logger(logger, func(_ *http.Request) string {
+		return "effective.test"
+	})
+	wrappedHandler := loggerMiddleware(testHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "http://received.test/path", nil)
+
+	sw := &tracing.StatusWriter{ResponseWriter: httptest.NewRecorder()}
+	wrappedHandler.ServeHTTP(sw, req)
+
+	require.Len(t, sink.entries, 1, "expected exactly one log entry")
+
+	fieldsMap := make(map[string]any)
+	for _, field := range sink.entries[0].Fields {
+		fieldsMap[field.Name] = field.Value
+	}
+
+	require.Equal(t, "effective.test", fieldsMap["host"])
+	require.Equal(t, "received.test", fieldsMap["received_host"])
 }
 
 func TestLoggerMiddleware_WebSocket(t *testing.T) {
@@ -129,7 +161,7 @@ func TestLoggerMiddleware_WebSocket(t *testing.T) {
 	})
 
 	// Wrap the test handler with the Logger middleware
-	loggerMiddleware := Logger(logger)
+	loggerMiddleware := Logger(logger, nil)
 	wrappedHandler := loggerMiddleware(testHandler)
 
 	// RequestLogger expects the ResponseWriter to be *tracing.StatusWriter
@@ -184,7 +216,7 @@ func TestRequestLogger_HTTPRouteParams(t *testing.T) {
 	})
 
 	// Wrap the test handler with the Logger middleware
-	loggerMiddleware := Logger(logger)
+	loggerMiddleware := Logger(logger, nil)
 	wrappedHandler := loggerMiddleware(testHandler)
 
 	// Create a test HTTP request

--- a/coderd/httpmw/realip.go
+++ b/coderd/httpmw/realip.go
@@ -105,6 +105,35 @@ func FilterUntrustedOriginHeaders(config *RealIPConfig, req *http.Request) {
 	}
 }
 
+// EffectiveHost returns the host Coder should trust for request handling.
+// It uses X-Forwarded-Host only when the immediate peer is a configured
+// trusted proxy. Otherwise it uses the received Host header.
+func EffectiveHost(config *RealIPConfig, r *http.Request) string {
+	if config == nil {
+		config = &RealIPConfig{
+			TrustedOrigins: nil,
+			TrustedHeaders: nil,
+		}
+	}
+
+	// When ExtractRealIP has run, r.RemoteAddr may hold the forwarded
+	// client IP, and we should use the original socket peer for proxy
+	// trust decisions.
+	remoteAddr := r.RemoteAddr
+	state := RealIP(r.Context())
+	if state != nil && state.OriginalRemoteAddr != "" {
+		remoteAddr = state.OriginalRemoteAddr
+	}
+
+	if isContainedIn(config.TrustedOrigins, getRemoteAddress(remoteAddr)) {
+		if host := r.Header.Get(httpapi.XForwardedHostHeader); host != "" {
+			return host
+		}
+	}
+
+	return r.Host
+}
+
 // EnsureXForwardedForHeader ensures that the request has an X-Forwarded-For
 // header. It uses the following logic:
 //

--- a/coderd/httpmw/realip_test.go
+++ b/coderd/httpmw/realip_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
 )
 
@@ -470,6 +471,112 @@ func TestFilterUntrusted(t *testing.T) {
 			require.Equal(t, test.ExpectedHeader, req.Header, "filtered headers should match")
 		})
 	}
+}
+
+func TestEffectiveHost(t *testing.T) {
+	t.Parallel()
+
+	cidr32 := func(t *testing.T, ip string) *net.IPNet {
+		t.Helper()
+
+		return &net.IPNet{
+			IP:   net.ParseIP(ip),
+			Mask: net.CIDRMask(32, 32),
+		}
+	}
+
+	t.Run("UntrustedPeerFallsBackToReceivedHost", func(t *testing.T) {
+		t.Parallel()
+
+		r := httptest.NewRequest(http.MethodGet, "http://received.test", nil)
+		r.RemoteAddr = "17.18.19.20:1234"
+		r.Header.Set(httpapi.XForwardedHostHeader, "app.test.coder.com")
+
+		require.Equal(t, "received.test", httpmw.EffectiveHost(nil, r))
+	})
+
+	t.Run("TrustedPeerUsesOriginalRemoteAddrForTrust", func(t *testing.T) {
+		t.Parallel()
+
+		config := &httpmw.RealIPConfig{
+			TrustedOrigins: []*net.IPNet{cidr32(t, "17.18.19.20")},
+			TrustedHeaders: []string{"X-Real-Ip"},
+		}
+
+		r := httptest.NewRequest(http.MethodGet, "http://received.test", nil)
+		r.RemoteAddr = "17.18.19.20:1234"
+		// X-Real-Ip causes ExtractRealIP to rewrite r.RemoteAddr, so
+		// this test can verify trust still uses OriginalRemoteAddr,
+		// the actual socket peer.
+		r.Header.Set("X-Real-Ip", "99.88.77.66")
+		r.Header.Set(httpapi.XForwardedHostHeader, "app.test.coder.com")
+
+		middleware := httpmw.ExtractRealIP(config)
+		next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "99.88.77.66", r.RemoteAddr)
+			require.Equal(t, "app.test.coder.com", httpmw.EffectiveHost(config, r))
+		})
+
+		middleware(next).ServeHTTP(httptest.NewRecorder(), r)
+	})
+
+	t.Run("UntrustedPeerDoesNotHonorForwardedHost", func(t *testing.T) {
+		t.Parallel()
+
+		config := &httpmw.RealIPConfig{
+			TrustedOrigins: []*net.IPNet{cidr32(t, "99.88.77.66")},
+			TrustedHeaders: []string{"X-Real-Ip"},
+		}
+
+		r := httptest.NewRequest(http.MethodGet, "http://received.test", nil)
+		r.RemoteAddr = "17.18.19.20:1234"
+		r.Header.Set("X-Real-Ip", "99.88.77.66")
+		r.Header.Set(httpapi.XForwardedHostHeader, "app.test.coder.com")
+
+		middleware := httpmw.ExtractRealIP(config)
+		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "17.18.19.20", r.RemoteAddr)
+			require.Equal(t, "received.test", httpmw.EffectiveHost(config, r))
+		})
+
+		middleware(nextHandler).ServeHTTP(httptest.NewRecorder(), r)
+	})
+
+	t.Run("TrustedPeerWithoutForwardedHostFallsBackToReceivedHost", func(t *testing.T) {
+		t.Parallel()
+
+		config := &httpmw.RealIPConfig{
+			TrustedOrigins: []*net.IPNet{cidr32(t, "17.18.19.20")},
+			TrustedHeaders: []string{"X-Real-Ip"},
+		}
+
+		r := httptest.NewRequest(http.MethodGet, "http://received.test", nil)
+		r.RemoteAddr = "17.18.19.20:1234"
+
+		middleware := httpmw.ExtractRealIP(config)
+		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "received.test", httpmw.EffectiveHost(config, r))
+		})
+
+		middleware(nextHandler).ServeHTTP(httptest.NewRecorder(), r)
+	})
+
+	t.Run("MalformedRemoteAddrFallsBackToReceivedHost", func(t *testing.T) {
+		t.Parallel()
+
+		config := &httpmw.RealIPConfig{
+			TrustedOrigins: []*net.IPNet{cidr32(t, "17.18.19.20")},
+			TrustedHeaders: []string{"X-Real-Ip"},
+		}
+
+		r := httptest.NewRequest(http.MethodGet, "http://received.test", nil)
+		// A RemoteAddr that cannot be parsed into an IP must be treated as
+		// untrusted, so the forwarded host is ignored.
+		r.RemoteAddr = "garbage"
+		r.Header.Set(httpapi.XForwardedHostHeader, "app.test.coder.com")
+
+		require.Equal(t, "received.test", httpmw.EffectiveHost(config, r))
+	})
 }
 
 // TestApplicationProxy checks headers passed to DevURL services are as expected.

--- a/coderd/workspaceapps/proxy.go
+++ b/coderd/workspaceapps/proxy.go
@@ -417,7 +417,7 @@ func (s *Server) HandleSubdomain(middlewares ...func(http.Handler) http.Handler)
 			}
 
 			// Step 2: Get the request Host.
-			host := httpapi.RequestHost(r)
+			host := httpmw.EffectiveHost(s.RealIPConfig, r)
 			if host == "" {
 				if r.URL.Path == "/derp" {
 					// The /derp endpoint is used by wireguard clients to tunnel

--- a/coderd/workspaceapps/proxy_test.go
+++ b/coderd/workspaceapps/proxy_test.go
@@ -1,3 +1,90 @@
 package workspaceapps_test
 
 // App tests can be found in the apptest package.
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/coderd/httpmw"
+	"github.com/coder/coder/v2/coderd/workspaceapps"
+	"github.com/coder/coder/v2/coderd/workspaceapps/appurl"
+	"github.com/coder/coder/v2/testutil"
+)
+
+type fakeSignedTokenProvider struct {
+	fromRequestCalls int
+	issueCalls       int
+}
+
+func (s *fakeSignedTokenProvider) FromRequest(_ *http.Request) (*workspaceapps.SignedToken, bool) {
+	s.fromRequestCalls++
+	return nil, false
+}
+
+func (s *fakeSignedTokenProvider) Issue(_ context.Context, _ http.ResponseWriter, _ *http.Request, _ workspaceapps.IssueTokenRequest) (*workspaceapps.SignedToken, string, bool) {
+	s.issueCalls++
+	return nil, "", false
+}
+
+func TestHandleSubdomain_IgnoresUntrustedForwardedHost(t *testing.T) {
+	t.Parallel()
+
+	hostnamePattern := "*--apps.test.coder.com"
+	hostnameRegex, err := appurl.CompileHostnamePattern(hostnamePattern)
+	require.NoError(t, err)
+
+	dashboardURL, err := url.Parse("https://dashboard.test.coder.com")
+	require.NoError(t, err)
+
+	provider := &fakeSignedTokenProvider{}
+	srv := workspaceapps.NewServer(workspaceapps.ServerOptions{
+		Logger:        testutil.Logger(t),
+		DashboardURL:  dashboardURL,
+		AccessURL:     dashboardURL,
+		Hostname:      hostnamePattern,
+		HostnameRegex: hostnameRegex,
+		RealIPConfig: &httpmw.RealIPConfig{
+			TrustedOrigins: []*net.IPNet{{
+				IP:   net.ParseIP("10.0.0.1"),
+				Mask: net.CIDRMask(32, 32),
+			}},
+		},
+		SignedTokenProvider: provider,
+	})
+
+	forgedHost := appurl.ApplicationURL{
+		AppSlugOrPort: "app",
+		WorkspaceName: "workspace",
+		Username:      "victim",
+	}.String() + "--apps.test.coder.com"
+
+	nextCalled := false
+	next := http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+	})
+
+	// Given: a request with a forged X-Forwarded-Host set to a valid
+	// app hostname, and an immediate peer outside the trusted proxy
+	// config.
+	req := httptest.NewRequest(http.MethodGet, "https://dashboard.test.coder.com/", nil)
+	req.Header.Set(httpapi.XForwardedHostHeader, forgedHost)
+	req.RemoteAddr = "17.18.19.20:1234"
+
+	// When: HandleSubdomain runs.
+	srv.HandleSubdomain()(next).ServeHTTP(httptest.NewRecorder(), req)
+
+	// Then: it ignores untrusted X-Forwarded-Host, so the received
+	// dashboard host is used, the request falls through to the next
+	// handler, and the signed app token provider is never called.
+	require.True(t, nextCalled)
+	require.Zero(t, provider.fromRequestCalls)
+	require.Zero(t, provider.issueCalls)
+}

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -2512,7 +2512,7 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			Name:        "Proxy Trusted Origins",
 			Flag:        "proxy-trusted-origins",
 			Env:         "CODER_PROXY_TRUSTED_ORIGINS",
-			Description: "Origin addresses to respect \"proxy-trusted-headers\". e.g. 192.168.1.0/24.",
+			Description: "Origin addresses to respect \"proxy-trusted-headers\" and X-Forwarded-Host for subdomain app routing. e.g. 192.168.1.0/24.",
 			Value:       &c.ProxyTrustedOrigins,
 			Group:       &deploymentGroupNetworking,
 			YAML:        "proxyTrustedOrigins",

--- a/docs/admin/networking/wildcard-access-url.md
+++ b/docs/admin/networking/wildcard-access-url.md
@@ -56,6 +56,12 @@ Use a reverse proxy to handle TLS termination with automatic certificate managem
 - [Apache with Let's Encrypt](../../tutorials/reverse-proxy-apache.md)
 - [Caddy reverse proxy](../../tutorials/reverse-proxy-caddy.md)
 
+If your reverse proxy rewrites the request `Host` and forwards the original
+host in `X-Forwarded-Host`, configure
+[`CODER_PROXY_TRUSTED_ORIGINS`](../../reference/cli/server.md#--proxy-trusted-origins)
+to trust that proxy's address. Otherwise Coder will ignore `X-Forwarded-Host`
+for subdomain app routing.
+
 ### DNS Setup
 
 You'll need to configure DNS to point wildcard subdomains to your Coder server:

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -971,7 +971,7 @@ Headers to trust for forwarding IP addresses. e.g. Cf-Connecting-Ip, True-Client
 | Environment | <code>$CODER_PROXY_TRUSTED_ORIGINS</code>   |
 | YAML        | <code>networking.proxyTrustedOrigins</code> |
 
-Origin addresses to respect "proxy-trusted-headers". e.g. 192.168.1.0/24.
+Origin addresses to respect "proxy-trusted-headers" and X-Forwarded-Host for subdomain app routing. e.g. 192.168.1.0/24.
 
 ### --cache-dir
 

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -296,8 +296,8 @@ NETWORKING OPTIONS:
           True-Client-Ip, X-Forwarded-For.
 
       --proxy-trusted-origins string-array, $CODER_PROXY_TRUSTED_ORIGINS
-          Origin addresses to respect "proxy-trusted-headers". e.g.
-          192.168.1.0/24.
+          Origin addresses to respect "proxy-trusted-headers" and
+          X-Forwarded-Host for subdomain app routing. e.g. 192.168.1.0/24.
 
       --redirect-to-access-url bool, $CODER_REDIRECT_TO_ACCESS_URL
           Specifies whether to redirect requests that do not match the access

--- a/enterprise/wsproxy/wsproxy.go
+++ b/enterprise/wsproxy/wsproxy.go
@@ -335,7 +335,9 @@ func New(ctx context.Context, opts *Options) (*Server, error) {
 		tracing.Middleware(s.TracerProvider),
 		httpmw.AttachRequestID,
 		httpmw.ExtractRealIP(s.Options.RealIPConfig),
-		loggermw.Logger(s.Logger),
+		loggermw.Logger(s.Logger, func(r *http.Request) string {
+			return httpmw.EffectiveHost(s.Options.RealIPConfig, r)
+		}),
 		prometheusMW,
 
 		// HandleSubdomain is a middleware that handles all requests to the

--- a/tailnet/test/integration/integration.go
+++ b/tailnet/test/integration/integration.go
@@ -215,7 +215,7 @@ func (o SimpleServerOptions) Router(t *testing.T, logger slog.Logger) *chi.Mux {
 			})
 		},
 		tracing.StatusWriterMiddleware,
-		loggermw.Logger(logger),
+		loggermw.Logger(logger, nil),
 	)
 
 	r.Route("/derp", func(r chi.Router) {


### PR DESCRIPTION
Backport of #26204 (commit b5ef700) to `release/2.29`

Replace RequestHost with httpmw.EffectiveHost, which honors
X-Forwarded-Host only when the original socket peer is a configured
trusted origin, otherwise falling back to the received Host header.

<details>
<summary>The following cherry-pick conflicts were resolved</summary>
This release branch predates several things the fix was built on: the agentchat
and agentproc packages, the OBSERVABILITY.md doc, the cdr.dev/slog v3 migration,
and the user_agent request-log field. Rebasing produced six conflicts.

Dropped (absent on this branch, so not part of the backport):

- .claude/docs/OBSERVABILITY.md
- agent/agentchat/log_test.go (entire agentchat package absent)
- agent/agentproc/api_test.go (entire agentproc package absent)

Adapted:

- agent/api.go — kept the release-branch version and added only the required , nil
for the new two-argument loggermw.Logger signature; did not pull in
agentchat.Middleware or its import.
- coderd/httpmw/loggermw/logger.go — kept cdr.dev/slog v1, removed the now-unused
httpapi import, and applied the security change (log the trust-aware effective
host plus received_host). Did not introduce the user_agent field, which this
branch doesn't log.
- coderd/httpmw/loggermw/logger_internal_test.go — updated requiredFields to match
(added received_host, kept user_agent out) and rewrote the new
TestLoggerMiddleware_HostFields to use the branch's local fakeSink helper, since
the fix's testutil.NewFakeSink/Entries() API doesn't exist here.
</details>

> [!NOTE]
> Breaking change. See the original PR for the breaking-change details.