### PR TITLE
fix(scripts/check_emdash.sh): skip emdash check when no diff base is available

### DIFF
--- a/scripts/check_emdash.sh
+++ b/scripts/check_emdash.sh
@@ -50,8 +50,16 @@ else
 	fi
 
 	if [[ -z "$base" ]]; then
-		echo "WARNING: no base ref found, scanning all tracked files."
-		scan_all_files
+		# No base ref is available outside of pull requests, for
+		# example push builds on release branches with a shallow
+		# clone where neither GITHUB_BASE_REF nor origin/main is
+		# present. The diff check has nothing to compare against,
+		# and scanning every tracked file would flag pre-existing
+		# characters that are unrelated to the change under test.
+		# Skip instead; pass --all to force a full-tree scan.
+		echo "OK: no base ref found (not a pull request); skipping emdash check."
+		echo "    Pass --all to scan every tracked file."
+		exit 0
 	else
 		# Ensure the base ref is fetchable. CI shallow clones
 		# (fetch-depth: 1) may not have the base branch available.


### PR DESCRIPTION
Backport of #26489 to `release/2.34`.

## Problem

On `release/2.34`, `make lint` (`lint/emdash`) fails on push builds. `scripts/check_emdash.sh` only resolves a base ref for pull requests (`GITHUB_BASE_REF`) or when `origin/main` is present. The `lint` job checks out with `fetch-depth: 1`, so on a release-branch push neither is available, and the script falls back to scanning **every tracked file**, flagging pre-existing emdash/endash characters the build did not introduce. Observed on run [27704528068](https://github.com/coder/coder/actions/runs/27704528068/job/81949529546).

## Fix

When no base ref can be determined (outside a pull request), skip the check instead of scanning the whole tree. `--all` still forces a full scan.

Note: this branch carries an older variant of the script than `main`, so the change is applied by hand rather than cherry-picked, but the behavior matches #26489.

## Testing

- Isolated no-base-ref repo (no `GITHUB_BASE_REF`, no `origin/main`): old script scans all files and fails on a pre-existing emdash; patched script skips and exits 0.
- `shellcheck`, `shfmt`, `bash -n` clean.

---
Generated by Coder Agents on behalf of @f0ssel.
