### PR TITLE
fix(coderd): harden context snapshot persistence

### DIFF
--- a/coderd/agentapi/context.go
+++ b/coderd/agentapi/context.go
@@ -244,6 +244,12 @@ func validateContextPushRequest(req *agentproto.PushContextStateRequest) error {
 	if req.Version > math.MaxInt64 {
 		return xerrors.Errorf("agentapi: PushContextState version %d exceeds int64 range", req.Version)
 	}
+	// AggregateHash anchors chat dirty-tracking and maps to a NOT NULL
+	// column. An empty hash pins chats that db2sdk then reports as
+	// untracked, and a nil hash violates the column on real Postgres.
+	if len(req.AggregateHash) == 0 {
+		return xerrors.New("agentapi: PushContextState aggregate hash is empty")
+	}
 	if len(req.AggregateHash) > maxContextHashBytes {
 		return xerrors.Errorf("agentapi: PushContextState aggregate hash is %d bytes, exceeds %d byte cap", len(req.AggregateHash), maxContextHashBytes)
 	}

--- a/coderd/agentapi/context_test.go
+++ b/coderd/agentapi/context_test.go
@@ -1,6 +1,7 @@
 package agentapi_test
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -159,8 +160,9 @@ func TestPushContextState(t *testing.T) {
 			t.Parallel()
 			api, _ := makeAPI(t)
 			resp, err := api.PushContextState(context.Background(), &agentproto.PushContextStateRequest{
-				Version: 1,
-				Initial: true,
+				AggregateHash: validAggregateHash(),
+				Version:       1,
+				Initial:       true,
 				Resources: []*agentproto.ContextResource{
 					instructionResource("", "x"),
 				},
@@ -174,8 +176,9 @@ func TestPushContextState(t *testing.T) {
 			t.Parallel()
 			api, _ := makeAPI(t)
 			resp, err := api.PushContextState(context.Background(), &agentproto.PushContextStateRequest{
-				Version: 1,
-				Initial: true,
+				AggregateHash: validAggregateHash(),
+				Version:       1,
+				Initial:       true,
 				Resources: []*agentproto.ContextResource{
 					instructionResource("/a", "x"),
 					instructionResource("/a", "y"),
@@ -196,9 +199,10 @@ func TestPushContextState(t *testing.T) {
 		resource := instructionResource("/a", "x")
 		resource.Status = agentproto.ContextResource_STATUS_UNSPECIFIED
 		resp, err := api.PushContextState(context.Background(), &agentproto.PushContextStateRequest{
-			Version:   1,
-			Initial:   true,
-			Resources: []*agentproto.ContextResource{resource},
+			AggregateHash: validAggregateHash(),
+			Version:       1,
+			Initial:       true,
+			Resources:     []*agentproto.ContextResource{resource},
 		})
 		require.Error(t, err)
 		require.Nil(t, resp)
@@ -209,8 +213,9 @@ func TestPushContextState(t *testing.T) {
 
 		api, _ := makeAPI(t)
 		resp, err := api.PushContextState(context.Background(), &agentproto.PushContextStateRequest{
-			Version: 1,
-			Initial: true,
+			AggregateHash: validAggregateHash(),
+			Version:       1,
+			Initial:       true,
 			Resources: []*agentproto.ContextResource{
 				{
 					Source:      "/a",
@@ -223,6 +228,57 @@ func TestPushContextState(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, resp)
 		require.Contains(t, err.Error(), "missing body")
+	})
+
+	t.Run("AggregateHash", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("RejectsEmpty", func(t *testing.T) {
+			t.Parallel()
+			api, _ := makeAPI(t)
+			// An empty aggregate hash would pin a chat the dashboard then
+			// reports as untracked and violates the snapshot's NOT NULL
+			// column, so it is rejected before the transaction starts.
+			resp, err := api.PushContextState(context.Background(), &agentproto.PushContextStateRequest{
+				Version: 1,
+				Initial: true,
+			})
+			require.Error(t, err)
+			require.Nil(t, resp)
+			require.Contains(t, err.Error(), "aggregate hash is empty")
+		})
+
+		t.Run("AcceptsThirtyTwoByteHash", func(t *testing.T) {
+			t.Parallel()
+			api, dbm := makeAPI(t)
+			expectInTx(dbm)
+
+			// A 32-byte SHA-256 digest is the shape the agent produces;
+			// it must be accepted and stored verbatim on the snapshot.
+			dbm.EXPECT().GetLatestWorkspaceAgentContextSnapshot(gomock.Any(), agentID).
+				Return(database.WorkspaceAgentContextSnapshot{}, errNoRows())
+			var gotHash []byte
+			dbm.EXPECT().UpsertWorkspaceAgentContextSnapshot(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, arg database.UpsertWorkspaceAgentContextSnapshotParams) (database.WorkspaceAgentContextSnapshot, error) {
+					gotHash = arg.AggregateHash
+					return database.WorkspaceAgentContextSnapshot{}, nil
+				})
+			dbm.EXPECT().DeleteStaleWorkspaceAgentContextResources(gomock.Any(), database.DeleteStaleWorkspaceAgentContextResourcesParams{
+				WorkspaceAgentID: agentID,
+				ActiveSources:    []string{},
+			}).Return(nil)
+
+			hash := bytes.Repeat([]byte{0x2a}, 32)
+			resp, err := api.PushContextState(context.Background(), &agentproto.PushContextStateRequest{
+				Version:       1,
+				Initial:       true,
+				AggregateHash: hash,
+			})
+			require.NoError(t, err)
+			require.True(t, resp.GetAccepted())
+			require.Len(t, gotHash, 32)
+			require.Equal(t, hash, gotHash)
+		})
 	})
 
 	t.Run("StaleVersionDropped", func(t *testing.T) {
@@ -238,8 +294,9 @@ func TestPushContextState(t *testing.T) {
 			Return(database.WorkspaceAgentContextSnapshot{Version: 5}, nil)
 
 		resp, err := api.PushContextState(context.Background(), &agentproto.PushContextStateRequest{
-			Version: 3,
-			Initial: false,
+			AggregateHash: validAggregateHash(),
+			Version:       3,
+			Initial:       false,
 			Resources: []*agentproto.ContextResource{
 				instructionResource("/a", "stale"),
 			},
@@ -258,8 +315,9 @@ func TestPushContextState(t *testing.T) {
 			Return(database.WorkspaceAgentContextSnapshot{Version: 5}, nil)
 
 		resp, err := api.PushContextState(context.Background(), &agentproto.PushContextStateRequest{
-			Version: 5,
-			Initial: false,
+			AggregateHash: validAggregateHash(),
+			Version:       5,
+			Initial:       false,
 		})
 		require.NoError(t, err)
 		require.False(t, resp.GetAccepted())
@@ -284,8 +342,9 @@ func TestPushContextState(t *testing.T) {
 			Return(nil)
 
 		resp, err := api.PushContextState(context.Background(), &agentproto.PushContextStateRequest{
-			Version: 1,
-			Initial: true,
+			AggregateHash: validAggregateHash(),
+			Version:       1,
+			Initial:       true,
 			Resources: []*agentproto.ContextResource{
 				instructionResource("/a", "fresh"),
 			},
@@ -315,8 +374,9 @@ func TestPushContextState(t *testing.T) {
 		}).Return(nil)
 
 		resp, err := api.PushContextState(context.Background(), &agentproto.PushContextStateRequest{
-			Version: 2,
-			Initial: false,
+			AggregateHash: validAggregateHash(),
+			Version:       2,
+			Initial:       false,
 			Resources: []*agentproto.ContextResource{
 				instructionResource("/a", "still here"),
 			},
@@ -344,8 +404,9 @@ func TestPushContextState(t *testing.T) {
 		}).Return(nil)
 
 		resp, err := api.PushContextState(context.Background(), &agentproto.PushContextStateRequest{
-			Version: 1,
-			Initial: true,
+			AggregateHash: validAggregateHash(),
+			Version:       1,
+			Initial:       true,
 		})
 		require.NoError(t, err)
 		require.True(t, resp.GetAccepted())
@@ -374,8 +435,9 @@ func TestPushContextState(t *testing.T) {
 
 		mcpServer := mcpServerResource("/srv/mcp/echo", "echo", "echo server")
 		resp, err := api.PushContextState(context.Background(), &agentproto.PushContextStateRequest{
-			Version: 1,
-			Initial: true,
+			AggregateHash: validAggregateHash(),
+			Version:       1,
+			Initial:       true,
 			Resources: []*agentproto.ContextResource{
 				instructionResource("/a/AGENTS.md", "hi"),
 				skillResource("/a/.agents/skills/example/SKILL.md", "example", "an example"),
@@ -426,9 +488,10 @@ func TestPushContextState(t *testing.T) {
 		oversized.Error = "file exceeds 64KiB per-resource cap"
 
 		resp, err := api.PushContextState(context.Background(), &agentproto.PushContextStateRequest{
-			Version:   1,
-			Initial:   true,
-			Resources: []*agentproto.ContextResource{oversized},
+			AggregateHash: validAggregateHash(),
+			Version:       1,
+			Initial:       true,
+			Resources:     []*agentproto.ContextResource{oversized},
 		})
 		require.NoError(t, err)
 		require.True(t, resp.GetAccepted())
@@ -477,8 +540,9 @@ func TestPushContextState(t *testing.T) {
 		dbm.EXPECT().DeleteStaleWorkspaceAgentContextResources(gomock.Any(), gomock.Any()).Return(nil)
 
 		resp, err := api.PushContextState(context.Background(), &agentproto.PushContextStateRequest{
-			Version: 6,
-			Initial: false,
+			AggregateHash: validAggregateHash(),
+			Version:       6,
+			Initial:       false,
 			Resources: []*agentproto.ContextResource{
 				instructionResource("/a", "racy"),
 			},
@@ -500,9 +564,10 @@ func TestPushContextState(t *testing.T) {
 				resources = append(resources, instructionResource("/r/"+string(rune('a'+i%26))+"/"+uuid.NewString(), "x"))
 			}
 			resp, err := api.PushContextState(context.Background(), &agentproto.PushContextStateRequest{
-				Version:   1,
-				Initial:   true,
-				Resources: resources,
+				AggregateHash: validAggregateHash(),
+				Version:       1,
+				Initial:       true,
+				Resources:     resources,
 			})
 			require.Error(t, err)
 			require.Nil(t, resp)
@@ -513,8 +578,9 @@ func TestPushContextState(t *testing.T) {
 			t.Parallel()
 			api, _ := makeAPI(t)
 			resp, err := api.PushContextState(context.Background(), &agentproto.PushContextStateRequest{
-				Version: uint64(math.MaxInt64) + 1,
-				Initial: true,
+				AggregateHash: validAggregateHash(),
+				Version:       uint64(math.MaxInt64) + 1,
+				Initial:       true,
 			})
 			require.Error(t, err)
 			require.Nil(t, resp)
@@ -525,8 +591,9 @@ func TestPushContextState(t *testing.T) {
 			t.Parallel()
 			api, _ := makeAPI(t)
 			resp, err := api.PushContextState(context.Background(), &agentproto.PushContextStateRequest{
-				Version: 1,
-				Initial: true,
+				AggregateHash: validAggregateHash(),
+				Version:       1,
+				Initial:       true,
 				Resources: []*agentproto.ContextResource{
 					instructionResource("/"+strings.Repeat("a", 1024), "x"),
 				},
@@ -541,8 +608,9 @@ func TestPushContextState(t *testing.T) {
 			api, _ := makeAPI(t)
 			// 256KiB of content base64-expands past the 256KiB body cap.
 			resp, err := api.PushContextState(context.Background(), &agentproto.PushContextStateRequest{
-				Version: 1,
-				Initial: true,
+				AggregateHash: validAggregateHash(),
+				Version:       1,
+				Initial:       true,
 				Resources: []*agentproto.ContextResource{
 					instructionResource("/big", strings.Repeat("x", 256*1024)),
 				},
@@ -563,9 +631,10 @@ func TestPushContextState(t *testing.T) {
 				resources = append(resources, instructionResource("/agg/"+uuid.NewString(), content))
 			}
 			resp, err := api.PushContextState(context.Background(), &agentproto.PushContextStateRequest{
-				Version:   1,
-				Initial:   true,
-				Resources: resources,
+				AggregateHash: validAggregateHash(),
+				Version:       1,
+				Initial:       true,
+				Resources:     resources,
 			})
 			require.Error(t, err)
 			require.Nil(t, resp)
@@ -578,9 +647,10 @@ func TestPushContextState(t *testing.T) {
 			resource := instructionResource("/a", "x")
 			resource.ContentHash = make([]byte, 65)
 			resp, err := api.PushContextState(context.Background(), &agentproto.PushContextStateRequest{
-				Version:   1,
-				Initial:   true,
-				Resources: []*agentproto.ContextResource{resource},
+				AggregateHash: validAggregateHash(),
+				Version:       1,
+				Initial:       true,
+				Resources:     []*agentproto.ContextResource{resource},
 			})
 			require.Error(t, err)
 			require.Nil(t, resp)
@@ -591,6 +661,7 @@ func TestPushContextState(t *testing.T) {
 			t.Parallel()
 			api, _ := makeAPI(t)
 			resp, err := api.PushContextState(context.Background(), &agentproto.PushContextStateRequest{
+				AggregateHash: validAggregateHash(),
 				Version:       1,
 				Initial:       true,
 				SnapshotError: strings.Repeat("e", 4097),
@@ -607,6 +678,13 @@ func TestPushContextState(t *testing.T) {
 // pushes vs. updates.
 func errNoRows() error {
 	return sql.ErrNoRows
+}
+
+// validAggregateHash returns a non-empty 32-byte aggregate hash matching the
+// SHA-256 digest the agent computes. PushContextState rejects an empty hash,
+// so fixtures that exercise other behavior supply this stand-in.
+func validAggregateHash() []byte {
+	return bytes.Repeat([]byte{0x2a}, 32)
 }
 
 func instructionResource(source, content string) *agentproto.ContextResource {

--- a/coderd/database/tx.go
+++ b/coderd/database/tx.go
@@ -38,8 +38,9 @@ func ReadModifyUpdate(db Store, f func(tx Store) error,
 		})
 		var pqe *pq.Error
 		if xerrors.As(err, &pqe) {
-			if pqe.Code == "40001" {
-				// serialization error, retry
+			// Retry transient conflicts that resolve on a fresh attempt:
+			// serialization_failure (40001) and deadlock_detected (40P01).
+			if pqe.Code == "40001" || pqe.Code == "40P01" {
 				continue
 			}
 		}

--- a/coderd/database/tx_test.go
+++ b/coderd/database/tx_test.go
@@ -49,6 +49,29 @@ func TestReadModifyUpdate_RetryOK(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestReadModifyUpdate_RetryDeadlock(t *testing.T) {
+	t.Parallel()
+
+	mDB := dbmock.NewMockStore(gomock.NewController(t))
+
+	// A deadlock (40P01) is transient like a serialization failure: the
+	// first attempt is rolled back and the retry commits cleanly.
+	firstUpdate := mDB.EXPECT().
+		InTx(gomock.Any(), &database.TxOptions{Isolation: sql.LevelRepeatableRead}).
+		Times(1).
+		Return(&pq.Error{Code: pq.ErrorCode("40P01")})
+	mDB.EXPECT().
+		InTx(gomock.Any(), &database.TxOptions{Isolation: sql.LevelRepeatableRead}).
+		After(firstUpdate).
+		Times(1).
+		Return(nil)
+
+	err := database.ReadModifyUpdate(mDB, func(tx database.Store) error {
+		return nil
+	})
+	require.NoError(t, err)
+}
+
 func TestReadModifyUpdate_HardError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- **Reject an empty context aggregate hash** (`coderd/agentapi/context.go`). `validateContextPushRequest` only bounded `AggregateHash` from above. An empty hash would pin a chat that `db2sdk` then reports as untracked, and a nil hash violates the snapshot's `NOT NULL` column on real Postgres, so it is now rejected before the push transaction starts.
- **Retry deadlocks in `ReadModifyUpdate`** (`coderd/database/tx.go`). The loop retried `serialization_failure` (`40001`) but not `deadlock_detected` (`40P01`), which is equally transient under RepeatableRead. Both are now retried within the existing retry cap.

<details>
<summary>Verification</summary>

Changes:

- `coderd/agentapi/context.go`: lower-bound check rejecting an empty aggregate hash, with a comment explaining the dirty-tracking and `NOT NULL` rationale.
- `coderd/database/tx.go`: extend the retry condition to `|| pqe.Code == "40P01"` and name both codes in a comment. Retry cap unchanged.

Scoped checks (all green):

- `go build ./coderd/agentapi/... ./coderd/database/...`
- `go test ./coderd/agentapi/` and `go test ./coderd/database/ -run TestReadModifyUpdate`
- `go vet`, `gofmt`, and the full `make pre-commit` (gen/fmt/lint/build) hook on each commit.

Tests added/adjusted:

- `TestPushContextState/AggregateHash/RejectsEmpty` (empty hash rejected) and `.../AcceptsThirtyTwoByteHash` (32-byte SHA-256 digest accepted and stored verbatim on the snapshot).
- Existing `TestPushContextState` fixtures that omitted a hash now supply a valid 32-byte stand-in via a `validAggregateHash()` helper, so they keep verifying their original behavior.
- `TestReadModifyUpdate_RetryDeadlock` mirrors the existing `40001` retry test: a `pq.Error{Code:"40P01"}` on the first attempt retries and then succeeds.

</details>

<details>
<summary>Deferred: partial-accept of malformed resources (stretch item)</summary>

The stretch goal was to record per-resource validation failures as synthetic `status=INVALID` rows (so a single poison resource no longer fails the whole `PushContextState` and the agent stops retrying it forever), while keeping request-level caps as hard failures. It is **deferred** because it cannot be done correctly within the owned files (`context.go`, `tx.go`) and the current schema:

1. `workspace_agent_context_resources.body_kind` is a `NOT NULL` enum (`instruction_file, skill, mcp_config, mcp_server, plugin, hook, subagent, command`) with no `unknown`/`invalid` variant. The cases that most need partial-accept (nil entry, nil/unknown body variant) have **no truthful `body_kind`** to assign.
2. Both downstream readers switch on `body_kind`: `contextResourcesToPrompt` drops non-OK rows, and `pinnedContextResources` **skips any row whose `body_kind` is untracked**. A synthetic row would have to fabricate a tracked kind to surface at all, mis-attributing the resource in the UI.
3. The resource PK is `ON CONFLICT (workspace_agent_id, source)`. Empty/nil/duplicate sources cannot form a distinct row; a duplicate-source INVALID row would **clobber the legitimate row**, corrupting good data, defeating the goal.
4. `body` is `jsonb NOT NULL`, so an "empty body" must still be valid JSON (`{}`), not empty bytes.

A correct implementation needs a schema migration (a new `body_kind`, or a redesign that does not key INVALID rows on `source`), regenerated models, and `db2sdk`/chatd changes, all outside this PR's ownership. Per the task this is left to the separate effort that owns that surface; items 1 and 2 are implemented solidly here. `boot_id`/version-gate changes are intentionally untouched.

</details>

Generated by Coder Agents on behalf of @kylecarbs. Part of a coordinated series fixing the workspace agent context refactor; draft pending review.
