### PR TITLE
chore(aibridge): update comments from AI Bridge to AI Gateway

### DIFF
--- a/aibridge/AGENTS.md
+++ b/aibridge/AGENTS.md
@@ -13,7 +13,7 @@
 
 ## Architecture Overview
 
-AI Bridge is a smart gateway that sits between AI clients (Claude Code,
+AI Gateway is a smart gateway that sits between AI clients (Claude Code,
 Cursor, etc.) and upstream providers (Anthropic, OpenAI). It intercepts
 all AI traffic to provide centralized authn/z, auditing, token
 attribution, and MCP tool administration. It runs as part of `coderd`

--- a/aibridge/README.md
+++ b/aibridge/README.md
@@ -2,7 +2,7 @@
 
 aibridge provides an HTTP handler that intercepts AI client requests bound for upstream AI providers (Anthropic, OpenAI, Copilot). It records token usage, prompts, and tool invocations per user. Optionally supports centralized [MCP](https://modelcontextprotocol.io/) tool injection with allowlist/denylist filtering.
 
-The handler is mounted by a host process. Today that host is `coderd`, which [mounts the handler](../enterprise/coderd/coderd.go#L294) at `/api/v2/aibridge/<provider>/*`. Running aibridge as a separate process is planned for the future.
+The handler is mounted by a host process. Today that host is `coderd`, which [mounts the handler](../enterprise/coderd/coderd.go#L294) at `/api/v2/ai-gateway/<provider>/*`. Running aibridge as a separate process is planned for the future.
 
 ## Architecture
 
@@ -92,7 +92,7 @@ type Recorder interface {
 
 ## Supported Routes
 
-Each provider instance is mounted under `/api/v2/aibridge/<name>`, where `<name>` is the provider's configured name. For example, with an Anthropic provider named `my-anthropic`, its `/messages` endpoint would be reachable at `/api/v2/aibridge/my-anthropic/v1/messages`.
+Each provider instance is mounted under `/api/v2/ai-gateway/<name>`, where `<name>` is the provider's configured name. For example, with an Anthropic provider named `my-anthropic`, its `/messages` endpoint would be reachable at `/api/v2/ai-gateway/my-anthropic/v1/messages`.
 
 If a name is not set, the route path defaults to the provider's type: `anthropic`, `openai`, or `copilot`. The table below uses the default names.
 

--- a/aibridge/bridge.go
+++ b/aibridge/bridge.go
@@ -33,7 +33,7 @@ const (
 	// The duration after which an async recording will be aborted.
 	recordingTimeout = time.Second * 5
 
-	// maxRequestBodyBytes caps the request body size for AI Bridge
+	// maxRequestBodyBytes caps the request body size for AI Gateway
 	// provider endpoints to prevent denial-of-service via memory exhaustion.
 	// Anthropic enforces 32 MB on the direct API, 30 MB on Vertex AI,
 	// and 20 MB on Amazon Bedrock.

--- a/aibridge/intercept/client_headers.go
+++ b/aibridge/intercept/client_headers.go
@@ -5,7 +5,7 @@ import (
 )
 
 // hopByHopHeaders are connection-level headers specific to the connection
-// between client and AI Bridge, not meant for the upstream.
+// between client and AI Gateway, not meant for the upstream.
 // See https://www.rfc-editor.org/rfc/rfc2616#section-13.5.1
 var hopByHopHeaders = []string{
 	"Connection",

--- a/aibridge/intercept/messages/base.go
+++ b/aibridge/intercept/messages/base.go
@@ -350,7 +350,7 @@ func (i *interceptionBase) augmentRequestForBedrock() {
 		// since Bedrock returns 400 for these models when the legacy shape is
 		// used. Claude Code falls back to the legacy shape when it cannot
 		// read the upstream model's capability metadata (which is the case
-		// when AI Bridge is in the path).
+		// when AI Gateway is in the path).
 		updated, err = i.reqPayload.convertEnabledThinkingForBedrock()
 		if err != nil {
 			i.logger.Warn(context.Background(), "failed to convert enabled thinking for Bedrock", slog.Error(err))

--- a/aibridge/intercept/messages/reqpayload.go
+++ b/aibridge/intercept/messages/reqpayload.go
@@ -340,7 +340,7 @@ func (RequestPayload) resultToRawMessage(items []gjson.Result) []json.RawMessage
 }
 
 // The two Bedrock thinking-type conversions below are a temporary shim.
-// AI Bridge relays the Anthropic Messages API shape to Bedrock, whose Claude
+// AI Gateway relays the Anthropic Messages API shape to Bedrock, whose Claude
 // models accept a disjoint subset on each generation (older models reject
 // "adaptive"; Opus 4.7+ rejects "enabled"). A planned native Bedrock provider
 // removes the impedance mismatch and lets us delete this whole block. Hopefully.

--- a/aibridge/intercept/responses/base.go
+++ b/aibridge/intercept/responses/base.go
@@ -123,7 +123,7 @@ func (i *responsesInterceptionBase) baseTraceAttributes(r *http.Request, streami
 
 func (i *responsesInterceptionBase) validateRequest(ctx context.Context, w http.ResponseWriter) error {
 	if i.reqPayload.background() {
-		err := xerrors.New("background requests are currently not supported by AI Bridge")
+		err := xerrors.New("background requests are currently not supported by AI Gateway")
 		i.sendCustomErr(ctx, w, http.StatusNotImplemented, err)
 		return err
 	}
@@ -389,7 +389,7 @@ type responseCopier struct {
 	// this closer to makes sure whole response body is in the buffer.
 	responseBody io.ReadCloser
 
-	// responseReceived flag is used to determine if AI Bridge needs to write custom error:
+	// responseReceived flag is used to determine if AI Gateway needs to write custom error:
 	// - If responseReceived is true, the upstream response is forwarded as-is.
 	// - If responseReceived is false, no response was returned and there is nothing to forward (eg. connection/client error). Custom error will be returned.
 	responseReceived atomic.Bool

--- a/aibridge/internal/integrationtest/responses_internal_test.go
+++ b/aibridge/internal/integrationtest/responses_internal_test.go
@@ -430,7 +430,7 @@ func TestResponsesBackgroundModeForbidden(t *testing.T) {
 
 			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
-			requireResponsesError(t, http.StatusNotImplemented, "background requests are currently not supported by AI Bridge", body)
+			requireResponsesError(t, http.StatusNotImplemented, "background requests are currently not supported by AI Gateway", body)
 		})
 	}
 }

--- a/aibridge/provider/provider.go
+++ b/aibridge/provider/provider.go
@@ -23,29 +23,29 @@ var ErrNoCredential = xerrors.New("no credential: request is not BYOK and the pr
 // Bridged routes are processed by dedicated interceptors.
 //
 // All routes have following pattern:
-//   - https://coder.host.com/api/v2 + /aibridge        + /{provider.RoutePrefix()}  + /{bridged or passthrough route}
-//     {host}                          {aibridge root}    {provider prefix}            {provider route}
+//   - https://coder.host.com/api/v2 + /ai-gateway      + /{provider.RoutePrefix()}  + /{bridged or passthrough route}
+//     {host}                          {ai-gateway root}   {provider prefix}            {provider route}
 //
-// {host} + {aibridge root} + {provider prefix} form the base URL used in tools/clients using AI Bridge (eg. Claude/Codex).
+// {host} + {ai-gateway root} + {provider prefix} form the base URL used in tools/clients using AI Gateway (e.g. Claude/Codex).
 //
 // When request is bridged, interceptor created based on route processes the request.
-// When request is passed through the {host} + {aibridge root} + {provider prefix} URL part
+// When request is passed through the {host} + {ai-gateway root} + {provider prefix} URL part
 // is replaced by provider's base URL and request is forwarded.
 // This mirrors behavior in bridged routes and SDKs used by interceptors.
 //
 // Example:
 //
 //   - OpenAI chat completions
-//     AI Bridge base URL (set in Codex): "https://host.coder.com/api/v2/aibridge/openai/v1"
+//     AI Gateway base URL (set in Codex): "https://host.coder.com/api/v2/ai-gateway/openai/v1"
 //     Upstream base URl (set in coder config): http://api.openai.com/v1
-//     Request: Codex -> https://host.coder.com/api/v2/aibridge/openai/v1/chat/completions -> AI Bridge -> http://api.openai.com/v1/chat/completions
-//     url change: 'https://host.coder.com/api/v2/aibridge/openai/v1' -> 'http://api.openai.com/v1' | '/chat/completions' suffix remains the same
+//     Request: Codex -> https://host.coder.com/api/v2/ai-gateway/openai/v1/chat/completions -> AI Gateway -> http://api.openai.com/v1/chat/completions
+//     url change: 'https://host.coder.com/api/v2/ai-gateway/openai/v1' -> 'http://api.openai.com/v1' | '/chat/completions' suffix remains the same
 //
 //   - Anthropic messages
-//     AI Bridge base URL (set in Codex): "https://host.coder.com/api/v2/aibridge/anthropic"
+//     AI Gateway base URL (set in Codex): "https://host.coder.com/api/v2/ai-gateway/anthropic"
 //     Upstream base URl (set in coder config): http://api.anthropic.com
-//     Request: Codex -> https://host.coder.com/api/v2/aibridge/anthropic/v1/messages -> AI Bridge -> http://api.anthropic.com/v1/messages
-//     url change: 'https://host.coder.com/api/v2/aibridge/anthropic' -> 'http://api.anthropic.com' | '/v1/messages' suffix remains the same
+//     Request: Codex -> https://host.coder.com/api/v2/ai-gateway/anthropic/v1/messages -> AI Gateway -> http://api.anthropic.com/v1/messages
+//     url change: 'https://host.coder.com/api/v2/ai-gateway/anthropic' -> 'http://api.anthropic.com' | '/v1/messages' suffix remains the same
 //
 // !Note!
 // OpenAI and Anthropic use different route patterns.


### PR DESCRIPTION
## Description

Updates comments, error strings, and documentation within the `aibridge/` package to use the new AI Gateway naming, following the backend rename in #26475.

## Changes

- Update `aibridge/provider/provider.go` comment examples from `/aibridge` to `/ai-gateway` and "AI Bridge" to "AI Gateway"
- Update `aibridge/AGENTS.md` architecture description
- Update `aibridge/README.md` mount path examples from `/api/v2/aibridge/` to `/api/v2/ai-gateway/`
- Rename "AI Bridge" to "AI Gateway" in comments across `bridge.go`, `intercept/client_headers.go`, `intercept/responses/base.go`, `intercept/messages/base.go`, and `intercept/messages/reqpayload.go`
- Update error string in `intercept/responses/base.go` and matching test assertion

Addresses https://github.com/coder/coder/pull/26475#pullrequestreview-4544441981

Refs https://linear.app/codercom/issue/AIGOV-226

> Generated with the assistance of Coder Agents (@ssncferreira)