### PR TITLE
docs: restore Bedrock static credentials walkthrough

### DIFF
--- a/docs/ai-coder/ai-gateway/providers.md
+++ b/docs/ai-coder/ai-gateway/providers.md
@@ -106,6 +106,33 @@ AI Gateway resolves AWS credentials one of two ways:
 - **Static credentials.** Provide an access key and secret for an IAM
   user with the same Bedrock permissions.
 
+#### Obtaining static Bedrock credentials
+
+When you cannot use the default credential chain, create a dedicated IAM
+user and generate a static access key:
+
+1. **Choose a region** where you want to use Bedrock.
+
+2. **Generate API keys** in the [AWS Bedrock console](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/api-keys/long-term/create) (replace `us-east-1` in the URL with your chosen region):
+   - Choose an expiry period for the key.
+   - Click **Generate**.
+   - This creates an IAM user with strictly-scoped permissions for Bedrock access.
+
+3. **Create an access key** for the IAM user:
+   - After generating the API key, click **"You can directly modify permissions for the IAM user associated"**.
+   - In the IAM user page, navigate to the **Security credentials** tab.
+   - Under **Access keys**, click **Create access key**.
+   - Select **"Application running outside AWS"** as the use case.
+   - Click **Next**.
+   - Add a description like "Coder AI Gateway token".
+   - Click **Create access key**.
+   - Save both the access key ID and secret access key securely.
+
+4. **Enter the access key ID and secret access key** when you add or edit
+   the Bedrock provider from the dashboard or the
+   [AI Providers API](../../reference/api/aiproviders.md), along with the
+   region (or base URL) and model identifiers.
+
 ### GitHub Copilot
 
 GitHub Copilot offers three plans: Individual, Business, and Enterprise,

--- a/docs/ai-coder/ai-gateway/providers.md
+++ b/docs/ai-coder/ai-gateway/providers.md
@@ -115,17 +115,17 @@ user and generate a static access key:
 
 2. **Generate API keys** in the [AWS Bedrock console](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/api-keys/long-term/create) (replace `us-east-1` in the URL with your chosen region):
    - Choose an expiry period for the key.
-   - Click **Generate**.
+   - Select **Generate**.
    - This creates an IAM user with strictly-scoped permissions for Bedrock access.
 
 3. **Create an access key** for the IAM user:
    - After generating the API key, click **"You can directly modify permissions for the IAM user associated"**.
    - In the IAM user page, navigate to the **Security credentials** tab.
-   - Under **Access keys**, click **Create access key**.
+   - Under **Access keys**, select **Create access key**.
    - Select **"Application running outside AWS"** as the use case.
-   - Click **Next**.
+   - Select **Next**.
    - Add a description like "Coder AI Gateway token".
-   - Click **Create access key**.
+   - Select **Create access key**.
    - Save both the access key ID and secret access key securely.
 
 4. **Enter the access key ID and secret access key** when you add or edit


### PR DESCRIPTION
## Summary

Restores the step-by-step "Obtaining static Bedrock credentials" walkthrough that was present on the v2.32.6 `ai-bridge/setup` page but missing from the current `ai-gateway/providers` page.

The current page mentions static credentials in a single line but no longer explains how to create the IAM user and access key in the AWS console. This PR brings back that walkthrough, adapted to the current database/dashboard-managed provider flow.

## Changes

- Add an `#### Obtaining static Bedrock credentials` subsection under the Amazon Bedrock provider section in `docs/ai-coder/ai-gateway/providers.md`.
- Keep the AWS console steps (choose region, generate API keys, create access key) from v2.32.6.
- Replace the deprecated `CODER_AIBRIDGE_BEDROCK_*` environment-variable configuration step with guidance to enter the credentials when adding/editing the provider via the dashboard or AI Providers API, matching the post-v2.34 database-managed model.

<details>
<summary>Context and decisions</summary>

- Source: [`docs/ai-coder/ai-bridge/setup.md` at v2.32.6](https://coder.com/docs/@v2.32.6/ai-coder/ai-bridge/setup) "Obtaining Bedrock credentials" section.
- The old flow set provider config via environment variables, which are deprecated since v2.34 (providers are now stored in the database and managed via dashboard/API). The restored content keeps the AWS-side credential-creation steps but routes the final configuration step through the current provider management flow rather than env vars.
- Open questions from [AIGOV-432](https://linear.app/codercom/issue/AIGOV-432/restore-bedrock-static-credentials-docs-from-v2326) (whether other pages also need this, and whether the content needs further accuracy updates) are left for review.

</details>

Closes [AIGOV-432](https://linear.app/codercom/issue/AIGOV-432/restore-bedrock-static-credentials-docs-from-v2326).

> [!NOTE]
> This PR was generated by Coder Agents on behalf of @dannykopping.
