### PR TITLE
fix(site): show delete menu for failed devcontainers

### DIFF
--- a/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
@@ -59,6 +59,31 @@ export const HasError: Story = {
 	},
 };
 
+export const ErrorWithNoContainerOrAgent: Story = {
+	args: {
+		devcontainer: {
+			...MockWorkspaceAgentDevcontainer,
+			status: "error",
+			error: "exit status 1",
+			container: undefined,
+			agent: undefined,
+		},
+		subAgents: [],
+	},
+	play: async ({ canvasElement }) => {
+		const user = userEvent.setup();
+		const canvas = within(canvasElement);
+
+		const moreActionsButton = canvas.getByRole("button", {
+			name: "Dev Container actions",
+		});
+		await user.click(moreActionsButton);
+
+		const body = canvasElement.ownerDocument.body;
+		await within(body).findByText("Delete…");
+	},
+};
+
 export const NoPorts: Story = {};
 
 export const WithPorts: Story = {

--- a/site/src/modules/resources/AgentDevcontainerCard.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.tsx
@@ -273,7 +273,7 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 							/>
 						)}
 
-					{showDevcontainerControls && (
+					{devcontainer.status !== "deleting" && (
 						<AgentDevcontainerMoreActions
 							deleteDevContainer={deleteDevcontainerMutation.mutate}
 						/>


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/23754

## Problem

The three-dot menu (containing the "Delete" option) does not appear on devcontainer cards in a failed/error state (e.g. `exit status 1`). Users have no way to clean up failed devcontainers from the UI.

## Root Cause

In `AgentDevcontainerCard.tsx`, the `showDevcontainerControls` flag required both a sub-agent and a container reference (`subAgent && devcontainer.container`). The `AgentDevcontainerMoreActions` component was gated on this condition, so it was hidden when a devcontainer failed and had no container or agent.

## Solution

Changed the rendering condition for `AgentDevcontainerMoreActions` from `showDevcontainerControls` to `devcontainer.status !== "deleting"`. The Delete action only needs `parentAgent` and `devcontainer` (always available as props), so the only state where the menu should be hidden is when deletion is already in progress. SSH and port-forwarding buttons remain gated on `showDevcontainerControls` since they require a running container/agent.

Added `ErrorWithNoContainerOrAgent` Storybook story with a play function that verifies the Delete option is accessible.

> Generated by Coder Agents on behalf of @stirby