### PR TITLE
fix: escape markdown in notification emails

### DIFF
--- a/coderd/notifications/dispatch/smtp/html.gotmpl
+++ b/coderd/notifications/dispatch/smtp/html.gotmpl
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>{{ .Labels._subject }}</title>
+    <title>{{ .Labels._subject | html }}</title>
   </head>
   <body style="margin: 0; padding: 0; font-family: -apple-system, system-ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif; color: #020617; background: #f8fafc;">
     <div style="max-width: 600px; margin: 20px auto; padding: 60px; border: 1px solid #e2e8f0; border-radius: 8px; background-color: #fff; text-align: left; font-size: 14px; line-height: 1.5;">
@@ -11,10 +11,10 @@
         <img src="{{ logo_url | html }}" alt="{{ app_name | html }} Logo" style="height: 40px;" />
       </div>
       <h1 style="text-align: center; font-size: 24px; font-weight: 400; margin: 8px 0 32px; line-height: 1.5;">
-        {{ .Labels._subject }}
+        {{ .Labels._subject | html }}
       </h1>
       <div style="line-height: 1.5;">
-        <p>Hi {{ .UserName }},</p>
+        <p>Hi {{ .UserName | html }},</p>
         {{ .Labels._body }}
       </div>
       <div style="text-align: center; margin-top: 32px;">

--- a/coderd/notifications/dispatch/smtp_internal_test.go
+++ b/coderd/notifications/dispatch/smtp_internal_test.go
@@ -11,19 +11,24 @@ import (
 	"github.com/coder/coder/v2/coderd/notifications/types"
 )
 
-func TestSMTPHTMLTemplateEscapesAppearanceHelpers(t *testing.T) {
+func TestSMTPHTMLTemplateEscapesUntrustedValues(t *testing.T) {
 	t.Parallel()
 
 	const (
-		appName = `Coder"><script>alert(1)</script>`
-		logoURL = `https://example.com/logo.png"><img src=x onerror=alert(1)>`
+		appName  = `Coder"><script>alert(1)</script>`
+		logoURL  = `https://example.com/logo.png"><img src=x onerror=alert(1)>`
+		userName = `Eve<img src=x onerror=alert(1)>`
+		// _subject is produced by PlaintextFromMarkdown, which decodes HTML
+		// entities, so it can contain literal HTML if a title interpolates an
+		// untrusted value. It must be HTML-escaped where it lands in markup.
+		subject = `Alert<img src=x onerror=alert(1)>`
 	)
 
 	payload := types.MessagePayload{
 		NotificationTemplateID: "00000000-0000-0000-0000-000000000000",
-		UserName:               "Test User",
+		UserName:               userName,
 		Labels: map[string]string{
-			"_subject": "Test notification",
+			"_subject": subject,
 			"_body":    "<p>Test body</p>",
 		},
 	}
@@ -39,8 +44,12 @@ func TestSMTPHTMLTemplateEscapesAppearanceHelpers(t *testing.T) {
 
 	require.True(t, strings.Contains(got, html.EscapeString(appName)), "application name must be HTML escaped")
 	require.True(t, strings.Contains(got, html.EscapeString(logoURL)), "logo URL must be HTML escaped")
+	require.True(t, strings.Contains(got, html.EscapeString(userName)), "recipient name must be HTML escaped")
+	require.True(t, strings.Contains(got, html.EscapeString(subject)), "subject must be HTML escaped")
 	require.False(t, strings.Contains(got, appName), "raw application name must not be rendered")
 	require.False(t, strings.Contains(got, logoURL), "raw logo URL must not be rendered")
+	require.False(t, strings.Contains(got, userName), "raw recipient name must not be rendered")
+	require.False(t, strings.Contains(got, subject), "raw subject must not be rendered")
 }
 
 func TestValidateFromAddr(t *testing.T) {

--- a/coderd/notifications/notifier.go
+++ b/coderd/notifications/notifier.go
@@ -17,6 +17,7 @@ import (
 	"github.com/coder/coder/v2/coderd/notifications/dispatch"
 	"github.com/coder/coder/v2/coderd/notifications/render"
 	"github.com/coder/coder/v2/coderd/notifications/types"
+	markdown "github.com/coder/coder/v2/coderd/render"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/quartz"
 )
@@ -222,6 +223,49 @@ func (n *notifier) fetch(ctx context.Context) ([]database.AcquireNotificationMes
 	return msgs, nil
 }
 
+// rawMarkdownLabels lists, per notification template, the label keys whose
+// values are authored as Markdown by a trusted path and must therefore NOT be
+// escaped. Every other label value is treated as untrusted plaintext and has
+// its Markdown link syntax neutralized before rendering.
+//
+// This only covers Labels. Values interpolated from Data are not escaped here;
+// any Data field that is user-controlled and rendered into a Markdown body must
+// be escaped at the site that builds it (see the reports generator and chatd
+// digest for examples).
+//
+// Keep this list minimal. A label belongs here only when a privileged actor
+// intentionally authors Markdown for it (see notifier_internal_test.go for the
+// authz rationale behind each entry).
+var rawMarkdownLabels = map[uuid.UUID]map[string]struct{}{
+	// Template version message, set by a template admin.
+	TemplateWorkspaceAutoUpdated: {"template_version_message": {}},
+	// Template deprecation message, set by a template admin.
+	TemplateTemplateDeprecated: {"message": {}},
+	// Custom notification content. This is safe to leave as raw Markdown only
+	// because custom notifications are self-sent: postCustomNotification
+	// enqueues to the calling user. If custom notifications ever gain
+	// multi-recipient or role-based targeting (see the TODO in
+	// codersdk.CustomNotificationRequest), these must be escaped or gated on
+	// the sender's privilege, or they become a phishing vector.
+	TemplateCustomNotification: {"custom_title": {}, "custom_message": {}},
+}
+
+// escapeMarkdownLabels returns a copy of labels with Markdown link syntax
+// neutralized in every value, except values allowlisted as intentional
+// Markdown for the given notification template. The input map is not mutated.
+func escapeMarkdownLabels(templateID uuid.UUID, labels map[string]string) map[string]string {
+	raw := rawMarkdownLabels[templateID]
+	out := make(map[string]string, len(labels))
+	for k, v := range labels {
+		if _, ok := raw[k]; ok {
+			out[k] = v
+			continue
+		}
+		out[k] = markdown.EscapeMarkdownLinks(v)
+	}
+	return out
+}
+
 // prepare has two roles:
 // 1. render the title & body templates
 // 2. build a dispatcher from the given message, payload, and these templates - to be used for delivering the notification
@@ -250,11 +294,19 @@ func (n *notifier) prepare(ctx context.Context, msg database.AcquireNotification
 		return nil, decorateHelpersError{err}
 	}
 
+	// Render the title & body with Markdown link syntax neutralized in
+	// user-controlled label values. This prevents an attacker-supplied label
+	// (e.g. a display name) from injecting a live link into the notification.
+	// The escaped copy is used only for rendering; the dispatcher still
+	// receives the original payload so structured consumers get raw values.
+	renderPayload := payload
+	renderPayload.Labels = escapeMarkdownLabels(msg.TemplateID, payload.Labels)
+
 	var title, body string
-	if title, err = render.GoTemplate(msg.TitleTemplate, payload, helpers); err != nil {
+	if title, err = render.GoTemplate(msg.TitleTemplate, renderPayload, helpers); err != nil {
 		return nil, xerrors.Errorf("render title: %w", err)
 	}
-	if body, err = render.GoTemplate(msg.BodyTemplate, payload, helpers); err != nil {
+	if body, err = render.GoTemplate(msg.BodyTemplate, renderPayload, helpers); err != nil {
 		return nil, xerrors.Errorf("render body: %w", err)
 	}
 

--- a/coderd/notifications/notifier_internal_test.go
+++ b/coderd/notifications/notifier_internal_test.go
@@ -1,0 +1,207 @@
+package notifications
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/notifications/render"
+	"github.com/coder/coder/v2/coderd/notifications/types"
+	markdown "github.com/coder/coder/v2/coderd/render"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestEscapeMarkdownLabels(t *testing.T) {
+	t.Parallel()
+
+	t.Run("EscapesNonAllowlisted", func(t *testing.T) {
+		t.Parallel()
+
+		in := map[string]string{"deleted_account_user_name": "Eve [x](https://evil.example)"}
+		out := escapeMarkdownLabels(TemplateUserAccountDeleted, in)
+
+		require.NotContains(t, out["deleted_account_user_name"], "[")
+		require.Contains(t, out["deleted_account_user_name"], "&#91;")
+		// The input map must not be mutated.
+		require.Equal(t, "Eve [x](https://evil.example)", in["deleted_account_user_name"])
+	})
+
+	t.Run("PreservesAllowlisted", func(t *testing.T) {
+		t.Parallel()
+
+		raw := "See [docs](https://coder.com)"
+		out := escapeMarkdownLabels(TemplateCustomNotification, map[string]string{
+			"custom_title":   raw,
+			"custom_message": raw,
+			"other":          raw,
+		})
+
+		// Allowlisted labels are left as-authored markdown.
+		require.Equal(t, raw, out["custom_title"])
+		require.Equal(t, raw, out["custom_message"])
+		// Any other label on the same template is still escaped.
+		require.NotEqual(t, raw, out["other"])
+	})
+}
+
+// TestNotificationLabelInjectionNeutralized is the regression test for
+// ANT-2026-22448 (and its generalization): a user-controlled label value with
+// markdown link/emphasis syntax must not render as a live link or emphasis in
+// the notification body, when rendered through the real template + markdown
+// pipeline.
+func TestNotificationLabelInjectionNeutralized(t *testing.T) {
+	t.Parallel()
+
+	const malicious = "Eve [Re-auth](https://coder-sso.evil.example)"
+
+	store, _ := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitLong)
+	templates := allNotificationTemplates(ctx, t, store)
+	helpers := testHelpers()
+
+	// The user-controlled name label for each account template.
+	cases := map[uuid.UUID]string{
+		TemplateUserAccountDeleted:   "deleted_account_user_name",
+		TemplateUserAccountCreated:   "created_account_user_name",
+		TemplateUserAccountSuspended: "suspended_account_user_name",
+		TemplateUserAccountActivated: "activated_account_user_name",
+	}
+
+	for id, targetLabel := range cases {
+		tmpl, ok := templates[id]
+		require.True(t, ok, "template %s not seeded", id)
+
+		labels := benignLabels(tmpl, malicious, targetLabel)
+		payload := types.MessagePayload{
+			UserName: "Recipient",
+			Labels:   escapeMarkdownLabels(id, labels),
+		}
+
+		// The malicious value lands in the body. It must not produce a link,
+		// and its link syntax must survive as literal text.
+		body, err := render.GoTemplate(tmpl.BodyTemplate, payload, helpers)
+		require.NoError(t, err)
+		bodyHTML := markdown.HTMLFromMarkdown(body)
+		require.NotContains(t, bodyHTML, "<a ", "%s body produced a link: %q", tmpl.Name, bodyHTML)
+		require.Contains(t, bodyHTML, "[Re-auth]", "%s body did not render the label literally: %q", tmpl.Name, bodyHTML)
+
+		// The title must never produce a link regardless of which label the
+		// value lands in.
+		title, err := render.GoTemplate(tmpl.TitleTemplate, payload, helpers)
+		require.NoError(t, err)
+		require.NotContains(t, markdown.HTMLFromMarkdown(title), "<a ", "%s title produced a link", tmpl.Name)
+	}
+}
+
+// TestAllowlistedNotificationLabelsRenderMarkdown proves the allowlist works:
+// intentional-markdown labels still render as markdown.
+func TestAllowlistedNotificationLabelsRenderMarkdown(t *testing.T) {
+	t.Parallel()
+
+	store, _ := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitLong)
+	templates := allNotificationTemplates(ctx, t, store)
+	helpers := testHelpers()
+
+	tmpl, ok := templates[TemplateCustomNotification]
+	require.True(t, ok)
+
+	labels := escapeMarkdownLabels(TemplateCustomNotification, map[string]string{
+		"custom_title":   "Heads up",
+		"custom_message": "Please read the [docs](https://coder.com).",
+	})
+	rendered, err := render.GoTemplate(tmpl.BodyTemplate, types.MessagePayload{Labels: labels}, helpers)
+	require.NoError(t, err)
+	html := markdown.HTMLFromMarkdown(rendered)
+	require.Contains(t, html, `<a href="https://coder.com"`, "allowlisted markdown should render: %q", html)
+}
+
+// TestNotificationTemplatesNoLineStartLabels guards the link-focused escaper's
+// assumption that untrusted labels never sit at the start of a line (where they
+// could still introduce a block element such as a heading or list). Allowlisted
+// (intentional-markdown) labels are exempt.
+func TestNotificationTemplatesNoLineStartLabels(t *testing.T) {
+	t.Parallel()
+
+	store, _ := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitLong)
+	templates := allNotificationTemplates(ctx, t, store)
+
+	for _, tmpl := range templates {
+		for field, text := range map[string]string{"title": tmpl.TitleTemplate, "body": tmpl.BodyTemplate} {
+			for _, label := range lineStartLabels(text) {
+				if _, ok := rawMarkdownLabels[tmpl.ID][label]; ok {
+					continue
+				}
+				t.Errorf("template %q (%s) %s places non-allowlisted label %q at a line start; "+
+					"wrap it mid-line, or add it to rawMarkdownLabels if it is intentional markdown",
+					tmpl.Name, tmpl.ID, field, label)
+			}
+		}
+	}
+}
+
+func testHelpers() template.FuncMap {
+	return template.FuncMap{
+		"base_url":     func() string { return "https://coder.example.com" },
+		"current_year": func() string { return "2026" },
+		"logo_url":     func() string { return "https://coder.com/logo.png" },
+		"app_name":     func() string { return "Coder" },
+	}
+}
+
+func allNotificationTemplates(ctx context.Context, t *testing.T, store database.Store) map[uuid.UUID]database.NotificationTemplate {
+	t.Helper()
+
+	out := make(map[uuid.UUID]database.NotificationTemplate)
+	for _, kind := range []database.NotificationTemplateKind{
+		database.NotificationTemplateKindSystem,
+		database.NotificationTemplateKindCustom,
+	} {
+		tmpls, err := store.GetNotificationTemplatesByKind(ctx, kind)
+		require.NoError(t, err)
+		for _, tmpl := range tmpls {
+			out[tmpl.ID] = tmpl
+		}
+	}
+	require.NotEmpty(t, out, "expected notification templates to be seeded")
+	return out
+}
+
+var labelRefRe = regexp.MustCompile(`\.Labels\.(\w+)`)
+
+// benignLabels sets every label referenced by the template to a benign value,
+// then overrides target with value. This ensures conditionals guarding the
+// target label ({{if .Labels.target}}) are satisfied.
+func benignLabels(tmpl database.NotificationTemplate, value, target string) map[string]string {
+	labels := make(map[string]string)
+	for _, text := range []string{tmpl.TitleTemplate, tmpl.BodyTemplate} {
+		for _, m := range labelRefRe.FindAllStringSubmatch(text, -1) {
+			labels[m[1]] = "benign"
+		}
+	}
+	labels[target] = value
+	return labels
+}
+
+// lineStartLabelRe matches a label output action at the start of a line, after
+// optional leading whitespace and any leading template control actions
+// (if/else/end/range/with) that render to nothing.
+var lineStartLabelRe = regexp.MustCompile(`^\s*(?:{{-?\s*(?:if|else|end|range|with)\b[^}]*}}\s*)*{{-?\s*\.Labels\.(\w+)`)
+
+func lineStartLabels(tmpl string) []string {
+	var out []string
+	for _, line := range strings.Split(tmpl, "\n") {
+		if m := lineStartLabelRe.FindStringSubmatch(line); m != nil {
+			out = append(out, m[1])
+		}
+	}
+	return out
+}

--- a/coderd/notifications/reports/generator.go
+++ b/coderd/notifications/reports/generator.go
@@ -16,6 +16,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/notifications"
+	markdown "github.com/coder/coder/v2/coderd/render"
 	"github.com/coder/coder/v2/coderd/util/slice"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/quartz"
@@ -285,7 +286,12 @@ func buildDataForReportFailedWorkspaceBuilds(reports []adminReport) map[string]a
 			"total_builds":  report.stats.TotalBuilds,
 			"versions":      templateVersions,
 			"name":          report.stats.TemplateName,
-			"display_name":  templateDisplayName,
+			// display_name is a free-form template display name that is
+			// interpolated into the markdown body, so escape its link syntax.
+			// The other fields are safe as-is: name/template_version_name and
+			// the workspace owner/name are constrained to alphanumeric charsets
+			// (and the latter two only appear inside a link URL).
+			"display_name": markdown.EscapeMarkdownLinks(templateDisplayName),
 		})
 	}
 

--- a/coderd/notifications/reports/generator_internal_test.go
+++ b/coderd/notifications/reports/generator_internal_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/coder/coder/v2/coderd/notifications"
 	"github.com/coder/coder/v2/coderd/notifications/notificationstest"
 	"github.com/coder/coder/v2/coderd/rbac"
+	markdown "github.com/coder/coder/v2/coderd/render"
 	"github.com/coder/quartz"
 )
 
@@ -559,6 +560,41 @@ func setup(t *testing.T) (context.Context, slog.Logger, database.Store, pubsub.P
 	notifyEnq := &notificationstest.FakeEnqueuer{}
 	clk := quartz.NewMock(t)
 	return ctx, logger, db, ps, notifyEnq, clk
+}
+
+func TestBuildDataForReportFailedWorkspaceBuildsEscapesDisplayName(t *testing.T) {
+	t.Parallel()
+
+	// A template display name is free-form and interpolated into the markdown
+	// body, so its link syntax must be neutralized. The workspace owner/name
+	// are alphanumeric and appear in a link URL, so they are left as-is.
+	reports := []adminReport{
+		{
+			stats: database.GetWorkspaceBuildStatsByTemplatesRow{
+				TemplateName:        "prod-template",
+				TemplateDisplayName: "Prod [click](https://evil.example)",
+			},
+			failedBuilds: []database.GetFailedWorkspaceBuildsByTemplateIDRow{
+				{
+					WorkspaceOwnerUsername: "bob",
+					WorkspaceName:          "dev",
+					TemplateVersionName:    "v1.2.3",
+					WorkspaceBuildNumber:   1,
+				},
+			},
+		},
+	}
+
+	data := buildDataForReportFailedWorkspaceBuilds(reports)
+	templates, ok := data["templates"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, templates, 1)
+
+	displayName, ok := templates[0]["display_name"].(string)
+	require.True(t, ok)
+	require.NotContains(t, displayName, "[", "display_name link syntax should be escaped: %q", displayName)
+	require.NotContains(t, markdown.HTMLFromMarkdown(displayName), "<a ",
+		"escaped display_name must not render a link")
 }
 
 func authedDB(t *testing.T, db database.Store, logger slog.Logger) database.Store {

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateTaskCompleted.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateTaskCompleted.html.golden
@@ -29,7 +29,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Task 'my-workspace' completed</title>
+    <title>Task &#39;my-workspace&#39; completed</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -44,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Task 'my-workspace' completed
+        Task &#39;my-workspace&#39; completed
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateTaskFailed.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateTaskFailed.html.golden
@@ -29,7 +29,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Task 'my-workspace' failed</title>
+    <title>Task &#39;my-workspace&#39; failed</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -44,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Task 'my-workspace' failed
+        Task &#39;my-workspace&#39; failed
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateTaskIdle.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateTaskIdle.html.golden
@@ -29,7 +29,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Task 'my-workspace' is idle</title>
+    <title>Task &#39;my-workspace&#39; is idle</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -44,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Task 'my-workspace' is idle
+        Task &#39;my-workspace&#39; is idle
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateTaskPaused.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateTaskPaused.html.golden
@@ -29,7 +29,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Task 'my-task' is paused</title>
+    <title>Task &#39;my-task&#39; is paused</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -44,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Task 'my-task' is paused
+        Task &#39;my-task&#39; is paused
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateTaskResumed.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateTaskResumed.html.golden
@@ -29,7 +29,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Task 'my-task' has resumed</title>
+    <title>Task &#39;my-task&#39; has resumed</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -44,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Task 'my-task' has resumed
+        Task &#39;my-task&#39; has resumed
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateTaskWorking.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateTaskWorking.html.golden
@@ -29,7 +29,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Task 'my-workspace' is working</title>
+    <title>Task &#39;my-workspace&#39; is working</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -44,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Task 'my-workspace' is working
+        Task &#39;my-workspace&#39; is working
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateTemplateDeleted.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateTemplateDeleted.html.golden
@@ -27,7 +27,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Template "Bobby's Template" deleted</title>
+    <title>Template &#34;Bobby&#39;s Template&#34; deleted</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -42,7 +42,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Template "Bobby's Template" deleted
+        Template &#34;Bobby&#39;s Template&#34; deleted
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateTemplateDeprecated.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateTemplateDeprecated.html.golden
@@ -35,7 +35,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Template 'alpha' has been deprecated</title>
+    <title>Template &#39;alpha&#39; has been deprecated</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -50,7 +50,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Template 'alpha' has been deprecated
+        Template &#39;alpha&#39; has been deprecated
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserAccountActivated.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserAccountActivated.html.golden
@@ -29,7 +29,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>User account "bobby" activated</title>
+    <title>User account &#34;bobby&#34; activated</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -44,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        User account "bobby" activated
+        User account &#34;bobby&#34; activated
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserAccountCreated.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserAccountCreated.html.golden
@@ -29,7 +29,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>User account "bobby" created</title>
+    <title>User account &#34;bobby&#34; created</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -44,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        User account "bobby" created
+        User account &#34;bobby&#34; created
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserAccountDeleted.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserAccountDeleted.html.golden
@@ -29,7 +29,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>User account "bobby" deleted</title>
+    <title>User account &#34;bobby&#34; deleted</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -44,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        User account "bobby" deleted
+        User account &#34;bobby&#34; deleted
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserAccountSuspended.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserAccountSuspended.html.golden
@@ -30,7 +30,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>User account "bobby" suspended</title>
+    <title>User account &#34;bobby&#34; suspended</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -45,7 +45,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        User account "bobby" suspended
+        User account &#34;bobby&#34; suspended
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceAutoUpdated.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceAutoUpdated.html.golden
@@ -30,7 +30,8 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Workspace "bobby-workspace" updated automatically</title>
+    <title>Workspace &#34;bobby-workspace&#34; updated automatically</title=
+>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -45,7 +46,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Workspace "bobby-workspace" updated automatically
+        Workspace &#34;bobby-workspace&#34; updated automatically
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceAutobuildFailed.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceAutobuildFailed.html.golden
@@ -29,7 +29,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Workspace "bobby-workspace" autobuild failed</title>
+    <title>Workspace &#34;bobby-workspace&#34; autobuild failed</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -44,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Workspace "bobby-workspace" autobuild failed
+        Workspace &#34;bobby-workspace&#34; autobuild failed
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceAutostopReminder.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceAutostopReminder.html.golden
@@ -30,7 +30,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Your workspace "bobby-workspace" will stop soon</title>
+    <title>Your workspace &#34;bobby-workspace&#34; will stop soon</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -45,7 +45,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Your workspace "bobby-workspace" will stop soon
+        Your workspace &#34;bobby-workspace&#34; will stop soon
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceCreated.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceCreated.html.golden
@@ -28,7 +28,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Workspace 'bobby-workspace' has been created</title>
+    <title>Workspace &#39;bobby-workspace&#39; has been created</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -43,7 +43,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Workspace 'bobby-workspace' has been created
+        Workspace &#39;bobby-workspace&#39; has been created
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceDeleted.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceDeleted.html.golden
@@ -31,7 +31,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Workspace "bobby-workspace" deleted</title>
+    <title>Workspace &#34;bobby-workspace&#34; deleted</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -46,7 +46,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Workspace "bobby-workspace" deleted
+        Workspace &#34;bobby-workspace&#34; deleted
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceDeleted_CustomAppearance.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceDeleted_CustomAppearance.html.golden
@@ -31,7 +31,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Workspace "bobby-workspace" deleted</title>
+    <title>Workspace &#34;bobby-workspace&#34; deleted</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -46,7 +46,7 @@ ication Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Workspace "bobby-workspace" deleted
+        Workspace &#34;bobby-workspace&#34; deleted
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceDormant.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceDormant.html.golden
@@ -34,7 +34,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Workspace "bobby-workspace" marked as dormant</title>
+    <title>Workspace &#34;bobby-workspace&#34; marked as dormant</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -49,7 +49,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Workspace "bobby-workspace" marked as dormant
+        Workspace &#34;bobby-workspace&#34; marked as dormant
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceDormant_NoAutoDelete.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceDormant_NoAutoDelete.html.golden
@@ -31,7 +31,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Workspace "bobby-workspace" marked as dormant</title>
+    <title>Workspace &#34;bobby-workspace&#34; marked as dormant</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -46,7 +46,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Workspace "bobby-workspace" marked as dormant
+        Workspace &#34;bobby-workspace&#34; marked as dormant
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceManualBuildFailed.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceManualBuildFailed.html.golden
@@ -29,7 +29,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Workspace "bobby-workspace" manual build failed</title>
+    <title>Workspace &#34;bobby-workspace&#34; manual build failed</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -44,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Workspace "bobby-workspace" manual build failed
+        Workspace &#34;bobby-workspace&#34; manual build failed
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceManuallyUpdated.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceManuallyUpdated.html.golden
@@ -31,7 +31,8 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Workspace 'bobby-workspace' has been manually updated</title>
+    <title>Workspace &#39;bobby-workspace&#39; has been manually updated</t=
+itle>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -46,7 +47,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Workspace 'bobby-workspace' has been manually updated
+        Workspace &#39;bobby-workspace&#39; has been manually updated
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceMarkedForDeletion.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceMarkedForDeletion.html.golden
@@ -31,7 +31,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Workspace "bobby-workspace" marked for deletion</title>
+    <title>Workspace &#34;bobby-workspace&#34; marked for deletion</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -46,7 +46,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Workspace "bobby-workspace" marked for deletion
+        Workspace &#34;bobby-workspace&#34; marked for deletion
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceOutOfDisk.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceOutOfDisk.html.golden
@@ -27,7 +27,8 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Your workspace "bobby-workspace" is low on volume space</title>
+    <title>Your workspace &#34;bobby-workspace&#34; is low on volume space<=
+/title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -42,7 +43,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Your workspace "bobby-workspace" is low on volume space
+        Your workspace &#34;bobby-workspace&#34; is low on volume space
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceOutOfDisk_MultipleVolumes.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceOutOfDisk_MultipleVolumes.html.golden
@@ -31,7 +31,8 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Your workspace "bobby-workspace" is low on volume space</title>
+    <title>Your workspace &#34;bobby-workspace&#34; is low on volume space<=
+/title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -46,7 +47,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Your workspace "bobby-workspace" is low on volume space
+        Your workspace &#34;bobby-workspace&#34; is low on volume space
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceOutOfMemory.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceOutOfMemory.html.golden
@@ -28,7 +28,8 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Your workspace "bobby-workspace" is low on memory</title>
+    <title>Your workspace &#34;bobby-workspace&#34; is low on memory</title=
+>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -43,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Your workspace "bobby-workspace" is low on memory
+        Your workspace &#34;bobby-workspace&#34; is low on memory
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateYourAccountActivated.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateYourAccountActivated.html.golden
@@ -27,7 +27,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Your account "bobby" has been activated</title>
+    <title>Your account &#34;bobby&#34; has been activated</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -42,7 +42,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Your account "bobby" has been activated
+        Your account &#34;bobby&#34; has been activated
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateYourAccountSuspended.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateYourAccountSuspended.html.golden
@@ -25,7 +25,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Your account "bobby" has been suspended</title>
+    <title>Your account &#34;bobby&#34; has been suspended</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -40,7 +40,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Your account "bobby" has been suspended
+        Your account &#34;bobby&#34; has been suspended
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/render/markdown.go
+++ b/coderd/render/markdown.go
@@ -2,7 +2,10 @@ package render
 
 import (
 	"bytes"
+	"strconv"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/glamour/ansi"
@@ -11,6 +14,79 @@ import (
 	"github.com/gomarkdown/markdown/parser"
 	"golang.org/x/xerrors"
 )
+
+// markdownLinkChars are the ASCII characters that can initiate a Markdown
+// link, image, or "<url>" autolink. Escaping these neutralizes link/phishing
+// injection while leaving all other punctuation, including emphasis and code
+// markers (* _ ~ `), parentheses, and common name punctuation
+// (- . , ' _ ! # & % @ ( )), untouched. ':' is handled separately (see
+// EscapeMarkdownLinks) so that benign values such as timestamps ("15:04") are
+// not modified.
+//
+// '(' and ')' are intentionally omitted: a link or image requires the "[...]"
+// label, and a bare-URL autolink requires the scheme ':'. Both are already
+// escaped, so parentheses cannot complete a link on their own, and escaping
+// them would needlessly mangle common names like "Jane Doe (she/her)".
+var markdownLinkChars = map[rune]struct{}{
+	'[': {}, ']': {}, // inline / reference links and images
+	'<': {}, '>': {}, // <url> autolinks
+}
+
+func isASCIILetter(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+}
+
+// EscapeMarkdownLinks renders untrusted text so it cannot form a Markdown link,
+// image, or autolink. Newlines are collapsed to spaces, and each link-forming
+// ASCII character is replaced with a numeric HTML entity that the HTML and
+// plaintext renderers decode back to the literal character for display.
+//
+// It deliberately escapes only link-forming characters, not emphasis or code
+// markers: an injected link is a phishing vector, whereas injected emphasis is
+// merely cosmetic. Leaving "* _ ~ ` ! # ( )" and name punctuation untouched
+// keeps names and identifiers (e.g. "muddy_russell78", "My *Cool* App",
+// "Jane Doe (she/her)") rendering cleanly on every delivery channel, including
+// webhook Markdown consumed by Slack or Teams. (An image "![alt](url)" is still
+// neutralized because its "[" and "]" are escaped.)
+//
+// A ':' is escaped only when it directly joins a scheme to a target, i.e. when
+// it is preceded by an ASCII letter and followed by a non-whitespace character
+// (e.g. "https://", "mailto:user@host"). This breaks every scheme autolink,
+// current or future, without touching a ':' that cannot start one, such as in
+// a timestamp ("15:04", digit before) or a label ("Note: hi", space after).
+//
+// Note: block-level markers such as '#' and '-' are not escaped ('>' is, since
+// it doubles as the "<url>" autolink closer). Because newlines are collapsed,
+// an interpolated value can only start a block element when a template places
+// it at the beginning of a line. Callers must not place untrusted values at a
+// line start (see the notifications line-start guard).
+func EscapeMarkdownLinks(s string) string {
+	s = strings.NewReplacer("\r\n", " ", "\r", " ", "\n", " ").Replace(s)
+	runes := []rune(s)
+	buf := make([]byte, 0, len(s))
+	for i, r := range runes {
+		escape := false
+		if r < 128 {
+			if _, ok := markdownLinkChars[r]; ok {
+				escape = true
+			} else if r == ':' && i > 0 && isASCIILetter(runes[i-1]) &&
+				i+1 < len(runes) && !unicode.IsSpace(runes[i+1]) {
+				// Break "scheme:" autolinks (e.g. https://, mailto:) without
+				// touching a ':' that cannot start one, such as a timestamp
+				// ("15:04") or a label ("Note: hi").
+				escape = true
+			}
+		}
+		if escape {
+			buf = append(buf, '&', '#')
+			buf = strconv.AppendInt(buf, int64(r), 10)
+			buf = append(buf, ';')
+		} else {
+			buf = utf8.AppendRune(buf, r)
+		}
+	}
+	return string(buf)
+}
 
 var plaintextStyle = ansi.StyleConfig{
 	Document: ansi.StyleBlock{
@@ -104,7 +180,10 @@ func HTMLFromMarkdown(markdown string) string {
 	p := parser.NewWithExtensions(parser.CommonExtensions | parser.HardLineBreak) // Added HardLineBreak.
 	doc := p.Parse([]byte(markdown))
 	renderer := html.NewRenderer(html.RendererOptions{
-		Flags: html.CommonFlags | html.SkipHTML,
+		// Safelink drops links with unsafe URI schemes (e.g. javascript:,
+		// data:) as defense-in-depth against injected markup. It applies to
+		// links only, not images.
+		Flags: html.CommonFlags | html.SkipHTML | html.Safelink,
 	})
 	return string(bytes.TrimSpace(gomarkdown.Render(doc, renderer)))
 }

--- a/coderd/render/markdown_test.go
+++ b/coderd/render/markdown_test.go
@@ -76,6 +76,13 @@ func TestHTML(t *testing.T) {
 			input:    "This is a simple description, so nothing changes.",
 			expected: "<p>This is a simple description, so nothing changes.</p>",
 		},
+		{
+			// Safelink drops links with unsafe URI schemes so they cannot
+			// render as a clickable anchor.
+			name:     "Unsafe link scheme",
+			input:    `[click](javascript:alert(1))`,
+			expected: `<p><tt>click</tt></p>`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -86,4 +93,72 @@ func TestHTML(t *testing.T) {
 			require.Equal(t, tt.expected, rendered)
 		})
 	}
+}
+
+func TestEscapeMarkdownLinks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NeutralizesLinks", func(t *testing.T) {
+		t.Parallel()
+
+		// Each of these would produce a live <a>/<img> if left unescaped,
+		// including the bare-URL autolink which needs no [](): gomarkdown
+		// autolinks any "scheme://" run.
+		for _, payload := range []string{
+			"Eve [Re-auth](https://coder-sso.evil.example)",
+			"![pixel](https://coder-sso.evil.example/x.png)",
+			"https://coder-sso.evil.example",
+			"<https://coder-sso.evil.example>",
+			"mailto:attacker@coder-sso.evil.example",
+			"MAILTO:attacker@coder-sso.evil.example",
+		} {
+			rendered := render.HTMLFromMarkdown(render.EscapeMarkdownLinks(payload))
+			require.NotContains(t, rendered, "<a ", "payload %q produced a link: %q", payload, rendered)
+			require.NotContains(t, rendered, "<img", "payload %q produced an image: %q", payload, rendered)
+			require.NotContains(t, rendered, "evil.example\"", "payload %q leaked a URL attribute: %q", payload, rendered)
+		}
+	})
+
+	t.Run("PreservesBenignPunctuation", func(t *testing.T) {
+		t.Parallel()
+
+		// Values with only benign punctuation are left completely untouched by
+		// the escaper (no numeric entities), so webhook Markdown stays clean.
+		// This includes emphasis/code markers (only links are escaped), ':'
+		// outside of a "scheme://" (e.g. timestamps), and '#'.
+		for _, name := range []string{
+			"Anne-Marie", "Smith, John", "José", "李雷", "v1.2.3", "R&D 100%",
+			"15:04:00 UTC", "Jan 2 15:04 MST", "C# developer",
+			"muddy_russell78", "My *Cool* App", "2*speed", "code: `x`",
+			// Parentheses are not escaped (they cannot complete a link
+			// without the "[...]" label, which is escaped).
+			"Jane Doe (she/her)", "Bob (Jr.)",
+			// A ':' followed by a space or preceded by a digit does not start
+			// a scheme, so it is left untouched.
+			"Note: hello", "TODO: fix bug", "ratio 3:2",
+		} {
+			require.Equal(t, name, render.EscapeMarkdownLinks(name),
+				"benign value %q should not be modified", name)
+		}
+	})
+
+	t.Run("RendersBenignNamesLiterally", func(t *testing.T) {
+		t.Parallel()
+
+		// Names containing link-forming punctuation are escaped but still
+		// render to the literal characters through the Markdown renderers.
+		// (The '&' in a name is rendered as the HTML entity &amp; by the HTML
+		// renderer, which is correct HTML escaping, so those names are only
+		// checked via the plaintext renderer below.)
+		for _, name := range []string{"J. Doe (Jr.)", "Anne-Marie"} {
+			html := render.HTMLFromMarkdown(render.EscapeMarkdownLinks(name))
+			require.Equal(t, "<p>"+name+"</p>", html)
+		}
+
+		for _, name := range []string{"J. Doe (Jr.)", "Café (R&D) 100%", "Anne-Marie"} {
+			plain, err := render.PlaintextFromMarkdown(render.EscapeMarkdownLinks(name))
+			require.NoError(t, err)
+			require.Equal(t, name, plain)
+		}
+	})
 }

--- a/coderd/x/chatd/auto_archive.go
+++ b/coderd/x/chatd/auto_archive.go
@@ -20,6 +20,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/notifications"
+	markdown "github.com/coder/coder/v2/coderd/render"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatdebug"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatstate"
 	"github.com/coder/coder/v2/codersdk"
@@ -309,7 +310,9 @@ func buildAutoArchiveDigestData(rows []autoArchivedChat, autoArchiveDays, retent
 	chats := make([]map[string]any, 0, len(rows))
 	for _, r := range rows {
 		chats = append(chats, map[string]any{
-			"title":                   r.Chat.Title,
+			// The chat title is free-form user text interpolated into the
+			// markdown digest body, so escape its link syntax.
+			"title":                   markdown.EscapeMarkdownLinks(r.Chat.Title),
 			"last_activity_humanized": humanize.RelTime(r.LastActivityAt, tickStart, "ago", "from now"),
 		})
 	}

--- a/coderd/x/chatd/auto_archive_internal_test.go
+++ b/coderd/x/chatd/auto_archive_internal_test.go
@@ -21,11 +21,36 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/notifications"
 	"github.com/coder/coder/v2/coderd/notifications/notificationstest"
+	markdown "github.com/coder/coder/v2/coderd/render"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatstate"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
 )
+
+func TestBuildAutoArchiveDigestDataEscapesTitle(t *testing.T) {
+	t.Parallel()
+
+	// A chat title is free-form user text interpolated into the markdown
+	// digest body, so its link syntax must be neutralized.
+	rows := []autoArchivedChat{
+		{
+			Chat:           database.Chat{Title: "Fix [prod](https://evil.example)"},
+			LastActivityAt: time.Now(),
+		},
+	}
+
+	data := buildAutoArchiveDigestData(rows, 30, 30, time.Now())
+	chats, ok := data["archived_chats"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, chats, 1)
+
+	title, ok := chats[0]["title"].(string)
+	require.True(t, ok)
+	require.NotContains(t, title, "[", "chat title link syntax should be escaped: %q", title)
+	require.NotContains(t, markdown.HTMLFromMarkdown(title), "<a ",
+		"escaped chat title must not render a link")
+}
 
 func TestWorker_AutoArchiveDisabled(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Prevents user-controlled values (display names, template/chat metadata) from injecting markdown links or raw HTML into notification emails sent to users
