### PR TITLE
feat(scaletest): llm-mock tool calls and paced streaming

### DIFF
--- a/cli/exp_scaletest_llmmock.go
+++ b/cli/exp_scaletest_llmmock.go
@@ -38,6 +38,13 @@ func (*RootCmd) scaletestLLMMock() *serpent.Command {
 			ctx, stop := signal.NotifyContext(inv.Context(), StopSignals...)
 			defer stop()
 
+			if (minStreamDuration > 0) != (maxStreamDuration > 0) {
+				return xerrors.New("--min-stream-duration and --max-stream-duration must be set together")
+			}
+			if minStreamDuration > maxStreamDuration {
+				return xerrors.New("--min-stream-duration must not exceed --max-stream-duration")
+			}
+
 			logger := slog.Make(sloghuman.Sink(inv.Stderr)).Leveled(slog.LevelInfo)
 
 			if pprofEnable {

--- a/cli/exp_scaletest_llmmock.go
+++ b/cli/exp_scaletest_llmmock.go
@@ -19,7 +19,12 @@ func (*RootCmd) scaletestLLMMock() *serpent.Command {
 	var (
 		address             string
 		artificialLatency   time.Duration
+		minStreamDuration   time.Duration
+		maxStreamDuration   time.Duration
 		responsePayloadSize int64
+		minToolCallsPerTurn int64
+		maxToolCallsPerTurn int64
+		toolCallCommand     string
 
 		pprofEnable  bool
 		pprofAddress string
@@ -34,6 +39,10 @@ func (*RootCmd) scaletestLLMMock() *serpent.Command {
 			ctx, stop := signal.NotifyContext(inv.Context(), StopSignals...)
 			defer stop()
 
+			if !userSetOption(inv, "min-tool-calls-per-turn") {
+				minToolCallsPerTurn = maxToolCallsPerTurn
+			}
+
 			logger := slog.Make(sloghuman.Sink(inv.Stderr)).Leveled(slog.LevelInfo)
 
 			if pprofEnable {
@@ -46,7 +55,12 @@ func (*RootCmd) scaletestLLMMock() *serpent.Command {
 				Address:             address,
 				Logger:              logger,
 				ArtificialLatency:   artificialLatency,
+				MinStreamDuration:   minStreamDuration,
+				MaxStreamDuration:   maxStreamDuration,
 				ResponsePayloadSize: int(responsePayloadSize),
+				MinToolCallsPerTurn: int(minToolCallsPerTurn),
+				MaxToolCallsPerTurn: int(maxToolCallsPerTurn),
+				ToolCallCommand:     toolCallCommand,
 				PprofEnable:         pprofEnable,
 				PprofAddress:        pprofAddress,
 				TraceEnable:         traceEnable,
@@ -88,11 +102,46 @@ func (*RootCmd) scaletestLLMMock() *serpent.Command {
 			Value:       serpent.DurationOf(&artificialLatency),
 		},
 		{
+			Flag:        "min-stream-duration",
+			Env:         "CODER_SCALETEST_LLM_MOCK_MIN_STREAM_DURATION",
+			Default:     "0s",
+			Description: "Minimum duration to stream a text response over (e.g., 5s, 10s). Set with max-stream-duration to pace response chunks.",
+			Value:       serpent.DurationOf(&minStreamDuration),
+		},
+		{
+			Flag:        "max-stream-duration",
+			Env:         "CODER_SCALETEST_LLM_MOCK_MAX_STREAM_DURATION",
+			Default:     "0s",
+			Description: "Maximum duration to stream a text response over (e.g., 10s, 30s). Set with min-stream-duration to pace response chunks.",
+			Value:       serpent.DurationOf(&maxStreamDuration),
+		},
+		{
 			Flag:        "response-payload-size",
 			Env:         "CODER_SCALETEST_LLM_MOCK_RESPONSE_PAYLOAD_SIZE",
 			Default:     "0",
 			Description: "Size in bytes of the response payload. If 0, uses default context-aware responses.",
 			Value:       serpent.Int64Of(&responsePayloadSize),
+		},
+		// No Default here because userSetOption must distinguish unset from explicit zero.
+		{
+			Flag:        "min-tool-calls-per-turn",
+			Env:         "CODER_SCALETEST_LLM_MOCK_MIN_TOOL_CALLS_PER_TURN",
+			Description: "Minimum `execute` tool calls to emit per user turn. Defaults to max-tool-calls-per-turn when unset. OpenAI Chat Completions only.",
+			Value:       serpent.Int64Of(&minToolCallsPerTurn),
+		},
+		{
+			Flag:        "max-tool-calls-per-turn",
+			Env:         "CODER_SCALETEST_LLM_MOCK_MAX_TOOL_CALLS_PER_TURN",
+			Default:     "0",
+			Description: "Maximum `execute` tool calls to emit per user turn. Set to 0 for text-only responses. OpenAI Chat Completions only.",
+			Value:       serpent.Int64Of(&maxToolCallsPerTurn),
+		},
+		{
+			Flag:        "tool-call-command",
+			Env:         "CODER_SCALETEST_LLM_MOCK_TOOL_CALL_COMMAND",
+			Default:     "echo scaletest",
+			Description: "Shell command sent in each mock `execute` tool call. OpenAI Chat Completions only.",
+			Value:       serpent.StringOf(&toolCallCommand),
 		},
 		{
 			Flag:        "pprof-enable",

--- a/cli/exp_scaletest_llmmock.go
+++ b/cli/exp_scaletest_llmmock.go
@@ -33,7 +33,7 @@ func (*RootCmd) scaletestLLMMock() *serpent.Command {
 	cmd := &serpent.Command{
 		Use:   "llm-mock",
 		Short: "Start a mock LLM API server for testing",
-		Long:  `Start a mock LLM API server that simulates OpenAI and Anthropic APIs. It can also simulate OpenAI Chat Completions tool calls.`,
+		Long:  `Start a mock LLM API server that simulates OpenAI and Anthropic APIs`,
 		Handler: func(inv *serpent.Invocation) error {
 			ctx, stop := signal.NotifyContext(inv.Context(), StopSignals...)
 			defer stop()
@@ -118,14 +118,14 @@ func (*RootCmd) scaletestLLMMock() *serpent.Command {
 			Flag:        "tool-calls-per-turn",
 			Env:         "CODER_SCALETEST_LLM_MOCK_TOOL_CALLS_PER_TURN",
 			Default:     "0",
-			Description: "Number of `execute` tool calls to emit per user turn. Set to 0 for text-only responses. OpenAI Chat Completions only.",
+			Description: "Number of execute tool calls to emit per user turn. Set to 0 for text-only responses. OpenAI Chat Completions only.",
 			Value:       serpent.Int64Of(&toolCallsPerTurn),
 		},
 		{
 			Flag:        "tool-call-command",
 			Env:         "CODER_SCALETEST_LLM_MOCK_TOOL_CALL_COMMAND",
-			Default:     llmmock.DefaultToolCallCommand,
-			Description: "Shell command sent in each mock `execute` tool call. OpenAI Chat Completions only.",
+			Default:     "echo scaletest",
+			Description: "Shell command sent in each mock execute tool call when tool calls are enabled. OpenAI Chat Completions only.",
 			Value:       serpent.StringOf(&toolCallCommand),
 		},
 		{

--- a/cli/exp_scaletest_llmmock.go
+++ b/cli/exp_scaletest_llmmock.go
@@ -22,8 +22,7 @@ func (*RootCmd) scaletestLLMMock() *serpent.Command {
 		minStreamDuration   time.Duration
 		maxStreamDuration   time.Duration
 		responsePayloadSize int64
-		minToolCallsPerTurn int64
-		maxToolCallsPerTurn int64
+		toolCallsPerTurn    int64
 		toolCallCommand     string
 
 		pprofEnable  bool
@@ -34,14 +33,10 @@ func (*RootCmd) scaletestLLMMock() *serpent.Command {
 	cmd := &serpent.Command{
 		Use:   "llm-mock",
 		Short: "Start a mock LLM API server for testing",
-		Long:  `Start a mock LLM API server that simulates OpenAI and Anthropic APIs`,
+		Long:  `Start a mock LLM API server that simulates OpenAI and Anthropic APIs. It can also simulate OpenAI Chat Completions tool calls.`,
 		Handler: func(inv *serpent.Invocation) error {
 			ctx, stop := signal.NotifyContext(inv.Context(), StopSignals...)
 			defer stop()
-
-			if !userSetOption(inv, "min-tool-calls-per-turn") {
-				minToolCallsPerTurn = maxToolCallsPerTurn
-			}
 
 			logger := slog.Make(sloghuman.Sink(inv.Stderr)).Leveled(slog.LevelInfo)
 
@@ -58,11 +53,8 @@ func (*RootCmd) scaletestLLMMock() *serpent.Command {
 				MinStreamDuration:   minStreamDuration,
 				MaxStreamDuration:   maxStreamDuration,
 				ResponsePayloadSize: int(responsePayloadSize),
-				MinToolCallsPerTurn: int(minToolCallsPerTurn),
-				MaxToolCallsPerTurn: int(maxToolCallsPerTurn),
+				ToolCallsPerTurn:    int(toolCallsPerTurn),
 				ToolCallCommand:     toolCallCommand,
-				PprofEnable:         pprofEnable,
-				PprofAddress:        pprofAddress,
 				TraceEnable:         traceEnable,
 			}
 			srv := new(llmmock.Server)
@@ -122,24 +114,17 @@ func (*RootCmd) scaletestLLMMock() *serpent.Command {
 			Description: "Size in bytes of the response payload. If 0, uses default context-aware responses.",
 			Value:       serpent.Int64Of(&responsePayloadSize),
 		},
-		// No Default here because userSetOption must distinguish unset from explicit zero.
 		{
-			Flag:        "min-tool-calls-per-turn",
-			Env:         "CODER_SCALETEST_LLM_MOCK_MIN_TOOL_CALLS_PER_TURN",
-			Description: "Minimum `execute` tool calls to emit per user turn. Defaults to max-tool-calls-per-turn when unset. OpenAI Chat Completions only.",
-			Value:       serpent.Int64Of(&minToolCallsPerTurn),
-		},
-		{
-			Flag:        "max-tool-calls-per-turn",
-			Env:         "CODER_SCALETEST_LLM_MOCK_MAX_TOOL_CALLS_PER_TURN",
+			Flag:        "tool-calls-per-turn",
+			Env:         "CODER_SCALETEST_LLM_MOCK_TOOL_CALLS_PER_TURN",
 			Default:     "0",
-			Description: "Maximum `execute` tool calls to emit per user turn. Set to 0 for text-only responses. OpenAI Chat Completions only.",
-			Value:       serpent.Int64Of(&maxToolCallsPerTurn),
+			Description: "Number of `execute` tool calls to emit per user turn. Set to 0 for text-only responses. OpenAI Chat Completions only.",
+			Value:       serpent.Int64Of(&toolCallsPerTurn),
 		},
 		{
 			Flag:        "tool-call-command",
 			Env:         "CODER_SCALETEST_LLM_MOCK_TOOL_CALL_COMMAND",
-			Default:     "echo scaletest",
+			Default:     llmmock.DefaultToolCallCommand,
 			Description: "Shell command sent in each mock `execute` tool call. OpenAI Chat Completions only.",
 			Value:       serpent.StringOf(&toolCallCommand),
 		},

--- a/scaletest/llmmock/openai_stream.go
+++ b/scaletest/llmmock/openai_stream.go
@@ -3,7 +3,6 @@ package llmmock
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"cdr.dev/slog/v3"
@@ -37,7 +36,6 @@ type openAIStreamChunk struct {
 }
 
 type openAIStreamWriter struct {
-	ctx      context.Context
 	logger   slog.Logger
 	w        http.ResponseWriter
 	flusher  http.Flusher
@@ -45,11 +43,6 @@ type openAIStreamWriter struct {
 }
 
 func (s *Server) newOpenAIStreamWriter(ctx context.Context, w http.ResponseWriter, resp openAIResponse) (openAIStreamWriter, bool) {
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-	w.WriteHeader(http.StatusOK)
-
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		s.logger.Error(ctx, "responseWriter does not support flushing",
@@ -58,8 +51,12 @@ func (s *Server) newOpenAIStreamWriter(ctx context.Context, w http.ResponseWrite
 		return openAIStreamWriter{}, false
 	}
 
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+
 	return openAIStreamWriter{
-		ctx:      ctx,
 		logger:   s.logger,
 		w:        w,
 		flusher:  flusher,
@@ -67,7 +64,7 @@ func (s *Server) newOpenAIStreamWriter(ctx context.Context, w http.ResponseWrite
 	}, true
 }
 
-func (sw openAIStreamWriter) writeDelta(delta openAIStreamDelta, finishReason *string) bool {
+func (sw openAIStreamWriter) writeDelta(ctx context.Context, delta openAIStreamDelta, finishReason *string) bool {
 	chunk := openAIStreamChunk{
 		ID:      sw.response.ID,
 		Object:  "chat.completion.chunk",
@@ -80,22 +77,24 @@ func (sw openAIStreamWriter) writeDelta(delta openAIStreamDelta, finishReason *s
 		}},
 	}
 	data, _ := json.Marshal(chunk)
-	return sw.writeData(string(data))
+	return sw.writeData(ctx, data)
 }
 
-func (sw openAIStreamWriter) writeDone() bool {
-	return sw.writeData("[DONE]")
+func (sw openAIStreamWriter) writeDone(ctx context.Context) bool {
+	return sw.writeData(ctx, []byte("[DONE]"))
 }
 
-func (sw openAIStreamWriter) writeData(data string) bool {
-	if _, err := fmt.Fprintf(sw.w, "data: %s\n\n", data); err != nil {
-		sw.logger.Error(sw.ctx, "failed to write OpenAI stream chunk",
-			slog.F("response_id", sw.response.ID),
-			slog.Error(err),
-			slog.F("error_type", "write_error"),
-			slog.F("likely_cause", "network_error"),
-		)
-		return false
+func (sw openAIStreamWriter) writeData(ctx context.Context, data []byte) bool {
+	for _, part := range [][]byte{[]byte("data: "), data, []byte("\n\n")} {
+		if _, err := sw.w.Write(part); err != nil {
+			sw.logger.Error(ctx, "failed to write OpenAI stream chunk",
+				slog.F("response_id", sw.response.ID),
+				slog.Error(err),
+				slog.F("error_type", "write_error"),
+				slog.F("likely_cause", "network_error"),
+			)
+			return false
+		}
 	}
 	sw.flusher.Flush()
 	return true
@@ -109,7 +108,7 @@ func (s *Server) sendOpenAIStream(ctx context.Context, w http.ResponseWriter, re
 
 	choice := resp.Choices[0]
 	if len(choice.Message.ToolCalls) > 0 {
-		if !writer.writeDelta(openAIStreamDelta{
+		if !writer.writeDelta(ctx, openAIStreamDelta{
 			Role:      "assistant",
 			ToolCalls: openAIStreamToolCallDeltas(choice.Message.ToolCalls),
 		}, nil) {
@@ -119,26 +118,26 @@ func (s *Server) sendOpenAIStream(ctx context.Context, w http.ResponseWriter, re
 		return
 	}
 
-	if !writer.writeDelta(openAIStreamDelta{}, &choice.FinishReason) {
+	if !writer.writeDelta(ctx, openAIStreamDelta{}, &choice.FinishReason) {
 		return
 	}
-	_ = writer.writeDone()
+	_ = writer.writeDone(ctx)
 }
 
 func (s *Server) writeOpenAITextStream(ctx context.Context, writer openAIStreamWriter, content string) bool {
 	totalDuration := s.randomStreamDuration()
 	if totalDuration == 0 {
-		return writer.writeDelta(openAITextDelta("assistant", content), nil)
+		return writer.writeDelta(ctx, openAITextDelta("assistant", content), nil)
 	}
 
 	first := true
-	return streamPacedChunks(ctx, totalDuration, s.streamContentChunks(content), func(chunk string) bool {
+	return s.streamPacedContent(ctx, totalDuration, content, func(chunk string) bool {
 		delta := openAITextDelta("", chunk)
 		if first {
 			delta.Role = "assistant"
 			first = false
 		}
-		return writer.writeDelta(delta, nil)
+		return writer.writeDelta(ctx, delta, nil)
 	})
 }
 

--- a/scaletest/llmmock/openai_stream.go
+++ b/scaletest/llmmock/openai_stream.go
@@ -1,0 +1,163 @@
+package llmmock
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"cdr.dev/slog/v3"
+)
+
+type openAIToolCallDelta struct {
+	Index    int                    `json:"index"`
+	ID       string                 `json:"id,omitempty"`
+	Type     string                 `json:"type,omitempty"`
+	Function openAIToolCallFunction `json:"function"`
+}
+
+type openAIStreamDelta struct {
+	Role      string                `json:"role,omitempty"`
+	Content   *string               `json:"content,omitempty"`
+	ToolCalls []openAIToolCallDelta `json:"tool_calls,omitempty"`
+}
+
+type openAIStreamChoice struct {
+	Index        int               `json:"index"`
+	Delta        openAIStreamDelta `json:"delta"`
+	FinishReason *string           `json:"finish_reason"`
+}
+
+type openAIStreamChunk struct {
+	ID      string               `json:"id"`
+	Object  string               `json:"object"`
+	Created int64                `json:"created"`
+	Model   string               `json:"model"`
+	Choices []openAIStreamChoice `json:"choices"`
+}
+
+type openAIStreamWriter struct {
+	ctx      context.Context
+	logger   slog.Logger
+	w        http.ResponseWriter
+	flusher  http.Flusher
+	response openAIResponse
+}
+
+func (s *Server) newOpenAIStreamWriter(ctx context.Context, w http.ResponseWriter, resp openAIResponse) (openAIStreamWriter, bool) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		s.logger.Error(ctx, "responseWriter does not support flushing",
+			slog.F("response_id", resp.ID),
+		)
+		return openAIStreamWriter{}, false
+	}
+
+	return openAIStreamWriter{
+		ctx:      ctx,
+		logger:   s.logger,
+		w:        w,
+		flusher:  flusher,
+		response: resp,
+	}, true
+}
+
+func (sw openAIStreamWriter) writeDelta(delta openAIStreamDelta, finishReason *string) bool {
+	chunk := openAIStreamChunk{
+		ID:      sw.response.ID,
+		Object:  "chat.completion.chunk",
+		Created: sw.response.Created,
+		Model:   sw.response.Model,
+		Choices: []openAIStreamChoice{{
+			Index:        0,
+			Delta:        delta,
+			FinishReason: finishReason,
+		}},
+	}
+	data, _ := json.Marshal(chunk)
+	return sw.writeData(string(data))
+}
+
+func (sw openAIStreamWriter) writeDone() bool {
+	return sw.writeData("[DONE]")
+}
+
+func (sw openAIStreamWriter) writeData(data string) bool {
+	if _, err := fmt.Fprintf(sw.w, "data: %s\n\n", data); err != nil {
+		sw.logger.Error(sw.ctx, "failed to write OpenAI stream chunk",
+			slog.F("response_id", sw.response.ID),
+			slog.Error(err),
+			slog.F("error_type", "write_error"),
+			slog.F("likely_cause", "network_error"),
+		)
+		return false
+	}
+	sw.flusher.Flush()
+	return true
+}
+
+func (s *Server) sendOpenAIStream(ctx context.Context, w http.ResponseWriter, resp openAIResponse) {
+	writer, ok := s.newOpenAIStreamWriter(ctx, w, resp)
+	if !ok {
+		return
+	}
+
+	choice := resp.Choices[0]
+	if len(choice.Message.ToolCalls) > 0 {
+		if !writer.writeDelta(openAIStreamDelta{
+			Role:      "assistant",
+			ToolCalls: openAIStreamToolCallDeltas(choice.Message.ToolCalls),
+		}, nil) {
+			return
+		}
+	} else if !s.writeOpenAITextStream(ctx, writer, choice.Message.Content) {
+		return
+	}
+
+	if !writer.writeDelta(openAIStreamDelta{}, &choice.FinishReason) {
+		return
+	}
+	_ = writer.writeDone()
+}
+
+func (s *Server) writeOpenAITextStream(ctx context.Context, writer openAIStreamWriter, content string) bool {
+	totalDuration := s.randomStreamDuration()
+	if totalDuration == 0 {
+		return writer.writeDelta(openAITextDelta("assistant", content), nil)
+	}
+
+	first := true
+	return streamPacedChunks(ctx, totalDuration, s.streamContentChunks(content), func(chunk string) bool {
+		delta := openAITextDelta("", chunk)
+		if first {
+			delta.Role = "assistant"
+			first = false
+		}
+		return writer.writeDelta(delta, nil)
+	})
+}
+
+func openAITextDelta(role string, content string) openAIStreamDelta {
+	return openAIStreamDelta{
+		Role:    role,
+		Content: &content,
+	}
+}
+
+func openAIStreamToolCallDeltas(toolCalls []openAIToolCall) []openAIToolCallDelta {
+	deltas := make([]openAIToolCallDelta, 0, len(toolCalls))
+	for i, toolCall := range toolCalls {
+		deltas = append(deltas, openAIToolCallDelta{
+			Index:    i,
+			ID:       toolCall.ID,
+			Type:     toolCall.Type,
+			Function: toolCall.Function,
+		})
+	}
+	return deltas
+}

--- a/scaletest/llmmock/openai_stream.go
+++ b/scaletest/llmmock/openai_stream.go
@@ -134,20 +134,18 @@ func (s *Server) sendOpenAIStream(ctx context.Context, w http.ResponseWriter, re
 }
 
 func (s *Server) writeOpenAITextStream(ctx context.Context, writer openAIStreamWriter, content string) bool {
-	totalDuration := s.randomStreamDuration()
-	if totalDuration == 0 {
-		return writer.writeDelta(ctx, openAITextDelta("assistant", content), nil)
-	}
-
 	first := true
-	return s.streamPacedContent(ctx, totalDuration, content, func(chunk string) bool {
+	for chunk := range s.streamContentChunks(ctx, s.randomStreamDuration(), content) {
 		delta := openAITextDelta("", chunk)
 		if first {
 			delta.Role = "assistant"
 			first = false
 		}
-		return writer.writeDelta(ctx, delta, nil)
-	})
+		if !writer.writeDelta(ctx, delta, nil) {
+			return false
+		}
+	}
+	return ctx.Err() == nil
 }
 
 func openAITextDelta(role string, content string) openAIStreamDelta {

--- a/scaletest/llmmock/openai_stream.go
+++ b/scaletest/llmmock/openai_stream.go
@@ -136,7 +136,7 @@ func (s *Server) sendOpenAIStream(ctx context.Context, w http.ResponseWriter, re
 func (s *Server) writeOpenAITextStream(ctx context.Context, writer openAIStreamWriter, content string) bool {
 	first := true
 	for chunk := range s.streamContentChunks(ctx, s.randomStreamDuration(), content) {
-		delta := openAITextDelta("", chunk)
+		delta := openAIStreamDelta{Content: &chunk}
 		if first {
 			delta.Role = "assistant"
 			first = false
@@ -146,13 +146,6 @@ func (s *Server) writeOpenAITextStream(ctx context.Context, writer openAIStreamW
 		}
 	}
 	return ctx.Err() == nil
-}
-
-func openAITextDelta(role string, content string) openAIStreamDelta {
-	return openAIStreamDelta{
-		Role:    role,
-		Content: &content,
-	}
 }
 
 func openAIStreamToolCallDeltas(toolCalls []openAIToolCall) []openAIToolCallDelta {

--- a/scaletest/llmmock/openai_stream.go
+++ b/scaletest/llmmock/openai_stream.go
@@ -3,6 +3,7 @@ package llmmock
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 
 	"cdr.dev/slog/v3"
@@ -85,19 +86,27 @@ func (sw openAIStreamWriter) writeDone(ctx context.Context) bool {
 }
 
 func (sw openAIStreamWriter) writeData(ctx context.Context, data []byte) bool {
-	for _, part := range [][]byte{[]byte("data: "), data, []byte("\n\n")} {
-		if _, err := sw.w.Write(part); err != nil {
-			sw.logger.Error(ctx, "failed to write OpenAI stream chunk",
-				slog.F("response_id", sw.response.ID),
-				slog.Error(err),
-				slog.F("error_type", "write_error"),
-				slog.F("likely_cause", "network_error"),
-			)
-			return false
-		}
+	if _, err := io.WriteString(sw.w, "data: "); err != nil {
+		return sw.logWriteError(ctx, err)
+	}
+	if _, err := sw.w.Write(data); err != nil {
+		return sw.logWriteError(ctx, err)
+	}
+	if _, err := io.WriteString(sw.w, "\n\n"); err != nil {
+		return sw.logWriteError(ctx, err)
 	}
 	sw.flusher.Flush()
 	return true
+}
+
+func (sw openAIStreamWriter) logWriteError(ctx context.Context, err error) bool {
+	sw.logger.Error(ctx, "failed to write OpenAI stream chunk",
+		slog.F("response_id", sw.response.ID),
+		slog.Error(err),
+		slog.F("error_type", "write_error"),
+		slog.F("likely_cause", "network_error"),
+	)
+	return false
 }
 
 func (s *Server) sendOpenAIStream(ctx context.Context, w http.ResponseWriter, resp openAIResponse) {

--- a/scaletest/llmmock/openai_stream_internal_test.go
+++ b/scaletest/llmmock/openai_stream_internal_test.go
@@ -130,7 +130,12 @@ func TestRandomStreamDuration(t *testing.T) {
 func TestSendOpenAIStreamTextContent(t *testing.T) {
 	t.Parallel()
 
-	srv := &Server{}
+	// Nanosecond pacing keeps the test instant while forcing the multi-chunk
+	// path so only the first delta should carry the assistant role.
+	srv := &Server{
+		minStreamDuration: time.Nanosecond,
+		maxStreamDuration: time.Nanosecond,
+	}
 	writer := httptest.NewRecorder()
 	resp := openAIResponse{
 		ID:      "chatcmpl-text",
@@ -138,7 +143,7 @@ func TestSendOpenAIStreamTextContent(t *testing.T) {
 		Created: 7,
 		Model:   "scaletest-model",
 		Choices: []openAIResponseChoice{{
-			Message:      openAIMessage{Role: "assistant", Content: "hello there"},
+			Message:      openAIMessage{Role: "assistant", Content: "hello world test"},
 			FinishReason: openAIStopFinishReason,
 		}},
 	}
@@ -146,21 +151,28 @@ func TestSendOpenAIStreamTextContent(t *testing.T) {
 	ctx := testutil.Context(t, testutil.WaitShort)
 	srv.sendOpenAIStream(ctx, writer, resp)
 	events := sseDataEvents(t, writer.Body.String())
-	require.Len(t, events, 3)
+	require.Len(t, events, 5) // 3 word chunks + finish + [DONE]
 
 	first := decodeStreamChunk(t, events[0])
 	require.Len(t, first.Choices, 1)
 	require.Nil(t, first.Choices[0].FinishReason)
 	require.Equal(t, "assistant", first.Choices[0].Delta.Role)
 	require.NotNil(t, first.Choices[0].Delta.Content)
-	require.Equal(t, "hello there", *first.Choices[0].Delta.Content)
+	require.Equal(t, "hello ", *first.Choices[0].Delta.Content)
 
 	second := decodeStreamChunk(t, events[1])
 	require.Len(t, second.Choices, 1)
-	require.NotNil(t, second.Choices[0].FinishReason)
-	require.Equal(t, openAIStopFinishReason, *second.Choices[0].FinishReason)
+	require.Nil(t, second.Choices[0].FinishReason)
 	require.Empty(t, second.Choices[0].Delta.Role)
-	require.Nil(t, second.Choices[0].Delta.Content)
+	require.NotNil(t, second.Choices[0].Delta.Content)
+	require.Equal(t, "world ", *second.Choices[0].Delta.Content)
 
-	require.Equal(t, "[DONE]", events[2])
+	finish := decodeStreamChunk(t, events[3])
+	require.Len(t, finish.Choices, 1)
+	require.NotNil(t, finish.Choices[0].FinishReason)
+	require.Equal(t, openAIStopFinishReason, *finish.Choices[0].FinishReason)
+	require.Empty(t, finish.Choices[0].Delta.Role)
+	require.Nil(t, finish.Choices[0].Delta.Content)
+
+	require.Equal(t, "[DONE]", events[4])
 }

--- a/scaletest/llmmock/openai_stream_internal_test.go
+++ b/scaletest/llmmock/openai_stream_internal_test.go
@@ -1,0 +1,166 @@
+package llmmock
+
+import (
+	"context"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestStreamWordChunks(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		content string
+		want    []string
+	}{
+		{
+			name:    "words",
+			content: "hello world test",
+			want:    []string{"hello ", "world ", "test"},
+		},
+		{
+			name:    "trailing space",
+			content: "hello world ",
+			want:    []string{"hello ", "world "},
+		},
+		{
+			name:    "single word",
+			content: "single",
+			want:    []string{"single"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.want, streamWordChunks(tc.content))
+		})
+	}
+}
+
+func TestStreamContentChunksWordSplit(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{}
+	ctx := testutil.Context(t, testutil.WaitShort)
+	got := slices.Collect(srv.streamContentChunks(ctx, time.Nanosecond, "hello world test"))
+	require.Equal(t, []string{"hello ", "world ", "test"}, got)
+}
+
+func TestStreamContentChunksFixedWindow(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{responsePayloadSize: 1}
+	ctx := testutil.Context(t, testutil.WaitShort)
+	content := strings.Repeat("x", 2050)
+
+	got := slices.Collect(srv.streamContentChunks(ctx, time.Nanosecond, content))
+	require.Len(t, got, 3)
+	require.Equal(t, streamFixedWindowSize, len(got[0]))
+	require.Equal(t, streamFixedWindowSize, len(got[1]))
+	require.Equal(t, 2, len(got[2]))
+	require.Equal(t, content, strings.Join(got, ""))
+}
+
+func TestStreamContentChunksShortCircuits(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name          string
+		totalDuration time.Duration
+		content       string
+		want          []string
+	}{
+		{
+			name:          "non-positive duration",
+			totalDuration: 0,
+			content:       "anything",
+			want:          []string{"anything"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := &Server{}
+			ctx := testutil.Context(t, testutil.WaitShort)
+			got := slices.Collect(srv.streamContentChunks(ctx, tc.totalDuration, tc.content))
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestStreamPacedChunksStopsOnCancel(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(testutil.Context(t, testutil.WaitShort))
+	defer cancel()
+
+	var got []string
+	for chunk := range streamPacedChunks(ctx, time.Hour, 3, slices.Values([]string{"a", "b", "c"})) {
+		got = append(got, chunk)
+		cancel()
+	}
+	require.Equal(t, []string{"a"}, got)
+}
+
+func TestRandomStreamDuration(t *testing.T) {
+	t.Parallel()
+
+	require.Zero(t, (&Server{}).randomStreamDuration())
+	require.Equal(t, 5*time.Second, (&Server{
+		minStreamDuration: 5 * time.Second,
+		maxStreamDuration: 5 * time.Second,
+	}).randomStreamDuration())
+
+	duration := (&Server{
+		minStreamDuration: time.Second,
+		maxStreamDuration: 2 * time.Second,
+	}).randomStreamDuration()
+	require.GreaterOrEqual(t, duration, time.Second)
+	require.Less(t, duration, 2*time.Second)
+}
+
+func TestSendOpenAIStreamTextContent(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{}
+	writer := httptest.NewRecorder()
+	resp := openAIResponse{
+		ID:      "chatcmpl-text",
+		Object:  "chat.completion",
+		Created: 7,
+		Model:   "scaletest-model",
+		Choices: []openAIResponseChoice{{
+			Message:      openAIMessage{Role: "assistant", Content: "hello there"},
+			FinishReason: openAIStopFinishReason,
+		}},
+	}
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	srv.sendOpenAIStream(ctx, writer, resp)
+	events := sseDataEvents(t, writer.Body.String())
+	require.Len(t, events, 3)
+
+	first := decodeStreamChunk(t, events[0])
+	require.Len(t, first.Choices, 1)
+	require.Nil(t, first.Choices[0].FinishReason)
+	require.Equal(t, "assistant", first.Choices[0].Delta.Role)
+	require.NotNil(t, first.Choices[0].Delta.Content)
+	require.Equal(t, "hello there", *first.Choices[0].Delta.Content)
+
+	second := decodeStreamChunk(t, events[1])
+	require.Len(t, second.Choices, 1)
+	require.NotNil(t, second.Choices[0].FinishReason)
+	require.Equal(t, openAIStopFinishReason, *second.Choices[0].FinishReason)
+	require.Empty(t, second.Choices[0].Delta.Role)
+	require.Nil(t, second.Choices[0].Delta.Content)
+
+	require.Equal(t, "[DONE]", events[2])
+}

--- a/scaletest/llmmock/openai_toolcalls.go
+++ b/scaletest/llmmock/openai_toolcalls.go
@@ -6,29 +6,21 @@ import (
 	"slices"
 
 	"github.com/google/uuid"
-	"golang.org/x/xerrors"
 )
 
-const (
-	executeToolName        = "execute"
-	defaultToolCallCommand = "echo scaletest"
-)
+const executeToolName = "execute"
 
-func (s *Server) buildOpenAIChoice(req llmRequest) (openAIResponseChoice, error) {
-	if !s.needsOpenAIToolCall(req) {
+func (s *Server) buildOpenAIChoice(req llmRequest) openAIResponseChoice {
+	if !s.needsOpenAIToolCall(req) || !slices.ContainsFunc(req.Tools, func(tool openAITool) bool {
+		return tool.Function.Name == executeToolName
+	}) {
 		return openAIResponseChoice{
 			Message: openAIMessage{
 				Role:    "assistant",
 				Content: s.responseText(openAIDefaultResponseText),
 			},
 			FinishReason: openAIStopFinishReason,
-		}, nil
-	}
-
-	if !slices.ContainsFunc(req.Tools, func(tool openAITool) bool {
-		return tool.Function.Name == executeToolName
-	}) {
-		return openAIResponseChoice{}, xerrors.Errorf("requested tool %q not present in tools list", executeToolName)
+		}
 	}
 
 	return openAIResponseChoice{
@@ -37,7 +29,7 @@ func (s *Server) buildOpenAIChoice(req llmRequest) (openAIResponseChoice, error)
 			ToolCalls: []openAIToolCall{executeToolCall(s.toolCallCommand)},
 		},
 		FinishReason: openAIToolCallFinishReason,
-	}, nil
+	}
 }
 
 func (s *Server) needsOpenAIToolCall(req llmRequest) bool {
@@ -46,8 +38,8 @@ func (s *Server) needsOpenAIToolCall(req llmRequest) bool {
 	}
 
 	completedToolCalls := 0
-	for i := len(req.Messages) - 1; i >= 0; i-- {
-		switch req.Messages[i].Role {
+	for _, msg := range slices.Backward(req.Messages) {
+		switch msg.Role {
 		case "tool":
 			completedToolCalls++
 		case "user":

--- a/scaletest/llmmock/openai_toolcalls.go
+++ b/scaletest/llmmock/openai_toolcalls.go
@@ -2,6 +2,7 @@ package llmmock
 
 import (
 	"encoding/json"
+	"fmt"
 	"slices"
 
 	"github.com/google/uuid"
@@ -9,20 +10,16 @@ import (
 )
 
 const (
-	executeToolName = "execute"
-	// DefaultToolCallCommand is the command emitted when no override is configured.
-	DefaultToolCallCommand     = "echo scaletest"
-	openAIToolCallFinishReason = "tool_calls"
-	openAIStopFinishReason     = "stop"
+	executeToolName        = "execute"
+	defaultToolCallCommand = "echo scaletest"
 )
 
 func (s *Server) buildOpenAIChoice(req llmRequest) (openAIResponseChoice, error) {
 	if !s.needsOpenAIToolCall(req) {
 		return openAIResponseChoice{
-			Index: 0,
 			Message: openAIMessage{
 				Role:    "assistant",
-				Content: responseText(s.responsePayloadSize, openAIDefaultResponseText),
+				Content: s.responseText(openAIDefaultResponseText),
 			},
 			FinishReason: openAIStopFinishReason,
 		}, nil
@@ -35,7 +32,6 @@ func (s *Server) buildOpenAIChoice(req llmRequest) (openAIResponseChoice, error)
 	}
 
 	return openAIResponseChoice{
-		Index: 0,
 		Message: openAIMessage{
 			Role:      "assistant",
 			ToolCalls: []openAIToolCall{executeToolCall(s.toolCallCommand)},
@@ -49,31 +45,22 @@ func (s *Server) needsOpenAIToolCall(req llmRequest) bool {
 		return false
 	}
 
-	lastUserIndex := -1
-	for i := len(req.Messages) - 1; i >= 0; i-- {
-		if req.Messages[i].Role == "user" {
-			lastUserIndex = i
-			break
-		}
-	}
-	if lastUserIndex < 0 {
-		return false
-	}
-
 	completedToolCalls := 0
-	for _, message := range req.Messages[lastUserIndex+1:] {
-		if message.Role == "tool" {
+	for i := len(req.Messages) - 1; i >= 0; i-- {
+		switch req.Messages[i].Role {
+		case "tool":
 			completedToolCalls++
+		case "user":
+			return completedToolCalls < s.toolCallsPerTurn
 		}
 	}
-
-	return completedToolCalls < s.toolCallsPerTurn
+	return false
 }
 
 func executeToolCall(command string) openAIToolCall {
 	payload, _ := json.Marshal(map[string]string{"command": command})
 	return openAIToolCall{
-		ID:   "call_" + uuid.New().String()[:8],
+		ID:   fmt.Sprintf("call_%s", uuid.New().String()[:8]),
 		Type: "function",
 		Function: openAIToolCallFunction{
 			Name:      executeToolName,

--- a/scaletest/llmmock/openai_toolcalls.go
+++ b/scaletest/llmmock/openai_toolcalls.go
@@ -1,0 +1,170 @@
+package llmmock
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"math/rand"
+	"slices"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+)
+
+const (
+	// coderChatIDHeader mirrors chatprovider.HeaderCoderChatID without adding a
+	// production chatd dependency to this scaletest mock.
+	coderChatIDHeader      = "X-Coder-Chat-Id"
+	executeToolName        = "execute"
+	defaultToolCallCommand = "echo scaletest"
+	// maxToolCallsPerTurnLimit is 1200 - 1, leaving room for the final
+	// assistant text under chatd's maxChatSteps.
+	// See coderd/x/chatd/chatd.go maxChatSteps.
+	maxToolCallsPerTurnLimit   = 1199
+	openAIToolCallFinishReason = "tool_calls"
+	openAIStopFinishReason     = "stop"
+)
+
+type toolCallConfig struct {
+	MinToolCallsPerTurn int
+	MaxToolCallsPerTurn int
+	ToolCallCommand     string
+	Seed                uint64
+}
+
+func (c Config) Validate() error {
+	if c.MinStreamDuration < 0 {
+		return xerrors.Errorf("validate min_stream_duration: must not be negative: %s", c.MinStreamDuration)
+	}
+	if c.MaxStreamDuration < 0 {
+		return xerrors.Errorf("validate max_stream_duration: must not be negative: %s", c.MaxStreamDuration)
+	}
+	if c.MinStreamDuration == 0 && c.MaxStreamDuration != 0 {
+		return xerrors.New("validate min_stream_duration: must be set when max_stream_duration is set")
+	}
+	if c.MaxStreamDuration == 0 && c.MinStreamDuration != 0 {
+		return xerrors.New("validate max_stream_duration: must be set when min_stream_duration is set")
+	}
+	if c.MinStreamDuration > c.MaxStreamDuration {
+		return xerrors.Errorf("validate min_stream_duration: must be <= max_stream_duration: %s > %s", c.MinStreamDuration, c.MaxStreamDuration)
+	}
+	if c.MinToolCallsPerTurn < 0 {
+		return xerrors.Errorf("validate min_tool_calls_per_turn: must not be negative: %d", c.MinToolCallsPerTurn)
+	}
+	if c.MaxToolCallsPerTurn < 0 {
+		return xerrors.Errorf("validate max_tool_calls_per_turn: must not be negative: %d", c.MaxToolCallsPerTurn)
+	}
+	if c.MinToolCallsPerTurn > c.MaxToolCallsPerTurn {
+		return xerrors.Errorf("validate min_tool_calls_per_turn: must be <= max_tool_calls_per_turn: %d > %d", c.MinToolCallsPerTurn, c.MaxToolCallsPerTurn)
+	}
+	if c.MaxToolCallsPerTurn > maxToolCallsPerTurnLimit {
+		return xerrors.Errorf("validate max_tool_calls_per_turn: must be <= %d", maxToolCallsPerTurnLimit)
+	}
+	return nil
+}
+
+func buildOpenAIResponse(req llmRequest, requestID uuid.UUID, now time.Time, responsePayloadSize int, chatID string, cfg toolCallConfig) (openAIResponse, error) {
+	message := openAIMessage{Role: "assistant"}
+	finishReason := openAIStopFinishReason
+
+	turnIndex, completedToolCalls := currentTurnState(req)
+	if turnIndex >= 0 && cfg.MaxToolCallsPerTurn > 0 {
+		target := targetForTurn(cfg.Seed, chatID, turnIndex, cfg.MinToolCallsPerTurn, cfg.MaxToolCallsPerTurn)
+		if completedToolCalls < target {
+			if !slices.ContainsFunc(req.Tools, func(tool openAITool) bool {
+				return tool.Function.Name == executeToolName
+			}) {
+				return openAIResponse{}, xerrors.Errorf("requested tool %q not present in tools list", executeToolName)
+			}
+
+			payload, err := json.Marshal(map[string]string{"command": cfg.ToolCallCommand})
+			if err != nil {
+				return openAIResponse{}, xerrors.Errorf("marshal %s arguments: %w", executeToolName, err)
+			}
+
+			message.ToolCalls = []openAIToolCall{{
+				Index: 0,
+				ID:    fmt.Sprintf("call_%s", uuid.New().String()[:8]),
+				Type:  "function",
+				Function: openAIToolCallFunction{
+					Name:      executeToolName,
+					Arguments: string(payload),
+				},
+			}}
+			finishReason = openAIToolCallFinishReason
+		}
+	}
+	if len(message.ToolCalls) == 0 {
+		message.Content = responseText(responsePayloadSize, openAIDefaultResponseText)
+	}
+
+	resp := openAIResponse{
+		ID:      fmt.Sprintf("chatcmpl-%s", requestID.String()[:8]),
+		Object:  "chat.completion",
+		Created: now.Unix(),
+		Model:   req.Model,
+		Choices: []openAIResponseChoice{{
+			Index:        0,
+			Message:      message,
+			FinishReason: finishReason,
+		}},
+	}
+	resp.Usage.PromptTokens = mockInputTokens
+	resp.Usage.CompletionTokens = mockOutputTokens
+	resp.Usage.TotalTokens = mockInputTokens + mockOutputTokens
+	return resp, nil
+}
+
+// currentTurnState returns the zero-based index of the most recent user turn
+// and the tool responses observed since that turn. It assumes the request
+// contains the full conversation history.
+func currentTurnState(req llmRequest) (turnIndex int, completedToolCalls int) {
+	lastUserIndex := -1
+	userCount := 0
+	for i, message := range req.Messages {
+		if message.Role == "user" {
+			lastUserIndex = i
+			userCount++
+		}
+	}
+	if lastUserIndex < 0 {
+		return -1, 0
+	}
+
+	for _, message := range req.Messages[lastUserIndex+1:] {
+		if message.Role == "tool" {
+			completedToolCalls++
+		}
+	}
+
+	return userCount - 1, completedToolCalls
+}
+
+func targetForTurn(seed uint64, chatID string, turnIndex int, minToolCalls, maxToolCalls int) int {
+	if maxToolCalls <= minToolCalls {
+		return minToolCalls
+	}
+
+	rng := rand.New(rand.NewSource(seedForTurn(seed, chatID, turnIndex)))
+	return minToolCalls + rng.Intn(maxToolCalls-minToolCalls+1)
+}
+
+func seedForTurn(seed uint64, chatID string, turnIndex int) int64 {
+	h := fnv.New64a()
+
+	var seedBytes [8]byte
+	binary.LittleEndian.PutUint64(seedBytes[:], seed)
+	_, _ = h.Write(seedBytes[:])
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(chatID))
+	_, _ = h.Write([]byte{0})
+
+	var turnBytes [8]byte
+	binary.LittleEndian.PutUint64(turnBytes[:], uint64(turnIndex))
+	_, _ = h.Write(turnBytes[:])
+
+	// #nosec G115 - Safe conversion to generate int64 hash from Sum64, data loss acceptable.
+	return int64(h.Sum64())
+}

--- a/scaletest/llmmock/openai_toolcalls.go
+++ b/scaletest/llmmock/openai_toolcalls.go
@@ -1,170 +1,83 @@
 package llmmock
 
 import (
-	"encoding/binary"
 	"encoding/json"
-	"fmt"
-	"hash/fnv"
-	"math/rand"
 	"slices"
-	"time"
 
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 )
 
 const (
-	// coderChatIDHeader mirrors chatprovider.HeaderCoderChatID without adding a
-	// production chatd dependency to this scaletest mock.
-	coderChatIDHeader      = "X-Coder-Chat-Id"
-	executeToolName        = "execute"
-	defaultToolCallCommand = "echo scaletest"
-	// maxToolCallsPerTurnLimit is 1200 - 1, leaving room for the final
-	// assistant text under chatd's maxChatSteps.
-	// See coderd/x/chatd/chatd.go maxChatSteps.
-	maxToolCallsPerTurnLimit   = 1199
+	executeToolName = "execute"
+	// DefaultToolCallCommand is the command emitted when no override is configured.
+	DefaultToolCallCommand     = "echo scaletest"
 	openAIToolCallFinishReason = "tool_calls"
 	openAIStopFinishReason     = "stop"
 )
 
-type toolCallConfig struct {
-	MinToolCallsPerTurn int
-	MaxToolCallsPerTurn int
-	ToolCallCommand     string
-	Seed                uint64
+func (s *Server) buildOpenAIChoice(req llmRequest) (openAIResponseChoice, error) {
+	if !s.needsOpenAIToolCall(req) {
+		return openAIResponseChoice{
+			Index: 0,
+			Message: openAIMessage{
+				Role:    "assistant",
+				Content: responseText(s.responsePayloadSize, openAIDefaultResponseText),
+			},
+			FinishReason: openAIStopFinishReason,
+		}, nil
+	}
+
+	if !slices.ContainsFunc(req.Tools, func(tool openAITool) bool {
+		return tool.Function.Name == executeToolName
+	}) {
+		return openAIResponseChoice{}, xerrors.Errorf("requested tool %q not present in tools list", executeToolName)
+	}
+
+	return openAIResponseChoice{
+		Index: 0,
+		Message: openAIMessage{
+			Role:      "assistant",
+			ToolCalls: []openAIToolCall{executeToolCall(s.toolCallCommand)},
+		},
+		FinishReason: openAIToolCallFinishReason,
+	}, nil
 }
 
-func (c Config) Validate() error {
-	if c.MinStreamDuration < 0 {
-		return xerrors.Errorf("validate min_stream_duration: must not be negative: %s", c.MinStreamDuration)
-	}
-	if c.MaxStreamDuration < 0 {
-		return xerrors.Errorf("validate max_stream_duration: must not be negative: %s", c.MaxStreamDuration)
-	}
-	if c.MinStreamDuration == 0 && c.MaxStreamDuration != 0 {
-		return xerrors.New("validate min_stream_duration: must be set when max_stream_duration is set")
-	}
-	if c.MaxStreamDuration == 0 && c.MinStreamDuration != 0 {
-		return xerrors.New("validate max_stream_duration: must be set when min_stream_duration is set")
-	}
-	if c.MinStreamDuration > c.MaxStreamDuration {
-		return xerrors.Errorf("validate min_stream_duration: must be <= max_stream_duration: %s > %s", c.MinStreamDuration, c.MaxStreamDuration)
-	}
-	if c.MinToolCallsPerTurn < 0 {
-		return xerrors.Errorf("validate min_tool_calls_per_turn: must not be negative: %d", c.MinToolCallsPerTurn)
-	}
-	if c.MaxToolCallsPerTurn < 0 {
-		return xerrors.Errorf("validate max_tool_calls_per_turn: must not be negative: %d", c.MaxToolCallsPerTurn)
-	}
-	if c.MinToolCallsPerTurn > c.MaxToolCallsPerTurn {
-		return xerrors.Errorf("validate min_tool_calls_per_turn: must be <= max_tool_calls_per_turn: %d > %d", c.MinToolCallsPerTurn, c.MaxToolCallsPerTurn)
-	}
-	if c.MaxToolCallsPerTurn > maxToolCallsPerTurnLimit {
-		return xerrors.Errorf("validate max_tool_calls_per_turn: must be <= %d", maxToolCallsPerTurnLimit)
-	}
-	return nil
-}
-
-func buildOpenAIResponse(req llmRequest, requestID uuid.UUID, now time.Time, responsePayloadSize int, chatID string, cfg toolCallConfig) (openAIResponse, error) {
-	message := openAIMessage{Role: "assistant"}
-	finishReason := openAIStopFinishReason
-
-	turnIndex, completedToolCalls := currentTurnState(req)
-	if turnIndex >= 0 && cfg.MaxToolCallsPerTurn > 0 {
-		target := targetForTurn(cfg.Seed, chatID, turnIndex, cfg.MinToolCallsPerTurn, cfg.MaxToolCallsPerTurn)
-		if completedToolCalls < target {
-			if !slices.ContainsFunc(req.Tools, func(tool openAITool) bool {
-				return tool.Function.Name == executeToolName
-			}) {
-				return openAIResponse{}, xerrors.Errorf("requested tool %q not present in tools list", executeToolName)
-			}
-
-			payload, err := json.Marshal(map[string]string{"command": cfg.ToolCallCommand})
-			if err != nil {
-				return openAIResponse{}, xerrors.Errorf("marshal %s arguments: %w", executeToolName, err)
-			}
-
-			message.ToolCalls = []openAIToolCall{{
-				Index: 0,
-				ID:    fmt.Sprintf("call_%s", uuid.New().String()[:8]),
-				Type:  "function",
-				Function: openAIToolCallFunction{
-					Name:      executeToolName,
-					Arguments: string(payload),
-				},
-			}}
-			finishReason = openAIToolCallFinishReason
-		}
-	}
-	if len(message.ToolCalls) == 0 {
-		message.Content = responseText(responsePayloadSize, openAIDefaultResponseText)
+func (s *Server) needsOpenAIToolCall(req llmRequest) bool {
+	if s.toolCallsPerTurn <= 0 {
+		return false
 	}
 
-	resp := openAIResponse{
-		ID:      fmt.Sprintf("chatcmpl-%s", requestID.String()[:8]),
-		Object:  "chat.completion",
-		Created: now.Unix(),
-		Model:   req.Model,
-		Choices: []openAIResponseChoice{{
-			Index:        0,
-			Message:      message,
-			FinishReason: finishReason,
-		}},
-	}
-	resp.Usage.PromptTokens = mockInputTokens
-	resp.Usage.CompletionTokens = mockOutputTokens
-	resp.Usage.TotalTokens = mockInputTokens + mockOutputTokens
-	return resp, nil
-}
-
-// currentTurnState returns the zero-based index of the most recent user turn
-// and the tool responses observed since that turn. It assumes the request
-// contains the full conversation history.
-func currentTurnState(req llmRequest) (turnIndex int, completedToolCalls int) {
 	lastUserIndex := -1
-	userCount := 0
-	for i, message := range req.Messages {
-		if message.Role == "user" {
+	for i := len(req.Messages) - 1; i >= 0; i-- {
+		if req.Messages[i].Role == "user" {
 			lastUserIndex = i
-			userCount++
+			break
 		}
 	}
 	if lastUserIndex < 0 {
-		return -1, 0
+		return false
 	}
 
+	completedToolCalls := 0
 	for _, message := range req.Messages[lastUserIndex+1:] {
 		if message.Role == "tool" {
 			completedToolCalls++
 		}
 	}
 
-	return userCount - 1, completedToolCalls
+	return completedToolCalls < s.toolCallsPerTurn
 }
 
-func targetForTurn(seed uint64, chatID string, turnIndex int, minToolCalls, maxToolCalls int) int {
-	if maxToolCalls <= minToolCalls {
-		return minToolCalls
+func executeToolCall(command string) openAIToolCall {
+	payload, _ := json.Marshal(map[string]string{"command": command})
+	return openAIToolCall{
+		ID:   "call_" + uuid.New().String()[:8],
+		Type: "function",
+		Function: openAIToolCallFunction{
+			Name:      executeToolName,
+			Arguments: string(payload),
+		},
 	}
-
-	rng := rand.New(rand.NewSource(seedForTurn(seed, chatID, turnIndex)))
-	return minToolCalls + rng.Intn(maxToolCalls-minToolCalls+1)
-}
-
-func seedForTurn(seed uint64, chatID string, turnIndex int) int64 {
-	h := fnv.New64a()
-
-	var seedBytes [8]byte
-	binary.LittleEndian.PutUint64(seedBytes[:], seed)
-	_, _ = h.Write(seedBytes[:])
-	_, _ = h.Write([]byte{0})
-	_, _ = h.Write([]byte(chatID))
-	_, _ = h.Write([]byte{0})
-
-	var turnBytes [8]byte
-	binary.LittleEndian.PutUint64(turnBytes[:], uint64(turnIndex))
-	_, _ = h.Write(turnBytes[:])
-
-	// #nosec G115 - Safe conversion to generate int64 hash from Sum64, data loss acceptable.
-	return int64(h.Sum64())
 }

--- a/scaletest/llmmock/openai_toolcalls.go
+++ b/scaletest/llmmock/openai_toolcalls.go
@@ -11,24 +11,26 @@ import (
 const executeToolName = "execute"
 
 func (s *Server) buildOpenAIChoice(req llmRequest) openAIResponseChoice {
-	if !s.needsOpenAIToolCall(req) || !slices.ContainsFunc(req.Tools, func(tool openAITool) bool {
+	executeToolIncluded := slices.ContainsFunc(req.Tools, func(tool openAITool) bool {
 		return tool.Function.Name == executeToolName
-	}) {
+	})
+
+	if s.needsOpenAIToolCall(req) && executeToolIncluded {
 		return openAIResponseChoice{
 			Message: openAIMessage{
-				Role:    "assistant",
-				Content: s.responseText(openAIDefaultResponseText),
+				Role:      "assistant",
+				ToolCalls: []openAIToolCall{executeToolCall(s.toolCallCommand)},
 			},
-			FinishReason: openAIStopFinishReason,
+			FinishReason: openAIToolCallFinishReason,
 		}
 	}
 
 	return openAIResponseChoice{
 		Message: openAIMessage{
-			Role:      "assistant",
-			ToolCalls: []openAIToolCall{executeToolCall(s.toolCallCommand)},
+			Role:    "assistant",
+			Content: s.responseText(openAIDefaultResponseText),
 		},
-		FinishReason: openAIToolCallFinishReason,
+		FinishReason: openAIStopFinishReason,
 	}
 }
 

--- a/scaletest/llmmock/openai_toolcalls_internal_test.go
+++ b/scaletest/llmmock/openai_toolcalls_internal_test.go
@@ -1,0 +1,252 @@
+package llmmock
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestBuildOpenAIResponseTextOnlyWithoutTools(t *testing.T) {
+	t.Parallel()
+
+	resp, err := buildOpenAIResponse(
+		llmRequest{Model: "scaletest-model"},
+		uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+		time.Unix(1, 0),
+		0,
+		"",
+		toolCallConfig{MaxToolCallsPerTurn: 0},
+	)
+	require.NoError(t, err)
+	require.Equal(t, openAIStopFinishReason, resp.Choices[0].FinishReason)
+	require.Empty(t, resp.Choices[0].Message.ToolCalls)
+	require.Equal(t, openAIDefaultResponseText, resp.Choices[0].Message.Content)
+}
+
+func TestBuildOpenAIResponseTextOnlyWithoutUserMessage(t *testing.T) {
+	t.Parallel()
+
+	resp, err := buildOpenAIResponse(
+		llmRequest{Model: "scaletest-model"},
+		uuid.MustParse("12121212-1212-1212-1212-121212121212"),
+		time.Unix(12, 0),
+		0,
+		"chat-a",
+		toolCallConfig{
+			MinToolCallsPerTurn: 1,
+			MaxToolCallsPerTurn: 1,
+			ToolCallCommand:     defaultToolCallCommand,
+			Seed:                123,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, openAIStopFinishReason, resp.Choices[0].FinishReason)
+	require.Empty(t, resp.Choices[0].Message.ToolCalls)
+	require.Equal(t, openAIDefaultResponseText, resp.Choices[0].Message.Content)
+}
+
+func TestBuildOpenAIResponseFixedToolCallTurn(t *testing.T) {
+	t.Parallel()
+
+	cfg := toolCallConfig{
+		MinToolCallsPerTurn: 2,
+		MaxToolCallsPerTurn: 2,
+		ToolCallCommand:     defaultToolCallCommand,
+		Seed:                123,
+	}
+	baseReq := llmRequest{
+		Model: "scaletest-model",
+		Messages: []openAIMessage{{
+			Role:    "user",
+			Content: "Reply with one short sentence.",
+		}},
+		Tools: []openAITool{{
+			Type:     "function",
+			Function: openAIToolFunction{Name: executeToolName},
+		}},
+	}
+
+	resp, err := buildOpenAIResponse(baseReq, uuid.MustParse("22222222-2222-2222-2222-222222222222"), time.Unix(2, 0), 0, "chat-a", cfg)
+	require.NoError(t, err)
+	require.Equal(t, openAIToolCallFinishReason, resp.Choices[0].FinishReason)
+	require.Len(t, resp.Choices[0].Message.ToolCalls, 1)
+	require.Equal(t, 0, resp.Choices[0].Message.ToolCalls[0].Index)
+	require.True(t, strings.HasPrefix(resp.Choices[0].Message.ToolCalls[0].ID, "call_"))
+	require.Equal(t, executeToolName, resp.Choices[0].Message.ToolCalls[0].Function.Name)
+	require.JSONEq(t, `{"command":"echo scaletest"}`, resp.Choices[0].Message.ToolCalls[0].Function.Arguments)
+
+	oneCompleted := baseReq
+	oneCompleted.Messages = append(oneCompleted.Messages,
+		openAIMessage{Role: "assistant", ToolCalls: resp.Choices[0].Message.ToolCalls},
+		openAIMessage{Role: "tool", ToolCallID: resp.Choices[0].Message.ToolCalls[0].ID, Content: "ok"},
+	)
+	resp, err = buildOpenAIResponse(oneCompleted, uuid.MustParse("33333333-3333-3333-3333-333333333333"), time.Unix(3, 0), 0, "chat-a", cfg)
+	require.NoError(t, err)
+	require.Equal(t, openAIToolCallFinishReason, resp.Choices[0].FinishReason)
+
+	twoCompleted := oneCompleted
+	twoCompleted.Messages = append(twoCompleted.Messages,
+		openAIMessage{Role: "assistant", ToolCalls: resp.Choices[0].Message.ToolCalls},
+		openAIMessage{Role: "tool", ToolCallID: resp.Choices[0].Message.ToolCalls[0].ID, Content: "ok"},
+	)
+	resp, err = buildOpenAIResponse(twoCompleted, uuid.MustParse("44444444-4444-4444-4444-444444444444"), time.Unix(4, 0), 0, "chat-a", cfg)
+	require.NoError(t, err)
+	require.Equal(t, openAIStopFinishReason, resp.Choices[0].FinishReason)
+	require.Empty(t, resp.Choices[0].Message.ToolCalls)
+	require.NotEmpty(t, resp.Choices[0].Message.Content)
+}
+
+func TestTargetForTurnDeterministicWithinRange(t *testing.T) {
+	t.Parallel()
+
+	first := targetForTurn(123, "chat-a", 0, 2, 6)
+	require.Equal(t, first, targetForTurn(123, "chat-a", 0, 2, 6))
+	require.GreaterOrEqual(t, first, 2)
+	require.LessOrEqual(t, first, 6)
+
+	seed := seedForTurn(123, "chat-a", 0)
+	require.Equal(t, seed, seedForTurn(123, "chat-a", 0))
+	require.NotEqual(t, seed, seedForTurn(123, "chat-a", 1))
+	require.NotEqual(t, seed, seedForTurn(123, "chat-b", 0))
+}
+
+func TestBuildOpenAIResponseRejectsMissingToolOnlyWhenNeeded(t *testing.T) {
+	t.Parallel()
+
+	req := llmRequest{
+		Model: "scaletest-model",
+		Messages: []openAIMessage{{
+			Role:    "user",
+			Content: "Continue.",
+		}},
+	}
+	cfg := toolCallConfig{
+		MinToolCallsPerTurn: 1,
+		MaxToolCallsPerTurn: 1,
+		ToolCallCommand:     defaultToolCallCommand,
+		Seed:                456,
+	}
+	_, err := buildOpenAIResponse(req, uuid.MustParse("55555555-5555-5555-5555-555555555555"), time.Unix(5, 0), 0, "chat-a", cfg)
+	require.ErrorContains(t, err, "requested tool")
+
+	cfg.MaxToolCallsPerTurn = 0
+	resp, err := buildOpenAIResponse(req, uuid.MustParse("66666666-6666-6666-6666-666666666666"), time.Unix(6, 0), 0, "chat-a", cfg)
+	require.NoError(t, err)
+	require.Equal(t, openAIStopFinishReason, resp.Choices[0].FinishReason)
+}
+
+func TestHandleOpenAIUsesChatIDHeaderForToolCallTarget(t *testing.T) {
+	t.Parallel()
+
+	const seed = uint64(1)
+	require.Equal(t, 0, targetForTurn(seed, "", 0, 0, 1))
+	require.Equal(t, 1, targetForTurn(seed, "chat-a", 0, 0, 1))
+
+	srv := &Server{
+		toolCallConfig: toolCallConfig{
+			MinToolCallsPerTurn: 0,
+			MaxToolCallsPerTurn: 1,
+			ToolCallCommand:     defaultToolCallCommand,
+			Seed:                seed,
+		},
+	}
+
+	call := func(t *testing.T, chatID string) openAIResponse {
+		t.Helper()
+
+		body := `{"model":"scaletest-model","messages":[{"role":"user","content":"Continue."}],"tools":[{"type":"function","function":{"name":"execute"}}]}`
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+		if chatID != "" {
+			req.Header.Set(coderChatIDHeader, chatID)
+		}
+		writer := httptest.NewRecorder()
+		srv.handleOpenAIWithLabels(writer, req)
+		require.Equal(t, http.StatusOK, writer.Code)
+
+		var resp openAIResponse
+		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), &resp))
+		return resp
+	}
+
+	withoutHeader := call(t, "")
+	require.Equal(t, openAIStopFinishReason, withoutHeader.Choices[0].FinishReason)
+	require.Empty(t, withoutHeader.Choices[0].Message.ToolCalls)
+
+	withHeader := call(t, "chat-a")
+	require.Equal(t, openAIToolCallFinishReason, withHeader.Choices[0].FinishReason)
+	require.Len(t, withHeader.Choices[0].Message.ToolCalls, 1)
+}
+
+func TestSendOpenAIStreamIncludesToolCalls(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{minStreamDuration: time.Second, maxStreamDuration: time.Second}
+	writer := httptest.NewRecorder()
+	resp := openAIResponse{
+		ID:      "chatcmpl-test",
+		Object:  "chat.completion",
+		Created: time.Unix(7, 0).Unix(),
+		Model:   "scaletest-model",
+		Choices: []openAIResponseChoice{{
+			Index: 0,
+			Message: openAIMessage{
+				Role: "assistant",
+				ToolCalls: []openAIToolCall{{
+					Index: 0,
+					ID:    "call_test",
+					Type:  "function",
+					Function: openAIToolCallFunction{
+						Name:      executeToolName,
+						Arguments: `{"command":"echo scaletest"}`,
+					},
+				}},
+			},
+			FinishReason: openAIToolCallFinishReason,
+		}},
+	}
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	srv.sendOpenAIStream(ctx, writer, resp)
+	body := writer.Body.String()
+	require.Contains(t, body, `"delta":{"role":"assistant","tool_calls"`)
+	require.Contains(t, body, `"name":"execute"`)
+	require.Contains(t, body, `"index":0`)
+	require.Contains(t, body, `"finish_reason":"tool_calls"`)
+	require.Equal(t, 2, strings.Count(body, "data: {"))
+	require.Contains(t, body, "[DONE]")
+}
+
+func TestSendOpenAIStreamPacesTextChunks(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{minStreamDuration: 2 * time.Millisecond, maxStreamDuration: 2 * time.Millisecond}
+	writer := httptest.NewRecorder()
+	resp := openAIResponse{
+		ID:      "chatcmpl-test",
+		Object:  "chat.completion",
+		Created: time.Unix(8, 0).Unix(),
+		Model:   "scaletest-model",
+		Choices: []openAIResponseChoice{{
+			Index:        0,
+			Message:      openAIMessage{Role: "assistant", Content: "one two"},
+			FinishReason: openAIStopFinishReason,
+		}},
+	}
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	startedAt := time.Now()
+	srv.sendOpenAIStream(ctx, writer, resp)
+	require.GreaterOrEqual(t, time.Since(startedAt), time.Millisecond)
+	body := writer.Body.String()
+	require.Contains(t, body, `"content":"one"`)
+	require.Contains(t, body, `"content":" two"`)
+	require.Contains(t, body, "[DONE]")
+}

--- a/scaletest/llmmock/openai_toolcalls_internal_test.go
+++ b/scaletest/llmmock/openai_toolcalls_internal_test.go
@@ -2,7 +2,6 @@ package llmmock
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -35,7 +34,7 @@ func TestBuildOpenAIChoice(t *testing.T) {
 		srv := &Server{toolCallsPerTurn: 1, toolCallCommand: testToolCallCommand}
 		choice := srv.buildOpenAIChoice(llmRequest{
 			Model:    "scaletest-model",
-			Messages: []openAIMessage{{Role: "system", Content: "Reply with one short sentence."}},
+			Messages: []llmRequestMessage{{Role: "system"}},
 		})
 		require.Equal(t, openAIStopFinishReason, choice.FinishReason)
 		require.Empty(t, choice.Message.ToolCalls)
@@ -204,15 +203,13 @@ func requireExecuteToolCall(t *testing.T, toolCall openAIToolCall, command strin
 func openAIExecuteRequest(completedToolCalls int) llmRequest {
 	req := llmRequest{
 		Model:    "scaletest-model",
-		Messages: []openAIMessage{{Role: "user", Content: "Reply with one short sentence."}},
+		Messages: []llmRequestMessage{{Role: "user"}},
 		Tools:    []openAITool{{Type: "function", Function: openAIToolFunction{Name: executeToolName}}},
 	}
-	for i := range completedToolCalls {
-		toolCall := executeToolCall(testToolCallCommand)
-		toolCall.ID = fmt.Sprintf("call_done_%d", i)
+	for range completedToolCalls {
 		req.Messages = append(req.Messages,
-			openAIMessage{Role: "assistant", ToolCalls: []openAIToolCall{toolCall}},
-			openAIMessage{Role: "tool", ToolCallID: toolCall.ID, Content: "ok"},
+			llmRequestMessage{Role: "assistant"},
+			llmRequestMessage{Role: "tool"},
 		)
 	}
 	return req

--- a/scaletest/llmmock/openai_toolcalls_internal_test.go
+++ b/scaletest/llmmock/openai_toolcalls_internal_test.go
@@ -1,6 +1,8 @@
 package llmmock
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -10,81 +12,91 @@ import (
 	"github.com/coder/coder/v2/testutil"
 )
 
-func TestBuildOpenAIChoiceTextOnlyDoesNotRequireTools(t *testing.T) {
+func TestBuildOpenAIChoice(t *testing.T) {
 	t.Parallel()
 
-	srv := &Server{toolCallsPerTurn: 0}
-	choice, err := srv.buildOpenAIChoice(openAIExecuteRequest(0))
-	require.NoError(t, err)
-	require.Equal(t, openAIStopFinishReason, choice.FinishReason)
-	require.Empty(t, choice.Message.ToolCalls)
-	require.Equal(t, openAIDefaultResponseText, choice.Message.Content)
-}
+	t.Run("TextOnlyDoesNotRequireTools", func(t *testing.T) {
+		t.Parallel()
 
-func TestBuildOpenAIChoiceNoUserMessageReturnsText(t *testing.T) {
-	t.Parallel()
-
-	srv := &Server{toolCallsPerTurn: 1, toolCallCommand: DefaultToolCallCommand}
-	choice, err := srv.buildOpenAIChoice(llmRequest{
-		Model:    "scaletest-model",
-		Messages: []openAIMessage{{Role: "system", Content: "Reply with one short sentence."}},
+		srv := &Server{toolCallsPerTurn: 0}
+		req := openAIExecuteRequest(0)
+		req.Tools = nil
+		choice, err := srv.buildOpenAIChoice(req)
+		require.NoError(t, err)
+		require.Equal(t, openAIStopFinishReason, choice.FinishReason)
+		require.Empty(t, choice.Message.ToolCalls)
+		require.Equal(t, openAIDefaultResponseText, choice.Message.Content)
 	})
-	require.NoError(t, err)
-	require.Equal(t, openAIStopFinishReason, choice.FinishReason)
-	require.Empty(t, choice.Message.ToolCalls)
-	require.Equal(t, openAIDefaultResponseText, choice.Message.Content)
-}
 
-func TestBuildOpenAIChoiceEmitsFixedToolCallsUntilCompleted(t *testing.T) {
-	t.Parallel()
+	t.Run("NoUserMessageReturnsText", func(t *testing.T) {
+		t.Parallel()
 
-	srv := &Server{toolCallsPerTurn: 2, toolCallCommand: DefaultToolCallCommand}
-	for _, tt := range []struct {
-		name          string
-		completed     int
-		wantFinish    string
-		wantToolCalls int
-	}{
-		{name: "none completed", completed: 0, wantFinish: openAIToolCallFinishReason, wantToolCalls: 1},
-		{name: "one completed", completed: 1, wantFinish: openAIToolCallFinishReason, wantToolCalls: 1},
-		{name: "all completed", completed: 2, wantFinish: openAIStopFinishReason},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			choice, err := srv.buildOpenAIChoice(openAIExecuteRequest(tt.completed))
-			require.NoError(t, err)
-			require.Equal(t, 0, choice.Index)
-			require.Equal(t, tt.wantFinish, choice.FinishReason)
-			require.Len(t, choice.Message.ToolCalls, tt.wantToolCalls)
-
-			if tt.wantToolCalls == 0 {
-				require.NotEmpty(t, choice.Message.Content)
-				return
-			}
-			if tt.completed == 0 {
-				toolCall := choice.Message.ToolCalls[0]
-				require.Equal(t, 0, toolCall.Index)
-				require.True(t, strings.HasPrefix(toolCall.ID, "call_"))
-				require.Equal(t, executeToolName, toolCall.Function.Name)
-				require.JSONEq(t, `{"command":"echo scaletest"}`, toolCall.Function.Arguments)
-			}
+		srv := &Server{toolCallsPerTurn: 1, toolCallCommand: defaultToolCallCommand}
+		choice, err := srv.buildOpenAIChoice(llmRequest{
+			Model:    "scaletest-model",
+			Messages: []openAIMessage{{Role: "system", Content: "Reply with one short sentence."}},
 		})
-	}
-}
+		require.NoError(t, err)
+		require.Equal(t, openAIStopFinishReason, choice.FinishReason)
+		require.Empty(t, choice.Message.ToolCalls)
+		require.Equal(t, openAIDefaultResponseText, choice.Message.Content)
+	})
 
-func TestBuildOpenAIChoiceRequiresExecuteToolWhenToolCallNeeded(t *testing.T) {
-	t.Parallel()
+	t.Run("EmitsToolCallNoneCompleted", func(t *testing.T) {
+		t.Parallel()
 
-	srv := &Server{toolCallsPerTurn: 1, toolCallCommand: DefaultToolCallCommand}
-	req := openAIExecuteRequest(0)
-	req.Tools = nil
-	_, err := srv.buildOpenAIChoice(req)
-	require.ErrorContains(t, err, `requested tool "execute" not present`)
+		srv := &Server{toolCallsPerTurn: 2, toolCallCommand: defaultToolCallCommand}
+		choice, err := srv.buildOpenAIChoice(openAIExecuteRequest(0))
+		require.NoError(t, err)
+		require.Equal(t, openAIToolCallFinishReason, choice.FinishReason)
+		require.Len(t, choice.Message.ToolCalls, 1)
+		toolCall := choice.Message.ToolCalls[0]
+		requireExecuteToolCall(t, toolCall, defaultToolCallCommand)
+
+		toolCallJSON, err := json.Marshal(toolCall)
+		require.NoError(t, err)
+		var toolCallFields map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(toolCallJSON, &toolCallFields))
+		require.NotContains(t, toolCallFields, "index")
+	})
+
+	t.Run("EmitsToolCallOneCompleted", func(t *testing.T) {
+		t.Parallel()
+
+		srv := &Server{toolCallsPerTurn: 2, toolCallCommand: defaultToolCallCommand}
+		choice, err := srv.buildOpenAIChoice(openAIExecuteRequest(1))
+		require.NoError(t, err)
+		require.Equal(t, openAIToolCallFinishReason, choice.FinishReason)
+		require.Len(t, choice.Message.ToolCalls, 1)
+		requireExecuteToolCall(t, choice.Message.ToolCalls[0], defaultToolCallCommand)
+	})
+
+	t.Run("StopsAfterAllToolCallsCompleted", func(t *testing.T) {
+		t.Parallel()
+
+		srv := &Server{toolCallsPerTurn: 2, toolCallCommand: defaultToolCallCommand}
+		choice, err := srv.buildOpenAIChoice(openAIExecuteRequest(2))
+		require.NoError(t, err)
+		require.Equal(t, openAIStopFinishReason, choice.FinishReason)
+		require.Empty(t, choice.Message.ToolCalls)
+		require.Equal(t, openAIDefaultResponseText, choice.Message.Content)
+	})
+
+	t.Run("RequiresExecuteToolWhenToolCallNeeded", func(t *testing.T) {
+		t.Parallel()
+
+		srv := &Server{toolCallsPerTurn: 1, toolCallCommand: defaultToolCallCommand}
+		req := openAIExecuteRequest(0)
+		req.Tools = nil
+		_, err := srv.buildOpenAIChoice(req)
+		require.ErrorContains(t, err, "requested tool \"execute\" not present")
+	})
 }
 
 func TestSendOpenAIStreamIncludesToolCalls(t *testing.T) {
 	t.Parallel()
 
-	toolCall := executeToolCall(DefaultToolCallCommand)
+	toolCall := executeToolCall(defaultToolCallCommand)
 
 	srv := &Server{}
 	writer := httptest.NewRecorder()
@@ -94,7 +106,6 @@ func TestSendOpenAIStreamIncludesToolCalls(t *testing.T) {
 		Created: 7,
 		Model:   "scaletest-model",
 		Choices: []openAIResponseChoice{{
-			Index:        0,
 			Message:      openAIMessage{Role: "assistant", ToolCalls: []openAIToolCall{toolCall}},
 			FinishReason: openAIToolCallFinishReason,
 		}},
@@ -102,13 +113,94 @@ func TestSendOpenAIStreamIncludesToolCalls(t *testing.T) {
 
 	ctx := testutil.Context(t, testutil.WaitShort)
 	srv.sendOpenAIStream(ctx, writer, resp)
-	body := writer.Body.String()
-	require.Contains(t, body, `"delta":{"role":"assistant","tool_calls"`)
-	require.Contains(t, body, `"name":"execute"`)
-	require.Contains(t, body, `"index":0`)
-	require.Contains(t, body, `"finish_reason":"tool_calls"`)
-	require.Equal(t, 2, strings.Count(body, "data: {"))
-	require.Contains(t, body, "[DONE]")
+	events := sseDataEvents(t, writer.Body.String())
+	require.Len(t, events, 3)
+
+	first := decodeOpenAIStreamEvent(t, events[0])
+	require.Len(t, first.Choices, 1)
+	require.Nil(t, first.Choices[0].FinishReason)
+	require.Equal(t, "assistant", first.Choices[0].Delta.Role)
+	require.Len(t, first.Choices[0].Delta.ToolCalls, 1)
+	requireExecuteStreamToolCall(t, first.Choices[0].Delta.ToolCalls[0], defaultToolCallCommand)
+
+	second := decodeOpenAIStreamEvent(t, events[1])
+	require.Len(t, second.Choices, 1)
+	require.NotNil(t, second.Choices[0].FinishReason)
+	require.Equal(t, openAIToolCallFinishReason, *second.Choices[0].FinishReason)
+	require.Empty(t, second.Choices[0].Delta.ToolCalls)
+
+	require.Equal(t, "[DONE]", events[2])
+}
+
+type openAIStreamEvent struct {
+	Choices []struct {
+		Delta struct {
+			Role      string                 `json:"role"`
+			ToolCalls []openAIStreamToolCall `json:"tool_calls"`
+		} `json:"delta"`
+		FinishReason *string `json:"finish_reason"`
+	} `json:"choices"`
+}
+
+type openAIStreamToolCall struct {
+	Index    *int                   `json:"index"`
+	ID       string                 `json:"id"`
+	Type     string                 `json:"type"`
+	Function openAIToolCallFunction `json:"function"`
+}
+
+func decodeOpenAIStreamEvent(t *testing.T, data string) openAIStreamEvent {
+	t.Helper()
+
+	var event openAIStreamEvent
+	require.NoError(t, json.Unmarshal([]byte(data), &event))
+	return event
+}
+
+func sseDataEvents(t *testing.T, body string) []string {
+	t.Helper()
+
+	var events []string
+	for _, event := range strings.Split(body, "\n\n") {
+		if event == "" {
+			continue
+		}
+
+		var dataLines []string
+		for _, line := range strings.Split(event, "\n") {
+			data, ok := strings.CutPrefix(line, "data: ")
+			if ok {
+				dataLines = append(dataLines, data)
+			}
+		}
+		if len(dataLines) > 0 {
+			events = append(events, strings.Join(dataLines, "\n"))
+		}
+	}
+	return events
+}
+
+func requireExecuteStreamToolCall(t *testing.T, toolCall openAIStreamToolCall, command string) {
+	t.Helper()
+
+	require.NotNil(t, toolCall.Index)
+	require.Zero(t, *toolCall.Index)
+	requireExecuteToolCall(t, openAIToolCall{
+		ID:       toolCall.ID,
+		Type:     toolCall.Type,
+		Function: toolCall.Function,
+	}, command)
+}
+
+func requireExecuteToolCall(t *testing.T, toolCall openAIToolCall, command string) {
+	t.Helper()
+
+	require.True(t, strings.HasPrefix(toolCall.ID, "call_"), "tool call ID %q", toolCall.ID)
+	require.Equal(t, "function", toolCall.Type)
+	require.Equal(t, executeToolName, toolCall.Function.Name)
+	expectedPayload, err := json.Marshal(map[string]string{"command": command})
+	require.NoError(t, err)
+	require.JSONEq(t, string(expectedPayload), toolCall.Function.Arguments)
 }
 
 func openAIExecuteRequest(completedToolCalls int) llmRequest {
@@ -117,10 +209,12 @@ func openAIExecuteRequest(completedToolCalls int) llmRequest {
 		Messages: []openAIMessage{{Role: "user", Content: "Reply with one short sentence."}},
 		Tools:    []openAITool{{Type: "function", Function: openAIToolFunction{Name: executeToolName}}},
 	}
-	for range completedToolCalls {
+	for i := range completedToolCalls {
+		toolCall := executeToolCall(defaultToolCallCommand)
+		toolCall.ID = fmt.Sprintf("call_done_%d", i)
 		req.Messages = append(req.Messages,
-			openAIMessage{Role: "assistant", ToolCalls: []openAIToolCall{{ID: "call_done"}}},
-			openAIMessage{Role: "tool", ToolCallID: "call_done", Content: "ok"},
+			openAIMessage{Role: "assistant", ToolCalls: []openAIToolCall{toolCall}},
+			openAIMessage{Role: "tool", ToolCallID: toolCall.ID, Content: "ok"},
 		)
 	}
 	return req

--- a/scaletest/llmmock/openai_toolcalls_internal_test.go
+++ b/scaletest/llmmock/openai_toolcalls_internal_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/coder/coder/v2/testutil"
 )
 
+const testToolCallCommand = "echo scaletest"
+
 func TestBuildOpenAIChoice(t *testing.T) {
 	t.Parallel()
 
@@ -21,8 +23,7 @@ func TestBuildOpenAIChoice(t *testing.T) {
 		srv := &Server{toolCallsPerTurn: 0}
 		req := openAIExecuteRequest(0)
 		req.Tools = nil
-		choice, err := srv.buildOpenAIChoice(req)
-		require.NoError(t, err)
+		choice := srv.buildOpenAIChoice(req)
 		require.Equal(t, openAIStopFinishReason, choice.FinishReason)
 		require.Empty(t, choice.Message.ToolCalls)
 		require.Equal(t, openAIDefaultResponseText, choice.Message.Content)
@@ -31,12 +32,11 @@ func TestBuildOpenAIChoice(t *testing.T) {
 	t.Run("NoUserMessageReturnsText", func(t *testing.T) {
 		t.Parallel()
 
-		srv := &Server{toolCallsPerTurn: 1, toolCallCommand: defaultToolCallCommand}
-		choice, err := srv.buildOpenAIChoice(llmRequest{
+		srv := &Server{toolCallsPerTurn: 1, toolCallCommand: testToolCallCommand}
+		choice := srv.buildOpenAIChoice(llmRequest{
 			Model:    "scaletest-model",
 			Messages: []openAIMessage{{Role: "system", Content: "Reply with one short sentence."}},
 		})
-		require.NoError(t, err)
 		require.Equal(t, openAIStopFinishReason, choice.FinishReason)
 		require.Empty(t, choice.Message.ToolCalls)
 		require.Equal(t, openAIDefaultResponseText, choice.Message.Content)
@@ -45,13 +45,12 @@ func TestBuildOpenAIChoice(t *testing.T) {
 	t.Run("EmitsToolCallNoneCompleted", func(t *testing.T) {
 		t.Parallel()
 
-		srv := &Server{toolCallsPerTurn: 2, toolCallCommand: defaultToolCallCommand}
-		choice, err := srv.buildOpenAIChoice(openAIExecuteRequest(0))
-		require.NoError(t, err)
+		srv := &Server{toolCallsPerTurn: 2, toolCallCommand: testToolCallCommand}
+		choice := srv.buildOpenAIChoice(openAIExecuteRequest(0))
 		require.Equal(t, openAIToolCallFinishReason, choice.FinishReason)
 		require.Len(t, choice.Message.ToolCalls, 1)
 		toolCall := choice.Message.ToolCalls[0]
-		requireExecuteToolCall(t, toolCall, defaultToolCallCommand)
+		requireExecuteToolCall(t, toolCall, testToolCallCommand)
 
 		toolCallJSON, err := json.Marshal(toolCall)
 		require.NoError(t, err)
@@ -63,40 +62,40 @@ func TestBuildOpenAIChoice(t *testing.T) {
 	t.Run("EmitsToolCallOneCompleted", func(t *testing.T) {
 		t.Parallel()
 
-		srv := &Server{toolCallsPerTurn: 2, toolCallCommand: defaultToolCallCommand}
-		choice, err := srv.buildOpenAIChoice(openAIExecuteRequest(1))
-		require.NoError(t, err)
+		srv := &Server{toolCallsPerTurn: 2, toolCallCommand: testToolCallCommand}
+		choice := srv.buildOpenAIChoice(openAIExecuteRequest(1))
 		require.Equal(t, openAIToolCallFinishReason, choice.FinishReason)
 		require.Len(t, choice.Message.ToolCalls, 1)
-		requireExecuteToolCall(t, choice.Message.ToolCalls[0], defaultToolCallCommand)
+		requireExecuteToolCall(t, choice.Message.ToolCalls[0], testToolCallCommand)
 	})
 
 	t.Run("StopsAfterAllToolCallsCompleted", func(t *testing.T) {
 		t.Parallel()
 
-		srv := &Server{toolCallsPerTurn: 2, toolCallCommand: defaultToolCallCommand}
-		choice, err := srv.buildOpenAIChoice(openAIExecuteRequest(2))
-		require.NoError(t, err)
+		srv := &Server{toolCallsPerTurn: 2, toolCallCommand: testToolCallCommand}
+		choice := srv.buildOpenAIChoice(openAIExecuteRequest(2))
 		require.Equal(t, openAIStopFinishReason, choice.FinishReason)
 		require.Empty(t, choice.Message.ToolCalls)
 		require.Equal(t, openAIDefaultResponseText, choice.Message.Content)
 	})
 
-	t.Run("RequiresExecuteToolWhenToolCallNeeded", func(t *testing.T) {
+	t.Run("FallsBackToTextWhenExecuteToolMissing", func(t *testing.T) {
 		t.Parallel()
 
-		srv := &Server{toolCallsPerTurn: 1, toolCallCommand: defaultToolCallCommand}
+		srv := &Server{toolCallsPerTurn: 1, toolCallCommand: testToolCallCommand}
 		req := openAIExecuteRequest(0)
 		req.Tools = nil
-		_, err := srv.buildOpenAIChoice(req)
-		require.ErrorContains(t, err, "requested tool \"execute\" not present")
+		choice := srv.buildOpenAIChoice(req)
+		require.Equal(t, openAIStopFinishReason, choice.FinishReason)
+		require.Empty(t, choice.Message.ToolCalls)
+		require.Equal(t, openAIDefaultResponseText, choice.Message.Content)
 	})
 }
 
 func TestSendOpenAIStreamIncludesToolCalls(t *testing.T) {
 	t.Parallel()
 
-	toolCall := executeToolCall(defaultToolCallCommand)
+	toolCall := executeToolCall(testToolCallCommand)
 
 	srv := &Server{}
 	writer := httptest.NewRecorder()
@@ -116,14 +115,14 @@ func TestSendOpenAIStreamIncludesToolCalls(t *testing.T) {
 	events := sseDataEvents(t, writer.Body.String())
 	require.Len(t, events, 3)
 
-	first := decodeOpenAIStreamEvent(t, events[0])
+	first := decodeStreamChunk(t, events[0])
 	require.Len(t, first.Choices, 1)
 	require.Nil(t, first.Choices[0].FinishReason)
 	require.Equal(t, "assistant", first.Choices[0].Delta.Role)
 	require.Len(t, first.Choices[0].Delta.ToolCalls, 1)
-	requireExecuteStreamToolCall(t, first.Choices[0].Delta.ToolCalls[0], defaultToolCallCommand)
+	requireExecuteStreamToolCall(t, events[0], first.Choices[0].Delta.ToolCalls[0], testToolCallCommand)
 
-	second := decodeOpenAIStreamEvent(t, events[1])
+	second := decodeStreamChunk(t, events[1])
 	require.Len(t, second.Choices, 1)
 	require.NotNil(t, second.Choices[0].FinishReason)
 	require.Equal(t, openAIToolCallFinishReason, *second.Choices[0].FinishReason)
@@ -132,29 +131,12 @@ func TestSendOpenAIStreamIncludesToolCalls(t *testing.T) {
 	require.Equal(t, "[DONE]", events[2])
 }
 
-type openAIStreamEvent struct {
-	Choices []struct {
-		Delta struct {
-			Role      string                 `json:"role"`
-			ToolCalls []openAIStreamToolCall `json:"tool_calls"`
-		} `json:"delta"`
-		FinishReason *string `json:"finish_reason"`
-	} `json:"choices"`
-}
-
-type openAIStreamToolCall struct {
-	Index    *int                   `json:"index"`
-	ID       string                 `json:"id"`
-	Type     string                 `json:"type"`
-	Function openAIToolCallFunction `json:"function"`
-}
-
-func decodeOpenAIStreamEvent(t *testing.T, data string) openAIStreamEvent {
+func decodeStreamChunk(t *testing.T, data string) openAIStreamChunk {
 	t.Helper()
 
-	var event openAIStreamEvent
-	require.NoError(t, json.Unmarshal([]byte(data), &event))
-	return event
+	var chunk openAIStreamChunk
+	require.NoError(t, json.Unmarshal([]byte(data), &chunk))
+	return chunk
 }
 
 func sseDataEvents(t *testing.T, body string) []string {
@@ -180,11 +162,27 @@ func sseDataEvents(t *testing.T, body string) []string {
 	return events
 }
 
-func requireExecuteStreamToolCall(t *testing.T, toolCall openAIStreamToolCall, command string) {
+// requireExecuteStreamToolCall asserts the streamed tool-call delta and that
+// its JSON payload includes the index field, which the production type marks
+// as non-omitempty but is otherwise indistinguishable from a zero default in
+// the decoded struct.
+func requireExecuteStreamToolCall(t *testing.T, rawEvent string, toolCall openAIToolCallDelta, command string) {
 	t.Helper()
 
-	require.NotNil(t, toolCall.Index)
-	require.Zero(t, *toolCall.Index)
+	require.Zero(t, toolCall.Index)
+
+	var rawChunk struct {
+		Choices []struct {
+			Delta struct {
+				ToolCalls []map[string]json.RawMessage `json:"tool_calls"`
+			} `json:"delta"`
+		} `json:"choices"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(rawEvent), &rawChunk))
+	require.Len(t, rawChunk.Choices, 1)
+	require.Len(t, rawChunk.Choices[0].Delta.ToolCalls, 1)
+	require.Contains(t, rawChunk.Choices[0].Delta.ToolCalls[0], "index")
+
 	requireExecuteToolCall(t, openAIToolCall{
 		ID:       toolCall.ID,
 		Type:     toolCall.Type,
@@ -210,7 +208,7 @@ func openAIExecuteRequest(completedToolCalls int) llmRequest {
 		Tools:    []openAITool{{Type: "function", Function: openAIToolFunction{Name: executeToolName}}},
 	}
 	for i := range completedToolCalls {
-		toolCall := executeToolCall(defaultToolCallCommand)
+		toolCall := executeToolCall(testToolCallCommand)
 		toolCall.ID = fmt.Sprintf("call_done_%d", i)
 		req.Messages = append(req.Messages,
 			openAIMessage{Role: "assistant", ToolCalls: []openAIToolCall{toolCall}},

--- a/scaletest/llmmock/openai_toolcalls_internal_test.go
+++ b/scaletest/llmmock/openai_toolcalls_internal_test.go
@@ -1,214 +1,101 @@
 package llmmock
 
 import (
-	"encoding/json"
-	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/testutil"
 )
 
-func TestBuildOpenAIResponseTextOnlyWithoutTools(t *testing.T) {
+func TestBuildOpenAIChoiceTextOnlyDoesNotRequireTools(t *testing.T) {
 	t.Parallel()
 
-	resp, err := buildOpenAIResponse(
-		llmRequest{Model: "scaletest-model"},
-		uuid.MustParse("11111111-1111-1111-1111-111111111111"),
-		time.Unix(1, 0),
-		0,
-		"",
-		toolCallConfig{MaxToolCallsPerTurn: 0},
-	)
+	srv := &Server{toolCallsPerTurn: 0}
+	choice, err := srv.buildOpenAIChoice(openAIExecuteRequest(0))
 	require.NoError(t, err)
-	require.Equal(t, openAIStopFinishReason, resp.Choices[0].FinishReason)
-	require.Empty(t, resp.Choices[0].Message.ToolCalls)
-	require.Equal(t, openAIDefaultResponseText, resp.Choices[0].Message.Content)
+	require.Equal(t, openAIStopFinishReason, choice.FinishReason)
+	require.Empty(t, choice.Message.ToolCalls)
+	require.Equal(t, openAIDefaultResponseText, choice.Message.Content)
 }
 
-func TestBuildOpenAIResponseTextOnlyWithoutUserMessage(t *testing.T) {
+func TestBuildOpenAIChoiceNoUserMessageReturnsText(t *testing.T) {
 	t.Parallel()
 
-	resp, err := buildOpenAIResponse(
-		llmRequest{Model: "scaletest-model"},
-		uuid.MustParse("12121212-1212-1212-1212-121212121212"),
-		time.Unix(12, 0),
-		0,
-		"chat-a",
-		toolCallConfig{
-			MinToolCallsPerTurn: 1,
-			MaxToolCallsPerTurn: 1,
-			ToolCallCommand:     defaultToolCallCommand,
-			Seed:                123,
-		},
-	)
+	srv := &Server{toolCallsPerTurn: 1, toolCallCommand: DefaultToolCallCommand}
+	choice, err := srv.buildOpenAIChoice(llmRequest{
+		Model:    "scaletest-model",
+		Messages: []openAIMessage{{Role: "system", Content: "Reply with one short sentence."}},
+	})
 	require.NoError(t, err)
-	require.Equal(t, openAIStopFinishReason, resp.Choices[0].FinishReason)
-	require.Empty(t, resp.Choices[0].Message.ToolCalls)
-	require.Equal(t, openAIDefaultResponseText, resp.Choices[0].Message.Content)
+	require.Equal(t, openAIStopFinishReason, choice.FinishReason)
+	require.Empty(t, choice.Message.ToolCalls)
+	require.Equal(t, openAIDefaultResponseText, choice.Message.Content)
 }
 
-func TestBuildOpenAIResponseFixedToolCallTurn(t *testing.T) {
+func TestBuildOpenAIChoiceEmitsFixedToolCallsUntilCompleted(t *testing.T) {
 	t.Parallel()
 
-	cfg := toolCallConfig{
-		MinToolCallsPerTurn: 2,
-		MaxToolCallsPerTurn: 2,
-		ToolCallCommand:     defaultToolCallCommand,
-		Seed:                123,
+	srv := &Server{toolCallsPerTurn: 2, toolCallCommand: DefaultToolCallCommand}
+	for _, tt := range []struct {
+		name          string
+		completed     int
+		wantFinish    string
+		wantToolCalls int
+	}{
+		{name: "none completed", completed: 0, wantFinish: openAIToolCallFinishReason, wantToolCalls: 1},
+		{name: "one completed", completed: 1, wantFinish: openAIToolCallFinishReason, wantToolCalls: 1},
+		{name: "all completed", completed: 2, wantFinish: openAIStopFinishReason},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			choice, err := srv.buildOpenAIChoice(openAIExecuteRequest(tt.completed))
+			require.NoError(t, err)
+			require.Equal(t, 0, choice.Index)
+			require.Equal(t, tt.wantFinish, choice.FinishReason)
+			require.Len(t, choice.Message.ToolCalls, tt.wantToolCalls)
+
+			if tt.wantToolCalls == 0 {
+				require.NotEmpty(t, choice.Message.Content)
+				return
+			}
+			if tt.completed == 0 {
+				toolCall := choice.Message.ToolCalls[0]
+				require.Equal(t, 0, toolCall.Index)
+				require.True(t, strings.HasPrefix(toolCall.ID, "call_"))
+				require.Equal(t, executeToolName, toolCall.Function.Name)
+				require.JSONEq(t, `{"command":"echo scaletest"}`, toolCall.Function.Arguments)
+			}
+		})
 	}
-	baseReq := llmRequest{
-		Model: "scaletest-model",
-		Messages: []openAIMessage{{
-			Role:    "user",
-			Content: "Reply with one short sentence.",
-		}},
-		Tools: []openAITool{{
-			Type:     "function",
-			Function: openAIToolFunction{Name: executeToolName},
-		}},
-	}
-
-	resp, err := buildOpenAIResponse(baseReq, uuid.MustParse("22222222-2222-2222-2222-222222222222"), time.Unix(2, 0), 0, "chat-a", cfg)
-	require.NoError(t, err)
-	require.Equal(t, openAIToolCallFinishReason, resp.Choices[0].FinishReason)
-	require.Len(t, resp.Choices[0].Message.ToolCalls, 1)
-	require.Equal(t, 0, resp.Choices[0].Message.ToolCalls[0].Index)
-	require.True(t, strings.HasPrefix(resp.Choices[0].Message.ToolCalls[0].ID, "call_"))
-	require.Equal(t, executeToolName, resp.Choices[0].Message.ToolCalls[0].Function.Name)
-	require.JSONEq(t, `{"command":"echo scaletest"}`, resp.Choices[0].Message.ToolCalls[0].Function.Arguments)
-
-	oneCompleted := baseReq
-	oneCompleted.Messages = append(oneCompleted.Messages,
-		openAIMessage{Role: "assistant", ToolCalls: resp.Choices[0].Message.ToolCalls},
-		openAIMessage{Role: "tool", ToolCallID: resp.Choices[0].Message.ToolCalls[0].ID, Content: "ok"},
-	)
-	resp, err = buildOpenAIResponse(oneCompleted, uuid.MustParse("33333333-3333-3333-3333-333333333333"), time.Unix(3, 0), 0, "chat-a", cfg)
-	require.NoError(t, err)
-	require.Equal(t, openAIToolCallFinishReason, resp.Choices[0].FinishReason)
-
-	twoCompleted := oneCompleted
-	twoCompleted.Messages = append(twoCompleted.Messages,
-		openAIMessage{Role: "assistant", ToolCalls: resp.Choices[0].Message.ToolCalls},
-		openAIMessage{Role: "tool", ToolCallID: resp.Choices[0].Message.ToolCalls[0].ID, Content: "ok"},
-	)
-	resp, err = buildOpenAIResponse(twoCompleted, uuid.MustParse("44444444-4444-4444-4444-444444444444"), time.Unix(4, 0), 0, "chat-a", cfg)
-	require.NoError(t, err)
-	require.Equal(t, openAIStopFinishReason, resp.Choices[0].FinishReason)
-	require.Empty(t, resp.Choices[0].Message.ToolCalls)
-	require.NotEmpty(t, resp.Choices[0].Message.Content)
 }
 
-func TestTargetForTurnDeterministicWithinRange(t *testing.T) {
+func TestBuildOpenAIChoiceRequiresExecuteToolWhenToolCallNeeded(t *testing.T) {
 	t.Parallel()
 
-	first := targetForTurn(123, "chat-a", 0, 2, 6)
-	require.Equal(t, first, targetForTurn(123, "chat-a", 0, 2, 6))
-	require.GreaterOrEqual(t, first, 2)
-	require.LessOrEqual(t, first, 6)
-
-	seed := seedForTurn(123, "chat-a", 0)
-	require.Equal(t, seed, seedForTurn(123, "chat-a", 0))
-	require.NotEqual(t, seed, seedForTurn(123, "chat-a", 1))
-	require.NotEqual(t, seed, seedForTurn(123, "chat-b", 0))
-}
-
-func TestBuildOpenAIResponseRejectsMissingToolOnlyWhenNeeded(t *testing.T) {
-	t.Parallel()
-
-	req := llmRequest{
-		Model: "scaletest-model",
-		Messages: []openAIMessage{{
-			Role:    "user",
-			Content: "Continue.",
-		}},
-	}
-	cfg := toolCallConfig{
-		MinToolCallsPerTurn: 1,
-		MaxToolCallsPerTurn: 1,
-		ToolCallCommand:     defaultToolCallCommand,
-		Seed:                456,
-	}
-	_, err := buildOpenAIResponse(req, uuid.MustParse("55555555-5555-5555-5555-555555555555"), time.Unix(5, 0), 0, "chat-a", cfg)
-	require.ErrorContains(t, err, "requested tool")
-
-	cfg.MaxToolCallsPerTurn = 0
-	resp, err := buildOpenAIResponse(req, uuid.MustParse("66666666-6666-6666-6666-666666666666"), time.Unix(6, 0), 0, "chat-a", cfg)
-	require.NoError(t, err)
-	require.Equal(t, openAIStopFinishReason, resp.Choices[0].FinishReason)
-}
-
-func TestHandleOpenAIUsesChatIDHeaderForToolCallTarget(t *testing.T) {
-	t.Parallel()
-
-	const seed = uint64(1)
-	require.Equal(t, 0, targetForTurn(seed, "", 0, 0, 1))
-	require.Equal(t, 1, targetForTurn(seed, "chat-a", 0, 0, 1))
-
-	srv := &Server{
-		toolCallConfig: toolCallConfig{
-			MinToolCallsPerTurn: 0,
-			MaxToolCallsPerTurn: 1,
-			ToolCallCommand:     defaultToolCallCommand,
-			Seed:                seed,
-		},
-	}
-
-	call := func(t *testing.T, chatID string) openAIResponse {
-		t.Helper()
-
-		body := `{"model":"scaletest-model","messages":[{"role":"user","content":"Continue."}],"tools":[{"type":"function","function":{"name":"execute"}}]}`
-		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
-		if chatID != "" {
-			req.Header.Set(coderChatIDHeader, chatID)
-		}
-		writer := httptest.NewRecorder()
-		srv.handleOpenAIWithLabels(writer, req)
-		require.Equal(t, http.StatusOK, writer.Code)
-
-		var resp openAIResponse
-		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), &resp))
-		return resp
-	}
-
-	withoutHeader := call(t, "")
-	require.Equal(t, openAIStopFinishReason, withoutHeader.Choices[0].FinishReason)
-	require.Empty(t, withoutHeader.Choices[0].Message.ToolCalls)
-
-	withHeader := call(t, "chat-a")
-	require.Equal(t, openAIToolCallFinishReason, withHeader.Choices[0].FinishReason)
-	require.Len(t, withHeader.Choices[0].Message.ToolCalls, 1)
+	srv := &Server{toolCallsPerTurn: 1, toolCallCommand: DefaultToolCallCommand}
+	req := openAIExecuteRequest(0)
+	req.Tools = nil
+	_, err := srv.buildOpenAIChoice(req)
+	require.ErrorContains(t, err, `requested tool "execute" not present`)
 }
 
 func TestSendOpenAIStreamIncludesToolCalls(t *testing.T) {
 	t.Parallel()
 
-	srv := &Server{minStreamDuration: time.Second, maxStreamDuration: time.Second}
+	toolCall := executeToolCall(DefaultToolCallCommand)
+
+	srv := &Server{}
 	writer := httptest.NewRecorder()
 	resp := openAIResponse{
 		ID:      "chatcmpl-test",
 		Object:  "chat.completion",
-		Created: time.Unix(7, 0).Unix(),
+		Created: 7,
 		Model:   "scaletest-model",
 		Choices: []openAIResponseChoice{{
-			Index: 0,
-			Message: openAIMessage{
-				Role: "assistant",
-				ToolCalls: []openAIToolCall{{
-					Index: 0,
-					ID:    "call_test",
-					Type:  "function",
-					Function: openAIToolCallFunction{
-						Name:      executeToolName,
-						Arguments: `{"command":"echo scaletest"}`,
-					},
-				}},
-			},
+			Index:        0,
+			Message:      openAIMessage{Role: "assistant", ToolCalls: []openAIToolCall{toolCall}},
 			FinishReason: openAIToolCallFinishReason,
 		}},
 	}
@@ -224,29 +111,17 @@ func TestSendOpenAIStreamIncludesToolCalls(t *testing.T) {
 	require.Contains(t, body, "[DONE]")
 }
 
-func TestSendOpenAIStreamPacesTextChunks(t *testing.T) {
-	t.Parallel()
-
-	srv := &Server{minStreamDuration: 2 * time.Millisecond, maxStreamDuration: 2 * time.Millisecond}
-	writer := httptest.NewRecorder()
-	resp := openAIResponse{
-		ID:      "chatcmpl-test",
-		Object:  "chat.completion",
-		Created: time.Unix(8, 0).Unix(),
-		Model:   "scaletest-model",
-		Choices: []openAIResponseChoice{{
-			Index:        0,
-			Message:      openAIMessage{Role: "assistant", Content: "one two"},
-			FinishReason: openAIStopFinishReason,
-		}},
+func openAIExecuteRequest(completedToolCalls int) llmRequest {
+	req := llmRequest{
+		Model:    "scaletest-model",
+		Messages: []openAIMessage{{Role: "user", Content: "Reply with one short sentence."}},
+		Tools:    []openAITool{{Type: "function", Function: openAIToolFunction{Name: executeToolName}}},
 	}
-
-	ctx := testutil.Context(t, testutil.WaitShort)
-	startedAt := time.Now()
-	srv.sendOpenAIStream(ctx, writer, resp)
-	require.GreaterOrEqual(t, time.Since(startedAt), time.Millisecond)
-	body := writer.Body.String()
-	require.Contains(t, body, `"content":"one"`)
-	require.Contains(t, body, `"content":" two"`)
-	require.Contains(t, body, "[DONE]")
+	for range completedToolCalls {
+		req.Messages = append(req.Messages,
+			openAIMessage{Role: "assistant", ToolCalls: []openAIToolCall{{ID: "call_done"}}},
+			openAIMessage{Role: "tool", ToolCallID: "call_done", Content: "ok"},
+		)
+	}
+	return req
 }

--- a/scaletest/llmmock/openai_toolcalls_internal_test.go
+++ b/scaletest/llmmock/openai_toolcalls_internal_test.go
@@ -20,9 +20,7 @@ func TestBuildOpenAIChoice(t *testing.T) {
 		t.Parallel()
 
 		srv := &Server{toolCallsPerTurn: 0}
-		req := openAIExecuteRequest(0)
-		req.Tools = nil
-		choice := srv.buildOpenAIChoice(req)
+		choice := srv.buildOpenAIChoice(openAIExecuteRequest(0))
 		require.Equal(t, openAIStopFinishReason, choice.FinishReason)
 		require.Empty(t, choice.Message.ToolCalls)
 		require.Equal(t, openAIDefaultResponseText, choice.Message.Content)

--- a/scaletest/llmmock/server.go
+++ b/scaletest/llmmock/server.go
@@ -100,13 +100,6 @@ type openAIToolCall struct {
 	Function openAIToolCallFunction `json:"function"`
 }
 
-type openAIToolCallDelta struct {
-	Index    int                    `json:"index"`
-	ID       string                 `json:"id,omitempty"`
-	Type     string                 `json:"type,omitempty"`
-	Function openAIToolCallFunction `json:"function"`
-}
-
 type openAIToolCallFunction struct {
 	Name      string `json:"name,omitempty"`
 	Arguments string `json:"arguments,omitempty"`
@@ -561,102 +554,6 @@ func (s *Server) handleAnthropicWithLabels(w http.ResponseWriter, r *http.Reques
 			slog.F("likely_cause", "network_error"),
 		)
 	}
-}
-
-func (s *Server) sendOpenAIStream(ctx context.Context, w http.ResponseWriter, resp openAIResponse) {
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-	w.WriteHeader(http.StatusOK)
-
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		s.logger.Error(ctx, "responseWriter does not support flushing",
-			slog.F("response_id", resp.ID),
-		)
-		return
-	}
-
-	writeChunk := func(data string) bool {
-		if _, err := fmt.Fprintf(w, "%s", data); err != nil {
-			s.logger.Error(ctx, "failed to write OpenAI stream chunk",
-				slog.F("response_id", resp.ID),
-				slog.Error(err),
-				slog.F("error_type", "write_error"),
-				slog.F("likely_cause", "network_error"),
-			)
-			return false
-		}
-		flusher.Flush()
-		return true
-	}
-
-	// Non-terminal chunks pass nil so JSON emits null for finish_reason.
-	writeStreamChunk := func(delta map[string]any, finishReason *string) bool {
-		chunk := map[string]any{
-			"id":      resp.ID,
-			"object":  "chat.completion.chunk",
-			"created": resp.Created,
-			"model":   resp.Model,
-			"choices": []map[string]any{
-				{
-					"index":         0,
-					"delta":         delta,
-					"finish_reason": finishReason,
-				},
-			},
-		}
-		chunkBytes, _ := json.Marshal(chunk)
-		return writeChunk(fmt.Sprintf("data: %s\n\n", chunkBytes))
-	}
-
-	choice := resp.Choices[0]
-	if len(choice.Message.ToolCalls) > 0 {
-		toolCalls := make([]openAIToolCallDelta, 0, len(choice.Message.ToolCalls))
-		for i, toolCall := range choice.Message.ToolCalls {
-			toolCalls = append(toolCalls, openAIToolCallDelta{
-				Index:    i,
-				ID:       toolCall.ID,
-				Type:     toolCall.Type,
-				Function: toolCall.Function,
-			})
-		}
-		if !writeStreamChunk(map[string]any{
-			"role":       "assistant",
-			"tool_calls": toolCalls,
-		}, nil) {
-			return
-		}
-	} else {
-		totalDuration := s.randomStreamDuration()
-		if totalDuration == 0 {
-			if !writeStreamChunk(map[string]any{
-				"role":    "assistant",
-				"content": choice.Message.Content,
-			}, nil) {
-				return
-			}
-		} else {
-			first := true
-			if !streamPacedChunks(ctx, totalDuration, s.streamContentChunks(choice.Message.Content), func(chunk string) bool {
-				delta := map[string]any{
-					"content": chunk,
-				}
-				if first {
-					delta["role"] = "assistant"
-					first = false
-				}
-				return writeStreamChunk(delta, nil)
-			}) {
-				return
-			}
-		}
-	}
-
-	if !writeStreamChunk(map[string]any{}, &choice.FinishReason) {
-		return
-	}
-	_ = writeChunk("data: [DONE]\n\n")
 }
 
 func (s *Server) sendResponsesStream(ctx context.Context, w http.ResponseWriter, resp responsesResponse) {

--- a/scaletest/llmmock/server.go
+++ b/scaletest/llmmock/server.go
@@ -2,9 +2,12 @@ package llmmock
 
 import (
 	"context"
+	crand "crypto/rand"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"strings"
@@ -24,15 +27,36 @@ import (
 	"github.com/coder/coder/v2/coderd/tracing"
 )
 
+const (
+	openAIDefaultResponseText          = "This is a mock response from OpenAI."
+	openAIResponsesDefaultResponseText = "This is a mock response from OpenAI Responses."
+	anthropicDefaultResponseText       = "This is a mock response from Anthropic."
+	mockInputTokens                    = 10
+	mockOutputTokens                   = 5
+	// streamFixedWindowSize makes large payload streams predictable and not whitespace-dependent.
+	streamFixedWindowSize = 10
+)
+
+func responseText(responsePayloadSize int, fallback string) string {
+	if responsePayloadSize > 0 {
+		return strings.Repeat("x", responsePayloadSize)
+	}
+	return fallback
+}
+
 // Server wraps the LLM mock server and provides an HTTP API to retrieve requests.
 type Server struct {
-	httpServer   *http.Server
-	httpListener net.Listener
-	logger       slog.Logger
+	httpServer        *http.Server
+	httpListener      net.Listener
+	cancelHTTPContext context.CancelFunc
+	logger            slog.Logger
 
 	address             string
 	artificialLatency   time.Duration
 	responsePayloadSize int
+	minStreamDuration   time.Duration
+	maxStreamDuration   time.Duration
+	toolCallConfig      toolCallConfig
 
 	tracerProvider trace.TracerProvider
 	closeTracing   func(context.Context) error
@@ -43,6 +67,11 @@ type Config struct {
 	Logger              slog.Logger
 	ArtificialLatency   time.Duration
 	ResponsePayloadSize int
+	MinStreamDuration   time.Duration
+	MaxStreamDuration   time.Duration
+	MinToolCallsPerTurn int
+	MaxToolCallsPerTurn int
+	ToolCallCommand     string
 
 	PprofEnable  bool
 	PprofAddress string
@@ -51,26 +80,53 @@ type Config struct {
 }
 
 type llmRequest struct {
-	Model  string `json:"model"`
-	Stream bool   `json:"stream,omitempty"`
+	Model    string          `json:"model"`
+	Messages []openAIMessage `json:"messages,omitempty"`
+	Tools    []openAITool    `json:"tools,omitempty"`
+	Stream   bool            `json:"stream,omitempty"`
 }
 
 type openAIMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role       string           `json:"role"`
+	Content    string           `json:"content,omitempty"`
+	ToolCalls  []openAIToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string           `json:"tool_call_id,omitempty"`
+}
+
+type openAITool struct {
+	Type     string             `json:"type"`
+	Function openAIToolFunction `json:"function"`
+}
+
+type openAIToolFunction struct {
+	Name string `json:"name"`
+}
+
+type openAIToolCall struct {
+	ID       string                 `json:"id,omitempty"`
+	Type     string                 `json:"type,omitempty"`
+	Function openAIToolCallFunction `json:"function,omitempty"`
+	Index    int                    `json:"index"`
+}
+
+type openAIToolCallFunction struct {
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments,omitempty"`
+}
+
+type openAIResponseChoice struct {
+	Index        int           `json:"index"`
+	Message      openAIMessage `json:"message"`
+	FinishReason string        `json:"finish_reason"`
 }
 
 type openAIResponse struct {
-	ID      string `json:"id"`
-	Object  string `json:"object"`
-	Created int64  `json:"created"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index        int           `json:"index"`
-		Message      openAIMessage `json:"message"`
-		FinishReason string        `json:"finish_reason"`
-	} `json:"choices"`
-	Usage struct {
+	ID      string                 `json:"id"`
+	Object  string                 `json:"object"`
+	Created int64                  `json:"created"`
+	Model   string                 `json:"model"`
+	Choices []openAIResponseChoice `json:"choices"`
+	Usage   struct {
 		PromptTokens     int `json:"prompt_tokens"`
 		CompletionTokens int `json:"completion_tokens"`
 		TotalTokens      int `json:"total_tokens"`
@@ -116,10 +172,32 @@ type anthropicResponse struct {
 }
 
 func (s *Server) Start(ctx context.Context, cfg Config) error {
+	if cfg.ToolCallCommand == "" {
+		cfg.ToolCallCommand = defaultToolCallCommand
+	}
+	if err := cfg.Validate(); err != nil {
+		return xerrors.Errorf("validate config: %w", err)
+	}
+
+	var seedBytes [8]byte
+	if _, err := crand.Read(seedBytes[:]); err != nil {
+		return xerrors.Errorf("generate tool-call seed: %w", err)
+	}
+	seed := binary.LittleEndian.Uint64(seedBytes[:])
+
 	s.address = cfg.Address
 	s.logger = cfg.Logger
 	s.artificialLatency = cfg.ArtificialLatency
 	s.responsePayloadSize = cfg.ResponsePayloadSize
+	s.minStreamDuration = cfg.MinStreamDuration
+	s.maxStreamDuration = cfg.MaxStreamDuration
+	s.toolCallConfig = toolCallConfig{
+		MinToolCallsPerTurn: cfg.MinToolCallsPerTurn,
+		MaxToolCallsPerTurn: cfg.MaxToolCallsPerTurn,
+		ToolCallCommand:     cfg.ToolCallCommand,
+		Seed:                seed,
+	}
+	s.logger.Info(ctx, "mock seed", slog.F("seed", seed))
 
 	if cfg.TraceEnable {
 		otel.SetTextMapPropagator(
@@ -148,6 +226,9 @@ func (s *Server) Start(ctx context.Context, cfg Config) error {
 }
 
 func (s *Server) Stop() error {
+	if s.cancelHTTPContext != nil {
+		s.cancelHTTPContext()
+	}
 	if s.httpServer != nil {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -169,6 +250,78 @@ func (s *Server) APIAddress() string {
 	return fmt.Sprintf("http://%s", s.httpListener.Addr().String())
 }
 
+func (s *Server) randomStreamDuration() time.Duration {
+	if s.minStreamDuration == 0 && s.maxStreamDuration == 0 {
+		return 0
+	}
+
+	delta := s.maxStreamDuration - s.minStreamDuration
+	//nolint:gosec // This is a scaletest mock, not security-sensitive.
+	return s.minStreamDuration + time.Duration(rand.Int64N(int64(delta+1)))
+}
+
+func (s *Server) streamPacedChunks(ctx context.Context, totalDuration time.Duration, content string, emit func(isFirst bool, chunk string) bool) bool {
+	var chunks []string
+	if s.responsePayloadSize > 0 {
+		chunks = streamContentFixedWindows(content)
+	} else {
+		fields := strings.Fields(content)
+		if len(fields) == 0 {
+			chunks = streamContentFixedWindows(content)
+		} else {
+			chunks = make([]string, 0, len(fields))
+			for i, field := range fields {
+				if i > 0 {
+					field = " " + field
+				}
+				chunks = append(chunks, field)
+			}
+		}
+	}
+
+	if len(chunks) <= 1 {
+		return emit(true, chunks[0])
+	}
+
+	delay := totalDuration / time.Duration(len(chunks)-1)
+	for i, chunk := range chunks {
+		if !emit(i == 0, chunk) {
+			return false
+		}
+		if i == len(chunks)-1 || delay <= 0 {
+			continue
+		}
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return false
+		case <-timer.C:
+		}
+	}
+	return true
+}
+
+func streamContentFixedWindows(content string) []string {
+	if content == "" {
+		return []string{""}
+	}
+
+	chunks := make([]string, 0, (len(content)+streamFixedWindowSize-1)/streamFixedWindowSize)
+	for start := 0; start < len(content); start += streamFixedWindowSize {
+		end := min(start+streamFixedWindowSize, len(content))
+		chunks = append(chunks, content[start:end])
+	}
+
+	return chunks
+}
+
 func (s *Server) startAPIServer(ctx context.Context) error {
 	mux := http.NewServeMux()
 
@@ -181,9 +334,14 @@ func (s *Server) startAPIServer(ctx context.Context) error {
 		handler = s.tracingMiddleware(handler)
 	}
 
+	baseCtx, cancelHTTPContext := context.WithCancel(ctx)
+	s.cancelHTTPContext = cancelHTTPContext
 	s.httpServer = &http.Server{
 		Handler:           handler,
 		ReadHeaderTimeout: 10 * time.Second,
+		BaseContext: func(net.Listener) context.Context {
+			return baseCtx
+		},
 	}
 
 	listener, err := net.Listen("tcp", s.address)
@@ -226,55 +384,33 @@ func (s *Server) handleOpenAIWithLabels(w http.ResponseWriter, r *http.Request) 
 		time.Sleep(s.artificialLatency)
 	}
 
-	var resp openAIResponse
-	resp.ID = fmt.Sprintf("chatcmpl-%s", requestID.String()[:8])
-	resp.Object = "chat.completion"
-	resp.Created = now.Unix()
-	resp.Model = req.Model
-
-	var responseContent string
-	if s.responsePayloadSize > 0 {
-		pattern := "x"
-		repeated := strings.Repeat(pattern, s.responsePayloadSize)
-		responseContent = repeated[:s.responsePayloadSize]
-	} else {
-		responseContent = "This is a mock response from OpenAI."
+	resp, err := buildOpenAIResponse(req, requestID, now, s.responsePayloadSize, r.Header.Get(coderChatIDHeader), s.toolCallConfig)
+	if err != nil {
+		s.logger.Error(ctx, "failed to build OpenAI response", slog.Error(err))
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
-
-	resp.Choices = []struct {
-		Index        int           `json:"index"`
-		Message      openAIMessage `json:"message"`
-		FinishReason string        `json:"finish_reason"`
-	}{
-		{
-			Index: 0,
-			Message: openAIMessage{
-				Role:    "assistant",
-				Content: responseContent,
-			},
-			FinishReason: "stop",
-		},
-	}
-
-	resp.Usage.PromptTokens = 10
-	resp.Usage.CompletionTokens = 5
-	resp.Usage.TotalTokens = 15
-
-	responseBody, _ := json.Marshal(resp)
 
 	if req.Stream {
 		s.sendOpenAIStream(ctx, w, resp)
-	} else {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write(responseBody); err != nil {
-			s.logger.Error(ctx, "failed to write OpenAI response",
-				slog.F("request_id", requestID),
-				slog.Error(err),
-				slog.F("error_type", "write_error"),
-				slog.F("likely_cause", "network_error"),
-			)
-		}
+		return
+	}
+
+	responseBody, err := json.Marshal(resp)
+	if err != nil {
+		s.logger.Error(ctx, "failed to marshal OpenAI response", slog.Error(err))
+		http.Error(w, "failed to marshal response", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(responseBody); err != nil {
+		s.logger.Error(ctx, "failed to write OpenAI response",
+			slog.F("request_id", requestID),
+			slog.Error(err),
+			slog.F("error_type", "write_error"),
+			slog.F("likely_cause", "network_error"),
+		)
 	}
 }
 
@@ -315,14 +451,7 @@ func (s *Server) handleResponsesWithLabels(w http.ResponseWriter, r *http.Reques
 	resp.Created = now.Unix()
 	resp.Model = req.Model
 
-	var responseContent string
-	if s.responsePayloadSize > 0 {
-		pattern := "x"
-		repeated := strings.Repeat(pattern, s.responsePayloadSize)
-		responseContent = repeated[:s.responsePayloadSize]
-	} else {
-		responseContent = "This is a mock response from OpenAI Responses."
-	}
+	assistantText := responseText(s.responsePayloadSize, openAIResponsesDefaultResponseText)
 
 	resp.Output = []struct {
 		ID      string `json:"id,omitempty"`
@@ -343,31 +472,36 @@ func (s *Server) handleResponsesWithLabels(w http.ResponseWriter, r *http.Reques
 			}{
 				{
 					Type: "output_text",
-					Text: responseContent,
+					Text: assistantText,
 				},
 			},
 		},
 	}
 
-	resp.Usage.InputTokens = 10
-	resp.Usage.OutputTokens = 5
-	resp.Usage.TotalTokens = 15
-
-	responseBody, _ := json.Marshal(resp)
+	resp.Usage.InputTokens = mockInputTokens
+	resp.Usage.OutputTokens = mockOutputTokens
+	resp.Usage.TotalTokens = mockInputTokens + mockOutputTokens
 
 	if req.Stream {
 		s.sendResponsesStream(ctx, w, resp)
-	} else {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write(responseBody); err != nil {
-			s.logger.Error(ctx, "failed to write OpenAI responses response",
-				slog.F("request_id", requestID),
-				slog.Error(err),
-				slog.F("error_type", "write_error"),
-				slog.F("likely_cause", "network_error"),
-			)
-		}
+		return
+	}
+
+	responseBody, err := json.Marshal(resp)
+	if err != nil {
+		s.logger.Error(ctx, "failed to marshal OpenAI responses response", slog.Error(err))
+		http.Error(w, "failed to marshal response", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(responseBody); err != nil {
+		s.logger.Error(ctx, "failed to write OpenAI responses response",
+			slog.F("request_id", requestID),
+			slog.Error(err),
+			slog.F("error_type", "write_error"),
+			slog.F("likely_cause", "network_error"),
+		)
 	}
 }
 
@@ -392,14 +526,7 @@ func (s *Server) handleAnthropicWithLabels(w http.ResponseWriter, r *http.Reques
 	resp.Type = "message"
 	resp.Role = "assistant"
 
-	var responseText string
-	if s.responsePayloadSize > 0 {
-		pattern := "x"
-		repeated := strings.Repeat(pattern, s.responsePayloadSize)
-		responseText = repeated[:s.responsePayloadSize]
-	} else {
-		responseText = "This is a mock response from Anthropic."
-	}
+	assistantText := responseText(s.responsePayloadSize, anthropicDefaultResponseText)
 
 	resp.Content = []struct {
 		Type string `json:"type"`
@@ -407,30 +534,35 @@ func (s *Server) handleAnthropicWithLabels(w http.ResponseWriter, r *http.Reques
 	}{
 		{
 			Type: "text",
-			Text: responseText,
+			Text: assistantText,
 		},
 	}
 	resp.Model = req.Model
 	resp.StopReason = "end_turn"
-	resp.Usage.InputTokens = 10
-	resp.Usage.OutputTokens = 5
-
-	responseBody, _ := json.Marshal(resp)
+	resp.Usage.InputTokens = mockInputTokens
+	resp.Usage.OutputTokens = mockOutputTokens
 
 	if req.Stream {
 		s.sendAnthropicStream(ctx, w, resp)
-	} else {
-		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("anthropic-version", "2023-06-01")
-		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write(responseBody); err != nil {
-			s.logger.Error(ctx, "failed to write Anthropic response",
-				slog.F("request_id", requestID),
-				slog.Error(err),
-				slog.F("error_type", "write_error"),
-				slog.F("likely_cause", "network_error"),
-			)
-		}
+		return
+	}
+
+	responseBody, err := json.Marshal(resp)
+	if err != nil {
+		s.logger.Error(ctx, "failed to marshal Anthropic response", slog.Error(err))
+		http.Error(w, "failed to marshal response", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("anthropic-version", "2023-06-01")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(responseBody); err != nil {
+		s.logger.Error(ctx, "failed to write Anthropic response",
+			slog.F("request_id", requestID),
+			slog.Error(err),
+			slog.F("error_type", "write_error"),
+			slog.F("likely_cause", "network_error"),
+		)
 	}
 }
 
@@ -462,44 +594,59 @@ func (s *Server) sendOpenAIStream(ctx context.Context, w http.ResponseWriter, re
 		return true
 	}
 
-	// Send initial chunk
-	chunk := map[string]interface{}{
-		"id":      resp.ID,
-		"object":  "chat.completion.chunk",
-		"created": resp.Created,
-		"model":   resp.Model,
-		"choices": []map[string]interface{}{
-			{
-				"index": 0,
-				"delta": map[string]interface{}{
-					"role":    "assistant",
-					"content": resp.Choices[0].Message.Content,
+	// Non-terminal chunks pass nil so JSON emits null for finish_reason.
+	writeStreamChunk := func(delta map[string]interface{}, finishReason interface{}) bool {
+		chunk := map[string]interface{}{
+			"id":      resp.ID,
+			"object":  "chat.completion.chunk",
+			"created": resp.Created,
+			"model":   resp.Model,
+			"choices": []map[string]interface{}{
+				{
+					"index":         0,
+					"delta":         delta,
+					"finish_reason": finishReason,
 				},
-				"finish_reason": nil,
 			},
-		},
-	}
-	chunkBytes, _ := json.Marshal(chunk)
-	if !writeChunk(fmt.Sprintf("data: %s\n\n", chunkBytes)) {
-		return
+		}
+		chunkBytes, _ := json.Marshal(chunk)
+		return writeChunk(fmt.Sprintf("data: %s\n\n", chunkBytes))
 	}
 
-	// Send final chunk
-	finalChunk := map[string]interface{}{
-		"id":      resp.ID,
-		"object":  "chat.completion.chunk",
-		"created": resp.Created,
-		"model":   resp.Model,
-		"choices": []map[string]interface{}{
-			{
-				"index":         0,
-				"delta":         map[string]interface{}{},
-				"finish_reason": resp.Choices[0].FinishReason,
-			},
-		},
+	choice := resp.Choices[0]
+	switch {
+	case len(choice.Message.ToolCalls) > 0:
+		if !writeStreamChunk(map[string]interface{}{
+			"role":       "assistant",
+			"tool_calls": choice.Message.ToolCalls,
+		}, nil) {
+			return
+		}
+	default:
+		totalDuration := s.randomStreamDuration()
+		if totalDuration == 0 {
+			if !writeStreamChunk(map[string]interface{}{
+				"role":    "assistant",
+				"content": choice.Message.Content,
+			}, nil) {
+				return
+			}
+			break
+		}
+		if !s.streamPacedChunks(ctx, totalDuration, choice.Message.Content, func(isFirst bool, chunk string) bool {
+			delta := map[string]interface{}{
+				"content": chunk,
+			}
+			if isFirst {
+				delta["role"] = "assistant"
+			}
+			return writeStreamChunk(delta, nil)
+		}) {
+			return
+		}
 	}
-	finalChunkBytes, _ := json.Marshal(finalChunk)
-	if !writeChunk(fmt.Sprintf("data: %s\n\n", finalChunkBytes)) {
+
+	if !writeStreamChunk(map[string]interface{}{}, choice.FinishReason) {
 		return
 	}
 	writeChunk("data: [DONE]\n\n")
@@ -533,18 +680,37 @@ func (s *Server) sendResponsesStream(ctx context.Context, w http.ResponseWriter,
 		return true
 	}
 
-	deltaChunk := map[string]interface{}{
-		"id":            resp.ID,
-		"object":        "response.output_text.delta",
-		"created":       resp.Created,
-		"model":         resp.Model,
-		"output_index":  0,
-		"content_index": 0,
-		"delta":         resp.Output[0].Content[0].Text,
-	}
-	deltaBytes, _ := json.Marshal(deltaChunk)
-	if !writeChunk(fmt.Sprintf("data: %s\n\n", deltaBytes)) {
-		return
+	totalDuration := s.randomStreamDuration()
+	if totalDuration == 0 {
+		deltaChunk := map[string]interface{}{
+			"id":            resp.ID,
+			"object":        "response.output_text.delta",
+			"created":       resp.Created,
+			"model":         resp.Model,
+			"output_index":  0,
+			"content_index": 0,
+			"delta":         resp.Output[0].Content[0].Text,
+		}
+		deltaBytes, _ := json.Marshal(deltaChunk)
+		if !writeChunk(fmt.Sprintf("data: %s\n\n", deltaBytes)) {
+			return
+		}
+	} else {
+		if !s.streamPacedChunks(ctx, totalDuration, resp.Output[0].Content[0].Text, func(_ bool, chunk string) bool {
+			deltaChunk := map[string]interface{}{
+				"id":            resp.ID,
+				"object":        "response.output_text.delta",
+				"created":       resp.Created,
+				"model":         resp.Model,
+				"output_index":  0,
+				"content_index": 0,
+				"delta":         chunk,
+			}
+			deltaBytes, _ := json.Marshal(deltaChunk)
+			return writeChunk(fmt.Sprintf("data: %s\n\n", deltaBytes))
+		}) {
+			return
+		}
 	}
 
 	finalChunk := map[string]interface{}{
@@ -597,6 +763,8 @@ func (s *Server) sendAnthropicStream(ctx context.Context, w http.ResponseWriter,
 		return true
 	}
 
+	totalDuration := s.randomStreamDuration()
+
 	startEventType := "message_start"
 	startEvent := map[string]interface{}{
 		"type": startEventType,
@@ -614,12 +782,16 @@ func (s *Server) sendAnthropicStream(ctx context.Context, w http.ResponseWriter,
 
 	// Send content_block_start event
 	contentStartEventType := "content_block_start"
+	contentStartText := resp.Content[0].Text
+	if totalDuration > 0 {
+		contentStartText = ""
+	}
 	contentStartEvent := map[string]interface{}{
 		"type":  contentStartEventType,
 		"index": 0,
 		"content_block": map[string]interface{}{
 			"type": "text",
-			"text": resp.Content[0].Text,
+			"text": contentStartText,
 		},
 	}
 	contentStartBytes, _ := json.Marshal(contentStartEvent)
@@ -627,19 +799,36 @@ func (s *Server) sendAnthropicStream(ctx context.Context, w http.ResponseWriter,
 		return
 	}
 
-	// Send content_block_delta event
+	// Send content_block_delta event(s)
 	deltaEventType := "content_block_delta"
-	deltaEvent := map[string]interface{}{
-		"type":  deltaEventType,
-		"index": 0,
-		"delta": map[string]interface{}{
-			"type": "text_delta",
-			"text": resp.Content[0].Text,
-		},
-	}
-	deltaBytes, _ := json.Marshal(deltaEvent)
-	if !writeChunk(deltaEventType, deltaBytes) {
-		return
+	if totalDuration == 0 {
+		deltaEvent := map[string]interface{}{
+			"type":  deltaEventType,
+			"index": 0,
+			"delta": map[string]interface{}{
+				"type": "text_delta",
+				"text": resp.Content[0].Text,
+			},
+		}
+		deltaBytes, _ := json.Marshal(deltaEvent)
+		if !writeChunk(deltaEventType, deltaBytes) {
+			return
+		}
+	} else {
+		if !s.streamPacedChunks(ctx, totalDuration, resp.Content[0].Text, func(_ bool, chunk string) bool {
+			deltaEvent := map[string]interface{}{
+				"type":  deltaEventType,
+				"index": 0,
+				"delta": map[string]interface{}{
+					"type": "text_delta",
+					"text": chunk,
+				},
+			}
+			deltaBytes, _ := json.Marshal(deltaEvent)
+			return writeChunk(deltaEventType, deltaBytes)
+		}) {
+			return
+		}
 	}
 
 	// Send content_block_stop event

--- a/scaletest/llmmock/server.go
+++ b/scaletest/llmmock/server.go
@@ -551,11 +551,6 @@ func (s *Server) handleAnthropicWithLabels(w http.ResponseWriter, r *http.Reques
 }
 
 func (s *Server) sendResponsesStream(ctx context.Context, w http.ResponseWriter, resp responsesResponse) {
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-	w.WriteHeader(http.StatusOK)
-
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		s.logger.Error(ctx, "responseWriter does not support flushing",
@@ -563,6 +558,11 @@ func (s *Server) sendResponsesStream(ctx context.Context, w http.ResponseWriter,
 		)
 		return
 	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
 
 	writeChunk := func(data string) bool {
 		if _, err := fmt.Fprintf(w, "%s", data); err != nil {
@@ -626,12 +626,6 @@ func (s *Server) sendResponsesStream(ctx context.Context, w http.ResponseWriter,
 }
 
 func (s *Server) sendAnthropicStream(ctx context.Context, w http.ResponseWriter, resp anthropicResponse) {
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("anthropic-version", "2023-06-01")
-	w.WriteHeader(http.StatusOK)
-
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		s.logger.Error(ctx, "responseWriter does not support flushing",
@@ -639,6 +633,12 @@ func (s *Server) sendAnthropicStream(ctx context.Context, w http.ResponseWriter,
 		)
 		return
 	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("anthropic-version", "2023-06-01")
+	w.WriteHeader(http.StatusOK)
 
 	writeChunk := func(eventType string, data []byte) bool {
 		if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventType, data); err != nil {
@@ -673,16 +673,12 @@ func (s *Server) sendAnthropicStream(ctx context.Context, w http.ResponseWriter,
 	}
 
 	contentStartEventType := "content_block_start"
-	var contentStartText string
-	if !paced {
-		contentStartText = resp.Content[0].Text
-	}
 	contentStartEvent := map[string]any{
 		"type":  contentStartEventType,
 		"index": 0,
 		"content_block": map[string]any{
 			"type": "text",
-			"text": contentStartText,
+			"text": "",
 		},
 	}
 	contentStartBytes, _ := json.Marshal(contentStartEvent)

--- a/scaletest/llmmock/server.go
+++ b/scaletest/llmmock/server.go
@@ -74,17 +74,24 @@ type Config struct {
 }
 
 type llmRequest struct {
-	Model    string          `json:"model"`
-	Messages []openAIMessage `json:"messages,omitempty"`
-	Tools    []openAITool    `json:"tools,omitempty"`
-	Stream   bool            `json:"stream,omitempty"`
+	Model    string              `json:"model"`
+	Messages []llmRequestMessage `json:"messages,omitempty"`
+	Tools    []openAITool        `json:"tools,omitempty"`
+	Stream   bool                `json:"stream,omitempty"`
 }
 
+// llmRequestMessage decodes only the request message fields the mock
+// inspects. Content is intentionally omitted: providers send it as either a
+// string or an array of content blocks, and the mock never reads it.
+type llmRequestMessage struct {
+	Role string `json:"role"`
+}
+
+// openAIMessage is the assistant message shape used in responses.
 type openAIMessage struct {
-	Role       string           `json:"role"`
-	Content    string           `json:"content,omitempty"`
-	ToolCalls  []openAIToolCall `json:"tool_calls,omitempty"`
-	ToolCallID string           `json:"tool_call_id,omitempty"`
+	Role      string           `json:"role"`
+	Content   string           `json:"content,omitempty"`
+	ToolCalls []openAIToolCall `json:"tool_calls,omitempty"`
 }
 
 type openAITool struct {

--- a/scaletest/llmmock/server.go
+++ b/scaletest/llmmock/server.go
@@ -33,8 +33,9 @@ const (
 	anthropicDefaultResponseText       = "This is a mock response from Anthropic."
 	mockInputTokens                    = 10
 	mockOutputTokens                   = 5
-	// streamFixedWindowSize keeps large payload chunks predictable.
-	streamFixedWindowSize = 10
+	// streamFixedWindowSize is the number of bytes per delta for fixed-size
+	// payload streams (when responsePayloadSize is set).
+	streamFixedWindowSize = 1024
 )
 
 // Server wraps the LLM mock server and provides an HTTP API to retrieve requests.
@@ -65,7 +66,6 @@ type Config struct {
 	ResponsePayloadSize int
 	ToolCallsPerTurn    int
 	// ToolCallCommand is the command sent in generated execute tool calls.
-	// Empty uses the default tool-call command.
 	ToolCallCommand string
 
 	TraceEnable bool
@@ -163,11 +163,6 @@ type anthropicResponse struct {
 }
 
 func (s *Server) Start(ctx context.Context, cfg Config) error {
-	toolCallCommand := cfg.ToolCallCommand
-	if toolCallCommand == "" {
-		toolCallCommand = defaultToolCallCommand
-	}
-
 	s.address = cfg.Address
 	s.logger = cfg.Logger
 	s.artificialLatency = cfg.ArtificialLatency
@@ -175,7 +170,7 @@ func (s *Server) Start(ctx context.Context, cfg Config) error {
 	s.maxStreamDuration = cfg.MaxStreamDuration
 	s.responsePayloadSize = cfg.ResponsePayloadSize
 	s.toolCallsPerTurn = cfg.ToolCallsPerTurn
-	s.toolCallCommand = toolCallCommand
+	s.toolCallCommand = cfg.ToolCallCommand
 
 	if cfg.TraceEnable {
 		otel.SetTextMapPropagator(
@@ -245,22 +240,31 @@ func (s *Server) randomStreamDuration() time.Duration {
 
 	delta := s.maxStreamDuration - s.minStreamDuration
 	//nolint:gosec // This is a scaletest mock, not security-sensitive.
-	return s.minStreamDuration + time.Duration(rand.Int64N(int64(delta+1)))
+	return s.minStreamDuration + time.Duration(rand.Int64N(int64(delta)))
 }
 
-func (s *Server) streamContentChunks(content string) []string {
+// streamPacedContent emits content as paced chunks. Fixed-size payloads use
+// byte windows of streamFixedWindowSize and iterate offsets directly; default
+// text is split on spaces.
+func (s *Server) streamPacedContent(ctx context.Context, totalDuration time.Duration, content string, emit func(chunk string) bool) bool {
 	if content == "" {
-		return []string{""}
+		return emit("")
 	}
 	if s.responsePayloadSize > 0 {
-		chunks := make([]string, 0, (len(content)+streamFixedWindowSize-1)/streamFixedWindowSize)
-		for start := 0; start < len(content); start += streamFixedWindowSize {
+		n := (len(content) + streamFixedWindowSize - 1) / streamFixedWindowSize
+		return streamPacedChunks(ctx, totalDuration, n, func(i int) string {
+			start := i * streamFixedWindowSize
 			end := min(start+streamFixedWindowSize, len(content))
-			chunks = append(chunks, content[start:end])
-		}
-		return chunks
+			return content[start:end]
+		}, emit)
 	}
+	chunks := streamWordChunks(content)
+	return streamPacedChunks(ctx, totalDuration, len(chunks), func(i int) string {
+		return chunks[i]
+	}, emit)
+}
 
+func streamWordChunks(content string) []string {
 	chunks := strings.SplitAfter(content, " ")
 	if chunks[len(chunks)-1] == "" {
 		chunks = chunks[:len(chunks)-1]
@@ -268,32 +272,27 @@ func (s *Server) streamContentChunks(content string) []string {
 	return chunks
 }
 
-func streamPacedChunks(ctx context.Context, totalDuration time.Duration, chunks []string, emit func(chunk string) bool) bool {
-	if len(chunks) == 0 {
+func streamPacedChunks(ctx context.Context, totalDuration time.Duration, n int, chunk func(i int) string, emit func(chunk string) bool) bool {
+	if n == 0 {
 		return emit("")
 	}
-	if len(chunks) == 1 {
-		return emit(chunks[0])
+	if n == 1 {
+		return emit(chunk(0))
 	}
 
-	delay := totalDuration / time.Duration(len(chunks)-1)
-	for i, chunk := range chunks {
-		if !emit(chunk) {
+	delay := totalDuration / time.Duration(n-1)
+	for i := range n {
+		if !emit(chunk(i)) {
 			return false
 		}
-		if i == len(chunks)-1 || delay <= 0 {
+		if i == n-1 || delay <= 0 {
 			continue
 		}
 
 		timer := time.NewTimer(delay)
 		select {
 		case <-ctx.Done():
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
+			timer.Stop()
 			return false
 		case <-timer.C:
 		}
@@ -363,12 +362,7 @@ func (s *Server) handleOpenAIWithLabels(w http.ResponseWriter, r *http.Request) 
 		time.Sleep(s.artificialLatency)
 	}
 
-	choice, err := s.buildOpenAIChoice(req)
-	if err != nil {
-		s.logger.Error(ctx, "failed to build OpenAI response", slog.Error(err))
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
+	choice := s.buildOpenAIChoice(req)
 
 	resp := openAIResponse{
 		ID:      fmt.Sprintf("chatcmpl-%s", requestID.String()[:8]),
@@ -605,7 +599,7 @@ func (s *Server) sendResponsesStream(ctx context.Context, w http.ResponseWriter,
 			return
 		}
 	} else {
-		if !streamPacedChunks(ctx, totalDuration, s.streamContentChunks(text), writeDelta) {
+		if !s.streamPacedContent(ctx, totalDuration, text, writeDelta) {
 			return
 		}
 	}
@@ -714,7 +708,7 @@ func (s *Server) sendAnthropicStream(ctx context.Context, w http.ResponseWriter,
 			return
 		}
 	} else {
-		if !streamPacedChunks(ctx, totalDuration, s.streamContentChunks(resp.Content[0].Text), writeDelta) {
+		if !s.streamPacedContent(ctx, totalDuration, resp.Content[0].Text, writeDelta) {
 			return
 		}
 	}

--- a/scaletest/llmmock/server.go
+++ b/scaletest/llmmock/server.go
@@ -27,33 +27,28 @@ import (
 
 const (
 	openAIDefaultResponseText          = "This is a mock response from OpenAI."
+	openAIStopFinishReason             = "stop"
+	openAIToolCallFinishReason         = "tool_calls"
 	openAIResponsesDefaultResponseText = "This is a mock response from OpenAI Responses."
 	anthropicDefaultResponseText       = "This is a mock response from Anthropic."
 	mockInputTokens                    = 10
 	mockOutputTokens                   = 5
-	// streamFixedWindowSize makes large payload streams predictable and not whitespace-dependent.
+	// streamFixedWindowSize keeps large payload chunks predictable.
 	streamFixedWindowSize = 10
 )
 
-func responseText(responsePayloadSize int, fallback string) string {
-	if responsePayloadSize > 0 {
-		return strings.Repeat("x", responsePayloadSize)
-	}
-	return fallback
-}
-
 // Server wraps the LLM mock server and provides an HTTP API to retrieve requests.
 type Server struct {
-	httpServer        *http.Server
-	httpListener      net.Listener
-	cancelHTTPContext context.CancelFunc
-	logger            slog.Logger
+	httpServer   *http.Server
+	httpListener net.Listener
+	httpCancel   context.CancelFunc
+	logger       slog.Logger
 
 	address             string
 	artificialLatency   time.Duration
-	responsePayloadSize int
 	minStreamDuration   time.Duration
 	maxStreamDuration   time.Duration
+	responsePayloadSize int
 	toolCallsPerTurn    int
 	toolCallCommand     string
 
@@ -65,11 +60,13 @@ type Config struct {
 	Address             string
 	Logger              slog.Logger
 	ArtificialLatency   time.Duration
-	ResponsePayloadSize int
 	MinStreamDuration   time.Duration
 	MaxStreamDuration   time.Duration
+	ResponsePayloadSize int
 	ToolCallsPerTurn    int
-	ToolCallCommand     string
+	// ToolCallCommand is the command sent in generated execute tool calls.
+	// Empty uses the default tool-call command.
+	ToolCallCommand string
 
 	TraceEnable bool
 }
@@ -98,10 +95,16 @@ type openAIToolFunction struct {
 }
 
 type openAIToolCall struct {
+	ID       string                 `json:"id"`
+	Type     string                 `json:"type"`
+	Function openAIToolCallFunction `json:"function"`
+}
+
+type openAIToolCallDelta struct {
+	Index    int                    `json:"index"`
 	ID       string                 `json:"id,omitempty"`
 	Type     string                 `json:"type,omitempty"`
-	Function openAIToolCallFunction `json:"function,omitempty"`
-	Index    int                    `json:"index"`
+	Function openAIToolCallFunction `json:"function"`
 }
 
 type openAIToolCallFunction struct {
@@ -167,17 +170,19 @@ type anthropicResponse struct {
 }
 
 func (s *Server) Start(ctx context.Context, cfg Config) error {
-	if cfg.ToolCallCommand == "" {
-		cfg.ToolCallCommand = DefaultToolCallCommand
+	toolCallCommand := cfg.ToolCallCommand
+	if toolCallCommand == "" {
+		toolCallCommand = defaultToolCallCommand
 	}
+
 	s.address = cfg.Address
 	s.logger = cfg.Logger
 	s.artificialLatency = cfg.ArtificialLatency
-	s.responsePayloadSize = cfg.ResponsePayloadSize
 	s.minStreamDuration = cfg.MinStreamDuration
 	s.maxStreamDuration = cfg.MaxStreamDuration
+	s.responsePayloadSize = cfg.ResponsePayloadSize
 	s.toolCallsPerTurn = cfg.ToolCallsPerTurn
-	s.toolCallCommand = cfg.ToolCallCommand
+	s.toolCallCommand = toolCallCommand
 
 	if cfg.TraceEnable {
 		otel.SetTextMapPropagator(
@@ -206,8 +211,8 @@ func (s *Server) Start(ctx context.Context, cfg Config) error {
 }
 
 func (s *Server) Stop() error {
-	if s.cancelHTTPContext != nil {
-		s.cancelHTTPContext()
+	if s.httpCancel != nil {
+		s.httpCancel()
 	}
 	if s.httpServer != nil {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -230,6 +235,13 @@ func (s *Server) APIAddress() string {
 	return fmt.Sprintf("http://%s", s.httpListener.Addr().String())
 }
 
+func (s *Server) responseText(fallback string) string {
+	if s.responsePayloadSize > 0 {
+		return strings.Repeat("x", s.responsePayloadSize)
+	}
+	return fallback
+}
+
 func (s *Server) randomStreamDuration() time.Duration {
 	if s.minStreamDuration <= 0 || s.maxStreamDuration <= 0 {
 		return 0
@@ -243,32 +255,37 @@ func (s *Server) randomStreamDuration() time.Duration {
 	return s.minStreamDuration + time.Duration(rand.Int64N(int64(delta+1)))
 }
 
-func (s *Server) streamPacedChunks(ctx context.Context, totalDuration time.Duration, content string, emit func(isFirst bool, chunk string) bool) bool {
-	var chunks []string
+func (s *Server) streamContentChunks(content string) []string {
+	if content == "" {
+		return []string{""}
+	}
 	if s.responsePayloadSize > 0 {
-		chunks = streamContentFixedWindows(content)
-	} else {
-		fields := strings.Fields(content)
-		if len(fields) == 0 {
-			chunks = streamContentFixedWindows(content)
-		} else {
-			chunks = make([]string, 0, len(fields))
-			for i, field := range fields {
-				if i > 0 {
-					field = " " + field
-				}
-				chunks = append(chunks, field)
-			}
+		chunks := make([]string, 0, (len(content)+streamFixedWindowSize-1)/streamFixedWindowSize)
+		for start := 0; start < len(content); start += streamFixedWindowSize {
+			end := min(start+streamFixedWindowSize, len(content))
+			chunks = append(chunks, content[start:end])
 		}
+		return chunks
 	}
 
-	if len(chunks) <= 1 {
-		return emit(true, chunks[0])
+	chunks := strings.SplitAfter(content, " ")
+	if chunks[len(chunks)-1] == "" {
+		chunks = chunks[:len(chunks)-1]
+	}
+	return chunks
+}
+
+func streamPacedChunks(ctx context.Context, totalDuration time.Duration, chunks []string, emit func(chunk string) bool) bool {
+	if len(chunks) == 0 {
+		return emit("")
+	}
+	if len(chunks) == 1 {
+		return emit(chunks[0])
 	}
 
 	delay := totalDuration / time.Duration(len(chunks)-1)
 	for i, chunk := range chunks {
-		if !emit(i == 0, chunk) {
+		if !emit(chunk) {
 			return false
 		}
 		if i == len(chunks)-1 || delay <= 0 {
@@ -291,20 +308,6 @@ func (s *Server) streamPacedChunks(ctx context.Context, totalDuration time.Durat
 	return true
 }
 
-func streamContentFixedWindows(content string) []string {
-	if content == "" {
-		return []string{""}
-	}
-
-	chunks := make([]string, 0, (len(content)+streamFixedWindowSize-1)/streamFixedWindowSize)
-	for start := 0; start < len(content); start += streamFixedWindowSize {
-		end := min(start+streamFixedWindowSize, len(content))
-		chunks = append(chunks, content[start:end])
-	}
-
-	return chunks
-}
-
 func (s *Server) startAPIServer(ctx context.Context) error {
 	mux := http.NewServeMux()
 
@@ -317,8 +320,8 @@ func (s *Server) startAPIServer(ctx context.Context) error {
 		handler = s.tracingMiddleware(handler)
 	}
 
-	baseCtx, cancelHTTPContext := context.WithCancel(ctx)
-	s.cancelHTTPContext = cancelHTTPContext
+	baseCtx, httpCancel := context.WithCancel(ctx)
+	s.httpCancel = httpCancel
 	s.httpServer = &http.Server{
 		Handler:           handler,
 		ReadHeaderTimeout: 10 * time.Second,
@@ -445,7 +448,7 @@ func (s *Server) handleResponsesWithLabels(w http.ResponseWriter, r *http.Reques
 	resp.Created = now.Unix()
 	resp.Model = req.Model
 
-	assistantText := responseText(s.responsePayloadSize, openAIResponsesDefaultResponseText)
+	assistantText := s.responseText(openAIResponsesDefaultResponseText)
 
 	resp.Output = []struct {
 		ID      string `json:"id,omitempty"`
@@ -520,7 +523,7 @@ func (s *Server) handleAnthropicWithLabels(w http.ResponseWriter, r *http.Reques
 	resp.Type = "message"
 	resp.Role = "assistant"
 
-	assistantText := responseText(s.responsePayloadSize, anthropicDefaultResponseText)
+	assistantText := s.responseText(anthropicDefaultResponseText)
 
 	resp.Content = []struct {
 		Type string `json:"type"`
@@ -589,13 +592,13 @@ func (s *Server) sendOpenAIStream(ctx context.Context, w http.ResponseWriter, re
 	}
 
 	// Non-terminal chunks pass nil so JSON emits null for finish_reason.
-	writeStreamChunk := func(delta map[string]interface{}, finishReason interface{}) bool {
-		chunk := map[string]interface{}{
+	writeStreamChunk := func(delta map[string]any, finishReason *string) bool {
+		chunk := map[string]any{
 			"id":      resp.ID,
 			"object":  "chat.completion.chunk",
 			"created": resp.Created,
 			"model":   resp.Model,
-			"choices": []map[string]interface{}{
+			"choices": []map[string]any{
 				{
 					"index":         0,
 					"delta":         delta,
@@ -608,42 +611,52 @@ func (s *Server) sendOpenAIStream(ctx context.Context, w http.ResponseWriter, re
 	}
 
 	choice := resp.Choices[0]
-	switch {
-	case len(choice.Message.ToolCalls) > 0:
-		if !writeStreamChunk(map[string]interface{}{
+	if len(choice.Message.ToolCalls) > 0 {
+		toolCalls := make([]openAIToolCallDelta, 0, len(choice.Message.ToolCalls))
+		for i, toolCall := range choice.Message.ToolCalls {
+			toolCalls = append(toolCalls, openAIToolCallDelta{
+				Index:    i,
+				ID:       toolCall.ID,
+				Type:     toolCall.Type,
+				Function: toolCall.Function,
+			})
+		}
+		if !writeStreamChunk(map[string]any{
 			"role":       "assistant",
-			"tool_calls": choice.Message.ToolCalls,
+			"tool_calls": toolCalls,
 		}, nil) {
 			return
 		}
-	default:
+	} else {
 		totalDuration := s.randomStreamDuration()
 		if totalDuration == 0 {
-			if !writeStreamChunk(map[string]interface{}{
+			if !writeStreamChunk(map[string]any{
 				"role":    "assistant",
 				"content": choice.Message.Content,
 			}, nil) {
 				return
 			}
-			break
-		}
-		if !s.streamPacedChunks(ctx, totalDuration, choice.Message.Content, func(isFirst bool, chunk string) bool {
-			delta := map[string]interface{}{
-				"content": chunk,
+		} else {
+			first := true
+			if !streamPacedChunks(ctx, totalDuration, s.streamContentChunks(choice.Message.Content), func(chunk string) bool {
+				delta := map[string]any{
+					"content": chunk,
+				}
+				if first {
+					delta["role"] = "assistant"
+					first = false
+				}
+				return writeStreamChunk(delta, nil)
+			}) {
+				return
 			}
-			if isFirst {
-				delta["role"] = "assistant"
-			}
-			return writeStreamChunk(delta, nil)
-		}) {
-			return
 		}
 	}
 
-	if !writeStreamChunk(map[string]interface{}{}, choice.FinishReason) {
+	if !writeStreamChunk(map[string]any{}, &choice.FinishReason) {
 		return
 	}
-	writeChunk("data: [DONE]\n\n")
+	_ = writeChunk("data: [DONE]\n\n")
 }
 
 func (s *Server) sendResponsesStream(ctx context.Context, w http.ResponseWriter, resp responsesResponse) {
@@ -674,45 +687,38 @@ func (s *Server) sendResponsesStream(ctx context.Context, w http.ResponseWriter,
 		return true
 	}
 
-	totalDuration := s.randomStreamDuration()
-	if totalDuration == 0 {
-		deltaChunk := map[string]interface{}{
+	writeDelta := func(text string) bool {
+		deltaChunk := map[string]any{
 			"id":            resp.ID,
 			"object":        "response.output_text.delta",
 			"created":       resp.Created,
 			"model":         resp.Model,
 			"output_index":  0,
 			"content_index": 0,
-			"delta":         resp.Output[0].Content[0].Text,
+			"delta":         text,
 		}
 		deltaBytes, _ := json.Marshal(deltaChunk)
-		if !writeChunk(fmt.Sprintf("data: %s\n\n", deltaBytes)) {
+		return writeChunk(fmt.Sprintf("data: %s\n\n", deltaBytes))
+	}
+
+	text := resp.Output[0].Content[0].Text
+	totalDuration := s.randomStreamDuration()
+	if totalDuration == 0 {
+		if !writeDelta(text) {
 			return
 		}
 	} else {
-		if !s.streamPacedChunks(ctx, totalDuration, resp.Output[0].Content[0].Text, func(_ bool, chunk string) bool {
-			deltaChunk := map[string]interface{}{
-				"id":            resp.ID,
-				"object":        "response.output_text.delta",
-				"created":       resp.Created,
-				"model":         resp.Model,
-				"output_index":  0,
-				"content_index": 0,
-				"delta":         chunk,
-			}
-			deltaBytes, _ := json.Marshal(deltaChunk)
-			return writeChunk(fmt.Sprintf("data: %s\n\n", deltaBytes))
-		}) {
+		if !streamPacedChunks(ctx, totalDuration, s.streamContentChunks(text), writeDelta) {
 			return
 		}
 	}
 
-	finalChunk := map[string]interface{}{
+	finalChunk := map[string]any{
 		"id":      resp.ID,
 		"object":  "response.completed",
 		"created": resp.Created,
 		"model":   resp.Model,
-		"response": map[string]interface{}{
+		"response": map[string]any{
 			"id":      resp.ID,
 			"object":  resp.Object,
 			"created": resp.Created,
@@ -725,7 +731,7 @@ func (s *Server) sendResponsesStream(ctx context.Context, w http.ResponseWriter,
 	if !writeChunk(fmt.Sprintf("data: %s\n\n", finalBytes)) {
 		return
 	}
-	writeChunk("data: [DONE]\n\n")
+	_ = writeChunk("data: [DONE]\n\n")
 }
 
 func (s *Server) sendAnthropicStream(ctx context.Context, w http.ResponseWriter, resp anthropicResponse) {
@@ -758,11 +764,12 @@ func (s *Server) sendAnthropicStream(ctx context.Context, w http.ResponseWriter,
 	}
 
 	totalDuration := s.randomStreamDuration()
+	paced := totalDuration > 0
 
 	startEventType := "message_start"
-	startEvent := map[string]interface{}{
+	startEvent := map[string]any{
 		"type": startEventType,
-		"message": map[string]interface{}{
+		"message": map[string]any{
 			"id":    resp.ID,
 			"type":  resp.Type,
 			"role":  resp.Role,
@@ -774,16 +781,15 @@ func (s *Server) sendAnthropicStream(ctx context.Context, w http.ResponseWriter,
 		return
 	}
 
-	// Send content_block_start event
 	contentStartEventType := "content_block_start"
-	contentStartText := resp.Content[0].Text
-	if totalDuration > 0 {
-		contentStartText = ""
+	var contentStartText string
+	if !paced {
+		contentStartText = resp.Content[0].Text
 	}
-	contentStartEvent := map[string]interface{}{
+	contentStartEvent := map[string]any{
 		"type":  contentStartEventType,
 		"index": 0,
-		"content_block": map[string]interface{}{
+		"content_block": map[string]any{
 			"type": "text",
 			"text": contentStartText,
 		},
@@ -793,41 +799,31 @@ func (s *Server) sendAnthropicStream(ctx context.Context, w http.ResponseWriter,
 		return
 	}
 
-	// Send content_block_delta event(s)
 	deltaEventType := "content_block_delta"
-	if totalDuration == 0 {
-		deltaEvent := map[string]interface{}{
+	writeDelta := func(text string) bool {
+		deltaEvent := map[string]any{
 			"type":  deltaEventType,
 			"index": 0,
-			"delta": map[string]interface{}{
+			"delta": map[string]any{
 				"type": "text_delta",
-				"text": resp.Content[0].Text,
+				"text": text,
 			},
 		}
 		deltaBytes, _ := json.Marshal(deltaEvent)
-		if !writeChunk(deltaEventType, deltaBytes) {
+		return writeChunk(deltaEventType, deltaBytes)
+	}
+	if !paced {
+		if !writeDelta(resp.Content[0].Text) {
 			return
 		}
 	} else {
-		if !s.streamPacedChunks(ctx, totalDuration, resp.Content[0].Text, func(_ bool, chunk string) bool {
-			deltaEvent := map[string]interface{}{
-				"type":  deltaEventType,
-				"index": 0,
-				"delta": map[string]interface{}{
-					"type": "text_delta",
-					"text": chunk,
-				},
-			}
-			deltaBytes, _ := json.Marshal(deltaEvent)
-			return writeChunk(deltaEventType, deltaBytes)
-		}) {
+		if !streamPacedChunks(ctx, totalDuration, s.streamContentChunks(resp.Content[0].Text), writeDelta) {
 			return
 		}
 	}
 
-	// Send content_block_stop event
 	contentStopEventType := "content_block_stop"
-	contentStopEvent := map[string]interface{}{
+	contentStopEvent := map[string]any{
 		"type":  contentStopEventType,
 		"index": 0,
 	}
@@ -836,11 +832,10 @@ func (s *Server) sendAnthropicStream(ctx context.Context, w http.ResponseWriter,
 		return
 	}
 
-	// Send message_delta event
 	deltaMsgEventType := "message_delta"
-	deltaMsgEvent := map[string]interface{}{
+	deltaMsgEvent := map[string]any{
 		"type": deltaMsgEventType,
-		"delta": map[string]interface{}{
+		"delta": map[string]any{
 			"stop_reason":   resp.StopReason,
 			"stop_sequence": resp.StopSequence,
 		},
@@ -851,13 +846,12 @@ func (s *Server) sendAnthropicStream(ctx context.Context, w http.ResponseWriter,
 		return
 	}
 
-	// Send message_stop event
 	stopEventType := "message_stop"
-	stopEvent := map[string]interface{}{
+	stopEvent := map[string]any{
 		"type": stopEventType,
 	}
 	stopBytes, _ := json.Marshal(stopEvent)
-	writeChunk(stopEventType, stopBytes)
+	_ = writeChunk(stopEventType, stopBytes)
 }
 
 func (s *Server) tracingMiddleware(next http.Handler) http.Handler {

--- a/scaletest/llmmock/server.go
+++ b/scaletest/llmmock/server.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"iter"
 	"math/rand/v2"
 	"net"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -243,25 +245,31 @@ func (s *Server) randomStreamDuration() time.Duration {
 	return s.minStreamDuration + time.Duration(rand.Int64N(int64(delta)))
 }
 
-// streamPacedContent emits content as paced chunks. Fixed-size payloads use
-// byte windows of streamFixedWindowSize and iterate offsets directly; default
-// text is split on spaces.
-func (s *Server) streamPacedContent(ctx context.Context, totalDuration time.Duration, content string, emit func(chunk string) bool) bool {
-	if content == "" {
-		return emit("")
+// streamContentChunks yields content as one chunk when totalDuration is
+// non-positive. Otherwise, it spaces generated chunks across totalDuration.
+// Fixed-size payloads use byte windows because generated fixed payloads are
+// ASCII.
+func (s *Server) streamContentChunks(ctx context.Context, totalDuration time.Duration, content string) iter.Seq[string] {
+	if totalDuration <= 0 || content == "" {
+		return func(yield func(string) bool) {
+			yield(content)
+		}
 	}
 	if s.responsePayloadSize > 0 {
 		n := (len(content) + streamFixedWindowSize - 1) / streamFixedWindowSize
-		return streamPacedChunks(ctx, totalDuration, n, func(i int) string {
-			start := i * streamFixedWindowSize
-			end := min(start+streamFixedWindowSize, len(content))
-			return content[start:end]
-		}, emit)
+		return streamPacedChunks(ctx, totalDuration, n, func(yield func(string) bool) {
+			for i := range n {
+				start := i * streamFixedWindowSize
+				end := min(start+streamFixedWindowSize, len(content))
+				if !yield(content[start:end]) {
+					return
+				}
+			}
+		})
 	}
+
 	chunks := streamWordChunks(content)
-	return streamPacedChunks(ctx, totalDuration, len(chunks), func(i int) string {
-		return chunks[i]
-	}, emit)
+	return streamPacedChunks(ctx, totalDuration, len(chunks), slices.Values(chunks))
 }
 
 func streamWordChunks(content string) []string {
@@ -272,32 +280,39 @@ func streamWordChunks(content string) []string {
 	return chunks
 }
 
-func streamPacedChunks(ctx context.Context, totalDuration time.Duration, n int, chunk func(i int) string, emit func(chunk string) bool) bool {
-	if n == 0 {
-		return emit("")
-	}
-	if n == 1 {
-		return emit(chunk(0))
-	}
-
-	delay := totalDuration / time.Duration(n-1)
-	for i := range n {
-		if !emit(chunk(i)) {
-			return false
-		}
-		if i == n-1 || delay <= 0 {
-			continue
+func streamPacedChunks(ctx context.Context, totalDuration time.Duration, n int, chunks iter.Seq[string]) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		if n == 0 {
+			yield("")
+			return
 		}
 
-		timer := time.NewTimer(delay)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return false
-		case <-timer.C:
+		delay := time.Duration(0)
+		if n > 1 {
+			delay = totalDuration / time.Duration(n-1)
+		}
+		i := 0
+		for chunk := range chunks {
+			if !yield(chunk) {
+				return
+			}
+			i++
+			if i == n {
+				return
+			}
+			if delay <= 0 {
+				continue
+			}
+
+			timer := time.NewTimer(delay)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
 		}
 	}
-	return true
 }
 
 func (s *Server) startAPIServer(ctx context.Context) error {
@@ -578,7 +593,8 @@ func (s *Server) sendResponsesStream(ctx context.Context, w http.ResponseWriter,
 		return true
 	}
 
-	writeDelta := func(text string) bool {
+	text := resp.Output[0].Content[0].Text
+	for chunk := range s.streamContentChunks(ctx, s.randomStreamDuration(), text) {
 		deltaChunk := map[string]any{
 			"id":            resp.ID,
 			"object":        "response.output_text.delta",
@@ -586,22 +602,15 @@ func (s *Server) sendResponsesStream(ctx context.Context, w http.ResponseWriter,
 			"model":         resp.Model,
 			"output_index":  0,
 			"content_index": 0,
-			"delta":         text,
+			"delta":         chunk,
 		}
 		deltaBytes, _ := json.Marshal(deltaChunk)
-		return writeChunk(fmt.Sprintf("data: %s\n\n", deltaBytes))
+		if !writeChunk(fmt.Sprintf("data: %s\n\n", deltaBytes)) {
+			return
+		}
 	}
-
-	text := resp.Output[0].Content[0].Text
-	totalDuration := s.randomStreamDuration()
-	if totalDuration == 0 {
-		if !writeDelta(text) {
-			return
-		}
-	} else {
-		if !s.streamPacedContent(ctx, totalDuration, text, writeDelta) {
-			return
-		}
+	if ctx.Err() != nil {
+		return
 	}
 
 	finalChunk := map[string]any{
@@ -654,9 +663,6 @@ func (s *Server) sendAnthropicStream(ctx context.Context, w http.ResponseWriter,
 		return true
 	}
 
-	totalDuration := s.randomStreamDuration()
-	paced := totalDuration > 0
-
 	startEventType := "message_start"
 	startEvent := map[string]any{
 		"type": startEventType,
@@ -687,26 +693,22 @@ func (s *Server) sendAnthropicStream(ctx context.Context, w http.ResponseWriter,
 	}
 
 	deltaEventType := "content_block_delta"
-	writeDelta := func(text string) bool {
+	for chunk := range s.streamContentChunks(ctx, s.randomStreamDuration(), resp.Content[0].Text) {
 		deltaEvent := map[string]any{
 			"type":  deltaEventType,
 			"index": 0,
 			"delta": map[string]any{
 				"type": "text_delta",
-				"text": text,
+				"text": chunk,
 			},
 		}
 		deltaBytes, _ := json.Marshal(deltaEvent)
-		return writeChunk(deltaEventType, deltaBytes)
+		if !writeChunk(deltaEventType, deltaBytes) {
+			return
+		}
 	}
-	if !paced {
-		if !writeDelta(resp.Content[0].Text) {
-			return
-		}
-	} else {
-		if !s.streamPacedContent(ctx, totalDuration, resp.Content[0].Text, writeDelta) {
-			return
-		}
+	if ctx.Err() != nil {
+		return
 	}
 
 	contentStopEventType := "content_block_stop"

--- a/scaletest/llmmock/server.go
+++ b/scaletest/llmmock/server.go
@@ -2,8 +2,6 @@ package llmmock
 
 import (
 	"context"
-	crand "crypto/rand"
-	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -56,7 +54,8 @@ type Server struct {
 	responsePayloadSize int
 	minStreamDuration   time.Duration
 	maxStreamDuration   time.Duration
-	toolCallConfig      toolCallConfig
+	toolCallsPerTurn    int
+	toolCallCommand     string
 
 	tracerProvider trace.TracerProvider
 	closeTracing   func(context.Context) error
@@ -69,12 +68,8 @@ type Config struct {
 	ResponsePayloadSize int
 	MinStreamDuration   time.Duration
 	MaxStreamDuration   time.Duration
-	MinToolCallsPerTurn int
-	MaxToolCallsPerTurn int
+	ToolCallsPerTurn    int
 	ToolCallCommand     string
-
-	PprofEnable  bool
-	PprofAddress string
 
 	TraceEnable bool
 }
@@ -173,31 +168,16 @@ type anthropicResponse struct {
 
 func (s *Server) Start(ctx context.Context, cfg Config) error {
 	if cfg.ToolCallCommand == "" {
-		cfg.ToolCallCommand = defaultToolCallCommand
+		cfg.ToolCallCommand = DefaultToolCallCommand
 	}
-	if err := cfg.Validate(); err != nil {
-		return xerrors.Errorf("validate config: %w", err)
-	}
-
-	var seedBytes [8]byte
-	if _, err := crand.Read(seedBytes[:]); err != nil {
-		return xerrors.Errorf("generate tool-call seed: %w", err)
-	}
-	seed := binary.LittleEndian.Uint64(seedBytes[:])
-
 	s.address = cfg.Address
 	s.logger = cfg.Logger
 	s.artificialLatency = cfg.ArtificialLatency
 	s.responsePayloadSize = cfg.ResponsePayloadSize
 	s.minStreamDuration = cfg.MinStreamDuration
 	s.maxStreamDuration = cfg.MaxStreamDuration
-	s.toolCallConfig = toolCallConfig{
-		MinToolCallsPerTurn: cfg.MinToolCallsPerTurn,
-		MaxToolCallsPerTurn: cfg.MaxToolCallsPerTurn,
-		ToolCallCommand:     cfg.ToolCallCommand,
-		Seed:                seed,
-	}
-	s.logger.Info(ctx, "mock seed", slog.F("seed", seed))
+	s.toolCallsPerTurn = cfg.ToolCallsPerTurn
+	s.toolCallCommand = cfg.ToolCallCommand
 
 	if cfg.TraceEnable {
 		otel.SetTextMapPropagator(
@@ -251,8 +231,11 @@ func (s *Server) APIAddress() string {
 }
 
 func (s *Server) randomStreamDuration() time.Duration {
-	if s.minStreamDuration == 0 && s.maxStreamDuration == 0 {
+	if s.minStreamDuration <= 0 || s.maxStreamDuration <= 0 {
 		return 0
+	}
+	if s.minStreamDuration >= s.maxStreamDuration {
+		return s.minStreamDuration
 	}
 
 	delta := s.maxStreamDuration - s.minStreamDuration
@@ -384,12 +367,23 @@ func (s *Server) handleOpenAIWithLabels(w http.ResponseWriter, r *http.Request) 
 		time.Sleep(s.artificialLatency)
 	}
 
-	resp, err := buildOpenAIResponse(req, requestID, now, s.responsePayloadSize, r.Header.Get(coderChatIDHeader), s.toolCallConfig)
+	choice, err := s.buildOpenAIChoice(req)
 	if err != nil {
 		s.logger.Error(ctx, "failed to build OpenAI response", slog.Error(err))
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+
+	resp := openAIResponse{
+		ID:      fmt.Sprintf("chatcmpl-%s", requestID.String()[:8]),
+		Object:  "chat.completion",
+		Created: now.Unix(),
+		Model:   req.Model,
+		Choices: []openAIResponseChoice{choice},
+	}
+	resp.Usage.PromptTokens = mockInputTokens
+	resp.Usage.CompletionTokens = mockOutputTokens
+	resp.Usage.TotalTokens = mockInputTokens + mockOutputTokens
 
 	if req.Stream {
 		s.sendOpenAIStream(ctx, w, resp)

--- a/scaletest/llmmock/server.go
+++ b/scaletest/llmmock/server.go
@@ -68,8 +68,7 @@ type Config struct {
 	MaxStreamDuration   time.Duration
 	ResponsePayloadSize int
 	ToolCallsPerTurn    int
-	// ToolCallCommand is the command sent in generated execute tool calls.
-	ToolCallCommand string
+	ToolCallCommand     string
 
 	TraceEnable bool
 }
@@ -88,7 +87,6 @@ type llmRequestMessage struct {
 	Role string `json:"role"`
 }
 
-// openAIMessage is the assistant message shape used in responses.
 type openAIMessage struct {
 	Role      string           `json:"role"`
 	Content   string           `json:"content,omitempty"`

--- a/scaletest/llmmock/server.go
+++ b/scaletest/llmmock/server.go
@@ -294,17 +294,12 @@ func streamPacedChunks(ctx context.Context, totalDuration time.Duration, n int, 
 			return
 		}
 
-		delay := time.Duration(0)
-		if n > 1 {
-			delay = totalDuration / time.Duration(n-1)
-		}
-		i := 0
+		// Delay after every chunk, including the last, so the stream stays open
+		// for roughly totalDuration even when there is a single chunk (small
+		// --response-payload-size or single-word text).
+		delay := totalDuration / time.Duration(n)
 		for chunk := range chunks {
 			if !yield(chunk) {
-				return
-			}
-			i++
-			if i == n {
 				return
 			}
 			if delay <= 0 {

--- a/scaletest/llmmock/server.go
+++ b/scaletest/llmmock/server.go
@@ -52,6 +52,7 @@ type Server struct {
 	minStreamDuration   time.Duration
 	maxStreamDuration   time.Duration
 	responsePayloadSize int
+	responsePayload     string
 	toolCallsPerTurn    int
 	toolCallCommand     string
 
@@ -178,6 +179,10 @@ func (s *Server) Start(ctx context.Context, cfg Config) error {
 	s.minStreamDuration = cfg.MinStreamDuration
 	s.maxStreamDuration = cfg.MaxStreamDuration
 	s.responsePayloadSize = cfg.ResponsePayloadSize
+	s.responsePayload = ""
+	if s.responsePayloadSize > 0 {
+		s.responsePayload = strings.Repeat("x", s.responsePayloadSize)
+	}
 	s.toolCallsPerTurn = cfg.ToolCallsPerTurn
 	s.toolCallCommand = cfg.ToolCallCommand
 
@@ -234,7 +239,7 @@ func (s *Server) APIAddress() string {
 
 func (s *Server) responseText(fallback string) string {
 	if s.responsePayloadSize > 0 {
-		return strings.Repeat("x", s.responsePayloadSize)
+		return s.responsePayload
 	}
 	return fallback
 }
@@ -252,10 +257,9 @@ func (s *Server) randomStreamDuration() time.Duration {
 	return s.minStreamDuration + time.Duration(rand.Int64N(int64(delta)))
 }
 
-// streamContentChunks yields content as one chunk when totalDuration is
-// non-positive. Otherwise, it spaces generated chunks across totalDuration.
-// Fixed-size payloads use byte windows because generated fixed payloads are
-// ASCII.
+// streamContentChunks paces content across totalDuration. The fixed-size path
+// slices content by byte offset, which is rune-safe only because that payload
+// is ASCII (see responseText).
 func (s *Server) streamContentChunks(ctx context.Context, totalDuration time.Duration, content string) iter.Seq[string] {
 	if totalDuration <= 0 || content == "" {
 		return func(yield func(string) bool) {
@@ -287,6 +291,22 @@ func streamWordChunks(content string) []string {
 	return chunks
 }
 
+// sleepContext blocks until d elapses or ctx is canceled. It reports whether
+// the duration elapsed so callers can stop work when the context is done.
+func sleepContext(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return ctx.Err() == nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
 func streamPacedChunks(ctx context.Context, totalDuration time.Duration, n int, chunks iter.Seq[string]) iter.Seq[string] {
 	return func(yield func(string) bool) {
 		if n == 0 {
@@ -302,16 +322,8 @@ func streamPacedChunks(ctx context.Context, totalDuration time.Duration, n int, 
 			if !yield(chunk) {
 				return
 			}
-			if delay <= 0 {
-				continue
-			}
-
-			timer := time.NewTimer(delay)
-			select {
-			case <-ctx.Done():
-				timer.Stop()
+			if !sleepContext(ctx, delay) {
 				return
-			case <-timer.C:
 			}
 		}
 	}
@@ -375,8 +387,8 @@ func (s *Server) handleOpenAIWithLabels(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if s.artificialLatency > 0 {
-		time.Sleep(s.artificialLatency)
+	if !sleepContext(ctx, s.artificialLatency) {
+		return
 	}
 
 	choice := s.buildOpenAIChoice(req)
@@ -442,8 +454,8 @@ func (s *Server) handleResponsesWithLabels(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if s.artificialLatency > 0 {
-		time.Sleep(s.artificialLatency)
+	if !sleepContext(ctx, s.artificialLatency) {
+		return
 	}
 
 	var resp responsesResponse
@@ -518,8 +530,8 @@ func (s *Server) handleAnthropicWithLabels(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if s.artificialLatency > 0 {
-		time.Sleep(s.artificialLatency)
+	if !sleepContext(ctx, s.artificialLatency) {
+		return
 	}
 
 	var resp anthropicResponse


### PR DESCRIPTION
`coder exp scaletest llm-mock` used to return only canned text, so Coder Agents scaletests pointed at it never exercised the path that matters most: the agentic tool-call loop where the model asks for a tool, the workspace runs it, the result is fed back, and the model is re-prompted before it finally answers. This teaches the mock to reproduce that loop deterministically so scaletests actually drive real tool execution and hold streams open the way a live model would.

It adds `--tool-calls-per-turn` and `--tool-call-command` so the OpenAI Chat Completions endpoint emits a controllable number of `execute` tool calls per turn (only when the request advertises an `execute` tool, otherwise it falls back to text, so it stays a safe drop-in). It also adds paced streaming with `--min-stream-duration`/`--max-stream-duration` (randomized per response) and `--response-payload-size`, so runs can simulate slow or long-lived responses instead of flushing everything at once.

Closes CODAGT-307

Closes GRU-48
