### PR TITLE
feat(coderd/x/chatd): improve title generation repeatability and quality

### DIFF
--- a/coderd/x/chatd/quickgen.go
+++ b/coderd/x/chatd/quickgen.go
@@ -21,6 +21,7 @@ import (
 
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatdebug"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprovider"
@@ -34,7 +35,24 @@ const titleGenerationPrompt = "Write a short title for the user's message. " +
 	"Do not answer the user or describe the title-writing task. " +
 	"Preserve specific identifiers such as PR numbers, repo names, file paths, function names, and error messages. " +
 	"If the message is short or vague, stay close to the user's wording instead of inventing context. " +
-	"Sentence case. No quotes, emoji, markdown, or trailing punctuation."
+	"Write the title in the same language as the user's message. " +
+	"Sentence case. No quotes, emoji, markdown, or trailing punctuation.\n\n" +
+	"Examples:\n" +
+	"Message: how do I set up SSO with Okta?\n" +
+	"Title: Set up SSO with Okta\n\n" +
+	"Message: getting `pq: duplicate key value violates unique constraint` when running migrations in coderd\n" +
+	"Title: Fix duplicate key error in coderd migrations\n\n" +
+	"Message: review PR #123 in acme/webapp and flag risky changes\n" +
+	"Title: Review risky changes in PR #123\n\n" +
+	"Message: help\n" +
+	"Title: Help request"
+
+// quickgenTemperature pins title and status-label generation to
+// temperature 0 so repeated runs over the same input produce stable
+// output. Fantasy providers drop the setting with a call warning for
+// models that reject it (OpenAI reasoning models, Anthropic thinking
+// models).
+const quickgenTemperature = 0.0
 
 const (
 	// maxConversationContextRunes caps the conversation sample in manual
@@ -504,6 +522,7 @@ func generateStructuredTitleWithUsage(
 			SchemaName:        "propose_title",
 			SchemaDescription: "Propose a short chat title.",
 			MaxOutputTokens:   &maxOutputTokens,
+			Temperature:       ptr.Ref(quickgenTemperature),
 		})
 		return genErr
 	}, nil)
@@ -774,6 +793,7 @@ func renderManualTitlePrompt(
 	write("- Do not answer the user or describe the title-writing task.\n")
 	write("- Preserve specific identifiers (PR numbers, repo names, file paths, function names, error messages).\n")
 	write("- If the conversation is short or vague, stay close to the user's wording.\n")
+	write("- Write the title in the same language as the user's messages.\n")
 	write("- Sentence case. No quotes, emoji, markdown, or trailing punctuation.\n")
 	return prompt.String()
 }
@@ -936,6 +956,7 @@ func generateStructuredTurnStatusLabel(
 			SchemaName:        "propose_turn_status_label",
 			SchemaDescription: "Propose a compact chat status label.",
 			MaxOutputTokens:   &maxOutputTokens,
+			Temperature:       ptr.Ref(quickgenTemperature),
 		})
 		return genErr
 	}, nil)

--- a/coderd/x/chatd/quickgen.go
+++ b/coderd/x/chatd/quickgen.go
@@ -47,11 +47,10 @@ const titleGenerationPrompt = "Write a short title for the user's message. " +
 	"Message: help\n" +
 	"Title: Help request"
 
-// quickgenTemperature pins title and status-label generation to
-// temperature 0 so repeated runs over the same input produce stable
-// output. Fantasy providers drop the setting with a call warning for
-// models that reject it (OpenAI reasoning models, Anthropic thinking
-// models).
+// quickgenTemperature keeps title and status-label output stable
+// across repeated runs over the same input. Fantasy providers drop
+// this with a call warning for models that reject it (OpenAI
+// reasoning models, Anthropic thinking models).
 const quickgenTemperature = 0.0
 
 const (

--- a/coderd/x/chatd/quickgen.go
+++ b/coderd/x/chatd/quickgen.go
@@ -41,9 +41,9 @@ const titleGenerationPrompt = "Write a short title for the user's message. " +
 	"Message: how do I set up SSO with Okta?\n" +
 	"Title: Set up SSO with Okta\n\n" +
 	"Message: getting `pq: duplicate key value violates unique constraint` when running migrations in coderd\n" +
-	"Title: Fix duplicate key error in coderd migrations\n\n" +
+	"Title: Fix pq duplicate key violation in coderd migrations\n\n" +
 	"Message: review PR #123 in acme/webapp and flag risky changes\n" +
-	"Title: Review risky changes in PR #123\n\n" +
+	"Title: Review risky changes in acme/webapp PR #123\n\n" +
 	"Message: corrige el error de compilación en main.go\n" +
 	"Title: Corregir error de compilación en main.go\n\n" +
 	"Message: help\n" +

--- a/coderd/x/chatd/quickgen.go
+++ b/coderd/x/chatd/quickgen.go
@@ -44,6 +44,8 @@ const titleGenerationPrompt = "Write a short title for the user's message. " +
 	"Title: Fix duplicate key error in coderd migrations\n\n" +
 	"Message: review PR #123 in acme/webapp and flag risky changes\n" +
 	"Title: Review risky changes in PR #123\n\n" +
+	"Message: corrige el error de compilación en main.go\n" +
+	"Title: Corregir error de compilación en main.go\n\n" +
 	"Message: help\n" +
 	"Title: Help request"
 

--- a/coderd/x/chatd/quickgen_internal_test.go
+++ b/coderd/x/chatd/quickgen_internal_test.go
@@ -789,6 +789,8 @@ func TestGenerateStructuredTurnStatusLabel(t *testing.T) {
 
 		body := testutil.TryReceive(t.Context(), t, requests)
 		require.Equal(t, "required", body["tool_choice"])
+		require.Equal(t, quickgenTemperature, body["temperature"],
+			"status-label generation should pin temperature for repeatable output")
 	})
 
 	t.Run("rejects narrative label", func(t *testing.T) {

--- a/coderd/x/chatd/quickgen_internal_test.go
+++ b/coderd/x/chatd/quickgen_internal_test.go
@@ -342,6 +342,7 @@ func Test_renderManualTitlePrompt(t *testing.T) {
 			require.Contains(t, prompt, "- Return only the title text in 2-8 words.")
 			require.Contains(t, prompt, "Do not answer the user or describe the title-writing task")
 			require.Contains(t, prompt, "stay close to the user's wording")
+			require.Contains(t, prompt, "same language as the user's messages")
 
 			if tt.wantConversationSample {
 				require.Contains(t, prompt, "Conversation sample:")
@@ -457,6 +458,8 @@ func Test_titleGenerationPrompt_UsesSlimRules(t *testing.T) {
 	require.Contains(t, titleGenerationPrompt, "Return only the title text in 2-8 words")
 	require.Contains(t, titleGenerationPrompt, "Do not answer the user or describe the title-writing task")
 	require.Contains(t, titleGenerationPrompt, "stay close to the user's wording")
+	require.Contains(t, titleGenerationPrompt, "same language as the user's message")
+	require.Contains(t, titleGenerationPrompt, "Examples:")
 	require.NotContains(t, titleGenerationPrompt, "I am a title generator")
 }
 
@@ -674,6 +677,8 @@ func TestGenerateStructuredTitleWithUsage_OpenAICompatibleRequiredToolChoice(t *
 
 	body := testutil.TryReceive(t.Context(), t, requests)
 	require.Equal(t, "required", body["tool_choice"])
+	require.Equal(t, quickgenTemperature, body["temperature"],
+		"title generation should pin temperature for repeatable output")
 }
 
 func newOpenAICompatStructuredOutputServer(


### PR DESCRIPTION
Chat title generation produced noticeably different titles for the same input across runs, occasionally rewrote non-English messages into English, and handled vague messages poorly.

Pin temperature 0 on the title and turn-status-label `ObjectCall`s so repeated runs over the same input produce stable output (fantasy providers drop the setting with a call warning for models that reject it, such as OpenAI reasoning models). Extend the title prompt with a same-language rule and four worked examples, and add the language rule to the manual regeneration prompt. The schema stays a single `{title}` field.

Compared against decomposed-schema alternatives (`{verb, object, context}` assembled in Go, and extract-then-compose) on a 20-prompt corpus at temperature 0 across `gpt-4o-mini` and `claude-haiku-4-5`: decomposition added token cost and new failure modes (literal `<UNKNOWN>` placeholders, dropped subjects, ungrammatical assemblies) without quality gains, while few-shot plus temperature 0 fixed the observed issues.

> This PR was authored by Mux (AI agent) working on behalf of Mike.
