### PR TITLE
fix(docs/about/contributing): repoint dead docs-backend-contrib-guide refs to main (DOCS-350)

### DIFF
--- a/docs/about/contributing/backend.md
+++ b/docs/about/contributing/backend.md
@@ -50,7 +50,7 @@ Coder's backend is built using a collection of robust, modern Go libraries and i
 The Coder backend is organized into multiple packages and directories, each with a specific purpose. Here's a high-level overview of the most important ones:
 
 * [agent](https://github.com/coder/coder/tree/main/agent): core logic of a workspace agent, supports DevContainers, remote SSH, startup/shutdown script execution. Protobuf definitions for DRPC communication with `coderd` are kept in [proto](https://github.com/coder/coder/tree/main/agent/proto).
-* [cli](https://github.com/coder/coder/tree/main/cli): CLI interface for `coder` command built on [coder/serpent](https://github.com/coder/serpent). Input controls are defined in [cliui](https://github.com/coder/coder/tree/docs-backend-contrib-guide/cli/cliui), and [testdata](https://github.com/coder/coder/tree/docs-backend-contrib-guide/cli/testdata) contains golden files for common CLI calls
+* [cli](https://github.com/coder/coder/tree/main/cli): CLI interface for `coder` command built on [coder/serpent](https://github.com/coder/serpent). Input controls are defined in [cliui](https://github.com/coder/coder/tree/main/cli/cliui), and [testdata](https://github.com/coder/coder/tree/main/cli/testdata) contains golden files for common CLI calls
 * [cmd](https://github.com/coder/coder/tree/main/cmd): entry points for CLI and services, including `coderd`
 * [coderd](https://github.com/coder/coder/tree/main/coderd): the main API server implementation with [chi](https://github.com/go-chi/chi) endpoints
   * [audit](https://github.com/coder/coder/tree/main/coderd/audit): audit log logic, defines target resources, actions and extra fields
@@ -72,7 +72,7 @@ The Coder backend is organized into multiple packages and directories, each with
   * [dbpurge](https://github.com/coder/coder/tree/main/coderd/database/dbpurge): simple wrapper for periodic database cleanup operations
   * [migrations](https://github.com/coder/coder/tree/main/coderd/database/migrations): an ordered list of up/down database migrations, use `./create_migration.sh my_migration_name` to modify the database schema
   * [pubsub](https://github.com/coder/coder/tree/main/coderd/database/pubsub): PubSub implementation using PostgreSQL and in-memory drop-in replacement
-  * [queries](https://github.com/coder/coder/tree/main/coderd/database/queries): contains SQL files with queries, `sqlc` compiles them to [Go functions](https://github.com/coder/coder/blob/docs-backend-contrib-guide/coderd/database/queries.sql.go)
+  * [queries](https://github.com/coder/coder/tree/main/coderd/database/queries): contains SQL files with queries, `sqlc` compiles them to [Go functions](https://github.com/coder/coder/blob/main/coderd/database/queries.sql.go)
   * [sqlc.yaml](https://github.com/coder/coder/tree/main/coderd/database/sqlc.yaml): defines mappings between SQL types and custom Go structures
 * [codersdk](https://github.com/coder/coder/tree/main/codersdk): user-facing API entities used by CLI and site to communicate with `coderd` endpoints
 * [dogfood](https://github.com/coder/coder/tree/main/dogfood): Terraform definition of the dogfood cluster deployment


### PR DESCRIPTION
Closes [DOCS-350](https://linear.app/codercom/issue/DOCS-350).

## Problem

Three GitHub links in `docs/about/contributing/backend.md` are pinned to a feature branch (`docs-backend-contrib-guide`) that no longer exists in this repo. All three return HTTP 404 on github.com today.

| File:line | Link text | Bad URL |
|---|---|---|
| `docs/about/contributing/backend.md:53` | `cliui` | `https://github.com/coder/coder/tree/docs-backend-contrib-guide/cli/cliui` |
| `docs/about/contributing/backend.md:53` | `testdata` | `https://github.com/coder/coder/tree/docs-backend-contrib-guide/cli/testdata` |
| `docs/about/contributing/backend.md:75` | `Go functions` | `https://github.com/coder/coder/blob/docs-backend-contrib-guide/coderd/database/queries.sql.go` |

## Fix

Repoint each URL's branch segment to `main`. All three targets exist on `main` unchanged.

## Verification

```
$ curl -fsS -o /dev/null -w '%{http_code}\n' https://github.com/coder/coder/tree/main/cli/cliui
200
$ curl -fsS -o /dev/null -w '%{http_code}\n' https://github.com/coder/coder/tree/main/cli/testdata
200
$ curl -fsS -o /dev/null -w '%{http_code}\n' https://github.com/coder/coder/blob/main/coderd/database/queries.sql.go
200
```

## Not triggering `/coder-agents-review`

Docs-only edit; per `AGENTS.md` the bot review is reserved for product/CI changes.

## Future-state note

These three URLs are absolute `(blob|tree)/main` references. They will eventually be flipped to relative paths by [DOCS-351](https://linear.app/codercom/issue/DOCS-351) once the coder.com rewriter classifier fix ([DOCS-349](https://linear.app/codercom/issue/DOCS-349)) ships. Repointing to `main` here is the right interim fix.

---

*Generated by Coder Agents on @nickvigilante's behalf.*