### PR TITLE
feat: return workspace skill directory from read_skill

### DIFF
--- a/coderd/x/chatd/chattool/skill.go
+++ b/coderd/x/chatd/chattool/skill.go
@@ -312,10 +312,10 @@ func ReadSkill(options ReadSkillOptions) fantasy.AgentTool {
 		"Read the full instructions for a skill by name. "+
 			"Returns the skill meta file body and a list of "+
 			"supporting files. For workspace skills the response "+
-			"also includes \"dir\", the absolute path to the skill "+
-			"directory in the workspace: join it with a supporting "+
-			"file's relative path to read or run that file with "+
-			"read_file or execute. Use read_skill before "+
+			"also includes \"skill_directory\", the absolute path "+
+			"to the skill directory in the workspace: join it with "+
+			"a supporting file's relative path to read or run that "+
+			"file with read_file or execute. Use read_skill before "+
 			"following a skill's instructions.",
 		func(ctx context.Context, args ReadSkillArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
 			if args.Name == "" {
@@ -359,13 +359,14 @@ func ReadSkill(options ReadSkillOptions) fantasy.AgentTool {
 				// reach supporting files with the general workspace
 				// tools (read_file, execute) that share this workspace
 				// connection, not just the relative-path-scoped
-				// read_skill_file. The dir is omitted for personal
-				// skills, which are database-backed and have no files.
+				// read_skill_file. The directory is omitted for
+				// personal skills, which are database-backed and have
+				// no files.
 				return toolResponse(map[string]any{
-					"name":  args.Name,
-					"dir":   content.Dir,
-					"body":  content.Body,
-					"files": nonNilFiles(content.Files),
+					"name":            args.Name,
+					"skill_directory": content.Dir,
+					"body":            content.Body,
+					"files":           nonNilFiles(content.Files),
 				}), nil
 			default:
 				return skillNotFoundResponse(args.Name), nil

--- a/coderd/x/chatd/chattool/skill.go
+++ b/coderd/x/chatd/chattool/skill.go
@@ -311,7 +311,11 @@ func ReadSkill(options ReadSkillOptions) fantasy.AgentTool {
 		"read_skill",
 		"Read the full instructions for a skill by name. "+
 			"Returns the skill meta file body and a list of "+
-			"supporting files. Use read_skill before "+
+			"supporting files. For workspace skills the response "+
+			"also includes \"dir\", the absolute path to the skill "+
+			"directory in the workspace: join it with a supporting "+
+			"file's relative path to read or run that file with "+
+			"read_file or execute. Use read_skill before "+
 			"following a skill's instructions.",
 		func(ctx context.Context, args ReadSkillArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
 			if args.Name == "" {
@@ -351,8 +355,15 @@ func ReadSkill(options ReadSkillOptions) fantasy.AgentTool {
 				if ok {
 					return response, nil
 				}
+				// Expose the absolute skill directory so the model can
+				// reach supporting files with the general workspace
+				// tools (read_file, execute) that share this workspace
+				// connection, not just the relative-path-scoped
+				// read_skill_file. The dir is omitted for personal
+				// skills, which are database-backed and have no files.
 				return toolResponse(map[string]any{
 					"name":  args.Name,
+					"dir":   content.Dir,
 					"body":  content.Body,
 					"files": nonNilFiles(content.Files),
 				}), nil

--- a/coderd/x/chatd/chattool/skill.go
+++ b/coderd/x/chatd/chattool/skill.go
@@ -311,9 +311,7 @@ func ReadSkill(options ReadSkillOptions) fantasy.AgentTool {
 		"read_skill",
 		"Read the full instructions for a skill by name. "+
 			"Returns the skill meta file body and a list of "+
-			"supporting files. For workspace skills the response "+
-			"also includes \"dir\", the absolute path to the skill "+
-			"directory in the workspace. Use read_skill before "+
+			"supporting files. Use read_skill before "+
 			"following a skill's instructions.",
 		func(ctx context.Context, args ReadSkillArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
 			if args.Name == "" {

--- a/coderd/x/chatd/chattool/skill.go
+++ b/coderd/x/chatd/chattool/skill.go
@@ -312,10 +312,10 @@ func ReadSkill(options ReadSkillOptions) fantasy.AgentTool {
 		"Read the full instructions for a skill by name. "+
 			"Returns the skill meta file body and a list of "+
 			"supporting files. For workspace skills the response "+
-			"also includes \"skill_directory\", the absolute path "+
-			"to the skill directory in the workspace: join it with "+
-			"a supporting file's relative path to read or run that "+
-			"file with read_file or execute. Use read_skill before "+
+			"also includes \"dir\", the absolute path to the skill "+
+			"directory in the workspace: join it with a supporting "+
+			"file's relative path to read or run that file with "+
+			"read_file or execute. Use read_skill before "+
 			"following a skill's instructions.",
 		func(ctx context.Context, args ReadSkillArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
 			if args.Name == "" {
@@ -359,14 +359,13 @@ func ReadSkill(options ReadSkillOptions) fantasy.AgentTool {
 				// reach supporting files with the general workspace
 				// tools (read_file, execute) that share this workspace
 				// connection, not just the relative-path-scoped
-				// read_skill_file. The directory is omitted for
-				// personal skills, which are database-backed and have
-				// no files.
+				// read_skill_file. The dir is omitted for personal
+				// skills, which are database-backed and have no files.
 				return toolResponse(map[string]any{
-					"name":            args.Name,
-					"skill_directory": content.Dir,
-					"body":            content.Body,
-					"files":           nonNilFiles(content.Files),
+					"name":  args.Name,
+					"dir":   content.Dir,
+					"body":  content.Body,
+					"files": nonNilFiles(content.Files),
 				}), nil
 			default:
 				return skillNotFoundResponse(args.Name), nil

--- a/coderd/x/chatd/chattool/skill.go
+++ b/coderd/x/chatd/chattool/skill.go
@@ -313,9 +313,7 @@ func ReadSkill(options ReadSkillOptions) fantasy.AgentTool {
 			"Returns the skill meta file body and a list of "+
 			"supporting files. For workspace skills the response "+
 			"also includes \"dir\", the absolute path to the skill "+
-			"directory in the workspace: join it with a supporting "+
-			"file's relative path to read or run that file with "+
-			"read_file or execute. Use read_skill before "+
+			"directory in the workspace. Use read_skill before "+
 			"following a skill's instructions.",
 		func(ctx context.Context, args ReadSkillArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
 			if args.Name == "" {
@@ -355,12 +353,8 @@ func ReadSkill(options ReadSkillOptions) fantasy.AgentTool {
 				if ok {
 					return response, nil
 				}
-				// Expose the absolute skill directory so the model can
-				// reach supporting files with the general workspace
-				// tools (read_file, execute) that share this workspace
-				// connection, not just the relative-path-scoped
-				// read_skill_file. The dir is omitted for personal
-				// skills, which are database-backed and have no files.
+				// Include the absolute skill directory so the agent can
+				// reach supporting files with read_file and execute.
 				return toolResponse(map[string]any{
 					"name":  args.Name,
 					"dir":   content.Dir,

--- a/coderd/x/chatd/chattool/skill_test.go
+++ b/coderd/x/chatd/chattool/skill_test.go
@@ -35,6 +35,18 @@ func responseName(t *testing.T, resp fantasy.ToolResponse) string {
 	return payload.Name
 }
 
+// responseDir extracts the "dir" field from a read_skill response. It is
+// empty when the field is absent, as it is for personal skills.
+func responseDir(t *testing.T, resp fantasy.ToolResponse) string {
+	t.Helper()
+
+	var payload struct {
+		Dir string `json:"dir"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resp.Content), &payload))
+	return payload.Dir
+}
+
 func TestFormatResolvedSkillIndex(t *testing.T) {
 	t.Parallel()
 
@@ -305,6 +317,9 @@ func TestReadSkillTool(t *testing.T) {
 		assert.False(t, resp.IsError)
 		assert.Contains(t, resp.Content, "Do the thing.")
 		assert.Contains(t, resp.Content, "helper.md")
+		// Workspace skills expose the absolute skill directory so the
+		// model can reach supporting files with read_file/execute.
+		assert.Equal(t, "/work/.agents/skills/my-skill", responseDir(t, resp))
 	})
 
 	t.Run("PinnedBodyServedWhenWorkspaceUnreachable", func(t *testing.T) {
@@ -334,6 +349,10 @@ func TestReadSkillTool(t *testing.T) {
 		assert.False(t, resp.IsError)
 		assert.Contains(t, resp.Content, "Do the thing.")
 		assert.Contains(t, resp.Content, `"files":[]`)
+		// The dir comes from the pinned SkillMeta, so it is still
+		// returned even when the workspace is unreachable and the file
+		// list degrades to empty.
+		assert.Equal(t, "/work/.agents/skills/my-skill", responseDir(t, resp))
 	})
 
 	t.Run("PersonalSkill", func(t *testing.T) {
@@ -372,6 +391,9 @@ func TestReadSkillTool(t *testing.T) {
 		assert.False(t, resp.IsError)
 		assert.Contains(t, resp.Content, "Personal instructions.")
 		assert.Contains(t, resp.Content, `"files":[]`)
+		// Personal skills are database-backed and have no directory.
+		assert.Empty(t, responseDir(t, resp))
+		assert.NotContains(t, resp.Content, `"dir"`)
 	})
 
 	t.Run("PersonalQualifiedAliasPreservesAlias", func(t *testing.T) {
@@ -459,6 +481,7 @@ func TestReadSkillTool(t *testing.T) {
 		assert.False(t, resp.IsError)
 		assert.Equal(t, "workspace/my-skill", responseName(t, resp))
 		assert.Contains(t, resp.Content, "Do the thing.")
+		assert.Equal(t, "/work/.agents/skills/my-skill", responseDir(t, resp))
 	})
 
 	t.Run("CollisionAliasRoundTrip", func(t *testing.T) {
@@ -530,6 +553,7 @@ func TestReadSkillTool(t *testing.T) {
 		assert.False(t, workspaceResp.IsError)
 		workspaceName := responseName(t, workspaceResp)
 		assert.Equal(t, "workspace/deploy", workspaceName)
+		assert.Equal(t, "/work/.agents/skills/deploy", responseDir(t, workspaceResp))
 		workspaceResolved, err := resolveAlias(workspaceName)
 		require.NoError(t, err)
 		assert.Equal(t, skillspkg.SourceWorkspace, workspaceResolved.Source)

--- a/coderd/x/chatd/chattool/skill_test.go
+++ b/coderd/x/chatd/chattool/skill_test.go
@@ -35,13 +35,14 @@ func responseName(t *testing.T, resp fantasy.ToolResponse) string {
 	return payload.Name
 }
 
-// responseDir extracts the "dir" field from a read_skill response. It is
-// empty when the field is absent, as it is for personal skills.
+// responseDir extracts the "skill_directory" field from a read_skill
+// response. It is empty when the field is absent, as it is for personal
+// skills.
 func responseDir(t *testing.T, resp fantasy.ToolResponse) string {
 	t.Helper()
 
 	var payload struct {
-		Dir string `json:"dir"`
+		Dir string `json:"skill_directory"`
 	}
 	require.NoError(t, json.Unmarshal([]byte(resp.Content), &payload))
 	return payload.Dir
@@ -393,7 +394,7 @@ func TestReadSkillTool(t *testing.T) {
 		assert.Contains(t, resp.Content, `"files":[]`)
 		// Personal skills are database-backed and have no directory.
 		assert.Empty(t, responseDir(t, resp))
-		assert.NotContains(t, resp.Content, `"dir"`)
+		assert.NotContains(t, resp.Content, `"skill_directory"`)
 	})
 
 	t.Run("PersonalQualifiedAliasPreservesAlias", func(t *testing.T) {

--- a/coderd/x/chatd/chattool/skill_test.go
+++ b/coderd/x/chatd/chattool/skill_test.go
@@ -35,14 +35,13 @@ func responseName(t *testing.T, resp fantasy.ToolResponse) string {
 	return payload.Name
 }
 
-// responseDir extracts the "skill_directory" field from a read_skill
-// response. It is empty when the field is absent, as it is for personal
-// skills.
+// responseDir extracts the "dir" field from a read_skill response. It is
+// empty when the field is absent, as it is for personal skills.
 func responseDir(t *testing.T, resp fantasy.ToolResponse) string {
 	t.Helper()
 
 	var payload struct {
-		Dir string `json:"skill_directory"`
+		Dir string `json:"dir"`
 	}
 	require.NoError(t, json.Unmarshal([]byte(resp.Content), &payload))
 	return payload.Dir
@@ -394,7 +393,7 @@ func TestReadSkillTool(t *testing.T) {
 		assert.Contains(t, resp.Content, `"files":[]`)
 		// Personal skills are database-backed and have no directory.
 		assert.Empty(t, responseDir(t, resp))
-		assert.NotContains(t, resp.Content, `"skill_directory"`)
+		assert.NotContains(t, resp.Content, `"dir"`)
 	})
 
 	t.Run("PersonalQualifiedAliasPreservesAlias", func(t *testing.T) {

--- a/docs/ai-coder/agents/extending-agents.md
+++ b/docs/ai-coder/agents/extending-agents.md
@@ -25,10 +25,17 @@ calls a tool.
 
 Two tools are registered when skills are present:
 
-| Tool              | Parameters                       | Description                                              |
-|-------------------|----------------------------------|----------------------------------------------------------|
-| `read_skill`      | `name` (string)                  | Returns the SKILL.md body and a list of supporting files |
-| `read_skill_file` | `name` (string), `path` (string) | Returns the content of a supporting file                 |
+| Tool              | Parameters                       | Description                                                                                                |
+|-------------------|----------------------------------|------------------------------------------------------------------------------------------------------------|
+| `read_skill`      | `name` (string)                  | Returns the SKILL.md body, the absolute skill directory (workspace skills), and a list of supporting files |
+| `read_skill_file` | `name` (string), `path` (string) | Returns the content of a supporting file                                                                   |
+
+For workspace skills, `read_skill` also returns `dir`, the absolute path to
+the skill directory in the workspace. The agent's `read_file` and `execute`
+tools operate on that same workspace filesystem, so you can join `dir` with a
+supporting file's relative path to read or run that file directly, for example
+to execute a bundled `scripts/` helper. `read_skill_file` remains available as
+a path-safe convenience for reading supporting files.
 
 ### Directory structure
 

--- a/docs/ai-coder/agents/extending-agents.md
+++ b/docs/ai-coder/agents/extending-agents.md
@@ -30,12 +30,13 @@ Two tools are registered when skills are present:
 | `read_skill`      | `name` (string)                  | Returns the SKILL.md body, the absolute skill directory (workspace skills), and a list of supporting files |
 | `read_skill_file` | `name` (string), `path` (string) | Returns the content of a supporting file                                                                   |
 
-For workspace skills, `read_skill` also returns `dir`, the absolute path to
-the skill directory in the workspace. The agent's `read_file` and `execute`
-tools operate on that same workspace filesystem, so you can join `dir` with a
-supporting file's relative path to read or run that file directly, for example
-to execute a bundled `scripts/` helper. `read_skill_file` remains available as
-a path-safe convenience for reading supporting files.
+For workspace skills, `read_skill` also returns `skill_directory`, the
+absolute path to the skill directory in the workspace. The agent's `read_file`
+and `execute` tools operate on that same workspace filesystem, so you can join
+`skill_directory` with a supporting file's relative path to read or run that
+file directly, for example to execute a bundled `scripts/` helper.
+`read_skill_file` remains available as a path-safe convenience for reading
+supporting files.
 
 ### Directory structure
 

--- a/docs/ai-coder/agents/extending-agents.md
+++ b/docs/ai-coder/agents/extending-agents.md
@@ -30,13 +30,12 @@ Two tools are registered when skills are present:
 | `read_skill`      | `name` (string)                  | Returns the SKILL.md body, the absolute skill directory (workspace skills), and a list of supporting files |
 | `read_skill_file` | `name` (string), `path` (string) | Returns the content of a supporting file                                                                   |
 
-For workspace skills, `read_skill` also returns `skill_directory`, the
-absolute path to the skill directory in the workspace. The agent's `read_file`
-and `execute` tools operate on that same workspace filesystem, so you can join
-`skill_directory` with a supporting file's relative path to read or run that
-file directly, for example to execute a bundled `scripts/` helper.
-`read_skill_file` remains available as a path-safe convenience for reading
-supporting files.
+For workspace skills, `read_skill` also returns `dir`, the absolute path to
+the skill directory in the workspace. The agent's `read_file` and `execute`
+tools operate on that same workspace filesystem, so you can join `dir` with a
+supporting file's relative path to read or run that file directly, for example
+to execute a bundled `scripts/` helper. `read_skill_file` remains available as
+a path-safe convenience for reading supporting files.
 
 ### Directory structure
 


### PR DESCRIPTION
## Summary

Workspace skills live on the workspace filesystem, and the agent's `read_file`/`execute` tools already operate on that same filesystem. But a skill's absolute directory was never surfaced to the model:

- the `<available-skills>` catalog lists only name + description,
- `read_skill` returned `{name, body, files}` where `files` are **relative** names, and
- `read_skill_file` is relative-path-scoped (it rejects absolute paths, `..`, and hidden files).

As a result, a bundled `scripts/foo.sh` could be **read** but never **run**, and the agent had no way to browse or glob the skill directory.

## Change

`read_skill` now returns `dir`, the absolute skill directory, for **workspace** skills. The model can join `dir` with a supporting file's relative path and pass the result to `read_file` or `execute` (which share the same workspace connection), so bundled scripts are runnable and the directory is browsable. This matches how Agent Skills work in `coder/mux` and `openai/codex`.

- **Personal skills** are database-backed with no supporting files, so `dir` is omitted for them.
- `read_skill_file` is unchanged and remains a path-safe convenience for reading supporting files.
- Progressive disclosure is preserved: the path is revealed only when a skill is activated via `read_skill`, not in the always-on catalog.

## Why this is safe

No new capability or boundary is crossed. The agent already has unrestricted workspace filesystem access through `read_file`/`execute`; the relative-only restriction on `read_skill_file` is a guardrail for that one convenience tool, not a sandbox around the agent. `ChatMessagePart.SkillDir` remains `typescript:"-"` and is still stripped by `StripInternal()` from the API/SSE wire format sent to the frontend. This change only affects the model-facing `read_skill` tool response.

## Testing

- `go test ./coderd/x/chatd/chattool/` (skill tool tests) and `./coderd/x/chatd/` (skill prompt/merge tests)
- `gofmt`, `go vet`, `golangci-lint` (clean), markdownlint (0 errors)

<details>
<summary>Investigation &amp; decision log</summary>

### Root cause trace

- Discovery records the absolute dir: `agent/agentcontextconfig/api.go` `discoverSkills` sets `SkillDir` on the skill context part.
- Catalog hides it: `coderd/x/chatd/chattool/skill.go` `renderSkillIndex` emits only `- <alias>: <description>`.
- `read_skill` omitted it: the `SourceWorkspace` branch returned only `name`, `body`, and relative `files`.
- `read_skill_file` is dir-scoped: `validateSkillFilePath` rejects absolute/`..`/hidden, `LoadSkillFile` joins `path.Join(skill.Dir, relativePath)` server-side.
- Wire-format stripping is separate from the model view: `codersdk/chats.go` `StripInternal()` zeroes `SkillDir` for API/SSE responses (`typescript:"-"`), which is the frontend channel, not the LLM tool channel.

### Key insight

In `coderd/x/chatd/generation_preparer.go`, `read_file`, `execute`, and the skill tools are all wired with the same `GetWorkspaceConn`. `execute` runs via `conn.StartProcess` and `read_file` via `conn.ReadFileLines`, both on the workspace filesystem where skills live. The agent was fully capable of reading/running bundled files; it just lacked the absolute path.

### Alternatives considered

- **Put the dir in the catalog index** — rejected: bloats the always-on prompt and leaks paths for never-used skills, breaking progressive disclosure.
- **Return per-file absolute paths** (`files: [{path, abs}]`) — heavier wire change; the single `dir` is sufficient since the model can join.
- **Drop `read_skill_file` and hand over only the dir** (pure Agent Skills model) — larger redesign; reasonable as a future simplification, out of scope here.

</details>

---

*PR generated with Coder Agents on behalf of @kylecarbs.*