### PR TITLE
feat(site): add dynamic browser tab titles and xterm title passthrough for terminals

### DIFF
--- a/site/src/modules/terminal/WorkspaceTerminal.tsx
+++ b/site/src/modules/terminal/WorkspaceTerminal.tsx
@@ -51,6 +51,7 @@ type WorkspaceTerminalProps = {
 	onStatusChange?: (status: ConnectionStatus) => void;
 	onError?: (error: Error) => void;
 	onContentReady?: () => void;
+	onTitleChange?: (title: string) => void;
 	reconnectionToken: string;
 	baseUrl?: string;
 	terminalFontFamily?: string;
@@ -82,6 +83,7 @@ export const WorkspaceTerminal = ({
 	onStatusChange,
 	onError,
 	onContentReady,
+	onTitleChange,
 	reconnectionToken,
 	baseUrl,
 	terminalFontFamily = DEFAULT_TERMINAL_FONT_FAMILY,
@@ -104,6 +106,9 @@ export const WorkspaceTerminal = ({
 	});
 	const handleContentReady = useEffectEvent(() => {
 		onContentReady?.();
+	});
+	const handleTitleChange = useEffectEvent((title: string) => {
+		onTitleChange?.(title);
 	});
 	const [terminal, setTerminal] = useState<Terminal>();
 	const { copyToClipboard, readFromClipboard } = useClipboard();
@@ -239,6 +244,10 @@ export const WorkspaceTerminal = ({
 				handleOpenLink(uri);
 			}),
 		);
+
+		nextTerminal.onTitleChange((title) => {
+			handleTitleChange(title);
+		});
 
 		const copySelection = () => {
 			const selection = nextTerminal.getSelection();

--- a/site/src/pages/TerminalPage/TerminalPage.tsx
+++ b/site/src/pages/TerminalPage/TerminalPage.tsx
@@ -31,6 +31,27 @@ import { openMaybePortForwardedURL } from "#/utils/portForward";
 import { getMatchingAgentOrFirst } from "#/utils/workspace";
 import { TerminalCommandConsentDialog } from "./TerminalCommandConsentDialog";
 
+/**
+ * Builds a contextual terminal label that includes the agent name and
+ * container name when available, so multiple terminal tabs are
+ * distinguishable at a glance.
+ */
+function buildTerminalLabel(
+	agentName?: string,
+	containerName?: string,
+): string {
+	if (agentName && containerName) {
+		return `Terminal (${agentName}: ${containerName})`;
+	}
+	if (agentName) {
+		return `Terminal (${agentName})`;
+	}
+	if (containerName) {
+		return `Terminal (${containerName})`;
+	}
+	return "Terminal";
+}
+
 const TerminalPage: FC = () => {
 	// Maybe one day we'll support a light themed terminal, but terminal coloring
 	// is notably a pain because of assumptions certain programs might make about
@@ -44,6 +65,7 @@ const TerminalPage: FC = () => {
 	const [connectionStatus, setConnectionStatus] =
 		useState<ConnectionStatus>("initializing");
 	const [commandConfirmed, setCommandConfirmed] = useState(false);
+	const [terminalTitle, setTerminalTitle] = useState<string | undefined>();
 	const [searchParams] = useSearchParams();
 	const isDebugging = searchParams.has("debug");
 	// The reconnection token is a unique token that identifies
@@ -152,7 +174,8 @@ const TerminalPage: FC = () => {
 			{workspace.data && (
 				<title>
 					{pageTitle(
-						"Terminal",
+						terminalTitle ??
+							buildTerminalLabel(workspaceAgent?.name, containerName),
 						`${workspace.data.owner_name}/${workspace.data.name}`,
 					)}
 				</title>
@@ -175,6 +198,7 @@ const TerminalPage: FC = () => {
 					containerUser={containerUser}
 					onStatusChange={setConnectionStatus}
 					onError={handleTerminalError}
+					onTitleChange={setTerminalTitle}
 					reconnectionToken={reconnectionToken}
 					baseUrl={terminalConfig.baseUrl}
 					terminalFontFamily={terminalConfig.fontFamily}


### PR DESCRIPTION
The web terminal browser tab was hardcoded to 'Terminal', making multiple open terminals indistinguishable. This change adds two improvements:

1. **Dynamic default title**: includes the agent name and container name in the tab title when available, producing titles like `Terminal (docker-agent)` or `Terminal (agent: container)`.

2. **xterm title passthrough**: wires the terminal's `onTitleChange` event so shell escape sequences (e.g. `ESC]0;My Title BEL`) update the browser tab title, matching native terminal behavior.

The `onTitleChange` prop is optional, so the embedded `TerminalPanel` in `AgentsPage` is unaffected.

Fixes #25693

<details><summary>Implementation details</summary>

### Changes

**`WorkspaceTerminal.tsx`**:
- Added `onTitleChange?: (title: string) => void` to `WorkspaceTerminalProps`
- Wired `terminal.onTitleChange` to invoke the callback via `useEffectEvent`

**`TerminalPage.tsx`**:
- Added `buildTerminalLabel(agentName?, containerName?)` helper that produces contextual labels
- Added `terminalTitle` state for xterm-provided titles
- Title uses `terminalTitle ?? buildTerminalLabel(...)` so shell escape sequences override the default, and the default includes agent/container context
- Passed `onTitleChange={setTerminalTitle}` to `WorkspaceTerminal`

### No backend changes needed

All data (`workspaceAgent.name`, `containerName` from search params) is already available client-side.
</details>

> Generated by Coder Agents on behalf of @stirby