### PR TITLE
fix: set git identity for release tagging and surface git stderr

### DIFF
--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -85,6 +85,14 @@ jobs:
       - name: Fetch git tags
         run: git fetch --tags --force
 
+      # prepare-release creates an annotated tag, which records a tagger
+      # identity. Runners have none configured, so git tag -a fails
+      # without this step.
+      - name: Configure git identity
+        run: |
+          git config --global user.email "ci@coder.com"
+          git config --global user.name "Coder CI"
+
       - name: Set up mise tools
         uses: ./.github/actions/setup-mise
         with:

--- a/scripts/release-action/cmdexec.go
+++ b/scripts/release-action/cmdexec.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
 	"os/exec"
 	"strings"
+
+	"golang.org/x/xerrors"
 )
 
 // CommandExecutor abstracts running CLI commands so that a dry-run
@@ -60,7 +63,18 @@ func (realExecutor) Run(name string, args ...string) error {
 
 func (realExecutor) RunMutation(name string, args ...string) error {
 	cmd := exec.Command(name, args...)
-	return cmd.Run()
+	// Capture stderr so that a failing mutation surfaces the command's
+	// error output (e.g. git's "fatal:" message) in the returned error
+	// instead of only the exit status.
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return xerrors.Errorf("%s: %w", msg, err)
+		}
+		return err
+	}
+	return nil
 }
 
 func (realExecutor) RunMutationStdout(stdout, stderr io.Writer, name string, args ...string) error {

--- a/scripts/release-action/cmdexec_test.go
+++ b/scripts/release-action/cmdexec_test.go
@@ -36,6 +36,14 @@ func TestRealExecutor_RunMutation(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestRealExecutor_RunMutationSurfacesStderr(t *testing.T) {
+	t.Parallel()
+	exec := realExecutor{}
+	err := exec.RunMutation("sh", "-c", "echo 'fatal: boom' 1>&2; exit 1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fatal: boom")
+}
+
 func TestRealExecutor_RunMutationStdout(t *testing.T) {
 	t.Parallel()
 	exec := realExecutor{}


### PR DESCRIPTION
## What happened

The [Tag and Release run](https://github.com/coder/coder/actions/runs/28549109434/job/84641825784) failed in the `prepare-release` job at the step "Prepare release (calculate version, create tag and branch)" with:

```
error: create tag v2.35.0-rc.0: exit status 128
```

## Root cause

`prepare-release` creates an **annotated** tag via `git tag -a` (`scripts/release-action/prepare.go`), which records a tagger and therefore requires a git identity. The job never ran `git config user.name/user.email`, and runners have none configured, so git aborts with exit status 128. The real `fatal:` message was hidden because `realExecutor.RunMutation` discarded the command's stderr.

## Changes

- **`.github/workflows/tag-and-release.yaml`**: add a "Configure git identity" step (`ci@coder.com` / `Coder CI`) to the `prepare-release` job, before the release tool runs. This matches the identity pattern already used later in the same workflow.
- **`scripts/release-action/cmdexec.go`**: capture stderr in `RunMutation` and include it in the returned error, so a failing mutation surfaces the underlying command output (e.g. git's `fatal:` line) instead of only `exit status N`.
- **`scripts/release-action/cmdexec_test.go`**: add a test asserting stderr is surfaced on failure.

## Testing

- `go test ./scripts/release-action/...` passes.
- `go vet ./scripts/release-action/...` and `gofmt` clean.
- `actionlint .github/workflows/tag-and-release.yaml` clean.
- Reproduced the failure locally: `git tag -a` with no usable identity exits 128 (`fatal: no email was given and auto-detection is disabled`); with an identity configured it succeeds.

<details>
<summary>Root-cause analysis / decision log</summary>

**Failing step** runs `go run ./scripts/release-action prepare-release --type create-release-branch --ref main --commit cb1a87b…`.

1. The tool computes the next version `v2.35.0-rc.0` and calls `createAndPushTag`, which runs `git tag -a v2.35.0-rc.0 -m "Release v2.35.0-rc.0" <targetRef>` (`prepare.go:56`).
2. That git command exits **128**, wrapped as `error: create tag v2.35.0-rc.0: exit status 128`.

**Why it's the identity, and not something else:**

- No `git config user.name/user.email` step exists in the `prepare-release` job; the `setup-mise` action does not set it; and the tool itself never sets an identity. Annotated tags require a tagger, so `git tag -a` fails on runners whose auto-detected identity is bogus (`…@runner.(none)`), which is rejected under git's strict identity check.
- Not a pre-existing tag collision: no `v2.35.0*` tag exists on the remote, and the code pre-checks for an existing tag (and would emit a different "already exists" error).
- Not an unresolved ref: `targetRef` resolves to the provided commit SHA, checked out at `fetch-depth: 0`.
- The log was unhelpful because `RunMutation` used `cmd.Run()` without wiring git's stderr (`cmdexec.go`), discarding the `fatal:` line and leaving only `exit status 128`. This PR fixes that too.
- The sibling `release.yaml` explicitly sets `git config user.email/user.name` before its git mutations; that step was simply missing from the newer `tag-and-release.yaml` `prepare-release` job.

</details>

---

> Generated by Coder Agents on behalf of @f0ssel.
