### PR TITLE
chore: replace testing.Testing with flag lookup

### DIFF
--- a/agent/x/agentmcp/mcphttpclient.go
+++ b/agent/x/agentmcp/mcphttpclient.go
@@ -1,8 +1,8 @@
 package agentmcp
 
 import (
+	"flag"
 	"net/http"
-	"testing"
 )
 
 // mcpHTTPClient returns an isolated *http.Client when running
@@ -13,7 +13,7 @@ import (
 // is a *http.Transport it is cloned; otherwise a minimal
 // transport with ProxyFromEnvironment is created as a fallback.
 func mcpHTTPClient() *http.Client {
-	if !testing.Testing() {
+	if flag.Lookup("testing.v") == nil {
 		return nil
 	}
 	if dt, ok := http.DefaultTransport.(*http.Transport); ok {

--- a/agent/x/agentmcp/mcphttpclient.go
+++ b/agent/x/agentmcp/mcphttpclient.go
@@ -13,7 +13,7 @@ import (
 // is a *http.Transport it is cloned; otherwise a minimal
 // transport with ProxyFromEnvironment is created as a fallback.
 func mcpHTTPClient() *http.Client {
-	if flag.Lookup("testing.v") == nil {
+	if flag.Lookup("test.v") == nil {
 		return nil
 	}
 	if dt, ok := http.DefaultTransport.(*http.Transport); ok {

--- a/aibridge/mcp/mcphttpclient.go
+++ b/aibridge/mcp/mcphttpclient.go
@@ -1,8 +1,8 @@
 package mcp
 
 import (
+	"flag"
 	"net/http"
-	"testing"
 )
 
 // mcpHTTPClient returns an isolated *http.Client when running
@@ -13,7 +13,7 @@ import (
 // is a *http.Transport it is cloned; otherwise a minimal
 // transport with ProxyFromEnvironment is created as a fallback.
 func mcpHTTPClient() *http.Client {
-	if !testing.Testing() {
+	if flag.Lookup("testing.v") == nil {
 		return nil
 	}
 	if dt, ok := http.DefaultTransport.(*http.Transport); ok {

--- a/aibridge/mcp/mcphttpclient.go
+++ b/aibridge/mcp/mcphttpclient.go
@@ -13,7 +13,7 @@ import (
 // is a *http.Transport it is cloned; otherwise a minimal
 // transport with ProxyFromEnvironment is created as a fallback.
 func mcpHTTPClient() *http.Client {
-	if flag.Lookup("testing.v") == nil {
+	if flag.Lookup("test.v") == nil {
 		return nil
 	}
 	if dt, ok := http.DefaultTransport.(*http.Transport); ok {

--- a/cli/server.go
+++ b/cli/server.go
@@ -2399,10 +2399,10 @@ func startBuiltinPostgres(ctx context.Context, cfg config.Root, logger slog.Logg
 	// in CI and cause flaky tests.
 	maxAttempts := 1
 	_, err = cfg.PostgresPort().Read()
-	// Important: if retryPortDiscovery is changed to not include flag.Lookup("testing.v") != nil,
+	// Important: if retryPortDiscovery is changed to not include flag.Lookup("test.v") != nil,
 	// the retry logic below also needs to be updated to ensure we don't delete an
 	// existing database
-	retryPortDiscovery := errors.Is(err, os.ErrNotExist) && flag.Lookup("testing.v") != nil
+	retryPortDiscovery := errors.Is(err, os.ErrNotExist) && flag.Lookup("test.v") != nil
 	if retryPortDiscovery {
 		maxAttempts = 10
 	}

--- a/cli/server.go
+++ b/cli/server.go
@@ -30,7 +30,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"testing"
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
@@ -2400,10 +2399,10 @@ func startBuiltinPostgres(ctx context.Context, cfg config.Root, logger slog.Logg
 	// in CI and cause flaky tests.
 	maxAttempts := 1
 	_, err = cfg.PostgresPort().Read()
-	// Important: if retryPortDiscovery is changed to not include testing.Testing(),
+	// Important: if retryPortDiscovery is changed to not include flag.Lookup("testing.v") != nil,
 	// the retry logic below also needs to be updated to ensure we don't delete an
 	// existing database
-	retryPortDiscovery := errors.Is(err, os.ErrNotExist) && testing.Testing()
+	retryPortDiscovery := errors.Is(err, os.ErrNotExist) && flag.Lookup("testing.v") != nil
 	if retryPortDiscovery {
 		maxAttempts = 10
 	}

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -2611,7 +2611,7 @@ func (q *querier) DeleteWorkspaceSubAgentByID(ctx context.Context, id uuid.UUID)
 }
 
 func (q *querier) DisableForeignKeysAndTriggers(ctx context.Context) error {
-	if flag.Lookup("testing.v") == nil {
+	if flag.Lookup("test.v") == nil {
 		return xerrors.Errorf("DisableForeignKeysAndTriggers is only allowed in tests")
 	}
 	return q.db.DisableForeignKeysAndTriggers(ctx)

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -5,10 +5,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"flag"
 	"slices"
 	"strings"
 	"sync/atomic"
-	"testing"
 	"time"
 
 	"github.com/google/uuid"
@@ -2611,7 +2611,7 @@ func (q *querier) DeleteWorkspaceSubAgentByID(ctx context.Context, id uuid.UUID)
 }
 
 func (q *querier) DisableForeignKeysAndTriggers(ctx context.Context) error {
-	if !testing.Testing() {
+	if flag.Lookup("testing.v") == nil {
 		return xerrors.Errorf("DisableForeignKeysAndTriggers is only allowed in tests")
 	}
 	return q.db.DisableForeignKeysAndTriggers(ctx)

--- a/coderd/x/chatd/mcpclient/mcphttpclient.go
+++ b/coderd/x/chatd/mcpclient/mcphttpclient.go
@@ -13,7 +13,7 @@ import (
 // is a *http.Transport it is cloned; otherwise a minimal
 // transport with ProxyFromEnvironment is created as a fallback.
 func mcpHTTPClient() *http.Client {
-	if flag.Lookup("testing.v") == nil {
+	if flag.Lookup("test.v") == nil {
 		return nil
 	}
 	if dt, ok := http.DefaultTransport.(*http.Transport); ok {

--- a/coderd/x/chatd/mcpclient/mcphttpclient.go
+++ b/coderd/x/chatd/mcpclient/mcphttpclient.go
@@ -1,8 +1,8 @@
 package mcpclient
 
 import (
+	"flag"
 	"net/http"
-	"testing"
 )
 
 // mcpHTTPClient returns an isolated *http.Client when running
@@ -13,7 +13,7 @@ import (
 // is a *http.Transport it is cloned; otherwise a minimal
 // transport with ProxyFromEnvironment is created as a fallback.
 func mcpHTTPClient() *http.Client {
-	if !testing.Testing() {
+	if flag.Lookup("testing.v") == nil {
 		return nil
 	}
 	if dt, ok := http.DefaultTransport.(*http.Transport); ok {


### PR DESCRIPTION
In our codebase we have an existing convention of using `flag.Lookup("test.v")` instead of `testing.Testing()`. This avoids pulling in the entire `testing` package. Another consequence: some of our custom linters trigger upon import of the `testing` package which can lead to unexpected linter errors.