### PR TITLE
refactor: simplify aws-bedrock-region configuration

### DIFF
--- a/aibridge/intercept/messages/base.go
+++ b/aibridge/intercept/messages/base.go
@@ -69,11 +69,6 @@ var bedrockSupportedBetaFlags = map[string]bool{
 type BedrockRuntime struct {
 	Cfg   aibconfig.AWSBedrock
 	Creds aws.CredentialsProvider
-	// ResolvedRegion is the region the AWS SDK resolved at construction (from
-	// the environment, shared config, or IMDS). It is used for request signing
-	// when Cfg.Region is empty, e.g. a custom base URL with the region supplied
-	// via AWS_REGION.
-	ResolvedRegion string
 }
 
 type interceptionBase struct {
@@ -298,14 +293,8 @@ func (i *interceptionBase) withAWSBedrockOptions(ctx context.Context) ([]option.
 		return nil, xerrors.Errorf("resolve AWS credentials: %w", err)
 	}
 
-	// Fall back to the SDK-resolved region (e.g. from AWS_REGION) when no
-	// explicit region is configured.
-	region := cfg.Region
-	if region == "" {
-		region = i.bedrock.ResolvedRegion
-	}
 	awsCfg := aws.Config{
-		Region:      region,
+		Region:      cfg.Region,
 		Credentials: i.bedrock.Creds,
 	}
 

--- a/aibridge/provider/anthropic.go
+++ b/aibridge/provider/anthropic.go
@@ -63,11 +63,17 @@ func NewAnthropic(ctx context.Context, cfg config.Anthropic, bedrockCfg *config.
 	// so it is cheap to run at construction.
 	var bedrock *messages.BedrockRuntime
 	if bedrockCfg != nil {
-		creds, region, err := buildBedrockCredentials(ctx, *bedrockCfg)
+		creds, resolvedRegion, err := buildBedrockCredentials(ctx, *bedrockCfg)
 		if err != nil {
 			return nil, xerrors.Errorf("build bedrock credentials: %w", err)
 		}
-		bedrock = &messages.BedrockRuntime{Cfg: *bedrockCfg, Creds: creds, ResolvedRegion: region}
+		runtimeCfg := *bedrockCfg
+		// resolvedRegion is bedrockCfg.Region if provided;
+		// otherwise, it is resolved from the environment via awsconfig.LoadDefaultConfig
+		if runtimeCfg.Region == "" {
+			runtimeCfg.Region = resolvedRegion
+		}
+		bedrock = &messages.BedrockRuntime{Cfg: runtimeCfg, Creds: creds}
 	}
 
 	return &Anthropic{


### PR DESCRIPTION
We currently have two possible sources of truth for the Bedrock region:

* `cfg.Region`, when explicitly provided (this also covers the case where the UI parses the base URL and populates `cfg.Region`)
* the region resolved from the AWS environment

An explicitly configured region should always take precedence over the environment-derived region.

I suggest implementing this resolution policy in the `NewAnthropic` constructor so that, after initialization, there is a single source of truth for the resolved region.
