### PR TITLE
fix(coderd/x/chatd): enable Anthropic prompt caching for Bedrock-served models

### DIFF
--- a/coderd/x/chatd/chatloop/chatloop.go
+++ b/coderd/x/chatd/chatloop/chatloop.go
@@ -1385,7 +1385,7 @@ func shouldApplyAnthropicPromptCaching(model fantasy.LanguageModel) bool {
 	if model == nil {
 		return false
 	}
-	return model.Provider() == fantasyanthropic.Name
+	return chatsanitize.IsAnthropicFamily(model.Provider())
 }
 
 // addAnthropicPromptCaching mutates messages in-place, setting

--- a/coderd/x/chatd/chatloop/prompt_caching_internal_test.go
+++ b/coderd/x/chatd/chatloop/prompt_caching_internal_test.go
@@ -1,0 +1,41 @@
+package chatloop
+
+import (
+	"testing"
+
+	fantasyanthropic "charm.land/fantasy/providers/anthropic"
+	fantasybedrock "charm.land/fantasy/providers/bedrock"
+
+	"github.com/coder/coder/v2/coderd/x/chatd/chattest"
+)
+
+// Regression test: Bedrock-served Claude models must get Anthropic prompt
+// caching. fantasy's bedrock provider reports Provider() == "bedrock", which a
+// strict == fantasyanthropic.Name gate wrongly excluded, so cache_control was
+// never emitted and every Bedrock chat re-billed its prefix at full price.
+func TestShouldApplyAnthropicPromptCaching(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		provider string
+		want     bool
+	}{
+		{"anthropic", fantasyanthropic.Name, true},
+		{"bedrock", fantasybedrock.Name, true},
+		{"openai", "openai", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			model := &chattest.FakeModel{ProviderName: tc.provider}
+			if got := shouldApplyAnthropicPromptCaching(model); got != tc.want {
+				t.Errorf("shouldApplyAnthropicPromptCaching(provider=%q) = %v, want %v", tc.provider, got, tc.want)
+			}
+		})
+	}
+
+	if shouldApplyAnthropicPromptCaching(nil) {
+		t.Error("shouldApplyAnthropicPromptCaching(nil) = true, want false")
+	}
+}

--- a/coderd/x/chatd/chatsanitize/anthropic.go
+++ b/coderd/x/chatd/chatsanitize/anthropic.go
@@ -7,12 +7,25 @@ import (
 
 	"charm.land/fantasy"
 	fantasyanthropic "charm.land/fantasy/providers/anthropic"
+	fantasybedrock "charm.land/fantasy/providers/bedrock"
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
 )
 
 const maxAnthropicProviderToolViolationLogDetails = 32
+
+// IsAnthropicFamily reports whether a provider speaks the Anthropic Messages
+// wire format and so needs Anthropic-specific handling (prompt caching, the
+// provider-executed tool guard, tool-history sanitization).
+//
+// fantasy's bedrock provider is the Anthropic provider wrapped with
+// WithName("bedrock"): it emits identical payloads but reports a different
+// Provider() string, so a bare == fantasyanthropic.Name check excludes it. Only
+// Anthropic models reach this provider, so matching on the id is sufficient.
+func IsAnthropicFamily(provider string) bool {
+	return provider == fantasyanthropic.Name || provider == fantasybedrock.Name
+}
 
 // Anthropic replay contract. Signed or redacted reasoning parts are preserved.
 // Provider-executed tool calls without matching results are incomplete
@@ -219,7 +232,7 @@ func AnthropicProviderToolPartsToRemove(
 	parts []fantasy.MessagePart,
 ) (map[int]struct{}, []AnthropicProviderToolHistoryViolation) {
 	remove := make(map[int]struct{})
-	if provider != fantasyanthropic.Name || len(parts) == 0 {
+	if !IsAnthropicFamily(provider) || len(parts) == 0 {
 		return remove, nil
 	}
 
@@ -246,7 +259,7 @@ func SanitizeAnthropicProviderToolHistory(
 	messages []fantasy.Message,
 ) ([]fantasy.Message, AnthropicProviderToolSanitizationStats) {
 	var stats AnthropicProviderToolSanitizationStats
-	if provider != fantasyanthropic.Name || len(messages) == 0 {
+	if !IsAnthropicFamily(provider) || len(messages) == 0 {
 		return messages, stats
 	}
 
@@ -333,7 +346,7 @@ func SanitizeAnthropicProviderToolContent(
 	content []fantasy.Content,
 ) ([]fantasy.Content, AnthropicProviderToolSanitizationStats) {
 	var stats AnthropicProviderToolSanitizationStats
-	if provider != fantasyanthropic.Name || len(content) == 0 {
+	if !IsAnthropicFamily(provider) || len(content) == 0 {
 		return content, stats
 	}
 	if contentHasAnthropicSignedReasoning(content) {
@@ -477,7 +490,7 @@ func ApplyAnthropicProviderToolGuard(
 	modelName string,
 	messages []fantasy.Message,
 ) ([]fantasy.Message, error) {
-	if provider != fantasyanthropic.Name || len(messages) == 0 {
+	if !IsAnthropicFamily(provider) || len(messages) == 0 {
 		return messages, nil
 	}
 

--- a/coderd/x/chatd/chatsanitize/anthropic_family_test.go
+++ b/coderd/x/chatd/chatsanitize/anthropic_family_test.go
@@ -1,0 +1,35 @@
+package chatsanitize_test
+
+import (
+	"testing"
+
+	fantasyanthropic "charm.land/fantasy/providers/anthropic"
+	fantasybedrock "charm.land/fantasy/providers/bedrock"
+
+	"github.com/coder/coder/v2/coderd/x/chatd/chatsanitize"
+)
+
+func TestIsAnthropicFamily(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		provider string
+		want     bool
+	}{
+		// fantasy's bedrock provider wraps Anthropic but reports "bedrock";
+		// both speak the Anthropic Messages wire format.
+		{fantasyanthropic.Name, true},
+		{fantasybedrock.Name, true},
+		{"anthropic", true},
+		{"bedrock", true},
+		{"openai", false},
+		{"google", false},
+		{"azure", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := chatsanitize.IsAnthropicFamily(tc.provider); got != tc.want {
+			t.Errorf("IsAnthropicFamily(%q) = %v, want %v", tc.provider, got, tc.want)
+		}
+	}
+}

--- a/coderd/x/chatd/chatsanitize/anthropic_test.go
+++ b/coderd/x/chatd/chatsanitize/anthropic_test.go
@@ -6,6 +6,7 @@ import (
 
 	"charm.land/fantasy"
 	fantasyanthropic "charm.land/fantasy/providers/anthropic"
+	fantasybedrock "charm.land/fantasy/providers/bedrock"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
@@ -318,6 +319,25 @@ func TestSanitizeAnthropicProviderToolHistory(t *testing.T) {
 		{
 			name:     "removes unpaired call and keeps text",
 			provider: fantasyanthropic.Name,
+			messages: []fantasy.Message{{
+				Role: fantasy.MessageRoleAssistant,
+				Content: []fantasy.MessagePart{
+					textPart,
+					providerCall("srvtoolu_orphan_call"),
+				},
+			}},
+			want: []fantasy.Message{{
+				Role:    fantasy.MessageRoleAssistant,
+				Content: []fantasy.MessagePart{textPart},
+			}},
+			wantRemovedCalls: 1,
+		},
+		{
+			// Regression: fantasy's bedrock provider reports Provider() ==
+			// "bedrock"; it must be sanitized identically to "anthropic".
+			// Before IsAnthropicFamily this case was skipped (call kept).
+			name:     "bedrock is treated as anthropic-family",
+			provider: fantasybedrock.Name,
 			messages: []fantasy.Message{{
 				Role: fantasy.MessageRoleAssistant,
 				Content: []fantasy.MessagePart{
@@ -925,7 +945,7 @@ func TestSanitizeAnthropicProviderToolHistory(t *testing.T) {
 			require.Equal(t, tc.wantRemovedResults, stats.RemovedToolResults)
 			require.Equal(t, tc.wantDropped, stats.DroppedMessages)
 			require.Equal(t, tc.want, sanitized)
-			if tc.provider == fantasyanthropic.Name {
+			if chatsanitize.IsAnthropicFamily(tc.provider) {
 				require.Empty(t, chatsanitize.ValidateAnthropicProviderToolHistory(sanitized))
 			}
 		})


### PR DESCRIPTION
## Problem

chatd gates Anthropic-specific handling — prompt-cache breakpoints, the provider-executed tool guard, and tool-history sanitization — on `model.Provider() == fantasyanthropic.Name` (`"anthropic"`). fantasy's [`bedrock` provider](https://github.com/coder/fantasy/blob/a2a3f2171ec8/providers/bedrock/bedrock.go#L24-L34) is the Anthropic provider wrapped with `WithName("bedrock")`, so Bedrock-served Claude models report `Provider() == "bedrock"` and fail that check: `addAnthropicPromptCaching` never runs, no `cache_control` reaches the wire, and `usage` reports `cache_read_input_tokens == 0` on every request. The tools+system prefix re-bills at full input price on every step — the cache-read discount is never realized on Bedrock — and the provider-tool guard and sanitizer are skipped for Bedrock chats too.

## Fix

Add `chatsanitize.IsAnthropicFamily(provider)` (true for both `anthropic` and `bedrock`) and use it at the caching gate and the four guard/sanitizer checks. Matching on the provider id is sufficient: fantasy's bedrock provider can only serve Anthropic models — a non-Anthropic Bedrock model would arrive through a different provider with a different `Name`.

## Verification

Built a server with this patch and exercised it end-to-end: cache reads go from `0` → the full prefix on the second turn, and coder's linters + the affected-package tests are clean.

<details>
<summary>End-to-end — real API + real Bedrock</summary>

Drove a 2-turn chat through the real `POST /api/experimental/chats` + `/{id}/messages` endpoints on a build with this patch (fantasy bedrock provider, Claude Opus), reading `usage` from each assistant message. Before this change both turns report `cache_creation_input_tokens = 0` and `cache_read_input_tokens = 0`. After:

| turn | input_tokens | cache_creation_input_tokens | cache_read_input_tokens |
|------|-------------:|----------------------------:|------------------------:|
| 1    | 2            | 9773                        | 0                       |
| 2    | 2            | 27                          | 9773                    |

Turn 1 writes the tools+system prefix; turn 2 reads it back at the cache-read rate.
</details>

<details>
<summary>Lint + tests — coder's pinned toolchain (go 1.26.4, golangci-lint v1.64.8)</summary>

```
$ golangci-lint run ./coderd/x/chatd/chatloop/... ./coderd/x/chatd/chatsanitize/...      # clean
$ paralleltestctx -custom-funcs="testutil.Context,chatdTestContext" ./coderd/x/chatd/... # clean
$ go run ./scripts/intxcheck ./coderd/x/chatd/...                                        # clean
$ typos <changed files>                                                                  # clean
$ go test ./coderd/x/chatd/chatsanitize/... ./coderd/x/chatd/chatloop/...
ok  github.com/coder/coder/v2/coderd/x/chatd/chatsanitize
ok  github.com/coder/coder/v2/coderd/x/chatd/chatloop
```

Tests added: the `IsAnthropicFamily` predicate, the caching gate for a `bedrock`-provider model, and a `chatsanitize` table case proving the sanitizer now runs for `bedrock` (the case fails on `main`). The existing "leaves other providers unchanged" case still passes, confirming non-Anthropic providers stay excluded.

`make gen` / frontend / proto are no-ops for this change — no generated, TypeScript, or proto files are touched.
</details>

## AI disclosure

Authored primarily with AI assistance (Claude), per coder's [AI contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING). I reviewed the diff, ran the checks above, and verified the runtime behavior myself; I am accountable for the contents.
