### PR TITLE
fix(coderd): require update permission to recreate devcontainers (#25812)

### DIFF
--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -1134,6 +1134,12 @@ func (api *API) workspaceAgentListContainers(rw http.ResponseWriter, r *http.Req
 func (api *API) workspaceAgentRecreateDevcontainer(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	workspaceAgent := httpmw.WorkspaceAgentParam(r)
+	workspace := httpmw.WorkspaceParam(r)
+
+	if !api.Authorize(r, policy.ActionUpdate, workspace) {
+		httpapi.Forbidden(rw)
+		return
+	}
 
 	devcontainer := chi.URLParam(r, "devcontainer")
 	if devcontainer == "" {

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -1571,6 +1571,57 @@ func TestWorkspaceAgentRecreateDevcontainer(t *testing.T) {
 	})
 }
 
+func TestWorkspaceAgentRecreateDevcontainerAuthorization(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		role func(uuid.UUID) rbac.RoleIdentifier
+	}{
+		{
+			name: "TemplateAdmin",
+			role: func(uuid.UUID) rbac.RoleIdentifier {
+				return rbac.RoleTemplateAdmin()
+			},
+		},
+		{
+			name: "OrgTemplateAdmin",
+			role: rbac.ScopedRoleOrgTemplateAdmin,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				ctx                    = testutil.Context(t, testutil.WaitMedium)
+				client, db             = coderdtest.NewWithDatabase(t, nil)
+				admin                  = coderdtest.CreateFirstUser(t, client)
+				_, workspaceOwner      = coderdtest.CreateAnotherUser(t, client, admin.OrganizationID)
+				templateAdminClient, _ = coderdtest.CreateAnotherUser(t, client, admin.OrganizationID, tc.role(admin.OrganizationID))
+			)
+			r := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+				OrganizationID: admin.OrganizationID,
+				OwnerID:        workspaceOwner.ID,
+			}).WithAgent(func(agents []*proto.Agent) []*proto.Agent {
+				return agents
+			}).Do()
+
+			ws, err := client.Workspace(ctx, r.Workspace.ID)
+			require.NoError(t, err)
+			require.NotEmpty(t, ws.LatestBuild.Resources)
+			require.NotEmpty(t, ws.LatestBuild.Resources[0].Agents)
+			agentID := ws.LatestBuild.Resources[0].Agents[0].ID
+
+			_, err = templateAdminClient.WorkspaceAgentRecreateDevcontainer(ctx, agentID, uuid.NewString())
+			require.Error(t, err)
+
+			var sdkErr *codersdk.Error
+			require.ErrorAs(t, err, &sdkErr)
+			require.Equal(t, http.StatusForbidden, sdkErr.StatusCode())
+		})
+	}
+}
+
 func TestWorkspaceAgentAppHealth(t *testing.T) {
 	t.Parallel()
 	client, db := coderdtest.NewWithDatabase(t, nil)


### PR DESCRIPTION
Backport of #25812 to `release/2.29` (SEC-84 / DEVEX-399).

Conflict resolution: 2.29 has no `WorkspaceAgentAndWorkspaceParam` middleware, so the handler authorizes against `httpmw.WorkspaceParam(r)`. The authorization test resolves the agent ID via the workspace API since `dbfake.WorkspaceResponse` has no `Agents` field on this branch. Dropped the out-of-scope `TestWorkspaceAgentDeleteDevcontainer` (DELETE endpoint does not exist on 2.29).

> 🤖 Backport prepared by Coder Agents on behalf of @f0ssel.