### PR TITLE
fix: left-align module names in SelectionSummary

### DIFF
--- a/site/src/pages/TemplateBuilder/SelectionSummary.tsx
+++ b/site/src/pages/TemplateBuilder/SelectionSummary.tsx
@@ -183,7 +183,7 @@ const ModuleSelection: React.FC<ModuleSelectionProps> = ({
 							className="block w-6 h-6 p-1 rounded-sm border border-border border-solid bg-surface-secondary"
 						/>
 					</div>
-					<span className="ml-2">{module.name}</span>
+					<span className="flex-1 ml-2">{module.name}</span>
 					<div className="h-[1lh] content-center">
 						<Button
 							size="xs"


### PR DESCRIPTION
fixes DEVEX-514, which I accidentally introduced in #26531