### PR TITLE
chore(dogfood): replace deprecated agent dir with vscode-desktop module

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -337,6 +337,14 @@ module "mux" {
   max_restart_attempts = 10
 }
 
+module "vscode-desktop" {
+  count    = contains(jsondecode(data.coder_parameter.ide_choices.value), "vscode") ? data.coder_workspace.me.start_count : 0
+  source   = "dev.registry.coder.com/coder/vscode-desktop/coder"
+  version  = "1.2.1"
+  agent_id = coder_agent.dev.id
+  folder   = local.repo_dir
+}
+
 module "code-server" {
   count                   = contains(jsondecode(data.coder_parameter.ide_choices.value), "code-server") ? data.coder_workspace.me.start_count : 0
   source                  = "dev.registry.coder.com/coder/code-server/coder"
@@ -426,7 +434,6 @@ module "portabledesktop" {
 resource "coder_agent" "dev" {
   arch = "amd64"
   os   = "linux"
-  dir  = local.repo_dir
   env = merge(
     {
       OIDC_TOKEN : data.coder_workspace_owner.me.oidc_access_token,
@@ -456,7 +463,7 @@ resource "coder_agent" "dev" {
   startup_script_behavior = "blocking"
 
   display_apps {
-    vscode          = contains(jsondecode(data.coder_parameter.ide_choices.value), "vscode")
+    vscode          = false # served by the vscode-desktop module instead, so `folder` keeps working without the deprecated agent `dir` attribute.
     vscode_insiders = false
   }
 
@@ -608,6 +615,41 @@ resource "coder_agent" "dev" {
 
     # Stop the Docker service to prevent errors during workspace destroy.
     sudo service docker stop
+  EOT
+}
+
+# The `dir` attribute on `coder_agent` is deprecated (it breaks Coder Desktop
+# file sync when set to anything other than `$HOME`). This coder_script
+# replaces it as the mechanism that lands plain `coder ssh`/web terminal
+# sessions in the cloned repo instead of $HOME.
+#
+# It writes to /etc/profile.d/ instead of ~/.bashrc, ~/.zshrc, etc. on
+# purpose: those are managed by the `dotfiles` module (which may symlink in
+# a user's own dotfiles repo) and the `personalize` script, and clobbering
+# either would silently undo someone's own shell customization. /etc/profile.d
+# lives outside $HOME, is sourced by /etc/profile for login shells only
+# (which is what a bare SSH/web terminal session requests), and won't be
+# touched by either of those.
+resource "coder_script" "default_workdir" {
+  agent_id           = coder_agent.dev.id
+  display_name       = "Configure Default Working Directory"
+  run_on_start       = true
+  start_blocks_login = false
+  script             = <<-EOT
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    sudo tee /etc/profile.d/00-coder-default-workdir.sh > /dev/null <<-'EOF'
+    # Managed by the coder/coder dogfood template (dogfood/coder/main.tf).
+    # Lands interactive login shells (plain ssh/web terminal) in the
+    # cloned repo instead of $HOME. Never edits the user's own dotfiles.
+    case "$-" in
+      *i*)
+        [ -d "${local.repo_dir}" ] && cd "${local.repo_dir}" || true
+        ;;
+    esac
+    EOF
+    sudo chmod 644 /etc/profile.d/00-coder-default-workdir.sh
   EOT
 }
 


### PR DESCRIPTION
## Summary

`coder_agent.dir` is deprecated ([terraform-provider-coder#…](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/agent)) because setting it to anything other than `$HOME` breaks Coder Desktop file sync. This template was one of the few remaining consumers, using `dir = local.repo_dir` for two unrelated purposes: the built-in VS Code Desktop `display_apps` folder, and the default landing directory for plain `ssh`/web terminal sessions.

## Changes

- Added a `vscode-desktop` module block (`folder = local.repo_dir`), matching the pattern already used by every other IDE in this template (`cursor`, `windsurf`, `zed`, `jetbrains`, `code-server`, `vscode-web`). Disabled the built-in `display_apps.vscode` app it replaces.
- Removed `dir = local.repo_dir` from `coder_agent.dev`.
- Added a `coder_script` (`default_workdir`) that writes `/etc/profile.d/00-coder-default-workdir.sh` to `cd` into the repo on interactive login shells, replacing what `dir` did for bare SSH/terminal sessions.

> [!NOTE]
> The workdir script deliberately writes to `/etc/profile.d/` instead of `~/.bashrc`/`~/.zshrc`. Those are managed by the `dotfiles` module (which may symlink in someone's own dotfiles repo) and the `personalize` script — writing there directly would either get clobbered or silently override a user's own customization. `/etc/profile.d` lives outside `$HOME`, is only sourced by `/etc/profile` for login shells (which is what a bare `ssh`/web terminal session requests), and is never touched by either mechanism.

## Validation

Not yet applied against a live dogfood workspace — flagging for review before merge given this touches the primary dev template.

<details>
<summary>Discussion context</summary>

This originated from a review of the `coder_agent.dir` deprecation, which conflates two use cases:

1. **Built-in `display_apps.vscode` folder** — solved by the `vscode-desktop` module's own `folder` variable, which is fully decoupled from `dir`.
2. **Default SSH/terminal landing directory** — no direct Terraform-level replacement exists; the agent's `agentssh.WorkingDirectory` falls back to `$HOME` once `dir` is gone. Recommended approach is to configure this at the shell layer during workspace startup, non-destructively.

The dogfood template exercised both cases directly (`dir = local.repo_dir` plus `display_apps.vscode` depending on it), which is why it's a good reference migration for other templates hitting the same deprecation.
</details>

> 🤖 This PR was created with the help of Coder Agents, and needs a human review. 🧑💻