### PR TITLE
test: use httptest server.Client() to isolate transport

### DIFF
--- a/coderd/webpush/webpush_test.go
+++ b/coderd/webpush/webpush_test.go
@@ -536,9 +536,7 @@ func setupPushTestWithOptions(ctx context.Context, t *testing.T, db database.Sto
 	server := httptest.NewServer(http.HandlerFunc(handlerFunc))
 	t.Cleanup(server.Close)
 
-	// Use an unrestricted HTTP client for tests. The default SSRF-safe
-	// client rejects loopback addresses, which blocks httptest.Server.
-	opts = append(opts, webpush.WithHTTPClient(http.DefaultClient))
+	opts = append(opts, webpush.WithHTTPClient(server.Client()))
 	manager, err := webpush.New(ctx, &logger, db, "http://example.com", opts...)
 	require.NoError(t, err, "Failed to create webpush manager")
 


### PR DESCRIPTION
`TestPush/CachesSubscriptionsWithinTTL` could fail with `Post "http://127.0.0.1:XXXXX": net/http: HTTP/1.x transport connection broken: http: CloseIdleConnections called` when a sibling parallel subtest's `httptest.Server.Close()` ran during an in-flight `Dispatch`.

`setupPushTestWithOptions` wired the dispatcher to `http.DefaultClient`, so every parallel subtest in `TestPush` shared `http.DefaultTransport`. `httptest.Server.Close()` calls `CloseIdleConnections` on `http.DefaultTransport`, which could break an in-flight request in any other subtest using the same transport.

`httptest.Server` already exposes a paired `*http.Client` backed by a transport dedicated to that server (see `net/http/httptest/server.go`). Closing one server only touches `http.DefaultTransport` and its own client's transport, so sibling cleanup can no longer reach into ours.

Same flake class and same isolation principle as #25015, #25407, #25430, and #25821.

Closes https://github.com/coder/internal/issues/1593
Closes ENG-2926
