### PR TITLE
fix(site/src/pages/AgentsPage/components/ChatElements): keep model picker visible above mobile keyboard

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
@@ -136,10 +136,20 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
 				align={dropdownAlign}
 				className={cn(
 					enableMobileFullWidthDropdown &&
-						"mobile-full-width-dropdown mobile-full-width-dropdown-bottom",
+						"mobile-full-width-dropdown mobile-full-width-dropdown-above-composer",
 					"w-72 overflow-hidden border-border-default p-0",
 					contentClassName,
 				)}
+				onOpenAutoFocus={(event) => {
+					// On touch devices, auto-focusing the search input pops the
+					// software keyboard as soon as the picker opens, hiding the
+					// model list behind it. Only keep the WAI-ARIA combobox
+					// focus-into-input behavior for fine pointers (keyboard and
+					// mouse users on desktop).
+					if (matchMedia("(pointer: coarse)").matches) {
+						event.preventDefault();
+					}
+				}}
 			>
 				<Command
 					shouldFilter={false}


### PR DESCRIPTION
After #26927 replaced the model picker's `Select` with a searchable Popover + Command, opening the picker on iOS became unusable: Radix auto-focuses the `CommandInput`, which pops the software keyboard, and the `mobile-full-width-dropdown-bottom` variant positions the dropdown against the layout viewport bottom, which iOS does not resize when the keyboard opens. The user ends up seeing only the search field hovering above the keyboard with the model list occluded.

Two changes to `ModelSelector`:

- Suppress popover auto-focus on coarse pointers via `onOpenAutoFocus`, so opening the picker on touch devices shows the model list without summoning the keyboard. Desktop keeps the WAI-ARIA combobox behavior (focus lands in the search input, arrow keys navigate). Same pattern as `PersonalSkillsTriggerMenu`.
- Switch the mobile dropdown from the `-bottom` variant to the keyboard-aware `-above-composer` variant, so when the user does tap the search field, the list stays inside the visible (visual) viewport instead of behind the keyboard. The `CommandList` already carries `mobile-full-width-dropdown-scroll-area`, which pairs with this variant's max-height.

## Testing

- `pnpm lint:types`, `pnpm check`
- `pnpm test:storybook src/pages/AgentsPage/components/ChatElements/ModelSelector.stories.tsx` (10 passed)
- `pnpm test -- src/pages/AgentsPage/components/ChatElements/ModelSelector.test.tsx`

> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood