### PR TITLE
fix(aibridge): increase circuit breaker test timeout to prevent flake

### DIFF
--- a/aibridge/internal/integrationtest/circuit_breaker_internal_test.go
+++ b/aibridge/internal/integrationtest/circuit_breaker_internal_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/coder/coder/v2/aibridge/config"
 	"github.com/coder/coder/v2/aibridge/metrics"
 	"github.com/coder/coder/v2/aibridge/provider"
+	"github.com/coder/coder/v2/testutil"
 )
 
 // Common response bodies for circuit breaker tests.
@@ -125,7 +126,7 @@ func TestCircuitBreaker_FullRecoveryCycle(t *testing.T) {
 			cbConfig := &config.CircuitBreaker{
 				FailureThreshold: 2,
 				Interval:         time.Minute,
-				Timeout:          50 * time.Millisecond,
+				Timeout:          testutil.IntervalSlow,
 				MaxRequests:      1,
 			}
 
@@ -282,7 +283,7 @@ func TestCircuitBreaker_HalfOpenFailure(t *testing.T) {
 			cbConfig := &config.CircuitBreaker{
 				FailureThreshold: 2,
 				Interval:         time.Minute,
-				Timeout:          50 * time.Millisecond,
+				Timeout:          testutil.IntervalSlow,
 				MaxRequests:      1,
 			}
 
@@ -430,7 +431,7 @@ func TestCircuitBreaker_HalfOpenMaxRequests(t *testing.T) {
 			cbConfig := &config.CircuitBreaker{
 				FailureThreshold: 2,
 				Interval:         time.Minute,
-				Timeout:          50 * time.Millisecond,
+				Timeout:          testutil.IntervalSlow,
 				MaxRequests:      maxRequests, // Allow only 2 concurrent requests in half-open
 			}
 

--- a/aibridge/internal/integrationtest/circuit_breaker_internal_test.go
+++ b/aibridge/internal/integrationtest/circuit_breaker_internal_test.go
@@ -126,7 +126,7 @@ func TestCircuitBreaker_FullRecoveryCycle(t *testing.T) {
 			cbConfig := &config.CircuitBreaker{
 				FailureThreshold: 2,
 				Interval:         time.Minute,
-				Timeout:          testutil.IntervalSlow,
+				Timeout:          testutil.IntervalMedium,
 				MaxRequests:      1,
 			}
 
@@ -283,7 +283,7 @@ func TestCircuitBreaker_HalfOpenFailure(t *testing.T) {
 			cbConfig := &config.CircuitBreaker{
 				FailureThreshold: 2,
 				Interval:         time.Minute,
-				Timeout:          testutil.IntervalSlow,
+				Timeout:          testutil.IntervalMedium,
 				MaxRequests:      1,
 			}
 
@@ -431,7 +431,7 @@ func TestCircuitBreaker_HalfOpenMaxRequests(t *testing.T) {
 			cbConfig := &config.CircuitBreaker{
 				FailureThreshold: 2,
 				Interval:         time.Minute,
-				Timeout:          testutil.IntervalSlow,
+				Timeout:          testutil.IntervalMedium,
 				MaxRequests:      maxRequests, // Allow only 2 concurrent requests in half-open
 			}
 


### PR DESCRIPTION
`TestCircuitBreaker_FullRecoveryCycle/OpenAI` flaked once on macOS CI. The most likely cause is that the circuit breaker `Timeout` (open-to-half-open transition) was too short relative to the time between test phases. On a slow runner, the breaker could transition to half-open before the test verified it was still open, so the request went through as a half-open probe instead of being rejected.

Increases `Timeout` to `testutil.IntervalMedium` (250ms) across all circuit breaker integration tests.

**Note:** Ideally, these tests would use a mock clock for deterministic timing, but https://github.com/sony/gobreaker (the library used for circuit breaker logic) uses real time internally and doesn't expose a clock interface.

Closes https://linear.app/codercom/issue/AIGOV-438

> Generated with [Coder Agents](https://coder.com/agents) on behalf of @ssncferreira 