### PR TITLE
feat: register scripts as sync units for lifecycle tracking

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -52,6 +52,7 @@ import (
 	"github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/agent/proto/resourcesmonitor"
 	"github.com/coder/coder/v2/agent/reconnectingpty"
+	"github.com/coder/coder/v2/agent/unit"
 	"github.com/coder/coder/v2/agent/usershell"
 	"github.com/coder/coder/v2/agent/x/agentdesktop"
 	"github.com/coder/coder/v2/agent/x/agentmcp"
@@ -367,6 +368,7 @@ type agent struct {
 	socketServerEnabled bool
 	socketPath          string
 	socketServer        *agentsocket.Server
+	unitManager         *unit.Manager
 
 	derpTLSConfig *tls.Config
 }
@@ -449,6 +451,7 @@ func (a *agent) init() {
 		panic(err)
 	}
 	a.sshServer = sshSrv
+	a.unitManager = unit.NewManager()
 	a.scriptRunner = agentscripts.New(agentscripts.Options{
 		LogDir:      a.logDir,
 		DataDirBase: a.scriptDataDir,
@@ -458,6 +461,7 @@ func (a *agent) init() {
 		GetScriptLogger: func(logSourceID uuid.UUID) agentscripts.ScriptLogger {
 			return a.logSender.GetScriptLogger(logSourceID)
 		},
+		UnitManager: a.unitManager,
 	})
 	// Register runner metrics. If the prom registry is nil, the metrics
 	// will not report anywhere.
@@ -553,6 +557,7 @@ func (a *agent) initSocketServer() {
 
 	server, err := agentsocket.NewServer(
 		a.logger.Named("socket"),
+		a.unitManager,
 		agentsocket.WithPath(a.socketPath),
 	)
 	if err != nil {

--- a/agent/agentscripts/agentscripts.go
+++ b/agent/agentscripts/agentscripts.go
@@ -23,6 +23,7 @@ import (
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/agent/agentssh"
 	"github.com/coder/coder/v2/agent/proto"
+	"github.com/coder/coder/v2/agent/unit"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
@@ -56,6 +57,9 @@ type Options struct {
 	SSHServer       *agentssh.Server
 	Filesystem      afero.Fs
 	GetScriptLogger func(logSourceID uuid.UUID) ScriptLogger
+	// UnitManager, when set, causes the runner to register each script as a
+	// sync unit during Init and to update unit status as scripts execute.
+	UnitManager *unit.Manager
 }
 
 // New creates a runner for the provided scripts.
@@ -138,6 +142,28 @@ func (r *Runner) Init(scripts []codersdk.WorkspaceAgentScript, scriptCompleted S
 		opt(r)
 	}
 	r.Logger.Info(r.cronCtx, "initializing agent scripts", slog.F("script_count", len(scripts)), slog.F("log_dir", r.LogDir))
+
+	// Register all scripts as sync units so they are immediately visible
+	// via "coder exp sync list". Registration happens before any script
+	// executes, giving observers a complete picture of pending work.
+	if r.UnitManager != nil {
+		for _, script := range scripts {
+			if script.DisplayName == "" {
+				r.Logger.Warn(r.cronCtx, "skipping unit registration for script with empty display name",
+					slog.F("script_id", script.ID))
+				continue
+			}
+			if err := r.UnitManager.Register(unit.ID(script.DisplayName)); err != nil {
+				if errors.Is(err, unit.ErrUnitAlreadyRegistered) {
+					r.Logger.Warn(r.cronCtx, "duplicate unit name during script registration",
+						slog.F("display_name", script.DisplayName),
+						slog.F("script_id", script.ID))
+					continue
+				}
+				return xerrors.Errorf("register script unit %q: %w", script.DisplayName, err)
+			}
+		}
+	}
 
 	err := r.Filesystem.MkdirAll(r.ScriptBinDir(), 0o700)
 	if err != nil {
@@ -335,6 +361,9 @@ func (r *Runner) run(ctx context.Context, script codersdk.WorkspaceAgentScript, 
 	cmd.Stdout = io.MultiWriter(fileWriter, infoW)
 	cmd.Stderr = io.MultiWriter(fileWriter, errW)
 
+	// Mark the script's sync unit as started before execution begins.
+	r.setUnitStatus(ctx, script, unit.StatusStarted)
+
 	start := dbtime.Now()
 	defer func() {
 		end := dbtime.Now()
@@ -404,6 +433,10 @@ func (r *Runner) run(ctx context.Context, script codersdk.WorkspaceAgentScript, 
 		if err != nil {
 			logger.Warn(ctx, "reporting script completed: track command goroutine", slog.Error(err))
 		}
+
+		// Mark the script's sync unit as completed after execution finishes,
+		// regardless of whether the script succeeded or failed.
+		r.setUnitStatus(ctx, script, unit.StatusComplete)
 	}()
 
 	err = cmd.Start()
@@ -486,5 +519,22 @@ func (r *Runner) isClosed() bool {
 		return true
 	default:
 		return false
+	}
+}
+
+// setUnitStatus updates the sync unit status for a script.
+// It is a no-op when no UnitManager is configured or when the script
+// has no DisplayName.
+func (r *Runner) setUnitStatus(ctx context.Context, script codersdk.WorkspaceAgentScript, status unit.Status) {
+	if r.UnitManager == nil || script.DisplayName == "" {
+		return
+	}
+	if err := r.UnitManager.UpdateStatus(unit.ID(script.DisplayName), status); err != nil {
+		// Log but do not fail; unit tracking is best-effort relative
+		// to script execution.
+		r.Logger.Warn(ctx, "failed to update unit status",
+			slog.F("display_name", script.DisplayName),
+			slog.F("status", string(status)),
+			slog.Error(err))
 	}
 }

--- a/agent/agentscripts/agentscripts_test.go
+++ b/agent/agentscripts/agentscripts_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/coder/coder/v2/agent/agentscripts"
 	"github.com/coder/coder/v2/agent/agentssh"
 	"github.com/coder/coder/v2/agent/agenttest"
+	"github.com/coder/coder/v2/agent/unit"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
 	"github.com/coder/coder/v2/testutil"
@@ -354,4 +355,116 @@ func (*fakeScriptLogger) Flush(context.Context) error {
 
 func newFakeScriptLogger() *fakeScriptLogger {
 	return &fakeScriptLogger{make(chan agentsdk.Log, 100)}
+}
+
+func setupWithUnitManager(t *testing.T, getScriptLogger func(uuid.UUID) agentscripts.ScriptLogger) (*agentscripts.Runner, *unit.Manager) {
+	t.Helper()
+	logger := testutil.Logger(t)
+	fs := afero.NewOsFs()
+	s, err := agentssh.NewServer(context.Background(), logger, prometheus.NewRegistry(), fs, agentexec.DefaultExecer, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = s.Close()
+	})
+	m := unit.NewManager()
+	r := agentscripts.New(agentscripts.Options{
+		LogDir:          t.TempDir(),
+		DataDirBase:     t.TempDir(),
+		Logger:          logger,
+		SSHServer:       s,
+		Filesystem:      fs,
+		GetScriptLogger: getScriptLogger,
+		UnitManager:     m,
+	})
+	return r, m
+}
+
+func TestScriptUnitsRegistered(t *testing.T) {
+	t.Parallel()
+
+	runner, mgr := setupWithUnitManager(t, func(_ uuid.UUID) agentscripts.ScriptLogger {
+		return noopScriptLogger{}
+	})
+	defer runner.Close()
+
+	scripts := []codersdk.WorkspaceAgentScript{
+		{
+			ID:          uuid.New(),
+			LogSourceID: uuid.New(),
+			DisplayName: "Install Tools",
+			Script:      "echo install",
+			RunOnStart:  true,
+		},
+		{
+			ID:          uuid.New(),
+			LogSourceID: uuid.New(),
+			DisplayName: "Configure Environment",
+			Script:      "echo configure",
+			RunOnStart:  true,
+		},
+		{
+			ID:          uuid.New(),
+			LogSourceID: uuid.New(),
+			DisplayName: "", // No display name; should be skipped.
+			Script:      "echo nameless",
+			RunOnStart:  true,
+		},
+	}
+
+	aAPI := agenttest.NewFakeAgentAPI(t, testutil.Logger(t), nil, nil)
+	err := runner.Init(scripts, aAPI.ScriptCompleted)
+	require.NoError(t, err)
+
+	// All scripts with a display name should be registered as pending.
+	units := mgr.ListUnits()
+	require.Len(t, units, 2)
+
+	unitsByName := make(map[unit.ID]unit.Unit)
+	for _, u := range units {
+		unitsByName[u.ID()] = u
+	}
+
+	for _, name := range []string{"Install Tools", "Configure Environment"} {
+		u, ok := unitsByName[unit.ID(name)]
+		require.True(t, ok, "expected unit %q to be registered", name)
+		require.Equal(t, unit.StatusPending, u.Status(), "unit %q should be pending", name)
+	}
+}
+
+func TestScriptUnitsLifecycle(t *testing.T) {
+	t.Parallel()
+
+	runner, mgr := setupWithUnitManager(t, func(_ uuid.UUID) agentscripts.ScriptLogger {
+		return noopScriptLogger{}
+	})
+	defer runner.Close()
+
+	scriptName := "My Script"
+	scripts := []codersdk.WorkspaceAgentScript{
+		{
+			ID:          uuid.New(),
+			LogSourceID: uuid.New(),
+			DisplayName: scriptName,
+			Script:      "echo lifecycle",
+			RunOnStart:  true,
+		},
+	}
+
+	aAPI := agenttest.NewFakeAgentAPI(t, testutil.Logger(t), nil, nil)
+	err := runner.Init(scripts, aAPI.ScriptCompleted)
+	require.NoError(t, err)
+
+	// Before execution: pending.
+	u, err := mgr.Unit(unit.ID(scriptName))
+	require.NoError(t, err)
+	require.Equal(t, unit.StatusPending, u.Status())
+
+	// Execute the script.
+	err = runner.Execute(context.Background(), agentscripts.ExecuteStartScripts)
+	require.NoError(t, err)
+
+	// After execution: completed.
+	u, err = mgr.Unit(unit.ID(scriptName))
+	require.NoError(t, err)
+	require.Equal(t, unit.StatusComplete, u.Status())
 }

--- a/agent/agentsocket/server.go
+++ b/agent/agentsocket/server.go
@@ -33,7 +33,12 @@ type Server struct {
 }
 
 // NewServer creates a new agent socket server.
-func NewServer(logger slog.Logger, opts ...Option) (*Server, error) {
+// The provided unit.Manager is used for dependency tracking and must not be nil.
+func NewServer(logger slog.Logger, unitManager *unit.Manager, opts ...Option) (*Server, error) {
+	if unitManager == nil {
+		return nil, xerrors.New("unit manager must not be nil")
+	}
+
 	options := &options{}
 	for _, opt := range opts {
 		opt(options)
@@ -45,7 +50,7 @@ func NewServer(logger slog.Logger, opts ...Option) (*Server, error) {
 		path:   options.path,
 		service: &DRPCAgentSocketService{
 			logger:      logger,
-			unitManager: unit.NewManager(),
+			unitManager: unitManager,
 		},
 	}
 

--- a/agent/agentsocket/server_test.go
+++ b/agent/agentsocket/server_test.go
@@ -7,6 +7,7 @@ import (
 
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/agent/agentsocket"
+	"github.com/coder/coder/v2/agent/unit"
 	"github.com/coder/coder/v2/testutil"
 )
 
@@ -18,7 +19,7 @@ func TestServer(t *testing.T) {
 
 		socketPath := testutil.AgentSocketPath(t)
 		logger := slog.Make().Leveled(slog.LevelDebug)
-		server, err := agentsocket.NewServer(logger, agentsocket.WithPath(socketPath))
+		server, err := agentsocket.NewServer(logger, unit.NewManager(), agentsocket.WithPath(socketPath))
 		require.NoError(t, err)
 		require.NoError(t, server.Close())
 	})
@@ -28,10 +29,10 @@ func TestServer(t *testing.T) {
 
 		socketPath := testutil.AgentSocketPath(t)
 		logger := slog.Make().Leveled(slog.LevelDebug)
-		server1, err := agentsocket.NewServer(logger, agentsocket.WithPath(socketPath))
+		server1, err := agentsocket.NewServer(logger, unit.NewManager(), agentsocket.WithPath(socketPath))
 		require.NoError(t, err)
 		defer server1.Close()
-		_, err = agentsocket.NewServer(logger, agentsocket.WithPath(socketPath))
+		_, err = agentsocket.NewServer(logger, unit.NewManager(), agentsocket.WithPath(socketPath))
 		require.ErrorContains(t, err, "create socket")
 	})
 }

--- a/agent/agentsocket/service_test.go
+++ b/agent/agentsocket/service_test.go
@@ -48,6 +48,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitShort)
 		server, err := agentsocket.NewServer(
 			slog.Make().Leveled(slog.LevelDebug),
+			unit.NewManager(),
 			agentsocket.WithPath(socketPath),
 		)
 		require.NoError(t, err)
@@ -68,6 +69,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitShort)
 			server, err := agentsocket.NewServer(
 				slog.Make().Leveled(slog.LevelDebug),
+				unit.NewManager(),
 				agentsocket.WithPath(socketPath),
 			)
 			require.NoError(t, err)
@@ -90,6 +92,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitShort)
 			server, err := agentsocket.NewServer(
 				slog.Make().Leveled(slog.LevelDebug),
+				unit.NewManager(),
 				agentsocket.WithPath(socketPath),
 			)
 			require.NoError(t, err)
@@ -120,6 +123,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitShort)
 			server, err := agentsocket.NewServer(
 				slog.Make().Leveled(slog.LevelDebug),
+				unit.NewManager(),
 				agentsocket.WithPath(socketPath),
 			)
 			require.NoError(t, err)
@@ -159,6 +163,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitShort)
 			server, err := agentsocket.NewServer(
 				slog.Make().Leveled(slog.LevelDebug),
+				unit.NewManager(),
 				agentsocket.WithPath(socketPath),
 			)
 			require.NoError(t, err)
@@ -189,6 +194,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitShort)
 			server, err := agentsocket.NewServer(
 				slog.Make().Leveled(slog.LevelDebug),
+				unit.NewManager(),
 				agentsocket.WithPath(socketPath),
 			)
 			require.NoError(t, err)
@@ -214,6 +220,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitShort)
 			server, err := agentsocket.NewServer(
 				slog.Make().Leveled(slog.LevelDebug),
+				unit.NewManager(),
 				agentsocket.WithPath(socketPath),
 			)
 			require.NoError(t, err)
@@ -249,6 +256,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitShort)
 			server, err := agentsocket.NewServer(
 				slog.Make().Leveled(slog.LevelDebug),
+				unit.NewManager(),
 				agentsocket.WithPath(socketPath),
 			)
 			require.NoError(t, err)
@@ -291,6 +299,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitShort)
 			server, err := agentsocket.NewServer(
 				slog.Make().Leveled(slog.LevelDebug),
+				unit.NewManager(),
 				agentsocket.WithPath(socketPath),
 			)
 			require.NoError(t, err)
@@ -310,6 +319,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitShort)
 			server, err := agentsocket.NewServer(
 				slog.Make().Leveled(slog.LevelDebug),
+				unit.NewManager(),
 				agentsocket.WithPath(socketPath),
 			)
 			require.NoError(t, err)
@@ -334,6 +344,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitShort)
 			server, err := agentsocket.NewServer(
 				slog.Make().Leveled(slog.LevelDebug),
+				unit.NewManager(),
 				agentsocket.WithPath(socketPath),
 			)
 			require.NoError(t, err)
@@ -375,6 +386,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitShort)
 			server, err := agentsocket.NewServer(
 				slog.Make().Leveled(slog.LevelDebug),
+				unit.NewManager(),
 				agentsocket.WithPath(socketPath),
 			)
 			require.NoError(t, err)
@@ -397,6 +409,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitShort)
 			server, err := agentsocket.NewServer(
 				slog.Make().Leveled(slog.LevelDebug),
+				unit.NewManager(),
 				agentsocket.WithPath(socketPath),
 			)
 			require.NoError(t, err)
@@ -436,6 +449,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitShort)
 			server, err := agentsocket.NewServer(
 				slog.Make().Leveled(slog.LevelDebug),
+				unit.NewManager(),
 				agentsocket.WithPath(socketPath),
 			)
 			require.NoError(t, err)
@@ -465,6 +479,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitShort)
 			server, err := agentsocket.NewServer(
 				slog.Make().Leveled(slog.LevelDebug),
+				unit.NewManager(),
 				agentsocket.WithPath(socketPath),
 			)
 			require.NoError(t, err)

--- a/cli/sync_test.go
+++ b/cli/sync_test.go
@@ -12,6 +12,7 @@ import (
 
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/agent/agentsocket"
+	"github.com/coder/coder/v2/agent/unit"
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -35,6 +36,7 @@ func setupSocketServer(t *testing.T) (path string, cleanup func()) {
 
 	server, err := agentsocket.NewServer(
 		slog.Make().Leveled(slog.LevelDebug),
+		unit.NewManager(),
 		agentsocket.WithPath(socketPath),
 	)
 	require.NoError(t, err, "create socket server")


### PR DESCRIPTION
The script runner now registers each workspace agent script as a sync unit during initialization, making all scripts immediately visible via `coder exp sync list`. As the script runner executes each script, its unit status transitions through the lifecycle: pending, started, completed.

## Problem

The `agent/unit.Manager` (sync unit system) and `agent/agentscripts.Runner` (script runner) were independent. Scripts run by the agent were invisible to `coder exp sync list`, and there was no way to observe script lifecycle through the dependency coordination system.

## Changes

**Shared `unit.Manager` (composition root)**

Previously, `unit.NewManager()` was created inside `agentsocket.NewServer()`, hidden from the rest of the agent. This PR lifts it out so the agent creates a single `unit.Manager` and passes it to both the script runner and the socket server.

- `agent/agentsocket/server.go`: `NewServer` takes `*unit.Manager` as an explicit required parameter instead of creating its own.
- `agent/agent.go`: Creates a shared `unit.NewManager()` in `init()`, passes it to both `agentscripts.New()` and `agentsocket.NewServer()`.

**Script lifecycle tracking**

- `agent/agentscripts/agentscripts.go`: `Options` gains a `UnitManager` field. `Init()` registers each script using its `DisplayName` as the unit ID. `run()` marks the unit as `started` before execution and `completed` after (regardless of success/failure).
- Unit name uses `DisplayName` for now. Uniqueness enforcement is deferred to a follow-up.
- All unit manager calls are nil-guarded, so the runner works without a manager (backwards compatible).

**Tests**

- Updated all `NewServer` call sites in tests to pass `unit.NewManager()`.
- Added `TestScriptUnitsRegistered`: verifies scripts with display names are registered as pending units during Init, and scripts without display names are skipped.
- Added `TestScriptUnitsLifecycle`: verifies the full pending, started, completed transition through Execute.

<details><summary>Mini RFC / Design notes</summary>

### Unit name

Each script's `DisplayName` is used as the unit name (`unit.ID`). This is user-friendly but not guaranteed unique. Uniqueness will be addressed in a follow-up.

### Status lifecycle per script

```
Init()                → Register(displayName)           → pending
run() before start    → UpdateStatus(_, StatusStarted)  → started
run() after complete  → UpdateStatus(_, StatusComplete) → completed
```

For cron scripts that run multiple times, the cycle repeats: `completed → started → completed → ...`

### What this does NOT change

- No proto/DRPC changes; the existing `SyncList` RPC from PR #26443 surfaces the units as-is.
- No new CLI commands.
- No uniqueness enforcement on `DisplayName` (follow-up).
- No dependency edges between scripts (follow-up).

</details>

> Generated by Coder Agents on behalf of @SasSwart