### PR TITLE
fix: prevent open redirect in proxy authentication flow

### DIFF
--- a/coderd/workspaceapps/proxy.go
+++ b/coderd/workspaceapps/proxy.go
@@ -266,19 +266,20 @@ func (s *Server) handleAPIKeySmuggling(rw http.ResponseWriter, r *http.Request, 
 		HttpOnly: true,
 	}))
 
-	// Strip the query parameter.
-	path := r.URL.Path
-	if path == "" {
-		path = "/"
-	}
-	q := r.URL.Query()
-	q.Del(SubdomainProxyAPIKeyParam)
-	rawQuery := q.Encode()
-	if rawQuery != "" {
-		path += "?" + q.Encode()
+	// Strip the smuggled API key query parameter and redirect back to the same
+	// path. r.URL.Path is attacker-controlled, so it can smuggle a separate
+	// host (e.g. "//evil.com") that http.Redirect would send the user to.
+	// Collapse the leading "/" and "\" run to a single "/" and set the path
+	// on a url.URL so it is escaped, keeping the redirect on the current origin.
+	redirectURL := url.URL{
+		Path: "/" + strings.TrimLeft(r.URL.Path, `/\`),
 	}
 
-	http.Redirect(rw, r, path, http.StatusSeeOther)
+	q := r.URL.Query()
+	q.Del(SubdomainProxyAPIKeyParam)
+	redirectURL.RawQuery = q.Encode()
+
+	http.Redirect(rw, r, redirectURL.String(), http.StatusSeeOther)
 	return false
 }
 

--- a/coderd/workspaceapps/proxy.go
+++ b/coderd/workspaceapps/proxy.go
@@ -166,16 +166,16 @@ func (s *Server) Attach(r chi.Router) {
 	r.Get("/api/v2/workspaceagents/{workspaceagent}/pty", s.workspaceAgentPTY)
 }
 
-// originLocalPath returns p rooted at the current origin so it is safe to use
-// as a redirect Location. p (typically r.URL.Path) is attacker-controlled and
-// already percent-decoded, so a leading "//" or "/\" run would otherwise be
-// parsed by http.Redirect or a browser as a scheme-relative URL pointing at
-// another host, turning a redirect back to the same path into an open redirect.
-// Collapsing the leading slash and backslash run to a single "/" keeps the
-// result same-origin. Callers must still build the Location through a url.URL so
-// control characters in the path are percent-encoded.
-func originLocalPath(p string) string {
-	return "/" + strings.TrimLeft(p, `/\`)
+// originLocalURL returns p as a relative URL rooted at the current origin,
+// safe to use as a redirect Location. p (typically r.URL.Path) is
+// attacker-controlled and already percent-decoded, so a leading "//" or "/\"
+// run would otherwise be parsed by http.Redirect or a browser as a
+// scheme-relative URL pointing at another host, turning a redirect back to the
+// same path into an open redirect. Collapsing the leading slash and backslash
+// run to a single "/" keeps the result same-origin, and url.URL.String()
+// percent-encodes any control characters in the path.
+func originLocalURL(p string) *url.URL {
+	return &url.URL{Path: "/" + strings.TrimLeft(p, `/\`)}
 }
 
 // handleAPIKeySmuggling is called by the proxy path and subdomain handlers to
@@ -280,9 +280,9 @@ func (s *Server) handleAPIKeySmuggling(rw http.ResponseWriter, r *http.Request, 
 
 	// Strip the smuggled API key query parameter and redirect back to the same
 	// path. r.URL.Path is attacker-controlled and can smuggle a separate host
-	// (e.g. "//evil.com"); originLocalPath plus url.URL keep the redirect on the
-	// current origin.
-	redirectURL := url.URL{Path: originLocalPath(r.URL.Path)}
+	// (e.g. "//evil.com"); originLocalURL keeps the redirect on the current
+	// origin.
+	redirectURL := originLocalURL(r.URL.Path)
 
 	q := r.URL.Query()
 	q.Del(SubdomainProxyAPIKeyParam)
@@ -628,12 +628,12 @@ func (s *Server) proxyWorkspaceApp(rw http.ResponseWriter, r *http.Request, appT
 		// See https://github.com/coder/code-server/issues/241 for examples.
 		//
 		// r.URL.Path is attacker-controlled, so sanitize it before redirecting
-		// to avoid an off-origin "//host" Location (see originLocalPath).
-		redirectPath := originLocalPath(r.URL.Path)
-		if !strings.HasSuffix(redirectPath, "/") {
-			redirectPath += "/"
+		// to avoid an off-origin "//host" Location (see originLocalURL).
+		redirectURL := originLocalURL(r.URL.Path)
+		if !strings.HasSuffix(redirectURL.Path, "/") {
+			redirectURL.Path += "/"
 		}
-		http.Redirect(rw, r, (&url.URL{Path: redirectPath}).String(), http.StatusTemporaryRedirect)
+		http.Redirect(rw, r, redirectURL.String(), http.StatusTemporaryRedirect)
 		return
 	}
 	if path == "/" && r.URL.RawQuery == "" && appURL.RawQuery != "" {
@@ -645,11 +645,9 @@ func (s *Server) proxyWorkspaceApp(rw http.ResponseWriter, r *http.Request, appT
 		//
 		// r.URL.Path is attacker-controlled, so build the Location from a
 		// sanitized same-origin path instead of r.URL directly (see
-		// originLocalPath).
-		redirectURL := url.URL{
-			Path:     originLocalPath(r.URL.Path),
-			RawQuery: appURL.RawQuery,
-		}
+		// originLocalURL).
+		redirectURL := originLocalURL(r.URL.Path)
+		redirectURL.RawQuery = appURL.RawQuery
 		http.Redirect(rw, r, redirectURL.String(), http.StatusTemporaryRedirect)
 		return
 	}

--- a/coderd/workspaceapps/proxy.go
+++ b/coderd/workspaceapps/proxy.go
@@ -166,6 +166,18 @@ func (s *Server) Attach(r chi.Router) {
 	r.Get("/api/v2/workspaceagents/{workspaceagent}/pty", s.workspaceAgentPTY)
 }
 
+// originLocalPath returns p rooted at the current origin so it is safe to use
+// as a redirect Location. p (typically r.URL.Path) is attacker-controlled and
+// already percent-decoded, so a leading "//" or "/\" run would otherwise be
+// parsed by http.Redirect or a browser as a scheme-relative URL pointing at
+// another host, turning a redirect back to the same path into an open redirect.
+// Collapsing the leading slash and backslash run to a single "/" keeps the
+// result same-origin. Callers must still build the Location through a url.URL so
+// control characters in the path are percent-encoded.
+func originLocalPath(p string) string {
+	return "/" + strings.TrimLeft(p, `/\`)
+}
+
 // handleAPIKeySmuggling is called by the proxy path and subdomain handlers to
 // process any "smuggled" API keys in the query parameters.
 //
@@ -267,13 +279,10 @@ func (s *Server) handleAPIKeySmuggling(rw http.ResponseWriter, r *http.Request, 
 	}))
 
 	// Strip the smuggled API key query parameter and redirect back to the same
-	// path. r.URL.Path is attacker-controlled, so it can smuggle a separate
-	// host (e.g. "//evil.com") that http.Redirect would send the user to.
-	// Collapse the leading "/" and "\" run to a single "/" and set the path
-	// on a url.URL so it is escaped, keeping the redirect on the current origin.
-	redirectURL := url.URL{
-		Path: "/" + strings.TrimLeft(r.URL.Path, `/\`),
-	}
+	// path. r.URL.Path is attacker-controlled and can smuggle a separate host
+	// (e.g. "//evil.com"); originLocalPath plus url.URL keep the redirect on the
+	// current origin.
+	redirectURL := url.URL{Path: originLocalPath(r.URL.Path)}
 
 	q := r.URL.Query()
 	q.Del(SubdomainProxyAPIKeyParam)
@@ -617,7 +626,14 @@ func (s *Server) proxyWorkspaceApp(rw http.ResponseWriter, r *http.Request, appT
 		// Web applications typically request paths relative to the
 		// root URL. This allows for routing behind a proxy or subpath.
 		// See https://github.com/coder/code-server/issues/241 for examples.
-		http.Redirect(rw, r, r.URL.Path+"/", http.StatusTemporaryRedirect)
+		//
+		// r.URL.Path is attacker-controlled, so sanitize it before redirecting
+		// to avoid an off-origin "//host" Location (see originLocalPath).
+		redirectPath := originLocalPath(r.URL.Path)
+		if !strings.HasSuffix(redirectPath, "/") {
+			redirectPath += "/"
+		}
+		http.Redirect(rw, r, (&url.URL{Path: redirectPath}).String(), http.StatusTemporaryRedirect)
 		return
 	}
 	if path == "/" && r.URL.RawQuery == "" && appURL.RawQuery != "" {
@@ -626,8 +642,15 @@ func (s *Server) proxyWorkspaceApp(rw http.ResponseWriter, r *http.Request, appT
 		// query parameters for server-side requests, but sometimes
 		// client-side applications require the query parameters to render
 		// properly. With code-server, this is the "folder" param.
-		r.URL.RawQuery = appURL.RawQuery
-		http.Redirect(rw, r, r.URL.String(), http.StatusTemporaryRedirect)
+		//
+		// r.URL.Path is attacker-controlled, so build the Location from a
+		// sanitized same-origin path instead of r.URL directly (see
+		// originLocalPath).
+		redirectURL := url.URL{
+			Path:     originLocalPath(r.URL.Path),
+			RawQuery: appURL.RawQuery,
+		}
+		http.Redirect(rw, r, redirectURL.String(), http.StatusTemporaryRedirect)
 		return
 	}
 

--- a/coderd/workspaceapps/proxy_internal_test.go
+++ b/coderd/workspaceapps/proxy_internal_test.go
@@ -16,41 +16,49 @@ func Test_originLocalURL(t *testing.T) {
 	t.Run("RejectsOffOrigin", func(t *testing.T) {
 		t.Parallel()
 
-		// Each input models an already-percent-decoded r.URL.Path that tries to
+		// Each path models an already-percent-decoded r.URL.Path that tries to
 		// smuggle a separate host into the redirect.
-		maliciousPaths := []string{
-			"//evil.com/phish",
-			"///evil.com/phish",
-			"/\\evil.com/phish",
-			"/\\/evil.com/phish",
-			"\\\\evil.com/phish",
-			"/\t/evil.com/phish",
-			"/\t\\evil.com/phish",
-			"/\n/evil.com/phish",
-			"/\r/evil.com/phish",
-			"/\t//evil.com/phish",
+		cases := []struct {
+			name string
+			path string
+		}{
+			{name: "DoubleSlash", path: "//evil.com/phish"},
+			{name: "TripleSlash", path: "///evil.com/phish"},
+			{name: "SlashBackslash", path: "/\\evil.com/phish"},
+			{name: "SlashBackslashSlash", path: "/\\/evil.com/phish"},
+			{name: "DoubleBackslash", path: "\\\\evil.com/phish"},
+			{name: "SlashTab", path: "/\t/evil.com/phish"},
+			{name: "SlashTabBackslash", path: "/\t\\evil.com/phish"},
+			{name: "SlashNewline", path: "/\n/evil.com/phish"},
+			{name: "SlashCarriageReturn", path: "/\r/evil.com/phish"},
+			{name: "SlashTabDoubleSlash", path: "/\t//evil.com/phish"},
 		}
 
-		for _, p := range maliciousPaths {
-			loc := originLocalURL(p).String()
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
 
-			// The Location must parse as a relative, same-origin reference.
-			require.Falsef(t, strings.HasPrefix(loc, "//"),
-				"path %q produced scheme-relative Location %q", p, loc)
-			parsed, err := url.Parse(loc)
-			require.NoErrorf(t, err, "path %q produced unparseable Location %q", p, loc)
-			require.Emptyf(t, parsed.Scheme, "path %q produced Location %q with a scheme", p, loc)
-			require.Emptyf(t, parsed.Host, "path %q produced Location %q with a host", p, loc)
+				loc := originLocalURL(tc.path).String()
 
-			// It must also be free of raw bytes a browser would normalize back
-			// into an authority before resolving (a backslash becomes "/", and
-			// tab/newline/CR are stripped, either of which could re-form "//host").
-			// url.URL.String() guarantees this by percent-encoding them; we assert
-			// it here rather than reproducing browser normalization in the code.
-			for _, raw := range []string{`\`, "\t", "\n", "\r"} {
-				require.NotContainsf(t, loc, raw,
-					"path %q produced Location %q containing a raw %q", p, loc, raw)
-			}
+				// The Location must parse as a relative, same-origin reference.
+				require.Falsef(t, strings.HasPrefix(loc, "//"),
+					"path %q produced scheme-relative Location %q", tc.path, loc)
+				parsed, err := url.Parse(loc)
+				require.NoErrorf(t, err, "path %q produced unparseable Location %q", tc.path, loc)
+				require.Emptyf(t, parsed.Scheme, "path %q produced Location %q with a scheme", tc.path, loc)
+				require.Emptyf(t, parsed.Host, "path %q produced Location %q with a host", tc.path, loc)
+
+				// It must also be free of raw bytes a browser would normalize back
+				// into an authority before resolving (a backslash becomes "/", and
+				// tab/newline/CR are stripped, either of which could re-form
+				// "//host"). url.URL.String() guarantees this by percent-encoding
+				// them; we assert it here rather than reproducing browser
+				// normalization in the code.
+				for _, raw := range []string{`\`, "\t", "\n", "\r"} {
+					require.NotContainsf(t, loc, raw,
+						"path %q produced Location %q containing a raw %q", tc.path, loc, raw)
+				}
+			})
 		}
 	})
 
@@ -74,8 +82,12 @@ func Test_originLocalURL(t *testing.T) {
 		}
 
 		for _, tc := range cases {
-			loc := originLocalURL(tc.in).String()
-			require.Equalf(t, tc.want, loc, "%s: originLocalURL(%q) must percent-encode the control character", tc.name, tc.in)
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				require.Equalf(t, tc.want, originLocalURL(tc.in).String(),
+					"originLocalURL(%q) must percent-encode the control character", tc.in)
+			})
 		}
 	})
 
@@ -83,18 +95,23 @@ func Test_originLocalURL(t *testing.T) {
 		t.Parallel()
 
 		cases := []struct {
+			name string
 			in   string
 			want string
 		}{
-			{in: "", want: "/"},
-			{in: "/", want: "/"},
-			{in: "/test", want: "/test"},
-			{in: "/app/sub/page", want: "/app/sub/page"},
-			{in: "/@user/ws/apps/app", want: "/@user/ws/apps/app"},
+			{name: "Empty", in: "", want: "/"},
+			{name: "Root", in: "/", want: "/"},
+			{name: "Simple", in: "/test", want: "/test"},
+			{name: "Nested", in: "/app/sub/page", want: "/app/sub/page"},
+			{name: "PathApp", in: "/@user/ws/apps/app", want: "/@user/ws/apps/app"},
 		}
 
 		for _, tc := range cases {
-			require.Equalf(t, tc.want, originLocalURL(tc.in).String(), "originLocalURL(%q)", tc.in)
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				require.Equalf(t, tc.want, originLocalURL(tc.in).String(), "originLocalURL(%q)", tc.in)
+			})
 		}
 	})
 }

--- a/coderd/workspaceapps/proxy_internal_test.go
+++ b/coderd/workspaceapps/proxy_internal_test.go
@@ -8,10 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Test_originLocalPath checks that originLocalPath keeps a redirect target on
-// the current origin. Call sites build the Location as
-// url.URL{Path: originLocalPath(...)}.String(), so the assertions mirror that.
-func Test_originLocalPath(t *testing.T) {
+// Test_originLocalURL checks that originLocalURL produces a redirect target that
+// stays on the current origin.
+func Test_originLocalURL(t *testing.T) {
 	t.Parallel()
 
 	t.Run("RejectsOffOrigin", func(t *testing.T) {
@@ -33,7 +32,7 @@ func Test_originLocalPath(t *testing.T) {
 		}
 
 		for _, p := range maliciousPaths {
-			loc := (&url.URL{Path: originLocalPath(p)}).String()
+			loc := originLocalURL(p).String()
 
 			// Model browser URL normalization: tab/newline/CR are stripped and a
 			// backslash is treated like a forward slash before resolving.
@@ -55,9 +54,9 @@ func Test_originLocalPath(t *testing.T) {
 		// A redirect built from a path containing a raw control character is an
 		// open redirect: http.Redirect emits it verbatim (url.Parse rejects the
 		// control byte and skips cleaning) and browsers strip tab/newline/CR
-		// before resolving, re-forming "//evil.com". Building the Location via
-		// url.URL percent-encodes each one. Assert every class is escaped so a
-		// future change that breaks encoding for only one class is caught.
+		// before resolving, re-forming "//evil.com". originLocalURL percent-encodes
+		// each one. Assert every class is escaped so a future change that breaks
+		// encoding for only one class is caught.
 		cases := []struct {
 			name string
 			in   string
@@ -69,8 +68,8 @@ func Test_originLocalPath(t *testing.T) {
 		}
 
 		for _, tc := range cases {
-			loc := (&url.URL{Path: originLocalPath(tc.in)}).String()
-			require.Equalf(t, tc.want, loc, "%s: originLocalPath(%q) must percent-encode the control character", tc.name, tc.in)
+			loc := originLocalURL(tc.in).String()
+			require.Equalf(t, tc.want, loc, "%s: originLocalURL(%q) must percent-encode the control character", tc.name, tc.in)
 		}
 	})
 
@@ -89,7 +88,7 @@ func Test_originLocalPath(t *testing.T) {
 		}
 
 		for _, tc := range cases {
-			require.Equalf(t, tc.want, originLocalPath(tc.in), "originLocalPath(%q)", tc.in)
+			require.Equalf(t, tc.want, originLocalURL(tc.in).String(), "originLocalURL(%q)", tc.in)
 		}
 	})
 }

--- a/coderd/workspaceapps/proxy_internal_test.go
+++ b/coderd/workspaceapps/proxy_internal_test.go
@@ -50,6 +50,31 @@ func Test_originLocalPath(t *testing.T) {
 		}
 	})
 
+	t.Run("EscapesControlCharacters", func(t *testing.T) {
+		t.Parallel()
+
+		// A redirect built from a path containing a raw control character is an
+		// open redirect: http.Redirect emits it verbatim (url.Parse rejects the
+		// control byte and skips cleaning) and browsers strip tab/newline/CR
+		// before resolving, re-forming "//evil.com". Building the Location via
+		// url.URL percent-encodes each one. Assert every class is escaped so a
+		// future change that breaks encoding for only one class is caught.
+		cases := []struct {
+			name string
+			in   string
+			want string
+		}{
+			{name: "Tab", in: "/\t/evil.com", want: "/%09/evil.com"},
+			{name: "Newline", in: "/\n/evil.com", want: "/%0A/evil.com"},
+			{name: "CarriageReturn", in: "/\r/evil.com", want: "/%0D/evil.com"},
+		}
+
+		for _, tc := range cases {
+			loc := (&url.URL{Path: originLocalPath(tc.in)}).String()
+			require.Equalf(t, tc.want, loc, "%s: originLocalPath(%q) must percent-encode the control character", tc.name, tc.in)
+		}
+	})
+
 	t.Run("PreservesLegitPaths", func(t *testing.T) {
 		t.Parallel()
 

--- a/coderd/workspaceapps/proxy_internal_test.go
+++ b/coderd/workspaceapps/proxy_internal_test.go
@@ -1,0 +1,71 @@
+package workspaceapps
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestOriginLocalPath verifies that originLocalPath, the helper used to build
+// every redirect Location derived from r.URL.Path, keeps the target on the
+// current origin (ANT-2026-22456). Call sites build the Location as
+// url.URL{Path: originLocalPath(...)}.String(), so the assertions mirror that.
+func TestOriginLocalPath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("RejectsOffOrigin", func(t *testing.T) {
+		t.Parallel()
+
+		// Each input models an already-percent-decoded r.URL.Path that tries to
+		// smuggle a separate host into the redirect.
+		maliciousPaths := []string{
+			"//evil.com/phish",
+			"///evil.com/phish",
+			"/\\evil.com/phish",
+			"/\\/evil.com/phish",
+			"\\\\evil.com/phish",
+			"/\t/evil.com/phish",
+			"/\t\\evil.com/phish",
+			"/\n/evil.com/phish",
+			"/\r/evil.com/phish",
+			"/\t//evil.com/phish",
+		}
+
+		for _, p := range maliciousPaths {
+			loc := (&url.URL{Path: originLocalPath(p)}).String()
+
+			// Model browser URL normalization: tab/newline/CR are stripped and a
+			// backslash is treated like a forward slash before resolving.
+			browserLoc := strings.NewReplacer("\t", "", "\n", "", "\r", "").Replace(loc)
+			browserLoc = strings.ReplaceAll(browserLoc, "\\", "/")
+			require.Falsef(t, strings.HasPrefix(browserLoc, "//"),
+				"path %q produced off-origin Location %q (browser-normalized %q)", p, loc, browserLoc)
+
+			parsed, err := url.Parse(loc)
+			require.NoErrorf(t, err, "path %q produced unparseable Location %q", p, loc)
+			require.Emptyf(t, parsed.Scheme, "path %q produced Location %q with a scheme", p, loc)
+			require.Emptyf(t, parsed.Host, "path %q produced Location %q with a host", p, loc)
+		}
+	})
+
+	t.Run("PreservesLegitPaths", func(t *testing.T) {
+		t.Parallel()
+
+		cases := []struct {
+			in   string
+			want string
+		}{
+			{in: "", want: "/"},
+			{in: "/", want: "/"},
+			{in: "/test", want: "/test"},
+			{in: "/app/sub/page", want: "/app/sub/page"},
+			{in: "/@user/ws/apps/app", want: "/@user/ws/apps/app"},
+		}
+
+		for _, tc := range cases {
+			require.Equalf(t, tc.want, originLocalPath(tc.in), "originLocalPath(%q)", tc.in)
+		}
+	})
+}

--- a/coderd/workspaceapps/proxy_internal_test.go
+++ b/coderd/workspaceapps/proxy_internal_test.go
@@ -34,17 +34,23 @@ func Test_originLocalURL(t *testing.T) {
 		for _, p := range maliciousPaths {
 			loc := originLocalURL(p).String()
 
-			// Model browser URL normalization: tab/newline/CR are stripped and a
-			// backslash is treated like a forward slash before resolving.
-			browserLoc := strings.NewReplacer("\t", "", "\n", "", "\r", "").Replace(loc)
-			browserLoc = strings.ReplaceAll(browserLoc, "\\", "/")
-			require.Falsef(t, strings.HasPrefix(browserLoc, "//"),
-				"path %q produced off-origin Location %q (browser-normalized %q)", p, loc, browserLoc)
-
+			// The Location must parse as a relative, same-origin reference.
+			require.Falsef(t, strings.HasPrefix(loc, "//"),
+				"path %q produced scheme-relative Location %q", p, loc)
 			parsed, err := url.Parse(loc)
 			require.NoErrorf(t, err, "path %q produced unparseable Location %q", p, loc)
 			require.Emptyf(t, parsed.Scheme, "path %q produced Location %q with a scheme", p, loc)
 			require.Emptyf(t, parsed.Host, "path %q produced Location %q with a host", p, loc)
+
+			// It must also be free of raw bytes a browser would normalize back
+			// into an authority before resolving (a backslash becomes "/", and
+			// tab/newline/CR are stripped, either of which could re-form "//host").
+			// url.URL.String() guarantees this by percent-encoding them; we assert
+			// it here rather than reproducing browser normalization in the code.
+			for _, raw := range []string{`\`, "\t", "\n", "\r"} {
+				require.NotContainsf(t, loc, raw,
+					"path %q produced Location %q containing a raw %q", p, loc, raw)
+			}
 		}
 	})
 

--- a/coderd/workspaceapps/proxy_internal_test.go
+++ b/coderd/workspaceapps/proxy_internal_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestOriginLocalPath verifies that originLocalPath, the helper used to build
+// Test_originLocalPath verifies that originLocalPath, the helper used to build
 // every redirect Location derived from r.URL.Path, keeps the target on the
 // current origin (ANT-2026-22456). Call sites build the Location as
 // url.URL{Path: originLocalPath(...)}.String(), so the assertions mirror that.
-func TestOriginLocalPath(t *testing.T) {
+func Test_originLocalPath(t *testing.T) {
 	t.Parallel()
 
 	t.Run("RejectsOffOrigin", func(t *testing.T) {

--- a/coderd/workspaceapps/proxy_internal_test.go
+++ b/coderd/workspaceapps/proxy_internal_test.go
@@ -8,9 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Test_originLocalPath verifies that originLocalPath, the helper used to build
-// every redirect Location derived from r.URL.Path, keeps the target on the
-// current origin (ANT-2026-22456). Call sites build the Location as
+// Test_originLocalPath checks that originLocalPath keeps a redirect target on
+// the current origin. Call sites build the Location as
 // url.URL{Path: originLocalPath(...)}.String(), so the assertions mirror that.
 func Test_originLocalPath(t *testing.T) {
 	t.Parallel()

--- a/coderd/workspaceapps/proxy_test.go
+++ b/coderd/workspaceapps/proxy_test.go
@@ -98,7 +98,7 @@ func TestHandleSubdomain(t *testing.T) {
 	// After consuming a smuggled API key, the handler redirects to strip the key.
 	// A path that smuggles a separate host (e.g. "//evil.com") must redirect back
 	// to the current origin, not off-site. The full path-sanitization matrix lives
-	// in Test_originLocalPath.
+	// in Test_originLocalURL.
 	t.Run("APIKeySmugglingStaysOnOrigin", func(t *testing.T) {
 		t.Parallel()
 

--- a/coderd/workspaceapps/proxy_test.go
+++ b/coderd/workspaceapps/proxy_test.go
@@ -37,155 +37,148 @@ func (s *fakeSignedTokenProvider) Issue(_ context.Context, _ http.ResponseWriter
 	return nil, "", false
 }
 
-func TestHandleSubdomain_IgnoresUntrustedForwardedHost(t *testing.T) {
+func TestHandleSubdomain(t *testing.T) {
 	t.Parallel()
 
-	hostnamePattern := "*--apps.test.coder.com"
-	hostnameRegex, err := appurl.CompileHostnamePattern(hostnamePattern)
-	require.NoError(t, err)
+	t.Run("IgnoresUntrustedForwardedHost", func(t *testing.T) {
+		t.Parallel()
 
-	dashboardURL, err := url.Parse("https://dashboard.test.coder.com")
-	require.NoError(t, err)
+		hostnamePattern := "*--apps.test.coder.com"
+		hostnameRegex, err := appurl.CompileHostnamePattern(hostnamePattern)
+		require.NoError(t, err)
 
-	provider := &fakeSignedTokenProvider{}
-	srv := workspaceapps.NewServer(workspaceapps.ServerOptions{
-		Logger:        testutil.Logger(t),
-		DashboardURL:  dashboardURL,
-		AccessURL:     dashboardURL,
-		Hostname:      hostnamePattern,
-		HostnameRegex: hostnameRegex,
-		RealIPConfig: &httpmw.RealIPConfig{
-			TrustedOrigins: []*net.IPNet{{
-				IP:   net.ParseIP("10.0.0.1"),
-				Mask: net.CIDRMask(32, 32),
-			}},
-		},
-		SignedTokenProvider: provider,
+		dashboardURL, err := url.Parse("https://dashboard.test.coder.com")
+		require.NoError(t, err)
+
+		provider := &fakeSignedTokenProvider{}
+		srv := workspaceapps.NewServer(workspaceapps.ServerOptions{
+			Logger:        testutil.Logger(t),
+			DashboardURL:  dashboardURL,
+			AccessURL:     dashboardURL,
+			Hostname:      hostnamePattern,
+			HostnameRegex: hostnameRegex,
+			RealIPConfig: &httpmw.RealIPConfig{
+				TrustedOrigins: []*net.IPNet{{
+					IP:   net.ParseIP("10.0.0.1"),
+					Mask: net.CIDRMask(32, 32),
+				}},
+			},
+			SignedTokenProvider: provider,
+		})
+
+		forgedHost := appurl.ApplicationURL{
+			AppSlugOrPort: "app",
+			WorkspaceName: "workspace",
+			Username:      "victim",
+		}.String() + "--apps.test.coder.com"
+
+		nextCalled := false
+		next := http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+			nextCalled = true
+		})
+
+		// Given: a request with a forged X-Forwarded-Host set to a valid
+		// app hostname, and an immediate peer outside the trusted proxy
+		// config.
+		req := httptest.NewRequest(http.MethodGet, "https://dashboard.test.coder.com/", nil)
+		req.Header.Set(httpapi.XForwardedHostHeader, forgedHost)
+		req.RemoteAddr = "17.18.19.20:1234"
+
+		// When: HandleSubdomain runs.
+		srv.HandleSubdomain()(next).ServeHTTP(httptest.NewRecorder(), req)
+
+		// Then: it ignores untrusted X-Forwarded-Host, so the received
+		// dashboard host is used, the request falls through to the next
+		// handler, and the signed app token provider is never called.
+		require.True(t, nextCalled)
+		require.Zero(t, provider.fromRequestCalls)
+		require.Zero(t, provider.issueCalls)
 	})
 
-	forgedHost := appurl.ApplicationURL{
-		AppSlugOrPort: "app",
-		WorkspaceName: "workspace",
-		Username:      "victim",
-	}.String() + "--apps.test.coder.com"
+	// After consuming a smuggled API key, the handler redirects to strip the key.
+	// A path that smuggles a separate host (e.g. "//evil.com") must redirect back
+	// to the current origin, not off-site. The full path-sanitization matrix lives
+	// in Test_originLocalPath.
+	t.Run("APIKeySmugglingStaysOnOrigin", func(t *testing.T) {
+		t.Parallel()
 
-	nextCalled := false
-	next := http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
-		nextCalled = true
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		hostnamePattern := "*--apps.test.coder.com"
+		hostnameRegex, err := appurl.CompileHostnamePattern(hostnamePattern)
+		require.NoError(t, err)
+
+		dashboardURL, err := url.Parse("https://dashboard.test.coder.com")
+		require.NoError(t, err)
+
+		// StaticKey lets us mint a smuggled key the handler can decrypt.
+		// A256GCMKW needs a 32-byte key.
+		keycache := jwtutils.StaticKey{ID: "test", Key: generateSecret(t, 32)}
+		payload := workspaceapps.EncryptedAPIKeyPayload{APIKey: "fake-api-key"}
+		payload.Fill(time.Now())
+		encryptedAPIKey, err := jwtutils.Encrypt(ctx, keycache, payload)
+		require.NoError(t, err)
+
+		srv := workspaceapps.NewServer(workspaceapps.ServerOptions{
+			Logger:        testutil.Logger(t),
+			DashboardURL:  dashboardURL,
+			AccessURL:     dashboardURL,
+			Hostname:      hostnamePattern,
+			HostnameRegex: hostnameRegex,
+			RealIPConfig: &httpmw.RealIPConfig{
+				TrustedOrigins: []*net.IPNet{{
+					IP:   net.ParseIP("10.0.0.1"),
+					Mask: net.CIDRMask(32, 32),
+				}},
+			},
+			SignedTokenProvider:      &fakeSignedTokenProvider{},
+			APIKeyEncryptionKeycache: keycache,
+		})
+
+		host := appurl.ApplicationURL{
+			AppSlugOrPort: "app",
+			WorkspaceName: "workspace",
+			Username:      "user",
+		}.String() + "--apps.test.coder.com"
+
+		// Set r.URL.Path directly: the slash-collapsing middleware writes to chi's
+		// RoutePath, not r.URL.Path, so the raw "//evil.com" survives to the handler.
+		// "x=1" rides along to confirm unrelated params are preserved.
+		req := httptest.NewRequest(http.MethodGet, "https://"+host+"/", nil)
+		req.Host = host
+		req.RemoteAddr = "10.0.0.1:1234"
+		req.URL.Path = "//evil.com/phish"
+		req.URL.RawQuery = url.Values{
+			workspaceapps.SubdomainProxyAPIKeyParam: {encryptedAPIKey},
+			"x":                                     {"1"},
+		}.Encode()
+
+		rec := httptest.NewRecorder()
+		nextCalled := false
+		next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			nextCalled = true
+		})
+
+		srv.HandleSubdomain()(next).ServeHTTP(rec, req)
+
+		res := rec.Result()
+		defer res.Body.Close()
+
+		// The key is consumed and a redirect is issued instead of proxying.
+		require.Equal(t, http.StatusSeeOther, res.StatusCode)
+		require.False(t, nextCalled)
+
+		loc := res.Header.Get("Location")
+		require.NotEmpty(t, loc)
+		require.False(t, strings.HasPrefix(loc, "//"), "redirect %q must stay same-origin", loc)
+
+		parsed, err := url.Parse(loc)
+		require.NoError(t, err)
+		require.Empty(t, parsed.Scheme, "redirect %q must not carry a scheme", loc)
+		require.Empty(t, parsed.Host, "redirect %q must not carry a host", loc)
+
+		// The smuggled key is stripped and unrelated query params survive.
+		require.Empty(t, parsed.Query().Get(workspaceapps.SubdomainProxyAPIKeyParam))
+		require.Equal(t, "1", parsed.Query().Get("x"))
 	})
-
-	// Given: a request with a forged X-Forwarded-Host set to a valid
-	// app hostname, and an immediate peer outside the trusted proxy
-	// config.
-	req := httptest.NewRequest(http.MethodGet, "https://dashboard.test.coder.com/", nil)
-	req.Header.Set(httpapi.XForwardedHostHeader, forgedHost)
-	req.RemoteAddr = "17.18.19.20:1234"
-
-	// When: HandleSubdomain runs.
-	srv.HandleSubdomain()(next).ServeHTTP(httptest.NewRecorder(), req)
-
-	// Then: it ignores untrusted X-Forwarded-Host, so the received
-	// dashboard host is used, the request falls through to the next
-	// handler, and the signed app token provider is never called.
-	require.True(t, nextCalled)
-	require.Zero(t, provider.fromRequestCalls)
-	require.Zero(t, provider.issueCalls)
-}
-
-// TestHandleSubdomain_APIKeySmuggling_NoOpenRedirect verifies that after
-// HandleSubdomain consumes a smuggled subdomain API key, the redirect it issues
-// to strip the key stays on the current origin and cannot be pointed at an
-// external host (ANT-2026-22456).
-//
-// This is a focused wiring test: it confirms the real handler sanitizes the
-// redirect target and strips the key while preserving other query parameters.
-// The exhaustive path-sanitization matrix (slash, backslash, tab, newline, CR,
-// encoded variants) lives in Test_originLocalPath, which exercises the same
-// url.URL construction without the server setup. It is built inline like the
-// sibling test above; there is no lighter shared fixture, and the full app test
-// harness cannot model an attacker path that bypasses slash-cleaning middleware.
-func TestHandleSubdomain_APIKeySmuggling_NoOpenRedirect(t *testing.T) {
-	t.Parallel()
-
-	ctx := testutil.Context(t, testutil.WaitShort)
-
-	hostnamePattern := "*--apps.test.coder.com"
-	hostnameRegex, err := appurl.CompileHostnamePattern(hostnamePattern)
-	require.NoError(t, err)
-
-	dashboardURL, err := url.Parse("https://dashboard.test.coder.com")
-	require.NoError(t, err)
-
-	// StaticKey satisfies cryptokeys.EncryptionKeycache and lets us mint a valid
-	// smuggled API key so the handler reaches the redirect. A256GCMKW needs a
-	// 32-byte key.
-	keycache := jwtutils.StaticKey{ID: "test", Key: generateSecret(t, 32)}
-	payload := workspaceapps.EncryptedAPIKeyPayload{APIKey: "fake-api-key"}
-	payload.Fill(time.Now())
-	encryptedAPIKey, err := jwtutils.Encrypt(ctx, keycache, payload)
-	require.NoError(t, err)
-
-	srv := workspaceapps.NewServer(workspaceapps.ServerOptions{
-		Logger:        testutil.Logger(t),
-		DashboardURL:  dashboardURL,
-		AccessURL:     dashboardURL,
-		Hostname:      hostnamePattern,
-		HostnameRegex: hostnameRegex,
-		RealIPConfig: &httpmw.RealIPConfig{
-			TrustedOrigins: []*net.IPNet{{
-				IP:   net.ParseIP("10.0.0.1"),
-				Mask: net.CIDRMask(32, 32),
-			}},
-		},
-		SignedTokenProvider:      &fakeSignedTokenProvider{},
-		APIKeyEncryptionKeycache: keycache,
-	})
-
-	host := appurl.ApplicationURL{
-		AppSlugOrPort: "app",
-		WorkspaceName: "workspace",
-		Username:      "user",
-	}.String() + "--apps.test.coder.com"
-
-	// The HTTP server populates r.URL.Path from the request line; set it directly
-	// to model the attacker-supplied "//evil.com" path that survives to the
-	// handler (the slash-collapsing middleware writes to chi's RoutePath, not
-	// r.URL.Path). A benign "x=1" rides along to confirm it is preserved.
-	req := httptest.NewRequest(http.MethodGet, "https://"+host+"/", nil)
-	req.Host = host
-	req.RemoteAddr = "10.0.0.1:1234"
-	req.URL.Path = "//evil.com/phish"
-	req.URL.RawQuery = url.Values{
-		workspaceapps.SubdomainProxyAPIKeyParam: {encryptedAPIKey},
-		"x":                                     {"1"},
-	}.Encode()
-
-	rec := httptest.NewRecorder()
-	nextCalled := false
-	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		nextCalled = true
-	})
-
-	srv.HandleSubdomain()(next).ServeHTTP(rec, req)
-
-	res := rec.Result()
-	defer res.Body.Close()
-
-	// The smuggled key is consumed and a redirect is issued instead of falling
-	// through to the proxied app.
-	require.Equal(t, http.StatusSeeOther, res.StatusCode)
-	require.False(t, nextCalled)
-
-	loc := res.Header.Get("Location")
-	require.NotEmpty(t, loc)
-	require.False(t, strings.HasPrefix(loc, "//"), "redirect %q must stay same-origin", loc)
-
-	parsed, err := url.Parse(loc)
-	require.NoError(t, err)
-	require.Empty(t, parsed.Scheme, "redirect %q must not carry a scheme", loc)
-	require.Empty(t, parsed.Host, "redirect %q must not carry a host", loc)
-
-	// The smuggled key is stripped and unrelated query params survive.
-	require.Empty(t, parsed.Query().Get(workspaceapps.SubdomainProxyAPIKeyParam))
-	require.Equal(t, "1", parsed.Query().Get("x"))
 }

--- a/coderd/workspaceapps/proxy_test.go
+++ b/coderd/workspaceapps/proxy_test.go
@@ -92,12 +92,20 @@ func TestHandleSubdomain_IgnoresUntrustedForwardedHost(t *testing.T) {
 	require.Zero(t, provider.issueCalls)
 }
 
-// newSmugglingTestServer builds a workspaceapps.Server wired with a static
-// encryption keycache and returns the server, a valid app subdomain host, and a
-// freshly minted smuggled API key that decrypts against the server. Each caller
-// gets its own server so parallel subtests never share mutable state.
-func newSmugglingTestServer(t *testing.T) (srv *workspaceapps.Server, host, encryptedAPIKey string) {
-	t.Helper()
+// TestHandleSubdomain_APIKeySmuggling_NoOpenRedirect verifies that after
+// HandleSubdomain consumes a smuggled subdomain API key, the redirect it issues
+// to strip the key stays on the current origin and cannot be pointed at an
+// external host (ANT-2026-22456).
+//
+// This is a focused wiring test: it confirms the real handler sanitizes the
+// redirect target and strips the key while preserving other query parameters.
+// The exhaustive path-sanitization matrix (slash, backslash, tab, newline, CR,
+// encoded variants) lives in Test_originLocalPath, which exercises the same
+// url.URL construction without the server setup. It is built inline like the
+// sibling test above; there is no lighter shared fixture, and the full app test
+// harness cannot model an attacker path that bypasses slash-cleaning middleware.
+func TestHandleSubdomain_APIKeySmuggling_NoOpenRedirect(t *testing.T) {
+	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitShort)
 
@@ -111,17 +119,13 @@ func newSmugglingTestServer(t *testing.T) (srv *workspaceapps.Server, host, encr
 	// StaticKey satisfies cryptokeys.EncryptionKeycache and lets us mint a valid
 	// smuggled API key so the handler reaches the redirect. A256GCMKW needs a
 	// 32-byte key.
-	keycache := jwtutils.StaticKey{
-		ID:  "test",
-		Key: generateSecret(t, 32),
-	}
-
+	keycache := jwtutils.StaticKey{ID: "test", Key: generateSecret(t, 32)}
 	payload := workspaceapps.EncryptedAPIKeyPayload{APIKey: "fake-api-key"}
 	payload.Fill(time.Now())
-	encryptedAPIKey, err = jwtutils.Encrypt(ctx, keycache, payload)
+	encryptedAPIKey, err := jwtutils.Encrypt(ctx, keycache, payload)
 	require.NoError(t, err)
 
-	srv = workspaceapps.NewServer(workspaceapps.ServerOptions{
+	srv := workspaceapps.NewServer(workspaceapps.ServerOptions{
 		Logger:        testutil.Logger(t),
 		DashboardURL:  dashboardURL,
 		AccessURL:     dashboardURL,
@@ -137,141 +141,51 @@ func newSmugglingTestServer(t *testing.T) (srv *workspaceapps.Server, host, encr
 		APIKeyEncryptionKeycache: keycache,
 	})
 
-	host = appurl.ApplicationURL{
+	host := appurl.ApplicationURL{
 		AppSlugOrPort: "app",
 		WorkspaceName: "workspace",
 		Username:      "user",
 	}.String() + "--apps.test.coder.com"
 
-	return srv, host, encryptedAPIKey
-}
-
-// doSmugglingRequest drives HandleSubdomain with a smuggled API key and the
-// given (already attacker-decoded) request path. It models how the path
-// survives to the handler by setting r.URL.Path directly: the slash-collapsing
-// middleware writes to chi's RoutePath, not r.URL.Path. A benign "x=1" query
-// parameter rides along to verify it is preserved across the redirect.
-func doSmugglingRequest(t *testing.T, srv *workspaceapps.Server, host, encryptedAPIKey, rawPath string) (status int, location string, nextCalled bool) {
-	t.Helper()
-
+	// The HTTP server populates r.URL.Path from the request line; set it directly
+	// to model the attacker-supplied "//evil.com" path that survives to the
+	// handler (the slash-collapsing middleware writes to chi's RoutePath, not
+	// r.URL.Path). A benign "x=1" rides along to confirm it is preserved.
 	req := httptest.NewRequest(http.MethodGet, "https://"+host+"/", nil)
 	req.Host = host
 	req.RemoteAddr = "10.0.0.1:1234"
-	req.URL.Path = rawPath
+	req.URL.Path = "//evil.com/phish"
 	req.URL.RawQuery = url.Values{
 		workspaceapps.SubdomainProxyAPIKeyParam: {encryptedAPIKey},
 		"x":                                     {"1"},
 	}.Encode()
 
 	rec := httptest.NewRecorder()
-	called := false
+	nextCalled := false
 	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		called = true
+		nextCalled = true
 	})
 
 	srv.HandleSubdomain()(next).ServeHTTP(rec, req)
 
 	res := rec.Result()
 	defer res.Body.Close()
-	return res.StatusCode, res.Header.Get("Location"), called
-}
 
-// TestHandleSubdomain_APIKeySmuggling_NoOpenRedirect ensures that the redirect
-// issued after consuming a smuggled subdomain API key cannot be turned into an
-// open redirect to an arbitrary external origin (ANT-2026-22456).
-//
-// The request path is attacker-controlled and already percent-decoded.
-// http.Redirect parses the Location with url.Parse (which treats a leading "//"
-// as a scheme-relative URL) and emits it verbatim when parsing fails. Browsers
-// additionally strip tab/newline characters and treat a leading "/\" like "//",
-// so a raw tab such as "/<tab>/evil.com" is a real bypass over HTTP/1 because
-// the header writer does not sanitize tabs.
-func TestHandleSubdomain_APIKeySmuggling_NoOpenRedirect(t *testing.T) {
-	t.Parallel()
+	// The smuggled key is consumed and a redirect is issued instead of falling
+	// through to the proxied app.
+	require.Equal(t, http.StatusSeeOther, res.StatusCode)
+	require.False(t, nextCalled)
 
-	cases := []struct {
-		name string
-		// path is the already-decoded value of r.URL.Path as seen by the handler.
-		path string
-	}{
-		{name: "DoubleSlash", path: "//evil.com/phish"},
-		{name: "TripleSlash", path: "///evil.com/phish"},
-		{name: "LeadingBackslash", path: "/\\evil.com/phish"},
-		{name: "LeadingTab", path: "/\t/evil.com/phish"},
-		{name: "TabThenBackslash", path: "/\t\\evil.com/phish"},
-		{name: "LeadingBackslashSlash", path: "/\\/evil.com/phish"},
-	}
+	loc := res.Header.Get("Location")
+	require.NotEmpty(t, loc)
+	require.False(t, strings.HasPrefix(loc, "//"), "redirect %q must stay same-origin", loc)
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+	parsed, err := url.Parse(loc)
+	require.NoError(t, err)
+	require.Empty(t, parsed.Scheme, "redirect %q must not carry a scheme", loc)
+	require.Empty(t, parsed.Host, "redirect %q must not carry a host", loc)
 
-			srv, host, encryptedAPIKey := newSmugglingTestServer(t)
-
-			status, loc, nextCalled := doSmugglingRequest(t, srv, host, encryptedAPIKey, tc.path)
-
-			// The smuggled key is consumed and a redirect is issued instead of
-			// falling through to the proxied app.
-			require.Equal(t, http.StatusSeeOther, status)
-			require.False(t, nextCalled)
-			require.NotEmpty(t, loc)
-
-			// Model browser URL normalization: tab/newline/CR are stripped and a
-			// backslash is treated like a forward slash before the URL is
-			// resolved. After that, the Location must not look like a
-			// scheme-relative ("//host") URL.
-			browserLoc := strings.NewReplacer("\t", "", "\n", "", "\r", "").Replace(loc)
-			browserLoc = strings.ReplaceAll(browserLoc, "\\", "/")
-			require.False(t, strings.HasPrefix(browserLoc, "//"),
-				"redirect %q resolves off-origin (browser-normalized to %q)", loc, browserLoc)
-
-			// Go's url.Parse must also see a same-origin, relative reference.
-			parsed, err := url.Parse(loc)
-			require.NoError(t, err)
-			require.Empty(t, parsed.Scheme, "redirect %q must not carry a scheme", loc)
-			require.Empty(t, parsed.Host, "redirect %q must not carry a host", loc)
-
-			// The smuggled key is stripped and unrelated query params survive.
-			require.Empty(t, parsed.Query().Get(workspaceapps.SubdomainProxyAPIKeyParam))
-			require.Equal(t, "1", parsed.Query().Get("x"))
-		})
-	}
-}
-
-// TestHandleSubdomain_APIKeySmuggling_PreservesPath ensures the security fix does
-// not change the redirect for legitimate paths: the path round-trips and the
-// smuggled key is stripped while other query params are preserved.
-func TestHandleSubdomain_APIKeySmuggling_PreservesPath(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name     string
-		path     string
-		wantPath string
-	}{
-		{name: "Empty", path: "", wantPath: "/"},
-		{name: "Root", path: "/", wantPath: "/"},
-		{name: "Simple", path: "/test", wantPath: "/test"},
-		{name: "Nested", path: "/app/sub/page", wantPath: "/app/sub/page"},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			srv, host, encryptedAPIKey := newSmugglingTestServer(t)
-
-			status, loc, nextCalled := doSmugglingRequest(t, srv, host, encryptedAPIKey, tc.path)
-
-			require.Equal(t, http.StatusSeeOther, status)
-			require.False(t, nextCalled)
-
-			parsed, err := url.Parse(loc)
-			require.NoError(t, err)
-			require.Equal(t, tc.wantPath, parsed.Path)
-			require.Empty(t, parsed.Host)
-			require.Empty(t, parsed.Query().Get(workspaceapps.SubdomainProxyAPIKeyParam))
-			require.Equal(t, "1", parsed.Query().Get("x"))
-		})
-	}
+	// The smuggled key is stripped and unrelated query params survive.
+	require.Empty(t, parsed.Query().Get(workspaceapps.SubdomainProxyAPIKeyParam))
+	require.Equal(t, "1", parsed.Query().Get("x"))
 }

--- a/coderd/workspaceapps/proxy_test.go
+++ b/coderd/workspaceapps/proxy_test.go
@@ -8,12 +8,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
+	"github.com/coder/coder/v2/coderd/jwtutils"
 	"github.com/coder/coder/v2/coderd/workspaceapps"
 	"github.com/coder/coder/v2/coderd/workspaceapps/appurl"
 	"github.com/coder/coder/v2/testutil"
@@ -87,4 +90,188 @@ func TestHandleSubdomain_IgnoresUntrustedForwardedHost(t *testing.T) {
 	require.True(t, nextCalled)
 	require.Zero(t, provider.fromRequestCalls)
 	require.Zero(t, provider.issueCalls)
+}
+
+// newSmugglingTestServer builds a workspaceapps.Server wired with a static
+// encryption keycache and returns the server, a valid app subdomain host, and a
+// freshly minted smuggled API key that decrypts against the server. Each caller
+// gets its own server so parallel subtests never share mutable state.
+func newSmugglingTestServer(t *testing.T) (srv *workspaceapps.Server, host, encryptedAPIKey string) {
+	t.Helper()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+
+	hostnamePattern := "*--apps.test.coder.com"
+	hostnameRegex, err := appurl.CompileHostnamePattern(hostnamePattern)
+	require.NoError(t, err)
+
+	dashboardURL, err := url.Parse("https://dashboard.test.coder.com")
+	require.NoError(t, err)
+
+	// StaticKey satisfies cryptokeys.EncryptionKeycache and lets us mint a valid
+	// smuggled API key so the handler reaches the redirect. A256GCMKW needs a
+	// 32-byte key.
+	keycache := jwtutils.StaticKey{
+		ID:  "test",
+		Key: generateSecret(t, 32),
+	}
+
+	payload := workspaceapps.EncryptedAPIKeyPayload{APIKey: "fake-api-key"}
+	payload.Fill(time.Now())
+	encryptedAPIKey, err = jwtutils.Encrypt(ctx, keycache, payload)
+	require.NoError(t, err)
+
+	srv = workspaceapps.NewServer(workspaceapps.ServerOptions{
+		Logger:        testutil.Logger(t),
+		DashboardURL:  dashboardURL,
+		AccessURL:     dashboardURL,
+		Hostname:      hostnamePattern,
+		HostnameRegex: hostnameRegex,
+		RealIPConfig: &httpmw.RealIPConfig{
+			TrustedOrigins: []*net.IPNet{{
+				IP:   net.ParseIP("10.0.0.1"),
+				Mask: net.CIDRMask(32, 32),
+			}},
+		},
+		SignedTokenProvider:      &fakeSignedTokenProvider{},
+		APIKeyEncryptionKeycache: keycache,
+	})
+
+	host = appurl.ApplicationURL{
+		AppSlugOrPort: "app",
+		WorkspaceName: "workspace",
+		Username:      "user",
+	}.String() + "--apps.test.coder.com"
+
+	return srv, host, encryptedAPIKey
+}
+
+// doSmugglingRequest drives HandleSubdomain with a smuggled API key and the
+// given (already attacker-decoded) request path. It models how the path
+// survives to the handler by setting r.URL.Path directly: the slash-collapsing
+// middleware writes to chi's RoutePath, not r.URL.Path. A benign "x=1" query
+// parameter rides along to verify it is preserved across the redirect.
+func doSmugglingRequest(t *testing.T, srv *workspaceapps.Server, host, encryptedAPIKey, rawPath string) (status int, location string, nextCalled bool) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "https://"+host+"/", nil)
+	req.Host = host
+	req.RemoteAddr = "10.0.0.1:1234"
+	req.URL.Path = rawPath
+	req.URL.RawQuery = url.Values{
+		workspaceapps.SubdomainProxyAPIKeyParam: {encryptedAPIKey},
+		"x":                                     {"1"},
+	}.Encode()
+
+	rec := httptest.NewRecorder()
+	called := false
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		called = true
+	})
+
+	srv.HandleSubdomain()(next).ServeHTTP(rec, req)
+
+	res := rec.Result()
+	defer res.Body.Close()
+	return res.StatusCode, res.Header.Get("Location"), called
+}
+
+// TestHandleSubdomain_APIKeySmuggling_NoOpenRedirect ensures that the redirect
+// issued after consuming a smuggled subdomain API key cannot be turned into an
+// open redirect to an arbitrary external origin (ANT-2026-22456).
+//
+// The request path is attacker-controlled and already percent-decoded.
+// http.Redirect parses the Location with url.Parse (which treats a leading "//"
+// as a scheme-relative URL) and emits it verbatim when parsing fails. Browsers
+// additionally strip tab/newline characters and treat a leading "/\" like "//",
+// so a raw tab such as "/<tab>/evil.com" is a real bypass over HTTP/1 because
+// the header writer does not sanitize tabs.
+func TestHandleSubdomain_APIKeySmuggling_NoOpenRedirect(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		// path is the already-decoded value of r.URL.Path as seen by the handler.
+		path string
+	}{
+		{name: "DoubleSlash", path: "//evil.com/phish"},
+		{name: "TripleSlash", path: "///evil.com/phish"},
+		{name: "LeadingBackslash", path: "/\\evil.com/phish"},
+		{name: "LeadingTab", path: "/\t/evil.com/phish"},
+		{name: "TabThenBackslash", path: "/\t\\evil.com/phish"},
+		{name: "LeadingBackslashSlash", path: "/\\/evil.com/phish"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, host, encryptedAPIKey := newSmugglingTestServer(t)
+
+			status, loc, nextCalled := doSmugglingRequest(t, srv, host, encryptedAPIKey, tc.path)
+
+			// The smuggled key is consumed and a redirect is issued instead of
+			// falling through to the proxied app.
+			require.Equal(t, http.StatusSeeOther, status)
+			require.False(t, nextCalled)
+			require.NotEmpty(t, loc)
+
+			// Model browser URL normalization: tab/newline/CR are stripped and a
+			// backslash is treated like a forward slash before the URL is
+			// resolved. After that, the Location must not look like a
+			// scheme-relative ("//host") URL.
+			browserLoc := strings.NewReplacer("\t", "", "\n", "", "\r", "").Replace(loc)
+			browserLoc = strings.ReplaceAll(browserLoc, "\\", "/")
+			require.False(t, strings.HasPrefix(browserLoc, "//"),
+				"redirect %q resolves off-origin (browser-normalized to %q)", loc, browserLoc)
+
+			// Go's url.Parse must also see a same-origin, relative reference.
+			parsed, err := url.Parse(loc)
+			require.NoError(t, err)
+			require.Empty(t, parsed.Scheme, "redirect %q must not carry a scheme", loc)
+			require.Empty(t, parsed.Host, "redirect %q must not carry a host", loc)
+
+			// The smuggled key is stripped and unrelated query params survive.
+			require.Empty(t, parsed.Query().Get(workspaceapps.SubdomainProxyAPIKeyParam))
+			require.Equal(t, "1", parsed.Query().Get("x"))
+		})
+	}
+}
+
+// TestHandleSubdomain_APIKeySmuggling_PreservesPath ensures the security fix does
+// not change the redirect for legitimate paths: the path round-trips and the
+// smuggled key is stripped while other query params are preserved.
+func TestHandleSubdomain_APIKeySmuggling_PreservesPath(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		path     string
+		wantPath string
+	}{
+		{name: "Empty", path: "", wantPath: "/"},
+		{name: "Root", path: "/", wantPath: "/"},
+		{name: "Simple", path: "/test", wantPath: "/test"},
+		{name: "Nested", path: "/app/sub/page", wantPath: "/app/sub/page"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, host, encryptedAPIKey := newSmugglingTestServer(t)
+
+			status, loc, nextCalled := doSmugglingRequest(t, srv, host, encryptedAPIKey, tc.path)
+
+			require.Equal(t, http.StatusSeeOther, status)
+			require.False(t, nextCalled)
+
+			parsed, err := url.Parse(loc)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantPath, parsed.Path)
+			require.Empty(t, parsed.Host)
+			require.Empty(t, parsed.Query().Get(workspaceapps.SubdomainProxyAPIKeyParam))
+			require.Equal(t, "1", parsed.Query().Get("x"))
+		})
+	}
 }


### PR DESCRIPTION
After consuming a smuggled subdomain API-key, handleAPIKeySmuggling issued a 303 redirect back to the request path to strip the query param. The target was built from the raw, already-decoded r.URL.Path, which can be manipulated by a malicious user.

The redirect target is now built through a url.URL whose Path collapses any leading / and \ run to a single /. url.URL.String() escapes the path, so control characters, backslashes, ?, and # are percent-encoded and can no longer introduce an off-origin host, query, or fragment. The redirect stays same-origin for every input while legitimate paths and unrelated query params are preserved