### PR TITLE
test(coderd): deflake TestAgentChatContext/AddSuccessUpdatesChatState…

### DIFF
--- a/coderd/workspaceagents_chat_context_test.go
+++ b/coderd/workspaceagents_chat_context_test.go
@@ -233,8 +233,9 @@ func TestAgentChatContext(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitLong)
 		baseDB, pubsub := dbtestutil.NewDB(t)
 		client := coderdtest.New(t, &coderdtest.Options{
-			Database: baseDB,
-			Pubsub:   pubsub,
+			Database:           baseDB,
+			Pubsub:             pubsub,
+			ChatWorkerDisabled: true,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
 		workspace := dbfake.WorkspaceBuild(t, baseDB, database.WorkspaceTable{
@@ -1120,7 +1121,9 @@ func agentChatContextExpectedCachedParts(agent database.WorkspaceAgent, parts []
 func newAgentChatContextTestSetup(t *testing.T) agentChatContextTestSetup {
 	t.Helper()
 
-	client, db := coderdtest.NewWithDatabase(t, nil)
+	client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{
+		ChatWorkerDisabled: true,
+	})
 	user := coderdtest.CreateFirstUser(t, client)
 	workspace := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
 		OrganizationID: user.OrganizationID,


### PR DESCRIPTION
…VersionsAndPublishes

Closes https://github.com/coder/internal/issues/1592. In the test, the background chat worker consumes an ownership hint before the test reads the DB. The worker acquires the chat via `ChatMachine.Update`, which calls `LockChatAndBumpSnapshotVersion`, bumping `snapshot_version` again from 2 to 3. Disabling the chat worker ensures there's no race between the acquisition and the test assertion.
