### PR TITLE
style(site/src/pages/AgentsPage): restyle model selector trigger as inline pill

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.stories.tsx
@@ -95,6 +95,8 @@ export const CustomPlaceholder: Story = {
 	},
 };
 
+// The default trigger is a borderless pill; a callsite can override
+// that via `className` to render a full bordered form field.
 export const InputBorderTreatment: Story = {
 	args: {
 		value: "openai/gpt-4o-mini",

--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
@@ -149,11 +149,14 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
 					disabled={isDisabled}
 					onTouchStart={onTriggerTouchStart}
 					className={cn(
-						// Matches the previous SelectTrigger base so this PR is
-						// only about the dropdown panel, not the trigger.
-						"h-8 min-w-0 shrink md:shrink-0 md:w-auto gap-0.5 md:gap-1.5 border-0 bg-transparent px-1 text-xs shadow-none transition-colors hover:bg-transparent hover:text-content-primary focus:ring-0 [&>span]:truncate [&>svg]:shrink-0 [&>svg]:transition-colors",
+						"inline-flex h-7 min-w-0 shrink items-center gap-1 rounded-md px-2 text-xs font-medium md:shrink-0 md:w-auto",
+						"border-0 bg-transparent text-content-primary",
+						"transition-colors hover:bg-surface-secondary",
+						"data-[state=open]:bg-surface-secondary",
+						"focus:outline-none focus:ring-0",
 						"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link",
-						"disabled:cursor-not-allowed disabled:opacity-50",
+						"disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent",
+						"[&>span]:truncate",
 						className,
 					)}
 				>


### PR DESCRIPTION
Restyles the model selector trigger as a subtle inline pill (`h-7`, `rounded-md`, `px-2`, hover background) that fits next to the existing chat-footer controls.

Mouse-focus ring is suppressed; keyboard-focus ring is preserved. The `className` prop still wins via `tailwind-merge`, so `SubagentModelOverrideSettings` keeps its bordered form-field treatment and `InputBorderTreatment` continues to pass.

Stacked on #26837.

---

<sub>This pull request was prepared by the Coder Agents bot at @tracyjohnsonux's direction.</sub>