### PR TITLE
docs: fix broken links in weekly-docs link check

### DIFF
--- a/.github/.linkspector.yml
+++ b/.github/.linkspector.yml
@@ -34,5 +34,9 @@ ignorePatterns:
   - pattern: "platform.openai.com"
   - pattern: "api.openai.com"
   - pattern: "openai.com"
+  # merriam-webster.com returns 403 from GitHub runner IPs
+  - pattern: "merriam-webster.com"
+  # Intentional directory link resolved to GitHub README by docs site
+  - pattern: "examples/templates/gcp-linux"
 aliveStatusCodes:
   - 200

--- a/.github/.linkspector.yml
+++ b/.github/.linkspector.yml
@@ -36,7 +36,5 @@ ignorePatterns:
   - pattern: "openai.com"
   # merriam-webster.com returns 403 from GitHub runner IPs
   - pattern: "merriam-webster.com"
-  # Intentional directory link resolved to GitHub README by docs site
-  - pattern: "examples/templates/gcp-linux"
 aliveStatusCodes:
   - 200

--- a/docs/install/cloud/compute-engine.md
+++ b/docs/install/cloud/compute-engine.md
@@ -65,12 +65,12 @@ sudo systemctl restart coder # restart Coder
 
 Instead of running containers on the Coder instance, you can offer developers
 full VM instances with the
-[gcp-linux](../../../examples/templates/gcp-linux)
+[gcp-linux](../../../examples/templates/gcp-linux/README.md)
 template.
 
 Before you can use this template, you must authorize Coder to create VM
 instances in your GCP project. Follow the instructions in the
-[gcp-linux template README](../../../examples/templates/gcp-linux#authentication)
+[gcp-linux template README](../../../examples/templates/gcp-linux/README.md#authentication)
 to set up authentication.
 
 ### Next Steps

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -118,7 +118,7 @@ coder:
 ```
 
 You can view our
-[Helm README](../../helm/coder#readme) for
+[Helm README](../../helm/coder) for
 details on the values that are available, or you can view the
 [values.yaml](../../helm/coder/values.yaml)
 file directly.

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -118,7 +118,7 @@ coder:
 ```
 
 You can view our
-[Helm README](../../helm/coder) for
+[Helm README](../../helm/coder/README.md) for
 details on the values that are available, or you can view the
 [values.yaml](../../helm/coder/values.yaml)
 file directly.

--- a/docs/install/rancher.md
+++ b/docs/install/rancher.md
@@ -127,7 +127,7 @@ kubectl create secret generic coder-db-url -n coder \
      #    - my-tls-secret-name
    ```
 
-   For available configuration options, refer to the [Helm chart documentation](../../helm#readme)
+   For available configuration options, refer to the [Helm chart documentation](../../helm)
    or [values.yaml file](../../helm/coder/values.yaml).
 
    </details>


### PR DESCRIPTION
Fix four broken links that caused the weekly-docs link-check CI job to fail.

**Changes:**

- `docs/install/rancher.md`: Remove `#readme` anchor from `../../helm#readme` — linkspector splits on `#`, finds a directory, and errors with EISDIR.
- `docs/install/kubernetes.md`: Same fix for `../../helm/coder#readme`.
- `docs/install/cloud/compute-engine.md`: Point both `gcp-linux` links to `README.md` explicitly (`../../../examples/templates/gcp-linux/README.md` and `../../../examples/templates/gcp-linux/README.md#authentication`) so linkspector can resolve the file and anchor.
- `.github/.linkspector.yml`: Add `merriam-webster.com` to `ignorePatterns` (returns 403 from GitHub runner IPs).

<details>
<summary>Linear issue and CI context</summary>

**Linear issue:** https://linear.app/codercom/issue/DOCS-494/fix-broken-links-in-weekly-docs-link-check

**Failing CI run:** https://github.com/coder/coder/actions/runs/28366176335/job/84032582533

The workflow is `.github/workflows/weekly-docs.yaml`, job `check-docs`, step `Check Markdown links` (umbrelladocs/action-linkspector).

Root causes confirmed per investigation:
- `#readme` anchors on directory paths trigger EISDIR in linkspector's local resolver.
- The `gcp-linux` directory links needed explicit `README.md` targets; linkspector cannot resolve bare directory references.
- `merriam-webster.com` blocks GitHub runner IPs with 403.

`ignorePatterns` is reserved for external links only, not internal or GitHub file links.

</details>

---
*Generated by Coder Agents on behalf of @nickvigilante*
