### PR TITLE
fix(site): flush deferred Radix focus-scope timer before jsdom teardown

### DIFF
--- a/site/test/setup/msw.ts
+++ b/site/test/setup/msw.ts
@@ -8,4 +8,21 @@ afterEach(() => {
 	server.resetHandlers();
 	vi.clearAllMocks();
 });
-afterAll(() => server.close());
+afterAll(async () => {
+	// If a test file left fake timers installed, restore real timers so the
+	// flush below cannot hang until the hook timeout.
+	if (vi.isFakeTimers()) {
+		vi.useRealTimers();
+	}
+	// Radix's FocusScope defers its unmount event dispatch and focus restore
+	// with setTimeout(0) (react#17894 workaround). The cleanup() call in
+	// afterEach schedules that timer, and for the last test in a file it
+	// would otherwise still be pending when vitest tears down the jsdom
+	// environment. It then fires with Node's CustomEvent instead of jsdom's,
+	// and jsdom rejects the dispatch with "parameter 1 is not of type
+	// 'Event'" as an unhandled error. Same-delay timers run in FIFO order,
+	// so awaiting one timer turn here deterministically drains every 0ms
+	// timer scheduled by cleanup() while the environment is still alive.
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	server.close();
+});

--- a/site/test/setup/msw.ts
+++ b/site/test/setup/msw.ts
@@ -9,20 +9,13 @@ afterEach(() => {
 	vi.clearAllMocks();
 });
 afterAll(async () => {
-	// If a test file left fake timers installed, restore real timers so the
-	// flush below cannot hang until the hook timeout.
+	// A leftover fake clock would make the timer flush below hang.
 	if (vi.isFakeTimers()) {
 		vi.useRealTimers();
 	}
-	// Radix's FocusScope defers its unmount event dispatch and focus restore
-	// with setTimeout(0) (react#17894 workaround). The cleanup() call in
-	// afterEach schedules that timer, and for the last test in a file it
-	// would otherwise still be pending when vitest tears down the jsdom
-	// environment. It then fires with Node's CustomEvent instead of jsdom's,
-	// and jsdom rejects the dispatch with "parameter 1 is not of type
-	// 'Event'" as an unhandled error. Same-delay timers run in FIFO order,
-	// so awaiting one timer turn here deterministically drains every 0ms
-	// timer scheduled by cleanup() while the environment is still alive.
+	// Radix FocusScope defers its unmount dispatch with setTimeout(0). Flush
+	// it before vitest tears down the jsdom environment, where it would throw
+	// an unhandled "parameter 1 is not of type 'Event'" TypeError.
 	await new Promise((resolve) => setTimeout(resolve, 0));
 	server.close();
 });


### PR DESCRIPTION
`UserDropdownContent.test.tsx` intermittently fails CI with an unhandled error:

```
TypeError: Failed to execute 'dispatchEvent' on 'EventTarget': parameter 1 is not of type 'Event'.
 ❯ Timeout._onTimeout @radix-ui/react-focus-scope/dist/index.mjs:92:21
```

Radix's `FocusScope` defers its unmount dispatch with `setTimeout(0)`. The shared `afterEach` `cleanup()` schedules that timer, and for the last test in a file it can still be pending when vitest tears down the per-file jsdom environment. It then fires with Node's built-in `CustomEvent` instead of jsdom's, and the dispatch throws. Any test file whose last test unmounts a focus-trapped Radix component (Dialog, Popover, DropdownMenu) can hit this.

Await one timer turn in the shared `afterAll`, before environment teardown. Same-delay timers run in FIFO order, so this deterministically drains the pending timer rather than shrinking the race window. Costs ~1ms per test file; a `vi.isFakeTimers()` guard keeps the flush from hanging if a file leaves fake timers installed.

Verified with A/B stress runs alternating main's and this branch's `msw.ts`, 20 jsdom teardowns per invocation:

| Conditions | main | this fix |
|---|---|---|
| idle machine, 60 invocations | 3/60 failed | 0/60 |
| pinned to 2 cores, 12 invocations | 12/12 failed | 0/12 |

All main failures match the CI error signature exactly; the full unit suite passes.

Closes https://github.com/coder/internal/issues/1613

---

*This PR was generated by [Coder Agents](https://coder.com) on behalf of @EhabY.*