### PR TITLE
feat: add group AI budget management UI

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2265,6 +2265,30 @@ class ApiMethods {
 		await this.axios.delete(`/api/v2/groups/${groupId}`);
 	};
 
+	getGroupAIBudget = async (
+		groupId: string,
+	): Promise<TypesGen.GroupAIBudget> => {
+		const response = await this.axios.get(
+			`/api/v2/groups/${groupId}/ai/budget`,
+		);
+		return response.data;
+	};
+
+	upsertGroupAIBudget = async (
+		groupId: string,
+		data: TypesGen.UpsertGroupAIBudgetRequest,
+	): Promise<TypesGen.GroupAIBudget> => {
+		const response = await this.axios.put(
+			`/api/v2/groups/${groupId}/ai/budget`,
+			data,
+		);
+		return response.data;
+	};
+
+	deleteGroupAIBudget = async (groupId: string): Promise<void> => {
+		await this.axios.delete(`/api/v2/groups/${groupId}/ai/budget`);
+	};
+
 	getWorkspaceQuota = async (
 		organizationName: string,
 		username: string,

--- a/site/src/api/queries/groups.ts
+++ b/site/src/api/queries/groups.ts
@@ -1,8 +1,10 @@
 import type { QueryClient, UseQueryOptions } from "react-query";
 import { API } from "#/api/api";
+import { isApiError } from "#/api/errors";
 import type {
 	CreateGroupRequest,
 	Group,
+	GroupAIBudget,
 	GroupMembersResponse,
 	GroupRequest,
 	PatchGroupRequest,
@@ -223,6 +225,53 @@ export const removeMember = (
 			API.removeMember(groupId, userId),
 		onSuccess: async (updatedGroup: Group) =>
 			invalidateGroup(queryClient, organization, updatedGroup.name),
+	};
+};
+
+const getGroupAIBudgetQueryKey = (groupId: string) => [
+	"group",
+	groupId,
+	"aiBudget",
+];
+
+/** Budget query; resolves to null when none is set (the GET 404s). */
+export const groupAIBudget = (
+	groupId: string,
+): UseQueryOptions<GroupAIBudget | null> => {
+	return {
+		queryKey: getGroupAIBudgetQueryKey(groupId),
+		queryFn: async () => {
+			try {
+				return await API.getGroupAIBudget(groupId);
+			} catch (error) {
+				if (isApiError(error) && error.response.status === 404) {
+					return null;
+				}
+				throw error;
+			}
+		},
+	};
+};
+
+/* Upserts the budget for a value, or deletes it (uncapped) when given null. */
+export const saveGroupAIBudget = (
+	queryClient: QueryClient,
+	groupId: string,
+) => {
+	return {
+		mutationFn: async (spendLimitMicros: number | null) => {
+			if (spendLimitMicros === null) {
+				await API.deleteGroupAIBudget(groupId);
+			} else {
+				await API.upsertGroupAIBudget(groupId, {
+					spend_limit_micros: spendLimitMicros,
+				});
+			}
+		},
+		onSuccess: async () =>
+			queryClient.invalidateQueries({
+				queryKey: getGroupAIBudgetQueryKey(groupId),
+			}),
 	};
 };
 

--- a/site/src/pages/GroupsPage/GroupSettingsPage.tsx
+++ b/site/src/pages/GroupsPage/GroupSettingsPage.tsx
@@ -10,12 +10,12 @@ import {
 } from "#/api/queries/groups";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Spinner } from "#/components/Spinner/Spinner";
+import { useDashboard } from "#/modules/dashboard/useDashboard";
 import { useFeatureVisibility } from "#/modules/dashboard/useFeatureVisibility";
 import { dollarsToMicros, microsToDollars } from "#/utils/currency";
 import type { GroupPageOutletContext } from "./GroupPage";
 import GroupSettingsPageView from "./GroupSettingsPageView";
 
-// Empty is uncapped (no budget row); otherwise the budget in micros.
 const budgetFromInput = (dollars: string): number | null =>
 	dollars.trim() === "" ? null : dollarsToMicros(dollars);
 
@@ -29,8 +29,12 @@ const GroupSettingsPage: FC = () => {
 	const patchGroupMutation = useMutation(patchGroup(queryClient, organization));
 	const navigate = useNavigate();
 
-	// Budget routes are gated on aibridge; useFeatureVisibility is {} unlicensed.
-	const aibridgeVisible = Boolean(useFeatureVisibility().aibridge);
+	const { experiments } = useDashboard();
+	// TODO(AIGOV-443): remove the ai-gateway-cost-control experiment gate once
+	// the cost-control feature is stable.
+	const aibridgeVisible =
+		Boolean(useFeatureVisibility().aibridge) &&
+		experiments.includes("ai-gateway-cost-control");
 	const budgetQuery = useQuery({
 		...groupAIBudget(groupData.id),
 		enabled: aibridgeVisible,
@@ -39,7 +43,6 @@ const GroupSettingsPage: FC = () => {
 		saveGroupAIBudget(queryClient, groupData.id),
 	);
 
-	// Load the budget before rendering so the form initializes with it.
 	if (aibridgeVisible && budgetQuery.isLoading) {
 		return (
 			<div className="flex items-center justify-center p-10">
@@ -69,20 +72,28 @@ const GroupSettingsPage: FC = () => {
 						add_users: [],
 						remove_users: [],
 					});
-
-					// Save only when the budget changed (0 disables, empty uncaps).
-					const next = budgetFromInput(monthly_budget_per_member);
-					if (aibridgeVisible && next !== currentBudgetMicros) {
-						await saveBudgetMutation.mutateAsync(next);
-					}
-
-					navigate(`/organizations/${organization}/groups/${data.name}`);
 				} catch (error) {
 					toast.error(
 						getErrorMessage(error, `Failed to update group "${groupName}".`),
 						{ description: getErrorDetail(error) },
 					);
+					return;
 				}
+
+				const next = budgetFromInput(monthly_budget_per_member);
+				if (aibridgeVisible && next !== currentBudgetMicros) {
+					try {
+						await saveBudgetMutation.mutateAsync(next);
+					} catch (error) {
+						toast.error(
+							getErrorMessage(error, "Failed to update the AI budget."),
+							{ description: getErrorDetail(error) },
+						);
+						return;
+					}
+				}
+
+				navigate(`/organizations/${organization}/groups/${data.name}`);
 			}}
 			group={groupData}
 			showAISettings={aibridgeVisible}

--- a/site/src/pages/GroupsPage/GroupSettingsPage.tsx
+++ b/site/src/pages/GroupsPage/GroupSettingsPage.tsx
@@ -1,11 +1,23 @@
 import type { FC } from "react";
-import { useMutation, useQueryClient } from "react-query";
+import { useMutation, useQuery, useQueryClient } from "react-query";
 import { useNavigate, useOutletContext, useParams } from "react-router";
 import { toast } from "sonner";
 import { getErrorDetail, getErrorMessage } from "#/api/errors";
-import { patchGroup } from "#/api/queries/groups";
+import {
+	groupAIBudget,
+	patchGroup,
+	saveGroupAIBudget,
+} from "#/api/queries/groups";
+import { ErrorAlert } from "#/components/Alert/ErrorAlert";
+import { Spinner } from "#/components/Spinner/Spinner";
+import { useFeatureVisibility } from "#/modules/dashboard/useFeatureVisibility";
+import { dollarsToMicros, microsToDollars } from "#/utils/currency";
 import type { GroupPageOutletContext } from "./GroupPage";
 import GroupSettingsPageView from "./GroupSettingsPageView";
+
+// Empty is uncapped (no budget row); otherwise the budget in micros.
+const budgetFromInput = (dollars: string): number | null =>
+	dollars.trim() === "" ? null : dollarsToMicros(dollars);
 
 const GroupSettingsPage: FC = () => {
 	const { organization = "default", groupName } = useParams() as {
@@ -17,39 +29,66 @@ const GroupSettingsPage: FC = () => {
 	const patchGroupMutation = useMutation(patchGroup(queryClient, organization));
 	const navigate = useNavigate();
 
+	// Budget routes are gated on aibridge; useFeatureVisibility is {} unlicensed.
+	const aibridgeVisible = Boolean(useFeatureVisibility().aibridge);
+	const budgetQuery = useQuery({
+		...groupAIBudget(groupData.id),
+		enabled: aibridgeVisible,
+	});
+	const saveBudgetMutation = useMutation(
+		saveGroupAIBudget(queryClient, groupData.id),
+	);
+
+	// Load the budget before rendering so the form initializes with it.
+	if (aibridgeVisible && budgetQuery.isLoading) {
+		return (
+			<div className="flex items-center justify-center p-10">
+				<Spinner loading className="size-6" />
+			</div>
+		);
+	}
+	if (aibridgeVisible && budgetQuery.error) {
+		return <ErrorAlert error={budgetQuery.error} />;
+	}
+
+	const currentBudgetMicros = budgetQuery.data?.spend_limit_micros ?? null;
+	const initialBudgetDollars =
+		currentBudgetMicros !== null ? microsToDollars(currentBudgetMicros) : null;
+	const isUpdating =
+		patchGroupMutation.isPending || saveBudgetMutation.isPending;
+
 	return (
 		<GroupSettingsPageView
 			onCancel={() => navigate("..")}
 			onSubmit={async (data) => {
-				await patchGroupMutation.mutateAsync(
-					{
+				const { monthly_budget_per_member, ...groupFields } = data;
+				try {
+					await patchGroupMutation.mutateAsync({
 						groupId: groupData.id,
-						...data,
+						...groupFields,
 						add_users: [],
 						remove_users: [],
-					},
-					{
-						onSuccess: () => {
-							navigate(`/organizations/${organization}/groups/${data.name}`);
-						},
-						onError: (error) => {
-							toast.error(
-								getErrorMessage(
-									error,
-									`Failed to update group "${groupName}".`,
-								),
-								{
-									description: getErrorDetail(error),
-								},
-							);
-						},
-					},
-				);
+					});
+
+					// Save only when the budget changed (0 disables, empty uncaps).
+					const next = budgetFromInput(monthly_budget_per_member);
+					if (aibridgeVisible && next !== currentBudgetMicros) {
+						await saveBudgetMutation.mutateAsync(next);
+					}
+
+					navigate(`/organizations/${organization}/groups/${data.name}`);
+				} catch (error) {
+					toast.error(
+						getErrorMessage(error, `Failed to update group "${groupName}".`),
+						{ description: getErrorDetail(error) },
+					);
+				}
 			}}
 			group={groupData}
+			showAISettings={aibridgeVisible}
+			initialBudgetDollars={initialBudgetDollars}
 			formErrors={undefined}
-			isLoading={false}
-			isUpdating={patchGroupMutation.isPending}
+			isUpdating={isUpdating}
 		/>
 	);
 };

--- a/site/src/pages/GroupsPage/GroupSettingsPageView.stories.tsx
+++ b/site/src/pages/GroupsPage/GroupSettingsPageView.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { action } from "storybook/actions";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import { MockGroup } from "#/testHelpers/entities";
 import GroupSettingsPageView from "./GroupSettingsPageView";
 
@@ -7,15 +7,88 @@ const meta: Meta<typeof GroupSettingsPageView> = {
 	title: "pages/OrganizationGroupsPage/GroupSettingsPageView",
 	component: GroupSettingsPageView,
 	args: {
-		onCancel: action("onCancel"),
+		onCancel: fn(),
+		onSubmit: fn(),
 		group: MockGroup,
-		isLoading: false,
+		showAISettings: false,
+		initialBudgetDollars: null,
+		formErrors: undefined,
+		isUpdating: false,
 	},
 };
 
 export default meta;
 type Story = StoryObj<typeof GroupSettingsPageView>;
 
-const Example: Story = {};
+export const Default: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// Without the AI add-on, the AI budget section is hidden.
+		await expect(canvas.queryByText("AI budget")).not.toBeInTheDocument();
+	},
+};
 
-export { Example as GroupSettingsPageView };
+export const WithAIBudget: Story = {
+	args: {
+		showAISettings: true,
+		group: { ...MockGroup, total_member_count: 7 },
+		initialBudgetDollars: 1000,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByText("AI budget")).toBeInTheDocument();
+		const helper = canvas.getByText(/month maximum/i);
+		await expect(helper).toHaveTextContent(
+			"$7,000.00/month maximum, based on 7 members.",
+		);
+	},
+};
+
+export const AIBudgetUncapped: Story = {
+	args: {
+		showAISettings: true,
+		initialBudgetDollars: null,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByText("Leave empty for uncapped spend."),
+		).toBeInTheDocument();
+	},
+};
+
+export const AIBudgetDisabled: Story = {
+	args: {
+		showAISettings: true,
+		group: { ...MockGroup, total_member_count: 7 },
+		initialBudgetDollars: 0,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// A budget of 0 is valid and reads as disabled spend.
+		const helper = canvas.getByText(/month maximum/i);
+		await expect(helper).toHaveTextContent(
+			"$0.00/month maximum, based on 7 members.",
+		);
+	},
+};
+
+export const SaveWithBudget: Story = {
+	args: {
+		showAISettings: true,
+		initialBudgetDollars: null,
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		const input = canvas.getByLabelText("Monthly budget per member (USD)");
+		await userEvent.type(input, "25");
+		await userEvent.click(canvas.getByRole("button", { name: "Save" }));
+		// onSubmit fires asynchronously with (values, formikHelpers).
+		await waitFor(() =>
+			expect(args.onSubmit).toHaveBeenCalledWith(
+				expect.objectContaining({ monthly_budget_per_member: "25" }),
+				expect.anything(),
+			),
+		);
+	},
+};

--- a/site/src/pages/GroupsPage/GroupSettingsPageView.stories.tsx
+++ b/site/src/pages/GroupsPage/GroupSettingsPageView.stories.tsx
@@ -39,7 +39,7 @@ export const WithAIBudget: Story = {
 		await expect(canvas.getByText("AI budget")).toBeInTheDocument();
 		const helper = canvas.getByText(/month maximum/i);
 		await expect(helper).toHaveTextContent(
-			"$7,000.00/month maximum, based on 7 members.",
+			"$7,000/month maximum, based on 7 members.",
 		);
 	},
 };
@@ -68,7 +68,23 @@ export const AIBudgetDisabled: Story = {
 		// A budget of 0 is valid and reads as disabled spend.
 		const helper = canvas.getByText(/month maximum/i);
 		await expect(helper).toHaveTextContent(
-			"$0.00/month maximum, based on 7 members.",
+			"$0/month maximum, based on 7 members.",
+		);
+	},
+};
+
+export const AIBudgetDecimal: Story = {
+	args: {
+		showAISettings: true,
+		group: { ...MockGroup, total_member_count: 1 },
+		initialBudgetDollars: 99.99,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// Cents are kept when the amount is not a whole dollar.
+		const helper = canvas.getByText(/month maximum/i);
+		await expect(helper).toHaveTextContent(
+			"$99.99/month maximum, based on 1 member.",
 		);
 	},
 };

--- a/site/src/pages/GroupsPage/GroupSettingsPageView.tsx
+++ b/site/src/pages/GroupsPage/GroupSettingsPageView.tsx
@@ -9,12 +9,19 @@ import { Input } from "#/components/Input/Input";
 import { Label } from "#/components/Label/Label";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { isEveryoneGroup } from "#/modules/groups";
-import { dollarsToMicros, formatCostMicros } from "#/utils/currency";
 import {
 	getFormHelpers,
 	nameValidator,
 	onChangeTrimmed,
 } from "#/utils/formUtils";
+
+// Drops the cents when the amount is a whole dollar (the common case).
+const usdMaximumFormatter = new Intl.NumberFormat("en-US", {
+	style: "currency",
+	currency: "USD",
+	minimumFractionDigits: 0,
+	maximumFractionDigits: 2,
+});
 
 type FormData = {
 	name: string;
@@ -79,8 +86,8 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
 	const budgetField = getFieldHelpers("monthly_budget_per_member");
 	const budgetDollars = form.values.monthly_budget_per_member;
 	const memberCount = group.total_member_count;
-	const monthlyMaximum = formatCostMicros(
-		dollarsToMicros(budgetDollars) * memberCount,
+	const monthlyMaximum = usdMaximumFormatter.format(
+		Number(budgetDollars) * memberCount,
 	);
 
 	return (

--- a/site/src/pages/GroupsPage/GroupSettingsPageView.tsx
+++ b/site/src/pages/GroupsPage/GroupSettingsPageView.tsx
@@ -2,12 +2,14 @@ import { useFormik } from "formik";
 import type { FC } from "react";
 import * as Yup from "yup";
 import type { Group } from "#/api/typesGenerated";
+import { Badge } from "#/components/Badge/Badge";
 import { Button } from "#/components/Button/Button";
 import { IconField } from "#/components/IconField/IconField";
 import { Input } from "#/components/Input/Input";
 import { Label } from "#/components/Label/Label";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { isEveryoneGroup } from "#/modules/groups";
+import { dollarsToMicros, formatCostMicros } from "#/utils/currency";
 import {
 	getFormHelpers,
 	nameValidator,
@@ -19,15 +21,25 @@ type FormData = {
 	display_name: string;
 	avatar_url: string;
 	quota_allowance: number;
+	// Per-member AI budget, in dollars. "" is no budget (uncapped); 0 disables.
+	monthly_budget_per_member: string;
 };
 
 const validationSchema = Yup.object({
 	name: nameValidator("Name"),
 	quota_allowance: Yup.number().required().min(0).integer(),
+	// Optional: empty is uncapped. A value must be zero or more (0 disables).
+	monthly_budget_per_member: Yup.number()
+		.transform((value, original) => (original === "" ? undefined : value))
+		.min(0, "Enter an amount of zero or more."),
 });
 
 interface UpdateGroupFormProps {
 	group: Group;
+	/** Whether the AI add-on settings are shown (gated by the aibridge feature). */
+	showAISettings: boolean;
+	/** Per-member AI budget in dollars, or null when none is set. */
+	initialBudgetDollars: number | null;
 	errors: unknown;
 	onSubmit: (data: FormData) => void;
 	onCancel: () => void;
@@ -36,6 +48,8 @@ interface UpdateGroupFormProps {
 
 const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
 	group,
+	showAISettings,
+	initialBudgetDollars,
 	errors,
 	onSubmit,
 	onCancel,
@@ -47,6 +61,8 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
 			display_name: group.display_name,
 			avatar_url: group.avatar_url,
 			quota_allowance: group.quota_allowance,
+			monthly_budget_per_member:
+				initialBudgetDollars === null ? "" : String(initialBudgetDollars),
 		},
 		validationSchema,
 		onSubmit,
@@ -60,6 +76,12 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
 		helperText: `This group gives ${form.values.quota_allowance} quota credits to each
             of its members.`,
 	});
+	const budgetField = getFieldHelpers("monthly_budget_per_member");
+	const budgetDollars = form.values.monthly_budget_per_member;
+	const memberCount = group.total_member_count;
+	const monthlyMaximum = formatCostMicros(
+		dollarsToMicros(budgetDollars) * memberCount,
+	);
 
 	return (
 		<form className="flex flex-col gap-10 pb-8" onSubmit={form.handleSubmit}>
@@ -132,6 +154,60 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
 					)}
 				</div>
 			</section>
+
+			{showAISettings && (
+				<section className="flex flex-col gap-8 max-w-md">
+					<div className="flex items-center gap-2">
+						<h2 className="text-xl font-semibold text-content-primary m-0">
+							AI budget
+						</h2>
+						<Badge variant="purple" size="sm">
+							AI add-on
+						</Badge>
+					</div>
+					<div className="flex flex-col gap-6">
+						<div className="flex flex-col items-start gap-2">
+							<Label htmlFor={budgetField.id}>
+								Monthly budget per member (USD)
+							</Label>
+							<Input
+								id={budgetField.id}
+								name={budgetField.name}
+								value={budgetField.value}
+								onChange={(event) =>
+									form.setFieldValue(budgetField.name, event.target.value)
+								}
+								onBlur={budgetField.onBlur}
+								type="number"
+								min="0"
+								step="1"
+								aria-invalid={budgetField.error}
+							/>
+							{budgetField.error ? (
+								<span className="text-xs text-left text-content-destructive">
+									{budgetField.helperText}
+								</span>
+							) : budgetDollars.trim() !== "" ? (
+								<span className="text-xs text-left text-content-secondary">
+									<span className="font-medium text-content-primary">
+										{monthlyMaximum}
+									</span>
+									/month maximum, based on{" "}
+									<span className="font-medium text-content-primary">
+										{memberCount}
+									</span>{" "}
+									{memberCount === 1 ? "member" : "members"}.
+								</span>
+							) : (
+								<span className="text-xs text-left text-content-secondary">
+									Leave empty for uncapped spend.
+								</span>
+							)}
+						</div>
+					</div>
+				</section>
+			)}
+
 			<section className="flex flex-col gap-8">
 				<div className="flex flex-col gap-2">
 					<h2 className="text-xl font-semibold text-content-primary m-0">
@@ -186,9 +262,10 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
 type SettingsGroupPageViewProps = {
 	onCancel: () => void;
 	onSubmit: (data: FormData) => void;
-	group: Group | undefined;
+	group: Group;
+	showAISettings: boolean;
+	initialBudgetDollars: number | null;
 	formErrors: unknown;
-	isLoading: boolean;
 	isUpdating: boolean;
 };
 
@@ -196,12 +273,16 @@ const GroupSettingsPageView: FC<SettingsGroupPageViewProps> = ({
 	onCancel,
 	onSubmit,
 	group,
+	showAISettings,
+	initialBudgetDollars,
 	formErrors,
 	isUpdating,
 }) => {
 	return (
 		<UpdateGroupForm
-			group={group!}
+			group={group}
+			showAISettings={showAISettings}
+			initialBudgetDollars={initialBudgetDollars}
 			onCancel={onCancel}
 			errors={formErrors}
 			isLoading={isUpdating}


### PR DESCRIPTION
Adds an AI budget section to the group settings page (`/organizations/{org}/groups/{group}/settings`), gated by the `aibridge` feature.

The page's existing Save persists a per-member monthly budget through `PUT`/`DELETE /api/v2/groups/{group}/ai/budget` alongside the group patch. An empty field is uncapped (deletes the budget), `0` disables spending, and any value `>= 0` is accepted (matching the API's `gte=0`). The helper shows the resulting group-wide monthly maximum.

Part of AIGOV-294. The "AI governance add-on" access toggle shown in the design is out of scope here, as no backend field or endpoint exists for it yet.

Closes AIGOV-294
