### PR TITLE
fix(coderd/database): escape composite-literal fields in NameOrganizationPair

### DIFF
--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -3078,6 +3078,78 @@ func TestReadCustomRoles(t *testing.T) {
 	}
 }
 
+// TestCustomRolesMalformedLookupName is a regression test for a customer
+// report where OAuth login failed with "pq: malformed record literal" when
+// IdP role-sync passed an unmapped group name (containing parentheses and
+// spaces) through as a Coder role lookup name. The CustomRoles query uses
+// the name_organization_pair composite type, and NameOrganizationPair.Value
+// must escape per Postgres composite-literal rules so that names containing
+// special characters do not abort the query.
+//
+// A name that could never be a real Coder role (NameValid rejects it) must
+// still produce a clean zero-row lookup, not an error.
+func TestCustomRolesMalformedLookupName(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	sqlDB := testSQLDB(t)
+	err := migrations.Up(sqlDB)
+	require.NoError(t, err)
+
+	db := database.New(sqlDB)
+	ctx := testutil.Context(t, testutil.WaitLong)
+
+	orgID := uuid.New()
+	validRole, err := db.InsertCustomRole(ctx, database.InsertCustomRoleParams{
+		Name: "valid-role",
+		OrganizationID: uuid.NullUUID{
+			UUID:  orgID,
+			Valid: true,
+		},
+	})
+	require.NoError(t, err)
+
+	// Sanity: the existing valid name still resolves through Value() after
+	// the escape change.
+	found, err := db.CustomRoles(ctx, database.CustomRolesParams{
+		LookupRoles: []database.NameOrganizationPair{{
+			Name:           validRole.Name,
+			OrganizationID: orgID,
+		}},
+		IncludeSystemRoles: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, found, 1)
+	require.Equal(t, validRole.Name, found[0].Name)
+
+	// Names that hit every special character covered by the composite
+	// literal grammar. None of these can exist as a row, so each lookup
+	// must succeed and return zero rows.
+	malformed := []string{
+		"Atlassian Developers (Bitbucket and Bamboo)", // exact customer payload
+		"with,comma",
+		`with"quote`,
+		`with\backslash`,
+		"with spaces",
+		"",
+		"NULL",
+	}
+	for _, name := range malformed {
+		found, err := db.CustomRoles(ctx, database.CustomRolesParams{
+			LookupRoles: []database.NameOrganizationPair{{
+				Name:           name,
+				OrganizationID: orgID,
+			}},
+			IncludeSystemRoles: true,
+		})
+		require.NoErrorf(t, err, "lookup with name %q must not error", name)
+		require.Emptyf(t, found, "lookup with name %q must return zero rows", name)
+	}
+}
+
 func TestDeleteCustomRoleDoesNotDeleteSystemRole(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/database/types.go
+++ b/coderd/database/types.go
@@ -293,8 +293,37 @@ func (*NameOrganizationPair) Scan(_ interface{}) error {
 // what that literal is as well, with proper quoting.
 //
 //	SELECT ARRAY[('customrole'::text,'ece79dac-926e-44ca-9790-2ff7c5eb6e0c'::uuid)];
+//
+// The name is escaped per Postgres composite-literal rules so that lookup
+// values originating from user-controlled input (e.g. IdP role-sync claims)
+// cannot produce a malformed record literal that aborts the query. Valid
+// Coder role names (alphanumeric with hyphens) round-trip unchanged.
 func (a NameOrganizationPair) Value() (driver.Value, error) {
-	return fmt.Sprintf(`(%s,%s)`, a.Name, a.OrganizationID.String()), nil
+	return fmt.Sprintf(`(%s,%s)`, pgEscapeCompositeField(a.Name), a.OrganizationID.String()), nil
+}
+
+// pgEscapeCompositeField escapes a string for inclusion in a Postgres
+// composite-type literal. Postgres requires fields containing parentheses,
+// commas, double quotes, backslashes, or whitespace, the empty string, or
+// the literal "NULL" (case-insensitive) to be wrapped in double quotes,
+// with internal backslashes and double quotes themselves escaped using a
+// backslash.
+//
+// Fields that contain none of those characters are returned unchanged so
+// existing valid identifiers (e.g. role and resource names) round-trip
+// byte-for-byte through this function.
+//
+// Reference: https://www.postgresql.org/docs/current/rowtypes.html#ROWTYPES-IO-SYNTAX
+func pgEscapeCompositeField(s string) string {
+	needsQuote := s == "" ||
+		strings.EqualFold(s, "NULL") ||
+		strings.ContainsAny(s, "(),\"\\ \t\n\r\v\f")
+	if !needsQuote {
+		return s
+	}
+	escaped := strings.ReplaceAll(s, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	return `"` + escaped + `"`
 }
 
 // AgentIDNamePair is used as a result tuple for workspace and agent rows.

--- a/coderd/database/types_test.go
+++ b/coderd/database/types_test.go
@@ -1,0 +1,73 @@
+package database_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+)
+
+// TestNameOrganizationPair_Value verifies that NameOrganizationPair serializes
+// to a Postgres composite literal that Postgres can parse, even when the
+// name contains characters that would otherwise produce a malformed record
+// literal (parentheses, commas, double quotes, backslashes, whitespace).
+//
+// Valid Coder identifiers (alphanumeric with hyphens) must round-trip
+// unchanged so existing rows continue to match.
+func TestNameOrganizationPair_Value(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.MustParse("e3b15ce2-0b6a-4934-a9aa-1d28613edb3e")
+	suffix := "," + orgID.String() + ")"
+
+	tests := []struct {
+		name       string
+		roleName   string
+		wantPrefix string
+	}{
+		// Valid Coder identifiers must serialize without quoting so existing
+		// rows continue to match byte-for-byte.
+		{"Simple", "owner", "(owner"},
+		{"Hyphen", "template-admin", "(template-admin"},
+		{"OrgRole", "organization-admin", "(organization-admin"},
+		{"WorkspaceCreationBan", "organization-workspace-creation-ban", "(organization-workspace-creation-ban"},
+		{"Numeric", "role123", "(role123"},
+
+		// Special characters must be quoted and, where required, escaped.
+		{"Space", "with space", `("with space"`},
+		{"Tab", "with\ttab", "(\"with\ttab\""},
+		{"Newline", "with\nnewline", "(\"with\nnewline\""},
+		{"Comma", "with,comma", `("with,comma"`},
+		{"OpenParen", "with(paren", `("with(paren"`},
+		{"CloseParen", "with)paren", `("with)paren"`},
+		{"DoubleQuote", `with"quote`, `("with\"quote"`},
+		{"Backslash", `with\backslash`, `("with\\backslash"`},
+		{"BothEscaped", `mix "and" \slash`, `("mix \"and\" \\slash"`},
+
+		// Empty and the literal "NULL" must be quoted to avoid Postgres
+		// parsing them as a NULL field.
+		{"Empty", "", `(""`},
+		{"NullUppercase", "NULL", `("NULL"`},
+		{"NullLowercase", "null", `("null"`},
+		{"NullMixedCase", "Null", `("Null"`},
+
+		// Regression: the exact value reported by the customer, which crashed
+		// OAuth login with a malformed record literal error.
+		{"CustomerReport", "Atlassian Developers (Bitbucket and Bamboo)", `("Atlassian Developers (Bitbucket and Bamboo)"`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := database.NameOrganizationPair{
+				Name:           tc.roleName,
+				OrganizationID: orgID,
+			}.Value()
+			require.NoError(t, err)
+			require.Equal(t, tc.wantPrefix+suffix, got)
+		})
+	}
+}


### PR DESCRIPTION
Customer report: OAuth login failed with `pq: malformed record literal` whenever IdP role sync touched a group named `Atlassian Developers (Bitbucket and Bamboo)`.

`NameOrganizationPair.Value` built a Postgres composite literal via plain `fmt.Sprintf("(%s,%s)", name, uuid)` with no escaping, so any name containing `()`, `,`, `"`, `\`, or whitespace produced an unparseable record and aborted the `CustomRoles` lookup. In `idpsync.SyncRoles`, an unmapped claim value is passed through as the lookup name verbatim ([role.go:148-157](https://github.com/coder/coder/blob/main/coderd/idpsync/role.go#L148-L157)), so a single bad IdP group bricked OAuth login for every user it touched.

## Fix

- `pgEscapeCompositeField` escapes per Postgres composite-literal rules: quote + backslash-escape `\` and `"` when the field contains any of `()`, `,`, `"`, `\`, whitespace, the empty string, or `NULL` (case-insensitive). Fields that are valid Coder identifiers (`codersdk.NameValid`: alphanumeric + hyphens) are returned unchanged, so existing rows still match byte-for-byte.
- `NameOrganizationPair.Value` runs the name through it.
- After the fix, a lookup for an impossible name returns zero rows (the documented graceful-degradation path in `rolestore.Expand`), and login completes without granting that role.

Reference: [PostgreSQL row-type I/O syntax](https://www.postgresql.org/docs/current/rowtypes.html#ROWTYPES-IO-SYNTAX).

## Tests

- `TestNameOrganizationPair_Value` — unit tests covering every special character class plus the customer's exact payload.
- `TestCustomRolesMalformedLookupName` — integration test against a real Postgres that issues a `CustomRoles` lookup with the customer payload and asserts the query succeeds with zero rows. Confirmed this fails before the fix with the customer's exact error message:

  ```
  pq: malformed record literal: "(Atlassian Developers (Bitbucket and Bamboo),<uuid>)"
  ```

## Follow-up (not in this PR)

`AgentIDNamePair.Value` ([types.go:329](https://github.com/coder/coder/blob/main/coderd/database/types.go#L329)) has the same unescaped-composite pattern. Its blast radius is workspace agent lookups, and its accompanying `Scan` also parses the result tuple naively (`strings.Trim(..., "()")` + `strings.Split(..., ",")`). Fixing it cleanly requires both an escape on `Value` and a real composite-literal parser on `Scan`, so it's a separate change.

<details>
<summary>Customer error trace</summary>

```
{"message":"Failed to process OAuth login.","detail":"in tx: execute transaction: sync roles: sync user roles(5cdd1f36-a3dd-4c26-8530-83dc6e0b4e8e): execute transaction: expand roles: fetch custom roles: pq: malformed record literal: \"(Atlassian Developers (Bitbucket and Bamboo),e3b15ce2-0b6a-4934-a9aa-1d28613edb3e)\""}
```

Chain: `oauth login → SyncRoles → rolestore.Expand → db.CustomRoles → NameOrganizationPair.Value`.

</details>

---

_Drafted by Coder Agents on behalf of @Emyrk._