### PR TITLE
ci(.github/actions): share embedded Postgres runtime setup via composite action

### DIFF
--- a/.github/actions/setup-embedded-pg-runtime/action.yaml
+++ b/.github/actions/setup-embedded-pg-runtime/action.yaml
@@ -1,0 +1,51 @@
+name: "Setup Embedded Postgres runtime"
+description: >-
+  macOS and Windows RAM disk and PTY setup for embedded Postgres test jobs,
+  plus the resolved embedded Postgres data path. Intended for non-Linux
+  runners; Linux uses a Docker Postgres container instead.
+
+outputs:
+  embedded-pg-path:
+    description: "Filesystem path for embedded Postgres data (empty on Linux)."
+    value: ${{ steps.pg-path.outputs.path }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup RAM disk for Embedded Postgres (Windows)
+      if: runner.os == 'Windows'
+      shell: bash
+      # The default C: drive is extremely slow:
+      # https://github.com/actions/runner-images/issues/8755
+      run: mkdir -p "R:/temp/embedded-pg"
+
+    - name: Setup RAM disk for Embedded Postgres (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        # Postgres runs faster on a ramdisk on macOS.
+        mkdir -p /tmp/tmpfs
+        sudo mount_tmpfs -o noowners -s 8g /tmp/tmpfs
+
+        # macOS will output "The default interactive shell is now zsh" intermittently in CI.
+        touch ~/.bash_profile && echo "export BASH_SILENCE_DEPRECATION_WARNING=1" >> ~/.bash_profile
+
+    - name: Increase PTY limit (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        # Increase PTY limit to avoid exhaustion during tests.
+        # Default is 511; 999 is the maximum value on CI runner.
+        sudo sysctl -w kern.tty.ptmx_max=999
+
+    - name: Resolve embedded Postgres path
+      id: pg-path
+      shell: bash
+      run: |
+        if [[ "${RUNNER_OS}" == "Windows" ]]; then
+          echo "path=R:/temp/embedded-pg" >> "$GITHUB_OUTPUT"
+        elif [[ "${RUNNER_OS}" == "macOS" ]]; then
+          echo "path=/tmp/tmpfs/embedded-pg" >> "$GITHUB_OUTPUT"
+        else
+          echo "path=" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -625,31 +625,10 @@ jobs:
           source scripts/normalize_path.sh
           normalize_path_with_symlinks "$RUNNER_TEMP/sym" "$(dirname "$(which terraform)")"
 
-      - name: Setup RAM disk for Embedded Postgres (Windows)
-        if: runner.os == 'Windows'
-        shell: bash
-        # The default C: drive is extremely slow:
-        # https://github.com/actions/runner-images/issues/8755
-        run: mkdir -p "R:/temp/embedded-pg"
-
-      - name: Setup RAM disk for Embedded Postgres (macOS)
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
-          # Postgres runs faster on a ramdisk on macOS.
-          mkdir -p /tmp/tmpfs
-          sudo mount_tmpfs -o noowners -s 8g /tmp/tmpfs
-
-          # macOS will output "The default interactive shell is now zsh" intermittently in CI.
-          touch ~/.bash_profile && echo "export BASH_SILENCE_DEPRECATION_WARNING=1" >> ~/.bash_profile
-
-      - name: Increase PTY limit (macOS)
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
-          # Increase PTY limit to avoid exhaustion during tests.
-          # Default is 511; 999 is the maximum value on CI runner.
-          sudo sysctl -w kern.tty.ptmx_max=999
+      - name: Setup Embedded Postgres runtime (macOS/Windows)
+        id: embedded-pg-runtime
+        if: runner.os != 'Linux'
+        uses: ./.github/actions/setup-embedded-pg-runtime
 
       - name: Test with PostgreSQL Database (Linux)
         if: runner.os == 'Linux'
@@ -679,7 +658,7 @@ jobs:
           test-count: ${{ github.ref == 'refs/heads/main' && '1' || '' }}
           # Only the CLI and Agent are officially supported on macOS; the rest are too flaky.
           test-packages: "./cli/... ./enterprise/cli/... ./agent/..."
-          embedded-pg-path: "/tmp/tmpfs/embedded-pg"
+          embedded-pg-path: ${{ steps.embedded-pg-runtime.outputs.embedded-pg-path }}
           embedded-pg-cache: ${{ steps.embedded-pg-cache.outputs.embedded-pg-cache }}
 
       - name: Test with PostgreSQL Database (Windows)
@@ -699,7 +678,7 @@ jobs:
           test-count: ${{ github.ref == 'refs/heads/main' && '1' || '' }}
           # Only the CLI and Agent are officially supported on Windows; the rest are too flaky.
           test-packages: "./cli/... ./enterprise/cli/... ./agent/..."
-          embedded-pg-path: "R:/temp/embedded-pg"
+          embedded-pg-path: ${{ steps.embedded-pg-runtime.outputs.embedded-pg-path }}
           embedded-pg-cache: ${{ steps.embedded-pg-cache.outputs.embedded-pg-cache }}
 
       - name: Publish Go test failure report

--- a/.github/workflows/flake-hunt.yaml
+++ b/.github/workflows/flake-hunt.yaml
@@ -119,25 +119,10 @@ jobs:
           key-prefix: embedded-pg-${{ runner.os }}-${{ runner.arch }}
           cache-path: ${{ steps.embedded-pg-cache.outputs.cached-dirs }}
 
-      - name: Setup RAM disk for Embedded Postgres (Windows)
-        if: runner.os == 'Windows'
-        shell: bash
-        run: mkdir -p "R:/temp/embedded-pg"
-
-      - name: Setup RAM disk for Embedded Postgres (macOS)
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
-          mkdir -p /tmp/tmpfs
-          sudo mount_tmpfs -o noowners -s 8g /tmp/tmpfs
-          touch ~/.bash_profile && echo "export BASH_SILENCE_DEPRECATION_WARNING=1" >> ~/.bash_profile
-
-      - name: Increase PTY limit (macOS)
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
-          # Default is 511; 999 is the maximum value on CI runner.
-          sudo sysctl -w kern.tty.ptmx_max=999
+      - name: Setup Embedded Postgres runtime (macOS/Windows)
+        id: embedded-pg-runtime
+        if: runner.os != 'Linux'
+        uses: ./.github/actions/setup-embedded-pg-runtime
 
       - name: Test with PostgreSQL Database (Linux)
         if: runner.os == 'Linux'
@@ -152,8 +137,8 @@ jobs:
           test-shuffle: ${{ inputs.test-shuffle }}
           gotestsum-json-file: default
 
-      - name: Test with PostgreSQL Database (macOS)
-        if: runner.os == 'macOS'
+      - name: Test with PostgreSQL Database (macOS/Windows)
+        if: runner.os != 'Linux'
         uses: ./.github/actions/test-go-pg
         with:
           postgres-version: ${{ inputs.postgres-version }}
@@ -164,22 +149,7 @@ jobs:
           run-regex: ${{ inputs.run-regex }}
           test-shuffle: ${{ inputs.test-shuffle }}
           gotestsum-json-file: default
-          embedded-pg-path: "/tmp/tmpfs/embedded-pg"
-          embedded-pg-cache: ${{ steps.embedded-pg-cache.outputs.embedded-pg-cache }}
-
-      - name: Test with PostgreSQL Database (Windows)
-        if: runner.os == 'Windows'
-        uses: ./.github/actions/test-go-pg
-        with:
-          postgres-version: ${{ inputs.postgres-version }}
-          test-parallelism-packages: ${{ inputs.test-parallelism-packages }}
-          test-parallelism-tests: ${{ inputs.test-parallelism-tests }}
-          test-count: ${{ inputs.test-count }}
-          test-packages: ${{ inputs.test-packages }}
-          run-regex: ${{ inputs.run-regex }}
-          test-shuffle: ${{ inputs.test-shuffle }}
-          gotestsum-json-file: default
-          embedded-pg-path: "R:/temp/embedded-pg"
+          embedded-pg-path: ${{ steps.embedded-pg-runtime.outputs.embedded-pg-path }}
           embedded-pg-cache: ${{ steps.embedded-pg-cache.outputs.embedded-pg-cache }}
 
       - name: Upload Embedded Postgres Cache

--- a/.github/workflows/nightly-gauntlet.yaml
+++ b/.github/workflows/nightly-gauntlet.yaml
@@ -84,17 +84,10 @@ jobs:
           key-prefix: embedded-pg-${{ runner.os }}-${{ runner.arch }}
           cache-path: ${{ steps.embedded-pg-cache.outputs.cached-dirs }}
 
-      - name: Setup RAM disk for Embedded Postgres (Windows)
-        if: runner.os == 'Windows'
-        shell: bash
-        run: mkdir -p "R:/temp/embedded-pg"
-
-      - name: Setup RAM disk for Embedded Postgres (macOS)
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
-          mkdir -p /tmp/tmpfs
-          sudo mount_tmpfs -o noowners -s 8g /tmp/tmpfs
+      - name: Setup Embedded Postgres runtime (macOS/Windows)
+        id: embedded-pg-runtime
+        if: runner.os != 'Linux'
+        uses: ./.github/actions/setup-embedded-pg-runtime
 
       - name: Test with PostgreSQL Database (macOS)
         if: runner.os == 'macOS'
@@ -105,7 +98,7 @@ jobs:
           test-parallelism-packages: "8"
           test-parallelism-tests: "16"
           test-count: "1"
-          embedded-pg-path: "/tmp/tmpfs/embedded-pg"
+          embedded-pg-path: ${{ steps.embedded-pg-runtime.outputs.embedded-pg-path }}
           embedded-pg-cache: ${{ steps.embedded-pg-cache.outputs.embedded-pg-cache }}
 
       - name: Test with PostgreSQL Database (Windows)
@@ -117,7 +110,7 @@ jobs:
           test-parallelism-packages: "8"
           test-parallelism-tests: "16"
           test-count: "1"
-          embedded-pg-path: "R:/temp/embedded-pg"
+          embedded-pg-path: ${{ steps.embedded-pg-runtime.outputs.embedded-pg-path }}
           embedded-pg-cache: ${{ steps.embedded-pg-cache.outputs.embedded-pg-cache }}
 
       - name: Upload Embedded Postgres Cache


### PR DESCRIPTION
Extracts the duplicated macOS/Windows embedded-Postgres prep (RAM disk, PTY limit, and the embedded Postgres data path) into a `setup-embedded-pg-runtime` composite action and adopts it in `ci.yaml`, `nightly-gauntlet.yaml`, and `flake-hunt.yaml`.

Stacked on #26773 (which adds `flake-hunt`); this PR is based on that branch and should merge after it.

## Changes

- New `.github/actions/setup-embedded-pg-runtime` composite. Exposes `embedded-pg-path` as an output, removing the hardcoded `/tmp/tmpfs` vs `R:/temp` split from each caller's test steps.
- `ci.yaml`: behavior-preserving. The composite is exactly the RAM-disk + PTY steps it replaces.
- `nightly-gauntlet.yaml`: additionally gains the macOS PTY-limit bump and the bash deprecation-warning silence. Both are already used by `ci.yaml` on the same depot runners and are safe (a higher PTY ceiling and a suppressed shell banner), so this normalizes the two jobs. Flag if you'd rather keep the gauntlet strictly unchanged; it can be parameterized instead.
- `flake-hunt.yaml`: adopts the composite, which also collapses its macOS and Windows test steps into one.

## Notes

- The pre-checkout steps (Spotlight disable, `setup-ramdisk-action`) cannot live in a local composite since the repo is not yet checked out, so they stay inline.
- This PR touches `.github`, so its own CI exercises the `ci.yaml` composite path on Linux, macOS, and Windows.

> [!NOTE]
> This PR was created by Coder Agents on behalf of @jscottmiller.
