### PR TITLE
feat(site): prefill agent chat input from `?q=` URL param

### DIFF
--- a/site/src/pages/AgentsPage/AgentsPage.test.ts
+++ b/site/src/pages/AgentsPage/AgentsPage.test.ts
@@ -289,6 +289,107 @@ describe("useEmptyStateDraft", () => {
 		expect(localStorage.getItem(emptyInputStorageKey)).toBeNull();
 		unmount();
 	});
+
+	describe("URL prompt", () => {
+		const renderWithUrlPrompt = (urlPrompt: string | null) =>
+			renderHook(() => useEmptyStateDraft(urlPrompt));
+
+		it("initializes the draft from the URL prompt when provided", () => {
+			const { result, unmount } = renderWithUrlPrompt("summarize this repo");
+
+			expect(result.current.initialInputValue).toBe("summarize this repo");
+			expect(result.current.initialEditorState).toBeUndefined();
+			expect(result.current.showUrlPromptWarning).toBe(true);
+			unmount();
+		});
+
+		it("prefers the URL prompt over a stored draft", () => {
+			localStorage.setItem(emptyInputStorageKey, "stored draft");
+
+			const { result, unmount } = renderWithUrlPrompt("from url");
+
+			expect(result.current.initialInputValue).toBe("from url");
+			expect(result.current.initialEditorState).toBeUndefined();
+			unmount();
+		});
+
+		it("falls back to the stored draft when no URL prompt is provided", () => {
+			localStorage.setItem(emptyInputStorageKey, "stored draft");
+
+			const { result, unmount } = renderWithUrlPrompt(null);
+
+			expect(result.current.initialInputValue).toBe("stored draft");
+			expect(result.current.showUrlPromptWarning).toBe(false);
+			unmount();
+		});
+
+		it("does not persist the URL prompt to localStorage on the initial content event", () => {
+			const { result, unmount } = renderWithUrlPrompt("from url");
+
+			// Editor mount fires onChange with the initial value.
+			act(() => {
+				result.current.handleContentChange("from url", "from url", false);
+			});
+
+			expect(localStorage.getItem(emptyInputStorageKey)).toBeNull();
+			expect(result.current.showUrlPromptWarning).toBe(true);
+			unmount();
+		});
+
+		it("persists to localStorage once the URL prompt is modified", () => {
+			const { result, unmount } = renderWithUrlPrompt("from url");
+
+			act(() => {
+				result.current.handleContentChange("from url", "from url", false);
+			});
+			expect(localStorage.getItem(emptyInputStorageKey)).toBeNull();
+
+			act(() => {
+				result.current.handleContentChange(
+					"from url with edits",
+					"from url with edits",
+					false,
+				);
+			});
+
+			expect(localStorage.getItem(emptyInputStorageKey)).toBe(
+				"from url with edits",
+			);
+			expect(result.current.showUrlPromptWarning).toBe(false);
+			unmount();
+		});
+
+		it("keeps persisting after modification even if the user retypes the URL prompt", () => {
+			const { result, unmount } = renderWithUrlPrompt("from url");
+
+			// Modify.
+			act(() => {
+				result.current.handleContentChange("modified", "modified", false);
+			});
+			expect(localStorage.getItem(emptyInputStorageKey)).toBe("modified");
+
+			// Retype exactly the URL prompt. The warning should stay
+			// dismissed and persistence continues.
+			act(() => {
+				result.current.handleContentChange("from url", "from url", false);
+			});
+			expect(localStorage.getItem(emptyInputStorageKey)).toBe("from url");
+			expect(result.current.showUrlPromptWarning).toBe(false);
+			unmount();
+		});
+
+		it("clears the draft via submitDraft even when the URL prompt was never modified", () => {
+			localStorage.setItem(emptyInputStorageKey, "stale unrelated draft");
+			const { result, unmount } = renderWithUrlPrompt("from url");
+
+			act(() => {
+				result.current.submitDraft();
+			});
+
+			expect(localStorage.getItem(emptyInputStorageKey)).toBeNull();
+			unmount();
+		});
+	});
 });
 
 describe("useFileAttachments persistence", () => {

--- a/site/src/pages/AgentsPage/AgentsPage.test.ts
+++ b/site/src/pages/AgentsPage/AgentsPage.test.ts
@@ -362,14 +362,12 @@ describe("useEmptyStateDraft", () => {
 		it("keeps persisting after modification even if the user retypes the URL prompt", () => {
 			const { result, unmount } = renderWithUrlPrompt("from url");
 
-			// Modify.
 			act(() => {
 				result.current.handleContentChange("modified", "modified", false);
 			});
 			expect(localStorage.getItem(emptyInputStorageKey)).toBe("modified");
 
-			// Retype exactly the URL prompt. The warning should stay
-			// dismissed and persistence continues.
+			// Retype the URL prompt verbatim: banner stays dismissed, persistence continues.
 			act(() => {
 				result.current.handleContentChange("from url", "from url", false);
 			});

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -155,10 +155,8 @@ interface AgentChatInputProps {
 	// History editing state, owned by the parent.
 	isEditingHistoryMessage?: boolean;
 	onCancelHistoryEdit?: () => void;
-	// URL-supplied prompt caution state, owned by the parent.
-	// When true, the composer renders a warning ring and an inline
-	// caution banner. Auto-dismisses upstream when the user edits
-	// the prefilled prompt.
+	// URL-prompt caution: wraps composer with a warning ring and a
+	// top-of-composer banner. Auto-dismissed upstream on user edit.
 	showUrlPromptWarning?: boolean;
 	// Newest-first list of non-empty user prompts for local history cycling.
 	userPromptHistory?: readonly string[];

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -10,6 +10,7 @@ import {
 	PlusIcon,
 	ServerIcon,
 	SquareIcon,
+	TriangleAlertIcon,
 	XIcon,
 } from "lucide-react";
 import type React from "react";
@@ -154,6 +155,11 @@ interface AgentChatInputProps {
 	// History editing state, owned by the parent.
 	isEditingHistoryMessage?: boolean;
 	onCancelHistoryEdit?: () => void;
+	// URL-supplied prompt caution state, owned by the parent.
+	// When true, the composer renders a warning ring and an inline
+	// caution banner. Auto-dismisses upstream when the user edits
+	// the prefilled prompt.
+	showUrlPromptWarning?: boolean;
 	// Newest-first list of non-empty user prompts for local history cycling.
 	userPromptHistory?: readonly string[];
 
@@ -373,6 +379,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	onCancelQueueEdit,
 	isEditingHistoryMessage = false,
 	onCancelHistoryEdit,
+	showUrlPromptWarning = false,
 	userPromptHistory = [],
 	contextUsage,
 	onRefreshContext,
@@ -1098,7 +1105,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 					"relative z-10 rounded-2xl border border-border-default/80 bg-surface-secondary sm:bg-surface-secondary/45 p-1 shadow-sm has-[textarea:focus]:ring-2 has-[textarea:focus]:ring-content-link/40",
 					showAgentSetupNotice && "sm:bg-surface-secondary",
 					isDragging && "ring-2 ring-content-link/40",
-					isEditingHistoryMessage &&
+					(isEditingHistoryMessage || showUrlPromptWarning) &&
 						"shadow-[0_0_0_2px_hsla(var(--border-warning),0.6)]",
 				)}
 				onKeyDown={handleComposerKeyDown}
@@ -1142,6 +1149,18 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 						</Button>
 					</div>
 				)}
+				{showUrlPromptWarning &&
+					!isEditingHistoryMessage &&
+					editingQueuedMessageID === null && (
+						<div className="flex items-start gap-1.5 border-b border-border-warning/50 px-3 py-1.5 text-xs font-medium text-content-warning">
+							<TriangleAlertIcon className="mt-0.5 size-3.5 shrink-0" />
+							<span>
+								Use caution before running this prompt. Malicious content could
+								trick Coder Agents into attempting harmful actions or sharing
+								your data.
+							</span>
+						</div>
+					)}
 				{onRemoveAttachment && (
 					<AttachmentPreview
 						attachments={attachments}

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -8,6 +8,7 @@ import {
 	waitFor,
 	within,
 } from "storybook/test";
+import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import { API } from "#/api/api";
 import type * as TypesGen from "#/api/typesGenerated";
 import { ConfirmDialog } from "#/components/Dialogs/ConfirmDialog/ConfirmDialog";
@@ -827,5 +828,130 @@ export const PermittedOrgsResolvesToSubset: Story = {
 			throw new Error("Expected onCreateChat to receive options");
 		}
 		expect(options.organizationId).toBe(MockOrganization2.id);
+	},
+};
+
+/**
+ * When the user follows a link like `/agents?q=<prompt>`, the composer
+ * is prefilled with that prompt and a warning banner is shown until
+ * the prompt is modified. The prompt is never auto-submitted.
+ */
+export const PrefillPromptFromUrl: Story = {
+	args: {
+		...defaultArgs,
+		onCreateChat: fn().mockResolvedValue(undefined),
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: {
+				path: "/agents",
+				searchParams: {
+					q: "summarize the top-level README of this repo",
+				},
+			},
+			routing: [{ path: "/agents", useStoryElement: true }],
+		}),
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+
+		// The composer is prefilled with the URL prompt.
+		const input = await canvas.findByTestId("chat-message-input");
+		await waitFor(() => {
+			expect(input.textContent).toContain(
+				"summarize the top-level README of this repo",
+			);
+		});
+
+		// The caution banner is visible while the prompt is unmodified.
+		await waitFor(() => {
+			expect(
+				canvas.getByText(/Use caution before running this prompt/),
+			).toBeInTheDocument();
+		});
+
+		// The user still has to press Send: nothing is auto-submitted.
+		expect(args.onCreateChat).not.toHaveBeenCalled();
+
+		// Submitting sends the URL prompt verbatim.
+		await userEvent.click(canvas.getByRole("button", { name: "Send" }));
+		await waitFor(() => {
+			expect(args.onCreateChat).toHaveBeenCalled();
+		});
+		const options = (args.onCreateChat as ReturnType<typeof fn>).mock
+			.calls[0]?.[0] as { message: string } | undefined;
+		if (!options) {
+			throw new Error("Expected onCreateChat to receive options");
+		}
+		expect(options.message).toBe("summarize the top-level README of this repo");
+	},
+};
+
+/**
+ * Editing the URL-supplied prompt dismisses the caution banner because
+ * the user has taken ownership of the text.
+ */
+export const UrlPromptWarningDismissesOnEdit: Story = {
+	args: {
+		...defaultArgs,
+		onCreateChat: fn().mockResolvedValue(undefined),
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: {
+				path: "/agents",
+				searchParams: { q: "prompt from url" },
+			},
+			routing: [{ path: "/agents", useStoryElement: true }],
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		await waitFor(() => {
+			expect(
+				canvas.getByText(/Use caution before running this prompt/),
+			).toBeInTheDocument();
+		});
+
+		// Type into the input to modify the URL-supplied prompt.
+		const input = canvas.getByTestId("chat-message-input");
+		await userEvent.click(input);
+		await userEvent.keyboard(" and add tests");
+
+		// The caution banner should be gone.
+		await waitFor(() => {
+			expect(
+				canvas.queryByText(/Use caution before running this prompt/),
+			).not.toBeInTheDocument();
+		});
+	},
+};
+
+/**
+ * An empty `?q=` param is ignored: no prompt is prefilled and the
+ * warning banner is not shown.
+ */
+export const EmptyUrlPromptIsIgnored: Story = {
+	args: {
+		...defaultArgs,
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: {
+				path: "/agents",
+				searchParams: { q: "   " },
+			},
+			routing: [{ path: "/agents", useStoryElement: true }],
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const input = await canvas.findByTestId("chat-message-input");
+		// The composer starts empty (placeholder visible).
+		expect(input.textContent).toBe("");
+		expect(
+			canvas.queryByText(/Use caution before running this prompt/),
+		).not.toBeInTheDocument();
 	},
 };

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -831,11 +831,7 @@ export const PermittedOrgsResolvesToSubset: Story = {
 	},
 };
 
-/**
- * When the user follows a link like `/agents?q=<prompt>`, the composer
- * is prefilled with that prompt and a warning banner is shown until
- * the prompt is modified. The prompt is never auto-submitted.
- */
+/** `/agents?q=<prompt>` prefills the composer with a caution banner; never auto-submits. */
 export const PrefillPromptFromUrl: Story = {
 	args: {
 		...defaultArgs,
@@ -855,7 +851,6 @@ export const PrefillPromptFromUrl: Story = {
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
 
-		// The composer is prefilled with the URL prompt.
 		const input = await canvas.findByTestId("chat-message-input");
 		await waitFor(() => {
 			expect(input.textContent).toContain(
@@ -863,17 +858,15 @@ export const PrefillPromptFromUrl: Story = {
 			);
 		});
 
-		// The caution banner is visible while the prompt is unmodified.
 		await waitFor(() => {
 			expect(
 				canvas.getByText(/Use caution before running this prompt/),
 			).toBeInTheDocument();
 		});
 
-		// The user still has to press Send: nothing is auto-submitted.
+		// Never auto-submits.
 		expect(args.onCreateChat).not.toHaveBeenCalled();
 
-		// Submitting sends the URL prompt verbatim.
 		await userEvent.click(canvas.getByRole("button", { name: "Send" }));
 		await waitFor(() => {
 			expect(args.onCreateChat).toHaveBeenCalled();
@@ -887,10 +880,7 @@ export const PrefillPromptFromUrl: Story = {
 	},
 };
 
-/**
- * Editing the URL-supplied prompt dismisses the caution banner because
- * the user has taken ownership of the text.
- */
+/** Editing the URL-supplied prompt dismisses the caution banner. */
 export const UrlPromptWarningDismissesOnEdit: Story = {
 	args: {
 		...defaultArgs,
@@ -914,12 +904,11 @@ export const UrlPromptWarningDismissesOnEdit: Story = {
 			).toBeInTheDocument();
 		});
 
-		// Type into the input to modify the URL-supplied prompt.
+		// Modify the prompt.
 		const input = canvas.getByTestId("chat-message-input");
 		await userEvent.click(input);
 		await userEvent.keyboard(" and add tests");
 
-		// The caution banner should be gone.
 		await waitFor(() => {
 			expect(
 				canvas.queryByText(/Use caution before running this prompt/),
@@ -928,10 +917,7 @@ export const UrlPromptWarningDismissesOnEdit: Story = {
 	},
 };
 
-/**
- * An empty `?q=` param is ignored: no prompt is prefilled and the
- * warning banner is not shown.
- */
+/** Whitespace-only `?q=` is ignored: no prefill, no banner. */
 export const EmptyUrlPromptIsIgnored: Story = {
 	args: {
 		...defaultArgs,
@@ -948,7 +934,6 @@ export const EmptyUrlPromptIsIgnored: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const input = await canvas.findByTestId("chat-message-input");
-		// The composer starts empty (placeholder visible).
 		expect(input.textContent).toBe("");
 		expect(
 			canvas.queryByText(/Use caution before running this prompt/),

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -40,29 +40,13 @@ export const emptyInputStorageKey = "agents.empty-input";
 const selectedWorkspaceIdStorageKey = "agents.selected-workspace-id";
 const lastModelConfigIDStorageKey = "agents.last-model-config-id";
 
-/**
- * URL query parameter that pre-fills the empty-state composer.
- * Matches the industry convention used by ChatGPT, Grok, Gemini,
- * and Perplexity so a copy/paste from those tools works.
- */
+// Industry-convention prefill param (ChatGPT, Grok, Gemini, Perplexity).
 const URL_PROMPT_PARAM = "q";
 
 /**
- * Read the `?q=<prompt>` URL search param and strip it from the
- * browser URL so a submit-and-navigate flow doesn't leak the
- * prompt into the resulting chat's URL and a subsequent "new
- * chat" action starts from a clean slate.
- *
- * The prompt is prefilled into the composer but never
- * auto-submitted; running the agent is always an explicit user
- * action, and a warning banner is shown while the prefilled
- * value is unmodified. See
- * https://www.tenable.com/security/research/tra-2025-22 for the
- * prompt-injection class of vulnerability this guards against.
- *
- * The captured value is held in local state so it survives the
- * URL strip that happens in the mount effect. Returns `null`
- * when no non-empty prompt is present.
+ * Reads `?q=<prompt>` and strips it from the URL on mount. The value
+ * survives the strip via `useState`, and is never auto-submitted.
+ * See https://www.tenable.com/security/research/tra-2025-22.
  */
 function useConsumedUrlPrompt(): string | null {
 	const [searchParams, setSearchParams] = useSearchParams();
@@ -107,12 +91,9 @@ export type CreateChatOptions = {
  * Persists the current input to localStorage so the user's draft
  * survives page reloads.
  *
- * When `urlPrompt` is provided, it wins over any stored draft: the
- * composer initializes with the URL prompt, a warning banner is
- * surfaced (`showUrlPromptWarning`), and the prompt is intentionally
- * not persisted to localStorage until the user modifies it. That
- * way a user who opens a link from an untrusted source and closes
- * the tab doesn't leave the prompt sitting in their next chat draft.
+ * When `urlPrompt` is provided it wins over any stored draft and is
+ * kept out of localStorage until modified, so opening an untrusted
+ * link and closing the tab leaves no residue.
  *
  * Once `submitDraft` is called, the stored draft is removed and further
  * content changes are no longer persisted for the lifetime of the hook.
@@ -142,8 +123,7 @@ export function useEmptyStateDraft(urlPrompt: string | null = null) {
 	);
 	const inputValueRef = useRef(initialInputValue);
 	const sentRef = useRef(false);
-	// Once the URL-supplied prompt has been modified by the user,
-	// resume normal draft persistence and drop the warning banner.
+	// Flips true on the first user edit, resuming persistence and dismissing the banner.
 	const [hasModifiedUrlPrompt, setHasModifiedUrlPrompt] = useState(false);
 	const showUrlPromptWarning = isFromUrl && !hasModifiedUrlPrompt;
 
@@ -156,9 +136,7 @@ export function useEmptyStateDraft(urlPrompt: string | null = null) {
 		if (sentRef.current) {
 			return;
 		}
-		// Skip persistence and warning-dismissal while the URL prompt
-		// is still exactly as delivered. Only once the user edits it
-		// do we treat the content as their own draft.
+		// Don't persist or dismiss while the URL prompt is unmodified.
 		if (isFromUrl && !hasModifiedUrlPrompt) {
 			if (content === initialInputValue) {
 				return;

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -1,6 +1,6 @@
 import { type FC, useEffect, useEffectEvent, useRef, useState } from "react";
 import { useQuery } from "react-query";
-import { Link } from "react-router";
+import { Link, useSearchParams } from "react-router";
 import { toast } from "sonner";
 import { isApiError } from "#/api/errors";
 import { permittedOrganizations } from "#/api/queries/organizations";
@@ -40,6 +40,56 @@ export const emptyInputStorageKey = "agents.empty-input";
 const selectedWorkspaceIdStorageKey = "agents.selected-workspace-id";
 const lastModelConfigIDStorageKey = "agents.last-model-config-id";
 
+/**
+ * URL query parameter that pre-fills the empty-state composer.
+ * Matches the industry convention used by ChatGPT, Grok, Gemini,
+ * and Perplexity so a copy/paste from those tools works.
+ */
+const URL_PROMPT_PARAM = "q";
+
+/**
+ * Read the `?q=<prompt>` URL search param and strip it from the
+ * browser URL so a submit-and-navigate flow doesn't leak the
+ * prompt into the resulting chat's URL and a subsequent "new
+ * chat" action starts from a clean slate.
+ *
+ * The prompt is prefilled into the composer but never
+ * auto-submitted; running the agent is always an explicit user
+ * action, and a warning banner is shown while the prefilled
+ * value is unmodified. See
+ * https://www.tenable.com/security/research/tra-2025-22 for the
+ * prompt-injection class of vulnerability this guards against.
+ *
+ * The captured value is held in local state so it survives the
+ * URL strip that happens in the mount effect. Returns `null`
+ * when no non-empty prompt is present.
+ */
+function useConsumedUrlPrompt(): string | null {
+	const [searchParams, setSearchParams] = useSearchParams();
+	const [urlPrompt] = useState<string | null>(() => {
+		const raw = searchParams.get(URL_PROMPT_PARAM);
+		const trimmed = raw?.trim();
+		return trimmed && trimmed.length > 0 ? trimmed : null;
+	});
+	useEffect(() => {
+		if (urlPrompt === null) {
+			return;
+		}
+		setSearchParams(
+			(prev) => {
+				if (!prev.has(URL_PROMPT_PARAM)) {
+					return prev;
+				}
+				const next = new URLSearchParams(prev);
+				next.delete(URL_PROMPT_PARAM);
+				return next;
+			},
+			{ replace: true },
+		);
+	}, [urlPrompt, setSearchParams]);
+	return urlPrompt;
+}
+
 type ChatModelOption = ModelSelectorOption;
 
 export type CreateChatOptions = {
@@ -57,22 +107,45 @@ export type CreateChatOptions = {
  * Persists the current input to localStorage so the user's draft
  * survives page reloads.
  *
+ * When `urlPrompt` is provided, it wins over any stored draft: the
+ * composer initializes with the URL prompt, a warning banner is
+ * surfaced (`showUrlPromptWarning`), and the prompt is intentionally
+ * not persisted to localStorage until the user modifies it. That
+ * way a user who opens a link from an untrusted source and closes
+ * the tab doesn't leave the prompt sitting in their next chat draft.
+ *
  * Once `submitDraft` is called, the stored draft is removed and further
  * content changes are no longer persisted for the lifetime of the hook.
  * Call `resetDraft` to re-enable persistence (e.g. on mutation failure).
  *
  * @internal Exported for testing.
  */
-export function useEmptyStateDraft() {
-	const [{ initialInputValue, initialEditorState }] = useState(() => {
-		const draft = parseStoredDraft(localStorage.getItem(emptyInputStorageKey));
-		return {
-			initialInputValue: draft.text,
-			initialEditorState: draft.editorState,
-		};
-	});
+export function useEmptyStateDraft(urlPrompt: string | null = null) {
+	const [{ initialInputValue, initialEditorState, isFromUrl }] = useState(
+		() => {
+			if (urlPrompt !== null) {
+				return {
+					initialInputValue: urlPrompt,
+					initialEditorState: undefined as string | undefined,
+					isFromUrl: true,
+				};
+			}
+			const draft = parseStoredDraft(
+				localStorage.getItem(emptyInputStorageKey),
+			);
+			return {
+				initialInputValue: draft.text,
+				initialEditorState: draft.editorState,
+				isFromUrl: false,
+			};
+		},
+	);
 	const inputValueRef = useRef(initialInputValue);
 	const sentRef = useRef(false);
+	// Once the URL-supplied prompt has been modified by the user,
+	// resume normal draft persistence and drop the warning banner.
+	const [hasModifiedUrlPrompt, setHasModifiedUrlPrompt] = useState(false);
+	const showUrlPromptWarning = isFromUrl && !hasModifiedUrlPrompt;
 
 	const handleContentChange = (
 		content: string,
@@ -80,17 +153,27 @@ export function useEmptyStateDraft() {
 		hasFileReferences: boolean,
 	) => {
 		inputValueRef.current = content;
-		if (!sentRef.current) {
-			const shouldPersist = content.trim() || hasFileReferences;
-			if (shouldPersist) {
-				try {
-					localStorage.setItem(emptyInputStorageKey, serializedEditorState);
-				} catch {
-					// QuotaExceededError, silently discard the draft.
-				}
-			} else {
-				localStorage.removeItem(emptyInputStorageKey);
+		if (sentRef.current) {
+			return;
+		}
+		// Skip persistence and warning-dismissal while the URL prompt
+		// is still exactly as delivered. Only once the user edits it
+		// do we treat the content as their own draft.
+		if (isFromUrl && !hasModifiedUrlPrompt) {
+			if (content === initialInputValue) {
+				return;
 			}
+			setHasModifiedUrlPrompt(true);
+		}
+		const shouldPersist = content.trim() || hasFileReferences;
+		if (shouldPersist) {
+			try {
+				localStorage.setItem(emptyInputStorageKey, serializedEditorState);
+			} catch {
+				// QuotaExceededError, silently discard the draft.
+			}
+		} else {
+			localStorage.removeItem(emptyInputStorageKey);
 		}
 	};
 
@@ -114,6 +197,7 @@ export function useEmptyStateDraft() {
 		handleContentChange,
 		submitDraft,
 		resetDraft,
+		showUrlPromptWarning,
 	};
 }
 
@@ -169,13 +253,15 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	isWorkspacesLoading,
 }) => {
 	const { organizations, showOrganizations } = useDashboard();
+	const urlPrompt = useConsumedUrlPrompt();
 	const {
 		initialInputValue,
 		initialEditorState,
 		handleContentChange,
 		submitDraft,
 		resetDraft,
-	} = useEmptyStateDraft();
+		showUrlPromptWarning,
+	} = useEmptyStateDraft(urlPrompt);
 	const [initialLastModelConfigID] = useState(() => {
 		return localStorage.getItem(lastModelConfigIDStorageKey) ?? "";
 	});
@@ -556,6 +642,15 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						unsupportedProviderNames={unsupportedProviderNames}
 						aiGatewayDisabled={aiGatewayDisabled}
 					/>
+					{showUrlPromptWarning && (
+						<Alert severity="warning" prominent>
+							<AlertDescription>
+								Use caution before running this prompt. Malicious content could
+								trick Coder Agents into attempting harmful actions or sharing
+								your data.
+							</AlertDescription>
+						</Alert>
+					)}
 					{modelSelectorHelp ? (
 						<div className="px-3 pt-1 text-2xs text-content-secondary">
 							{modelSelectorHelp}

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -641,16 +641,8 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						modelCount={modelCount}
 						unsupportedProviderNames={unsupportedProviderNames}
 						aiGatewayDisabled={aiGatewayDisabled}
+						showUrlPromptWarning={showUrlPromptWarning}
 					/>
-					{showUrlPromptWarning && (
-						<Alert severity="warning" prominent>
-							<AlertDescription>
-								Use caution before running this prompt. Malicious content could
-								trick Coder Agents into attempting harmful actions or sharing
-								your data.
-							</AlertDescription>
-						</Alert>
-					)}
 					{modelSelectorHelp ? (
 						<div className="px-3 pt-1 text-2xs text-content-secondary">
 							{modelSelectorHelp}


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

## What

Add support for `/agents?q=` so links from GitHub, Linear, Slack, or in-product buttons can land users in the Coder Agents composer with a starter prompt already typed. Matches the `?q=` convention used by ChatGPT, Grok, Gemini, Perplexity, and old-Claude so a copy/paste from those tools works.

See `Storybook > pages/AgentsPage/AgentCreateForm > Prefill Prompt From Url` for the interactive behavior.

## Safety model

The equivalent ChatGPT feature was exploited as a prompt-injection vector in [Tenable TRA-2025-22](https://www.tenable.com/security/research/tra-2025-22): any third-party site could `<a href="chatgpt.com/?q=…" rel="nofollow noreferrer">` and the prompt auto-submitted as the logged-in user. Anthropic pulled `claude.ai/new?q=` entirely in October 2025 (it no longer auto submits).

This implementation ships the mitigation up front:

- **Never auto-submits.** The prompt is prefilled; the user still has to press Send. This is the same mitigation OpenAI ended up shipping.
- **In-composer caution banner** with a warning ring around the composer while the value is unmodified, reusing the same visual pattern as the existing edit-history-message warning:
  > Use caution before running this prompt. Malicious content could trick Coder Agents into attempting harmful actions or sharing your data.

  Dismisses as soon as the user edits the input (`hasModifiedUrlPrompt` state).
- **Doesn't persist to the localStorage draft** until the user modifies the prompt. Opening a sketchy link and closing the tab leaves no residue in `agents.empty-input`.
- **Strips `?q=`** from the browser URL in a mount effect (`setSearchParams({...}, { replace: true })`). Prevents the prompt leaking into `location.search`, which `AgentCreatePage`'s submit handler would otherwise carry into `navigate({ search: location.search })` and put it in the new chat URL.
- **Plain text only.** Route through `AgentChatInput.initialValue`, not `initialEditorState` – the Lexical serialized state is not a public contract and shouldn't be accepted from a URL.

## Test coverage

- `useEmptyStateDraft` – seven new unit tests under a `URL prompt` describe covering: prefill from URL, URL prompt wins over localStorage draft, no persistence until modified, persistence resumes after modify, `submitDraft` clears the URL prompt cleanly.
- Three new Storybook stories with `play` functions:
  - `PrefillPromptFromUrl` – renders with `?q=`, verifies the composer is prefilled, banner is visible, no auto-submit, `onCreateChat` receives the URL prompt verbatim on Send.
  - `UrlPromptWarningDismissesOnEdit` – typing into the input drops the banner.
  - `EmptyUrlPromptIsIgnored` – whitespace-only `?q=` doesn't prefill or show the banner.

Local validation:

- `pnpm check`
- `pnpm lint`
- `pnpm vitest run --project=unit src/pages/AgentsPage/AgentsPage.test.ts` (46 tests, all pass)
- `pnpm test:storybook src/pages/AgentsPage/components/AgentCreateForm.stories.tsx` (27 stories, all pass)
- `make pre-commit` (via git hook)

<details>
<summary>Decision log</summary>

**Param name: `?q=`.** Not `?prompt=`, because `?q=` is the near-universal convention (ChatGPT, Grok, Gemini, Perplexity, old-Claude). The existing `?q=title:deploy` reference in `docs/ai-coder/agents/chat-search-syntax.md` is for the **API endpoint** (`/api/experimental/chats?q=…`), a different URL namespace. If we want a frontend search param later, name it `?search=`.

**Where the read/strip happens.** Inside `AgentCreateForm.tsx`, not `AgentsPage.tsx`. The empty-state composer is the only consumer, so pushing the URL logic to the page above would be strictly worse plumbing.

**Cache / strip approach.** Went through several iterations to survive React 19 StrictMode. Landed on: capture the URL prompt in `useState` initializer (impurity-check safe, called twice with the same URL both times), then strip in `useEffect`. StrictMode re-runs the effect with cleanup in between; the second strip is a no-op because `?q=` is already gone. State is preserved across the effect cycle, so no data loss. Verified empirically by the passing Storybook tests, which run under StrictMode.

**Warning banner UX.** Reuses the existing edit-history warning pattern inside `AgentChatInput`: `showUrlPromptWarning` prop applies a `shadow-[0_0_0_2px_hsla(var(--border-warning),0.6)]` ring around the composer wrapper and renders a top-of-composer banner (`border-b border-border-warning/50`, `text-content-warning`, `TriangleAlertIcon`). Keeps the visual language consistent with `isEditingHistoryMessage` instead of introducing a separate `<Alert>` block underneath. Dismisses on the first `onContentChange` where `content !== initialInputValue` – taking a keystroke as "user has taken ownership of the prompt."

**Modification detection.** `useEmptyStateDraft` tracks `hasModifiedUrlPrompt` in local state. `handleContentChange` short-circuits persistence while `isFromUrl && !hasModifiedUrlPrompt && content === initialInputValue`. First deviating character trips the flag; normal draft persistence resumes from that point (including retyping the URL prompt verbatim after modification).

**Editor state.** URL prompts always use `AgentChatInput.initialValue` (plain text) and set `initialEditorState = undefined`. Never accept a Lexical serialized state from a URL.

**Out of scope for this PR.**
- `?model=`, `?workspace=`, `?org=`, `?mcp=` URL params.
- Any `submit=true` / auto-run behavior.
- Multi-message / conversation replay from URL.
- Prefill from an external URL fetch (à la TypingMind's `initialContextURL=`).

</details>
