### PR TITLE
fix(site): redirect to new organization after create

### DIFF
--- a/site/src/pages/OrganizationSettingsPage/CreateOrganizationPage.tsx
+++ b/site/src/pages/OrganizationSettingsPage/CreateOrganizationPage.tsx
@@ -27,14 +27,11 @@ const CreateOrganizationPage: FC = () => {
 					error={error}
 					isEntitled={feats.multiple_organizations}
 					onSubmit={async (values) => {
-						await createOrganizationMutation.mutateAsync(values, {
-							onSuccess: () => {
-								toast.success(
-									`Organization "${values.name}" created successfully.`,
-								);
-								navigate(`/organizations/${values.name}`);
-							},
-						});
+						await createOrganizationMutation.mutateAsync(values);
+						toast.success(
+							`Organization "${values.name}" created successfully.`,
+						);
+						navigate(`/organizations/${values.name}`);
 					}}
 				/>
 			</RequirePermission>


### PR DESCRIPTION
When submitting the create organization form on a deployment with more than a handful of organizations the form was being re-rendered as empty instead of taking the user to the freshly created organization, even though the API call succeeded.

The form posts through `mutateAsync` with a per-call `onSuccess` that calls `navigate`. The mutation-level `onSuccess` awaits `invalidateQueries`, which refetches the organizations list and changes the `organizationsPermissions` query key. While that new query loads, `OrganizationSettingsLayout` shows its loader and unmounts `CreateOrganizationPage`. `@tanstack/react-query` only fires per-call mutation callbacks when the observer still has listeners, so the navigate gets dropped. The form re-mounts on `/organizations/new` once permissions resolve, which the user sees as an empty form.

Awaiting `mutateAsync` and running `navigate` inline keeps the navigation out of the observer lifecycle.

Coder Agents generated.