### PR TITLE
test(cli): increase timeouts to fix Golden test flakes under CI load

### DIFF
--- a/cli/clitest/golden.go
+++ b/cli/clitest/golden.go
@@ -74,7 +74,7 @@ ExtractCommandPathsLoop:
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			ctx := testutil.Context(t, testutil.WaitLong)
+			ctx := testutil.Context(t, testutil.WaitSuperLong)
 
 			var outBuf bytes.Buffer
 
@@ -249,7 +249,7 @@ func extractVisibleCommandPaths(cmdPath []string, cmds []*serpent.Command) [][]s
 func prepareTestData(t *testing.T) (*codersdk.Client, map[string]string) {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
 	defer cancel()
 
 	// This needs to be a fixed timezone because timezones increase the length

--- a/cli/task_logs_test.go
+++ b/cli/task_logs_test.go
@@ -40,14 +40,14 @@ func Test_TaskLogs_Golden(t *testing.T) {
 	t.Run("ByTaskName_JSON", func(t *testing.T) {
 		t.Parallel()
 
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		setup := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskLogsOK(testMessages))
 
 		inv, root := clitest.New(t, "task", "logs", setup.task.Name, "--output", "json")
 		output := clitest.Capture(inv)
 		clitest.SetupConfig(t, setup.userClient, root)
 
-		ctx := testutil.Context(t, testutil.WaitLong)
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err)
 
@@ -63,14 +63,14 @@ func Test_TaskLogs_Golden(t *testing.T) {
 	t.Run("ByTaskID_JSON", func(t *testing.T) {
 		t.Parallel()
 
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		setup := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskLogsOK(testMessages))
 
 		inv, root := clitest.New(t, "task", "logs", setup.task.ID.String(), "--output", "json")
 		output := clitest.Capture(inv)
 		clitest.SetupConfig(t, setup.userClient, root)
 
-		ctx := testutil.Context(t, testutil.WaitLong)
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err)
 
@@ -86,14 +86,14 @@ func Test_TaskLogs_Golden(t *testing.T) {
 	t.Run("ByTaskID_Table", func(t *testing.T) {
 		t.Parallel()
 
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		setup := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskLogsOK(testMessages))
 
 		inv, root := clitest.New(t, "task", "logs", setup.task.ID.String())
 		output := clitest.Capture(inv)
 		clitest.SetupConfig(t, setup.userClient, root)
 
-		ctx := testutil.Context(t, testutil.WaitLong)
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err)
 
@@ -103,7 +103,7 @@ func Test_TaskLogs_Golden(t *testing.T) {
 
 	t.Run("TaskNotFound_ByName", func(t *testing.T) {
 		t.Parallel()
-		ctx := testutil.Context(t, testutil.WaitLong)
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
 
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		owner := coderdtest.CreateFirstUser(t, client)
@@ -121,7 +121,7 @@ func Test_TaskLogs_Golden(t *testing.T) {
 
 	t.Run("TaskNotFound_ByID", func(t *testing.T) {
 		t.Parallel()
-		ctx := testutil.Context(t, testutil.WaitLong)
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
 
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		owner := coderdtest.CreateFirstUser(t, client)
@@ -140,13 +140,13 @@ func Test_TaskLogs_Golden(t *testing.T) {
 	t.Run("ErrorFetchingLogs", func(t *testing.T) {
 		t.Parallel()
 
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		setup := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskLogsErr(assert.AnError))
 
 		inv, root := clitest.New(t, "task", "logs", setup.task.ID.String())
 		clitest.SetupConfig(t, setup.userClient, root)
 
-		ctx := testutil.Context(t, testutil.WaitLong)
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
 		err := inv.WithContext(ctx).Run()
 		require.ErrorContains(t, err, assert.AnError.Error())
 	})
@@ -154,7 +154,7 @@ func Test_TaskLogs_Golden(t *testing.T) {
 	t.Run("SnapshotWithLogs_Table", func(t *testing.T) {
 		t.Parallel()
 
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		client, task := setupCLITaskTestWithSnapshot(setupCtx, t, codersdk.TaskStatusPaused, testMessages)
 		userClient := client
 
@@ -162,7 +162,7 @@ func Test_TaskLogs_Golden(t *testing.T) {
 		output := clitest.Capture(inv)
 		clitest.SetupConfig(t, userClient, root)
 
-		ctx := testutil.Context(t, testutil.WaitLong)
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err)
 
@@ -173,7 +173,7 @@ func Test_TaskLogs_Golden(t *testing.T) {
 	t.Run("SnapshotWithLogs_JSON", func(t *testing.T) {
 		t.Parallel()
 
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		client, task := setupCLITaskTestWithSnapshot(setupCtx, t, codersdk.TaskStatusPaused, testMessages)
 		userClient := client
 
@@ -181,7 +181,7 @@ func Test_TaskLogs_Golden(t *testing.T) {
 		output := clitest.Capture(inv)
 		clitest.SetupConfig(t, userClient, root)
 
-		ctx := testutil.Context(t, testutil.WaitLong)
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err)
 
@@ -203,7 +203,7 @@ func Test_TaskLogs_Golden(t *testing.T) {
 		output := clitest.Capture(inv)
 		clitest.SetupConfig(t, userClient, root)
 
-		ctx := testutil.Context(t, testutil.WaitLong)
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err)
 
@@ -223,7 +223,7 @@ func Test_TaskLogs_Golden(t *testing.T) {
 			},
 		}
 
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		client, task := setupCLITaskTestWithSnapshot(setupCtx, t, codersdk.TaskStatusPending, singleMessage)
 		userClient := client
 
@@ -231,7 +231,7 @@ func Test_TaskLogs_Golden(t *testing.T) {
 		output := clitest.Capture(inv)
 		clitest.SetupConfig(t, userClient, root)
 
-		ctx := testutil.Context(t, testutil.WaitLong)
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err)
 
@@ -242,7 +242,7 @@ func Test_TaskLogs_Golden(t *testing.T) {
 	t.Run("SnapshotEmptyLogs", func(t *testing.T) {
 		t.Parallel()
 
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		client, task := setupCLITaskTestWithSnapshot(setupCtx, t, codersdk.TaskStatusInitializing, []agentapisdk.Message{})
 		userClient := client
 
@@ -250,7 +250,7 @@ func Test_TaskLogs_Golden(t *testing.T) {
 		output := clitest.Capture(inv)
 		clitest.SetupConfig(t, userClient, root)
 
-		ctx := testutil.Context(t, testutil.WaitLong)
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err)
 
@@ -261,7 +261,7 @@ func Test_TaskLogs_Golden(t *testing.T) {
 	t.Run("InitializingTaskSnapshot", func(t *testing.T) {
 		t.Parallel()
 
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		client, task := setupCLITaskTestWithSnapshot(setupCtx, t, codersdk.TaskStatusInitializing, testMessages)
 		userClient := client
 
@@ -269,7 +269,7 @@ func Test_TaskLogs_Golden(t *testing.T) {
 		output := clitest.Capture(inv)
 		clitest.SetupConfig(t, userClient, root)
 
-		ctx := testutil.Context(t, testutil.WaitLong)
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err)
 

--- a/cli/task_pause_test.go
+++ b/cli/task_pause_test.go
@@ -19,7 +19,7 @@ func TestExpTaskPause(t *testing.T) {
 		t.Parallel()
 
 		// Given: A running task
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		setup := setupCLITaskTest(setupCtx, t, nil)
 
 		// When: We attempt to pause the task
@@ -44,7 +44,7 @@ func TestExpTaskPause(t *testing.T) {
 		t.Parallel()
 
 		// Given: A different user's running task
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		setup := setupCLITaskTest(setupCtx, t, nil)
 
 		// When: We attempt to pause their task
@@ -69,7 +69,7 @@ func TestExpTaskPause(t *testing.T) {
 
 		logger := testutil.Logger(t)
 		// Given: A running task
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		setup := setupCLITaskTest(setupCtx, t, nil)
 
 		// When: We attempt to pause the task
@@ -99,7 +99,7 @@ func TestExpTaskPause(t *testing.T) {
 
 		logger := testutil.Logger(t)
 		// Given: A running task
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		setup := setupCLITaskTest(setupCtx, t, nil)
 
 		// When: We attempt to pause the task
@@ -126,7 +126,7 @@ func TestExpTaskPause(t *testing.T) {
 		t.Parallel()
 
 		// Given: A running task
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		setup := setupCLITaskTest(setupCtx, t, nil)
 
 		// And: We paused the running task

--- a/cli/task_resume_test.go
+++ b/cli/task_resume_test.go
@@ -20,7 +20,7 @@ func TestExpTaskResume(t *testing.T) {
 		t.Parallel()
 
 		// Given: A paused task
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		setup := setupCLITaskTest(setupCtx, t, nil)
 		pauseTask(setupCtx, t, setup.userClient, setup.task)
 
@@ -46,7 +46,7 @@ func TestExpTaskResume(t *testing.T) {
 		t.Parallel()
 
 		// Given: A different user's paused task
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		setup := setupCLITaskTest(setupCtx, t, nil)
 		pauseTask(setupCtx, t, setup.userClient, setup.task)
 
@@ -71,7 +71,7 @@ func TestExpTaskResume(t *testing.T) {
 		t.Parallel()
 
 		// Given: A paused task
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		setup := setupCLITaskTest(setupCtx, t, nil)
 		pauseTask(setupCtx, t, setup.userClient, setup.task)
 
@@ -101,7 +101,7 @@ func TestExpTaskResume(t *testing.T) {
 
 		logger := testutil.Logger(t)
 		// Given: A paused task
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		setup := setupCLITaskTest(setupCtx, t, nil)
 		pauseTask(setupCtx, t, setup.userClient, setup.task)
 
@@ -132,7 +132,7 @@ func TestExpTaskResume(t *testing.T) {
 
 		logger := testutil.Logger(t)
 		// Given: A paused task
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		setup := setupCLITaskTest(setupCtx, t, nil)
 		pauseTask(setupCtx, t, setup.userClient, setup.task)
 
@@ -160,7 +160,7 @@ func TestExpTaskResume(t *testing.T) {
 		t.Parallel()
 
 		// Given: A running task
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		setup := setupCLITaskTest(setupCtx, t, nil)
 
 		// When: We attempt to resume the task that is not paused

--- a/cli/task_send_test.go
+++ b/cli/task_send_test.go
@@ -30,7 +30,7 @@ func Test_TaskSend(t *testing.T) {
 	t.Run("ByTaskName_WithArgument", func(t *testing.T) {
 		t.Parallel()
 
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		setup := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendOK(t, "carry on with the task", "you got it"))
 
 		var stdout strings.Builder
@@ -38,7 +38,7 @@ func Test_TaskSend(t *testing.T) {
 		inv.Stdout = &stdout
 		clitest.SetupConfig(t, setup.userClient, root)
 
-		ctx := testutil.Context(t, testutil.WaitLong)
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err)
 	})
@@ -46,7 +46,7 @@ func Test_TaskSend(t *testing.T) {
 	t.Run("ByTaskID_WithArgument", func(t *testing.T) {
 		t.Parallel()
 
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		setup := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendOK(t, "carry on with the task", "you got it"))
 
 		var stdout strings.Builder
@@ -54,7 +54,7 @@ func Test_TaskSend(t *testing.T) {
 		inv.Stdout = &stdout
 		clitest.SetupConfig(t, setup.userClient, root)
 
-		ctx := testutil.Context(t, testutil.WaitLong)
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err)
 	})
@@ -62,7 +62,7 @@ func Test_TaskSend(t *testing.T) {
 	t.Run("ByTaskName_WithStdin", func(t *testing.T) {
 		t.Parallel()
 
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		setup := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendOK(t, "carry on with the task", "you got it"))
 
 		var stdout strings.Builder
@@ -71,14 +71,14 @@ func Test_TaskSend(t *testing.T) {
 		inv.Stdin = strings.NewReader("carry on with the task")
 		clitest.SetupConfig(t, setup.userClient, root)
 
-		ctx := testutil.Context(t, testutil.WaitLong)
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err)
 	})
 
 	t.Run("TaskNotFound_ByName", func(t *testing.T) {
 		t.Parallel()
-		ctx := testutil.Context(t, testutil.WaitLong)
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
 
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		owner := coderdtest.CreateFirstUser(t, client)
@@ -96,7 +96,7 @@ func Test_TaskSend(t *testing.T) {
 
 	t.Run("TaskNotFound_ByID", func(t *testing.T) {
 		t.Parallel()
-		ctx := testutil.Context(t, testutil.WaitLong)
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
 
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		owner := coderdtest.CreateFirstUser(t, client)
@@ -115,7 +115,7 @@ func Test_TaskSend(t *testing.T) {
 	t.Run("SendError", func(t *testing.T) {
 		t.Parallel()
 
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		setup := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendErr(assert.AnError))
 
 		var stdout strings.Builder
@@ -123,7 +123,7 @@ func Test_TaskSend(t *testing.T) {
 		inv.Stdout = &stdout
 		clitest.SetupConfig(t, setup.userClient, root)
 
-		ctx := testutil.Context(t, testutil.WaitLong)
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
 		err := inv.WithContext(ctx).Run()
 		require.ErrorContains(t, err, assert.AnError.Error())
 	})
@@ -131,7 +131,7 @@ func Test_TaskSend(t *testing.T) {
 	t.Run("WaitsForInitializingTask", func(t *testing.T) {
 		t.Parallel()
 
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		setup := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendOK(t, "some task input", "some task response"))
 
 		// Close the first agent, pause, then resume the task so the
@@ -145,7 +145,7 @@ func Test_TaskSend(t *testing.T) {
 		inv, root := clitest.New(t, "task", "send", setup.task.Name, "some task input")
 		clitest.SetupConfig(t, setup.userClient, root)
 
-		ctx := testutil.Context(t, testutil.WaitLong)
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
 		inv = inv.WithContext(ctx)
 
 		// Use a pty so we can wait for the command to produce build
@@ -185,7 +185,7 @@ func Test_TaskSend(t *testing.T) {
 	t.Run("ResumesPausedTask", func(t *testing.T) {
 		t.Parallel()
 
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		setup := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendOK(t, "some task input", "some task response"))
 
 		// Close the first agent before pausing so it does not conflict
@@ -197,7 +197,7 @@ func Test_TaskSend(t *testing.T) {
 		inv, root := clitest.New(t, "task", "send", setup.task.Name, "some task input")
 		clitest.SetupConfig(t, setup.userClient, root)
 
-		ctx := testutil.Context(t, testutil.WaitLong)
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
 		inv = inv.WithContext(ctx)
 
 		// Use a pty so we can wait for the command to produce build
@@ -241,7 +241,7 @@ func Test_TaskSend(t *testing.T) {
 		// workspace is started but no agent is connected. The
 		// command enters waitForTaskIdle directly (initializing
 		// path), where we verify it handles an external pause.
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		setup := setupCLITaskTest(setupCtx, t, nil)
 
 		require.NoError(t, setup.agent.Close())
@@ -257,7 +257,7 @@ func Test_TaskSend(t *testing.T) {
 		inv, root := clitest.NewWithClock(t, mClock, "task", "send", setup.task.Name, "some task input")
 		clitest.SetupConfig(t, setup.userClient, root)
 
-		ctx := testutil.Context(t, testutil.WaitLong)
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
 		inv = inv.WithContext(ctx)
 
 		stdout := expecter.NewAttachedToInvocation(t, inv)
@@ -305,7 +305,7 @@ func Test_TaskSend(t *testing.T) {
 		t.Parallel()
 
 		// Given: An active task whose app is in "working" state.
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		setup := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendOK(t, "some task input", "some task response"))
 
 		// Move the app into "working" state before running the command.
@@ -325,7 +325,7 @@ func Test_TaskSend(t *testing.T) {
 		inv, root := clitest.NewWithClock(t, mClock, "task", "send", setup.task.Name, "some task input")
 		clitest.SetupConfig(t, setup.userClient, root)
 
-		ctx := testutil.Context(t, testutil.WaitLong)
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
 		inv = inv.WithContext(ctx)
 		w := clitest.StartWithWaiter(t, inv)
 
@@ -374,7 +374,7 @@ func Test_TaskSend(t *testing.T) {
 			t.Run(string(appState), func(t *testing.T) {
 				t.Parallel()
 
-				setupCtx := testutil.Context(t, testutil.WaitLong)
+				setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 				setup := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendOK(t, "some input", "some response"))
 
 				agentClient := agentsdk.New(setup.userClient.URL, agentsdk.WithFixedToken(setup.agentToken))
@@ -387,7 +387,7 @@ func Test_TaskSend(t *testing.T) {
 				inv, root := clitest.New(t, "task", "send", setup.task.Name, "some input")
 				clitest.SetupConfig(t, setup.userClient, root)
 
-				ctx := testutil.Context(t, testutil.WaitLong)
+				ctx := testutil.Context(t, testutil.WaitSuperLong)
 				err := inv.WithContext(ctx).Run()
 				require.NoError(t, err)
 			})


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

The `gen` CI job runs `TZ=UTC go test ./cli -run="Test(CommandHelp|ServerYAML|ErrorExamples|.*Golden)" -update`, which executes all matching tests in a single `go test` invocation with full parallelism. Several subtests spin up their own coderd with provisioner daemons (`setupCLITaskTest` with `IncludeProvisionerDaemon: true`, `prepareTestData` with `IncludeProvisionerDaemon: true`). Under CI load, the 25-second `testutil.WaitLong` timeout is insufficient for provisioning operations to complete, causing `context deadline exceeded` errors across `Test_TaskLogs_Golden`, `TestCommandHelp`, and other golden tests.

Increase all setup and command execution timeouts from `testutil.WaitLong` (25s) to `testutil.WaitSuperLong` (60s) in the task test files and `prepareTestData`. This follows the precedent set by #21725, which fixed a similar timeout flake in `TestGitSSH`.

Closes https://github.com/coder/internal/issues/1561