### PR TITLE
fix(site): accessibility and correctness fixes for the chat context indicator

### DIFF
--- a/site/src/pages/AgentsPage/components/ContextUsageIndicator.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ContextUsageIndicator.stories.tsx
@@ -228,3 +228,301 @@ export const SnapshotError: Story = {
 		).toBeVisible();
 	},
 };
+
+// Keyboard access: the focusable trigger button itself carries the Radix popup
+// semantics, and Tab focus (no pointer) opens the popover so keyboard and
+// screen-reader users get the same affordance as hover.
+export const KeyboardFocusOpensPopover: Story = {
+	args: {
+		usage: {
+			usedTokens: 12_000,
+			contextLimitTokens: 200_000,
+			context: MockChatContextClean,
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const button = within(canvasElement).getByRole("button");
+		// The popup semantics live on the focusable element, not a wrapper.
+		expect(button).toHaveAttribute("aria-haspopup", "dialog");
+		expect(button).toHaveAttribute("aria-expanded", "false");
+
+		// Tabbing to the trigger opens the popover and flips aria-expanded.
+		await userEvent.tab();
+		expect(button).toHaveFocus();
+		await waitFor(() =>
+			expect(button).toHaveAttribute("aria-expanded", "true"),
+		);
+		const body = within(document.body);
+		await waitFor(() => expect(body.getByText("Context files")).toBeVisible());
+	},
+};
+
+// Every non-ok resource is surfaced as an issue with its error instead of being
+// silently dropped, across kinds (file, MCP config, MCP server, skill) and
+// statuses (oversize, unreadable, excluded, invalid).
+export const Issues: Story = {
+	args: {
+		usage: {
+			usedTokens: 12_000,
+			contextLimitTokens: 200_000,
+			context: {
+				dirty: false,
+				resources: [
+					{
+						source: "/home/coder/big/CLAUDE.md",
+						kind: "instruction_file",
+						size_bytes: 70_000,
+						status: "oversize",
+						error: "file exceeds the 64KiB instruction limit",
+					},
+					{
+						source: "/home/coder/secret/AGENTS.md",
+						kind: "instruction_file",
+						size_bytes: 0,
+						status: "unreadable",
+						error: "permission denied",
+					},
+					{
+						source: "/home/coder/.coder/skills/legacy",
+						kind: "skill",
+						size_bytes: 0,
+						status: "excluded",
+						skill_name: "legacy",
+						error: "excluded by .coderignore",
+					},
+					{
+						source: "/home/coder/.mcp.json",
+						kind: "mcp_config",
+						size_bytes: 0,
+						status: "unreadable",
+						error: "invalid JSON at line 3",
+					},
+					{
+						source: "broken-server",
+						kind: "mcp_server",
+						size_bytes: 0,
+						status: "invalid",
+						error: "failed to start MCP server",
+					},
+				],
+			},
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const button = within(canvasElement).getByRole("button");
+		await userEvent.hover(button);
+		const body = within(document.body);
+		await waitFor(() => expect(body.getByText("Issues")).toBeVisible());
+		// Each non-ok resource shows its name and error.
+		expect(body.getByText("CLAUDE.md")).toBeVisible();
+		expect(
+			body.getByText("file exceeds the 64KiB instruction limit"),
+		).toBeVisible();
+		expect(body.getByText("permission denied")).toBeVisible();
+		expect(body.getByText("legacy")).toBeVisible();
+		expect(body.getByText("excluded by .coderignore")).toBeVisible();
+		expect(body.getByText("invalid JSON at line 3")).toBeVisible();
+		expect(body.getByText("broken-server")).toBeVisible();
+		expect(body.getByText("failed to start MCP server")).toBeVisible();
+		// The kind label and status accompany the name (leaf span exact match).
+		expect(
+			body.getAllByText((_, el) => el?.textContent === "(file: oversize)")
+				.length,
+		).toBeGreaterThan(0);
+	},
+};
+
+// No usage data: the trigger still announces itself and the popover reports
+// that usage is unavailable rather than rendering a broken percentage.
+export const UsageUnavailable: Story = {
+	args: {
+		usage: null,
+	},
+	play: async ({ canvasElement }) => {
+		const button = within(canvasElement).getByRole("button");
+		expect(button.getAttribute("aria-label")).toBe("Context usage");
+		await userEvent.hover(button);
+		const dialog = await within(document.body).findByRole("dialog");
+		await waitFor(() =>
+			expect(
+				within(dialog).getByText("Context usage unavailable"),
+			).toBeVisible(),
+		);
+	},
+};
+
+// Empty pinned context: the usage line renders, but with no resources none of
+// the resource sections appear.
+export const EmptyResources: Story = {
+	args: {
+		usage: {
+			usedTokens: 8_000,
+			contextLimitTokens: 200_000,
+			context: {
+				dirty: false,
+				resources: [],
+			},
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const button = within(canvasElement).getByRole("button");
+		await userEvent.hover(button);
+		const dialog = await within(document.body).findByRole("dialog");
+		const panel = within(dialog);
+		await waitFor(() => expect(panel.getByText(/context used/)).toBeVisible());
+		expect(panel.queryByText("Context files")).toBeNull();
+		expect(panel.queryByText("Skills")).toBeNull();
+		expect(panel.queryByText("MCP")).toBeNull();
+		expect(panel.queryByText("Issues")).toBeNull();
+	},
+};
+
+// Skill and MCP tool descriptions surface as side tooltips on hover.
+export const ResourceTooltips: Story = {
+	args: {
+		usage: {
+			usedTokens: 12_000,
+			contextLimitTokens: 200_000,
+			context: MockChatContextClean,
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const button = within(canvasElement).getByRole("button");
+		await userEvent.hover(button);
+		const body = within(document.body);
+		await waitFor(() => expect(body.getByText("Skills")).toBeVisible());
+
+		// Hovering a skill row reveals its description. Radix renders a
+		// visually-hidden copy of the text for assistive tech, so scope the
+		// assertion to the visible tooltip role.
+		await userEvent.hover(body.getByText("deploy"));
+		await waitFor(() =>
+			expect(
+				body
+					.getAllByRole("tooltip")
+					.some((tip) =>
+						tip.textContent?.includes("Deploy the app to staging."),
+					),
+			).toBe(true),
+		);
+
+		// Hovering an MCP tool row reveals the tool description.
+		await userEvent.hover(body.getByText("search_issues"));
+		await waitFor(() =>
+			expect(
+				body
+					.getAllByRole("tooltip")
+					.some((tip) =>
+						tip.textContent?.includes("Search issues and pull requests."),
+					),
+			).toBe(true),
+		);
+	},
+};
+
+// Duplicate MCP tool names (two tools collide after the "<server>__" prefix is
+// stripped) are deduped so a duplicate cannot render twice or produce a
+// duplicate React key.
+export const DuplicateMcpToolNames: Story = {
+	args: {
+		usage: {
+			usedTokens: 20_000,
+			contextLimitTokens: 200_000,
+			context: {
+				dirty: false,
+				resources: [
+					{
+						source: "github",
+						kind: "mcp_server",
+						size_bytes: 512,
+						status: "ok",
+						tools: [
+							{ name: "search", description: "First search tool." },
+							{ name: "search", description: "Duplicate after prefix strip." },
+							{ name: "create", description: "Create something." },
+						],
+					},
+				],
+			},
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const button = within(canvasElement).getByRole("button");
+		await userEvent.hover(button);
+		const body = within(document.body);
+		await waitFor(() => expect(body.getByText("MCP")).toBeVisible());
+		// The duplicate name renders exactly once.
+		expect(body.getAllByText("search")).toHaveLength(1);
+		expect(body.getByText("create")).toBeVisible();
+	},
+};
+
+// Whitespace-only or empty resource names are dropped so a nameless resource
+// never renders as a blank row. Only the valid file survives; the
+// whitespace-named skill, MCP, and issue entries leave no section behind.
+export const DropsEmptyNames: Story = {
+	args: {
+		usage: {
+			usedTokens: 12_000,
+			contextLimitTokens: 200_000,
+			context: {
+				dirty: false,
+				resources: [
+					{
+						source: "/home/coder/AGENTS.md",
+						kind: "instruction_file",
+						size_bytes: 100,
+						status: "ok",
+					},
+					{
+						source: "   ",
+						kind: "instruction_file",
+						size_bytes: 0,
+						status: "ok",
+					},
+					{
+						source: "   ",
+						kind: "skill",
+						size_bytes: 0,
+						status: "ok",
+						skill_name: "   ",
+					},
+					{
+						source: "   ",
+						kind: "mcp_config",
+						size_bytes: 0,
+						status: "ok",
+					},
+					{
+						source: "   ",
+						kind: "mcp_server",
+						size_bytes: 0,
+						status: "ok",
+						tools: [],
+					},
+					{
+						source: "   ",
+						kind: "skill",
+						size_bytes: 0,
+						status: "invalid",
+						skill_name: "   ",
+						error: "should be dropped",
+					},
+				],
+			},
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const button = within(canvasElement).getByRole("button");
+		await userEvent.hover(button);
+		const dialog = await within(document.body).findByRole("dialog");
+		const panel = within(dialog);
+		// The single valid file renders.
+		await waitFor(() => expect(panel.getByText("AGENTS.md")).toBeVisible());
+		// Whitespace-only entries produce neither a section nor a blank row.
+		expect(panel.queryByText("Skills")).toBeNull();
+		expect(panel.queryByText("MCP")).toBeNull();
+		expect(panel.queryByText("Issues")).toBeNull();
+		expect(panel.queryByText("should be dropped")).toBeNull();
+	},
+};

--- a/site/src/pages/AgentsPage/components/ContextUsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/ContextUsageIndicator.tsx
@@ -6,7 +6,7 @@ import {
 	WrenchIcon,
 	ZapIcon,
 } from "lucide-react";
-import { type FC, useRef, useState } from "react";
+import { type FC, useEffect, useRef, useState } from "react";
 import type {
 	ChatContext,
 	ChatContextResource,
@@ -87,7 +87,7 @@ const hasFiniteTokenValue = (value: number | undefined): value is number =>
 	typeof value === "number" && Number.isFinite(value) && value >= 0;
 
 const formatTokenCount = (value: number | undefined): string =>
-	hasFiniteTokenValue(value) ? value.toLocaleString() : "--";
+	hasFiniteTokenValue(value) ? value.toLocaleString("en-US") : "--";
 
 const formatTokenCountCompact = (value: number | undefined): string => {
 	if (!hasFiniteTokenValue(value)) {
@@ -102,6 +102,24 @@ const formatTokenCountCompact = (value: number | undefined): string => {
 		return `${Number.isInteger(k) ? k : k.toFixed(1).replace(/\.0$/, "")}K`;
 	}
 	return String(value);
+};
+
+// Two MCP tools can collide on name after the agent strips the "<server>__"
+// prefix. Dedupe by name so a duplicate cannot render twice or produce a
+// duplicate React key.
+const dedupeToolsByName = (
+	tools: readonly ChatContextTool[],
+): readonly ChatContextTool[] => {
+	const seen = new Set<string>();
+	const unique: ChatContextTool[] = [];
+	for (const tool of tools) {
+		if (seen.has(tool.name)) {
+			continue;
+		}
+		seen.add(tool.name);
+		unique.push(tool);
+	}
+	return unique;
 };
 
 // Sum the byte size of the OK resources in the given kinds so each popover
@@ -194,7 +212,33 @@ export const ContextUsageIndicator: FC<{
 	isRefreshingContext?: boolean;
 }> = ({ usage, onRefreshContext, isRefreshingContext }) => {
 	const [open, setOpen] = useState(false);
+	// Track the mobile breakpoint reactively so a viewport crossing it swaps
+	// between the tap (mobile) and hover/focus (desktop) interaction models.
+	const [isMobile, setIsMobile] = useState(isMobileViewport);
 	const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	// Clear any pending close timer on unmount so it cannot fire setState after
+	// the component is gone.
+	useEffect(() => {
+		return () => {
+			if (closeTimerRef.current) {
+				clearTimeout(closeTimerRef.current);
+				closeTimerRef.current = null;
+			}
+		};
+	}, []);
+
+	// Subscribe to the mobile media query so crossing the breakpoint re-renders
+	// into the correct interaction model.
+	useEffect(() => {
+		const mediaQuery = window.matchMedia("(max-width: 639px)");
+		const onChange = () => setIsMobile(mediaQuery.matches);
+		// Sync once in case the viewport changed between the initial render and
+		// the effect running.
+		onChange();
+		mediaQuery.addEventListener("change", onChange);
+		return () => mediaQuery.removeEventListener("change", onChange);
+	}, []);
 
 	const cancelClose = () => {
 		if (closeTimerRef.current) {
@@ -211,7 +255,8 @@ export const ContextUsageIndicator: FC<{
 		}, HOVER_CLOSE_DELAY_MS);
 	};
 
-	const handleMouseEnter = () => {
+	// Open on hover or keyboard focus; cancel any pending close first.
+	const openPopover = () => {
 		cancelClose();
 		setOpen(true);
 	};
@@ -286,7 +331,7 @@ export const ContextUsageIndicator: FC<{
 		.map((resource) => ({
 			name: resource.source,
 			source: resource.source,
-			tools: resource.tools ?? [],
+			tools: dedupeToolsByName(resource.tools ?? []),
 		}))
 		// Drop entries with no usable name so an empty MCP marker never renders as
 		// a blank row.
@@ -458,7 +503,10 @@ export const ContextUsageIndicator: FC<{
 										</div>
 										{mcp.tools.length > 0 && (
 											<div className="ml-4 flex flex-col gap-0.5">
-												{mcp.tools.map((tool) => {
+												{mcp.tools.map((tool, index) => {
+													// Tool names are deduped above; the index keeps the
+													// key unique even if a duplicate ever slips through.
+													const toolKey = `${mcp.source}__${tool.name}__${index}`;
 													const row = (
 														<div className="flex items-center gap-1.5 rounded px-0.5 py-px text-content-secondary transition-colors hover:bg-surface-tertiary">
 															<WrenchIcon className="size-3 shrink-0" />
@@ -466,10 +514,10 @@ export const ContextUsageIndicator: FC<{
 														</div>
 													);
 													if (!tool.description) {
-														return <div key={tool.name}>{row}</div>;
+														return <div key={toolKey}>{row}</div>;
 													}
 													return (
-														<Tooltip key={tool.name}>
+														<Tooltip key={toolKey}>
 															<TooltipTrigger asChild>
 																<div className="cursor-default">{row}</div>
 															</TooltipTrigger>
@@ -556,12 +604,13 @@ export const ContextUsageIndicator: FC<{
 		</div>
 	);
 
-	const triggerButton = (
-		<button
-			type="button"
-			aria-label={ariaLabel}
-			className="relative inline-flex size-7 shrink-0 items-center justify-center rounded-full border-none bg-transparent p-0 outline-none transition-colors hover:bg-surface-secondary/60 focus-visible:ring-2 focus-visible:ring-content-link/40"
-		>
+	const triggerClassName =
+		"relative inline-flex size-7 shrink-0 items-center justify-center rounded-full border-none bg-transparent p-0 outline-none transition-colors hover:bg-surface-secondary/60 focus-visible:ring-2 focus-visible:ring-content-link/40";
+
+	// Inner visual of the trigger. Each branch wraps it in a real <button> so the
+	// focusable element is itself the Radix popover trigger.
+	const triggerVisual = (
+		<>
 			<SvgRingProgress
 				size={RING_SIZE}
 				strokeWidth={RING_STROKE}
@@ -581,16 +630,24 @@ export const ContextUsageIndicator: FC<{
 					)}
 				/>
 			)}
-		</button>
+		</>
 	);
 
-	// On mobile, a tap toggles the popover. On desktop, hover opens
-	// it like a dropdown menu and skill descriptions appear as
-	// nested tooltips to the right (same pattern as ModelSelector).
-	if (isMobileViewport()) {
+	// On mobile, a tap toggles the popover. On desktop, hover or keyboard focus
+	// opens it like a dropdown menu and skill descriptions appear as nested
+	// tooltips to the right (same pattern as ModelSelector).
+	if (isMobile) {
 		return (
 			<Popover>
-				<PopoverTrigger asChild>{triggerButton}</PopoverTrigger>
+				<PopoverTrigger asChild>
+					<button
+						type="button"
+						aria-label={ariaLabel}
+						className={triggerClassName}
+					>
+						{triggerVisual}
+					</button>
+				</PopoverTrigger>
 				<PopoverContent
 					side="top"
 					className="mobile-full-width-dropdown mobile-full-width-dropdown-bottom w-auto max-w-72 px-3 py-2"
@@ -604,9 +661,20 @@ export const ContextUsageIndicator: FC<{
 	return (
 		<Popover open={open} onOpenChange={setOpen}>
 			<PopoverTrigger asChild>
-				<div onMouseEnter={handleMouseEnter} onMouseLeave={scheduleClose}>
-					{triggerButton}
-				</div>
+				{/* The focusable button is the trigger, so Radix applies
+				    aria-haspopup/aria-expanded to it and hover or keyboard focus
+				    both open the popover. */}
+				<button
+					type="button"
+					aria-label={ariaLabel}
+					className={triggerClassName}
+					onMouseEnter={openPopover}
+					onMouseLeave={scheduleClose}
+					onFocus={openPopover}
+					onBlur={scheduleClose}
+				>
+					{triggerVisual}
+				</button>
 			</PopoverTrigger>
 			<PopoverContent
 				side="top"


### PR DESCRIPTION
## Summary

- Move the Radix popover trigger onto the focusable `<button>` on desktop so `aria-haspopup`/`aria-expanded` land on the element that actually receives focus, and open the popover on `onFocus` as well as hover. Keyboard users and screen readers now get the same affordance as mouse users. Mobile tap behavior is unchanged.
- Dedupe MCP tool rows by name and key them on a composite (`${source}__${name}__${index}`) so two tools that collide after the `<server>__` prefix is stripped cannot produce duplicate React keys or a repeated row.
- Pass an explicit `"en-US"` locale to `formatTokenCount`'s `toLocaleString` so the token count (which also feeds an aria-label) is deterministic across environments.
- Clear the popover close timer on unmount via a cleanup effect so it cannot fire `setState` after the component is gone.
- Subscribe to the `(max-width: 639px)` media query with `useState` + `useEffect` so crossing the mobile breakpoint re-renders into the correct interaction model instead of being read once at render.
- Expand Storybook coverage with `play` functions for the previously-missing states.

<details>
<summary>Verification</summary>

### Changes
- `ContextUsageIndicator.tsx`: a11y trigger refactor, MCP tool dedupe + composite keys, `toLocaleString("en-US")`, unmount timer-cleanup effect, and a reactive viewport subscription. All hooks are hoisted above the event-handler closures so the repo's React Compiler check (`scripts/check-compiler.mjs`) does not flag a closure that spans a hook; the unmount effect clears the timer ref directly. No `useMemo`/`useCallback`/`memo` added (React Compiler directory).
- `ContextUsageIndicator.stories.tsx`: new stories with `play` functions.

### Stories / play coverage added
- `KeyboardFocusOpensPopover` - Tab-focuses the trigger; asserts `aria-haspopup="dialog"` and the `aria-expanded` flip on the focused element, and that focus opens the popover (covers the a11y fix).
- `Issues` - non-ok resources across kinds (file, MCP config, MCP server, skill) and statuses (oversize, unreadable, excluded, invalid) are surfaced with their errors.
- `UsageUnavailable` - `usage={null}`.
- `EmptyResources` - empty `resources` array renders no resource sections.
- `ResourceTooltips` - skill-description and MCP-tool-description tooltip hovers.
- `DuplicateMcpToolNames` - duplicate tool names render exactly once (dedupe).
- `DropsEmptyNames` - whitespace/empty-name resources never render a blank row.

### Checks (scoped, run in the worktree)
- `biome check --error-on-warnings` (both files): clean
- `tsc -p . --noEmit`: clean
- `node scripts/check-compiler.mjs`: all files compile cleanly, no unmemoized-closure findings
- `vitest run --project=storybook ContextUsageIndicator.stories.tsx`: 12/12 stories pass
- `make pre-commit` (git hook): passed

</details>

Generated by Coder Agents on behalf of @kylecarbs. Part of a coordinated series fixing the workspace agent context refactor; draft pending review.
