### PR TITLE
fix(aibridge): support Bedrock Opus 4.8 adaptive thinking (#26691)

### DIFF
--- a/aibridge/intercept/messages/base.go
+++ b/aibridge/intercept/messages/base.go
@@ -421,7 +421,8 @@ func bedrockModelSupportsAdaptiveThinking(model string) bool {
 //
 // See https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-7.html
 func bedrockModelRequiresAdaptiveThinking(model string) bool {
-	return strings.Contains(model, "anthropic.claude-opus-4-7")
+	return strings.Contains(model, "anthropic.claude-opus-4-7") ||
+		strings.Contains(model, "anthropic.claude-opus-4-8")
 }
 
 // filterBedrockBetaFlags removes unsupported beta flags from the Anthropic-Beta

--- a/aibridge/intercept/messages/base_test.go
+++ b/aibridge/intercept/messages/base_test.go
@@ -847,6 +847,12 @@ func TestAugmentRequestForBedrock_AdaptiveThinking(t *testing.T) {
 			expectThinkingType: "adaptive",
 		},
 		{
+			name:               "opus_4_8_model_with_enabled_thinking_is_converted_to_adaptive_and_drops_budget",
+			bedrockModel:       "eu.anthropic.claude-opus-4-8",
+			requestBody:        `{"max_tokens":10000,"thinking":{"type":"enabled","budget_tokens":5000}}`,
+			expectThinkingType: "adaptive",
+		},
+		{
 			// Opus 4.7 on Bedrock rejects output_config.format (structured
 			// outputs) with a 400 even though it accepts output_config.effort.
 			name:                "opus_4_7_model_strips_output_config_format_but_keeps_effort",


### PR DESCRIPTION
Bedrock rejects legacy `thinking.type=enabled` requests for Claude Opus 4.8 because the model requires adaptive thinking. The AI Bridge Bedrock shim only recognized Opus 4.7 as adaptive-only, so Opus 4.8 requests could fall through and produce Bedrock 400 responses.

Add Opus 4.8 to the adaptive-only model detection and cover the regional Bedrock model ID form with a regression test.

<details>
<summary>Coder Agents disclosure</summary>

This PR was generated by Coder Agents on behalf of @ericpaulsen.

</details>

(cherry picked from commit 96aecd83fa7d5f4add02d76c6acde480de21e138)

<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->
