### PR TITLE
fix(site/src/pages/AgentsPage): preserve chat input typed while loading

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.test.ts
+++ b/site/src/pages/AgentsPage/AgentChatPage.test.ts
@@ -324,6 +324,9 @@ describe("useConversationEditingState", () => {
 			);
 		});
 		expect(localStorage.getItem(expectedKey)).toBe("work in progress");
+		// handleContentChange persists only; it must not advance the seed.
+		expect(result.current.editorInitialValue).toBe("");
+		expect(result.current.initialEditorState).toBeUndefined();
 
 		act(() => {
 			// Even though the serialized state is non-empty (Lexical always
@@ -339,10 +342,7 @@ describe("useConversationEditingState", () => {
 	it("carries a draft typed during loading into the seed for the loaded editor", () => {
 		const { result, unmount } = renderEditing();
 
-		// The loaded editor seeds from editorInitialValue/initialEditorState
-		// on its first mount. handleContentChange alone only persists and
-		// does not move the seed, so text typed before the loaded editor
-		// mounts would be lost without handleLoadingDraftChange.
+		// handleContentChange persists but does not advance the seed.
 		const editorState =
 			'{"root":{"children":[{"text":"typed while loading"}]}}';
 		act(() => {

--- a/site/src/pages/AgentsPage/AgentChatPage.test.ts
+++ b/site/src/pages/AgentsPage/AgentChatPage.test.ts
@@ -336,6 +336,30 @@ describe("useConversationEditingState", () => {
 		unmount();
 	});
 
+	it("carries a draft typed during loading into the seed for the loaded editor", () => {
+		const { result, unmount } = renderEditing();
+
+		// The loaded editor seeds from editorInitialValue/initialEditorState
+		// on its first mount. handleContentChange alone only persists and
+		// does not move the seed, so text typed before the loaded editor
+		// mounts would be lost without handleLoadingDraftChange.
+		const editorState =
+			'{"root":{"children":[{"text":"typed while loading"}]}}';
+		act(() => {
+			result.current.handleLoadingDraftChange(
+				"typed while loading",
+				editorState,
+				false,
+			);
+		});
+
+		expect(localStorage.getItem(expectedKey)).toBe(editorState);
+		expect(result.current.editorInitialValue).toBe("typed while loading");
+		expect(result.current.initialEditorState).toBe(editorState);
+
+		unmount();
+	});
+
 	it("loads edit text into the composer and restores the prior draft on cancel without refocusing", () => {
 		const { result, unmount } = renderEditing();
 

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -569,6 +569,24 @@ export function useConversationEditingState(deps: {
 		}
 	};
 
+	// The loaded editor seeds from editorInitialValue/initialEditorState
+	// the first time it mounts. While the chat is still loading the editor
+	// receiving keystrokes is a different, soon-to-unmount instance, so the
+	// seed state is updated here (not in handleContentChange, which runs per
+	// keystroke in the loaded editor and must avoid re-renders) to carry the
+	// draft across the swap.
+	const handleLoadingDraftChange = (
+		content: string,
+		serializedEditorState: string,
+		hasFileReferences: boolean,
+	) => {
+		handleContentChange(content, serializedEditorState, hasFileReferences);
+		setDraftState({
+			editorInitialValue: content,
+			initialEditorState: serializedEditorState,
+		});
+	};
+
 	return {
 		inputValueRef,
 		chatInputRef,
@@ -584,6 +602,7 @@ export function useConversationEditingState(deps: {
 		handleCancelQueueEdit,
 		handleSendFromInput,
 		handleContentChange,
+		handleLoadingDraftChange,
 	};
 }
 
@@ -1548,6 +1567,11 @@ const AgentChatPage: FC = () => {
 					preferencesQuery.isLoading,
 				)}
 				titleElement={titleElement}
+				inputRef={editing.chatInputRef}
+				initialValue={editing.editorInitialValue}
+				initialEditorState={editing.initialEditorState}
+				remountKey={editing.remountKey}
+				onContentChange={editing.handleLoadingDraftChange}
 				isInputDisabled={isInputDisabled}
 				effectiveSelectedModel={effectiveSelectedModel}
 				setSelectedModel={setSelectedModel}

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -569,12 +569,9 @@ export function useConversationEditingState(deps: {
 		}
 	};
 
-	// The loaded editor seeds from editorInitialValue/initialEditorState
-	// the first time it mounts. While the chat is still loading the editor
-	// receiving keystrokes is a different, soon-to-unmount instance, so the
-	// seed state is updated here (not in handleContentChange, which runs per
-	// keystroke in the loaded editor and must avoid re-renders) to carry the
-	// draft across the swap.
+	// Separate from handleContentChange, which avoids setState to prevent
+	// per-keystroke re-renders. The loading editor is a different instance
+	// that unmounts on load, so the seed must advance here.
 	const handleLoadingDraftChange = (
 		content: string,
 		serializedEditorState: string,

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -748,6 +748,11 @@ export const Loading: Story = {
 		<AgentChatPageLoadingView
 			sendShortcut="enter"
 			titleElement={<title>Loading — Agents</title>}
+			inputRef={{ current: null }}
+			initialValue=""
+			initialEditorState={undefined}
+			remountKey={0}
+			onContentChange={fn()}
 			isInputDisabled
 			effectiveSelectedModel={defaultModelConfigID}
 			setSelectedModel={fn()}
@@ -767,6 +772,11 @@ export const LoadingWithModelOptions: Story = {
 		<AgentChatPageLoadingView
 			sendShortcut="enter"
 			titleElement={<title>Loading — Agents</title>}
+			inputRef={{ current: null }}
+			initialValue=""
+			initialEditorState={undefined}
+			remountKey={0}
+			onContentChange={fn()}
 			isInputDisabled={false}
 			effectiveSelectedModel={defaultModelConfigID}
 			setSelectedModel={fn()}
@@ -785,6 +795,11 @@ export const LoadingWithRightPanel: Story = {
 		<AgentChatPageLoadingView
 			sendShortcut="enter"
 			titleElement={<title>Loading — Agents</title>}
+			inputRef={{ current: null }}
+			initialValue=""
+			initialEditorState={undefined}
+			remountKey={0}
+			onContentChange={fn()}
 			isInputDisabled
 			effectiveSelectedModel={defaultModelConfigID}
 			setSelectedModel={fn()}
@@ -804,6 +819,11 @@ export const LoadingSidebarCollapsed: Story = {
 		<AgentChatPageLoadingView
 			sendShortcut="enter"
 			titleElement={<title>Loading — Agents</title>}
+			inputRef={{ current: null }}
+			initialValue=""
+			initialEditorState={undefined}
+			remountKey={0}
+			onContentChange={fn()}
 			isInputDisabled
 			effectiveSelectedModel={defaultModelConfigID}
 			setSelectedModel={fn()}

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -837,6 +837,15 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 interface AgentChatPageLoadingViewProps {
 	sendShortcut: AgentChatSendShortcut;
 	titleElement: React.ReactNode;
+	inputRef: RefObject<ChatMessageInputRef | null>;
+	initialValue: string;
+	initialEditorState: string | undefined;
+	remountKey: number;
+	onContentChange: (
+		content: string,
+		serializedEditorState: string,
+		hasFileReferences: boolean,
+	) => void;
 	isInputDisabled: boolean;
 	effectiveSelectedModel: string;
 	setSelectedModel: (model: string) => void;
@@ -854,6 +863,11 @@ interface AgentChatPageLoadingViewProps {
 export const AgentChatPageLoadingView: FC<AgentChatPageLoadingViewProps> = ({
 	sendShortcut,
 	titleElement,
+	inputRef,
+	initialValue,
+	initialEditorState,
+	remountKey,
+	onContentChange,
 	isInputDisabled,
 	effectiveSelectedModel,
 	setSelectedModel,
@@ -906,7 +920,11 @@ export const AgentChatPageLoadingView: FC<AgentChatPageLoadingViewProps> = ({
 					<AgentChatInput
 						onSend={() => {}}
 						sendShortcut={sendShortcut}
-						initialValue=""
+						inputRef={inputRef}
+						initialValue={initialValue}
+						initialEditorState={initialEditorState}
+						remountKey={remountKey}
+						onContentChange={onContentChange}
 						isDisabled={isInputDisabled}
 						isLoading={false}
 						selectedModel={effectiveSelectedModel}


### PR DESCRIPTION
## Problem

Typed chat input was lost when a chat was still loading. If the user started
typing in the message composer before the chat finished loading, their text was
discarded once the chat loaded.

## Root cause

While the chat is loading, `AgentChatPage` renders a separate
`AgentChatPageLoadingView` whose `AgentChatInput` was wired with
`initialValue=""` and no `onContentChange`, so anything typed was never
persisted. When the queries resolved, that subtree unmounted and the loaded
editor mounted seeded from `editing.editorInitialValue` / `initialEditorState`,
which were captured (empty) at the page's first mount. The typed text was
therefore discarded.

## Fix

- Add `handleLoadingDraftChange` to `useConversationEditingState`. It persists
  the draft via the existing `handleContentChange` and also advances the seed
  state so the draft survives the loading-to-loaded editor swap. It is kept
  separate from `handleContentChange`, which runs on every keystroke in the
  loaded editor and must avoid re-renders.
- Wire the loading branch to pass `inputRef`, `initialValue`,
  `initialEditorState`, `remountKey`, and
  `onContentChange={editing.handleLoadingDraftChange}` to the loading view.
- `AgentChatPageLoadingView` now accepts and forwards those props to its
  `AgentChatInput`. As a side effect it also restores any pre-existing draft,
  which it previously ignored.

## Testing

- `tsc --noEmit`: clean
- `vitest` (`useConversationEditingState`): passing, including a new regression
  test that a draft typed during loading is carried into the seed for the loaded
  editor
- `biome check`: clean
- Updated the 4 `AgentChatPageLoadingView` stories for the new props

<details>
<summary>Implementation notes</summary>

The seed update lives in a dedicated loading-only handler rather than in
`handleContentChange` because the latter is called on every keystroke in the
mounted loaded editor and deliberately avoids `setState` to prevent per-keystroke
re-renders. During loading there is no heavy editor mounted, so updating the seed
state there is cheap and the active Lexical instance is preserved (its
`LexicalComposer` key, `remountKey`, is unchanged and `ValueSyncPlugin` only seeds
once per mount).

</details>

> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood
