### PR TITLE
feat(site): move frontend routes from /aibridge to /ai-gateway with redirects

### DIFF
--- a/site/src/modules/dashboard/Navbar/DeploymentDropdown.tsx
+++ b/site/src/modules/dashboard/Navbar/DeploymentDropdown.tsx
@@ -100,7 +100,7 @@ const DeploymentDropdownContent: FC<DeploymentDropdownProps> = ({
 			)}
 			{canViewAIBridge && (
 				<DropdownMenuItem asChild>
-					<Link to="/aibridge/sessions">AI Sessions</Link>
+					<Link to="/ai-gateway/sessions">AI Sessions</Link>
 				</DropdownMenuItem>
 			)}
 			{canViewHealth && (

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsPage.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsPage.tsx
@@ -86,7 +86,7 @@ const AISessionListPage: FC = () => {
 				sessions={sessionsQuery.data?.sessions}
 				sessionsQuery={sessionsQuery}
 				onSessionRowClick={(sessionId) =>
-					navigate(`/aibridge/sessions/${sessionId}`)
+					navigate(`/ai-gateway/sessions/${sessionId}`)
 				}
 				filterProps={{
 					filter,

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionThreadsPage.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionThreadsPage.tsx
@@ -52,7 +52,7 @@ const SessionThreadsPage: FC = () => {
 					// is a previous page in the history stack, navigate back. otherwise,
 					// navigate to the sessions list page without params
 					if (location.key === "default") {
-						navigate("/aibridge/sessions");
+						navigate("/ai-gateway/sessions");
 					} else {
 						navigate(-1);
 					}

--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -7,6 +7,7 @@ import {
 	Route,
 	ScrollRestoration,
 	useLocation,
+	useParams,
 } from "react-router";
 import { GlobalErrorBoundary } from "./components/ErrorBoundary/GlobalErrorBoundary";
 import { Loader } from "./components/Loader/Loader";
@@ -537,6 +538,12 @@ const NavigateWithSearch = ({ to }: { to: string }) => {
 	return <Navigate to={{ pathname: to, search: location.search }} replace />;
 };
 
+/** Redirect /aibridge/sessions/:sessionId to /ai-gateway/sessions/:sessionId. */
+const RedirectAIBridgeSession = () => {
+	const { sessionId } = useParams() as { sessionId: string };
+	return <Navigate to={`/ai-gateway/sessions/${sessionId}`} replace />;
+};
+
 export const router = createBrowserRouter(
 	createRoutesFromChildren(
 		<Route element={<GlobalLayout />} errorElement={<GlobalErrorBoundary />}>
@@ -709,17 +716,34 @@ export const router = createBrowserRouter(
 						</Route>
 					</Route>
 
-					<Route path="/aibridge" element={<AIBridgeLayout />}>
+					<Route path="/ai-gateway" element={<AIBridgeLayout />}>
 						<Route
 							index
-							element={<Navigate to="/aibridge/sessions" replace />}
+							element={<Navigate to="/ai-gateway/sessions" replace />}
 						/>
 					</Route>
 
-					<Route path="/aibridge/sessions" element={<AIBridgeSessionsLayout />}>
+					<Route
+						path="/ai-gateway/sessions"
+						element={<AIBridgeSessionsLayout />}
+					>
 						<Route index element={<AIBridgeListSessionsPage />} />
 						<Route path=":sessionId" element={<AIBridgeSessionThreadsPage />} />
 					</Route>
+
+					{/* Legacy /aibridge routes redirect to /ai-gateway */}
+					<Route
+						path="/aibridge"
+						element={<Navigate to="/ai-gateway" replace />}
+					/>
+					<Route
+						path="/aibridge/sessions"
+						element={<Navigate to="/ai-gateway/sessions" replace />}
+					/>
+					<Route
+						path="/aibridge/sessions/:sessionId"
+						element={<RedirectAIBridgeSession />}
+					/>
 
 					<Route path="/ai/settings" element={<AISettingsLayout />}>
 						<Route element={<DeploymentConfigProvider />}>


### PR DESCRIPTION
## Description

Moves frontend routes from `/aibridge` to `/ai-gateway` and adds client-side redirects so existing bookmarks and deep links continue to work.

## Changes

- Move React Router paths from `/aibridge` to `/ai-gateway`
- Add `<Navigate>` redirects from `/aibridge`, `/aibridge/sessions`, and `/aibridge/sessions/:sessionId`
- Update `navigate()` calls and `Link` components to use new paths

Closes https://linear.app/coder/issue/AIGOV-233

> Generated with the assistance of Coder Agents (@ssncferreira)