### PR TITLE
fix(coderd/httpmw): honor fixed lifetime for CLI API tokens (#26376)

### DIFF
--- a/coderd/httpmw/apikey.go
+++ b/coderd/httpmw/apikey.go
@@ -390,7 +390,11 @@ func ExtractAPIKey(rw http.ResponseWriter, r *http.Request, cfg ExtractAPIKeyCon
 	}
 	// Only update the ExpiresAt once an hour to prevent database spam.
 	// We extend the ExpiresAt to reduce re-authentication.
-	if !cfg.DisableSessionExpiryRefresh {
+	// Only apply sliding-window expiry refresh to interactive login
+	// sessions. Programmatic API tokens (LoginTypeToken, created via
+	// `coder tokens create`) honor a fixed, finite lifetime and must not be
+	// silently extended to now+lifetime on each authenticated request.
+	if !cfg.DisableSessionExpiryRefresh && key.LoginType != database.LoginTypeToken {
 		apiKeyLifetime := time.Duration(key.LifetimeSeconds) * time.Second
 		if key.ExpiresAt.Sub(now) <= apiKeyLifetime-time.Hour {
 			key.ExpiresAt = now.Add(apiKeyLifetime)

--- a/coderd/httpmw/apikey_test.go
+++ b/coderd/httpmw/apikey_test.go
@@ -440,6 +440,39 @@ func TestAPIKey(t *testing.T) {
 		require.NotEqual(t, sentAPIKey.ExpiresAt, gotAPIKey.ExpiresAt)
 	})
 
+	t.Run("TokenNoExpiryRefresh", func(t *testing.T) {
+		t.Parallel()
+		var (
+			db, _             = dbtestutil.NewDB(t)
+			user              = dbgen.User(t, db, database.User{})
+			sentAPIKey, token = dbgen.APIKey(t, db, database.APIKey{
+				UserID:    user.ID,
+				LastUsed:  dbtime.Now(),
+				ExpiresAt: dbtime.Now().Add(time.Minute),
+				LoginType: database.LoginTypeToken,
+			})
+
+			r  = httptest.NewRequest("GET", "/", nil)
+			rw = httptest.NewRecorder()
+		)
+		r.Header.Set(codersdk.SessionTokenHeader, token)
+
+		httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
+			DB:              db,
+			RedirectToLogin: false,
+		})(successHandler).ServeHTTP(rw, r)
+		res := rw.Result()
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		gotAPIKey, err := db.GetAPIKeyByID(r.Context(), sentAPIKey.ID)
+		require.NoError(t, err)
+
+		// Programmatic tokens honor a fixed lifetime, so the expiry must not be
+		// extended on use even though it is within the refresh window.
+		require.Equal(t, sentAPIKey.ExpiresAt, gotAPIKey.ExpiresAt)
+	})
+
 	t.Run("NoRefresh", func(t *testing.T) {
 		t.Parallel()
 		var (


### PR DESCRIPTION
Backport of https://github.com/coder/coder/pull/26376

Original PR: #26376 — fix(coderd/httpmw): honor fixed lifetime for CLI API tokens
Merge commit: 450ddff568afbed9e61d4ab1628fcc1c2f6d4e05
Requested by: @jdomeracki-coder

Programmatic API tokens (login type `token`, created via `coder tokens create`) had their `expires_at` extended to `now + lifetime` on each authenticated request, so a token used within its lifetime window never actually expired. This restricts the sliding-window expiry refresh to interactive login sessions (password / OIDC / GitHub) so programmatic tokens honor their fixed `expires_at`.

<details>
<summary>Backport note</summary>

#26376 was authored against `main`, where this logic lives in the refactored `ValidateAPIKey`. On `release/2.29` the equivalent sliding-window expiry refresh is in `ExtractAPIKey`, so the same one-line guard (`key.LoginType != database.LoginTypeToken`) and the `TokenNoExpiryRefresh` regression test were applied there. The resulting diff is identical in size (+38/-1).
</details>

<details>
<summary>Validation</summary>

- `go build ./coderd/httpmw/...` (clean)
- `gofmt -l` and `go vet ./coderd/httpmw/` (clean)
- `go test ./coderd/httpmw/ -run 'TestAPIKey/(TokenNoExpiryRefresh|ValidUpdateExpiry|NoRefresh)' -count=1` (all pass)
- Confirmed the new `TokenNoExpiryRefresh` test fails without the production change and passes with it.
</details>

---
🤖 Generated by Coder Agents on behalf of @jdomeracki-coder.