### PR TITLE
fix(flake.nix): build go-migrate with only postgres driver

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -246,6 +246,14 @@
             xcbuild
           ]);
 
+        migrate = pkgs.go-migrate.overrideAttrs (_oldAttrs: {
+          # Coder only needs migrate for migration creation and local Postgres
+          # migrations. The nixpkgs default build includes every database
+          # driver and is broken by a bad Go and driver combination, so rebuild
+          # only with the driver we need.
+          tags = [ "postgres" ];
+        });
+
         # The minimal set of packages to build Coder.
         devShellPackages =
           with pkgs;
@@ -277,7 +285,7 @@
             gnutar
             unstablePkgs.go_1_26
             gofumpt
-            go-migrate
+            migrate
             (pinnedPkgs.golangci-lint)
             gopls
             gotestsum


### PR DESCRIPTION
Follow-up to #26584.

After the nixpkgs 25.05 update, the default go-migrate package panics at startup due to its Snowflake driver before Postgres commands can run:

```
[nix-shell:~/coder]$ migrate
panic: failed to parse CA certificate.

goroutine 1 [running]:
github.com/snowflakedb/gosnowflake.readCACerts()
	github.com/snowflakedb/gosnowflake@v1.6.19/ocsp.go:881 +0x225
github.com/snowflakedb/gosnowflake.init.3()
	github.com/snowflakedb/gosnowflake@v1.6.19/ocsp.go:928 +0xf
```

The panic comes from the combination of Go 1.23+ x509 defaults and a negative-serial certificate in the Snowflake driver's embedded CA bundle. It can be avoided by setting `GODEBUG=x509negativeserial=1`, but Coder only uses the migrate CLI for migration creation and local Postgres migrations.

This PR overrides the build tags to include only the Postgres driver, which removes the Snowflake startup path entirely.