### PR TITLE
fix(coderd): allow user-admin role to reset member passwords

### DIFF
--- a/coderd/users.go
+++ b/coderd/users.go
@@ -1713,7 +1713,10 @@ func (api *API) putUserPassword(rw http.ResponseWriter, r *http.Request) {
 			return xerrors.Errorf("update user hashed password: %w", err)
 		}
 
-		err = tx.DeleteAPIKeysByUserID(ctx, user.ID)
+		//nolint:gocritic // The handler already validated the caller can update
+		// the user's password. Deleting the target's API keys is a security
+		// side-effect that requires system context.
+		err = tx.DeleteAPIKeysByUserID(dbauthz.AsSystemRestricted(ctx), user.ID)
 		if err != nil {
 			return xerrors.Errorf("delete api keys by user ID: %w", err)
 		}

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -1653,6 +1653,35 @@ func TestUpdateUserPassword(t *testing.T) {
 		require.Contains(t, apiErr.Message, "Only owners can change the password of an owner")
 	})
 
+	t.Run("UserAdminCanResetMemberPassword", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		owner := coderdtest.CreateFirstUser(t, client)
+		userAdmin, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, rbac.RoleUserAdmin())
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		member, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
+			Email:           "member@coder.com",
+			Username:        "member",
+			Password:        "SomeStrongPassword!",
+			OrganizationIDs: []uuid.UUID{owner.OrganizationID},
+		})
+		require.NoError(t, err)
+
+		err = userAdmin.UpdateUserPassword(ctx, member.ID.String(), codersdk.UpdateUserPasswordRequest{
+			Password: "SomeNewStrongPassword!",
+		})
+		require.NoError(t, err, "user-admin should be able to reset member password")
+
+		_, err = client.LoginWithPassword(ctx, codersdk.LoginWithPasswordRequest{
+			Email:    "member@coder.com",
+			Password: "SomeNewStrongPassword!",
+		})
+		require.NoError(t, err, "member should login with the new password")
+	})
+
 	t.Run("OwnerCanResetOwnerPassword", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, nil)


### PR DESCRIPTION
The `putUserPassword` handler used the caller's RBAC context for `DeleteAPIKeysByUserID`, which requires `ResourceApiKey` delete permission. The `user-admin` role does not have this permission, causing an HTTP 500 when a user-admin tries to reset another user's password.

Switch to `dbauthz.AsSystemRestricted` for the `DeleteAPIKeysByUserID` call, matching the existing pattern in the OIDC password-change flow in `userauth.go`. The handler already validates the caller can update the user's password before reaching this point.

Add a test verifying that user-admin can successfully reset a member's password.

Fixes #25873

<details><summary>Implementation details</summary>

### Root cause

The transaction in `putUserPassword` runs two operations:
1. `tx.UpdateUserHashedPassword(ctx, ...)` - succeeds (user-admin has `ActionUpdate` on `ResourceUser`)
2. `tx.DeleteAPIKeysByUserID(ctx, user.ID)` - **fails** (user-admin has no `ResourceApiKey` permissions)

### Fix

One-line change: use `dbauthz.AsSystemRestricted(ctx)` for the `DeleteAPIKeysByUserID` call. This mirrors the identical pattern already used in `coderd/userauth.go:434` for the OIDC password-change flow.

### Why this is safe

- The handler validates the caller can update the target user's password at line 1610
- There's an additional owner-only guard for owner targets at line 1616
- The API key deletion is a security side-effect (invalidate sessions on password change), not a standalone user-initiated action
</details>

> Generated by Coder Agents on behalf of @stirby