### PR TITLE
fix: redact env var values in agent debug manifest endpoint

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2291,16 +2291,19 @@ func (a *agent) HandleHTTPDebugManifest(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Redact environment variable values before serving the manifest. This
-	// debug endpoint is unauthenticated on the loopback interface, so it is
-	// reachable by any process in the workspace regardless of Unix user. The
-	// keys are preserved so operators can still confirm which variables are
-	// configured without exposing template-provided values that may carry
-	// credentials.
+	// Redact env values. This endpoint is unauthenticated on loopback,
+	// reachable by any process regardless of Unix user. Keys are preserved
+	// so operators can still see which variables are configured.
 	debugManifest := *sdkManifest
 	if len(sdkManifest.EnvironmentVariables) > 0 {
 		envs := make(map[string]string, len(sdkManifest.EnvironmentVariables))
-		for k := range sdkManifest.EnvironmentVariables {
+		for k, v := range sdkManifest.EnvironmentVariables {
+			// Preserve empty values, which carry no secret, matching
+			// sanitizeEnv in support/support.go.
+			if v == "" {
+				envs[k] = v
+				continue
+			}
 			envs[k] = redactedManifestEnvValue
 		}
 		debugManifest.EnvironmentVariables = envs
@@ -2312,9 +2315,9 @@ func (a *agent) HandleHTTPDebugManifest(w http.ResponseWriter, r *http.Request) 
 	}
 }
 
-// redactedManifestEnvValue replaces environment variable values in the
-// unauthenticated debug manifest response.
-const redactedManifestEnvValue = "*redacted*"
+// redactedManifestEnvValue matches the marker used by sanitizeEnv in
+// support/support.go so a support bundle and this endpoint agree.
+const redactedManifestEnvValue = "***REDACTED***"
 
 func (a *agent) HTTPDebug() http.Handler {
 	r := chi.NewRouter()

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2291,11 +2291,30 @@ func (a *agent) HandleHTTPDebugManifest(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Redact environment variable values before serving the manifest. This
+	// debug endpoint is unauthenticated on the loopback interface, so it is
+	// reachable by any process in the workspace regardless of Unix user. The
+	// keys are preserved so operators can still confirm which variables are
+	// configured without exposing template-provided values that may carry
+	// credentials.
+	debugManifest := *sdkManifest
+	if len(sdkManifest.EnvironmentVariables) > 0 {
+		envs := make(map[string]string, len(sdkManifest.EnvironmentVariables))
+		for k := range sdkManifest.EnvironmentVariables {
+			envs[k] = redactedManifestEnvValue
+		}
+		debugManifest.EnvironmentVariables = envs
+	}
+
 	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(sdkManifest); err != nil {
+	if err := json.NewEncoder(w).Encode(debugManifest); err != nil {
 		a.logger.Error(a.hardCtx, "write debug manifest", slog.Error(err))
 	}
 }
+
+// redactedManifestEnvValue replaces environment variable values in the
+// unauthenticated debug manifest response.
+const redactedManifestEnvValue = "*redacted*"
 
 func (a *agent) HTTPDebug() http.Handler {
 	r := chi.NewRouter()

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3672,6 +3672,9 @@ func TestAgent_DebugServer(t *testing.T) {
 	//nolint:dogsled
 	conn, _, _, _, agnt := setupAgentWithSecrets(t, agentsdk.Manifest{
 		DERPMap: derpMap,
+		EnvironmentVariables: map[string]string{
+			"AWS_SECRET_ACCESS_KEY": "super-secret-value-12345",
+		},
 	}, []agentsdk.WorkspaceSecret{
 		{EnvName: "DEBUG_SECRET", Value: []byte("super-secret-value-12345")},
 	}, 0, func(c *agenttest.Client, o *agent.Options) {
@@ -3798,6 +3801,34 @@ func TestAgent_DebugServer(t *testing.T) {
 		// to leak through JSON encoding.
 		var v agentsdk.Manifest
 		require.NoError(t, json.Unmarshal(body, &v))
+	})
+
+	t.Run("ManifestEnvVarValuesRedacted", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/debug/manifest", nil)
+		require.NoError(t, err)
+
+		res, err := srv.Client().Do(req)
+		require.NoError(t, err)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		body, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+
+		// Environment variable values may carry template-provided
+		// credentials, so the debug endpoint must not expose them.
+		require.NotContains(t, string(body), "super-secret-value-12345")
+
+		var v agentsdk.Manifest
+		require.NoError(t, json.Unmarshal(body, &v))
+
+		// The key is preserved so operators can confirm which
+		// variables are configured, but the value is redacted.
+		require.Contains(t, v.EnvironmentVariables, "AWS_SECRET_ACCESS_KEY")
+		require.Equal(t, "*redacted*", v.EnvironmentVariables["AWS_SECRET_ACCESS_KEY"])
 	})
 
 	t.Run("Logs", func(t *testing.T) {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3673,7 +3673,8 @@ func TestAgent_DebugServer(t *testing.T) {
 	conn, _, _, _, agnt := setupAgentWithSecrets(t, agentsdk.Manifest{
 		DERPMap: derpMap,
 		EnvironmentVariables: map[string]string{
-			"AWS_SECRET_ACCESS_KEY": "super-secret-value-12345",
+			"AWS_SECRET_ACCESS_KEY": "env-value-should-be-redacted-67890",
+			"EMPTY_VAR":             "",
 		},
 	}, []agentsdk.WorkspaceSecret{
 		{EnvName: "DEBUG_SECRET", Value: []byte("super-secret-value-12345")},
@@ -3818,17 +3819,17 @@ func TestAgent_DebugServer(t *testing.T) {
 		body, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 
-		// Environment variable values may carry template-provided
-		// credentials, so the debug endpoint must not expose them.
-		require.NotContains(t, string(body), "super-secret-value-12345")
+		require.NotContains(t, string(body), "env-value-should-be-redacted-67890")
 
 		var v agentsdk.Manifest
 		require.NoError(t, json.Unmarshal(body, &v))
 
-		// The key is preserved so operators can confirm which
-		// variables are configured, but the value is redacted.
 		require.Contains(t, v.EnvironmentVariables, "AWS_SECRET_ACCESS_KEY")
-		require.Equal(t, "*redacted*", v.EnvironmentVariables["AWS_SECRET_ACCESS_KEY"])
+		require.Equal(t, "***REDACTED***", v.EnvironmentVariables["AWS_SECRET_ACCESS_KEY"])
+
+		// Empty values carry no secret and are preserved as empty.
+		require.Contains(t, v.EnvironmentVariables, "EMPTY_VAR")
+		require.Equal(t, "", v.EnvironmentVariables["EMPTY_VAR"])
 	})
 
 	t.Run("Logs", func(t *testing.T) {


### PR DESCRIPTION
The unauthenticated /debug/manifest endpoint on the agent debug server (127.0.0.1:2113 by default) JSON-encoded the full manifest, including EnvironmentVariables values. Because the endpoint is reachable by any process in the workspace regardless of Unix user, template-provided values that may carry credentials were readable across users.

Redact the environment variable values in the debug manifest response while preserving the keys, so operators can still confirm which variables are configured. This matches the existing support-bundle behavior, which already redacts these values via sanitizeEnv.