### PR TITLE
fix: correct MCP registry remote URL in server.json

### DIFF
--- a/docs/ai-coder/mcp-server.md
+++ b/docs/ai-coder/mcp-server.md
@@ -112,7 +112,7 @@ as `io.github.coder/coder`, enabling easy installation in supported MCP clients.
 1. Open VS Code Command Palette and run **MCP: Add Server...**
 1. Select **From MCP Registry**
 1. Search for "Coder" and select it
-1. Enter your Coder deployment URL when prompted (e.g., `https://coder.example.com`)
+1. Enter your Coder deployment hostname when prompted (e.g., `coder.example.com`)
 1. VS Code will automatically handle OAuth2 authentication
 
 #### Claude Desktop (Remote)

--- a/server.json
+++ b/server.json
@@ -18,13 +18,13 @@
   "remotes": [
     {
       "type": "streamable-http",
-      "url": "{coder_url}/api/experimental/mcp/http",
+      "url": "https://{coder_hostname}/api/experimental/mcp/http",
       "variables": {
-        "coder_url": {
-          "description": "URL of your Coder deployment (e.g., https://coder.example.com)",
+        "coder_hostname": {
+          "description": "Hostname of your Coder deployment (e.g., coder.example.com)",
           "isRequired": true,
           "format": "string",
-          "placeholder": "https://coder.example.com"
+          "placeholder": "coder.example.com"
         }
       }
     }


### PR DESCRIPTION
The MCP Registry rejects our `server.json` remote because the URL uses `{coder_url}` as the entire base. Registry validation requires remote URLs to literally begin with `https://`, and template variables are only allowed after the scheme/host. The previous value (`{coder_url}/api/experimental/mcp/http`) fails both the JSON schema `^https?://[^\s]+$` pattern and the semantic remote-URL check.

## Changes

- Use `https://{coder_hostname}/api/experimental/mcp/http` with a `coder_hostname` variable (users now enter a hostname like `coder.example.com` instead of a full URL).
- Update the VS Code registry instructions in `docs/ai-coder/mcp-server.md` to ask for the deployment hostname.

Verified with `mcp-publisher validate` against `registry.modelcontextprotocol.io`:

```
Validating against https://registry.modelcontextprotocol.io...
✅ server.json is valid
```

This was caught by running the `Publish to MCP Registry` workflow in validate-only mode (`publish: false`) before any real publish, so nothing broken reached the public registry.

<details>
<summary>Root cause detail</summary>

The registry validator (`internal/validators`) substitutes known template variables, then parses the URL. Because `{coder_url}` replaces the whole scheme+host, the parsed URL has no scheme and is rejected as an invalid remote URL. Hard-coding `https://` and scoping the variable to the host satisfies both the schema pattern and `IsValidRemoteURL` (which also requires `https`). The registry mandates `https` for remotes regardless, so there is no loss of functionality.

</details>

---
_Generated with Coder Agents._