### PR TITLE
fix(coderd/x/chatd): deflake TestStreamPartsDialerDialsPartsEndpoint

### DIFF
--- a/coderd/x/chatd/stream_parts_transport.go
+++ b/coderd/x/chatd/stream_parts_transport.go
@@ -214,6 +214,9 @@ func (s *streamPartsTransportSession) Close() error {
 	s.closeOnce.Do(func() {
 		s.cancel()
 		s.closeErr = s.transport.Close()
+		if streamPartsExpectedTransportClose(s.closeErr) {
+			s.closeErr = nil
+		}
 	})
 	return s.closeErr
 }


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/1601. Fixes a stream parts WebSocket close race. If the peer closed first, the session read loop could close the connection before `StreamPartsSession.Close()` ran, causing cleanup to return a wrapped `net.ErrClosed`. The fix treats expected transport close errors as successful cleanup.