### PR TITLE
fix(aibridge): guard negative token counts at the prometheus sink

### DIFF
--- a/aibridge/metrics/metrics.go
+++ b/aibridge/metrics/metrics.go
@@ -1,10 +1,9 @@
 package metrics
 
 import (
-	"golang.org/x/xerrors"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"golang.org/x/xerrors"
 )
 
 var baseLabels = []string{"provider", "model"}

--- a/aibridge/metrics/metrics.go
+++ b/aibridge/metrics/metrics.go
@@ -1,6 +1,8 @@
 package metrics
 
 import (
+	"golang.org/x/xerrors"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -162,4 +164,15 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 			Buckets: []float64{1, 2, 3, 4, 5, 10, 25},
 		}, []string{"provider"}),
 	}
+}
+
+// AddTokenCount rejects negatives to avoid a Counter.Add panic; the caller
+// must log the returned error so an upstream provider contract violation
+// stays observable.
+func (m *Metrics) AddTokenCount(provider, model, typ, initiatorID, client string, v int64) error {
+	if v < 0 {
+		return xerrors.Errorf("negative token count for type %q: %d", typ, v)
+	}
+	m.TokenUseCount.WithLabelValues(provider, model, typ, initiatorID, client).Add(float64(v))
+	return nil
 }

--- a/aibridge/metrics/metrics.go
+++ b/aibridge/metrics/metrics.go
@@ -24,6 +24,7 @@ type Metrics struct {
 	PromptCount *prometheus.CounterVec
 
 	// Token-related metrics.
+	// Use AddTokenCount to increment; direct Add panics on negative values.
 	TokenUseCount *prometheus.CounterVec
 
 	// Tool-related metrics.
@@ -168,10 +169,10 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 // AddTokenCount rejects negatives to avoid a Counter.Add panic; the caller
 // must log the returned error so an upstream provider contract violation
 // stays observable.
-func (m *Metrics) AddTokenCount(provider, model, typ, initiatorID, client string, v int64) error {
-	if v < 0 {
-		return xerrors.Errorf("negative token count for type %q: %d", typ, v)
+func (m *Metrics) AddTokenCount(provider, model, typ, initiatorID, client string, count int64) error {
+	if count < 0 {
+		return xerrors.Errorf("negative token count for type %q: %d", typ, count)
 	}
-	m.TokenUseCount.WithLabelValues(provider, model, typ, initiatorID, client).Add(float64(v))
+	m.TokenUseCount.WithLabelValues(provider, model, typ, initiatorID, client).Add(float64(count))
 	return nil
 }

--- a/aibridge/metrics/metrics_test.go
+++ b/aibridge/metrics/metrics_test.go
@@ -1,0 +1,63 @@
+package metrics_test
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/aibridge/metrics"
+)
+
+const (
+	testProvider    = "openai"
+	testModel       = "gpt-test"
+	testInitiatorID = "init-test"
+	testClient      = "client-test"
+)
+
+// TestAddTokenCount_NegativeRejected guards the bug class fixed in PR #26547:
+// a provider violating its own invariant must not panic the counter.
+func TestAddTokenCount_NegativeRejected(t *testing.T) {
+	t.Parallel()
+
+	reg := prometheus.NewRegistry()
+	m := metrics.NewMetrics(reg)
+
+	counter := m.TokenUseCount.WithLabelValues(testProvider, testModel, "input", testInitiatorID, testClient)
+
+	require.NoError(t, m.AddTokenCount(testProvider, testModel, "input", testInitiatorID, testClient, 10))
+	require.Equal(t, 10.0, testutil.ToFloat64(counter))
+
+	err := m.AddTokenCount(testProvider, testModel, "input", testInitiatorID, testClient, -5)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "negative token count")
+
+	assert.Equal(t, 10.0, testutil.ToFloat64(counter))
+}
+
+func TestAddTokenCount_PositiveIncrements(t *testing.T) {
+	t.Parallel()
+
+	reg := prometheus.NewRegistry()
+	m := metrics.NewMetrics(reg)
+
+	err := m.AddTokenCount(testProvider, testModel, "output", testInitiatorID, testClient, 42)
+	require.NoError(t, err)
+
+	counter := m.TokenUseCount.WithLabelValues(testProvider, testModel, "output", testInitiatorID, testClient)
+	assert.Equal(t, 42.0, testutil.ToFloat64(counter))
+}
+
+// TestAddTokenCount_ZeroIsAllowed documents that zero is not a violation.
+func TestAddTokenCount_ZeroIsAllowed(t *testing.T) {
+	t.Parallel()
+
+	reg := prometheus.NewRegistry()
+	m := metrics.NewMetrics(reg)
+
+	err := m.AddTokenCount(testProvider, testModel, "input", testInitiatorID, testClient, 0)
+	require.NoError(t, err)
+}

--- a/aibridge/recorder/recorder.go
+++ b/aibridge/recorder/recorder.go
@@ -249,7 +249,7 @@ func (a *AsyncRecorder) RecordTokenUsage(ctx context.Context, req *TokenUsageRec
 						slog.F("provider", a.provider),
 						slog.F("model", a.model),
 						slog.F("type", typ),
-						slog.F("value", count),
+						slog.F("count", count),
 						slog.Error(err),
 					}
 					if flag.Lookup("test.v") != nil {

--- a/aibridge/recorder/recorder.go
+++ b/aibridge/recorder/recorder.go
@@ -239,19 +239,17 @@ func (a *AsyncRecorder) RecordTokenUsage(ctx context.Context, req *TokenUsageRec
 		}
 
 		if a.metrics != nil {
-			// AddTokenCount rejects negatives; without it a provider
-			// violating its own usage invariant would panic the counter.
-			// Fail loudly in tests, warn in prod to avoid paging on a
-			// non-actionable upstream bug.
-			addTokenCount := func(typ string, v int64) {
-				if err := a.metrics.AddTokenCount(a.provider, a.model, typ, a.initiatorID, a.client, v); err != nil {
+			// Warn rather than error in production: the operator cannot
+			// act on an upstream provider bug.
+			addTokenCount := func(typ string, count int64) {
+				if err := a.metrics.AddTokenCount(a.provider, a.model, typ, a.initiatorID, a.client, count); err != nil {
 					fields := []slog.Field{
 						slog.F("interception_id", req.InterceptionID),
 						slog.F("msg_id", req.MsgID),
 						slog.F("provider", a.provider),
 						slog.F("model", a.model),
 						slog.F("type", typ),
-						slog.F("value", v),
+						slog.F("value", count),
 						slog.Error(err),
 					}
 					if flag.Lookup("test.v") != nil {
@@ -265,8 +263,8 @@ func (a *AsyncRecorder) RecordTokenUsage(ctx context.Context, req *TokenUsageRec
 			addTokenCount("output", req.Output)
 			addTokenCount("cache_read_input_tokens", req.CacheReadInputTokens)
 			addTokenCount("cache_write_input_tokens", req.CacheWriteInputTokens)
-			for k, v := range req.ExtraTokenTypes {
-				addTokenCount(k, v)
+			for k, count := range req.ExtraTokenTypes {
+				addTokenCount(k, count)
 			}
 		}
 	}()

--- a/aibridge/recorder/recorder.go
+++ b/aibridge/recorder/recorder.go
@@ -2,8 +2,8 @@ package recorder
 
 import (
 	"context"
+	"flag"
 	"sync"
-	"testing"
 	"time"
 
 	"go.opentelemetry.io/otel/trace"
@@ -254,7 +254,7 @@ func (a *AsyncRecorder) RecordTokenUsage(ctx context.Context, req *TokenUsageRec
 						slog.F("value", v),
 						slog.Error(err),
 					}
-					if testing.Testing() {
+					if flag.Lookup("test.v") != nil {
 						a.logger.Error(timedCtx, "dropped negative token count from metric", fields...)
 					} else {
 						a.logger.Warn(timedCtx, "dropped negative token count from metric", fields...)

--- a/aibridge/recorder/recorder.go
+++ b/aibridge/recorder/recorder.go
@@ -3,6 +3,7 @@ package recorder
 import (
 	"context"
 	"sync"
+	"testing"
 	"time"
 
 	"go.opentelemetry.io/otel/trace"
@@ -238,12 +239,34 @@ func (a *AsyncRecorder) RecordTokenUsage(ctx context.Context, req *TokenUsageRec
 		}
 
 		if a.metrics != nil {
-			a.metrics.TokenUseCount.WithLabelValues(a.provider, a.model, "input", a.initiatorID, a.client).Add(float64(req.Input))
-			a.metrics.TokenUseCount.WithLabelValues(a.provider, a.model, "output", a.initiatorID, a.client).Add(float64(req.Output))
-			a.metrics.TokenUseCount.WithLabelValues(a.provider, a.model, "cache_read_input_tokens", a.initiatorID, a.client).Add(float64(req.CacheReadInputTokens))
-			a.metrics.TokenUseCount.WithLabelValues(a.provider, a.model, "cache_write_input_tokens", a.initiatorID, a.client).Add(float64(req.CacheWriteInputTokens))
+			// AddTokenCount rejects negatives; without it a provider
+			// violating its own usage invariant would panic the counter.
+			// Fail loudly in tests, warn in prod to avoid paging on a
+			// non-actionable upstream bug.
+			addTokenCount := func(typ string, v int64) {
+				if err := a.metrics.AddTokenCount(a.provider, a.model, typ, a.initiatorID, a.client, v); err != nil {
+					fields := []slog.Field{
+						slog.F("interception_id", req.InterceptionID),
+						slog.F("msg_id", req.MsgID),
+						slog.F("provider", a.provider),
+						slog.F("model", a.model),
+						slog.F("type", typ),
+						slog.F("value", v),
+						slog.Error(err),
+					}
+					if testing.Testing() {
+						a.logger.Error(timedCtx, "dropped negative token count from metric", fields...)
+					} else {
+						a.logger.Warn(timedCtx, "dropped negative token count from metric", fields...)
+					}
+				}
+			}
+			addTokenCount("input", req.Input)
+			addTokenCount("output", req.Output)
+			addTokenCount("cache_read_input_tokens", req.CacheReadInputTokens)
+			addTokenCount("cache_write_input_tokens", req.CacheWriteInputTokens)
 			for k, v := range req.ExtraTokenTypes {
-				a.metrics.TokenUseCount.WithLabelValues(a.provider, a.model, k, a.initiatorID, a.client).Add(float64(v))
+				addTokenCount(k, v)
 			}
 		}
 	}()

--- a/aibridge/recorder/recorder_internal_test.go
+++ b/aibridge/recorder/recorder_internal_test.go
@@ -1,0 +1,105 @@
+package recorder
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/aibridge/metrics"
+)
+
+// captureRecorder avoids an import cycle: aibridge/internal/testutil imports
+// this package, so the recorder internal test cannot.
+type captureRecorder struct {
+	mu   sync.Mutex
+	seen []*TokenUsageRecord
+}
+
+func (c *captureRecorder) RecordTokenUsage(_ context.Context, req *TokenUsageRecord) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.seen = append(c.seen, req)
+	return nil
+}
+
+func (*captureRecorder) RecordInterception(context.Context, *InterceptionRecord) error {
+	return nil
+}
+
+func (*captureRecorder) RecordInterceptionEnded(context.Context, *InterceptionRecordEnded) error {
+	return nil
+}
+
+func (*captureRecorder) RecordPromptUsage(context.Context, *PromptUsageRecord) error {
+	return nil
+}
+
+func (*captureRecorder) RecordToolUsage(context.Context, *ToolUsageRecord) error {
+	return nil
+}
+
+func (*captureRecorder) RecordModelThought(context.Context, *ModelThoughtRecord) error {
+	return nil
+}
+
+func (c *captureRecorder) tokenUsages() []*TokenUsageRecord {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cp := make([]*TokenUsageRecord, len(c.seen))
+	copy(cp, c.seen)
+	return cp
+}
+
+// TestAsyncRecorder_RecordTokenUsage_NegativeDoesNotPanic exercises the full
+// async path: a provider emitting negative values must not panic the counter.
+func TestAsyncRecorder_RecordTokenUsage_NegativeDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	reg := prometheus.NewRegistry()
+	m := metrics.NewMetrics(reg)
+
+	mock := &captureRecorder{}
+	ar := NewAsyncRecorder(slog.Make(), mock, time.Second)
+	ar.WithProvider("openai")
+	ar.WithModel("gpt-test")
+	ar.WithInitiatorID("init-test")
+	ar.WithClient("client-test")
+	ar.WithMetrics(m)
+
+	// Input and an ExtraTokenTypes value are negative; before the guard this
+	// reached Counter.Add and panicked.
+	err := ar.RecordTokenUsage(context.Background(), &TokenUsageRecord{
+		InterceptionID: "intc-1",
+		MsgID:          "msg-1",
+		Input:          -5,
+		Output:         20,
+		ExtraTokenTypes: map[string]int64{
+			"completion_reasoning": -3,
+		},
+	})
+	require.NoError(t, err)
+
+	// Drain the goroutine before reading, or the writes may not have landed.
+	ar.Wait()
+
+	inputCounter := m.TokenUseCount.WithLabelValues("openai", "gpt-test", "input", "init-test", "client-test")
+	outputCounter := m.TokenUseCount.WithLabelValues("openai", "gpt-test", "output", "init-test", "client-test")
+	reasoningCounter := m.TokenUseCount.WithLabelValues("openai", "gpt-test", "completion_reasoning", "init-test", "client-test")
+
+	assert.Equal(t, 0.0, testutil.ToFloat64(inputCounter))
+	assert.Equal(t, 0.0, testutil.ToFloat64(reasoningCounter))
+	assert.Equal(t, 20.0, testutil.ToFloat64(outputCounter))
+
+	// The DB path is untouched by the metric guard: the raw record is still
+	// recorded exactly as the provider sent it.
+	usages := mock.tokenUsages()
+	require.Len(t, usages, 1)
+	assert.Equal(t, int64(-5), usages[0].Input)
+}

--- a/aibridge/recorder/recorder_test.go
+++ b/aibridge/recorder/recorder_test.go
@@ -1,61 +1,20 @@
-package recorder
+package recorder_test
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/testutil"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/aibridge/internal/testutil"
 	"github.com/coder/coder/v2/aibridge/metrics"
+	"github.com/coder/coder/v2/aibridge/recorder"
 )
-
-// captureRecorder avoids an import cycle: aibridge/internal/testutil imports
-// this package, so the recorder internal test cannot.
-type captureRecorder struct {
-	mu   sync.Mutex
-	seen []*TokenUsageRecord
-}
-
-func (c *captureRecorder) RecordTokenUsage(_ context.Context, req *TokenUsageRecord) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.seen = append(c.seen, req)
-	return nil
-}
-
-func (*captureRecorder) RecordInterception(context.Context, *InterceptionRecord) error {
-	return nil
-}
-
-func (*captureRecorder) RecordInterceptionEnded(context.Context, *InterceptionRecordEnded) error {
-	return nil
-}
-
-func (*captureRecorder) RecordPromptUsage(context.Context, *PromptUsageRecord) error {
-	return nil
-}
-
-func (*captureRecorder) RecordToolUsage(context.Context, *ToolUsageRecord) error {
-	return nil
-}
-
-func (*captureRecorder) RecordModelThought(context.Context, *ModelThoughtRecord) error {
-	return nil
-}
-
-func (c *captureRecorder) tokenUsages() []*TokenUsageRecord {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	cp := make([]*TokenUsageRecord, len(c.seen))
-	copy(cp, c.seen)
-	return cp
-}
 
 // TestAsyncRecorder_RecordTokenUsage_NegativeDoesNotPanic exercises the full
 // async path: a provider emitting negative values must not panic the counter.
@@ -65,8 +24,8 @@ func TestAsyncRecorder_RecordTokenUsage_NegativeDoesNotPanic(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	m := metrics.NewMetrics(reg)
 
-	mock := &captureRecorder{}
-	ar := NewAsyncRecorder(slog.Make(), mock, time.Second)
+	mock := &testutil.MockRecorder{}
+	ar := recorder.NewAsyncRecorder(slog.Make(), mock, time.Second)
 	ar.WithProvider("openai")
 	ar.WithModel("gpt-test")
 	ar.WithInitiatorID("init-test")
@@ -75,7 +34,7 @@ func TestAsyncRecorder_RecordTokenUsage_NegativeDoesNotPanic(t *testing.T) {
 
 	// Input and an ExtraTokenTypes value are negative; before the guard this
 	// reached Counter.Add and panicked.
-	err := ar.RecordTokenUsage(context.Background(), &TokenUsageRecord{
+	err := ar.RecordTokenUsage(context.Background(), &recorder.TokenUsageRecord{
 		InterceptionID: "intc-1",
 		MsgID:          "msg-1",
 		Input:          -5,
@@ -93,13 +52,13 @@ func TestAsyncRecorder_RecordTokenUsage_NegativeDoesNotPanic(t *testing.T) {
 	outputCounter := m.TokenUseCount.WithLabelValues("openai", "gpt-test", "output", "init-test", "client-test")
 	reasoningCounter := m.TokenUseCount.WithLabelValues("openai", "gpt-test", "completion_reasoning", "init-test", "client-test")
 
-	assert.Equal(t, 0.0, testutil.ToFloat64(inputCounter))
-	assert.Equal(t, 0.0, testutil.ToFloat64(reasoningCounter))
-	assert.Equal(t, 20.0, testutil.ToFloat64(outputCounter))
+	assert.Equal(t, 0.0, promtestutil.ToFloat64(inputCounter))
+	assert.Equal(t, 0.0, promtestutil.ToFloat64(reasoningCounter))
+	assert.Equal(t, 20.0, promtestutil.ToFloat64(outputCounter))
 
 	// The DB path is untouched by the metric guard: the raw record is still
 	// recorded exactly as the provider sent it.
-	usages := mock.tokenUsages()
+	usages := mock.RecordedTokenUsages()
 	require.Len(t, usages, 1)
 	assert.Equal(t, int64(-5), usages[0].Input)
 }


### PR DESCRIPTION
Follow-up to #26547, which clamped one derived value (`PromptTokens - CachedTokens`) to prevent a `prometheus.Counter.Add` panic. That fix only covered the `Input` field on the two OpenAI paths; the remaining token fields (`Output`, `CacheRead`, `CacheWrite`, and every `ExtraTokenTypes` map value) still reached `Counter.Add` unguarded on all provider paths.

Add `metrics.AddTokenCount`, which rejects negatives and returns an error. All five token counter increments in `AsyncRecorder.RecordTokenUsage` now funnel through it. The single caller handles the error by logging at `slog.LevelError` under a test binary (detected via `flag.Lookup("test.v")`, matching the existing codebase convention) and at `slog.LevelWarn` in production, to avoid paging on a non-actionable upstream provider contract violation. The `TokenUsageRecord` and DB/cost path are untouched so a buggy provider stays observable in the database.

> Disclosure: produced using Coder Agents.