### PR TITLE
feat: add CODER_CLUSTER_HOST CLI argument

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -964,6 +964,9 @@ These options are only available in the Enterprise Edition.
       --browser-only bool, $CODER_BROWSER_ONLY
           Whether Coder only allows connections to workspaces via the browser.
 
+      --cluster-host string, $CODER_CLUSTER_HOST
+          Hostname or (more commonly) IP to reach this replica for clustering.
+
       --derp-server-relay-url url, $CODER_DERP_SERVER_RELAY_URL
           An HTTP URL that is accessible by other replicas to relay DERP
           traffic. Required for high availability.

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -190,6 +190,13 @@ networking:
   # Whether Coder only allows connections to workspaces via the browser.
   # (default: <unset>, type: bool)
   browserOnly: false
+  # Configure network clustering. Coder Servers in the primary region form a cluster
+  # by
+  # communicating directly.
+  cluster:
+    # Hostname or (more commonly) IP to reach this replica for clustering.
+    # (default: <unset>, type: string)
+    clusterHost: ""
 # Interval to poll for scheduled workspace builds.
 # (default: 1m0s, type: duration)
 autobuildPollInterval: 1m0s

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -1455,6 +1455,13 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
  Tailscale and WireGuard.`,
 			YAML: "derp",
 		}
+		deploymentGroupNetworkingCluster = serpent.Group{
+			Parent: &deploymentGroupNetworking,
+			Name:   "Cluster",
+			Description: `Configure network clustering. Coder Servers in the primary region form a cluster by
+communicating directly.`,
+			YAML: "cluster",
+		}
 		deploymentGroupIntrospection = serpent.Group{
 			Name:        "Introspection",
 			Description: `Configure logging, tracing, stat collection, and metrics exporting.`,
@@ -3575,6 +3582,16 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			Value:       &c.BrowserOnly,
 			Group:       &deploymentGroupNetworking,
 			YAML:        "browserOnly",
+		},
+		{
+			Name:        "Cluster Host",
+			Description: "Hostname or (more commonly) IP to reach this replica for clustering.",
+			Flag:        "cluster-host",
+			Env:         "CODER_CLUSTER_HOST",
+			Annotations: serpent.Annotations{}.Mark(annotationEnterpriseKey, "true"),
+			Value:       &c.Cluster.Host,
+			Group:       &deploymentGroupNetworkingCluster,
+			YAML:        "clusterHost",
 		},
 		{
 			Name:        "SCIM API Key",

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1122,6 +1122,16 @@ The algorithm to use for generating ssh keys. Accepted values are "ed25519", "ec
 
 Whether Coder only allows connections to workspaces via the browser.
 
+### --cluster-host
+
+|             |                                             |
+|-------------|---------------------------------------------|
+| Type        | <code>string</code>                         |
+| Environment | <code>$CODER_CLUSTER_HOST</code>            |
+| YAML        | <code>networking.cluster.clusterHost</code> |
+
+Hostname or (more commonly) IP to reach this replica for clustering.
+
 ### --scim-auth-header
 
 |             |                                      |

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -965,6 +965,9 @@ These options are only available in the Enterprise Edition.
       --browser-only bool, $CODER_BROWSER_ONLY
           Whether Coder only allows connections to workspaces via the browser.
 
+      --cluster-host string, $CODER_CLUSTER_HOST
+          Hostname or (more commonly) IP to reach this replica for clustering.
+
       --derp-server-relay-url url, $CODER_DERP_SERVER_RELAY_URL
           An HTTP URL that is accessible by other replicas to relay DERP
           traffic. Required for high availability.

--- a/helm/coder/templates/_coder.tpl
+++ b/helm/coder/templates/_coder.tpl
@@ -94,6 +94,10 @@ env:
       fieldPath: status.podIP
 - name: CODER_DERP_SERVER_RELAY_URL
   value: "http://$(KUBE_POD_IP):8080"
+- name: CODER_CLUSTER_HOST
+  valueFrom:
+    fieldRef:
+      fieldPath: status.podIP
 {{- include "coder.tlsEnv" . }}
 {{- with .Values.coder.env }}
 {{ toYaml . }}

--- a/helm/coder/tests/testdata/auto_access_url_1.golden
+++ b/helm/coder/tests/testdata/auto_access_url_1.golden
@@ -162,6 +162,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: SOME_ENV
           value: some value
         - name: CODER_ACCESS_URL

--- a/helm/coder/tests/testdata/auto_access_url_1_coder.golden
+++ b/helm/coder/tests/testdata/auto_access_url_1_coder.golden
@@ -162,6 +162,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: SOME_ENV
           value: some value
         - name: CODER_ACCESS_URL

--- a/helm/coder/tests/testdata/auto_access_url_2.golden
+++ b/helm/coder/tests/testdata/auto_access_url_2.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: SOME_ENV
           value: some value
         image: ghcr.io/coder/coder:latest

--- a/helm/coder/tests/testdata/auto_access_url_2_coder.golden
+++ b/helm/coder/tests/testdata/auto_access_url_2_coder.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: SOME_ENV
           value: some value
         image: ghcr.io/coder/coder:latest

--- a/helm/coder/tests/testdata/auto_access_url_3.golden
+++ b/helm/coder/tests/testdata/auto_access_url_3.golden
@@ -162,6 +162,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: SOME_ENV
           value: some value
         image: ghcr.io/coder/coder:latest

--- a/helm/coder/tests/testdata/auto_access_url_3_coder.golden
+++ b/helm/coder/tests/testdata/auto_access_url_3_coder.golden
@@ -162,6 +162,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: SOME_ENV
           value: some value
         image: ghcr.io/coder/coder:latest

--- a/helm/coder/tests/testdata/command.golden
+++ b/helm/coder/tests/testdata/command.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/command_args.golden
+++ b/helm/coder/tests/testdata/command_args.golden
@@ -165,6 +165,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/command_args_coder.golden
+++ b/helm/coder/tests/testdata/command_args_coder.golden
@@ -165,6 +165,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/command_coder.golden
+++ b/helm/coder/tests/testdata/command_coder.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/custom_resources.golden
+++ b/helm/coder/tests/testdata/custom_resources.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/custom_resources_coder.golden
+++ b/helm/coder/tests/testdata/custom_resources_coder.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/default_values.golden
+++ b/helm/coder/tests/testdata/default_values.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/default_values_coder.golden
+++ b/helm/coder/tests/testdata/default_values_coder.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/env_from.golden
+++ b/helm/coder/tests/testdata/env_from.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: COOL_ENV
           valueFrom:
             configMapKeyRef:

--- a/helm/coder/tests/testdata/env_from_coder.golden
+++ b/helm/coder/tests/testdata/env_from_coder.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: COOL_ENV
           valueFrom:
             configMapKeyRef:

--- a/helm/coder/tests/testdata/extra_templates.golden
+++ b/helm/coder/tests/testdata/extra_templates.golden
@@ -173,6 +173,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/extra_templates_coder.golden
+++ b/helm/coder/tests/testdata/extra_templates_coder.golden
@@ -173,6 +173,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/host_aliases.golden
+++ b/helm/coder/tests/testdata/host_aliases.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/host_aliases_coder.golden
+++ b/helm/coder/tests/testdata/host_aliases_coder.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/labels_annotations.golden
+++ b/helm/coder/tests/testdata/labels_annotations.golden
@@ -172,6 +172,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/labels_annotations_coder.golden
+++ b/helm/coder/tests/testdata/labels_annotations_coder.golden
@@ -172,6 +172,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/namespace_rbac.golden
+++ b/helm/coder/tests/testdata/namespace_rbac.golden
@@ -354,6 +354,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/namespace_rbac_coder.golden
+++ b/helm/coder/tests/testdata/namespace_rbac_coder.golden
@@ -354,6 +354,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/partial_resources.golden
+++ b/helm/coder/tests/testdata/partial_resources.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/partial_resources_coder.golden
+++ b/helm/coder/tests/testdata/partial_resources_coder.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/pod_securitycontext.golden
+++ b/helm/coder/tests/testdata/pod_securitycontext.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/pod_securitycontext_coder.golden
+++ b/helm/coder/tests/testdata/pod_securitycontext_coder.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/pprof_address_override.golden
+++ b/helm/coder/tests/testdata/pprof_address_override.golden
@@ -162,6 +162,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: CODER_PPROF_ADDRESS
           value: 127.0.0.1:6060
         - name: CODER_PPROF_ENABLE

--- a/helm/coder/tests/testdata/pprof_address_override_coder.golden
+++ b/helm/coder/tests/testdata/pprof_address_override_coder.golden
@@ -162,6 +162,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: CODER_PPROF_ADDRESS
           value: 127.0.0.1:6060
         - name: CODER_PPROF_ENABLE

--- a/helm/coder/tests/testdata/priority_class_name.golden
+++ b/helm/coder/tests/testdata/priority_class_name.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/priority_class_name_coder.golden
+++ b/helm/coder/tests/testdata/priority_class_name_coder.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/probes_custom.golden
+++ b/helm/coder/tests/testdata/probes_custom.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/probes_custom_coder.golden
+++ b/helm/coder/tests/testdata/probes_custom_coder.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/probes_disabled.golden
+++ b/helm/coder/tests/testdata/probes_disabled.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/probes_disabled_coder.golden
+++ b/helm/coder/tests/testdata/probes_disabled_coder.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/prometheus.golden
+++ b/helm/coder/tests/testdata/prometheus.golden
@@ -163,6 +163,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: CODER_PROMETHEUS_ENABLE
           value: "true"
         image: ghcr.io/coder/coder:latest

--- a/helm/coder/tests/testdata/prometheus_address_override.golden
+++ b/helm/coder/tests/testdata/prometheus_address_override.golden
@@ -162,6 +162,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: CODER_PROMETHEUS_ADDRESS
           value: 127.0.0.1:2112
         - name: CODER_PROMETHEUS_ENABLE

--- a/helm/coder/tests/testdata/prometheus_address_override_coder.golden
+++ b/helm/coder/tests/testdata/prometheus_address_override_coder.golden
@@ -162,6 +162,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: CODER_PROMETHEUS_ADDRESS
           value: 127.0.0.1:2112
         - name: CODER_PROMETHEUS_ENABLE

--- a/helm/coder/tests/testdata/prometheus_coder.golden
+++ b/helm/coder/tests/testdata/prometheus_coder.golden
@@ -163,6 +163,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: CODER_PROMETHEUS_ENABLE
           value: "true"
         image: ghcr.io/coder/coder:latest

--- a/helm/coder/tests/testdata/provisionerd_psk.golden
+++ b/helm/coder/tests/testdata/provisionerd_psk.golden
@@ -169,6 +169,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/provisionerd_psk_coder.golden
+++ b/helm/coder/tests/testdata/provisionerd_psk_coder.golden
@@ -169,6 +169,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/sa.golden
+++ b/helm/coder/tests/testdata/sa.golden
@@ -166,6 +166,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/sa_coder.golden
+++ b/helm/coder/tests/testdata/sa_coder.golden
@@ -166,6 +166,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/sa_disabled.golden
+++ b/helm/coder/tests/testdata/sa_disabled.golden
@@ -150,6 +150,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/sa_disabled_coder.golden
+++ b/helm/coder/tests/testdata/sa_disabled_coder.golden
@@ -150,6 +150,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/sa_extra_rules.golden
+++ b/helm/coder/tests/testdata/sa_extra_rules.golden
@@ -177,6 +177,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/sa_extra_rules_coder.golden
+++ b/helm/coder/tests/testdata/sa_extra_rules_coder.golden
@@ -177,6 +177,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/securitycontext.golden
+++ b/helm/coder/tests/testdata/securitycontext.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/securitycontext_coder.golden
+++ b/helm/coder/tests/testdata/securitycontext_coder.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/svc_loadbalancer.golden
+++ b/helm/coder/tests/testdata/svc_loadbalancer.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/svc_loadbalancer_class.golden
+++ b/helm/coder/tests/testdata/svc_loadbalancer_class.golden
@@ -165,6 +165,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/svc_loadbalancer_class_coder.golden
+++ b/helm/coder/tests/testdata/svc_loadbalancer_class_coder.golden
@@ -165,6 +165,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/svc_loadbalancer_coder.golden
+++ b/helm/coder/tests/testdata/svc_loadbalancer_coder.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/svc_nodeport.golden
+++ b/helm/coder/tests/testdata/svc_nodeport.golden
@@ -163,6 +163,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/svc_nodeport_coder.golden
+++ b/helm/coder/tests/testdata/svc_nodeport_coder.golden
@@ -163,6 +163,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/tls.golden
+++ b/helm/coder/tests/testdata/tls.golden
@@ -169,6 +169,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: CODER_TLS_ENABLE
           value: "true"
         - name: CODER_TLS_ADDRESS

--- a/helm/coder/tests/testdata/tls_coder.golden
+++ b/helm/coder/tests/testdata/tls_coder.golden
@@ -169,6 +169,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: CODER_TLS_ENABLE
           value: "true"
         - name: CODER_TLS_ADDRESS

--- a/helm/coder/tests/testdata/topology.golden
+++ b/helm/coder/tests/testdata/topology.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/topology_coder.golden
+++ b/helm/coder/tests/testdata/topology_coder.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/workspace_proxy.golden
+++ b/helm/coder/tests/testdata/workspace_proxy.golden
@@ -165,6 +165,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: CODER_PRIMARY_ACCESS_URL
           value: https://dev.coder.com
         - name: CODER_PROXY_SESSION_TOKEN

--- a/helm/coder/tests/testdata/workspace_proxy_coder.golden
+++ b/helm/coder/tests/testdata/workspace_proxy_coder.golden
@@ -165,6 +165,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: CODER_PRIMARY_ACCESS_URL
           value: https://dev.coder.com
         - name: CODER_PROXY_SESSION_TOKEN

--- a/helm/coder/values.yaml
+++ b/helm/coder/values.yaml
@@ -12,6 +12,7 @@ coder:
   # - CODER_TLS_KEY_FILE: set if tls.secretName is not empty.
   # - KUBE_POD_IP
   # - CODER_DERP_SERVER_RELAY_URL
+  # - CODER_CLUSTER_HOST: set to the pod IP
   #
   # The following environment variables have defaults but CAN be overridden:
   # - CODER_PROMETHEUS_ADDRESS: defaults to 0.0.0.0:2112. Override to restrict


### PR DESCRIPTION
Closes GRU-69

Adds CODER_CLUSTER_HOST enviroment variable and CLI arg.

I ended up not making it hidden since we'll just have to unhide it later and even when hidden it still shows up in some autogenerated stuff. Might as well just go for it.

I also added it to the helm chart.