### PR TITLE
fix(site): truncate devcontainer name with ellipsis at all screen sizes

### DIFF
--- a/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
@@ -137,6 +137,20 @@ export const NoContainerOrAgentOrName: Story = {
 	},
 };
 
+export const NoContainerOrAgentOrNameWithLongConfigPath: Story = {
+	args: {
+		devcontainer: {
+			...MockWorkspaceAgentDevcontainer,
+			config_path:
+				"/home/coder/repos/coder/coder/.claude/worktrees/i-waited-for-some-things-and-i-got-some-banana-bread-at-work-today-dude/.devcontainer/devcontainer.json",
+			container: undefined,
+			agent: undefined,
+			name: "",
+		},
+		subAgents: [],
+	},
+};
+
 export const NoSubAgent: Story = {
 	args: {
 		devcontainer: {

--- a/site/src/modules/resources/AgentDevcontainerCard.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.tsx
@@ -204,7 +204,7 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 				gap-6 px-4 pl-8 leading-6
 				md:gap-4"
 			>
-				<div className="flex-1 min-w-[284px] flex items-center gap-6 text-xs text-content-secondary">
+				<div className="min-w-[284px] flex items-center gap-6 text-xs text-content-secondary">
 					<div className="flex items-center gap-4 w-full">
 						<DevcontainerStatus
 							devcontainer={devcontainer}

--- a/site/src/modules/resources/AgentDevcontainerCard.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.tsx
@@ -200,11 +200,11 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 				)}
 			</div>
 			<header
-				className="flex items-center justify-between
+				className="flex items-center justify-between flex-wrap
 				gap-6 px-4 pl-8 leading-6
 				md:gap-4"
 			>
-				<div className="flex-1 min-w-0 flex items-center gap-6 text-xs text-content-secondary">
+				<div className="flex-1 min-w-[284px] flex items-center gap-6 text-xs text-content-secondary">
 					<div className="flex items-center gap-4 w-full">
 						<DevcontainerStatus
 							devcontainer={devcontainer}

--- a/site/src/modules/resources/AgentDevcontainerCard.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.tsx
@@ -200,22 +200,21 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 				)}
 			</div>
 			<header
-				className="flex items-center justify-between flex-wrap
+				className="flex items-center justify-between
 				gap-6 px-4 pl-8 leading-6
 				md:gap-4"
 			>
-				<div className="flex items-center gap-6 text-xs text-content-secondary">
-					<div className="flex items-center gap-4 md:w-full">
+				<div className="flex-1 min-w-0 flex items-center gap-6 text-xs text-content-secondary">
+					<div className="flex items-center gap-4 w-full">
 						<DevcontainerStatus
 							devcontainer={devcontainer}
 							parentAgent={parentAgent}
 							agent={subAgent}
 						/>
 						<span
-							className="max-w-xs shrink-0
+							className="flex-1 shrink-0
 							overflow-hidden text-ellipsis whitespace-nowrap
-							text-sm font-semibold text-content-primary
-							md:overflow-visible"
+							text-sm font-semibold text-content-primary"
 						>
 							{subAgent?.name ??
 								(devcontainer.name || devcontainer.config_path)}


### PR DESCRIPTION
ref DEVEX-449

## before

In `AgentDevcontainerCard`, the devcontainer's display name truncated with an ellipsis--but only when the viewport is <768px (parent has `md:w-full`), which is also when the display name width gets capped at 320px (`max-w-xs`). At larger screen sizes, the display name overlaps with the rebuild button to the right.

https://github.com/user-attachments/assets/47af30a2-f446-4b5f-bf63-24afb0532b19

## after

Now, the devcontainer display name fills up as much width as possible at all screen sizes (not just >=768px), and it also gets truncated with an ellipsis at all screen sizes.

https://github.com/user-attachments/assets/68579438-6fb5-40ea-93cf-c3814dfaac1a

---

(If we have a way to automate resizing screens in Storybook, lmk!)

The trick is to set a `min-width` on the text we want to truncate, see this CSS Tricks article: https://css-tricks.com/flexbox-truncated-text/

I changed `max-w-xs` to `min-w-[284px]`. In addition to constraining the display name's width (see "before" above), the `max-width` caused the rebuild button to wrap to the next line if the screen is too narrow to show the display name at that width. This behavior on small screens is preserved. 🙂 However, since the display name's width isn't constrained anymore, it's written out fully if possible, which causes the rebuild button to wrap lines on wider screens if the display name is very long.