### PR TITLE
ci(.github/workflows): add cross-OS and manual-target inputs to flake-go

### DIFF
--- a/.github/actions/test-go-pg/action.yaml
+++ b/.github/actions/test-go-pg/action.yaml
@@ -22,10 +22,6 @@ inputs:
     description: "Number of times to run each test (empty for cached results)"
     required: false
     default: ""
-  test-timeout:
-    description: "Go test -timeout value (e.g. 20m). Empty uses the Makefile default."
-    required: false
-    default: ""
   test-packages:
     description: "Packages to test (default: ./...)"
     required: false
@@ -77,7 +73,6 @@ runs:
         TEST_NUM_PARALLEL_PACKAGES: ${{ inputs.test-parallelism-packages }}
         TEST_NUM_PARALLEL_TESTS: ${{ inputs.test-parallelism-tests }}
         TEST_COUNT: ${{ inputs.test-count }}
-        TEST_TIMEOUT: ${{ inputs.test-timeout }}
         RUN: ${{ inputs.run-regex }}
         TEST_SHUFFLE: ${{ inputs.test-shuffle }}
         TEST_PACKAGES: ${{ inputs.test-packages }}

--- a/.github/actions/test-go-pg/action.yaml
+++ b/.github/actions/test-go-pg/action.yaml
@@ -22,6 +22,10 @@ inputs:
     description: "Number of times to run each test (empty for cached results)"
     required: false
     default: ""
+  test-timeout:
+    description: "Go test -timeout value (e.g. 20m). Empty uses the Makefile default."
+    required: false
+    default: ""
   test-packages:
     description: "Packages to test (default: ./...)"
     required: false
@@ -35,7 +39,7 @@ inputs:
     required: false
     default: ""
   gotestsum-json-file:
-    description: "Optional Linux path for gotestsum --jsonfile output. Use default for RUNNER_TEMP/go-test.json."
+    description: "Optional path for gotestsum --jsonfile output. Use default for RUNNER_TEMP/go-test.json."
     required: false
     default: ""
   embedded-pg-path:
@@ -73,6 +77,7 @@ runs:
         TEST_NUM_PARALLEL_PACKAGES: ${{ inputs.test-parallelism-packages }}
         TEST_NUM_PARALLEL_TESTS: ${{ inputs.test-parallelism-tests }}
         TEST_COUNT: ${{ inputs.test-count }}
+        TEST_TIMEOUT: ${{ inputs.test-timeout }}
         RUN: ${{ inputs.run-regex }}
         TEST_SHUFFLE: ${{ inputs.test-shuffle }}
         TEST_PACKAGES: ${{ inputs.test-packages }}

--- a/.github/workflows/flake-go.yaml
+++ b/.github/workflows/flake-go.yaml
@@ -33,6 +33,21 @@ on:
         required: false
         type: string
         default: "on"
+      test-timeout:
+        description: "Go test -timeout value (e.g. 20m, 1h). Raise for high-count whole-package runs."
+        required: false
+        type: string
+        default: "20m"
+      test-parallelism-packages:
+        description: "Packages tested in parallel (go test -p)."
+        required: false
+        type: string
+        default: "4"
+      test-parallelism-tests:
+        description: "Tests run in parallel within each package (go test -parallel). Lower this if embedded Postgres on macOS/Windows hits connection limits."
+        required: false
+        type: string
+        default: "16"
       base_sha:
         description: "Base commit to diff against. Defaults to merge-base against origin/main."
         required: false
@@ -130,6 +145,10 @@ jobs:
           SELECTOR_MATRIX: ${{ steps.selector.outputs.matrix }}
         run: |
           set -euo pipefail
+          if [[ -z "${MANUAL_PACKAGES}" && -n "${MANUAL_RUN_REGEX}" ]]; then
+            echo "::error::run-regex was set without test-packages. run-regex only applies in manual mode; set test-packages to use it." >&2
+            exit 1
+          fi
           if [[ -n "${MANUAL_PACKAGES}" ]]; then
             {
               echo "package=${MANUAL_PACKAGES}"
@@ -196,9 +215,10 @@ jobs:
         uses: ./.github/actions/test-go-pg
         with:
           postgres-version: "13"
-          test-parallelism-packages: "4"
-          test-parallelism-tests: "16"
+          test-parallelism-packages: ${{ inputs.test-parallelism-packages || '4' }}
+          test-parallelism-tests: ${{ inputs.test-parallelism-tests || '16' }}
           test-count: ${{ inputs.test-count || '35' }}
+          test-timeout: ${{ inputs.test-timeout || '20m' }}
           test-packages: ${{ steps.target.outputs.package }}
           run-regex: ${{ steps.target.outputs.run_regex }}
           test-shuffle: ${{ inputs.test-shuffle || 'on' }}
@@ -209,12 +229,14 @@ jobs:
         uses: ./.github/actions/test-go-pg
         with:
           postgres-version: "13"
-          test-parallelism-packages: "4"
-          test-parallelism-tests: "16"
+          test-parallelism-packages: ${{ inputs.test-parallelism-packages || '4' }}
+          test-parallelism-tests: ${{ inputs.test-parallelism-tests || '16' }}
           test-count: ${{ inputs.test-count || '35' }}
+          test-timeout: ${{ inputs.test-timeout || '20m' }}
           test-packages: ${{ steps.target.outputs.package }}
           run-regex: ${{ steps.target.outputs.run_regex }}
           test-shuffle: ${{ inputs.test-shuffle || 'on' }}
+          gotestsum-json-file: default
           embedded-pg-path: "/tmp/tmpfs/embedded-pg"
           embedded-pg-cache: ${{ steps.embedded-pg-cache.outputs.embedded-pg-cache }}
 
@@ -223,12 +245,14 @@ jobs:
         uses: ./.github/actions/test-go-pg
         with:
           postgres-version: "13"
-          test-parallelism-packages: "4"
-          test-parallelism-tests: "16"
+          test-parallelism-packages: ${{ inputs.test-parallelism-packages || '4' }}
+          test-parallelism-tests: ${{ inputs.test-parallelism-tests || '16' }}
           test-count: ${{ inputs.test-count || '35' }}
+          test-timeout: ${{ inputs.test-timeout || '20m' }}
           test-packages: ${{ steps.target.outputs.package }}
           run-regex: ${{ steps.target.outputs.run_regex }}
           test-shuffle: ${{ inputs.test-shuffle || 'on' }}
+          gotestsum-json-file: default
           embedded-pg-path: "R:/temp/embedded-pg"
           embedded-pg-cache: ${{ steps.embedded-pg-cache.outputs.embedded-pg-cache }}
 
@@ -238,6 +262,14 @@ jobs:
         with:
           cache-key: ${{ steps.download-embedded-pg-cache.outputs.cache-key }}
           cache-path: "${{ steps.embedded-pg-cache.outputs.embedded-pg-cache }}"
+
+      - name: Upload test JSON (macOS/Windows)
+        if: ${{ always() && steps.target.outputs.should_run == 'true' && runner.os != 'Linux' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: go-test-json-${{ runner.os }}
+          path: ${{ runner.temp }}/go-test.json
+          if-no-files-found: warn
 
       - name: Publish Go test failure report
         if: failure() && steps.flake_check.outcome == 'failure' && github.actor != 'dependabot[bot]' && runner.os == 'Linux' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)

--- a/.github/workflows/flake-go.yaml
+++ b/.github/workflows/flake-go.yaml
@@ -4,6 +4,35 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
+      os:
+        description: "Runner OS for the run."
+        type: choice
+        required: false
+        default: "ubuntu-latest"
+        options:
+          - ubuntu-latest
+          - macos-latest
+          - windows-2022
+      test-packages:
+        description: "Manual target: packages to test. When set, skips changed-test selection."
+        required: false
+        type: string
+        default: ""
+      run-regex:
+        description: "Manual target: go test -run regex, used with test-packages."
+        required: false
+        type: string
+        default: ""
+      test-count:
+        description: "Times to run each test (go test -count)."
+        required: false
+        type: string
+        default: "35"
+      test-shuffle:
+        description: "Go test -shuffle mode: off, on, or an integer seed."
+        required: false
+        type: string
+        default: "on"
       base_sha:
         description: "Base commit to diff against. Defaults to merge-base against origin/main."
         required: false
@@ -23,16 +52,38 @@ concurrency:
 jobs:
   flake_go:
     name: Flake Check
-    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-4' || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.os == 'macos-latest' && github.repository_owner == 'coder' && 'depot-macos-latest' || inputs.os == 'windows-2022' && github.repository_owner == 'coder' && 'depot-windows-2022-16' || github.repository_owner == 'coder' && 'depot-ubuntu-22.04-4' || inputs.os || 'ubuntu-latest' }}
     # This timeout must be greater than the Go test timeout set in `make test`
     # (-timeout 20m) so we receive a goroutine trace before the runner kills
-    # the job. Mirrors the test-go-pg job in ci.yaml.
-    timeout-minutes: 25
+    # the job. PR runs keep the 25m gate; manual cross-OS runs with high
+    # counts get extra headroom.
+    timeout-minutes: ${{ github.event_name == 'pull_request' && 25 || 60 }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
         with:
           egress-policy: audit
+
+      # macOS indexes all new files in the background. Our Postgres tests
+      # create and destroy thousands of databases on disk, and Spotlight
+      # tries to index all of them, seriously slowing down the tests.
+      - name: Disable Spotlight Indexing
+        if: runner.os == 'macOS'
+        run: |
+          enabled=$(sudo mdutil -a -s | { grep -Fc "Indexing enabled" || true; })
+          if [ "$enabled" -eq 0 ]; then
+            echo "Spotlight indexing is already disabled"
+            exit 0
+          fi
+          sudo mdutil -a -i off
+          sudo mdutil -X /
+          sudo launchctl bootout system /System/Library/LaunchDaemons/com.apple.metadata.mds.plist
+
+      # Set up RAM disks to speed up the rest of the job. This action is in
+      # a separate repository to allow its use before actions/checkout.
+      - name: Setup RAM Disks
+        if: runner.os == 'Windows'
+        uses: coder/setup-ramdisk-action@e1100847ab2d7bcd9d14bcda8f2d1b0f07b36f1b # v0.1.0
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -41,6 +92,9 @@ jobs:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.inputs.head_sha || github.sha }}
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Setup GNU tools (macOS)
+        uses: ./.github/actions/setup-gnu-tools
 
       - name: Set up Go
         uses: ./.github/actions/setup-mise
@@ -55,6 +109,7 @@ jobs:
 
       - name: Select changed tests
         id: selector
+        if: ${{ inputs.test-packages == '' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -64,25 +119,125 @@ jobs:
             --coalesce \
             --out-matrix "$RUNNER_TEMP/flake-matrix.json"
 
+      # Resolve the package and run regex from either the manual inputs or the
+      # changed-test selector, and decide whether there is anything to run.
+      - name: Resolve test target
+        id: target
+        shell: bash
+        env:
+          MANUAL_PACKAGES: ${{ inputs.test-packages }}
+          MANUAL_RUN_REGEX: ${{ inputs.run-regex }}
+          SELECTOR_MATRIX: ${{ steps.selector.outputs.matrix }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${MANUAL_PACKAGES}" ]]; then
+            {
+              echo "package=${MANUAL_PACKAGES}"
+              echo "run_regex=${MANUAL_RUN_REGEX}"
+              echo "should_run=true"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          pkg=$(printf '%s' "${SELECTOR_MATRIX}" | jq -r '.include[0].package // empty')
+          rgx=$(printf '%s' "${SELECTOR_MATRIX}" | jq -r '.include[0].run_regex // empty')
+          if [[ -z "${pkg}" ]]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "No changed tests detected; nothing to run."
+            exit 0
+          fi
+          {
+            echo "package=${pkg}"
+            echo "run_regex=${rgx}"
+            echo "should_run=true"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Set up Terraform
-        if: ${{ fromJSON(steps.selector.outputs.matrix).include[0] != null }}
+        if: ${{ steps.target.outputs.should_run == 'true' }}
         uses: ./.github/actions/setup-mise
         with:
           install-args: "terraform"
 
-      - name: Run targeted Go flake checks
+      - name: Setup Embedded Postgres Cache Paths
+        id: embedded-pg-cache
+        if: ${{ steps.target.outputs.should_run == 'true' && runner.os != 'Linux' }}
+        uses: ./.github/actions/setup-embedded-pg-cache-paths
+
+      - name: Download Embedded Postgres Cache
+        id: download-embedded-pg-cache
+        if: ${{ steps.target.outputs.should_run == 'true' && runner.os != 'Linux' }}
+        uses: ./.github/actions/embedded-pg-cache/download
+        with:
+          key-prefix: embedded-pg-${{ runner.os }}-${{ runner.arch }}
+          cache-path: ${{ steps.embedded-pg-cache.outputs.cached-dirs }}
+
+      - name: Setup RAM disk for Embedded Postgres (Windows)
+        if: ${{ steps.target.outputs.should_run == 'true' && runner.os == 'Windows' }}
+        shell: bash
+        run: mkdir -p "R:/temp/embedded-pg"
+
+      - name: Setup RAM disk for Embedded Postgres (macOS)
+        if: ${{ steps.target.outputs.should_run == 'true' && runner.os == 'macOS' }}
+        shell: bash
+        run: |
+          mkdir -p /tmp/tmpfs
+          sudo mount_tmpfs -o noowners -s 8g /tmp/tmpfs
+          touch ~/.bash_profile && echo "export BASH_SILENCE_DEPRECATION_WARNING=1" >> ~/.bash_profile
+
+      - name: Increase PTY limit (macOS)
+        if: ${{ steps.target.outputs.should_run == 'true' && runner.os == 'macOS' }}
+        shell: bash
+        run: |
+          # Default is 511; 999 is the maximum value on CI runner.
+          sudo sysctl -w kern.tty.ptmx_max=999
+
+      - name: Run targeted Go flake checks (Linux)
         id: flake_check
-        if: ${{ fromJSON(steps.selector.outputs.matrix).include[0] != null }}
+        if: ${{ steps.target.outputs.should_run == 'true' && runner.os == 'Linux' }}
         uses: ./.github/actions/test-go-pg
         with:
           postgres-version: "13"
           test-parallelism-packages: "4"
           test-parallelism-tests: "16"
-          test-count: "35"
-          test-packages: ${{ fromJSON(steps.selector.outputs.matrix).include[0].package }}
-          run-regex: ${{ fromJSON(steps.selector.outputs.matrix).include[0].run_regex }}
-          test-shuffle: "on"
+          test-count: ${{ inputs.test-count || '35' }}
+          test-packages: ${{ steps.target.outputs.package }}
+          run-regex: ${{ steps.target.outputs.run_regex }}
+          test-shuffle: ${{ inputs.test-shuffle || 'on' }}
           gotestsum-json-file: default
+
+      - name: Run targeted Go flake checks (macOS)
+        if: ${{ steps.target.outputs.should_run == 'true' && runner.os == 'macOS' }}
+        uses: ./.github/actions/test-go-pg
+        with:
+          postgres-version: "13"
+          test-parallelism-packages: "4"
+          test-parallelism-tests: "16"
+          test-count: ${{ inputs.test-count || '35' }}
+          test-packages: ${{ steps.target.outputs.package }}
+          run-regex: ${{ steps.target.outputs.run_regex }}
+          test-shuffle: ${{ inputs.test-shuffle || 'on' }}
+          embedded-pg-path: "/tmp/tmpfs/embedded-pg"
+          embedded-pg-cache: ${{ steps.embedded-pg-cache.outputs.embedded-pg-cache }}
+
+      - name: Run targeted Go flake checks (Windows)
+        if: ${{ steps.target.outputs.should_run == 'true' && runner.os == 'Windows' }}
+        uses: ./.github/actions/test-go-pg
+        with:
+          postgres-version: "13"
+          test-parallelism-packages: "4"
+          test-parallelism-tests: "16"
+          test-count: ${{ inputs.test-count || '35' }}
+          test-packages: ${{ steps.target.outputs.package }}
+          run-regex: ${{ steps.target.outputs.run_regex }}
+          test-shuffle: ${{ inputs.test-shuffle || 'on' }}
+          embedded-pg-path: "R:/temp/embedded-pg"
+          embedded-pg-cache: ${{ steps.embedded-pg-cache.outputs.embedded-pg-cache }}
+
+      - name: Upload Embedded Postgres Cache
+        if: ${{ steps.target.outputs.should_run == 'true' && runner.os != 'Linux' }}
+        uses: ./.github/actions/embedded-pg-cache/upload
+        with:
+          cache-key: ${{ steps.download-embedded-pg-cache.outputs.cache-key }}
+          cache-path: "${{ steps.embedded-pg-cache.outputs.embedded-pg-cache }}"
 
       - name: Publish Go test failure report
         if: failure() && steps.flake_check.outcome == 'failure' && github.actor != 'dependabot[bot]' && runner.os == 'Linux' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)

--- a/.github/workflows/flake-go.yaml
+++ b/.github/workflows/flake-go.yaml
@@ -24,7 +24,12 @@ on:
         type: string
         default: ""
       test-count:
-        description: "Times to run each test (go test -count)."
+        # Each package runs under a fixed 20m Go test timeout (-timeout in the
+        # Makefile). count multiplies a package's runtime within that one
+        # budget, so high counts on slow tests can abort with a timeout panic
+        # instead of reporting a flake. Narrow with run-regex and/or keep
+        # count x per-run time under ~20m.
+        description: "Times to run each test (go test -count). High counts on slow tests can hit the per-package 20m Go timeout; narrow with run-regex."
         required: false
         type: string
         default: "35"
@@ -33,11 +38,6 @@ on:
         required: false
         type: string
         default: "on"
-      test-timeout:
-        description: "Go test -timeout value (e.g. 20m, 1h). Raise for high-count whole-package runs."
-        required: false
-        type: string
-        default: "20m"
       test-parallelism-packages:
         description: "Packages tested in parallel (go test -p)."
         required: false
@@ -218,7 +218,6 @@ jobs:
           test-parallelism-packages: ${{ inputs.test-parallelism-packages || '4' }}
           test-parallelism-tests: ${{ inputs.test-parallelism-tests || '16' }}
           test-count: ${{ inputs.test-count || '35' }}
-          test-timeout: ${{ inputs.test-timeout || '20m' }}
           test-packages: ${{ steps.target.outputs.package }}
           run-regex: ${{ steps.target.outputs.run_regex }}
           test-shuffle: ${{ inputs.test-shuffle || 'on' }}
@@ -232,7 +231,6 @@ jobs:
           test-parallelism-packages: ${{ inputs.test-parallelism-packages || '4' }}
           test-parallelism-tests: ${{ inputs.test-parallelism-tests || '16' }}
           test-count: ${{ inputs.test-count || '35' }}
-          test-timeout: ${{ inputs.test-timeout || '20m' }}
           test-packages: ${{ steps.target.outputs.package }}
           run-regex: ${{ steps.target.outputs.run_regex }}
           test-shuffle: ${{ inputs.test-shuffle || 'on' }}
@@ -248,7 +246,6 @@ jobs:
           test-parallelism-packages: ${{ inputs.test-parallelism-packages || '4' }}
           test-parallelism-tests: ${{ inputs.test-parallelism-tests || '16' }}
           test-count: ${{ inputs.test-count || '35' }}
-          test-timeout: ${{ inputs.test-timeout || '20m' }}
           test-packages: ${{ steps.target.outputs.package }}
           run-regex: ${{ steps.target.outputs.run_regex }}
           test-shuffle: ${{ inputs.test-shuffle || 'on' }}

--- a/Makefile
+++ b/Makefile
@@ -1461,21 +1461,13 @@ TEST_PARALLEL_TESTS := $(or $(TEST_NUM_PARALLEL_TESTS),8)
 RACE_PARALLEL_PACKAGES := $(or $(TEST_NUM_PARALLEL_PACKAGES),4)
 RACE_PARALLEL_TESTS := $(or $(TEST_NUM_PARALLEL_TESTS),4)
 
-# TEST_TIMEOUT sets the Go test -timeout. The default 20m stays shorter than
-# the 25m CI job timeout (see test-go-pg in ci.yaml) so tests produce goroutine
-# dumps instead of the CI runner killing the process with no output. High-count
-# flake runs can raise it. An empty value falls back to the default.
-ifeq ($(strip $(TEST_TIMEOUT)),)
-GOTEST_TIMEOUT := 20m
-else
-GOTEST_TIMEOUT := $(TEST_TIMEOUT)
-endif
-
 # Use testsmallbatch tag to reduce wireguard memory allocation in tests
 # (from ~18GB to negligible). Recursively expanded so target-specific
 # overrides of TEST_PARALLEL_* take effect (e.g. test-race lowers
-# parallelism).
-GOTEST_FLAGS = -tags=testsmallbatch -v -timeout $(GOTEST_TIMEOUT) -p $(TEST_PARALLEL_PACKAGES) -parallel=$(TEST_PARALLEL_TESTS)
+# parallelism). CI job timeout is 25m (see test-go-pg in ci.yaml),
+# keep the Go timeout 5m shorter so tests produce goroutine dumps
+# instead of the CI runner killing the process with no output.
+GOTEST_FLAGS = -tags=testsmallbatch -v -timeout 20m -p $(TEST_PARALLEL_PACKAGES) -parallel=$(TEST_PARALLEL_TESTS)
 
 # The most common use is to set TEST_COUNT=1 to avoid Go's test cache.
 ifdef TEST_COUNT

--- a/Makefile
+++ b/Makefile
@@ -1461,13 +1461,21 @@ TEST_PARALLEL_TESTS := $(or $(TEST_NUM_PARALLEL_TESTS),8)
 RACE_PARALLEL_PACKAGES := $(or $(TEST_NUM_PARALLEL_PACKAGES),4)
 RACE_PARALLEL_TESTS := $(or $(TEST_NUM_PARALLEL_TESTS),4)
 
+# TEST_TIMEOUT sets the Go test -timeout. The default 20m stays shorter than
+# the 25m CI job timeout (see test-go-pg in ci.yaml) so tests produce goroutine
+# dumps instead of the CI runner killing the process with no output. High-count
+# flake runs can raise it. An empty value falls back to the default.
+ifeq ($(strip $(TEST_TIMEOUT)),)
+GOTEST_TIMEOUT := 20m
+else
+GOTEST_TIMEOUT := $(TEST_TIMEOUT)
+endif
+
 # Use testsmallbatch tag to reduce wireguard memory allocation in tests
 # (from ~18GB to negligible). Recursively expanded so target-specific
 # overrides of TEST_PARALLEL_* take effect (e.g. test-race lowers
-# parallelism). CI job timeout is 25m (see test-go-pg in ci.yaml),
-# keep the Go timeout 5m shorter so tests produce goroutine dumps
-# instead of the CI runner killing the process with no output.
-GOTEST_FLAGS = -tags=testsmallbatch -v -timeout 20m -p $(TEST_PARALLEL_PACKAGES) -parallel=$(TEST_PARALLEL_TESTS)
+# parallelism).
+GOTEST_FLAGS = -tags=testsmallbatch -v -timeout $(GOTEST_TIMEOUT) -p $(TEST_PARALLEL_PACKAGES) -parallel=$(TEST_PARALLEL_TESTS)
 
 # The most common use is to set TEST_COUNT=1 to avoid Go's test cache.
 ifdef TEST_COUNT


### PR DESCRIPTION
Extends the existing `flake-go` workflow with an on-demand, cross-OS manual mode for reproducing and confirming fixes for flaky Go tests, instead of adding a separate workflow.

## What changes

- **`os` choice input** (`ubuntu-latest` / `macos-latest` / `windows-2022`) wired into `runs-on`, mapping to the same depot runners CI and the nightly gauntlet use.
- **Manual-target mode:** new `test-packages` and `run-regex` inputs. When `test-packages` is set, the `whichtests` changed-test selector is skipped and the run targets exactly what you specify. A `Resolve test target` step picks either the manual inputs or the selector output and decides whether there is anything to run.
- **`test-count` and `test-shuffle` inputs** (defaults `35` / `on`, matching the previously hardcoded values).
- **macOS and Windows support:** Spotlight disable, RAM disks, embedded-Postgres cache and paths, and the PTY limit, all gated behind `runner.os`, mirroring the nightly gauntlet. Linux keeps the Docker Postgres path.

## What stays the same

- On `pull_request`, the workflow still runs `whichtests` on Linux and stress-runs the changed tests at `-count=35 -shuffle=on`, with the 25-minute gate. Manual dispatches get 60 minutes of headroom.
- Failure reporting is unchanged (Linux only).

This avoids duplicating flake-detection logic in a separate workflow: developers and agents keep the passive per-PR flake gate and gain an on-demand tool to reproduce a specific flake on the exact OS where it occurs.

<details>
<summary>Validation</summary>

Dispatched from this branch against the two real-terraform tests that #26315 deflakes, on Windows:

```
gh workflow run flake-go.yaml --ref ci/flake-go-cross-os \
  -f os=windows-2022 \
  -f test-packages='./enterprise/coderd/...' \
  -f run-regex='TestWorkspaceTagsTerraform|TestWorkspaceTemplateParamsChange' \
  -f test-count=2 -f test-shuffle=on
```

Result: success. The run took the manual path (`Select changed tests` skipped, `Resolve test target` ran), exercised only the Windows steps (RAM disks, embedded Postgres, Windows test step), and ran the targeted tests with `TEST_PACKAGES=./enterprise/coderd/...`, `RUN=TestWorkspaceTagsTerraform|TestWorkspaceTemplateParamsChange`, `TEST_COUNT=2`, `TEST_SHUFFLE=on` (`DONE 64 tests`, i.e. 32 tests/subtests x count 2). Validated with `actionlint`.

</details>

> [!NOTE]
> This PR was created by Coder Agents on behalf of @jscottmiller.
