### PR TITLE
fix: alias coder testutil to resolve import collision

### DIFF
--- a/aibridge/internal/integrationtest/circuit_breaker_internal_test.go
+++ b/aibridge/internal/integrationtest/circuit_breaker_internal_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/coder/coder/v2/aibridge/internal/testutil"
 	"github.com/coder/coder/v2/aibridge/metrics"
 	"github.com/coder/coder/v2/aibridge/provider"
-	"github.com/coder/coder/v2/testutil"
+	codertestutil "github.com/coder/coder/v2/testutil"
 )
 
 // Common response bodies for circuit breaker tests.
@@ -127,7 +127,7 @@ func TestCircuitBreaker_FullRecoveryCycle(t *testing.T) {
 			cbConfig := &config.CircuitBreaker{
 				FailureThreshold: 2,
 				Interval:         time.Minute,
-				Timeout:          testutil.IntervalMedium,
+				Timeout:          codertestutil.IntervalMedium,
 				MaxRequests:      1,
 			}
 
@@ -284,7 +284,7 @@ func TestCircuitBreaker_HalfOpenFailure(t *testing.T) {
 			cbConfig := &config.CircuitBreaker{
 				FailureThreshold: 2,
 				Interval:         time.Minute,
-				Timeout:          testutil.IntervalMedium,
+				Timeout:          codertestutil.IntervalMedium,
 				MaxRequests:      1,
 			}
 
@@ -432,7 +432,7 @@ func TestCircuitBreaker_HalfOpenMaxRequests(t *testing.T) {
 			cbConfig := &config.CircuitBreaker{
 				FailureThreshold: 2,
 				Interval:         time.Minute,
-				Timeout:          testutil.IntervalMedium,
+				Timeout:          codertestutil.IntervalMedium,
 				MaxRequests:      maxRequests, // Allow only 2 concurrent requests in half-open
 			}
 


### PR DESCRIPTION
PRs https://github.com/coder/coder/pull/26092 and https://github.com/coder/coder/pull/26519 both landed on main and the circuit breaker test file ended up importing both `aibridge/internal/testutil` and `coder/v2/testutil` under the same name, causing a redeclaration error and breaking `make lint`. 

Alias the latter as `codertestutil`, matching the convention already used in `passthrough_internal_test.go` and `keyfailover_test.go`.

Closes https://github.com/coder/internal/issues/1604
Closes https://linear.app/codercom/issue/ENG-2943/flake-aibridgeinternalintegrationtest-build-failure-testutil-import