### PR TITLE
fix(agent): gate workspace context collection until the agent is ready

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1552,10 +1552,10 @@ func (a *agent) handleManifest(manifestOK *checkpoint) func(ctx context.Context,
 				a.metrics.startupScriptSeconds.WithLabelValues(label).Set(dur)
 				a.scriptRunner.StartCron()
 
-				// Startup finished (success or terminal failure). Release
-				// the context manager's gate so it collects and pushes the
-				// now-complete inventory instead of pre-startup partial
-				// state.
+				// Startup finished (success or terminal failure): release
+				// the context gate. MCP servers connect below and
+				// re-trigger a push once up, so we don't block readiness
+				// on them.
 				a.contextManager.SetReady()
 
 				// Connect to workspace MCP servers after the

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -513,6 +513,14 @@ func (a *agent) init() {
 		Clock:          a.clock,
 		WorkingDir:     workingDirFn,
 		InitialSources: initialContextSources(a.contextConfig, workingDirFn),
+		// Gate collection until startup scripts finish. SetReady is
+		// called from the lifecycle transition in handleManifest. Without
+		// this the Manager resolves and pushes at boot, before
+		// instruction-file symlinks (CLAUDE.md / .cursorrules ->
+		// AGENTS.md) resolve, before skills sync, and before MCP servers
+		// connect, which surfaces transient "unreadable" issues and a
+		// partial inventory in chat.
+		GateUntilReady: true,
 		// The manager surfaces MCP servers and their tools as
 		// KindMCPServer resources by reading the shared MCP engine's
 		// catalog (a.mcpManager). That engine owns the single set of
@@ -1551,6 +1559,16 @@ func (a *agent) handleManifest(manifestOK *checkpoint) func(ctx context.Context,
 				}
 				a.metrics.startupScriptSeconds.WithLabelValues(label).Set(dur)
 				a.scriptRunner.StartCron()
+
+				// Startup scripts have finished (success or terminal
+				// failure). Release the context manager's gate so it
+				// collects and pushes the now-complete inventory:
+				// instruction-file symlinks (CLAUDE.md / .cursorrules ->
+				// AGENTS.md) resolve, skills have synced, and MCP servers
+				// are about to connect. Gating until now keeps pre-startup
+				// partial state and transient "unreadable" issues out of
+				// coderd and chats.
+				a.contextManager.SetReady()
 
 				// Connect to workspace MCP servers after the
 				// lifecycle transition to avoid delaying Ready.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -513,14 +513,6 @@ func (a *agent) init() {
 		Clock:          a.clock,
 		WorkingDir:     workingDirFn,
 		InitialSources: initialContextSources(a.contextConfig, workingDirFn),
-		// Gate collection until startup scripts finish. SetReady is
-		// called from the lifecycle transition in handleManifest. Without
-		// this the Manager resolves and pushes at boot, before
-		// instruction-file symlinks (CLAUDE.md / .cursorrules ->
-		// AGENTS.md) resolve, before skills sync, and before MCP servers
-		// connect, which surfaces transient "unreadable" issues and a
-		// partial inventory in chat.
-		GateUntilReady: true,
 		// The manager surfaces MCP servers and their tools as
 		// KindMCPServer resources by reading the shared MCP engine's
 		// catalog (a.mcpManager). That engine owns the single set of

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1552,14 +1552,10 @@ func (a *agent) handleManifest(manifestOK *checkpoint) func(ctx context.Context,
 				a.metrics.startupScriptSeconds.WithLabelValues(label).Set(dur)
 				a.scriptRunner.StartCron()
 
-				// Startup scripts have finished (success or terminal
-				// failure). Release the context manager's gate so it
-				// collects and pushes the now-complete inventory:
-				// instruction-file symlinks (CLAUDE.md / .cursorrules ->
-				// AGENTS.md) resolve, skills have synced, and MCP servers
-				// are about to connect. Gating until now keeps pre-startup
-				// partial state and transient "unreadable" issues out of
-				// coderd and chats.
+				// Startup finished (success or terminal failure). Release
+				// the context manager's gate so it collects and pushes the
+				// now-complete inventory instead of pre-startup partial
+				// state.
 				a.contextManager.SetReady()
 
 				// Connect to workspace MCP servers after the

--- a/agent/agent_context_test.go
+++ b/agent/agent_context_test.go
@@ -17,8 +17,13 @@ import (
 )
 
 // TestAgent_ContextStatePushed verifies the agent's
-// agentcontext.Manager pushes its initial Snapshot to coderd
-// over the v2.10 PushContextState RPC during a normal boot.
+// agentcontext.Manager pushes its workspace context to coderd over the
+// v2.10 PushContextState RPC, and that the readiness gate
+// (GateUntilReady + SetReady, wired to the lifecycle transition) holds
+// the push until startup completes. The first push the agent sends
+// therefore already contains the seeded AGENTS.md with Initial=true:
+// the agent never ships a pre-startup empty or partial snapshot, and
+// never surfaces transient "unreadable" issues.
 func TestAgent_ContextStatePushed(t *testing.T) {
 	t.Parallel()
 
@@ -35,28 +40,34 @@ func TestAgent_ContextStatePushed(t *testing.T) {
 		},
 	)
 
-	// The first push is the initial empty-workspace snapshot
-	// because the manifest has not been fetched yet. Wait for a
-	// later push that includes the seeded AGENTS.md.
+	// The push is gated until the agent reaches lifecycle ready (its
+	// startup scripts finish). Wait for that first push to land.
 	var pushes []*agentproto.PushContextStateRequest
 	require.Eventually(t, func() bool {
 		pushes = client.ContextStatePushes()
-		for _, push := range pushes {
-			for _, r := range push.GetResources() {
-				if r.GetInstructionFile() != nil &&
-					filepath.Base(r.GetSource()) == "AGENTS.md" {
-					return true
-				}
-			}
-		}
-		return false
+		return len(pushes) > 0
 	}, testutil.WaitMedium, testutil.IntervalFast,
-		"expected the seeded AGENTS.md to appear in a snapshot push; got %d pushes", len(pushes))
+		"expected a context snapshot push after startup; got %d pushes", len(pushes))
 
-	require.NotEmpty(t, pushes)
 	first := pushes[0]
 	assert.True(t, first.GetInitial(), "first push must carry Initial=true")
 	assert.NotEmpty(t, first.GetAggregateHash(), "aggregate_hash must be populated")
+
+	// The gate guarantees the very first push already reflects the
+	// ready workspace: the seeded AGENTS.md is present and no resource
+	// is reported as a transient UNREADABLE issue. Before the fix the
+	// first push was the empty boot snapshot, and intermediate pushes
+	// could carry unresolved instruction-file symlinks.
+	var foundAgents bool
+	for _, r := range first.GetResources() {
+		if r.GetInstructionFile() != nil &&
+			filepath.Base(r.GetSource()) == "AGENTS.md" {
+			foundAgents = true
+		}
+		assert.NotEqualf(t, agentproto.ContextResource_UNREADABLE, r.GetStatus(),
+			"no resource should be UNREADABLE in the post-ready snapshot: %s", r.GetSource())
+	}
+	assert.True(t, foundAgents, "first push must already include the seeded AGENTS.md")
 
 	// Subsequent pushes must not be Initial.
 	for _, p := range pushes[1:] {

--- a/agent/agent_context_test.go
+++ b/agent/agent_context_test.go
@@ -16,14 +16,11 @@ import (
 	"github.com/coder/coder/v2/testutil"
 )
 
-// TestAgent_ContextStatePushed verifies the agent's
-// agentcontext.Manager pushes its workspace context to coderd over the
-// v2.10 PushContextState RPC, and that the readiness gate
-// (SetReady, wired to the lifecycle transition) holds
-// the push until startup completes. The first push the agent sends
-// therefore already contains the seeded AGENTS.md with Initial=true:
-// the agent never ships a pre-startup empty or partial snapshot, and
-// never surfaces transient "unreadable" issues.
+// TestAgent_ContextStatePushed verifies the agent pushes its workspace
+// context over the v2.10 PushContextState RPC, and that the readiness
+// gate (SetReady, wired to the lifecycle transition) holds the push
+// until startup completes. The first push therefore already contains
+// the seeded AGENTS.md with Initial=true and no "unreadable" issues.
 func TestAgent_ContextStatePushed(t *testing.T) {
 	t.Parallel()
 
@@ -40,8 +37,8 @@ func TestAgent_ContextStatePushed(t *testing.T) {
 		},
 	)
 
-	// The push is gated until the agent reaches lifecycle ready (its
-	// startup scripts finish). Wait for that first push to land.
+	// The push is gated until the agent reaches lifecycle ready. Wait
+	// for that first push to land.
 	var pushes []*agentproto.PushContextStateRequest
 	require.Eventually(t, func() bool {
 		pushes = client.ContextStatePushes()
@@ -53,11 +50,8 @@ func TestAgent_ContextStatePushed(t *testing.T) {
 	assert.True(t, first.GetInitial(), "first push must carry Initial=true")
 	assert.NotEmpty(t, first.GetAggregateHash(), "aggregate_hash must be populated")
 
-	// The gate guarantees the very first push already reflects the
-	// ready workspace: the seeded AGENTS.md is present and no resource
-	// is reported as a transient UNREADABLE issue. Before the fix the
-	// first push was the empty boot snapshot, and intermediate pushes
-	// could carry unresolved instruction-file symlinks.
+	// The first push must already reflect the ready workspace: the
+	// seeded AGENTS.md is present and no resource is UNREADABLE.
 	var foundAgents bool
 	for _, r := range first.GetResources() {
 		if r.GetInstructionFile() != nil &&

--- a/agent/agent_context_test.go
+++ b/agent/agent_context_test.go
@@ -19,7 +19,7 @@ import (
 // TestAgent_ContextStatePushed verifies the agent's
 // agentcontext.Manager pushes its workspace context to coderd over the
 // v2.10 PushContextState RPC, and that the readiness gate
-// (GateUntilReady + SetReady, wired to the lifecycle transition) holds
+// (SetReady, wired to the lifecycle transition) holds
 // the push until startup completes. The first push the agent sends
 // therefore already contains the seeded AGENTS.md with Initial=true:
 // the agent never ships a pre-startup empty or partial snapshot, and

--- a/agent/agentcontext/api.go
+++ b/agent/agentcontext/api.go
@@ -50,6 +50,11 @@ type SnapshotResponse struct {
 	Resources     []SnapshotResource `json:"resources"`
 	PayloadBytes  uint64             `json:"payload_bytes"`
 	SnapshotError string             `json:"snapshot_error,omitempty"`
+	// Initializing is true while the agent gates context collection
+	// until startup scripts finish. Clients should render a "still
+	// initializing" state rather than treating the empty Resources as
+	// "no context".
+	Initializing bool `json:"initializing,omitempty"`
 }
 
 // API exposes the Manager over HTTP. The routes match the RFC:
@@ -187,6 +192,7 @@ func snapshotResponse(s Snapshot) SnapshotResponse {
 		Resources:     make([]SnapshotResource, 0, len(s.Resources)),
 		PayloadBytes:  s.PayloadBytes,
 		SnapshotError: s.SnapshotError,
+		Initializing:  s.Initializing,
 	}
 	for _, r := range s.Resources {
 		out.Resources = append(out.Resources, SnapshotResource{

--- a/agent/agentcontext/api.go
+++ b/agent/agentcontext/api.go
@@ -50,11 +50,6 @@ type SnapshotResponse struct {
 	Resources     []SnapshotResource `json:"resources"`
 	PayloadBytes  uint64             `json:"payload_bytes"`
 	SnapshotError string             `json:"snapshot_error,omitempty"`
-	// Initializing is true while the agent gates context collection
-	// until startup scripts finish. Clients should render a "still
-	// initializing" state rather than treating the empty Resources as
-	// "no context".
-	Initializing bool `json:"initializing,omitempty"`
 }
 
 // API exposes the Manager over HTTP. The routes match the RFC:
@@ -192,7 +187,6 @@ func snapshotResponse(s Snapshot) SnapshotResponse {
 		Resources:     make([]SnapshotResource, 0, len(s.Resources)),
 		PayloadBytes:  s.PayloadBytes,
 		SnapshotError: s.SnapshotError,
-		Initializing:  s.Initializing,
 	}
 	for _, r := range s.Resources {
 		out.Resources = append(out.Resources, SnapshotResource{

--- a/agent/agentcontext/doc.go
+++ b/agent/agentcontext/doc.go
@@ -17,15 +17,14 @@
 //     the tree downward or up to a parent directory.
 //   - A fixed-location fsnotify watcher that signals a re-resolve
 //     when any recognized file changes.
-//   - An optional readiness gate (ManagerOptions.GateUntilReady plus
-//     Manager.SetReady). While gated the Manager publishes only an
-//     Initializing snapshot and the push loop ships nothing, so
-//     pre-startup partial state (instruction-file symlinks whose
-//     target has not been checked out, skills that have not synced,
-//     MCP servers that have not connected) never reaches coderd or
-//     hydrates a chat. The agent enables the gate and calls SetReady
-//     from the workspace lifecycle transition once startup scripts
-//     finish.
+//   - A readiness gate (Manager.SetReady). The Manager always starts
+//     gated: until SetReady fires it publishes only an Initializing
+//     snapshot and the push loop ships nothing, so pre-startup partial
+//     state (instruction-file symlinks whose target has not been
+//     checked out, skills that have not synced, MCP servers that have
+//     not connected) never reaches coderd or hydrates a chat. The
+//     agent calls SetReady from the workspace lifecycle transition
+//     once startup scripts finish.
 //   - An HTTP API at /api/v0/context/sources for source CRUD
 //     and /api/v0/context/resync for synchronous push barriers.
 //   - A Pusher abstraction so the latest Snapshot can be shipped

--- a/agent/agentcontext/doc.go
+++ b/agent/agentcontext/doc.go
@@ -17,6 +17,15 @@
 //     the tree downward or up to a parent directory.
 //   - A fixed-location fsnotify watcher that signals a re-resolve
 //     when any recognized file changes.
+//   - An optional readiness gate (ManagerOptions.GateUntilReady plus
+//     Manager.SetReady). While gated the Manager publishes only an
+//     Initializing snapshot and the push loop ships nothing, so
+//     pre-startup partial state (instruction-file symlinks whose
+//     target has not been checked out, skills that have not synced,
+//     MCP servers that have not connected) never reaches coderd or
+//     hydrates a chat. The agent enables the gate and calls SetReady
+//     from the workspace lifecycle transition once startup scripts
+//     finish.
 //   - An HTTP API at /api/v0/context/sources for source CRUD
 //     and /api/v0/context/resync for synchronous push barriers.
 //   - A Pusher abstraction so the latest Snapshot can be shipped

--- a/agent/agentcontext/doc.go
+++ b/agent/agentcontext/doc.go
@@ -17,14 +17,11 @@
 //     the tree downward or up to a parent directory.
 //   - A fixed-location fsnotify watcher that signals a re-resolve
 //     when any recognized file changes.
-//   - A readiness gate (Manager.SetReady). The Manager always starts
-//     gated: until SetReady fires it publishes only an Initializing
-//     snapshot and the push loop ships nothing, so pre-startup partial
-//     state (instruction-file symlinks whose target has not been
-//     checked out, skills that have not synced, MCP servers that have
-//     not connected) never reaches coderd or hydrates a chat. The
-//     agent calls SetReady from the workspace lifecycle transition
-//     once startup scripts finish.
+//   - A readiness gate (Manager.SetReady). The Manager starts gated,
+//     publishing only an Initializing snapshot until the agent calls
+//     SetReady from the workspace lifecycle transition once startup
+//     scripts finish. This keeps pre-startup partial state out of
+//     coderd and chats.
 //   - An HTTP API at /api/v0/context/sources for source CRUD
 //     and /api/v0/context/resync for synchronous push barriers.
 //   - A Pusher abstraction so the latest Snapshot can be shipped

--- a/agent/agentcontext/doc.go
+++ b/agent/agentcontext/doc.go
@@ -18,7 +18,7 @@
 //   - A fixed-location fsnotify watcher that signals a re-resolve
 //     when any recognized file changes.
 //   - A readiness gate (Manager.SetReady). The Manager starts gated,
-//     publishing only an Initializing snapshot until the agent calls
+//     publishing only an empty version-0 snapshot until the agent calls
 //     SetReady from the workspace lifecycle transition once startup
 //     scripts finish. This keeps pre-startup partial state out of
 //     coderd and chats.

--- a/agent/agentcontext/manager.go
+++ b/agent/agentcontext/manager.go
@@ -47,6 +47,16 @@ type ManagerOptions struct {
 	MCPCatalog func() []MCPServerStatus
 	// Debounce overrides the watcher's debounce window.
 	Debounce time.Duration
+	// GateUntilReady withholds context collection until SetReady is
+	// called. While gated the Manager publishes only an Initializing
+	// snapshot (no resources, no errors) and the push loop ships
+	// nothing, so partial pre-startup state never reaches coderd or
+	// hydrates a chat. The agent sets this and calls SetReady once the
+	// workspace finishes its startup scripts (lifecycle ready, or a
+	// terminal start_error / start_timeout). Embedders and tests that
+	// want the eager resolve-on-construct behavior leave it false (the
+	// default).
+	GateUntilReady bool
 }
 
 // Source is a user-declared scan root added to the agent's
@@ -98,6 +108,14 @@ type Manager struct {
 	// observe a change.
 	trigger chan struct{}
 
+	// ready gates collection. It starts false when
+	// ManagerOptions.GateUntilReady is set and flips true on the first
+	// SetReady call; otherwise it starts true. While false the Manager
+	// publishes only the Initializing snapshot and never walks the
+	// filesystem, so pre-startup partial state is never collected.
+	// Guarded by mu.
+	ready bool
+
 	// running tracks Run lifetime.
 	running      bool
 	closed       bool
@@ -140,6 +158,10 @@ func NewManager(opts ManagerOptions) *Manager {
 		closedCh:     make(chan struct{}),
 		runDoneCh:    make(chan struct{}),
 		runStartedCh: make(chan struct{}),
+		// ready starts true unless the caller asked to gate collection
+		// until SetReady. Gating keeps pre-startup partial state out of
+		// the first snapshot and the first push.
+		ready: !opts.GateUntilReady,
 	}
 
 	// Surface the shared MCP engine's catalog as KindMCPServer
@@ -170,10 +192,11 @@ func NewManager(opts ManagerOptions) *Manager {
 		m.addSourceLocked(identity)
 	}
 
-	// First snapshot is computed eagerly. The push protocol
-	// requires a snapshot to be present before the agent signals
-	// lifecycle = ready, so callers can rely on Snapshot() being
-	// populated immediately after NewManager returns.
+	// Compute the first snapshot eagerly so Snapshot() is populated the
+	// moment NewManager returns. When gated (GateUntilReady),
+	// resolveLocked publishes only the Initializing placeholder and
+	// skips the filesystem walk; the first real resolve runs on
+	// SetReady once startup scripts finish.
 	m.resolveLocked()
 
 	return m
@@ -444,6 +467,15 @@ func (m *Manager) Resync(ctx context.Context) (Snapshot, error) {
 		m.mu.Unlock()
 		return m.Snapshot(), ErrManagerClosed
 	}
+	if !m.ready {
+		// Gated by GateUntilReady: return the Initializing placeholder
+		// rather than walking the filesystem and publishing partial
+		// state. Callers (HTTP /resync, the socket server, the CLI) can
+		// surface a "still initializing" state until SetReady fires.
+		snap := m.snapshot
+		m.mu.Unlock()
+		return snap, nil
+	}
 	roots := m.scanRootsLocked()
 	resolver := m.resolver
 	watcher := m.watcher
@@ -535,6 +567,40 @@ func (m *Manager) Trigger() {
 	m.signal()
 }
 
+// SetReady releases the collection gate enabled by
+// ManagerOptions.GateUntilReady. The first call flips the Manager to
+// ready, performs the first real resolve, and broadcasts it so the
+// push loop ships the complete inventory (instruction files, skills,
+// and any connected MCP servers) instead of pre-startup partial
+// state. SetReady is idempotent and a no-op for a Manager that was
+// never gated.
+//
+// The agent calls SetReady once the workspace reaches lifecycle ready
+// (or a terminal start_error / start_timeout), so a failed startup
+// still surfaces whatever context exists rather than gating forever.
+func (m *Manager) SetReady() {
+	m.mu.Lock()
+	if m.ready || m.closed {
+		m.mu.Unlock()
+		return
+	}
+	m.ready = true
+	running := m.running
+	m.mu.Unlock()
+
+	if running {
+		// The Run loop owns the watcher; signal it so it re-syncs the
+		// watch set and resolves with ready=true, then broadcasts the
+		// first real snapshot to the push loop.
+		m.signal()
+		return
+	}
+	// No Run loop yet (embedders or tests driving the Manager
+	// directly): resolve inline so Snapshot reflects readiness
+	// immediately and any subscribers are notified.
+	m.resolveAndBroadcast(context.Background())
+}
+
 // scanRootsLocked returns the list of ScanRoots to feed the
 // resolver and watcher. The Manager's mutex must be held.
 func (m *Manager) scanRootsLocked() []ScanRoot {
@@ -599,6 +665,14 @@ func (m *Manager) resolveAndBroadcast(ctx context.Context) {
 	// RemoveSource, Snapshot, and SubscribeChanges for the
 	// duration of the pass.
 	m.mu.Lock()
+	if !m.ready {
+		// Gated by GateUntilReady: keep the Initializing snapshot and
+		// skip both the filesystem walk and the broadcast so no
+		// pre-startup partial state is published. SetReady runs the
+		// first real resolve.
+		m.mu.Unlock()
+		return
+	}
 	roots := m.scanRootsLocked()
 	resolver := m.resolver
 	watcher := m.watcher
@@ -660,6 +734,14 @@ func (m *Manager) resolveAndBroadcast(ctx context.Context) {
 // must use resolveAndBroadcast, which drops the lock around
 // filesystem I/O.
 func (m *Manager) resolveLocked() {
+	if !m.ready {
+		// Gated by GateUntilReady: publish the Initializing placeholder
+		// without touching the filesystem. SetReady runs the first real
+		// resolve once the workspace finishes startup.
+		m.version++
+		m.snapshot = Snapshot{Version: m.version, Initializing: true}
+		return
+	}
 	roots := m.scanRootsLocked()
 	snap := m.resolver.Resolve(roots)
 	m.version++

--- a/agent/agentcontext/manager.go
+++ b/agent/agentcontext/manager.go
@@ -175,10 +175,7 @@ func NewManager(opts ManagerOptions) *Manager {
 	}
 
 	// Start gated: m.snapshot stays the zero value (version 0) until
-	// SetReady runs the first resolve. The push loop treats version 0 as
-	// the pre-ready placeholder and withholds it, keeping pre-startup
-	// partial state out of every snapshot.
-
+	// SetReady runs the first resolve.
 	return m
 }
 
@@ -448,9 +445,7 @@ func (m *Manager) Resync(ctx context.Context) (Snapshot, error) {
 		return m.Snapshot(), ErrManagerClosed
 	}
 	if !m.ready {
-		// Gated: return the version-0 placeholder instead of walking the
-		// filesystem; callers can treat version 0 as "still initializing"
-		// until SetReady fires.
+		// Gated until SetReady: return the version-0 placeholder, no scan.
 		snap := m.snapshot
 		m.mu.Unlock()
 		return snap, nil
@@ -638,8 +633,7 @@ func (m *Manager) resolveAndBroadcast(ctx context.Context) {
 	// duration of the pass.
 	m.mu.Lock()
 	if !m.ready {
-		// Gated: keep the version-0 placeholder and skip the walk and
-		// broadcast.
+		// Gated until SetReady: no scan, no broadcast.
 		m.mu.Unlock()
 		return
 	}

--- a/agent/agentcontext/manager.go
+++ b/agent/agentcontext/manager.go
@@ -47,16 +47,6 @@ type ManagerOptions struct {
 	MCPCatalog func() []MCPServerStatus
 	// Debounce overrides the watcher's debounce window.
 	Debounce time.Duration
-	// GateUntilReady withholds context collection until SetReady is
-	// called. While gated the Manager publishes only an Initializing
-	// snapshot (no resources, no errors) and the push loop ships
-	// nothing, so partial pre-startup state never reaches coderd or
-	// hydrates a chat. The agent sets this and calls SetReady once the
-	// workspace finishes its startup scripts (lifecycle ready, or a
-	// terminal start_error / start_timeout). Embedders and tests that
-	// want the eager resolve-on-construct behavior leave it false (the
-	// default).
-	GateUntilReady bool
 }
 
 // Source is a user-declared scan root added to the agent's
@@ -108,12 +98,10 @@ type Manager struct {
 	// observe a change.
 	trigger chan struct{}
 
-	// ready gates collection. It starts false when
-	// ManagerOptions.GateUntilReady is set and flips true on the first
-	// SetReady call; otherwise it starts true. While false the Manager
-	// publishes only the Initializing snapshot and never walks the
-	// filesystem, so pre-startup partial state is never collected.
-	// Guarded by mu.
+	// ready gates collection. It starts false and flips true on the
+	// first SetReady call. While false the Manager publishes only the
+	// Initializing snapshot and never walks the filesystem, so
+	// pre-startup partial state is never collected. Guarded by mu.
 	ready bool
 
 	// running tracks Run lifetime.
@@ -126,10 +114,11 @@ type Manager struct {
 	watcher *Watcher
 }
 
-// NewManager validates options, canonicalizes initial sources,
-// performs the first resolver pass synchronously, and returns
-// the resulting Manager. Run must be called separately to start
-// the watcher and re-resolve goroutine.
+// NewManager validates options, canonicalizes initial sources, and
+// returns a Manager whose first snapshot is the Initializing
+// placeholder. The Manager starts gated: the first real resolver pass
+// runs on SetReady. Run must be called separately to start the watcher
+// and re-resolve goroutine.
 func NewManager(opts ManagerOptions) *Manager {
 	clock := opts.Clock
 	if clock == nil {
@@ -158,10 +147,6 @@ func NewManager(opts ManagerOptions) *Manager {
 		closedCh:     make(chan struct{}),
 		runDoneCh:    make(chan struct{}),
 		runStartedCh: make(chan struct{}),
-		// ready starts true unless the caller asked to gate collection
-		// until SetReady. Gating keeps pre-startup partial state out of
-		// the first snapshot and the first push.
-		ready: !opts.GateUntilReady,
 	}
 
 	// Surface the shared MCP engine's catalog as KindMCPServer
@@ -169,8 +154,8 @@ func NewManager(opts ManagerOptions) *Manager {
 	// inject one via Resolver). The engine owns the connection
 	// lifecycle and notifies this Manager via Trigger when its
 	// catalog changes (see agent wiring). The provider must be wired
-	// before the eager first resolve below so the seam is present
-	// from the first snapshot.
+	// here, before SetReady runs the first resolve, so the seam is
+	// present from the first real snapshot.
 	if resolver.MCPResources == nil && opts.MCPCatalog != nil {
 		resolver.MCPResources = func() []Resource {
 			return buildMCPServerResources(opts.MCPCatalog())
@@ -192,12 +177,13 @@ func NewManager(opts ManagerOptions) *Manager {
 		m.addSourceLocked(identity)
 	}
 
-	// Compute the first snapshot eagerly so Snapshot() is populated the
-	// moment NewManager returns. When gated (GateUntilReady),
-	// resolveLocked publishes only the Initializing placeholder and
-	// skips the filesystem walk; the first real resolve runs on
-	// SetReady once startup scripts finish.
-	m.resolveLocked()
+	// The Manager starts gated: until SetReady fires it withholds
+	// collection and publishes only this initializing placeholder, so
+	// pre-startup partial state (unresolved instruction-file symlinks,
+	// unsynced skills, MCP servers that have not connected) never
+	// reaches a snapshot, the push loop, or a chat. SetReady performs
+	// the first real resolve once the workspace finishes startup.
+	m.snapshot = Snapshot{Initializing: true}
 
 	return m
 }
@@ -468,7 +454,7 @@ func (m *Manager) Resync(ctx context.Context) (Snapshot, error) {
 		return m.Snapshot(), ErrManagerClosed
 	}
 	if !m.ready {
-		// Gated by GateUntilReady: return the Initializing placeholder
+		// Gated until SetReady: return the Initializing placeholder
 		// rather than walking the filesystem and publishing partial
 		// state. Callers (HTTP /resync, the socket server, the CLI) can
 		// surface a "still initializing" state until SetReady fires.
@@ -567,13 +553,12 @@ func (m *Manager) Trigger() {
 	m.signal()
 }
 
-// SetReady releases the collection gate enabled by
-// ManagerOptions.GateUntilReady. The first call flips the Manager to
-// ready, performs the first real resolve, and broadcasts it so the
-// push loop ships the complete inventory (instruction files, skills,
-// and any connected MCP servers) instead of pre-startup partial
-// state. SetReady is idempotent and a no-op for a Manager that was
-// never gated.
+// SetReady releases the collection gate. The Manager starts gated and
+// withholds collection (publishing only an Initializing snapshot)
+// until the first SetReady call, which performs the first resolve and
+// broadcasts it so the push loop ships the complete inventory
+// (instruction files, skills, and any connected MCP servers) instead
+// of pre-startup partial state. SetReady is idempotent.
 //
 // The agent calls SetReady once the workspace reaches lifecycle ready
 // (or a terminal start_error / start_timeout), so a failed startup
@@ -666,10 +651,9 @@ func (m *Manager) resolveAndBroadcast(ctx context.Context) {
 	// duration of the pass.
 	m.mu.Lock()
 	if !m.ready {
-		// Gated by GateUntilReady: keep the Initializing snapshot and
-		// skip both the filesystem walk and the broadcast so no
-		// pre-startup partial state is published. SetReady runs the
-		// first real resolve.
+		// Gated until SetReady: keep the Initializing snapshot and skip
+		// both the filesystem walk and the broadcast so no pre-startup
+		// partial state is published. SetReady runs the first resolve.
 		m.mu.Unlock()
 		return
 	}
@@ -726,34 +710,6 @@ func (m *Manager) resolveAndBroadcast(ctx context.Context) {
 		default:
 		}
 	}
-}
-
-// resolveLocked runs the resolver inline while m.mu is held.
-// It is used by the synchronous initial resolve in NewManager,
-// where there is no concurrent reader. Background re-resolves
-// must use resolveAndBroadcast, which drops the lock around
-// filesystem I/O.
-func (m *Manager) resolveLocked() {
-	if !m.ready {
-		// Gated by GateUntilReady: publish the Initializing placeholder
-		// without touching the filesystem. SetReady runs the first real
-		// resolve once the workspace finishes startup.
-		m.version++
-		m.snapshot = Snapshot{Version: m.version, Initializing: true}
-		return
-	}
-	roots := m.scanRootsLocked()
-	snap := m.resolver.Resolve(roots)
-	m.version++
-	snap.Version = m.version
-	// Surface watcher degradation as a snapshot-level error
-	// when the resolver did not already emit one.
-	if snap.SnapshotError == "" && m.watcher != nil {
-		if d := m.watcher.Degraded(); d != "" {
-			snap.SnapshotError = d
-		}
-	}
-	m.snapshot = snap
 }
 
 // ErrSourceNotFound is returned by RemoveSource when the

--- a/agent/agentcontext/manager.go
+++ b/agent/agentcontext/manager.go
@@ -98,9 +98,10 @@ type Manager struct {
 	// observe a change.
 	trigger chan struct{}
 
-	// ready gates collection: while false (until the first SetReady
-	// call) the Manager publishes only the empty version-0 snapshot and
-	// never walks the filesystem. Guarded by mu.
+	// ready gates collection. While false (until the first SetReady
+	// call) the Manager does not scan; Snapshot() returns the empty
+	// version-0 value, which the push loop never sends to coderd.
+	// Guarded by mu.
 	ready bool
 
 	// running tracks Run lifetime.
@@ -541,12 +542,10 @@ func (m *Manager) Trigger() {
 	m.signal()
 }
 
-// SetReady releases the collection gate. The first call performs the
-// first real resolve and broadcasts it, so the push loop ships the
-// complete inventory instead of pre-startup partial state. SetReady is
-// idempotent. The agent calls it once the workspace reaches lifecycle
-// ready (or a terminal start_error / start_timeout, so a failed startup
-// still surfaces whatever context exists rather than gating forever).
+// SetReady starts context collection: the agent calls it once startup
+// scripts finish (or terminally fail) so context is never collected
+// from a half-built workspace. Idempotent; the first call triggers the
+// first resolve and push.
 func (m *Manager) SetReady() {
 	m.mu.Lock()
 	if m.ready || m.closed {

--- a/agent/agentcontext/manager.go
+++ b/agent/agentcontext/manager.go
@@ -98,10 +98,9 @@ type Manager struct {
 	// observe a change.
 	trigger chan struct{}
 
-	// ready gates collection. It starts false and flips true on the
-	// first SetReady call. While false the Manager publishes only the
-	// Initializing snapshot and never walks the filesystem, so
-	// pre-startup partial state is never collected. Guarded by mu.
+	// ready gates collection: while false (until the first SetReady
+	// call) the Manager publishes only the Initializing snapshot and
+	// never walks the filesystem. Guarded by mu.
 	ready bool
 
 	// running tracks Run lifetime.
@@ -114,11 +113,10 @@ type Manager struct {
 	watcher *Watcher
 }
 
-// NewManager validates options, canonicalizes initial sources, and
-// returns a Manager whose first snapshot is the Initializing
-// placeholder. The Manager starts gated: the first real resolver pass
-// runs on SetReady. Run must be called separately to start the watcher
-// and re-resolve goroutine.
+// NewManager validates options and canonicalizes initial sources. The
+// returned Manager is gated, so its first snapshot is the Initializing
+// placeholder and the first real resolve runs on SetReady. Call Run to
+// start the watcher and re-resolve goroutine.
 func NewManager(opts ManagerOptions) *Manager {
 	clock := opts.Clock
 	if clock == nil {
@@ -153,9 +151,8 @@ func NewManager(opts ManagerOptions) *Manager {
 	// resources unless the resolver already has a provider (tests
 	// inject one via Resolver). The engine owns the connection
 	// lifecycle and notifies this Manager via Trigger when its
-	// catalog changes (see agent wiring). The provider must be wired
-	// here, before SetReady runs the first resolve, so the seam is
-	// present from the first real snapshot.
+	// catalog changes (see agent wiring). Wire it before SetReady runs
+	// the first resolve.
 	if resolver.MCPResources == nil && opts.MCPCatalog != nil {
 		resolver.MCPResources = func() []Resource {
 			return buildMCPServerResources(opts.MCPCatalog())
@@ -177,12 +174,9 @@ func NewManager(opts ManagerOptions) *Manager {
 		m.addSourceLocked(identity)
 	}
 
-	// The Manager starts gated: until SetReady fires it withholds
-	// collection and publishes only this initializing placeholder, so
-	// pre-startup partial state (unresolved instruction-file symlinks,
-	// unsynced skills, MCP servers that have not connected) never
-	// reaches a snapshot, the push loop, or a chat. SetReady performs
-	// the first real resolve once the workspace finishes startup.
+	// Start gated: until SetReady the Manager publishes only this
+	// placeholder, keeping pre-startup partial state out of every
+	// snapshot and the push loop.
 	m.snapshot = Snapshot{Initializing: true}
 
 	return m
@@ -454,10 +448,8 @@ func (m *Manager) Resync(ctx context.Context) (Snapshot, error) {
 		return m.Snapshot(), ErrManagerClosed
 	}
 	if !m.ready {
-		// Gated until SetReady: return the Initializing placeholder
-		// rather than walking the filesystem and publishing partial
-		// state. Callers (HTTP /resync, the socket server, the CLI) can
-		// surface a "still initializing" state until SetReady fires.
+		// Gated: return the placeholder instead of walking the filesystem,
+		// so callers see "initializing" until SetReady fires.
 		snap := m.snapshot
 		m.mu.Unlock()
 		return snap, nil
@@ -553,16 +545,12 @@ func (m *Manager) Trigger() {
 	m.signal()
 }
 
-// SetReady releases the collection gate. The Manager starts gated and
-// withholds collection (publishing only an Initializing snapshot)
-// until the first SetReady call, which performs the first resolve and
-// broadcasts it so the push loop ships the complete inventory
-// (instruction files, skills, and any connected MCP servers) instead
-// of pre-startup partial state. SetReady is idempotent.
-//
-// The agent calls SetReady once the workspace reaches lifecycle ready
-// (or a terminal start_error / start_timeout), so a failed startup
-// still surfaces whatever context exists rather than gating forever.
+// SetReady releases the collection gate. The first call performs the
+// first real resolve and broadcasts it, so the push loop ships the
+// complete inventory instead of pre-startup partial state. SetReady is
+// idempotent. The agent calls it once the workspace reaches lifecycle
+// ready (or a terminal start_error / start_timeout, so a failed startup
+// still surfaces whatever context exists rather than gating forever).
 func (m *Manager) SetReady() {
 	m.mu.Lock()
 	if m.ready || m.closed {
@@ -574,15 +562,13 @@ func (m *Manager) SetReady() {
 	m.mu.Unlock()
 
 	if running {
-		// The Run loop owns the watcher; signal it so it re-syncs the
-		// watch set and resolves with ready=true, then broadcasts the
-		// first real snapshot to the push loop.
+		// The Run loop owns the watcher; signal it to re-sync and resolve
+		// with ready=true.
 		m.signal()
 		return
 	}
-	// No Run loop yet (embedders or tests driving the Manager
-	// directly): resolve inline so Snapshot reflects readiness
-	// immediately and any subscribers are notified.
+	// No Run loop yet (embedders or tests driving the Manager directly):
+	// resolve inline.
 	m.resolveAndBroadcast(context.Background())
 }
 
@@ -651,9 +637,7 @@ func (m *Manager) resolveAndBroadcast(ctx context.Context) {
 	// duration of the pass.
 	m.mu.Lock()
 	if !m.ready {
-		// Gated until SetReady: keep the Initializing snapshot and skip
-		// both the filesystem walk and the broadcast so no pre-startup
-		// partial state is published. SetReady runs the first resolve.
+		// Gated: keep the placeholder and skip the walk and broadcast.
 		m.mu.Unlock()
 		return
 	}

--- a/agent/agentcontext/manager.go
+++ b/agent/agentcontext/manager.go
@@ -99,7 +99,7 @@ type Manager struct {
 	trigger chan struct{}
 
 	// ready gates collection: while false (until the first SetReady
-	// call) the Manager publishes only the Initializing snapshot and
+	// call) the Manager publishes only the empty version-0 snapshot and
 	// never walks the filesystem. Guarded by mu.
 	ready bool
 
@@ -114,9 +114,9 @@ type Manager struct {
 }
 
 // NewManager validates options and canonicalizes initial sources. The
-// returned Manager is gated, so its first snapshot is the Initializing
-// placeholder and the first real resolve runs on SetReady. Call Run to
-// start the watcher and re-resolve goroutine.
+// returned Manager is gated, so its first snapshot is the empty
+// version-0 placeholder and the first real resolve runs on SetReady.
+// Call Run to start the watcher and re-resolve goroutine.
 func NewManager(opts ManagerOptions) *Manager {
 	clock := opts.Clock
 	if clock == nil {
@@ -174,10 +174,10 @@ func NewManager(opts ManagerOptions) *Manager {
 		m.addSourceLocked(identity)
 	}
 
-	// Start gated: until SetReady the Manager publishes only this
-	// placeholder, keeping pre-startup partial state out of every
-	// snapshot and the push loop.
-	m.snapshot = Snapshot{Initializing: true}
+	// Start gated: m.snapshot stays the zero value (version 0) until
+	// SetReady runs the first resolve. The push loop treats version 0 as
+	// the pre-ready placeholder and withholds it, keeping pre-startup
+	// partial state out of every snapshot.
 
 	return m
 }
@@ -448,8 +448,9 @@ func (m *Manager) Resync(ctx context.Context) (Snapshot, error) {
 		return m.Snapshot(), ErrManagerClosed
 	}
 	if !m.ready {
-		// Gated: return the placeholder instead of walking the filesystem,
-		// so callers see "initializing" until SetReady fires.
+		// Gated: return the version-0 placeholder instead of walking the
+		// filesystem; callers can treat version 0 as "still initializing"
+		// until SetReady fires.
 		snap := m.snapshot
 		m.mu.Unlock()
 		return snap, nil
@@ -637,7 +638,8 @@ func (m *Manager) resolveAndBroadcast(ctx context.Context) {
 	// duration of the pass.
 	m.mu.Lock()
 	if !m.ready {
-		// Gated: keep the placeholder and skip the walk and broadcast.
+		// Gated: keep the version-0 placeholder and skip the walk and
+		// broadcast.
 		m.mu.Unlock()
 		return
 	}

--- a/agent/agentcontext/manager_test.go
+++ b/agent/agentcontext/manager_test.go
@@ -370,6 +370,97 @@ func TestManager_SeedSourcesLateBindsAfterManifest(t *testing.T) {
 	require.Equal(t, late, snap.Resources[0].SourcePath)
 }
 
+// TestManager_GateUntilReadyWithholdsPartialState reproduces the
+// boot-time race the agent hit: when context is collected before
+// startup scripts finish, instruction-file symlinks (CLAUDE.md /
+// .cursorrules -> AGENTS.md) have no target yet, so an eager resolve
+// reports them as StatusUnreadable and ships a partial inventory.
+// With GateUntilReady the Manager withholds collection until
+// SetReady: the pre-ready snapshot is Initializing with no resources
+// and no errors, and the post-ready snapshot has the resolved files
+// with no spurious issues.
+func TestManager_GateUntilReadyWithholdsPartialState(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require admin privileges on Windows runners")
+	}
+	dir := testutil.TempDirResolved(t)
+	// CLAUDE.md and .cursorrules symlink to AGENTS.md, which does not
+	// exist yet (a startup script is still checking out the repo).
+	// EvalSymlinks fails, which an eager resolve would surface as a
+	// "symlink resolve" StatusUnreadable issue plus a partial inventory.
+	require.NoError(t, os.Symlink(filepath.Join(dir, "AGENTS.md"), filepath.Join(dir, "CLAUDE.md")))
+	require.NoError(t, os.Symlink(filepath.Join(dir, "AGENTS.md"), filepath.Join(dir, ".cursorrules")))
+
+	m := newTestManager(t, agentcontext.ManagerOptions{
+		WorkingDir:     func() string { return dir },
+		GateUntilReady: true,
+	})
+
+	// Before SetReady the snapshot is the initializing placeholder: no
+	// resources, no errors, Initializing=true. The broken symlinks are
+	// NOT reported as issues.
+	snap := m.Snapshot()
+	require.True(t, snap.Initializing, "gated snapshot must be marked initializing")
+	require.Empty(t, snap.Resources, "gated snapshot must not collect a partial inventory")
+	require.Empty(t, snap.SnapshotError, "gated snapshot must not surface transient errors")
+
+	// Resync stays gated too, so in-workspace callers see Initializing
+	// instead of a partial result.
+	rs, err := m.Resync(testutil.Context(t, testutil.WaitShort))
+	require.NoError(t, err)
+	require.True(t, rs.Initializing)
+	require.Empty(t, rs.Resources)
+
+	// Startup finishes: AGENTS.md now exists, so the symlinks resolve.
+	mustWriteFile(t, filepath.Join(dir, "AGENTS.md"), "# rules\n")
+
+	// Release the gate. SetReady performs the first real resolve.
+	m.SetReady()
+
+	snap = m.Snapshot()
+	require.False(t, snap.Initializing, "post-ready snapshot must not be initializing")
+	require.NotEmpty(t, snap.Resources, "post-ready snapshot must include resolved files")
+	require.Empty(t, snap.SnapshotError)
+	var instr int
+	for _, r := range snap.Resources {
+		require.NotEqualf(t, agentcontext.StatusUnreadable, r.Status,
+			"resolved snapshot must not contain spurious unreadable issues: %s", r.Source)
+		if r.Kind == agentcontext.KindInstructionFile {
+			instr++
+		}
+	}
+	// AGENTS.md and the two symlinks that resolve to it collapse to a
+	// single instruction-file resource.
+	require.Equal(t, 1, instr)
+}
+
+// TestManager_SetReadyIdempotentAndUngatedNoop verifies SetReady is
+// safe to call repeatedly and is a no-op for a Manager that was not
+// gated (the default), which collects eagerly at construction.
+func TestManager_SetReadyIdempotentAndUngatedNoop(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "AGENTS.md"), "rules")
+
+	// Ungated (default): the eager snapshot is already populated and not
+	// Initializing.
+	m := newTestManager(t, agentcontext.ManagerOptions{
+		WorkingDir: func() string { return dir },
+	})
+	snap := m.Snapshot()
+	require.False(t, snap.Initializing)
+	require.Len(t, snap.Resources, 1)
+
+	// SetReady on an ungated Manager is a no-op: it must not panic or
+	// change the inventory, and stays safe across repeated calls.
+	m.SetReady()
+	m.SetReady()
+	snap = m.Snapshot()
+	require.False(t, snap.Initializing)
+	require.Len(t, snap.Resources, 1)
+}
+
 func TestManager_CloseIsIdempotent(t *testing.T) {
 	t.Parallel()
 	m := newTestManager(t, agentcontext.ManagerOptions{

--- a/agent/agentcontext/manager_test.go
+++ b/agent/agentcontext/manager_test.go
@@ -53,7 +53,7 @@ func newTestManager(t *testing.T, opts agentcontext.ManagerOptions) *agentcontex
 }
 
 // newPendingTestManager builds a gated Manager (first snapshot is the
-// Initializing placeholder at version 0) for tests that drive SetReady
+// empty version-0 placeholder) for tests that drive SetReady
 // themselves.
 func newPendingTestManager(t *testing.T, opts agentcontext.ManagerOptions) *agentcontext.Manager {
 	t.Helper()
@@ -386,8 +386,8 @@ func TestManager_SeedSourcesLateBindsAfterManifest(t *testing.T) {
 // TestManager_WithholdsCollectionUntilReady reproduces the boot-time
 // race: collecting before startup finishes sees instruction-file
 // symlinks (CLAUDE.md / .cursorrules -> AGENTS.md) with no target yet.
-// The gated snapshot is Initializing with no resources or errors;
-// after SetReady the symlinks resolve cleanly.
+// The gated snapshot is the version-0 placeholder with no resources or
+// errors; after SetReady the symlinks resolve cleanly.
 func TestManager_WithholdsCollectionUntilReady(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {
@@ -403,19 +403,18 @@ func TestManager_WithholdsCollectionUntilReady(t *testing.T) {
 		WorkingDir: func() string { return dir },
 	})
 
-	// Before SetReady the snapshot is the initializing placeholder: no
-	// resources, no errors, Initializing=true. The broken symlinks are
-	// NOT reported as issues.
+	// Before SetReady the snapshot is the version-0 placeholder: no
+	// resources and no errors. The broken symlinks are NOT reported.
 	snap := m.Snapshot()
-	require.True(t, snap.Initializing, "gated snapshot must be marked initializing")
+	require.Zero(t, snap.Version, "gated snapshot must be the version-0 placeholder")
 	require.Empty(t, snap.Resources, "gated snapshot must not collect a partial inventory")
 	require.Empty(t, snap.SnapshotError, "gated snapshot must not surface transient errors")
 
-	// Resync stays gated too, so in-workspace callers see Initializing
+	// Resync stays gated too, so callers see the version-0 placeholder
 	// instead of a partial result.
 	rs, err := m.Resync(testutil.Context(t, testutil.WaitShort))
 	require.NoError(t, err)
-	require.True(t, rs.Initializing)
+	require.Zero(t, rs.Version)
 	require.Empty(t, rs.Resources)
 
 	// Startup finishes: AGENTS.md now exists, so the symlinks resolve.
@@ -425,7 +424,7 @@ func TestManager_WithholdsCollectionUntilReady(t *testing.T) {
 	m.SetReady()
 
 	snap = m.Snapshot()
-	require.False(t, snap.Initializing, "post-ready snapshot must not be initializing")
+	require.NotZero(t, snap.Version, "post-ready snapshot must be a real resolve")
 	require.NotEmpty(t, snap.Resources, "post-ready snapshot must include resolved files")
 	require.Empty(t, snap.SnapshotError)
 	var instr int
@@ -448,18 +447,17 @@ func TestManager_SetReadyIsIdempotent(t *testing.T) {
 	dir := t.TempDir()
 	mustWriteFile(t, filepath.Join(dir, "AGENTS.md"), "rules")
 
-	// Gated: first snapshot is the version-0 Initializing placeholder.
+	// Gated: first snapshot is the version-0 placeholder.
 	m := newPendingTestManager(t, agentcontext.ManagerOptions{
 		WorkingDir: func() string { return dir },
 	})
 	snap := m.Snapshot()
-	require.True(t, snap.Initializing)
+	require.Zero(t, snap.Version)
 	require.Empty(t, snap.Resources)
 
 	// First SetReady resolves once: version 1 with the inventory.
 	m.SetReady()
 	snap = m.Snapshot()
-	require.False(t, snap.Initializing)
 	require.Equal(t, uint64(1), snap.Version)
 	require.Len(t, snap.Resources, 1)
 
@@ -467,7 +465,6 @@ func TestManager_SetReadyIsIdempotent(t *testing.T) {
 	m.SetReady()
 	m.SetReady()
 	snap = m.Snapshot()
-	require.False(t, snap.Initializing)
 	require.Equal(t, uint64(1), snap.Version)
 	require.Len(t, snap.Resources, 1)
 }

--- a/agent/agentcontext/manager_test.go
+++ b/agent/agentcontext/manager_test.go
@@ -45,19 +45,16 @@ func TestMain(m *testing.M) {
 func newTestManager(t *testing.T, opts agentcontext.ManagerOptions) *agentcontext.Manager {
 	t.Helper()
 	m := newPendingTestManager(t, opts)
-	// The Manager always starts gated. Most tests want the eager, ready
-	// behavior, so release the gate here: SetReady performs the first
-	// resolve inline (Run is not active yet), leaving the resolved
-	// inventory at version 1. Gate-specific tests call
-	// newPendingTestManager directly and drive SetReady themselves.
+	// Most tests want the ready behavior; release the gate so the first
+	// snapshot is the resolved inventory at version 1. Gate tests use
+	// newPendingTestManager directly.
 	m.SetReady()
 	return m
 }
 
-// newPendingTestManager builds a Manager and leaves the readiness gate
-// closed, so its first snapshot is the Initializing placeholder at
-// version 0. Gate tests use it to assert pre-ready behavior before
-// calling SetReady.
+// newPendingTestManager builds a gated Manager (first snapshot is the
+// Initializing placeholder at version 0) for tests that drive SetReady
+// themselves.
 func newPendingTestManager(t *testing.T, opts agentcontext.ManagerOptions) *agentcontext.Manager {
 	t.Helper()
 	opts.Logger = testutil.Logger(t).Named("agentcontext-test")
@@ -386,25 +383,19 @@ func TestManager_SeedSourcesLateBindsAfterManifest(t *testing.T) {
 	require.Equal(t, late, snap.Resources[0].SourcePath)
 }
 
-// TestManager_WithholdsCollectionUntilReady reproduces the
-// boot-time race the agent hit: when context is collected before
-// startup scripts finish, instruction-file symlinks (CLAUDE.md /
-// .cursorrules -> AGENTS.md) have no target yet, so an eager resolve
-// reports them as StatusUnreadable and ships a partial inventory.
-// The Manager always starts gated and withholds collection until
-// SetReady: the pre-ready snapshot is Initializing with no resources
-// and no errors, and the post-ready snapshot has the resolved files
-// with no spurious issues.
+// TestManager_WithholdsCollectionUntilReady reproduces the boot-time
+// race: collecting before startup finishes sees instruction-file
+// symlinks (CLAUDE.md / .cursorrules -> AGENTS.md) with no target yet.
+// The gated snapshot is Initializing with no resources or errors;
+// after SetReady the symlinks resolve cleanly.
 func TestManager_WithholdsCollectionUntilReady(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("symlinks require admin privileges on Windows runners")
 	}
 	dir := testutil.TempDirResolved(t)
-	// CLAUDE.md and .cursorrules symlink to AGENTS.md, which does not
-	// exist yet (a startup script is still checking out the repo).
-	// EvalSymlinks fails, which an eager resolve would surface as a
-	// "symlink resolve" StatusUnreadable issue plus a partial inventory.
+	// CLAUDE.md and .cursorrules symlink to an AGENTS.md that does not
+	// exist yet, so an eager resolve would report them unreadable.
 	require.NoError(t, os.Symlink(filepath.Join(dir, "AGENTS.md"), filepath.Join(dir, "CLAUDE.md")))
 	require.NoError(t, os.Symlink(filepath.Join(dir, "AGENTS.md"), filepath.Join(dir, ".cursorrules")))
 
@@ -450,17 +441,14 @@ func TestManager_WithholdsCollectionUntilReady(t *testing.T) {
 	require.Equal(t, 1, instr)
 }
 
-// TestManager_SetReadyIsIdempotent verifies SetReady releases the gate
-// exactly once: the first call performs the initial resolve, and
-// repeated calls neither panic nor re-resolve (the version and
-// inventory stay put).
+// TestManager_SetReadyIsIdempotent verifies the first SetReady resolves
+// once (version 1) and repeated calls neither panic nor re-resolve.
 func TestManager_SetReadyIsIdempotent(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	mustWriteFile(t, filepath.Join(dir, "AGENTS.md"), "rules")
 
-	// The Manager starts gated: the first snapshot is the Initializing
-	// placeholder at version 0 with no resources.
+	// Gated: first snapshot is the version-0 Initializing placeholder.
 	m := newPendingTestManager(t, agentcontext.ManagerOptions{
 		WorkingDir: func() string { return dir },
 	})
@@ -468,16 +456,14 @@ func TestManager_SetReadyIsIdempotent(t *testing.T) {
 	require.True(t, snap.Initializing)
 	require.Empty(t, snap.Resources)
 
-	// The first SetReady resolves once: version advances to 1 with the
-	// resolved inventory.
+	// First SetReady resolves once: version 1 with the inventory.
 	m.SetReady()
 	snap = m.Snapshot()
 	require.False(t, snap.Initializing)
 	require.Equal(t, uint64(1), snap.Version)
 	require.Len(t, snap.Resources, 1)
 
-	// Further SetReady calls are no-ops: no panic, no re-resolve, and the
-	// version and inventory are unchanged.
+	// Further calls are no-ops: version and inventory unchanged.
 	m.SetReady()
 	m.SetReady()
 	snap = m.Snapshot()

--- a/agent/agentcontext/manager_test.go
+++ b/agent/agentcontext/manager_test.go
@@ -44,6 +44,22 @@ func TestMain(m *testing.M) {
 
 func newTestManager(t *testing.T, opts agentcontext.ManagerOptions) *agentcontext.Manager {
 	t.Helper()
+	m := newPendingTestManager(t, opts)
+	// The Manager always starts gated. Most tests want the eager, ready
+	// behavior, so release the gate here: SetReady performs the first
+	// resolve inline (Run is not active yet), leaving the resolved
+	// inventory at version 1. Gate-specific tests call
+	// newPendingTestManager directly and drive SetReady themselves.
+	m.SetReady()
+	return m
+}
+
+// newPendingTestManager builds a Manager and leaves the readiness gate
+// closed, so its first snapshot is the Initializing placeholder at
+// version 0. Gate tests use it to assert pre-ready behavior before
+// calling SetReady.
+func newPendingTestManager(t *testing.T, opts agentcontext.ManagerOptions) *agentcontext.Manager {
+	t.Helper()
 	opts.Logger = testutil.Logger(t).Named("agentcontext-test")
 	m := agentcontext.NewManager(opts)
 	t.Cleanup(func() { _ = m.Close() })
@@ -370,16 +386,16 @@ func TestManager_SeedSourcesLateBindsAfterManifest(t *testing.T) {
 	require.Equal(t, late, snap.Resources[0].SourcePath)
 }
 
-// TestManager_GateUntilReadyWithholdsPartialState reproduces the
+// TestManager_WithholdsCollectionUntilReady reproduces the
 // boot-time race the agent hit: when context is collected before
 // startup scripts finish, instruction-file symlinks (CLAUDE.md /
 // .cursorrules -> AGENTS.md) have no target yet, so an eager resolve
 // reports them as StatusUnreadable and ships a partial inventory.
-// With GateUntilReady the Manager withholds collection until
+// The Manager always starts gated and withholds collection until
 // SetReady: the pre-ready snapshot is Initializing with no resources
 // and no errors, and the post-ready snapshot has the resolved files
 // with no spurious issues.
-func TestManager_GateUntilReadyWithholdsPartialState(t *testing.T) {
+func TestManager_WithholdsCollectionUntilReady(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("symlinks require admin privileges on Windows runners")
@@ -392,9 +408,8 @@ func TestManager_GateUntilReadyWithholdsPartialState(t *testing.T) {
 	require.NoError(t, os.Symlink(filepath.Join(dir, "AGENTS.md"), filepath.Join(dir, "CLAUDE.md")))
 	require.NoError(t, os.Symlink(filepath.Join(dir, "AGENTS.md"), filepath.Join(dir, ".cursorrules")))
 
-	m := newTestManager(t, agentcontext.ManagerOptions{
-		WorkingDir:     func() string { return dir },
-		GateUntilReady: true,
+	m := newPendingTestManager(t, agentcontext.ManagerOptions{
+		WorkingDir: func() string { return dir },
 	})
 
 	// Before SetReady the snapshot is the initializing placeholder: no
@@ -435,29 +450,39 @@ func TestManager_GateUntilReadyWithholdsPartialState(t *testing.T) {
 	require.Equal(t, 1, instr)
 }
 
-// TestManager_SetReadyIdempotentAndUngatedNoop verifies SetReady is
-// safe to call repeatedly and is a no-op for a Manager that was not
-// gated (the default), which collects eagerly at construction.
-func TestManager_SetReadyIdempotentAndUngatedNoop(t *testing.T) {
+// TestManager_SetReadyIsIdempotent verifies SetReady releases the gate
+// exactly once: the first call performs the initial resolve, and
+// repeated calls neither panic nor re-resolve (the version and
+// inventory stay put).
+func TestManager_SetReadyIsIdempotent(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	mustWriteFile(t, filepath.Join(dir, "AGENTS.md"), "rules")
 
-	// Ungated (default): the eager snapshot is already populated and not
-	// Initializing.
-	m := newTestManager(t, agentcontext.ManagerOptions{
+	// The Manager starts gated: the first snapshot is the Initializing
+	// placeholder at version 0 with no resources.
+	m := newPendingTestManager(t, agentcontext.ManagerOptions{
 		WorkingDir: func() string { return dir },
 	})
 	snap := m.Snapshot()
+	require.True(t, snap.Initializing)
+	require.Empty(t, snap.Resources)
+
+	// The first SetReady resolves once: version advances to 1 with the
+	// resolved inventory.
+	m.SetReady()
+	snap = m.Snapshot()
 	require.False(t, snap.Initializing)
+	require.Equal(t, uint64(1), snap.Version)
 	require.Len(t, snap.Resources, 1)
 
-	// SetReady on an ungated Manager is a no-op: it must not panic or
-	// change the inventory, and stays safe across repeated calls.
+	// Further SetReady calls are no-ops: no panic, no re-resolve, and the
+	// version and inventory are unchanged.
 	m.SetReady()
 	m.SetReady()
 	snap = m.Snapshot()
 	require.False(t, snap.Initializing)
+	require.Equal(t, uint64(1), snap.Version)
 	require.Len(t, snap.Resources, 1)
 }
 

--- a/agent/agentcontext/push.go
+++ b/agent/agentcontext/push.go
@@ -101,12 +101,9 @@ func (m *Manager) RunPush(ctx context.Context, p Pusher, opts PushOptions) error
 	changes, unsub := m.SubscribeChanges()
 	defer unsub()
 
-	// First push uses the snapshot computed once the Manager is ready.
-	// While the Manager is gated (until SetReady) it publishes an
-	// Initializing snapshot; skip those so coderd never persists, and a
-	// chat never hydrates against, pre-startup partial state. The
-	// SetReady broadcast wakes this loop with the first real snapshot,
-	// which is then sent with Initial=true.
+	// Skip Initializing snapshots (published while the Manager is gated).
+	// The SetReady broadcast wakes this loop with the first real
+	// snapshot, sent with Initial=true.
 	initial := true
 	for {
 		snap := m.Snapshot()

--- a/agent/agentcontext/push.go
+++ b/agent/agentcontext/push.go
@@ -101,13 +101,13 @@ func (m *Manager) RunPush(ctx context.Context, p Pusher, opts PushOptions) error
 	changes, unsub := m.SubscribeChanges()
 	defer unsub()
 
-	// Skip Initializing snapshots (published while the Manager is gated).
-	// The SetReady broadcast wakes this loop with the first real
-	// snapshot, sent with Initial=true.
+	// Skip the gated placeholder: the Manager holds a version-0 snapshot
+	// until SetReady. The SetReady broadcast wakes this loop with the
+	// first real snapshot (version 1+), sent with Initial=true.
 	initial := true
 	for {
 		snap := m.Snapshot()
-		if snap.Initializing {
+		if snap.Version == 0 {
 			select {
 			case <-ctx.Done():
 				return ctx.Err()

--- a/agent/agentcontext/push.go
+++ b/agent/agentcontext/push.go
@@ -101,10 +101,25 @@ func (m *Manager) RunPush(ctx context.Context, p Pusher, opts PushOptions) error
 	changes, unsub := m.SubscribeChanges()
 	defer unsub()
 
-	// First push uses the snapshot computed by NewManager.
+	// First push uses the snapshot computed once the Manager is ready.
+	// While the Manager is gated (GateUntilReady) it publishes an
+	// Initializing snapshot; skip those so coderd never persists, and a
+	// chat never hydrates against, pre-startup partial state. The
+	// SetReady broadcast wakes this loop with the first real snapshot,
+	// which is then sent with Initial=true.
 	initial := true
 	for {
 		snap := m.Snapshot()
+		if snap.Initializing {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-m.closedCh:
+				return nil
+			case <-changes:
+			}
+			continue
+		}
 		req := snapshotToPushRequest(snap, initial)
 
 		err := pushWithRetry(ctx, p, req, initialBackoff, maxBackoff, clock, logger)

--- a/agent/agentcontext/push.go
+++ b/agent/agentcontext/push.go
@@ -102,7 +102,7 @@ func (m *Manager) RunPush(ctx context.Context, p Pusher, opts PushOptions) error
 	defer unsub()
 
 	// First push uses the snapshot computed once the Manager is ready.
-	// While the Manager is gated (GateUntilReady) it publishes an
+	// While the Manager is gated (until SetReady) it publishes an
 	// Initializing snapshot; skip those so coderd never persists, and a
 	// chat never hydrates against, pre-startup partial state. The
 	// SetReady broadcast wakes this loop with the first real snapshot,

--- a/agent/agentcontext/push.go
+++ b/agent/agentcontext/push.go
@@ -101,9 +101,7 @@ func (m *Manager) RunPush(ctx context.Context, p Pusher, opts PushOptions) error
 	changes, unsub := m.SubscribeChanges()
 	defer unsub()
 
-	// Skip the gated placeholder: the Manager holds a version-0 snapshot
-	// until SetReady. The SetReady broadcast wakes this loop with the
-	// first real snapshot (version 1+), sent with Initial=true.
+	// Until SetReady the snapshot is version 0: wait, don't push it.
 	initial := true
 	for {
 		snap := m.Snapshot()

--- a/agent/agentcontext/push_test.go
+++ b/agent/agentcontext/push_test.go
@@ -293,6 +293,64 @@ func TestRunPush_RejectedResponseProceeds(t *testing.T) {
 	require.ErrorIs(t, <-pushDone, context.Canceled)
 }
 
+// TestRunPush_GatedUntilReady verifies the push loop ships nothing
+// while the Manager is gated (GateUntilReady) and ships the complete
+// inventory once SetReady fires. This is the push-side guarantee that
+// coderd never persists, and a chat never hydrates against,
+// pre-startup partial state.
+func TestRunPush_GatedUntilReady(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// Content exists from the start, but the Manager is gated: nothing
+	// must be pushed until SetReady, proving coderd never sees a
+	// pre-startup snapshot even when one could be collected.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("rules"), 0o600))
+
+	m := newTestManager(t, agentcontext.ManagerOptions{
+		WorkingDir:     func() string { return dir },
+		GateUntilReady: true,
+	})
+
+	p := newFakePusher()
+	ctx, cancel := context.WithCancel(testutil.Context(t, testutil.WaitLong))
+	defer cancel()
+
+	pushDone := make(chan error, 1)
+	go func() {
+		pushDone <- m.RunPush(ctx, p, agentcontext.PushOptions{
+			Logger: testutil.Logger(t).Named("push"),
+		})
+	}()
+
+	// While gated, no push must be sent even though AGENTS.md exists.
+	select {
+	case <-p.signal:
+		t.Fatal("push loop shipped a snapshot before SetReady")
+	case <-time.After(testutil.IntervalMedium):
+	}
+	require.Empty(t, p.snapshot(), "no push must happen before the gate releases")
+
+	// Startup completes; the gate releases and the first real snapshot
+	// is pushed with Initial=true.
+	m.SetReady()
+
+	select {
+	case <-p.signal:
+	case <-time.After(testutil.WaitShort):
+		t.Fatal("expected a push after SetReady")
+	}
+
+	requests := p.snapshot()
+	require.NotEmpty(t, requests)
+	first := requests[0]
+	require.True(t, first.Initial, "first push after the gate releases must be Initial")
+	require.NotEmpty(t, first.Resources, "first push must carry the resolved inventory")
+	require.Empty(t, first.SnapshotError, "first push must not carry a transient snapshot error")
+
+	cancel()
+	require.ErrorIs(t, <-pushDone, context.Canceled)
+}
+
 func TestRunPush_NilPusherErrors(t *testing.T) {
 	t.Parallel()
 	m := newTestManager(t, agentcontext.ManagerOptions{

--- a/agent/agentcontext/push_test.go
+++ b/agent/agentcontext/push_test.go
@@ -293,12 +293,12 @@ func TestRunPush_RejectedResponseProceeds(t *testing.T) {
 	require.ErrorIs(t, <-pushDone, context.Canceled)
 }
 
-// TestRunPush_GatedUntilReady verifies the push loop ships nothing
-// while the Manager is gated (GateUntilReady) and ships the complete
+// TestRunPush_WaitsForReady verifies the push loop ships nothing
+// while the Manager is gated (before SetReady) and ships the complete
 // inventory once SetReady fires. This is the push-side guarantee that
 // coderd never persists, and a chat never hydrates against,
 // pre-startup partial state.
-func TestRunPush_GatedUntilReady(t *testing.T) {
+func TestRunPush_WaitsForReady(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	// Content exists from the start, but the Manager is gated: nothing
@@ -306,9 +306,8 @@ func TestRunPush_GatedUntilReady(t *testing.T) {
 	// pre-startup snapshot even when one could be collected.
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("rules"), 0o600))
 
-	m := newTestManager(t, agentcontext.ManagerOptions{
-		WorkingDir:     func() string { return dir },
-		GateUntilReady: true,
+	m := newPendingTestManager(t, agentcontext.ManagerOptions{
+		WorkingDir: func() string { return dir },
 	})
 
 	p := newFakePusher()

--- a/agent/agentcontext/push_test.go
+++ b/agent/agentcontext/push_test.go
@@ -293,17 +293,14 @@ func TestRunPush_RejectedResponseProceeds(t *testing.T) {
 	require.ErrorIs(t, <-pushDone, context.Canceled)
 }
 
-// TestRunPush_WaitsForReady verifies the push loop ships nothing
-// while the Manager is gated (before SetReady) and ships the complete
-// inventory once SetReady fires. This is the push-side guarantee that
-// coderd never persists, and a chat never hydrates against,
-// pre-startup partial state.
+// TestRunPush_WaitsForReady verifies the push loop ships nothing while
+// the Manager is gated and ships the complete inventory once SetReady
+// fires, so coderd never sees pre-startup partial state.
 func TestRunPush_WaitsForReady(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	// Content exists from the start, but the Manager is gated: nothing
-	// must be pushed until SetReady, proving coderd never sees a
-	// pre-startup snapshot even when one could be collected.
+	// is pushed until SetReady.
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("rules"), 0o600))
 
 	m := newPendingTestManager(t, agentcontext.ManagerOptions{

--- a/agent/agentcontext/resolve.go
+++ b/agent/agentcontext/resolve.go
@@ -974,14 +974,10 @@ type Snapshot struct {
 	// string when present (count cap exceeded, watcher
 	// degraded, ENOSPC, etc.). Empty when healthy.
 	SnapshotError string
-	// Initializing reports that the Manager is gated until the agent
-	// signals startup completion (see Manager.SetReady). While true,
-	// Resources and SnapshotError are
-	// empty: the Manager deliberately withholds collection so
-	// pre-startup partial state (instruction-file symlinks whose target
-	// has not been checked out, skills that have not synced, MCP servers
-	// that have not connected) is never observed as real context. The
-	// push loop never ships an initializing snapshot to coderd.
+	// Initializing reports that the Manager is gated until SetReady.
+	// While true, Resources and SnapshotError are empty and the push
+	// loop ships nothing, so pre-startup partial state never reaches
+	// coderd.
 	Initializing bool
 }
 

--- a/agent/agentcontext/resolve.go
+++ b/agent/agentcontext/resolve.go
@@ -953,8 +953,10 @@ type MCPTool struct {
 // Snapshot is the immutable bundle of resources produced by a
 // single resolver pass.
 type Snapshot struct {
-	// Version is monotonically increasing per Manager
-	// instance; resets when the agent process restarts.
+	// Version is monotonically increasing per Manager instance; resets
+	// when the agent process restarts. Version 0 is the gated pre-ready
+	// placeholder (the first real resolve is version 1), which the push
+	// loop withholds.
 	Version uint64
 	// AggregateHash is sha256 over a canonical encoding of
 	// (ID, Kind, Source, ContentHash, Status) for every
@@ -974,11 +976,6 @@ type Snapshot struct {
 	// string when present (count cap exceeded, watcher
 	// degraded, ENOSPC, etc.). Empty when healthy.
 	SnapshotError string
-	// Initializing reports that the Manager is gated until SetReady.
-	// While true, Resources and SnapshotError are empty and the push
-	// loop ships nothing, so pre-startup partial state never reaches
-	// coderd.
-	Initializing bool
 }
 
 // driftResources returns the subset of resources that participate in

--- a/agent/agentcontext/resolve.go
+++ b/agent/agentcontext/resolve.go
@@ -974,6 +974,15 @@ type Snapshot struct {
 	// string when present (count cap exceeded, watcher
 	// degraded, ENOSPC, etc.). Empty when healthy.
 	SnapshotError string
+	// Initializing reports that the Manager is gated until the agent
+	// signals startup completion (see ManagerOptions.GateUntilReady and
+	// Manager.SetReady). While true, Resources and SnapshotError are
+	// empty: the Manager deliberately withholds collection so
+	// pre-startup partial state (instruction-file symlinks whose target
+	// has not been checked out, skills that have not synced, MCP servers
+	// that have not connected) is never observed as real context. The
+	// push loop never ships an initializing snapshot to coderd.
+	Initializing bool
 }
 
 // driftResources returns the subset of resources that participate in

--- a/agent/agentcontext/resolve.go
+++ b/agent/agentcontext/resolve.go
@@ -975,8 +975,8 @@ type Snapshot struct {
 	// degraded, ENOSPC, etc.). Empty when healthy.
 	SnapshotError string
 	// Initializing reports that the Manager is gated until the agent
-	// signals startup completion (see ManagerOptions.GateUntilReady and
-	// Manager.SetReady). While true, Resources and SnapshotError are
+	// signals startup completion (see Manager.SetReady). While true,
+	// Resources and SnapshotError are
 	// empty: the Manager deliberately withholds collection so
 	// pre-startup partial state (instruction-file symlinks whose target
 	// has not been checked out, skills that have not synced, MCP servers


### PR DESCRIPTION
## Problem

Workspace context surfaced in chat (Coder Agents) is incomplete and racy on a fresh boot:

- The context panel is missing personal skills (only repo-level skills under `.claude/skills` show up).
- The MCP section lists `.mcp.json` files but no MCP servers are registered.
- The Issues panel reports instruction files as unreadable, e.g. `CLAUDE.md (file: unreadable)` and `.cursorrules (file: unreadable)` with `symlink resolve: lstat .../AGENTS.md: no such file or directory`.

## Root cause

`agentcontext.Manager` collected and pushed context too eagerly:

- `NewManager` ran an eager resolve at agent `init()`.
- `RunPush` starts as a normal connection routine (`startAgentAPI210`) with no lifecycle gating, so the first snapshot was pushed (`Initial=true`) as soon as the agent API connected.

Both happened **before startup scripts finish** and before the lifecycle reaches `ready`. At that point:

- `CLAUDE.md` / `.cursorrules` symlinks to `AGENTS.md` don't resolve yet, so `EvalSymlinks` fails and the resolver emits `StatusUnreadable` "symlink resolve" issues.
- Personal skills haven't synced yet, so they're missing.
- MCP servers connect via `mcpManager.Reload(...)` only **after** `ready`, so only `.mcp.json` configs appear, with no servers.

That partial, error-laden snapshot is persisted by coderd and can hydrate a chat.

## Fix

Gate `agentcontext.Manager` until the agent is ready, unconditionally:

- The Manager always starts gated. `NewManager` leaves the zero-value (version 0) snapshot in place and never walks the filesystem; `RunPush` withholds version-0 snapshots, so nothing reaches coderd.
- The agent calls `Manager.SetReady()` from the lifecycle transition in `handleManifest`, right after startup scripts finish (`ready`, or terminal `start_error` / `start_timeout` so a failed startup still surfaces whatever context exists).
- On `SetReady`, the Manager performs the first real resolve (version 1) and broadcasts it; `RunPush` ships it with `Initial=true`. Later changes (MCP connect, skill edits) re-resolve and push as before.

Eager resolution before `ready` was the bug, not a mode worth preserving, so the gate is always on rather than an opt-in option. This aligns the agent-side push with chatd, which already waits for agent readiness before loading context. No proto/coderd/DB changes: coderd simply never receives a pre-ready snapshot.

<details>
<summary>Design notes &amp; decisions</summary>

- **Unconditional, not opt-in.** An earlier iteration added the gate as an opt-in `ManagerOptions.GateUntilReady`. Since the eager resolve-on-construct was the defect, the option, the eager first resolve, and the now-dead `resolveLocked` helper were all removed; the Manager is always gated until `SetReady`.
- **Version 0 is the pre-ready sentinel.** The gated placeholder is just the zero-value snapshot (version 0); the first real resolve is version 1, so the push loop withholds anything at version 0. An earlier revision carried a dedicated `Snapshot.Initializing` bool plus an HTTP `/resync` field, but the push loop was the only consumer and nothing read the HTTP field, so both were dropped.
- **Defer, don't retry symlinks.** Transient "unreadable" symlinks are an artifact of collecting before checkout. Deferring until `ready` fixes all three symptom classes at once and avoids masking genuine post-ready errors (a broken symlink at `ready` is still reported).
- **Release on terminal startup states too** (`start_error`, `start_timeout`), so a failed startup still surfaces whatever context exists instead of gating forever. On reconnect the Manager instance is reused and stays ready.

</details>

## Tests

- `agentcontext.TestManager_WithholdsCollectionUntilReady` simulates collection running before startup finishes (broken `CLAUDE.md` / `.cursorrules` -> `AGENTS.md` symlinks): asserts the gated snapshot is the empty version-0 placeholder with no resources and no `unreadable` issues, and that after `SetReady` (target now present) the inventory resolves cleanly to a single instruction file with no spurious issues.
- `agentcontext.TestRunPush_WaitsForReady` asserts the push loop ships nothing while gated even when content exists, then ships the full inventory with `Initial=true` after `SetReady`.
- `agentcontext.TestManager_SetReadyIsIdempotent` covers the version-0 placeholder before ready, the single resolve to version 1 on `SetReady`, and idempotency across repeated calls.
- Updated `agent.TestAgent_ContextStatePushed`: the first push now already contains `AGENTS.md` with `Initial=true` and no `UNREADABLE` resources (no pre-startup empty/partial push).

Validated on the changed packages: `go test -race ./agent/agentcontext/...`, `go test ./agent/ -run TestAgent_ContextStatePushed`, `golangci-lint run`, `go vet`, `gofmt` (all clean).

---
🤖 Generated by Coder Agents on behalf of @kylecarbs.