### PR TITLE
fix(agent/agentcontext): identify context sources by lexical path

### DIFF
--- a/agent/agentcontext/manager.go
+++ b/agent/agentcontext/manager.go
@@ -276,9 +276,8 @@ func (m *Manager) Sources() []Source {
 	return out
 }
 
-// HasSource reports whether path matches an existing source
-// after resolving it to its lexical identity. Returns the
-// lexical identity path on success.
+// HasSource reports whether path matches a registered source,
+// returning its lexical identity.
 func (m *Manager) HasSource(path string) (canonical string, ok bool) {
 	c, err := lexicalPath(path)
 	if err != nil {
@@ -290,18 +289,15 @@ func (m *Manager) HasSource(path string) (canonical string, ok bool) {
 	return c, ok
 }
 
-// AddSource adds a new source. The path is validated against
-// the AllowedRoots set using its resolved (symlink-followed)
-// form, but it is identified and stored by its lexical path so
-// the source listing reflects the configured path and stays
-// stable across symlink-target changes. AddSource is idempotent.
+// AddSource validates a new source against the AllowedRoots set
+// and registers it by its lexical identity. AddSource is
+// idempotent.
 func (m *Manager) AddSource(s Source) (Source, error) {
 	identity, err := lexicalPath(s.Path)
 	if err != nil {
 		return Source{}, xerrors.Errorf("canonicalize: %w", err)
 	}
-	// Validate the resolved path so a symlink cannot escape the
-	// allowed roots, even though identity is the lexical path.
+	// Validate the resolved path so symlinks can't escape the allowed roots.
 	resolved, err := CanonicalizePath(s.Path)
 	if err != nil {
 		return Source{}, xerrors.Errorf("canonicalize: %w", err)
@@ -324,20 +320,14 @@ func (m *Manager) AddSource(s Source) (Source, error) {
 	return Source{Path: identity}, nil
 }
 
-// SeedSources resolves and inserts a batch of trusted sources
-// without applying AllowedRoots validation. It is the
-// late-binding equivalent of ManagerOptions.InitialSources for
-// callers that need the working directory to resolve relative
-// paths but only learn the working directory after Run has
-// started. Paths that fail canonicalization are silently
-// skipped, matching the boot-time seeding contract. SeedSources
-// is idempotent: previously seeded sources are deduplicated by
-// their lexical identity.
+// SeedSources registers a batch of trusted sources without
+// AllowedRoots validation, the late-binding equivalent of
+// ManagerOptions.InitialSources for when the working directory
+// is only known after Run starts. Invalid paths are skipped and
+// duplicates are ignored.
 //
-// AddSource is the correct entry point for untrusted HTTP
-// callers; this method exists only for the agent's manifest-
-// triggered seeding from CODER_AGENT_EXP_*_DIRS, where the
-// template author already authorized the paths.
+// Untrusted callers must use AddSource; SeedSources exists only
+// for manifest-triggered seeding from CODER_AGENT_EXP_*_DIRS.
 func (m *Manager) SeedSources(sources []Source) {
 	if len(sources) == 0 {
 		return
@@ -363,10 +353,8 @@ func (m *Manager) SeedSources(sources []Source) {
 	}
 }
 
-// RemoveSource removes the source matching path. Path is
-// resolved to its lexical identity before matching. Returns
-// ErrSourceNotFound when no such source exists or when the path
-// cannot be canonicalized.
+// RemoveSource removes the source matching path by its lexical
+// identity, returning ErrSourceNotFound if none matches.
 func (m *Manager) RemoveSource(path string) error {
 	identity, err := lexicalPath(path)
 	if err != nil {
@@ -396,9 +384,8 @@ func (m *Manager) RemoveSource(path string) error {
 	return nil
 }
 
-// addSourceLocked appends a source identified by its lexical path unless an
-// identical identity is already registered. It reports whether a new source
-// was added. m.mu must be held.
+// addSourceLocked registers identity unless already present,
+// reporting whether it was added. m.mu must be held.
 func (m *Manager) addSourceLocked(identity string) bool {
 	if _, ok := m.sourceIndex[identity]; ok {
 		return false

--- a/agent/agentcontext/manager.go
+++ b/agent/agentcontext/manager.go
@@ -2,6 +2,7 @@ package agentcontext
 
 import (
 	"context"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -167,11 +168,7 @@ func NewManager(opts ManagerOptions) *Manager {
 				slog.Error(err))
 			continue
 		}
-		if _, ok := m.sourceIndex[canonical]; ok {
-			continue
-		}
-		m.sourceIndex[canonical] = len(m.sources)
-		m.sources = append(m.sources, Source{Path: canonical})
+		m.addCanonicalSourceLocked(canonical)
 	}
 
 	// First snapshot is computed eagerly. The push protocol
@@ -307,8 +304,8 @@ func (m *Manager) AddSource(s Source) (Source, error) {
 	}
 
 	m.mu.Lock()
-	if _, ok := m.sourceIndex[canonical]; ok {
-		out := m.sources[m.sourceIndex[canonical]]
+	if idx, ok := m.resolvedSourceIndexLocked(canonical); ok {
+		out := m.sources[idx]
 		m.mu.Unlock()
 		return out, nil
 	}
@@ -349,12 +346,9 @@ func (m *Manager) SeedSources(sources []Source) {
 				slog.Error(err))
 			continue
 		}
-		if _, ok := m.sourceIndex[canonical]; ok {
-			continue
+		if m.addCanonicalSourceLocked(canonical) {
+			changed = true
 		}
-		m.sourceIndex[canonical] = len(m.sources)
-		m.sources = append(m.sources, Source{Path: canonical})
-		changed = true
 	}
 	m.mu.Unlock()
 	if changed {
@@ -392,6 +386,46 @@ func (m *Manager) RemoveSource(path string) error {
 
 	m.signal()
 	return nil
+}
+
+// resolvedSourceIndexLocked returns the index of an existing source that
+// refers to the same path as canonical, matching first by exact canonical
+// path and then by resolved filesystem identity. The identity fallback
+// collapses a symlink and its target (or a path canonicalized before vs
+// after its symlink target existed) onto a single source, so the source
+// list never reports the same directory twice. A path that does not exist
+// yet cannot be compared by identity, so it registers as-is. m.mu must be
+// held.
+func (m *Manager) resolvedSourceIndexLocked(canonical string) (int, bool) {
+	if idx, ok := m.sourceIndex[canonical]; ok {
+		return idx, true
+	}
+	info, err := os.Stat(canonical)
+	if err != nil {
+		return 0, false
+	}
+	for i, s := range m.sources {
+		existing, err := os.Stat(s.Path)
+		if err != nil {
+			continue
+		}
+		if os.SameFile(info, existing) {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// addCanonicalSourceLocked appends a canonical source unless it duplicates an
+// existing one by exact path or resolved filesystem identity. It reports
+// whether a new source was added. m.mu must be held.
+func (m *Manager) addCanonicalSourceLocked(canonical string) bool {
+	if _, ok := m.resolvedSourceIndexLocked(canonical); ok {
+		return false
+	}
+	m.sourceIndex[canonical] = len(m.sources)
+	m.sources = append(m.sources, Source{Path: canonical})
+	return true
 }
 
 // Snapshot returns the latest Snapshot. The returned value is

--- a/agent/agentcontext/manager.go
+++ b/agent/agentcontext/manager.go
@@ -2,7 +2,6 @@ package agentcontext
 
 import (
 	"context"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -157,7 +156,7 @@ func NewManager(opts ManagerOptions) *Manager {
 	}
 
 	for _, s := range opts.InitialSources {
-		canonical, err := CanonicalizePath(s.Path)
+		identity, err := lexicalPath(s.Path)
 		if err != nil {
 			// Initial sources may not exist yet at boot
 			// time; log and skip rather than abort the
@@ -168,7 +167,7 @@ func NewManager(opts ManagerOptions) *Manager {
 				slog.Error(err))
 			continue
 		}
-		m.addCanonicalSourceLocked(canonical)
+		m.addSourceLocked(identity)
 	}
 
 	// First snapshot is computed eagerly. The push protocol
@@ -278,10 +277,10 @@ func (m *Manager) Sources() []Source {
 }
 
 // HasSource reports whether path matches an existing source
-// after canonicalization. Returns the canonical path on
-// success.
+// after resolving it to its lexical identity. Returns the
+// lexical identity path on success.
 func (m *Manager) HasSource(path string) (canonical string, ok bool) {
-	c, err := CanonicalizePath(path)
+	c, err := lexicalPath(path)
 	if err != nil {
 		return "", false
 	}
@@ -291,41 +290,49 @@ func (m *Manager) HasSource(path string) (canonical string, ok bool) {
 	return c, ok
 }
 
-// AddSource adds a new source. The path is canonicalized and
-// validated against the AllowedRoots set. AddSource is
-// idempotent.
+// AddSource adds a new source. The path is validated against
+// the AllowedRoots set using its resolved (symlink-followed)
+// form, but it is identified and stored by its lexical path so
+// the source listing reflects the configured path and stays
+// stable across symlink-target changes. AddSource is idempotent.
 func (m *Manager) AddSource(s Source) (Source, error) {
-	canonical, err := CanonicalizePath(s.Path)
+	identity, err := lexicalPath(s.Path)
 	if err != nil {
 		return Source{}, xerrors.Errorf("canonicalize: %w", err)
 	}
-	if err := ValidateSourcePath(canonical, m.effectiveAllowedRoots()); err != nil {
+	// Validate the resolved path so a symlink cannot escape the
+	// allowed roots, even though identity is the lexical path.
+	resolved, err := CanonicalizePath(s.Path)
+	if err != nil {
+		return Source{}, xerrors.Errorf("canonicalize: %w", err)
+	}
+	if err := ValidateSourcePath(resolved, m.effectiveAllowedRoots()); err != nil {
 		return Source{}, err
 	}
 
 	m.mu.Lock()
-	if idx, ok := m.resolvedSourceIndexLocked(canonical); ok {
+	if idx, ok := m.sourceIndex[identity]; ok {
 		out := m.sources[idx]
 		m.mu.Unlock()
 		return out, nil
 	}
-	m.sourceIndex[canonical] = len(m.sources)
-	m.sources = append(m.sources, Source{Path: canonical})
+	m.sourceIndex[identity] = len(m.sources)
+	m.sources = append(m.sources, Source{Path: identity})
 	m.mu.Unlock()
 
 	m.signal()
-	return Source{Path: canonical}, nil
+	return Source{Path: identity}, nil
 }
 
-// SeedSources canonicalizes and inserts a batch of trusted
-// sources without applying AllowedRoots validation. It is the
+// SeedSources resolves and inserts a batch of trusted sources
+// without applying AllowedRoots validation. It is the
 // late-binding equivalent of ManagerOptions.InitialSources for
 // callers that need the working directory to resolve relative
 // paths but only learn the working directory after Run has
 // started. Paths that fail canonicalization are silently
 // skipped, matching the boot-time seeding contract. SeedSources
-// is idempotent: previously seeded canonical paths are
-// deduplicated via the existing source index.
+// is idempotent: previously seeded sources are deduplicated by
+// their lexical identity.
 //
 // AddSource is the correct entry point for untrusted HTTP
 // callers; this method exists only for the agent's manifest-
@@ -338,7 +345,7 @@ func (m *Manager) SeedSources(sources []Source) {
 	m.mu.Lock()
 	changed := false
 	for _, s := range sources {
-		canonical, err := CanonicalizePath(s.Path)
+		identity, err := lexicalPath(s.Path)
 		if err != nil {
 			m.logger.Warn(context.Background(),
 				"skipping invalid seeded source",
@@ -346,7 +353,7 @@ func (m *Manager) SeedSources(sources []Source) {
 				slog.Error(err))
 			continue
 		}
-		if m.addCanonicalSourceLocked(canonical) {
+		if m.addSourceLocked(identity) {
 			changed = true
 		}
 	}
@@ -357,10 +364,11 @@ func (m *Manager) SeedSources(sources []Source) {
 }
 
 // RemoveSource removes the source matching path. Path is
-// canonicalized before matching. Returns ErrSourceNotFound when
-// no such source exists or when the path cannot be canonicalized.
+// resolved to its lexical identity before matching. Returns
+// ErrSourceNotFound when no such source exists or when the path
+// cannot be canonicalized.
 func (m *Manager) RemoveSource(path string) error {
-	canonical, err := CanonicalizePath(path)
+	identity, err := lexicalPath(path)
 	if err != nil {
 		// A path that does not canonicalize cannot match any
 		// existing source. Mirror HasSource semantics by
@@ -370,7 +378,7 @@ func (m *Manager) RemoveSource(path string) error {
 	}
 
 	m.mu.Lock()
-	idx, ok := m.sourceIndex[canonical]
+	idx, ok := m.sourceIndex[identity]
 	if !ok {
 		m.mu.Unlock()
 		return ErrSourceNotFound
@@ -378,7 +386,7 @@ func (m *Manager) RemoveSource(path string) error {
 	// O(n) compaction is fine for the typical handful of
 	// user-added sources.
 	m.sources = append(m.sources[:idx], m.sources[idx+1:]...)
-	delete(m.sourceIndex, canonical)
+	delete(m.sourceIndex, identity)
 	for i := idx; i < len(m.sources); i++ {
 		m.sourceIndex[m.sources[i].Path] = i
 	}
@@ -388,43 +396,15 @@ func (m *Manager) RemoveSource(path string) error {
 	return nil
 }
 
-// resolvedSourceIndexLocked returns the index of an existing source that
-// refers to the same path as canonical, matching first by exact canonical
-// path and then by resolved filesystem identity. The identity fallback
-// collapses a symlink and its target (or a path canonicalized before vs
-// after its symlink target existed) onto a single source, so the source
-// list never reports the same directory twice. A path that does not exist
-// yet cannot be compared by identity, so it registers as-is. m.mu must be
-// held.
-func (m *Manager) resolvedSourceIndexLocked(canonical string) (int, bool) {
-	if idx, ok := m.sourceIndex[canonical]; ok {
-		return idx, true
-	}
-	info, err := os.Stat(canonical)
-	if err != nil {
-		return 0, false
-	}
-	for i, s := range m.sources {
-		existing, err := os.Stat(s.Path)
-		if err != nil {
-			continue
-		}
-		if os.SameFile(info, existing) {
-			return i, true
-		}
-	}
-	return 0, false
-}
-
-// addCanonicalSourceLocked appends a canonical source unless it duplicates an
-// existing one by exact path or resolved filesystem identity. It reports
-// whether a new source was added. m.mu must be held.
-func (m *Manager) addCanonicalSourceLocked(canonical string) bool {
-	if _, ok := m.resolvedSourceIndexLocked(canonical); ok {
+// addSourceLocked appends a source identified by its lexical path unless an
+// identical identity is already registered. It reports whether a new source
+// was added. m.mu must be held.
+func (m *Manager) addSourceLocked(identity string) bool {
+	if _, ok := m.sourceIndex[identity]; ok {
 		return false
 	}
-	m.sourceIndex[canonical] = len(m.sources)
-	m.sources = append(m.sources, Source{Path: canonical})
+	m.sourceIndex[identity] = len(m.sources)
+	m.sources = append(m.sources, Source{Path: identity})
 	return true
 }
 

--- a/agent/agentcontext/manager_test.go
+++ b/agent/agentcontext/manager_test.go
@@ -171,14 +171,9 @@ func TestManager_AddSourceIsIdempotent(t *testing.T) {
 	require.Len(t, sources, 1)
 }
 
-// TestManager_SourceIdentityIsLexicalAndStable guards the duplicate-source
-// bug: source identity is the lexical (configured) path, not the
-// symlink-resolved path. The same configured path is seeded at boot (before a
-// startup script creates the symlink target) and again once the target
-// exists. Resolving symlinks would yield two different strings for one
-// directory and list it twice; the lexical identity is stable across the
-// target's existence, so the source list collapses to a single entry that
-// keeps the path the operator configured.
+// TestManager_SourceIdentityIsLexicalAndStable verifies the same configured
+// source added before and after its symlink target exists collapses to one
+// source keyed by the lexical (configured) path, not the resolved target.
 func TestManager_SourceIdentityIsLexicalAndStable(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {
@@ -194,15 +189,13 @@ func TestManager_SourceIdentityIsLexicalAndStable(t *testing.T) {
 		AllowedRoots: []string{root},
 	})
 
-	// The symlink target does not exist yet. Identity is the lexical link
-	// path, not the resolved target.
+	// Target missing: identity is the lexical link path.
 	added1, err := m.AddSource(agentcontext.Source{Path: link})
 	require.NoError(t, err)
 	require.Equal(t, link, added1.Path)
 
-	// Create the target so the symlink now resolves, then add the same
-	// configured path again. Identity is lexical and therefore unchanged, so
-	// it must not register a second source.
+	// Once the target exists the link resolves, but the same configured
+	// path must still dedupe to one source.
 	require.NoError(t, os.MkdirAll(target, 0o755))
 	added2, err := m.AddSource(agentcontext.Source{Path: link})
 	require.NoError(t, err)

--- a/agent/agentcontext/manager_test.go
+++ b/agent/agentcontext/manager_test.go
@@ -171,6 +171,40 @@ func TestManager_AddSourceIsIdempotent(t *testing.T) {
 	require.Len(t, sources, 1)
 }
 
+// TestManager_AddSourceDedupesByResolvedIdentity guards the duplicate-source
+// bug: a path added before its symlink target exists canonicalizes to the
+// lexical link path, while the same directory added later (once the target
+// exists) canonicalizes to the resolved target. The two distinct path strings
+// denote one inode, so the source list must collapse them to a single entry.
+func TestManager_AddSourceDedupesByResolvedIdentity(t *testing.T) {
+	t.Parallel()
+	root := testutil.TempDirResolved(t)
+	target := filepath.Join(root, "target")
+	link := filepath.Join(root, "link")
+	require.NoError(t, os.Symlink(target, link))
+
+	m := newTestManager(t, agentcontext.ManagerOptions{
+		WorkingDir:   func() string { return root },
+		AllowedRoots: []string{root},
+	})
+
+	// The symlink target does not exist yet, so canonicalization keeps the
+	// lexical link path.
+	added1, err := m.AddSource(agentcontext.Source{Path: link})
+	require.NoError(t, err)
+	require.Equal(t, link, added1.Path)
+
+	// Create the target so the symlink resolves, then add it directly. It is
+	// the same inode as the link, so it must not register a second source.
+	require.NoError(t, os.MkdirAll(target, 0o755))
+	added2, err := m.AddSource(agentcontext.Source{Path: target})
+	require.NoError(t, err)
+	require.Equal(t, link, added2.Path,
+		"expected the target to collapse onto the existing link source")
+
+	require.Len(t, m.Sources(), 1)
+}
+
 func TestManager_RemoveSource(t *testing.T) {
 	t.Parallel()
 	wd := t.TempDir()

--- a/agent/agentcontext/manager_test.go
+++ b/agent/agentcontext/manager_test.go
@@ -171,13 +171,19 @@ func TestManager_AddSourceIsIdempotent(t *testing.T) {
 	require.Len(t, sources, 1)
 }
 
-// TestManager_AddSourceDedupesByResolvedIdentity guards the duplicate-source
-// bug: a path added before its symlink target exists canonicalizes to the
-// lexical link path, while the same directory added later (once the target
-// exists) canonicalizes to the resolved target. The two distinct path strings
-// denote one inode, so the source list must collapse them to a single entry.
-func TestManager_AddSourceDedupesByResolvedIdentity(t *testing.T) {
+// TestManager_SourceIdentityIsLexicalAndStable guards the duplicate-source
+// bug: source identity is the lexical (configured) path, not the
+// symlink-resolved path. The same configured path is seeded at boot (before a
+// startup script creates the symlink target) and again once the target
+// exists. Resolving symlinks would yield two different strings for one
+// directory and list it twice; the lexical identity is stable across the
+// target's existence, so the source list collapses to a single entry that
+// keeps the path the operator configured.
+func TestManager_SourceIdentityIsLexicalAndStable(t *testing.T) {
 	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require admin privileges on Windows runners")
+	}
 	root := testutil.TempDirResolved(t)
 	target := filepath.Join(root, "target")
 	link := filepath.Join(root, "link")
@@ -188,19 +194,20 @@ func TestManager_AddSourceDedupesByResolvedIdentity(t *testing.T) {
 		AllowedRoots: []string{root},
 	})
 
-	// The symlink target does not exist yet, so canonicalization keeps the
-	// lexical link path.
+	// The symlink target does not exist yet. Identity is the lexical link
+	// path, not the resolved target.
 	added1, err := m.AddSource(agentcontext.Source{Path: link})
 	require.NoError(t, err)
 	require.Equal(t, link, added1.Path)
 
-	// Create the target so the symlink resolves, then add it directly. It is
-	// the same inode as the link, so it must not register a second source.
+	// Create the target so the symlink now resolves, then add the same
+	// configured path again. Identity is lexical and therefore unchanged, so
+	// it must not register a second source.
 	require.NoError(t, os.MkdirAll(target, 0o755))
-	added2, err := m.AddSource(agentcontext.Source{Path: target})
+	added2, err := m.AddSource(agentcontext.Source{Path: link})
 	require.NoError(t, err)
 	require.Equal(t, link, added2.Path,
-		"expected the target to collapse onto the existing link source")
+		"expected the source identity to stay the lexical link path")
 
 	require.Len(t, m.Sources(), 1)
 }

--- a/agent/agentcontext/paths.go
+++ b/agent/agentcontext/paths.go
@@ -8,15 +8,14 @@ import (
 	"golang.org/x/xerrors"
 )
 
-// CanonicalizePath produces the canonical form of a user-
-// supplied path. The result is absolute, has ~ expanded, has
-// path-traversal segments collapsed, and has symlinks resolved
-// when the target exists. The path is left lexically clean if
-// it does not yet exist (so adding a not-yet-created directory
-// remains possible).
-//
-// CanonicalizePath returns the original input when it is empty.
-func CanonicalizePath(raw string) (string, error) {
+// lexicalPath produces the lexically clean, absolute form of a
+// user-supplied path. The result is absolute, has ~ expanded,
+// and has path-traversal segments collapsed, but symlinks are
+// NOT resolved. It is the stable identity used to deduplicate
+// and display context sources: a source keeps the path the
+// operator configured, and that identity does not change when a
+// symlink target is created or removed later.
+func lexicalPath(raw string) (string, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return "", xerrors.New("path is empty")
@@ -44,7 +43,25 @@ func CanonicalizePath(raw string) (string, error) {
 		return "", xerrors.Errorf("path %q is not absolute", raw)
 	}
 
-	cleaned := filepath.Clean(raw)
+	return filepath.Clean(raw), nil
+}
+
+// CanonicalizePath produces the canonical form of a user-
+// supplied path. The result is absolute, has ~ expanded, has
+// path-traversal segments collapsed, and has symlinks resolved
+// when the target exists. The path is left lexically clean if
+// it does not yet exist (so adding a not-yet-created directory
+// remains possible).
+//
+// Symlink resolution makes the result time-dependent, so
+// CanonicalizePath is used for security validation (enforcing a
+// path's real target is inside an allowed root), not for source
+// identity. Use lexicalPath for identity.
+func CanonicalizePath(raw string) (string, error) {
+	cleaned, err := lexicalPath(raw)
+	if err != nil {
+		return "", err
+	}
 	if resolved, err := filepath.EvalSymlinks(cleaned); err == nil {
 		return resolved, nil
 	}

--- a/agent/agentcontext/paths.go
+++ b/agent/agentcontext/paths.go
@@ -8,22 +8,15 @@ import (
 	"golang.org/x/xerrors"
 )
 
-// lexicalPath produces the lexically clean, absolute form of a
-// user-supplied path. The result is absolute, has ~ expanded,
-// and has path-traversal segments collapsed, but symlinks are
-// NOT resolved. It is the stable identity used to deduplicate
-// and display context sources: a source keeps the path the
-// operator configured, and that identity does not change when a
-// symlink target is created or removed later.
+// lexicalPath returns raw as a cleaned, absolute path with ~
+// expanded and symlinks left unresolved.
 func lexicalPath(raw string) (string, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return "", xerrors.New("path is empty")
 	}
 
-	// Expand ~ and ~/ prefixes against the current user's home
-	// directory. Other ~user forms are not supported on
-	// purpose; the agent runs as a known user.
+	// ~user forms are intentionally unsupported.
 	if raw == "~" || strings.HasPrefix(raw, "~/") {
 		home, err := os.UserHomeDir()
 		if err != nil {
@@ -37,26 +30,15 @@ func lexicalPath(raw string) (string, error) {
 	}
 
 	if !filepath.IsAbs(raw) {
-		// Fail closed: relative paths could mean different
-		// things depending on the agent's working directory at
-		// add-time, so require the caller to absolutize first.
+		// Relative paths are ambiguous; require an absolute path.
 		return "", xerrors.Errorf("path %q is not absolute", raw)
 	}
 
 	return filepath.Clean(raw), nil
 }
 
-// CanonicalizePath produces the canonical form of a user-
-// supplied path. The result is absolute, has ~ expanded, has
-// path-traversal segments collapsed, and has symlinks resolved
-// when the target exists. The path is left lexically clean if
-// it does not yet exist (so adding a not-yet-created directory
-// remains possible).
-//
-// Symlink resolution makes the result time-dependent, so
-// CanonicalizePath is used for security validation (enforcing a
-// path's real target is inside an allowed root), not for source
-// identity. Use lexicalPath for identity.
+// CanonicalizePath returns lexicalPath with symlinks resolved
+// when the target exists.
 func CanonicalizePath(raw string) (string, error) {
 	cleaned, err := lexicalPath(raw)
 	if err != nil {


### PR DESCRIPTION
## What

Identify agent workspace-context **sources** by their lexical (configured) path so `coder exp chat context list` no longer shows the same directory twice, and so a source is shown as the path the operator actually configured.

## Why (the bug)

Source identity was the canonical path from `CanonicalizePath`, which resolves symlinks via `EvalSymlinks` **only when the target exists**. That makes canonicalization time-dependent:

- At boot the agent seeds sources from `CODER_AGENT_EXP_*_DIRS`. If `~/.coder/skills -> ~/my-agent/agent-rules/skills` and the target does not exist yet (a startup script creates it later), `~/.coder/skills` canonicalizes to the lexical `/home/coder/.coder/skills`.
- After the manifest lands (or the target is added directly), the same configured source canonicalizes to the resolved `/home/coder/my-agent/agent-rules/skills`.

The same configured source produced two different strings, so dedupe keyed on the string registered both and the list showed one directory twice.

Resolving symlinks for identity is also misleading on its own (per @mafredri's review): a source added by a symlink path appears in the list as its resolved target, as if that target had been added explicitly.

## How

Source identity is now the **lexical** path: cleaned, `~`-expanded, absolute, with symlinks **not** resolved (new `lexicalPath`; `CanonicalizePath` is refactored to build on it). `AddSource`, `SeedSources`, `HasSource`, `RemoveSource`, and boot seeding all key on this stable identity.

`AddSource` still **validates** the resolved (`CanonicalizePath`) path against the allowed roots, so a symlink cannot escape them. Only the identity/display path changed.

This replaces the earlier `os.SameFile`/inode dedupe, which was unstable and failed on Windows runners.

## Testing

- `go test ./agent/agentcontext/` (full package) and `go vet` pass; `gofmt` clean.
- `TestManager_SourceIdentityIsLexicalAndStable`: adds the same symlinked source before and after its target exists and asserts one source whose path is the lexical link (skipped on Windows, matching the package's other symlink tests).
- Existing `TestCanonicalizePath_FollowsSymlinks` and `TestValidateSourcePath_*` confirm symlink resolution and the security boundary are unchanged.

<details>
<summary>Related review findings</summary>

Fixes the "duplicate symlinked paths in `context list`" issue from the chat-context system review and the dedupe-ordering question (lexical identity preserves first-come-first-served order). Showing the configured path for **resources** (not just sources) and restoring scope-based skill precedence are separate, larger changes tracked elsewhere.

</details>

---

*This PR was created by Coder Agents on behalf of @kylecarbs.*