### PR TITLE
fix(site): handle invalid coder_app URLs gracefully

### DIFF
--- a/site/src/modules/apps/WorkspaceAppFrame.tsx
+++ b/site/src/modules/apps/WorkspaceAppFrame.tsx
@@ -63,7 +63,7 @@ export const WorkspaceAppFrame: FC<WorkspaceAppFrameProps> = ({
 						variant="subtle"
 						onClick={(e) => {
 							e.preventDefault();
-							if (frameRef.current?.contentWindow) {
+							if (frameRef.current?.contentWindow && link.href) {
 								frameRef.current.contentWindow.location.href = link.href;
 							}
 						}}
@@ -83,7 +83,11 @@ export const WorkspaceAppFrame: FC<WorkspaceAppFrameProps> = ({
 						</DropdownMenuTrigger>
 						<DropdownMenuContent align="end">
 							<DropdownMenuItem asChild>
-								<RouterLink to={link.href} target="_blank" rel="noreferrer">
+								<RouterLink
+									to={link.href ?? ""}
+									target="_blank"
+									rel="noreferrer"
+								>
 									<ExternalLinkIcon />
 									Open app in new tab
 								</RouterLink>
@@ -94,7 +98,11 @@ export const WorkspaceAppFrame: FC<WorkspaceAppFrameProps> = ({
 			)}
 
 			{app.health === "healthy" || app.health === "disabled" ? (
-				<WorkspaceIframe ref={frameRef} src={link.href} title={link.label} />
+				<WorkspaceIframe
+					ref={frameRef}
+					src={link.href ?? undefined}
+					title={link.label}
+				/>
 			) : app.health === "unhealthy" ? (
 				<div className="w-full h-full flex flex-col items-center justify-center p-4">
 					<h3 className="m-0 font-medium text-content-primary text-base text-center">

--- a/site/src/modules/apps/apps.test.ts
+++ b/site/src/modules/apps/apps.test.ts
@@ -65,6 +65,21 @@ describe("getVSCodeHref", () => {
 });
 
 describe("getAppHref", () => {
+	it("returns null when external app has an invalid URL", () => {
+		const externalApp = {
+			...MockWorkspaceApp,
+			external: true,
+			url: "my-repo",
+		};
+		const href = getAppHref(externalApp, {
+			host: "*.apps-host.tld",
+			path: "/path-base",
+			agent: MockWorkspaceAgent,
+			workspace: MockWorkspace,
+		});
+		expect(href).toBeNull();
+	});
+
 	it("returns the URL without changes when external app has regular URL", () => {
 		const externalApp = {
 			...MockWorkspaceApp,

--- a/site/src/modules/apps/apps.ts
+++ b/site/src/modules/apps/apps.ts
@@ -115,9 +115,14 @@ type GetAppHrefParams = {
 export const getAppHref = (
 	app: WorkspaceApp,
 	{ path, token, workspace, agent, host }: GetAppHrefParams,
-): string => {
+): string | null => {
 	if (isExternalApp(app)) {
-		const appProtocol = new URL(app.url).protocol;
+		let appProtocol: string;
+		try {
+			appProtocol = new URL(app.url).protocol;
+		} catch {
+			return null;
+		}
 		const isAllowedProtocol =
 			ALLOWED_EXTERNAL_APP_PROTOCOLS.includes(appProtocol);
 

--- a/site/src/modules/apps/useAppLink.ts
+++ b/site/src/modules/apps/useAppLink.ts
@@ -21,7 +21,7 @@ type UseAppLinkParams = {
 };
 
 type AppLink = {
-	href: string;
+	href: string | null;
 	onClick: (e: React.MouseEvent) => void;
 	label: string;
 	hasToken: boolean;
@@ -101,7 +101,9 @@ export const useAppLink = (
 		switch (app.open_in) {
 			case "slim-window": {
 				e.preventDefault();
-				openAppInNewWindow(href);
+				if (href) {
+					openAppInNewWindow(href);
+				}
 				return;
 			}
 		}

--- a/site/src/modules/resources/AppLink/AppLink.stories.tsx
+++ b/site/src/modules/resources/AppLink/AppLink.stories.tsx
@@ -243,3 +243,20 @@ export const SlimWindowPopupBlocked: Story = {
 		expect(toastMessage).toBeInTheDocument();
 	},
 };
+
+export const InvalidUrl: Story = {
+	args: {
+		workspace: MockWorkspace,
+		app: {
+			...MockWorkspaceApp,
+			external: true,
+			url: "my-repo",
+		},
+		agent: MockWorkspaceAgent,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const button = canvas.getByRole("link");
+		expect(button).not.toHaveAttribute("href");
+	},
+};

--- a/site/src/modules/resources/AppLink/AppLink.tsx
+++ b/site/src/modules/resources/AppLink/AppLink.tsx
@@ -114,6 +114,17 @@ export const AppLink: FC<AppLinkProps> = ({
 		);
 	}
 
+	if (link.href === null) {
+		canClick = false;
+		icon = (
+			<CircleAlertIcon
+				aria-hidden="true"
+				className="size-icon-sm text-content-warning"
+			/>
+		);
+		primaryTooltip = "This app has an invalid URL and cannot be opened";
+	}
+
 	if (isExternalApp(app) && needsSessionToken(app) && !link.hasToken) {
 		canClick = false;
 	}
@@ -141,7 +152,7 @@ export const AppLink: FC<AppLinkProps> = ({
 	const button = grouped ? (
 		<DropdownMenuItem asChild>
 			<a
-				href={canClick ? link.href : undefined}
+				href={canClick && link.href ? link.href : undefined}
 				onClick={link.onClick}
 				target={app.open_in === "tab" ? "_blank" : undefined}
 				rel={app.open_in === "tab" ? "noreferrer" : undefined}
@@ -154,7 +165,7 @@ export const AppLink: FC<AppLinkProps> = ({
 	) : (
 		<AgentButton asChild>
 			<a
-				href={canClick ? link.href : undefined}
+				href={canClick && link.href ? link.href : undefined}
 				onClick={link.onClick}
 				target={app.open_in === "tab" ? "_blank" : undefined}
 				rel={app.open_in === "tab" ? "noreferrer" : undefined}

--- a/site/src/pages/AgentsPage/components/WorkspacePill.tsx
+++ b/site/src/pages/AgentsPage/components/WorkspacePill.tsx
@@ -344,7 +344,7 @@ const AppMenuItem: FC<{
 	return (
 		<DropdownMenuItem asChild disabled={!canClick || !isRunning}>
 			<a
-				href={canClick && isRunning ? link.href : undefined}
+				href={canClick && isRunning && link.href ? link.href : undefined}
 				onClick={link.onClick}
 				target="_blank"
 				rel="noreferrer"

--- a/site/src/pages/TaskPage/TaskApps.tsx
+++ b/site/src/pages/TaskPage/TaskApps.tsx
@@ -174,7 +174,7 @@ const ExternalAppMenuItem: FC<{
 
 	return (
 		<DropdownMenuItem asChild>
-			<RouterLink to={link.href}>
+			<RouterLink to={link.href ?? ""}>
 				{app.icon ? <ExternalImage src={app.icon} /> : <LayoutGridIcon />}
 				{link.label}
 			</RouterLink>
@@ -201,7 +201,7 @@ const TaskAppTab: FC<TaskAppTabProps> = ({
 	});
 
 	return (
-		<TaskTab active={active} to={link.href} onClick={onClick}>
+		<TaskTab active={active} to={link.href ?? ""} onClick={onClick}>
 			{app.icon ? <ExternalImage src={app.icon} /> : <LayoutGridIcon />}
 			{link.label}
 			{app.health === "unhealthy" && (

--- a/site/src/pages/WorkspacePage/AppStatuses.tsx
+++ b/site/src/pages/WorkspacePage/AppStatuses.tsx
@@ -175,7 +175,7 @@ const AppLink: FC<AppLinkProps> = ({ app, agent, workspace }) => {
 	return (
 		<Button asChild variant="outline" size="sm">
 			<a
-				href={link.href}
+				href={link.href ?? undefined}
 				onClick={link.onClick}
 				target="_blank"
 				rel="noreferrer"

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -809,7 +809,7 @@ const IconAppLink: FC<IconAppLinkProps> = ({ app, workspace, agent }) => {
 		<BaseIconLink
 			key={app.id}
 			label={`Open ${link.label}`}
-			href={link.href}
+			href={link.href ?? undefined}
 			onClick={link.onClick}
 		>
 			<ExternalImage src={app.icon ?? "/icon/widgets.svg"} />


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/22350

## Problem

`getAppHref()` in `site/src/modules/apps/apps.ts` calls `new URL(app.url)` without error handling. When a template author provides an invalid URL (e.g. a bare string with no scheme like `"my-repo"`), this throws `TypeError: Failed to construct 'URL': Invalid URL` during render, crashing both the Workspace List and Workspace detail pages.

## Solution

- **`apps.ts`**: Wrapped `new URL(app.url)` in a try-catch; `getAppHref()` now returns `null` instead of throwing
- **`useAppLink.ts`**: Updated `AppLink.href` type from `string` to `string | null` with null guard
- **`AppLink.tsx`**: When `link.href === null`, renders a disabled button with tooltip "This app has an invalid URL and cannot be opened", following the existing pattern for `isAppBlockedByMissingWildcard`
- **5 consumer files**: Added null guards for `WorkspaceAppFrame`, `WorkspacePill`, `TaskApps`, `AppStatuses`, `WorkspacesTable`
- **Tests**: Added unit test for `getAppHref` returning null on invalid URLs, and an `InvalidUrl` Storybook story

<details><summary>Implementation details</summary>

The fix follows the existing error-state pattern where subdomain misconfiguration shows a disabled button with tooltip. All downstream consumers of `useAppLink` are updated to handle the nullable href without breaking existing functionality.

</details>

> Generated by Coder Agents on behalf of @stirby