### PR TITLE
feat(site): add Network section and Network activity dialog to AI session view

### DIFF
--- a/site/src/pages/AIBridgePage/SessionThreadsPage/NetworkActivity/NetworkActivityButton.stories.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/NetworkActivity/NetworkActivityButton.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+import { mockNetworkActivity } from "./mocks";
+import { NetworkActivityButton } from "./NetworkActivityButton";
+
+const meta: Meta<typeof NetworkActivityButton> = {
+	title: "pages/AIBridgePage/NetworkActivity/Button",
+	component: NetworkActivityButton,
+	parameters: {
+		// Keep the dialog room below the trigger in Storybook's iframe.
+		layout: "padded",
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof NetworkActivityButton>;
+
+const open = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+	const canvas = within(canvasElement);
+	const trigger = await canvas.findByRole("button", {
+		name: /Network activity/i,
+	});
+	await userEvent.click(trigger);
+	// Popover content is portaled, so look at the whole document.
+	const body = within(document.body);
+	await waitFor(() =>
+		expect(
+			body.getByRole("heading", { name: /Network activity/i }),
+		).toBeVisible(),
+	);
+};
+
+export const AllAllowed: Story = {
+	args: { networkActivity: mockNetworkActivity("all-allowed") },
+	play: open,
+};
+
+export const Mixed: Story = {
+	args: { networkActivity: mockNetworkActivity("mixed") },
+	play: open,
+};
+
+export const ErrorOnly: Story = {
+	args: { networkActivity: mockNetworkActivity("error-only") },
+	play: open,
+};
+
+export const MidSessionFailure: Story = {
+	args: { networkActivity: mockNetworkActivity("mid-session-failure") },
+	play: open,
+};
+
+export const Many: Story = {
+	args: { networkActivity: mockNetworkActivity("many") },
+	play: open,
+};
+
+// With no events the button does not render. Verifies the empty-state.
+export const HiddenWhenEmpty: Story = {
+	args: { networkActivity: mockNetworkActivity("none") },
+};

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/NetworkActivity/NetworkActivityButton.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/NetworkActivity/NetworkActivityButton.tsx
@@ -1,0 +1,283 @@
+import {
+	CheckIcon,
+	ChevronRightIcon,
+	NetworkIcon,
+	TriangleAlertIcon,
+} from "lucide-react";
+import { type FC, useState } from "react";
+import { Badge } from "#/components/Badge/Badge";
+import { Button } from "#/components/Button/Button";
+import { Link } from "#/components/Link/Link";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "#/components/Popover/Popover";
+import { cn } from "#/utils/cn";
+import { formatDateTime } from "#/utils/time";
+import {
+	computeNetworkCounts,
+	type NetworkActivity,
+	type NetworkEvent,
+	type NetworkFailureEvent,
+	type NetworkRequestEvent,
+} from "./types";
+
+interface NetworkActivityButtonProps {
+	networkActivity: NetworkActivity;
+}
+
+/**
+ * Button + Popover combo. Triggered by the `Network activity (N)` button at
+ * the top of the session timeline. The popover anchors to the trigger and
+ * Radix auto-flips it above/below when there is not enough room. Internal
+ * scrolling keeps the dialog from being cut off in small viewports.
+ */
+export const NetworkActivityButton: FC<NetworkActivityButtonProps> = ({
+	networkActivity,
+}) => {
+	const counts = computeNetworkCounts(networkActivity);
+
+	if (counts.total === 0) {
+		return null;
+	}
+
+	return (
+		<Popover>
+			<PopoverTrigger asChild>
+				<Button variant="outline" size="sm">
+					<NetworkIcon />
+					<span className="font-normal">Network activity ({counts.total})</span>
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent
+				align="start"
+				side="bottom"
+				sideOffset={8}
+				className="flex flex-col overflow-hidden p-0 w-[min(36rem,calc(100vw-2rem))]"
+			>
+				<NetworkActivityDialog
+					events={networkActivity.events}
+					counts={counts}
+				/>
+			</PopoverContent>
+		</Popover>
+	);
+};
+
+interface NetworkActivityDialogProps {
+	events: readonly NetworkEvent[];
+	counts: ReturnType<typeof computeNetworkCounts>;
+}
+
+const NetworkActivityDialog: FC<NetworkActivityDialogProps> = ({
+	events,
+	counts,
+}) => (
+	<>
+		<header className="border-0 border-b border-solid px-4 py-3 flex flex-col gap-1.5 shrink-0">
+			<h2 className="m-0 text-sm font-semibold text-content-primary">
+				Network activity ({counts.total})
+			</h2>
+			<dl className="m-0 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-content-secondary">
+				<SummaryCount
+					tone="success"
+					value={counts.allowed}
+					label={counts.allowed === 1 ? "allowed" : "allowed"}
+				/>
+				<SummaryCount
+					tone="warning"
+					value={counts.warnings}
+					label={counts.warnings === 1 ? "warning" : "warnings"}
+				/>
+				<SummaryCount
+					tone="error"
+					value={counts.errors}
+					label={counts.errors === 1 ? "error" : "errors"}
+				/>
+			</dl>
+		</header>
+		<ul className="m-0 p-0 list-none overflow-y-auto flex-1 divide-y divide-solid divide-border-default">
+			{events.map((event) => (
+				<NetworkEventRow key={event.id} event={event} />
+			))}
+		</ul>
+	</>
+);
+
+interface SummaryCountProps {
+	value: number;
+	label: string;
+	tone: "success" | "warning" | "error";
+}
+
+const SummaryCount: FC<SummaryCountProps> = ({ value, label, tone }) => (
+	<div className="inline-flex items-center gap-1.5">
+		<ToneIcon tone={tone} />
+		<span className="text-content-primary">
+			{value} {label}
+		</span>
+	</div>
+);
+
+const ToneIcon: FC<{ tone: "success" | "warning" | "error" }> = ({ tone }) => {
+	if (tone === "success") {
+		return (
+			<CheckIcon className="size-icon-xs p-0.5 text-content-success shrink-0" />
+		);
+	}
+	if (tone === "warning") {
+		return (
+			<TriangleAlertIcon className="size-icon-xs p-0.5 text-content-warning shrink-0" />
+		);
+	}
+	return (
+		<TriangleAlertIcon className="size-icon-xs p-0.5 text-content-destructive shrink-0" />
+	);
+};
+
+interface NetworkEventRowProps {
+	event: NetworkEvent;
+}
+
+const NetworkEventRow: FC<NetworkEventRowProps> = ({ event }) => {
+	const [isOpen, setIsOpen] = useState(false);
+	const toggle = () => setIsOpen((v) => !v);
+
+	return (
+		<li className="m-0">
+			<button
+				type="button"
+				onClick={toggle}
+				aria-expanded={isOpen}
+				className={cn(
+					"w-full bg-transparent border-0 p-0 m-0 text-left cursor-pointer",
+					"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link",
+				)}
+			>
+				<div className="flex items-center gap-2 px-3 py-2 hover:bg-surface-secondary min-w-0">
+					<ChevronRightIcon
+						className={cn(
+							"size-3.5 shrink-0 text-content-secondary transition-transform",
+							isOpen && "rotate-90",
+						)}
+					/>
+					{event.kind === "request" ? (
+						<RequestHead event={event} />
+					) : (
+						<FailureHead event={event} />
+					)}
+				</div>
+			</button>
+			{isOpen && (
+				<div className="px-3 pb-3 pl-9">
+					{event.kind === "request" ? (
+						<RequestDetails event={event} />
+					) : (
+						<FailureDetails event={event} />
+					)}
+				</div>
+			)}
+		</li>
+	);
+};
+
+const RequestHead: FC<{ event: NetworkRequestEvent }> = ({ event }) => (
+	<div className="flex items-center gap-2 min-w-0 flex-1">
+		<Badge size="xs" className="font-mono shrink-0 min-w-[3rem] justify-center">
+			{event.method}
+		</Badge>
+		<StatusBadge status={event.status} />
+		<span
+			className="text-xs font-mono text-content-primary truncate min-w-0 flex-1"
+			title={event.url}
+		>
+			{event.url}
+		</span>
+	</div>
+);
+
+const FailureHead: FC<{ event: NetworkFailureEvent }> = ({ event }) => (
+	<div className="flex items-center gap-2 min-w-0 flex-1">
+		<Badge size="xs" variant="destructive" className="shrink-0 gap-1">
+			<TriangleAlertIcon className="size-3" />
+			{event.label}
+		</Badge>
+		<span
+			className="text-xs font-mono text-content-primary truncate min-w-0 flex-1"
+			title={event.detail}
+		>
+			{event.detail}
+		</span>
+	</div>
+);
+
+const StatusBadge: FC<{ status: NetworkRequestEvent["status"] }> = ({
+	status,
+}) => {
+	if (status === "allowed") {
+		return (
+			<Badge size="xs" className="shrink-0 gap-1">
+				<CheckIcon className="size-3 text-content-success" />
+				Allowed
+			</Badge>
+		);
+	}
+	return (
+		<Badge size="xs" variant="warning" className="shrink-0 gap-1">
+			<TriangleAlertIcon className="size-3" />
+			Blocked
+		</Badge>
+	);
+};
+
+const RequestDetails: FC<{ event: NetworkRequestEvent }> = ({ event }) => (
+	<DetailGrid>
+		<DetailRow label="Start time" value={formatDateTime(event.timestamp)} />
+		{event.policy && <DetailRow label="Policy" value={event.policy} />}
+		{event.error && <DetailRow label="Error" value={event.error} />}
+		{event.policyConfigurationHref && (
+			<PolicyConfigurationLink href={event.policyConfigurationHref} />
+		)}
+	</DetailGrid>
+);
+
+const FailureDetails: FC<{ event: NetworkFailureEvent }> = ({ event }) => (
+	<DetailGrid>
+		{event.description && (
+			<p className="m-0 text-sm text-content-primary leading-snug">
+				{event.description}
+			</p>
+		)}
+		<DetailRow label="Timestamp" value={formatDateTime(event.timestamp)} />
+		{event.policy && <DetailRow label="Policy" value={event.policy} />}
+		{event.error && <DetailRow label="Error" value={event.error} />}
+		{event.policyConfigurationHref && (
+			<PolicyConfigurationLink href={event.policyConfigurationHref} />
+		)}
+	</DetailGrid>
+);
+
+const DetailGrid: FC<{ children: React.ReactNode }> = ({ children }) => (
+	<div className="flex flex-col gap-1.5 text-sm">{children}</div>
+);
+
+const DetailRow: FC<{ label: string; value: string }> = ({ label, value }) => (
+	<div className="flex items-baseline gap-3 min-w-0">
+		<span className="text-content-secondary font-normal shrink-0">
+			{label}:
+		</span>
+		<span
+			className="text-content-primary font-mono text-xs truncate min-w-0 flex-1"
+			title={value}
+		>
+			{value}
+		</span>
+	</div>
+);
+
+const PolicyConfigurationLink: FC<{ href: string }> = ({ href }) => (
+	<Link href={href} size="sm" target="_blank" rel="noreferrer">
+		View policy configuration
+	</Link>
+);

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/NetworkActivity/NetworkSummary.stories.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/NetworkActivity/NetworkSummary.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { mockNetworkActivity } from "./mocks";
+import { NetworkSummary } from "./NetworkSummary";
+
+const meta: Meta<typeof NetworkSummary> = {
+	title: "pages/AIBridgePage/NetworkActivity/Summary",
+	component: NetworkSummary,
+	// The summary is laid out as a row inside a definition list. Wrap it in a
+	// minimal <dl> so it renders with realistic typography in isolation.
+	decorators: [
+		(Story) => (
+			<dl className="m-0 w-64 text-sm text-content-secondary border border-solid rounded-md p-3 flex flex-col gap-2">
+				<Story />
+			</dl>
+		),
+	],
+};
+
+export default meta;
+type Story = StoryObj<typeof NetworkSummary>;
+
+export const NoActivity: Story = {
+	args: { networkActivity: mockNetworkActivity("none") },
+};
+
+export const AllAllowed: Story = {
+	args: { networkActivity: mockNetworkActivity("all-allowed") },
+};
+
+export const Mixed: Story = {
+	args: { networkActivity: mockNetworkActivity("mixed") },
+};
+
+export const ErrorOnly: Story = {
+	args: { networkActivity: mockNetworkActivity("error-only") },
+};
+
+export const MidSessionFailure: Story = {
+	args: { networkActivity: mockNetworkActivity("mid-session-failure") },
+};
+
+export const Many: Story = {
+	args: { networkActivity: mockNetworkActivity("many") },
+};

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/NetworkActivity/NetworkSummary.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/NetworkActivity/NetworkSummary.tsx
@@ -1,0 +1,99 @@
+import { CheckIcon, TriangleAlertIcon } from "lucide-react";
+import type { FC } from "react";
+import { cn } from "#/utils/cn";
+import type { NetworkActivity } from "./types";
+import { computeNetworkCounts } from "./types";
+
+interface NetworkSummaryProps {
+	networkActivity?: NetworkActivity;
+}
+
+/**
+ * Network row rendered inside the Session summary side panel.
+ *
+ * States:
+ * - No events at all -> "No activity".
+ * - One or more counts -> a line per non-zero count, each with its severity
+ *   icon. Multi-line layouts stack right-aligned.
+ */
+export const NetworkSummary: FC<NetworkSummaryProps> = ({
+	networkActivity,
+}) => {
+	const counts = computeNetworkCounts(networkActivity);
+	const isEmpty = counts.total === 0;
+
+	return (
+		<div
+			className={cn(
+				"flex justify-between",
+				isEmpty ? "items-center" : "items-start",
+			)}
+		>
+			<dt
+				className={cn(
+					"shrink-0 font-normal whitespace-nowrap",
+					!isEmpty && "pt-px",
+				)}
+			>
+				Network
+			</dt>
+			<dd className="ml-4 min-w-0 text-content-primary flex flex-col items-end gap-1">
+				{isEmpty ? (
+					<span className="text-content-secondary">No activity</span>
+				) : (
+					<>
+						{counts.allowed > 0 && (
+							<NetworkSummaryLine
+								label={`${counts.allowed} allowed`}
+								tone="success"
+							/>
+						)}
+						{counts.warnings > 0 && (
+							<NetworkSummaryLine
+								label={`${counts.warnings} ${counts.warnings === 1 ? "warning" : "warnings"}`}
+								tone="warning"
+							/>
+						)}
+						{counts.errors > 0 && (
+							<NetworkSummaryLine
+								label={`${counts.errors} ${counts.errors === 1 ? "error" : "errors"}`}
+								tone="error"
+							/>
+						)}
+					</>
+				)}
+			</dd>
+		</div>
+	);
+};
+
+type Tone = "success" | "warning" | "error";
+
+interface NetworkSummaryLineProps {
+	label: string;
+	tone: Tone;
+}
+
+const NetworkSummaryLine: FC<NetworkSummaryLineProps> = ({ label, tone }) => (
+	<span className="inline-flex items-center gap-1.5 text-sm font-mono text-content-primary">
+		{label}
+		<NetworkToneIcon tone={tone} />
+	</span>
+);
+
+const NetworkToneIcon: FC<{ tone: Tone }> = ({ tone }) => {
+	switch (tone) {
+		case "success":
+			return (
+				<CheckIcon className="size-icon-xs p-0.5 text-content-success shrink-0" />
+			);
+		case "warning":
+			return (
+				<TriangleAlertIcon className="size-icon-xs p-0.5 text-content-warning shrink-0" />
+			);
+		case "error":
+			return (
+				<TriangleAlertIcon className="size-icon-xs p-0.5 text-content-destructive shrink-0" />
+			);
+	}
+};

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/NetworkActivity/mocks.ts
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/NetworkActivity/mocks.ts
@@ -1,0 +1,181 @@
+/**
+ * Deterministic, frontend-only mock data for network activity. Pure visual
+ * validation, no backend impact. The mock variant is picked from a stable
+ * hash of the session ID so different sessions render different states for
+ * manual QA on the live page. Storybook stories exercise each state
+ * explicitly.
+ */
+
+import type {
+	HttpMethod,
+	NetworkActivity,
+	NetworkEvent,
+	NetworkFailureEvent,
+	NetworkRequestEvent,
+} from "./types";
+
+type MockNetworkVariant =
+	| "none"
+	| "all-allowed"
+	| "mixed"
+	| "error-only"
+	| "mid-session-failure"
+	| "many";
+
+const hashString = (value: string): number => {
+	let hash = 0;
+	for (let i = 0; i < value.length; i++) {
+		hash = (hash * 31 + value.charCodeAt(i)) | 0;
+	}
+	return Math.abs(hash);
+};
+
+// Cycle of variants used when generating mock data per session ID. Keeping
+// "none" out of the live cycle so the feature is visible on every session;
+// Storybook still has an explicit empty story.
+const LIVE_VARIANTS: readonly MockNetworkVariant[] = [
+	"all-allowed",
+	"mixed",
+	"error-only",
+	"mid-session-failure",
+	"many",
+];
+
+const pickMockVariantForSession = (sessionId: string): MockNetworkVariant => {
+	if (!sessionId) {
+		return "mixed";
+	}
+	return LIVE_VARIANTS[hashString(sessionId) % LIVE_VARIANTS.length];
+};
+
+const BASE_TIME = new Date("2026-12-12T15:00:59Z").getTime();
+const POLICY = "no-external-apis v1.2 (Org policy)";
+const POLICY_HREF =
+	"/deployment/ai-gateway/policies/no-external-apis?version=1.2";
+
+const stepTime = (offsetSeconds: number): Date =>
+	new Date(BASE_TIME + offsetSeconds * 1000);
+
+const makeAllowed = (
+	id: string,
+	method: HttpMethod,
+	url: string,
+	offset: number,
+): NetworkRequestEvent => ({
+	kind: "request",
+	id,
+	method,
+	status: "allowed",
+	url,
+	timestamp: stepTime(offset),
+	policy: POLICY,
+	policyConfigurationHref: POLICY_HREF,
+});
+
+const makeBlocked = (
+	id: string,
+	method: HttpMethod,
+	url: string,
+	offset: number,
+	error = "Destination not in allowlist",
+): NetworkRequestEvent => ({
+	kind: "request",
+	id,
+	method,
+	status: "blocked",
+	url,
+	timestamp: stepTime(offset),
+	policy: POLICY,
+	error,
+	policyConfigurationHref: POLICY_HREF,
+});
+
+const makeFailure = (
+	id: string,
+	offset: number,
+	overrides: Partial<NetworkFailureEvent> = {},
+): NetworkFailureEvent => ({
+	kind: "failure",
+	id,
+	label: "Network Error",
+	detail: "Failed mid-session",
+	description:
+		"Boundaries stopped recording during the session. Network data may be incomplete.",
+	timestamp: stepTime(offset),
+	policy: POLICY,
+	error: "Unexpected key domains at line 14",
+	policyConfigurationHref: POLICY_HREF,
+	...overrides,
+});
+
+const allAllowed: readonly NetworkEvent[] = Array.from({ length: 12 }, (_, i) =>
+	makeAllowed(
+		`allowed-${i}`,
+		i % 3 === 0 ? "GET" : "POST",
+		`api.github.com/repos/coder/coder/issues/${1000 + i}`,
+		i * 2,
+	),
+);
+
+const mixed: readonly NetworkEvent[] = [
+	makeAllowed("m-1", "POST", "api.github.com/repos/coder/coder", 0),
+	makeBlocked("m-2", "GET", "registry.npmjs.org/lodash", 5),
+	makeBlocked("m-3", "POST", "hooks.slack.com/services/T01ABCDE/B0123/xyz", 6),
+	makeAllowed("m-4", "POST", "api.github.com/repos/coder/coder/pulls", 12),
+	makeAllowed("m-5", "POST", "api.github.com/repos/coder/coder/contents", 18),
+	makeBlocked("m-6", "POST", "sentry.io/api/0/store/", 24),
+	makeFailure("m-7", 30),
+];
+
+const errorOnly: readonly NetworkEvent[] = [
+	makeFailure("e-1", 0, {
+		label: "Network Error",
+		detail: "Failed at session start",
+		description:
+			"Boundaries failed to start. No network activity was recorded for this session.",
+		error: "Failed to attach boundary agent",
+	}),
+];
+
+const midSessionFailure: readonly NetworkEvent[] = [
+	makeAllowed("ms-1", "POST", "api.github.com/repos/coder/coder", 0),
+	makeAllowed("ms-2", "GET", "api.github.com/repos/coder/coder/contents", 6),
+	makeFailure("ms-3", 14),
+];
+
+const many: readonly NetworkEvent[] = [
+	...Array.from({ length: 14 }, (_, i) =>
+		makeAllowed(
+			`many-allowed-${i}`,
+			i % 2 === 0 ? "POST" : "GET",
+			`api.github.com/repos/coder/coder/issues/${2000 + i}`,
+			i,
+		),
+	),
+	...Array.from({ length: 5 }, (_, i) =>
+		makeBlocked(
+			`many-blocked-${i}`,
+			"POST",
+			`hooks.slack.com/services/T${i}/B${i}/secret-${i}`,
+			20 + i,
+		),
+	),
+	makeFailure("many-failure", 30),
+];
+
+const variants: Record<MockNetworkVariant, readonly NetworkEvent[]> = {
+	none: [],
+	"all-allowed": allAllowed,
+	mixed,
+	"error-only": errorOnly,
+	"mid-session-failure": midSessionFailure,
+	many,
+};
+
+export const mockNetworkActivity = (
+	variant: MockNetworkVariant,
+): NetworkActivity => ({ events: variants[variant] });
+
+export const mockNetworkActivityForSession = (
+	sessionId: string,
+): NetworkActivity => mockNetworkActivity(pickMockVariantForSession(sessionId));

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/NetworkActivity/types.ts
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/NetworkActivity/types.ts
@@ -1,0 +1,90 @@
+/**
+ * Frontend-only types describing network activity captured during an AI
+ * session. The backend does not currently surface this data, so these types
+ * are decoupled from any generated API model. They exist purely to drive the
+ * visual validation of the Network section and the Network activity dialog.
+ */
+
+type NetworkRequestStatus = "allowed" | "blocked";
+
+export type HttpMethod =
+	| "GET"
+	| "POST"
+	| "PUT"
+	| "PATCH"
+	| "DELETE"
+	| "HEAD"
+	| "OPTIONS";
+
+interface NetworkEventBase {
+	id: string;
+	timestamp: Date;
+	policy?: string;
+	error?: string;
+	policyConfigurationHref?: string;
+}
+
+/**
+ * A single intercepted HTTP request. `allowed` requests succeeded against the
+ * configured policy, `blocked` requests were stopped before reaching their
+ * destination.
+ */
+export interface NetworkRequestEvent extends NetworkEventBase {
+	kind: "request";
+	method: HttpMethod;
+	status: NetworkRequestStatus;
+	url: string;
+}
+
+/**
+ * A non-request failure that affected the network audit itself, such as the
+ * boundary recorder dropping events mid-session. Counted as an `error` in the
+ * summary.
+ */
+export interface NetworkFailureEvent extends NetworkEventBase {
+	kind: "failure";
+	label: string;
+	detail: string;
+	description?: string;
+}
+
+export type NetworkEvent = NetworkRequestEvent | NetworkFailureEvent;
+
+export interface NetworkActivity {
+	events: readonly NetworkEvent[];
+}
+
+interface NetworkCounts {
+	allowed: number;
+	warnings: number;
+	errors: number;
+	total: number;
+}
+
+export const computeNetworkCounts = (
+	activity: NetworkActivity | undefined,
+): NetworkCounts => {
+	const counts: NetworkCounts = {
+		allowed: 0,
+		warnings: 0,
+		errors: 0,
+		total: 0,
+	};
+
+	if (!activity) {
+		return counts;
+	}
+
+	for (const event of activity.events) {
+		counts.total++;
+		if (event.kind === "failure") {
+			counts.errors++;
+		} else if (event.status === "allowed") {
+			counts.allowed++;
+		} else {
+			counts.warnings++;
+		}
+	}
+
+	return counts;
+};

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionSummaryTable.stories.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionSummaryTable.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { MockSession } from "#/testHelpers/entities";
+import { mockNetworkActivity } from "./NetworkActivity/mocks";
 import { SessionSummaryTable } from "./SessionSummaryTable";
 
 const meta: Meta<typeof SessionSummaryTable> = {
@@ -10,38 +11,40 @@ const meta: Meta<typeof SessionSummaryTable> = {
 export default meta;
 type Story = StoryObj<typeof SessionSummaryTable>;
 
+const baseArgs = {
+	sessionId: MockSession.id,
+	startTime: new Date(MockSession.started_at),
+	endTime: new Date(MockSession.ended_at!),
+	initiator: MockSession.initiator,
+	client: MockSession.client ?? "Unknown",
+	providers: MockSession.providers,
+	inputTokens: MockSession.token_usage_summary.input_tokens,
+	outputTokens: MockSession.token_usage_summary.output_tokens,
+	threadCount: MockSession.threads,
+	toolCallCount: 12,
+};
+
 export const Default: Story = {
-	args: {
-		sessionId: MockSession.id,
-		startTime: new Date(MockSession.started_at),
-		endTime: new Date(MockSession.ended_at!),
-		initiator: MockSession.initiator,
-		client: MockSession.client ?? "Unknown",
-		providers: MockSession.providers,
-		inputTokens: MockSession.token_usage_summary.input_tokens,
-		outputTokens: MockSession.token_usage_summary.output_tokens,
-		threadCount: MockSession.threads,
-		toolCallCount: 12,
-	},
+	args: baseArgs,
 };
 
 export const InProgress: Story = {
 	args: {
-		...Default.args,
+		...baseArgs,
 		endTime: undefined,
 	},
 };
 
 export const MultipleProviders: Story = {
 	args: {
-		...Default.args,
+		...baseArgs,
 		providers: ["anthropic", "openai", "copilot"],
 	},
 };
 
 export const WithTokenMetadata: Story = {
 	args: {
-		...Default.args,
+		...baseArgs,
 		tokenUsageMetadata: {
 			cache_read_input_tokens: 3200,
 			cache_creation_input_tokens: 800,
@@ -51,8 +54,43 @@ export const WithTokenMetadata: Story = {
 
 export const LargeTokenCounts: Story = {
 	args: {
-		...Default.args,
+		...baseArgs,
 		inputTokens: 198_000,
 		outputTokens: 32_000,
+	},
+};
+
+export const NetworkNoActivity: Story = {
+	args: {
+		...baseArgs,
+		networkActivity: mockNetworkActivity("none"),
+	},
+};
+
+export const NetworkAllAllowed: Story = {
+	args: {
+		...baseArgs,
+		networkActivity: mockNetworkActivity("all-allowed"),
+	},
+};
+
+export const NetworkMixed: Story = {
+	args: {
+		...baseArgs,
+		networkActivity: mockNetworkActivity("mixed"),
+	},
+};
+
+export const NetworkErrorOnly: Story = {
+	args: {
+		...baseArgs,
+		networkActivity: mockNetworkActivity("error-only"),
+	},
+};
+
+export const NetworkMidSessionFailure: Story = {
+	args: {
+		...baseArgs,
+		networkActivity: mockNetworkActivity("mid-session-failure"),
 	},
 };

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionSummaryTable.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionSummaryTable.tsx
@@ -6,6 +6,8 @@ import { AIBridgeProviderIcon } from "#/pages/AIBridgePage/icons/AIBridgeProvide
 import { formatDateTime } from "#/utils/time";
 import { TokenBadges } from "../TokenBadges";
 import { getProviderDisplayName } from "../utils";
+import { NetworkSummary } from "./NetworkActivity/NetworkSummary";
+import type { NetworkActivity } from "./NetworkActivity/types";
 
 const Separator = () => <div className="border-0 border-t border-solid my-1" />;
 
@@ -21,6 +23,7 @@ interface SessionSummaryTableProps {
 	threadCount: number;
 	toolCallCount: number;
 	tokenUsageMetadata?: Record<string, unknown>;
+	networkActivity?: NetworkActivity;
 }
 
 export const SessionSummaryTable = ({
@@ -35,6 +38,7 @@ export const SessionSummaryTable = ({
 	threadCount,
 	toolCallCount,
 	tokenUsageMetadata,
+	networkActivity,
 }: SessionSummaryTableProps) => {
 	const durationInMs =
 		endTime !== undefined
@@ -163,6 +167,10 @@ export const SessionSummaryTable = ({
 					<Badge>{toolCallCount}</Badge>
 				</dd>
 			</div>
+
+			<Separator />
+
+			<NetworkSummary networkActivity={networkActivity} />
 		</dl>
 	);
 };

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionThreadsPageView.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionThreadsPageView.tsx
@@ -14,6 +14,7 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { AIBridgeSetupAlert } from "../AIBridgeSetupAlert";
+import { mockNetworkActivityForSession } from "./NetworkActivity/mocks";
 import { SessionSummaryTable } from "./SessionSummaryTable";
 import { SessionTimeline } from "./SessionTimeline/SessionTimeline";
 import { SessionTimelineSkeleton } from "./SessionTimeline/SessionTimelineSkeleton";
@@ -75,6 +76,13 @@ export const SessionThreadsPageView: FC<SessionThreadsPageViewProps> = ({
 		0,
 	);
 
+	// TODO(network-activity): mock data, no backend wiring yet. The variant is
+	// derived from the session ID so different sessions surface different
+	// states on the live page for visual validation.
+	const networkActivity = session
+		? mockNetworkActivityForSession(session.id)
+		: undefined;
+
 	return (
 		<>
 			<nav className="mb-6">
@@ -115,6 +123,7 @@ export const SessionThreadsPageView: FC<SessionThreadsPageViewProps> = ({
 							threadCount={threads.length}
 							toolCallCount={toolCallCount}
 							tokenUsageMetadata={session.token_usage_summary.metadata}
+							networkActivity={networkActivity}
 						/>
 					)}
 				</aside>
@@ -126,6 +135,7 @@ export const SessionThreadsPageView: FC<SessionThreadsPageViewProps> = ({
 							hasNextPage={hasNextPage}
 							isFetchingNextPage={isFetchingNextPage}
 							onFetchNextPage={onFetchNextPage}
+							networkActivity={networkActivity}
 						/>
 					) : (
 						loading && <SessionTimelineSkeleton />

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/SessionTimeline.stories.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/SessionTimeline.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { AIBridgeThread } from "#/api/typesGenerated";
 import { MockSession } from "#/testHelpers/entities";
+import { mockNetworkActivity } from "../NetworkActivity/mocks";
 import { SessionTimeline } from "./SessionTimeline";
 
 // A thread with one thinking block and one tool call.
@@ -141,4 +142,18 @@ export const MultipleThreads: Story = {
 
 export const FetchingNextPage: Story = {
 	args: { hasNextPage: true, isFetchingNextPage: true },
+};
+
+export const WithNetworkActivity: Story = {
+	args: {
+		threads: [mockThread, mockThreadLong],
+		networkActivity: mockNetworkActivity("mixed"),
+	},
+};
+
+export const WithNetworkActivityErrorOnly: Story = {
+	args: {
+		threads: [mockThread],
+		networkActivity: mockNetworkActivity("error-only"),
+	},
 };

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/SessionTimeline.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/SessionTimeline.tsx
@@ -20,6 +20,8 @@ import {
 import { cn } from "#/utils/cn";
 import { docs } from "#/utils/docs";
 import { JsonPrettyPrinter } from "../../JsonPrettyPrinter";
+import { NetworkActivityButton } from "../NetworkActivity/NetworkActivityButton";
+import type { NetworkActivity } from "../NetworkActivity/types";
 import { AgenticLoopTable } from "./AgenticLoopTable";
 import { PromptTable } from "./PromptTable";
 import { ToolCallTable } from "./ToolCallTable";
@@ -411,6 +413,7 @@ interface SessionTimelineProps {
 	hasNextPage: boolean;
 	isFetchingNextPage: boolean;
 	onFetchNextPage: () => void;
+	networkActivity?: NetworkActivity;
 }
 
 export const SessionTimeline: FC<SessionTimelineProps> = ({
@@ -419,6 +422,7 @@ export const SessionTimeline: FC<SessionTimelineProps> = ({
 	hasNextPage,
 	isFetchingNextPage,
 	onFetchNextPage,
+	networkActivity,
 }) => {
 	const sentinelRef = useRef<HTMLDivElement>(null);
 
@@ -524,6 +528,11 @@ export const SessionTimeline: FC<SessionTimelineProps> = ({
 					{/* left vertical line */}
 				</div>
 				<div className="row-start-5 col-start-2 col-span-4">
+					{networkActivity && networkActivity.events.length > 0 && (
+						<div className="flex items-center mb-2">
+							<NetworkActivityButton networkActivity={networkActivity} />
+						</div>
+					)}
 					{/* threads */}
 					<div className="[&>.thread-gap:last-child]:hidden">
 						{threads.map((thread) => (


### PR DESCRIPTION
Visual-only addition to the individual AI session page at `/ai-gateway/sessions/:id`. No backend changes. Stays decoupled from the generated SDK types so backend wiring can land separately.

## What changed

**Session summary side panel** — new `Network` row that renders one of four states based on the counts:

- _No activity_ — secondary text only.
- _All allowed_ — single line, e.g. `12 allowed` with a success check.
- _Mixed_ — stacked right-aligned lines, one per non-zero count (`3 allowed`, `3 warnings`, `1 error`).
- _Error only_ — single line, e.g. `1 error` with a destructive triangle. Used when the only event is a mid-session boundary failure (or a failure that happened before any request was recorded).

**Session timeline** — `Network activity (N)` button at the top of the timeline opens a Popover dialog with:

- Header with the total count and per-severity sub-counts (`allowed`, `warnings`, `errors`).
- One row per event: chevron, method badge (`GET`/`POST`/…), status badge (`Allowed`/`Blocked`), truncated URL with `title` tooltip.
- A distinct `Network Error` row variant for boundary failures (red `destructive` badge, free-form detail text, description paragraph when expanded).
- Per-row expand/collapse, revealing `Start time`, `Policy`, `Error`, and a `View policy configuration` link.
- Anchored to the trigger with `side="bottom"`; Radix auto-flips it above when there is not enough room. `max-height: var(--radix-popper-available-height)` plus internal `overflow-y-auto` on the list keeps the header visible and the dialog from ever being cut off in small viewports.
- Width caps at `min(36rem, calc(100vw - 2rem))` so it adapts on narrow screens. Long URLs truncate with `…` and surface in a hover title.
- Hidden entirely when there are zero events.

## Mock data strategy

No backend wiring exists yet, so events are generated client-side from a small set of fixtures in `NetworkActivity/mocks.ts`. The variant is picked deterministically from a hash of the session ID, which means different sessions on the live page render different states for manual QA without anyone touching code. Storybook still has explicit stories for every state.

Swapping to real data later is a single-spot change: replace `mockNetworkActivityForSession(session.id)` in `SessionThreadsPageView.tsx` with the eventual data source. The `NetworkActivity` shape lives in `NetworkActivity/types.ts` and is intentionally decoupled from `codersdk`.

## Validation

- `pnpm lint` (biome lint, tsc, dpdm, knip, compiler check) clean on `site`.
- `pnpm test:storybook` passes for all four touched story files (21 tests, including play interactions that open the popover for each variant).

<details>
<summary>Storybook coverage</summary>

- `pages/AIBridgePage/NetworkActivity/Summary` — NoActivity, AllAllowed, Mixed, ErrorOnly, MidSessionFailure, Many
- `pages/AIBridgePage/NetworkActivity/Button` — AllAllowed, Mixed, ErrorOnly, MidSessionFailure, Many, HiddenWhenEmpty (with play functions that open the popover and assert the dialog renders)
- `pages/AIBridgePage/SessionSummaryTable` — adds NetworkNoActivity, NetworkAllAllowed, NetworkMixed, NetworkErrorOnly, NetworkMidSessionFailure on top of the existing stories
- `pages/AIBridgePage/SessionTimeline` — adds WithNetworkActivity, WithNetworkActivityErrorOnly

</details>

<details>
<summary>Files touched</summary>

New:

- `site/src/pages/AIBridgePage/SessionThreadsPage/NetworkActivity/types.ts`
- `site/src/pages/AIBridgePage/SessionThreadsPage/NetworkActivity/mocks.ts`
- `site/src/pages/AIBridgePage/SessionThreadsPage/NetworkActivity/NetworkSummary.tsx` (+ stories)
- `site/src/pages/AIBridgePage/SessionThreadsPage/NetworkActivity/NetworkActivityButton.tsx` (+ stories)

Modified:

- `site/src/pages/AIBridgePage/SessionThreadsPage/SessionSummaryTable.tsx` (+ stories) — accepts `networkActivity` and renders the new row.
- `site/src/pages/AIBridgePage/SessionThreadsPage/SessionThreadsPageView.tsx` — generates the mock activity once per session and passes it to both the side panel and the timeline.
- `site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/SessionTimeline.tsx` (+ stories) — accepts `networkActivity` and mounts the button above the threads.

</details>

Generated with the help of Coder Agents.