### PR TITLE
feat: add BaseTemplateParametersStep

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -23621,6 +23621,12 @@ const docTemplate = `{
                 },
                 "os": {
                     "type": "string"
+                },
+                "variables": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.TemplateBuilderModuleVariable"
+                    }
                 }
             }
         },
@@ -23655,6 +23661,12 @@ const docTemplate = `{
                 "base_template_id": {
                     "type": "string"
                 },
+                "base_variable_values": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "modules": {
                     "type": "array",
                     "items": {
@@ -23683,6 +23695,12 @@ const docTemplate = `{
             "properties": {
                 "base_template_id": {
                     "type": "string"
+                },
+                "base_variable_values": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "description": {
                     "type": "string"

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -21671,6 +21671,12 @@
 				},
 				"os": {
 					"type": "string"
+				},
+				"variables": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.TemplateBuilderModuleVariable"
+					}
 				}
 			}
 		},
@@ -21705,6 +21711,12 @@
 				"base_template_id": {
 					"type": "string"
 				},
+				"base_variable_values": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "string"
+					}
+				},
 				"modules": {
 					"type": "array",
 					"items": {
@@ -21730,6 +21742,12 @@
 			"properties": {
 				"base_template_id": {
 					"type": "string"
+				},
+				"base_variable_values": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "string"
+					}
 				},
 				"description": {
 					"type": "string"

--- a/coderd/templatebuilder/bases.go
+++ b/coderd/templatebuilder/bases.go
@@ -41,6 +41,7 @@ type BaseManifest struct {
 	DisplayName    string             `json:"display_name"`
 	OS             string             `json:"os"`
 	DefaultContext BaseDefaultContext `json:"default_context"`
+	Variables      []ModuleVariable   `json:"variables"`
 }
 
 // BaseDefaultContext holds default render values stored in base.json.
@@ -190,6 +191,17 @@ func BaseTemplateIDs() []string {
 		ids = append(ids, id)
 	}
 	return ids
+}
+
+// BaseVariables returns the user-facing variables for a given base
+// template ID. Computed variables are excluded. Returns nil if the
+// base is unknown or has no variables.
+func BaseVariables(exampleID string) []ModuleVariable {
+	bases, err := loadBases()
+	if err != nil || bases[exampleID] == nil {
+		return nil
+	}
+	return bases[exampleID].Manifest.Variables
 }
 
 // BaseTemplateFS returns a filesystem rooted at the given base template

--- a/coderd/templatebuilder/bases/kubernetes/base.json
+++ b/coderd/templatebuilder/bases/kubernetes/base.json
@@ -4,5 +4,24 @@
 	"os": "linux",
 	"default_context": {
 		"container_image": "codercom/enterprise-base:ubuntu"
-	}
+	},
+	"variables": [
+		{
+			"name": "use_kubeconfig",
+			"type": "bool",
+			"description": "Use host kubeconfig. Set to true if the Coder host is running outside the Kubernetes cluster for workspaces.",
+			"default": false,
+			"required": false,
+			"sensitive": false,
+			"computed": false
+		},
+		{
+			"name": "namespace",
+			"type": "string",
+			"description": "The Kubernetes namespace to create workspaces in. Must exist prior to creating workspaces.",
+			"required": true,
+			"sensitive": false,
+			"computed": false
+		}
+	]
 }

--- a/coderd/templatebuilder/compose.go
+++ b/coderd/templatebuilder/compose.go
@@ -21,6 +21,9 @@ var numberPattern = regexp.MustCompile(`^-?[0-9]+(\.[0-9]+)?$`)
 // ComposeRequest describes which base template and modules to render.
 type ComposeRequest struct {
 	BaseTemplateID string
+	// BaseVariableValues maps base template variable names to their
+	// user-supplied values.
+	BaseVariableValues map[string]string
 	// RegistryURL is the module registry base URL from the deployment
 	// config (CODER_TEMPLATE_BUILDER_REGISTRY_URL).
 	RegistryURL string
@@ -49,7 +52,7 @@ type ComposeResult struct {
 // source files. It extracts the coder_agent resource name from the
 // rendered base HCL and wires it into each module block.
 func Compose(req ComposeRequest) (*ComposeResult, error) {
-	mainTF, err := renderBase(req.BaseTemplateID)
+	mainTF, err := renderBase(req.BaseTemplateID, req.BaseVariableValues)
 	if err != nil {
 		return nil, err
 	}
@@ -93,9 +96,16 @@ func formatHCL(src []byte) []byte {
 	return hclwrite.Format(src)
 }
 
-// renderBase renders the base template for the given example ID.
-func renderBase(baseTemplateID string) ([]byte, error) {
+// renderBase renders the base template for the given example ID,
+// merging any user-supplied variable values into the render context.
+func renderBase(baseTemplateID string, baseVars map[string]string) ([]byte, error) {
 	renderCtx := DefaultBaseRenderContext(baseTemplateID)
+	if renderCtx.Variables == nil {
+		renderCtx.Variables = make(map[string]string)
+	}
+	for k, v := range baseVars {
+		renderCtx.Variables[k] = v
+	}
 	mainTF, err := RenderBaseTemplate(baseTemplateID, "main.tf.tmpl", renderCtx)
 	if err != nil {
 		return nil, xerrors.Errorf("render base template: %w", err)

--- a/coderd/templatebuilder/compose.go
+++ b/coderd/templatebuilder/compose.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"encoding/json"
+	"maps"
 	"regexp"
 	"strings"
 	"time"
@@ -103,9 +104,7 @@ func renderBase(baseTemplateID string, baseVars map[string]string) ([]byte, erro
 	if renderCtx.Variables == nil {
 		renderCtx.Variables = make(map[string]string)
 	}
-	for k, v := range baseVars {
-		renderCtx.Variables[k] = v
-	}
+	maps.Copy(renderCtx.Variables, baseVars)
 	mainTF, err := RenderBaseTemplate(baseTemplateID, "main.tf.tmpl", renderCtx)
 	if err != nil {
 		return nil, xerrors.Errorf("render base template: %w", err)

--- a/coderd/templatebuilder_handler.go
+++ b/coderd/templatebuilder_handler.go
@@ -72,12 +72,14 @@ func (api *API) templateBuilderBases(rw http.ResponseWriter, r *http.Request) {
 				slog.F("base_template_id", id))
 			continue
 		}
+		vars := baseVariablesToSDK(templatebuilder.BaseVariables(id))
 		bases = append(bases, codersdk.TemplateBuilderBase{
 			ID:          ex.ID,
 			Name:        ex.Name,
 			Description: ex.Description,
 			Icon:        ex.Icon,
 			OS:          string(templatebuilder.BaseTemplateOS(id)),
+			Variables:   vars,
 		})
 	}
 
@@ -88,6 +90,26 @@ func (api *API) templateBuilderBases(rw http.ResponseWriter, r *http.Request) {
 	httpapi.Write(ctx, rw, http.StatusOK, codersdk.TemplateBuilderBasesResponse{
 		Bases: bases,
 	})
+}
+
+// baseVariablesToSDK converts base template variables to the SDK type,
+// filtering out computed variables that the builder wires automatically.
+func baseVariablesToSDK(vars []templatebuilder.ModuleVariable) []codersdk.TemplateBuilderModuleVariable {
+	out := make([]codersdk.TemplateBuilderModuleVariable, 0, len(vars))
+	for _, v := range vars {
+		if v.Computed {
+			continue
+		}
+		out = append(out, codersdk.TemplateBuilderModuleVariable{
+			Name:        v.Name,
+			Type:        codersdk.TemplateBuilderVariableType(v.Type),
+			Description: v.Description,
+			Default:     v.Default,
+			Required:    v.Required,
+			Sensitive:   v.Sensitive,
+		})
+	}
+	return out
 }
 
 // @Summary List template builder modules
@@ -171,8 +193,9 @@ func (api *API) templateBuilderCompose(rw http.ResponseWriter, r *http.Request) 
 	}
 
 	composeReq := templatebuilder.ComposeRequest{
-		BaseTemplateID: req.BaseTemplateID,
-		RegistryURL:    api.DeploymentValues.TemplateBuilder.RegistryURL.String(),
+		BaseTemplateID:     req.BaseTemplateID,
+		BaseVariableValues: req.BaseVariableValues,
+		RegistryURL:        api.DeploymentValues.TemplateBuilder.RegistryURL.String(),
 	}
 	for _, m := range req.Modules {
 		composeReq.Modules = append(composeReq.Modules, templatebuilder.ComposeModule{
@@ -280,8 +303,9 @@ func (api *API) templateBuilderCreateTemplate(rw http.ResponseWriter, r *http.Re
 
 	// Compose the template.
 	composeReq := templatebuilder.ComposeRequest{
-		BaseTemplateID: req.BaseTemplateID,
-		RegistryURL:    api.DeploymentValues.TemplateBuilder.RegistryURL.String(),
+		BaseTemplateID:     req.BaseTemplateID,
+		BaseVariableValues: req.BaseVariableValues,
+		RegistryURL:        api.DeploymentValues.TemplateBuilder.RegistryURL.String(),
 	}
 	for _, m := range req.Modules {
 		composeReq.Modules = append(composeReq.Modules, templatebuilder.ComposeModule{

--- a/coderd/templatebuilder_handler_test.go
+++ b/coderd/templatebuilder_handler_test.go
@@ -34,12 +34,53 @@ func TestTemplateBuilderBases(t *testing.T) {
 			basesByID[b.ID] = b
 		}
 
-		for _, id := range templatebuilder.BaseTemplateIDs() {
-			b, ok := basesByID[id]
-			require.True(t, ok, "base %q missing from response", id)
-			require.NotEmpty(t, b.Name)
-			require.NotEmpty(t, b.Icon)
-			require.Equal(t, string(templatebuilder.BaseTemplateOS(id)), b.OS)
+		type baseSpec struct {
+			id           string
+			expectedOS   string
+			expectedVars []string
+			hasVariables bool
+		}
+
+		specs := []baseSpec{
+			{
+				id:           "docker",
+				expectedOS:   "linux",
+				hasVariables: false,
+			},
+			{
+				id:           "kubernetes",
+				expectedOS:   "linux",
+				hasVariables: true,
+				expectedVars: []string{"namespace", "use_kubeconfig"},
+			},
+			{
+				id:           "aws-linux",
+				expectedOS:   "linux",
+				hasVariables: false,
+			},
+		}
+
+		for _, spec := range specs {
+			b, ok := basesByID[spec.id]
+			require.True(t, ok, "base %q missing from response", spec.id)
+			require.NotEmpty(t, b.Name, "base %q should have a name", spec.id)
+			require.NotEmpty(t, b.Icon, "base %q should have an icon", spec.id)
+			require.Equal(t, spec.expectedOS, b.OS, "base %q OS mismatch", spec.id)
+			require.NotNil(t, b.Variables, "base %q should have non-nil variables slice", spec.id)
+
+			if spec.hasVariables {
+				require.NotEmpty(t, b.Variables, "base %q should have variables", spec.id)
+				varNames := make(map[string]bool, len(b.Variables))
+				for _, v := range b.Variables {
+					varNames[v.Name] = true
+				}
+				for _, expected := range spec.expectedVars {
+					require.True(t, varNames[expected],
+						"base %q should have variable %q", spec.id, expected)
+				}
+			} else {
+				require.Empty(t, b.Variables, "base %q should have no variables", spec.id)
+			}
 		}
 	})
 

--- a/codersdk/templatebuilder.go
+++ b/codersdk/templatebuilder.go
@@ -52,11 +52,12 @@ type TemplateBuilderModulesResponse struct {
 // TemplateBuilderBase is the API response type for a base template
 // returned by GET /api/v2/templatebuilder/bases.
 type TemplateBuilderBase struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Icon        string `json:"icon"`
-	OS          string `json:"os"`
+	ID          string                          `json:"id"`
+	Name        string                          `json:"name"`
+	Description string                          `json:"description"`
+	Icon        string                          `json:"icon"`
+	OS          string                          `json:"os"`
+	Variables   []TemplateBuilderModuleVariable `json:"variables"`
 }
 
 // TemplateBuilderBasesResponse is the response body for listing template builder bases.
@@ -102,8 +103,9 @@ func (c *Client) TemplateBuilderModules(ctx context.Context, base string) (Templ
 // TemplateBuilderComposeRequest is the request body for
 // POST /api/v2/templatebuilder/compose.
 type TemplateBuilderComposeRequest struct {
-	BaseTemplateID string                         `json:"base_template_id"`
-	Modules        []TemplateBuilderComposeModule `json:"modules"`
+	BaseTemplateID     string                         `json:"base_template_id"`
+	BaseVariableValues map[string]string              `json:"base_variable_values,omitempty"`
+	Modules            []TemplateBuilderComposeModule `json:"modules"`
 }
 
 // TemplateBuilderComposeModule identifies a module and its variable
@@ -130,14 +132,15 @@ func (c *Client) TemplateBuilderCompose(ctx context.Context, req TemplateBuilder
 // TemplateBuilderCreateTemplateRequest is the request body for
 // POST /api/v2/templatebuilder/compose/template.
 type TemplateBuilderCreateTemplateRequest struct {
-	BaseTemplateID  string                         `json:"base_template_id"`
-	Modules         []TemplateBuilderComposeModule `json:"modules"`
-	OrganizationID  uuid.UUID                      `json:"organization_id" format:"uuid" validate:"required"`
-	Name            string                         `json:"name" validate:"required,template_name"`
-	DisplayName     string                         `json:"display_name,omitempty" validate:"template_display_name"`
-	Description     string                         `json:"description,omitempty" validate:"lt=128"`
-	Icon            string                         `json:"icon,omitempty"`
-	ProvisionerTags map[string]string              `json:"provisioner_tags,omitempty"`
+	BaseTemplateID     string                         `json:"base_template_id"`
+	BaseVariableValues map[string]string              `json:"base_variable_values,omitempty"`
+	Modules            []TemplateBuilderComposeModule `json:"modules"`
+	OrganizationID     uuid.UUID                      `json:"organization_id" format:"uuid" validate:"required"`
+	Name               string                         `json:"name" validate:"required,template_name"`
+	DisplayName        string                         `json:"display_name,omitempty" validate:"template_display_name"`
+	Description        string                         `json:"description,omitempty" validate:"lt=128"`
+	Icon               string                         `json:"icon,omitempty"`
+	ProvisionerTags    map[string]string              `json:"provisioner_tags,omitempty"`
 }
 
 // TemplateBuilderCreateTemplateResponse is the response body for

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -11883,19 +11883,32 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
   "icon": "string",
   "id": "string",
   "name": "string",
-  "os": "string"
+  "os": "string",
+  "variables": [
+    {
+      "default": [
+        0
+      ],
+      "description": "string",
+      "name": "string",
+      "required": true,
+      "sensitive": true,
+      "type": "string"
+    }
+  ]
 }
 ```
 
 ### Properties
 
-| Name          | Type   | Required | Restrictions | Description |
-|---------------|--------|----------|--------------|-------------|
-| `description` | string | false    |              |             |
-| `icon`        | string | false    |              |             |
-| `id`          | string | false    |              |             |
-| `name`        | string | false    |              |             |
-| `os`          | string | false    |              |             |
+| Name          | Type                                                                                      | Required | Restrictions | Description |
+|---------------|-------------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `description` | string                                                                                    | false    |              |             |
+| `icon`        | string                                                                                    | false    |              |             |
+| `id`          | string                                                                                    | false    |              |             |
+| `name`        | string                                                                                    | false    |              |             |
+| `os`          | string                                                                                    | false    |              |             |
+| `variables`   | array of [codersdk.TemplateBuilderModuleVariable](#codersdktemplatebuildermodulevariable) | false    |              |             |
 
 ## codersdk.TemplateBuilderBasesResponse
 
@@ -11907,7 +11920,19 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
       "icon": "string",
       "id": "string",
       "name": "string",
-      "os": "string"
+      "os": "string",
+      "variables": [
+        {
+          "default": [
+            0
+          ],
+          "description": "string",
+          "name": "string",
+          "required": true,
+          "sensitive": true,
+          "type": "string"
+        }
+      ]
     }
   ]
 }
@@ -11944,6 +11969,10 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 ```json
 {
   "base_template_id": "string",
+  "base_variable_values": {
+    "property1": "string",
+    "property2": "string"
+  },
   "modules": [
     {
       "id": "string",
@@ -11958,10 +11987,12 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 
 ### Properties
 
-| Name               | Type                                                                                    | Required | Restrictions | Description |
-|--------------------|-----------------------------------------------------------------------------------------|----------|--------------|-------------|
-| `base_template_id` | string                                                                                  | false    |              |             |
-| `modules`          | array of [codersdk.TemplateBuilderComposeModule](#codersdktemplatebuildercomposemodule) | false    |              |             |
+| Name                   | Type                                                                                    | Required | Restrictions | Description |
+|------------------------|-----------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `base_template_id`     | string                                                                                  | false    |              |             |
+| `base_variable_values` | object                                                                                  | false    |              |             |
+| » `[any property]`     | string                                                                                  | false    |              |             |
+| `modules`              | array of [codersdk.TemplateBuilderComposeModule](#codersdktemplatebuildercomposemodule) | false    |              |             |
 
 ## codersdk.TemplateBuilderConfig
 
@@ -11984,6 +12015,10 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 ```json
 {
   "base_template_id": "string",
+  "base_variable_values": {
+    "property1": "string",
+    "property2": "string"
+  },
   "description": "string",
   "display_name": "string",
   "icon": "string",
@@ -12007,17 +12042,19 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 
 ### Properties
 
-| Name               | Type                                                                                    | Required | Restrictions | Description |
-|--------------------|-----------------------------------------------------------------------------------------|----------|--------------|-------------|
-| `base_template_id` | string                                                                                  | false    |              |             |
-| `description`      | string                                                                                  | false    |              |             |
-| `display_name`     | string                                                                                  | false    |              |             |
-| `icon`             | string                                                                                  | false    |              |             |
-| `modules`          | array of [codersdk.TemplateBuilderComposeModule](#codersdktemplatebuildercomposemodule) | false    |              |             |
-| `name`             | string                                                                                  | true     |              |             |
-| `organization_id`  | string                                                                                  | true     |              |             |
-| `provisioner_tags` | object                                                                                  | false    |              |             |
-| » `[any property]` | string                                                                                  | false    |              |             |
+| Name                   | Type                                                                                    | Required | Restrictions | Description |
+|------------------------|-----------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `base_template_id`     | string                                                                                  | false    |              |             |
+| `base_variable_values` | object                                                                                  | false    |              |             |
+| » `[any property]`     | string                                                                                  | false    |              |             |
+| `description`          | string                                                                                  | false    |              |             |
+| `display_name`         | string                                                                                  | false    |              |             |
+| `icon`                 | string                                                                                  | false    |              |             |
+| `modules`              | array of [codersdk.TemplateBuilderComposeModule](#codersdktemplatebuildercomposemodule) | false    |              |             |
+| `name`                 | string                                                                                  | true     |              |             |
+| `organization_id`      | string                                                                                  | true     |              |             |
+| `provisioner_tags`     | object                                                                                  | false    |              |             |
+| » `[any property]`     | string                                                                                  | false    |              |             |
 
 ## codersdk.TemplateBuilderCreateTemplateResponse
 

--- a/docs/reference/api/templatebuilder.md
+++ b/docs/reference/api/templatebuilder.md
@@ -25,7 +25,19 @@ curl -X GET http://coder-server:8080/api/v2/templatebuilder/bases \
       "icon": "string",
       "id": "string",
       "name": "string",
-      "os": "string"
+      "os": "string",
+      "variables": [
+        {
+          "default": [
+            0
+          ],
+          "description": "string",
+          "name": "string",
+          "required": true,
+          "sensitive": true,
+          "type": "string"
+        }
+      ]
     }
   ]
 }
@@ -57,6 +69,10 @@ curl -X POST http://coder-server:8080/api/v2/templatebuilder/compose \
 ```json
 {
   "base_template_id": "string",
+  "base_variable_values": {
+    "property1": "string",
+    "property2": "string"
+  },
   "modules": [
     {
       "id": "string",
@@ -102,6 +118,10 @@ curl -X POST http://coder-server:8080/api/v2/templatebuilder/compose/template \
 ```json
 {
   "base_template_id": "string",
+  "base_variable_values": {
+    "property1": "string",
+    "property2": "string"
+  },
   "description": "string",
   "display_name": "string",
   "icon": "string",

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -8119,6 +8119,7 @@ export interface TemplateBuilderBase {
 	readonly description: string;
 	readonly icon: string;
 	readonly os: string;
+	readonly variables: readonly TemplateBuilderModuleVariable[];
 }
 
 // From codersdk/templatebuilder.go
@@ -8146,6 +8147,7 @@ export interface TemplateBuilderComposeModule {
  */
 export interface TemplateBuilderComposeRequest {
 	readonly base_template_id: string;
+	readonly base_variable_values?: Record<string, string>;
 	readonly modules: readonly TemplateBuilderComposeModule[];
 }
 
@@ -8162,6 +8164,7 @@ export interface TemplateBuilderConfig {
  */
 export interface TemplateBuilderCreateTemplateRequest {
 	readonly base_template_id: string;
+	readonly base_variable_values?: Record<string, string>;
 	readonly modules: readonly TemplateBuilderComposeModule[];
 	readonly organization_id: string;
 	readonly name: string;

--- a/site/src/pages/TemplateBuilder/BaseInfraSelectStep.tsx
+++ b/site/src/pages/TemplateBuilder/BaseInfraSelectStep.tsx
@@ -18,7 +18,8 @@ function toSelectedBaseMeta(base: TemplateBuilderBase): SelectedBaseMeta {
 		name: base.name,
 		iconUrl: base.icon,
 		os: base.os,
-		hasParameters: false,
+		hasParameters:
+			base.variables.length > 0 && base.variables.some((v) => !v.sensitive),
 	};
 }
 

--- a/site/src/pages/TemplateBuilder/BaseTemplateParametersStep.tsx
+++ b/site/src/pages/TemplateBuilder/BaseTemplateParametersStep.tsx
@@ -1,0 +1,110 @@
+import type { FC } from "react";
+import { useQuery } from "react-query";
+import { templateBuilderBases } from "#/api/queries/templateBuilder";
+import type {
+	TemplateBuilderBasesResponse,
+	TemplateBuilderModuleVariable,
+} from "#/api/typesGenerated";
+import type { ConfigurationFieldDefinition } from "./ConfigurationField";
+import { TemplateConfiguration } from "./TemplateConfiguration";
+
+interface BaseTemplateParametersStepProps {
+	baseId: string;
+	values: Record<string, string>;
+	onChangeValues: (values: Record<string, string>) => void;
+}
+
+function detailsUrl(baseId: string): string {
+	return `https://registry.coder.com/templates/${baseId}`;
+}
+
+/**
+ * Maps a TemplateBuilderModuleVariable to a ConfigurationFieldDefinition,
+ * using the controlled values from wizard state.
+ */
+function variableToField(
+	variable: TemplateBuilderModuleVariable,
+	value: string,
+	onChange: (name: string, value: string) => void,
+): ConfigurationFieldDefinition {
+	const id = `base-var-${variable.name}`;
+
+	if (variable.type === "bool") {
+		return {
+			type: "switch",
+			id,
+			label: variable.name,
+			description: variable.description || undefined,
+			required: variable.required,
+			checked: value === "true",
+			onCheckedChange: (checked) =>
+				onChange(variable.name, checked ? "true" : "false"),
+		};
+	}
+
+	return {
+		type: "text",
+		id,
+		label: variable.name,
+		description: variable.description || undefined,
+		required: variable.required,
+		placeholder: variable.required ? "Required" : "Optional",
+		field: {
+			name: variable.name,
+			id,
+			value,
+			onChange: (e) => onChange(variable.name, e.target.value),
+			onBlur: () => {},
+			error: false,
+		},
+	};
+}
+
+/**
+ * Returns true when all required, non-sensitive base variables have
+ * a non-empty value. Returns true when no variables need filling.
+ */
+export function baseParametersComplete(
+	bases: TemplateBuilderBasesResponse | undefined,
+	baseId: string | null,
+	values: Record<string, string>,
+): boolean {
+	if (!bases || !baseId) {
+		return true;
+	}
+	const base = bases.bases.find((b) => b.id === baseId);
+	if (!base) {
+		return true;
+	}
+	const required = base.variables.filter((v) => v.required && !v.sensitive);
+	return required.every((v) => {
+		const val = values[v.name];
+		return val !== undefined && val !== "";
+	});
+}
+
+export const BaseTemplateParametersStep: FC<
+	BaseTemplateParametersStepProps
+> = ({ baseId, values, onChangeValues }) => {
+	const { data } = useQuery(templateBuilderBases());
+	const base = data?.bases.find((b) => b.id === baseId);
+	const variables = base?.variables.filter((v) => !v.sensitive) ?? [];
+
+	const handleChange = (name: string, value: string) => {
+		onChangeValues({ ...values, [name]: value });
+	};
+
+	const fields: ConfigurationFieldDefinition[] = variables.map((v) =>
+		variableToField(v, values[v.name] ?? "", handleChange),
+	);
+
+	return (
+		<TemplateConfiguration
+			name={base?.name ?? "Base Template"}
+			description={base?.description ?? ""}
+			iconUrl={base?.icon}
+			detailsUrl={detailsUrl(baseId)}
+			fields={fields}
+		/>
+	);
+};

--- a/site/src/pages/TemplateBuilder/ConfigurationField.tsx
+++ b/site/src/pages/TemplateBuilder/ConfigurationField.tsx
@@ -124,14 +124,14 @@ const SelectField: FC<SelectFieldDefinition> = ({
 				{required && (
 					<>
 						{" "}
-						<span className="text-xs font-bold text-content-destructive">
+						<span className="text-sm font-bold text-content-destructive">
 							*
 						</span>
 					</>
 				)}
 			</Label>
 			{description && (
-				<div id={descriptionId} className="text-xs text-content-secondary">
+				<div id={descriptionId} className="text-sm text-content-secondary">
 					{description}
 				</div>
 			)}
@@ -172,14 +172,14 @@ const RadioField: FC<RadioFieldDefinition> = ({
 				{required && (
 					<>
 						{" "}
-						<span className="text-xs font-bold text-content-destructive">
+						<span className="text-sm font-bold text-content-destructive">
 							*
 						</span>
 					</>
 				)}
 			</Label>
 			{description && (
-				<div id={descriptionId} className="text-xs text-content-secondary">
+				<div id={descriptionId} className="text-sm text-content-secondary">
 					{description}
 				</div>
 			)}
@@ -257,7 +257,7 @@ const SwitchField: FC<SwitchFieldDefinition> = ({
 						{required && (
 							<>
 								{" "}
-								<span className="text-xs font-bold text-content-destructive">
+								<span className="text-sm font-bold text-content-destructive">
 									*
 								</span>
 							</>
@@ -270,7 +270,7 @@ const SwitchField: FC<SwitchFieldDefinition> = ({
 				describedBy={description ? descriptionId : undefined}
 			/>
 			{description && (
-				<div id={descriptionId} className="text-xs text-content-secondary">
+				<div id={descriptionId} className="text-sm text-content-secondary">
 					{description}
 				</div>
 			)}
@@ -294,14 +294,14 @@ const SwitchGroupField: FC<SwitchGroupFieldDefinition> = ({
 				{required && (
 					<>
 						{" "}
-						<span className="text-xs font-bold text-content-destructive">
+						<span className="text-sm font-bold text-content-destructive">
 							*
 						</span>
 					</>
 				)}
 			</Label>
 			{description && (
-				<div id={descriptionId} className="text-xs text-content-secondary">
+				<div id={descriptionId} className="text-sm text-content-secondary">
 					{description}
 				</div>
 			)}

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
@@ -1,4 +1,6 @@
 import { type FC, useReducer, useState } from "react";
+import { useQuery } from "react-query";
+import { templateBuilderBases } from "#/api/queries/templateBuilder";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Button } from "#/components/Button/Button";
 import { Link } from "#/components/Link/Link";
@@ -10,6 +12,10 @@ import {
 } from "#/components/PageHeader/PageHeader";
 import { docs } from "#/utils/docs";
 import { BaseInfraSelectStep } from "./BaseInfraSelectStep";
+import {
+	BaseTemplateParametersStep,
+	baseParametersComplete,
+} from "./BaseTemplateParametersStep";
 import { SelectionSummary } from "./SelectionSummary";
 import {
 	findNextVisibleIndex,
@@ -28,6 +34,7 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 }) => {
 	const [state, dispatch] = useReducer(wizardReducer, initialWizardState);
 	const [stepIndex, setStepIndex] = useState(0);
+	const basesQuery = useQuery(templateBuilderBases());
 
 	const currentIndex = nearestVisible(stepIndex, state);
 	const currentStep = WIZARD_STEPS[currentIndex];
@@ -35,6 +42,14 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 	const prevIndex = findPrevVisibleIndex(currentIndex, state);
 	const isFirstStep = prevIndex === -1;
 	const isLastStep = nextIndex === -1;
+
+	const canContinue =
+		currentStep.id !== "base-parameters" ||
+		baseParametersComplete(
+			basesQuery.data,
+			state.selectedBase?.id ?? null,
+			state.baseVariableValues,
+		);
 
 	const handleBack = () => {
 		setStepIndex(prevIndex);
@@ -78,6 +93,14 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 							selectedBaseId={state.selectedBase?.id ?? null}
 							onSelectBase={(base) => dispatch({ type: "SET_BASE", base })}
 						/>
+					) : currentStep.id === "base-parameters" && state.selectedBase ? (
+						<BaseTemplateParametersStep
+							baseId={state.selectedBase.id}
+							values={state.baseVariableValues}
+							onChangeValues={(values) =>
+								dispatch({ type: "SET_BASE_VARIABLES", values })
+							}
+						/>
 					) : (
 						<div className="rounded-lg border border-solid border-border bg-surface-primary p-6 min-h-[400px]">
 							<p className="text-sm text-content-secondary">
@@ -95,7 +118,7 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 								Back
 							</Button>
 						)}
-						<Button onClick={handleNext}>
+						<Button onClick={handleNext} disabled={!canContinue}>
 							{isLastStep ? "Create Template" : "Continue"}
 						</Button>
 					</div>

--- a/site/src/pages/TemplateBuilder/TemplateConfiguration.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateConfiguration.tsx
@@ -22,7 +22,7 @@ export const TemplateConfiguration: React.FC<TemplateConfigurationProps> = ({
 	return (
 		<section className="pt-4 px-4 pb-6 rounded bg-surface-secondary">
 			<header className="mb-6">
-				<figure className="flex items-center justify-center p-1 rounded-md size-10 shrink-0 bg-surface-secondary border border-solid border-border mb-3">
+				<figure className="flex items-center justify-center p-1 rounded-md size-10 shrink-0 bg-surface-secondary border border-solid border-border m-0 mb-3">
 					{iconUrl ? (
 						<img
 							src={iconUrl}
@@ -34,8 +34,8 @@ export const TemplateConfiguration: React.FC<TemplateConfigurationProps> = ({
 					)}
 				</figure>
 				<div>
-					<h3 className="text-sm font-semibold text-content-primary">{name}</h3>
-					<p className="text-xs font-normal text-content-secondary inline">
+					<h3 className="text-md font-semibold text-content-primary">{name}</h3>
+					<p className="text-sm font-normal text-content-secondary inline">
 						{description}
 					</p>
 					{detailsUrl && (
@@ -44,7 +44,7 @@ export const TemplateConfiguration: React.FC<TemplateConfigurationProps> = ({
 							target="_blank"
 							rel="noreferrer"
 							size="sm"
-							className="text-xs font-normal ml-1"
+							className="text-sm font-normal ml-1"
 						>
 							View details
 						</Link>

--- a/site/src/pages/TemplateBuilder/wizardState.test.ts
+++ b/site/src/pages/TemplateBuilder/wizardState.test.ts
@@ -354,5 +354,19 @@ describe("toComposeRequest", () => {
 		const request = toComposeRequest(initialWizardState);
 		expect(request.base_template_id).toBe("");
 		expect(request.modules).toEqual([]);
+		expect(request.base_variable_values).toBeUndefined();
+	});
+
+	it("includes base_variable_values when set", () => {
+		const state: TemplateBuilderWizardState = {
+			...initialWizardState,
+			baseTemplateId: "kubernetes",
+			baseVariableValues: { namespace: "default", use_kubeconfig: "false" },
+		};
+		const request = toComposeRequest(state);
+		expect(request.base_variable_values).toEqual({
+			namespace: "default",
+			use_kubeconfig: "false",
+		});
 	});
 });

--- a/site/src/pages/TemplateBuilder/wizardState.ts
+++ b/site/src/pages/TemplateBuilder/wizardState.ts
@@ -142,6 +142,10 @@ export const toComposeRequest = (
 ): TemplateBuilderComposeRequest => {
 	return {
 		base_template_id: state.baseTemplateId ?? "",
+		base_variable_values:
+			Object.keys(state.baseVariableValues).length > 0
+				? state.baseVariableValues
+				: undefined,
 		modules: state.modules,
 	};
 };


### PR DESCRIPTION
Implement the base template parameters wizard step, which renders a configuration form for base template variables using the existing `TemplateConfiguration` and `ConfigurationField` components.

- Map `TemplateBuilderModuleVariable` to `ConfigurationFieldDefinition` (switch for bool, text input for string/number)
- Read variable definitions from the cached bases query
- Disable Continue button until all required non-sensitive variables have values (`baseParametersComplete` helper)
- Step is automatically skipped when the selected base has no parameters (e.g. Docker)
- Update `toComposeRequest` to include `base_variable_values` in the API payload

Relates to [DEVEX-284](https://linear.app/codercom/issue/DEVEX-284).

> [!NOTE]
> This PR was authored with Coder Agents.