### PR TITLE
chore: add Vercel CLI to the dogfood image via mise

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -747,6 +747,10 @@ backend = "npm:@devcontainers/cli"
 version = "2.13.0"
 backend = "npm:@puppeteer/browsers"
 
+[[tools."npm:vercel"]]
+version = "54.14.0"
+backend = "npm:vercel"
+
 [[tools.pnpm]]
 version = "10.33.2"
 backend = "aqua:pnpm/pnpm"

--- a/mise.lock
+++ b/mise.lock
@@ -747,10 +747,6 @@ backend = "npm:@devcontainers/cli"
 version = "2.13.0"
 backend = "npm:@puppeteer/browsers"
 
-[[tools."npm:vercel"]]
-version = "54.14.0"
-backend = "npm:vercel"
-
 [[tools.pnpm]]
 version = "10.33.2"
 backend = "aqua:pnpm/pnpm"
@@ -970,6 +966,10 @@ url = "https://releases.hashicorp.com/terraform/1.15.5/terraform_1.15.5_windows_
 [tools.terraform."platforms.windows-x64-baseline"]
 checksum = "sha256:2f652dd854af7b7fbb51301afc55b5ef1d3f6e287be7889d4cc3818df891cd38"
 url = "https://releases.hashicorp.com/terraform/1.15.5/terraform_1.15.5_windows_amd64.zip"
+
+[[tools.vercel]]
+version = "54.14.0"
+backend = "npm:vercel"
 
 [[tools.zizmor]]
 version = "1.11.0"

--- a/mise.toml
+++ b/mise.toml
@@ -72,7 +72,7 @@ lazygit = "0.61.1"
 # module's `command -v devcontainer` short-circuit fires
 "npm:@devcontainers/cli" = "0.87.0"
 # Vercel CLI for deploying/previewing projects from dogfood workspaces.
-"npm:vercel" = "54.14.0"
+vercel = "54.14.0"
 # weekly-docs uses this pinned Puppeteer browser installer to install Chrome for
 # action-linkspector without resolving mutable npm metadata at runtime.
 "npm:@puppeteer/browsers" = "2.13.0"

--- a/mise.toml
+++ b/mise.toml
@@ -71,6 +71,8 @@ lazygit = "0.61.1"
 # Pre-installs the binary so the upstream devcontainers-cli coder
 # module's `command -v devcontainer` short-circuit fires
 "npm:@devcontainers/cli" = "0.87.0"
+# Vercel CLI for deploying/previewing projects from dogfood workspaces.
+"npm:vercel" = "54.14.0"
 # weekly-docs uses this pinned Puppeteer browser installer to install Chrome for
 # action-linkspector without resolving mutable npm metadata at runtime.
 "npm:@puppeteer/browsers" = "2.13.0"


### PR DESCRIPTION
Vercel is our vetted tool for deploying apps. Baking it into the dogfood image makes it available for both dogfood (coder.com dev) and cdrstable.dev work, without a per-workspace install.

Pinned via mise's npm backend, matching the existing `@devcontainers/cli` and `@puppeteer/browsers` entries.

Generated with Coder Agents on behalf of @bpmct
