### PR TITLE
fix(site): avoid chat-list refetch on chat select

### DIFF
--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -39,6 +39,7 @@ import {
 	promoteChatQueuedMessage,
 	proposeChatTitle,
 	regenerateChatTitle,
+	removeChatFromUnreadChatListCache,
 	removeChildFromParentInCache,
 	reorderPinnedChat,
 	setChatGroupRole,
@@ -2695,5 +2696,66 @@ describe("chat ACL query factories", () => {
 		expect(queryClient.getQueryState(chatACLKey(chatId))?.isInvalidated).toBe(
 			true,
 		);
+	});
+});
+
+describe("removeChatFromUnreadChatListCache", () => {
+	it("removes the chat from the unread-filter cache, keeping other chats", () => {
+		const queryClient = createTestQueryClient();
+		const readChat = makeChat("chat-read", { has_unread: false });
+		const otherChat = makeChat("chat-other", { has_unread: true });
+		seedInfiniteChats(queryClient, [readChat, otherChat], {
+			chatStatus: "unread",
+		});
+
+		removeChatFromUnreadChatListCache(queryClient, readChat.id);
+
+		const remaining = readInfiniteChats(queryClient, { chatStatus: "unread" });
+		expect(remaining?.map((c) => c.id)).toEqual(["chat-other"]);
+	});
+
+	it("leaves non-unread chat-list caches untouched", () => {
+		const queryClient = createTestQueryClient();
+		const readChat = makeChat("chat-read", { has_unread: false });
+		const otherChat = makeChat("chat-other", { has_unread: true });
+		// Unread-filter cache: the read chat should be removed.
+		seedInfiniteChats(queryClient, [readChat, otherChat], {
+			chatStatus: "unread",
+		});
+		// Default (no filter) and read-filter caches: untouched.
+		seedInfiniteChats(queryClient, [readChat, otherChat], { archived: false });
+		seedInfiniteChats(queryClient, [readChat, otherChat], {
+			chatStatus: "read",
+		});
+
+		removeChatFromUnreadChatListCache(queryClient, readChat.id);
+
+		expect(
+			readInfiniteChats(queryClient, { chatStatus: "unread" })?.map(
+				(c) => c.id,
+			),
+		).toEqual(["chat-other"]);
+		expect(
+			readInfiniteChats(queryClient, { archived: false })?.map((c) => c.id),
+		).toEqual(["chat-read", "chat-other"]);
+		expect(
+			readInfiniteChats(queryClient, { chatStatus: "read" })?.map((c) => c.id),
+		).toEqual(["chat-read", "chat-other"]);
+	});
+
+	it("is a no-op when the chat is absent (preserves the cache reference)", () => {
+		const queryClient = createTestQueryClient();
+		const otherChat = makeChat("chat-other", { has_unread: true });
+		seedInfiniteChats(queryClient, [otherChat], { chatStatus: "unread" });
+		const before = queryClient.getQueryData(
+			infiniteChatsKey({ chatStatus: "unread" }),
+		);
+
+		removeChatFromUnreadChatListCache(queryClient, "chat-missing");
+
+		const after = queryClient.getQueryData(
+			infiniteChatsKey({ chatStatus: "unread" }),
+		);
+		expect(after).toBe(before);
 	});
 });

--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -2718,11 +2718,9 @@ describe("removeChatFromUnreadChatListCache", () => {
 		const queryClient = createTestQueryClient();
 		const readChat = makeChat("chat-read", { has_unread: false });
 		const otherChat = makeChat("chat-other", { has_unread: true });
-		// Unread-filter cache: the read chat should be removed.
 		seedInfiniteChats(queryClient, [readChat, otherChat], {
 			chatStatus: "unread",
 		});
-		// Default (no filter) and read-filter caches: untouched.
 		seedInfiniteChats(queryClient, [readChat, otherChat], { archived: false });
 		seedInfiniteChats(queryClient, [readChat, otherChat], {
 			chatStatus: "read",

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -87,10 +87,14 @@ export const chatsByWorkspace = (workspaceIds: string[]) => {
 export const updateInfiniteChatsCache = (
 	queryClient: QueryClient,
 	updater: (chats: TypesGen.Chat[]) => TypesGen.Chat[],
+	predicate: (query: {
+		queryKey: readonly unknown[];
+	}) => boolean = isChatListQuery,
 ) => {
-	// Update ALL infinite chat queries regardless of their filter opts.
+	// Update every matching infinite chat query. Defaults to all chat-list
+	// queries; pass a narrower predicate to target a subset.
 	queryClient.setQueriesData<InfiniteChatsCacheData>(
-		{ queryKey: chatsKey, predicate: isChatListQuery },
+		{ queryKey: chatsKey, predicate },
 		(prev) => {
 			if (!prev?.pages) return prev;
 			const nextPages = prev.pages.map((page) => updater(page));
@@ -482,10 +486,8 @@ export const invalidateChatListQueries = (queryClient: QueryClient) => {
 };
 
 /**
- * Predicate that matches only the unread-filter (has_unread:true)
- * sidebar chat-list queries. The filter object lives at queryKey[1]
- * (see infiniteChatsKey), so this narrows isChatListQuery to queries
- * whose filter has chatStatus === "unread".
+ * Narrows isChatListQuery to unread (has_unread:true) filter queries.
+ * The filter object sits at queryKey[1] (see infiniteChatsKey).
  */
 const isUnreadChatListQuery = (query: {
 	queryKey: readonly unknown[];
@@ -501,31 +503,21 @@ const isUnreadChatListQuery = (query: {
 };
 
 /**
- * Removes a chat from every unread-filter (has_unread:true) infinite
- * chat-list cache so a chat that was just read leaves the unread view
- * without a refetch. Other filter caches keep the chat (its has_unread
- * flag is cleared separately). Returns a new reference only for caches
- * that actually changed.
+ * Prunes the chat from unread-filter caches so a just-read chat leaves
+ * the unread view with no refetch; its has_unread flag is cleared
+ * separately.
  */
 export const removeChatFromUnreadChatListCache = (
 	queryClient: QueryClient,
 	chatId: string,
 ) => {
-	queryClient.setQueriesData<InfiniteChatsCacheData>(
-		{ queryKey: chatsKey, predicate: isUnreadChatListQuery },
-		(prev) => {
-			if (!prev?.pages) return prev;
-			let changed = false;
-			const nextPages = prev.pages.map((page) => {
-				const filtered = page.filter((c) => c.id !== chatId);
-				if (filtered.length !== page.length) {
-					changed = true;
-					return filtered;
-				}
-				return page;
-			});
-			return changed ? { ...prev, pages: nextPages } : prev;
+	updateInfiniteChatsCache(
+		queryClient,
+		(page) => {
+			const filtered = page.filter((c) => c.id !== chatId);
+			return filtered.length === page.length ? page : filtered;
 		},
+		isUnreadChatListQuery,
 	);
 };
 

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -482,6 +482,54 @@ export const invalidateChatListQueries = (queryClient: QueryClient) => {
 };
 
 /**
+ * Predicate that matches only the unread-filter (has_unread:true)
+ * sidebar chat-list queries. The filter object lives at queryKey[1]
+ * (see infiniteChatsKey), so this narrows isChatListQuery to queries
+ * whose filter has chatStatus === "unread".
+ */
+const isUnreadChatListQuery = (query: {
+	queryKey: readonly unknown[];
+}): boolean => {
+	if (!isChatListQuery(query)) return false;
+	const segment = query.queryKey[1];
+	return (
+		typeof segment === "object" &&
+		segment !== null &&
+		"chatStatus" in segment &&
+		segment.chatStatus === "unread"
+	);
+};
+
+/**
+ * Removes a chat from every unread-filter (has_unread:true) infinite
+ * chat-list cache so a chat that was just read leaves the unread view
+ * without a refetch. Other filter caches keep the chat (its has_unread
+ * flag is cleared separately). Returns a new reference only for caches
+ * that actually changed.
+ */
+export const removeChatFromUnreadChatListCache = (
+	queryClient: QueryClient,
+	chatId: string,
+) => {
+	queryClient.setQueriesData<InfiniteChatsCacheData>(
+		{ queryKey: chatsKey, predicate: isUnreadChatListQuery },
+		(prev) => {
+			if (!prev?.pages) return prev;
+			let changed = false;
+			const nextPages = prev.pages.map((page) => {
+				const filtered = page.filter((c) => c.id !== chatId);
+				if (filtered.length !== page.length) {
+					changed = true;
+					return filtered;
+				}
+				return page;
+			});
+			return changed ? { ...prev, pages: nextPages } : prev;
+		},
+	);
+};
+
+/**
  * Predicate that matches chat-list queries performing a regular
  * refetch (window-focus, invalidation, mount) but not a
  * fetchNextPage or fetchPreviousPage. During pagination fetches

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -91,8 +91,7 @@ export const updateInfiniteChatsCache = (
 		queryKey: readonly unknown[];
 	}) => boolean = isChatListQuery,
 ) => {
-	// Defaults to all chat-list queries; pass a narrower predicate to target a
-	// subset.
+	// Pass a narrower predicate to update only a subset of chat-list queries.
 	queryClient.setQueriesData<InfiniteChatsCacheData>(
 		{ queryKey: chatsKey, predicate },
 		(prev) => {

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -91,8 +91,8 @@ export const updateInfiniteChatsCache = (
 		queryKey: readonly unknown[];
 	}) => boolean = isChatListQuery,
 ) => {
-	// Update every matching infinite chat query. Defaults to all chat-list
-	// queries; pass a narrower predicate to target a subset.
+	// Defaults to all chat-list queries; pass a narrower predicate to target a
+	// subset.
 	queryClient.setQueriesData<InfiniteChatsCacheData>(
 		{ queryKey: chatsKey, predicate },
 		(prev) => {
@@ -486,8 +486,7 @@ export const invalidateChatListQueries = (queryClient: QueryClient) => {
 };
 
 /**
- * Narrows isChatListQuery to unread (has_unread:true) filter queries.
- * The filter object sits at queryKey[1] (see infiniteChatsKey).
+ * The chatStatus filter object sits at queryKey[1] (see infiniteChatsKey).
  */
 const isUnreadChatListQuery = (query: {
 	queryKey: readonly unknown[];

--- a/site/src/pages/AgentsPage/AgentsPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.stories.tsx
@@ -1,0 +1,108 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useParams } from "react-router";
+import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
+import { reactRouterParameters } from "storybook-addon-remix-react-router";
+import { API } from "#/api/api";
+import type * as TypesGen from "#/api/typesGenerated";
+import { MockChat } from "#/testHelpers/chatEntities";
+import { MockPermissions, MockUserOwner } from "#/testHelpers/entities";
+import {
+	withAuthProvider,
+	withDashboardProvider,
+	withProxyProvider,
+	withWebSocket,
+} from "#/testHelpers/storybook";
+import AgentsPage from "./AgentsPage";
+
+const chatList: TypesGen.Chat[] = [
+	{
+		...MockChat,
+		id: "chat-1",
+		title: "First agent",
+		status: "completed",
+		has_unread: false,
+	},
+	{
+		...MockChat,
+		id: "chat-2",
+		title: "Second agent",
+		status: "completed",
+		has_unread: false,
+	},
+];
+
+const emptyPersonalModelOverrides = {
+	enabled: false,
+} as TypesGen.UserChatPersonalModelOverridesResponse;
+
+// Renders inside the AgentsPage layout's <Outlet> at /agents/:agentId so the
+// play function can confirm that selecting a chat changed the active route
+// without depending on the real AgentChatPage and its queries.
+const ActiveChatProbe = () => {
+	const { agentId } = useParams();
+	return <div data-testid="active-chat-id">{agentId ?? ""}</div>;
+};
+
+const meta: Meta<typeof AgentsPage> = {
+	title: "pages/AgentsPage/AgentsPage",
+	component: AgentsPage,
+	decorators: [
+		withAuthProvider,
+		withDashboardProvider,
+		withProxyProvider(),
+		withWebSocket,
+	],
+	parameters: {
+		layout: "fullscreen",
+		user: MockUserOwner,
+		permissions: MockPermissions,
+		webSocket: [],
+		reactRouter: reactRouterParameters({
+			location: { path: "/agents" },
+			routing: {
+				path: "/agents",
+				useStoryElement: true,
+				children: [{ path: ":agentId", element: <ActiveChatProbe /> }],
+			},
+		}),
+	},
+	beforeEach: () => {
+		spyOn(API.experimental, "getChats").mockResolvedValue(chatList);
+		spyOn(API.experimental, "getChatModels").mockResolvedValue({
+			providers: [],
+		});
+		spyOn(API.experimental, "getChatModelConfigs").mockResolvedValue([]);
+		spyOn(
+			API.experimental,
+			"getUserChatPersonalModelOverrides",
+		).mockResolvedValue(emptyPersonalModelOverrides);
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof AgentsPage>;
+
+// Regression guard for CODAGT-673: selecting a chat must not refetch the
+// chat list. The infinite chat-list query is fetched once on mount; clicking
+// a chat changes the :agentId route param, and the read-clearing effect must
+// update the cache without invalidating (and thus refetching) the list.
+export const SelectingChatIssuesNoListRequest: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		// Wait for the initial chat-list fetch to populate the sidebar.
+		const link = await canvas.findByRole("link", { name: /First agent/ });
+		await waitFor(() =>
+			expect(API.experimental.getChats).toHaveBeenCalledTimes(1),
+		);
+
+		// Selecting a chat navigates to /agents/:agentId.
+		await userEvent.click(link);
+		await waitFor(() =>
+			expect(canvas.getByTestId("active-chat-id")).toHaveTextContent("chat-1"),
+		);
+
+		// The selection must not have triggered another chat-list request.
+		expect(API.experimental.getChats).toHaveBeenCalledTimes(1);
+	},
+};

--- a/site/src/pages/AgentsPage/AgentsPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.stories.tsx
@@ -118,8 +118,6 @@ const unreadChatList: TypesGen.Chat[] = [
 	},
 ];
 
-// Selecting a chat while on the unread filter removes it from the unread
-// sidebar without a refetch.
 export const SelectingUnreadChatLeavesUnreadView: Story = {
 	parameters: {
 		reactRouter: reactRouterParameters({
@@ -152,6 +150,9 @@ export const SelectingUnreadChatLeavesUnreadView: Story = {
 				canvas.queryByRole("link", { name: /Unread agent one/ }),
 			).toBeNull(),
 		);
+		expect(
+			canvas.getByRole("link", { name: /Unread agent two/ }),
+		).toBeInTheDocument();
 		expect(API.experimental.getChats).toHaveBeenCalledTimes(1);
 	},
 };

--- a/site/src/pages/AgentsPage/AgentsPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.stories.tsx
@@ -35,9 +35,8 @@ const emptyPersonalModelOverrides = {
 	enabled: false,
 } as TypesGen.UserChatPersonalModelOverridesResponse;
 
-// Renders inside the AgentsPage layout's <Outlet> at /agents/:agentId so the
-// play function can confirm that selecting a chat changed the active route
-// without depending on the real AgentChatPage and its queries.
+// Probe so the play can assert the route changed without mounting the real
+// AgentChatPage and its queries.
 const ActiveChatProbe = () => {
 	const { agentId } = useParams();
 	return <div data-testid="active-chat-id">{agentId ?? ""}</div>;
@@ -83,26 +82,76 @@ export default meta;
 type Story = StoryObj<typeof AgentsPage>;
 
 // Regression guard for CODAGT-673: selecting a chat must not refetch the
-// chat list. The infinite chat-list query is fetched once on mount; clicking
-// a chat changes the :agentId route param, and the read-clearing effect must
-// update the cache without invalidating (and thus refetching) the list.
+// chat list.
 export const SelectingChatIssuesNoListRequest: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 
-		// Wait for the initial chat-list fetch to populate the sidebar.
 		const link = await canvas.findByRole("link", { name: /First agent/ });
 		await waitFor(() =>
 			expect(API.experimental.getChats).toHaveBeenCalledTimes(1),
 		);
 
-		// Selecting a chat navigates to /agents/:agentId.
 		await userEvent.click(link);
 		await waitFor(() =>
 			expect(canvas.getByTestId("active-chat-id")).toHaveTextContent("chat-1"),
 		);
 
-		// The selection must not have triggered another chat-list request.
+		expect(API.experimental.getChats).toHaveBeenCalledTimes(1);
+	},
+};
+
+const unreadChatList: TypesGen.Chat[] = [
+	{
+		...MockChat,
+		id: "chat-1",
+		title: "Unread agent one",
+		status: "running",
+		has_unread: true,
+	},
+	{
+		...MockChat,
+		id: "chat-2",
+		title: "Unread agent two",
+		status: "running",
+		has_unread: true,
+	},
+];
+
+// Selecting a chat while on the unread filter removes it from the unread
+// sidebar without a refetch.
+export const SelectingUnreadChatLeavesUnreadView: Story = {
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: { path: "/agents", searchParams: { chat_status: "unread" } },
+			routing: {
+				path: "/agents",
+				useStoryElement: true,
+				children: [{ path: ":agentId", element: <ActiveChatProbe /> }],
+			},
+		}),
+	},
+	beforeEach: () => {
+		spyOn(API.experimental, "getChats").mockResolvedValue(unreadChatList);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		const link = await canvas.findByRole("link", { name: /Unread agent one/ });
+		await waitFor(() =>
+			expect(API.experimental.getChats).toHaveBeenCalledTimes(1),
+		);
+
+		await userEvent.click(link);
+		await waitFor(() =>
+			expect(canvas.getByTestId("active-chat-id")).toHaveTextContent("chat-1"),
+		);
+
+		await waitFor(() =>
+			expect(
+				canvas.queryByRole("link", { name: /Unread agent one/ }),
+			).toBeNull(),
+		);
 		expect(API.experimental.getChats).toHaveBeenCalledTimes(1);
 	},
 };

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -31,6 +31,7 @@ import {
 	proposeChatTitle,
 	readInfiniteChatsCache,
 	regenerateChatTitle,
+	removeChatFromUnreadChatListCache,
 	removeChildFromParentInCache,
 	reorderPinnedChat,
 	unarchiveChat,
@@ -545,7 +546,10 @@ const AgentsPage: FC = () => {
 			});
 			return changed ? next : chats;
 		});
-		void invalidateChatListQueries(queryClient);
+		// Drop the now-read chat from the unread (has_unread:true) filter
+		// cache so it leaves the unread view without a refetch. Window
+		// focus remains the backstop for any other drift.
+		removeChatFromUnreadChatListCache(queryClient, agentId);
 	}, [agentId, queryClient]);
 	useEffect(() => {
 		return createReconnectingWebSocket({

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -546,9 +546,8 @@ const AgentsPage: FC = () => {
 			});
 			return changed ? next : chats;
 		});
-		// Drop the now-read chat from the unread (has_unread:true) filter
-		// cache so it leaves the unread view without a refetch. Window
-		// focus remains the backstop for any other drift.
+		// Prune the read chat from the unread filter cache so it leaves the
+		// unread view; window-focus refetch backstops other drift.
 		removeChatFromUnreadChatListCache(queryClient, agentId);
 	}, [agentId, queryClient]);
 	useEffect(() => {

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -546,8 +546,7 @@ const AgentsPage: FC = () => {
 			});
 			return changed ? next : chats;
 		});
-		// Prune the read chat from the unread filter cache so it leaves the
-		// unread view; window-focus refetch backstops other drift.
+		// Window-focus refetch backstops any other unread drift.
 		removeChatFromUnreadChatListCache(queryClient, agentId);
 	}, [agentId, queryClient]);
 	useEffect(() => {


### PR DESCRIPTION
Selecting a chat issued a full chat-list refetch every time. The `agentId` effect that clears the active chat's unread dot also called `invalidateChatListQueries`. The infinite chat-list query carries no `staleTime`, so that invalidation forced an immediate refetch of the active sidebar list on every selection, re-downloading the whole list (an observed ~609KB response during development) for a change the client had already applied.

That invalidation only existed to drop a just-read chat from the `has_unread:true` (unread) filter. The effect already writes `has_unread:false` into the list caches optimistically, so the refetch was redundant for every view except that one filtered list.

The fix keeps the optimistic write and replaces the invalidation with a client-side prune: the read chat is removed from the unread-filter caches directly, so it leaves the unread view with no network request. `refetchOnWindowFocus` stays as the backstop for any other drift. Selecting a chat now issues zero chat-list requests.

Resolves CODAGT-673.

For reviewer context: CODAGT-653 is already resolved by #26585, and the originally planned server-side read-state push (CODAGT-674) was considered and dropped, so this change stands alone rather than as part of a stack. The client-side prune plus the window-focus backstop is sufficient on its own.

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
