### PR TITLE
chore: move ai gateway keys link up in ai settings

### DIFF
--- a/site/src/modules/management/AISettingsSidebarView.tsx
+++ b/site/src/modules/management/AISettingsSidebarView.tsx
@@ -22,14 +22,14 @@ const AISettingsSidebarView: FC<AISettingsSidebarViewProps> = ({
 						AI Governance
 					</SidebarNavItem>
 				)}
-				{permissions.viewAnyAIProvider && (
-					<SidebarNavItem href="/ai/settings" end>
-						Providers
-					</SidebarNavItem>
-				)}
 				{permissions.viewAIGatewayKeys && (
 					<SidebarNavItem href="/ai/settings/gateway-keys">
 						AI Gateway Keys
+					</SidebarNavItem>
+				)}
+				{permissions.viewAnyAIProvider && (
+					<SidebarNavItem href="/ai/settings" end>
+						Providers
 					</SidebarNavItem>
 				)}
 				{permissions.editDeploymentConfig && (


### PR DESCRIPTION
Moves 'AI Gateway Keys' link under 'AI Governance' so it doesn't sit between 'Providers' and 'Models'.
Providers remain page loaded by default.

Before: 
<img width="1561" height="652" alt="image" src="https://github.com/user-attachments/assets/a72a2860-464e-496b-af7e-13b1dadd84fd" />

After: 
<img width="550" height="329" alt="image" src="https://github.com/user-attachments/assets/1d57ddcb-644c-497b-ab05-7ca183bc61e4" />