### PR TITLE
fix(site/src/pages/AISettingsPage/LifecyclePage): use content-primary for DaysField number

### DIFF
--- a/site/src/pages/AISettingsPage/LifecyclePage/components/LifecycleSettingLayout.tsx
+++ b/site/src/pages/AISettingsPage/LifecyclePage/components/LifecycleSettingLayout.tsx
@@ -123,7 +123,7 @@ export const DaysField: FC<DaysFieldProps> = ({
 				onBlur={onBlur}
 				aria-invalid={error}
 				disabled={disabled}
-				className="min-w-0 w-full border-none bg-transparent p-0 text-sm font-medium leading-6 text-content-placeholder outline-none disabled:cursor-not-allowed [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [-moz-appearance:textfield]"
+				className="min-w-0 w-full border-none bg-transparent p-0 text-sm font-medium leading-6 text-content-primary outline-none disabled:cursor-not-allowed [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [-moz-appearance:textfield]"
 			/>
 			<span className="shrink-0 text-xs font-normal leading-[18px] text-content-placeholder">
 				Days


### PR DESCRIPTION
Tweak in `/ai/settings/lifecycle`: the `DaysField` rendered the number as `text-content-placeholder`, so values like `30` read like an empty hint rather than a real value. The trailing `Days` text is just a static unit label and shouldn't track the value's color.

- Number input: `text-content-placeholder` → `text-content-primary`
- `Days` label: unchanged (`text-content-placeholder`)

Applies to every DaysField on the page: Workspace autostop, Auto-archive, Conversation retention, Debug retention.

---

> [!NOTE]
> 🤖 Opened by Coder Agents on behalf of @tracyjohnsonux.