### PR TITLE
docs: rename AI Bridge to AI Gateway in swagger summaries

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -1389,8 +1389,8 @@ const docTemplate = `{
                 "tags": [
                     "AI Gateway"
                 ],
-                "summary": "List AI Bridge clients",
-                "operationId": "list-ai-bridge-clients",
+                "summary": "List AI Gateway clients",
+                "operationId": "list-ai-gateway-clients",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -1512,8 +1512,8 @@ const docTemplate = `{
                 "tags": [
                     "AI Gateway"
                 ],
-                "summary": "List AI Bridge models",
-                "operationId": "list-ai-bridge-models",
+                "summary": "List AI Gateway models",
+                "operationId": "list-ai-gateway-models",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -1541,8 +1541,8 @@ const docTemplate = `{
                 "tags": [
                     "AI Gateway"
                 ],
-                "summary": "List AI Bridge sessions",
-                "operationId": "list-ai-bridge-sessions",
+                "summary": "List AI Gateway sessions",
+                "operationId": "list-ai-gateway-sessions",
                 "parameters": [
                     {
                         "type": "string",
@@ -1593,8 +1593,8 @@ const docTemplate = `{
                 "tags": [
                     "AI Gateway"
                 ],
-                "summary": "Get AI Bridge session threads",
-                "operationId": "get-ai-bridge-session-threads",
+                "summary": "Get AI Gateway session threads",
+                "operationId": "get-ai-gateway-session-threads",
                 "parameters": [
                     {
                         "type": "string",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -1228,8 +1228,8 @@
 				"description": "Alias: also available at /api/v2/aibridge/clients for backward compatibility.",
 				"produces": ["application/json"],
 				"tags": ["AI Gateway"],
-				"summary": "List AI Bridge clients",
-				"operationId": "list-ai-bridge-clients",
+				"summary": "List AI Gateway clients",
+				"operationId": "list-ai-gateway-clients",
 				"responses": {
 					"200": {
 						"description": "OK",
@@ -1335,8 +1335,8 @@
 				"description": "Alias: also available at /api/v2/aibridge/models for backward compatibility.",
 				"produces": ["application/json"],
 				"tags": ["AI Gateway"],
-				"summary": "List AI Bridge models",
-				"operationId": "list-ai-bridge-models",
+				"summary": "List AI Gateway models",
+				"operationId": "list-ai-gateway-models",
 				"responses": {
 					"200": {
 						"description": "OK",
@@ -1360,8 +1360,8 @@
 				"description": "Alias: also available at /api/v2/aibridge/sessions for backward compatibility.",
 				"produces": ["application/json"],
 				"tags": ["AI Gateway"],
-				"summary": "List AI Bridge sessions",
-				"operationId": "list-ai-bridge-sessions",
+				"summary": "List AI Gateway sessions",
+				"operationId": "list-ai-gateway-sessions",
 				"parameters": [
 					{
 						"type": "string",
@@ -1408,8 +1408,8 @@
 				"description": "Alias: also available at /api/v2/aibridge/sessions/{session_id} for backward compatibility.",
 				"produces": ["application/json"],
 				"tags": ["AI Gateway"],
-				"summary": "Get AI Bridge session threads",
-				"operationId": "get-ai-bridge-session-threads",
+				"summary": "Get AI Gateway session threads",
+				"operationId": "get-ai-gateway-session-threads",
 				"parameters": [
 					{
 						"type": "string",

--- a/docs/reference/api/aigateway.md
+++ b/docs/reference/api/aigateway.md
@@ -1,6 +1,6 @@
 # AI Gateway
 
-## List AI Bridge clients
+## List AI Gateway clients
 
 ### Code samples
 
@@ -31,11 +31,11 @@ Alias: also available at /api/v2/aibridge/clients for backward compatibility.
 |--------|---------------------------------------------------------|-------------|-----------------|
 | 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | array of string |
 
-<h3 id="list-ai-bridge-clients-responseschema">Response Schema</h3>
+<h3 id="list-ai-gateway-clients-responseschema">Response Schema</h3>
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
-## List AI Bridge models
+## List AI Gateway models
 
 ### Code samples
 
@@ -66,11 +66,11 @@ Alias: also available at /api/v2/aibridge/models for backward compatibility.
 |--------|---------------------------------------------------------|-------------|-----------------|
 | 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | array of string |
 
-<h3 id="list-ai-bridge-models-responseschema">Response Schema</h3>
+<h3 id="list-ai-gateway-models-responseschema">Response Schema</h3>
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
-## List AI Bridge sessions
+## List AI Gateway sessions
 
 ### Code samples
 
@@ -145,7 +145,7 @@ Alias: also available at /api/v2/aibridge/sessions for backward compatibility.
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
-## Get AI Bridge session threads
+## Get AI Gateway session threads
 
 ### Code samples
 

--- a/enterprise/coderd/aibridge.go
+++ b/enterprise/coderd/aibridge.go
@@ -122,9 +122,9 @@ func aiBridgeRoutes(api *API, stripPrefix string, middlewares ...func(http.Handl
 
 // aiBridgeListSessions returns AI Bridge sessions (aggregated interceptions).
 //
-// @Summary List AI Bridge sessions
+// @Summary List AI Gateway sessions
 // @Description Alias: also available at /api/v2/aibridge/sessions for backward compatibility.
-// @ID list-ai-bridge-sessions
+// @ID list-ai-gateway-sessions
 // @Security CoderSessionToken
 // @Produce json
 // @Tags AI Gateway
@@ -249,9 +249,9 @@ func (api *API) aiBridgeListSessions(rw http.ResponseWriter, r *http.Request) {
 // aiBridgeGetSessionThreads returns a single session with fully expanded
 // threads including agentic actions and thinking blocks.
 //
-// @Summary Get AI Bridge session threads
+// @Summary Get AI Gateway session threads
 // @Description Alias: also available at /api/v2/aibridge/sessions/{session_id} for backward compatibility.
-// @ID get-ai-bridge-session-threads
+// @ID get-ai-gateway-session-threads
 // @Security CoderSessionToken
 // @Produce json
 // @Tags AI Gateway
@@ -441,9 +441,9 @@ func (api *API) aiBridgeGetSessionThreads(rw http.ResponseWriter, r *http.Reques
 
 // aiBridgeListModels returns all AI Bridge models a user can see.
 //
-// @Summary List AI Bridge models
+// @Summary List AI Gateway models
 // @Description Alias: also available at /api/v2/aibridge/models for backward compatibility.
-// @ID list-ai-bridge-models
+// @ID list-ai-gateway-models
 // @Security CoderSessionToken
 // @Produce json
 // @Tags AI Gateway
@@ -494,9 +494,9 @@ func (api *API) aiBridgeListModels(rw http.ResponseWriter, r *http.Request) {
 
 // aiBridgeListClients returns all AI Bridge clients a user can see.
 //
-// @Summary List AI Bridge clients
+// @Summary List AI Gateway clients
 // @Description Alias: also available at /api/v2/aibridge/clients for backward compatibility.
-// @ID list-ai-bridge-clients
+// @ID list-ai-gateway-clients
 // @Security CoderSessionToken
 // @Produce json
 // @Tags AI Gateway


### PR DESCRIPTION
Update `@Summary` and `@ID` annotations in `enterprise/coderd/aibridge.go` from "AI Bridge" to "AI Gateway". Regenerate swagger docs and API reference via `make gen`.

This was missed in the original API route aliases PR (#26475) which renamed `@Tags` but not `@Summary` or `@ID` values. The `@ID` must also change because a test (`assertConsistencyBetweenRouteIDAndSummary`) enforces that the ID is the kebab-case form of the summary.

Refs https://linear.app/codercom/issue/AIGOV-230

> Generated with the assistance of Coder Agents (@ssncferreira)