### PR TITLE
fix(site): add bottom padding to create workspace page

### DIFF
--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -404,7 +404,7 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 					Go back
 				</button>
 			</div>
-			<div className="flex flex-col gap-6 max-w-screen-md mx-auto">
+			<div className="flex flex-col gap-6 max-w-screen-md mx-auto pb-96">
 				<header className="flex flex-col items-start gap-3 mt-10">
 					<div className="flex items-center gap-2 justify-between w-full">
 						<span className="flex items-center gap-2">


### PR DESCRIPTION
The form on the create workspace page sat flush against the bottom of the scrollable area, and the dropdown for a multi-select parameter near the bottom of the form would extend past the visible viewport with no way to scroll past it. Reserve enough room below the form for a fully expanded multi-select dropdown.

The added padding matches `max-h-96` on the `MultiSelectCombobox` dropdown's `CommandList`, so the dropdown can fully expand without being clipped by the bottom of the page.

This PR was Coder Agents generated.
