### PR TITLE
feat(site/src/pages/GroupsPage): update group AI budget UI

### DIFF
--- a/site/src/pages/GroupsPage/GroupSettingsPageView.stories.tsx
+++ b/site/src/pages/GroupsPage/GroupSettingsPageView.stories.tsx
@@ -37,6 +37,9 @@ export const WithAIBudget: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		await expect(canvas.getByText("AI budget")).toBeInTheDocument();
+		await expect(canvas.getByLabelText("Monthly limit per member")).toHaveValue(
+			1000,
+		);
 		const helper = canvas.getByText(/month maximum/i);
 		await expect(helper).toHaveTextContent(
 			"$7,000/month maximum, based on 7 members.",
@@ -52,7 +55,11 @@ export const AIBudgetUncapped: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		await expect(
-			canvas.getByText("Leave empty for uncapped spend."),
+			canvas.getByLabelText("Monthly limit per member"),
+		).toHaveAttribute("placeholder", "unlimited");
+		await expect(canvas.getByText("unlimited budget")).toBeInTheDocument();
+		await expect(
+			canvas.getByText("Members in this group have no spending cap."),
 		).toBeInTheDocument();
 	},
 };
@@ -65,11 +72,13 @@ export const AIBudgetDisabled: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		// A budget of 0 is valid and reads as disabled spend.
-		const helper = canvas.getByText(/month maximum/i);
-		await expect(helper).toHaveTextContent(
-			"$0/month maximum, based on 7 members.",
+		await expect(canvas.getByLabelText("Monthly limit per member")).toHaveValue(
+			0,
 		);
+		await expect(canvas.getByText("no budget")).toBeInTheDocument();
+		await expect(
+			canvas.getByText("A $0 limit disables AI access for this group."),
+		).toBeInTheDocument();
 	},
 };
 
@@ -96,7 +105,7 @@ export const SaveWithBudget: Story = {
 	},
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
-		const input = canvas.getByLabelText("Monthly budget per member (USD)");
+		const input = canvas.getByLabelText("Monthly limit per member");
 		await userEvent.type(input, "25");
 		await userEvent.click(canvas.getByRole("button", { name: "Save" }));
 		// onSubmit fires asynchronously with (values, formikHelpers).

--- a/site/src/pages/GroupsPage/GroupSettingsPageView.tsx
+++ b/site/src/pages/GroupsPage/GroupSettingsPageView.tsx
@@ -2,10 +2,16 @@ import { useFormik } from "formik";
 import type { FC } from "react";
 import * as Yup from "yup";
 import type { Group } from "#/api/typesGenerated";
+import { Alert } from "#/components/Alert/Alert";
 import { Badge } from "#/components/Badge/Badge";
 import { Button } from "#/components/Button/Button";
 import { IconField } from "#/components/IconField/IconField";
 import { Input } from "#/components/Input/Input";
+import {
+	InputGroup,
+	InputGroupAddon,
+	InputGroupInput,
+} from "#/components/InputGroup/InputGroup";
 import { Label } from "#/components/Label/Label";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { isEveryoneGroup } from "#/modules/groups";
@@ -21,14 +27,14 @@ type FormData = {
 	display_name: string;
 	avatar_url: string;
 	quota_allowance: number;
-	// Per-member AI budget, in dollars. "" is no budget (uncapped); 0 disables.
+	// Per-member AI budget, in dollars. "" is unlimited; 0 disables.
 	monthly_budget_per_member: string;
 };
 
 const validationSchema = Yup.object({
 	name: nameValidator("Name"),
 	quota_allowance: Yup.number().required().min(0).integer(),
-	// Optional: empty is uncapped. A value must be zero or more (0 disables).
+	// Optional: empty is unlimited. A value must be zero or more; 0 disables.
 	monthly_budget_per_member: Yup.number()
 		.transform((value, original) => (original === "" ? undefined : value))
 		.min(0, "Enter an amount of zero or more."),
@@ -38,7 +44,7 @@ interface UpdateGroupFormProps {
 	group: Group;
 	/** Whether the AI add-on settings are shown (gated by the aibridge feature). */
 	showAISettings: boolean;
-	/** Per-member AI budget in dollars, or null when none is set. */
+	/** Per-member AI budget in dollars, or null for unlimited spend. */
 	initialBudgetDollars: number | null;
 	errors: unknown;
 	onSubmit: (data: FormData) => void;
@@ -78,10 +84,16 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
 	});
 	const budgetField = getFieldHelpers("monthly_budget_per_member");
 	const budgetDollars = form.values.monthly_budget_per_member;
+	const trimmedBudgetDollars = budgetDollars.trim();
+	const budgetAmount = Number(trimmedBudgetDollars);
+	const hasBudgetValue = trimmedBudgetDollars !== "";
+	const hasNoBudget = hasBudgetValue && budgetAmount === 0;
+	const hasMonthlyLimit =
+		hasBudgetValue && Number.isFinite(budgetAmount) && budgetAmount > 0;
 	const memberCount = group.total_member_count;
-	const monthlyMaximum = usdBudgetFormatter.format(
-		Number(budgetDollars) * memberCount,
-	);
+	const monthlyMaximum = hasMonthlyLimit
+		? usdBudgetFormatter.format(budgetAmount * memberCount)
+		: "";
 
 	return (
 		<form className="flex flex-col gap-10 pb-8" onSubmit={form.handleSubmit}>
@@ -156,9 +168,9 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
 			</section>
 
 			{showAISettings && (
-				<section className="flex flex-col gap-8 max-w-md">
+				<section className="flex max-w-xl flex-col gap-8">
 					<div className="flex items-center gap-2">
-						<h2 className="text-xl font-semibold text-content-primary m-0">
+						<h2 className="m-0 text-xl font-semibold text-content-primary">
 							AI budget
 						</h2>
 						<Badge variant="purple" size="sm">
@@ -167,28 +179,30 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
 					</div>
 					<div className="flex flex-col gap-6">
 						<div className="flex flex-col items-start gap-2">
-							<Label htmlFor={budgetField.id}>
-								Monthly budget per member (USD)
-							</Label>
-							<Input
-								id={budgetField.id}
-								name={budgetField.name}
-								value={budgetField.value}
-								onChange={(event) =>
-									form.setFieldValue(budgetField.name, event.target.value)
-								}
-								onBlur={budgetField.onBlur}
-								type="number"
-								min="0"
-								step="1"
-								aria-invalid={budgetField.error}
-							/>
+							<Label htmlFor={budgetField.id}>Monthly limit per member</Label>
+							<InputGroup>
+								<InputGroupInput
+									id={budgetField.id}
+									name={budgetField.name}
+									value={budgetField.value}
+									onChange={(event) =>
+										form.setFieldValue(budgetField.name, event.target.value)
+									}
+									onBlur={budgetField.onBlur}
+									type="number"
+									min="0"
+									step="1"
+									placeholder="unlimited"
+									aria-invalid={budgetField.error}
+								/>
+								<InputGroupAddon align="inline-end">USD</InputGroupAddon>
+							</InputGroup>
 							{budgetField.error ? (
-								<span className="text-xs text-left text-content-destructive">
+								<span className="text-left text-xs text-content-destructive">
 									{budgetField.helperText}
 								</span>
-							) : budgetDollars.trim() !== "" ? (
-								<span className="text-xs text-left text-content-secondary">
+							) : hasMonthlyLimit ? (
+								<span className="text-left text-xs text-content-secondary">
 									<span className="font-medium text-content-primary">
 										{monthlyMaximum}
 									</span>
@@ -198,12 +212,34 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
 									</span>{" "}
 									{memberCount === 1 ? "member" : "members"}.
 								</span>
-							) : (
-								<span className="text-xs text-left text-content-secondary">
-									Leave empty for uncapped spend.
+							) : hasNoBudget ? (
+								<span className="text-left text-xs text-content-secondary">
+									This group has{" "}
+									<span className="font-medium text-content-primary">
+										no budget
+									</span>
+									.
 								</span>
-							)}
+							) : !hasBudgetValue ? (
+								<span className="text-left text-xs text-content-secondary">
+									This group has{" "}
+									<span className="font-medium text-content-primary">
+										unlimited budget
+									</span>
+									.
+								</span>
+							) : null}
 						</div>
+						{!budgetField.error && !hasBudgetValue && (
+							<Alert severity="info">
+								Members in this group have no spending cap.
+							</Alert>
+						)}
+						{!budgetField.error && hasNoBudget && (
+							<Alert severity="info">
+								A $0 limit disables AI access for this group.
+							</Alert>
+						)}
 					</div>
 				</section>
 			)}

--- a/site/src/pages/GroupsPage/GroupSettingsPageView.tsx
+++ b/site/src/pages/GroupsPage/GroupSettingsPageView.tsx
@@ -62,34 +62,28 @@ const AIBudgetFeedback: FC<AIBudgetFeedbackProps> = ({
 	}
 
 	const budgetValue = monthlyBudgetPerMember.trim();
-	if (budgetValue === "") {
-		return (
-			<>
-				<span className="text-left text-xs text-content-secondary">
-					This group has{" "}
-					<span className="font-medium text-content-primary">
-						unlimited budget
-					</span>
-					.
-				</span>
-				<Alert severity="info">
-					Members in this group have no spending cap.
-				</Alert>
-			</>
-		);
-	}
-
 	const budgetAmount = Number(budgetValue);
-	if (budgetAmount === 0) {
+
+	// Empty means unlimited spend; $0 disables AI access. Both states show an
+	// explanatory alert alongside the summary line.
+	if (budgetValue === "" || budgetAmount === 0) {
+		const { label, message } =
+			budgetValue === ""
+				? {
+						label: "unlimited budget",
+						message: "Members in this group have no spending cap.",
+					}
+				: {
+						label: "no budget",
+						message: "A $0 limit disables AI access for this group.",
+					};
 		return (
 			<>
 				<span className="text-left text-xs text-content-secondary">
 					This group has{" "}
-					<span className="font-medium text-content-primary">no budget</span>.
+					<span className="font-medium text-content-primary">{label}</span>.
 				</span>
-				<Alert severity="info">
-					A $0 limit disables AI access for this group.
-				</Alert>
+				<Alert severity="info">{message}</Alert>
 			</>
 		);
 	}

--- a/site/src/pages/GroupsPage/GroupSettingsPageView.tsx
+++ b/site/src/pages/GroupsPage/GroupSettingsPageView.tsx
@@ -1,5 +1,5 @@
 import { useFormik } from "formik";
-import type { FC } from "react";
+import type { FC, ReactNode } from "react";
 import * as Yup from "yup";
 import type { Group } from "#/api/typesGenerated";
 import { Alert } from "#/components/Alert/Alert";
@@ -39,6 +39,76 @@ const validationSchema = Yup.object({
 		.transform((value, original) => (original === "" ? undefined : value))
 		.min(0, "Enter an amount of zero or more."),
 });
+
+interface AIBudgetFeedbackProps {
+	error: boolean;
+	helperText?: ReactNode;
+	monthlyBudgetPerMember: string;
+	memberCount: number;
+}
+
+const AIBudgetFeedback: FC<AIBudgetFeedbackProps> = ({
+	error,
+	helperText,
+	monthlyBudgetPerMember,
+	memberCount,
+}) => {
+	if (error) {
+		return (
+			<span className="text-left text-xs text-content-destructive">
+				{helperText}
+			</span>
+		);
+	}
+
+	const budgetValue = monthlyBudgetPerMember.trim();
+	if (budgetValue === "") {
+		return (
+			<>
+				<span className="text-left text-xs text-content-secondary">
+					This group has{" "}
+					<span className="font-medium text-content-primary">
+						unlimited budget
+					</span>
+					.
+				</span>
+				<Alert severity="info">
+					Members in this group have no spending cap.
+				</Alert>
+			</>
+		);
+	}
+
+	const budgetAmount = Number(budgetValue);
+	if (budgetAmount === 0) {
+		return (
+			<>
+				<span className="text-left text-xs text-content-secondary">
+					This group has{" "}
+					<span className="font-medium text-content-primary">no budget</span>.
+				</span>
+				<Alert severity="info">
+					A $0 limit disables AI access for this group.
+				</Alert>
+			</>
+		);
+	}
+
+	if (Number.isFinite(budgetAmount) && budgetAmount > 0) {
+		return (
+			<span className="text-left text-xs text-content-secondary">
+				<span className="font-medium text-content-primary">
+					{usdBudgetFormatter.format(budgetAmount * memberCount)}
+				</span>
+				/month maximum, based on{" "}
+				<span className="font-medium text-content-primary">{memberCount}</span>{" "}
+				{memberCount === 1 ? "member" : "members"}.
+			</span>
+		);
+	}
+
+	return null;
+};
 
 interface UpdateGroupFormProps {
 	group: Group;
@@ -83,16 +153,10 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
             of its members.`,
 	});
 	const budgetField = getFieldHelpers("monthly_budget_per_member");
-	const budgetValue = form.values.monthly_budget_per_member.trim();
-	const budgetAmount = Number(budgetValue);
-	const isUnlimitedBudget = budgetValue === "";
-	const isNoBudget = !isUnlimitedBudget && budgetAmount === 0;
-	const hasMonthlyLimit = Number.isFinite(budgetAmount) && budgetAmount > 0;
-	const memberCount = group.total_member_count;
 
 	return (
 		<form className="flex flex-col gap-10 pb-8" onSubmit={form.handleSubmit}>
-			<section className="flex max-w-xl flex-col gap-4">
+			<section className="flex flex-col gap-4 max-w-md">
 				<div className="flex flex-col gap-2">
 					<h2 className="text-xl font-semibold text-content-primary m-0">
 						General
@@ -163,7 +227,7 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
 			</section>
 
 			{showAISettings && (
-				<section className="flex max-w-xl flex-col gap-8">
+				<section className="flex flex-col gap-8 max-w-md">
 					<div className="flex items-center gap-2">
 						<h2 className="m-0 text-xl font-semibold text-content-primary">
 							AI budget
@@ -192,52 +256,13 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
 								/>
 								<InputGroupAddon align="inline-end">USD</InputGroupAddon>
 							</InputGroup>
-							{budgetField.error && (
-								<span className="text-left text-xs text-content-destructive">
-									{budgetField.helperText}
-								</span>
-							)}
-							{!budgetField.error && hasMonthlyLimit && (
-								<span className="text-left text-xs text-content-secondary">
-									<span className="font-medium text-content-primary">
-										{usdBudgetFormatter.format(budgetAmount * memberCount)}
-									</span>
-									/month maximum, based on{" "}
-									<span className="font-medium text-content-primary">
-										{memberCount}
-									</span>{" "}
-									{memberCount === 1 ? "member" : "members"}.
-								</span>
-							)}
-							{!budgetField.error && isNoBudget && (
-								<span className="text-left text-xs text-content-secondary">
-									This group has{" "}
-									<span className="font-medium text-content-primary">
-										no budget
-									</span>
-									.
-								</span>
-							)}
-							{!budgetField.error && isUnlimitedBudget && (
-								<span className="text-left text-xs text-content-secondary">
-									This group has{" "}
-									<span className="font-medium text-content-primary">
-										unlimited budget
-									</span>
-									.
-								</span>
-							)}
+							<AIBudgetFeedback
+								error={budgetField.error}
+								helperText={budgetField.helperText}
+								monthlyBudgetPerMember={form.values.monthly_budget_per_member}
+								memberCount={group.total_member_count}
+							/>
 						</div>
-						{!budgetField.error && isUnlimitedBudget && (
-							<Alert severity="info">
-								Members in this group have no spending cap.
-							</Alert>
-						)}
-						{!budgetField.error && isNoBudget && (
-							<Alert severity="info">
-								A $0 limit disables AI access for this group.
-							</Alert>
-						)}
 					</div>
 				</section>
 			)}

--- a/site/src/pages/GroupsPage/GroupSettingsPageView.tsx
+++ b/site/src/pages/GroupsPage/GroupSettingsPageView.tsx
@@ -92,7 +92,7 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
 
 	return (
 		<form className="flex flex-col gap-10 pb-8" onSubmit={form.handleSubmit}>
-			<section className="flex flex-col gap-4 max-w-md">
+			<section className="flex max-w-xl flex-col gap-4">
 				<div className="flex flex-col gap-2">
 					<h2 className="text-xl font-semibold text-content-primary m-0">
 						General

--- a/site/src/pages/GroupsPage/GroupSettingsPageView.tsx
+++ b/site/src/pages/GroupsPage/GroupSettingsPageView.tsx
@@ -83,17 +83,12 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
             of its members.`,
 	});
 	const budgetField = getFieldHelpers("monthly_budget_per_member");
-	const budgetDollars = form.values.monthly_budget_per_member;
-	const trimmedBudgetDollars = budgetDollars.trim();
-	const budgetAmount = Number(trimmedBudgetDollars);
-	const hasBudgetValue = trimmedBudgetDollars !== "";
-	const hasNoBudget = hasBudgetValue && budgetAmount === 0;
-	const hasMonthlyLimit =
-		hasBudgetValue && Number.isFinite(budgetAmount) && budgetAmount > 0;
+	const budgetValue = form.values.monthly_budget_per_member.trim();
+	const budgetAmount = Number(budgetValue);
+	const isUnlimitedBudget = budgetValue === "";
+	const isNoBudget = !isUnlimitedBudget && budgetAmount === 0;
+	const hasMonthlyLimit = Number.isFinite(budgetAmount) && budgetAmount > 0;
 	const memberCount = group.total_member_count;
-	const monthlyMaximum = hasMonthlyLimit
-		? usdBudgetFormatter.format(budgetAmount * memberCount)
-		: "";
 
 	return (
 		<form className="flex flex-col gap-10 pb-8" onSubmit={form.handleSubmit}>
@@ -197,14 +192,15 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
 								/>
 								<InputGroupAddon align="inline-end">USD</InputGroupAddon>
 							</InputGroup>
-							{budgetField.error ? (
+							{budgetField.error && (
 								<span className="text-left text-xs text-content-destructive">
 									{budgetField.helperText}
 								</span>
-							) : hasMonthlyLimit ? (
+							)}
+							{!budgetField.error && hasMonthlyLimit && (
 								<span className="text-left text-xs text-content-secondary">
 									<span className="font-medium text-content-primary">
-										{monthlyMaximum}
+										{usdBudgetFormatter.format(budgetAmount * memberCount)}
 									</span>
 									/month maximum, based on{" "}
 									<span className="font-medium text-content-primary">
@@ -212,7 +208,8 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
 									</span>{" "}
 									{memberCount === 1 ? "member" : "members"}.
 								</span>
-							) : hasNoBudget ? (
+							)}
+							{!budgetField.error && isNoBudget && (
 								<span className="text-left text-xs text-content-secondary">
 									This group has{" "}
 									<span className="font-medium text-content-primary">
@@ -220,7 +217,8 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
 									</span>
 									.
 								</span>
-							) : !hasBudgetValue ? (
+							)}
+							{!budgetField.error && isUnlimitedBudget && (
 								<span className="text-left text-xs text-content-secondary">
 									This group has{" "}
 									<span className="font-medium text-content-primary">
@@ -228,14 +226,14 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
 									</span>
 									.
 								</span>
-							) : null}
+							)}
 						</div>
-						{!budgetField.error && !hasBudgetValue && (
+						{!budgetField.error && isUnlimitedBudget && (
 							<Alert severity="info">
 								Members in this group have no spending cap.
 							</Alert>
 						)}
-						{!budgetField.error && hasNoBudget && (
+						{!budgetField.error && isNoBudget && (
 							<Alert severity="info">
 								A $0 limit disables AI access for this group.
 							</Alert>


### PR DESCRIPTION
Update the group AI budget settings UI to match the new unlimited, no-budget, and finite-budget states. The field now uses a `USD` input suffix, the label reads `Monthly limit per member`, and unlimited or `$0` budgets show explanatory helper text with an info alert.

Also updates the Storybook interactions for the changed copy and states.
