### PR TITLE
fix(site): hide slash skills menu when user has no personal skills

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatMessageInput/ChatMessageInput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatMessageInput/ChatMessageInput.stories.tsx
@@ -79,8 +79,7 @@ export const EmptySkills: Story = {
 	},
 	play: async ({ canvasElement, args }) => {
 		const editor = await typeInEditor(canvasElement, "/");
-		// With no personal skills, "/" behaves like plain text: no popover
-		// opens and Enter submits instead of being swallowed.
+		// "/" is plain text when the skills list is empty.
 		expectNoVisibleTextImmediately("No personal skills found.");
 		await userEvent.keyboard("{Enter}");
 		expect(args.onEnter).toHaveBeenCalledTimes(1);

--- a/site/src/pages/AgentsPage/components/ChatMessageInput/ChatMessageInput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatMessageInput/ChatMessageInput.stories.tsx
@@ -79,10 +79,27 @@ export const EmptySkills: Story = {
 	},
 	play: async ({ canvasElement, args }) => {
 		const editor = await typeInEditor(canvasElement, "/");
-		expect(await findVisibleText("No personal skills found.")).toBeDefined();
+		// With no personal skills, "/" behaves like plain text: no popover
+		// opens and Enter submits instead of being swallowed.
+		expectNoVisibleTextImmediately("No personal skills found.");
+		await userEvent.keyboard("{Enter}");
+		expect(args.onEnter).toHaveBeenCalledTimes(1);
+		expect(editor.textContent).toBe("/");
+	},
+};
+
+export const FilteredEmptyKeepsMenuOpen: Story = {
+	args: {
+		onEnter: fn(),
+	},
+	play: async ({ canvasElement, args }) => {
+		const editor = await typeInEditor(canvasElement, "/zzzz");
+		expect(
+			await findVisibleText("No personal skills match that query."),
+		).toBeDefined();
 		await userEvent.keyboard("{Enter}");
 		expect(args.onEnter).not.toHaveBeenCalled();
-		expect(editor.textContent).toBe("/");
+		expect(editor.textContent).toBe("/zzzz");
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatMessageInput/ChatMessageInput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatMessageInput/ChatMessageInput.tsx
@@ -600,22 +600,18 @@ const ChatMessageInput = ({
 	const skillsQuery = useQuery({
 		...userSkills(),
 		enabled: hasSkillsTrigger && !hasPersonalSkillsOverride,
-		// Keep cached skills fresh briefly so caret movement that closes and
-		// reopens the trigger does not refetch on every toggle.
+		// Avoid refetching on each trigger toggle from caret movement.
 		staleTime: 60_000,
 	});
 	const personalSkills = personalSkillsOverride ?? skillsQuery.data ?? [];
-	// Only a settled fetch counts as resolved. A stale cached empty list with
-	// a refetch in flight must keep the menu open so it is not dismissed
-	// right before skills arrive.
+	// A stale empty cache with a refetch in flight must not dismiss the menu.
 	const isResolvedEmptySkillsList = hasPersonalSkillsOverride
 		? personalSkills.length === 0
 		: skillsQuery.isSuccess &&
 			!skillsQuery.isFetching &&
 			personalSkills.length === 0;
-	// With no personal skills, "/" behaves like plain text: no popover and no
-	// Enter/arrow interception. Filtered-empty (user has skills, query
-	// matches none) keeps the menu open to show the no-match message.
+	// Resolved-empty suppresses the menu; filtered-empty keeps it open for
+	// the no-match message.
 	const skillsMenuOpen = hasSkillsTrigger && !isResolvedEmptySkillsList;
 	const filteredPersonalSkills = skillsTrigger
 		? filterPersonalSkills(personalSkills, skillsTrigger.query)
@@ -909,7 +905,7 @@ const ChatMessageInput = ({
 					isLoading={
 						skillsMenuOpen &&
 						personalSkills.length === 0 &&
-						(skillsQuery.isLoading || skillsQuery.isFetching)
+						skillsQuery.isFetching
 					}
 					onSelectedIndexChange={setSkillsMenuSelectedIndex}
 					isError={skillsMenuOpen && skillsQuery.isError}

--- a/site/src/pages/AgentsPage/components/ChatMessageInput/ChatMessageInput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatMessageInput/ChatMessageInput.tsx
@@ -595,12 +595,28 @@ const ChatMessageInput = ({
 		useState<ActiveSkillsTrigger | null>(null);
 	const suppressedSkillsTriggerRef = useRef<SkillsTriggerLocation | null>(null);
 	const [skillsMenuSelectedIndex, setSkillsMenuSelectedIndex] = useState(0);
-	const skillsMenuOpen = Boolean(skillsTrigger);
+	const hasSkillsTrigger = Boolean(skillsTrigger);
+	const hasPersonalSkillsOverride = personalSkillsOverride !== undefined;
 	const skillsQuery = useQuery({
 		...userSkills(),
-		enabled: skillsMenuOpen && personalSkillsOverride === undefined,
+		enabled: hasSkillsTrigger && !hasPersonalSkillsOverride,
+		// Keep cached skills fresh briefly so caret movement that closes and
+		// reopens the trigger does not refetch on every toggle.
+		staleTime: 60_000,
 	});
 	const personalSkills = personalSkillsOverride ?? skillsQuery.data ?? [];
+	// Only a settled fetch counts as resolved. A stale cached empty list with
+	// a refetch in flight must keep the menu open so it is not dismissed
+	// right before skills arrive.
+	const isResolvedEmptySkillsList = hasPersonalSkillsOverride
+		? personalSkills.length === 0
+		: skillsQuery.isSuccess &&
+			!skillsQuery.isFetching &&
+			personalSkills.length === 0;
+	// With no personal skills, "/" behaves like plain text: no popover and no
+	// Enter/arrow interception. Filtered-empty (user has skills, query
+	// matches none) keeps the menu open to show the no-match message.
+	const skillsMenuOpen = hasSkillsTrigger && !isResolvedEmptySkillsList;
 	const filteredPersonalSkills = skillsTrigger
 		? filterPersonalSkills(personalSkills, skillsTrigger.query)
 		: [];
@@ -890,7 +906,11 @@ const ChatMessageInput = ({
 					anchorRect={skillsTrigger?.anchorRect ?? null}
 					query={skillsTrigger?.query ?? ""}
 					skills={filteredPersonalSkills}
-					isLoading={skillsMenuOpen && skillsQuery.isLoading}
+					isLoading={
+						skillsMenuOpen &&
+						personalSkills.length === 0 &&
+						(skillsQuery.isLoading || skillsQuery.isFetching)
+					}
 					onSelectedIndexChange={setSkillsMenuSelectedIndex}
 					isError={skillsMenuOpen && skillsQuery.isError}
 					selectedIndex={selectedSkillIndex}

--- a/site/src/pages/AgentsPage/components/ChatMessageInput/ChatMessageInput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatMessageInput/ChatMessageInput.tsx
@@ -610,8 +610,9 @@ const ChatMessageInput = ({
 		: skillsQuery.isSuccess &&
 			!skillsQuery.isFetching &&
 			personalSkills.length === 0;
-	// Resolved-empty suppresses the menu; filtered-empty keeps it open for
-	// the no-match message.
+	// When the loaded skills list is empty, "/" is plain text. When only
+	// the filtered result is empty, keep the menu open for the no-match
+	// message.
 	const skillsMenuOpen = hasSkillsTrigger && !isResolvedEmptySkillsList;
 	const filteredPersonalSkills = skillsTrigger
 		? filterPersonalSkills(personalSkills, skillsTrigger.query)


### PR DESCRIPTION
Typing `/` in the /agents chat composer always opened the personal skills popover, even for users with zero skills. The empty popover offered no value and, worse, `SkillsTriggerPlugin` swallowed Enter and arrow keys whenever it was open, so a zero-skill user pressing Enter after `/` could not submit the message. Additionally, the skills query re-enabled every time the caret re-entered a slash token, refetching on every toggle with the app's default `staleTime: 0`.

Changes in `ChatMessageInput`:

- Gate `skillsMenuOpen` on a definitively empty base skill list: when the query has settled (`isSuccess && !isFetching`) and returned no skills, `/` behaves like plain text with no popover and no key interception. Loading and error states still show the popover, and filtered-empty (user has skills, query matches none) keeps showing the no-match message.
- Add `staleTime: 60_000` at the call site so caret movement no longer refetches on each trigger toggle. The settings page keeps its refetch-on-mount freshness.
- Show the loading state while a background refetch runs over a cached empty list, avoiding a premature empty-state flash.

Stories: `EmptySkills` now asserts no popover renders and Enter submits; new `FilteredEmptyKeepsMenuOpen` asserts the no-match message stays and Enter is swallowed when the user has skills.

> This PR was created by Mux on Mike's behalf.
