### PR TITLE
fix: regenerate listenerset golden files

### DIFF
--- a/helm/coder/tests/testdata/listenerset.golden
+++ b/helm/coder/tests/testdata/listenerset.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/listenerset_coder.golden
+++ b/helm/coder/tests/testdata/listenerset_coder.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/listenerset_redirect.golden
+++ b/helm/coder/tests/testdata/listenerset_redirect.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}

--- a/helm/coder/tests/testdata/listenerset_redirect_coder.golden
+++ b/helm/coder/tests/testdata/listenerset_redirect_coder.golden
@@ -164,6 +164,10 @@ spec:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
+        - name: CODER_CLUSTER_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}


### PR DESCRIPTION
The golden files from #24993 were generated against a stale fork that predated the `CODER_CLUSTER_HOST` env var addition. This regenerates them against current main.

All 4 files just need the missing env var block:
```yaml
- name: CODER_CLUSTER_HOST
  valueFrom:
    fieldRef:
      fieldPath: status.podIP
```

Fixes the `gen` / `TestRenderChart` failures tracked in https://github.com/coder/internal/issues/1611#issuecomment-4835998513.

---
*PR created by [Coder Agents](https://coder.com/docs/ai-coder) on behalf of @bpmct*