### PR TITLE
feat(site): surface reasoning effort configuration on the models page

### DIFF
--- a/site/src/pages/AISettingsPage/ModelsPage/components/ModelForm.stories.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ModelForm.stories.tsx
@@ -218,6 +218,79 @@ export const EditUpdateDisabledUntilDirty: Story = {
 	},
 };
 
+export const ReasoningEffortVisibleWithoutExpanding: Story = {
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+
+		const defaultSelect = canvas.getByRole("combobox", {
+			name: /default reasoning effort/i,
+		});
+		const maxSelect = canvas.getByRole("combobox", {
+			name: /max reasoning effort/i,
+		});
+		await expect(defaultSelect).toBeVisible();
+		await expect(maxSelect).toBeVisible();
+		await expect(defaultSelect).toHaveTextContent("Not set");
+		await expect(maxSelect).toHaveTextContent("Not set");
+
+		await userEvent.type(canvas.getByLabelText(/model identifier/i), "gpt-5");
+		await userEvent.type(canvas.getByLabelText(/context limit/i), "200000");
+
+		await userEvent.click(defaultSelect);
+		for (const option of [
+			"None",
+			"Minimal",
+			"Low",
+			"Medium",
+			"High",
+			"Xhigh",
+			"Max",
+		]) {
+			await expect(
+				await screen.findByRole("option", { name: option }),
+			).toBeInTheDocument();
+		}
+		await userEvent.click(
+			await screen.findByRole("option", { name: "Medium" }),
+		);
+
+		await userEvent.click(maxSelect);
+		await userEvent.click(await screen.findByRole("option", { name: "Max" }));
+
+		await userEvent.click(canvas.getByRole("button", { name: /add model/i }));
+		await expect(args.onCreateModel).toHaveBeenCalledWith(
+			expect.objectContaining({
+				model_config: expect.objectContaining({
+					reasoning_effort: { default: "medium", max: "max" },
+				}),
+			}),
+		);
+	},
+};
+
+export const ReasoningEffortValidationError: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const defaultSelect = canvas.getByRole("combobox", {
+			name: /default reasoning effort/i,
+		});
+		const maxSelect = canvas.getByRole("combobox", {
+			name: /max reasoning effort/i,
+		});
+
+		await userEvent.click(defaultSelect);
+		await userEvent.click(await screen.findByRole("option", { name: "High" }));
+		await userEvent.click(maxSelect);
+		await userEvent.click(await screen.findByRole("option", { name: "Low" }));
+
+		await expect(
+			canvas.getByText(
+				"Default reasoning effort must not exceed the max reasoning effort.",
+			),
+		).toBeVisible();
+	},
+};
+
 export const CostTrackingExpanded: Story = {
 	args: {
 		editingModel: mockGPT5,

--- a/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormFields.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormFields.tsx
@@ -29,6 +29,7 @@ import {
 	GeneralModelConfigFields,
 	ModelConfigFields,
 	PricingModelConfigFields,
+	ReasoningEffortConfigFields,
 } from "#/pages/AgentsPage/components/ChatModelAdminPanel/ModelConfigFields";
 import { ModelIdentifierField } from "#/pages/AgentsPage/components/ChatModelAdminPanel/ModelIdentifierField";
 import type {
@@ -239,6 +240,12 @@ export const ModelFormFields: FC<{
 							</InputGroupAddon>
 						</InputGroup>
 					</div>
+					<ReasoningEffortConfigFields
+						provider={selectedProviderState.provider}
+						form={form}
+						fieldErrors={modelConfigFormBuildResult.fieldErrors}
+						disabled={isSaving}
+					/>
 				</div>
 
 				<div className="overflow-hidden rounded-lg border border-solid border-border">

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelConfigFields.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelConfigFields.tsx
@@ -50,6 +50,10 @@ const booleanFieldOptions = [
 /** Sentinel value for Select components to represent "no selection". */
 const unsetSelectValue = "__unset__";
 
+const isReasoningEffortField = (jsonName: string): boolean =>
+	jsonName === "reasoning_effort.default" ||
+	jsonName === "reasoning_effort.max";
+
 // ── Helpers ────────────────────────────────────────────────────
 
 /** Short display labels for pricing fields to avoid overly verbose names. */
@@ -79,10 +83,10 @@ const fieldSuffix: Record<string, string> = {
  * where the valid range is more useful than an empty box.
  */
 const placeholderOverrides: Record<string, string> = {
-	temperature: "0.0–2.0",
-	top_p: "0.0–1.0",
-	presence_penalty: "-2.0–2.0",
-	frequency_penalty: "-2.0–2.0",
+	temperature: "0.0 to 2.0",
+	top_p: "0.0 to 1.0",
+	presence_penalty: "-2.0 to 2.0",
+	frequency_penalty: "-2.0 to 2.0",
 };
 
 /**
@@ -240,6 +244,7 @@ const SelectField: FC<
 		label: string;
 		description?: string;
 		options: readonly string[];
+		placeholderLabel?: string;
 	}
 > = ({
 	form,
@@ -250,6 +255,7 @@ const SelectField: FC<
 	label,
 	description,
 	options,
+	placeholderLabel = "Default",
 }) => {
 	const errorId = `${fieldKey}-error`;
 	const fieldError = fieldErrors[errorKey ?? fieldKey];
@@ -273,10 +279,10 @@ const SelectField: FC<
 					aria-invalid={Boolean(fieldError)}
 					aria-describedby={fieldError ? errorId : undefined}
 				>
-					<SelectValue placeholder="Default" />
+					<SelectValue placeholder={placeholderLabel} />
 				</SelectTrigger>
 				<SelectContent>
-					<SelectItem value={unsetSelectValue}>Default</SelectItem>
+					<SelectItem value={unsetSelectValue}>{placeholderLabel}</SelectItem>
 					{options.map((option) => (
 						<SelectItem key={option} value={option}>
 							{capitalize(option)}
@@ -655,13 +661,44 @@ export const PricingModelConfigFields: FC<ModelConfigFieldsProps> = ({
 	);
 };
 
-/**
- * General model config fields (max output tokens, temperature,
- * top P, etc.) intended to be shown under an "Advanced" section.
- *
- * Fields are driven by the auto-generated schema in
- * `api/chatModelOptions`.
- */
+/** Reasoning effort selects, outside Advanced. */
+export const ReasoningEffortConfigFields: FC<ModelConfigFieldsProps> = ({
+	form,
+	fieldErrors,
+	disabled,
+}) => {
+	const ctx: FieldRenderContext = { form, fieldErrors, disabled };
+	const fields = getVisibleGeneralFields().filter(({ json_name }) =>
+		isReasoningEffortField(json_name),
+	);
+
+	return (
+		<>
+			{fields.map((field) => {
+				const camelName = field.json_name
+					.split(".")
+					.map(snakeToCamel)
+					.join(".");
+				const fieldKey = `config.${camelName}`;
+
+				return (
+					<SelectField
+						key={fieldKey}
+						{...ctx}
+						fieldKey={fieldKey}
+						errorKey={camelName}
+						label={snakeToPrettyLabel(field)}
+						description={field.description}
+						options={field.enum ?? []}
+						placeholderLabel="Not set"
+					/>
+				);
+			})}
+		</>
+	);
+};
+
+/** See ReasoningEffortConfigFields for reasoning effort fields. */
 export const GeneralModelConfigFields: FC<ModelConfigFieldsProps> = ({
 	form,
 	fieldErrors,
@@ -669,7 +706,8 @@ export const GeneralModelConfigFields: FC<ModelConfigFieldsProps> = ({
 }) => {
 	const ctx: FieldRenderContext = { form, fieldErrors, disabled };
 	const fields = getVisibleGeneralFields().filter(
-		({ json_name }) => !pricingFieldNames.has(json_name),
+		({ json_name }) =>
+			!pricingFieldNames.has(json_name) && !isReasoningEffortField(json_name),
 	);
 
 	return (


### PR DESCRIPTION
Adds "Default reasoning effort" and "Max reasoning effort" selects to the model form on the deployment Models page, rendered in the always-visible top section (not under the collapsed Advanced section).

The selects are schema-driven from the generated general model options and use the global effort scale through provider-independent model config. They are validated as `default <= max`. Includes a Storybook play test asserting the fields are visible without expanding any section and submit as `model_config.reasoning_effort`.

Part of the reasoning effort stack (base: #26974).

🤖 Generated by Coder Agents on behalf of @DanielleMaywood
