### PR TITLE
fix(site): open TemplateBuilder template docs in new tab

### DIFF
--- a/site/src/pages/TemplateBuilder/ModuleCard.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleCard.tsx
@@ -78,7 +78,7 @@ export const ModuleCard: React.FC<ModuleCardProps> = ({
 						target="_blank"
 						className="text-sm font-normal"
 					>
-						View Details
+						View details
 					</Link>
 				</div>
 			</div>

--- a/site/src/pages/TemplateBuilder/ModuleConfiguration.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleConfiguration.tsx
@@ -49,7 +49,6 @@ export const ModuleConfiguration: React.FC<ModuleConfigurationProps> = ({
 							<Link
 								href={detailsUrl}
 								target="_blank"
-								rel="noreferrer"
 								size="sm"
 								className="text-xs font-normal ml-1"
 							>

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
@@ -101,7 +101,11 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 				<PageHeaderTitle>Create new template</PageHeaderTitle>
 				<PageHeaderSubtitle>
 					A Terraform blueprint for reproducible workspaces.
-					<Link href={docs("/admin/templates")} className="ml-1">
+					<Link
+						href={docs("/admin/templates")}
+						target="_blank"
+						className="ml-1"
+					>
 						View docs
 					</Link>
 				</PageHeaderSubtitle>

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
@@ -100,7 +100,7 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 			<PageHeader>
 				<PageHeaderTitle>Create new template</PageHeaderTitle>
 				<PageHeaderSubtitle>
-					A Terraform blueprint for reproducible workspaces
+					A Terraform blueprint for reproducible workspaces.
 					<Link href={docs("/admin/templates")} className="ml-1">
 						View docs
 					</Link>

--- a/site/src/pages/TemplateBuilder/TemplateCard.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCard.tsx
@@ -76,7 +76,7 @@ export const TemplateCard: React.FC<TemplateCardProps> = ({
 						target="_blank"
 						className="text-sm font-normal"
 					>
-						View Details
+						View details
 					</Link>
 				</div>
 			</div>

--- a/site/src/pages/TemplateBuilder/TemplateConfiguration.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateConfiguration.tsx
@@ -42,7 +42,6 @@ export const TemplateConfiguration: React.FC<TemplateConfigurationProps> = ({
 						<Link
 							href={detailsUrl}
 							target="_blank"
-							rel="noreferrer"
 							size="sm"
 							className="text-sm font-normal ml-1"
 						>


### PR DESCRIPTION
Mainly makes the template builder's external docs/registry links behave consistently.

Includes some small changes to make copy consistent (sentence casing for links + period after page header subtitle, sourced from [Figma](https://www.figma.com/design/z1qkNiNIya2myaVW4kR6jP/Template-creation-builder?node-id=257-906&m=dev))

Also, `noreferrer` has automatically been applied to `target="_blank"` links in major browsers since 2021 ([source 1](https://frontendmasters.com/blog/bone-up-html-2025/#you-probably-dont-need-noopener-noreferrer-on-links-anymore), [source 2](https://stackoverflow.com/a/50709724/6432160))