### PR TITLE
docs: fix contributing guide link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ New integrations are always in progress. Open an issue to request one. Contribut
 ## Contributing
 
 New contributors are always welcome. If you are new to the Coder codebase, see
-[the contribution guide](https://coder.com/docs/CONTRIBUTING) to get started.
+[the contribution guide](https://coder.com/docs/about/contributing/CONTRIBUTING) to get started.
 
 ## Hiring
 


### PR DESCRIPTION
The Contributing section of README.md linked to https://coder.com/docs/CONTRIBUTING, which is missing the `about/contributing/` path prefix. Updated to the correct URL: https://coder.com/docs/about/contributing/CONTRIBUTING.