### PR TITLE
fix(coderd/x/chatd/chattool): sanitize workspace MCP tool names

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -463,11 +463,7 @@ func (p *Server) pinnedWorkspaceMCPTools(
 		return nil, xerrors.Errorf("list chat context resources: %w", err)
 	}
 	infos := workspaceMCPToolInfosFromResources(resources)
-	tools := make([]fantasy.AgentTool, 0, len(infos))
-	for _, info := range infos {
-		tools = append(tools, chattool.NewWorkspaceMCPTool(info, getConn, nil))
-	}
-	return tools, nil
+	return chattool.NewWorkspaceMCPTools(infos, getConn, nil), nil
 }
 
 type turnWorkspaceContext struct {

--- a/coderd/x/chatd/chattool/mcpworkspace.go
+++ b/coderd/x/chatd/chattool/mcpworkspace.go
@@ -10,6 +10,7 @@ import (
 
 	"charm.land/fantasy"
 
+	aidmcp "github.com/coder/coder/v2/aibridge/mcp"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 )
@@ -19,7 +20,13 @@ import (
 // connection. It implements fantasy.AgentTool so it can be
 // registered alongside built-in chat tools.
 type WorkspaceMCPTool struct {
-	info            fantasy.ToolInfo
+	info fantasy.ToolInfo
+	// routingName is the unsanitized "serverName__toolName" form the
+	// workspace agent expects: it splits on "__" to locate the server and
+	// calls the original tool name. info.Name is the sanitized, provider-safe
+	// name shown to the model, so the two can differ when the server or tool
+	// name contains characters outside the provider's allowed set.
+	routingName     string
 	getConn         func(context.Context) (workspacesdk.AgentConn, error)
 	providerOpts    fantasy.ProviderOptions
 	invalidateCache func()
@@ -31,6 +38,13 @@ type WorkspaceMCPTool struct {
 // callback is invoked when CallMCPTool returns a 404 error,
 // indicating that the server was removed and the chat's cached
 // tool list should be dropped.
+//
+// The model-facing name is sanitized to the provider-safe character set and
+// length so a server or tool name containing characters such as "@" cannot
+// produce an invalid tool name that the provider rejects (Anthropic and
+// Bedrock require ^[a-zA-Z0-9_-]{1,128}$). The unsanitized name is retained
+// as routingName so the workspace agent can still route the call to the
+// original server and tool.
 func NewWorkspaceMCPTool(
 	tool workspacesdk.MCPToolInfo,
 	getConn func(context.Context) (workspacesdk.AgentConn, error),
@@ -42,15 +56,29 @@ func NewWorkspaceMCPTool(
 	}
 	return &WorkspaceMCPTool{
 		info: fantasy.ToolInfo{
-			Name:        tool.Name,
+			Name:        sanitizeModelToolName(tool.Name),
 			Description: tool.Description,
 			Parameters:  tool.Schema,
 			Required:    required,
 			Parallel:    true,
 		},
+		routingName:     tool.Name,
 		getConn:         getConn,
 		invalidateCache: invalidateCache,
 	}
+}
+
+// sanitizeModelToolName returns the provider-safe form of a workspace MCP
+// tool name. Characters outside [a-zA-Z0-9_-] are replaced with "_" and the
+// result is capped at the strictest provider tool-name limit, matching the
+// remote MCP path in mcpclient. The "__" server/tool separator survives
+// because underscores are already in the allowed set.
+func sanitizeModelToolName(name string) string {
+	sanitized := aidmcp.SanitizeToolName(name)
+	if len(sanitized) > aidmcp.MaxToolNameLen {
+		sanitized = sanitized[:aidmcp.MaxToolNameLen]
+	}
+	return sanitized
 }
 
 func (t *WorkspaceMCPTool) Info() fantasy.ToolInfo {
@@ -80,7 +108,7 @@ func (t *WorkspaceMCPTool) Run(
 	}
 
 	resp, err := conn.CallMCPTool(ctx, workspacesdk.CallMCPToolRequest{
-		ToolName:  t.info.Name,
+		ToolName:  t.routingName,
 		Arguments: args,
 	})
 	if err != nil {

--- a/coderd/x/chatd/chattool/mcpworkspace.go
+++ b/coderd/x/chatd/chattool/mcpworkspace.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"slices"
+	"strconv"
 	"strings"
 
 	"charm.land/fantasy"
@@ -32,12 +34,11 @@ type WorkspaceMCPTool struct {
 	invalidateCache func()
 }
 
-// NewWorkspaceMCPTool creates a tool wrapper from an MCPToolInfo
-// discovered on a workspace agent. Each tool proxies calls back
-// through the agent connection. The optional invalidateCache
-// callback is invoked when CallMCPTool returns a 404 error,
-// indicating that the server was removed and the chat's cached
-// tool list should be dropped.
+// NewWorkspaceMCPTool creates a single tool wrapper from an MCPToolInfo
+// discovered on a workspace agent. Each tool proxies calls back through the
+// agent connection. The optional invalidateCache callback is invoked when
+// CallMCPTool returns a 404 error, indicating that the server was removed and
+// the chat's cached tool list should be dropped.
 //
 // The model-facing name is sanitized to the provider-safe character set and
 // length so a server or tool name containing characters such as "@" cannot
@@ -45,8 +46,49 @@ type WorkspaceMCPTool struct {
 // Bedrock require ^[a-zA-Z0-9_-]{1,128}$). The unsanitized name is retained
 // as routingName so the workspace agent can still route the call to the
 // original server and tool.
+//
+// Prefer NewWorkspaceMCPTools when building a set of tools, because that path
+// also disambiguates names that collide after sanitization. This single-tool
+// constructor cannot detect collisions on its own.
 func NewWorkspaceMCPTool(
 	tool workspacesdk.MCPToolInfo,
+	getConn func(context.Context) (workspacesdk.AgentConn, error),
+	invalidateCache func(),
+) *WorkspaceMCPTool {
+	return newWorkspaceMCPTool(tool, sanitizeModelToolName(tool.Name), getConn, invalidateCache)
+}
+
+// NewWorkspaceMCPTools builds wrappers for a set of workspace MCP tools.
+// Because the model-facing name is sanitized and length-capped, two distinct
+// servers or tools can normalize to the same string (for example server keys
+// "foo.bar" and "foo_bar" each exposing "echo", or names that share the first
+// MaxToolNameLen bytes). Duplicate names would be sent to the provider, which
+// can reject the request, and the dispatch map keyed by name would make one
+// tool unreachable. To keep every tool addressable, colliding model-facing
+// names are disambiguated with a numeric suffix while each tool keeps its own
+// original routing name. Tools are sorted by routing name first so the suffix
+// assignment is stable across turns.
+func NewWorkspaceMCPTools(
+	infos []workspacesdk.MCPToolInfo,
+	getConn func(context.Context) (workspacesdk.AgentConn, error),
+	invalidateCache func(),
+) []fantasy.AgentTool {
+	sorted := slices.Clone(infos)
+	slices.SortFunc(sorted, func(a, b workspacesdk.MCPToolInfo) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	tools := make([]fantasy.AgentTool, 0, len(sorted))
+	seen := make(map[string]struct{}, len(sorted))
+	for _, info := range sorted {
+		modelName := uniqueToolName(sanitizeModelToolName(info.Name), seen)
+		tools = append(tools, newWorkspaceMCPTool(info, modelName, getConn, invalidateCache))
+	}
+	return tools
+}
+
+func newWorkspaceMCPTool(
+	tool workspacesdk.MCPToolInfo,
+	modelName string,
 	getConn func(context.Context) (workspacesdk.AgentConn, error),
 	invalidateCache func(),
 ) *WorkspaceMCPTool {
@@ -56,7 +98,7 @@ func NewWorkspaceMCPTool(
 	}
 	return &WorkspaceMCPTool{
 		info: fantasy.ToolInfo{
-			Name:        sanitizeModelToolName(tool.Name),
+			Name:        modelName,
 			Description: tool.Description,
 			Parameters:  tool.Schema,
 			Required:    required,
@@ -79,6 +121,33 @@ func sanitizeModelToolName(name string) string {
 		sanitized = sanitized[:aidmcp.MaxToolNameLen]
 	}
 	return sanitized
+}
+
+// uniqueToolName returns name when it is unused, otherwise it appends an
+// incrementing "_N" suffix, truncating the base so the result stays within
+// the provider length limit, until it finds a name not already in seen. The
+// returned name is recorded in seen.
+func uniqueToolName(name string, seen map[string]struct{}) string {
+	if _, ok := seen[name]; !ok {
+		seen[name] = struct{}{}
+		return name
+	}
+	for i := 2; ; i++ {
+		suffix := "_" + strconv.Itoa(i)
+		base := name
+		if len(base)+len(suffix) > aidmcp.MaxToolNameLen {
+			cut := aidmcp.MaxToolNameLen - len(suffix)
+			if cut < 0 {
+				cut = 0
+			}
+			base = base[:cut]
+		}
+		candidate := base + suffix
+		if _, ok := seen[candidate]; !ok {
+			seen[candidate] = struct{}{}
+			return candidate
+		}
+	}
 }
 
 func (t *WorkspaceMCPTool) Info() fantasy.ToolInfo {

--- a/coderd/x/chatd/chattool/mcpworkspace_test.go
+++ b/coderd/x/chatd/chattool/mcpworkspace_test.go
@@ -3,6 +3,7 @@ package chattool_test
 import (
 	"context"
 	"net/http"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	aidmcp "github.com/coder/coder/v2/aibridge/mcp"
 	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
@@ -151,5 +153,96 @@ func TestWorkspaceMCPTool_InvalidateOn404(t *testing.T) {
 		resp, err := tool.Run(context.Background(), fantasy.ToolCall{})
 		require.NoError(t, err)
 		assert.True(t, resp.IsError)
+	})
+}
+
+func TestWorkspaceMCPTool_SanitizesModelNameKeepsRoutingName(t *testing.T) {
+	t.Parallel()
+
+	t.Run("InvalidCharsSanitizedForModelOriginalForRouting", func(t *testing.T) {
+		t.Parallel()
+
+		var gotToolName string
+		tool := chattool.NewWorkspaceMCPTool(
+			workspacesdk.MCPToolInfo{
+				// "@" is outside the provider's allowed tool-name set; the
+				// model must never see it or the whole request is rejected.
+				Name:        "weather@home__get_forecast",
+				Description: "test tool",
+			},
+			func(ctx context.Context) (workspacesdk.AgentConn, error) {
+				return &fakeAgentConn{
+					callMCPToolFunc: func(_ context.Context, req workspacesdk.CallMCPToolRequest) (workspacesdk.CallMCPToolResponse, error) {
+						gotToolName = req.ToolName
+						return workspacesdk.CallMCPToolResponse{
+							Content: []workspacesdk.MCPToolContent{{Type: "text", Text: "ok"}},
+						}, nil
+					},
+				}, nil
+			},
+			nil,
+		)
+
+		// The model-facing name is sanitized to the provider-safe set.
+		assert.Equal(t, "weather_home__get_forecast", tool.Info().Name)
+
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{})
+		require.NoError(t, err)
+		assert.False(t, resp.IsError)
+		// The agent receives the original name so it can route the call to
+		// the correct server and original tool.
+		assert.Equal(t, "weather@home__get_forecast", gotToolName)
+	})
+
+	t.Run("ValidNameUnchanged", func(t *testing.T) {
+		t.Parallel()
+
+		var gotToolName string
+		tool := chattool.NewWorkspaceMCPTool(
+			workspacesdk.MCPToolInfo{
+				Name:        "github__create_issue",
+				Description: "test tool",
+			},
+			func(ctx context.Context) (workspacesdk.AgentConn, error) {
+				return &fakeAgentConn{
+					callMCPToolFunc: func(_ context.Context, req workspacesdk.CallMCPToolRequest) (workspacesdk.CallMCPToolResponse, error) {
+						gotToolName = req.ToolName
+						return workspacesdk.CallMCPToolResponse{}, nil
+					},
+				}, nil
+			},
+			nil,
+		)
+
+		// A name already within the allowed set is left untouched, so the
+		// model-facing and routing names match.
+		assert.Equal(t, "github__create_issue", tool.Info().Name)
+
+		_, err := tool.Run(context.Background(), fantasy.ToolCall{})
+		require.NoError(t, err)
+		assert.Equal(t, "github__create_issue", gotToolName)
+	})
+
+	t.Run("LongNameTruncatedForModel", func(t *testing.T) {
+		t.Parallel()
+
+		longName := "srv__" + strings.Repeat("a", aidmcp.MaxToolNameLen)
+		tool := chattool.NewWorkspaceMCPTool(
+			workspacesdk.MCPToolInfo{
+				Name:        longName,
+				Description: "test tool",
+			},
+			func(ctx context.Context) (workspacesdk.AgentConn, error) {
+				return &fakeAgentConn{
+					callMCPToolFunc: func(_ context.Context, _ workspacesdk.CallMCPToolRequest) (workspacesdk.CallMCPToolResponse, error) {
+						return workspacesdk.CallMCPToolResponse{}, nil
+					},
+				}, nil
+			},
+			nil,
+		)
+
+		// The model-facing name is capped at the strictest provider limit.
+		assert.LessOrEqual(t, len(tool.Info().Name), aidmcp.MaxToolNameLen)
 	})
 }

--- a/coderd/x/chatd/chattool/mcpworkspace_test.go
+++ b/coderd/x/chatd/chattool/mcpworkspace_test.go
@@ -246,3 +246,41 @@ func TestWorkspaceMCPTool_SanitizesModelNameKeepsRoutingName(t *testing.T) {
 		assert.LessOrEqual(t, len(tool.Info().Name), aidmcp.MaxToolNameLen)
 	})
 }
+
+func TestNewWorkspaceMCPTools_DisambiguatesCollidingNames(t *testing.T) {
+	t.Parallel()
+
+	var routed []string
+	getConn := func(_ context.Context) (workspacesdk.AgentConn, error) {
+		return &fakeAgentConn{
+			callMCPToolFunc: func(_ context.Context, req workspacesdk.CallMCPToolRequest) (workspacesdk.CallMCPToolResponse, error) {
+				routed = append(routed, req.ToolName)
+				return workspacesdk.CallMCPToolResponse{}, nil
+			},
+		}, nil
+	}
+
+	// Both names sanitize to "foo_bar__echo"; the set builder must keep them
+	// distinct for the model while routing each to its own original name.
+	infos := []workspacesdk.MCPToolInfo{
+		{Name: "foo.bar__echo"},
+		{Name: "foo_bar__echo"},
+	}
+
+	tools := chattool.NewWorkspaceMCPTools(infos, getConn, nil)
+	require.Len(t, tools, 2)
+
+	names := []string{tools[0].Info().Name, tools[1].Info().Name}
+	assert.NotEqual(t, names[0], names[1],
+		"colliding model-facing names must be disambiguated")
+	assert.ElementsMatch(t,
+		[]string{"foo_bar__echo", "foo_bar__echo_2"}, names)
+
+	// Each tool routes to its own original (unsanitized) name.
+	for _, tl := range tools {
+		_, err := tl.Run(context.Background(), fantasy.ToolCall{})
+		require.NoError(t, err)
+	}
+	assert.ElementsMatch(t,
+		[]string{"foo.bar__echo", "foo_bar__echo"}, routed)
+}


### PR DESCRIPTION
## Summary

Workspace MCP tools (servers a workspace declares in its `.mcp.json`) take their model-facing name from the server key joined with the tool name as `serverName__toolName`. Two of the three MCP tool paths already sanitize that name to the provider-safe set before it reaches the model:

- Remote MCP servers: `coderd/x/chatd/mcpclient` applies `SanitizeToolName` + truncation at tool construction.
- AI Gateway: `aibridge/mcp` sanitizes for the same reason (its comment notes a single invalid name can `400` the entire request).

The **workspace** path did not. `workspaceMCPToolInfosFromResources` builds `server + "__" + name` and `NewWorkspaceMCPTool` passed it straight into `fantasy.ToolInfo.Name`. A server or tool name containing a character outside `^[a-zA-Z0-9_-]{1,128}$` (for example `@`) therefore produced an invalid tool name. Anthropic and Bedrock reject the whole request with `HTTP 400`:

```
tools.N.custom.name: String should match pattern '^[a-zA-Z0-9_-]{1,128}$'
```

which fails the entire turn, not just that one tool.

## Fix

Sanitize and length-cap the model-facing name in `NewWorkspaceMCPTool`, matching the remote MCP path. The original, unsanitized `serverName__toolName` is retained as `routingName` and used when proxying the call back through the workspace agent, which splits on `__` to locate the server and call the original tool. Names already within the allowed set are unchanged, so the model-facing and routing names stay identical in the common case (no behavior change for valid names).

The agent-side config parser (`agent/x/agentmcp/config.go`) only guards the `__` separator and leading/trailing underscores, so it does not prevent these other invalid characters from reaching the model.

## Test plan

- Added `TestWorkspaceMCPTool_SanitizesModelNameKeepsRoutingName`:
  - `@` in the name is sanitized for the model, while the original name is sent to the agent for routing
  - a valid name is left unchanged (no regression)
  - an over-limit name is truncated for the model
- Existing `TestWorkspaceMCPToolInfosFromResources` and `TestPinnedWorkspaceMCPTools` still pass.
- `go vet` and `gofmt` clean.