### PR TITLE
fix: add Gemini/Google provider support to AI Bridge session page

### DIFF
--- a/coderd/x/chatd/chatprovider/chatprovider.go
+++ b/coderd/x/chatd/chatprovider/chatprovider.go
@@ -655,6 +655,9 @@ func ResolveModelWithProviderHint(modelName, providerHint string) (provider stri
 	if isChatModelForProvider(fantasyopenai.Name, normalized) {
 		return fantasyopenai.Name, modelName, nil
 	}
+	if isChatModelForProvider(fantasygoogle.Name, normalized) {
+		return fantasygoogle.Name, modelName, nil
+	}
 
 	return "", "", xerrors.Errorf("unknown model %q", modelName)
 }

--- a/coderd/x/chatd/chatprovider/chatprovider_test.go
+++ b/coderd/x/chatd/chatprovider/chatprovider_test.go
@@ -11,6 +11,7 @@ import (
 	"charm.land/fantasy"
 	fantasyanthropic "charm.land/fantasy/providers/anthropic"
 	fantasybedrock "charm.land/fantasy/providers/bedrock"
+	fantasygoogle "charm.land/fantasy/providers/google"
 	fantasyopenai "charm.land/fantasy/providers/openai"
 	fantasyopenaicompat "charm.land/fantasy/providers/openaicompat"
 	fantasyopenrouter "charm.land/fantasy/providers/openrouter"
@@ -1621,6 +1622,34 @@ func TestResolveModelWithProviderHint(t *testing.T) {
 			providerHint: fantasyvercel.Name,
 			wantProvider: fantasyvercel.Name,
 			wantModel:    "claude-4-5-sonnet",
+		},
+		{
+			name:         "BareGeminiModelResolvesToGoogle",
+			modelName:    "gemini-3.5-flash",
+			providerHint: "",
+			wantProvider: fantasygoogle.Name,
+			wantModel:    "gemini-3.5-flash",
+		},
+		{
+			name:         "BareGemmaModelResolvesToGoogle",
+			modelName:    "gemma-3-27b",
+			providerHint: "",
+			wantProvider: fantasygoogle.Name,
+			wantModel:    "gemma-3-27b",
+		},
+		{
+			name:         "GoogleHintWithGeminiModel",
+			modelName:    "gemini-2.5-pro",
+			providerHint: fantasygoogle.Name,
+			wantProvider: fantasygoogle.Name,
+			wantModel:    "gemini-2.5-pro",
+		},
+		{
+			name:         "CanonicalGoogleRefResolvesToGoogle",
+			modelName:    "google/gemini-3.5-flash",
+			providerHint: "",
+			wantProvider: fantasygoogle.Name,
+			wantModel:    "gemini-3.5-flash",
 		},
 	}
 

--- a/site/src/pages/AIBridgePage/icons/AIBridgeModelIcon.tsx
+++ b/site/src/pages/AIBridgePage/icons/AIBridgeModelIcon.tsx
@@ -6,6 +6,7 @@ import { cn } from "#/utils/cn";
 // See official model naming docs:
 // - Anthropic: https://docs.anthropic.com/en/docs/about-claude/models/all-models
 // - OpenAI: https://platform.openai.com/docs/models
+// - Google: https://ai.google.dev/gemini-api/docs/models
 function inferModelFamily(model: string): string {
 	const modelFamily = model.toLowerCase();
 	// Anthropic model families
@@ -27,6 +28,10 @@ function inferModelFamily(model: string): string {
 		modelFamily.includes("whisper")
 	) {
 		return "openai";
+	}
+	// Google model families (gemini-*, gemma-*)
+	if (modelFamily.includes("gemini") || modelFamily.includes("gemma")) {
+		return "gemini";
 	}
 	return "unknown";
 }
@@ -52,6 +57,13 @@ export const AIBridgeModelIcon = ({
 			return (
 				<ExternalImage
 					src="/icon/openai.svg"
+					className={cn(iconClassName, className)}
+				/>
+			);
+		case "gemini":
+			return (
+				<ExternalImage
+					src="/icon/gemini.svg"
 					className={cn(iconClassName, className)}
 				/>
 			);

--- a/site/src/pages/AIBridgePage/icons/AIBridgeProviderIcon.tsx
+++ b/site/src/pages/AIBridgePage/icons/AIBridgeProviderIcon.tsx
@@ -25,10 +25,38 @@ export const AIBridgeProviderIcon = ({
 					className={cn(iconClassName, className)}
 				/>
 			);
+		case "google":
+			return (
+				<ExternalImage
+					src="/icon/google.svg"
+					className={cn(iconClassName, className)}
+				/>
+			);
+		case "azure":
+			return (
+				<ExternalImage
+					src="/icon/azure.svg"
+					className={cn(iconClassName, className)}
+				/>
+			);
+		case "bedrock":
+			return (
+				<ExternalImage
+					src="/icon/aws.svg"
+					className={cn(iconClassName, className)}
+				/>
+			);
 		case "copilot":
 			return (
 				<ExternalImage
 					src="/icon/github.svg"
+					className={cn(iconClassName, className)}
+				/>
+			);
+		case "vercel":
+			return (
+				<ExternalImage
+					src="/icon/vercel.svg"
 					className={cn(iconClassName, className)}
 				/>
 			);

--- a/site/src/pages/AIBridgePage/utils.test.ts
+++ b/site/src/pages/AIBridgePage/utils.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { getProviderDisplayName } from "./utils";
+
+describe("getProviderDisplayName", () => {
+	it.each([
+		["anthropic", "Anthropic"],
+		["openai", "OpenAI"],
+		["google", "Google"],
+		["azure", "Azure OpenAI"],
+		["bedrock", "AWS Bedrock"],
+		["copilot", "GitHub Copilot"],
+		["openai-compat", "OpenAI-compatible"],
+		["openrouter", "OpenRouter"],
+		["vercel", "Vercel"],
+	])("maps known provider %s to %s", (input, expected) => {
+		expect(getProviderDisplayName(input)).toBe(expected);
+	});
+
+	it("capitalizes unknown provider names", () => {
+		expect(getProviderDisplayName("custom")).toBe("Custom");
+		expect(getProviderDisplayName("some-provider")).toBe("Some-provider");
+	});
+
+	it("returns Unknown for empty string", () => {
+		expect(getProviderDisplayName("")).toBe("Unknown");
+	});
+});

--- a/site/src/pages/AIBridgePage/utils.ts
+++ b/site/src/pages/AIBridgePage/utils.ts
@@ -32,7 +32,11 @@ export const getProviderDisplayName = (provider: string) => {
 			return "OpenRouter";
 		case "vercel":
 			return "Vercel";
-		default:
-			return provider || "Unknown";
+		default: {
+			if (!provider) {
+				return "Unknown";
+			}
+			return provider.charAt(0).toUpperCase() + provider.slice(1);
+		}
 	}
 };

--- a/site/src/pages/AIBridgePage/utils.ts
+++ b/site/src/pages/AIBridgePage/utils.ts
@@ -18,9 +18,21 @@ export const getProviderDisplayName = (provider: string) => {
 			return "Anthropic";
 		case "openai":
 			return "OpenAI";
+		case "google":
+			return "Google";
+		case "azure":
+			return "Azure OpenAI";
+		case "bedrock":
+			return "AWS Bedrock";
 		case "copilot":
-			return "Github";
+			return "GitHub Copilot";
+		case "openai-compat":
+			return "OpenAI-compatible";
+		case "openrouter":
+			return "OpenRouter";
+		case "vercel":
+			return "Vercel";
 		default:
-			return "Unknown";
+			return provider || "Unknown";
 	}
 };


### PR DESCRIPTION
The AI Bridge session summary page only recognized three providers (Anthropic, OpenAI, Copilot). Gemini models showed a wrong provider label and a placeholder icon instead of the Gemini logo.

**Frontend**: extend provider display names, icons, and model family inference across AIBridgePage components to cover Google, Azure, Bedrock, Vercel, and OpenRouter, matching the coverage already present in AISettingsPage and AgentsPage.

**Backend**: add Google to the prefix-based fallback in `ResolveModelWithProviderHint` so bare `gemini-*`/`gemma-*` model names resolve without an explicit provider hint.

Closes https://github.com/coder/internal/issues/1576

> Generated by Coder Agents on behalf of @mtojek