### PR TITLE
fix(site): embed all readable organizations in dashboard metadata

### DIFF
--- a/site/site.go
+++ b/site/site.go
@@ -408,7 +408,7 @@ func (h *Handler) renderHTMLWithState(r *http.Request, filePath string, state ht
 	var user database.User
 	var userAppearance codersdk.UserAppearanceSettings
 	orgIDs := []uuid.UUID{}
-	var userOrgs []database.Organization
+	var readableOrgs []database.Organization
 	eg.Go(func() error {
 		var err error
 		user, err = h.opts.Database.GetUserByID(ctx, apiKey.UserID)
@@ -434,18 +434,23 @@ func (h *Handler) renderHTMLWithState(r *http.Request, filePath string, state ht
 		return err
 	})
 	eg.Go(func() error {
-		orgs, err := h.opts.Database.GetOrganizationsByUserID(ctx, database.GetOrganizationsByUserIDParams{
-			UserID: apiKey.UserID,
-		})
+		// Embed every organization the user is authorized to read, matching
+		// the GET /api/v2/organizations endpoint. The frontend seeds its
+		// organizations query from this metadata and then disables
+		// refetching, so embedding only the user's member organizations
+		// (GetOrganizationsByUserID) hid organizations the user can otherwise
+		// see, such as org admins, auditors, and owners, until the query was
+		// invalidated by an unrelated action.
+		orgs, err := h.opts.Database.GetOrganizations(ctx, database.GetOrganizationsParams{})
 		if err == nil {
-			userOrgs = orgs
+			readableOrgs = orgs
 		}
 		// Don't fail the entire group if we can't fetch orgs.
 		return nil
 	})
 	err := eg.Wait()
 	if err == nil {
-		h.populateHTMLState(ctx, &state, af, actor, user, orgIDs, userOrgs, userAppearance)
+		h.populateHTMLState(ctx, &state, af, actor, user, orgIDs, readableOrgs, userAppearance)
 	}
 
 	return execTmpl(tmpl, state)
@@ -461,7 +466,7 @@ func (h *Handler) populateHTMLState(
 	actor *rbac.Subject,
 	user database.User,
 	orgIDs []uuid.UUID,
-	userOrgs []database.Organization,
+	readableOrgs []database.Organization,
 	userAppearance codersdk.UserAppearanceSettings,
 ) {
 	var wg sync.WaitGroup
@@ -520,7 +525,7 @@ func (h *Handler) populateHTMLState(
 		}
 	})
 	wg.Go(func() {
-		sdkOrgs := slice.List(userOrgs, db2sdk.Organization)
+		sdkOrgs := slice.List(readableOrgs, db2sdk.Organization)
 		data, err := json.Marshal(sdkOrgs)
 		if err == nil {
 			state.Organizations = html.EscapeString(string(data))

--- a/site/site_test.go
+++ b/site/site_test.go
@@ -159,6 +159,68 @@ func TestInjection(t *testing.T) {
 	require.Equal(t, db2sdk.User(user, []uuid.UUID{}), got)
 }
 
+// TestInjectionOrganizations ensures the embedded organizations metadata
+// matches the GET /api/v2/organizations endpoint: it must include every
+// organization the user is authorized to read, not just the ones they are a
+// member of. The frontend seeds its organizations query from this metadata and
+// then disables refetching, so embedding only member organizations previously
+// hid organizations that admins, auditors, and owners could otherwise see.
+func TestInjectionOrganizations(t *testing.T) {
+	t.Parallel()
+
+	siteFS := fstest.MapFS{
+		"index.html": &fstest.MapFile{
+			Data: []byte("{{ .Organizations }}"),
+		},
+	}
+	db, _ := dbtestutil.NewDB(t)
+	handler, err := site.New(&site.Options{
+		Telemetry: telemetry.NewNoop(),
+		Database:  db,
+		SiteFS:    siteFS,
+	})
+	require.NoError(t, err)
+
+	// An owner can read every organization, including ones they are not a
+	// member of.
+	user := dbgen.User(t, db, database.User{
+		RBACRoles: []string{rbac.RoleOwner().String()},
+	})
+	_, token := dbgen.APIKey(t, db, database.APIKey{
+		UserID:    user.ID,
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+
+	// memberOrg: the user is a member. nonMemberOrg: the user is not a member,
+	// but as an owner is still authorized to read it.
+	memberOrg := dbgen.Organization(t, db, database.Organization{})
+	dbgen.OrganizationMember(t, db, database.OrganizationMember{
+		UserID:         user.ID,
+		OrganizationID: memberOrg.ID,
+	})
+	nonMemberOrg := dbgen.Organization(t, db, database.Organization{})
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set(codersdk.SessionTokenHeader, token)
+	rw := httptest.NewRecorder()
+
+	handler.ServeHTTP(rw, r)
+	require.Equal(t, http.StatusOK, rw.Code)
+
+	var got []codersdk.Organization
+	err = json.Unmarshal([]byte(html.UnescapeString(rw.Body.String())), &got)
+	require.NoError(t, err)
+
+	gotIDs := make([]uuid.UUID, 0, len(got))
+	for _, o := range got {
+		gotIDs = append(gotIDs, o.ID)
+	}
+	require.Contains(t, gotIDs, memberOrg.ID,
+		"member organizations must be embedded")
+	require.Contains(t, gotIDs, nonMemberOrg.ID,
+		"organizations the user can read but is not a member of must be embedded")
+}
+
 func TestInjectionUserAppearance(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

On multi-org deployments, organizations went missing from the dashboard Organizations dropdown / `/organizations/{org}` views after a page load or refresh, even though the same user could see them via `GET /api/v2/organizations` and `coder organizations list`. Creating a new org temporarily restored the full list, but the next refresh dropped them again.

## Root cause

The dashboard `organizations` React Query is seeded from server-embedded HTML metadata via `cachedQuery`. When metadata is present, `cachedQuery` applies `disabledRefetchOptions` (`staleTime`/`gcTime` Infinity, all `refetchOn*` false), so the query is seeded once and never refetches.

The embedded metadata did not match the API, though:

- `site/site.go` populated the `organizations` meta tag from `GetOrganizationsByUserID` (only orgs the user is a **member of**).
- `GET /api/v2/organizations` and the CLI use `GetOrganizations`, RBAC-filtered to every org the user can **read** (a superset for org admins, auditors, and owners).

So the dropdown was permanently seeded with the member-only subset. `createOrganization.onSuccess` calls `invalidateQueries(['organizations'])`, forcing a one-time refetch from the API that briefly showed the full list, until the next refresh re-seeded from the incomplete metadata.

This was introduced in #22741 (org/permissions metadata injection), matching the customer's 2.30.2 -> 2.32.5 upgrade window.

## Fix

Embed the RBAC-readable organization list (`GetOrganizations` under the actor-authorized `dbauthz` context) so the metadata matches `GET /api/v2/organizations`. `user.organization_ids` still comes from membership (`GetOrganizationIDsByMemberIDs`), since that field genuinely represents memberships. The no-spinner optimization from #22741 is preserved.

In production the site handler receives the `dbauthz`-wrapped store (`coderd/coderd.go`), so `GetOrganizations` is RBAC-filtered to the readable set exactly like the API handler.

## Testing

- Added `TestInjectionOrganizations`: an owner who is a member of one org and a non-member of another verifies both appear in the embedded metadata. This fails on the previous member-only behavior.
- `go test ./site/ -run TestInjection`, `gofmt`, `go vet ./site/` pass.

Fixes ENG-2966

<details>
<summary>Investigation & decision log</summary>

- Validated the report against the codebase: confirmed `organizations.ts` uses `cachedQuery`, `util.ts` disables refetch when metadata is available, and `site.go` embedded member-only orgs while `coderd/organizations.go` returns readable orgs.
- Confirmed via `dbauthz.GetOrganizations` (`fetchWithPostFilter` on `ActionRead`) that the readable subset is returned, and that `coderd/coderd.go` passes the `dbauthz`-wrapped store to `site.New`, so RBAC is enforced identically to the API.
- Considered changing the frontend `cachedQuery` refetch behavior, but that affects all metadata consumers (user, build-info, entitlements, regions, permissions) and is intentional. Aligning the embedded data is the targeted, low-risk fix.
- Searched Linear; no existing issue tracked this. Filed ENG-2966.

</details>

---

_Opened by Coder Agents on behalf of @ericpaulsen._