### PR TITLE
docs: update AI Gateway URLs from /aibridge to /ai-gateway

### DIFF
--- a/docs/ai-coder/agents/models.md
+++ b/docs/ai-coder/agents/models.md
@@ -61,7 +61,7 @@ implements the APIs Coder sends.
 
 For the default Agents path through AI Gateway, set the endpoint/base URL to
 the upstream provider or proxy endpoint. Do not set it to Coder's public AI
-Gateway route, such as `https://<coder-host>/api/v2/aibridge/openai/v1`.
+Gateway route, such as `https://<coder-host>/api/v2/ai-gateway/openai/v1`.
 
 OpenAI-shaped provider types require the upstream OpenAI-compatible prefix in
 the endpoint/base URL because Coder appends request suffixes such as

--- a/docs/ai-coder/ai-gateway/ai-gateway-proxy/setup.md
+++ b/docs/ai-coder/ai-gateway/ai-gateway-proxy/setup.md
@@ -153,7 +153,7 @@ AI tools need to trust the CA certificate before connecting through the proxy.
 For **self-signed certificates**, AI tools must be configured to trust the CA certificate. The certificate (without the private key) is available at:
 
 ```shell
-https://<coder-url>/api/v2/aibridge/proxy/ca-cert.pem
+https://<coder-url>/api/v2/ai-gateway/proxy/ca-cert.pem
 ```
 
 For **corporate CA certificates**, if the systems where AI tools run already trust your organization's root CA, and the intermediate certificate chains correctly to that root, no additional certificate distribution is needed.
@@ -308,7 +308,7 @@ Download the certificate:
 ```shell
 curl -o coder-ai-gateway-proxy-ca.pem \
   -H "Coder-Session-Token: ${CODER_SESSION_TOKEN}" \
-  https://<coder-url>/api/v2/aibridge/proxy/ca-cert.pem
+  https://<coder-url>/api/v2/ai-gateway/proxy/ca-cert.pem
 ```
 
 Replace `<coder-url>` with your Coder deployment URL.

--- a/docs/ai-coder/ai-gateway/audit.md
+++ b/docs/ai-coder/ai-gateway/audit.md
@@ -47,7 +47,7 @@ not just what was called.
 
 ### Sessions list
 
-The sessions page (`http://<deployment-url>/aibridge/sessions`) lists all sessions in
+The sessions page (`http://<deployment-url>/ai-gateway/sessions`) lists all sessions in
 reverse-chronological order. Each row shows the last prompt, initiator, provider,
 client, token usage, thread count, and timestamp.
 

--- a/docs/ai-coder/ai-gateway/auth.md
+++ b/docs/ai-coder/ai-gateway/auth.md
@@ -50,7 +50,7 @@ by using [`coder login token`](../../reference/cli/login_token.md):
 
 ```sh
 export ANTHROPIC_API_KEY=$(coder login token)
-export ANTHROPIC_BASE_URL="https://coder.example.com/api/v2/aibridge/anthropic"
+export ANTHROPIC_BASE_URL="https://coder.example.com/api/v2/ai-gateway/anthropic"
 ```
 
 Alternatively, you can [generate a long-lived API token](../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)

--- a/docs/ai-coder/ai-gateway/clients/claude-code.md
+++ b/docs/ai-coder/ai-gateway/clients/claude-code.md
@@ -11,7 +11,7 @@ Claude Code can be configured using environment variables. All modes require a *
 
 ```bash
 # AI Gateway base URL.
-export ANTHROPIC_BASE_URL="<your-deployment-url>/api/v2/aibridge/anthropic"
+export ANTHROPIC_BASE_URL="<your-deployment-url>/api/v2/ai-gateway/anthropic"
 
 # Your Coder API token, used for authentication with AI Gateway.
 export ANTHROPIC_AUTH_TOKEN="<your-coder-api-token>"
@@ -21,7 +21,7 @@ export ANTHROPIC_AUTH_TOKEN="<your-coder-api-token>"
 
 ```bash
 # AI Gateway base URL.
-export ANTHROPIC_BASE_URL="<your-deployment-url>/api/v2/aibridge/anthropic"
+export ANTHROPIC_BASE_URL="<your-deployment-url>/api/v2/ai-gateway/anthropic"
 
 # Your personal Anthropic API key, forwarded to Anthropic.
 export ANTHROPIC_API_KEY="<your-anthropic-api-key>"
@@ -37,7 +37,7 @@ unset ANTHROPIC_AUTH_TOKEN
 
 ```bash
 # AI Gateway base URL.
-export ANTHROPIC_BASE_URL="<your-deployment-url>/api/v2/aibridge/anthropic"
+export ANTHROPIC_BASE_URL="<your-deployment-url>/api/v2/ai-gateway/anthropic"
 
 # Your Coder API token, used for authentication with AI Gateway.
 export ANTHROPIC_CUSTOM_HEADERS="X-Coder-AI-Governance-Token: <your-coder-api-token>"

--- a/docs/ai-coder/ai-gateway/clients/cline.md
+++ b/docs/ai-coder/ai-gateway/clients/cline.md
@@ -21,7 +21,7 @@ To configure Cline to use AI Gateway, follow these steps:
 1. Open Cline in VS Code.
 1. Go to **Settings**.
 1. **API Provider**: Select **OpenAI Compatible**.
-1. **Base URL**: Enter `https://coder.example.com/api/v2/aibridge/openai/v1`.
+1. **Base URL**: Enter `https://coder.example.com/api/v2/ai-gateway/openai/v1`.
 1. **OpenAI Compatible API Key**: Enter your **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.
 1. **Model ID** (Optional): Enter the model you wish to use (e.g., `gpt-5.2-codex`).
 
@@ -33,7 +33,7 @@ To configure Cline to use AI Gateway, follow these steps:
 1. Go to **Settings**.
 1. **API Provider**: Select **Anthropic**.
 1. **Anthropic API Key**: Enter your **Coder API token**.
-1. **Base URL**: Enter `https://coder.example.com/api/v2/aibridge/anthropic` after checking **_Use custom base URL_**.
+1. **Base URL**: Enter `https://coder.example.com/api/v2/ai-gateway/anthropic` after checking **_Use custom base URL_**.
 1. **Model ID** (Optional): Select your desired Claude model.
 
 ![Cline Anthropic Settings](../../../images/aibridge/clients/cline-anthropic.png)
@@ -49,7 +49,7 @@ To configure Cline to use AI Gateway, follow these steps:
 1. Open Cline in VS Code.
 1. Go to **Settings**.
 1. **API Provider**: Select **OpenAI Compatible**.
-1. **Base URL**: Enter `https://coder.example.com/api/v2/aibridge/openai/v1`.
+1. **Base URL**: Enter `https://coder.example.com/api/v2/ai-gateway/openai/v1`.
 1. **OpenAI Compatible API Key**: Enter your personal OpenAI API key.
 1. **Model ID** (Optional): Enter the model you wish to use (e.g., `gpt-5.2-codex`).
 1. **Custom Headers**: Add `X-Coder-AI-Governance-Token` with your **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.

--- a/docs/ai-coder/ai-gateway/clients/codex.md
+++ b/docs/ai-coder/ai-gateway/clients/codex.md
@@ -16,7 +16,7 @@ model_provider = "ai_gateway"
 
 [model_providers.ai_gateway]
 name = "AI Gateway"
-base_url = "<your-deployment-url>/api/v2/aibridge/openai/v1"
+base_url = "<your-deployment-url>/api/v2/ai-gateway/openai/v1"
 env_key = "OPENAI_API_KEY"
 wire_api = "responses"
 ```
@@ -38,7 +38,7 @@ model_provider = "ai_gateway"
 
 [model_providers.ai_gateway]
 name = "AI Gateway"
-base_url = "<your-deployment-url>/api/v2/aibridge/openai/v1"
+base_url = "<your-deployment-url>/api/v2/ai-gateway/openai/v1"
 wire_api = "responses"
 requires_openai_auth = true
 env_http_headers = { "X-Coder-AI-Governance-Token" = "CODER_API_TOKEN" }
@@ -68,14 +68,14 @@ model_provider = "ai_gateway"
 
 [model_providers.ai_gateway]
 name = "AI Gateway"
-base_url = "<your-deployment-url>/api/v2/aibridge/chatgpt/v1"
+base_url = "<your-deployment-url>/api/v2/ai-gateway/chatgpt/v1"
 wire_api = "responses"
 requires_openai_auth = true
 env_http_headers = { "X-Coder-AI-Governance-Token" = "CODER_API_TOKEN" }
 ```
 
 > [!NOTE]
-> The `base_url` uses `/aibridge/chatgpt/v1` instead of `/aibridge/openai/v1` to route requests through the ChatGPT provider.
+> The `base_url` uses `/ai-gateway/chatgpt/v1` instead of `/ai-gateway/openai/v1` to route requests through the ChatGPT provider.
 
 Set your Coder API token and ensure `OPENAI_API_KEY` is not set:
 
@@ -129,7 +129,7 @@ module "codex" {
 
     [model_providers.ai_gateway]
     name = "AI Gateway"
-    base_url = "${data.coder_workspace.me.access_url}/api/v2/aibridge/chatgpt/v1"
+    base_url = "${data.coder_workspace.me.access_url}/api/v2/ai-gateway/chatgpt/v1"
     wire_api = "responses"
     requires_openai_auth = true
     env_http_headers = { "X-Coder-AI-Governance-Token" = "CODER_API_TOKEN" }
@@ -165,7 +165,7 @@ model_provider = "ai_gateway"
 
 [model_providers.ai_gateway]
 name = "AI Gateway"
-base_url = "<your-deployment-url>/api/v2/aibridge/openai/v1"
+base_url = "<your-deployment-url>/api/v2/ai-gateway/openai/v1"
 wire_api = "responses"
 supports_websockets = false
 ```

--- a/docs/ai-coder/ai-gateway/clients/factory.md
+++ b/docs/ai-coder/ai-gateway/clients/factory.md
@@ -20,7 +20,7 @@ Factort's Droid agent can be configured to use AI Gateway by setting up custom m
     {
       "model": "claude-sonnet-4-5-20250929",
       "displayName": "Claude (Coder AI Gateway)",
-      "baseUrl": "https://coder.example.com/api/v2/aibridge/anthropic",
+      "baseUrl": "https://coder.example.com/api/v2/ai-gateway/anthropic",
       "apiKey": "<your-coder-api-token>",
       "provider": "anthropic",
       "maxOutputTokens": 8192
@@ -28,7 +28,7 @@ Factort's Droid agent can be configured to use AI Gateway by setting up custom m
     {
       "model": "gpt-5.2-codex",
       "displayName": "GPT (Coder AI Gateway)",
-      "baseUrl": "https://coder.example.com/api/v2/aibridge/openai/v1",
+      "baseUrl": "https://coder.example.com/api/v2/ai-gateway/openai/v1",
       "apiKey": "<your-coder-api-token>",
       "provider": "openai",
       "maxOutputTokens": 16384
@@ -51,7 +51,7 @@ Factort's Droid agent can be configured to use AI Gateway by setting up custom m
     {
       "model": "claude-sonnet-4-5-20250929",
       "displayName": "Claude (Coder AI Gateway)",
-      "baseUrl": "https://coder.example.com/api/v2/aibridge/anthropic",
+      "baseUrl": "https://coder.example.com/api/v2/ai-gateway/anthropic",
       "apiKey": "<your-anthropic-api-key>",
       "provider": "anthropic",
       "maxOutputTokens": 8192,
@@ -62,7 +62,7 @@ Factort's Droid agent can be configured to use AI Gateway by setting up custom m
     {
       "model": "gpt-5.2-codex",
       "displayName": "GPT (Coder AI Gateway)",
-      "baseUrl": "https://coder.example.com/api/v2/aibridge/openai/v1",
+      "baseUrl": "https://coder.example.com/api/v2/ai-gateway/openai/v1",
       "apiKey": "<your-openai-api-key>",
       "provider": "openai",
       "maxOutputTokens": 16384,

--- a/docs/ai-coder/ai-gateway/clients/index.md
+++ b/docs/ai-coder/ai-gateway/clients/index.md
@@ -18,12 +18,12 @@ There are two ways to connect AI tools to AI Gateway:
 
 ## Base URLs
 
-Most AI coding tools allow the "base URL" to be customized. In other words, when a request is made to OpenAI's API from your coding tool, the API endpoint such as [`/v1/chat/completions`](https://platform.openai.com/docs/api-reference/chat) will be appended to the configured base. Therefore, instead of the default base URL of `https://api.openai.com/v1`, you'll need to set it to `https://coder.example.com/api/v2/aibridge/openai/v1`.
+Most AI coding tools allow the "base URL" to be customized. In other words, when a request is made to OpenAI's API from your coding tool, the API endpoint such as [`/v1/chat/completions`](https://platform.openai.com/docs/api-reference/chat) will be appended to the configured base. Therefore, instead of the default base URL of `https://api.openai.com/v1`, you'll need to set it to `https://coder.example.com/api/v2/ai-gateway/openai/v1`.
 
 The exact configuration method varies by client, some use environment variables, others use configuration files or UI settings:
 
-- **OpenAI-compatible clients**: Set the base URL (commonly via the `OPENAI_BASE_URL` environment variable) to `https://coder.example.com/api/v2/aibridge/openai/v1`
-- **Anthropic-compatible clients**: Set the base URL (commonly via the `ANTHROPIC_BASE_URL` environment variable) to `https://coder.example.com/api/v2/aibridge/anthropic`
+- **OpenAI-compatible clients**: Set the base URL (commonly via the `OPENAI_BASE_URL` environment variable) to `https://coder.example.com/api/v2/ai-gateway/openai/v1`
+- **Anthropic-compatible clients**: Set the base URL (commonly via the `ANTHROPIC_BASE_URL` environment variable) to `https://coder.example.com/api/v2/ai-gateway/anthropic`
 
 Replace `coder.example.com` with your actual Coder deployment URL.
 
@@ -78,7 +78,7 @@ resource "coder_agent" "dev" {
     os   = "linux"
     dir  = local.repo_dir
     env = {
-        ANTHROPIC_BASE_URL : "${data.coder_workspace.me.access_url}/api/v2/aibridge/anthropic",
+        ANTHROPIC_BASE_URL : "${data.coder_workspace.me.access_url}/api/v2/ai-gateway/anthropic",
         ANTHROPIC_AUTH_TOKEN : data.coder_workspace_owner.me.session_token
     }
     ... # other agent configuration
@@ -100,7 +100,7 @@ For headless scenarios, first [create a service account](../../../admin/users/he
 For clients supporting [base URL](#base-urls), eg. [Claude Code](./claude-code.md):
 
 ```sh
-export ANTHROPIC_BASE_URL="https://coder.example.com/api/v2/aibridge/anthropic"
+export ANTHROPIC_BASE_URL="https://coder.example.com/api/v2/ai-gateway/anthropic"
 export ANTHROPIC_AUTH_TOKEN="<your-coder-api-token>"
 ```
 

--- a/docs/ai-coder/ai-gateway/clients/jetbrains.md
+++ b/docs/ai-coder/ai-gateway/clients/jetbrains.md
@@ -17,7 +17,7 @@ JetBrains IDE (IntelliJ IDEA, PyCharm, WebStorm, etc.) support AI Gateway via th
 1. **Open Settings**: Go to **Settings** > **Tools** > **AI Assistant** > **Models & API Keys**.
 1. **Configure Provider**: Go to **Third-party AI providers**.
 1. **Choose Provider**: Choose **OpenAI-compatible**.
-1. **URL**: `https://coder.example.com/api/v2/aibridge/openai/v1`
+1. **URL**: `https://coder.example.com/api/v2/ai-gateway/openai/v1`
 1. **API Key**: Paste your **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.
 1. **Apply**: Click **Apply** and **OK**.
 

--- a/docs/ai-coder/ai-gateway/clients/kilo-code.md
+++ b/docs/ai-coder/ai-gateway/clients/kilo-code.md
@@ -16,7 +16,7 @@ Kilo Code allows you to configure providers via the UI and can be set up to use 
 1. Open Kilo Code in VS Code.
 1. Go to **Settings**.
 1. **Provider**: Select **OpenAI**.
-1. **Base URL**: Enter `https://coder.example.com/api/v2/aibridge/openai/v1`.
+1. **Base URL**: Enter `https://coder.example.com/api/v2/ai-gateway/openai/v1`.
 1. **API Key**: Enter your **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.
 1. **Model ID**: Enter the model you wish to use (e.g., `gpt-5.2-codex`).
 
@@ -27,7 +27,7 @@ Kilo Code allows you to configure providers via the UI and can be set up to use 
 1. Open Kilo Code in VS Code.
 1. Go to **Settings**.
 1. **Provider**: Select **Anthropic**.
-1. **Base URL**: Enter `https://coder.example.com/api/v2/aibridge/anthropic`.
+1. **Base URL**: Enter `https://coder.example.com/api/v2/ai-gateway/anthropic`.
 1. **API Key**: Enter your **Coder API token**.
 1. **Model ID**: Select your desired Claude model.
 

--- a/docs/ai-coder/ai-gateway/clients/mux.md
+++ b/docs/ai-coder/ai-gateway/clients/mux.md
@@ -23,14 +23,14 @@ Mux can be configured to route OpenAI- and Anthropic-compatible traffic through 
 1. Open Mux settings (`Cmd+,` / `Ctrl+,`).
 2. Go to **Providers** → **OpenAI**.
 3. Set **API Key** to your Coder API token.
-4. Set **Base URL** to `https://coder.example.com/api/v2/aibridge/openai/v1`.
+4. Set **Base URL** to `https://coder.example.com/api/v2/ai-gateway/openai/v1`.
 
 ### Anthropic
 
 1. Open Mux settings (`Cmd+,` / `Ctrl+,`).
 2. Go to **Providers** → **Anthropic**.
 3. Set **API Key** to your Coder API token.
-4. Set **Base URL** to `https://coder.example.com/api/v2/aibridge/anthropic`.
+4. Set **Base URL** to `https://coder.example.com/api/v2/ai-gateway/anthropic`.
 
 </div>
 
@@ -48,11 +48,11 @@ Environment variables are useful in CI or when running Mux inside a Coder worksp
 ```sh
 # OpenAI-compatible traffic (GPT, Codex, etc.)
 export OPENAI_API_KEY="<your-coder-api-token>"
-export OPENAI_BASE_URL="https://coder.example.com/api/v2/aibridge/openai/v1"
+export OPENAI_BASE_URL="https://coder.example.com/api/v2/ai-gateway/openai/v1"
 
 # Anthropic-compatible traffic (Claude, etc.)
 export ANTHROPIC_API_KEY="<your-coder-api-token>"
-export ANTHROPIC_BASE_URL="https://coder.example.com/api/v2/aibridge/anthropic"
+export ANTHROPIC_BASE_URL="https://coder.example.com/api/v2/ai-gateway/anthropic"
 ```
 
 ## Running Mux in a Coder workspace
@@ -68,9 +68,9 @@ resource "coder_agent" "main" {
   # ... other agent configuration
   env = {
     OPENAI_API_KEY     = data.coder_workspace_owner.me.session_token
-    OPENAI_BASE_URL    = "${data.coder_workspace.me.access_url}/api/v2/aibridge/openai/v1"
+    OPENAI_BASE_URL    = "${data.coder_workspace.me.access_url}/api/v2/ai-gateway/openai/v1"
     ANTHROPIC_API_KEY  = data.coder_workspace_owner.me.session_token
-    ANTHROPIC_BASE_URL = "${data.coder_workspace.me.access_url}/api/v2/aibridge/anthropic"
+    ANTHROPIC_BASE_URL = "${data.coder_workspace.me.access_url}/api/v2/ai-gateway/anthropic"
   }
 }
 
@@ -89,11 +89,11 @@ If you prefer a file-based config, edit `~/.mux/providers.jsonc`:
 {
   "openai": {
     "apiKey": "<your-coder-api-token>",
-    "baseUrl": "https://coder.example.com/api/v2/aibridge/openai/v1"
+    "baseUrl": "https://coder.example.com/api/v2/ai-gateway/openai/v1"
   },
   "anthropic": {
     "apiKey": "<your-coder-api-token>",
-    "baseUrl": "https://coder.example.com/api/v2/aibridge/anthropic"
+    "baseUrl": "https://coder.example.com/api/v2/ai-gateway/anthropic"
   }
 }
 ```

--- a/docs/ai-coder/ai-gateway/clients/opencode.md
+++ b/docs/ai-coder/ai-gateway/clients/opencode.md
@@ -17,12 +17,12 @@ You can configure OpenCode to connect to AI Gateway by setting the following con
   "provider": {
     "anthropic": {
       "options": {
-        "baseURL": "https://coder.example.com/api/v2/aibridge/anthropic/v1"
+        "baseURL": "https://coder.example.com/api/v2/ai-gateway/anthropic/v1"
       }
     },
     "openai": {
       "options": {
-        "baseURL": "https://coder.example.com/api/v2/aibridge/openai/v1"
+        "baseURL": "https://coder.example.com/api/v2/ai-gateway/openai/v1"
       }
     }
   }
@@ -54,7 +54,7 @@ Set the following in `~/.config/opencode/opencode.json`, including the `X-Coder-
   "provider": {
     "anthropic": {
       "options": {
-        "baseURL": "https://coder.example.com/api/v2/aibridge/anthropic/v1",
+        "baseURL": "https://coder.example.com/api/v2/ai-gateway/anthropic/v1",
         "headers": {
           "X-Coder-AI-Governance-Token": "<your-coder-api-token>"
         }
@@ -62,7 +62,7 @@ Set the following in `~/.config/opencode/opencode.json`, including the `X-Coder-
     },
     "openai": {
       "options": {
-        "baseURL": "https://coder.example.com/api/v2/aibridge/openai/v1",
+        "baseURL": "https://coder.example.com/api/v2/ai-gateway/openai/v1",
         "headers": {
           "X-Coder-AI-Governance-Token": "<your-coder-api-token>"
         }

--- a/docs/ai-coder/ai-gateway/clients/vscode.md
+++ b/docs/ai-coder/ai-gateway/clients/vscode.md
@@ -36,7 +36,7 @@ Set **API type** to `responses`.
         {
             "id": "gpt-5.5",
             "name": "GPT 5.5",
-            "url": "https://coder.example.com/api/v2/aibridge/openai",
+            "url": "https://coder.example.com/api/v2/ai-gateway/openai",
             "toolCalling": true,
             "vision": true,
             "thinking": true,
@@ -62,7 +62,7 @@ Set **API type** to `messages`.
         {
             "id": "claude-sonnet-4.6",
             "name": "Claude Sonnet 4.6",
-            "url": "https://coder.example.com/api/v2/aibridge/anthropic",
+            "url": "https://coder.example.com/api/v2/ai-gateway/anthropic",
             "toolCalling": true,
             "vision": true,
             "thinking": true,

--- a/docs/ai-coder/ai-gateway/clients/zed.md
+++ b/docs/ai-coder/ai-gateway/clients/zed.md
@@ -17,10 +17,10 @@ You can configure both Anthropic and OpenAI providers to point to AI Gateway.
 {
   "language_models": {
     "anthropic": {
-      "api_url": "https://coder.example.com/api/v2/aibridge/anthropic",
+      "api_url": "https://coder.example.com/api/v2/ai-gateway/anthropic",
     },
     "openai": {
-      "api_url": "https://coder.example.com/api/v2/aibridge/openai/v1",
+      "api_url": "https://coder.example.com/api/v2/ai-gateway/openai/v1",
     },
   },
   // optional settings to set favorite models for the AI

--- a/docs/ai-coder/ai-gateway/index.md
+++ b/docs/ai-coder/ai-gateway/index.md
@@ -1,6 +1,6 @@
 # AI Gateway
 
-![AI bridge diagram](../../images/aibridge/aibridge_diagram.png)
+![AI Gateway diagram](../../images/aibridge/aibridge_diagram.png)
 
 AI Gateway is a smart gateway for AI. It acts as an intermediary between your users' coding agents / IDEs
 and providers like OpenAI and Anthropic. By intercepting all the AI traffic between these clients and

--- a/docs/ai-coder/ai-gateway/monitoring.md
+++ b/docs/ai-coder/ai-gateway/monitoring.md
@@ -98,7 +98,7 @@ AI Gateway interception data can be exported for external analysis, compliance r
 You can retrieve AI Gateway sessions via the Coder API, with filtering and pagination support.
 
 ```sh
-curl -X GET "https://coder.example.com/api/v2/aibridge/sessions" \
+curl -X GET "https://coder.example.com/api/v2/ai-gateway/sessions" \
   -H "Coder-Session-Token: $CODER_SESSION_TOKEN"
 ```
 

--- a/docs/ai-coder/ai-gateway/providers.md
+++ b/docs/ai-coder/ai-gateway/providers.md
@@ -162,7 +162,7 @@ provider of type `openai` with a specific name and base URL:
 | Base URL | `https://chatgpt.com/backend-api/codex` |
 
 The name must be exactly `chatgpt`. It determines the route clients use
-to reach the provider: `/api/v2/aibridge/chatgpt/v1`. If no provider
+to reach the provider: `/api/v2/ai-gateway/chatgpt/v1`. If no provider
 with this name exists, requests to that route fail with
 `404 route not supported`.
 

--- a/docs/ai-coder/ai-gateway/setup.md
+++ b/docs/ai-coder/ai-gateway/setup.md
@@ -41,7 +41,7 @@ without restarting `coderd`.
 1. Save the provider
 
 Each provider gets its own AI Gateway route at
-`/api/v2/aibridge/<provider-name>/`.
+`/api/v2/ai-gateway/<provider-name>/`.
 
 > [!NOTE]
 > Provider names must be unique and use lowercase, hyphen-separated identifiers


### PR DESCRIPTION
## Description

Updates documentation to use the new `/api/v2/ai-gateway/` URLs and `/ai-gateway/` UI paths, following the backend rename in #26475 and frontend route rename in #26569.

## Changes

- Update URL references across documentation files from `/api/v2/aibridge/` to `/api/v2/ai-gateway/`
- Update UI path reference from `/aibridge/sessions` to `/ai-gateway/sessions`
- Update route path references in client setup guides
- Covers client setup guides, authentication, monitoring, proxy setup, and provider configuration

Addresses https://github.com/coder/coder/pull/26475#issuecomment-4768351217

Refs https://linear.app/codercom/issue/AIGOV-226

> Generated with the assistance of Coder Agents (@ssncferreira)