### PR TITLE
fix(site/src): stop blocking post-login redirect on CSRF-protected authcheck

### DIFF
--- a/site/e2e/tests/loginRedirect.spec.ts
+++ b/site/e2e/tests/loginRedirect.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/test";
+import { users } from "../constants";
+import { expectUrl } from "../expectUrl";
+import { beforeCoderTest } from "../hooks";
+
+test.beforeEach(({ page }) => {
+	beforeCoderTest(page);
+});
+
+// The post-login redirect to `/workspaces` must not depend on
+// `POST /api/v2/authcheck`. Inject the CSRF middleware's 400 response on
+// every authcheck request and assert the redirect still happens.
+test("login redirect survives a CSRF failure on /api/v2/authcheck", async ({
+	page,
+}) => {
+	await page.context().clearCookies();
+
+	let authcheckHits = 0;
+	await page.route("**/api/v2/authcheck", async (route) => {
+		authcheckHits++;
+		await route.fulfill({
+			status: 400,
+			contentType: "text/plain",
+			body: "Something is wrong with your CSRF token. Please refresh the page. If this error persists, try clearing your cookies.\n",
+		});
+	});
+
+	await page.goto("/login");
+	await page.getByLabel("Email").fill(users.owner.email);
+	await page.getByLabel("Password").fill(users.owner.password);
+	await page.getByRole("button", { name: "Sign In" }).click();
+
+	await expectUrl(page).toHavePathName("/workspaces", { timeout: 15000 });
+	// Without this, the test could pass vacuously if the SPA stopped calling
+	// authcheck on the login path entirely.
+	expect(authcheckHits).toBeGreaterThan(0);
+});

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -4043,12 +4043,23 @@ class ExperimentalApiMethods {
 const csrfToken =
 	"KNKvagCBEHZK7ihe2t7fj6VeJ0UyTDco1yVUJE8N06oNqxLu5Zx1vRxZbgfC0mJJgeGkVjgs08mgPbcWPBkZ1A==";
 
-// Always attach CSRF token to all requests. In puppeteer the document is
-// undefined. In those cases, just do nothing.
-const tokenMetadataElement =
-	typeof document !== "undefined"
-		? document.head.querySelector('meta[property="csrf-token"]')
-		: null;
+// Reads the CSRF token from the `<meta property="csrf-token">` tag at
+// request time so the `X-CSRF-TOKEN` header stays in sync with whatever the
+// server most recently rendered. Pinning the value at module init raced with
+// meta tag population and cookie rotation.
+function getCsrfToken(): string {
+	if (typeof document === "undefined") {
+		return "";
+	}
+	if (process.env.NODE_ENV === "development") {
+		return csrfToken;
+	}
+	return (
+		document.head
+			.querySelector('meta[property="csrf-token"]')
+			?.getAttribute("content") ?? ""
+	);
+}
 
 function getConfiguredAxiosInstance(): AxiosInstance {
 	const instance = globalAxios.create();
@@ -4060,29 +4071,34 @@ function getConfiguredAxiosInstance(): AxiosInstance {
 		return (status >= 200 && status < 300) || status === 304;
 	};
 
-	const metadataIsAvailable =
-		tokenMetadataElement !== null &&
-		tokenMetadataElement.getAttribute("content") !== null;
+	// Warn on missing meta tag at module init so misconfigured pages are still
+	// obvious in the console. In dev, rewrite the meta tag to the hardcoded
+	// token so anything reading it directly sees the value the dev proxy
+	// accepts.
+	if (typeof document !== "undefined") {
+		const tokenMetadataElement = document.head.querySelector(
+			'meta[property="csrf-token"]',
+		);
+		const metaContent = tokenMetadataElement?.getAttribute("content");
 
-	if (metadataIsAvailable) {
-		if (process.env.NODE_ENV === "development") {
-			// Development mode uses a hard-coded CSRF token
-			instance.defaults.headers.common["X-CSRF-TOKEN"] = csrfToken;
+		if (process.env.NODE_ENV === "development" && tokenMetadataElement) {
 			tokenMetadataElement.setAttribute("content", csrfToken);
-		} else {
-			instance.defaults.headers.common["X-CSRF-TOKEN"] =
-				tokenMetadataElement.getAttribute("content") ?? "";
-		}
-	} else {
-		// Do not write error logs if we are in a FE unit test or if there is no document (e.g., Electron)
-		if (
-			typeof document !== "undefined" &&
+		} else if (
+			!metaContent &&
 			!process.env.JEST_WORKER_ID &&
 			!process.env.VITEST
 		) {
 			console.error("CSRF token not found");
 		}
 	}
+
+	instance.interceptors.request.use((config) => {
+		const token = getCsrfToken();
+		if (token) {
+			config.headers.set("X-CSRF-TOKEN", token);
+		}
+		return config;
+	});
 
 	return instance;
 }

--- a/site/src/api/queries/users.ts
+++ b/site/src/api/queries/users.ts
@@ -7,7 +7,6 @@ import type {
 import { API } from "#/api/api";
 import { isApiError } from "#/api/errors";
 import type {
-	AuthorizationRequest,
 	GenerateAPIKeyResponse,
 	GetUsersResponse,
 	MinimalUser,
@@ -29,7 +28,6 @@ import {
 } from "#/hooks/useEmbeddedMetadata";
 import type { UsePaginatedQueryOptions } from "#/hooks/usePaginatedQuery";
 import { prepareQuery } from "#/utils/filters";
-import { getAuthorizationKey } from "./authCheck";
 import { cachedQuery } from "./util";
 
 export function usersKey(req: UsersRequest) {
@@ -237,19 +235,16 @@ export const hasFirstUser = (userMetadata: MetadataState<User>) => {
 	});
 };
 
-export const login = (
-	authorization: AuthorizationRequest,
-	queryClient: QueryClient,
-) => {
+export const login = (queryClient: QueryClient) => {
 	return {
 		mutationFn: async (credentials: { email: string; password: string }) =>
-			loginFn({ ...credentials, authorization }),
+			loginFn(credentials),
 		onSuccess: async (data: Awaited<ReturnType<typeof loginFn>>) => {
 			queryClient.setQueryData(meKey, data.user);
-			queryClient.setQueryData(
-				getAuthorizationKey(authorization),
-				data.permissions,
-			);
+			// AuthProvider's permissionsQuery fetches authorization lazily.
+			// We deliberately don't pre-seed it here because chaining a
+			// CSRF-protected POST onto the login response made post-login
+			// navigation hang on a single rejected authcheck.
 		},
 	};
 };
@@ -257,21 +252,13 @@ export const login = (
 const loginFn = async ({
 	email,
 	password,
-	authorization,
 }: {
 	email: string;
 	password: string;
-	authorization: AuthorizationRequest;
 }) => {
 	await API.login(email, password);
-	const [user, permissions] = await Promise.all([
-		API.getAuthenticatedUser(),
-		API.checkAuthorization(authorization),
-	]);
-	return {
-		user,
-		permissions,
-	};
+	const user = await API.getAuthenticatedUser();
+	return { user };
 };
 
 export const logout = (queryClient: QueryClient): MutationOptions => {

--- a/site/src/contexts/auth/AuthProvider.tsx
+++ b/site/src/contexts/auth/AuthProvider.tsx
@@ -58,9 +58,7 @@ export const AuthProvider: FC<PropsWithChildren> = ({ children }) => {
 	});
 
 	const queryClient = useQueryClient();
-	const loginMutation = useMutation(
-		login({ checks: permissionChecks }, queryClient),
-	);
+	const loginMutation = useMutation(login(queryClient));
 
 	const logoutMutation = useMutation(logout(queryClient));
 	const updateProfileMutation = useMutation({


### PR DESCRIPTION
> 🤖 This PR was modified by Coder Agents on behalf of Jake Howell.

The `test-e2e` / `test-e2e-premium` flake tracked in [DEVEX-334](https://linear.app/codercom/issue/DEVEX-334-flake-test-e2e-premium-and-test-e2e) ([internal#461](https://github.com/coder/internal/issues/461)) is two latent SPA bugs lined up on the post-login redirect path:

1. `loginFn` in `site/src/api/queries/users.ts` fires `POST /api/v2/authcheck` in a `Promise.all` immediately after the login response sets the session cookie, which makes that authcheck CSRF-protected. Any failure there rejects the login mutation, so the `location.href = sanitizeRedirect(redirectTo)` hard reload in `LoginPage` never runs and the page stays on `/login`.
2. `X-CSRF-TOKEN` was captured on the axios default headers exactly once, at module init, from `<meta property="csrf-token">`. If the bundle evaluated before the meta tag was populated, or a later document refetch rotated the `csrf_token` cookie, the cached header drifted from the cookie and every CSRF-protected POST 400'd.

## Scope: not test-only

Three of the four touched files ship to real users. Only `loginRedirect.spec.ts` is regression infrastructure.

**`site/src/api/queries/users.ts` (shipped, login critical path)**

Real users hitting the CSRF race were stuck on `/login` until manual reload. This unblocks them.

Behavior delta on the non-flake happy path: authorization is no longer pre-seeded into React Query during the login mutation. `AuthProvider.permissionsQuery` fetches it on dashboard mount instead. The post-login hard reload was already going to fire that query against a fresh document, so the net cost is one extra round trip after navigation rather than during the login mutation. A single-render permission-gated UI flicker is theoretically possible on slow connections; in practice the dashboard shell renders first and gated regions hydrate within the same paint.

**`site/src/api/api.ts` (shipped, every mutating request in the SPA)**

The CSRF header is now read from the meta tag per request via an axios interceptor, instead of being cached on `axios.defaults.headers.common` at module init.

- Steady state (token stable): identical behavior, plus one `document.head.querySelector` per outbound axios call. Sub-microsecond.
- Rotation case (token changed since module init): strictly safer. The old code 400'd until full page reload; the new code picks up the current value.
- Missing meta tag: identical fallback. Header is omitted, same as before.

**`site/src/contexts/auth/AuthProvider.tsx` (shipped)**

Call-site rename for the new `login` signature. No behavior change.

**`site/e2e/tests/loginRedirect.spec.ts` (test-only)**

Playwright regression using `page.route()` to deterministically return the production CSRF 400 body on `/api/v2/authcheck` and assert the post-login redirect still happens.

No server changes. No new endpoints. No auth contract changes. CSRF middleware (`coderd/httpmw/csrf.go`) is untouched.

## Fix

Drop `checkAuthorization` from `loginFn` and let `AuthProvider.permissionsQuery` fetch authorization on the next render.

Replace the cached header with a per-request axios interceptor that reads the meta tag on every call. The module-init `CSRF token not found` warning is preserved.

Add `site/e2e/tests/loginRedirect.spec.ts` to guard the new contract.

Refs: [DEVEX-334](https://linear.app/codercom/issue/DEVEX-334-flake-test-e2e-premium-and-test-e2e), https://github.com/coder/internal/issues/461

## Validation

The natural CSRF race is too rare to reproduce locally on either branch (30/30 on both). The new regression test isolates the bug from environmental flakiness.

| Condition | Test | N | Pass | Fail |
|---|---|---|---|---|
| **fix branch** | `updateWorkspace.spec.ts:76` (the test cited in the issue) | 30 | 30 | 0 |
| **fix branch** | `updateWorkspace.spec.ts:76`, `workers=4` | 50 | 50 | 0 |
| **fix branch** | `loginRedirect.spec.ts` (synthetic 400 on `/api/v2/authcheck`) | 50 | **50** | 0 |
| **main** | same `loginRedirect.spec.ts` test | 20 | 0 | **20** |
| **main** | `updateWorkspace.spec.ts:76`, parallel | 30 | 30 | 0 |

On `main`, the regression test fails with the byte-for-byte signature from [internal#461](https://github.com/coder/internal/issues/461):

```
Error: The page does not have the expected URL pathname.
Expected: "/workspaces"
Actual:   "/login"
   at helpers.ts:82
```

On the fix branch, the same test passes in roughly 1s.

Unit suite: 2933 pass, 2 skipped. `pnpm lint:types`, `biome check`, and `make lint/emdash` are clean.

<details>
<summary>Decision log</summary>

- Considered exempting `/api/v2/authcheck` from CSRF on the server (mirroring `/api/v2/users/first`) and rejected it: authcheck is authoritative for permissions and exempting it would weaken the CSRF posture without addressing the broader header-staleness bug.
- Considered keeping `checkAuthorization` inside `loginFn` but reordering it after the hard reload point. Rejected: same race window, and the hard reload already gets a fresh permissions fetch for free on the new document.
- Considered swapping the meta-tag lookup for the `csrf_token` cookie, but it is `HttpOnly`, so the client cannot read it.
- `EmbedContext.tsx` (VS Code embed flow) uses the same `data.permissions` pattern but authenticates via `setSessionToken` (header, not cookie), which exempts it from CSRF per `coderd/httpmw/csrf.go`. Out of scope.

</details>
