### PR TITLE
feat: escape composite-literal fields in NameOrganizationPair

### DIFF
--- a/coderd/database/types.go
+++ b/coderd/database/types.go
@@ -294,7 +294,29 @@ func (*NameOrganizationPair) Scan(_ interface{}) error {
 //
 //	SELECT ARRAY[('customrole'::text,'ece79dac-926e-44ca-9790-2ff7c5eb6e0c'::uuid)];
 func (a NameOrganizationPair) Value() (driver.Value, error) {
-	return fmt.Sprintf(`(%s,%s)`, a.Name, a.OrganizationID.String()), nil
+	// The string values must be escaped in case there are special characters, quotes, etc.
+	// 'NameOrganizationPair' is a composite value, which has no driver handler
+	// in the `pq` package.
+	//
+	// pq.StringArray formats the single name as `{"<escaped>"}`. Strip
+	// the outer braces to get the quoted+escaped form that composite
+	// literal syntax accepts unchanged.
+	//
+	// Ideally `appendArrayQuotedBytes` would be exported, and we could call
+	// it directly.
+	v, err := (&pq.StringArray{a.Name}).Value()
+	if err != nil {
+		return nil, err
+	}
+
+	s, ok := v.(string)
+	if !ok {
+		return nil, xerrors.Errorf("unexpected type %T", v)
+	}
+
+	stripCurlyBraces := s[1 : len(s)-1]
+
+	return fmt.Sprintf("(%s,%s)", stripCurlyBraces, a.OrganizationID.String()), nil
 }
 
 // AgentIDNamePair is used as a result tuple for workspace and agent rows.

--- a/coderd/idpsync/role_test.go
+++ b/coderd/idpsync/role_test.go
@@ -31,6 +31,9 @@ func TestRoleSyncTable(t *testing.T) {
 			"foo", "bar", "baz",
 			"create-bar", "create-baz",
 			"legacy-bar", rbac.RoleOrgAuditor(),
+			// Some arbitrary values to attempt to trip up the SQL in the matching.
+			"Role with (Special Characters)",
+			"NULL",
 		},
 		// bad-claim is a number, and will fail any role sync
 		"bad-claim": 100,


### PR DESCRIPTION
## Report

Report: OAuth login failed with `pq: malformed record literal` whenever IdP role sync touched a group named `Atlassian Developers (Bitbucket and Bamboo)`.

`NameOrganizationPair.Value` built a Postgres composite literal via plain `fmt.Sprintf("(%s,%s)", name, uuid)` with no escaping, so any name containing `()`, `,`, `"`, `\`, or whitespace produced an unparseable record and aborted the `CustomRoles` lookup. In `idpsync.SyncRoles`, an unmapped claim value is passed through as the lookup name verbatim ([role.go:148-157](https://github.com/coder/coder/blob/main/coderd/idpsync/role.go#L148-L157)), so a single bad IdP group bricked OAuth login for every user it touched.
