### PR TITLE
chore: gate Coder Agents app and port tabs behind experiment

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -19344,10 +19344,12 @@ const docTemplate = `{
                 "workspace-build-updates",
                 "nats_pubsub",
                 "minimum-implicit-member",
-                "ai-gateway-cost-control"
+                "ai-gateway-cost-control",
+                "agent-app-tabs"
             ],
             "x-enum-comments": {
                 "ExperimentAIGatewayCostControl": "Enables AI Gateway cost control functionality.",
+                "ExperimentAgentAppTabs": "Enables workspace-app and port preview tabs in the Coder Agents right panel.",
                 "ExperimentAutoFillParameters": "This should not be taken out of experiments until we have redesigned the feature.",
                 "ExperimentExample": "This isn't used for anything.",
                 "ExperimentMCPServerHTTP": "Enables the MCP HTTP server functionality.",
@@ -19368,7 +19370,8 @@ const docTemplate = `{
                 "Enables publishing workspace build updates to the all builds pubsub channel.",
                 "Enables embedded NATS pubsub.",
                 "Allows organizations to deviate from the default organization-member roles, in support of Gateway Accounts.",
-                "Enables AI Gateway cost control functionality."
+                "Enables AI Gateway cost control functionality.",
+                "Enables workspace-app and port preview tabs in the Coder Agents right panel."
             ],
             "x-enum-varnames": [
                 "ExperimentExample",
@@ -19380,7 +19383,8 @@ const docTemplate = `{
                 "ExperimentWorkspaceBuildUpdates",
                 "ExperimentNATSPubsub",
                 "ExperimentMinimumImplicitMember",
-                "ExperimentAIGatewayCostControl"
+                "ExperimentAIGatewayCostControl",
+                "ExperimentAgentAppTabs"
             ]
         },
         "codersdk.ExternalAPIKeyScopes": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -17554,10 +17554,12 @@
 				"workspace-build-updates",
 				"nats_pubsub",
 				"minimum-implicit-member",
-				"ai-gateway-cost-control"
+				"ai-gateway-cost-control",
+				"agent-app-tabs"
 			],
 			"x-enum-comments": {
 				"ExperimentAIGatewayCostControl": "Enables AI Gateway cost control functionality.",
+				"ExperimentAgentAppTabs": "Enables workspace-app and port preview tabs in the Coder Agents right panel.",
 				"ExperimentAutoFillParameters": "This should not be taken out of experiments until we have redesigned the feature.",
 				"ExperimentExample": "This isn't used for anything.",
 				"ExperimentMCPServerHTTP": "Enables the MCP HTTP server functionality.",
@@ -17578,7 +17580,8 @@
 				"Enables publishing workspace build updates to the all builds pubsub channel.",
 				"Enables embedded NATS pubsub.",
 				"Allows organizations to deviate from the default organization-member roles, in support of Gateway Accounts.",
-				"Enables AI Gateway cost control functionality."
+				"Enables AI Gateway cost control functionality.",
+				"Enables workspace-app and port preview tabs in the Coder Agents right panel."
 			],
 			"x-enum-varnames": [
 				"ExperimentExample",
@@ -17590,7 +17593,8 @@
 				"ExperimentWorkspaceBuildUpdates",
 				"ExperimentNATSPubsub",
 				"ExperimentMinimumImplicitMember",
-				"ExperimentAIGatewayCostControl"
+				"ExperimentAIGatewayCostControl",
+				"ExperimentAgentAppTabs"
 			]
 		},
 		"codersdk.ExternalAPIKeyScopes": {

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -5154,6 +5154,7 @@ const (
 	ExperimentNATSPubsub            Experiment = "nats_pubsub"             // Enables embedded NATS pubsub.
 	ExperimentMinimumImplicitMember Experiment = "minimum-implicit-member" // Allows organizations to deviate from the default organization-member roles, in support of Gateway Accounts.
 	ExperimentAIGatewayCostControl  Experiment = "ai-gateway-cost-control" // Enables AI Gateway cost control functionality.
+	ExperimentAgentAppTabs          Experiment = "agent-app-tabs"          // Enables workspace-app and port preview tabs in the Coder Agents right panel.
 )
 
 func (e Experiment) DisplayName() string {
@@ -5178,6 +5179,8 @@ func (e Experiment) DisplayName() string {
 		return "Gateway Accounts (minimum implicit member)"
 	case ExperimentAIGatewayCostControl:
 		return "AI Gateway Cost Control"
+	case ExperimentAgentAppTabs:
+		return "Coder Agents App and Port Tabs"
 	default:
 		// Split on hyphen and convert to title case
 		// e.g. "mcp-server-http" -> "Mcp Server Http"
@@ -5198,6 +5201,7 @@ var ExperimentsKnown = Experiments{
 	ExperimentWorkspaceBuildUpdates,
 	ExperimentMinimumImplicitMember,
 	ExperimentAIGatewayCostControl,
+	ExperimentAgentAppTabs,
 }
 
 // ExperimentsSafe should include all experiments that are safe for

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -6999,9 +6999,9 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 
 #### Enumerated Values
 
-| Value(s)                                                                                                                                                                                           |
-|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `ai-gateway-cost-control`, `auto-fill-parameters`, `example`, `mcp-server-http`, `minimum-implicit-member`, `nats_pubsub`, `notifications`, `oauth2`, `workspace-build-updates`, `workspace-usage` |
+| Value(s)                                                                                                                                                                                                             |
+|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `agent-app-tabs`, `ai-gateway-cost-control`, `auto-fill-parameters`, `example`, `mcp-server-http`, `minimum-implicit-member`, `nats_pubsub`, `notifications`, `oauth2`, `workspace-build-updates`, `workspace-usage` |
 
 ## codersdk.ExternalAPIKeyScopes
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -4378,8 +4378,8 @@ export const EntitlementsWarningHeader = "X-Coder-Entitlements-Warning";
 
 // From codersdk/deployment.go
 export type Experiment =
-	| "agent-app-tabs"
 	| "ai-gateway-cost-control"
+	| "agent-app-tabs"
 	| "auto-fill-parameters"
 	| "example"
 	| "mcp-server-http"
@@ -4391,8 +4391,8 @@ export type Experiment =
 	| "workspace-usage";
 
 export const Experiments: Experiment[] = [
-	"agent-app-tabs",
 	"ai-gateway-cost-control",
+	"agent-app-tabs",
 	"auto-fill-parameters",
 	"example",
 	"mcp-server-http",

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -4378,6 +4378,7 @@ export const EntitlementsWarningHeader = "X-Coder-Entitlements-Warning";
 
 // From codersdk/deployment.go
 export type Experiment =
+	| "agent-app-tabs"
 	| "ai-gateway-cost-control"
 	| "auto-fill-parameters"
 	| "example"
@@ -4390,6 +4391,7 @@ export type Experiment =
 	| "workspace-usage";
 
 export const Experiments: Experiment[] = [
+	"agent-app-tabs",
 	"ai-gateway-cost-control",
 	"auto-fill-parameters",
 	"example",

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -23,7 +23,6 @@ import { isWorkspaceAppEmbeddable } from "#/modules/apps/apps";
 import { WorkspaceAppFrame } from "#/modules/apps/WorkspaceAppFrame";
 import { findWorkspaceAppWithAgent } from "#/modules/apps/workspaceApps";
 import { useDashboard } from "#/modules/dashboard/useDashboard";
-import { getPrereleaseFlag } from "#/utils/buildInfo";
 import { cn } from "#/utils/cn";
 import { pageTitle } from "#/utils/page";
 import { findWorkspaceAgent } from "#/utils/workspace";
@@ -378,10 +377,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	const queryClient = useQueryClient();
 	const { proxy } = useProxy();
 	const wildcardHostname = proxy.preferredWildcardHostname;
-	const { buildInfo } = useDashboard();
-	// Workspace app and port preview tabs are experimental and limited to
-	// devel builds for now. Terminal tabs are generally available.
-	const userAppTabsEnabled = getPrereleaseFlag(buildInfo) === "devel";
+	const { experiments } = useDashboard();
 
 	const canOpenChatSharing = canShareChat && organizationId !== undefined;
 
@@ -487,6 +483,12 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	// "desktop" when no desktop panel is rendered.
 	const availableDesktopChatId =
 		workspace && workspaceAgent ? desktopChatId : undefined;
+
+	// Workspace app and port preview tabs are gated behind the agent-app-tabs
+	// experiment. Terminal tabs are generally available. Derived after all hook
+	// calls so the React Compiler keeps the tab list and the tab-open handlers
+	// below in a single memoization scope.
+	const userAppTabsEnabled = experiments.includes("agent-app-tabs");
 
 	// When app and port tabs are gated off, persisted tabs of those kinds
 	// are hidden rather than deleted; the save effect persists the raw tab


### PR DESCRIPTION
The workspace-app and port preview tabs in the Coder Agents right panel were previously gated behind a `devel` prerelease build check, which can't be toggled in real deployments.

This replaces that check with a proper `agent-app-tabs` deployment experiment, registered in `ExperimentsKnown`, so the feature can be enabled via `CODER_EXPERIMENTS=agent-app-tabs` like any other experiment. The frontend now reads `experiments.includes("agent-app-tabs")` from the dashboard instead of `getPrereleaseFlag(buildInfo) === "devel"`.

Depends on #26208
