### PR TITLE
fix(site): use AvatarData in user settings sidebar header

### DIFF
--- a/site/src/pages/UserSettingsPage/Sidebar.tsx
+++ b/site/src/pages/UserSettingsPage/Sidebar.tsx
@@ -1,11 +1,10 @@
 import type { FC } from "react";
 import type { User } from "#/api/typesGenerated";
-import { Avatar } from "#/components/Avatar/Avatar";
+import { AvatarData } from "#/components/Avatar/AvatarData";
 import { FeatureStageBadge } from "#/components/FeatureStageBadge/FeatureStageBadge";
 import {
 	Sidebar as BaseSidebar,
 	SettingsSidebarNavItem,
-	SidebarHeader,
 } from "#/components/Sidebar/Sidebar";
 import { useDashboard } from "#/modules/dashboard/useDashboard";
 import { getPrereleaseFlag } from "#/utils/buildInfo";
@@ -23,11 +22,15 @@ export const Sidebar: FC<SidebarProps> = ({ user }) => {
 
 	return (
 		<BaseSidebar>
-			<SidebarHeader
-				avatar={<Avatar fallback={user.username} src={user.avatar_url} />}
-				title={user.username}
-				subtitle={user.email}
-			/>
+			<div className="mb-4">
+				<AvatarData
+					title={user.username}
+					subtitle={user.email}
+					src={user.avatar_url}
+					imgFallbackText={user.username}
+					truncate
+				/>
+			</div>
 			<div className="flex flex-col gap-1">
 				<SettingsSidebarNavItem href="account">Account</SettingsSidebarNavItem>
 				<SettingsSidebarNavItem href="appearance">


### PR DESCRIPTION
Aligns the user settings (account) sidebar header with the avatar + name + subtitle style used in the workspaces table and member tables on [dev.coder.com/workspaces](https://dev.coder.com/workspaces).

In `site/src/pages/UserSettingsPage/Sidebar.tsx`, the bare `<Avatar>` + `SidebarHeader` combo is replaced with the shared `AvatarData` component. This bumps the avatar from the default `md` (32 px) to `lg` (40 px) and adopts the same typography hierarchy (`text-sm font-semibold` title / `text-xs font-medium` subtitle) used across our tables, so the account page header reads the same as a row in the workspaces / members tables.

No behavior changes elsewhere — `SidebarHeader` itself is left intact since it's still used by `TemplateSettingsPage/Sidebar.tsx` and `WorkspaceSettingsPage/Sidebar.tsx`.

<details>
<summary>Why</summary>

The previous header rendered `<Avatar fallback={user.username} src={user.avatar_url} />` with no `size` prop, so it defaulted to `md` (`--avatar-default: 2rem`). That's noticeably smaller than the user/member rows elsewhere in the product, which consistently use `AvatarData` with `size="lg"`. Matching that style keeps the account surface consistent with the rest of the app.

</details>

---

_PR opened by Coder Agents on behalf of @tracyjohnsonux._