### PR TITLE
fix: skip failing azureidentity test while under investigation (#26545)

### DIFF
--- a/coderd/azureidentity/azureidentity_test.go
+++ b/coderd/azureidentity/azureidentity_test.go
@@ -21,6 +21,7 @@ import (
 
 func TestValidate(t *testing.T) {
 	t.Parallel()
+	t.Skip("See https://github.com/coder/internal/issues/1602")
 	if runtime.GOOS == "darwin" {
 		// This test fails on MacOS for some reason. See https://github.com/coder/coder/issues/12978
 		t.Skip()


### PR DESCRIPTION
Backport of #26545 to `release/2.29`.

Original PR: #26545 - chore: skip failing azureidentity test while under investigation
Merge commit: a12b0518344dee37cf747b9a95770fbddbcecee8
Requested by: @ethanndickson

Skips `TestValidate` in `coderd/azureidentity`, which fails on the release branch due to Azure instance-identity certificate chain verification (`certificate signed by unknown authority`), unrelated to release content. This mirrors the skip added on `main` in #26545. The cherry-pick conflicts only on surrounding context because this branch has a `darwin`-only skip block right after `t.Parallel()`; the unconditional skip is inserted ahead of it to match main, consistent with the existing `release/2.32` and `release/2.33` backports.

Ref: https://github.com/coder/internal/issues/1602
