### PR TITLE
fix: converge workspace MCP context for pinned chats

### DIFF
--- a/cli/exp_chat.go
+++ b/cli/exp_chat.go
@@ -276,7 +276,8 @@ func (r *RootCmd) chatContextRefreshCommand(socketPath *string) *serpent.Command
 			"<chat> argument, refreshes that chat and works from anywhere.\n\nWith no " +
 			"argument, run from inside the workspace: forces the agent to re-resolve its " +
 			"sources (catching freshly-cloned repos and startup-script writes the watcher " +
-			"has not seen yet), then refreshes every drifted chat. This path authenticates " +
+			"has not seen yet), then re-pins every chat bound to this workspace's agent. " +
+			"This path authenticates " +
 			"with the agent token, so it does not require 'coder login'.",
 		Middleware: serpent.RequireRangeArgs(0, 1),
 		Handler: func(inv *serpent.Invocation) error {
@@ -307,7 +308,7 @@ func (r *RootCmd) chatContextRefreshCommand(socketPath *string) *serpent.Command
 
 			// No argument: in-workspace. Re-resolve the agent's sources over
 			// the local context socket, then ask the agent (using its own
-			// token) to re-pin every drifted chat. Neither step needs a
+			// token) to re-pin every chat bound to it. Neither step needs a
 			// logged-in user session.
 			sock, err := dialAgentContextSocket(ctx, *socketPath)
 			if err != nil {
@@ -332,7 +333,7 @@ func (r *RootCmd) chatContextRefreshCommand(socketPath *string) *serpent.Command
 			if err != nil {
 				return xerrors.Errorf("refresh chat context: %w", err)
 			}
-			_, _ = fmt.Fprintf(inv.Stdout, "Refreshed %d drifted chat(s).\n", resp.Refreshed)
+			_, _ = fmt.Fprintf(inv.Stdout, "Refreshed %d chat(s).\n", resp.Refreshed)
 			return nil
 		},
 	}

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -2414,11 +2414,17 @@ func convertWorkspaceAgentLogs(logs []database.WorkspaceAgentLog) []codersdk.Wor
 	return sdk
 }
 
-// workspaceAgentRefreshChatContext re-pins every drifted chat bound to the
-// calling agent to the agent's latest context snapshot, clearing their
-// drift markers. It backs the in-workspace `coder exp chat context refresh`
+// workspaceAgentRefreshChatContext re-pins every active chat bound to the
+// calling agent to the agent's latest context snapshot, clearing any drift
+// markers. It backs the in-workspace `coder exp chat context refresh`
 // (no chat argument), which uses the agent token rather than a user
 // session.
+//
+// The re-pin is unconditional: it runs even for chats that are not marked
+// dirty. MCP config and server changes are excluded from the drift hash, so
+// they never flip a pinned chat dirty; re-pinning regardless lets those
+// changes reach an already-pinned chat. This matches the per-chat and
+// user-facing refresh paths, which also re-pin without a dirty check.
 //
 // @x-apidocgen {"skip": true}
 func (api *API) workspaceAgentRefreshChatContext(rw http.ResponseWriter, r *http.Request) {
@@ -2456,9 +2462,10 @@ func (api *API) workspaceAgentRefreshChatContext(rw http.ResponseWriter, r *http
 
 	refreshed := 0
 	for _, chat := range chats {
-		// Only re-pin chats owned by this workspace's owner that have
-		// drifted from the agent's latest snapshot.
-		if chat.OwnerID != workspace.OwnerID || !chat.ContextDirtySince.Valid {
+		// Only re-pin chats owned by this workspace's owner. Re-pin every
+		// such chat, not just drifted ones, so MCP-only changes that the
+		// drift hash ignores are still applied.
+		if chat.OwnerID != workspace.OwnerID {
 			continue
 		}
 		if _, err := api.chatDaemon.RefreshChatContext(sysCtx, chat); err != nil {

--- a/coderd/x/chatd/context_integration_test.go
+++ b/coderd/x/chatd/context_integration_test.go
@@ -358,10 +358,20 @@ func TestChatContextRefreshFromAgentToken(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, resp.GetAccepted())
 
-	// With nothing dirty, the agent-token refresh is a no-op.
+	// Even with nothing dirty, the agent-token refresh re-pins the owned chat
+	// bound to the agent. The re-pin is unconditional so MCP-only changes,
+	// which the drift hash ignores, still reach an already-pinned chat.
 	refresh, err := agentClient.RefreshChatContext(ctx)
 	require.NoError(t, err)
-	require.Equal(t, 0, refresh.Refreshed, "no dirty chats to refresh")
+	require.Equal(t, 1, refresh.Refreshed, "non-dirty owned chat is re-pinned")
+
+	// The re-pin leaves the clean chat clean and still pinned to the v1
+	// snapshot it hydrated from.
+	afterClean, err := expClient.GetChat(ctx, chat.ID)
+	require.NoError(t, err)
+	require.NotNil(t, afterClean.Context)
+	require.False(t, afterClean.Context.Dirty, "re-pinning a clean chat keeps it clean")
+	require.Len(t, afterClean.Context.Resources, 1)
 
 	// A second push with a different hash drifts the bound chat dirty.
 	resp, err = aAPI.PushContextState(ctx, &agentproto.PushContextStateRequest{
@@ -395,10 +405,11 @@ func TestChatContextRefreshFromAgentToken(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, other.Context, "agent-less chat stays untouched")
 
-	// A follow-up refresh with nothing dirty is a no-op again.
+	// A follow-up refresh re-pins the now-clean owned chat again: the re-pin
+	// is unconditional, so the count stays 1 rather than dropping to 0.
 	refresh, err = agentClient.RefreshChatContext(ctx)
 	require.NoError(t, err)
-	require.Equal(t, 0, refresh.Refreshed, "nothing left to refresh")
+	require.Equal(t, 1, refresh.Refreshed, "re-pin is unconditional, not drift-gated")
 }
 
 // agentMCPToolContext specifies an mcp_server tool to seed into an agent's

--- a/coderd/x/chatd/context_prompt.go
+++ b/coderd/x/chatd/context_prompt.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"strings"
 
+	"charm.land/fantasy"
+	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -12,6 +14,7 @@ import (
 	"cdr.dev/slog/v3"
 	agentproto "github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
@@ -98,41 +101,70 @@ func mcpToolsFromServerBody(server string, body json.RawMessage) []codersdk.Chat
 
 // workspaceMCPToolInfosFromResources decodes a chat's pinned mcp_server
 // resources into execution-ready tool infos. Only OK mcp_server rows
-// contribute. The agent reports tool names unprefixed alongside the server
-// name, so each tool is re-prefixed to "<server>__<tool>", the model-facing
-// and proxy-routable form the live discovery path also produces. The pushed
-// input schema is a full JSON Schema object; its "properties" and "required"
-// are split out to match the shape the workspace agent's live tool list
-// produces (see agent/x/agentmcp). Tools with an empty name are skipped.
+// contribute; the per-resource decode and "<server>__<tool>" re-prefixing
+// live in appendMCPToolInfos, shared with the live agent reader.
 func workspaceMCPToolInfosFromResources(resources []database.ChatContextResource) []workspacesdk.MCPToolInfo {
 	var out []workspacesdk.MCPToolInfo
 	for _, r := range resources {
-		if r.BodyKind != database.WorkspaceAgentContextBodyKindMcpServer ||
-			r.Status != database.WorkspaceAgentContextResourceStatusOk {
+		out = appendMCPToolInfos(out, r.BodyKind, r.Status, r.Source, r.Body)
+	}
+	return out
+}
+
+// agentWorkspaceMCPToolInfos decodes an agent's latest pushed mcp_server
+// resources (workspace_agent_context_resources) into execution-ready tool
+// infos. It is the live counterpart to workspaceMCPToolInfosFromResources,
+// which reads the chat's frozen pinned copy; both share appendMCPToolInfos so
+// a stored server body is interpreted identically on either path.
+func agentWorkspaceMCPToolInfos(resources []database.WorkspaceAgentContextResource) []workspacesdk.MCPToolInfo {
+	var out []workspacesdk.MCPToolInfo
+	for _, r := range resources {
+		out = appendMCPToolInfos(out, r.BodyKind, r.Status, r.Source, r.Body)
+	}
+	return out
+}
+
+// appendMCPToolInfos decodes one mcp_server resource body and appends its
+// execution-ready tool infos to out. Non-mcp_server kinds, non-OK statuses,
+// undecodable bodies, and tools with an empty name are skipped. The agent
+// reports tool names unprefixed alongside the server name, so each tool is
+// re-prefixed to "<server>__<tool>", the model-facing and proxy-routable form
+// the live discovery path also produces. The pushed input schema is a full
+// JSON Schema object; its "properties" and "required" are split out to match
+// the shape the workspace agent's live tool list produces (see
+// agent/x/agentmcp).
+func appendMCPToolInfos(
+	out []workspacesdk.MCPToolInfo,
+	bodyKind database.WorkspaceAgentContextBodyKind,
+	status database.WorkspaceAgentContextResourceStatus,
+	source string,
+	body json.RawMessage,
+) []workspacesdk.MCPToolInfo {
+	if bodyKind != database.WorkspaceAgentContextBodyKindMcpServer ||
+		status != database.WorkspaceAgentContextResourceStatusOk {
+		return out
+	}
+	var decoded agentproto.MCPServerBody
+	if err := contextBodyUnmarshalOptions.Unmarshal(body, &decoded); err != nil {
+		return out
+	}
+	server := decoded.GetServerName()
+	if server == "" {
+		server = source
+	}
+	for _, t := range decoded.GetTools() {
+		name := t.GetName()
+		if name == "" {
 			continue
 		}
-		var decoded agentproto.MCPServerBody
-		if err := contextBodyUnmarshalOptions.Unmarshal(r.Body, &decoded); err != nil {
-			continue
-		}
-		server := decoded.GetServerName()
-		if server == "" {
-			server = r.Source
-		}
-		for _, t := range decoded.GetTools() {
-			name := t.GetName()
-			if name == "" {
-				continue
-			}
-			properties, required := splitMCPInputSchema(t.GetInputSchema())
-			out = append(out, workspacesdk.MCPToolInfo{
-				ServerName:  server,
-				Name:        server + mcpToolNameSeparator + name,
-				Description: t.GetDescription(),
-				Schema:      properties,
-				Required:    required,
-			})
-		}
+		properties, required := splitMCPInputSchema(t.GetInputSchema())
+		out = append(out, workspacesdk.MCPToolInfo{
+			ServerName:  server,
+			Name:        server + mcpToolNameSeparator + name,
+			Description: t.GetDescription(),
+			Schema:      properties,
+			Required:    required,
+		})
 	}
 	return out
 }
@@ -156,6 +188,105 @@ func splitMCPInputSchema(schema *structpb.Struct) (properties map[string]any, re
 		}
 	}
 	return properties, required
+}
+
+// resolveWorkspaceMCPToolsConverged returns the workspace MCP tools for a turn.
+// It starts from the chat's pinned baseline (resolveWorkspaceMCPTools) and
+// overlays the agent's latest pushed MCP set. MCP config and server resources
+// are excluded from the drift hash, so a server the agent connects after a
+// chat was pinned never flips the chat dirty and would otherwise never reach
+// it. Overlaying the live set lets an already-pinned parent and a later child
+// expose the same MCP servers without a manual refresh. Instruction and skill
+// content stay pinned; only the MCP tool set is sourced live.
+func (server *Server) resolveWorkspaceMCPToolsConverged(
+	ctx context.Context,
+	logger slog.Logger,
+	chat database.Chat,
+	workspaceCtx *turnWorkspaceContext,
+) []fantasy.AgentTool {
+	pinned := server.resolveWorkspaceMCPTools(ctx, logger, chat, workspaceCtx)
+
+	agent, err := workspaceCtx.getWorkspaceAgent(ctx)
+	if err != nil || agent.ID == uuid.Nil {
+		// Agent unbound or unreachable: keep the pin.
+		return pinned
+	}
+	return server.overlayLiveWorkspaceMCPTools(ctx, logger, chat.ID, agent.ID, pinned, workspaceCtx.getWorkspaceConn)
+}
+
+// overlayLiveWorkspaceMCPTools reads agentID's latest pushed MCP set and merges
+// it over the pinned baseline. Live wins per server; a server present only in
+// the pin is retained. A read failure or an empty live MCP set keeps the pin
+// intact, so a transiently empty or disconnected snapshot never strips MCP
+// tools mid-turn: the agent re-pushes and the next turn reconverges.
+func (server *Server) overlayLiveWorkspaceMCPTools(
+	ctx context.Context,
+	logger slog.Logger,
+	chatID uuid.UUID,
+	agentID uuid.UUID,
+	pinned []fantasy.AgentTool,
+	getConn func(context.Context) (workspacesdk.AgentConn, error),
+) []fantasy.AgentTool {
+	//nolint:gocritic // Chatd reads the agent's live context as the daemon subject.
+	resources, err := server.db.ListWorkspaceAgentContextResources(dbauthz.AsChatd(ctx), agentID)
+	if err != nil {
+		logger.Warn(ctx, "failed to read live workspace MCP context for convergence",
+			slog.F("chat_id", chatID), slog.F("agent_id", agentID), slog.Error(err))
+		return pinned
+	}
+	liveInfos := agentWorkspaceMCPToolInfos(resources)
+	if len(liveInfos) == 0 {
+		return pinned
+	}
+	return mergeWorkspaceMCPToolsByServer(ctx, logger, pinned, liveInfos, getConn)
+}
+
+// mergeWorkspaceMCPToolsByServer overlays the live MCP tool infos over the
+// pinned baseline tools, replacing per server: a pinned tool whose server the
+// live set also advertises is dropped in favor of the live definition, while a
+// pinned tool for a server absent from the live set is retained. The live
+// tools are then appended. This converges an already-pinned chat onto the
+// agent's current MCP set while never dropping a server the live snapshot
+// happens to omit. The prefix test uses the server separator so a server name
+// is matched on a whole segment, not a partial name.
+func mergeWorkspaceMCPToolsByServer(
+	ctx context.Context,
+	logger slog.Logger,
+	pinned []fantasy.AgentTool,
+	liveInfos []workspacesdk.MCPToolInfo,
+	getConn func(context.Context) (workspacesdk.AgentConn, error),
+) []fantasy.AgentTool {
+	livePrefixes := make([]string, 0, len(liveInfos))
+	seenServer := make(map[string]struct{}, len(liveInfos))
+	for _, info := range liveInfos {
+		if _, ok := seenServer[info.ServerName]; ok {
+			continue
+		}
+		seenServer[info.ServerName] = struct{}{}
+		livePrefixes = append(livePrefixes, info.ServerName+mcpToolNameSeparator)
+	}
+
+	merged := make([]fantasy.AgentTool, 0, len(pinned)+len(liveInfos))
+	for _, tool := range pinned {
+		name := tool.Info().Name
+		superseded := false
+		for _, prefix := range livePrefixes {
+			if strings.HasPrefix(name, prefix) {
+				superseded = true
+				break
+			}
+		}
+		if superseded {
+			logger.Debug(ctx, "replacing pinned workspace MCP tool with live definition",
+				slog.F("tool_name", name))
+			continue
+		}
+		merged = append(merged, tool)
+	}
+	for _, info := range liveInfos {
+		merged = append(merged, chattool.NewWorkspaceMCPTool(info, getConn, nil))
+	}
+	return merged
 }
 
 // decodeInstructionContent decodes an instruction-file resource body and

--- a/coderd/x/chatd/context_prompt.go
+++ b/coderd/x/chatd/context_prompt.go
@@ -221,6 +221,17 @@ func (server *Server) pinnedWorkspaceContext(
 			slog.F("resource_count", len(resources)),
 		)
 	}
+	// Non-OK resources (oversize, unreadable, invalid, excluded) are dropped
+	// from the prompt without an error. Emit one aggregated debug line with
+	// the per-status counts so a "missing context" report is diagnosable
+	// without dumping every pinned row.
+	if statusFields := nonOKResourceStatusFields(resources); len(statusFields) > 0 {
+		server.logger.Debug(ctx, "skipped non-ok pinned chat context resources",
+			slog.F("chat_id", chat.ID),
+			slog.F("resource_count", len(resources)),
+			slog.F("status_counts", slog.M(statusFields...)),
+		)
+	}
 	server.logger.Debug(ctx, "built prompt context from pinned chat resources",
 		slog.F("chat_id", chat.ID),
 		slog.F("resource_count", len(resources)),
@@ -228,6 +239,34 @@ func (server *Server) pinnedWorkspaceContext(
 		slog.F("has_instruction", instruction != ""),
 	)
 	return instruction, skills, nil
+}
+
+// nonOKResourceStatusFields tallies pinned resources whose status is not OK
+// and returns one log field per non-OK status present, in a fixed order so the
+// emitted log is deterministic. These statuses (oversize, unreadable, invalid,
+// excluded) are exactly the bodies contextResourcesToPrompt drops from the
+// prompt, so the counts explain a "missing context" report without dumping
+// every row. Returns nil when every resource is OK.
+func nonOKResourceStatusFields(resources []database.ChatContextResource) []slog.Field {
+	counts := map[database.WorkspaceAgentContextResourceStatus]int{}
+	for _, r := range resources {
+		if r.Status != database.WorkspaceAgentContextResourceStatusOk {
+			counts[r.Status]++
+		}
+	}
+	ordered := []database.WorkspaceAgentContextResourceStatus{
+		database.WorkspaceAgentContextResourceStatusOversize,
+		database.WorkspaceAgentContextResourceStatusUnreadable,
+		database.WorkspaceAgentContextResourceStatusInvalid,
+		database.WorkspaceAgentContextResourceStatusExcluded,
+	}
+	var fields []slog.Field
+	for _, status := range ordered {
+		if n := counts[status]; n > 0 {
+			fields = append(fields, slog.F(string(status), n))
+		}
+	}
+	return fields
 }
 
 // resolveTurnWorkspaceContext selects the instruction block and workspace

--- a/coderd/x/chatd/context_prompt.go
+++ b/coderd/x/chatd/context_prompt.go
@@ -72,11 +72,19 @@ func mcpToolsFromServerBody(server string, body json.RawMessage) []codersdk.Chat
 	}
 	prefix := server + mcpToolNameSeparator
 	out := make([]codersdk.ChatContextTool, 0, len(tools))
+	seen := make(map[string]struct{}, len(tools))
 	for _, t := range tools {
 		name := strings.TrimPrefix(t.GetName(), prefix)
 		if name == "" {
 			continue
 		}
+		// A server that lists the same tool twice would otherwise report it
+		// twice; keep the first occurrence so the reported tool set matches
+		// the deduplicated set the turn assembles.
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
 		out = append(out, codersdk.ChatContextTool{
 			Name:        name,
 			Description: t.GetDescription(),

--- a/coderd/x/chatd/context_prompt_internal_test.go
+++ b/coderd/x/chatd/context_prompt_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"charm.land/fantasy"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -22,6 +23,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbmock"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 	"github.com/coder/coder/v2/testutil"
@@ -61,6 +63,19 @@ func skillResource(t *testing.T, source, name, description string, status databa
 func mcpServerResource(t *testing.T, source string, body *agentproto.MCPServerBody, status database.WorkspaceAgentContextResourceStatus) database.ChatContextResource {
 	t.Helper()
 	return database.ChatContextResource{
+		Source:   source,
+		BodyKind: database.WorkspaceAgentContextBodyKindMcpServer,
+		Body:     mustMarshalContextBody(t, body),
+		Status:   status,
+	}
+}
+
+// agentMCPServerResource builds an agent-side mcp_server context row
+// (workspace_agent_context_resources), the live counterpart to
+// mcpServerResource's pinned chat row.
+func agentMCPServerResource(t *testing.T, source string, body *agentproto.MCPServerBody, status database.WorkspaceAgentContextResourceStatus) database.WorkspaceAgentContextResource {
+	t.Helper()
+	return database.WorkspaceAgentContextResource{
 		Source:   source,
 		BodyKind: database.WorkspaceAgentContextBodyKindMcpServer,
 		Body:     mustMarshalContextBody(t, body),
@@ -893,5 +908,144 @@ func TestNonOKResourceStatusFields(t *testing.T) {
 			instructionResource(t, "/a", "ok", database.WorkspaceAgentContextResourceStatusOk),
 		}
 		require.Nil(t, nonOKResourceStatusFields(resources))
+	})
+}
+
+func mcpToolNames(tools []fantasy.AgentTool) []string {
+	out := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		out = append(out, tool.Info().Name)
+	}
+	return out
+}
+
+func TestMergeWorkspaceMCPToolsByServer(t *testing.T) {
+	t.Parallel()
+
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	// getConn is nil-returning: the merge only wraps infos, it never dials.
+	getConn := func(context.Context) (workspacesdk.AgentConn, error) {
+		return nil, xerrors.New("not dialed in this test")
+	}
+	mcpTool := func(server, tool string) fantasy.AgentTool {
+		return chattool.NewWorkspaceMCPTool(workspacesdk.MCPToolInfo{
+			ServerName: server,
+			Name:       server + "__" + tool,
+		}, getConn, nil)
+	}
+
+	t.Run("LiveWinsPerServerAndRetainsPinnedOnly", func(t *testing.T) {
+		t.Parallel()
+
+		pinned := []fantasy.AgentTool{
+			mcpTool("jira", "list_issues"),  // server absent from live: retained
+			mcpTool("github", "stale_tool"), // server present in live: replaced
+		}
+		liveInfos := []workspacesdk.MCPToolInfo{
+			{ServerName: "github", Name: "github__create_issue"},
+			{ServerName: "github", Name: "github__search"},
+		}
+
+		merged := mergeWorkspaceMCPToolsByServer(context.Background(), logger, pinned, liveInfos, getConn)
+		require.ElementsMatch(t, []string{
+			"jira__list_issues",
+			"github__create_issue",
+			"github__search",
+		}, mcpToolNames(merged))
+	})
+
+	t.Run("EmptyPinnedYieldsLiveOnly", func(t *testing.T) {
+		t.Parallel()
+
+		liveInfos := []workspacesdk.MCPToolInfo{
+			{ServerName: "github", Name: "github__create_issue"},
+		}
+		merged := mergeWorkspaceMCPToolsByServer(context.Background(), logger, nil, liveInfos, getConn)
+		require.Equal(t, []string{"github__create_issue"}, mcpToolNames(merged))
+	})
+}
+
+func TestOverlayLiveWorkspaceMCPTools(t *testing.T) {
+	t.Parallel()
+
+	getConn := func(context.Context) (workspacesdk.AgentConn, error) {
+		return nil, xerrors.New("not dialed in this test")
+	}
+	pinnedGithubTool := func() fantasy.AgentTool {
+		return chattool.NewWorkspaceMCPTool(workspacesdk.MCPToolInfo{
+			ServerName: "github",
+			Name:       "github__create_issue",
+		}, getConn, nil)
+	}
+	liveGithub := func() []database.WorkspaceAgentContextResource {
+		return []database.WorkspaceAgentContextResource{
+			agentMCPServerResource(t, "github", &agentproto.MCPServerBody{
+				ServerName: "github",
+				Tools: []*agentproto.MCPTool{
+					{Name: "create_issue", Description: "Create an issue"},
+					{Name: "search", Description: "Search code"},
+				},
+			}, database.WorkspaceAgentContextResourceStatusOk),
+		}
+	}
+	newServer := func(t *testing.T, agentID uuid.UUID, resources []database.WorkspaceAgentContextResource, err error) *Server {
+		t.Helper()
+		ctrl := gomock.NewController(t)
+		db := dbmock.NewMockStore(ctrl)
+		db.EXPECT().ListWorkspaceAgentContextResources(gomock.Any(), agentID).
+			Return(resources, err)
+		return newPinServer(t, db)
+	}
+
+	t.Run("PinnedParentAndLaterChildConvergeOnLiveSet", func(t *testing.T) {
+		t.Parallel()
+
+		agentID := uuid.New()
+
+		// Parent was pinned before the MCP server connected: empty MCP
+		// baseline. The live overlay supplies the server.
+		parent := newServer(t, agentID, liveGithub(), nil)
+		parentTools := parent.overlayLiveWorkspaceMCPTools(
+			context.Background(), parent.logger, uuid.New(), agentID, nil, getConn)
+
+		// A child created after the server connected carries the server in its
+		// pinned baseline. Live wins per server, so it resolves the same set.
+		child := newServer(t, agentID, liveGithub(), nil)
+		childTools := child.overlayLiveWorkspaceMCPTools(
+			context.Background(), child.logger, uuid.New(), agentID,
+			[]fantasy.AgentTool{pinnedGithubTool()}, getConn)
+
+		require.ElementsMatch(t, []string{"github__create_issue", "github__search"}, mcpToolNames(parentTools))
+		require.ElementsMatch(t, mcpToolNames(parentTools), mcpToolNames(childTools))
+	})
+
+	t.Run("LiveReadErrorKeepsPin", func(t *testing.T) {
+		t.Parallel()
+
+		agentID := uuid.New()
+		server := newServer(t, agentID, nil, xerrors.New("boom"))
+		got := server.overlayLiveWorkspaceMCPTools(
+			context.Background(), server.logger, uuid.New(), agentID,
+			[]fantasy.AgentTool{pinnedGithubTool()}, getConn)
+		require.Equal(t, []string{"github__create_issue"}, mcpToolNames(got))
+	})
+
+	t.Run("EmptyLiveMCPSetKeepsPin", func(t *testing.T) {
+		t.Parallel()
+
+		// The agent has a snapshot but advertises no mcp_server rows (a
+		// transient disconnect, or a workspace that never had MCP servers):
+		// keep the pin rather than stripping its tools mid-turn.
+		agentID := uuid.New()
+		nonMCP := []database.WorkspaceAgentContextResource{{
+			Source:   "/home/coder/AGENTS.md",
+			BodyKind: database.WorkspaceAgentContextBodyKindInstructionFile,
+			Status:   database.WorkspaceAgentContextResourceStatusOk,
+		}}
+		server := newServer(t, agentID, nonMCP, nil)
+		got := server.overlayLiveWorkspaceMCPTools(
+			context.Background(), server.logger, uuid.New(), agentID,
+			[]fantasy.AgentTool{pinnedGithubTool()}, getConn)
+		require.Equal(t, []string{"github__create_issue"}, mcpToolNames(got))
 	})
 }

--- a/coderd/x/chatd/context_prompt_internal_test.go
+++ b/coderd/x/chatd/context_prompt_internal_test.go
@@ -829,3 +829,35 @@ func TestPinnedWorkspaceMCPTools(t *testing.T) {
 		require.Empty(t, tools)
 	})
 }
+
+func TestMCPToolsFromServerBody(t *testing.T) {
+	t.Parallel()
+
+	t.Run("DedupsRepeatedToolNames", func(t *testing.T) {
+		t.Parallel()
+
+		// A server that lists the same tool name twice must report it once so
+		// the reported set matches the deduplicated set the turn assembles.
+		body := mustMarshalContextBody(t, &agentproto.MCPServerBody{
+			ServerName: "github",
+			Tools: []*agentproto.MCPTool{
+				{Name: "create_issue", Description: "first wins"},
+				{Name: "create_issue", Description: "dropped duplicate"},
+				{Name: "search", Description: "search code"},
+			},
+		})
+
+		tools := mcpToolsFromServerBody("github", body)
+		require.Len(t, tools, 2)
+		require.Equal(t, "create_issue", tools[0].Name)
+		require.Equal(t, "first wins", tools[0].Description)
+		require.Equal(t, "search", tools[1].Name)
+	})
+
+	t.Run("NoToolsYieldsNil", func(t *testing.T) {
+		t.Parallel()
+
+		body := mustMarshalContextBody(t, &agentproto.MCPServerBody{ServerName: "github"})
+		require.Nil(t, mcpToolsFromServerBody("github", body))
+	})
+}

--- a/coderd/x/chatd/context_prompt_internal_test.go
+++ b/coderd/x/chatd/context_prompt_internal_test.go
@@ -861,3 +861,37 @@ func TestMCPToolsFromServerBody(t *testing.T) {
 		require.Nil(t, mcpToolsFromServerBody("github", body))
 	})
 }
+
+func TestNonOKResourceStatusFields(t *testing.T) {
+	t.Parallel()
+
+	t.Run("CountsPerNonOKStatusInFixedOrder", func(t *testing.T) {
+		t.Parallel()
+
+		resources := []database.ChatContextResource{
+			instructionResource(t, "/a", "ok", database.WorkspaceAgentContextResourceStatusOk),
+			instructionResource(t, "/b", "", database.WorkspaceAgentContextResourceStatusInvalid),
+			instructionResource(t, "/c", "", database.WorkspaceAgentContextResourceStatusOversize),
+			instructionResource(t, "/d", "", database.WorkspaceAgentContextResourceStatusOversize),
+			skillResource(t, "/e", "x", "y", database.WorkspaceAgentContextResourceStatusExcluded),
+		}
+
+		// Fixed order is oversize, unreadable, invalid, excluded; unreadable is
+		// absent so it is omitted.
+		fields := nonOKResourceStatusFields(resources)
+		require.Equal(t, []slog.Field{
+			slog.F("oversize", 2),
+			slog.F("invalid", 1),
+			slog.F("excluded", 1),
+		}, fields)
+	})
+
+	t.Run("AllOKReturnsNil", func(t *testing.T) {
+		t.Parallel()
+
+		resources := []database.ChatContextResource{
+			instructionResource(t, "/a", "ok", database.WorkspaceAgentContextResourceStatusOk),
+		}
+		require.Nil(t, nonOKResourceStatusFields(resources))
+	})
+}

--- a/coderd/x/chatd/generation_preparer.go
+++ b/coderd/x/chatd/generation_preparer.go
@@ -284,7 +284,7 @@ func (server *Server) prepareGeneration(
 	}
 	if chat.WorkspaceID.Valid && !isPlanModeTurn && !isExploreSubagent {
 		g2.Go(func() error {
-			workspaceMCPTools = server.resolveWorkspaceMCPTools(ctx, logger, chat, &workspaceCtx)
+			workspaceMCPTools = server.resolveWorkspaceMCPToolsConverged(ctx, logger, chat, &workspaceCtx)
 			return nil
 		})
 	}

--- a/coderd/x/chatd/generation_preparer.go
+++ b/coderd/x/chatd/generation_preparer.go
@@ -449,6 +449,11 @@ func (server *Server) prepareGeneration(
 	if !isExploreSubagent {
 		tools = append(tools, workspaceMCPTools...)
 	}
+	// Builtin tools are assembled first, then external and workspace MCP
+	// tools are appended above. Two MCP servers (or an MCP server and a
+	// builtin) can expose the same tool name; dedup here so a duplicate
+	// definition never reaches the provider request, which rejects them.
+	tools = dedupeToolsByName(ctx, logger, tools)
 	tools = filterToolsForTurn(tools, currentPlanMode, chat.ParentChatID, approvedPlanMCPConfigIDs)
 
 	tools, dynamicToolNames, err := appendDynamicTools(ctx, logger, tools, chat.DynamicTools, currentPlanMode, chat.Mode)
@@ -628,6 +633,28 @@ func (server *Server) prepareGeneration(
 		Cleanup: cleanup,
 		Debug:   debug,
 	}, nil
+}
+
+// dedupeToolsByName removes tools whose Info().Name collides with an earlier
+// tool, keeping the first occurrence. The assembled slice is builtin tools
+// followed by external and workspace MCP tools, so a collision keeps the
+// builtin or earlier-listed server's tool. A duplicate tool definition that
+// reaches the provider request is rejected by the provider, so dropping the
+// later collision keeps the turn valid. Dropped names are logged at debug to
+// keep an unexpected collision diagnosable.
+func dedupeToolsByName(ctx context.Context, logger slog.Logger, tools []fantasy.AgentTool) []fantasy.AgentTool {
+	seen := make(map[string]struct{}, len(tools))
+	deduped := make([]fantasy.AgentTool, 0, len(tools))
+	for _, t := range tools {
+		name := t.Info().Name
+		if _, ok := seen[name]; ok {
+			logger.Debug(ctx, "dropped duplicate tool definition", slog.F("tool_name", name))
+			continue
+		}
+		seen[name] = struct{}{}
+		deduped = append(deduped, t)
+	}
+	return deduped
 }
 
 func latestPromptUsage(messages []database.ChatMessage) fantasy.Usage {

--- a/coderd/x/chatd/generation_preparer_internal_test.go
+++ b/coderd/x/chatd/generation_preparer_internal_test.go
@@ -1,10 +1,12 @@
 package chatd //nolint:testpackage // Exercises unexported re-derivation helpers.
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"testing"
 
+	"charm.land/fantasy"
 	"github.com/google/uuid"
 	"github.com/sqlc-dev/pqtype"
 	"github.com/stretchr/testify/require"
@@ -16,7 +18,9 @@ import (
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprovider"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatstate"
+	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/codersdk/workspacesdk"
 )
 
 func mustMarshalText(t *testing.T, parts ...string) pqtype.NullRawMessage {
@@ -38,6 +42,43 @@ func textMessage(t *testing.T, id int64, role database.ChatMessageRole, parts ..
 		Content:        mustMarshalText(t, parts...),
 		ContentVersion: chatprompt.CurrentContentVersion,
 	}
+}
+
+func TestDedupeToolsByName(t *testing.T) {
+	t.Parallel()
+
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	// getConn is nil: dedup inspects only Info().Name and never runs a tool.
+	namedTool := func(name string) fantasy.AgentTool {
+		return chattool.NewWorkspaceMCPTool(workspacesdk.MCPToolInfo{Name: name}, nil, nil)
+	}
+
+	t.Run("KeepsFirstOccurrence", func(t *testing.T) {
+		t.Parallel()
+		// Two servers expose "github__create_issue"; the first wins and the
+		// duplicate is dropped so it never reaches the provider request.
+		tools := []fantasy.AgentTool{
+			namedTool("read_file"),
+			namedTool("github__create_issue"),
+			namedTool("github__create_issue"),
+			namedTool("search"),
+		}
+		got := dedupeToolsByName(context.Background(), logger, tools)
+		names := make([]string, 0, len(got))
+		for _, tool := range got {
+			names = append(names, tool.Info().Name)
+		}
+		require.Equal(t, []string{"read_file", "github__create_issue", "search"}, names)
+	})
+
+	t.Run("NoDuplicatesPreservesOrder", func(t *testing.T) {
+		t.Parallel()
+		tools := []fantasy.AgentTool{namedTool("a"), namedTool("b"), namedTool("c")}
+		got := dedupeToolsByName(context.Background(), logger, tools)
+		require.Len(t, got, 3)
+		require.Equal(t, "a", got[0].Info().Name)
+		require.Equal(t, "c", got[2].Info().Name)
+	})
 }
 
 func TestLatestAssistantText(t *testing.T) {


### PR DESCRIPTION
## Summary

Converges the workspace-agent context that backs chatd MCP tools so an already-pinned chat reflects the agent's *current* MCP servers, and aligns the three context-refresh entry points. The symptom this fixes: a chat created **before** MCP servers connect never shows their tools, while a child created **after** does, because MCP resources are excluded from the drift hash and never re-pin.

- **Priority 1 (small, high value).** `workspaceAgentRefreshChatContext` now re-pins every owned chat **unconditionally**, not just drifted ones (dropped the `!ContextDirtySince.Valid` half of the guard, kept the `OwnerID` check). MCP config/server changes are excluded from the drift hash, so a dirty-only guard could never apply an MCP-only change. This matches the per-chat and user-facing refresh paths. `coder exp chat context refresh` messaging is updated to match.
- **Priority 2 (small).** The final assembled tool slice is deduped by `Info().Name` before it reaches the provider request (external `mcpTools` + `workspaceMCPTools` previously had no name dedup; only skill tools did), keeping the first occurrence and logging dropped collisions at debug. `mcpToolsFromServerBody` also dedups per-server tool names. Verified `buildToolDefinitions` does not reintroduce duplicates.
- **Priority 3 (small).** `pinnedWorkspaceContext` emits a single aggregated debug log with per-status counts of non-OK pinned resources (oversize/unreadable/invalid/excluded) so "missing context" is debuggable.
- **Priority 4 (convergence).** Implemented **mechanism (a): an assembly-time overlay**. When a turn assembles workspace MCP tools, it overlays the agent's latest pushed MCP set (`ListWorkspaceAgentContextResources`) over the chat's frozen pinned baseline: **live wins per server, pinned-only servers are retained, and an empty/failed live read keeps the pin** (so a transient/disconnected snapshot never strips tools mid-turn). Instruction and skill content stay pinned. It is read-only (no DB writes, no feedback loop), so a pinned parent and a later child resolve the same MCP set and async-connected servers appear without a manual repin.

**Why (a) over (b):** mechanism (b) (push-time MCP-row sync) would need new MCP-kind-only DB queries plus codegen, which fall outside this change's file ownership, and it risks wiping rows on a transient empty snapshot. The read-only overlay achieves the same convergence with no persistence and no feedback loop.

**Out of scope (separate agent-side effort):** folding `.mcp.json` config into the drift hash, and the agent-side resync push-barrier. If Priority 1's unconditional refresh races the agent's resync push (refresh re-pins before the resync push lands), the barrier fix lands separately.

<details>
<summary>Verification</summary>

### Changes
- `coderd/workspaceagents.go` — drop the `!ContextDirtySince.Valid` guard half in `workspaceAgentRefreshChatContext`; re-pin all owned active chats; updated doc/inline comments.
- `cli/exp_chat.go` — refresh command help text and the post-refresh message no longer say "drifted".
- `coderd/x/chatd/generation_preparer.go` — `dedupeToolsByName` applied to the assembled tool slice after the MCP appends; call site now uses `resolveWorkspaceMCPToolsConverged`.
- `coderd/x/chatd/context_prompt.go` — per-server tool-name dedup in `mcpToolsFromServerBody`; aggregated `nonOKResourceStatusFields` debug log; convergence overlay (`resolveWorkspaceMCPToolsConverged`, `overlayLiveWorkspaceMCPTools`, `mergeWorkspaceMCPToolsByServer`) plus a shared `appendMCPToolInfos`/`agentWorkspaceMCPToolInfos` decoder for agent-side rows.

### Tests
- `TestChatContextRefreshFromAgentToken` adjusted: a non-dirty owned chat is now re-pinned (`Refreshed == 1`, not `0`), and the re-pin keeps the clean chat clean.
- `TestDedupeToolsByName`, `TestMCPToolsFromServerBody` — dedup behavior (first occurrence kept).
- `TestNonOKResourceStatusFields` — per-status counts in fixed order.
- `TestMergeWorkspaceMCPToolsByServer` — live wins per server, pinned-only retained.
- `TestOverlayLiveWorkspaceMCPTools` — **pinned parent and a later child converge on the same live MCP set**; live read error and empty live set keep the pin.

### Scoped checks
- `go build ./coderd/... ./cli/...` passes.
- `go test ./coderd/x/chatd/...` passes (full package).
- `git commit` pre-commit hooks (gen/fmt/lint/build) green on every commit.

</details>

Generated by Coder Agents on behalf of @kylecarbs. Part of a coordinated series fixing the workspace agent context refactor; draft pending review.
