### PR TITLE
feat: add NATS CA cert generation

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -305,7 +305,10 @@ type Options struct {
 	AppSigningKeyCache    cryptokeys.SigningKeycache
 	AppEncryptionKeyCache cryptokeys.EncryptionKeycache
 	OIDCConvertKeyCache   cryptokeys.SigningKeycache
-	Clock                 quartz.Clock
+	// NATSCACache serves the NATS cluster mTLS CA. The key rotator is the sole
+	// creator of nats_ca rows, so this cache is read-only.
+	NATSCACache cryptokeys.NATSCACache
+	Clock       quartz.Clock
 
 	// WebPushDispatcher is a way to send notifications over Web Push.
 	WebPushDispatcher webpush.Dispatcher
@@ -610,7 +613,25 @@ func New(options *Options) *API {
 	// Start a background process that rotates keys. We intentionally start this after the caches
 	// are created to force initial requests for a key to populate the caches. This helps catch
 	// bugs that may only occur when a key isn't precached in tests and the latency cost is minimal.
-	cryptokeys.StartRotator(ctx, options.Logger, options.Database)
+	//
+	// The NATS cluster mTLS CA is only rotated when the NATS pubsub experiment
+	// is enabled; the rotator has no generator for it otherwise and would fail
+	// to mint a key. The CA cache is likewise only constructed in that case.
+	rotatedFeatures := cryptokeys.DefaultRotatedFeatures()
+	natsClusterEnabled := experiments.Enabled(codersdk.ExperimentNATSPubsub)
+	if natsClusterEnabled {
+		rotatedFeatures = append(rotatedFeatures, database.CryptoKeyFeatureNATSCA)
+	}
+	cryptokeys.StartRotator(ctx, options.Logger, options.Database, cryptokeys.WithFeatures(rotatedFeatures...))
+
+	// The NATS CA cache is read-only and depends on the rotator having minted
+	// the nats_ca CA, so it must be constructed after StartRotator.
+	if natsClusterEnabled && options.NATSCACache == nil {
+		options.NATSCACache, err = cryptokeys.NewNATSCACache(ctx, options.Logger, options.Database)
+		if err != nil {
+			options.Logger.Fatal(ctx, "failed to create NATS CA cache", slog.Error(err))
+		}
+	}
 
 	// Ensure all system role permissions are current.
 	//nolint:gocritic // Startup reconciliation reads/writes system roles. There is
@@ -2367,6 +2388,9 @@ func (api *API) Close() error {
 	_ = api.OIDCConvertKeyCache.Close()
 	_ = api.AppSigningKeyCache.Close()
 	_ = api.AppEncryptionKeyCache.Close()
+	if api.NATSCACache != nil {
+		_ = api.NATSCACache.Close()
+	}
 	_ = api.UpdatesProvider.Close()
 	api.workspaceAgentConnWatcher.Close()
 

--- a/coderd/cryptokeys/ca.go
+++ b/coderd/cryptokeys/ca.go
@@ -1,0 +1,232 @@
+package cryptokeys
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
+)
+
+const (
+	caCertPEMBlockType = "CERTIFICATE"
+	caKeyPEMBlockType  = "EC PRIVATE KEY"
+
+	// clockSkewTolerance backdates the CA certificate's NotBefore and extends
+	// its NotAfter so that replicas with mildly skewed clocks still accept it.
+	clockSkewTolerance = time.Hour
+)
+
+// NATSCA is the parsed state of the nats_ca crypto key feature at one point in
+// time. The CA signs the ephemeral leaf certificates that replicas use for
+// NATS cluster mTLS.
+//
+// Callers that need to react to CA rotation (re-minting leaves and reloading
+// the NATS server config) should poll FetchNATSCA and compare Sequence to
+// detect when the active CA has changed.
+type NATSCA struct {
+	// Sequence is the crypto_keys sequence of the active row.
+	Sequence int32
+	// Cert is the active CA certificate used to sign leaf certificates.
+	Cert *x509.Certificate
+	// Key is the active CA private key.
+	Key crypto.Signer
+	// TrustBundle contains the certificates of all currently valid CA rows,
+	// including Cert. During a rotation overlap window it has two entries;
+	// installing the full bundle as the trust root lets replicas on either
+	// side of a rotation verify each other.
+	TrustBundle []*x509.Certificate
+}
+
+// ErrNATSCANotFound is returned by FetchNATSCA when no active nats_ca CA row
+// exists yet. On a fresh deployment this resolves once the key rotator mints
+// the initial CA, so callers should treat it as a transient condition and
+// retry rather than a permanent failure.
+var ErrNATSCANotFound = xerrors.New("no active NATS CA found")
+
+// FetchNATSCA returns the current NATS cluster CA. It is read-only: the key
+// rotator is the sole creator of nats_ca rows, so this never inserts. Before
+// the rotator has minted the initial CA (or during a transient gap) it returns
+// ErrNATSCANotFound; callers should retry.
+func FetchNATSCA(ctx context.Context, logger slog.Logger, db database.Store) (*NATSCA, error) {
+	//nolint:gocritic // The CA accessor requires the same crypto key read access as the cache.
+	ctx = dbauthz.AsKeyReader(ctx)
+
+	now := dbtime.Now()
+
+	keys, err := db.GetCryptoKeysByFeature(ctx, database.CryptoKeyFeatureNATSCA)
+	if err != nil {
+		return nil, xerrors.Errorf("get crypto keys by feature: %w", err)
+	}
+
+	ca, ok, err := parseNATSCAKeys(ctx, logger, keys, now)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrNATSCANotFound
+	}
+	return ca, nil
+}
+
+// parseNATSCAKeys builds a NATSCA from the database rows for the nats_ca
+// feature. Rows must be ordered by sequence descending (the order returned by
+// GetCryptoKeysByFeature). The active CA is the newest row that is usable for
+// signing; the trust bundle contains the certificates of every row that is
+// still valid for verification. The boolean reports whether a row could act
+// as the active CA.
+//
+// A corrupt secret on the active (newest signable) key is fatal: there is no
+// usable CA to sign leaves with. A corrupt secret on a non-active verify-only
+// key is logged and skipped: it has already lost its usefulness as a trust
+// root, and failing the whole fetch over it would needlessly take down the
+// NATS mTLS subsystem.
+func parseNATSCAKeys(ctx context.Context, logger slog.Logger, keys []database.CryptoKey, now time.Time) (*NATSCA, bool, error) {
+	ca := &NATSCA{}
+	for _, key := range keys {
+		if !key.CanVerify(now) {
+			continue
+		}
+		// The newest signable key we have not yet claimed becomes the active
+		// CA. Its secret must parse; everything else is a best-effort trust
+		// root.
+		isActiveCandidate := ca.Cert == nil && key.CanSign(now)
+		cert, signer, err := parseCASecret(key.Secret.String)
+		if err != nil {
+			if isActiveCandidate {
+				return nil, false, xerrors.Errorf("parse active CA secret for sequence %d: %w", key.Sequence, err)
+			}
+			logger.Warn(ctx, "skipping corrupt non-active NATS CA key",
+				slog.F("sequence", key.Sequence), slog.Error(err))
+			continue
+		}
+		ca.TrustBundle = append(ca.TrustBundle, cert)
+		if isActiveCandidate {
+			ca.Sequence = key.Sequence
+			ca.Cert = cert
+			ca.Key = signer
+		}
+	}
+	if ca.Cert == nil {
+		return nil, false, nil
+	}
+	return ca, true, nil
+}
+
+// generateCASecret generates a new self-signed CA certificate and private key
+// for signing NATS cluster leaf certificates, PEM-encoded into a single
+// bundle for storage in the crypto_keys secret column.
+//
+// anchorTime is the key row's starts_at (which may be in the future for a
+// rotated-in key). keyDuration is the rotator's key duration: the row stays the
+// active signer for that long. The certificate must outlive that window plus
+// the longest leaf it could sign (NATSCALeafValidity) plus clock-skew slack, so
+// leaves minted just before rotation still chain to a valid CA.
+func generateCASecret(anchorTime time.Time, keyDuration time.Duration) (string, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return "", xerrors.Errorf("generate key: %w", err)
+	}
+
+	// 128-bit random serial per CA/Browser Forum conventions.
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return "", xerrors.Errorf("generate serial: %w", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: "coder-nats-ca",
+		},
+		NotBefore:             anchorTime.Add(-clockSkewTolerance),
+		NotAfter:              anchorTime.Add(keyDuration + NATSCALeafValidity + clockSkewTolerance),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLenZero:        true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, key.Public(), key)
+	if err != nil {
+		return "", xerrors.Errorf("create certificate: %w", err)
+	}
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return "", xerrors.Errorf("marshal private key: %w", err)
+	}
+
+	var secret []byte
+	secret = append(secret, pem.EncodeToMemory(&pem.Block{Type: caCertPEMBlockType, Bytes: der})...)
+	secret = append(secret, pem.EncodeToMemory(&pem.Block{Type: caKeyPEMBlockType, Bytes: keyDER})...)
+	return string(secret), nil
+}
+
+// parseCASecret parses a PEM bundle produced by generateCASecret back into
+// the CA certificate and private key.
+func parseCASecret(secret string) (*x509.Certificate, crypto.Signer, error) {
+	var (
+		cert *x509.Certificate
+		key  *ecdsa.PrivateKey
+	)
+	rest := []byte(secret)
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		switch block.Type {
+		case caCertPEMBlockType:
+			if cert != nil {
+				return nil, nil, xerrors.New("multiple certificates in CA secret")
+			}
+			var err error
+			cert, err = x509.ParseCertificate(block.Bytes)
+			if err != nil {
+				return nil, nil, xerrors.Errorf("parse certificate: %w", err)
+			}
+		case caKeyPEMBlockType:
+			if key != nil {
+				return nil, nil, xerrors.New("multiple private keys in CA secret")
+			}
+			var err error
+			key, err = x509.ParseECPrivateKey(block.Bytes)
+			if err != nil {
+				return nil, nil, xerrors.Errorf("parse private key: %w", err)
+			}
+		default:
+			return nil, nil, xerrors.Errorf("unexpected PEM block type: %q", block.Type)
+		}
+	}
+	if cert == nil {
+		return nil, nil, xerrors.New("no certificate in CA secret")
+	}
+	if key == nil {
+		return nil, nil, xerrors.New("no private key in CA secret")
+	}
+	if !key.PublicKey.Equal(cert.PublicKey) {
+		return nil, nil, xerrors.New("private key does not match certificate")
+	}
+	// Reject a structurally valid bundle whose certificate cannot act as a
+	// signing CA. Without this, a corrupted secret could yield a non-CA cert
+	// that silently becomes the active signer; leaves signed under it would
+	// then fail x509 verification on every replica.
+	if !cert.IsCA || !cert.BasicConstraintsValid || cert.KeyUsage&x509.KeyUsageCertSign == 0 {
+		return nil, nil, xerrors.New("certificate is not a valid signing CA")
+	}
+	return cert, key, nil
+}

--- a/coderd/cryptokeys/ca_cache.go
+++ b/coderd/cryptokeys/ca_cache.go
@@ -1,0 +1,135 @@
+package cryptokeys
+
+import (
+	"context"
+	"io"
+	"sync"
+
+	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/quartz"
+)
+
+// NATSCACache caches the active NATS cluster CA and refreshes it in the
+// background to track rotation. It is strictly read-only: the key rotator is
+// the sole creator of nats_ca rows, so the cache never inserts.
+type NATSCACache interface {
+	// CA returns the current NATS cluster CA. It returns ErrNATSCANotFound
+	// until the rotator has minted the initial CA; callers should retry.
+	CA(ctx context.Context) (*NATSCA, error)
+	io.Closer
+}
+
+type natsCACache struct {
+	logger slog.Logger
+	db     database.Store
+	clock  quartz.Clock
+
+	// ctx is canceled by Close to stop background refreshes.
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	mu        sync.Mutex
+	ca        *NATSCA
+	refresher *quartz.Timer
+	closed    bool
+}
+
+// NATSCACacheOption configures a NATSCACache.
+type NATSCACacheOption func(*natsCACache)
+
+// WithNATSCACacheClock overrides the cache clock, for tests.
+func WithNATSCACacheClock(clock quartz.Clock) NATSCACacheOption {
+	return func(c *natsCACache) {
+		c.clock = clock
+	}
+}
+
+// NewNATSCACache constructs a NATSCACache and performs an initial fetch. A
+// failed initial fetch is logged but not fatal: the active CA may not exist
+// until the rotator mints it, and the next CA call (or the periodic refresh)
+// retries.
+func NewNATSCACache(ctx context.Context, logger slog.Logger, db database.Store, opts ...NATSCACacheOption) (NATSCACache, error) {
+	c := &natsCACache{
+		logger: logger.Named("nats_ca_cache"),
+		db:     db,
+		clock:  quartz.NewReal(),
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	c.ctx, c.cancel = context.WithCancel(ctx)
+	c.refresher = c.clock.AfterFunc(refreshInterval, c.refresh)
+
+	// A missing CA at construction is expected before the rotator mints it, and
+	// any transient error self-heals via CA or the periodic refresh, so this is
+	// not fatal.
+	if ca, err := FetchNATSCA(c.ctx, c.logger, c.db); err != nil {
+		c.logger.Warn(c.ctx, "initial NATS CA fetch failed; will retry", slog.Error(err))
+	} else {
+		c.ca = ca
+	}
+
+	return c, nil
+}
+
+func (c *natsCACache) CA(ctx context.Context) (*NATSCA, error) {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil, ErrClosed
+	}
+	ca := c.ca
+	c.mu.Unlock()
+
+	if ca != nil {
+		return ca, nil
+	}
+
+	// Not yet populated (initial fetch failed, or the rotator has not minted
+	// the CA yet). Fetch on demand so a transient startup gap self-heals.
+	fetched, err := FetchNATSCA(ctx, c.logger, c.db)
+	if err != nil {
+		return nil, err
+	}
+
+	c.mu.Lock()
+	if !c.closed {
+		c.ca = fetched
+	}
+	c.mu.Unlock()
+	return fetched, nil
+}
+
+func (c *natsCACache) refresh() {
+	ca, err := FetchNATSCA(c.ctx, c.logger, c.db)
+	if err != nil {
+		if c.ctx.Err() == nil {
+			c.logger.Warn(c.ctx, "failed to refresh NATS CA", slog.Error(err))
+		}
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return
+	}
+	if err == nil {
+		c.ca = ca
+	}
+	c.refresher.Reset(refreshInterval)
+}
+
+func (c *natsCACache) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.closed {
+		return nil
+	}
+	c.closed = true
+	c.cancel()
+	c.refresher.Stop()
+	return nil
+}

--- a/coderd/cryptokeys/ca_cache_internal_test.go
+++ b/coderd/cryptokeys/ca_cache_internal_test.go
@@ -1,0 +1,106 @@
+package cryptokeys
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/quartz"
+)
+
+func TestNATSCACache(t *testing.T) {
+	t.Parallel()
+
+	t.Run("RefreshesOnRotation", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := dbtestutil.NewDB(t)
+		ctx := testutil.Context(t, testutil.WaitShort)
+		clock := quartz.NewMock(t)
+		now := dbtime.Now()
+		clock.Set(now)
+
+		first := dbgen.CryptoKey(t, db, database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureNATSCA,
+			Sequence: 1,
+			StartsAt: now.Add(-time.Hour),
+		})
+
+		cache, err := NewNATSCACache(ctx, testutil.Logger(t), db, WithNATSCACacheClock(clock))
+		require.NoError(t, err)
+		defer cache.Close()
+
+		ca, err := cache.CA(ctx)
+		require.NoError(t, err)
+		require.Equal(t, first.Sequence, ca.Sequence)
+
+		// Simulate a rotation by inserting a higher-sequence active CA.
+		second := dbgen.CryptoKey(t, db, database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureNATSCA,
+			Sequence: 2,
+			StartsAt: now.Add(-time.Minute),
+		})
+
+		// The cache still serves the old CA until the next refresh.
+		ca, err = cache.CA(ctx)
+		require.NoError(t, err)
+		require.Equal(t, first.Sequence, ca.Sequence)
+
+		// Fire the background refresher.
+		clock.Advance(refreshInterval).MustWait(ctx)
+
+		ca, err = cache.CA(ctx)
+		require.NoError(t, err)
+		require.Equal(t, second.Sequence, ca.Sequence)
+	})
+
+	t.Run("FetchesOnDemandAfterEmptyStart", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := dbtestutil.NewDB(t)
+		ctx := testutil.Context(t, testutil.WaitShort)
+		now := dbtime.Now()
+
+		// The cache is constructed against an empty DB, so the initial fetch
+		// returns ErrNATSCANotFound and leaves the cache unpopulated.
+		cache, err := NewNATSCACache(ctx, testutil.Logger(t), db)
+		require.NoError(t, err)
+		defer cache.Close()
+
+		// Until a CA exists, CA surfaces the transient not-found condition.
+		_, err = cache.CA(ctx)
+		require.ErrorIs(t, err, ErrNATSCANotFound)
+
+		// Once the rotator mints the CA, the on-demand fetch path populates the
+		// cache without waiting for the periodic refresh.
+		key := dbgen.CryptoKey(t, db, database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureNATSCA,
+			Sequence: 1,
+			StartsAt: now.Add(-time.Hour),
+		})
+
+		ca, err := cache.CA(ctx)
+		require.NoError(t, err)
+		require.Equal(t, key.Sequence, ca.Sequence)
+	})
+
+	t.Run("CloseStops", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := dbtestutil.NewDB(t)
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		cache, err := NewNATSCACache(ctx, testutil.Logger(t), db)
+		require.NoError(t, err)
+		require.NoError(t, cache.Close())
+
+		_, err = cache.CA(ctx)
+		require.ErrorIs(t, err, ErrClosed)
+	})
+}

--- a/coderd/cryptokeys/ca_internal_test.go
+++ b/coderd/cryptokeys/ca_internal_test.go
@@ -1,0 +1,327 @@
+package cryptokeys
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"database/sql"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestCASecretRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// The certificate's NotAfter must track the supplied keyDuration, not a
+	// hardcoded default, so a CA stays valid for as long as it can be the
+	// active signer plus the longest leaf it signs.
+	for _, keyDuration := range []time.Duration{DefaultKeyDuration, DefaultKeyDuration * 3, time.Hour} {
+		now := time.Now().UTC().Truncate(time.Second)
+		secret, err := generateCASecret(now, keyDuration)
+		require.NoError(t, err)
+
+		cert, signer, err := parseCASecret(secret)
+		require.NoError(t, err)
+
+		require.True(t, cert.IsCA)
+		require.True(t, cert.BasicConstraintsValid)
+		require.True(t, cert.MaxPathLenZero)
+		require.Equal(t, x509.KeyUsageCertSign, cert.KeyUsage)
+		require.Equal(t, now.Add(-clockSkewTolerance), cert.NotBefore)
+		require.Equal(t, now.Add(keyDuration+NATSCALeafValidity+clockSkewTolerance), cert.NotAfter)
+		require.Equal(t, cert.PublicKey, signer.Public())
+
+		// The cert must outlive its active-signer window so leaves signed at
+		// the end of that window still chain to a valid CA.
+		require.True(t, cert.NotAfter.After(now.Add(keyDuration)),
+			"cert must remain valid past the end of its active-signer window")
+
+		// The cert must be able to verify itself as a trust root.
+		pool := x509.NewCertPool()
+		pool.AddCert(cert)
+		_, err = cert.Verify(x509.VerifyOptions{Roots: pool})
+		require.NoError(t, err)
+	}
+}
+
+func TestParseCASecretErrors(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	secretA, err := generateCASecret(now, DefaultKeyDuration)
+	require.NoError(t, err)
+	secretB, err := generateCASecret(now, DefaultKeyDuration)
+	require.NoError(t, err)
+
+	certA, keyA := splitCAPEM(t, secretA)
+	_, keyB := splitCAPEM(t, secretB)
+
+	nonCACert, nonCAKey := generateNonCAPEM(t, now)
+
+	cases := []struct {
+		name    string
+		secret  string
+		errText string
+	}{
+		{"Empty", "", "no certificate"},
+		{"NotPEM", "not pem at all", "no certificate"},
+		{"CertOnly", string(certA), "no private key"},
+		{"KeyCertMismatch", string(certA) + string(keyB), "does not match certificate"},
+		{"MultipleCertificates", string(certA) + string(certA) + string(keyA), "multiple certificates"},
+		{"MultiplePrivateKeys", string(certA) + string(keyA) + string(keyA), "multiple private keys"},
+		{"UnexpectedBlockType", string(pemBlock("RSA PRIVATE KEY", []byte("x"))), "unexpected PEM block type"},
+		{"BadCertificateBytes", string(pemBlock(caCertPEMBlockType, []byte("garbage"))), "parse certificate"},
+		{"BadPrivateKeyBytes", string(certA) + string(pemBlock(caKeyPEMBlockType, []byte("garbage"))), "parse private key"},
+		{"NotASigningCA", string(nonCACert) + string(nonCAKey), "not a valid signing CA"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := parseCASecret(tc.secret)
+			require.ErrorContains(t, err, tc.errText)
+		})
+	}
+}
+
+// splitCAPEM splits a CA secret bundle into its certificate and private key
+// PEM blocks so tests can recombine them into malformed bundles.
+func splitCAPEM(t *testing.T, secret string) (certPEM, keyPEM []byte) {
+	t.Helper()
+	rest := []byte(secret)
+	for {
+		block, r := pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		rest = r
+		switch block.Type {
+		case caCertPEMBlockType:
+			certPEM = pem.EncodeToMemory(block)
+		case caKeyPEMBlockType:
+			keyPEM = pem.EncodeToMemory(block)
+		}
+	}
+	require.NotNil(t, certPEM)
+	require.NotNil(t, keyPEM)
+	return certPEM, keyPEM
+}
+
+func pemBlock(blockType string, der []byte) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: blockType, Bytes: der})
+}
+
+// generateNonCAPEM produces a structurally valid cert+key bundle whose
+// certificate is not a CA (no IsCA, no KeyUsageCertSign). The key matches the
+// cert, so it passes every parseCASecret check except the signing-CA check.
+func generateNonCAPEM(t *testing.T, now time.Time) (certPEM, keyPEM []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "not-a-ca"},
+		NotBefore:    now.Add(-time.Hour),
+		NotAfter:     now.Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, key.Public(), key)
+	require.NoError(t, err)
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+	return pemBlock(caCertPEMBlockType, der), pemBlock(caKeyPEMBlockType, keyDER)
+}
+
+func TestFetchNATSCA(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NotFoundWhenMissing", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := dbtestutil.NewDB(t)
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		// FetchNATSCA never creates: with no nats_ca rows it reports the
+		// transient not-found condition the rotator resolves.
+		_, err := FetchNATSCA(ctx, testutil.Logger(t), db)
+		require.ErrorIs(t, err, ErrNATSCANotFound)
+
+		keys, err := db.GetCryptoKeysByFeature(ctx, database.CryptoKeyFeatureNATSCA)
+		require.NoError(t, err)
+		require.Empty(t, keys)
+	})
+
+	t.Run("ReturnsActive", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := dbtestutil.NewDB(t)
+		ctx := testutil.Context(t, testutil.WaitShort)
+		now := time.Now().UTC()
+
+		current := dbgen.CryptoKey(t, db, database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureNATSCA,
+			Sequence: 1,
+			StartsAt: now.Add(-time.Hour),
+		})
+
+		ca, err := FetchNATSCA(ctx, testutil.Logger(t), db)
+		require.NoError(t, err)
+		require.Equal(t, current.Sequence, ca.Sequence)
+		require.NotNil(t, ca.Cert)
+		require.NotNil(t, ca.Key)
+		require.Len(t, ca.TrustBundle, 1)
+
+		currentCert, _, err := parseCASecret(current.Secret.String)
+		require.NoError(t, err)
+		require.Equal(t, currentCert.Raw, ca.Cert.Raw)
+	})
+
+	t.Run("SkipsCorruptNonActiveKey", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := dbtestutil.NewDB(t)
+		ctx := testutil.Context(t, testutil.WaitShort)
+		now := time.Now().UTC()
+
+		// Newest signable key is the active CA.
+		active := dbgen.CryptoKey(t, db, database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureNATSCA,
+			Sequence: 2,
+			StartsAt: now.Add(-time.Hour),
+		})
+		// Older still-verifiable key with a corrupt secret: it must be skipped
+		// rather than failing the whole fetch.
+		dbgen.CryptoKey(t, db, database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureNATSCA,
+			Sequence: 1,
+			StartsAt: now.Add(-2 * time.Hour),
+			Secret:   sql.NullString{String: "not a pem", Valid: true},
+		})
+
+		ca, err := FetchNATSCA(ctx, testutil.Logger(t), db)
+		require.NoError(t, err)
+		require.Equal(t, active.Sequence, ca.Sequence)
+
+		// The corrupt key is excluded from the trust bundle.
+		activeCert, _, err := parseCASecret(active.Secret.String)
+		require.NoError(t, err)
+		require.Len(t, ca.TrustBundle, 1)
+		require.Equal(t, activeCert.Raw, ca.TrustBundle[0].Raw)
+	})
+
+	t.Run("CorruptActiveKeyIsFatal", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := dbtestutil.NewDB(t)
+		ctx := testutil.Context(t, testutil.WaitShort)
+		now := time.Now().UTC()
+
+		// The active (newest signable) key is corrupt: there is no usable CA to
+		// sign leaves with, so the fetch must fail loudly.
+		dbgen.CryptoKey(t, db, database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureNATSCA,
+			Sequence: 1,
+			StartsAt: now.Add(-time.Hour),
+			Secret:   sql.NullString{String: "not a pem", Valid: true},
+		})
+
+		_, err := FetchNATSCA(ctx, testutil.Logger(t), db)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "active CA secret for sequence 1")
+	})
+
+	t.Run("RotationOverlap", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := dbtestutil.NewDB(t)
+		ctx := testutil.Context(t, testutil.WaitShort)
+		now := time.Now().UTC()
+
+		// Old CA scheduled for deletion in the future: still a trust root,
+		// no longer the active signer.
+		oldKey := dbgen.CryptoKey(t, db, database.CryptoKey{
+			Feature:   database.CryptoKeyFeatureNATSCA,
+			Sequence:  1,
+			StartsAt:  now.Add(-2 * time.Hour),
+			DeletesAt: sql.NullTime{Time: now.Add(time.Hour), Valid: true},
+		})
+		newKey := dbgen.CryptoKey(t, db, database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureNATSCA,
+			Sequence: 2,
+			StartsAt: now.Add(-time.Hour),
+		})
+		// Deleted key: excluded entirely.
+		deletedKey := dbgen.CryptoKey(t, db, database.CryptoKey{
+			Feature:   database.CryptoKeyFeatureNATSCA,
+			Sequence:  3,
+			StartsAt:  now.Add(-3 * time.Hour),
+			DeletesAt: sql.NullTime{Time: now.Add(-time.Hour), Valid: true},
+		})
+
+		ca, err := FetchNATSCA(ctx, testutil.Logger(t), db)
+		require.NoError(t, err)
+		require.Equal(t, newKey.Sequence, ca.Sequence)
+
+		newCert, _, err := parseCASecret(newKey.Secret.String)
+		require.NoError(t, err)
+		oldCert, _, err := parseCASecret(oldKey.Secret.String)
+		require.NoError(t, err)
+		deletedCert, _, err := parseCASecret(deletedKey.Secret.String)
+		require.NoError(t, err)
+
+		require.Equal(t, newCert.Raw, ca.Cert.Raw)
+		require.Len(t, ca.TrustBundle, 2)
+		bundle := [][]byte{ca.TrustBundle[0].Raw, ca.TrustBundle[1].Raw}
+		require.Contains(t, bundle, newCert.Raw)
+		require.Contains(t, bundle, oldCert.Raw)
+		require.NotContains(t, bundle, deletedCert.Raw)
+	})
+
+	t.Run("FutureKeyNotActive", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := dbtestutil.NewDB(t)
+		ctx := testutil.Context(t, testutil.WaitShort)
+		now := time.Now().UTC()
+
+		current := dbgen.CryptoKey(t, db, database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureNATSCA,
+			Sequence: 1,
+			StartsAt: now.Add(-time.Hour),
+		})
+		// A rotated-in key that hasn't started yet must not be the active
+		// signer, but its cert belongs in the trust bundle.
+		future := dbgen.CryptoKey(t, db, database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureNATSCA,
+			Sequence: 2,
+			StartsAt: now.Add(time.Hour),
+		})
+
+		ca, err := FetchNATSCA(ctx, testutil.Logger(t), db)
+		require.NoError(t, err)
+		require.Equal(t, current.Sequence, ca.Sequence)
+
+		currentCert, _, err := parseCASecret(current.Secret.String)
+		require.NoError(t, err)
+		futureCert, _, err := parseCASecret(future.Secret.String)
+		require.NoError(t, err)
+
+		require.Equal(t, currentCert.Raw, ca.Cert.Raw)
+		require.Len(t, ca.TrustBundle, 2)
+		bundle := [][]byte{ca.TrustBundle[0].Raw, ca.TrustBundle[1].Raw}
+		require.Contains(t, bundle, currentCert.Raw)
+		require.Contains(t, bundle, futureCert.Raw)
+		require.NotEqual(t, currentCert.Raw, futureCert.Raw)
+	})
+}

--- a/coderd/cryptokeys/rotate.go
+++ b/coderd/cryptokeys/rotate.go
@@ -21,6 +21,11 @@ const (
 	WorkspaceAppsTokenDuration = time.Minute
 	OIDCConvertTokenDuration   = time.Minute * 5
 	TailnetResumeTokenDuration = time.Hour * 24
+	// NATSCALeafValidity is the maximum lifetime of a leaf certificate
+	// minted under the NATS cluster CA. Old CA rows must remain valid trust
+	// roots for this long after rotation so that replicas holding leaves
+	// signed by the old CA can still be verified.
+	NATSCALeafValidity = time.Hour * 24 * 30
 
 	// defaultRotationInterval is the default interval at which keys are checked for rotation.
 	defaultRotationInterval = time.Minute * 10
@@ -67,6 +72,15 @@ func WithClock(clock quartz.Clock) RotatorOption {
 func WithKeyDuration(keyDuration time.Duration) RotatorOption {
 	return func(r *rotator) {
 		r.keyDuration = keyDuration
+	}
+}
+
+// WithFeatures overrides the set of crypto key features the rotator manages.
+// Callers use this to opt experiment-gated features (such as the NATS CA) into
+// rotation only when the corresponding experiment is enabled.
+func WithFeatures(features ...database.CryptoKeyFeature) RotatorOption {
+	return func(r *rotator) {
+		r.features = features
 	}
 }
 
@@ -189,7 +203,7 @@ func (k *rotator) rotateKeys(ctx context.Context) error {
 }
 
 func (k *rotator) insertNewKey(ctx context.Context, tx database.Store, feature database.CryptoKeyFeature, startsAt time.Time) (database.CryptoKey, error) {
-	secret, err := generateNewSecret(feature)
+	secret, err := generateNewSecret(feature, startsAt, k.keyDuration)
 	if err != nil {
 		return database.CryptoKey{}, xerrors.Errorf("generate new secret: %w", err)
 	}
@@ -246,7 +260,11 @@ func (k *rotator) rotateKey(ctx context.Context, tx database.Store, key database
 	return []database.CryptoKey{updatedKey, newKey}, nil
 }
 
-func generateNewSecret(feature database.CryptoKeyFeature) (string, error) {
+// generateNewSecret generates the secret for a new key of the given feature.
+// keyDuration is the rotator's key duration; it is only used by features whose
+// secret encodes its own validity window (currently only the NATS CA, whose
+// certificate must outlive the key row's active-signer period).
+func generateNewSecret(feature database.CryptoKeyFeature, startsAt time.Time, keyDuration time.Duration) (string, error) {
 	switch feature {
 	case database.CryptoKeyFeatureWorkspaceAppsAPIKey:
 		return generateKey(32)
@@ -256,6 +274,8 @@ func generateNewSecret(feature database.CryptoKeyFeature) (string, error) {
 		return generateKey(64)
 	case database.CryptoKeyFeatureTailnetResume:
 		return generateKey(64)
+	case database.CryptoKeyFeatureNATSCA:
+		return generateCASecret(startsAt, keyDuration)
 	}
 	return "", xerrors.Errorf("unknown feature: %s", feature)
 }
@@ -279,6 +299,8 @@ func tokenDuration(feature database.CryptoKeyFeature) time.Duration {
 		return OIDCConvertTokenDuration
 	case database.CryptoKeyFeatureTailnetResume:
 		return TailnetResumeTokenDuration
+	case database.CryptoKeyFeatureNATSCA:
+		return NATSCALeafValidity
 	default:
 		return 0
 	}

--- a/coderd/cryptokeys/rotate_internal_test.go
+++ b/coderd/cryptokeys/rotate_internal_test.go
@@ -104,6 +104,58 @@ func Test_rotateKeys(t *testing.T) {
 		require.Equal(t, newKey, keys[0])
 	})
 
+	t.Run("RotatesNATSCA", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			db, _       = dbtestutil.NewDB(t)
+			clock       = quartz.NewMock(t)
+			keyDuration = time.Hour * 24 * 7
+			logger      = testutil.Logger(t)
+			ctx         = testutil.Context(t, testutil.WaitShort)
+		)
+
+		kr := &rotator{
+			db:          db,
+			keyDuration: keyDuration,
+			clock:       clock,
+			logger:      logger,
+			features: []database.CryptoKeyFeature{
+				database.CryptoKeyFeatureNATSCA,
+			},
+		}
+
+		now := dbnow(clock)
+
+		oldKey := dbgen.CryptoKey(t, db, database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureNATSCA,
+			StartsAt: now,
+			Sequence: 4,
+		})
+
+		// Advance the window to just inside rotation time.
+		_ = clock.Advance(keyDuration - time.Minute*59)
+		err := kr.rotateKeys(ctx)
+		require.NoError(t, err)
+
+		// The old CA must remain a valid trust root for the maximum leaf
+		// lifetime after rotation.
+		expectedDeletesAt := oldKey.ExpiresAt(keyDuration).Add(NATSCALeafValidity + time.Hour)
+		oldKey, err = db.GetCryptoKeyByFeatureAndSequence(ctx, database.GetCryptoKeyByFeatureAndSequenceParams{
+			Feature:  oldKey.Feature,
+			Sequence: oldKey.Sequence,
+		})
+		require.NoError(t, err)
+		require.Equal(t, expectedDeletesAt, oldKey.DeletesAt.Time.UTC())
+
+		newKey, err := db.GetCryptoKeyByFeatureAndSequence(ctx, database.GetCryptoKeyByFeatureAndSequenceParams{
+			Feature:  database.CryptoKeyFeatureNATSCA,
+			Sequence: oldKey.Sequence + 1,
+		})
+		require.NoError(t, err)
+		requireKey(t, newKey, database.CryptoKeyFeatureNATSCA, oldKey.ExpiresAt(keyDuration), nullTime, oldKey.Sequence+1)
+	})
+
 	t.Run("DoesNotRotateValidKeys", func(t *testing.T) {
 		t.Parallel()
 
@@ -358,7 +410,10 @@ func Test_rotateKeys(t *testing.T) {
 			keyDuration: keyDuration,
 			clock:       clock,
 			logger:      logger,
-			features:    defaultRotatedFeatures,
+			// Include the experiment-gated NATS CA so this test exercises
+			// every feature the rotator can manage, matching the set the
+			// caller opts into when ExperimentNATSPubsub is enabled.
+			features: database.AllCryptoKeyFeatureValues(),
 		}
 
 		now := dbnow(clock)
@@ -407,9 +462,9 @@ func Test_rotateKeys(t *testing.T) {
 
 		keys, err := db.GetCryptoKeys(ctx)
 		require.NoError(t, err)
-		require.Len(t, keys, 5)
+		require.Len(t, keys, 6)
 
-		kbf, err := keysByFeature(keys, defaultRotatedFeatures)
+		kbf, err := keysByFeature(keys, database.AllCryptoKeyFeatureValues())
 		require.NoError(t, err)
 
 		// No actions on OIDC convert.
@@ -420,6 +475,7 @@ func Test_rotateKeys(t *testing.T) {
 		// caused a key to be inserted.
 		require.Len(t, kbf[database.CryptoKeyFeatureTailnetResume], 1)
 		require.Len(t, kbf[database.CryptoKeyFeatureWorkspaceAppsToken], 1)
+		require.Len(t, kbf[database.CryptoKeyFeatureNATSCA], 1)
 
 		oidcKey := kbf[database.CryptoKeyFeatureOIDCConvert][0]
 		tailnetKey := kbf[database.CryptoKeyFeatureTailnetResume][0]
@@ -585,6 +641,14 @@ func requireKey(t *testing.T, key database.CryptoKey, feature database.CryptoKey
 	require.Equal(t, deletesAt.Valid, key.DeletesAt.Valid)
 	require.Equal(t, deletesAt.Time.UTC(), key.DeletesAt.Time.UTC())
 	require.Equal(t, sequence, key.Sequence)
+
+	// The NATS CA secret is a PEM bundle rather than hex-encoded bytes.
+	if key.Feature == database.CryptoKeyFeatureNATSCA {
+		cert, _, err := parseCASecret(key.Secret.String)
+		require.NoError(t, err)
+		require.True(t, cert.IsCA)
+		return
+	}
 
 	secret, err := hex.DecodeString(key.Secret.String)
 	require.NoError(t, err)

--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -2,13 +2,19 @@ package dbgen
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"maps"
+	"math/big"
 	"net"
 	"strings"
 	"testing"
@@ -2219,8 +2225,42 @@ func newCryptoKeySecret(feature database.CryptoKeyFeature) (string, error) {
 		return generateCryptoKey(64)
 	case database.CryptoKeyFeatureTailnetResume:
 		return generateCryptoKey(64)
+	case database.CryptoKeyFeatureNATSCA:
+		return generateCACryptoKeySecret()
 	}
 	return "", xerrors.Errorf("unknown feature: %s", feature)
+}
+
+// generateCACryptoKeySecret generates a self-signed CA certificate and
+// private key as a PEM bundle, matching the secret format that
+// coderd/cryptokeys produces for the nats_ca feature.
+func generateCACryptoKeySecret() (string, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return "", xerrors.Errorf("generate key: %w", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "dbgen-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLenZero:        true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, key.Public(), key)
+	if err != nil {
+		return "", xerrors.Errorf("create certificate: %w", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return "", xerrors.Errorf("marshal private key: %w", err)
+	}
+	var secret []byte
+	secret = append(secret, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})...)
+	secret = append(secret, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})...)
+	return string(secret), nil
 }
 
 func generateCryptoKey(length int) (string, error) {

--- a/coderd/database/modelmethods.go
+++ b/coderd/database/modelmethods.go
@@ -869,6 +869,13 @@ func (k CryptoKey) ExpiresAt(keyDuration time.Duration) time.Time {
 	return k.StartsAt.Add(keyDuration).UTC()
 }
 
+// DecodeString hex-decodes the key's secret. It is only valid for features
+// whose secret is hex-encoded bytes; it must NOT be used for nats_ca, whose
+// secret is a PEM certificate+key bundle (see coderd/cryptokeys parseCASecret).
+//
+// TODO: this method currently has no callers (the keycache hex-decodes via its
+// own helper). Investigate removing it, or making it feature-aware, so the
+// secret column's dual format (hex bytes vs PEM bundle) cannot be misdecoded.
 func (k CryptoKey) DecodeString() ([]byte, error) {
 	return hex.DecodeString(k.Secret.String)
 }

--- a/enterprise/coderd/workspaceproxy_test.go
+++ b/enterprise/coderd/workspaceproxy_test.go
@@ -1092,6 +1092,12 @@ func TestGetCryptoKeys(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorAs(t, err, &sdkErr)
 		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
+		// The NATS cluster CA bundle contains a private key and must never be
+		// served to workspace proxies.
+		_, err = proxy.SDKClient.CryptoKeys(ctx, codersdk.CryptoKeyFeature(database.CryptoKeyFeatureNATSCA))
+		require.Error(t, err)
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
 		_, err = proxy.SDKClient.CryptoKeys(ctx, "invalid")
 		require.Error(t, err)
 		require.ErrorAs(t, err, &sdkErr)


### PR DESCRIPTION
NOTE: The changes in this PR were generated with heavy AI help. I have verified general functionality (manual test) and reviewed the code structure itself. Crypto details are outside my current knowledge base, but I believe relying on the stdlib x509 package is safe here. Please nit pick both the code and implementation details if anything smells off at all.





AI summary of changes:



Adds cryptokeys support for a CA that will sign the ephemeral leaf certificates replicas use for NATS cluster mTLS:



- New crypto_key_feature enum value nats_ca; the rotator generates a self-signed ECDSA P-256 CA (PEM cert+key bundle in the secret column) and rotates it on the shared key duration with a 30 day token duration matching the maximum leaf lifetime. The rotator is the sole creator of nats_ca rows.

- FetchNATSCA is a read-only accessor that returns the active CA (parsed cert and signer) plus a trust bundle of all valid CA rows and the active row sequence so callers can detect rotation. It never creates the CA: before the rotator has minted the initial CA it returns ErrNATSCANotFound, and NATSCACache retries on demand and via its periodic refresh loop until the CA exists.

- The CA bundle contains a private key and stays excluded from the wsproxy crypto-keys endpoint allowlist and the signing/encryption keycaches.



The feature is dormant: nothing fetches the CA until cli/server.go is wired up in a follow-up branch.
