### PR TITLE
fix: several UI fixes for Template Builder

### DIFF
--- a/site/src/pages/TemplateBuilder/ModuleConfiguration.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleConfiguration.tsx
@@ -1,4 +1,4 @@
-import { TrashIcon } from "lucide-react";
+import { CheckIcon, TrashIcon } from "lucide-react";
 import { Button } from "#/components/Button/Button";
 import { CollapsibleSummary } from "#/components/CollapsibleSummary/CollapsibleSummary";
 import { TemplateBuilderAvatarData } from "#/pages/TemplateBuilder/TemplateBuilderAvatarData";
@@ -58,14 +58,19 @@ export const ModuleConfiguration: React.FC<ModuleConfigurationProps> = ({
 				</ConfigurationFieldContainer>
 			)}
 
-			{optionalFields && optionalFields.length > 0 && (
-				<CollapsibleSummary label="Advanced settings" className="mt-4">
+			{optionalFields && optionalFields.length > 0 ? (
+				<CollapsibleSummary label="Additional settings" className="mt-4">
 					<ConfigurationFieldContainer>
 						{optionalFields.map((f) => (
 							<ConfigurationField key={f.id} field={f} />
 						))}
 					</ConfigurationFieldContainer>
 				</CollapsibleSummary>
+			) : (
+				<div className="text-sm text-content-secondary flex items-center gap-2 mt-4">
+					<CheckIcon className="w-4 h-4" />
+					No configuration required.
+				</div>
 			)}
 		</section>
 	);

--- a/site/src/pages/TemplateBuilder/SelectionSummary.tsx
+++ b/site/src/pages/TemplateBuilder/SelectionSummary.tsx
@@ -174,7 +174,7 @@ const ModuleSelection: React.FC<ModuleSelectionProps> = ({
 			{modules.map((module) => (
 				<div
 					key={module.id}
-					className="group flex items-start justify-between p-1 mb-1 hover:bg-surface-secondary"
+					className="group flex items-start justify-between p-1 mb-1 rounded-sm hover:bg-surface-secondary"
 				>
 					<div className="h-[1lh] content-center">
 						<img


### PR DESCRIPTION
- Module selection summary now has `rounded-sm` corners to fit the icon
- Modules without configuration now say so with a check mark
- Correct "Additional settings" label
