### PR TITLE
fix: resolve client IP from the rightmost untrusted X-Forwarded-For entry

### DIFF
--- a/coderd/httpmw/realip.go
+++ b/coderd/httpmw/realip.go
@@ -70,7 +70,17 @@ func ExtractRealIPAddress(config *RealIPConfig, req *http.Request) (net.IP, erro
 	}
 
 	for _, trustedHeader := range config.TrustedHeaders {
-		addr := extractForwardedAddress(config, req.Header.Get(trustedHeader))
+		// X-Forwarded-For is a list-valued header. Per RFC 7230, multiple
+		// field lines with the same name are equivalent to a single
+		// comma-separated value. Join them so a client cannot hide a spoofed
+		// address in the first field line, which Header.Get would return on
+		// its own. Other forwarding headers carry a single edge-proxy value,
+		// so use Header.Get to preserve their first-value semantics.
+		value := req.Header.Get(trustedHeader)
+		if http.CanonicalHeaderKey(trustedHeader) == headerXForwardedFor {
+			value = strings.Join(req.Header.Values(trustedHeader), ",")
+		}
+		addr := extractForwardedAddress(config, value)
 		if addr != nil {
 			return addr, nil
 		}
@@ -208,11 +218,12 @@ func getRemoteAddress(address string) net.IP {
 
 // extractForwardedAddress parses a comma-separated forwarding header value and
 // returns the rightmost address that is not a trusted origin. Reverse proxies
-// append the peer that connected to them, so the rightmost untrusted address is
-// the real client; any values a client prepends to spoof its address sit to the
-// left of the addresses inserted by trusted proxies and are ignored. If every
-// parsed address is a trusted origin, the leftmost address is returned. It
-// returns nil when no address can be parsed.
+// append the peer that connected to them, so when every trusted proxy hop is
+// listed in TrustedOrigins, the rightmost untrusted address is the real client;
+// any values a client prepends to spoof its address sit to the left of the
+// addresses inserted by trusted proxies and are ignored. If every parsed address
+// is a trusted origin, the leftmost address is returned. It returns nil when no
+// address can be parsed.
 func extractForwardedAddress(config *RealIPConfig, value string) net.IP {
 	parts := strings.Split(value, ",")
 	var leftmost net.IP

--- a/coderd/httpmw/realip.go
+++ b/coderd/httpmw/realip.go
@@ -111,6 +111,14 @@ func FilterUntrustedOriginHeaders(config *RealIPConfig, req *http.Request) {
 	}
 
 	for _, header := range config.TrustedHeaders {
+		// X-Forwarded-For is a list-valued header whose field lines are
+		// equivalent to a single comma-separated value (RFC 7230 section
+		// 3.2.2). Join them so later hops are not dropped when collapsing to a
+		// single line. Other forwarding headers carry a single value.
+		if http.CanonicalHeaderKey(header) == headerXForwardedFor {
+			req.Header.Set(header, strings.Join(req.Header.Values(header), ","))
+			continue
+		}
 		req.Header.Set(header, req.Header.Get(header))
 	}
 }
@@ -195,12 +203,15 @@ func EnsureXForwardedForHeader(req *http.Request) error {
 	return nil
 }
 
-// getRemoteAddress extracts the IP address from the given string. If
-// the string contains commas, it assumes that the first part is the
-// original address.
+// getRemoteAddress extracts a single IP address from the given string,
+// stripping a port if present. If the string contains commas, only the
+// portion before the first comma is parsed. This helper does not select the
+// real client from a multi-hop X-Forwarded-For chain; use
+// extractForwardedAddress for that, which accounts for client-supplied values.
 func getRemoteAddress(address string) net.IP {
-	// X-Forwarded-For may contain multiple addresses, in case the
-	// proxies are chained; the first value is the client address
+	// A value may contain a port and, for a raw X-Forwarded-For value, more
+	// than one comma-separated address. Parse only the part before the first
+	// comma.
 	i := strings.IndexByte(address, ',')
 	if i == -1 {
 		i = len(address)

--- a/coderd/httpmw/realip.go
+++ b/coderd/httpmw/realip.go
@@ -70,7 +70,7 @@ func ExtractRealIPAddress(config *RealIPConfig, req *http.Request) (net.IP, erro
 	}
 
 	for _, trustedHeader := range config.TrustedHeaders {
-		addr := getRemoteAddress(req.Header.Get(trustedHeader))
+		addr := extractForwardedAddress(config, req.Header.Get(trustedHeader))
 		if addr != nil {
 			return addr, nil
 		}
@@ -204,6 +204,31 @@ func getRemoteAddress(address string) net.IP {
 		return net.ParseIP(firstAddress)
 	}
 	return net.ParseIP(host)
+}
+
+// extractForwardedAddress parses a comma-separated forwarding header value and
+// returns the rightmost address that is not a trusted origin. Reverse proxies
+// append the peer that connected to them, so the rightmost untrusted address is
+// the real client; any values a client prepends to spoof its address sit to the
+// left of the addresses inserted by trusted proxies and are ignored. If every
+// parsed address is a trusted origin, the leftmost address is returned. It
+// returns nil when no address can be parsed.
+func extractForwardedAddress(config *RealIPConfig, value string) net.IP {
+	parts := strings.Split(value, ",")
+	var leftmost net.IP
+	for i := len(parts) - 1; i >= 0; i-- {
+		ip := getRemoteAddress(strings.TrimSpace(parts[i]))
+		if ip == nil {
+			continue
+		}
+		// Iterating right-to-left, so the last assignment is the leftmost
+		// valid address, used as the fallback when all hops are trusted.
+		leftmost = ip
+		if !isContainedIn(config.TrustedOrigins, ip) {
+			return ip
+		}
+	}
+	return leftmost
 }
 
 // isContainedIn checks that the given address is contained in the given

--- a/coderd/httpmw/realip_test.go
+++ b/coderd/httpmw/realip_test.go
@@ -744,3 +744,86 @@ func TestApplicationProxy(t *testing.T) {
 		})
 	}
 }
+
+// TestExtractRealIPSpoofedXForwardedFor is a regression test for an IP-spoofing
+// vulnerability. When a request arrives from a trusted proxy, X-Forwarded-For was
+// parsed left-to-right, so the leftmost (client-controlled) value was accepted as
+// the real IP. Because reverse proxies append the peer that connected to them, the
+// leftmost value is the part a client can forge. An attacker could prepend an
+// arbitrary address to X-Forwarded-For to spoof the IP used for per-IP login rate
+// limiting and audit log source addresses. The real client is the rightmost address
+// that is not a trusted origin.
+func TestExtractRealIPSpoofedXForwardedFor(t *testing.T) {
+	t.Parallel()
+
+	const (
+		spoofedAddr = "1.2.3.4"
+		realClient  = "203.0.113.5"
+	)
+
+	// Trust a realistic proxy range (not 0.0.0.0/0) so that a spoofed
+	// public-client address falls outside the trusted set.
+	newConfig := func() *httpmw.RealIPConfig {
+		return &httpmw.RealIPConfig{
+			TrustedOrigins: []*net.IPNet{
+				{
+					IP:   net.ParseIP("10.0.0.0"),
+					Mask: net.CIDRMask(8, 32),
+				},
+			},
+			TrustedHeaders: []string{"X-Forwarded-For"},
+		}
+	}
+
+	cases := []struct {
+		name          string
+		xForwardedFor string
+	}{
+		{
+			// A single trusted proxy appends the real client to whatever the
+			// client claimed, so the leftmost value is attacker-controlled.
+			name:          "single-proxy",
+			xForwardedFor: spoofedAddr + ", " + realClient,
+		},
+		{
+			// A chain of trusted proxies appends each hop. The rightmost
+			// untrusted address (the real client) must win, skipping the
+			// trusted inner-proxy hop.
+			name:          "chained-proxies",
+			xForwardedFor: spoofedAddr + ", " + realClient + ", 10.0.0.2",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Direct call to ExtractRealIPAddress.
+			req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+			req.RemoteAddr = "10.0.0.1" // trusted proxy peer
+			req.Header.Set("X-Forwarded-For", tc.xForwardedFor)
+
+			addr, err := httpmw.ExtractRealIPAddress(newConfig(), req)
+			require.NoError(t, err)
+			require.Equal(t, realClient, addr.String(),
+				"must use the real client IP, not the spoofed leftmost value")
+			require.NotEqual(t, spoofedAddr, addr.String(),
+				"spoofed leftmost X-Forwarded-For value must be ignored")
+
+			// Middleware rewrites RemoteAddr to the same value that
+			// httprate.KeyByIP (rate limiting) and audit.InitRequest consume.
+			mwReq := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+			mwReq.RemoteAddr = "10.0.0.1"
+			mwReq.Header.Set("X-Forwarded-For", tc.xForwardedFor)
+
+			handlerCalled := false
+			next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				handlerCalled = true
+				require.Equal(t, realClient, r.RemoteAddr,
+					"middleware must set RemoteAddr to the real client IP")
+			})
+			httpmw.ExtractRealIP(newConfig())(next).ServeHTTP(httptest.NewRecorder(), mwReq)
+			require.True(t, handlerCalled, "expected handler to be invoked")
+		})
+	}
+}

--- a/coderd/httpmw/realip_test.go
+++ b/coderd/httpmw/realip_test.go
@@ -745,14 +745,12 @@ func TestApplicationProxy(t *testing.T) {
 	}
 }
 
-// TestExtractRealIPSpoofedXForwardedFor is a regression test for an IP-spoofing
-// vulnerability. When a request arrives from a trusted proxy, X-Forwarded-For was
-// parsed left-to-right, so the leftmost (client-controlled) value was accepted as
-// the real IP. Because reverse proxies append the peer that connected to them, the
-// leftmost value is the part a client can forge. An attacker could prepend an
-// arbitrary address to X-Forwarded-For to spoof the IP used for per-IP login rate
-// limiting and audit log source addresses. The real client is the rightmost address
-// that is not a trusted origin.
+// TestExtractRealIPSpoofedXForwardedFor verifies that a client cannot control
+// the resolved real IP by setting X-Forwarded-For. Reverse proxies append the
+// peer that connected to them, so a client can set the leftmost entries to
+// arbitrary values, while trusted proxies append the real client to the right.
+// The resolved address must therefore be the rightmost entry that is not a
+// trusted origin, not the leftmost (client-supplied) entry.
 func TestExtractRealIPSpoofedXForwardedFor(t *testing.T) {
 	t.Parallel()
 
@@ -776,22 +774,38 @@ func TestExtractRealIPSpoofedXForwardedFor(t *testing.T) {
 	}
 
 	cases := []struct {
-		name          string
-		xForwardedFor string
+		name string
+		// xForwardedFor holds one entry per physical X-Forwarded-For header
+		// line. Multiple entries exercise the case where a proxy appends its
+		// hop as a separate header field rather than to the existing value.
+		xForwardedFor []string
 	}{
 		{
 			// A single trusted proxy appends the real client to whatever the
 			// client claimed, so the leftmost value is attacker-controlled.
 			name:          "single-proxy",
-			xForwardedFor: spoofedAddr + ", " + realClient,
+			xForwardedFor: []string{spoofedAddr + ", " + realClient},
 		},
 		{
 			// A chain of trusted proxies appends each hop. The rightmost
 			// untrusted address (the real client) must win, skipping the
 			// trusted inner-proxy hop.
 			name:          "chained-proxies",
-			xForwardedFor: spoofedAddr + ", " + realClient + ", 10.0.0.2",
+			xForwardedFor: []string{spoofedAddr + ", " + realClient + ", 10.0.0.2"},
 		},
+		{
+			// A proxy may append its hop as a separate header line. Per
+			// RFC 7230 these are equivalent to a single comma-joined value,
+			// so the spoofed first line must not be trusted on its own.
+			name:          "multiple-header-lines",
+			xForwardedFor: []string{spoofedAddr, realClient + ", 10.0.0.2"},
+		},
+	}
+
+	setXFF := func(req *http.Request, lines []string) {
+		// Assign directly to preserve multiple header lines; Header.Set would
+		// collapse them into a single value.
+		req.Header["X-Forwarded-For"] = lines
 	}
 
 	for _, tc := range cases {
@@ -801,7 +815,7 @@ func TestExtractRealIPSpoofedXForwardedFor(t *testing.T) {
 			// Direct call to ExtractRealIPAddress.
 			req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
 			req.RemoteAddr = "10.0.0.1" // trusted proxy peer
-			req.Header.Set("X-Forwarded-For", tc.xForwardedFor)
+			setXFF(req, tc.xForwardedFor)
 
 			addr, err := httpmw.ExtractRealIPAddress(newConfig(), req)
 			require.NoError(t, err)
@@ -814,7 +828,7 @@ func TestExtractRealIPSpoofedXForwardedFor(t *testing.T) {
 			// httprate.KeyByIP (rate limiting) and audit.InitRequest consume.
 			mwReq := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
 			mwReq.RemoteAddr = "10.0.0.1"
-			mwReq.Header.Set("X-Forwarded-For", tc.xForwardedFor)
+			setXFF(mwReq, tc.xForwardedFor)
 
 			handlerCalled := false
 			next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {

--- a/coderd/httpmw/realip_test.go
+++ b/coderd/httpmw/realip_test.go
@@ -83,27 +83,15 @@ func TestExtractAddress(t *testing.T) {
 			ExpectedRemoteAddr: "10.24.1.1",
 		},
 		{
-			// Reverse proxies append the peer that connected to them, so a
-			// client controls the leftmost X-Forwarded-For entries while a
-			// trusted proxy appends the real client to the right. With a
-			// realistic proxy CIDR (not 0.0.0.0/0), the resolved address must
-			// be the rightmost entry outside the trusted set, never the
-			// leftmost client-supplied value.
-			Name: "spoofed-x-forwarded-for-single-proxy",
+			Name: "no-trusted-origins",
 			Config: &httpmw.RealIPConfig{
-				TrustedOrigins: []*net.IPNet{
-					{
-						IP:   net.ParseIP("10.0.0.0"),
-						Mask: net.CIDRMask(8, 32),
-					},
-				},
 				TrustedHeaders: []string{
 					"X-Forwarded-For",
 				},
 			},
-			RemoteAddr: "10.0.0.1",
+			RemoteAddr: "203.0.113.5",
 			Header: http.Header{
-				"X-Forwarded-For": []string{"1.2.3.4, 203.0.113.5"},
+				"X-Forwarded-For": []string{"1.2.3.4"},
 			},
 			ExpectedRemoteAddr: "203.0.113.5",
 		},
@@ -111,7 +99,7 @@ func TestExtractAddress(t *testing.T) {
 			// A chain of trusted proxies appends each hop. The rightmost
 			// untrusted address (the real client) wins, skipping the trusted
 			// inner-proxy hop.
-			Name: "spoofed-x-forwarded-for-chained-proxies",
+			Name: "picks-rightmost-untrusted",
 			Config: &httpmw.RealIPConfig{
 				TrustedOrigins: []*net.IPNet{
 					{
@@ -134,7 +122,7 @@ func TestExtractAddress(t *testing.T) {
 			// RFC 7230 section 3.2.2 these are equivalent to a single
 			// comma-joined value, so the spoofed first line must not be
 			// trusted on its own.
-			Name: "spoofed-x-forwarded-for-multiple-lines",
+			Name: "x-forwarded-for-set-multiple-times",
 			Config: &httpmw.RealIPConfig{
 				TrustedOrigins: []*net.IPNet{
 					{

--- a/coderd/httpmw/realip_test.go
+++ b/coderd/httpmw/realip_test.go
@@ -83,19 +83,6 @@ func TestExtractAddress(t *testing.T) {
 			ExpectedRemoteAddr: "10.24.1.1",
 		},
 		{
-			Name: "no-trusted-origins",
-			Config: &httpmw.RealIPConfig{
-				TrustedHeaders: []string{
-					"X-Forwarded-For",
-				},
-			},
-			RemoteAddr: "203.0.113.5",
-			Header: http.Header{
-				"X-Forwarded-For": []string{"1.2.3.4"},
-			},
-			ExpectedRemoteAddr: "203.0.113.5",
-		},
-		{
 			// A chain of trusted proxies appends each hop. The rightmost
 			// untrusted address (the real client) wins, skipping the trusted
 			// inner-proxy hop.

--- a/coderd/httpmw/realip_test.go
+++ b/coderd/httpmw/realip_test.go
@@ -83,6 +83,76 @@ func TestExtractAddress(t *testing.T) {
 			ExpectedRemoteAddr: "10.24.1.1",
 		},
 		{
+			// Reverse proxies append the peer that connected to them, so a
+			// client controls the leftmost X-Forwarded-For entries while a
+			// trusted proxy appends the real client to the right. With a
+			// realistic proxy CIDR (not 0.0.0.0/0), the resolved address must
+			// be the rightmost entry outside the trusted set, never the
+			// leftmost client-supplied value.
+			Name: "spoofed-x-forwarded-for-single-proxy",
+			Config: &httpmw.RealIPConfig{
+				TrustedOrigins: []*net.IPNet{
+					{
+						IP:   net.ParseIP("10.0.0.0"),
+						Mask: net.CIDRMask(8, 32),
+					},
+				},
+				TrustedHeaders: []string{
+					"X-Forwarded-For",
+				},
+			},
+			RemoteAddr: "10.0.0.1",
+			Header: http.Header{
+				"X-Forwarded-For": []string{"1.2.3.4, 203.0.113.5"},
+			},
+			ExpectedRemoteAddr: "203.0.113.5",
+		},
+		{
+			// A chain of trusted proxies appends each hop. The rightmost
+			// untrusted address (the real client) wins, skipping the trusted
+			// inner-proxy hop.
+			Name: "spoofed-x-forwarded-for-chained-proxies",
+			Config: &httpmw.RealIPConfig{
+				TrustedOrigins: []*net.IPNet{
+					{
+						IP:   net.ParseIP("10.0.0.0"),
+						Mask: net.CIDRMask(8, 32),
+					},
+				},
+				TrustedHeaders: []string{
+					"X-Forwarded-For",
+				},
+			},
+			RemoteAddr: "10.0.0.1",
+			Header: http.Header{
+				"X-Forwarded-For": []string{"1.2.3.4, 203.0.113.5, 10.0.0.2"},
+			},
+			ExpectedRemoteAddr: "203.0.113.5",
+		},
+		{
+			// A proxy may append its hop as a separate header line. Per
+			// RFC 7230 section 3.2.2 these are equivalent to a single
+			// comma-joined value, so the spoofed first line must not be
+			// trusted on its own.
+			Name: "spoofed-x-forwarded-for-multiple-lines",
+			Config: &httpmw.RealIPConfig{
+				TrustedOrigins: []*net.IPNet{
+					{
+						IP:   net.ParseIP("10.0.0.0"),
+						Mask: net.CIDRMask(8, 32),
+					},
+				},
+				TrustedHeaders: []string{
+					"X-Forwarded-For",
+				},
+			},
+			RemoteAddr: "10.0.0.1",
+			Header: http.Header{
+				"X-Forwarded-For": []string{"1.2.3.4", "203.0.113.5, 10.0.0.2"},
+			},
+			ExpectedRemoteAddr: "203.0.113.5",
+		},
+		{
 			Name: "single-real-ip",
 			Config: &httpmw.RealIPConfig{
 				TrustedOrigins: []*net.IPNet{
@@ -740,103 +810,6 @@ func TestApplicationProxy(t *testing.T) {
 
 			middleware(nextHandler).ServeHTTP(httptest.NewRecorder(), req)
 
-			require.True(t, handlerCalled, "expected handler to be invoked")
-		})
-	}
-}
-
-// TestExtractRealIPSpoofedXForwardedFor verifies that a client cannot control
-// the resolved real IP by setting X-Forwarded-For. Reverse proxies append the
-// peer that connected to them, so a client can set the leftmost entries to
-// arbitrary values, while trusted proxies append the real client to the right.
-// The resolved address must therefore be the rightmost entry that is not a
-// trusted origin, not the leftmost (client-supplied) entry.
-func TestExtractRealIPSpoofedXForwardedFor(t *testing.T) {
-	t.Parallel()
-
-	const (
-		spoofedAddr = "1.2.3.4"
-		realClient  = "203.0.113.5"
-	)
-
-	// Trust a realistic proxy range (not 0.0.0.0/0) so that a spoofed
-	// public-client address falls outside the trusted set.
-	newConfig := func() *httpmw.RealIPConfig {
-		return &httpmw.RealIPConfig{
-			TrustedOrigins: []*net.IPNet{
-				{
-					IP:   net.ParseIP("10.0.0.0"),
-					Mask: net.CIDRMask(8, 32),
-				},
-			},
-			TrustedHeaders: []string{"X-Forwarded-For"},
-		}
-	}
-
-	cases := []struct {
-		name string
-		// xForwardedFor holds one entry per physical X-Forwarded-For header
-		// line. Multiple entries exercise the case where a proxy appends its
-		// hop as a separate header field rather than to the existing value.
-		xForwardedFor []string
-	}{
-		{
-			// A single trusted proxy appends the real client to whatever the
-			// client claimed, so the leftmost value is attacker-controlled.
-			name:          "single-proxy",
-			xForwardedFor: []string{spoofedAddr + ", " + realClient},
-		},
-		{
-			// A chain of trusted proxies appends each hop. The rightmost
-			// untrusted address (the real client) must win, skipping the
-			// trusted inner-proxy hop.
-			name:          "chained-proxies",
-			xForwardedFor: []string{spoofedAddr + ", " + realClient + ", 10.0.0.2"},
-		},
-		{
-			// A proxy may append its hop as a separate header line. Per
-			// RFC 7230 these are equivalent to a single comma-joined value,
-			// so the spoofed first line must not be trusted on its own.
-			name:          "multiple-header-lines",
-			xForwardedFor: []string{spoofedAddr, realClient + ", 10.0.0.2"},
-		},
-	}
-
-	setXFF := func(req *http.Request, lines []string) {
-		// Assign directly to preserve multiple header lines; Header.Set would
-		// collapse them into a single value.
-		req.Header["X-Forwarded-For"] = lines
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			// Direct call to ExtractRealIPAddress.
-			req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
-			req.RemoteAddr = "10.0.0.1" // trusted proxy peer
-			setXFF(req, tc.xForwardedFor)
-
-			addr, err := httpmw.ExtractRealIPAddress(newConfig(), req)
-			require.NoError(t, err)
-			require.Equal(t, realClient, addr.String(),
-				"must use the real client IP, not the spoofed leftmost value")
-			require.NotEqual(t, spoofedAddr, addr.String(),
-				"spoofed leftmost X-Forwarded-For value must be ignored")
-
-			// Middleware rewrites RemoteAddr to the same value that
-			// httprate.KeyByIP (rate limiting) and audit.InitRequest consume.
-			mwReq := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
-			mwReq.RemoteAddr = "10.0.0.1"
-			setXFF(mwReq, tc.xForwardedFor)
-
-			handlerCalled := false
-			next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-				handlerCalled = true
-				require.Equal(t, realClient, r.RemoteAddr,
-					"middleware must set RemoteAddr to the real client IP")
-			})
-			httpmw.ExtractRealIP(newConfig())(next).ServeHTTP(httptest.NewRecorder(), mwReq)
 			require.True(t, handlerCalled, "expected handler to be invoked")
 		})
 	}

--- a/coderd/httpmw/realip_test.go
+++ b/coderd/httpmw/realip_test.go
@@ -105,6 +105,27 @@ func TestExtractAddress(t *testing.T) {
 			ExpectedRemoteAddr: "203.0.113.5",
 		},
 		{
+			// When every parsed hop is a trusted origin, there is no untrusted
+			// client to select, so the leftmost address is used.
+			Name: "all-trusted-falls-back-to-leftmost",
+			Config: &httpmw.RealIPConfig{
+				TrustedOrigins: []*net.IPNet{
+					{
+						IP:   net.ParseIP("10.0.0.0"),
+						Mask: net.CIDRMask(8, 32),
+					},
+				},
+				TrustedHeaders: []string{
+					"X-Forwarded-For",
+				},
+			},
+			RemoteAddr: "10.0.0.1",
+			Header: http.Header{
+				"X-Forwarded-For": []string{"10.0.0.1, 10.0.0.2"},
+			},
+			ExpectedRemoteAddr: "10.0.0.1",
+		},
+		{
 			// A proxy may append its hop as a separate header line. Per
 			// RFC 7230 section 3.2.2 these are equivalent to a single
 			// comma-joined value, so the spoofed first line must not be
@@ -500,6 +521,31 @@ func TestFilterUntrusted(t *testing.T) {
 				"X-Forwarded-Proto": []string{"https"},
 			},
 			ExpectedRemoteAddr: "1.2.3.4",
+		},
+		{
+			// For a trusted origin, multiple X-Forwarded-For field lines are
+			// joined into one comma-separated value rather than collapsed to
+			// the first line, so later hops are preserved.
+			Name: "trusted-origin-joins-multiple-x-forwarded-for",
+			Config: &httpmw.RealIPConfig{
+				TrustedOrigins: []*net.IPNet{
+					{
+						IP:   net.ParseIP("10.0.0.0"),
+						Mask: net.CIDRMask(8, 32),
+					},
+				},
+				TrustedHeaders: []string{
+					"X-Forwarded-For",
+				},
+			},
+			Header: http.Header{
+				"X-Forwarded-For": []string{"1.2.3.4", "203.0.113.5, 10.0.0.2"},
+			},
+			RemoteAddr: "10.0.0.1",
+			ExpectedHeader: http.Header{
+				"X-Forwarded-For": []string{"1.2.3.4,203.0.113.5, 10.0.0.2"},
+			},
+			ExpectedRemoteAddr: "10.0.0.1",
 		},
 	}
 


### PR DESCRIPTION
Resolve `X-Forwarded-For` by walking the chain right-to-left and selecting the rightmost entry that is not a trusted origin (the real client), falling back to the leftmost entry only when every parsed hop is a trusted origin. 