### PR TITLE
fix(cli): increase agent log backups

### DIFF
--- a/cli/agent.go
+++ b/cli/agent.go
@@ -161,9 +161,8 @@ func workspaceAgent() *serpent.Command {
 			logWriter := &clilog.LumberjackWriteCloseFixer{Writer: &lumberjack.Logger{
 				Filename: filepath.Join(logDir, "coder-agent.log"),
 				MaxSize:  5, // MB
-				// Per customer incident on November 17th, 2023, its helpful
-				// to have the log of the last few restarts to debug a failing agent.
-				MaxBackups: 10,
+				// Keep up to the debug logs response cap across the active log and rotations.
+				MaxBackups: 19,
 			}}
 			defer logWriter.Close()
 


### PR DESCRIPTION
The agent log rotation kept only about 55 MiB on disk, which could fall short of the 24h support bundle lookback during high-volume debug logging.

Increase the retained `coder-agent.log` rotations from 10 to 19 so the active log plus rotations align with the existing 100 MiB debug logs response cap.

Closes #26737

<details>
<summary>Coder Agents disclosure</summary>

This PR was generated by Coder Agents on behalf of @EhabY.

</details>
