### PR TITLE
refactor(site/TemplateBuilder): remove hasProvisioners from wizard state

### DIFF
--- a/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
@@ -1,10 +1,4 @@
-import {
-	type FC,
-	type ReactNode,
-	useCallback,
-	useReducer,
-	useState,
-} from "react";
+import { type FC, type ReactNode, useReducer, useState } from "react";
 
 import { useQuery } from "react-query";
 import { templateBuilderModules } from "#/api/queries/templateBuilder";
@@ -110,13 +104,6 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 		setStepIndex(nextIndex);
 	};
 
-	const handleProvisionerStatusChange = useCallback(
-		(value: boolean | undefined) => {
-			dispatch({ type: "SET_HAS_PROVISIONERS", value });
-		},
-		[],
-	);
-
 	const handleDeselectModule = (moduleId: string) => {
 		// If the only module gets deselected, go back to module selection
 		if (state.modules.length === 1) {
@@ -161,7 +148,6 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 							dispatch,
 							moduleVarMap,
 							createError,
-							handleProvisionerStatusChange,
 						)}
 					</div>
 
@@ -213,7 +199,6 @@ function renderStepContent(
 	dispatch: (action: WizardAction) => void,
 	moduleVarMap: Record<string, Record<string, string>>,
 	createError: Error | null,
-	onProvisionerStatusChange: (value: boolean | undefined) => void,
 ): ReactNode {
 	switch (stepId) {
 		case "base-infra":
@@ -274,7 +259,6 @@ function renderStepContent(
 								value,
 							})
 						}
-						onProvisionerStatusChange={onProvisionerStatusChange}
 					/>
 				</>
 			);
@@ -306,7 +290,7 @@ function computeCanContinue(
 				moduleVarMap,
 			);
 		case "customizations":
-			return state.name.trim() !== "" && state.hasProvisioners !== false;
+			return state.name.trim() !== "";
 		default:
 			return true;
 	}

--- a/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
@@ -28,12 +28,11 @@ interface TemplateCustomizationsStepProps {
 		field: "organizationId" | "name" | "displayName" | "description" | "icon",
 		value: string,
 	) => void;
-	onProvisionerStatusChange: (hasProvisioners: boolean | undefined) => void;
 }
 
 export const TemplateCustomizationsStep: FC<
 	TemplateCustomizationsStepProps
-> = ({ state, onChangeField, onProvisionerStatusChange }) => {
+> = ({ state, onChangeField }) => {
 	const permittedOrgsQuery = useQuery(
 		permittedOrganizations({
 			object: { resource_type: "template" },
@@ -48,14 +47,7 @@ export const TemplateCustomizationsStep: FC<
 		...provisionerDaemons(selectedOrg?.id ?? ""),
 		enabled: Boolean(selectedOrg),
 	});
-	const hasProvisioners = provisioners ? provisioners.length > 0 : undefined;
-	const showProvisionerWarning = hasProvisioners === false;
-
-	// Notify parent when provisioner status changes so the wizard can
-	// disable the create button when no provisioners are available.
-	useEffect(() => {
-		onProvisionerStatusChange(hasProvisioners);
-	}, [hasProvisioners, onProvisionerStatusChange]);
+	const showProvisionerWarning = provisioners ? provisioners.length < 1 : false;
 
 	// Auto-select when exactly one org is available.
 	useEffect(() => {

--- a/site/src/pages/TemplateBuilder/wizardState.ts
+++ b/site/src/pages/TemplateBuilder/wizardState.ts
@@ -34,7 +34,6 @@ export type TemplateBuilderWizardState = {
 	baseVariableValues: Record<string, string>;
 	modules: TemplateBuilderComposeModule[];
 	organizationId?: string;
-	hasProvisioners: boolean | undefined;
 	name: string;
 	displayName: string;
 	description: string;
@@ -47,7 +46,6 @@ export const initialWizardState: TemplateBuilderWizardState = {
 	baseTemplateId: null,
 	baseVariableValues: {},
 	modules: [],
-	hasProvisioners: undefined,
 	name: "",
 	displayName: "",
 	description: "",
@@ -74,7 +72,6 @@ export type WizardAction =
 			field: "organizationId" | "name" | "displayName" | "description" | "icon";
 			value: string;
 	  }
-	| { type: "SET_HAS_PROVISIONERS"; value: boolean | undefined }
 	| { type: "RESET_CUSTOMIZATIONS" }
 	| { type: "RESET" };
 
@@ -127,16 +124,10 @@ export function wizardReducer(
 				...state,
 				[action.field]: action.value,
 			};
-		case "SET_HAS_PROVISIONERS":
-			return {
-				...state,
-				hasProvisioners: action.value,
-			};
 		case "RESET_CUSTOMIZATIONS":
 			return {
 				...state,
 				organizationId: undefined,
-				hasProvisioners: undefined,
 				name: "",
 				displayName: "",
 				description: "",


### PR DESCRIPTION
## Summary

Remove `hasProvisioners` from `TemplateBuilderWizardState`. Provisioner availability is a transient, environment-level concern that doesn't belong in the wizard's form state.

## Changes

- Removed `hasProvisioners` field from `TemplateBuilderWizardState` and `initialWizardState`
- Removed `SET_HAS_PROVISIONERS` action and its reducer case
- Removed `onProvisionerStatusChange` callback prop from `TemplateCustomizationsStep` and the `useCallback`/`useEffect` plumbing in the parent
- Reverted `computeCanContinue` for the customizations step to only check `state.name.trim() !== ""`
- Kept the provisioner warning as informational only (not blocking submission)

## Rationale

This aligns with the existing `CreateTemplateForm` approach, which explicitly notes that submission should not be disabled based on provisioner status. A user can connect a provisioner after seeing the warning and submit without refreshing, so blocking based on a potentially stale query result is counterproductive.

> 🤖 Generated by Coder Agents on behalf of @jeremyruppel