### PR TITLE
fix(enterprise/aibridgedserver): check user is active in aibridge auth (#26173)

### DIFF
--- a/enterprise/aibridgedserver/aibridgedserver.go
+++ b/enterprise/aibridgedserver/aibridgedserver.go
@@ -37,12 +37,13 @@ var (
 	// matching.
 	// TODO: return these errors to the client in a more structured/comparable
 	//       way.
-	ErrInvalidKey  = xerrors.New("invalid key")
-	ErrUnknownKey  = xerrors.New("unknown key")
-	ErrExpired     = xerrors.New("expired")
-	ErrUnknownUser = xerrors.New("unknown user")
-	ErrDeletedUser = xerrors.New("deleted user")
-	ErrSystemUser  = xerrors.New("system user")
+	ErrInvalidKey   = xerrors.New("invalid key")
+	ErrUnknownKey   = xerrors.New("unknown key")
+	ErrExpired      = xerrors.New("expired")
+	ErrUnknownUser  = xerrors.New("unknown user")
+	ErrDeletedUser  = xerrors.New("deleted user")
+	ErrInactiveUser = xerrors.New("inactive user")
+	ErrSystemUser   = xerrors.New("system user")
 
 	ErrNoExternalAuthLinkFound = xerrors.New("no external auth link found")
 )
@@ -399,9 +400,12 @@ func (s *Server) IsAuthorized(ctx context.Context, in *proto.IsAuthorizedRequest
 		return nil, ErrUnknownUser
 	}
 
-	// User is not deleted or a system user.
+	// User is active, not deleted, and not a system user.
 	if user.Deleted {
 		return nil, ErrDeletedUser
+	}
+	if user.Status != database.UserStatusActive {
+		return nil, ErrInactiveUser
 	}
 	if user.IsSystem {
 		return nil, ErrSystemUser

--- a/enterprise/aibridgedserver/aibridgedserver_test.go
+++ b/enterprise/aibridgedserver/aibridgedserver_test.go
@@ -94,16 +94,36 @@ func TestAuthorization(t *testing.T) {
 			name:        "deleted user",
 			expectedErr: aibridgedserver.ErrDeletedUser,
 			mocksFn: func(db *dbmock.MockStore, apiKey database.APIKey, user database.User) {
+				user.Deleted = true
 				db.EXPECT().GetAPIKeyByID(gomock.Any(), apiKey.ID).Times(1).Return(apiKey, nil)
-				db.EXPECT().GetUserByID(gomock.Any(), user.ID).Times(1).Return(database.User{ID: user.ID, Deleted: true}, nil)
+				db.EXPECT().GetUserByID(gomock.Any(), user.ID).Times(1).Return(user, nil)
+			},
+		},
+		{
+			name:        "suspended user",
+			expectedErr: aibridgedserver.ErrInactiveUser,
+			mocksFn: func(db *dbmock.MockStore, apiKey database.APIKey, user database.User) {
+				user.Status = database.UserStatusSuspended
+				db.EXPECT().GetAPIKeyByID(gomock.Any(), apiKey.ID).Times(1).Return(apiKey, nil)
+				db.EXPECT().GetUserByID(gomock.Any(), user.ID).Times(1).Return(user, nil)
+			},
+		},
+		{
+			name:        "dormant user",
+			expectedErr: aibridgedserver.ErrInactiveUser,
+			mocksFn: func(db *dbmock.MockStore, apiKey database.APIKey, user database.User) {
+				user.Status = database.UserStatusDormant
+				db.EXPECT().GetAPIKeyByID(gomock.Any(), apiKey.ID).Times(1).Return(apiKey, nil)
+				db.EXPECT().GetUserByID(gomock.Any(), user.ID).Times(1).Return(user, nil)
 			},
 		},
 		{
 			name:        "system user",
 			expectedErr: aibridgedserver.ErrSystemUser,
 			mocksFn: func(db *dbmock.MockStore, apiKey database.APIKey, user database.User) {
+				user.IsSystem = true
 				db.EXPECT().GetAPIKeyByID(gomock.Any(), apiKey.ID).Times(1).Return(apiKey, nil)
-				db.EXPECT().GetUserByID(gomock.Any(), user.ID).Times(1).Return(database.User{ID: user.ID, IsSystem: true}, nil)
+				db.EXPECT().GetUserByID(gomock.Any(), user.ID).Times(1).Return(user, nil)
 			},
 		},
 		{


### PR DESCRIPTION
Backport of #26173 to `release/2.29` (SEC-106 / AIGOV-385).

Conflict resolution: the package lives at `enterprise/aibridgedserver` on 2.29 (moved to `coderd/` on main); the diff was retargeted. Dropped the `TestAuthorization_Delegated` cases and `ErrAmbiguousAuth`, since the delegated KeyId auth path does not exist on this branch.

> 🤖 Backport prepared by Coder Agents on behalf of @f0ssel.