### PR TITLE
docs: refresh the docs homepage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,47 +2,33 @@
 
 <!-- Warning for docs contributors: The first route in manifest.json must be titled "About" for the static landing page to work correctly. -->
 
-Coder is a self-hosted platform for running AI coding agents and cloud
-development environments on infrastructure you control. It works with any
-cloud, IDE, OS, Git provider, and IDP.
+Coder is a self-hosted platform for running AI coding agents and cloud development environments on infrastructure you control.
+It works with any cloud, IDE, OS, Git provider, and IDP.
 
 ![Coder platform showing templates and a running workspace](./images/hero-image.png)
 
 ## Coder Workspaces
 
-[Coder Workspaces](./user-guides/index.md) are cloud development environments
-defined with Terraform, connected through a secure Wireguard tunnel, and
-automatically shut down when not in use. Agents and developers share the same
-workspace infrastructure.
+[Coder Workspaces](./user-guides/index.md) are cloud development environments defined with Terraform, connected through a secure WireGuard tunnel, and automatically shut down when not in use.
+Agents and developers share the same workspace infrastructure.
 
-- **Defined in Terraform**: Templates describe the infrastructure for each
-  workspace, from EC2 VMs and Kubernetes Pods to Docker containers.
-- **Any architecture and OS**: Support ARM and x86-64 across Windows, Linux,
-  and macOS from a single deployment.
-- **Managed by admins**: Platform teams create and maintain templates that
-  enforce approved images, resource limits, and security policies.
-- **Accessed from any IDE**: Connect through VS Code, JetBrains, Cursor,
-  a web terminal, remote desktop, or SSH.
-- **Automatic shutdown**: Idle workspaces stop automatically to reduce
-  cloud spend, and restart in seconds when needed.
+- **Defined in Terraform**: Templates describe the infrastructure for each workspace, from EC2 VMs and Kubernetes Pods to Docker containers.
+- **Any architecture and OS**: Support ARM and x86-64 across Windows, Linux, and macOS from a single deployment.
+- **Managed by admins**: Platform teams create and maintain templates that enforce approved images, resource limits, and security policies.
+- **Accessed from any IDE**: Connect through VS Code, JetBrains, Cursor, a web terminal, remote desktop, or SSH.
+- **Automatic shutdown**: Idle workspaces stop automatically to reduce cloud spend, and restart in seconds when needed.
 
 ## Coder Agents
 
-[Coder Agents](./ai-coder/agents/index.md) is a native AI coding agent built
-into Coder. The agent loop runs in the Coder control plane on your
-infrastructure, not in the workspace and not in a vendor's cloud. Developers
-interact with agents through the web UI or the REST API for programmatic and
-CI-driven workflows.
+[Coder Agents](./ai-coder/index.md) is a native AI coding agent built into Coder.
+The agent loop runs in the Coder control plane on your infrastructure, not in the workspace and not in a vendor's cloud.
+Developers interact with agents through the web UI or the REST API for programmatic and CI-driven workflows.
 
-- **Self-hosted agent loop**: The control plane handles planning, model
-  calls, and tool dispatch. Workspaces have zero AI awareness.
+- **Self-hosted agent loop**: The control plane handles planning, model calls, and tool dispatch. Workspaces have zero AI awareness.
 - **No API keys in workspaces**: LLM credentials stay in the control plane.
-- **Any model**: Anthropic, OpenAI, Google, Bedrock, or self-hosted
-  endpoints. Switching is a configuration change.
-- **Governance and cost controls**: Centralized model approval, per-user
-  spend limits, and audit logging.
-- **Open source and inspectable**: The full platform is available to audit
-  and extend.
+- **Any model**: Anthropic, OpenAI, Google, Bedrock, or self-hosted endpoints. Switching is a configuration change.
+- **Governance and cost controls**: Centralized model approval, per-user spend limits, and audit logging.
+- **Open source and inspectable**: The full platform is available to audit and extend.
 
 ![Coder Agents chat interface with git diff sidebar](./images/agents-hero-image.png)
 
@@ -50,138 +36,67 @@ CI-driven workflows.
 
 ![IDE icons](./images/ide-icons.svg)
 
-You can use:
+Coder workspaces support desktop IDEs, browser-based editors, and terminal access.
 
-- Any Web IDE, such as
+### Desktop IDEs
 
-  - [code-server](https://github.com/coder/code-server)
-  - [JetBrains Projector](https://github.com/JetBrains/projector-server)
-  - [Jupyter](https://jupyter.org/)
-  - And others
+Connect your local IDE to a remote workspace:
 
-- Your existing remote development environment:
+- [VS Code](./user-guides/workspace-access/vscode.md)
+- [Cursor](./user-guides/workspace-access/cursor.md)
+- [Windsurf](./user-guides/workspace-access/windsurf.md)
+- [Zed](./user-guides/workspace-access/zed.md)
+- [JetBrains Gateway](./user-guides/workspace-access/jetbrains/gateway.md)
 
-  - [JetBrains Gateway](https://www.jetbrains.com/remote-development/gateway/)
-  - [VS Code Remote](https://code.visualstudio.com/docs/remote/ssh-tutorial)
-  - [Emacs](./user-guides/workspace-access/emacs-tramp.md)
+### Browser-based IDEs
 
-- A file sync such as [Mutagen](https://mutagen.io/)
+Run a full editor in the browser without a local IDE installation:
 
-## Why remote development
+- [code-server](./user-guides/workspace-access/code-server.md) (VS Code in the browser)
+- [Jupyter](./user-guides/workspace-access/port-forwarding.md) via port forwarding
 
-Provisioning consistent development environments for a large engineering team
-is difficult. Each developer has preferences for operating systems, editors,
-and toolchains, and ensuring a reliable build environment across all of them
-is a maintenance burden. A missed step during onboarding or an unsupported
-local configuration can cost hours of debugging.
+### Terminal and other access
 
-Remote development solves this by moving the environment off the developer's
-machine and into managed infrastructure. The developer's laptop becomes a
-portal into the actual compute where work happens. If a device is lost or
-replaced, access is simply revoked; no source code or credentials are stored
-locally.
-
-This approach provides:
-
-- **Speed**: Server-grade hardware accelerates builds, tests, and large
-  workloads without requiring expensive local machines.
-- **Consistency**: Infrastructure tools such as Terraform, nix, Docker, and
-  Dev Containers produce identical environments for every developer.
-- **Security**: Source code stays on private servers. Users and groups are
-  managed through [SSO](./admin/users/oidc-auth/index.md) and
-  [RBAC](./admin/users/groups-roles.md#roles).
-- **Compatibility**: Workspaces share infrastructure configurations with
-  staging and production, reducing configuration drift.
-- **Accessibility**: Browser-based IDEs and remote IDE extensions let
-  developers work from any device, including lightweight laptops,
-  Chromebooks, and tablets.
-
-Read more on the [Coder blog](https://coder.com/blog), the
-[Slack engineering blog](https://slack.engineering/development-environments-at-slack),
-or from [Alex Ellis at OpenFaaS](https://blog.alexellis.io/the-internet-is-my-computer/).
-
-## Why Coder
-
-The key difference between Coder and other platforms is that the entire system,
-agent loop, control plane, model routing, and workspace provisioning, runs on
-infrastructure you control.
-
-For agents, this means platform teams can:
-
-- Run the entire agent loop on their infrastructure, with no SaaS
-  dependency for orchestration.
-- Define MCP servers, skills, and system prompts centrally so every agent
-  session starts with the same tools, policies, and context.
-- Keep LLM credentials out of workspaces entirely.
-- Tie every agent action to an authenticated user identity.
-- Support air-gapped and restricted-network deployments with self-hosted models.
-
-For workspaces, this means admins can:
-
-- Support any architecture (ARM, x86-64) and operating system
-  (Windows, Linux, macOS).
-- Modify pod/container specs, such as adding disks, managing network policies, or
-  setting/updating environment variables.
-- Use VM or dedicated workspaces, developing with Kernel features (no container
-  knowledge required).
-- Enable persistent workspaces, which are like local machines, but faster and
-  hosted by a cloud service.
-
-## Pricing
-
-Coder is free and open source under the
-[GNU Affero General Public License v3.0](../LICENSE).
-All developer productivity features are included in the open source version.
-A [Premium license](https://coder.com/pricing#compare-plans) is available for
-enhanced support and custom deployments.
+- [Coder Desktop](./user-guides/desktop/index.md) (macOS and Windows)
+- [Web terminal](./user-guides/workspace-access/web-terminal.md)
+- [SSH](./user-guides/workspace-access/index.md#ssh)
+- [Emacs TRAMP](./user-guides/workspace-access/emacs-tramp.md)
 
 ## How Coder works
 
-Coder workspaces are represented with Terraform, but you do not need to know
-Terraform to get started. The
-[Coder Registry](https://registry.coder.com/templates) provides production-ready
-templates for AWS EC2, Azure, Google Cloud, Kubernetes, and other providers.
+Coder workspaces are represented with Terraform, but you do not need to know Terraform to get started.
+The [Coder Registry](https://registry.coder.com/templates) provides production-ready templates for AWS EC2, Azure, Google Cloud, Kubernetes, and other providers.
 
-![Providers and compute environments](./images/providers-compute.png)_Providers and compute environments_
+![Providers and compute environments](./images/providers-compute.png)
 
-Workspaces can include more than just compute. Terraform can add storage
-buckets, secrets, sidecars, and
-[other resources](https://developer.hashicorp.com/terraform/tutorials).
+<small>Providers and compute environments</small>
 
-See the [templates documentation](./admin/templates/index.md) for details.
+Workspaces can include more than just compute.
+Terraform can add storage buckets, secrets, sidecars, and [other resources](https://developer.hashicorp.com/terraform/tutorials).
 
-## What Coder is not
+Refer to the [templates documentation](./admin/templates/index.md) for details.
 
-- Coder is not an infrastructure as code (IaC) platform.
+## Pricing
 
-  - Terraform is the first IaC _provisioner_ in Coder, allowing Coder admins to
-    define Terraform resources as Coder workspaces.
+Coder is free and open source under the [GNU Affero General Public License v3.0](../LICENSE).
+All developer productivity features are included in the open source version.
+A [Premium license](https://coder.com/pricing#compare-plans) is available for enhanced support and custom deployments.
 
-- Coder is not a DevOps/CI platform.
+## Get started
 
-  - Coder workspaces can be configured to follow best practices for
-    cloud-service-based workloads, but Coder is not responsible for how you
-    define or deploy the software you write.
+**New to Coder:**
 
-- Coder is not an online IDE.
+- [Quickstart](./tutorials/quickstart.md)
 
-  - Coder supports common editors, such as VS Code, vim, and JetBrains,
-    all over HTTPS or SSH.
+**Platform administrators:**
 
-- Coder is not a collaboration platform.
+- [Install Coder](./install/index.md)
+- [Manage templates](./admin/templates/index.md)
+- [Manage users](./admin/users/index.md)
+- [Set up Coder Agents](./ai-coder/index.md)
 
-  - You can use Git with your favorite Git platform and dedicated IDE
-    extensions for pull requests, code reviews, and pair programming.
+**Developers:**
 
-- Coder is not a SaaS/fully-managed offering.
-  - Coder is a [self-hosted](<https://en.wikipedia.org/wiki/Self-hosting_(web_services)>)
-    solution.
-    You must host Coder in a private data center or on a cloud service, such as
-    AWS, Azure, or GCP.
-
-## Learn more
-
-- [Coder Agents](./ai-coder/agents/index.md)
-- [Templates](./admin/templates/index.md)
-- [Installing Coder](./install/index.md)
-- [Quickstart tutorial](./tutorials/quickstart.md)
+- [Access your workspace](./user-guides/workspace-access/index.md)
+- [Use Coder Agents](./ai-coder/index.md)
+- [Dev Containers](./user-guides/devcontainers/index.md)


### PR DESCRIPTION
Refresh the docs homepage (`docs/README.md`) to fix broken links, update IDE coverage, restructure navigation, and apply current prose style.

Closes https://linear.app/codercom/issue/DOCS-495

**Changes:**

- Fix WireGuard capitalization (was: Wireguard)
- Update Coder Agents link from `ai-coder/agents/index.md` to section overview `ai-coder/index.md`
- Remove JetBrains Projector (EOL December 2023)
- Remove Mutagen standalone reference (now integrated into Coder Desktop)
- Add missing IDEs with dedicated docs pages: Cursor, Windsurf, Zed
- Restructure IDE section into three groups: Desktop, Browser-based, Terminal and other access
- Move Coder Desktop to top of Terminal section
- Fix providers-compute image caption to use `<small>` tags (was inline italic)
- Remove "Why remote development," "Why Coder," and "What Coder is not" sections
- Replace generic "Learn more" with audience-organized "Get started" section
- Apply one-sentence-per-line style throughout prose

<details>
<summary>Audit findings and decisions</summary>

### Broken/outdated content removed

- **JetBrains Projector**: EOL'd December 2023, still listed as active Web IDE. JetBrains Gateway already covered.
- **Mutagen**: Referenced as standalone file sync tool; functionality now lives in Coder Desktop.
- **Coder Agents link**: Pointed to sub-page `agents/index.md` rather than section overview `ai-coder/index.md`.
- **"Why remote development"**: Marketing content that belongs in `about/why-coder.md`, not on the homepage.
- **"What Coder is not"**: Defensive framing not appropriate for a homepage.
- **"Learn more" section**: Only 4 generic links, no audience organization.

### New IDEs added

Cursor, Windsurf, and Zed each have dedicated docs pages under `user-guides/workspace-access/` but were absent from the homepage.

### All relative links verified against the filesystem before writing.

</details>

> Generated by [Coder Agents](https://coder.com/docs/ai-coder)
