### PR TITLE
fix(provisioner/terraform/testdata): make provider version check work with BSD sed

### DIFF
--- a/provisioner/terraform/testdata/generate.sh
+++ b/provisioner/terraform/testdata/generate.sh
@@ -131,7 +131,12 @@ fi
 # Verify that the canonical lockfile matches provider-version.txt.
 if [[ " $* " == *" --check "* ]]; then
 	expected="$(<"$scriptdir/provider-version.txt")"
-	actual="$(sed -n '/coder\/coder/,/^}/{ /version[[:space:]]*=/{ s/.*"\(.*\)"/\1/; p; q; } }' "$canonical_lock")"
+	# Two sed passes instead of nested brace blocks, which BSD sed
+	# rejects. A failing check here makes `make gen` regenerate all
+	# fixtures, which is not reproducible on macOS hosts.
+	actual="$(sed -n '/coder\/coder/,/^}/p' "$canonical_lock" |
+		sed -n 's/.*version[[:space:]]*=[[:space:]]*"\(.*\)".*/\1/p' |
+		head -n 1)"
 	if [[ "$expected" == "$actual" ]]; then
 		exit 0
 	else

--- a/provisioner/terraform/testdata/generate.sh
+++ b/provisioner/terraform/testdata/generate.sh
@@ -79,6 +79,15 @@ minimize_diff() {
 	done
 }
 
+# Extract the coder/coder provider version from the given lockfile.
+# Two sed passes instead of nested brace blocks; BSD sed rejects
+# them and would silently return an empty string on macOS.
+extract_provider_version() {
+	sed -n '/coder\/coder/,/^}/p' "$1" |
+		sed -n 's/.*version[[:space:]]*=[[:space:]]*"\(.*\)".*/\1/p' |
+		head -n 1
+}
+
 run() {
 	d="$1"
 	cd "$d"
@@ -131,12 +140,7 @@ fi
 # Verify that the canonical lockfile matches provider-version.txt.
 if [[ " $* " == *" --check "* ]]; then
 	expected="$(<"$scriptdir/provider-version.txt")"
-	# Two sed passes instead of nested brace blocks, which BSD sed
-	# rejects. A failing check here makes `make gen` regenerate all
-	# fixtures, which is not reproducible on macOS hosts.
-	actual="$(sed -n '/coder\/coder/,/^}/p' "$canonical_lock" |
-		sed -n 's/.*version[[:space:]]*=[[:space:]]*"\(.*\)".*/\1/p' |
-		head -n 1)"
+	actual="$(extract_provider_version "$canonical_lock")"
 	if [[ "$expected" == "$actual" ]]; then
 		exit 0
 	else
@@ -200,12 +204,7 @@ if ((upgrade)); then
 	fi
 	if [[ -n "$src" ]]; then
 		cp "$src" "$canonical_lock"
-		# Two sed passes instead of nested brace blocks, which BSD sed
-		# rejects. Otherwise $version would be empty on macOS hosts and
-		# blank out provider-version.txt.
-		version="$(sed -n '/coder\/coder/,/^}/p' "$canonical_lock" |
-			sed -n 's/.*version[[:space:]]*=[[:space:]]*"\(.*\)".*/\1/p' |
-			head -n 1)"
+		version="$(extract_provider_version "$canonical_lock")"
 		echo "$version" >"$scriptdir/provider-version.txt"
 		echo "== Updated canonical lockfile and provider-version.txt (coder provider $version)"
 	fi

--- a/provisioner/terraform/testdata/generate.sh
+++ b/provisioner/terraform/testdata/generate.sh
@@ -200,7 +200,12 @@ if ((upgrade)); then
 	fi
 	if [[ -n "$src" ]]; then
 		cp "$src" "$canonical_lock"
-		version="$(sed -n '/coder\/coder/,/^}/{ /version[[:space:]]*=/{ s/.*"\(.*\)"/\1/; p; q; } }' "$canonical_lock")"
+		# Two sed passes instead of nested brace blocks, which BSD sed
+		# rejects. Otherwise $version would be empty on macOS hosts and
+		# blank out provider-version.txt.
+		version="$(sed -n '/coder\/coder/,/^}/p' "$canonical_lock" |
+			sed -n 's/.*version[[:space:]]*=[[:space:]]*"\(.*\)".*/\1/p' |
+			head -n 1)"
 		echo "$version" >"$scriptdir/provider-version.txt"
 		echo "== Updated canonical lockfile and provider-version.txt (coder provider $version)"
 	fi


### PR DESCRIPTION
The provider version check in `generate.sh --check` uses nested sed brace blocks that BSD sed rejects ("extra characters at the end of } command"), so the check always fails on stock macOS. A failing check makes `make gen` (and therefore the full pre-commit hook) regenerate every terraform fixture, which is not reproducible on macOS hosts because the `coder_provisioner` data source records the host `os`/`arch` (`darwin`/`arm64` instead of the committed `linux`/`amd64`), leaving permanent unstaged churn that fails `check-unstaged`.

Replace the nested-brace expression with two simple sed passes that behave identically under GNU and BSD sed. Verified on macOS (`/usr/bin/sed`) and GNU sed: both extract `2.15.0`, matching `provider-version.txt`, and `generate.sh --check` now exits 0 on a clean checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)