### PR TITLE
chore(dogfood): rename AI Bridge to AI Gateway in dogfood templates

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -183,7 +183,7 @@ data "coder_parameter" "devcontainer_autostart" {
 # Currently unused since AI Gateway is always enabled, but kept for emergency fallback.
 variable "anthropic_api_key" {
   type        = string
-  description = "The API key used to authenticate with the Anthropic API, if AI Bridge is disabled."
+  description = "The API key used to authenticate with the Anthropic API, if AI Gateway is disabled."
   default     = ""
   sensitive   = true
 }
@@ -435,9 +435,9 @@ resource "coder_agent" "dev" {
       MISE_DATA_DIR : "/home/coder/.local/share/mise",
     },
     {
-      ANTHROPIC_BASE_URL : "https://dev.coder.com/api/v2/aibridge/anthropic",
+      ANTHROPIC_BASE_URL : "https://dev.coder.com/api/v2/ai-gateway/anthropic",
       ANTHROPIC_AUTH_TOKEN : data.coder_workspace_owner.me.session_token,
-      OPENAI_BASE_URL : "https://dev.coder.com/api/v2/aibridge/openai/v1",
+      OPENAI_BASE_URL : "https://dev.coder.com/api/v2/ai-gateway/openai/v1",
       OPENAI_API_KEY : data.coder_workspace_owner.me.session_token,
     }
   )

--- a/dogfood/vscode-coder/main.tf
+++ b/dogfood/vscode-coder/main.tf
@@ -115,7 +115,7 @@ data "coder_parameter" "res_mon_volume_path" {
   mutable     = true
 }
 
-data "coder_parameter" "use_ai_bridge" {
+data "coder_parameter" "use_ai_gateway" {
   type        = "bool"
   name        = "Use AI Gateway"
   default     = true
@@ -322,7 +322,7 @@ resource "coder_agent" "dev" {
     {
       OIDC_TOKEN : data.coder_workspace_owner.me.oidc_access_token,
     },
-    data.coder_parameter.use_ai_bridge.value ? {
+    data.coder_parameter.use_ai_gateway.value ? {
       ANTHROPIC_BASE_URL : "https://dev.coder.com/api/v2/ai-gateway/anthropic",
       ANTHROPIC_AUTH_TOKEN : data.coder_workspace_owner.me.session_token,
       OPENAI_BASE_URL : "https://dev.coder.com/api/v2/ai-gateway/openai/v1",
@@ -546,8 +546,8 @@ module "claude-code" {
   count             = data.coder_workspace.me.start_count
   source            = "dev.registry.coder.com/coder/claude-code/coder"
   version           = "5.2.0"
-  enable_ai_gateway = data.coder_parameter.use_ai_bridge.value
-  anthropic_api_key = data.coder_parameter.use_ai_bridge.value ? "" : var.anthropic_api_key
+  enable_ai_gateway = data.coder_parameter.use_ai_gateway.value
+  anthropic_api_key = data.coder_parameter.use_ai_gateway.value ? "" : var.anthropic_api_key
   agent_id          = coder_agent.dev.id
   workdir           = local.repo_dir
 }

--- a/dogfood/vscode-coder/main.tf
+++ b/dogfood/vscode-coder/main.tf
@@ -117,17 +117,17 @@ data "coder_parameter" "res_mon_volume_path" {
 
 data "coder_parameter" "use_ai_bridge" {
   type        = "bool"
-  name        = "Use AI Bridge"
+  name        = "Use AI Gateway"
   default     = true
-  description = "If enabled, AI requests will be sent via AI Bridge."
+  description = "If enabled, AI requests will be sent via AI Gateway."
   mutable     = true
 }
 
-# Fallback when AI Bridge is disabled. Injected by dogfood/main.tf
+# Fallback when AI Gateway is disabled. Injected by dogfood/main.tf
 # from the CODER_DOGFOOD_ANTHROPIC_API_KEY secret.
 variable "anthropic_api_key" {
   type        = string
-  description = "Anthropic API key, used when AI Bridge is disabled."
+  description = "Anthropic API key, used when AI Gateway is disabled."
   default     = ""
   sensitive   = true
 }
@@ -323,9 +323,9 @@ resource "coder_agent" "dev" {
       OIDC_TOKEN : data.coder_workspace_owner.me.oidc_access_token,
     },
     data.coder_parameter.use_ai_bridge.value ? {
-      ANTHROPIC_BASE_URL : "https://dev.coder.com/api/v2/aibridge/anthropic",
+      ANTHROPIC_BASE_URL : "https://dev.coder.com/api/v2/ai-gateway/anthropic",
       ANTHROPIC_AUTH_TOKEN : data.coder_workspace_owner.me.session_token,
-      OPENAI_BASE_URL : "https://dev.coder.com/api/v2/aibridge/openai/v1",
+      OPENAI_BASE_URL : "https://dev.coder.com/api/v2/ai-gateway/openai/v1",
       OPENAI_API_KEY : data.coder_workspace_owner.me.session_token,
     } : {}
   )


### PR DESCRIPTION
## Description

Updates dogfood templates to use the new AI Gateway naming and `/api/v2/ai-gateway` URLs, following the backend rename in #26475.

## Changes

- Update `ANTHROPIC_BASE_URL` and `OPENAI_BASE_URL` from `/api/v2/aibridge/` to `/api/v2/ai-gateway/`
- Rename user-facing parameter names and descriptions from "AI Bridge" to "AI Gateway"

Refs https://linear.app/codercom/issue/AIGOV-226/ai-gateway-rebrand-work

> Generated with the assistance of Coder Agents (@ssncferreira)