### PR TITLE
fix: surface GitHub Copilot AI provider in Coder Agents chat

### DIFF
--- a/coderd/x/chatd/chatprovider/chatprovider.go
+++ b/coderd/x/chatd/chatprovider/chatprovider.go
@@ -25,10 +25,17 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 )
 
+// copilotProviderName is the canonical chat provider name for GitHub
+// Copilot. Fantasy has no Copilot provider; Copilot requests route
+// through aibridge's OpenAI-compatible Copilot client, which supplies
+// request-time GitHub OAuth credentials.
+const copilotProviderName = string(codersdk.AIProviderTypeCopilot)
+
 var supportedProviderNames = []string{
 	fantasyanthropic.Name,
 	fantasyazure.Name,
 	fantasybedrock.Name,
+	copilotProviderName,
 	fantasygoogle.Name,
 	fantasyopenai.Name,
 	fantasyopenaicompat.Name,
@@ -40,6 +47,7 @@ var providerDisplayNameByName = map[string]string{
 	fantasyanthropic.Name:    "Anthropic",
 	fantasyazure.Name:        "Azure OpenAI",
 	fantasybedrock.Name:      "AWS Bedrock",
+	copilotProviderName:      "GitHub Copilot",
 	fantasygoogle.Name:       "Google",
 	fantasyopenai.Name:       "OpenAI",
 	fantasyopenaicompat.Name: "OpenAI Compatible",
@@ -57,10 +65,16 @@ func ProviderDisplayName(provider string) string {
 }
 
 // ProviderAllowsAmbientCredentials reports whether provider can use
-// ambient credentials from the Coder server instead of an explicit
-// API key.
+// ambient credentials instead of an explicit API key. Bedrock uses the
+// Coder server's AWS credentials; Copilot uses request-time GitHub
+// OAuth tokens injected by aibridge.
 func ProviderAllowsAmbientCredentials(provider string) bool {
-	return NormalizeProvider(provider) == fantasybedrock.Name
+	switch NormalizeProvider(provider) {
+	case fantasybedrock.Name, copilotProviderName:
+		return true
+	default:
+		return false
+	}
 }
 
 // InlineImageCapBytes returns the per-image byte cap for inline
@@ -340,6 +354,12 @@ func ResolveUserProviderKeys(
 			} else {
 				resolved.UnavailableReason = codersdk.ChatModelProviderUnavailableReasonUserAPIKeyRequired
 			}
+		case normalizedProvider == copilotProviderName:
+			// Copilot never carries a stored or user API key; aibridge
+			// supplies request-time GitHub OAuth credentials. A configured
+			// Copilot provider is therefore always available here, and any
+			// missing GitHub link surfaces as a runtime error instead.
+			resolved.Available = true
 		case normalizedProvider == fantasybedrock.Name && provider.CentralAPIKeyEnabled:
 			// Bedrock can use ambient AWS credentials from the Coder server
 			// without an explicit key, but only when the credential policy
@@ -601,6 +621,8 @@ func NormalizeProvider(provider string) string {
 		return fantasyazure.Name
 	case fantasybedrock.Name:
 		return fantasybedrock.Name
+	case copilotProviderName:
+		return copilotProviderName
 	case fantasygoogle.Name:
 		return fantasygoogle.Name
 	case fantasyopenai.Name:

--- a/coderd/x/chatd/chatprovider/chatprovider_test.go
+++ b/coderd/x/chatd/chatprovider/chatprovider_test.go
@@ -290,6 +290,83 @@ func TestResolveUserProviderKeys(t *testing.T) {
 	}
 }
 
+func TestResolveUserProviderKeys_Copilot(t *testing.T) {
+	t.Parallel()
+
+	copilotProviderID := uuid.MustParse("00000000-0000-0000-0000-000000000010")
+	copilotName := string(codersdk.AIProviderTypeCopilot)
+
+	// Copilot authenticates via request-time GitHub OAuth tokens that
+	// aibridge injects, so it never carries a stored or user API key.
+	// It must still resolve as available when configured.
+	copilotProvider := chatprovider.ConfiguredProvider{
+		ProviderID:                 copilotProviderID,
+		Provider:                   copilotName,
+		CentralAPIKeyEnabled:       true,
+		AllowUserAPIKey:            false,
+		AllowCentralAPIKeyFallback: true,
+	}
+
+	keys, availability := chatprovider.ResolveUserProviderKeys(
+		chatprovider.ProviderAPIKeys{},
+		[]chatprovider.ConfiguredProvider{copilotProvider},
+		nil,
+	)
+
+	got, ok := availability[copilotName]
+	require.True(t, ok, "expected availability entry for copilot")
+	require.Equal(t, chatprovider.ProviderAvailability{Available: true}, got,
+		"copilot must be available without an API key")
+	// Copilot uses ambient (delegated) credentials, so the key entry is
+	// present but empty, mirroring Bedrock.
+	gotKey, present := keys.ByProvider[copilotName]
+	require.True(t, present, "expected ambient key presence for copilot")
+	require.Equal(t, "", gotKey)
+}
+
+func TestListConfiguredModels_Copilot(t *testing.T) {
+	t.Parallel()
+
+	copilotName := string(codersdk.AIProviderTypeCopilot)
+	copilotProviderID := uuid.MustParse("00000000-0000-0000-0000-000000000011")
+
+	catalog := chatprovider.NewModelCatalog()
+	configuredProviders := []chatprovider.ConfiguredProvider{{
+		ProviderID:           copilotProviderID,
+		Provider:             copilotName,
+		CentralAPIKeyEnabled: true,
+	}}
+	configuredModels := []chatprovider.ConfiguredModel{{
+		Provider:    copilotName,
+		Model:       "gpt-4o",
+		DisplayName: "GPT-4o (Copilot)",
+	}}
+	availability := map[string]chatprovider.ProviderAvailability{
+		copilotName: {Available: true},
+	}
+	enabledProviders := map[string]struct{}{copilotName: {}}
+
+	response, ok := catalog.ListConfiguredModels(
+		configuredProviders,
+		configuredModels,
+		availability,
+		enabledProviders,
+	)
+	require.True(t, ok, "expected DB-backed models to be used")
+
+	var copilot *codersdk.ChatModelProvider
+	for i := range response.Providers {
+		if response.Providers[i].Provider == copilotName {
+			copilot = &response.Providers[i]
+			break
+		}
+	}
+	require.NotNil(t, copilot, "copilot provider must appear in the catalog")
+	require.True(t, copilot.Available, "copilot provider must be available")
+	require.Len(t, copilot.Models, 1)
+	require.Equal(t, "gpt-4o", copilot.Models[0].Model)
+}
+
 type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (fn roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/site/src/utils/aiProviders.ts
+++ b/site/src/utils/aiProviders.ts
@@ -9,6 +9,8 @@ export const formatProviderLabel = (provider: string): string => {
 			return "Azure OpenAI";
 		case "bedrock":
 			return "AWS Bedrock";
+		case "copilot":
+			return "GitHub Copilot";
 		case "google":
 			return "Google";
 		case "openai-compat":


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

## Problem

After an admin configures a GitHub **Copilot** AI provider and creates a model for it, the Coder Agents page still shows *"set up a provider then add a model"* and the model never appears in the selector. Configuring an **Anthropic** provider + model works.

## Root cause

The chat model catalog only surfaces providers it marks `available: true`. For a Copilot provider, that flag is never set:

- `chatprovider.NormalizeProvider` had **no `copilot` case**, so `"copilot"` normalized to `""` and was dropped before availability was ever computed (in `ResolveUserProviderKeys`, `ListConfiguredModels`, and `orderProviders` via `supportedProviderNames`).
- Even if it were normalized, `ResolveUserProviderKeys` had no path to mark Copilot available. Copilot **rejects API keys by design** (`coderd/ai_providers.go`) and authenticates via request-time GitHub OAuth tokens injected by aibridge, so it can never satisfy the key-based availability check. The only keyless ("ambient credentials") path was hard-coded to Bedrock.

Net effect on the frontend: `getAvailableProviders` filters to `provider.available === true`, so `countConfiguredProviderConfigs` and `getModelOptionsFromConfigs` both drop Copilot, collapsing `providerCount`/`modelCount` to `0` and rendering the setup notice. Anthropic works only because it carries a stored API key.

Execution was never the problem: chatd already routes Copilot through the AI Gateway via the OpenAI-compatible `default` branch of `fantasyConfigForAIBridge`, with credentials delegated to aibridged.

## Fix

In `coderd/x/chatd/chatprovider/chatprovider.go`:

- Recognize `copilot` as a supported provider (`NormalizeProvider`, `supportedProviderNames`, display name `GitHub Copilot`).
- Treat Copilot like Bedrock's ambient-credential path: `ProviderAllowsAmbientCredentials` returns true for Copilot, and `ResolveUserProviderKeys` resolves a configured Copilot provider as available without an API key. A missing GitHub link now surfaces as a runtime error instead of silently hiding the provider.

In `site/src/utils/aiProviders.ts`:

- Add a `GitHub Copilot` display label for the model selector.

## Tests

- `TestResolveUserProviderKeys_Copilot` — a keyless Copilot provider resolves `Available: true` with an ambient (empty) key entry.
- `TestListConfiguredModels_Copilot` — a Copilot provider + model appears in the catalog and is available.

Both fail on `main` and pass with this change. Existing `TestListChatModels` and the full `chatprovider` package still pass.

<details>
<summary>Verification</summary>

```
go test ./coderd/x/chatd/chatprovider/ -count=1   # ok
go test ./coderd/ -run TestListChatModels -count=1 # ok
go build ./coderd/... ; go vet ./coderd/x/chatd/chatprovider/ ; gofmt -l (clean)
```

</details>

## Notes / follow-ups

- Availability here means "the provider is configured and routable." It intentionally does not pre-validate that the requesting user has a linked GitHub external-auth token; that failure surfaces at request time, consistent with Bedrock's ambient-credential model. If we want a pre-flight check that the user has a usable GitHub link, that can be a follow-up.
