### PR TITLE
fix(site): guard Organizations menu item behind canViewOrganizations

### DIFF
--- a/site/src/modules/dashboard/Navbar/DeploymentDropdown.tsx
+++ b/site/src/modules/dashboard/Navbar/DeploymentDropdown.tsx
@@ -67,6 +67,7 @@ export const DeploymentDropdown: FC<DeploymentDropdownProps> = ({
 
 const DeploymentDropdownContent: FC<DeploymentDropdownProps> = ({
 	canViewDeployment,
+	canViewOrganizations,
 	canViewAuditLog,
 	canViewConnectionLog,
 	canViewAIBridge,
@@ -80,9 +81,11 @@ const DeploymentDropdownContent: FC<DeploymentDropdownProps> = ({
 					<Link to="/deployment">Deployment</Link>
 				</DropdownMenuItem>
 			)}
-			<DropdownMenuItem asChild>
-				<Link to="/organizations">Organizations</Link>
-			</DropdownMenuItem>
+			{canViewOrganizations && (
+				<DropdownMenuItem asChild>
+					<Link to="/organizations">Organizations</Link>
+				</DropdownMenuItem>
+			)}
 			{canViewAISettings && (
 				<DropdownMenuItem asChild>
 					<Link to="/ai/settings">AI</Link>

--- a/site/src/modules/dashboard/Navbar/MobileMenu.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.tsx
@@ -208,6 +208,7 @@ const ProxySettingsSub: FC<ProxySettingsSubProps> = ({ proxyContextValue }) => {
 
 const AdminSettingsSub: FC<MobileMenuPermissions> = ({
 	canViewDeployment,
+	canViewOrganizations,
 	canViewAuditLog,
 	canViewConnectionLog,
 	canViewHealth,
@@ -239,12 +240,14 @@ const AdminSettingsSub: FC<MobileMenuPermissions> = ({
 						<Link to="/deployment">Deployment</Link>
 					</DropdownMenuItem>
 				)}
-				<DropdownMenuItem
-					asChild
-					className={cn(itemStyles.default, itemStyles.sub)}
-				>
-					<Link to="/organizations">Organizations</Link>
-				</DropdownMenuItem>
+				{canViewOrganizations && (
+					<DropdownMenuItem
+						asChild
+						className={cn(itemStyles.default, itemStyles.sub)}
+					>
+						<Link to="/organizations">Organizations</Link>
+					</DropdownMenuItem>
+				)}
 				{canViewAuditLog && (
 					<DropdownMenuItem
 						asChild


### PR DESCRIPTION
The Organizations menu item in both `DeploymentDropdown` and `MobileMenu` rendered unconditionally, making it visible to non-admin users. The `canViewOrganizations` prop was already defined and passed but was not destructured or checked in the inner rendering components.

Destructure `canViewOrganizations` in `DeploymentDropdownContent` and `AdminSettingsSub`, and wrap the Organizations menu item with the same conditional pattern used by all other menu items.

Fixes #26695

<details><summary>Implementation details</summary>

### Changes

- **`DeploymentDropdown.tsx`**: Added `canViewOrganizations` to the destructured props in `DeploymentDropdownContent` and wrapped the Organizations `<DropdownMenuItem>` with `{canViewOrganizations && (...)}`.
- **`MobileMenu.tsx`**: Added `canViewOrganizations` to the destructured props in `AdminSettingsSub` and wrapped the Organizations `<DropdownMenuItem>` with the same conditional guard.

The existing stories (`NavbarView.stories.tsx` and `MobileMenu.stories.tsx`) already have `ForMember` / `Member` variants with `canViewOrganizations: false`, so Chromatic will catch the visual change automatically.
</details>

> Generated by Coder Agents on behalf of @stirby