### PR TITLE
fix(site): normalize notification action URLs for React Router

### DIFF
--- a/site/src/modules/notifications/NotificationsInbox/InboxItem.test.ts
+++ b/site/src/modules/notifications/NotificationsInbox/InboxItem.test.ts
@@ -1,0 +1,28 @@
+import { normalizeActionURL } from "./InboxItem";
+
+describe("normalizeActionURL", () => {
+	it("strips origin from same-origin absolute URL", () => {
+		const url = `${window.location.origin}/deployment/users?filter=status%3Aactive`;
+		expect(normalizeActionURL(url)).toBe(
+			"/deployment/users?filter=status%3Aactive",
+		);
+	});
+
+	it("preserves cross-origin absolute URL", () => {
+		const url = "https://external.example.com/some/path";
+		expect(normalizeActionURL(url)).toBe(url);
+	});
+
+	it("returns relative paths unchanged", () => {
+		expect(normalizeActionURL("/deployment/users")).toBe("/deployment/users");
+	});
+
+	it("preserves hash fragments", () => {
+		const url = `${window.location.origin}/settings#section`;
+		expect(normalizeActionURL(url)).toBe("/settings#section");
+	});
+
+	it("handles empty string", () => {
+		expect(normalizeActionURL("")).toBe("/");
+	});
+});

--- a/site/src/modules/notifications/NotificationsInbox/InboxItem.tsx
+++ b/site/src/modules/notifications/NotificationsInbox/InboxItem.tsx
@@ -8,6 +8,26 @@ import { Link } from "#/components/Link/Link";
 import { relativeTime } from "#/utils/time";
 import { InboxAvatar } from "./InboxAvatar";
 
+/**
+ * Normalizes a notification action URL for use with React Router.
+ * Backend notification templates produce absolute URLs like
+ * "https://coder.example.com/deployment/users?filter=...". React Router's
+ * <Link> treats these as external, which corrupts the navigation target.
+ * This function strips the origin when the URL matches the current page's
+ * origin, returning a relative path that React Router can handle.
+ */
+export function normalizeActionURL(raw: string): string {
+	try {
+		const parsed = new URL(raw, window.location.origin);
+		if (parsed.origin === window.location.origin) {
+			return parsed.pathname + parsed.search + parsed.hash;
+		}
+	} catch {
+		// If parsing fails, return the raw URL unchanged.
+	}
+	return raw;
+}
+
 type InboxItemProps = {
 	notification: InboxNotification;
 	onMarkNotificationAsRead: (notificationId: string) => void;
@@ -43,7 +63,7 @@ export const InboxItem: FC<InboxItemProps> = ({
 						return (
 							<Button variant="outline" size="sm" key={action.label} asChild>
 								<RouterLink
-									to={action.url}
+									to={normalizeActionURL(action.url)}
 									onClick={() => {
 										onMarkNotificationAsRead(notification.id);
 									}}


### PR DESCRIPTION
Notification action URLs are absolute URLs produced by backend templates (e.g. `https://coder.example.com/deployment/users?filter=...`). React Router's `<Link>` component does not handle absolute URLs correctly, treating the pathname as a hostname and navigating to the wrong destination.

Add `normalizeActionURL()` that strips the origin from same-origin URLs, producing a relative path that React Router handles correctly. Cross-origin URLs are preserved as-is.

Fixes #25875

<details><summary>Implementation details</summary>

### Problem

Backend notification templates produce URLs like `https://coder.fiserv.one/deployment/users?filter=status%3Aactive`. The frontend passes this absolute URL directly to React Router's `<Link to={action.url}>`. React Router treats this as a relative path, resulting in navigation to `https://deployment/users?filter=status%3Aactive` (treating `deployment` as the hostname).

### Fix

- Added `normalizeActionURL(raw: string): string` utility in `InboxItem.tsx`
- Uses `new URL(raw, window.location.origin)` to parse the URL
- If the parsed origin matches the current page's origin, returns just the pathname + search + hash
- Otherwise returns the raw URL unchanged (for external links)
- Applied to the `<RouterLink to={...}>` in the notification action buttons

### Tests

Added `InboxItem.test.ts` with unit tests covering: same-origin URLs, cross-origin URLs, relative paths, hash fragments, and empty strings.
</details>

> Generated by Coder Agents on behalf of @stirby