### PR TITLE
chore: replace flag lookup with testing.Testing

### DIFF
--- a/cli/cliui/cliui.go
+++ b/cli/cliui/cliui.go
@@ -1,9 +1,9 @@
 package cliui
 
 import (
-	"flag"
 	"os"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/muesli/termenv"
@@ -53,7 +53,7 @@ func Color(s string) termenv.Color {
 	colorOnce.Do(func() {
 		color = termenv.NewOutput(os.Stdout).EnvColorProfile()
 
-		if flag.Lookup("test.v") != nil {
+		if testing.Testing() {
 			// Use a consistent colorless profile in tests so that results
 			// are deterministic.
 			color = termenv.Ascii

--- a/cli/cliui/select.go
+++ b/cli/cliui/select.go
@@ -1,13 +1,13 @@
 package cliui
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"os/signal"
 	"slices"
 	"strings"
 	"syscall"
+	"testing"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -107,7 +107,7 @@ func Select(inv *serpent.Invocation, opts SelectOptions) (string, error) {
 	// this library to add a dummy fallback, that simply reads/writes
 	// to the IO provided. See:
 	// https://github.com/AlecAivazis/survey/blob/master/terminal/runereader_windows.go#L94
-	if flag.Lookup("test.v") != nil {
+	if testing.Testing() {
 		return opts.Options[0], nil
 	}
 
@@ -383,7 +383,7 @@ type MultiSelectOptions struct {
 
 func MultiSelect(inv *serpent.Invocation, opts MultiSelectOptions) ([]string, error) {
 	// Similar hack is applied to Select()
-	if flag.Lookup("test.v") != nil {
+	if testing.Testing() {
 		return opts.Defaults, nil
 	}
 

--- a/cli/server.go
+++ b/cli/server.go
@@ -12,7 +12,6 @@ import (
 	"crypto/x509"
 	"database/sql"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"log"
@@ -1170,7 +1169,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 			// Coder may be ran as users that don't have permission to write in the homedir,
 			// such as via the systemd service.
 			err = config.URL().Write(localURL.String())
-			if err != nil && flag.Lookup("test.v") != nil {
+			if err != nil && testing.Testing() {
 				return xerrors.Errorf("write config url: %w", err)
 			}
 
@@ -1554,7 +1553,7 @@ func WriteConfigMW(cfg *codersdk.DeploymentValues) serpent.MiddlewareFunc {
 func IsLocalURL(ctx context.Context, u *url.URL) (bool, error) {
 	// In tests, we commonly use "example.com" or "google.com", which
 	// are not loopback, so avoid the DNS lookup to avoid flakes.
-	if flag.Lookup("test.v") != nil {
+	if testing.Testing() {
 		if u.Hostname() == "example.com" || u.Hostname() == "google.com" {
 			return false, nil
 		}

--- a/coderd/audit/request.go
+++ b/coderd/audit/request.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"net/http"
 	"strconv"
+	"testing"
 	"time"
 
 	"github.com/google/uuid"
@@ -409,7 +409,7 @@ func requireOrgID[T Auditable](ctx context.Context, id uuid.UUID, log slog.Logge
 	if ResourceRequiresOrgID[T]() && id == uuid.Nil {
 		var tgt T
 		resourceName := fmt.Sprintf("%T", tgt)
-		if flag.Lookup("test.v") != nil {
+		if testing.Testing() {
 			// In unit tests we panic to fail the tests
 			panic(fmt.Sprintf("missing required organization ID for resource %q", resourceName))
 		}

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -2370,7 +2370,7 @@ func (api *API) Close() error {
 
 func compressHandler(h http.Handler) http.Handler {
 	level := 5
-	if flag.Lookup("test.v") != nil {
+	if testing.Testing() {
 		level = 1
 	}
 
@@ -2448,7 +2448,7 @@ func (api *API) CreateInMemoryTaggedProvisionerDaemon(dialCtx context.Context, n
 	}
 
 	apiVersion := proto.CurrentVersion.String()
-	if options.versionOverride != "" && flag.Lookup("test.v") != nil {
+	if options.versionOverride != "" && testing.Testing() {
 		// This should only be usable for unit testing. To fake a different provisioner version
 		apiVersion = options.versionOverride
 	}

--- a/coderd/gitsshkey/gitsshkey.go
+++ b/coderd/gitsshkey/gitsshkey.go
@@ -10,10 +10,10 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-	"flag"
 	"io"
 	insecurerand "math/rand"
 	"strings"
+	"testing"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -33,7 +33,7 @@ const (
 )
 
 func entropy() io.Reader {
-	if flag.Lookup("test.v") != nil {
+	if testing.Testing() {
 		// This helps speed along our tests, esp. in CI where entropy is
 		// sparse.
 		//nolint:gosec

--- a/coderd/httpapi/httpapi.go
+++ b/coderd/httpapi/httpapi.go
@@ -6,11 +6,11 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/go-playground/validator/v10"
@@ -190,7 +190,7 @@ func RouteNotFound(rw http.ResponseWriter) {
 // spot routes that need to be paginated.
 func Write(ctx context.Context, rw http.ResponseWriter, status int, response interface{}) {
 	// Pretty up JSON when testing.
-	if flag.Lookup("test.v") != nil {
+	if testing.Testing() {
 		WriteIndent(ctx, rw, status, response)
 		return
 	}

--- a/coderd/rbac/error.go
+++ b/coderd/rbac/error.go
@@ -3,8 +3,8 @@ package rbac
 import (
 	"context"
 	"errors"
-	"flag"
 	"fmt"
+	"testing"
 
 	"github.com/open-policy-agent/opa/topdown"
 	"github.com/open-policy-agent/opa/v1/rego"
@@ -76,7 +76,7 @@ func (e *UnauthorizedError) longError() string {
 
 // Error implements the error interface.
 func (e UnauthorizedError) Error() string {
-	if flag.Lookup("test.v") != nil {
+	if testing.Testing() {
 		return e.longError()
 	}
 	return errUnauthorized

--- a/coderd/tracing/status_writer.go
+++ b/coderd/tracing/status_writer.go
@@ -2,13 +2,13 @@ package tracing
 
 import (
 	"bufio"
-	"flag"
 	"fmt"
 	"log"
 	"net"
 	"net/http"
 	"runtime"
 	"strings"
+	"testing"
 
 	"golang.org/x/xerrors"
 
@@ -41,7 +41,7 @@ func StatusWriterMiddleware(next http.Handler) http.Handler {
 }
 
 func (w *StatusWriter) WriteHeader(status int) {
-	if buildinfo.IsDev() || flag.Lookup("test.v") != nil {
+	if buildinfo.IsDev() || testing.Testing() {
 		if w.wroteHeader {
 			stack := getStackString(2)
 			wroteHeaderStack := w.wroteHeaderStack


### PR DESCRIPTION
Mechanical refactor to replace existing instances of `flag.Lookup("test.v") != nil` with `testing.Testing()`.
Both versions were in use across the codebase.
