### PR TITLE
refactor(site): split spend page sections

### DIFF
--- a/site/src/pages/AISettingsPage/SpendPage/SpendPageView.tsx
+++ b/site/src/pages/AISettingsPage/SpendPage/SpendPageView.tsx
@@ -1,40 +1,16 @@
-import { EllipsisVerticalIcon } from "lucide-react";
 import type { FC } from "react";
-
 import { getErrorMessage } from "#/api/errors";
 import type * as TypesGen from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
-import { AvatarData } from "#/components/Avatar/AvatarData";
 import { Button } from "#/components/Button/Button";
-import {
-	DateRangePicker,
-	type DateRangeValue,
-} from "#/components/DateRangePicker/DateRangePicker";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
-} from "#/components/DropdownMenu/DropdownMenu";
-import {
-	PaginationContainer,
-	type PaginationResult,
-} from "#/components/PaginationWidget/PaginationContainer";
-import { SearchField } from "#/components/SearchField/SearchField";
+import type { DateRangeValue } from "#/components/DateRangePicker/DateRangePicker";
+import type { PaginationResult } from "#/components/PaginationWidget/PaginationContainer";
 import {
 	SettingsHeader,
 	SettingsHeaderDescription,
 	SettingsHeaderTitle,
 } from "#/components/SettingsHeader/SettingsHeader";
 import { Spinner } from "#/components/Spinner/Spinner";
-import {
-	Table,
-	TableBody,
-	TableCell,
-	TableHead,
-	TableHeader,
-	TableRow,
-} from "#/components/Table/Table";
 import {
 	Tabs,
 	TabsContent,
@@ -45,18 +21,7 @@ import {
 	TemporarySavedState,
 	useTemporarySavedState,
 } from "#/components/TemporarySavedState/TemporarySavedState";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "#/components/Tooltip/Tooltip";
-import { useClickableTableRow } from "#/hooks/useClickableTableRow";
-import { formatTokenCount } from "#/utils/analytics";
-import {
-	dollarsToMicros,
-	formatCostMicros,
-	microsToDollars,
-} from "#/utils/currency";
+import { dollarsToMicros, microsToDollars } from "#/utils/currency";
 import {
 	DefaultLimitController,
 	type DefaultLimitFormValues,
@@ -69,90 +34,8 @@ import { UserOverrideController } from "./components/LimitsTab/UserOverrideContr
 import { UserOverridesSection } from "./components/LimitsTab/UserOverridesSection";
 import { SpendDrillInView } from "./components/SpendDrillInView";
 import { SpendSectionHeader } from "./components/SpendSectionHeader";
+import { UsageTab } from "./components/UsageTab/UsageTab";
 import { formatUsageDateRange, toInclusiveDateRange } from "./utils/dateRange";
-
-const UserRow: FC<{
-	user: TypesGen.ChatCostUserRollup;
-	onSelect: (user: TypesGen.ChatCostUserRollup) => void;
-	onEditBudget: (user: TypesGen.ChatCostUserRollup) => void;
-}> = ({ user, onSelect, onEditBudget }) => {
-	const clickableRowProps = useClickableTableRow({
-		onClick: () => onSelect(user),
-	});
-
-	return (
-		<TableRow
-			{...clickableRowProps}
-			aria-label={`View details for ${user.name || user.username}`}
-			className="text-xs"
-		>
-			<TableCell className="max-w-[200px] px-3 py-2">
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<div>
-							<AvatarData
-								title={
-									<span className="block truncate">
-										{user.name || user.username}
-									</span>
-								}
-								subtitle={
-									<span className="block truncate">@{user.username}</span>
-								}
-								src={user.avatar_url}
-								imgFallbackText={user.username}
-							/>
-						</div>
-					</TooltipTrigger>
-					<TooltipContent>{user.name || user.username}</TooltipContent>
-				</Tooltip>
-			</TableCell>
-			<TableCell className="text-right tabular-nums">
-				{formatCostMicros(user.total_cost_micros)}
-			</TableCell>
-			<TableCell className="text-right tabular-nums">
-				{user.message_count.toLocaleString()}
-			</TableCell>
-			<TableCell className="text-right tabular-nums">
-				{user.chat_count.toLocaleString()}
-			</TableCell>
-			<TableCell className="text-right tabular-nums">
-				{formatTokenCount(user.total_input_tokens)}
-			</TableCell>
-			<TableCell className="text-right tabular-nums">
-				{formatTokenCount(user.total_output_tokens)}
-			</TableCell>
-			<TableCell className="text-right tabular-nums">
-				{formatTokenCount(user.total_cache_read_tokens)}
-			</TableCell>
-			<TableCell className="text-right tabular-nums">
-				{formatTokenCount(user.total_cache_creation_tokens)}
-			</TableCell>
-			<TableCell className="w-1" onClick={(event) => event.stopPropagation()}>
-				<DropdownMenu>
-					<DropdownMenuTrigger asChild>
-						<Button
-							type="button"
-							size="icon"
-							variant="subtle"
-							aria-label={`Open spend actions for ${user.name || user.username}`}
-						>
-							<EllipsisVerticalIcon aria-hidden="true" className="size-4" />
-						</Button>
-					</DropdownMenuTrigger>
-					<DropdownMenuContent align="end">
-						<DropdownMenuItem onClick={() => onEditBudget(user)}>
-							Update budget
-						</DropdownMenuItem>
-						<DropdownMenuItem onClick={() => onSelect(user)}>
-							View spend details
-						</DropdownMenuItem>
-					</DropdownMenuContent>
-				</DropdownMenu>
-			</TableCell>
-		</TableRow>
-	);
-};
 
 interface SpendPageViewProps {
 	configData: TypesGen.ChatUsageLimitConfigResponse | undefined;
@@ -534,142 +417,19 @@ export const SpendPageView: FC<SpendPageViewProps> = ({
 								</TabsContent>
 
 								<TabsContent value="usage" className="pt-8">
-									<section className="space-y-6">
-										<SpendSectionHeader
-											title="Usage by user"
-											description="Monitor AI usage and spend for users in the selected date range."
-											actions={
-												<DateRangePicker
-													value={displayDateRange}
-													onChange={onDateRangeChange}
-												/>
-											}
-										/>
-										<div>
-											<div className="w-full md:max-w-sm">
-												<SearchField
-													value={searchFilter}
-													onChange={onSearchFilterChange}
-													placeholder="Search by name or username"
-													aria-label="Search usage by name or username"
-												/>
-											</div>
-										</div>
-										{usersQuery.isLoading && (
-											<div
-												role="status"
-												aria-label="Loading usage"
-												className="flex min-h-[240px] items-center justify-center"
-											>
-												<Spinner
-													size="lg"
-													loading
-													className="text-content-secondary"
-												/>
-											</div>
-										)}
-										{usersQuery.error != null && (
-											<div className="flex min-h-[240px] flex-col items-center justify-center gap-4 text-center">
-												<ErrorAlert error={usersQuery.error} />
-												<Button
-													variant="outline"
-													size="sm"
-													type="button"
-													onClick={() => void usersQuery.refetch()}
-												>
-													Retry
-												</Button>
-											</div>
-										)}
-										{usersQuery.data && (
-											<div className="relative pt-3">
-												{usersQuery.isFetching && !usersQuery.isLoading && (
-													<div
-														role="status"
-														aria-label="Refreshing usage"
-														className="absolute inset-0 z-10 flex items-center justify-center bg-surface-primary/50"
-													>
-														<Spinner
-															size="lg"
-															loading
-															className="text-content-secondary"
-														/>
-													</div>
-												)}
-												{usersQuery.data.users.length === 0 ? (
-													<p className="py-12 text-center text-content-secondary">
-														No usage data for this period.
-													</p>
-												) : (
-													<PaginationContainer
-														query={usersQuery}
-														paginationUnitLabel="users"
-													>
-														<div className="overflow-hidden rounded-lg border border-border-default">
-															<Table aria-label="User spend details">
-																<TableHeader>
-																	<TableRow>
-																		<TableHead>User</TableHead>
-																		<TableHead className="text-right">
-																			Cost
-																		</TableHead>
-																		<TableHead className="text-right">
-																			Messages
-																		</TableHead>
-																		<TableHead className="text-right">
-																			Chats
-																		</TableHead>
-																		<TableHead className="text-right">
-																			Input
-																		</TableHead>
-																		<TableHead className="text-right">
-																			Output
-																		</TableHead>
-																		<TableHead className="text-right">
-																			Cache Read
-																		</TableHead>
-																		<TableHead className="text-right">
-																			Cache Write
-																		</TableHead>
-																		<TableHead className="w-1">
-																			Actions
-																		</TableHead>
-																	</TableRow>
-																</TableHeader>
-																<TableBody>
-																	{usersQuery.data.users.map((user) => (
-																		<UserRow
-																			key={user.user_id}
-																			user={user}
-																			onSelect={onSelectUser}
-																			onEditBudget={(selectedUser) => {
-																				const override = overrides.find(
-																					(o) =>
-																						o.user_id === selectedUser.user_id,
-																				) ?? {
-																					user_id: selectedUser.user_id,
-																					name: selectedUser.name,
-																					username: selectedUser.username,
-																					avatar_url: selectedUser.avatar_url,
-																					spend_limit_micros: null,
-																				};
-																				groupCtrl.handleShowGroupFormChange(
-																					false,
-																				);
-																				userCtrl.handleEditUserOverride(
-																					override,
-																				);
-																			}}
-																		/>
-																	))}
-																</TableBody>
-															</Table>
-														</div>
-													</PaginationContainer>
-												)}
-											</div>
-										)}
-									</section>
+									<UsageTab
+										displayDateRange={displayDateRange}
+										onDateRangeChange={onDateRangeChange}
+										searchFilter={searchFilter}
+										onSearchFilterChange={onSearchFilterChange}
+										usersQuery={usersQuery}
+										overrides={overrides}
+										onSelectUser={onSelectUser}
+										onEditBudget={(override) => {
+											groupCtrl.handleShowGroupFormChange(false);
+											userCtrl.handleEditUserOverride(override);
+										}}
+									/>
 								</TabsContent>
 							</Tabs>
 						</div>

--- a/site/src/pages/AISettingsPage/SpendPage/components/LimitsTab/GroupLimitDialog.tsx
+++ b/site/src/pages/AISettingsPage/SpendPage/components/LimitsTab/GroupLimitDialog.tsx
@@ -1,0 +1,183 @@
+import { CheckIcon } from "lucide-react";
+import type { FC } from "react";
+import { getErrorMessage } from "#/api/errors";
+import type { Group } from "#/api/typesGenerated";
+import { Autocomplete } from "#/components/Autocomplete/Autocomplete";
+import { AvatarData } from "#/components/Avatar/AvatarData";
+import { Button } from "#/components/Button/Button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "#/components/Dialog/Dialog";
+import { Input } from "#/components/Input/Input";
+import { Label } from "#/components/Label/Label";
+import { Spinner } from "#/components/Spinner/Spinner";
+import { getGroupSubtitle } from "#/modules/groups";
+import { isPositiveFiniteDollarAmount } from "#/utils/currency";
+import type { GroupLimitOverrideGroup } from "./groupLimits";
+
+interface GroupLimitDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	selectedGroup: Group | null;
+	onSelectedGroupChange: (group: Group | null) => void;
+	groupAmount: string;
+	onGroupAmountChange: (amount: string) => void;
+	availableGroups: Group[];
+	groupAutocompleteNoOptionsText: string;
+	groupsLoading: boolean;
+	editingGroupOverride: GroupLimitOverrideGroup | null;
+	upsertPending: boolean;
+	upsertError: Error | null;
+	onSave: () => void;
+	groupAutocompleteId: string;
+	groupAmountId: string;
+}
+
+export const GroupLimitDialog: FC<GroupLimitDialogProps> = ({
+	open,
+	onOpenChange,
+	selectedGroup,
+	onSelectedGroupChange,
+	groupAmount,
+	onGroupAmountChange,
+	availableGroups,
+	groupAutocompleteNoOptionsText,
+	groupsLoading,
+	editingGroupOverride,
+	upsertPending,
+	upsertError,
+	onSave,
+	groupAutocompleteId,
+	groupAmountId,
+}) => {
+	const isEditing = editingGroupOverride !== null;
+	const saveDisabled = isEditing
+		? upsertPending || !isPositiveFiniteDollarAmount(groupAmount)
+		: upsertPending ||
+			selectedGroup === null ||
+			!isPositiveFiniteDollarAmount(groupAmount);
+
+	return (
+		<Dialog
+			open={open}
+			onOpenChange={(nextOpen) => {
+				if (upsertPending) {
+					return;
+				}
+
+				onOpenChange(nextOpen);
+				if (!nextOpen) {
+					onSelectedGroupChange(null);
+					onGroupAmountChange("");
+				}
+			}}
+		>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>
+						{isEditing ? "Update group budget" : "Add group budget"}
+					</DialogTitle>
+					<DialogDescription>
+						{isEditing
+							? "Update this group's spend limit override."
+							: "Set a spend limit override for a specific group."}
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="space-y-5">
+					<div className="space-y-1.5">
+						{editingGroupOverride ? (
+							<>
+								<Label>Group</Label>
+								<div className="rounded-md border border-border bg-surface-secondary/40 p-2">
+									<AvatarData
+										title={
+											editingGroupOverride.group_display_name ||
+											editingGroupOverride.group_name
+										}
+										subtitle={editingGroupOverride.group_name}
+										src={editingGroupOverride.group_avatar_url}
+										imgFallbackText={editingGroupOverride.group_name}
+									/>
+								</div>
+							</>
+						) : (
+							<>
+								<Label htmlFor={groupAutocompleteId}>Group</Label>
+								<Autocomplete
+									id={groupAutocompleteId}
+									value={selectedGroup}
+									onChange={onSelectedGroupChange}
+									options={availableGroups}
+									getOptionValue={(group) => group.id}
+									getOptionLabel={(group) => group.display_name || group.name}
+									isOptionEqualToValue={(option, optionValue) =>
+										option.id === optionValue.id
+									}
+									renderOption={(option, isSelected) => (
+										<div className="flex w-full items-center justify-between gap-2">
+											<AvatarData
+												title={option.display_name || option.name}
+												subtitle={getGroupSubtitle(option)}
+												src={option.avatar_url}
+												imgFallbackText={option.name}
+											/>
+											{isSelected && <CheckIcon className="size-4 shrink-0" />}
+										</div>
+									)}
+									placeholder="Search groups..."
+									noOptionsText={groupAutocompleteNoOptionsText}
+									loading={groupsLoading}
+									disabled={groupsLoading}
+									className="w-full"
+								/>
+							</>
+						)}
+					</div>
+					<div className="space-y-1.5">
+						<Label htmlFor={groupAmountId}>Spend limit ($)</Label>
+						<Input
+							id={groupAmountId}
+							type="number"
+							step="0.01"
+							min="0.01"
+							disabled={upsertPending}
+							value={groupAmount}
+							onChange={(event) => onGroupAmountChange(event.target.value)}
+							placeholder="0.00"
+						/>
+					</div>
+					{upsertError && (
+						<p className="text-xs text-content-destructive">
+							{getErrorMessage(upsertError, "Failed to save group override.")}
+						</p>
+					)}
+				</div>
+
+				<DialogFooter>
+					<Button
+						variant="outline"
+						type="button"
+						onClick={() => {
+							onOpenChange(false);
+							onSelectedGroupChange(null);
+							onGroupAmountChange("");
+						}}
+						disabled={upsertPending}
+					>
+						Cancel
+					</Button>
+					<Button type="button" onClick={onSave} disabled={saveDisabled}>
+						{upsertPending ? <Spinner loading className="h-4 w-4" /> : null}
+						{isEditing ? "Update budget" : "Add group"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/site/src/pages/AISettingsPage/SpendPage/components/LimitsTab/GroupLimitsSection.tsx
+++ b/site/src/pages/AISettingsPage/SpendPage/components/LimitsTab/GroupLimitsSection.tsx
@@ -1,61 +1,23 @@
-import {
-	CheckIcon,
-	EllipsisVerticalIcon,
-	PlusIcon,
-	TrashIcon,
-} from "lucide-react";
+import { PlusIcon } from "lucide-react";
 import { type FC, useId, useState } from "react";
-import { Link } from "react-router";
 import { getErrorMessage } from "#/api/errors";
-import type { ChatUsageLimitGroupOverride, Group } from "#/api/typesGenerated";
-import { Autocomplete } from "#/components/Autocomplete/Autocomplete";
-import { AvatarData } from "#/components/Avatar/AvatarData";
+import type { Group } from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
-import {
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogFooter,
-	DialogHeader,
-	DialogTitle,
-} from "#/components/Dialog/Dialog";
 import { ConfirmDeleteDialog } from "#/components/Dialogs/ConfirmDeleteDialog/ConfirmDeleteDialog";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
-} from "#/components/DropdownMenu/DropdownMenu";
-import { Input } from "#/components/Input/Input";
-import { Label } from "#/components/Label/Label";
-import { PaginationAmount } from "#/components/PaginationWidget/PaginationAmount";
-import { PaginationWidgetBase } from "#/components/PaginationWidget/PaginationWidgetBase";
 import { SearchField } from "#/components/SearchField/SearchField";
-import { Spinner } from "#/components/Spinner/Spinner";
-import {
-	Table,
-	TableBody,
-	TableCell,
-	TableHead,
-	TableHeader,
-	TableRow,
-} from "#/components/Table/Table";
-import { getGroupSubtitle } from "#/modules/groups";
-import {
-	formatCostMicros,
-	isPositiveFiniteDollarAmount,
-} from "#/utils/currency";
 import { paginateItems } from "#/utils/paginateItems";
 import { SpendSectionHeader } from "../SpendSectionHeader";
-
-const GROUP_LIMITS_PAGE_SIZE = 10;
+import { GroupLimitDialog } from "./GroupLimitDialog";
+import { GroupLimitsTable } from "./GroupLimitsTable";
+import {
+	GROUP_LIMITS_PAGE_SIZE,
+	type GroupLimitOverride,
+	type GroupLimitOverrideGroup,
+} from "./groupLimits";
 
 interface GroupLimitsSectionProps {
 	hideHeader?: boolean;
-	groupOverrides: readonly ChatUsageLimitGroupOverride[];
-	/** Maps group_id to organization_name so override rows can link to
-	 * the group's organization page. Overrides without a known org name
-	 * fall back to plain (non-linked) display. */
+	groupOverrides: readonly GroupLimitOverride[];
 	groupOrganizationNames?: Record<string, string | undefined>;
 	showGroupForm: boolean;
 	onShowGroupFormChange: (show: boolean) => void;
@@ -66,16 +28,8 @@ interface GroupLimitsSectionProps {
 	availableGroups: Group[];
 	groupAutocompleteNoOptionsText: string;
 	groupsLoading: boolean;
-	editingGroupOverride: {
-		group_id: string;
-		group_display_name: string;
-		group_name: string;
-		group_avatar_url: string;
-		member_count: number;
-	} | null;
-	onEditGroupOverride: (
-		override: GroupLimitsSectionProps["groupOverrides"][number],
-	) => void;
+	editingGroupOverride: GroupLimitOverrideGroup | null;
+	onEditGroupOverride: (override: GroupLimitOverride) => void;
 	onAddGroupOverride: () => void;
 	onDeleteGroupOverride: (groupID: string) => void;
 	upsertPending: boolean;
@@ -163,116 +117,26 @@ export const GroupLimitsSection: FC<GroupLimitsSectionProps> = ({
 						Add group
 					</Button>
 				</div>
-				{filteredGroupOverrides.length > 0 ? (
-					<div className="space-y-4">
-						<Table>
-							<TableHeader>
-								<TableRow>
-									<TableHead>Group</TableHead>
-									<TableHead>Members</TableHead>
-									<TableHead>Spend limit</TableHead>
-									<TableHead className="w-1">Actions</TableHead>
-								</TableRow>
-							</TableHeader>
-							<TableBody>
-								{pagedItems.map((override) => {
-									const orgName = groupOrganizationNames?.[override.group_id];
-									const groupAvatar = (
-										<AvatarData
-											title={override.group_display_name || override.group_name}
-											subtitle={override.group_name}
-											src={override.group_avatar_url}
-											imgFallbackText={override.group_name}
-										/>
-									);
-									return (
-										<TableRow key={override.group_id}>
-											<TableCell>
-												{orgName ? (
-													<Link
-														to={`/organizations/${orgName}/groups/${override.group_name}`}
-														className="inline-block"
-													>
-														{groupAvatar}
-													</Link>
-												) : (
-													groupAvatar
-												)}
-											</TableCell>
-											<TableCell>{override.member_count}</TableCell>
-											<TableCell>
-												{override.spend_limit_micros !== null
-													? formatCostMicros(override.spend_limit_micros)
-													: "Unlimited"}
-											</TableCell>
-											<TableCell className="w-1 whitespace-nowrap text-right">
-												<DropdownMenu>
-													<DropdownMenuTrigger asChild>
-														<Button
-															variant="subtle"
-															size="icon"
-															type="button"
-															disabled={deletePending || upsertPending}
-															aria-label={`Actions for ${
-																override.group_display_name ||
-																override.group_name
-															}`}
-														>
-															<EllipsisVerticalIcon />
-														</Button>
-													</DropdownMenuTrigger>
-													<DropdownMenuContent align="end">
-														<DropdownMenuItem
-															onSelect={() => onEditGroupOverride(override)}
-														>
-															Update budget
-														</DropdownMenuItem>
-														<DropdownMenuItem
-															className="text-content-destructive focus:text-content-destructive"
-															disabled={isEditing}
-															onSelect={() =>
-																setPendingDeleteGroupId(override.group_id)
-															}
-														>
-															<TrashIcon />
-															Remove group limit
-														</DropdownMenuItem>
-													</DropdownMenuContent>
-												</DropdownMenu>
-											</TableCell>
-										</TableRow>
-									);
-								})}
-							</TableBody>
-						</Table>
-						<PaginationAmount
-							limit={GROUP_LIMITS_PAGE_SIZE}
-							totalRecords={filteredGroupOverrides.length}
-							currentOffsetStart={
-								(clampedPage - 1) * GROUP_LIMITS_PAGE_SIZE + 1
-							}
-							paginationUnitLabel="groups"
-							className="justify-end"
-						/>
-					</div>
-				) : (
-					<div className="rounded-lg border border-border bg-surface-secondary px-4 py-6 text-center text-sm text-content-secondary">
-						{groupOverrides.length === 0
-							? "No group overrides configured."
-							: "No group limits match your search."}
-					</div>
-				)}
 
-				{filteredGroupOverrides.length > GROUP_LIMITS_PAGE_SIZE && (
-					<PaginationWidgetBase
-						currentPage={clampedPage}
-						pageSize={GROUP_LIMITS_PAGE_SIZE}
-						totalRecords={filteredGroupOverrides.length}
-						onPageChange={setPage}
-						hasPreviousPage={hasPreviousPage}
-						hasNextPage={hasNextPage}
-					/>
-				)}
+				<GroupLimitsTable
+					pagedOverrides={pagedItems}
+					totalOverrides={filteredGroupOverrides.length}
+					clampedPage={clampedPage}
+					hasPreviousPage={hasPreviousPage}
+					hasNextPage={hasNextPage}
+					onPageChange={setPage}
+					onEditGroupOverride={onEditGroupOverride}
+					onRequestDelete={setPendingDeleteGroupId}
+					groupOrganizationNames={groupOrganizationNames}
+					deletePending={deletePending}
+					upsertPending={upsertPending}
+					isEditing={isEditing}
+					emptyMessage={
+						groupOverrides.length === 0
+							? "No group overrides configured."
+							: "No group limits match your search."
+					}
+				/>
 
 				{deleteError && (
 					<p className="text-xs text-content-destructive">
@@ -280,140 +144,23 @@ export const GroupLimitsSection: FC<GroupLimitsSectionProps> = ({
 					</p>
 				)}
 
-				<Dialog
+				<GroupLimitDialog
 					open={showGroupForm}
-					onOpenChange={(open) => {
-						if (upsertPending) {
-							return;
-						}
-
-						onShowGroupFormChange(open);
-						if (!open) {
-							onSelectedGroupChange(null);
-							onGroupAmountChange("");
-						}
-					}}
-				>
-					<DialogContent>
-						<DialogHeader>
-							<DialogTitle>
-								{isEditing ? "Update group budget" : "Add group budget"}
-							</DialogTitle>
-							<DialogDescription>
-								{isEditing
-									? "Update this group's spend limit override."
-									: "Set a spend limit override for a specific group."}
-							</DialogDescription>
-						</DialogHeader>
-
-						<div className="space-y-5">
-							<div className="space-y-1.5">
-								{editingGroupOverride ? (
-									<>
-										<Label>Group</Label>
-										<div className="rounded-md border border-border bg-surface-secondary/40 p-2">
-											<AvatarData
-												title={
-													editingGroupOverride.group_display_name ||
-													editingGroupOverride.group_name
-												}
-												subtitle={editingGroupOverride.group_name}
-												src={editingGroupOverride.group_avatar_url}
-												imgFallbackText={editingGroupOverride.group_name}
-											/>
-										</div>
-									</>
-								) : (
-									<>
-										<Label htmlFor={groupAutocompleteId}>Group</Label>
-										<Autocomplete
-											id={groupAutocompleteId}
-											value={selectedGroup}
-											onChange={onSelectedGroupChange}
-											options={availableGroups}
-											getOptionValue={(group) => group.id}
-											getOptionLabel={(group) =>
-												group.display_name || group.name
-											}
-											isOptionEqualToValue={(option, optionValue) =>
-												option.id === optionValue.id
-											}
-											renderOption={(option, isSelected) => (
-												<div className="flex w-full items-center justify-between gap-2">
-													<AvatarData
-														title={option.display_name || option.name}
-														subtitle={getGroupSubtitle(option)}
-														src={option.avatar_url}
-														imgFallbackText={option.name}
-													/>
-													{isSelected && (
-														<CheckIcon className="size-4 shrink-0" />
-													)}
-												</div>
-											)}
-											placeholder="Search groups..."
-											noOptionsText={groupAutocompleteNoOptionsText}
-											loading={groupsLoading}
-											disabled={groupsLoading}
-											className="w-full"
-										/>
-									</>
-								)}
-							</div>
-							<div className="space-y-1.5">
-								<Label htmlFor={groupAmountId}>Spend limit ($)</Label>
-								<Input
-									id={groupAmountId}
-									type="number"
-									step="0.01"
-									min="0.01"
-									disabled={upsertPending}
-									value={groupAmount}
-									onChange={(event) => onGroupAmountChange(event.target.value)}
-									placeholder="0.00"
-								/>
-							</div>
-							{upsertError && (
-								<p className="text-xs text-content-destructive">
-									{getErrorMessage(
-										upsertError,
-										"Failed to save group override.",
-									)}
-								</p>
-							)}
-						</div>
-
-						<DialogFooter>
-							<Button
-								variant="outline"
-								type="button"
-								onClick={() => {
-									onShowGroupFormChange(false);
-									onSelectedGroupChange(null);
-									onGroupAmountChange("");
-								}}
-								disabled={upsertPending}
-							>
-								Cancel
-							</Button>
-							<Button
-								type="button"
-								onClick={() => void onAddGroupOverride()}
-								disabled={
-									isEditing
-										? upsertPending ||
-											!isPositiveFiniteDollarAmount(groupAmount)
-										: upsertPending ||
-											selectedGroup === null ||
-											!isPositiveFiniteDollarAmount(groupAmount)
-								}
-							>
-								{upsertPending ? <Spinner loading className="h-4 w-4" /> : null}
-								{isEditing ? "Update budget" : "Add group"}
-							</Button>
-						</DialogFooter>
-					</DialogContent>
-				</Dialog>
+					onOpenChange={onShowGroupFormChange}
+					selectedGroup={selectedGroup}
+					onSelectedGroupChange={onSelectedGroupChange}
+					groupAmount={groupAmount}
+					onGroupAmountChange={onGroupAmountChange}
+					availableGroups={availableGroups}
+					groupAutocompleteNoOptionsText={groupAutocompleteNoOptionsText}
+					groupsLoading={groupsLoading}
+					editingGroupOverride={editingGroupOverride}
+					upsertPending={upsertPending}
+					upsertError={upsertError}
+					onSave={onAddGroupOverride}
+					groupAutocompleteId={groupAutocompleteId}
+					groupAmountId={groupAmountId}
+				/>
 				{groupsError && (
 					<p className="text-xs text-content-destructive">
 						{getErrorMessage(groupsError, "Failed to load groups.")}

--- a/site/src/pages/AISettingsPage/SpendPage/components/LimitsTab/GroupLimitsTable.tsx
+++ b/site/src/pages/AISettingsPage/SpendPage/components/LimitsTab/GroupLimitsTable.tsx
@@ -1,0 +1,165 @@
+import { EllipsisVerticalIcon, TrashIcon } from "lucide-react";
+import type { FC } from "react";
+import { Link } from "react-router";
+import { AvatarData } from "#/components/Avatar/AvatarData";
+import { Button } from "#/components/Button/Button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "#/components/DropdownMenu/DropdownMenu";
+import { PaginationAmount } from "#/components/PaginationWidget/PaginationAmount";
+import { PaginationWidgetBase } from "#/components/PaginationWidget/PaginationWidgetBase";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "#/components/Table/Table";
+import { formatCostMicros } from "#/utils/currency";
+import { GROUP_LIMITS_PAGE_SIZE, type GroupLimitOverride } from "./groupLimits";
+
+interface GroupLimitsTableProps {
+	pagedOverrides: readonly GroupLimitOverride[];
+	totalOverrides: number;
+	clampedPage: number;
+	hasPreviousPage: boolean;
+	hasNextPage: boolean;
+	onPageChange: (page: number) => void;
+	onEditGroupOverride: (override: GroupLimitOverride) => void;
+	onRequestDelete: (groupID: string) => void;
+	groupOrganizationNames?: Record<string, string | undefined>;
+	deletePending: boolean;
+	upsertPending: boolean;
+	isEditing: boolean;
+	emptyMessage: string;
+}
+
+export const GroupLimitsTable: FC<GroupLimitsTableProps> = ({
+	pagedOverrides,
+	totalOverrides,
+	clampedPage,
+	hasPreviousPage,
+	hasNextPage,
+	onPageChange,
+	onEditGroupOverride,
+	onRequestDelete,
+	groupOrganizationNames,
+	deletePending,
+	upsertPending,
+	isEditing,
+	emptyMessage,
+}) => {
+	if (totalOverrides === 0) {
+		return (
+			<div className="rounded-lg border border-border bg-surface-secondary px-4 py-6 text-center text-sm text-content-secondary">
+				{emptyMessage}
+			</div>
+		);
+	}
+
+	return (
+		<>
+			<div className="space-y-4">
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead>Group</TableHead>
+							<TableHead>Members</TableHead>
+							<TableHead>Spend limit</TableHead>
+							<TableHead className="w-1">Actions</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{pagedOverrides.map((override) => {
+							const orgName = groupOrganizationNames?.[override.group_id];
+							const groupAvatar = (
+								<AvatarData
+									title={override.group_display_name || override.group_name}
+									subtitle={override.group_name}
+									src={override.group_avatar_url}
+									imgFallbackText={override.group_name}
+								/>
+							);
+
+							return (
+								<TableRow key={override.group_id}>
+									<TableCell>
+										{orgName ? (
+											<Link
+												to={`/organizations/${orgName}/groups/${override.group_name}`}
+												className="inline-block"
+											>
+												{groupAvatar}
+											</Link>
+										) : (
+											groupAvatar
+										)}
+									</TableCell>
+									<TableCell>{override.member_count}</TableCell>
+									<TableCell>
+										{override.spend_limit_micros !== null
+											? formatCostMicros(override.spend_limit_micros)
+											: "Unlimited"}
+									</TableCell>
+									<TableCell className="w-1 whitespace-nowrap text-right">
+										<DropdownMenu>
+											<DropdownMenuTrigger asChild>
+												<Button
+													variant="subtle"
+													size="icon"
+													type="button"
+													disabled={deletePending || upsertPending}
+													aria-label={`Actions for ${
+														override.group_display_name || override.group_name
+													}`}
+												>
+													<EllipsisVerticalIcon />
+												</Button>
+											</DropdownMenuTrigger>
+											<DropdownMenuContent align="end">
+												<DropdownMenuItem
+													onSelect={() => onEditGroupOverride(override)}
+												>
+													Update budget
+												</DropdownMenuItem>
+												<DropdownMenuItem
+													className="text-content-destructive focus:text-content-destructive"
+													disabled={isEditing}
+													onSelect={() => onRequestDelete(override.group_id)}
+												>
+													<TrashIcon />
+													Remove group limit
+												</DropdownMenuItem>
+											</DropdownMenuContent>
+										</DropdownMenu>
+									</TableCell>
+								</TableRow>
+							);
+						})}
+					</TableBody>
+				</Table>
+				<PaginationAmount
+					limit={GROUP_LIMITS_PAGE_SIZE}
+					totalRecords={totalOverrides}
+					currentOffsetStart={(clampedPage - 1) * GROUP_LIMITS_PAGE_SIZE + 1}
+					paginationUnitLabel="groups"
+					className="justify-end"
+				/>
+			</div>
+			{totalOverrides > GROUP_LIMITS_PAGE_SIZE && (
+				<PaginationWidgetBase
+					currentPage={clampedPage}
+					pageSize={GROUP_LIMITS_PAGE_SIZE}
+					totalRecords={totalOverrides}
+					onPageChange={onPageChange}
+					hasPreviousPage={hasPreviousPage}
+					hasNextPage={hasNextPage}
+				/>
+			)}
+		</>
+	);
+};

--- a/site/src/pages/AISettingsPage/SpendPage/components/LimitsTab/UserOverrideDialog.tsx
+++ b/site/src/pages/AISettingsPage/SpendPage/components/LimitsTab/UserOverrideDialog.tsx
@@ -1,0 +1,157 @@
+import type { FC } from "react";
+import { getErrorMessage } from "#/api/errors";
+import type { User } from "#/api/typesGenerated";
+import { AvatarData } from "#/components/Avatar/AvatarData";
+import { Button } from "#/components/Button/Button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "#/components/Dialog/Dialog";
+import { Input } from "#/components/Input/Input";
+import { Label } from "#/components/Label/Label";
+import { Spinner } from "#/components/Spinner/Spinner";
+import { UserAutocomplete } from "#/components/UserAutocomplete/UserAutocomplete";
+import { isPositiveFiniteDollarAmount } from "#/utils/currency";
+import type { UserOverrideUser } from "./userOverrides";
+
+interface UserOverrideDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	selectedUser: User | null;
+	onSelectedUserChange: (user: User | null) => void;
+	userOverrideAmount: string;
+	onUserOverrideAmountChange: (amount: string) => void;
+	selectedUserAlreadyOverridden: boolean;
+	editingUserOverride: UserOverrideUser | null;
+	upsertPending: boolean;
+	upsertError: Error | null;
+	onSave: () => void;
+	amountInputId: string;
+}
+
+export const UserOverrideDialog: FC<UserOverrideDialogProps> = ({
+	open,
+	onOpenChange,
+	selectedUser,
+	onSelectedUserChange,
+	userOverrideAmount,
+	onUserOverrideAmountChange,
+	selectedUserAlreadyOverridden,
+	editingUserOverride,
+	upsertPending,
+	upsertError,
+	onSave,
+	amountInputId,
+}) => {
+	const isEditing = editingUserOverride !== null;
+	const saveDisabled = isEditing
+		? upsertPending || !isPositiveFiniteDollarAmount(userOverrideAmount)
+		: upsertPending ||
+			!selectedUser ||
+			selectedUserAlreadyOverridden ||
+			!isPositiveFiniteDollarAmount(userOverrideAmount);
+
+	return (
+		<Dialog
+			open={open}
+			onOpenChange={(nextOpen) => {
+				if (upsertPending) {
+					return;
+				}
+
+				onOpenChange(nextOpen);
+				if (!nextOpen) {
+					onSelectedUserChange(null);
+					onUserOverrideAmountChange("");
+				}
+			}}
+		>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>
+						{isEditing ? "Update user budget" : "Add user budget"}
+					</DialogTitle>
+					<DialogDescription>
+						{isEditing
+							? "Update this user's spend limit override."
+							: "Set a spend limit override for a specific user."}
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="space-y-5">
+					<div className="space-y-1.5">
+						{editingUserOverride ? (
+							<>
+								<Label>User</Label>
+								<div className="rounded-md border border-border bg-surface-secondary/40 p-2">
+									<AvatarData
+										title={
+											editingUserOverride.name || editingUserOverride.username
+										}
+										subtitle={`@${editingUserOverride.username}`}
+										src={editingUserOverride.avatar_url}
+										imgFallbackText={editingUserOverride.username}
+									/>
+								</div>
+							</>
+						) : (
+							<UserAutocomplete
+								value={selectedUser}
+								onChange={onSelectedUserChange}
+								label="User"
+							/>
+						)}
+					</div>
+					<div className="space-y-1.5">
+						<Label htmlFor={amountInputId}>Spend limit ($)</Label>
+						<Input
+							id={amountInputId}
+							type="number"
+							step="0.01"
+							min="0.01"
+							disabled={upsertPending}
+							value={userOverrideAmount}
+							onChange={(event) =>
+								onUserOverrideAmountChange(event.target.value)
+							}
+							placeholder="0.00"
+						/>
+					</div>
+					{!isEditing && selectedUserAlreadyOverridden && (
+						<p className="text-xs text-content-warning">
+							This user already has an override.
+						</p>
+					)}
+					{upsertError && (
+						<p className="text-xs text-content-destructive">
+							{getErrorMessage(upsertError, "Failed to save the override.")}
+						</p>
+					)}
+				</div>
+
+				<DialogFooter>
+					<Button
+						variant="outline"
+						type="button"
+						onClick={() => {
+							onOpenChange(false);
+							onSelectedUserChange(null);
+							onUserOverrideAmountChange("");
+						}}
+						disabled={upsertPending}
+					>
+						Cancel
+					</Button>
+					<Button type="button" onClick={onSave} disabled={saveDisabled}>
+						{upsertPending ? <Spinner loading className="h-4 w-4" /> : null}
+						{isEditing ? "Update budget" : "Add user"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/site/src/pages/AISettingsPage/SpendPage/components/LimitsTab/UserOverridesSection.tsx
+++ b/site/src/pages/AISettingsPage/SpendPage/components/LimitsTab/UserOverridesSection.tsx
@@ -1,57 +1,23 @@
-import { EllipsisVerticalIcon, PlusIcon, TrashIcon } from "lucide-react";
+import { PlusIcon } from "lucide-react";
 import { type FC, useId, useState } from "react";
 import { getErrorMessage } from "#/api/errors";
 import type { User } from "#/api/typesGenerated";
-import { AvatarData } from "#/components/Avatar/AvatarData";
 import { Button } from "#/components/Button/Button";
-import {
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogFooter,
-	DialogHeader,
-	DialogTitle,
-} from "#/components/Dialog/Dialog";
 import { ConfirmDeleteDialog } from "#/components/Dialogs/ConfirmDeleteDialog/ConfirmDeleteDialog";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
-} from "#/components/DropdownMenu/DropdownMenu";
-import { Input } from "#/components/Input/Input";
-import { Label } from "#/components/Label/Label";
-import { PaginationAmount } from "#/components/PaginationWidget/PaginationAmount";
-import { PaginationWidgetBase } from "#/components/PaginationWidget/PaginationWidgetBase";
 import { SearchField } from "#/components/SearchField/SearchField";
-import { Spinner } from "#/components/Spinner/Spinner";
-import {
-	Table,
-	TableBody,
-	TableCell,
-	TableHead,
-	TableHeader,
-	TableRow,
-} from "#/components/Table/Table";
-import { UserAutocomplete } from "#/components/UserAutocomplete/UserAutocomplete";
-import {
-	formatCostMicros,
-	isPositiveFiniteDollarAmount,
-} from "#/utils/currency";
 import { paginateItems } from "#/utils/paginateItems";
 import { SpendSectionHeader } from "../SpendSectionHeader";
-
-const USER_OVERRIDES_PAGE_SIZE = 10;
+import { UserOverrideDialog } from "./UserOverrideDialog";
+import { UserOverridesTable } from "./UserOverridesTable";
+import {
+	USER_OVERRIDES_PAGE_SIZE,
+	type UserOverride,
+	type UserOverrideUser,
+} from "./userOverrides";
 
 interface UserOverridesSectionProps {
 	hideHeader?: boolean;
-	overrides: ReadonlyArray<{
-		user_id: string;
-		name: string;
-		username: string;
-		avatar_url: string;
-		spend_limit_micros: number | null;
-	}>;
+	overrides: readonly UserOverride[];
 	showUserForm: boolean;
 	onShowUserFormChange: (show: boolean) => void;
 	selectedUser: User | null;
@@ -59,15 +25,8 @@ interface UserOverridesSectionProps {
 	userOverrideAmount: string;
 	onUserOverrideAmountChange: (amount: string) => void;
 	selectedUserAlreadyOverridden: boolean;
-	editingUserOverride: {
-		user_id: string;
-		name: string;
-		username: string;
-		avatar_url: string;
-	} | null;
-	onEditUserOverride: (
-		override: UserOverridesSectionProps["overrides"][number],
-	) => void;
+	editingUserOverride: UserOverrideUser | null;
+	onEditUserOverride: (override: UserOverride) => void;
 	onAddOverride: () => void;
 	onDeleteOverride: (userID: string) => void;
 	upsertPending: boolean;
@@ -144,96 +103,25 @@ export const UserOverridesSection: FC<UserOverridesSectionProps> = ({
 						Add user
 					</Button>
 				</div>
-				{filteredOverrides.length > 0 ? (
-					<div className="space-y-4">
-						<Table>
-							<TableHeader>
-								<TableRow>
-									<TableHead>User</TableHead>
-									<TableHead>Spend limit</TableHead>
-									<TableHead className="w-1">Actions</TableHead>
-								</TableRow>
-							</TableHeader>
-							<TableBody>
-								{pagedItems.map((override) => (
-									<TableRow key={override.user_id}>
-										<TableCell>
-											<AvatarData
-												title={override.name || override.username}
-												subtitle={`@${override.username}`}
-												src={override.avatar_url}
-												imgFallbackText={override.username}
-											/>
-										</TableCell>
-										<TableCell>
-											{override.spend_limit_micros !== null
-												? formatCostMicros(override.spend_limit_micros)
-												: "Unlimited"}
-										</TableCell>
-										<TableCell className="w-1 whitespace-nowrap text-right">
-											<DropdownMenu>
-												<DropdownMenuTrigger asChild>
-													<Button
-														variant="subtle"
-														size="icon"
-														type="button"
-														disabled={deletePending || upsertPending}
-														aria-label={`Actions for ${override.name || override.username}`}
-													>
-														<EllipsisVerticalIcon />
-													</Button>
-												</DropdownMenuTrigger>
-												<DropdownMenuContent align="end">
-													<DropdownMenuItem
-														onSelect={() => onEditUserOverride(override)}
-													>
-														Update budget
-													</DropdownMenuItem>
-													<DropdownMenuItem
-														className="text-content-destructive focus:text-content-destructive"
-														disabled={isEditing}
-														onSelect={() =>
-															setPendingDeleteUserId(override.user_id)
-														}
-													>
-														<TrashIcon />
-														Remove override
-													</DropdownMenuItem>
-												</DropdownMenuContent>
-											</DropdownMenu>
-										</TableCell>
-									</TableRow>
-								))}
-							</TableBody>
-						</Table>
-						<PaginationAmount
-							limit={USER_OVERRIDES_PAGE_SIZE}
-							totalRecords={filteredOverrides.length}
-							currentOffsetStart={
-								(clampedPage - 1) * USER_OVERRIDES_PAGE_SIZE + 1
-							}
-							paginationUnitLabel="users"
-							className="justify-end"
-						/>
-					</div>
-				) : (
-					<div className="rounded-lg border border-border bg-surface-secondary px-4 py-6 text-center text-sm text-content-secondary">
-						{overrides.length === 0
-							? "No overrides configured."
-							: "No user overrides match your search."}
-					</div>
-				)}
 
-				{filteredOverrides.length > USER_OVERRIDES_PAGE_SIZE && (
-					<PaginationWidgetBase
-						currentPage={clampedPage}
-						pageSize={USER_OVERRIDES_PAGE_SIZE}
-						totalRecords={filteredOverrides.length}
-						onPageChange={setPage}
-						hasPreviousPage={hasPreviousPage}
-						hasNextPage={hasNextPage}
-					/>
-				)}
+				<UserOverridesTable
+					pagedOverrides={pagedItems}
+					totalOverrides={filteredOverrides.length}
+					clampedPage={clampedPage}
+					hasPreviousPage={hasPreviousPage}
+					hasNextPage={hasNextPage}
+					onPageChange={setPage}
+					onEditUserOverride={onEditUserOverride}
+					onRequestDelete={setPendingDeleteUserId}
+					deletePending={deletePending}
+					upsertPending={upsertPending}
+					isEditing={isEditing}
+					emptyMessage={
+						overrides.length === 0
+							? "No overrides configured."
+							: "No user overrides match your search."
+					}
+				/>
 
 				{deleteError && (
 					<p className="text-xs text-content-destructive">
@@ -241,116 +129,20 @@ export const UserOverridesSection: FC<UserOverridesSectionProps> = ({
 					</p>
 				)}
 
-				<Dialog
+				<UserOverrideDialog
 					open={showUserForm}
-					onOpenChange={(open) => {
-						if (upsertPending) {
-							return;
-						}
-
-						onShowUserFormChange(open);
-						if (!open) {
-							onSelectedUserChange(null);
-							onUserOverrideAmountChange("");
-						}
-					}}
-				>
-					<DialogContent>
-						<DialogHeader>
-							<DialogTitle>
-								{isEditing ? "Update user budget" : "Add user budget"}
-							</DialogTitle>
-							<DialogDescription>
-								{isEditing
-									? "Update this user's spend limit override."
-									: "Set a spend limit override for a specific user."}
-							</DialogDescription>
-						</DialogHeader>
-
-						<div className="space-y-5">
-							<div className="space-y-1.5">
-								{editingUserOverride ? (
-									<>
-										<Label>User</Label>
-										<div className="rounded-md border border-border bg-surface-secondary/40 p-2">
-											<AvatarData
-												title={
-													editingUserOverride.name ||
-													editingUserOverride.username
-												}
-												subtitle={`@${editingUserOverride.username}`}
-												src={editingUserOverride.avatar_url}
-												imgFallbackText={editingUserOverride.username}
-											/>
-										</div>
-									</>
-								) : (
-									<UserAutocomplete
-										value={selectedUser}
-										onChange={onSelectedUserChange}
-										label="User"
-									/>
-								)}
-							</div>
-							<div className="space-y-1.5">
-								<Label htmlFor={userOverrideAmountId}>Spend limit ($)</Label>
-								<Input
-									id={userOverrideAmountId}
-									type="number"
-									step="0.01"
-									min="0.01"
-									disabled={upsertPending}
-									value={userOverrideAmount}
-									onChange={(event) =>
-										onUserOverrideAmountChange(event.target.value)
-									}
-									placeholder="0.00"
-								/>
-							</div>
-							{!isEditing && selectedUserAlreadyOverridden && (
-								<p className="text-xs text-content-warning">
-									This user already has an override.
-								</p>
-							)}
-							{upsertError && (
-								<p className="text-xs text-content-destructive">
-									{getErrorMessage(upsertError, "Failed to save the override.")}
-								</p>
-							)}
-						</div>
-
-						<DialogFooter>
-							<Button
-								variant="outline"
-								type="button"
-								onClick={() => {
-									onShowUserFormChange(false);
-									onSelectedUserChange(null);
-									onUserOverrideAmountChange("");
-								}}
-								disabled={upsertPending}
-							>
-								Cancel
-							</Button>
-							<Button
-								type="button"
-								onClick={() => void onAddOverride()}
-								disabled={
-									isEditing
-										? upsertPending ||
-											!isPositiveFiniteDollarAmount(userOverrideAmount)
-										: upsertPending ||
-											!selectedUser ||
-											selectedUserAlreadyOverridden ||
-											!isPositiveFiniteDollarAmount(userOverrideAmount)
-								}
-							>
-								{upsertPending ? <Spinner loading className="h-4 w-4" /> : null}
-								{isEditing ? "Update budget" : "Add user"}
-							</Button>
-						</DialogFooter>
-					</DialogContent>
-				</Dialog>
+					onOpenChange={onShowUserFormChange}
+					selectedUser={selectedUser}
+					onSelectedUserChange={onSelectedUserChange}
+					userOverrideAmount={userOverrideAmount}
+					onUserOverrideAmountChange={onUserOverrideAmountChange}
+					selectedUserAlreadyOverridden={selectedUserAlreadyOverridden}
+					editingUserOverride={editingUserOverride}
+					upsertPending={upsertPending}
+					upsertError={upsertError}
+					onSave={onAddOverride}
+					amountInputId={userOverrideAmountId}
+				/>
 			</div>
 			{pendingDeleteUserId && (
 				<ConfirmDeleteDialog

--- a/site/src/pages/AISettingsPage/SpendPage/components/LimitsTab/UserOverridesTable.tsx
+++ b/site/src/pages/AISettingsPage/SpendPage/components/LimitsTab/UserOverridesTable.tsx
@@ -1,0 +1,142 @@
+import { EllipsisVerticalIcon, TrashIcon } from "lucide-react";
+import type { FC } from "react";
+import { AvatarData } from "#/components/Avatar/AvatarData";
+import { Button } from "#/components/Button/Button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "#/components/DropdownMenu/DropdownMenu";
+import { PaginationAmount } from "#/components/PaginationWidget/PaginationAmount";
+import { PaginationWidgetBase } from "#/components/PaginationWidget/PaginationWidgetBase";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "#/components/Table/Table";
+import { formatCostMicros } from "#/utils/currency";
+import { USER_OVERRIDES_PAGE_SIZE, type UserOverride } from "./userOverrides";
+
+interface UserOverridesTableProps {
+	pagedOverrides: readonly UserOverride[];
+	totalOverrides: number;
+	clampedPage: number;
+	hasPreviousPage: boolean;
+	hasNextPage: boolean;
+	onPageChange: (page: number) => void;
+	onEditUserOverride: (override: UserOverride) => void;
+	onRequestDelete: (userID: string) => void;
+	deletePending: boolean;
+	upsertPending: boolean;
+	isEditing: boolean;
+	emptyMessage: string;
+}
+
+export const UserOverridesTable: FC<UserOverridesTableProps> = ({
+	pagedOverrides,
+	totalOverrides,
+	clampedPage,
+	hasPreviousPage,
+	hasNextPage,
+	onPageChange,
+	onEditUserOverride,
+	onRequestDelete,
+	deletePending,
+	upsertPending,
+	isEditing,
+	emptyMessage,
+}) => {
+	if (totalOverrides === 0) {
+		return (
+			<div className="rounded-lg border border-border bg-surface-secondary px-4 py-6 text-center text-sm text-content-secondary">
+				{emptyMessage}
+			</div>
+		);
+	}
+
+	return (
+		<>
+			<div className="space-y-4">
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead>User</TableHead>
+							<TableHead>Spend limit</TableHead>
+							<TableHead className="w-1">Actions</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{pagedOverrides.map((override) => (
+							<TableRow key={override.user_id}>
+								<TableCell>
+									<AvatarData
+										title={override.name || override.username}
+										subtitle={`@${override.username}`}
+										src={override.avatar_url}
+										imgFallbackText={override.username}
+									/>
+								</TableCell>
+								<TableCell>
+									{override.spend_limit_micros !== null
+										? formatCostMicros(override.spend_limit_micros)
+										: "Unlimited"}
+								</TableCell>
+								<TableCell className="w-1 whitespace-nowrap text-right">
+									<DropdownMenu>
+										<DropdownMenuTrigger asChild>
+											<Button
+												variant="subtle"
+												size="icon"
+												type="button"
+												disabled={deletePending || upsertPending}
+												aria-label={`Actions for ${override.name || override.username}`}
+											>
+												<EllipsisVerticalIcon />
+											</Button>
+										</DropdownMenuTrigger>
+										<DropdownMenuContent align="end">
+											<DropdownMenuItem
+												onSelect={() => onEditUserOverride(override)}
+											>
+												Update budget
+											</DropdownMenuItem>
+											<DropdownMenuItem
+												className="text-content-destructive focus:text-content-destructive"
+												disabled={isEditing}
+												onSelect={() => onRequestDelete(override.user_id)}
+											>
+												<TrashIcon />
+												Remove override
+											</DropdownMenuItem>
+										</DropdownMenuContent>
+									</DropdownMenu>
+								</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
+				<PaginationAmount
+					limit={USER_OVERRIDES_PAGE_SIZE}
+					totalRecords={totalOverrides}
+					currentOffsetStart={(clampedPage - 1) * USER_OVERRIDES_PAGE_SIZE + 1}
+					paginationUnitLabel="users"
+					className="justify-end"
+				/>
+			</div>
+			{totalOverrides > USER_OVERRIDES_PAGE_SIZE && (
+				<PaginationWidgetBase
+					currentPage={clampedPage}
+					pageSize={USER_OVERRIDES_PAGE_SIZE}
+					totalRecords={totalOverrides}
+					onPageChange={onPageChange}
+					hasPreviousPage={hasPreviousPage}
+					hasNextPage={hasNextPage}
+				/>
+			)}
+		</>
+	);
+};

--- a/site/src/pages/AISettingsPage/SpendPage/components/LimitsTab/groupLimits.ts
+++ b/site/src/pages/AISettingsPage/SpendPage/components/LimitsTab/groupLimits.ts
@@ -1,0 +1,13 @@
+import type { ChatUsageLimitGroupOverride } from "#/api/typesGenerated";
+
+export const GROUP_LIMITS_PAGE_SIZE = 10;
+
+export interface GroupLimitOverrideGroup {
+	group_id: string;
+	group_display_name: string;
+	group_name: string;
+	group_avatar_url: string;
+	member_count: number;
+}
+
+export type GroupLimitOverride = ChatUsageLimitGroupOverride;

--- a/site/src/pages/AISettingsPage/SpendPage/components/LimitsTab/userOverrides.ts
+++ b/site/src/pages/AISettingsPage/SpendPage/components/LimitsTab/userOverrides.ts
@@ -1,0 +1,12 @@
+export const USER_OVERRIDES_PAGE_SIZE = 10;
+
+export interface UserOverrideUser {
+	user_id: string;
+	name: string;
+	username: string;
+	avatar_url: string;
+}
+
+export interface UserOverride extends UserOverrideUser {
+	spend_limit_micros: number | null;
+}

--- a/site/src/pages/AISettingsPage/SpendPage/components/UsageTab/UsageTab.tsx
+++ b/site/src/pages/AISettingsPage/SpendPage/components/UsageTab/UsageTab.tsx
@@ -1,0 +1,264 @@
+import { EllipsisVerticalIcon } from "lucide-react";
+import type { FC } from "react";
+import type * as TypesGen from "#/api/typesGenerated";
+import { ErrorAlert } from "#/components/Alert/ErrorAlert";
+import { AvatarData } from "#/components/Avatar/AvatarData";
+import { Button } from "#/components/Button/Button";
+import {
+	DateRangePicker,
+	type DateRangeValue,
+} from "#/components/DateRangePicker/DateRangePicker";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "#/components/DropdownMenu/DropdownMenu";
+import {
+	PaginationContainer,
+	type PaginationResult,
+} from "#/components/PaginationWidget/PaginationContainer";
+import { SearchField } from "#/components/SearchField/SearchField";
+import { Spinner } from "#/components/Spinner/Spinner";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "#/components/Table/Table";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
+import { useClickableTableRow } from "#/hooks/useClickableTableRow";
+import { formatTokenCount } from "#/utils/analytics";
+import { formatCostMicros } from "#/utils/currency";
+import { SpendSectionHeader } from "../SpendSectionHeader";
+
+type UsageUserOverride = {
+	user_id: string;
+	name: string;
+	username: string;
+	avatar_url: string;
+	spend_limit_micros: number | null;
+};
+
+interface UsageTabProps {
+	displayDateRange: DateRangeValue;
+	onDateRangeChange: (value: DateRangeValue) => void;
+	searchFilter: string;
+	onSearchFilterChange: (value: string) => void;
+	usersQuery: PaginationResult & {
+		data: TypesGen.ChatCostUsersResponse | undefined;
+		isLoading: boolean;
+		isFetching: boolean;
+		error: unknown;
+		refetch: () => unknown;
+	};
+	overrides: readonly UsageUserOverride[];
+	onSelectUser: (user: TypesGen.ChatCostUserRollup) => void;
+	onEditBudget: (override: UsageUserOverride) => void;
+}
+
+export const UsageTab: FC<UsageTabProps> = ({
+	displayDateRange,
+	onDateRangeChange,
+	searchFilter,
+	onSearchFilterChange,
+	usersQuery,
+	overrides,
+	onSelectUser,
+	onEditBudget,
+}) => {
+	return (
+		<section className="space-y-6">
+			<SpendSectionHeader
+				title="Usage by user"
+				description="Monitor AI usage and spend for users in the selected date range."
+				actions={
+					<DateRangePicker
+						value={displayDateRange}
+						onChange={onDateRangeChange}
+					/>
+				}
+			/>
+			<div>
+				<div className="w-full md:max-w-sm">
+					<SearchField
+						value={searchFilter}
+						onChange={onSearchFilterChange}
+						placeholder="Search by name or username"
+						aria-label="Search usage by name or username"
+					/>
+				</div>
+			</div>
+			{usersQuery.isLoading && (
+				<div
+					role="status"
+					aria-label="Loading usage"
+					className="flex min-h-[240px] items-center justify-center"
+				>
+					<Spinner size="lg" loading className="text-content-secondary" />
+				</div>
+			)}
+			{usersQuery.error != null && (
+				<div className="flex min-h-[240px] flex-col items-center justify-center gap-4 text-center">
+					<ErrorAlert error={usersQuery.error} />
+					<Button
+						variant="outline"
+						size="sm"
+						type="button"
+						onClick={() => void usersQuery.refetch()}
+					>
+						Retry
+					</Button>
+				</div>
+			)}
+			{usersQuery.data && (
+				<div className="relative pt-3">
+					{usersQuery.isFetching && !usersQuery.isLoading && (
+						<div
+							role="status"
+							aria-label="Refreshing usage"
+							className="absolute inset-0 z-10 flex items-center justify-center bg-surface-primary/50"
+						>
+							<Spinner size="lg" loading className="text-content-secondary" />
+						</div>
+					)}
+					{usersQuery.data.users.length === 0 ? (
+						<p className="py-12 text-center text-content-secondary">
+							No usage data for this period.
+						</p>
+					) : (
+						<PaginationContainer query={usersQuery} paginationUnitLabel="users">
+							<div className="overflow-hidden rounded-lg border border-border-default">
+								<Table aria-label="User spend details">
+									<TableHeader>
+										<TableRow>
+											<TableHead>User</TableHead>
+											<TableHead className="text-right">Cost</TableHead>
+											<TableHead className="text-right">Messages</TableHead>
+											<TableHead className="text-right">Chats</TableHead>
+											<TableHead className="text-right">Input</TableHead>
+											<TableHead className="text-right">Output</TableHead>
+											<TableHead className="text-right">Cache Read</TableHead>
+											<TableHead className="text-right">Cache Write</TableHead>
+											<TableHead className="w-1">Actions</TableHead>
+										</TableRow>
+									</TableHeader>
+									<TableBody>
+										{usersQuery.data.users.map((user) => (
+											<UserRow
+												key={user.user_id}
+												user={user}
+												onSelect={onSelectUser}
+												onEditBudget={(selectedUser) => {
+													const override = overrides.find(
+														(o) => o.user_id === selectedUser.user_id,
+													) ?? {
+														user_id: selectedUser.user_id,
+														name: selectedUser.name,
+														username: selectedUser.username,
+														avatar_url: selectedUser.avatar_url,
+														spend_limit_micros: null,
+													};
+													onEditBudget(override);
+												}}
+											/>
+										))}
+									</TableBody>
+								</Table>
+							</div>
+						</PaginationContainer>
+					)}
+				</div>
+			)}
+		</section>
+	);
+};
+
+const UserRow: FC<{
+	user: TypesGen.ChatCostUserRollup;
+	onSelect: (user: TypesGen.ChatCostUserRollup) => void;
+	onEditBudget: (user: TypesGen.ChatCostUserRollup) => void;
+}> = ({ user, onSelect, onEditBudget }) => {
+	const clickableRowProps = useClickableTableRow({
+		onClick: () => onSelect(user),
+	});
+
+	return (
+		<TableRow
+			{...clickableRowProps}
+			aria-label={`View details for ${user.name || user.username}`}
+			className="text-xs"
+		>
+			<TableCell className="max-w-[200px] px-3 py-2">
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<div>
+							<AvatarData
+								title={
+									<span className="block truncate">
+										{user.name || user.username}
+									</span>
+								}
+								subtitle={
+									<span className="block truncate">@{user.username}</span>
+								}
+								src={user.avatar_url}
+								imgFallbackText={user.username}
+							/>
+						</div>
+					</TooltipTrigger>
+					<TooltipContent>{user.name || user.username}</TooltipContent>
+				</Tooltip>
+			</TableCell>
+			<TableCell className="text-right tabular-nums">
+				{formatCostMicros(user.total_cost_micros)}
+			</TableCell>
+			<TableCell className="text-right tabular-nums">
+				{user.message_count.toLocaleString()}
+			</TableCell>
+			<TableCell className="text-right tabular-nums">
+				{user.chat_count.toLocaleString()}
+			</TableCell>
+			<TableCell className="text-right tabular-nums">
+				{formatTokenCount(user.total_input_tokens)}
+			</TableCell>
+			<TableCell className="text-right tabular-nums">
+				{formatTokenCount(user.total_output_tokens)}
+			</TableCell>
+			<TableCell className="text-right tabular-nums">
+				{formatTokenCount(user.total_cache_read_tokens)}
+			</TableCell>
+			<TableCell className="text-right tabular-nums">
+				{formatTokenCount(user.total_cache_creation_tokens)}
+			</TableCell>
+			<TableCell className="w-1" onClick={(event) => event.stopPropagation()}>
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild>
+						<Button
+							type="button"
+							size="icon"
+							variant="subtle"
+							aria-label={`Open spend actions for ${user.name || user.username}`}
+						>
+							<EllipsisVerticalIcon aria-hidden="true" className="size-4" />
+						</Button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent align="end">
+						<DropdownMenuItem onClick={() => onEditBudget(user)}>
+							Update budget
+						</DropdownMenuItem>
+						<DropdownMenuItem onClick={() => onSelect(user)}>
+							View spend details
+						</DropdownMenuItem>
+					</DropdownMenuContent>
+				</DropdownMenu>
+			</TableCell>
+		</TableRow>
+	);
+};


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

## Summary

- Split the AI Spend page into smaller focused components.
- Extract user override and group limit tables and dialogs from their section coordinators.
- Extract the Usage tab from `SpendPageView`.

## Stack

Base: #26800

## Validation

- `pnpm --dir site exec biome check --error-on-warnings src/pages/AISettingsPage/SpendPage --no-errors-on-unmatched`
- `pnpm --dir site run lint:types`
- `pnpm --dir site exec vitest --project=storybook --run src/pages/AISettingsPage/SpendPage/components/LimitsTab/GroupLimitsSection.stories.tsx src/pages/AISettingsPage/SpendPage/components/LimitsTab/UserOverridesSection.stories.tsx src/pages/AISettingsPage/SpendPage/SpendPageView.stories.tsx --testTimeout=30000`

