### PR TITLE
fix(site): set minimum width for TemplateCustomizationsStep

### DIFF
--- a/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
@@ -135,7 +135,7 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 			<div className="flex gap-8">
 				{/* Main content area */}
 				<div className="flex-1 min-w-0">
-					<div className="p-6 border border-solid rounded-lg">
+					<div className="p-6 border border-solid rounded-lg overflow-x-auto">
 						{renderStepContent(
 							currentStep.id,
 							state,

--- a/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
@@ -63,7 +63,7 @@ export const TemplateCustomizationsStep: FC<
 	};
 
 	return (
-		<>
+		<div className="min-w-[654px]">
 			<TemplateBuilderTitle>Customizations</TemplateBuilderTitle>
 			<TemplateBuilderSubtitle>
 				Add additional configurations.
@@ -152,7 +152,7 @@ export const TemplateCustomizationsStep: FC<
 					</div>
 				</div>
 			</div>
-		</>
+		</div>
 	);
 };
 


### PR DESCRIPTION
fixes DEVEX-577

Now the template customizations step gets a horizontal scrollbar if the window is too narrow to nicely display its 2 columns of inputs:

https://github.com/user-attachments/assets/888f723c-8d54-4e37-b53a-e31b6b486e88