### PR TITLE
fix(aibridge): prevent control plane panic on negative cached tokens

### DIFF
--- a/aibridge/intercept/chatcompletions/base.go
+++ b/aibridge/intercept/chatcompletions/base.go
@@ -245,10 +245,10 @@ func sumUsage(ref, in openai.CompletionUsage) openai.CompletionUsage {
 }
 
 // calculateActualInputTokenUsage accounts for cached tokens which are included in [openai.CompletionUsage].PromptTokens.
-func calculateActualInputTokenUsage(in openai.CompletionUsage) int64 {
-	// Input *includes* the cached tokens, so we subtract them here to reflect actual input token usage.
-	// The original value can be reconstructed by adding CachedTokens back to Input.
-	// See https://platform.openai.com/docs/api-reference/usage/completions_object#usage/completions_object-input_tokens.
-	return in.PromptTokens /* The aggregated number of text input tokens used, including cached tokens. */ -
-		in.PromptTokensDetails.CachedTokens /* The aggregated number of text input tokens that has been cached from previous requests. */
+// Input *includes* the cached tokens, so they are subtracted to reflect actual input token usage; the original value can
+// be reconstructed by adding CachedTokens back. The result is clamped to zero.
+// See https://platform.openai.com/docs/api-reference/usage/completions_object#usage/completions_object-input_tokens.
+func (i *interceptionBase) calculateActualInputTokenUsage(ctx context.Context, in openai.CompletionUsage) int64 {
+	return intercept.NonNegativeInputTokens(ctx, i.logger, i.cfg.ProviderName, "/v1/chat/completions",
+		in.PromptTokens, in.PromptTokensDetails.CachedTokens)
 }

--- a/aibridge/intercept/chatcompletions/blocking.go
+++ b/aibridge/intercept/chatcompletions/blocking.go
@@ -126,7 +126,7 @@ func (i *BlockingInterception) ProcessRequest(w http.ResponseWriter, r *http.Req
 		_ = i.recorder.RecordTokenUsage(ctx, &recorder.TokenUsageRecord{
 			InterceptionID:       i.ID().String(),
 			MsgID:                completion.ID,
-			Input:                calculateActualInputTokenUsage(lastUsage),
+			Input:                i.calculateActualInputTokenUsage(ctx, lastUsage),
 			Output:               lastUsage.CompletionTokens,
 			CacheReadInputTokens: lastUsage.PromptTokensDetails.CachedTokens,
 			ExtraTokenTypes: map[string]int64{

--- a/aibridge/intercept/chatcompletions/streaming.go
+++ b/aibridge/intercept/chatcompletions/streaming.go
@@ -273,7 +273,7 @@ func (i *StreamingInterception) ProcessRequest(w http.ResponseWriter, r *http.Re
 			_ = i.recorder.RecordTokenUsage(streamCtx, &recorder.TokenUsageRecord{
 				InterceptionID:       i.ID().String(),
 				MsgID:                processor.getMsgID(),
-				Input:                calculateActualInputTokenUsage(lastUsage),
+				Input:                i.calculateActualInputTokenUsage(streamCtx, lastUsage),
 				Output:               lastUsage.CompletionTokens,
 				CacheReadInputTokens: lastUsage.PromptTokensDetails.CachedTokens,
 				ExtraTokenTypes: map[string]int64{

--- a/aibridge/intercept/responses/base.go
+++ b/aibridge/intercept/responses/base.go
@@ -301,9 +301,10 @@ func (i *responsesInterceptionBase) recordTokenUsage(ctx context.Context, respon
 
 	usage := response.Usage
 
-	// Keeping logic consistent with chat completions
-	// Input *includes* the cached tokens, so we subtract them here to reflect actual input token usage.
-	inputNonCacheTokens := usage.InputTokens - usage.InputTokensDetails.CachedTokens
+	// Keeping logic consistent with chat completions: input *includes* the cached tokens, so they are
+	// subtracted to reflect actual input token usage.
+	inputNonCacheTokens := intercept.NonNegativeInputTokens(ctx, i.logger, i.cfg.ProviderName, "/v1/responses",
+		usage.InputTokens, usage.InputTokensDetails.CachedTokens)
 
 	if err := i.recorder.RecordTokenUsage(ctx, &recorder.TokenUsageRecord{
 		InterceptionID:       i.ID().String(),

--- a/aibridge/intercept/token_usage.go
+++ b/aibridge/intercept/token_usage.go
@@ -1,0 +1,26 @@
+package intercept
+
+import (
+	"context"
+
+	"cdr.dev/slog/v3"
+)
+
+// NonNegativeInputTokens returns the non-cached input token count (total minus cached), clamped to
+// zero. Some providers violate the spec and report more cached tokens than total input tokens, which
+// would yield a negative value and panic the Prometheus token counters downstream. When that happens
+// it logs an error with the provider, endpoint, and constituent values so the offending response can
+// be debugged.
+func NonNegativeInputTokens(ctx context.Context, logger slog.Logger, provider, endpoint string, totalInputTokens, cachedInputTokens int64) int64 {
+	input := totalInputTokens - cachedInputTokens
+	if input < 0 {
+		logger.Error(ctx, "provider reported more cached tokens than input tokens; clamping input token usage to zero",
+			slog.F("provider", provider),
+			slog.F("endpoint", endpoint),
+			slog.F("total_input_tokens", totalInputTokens),
+			slog.F("cached_input_tokens", cachedInputTokens),
+		)
+		return 0
+	}
+	return input
+}

--- a/aibridge/intercept/token_usage_test.go
+++ b/aibridge/intercept/token_usage_test.go
@@ -1,0 +1,80 @@
+package intercept_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/aibridge/intercept"
+)
+
+// captureSink records log entries for assertions.
+type captureSink struct {
+	mu      sync.Mutex
+	entries []slog.SinkEntry
+}
+
+func (s *captureSink) LogEntry(_ context.Context, e slog.SinkEntry) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries = append(s.entries, e)
+}
+
+func (*captureSink) Sync() {}
+
+func TestNonNegativeInputTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		total       int64
+		cached      int64
+		expected    int64
+		expectError bool
+	}{
+		{name: "no_cached_tokens", total: 100, cached: 0, expected: 100},
+		{name: "cached_less_than_total", total: 100, cached: 25, expected: 75},
+		{name: "cached_equals_total", total: 50, cached: 50, expected: 0},
+		{name: "zero", total: 0, cached: 0, expected: 0},
+		// AIGOV-452: cached > total must clamp to zero and log an error.
+		{name: "cached_greater_than_total_clamps_and_logs", total: 805, cached: 4352, expected: 0, expectError: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sink := &captureSink{}
+			logger := slog.Make(sink)
+
+			got := intercept.NonNegativeInputTokens(t.Context(), logger, "test-provider", "/v1/test", tc.total, tc.cached)
+			require.Equal(t, tc.expected, got)
+			require.GreaterOrEqual(t, got, int64(0), "result must never be negative")
+
+			if !tc.expectError {
+				require.Empty(t, sink.entries)
+				return
+			}
+
+			require.Len(t, sink.entries, 1)
+			e := sink.entries[0]
+			require.Equal(t, slog.LevelError, e.Level)
+			fields := fieldMap(e.Fields)
+			require.Equal(t, "test-provider", fields["provider"])
+			require.Equal(t, "/v1/test", fields["endpoint"])
+			require.Equal(t, tc.total, fields["total_input_tokens"])
+			require.Equal(t, tc.cached, fields["cached_input_tokens"])
+		})
+	}
+}
+
+func fieldMap(fields slog.Map) map[string]any {
+	m := make(map[string]any, len(fields))
+	for _, f := range fields {
+		m[f.Name] = f.Value
+	}
+	return m
+}


### PR DESCRIPTION
Coder can panic with `panic: counter cannot decrease in value` in `aibridge/recorder` when token usage is recorded from a provider response where cached input tokens exceed total input tokens.

Both the chat completions and responses interceptors derive input token usage by subtracting cached tokens from total input tokens. The reported response had `prompt_tokens: 805` and `cached_tokens: 4352`, yielding `-3547`. That negative value is later passed to `prometheus.Counter.Add`, which panics on negative deltas.

This adds `intercept.NonNegativeInputTokens`, a shared helper that clamps the subtraction to zero and, when it would have gone negative, logs an error with the provider, endpoint, and the constituent values used in the calculation so the offending provider can be debugged. Both subtraction sites now use it.

`TestNonNegativeInputTokens` covers the normal, equal, zero, and negative (AIGOV-452) cases, asserting both the clamped result and that the error is logged with the expected fields.

Refs: AIGOV-452

---

This PR was generated by a Coder Agent on behalf of @dannykopping.
