### PR TITLE
fix(site/src/pages/TemplateBuilder): remove required/optional placeholder from fields

### DIFF
--- a/site/src/pages/TemplateBuilder/BaseTemplateParametersStep.tsx
+++ b/site/src/pages/TemplateBuilder/BaseTemplateParametersStep.tsx
@@ -54,7 +54,6 @@ function variableToField(
 		label: variable.name,
 		description: variable.description || undefined,
 		required: variable.required,
-		placeholder: variable.required ? "Required" : "Optional",
 		field: {
 			name: variable.name,
 			id,

--- a/site/src/pages/TemplateBuilder/ModuleSettingsStep.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleSettingsStep.tsx
@@ -51,7 +51,6 @@ function variableToField(
 		label: variable.name,
 		description: variable.description || undefined,
 		required: variable.required,
-		placeholder: variable.required ? "Required" : "Optional",
 		field: {
 			name: variable.name,
 			id,

--- a/site/src/pages/TemplateBuilder/TemplateBuilderAvatarData.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderAvatarData.tsx
@@ -18,7 +18,7 @@ export const TemplateBuilderAvatarData: FC<TemplateBuilderAvatarDataProps> = ({
 }) => {
 	return (
 		<AvatarData
-			avatar={<Avatar src={iconUrl} size="lg" />}
+			avatar={<Avatar src={iconUrl} size="lg" variant="icon" />}
 			title={<h3 className="m-0 text-xl font-semibold">{name}</h3>}
 			subtitle={
 				<>


### PR DESCRIPTION
Template Builder text inputs showed "Required" or "Optional" as placeholder text inside the field itself. Remove that placeholder.

Required state is already conveyed by the asterisk on the field label, and optional variables already live under the "Advanced settings" section, so the in-field text was redundant.

Also restore the internal padding on the config card logos by passing `variant="icon"` to the `Avatar`, so the logo no longer sits flush against the card border (matching how logos render elsewhere).