### PR TITLE
fix(cli): match context show resources by scan-root containment

### DIFF
--- a/cli/exp_chat.go
+++ b/cli/exp_chat.go
@@ -87,6 +87,40 @@ func resolveContextSourcePath(p string) (string, error) {
 	return abs, nil
 }
 
+// contextResourceFromSource reports whether a resolved snapshot resource was
+// contributed by the source at srcPath. A resource matches when the agent
+// attributed it to that user source (SourcePath), or when its own path lies at
+// or under the source root. The path-containment fallback is what makes
+// `show` useful for built-in and working-directory roots: the agent
+// deduplicates overlapping scan roots and attributes a resource to the first
+// (built-in / working-dir) root, leaving SourcePath empty, so matching on
+// SourcePath alone reports zero resources for an overlapping source. MCP
+// servers are keyed by a server name rather than a filesystem path, so they
+// are matched only by SourcePath.
+func contextResourceFromSource(res agentsocket.ContextResource, srcPath string) bool {
+	if srcPath == "" {
+		return false
+	}
+	if res.SourcePath == srcPath {
+		return true
+	}
+	if res.Kind == "mcp_server" || res.Source == "" {
+		return false
+	}
+	return res.Source == srcPath || posixPathWithin(res.Source, srcPath)
+}
+
+// posixPathWithin reports whether p is a descendant of dir using POSIX path
+// semantics. Agent context paths are absolute POSIX paths even when the CLI
+// runs on a Windows host, so this avoids host-OS filepath separators.
+func posixPathWithin(p, dir string) bool {
+	dir = strings.TrimRight(dir, "/")
+	if dir == "" {
+		return false
+	}
+	return strings.HasPrefix(p, dir+"/")
+}
+
 // dialAgentContextSocket connects to the workspace agent's local IPC socket.
 // It is only reachable from inside the workspace.
 func dialAgentContextSocket(ctx context.Context, socketPath string) (*agentsocket.Client, error) {
@@ -178,7 +212,7 @@ func (*RootCmd) chatContextShowCommand(socketPath *string) *serpent.Command {
 			}
 			resources := make([]agentsocket.ContextResource, 0, len(snap.Resources))
 			for _, res := range snap.Resources {
-				if res.SourcePath == src.Path {
+				if contextResourceFromSource(res, src.Path) {
 					resources = append(resources, res)
 				}
 			}

--- a/cli/exp_chat_internal_test.go
+++ b/cli/exp_chat_internal_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/agent/agentsocket"
 )
 
 func TestResolveContextSourcePath(t *testing.T) {
@@ -47,4 +49,132 @@ func TestResolveContextSourcePath(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, want, got)
 	})
+}
+
+func TestContextResourceFromSource(t *testing.T) {
+	t.Parallel()
+
+	// Built-in scan roots overlap user sources, and the agent attributes an
+	// overlapping resource to the first (built-in / working-dir) root, leaving
+	// SourcePath empty. `show` therefore has to fall back to path containment.
+	const (
+		coderHome = "/home/coder/.coder"
+		skillsDir = "/home/coder/coder/.agents/skills"
+	)
+
+	cases := []struct {
+		name    string
+		res     agentsocket.ContextResource
+		srcPath string
+		want    bool
+	}{
+		{
+			name: "ExplicitSourcePathMatch",
+			// SourcePath wins even when Source points elsewhere.
+			res: agentsocket.ContextResource{
+				Kind:       "instruction_file",
+				Source:     "/var/lib/builtin/AGENTS.md",
+				SourcePath: "/home/coder/AGENTS.md",
+			},
+			srcPath: "/home/coder/AGENTS.md",
+			want:    true,
+		},
+		{
+			name: "InstructionFileUnderBuiltinRoot",
+			// Empty SourcePath: matched only by containment under the root.
+			res: agentsocket.ContextResource{
+				Kind:   "instruction_file",
+				Source: coderHome + "/AGENTS.md",
+			},
+			srcPath: coderHome,
+			want:    true,
+		},
+		{
+			name: "SkillUnderSkillsRoot",
+			res: agentsocket.ContextResource{
+				Kind:   "skill",
+				Source: skillsDir + "/deploy/SKILL.md",
+			},
+			srcPath: skillsDir,
+			want:    true,
+		},
+		{
+			name: "ExactFileSource",
+			res: agentsocket.ContextResource{
+				Kind:   "instruction_file",
+				Source: "/home/coder/AGENTS.md",
+			},
+			srcPath: "/home/coder/AGENTS.md",
+			want:    true,
+		},
+		{
+			name: "DifferentSubtreeDoesNotMatch",
+			res: agentsocket.ContextResource{
+				Kind:   "skill",
+				Source: "/home/coder/other/skills/deploy/SKILL.md",
+			},
+			srcPath: skillsDir,
+			want:    false,
+		},
+		{
+			name: "SymlinkedSkillNotUnderBuiltinRoot",
+			// A skill resolved outside the built-in root must not be attributed
+			// to it just because the user added the built-in root.
+			res: agentsocket.ContextResource{
+				Kind:   "skill",
+				Source: "/home/coder/my-agent/skills/deploy/SKILL.md",
+			},
+			srcPath: coderHome,
+			want:    false,
+		},
+		{
+			name: "McpServerMatchedBySourcePath",
+			// Source carries the server name, not a path; SourcePath still matches.
+			res: agentsocket.ContextResource{
+				Kind:       "mcp_server",
+				Name:       "playwright",
+				Source:     "playwright",
+				SourcePath: "/home/coder/.mcp.json",
+			},
+			srcPath: "/home/coder/.mcp.json",
+			want:    true,
+		},
+		{
+			name: "McpServerNotMatchedByName",
+			// Server name in Source must never be treated as a path to contain.
+			res: agentsocket.ContextResource{
+				Kind:   "mcp_server",
+				Name:   "playwright",
+				Source: "playwright",
+			},
+			srcPath: "playwright",
+			want:    false,
+		},
+		{
+			name: "PrefixBoundaryNotMatched",
+			// /a/bc is not under /a/b despite the shared string prefix.
+			res: agentsocket.ContextResource{
+				Kind:   "instruction_file",
+				Source: "/a/bc/file.md",
+			},
+			srcPath: "/a/b",
+			want:    false,
+		},
+		{
+			name: "EmptySourcePathNeverMatches",
+			res: agentsocket.ContextResource{
+				Kind:   "instruction_file",
+				Source: "/home/coder/AGENTS.md",
+			},
+			srcPath: "",
+			want:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, contextResourceFromSource(tc.res, tc.srcPath))
+		})
+	}
 }


### PR DESCRIPTION
## Problem

`coder exp chat context show <path>` reports **0 resources** for many valid sources (for example a built-in root like `~/.coder` or the workspace working directory), even though those resources are present in the snapshot and injected into chat context.

## Root cause

The `show` handler filtered the snapshot with `res.SourcePath == src.Path`. Built-in and working-directory scan roots overlap user sources, and the resolver (`agent/agentcontext/resolve.go`) deduplicates overlapping scan roots by attributing each resource to the **first** (built-in / working-dir) root. That leaves `SourcePath` empty on the resource, so an exact-`SourcePath` filter matches nothing for the overlapping source.

## Fix

Match a resource to a source when:

- `SourcePath` equals the source path (unchanged, explicit attribution), **or**
- the resource's own path (`Source`) is equal to, or lies under, the source root.

Containment uses POSIX path semantics (`strings.HasPrefix(p, dir+"/")` after trimming a trailing slash) because agent context paths are absolute POSIX paths even when the CLI runs on a Windows host, and the boundary check avoids false positives like `/a/bc` matching `/a/b`.

MCP servers are keyed by a server **name** rather than a filesystem path, so they continue to match only by `SourcePath` and are never matched by containment.

## Tests

Adds `TestContextResourceFromSource` (table-driven) covering: explicit `SourcePath` match, built-in-root containment with empty `SourcePath`, skills under a skills root, exact file source, different-subtree non-match, a symlinked resource resolved outside a root, prefix-boundary safety, and MCP-server matching by `SourcePath` only.

```
go test ./cli/ -run 'TestContextResourceFromSource|TestResolveContextSourcePath' -count=1
ok  github.com/coder/coder/v2/cli
```

`gofmt`, `go vet ./cli/`, and `go build ./cli/...` are clean.

<details>
<summary>Related investigation</summary>

This is one of several issues found while investigating reports about the recently merged chat-context system. It is a self-contained, low-risk fix opened independently of the others:

- **This PR** (issue 7): `context show` returns 0 resources due to scan-root dedupe leaving `SourcePath` empty.
- #26614 (issues 5 + 4-frontend): show context sizes and full `.mcp.json` paths in the Agents page UI.
- #26616 (issues 9 + 10): dedupe context sources by resolved identity in the agent.

Remaining items from the investigation are architectural (lazy-load/bloat, skill scope precedence, raw-path plumbing, backend server-to-config linkage, startup-timing re-pin, stale-pin rebind-on-open) and are deferred for design sign-off.

</details>

Generated by Coder Agents on behalf of @kylecarbs.