### PR TITLE
test(provisionerd): standardize cancel-tolerant acquire asserts

### DIFF
--- a/provisionerd/provisionerd_test.go
+++ b/provisionerd/provisionerd_test.go
@@ -47,6 +47,18 @@ func closedWithin(c chan struct{}, d time.Duration) func() bool {
 	}
 }
 
+// assertAcquireNoError asserts that a send or receive on the AcquireJobWithCancel
+// stream succeeded, tolerating context.Canceled. dRPC can return context.Canceled
+// after it has successfully sent the message when the stream is canceled right
+// away, e.g. a test that closes the daemon immediately after acquisition. Any
+// other error fails the test.
+func assertAcquireNoError(t *testing.T, err error) {
+	t.Helper()
+	if !xerrors.Is(err, context.Canceled) {
+		assert.NoError(t, err)
+	}
+}
+
 func TestProvisionerd(t *testing.T) {
 	t.Parallel()
 
@@ -110,14 +122,7 @@ func TestProvisionerd(t *testing.T) {
 							},
 						},
 					})
-					// The daemon is closed immediately after acquisition, which
-					// cancels the acquire RPC. dRPC can report context.Canceled
-					// from Send even after the job was successfully delivered, so
-					// tolerate it. If the job was never delivered, the test fails
-					// waiting on completeChan instead.
-					if !xerrors.Is(err, context.Canceled) {
-						assert.NoError(t, err)
-					}
+					assertAcquireNoError(t, err)
 					return nil
 				},
 				updateJob: noopUpdateJob,
@@ -263,7 +268,7 @@ func TestProvisionerd(t *testing.T) {
 							},
 						},
 					})
-					assert.NoError(t, err)
+					assertAcquireNoError(t, err)
 					return nil
 				},
 				updateJob: func(ctx context.Context, update *proto.UpdateJobRequest) (*proto.UpdateJobResponse, error) {
@@ -741,7 +746,7 @@ func TestProvisionerd(t *testing.T) {
 							},
 						},
 					})
-					assert.NoError(t, err)
+					assertAcquireNoError(t, err)
 					return nil
 				},
 				updateJob: func(ctx context.Context, update *proto.UpdateJobRequest) (*proto.UpdateJobResponse, error) {
@@ -824,7 +829,7 @@ func TestProvisionerd(t *testing.T) {
 							},
 						},
 					})
-					assert.NoError(t, err)
+					assertAcquireNoError(t, err)
 					return nil
 				},
 				updateJob: func(ctx context.Context, update *proto.UpdateJobRequest) (*proto.UpdateJobResponse, error) {
@@ -924,10 +929,10 @@ func TestProvisionerd(t *testing.T) {
 					if second.Load() {
 						job = &proto.AcquiredJob{}
 						_, err := stream.Recv()
-						assert.NoError(t, err)
+						assertAcquireNoError(t, err)
 					}
 					err := stream.Send(job)
-					assert.NoError(t, err)
+					assertAcquireNoError(t, err)
 					return nil
 				},
 				updateJob: func(ctx context.Context, update *proto.UpdateJobRequest) (*proto.UpdateJobResponse, error) {
@@ -1006,7 +1011,7 @@ func TestProvisionerd(t *testing.T) {
 					if second.Load() {
 						completeOnce.Do(func() { close(completeChan) })
 						_, err := stream.Recv()
-						assert.NoError(t, err)
+						assertAcquireNoError(t, err)
 						return nil
 					}
 					job := &proto.AcquiredJob{
@@ -1022,7 +1027,7 @@ func TestProvisionerd(t *testing.T) {
 						},
 					}
 					err := stream.Send(job)
-					assert.NoError(t, err)
+					assertAcquireNoError(t, err)
 					return nil
 				},
 				failJob: func(ctx context.Context, job *proto.FailedJob) (*proto.Empty, error) {
@@ -1102,9 +1107,9 @@ func TestProvisionerd(t *testing.T) {
 					logger.Info(ctx, "provisioner stage: AcquiredJob")
 					if len(ops) > 0 {
 						_, err := stream.Recv()
-						assert.NoError(t, err)
+						assertAcquireNoError(t, err)
 						err = stream.Send(&proto.AcquiredJob{})
-						assert.NoError(t, err)
+						assertAcquireNoError(t, err)
 						return nil
 					}
 					ops = append(ops, "AcquireJob")
@@ -1121,7 +1126,7 @@ func TestProvisionerd(t *testing.T) {
 							},
 						},
 					})
-					assert.NoError(t, err)
+					assertAcquireNoError(t, err)
 					return nil
 				},
 				updateJob: func(ctx context.Context, update *proto.UpdateJobRequest) (*proto.UpdateJobResponse, error) {
@@ -1401,12 +1406,7 @@ func (a *acquireOne) acquireWithCancel(stream proto.DRPCProvisionerDaemon_Acquir
 		return nil
 	}
 	err := stream.Send(a.job)
-	// dRPC is racy, and sometimes will return context.Canceled after it has successfully sent the message if we cancel
-	// right away, e.g. in unit tests that complete. So, just swallow the error in that case. If we are canceled before
-	// the job was acquired, presumably something else in the test will have failed.
-	if !xerrors.Is(err, context.Canceled) {
-		assert.NoError(a.t, err)
-	}
+	assertAcquireNoError(a.t, err)
 	return nil
 }
 

--- a/provisionerd/provisionerd_test.go
+++ b/provisionerd/provisionerd_test.go
@@ -48,10 +48,12 @@ func closedWithin(c chan struct{}, d time.Duration) func() bool {
 }
 
 // assertAcquireNoError asserts that a send or receive on the AcquireJobWithCancel
-// stream succeeded, tolerating context.Canceled. dRPC can return context.Canceled
-// after it has successfully sent the message when the stream is canceled right
-// away, e.g. a test that closes the daemon immediately after acquisition. Any
-// other error fails the test.
+// stream succeeded, but tolerates context.Canceled. dRPC is racy and will
+// sometimes return context.Canceled even after it has successfully sent the
+// message, when the stream is canceled right away, e.g. a test that closes the
+// daemon immediately after acquisition. Swallowing it here is safe: a job that
+// was genuinely never delivered surfaces as a downstream failure when the test
+// waits on its completion signal. Any other error fails the test.
 func assertAcquireNoError(t *testing.T, err error) {
 	t.Helper()
 	if !xerrors.Is(err, context.Canceled) {

--- a/provisionerd/provisionerd_test.go
+++ b/provisionerd/provisionerd_test.go
@@ -47,14 +47,14 @@ func closedWithin(c chan struct{}, d time.Duration) func() bool {
 	}
 }
 
-// assertAcquireNoError asserts that a send or receive on the AcquireJobWithCancel
+// assertNoErrorOrCanceled asserts that a send or receive on the AcquireJobWithCancel
 // stream succeeded, but tolerates context.Canceled. dRPC is racy and will
 // sometimes return context.Canceled even after it has successfully sent the
 // message, when the stream is canceled right away, e.g. a test that closes the
 // daemon immediately after acquisition. Swallowing it here is safe: a job that
 // was genuinely never delivered surfaces as a downstream failure when the test
 // waits on its completion signal. Any other error fails the test.
-func assertAcquireNoError(t *testing.T, err error) {
+func assertNoErrorOrCanceled(t *testing.T, err error) {
 	t.Helper()
 	if !xerrors.Is(err, context.Canceled) {
 		assert.NoError(t, err)
@@ -124,7 +124,7 @@ func TestProvisionerd(t *testing.T) {
 							},
 						},
 					})
-					assertAcquireNoError(t, err)
+					assertNoErrorOrCanceled(t, err)
 					return nil
 				},
 				updateJob: noopUpdateJob,
@@ -270,7 +270,7 @@ func TestProvisionerd(t *testing.T) {
 							},
 						},
 					})
-					assertAcquireNoError(t, err)
+					assertNoErrorOrCanceled(t, err)
 					return nil
 				},
 				updateJob: func(ctx context.Context, update *proto.UpdateJobRequest) (*proto.UpdateJobResponse, error) {
@@ -748,7 +748,7 @@ func TestProvisionerd(t *testing.T) {
 							},
 						},
 					})
-					assertAcquireNoError(t, err)
+					assertNoErrorOrCanceled(t, err)
 					return nil
 				},
 				updateJob: func(ctx context.Context, update *proto.UpdateJobRequest) (*proto.UpdateJobResponse, error) {
@@ -831,7 +831,7 @@ func TestProvisionerd(t *testing.T) {
 							},
 						},
 					})
-					assertAcquireNoError(t, err)
+					assertNoErrorOrCanceled(t, err)
 					return nil
 				},
 				updateJob: func(ctx context.Context, update *proto.UpdateJobRequest) (*proto.UpdateJobResponse, error) {
@@ -931,10 +931,10 @@ func TestProvisionerd(t *testing.T) {
 					if second.Load() {
 						job = &proto.AcquiredJob{}
 						_, err := stream.Recv()
-						assertAcquireNoError(t, err)
+						assertNoErrorOrCanceled(t, err)
 					}
 					err := stream.Send(job)
-					assertAcquireNoError(t, err)
+					assertNoErrorOrCanceled(t, err)
 					return nil
 				},
 				updateJob: func(ctx context.Context, update *proto.UpdateJobRequest) (*proto.UpdateJobResponse, error) {
@@ -1013,7 +1013,7 @@ func TestProvisionerd(t *testing.T) {
 					if second.Load() {
 						completeOnce.Do(func() { close(completeChan) })
 						_, err := stream.Recv()
-						assertAcquireNoError(t, err)
+						assertNoErrorOrCanceled(t, err)
 						return nil
 					}
 					job := &proto.AcquiredJob{
@@ -1029,7 +1029,7 @@ func TestProvisionerd(t *testing.T) {
 						},
 					}
 					err := stream.Send(job)
-					assertAcquireNoError(t, err)
+					assertNoErrorOrCanceled(t, err)
 					return nil
 				},
 				failJob: func(ctx context.Context, job *proto.FailedJob) (*proto.Empty, error) {
@@ -1109,9 +1109,9 @@ func TestProvisionerd(t *testing.T) {
 					logger.Info(ctx, "provisioner stage: AcquiredJob")
 					if len(ops) > 0 {
 						_, err := stream.Recv()
-						assertAcquireNoError(t, err)
+						assertNoErrorOrCanceled(t, err)
 						err = stream.Send(&proto.AcquiredJob{})
-						assertAcquireNoError(t, err)
+						assertNoErrorOrCanceled(t, err)
 						return nil
 					}
 					ops = append(ops, "AcquireJob")
@@ -1128,7 +1128,7 @@ func TestProvisionerd(t *testing.T) {
 							},
 						},
 					})
-					assertAcquireNoError(t, err)
+					assertNoErrorOrCanceled(t, err)
 					return nil
 				},
 				updateJob: func(ctx context.Context, update *proto.UpdateJobRequest) (*proto.UpdateJobResponse, error) {
@@ -1408,7 +1408,7 @@ func (a *acquireOne) acquireWithCancel(stream proto.DRPCProvisionerDaemon_Acquir
 		return nil
 	}
 	err := stream.Send(a.job)
-	assertAcquireNoError(a.t, err)
+	assertNoErrorOrCanceled(a.t, err)
 	return nil
 }
 

--- a/provisionerd/provisionerd_test.go
+++ b/provisionerd/provisionerd_test.go
@@ -110,7 +110,14 @@ func TestProvisionerd(t *testing.T) {
 							},
 						},
 					})
-					assert.NoError(t, err)
+					// The daemon is closed immediately after acquisition, which
+					// cancels the acquire RPC. dRPC can report context.Canceled
+					// from Send even after the job was successfully delivered, so
+					// tolerate it. If the job was never delivered, the test fails
+					// waiting on completeChan instead.
+					if !xerrors.Is(err, context.Canceled) {
+						assert.NoError(t, err)
+					}
 					return nil
 				},
 				updateJob: noopUpdateJob,


### PR DESCRIPTION
`TestProvisionerd/CloseCancelsJob` closes the daemon inside the provisioner parse/init callback, which cancels the in-flight `AcquireJobWithCancel` RPC immediately after the job is delivered. dRPC can report `context.Canceled` from the server-side `stream.Send` even after the message was successfully sent, causing a spurious `assert.NoError` failure.

The tolerance for this race already existed in the `acquireOne` test helper (added in #17448 for coder/internal#584), but the inline acquire handlers each carried their own bare `assert.NoError`, so `CloseCancelsJob` never got it and flaked.

This extracts a single `assertAcquireNoError` helper that tolerates `context.Canceled` on an acquire-stream `Send`/`Recv` (and fails on any other error), and routes every `AcquireJobWithCancel` test handler and `acquireOne` through it. The tolerance now has one definition and cannot drift out of sync. If a job is never delivered, the affected tests still fail waiting on their completion channels.

Fixes PLAT-172. Refs https://github.com/coder/internal/issues/1478

<details>
<summary>Investigation and validation</summary>

- The reported failure was `assert.NoError` at `provisionerd_test.go:112` (commit 615be176) receiving `context canceled`. The same dRPC behavior is documented in `retryable()` in `provisionerd.go` and was already handled in `acquireOne.acquireWithCancel`.
- Prior art: PR #17448 (merged 2025-04-17) added the identical tolerance to `acquireOne` to fix coder/internal#584 (`flake: TestProvisionerd/MaliciousTar`), which failed with the same signature. That fix did not reach the inline handlers, which is the gap addressed here.
- The natural timing race did not reproduce locally (~96,000 iterations, including single-threaded and race-detector runs); it requires the server `Send` goroutine to be descheduled past cancel propagation, which only manifests under CI load.
- To validate deterministically, the handler was temporarily instrumented to surface `context.Canceled` once the stream context cancelled after a successful `Send`. With a bare `assert.NoError` this reproduced the exact CI failure (`context canceled` at line 112); with the tolerance it passed. The instrumentation was reverted.
- Scope note: `CloseCancelsJob` is the only handler with an observed CI failure (it closes synchronously at acquisition). The other handlers shut down only after job progress, so their first `Send` is not realistically racing a cancel; applying the helper there is consistency and drift-prevention, not a fix for an observed flake. This resolves review finding CRF-1 in code.

</details>

> Generated by Coder Agents on behalf of @jscottmiller.
