### PR TITLE
Revert "chore: hide AI Gateway key management UI/CLI/API (#26879)"

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -1434,10 +1434,7 @@ const docTemplate = `{
                     {
                         "CoderSessionToken": []
                     }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
+                ]
             },
             "post": {
                 "consumes": [
@@ -1474,10 +1471,7 @@ const docTemplate = `{
                     {
                         "CoderSessionToken": []
                     }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
+                ]
             }
         },
         "/api/v2/ai-gateway/keys/{key}": {
@@ -1506,10 +1500,7 @@ const docTemplate = `{
                     {
                         "CoderSessionToken": []
                     }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
+                ]
             }
         },
         "/api/v2/ai-gateway/models": {
@@ -1557,10 +1548,7 @@ const docTemplate = `{
                     {
                         "AIGatewayKey": []
                     }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
+                ]
             }
         },
         "/api/v2/ai-gateway/sessions": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -1269,10 +1269,7 @@
 					{
 						"CoderSessionToken": []
 					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
+				]
 			},
 			"post": {
 				"consumes": ["application/json"],
@@ -1303,10 +1300,7 @@
 					{
 						"CoderSessionToken": []
 					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
+				]
 			}
 		},
 		"/api/v2/ai-gateway/keys/{key}": {
@@ -1333,10 +1327,7 @@
 					{
 						"CoderSessionToken": []
 					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
+				]
 			}
 		},
 		"/api/v2/ai-gateway/models": {
@@ -1378,10 +1369,7 @@
 					{
 						"AIGatewayKey": []
 					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
+				]
 			}
 		},
 		"/api/v2/ai-gateway/sessions": {

--- a/docs/reference/api/enterprise.md
+++ b/docs/reference/api/enterprise.md
@@ -178,6 +178,152 @@ curl -X GET http://coder-server:8080/api/v2/agent-firewall/sessions/{id}/logs \
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## List AI Gateway keys
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/ai-gateway/keys \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/v2/ai-gateway/keys`
+
+### Example responses
+
+> 200 Response
+
+```json
+[
+  {
+    "created_at": "2019-08-24T14:15:22Z",
+    "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+    "key_prefix": "string",
+    "last_heartbeat_at": "2019-08-24T14:15:22Z",
+    "name": "string"
+  }
+]
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                            |
+|--------|---------------------------------------------------------|-------------|-------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | array of [codersdk.AIGatewayKey](schemas.md#codersdkaigatewaykey) |
+
+<h3 id="list-ai-gateway-keys-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+| Name                  | Type              | Required | Restrictions | Description |
+|-----------------------|-------------------|----------|--------------|-------------|
+| `[array item]`        | array             | false    |              |             |
+| `» created_at`        | string(date-time) | false    |              |             |
+| `» id`                | string(uuid)      | false    |              |             |
+| `» key_prefix`        | string            | false    |              |             |
+| `» last_heartbeat_at` | string(date-time) | false    |              |             |
+| `» name`              | string            | false    |              |             |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Create AI Gateway key
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X POST http://coder-server:8080/api/v2/ai-gateway/keys \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`POST /api/v2/ai-gateway/keys`
+
+> Body parameter
+
+```json
+{
+  "name": "string"
+}
+```
+
+### Parameters
+
+| Name   | In   | Type                                                                               | Required | Description                   |
+|--------|------|------------------------------------------------------------------------------------|----------|-------------------------------|
+| `body` | body | [codersdk.CreateAIGatewayKeyRequest](schemas.md#codersdkcreateaigatewaykeyrequest) | true     | Create AI Gateway key request |
+
+### Example responses
+
+> 201 Response
+
+```json
+{
+  "created_at": "2019-08-24T14:15:22Z",
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "key": "string",
+  "key_prefix": "string",
+  "name": "string"
+}
+```
+
+### Responses
+
+| Status | Meaning                                                      | Description | Schema                                                                               |
+|--------|--------------------------------------------------------------|-------------|--------------------------------------------------------------------------------------|
+| 201    | [Created](https://tools.ietf.org/html/rfc7231#section-6.3.2) | Created     | [codersdk.CreateAIGatewayKeyResponse](schemas.md#codersdkcreateaigatewaykeyresponse) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Delete AI Gateway key
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X DELETE http://coder-server:8080/api/v2/ai-gateway/keys/{key} \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`DELETE /api/v2/ai-gateway/keys/{key}`
+
+### Parameters
+
+| Name  | In   | Type         | Required | Description |
+|-------|------|--------------|----------|-------------|
+| `key` | path | string(uuid) | true     | Key ID      |
+
+### Responses
+
+| Status | Meaning                                                         | Description | Schema |
+|--------|-----------------------------------------------------------------|-------------|--------|
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## AI Gateway serve
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/ai-gateway/serve \
+  -H 'X-AI-Governance-Gateway-Key: API_KEY'
+```
+
+`GET /api/v2/ai-gateway/serve`
+
+### Responses
+
+| Status | Meaning                                                                  | Description         | Schema |
+|--------|--------------------------------------------------------------------------|---------------------|--------|
+| 101    | [Switching Protocols](https://tools.ietf.org/html/rfc7231#section-6.2.2) | Switching Protocols |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## Get appearance
 
 ### Code samples

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -66,6 +66,7 @@ Coder — A tool for provisioning self-hosted development environments with Terr
 | [<code>support</code>](./support.md)                         | Commands for troubleshooting issues with a Coder deployment.                                                                 |
 | [<code>server</code>](./server.md)                           | Start a Coder server                                                                                                         |
 | [<code>provisioner</code>](./provisioner.md)                 | View and manage provisioner daemons and jobs                                                                                 |
+| [<code>ai-gateway</code>](./ai-gateway.md)                   | Manage AI Gateway                                                                                                            |
 | [<code>agent-firewall</code>](./agent-firewall.md)           | Network isolation tool for monitoring and restricting HTTP/HTTPS requests                                                    |
 | [<code>features</code>](./features.md)                       | List Enterprise features                                                                                                     |
 | [<code>licenses</code>](./licenses.md)                       | Add, delete, and list licenses                                                                                               |

--- a/enterprise/cli/aigateway.go
+++ b/enterprise/cli/aigateway.go
@@ -14,9 +14,8 @@ import (
 
 func (r *RootCmd) aiGateway() *serpent.Command {
 	return &serpent.Command{
-		Use:    "ai-gateway",
-		Short:  "Manage AI Gateway",
-		Hidden: true,
+		Use:   "ai-gateway",
+		Short: "Manage AI Gateway",
 		Handler: func(inv *serpent.Invocation) error {
 			return inv.Command.HelpHandler(inv)
 		},

--- a/enterprise/cli/testdata/coder_--help.golden
+++ b/enterprise/cli/testdata/coder_--help.golden
@@ -16,6 +16,7 @@ USAGE:
 SUBCOMMANDS:
     agent-firewall         Network isolation tool for monitoring and restricting
                            HTTP/HTTPS requests
+    ai-gateway             Manage AI Gateway
     external-workspaces    Create or manage external workspaces
     features               List Enterprise features
     groups                 Manage groups

--- a/enterprise/cli/testdata/coder_ai-gateway_--help.golden
+++ b/enterprise/cli/testdata/coder_ai-gateway_--help.golden
@@ -1,0 +1,12 @@
+coder v0.0.0-devel
+
+USAGE:
+  coder ai-gateway
+
+  Manage AI Gateway
+
+SUBCOMMANDS:
+    keys    Manage AI Gateway keys
+
+———
+Run `coder --help` for a list of global options.

--- a/enterprise/cli/testdata/coder_ai-gateway_keys_--help.golden
+++ b/enterprise/cli/testdata/coder_ai-gateway_keys_--help.golden
@@ -1,0 +1,14 @@
+coder v0.0.0-devel
+
+USAGE:
+  coder ai-gateway keys
+
+  Manage AI Gateway keys
+
+SUBCOMMANDS:
+    create    Create an AI Gateway key
+    delete    Delete an AI Gateway key
+    list      List AI Gateway keys
+
+———
+Run `coder --help` for a list of global options.

--- a/enterprise/cli/testdata/coder_ai-gateway_keys_create_--help.golden
+++ b/enterprise/cli/testdata/coder_ai-gateway_keys_create_--help.golden
@@ -1,0 +1,9 @@
+coder v0.0.0-devel
+
+USAGE:
+  coder ai-gateway keys create <name>
+
+  Create an AI Gateway key
+
+———
+Run `coder --help` for a list of global options.

--- a/enterprise/cli/testdata/coder_ai-gateway_keys_delete_--help.golden
+++ b/enterprise/cli/testdata/coder_ai-gateway_keys_delete_--help.golden
@@ -1,0 +1,15 @@
+coder v0.0.0-devel
+
+USAGE:
+  coder ai-gateway keys delete [flags] <name|id>
+
+  Delete an AI Gateway key
+
+  Aliases: rm
+
+OPTIONS:
+  -y, --yes bool
+          Bypass confirmation prompts.
+
+———
+Run `coder --help` for a list of global options.

--- a/enterprise/cli/testdata/coder_ai-gateway_keys_list_--help.golden
+++ b/enterprise/cli/testdata/coder_ai-gateway_keys_list_--help.golden
@@ -1,0 +1,18 @@
+coder v0.0.0-devel
+
+USAGE:
+  coder ai-gateway keys list [flags]
+
+  List AI Gateway keys
+
+  Aliases: ls
+
+OPTIONS:
+  -c, --column [id|name|key prefix|created at|last heartbeat at] (default: id,name,key prefix,last heartbeat at,created at)
+          Columns to display in table output.
+
+  -o, --output table|json (default: table)
+          Output format.
+
+———
+Run `coder --help` for a list of global options.

--- a/enterprise/coderd/aibridgeserve.go
+++ b/enterprise/coderd/aibridgeserve.go
@@ -42,7 +42,6 @@ const aiGatewayKeyHeartbeatInterval = 60 * time.Second
 // @Tags Enterprise
 // @Success 101
 // @Router /api/v2/ai-gateway/serve [get]
-// @x-apidocgen {"skip": true}
 func (api *API) aiGatewayServe(rw http.ResponseWriter, r *http.Request) {
 	key := r.Header.Get(codersdk.AIGatewayKeyHeader)
 	if key == "" {

--- a/enterprise/coderd/aigatewaykeys.go
+++ b/enterprise/coderd/aigatewaykeys.go
@@ -29,7 +29,6 @@ const nameFormatDetail = "Must be 64 characters or fewer, lowercase letters, num
 // @Param request body codersdk.CreateAIGatewayKeyRequest true "Create AI Gateway key request"
 // @Success 201 {object} codersdk.CreateAIGatewayKeyResponse
 // @Router /api/v2/ai-gateway/keys [post]
-// @x-apidocgen {"skip": true}
 func (api *API) postAIGatewayKey(rw http.ResponseWriter, r *http.Request) {
 	var (
 		ctx               = r.Context()
@@ -118,7 +117,6 @@ func writeKeyInsertError(ctx context.Context, rw http.ResponseWriter, err error)
 // @Tags Enterprise
 // @Success 200 {array} codersdk.AIGatewayKey
 // @Router /api/v2/ai-gateway/keys [get]
-// @x-apidocgen {"skip": true}
 func (api *API) aiGatewayKeys(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
@@ -149,7 +147,6 @@ func (api *API) aiGatewayKeys(rw http.ResponseWriter, r *http.Request) {
 // @Param key path string true "Key ID" format(uuid)
 // @Success 204
 // @Router /api/v2/ai-gateway/keys/{key} [delete]
-// @x-apidocgen {"skip": true}
 func (api *API) deleteAIGatewayKey(rw http.ResponseWriter, r *http.Request) {
 	var (
 		ctx               = r.Context()

--- a/site/src/modules/management/AISettingsSidebarView.tsx
+++ b/site/src/modules/management/AISettingsSidebarView.tsx
@@ -42,6 +42,11 @@ const AISettingsSidebarView: FC<AISettingsSidebarViewProps> = ({
 						AI Governance
 					</SidebarNavItem>
 				)}
+				{permissions.viewAIGatewayKeys && (
+					<SidebarNavItem href="/ai/settings/gateway-keys">
+						AI Gateway keys
+					</SidebarNavItem>
+				)}
 				{permissions.viewAnyAIProvider && (
 					<SidebarNavItem href="/ai/settings/providers">
 						Providers

--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -434,7 +434,7 @@ const AISettingsAddProviderPage = lazy(
 			"./pages/AISettingsPage/ProvidersPage/AddProviderPage/AddProviderPage"
 		),
 );
-const _AISettingsGatewayKeysPage = lazy(
+const AISettingsGatewayKeysPage = lazy(
 	() => import("./pages/AISettingsPage/GatewayKeysPage/GatewayKeysPage"),
 );
 const AISettingsModelsPage = lazy(
@@ -474,6 +474,10 @@ const AISettingsIndexRedirect = () => {
 
 	if (permissions.viewAnyAIProvider) {
 		return <Navigate to="/ai/settings/providers" replace />;
+	}
+
+	if (permissions.viewAIGatewayKeys) {
+		return <Navigate to="/ai/settings/gateway-keys" replace />;
 	}
 
 	if (permissions.editDeploymentConfig) {
@@ -756,6 +760,10 @@ export const router = createBrowserRouter(
 						<Route element={<DeploymentConfigProvider />}>
 							<Route path="governance" element={<AIGovernanceSettingsPage />} />
 						</Route>
+						<Route
+							path="gateway-keys"
+							element={<AISettingsGatewayKeysPage />}
+						/>
 						<Route index element={<AISettingsIndexRedirect />} />
 						<Route path="models" element={<AISettingsModelsPage />} />
 						<Route path="spend" element={<AISettingsSpendPage />} />


### PR DESCRIPTION
Reverting https://github.com/coder/coder/commit/377c1309b7a42ead9cfbd864f0af8e9b6e472851 since release 2.35 was already cut: https://github.com/coder/coder/tree/release/2.35