### PR TITLE
chore: make ubuntu 26.04 the default

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -123,8 +123,9 @@ data "coder_parameter" "repo_base_dir" {
 data "coder_parameter" "image_type" {
   type        = "string"
   name        = "Coder Image"
-  default     = "codercom/oss-dogfood:latest"
+  default     = "ubuntu-latest"
   description = "The Docker image used to run your workspace."
+  mutable     = true
   option {
     icon  = "/icon/coder.svg"
     name  = "Ubuntu 26.04"


### PR DESCRIPTION
<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->

I've been testing it myself for over a month at this point and the only real issue I had was the Playwright versioning thing, which we patched. Should be low risk to make it the default now. Plus, now that Nix isn't one of the options it's safer to make the image param mutable, giving people an easier upgrade path.