### PR TITLE
chore: add AWS PRM user-agent attribution for partner revenue tracking (#23138)

### DIFF
--- a/provisioner/terraform/provision.go
+++ b/provisioner/terraform/provision.go
@@ -265,7 +265,7 @@ func provisionEnv(
 		"CODER_WORKSPACE_BUILD_ID="+metadata.GetWorkspaceBuildId(),
 		"CODER_TASK_ID="+metadata.GetTaskId(),
 		"CODER_TASK_PROMPT="+metadata.GetTaskPrompt(),
-		"AWS_SDK_UA_APP_ID=APN_1.1/pc_cdfmjwn8i6u8l9fwz8h82e4w3$",
+		awsSDKUserAgentEnv(safeEnvironValue(env, awsSDKUserAgentEnvKey)),
 	)
 	if metadata.GetPrebuiltWorkspaceBuildStage().IsPrebuild() {
 		env = append(env, provider.IsPrebuildEnvironmentVariable()+"=true")

--- a/provisioner/terraform/provision.go
+++ b/provisioner/terraform/provision.go
@@ -265,6 +265,7 @@ func provisionEnv(
 		"CODER_WORKSPACE_BUILD_ID="+metadata.GetWorkspaceBuildId(),
 		"CODER_TASK_ID="+metadata.GetTaskId(),
 		"CODER_TASK_PROMPT="+metadata.GetTaskPrompt(),
+		"AWS_SDK_UA_APP_ID=APN_1.1/pc_cdfmjwn8i6u8l9fwz8h82e4w3$",
 	)
 	if metadata.GetPrebuiltWorkspaceBuildStage().IsPrebuild() {
 		env = append(env, provider.IsPrebuildEnvironmentVariable()+"=true")

--- a/provisioner/terraform/provision_test.go
+++ b/provisioner/terraform/provision_test.go
@@ -1226,6 +1226,7 @@ func TestProvision_SafeEnv(t *testing.T) {
 	require.Contains(t, log, passedValue)
 	require.NotContains(t, log, secretValue)
 	require.Contains(t, log, "CODER_")
+	require.Contains(t, log, "AWS_SDK_UA_APP_ID=APN_1.1/pc_cdfmjwn8i6u8l9fwz8h82e4w3$")
 }
 
 func TestProvision_MalformedModules(t *testing.T) {

--- a/provisioner/terraform/safeenv.go
+++ b/provisioner/terraform/safeenv.go
@@ -53,3 +53,39 @@ func safeEnviron() []string {
 	}
 	return strippedEnv
 }
+
+// safeEnvironValue returns the value of the named variable in the given
+// `KEY=VALUE` environment slice, or an empty string if it is not present.
+func safeEnvironValue(env []string, name string) string {
+	prefix := name + "="
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			return strings.TrimPrefix(e, prefix)
+		}
+	}
+	return ""
+}
+
+const (
+	awsSDKUserAgentEnvKey = "AWS_SDK_UA_APP_ID"
+	// awsSDKUserAgentCoder is Coder's AWS Partner Revenue Measurement
+	// User-Agent string. The `APN_1.1/pc_<product-code>$` format and the
+	// space-delimited append behavior below follow AWS's guidance:
+	// https://docs.aws.amazon.com/PRM/latest/aws-prm-onboarding-guide/automated-user-agent.html
+	awsSDKUserAgentCoder = "APN_1.1/pc_cdfmjwn8i6u8l9fwz8h82e4w3$"
+)
+
+// awsSDKUserAgentEnv returns the AWS_SDK_UA_APP_ID value to pass to the
+// Terraform subprocess. If the caller's environment already configures an
+// Application ID (e.g. an operator who is also an AWS Partner and wants
+// their own revenue attribution), Coder's value is appended with a space
+// delimiter so both attributions are preserved. Otherwise Coder's value is
+// used on its own.
+//
+// See: https://docs.aws.amazon.com/PRM/latest/aws-prm-onboarding-guide/automated-user-agent.html
+func awsSDKUserAgentEnv(existing string) string {
+	if existing == "" {
+		return awsSDKUserAgentEnvKey + "=" + awsSDKUserAgentCoder
+	}
+	return awsSDKUserAgentEnvKey + "=" + existing + " " + awsSDKUserAgentCoder
+}

--- a/provisioner/terraform/safeenv_internal_test.go
+++ b/provisioner/terraform/safeenv_internal_test.go
@@ -1,0 +1,44 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSafeEnvironValue(t *testing.T) {
+	t.Parallel()
+
+	env := []string{
+		"FOO=bar",
+		"AWS_SDK_UA_APP_ID=my-existing-id",
+		"BAZ=qux",
+	}
+	require.Equal(t, "my-existing-id", safeEnvironValue(env, "AWS_SDK_UA_APP_ID"))
+	require.Equal(t, "bar", safeEnvironValue(env, "FOO"))
+	require.Equal(t, "", safeEnvironValue(env, "MISSING"))
+}
+
+func TestAWSSDKUserAgentEnv(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NoExisting", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t,
+			"AWS_SDK_UA_APP_ID=APN_1.1/pc_cdfmjwn8i6u8l9fwz8h82e4w3$",
+			awsSDKUserAgentEnv(""),
+		)
+	})
+
+	t.Run("AppendToExisting", func(t *testing.T) {
+		t.Parallel()
+		// When the operator is themselves an AWS Partner and has set their own
+		// Application ID, we append Coder's with a space delimiter so both
+		// attributions are preserved. See:
+		// https://docs.aws.amazon.com/PRM/latest/aws-prm-onboarding-guide/automated-user-agent.html
+		require.Equal(t,
+			"AWS_SDK_UA_APP_ID=EXISTING_APP_ID APN_1.1/pc_cdfmjwn8i6u8l9fwz8h82e4w3$",
+			awsSDKUserAgentEnv("EXISTING_APP_ID"),
+		)
+	})
+}


### PR DESCRIPTION
Backport of https://github.com/coder/coder/pull/23138 to `release/2.29`.

Original PR: #23138 — feat: add AWS PRM user-agent attribution for partner revenue tracking
Merge commit: 5ff1058f302b09d707f6c43d2cd5ebed43607159
Requested by: @matifali (per Slack thread, ESR 2.29 included)

2.29 is outside the auto-backport workflow's scope (latest 3 release branches), so this was cherry-picked manually. The `provision.go` hunk auto-merged cleanly. The `provision_test.go` hunk needed a small manual resolution because 2.29's `TestProvision_SafeEnv` ends right after the `CODER_` assertion (no `apply` follow-up checks yet on this branch); only the new `AWS_SDK_UA_APP_ID` assertion was kept.

`go test -run TestProvision_SafeEnv ./provisioner/terraform/` passes locally.

_Cherry-picked by Coder Agents on behalf of @DevelopmentCats._