### PR TITLE
fix(site): hide empty model provider configuration

### DIFF
--- a/site/src/pages/AISettingsPage/ModelsPage/AddModelPage/AddModelPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/AddModelPage/AddModelPageView.stories.tsx
@@ -3,6 +3,7 @@ import { expect, fn, userEvent, within } from "storybook/test";
 import { withToaster } from "#/testHelpers/storybook";
 import {
 	MockAnthropicProviderState,
+	MockCopilotProviderState,
 	MockOpenAIProviderState,
 } from "../testFixtures";
 import AddModelPageView from "./AddModelPageView";
@@ -51,6 +52,19 @@ export const WebSearchDependentFields: Story = {
 		const blocked = await canvas.findByLabelText(/blocked domains/i);
 		await userEvent.type(allowed, "example.com");
 		expect(blocked).toBeDisabled();
+	},
+};
+
+export const NoProviderConfigurationFields: Story = {
+	args: {
+		providerStates: [MockCopilotProviderState],
+		selectedProviderState: MockCopilotProviderState,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.queryByRole("button", { name: /provider configuration/i }),
+		).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormFields.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormFields.tsx
@@ -133,7 +133,7 @@ export const ModelFormFields: FC<{
 	showAdvanced,
 	setShowAdvanced,
 }) => {
-	const showProviderConfiguration =
+	const hasProviderConfigFields =
 		getVisibleProviderFields(selectedProviderState.provider).length > 0;
 
 	return (
@@ -257,7 +257,7 @@ export const ModelFormFields: FC<{
 						/>
 					</CollapsibleSection>
 
-					{showProviderConfiguration && (
+					{hasProviderConfigFields && (
 						<CollapsibleSection
 							title="Provider configuration"
 							description="Tune provider-specific behavior like reasoning, tool calling, and web search."

--- a/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormFields.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormFields.tsx
@@ -2,6 +2,7 @@ import type { FormikContextType } from "formik";
 import { ChevronDownIcon, ChevronRightIcon, InfoIcon } from "lucide-react";
 import type { FC, ReactNode } from "react";
 import { Link } from "react-router";
+import { getVisibleProviderFields } from "#/api/chatModelOptions";
 import type * as TypesGen from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
 import { Checkbox } from "#/components/Checkbox/Checkbox";
@@ -132,6 +133,9 @@ export const ModelFormFields: FC<{
 	showAdvanced,
 	setShowAdvanced,
 }) => {
+	const showProviderConfiguration =
+		getVisibleProviderFields(selectedProviderState.provider).length > 0;
+
 	return (
 		<div className="border border-solid p-6 rounded-lg">
 			<form
@@ -253,21 +257,23 @@ export const ModelFormFields: FC<{
 						/>
 					</CollapsibleSection>
 
-					<CollapsibleSection
-						title="Provider configuration"
-						description="Tune provider-specific behavior like reasoning, tool calling, and web search."
-						open={showProviderConfig}
-						onOpenChange={setShowProviderConfig}
-						className="border-0 border-t border-solid border-border"
-						contentClassName="pt-3 pl-6"
-					>
-						<ModelConfigFields
-							provider={selectedProviderState.provider}
-							form={form}
-							fieldErrors={modelConfigFormBuildResult.fieldErrors}
-							disabled={isSaving}
-						/>
-					</CollapsibleSection>
+					{showProviderConfiguration && (
+						<CollapsibleSection
+							title="Provider configuration"
+							description="Tune provider-specific behavior like reasoning, tool calling, and web search."
+							open={showProviderConfig}
+							onOpenChange={setShowProviderConfig}
+							className="border-0 border-t border-solid border-border"
+							contentClassName="pt-3 pl-6"
+						>
+							<ModelConfigFields
+								provider={selectedProviderState.provider}
+								form={form}
+								fieldErrors={modelConfigFormBuildResult.fieldErrors}
+								disabled={isSaving}
+							/>
+						</CollapsibleSection>
+					)}
 
 					<CollapsibleSection
 						title="Advanced"

--- a/site/src/pages/AISettingsPage/ModelsPage/testFixtures.ts
+++ b/site/src/pages/AISettingsPage/ModelsPage/testFixtures.ts
@@ -82,3 +82,17 @@ export const MockAnthropicProviderState: ProviderState = {
 	providerConfig: MockAnthropicProviderConfig,
 	modelConfigs: [mockClaude],
 };
+
+export const MockCopilotProviderState: ProviderState = {
+	...MockOpenAIProviderState,
+	key: "prov-copilot",
+	provider: "copilot",
+	label: "GitHub Copilot",
+	providerConfig: {
+		...MockOpenAIProviderConfig,
+		id: "prov-copilot",
+		provider: "copilot",
+		display_name: "GitHub Copilot",
+	},
+	modelConfigs: [],
+};


### PR DESCRIPTION
Hide the model form's "Provider configuration" accordion when the selected provider has no visible provider-specific configuration fields.

Adds Storybook coverage with a Copilot provider fixture to verify the empty accordion segment is not rendered.

> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood
