### PR TITLE
ci: capture PostgreSQL logs in the gen job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -342,6 +342,9 @@ jobs:
       - name: Install Go mise tools
         run: ./.github/scripts/retry.sh -- mise install --locked go:storj.io/drpc/cmd/protoc-gen-go-drpc go:github.com/coder/sqlc/cmd/sqlc
 
+      - name: Start PostgreSQL container
+        run: make test-postgres-docker
+
       - name: make gen
         timeout-minutes: 8
         run: |
@@ -354,6 +357,17 @@ jobs:
 
       - name: Check for unstaged files
         run: ./scripts/check_unstaged.sh
+
+      - name: Collect PostgreSQL logs
+        if: always()
+        run: make test-postgres-docker-logs > postgres.log 2>&1
+
+      - name: Upload PostgreSQL logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gen-postgres-logs
+          path: postgres.log
 
   fmt:
     needs: changes

--- a/Makefile
+++ b/Makefile
@@ -1598,6 +1598,15 @@ test-postgres-docker:
 	done
 .PHONY: test-postgres-docker
 
+# test-postgres-docker-logs prints the PostgreSQL container's logs. The
+# postgres image logs to stderr (no logging_collector), which Docker captures,
+# so combined with log_statement=all in test-postgres-docker these logs include
+# every executed statement. Redirect to a file to save them, e.g.
+# `make test-postgres-docker-logs > postgres.log`.
+test-postgres-docker-logs:
+	docker logs test-postgres-docker-${POSTGRES_VERSION}
+.PHONY: test-postgres-docker-logs
+
 test-tailnet-integration:
 	env \
 		CODER_TAILNET_TESTS=true \


### PR DESCRIPTION
Adds a `test-postgres-docker-logs` Make target that dumps the test PostgreSQL container's logs via `docker logs`. The container already logs every statement to stderr (`log_statement=all`, no `logging_collector`), so Docker captures them and no volume mounting or reconfiguration is needed.

The CI `gen` job now starts the container with `make test-postgres-docker` before `make gen`, collects the logs at the end (always, even on failure), and uploads them as the `gen-postgres-logs` artifact to help debug generation issues that depend on the database.

Refs: https://github.com/coder/internal/issues/1568

<sub>Opened by Coder Agents on behalf of @spikecurtis.</sub>
