### PR TITLE
fix(scripts): add retry with backoff for GHCR registry operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -530,8 +530,9 @@ $(CODER_MAIN_IMAGE): $(CODER_ARCH_IMAGES_PUSHED)
 
 # Push a Docker image.
 $(CODER_ARCH_IMAGES_PUSHED): push/%: %
+	source ./scripts/lib.sh
 	image_tag="$$(cat "$<")"
-	docker push "$$image_tag"
+	retry 3 10 -- docker push "$$image_tag"
 .PHONY: $(CODER_ARCH_IMAGES_PUSHED)
 
 # Push the multi-arch Docker manifest.

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -131,7 +131,7 @@ if [[ "$build_base" != "" ]]; then
 
 	base_image="$build_base"
 else
-	docker pull --platform "$arch" "$base_image" 1>&2
+	retry 5 5 -- docker pull --platform "$arch" "$base_image" 1>&2
 fi
 
 log "--- Building Docker image for $arch ($image_tag)"
@@ -150,7 +150,7 @@ rm -rf "$temp_dir"
 
 if [[ "$push" == 1 ]]; then
 	log "--- Pushing Docker image for $arch ($image_tag)"
-	docker push "$image_tag" 1>&2
+	retry 5 5 -- docker push "$image_tag" 1>&2
 fi
 
 # SBOM generation and attestation moved to the GitHub workflow

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -131,7 +131,7 @@ if [[ "$build_base" != "" ]]; then
 
 	base_image="$build_base"
 else
-	retry 5 5 -- docker pull --platform "$arch" "$base_image" 1>&2
+	retry 3 10 -- docker pull --platform "$arch" "$base_image" 1>&2
 fi
 
 log "--- Building Docker image for $arch ($image_tag)"
@@ -150,7 +150,7 @@ rm -rf "$temp_dir"
 
 if [[ "$push" == 1 ]]; then
 	log "--- Pushing Docker image for $arch ($image_tag)"
-	retry 5 5 -- docker push "$image_tag" 1>&2
+	retry 3 10 -- docker push "$image_tag" 1>&2
 fi
 
 # SBOM generation and attestation moved to the GitHub workflow

--- a/scripts/build_docker_multiarch.sh
+++ b/scripts/build_docker_multiarch.sh
@@ -77,13 +77,13 @@ done
 
 # Sadly, manifests don't seem to support labels.
 log "--- Creating multi-arch Docker image ($target)"
-retry 5 5 -- docker manifest create \
+retry 3 10 -- docker manifest create \
 	"$target" \
 	"${create_args[@]}"
 
 if [[ "$push" == 1 ]]; then
 	log "--- Pushing multi-arch Docker image ($target)"
-	retry 5 5 -- docker manifest push "$target"
+	retry 3 10 -- docker manifest push "$target"
 fi
 
 echo "$target"

--- a/scripts/build_docker_multiarch.sh
+++ b/scripts/build_docker_multiarch.sh
@@ -77,13 +77,13 @@ done
 
 # Sadly, manifests don't seem to support labels.
 log "--- Creating multi-arch Docker image ($target)"
-docker manifest create \
+retry 5 5 -- docker manifest create \
 	"$target" \
 	"${create_args[@]}"
 
 if [[ "$push" == 1 ]]; then
 	log "--- Pushing multi-arch Docker image ($target)"
-	docker manifest push "$target"
+	retry 5 5 -- docker manifest push "$target"
 fi
 
 echo "$target"

--- a/scripts/build_docker_multiarch.sh
+++ b/scripts/build_docker_multiarch.sh
@@ -79,11 +79,11 @@ done
 log "--- Creating multi-arch Docker image ($target)"
 retry 3 10 -- docker manifest create \
 	"$target" \
-	"${create_args[@]}"
+	"${create_args[@]}" 1>&2
 
 if [[ "$push" == 1 ]]; then
 	log "--- Pushing multi-arch Docker image ($target)"
-	retry 3 10 -- docker manifest push "$target"
+	retry 3 10 -- docker manifest push "$target" 1>&2
 fi
 
 echo "$target"

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -197,6 +197,57 @@ error() {
 	exit 1
 }
 
+# retry runs a command, retrying it with exponential backoff if it fails. It is
+# intended for commands that touch flaky external services such as a container
+# registry.
+#
+# Usage: retry <max_attempts> <base_delay_seconds> -- <command...>
+#
+# The delay starts at base_delay_seconds and doubles after each failed attempt,
+# capped at 60 seconds. The command's stderr is left intact so the underlying
+# error stays visible. Returns the command's exit status from the final attempt.
+retry() {
+	if (($# < 3)); then
+		log "retry: usage: retry <max_attempts> <base_delay_seconds> [--] <command...>"
+		return 1
+	fi
+	local max_attempts="$1"
+	local delay="$2"
+	shift 2
+	if [[ ${1-} == "--" ]]; then
+		shift
+	fi
+	if (($# == 0)); then
+		log "retry: no command specified"
+		return 1
+	fi
+
+	local max_delay=60
+	local attempt=1
+	local status=0
+	while true; do
+		status=0
+		"$@" || status=$?
+		if ((status == 0)); then
+			if ((attempt > 1)); then
+				log "retry: succeeded after ${attempt} attempt(s)"
+			fi
+			return 0
+		fi
+		if ((attempt >= max_attempts)); then
+			log "retry: command failed after ${attempt} attempt(s)"
+			return "$status"
+		fi
+		log "retry: attempt ${attempt}/${max_attempts} failed (exit ${status}), retrying in ${delay}s"
+		sleep "$delay"
+		attempt=$((attempt + 1))
+		delay=$((delay * 2))
+		if ((delay > max_delay)); then
+			delay=$max_delay
+		fi
+	done
+}
+
 # isdarwin returns an error if the current platform is not darwin.
 isdarwin() {
 	[[ "${OSTYPE:-darwin}" == *darwin* ]]

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -221,6 +221,14 @@ retry() {
 		log "retry: no command specified"
 		return 1
 	fi
+	if ! [[ $max_attempts =~ ^[0-9]+$ ]] || ((max_attempts < 1)); then
+		log "retry: max_attempts must be a positive integer, got: ${max_attempts}"
+		return 1
+	fi
+	if ! [[ $delay =~ ^[0-9]+$ ]]; then
+		log "retry: base_delay_seconds must be a non-negative integer, got: ${delay}"
+		return 1
+	fi
 
 	local max_delay=60
 	local attempt=1


### PR DESCRIPTION
Adds exponential backoff retry logic to Docker registry operations to handle transient GHCR failures (timeouts, 503 errors).

## Changes

- Add `retry()` helper to `scripts/lib.sh` (3 attempts, 10s base delay, 60s cap)
- Wrap `docker pull`, `docker push`, `docker manifest create/push` with retry
- Log successful retries for observability
- Input validation for `set -u` safety

## Notes

- Worst-case: ~30s retry overhead per operation (10s + 20s) vs. 20+ min job re-run
- Underlying errors remain visible on stderr

Fixes: PLAT-207