### PR TITLE
ci(.github/workflows): add flake-hunt workflow for targeted test reproduction

### DIFF
--- a/.github/workflows/flake-hunt.yaml
+++ b/.github/workflows/flake-hunt.yaml
@@ -1,0 +1,182 @@
+# flake-hunt runs a targeted Go test selection on a single chosen OS with
+# caller-controlled repetition and shuffling. It is for reproducing and
+# confirming fixes for flaky tests on demand, separate from the ci.yaml gate
+# and the scheduled nightly-gauntlet.
+name: flake-hunt
+
+on:
+  workflow_dispatch:
+    inputs:
+      os:
+        description: "Runner OS to test on."
+        type: choice
+        required: true
+        default: "ubuntu-latest"
+        options:
+          - ubuntu-latest
+          - macos-latest
+          - windows-2022
+      test-packages:
+        description: "Packages to test (go test path patterns)."
+        required: false
+        default: "./..."
+      run-regex:
+        description: "Go test name regex passed to go test -run. Empty runs all tests in the selected packages."
+        required: false
+        default: ""
+      test-count:
+        description: "Times to run each test (go test -count)."
+        required: false
+        default: "10"
+      test-shuffle:
+        description: "Go test -shuffle mode: off, on, or an integer seed."
+        required: false
+        default: "on"
+      postgres-version:
+        description: "PostgreSQL version to use."
+        required: false
+        default: "13"
+      test-parallelism-packages:
+        description: "Packages tested in parallel (go test -p)."
+        required: false
+        default: "8"
+      test-parallelism-tests:
+        description: "Tests run in parallel within each package (go test -parallel)."
+        required: false
+        default: "8"
+
+permissions:
+  contents: read
+
+jobs:
+  flake-hunt:
+    runs-on: ${{ inputs.os == 'ubuntu-latest' && github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || inputs.os == 'macos-latest' && github.repository_owner == 'coder' && 'depot-macos-latest' || inputs.os == 'windows-2022' && github.repository_owner == 'coder' && 'depot-windows-2022-16' || inputs.os }}
+    # High repetition counts can run long, so this ceiling is generous. The
+    # go test timeout inside make test still bounds individual runs.
+    timeout-minutes: 60
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      # macOS indexes all new files in the background. Our Postgres tests
+      # create and destroy thousands of databases on disk, and Spotlight
+      # tries to index all of them, seriously slowing down the tests.
+      - name: Disable Spotlight Indexing
+        if: runner.os == 'macOS'
+        run: |
+          enabled=$(sudo mdutil -a -s | { grep -Fc "Indexing enabled" || true; })
+          if [ "$enabled" -eq 0 ]; then
+            echo "Spotlight indexing is already disabled"
+            exit 0
+          fi
+          sudo mdutil -a -i off
+          sudo mdutil -X /
+          sudo launchctl bootout system /System/Library/LaunchDaemons/com.apple.metadata.mds.plist
+
+      # Set up RAM disks to speed up the rest of the job. This action is in
+      # a separate repository to allow its use before actions/checkout.
+      - name: Setup RAM Disks
+        if: runner.os == 'Windows'
+        uses: coder/setup-ramdisk-action@e1100847ab2d7bcd9d14bcda8f2d1b0f07b36f1b # v0.1.0
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup GNU tools (macOS)
+        uses: ./.github/actions/setup-gnu-tools
+
+      - name: Set up mise tools
+        uses: ./.github/actions/setup-mise
+        with:
+          install-args: "go terraform"
+
+      - name: Restore Go cache
+        uses: ./.github/actions/go-cache
+
+      - name: Install Go mise tools
+        run: ./.github/scripts/retry.sh -- mise install --locked go:gotest.tools/gotestsum
+
+      - name: Setup Embedded Postgres Cache Paths
+        id: embedded-pg-cache
+        if: runner.os != 'Linux'
+        uses: ./.github/actions/setup-embedded-pg-cache-paths
+
+      - name: Download Embedded Postgres Cache
+        id: download-embedded-pg-cache
+        if: runner.os != 'Linux'
+        uses: ./.github/actions/embedded-pg-cache/download
+        with:
+          key-prefix: embedded-pg-${{ runner.os }}-${{ runner.arch }}
+          cache-path: ${{ steps.embedded-pg-cache.outputs.cached-dirs }}
+
+      - name: Setup RAM disk for Embedded Postgres (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: mkdir -p "R:/temp/embedded-pg"
+
+      - name: Setup RAM disk for Embedded Postgres (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          mkdir -p /tmp/tmpfs
+          sudo mount_tmpfs -o noowners -s 8g /tmp/tmpfs
+          touch ~/.bash_profile && echo "export BASH_SILENCE_DEPRECATION_WARNING=1" >> ~/.bash_profile
+
+      - name: Increase PTY limit (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          # Default is 511; 999 is the maximum value on CI runner.
+          sudo sysctl -w kern.tty.ptmx_max=999
+
+      - name: Test with PostgreSQL Database (Linux)
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/test-go-pg
+        with:
+          postgres-version: ${{ inputs.postgres-version }}
+          test-parallelism-packages: ${{ inputs.test-parallelism-packages }}
+          test-parallelism-tests: ${{ inputs.test-parallelism-tests }}
+          test-count: ${{ inputs.test-count }}
+          test-packages: ${{ inputs.test-packages }}
+          run-regex: ${{ inputs.run-regex }}
+          test-shuffle: ${{ inputs.test-shuffle }}
+
+      - name: Test with PostgreSQL Database (macOS)
+        if: runner.os == 'macOS'
+        uses: ./.github/actions/test-go-pg
+        with:
+          postgres-version: ${{ inputs.postgres-version }}
+          test-parallelism-packages: ${{ inputs.test-parallelism-packages }}
+          test-parallelism-tests: ${{ inputs.test-parallelism-tests }}
+          test-count: ${{ inputs.test-count }}
+          test-packages: ${{ inputs.test-packages }}
+          run-regex: ${{ inputs.run-regex }}
+          test-shuffle: ${{ inputs.test-shuffle }}
+          embedded-pg-path: "/tmp/tmpfs/embedded-pg"
+          embedded-pg-cache: ${{ steps.embedded-pg-cache.outputs.embedded-pg-cache }}
+
+      - name: Test with PostgreSQL Database (Windows)
+        if: runner.os == 'Windows'
+        uses: ./.github/actions/test-go-pg
+        with:
+          postgres-version: ${{ inputs.postgres-version }}
+          test-parallelism-packages: ${{ inputs.test-parallelism-packages }}
+          test-parallelism-tests: ${{ inputs.test-parallelism-tests }}
+          test-count: ${{ inputs.test-count }}
+          test-packages: ${{ inputs.test-packages }}
+          run-regex: ${{ inputs.run-regex }}
+          test-shuffle: ${{ inputs.test-shuffle }}
+          embedded-pg-path: "R:/temp/embedded-pg"
+          embedded-pg-cache: ${{ steps.embedded-pg-cache.outputs.embedded-pg-cache }}
+
+      - name: Upload Embedded Postgres Cache
+        if: runner.os != 'Linux'
+        uses: ./.github/actions/embedded-pg-cache/upload
+        with:
+          cache-key: ${{ steps.download-embedded-pg-cache.outputs.cache-key }}
+          cache-path: "${{ steps.embedded-pg-cache.outputs.embedded-pg-cache }}"


### PR DESCRIPTION
Adds a dispatch-only `flake-hunt` workflow for reproducing and confirming fixes for flaky Go tests on demand, on a single chosen environment.

It reuses the existing `test-go-pg` composite action and exposes the knobs that matter for flake hunting:

- `os` choice: `ubuntu-latest`, `macos-latest`, or `windows-2022` (one environment per run).
- `test-packages`, `run-regex` to scope the selection.
- `test-count` (default `10`) and `test-shuffle` (default `on`) to surface intermittent failures through repetition and reordering.
- `postgres-version` and parallelism inputs for tuning.

All three OSes are supported: Linux uses the action's Docker Postgres path; macOS and Windows use the embedded-Postgres RAM-disk and cache scaffolding mirrored from the `nightly-gauntlet` job.

This keeps `ci.yaml` a clean PR gate and `nightly-gauntlet` a scheduled pass/fail run, while giving developers and agents an on-demand tool to reproduce a specific flake on the exact OS where it occurs.

<details>
<summary>Notes</summary>

- Validated with `actionlint`. As a brand-new dispatch-only workflow, it cannot be manually dispatched until it lands on the default branch (GitHub only registers `workflow_dispatch` from the default branch), so a real dispatch run is not possible pre-merge.
- The macOS/Windows scaffolding (Spotlight disable, ramdisks, PTY limit, embedded-pg cache) is copied from the proven `nightly-gauntlet` job to match its behavior.

</details>

> [!NOTE]
> This PR was created by Coder Agents on behalf of @jscottmiller.
