### PR TITLE
chore(provisioner/terraform): preserve existing AWS_SDK_UA_APP_ID (#24606)

### DIFF
--- a/provisioner/terraform/provision.go
+++ b/provisioner/terraform/provision.go
@@ -265,7 +265,7 @@ func provisionEnv(
 		"CODER_WORKSPACE_BUILD_ID="+metadata.GetWorkspaceBuildId(),
 		"CODER_TASK_ID="+metadata.GetTaskId(),
 		"CODER_TASK_PROMPT="+metadata.GetTaskPrompt(),
-		"AWS_SDK_UA_APP_ID=APN_1.1/pc_cdfmjwn8i6u8l9fwz8h82e4w3$",
+		awsSDKUserAgentEnv(safeEnvironValue(env, awsSDKUserAgentEnvKey)),
 	)
 	if metadata.GetPrebuiltWorkspaceBuildStage().IsPrebuild() {
 		env = append(env, provider.IsPrebuildEnvironmentVariable()+"=true")

--- a/provisioner/terraform/safeenv.go
+++ b/provisioner/terraform/safeenv.go
@@ -53,3 +53,39 @@ func safeEnviron() []string {
 	}
 	return strippedEnv
 }
+
+// safeEnvironValue returns the value of the named variable in the given
+// `KEY=VALUE` environment slice, or an empty string if it is not present.
+func safeEnvironValue(env []string, name string) string {
+	prefix := name + "="
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			return strings.TrimPrefix(e, prefix)
+		}
+	}
+	return ""
+}
+
+const (
+	awsSDKUserAgentEnvKey = "AWS_SDK_UA_APP_ID"
+	// awsSDKUserAgentCoder is Coder's AWS Partner Revenue Measurement
+	// User-Agent string. The `APN_1.1/pc_<product-code>$` format and the
+	// space-delimited append behavior below follow AWS's guidance:
+	// https://docs.aws.amazon.com/PRM/latest/aws-prm-onboarding-guide/automated-user-agent.html
+	awsSDKUserAgentCoder = "APN_1.1/pc_cdfmjwn8i6u8l9fwz8h82e4w3$"
+)
+
+// awsSDKUserAgentEnv returns the AWS_SDK_UA_APP_ID value to pass to the
+// Terraform subprocess. If the caller's environment already configures an
+// Application ID (e.g. an operator who is also an AWS Partner and wants
+// their own revenue attribution), Coder's value is appended with a space
+// delimiter so both attributions are preserved. Otherwise Coder's value is
+// used on its own.
+//
+// See: https://docs.aws.amazon.com/PRM/latest/aws-prm-onboarding-guide/automated-user-agent.html
+func awsSDKUserAgentEnv(existing string) string {
+	if existing == "" {
+		return awsSDKUserAgentEnvKey + "=" + awsSDKUserAgentCoder
+	}
+	return awsSDKUserAgentEnvKey + "=" + existing + " " + awsSDKUserAgentCoder
+}

--- a/provisioner/terraform/safeenv_internal_test.go
+++ b/provisioner/terraform/safeenv_internal_test.go
@@ -1,0 +1,44 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSafeEnvironValue(t *testing.T) {
+	t.Parallel()
+
+	env := []string{
+		"FOO=bar",
+		"AWS_SDK_UA_APP_ID=my-existing-id",
+		"BAZ=qux",
+	}
+	require.Equal(t, "my-existing-id", safeEnvironValue(env, "AWS_SDK_UA_APP_ID"))
+	require.Equal(t, "bar", safeEnvironValue(env, "FOO"))
+	require.Equal(t, "", safeEnvironValue(env, "MISSING"))
+}
+
+func TestAWSSDKUserAgentEnv(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NoExisting", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t,
+			"AWS_SDK_UA_APP_ID=APN_1.1/pc_cdfmjwn8i6u8l9fwz8h82e4w3$",
+			awsSDKUserAgentEnv(""),
+		)
+	})
+
+	t.Run("AppendToExisting", func(t *testing.T) {
+		t.Parallel()
+		// When the operator is themselves an AWS Partner and has set their own
+		// Application ID, we append Coder's with a space delimiter so both
+		// attributions are preserved. See:
+		// https://docs.aws.amazon.com/PRM/latest/aws-prm-onboarding-guide/automated-user-agent.html
+		require.Equal(t,
+			"AWS_SDK_UA_APP_ID=EXISTING_APP_ID APN_1.1/pc_cdfmjwn8i6u8l9fwz8h82e4w3$",
+			awsSDKUserAgentEnv("EXISTING_APP_ID"),
+		)
+	})
+}


### PR DESCRIPTION
Backport of https://github.com/coder/coder/pull/24606 to `release/2.29`.

Original PR: #24606 — chore(provisioner/terraform): preserve existing AWS_SDK_UA_APP_ID
Merge commit: 9d28489abbeab2de7cb5efae81faca78d2e4719d
Requested by: @matifali (per Slack thread, ESR 2.29 included)

## Stacking

2.29 is outside the auto-backport workflow's scope (latest 3 release branches), so this is cherry-picked manually. Because #24606 builds on #23138 (it replaces the literal `AWS_SDK_UA_APP_ID=...` line introduced there), this PR is stacked on top of #26473.

Once #26473 merges into `release/2.29`, please retarget this PR's base from `backport/23138-to-2.29` to `release/2.29`.

The cherry-pick applied cleanly with no manual conflict resolution needed (`provision.go` auto-merged once #23138 was in place; `safeenv.go` and the new `safeenv_internal_test.go` had no overlap with 2.29).

`go test -run 'TestProvision_SafeEnv|TestSafeEnvironValue|TestAWSSDKUserAgentEnv' ./provisioner/terraform/` passes locally.

_Cherry-picked by Coder Agents on behalf of @DevelopmentCats._