### PR TITLE
feat(site): render Markdown in template variable descriptions

### DIFF
--- a/site/src/pages/CreateTemplatePage/CreateTemplatePage.test.tsx
+++ b/site/src/pages/CreateTemplatePage/CreateTemplatePage.test.tsx
@@ -124,10 +124,14 @@ test("Create template from duplicating a template", async () => {
 	);
 	// Variables are using the same values
 	expect(
-		screen.getByLabelText(MockTemplateVersionVariable1.description, {
+		screen.getByLabelText(`var.${MockTemplateVersionVariable1.name}`, {
 			exact: false,
 		}),
 	).toHaveValue(MockTemplateVersionVariable1.value);
+	// The variable description is rendered (as Markdown) alongside the field
+	expect(
+		screen.getByText(MockTemplateVersionVariable1.description),
+	).toBeInTheDocument();
 	// Create template
 	vi.spyOn(API, "createTemplateVersion").mockResolvedValue(MockTemplateVersion);
 	vi.spyOn(API, "getTemplateVersion").mockResolvedValue(MockTemplateVersion);

--- a/site/src/pages/CreateTemplatePage/VariableInput.stories.tsx
+++ b/site/src/pages/CreateTemplatePage/VariableInput.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, within } from "storybook/test";
+import type { TemplateVersionVariable } from "#/api/typesGenerated";
+import { VariableInput } from "./VariableInput";
+
+const baseVariable: TemplateVersionVariable = {
+	name: "region",
+	description: "The deployment region.",
+	type: "string",
+	value: "",
+	default_value: "us-east-1",
+	required: false,
+	sensitive: false,
+};
+
+const meta: Meta<typeof VariableInput> = {
+	title: "pages/CreateTemplatePage/VariableInput",
+	component: VariableInput,
+	args: {
+		onChange: fn(),
+		variable: baseVariable,
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof VariableInput>;
+
+export const PlainDescription: Story = {};
+
+export const MarkdownDescription: Story = {
+	args: {
+		variable: {
+			...baseVariable,
+			name: "bingbong",
+			description:
+				"I am trying [markdown](https://google.com) with **bold** and `code`.",
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// The Markdown link renders as an anchor pointing at the URL.
+		const link = canvas.getByRole("link", { name: /markdown/i });
+		await expect(link).toHaveAttribute("href", "https://google.com");
+		// Inline formatting renders rather than showing raw Markdown syntax.
+		await expect(canvas.queryByText(/\[markdown\]/)).not.toBeInTheDocument();
+	},
+};
+
+export const Optional: Story = {
+	args: {
+		variable: {
+			...baseVariable,
+			name: "docker_socket",
+			description: "(Optional) Docker socket URI",
+		},
+	},
+};

--- a/site/src/pages/CreateTemplatePage/VariableInput.tsx
+++ b/site/src/pages/CreateTemplatePage/VariableInput.tsx
@@ -4,6 +4,7 @@ import RadioGroup from "@mui/material/RadioGroup";
 import TextField from "@mui/material/TextField";
 import type { FC } from "react";
 import type { TemplateVersionVariable } from "#/api/typesGenerated";
+import { MemoizedMarkdown } from "#/components/Markdown/Markdown";
 
 const isBoolean = (variable: TemplateVersionVariable) => {
 	return variable.type === "bool";
@@ -13,17 +14,32 @@ interface VariableLabelProps {
 	variable: TemplateVersionVariable;
 }
 
+const descriptionId = (variable: TemplateVersionVariable) =>
+	`${variable.name}-description`;
+
 const VariableLabel: FC<VariableLabelProps> = ({ variable }) => {
 	return (
-		<label htmlFor={variable.name}>
-			<span className="mb-1 block text-sm text-content-secondary">
-				var.{variable.name}
-				{!variable.required && " (optional)"}
-			</span>
-			<span className="block text-base font-semibold text-content-primary">
-				{variable.description}
-			</span>
-		</label>
+		<div className="flex flex-col">
+			<label htmlFor={variable.name}>
+				<span className="block text-sm text-content-secondary">
+					var.{variable.name}
+					{!variable.required && " (optional)"}
+				</span>
+			</label>
+			{/*
+			 * The description is rendered as Markdown and kept outside the <label>
+			 * so interactive content like links is not nested inside it (which would
+			 * steal clicks meant for the link to focus the field). It is associated
+			 * with the field via aria-describedby instead.
+			 */}
+			{variable.description && (
+				<div id={descriptionId(variable)}>
+					<MemoizedMarkdown className="mt-1 text-base font-semibold text-content-primary">
+						{variable.description}
+					</MemoizedMarkdown>
+				</div>
+			)}
+		</div>
 	);
 };
 
@@ -65,6 +81,9 @@ const VariableField: FC<VariableInputProps> = ({
 		return (
 			<RadioGroup
 				id={variable.name}
+				aria-describedby={
+					variable.description ? descriptionId(variable) : undefined
+				}
 				defaultValue={variable.default_value}
 				onChange={(event) => {
 					onChange(event.target.value);
@@ -90,6 +109,9 @@ const VariableField: FC<VariableInputProps> = ({
 		<TextField
 			autoComplete="off"
 			id={variable.name}
+			aria-describedby={
+				variable.description ? descriptionId(variable) : undefined
+			}
 			size="small"
 			disabled={disabled}
 			placeholder={variable.sensitive ? "" : variable.default_value}

--- a/site/src/pages/TemplateBuilder/ModuleSettingsStep.stories.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleSettingsStep.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, within } from "storybook/test";
+import { templateBuilderModules } from "#/api/queries/templateBuilder";
+import type { TemplateBuilderModulesResponse } from "#/api/typesGenerated";
+import { ModuleSettingsStep } from "./ModuleSettingsStep";
+
+const BASE_ID = "docker";
+
+const modulesResponse: TemplateBuilderModulesResponse = {
+	modules: [
+		{
+			id: "code-server",
+			display_name: "code-server",
+			description: "Run VS Code in the browser.",
+			icon: "/icon/code.svg",
+			category: "IDE",
+			version: "1.0.0",
+			compatible_os: ["linux"],
+			conflicts_with: [],
+			variables: [
+				{
+					name: "folder",
+					type: "string",
+					description:
+						"The [folder](https://coder.com/docs) to open in **code-server**.",
+					required: true,
+					sensitive: false,
+				},
+				{
+					name: "install_prerelease",
+					type: "bool",
+					description: "Install the `--prerelease` build instead of stable.",
+					required: false,
+					sensitive: false,
+				},
+			],
+		},
+	],
+};
+
+const meta: Meta<typeof ModuleSettingsStep> = {
+	title: "pages/TemplateBuilder/ModuleSettingsStep",
+	component: ModuleSettingsStep,
+	parameters: {
+		queries: [
+			{
+				key: templateBuilderModules(BASE_ID).queryKey,
+				data: modulesResponse,
+			},
+		],
+	},
+	args: {
+		baseId: BASE_ID,
+		selectedModuleIds: ["code-server"],
+		moduleVariables: {},
+		onChangeModuleVariables: fn(),
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof ModuleSettingsStep>;
+
+export const Default: Story = {};
+
+export const MarkdownDescription: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// The variable description renders Markdown, so the link becomes an anchor.
+		const link = await canvas.findByRole("link", { name: /folder/i });
+		await expect(link).toHaveAttribute("href", "https://coder.com/docs");
+		// Raw Markdown syntax is not shown to the user.
+		await expect(canvas.queryByText(/\[folder\]/)).not.toBeInTheDocument();
+	},
+};

--- a/site/src/pages/TemplateBuilder/ModuleSettingsStep.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleSettingsStep.tsx
@@ -7,6 +7,7 @@ import type {
 	TemplateBuilderModulesResponse,
 	TemplateBuilderModuleVariable,
 } from "#/api/typesGenerated";
+import { MemoizedMarkdown } from "#/components/Markdown/Markdown";
 import type { ConfigurationFieldDefinition } from "./ConfigurationField";
 import { ModuleConfiguration } from "./ModuleConfiguration";
 
@@ -27,13 +28,18 @@ function variableToField(
 	onChange: (name: string, value: string) => void,
 ): ConfigurationFieldDefinition {
 	const id = `mod-${moduleId}-${variable.name}`;
+	const description = variable.description ? (
+		<MemoizedMarkdown className="text-xs text-content-secondary">
+			{variable.description}
+		</MemoizedMarkdown>
+	) : undefined;
 
 	if (variable.type === "bool") {
 		return {
 			type: "switch",
 			id,
 			label: variable.name,
-			description: variable.description || undefined,
+			description,
 			required: variable.required,
 			checked: value === "true",
 			onCheckedChange: (checked) =>
@@ -45,7 +51,7 @@ function variableToField(
 		type: "text",
 		id,
 		label: variable.name,
-		description: variable.description || undefined,
+		description,
 		required: variable.required,
 		placeholder: variable.required ? "Required" : "Optional",
 		field: {


### PR DESCRIPTION
Template variable `description`s are plain Terraform strings, so a description like `"I am trying [markdown](https://google.com)"` shows up verbatim (brackets, parens, and all) wherever we surface it. Dynamic parameter descriptions already render as Markdown via `MemoizedMarkdown`; this brings template variables to parity.

This covers all three places a variable description is shown:

- **Create template** form (`CreateTemplateForm` → `VariableInput`)
- **Template editor** "Template variables" dialog (`MissingTemplateVariablesDialog` → `VariableInput`)
- **Template Builder** wizard module settings (`ModuleSettingsStep` → `ConfigurationField`)

No backend changes — the description already reaches the client on `TemplateVersionVariable` and `TemplateBuilderModuleVariable`.

## Changes

- `VariableInput`: render the description with `MemoizedMarkdown`. The description is moved out of the `<label>` and associated with the field via `aria-describedby`, so Markdown links don't sit inside the label (which would steal the click to focus the field instead). Covers the create form and the editor's missing-variables dialog, which share this component.
- `ModuleSettingsStep.variableToField`: wrap the module variable description in `MemoizedMarkdown` (the builder's `ConfigurationField`/`FormField` already render `description` as a `ReactNode`).
- Stories: new `VariableInput.stories.tsx` and `ModuleSettingsStep.stories.tsx` with `play` functions asserting a Markdown link renders as an anchor and raw `[markdown]` syntax is not shown.
- Update the existing `CreateTemplatePage` duplicate-template test, which previously located the field by its description text (the description is now a separate, `aria-describedby`-linked node rather than the label).

## Verification

- `biome check --error-on-warnings` clean on all changed files
- `tsc -p .` clean
- `vitest --project=unit CreateTemplatePage` — 3 passed
- `vitest --project=storybook VariableInput ModuleSettingsStep` — 5 passed (includes the Markdown-link assertions for both surfaces)

<details>
<summary>Implementation notes</summary>

- Both surfaces converge on the existing `MemoizedMarkdown` component (full GFM: links, code, bold, tables, alert callouts), so there's no new rendering infrastructure and behavior stays consistent with dynamic parameters.
- The description keeps its existing visual weight in `VariableInput` (`text-base font-semibold`); `Markdown.tsx`'s `p:only-child { margin: 0 }` rule keeps single-line descriptions from gaining block spacing.
- The main non-trivial bit is accessibility: the old markup used the description as the field's label text, which is why a Markdown link inside `<label>` was a problem. The field is now labeled by `var.<name>` and the description is linked via `aria-describedby`.
- No running-UI screenshots here; the Storybook stories double as the visual/interaction coverage per the frontend guidelines.

</details>

---

🤖 Generated with Coder Agents on behalf of @bpmct