### PR TITLE
chore: allowlist Go-standard marshal spelling in typos config

### DIFF
--- a/.github/workflows/typos.toml
+++ b/.github/workflows/typos.toml
@@ -36,6 +36,9 @@ typ = "typ"
 styl = "styl"
 edn = "edn"
 Inferrable = "Inferrable"
+# Go standard library uses American English single-l spelling throughout encoding/json etc.
+unmarshaling = "unmarshaling"
+marshaling = "marshaling"
 IIF = "IIF"
 
 [files]


### PR DESCRIPTION
typos-cli 1.47.x started flagging `unmarshaling` and `marshaling` as misspellings of the British-English double-l forms.
The Go standard library uses the single-l American English spelling throughout `encoding/json`, `encoding/xml`, etc., so these are correct and intentional.

Adds both words to the `extend-words` allowlist so the linter accepts the canonical Go spelling regardless of which typos version is in use.

---
🤖 Built with AI assistance.