### PR TITLE
fix(agent/agentcontext): release watcher mutex around fsnotify Add/Remove

### DIFF
--- a/agent/agentcontext/watcher.go
+++ b/agent/agentcontext/watcher.go
@@ -53,6 +53,14 @@ type Watcher struct {
 	maxDepth int
 	onChange func()
 
+	// syncMu serializes Sync calls so the diff-then-apply
+	// sequence is atomic with respect to other Sync callers.
+	// It is never held when calling into fsnotify or any other
+	// Watcher method, so it cannot participate in a deadlock
+	// cycle with the fsnotify reader. Lock ordering when both
+	// are held: syncMu first, then mu.
+	syncMu sync.Mutex
+
 	mu        sync.Mutex
 	watcher   *fsnotify.Watcher
 	watched   map[string]struct{}
@@ -142,11 +150,20 @@ func (w *Watcher) Degraded() string {
 // basename. Files that are themselves scan roots are handled by
 // watching their parent.
 //
-// Sync is idempotent and safe to call repeatedly. The lock is
-// released around the recursive directory walk so concurrent
-// Close, schedule, and the run goroutine are not blocked by a
-// slow filesystem.
+// Sync is idempotent and safe to call repeatedly. syncMu
+// serializes concurrent Sync callers so the diff-then-apply
+// sequence is atomic. mu is released around the recursive
+// directory walk and around the fsnotify Add/Remove calls so a
+// slow filesystem, or a fsnotify reader that is currently
+// delivering an event, cannot block Close, schedule, or the
+// run goroutine. Holding mu across fsnotify.Add on Windows
+// would deadlock: fsnotify's Windows backend routes Add through
+// the reader goroutine, which itself needs run to drain
+// w.watcher.Events, which needs mu via schedule.
 func (w *Watcher) Sync(ctx context.Context, roots []ScanRoot) {
+	w.syncMu.Lock()
+	defer w.syncMu.Unlock()
+
 	w.mu.Lock()
 	if w.closed {
 		w.mu.Unlock()
@@ -174,45 +191,83 @@ func (w *Watcher) Sync(ctx context.Context, roots []ScanRoot) {
 	// Close, or schedule.
 	desired := w.collectDirs(roots)
 
+	// Snapshot the current watch set under mu and compute the
+	// diff. Capture the fsnotify watcher reference so a
+	// concurrent Close that nils w.watcher does not race with
+	// the apply step; fsnotify.Watcher is safe to call after
+	// Close (Add returns ErrClosed).
 	w.mu.Lock()
-	defer w.mu.Unlock()
 	if w.closed {
+		w.mu.Unlock()
 		return
 	}
-
-	// Remove directories no longer wanted.
+	fsw := w.watcher
+	var toRemove []string
 	for path := range w.watched {
-		if _, ok := desired[path]; ok {
-			continue
+		if _, ok := desired[path]; !ok {
+			toRemove = append(toRemove, path)
 		}
-		_ = w.watcher.Remove(path)
-		delete(w.watched, path)
 	}
-	// Track whether every Add in this pass succeeded so a
-	// recovered ENOSPC clears the degraded marker.
-	addedAll := true
-	// Add directories that are new.
+	toAdd := make([]string, 0, len(desired))
 	for path := range desired {
-		if _, ok := w.watched[path]; ok {
-			continue
+		if _, ok := w.watched[path]; !ok {
+			toAdd = append(toAdd, path)
 		}
-		if err := w.watcher.Add(path); err != nil {
+	}
+	w.mu.Unlock()
+
+	// Apply the diff to fsnotify with mu released. On Windows
+	// fsnotify.Add and Remove block on the reader goroutine,
+	// which must be able to deliver pending events to
+	// w.watcher.Events; the consumer is run, which needs mu
+	// via schedule. Holding mu here would close the cycle.
+	for _, path := range toRemove {
+		_ = fsw.Remove(path)
+	}
+	var (
+		addedAll  = true
+		addedOK   = make([]string, 0, len(toAdd))
+		enospcDir string
+		hitENOSPC bool
+	)
+	for _, path := range toAdd {
+		if err := fsw.Add(path); err != nil {
 			// ENOSPC means the kernel's per-user inotify
 			// watch budget is exhausted. Mark the watcher
 			// degraded; subsequent Sync calls still fire
 			// the change callback so resync still works.
 			if errors.Is(err, syscall.ENOSPC) {
-				w.degraded = "inotify watch limit exceeded (ENOSPC)"
+				hitENOSPC = true
+				enospcDir = path
 				addedAll = false
-				w.logger.Warn(ctx, "context watcher degraded: inotify watch limit exceeded",
-					slog.F("dir", path))
 				break
 			}
 			w.logger.Debug(ctx, "context watcher could not add dir",
 				slog.F("dir", path), slog.Error(err))
 			continue
 		}
+		addedOK = append(addedOK, path)
+	}
+
+	// Reconcile the in-memory watch set under mu. If Close
+	// fired while we were applying, fsnotify already released
+	// the watches so the state mutation here is dropped.
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return
+	}
+	for _, path := range toRemove {
+		delete(w.watched, path)
+	}
+	for _, path := range addedOK {
 		w.watched[path] = struct{}{}
+	}
+	if hitENOSPC {
+		w.degraded = "inotify watch limit exceeded (ENOSPC)"
+		w.logger.Warn(ctx, "context watcher degraded: inotify watch limit exceeded",
+			slog.F("dir", enospcDir))
+		return
 	}
 	// Clear a previously-set ENOSPC mark when every Add in this
 	// pass succeeded. A user who bumps the kernel's inotify

--- a/agent/agentcontext/watcher_test.go
+++ b/agent/agentcontext/watcher_test.go
@@ -2,8 +2,10 @@ package agentcontext_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -94,4 +96,87 @@ func TestWatcher_SyncAfterCloseNoop(t *testing.T) {
 
 	// Must not panic.
 	w.Sync(context.Background(), []agentcontext.ScanRoot{{Path: t.TempDir()}})
+}
+
+// TestWatcher_SyncDoesNotDeadlockOnActiveDirectory is a regression
+// test for a Windows-only deadlock in Sync. Before the fix, Sync
+// held the watcher mutex while calling fsnotify.Watcher.Add. On
+// Windows fsnotify routes Add through a thread-pinned reader
+// goroutine; the reader can only process the next Add after it
+// delivers any pending event to the Events channel. The Events
+// consumer is the watcher's run goroutine, which acquires the same
+// mutex via schedule(). The combination produced a cycle:
+//
+//	Sync (holds mu)
+//	  -> fsnotify.Add -> waits for reader reply
+//	fsnotify reader
+//	  -> sendEvent -> waits to send into Events
+//	Watcher.run
+//	  -> schedule() -> waits for mu
+//
+// The bug surfaced as TestAgent_Startup/HomeDirectory and
+// /HomeEnvironmentVariable hanging until the 20m test timeout
+// fired on the Windows nightly-gauntlet test-go-pg job. This
+// test reliably reproduces the cycle on Windows by rewriting a
+// single watched file while issuing repeated Sync calls. The
+// rewrites keep the fsnotify Events channel non-empty, exposing
+// the lock-during-Add window. On Linux and macOS the deadlock
+// cannot manifest because their fsnotify backends do not route
+// Add through the reader, but the test still exercises the
+// diff-then-apply logic and confirms the watch set converges
+// under churn.
+func TestWatcher_SyncDoesNotDeadlockOnActiveDirectory(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte("v1"), 0o600))
+
+	w, err := agentcontext.NewWatcher(agentcontext.WatcherOptions{
+		Logger:   testutil.Logger(t).Named("watcher"),
+		Debounce: 10 * time.Millisecond,
+		OnChange: func() {},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	ctx := testutil.Context(t, testutil.WaitMedium)
+	w.Sync(ctx, []agentcontext.ScanRoot{{Path: root}})
+
+	// Rewrite AGENTS.md in a tight loop so the fsnotify Events
+	// channel always has something pending. Rewriting an existing
+	// file (rather than creating new ones) keeps the directory
+	// shape stable so each Sync walks the same small tree.
+	var (
+		stop atomic.Bool
+		wg   sync.WaitGroup
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; !stop.Load(); i++ {
+			_ = os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte(fmt.Sprintf("v%d", i)), 0o600)
+		}
+	}()
+	t.Cleanup(func() {
+		stop.Store(true)
+		wg.Wait()
+	})
+
+	// Repeatedly re-sync while events flow. Under the previous
+	// code, any one of these Sync calls could deadlock on Windows;
+	// the surrounding ctx deadline catches the hang.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 200; i++ {
+			w.Sync(ctx, []agentcontext.ScanRoot{{Path: root}})
+			if ctx.Err() != nil {
+				return
+			}
+		}
+	}()
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatalf("Sync deadlocked under filesystem event churn: %v", ctx.Err())
+	}
 }


### PR DESCRIPTION
Fixes the Windows-only deadlock that has been hanging `TestAgent_Startup/HomeDirectory` and `TestAgent_Startup/HomeEnvironmentVariable` for the full 20m `go test` timeout on every `nightly-gauntlet` `test-go-pg (windows-2022)` run since the `agent/agentcontext` package was introduced. Most recent failure: [run 27739177723, job 82062378148](https://github.com/coder/coder/actions/runs/27739177723/job/82062378148).

`Watcher.Sync` held `w.mu` while calling `fsnotify.Watcher.Add` and `Remove`. On Windows, fsnotify routes those calls through a thread-pinned reader goroutine that can only handle the next request after delivering any pending event to its `Events` channel. The `Events` consumer is the watcher's own `run` goroutine, which reacquires `w.mu` via `schedule()`. Result: a deadlock cycle through the fsnotify reader.

```
Sync (holds w.mu)
  -> fsnotify.Add -> waits for reader reply
fsnotify reader
  -> sendEvent -> waits to send into Events
Watcher.run
  -> schedule() -> waits for w.mu
```

`Sync` now snapshots the watch set under `w.mu`, releases the lock, mutates fsnotify, then reacquires `w.mu` to reconcile `w.watched` and `w.degraded`. A new `syncMu` serializes concurrent `Sync` callers so the diff-then-apply sequence stays atomic. Lock ordering is `syncMu` first, then `w.mu`; `w.mu` is never held while calling into fsnotify, breaking the cycle.

The regression test rewrites the watched file in a tight loop while issuing repeated `Sync` calls. On Windows the previous code deadlocks inside that loop and the surrounding context expires; on Linux and macOS the test smoke-checks the diff-then-apply path.

<details>
<summary>Goroutine evidence from the failing CI dump</summary>

```
goroutine 118 [chan receive, 19 minutes]:
  agent/agentcontext.(*Manager).Close            manager.go:249  // <-m.runDoneCh
  agent.(*agent).Close                           agent.go:2394
  agent_test.setupAgentWithSecrets.func2         agent_test.go:4007

goroutine 14423 [chan receive, 19 minutes]:
  fsnotify.(*readDirChangesW).AddWith            backend_windows.go:145 // <-in.reply
  agentcontext.(*Watcher).Sync                   watcher.go:199         // w.watcher.Add(path), holding w.mu
  agentcontext.(*Manager).Run                    manager.go:218         // watcher.Sync(ctx, roots)

goroutine 14097 [select, 19 minutes, locked to thread]:
  fsnotify.(*readDirChangesW).sendEvent          backend_windows.go:76  // w.Events <- event
  fsnotify.(*readDirChangesW).readEvents         backend_windows.go:642

goroutine 14434 [sync.Mutex.Lock, 19 minutes]:
  agentcontext.(*Watcher).schedule               watcher.go:307         // w.mu.Lock()
  agentcontext.(*Watcher).run                    watcher.go:276
```

The same pattern reproduces in runs on 2026-06-11, 2026-06-12, 2026-06-16, 2026-06-17, 2026-06-18, and 2026-06-19. macOS and Linux pass because their fsnotify backends do not route `Add` through the reader goroutine.
</details>

This change was authored by Coder Agents on @zedkipp's behalf.
