### PR TITLE
feat(coderd): notify users when chats are shared

### DIFF
--- a/coderd/database/migrations/000519_chat_shared_notification.down.sql
+++ b/coderd/database/migrations/000519_chat_shared_notification.down.sql
@@ -1,0 +1,1 @@
+DELETE FROM notification_templates WHERE id = 'b789bd75-d7c6-4cab-9757-1147ab184903';

--- a/coderd/database/migrations/000519_chat_shared_notification.up.sql
+++ b/coderd/database/migrations/000519_chat_shared_notification.up.sql
@@ -1,0 +1,27 @@
+INSERT INTO notification_templates (
+    id,
+    name,
+    title_template,
+    body_template,
+    actions,
+    "group",
+    method,
+    kind,
+    enabled_by_default
+)
+VALUES (
+    'b789bd75-d7c6-4cab-9757-1147ab184903',
+    'Chat Shared',
+    E'{{.Labels.initiator}} shared a chat with you',
+    E'{{.Labels.initiator}} shared the chat **{{.Labels.chat_title}}** with you.',
+    '[
+        {
+            "label": "View chat",
+            "url": "{{base_url}}/agents/{{.Labels.chat_id}}"
+        }
+    ]'::jsonb,
+    'Chat Events',
+    NULL,
+    'system'::notification_template_kind,
+    true
+);

--- a/coderd/exp_chats_acl.go
+++ b/coderd/exp_chats_acl.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/google/uuid"
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/xerrors"
 
 	slog "cdr.dev/slog/v3"
@@ -15,6 +16,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
+	"github.com/coder/coder/v2/coderd/notifications"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/rbac/acl"
 	"github.com/coder/coder/v2/coderd/rbac/policy"
@@ -199,7 +201,72 @@ func (api *API) patchChatACL(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := api.notifyChatShared(ctx, api.Database, aReq.New, apiKey.UserID, req); err != nil {
+		api.Logger.Warn(ctx, "failed to enqueue chat shared notification", slog.Error(err), slog.F("chat_id", chat.ID))
+	}
+
 	rw.WriteHeader(http.StatusNoContent)
+}
+
+func (api *API) notifyChatShared(ctx context.Context, store database.Store, chat database.Chat, initiatorID uuid.UUID, req codersdk.UpdateChatACL) error {
+	userIDs := make([]uuid.UUID, 0, len(req.UserRoles))
+	for rawUserID, role := range req.UserRoles {
+		if role != codersdk.ChatRoleRead {
+			continue
+		}
+		userID, err := uuid.Parse(rawUserID)
+		if err != nil {
+			continue
+		}
+		userIDs = append(userIDs, userID)
+	}
+	for rawGroupID, role := range req.GroupRoles {
+		if role != codersdk.ChatRoleRead {
+			continue
+		}
+		groupID, err := uuid.Parse(rawGroupID)
+		if err != nil {
+			continue
+		}
+		members, err := store.GetGroupMembersByGroupID(ctx, database.GetGroupMembersByGroupIDParams{
+			GroupID:       groupID,
+			IncludeSystem: false,
+		})
+		if err != nil {
+			return xerrors.Errorf("get group members by group ID: %w", err)
+		}
+		for _, member := range members {
+			userIDs = append(userIDs, member.UserID)
+		}
+	}
+	userIDs = slice.Unique(userIDs)
+	if len(userIDs) == 0 {
+		return nil
+	}
+
+	initiator, err := store.GetUserByID(ctx, initiatorID)
+	if err != nil {
+		return xerrors.Errorf("get initiator: %w", err)
+	}
+	labels := map[string]string{
+		"chat_id":    chat.ID.String(),
+		"chat_title": chat.Title,
+		"initiator":  initiator.Username,
+	}
+
+	var eg errgroup.Group
+	for _, userID := range userIDs {
+		userID := userID
+		eg.Go(func() error {
+			//nolint:gocritic // Need notifier actor to enqueue notifications.
+			_, err := api.NotificationsEnqueuer.Enqueue(dbauthz.AsNotifier(ctx), userID, notifications.TemplateChatShared, labels, initiatorID.String(), chat.ID)
+			if err != nil {
+				return xerrors.Errorf("enqueue chat shared notification: %w", err)
+			}
+			return nil
+		})
+	}
+	return eg.Wait()
 }
 
 func (api *API) chatACLUsers(ctx context.Context, rw http.ResponseWriter, chat database.Chat, entries database.ChatACL) ([]codersdk.ChatUser, bool) {

--- a/coderd/exp_chats_acl_test.go
+++ b/coderd/exp_chats_acl_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/notifications"
+	"github.com/coder/coder/v2/coderd/notifications/notificationstest"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/coderd/util/ptr"
@@ -28,8 +30,10 @@ func TestChatACLSharingLifecycle(t *testing.T) {
 
 	ctx := testutil.Context(t, testutil.WaitLong)
 	mAudit := audit.NewMock()
+	notifyEnq := &notificationstest.FakeEnqueuer{}
 	client, db := newChatClientWithDatabase(t, func(opts *coderdtest.Options) {
 		opts.Auditor = mAudit
+		opts.NotificationsEnqueuer = notifyEnq
 	})
 	firstUser := coderdtest.CreateFirstUser(t, client.Client)
 	_ = createChatModelConfig(t, client)
@@ -68,6 +72,23 @@ func TestChatACLSharingLifecycle(t *testing.T) {
 		ResourceID:   chat.ID,
 		UserID:       firstUser.UserID,
 	}))
+	sent := notifyEnq.Sent(notificationstest.WithTemplateID(notifications.TemplateChatShared))
+	require.Len(t, sent, 2)
+	byUserID := map[uuid.UUID]*notificationstest.FakeNotification{}
+	for _, notification := range sent {
+		byUserID[notification.UserID] = notification
+	}
+	for _, userID := range []uuid.UUID{sharedUser.ID, groupMember.ID} {
+		notification := byUserID[userID]
+		require.NotNil(t, notification)
+		require.Equal(t, firstUser.UserID.String(), notification.CreatedBy)
+		require.Equal(t, map[string]string{
+			"chat_id":    chat.ID.String(),
+			"chat_title": chat.Title,
+			"initiator":  coderdtest.FirstUserParams.Username,
+		}, notification.Labels)
+		require.Equal(t, []uuid.UUID{chat.ID}, notification.Targets)
+	}
 
 	acl, err := client.GetChatACL(ctx, chat.ID)
 	require.NoError(t, err)

--- a/coderd/inboxnotifications.go
+++ b/coderd/inboxnotifications.go
@@ -57,6 +57,7 @@ var fallbackIcons = map[uuid.UUID]string{
 
 	// chat related notifications
 	notifications.TemplateChatAutoArchiveDigest: codersdk.InboxNotificationFallbackIconOther,
+	notifications.TemplateChatShared:            codersdk.InboxNotificationFallbackIconOther,
 }
 
 func ensureNotificationIcon(notif codersdk.InboxNotification) codersdk.InboxNotification {

--- a/coderd/inboxnotifications_internal_test.go
+++ b/coderd/inboxnotifications_internal_test.go
@@ -23,6 +23,7 @@ func TestInboxNotifications_ensureNotificationIcon(t *testing.T) {
 		{"WorkspaceCreated", "", notifications.TemplateWorkspaceCreated, codersdk.InboxNotificationFallbackIconWorkspace},
 		{"UserAccountCreated", "", notifications.TemplateUserAccountCreated, codersdk.InboxNotificationFallbackIconAccount},
 		{"TemplateDeleted", "", notifications.TemplateTemplateDeleted, codersdk.InboxNotificationFallbackIconTemplate},
+		{"ChatShared", "", notifications.TemplateChatShared, codersdk.InboxNotificationFallbackIconOther},
 		{"TestNotification", "", notifications.TemplateTestNotification, codersdk.InboxNotificationFallbackIconOther},
 		{"TestExistingIcon", "https://cdn.coder.com/icon_notif.png", notifications.TemplateTemplateDeleted, "https://cdn.coder.com/icon_notif.png"},
 		{"UnknownTemplate", "", uuid.New(), codersdk.InboxNotificationFallbackIconOther},

--- a/coderd/notifications/events.go
+++ b/coderd/notifications/events.go
@@ -66,4 +66,5 @@ var (
 // Chat-related events.
 var (
 	TemplateChatAutoArchiveDigest = uuid.MustParse("764031be-4863-4220-867b-6ce1a1b7a5f5")
+	TemplateChatShared            = uuid.MustParse("b789bd75-d7c6-4cab-9757-1147ab184903")
 )

--- a/coderd/notifications/notifications_test.go
+++ b/coderd/notifications/notifications_test.go
@@ -1333,6 +1333,21 @@ func TestNotificationTemplates_Golden(t *testing.T) {
 			},
 		},
 		{
+			name: "TemplateChatShared",
+			id:   notifications.TemplateChatShared,
+			payload: types.MessagePayload{
+				UserName:     "Bobby",
+				UserEmail:    "bobby@coder.com",
+				UserUsername: "bobby",
+				Labels: map[string]string{
+					"chat_id":    "00000000-0000-0000-0000-000000000001",
+					"chat_title": "Onboarding kickoff",
+					"initiator":  "alice",
+				},
+				Data: map[string]any{},
+			},
+		},
+		{
 			// Default branch: multiple visible chats, retention enabled,
 			// no overflow. Body phrasing is number-neutral so this also
 			// covers the n>1 grammar shape without a dedicated branch in

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateChatShared.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateChatShared.html.golden
@@ -1,0 +1,78 @@
+From: system@coder.com
+To: bobby@coder.com
+Subject: alice shared a chat with you
+Message-Id: 02ee4935-73be-4fa1-a290-ff9999026b13@blush-whale-48
+Date: Fri, 11 Oct 2024 09:03:06 +0000
+Content-Type: multipart/alternative;  boundary=bbe61b741255b6098bb6b3c1f41b885773df633cb18d2a3002b68e4bc9c4
+MIME-Version: 1.0
+
+--bbe61b741255b6098bb6b3c1f41b885773df633cb18d2a3002b68e4bc9c4
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain; charset=UTF-8
+
+Hi Bobby,
+
+alice shared the chat Onboarding kickoff with you.
+
+
+View chat: http://test.com/agents/00000000-0000-0000-0000-000000000001
+
+--bbe61b741255b6098bb6b3c1f41b885773df633cb18d2a3002b68e4bc9c4
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/html; charset=UTF-8
+
+<!doctype html>
+<html lang=3D"en">
+  <head>
+    <meta charset=3D"UTF-8" />
+    <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
+=3D1.0" />
+    <title>alice shared a chat with you</title>
+  </head>
+  <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
+ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
+l', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif; color: #020617=
+; background: #f8fafc;">
+    <div style=3D"max-width: 600px; margin: 20px auto; padding: 60px; borde=
+r: 1px solid #e2e8f0; border-radius: 8px; background-color: #fff; text-alig=
+n: left; font-size: 14px; line-height: 1.5;">
+      <div style=3D"text-align: center;">
+        <img src=3D"https://coder.com/coder-logo-horizontal.png" alt=3D"Cod=
+er Logo" style=3D"height: 40px;" />
+      </div>
+      <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
+argin: 8px 0 32px; line-height: 1.5;">
+        alice shared a chat with you
+      </h1>
+      <div style=3D"line-height: 1.5;">
+        <p>Hi Bobby,</p>
+        <p>alice shared the chat <strong>Onboarding kickoff</strong> with y=
+ou.</p>
+      </div>
+      <div style=3D"text-align: center; margin-top: 32px;">
+       =20
+        <a href=3D"http://test.com/agents/00000000-0000-0000-0000-000000000=
+001" style=3D"display: inline-block; padding: 13px 24px; background-color: =
+#020617; color: #f8fafc; text-decoration: none; border-radius: 8px; margin:=
+ 0 4px;">
+          View chat
+        </a>
+       =20
+      </div>
+      <div style=3D"border-top: 1px solid #e2e8f0; color: #475569; font-siz=
+e: 12px; margin-top: 64px; padding-top: 24px; line-height: 1.6;">
+        <p>&copy;&nbsp;2024&nbsp;Coder. All rights reserved&nbsp;-&nbsp;<a =
+href=3D"http://test.com" style=3D"color: #2563eb; text-decoration: none;">h=
+ttp://test.com</a></p>
+        <p><a href=3D"http://test.com/settings/notifications" style=3D"colo=
+r: #2563eb; text-decoration: none;">Click here to manage your notification =
+settings</a></p>
+        <p><a href=3D"http://test.com/settings/notifications?disabled=3Db78=
+9bd75-d7c6-4cab-9757-1147ab184903" style=3D"color: #2563eb; text-decoration=
+: none;">Stop receiving emails like this</a></p>
+      </div>
+    </div>
+  </body>
+</html>
+
+--bbe61b741255b6098bb6b3c1f41b885773df633cb18d2a3002b68e4bc9c4--

--- a/coderd/notifications/testdata/rendered-templates/webhook/TemplateChatShared.json.golden
+++ b/coderd/notifications/testdata/rendered-templates/webhook/TemplateChatShared.json.golden
@@ -1,0 +1,30 @@
+{
+  "_version": "1.1",
+  "msg_id": "00000000-0000-0000-0000-000000000000",
+  "payload": {
+    "_version": "1.2",
+    "notification_name": "Chat Shared",
+    "notification_template_id": "00000000-0000-0000-0000-000000000000",
+    "user_id": "00000000-0000-0000-0000-000000000000",
+    "user_email": "bobby@coder.com",
+    "user_name": "Bobby",
+    "user_username": "bobby",
+    "actions": [
+      {
+        "label": "View chat",
+        "url": "http://test.com/agents/00000000-0000-0000-0000-000000000000"
+      }
+    ],
+    "labels": {
+      "chat_id": "00000000-0000-0000-0000-000000000000",
+      "chat_title": "Onboarding kickoff",
+      "initiator": "alice"
+    },
+    "data": {},
+    "targets": null
+  },
+  "title": "alice shared a chat with you",
+  "title_markdown": "alice shared a chat with you",
+  "body": "alice shared the chat Onboarding kickoff with you.",
+  "body_markdown": "alice shared the chat **Onboarding kickoff** with you."
+}


### PR DESCRIPTION
Adds a system notification template for chats shared through chat ACL updates.

When a chat is shared with users or groups, coderd now enqueues chat share notifications after the ACL update succeeds. The notification links recipients to `/agents/{chatID}` and includes inbox fallback and golden coverage.

> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood
