### PR TITLE
chore: reduce default session duration for improved security posture

### DIFF
--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -3642,7 +3642,7 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			Description: "The token expiry duration for browser sessions. Sessions may last longer if they are actively making requests, but this functionality can be disabled via --disable-session-expiry-refresh.",
 			Flag:        "session-duration",
 			Env:         "CODER_SESSION_DURATION",
-			Default:     (24 * time.Hour).String(),
+			Default:     (12 * time.Hour).String(),
 			Value:       &c.Sessions.DefaultDuration,
 			Group:       &deploymentGroupNetworkingHTTP,
 			YAML:        "sessionDuration",

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1198,7 +1198,7 @@ Disable chat sharing. Chat ACL checking is disabled and only owners can access t
 | Type        | <code>duration</code>                        |
 | Environment | <code>$CODER_SESSION_DURATION</code>         |
 | YAML        | <code>networking.http.sessionDuration</code> |
-| Default     | <code>24h0m0s</code>                         |
+| Default     | <code>12h0m0s</code>                         |
 
 The token expiry duration for browser sessions. Sessions may last longer if they are actively making requests, but this functionality can be disabled via --disable-session-expiry-refresh.
 


### PR DESCRIPTION
Reduces the default browser session token expiry from 24 hours to 12 hours. This improves the security posture for deployments that haven't explicitly configured a session duration.

Sessions are still automatically refreshed on activity (unless `--disable-session-expiry-refresh` is set), so active users won't notice any difference in practice.

> This PR was authored by Coder Agents on behalf of @bpmct