### PR TITLE
fix: fix `playwright install` on ubuntu 26.04

### DIFF
--- a/dogfood/coder/ubuntu-26.04/Dockerfile.base
+++ b/dogfood/coder/ubuntu-26.04/Dockerfile.base
@@ -277,3 +277,6 @@ ENV GOPRIVATE="coder.com,cdr.dev,go.coder.com,github.com/cdr,github.com/coder"
 
 # Increase memory allocation to NodeJS
 ENV NODE_OPTIONS="--max-old-space-size=8192"
+
+# This should be removed when we can upgrade to Playwright 1.61.
+ENV PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-x64


### PR DESCRIPTION
<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->

<img width="683" height="65" alt="Screenshot 2026-06-12 at 3 04 50 PM" src="https://github.com/user-attachments/assets/61781734-0178-493f-b89e-8d91bb0df934" />

I've been using the Ubuntu 26.04 image pretty seamlessly for the last month, except that my workspace is always labeled as unhealthy because `playwright install` fails during one of the startup scripts. I was hoping Playwright would be quick to release a proper patch but they seem to be dragging their feet. This fixes things in the meantime.