### PR TITLE
fix: upgrade nixpkgs to 25.05 and pin protoc 23.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -44,16 +44,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751274312,
-        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Development environments on your infrastructure";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
     nixpkgs-pinned.url = "github:nixos/nixpkgs/5deee6281831847857720668867729617629ef1f";
     flake-utils.url = "github:numtide/flake-utils";
@@ -107,6 +107,47 @@
           subPackages = [ "cmd/protoc-gen-go" ];
           vendorHash = null;
         };
+
+        # Keep protoc aligned with mise.toml so local Nix shells use
+        # the same codegen tool version as CI and release workflows,
+        # regardless of nixpkgs channel defaults.
+        protobuf_23_4 =
+          let
+            releases = {
+              x86_64-linux = {
+                platform = "linux-x86_64";
+                hash = "sha256-BQLyhqye2GC2KaeWWhRSex8t0THkKD+iPC1/GEZyqpo=";
+              };
+              aarch64-linux = {
+                platform = "linux-aarch_64";
+                hash = "sha256-HHdQtuA4MFtaf8PQzaHr798Qak8wp4e/gm7S/EfDln0=";
+              };
+              aarch64-darwin = {
+                platform = "osx-aarch_64";
+                hash = "sha256-jHr66GJraBHntYl9FtlAwtv1Cx4TXtlYoB22VmvdpyY=";
+              };
+              x86_64-darwin = {
+                platform = "osx-x86_64";
+                hash = "sha256-B+X9zxsHCNM2fcXm640TXefkB9dTFskxVc/YqzYu7IA=";
+              };
+            };
+            target = releases.${system} or null;
+          in
+          if target != null then
+            pkgs.runCommand "protobuf-23.4" {
+              nativeBuildInputs = [ pkgs.unzip ];
+              src = pkgs.fetchurl {
+                url = "https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-${target.platform}.zip";
+                hash = target.hash;
+              };
+            } ''
+              mkdir -p "$out"
+              cd "$out"
+              unzip "$src"
+              chmod +x "$out/bin/protoc"
+            ''
+          else
+            throw "protobuf 23.4 is not defined for ${system}";
 
         # Custom sqlc build from coder/sqlc fork to fix ambiguous column bug, see:
         # - https://github.com/coder/sqlc/pull/1
@@ -263,7 +304,7 @@
             pnpm
             postgresql_16
             proto_gen_go_1_30
-            protobuf_23
+            protobuf_23_4
             ripgrep
             shellcheck
             (pinnedPkgs.shfmt)


### PR DESCRIPTION
`nix develop` and `nix-shell` were broken because the `nixos-24.11` `google-chrome` derivation still pointed at Chrome 138, and Google no longer serves that versioned `.deb`:

```
$ nix-shell
these 2 derivations will be built:
  /nix/store/af59wjk8a8ys18bam92y3jns14pgj01n-google-chrome-stable_138.0.7204.49-1_amd64.deb.drv
  /nix/store/bc5fw07dw1f7g7y3yv7fricbynsnfx21-google-chrome-138.0.7204.49.drv
building '/nix/store/af59wjk8a8ys18bam92y3jns14pgj01n-google-chrome-stable_138.0.7204.49-1_amd64.deb.drv'...

trying https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_138.0.7204.49-1_amd64.deb
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
error: cannot download google-chrome-stable_138.0.7204.49-1_amd64.deb from any mirror
error: builder for '/nix/store/af59wjk8a8ys18bam92y3jns14pgj01n-google-chrome-stable_138.0.7204.49-1_amd64.deb.drv' failed with exit code 1;
       last 7 log lines:
       >
       > trying https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_138.0.7204.49-1_amd64.deb
       >   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
       >                                  Dload  Upload   Total   Spent    Left  Speed
       >   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       > curl: (22) The requested URL returned error: 404
       > error: cannot download google-chrome-stable_138.0.7204.49-1_amd64.deb from any mirror
       For full logs, run 'nix-store -l /nix/store/af59wjk8a8ys18bam92y3jns14pgj01n-google-chrome-stable_138.0.7204.49-1_amd64.deb.drv'.
error: 1 dependencies of derivation '/nix/store/bc5fw07dw1f7g7y3yv7fricbynsnfx21-google-chrome-138.0.7204.49.drv' failed to build

```
This PR updates the flake's main `nixpkgs` input to `nixos-25.05` so the shell resolves a current Chrome package again.

The `25.05` upgrade also removed the `protobuf_23` attr. Rather than switching the shell to the channel-default protobuf package, pin `protoc 23.4` explicitly from the upstream protobuf release archives. This keeps the local Nix shell aligned with `mise.toml` and the CI/release codegen toolchain.

_Disclaimer: I'm not experienced with Nix, so I used an agent to write most of the fix. I checked the download URLs and ran `make pre-commit`, `make pre-push` and `scripts/develop.sh` locally (Ubuntu 24.04.4 LTS)._
