### PR TITLE
fix(.github/workflows): restore mise tool setup in tag-and-release

### DIFF
--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -85,10 +85,10 @@ jobs:
       - name: Fetch git tags
         run: git fetch --tags --force
 
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
+      - name: Set up mise tools
+        uses: ./.github/actions/setup-mise
         with:
-          use-cache: false
+          install-args: "go"
 
       - name: Prepare release (calculate version, create tag and branch)
         id: prepare
@@ -902,8 +902,13 @@ jobs:
       - name: Fetch git tags
         run: git fetch --tags --force
 
-      - name: Setup Node
-        uses: ./.github/actions/setup-node
+      - name: Set up mise tools
+        uses: ./.github/actions/setup-mise
+        with:
+          install-args: "node pnpm"
+
+      - name: Install pnpm dependencies
+        uses: ./.github/actions/pnpm-install
 
       - name: Update release calendar
         run: ./scripts/update-release-calendar.sh


### PR DESCRIPTION
The `tag-and-release` workflow fails at startup with `Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under .../.github/actions/setup-go`. #26422 reintroduced stale references to the `./.github/actions/setup-go` and `./.github/actions/setup-node` composite actions, both of which were removed in #25727 when CI migrated shared tool setup to `mise`.

This replaces both with the `setup-mise` pattern already used elsewhere in the same workflow. The `prepare-release` job now installs `go` via `setup-mise` (dropping the old `use-cache: false`, since Go caching is now opt-in through the `go-cache` action). The `update-docs` job installs `node pnpm` via `setup-mise` and adds `pnpm-install` so `scripts/update-release-calendar.sh` still has the dependencies it needs for `make fmt/markdown`.

`actionlint` and the `pre-commit` hook pass locally.

<details>
<summary>Root cause and decision log</summary>

**Symptom:** `tag-and-release.yaml` references `./.github/actions/setup-go`, but that directory has no `action.yml`/`action.yaml`/`Dockerfile`.

**How it broke:**

- #25727 (`ci: refactor CI to use mise for shared tool setup`) deleted `.github/actions/setup-go/action.yaml` and `.github/actions/setup-node/action.yaml`, migrating every workflow to `./.github/actions/setup-mise`.
- #26422 (`feat: add dry-run flag via CommandExecutor interface`) rewrote `tag-and-release.yaml`. It adopted `setup-mise` in one job but left two stale references: `setup-go` (prepare-release) and `setup-node` (update-docs), likely a rebase/merge artifact.

**Scope check:** Swept every workflow for local-action references pointing at missing directories. The only genuine misses were `setup-go` and `setup-node`. `create-task-action` is an external action checked out at runtime via `actions/checkout` (not a repo-local action), and `embedded-pg-cache`/`test-cache` resolve to existing `download`/`upload` subdirectories.

**Mapping decisions:**

- `setup-go` (`use-cache: false`) to `setup-mise` with `install-args: "go"`. The old action also installed `gotestsum`/`mtimehash` and pre-warmed modules, but `prepare-release` only runs `go run ./scripts/release-action`, so `go` alone is sufficient. Caching stays off, matching the original `use-cache: false`.
- `setup-node` to `setup-mise` with `install-args: "node pnpm"` plus `pnpm-install`. The old action provided node + pnpm and installed `node_modules`; `make fmt/markdown` (invoked at the end of the calendar script) needs `node_modules/.installed` and `pnpm exec markdown-table-formatter`.
</details>

---
Generated by Coder Agents on behalf of @f0ssel.
