### PR TITLE
test(coderd/agentapi): fix pre-existing rebind test on release/2.29

### DIFF
--- a/coderd/agentapi/subagent_test.go
+++ b/coderd/agentapi/subagent_test.go
@@ -819,6 +819,14 @@ func TestSubAgentAPI(t *testing.T) {
 			TroubleshootingURL:       "https://example.com/troubleshoot",
 			APIKeyScope:              database.AgentKeyScopeEnumAll,
 		}
+		workspace := database.Workspace{
+			ID:         uuid.New(),
+			TemplateID: uuid.New(),
+		}
+		template := database.Template{
+			ID:                  workspace.TemplateID,
+			MaxPortSharingLevel: database.AppSharingLevelPublic,
+		}
 		insertedSubAgent := database.WorkspaceAgent{
 			ID:         uuid.New(),
 			ParentID:   uuid.NullUUID{UUID: parentAgent.ID, Valid: true},
@@ -828,6 +836,8 @@ func TestSubAgentAPI(t *testing.T) {
 		}
 
 		dbM := dbmock.NewMockStore(gomock.NewController(t))
+		dbM.EXPECT().GetWorkspaceByAgentID(gomock.Any(), parentAgent.ID).Return(workspace, nil)
+		dbM.EXPECT().GetTemplateByID(gomock.Any(), workspace.TemplateID).Return(template, nil)
 		dbM.EXPECT().InsertWorkspaceAgent(gomock.Any(), gomock.Cond(func(params database.InsertWorkspaceAgentParams) bool {
 			return params.ParentID.Valid && params.ParentID.UUID == parentAgent.ID &&
 				params.ResourceID == parentAgent.ResourceID &&


### PR DESCRIPTION
## Summary

Fixes a pre-existing test failure on `release/2.29`: `TestSubAgentAPI/CreateSubAgentWithAppRebindRejected` in `coderd/agentapi`. The branch is currently red because of this test.

## Root cause

The `CreateSubAgentWithAppRebindRejected` case passes apps in the request, so `SubAgentAPI.CreateSubAgent` (`coderd/agentapi/subagent.go`) resolves the parent agent's workspace and template — calling `GetWorkspaceByAgentID` and `GetTemplateByID` — to determine the maximum app sharing level.

On `release/2.29` the test sets up a `dbmock.MockStore` but does **not** register expectations for those two calls, so the test aborts with:

```
subagent.go:92: Unexpected call to *dbmock.MockStore.GetWorkspaceByAgentID(...) because: there are no expected calls of the method "GetWorkspaceByAgentID" for that receiver
```

The mocks exist on `main` (added alongside the sub-agent app-sharing-level work) but were missing from the version that landed on `release/2.29` (via #26290, the backport of #26103). This change adds the missing `workspace`/`template` fixtures and the two mock expectations so the test matches `main`.

## Verification

```
go test ./coderd/agentapi/ -run "TestSubAgentAPI/CreateSubAgentWithAppRebindRejected" -count=1   # ok
go test ./coderd/agentapi/ -run "TestSubAgentAPI" -count=1                                       # ok
gofmt -l coderd/agentapi/subagent_test.go                                                        # clean
```

This is a test-only change; no production code is touched.

## Notes

This also unblocks the `test-go-pg` jobs on #26486 (backport of #26418 + #26419), which were failing solely on this same pre-existing test.

---

<sub>Opened by Coder Agents on behalf of @f0ssel.</sub>
