### PR TITLE
fix(coderd): let admins change their own workspace sharing role

### DIFF
--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -2425,10 +2425,16 @@ func (api *API) patchWorkspaceACL(rw http.ResponseWriter, r *http.Request) {
 
 	apiKey := httpmw.APIKey(r)
 	if _, ok := req.UserRoles[apiKey.UserID.String()]; ok {
-		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: "You cannot change your own workspace sharing role.",
-		})
-		return
+		// Block changing your own sharing role unless you can share any
+		// workspace in the organization. This keeps a user whose only access is
+		// this share from destructively demoting themselves, while letting org
+		// and deployment admins manage their own access.
+		if !api.Authorize(r, policy.ActionShare, rbac.ResourceWorkspace.InOrg(workspace.OrganizationID)) {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "You cannot change your own workspace sharing role.",
+			})
+			return
+		}
 	}
 
 	validErrs := acl.Validate(ctx, api.Database, WorkspaceACLUpdateValidator(req))

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -5669,6 +5669,59 @@ func TestUpdateWorkspaceACL(t *testing.T) {
 		})
 		require.NoError(t, err)
 	})
+
+	//nolint:tparallel,paralleltest // Modifies package global rbac.workspaceACLDisabled.
+	t.Run("OrgAdminCanChangeOwnRole", func(t *testing.T) {
+		// Save and restore the global to avoid affecting other tests.
+		prevWorkspaceACLDisabled := rbac.WorkspaceACLDisabled()
+		rbac.SetWorkspaceACLDisabled(false)
+		t.Cleanup(func() { rbac.SetWorkspaceACLDisabled(prevWorkspaceACLDisabled) })
+
+		dv := coderdtest.DeploymentValues(t)
+
+		adminClient := coderdtest.New(t, &coderdtest.Options{
+			IncludeProvisionerDaemon: true,
+			DeploymentValues:         dv,
+		})
+		adminUser := coderdtest.CreateFirstUser(t, adminClient)
+		orgID := adminUser.OrganizationID
+		workspaceOwnerClient, _ := coderdtest.CreateAnotherUser(t, adminClient, orgID)
+		orgAdminClient, orgAdminUser := coderdtest.CreateAnotherUser(t, adminClient, orgID, rbac.ScopedRoleOrgAdmin(orgID))
+
+		tv := coderdtest.CreateTemplateVersion(t, adminClient, orgID, nil)
+		coderdtest.AwaitTemplateVersionJobCompleted(t, adminClient, tv.ID)
+		template := coderdtest.CreateTemplate(t, adminClient, orgID, tv.ID)
+
+		ws := coderdtest.CreateWorkspace(t, workspaceOwnerClient, template.ID)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, workspaceOwnerClient, ws.LatestBuild.ID)
+
+		ctx := testutil.Context(t, testutil.WaitMedium)
+
+		// An org admin can share a workspace they do not own with themselves,
+		// because they hold workspace share permission across the organization
+		// independent of this workspace's ACL.
+		err := orgAdminClient.UpdateWorkspaceACL(ctx, ws.ID, codersdk.UpdateWorkspaceACL{
+			UserRoles: map[string]codersdk.WorkspaceRole{
+				orgAdminUser.ID.String(): codersdk.WorkspaceRoleAdmin,
+			},
+		})
+		require.NoError(t, err)
+
+		// They can also change and then remove their own role.
+		err = orgAdminClient.UpdateWorkspaceACL(ctx, ws.ID, codersdk.UpdateWorkspaceACL{
+			UserRoles: map[string]codersdk.WorkspaceRole{
+				orgAdminUser.ID.String(): codersdk.WorkspaceRoleUse,
+			},
+		})
+		require.NoError(t, err)
+
+		err = orgAdminClient.UpdateWorkspaceACL(ctx, ws.ID, codersdk.UpdateWorkspaceACL{
+			UserRoles: map[string]codersdk.WorkspaceRole{
+				orgAdminUser.ID.String(): codersdk.WorkspaceRoleDeleted,
+			},
+		})
+		require.NoError(t, err)
+	})
 }
 
 func TestDeleteWorkspaceACL(t *testing.T) {


### PR DESCRIPTION
Org and deployment admins couldn't share a workspace with themselves. Workspace ACL updates rejected any change to the caller's own sharing role, even for admins whose share permission comes from their role rather than the workspace.

Self-edits are now allowed when the caller can share any workspace in the organization. Users whose only access is the share itself remain blocked from destructively demoting themselves.

<details>
<summary>Design notes</summary>

The self-guard is skipped only when `Authorize(share, ResourceWorkspace.InOrg(org))` passes. That abstract, owner-less check is satisfied by org/site-level role grants, but not by owner-scoped member permissions or by a specific workspace's ACL, so it distinguishes role-based share from share that derives from the workspace itself. The dbauthz layer still independently authorizes `share` on the workspace.

</details>

---

This PR was created by Coder Agents on behalf of @aslilac.
