### PR TITLE
fix(site): update providers docs link

### DIFF
--- a/site/src/pages/AISettingsPage/ProvidersPage/ProvidersPageView.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/ProvidersPageView.tsx
@@ -88,7 +88,7 @@ const ProvidersPageView: React.FC<ProvidersPageViewProps> = ({
 					Bedrock. Providers configured here power Coder Agents, AI Gateway, and
 					other capabilities such as APIs, CLI or IDEs that use LLMs. By
 					default, users can supply their own keys for any provider.{" "}
-					<Link href={docs("/ai-coder/ai-gateway/auth#enable-or-disable-byok")}>
+					<Link href={docs("/ai-coder/ai-gateway/setup#configure-providers")}>
 						View docs
 					</Link>
 				</SettingsHeaderDescription>


### PR DESCRIPTION
Updates the Providers page docs link to the AI Gateway provider configuration setup section instead of the BYOK configuration section.

The inline page-header link pattern is preserved to match nearby AI Settings pages.

> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood
