### PR TITLE
refactor(aibridge/intercept): move actor header injection into client-header middleware

### DIFF
--- a/aibridge/intercept/actor_headers.go
+++ b/aibridge/intercept/actor_headers.go
@@ -2,6 +2,7 @@ package intercept
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 
 	ant_option "github.com/anthropics/anthropic-sdk-go/option"
@@ -58,6 +59,15 @@ func ActorHeadersAsAnthropicOpts(actor *context.Actor) []ant_option.RequestOptio
 	}
 
 	return opts
+}
+
+// SetActorHeaders injects actor identity headers directly into an
+// http.Header. This is used by the client-header middleware to add
+// actor headers to the outgoing upstream request.
+func SetActorHeaders(headers http.Header, actor *context.Actor) {
+	for k, v := range headersFromActor(actor) {
+		headers.Set(k, v)
+	}
 }
 
 // headersFromActor produces a map of headers from a given [context.Actor].

--- a/aibridge/intercept/actor_headers_test.go
+++ b/aibridge/intercept/actor_headers_test.go
@@ -1,6 +1,7 @@
 package intercept_test
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/google/uuid"
@@ -54,4 +55,48 @@ func TestBasicAndMetadata(t *testing.T) {
 	require.Len(t, oaiOpts, 1+len(actor.Metadata))
 	antOpts := intercept.ActorHeadersAsAnthropicOpts(actor)
 	require.Len(t, antOpts, 1+len(actor.Metadata))
+}
+
+func TestSetActorHeaders(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil actor is a no-op", func(t *testing.T) {
+		t.Parallel()
+
+		headers := http.Header{"User-Agent": {"test"}}
+		intercept.SetActorHeaders(headers, nil)
+		require.Equal(t, http.Header{"User-Agent": {"test"}}, headers)
+	})
+
+	t.Run("sets actor ID header", func(t *testing.T) {
+		t.Parallel()
+
+		actorID := uuid.NewString()
+		actor := &context.Actor{ID: actorID}
+
+		headers := http.Header{}
+		intercept.SetActorHeaders(headers, actor)
+
+		require.Equal(t, actorID, headers.Get(intercept.ActorIDHeader()))
+	})
+
+	t.Run("sets actor ID and metadata headers", func(t *testing.T) {
+		t.Parallel()
+
+		actorID := uuid.NewString()
+		actor := &context.Actor{
+			ID: actorID,
+			Metadata: recorder.Metadata{
+				"Name":  "alice",
+				"Email": "alice@example.com",
+			},
+		}
+
+		headers := http.Header{}
+		intercept.SetActorHeaders(headers, actor)
+
+		require.Equal(t, actorID, headers.Get(intercept.ActorIDHeader()))
+		require.Equal(t, "alice", headers.Get(intercept.ActorMetadataHeader("Name")))
+		require.Equal(t, "alice@example.com", headers.Get(intercept.ActorMetadataHeader("Email")))
+	})
 }

--- a/aibridge/intercept/chatcompletions/base.go
+++ b/aibridge/intercept/chatcompletions/base.go
@@ -63,6 +63,11 @@ func (i *interceptionBase) newCompletionsService(ctx context.Context) openai.Cha
 	if i.clientHeaders != nil {
 		opts = append(opts, option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
 			req.Header = intercept.BuildUpstreamHeaders(req.Header, i.clientHeaders, i.cred.AuthHeader())
+			if i.cfg.SendActorHeaders {
+				if actor := aibcontext.ActorFromContext(req.Context()); actor != nil {
+					intercept.SetActorHeaders(req.Header, actor)
+				}
+			}
 			return next(req)
 		}))
 	}

--- a/aibridge/intercept/chatcompletions/blocking.go
+++ b/aibridge/intercept/chatcompletions/blocking.go
@@ -16,7 +16,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
-	aibcontext "github.com/coder/coder/v2/aibridge/context"
 	"github.com/coder/coder/v2/aibridge/intercept"
 	"github.com/coder/coder/v2/aibridge/intercept/eventstream"
 	"github.com/coder/coder/v2/aibridge/keypool"
@@ -97,12 +96,6 @@ func (i *BlockingInterception) ProcessRequest(w http.ResponseWriter, r *http.Req
 
 		var opts []option.RequestOption
 		opts = append(opts, option.WithRequestTimeout(time.Second*600))
-
-		// TODO(ssncferreira): inject actor headers directly in the client-header
-		//   middleware instead of using SDK options.
-		if actor := aibcontext.ActorFromContext(r.Context()); actor != nil && i.cfg.SendActorHeaders {
-			opts = append(opts, intercept.ActorHeadersAsOpenAIOpts(actor)...)
-		}
 
 		var keyAttempts int
 		completion, keyAttempts, err = i.newChatCompletion(ctx, svc, opts)

--- a/aibridge/intercept/chatcompletions/streaming.go
+++ b/aibridge/intercept/chatcompletions/streaming.go
@@ -20,7 +20,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
-	aibcontext "github.com/coder/coder/v2/aibridge/context"
 	"github.com/coder/coder/v2/aibridge/intercept"
 	"github.com/coder/coder/v2/aibridge/intercept/eventstream"
 	"github.com/coder/coder/v2/aibridge/keypool"
@@ -172,12 +171,6 @@ func (i *StreamingInterception) ProcessRequest(w http.ResponseWriter, r *http.Re
 				option.WithMaxRetries(0),
 			)
 			totalKeyAttempts += walker.Attempts()
-		}
-
-		// TODO(ssncferreira): inject actor headers directly in the client-header
-		//   middleware instead of using SDK options.
-		if actor := aibcontext.ActorFromContext(r.Context()); actor != nil && i.cfg.SendActorHeaders {
-			opts = append(opts, intercept.ActorHeadersAsOpenAIOpts(actor)...)
 		}
 
 		// We take control of request body here and pass it to the SDK as a raw byte slice.

--- a/aibridge/intercept/client_headers.go
+++ b/aibridge/intercept/client_headers.go
@@ -77,12 +77,5 @@ func BuildUpstreamHeaders(sdkHeader http.Header, clientHeaders http.Header, auth
 		headers.Set(authHeaderName, v)
 	}
 
-	// Preserve actor headers injected by aibridge as per-request SDK options.
-	for name, values := range sdkHeader {
-		if IsActorHeader(name) {
-			headers[name] = values
-		}
-	}
-
 	return headers
 }

--- a/aibridge/intercept/client_headers_test.go
+++ b/aibridge/intercept/client_headers_test.go
@@ -162,7 +162,7 @@ func TestBuildUpstreamHeaders(t *testing.T) {
 		assert.Equal(t, "prompt-caching-2024-07-31", result.Get("Anthropic-Beta"))
 	})
 
-	t.Run("preserves actor headers from SDK", func(t *testing.T) {
+	t.Run("does not preserve actor headers from SDK", func(t *testing.T) {
 		t.Parallel()
 
 		sdkHeader := http.Header{
@@ -178,8 +178,8 @@ func TestBuildUpstreamHeaders(t *testing.T) {
 		result := intercept.BuildUpstreamHeaders(sdkHeader, clientHeaders, "Authorization")
 
 		assert.Equal(t, "Bearer sk-key", result.Get("Authorization"))
-		assert.Equal(t, "user-123", result.Get("X-Ai-Bridge-Actor-Id"))
-		assert.Equal(t, "alice", result.Get("X-Ai-Bridge-Actor-Metadata-Name"))
+		assert.Empty(t, result.Get("X-Ai-Bridge-Actor-Id"))
+		assert.Empty(t, result.Get("X-Ai-Bridge-Actor-Metadata-Name"))
 		assert.Equal(t, "claude-code/1.0", result.Get("User-Agent"))
 	})
 

--- a/aibridge/intercept/messages/base.go
+++ b/aibridge/intercept/messages/base.go
@@ -229,6 +229,11 @@ func (i *interceptionBase) newMessagesService(ctx context.Context, opts ...optio
 	if i.clientHeaders != nil {
 		opts = append(opts, option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
 			req.Header = intercept.BuildUpstreamHeaders(req.Header, i.clientHeaders, i.cred.AuthHeader())
+			if i.cfg.SendActorHeaders {
+				if actor := aibcontext.ActorFromContext(req.Context()); actor != nil {
+					intercept.SetActorHeaders(req.Header, actor)
+				}
+			}
 			return next(req)
 		}))
 	}

--- a/aibridge/intercept/messages/blocking.go
+++ b/aibridge/intercept/messages/blocking.go
@@ -18,7 +18,6 @@ import (
 
 	"cdr.dev/slog/v3"
 	aibconfig "github.com/coder/coder/v2/aibridge/config"
-	aibcontext "github.com/coder/coder/v2/aibridge/context"
 	"github.com/coder/coder/v2/aibridge/intercept"
 	"github.com/coder/coder/v2/aibridge/intercept/eventstream"
 	"github.com/coder/coder/v2/aibridge/keypool"
@@ -81,12 +80,9 @@ func (i *BlockingInterception) ProcessRequest(w http.ResponseWriter, r *http.Req
 		prompt = &promptText
 	}
 
-	// TODO(ssncferreira): inject actor headers directly in the client-header
-	//   middleware instead of using SDK options.
+	// Actor headers are injected by the client-header middleware in
+	// newMessagesService.
 	opts := []option.RequestOption{option.WithRequestTimeout(time.Second * 600)}
-	if actor := aibcontext.ActorFromContext(r.Context()); actor != nil && i.cfg.SendActorHeaders {
-		opts = append(opts, intercept.ActorHeadersAsAnthropicOpts(actor)...)
-	}
 
 	svc, err := i.newMessagesService(ctx, opts...)
 	if err != nil {

--- a/aibridge/intercept/messages/streaming.go
+++ b/aibridge/intercept/messages/streaming.go
@@ -22,7 +22,6 @@ import (
 
 	"cdr.dev/slog/v3"
 	aibconfig "github.com/coder/coder/v2/aibridge/config"
-	aibcontext "github.com/coder/coder/v2/aibridge/context"
 	"github.com/coder/coder/v2/aibridge/intercept"
 	"github.com/coder/coder/v2/aibridge/intercept/eventstream"
 	"github.com/coder/coder/v2/aibridge/keypool"
@@ -123,12 +122,9 @@ func (i *StreamingInterception) ProcessRequest(w http.ResponseWriter, r *http.Re
 	streamCtx, streamCancel := context.WithCancelCause(ctx)
 	defer streamCancel(xerrors.New("deferred"))
 
-	// TODO(ssncferreira): inject actor headers directly in the client-header
-	//   middleware instead of using SDK options.
+	// Actor headers are injected by the client-header middleware in
+	// newMessagesService.
 	var opts []option.RequestOption
-	if actor := aibcontext.ActorFromContext(ctx); actor != nil && i.cfg.SendActorHeaders {
-		opts = append(opts, intercept.ActorHeadersAsAnthropicOpts(actor)...)
-	}
 
 	svc, err := i.newMessagesService(streamCtx, opts...)
 	if err != nil {

--- a/aibridge/intercept/responses/base.go
+++ b/aibridge/intercept/responses/base.go
@@ -76,6 +76,11 @@ func (i *responsesInterceptionBase) newResponsesService(ctx context.Context) res
 	if i.clientHeaders != nil {
 		opts = append(opts, option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
 			req.Header = intercept.BuildUpstreamHeaders(req.Header, i.clientHeaders, i.cred.AuthHeader())
+			if i.cfg.SendActorHeaders {
+				if actor := aibcontext.ActorFromContext(req.Context()); actor != nil {
+					intercept.SetActorHeaders(req.Header, actor)
+				}
+			}
 			return next(req)
 		}))
 	}

--- a/aibridge/intercept/responses/blocking.go
+++ b/aibridge/intercept/responses/blocking.go
@@ -14,7 +14,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
-	aibcontext "github.com/coder/coder/v2/aibridge/context"
 	"github.com/coder/coder/v2/aibridge/intercept"
 	"github.com/coder/coder/v2/aibridge/keypool"
 	"github.com/coder/coder/v2/aibridge/mcp"
@@ -96,12 +95,6 @@ func (i *BlockingResponsesInterceptor) ProcessRequest(w http.ResponseWriter, r *
 
 		opts := i.requestOptions(&respCopy)
 		opts = append(opts, option.WithRequestTimeout(time.Second*600))
-
-		// TODO(ssncferreira): inject actor headers directly in the client-header
-		//   middleware instead of using SDK options.
-		if actor := aibcontext.ActorFromContext(r.Context()); actor != nil && i.cfg.SendActorHeaders {
-			opts = append(opts, intercept.ActorHeadersAsOpenAIOpts(actor)...)
-		}
 
 		var keyAttempts int
 		response, keyAttempts, upstreamErr = i.newResponse(ctx, srv, opts)

--- a/aibridge/intercept/responses/streaming.go
+++ b/aibridge/intercept/responses/streaming.go
@@ -16,7 +16,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
-	aibcontext "github.com/coder/coder/v2/aibridge/context"
 	"github.com/coder/coder/v2/aibridge/intercept"
 	"github.com/coder/coder/v2/aibridge/intercept/eventstream"
 	"github.com/coder/coder/v2/aibridge/keypool"
@@ -130,12 +129,6 @@ func (i *StreamingResponsesInterceptor) ProcessRequest(w http.ResponseWriter, r 
 		for {
 			respCopy = responseCopier{}
 			opts := i.requestOptions(&respCopy)
-
-			// TODO(ssncferreira): inject actor headers directly in the client-header
-			//   middleware instead of using SDK options.
-			if actor := aibcontext.ActorFromContext(r.Context()); actor != nil && i.cfg.SendActorHeaders {
-				opts = append(opts, intercept.ActorHeadersAsOpenAIOpts(actor)...)
-			}
 
 			var currentPoolKey *keypool.Key
 			if isPool && walker != nil {


### PR DESCRIPTION
Move actor header injection from per-request SDK options in the 6 blocking/streaming handlers into the client-header middleware in the 3 service builders (`newResponsesService`, `newMessagesService`, `newCompletionsService`). This eliminates duplicated logic and resolves all `ssncferreira` TODO comments about actor headers.

Previously, each blocking and streaming handler in `responses`, `messages`, and `chatcompletions` independently checked for an actor in the request context and injected actor headers as SDK request options. The client-header middleware then had to preserve these headers from the SDK-built request. Now, the middleware injects actor headers directly after building upstream headers, using the request context that the SDK propagates from the caller.

- Add `SetActorHeaders` to inject actor headers directly into `http.Header`
- Inject actor headers in the middleware closures of the 3 service builders
- Remove actor header SDK option injection from all 6 blocking/streaming handlers
- Remove actor header preservation from `BuildUpstreamHeaders` (no longer needed)
- Add unit tests for `SetActorHeaders`; update `BuildUpstreamHeaders` tests

> Generated by Coder Agents