### PR TITLE
test(enterprise/coderd): stabilize TestUserSkillAuditDiffTracksContent

### DIFF
--- a/enterprise/coderd/userskills_audit_test.go
+++ b/enterprise/coderd/userskills_audit_test.go
@@ -3,6 +3,7 @@ package coderd_test
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -71,6 +72,7 @@ func TestUserSkillAuditDiffTracksContent(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Len(t, rows, 2, "expected exactly two rows")
+	sort.Slice(rows, func(i, j int) bool { return rows[i].AuditLog.Action > rows[j].AuditLog.Action })
 	createLog := rows[1].AuditLog
 	updateLog := rows[0].AuditLog
 


### PR DESCRIPTION
`GetAuditLogsOffset` orders by `"time" DESC` with no tiebreaker, and `dbtime.Now` rounds to microseconds, so two audit logs emitted in quick succession (especially on platforms with coarser clock resolution like Windows) can land in the same microsecond and Postgres is free to return them in either order. The test then assumes positional ordering and breaks.

Sort `rows` by `Action` descending before indexing so `rows[0]` is the update log and `rows[1]` is the create log regardless of timestamp collisions.

Closes CODAGT-585
Closes https://github.com/coder/internal/issues/1551
