### PR TITLE
chore(dogfood/coder): bump codex module to 5.2.0

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -1039,7 +1039,7 @@ resource "coder_app" "claude" {
 
 module "codex" {
   source            = "dev.registry.coder.com/coder-labs/codex/coder"
-  version           = "5.1.1"
+  version           = "5.2.0"
   agent_id          = coder_agent.dev.id
   workdir           = local.repo_dir
   enable_ai_gateway = data.coder_parameter.enable_ai_gateway.value


### PR DESCRIPTION
Bumps the `coder-labs/codex` module in the dogfood template from `5.1.1` to `5.2.0`.

> Generated by Coder Agents on behalf of @35C4n0r