### PR TITLE
feat: add nats_ca crypto_key_feature enum value

### DIFF
--- a/coderd/cryptokeys/rotate.go
+++ b/coderd/cryptokeys/rotate.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"encoding/hex"
+	"slices"
 	"time"
 
 	"golang.org/x/xerrors"
@@ -26,6 +27,24 @@ const (
 	// DefaultKeyDuration is the default duration for which a key is valid. It applies to all features.
 	DefaultKeyDuration = time.Hour * 24 * 30
 )
+
+// defaultRotatedFeatures are the crypto key features the rotator manages. It
+// intentionally excludes features that are gated behind an experiment or
+// deployment flag so that a dormant feature's enum value does not cause the
+// rotator to mint keys it has no generator for. Gated features are opted in by
+// the caller that owns their generator.
+var defaultRotatedFeatures = []database.CryptoKeyFeature{
+	database.CryptoKeyFeatureWorkspaceAppsToken,
+	database.CryptoKeyFeatureWorkspaceAppsAPIKey,
+	database.CryptoKeyFeatureOIDCConvert,
+	database.CryptoKeyFeatureTailnetResume,
+}
+
+// DefaultRotatedFeatures returns the crypto key features the rotator manages by
+// default. It excludes experiment-gated features such as the NATS CA.
+func DefaultRotatedFeatures() []database.CryptoKeyFeature {
+	return slices.Clone(defaultRotatedFeatures)
+}
 
 // rotator is responsible for rotating keys in the database.
 type rotator struct {
@@ -62,7 +81,7 @@ func StartRotator(ctx context.Context, logger slog.Logger, db database.Store, op
 		logger:      logger.Named("keyrotator"),
 		clock:       quartz.NewReal(),
 		keyDuration: DefaultKeyDuration,
-		features:    database.AllCryptoKeyFeatureValues(),
+		features:    defaultRotatedFeatures,
 	}
 
 	for _, opt := range opts {

--- a/coderd/cryptokeys/rotate_internal_test.go
+++ b/coderd/cryptokeys/rotate_internal_test.go
@@ -358,7 +358,7 @@ func Test_rotateKeys(t *testing.T) {
 			keyDuration: keyDuration,
 			clock:       clock,
 			logger:      logger,
-			features:    database.AllCryptoKeyFeatureValues(),
+			features:    defaultRotatedFeatures,
 		}
 
 		now := dbnow(clock)
@@ -409,7 +409,7 @@ func Test_rotateKeys(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, keys, 5)
 
-		kbf, err := keysByFeature(keys, database.AllCryptoKeyFeatureValues())
+		kbf, err := keysByFeature(keys, defaultRotatedFeatures)
 		require.NoError(t, err)
 
 		// No actions on OIDC convert.

--- a/coderd/cryptokeys/rotate_test.go
+++ b/coderd/cryptokeys/rotate_test.go
@@ -37,7 +37,7 @@ func TestRotator(t *testing.T) {
 		// are as expected.
 		dbkeys, err = db.GetCryptoKeys(ctx)
 		require.NoError(t, err)
-		require.Len(t, dbkeys, len(database.AllCryptoKeyFeatureValues()))
+		require.Len(t, dbkeys, len(cryptokeys.DefaultRotatedFeatures()))
 		requireContainsAllFeatures(t, dbkeys)
 	})
 
@@ -64,7 +64,7 @@ func TestRotator(t *testing.T) {
 
 		cryptokeys.StartRotator(ctx, logger, db, cryptokeys.WithClock(clock))
 
-		initialKeyLen := len(database.AllCryptoKeyFeatureValues())
+		initialKeyLen := len(cryptokeys.DefaultRotatedFeatures())
 		// Fetch the keys from the database and ensure they
 		// are as expected.
 		dbkeys, err := db.GetCryptoKeys(ctx)
@@ -113,7 +113,7 @@ func requireContainsAllFeatures(t *testing.T, keys []database.CryptoKey) {
 	for _, key := range keys {
 		features[key.Feature] = true
 	}
-	for _, feature := range database.AllCryptoKeyFeatureValues() {
+	for _, feature := range cryptokeys.DefaultRotatedFeatures() {
 		require.True(t, features[feature])
 	}
 }

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -374,7 +374,8 @@ CREATE TYPE crypto_key_feature AS ENUM (
     'workspace_apps_token',
     'workspace_apps_api_key',
     'oidc_convert',
-    'tailnet_resume'
+    'tailnet_resume',
+    'nats_ca'
 );
 
 CREATE TYPE display_app AS ENUM (

--- a/coderd/database/migrations/000533_nats_ca_crypto_key_feature.down.sql
+++ b/coderd/database/migrations/000533_nats_ca_crypto_key_feature.down.sql
@@ -1,0 +1,16 @@
+DELETE FROM crypto_keys WHERE feature = 'nats_ca';
+
+CREATE TYPE old_crypto_key_feature AS ENUM (
+    'workspace_apps_token',
+    'workspace_apps_api_key',
+    'oidc_convert',
+    'tailnet_resume'
+);
+
+ALTER TABLE crypto_keys
+    ALTER COLUMN feature TYPE old_crypto_key_feature
+    USING (feature::text::old_crypto_key_feature);
+
+DROP TYPE crypto_key_feature;
+
+ALTER TYPE old_crypto_key_feature RENAME TO crypto_key_feature;

--- a/coderd/database/migrations/000533_nats_ca_crypto_key_feature.up.sql
+++ b/coderd/database/migrations/000533_nats_ca_crypto_key_feature.up.sql
@@ -1,0 +1,1 @@
+ALTER TYPE crypto_key_feature ADD VALUE IF NOT EXISTS 'nats_ca';

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -1887,6 +1887,7 @@ const (
 	CryptoKeyFeatureWorkspaceAppsAPIKey CryptoKeyFeature = "workspace_apps_api_key"
 	CryptoKeyFeatureOIDCConvert         CryptoKeyFeature = "oidc_convert"
 	CryptoKeyFeatureTailnetResume       CryptoKeyFeature = "tailnet_resume"
+	CryptoKeyFeatureNATSCA              CryptoKeyFeature = "nats_ca"
 )
 
 func (e *CryptoKeyFeature) Scan(src interface{}) error {
@@ -1929,7 +1930,8 @@ func (e CryptoKeyFeature) Valid() bool {
 	case CryptoKeyFeatureWorkspaceAppsToken,
 		CryptoKeyFeatureWorkspaceAppsAPIKey,
 		CryptoKeyFeatureOIDCConvert,
-		CryptoKeyFeatureTailnetResume:
+		CryptoKeyFeatureTailnetResume,
+		CryptoKeyFeatureNATSCA:
 		return true
 	}
 	return false
@@ -1941,6 +1943,7 @@ func AllCryptoKeyFeatureValues() []CryptoKeyFeature {
 		CryptoKeyFeatureWorkspaceAppsAPIKey,
 		CryptoKeyFeatureOIDCConvert,
 		CryptoKeyFeatureTailnetResume,
+		CryptoKeyFeatureNATSCA,
 	}
 }
 

--- a/coderd/database/sqlc.yaml
+++ b/coderd/database/sqlc.yaml
@@ -254,6 +254,7 @@ sql:
           login_type_oauth2_provider_app: LoginTypeOAuth2ProviderApp
           crypto_key_feature_workspace_apps_api_key: CryptoKeyFeatureWorkspaceAppsAPIKey
           crypto_key_feature_oidc_convert: CryptoKeyFeatureOIDCConvert
+          crypto_key_feature_nats_ca: CryptoKeyFeatureNATSCA
           stale_interval_ms: StaleIntervalMS
           has_ai_task: HasAITask
           ai_task_sidebar_app_id: AITaskSidebarAppID


### PR DESCRIPTION
This PR separates the database cryptokeys CA cert feature for NATS mtls from the rest of #26590 

Here we add the `nats_ca` value to the crypto_key_feature enum so a CA used to sign ephemeral NATS cluster mTLS leaf certificates can be stored in crypto_keys. However, we also modify the rotator slightly to allow this PR to be the minimum changes required to get the database migration in but still leave coder in a functioning state without the rest of the mTLS related changes. 

Namely this means modifying the rotator to not always use `AllCryptoKeyFeatureValues()` for determining which key features to rotate keys for. This will make more sense in the updated version of #26590 where we will add the new CA feature to the rotators set of keys to rotate **iff** the nats pubsub experiment is turned on. 

This is needed because the actual generator for the NATS CA cert is in the follow up PR(s), and without that or the rotator change we have here coderd would crash at startup.