### PR TITLE
feat(site/src/pages/TemplateBuilder): deep-link base template via query param

### DIFF
--- a/site/src/pages/TemplateBuilder/BaseInfraSelectStep.tsx
+++ b/site/src/pages/TemplateBuilder/BaseInfraSelectStep.tsx
@@ -1,7 +1,6 @@
 import type { FC } from "react";
 import { useQuery } from "react-query";
 import { templateBuilderBases } from "#/api/queries/templateBuilder";
-import type { TemplateBuilderBase } from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Loader } from "#/components/Loader/Loader";
 import {
@@ -9,23 +8,11 @@ import {
 	TemplateBuilderTitle,
 } from "#/pages/TemplateBuilder/TemplateBuilderHeader";
 import { TemplateCard } from "./TemplateCard";
-import type { SelectedBaseMeta } from "./wizardState";
+import { type SelectedBaseMeta, toSelectedBaseMeta } from "./wizardState";
 
 interface BaseInfraSelectStepProps {
 	selectedBaseId: string | null;
 	onSelectBase: (base: SelectedBaseMeta) => void;
-}
-
-function toSelectedBaseMeta(base: TemplateBuilderBase): SelectedBaseMeta {
-	return {
-		id: base.id,
-		name: base.name,
-		iconUrl: base.icon,
-		os: base.os,
-		hasParameters:
-			base.variables.length > 0 && base.variables.some((v) => !v.sensitive),
-		hasPrerequisites: Boolean(base.prerequisites?.length),
-	};
 }
 
 function detailsUrl(baseId: string): string {

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPage.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPage.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
 import { useMutation, useQuery } from "react-query";
-import { Navigate, useNavigate } from "react-router";
+import { Navigate, useNavigate, useSearchParams } from "react-router";
 import { deploymentConfig } from "#/api/queries/deployment";
 import {
 	createTemplateFromBuilder,
@@ -12,12 +12,13 @@ import { linkToTemplate, useLinks } from "#/modules/navigation";
 import { pageTitle } from "#/utils/page";
 import { TemplateBuilderPageView } from "./TemplateBuilderPageView";
 import type { TemplateBuilderWizardState } from "./wizardState";
-import { toCreateTemplateRequest } from "./wizardState";
+import { toCreateTemplateRequest, toSelectedBaseMeta } from "./wizardState";
 
 const TemplateBuilderPage: FC = () => {
 	const navigate = useNavigate();
 	const getLink = useLinks();
 	const { permissions } = useAuthenticated();
+	const [searchParams] = useSearchParams();
 	const { data, error, isLoading } = useQuery(deploymentConfig());
 	const createMutation = useMutation(createTemplateFromBuilder());
 
@@ -28,7 +29,11 @@ const TemplateBuilderPage: FC = () => {
 		enabled: !builderDisabled && !isLoading && permissions.createTemplates,
 	});
 
-	if (isLoading) {
+	const baseParam = searchParams.get("base");
+
+	// Wait for bases to load when a base query param is present so we can
+	// resolve it before the wizard mounts and initializes its state.
+	if (isLoading || (baseParam && basesQuery.isLoading)) {
 		return <Loader />;
 	}
 
@@ -53,12 +58,20 @@ const TemplateBuilderPage: FC = () => {
 		});
 	};
 
+	// Resolve the preselected base from the query param, if present.
+	const preselectedBase = baseParam
+		? basesQuery.data?.bases?.find((b) => b.id === baseParam)
+		: undefined;
+
 	return (
 		<>
 			<title>{pageTitle("Create Template")}</title>
 			<TemplateBuilderPageView
 				error={error}
 				basesData={basesQuery.data}
+				preselectedBase={
+					preselectedBase ? toSelectedBaseMeta(preselectedBase) : undefined
+				}
 				onCreateTemplate={handleCreate}
 				createError={createMutation.error}
 				isCreating={createMutation.isPending}

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
@@ -37,6 +37,7 @@ import {
 import { TemplateCustomizationsStep } from "./TemplateCustomizationsStep";
 import {
 	initialWizardState,
+	type SelectedBaseMeta,
 	type TemplateBuilderWizardState,
 	type WizardAction,
 	wizardReducer,
@@ -45,6 +46,7 @@ import {
 interface TemplateBuilderPageViewProps {
 	error: unknown;
 	basesData: TemplateBuilderBasesResponse | undefined;
+	preselectedBase?: SelectedBaseMeta;
 	onCreateTemplate: (state: TemplateBuilderWizardState) => void;
 	createError: Error | null;
 	isCreating: boolean;
@@ -53,12 +55,26 @@ interface TemplateBuilderPageViewProps {
 export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 	error,
 	basesData,
+	preselectedBase,
 	onCreateTemplate,
 	createError,
 	isCreating,
 }) => {
-	const [state, dispatch] = useReducer(wizardReducer, initialWizardState);
-	const [stepIndex, setStepIndex] = useState(0);
+	const wizardInitialState = preselectedBase
+		? {
+				...initialWizardState,
+				baseTemplateId: preselectedBase.id,
+				selectedBase: preselectedBase,
+			}
+		: initialWizardState;
+	const [state, dispatch] = useReducer(wizardReducer, wizardInitialState);
+	const [stepIndex, setStepIndex] = useState(() => {
+		if (!preselectedBase) {
+			return 0;
+		}
+		const next = findNextVisibleIndex(0, state);
+		return next !== -1 ? next : 0;
+	});
 	const modulesQuery = useQuery(templateBuilderModules(state.selectedBase?.id));
 
 	const moduleVarMap = Object.fromEntries(

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
@@ -60,14 +60,14 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 	createError,
 	isCreating,
 }) => {
-	const wizardInitialState = preselectedBase
+	const resolvedInitialState = preselectedBase
 		? {
 				...initialWizardState,
 				baseTemplateId: preselectedBase.id,
 				selectedBase: preselectedBase,
 			}
 		: initialWizardState;
-	const [state, dispatch] = useReducer(wizardReducer, wizardInitialState);
+	const [state, dispatch] = useReducer(wizardReducer, resolvedInitialState);
 	const [stepIndex, setStepIndex] = useState(() => {
 		if (!preselectedBase) {
 			return 0;

--- a/site/src/pages/TemplateBuilder/wizardState.ts
+++ b/site/src/pages/TemplateBuilder/wizardState.ts
@@ -1,4 +1,5 @@
 import type {
+	TemplateBuilderBase,
 	TemplateBuilderComposeModule,
 	TemplateBuilderComposeRequest,
 	TemplateBuilderCreateTemplateRequest,
@@ -17,6 +18,23 @@ export type SelectedBaseMeta = {
 	hasParameters: boolean;
 	hasPrerequisites: boolean;
 };
+
+/**
+ * Maps an API TemplateBuilderBase to the UI-only SelectedBaseMeta.
+ */
+export function toSelectedBaseMeta(
+	base: TemplateBuilderBase,
+): SelectedBaseMeta {
+	return {
+		id: base.id,
+		name: base.name,
+		iconUrl: base.icon,
+		os: base.os,
+		hasParameters:
+			base.variables.length > 0 && base.variables.some((v) => !v.sensitive),
+		hasPrerequisites: Boolean(base.prerequisites?.length),
+	};
+}
 
 /**
  * UI-only metadata for a selected module.


### PR DESCRIPTION
Adds support for a `?base=<id>` query parameter on `/templates/new/builder` that preselects a base template and advances the wizard to the next available step (base parameters if applicable, otherwise module select).

## Changes

- **`wizardState.ts`**: Move `toSelectedBaseMeta` here as a shared data mapper between the API `TemplateBuilderBase` type and the UI `SelectedBaseMeta` type.
- **`BaseInfraSelectStep.tsx`**: Import `toSelectedBaseMeta` from `wizardState` instead of defining it locally.
- **`TemplateBuilderPage.tsx`**: Read the `?base` search param. When present, wait for bases data to load, resolve the matching base, and pass it as a `preselectedBase` prop.
- **`TemplateBuilderPageView.tsx`**: Accept `preselectedBase` prop. Use it to initialize wizard reducer state and starting step index at mount time (no effects or refs needed).

## Example

`/templates/new/builder?base=docker` opens the wizard with Docker preselected, landing on base parameters or module select depending on the base.

> Generated by Coder Agents