### PR TITLE
chore(scaletest): update AI Gateway URLs from /aibridge to /ai-gateway

### DIFF
--- a/cli/exp_scaletest_bridge.go
+++ b/cli/exp_scaletest_bridge.go
@@ -42,8 +42,8 @@ func (r *RootCmd) scaletestBridge() *serpent.Command {
 
 	cmd := &serpent.Command{
 		Use:   "bridge",
-		Short: "Generate load on the AI Bridge service.",
-		Long: `Generate load for AI Bridge testing. Supports two modes: 'bridge' mode routes requests through the Coder AI Bridge, 'direct' mode makes requests directly to an upstream URL (useful for baseline comparisons).
+		Short: "Generate load on the AI Gateway service.",
+		Long: `Generate load for AI Gateway testing. Supports two modes: 'bridge' mode routes requests through the Coder AI Gateway, 'direct' mode makes requests directly to an upstream URL (useful for baseline comparisons).
 
 Examples:
   # Test OpenAI API through bridge
@@ -100,7 +100,7 @@ Examples:
 				userConfig = createusers.Config{
 					OrganizationID: me.OrganizationIDs[0],
 				}
-				_, _ = fmt.Fprintln(inv.Stderr, "Bridge mode: creating users and making requests through AI Bridge...")
+				_, _ = fmt.Fprintln(inv.Stderr, "Bridge mode: creating users and making requests through AI Gateway...")
 			} else {
 				_, _ = fmt.Fprintf(inv.Stderr, "Direct mode: making requests directly to %s\n", upstreamURL)
 			}
@@ -210,7 +210,7 @@ Examples:
 			Flag:        "mode",
 			Env:         "CODER_SCALETEST_BRIDGE_MODE",
 			Default:     "direct",
-			Description: "Request mode: 'bridge' (create users and use AI Bridge) or 'direct' (make requests directly to upstream-url).",
+			Description: "Request mode: 'bridge' (create users and use AI Gateway) or 'direct' (make requests directly to upstream-url).",
 			Value:       serpent.EnumOf(&mode, string(bridge.RequestModeBridge), string(bridge.RequestModeDirect)),
 		},
 		{

--- a/scaletest/bridge/config.go
+++ b/scaletest/bridge/config.go
@@ -20,7 +20,7 @@ const (
 
 type Config struct {
 	// Mode determines how requests are made.
-	// "bridge": Create users in Coder and use their session tokens to make requests through AI Bridge.
+	// "bridge": Create users in Coder and use their session tokens to make requests through AI Gateway.
 	// "direct": Make requests directly to UpstreamURL without user creation.
 	Mode RequestMode `json:"mode"`
 

--- a/scaletest/bridge/strategy.go
+++ b/scaletest/bridge/strategy.go
@@ -18,7 +18,7 @@ type requestModeStrategy interface {
 	Cleanup(ctx context.Context, id string, logs io.Writer) error
 }
 
-// bridgeStrategy creates users via Coder and routes requests through AI Bridge.
+// bridgeStrategy creates users via Coder and routes requests through AI Gateway.
 type bridgeStrategy struct {
 	client   *codersdk.Client
 	provider string
@@ -66,11 +66,11 @@ func (s *bridgeStrategy) Setup(ctx context.Context, id string, logs io.Writer) (
 
 	switch s.provider {
 	case "messages":
-		requestURL = fmt.Sprintf("%s/api/v2/aibridge/anthropic/v1/messages", s.client.URL)
+		requestURL = fmt.Sprintf("%s/api/v2/ai-gateway/anthropic/v1/messages", s.client.URL)
 	case "responses":
-		requestURL = fmt.Sprintf("%s/api/v2/aibridge/openai/v1/responses", s.client.URL)
+		requestURL = fmt.Sprintf("%s/api/v2/ai-gateway/openai/v1/responses", s.client.URL)
 	case "completions":
-		requestURL = fmt.Sprintf("%s/api/v2/aibridge/openai/v1/chat/completions", s.client.URL)
+		requestURL = fmt.Sprintf("%s/api/v2/ai-gateway/openai/v1/chat/completions", s.client.URL)
 	}
 	logger.Info(ctx, "bridge runner in bridge mode",
 		slog.F("url", requestURL),


### PR DESCRIPTION
Update scaletest bridge code to use the new AI Gateway naming and API paths.

## Changes

- `scaletest/bridge/strategy.go`: Update API URLs from `/api/v2/aibridge/` to `/api/v2/ai-gateway/` and rename comment from "AI Bridge" to "AI Gateway".
- `scaletest/bridge/config.go`: Rename comment from "AI Bridge" to "AI Gateway".
- `cli/exp_scaletest_bridge.go`: Rename user-facing CLI strings (Short, Long, Description, stderr output) from "AI Bridge" to "AI Gateway".

Refs https://linear.app/codercom/issue/AIGOV-230

> Generated with the assistance of Coder Agents (@ssncferreira)