### PR TITLE
feat(site): clarify module listing's empty state copy if selected base template has no modules

### DIFF
--- a/site/src/pages/TemplateBuilder/ModuleSelectStep.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleSelectStep.tsx
@@ -112,6 +112,7 @@ export const ModuleSelectStep: FC<ModuleSelectStepProps> = ({
 	const { data, error, isLoading } = useQuery(templateBuilderModules(baseId));
 	const [moduleSearchText, setModuleSearchText] = useState("");
 	const modules = data?.modules ?? [];
+	const doesBaseTemplateHaveModules = modules.length > 0;
 	const sortedModules = sortByPriority(modules, MODULE_PRIORITY);
 	const categories = [
 		...new Set(sortedModules.map((module) => module.category)),
@@ -261,7 +262,9 @@ export const ModuleSelectStep: FC<ModuleSelectStepProps> = ({
 					<div className="col-span-full my-12 flex flex-col items-center gap-1 text-content-secondary">
 						<SearchIcon />
 						<p className="m-0 text-sm font-normal">
-							No module matched your search
+							{doesBaseTemplateHaveModules
+								? "No module matched your search"
+								: "No modules available for this base template"}
 						</p>
 					</div>
 				)}


### PR DESCRIPTION
ref DEVEX-578

One base template I'm aware of where you can test this state is AWS EC2 (Windows):

<img width="1840" height="1191" alt="image" src="https://github.com/user-attachments/assets/ffd22fd2-a811-424d-a840-be6114b38560" />

The previous copy is still shown if you choose a different base and search modules for a term with no matches:

<img width="1840" height="1191" alt="image" src="https://github.com/user-attachments/assets/3db95c6a-42e6-48c1-8800-e482680cb109" />