### PR TITLE
fix: link to /templates/new from Template Builder options

### DIFF
--- a/site/src/pages/TemplateBuilder/TemplateAlternatives.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateAlternatives.tsx
@@ -17,7 +17,7 @@ const alternatives: readonly AlternativeLink[] = [
 	},
 	{
 		label: "Upload an existing template",
-		href: "/starter-templates",
+		href: "/templates/new",
 		external: false,
 	},
 	{
@@ -35,7 +35,7 @@ const alternatives: readonly AlternativeLink[] = [
 export const TemplateAlternatives: FC = () => {
 	return (
 		<div className="p-6 border border-solid rounded-lg mt-6">
-			<p className="text-sm text-content-secondary mb-4">
+			<p className="text-sm text-content-secondary mb-4 mt-0">
 				Alternatives to create a template:
 			</p>
 			<div className="flex flex-wrap gap-2">


### PR DESCRIPTION
- "Upload an existing template" now points to `/templates/new`
- Removes a bit of top margin for the additional actions box

<img width="1099" height="168" alt="Screenshot 2026-07-01 at 1 02 57 PM" src="https://github.com/user-attachments/assets/12d4683e-2ee8-45e3-b94f-e04a3a583c75" />
