### PR TITLE
fix(site/src): keep short mobile dropdowns above the software keyboard

### DIFF
--- a/site/src/index.css
+++ b/site/src/index.css
@@ -36,7 +36,8 @@
 			  dropdowns.
 			- `--mobile-dropdown-above-composer-bottom`: distance from
 			  the layout viewport bottom to a point just above the
-			  composer's top edge.
+			  composer's top edge, clamped to stay above the software
+			  keyboard when the keyboard covers the composer.
 			- `--mobile-dropdown-above-composer-max-height`: maximum
 			  height the `-above-composer` variant can grow to without
 			  extending past the visible viewport top.

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -645,15 +645,33 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 			const fixedViewportBottom = fixedProbe.getBoundingClientRect().bottom;
 			const visibleViewportTop = viewport?.offsetTop ?? 0;
 			const bottom = Math.max(0, fixedViewportBottom - rect.bottom);
+			// The software keyboard covers the bottom of the layout
+			// viewport without moving fixed-positioned elements. Clamp the
+			// dropdown's bottom edge to stay above the keyboard so short
+			// dropdowns are not anchored inside the obscured region.
+			const keyboardInset = viewport
+				? Math.max(
+						0,
+						fixedViewportBottom - (viewport.offsetTop + viewport.height),
+					)
+				: 0;
 			// Distance from the fixed-position viewport bottom to a point
-			// just above the composer's top edge.
+			// just above the composer's top edge, or just above the
+			// keyboard when the keyboard covers the composer.
 			const aboveComposerBottom = Math.max(
 				0,
 				fixedViewportBottom - rect.top + composerGap,
+				keyboardInset + composerGap,
 			);
+			// Top edge of the dropdown's anchored bottom position in
+			// layout-viewport coordinates. Max-height candidates measure
+			// from here so the dropdown never extends past the visible
+			// viewport top, even when the bottom edge was clamped above
+			// the keyboard.
+			const dropdownBottomEdgeTop = fixedViewportBottom - aboveComposerBottom;
 			const maxHeightCandidates = [
-				rect.top - visibleViewportTop - composerGap - viewportPadding,
-				rect.top - composerGap - viewportPadding,
+				dropdownBottomEdgeTop - visibleViewportTop - viewportPadding,
+				dropdownBottomEdgeTop - viewportPadding,
 			].filter((height) => height > 0);
 			const aboveComposerMaxHeight = Math.max(
 				minimumMenuHeight,

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -645,29 +645,20 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 			const fixedViewportBottom = fixedProbe.getBoundingClientRect().bottom;
 			const visibleViewportTop = viewport?.offsetTop ?? 0;
 			const bottom = Math.max(0, fixedViewportBottom - rect.bottom);
-			// The software keyboard covers the bottom of the layout
-			// viewport without moving fixed-positioned elements. Clamp the
-			// dropdown's bottom edge to stay above the keyboard so short
-			// dropdowns are not anchored inside the obscured region.
+			// Keep the dropdown's bottom edge above the software keyboard,
+			// which covers the bottom of the layout viewport without moving
+			// fixed-positioned elements.
 			const keyboardInset = viewport
 				? Math.max(
 						0,
 						fixedViewportBottom - (viewport.offsetTop + viewport.height),
 					)
 				: 0;
-			// Distance from the fixed-position viewport bottom to a point
-			// just above the composer's top edge, or just above the
-			// keyboard when the keyboard covers the composer.
 			const aboveComposerBottom = Math.max(
 				0,
 				fixedViewportBottom - rect.top + composerGap,
 				keyboardInset + composerGap,
 			);
-			// Top edge of the dropdown's anchored bottom position in
-			// layout-viewport coordinates. Max-height candidates measure
-			// from here so the dropdown never extends past the visible
-			// viewport top, even when the bottom edge was clamped above
-			// the keyboard.
 			const dropdownBottomEdgeTop = fixedViewportBottom - aboveComposerBottom;
 			const maxHeightCandidates = [
 				dropdownBottomEdgeTop - visibleViewportTop - viewportPadding,


### PR DESCRIPTION
Follow-up to #26964. The mobile model picker was still hidden behind the software keyboard when the model list is short: tapping the picker's search box opens the keyboard, but the dropdown stays bottom-anchored just above the composer in layout-viewport coordinates, which is inside the keyboard-obscured region. A tall list only stayed visible by accident because its height pushed it up past the keyboard; a short list was fully covered.

Clamp `--mobile-dropdown-above-composer-bottom` so the dropdown's bottom edge stays above the keyboard, measured as the gap between the fixed-position viewport bottom and `visualViewport.offsetTop + height`. The existing `visualViewport` resize/scroll and `focusin` listeners already recompute the variables, so the dropdown moves up live as the keyboard animates in. Max-height candidates now measure from the clamped bottom edge so a tall list still cannot overflow the visible viewport top.

<details>
<summary>Diagnosis notes</summary>

- `#26964` moved the picker to the `mobile-full-width-dropdown-above-composer` variant and suppressed search autofocus on coarse pointers, fixing the open-with-keyboard case.
- The remaining bug: `--mobile-dropdown-above-composer-bottom` was computed as `fixedViewportBottom - composerRect.top + gap`, ignoring the keyboard. Only the max-height accounted for `visualViewport.offsetTop`.
- With the keyboard open, the composer (and the dropdown's bottom anchor) sits behind the keyboard. Visibility then depended on content height: a large model list overflowed upward into the visible area, a small one did not.
- Fix: `aboveComposerBottom = max(composer-based offset, keyboardInset + gap)` where `keyboardInset = fixedViewportBottom - (visualViewport.offsetTop + visualViewport.height)`. When clamped, the dropdown may overlap the composer, which is acceptable since the keyboard covers the composer in that state.

</details>

---

Generated by Coder Agents on behalf of @DanielleMaywood.
