### PR TITLE
feat: update API URLs from /aibridge to /ai-gateway

### DIFF
--- a/codersdk/aibridge.go
+++ b/codersdk/aibridge.go
@@ -40,7 +40,7 @@ type AIBridgeListSessionsResponse struct {
 }
 
 // AIBridgeSessionThreadsResponse is the response for GET
-// /api/v2/aibridge/sessions/{session_id} which returns a single
+// /api/v2/ai-gateway/sessions/{session_id} which returns a single
 // session with fully expanded threads.
 type AIBridgeSessionThreadsResponse struct {
 	ID                string                           `json:"id"`

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -3127,21 +3127,21 @@ class ApiMethods {
 	};
 
 	getAIBridgeModels = async (options: SearchParamOptions) => {
-		const url = getURLWithSearchParams("/api/v2/aibridge/models", options);
+		const url = getURLWithSearchParams("/api/v2/ai-gateway/models", options);
 
 		const response = await this.axios.get<string[]>(url);
 		return response.data;
 	};
 
 	getAIBridgeClients = async (options: SearchParamOptions) => {
-		const url = getURLWithSearchParams("/api/v2/aibridge/clients", options);
+		const url = getURLWithSearchParams("/api/v2/ai-gateway/clients", options);
 
 		const response = await this.axios.get<string[]>(url);
 		return response.data;
 	};
 
 	getAIBridgeSessionList = async (options: SearchParamOptions) => {
-		const url = getURLWithSearchParams("/api/v2/aibridge/sessions", options);
+		const url = getURLWithSearchParams("/api/v2/ai-gateway/sessions", options);
 		const response =
 			await this.axios.get<TypesGen.AIBridgeListSessionsResponse>(url);
 		return response.data;
@@ -3152,7 +3152,7 @@ class ApiMethods {
 		options?: { after_id?: string; before_id?: string; limit?: number },
 	) => {
 		const url = getURLWithSearchParams(
-			`/api/v2/aibridge/sessions/${sessionId}`,
+			`/api/v2/ai-gateway/sessions/${sessionId}`,
 			options,
 		);
 		const response =
@@ -3203,7 +3203,7 @@ class ApiMethods {
 
 	getAIGatewayKeys = async (): Promise<TypesGen.AIGatewayKey[]> => {
 		const response = await this.axios.get<TypesGen.AIGatewayKey[]>(
-			"/api/v2/aibridge/keys",
+			"/api/v2/ai-gateway/keys",
 		);
 		return response.data;
 	};
@@ -3212,14 +3212,16 @@ class ApiMethods {
 		req: TypesGen.CreateAIGatewayKeyRequest,
 	): Promise<TypesGen.CreateAIGatewayKeyResponse> => {
 		const response = await this.axios.post<TypesGen.CreateAIGatewayKeyResponse>(
-			"/api/v2/aibridge/keys",
+			"/api/v2/ai-gateway/keys",
 			req,
 		);
 		return response.data;
 	};
 
 	deleteAIGatewayKey = async (id: string): Promise<void> => {
-		await this.axios.delete(`/api/v2/aibridge/keys/${encodeURIComponent(id)}`);
+		await this.axios.delete(
+			`/api/v2/ai-gateway/keys/${encodeURIComponent(id)}`,
+		);
 	};
 }
 

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -408,6 +408,7 @@ export type DeploymentConfig = Readonly<{
 }>;
 
 const aiProviderConfigsPath = "/api/v2/ai/providers";
+const aiGatewayPath = "/api/v2/ai-gateway";
 const chatModelConfigsPath = "/api/experimental/chats/model-configs";
 const userSkillsPath = (user: string) =>
 	`/api/experimental/users/${encodeURIComponent(user)}/skills`;
@@ -3127,21 +3128,21 @@ class ApiMethods {
 	};
 
 	getAIBridgeModels = async (options: SearchParamOptions) => {
-		const url = getURLWithSearchParams("/api/v2/ai-gateway/models", options);
+		const url = getURLWithSearchParams(`${aiGatewayPath}/models`, options);
 
 		const response = await this.axios.get<string[]>(url);
 		return response.data;
 	};
 
 	getAIBridgeClients = async (options: SearchParamOptions) => {
-		const url = getURLWithSearchParams("/api/v2/ai-gateway/clients", options);
+		const url = getURLWithSearchParams(`${aiGatewayPath}/clients`, options);
 
 		const response = await this.axios.get<string[]>(url);
 		return response.data;
 	};
 
 	getAIBridgeSessionList = async (options: SearchParamOptions) => {
-		const url = getURLWithSearchParams("/api/v2/ai-gateway/sessions", options);
+		const url = getURLWithSearchParams(`${aiGatewayPath}/sessions`, options);
 		const response =
 			await this.axios.get<TypesGen.AIBridgeListSessionsResponse>(url);
 		return response.data;
@@ -3152,7 +3153,7 @@ class ApiMethods {
 		options?: { after_id?: string; before_id?: string; limit?: number },
 	) => {
 		const url = getURLWithSearchParams(
-			`/api/v2/ai-gateway/sessions/${sessionId}`,
+			`${aiGatewayPath}/sessions/${sessionId}`,
 			options,
 		);
 		const response =
@@ -3203,7 +3204,7 @@ class ApiMethods {
 
 	getAIGatewayKeys = async (): Promise<TypesGen.AIGatewayKey[]> => {
 		const response = await this.axios.get<TypesGen.AIGatewayKey[]>(
-			"/api/v2/ai-gateway/keys",
+			`${aiGatewayPath}/keys`,
 		);
 		return response.data;
 	};
@@ -3212,16 +3213,14 @@ class ApiMethods {
 		req: TypesGen.CreateAIGatewayKeyRequest,
 	): Promise<TypesGen.CreateAIGatewayKeyResponse> => {
 		const response = await this.axios.post<TypesGen.CreateAIGatewayKeyResponse>(
-			"/api/v2/ai-gateway/keys",
+			`${aiGatewayPath}/keys`,
 			req,
 		);
 		return response.data;
 	};
 
 	deleteAIGatewayKey = async (id: string): Promise<void> => {
-		await this.axios.delete(
-			`/api/v2/ai-gateway/keys/${encodeURIComponent(id)}`,
-		);
+		await this.axios.delete(`${aiGatewayPath}/keys/${encodeURIComponent(id)}`);
 	};
 }
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -146,7 +146,7 @@ export interface AIBridgeSession {
 // From codersdk/aibridge.go
 /**
  * AIBridgeSessionThreadsResponse is the response for GET
- * /api/v2/aibridge/sessions/{session_id} which returns a single
+ * /api/v2/ai-gateway/sessions/{session_id} which returns a single
  * session with fully expanded threads.
  */
 export interface AIBridgeSessionThreadsResponse {


### PR DESCRIPTION
## Description

Updates frontend and Go SDK client URLs from `/api/v2/aibridge/*` to `/api/v2/ai-gateway/*` to match the new route aliases introduced in #26475.

## Changes

- Update `site/src/api/api.ts` to call `/api/v2/ai-gateway/*` for all AI Gateway endpoints
- Update `codersdk/aibridge.go` type comment to reference the new path
- Regenerate `site/src/api/typesGenerated.ts`

Closes https://linear.app/coder/issue/AIGOV-230

> Generated with the assistance of Coder Agents (@ssncferreira)