### PR TITLE
feat: add ai-gateway start command

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -59,6 +59,8 @@ var (
 	ErrSilent = xerrors.New("silent error")
 
 	errKeyringNotSupported = xerrors.New("keyring storage is not supported on this operating system; omit --use-keyring to use file-based storage")
+
+	ErrClientURLNotConfigured = xerrors.New("client URL is not configured")
 )
 
 const (
@@ -619,6 +621,45 @@ func (r *RootCmd) ensureClientURL() error {
 	}
 	r.clientURL, err = url.Parse(strings.TrimSpace(rawURL))
 	return err
+}
+
+// ResolveClientConnection resolves the deployment URL from --url/CODER_URL or
+// the on-disk config file, then builds an HTTP transport configured with the
+// global client TLS options. Unlike InitClient, it does not read or require a
+// session token, making it suitable for commands that authenticate with a
+// different credential.
+func (r *RootCmd) ResolveClientConnection() (*url.URL, http.RoundTripper, error) {
+	serverURL, err := r.resolveClientURL()
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := r.ensureTLSConfig(); err != nil {
+		return nil, nil, xerrors.Errorf("load client TLS config: %w", err)
+	}
+	transport, err := newHTTPTransport(r.tlsConfig)
+	if err != nil {
+		return nil, nil, xerrors.Errorf("create HTTP transport: %w", err)
+	}
+	return serverURL, transport, nil
+}
+
+func (r *RootCmd) resolveClientURL() (*url.URL, error) {
+	if r.clientURL != nil && r.clientURL.String() != "" {
+		return r.clientURL, nil
+	}
+
+	rawURL, err := r.createConfig().URL().Read()
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrClientURLNotConfigured
+		}
+		return nil, xerrors.Errorf("read configured URL: %w", err)
+	}
+	r.clientURL, err = url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return nil, xerrors.Errorf("parse configured URL: %w", err)
+	}
+	return r.clientURL, nil
 }
 
 // ensureTLSConfig loads the TLS configuration from files if specified.

--- a/cli/root.go
+++ b/cli/root.go
@@ -604,43 +604,18 @@ func (r *RootCmd) SetClock(clk quartz.Clock) {
 // ensureClientURL loads the client URL from the config file if it
 // wasn't provided via --url or CODER_URL.
 func (r *RootCmd) ensureClientURL() error {
-	if r.clientURL != nil && r.clientURL.String() != "" {
-		return nil
+	u, err := r.resolveClientURL()
+	if err == nil {
+		r.clientURL = u
 	}
-	rawURL, err := r.createConfig().URL().Read()
-	// If the configuration files are absent, the user is logged out.
-	if os.IsNotExist(err) {
-		binPath, err := os.Executable()
-		if err != nil {
+	if errors.Is(err, ErrClientURLNotConfigured) {
+		binPath, execErr := os.Executable()
+		if execErr != nil {
 			binPath = "coder"
 		}
 		return xerrors.Errorf(notLoggedInMessage, binPath)
 	}
-	if err != nil {
-		return err
-	}
-	r.clientURL, err = url.Parse(strings.TrimSpace(rawURL))
 	return err
-}
-
-// ResolveClientConnection resolves the deployment URL from --url/CODER_URL or
-// the on-disk config file, then builds an HTTP transport configured with the
-// global client TLS options. Unlike InitClient, it does not read or require a
-// session token, making it suitable for commands that authenticate with a
-// different credential.
-func (r *RootCmd) ResolveClientConnection() (*url.URL, http.RoundTripper, error) {
-	serverURL, err := r.resolveClientURL()
-	if err != nil {
-		return nil, nil, err
-	}
-	if err := r.ensureTLSConfig(); err != nil {
-		return nil, nil, xerrors.Errorf("load client TLS config: %w", err)
-	}
-	transport, err := newHTTPTransport(r.tlsConfig)
-	if err != nil {
-		return nil, nil, xerrors.Errorf("create HTTP transport: %w", err)
-	}
-	return serverURL, transport, nil
 }
 
 func (r *RootCmd) resolveClientURL() (*url.URL, error) {
@@ -655,11 +630,28 @@ func (r *RootCmd) resolveClientURL() (*url.URL, error) {
 		}
 		return nil, xerrors.Errorf("read configured URL: %w", err)
 	}
-	r.clientURL, err = url.Parse(strings.TrimSpace(rawURL))
+	parsedURL, err := url.Parse(strings.TrimSpace(rawURL))
 	if err != nil {
 		return nil, xerrors.Errorf("parse configured URL: %w", err)
 	}
-	return r.clientURL, nil
+	return parsedURL, nil
+}
+
+// ResolveClientConnection resolves the deployment URL and client TLS transport
+// without reading or requiring a user session.
+func (r *RootCmd) ResolveClientConnection() (*url.URL, http.RoundTripper, error) {
+	serverURL, err := r.resolveClientURL()
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := r.ensureTLSConfig(); err != nil {
+		return nil, nil, xerrors.Errorf("load client TLS config: %w", err)
+	}
+	transport, err := newHTTPTransport(r.tlsConfig)
+	if err != nil {
+		return nil, nil, xerrors.Errorf("create HTTP transport: %w", err)
+	}
+	return serverURL, transport, nil
 }
 
 // ensureTLSConfig loads the TLS configuration from files if specified.

--- a/cli/root.go
+++ b/cli/root.go
@@ -625,7 +625,7 @@ func (r *RootCmd) resolveClientURL() (*url.URL, error) {
 
 	rawURL, err := r.createConfig().URL().Read()
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil, ErrClientURLNotConfigured
 		}
 		return nil, xerrors.Errorf("read configured URL: %w", err)

--- a/cli/root.go
+++ b/cli/root.go
@@ -605,9 +605,7 @@ func (r *RootCmd) SetClock(clk quartz.Clock) {
 // wasn't provided via --url or CODER_URL.
 func (r *RootCmd) ensureClientURL() error {
 	u, err := r.resolveClientURL()
-	if err == nil {
-		r.clientURL = u
-	}
+
 	if errors.Is(err, ErrClientURLNotConfigured) {
 		binPath, execErr := os.Executable()
 		if execErr != nil {
@@ -615,7 +613,13 @@ func (r *RootCmd) ensureClientURL() error {
 		}
 		return xerrors.Errorf(notLoggedInMessage, binPath)
 	}
-	return err
+
+	if err != nil {
+		return err
+	}
+
+	r.clientURL = u
+	return nil
 }
 
 func (r *RootCmd) resolveClientURL() (*url.URL, error) {

--- a/cli/root.go
+++ b/cli/root.go
@@ -58,9 +58,9 @@ var (
 	// anything.
 	ErrSilent = xerrors.New("silent error")
 
-	errKeyringNotSupported = xerrors.New("keyring storage is not supported on this operating system; omit --use-keyring to use file-based storage")
-
 	ErrClientURLNotConfigured = xerrors.New("client URL is not configured")
+
+	errKeyringNotSupported = xerrors.New("keyring storage is not supported on this operating system; omit --use-keyring to use file-based storage")
 )
 
 const (

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -201,27 +201,27 @@ func TestResolveClientConnection(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			var configure func(config.Root)
-			if tt.configure != nil {
+			if tc.configure != nil {
 				configure = func(cfg config.Root) {
-					tt.configure(t, cfg)
+					tc.configure(t, cfg)
 				}
 			}
 
-			serverURL, transport, err := run(t, configure, tt.args...)
-			if tt.wantErr != "" {
-				require.ErrorContains(t, err, tt.wantErr)
+			serverURL, transport, err := run(t, configure, tc.args...)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
 				require.NoError(t, err)
 			}
-			require.Equal(t, tt.wantURL, serverURL)
-			require.Equal(t, tt.wantTransport, transport != nil)
-			if tt.checkTransport != nil {
-				tt.checkTransport(t, transport)
+			require.Equal(t, tc.wantURL, serverURL)
+			require.Equal(t, tc.wantTransport, transport != nil)
+			if tc.checkTransport != nil {
+				tc.checkTransport(t, transport)
 			}
 		})
 	}

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/cli"
 	"github.com/coder/coder/v2/cli/clitest"
+	"github.com/coder/coder/v2/cli/config"
 	"github.com/coder/coder/v2/coderd"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/codersdk"
@@ -103,6 +104,127 @@ func TestCommandHelp(t *testing.T) {
 			Cmd:  []string{"exp", "sync", "list", "--help"},
 		},
 	))
+}
+
+func TestResolveClientConnection(t *testing.T) {
+	t.Parallel()
+
+	run := func(t *testing.T, configure func(config.Root), args ...string) (string, http.RoundTripper, error) {
+		t.Helper()
+
+		var root cli.RootCmd
+		var gotURL string
+		var gotTransport http.RoundTripper
+		var gotErr error
+		cmd, err := root.Command([]*serpent.Command{{
+			Use: "resolve",
+			Handler: func(*serpent.Invocation) error {
+				serverURL, transport, err := root.ResolveClientConnection()
+				if serverURL != nil {
+					gotURL = serverURL.String()
+				}
+				gotTransport = transport
+				gotErr = err
+				return nil
+			},
+		}})
+		require.NoError(t, err)
+
+		inv, cfg := clitest.NewWithCommand(t, cmd, args...)
+		if configure != nil {
+			configure(cfg)
+		}
+		require.NoError(t, inv.Run())
+		return gotURL, gotTransport, gotErr
+	}
+
+	tests := []struct {
+		name           string
+		args           []string
+		configure      func(*testing.T, config.Root)
+		wantURL        string
+		wantTransport  bool
+		wantErr        string
+		checkTransport func(*testing.T, http.RoundTripper)
+	}{
+		{
+			name:    "MissingURL",
+			args:    []string{"resolve"},
+			wantErr: cli.ErrClientURLNotConfigured.Error(),
+		},
+		{
+			name:          "URLFlag",
+			args:          []string{"--url", "https://example.com", "resolve"},
+			wantURL:       "https://example.com",
+			wantTransport: true,
+		},
+		{
+			name: "ConfiguredURL",
+			args: []string{"resolve"},
+			configure: func(t *testing.T, cfg config.Root) {
+				t.Helper()
+				require.NoError(t, cfg.URL().Write("https://configured.example.com"))
+			},
+			wantURL:       "https://configured.example.com",
+			wantTransport: true,
+		},
+		{
+			name: "ClientTLSConfig",
+			args: func() []string {
+				certPath, keyPath := generateTLSCertificate(t)
+				return []string{
+					"--url", "https://example.com",
+					"--client-tls-cert-file", certPath,
+					"--client-tls-key-file", keyPath,
+					"resolve",
+				}
+			}(),
+			wantURL:       "https://example.com",
+			wantTransport: true,
+			checkTransport: func(t *testing.T, transport http.RoundTripper) {
+				t.Helper()
+
+				httpTransport, ok := transport.(*http.Transport)
+				require.True(t, ok)
+				require.NotNil(t, httpTransport.TLSClientConfig)
+				require.Len(t, httpTransport.TLSClientConfig.Certificates, 1)
+			},
+		},
+		{
+			name: "TLSConfigError",
+			args: []string{
+				"--url", "https://example.com",
+				"--client-tls-cert-file", "/tmp/missing-cert.pem",
+				"resolve",
+			},
+			wantErr: "load client TLS config: --client-tls-cert-file and --client-tls-key-file must be specified together",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var configure func(config.Root)
+			if tt.configure != nil {
+				configure = func(cfg config.Root) {
+					tt.configure(t, cfg)
+				}
+			}
+
+			serverURL, transport, err := run(t, configure, tt.args...)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.wantURL, serverURL)
+			require.Equal(t, tt.wantTransport, transport != nil)
+			if tt.checkTransport != nil {
+				tt.checkTransport(t, transport)
+			}
+		})
+	}
 }
 
 func TestRoot(t *testing.T) {

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -109,7 +109,7 @@ func TestCommandHelp(t *testing.T) {
 func TestResolveClientConnection(t *testing.T) {
 	t.Parallel()
 
-	run := func(t *testing.T, configure func(config.Root), args ...string) (string, http.RoundTripper, error) {
+	run := func(t *testing.T, configure func(config.Root), args ...string) (string, http.RoundTripper, error, error) {
 		t.Helper()
 
 		var root cli.RootCmd
@@ -134,8 +134,8 @@ func TestResolveClientConnection(t *testing.T) {
 		if configure != nil {
 			configure(cfg)
 		}
-		require.NoError(t, inv.Run())
-		return gotURL, gotTransport, gotErr
+		runErr := inv.Run()
+		return gotURL, gotTransport, gotErr, runErr
 	}
 
 	tests := []struct {
@@ -145,6 +145,7 @@ func TestResolveClientConnection(t *testing.T) {
 		wantURL        string
 		wantTransport  bool
 		wantErr        string
+		wantRunErr     string
 		checkTransport func(*testing.T, http.RoundTripper)
 	}{
 		{
@@ -167,6 +168,21 @@ func TestResolveClientConnection(t *testing.T) {
 			},
 			wantURL:       "https://configured.example.com",
 			wantTransport: true,
+		},
+		{
+			name: "URLFlagOverridesConfig",
+			args: []string{"--url", "https://flag.example.com", "resolve"},
+			configure: func(t *testing.T, cfg config.Root) {
+				t.Helper()
+				require.NoError(t, cfg.URL().Write("https://configured.example.com"))
+			},
+			wantURL:       "https://flag.example.com",
+			wantTransport: true,
+		},
+		{
+			name:       "InvalidURLFlag",
+			args:       []string{"--url", "%zz", "resolve"},
+			wantRunErr: "invalid URL escape",
 		},
 		{
 			name: "ClientTLSConfig",
@@ -212,7 +228,12 @@ func TestResolveClientConnection(t *testing.T) {
 				}
 			}
 
-			serverURL, transport, err := run(t, configure, tc.args...)
+			serverURL, transport, err, runErr := run(t, configure, tc.args...)
+			if tc.wantRunErr != "" {
+				require.ErrorContains(t, runErr, tc.wantRunErr)
+				return
+			}
+			require.NoError(t, runErr)
 			if tc.wantErr != "" {
 				require.ErrorContains(t, err, tc.wantErr)
 			} else {

--- a/coderd/aibridged/aibridged.go
+++ b/coderd/aibridged/aibridged.go
@@ -151,7 +151,13 @@ connectLoop:
 }
 
 func (s *Server) Client() (DRPCClient, error) {
+	return s.ClientContext(context.Background())
+}
+
+func (s *Server) ClientContext(ctx context.Context) (DRPCClient, error) {
 	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	case <-s.lifecycleCtx.Done():
 		if cause := context.Cause(s.lifecycleCtx); cause != nil {
 			return nil, cause

--- a/coderd/aibridged/aibridged.go
+++ b/coderd/aibridged/aibridged.go
@@ -105,12 +105,18 @@ connectLoop:
 				return
 			}
 			var sdkErr *codersdk.Error
-			// If something is wrong with our auth, stop trying to connect.
-			if errors.As(err, &sdkErr) && sdkErr.StatusCode() == http.StatusForbidden {
-				err = xerrors.Errorf("dial coderd: %w", err)
-				s.logger.Error(s.lifecycleCtx, "not authorized to dial coderd", slog.Error(err))
-				s.cancelFn(err)
-				return
+			// If something is wrong with configuration, stop trying to connect.
+			if errors.As(err, &sdkErr) {
+				switch sdkErr.StatusCode() {
+				// These statuses are returned by the /api/v2/ai-gateway/serve
+				// (wrong Gateway key or incompatible API versions)
+				// or FeatureAIBridge check the WebSocket upgrade.
+				case http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden:
+					err = xerrors.Errorf("dial coderd: %w", err)
+					s.logger.Error(s.lifecycleCtx, "fatal error dialing coderd", slog.Error(err))
+					s.cancelFn(err)
+					return
+				}
 			}
 			if s.isShutdown() {
 				return

--- a/coderd/aibridged/aibridged.go
+++ b/coderd/aibridged/aibridged.go
@@ -108,9 +108,8 @@ connectLoop:
 			// If something is wrong with configuration, stop trying to connect.
 			if errors.As(err, &sdkErr) {
 				switch sdkErr.StatusCode() {
-				// These statuses are returned by the /api/v2/ai-gateway/serve
-				// (wrong Gateway key or incompatible API versions)
-				// or FeatureAIBridge check the WebSocket upgrade.
+				// These statuses are returned by the /api/v2/ai-gateway/serve (wrong Gateway key or incompatible API versions)
+				// or FeatureAIBridge check.
 				case http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden:
 					err = xerrors.Errorf("dial coderd: %w", err)
 					s.logger.Error(s.lifecycleCtx, "fatal error dialing coderd", slog.Error(err))

--- a/coderd/aibridged/aibridged.go
+++ b/coderd/aibridged/aibridged.go
@@ -150,6 +150,20 @@ connectLoop:
 	}
 }
 
+// Done returns a channel that is closed when the server lifecycle ends.
+// It closes on explicit shutdown and on fatal connection-loop exit.
+func (s *Server) Done() <-chan struct{} {
+	return s.lifecycleCtx.Done()
+}
+
+// Err returns the reason the server lifecycle ended.
+func (s *Server) Err() error {
+	if cause := context.Cause(s.lifecycleCtx); cause != nil {
+		return cause
+	}
+	return s.lifecycleCtx.Err()
+}
+
 func (s *Server) Client() (DRPCClient, error) {
 	return s.ClientContext(context.Background())
 }
@@ -158,9 +172,9 @@ func (s *Server) ClientContext(ctx context.Context) (DRPCClient, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
-	case <-s.lifecycleCtx.Done():
-		if cause := context.Cause(s.lifecycleCtx); cause != nil {
-			return nil, cause
+	case <-s.Done():
+		if err := s.Err(); err != nil {
+			return nil, err
 		}
 		return nil, xerrors.New("context closed")
 	case client := <-s.clientCh:

--- a/coderd/aibridged/aibridged.go
+++ b/coderd/aibridged/aibridged.go
@@ -42,10 +42,11 @@ type Server struct {
 	initConnectionCh   chan struct{}
 	initConnectionOnce sync.Once
 
-	// lifecycleCtx is canceled when we start closing.
+	// lifecycleCtx is canceled when we start closing or when the
+	// connection loop exits permanently.
 	lifecycleCtx context.Context
-	// cancelFn closes the lifecycleCtx.
-	cancelFn func()
+	// cancelFn closes the lifecycleCtx with the reason it closed.
+	cancelFn context.CancelCauseFunc
 
 	shutdownOnce sync.Once
 }
@@ -55,7 +56,7 @@ func New(ctx context.Context, pool Pooler, rpcDialer Dialer, logger slog.Logger,
 		return nil, xerrors.Errorf("nil rpcDialer given")
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancelCause(ctx)
 	daemon := &Server{
 		logger:           logger,
 		tracer:           tracer,
@@ -78,6 +79,11 @@ func New(ctx context.Context, pool Pooler, rpcDialer Dialer, logger slog.Logger,
 func (s *Server) connect() {
 	defer s.logger.Debug(s.lifecycleCtx, "connect loop exited")
 	defer s.wg.Done()
+	defer func() {
+		if s.lifecycleCtx.Err() == nil {
+			s.cancelFn(xerrors.New("connect loop exited"))
+		}
+	}()
 
 	logConnect := s.logger.With(slog.F("context", "aibridged.server")).Debug
 	// An exponential back-off occurs when the connection is failing to dial.
@@ -93,12 +99,17 @@ connectLoop:
 		client, err := s.clientDialer(s.lifecycleCtx)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
+				if s.lifecycleCtx.Err() == nil {
+					s.cancelFn(err)
+				}
 				return
 			}
 			var sdkErr *codersdk.Error
 			// If something is wrong with our auth, stop trying to connect.
 			if errors.As(err, &sdkErr) && sdkErr.StatusCode() == http.StatusForbidden {
+				err = xerrors.Errorf("dial coderd: %w", err)
 				s.logger.Error(s.lifecycleCtx, "not authorized to dial coderd", slog.Error(err))
+				s.cancelFn(err)
 				return
 			}
 			if s.isShutdown() {
@@ -136,6 +147,9 @@ connectLoop:
 func (s *Server) Client() (DRPCClient, error) {
 	select {
 	case <-s.lifecycleCtx.Done():
+		if cause := context.Cause(s.lifecycleCtx); cause != nil {
+			return nil, cause
+		}
 		return nil, xerrors.New("context closed")
 	case client := <-s.clientCh:
 		return client, nil
@@ -170,7 +184,7 @@ func (s *Server) isShutdown() bool {
 func (s *Server) Shutdown(ctx context.Context) error {
 	var err error
 	s.shutdownOnce.Do(func() {
-		s.cancelFn()
+		s.cancelFn(context.Canceled)
 
 		// Wait for any outstanding connections to terminate.
 		s.wg.Wait()

--- a/coderd/aibridged/aibridged.go
+++ b/coderd/aibridged/aibridged.go
@@ -16,7 +16,11 @@ import (
 	"github.com/coder/retry"
 )
 
-var _ io.Closer = &Server{}
+var (
+	_ io.Closer = &Server{}
+
+	ErrShutdown = xerrors.New("aibridged server shutdown")
+)
 
 // Server provides the AI Bridge functionality.
 // It is responsible for:
@@ -108,13 +112,15 @@ connectLoop:
 			// If something is wrong with configuration, stop trying to connect.
 			if errors.As(err, &sdkErr) {
 				switch sdkErr.StatusCode() {
-				// These statuses are returned by the /api/v2/ai-gateway/serve (wrong Gateway key or incompatible API versions)
-				// or FeatureAIBridge check.
+				// These statuses are terminal failures from the /api/v2/ai-gateway/serve
+				// handshake: wrong gateway key, incompatible API version, or entitlement failure.
 				case http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden:
 					err = xerrors.Errorf("dial coderd: %w", err)
 					s.logger.Error(s.lifecycleCtx, "fatal error dialing coderd", slog.Error(err))
 					s.cancelFn(err)
 					return
+				default:
+					err = xerrors.Errorf("unexpected HTTP response dialing coderd: %w", err)
 				}
 			}
 			if s.isShutdown() {
@@ -209,7 +215,7 @@ func (s *Server) isShutdown() bool {
 func (s *Server) Shutdown(ctx context.Context) error {
 	var err error
 	s.shutdownOnce.Do(func() {
-		s.cancelFn(context.Canceled)
+		s.cancelFn(ErrShutdown)
 
 		// Wait for any outstanding connections to terminate.
 		s.wg.Wait()

--- a/coderd/aibridged/aibridged_test.go
+++ b/coderd/aibridged/aibridged_test.go
@@ -135,7 +135,33 @@ func TestServeHTTP_FailureModes(t *testing.T) {
 
 		// Coderd connection-related failures.
 		{
-			name: "fatal dial error",
+			name: "fatal bad request dial error",
+			dialerFn: func(context.Context) (aibridged.DRPCClient, error) {
+				return nil, codersdk.ReadBodyAsError(&http.Response{
+					StatusCode: http.StatusBadRequest,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(bytes.NewBufferString(`{"message":"bad request"}`)),
+				})
+			},
+			ignoreLogs:     true,
+			expectedErr:    aibridged.ErrConnect,
+			expectedStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name: "fatal unauthorized dial error",
+			dialerFn: func(context.Context) (aibridged.DRPCClient, error) {
+				return nil, codersdk.ReadBodyAsError(&http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(bytes.NewBufferString(`{"message":"unauthorized"}`)),
+				})
+			},
+			ignoreLogs:     true,
+			expectedErr:    aibridged.ErrConnect,
+			expectedStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name: "fatal forbidden dial error",
 			dialerFn: func(context.Context) (aibridged.DRPCClient, error) {
 				return nil, codersdk.ReadBodyAsError(&http.Response{
 					StatusCode: http.StatusForbidden,

--- a/coderd/aibridged/aibridged_test.go
+++ b/coderd/aibridged/aibridged_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/uuid"
@@ -84,6 +85,39 @@ func (*mockDRPCConn) NewStream(ctx context.Context, rpc string, enc drpc.Encodin
 	return nil, nil
 }
 
+func sdkError(status int, message string) error {
+	return codersdk.ReadBodyAsError(&http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewBufferString(`{"message":"` + message + `"}`)),
+	})
+}
+
+func TestClient_TransientDialErrorRetries(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	ctrl := gomock.NewController(t)
+	client := mock.NewMockDRPCClient(ctrl)
+	client.EXPECT().DRPCConn().AnyTimes().Return(&mockDRPCConn{})
+	pool := mock.NewMockPooler(ctrl)
+	pool.EXPECT().Shutdown(gomock.Any()).MinTimes(1).Return(nil)
+	dialFc := func(context.Context) (aibridged.DRPCClient, error) {
+		if calls.Add(1) == 1 {
+			return nil, sdkError(http.StatusInternalServerError, "internal error")
+		}
+		return client, nil
+	}
+
+	srv, err := aibridged.New(t.Context(), pool, dialFc, slogtest.Make(t, nil), testTracer)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+
+	_, err = srv.ClientContext(testutil.Context(t, testutil.WaitShort))
+	require.NoError(t, err)
+	require.Equal(t, int32(2), calls.Load())
+}
+
 func TestServeHTTP_FailureModes(t *testing.T) {
 	t.Parallel()
 
@@ -137,11 +171,7 @@ func TestServeHTTP_FailureModes(t *testing.T) {
 		{
 			name: "fatal bad request dial error",
 			dialerFn: func(context.Context) (aibridged.DRPCClient, error) {
-				return nil, codersdk.ReadBodyAsError(&http.Response{
-					StatusCode: http.StatusBadRequest,
-					Header:     http.Header{"Content-Type": []string{"application/json"}},
-					Body:       io.NopCloser(bytes.NewBufferString(`{"message":"bad request"}`)),
-				})
+				return nil, sdkError(http.StatusBadRequest, "bad request")
 			},
 			ignoreLogs:     true,
 			expectedErr:    aibridged.ErrConnect,
@@ -150,11 +180,7 @@ func TestServeHTTP_FailureModes(t *testing.T) {
 		{
 			name: "fatal unauthorized dial error",
 			dialerFn: func(context.Context) (aibridged.DRPCClient, error) {
-				return nil, codersdk.ReadBodyAsError(&http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Header:     http.Header{"Content-Type": []string{"application/json"}},
-					Body:       io.NopCloser(bytes.NewBufferString(`{"message":"unauthorized"}`)),
-				})
+				return nil, sdkError(http.StatusUnauthorized, "unauthorized")
 			},
 			ignoreLogs:     true,
 			expectedErr:    aibridged.ErrConnect,
@@ -163,11 +189,7 @@ func TestServeHTTP_FailureModes(t *testing.T) {
 		{
 			name: "fatal forbidden dial error",
 			dialerFn: func(context.Context) (aibridged.DRPCClient, error) {
-				return nil, codersdk.ReadBodyAsError(&http.Response{
-					StatusCode: http.StatusForbidden,
-					Header:     http.Header{"Content-Type": []string{"application/json"}},
-					Body:       io.NopCloser(bytes.NewBufferString(`{"message":"forbidden"}`)),
-				})
+				return nil, sdkError(http.StatusForbidden, "forbidden")
 			},
 			ignoreLogs:     true,
 			expectedErr:    aibridged.ErrConnect,

--- a/coderd/aibridged/aibridged_test.go
+++ b/coderd/aibridged/aibridged_test.go
@@ -40,8 +40,13 @@ func singleKeyPool(t *testing.T, name, key string) *keypool.Pool {
 
 func newTestServer(t *testing.T) (*aibridged.Server, *mock.MockDRPCClient, *mock.MockPooler) {
 	t.Helper()
+	return newTestServerWithDialer(t, nil, nil)
+}
 
-	logger := slogtest.Make(t, nil)
+func newTestServerWithDialer(t *testing.T, dialer aibridged.Dialer, loggerOptions *slogtest.Options) (*aibridged.Server, *mock.MockDRPCClient, *mock.MockPooler) {
+	t.Helper()
+
+	logger := slogtest.Make(t, loggerOptions)
 	ctrl := gomock.NewController(t)
 	client := mock.NewMockDRPCClient(ctrl)
 	pool := mock.NewMockPooler(ctrl)
@@ -50,12 +55,12 @@ func newTestServer(t *testing.T) (*aibridged.Server, *mock.MockDRPCClient, *mock
 	client.EXPECT().DRPCConn().AnyTimes().Return(conn)
 	pool.EXPECT().Shutdown(gomock.Any()).MinTimes(1).Return(nil)
 
-	srv, err := aibridged.New(
-		t.Context(),
-		pool,
-		func(ctx context.Context) (aibridged.DRPCClient, error) {
+	if dialer == nil {
+		dialer = func(ctx context.Context) (aibridged.DRPCClient, error) {
 			return client, nil
-		}, logger, testTracer)
+		}
+	}
+	srv, err := aibridged.New(t.Context(), pool, dialer, logger, testTracer)
 	require.NoError(t, err, "create new aibridged")
 	t.Cleanup(func() {
 		srv.Shutdown(context.Background())
@@ -91,6 +96,7 @@ func TestServeHTTP_FailureModes(t *testing.T) {
 		applyMocksFn   func(client *mock.MockDRPCClient, pool *mock.MockPooler)
 		dialerFn       aibridged.Dialer
 		contextFn      func() context.Context
+		ignoreLogs     bool
 		expectedErr    error
 		expectedStatus int
 	}{
@@ -127,7 +133,20 @@ func TestServeHTTP_FailureModes(t *testing.T) {
 			expectedStatus: http.StatusForbidden,
 		},
 
-		// TODO: coderd connection-related failures.
+		// Coderd connection-related failures.
+		{
+			name: "fatal dial error",
+			dialerFn: func(context.Context) (aibridged.DRPCClient, error) {
+				return nil, codersdk.ReadBodyAsError(&http.Response{
+					StatusCode: http.StatusForbidden,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(bytes.NewBufferString(`{"message":"forbidden"}`)),
+				})
+			},
+			ignoreLogs:     true,
+			expectedErr:    aibridged.ErrConnect,
+			expectedStatus: http.StatusServiceUnavailable,
+		},
 
 		// Budget-related failures.
 		{
@@ -173,7 +192,11 @@ func TestServeHTTP_FailureModes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			srv, client, pool := newTestServer(t)
+			var loggerOptions *slogtest.Options
+			if tc.ignoreLogs {
+				loggerOptions = &slogtest.Options{IgnoreErrors: true}
+			}
+			srv, client, pool := newTestServerWithDialer(t, tc.dialerFn, loggerOptions)
 			conn := &mockDRPCConn{}
 			client.EXPECT().DRPCConn().AnyTimes().Return(conn)
 

--- a/coderd/aibridged/dialer.go
+++ b/coderd/aibridged/dialer.go
@@ -1,0 +1,90 @@
+package aibridged
+
+import (
+	"context"
+	"io"
+	"net/http"
+
+	"github.com/hashicorp/yamux"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/buildinfo"
+	aibridgedproto "github.com/coder/coder/v2/coderd/aibridged/proto"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/codersdk/drpcsdk"
+	"github.com/coder/websocket"
+)
+
+// NewWebsocketDialer returns a [Dialer] that connects a standalone AI
+// Gateway to coderd's /api/v2/ai-gateway/serve endpoint over a WebSocket,
+// multiplexes it with yamux, and exposes the aibridged DRPC services
+// (Recorder, MCPConfigurator, Authorizer, ProviderConfigurator) over it.
+// This is the standalone counterpart to API.CreateInMemoryAIBridgeServer,
+// which wires the same services over an in-memory pipe for the embedded
+// daemon.
+//
+// It mirrors codersdk.Client.ServeProvisionerDaemon: the gateway
+// authenticates with an AI Gateway key (codersdk.AIGatewayKeyHeader),
+// advertises its API version via the "version" query parameter, and
+// reports its build version via codersdk.BuildVersionHeader (used by
+// coderd for observability only). TLS for this connection is governed by
+// the scheme of the client's URL (standard Go TLS).
+//
+// On a failed upgrade the coderd HTTP error is returned as a
+// *codersdk.Error so [Server.connect] can distinguish fatal
+// auth/entitlement failures from transient ones.
+func NewWebsocketDialer(client *codersdk.Client, key string) Dialer {
+	return func(ctx context.Context) (DRPCClient, error) {
+		serverURL, err := client.URL.Parse("/api/v2/ai-gateway/serve")
+		if err != nil {
+			return nil, xerrors.Errorf("parse url: %w", err)
+		}
+		query := serverURL.Query()
+		query.Add("version", aibridgedproto.CurrentVersion.String())
+		serverURL.RawQuery = query.Encode()
+
+		headers := http.Header{}
+		headers.Set(codersdk.BuildVersionHeader, buildinfo.Version())
+		headers.Set(codersdk.AIGatewayKeyHeader, key)
+
+		httpClient := &http.Client{
+			Transport: client.HTTPClient.Transport,
+		}
+		// nolint:bodyclose // ReadBodyAsError closes the body; success path hands off to the websocket conn.
+		conn, res, err := websocket.Dial(ctx, serverURL.String(), &websocket.DialOptions{
+			HTTPClient: httpClient,
+			// Need to disable compression to avoid a data-race.
+			CompressionMode: websocket.CompressionDisabled,
+			HTTPHeader:      headers,
+		})
+		if err != nil {
+			if res == nil {
+				return nil, err
+			}
+			return nil, codersdk.ReadBodyAsError(res)
+		}
+		// Align with yamux's default stream window size.
+		conn.SetReadLimit(drpcsdk.YamuxDefaultStreamWindowSize)
+
+		config := yamux.DefaultConfig()
+		config.LogOutput = io.Discard
+		// Use a background context because the caller closes the client
+		// (and thus the multiplexed session) explicitly.
+		_, wsNetConn := codersdk.WebsocketNetConn(context.Background(), conn, websocket.MessageBinary)
+		session, err := yamux.Client(wsNetConn, config)
+		if err != nil {
+			_ = conn.Close(websocket.StatusGoingAway, "")
+			_ = wsNetConn.Close()
+			return nil, xerrors.Errorf("multiplex client: %w", err)
+		}
+
+		dconn := drpcsdk.MultiplexedConn(session)
+		return &Client{
+			Conn:                           dconn,
+			DRPCRecorderClient:             aibridgedproto.NewDRPCRecorderClient(dconn),
+			DRPCMCPConfiguratorClient:      aibridgedproto.NewDRPCMCPConfiguratorClient(dconn),
+			DRPCAuthorizerClient:           aibridgedproto.NewDRPCAuthorizerClient(dconn),
+			DRPCProviderConfiguratorClient: aibridgedproto.NewDRPCProviderConfiguratorClient(dconn),
+		}, nil
+	}
+}

--- a/coderd/aibridged/dialer.go
+++ b/coderd/aibridged/dialer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/hashicorp/yamux"
 	"golang.org/x/xerrors"
@@ -23,35 +24,35 @@ import (
 // which wires the same services over an in-memory pipe for the embedded
 // daemon.
 //
-// It mirrors codersdk.Client.ServeProvisionerDaemon: the gateway
-// authenticates with an AI Gateway key (codersdk.AIGatewayKeyHeader),
-// advertises its API version via the "version" query parameter, and
-// reports its build version via codersdk.BuildVersionHeader (used by
-// coderd for observability only). TLS for this connection is governed by
-// the scheme of the client's URL (standard Go TLS).
+// The gateway authenticates with an AI Gateway key
+// (codersdk.AIGatewayKeyHeader), advertises its API version via the
+// "version" query parameter, and reports its build version via
+// codersdk.BuildVersionHeader (used by coderd for observability only).
+// TLS for this connection is governed by the scheme of serverURL and any
+// TLS configuration baked into transport.
 //
 // On a failed upgrade the coderd HTTP error is returned as a
 // *codersdk.Error so [Server.connect] can distinguish fatal
 // auth/entitlement failures from transient ones.
-func NewWebsocketDialer(client *codersdk.Client, key string) Dialer {
+func NewWebsocketDialer(serverURL *url.URL, transport http.RoundTripper, key string) Dialer {
 	return func(ctx context.Context) (DRPCClient, error) {
-		serverURL, err := client.URL.Parse("/api/v2/ai-gateway/serve")
+		serveURL, err := serverURL.Parse("/api/v2/ai-gateway/serve")
 		if err != nil {
 			return nil, xerrors.Errorf("parse url: %w", err)
 		}
-		query := serverURL.Query()
+		query := serveURL.Query()
 		query.Add(aibridgedproto.VersionQueryParam, aibridgedproto.CurrentVersion.String())
-		serverURL.RawQuery = query.Encode()
+		serveURL.RawQuery = query.Encode()
 
 		headers := http.Header{}
 		headers.Set(codersdk.BuildVersionHeader, buildinfo.Version())
 		headers.Set(codersdk.AIGatewayKeyHeader, key)
 
 		httpClient := &http.Client{
-			Transport: client.HTTPClient.Transport,
+			Transport: transport,
 		}
 		// nolint:bodyclose // ReadBodyAsError closes the body; success path hands off to the websocket conn.
-		conn, res, err := websocket.Dial(ctx, serverURL.String(), &websocket.DialOptions{
+		conn, res, err := websocket.Dial(ctx, serveURL.String(), &websocket.DialOptions{
 			HTTPClient:      httpClient,
 			CompressionMode: websocket.CompressionDisabled,
 			HTTPHeader:      headers,

--- a/coderd/aibridged/dialer.go
+++ b/coderd/aibridged/dialer.go
@@ -52,8 +52,7 @@ func NewWebsocketDialer(client *codersdk.Client, key string) Dialer {
 		}
 		// nolint:bodyclose // ReadBodyAsError closes the body; success path hands off to the websocket conn.
 		conn, res, err := websocket.Dial(ctx, serverURL.String(), &websocket.DialOptions{
-			HTTPClient: httpClient,
-			// Need to disable compression to avoid a data-race.
+			HTTPClient:      httpClient,
 			CompressionMode: websocket.CompressionDisabled,
 			HTTPHeader:      headers,
 		})
@@ -63,14 +62,12 @@ func NewWebsocketDialer(client *codersdk.Client, key string) Dialer {
 			}
 			return nil, codersdk.ReadBodyAsError(res)
 		}
-		// Align with yamux's default stream window size.
-		conn.SetReadLimit(drpcsdk.YamuxDefaultStreamWindowSize)
-
 		config := yamux.DefaultConfig()
 		config.LogOutput = io.Discard
 		// Use a background context because the caller closes the client
 		// (and thus the multiplexed session) explicitly.
 		_, wsNetConn := codersdk.WebsocketNetConn(context.Background(), conn, websocket.MessageBinary)
+		conn.SetReadLimit(drpcsdk.YamuxDefaultStreamWindowSize)
 		session, err := yamux.Client(wsNetConn, config)
 		if err != nil {
 			_ = conn.Close(websocket.StatusGoingAway, "")

--- a/coderd/aibridged/dialer.go
+++ b/coderd/aibridged/dialer.go
@@ -40,7 +40,7 @@ func NewWebsocketDialer(client *codersdk.Client, key string) Dialer {
 			return nil, xerrors.Errorf("parse url: %w", err)
 		}
 		query := serverURL.Query()
-		query.Add("version", aibridgedproto.CurrentVersion.String())
+		query.Add(aibridgedproto.VersionQueryParam, aibridgedproto.CurrentVersion.String())
 		serverURL.RawQuery = query.Encode()
 
 		headers := http.Header{}

--- a/coderd/aibridged/dialer.go
+++ b/coderd/aibridged/dialer.go
@@ -2,6 +2,7 @@ package aibridged
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
@@ -34,6 +35,18 @@ import (
 // On a failed upgrade the coderd HTTP error is returned as a
 // *codersdk.Error so [Server.connect] can distinguish fatal
 // auth/entitlement failures from transient ones.
+func readAIGatewayServeError(res *http.Response) error {
+	err := codersdk.ReadBodyAsError(res)
+
+	var sdkErr *codersdk.Error
+	if errors.As(err, &sdkErr) && res.StatusCode == http.StatusUnauthorized {
+		// /ai-gateway/serve authenticates with an AI Gateway key, not a user
+		// session. Generic user-login helpers are misleading here.
+		sdkErr.Helper = ""
+	}
+	return err
+}
+
 func NewWebsocketDialer(serverURL *url.URL, transport http.RoundTripper, key string) Dialer {
 	return func(ctx context.Context) (DRPCClient, error) {
 		serveURL, err := serverURL.Parse("/api/v2/ai-gateway/serve")
@@ -61,7 +74,7 @@ func NewWebsocketDialer(serverURL *url.URL, transport http.RoundTripper, key str
 			if res == nil {
 				return nil, err
 			}
-			return nil, codersdk.ReadBodyAsError(res)
+			return nil, readAIGatewayServeError(res)
 		}
 		config := yamux.DefaultConfig()
 		config.LogOutput = io.Discard

--- a/coderd/aibridged/http.go
+++ b/coderd/aibridged/http.go
@@ -117,7 +117,7 @@ func (s *Server) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		r.Header.Del("X-Api-Key")
 	}
 
-	client, err := s.Client()
+	client, err := s.ClientContext(ctx)
 	if err != nil {
 		logger.Warn(ctx, "failed to connect to coderd", slog.Error(err))
 		http.Error(rw, ErrConnect.Error(), http.StatusServiceUnavailable)

--- a/coderd/aibridged/http.go
+++ b/coderd/aibridged/http.go
@@ -136,7 +136,7 @@ func (s *Server) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 	resp, err := client.IsAuthorized(ctx, authReq)
 	if err != nil {
-		logger.Warn(ctx, "key authorization check failed", slog.F("error", err.Error()))
+		logger.Warn(ctx, "key authorization check failed", slog.Error(err))
 		http.Error(rw, ErrUnauthorized.Error(), http.StatusForbidden)
 		return
 	}

--- a/coderd/aibridged/http.go
+++ b/coderd/aibridged/http.go
@@ -136,7 +136,7 @@ func (s *Server) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 	resp, err := client.IsAuthorized(ctx, authReq)
 	if err != nil {
-		logger.Warn(ctx, "key authorization check failed", slog.Error(err))
+		logger.Warn(ctx, "key authorization check failed", slog.F("error", err.Error()))
 		http.Error(rw, ErrUnauthorized.Error(), http.StatusForbidden)
 		return
 	}

--- a/coderd/aibridged/proto/version.go
+++ b/coderd/aibridged/proto/version.go
@@ -17,6 +17,11 @@ const (
 	CurrentMinor = 1
 )
 
+// VersionQueryParam is the URL query parameter the standalone AI Gateway
+// uses to advertise its aibridged API version when dialing coderd's serve
+// endpoint, and that coderd reads to negotiate compatibility.
+const VersionQueryParam = "version"
+
 // CurrentVersion is the current aibridged API version.
 // Breaking changes to the aibridged API **MUST** increment CurrentMajor above.
 // Non-breaking changes to the aibridged API **MUST** increment CurrentMinor

--- a/docs/reference/cli/ai-gateway.md
+++ b/docs/reference/cli/ai-gateway.md
@@ -11,6 +11,7 @@ coder ai-gateway
 
 ## Subcommands
 
-| Name                                      | Purpose                |
-|-------------------------------------------|------------------------|
-| [<code>keys</code>](./ai-gateway_keys.md) | Manage AI Gateway keys |
+| Name                                        | Purpose                            |
+|---------------------------------------------|------------------------------------|
+| [<code>start</code>](./ai-gateway_start.md) | Run a standalone AI Gateway server |
+| [<code>keys</code>](./ai-gateway_keys.md)   | Manage AI Gateway keys             |

--- a/docs/reference/cli/ai-gateway_start.md
+++ b/docs/reference/cli/ai-gateway_start.md
@@ -1,0 +1,287 @@
+<!-- DO NOT EDIT | GENERATED CONTENT -->
+# ai-gateway start
+
+Run a standalone AI Gateway server
+
+## Usage
+
+```console
+coder ai-gateway start [flags]
+```
+
+## Description
+
+```console
+The standalone AI Gateway connects to a Coder deployment over DRPC to authenticate users, record interceptions, and configure MCP, while serving LLM client traffic on its own HTTP listener.
+
+The deployment address is taken from the global --url flag (CODER_URL) and is required. The gateway authenticates with the key from --key (CODER_AI_GATEWAY_KEY). Provider and other AI Gateway settings use the same CODER_AI_GATEWAY_* options as embedded mode.
+```
+
+## Options
+
+### --key
+
+|             |                                    |
+|-------------|------------------------------------|
+| Type        | <code>string</code>                |
+| Environment | <code>$CODER_AI_GATEWAY_KEY</code> |
+
+The AI Gateway key used to authenticate to coderd.
+
+### --http-address
+
+|             |                                             |
+|-------------|---------------------------------------------|
+| Type        | <code>string</code>                         |
+| Environment | <code>$CODER_AI_GATEWAY_HTTP_ADDRESS</code> |
+| Default     | <code>127.0.0.1:4001</code>                 |
+
+The bind address to serve incoming AI Gateway client traffic.
+
+### --tls-cert-file
+
+|             |                                              |
+|-------------|----------------------------------------------|
+| Type        | <code>string</code>                          |
+| Environment | <code>$CODER_AI_GATEWAY_TLS_CERT_FILE</code> |
+
+Path to a PEM-encoded TLS certificate. Enables TLS termination when set together with --tls-key-file.
+
+### --tls-key-file
+
+|             |                                             |
+|-------------|---------------------------------------------|
+| Type        | <code>string</code>                         |
+| Environment | <code>$CODER_AI_GATEWAY_TLS_KEY_FILE</code> |
+
+Path to a PEM-encoded TLS private key. Enables TLS termination when set together with --tls-cert-file.
+
+### --verbose
+
+|             |                                        |
+|-------------|----------------------------------------|
+| Type        | <code>bool</code>                      |
+| Environment | <code>$CODER_AI_GATEWAY_VERBOSE</code> |
+| Default     | <code>false</code>                     |
+
+Output debug-level logs.
+
+### --ai-gateway-enabled
+
+|             |                                        |
+|-------------|----------------------------------------|
+| Type        | <code>bool</code>                      |
+| Environment | <code>$CODER_AI_GATEWAY_ENABLED</code> |
+| YAML        | <code>ai_gateway.enabled</code>        |
+| Default     | <code>true</code>                      |
+
+Whether to start an in-memory AI Gateway instance.
+
+### --ai-gateway-openai-base-url
+
+|             |                                                |
+|-------------|------------------------------------------------|
+| Type        | <code>string</code>                            |
+| Environment | <code>$CODER_AI_GATEWAY_OPENAI_BASE_URL</code> |
+| YAML        | <code>ai_gateway.openai_base_url</code>        |
+| Default     | <code>https://api.openai.com/v1/</code>        |
+
+Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The base URL of the OpenAI API.
+
+### --ai-gateway-openai-key
+
+|             |                                           |
+|-------------|-------------------------------------------|
+| Type        | <code>string</code>                       |
+| Environment | <code>$CODER_AI_GATEWAY_OPENAI_KEY</code> |
+
+Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The key to authenticate against the OpenAI API.
+
+### --ai-gateway-anthropic-base-url
+
+|             |                                                   |
+|-------------|---------------------------------------------------|
+| Type        | <code>string</code>                               |
+| Environment | <code>$CODER_AI_GATEWAY_ANTHROPIC_BASE_URL</code> |
+| YAML        | <code>ai_gateway.anthropic_base_url</code>        |
+| Default     | <code>https://api.anthropic.com/</code>           |
+
+Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The base URL of the Anthropic API.
+
+### --ai-gateway-anthropic-key
+
+|             |                                              |
+|-------------|----------------------------------------------|
+| Type        | <code>string</code>                          |
+| Environment | <code>$CODER_AI_GATEWAY_ANTHROPIC_KEY</code> |
+
+Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The key to authenticate against the Anthropic API.
+
+### --ai-gateway-bedrock-base-url
+
+|             |                                                 |
+|-------------|-------------------------------------------------|
+| Type        | <code>string</code>                             |
+| Environment | <code>$CODER_AI_GATEWAY_BEDROCK_BASE_URL</code> |
+| YAML        | <code>ai_gateway.bedrock_base_url</code>        |
+
+Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The base URL to use for the AWS Bedrock API. Use this setting to specify an exact URL to use. Takes precedence over CODER_AI_GATEWAY_BEDROCK_REGION.
+
+### --ai-gateway-bedrock-region
+
+|             |                                               |
+|-------------|-----------------------------------------------|
+| Type        | <code>string</code>                           |
+| Environment | <code>$CODER_AI_GATEWAY_BEDROCK_REGION</code> |
+| YAML        | <code>ai_gateway.bedrock_region</code>        |
+
+Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The AWS Bedrock API region to use. Constructs a base URL to use for the AWS Bedrock API in the form of 'https://bedrock-runtime.<region>.amazonaws.com'.
+
+### --ai-gateway-bedrock-access-key
+
+|             |                                                   |
+|-------------|---------------------------------------------------|
+| Type        | <code>string</code>                               |
+| Environment | <code>$CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY</code> |
+
+Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The access key to authenticate against the AWS Bedrock API.
+
+### --ai-gateway-bedrock-access-key-secret
+
+|             |                                                          |
+|-------------|----------------------------------------------------------|
+| Type        | <code>string</code>                                      |
+| Environment | <code>$CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY_SECRET</code> |
+
+Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The access key secret to use with the access key to authenticate against the AWS Bedrock API.
+
+### --ai-gateway-bedrock-model
+
+|             |                                                               |
+|-------------|---------------------------------------------------------------|
+| Type        | <code>string</code>                                           |
+| Environment | <code>$CODER_AI_GATEWAY_BEDROCK_MODEL</code>                  |
+| YAML        | <code>ai_gateway.bedrock_model</code>                         |
+| Default     | <code>global.anthropic.claude-sonnet-4-5-20250929-v1:0</code> |
+
+Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The model to use when making requests to the AWS Bedrock API.
+
+### --ai-gateway-bedrock-small-fastmodel
+
+|             |                                                              |
+|-------------|--------------------------------------------------------------|
+| Type        | <code>string</code>                                          |
+| Environment | <code>$CODER_AI_GATEWAY_BEDROCK_SMALL_FAST_MODEL</code>      |
+| YAML        | <code>ai_gateway.bedrock_small_fast_model</code>             |
+| Default     | <code>global.anthropic.claude-haiku-4-5-20251001-v1:0</code> |
+
+Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The small fast model to use when making requests to the AWS Bedrock API. Claude Code uses Haiku-class models to perform background tasks. See https://docs.claude.com/en/docs/claude-code/settings#environment-variables.
+
+### --ai-gateway-retention
+
+|             |                                          |
+|-------------|------------------------------------------|
+| Type        | <code>duration</code>                    |
+| Environment | <code>$CODER_AI_GATEWAY_RETENTION</code> |
+| YAML        | <code>ai_gateway.retention</code>        |
+| Default     | <code>60d</code>                         |
+
+Length of time to retain data such as interceptions and all related records (token, prompt, tool use).
+
+### --ai-gateway-max-concurrency
+
+|             |                                                |
+|-------------|------------------------------------------------|
+| Type        | <code>int</code>                               |
+| Environment | <code>$CODER_AI_GATEWAY_MAX_CONCURRENCY</code> |
+| YAML        | <code>ai_gateway.max_concurrency</code>        |
+| Default     | <code>0</code>                                 |
+
+Maximum number of concurrent AI Gateway requests per replica. Set to 0 to disable (unlimited).
+
+### --ai-gateway-rate-limit
+
+|             |                                           |
+|-------------|-------------------------------------------|
+| Type        | <code>int</code>                          |
+| Environment | <code>$CODER_AI_GATEWAY_RATE_LIMIT</code> |
+| YAML        | <code>ai_gateway.rate_limit</code>        |
+| Default     | <code>0</code>                            |
+
+Maximum number of AI Gateway requests per second per replica. Set to 0 to disable (unlimited).
+
+### --ai-gateway-structured-logging
+
+|             |                                                   |
+|-------------|---------------------------------------------------|
+| Type        | <code>bool</code>                                 |
+| Environment | <code>$CODER_AI_GATEWAY_STRUCTURED_LOGGING</code> |
+| YAML        | <code>ai_gateway.structured_logging</code>        |
+| Default     | <code>false</code>                                |
+
+Emit structured logs for AI Gateway interception records. Use this for exporting these records to external SIEM or observability systems.
+
+### --ai-gateway-send-actor-headers
+
+|             |                                                   |
+|-------------|---------------------------------------------------|
+| Type        | <code>bool</code>                                 |
+| Environment | <code>$CODER_AI_GATEWAY_SEND_ACTOR_HEADERS</code> |
+| YAML        | <code>ai_gateway.send_actor_headers</code>        |
+| Default     | <code>false</code>                                |
+
+Once enabled, extra headers will be added to upstream requests to identify the user (actor) making requests to AI Gateway. This is only needed if you are using a proxy between AI Gateway and an upstream AI provider. This will send X-Ai-Bridge-Actor-Id (the ID of the user making the request) and X-Ai-Bridge-Actor-Metadata-Username (their username).
+
+### --ai-gateway-dump-dir
+
+|             |                                         |
+|-------------|-----------------------------------------|
+| Type        | <code>string</code>                     |
+| Environment | <code>$CODER_AI_GATEWAY_DUMP_DIR</code> |
+| YAML        | <code>ai_gateway.api_dump_dir</code>    |
+
+Base directory for dumping AI Bridge request/response pairs to disk for debugging. When set, each provider writes under a subdirectory named after the provider. Sensitive headers are redacted. Leave empty to disable.
+
+### --ai-gateway-allow-byok
+
+|             |                                           |
+|-------------|-------------------------------------------|
+| Type        | <code>bool</code>                         |
+| Environment | <code>$CODER_AI_GATEWAY_ALLOW_BYOK</code> |
+| YAML        | <code>ai_gateway.allow_byok</code>        |
+| Default     | <code>true</code>                         |
+
+Allow users to provide their own LLM API keys or subscriptions. When disabled, only centralized key authentication is permitted.
+
+### --ai-gateway-circuit-breaker-enabled
+
+|             |                                                        |
+|-------------|--------------------------------------------------------|
+| Type        | <code>bool</code>                                      |
+| Environment | <code>$CODER_AI_GATEWAY_CIRCUIT_BREAKER_ENABLED</code> |
+| YAML        | <code>ai_gateway.circuit_breaker_enabled</code>        |
+| Default     | <code>false</code>                                     |
+
+Enable the circuit breaker to protect against cascading failures from upstream AI provider overload (503, 529).
+
+### --ai-budget-policy
+
+|             |                                       |
+|-------------|---------------------------------------|
+| Type        | <code>highest</code>                  |
+| Environment | <code>$CODER_AI_BUDGET_POLICY</code>  |
+| YAML        | <code>ai_gateway.budget_policy</code> |
+| Default     | <code>highest</code>                  |
+
+Determines the effective group when a user belongs to multiple groups with AI budgets. "highest" selects the group with the largest spend limit, and is currently the only supported value.
+
+### --ai-budget-period
+
+|             |                                       |
+|-------------|---------------------------------------|
+| Type        | <code>month</code>                    |
+| Environment | <code>$CODER_AI_BUDGET_PERIOD</code>  |
+| YAML        | <code>ai_gateway.budget_period</code> |
+| Default     | <code>month</code>                    |
+
+Determines when accumulated AI spend resets to zero, aligned to UTC calendar boundaries. Only "month" is currently supported.

--- a/docs/reference/cli/ai-gateway_start.md
+++ b/docs/reference/cli/ai-gateway_start.md
@@ -12,9 +12,9 @@ coder ai-gateway start [flags]
 ## Description
 
 ```console
-The standalone AI Gateway connects to a Coder deployment over DRPC to authenticate users, record interceptions, and configure MCP, while serving LLM client traffic on its own HTTP listener.
+Runs a standalone replica of the AI Gateway. Standalone replicas serve LLM client traffic on a dedicated HTTP listener and connect to a Coder deployment over DRPC.
 
-The deployment address is taken from the global --url flag (CODER_URL) and is required. The gateway authenticates with the key from --key (CODER_AI_GATEWAY_KEY). The provider set is fetched from coderd over DRPC; other AI Gateway settings use the same CODER_AI_GATEWAY_* options as embedded mode.
+Set --url or CODER_URL to the Coder deployment address, and set --key or CODER_AI_GATEWAY_KEY to the AI Gateway key used for gateway-to-coderd authentication. A user login or session token is not required.
 ```
 
 ## Options
@@ -66,128 +66,6 @@ Path to a PEM-encoded TLS private key. Enables TLS termination when set together
 
 Output debug-level logs.
 
-### --ai-gateway-enabled
-
-|             |                                        |
-|-------------|----------------------------------------|
-| Type        | <code>bool</code>                      |
-| Environment | <code>$CODER_AI_GATEWAY_ENABLED</code> |
-| YAML        | <code>ai_gateway.enabled</code>        |
-| Default     | <code>true</code>                      |
-
-Whether to start an in-memory AI Gateway instance.
-
-### --ai-gateway-openai-base-url
-
-|             |                                                |
-|-------------|------------------------------------------------|
-| Type        | <code>string</code>                            |
-| Environment | <code>$CODER_AI_GATEWAY_OPENAI_BASE_URL</code> |
-| YAML        | <code>ai_gateway.openai_base_url</code>        |
-| Default     | <code>https://api.openai.com/v1/</code>        |
-
-Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The base URL of the OpenAI API.
-
-### --ai-gateway-openai-key
-
-|             |                                           |
-|-------------|-------------------------------------------|
-| Type        | <code>string</code>                       |
-| Environment | <code>$CODER_AI_GATEWAY_OPENAI_KEY</code> |
-
-Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The key to authenticate against the OpenAI API.
-
-### --ai-gateway-anthropic-base-url
-
-|             |                                                   |
-|-------------|---------------------------------------------------|
-| Type        | <code>string</code>                               |
-| Environment | <code>$CODER_AI_GATEWAY_ANTHROPIC_BASE_URL</code> |
-| YAML        | <code>ai_gateway.anthropic_base_url</code>        |
-| Default     | <code>https://api.anthropic.com/</code>           |
-
-Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The base URL of the Anthropic API.
-
-### --ai-gateway-anthropic-key
-
-|             |                                              |
-|-------------|----------------------------------------------|
-| Type        | <code>string</code>                          |
-| Environment | <code>$CODER_AI_GATEWAY_ANTHROPIC_KEY</code> |
-
-Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The key to authenticate against the Anthropic API.
-
-### --ai-gateway-bedrock-base-url
-
-|             |                                                 |
-|-------------|-------------------------------------------------|
-| Type        | <code>string</code>                             |
-| Environment | <code>$CODER_AI_GATEWAY_BEDROCK_BASE_URL</code> |
-| YAML        | <code>ai_gateway.bedrock_base_url</code>        |
-
-Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The base URL to use for the AWS Bedrock API. Use this setting to specify an exact URL to use. Takes precedence over CODER_AI_GATEWAY_BEDROCK_REGION.
-
-### --ai-gateway-bedrock-region
-
-|             |                                               |
-|-------------|-----------------------------------------------|
-| Type        | <code>string</code>                           |
-| Environment | <code>$CODER_AI_GATEWAY_BEDROCK_REGION</code> |
-| YAML        | <code>ai_gateway.bedrock_region</code>        |
-
-Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The AWS Bedrock API region to use. Constructs a base URL to use for the AWS Bedrock API in the form of 'https://bedrock-runtime.<region>.amazonaws.com'.
-
-### --ai-gateway-bedrock-access-key
-
-|             |                                                   |
-|-------------|---------------------------------------------------|
-| Type        | <code>string</code>                               |
-| Environment | <code>$CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY</code> |
-
-Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The access key to authenticate against the AWS Bedrock API.
-
-### --ai-gateway-bedrock-access-key-secret
-
-|             |                                                          |
-|-------------|----------------------------------------------------------|
-| Type        | <code>string</code>                                      |
-| Environment | <code>$CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY_SECRET</code> |
-
-Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The access key secret to use with the access key to authenticate against the AWS Bedrock API.
-
-### --ai-gateway-bedrock-model
-
-|             |                                                               |
-|-------------|---------------------------------------------------------------|
-| Type        | <code>string</code>                                           |
-| Environment | <code>$CODER_AI_GATEWAY_BEDROCK_MODEL</code>                  |
-| YAML        | <code>ai_gateway.bedrock_model</code>                         |
-| Default     | <code>global.anthropic.claude-sonnet-4-5-20250929-v1:0</code> |
-
-Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The model to use when making requests to the AWS Bedrock API.
-
-### --ai-gateway-bedrock-small-fastmodel
-
-|             |                                                              |
-|-------------|--------------------------------------------------------------|
-| Type        | <code>string</code>                                          |
-| Environment | <code>$CODER_AI_GATEWAY_BEDROCK_SMALL_FAST_MODEL</code>      |
-| YAML        | <code>ai_gateway.bedrock_small_fast_model</code>             |
-| Default     | <code>global.anthropic.claude-haiku-4-5-20251001-v1:0</code> |
-
-Deprecated: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The small fast model to use when making requests to the AWS Bedrock API. Claude Code uses Haiku-class models to perform background tasks. See https://docs.claude.com/en/docs/claude-code/settings#environment-variables.
-
-### --ai-gateway-retention
-
-|             |                                          |
-|-------------|------------------------------------------|
-| Type        | <code>duration</code>                    |
-| Environment | <code>$CODER_AI_GATEWAY_RETENTION</code> |
-| YAML        | <code>ai_gateway.retention</code>        |
-| Default     | <code>60d</code>                         |
-
-Length of time to retain data such as interceptions and all related records (token, prompt, tool use).
-
 ### --ai-gateway-max-concurrency
 
 |             |                                                |
@@ -210,17 +88,6 @@ Maximum number of concurrent AI Gateway requests per replica. Set to 0 to disabl
 
 Maximum number of AI Gateway requests per second per replica. Set to 0 to disable (unlimited).
 
-### --ai-gateway-structured-logging
-
-|             |                                                   |
-|-------------|---------------------------------------------------|
-| Type        | <code>bool</code>                                 |
-| Environment | <code>$CODER_AI_GATEWAY_STRUCTURED_LOGGING</code> |
-| YAML        | <code>ai_gateway.structured_logging</code>        |
-| Default     | <code>false</code>                                |
-
-Emit structured logs for AI Gateway interception records. Use this for exporting these records to external SIEM or observability systems.
-
 ### --ai-gateway-send-actor-headers
 
 |             |                                                   |
@@ -240,7 +107,7 @@ Once enabled, extra headers will be added to upstream requests to identify the u
 | Environment | <code>$CODER_AI_GATEWAY_DUMP_DIR</code> |
 | YAML        | <code>ai_gateway.api_dump_dir</code>    |
 
-Base directory for dumping AI Bridge request/response pairs to disk for debugging. When set, each provider writes under a subdirectory named after the provider. Sensitive headers are redacted. Leave empty to disable.
+Base directory for dumping AI Gateway request/response pairs to disk for debugging. When set, each provider writes under a subdirectory named after the provider. Sensitive headers are redacted. Leave empty to disable.
 
 ### --ai-gateway-allow-byok
 
@@ -263,25 +130,3 @@ Allow users to provide their own LLM API keys or subscriptions. When disabled, o
 | Default     | <code>false</code>                                     |
 
 Enable the circuit breaker to protect against cascading failures from upstream AI provider overload (503, 529).
-
-### --ai-budget-policy
-
-|             |                                       |
-|-------------|---------------------------------------|
-| Type        | <code>highest</code>                  |
-| Environment | <code>$CODER_AI_BUDGET_POLICY</code>  |
-| YAML        | <code>ai_gateway.budget_policy</code> |
-| Default     | <code>highest</code>                  |
-
-Determines the effective group when a user belongs to multiple groups with AI budgets. "highest" selects the group with the largest spend limit, and is currently the only supported value.
-
-### --ai-budget-period
-
-|             |                                       |
-|-------------|---------------------------------------|
-| Type        | <code>month</code>                    |
-| Environment | <code>$CODER_AI_BUDGET_PERIOD</code>  |
-| YAML        | <code>ai_gateway.budget_period</code> |
-| Default     | <code>month</code>                    |
-
-Determines when accumulated AI spend resets to zero, aligned to UTC calendar boundaries. Only "month" is currently supported.

--- a/docs/reference/cli/ai-gateway_start.md
+++ b/docs/reference/cli/ai-gateway_start.md
@@ -14,7 +14,7 @@ coder ai-gateway start [flags]
 ```console
 The standalone AI Gateway connects to a Coder deployment over DRPC to authenticate users, record interceptions, and configure MCP, while serving LLM client traffic on its own HTTP listener.
 
-The deployment address is taken from the global --url flag (CODER_URL) and is required. The gateway authenticates with the key from --key (CODER_AI_GATEWAY_KEY). Provider and other AI Gateway settings use the same CODER_AI_GATEWAY_* options as embedded mode.
+The deployment address is taken from the global --url flag (CODER_URL) and is required. The gateway authenticates with the key from --key (CODER_AI_GATEWAY_KEY). The provider set is fetched from coderd over DRPC; other AI Gateway settings use the same CODER_AI_GATEWAY_* options as embedded mode.
 ```
 
 ## Options

--- a/docs/reference/cli/ai-gateway_start.md
+++ b/docs/reference/cli/ai-gateway_start.md
@@ -14,7 +14,7 @@ coder ai-gateway start [flags]
 ```console
 Runs a standalone replica of the AI Gateway. Standalone replicas serve LLM client traffic on a dedicated HTTP listener and connect to coderd using the Coder deployment URL and an AI Gateway key.
 
-Set --url or CODER_URL to the Coder deployment address, and set --key or CODER_AI_GATEWAY_KEY to the AI Gateway key. A user login or session token is not required.
+Set --url or CODER_URL to the Coder deployment address, and set --key (CODER_AI_GATEWAY_KEY) or --key-file (CODER_AI_GATEWAY_KEY_FILE). A user login or session token is not required.
 ```
 
 ## Options
@@ -27,6 +27,15 @@ Set --url or CODER_URL to the Coder deployment address, and set --key or CODER_A
 | Environment | <code>$CODER_AI_GATEWAY_KEY</code> |
 
 The AI Gateway key used to authenticate to coderd.
+
+### --key-file
+
+|             |                                         |
+|-------------|-----------------------------------------|
+| Type        | <code>string</code>                     |
+| Environment | <code>$CODER_AI_GATEWAY_KEY_FILE</code> |
+
+Path to a file containing the AI Gateway key used to authenticate to coderd.
 
 ### --http-address
 

--- a/docs/reference/cli/ai-gateway_start.md
+++ b/docs/reference/cli/ai-gateway_start.md
@@ -12,9 +12,9 @@ coder ai-gateway start [flags]
 ## Description
 
 ```console
-Runs a standalone replica of the AI Gateway. Standalone replicas serve LLM client traffic on a dedicated HTTP listener and connect to a Coder deployment over DRPC.
+Runs a standalone replica of the AI Gateway. Standalone replicas serve LLM client traffic on a dedicated HTTP listener and connect to coderd using the Coder deployment URL and an AI Gateway key.
 
-Set --url or CODER_URL to the Coder deployment address, and set --key or CODER_AI_GATEWAY_KEY to the AI Gateway key used for gateway-to-coderd authentication. A user login or session token is not required.
+Set --url or CODER_URL to the Coder deployment address, and set --key or CODER_AI_GATEWAY_KEY to the AI Gateway key. A user login or session token is not required.
 ```
 
 ## Options

--- a/enterprise/cli/aigateway.go
+++ b/enterprise/cli/aigateway.go
@@ -20,6 +20,7 @@ func (r *RootCmd) aiGateway() *serpent.Command {
 			return inv.Command.HelpHandler(inv)
 		},
 		Children: []*serpent.Command{
+			r.aiGatewayStart(),
 			r.aiGatewayKeys(),
 		},
 	}

--- a/enterprise/cli/aigatewaystart.go
+++ b/enterprise/cli/aigatewaystart.go
@@ -1,0 +1,245 @@
+//go:build !slim
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog/v3"
+	"cdr.dev/slog/v3/sloggers/sloghuman"
+	"github.com/coder/coder/v2/aibridge"
+	agpl "github.com/coder/coder/v2/cli"
+	"github.com/coder/coder/v2/coderd/aibridged"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/retry"
+	"github.com/coder/serpent"
+)
+
+// aiGatewayStart runs the AI Gateway as a standalone process.
+// It connects to coderd over DRPC via /api/v2/ai-gateway/serve for
+// authentication, recording, and MCP configuration, and listens on its
+// own HTTP address for incoming LLM client traffic. Providers are built
+// from the deployment configuration; the standalone process does not read
+// the database directly.
+func (r *RootCmd) aiGatewayStart() *serpent.Command {
+	var (
+		key         string
+		httpAddress string
+		tlsCertFile string
+		tlsKeyFile  string
+		verbose     bool
+	)
+
+	// Reuse the shared AI Gateway deployment options (CODER_AI_GATEWAY_*)
+	// so standalone mode is configured exactly like embedded mode. The
+	// option Values point into vals, which is captured by the handler.
+	vals := new(codersdk.DeploymentValues)
+	var aiGatewayOpts serpent.OptionSet
+	for _, opt := range vals.Options() {
+		if opt.Group != nil && opt.Group.Name == "AI Gateway" {
+			aiGatewayOpts = append(aiGatewayOpts, opt)
+		}
+	}
+
+	cmd := &serpent.Command{
+		Use:   "start",
+		Short: "Run a standalone AI Gateway server",
+		Long: "The standalone AI Gateway connects to a Coder deployment over DRPC to " +
+			"authenticate users, record interceptions, and configure MCP, while serving " +
+			"LLM client traffic on its own HTTP listener.\n\n" +
+			"The deployment address is taken from the global --url flag (CODER_URL) and " +
+			"is required. The gateway authenticates with the key from --key " +
+			"(CODER_AI_GATEWAY_KEY). Provider and other AI Gateway settings use the same " +
+			"CODER_AI_GATEWAY_* options as embedded mode.",
+		Handler: func(inv *serpent.Invocation) error {
+			// Derive a single signal-aware context so a stop signal interrupts
+			// every phase, including connecting to coderd and the initial
+			// provider fetch, not just the serving select below. Using a
+			// non-signal context for startup left Ctrl+C ignored until the
+			// gateway had finished starting up.
+			ctx, stop := inv.SignalNotifyContext(inv.Context(), agpl.StopSignals...)
+			defer stop()
+
+			if key == "" {
+				return xerrors.New("an AI Gateway key is required; set --key or CODER_AI_GATEWAY_KEY")
+			}
+			// TLS is opt-in and requires both files; setting only one is
+			// an error. Default is plain HTTP.
+			if (tlsCertFile == "") != (tlsKeyFile == "") {
+				return xerrors.New("--tls-cert-file and --tls-key-file must be provided together")
+			}
+
+			client, err := r.InitClient(inv)
+			if err != nil {
+				return err
+			}
+
+			logger := slog.Make(sloghuman.Sink(inv.Stderr))
+			if verbose {
+				logger = logger.Leveled(slog.LevelDebug)
+			}
+
+			// Metrics and tracing are not yet exposed by standalone mode
+			// (future work), but the pool and the reloader require a metrics
+			// object and a tracer, so wire up no-op sinks registered against a
+			// throwaway registry until standalone metrics are exported.
+			metrics := aibridge.NewMetrics(prometheus.NewRegistry())
+			providerMetrics := aibridged.NewMetrics(prometheus.NewRegistry())
+			tracer := trace.NewNoopTracerProvider().Tracer("aibridged")
+
+			// The standalone gateway has no provider env vars and no database
+			// access. It starts with an empty pool, connects to coderd over
+			// DRPC, then fetches the provider set via GetAIProviders and builds
+			// the pool from it.
+			pool, err := aibridged.NewCachedBridgePool(aibridged.DefaultPoolOptions, nil, logger.Named("pool"), metrics, tracer)
+			if err != nil {
+				return xerrors.Errorf("create request pool: %w", err)
+			}
+
+			dialer := aibridged.NewWebsocketDialer(client, key)
+			srv, err := aibridged.New(ctx, pool, dialer, logger.Named("aibridged"), tracer)
+			if err != nil {
+				return xerrors.Errorf("start aibridge daemon: %w", err)
+			}
+			defer srv.Close()
+
+			// Fetch the initial provider set from coderd, retrying until
+			// success. The reloader owns the fetch/build/replace/metrics work;
+			// the standalone gateway just drives it once at startup.
+			// TODO(AIGOV-465): the standalone gateway has no refresh trigger
+			// yet, so this runs once on startup.
+			providerLogger := logger.Named("aibridge.providers")
+			reloader := agpl.NewPoolRPCReloader(pool, srv.Client, vals.AI.BridgeConfig, providerLogger, metrics, providerMetrics)
+			if err := loadProviders(ctx, reloader, providerLogger); err != nil {
+				// A stop signal during startup cancels ctx (and the daemon's
+				// lifecycle). Treat that as a graceful shutdown rather than a
+				// failure, so interrupting before the gateway is serving still
+				// exits cleanly.
+				if ctx.Err() != nil {
+					logger.Info(ctx, "shutting down standalone AI Gateway")
+					return nil
+				}
+				return xerrors.Errorf("initialize ai providers: %w", err)
+			}
+
+			// The standalone listener is dedicated to Gateway traffic, so
+			// the daemon is served at the root. The /api/v2/ai-gateway alias
+			// keeps parity with the embedded route, so a Gateway proxy
+			// pointed here with the embedded path still works.
+			mux := http.NewServeMux()
+			mux.Handle("/api/v2/aibridge/", http.StripPrefix("/api/v2/aibridge", srv))
+			mux.Handle("/api/v2/ai-gateway/", http.StripPrefix("/api/v2/ai-gateway", srv))
+			mux.Handle("/", srv)
+
+			listener, err := net.Listen("tcp", httpAddress)
+			if err != nil {
+				return xerrors.Errorf("listen on %q: %w", httpAddress, err)
+			}
+			defer listener.Close()
+
+			httpServer := &http.Server{
+				Handler:           mux,
+				ReadHeaderTimeout: time.Minute,
+			}
+
+			serveErr := make(chan error, 1)
+			go func() {
+				if tlsCertFile != "" {
+					serveErr <- httpServer.ServeTLS(listener, tlsCertFile, tlsKeyFile)
+				} else {
+					serveErr <- httpServer.Serve(listener)
+				}
+			}()
+
+			logger.Info(ctx, "standalone AI Gateway listening",
+				slog.F("address", listener.Addr().String()),
+				slog.F("tls", tlsCertFile != ""),
+			)
+
+			select {
+			case <-ctx.Done():
+				logger.Info(ctx, "shutting down standalone AI Gateway")
+			case err := <-serveErr:
+				if err != nil && !errors.Is(err, http.ErrServerClosed) {
+					return xerrors.Errorf("serve: %w", err)
+				}
+			}
+
+			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer shutdownCancel()
+			if err := httpServer.Shutdown(shutdownCtx); err != nil {
+				return xerrors.Errorf("shutdown http server: %w", err)
+			}
+			return nil
+		},
+	}
+
+	cmd.Options = serpent.OptionSet{
+		{
+			Flag:        "key",
+			Env:         "CODER_AI_GATEWAY_KEY",
+			Description: "The AI Gateway key used to authenticate to coderd.",
+			Value:       serpent.StringOf(&key),
+		},
+		{
+			Flag:        "http-address",
+			Env:         "CODER_AI_GATEWAY_HTTP_ADDRESS",
+			Description: "The bind address to serve incoming AI Gateway client traffic.",
+			Default:     "127.0.0.1:4001",
+			Value:       serpent.StringOf(&httpAddress),
+		},
+		{
+			Flag:        "tls-cert-file",
+			Env:         "CODER_AI_GATEWAY_TLS_CERT_FILE",
+			Description: "Path to a PEM-encoded TLS certificate. Enables TLS termination when set together with --tls-key-file.",
+			Value:       serpent.StringOf(&tlsCertFile),
+		},
+		{
+			Flag:        "tls-key-file",
+			Env:         "CODER_AI_GATEWAY_TLS_KEY_FILE",
+			Description: "Path to a PEM-encoded TLS private key. Enables TLS termination when set together with --tls-cert-file.",
+			Value:       serpent.StringOf(&tlsKeyFile),
+		},
+		{
+			Flag:        "verbose",
+			Env:         "CODER_AI_GATEWAY_VERBOSE",
+			Description: "Output debug-level logs.",
+			Value:       serpent.BoolOf(&verbose),
+			Default:     "false",
+		},
+	}
+	cmd.Options = append(cmd.Options, aiGatewayOpts...)
+
+	return cmd
+}
+
+// loadProviders performs the standalone gateway's initial provider
+// load by driving reloader until it succeeds or ctx is canceled. The reloader
+// owns the actual fetch/build/replace/metrics work; the reloader's underlying
+// client blocks until the daemon connects to coderd, and the fetch may still
+// fail transiently (e.g. mid-seed contention or a dropped connection), so the
+// reload is retried with backoff. A successful empty provider list is a valid
+// result and ends the loop.
+//
+// TODO(AIGOV-465): the standalone gateway has no provider-change refresh
+// trigger yet, so this runs once on startup; provider add/enable will not
+// propagate to a running standalone gateway.
+func loadProviders(ctx context.Context, reloader aibridged.ProviderReloader, logger slog.Logger) error {
+	for r := retry.New(50*time.Millisecond, 10*time.Second); r.Wait(ctx); {
+		if err := reloader.Reload(ctx); err != nil {
+			logger.Warn(ctx, "failed to load ai providers, will retry", slog.Error(err))
+			continue
+		}
+		logger.Info(ctx, "loaded ai providers from coderd")
+		return nil
+	}
+	return ctx.Err()
+}

--- a/enterprise/cli/aigatewaystart.go
+++ b/enterprise/cli/aigatewaystart.go
@@ -26,9 +26,10 @@ import (
 // aiGatewayStart runs the AI Gateway as a standalone process.
 // It connects to coderd over DRPC via /api/v2/ai-gateway/serve for
 // authentication, recording, and MCP configuration, and listens on its
-// own HTTP address for incoming LLM client traffic. Providers are built
-// from the deployment configuration; the standalone process does not read
-// the database directly.
+// own HTTP address for incoming LLM client traffic. The provider set is
+// fetched from coderd over DRPC (GetAIProviders); the standalone process
+// does not read the database directly. Other AI Gateway settings come from
+// the shared CODER_AI_GATEWAY_* deployment options.
 func (r *RootCmd) aiGatewayStart() *serpent.Command {
 	var (
 		key         string
@@ -57,8 +58,8 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 			"LLM client traffic on its own HTTP listener.\n\n" +
 			"The deployment address is taken from the global --url flag (CODER_URL) and " +
 			"is required. The gateway authenticates with the key from --key " +
-			"(CODER_AI_GATEWAY_KEY). Provider and other AI Gateway settings use the same " +
-			"CODER_AI_GATEWAY_* options as embedded mode.",
+			"(CODER_AI_GATEWAY_KEY). The provider set is fetched from coderd over DRPC; " +
+			"other AI Gateway settings use the same CODER_AI_GATEWAY_* options as embedded mode.",
 		Handler: func(inv *serpent.Invocation) error {
 			// Derive a single signal-aware context so a stop signal interrupts
 			// every phase, including connecting to coderd and the initial

--- a/enterprise/cli/aigatewaystart.go
+++ b/enterprise/cli/aigatewaystart.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"go.opentelemetry.io/otel/trace"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
@@ -51,12 +51,7 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 			"gateway-to-coderd authentication. A user login or session token is " +
 			"not required.",
 		Handler: func(inv *serpent.Invocation) error {
-			// Derive a single signal-aware context so a stop signal interrupts
-			// every phase, including connecting to coderd and the initial
-			// provider fetch, not just the serving select below. Using a
-			// non-signal context for startup left Ctrl+C ignored until the
-			// gateway had finished starting up.
-			ctx, stop := inv.SignalNotifyContext(inv.Context(), agpl.StopSignals...)
+			signalCtx, stop := inv.SignalNotifyContext(inv.Context(), agpl.StopSignals...)
 			defer stop()
 
 			if key == "" {
@@ -84,9 +79,10 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 			// Metrics and tracing are not yet exposed by standalone mode yet
 			// (TODO AIGOV-317), but the pool and the reloader require a metrics
 			// object and a tracer.
-			metrics := aibridge.NewMetrics(prometheus.NewRegistry())
-			providerMetrics := aibridged.NewMetrics(prometheus.NewRegistry())
-			tracer := trace.NewNoopTracerProvider().Tracer("aibridged")
+			registry := prometheus.NewRegistry()
+			metrics := aibridge.NewMetrics(registry)
+			providerMetrics := aibridged.NewMetrics(registry)
+			tracer := tracenoop.NewTracerProvider().Tracer("aibridged")
 
 			// Standalone Gateway starts with an empty pool. Providers are
 			// fetched later via GetAIProviders DRPC and pool is updated.
@@ -96,7 +92,9 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 			}
 
 			dialer := aibridged.NewWebsocketDialer(serverURL, transport, key)
-			srv, err := aibridged.New(ctx, pool, dialer, logger.Named("aibridged"), tracer)
+			daemonCtx, daemonCancel := context.WithCancel(context.Background())
+			defer daemonCancel()
+			srv, err := aibridged.New(daemonCtx, pool, dialer, logger.Named("aibridged"), tracer)
 			if err != nil {
 				return xerrors.Errorf("start AI Gateway daemon: %w", err)
 			}
@@ -106,15 +104,14 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 			// success.
 			// TODO(AIGOV-465): the standalone gateway has no refresh trigger
 			// yet, so this runs once on startup.
+			clientFn := func() (aibridged.DRPCClient, error) {
+				return srv.ClientContext(signalCtx)
+			}
 			providerLogger := logger.Named("aibridge.providers")
-			reloader := agpl.NewPoolRPCReloader(pool, srv.Client, vals.AI.BridgeConfig, providerLogger, metrics, providerMetrics)
-			if err := loadProviders(ctx, reloader, providerLogger); err != nil {
-				// A stop signal during startup cancels ctx (and the daemon's
-				// lifecycle). Treat that as a graceful shutdown rather than a
-				// failure, so interrupting before the gateway is serving still
-				// exits cleanly.
-				if ctx.Err() != nil {
-					logger.Info(ctx, "shutting down standalone AI Gateway")
+			reloader := agpl.NewPoolRPCReloader(pool, clientFn, vals.AI.BridgeConfig, providerLogger, metrics, providerMetrics)
+			if err := loadProviders(signalCtx, reloader, providerLogger); err != nil {
+				if signalCtx.Err() != nil {
+					logger.Info(signalCtx, "shutting down standalone AI Gateway")
 					return nil
 				}
 				return xerrors.Errorf("initialize ai providers: %w", err)
@@ -137,7 +134,7 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 			}
 			defer listener.Close()
 
-			logger.Info(ctx, "standalone AI Gateway listening",
+			logger.Info(signalCtx, "standalone AI Gateway listening",
 				slog.F("address", listener.Addr().String()),
 				slog.F("tls", tlsCertFile != ""),
 			)
@@ -157,8 +154,8 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 			}()
 
 			select {
-			case <-ctx.Done():
-				logger.Info(ctx, "shutting down standalone AI Gateway")
+			case <-signalCtx.Done():
+				logger.Info(signalCtx, "shutting down standalone AI Gateway")
 			case err := <-serveErr:
 				if err != nil && !errors.Is(err, http.ErrServerClosed) {
 					return xerrors.Errorf("serve: %w", err)

--- a/enterprise/cli/aigatewaystart.go
+++ b/enterprise/cli/aigatewaystart.go
@@ -98,7 +98,7 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 			dialer := aibridged.NewWebsocketDialer(serverURL, transport, key)
 			srv, err := aibridged.New(ctx, pool, dialer, logger.Named("aibridged"), tracer)
 			if err != nil {
-				return xerrors.Errorf("start aibridge daemon: %w", err)
+				return xerrors.Errorf("start AI Gateway daemon: %w", err)
 			}
 			defer srv.Close()
 
@@ -210,7 +210,7 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 	}
 
 	// Standalone Gateway only uses part of the options from "AI Gateway" group.
-	// Every other option in the group is coderd-only (eg. budget, provider-seeding).
+	// Other options from the group are coderd-only (eg. budget, provider-seeding).
 	standaloneOpts := map[string]struct{}{
 		"CODER_AI_GATEWAY_ALLOW_BYOK":                        {},
 		"CODER_AI_GATEWAY_SEND_ACTOR_HEADERS":                {},
@@ -224,8 +224,6 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 		"CODER_AI_GATEWAY_RATE_LIMIT":                        {},
 	}
 
-	// Reuse the shared AI Gateway deployment options for
-	// parity (of applicable options) between embedded and standalone.
 	var aiGatewayOpts serpent.OptionSet
 	for _, opt := range vals.Options() {
 		if opt.Group == nil || opt.Group.Name != "AI Gateway" {

--- a/enterprise/cli/aigatewaystart.go
+++ b/enterprise/cli/aigatewaystart.go
@@ -76,7 +76,7 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 				logger = logger.Leveled(slog.LevelDebug)
 			}
 
-			// Metrics and tracing are not yet exposed by standalone mode yet
+			// Metrics and tracing are not exposed by standalone mode yet
 			// (TODO AIGOV-317), but the pool and the reloader require a metrics
 			// object and a tracer.
 			registry := prometheus.NewRegistry()
@@ -136,6 +136,7 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 
 			logger.Info(signalCtx, "standalone AI Gateway listening",
 				slog.F("address", listener.Addr().String()),
+				slog.F("coder_url", serverURL.String()),
 				slog.F("tls", tlsCertFile != ""),
 			)
 

--- a/enterprise/cli/aigatewaystart.go
+++ b/enterprise/cli/aigatewaystart.go
@@ -92,9 +92,9 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 			}
 
 			dialer := aibridged.NewWebsocketDialer(serverURL, transport, key)
-			daemonCtx, daemonCancel := context.WithCancel(context.Background())
-			defer daemonCancel()
-			srv, err := aibridged.New(daemonCtx, pool, dialer, logger.Named("aibridged"), tracer)
+			aibridgedCtx, aibridgedCancel := context.WithCancel(context.Background())
+			defer aibridgedCancel()
+			srv, err := aibridged.New(aibridgedCtx, pool, dialer, logger.Named("aibridged"), tracer)
 			if err != nil {
 				return xerrors.Errorf("start AI Gateway daemon: %w", err)
 			}
@@ -109,7 +109,7 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 			}
 			providerLogger := logger.Named("aibridge.providers")
 			reloader := agpl.NewPoolRPCReloader(pool, clientFn, vals.AI.BridgeConfig, providerLogger, metrics, providerMetrics)
-			if err := loadProviders(signalCtx, reloader, providerLogger); err != nil {
+			if err := loadProviders(signalCtx, reloader, providerLogger, srv.Done()); err != nil {
 				if signalCtx.Err() != nil {
 					logger.Info(signalCtx, "shutting down standalone AI Gateway")
 					return nil
@@ -154,9 +154,12 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 				}
 			}()
 
+			var aibridgedErr error
 			select {
 			case <-signalCtx.Done():
 				logger.Info(signalCtx, "shutting down standalone AI Gateway")
+			case <-srv.Done():
+				aibridgedErr = srv.Err()
 			case err := <-serveErr:
 				if err != nil && !errors.Is(err, http.ErrServerClosed) {
 					return xerrors.Errorf("serve: %w", err)
@@ -167,6 +170,9 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 			defer shutdownCancel()
 			if err := httpServer.Shutdown(shutdownCtx); err != nil {
 				return xerrors.Errorf("shutdown http server: %w", err)
+			}
+			if aibridgedErr != nil {
+				return xerrors.Errorf("AI Gateway daemon exited: %w", aibridgedErr)
 			}
 			return nil
 		},
@@ -249,14 +255,22 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 // TODO(AIGOV-465): the standalone gateway has no provider-change refresh
 // trigger yet, so this runs once on startup; provider add/enable will not
 // propagate to a running standalone gateway.
-func loadProviders(ctx context.Context, reloader aibridged.ProviderReloader, logger slog.Logger) error {
+func loadProviders(ctx context.Context, reloader aibridged.ProviderReloader, logger slog.Logger, aibridgedDone <-chan struct{}) error {
 	for r := retry.New(50*time.Millisecond, 10*time.Second); r.Wait(ctx); {
 		if err := reloader.Reload(ctx); err != nil {
+			select {
+			case <-aibridgedDone:
+				return err
+			default:
+			}
 			logger.Warn(ctx, "failed to load ai providers, will retry", slog.Error(err))
 			continue
 		}
 		logger.Info(ctx, "loaded ai providers from coderd")
 		return nil
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
 	}
 	return ctx.Err()
 }

--- a/enterprise/cli/aigatewaystart.go
+++ b/enterprise/cli/aigatewaystart.go
@@ -19,17 +19,16 @@ import (
 	agpl "github.com/coder/coder/v2/cli"
 	"github.com/coder/coder/v2/coderd/aibridged"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/enterprise/coderd"
 	"github.com/coder/retry"
 	"github.com/coder/serpent"
 )
 
+const (
+	shutdownTimeout = 15 * time.Second
+)
+
 // aiGatewayStart runs the AI Gateway as a standalone process.
-// It connects to coderd over DRPC via /api/v2/ai-gateway/serve for
-// authentication, recording, and MCP configuration, and listens on its
-// own HTTP address for incoming LLM client traffic. The provider set is
-// fetched from coderd over DRPC (GetAIProviders); the standalone process
-// does not read the database directly. Other AI Gateway settings come from
-// the shared CODER_AI_GATEWAY_* deployment options.
 func (r *RootCmd) aiGatewayStart() *serpent.Command {
 	var (
 		key         string
@@ -39,27 +38,18 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 		verbose     bool
 	)
 
-	// Reuse the shared AI Gateway deployment options (CODER_AI_GATEWAY_*)
-	// so standalone mode is configured exactly like embedded mode. The
-	// option Values point into vals, which is captured by the handler.
 	vals := new(codersdk.DeploymentValues)
-	var aiGatewayOpts serpent.OptionSet
-	for _, opt := range vals.Options() {
-		if opt.Group != nil && opt.Group.Name == "AI Gateway" {
-			aiGatewayOpts = append(aiGatewayOpts, opt)
-		}
-	}
 
 	cmd := &serpent.Command{
 		Use:   "start",
 		Short: "Run a standalone AI Gateway server",
-		Long: "The standalone AI Gateway connects to a Coder deployment over DRPC to " +
-			"authenticate users, record interceptions, and configure MCP, while serving " +
-			"LLM client traffic on its own HTTP listener.\n\n" +
-			"The deployment address is taken from the global --url flag (CODER_URL) and " +
-			"is required. The gateway authenticates with the key from --key " +
-			"(CODER_AI_GATEWAY_KEY). The provider set is fetched from coderd over DRPC; " +
-			"other AI Gateway settings use the same CODER_AI_GATEWAY_* options as embedded mode.",
+		Long: "Runs a standalone replica of the AI Gateway. Standalone replicas " +
+			"serve LLM client traffic on a dedicated HTTP listener and connect " +
+			"to a Coder deployment over DRPC.\n\n" +
+			"Set --url or CODER_URL to the Coder deployment address, and set " +
+			"--key or CODER_AI_GATEWAY_KEY to the AI Gateway key used for " +
+			"gateway-to-coderd authentication. A user login or session token is " +
+			"not required.",
 		Handler: func(inv *serpent.Invocation) error {
 			// Derive a single signal-aware context so a stop signal interrupts
 			// every phase, including connecting to coderd and the initial
@@ -70,7 +60,7 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 			defer stop()
 
 			if key == "" {
-				return xerrors.New("an AI Gateway key is required; set --key or CODER_AI_GATEWAY_KEY")
+				return xerrors.New("an AI Gateway key is required, set --key or CODER_AI_GATEWAY_KEY")
 			}
 			// TLS is opt-in and requires both files; setting only one is
 			// an error. Default is plain HTTP.
@@ -78,9 +68,12 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 				return xerrors.New("--tls-cert-file and --tls-key-file must be provided together")
 			}
 
-			client, err := r.InitClient(inv)
+			serverURL, transport, err := r.ResolveClientConnection()
 			if err != nil {
-				return err
+				if errors.Is(err, agpl.ErrClientURLNotConfigured) {
+					return xerrors.New("AI Gateway requires --url or CODER_URL to point at the Coder deployment")
+				}
+				return xerrors.Errorf("configure Coder deployment connection: %w", err)
 			}
 
 			logger := slog.Make(sloghuman.Sink(inv.Stderr))
@@ -88,24 +81,21 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 				logger = logger.Leveled(slog.LevelDebug)
 			}
 
-			// Metrics and tracing are not yet exposed by standalone mode
-			// (future work), but the pool and the reloader require a metrics
-			// object and a tracer, so wire up no-op sinks registered against a
-			// throwaway registry until standalone metrics are exported.
+			// Metrics and tracing are not yet exposed by standalone mode yet
+			// (TODO AIGOV-317), but the pool and the reloader require a metrics
+			// object and a tracer.
 			metrics := aibridge.NewMetrics(prometheus.NewRegistry())
 			providerMetrics := aibridged.NewMetrics(prometheus.NewRegistry())
 			tracer := trace.NewNoopTracerProvider().Tracer("aibridged")
 
-			// The standalone gateway has no provider env vars and no database
-			// access. It starts with an empty pool, connects to coderd over
-			// DRPC, then fetches the provider set via GetAIProviders and builds
-			// the pool from it.
+			// Standalone Gateway starts with an empty pool. Providers are
+			// fetched later via GetAIProviders DRPC and pool is updated.
 			pool, err := aibridged.NewCachedBridgePool(aibridged.DefaultPoolOptions, nil, logger.Named("pool"), metrics, tracer)
 			if err != nil {
 				return xerrors.Errorf("create request pool: %w", err)
 			}
 
-			dialer := aibridged.NewWebsocketDialer(client, key)
+			dialer := aibridged.NewWebsocketDialer(serverURL, transport, key)
 			srv, err := aibridged.New(ctx, pool, dialer, logger.Named("aibridged"), tracer)
 			if err != nil {
 				return xerrors.Errorf("start aibridge daemon: %w", err)
@@ -113,8 +103,7 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 			defer srv.Close()
 
 			// Fetch the initial provider set from coderd, retrying until
-			// success. The reloader owns the fetch/build/replace/metrics work;
-			// the standalone gateway just drives it once at startup.
+			// success.
 			// TODO(AIGOV-465): the standalone gateway has no refresh trigger
 			// yet, so this runs once on startup.
 			providerLogger := logger.Named("aibridge.providers")
@@ -131,20 +120,27 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 				return xerrors.Errorf("initialize ai providers: %w", err)
 			}
 
+			mw := coderd.AIGatewayDataPlaneMiddleware(vals.AI.BridgeConfig)
+
 			// The standalone listener is dedicated to Gateway traffic, so
-			// the daemon is served at the root. The /api/v2/ai-gateway alias
-			// keeps parity with the embedded route, so a Gateway proxy
-			// pointed here with the embedded path still works.
+			// the daemon is served at the root. The /api/v2/ai-gateway
+			// and /api/v2/aibridge/ aliases are added for compatibility
+			// with the embedded route.
 			mux := http.NewServeMux()
-			mux.Handle("/api/v2/aibridge/", http.StripPrefix("/api/v2/aibridge", srv))
-			mux.Handle("/api/v2/ai-gateway/", http.StripPrefix("/api/v2/ai-gateway", srv))
-			mux.Handle("/", srv)
+			mux.Handle("/api/v2/aibridge/", mw(http.StripPrefix("/api/v2/aibridge", srv)))
+			mux.Handle("/api/v2/ai-gateway/", mw(http.StripPrefix("/api/v2/ai-gateway", srv)))
+			mux.Handle("/", mw(srv))
 
 			listener, err := net.Listen("tcp", httpAddress)
 			if err != nil {
 				return xerrors.Errorf("listen on %q: %w", httpAddress, err)
 			}
 			defer listener.Close()
+
+			logger.Info(ctx, "standalone AI Gateway listening",
+				slog.F("address", listener.Addr().String()),
+				slog.F("tls", tlsCertFile != ""),
+			)
 
 			httpServer := &http.Server{
 				Handler:           mux,
@@ -160,11 +156,6 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 				}
 			}()
 
-			logger.Info(ctx, "standalone AI Gateway listening",
-				slog.F("address", listener.Addr().String()),
-				slog.F("tls", tlsCertFile != ""),
-			)
-
 			select {
 			case <-ctx.Done():
 				logger.Info(ctx, "shutting down standalone AI Gateway")
@@ -174,7 +165,7 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 				}
 			}
 
-			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), shutdownTimeout)
 			defer shutdownCancel()
 			if err := httpServer.Shutdown(shutdownCtx); err != nil {
 				return xerrors.Errorf("shutdown http server: %w", err)
@@ -217,6 +208,35 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 			Default:     "false",
 		},
 	}
+
+	// Standalone Gateway only uses part of the options from "AI Gateway" group.
+	// Every other option in the group is coderd-only (eg. budget, provider-seeding).
+	standaloneOpts := map[string]struct{}{
+		"CODER_AI_GATEWAY_ALLOW_BYOK":                        {},
+		"CODER_AI_GATEWAY_SEND_ACTOR_HEADERS":                {},
+		"CODER_AI_GATEWAY_DUMP_DIR":                          {},
+		"CODER_AI_GATEWAY_CIRCUIT_BREAKER_ENABLED":           {},
+		"CODER_AI_GATEWAY_CIRCUIT_BREAKER_FAILURE_THRESHOLD": {},
+		"CODER_AI_GATEWAY_CIRCUIT_BREAKER_INTERVAL":          {},
+		"CODER_AI_GATEWAY_CIRCUIT_BREAKER_TIMEOUT":           {},
+		"CODER_AI_GATEWAY_CIRCUIT_BREAKER_MAX_REQUESTS":      {},
+		"CODER_AI_GATEWAY_MAX_CONCURRENCY":                   {},
+		"CODER_AI_GATEWAY_RATE_LIMIT":                        {},
+	}
+
+	// Reuse the shared AI Gateway deployment options for
+	// parity (of applicable options) between embedded and standalone.
+	var aiGatewayOpts serpent.OptionSet
+	for _, opt := range vals.Options() {
+		if opt.Group == nil || opt.Group.Name != "AI Gateway" {
+			continue
+		}
+		if _, ok := standaloneOpts[opt.Env]; !ok {
+			continue
+		}
+		aiGatewayOpts = append(aiGatewayOpts, opt)
+	}
+
 	cmd.Options = append(cmd.Options, aiGatewayOpts...)
 
 	return cmd

--- a/enterprise/cli/aigatewaystart.go
+++ b/enterprise/cli/aigatewaystart.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	shutdownTimeout = 15 * time.Second
+	shutdownTimeout = 5 * time.Minute
 )
 
 // aiGatewayStart runs the AI Gateway as a standalone process.
@@ -45,11 +45,10 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 		Short: "Run a standalone AI Gateway server",
 		Long: "Runs a standalone replica of the AI Gateway. Standalone replicas " +
 			"serve LLM client traffic on a dedicated HTTP listener and connect " +
-			"to a Coder deployment over DRPC.\n\n" +
+			"to coderd using the Coder deployment URL and an AI Gateway key.\n\n" +
 			"Set --url or CODER_URL to the Coder deployment address, and set " +
-			"--key or CODER_AI_GATEWAY_KEY to the AI Gateway key used for " +
-			"gateway-to-coderd authentication. A user login or session token is " +
-			"not required.",
+			"--key or CODER_AI_GATEWAY_KEY to the AI Gateway key. A user login " +
+			"or session token is not required.",
 		Handler: func(inv *serpent.Invocation) error {
 			signalCtx, stop := inv.SignalNotifyContext(inv.Context(), agpl.StopSignals...)
 			defer stop()

--- a/enterprise/cli/aigatewaystart.go
+++ b/enterprise/cli/aigatewaystart.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -26,12 +28,16 @@ import (
 
 const (
 	shutdownTimeout = 5 * time.Minute
+
+	keyFlagsExclusiveErr = "--key and --key-file options are mutually exclusive"
+	keyFlagsMissingErr   = "an AI Gateway key is required, set --key (CODER_AI_GATEWAY_KEY) or --key-file (CODER_AI_GATEWAY_KEY_FILE)"
 )
 
 // aiGatewayStart runs the AI Gateway as a standalone process.
 func (r *RootCmd) aiGatewayStart() *serpent.Command {
 	var (
 		key         string
+		keyFile     string
 		httpAddress string
 		tlsCertFile string
 		tlsKeyFile  string
@@ -47,19 +53,22 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 			"serve LLM client traffic on a dedicated HTTP listener and connect " +
 			"to coderd using the Coder deployment URL and an AI Gateway key.\n\n" +
 			"Set --url or CODER_URL to the Coder deployment address, and set " +
-			"--key or CODER_AI_GATEWAY_KEY to the AI Gateway key. A user login " +
-			"or session token is not required.",
+			"--key (CODER_AI_GATEWAY_KEY) or --key-file " +
+			"(CODER_AI_GATEWAY_KEY_FILE). A user login or session token is " +
+			"not required.",
 		Handler: func(inv *serpent.Invocation) error {
 			signalCtx, stop := inv.SignalNotifyContext(inv.Context(), agpl.StopSignals...)
 			defer stop()
 
-			if key == "" {
-				return xerrors.New("an AI Gateway key is required, set --key or CODER_AI_GATEWAY_KEY")
+			resolvedKey, err := resolveAIGatewayKey(key, keyFile)
+			if err != nil {
+				return err
 			}
+
 			// TLS is opt-in and requires both files; setting only one is
 			// an error. Default is plain HTTP.
 			if (tlsCertFile == "") != (tlsKeyFile == "") {
-				return xerrors.New("--tls-cert-file and --tls-key-file must be provided together")
+				return xerrors.New("--tls-cert-file and --tls-key-file options must be provided together")
 			}
 
 			serverURL, transport, err := r.ResolveClientConnection()
@@ -90,7 +99,7 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 				return xerrors.Errorf("create request pool: %w", err)
 			}
 
-			dialer := aibridged.NewWebsocketDialer(serverURL, transport, key)
+			dialer := aibridged.NewWebsocketDialer(serverURL, transport, resolvedKey)
 			aibridgedCtx, aibridgedCancel := context.WithCancel(context.Background())
 			defer aibridgedCancel()
 			srv, err := aibridged.New(aibridgedCtx, pool, dialer, logger.Named("aibridged"), tracer)
@@ -185,6 +194,12 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 			Value:       serpent.StringOf(&key),
 		},
 		{
+			Flag:        "key-file",
+			Env:         "CODER_AI_GATEWAY_KEY_FILE",
+			Description: "Path to a file containing the AI Gateway key used to authenticate to coderd.",
+			Value:       serpent.StringOf(&keyFile),
+		},
+		{
 			Flag:        "http-address",
 			Env:         "CODER_AI_GATEWAY_HTTP_ADDRESS",
 			Description: "The bind address to serve incoming AI Gateway client traffic.",
@@ -241,6 +256,25 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 	cmd.Options = append(cmd.Options, aiGatewayOpts...)
 
 	return cmd
+}
+
+// resolveAIGatewayKey resolves key from --key or --key-file flags.
+// If both are set, an error is returned. If neither is set, an empty string is returned.
+func resolveAIGatewayKey(key string, keyFile string) (string, error) {
+	if key != "" && keyFile != "" {
+		return "", xerrors.New(keyFlagsExclusiveErr)
+	}
+	if key == "" && keyFile == "" {
+		return "", xerrors.New(keyFlagsMissingErr)
+	}
+	if keyFile == "" {
+		return key, nil
+	}
+	data, err := os.ReadFile(keyFile)
+	if err != nil {
+		return "", xerrors.Errorf("read AI Gateway key file %q: %w", keyFile, err)
+	}
+	return strings.TrimSpace(string(data)), nil
 }
 
 // loadProviders performs the standalone gateway's initial provider

--- a/enterprise/cli/aigatewaystart_internal_test.go
+++ b/enterprise/cli/aigatewaystart_internal_test.go
@@ -1,0 +1,91 @@
+//go:build !slim
+
+package cli
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/testutil"
+)
+
+// blockingReloader blocks in Reload until the context is canceled, then
+// returns its error. It models the standalone gateway's initial reload
+// waiting on a daemon connection to an unreachable coderd.
+type blockingReloader struct {
+	started chan struct{}
+}
+
+func (r *blockingReloader) Reload(ctx context.Context) error {
+	select {
+	case r.started <- struct{}{}:
+	default:
+	}
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// TestLoadProviders_Interruptible verifies that a stop signal,
+// modeled by canceling the context, unblocks the initial provider load even
+// when the reloader is stuck waiting for coderd. This guards the standalone
+// "ai-gateway start" command against the regression where startup could not
+// be interrupted.
+func TestLoadProviders_Interruptible(t *testing.T) {
+	t.Parallel()
+
+	// testCtx bounds the test and drives the channel receives; runCtx is the
+	// context handed to loadProviders and is canceled to model a
+	// stop signal. They are distinct so the receives still work after the
+	// signal context is canceled.
+	testCtx := testutil.Context(t, testutil.WaitShort)
+	runCtx, cancel := context.WithCancel(testCtx)
+	defer cancel()
+
+	reloader := &blockingReloader{started: make(chan struct{}, 1)}
+	logger := slog.Make()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- loadProviders(runCtx, reloader, logger)
+	}()
+
+	// Wait for the reload to be in-flight, then cancel as a signal would.
+	testutil.RequireReceive(testCtx, t, reloader.started)
+	cancel()
+
+	err := testutil.RequireReceive(testCtx, t, done)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// failThenSucceedReloader fails the first failUntil reloads, then succeeds,
+// modeling a coderd connection or provider fetch that recovers after a few
+// transient failures.
+type failThenSucceedReloader struct {
+	calls     atomic.Int32
+	failUntil int32
+}
+
+func (r *failThenSucceedReloader) Reload(_ context.Context) error {
+	if r.calls.Add(1) <= r.failUntil {
+		return xerrors.New("transient failure")
+	}
+	return nil
+}
+
+// TestLoadProviders_RetrySucceeds verifies loadProviders keeps retrying past
+// transient failures and returns nil once a reload succeeds. This guards the
+// retry contract: replacing the loop's continue with a return would fail here.
+func TestLoadProviders_RetrySucceeds(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	reloader := &failThenSucceedReloader{failUntil: 2}
+
+	require.NoError(t, loadProviders(ctx, reloader, slog.Make()))
+	require.GreaterOrEqual(t, reloader.calls.Load(), int32(3))
+}

--- a/enterprise/cli/aigatewaystart_internal_test.go
+++ b/enterprise/cli/aigatewaystart_internal_test.go
@@ -89,39 +89,3 @@ func TestLoadProviders_RetrySucceeds(t *testing.T) {
 	require.NoError(t, loadProviders(ctx, reloader, slog.Make()))
 	require.GreaterOrEqual(t, reloader.calls.Load(), int32(3))
 }
-
-// TestAIGatewayStart_DeploymentOptions pins the AI Gateway deployment options
-// the standalone "ai-gateway start" command exposes. Only settings the gateway
-// actually consumes when building providers from the DRPC-sourced provider set
-// (circuit breaker, BYOK, actor headers, dump dir) should be inherited.
-// Provider-seeding and coderd-only options (Enabled, Retention, MaxConcurrency,
-// RateLimit, StructuredLogging, InjectCoderMCPTools) must not leak into
-// standalone mode. This guards against a new option silently slipping in.
-func TestAIGatewayStart_DeploymentOptions(t *testing.T) {
-	t.Parallel()
-
-	cmd := (&RootCmd{}).aiGatewayStart()
-
-	// The command's own flags have no Group; inherited deployment options
-	// carry the "AI Gateway" group.
-	var got []string
-	for _, opt := range cmd.Options {
-		if opt.Group != nil && opt.Group.Name == "AI Gateway" {
-			got = append(got, opt.Env)
-		}
-	}
-
-	want := []string{
-		"CODER_AI_GATEWAY_ALLOW_BYOK",
-		"CODER_AI_GATEWAY_CIRCUIT_BREAKER_ENABLED",
-		"CODER_AI_GATEWAY_CIRCUIT_BREAKER_FAILURE_THRESHOLD",
-		"CODER_AI_GATEWAY_CIRCUIT_BREAKER_INTERVAL",
-		"CODER_AI_GATEWAY_CIRCUIT_BREAKER_MAX_REQUESTS",
-		"CODER_AI_GATEWAY_CIRCUIT_BREAKER_TIMEOUT",
-		"CODER_AI_GATEWAY_DUMP_DIR",
-		"CODER_AI_GATEWAY_SEND_ACTOR_HEADERS",
-		"CODER_AI_GATEWAY_MAX_CONCURRENCY",
-		"CODER_AI_GATEWAY_RATE_LIMIT",
-	}
-	require.ElementsMatch(t, want, got)
-}

--- a/enterprise/cli/aigatewaystart_internal_test.go
+++ b/enterprise/cli/aigatewaystart_internal_test.go
@@ -30,6 +30,41 @@ func (r *blockingReloader) Reload(ctx context.Context) error {
 	return ctx.Err()
 }
 
+// failThenSucceedReloader fails the first failUntil reloads, then succeeds,
+// modeling a coderd connection or provider fetch that recovers after a few
+// transient failures.
+type failThenSucceedReloader struct {
+	calls     atomic.Int32
+	failUntil int32
+}
+
+func (r *failThenSucceedReloader) Reload(_ context.Context) error {
+	if r.calls.Add(1) <= r.failUntil {
+		return xerrors.New("transient failure")
+	}
+	return nil
+}
+
+// alwaysFailReloader returns the same error every time Reload is called.
+type alwaysFailReloader struct {
+	calls  atomic.Int32
+	err    error
+	after  func()
+	called chan struct{}
+}
+
+func (r *alwaysFailReloader) Reload(context.Context) error {
+	r.calls.Add(1)
+	if r.after != nil {
+		r.after()
+	}
+	select {
+	case r.called <- struct{}{}:
+	default:
+	}
+	return r.err
+}
+
 // TestLoadProviders_Interruptible verifies that a stop signal,
 // modeled by canceling the context, unblocks the initial provider load even
 // when the reloader is stuck waiting for coderd. This guards the standalone
@@ -51,7 +86,7 @@ func TestLoadProviders_Interruptible(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- loadProviders(runCtx, reloader, logger)
+		done <- loadProviders(runCtx, reloader, logger, nil)
 	}()
 
 	// Wait for the reload to be in-flight, then cancel as a signal would.
@@ -60,21 +95,6 @@ func TestLoadProviders_Interruptible(t *testing.T) {
 
 	err := testutil.RequireReceive(testCtx, t, done)
 	require.ErrorIs(t, err, context.Canceled)
-}
-
-// failThenSucceedReloader fails the first failUntil reloads, then succeeds,
-// modeling a coderd connection or provider fetch that recovers after a few
-// transient failures.
-type failThenSucceedReloader struct {
-	calls     atomic.Int32
-	failUntil int32
-}
-
-func (r *failThenSucceedReloader) Reload(_ context.Context) error {
-	if r.calls.Add(1) <= r.failUntil {
-		return xerrors.New("transient failure")
-	}
-	return nil
 }
 
 // TestLoadProviders_RetrySucceeds verifies loadProviders keeps retrying past
@@ -86,6 +106,25 @@ func TestLoadProviders_RetrySucceeds(t *testing.T) {
 	ctx := testutil.Context(t, testutil.WaitShort)
 	reloader := &failThenSucceedReloader{failUntil: 2}
 
-	require.NoError(t, loadProviders(ctx, reloader, slog.Make()))
+	require.NoError(t, loadProviders(ctx, reloader, slog.Make(), nil))
 	require.GreaterOrEqual(t, reloader.calls.Load(), int32(3))
+}
+
+func TestLoadProviders_AIBridgedDoneStopsRetry(t *testing.T) {
+	t.Parallel()
+
+	errMsg := "aibridged fatal"
+	ctx := testutil.Context(t, testutil.WaitShort)
+	aibridgedDone := make(chan struct{})
+	reloader := &alwaysFailReloader{
+		err:    xerrors.New(errMsg),
+		called: make(chan struct{}, 1),
+		after: func() {
+			close(aibridgedDone)
+		},
+	}
+
+	err := loadProviders(ctx, reloader, slog.Make(), aibridgedDone)
+	require.ErrorContains(t, err, errMsg)
+	require.Equal(t, int32(1), reloader.calls.Load())
 }

--- a/enterprise/cli/aigatewaystart_internal_test.go
+++ b/enterprise/cli/aigatewaystart_internal_test.go
@@ -89,3 +89,39 @@ func TestLoadProviders_RetrySucceeds(t *testing.T) {
 	require.NoError(t, loadProviders(ctx, reloader, slog.Make()))
 	require.GreaterOrEqual(t, reloader.calls.Load(), int32(3))
 }
+
+// TestAIGatewayStart_DeploymentOptions pins the AI Gateway deployment options
+// the standalone "ai-gateway start" command exposes. Only settings the gateway
+// actually consumes when building providers from the DRPC-sourced provider set
+// (circuit breaker, BYOK, actor headers, dump dir) should be inherited.
+// Provider-seeding and coderd-only options (Enabled, Retention, MaxConcurrency,
+// RateLimit, StructuredLogging, InjectCoderMCPTools) must not leak into
+// standalone mode. This guards against a new option silently slipping in.
+func TestAIGatewayStart_DeploymentOptions(t *testing.T) {
+	t.Parallel()
+
+	cmd := (&RootCmd{}).aiGatewayStart()
+
+	// The command's own flags have no Group; inherited deployment options
+	// carry the "AI Gateway" group.
+	var got []string
+	for _, opt := range cmd.Options {
+		if opt.Group != nil && opt.Group.Name == "AI Gateway" {
+			got = append(got, opt.Env)
+		}
+	}
+
+	want := []string{
+		"CODER_AI_GATEWAY_ALLOW_BYOK",
+		"CODER_AI_GATEWAY_CIRCUIT_BREAKER_ENABLED",
+		"CODER_AI_GATEWAY_CIRCUIT_BREAKER_FAILURE_THRESHOLD",
+		"CODER_AI_GATEWAY_CIRCUIT_BREAKER_INTERVAL",
+		"CODER_AI_GATEWAY_CIRCUIT_BREAKER_MAX_REQUESTS",
+		"CODER_AI_GATEWAY_CIRCUIT_BREAKER_TIMEOUT",
+		"CODER_AI_GATEWAY_DUMP_DIR",
+		"CODER_AI_GATEWAY_SEND_ACTOR_HEADERS",
+		"CODER_AI_GATEWAY_MAX_CONCURRENCY",
+		"CODER_AI_GATEWAY_RATE_LIMIT",
+	}
+	require.ElementsMatch(t, want, got)
+}

--- a/enterprise/cli/aigatewaystart_internal_test.go
+++ b/enterprise/cli/aigatewaystart_internal_test.go
@@ -128,3 +128,33 @@ func TestLoadProviders_AIBridgedDoneStopsRetry(t *testing.T) {
 	require.ErrorContains(t, err, errMsg)
 	require.Equal(t, int32(1), reloader.calls.Load())
 }
+
+func TestAIGatewayStart_DeploymentOptions(t *testing.T) {
+	t.Parallel()
+
+	cmd := (&RootCmd{}).aiGatewayStart()
+
+	// Standalone Gateway only consumes options used in LLM traffic.
+	// Coderd-only settings such as provider seeds, retention,
+	// structured logging, and Coder MCP injection must stay server-only.
+	var got []string
+	for _, opt := range cmd.Options {
+		if opt.Group != nil && opt.Group.Name == "AI Gateway" {
+			got = append(got, opt.Env)
+		}
+	}
+
+	want := []string{
+		"CODER_AI_GATEWAY_ALLOW_BYOK",
+		"CODER_AI_GATEWAY_CIRCUIT_BREAKER_ENABLED",
+		"CODER_AI_GATEWAY_CIRCUIT_BREAKER_FAILURE_THRESHOLD",
+		"CODER_AI_GATEWAY_CIRCUIT_BREAKER_INTERVAL",
+		"CODER_AI_GATEWAY_CIRCUIT_BREAKER_MAX_REQUESTS",
+		"CODER_AI_GATEWAY_CIRCUIT_BREAKER_TIMEOUT",
+		"CODER_AI_GATEWAY_DUMP_DIR",
+		"CODER_AI_GATEWAY_MAX_CONCURRENCY",
+		"CODER_AI_GATEWAY_RATE_LIMIT",
+		"CODER_AI_GATEWAY_SEND_ACTOR_HEADERS",
+	}
+	require.ElementsMatch(t, want, got)
+}

--- a/enterprise/cli/aigatewaystart_internal_test.go
+++ b/enterprise/cli/aigatewaystart_internal_test.go
@@ -4,6 +4,8 @@ package cli
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 
@@ -129,12 +131,67 @@ func TestLoadProviders_AIBridgedDoneStopsRetry(t *testing.T) {
 	require.Equal(t, int32(1), reloader.calls.Load())
 }
 
+func TestResolveAIGatewayKey(t *testing.T) {
+	t.Parallel()
+
+	keyFile := filepath.Join(t.TempDir(), "gateway.key")
+	require.NoError(t, os.WriteFile(keyFile, []byte("file-key\n"), 0o600))
+
+	tests := []struct {
+		name    string
+		key     string
+		keyFile string
+		want    string
+		wantErr string
+	}{
+		{
+			name:    "Nothing set",
+			wantErr: keyFlagsMissingErr,
+		},
+		{
+			name: "Key",
+			key:  "flag-key",
+			want: "flag-key",
+		},
+		{
+			name:    "KeyFile",
+			keyFile: keyFile,
+			want:    "file-key",
+		},
+		{
+			name:    "MutuallyExclusive",
+			key:     "flag-key",
+			keyFile: keyFile,
+			wantErr: keyFlagsExclusiveErr,
+		},
+		{
+			name:    "MissingKeyFile",
+			keyFile: filepath.Join(t.TempDir(), "missing.key"),
+			wantErr: "read AI Gateway key file",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := resolveAIGatewayKey(tc.key, tc.keyFile)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestAIGatewayStart_DeploymentOptions(t *testing.T) {
 	t.Parallel()
 
 	cmd := (&RootCmd{}).aiGatewayStart()
 
-	// Standalone Gateway only consumes options used in LLM traffic.
+	// Standalone Gateway only consumes deployment options used in LLM traffic.
 	// Coderd-only settings such as provider seeds, retention,
 	// structured logging, and Coder MCP injection must stay server-only.
 	var got []string

--- a/enterprise/cli/aigatewaystart_slim.go
+++ b/enterprise/cli/aigatewaystart_slim.go
@@ -1,0 +1,24 @@
+//go:build slim
+
+package cli
+
+import (
+	agplcli "github.com/coder/coder/v2/cli"
+	"github.com/coder/serpent"
+)
+
+func (r *RootCmd) aiGatewayStart() *serpent.Command {
+	cmd := &serpent.Command{
+		Use:   "start",
+		Short: "Run a standalone AI Gateway server",
+		// We accept RawArgs so all commands and flags are accepted.
+		RawArgs: true,
+		Hidden:  true,
+		Handler: func(inv *serpent.Invocation) error {
+			agplcli.SlimUnsupported(inv.Stderr, "ai-gateway start")
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/enterprise/cli/testdata/coder_ai-gateway_--help.golden
+++ b/enterprise/cli/testdata/coder_ai-gateway_--help.golden
@@ -6,7 +6,8 @@ USAGE:
   Manage AI Gateway
 
 SUBCOMMANDS:
-    keys    Manage AI Gateway keys
+    keys     Manage AI Gateway keys
+    start    Run a standalone AI Gateway server
 
 ———
 Run `coder --help` for a list of global options.

--- a/enterprise/cli/testdata/coder_ai-gateway_start_--help.golden
+++ b/enterprise/cli/testdata/coder_ai-gateway_start_--help.golden
@@ -1,0 +1,151 @@
+coder v0.0.0-devel
+
+USAGE:
+  coder ai-gateway start [flags]
+
+  Run a standalone AI Gateway server
+
+  The standalone AI Gateway connects to a Coder deployment over DRPC to
+  authenticate users, record interceptions, and configure MCP, while serving LLM
+  client traffic on its own HTTP listener.
+  
+  The deployment address is taken from the global --url flag (CODER_URL) and is
+  required. The gateway authenticates with the key from --key
+  (CODER_AI_GATEWAY_KEY). Provider and other AI Gateway settings use the same
+  CODER_AI_GATEWAY_* options as embedded mode.
+
+OPTIONS:
+      --http-address string, $CODER_AI_GATEWAY_HTTP_ADDRESS (default: 127.0.0.1:4001)
+          The bind address to serve incoming AI Gateway client traffic.
+
+      --key string, $CODER_AI_GATEWAY_KEY
+          The AI Gateway key used to authenticate to coderd.
+
+      --tls-cert-file string, $CODER_AI_GATEWAY_TLS_CERT_FILE
+          Path to a PEM-encoded TLS certificate. Enables TLS termination when
+          set together with --tls-key-file.
+
+      --tls-key-file string, $CODER_AI_GATEWAY_TLS_KEY_FILE
+          Path to a PEM-encoded TLS private key. Enables TLS termination when
+          set together with --tls-cert-file.
+
+      --verbose bool, $CODER_AI_GATEWAY_VERBOSE (default: false)
+          Output debug-level logs.
+
+AI GATEWAY OPTIONS: 
+      --ai-budget-period month, $CODER_AI_BUDGET_PERIOD (default: month)
+          Determines when accumulated AI spend resets to zero, aligned to UTC
+          calendar boundaries. Only "month" is currently supported.
+
+      --ai-budget-policy highest, $CODER_AI_BUDGET_POLICY (default: highest)
+          Determines the effective group when a user belongs to multiple groups
+          with AI budgets. "highest" selects the group with the largest spend
+          limit, and is currently the only supported value.
+
+      --ai-gateway-dump-dir string, $CODER_AI_GATEWAY_DUMP_DIR
+          Base directory for dumping AI Bridge request/response pairs to disk
+          for debugging. When set, each provider writes under a subdirectory
+          named after the provider. Sensitive headers are redacted. Leave empty
+          to disable.
+
+      --ai-gateway-allow-byok bool, $CODER_AI_GATEWAY_ALLOW_BYOK (default: true)
+          Allow users to provide their own LLM API keys or subscriptions. When
+          disabled, only centralized key authentication is permitted.
+
+      --ai-gateway-anthropic-base-url string, $CODER_AI_GATEWAY_ANTHROPIC_BASE_URL (default: https://api.anthropic.com/)
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The base URL of the Anthropic
+          API.
+
+      --ai-gateway-anthropic-key string, $CODER_AI_GATEWAY_ANTHROPIC_KEY
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The key to authenticate
+          against the Anthropic API.
+
+      --ai-gateway-bedrock-access-key string, $CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The access key to authenticate
+          against the AWS Bedrock API.
+
+      --ai-gateway-bedrock-access-key-secret string, $CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY_SECRET
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The access key secret to use
+          with the access key to authenticate against the AWS Bedrock API.
+
+      --ai-gateway-bedrock-base-url string, $CODER_AI_GATEWAY_BEDROCK_BASE_URL
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The base URL to use for the
+          AWS Bedrock API. Use this setting to specify an exact URL to use.
+          Takes precedence over CODER_AI_GATEWAY_BEDROCK_REGION.
+
+      --ai-gateway-bedrock-model string, $CODER_AI_GATEWAY_BEDROCK_MODEL (default: global.anthropic.claude-sonnet-4-5-20250929-v1:0)
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The model to use when making
+          requests to the AWS Bedrock API.
+
+      --ai-gateway-bedrock-region string, $CODER_AI_GATEWAY_BEDROCK_REGION
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The AWS Bedrock API region to
+          use. Constructs a base URL to use for the AWS Bedrock API in the form
+          of 'https://bedrock-runtime.<region>.amazonaws.com'.
+
+      --ai-gateway-bedrock-small-fastmodel string, $CODER_AI_GATEWAY_BEDROCK_SMALL_FAST_MODEL (default: global.anthropic.claude-haiku-4-5-20251001-v1:0)
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The small fast model to use
+          when making requests to the AWS Bedrock API. Claude Code uses
+          Haiku-class models to perform background tasks. See
+          https://docs.claude.com/en/docs/claude-code/settings#environment-variables.
+
+      --ai-gateway-circuit-breaker-enabled bool, $CODER_AI_GATEWAY_CIRCUIT_BREAKER_ENABLED (default: false)
+          Enable the circuit breaker to protect against cascading failures from
+          upstream AI provider overload (503, 529).
+
+      --ai-gateway-retention duration, $CODER_AI_GATEWAY_RETENTION (default: 60d)
+          Length of time to retain data such as interceptions and all related
+          records (token, prompt, tool use).
+
+      --ai-gateway-enabled bool, $CODER_AI_GATEWAY_ENABLED (default: true)
+          Whether to start an in-memory AI Gateway instance.
+
+      --ai-gateway-max-concurrency int, $CODER_AI_GATEWAY_MAX_CONCURRENCY (default: 0)
+          Maximum number of concurrent AI Gateway requests per replica. Set to 0
+          to disable (unlimited).
+
+      --ai-gateway-openai-base-url string, $CODER_AI_GATEWAY_OPENAI_BASE_URL (default: https://api.openai.com/v1/)
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The base URL of the OpenAI
+          API.
+
+      --ai-gateway-openai-key string, $CODER_AI_GATEWAY_OPENAI_KEY
+          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
+          this option seeds provider configuration at startup only exactly once.
+          It will not be used in service runtime. The key to authenticate
+          against the OpenAI API.
+
+      --ai-gateway-rate-limit int, $CODER_AI_GATEWAY_RATE_LIMIT (default: 0)
+          Maximum number of AI Gateway requests per second per replica. Set to 0
+          to disable (unlimited).
+
+      --ai-gateway-send-actor-headers bool, $CODER_AI_GATEWAY_SEND_ACTOR_HEADERS (default: false)
+          Once enabled, extra headers will be added to upstream requests to
+          identify the user (actor) making requests to AI Gateway. This is only
+          needed if you are using a proxy between AI Gateway and an upstream AI
+          provider. This will send X-Ai-Bridge-Actor-Id (the ID of the user
+          making the request) and X-Ai-Bridge-Actor-Metadata-Username (their
+          username).
+
+      --ai-gateway-structured-logging bool, $CODER_AI_GATEWAY_STRUCTURED_LOGGING (default: false)
+          Emit structured logs for AI Gateway interception records. Use this for
+          exporting these records to external SIEM or observability systems.
+
+———
+Run `coder --help` for a list of global options.

--- a/enterprise/cli/testdata/coder_ai-gateway_start_--help.golden
+++ b/enterprise/cli/testdata/coder_ai-gateway_start_--help.golden
@@ -11,8 +11,9 @@ USAGE:
   
   The deployment address is taken from the global --url flag (CODER_URL) and is
   required. The gateway authenticates with the key from --key
-  (CODER_AI_GATEWAY_KEY). Provider and other AI Gateway settings use the same
-  CODER_AI_GATEWAY_* options as embedded mode.
+  (CODER_AI_GATEWAY_KEY). The provider set is fetched from coderd over DRPC;
+  other AI Gateway settings use the same CODER_AI_GATEWAY_* options as embedded
+  mode.
 
 OPTIONS:
       --http-address string, $CODER_AI_GATEWAY_HTTP_ADDRESS (default: 127.0.0.1:4001)

--- a/enterprise/cli/testdata/coder_ai-gateway_start_--help.golden
+++ b/enterprise/cli/testdata/coder_ai-gateway_start_--help.golden
@@ -5,15 +5,13 @@ USAGE:
 
   Run a standalone AI Gateway server
 
-  The standalone AI Gateway connects to a Coder deployment over DRPC to
-  authenticate users, record interceptions, and configure MCP, while serving LLM
-  client traffic on its own HTTP listener.
+  Runs a standalone replica of the AI Gateway. Standalone replicas serve LLM
+  client traffic on a dedicated HTTP listener and connect to a Coder deployment
+  over DRPC.
   
-  The deployment address is taken from the global --url flag (CODER_URL) and is
-  required. The gateway authenticates with the key from --key
-  (CODER_AI_GATEWAY_KEY). The provider set is fetched from coderd over DRPC;
-  other AI Gateway settings use the same CODER_AI_GATEWAY_* options as embedded
-  mode.
+  Set --url or CODER_URL to the Coder deployment address, and set --key or
+  CODER_AI_GATEWAY_KEY to the AI Gateway key used for gateway-to-coderd
+  authentication. A user login or session token is not required.
 
 OPTIONS:
       --http-address string, $CODER_AI_GATEWAY_HTTP_ADDRESS (default: 127.0.0.1:4001)
@@ -34,17 +32,8 @@ OPTIONS:
           Output debug-level logs.
 
 AI GATEWAY OPTIONS: 
-      --ai-budget-period month, $CODER_AI_BUDGET_PERIOD (default: month)
-          Determines when accumulated AI spend resets to zero, aligned to UTC
-          calendar boundaries. Only "month" is currently supported.
-
-      --ai-budget-policy highest, $CODER_AI_BUDGET_POLICY (default: highest)
-          Determines the effective group when a user belongs to multiple groups
-          with AI budgets. "highest" selects the group with the largest spend
-          limit, and is currently the only supported value.
-
       --ai-gateway-dump-dir string, $CODER_AI_GATEWAY_DUMP_DIR
-          Base directory for dumping AI Bridge request/response pairs to disk
+          Base directory for dumping AI Gateway request/response pairs to disk
           for debugging. When set, each provider writes under a subdirectory
           named after the provider. Sensitive headers are redacted. Leave empty
           to disable.
@@ -53,84 +42,13 @@ AI GATEWAY OPTIONS:
           Allow users to provide their own LLM API keys or subscriptions. When
           disabled, only centralized key authentication is permitted.
 
-      --ai-gateway-anthropic-base-url string, $CODER_AI_GATEWAY_ANTHROPIC_BASE_URL (default: https://api.anthropic.com/)
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
-          this option seeds provider configuration at startup only exactly once.
-          It will not be used in service runtime. The base URL of the Anthropic
-          API.
-
-      --ai-gateway-anthropic-key string, $CODER_AI_GATEWAY_ANTHROPIC_KEY
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
-          this option seeds provider configuration at startup only exactly once.
-          It will not be used in service runtime. The key to authenticate
-          against the Anthropic API.
-
-      --ai-gateway-bedrock-access-key string, $CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
-          this option seeds provider configuration at startup only exactly once.
-          It will not be used in service runtime. The access key to authenticate
-          against the AWS Bedrock API.
-
-      --ai-gateway-bedrock-access-key-secret string, $CODER_AI_GATEWAY_BEDROCK_ACCESS_KEY_SECRET
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
-          this option seeds provider configuration at startup only exactly once.
-          It will not be used in service runtime. The access key secret to use
-          with the access key to authenticate against the AWS Bedrock API.
-
-      --ai-gateway-bedrock-base-url string, $CODER_AI_GATEWAY_BEDROCK_BASE_URL
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
-          this option seeds provider configuration at startup only exactly once.
-          It will not be used in service runtime. The base URL to use for the
-          AWS Bedrock API. Use this setting to specify an exact URL to use.
-          Takes precedence over CODER_AI_GATEWAY_BEDROCK_REGION.
-
-      --ai-gateway-bedrock-model string, $CODER_AI_GATEWAY_BEDROCK_MODEL (default: global.anthropic.claude-sonnet-4-5-20250929-v1:0)
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
-          this option seeds provider configuration at startup only exactly once.
-          It will not be used in service runtime. The model to use when making
-          requests to the AWS Bedrock API.
-
-      --ai-gateway-bedrock-region string, $CODER_AI_GATEWAY_BEDROCK_REGION
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
-          this option seeds provider configuration at startup only exactly once.
-          It will not be used in service runtime. The AWS Bedrock API region to
-          use. Constructs a base URL to use for the AWS Bedrock API in the form
-          of 'https://bedrock-runtime.<region>.amazonaws.com'.
-
-      --ai-gateway-bedrock-small-fastmodel string, $CODER_AI_GATEWAY_BEDROCK_SMALL_FAST_MODEL (default: global.anthropic.claude-haiku-4-5-20251001-v1:0)
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
-          this option seeds provider configuration at startup only exactly once.
-          It will not be used in service runtime. The small fast model to use
-          when making requests to the AWS Bedrock API. Claude Code uses
-          Haiku-class models to perform background tasks. See
-          https://docs.claude.com/en/docs/claude-code/settings#environment-variables.
-
       --ai-gateway-circuit-breaker-enabled bool, $CODER_AI_GATEWAY_CIRCUIT_BREAKER_ENABLED (default: false)
           Enable the circuit breaker to protect against cascading failures from
           upstream AI provider overload (503, 529).
 
-      --ai-gateway-retention duration, $CODER_AI_GATEWAY_RETENTION (default: 60d)
-          Length of time to retain data such as interceptions and all related
-          records (token, prompt, tool use).
-
-      --ai-gateway-enabled bool, $CODER_AI_GATEWAY_ENABLED (default: true)
-          Whether to start an in-memory AI Gateway instance.
-
       --ai-gateway-max-concurrency int, $CODER_AI_GATEWAY_MAX_CONCURRENCY (default: 0)
           Maximum number of concurrent AI Gateway requests per replica. Set to 0
           to disable (unlimited).
-
-      --ai-gateway-openai-base-url string, $CODER_AI_GATEWAY_OPENAI_BASE_URL (default: https://api.openai.com/v1/)
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
-          this option seeds provider configuration at startup only exactly once.
-          It will not be used in service runtime. The base URL of the OpenAI
-          API.
-
-      --ai-gateway-openai-key string, $CODER_AI_GATEWAY_OPENAI_KEY
-          Deprecated: manage AI Providers from the Coder UI or HTTP API. If set,
-          this option seeds provider configuration at startup only exactly once.
-          It will not be used in service runtime. The key to authenticate
-          against the OpenAI API.
 
       --ai-gateway-rate-limit int, $CODER_AI_GATEWAY_RATE_LIMIT (default: 0)
           Maximum number of AI Gateway requests per second per replica. Set to 0
@@ -143,10 +61,6 @@ AI GATEWAY OPTIONS:
           provider. This will send X-Ai-Bridge-Actor-Id (the ID of the user
           making the request) and X-Ai-Bridge-Actor-Metadata-Username (their
           username).
-
-      --ai-gateway-structured-logging bool, $CODER_AI_GATEWAY_STRUCTURED_LOGGING (default: false)
-          Emit structured logs for AI Gateway interception records. Use this for
-          exporting these records to external SIEM or observability systems.
 
 ———
 Run `coder --help` for a list of global options.

--- a/enterprise/cli/testdata/coder_ai-gateway_start_--help.golden
+++ b/enterprise/cli/testdata/coder_ai-gateway_start_--help.golden
@@ -9,9 +9,9 @@ USAGE:
   client traffic on a dedicated HTTP listener and connect to coderd using the
   Coder deployment URL and an AI Gateway key.
   
-  Set --url or CODER_URL to the Coder deployment address, and set --key or
-  CODER_AI_GATEWAY_KEY to the AI Gateway key. A user login or session token is
-  not required.
+  Set --url or CODER_URL to the Coder deployment address, and set --key
+  (CODER_AI_GATEWAY_KEY) or --key-file (CODER_AI_GATEWAY_KEY_FILE). A user login
+  or session token is not required.
 
 OPTIONS:
       --http-address string, $CODER_AI_GATEWAY_HTTP_ADDRESS (default: 127.0.0.1:4001)
@@ -19,6 +19,10 @@ OPTIONS:
 
       --key string, $CODER_AI_GATEWAY_KEY
           The AI Gateway key used to authenticate to coderd.
+
+      --key-file string, $CODER_AI_GATEWAY_KEY_FILE
+          Path to a file containing the AI Gateway key used to authenticate to
+          coderd.
 
       --tls-cert-file string, $CODER_AI_GATEWAY_TLS_CERT_FILE
           Path to a PEM-encoded TLS certificate. Enables TLS termination when

--- a/enterprise/cli/testdata/coder_ai-gateway_start_--help.golden
+++ b/enterprise/cli/testdata/coder_ai-gateway_start_--help.golden
@@ -6,12 +6,12 @@ USAGE:
   Run a standalone AI Gateway server
 
   Runs a standalone replica of the AI Gateway. Standalone replicas serve LLM
-  client traffic on a dedicated HTTP listener and connect to a Coder deployment
-  over DRPC.
+  client traffic on a dedicated HTTP listener and connect to coderd using the
+  Coder deployment URL and an AI Gateway key.
   
   Set --url or CODER_URL to the Coder deployment address, and set --key or
-  CODER_AI_GATEWAY_KEY to the AI Gateway key used for gateway-to-coderd
-  authentication. A user login or session token is not required.
+  CODER_AI_GATEWAY_KEY to the AI Gateway key. A user login or session token is
+  not required.
 
 OPTIONS:
       --http-address string, $CODER_AI_GATEWAY_HTTP_ADDRESS (default: 127.0.0.1:4001)

--- a/enterprise/coderd/aibridge.go
+++ b/enterprise/coderd/aibridge.go
@@ -72,12 +72,6 @@ func aiGatewayHTTPHandler(api *API, middlewares ...func(http.Handler) http.Handl
 // under /aibridge. The stripPrefix parameter selects which URL prefix
 // to strip before forwarding to the in-memory aibridged handler.
 func aiBridgeRoutes(api *API, stripPrefix string, middlewares ...func(http.Handler) http.Handler) func(r chi.Router) {
-	// Build the overload protection middleware chain for the aibridged handler.
-	// These limits are applied per-replica.
-	bridgeCfg := api.DeploymentValues.AI.BridgeConfig
-	concurrencyLimiter := httpmw.ConcurrencyLimit(bridgeCfg.MaxConcurrency.Value(), "AI Gateway")
-	rateLimiter := httpmw.RateLimitByAuthToken(int(bridgeCfg.RateLimit.Value()), aiBridgeRateLimitWindow)
-
 	return func(r chi.Router) {
 		r.Use(api.RequireFeatureMW(codersdk.FeatureAIBridge))
 		r.Group(func(r chi.Router) {
@@ -88,10 +82,10 @@ func aiBridgeRoutes(api *API, stripPrefix string, middlewares ...func(http.Handl
 			r.Get("/clients", api.aiBridgeListClients)
 		})
 
-		// Apply overload protection middleware to the aibridged handler.
-		// Concurrency limit is checked first for faster rejection under load.
+		// Apply the shared per-request data-plane middleware (per-replica
+		// overload protection plus BYOK gating) to the aibridged handler.
 		r.Group(func(r chi.Router) {
-			r.Use(concurrencyLimiter, rateLimiter)
+			r.Use(AIGatewayDataPlaneMiddleware(api.DeploymentValues.AI.BridgeConfig))
 			// This is a bit funky but since aibridge only exposes a HTTP
 			// handler, this is how it has to be.
 			r.HandleFunc("/*", func(rw http.ResponseWriter, r *http.Request) {
@@ -103,19 +97,36 @@ func aiBridgeRoutes(api *API, stripPrefix string, middlewares ...func(http.Handl
 					return
 				}
 
-				// Reject BYOK requests when the deployment has not
-				// enabled bring-your-own-key mode.
-				if agplaibridge.IsBYOK(r.Header) && !bridgeCfg.AllowBYOK.Value() {
-					httpapi.Write(r.Context(), rw, http.StatusForbidden, codersdk.Response{
-						Message: "Bring Your Own Key (BYOK) mode is not enabled.",
-						Detail:  "Contact your administrator to enable it with --aibridge-allow-byok.",
-					})
-					return
-				}
-
 				// Strip the prefix and relay to the aibridged handler.
 				http.StripPrefix(stripPrefix, handler).ServeHTTP(rw, r)
 			})
+		})
+	}
+}
+
+// AIGatewayDataPlaneMiddleware returns the per-request middleware chain that
+// guards the AI Gateway data-plane handler. It is the single source of truth
+// shared by the embedded route and the standalone gateway.
+func AIGatewayDataPlaneMiddleware(cfg codersdk.AIBridgeConfig) func(http.Handler) http.Handler {
+	concurrencyLimiter := httpmw.ConcurrencyLimit(cfg.MaxConcurrency.Value(), "AI Gateway")
+	rateLimiter := httpmw.RateLimitByAuthToken(int(cfg.RateLimit.Value()), aiBridgeRateLimitWindow)
+	byokGuard := aiGatewayBYOKGuard(cfg)
+	return func(next http.Handler) http.Handler {
+		return concurrencyLimiter(rateLimiter(byokGuard(next)))
+	}
+}
+
+func aiGatewayBYOKGuard(cfg codersdk.AIBridgeConfig) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			if agplaibridge.IsBYOK(r.Header) && !cfg.AllowBYOK.Value() {
+				httpapi.Write(r.Context(), rw, http.StatusForbidden, codersdk.Response{
+					Message: "Bring Your Own Key (BYOK) mode is not enabled.",
+					Detail:  "Contact your administrator to enable it with --ai-gateway-allow-byok.",
+				})
+				return
+			}
+			next.ServeHTTP(rw, r)
 		})
 	}
 }

--- a/enterprise/coderd/aibridgeserve.go
+++ b/enterprise/coderd/aibridgeserve.go
@@ -66,7 +66,7 @@ func (api *API) aiGatewayServe(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	clientAPIVersion := r.URL.Query().Get("version")
+	clientAPIVersion := r.URL.Query().Get(aibridgedproto.VersionQueryParam)
 	clientCoderVersion := r.Header.Get(codersdk.BuildVersionHeader)
 	logger := api.Logger.Named("aigateway-serve").With(
 		slog.F("remote_addr", r.RemoteAddr),
@@ -88,7 +88,7 @@ func (api *API) aiGatewayServe(rw http.ResponseWriter, r *http.Request) {
 		httpapi.Write(keyCtx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Incompatible or unparsable version",
 			Validations: []codersdk.ValidationError{
-				{Field: "version", Detail: err.Error()},
+				{Field: aibridgedproto.VersionQueryParam, Detail: err.Error()},
 				{Field: "client_api_version", Detail: clientAPIVersion},
 				{Field: "server_api_version", Detail: aibridgedproto.CurrentVersion.String()},
 			},

--- a/enterprise/coderd/aibridgeserve.go
+++ b/enterprise/coderd/aibridgeserve.go
@@ -131,7 +131,7 @@ func (api *API) aiGatewayServe(rw http.ResponseWriter, r *http.Request) {
 	if _, err := aiGatewayUpdateKeyLastHeartbeat(connCtx, api, gatewayKey.ID); err != nil {
 		logger.Warn(connCtx, "update ai gateway key last heartbeat", slog.Error(err))
 	}
-	go aiGatewayTrackKeyUsage(connCtx, keyCtxCancel, api, gatewayKey.ID, logger)
+	go aiGatewayCheckEntitlementAndTrackKeyUsage(connCtx, keyCtxCancel, api, gatewayKey.ID, logger)
 
 	mux := drpcmux.New()
 	srv, err := aibridgedserver.NewServer(
@@ -194,8 +194,11 @@ func aiGatewayUpdateKeyLastHeartbeat(ctx context.Context, api *API, keyID uuid.U
 	return rows > 0, nil
 }
 
-// aiGatewayTrackKeyUsage refreshes last_heartbeat_at for keyID on a fixed interval until ctx is canceled.
-func aiGatewayTrackKeyUsage(ctx context.Context, ctxCancel context.CancelFunc, api *API, keyID uuid.UUID, logger slog.Logger) {
+// aiGatewayCheckEntitlementAndTrackKeyUsage until ctx is canceled on a fixed interval:
+// - refreshes last_heartbeat_at for keyID.
+// - checks if key still exists, cancels ctx if it does not.
+// - checks if the AI Gov entitlement is still enabled, cancels ctx if it is not.
+func aiGatewayCheckEntitlementAndTrackKeyUsage(ctx context.Context, ctxCancel context.CancelFunc, api *API, keyID uuid.UUID, logger slog.Logger) {
 	ticker, done := api.NewTicker(aiGatewayKeyHeartbeatInterval)
 	defer done()
 
@@ -210,6 +213,13 @@ func aiGatewayTrackKeyUsage(ctx context.Context, ctxCancel context.CancelFunc, a
 		active, err := aiGatewayUpdateKeyLastHeartbeat(ctx, api, keyID)
 		if err == nil && !active {
 			logger.Info(ctx, "ai gateway key no longer exists, closing connection")
+			ctxCancel()
+			return
+		}
+
+		// Close connection when the entitlement is revoked.
+		if !api.Entitlements.Enabled(codersdk.FeatureAIBridge) {
+			logger.Info(ctx, "ai gateway entitlement no longer enabled, closing connection")
 			ctxCancel()
 			return
 		}

--- a/enterprise/coderd/aibridgeserve_test.go
+++ b/enterprise/coderd/aibridgeserve_test.go
@@ -75,7 +75,7 @@ func manualDialAIGatewayServe(ctx context.Context, t *testing.T, client *codersd
 func dialAIGatewayServe(ctx context.Context, t *testing.T, client *codersdk.Client, key string) (aibridged.DRPCClient, error) {
 	t.Helper()
 
-	dc, err := aibridged.NewWebsocketDialer(client, key)(ctx)
+	dc, err := aibridged.NewWebsocketDialer(client.URL, client.HTTPClient.Transport, key)(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/coderd/aibridgeserve_test.go
+++ b/enterprise/coderd/aibridgeserve_test.go
@@ -35,7 +35,7 @@ func manualDialAIGatewayServe(ctx context.Context, t *testing.T, client *codersd
 	require.NoError(t, err)
 	query := serverURL.Query()
 	if version != "" {
-		query.Set("version", version)
+		query.Set(aibridgedproto.VersionQueryParam, version)
 	}
 	serverURL.RawQuery = query.Encode()
 

--- a/enterprise/coderd/aibridgeserve_test.go
+++ b/enterprise/coderd/aibridgeserve_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/drpcsdk"
+	entcoderd "github.com/coder/coder/v2/enterprise/coderd"
 	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
 	"github.com/coder/coder/v2/enterprise/coderd/license"
 	"github.com/coder/coder/v2/testutil"
@@ -228,35 +229,65 @@ func TestAIGatewayServeMissingEntitlement(t *testing.T) {
 	require.Equal(t, http.StatusForbidden, sdkErr.StatusCode())
 }
 
-func TestAIGatewayServeDeletedKeyClosesActiveSession(t *testing.T) {
+func TestAIGatewayServeTrackKeyUsageClosesActiveSession(t *testing.T) {
 	t.Parallel()
 
-	tick := make(chan time.Time, 1)
-	opts := aibridgeOpts(t)
-	opts.Options.NewTicker = func(time.Duration) (<-chan time.Time, func()) {
-		return tick, func() {}
+	tests := []struct {
+		name   string
+		mutate func(context.Context, *codersdk.Client, *entcoderd.API, codersdk.CreateAIGatewayKeyResponse) error
+	}{
+		{
+			name: "DeletedKey",
+			mutate: func(ctx context.Context, client *codersdk.Client, _ *entcoderd.API, created codersdk.CreateAIGatewayKeyResponse) error {
+				//nolint:gocritic // Owner role is needed for gateway key management.
+				return client.DeleteAIGatewayKey(ctx, created.ID)
+			},
+		},
+		{
+			name: "RevokedEntitlement",
+			mutate: func(_ context.Context, _ *codersdk.Client, api *entcoderd.API, _ codersdk.CreateAIGatewayKeyResponse) error {
+				api.Entitlements.Modify(func(entitlements *codersdk.Entitlements) {
+					entitlements.Features[codersdk.FeatureAIBridge] = codersdk.Feature{
+						Entitlement: codersdk.EntitlementNotEntitled,
+						Enabled:     false,
+					}
+				})
+				return nil
+			},
+		},
 	}
 
-	client, _ := coderdenttest.New(t, opts)
-	ctx := testutil.Context(t, testutil.WaitLong)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	//nolint:gocritic // Owner role is needed for gateway key management.
-	created, err := client.CreateAIGatewayKey(ctx, codersdk.CreateAIGatewayKeyRequest{Name: "serve-delete-active"})
-	require.NoError(t, err)
+			tick := make(chan time.Time, 1)
+			opts := aibridgeOpts(t)
+			opts.Options.NewTicker = func(time.Duration) (<-chan time.Time, func()) {
+				return tick, func() {}
+			}
 
-	dc, err := dialAIGatewayServe(ctx, t, client, created.Key)
-	require.NoError(t, err)
+			client, _, api, _ := coderdenttest.NewWithAPI(t, opts)
+			ctx := testutil.Context(t, testutil.WaitLong)
 
-	//nolint:gocritic // Owner role is needed for gateway key management.
-	require.NoError(t, client.DeleteAIGatewayKey(ctx, created.ID))
+			//nolint:gocritic // Owner role is needed for gateway key management.
+			created, err := client.CreateAIGatewayKey(ctx, codersdk.CreateAIGatewayKeyRequest{Name: "serve-active"})
+			require.NoError(t, err)
 
-	tick <- time.Now() // trigger aiGatewayTrackKeyUsage.
-	require.Eventually(t, func() bool {
-		select {
-		case <-dc.DRPCConn().Closed():
-			return true
-		default:
-			return false
-		}
-	}, testutil.WaitShort, testutil.IntervalFast)
+			dc, err := dialAIGatewayServe(ctx, t, client, created.Key)
+			require.NoError(t, err)
+
+			require.NoError(t, tt.mutate(ctx, client, api, created))
+
+			tick <- time.Now() // trigger aiGatewayTrackKeyUsage.
+			require.Eventually(t, func() bool {
+				select {
+				case <-dc.DRPCConn().Closed():
+					return true
+				default:
+					return false
+				}
+			}, testutil.WaitShort, testutil.IntervalFast)
+		})
+	}
 }

--- a/enterprise/coderd/aibridgeserve_test.go
+++ b/enterprise/coderd/aibridgeserve_test.go
@@ -7,9 +7,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/yamux"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/coder/coder/v2/coderd/aibridged"
 	aibridgedproto "github.com/coder/coder/v2/coderd/aibridged/proto"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/codersdk"
@@ -21,11 +24,11 @@ import (
 	"github.com/coder/websocket"
 )
 
-// dialAIGatewayServe dials /api/v2/ai-gateway/serve, authenticating with the given
+// manualDialAIGatewayServe dials /api/v2/ai-gateway/serve, authenticating with the given
 // gateway key and API version. On a successful WebSocket upgrade it returns a
 // yamux session and http.StatusSwitchingProtocols. Otherwise it returns a nil
 // session and the HTTP status code coderd responded with.
-func dialAIGatewayServe(ctx context.Context, t *testing.T, client *codersdk.Client, key string, version string) (*yamux.Session, int) {
+func manualDialAIGatewayServe(ctx context.Context, t *testing.T, client *codersdk.Client, key string, version string) (*yamux.Session, int) {
 	t.Helper()
 
 	serverURL, err := client.URL.Parse("/api/v2/ai-gateway/serve")
@@ -68,6 +71,53 @@ func dialAIGatewayServe(ctx context.Context, t *testing.T, client *codersdk.Clie
 	return session, http.StatusSwitchingProtocols
 }
 
+// dialAIGatewayServe connects to /api/v2/ai-gateway/serve using the production NewWebsocketDialer.
+func dialAIGatewayServe(ctx context.Context, t *testing.T, client *codersdk.Client, key string) (aibridged.DRPCClient, error) {
+	t.Helper()
+
+	dc, err := aibridged.NewWebsocketDialer(client, key)(ctx)
+	if err != nil {
+		return nil, err
+	}
+	t.Cleanup(func() {
+		_ = dc.DRPCConn().Close()
+	})
+	return dc, nil
+}
+
+func requireAuthorizerServed(ctx context.Context, t *testing.T, dc aibridged.DRPCClient, sessionToken, wantOwnerID string) {
+	t.Helper()
+	resp, err := dc.IsAuthorized(ctx, &aibridgedproto.IsAuthorizedRequest{Key: sessionToken})
+	require.NoError(t, err)
+	require.Equal(t, wantOwnerID, resp.GetOwnerId())
+}
+
+func requireProviderConfiguratorServed(ctx context.Context, t *testing.T, dc aibridged.DRPCClient) {
+	t.Helper()
+
+	_, err := dc.GetAIProviders(ctx, &aibridgedproto.GetAIProvidersRequest{})
+	require.NoError(t, err)
+}
+
+func requireMCPConfiguratorServed(ctx context.Context, t *testing.T, dc aibridged.DRPCClient, userID string) {
+	t.Helper()
+	_, err := dc.GetMCPServerConfigs(ctx, &aibridgedproto.GetMCPServerConfigsRequest{UserId: userID})
+	require.NoError(t, err)
+}
+
+func requireRecorderServed(ctx context.Context, t *testing.T, dc aibridged.DRPCClient, initiatorID string) {
+	t.Helper()
+	_, err := dc.RecordInterception(ctx, &aibridgedproto.RecordInterceptionRequest{
+		Id:          uuid.NewString(),
+		InitiatorId: initiatorID,
+		ApiKeyId:    "serve-success-key",
+		Provider:    "openai",
+		Model:       "gpt-4",
+		StartedAt:   timestamppb.Now(),
+	})
+	require.NoError(t, err)
+}
+
 func TestAIGatewayServeSuccess(t *testing.T) {
 	t.Parallel()
 
@@ -78,18 +128,17 @@ func TestAIGatewayServeSuccess(t *testing.T) {
 	created, err := client.CreateAIGatewayKey(ctx, codersdk.CreateAIGatewayKeyRequest{Name: "serve-success"})
 	require.NoError(t, err)
 
-	session, status := dialAIGatewayServe(ctx, t, client, created.Key, aibridgedproto.CurrentVersion.String())
-	require.Equal(t, http.StatusSwitchingProtocols, status)
-	require.NotNil(t, session)
-
-	// The Authorizer service should be served and authorize the owner's
-	// session token, exercising a full DRPC round trip over the WebSocket.
-	authorizer := aibridgedproto.NewDRPCAuthorizerClient(drpcsdk.MultiplexedConn(session))
-	resp, err := authorizer.IsAuthorized(ctx, &aibridgedproto.IsAuthorizedRequest{
-		Key: client.SessionToken(),
-	})
+	// Dial with the production NewWebsocketDialer the standalone gateway uses;
+	// a successful return implies the WebSocket upgrade succeeded.
+	dc, err := dialAIGatewayServe(ctx, t, client, created.Key)
 	require.NoError(t, err)
-	require.Equal(t, firstUser.UserID.String(), resp.GetOwnerId())
+
+	// Exercise one RPC from each service in the DRPCClient union to verify the
+	// dialer wires every service and the serve mux registers them all.
+	requireAuthorizerServed(ctx, t, dc, client.SessionToken(), firstUser.UserID.String())
+	requireProviderConfiguratorServed(ctx, t, dc)
+	requireMCPConfiguratorServed(ctx, t, dc, firstUser.UserID.String())
+	requireRecorderServed(ctx, t, dc, firstUser.UserID.String())
 
 	// The session records liveness for the authenticating key.
 	require.Eventually(t, func() bool {
@@ -164,7 +213,7 @@ func TestAIGatewayServeKeyAndVersionValidationErr(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			_, status := dialAIGatewayServe(t.Context(), t, client, tc.key, tc.version)
+			_, status := manualDialAIGatewayServe(t.Context(), t, client, tc.key, tc.version)
 			require.Equal(t, tc.wantStatus, status)
 		})
 	}
@@ -184,8 +233,13 @@ func TestAIGatewayServeMissingEntitlement(t *testing.T) {
 	})
 	ctx := testutil.Context(t, testutil.WaitLong)
 
-	_, status := dialAIGatewayServe(ctx, t, client, "any-key", aibridgedproto.CurrentVersion.String())
-	require.Equal(t, http.StatusForbidden, status)
+	// The production dialer must surface the upgrade failure as a
+	// *codersdk.Error so the standalone gateway's connect loop can detect the
+	// 403 and stop retrying instead of looping forever.
+	_, err := dialAIGatewayServe(ctx, t, client, "any-key")
+	var sdkErr *codersdk.Error
+	require.ErrorAs(t, err, &sdkErr)
+	require.Equal(t, http.StatusForbidden, sdkErr.StatusCode())
 }
 
 func TestAIGatewayServeDeletedKeyClosesActiveSession(t *testing.T) {
@@ -204,9 +258,8 @@ func TestAIGatewayServeDeletedKeyClosesActiveSession(t *testing.T) {
 	created, err := client.CreateAIGatewayKey(ctx, codersdk.CreateAIGatewayKeyRequest{Name: "serve-delete-active"})
 	require.NoError(t, err)
 
-	session, status := dialAIGatewayServe(ctx, t, client, created.Key, aibridgedproto.CurrentVersion.String())
-	require.Equal(t, http.StatusSwitchingProtocols, status)
-	require.NotNil(t, session)
+	dc, err := dialAIGatewayServe(ctx, t, client, created.Key)
+	require.NoError(t, err)
 
 	//nolint:gocritic // Owner role is needed for gateway key management.
 	require.NoError(t, client.DeleteAIGatewayKey(ctx, created.ID))
@@ -214,7 +267,7 @@ func TestAIGatewayServeDeletedKeyClosesActiveSession(t *testing.T) {
 	tick <- time.Now() // trigger aiGatewayTrackKeyUsage.
 	require.Eventually(t, func() bool {
 		select {
-		case <-session.CloseChan():
+		case <-dc.DRPCConn().Closed():
 			return true
 		default:
 			return false

--- a/enterprise/coderd/aibridgeserve_test.go
+++ b/enterprise/coderd/aibridgeserve_test.go
@@ -232,62 +232,81 @@ func TestAIGatewayServeMissingEntitlement(t *testing.T) {
 func TestAIGatewayServeTrackKeyUsageClosesActiveSession(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name   string
-		mutate func(context.Context, *codersdk.Client, *entcoderd.API, codersdk.CreateAIGatewayKeyResponse) error
-	}{
-		{
-			name: "DeletedKey",
-			mutate: func(ctx context.Context, client *codersdk.Client, _ *entcoderd.API, created codersdk.CreateAIGatewayKeyResponse) error {
-				//nolint:gocritic // Owner role is needed for gateway key management.
-				return client.DeleteAIGatewayKey(ctx, created.ID)
-			},
-		},
-		{
-			name: "RevokedEntitlement",
-			mutate: func(_ context.Context, _ *codersdk.Client, api *entcoderd.API, _ codersdk.CreateAIGatewayKeyResponse) error {
-				api.Entitlements.Modify(func(entitlements *codersdk.Entitlements) {
-					entitlements.Features[codersdk.FeatureAIBridge] = codersdk.Feature{
-						Entitlement: codersdk.EntitlementNotEntitled,
-						Enabled:     false,
-					}
-				})
-				return nil
-			},
-		},
+	t.Run("DeletedKey", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		session := setupActiveAIGatewayServeSession(ctx, t)
+
+		//nolint:gocritic // Owner role is needed for gateway key management.
+		require.NoError(t, session.client.DeleteAIGatewayKey(ctx, session.created.ID))
+		requireAIGatewayServeSessionClosed(t, session)
+	})
+
+	t.Run("RevokedEntitlement", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		session := setupActiveAIGatewayServeSession(ctx, t)
+
+		licenses, err := session.client.Licenses(ctx)
+		require.NoError(t, err)
+		for _, license := range licenses {
+			require.NoError(t, session.client.DeleteLicense(ctx, license.ID))
+		}
+		require.Eventually(t, func() bool {
+			return !session.api.Entitlements.Enabled(codersdk.FeatureAIBridge)
+		}, testutil.WaitShort, testutil.IntervalFast)
+
+		requireAIGatewayServeSessionClosed(t, session)
+	})
+}
+
+type activeAIGatewayServeSession struct {
+	client  *codersdk.Client
+	api     *entcoderd.API
+	created codersdk.CreateAIGatewayKeyResponse
+	tick    chan time.Time
+	dc      aibridged.DRPCClient
+}
+
+func setupActiveAIGatewayServeSession(ctx context.Context, t *testing.T) activeAIGatewayServeSession {
+	t.Helper()
+
+	tick := make(chan time.Time, 1)
+	opts := aibridgeOpts(t)
+	opts.Options.NewTicker = func(time.Duration) (<-chan time.Time, func()) {
+		return tick, func() {}
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+	client, _, api, _ := coderdenttest.NewWithAPI(t, opts)
 
-			tick := make(chan time.Time, 1)
-			opts := aibridgeOpts(t)
-			opts.Options.NewTicker = func(time.Duration) (<-chan time.Time, func()) {
-				return tick, func() {}
-			}
+	//nolint:gocritic // Owner role is needed for gateway key management.
+	created, err := client.CreateAIGatewayKey(ctx, codersdk.CreateAIGatewayKeyRequest{Name: "key-name"})
+	require.NoError(t, err)
 
-			client, _, api, _ := coderdenttest.NewWithAPI(t, opts)
-			ctx := testutil.Context(t, testutil.WaitLong)
+	dc, err := dialAIGatewayServe(ctx, t, client, created.Key)
+	require.NoError(t, err)
 
-			//nolint:gocritic // Owner role is needed for gateway key management.
-			created, err := client.CreateAIGatewayKey(ctx, codersdk.CreateAIGatewayKeyRequest{Name: "key-name"})
-			require.NoError(t, err)
-
-			dc, err := dialAIGatewayServe(ctx, t, client, created.Key)
-			require.NoError(t, err)
-
-			require.NoError(t, tc.mutate(ctx, client, api, created))
-
-			tick <- time.Now() // trigger aiGatewayTrackKeyUsage.
-			require.Eventually(t, func() bool {
-				select {
-				case <-dc.DRPCConn().Closed():
-					return true
-				default:
-					return false
-				}
-			}, testutil.WaitShort, testutil.IntervalFast)
-		})
+	return activeAIGatewayServeSession{
+		client:  client,
+		api:     api,
+		created: created,
+		tick:    tick,
+		dc:      dc,
 	}
+}
+
+func requireAIGatewayServeSessionClosed(t *testing.T, s activeAIGatewayServeSession) {
+	t.Helper()
+
+	s.tick <- time.Now() // trigger aiGatewayTrackKeyUsage.
+	require.Eventually(t, func() bool {
+		select {
+		case <-s.dc.DRPCConn().Closed():
+			return true
+		default:
+			return false
+		}
+	}, testutil.WaitShort, testutil.IntervalFast)
 }

--- a/enterprise/coderd/aibridgeserve_test.go
+++ b/enterprise/coderd/aibridgeserve_test.go
@@ -257,8 +257,8 @@ func TestAIGatewayServeTrackKeyUsageClosesActiveSession(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			tick := make(chan time.Time, 1)
@@ -271,13 +271,13 @@ func TestAIGatewayServeTrackKeyUsageClosesActiveSession(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitLong)
 
 			//nolint:gocritic // Owner role is needed for gateway key management.
-			created, err := client.CreateAIGatewayKey(ctx, codersdk.CreateAIGatewayKeyRequest{Name: "serve-active"})
+			created, err := client.CreateAIGatewayKey(ctx, codersdk.CreateAIGatewayKeyRequest{Name: "key-name"})
 			require.NoError(t, err)
 
 			dc, err := dialAIGatewayServe(ctx, t, client, created.Key)
 			require.NoError(t, err)
 
-			require.NoError(t, tt.mutate(ctx, client, api, created))
+			require.NoError(t, tc.mutate(ctx, client, api, created))
 
 			tick <- time.Now() // trigger aiGatewayTrackKeyUsage.
 			require.Eventually(t, func() bool {

--- a/enterprise/coderd/aibridgeserve_test.go
+++ b/enterprise/coderd/aibridgeserve_test.go
@@ -285,7 +285,7 @@ func setupActiveAIGatewayServeSession(ctx context.Context, t *testing.T) activeA
 func requireAIGatewayServeSessionClosed(t *testing.T, s activeAIGatewayServeSession) {
 	t.Helper()
 
-	s.tick <- time.Now() // trigger aiGatewayTrackKeyUsage.
+	s.tick <- time.Now() // trigger gateway key / license check.
 	require.Eventually(t, func() bool {
 		select {
 		case <-s.dc.DRPCConn().Closed():

--- a/enterprise/coderd/aibridgeserve_test.go
+++ b/enterprise/coderd/aibridgeserve_test.go
@@ -2,13 +2,11 @@ package coderd_test
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/hashicorp/yamux"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -16,67 +14,44 @@ import (
 	aibridgedproto "github.com/coder/coder/v2/coderd/aibridged/proto"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/codersdk"
-	"github.com/coder/coder/v2/codersdk/drpcsdk"
 	entcoderd "github.com/coder/coder/v2/enterprise/coderd"
 	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
 	"github.com/coder/coder/v2/enterprise/coderd/license"
 	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/serpent"
-	"github.com/coder/websocket"
 )
 
-// manualDialAIGatewayServe dials /api/v2/ai-gateway/serve, authenticating with the given
-// gateway key and API version. On a successful WebSocket upgrade it returns a
-// yamux session and http.StatusSwitchingProtocols. Otherwise it returns a nil
-// session and the HTTP status code coderd responded with.
-func manualDialAIGatewayServe(ctx context.Context, t *testing.T, client *codersdk.Client, key string, version string) (*yamux.Session, int) {
-	t.Helper()
-
-	serverURL, err := client.URL.Parse("/api/v2/ai-gateway/serve")
-	require.NoError(t, err)
-	query := serverURL.Query()
-	if version != "" {
-		query.Set(aibridgedproto.VersionQueryParam, version)
-	}
-	serverURL.RawQuery = query.Encode()
-
-	headers := http.Header{}
-	if key != "" {
-		headers.Set(codersdk.AIGatewayKeyHeader, key)
-	}
-
-	conn, res, err := websocket.Dial(ctx, serverURL.String(), &websocket.DialOptions{
-		HTTPClient:      &http.Client{Transport: client.HTTPClient.Transport},
-		CompressionMode: websocket.CompressionDisabled,
-		HTTPHeader:      headers,
-	})
-	if err != nil {
-		statusCode := 0
-		if res != nil {
-			statusCode = res.StatusCode
-			_ = res.Body.Close()
-		}
-		return nil, statusCode
-	}
-	cfg := yamux.DefaultConfig()
-	cfg.LogOutput = io.Discard
-	_, wsNetConn := codersdk.WebsocketNetConn(context.Background(), conn, websocket.MessageBinary)
-	conn.SetReadLimit(drpcsdk.YamuxDefaultStreamWindowSize)
-	session, err := yamux.Client(wsNetConn, cfg)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = session.Close()
-		_ = wsNetConn.Close()
-		_ = conn.Close(websocket.StatusNormalClosure, "")
-	})
-	return session, http.StatusSwitchingProtocols
+type versionOverridingRoundTripper struct {
+	baseTransport      http.RoundTripper
+	overrideAPIVersion string
 }
 
-// dialAIGatewayServe connects to /api/v2/ai-gateway/serve using the production NewWebsocketDialer.
+func (f versionOverridingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	query := req.URL.Query()
+	query.Del(aibridgedproto.VersionQueryParam)
+	if f.overrideAPIVersion != "" {
+		query.Set(aibridgedproto.VersionQueryParam, f.overrideAPIVersion)
+	}
+	req.URL.RawQuery = query.Encode()
+	return f.baseTransport.RoundTrip(req)
+}
+
 func dialAIGatewayServe(ctx context.Context, t *testing.T, client *codersdk.Client, key string) (aibridged.DRPCClient, error) {
+	return dialAIGatewayServeWithVersion(ctx, t, client, key, nil)
+}
+
+func dialAIGatewayServeWithVersion(ctx context.Context, t *testing.T, client *codersdk.Client, key string, version *string) (aibridged.DRPCClient, error) {
 	t.Helper()
 
-	dc, err := aibridged.NewWebsocketDialer(client.URL, client.HTTPClient.Transport, key)(ctx)
+	transport := client.HTTPClient.Transport
+	if version != nil {
+		transport = versionOverridingRoundTripper{
+			baseTransport:      transport,
+			overrideAPIVersion: *version,
+		}
+	}
+
+	dc, err := aibridged.NewWebsocketDialer(client.URL, transport, key)(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -160,48 +135,58 @@ func TestAIGatewayServeKeyAndVersionValidationErr(t *testing.T) {
 	require.NoError(t, client.DeleteAIGatewayKey(ctx, revoked.ID))
 
 	tests := []struct {
-		name       string
-		key        string
-		version    string
-		wantStatus int
+		name        string
+		key         string
+		version     string
+		wantStatus  int
+		wantMessage string
 	}{
 		{
-			name:       "MissingKey",
-			key:        "",
-			version:    aibridgedproto.CurrentVersion.String(),
-			wantStatus: http.StatusUnauthorized,
+			name:        "MissingKey",
+			key:         "",
+			version:     aibridgedproto.CurrentVersion.String(),
+			wantStatus:  http.StatusUnauthorized,
+			wantMessage: "AI Gateway key required.",
 		},
 		{
-			name:       "InvalidKey",
-			key:        "not-a-real-key",
-			version:    aibridgedproto.CurrentVersion.String(),
-			wantStatus: http.StatusUnauthorized,
+			name:        "InvalidKey",
+			key:         "not-a-real-key",
+			version:     aibridgedproto.CurrentVersion.String(),
+			wantStatus:  http.StatusUnauthorized,
+			wantMessage: "AI Gateway key invalid.",
 		},
 		{
-			name:       "RevokedKey",
-			key:        revoked.Key,
-			version:    aibridgedproto.CurrentVersion.String(),
-			wantStatus: http.StatusUnauthorized,
+			name:        "RevokedKey",
+			key:         revoked.Key,
+			version:     aibridgedproto.CurrentVersion.String(),
+			wantStatus:  http.StatusUnauthorized,
+			wantMessage: "AI Gateway key invalid.",
 		},
 		{
-			name:       "IncompatibleVersion",
-			key:        validKey,
-			version:    "999.0",
-			wantStatus: http.StatusBadRequest,
+			name:        "IncompatibleVersion",
+			key:         validKey,
+			version:     "999.0",
+			wantStatus:  http.StatusBadRequest,
+			wantMessage: "Incompatible or unparsable version",
 		},
 		{
-			name:       "MissingVersion",
-			key:        validKey,
-			version:    "",
-			wantStatus: http.StatusBadRequest,
+			name:        "MissingVersion",
+			key:         validKey,
+			version:     "",
+			wantStatus:  http.StatusBadRequest,
+			wantMessage: "Incompatible or unparsable version",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			_, status := manualDialAIGatewayServe(t.Context(), t, client, tc.key, tc.version)
-			require.Equal(t, tc.wantStatus, status)
+
+			_, err := dialAIGatewayServeWithVersion(t.Context(), t, client, tc.key, &tc.version)
+			var sdkErr *codersdk.Error
+			require.ErrorAs(t, err, &sdkErr)
+			require.Equal(t, tc.wantStatus, sdkErr.StatusCode())
+			require.Contains(t, sdkErr.Error(), tc.wantMessage)
 		})
 	}
 }

--- a/enterprise/coderd/aibridgeserve_test.go
+++ b/enterprise/coderd/aibridgeserve_test.go
@@ -85,39 +85,6 @@ func dialAIGatewayServe(ctx context.Context, t *testing.T, client *codersdk.Clie
 	return dc, nil
 }
 
-func requireAuthorizerServed(ctx context.Context, t *testing.T, dc aibridged.DRPCClient, sessionToken, wantOwnerID string) {
-	t.Helper()
-	resp, err := dc.IsAuthorized(ctx, &aibridgedproto.IsAuthorizedRequest{Key: sessionToken})
-	require.NoError(t, err)
-	require.Equal(t, wantOwnerID, resp.GetOwnerId())
-}
-
-func requireProviderConfiguratorServed(ctx context.Context, t *testing.T, dc aibridged.DRPCClient) {
-	t.Helper()
-
-	_, err := dc.GetAIProviders(ctx, &aibridgedproto.GetAIProvidersRequest{})
-	require.NoError(t, err)
-}
-
-func requireMCPConfiguratorServed(ctx context.Context, t *testing.T, dc aibridged.DRPCClient, userID string) {
-	t.Helper()
-	_, err := dc.GetMCPServerConfigs(ctx, &aibridgedproto.GetMCPServerConfigsRequest{UserId: userID})
-	require.NoError(t, err)
-}
-
-func requireRecorderServed(ctx context.Context, t *testing.T, dc aibridged.DRPCClient, initiatorID string) {
-	t.Helper()
-	_, err := dc.RecordInterception(ctx, &aibridgedproto.RecordInterceptionRequest{
-		Id:          uuid.NewString(),
-		InitiatorId: initiatorID,
-		ApiKeyId:    "serve-success-key",
-		Provider:    "openai",
-		Model:       "gpt-4",
-		StartedAt:   timestamppb.Now(),
-	})
-	require.NoError(t, err)
-}
-
 func TestAIGatewayServeSuccess(t *testing.T) {
 	t.Parallel()
 
@@ -128,19 +95,38 @@ func TestAIGatewayServeSuccess(t *testing.T) {
 	created, err := client.CreateAIGatewayKey(ctx, codersdk.CreateAIGatewayKeyRequest{Name: "serve-success"})
 	require.NoError(t, err)
 
-	// Dial with the production NewWebsocketDialer the standalone gateway uses;
-	// a successful return implies the WebSocket upgrade succeeded.
+	// Use NewWebsocketDialer that production code of standalone gateway uses
 	dc, err := dialAIGatewayServe(ctx, t, client, created.Key)
 	require.NoError(t, err)
 
 	// Exercise one RPC from each service in the DRPCClient union to verify the
 	// dialer wires every service and the serve mux registers them all.
-	requireAuthorizerServed(ctx, t, dc, client.SessionToken(), firstUser.UserID.String())
-	requireProviderConfiguratorServed(ctx, t, dc)
-	requireMCPConfiguratorServed(ctx, t, dc, firstUser.UserID.String())
-	requireRecorderServed(ctx, t, dc, firstUser.UserID.String())
 
-	// The session records liveness for the authenticating key.
+	// DRPCAuthorizerClient
+	resp, err := dc.IsAuthorized(ctx, &aibridgedproto.IsAuthorizedRequest{Key: client.SessionToken()})
+	require.NoError(t, err)
+	require.Equal(t, firstUser.UserID.String(), resp.GetOwnerId())
+
+	// DRPCProviderConfiguratorClient
+	_, err = dc.GetAIProviders(ctx, &aibridgedproto.GetAIProvidersRequest{})
+	require.NoError(t, err)
+
+	// DRPCMCPConfiguratorClient
+	_, err = dc.GetMCPServerConfigs(ctx, &aibridgedproto.GetMCPServerConfigsRequest{UserId: firstUser.UserID.String()})
+	require.NoError(t, err)
+
+	// DRPCRecorderClient
+	_, err = dc.RecordInterception(ctx, &aibridgedproto.RecordInterceptionRequest{
+		Id:          uuid.NewString(),
+		InitiatorId: firstUser.UserID.String(),
+		ApiKeyId:    "serve-success-key",
+		Provider:    "openai",
+		Model:       "gpt-4",
+		StartedAt:   timestamppb.Now(),
+	})
+	require.NoError(t, err)
+
+	// Verify the session records liveness for the authenticating key.
 	require.Eventually(t, func() bool {
 		//nolint:gocritic // Owner role is needed for gateway key management.
 		keys, err := client.ListAIGatewayKeys(ctx)

--- a/enterprise/coderd/aibridgeserve_test.go
+++ b/enterprise/coderd/aibridgeserve_test.go
@@ -135,32 +135,36 @@ func TestAIGatewayServeKeyAndVersionValidationErr(t *testing.T) {
 	require.NoError(t, client.DeleteAIGatewayKey(ctx, revoked.ID))
 
 	tests := []struct {
-		name        string
-		key         string
-		version     string
-		wantStatus  int
-		wantMessage string
+		name             string
+		key              string
+		version          string
+		wantStatus       int
+		wantMessage      string
+		forbidErrMessage string
 	}{
 		{
-			name:        "MissingKey",
-			key:         "",
-			version:     aibridgedproto.CurrentVersion.String(),
-			wantStatus:  http.StatusUnauthorized,
-			wantMessage: "AI Gateway key required.",
+			name:             "MissingKey",
+			key:              "",
+			version:          aibridgedproto.CurrentVersion.String(),
+			wantStatus:       http.StatusUnauthorized,
+			wantMessage:      "AI Gateway key required.",
+			forbidErrMessage: "Try logging in",
 		},
 		{
-			name:        "InvalidKey",
-			key:         "not-a-real-key",
-			version:     aibridgedproto.CurrentVersion.String(),
-			wantStatus:  http.StatusUnauthorized,
-			wantMessage: "AI Gateway key invalid.",
+			name:             "InvalidKey",
+			key:              "not-a-real-key",
+			version:          aibridgedproto.CurrentVersion.String(),
+			wantStatus:       http.StatusUnauthorized,
+			wantMessage:      "AI Gateway key invalid.",
+			forbidErrMessage: "Try logging in",
 		},
 		{
-			name:        "RevokedKey",
-			key:         revoked.Key,
-			version:     aibridgedproto.CurrentVersion.String(),
-			wantStatus:  http.StatusUnauthorized,
-			wantMessage: "AI Gateway key invalid.",
+			name:             "RevokedKey",
+			key:              revoked.Key,
+			version:          aibridgedproto.CurrentVersion.String(),
+			wantStatus:       http.StatusUnauthorized,
+			wantMessage:      "AI Gateway key invalid.",
+			forbidErrMessage: "Try logging in",
 		},
 		{
 			name:        "IncompatibleVersion",
@@ -187,6 +191,9 @@ func TestAIGatewayServeKeyAndVersionValidationErr(t *testing.T) {
 			require.ErrorAs(t, err, &sdkErr)
 			require.Equal(t, tc.wantStatus, sdkErr.StatusCode())
 			require.Contains(t, sdkErr.Error(), tc.wantMessage)
+			if tc.forbidErrMessage != "" {
+				require.NotContains(t, sdkErr.Error(), tc.forbidErrMessage)
+			}
 		})
 	}
 }


### PR DESCRIPTION
> AI Tools were used to produce this PR

This PR adds `coder ai-gateway start` command that runs the AI Gateway as an independent process.

- Standalone process doesn't have access to DB. Uses  DRPC services under `/api/v2/ai-gateway/serve`for auth, recording and provider initialization.
- It only handles LLM traffic, other endpoints (eg. `/sessions`) are only available though `coderd`.
- The standalone gateway reuses applicable flags from AI Gateway deployment options. Provider-seeding and coderd-only options are excluded.
- Only added to fat build, the slim build stub rejects the command.

Some wiring used by this new command is added.

**`NewWebsocketDialer`** - implements the standalone gateway's connection to coderd's `/api/v2/ai-gateway/serve` endpoint. It upgrades to a WebSocket, multiplexes with yamux, and wires all DRPC services.

**`AIGatewayDataPlaneMiddleware`** - extracts the per-request middleware chain (concurrency limiting, rate limiting, BYOK gating) into a shared function used by both the embedded route and the standalone gateway.

**`RootCmd.ResolveClientConnection`** - resolve the deployment URL and builds an HTTP transport without requiring a session token. Used in `ai-gateway start`command as it authenticates using different credential type.