### PR TITLE
fix(site): use large avatar on provider table

### DIFF
--- a/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderRow.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderRow.tsx
@@ -28,7 +28,10 @@ export const ProviderRow: React.FC<ProviderRowProps> = ({
 				<AvatarData
 					title={displayName}
 					avatar={
-						<Avatar className="flex shrink-0 items-center justify-center">
+						<Avatar
+							size="lg"
+							className="flex shrink-0 items-center justify-center"
+						>
 							<ProviderIcon provider={getProviderDisplayType(provider)} />
 						</Avatar>
 					}


### PR DESCRIPTION
The provider icons on the AI Settings providers table were rendered at the default medium avatar size, making them noticeably smaller than the provider icons on the adjacent models table.

The models table (`ModelRow`) passes `size="lg"` to `Avatar`, while the providers table (`ProviderRow`) omitted the size prop and fell back to the `md` default. Add `size="lg"` to the `ProviderRow` avatar so both tables match.

> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood