### PR TITLE
test(agent/agentcontext): use resolved temp dirs in symlink tests

### DIFF
--- a/agent/agentcontext/resolve_test.go
+++ b/agent/agentcontext/resolve_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/agent/agentcontext"
+	"github.com/coder/coder/v2/testutil"
 )
 
 func mustWriteFile(t *testing.T, path, content string) {
@@ -165,7 +166,7 @@ func TestResolver_SymlinkInsideScanRootAllowed(t *testing.T) {
 		t.Skip("symlinks require admin privileges on Windows runners")
 	}
 	t.Parallel()
-	dir := t.TempDir()
+	dir := testutil.TempDirResolved(t)
 	target := filepath.Join(dir, "docs", "AGENTS.md")
 	require.NoError(t, os.MkdirAll(filepath.Dir(target), 0o755))
 	mustWriteFile(t, target, "shared monorepo guidance")
@@ -196,7 +197,7 @@ func TestResolver_SymlinkedInstructionFilesDeduplicated(t *testing.T) {
 		t.Skip("symlinks require admin privileges on Windows runners")
 	}
 	t.Parallel()
-	dir := t.TempDir()
+	dir := testutil.TempDirResolved(t)
 	agents := filepath.Join(dir, "AGENTS.md")
 	mustWriteFile(t, agents, "the one true guidance")
 	require.NoError(t, os.Symlink(agents, filepath.Join(dir, "CLAUDE.md")))


### PR DESCRIPTION
These symlink resolver tests build expected paths from `t.TempDir()`, but the resolver canonicalizes symlink targets with `filepath.EvalSymlinks`.

On macOS, `/var` resolves to `/private/var`, so the raw temp dir path can disagree with the resolver output and flake. Use `testutil.TempDirResolved` in the symlink-sensitive tests so the expectations are canonicalized the same way.

In a followup, I'm considering adding a lint rule to block t.TempDir() altogether, in favour of `TempDirResolved`.

Closes https://github.com/coder/internal/issues/1574
Closes ENG-2849
