### PR TITLE
feat(site/src): split context indicator into popover and details dialog

### DIFF
--- a/site/src/hooks/useIsMobileViewport.ts
+++ b/site/src/hooks/useIsMobileViewport.ts
@@ -2,7 +2,7 @@ import { useSyncExternalStore } from "react";
 import { isMobileViewport, mobileViewportMediaQuery } from "#/utils/mobile";
 
 const subscribeMobileViewport = (onStoreChange: () => void) => {
-	const mediaQuery = window.matchMedia(mobileViewportMediaQuery);
+	const mediaQuery = matchMedia(mobileViewportMediaQuery);
 	mediaQuery.addEventListener("change", onStoreChange);
 	return () => mediaQuery.removeEventListener("change", onStoreChange);
 };

--- a/site/src/hooks/useIsMobileViewport.ts
+++ b/site/src/hooks/useIsMobileViewport.ts
@@ -1,0 +1,12 @@
+import { useSyncExternalStore } from "react";
+import { isMobileViewport, mobileViewportMediaQuery } from "#/utils/mobile";
+
+const subscribeMobileViewport = (onStoreChange: () => void) => {
+	const mediaQuery = window.matchMedia(mobileViewportMediaQuery);
+	mediaQuery.addEventListener("change", onStoreChange);
+	return () => mediaQuery.removeEventListener("change", onStoreChange);
+};
+
+export const useIsMobileViewport = (): boolean => {
+	return useSyncExternalStore(subscribeMobileViewport, isMobileViewport);
+};

--- a/site/src/pages/AgentsPage/components/ContextDetailsDialog.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ContextDetailsDialog.stories.tsx
@@ -49,6 +49,7 @@ export const Clean: Story = {
 		// Invalid resources are surfaced as issues with their error, not
 		// silently dropped.
 		expect(dialog.getByText("Issues")).toBeInTheDocument();
+		expect(dialog.getByText(/skill: invalid/)).toBeInTheDocument();
 		expect(
 			dialog.getByText(
 				'front-matter name "coder-review" does not match directory "moo"',

--- a/site/src/pages/AgentsPage/components/ContextDetailsDialog.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ContextDetailsDialog.stories.tsx
@@ -222,7 +222,7 @@ export const Dirty: Story = {
 		expect(dialog.getByText("Context changed")).toBeInTheDocument();
 		expect(
 			dialog.getByText(
-				"The workspace context changed since this chat was pinned.",
+				"The workspace context changed, so this chat's context files may be outdated.",
 			),
 		).toBeInTheDocument();
 
@@ -230,6 +230,23 @@ export const Dirty: Story = {
 			dialog.getByRole("button", { name: "Refresh context" }),
 		);
 		expect(args.onRefreshContext).toHaveBeenCalledTimes(1);
+	},
+};
+
+// Drift with no resources at all: the dialog still opens (via the warning
+// footer) and renders the empty-resources message.
+export const DirtyNoResources: Story = {
+	args: {
+		usage: {
+			usedTokens: 12_000,
+			contextLimitTokens: 200_000,
+			context: { dirty: true, resources: [] },
+		},
+	},
+	play: async () => {
+		const dialog = await getDialog();
+		expect(dialog.getByText("No context resources.")).toBeInTheDocument();
+		expect(dialog.getByText("Context changed")).toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ContextDetailsDialog.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ContextDetailsDialog.stories.tsx
@@ -1,0 +1,309 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
+import {
+	MockChatContextClean,
+	MockChatContextDirty,
+} from "#/testHelpers/chatEntities";
+import { ContextDetailsDialog } from "./ContextDetailsDialog";
+
+const meta: Meta<typeof ContextDetailsDialog> = {
+	title: "pages/AgentsPage/ContextDetailsDialog",
+	component: ContextDetailsDialog,
+	args: {
+		open: true,
+		onOpenChange: fn(),
+		onRefreshContext: fn(),
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof ContextDetailsDialog>;
+
+const getDialog = async () => {
+	const dialog = await within(document.body).findByRole("dialog");
+	return within(dialog);
+};
+
+// Clean pin: the dialog lists every pinned resource grouped into collapsible
+// sections, with no refresh affordance.
+export const Clean: Story = {
+	args: {
+		usage: {
+			usedTokens: 12_000,
+			contextLimitTokens: 200_000,
+			compressionThreshold: 80,
+			context: MockChatContextClean,
+		},
+	},
+	play: async () => {
+		const dialog = await getDialog();
+		// The header summarizes usage and the compaction threshold.
+		expect(
+			dialog.getByText(/6% - 12K \/ 200K context used/),
+		).toBeInTheDocument();
+		expect(dialog.getByText(/Compacts at 80%/)).toBeInTheDocument();
+		// A single context root still shows its directory header.
+		expect(dialog.getByText("Context files")).toBeInTheDocument();
+		expect(dialog.getByText("/home/coder")).toBeInTheDocument();
+		expect(dialog.getByText("/home/coder/.coder/skills")).toBeInTheDocument();
+		// The list is driven by the pinned resources.
+		expect(dialog.getByText("AGENTS.md")).toBeInTheDocument();
+		expect(dialog.getByText("deploy")).toBeInTheDocument();
+		// MCP configs are listed by full path (so multiple .mcp.json files stay
+		// distinct) and servers by name with their tool count.
+		expect(dialog.getByText("MCP")).toBeInTheDocument();
+		expect(dialog.getByText("/home/coder/.mcp.json")).toBeInTheDocument();
+		expect(dialog.getByText("github")).toBeInTheDocument();
+		expect(dialog.getByText("(2 tools)")).toBeInTheDocument();
+		// MCP server tools are listed under their server.
+		expect(dialog.getByText("search_issues")).toBeInTheDocument();
+		expect(dialog.getByText("create_issue")).toBeInTheDocument();
+		// Each populated category shows its total context size.
+		expect(dialog.getByText("(0.2 KiB)")).toBeInTheDocument(); // context files
+		expect(dialog.getByText("(0.1 KiB)")).toBeInTheDocument(); // skills
+		expect(dialog.getByText("(0.7 KiB)")).toBeInTheDocument(); // MCP
+		// Invalid resources are surfaced as issues with their error, not
+		// silently dropped.
+		expect(dialog.getByText("Issues")).toBeInTheDocument();
+		expect(
+			dialog.getByText(
+				'front-matter name "coder-review" does not match directory "moo"',
+			),
+		).toBeInTheDocument();
+		// A clean pin offers no refresh affordance.
+		expect(
+			dialog.queryByRole("button", { name: "Refresh context" }),
+		).toBeNull();
+	},
+};
+
+// Skill and tool descriptions surface as tooltips to the right of their rows.
+export const DescriptionTooltips: Story = {
+	args: {
+		usage: {
+			usedTokens: 12_000,
+			contextLimitTokens: 200_000,
+			context: MockChatContextClean,
+		},
+	},
+	play: async ({ step }) => {
+		const dialog = await getDialog();
+		const body = within(document.body);
+
+		await step("skill description tooltip", async () => {
+			await userEvent.hover(dialog.getByText("deploy"));
+			// Radix mirrors tooltip content into a visually hidden copy, so
+			// assert on presence rather than a unique visible node.
+			await waitFor(() => {
+				expect(
+					body.getAllByText("Deploy the app to staging.").length,
+				).toBeGreaterThan(0);
+			});
+		});
+
+		await step("tool description tooltip", async () => {
+			await userEvent.hover(dialog.getByText("create_issue"));
+			await waitFor(() => {
+				expect(body.getAllByText("Open a new issue.").length).toBeGreaterThan(
+					0,
+				);
+			});
+		});
+	},
+};
+
+// Multiple context roots: files and skills are pulled from several
+// directories, so each list groups by its parent directory. Without grouping
+// the two AGENTS.md files would render as identical, ambiguous rows.
+export const MultipleContextRoots: Story = {
+	args: {
+		usage: {
+			usedTokens: 48_000,
+			contextLimitTokens: 200_000,
+			context: {
+				dirty: false,
+				resources: [
+					{
+						source: "/home/coder/AGENTS.md",
+						kind: "instruction_file",
+						size_bytes: 248,
+						status: "ok",
+					},
+					{
+						source: "/home/coder/site/AGENTS.md",
+						kind: "instruction_file",
+						size_bytes: 512,
+						status: "ok",
+					},
+					{
+						source: "/home/coder/.coder/skills/deploy",
+						kind: "skill",
+						size_bytes: 96,
+						status: "ok",
+						skill_name: "deploy",
+						skill_description: "Deploy the app to staging.",
+					},
+					{
+						source: "/home/coder/.coder/skills/migrate",
+						kind: "skill",
+						size_bytes: 120,
+						status: "ok",
+						skill_name: "migrate",
+						skill_description: "Run database migrations.",
+					},
+					{
+						source: "/home/coder/.agents/skills/review",
+						kind: "skill",
+						size_bytes: 140,
+						status: "ok",
+						skill_name: "review",
+						skill_description: "Review a pull request.",
+					},
+				],
+			},
+		},
+	},
+	play: async () => {
+		const dialog = await getDialog();
+		// Both directories that contribute instruction files are listed, so the
+		// two AGENTS.md files are no longer ambiguous.
+		expect(dialog.getByText("/home/coder")).toBeInTheDocument();
+		expect(dialog.getByText("/home/coder/site")).toBeInTheDocument();
+		expect(dialog.getAllByText("AGENTS.md")).toHaveLength(2);
+		// Skills are grouped under each skill root.
+		expect(dialog.getByText("/home/coder/.coder/skills")).toBeInTheDocument();
+		expect(dialog.getByText("/home/coder/.agents/skills")).toBeInTheDocument();
+		expect(dialog.getByText("deploy")).toBeInTheDocument();
+		expect(dialog.getByText("migrate")).toBeInTheDocument();
+		expect(dialog.getByText("review")).toBeInTheDocument();
+	},
+};
+
+// Multiple .mcp.json files: each config is listed by its full path so the two
+// otherwise-identical .mcp.json files stay disambiguated.
+export const MultipleMcpConfigs: Story = {
+	args: {
+		usage: {
+			usedTokens: 20_000,
+			contextLimitTokens: 200_000,
+			context: {
+				dirty: false,
+				resources: [
+					{
+						source: "/home/coder/.mcp.json",
+						kind: "mcp_config",
+						size_bytes: 184,
+						status: "ok",
+					},
+					{
+						source: "/home/coder/project/.mcp.json",
+						kind: "mcp_config",
+						size_bytes: 256,
+						status: "ok",
+					},
+				],
+			},
+		},
+	},
+	play: async () => {
+		const dialog = await getDialog();
+		expect(dialog.getByText("/home/coder/.mcp.json")).toBeInTheDocument();
+		// The two configs are distinguishable by their full path.
+		expect(
+			dialog.getByText("/home/coder/project/.mcp.json"),
+		).toBeInTheDocument();
+	},
+};
+
+// Sections, directory groups, and MCP servers collapse on demand and
+// re-expand, taming long lists.
+export const CollapseAndExpand: Story = {
+	args: {
+		usage: {
+			usedTokens: 12_000,
+			contextLimitTokens: 200_000,
+			context: MockChatContextClean,
+		},
+	},
+	play: async ({ step }) => {
+		const dialog = await getDialog();
+
+		await step("collapse and expand a section", async () => {
+			const section = dialog.getByRole("button", { name: /Context files/ });
+			await userEvent.click(section);
+			await waitFor(() => expect(dialog.queryByText("AGENTS.md")).toBeNull());
+			await userEvent.click(section);
+			await waitFor(() =>
+				expect(dialog.getByText("AGENTS.md")).toBeInTheDocument(),
+			);
+		});
+
+		await step("collapse a directory group", async () => {
+			await userEvent.click(
+				dialog.getByRole("button", { name: "/home/coder" }),
+			);
+			await waitFor(() => expect(dialog.queryByText("AGENTS.md")).toBeNull());
+			// The section header stays visible.
+			expect(dialog.getByText("Context files")).toBeInTheDocument();
+		});
+
+		await step("collapse an MCP server", async () => {
+			await userEvent.click(dialog.getByRole("button", { name: /github/ }));
+			await waitFor(() =>
+				expect(dialog.queryByText("search_issues")).toBeNull(),
+			);
+			// The config leaf under the same section stays visible.
+			expect(dialog.getByText("/home/coder/.mcp.json")).toBeInTheDocument();
+		});
+	},
+};
+
+// Drifted pin: the dialog mirrors the popover's warning footer and refresh
+// affordance.
+export const Dirty: Story = {
+	args: {
+		usage: {
+			usedTokens: 12_000,
+			contextLimitTokens: 200_000,
+			context: MockChatContextDirty,
+		},
+	},
+	play: async ({ args }) => {
+		const dialog = await getDialog();
+		expect(dialog.getByText("Context changed")).toBeInTheDocument();
+		expect(
+			dialog.getByText(
+				"The workspace context changed since this chat was pinned.",
+			),
+		).toBeInTheDocument();
+
+		// Refresh from the dialog invokes the handler.
+		await userEvent.click(
+			dialog.getByRole("button", { name: "Refresh context" }),
+		);
+		expect(args.onRefreshContext).toHaveBeenCalledTimes(1);
+	},
+};
+
+// Snapshot-level error: the footer surfaces the error message instead of the
+// drift warning.
+export const SnapshotError: Story = {
+	args: {
+		usage: {
+			usedTokens: 12_000,
+			contextLimitTokens: 200_000,
+			context: {
+				dirty: false,
+				error: "failed to read AGENTS.md: permission denied",
+				resources: MockChatContextClean.resources,
+			},
+		},
+	},
+	play: async () => {
+		const dialog = await getDialog();
+		expect(dialog.getByText("Context error")).toBeInTheDocument();
+		expect(
+			dialog.getByText("failed to read AGENTS.md: permission denied"),
+		).toBeInTheDocument();
+	},
+};

--- a/site/src/pages/AgentsPage/components/ContextDetailsDialog.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ContextDetailsDialog.stories.tsx
@@ -37,31 +37,15 @@ export const Clean: Story = {
 	},
 	play: async () => {
 		const dialog = await getDialog();
-		// The header summarizes usage and the compaction threshold.
 		expect(
 			dialog.getByText(/6% - 12K \/ 200K context used/),
 		).toBeInTheDocument();
 		expect(dialog.getByText(/Compacts at 80%/)).toBeInTheDocument();
-		// A single context root still shows its directory header.
 		expect(dialog.getByText("Context files")).toBeInTheDocument();
-		expect(dialog.getByText("/home/coder")).toBeInTheDocument();
-		expect(dialog.getByText("/home/coder/.coder/skills")).toBeInTheDocument();
-		// The list is driven by the pinned resources.
 		expect(dialog.getByText("AGENTS.md")).toBeInTheDocument();
 		expect(dialog.getByText("deploy")).toBeInTheDocument();
-		// MCP configs are listed by full path (so multiple .mcp.json files stay
-		// distinct) and servers by name with their tool count.
 		expect(dialog.getByText("MCP")).toBeInTheDocument();
-		expect(dialog.getByText("/home/coder/.mcp.json")).toBeInTheDocument();
 		expect(dialog.getByText("github")).toBeInTheDocument();
-		expect(dialog.getByText("(2 tools)")).toBeInTheDocument();
-		// MCP server tools are listed under their server.
-		expect(dialog.getByText("search_issues")).toBeInTheDocument();
-		expect(dialog.getByText("create_issue")).toBeInTheDocument();
-		// Each populated category shows its total context size.
-		expect(dialog.getByText("(0.2 KiB)")).toBeInTheDocument(); // context files
-		expect(dialog.getByText("(0.1 KiB)")).toBeInTheDocument(); // skills
-		expect(dialog.getByText("(0.7 KiB)")).toBeInTheDocument(); // MCP
 		// Invalid resources are surfaced as issues with their error, not
 		// silently dropped.
 		expect(dialog.getByText("Issues")).toBeInTheDocument();
@@ -70,7 +54,6 @@ export const Clean: Story = {
 				'front-matter name "coder-review" does not match directory "moo"',
 			),
 		).toBeInTheDocument();
-		// A clean pin offers no refresh affordance.
 		expect(
 			dialog.queryByRole("button", { name: "Refresh context" }),
 		).toBeNull();
@@ -86,28 +69,16 @@ export const DescriptionTooltips: Story = {
 			context: MockChatContextClean,
 		},
 	},
-	play: async ({ step }) => {
+	play: async () => {
 		const dialog = await getDialog();
 		const body = within(document.body);
-
-		await step("skill description tooltip", async () => {
-			await userEvent.hover(dialog.getByText("deploy"));
-			// Radix mirrors tooltip content into a visually hidden copy, so
-			// assert on presence rather than a unique visible node.
-			await waitFor(() => {
-				expect(
-					body.getAllByText("Deploy the app to staging.").length,
-				).toBeGreaterThan(0);
-			});
-		});
-
-		await step("tool description tooltip", async () => {
-			await userEvent.hover(dialog.getByText("create_issue"));
-			await waitFor(() => {
-				expect(body.getAllByText("Open a new issue.").length).toBeGreaterThan(
-					0,
-				);
-			});
+		await userEvent.hover(dialog.getByText("deploy"));
+		// Radix mirrors tooltip content into a visually hidden copy, so
+		// assert on presence rather than a unique visible node.
+		await waitFor(() => {
+			expect(
+				body.getAllByText("Deploy the app to staging.").length,
+			).toBeGreaterThan(0);
 		});
 	},
 };
@@ -208,15 +179,14 @@ export const MultipleMcpConfigs: Story = {
 	play: async () => {
 		const dialog = await getDialog();
 		expect(dialog.getByText("/home/coder/.mcp.json")).toBeInTheDocument();
-		// The two configs are distinguishable by their full path.
 		expect(
 			dialog.getByText("/home/coder/project/.mcp.json"),
 		).toBeInTheDocument();
 	},
 };
 
-// Sections, directory groups, and MCP servers collapse on demand and
-// re-expand, taming long lists.
+// Sections, directory groups, and MCP servers all render through the same
+// collapsible branch, so one section collapse/expand covers that path.
 export const CollapseAndExpand: Story = {
 	args: {
 		usage: {
@@ -225,36 +195,15 @@ export const CollapseAndExpand: Story = {
 			context: MockChatContextClean,
 		},
 	},
-	play: async ({ step }) => {
+	play: async () => {
 		const dialog = await getDialog();
-
-		await step("collapse and expand a section", async () => {
-			const section = dialog.getByRole("button", { name: /Context files/ });
-			await userEvent.click(section);
-			await waitFor(() => expect(dialog.queryByText("AGENTS.md")).toBeNull());
-			await userEvent.click(section);
-			await waitFor(() =>
-				expect(dialog.getByText("AGENTS.md")).toBeInTheDocument(),
-			);
-		});
-
-		await step("collapse a directory group", async () => {
-			await userEvent.click(
-				dialog.getByRole("button", { name: "/home/coder" }),
-			);
-			await waitFor(() => expect(dialog.queryByText("AGENTS.md")).toBeNull());
-			// The section header stays visible.
-			expect(dialog.getByText("Context files")).toBeInTheDocument();
-		});
-
-		await step("collapse an MCP server", async () => {
-			await userEvent.click(dialog.getByRole("button", { name: /github/ }));
-			await waitFor(() =>
-				expect(dialog.queryByText("search_issues")).toBeNull(),
-			);
-			// The config leaf under the same section stays visible.
-			expect(dialog.getByText("/home/coder/.mcp.json")).toBeInTheDocument();
-		});
+		const section = dialog.getByRole("button", { name: /Context files/ });
+		await userEvent.click(section);
+		await waitFor(() => expect(dialog.queryByText("AGENTS.md")).toBeNull());
+		await userEvent.click(section);
+		await waitFor(() =>
+			expect(dialog.getByText("AGENTS.md")).toBeInTheDocument(),
+		);
 	},
 };
 
@@ -277,7 +226,6 @@ export const Dirty: Story = {
 			),
 		).toBeInTheDocument();
 
-		// Refresh from the dialog invokes the handler.
 		await userEvent.click(
 			dialog.getByRole("button", { name: "Refresh context" }),
 		);

--- a/site/src/pages/AgentsPage/components/ContextDetailsDialog.tsx
+++ b/site/src/pages/AgentsPage/components/ContextDetailsDialog.tsx
@@ -1,0 +1,393 @@
+import {
+	ChevronDownIcon,
+	FileIcon,
+	FolderIcon,
+	PlugIcon,
+	TriangleAlertIcon,
+	WrenchIcon,
+	ZapIcon,
+} from "lucide-react";
+import type { FC, ReactNode } from "react";
+import { Button } from "#/components/Button/Button";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "#/components/Collapsible/Collapsible";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "#/components/Dialog/Dialog";
+import { Spinner } from "#/components/Spinner/Spinner";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
+import { cn } from "#/utils/cn";
+import { formatKiB } from "#/utils/fileSize";
+import { getPathBasename } from "../utils/path";
+import {
+	type AgentContextUsage,
+	countLabel,
+	formatContextUsageLine,
+	getCompactionThresholdPercent,
+	normalizeContextResources,
+	RESOURCE_KIND_LABELS,
+} from "./contextResources";
+
+// Warning (drifted pin) or error (failed snapshot) notice with the refresh
+// affordance. Shown in the compact popover footer and mirrored in the details
+// dialog footer.
+export const ContextSyncStatus: FC<{
+	contextError: string;
+	onRefreshContext?: () => void;
+	isRefreshingContext?: boolean;
+}> = ({ contextError, onRefreshContext, isRefreshingContext }) => {
+	const hasContextError = contextError !== "";
+	return (
+		<div className="flex flex-col gap-1.5">
+			{hasContextError ? (
+				<span className="flex items-center gap-1.5 font-medium text-content-destructive">
+					<TriangleAlertIcon className="size-3 shrink-0" />
+					Context error
+				</span>
+			) : (
+				<span className="flex items-center gap-1.5 font-medium text-content-warning">
+					<TriangleAlertIcon className="size-3 shrink-0" />
+					Context changed
+				</span>
+			)}
+			{hasContextError ? (
+				<span className="text-content-secondary">{contextError}</span>
+			) : (
+				<span className="text-content-secondary">
+					The workspace context changed since this chat was pinned.
+				</span>
+			)}
+			{onRefreshContext && (
+				<div className="flex flex-wrap gap-2">
+					<Button
+						size="sm"
+						disabled={isRefreshingContext}
+						onClick={() => onRefreshContext()}
+					>
+						<Spinner loading={isRefreshingContext} />
+						Refresh context
+					</Button>
+				</div>
+			)}
+		</div>
+	);
+};
+
+// Dimmed "(N.N KiB)" size suffix for a section header, omitted when the
+// section has no measurable size.
+const SectionSize: FC<{ bytes: number }> = ({ bytes }) =>
+	bytes > 0 ? (
+		<span className="ml-1 font-normal text-content-secondary">
+			{`(${formatKiB(bytes)})`}
+		</span>
+	) : null;
+
+// Collapsible branch of the details tree: a disclosure row with a rotating
+// chevron whose children render indented one level below.
+const TreeBranch: FC<{
+	label: ReactNode;
+	icon?: ReactNode;
+	title?: string;
+	// Extra classes for the disclosure row, e.g. section emphasis or tone.
+	className?: string;
+	children: ReactNode;
+}> = ({ label, icon, title, className, children }) => (
+	<Collapsible defaultOpen>
+		<CollapsibleTrigger asChild>
+			<button
+				type="button"
+				title={title}
+				className={cn(
+					"group flex w-full min-w-0 cursor-pointer items-center gap-1.5 rounded border-0 bg-transparent px-0.5 py-px text-left text-xs text-content-primary transition-colors hover:bg-surface-tertiary",
+					className,
+				)}
+			>
+				<ChevronDownIcon className="size-3 shrink-0 transition-transform group-data-[state=closed]:-rotate-90" />
+				{icon}
+				<span className="min-w-0 flex-1 truncate">{label}</span>
+			</button>
+		</CollapsibleTrigger>
+		<CollapsibleContent className="flex flex-col gap-0.5 pl-4 pt-0.5">
+			{children}
+		</CollapsibleContent>
+	</Collapsible>
+);
+
+// Leaf row of the details tree. When a description is present the row gains
+// a tooltip to its right, matching the compact popover's previous behavior.
+const TreeLeaf: FC<{
+	icon: ReactNode;
+	label: string;
+	title?: string;
+	description?: string;
+}> = ({ icon, label, title, description }) => {
+	const row = (
+		<div
+			title={title}
+			className="flex items-center gap-1.5 rounded px-0.5 py-px text-xs text-content-secondary transition-colors hover:bg-surface-tertiary"
+		>
+			{icon}
+			<span className="truncate">{label}</span>
+		</div>
+	);
+	if (!description) {
+		return row;
+	}
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<div className="cursor-default">{row}</div>
+			</TooltipTrigger>
+			<TooltipContent side="right" sideOffset={4} className="max-w-48 text-xs">
+				{description}
+			</TooltipContent>
+		</Tooltip>
+	);
+};
+
+// Full listing of the chat's pinned context resources, opened from the
+// compact context usage popover. Sections, directory groups, and MCP servers
+// are collapsible and default to expanded.
+export const ContextDetailsDialog: FC<{
+	usage: AgentContextUsage;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onRefreshContext?: () => void;
+	isRefreshingContext?: boolean;
+}> = ({ usage, open, onOpenChange, onRefreshContext, isRefreshingContext }) => {
+	const context = usage.context;
+	const isDirty = context?.dirty ?? false;
+	const contextError = context?.error ?? "";
+	const {
+		fileItems,
+		fileGroups,
+		fileBytes,
+		skillItems,
+		skillGroups,
+		skillBytes,
+		mcpConfigItems,
+		mcpServerItems,
+		mcpBytes,
+		issueItems,
+	} = normalizeContextResources(context?.resources);
+	const compactionThreshold = getCompactionThresholdPercent(usage);
+	const hasList =
+		fileItems.length > 0 ||
+		skillItems.length > 0 ||
+		mcpConfigItems.length > 0 ||
+		mcpServerItems.length > 0 ||
+		issueItems.length > 0;
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="gap-4 p-6">
+				<DialogHeader className="space-y-1">
+					<DialogTitle>Context details</DialogTitle>
+					<DialogDescription>
+						{formatContextUsageLine(usage)}
+						{compactionThreshold !== null &&
+							` · Compacts at ${compactionThreshold}%`}
+					</DialogDescription>
+				</DialogHeader>
+				<div className="max-h-[60vh] overflow-y-auto">
+					{hasList ? (
+						<TooltipProvider delayDuration={300}>
+							<div className="flex flex-col gap-1">
+								{fileItems.length > 0 && (
+									<TreeBranch
+										className="font-medium"
+										label={
+											<>
+												Context files
+												<SectionSize bytes={fileBytes} />
+											</>
+										}
+									>
+										{fileGroups.map((group) =>
+											group.dir === "" ? (
+												group.items.map((file) => (
+													<TreeLeaf
+														key={file.path}
+														icon={<FileIcon className="size-3 shrink-0" />}
+														label={getPathBasename(file.path)}
+														title={file.path}
+													/>
+												))
+											) : (
+												<TreeBranch
+													key={group.dir}
+													className="text-content-secondary"
+													icon={<FolderIcon className="size-3 shrink-0" />}
+													label={group.dir}
+													title={group.dir}
+												>
+													{group.items.map((file) => (
+														<TreeLeaf
+															key={file.path}
+															icon={<FileIcon className="size-3 shrink-0" />}
+															label={getPathBasename(file.path)}
+															title={file.path}
+														/>
+													))}
+												</TreeBranch>
+											),
+										)}
+									</TreeBranch>
+								)}
+								{skillItems.length > 0 && (
+									<TreeBranch
+										className="font-medium"
+										label={
+											<>
+												Skills
+												<SectionSize bytes={skillBytes} />
+											</>
+										}
+									>
+										{skillGroups.map((group) =>
+											group.dir === "" ? (
+												group.items.map((skill) => (
+													<TreeLeaf
+														key={skill.source}
+														icon={<ZapIcon className="size-3 shrink-0" />}
+														label={skill.name}
+														title={skill.source}
+														description={skill.description}
+													/>
+												))
+											) : (
+												<TreeBranch
+													key={group.dir}
+													className="text-content-secondary"
+													icon={<FolderIcon className="size-3 shrink-0" />}
+													label={group.dir}
+													title={group.dir}
+												>
+													{group.items.map((skill) => (
+														<TreeLeaf
+															key={skill.source}
+															icon={<ZapIcon className="size-3 shrink-0" />}
+															label={skill.name}
+															title={skill.source}
+															description={skill.description}
+														/>
+													))}
+												</TreeBranch>
+											),
+										)}
+									</TreeBranch>
+								)}
+								{(mcpConfigItems.length > 0 || mcpServerItems.length > 0) && (
+									<TreeBranch
+										className="font-medium"
+										label={
+											<>
+												MCP
+												<SectionSize bytes={mcpBytes} />
+											</>
+										}
+									>
+										{mcpConfigItems.map((config) => (
+											<TreeLeaf
+												key={config.source}
+												icon={<FileIcon className="size-3 shrink-0" />}
+												label={config.source}
+												title={config.source}
+											/>
+										))}
+										{mcpServerItems.map((server) =>
+											server.tools.length === 0 ? (
+												<TreeLeaf
+													key={server.source}
+													icon={<PlugIcon className="size-3 shrink-0" />}
+													label={server.name}
+													title={server.source}
+												/>
+											) : (
+												<TreeBranch
+													key={server.source}
+													className="text-content-secondary"
+													icon={<PlugIcon className="size-3 shrink-0" />}
+													title={server.source}
+													label={
+														<>
+															{server.name}
+															<span className="ml-1 text-content-secondary">
+																({countLabel(server.tools.length, "tool")})
+															</span>
+														</>
+													}
+												>
+													{server.tools.map((tool) => (
+														<TreeLeaf
+															key={tool.name}
+															icon={<WrenchIcon className="size-3 shrink-0" />}
+															label={tool.name}
+															description={tool.description}
+														/>
+													))}
+												</TreeBranch>
+											),
+										)}
+									</TreeBranch>
+								)}
+								{issueItems.length > 0 && (
+									<TreeBranch
+										className="font-medium text-content-warning"
+										icon={<TriangleAlertIcon className="size-3 shrink-0" />}
+										label="Issues"
+									>
+										{issueItems.map((issue) => (
+											<div
+												key={issue.source}
+												className="flex flex-col px-0.5 py-px text-xs"
+												title={issue.source}
+											>
+												<span className="truncate text-content-primary">
+													{issue.name}{" "}
+													<span className="text-content-secondary">
+														({RESOURCE_KIND_LABELS[issue.kind]}: {issue.status})
+													</span>
+												</span>
+												{issue.error && (
+													<span className="text-content-secondary">
+														{issue.error}
+													</span>
+												)}
+											</div>
+										))}
+									</TreeBranch>
+								)}
+							</div>
+						</TooltipProvider>
+					) : (
+						<p className="m-0 text-xs text-content-secondary">
+							No context resources pinned.
+						</p>
+					)}
+				</div>
+				{(isDirty || contextError !== "") && (
+					<div className="border-0 border-t border-solid border-border-default pt-3 text-xs">
+						<ContextSyncStatus
+							contextError={contextError}
+							onRefreshContext={onRefreshContext}
+							isRefreshingContext={isRefreshingContext}
+						/>
+					</div>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/site/src/pages/AgentsPage/components/ContextDetailsDialog.tsx
+++ b/site/src/pages/AgentsPage/components/ContextDetailsDialog.tsx
@@ -51,30 +51,26 @@ export const ContextSyncStatus: FC<{
 	const hasContextError = contextError !== "";
 	return (
 		<div className="flex flex-col gap-1.5">
-			{hasContextError ? (
-				<span className="flex items-center gap-1.5 font-medium text-content-destructive">
-					<TriangleAlertIcon className="size-3 shrink-0" />
-					Context error
-				</span>
-			) : (
-				<span className="flex items-center gap-1.5 font-medium text-content-warning">
-					<TriangleAlertIcon className="size-3 shrink-0" />
-					Context changed
-				</span>
-			)}
-			{hasContextError ? (
-				<span className="text-content-secondary">{contextError}</span>
-			) : (
-				<span className="text-content-secondary">
-					The workspace context changed since this chat was pinned.
-				</span>
-			)}
+			<span
+				className={cn(
+					"flex items-center gap-1.5 font-medium",
+					hasContextError ? "text-content-destructive" : "text-content-warning",
+				)}
+			>
+				<TriangleAlertIcon className="size-3 shrink-0" />
+				{hasContextError ? "Context error" : "Context changed"}
+			</span>
+			<span className="text-content-secondary">
+				{hasContextError
+					? contextError
+					: "The workspace context changed since this chat was pinned."}
+			</span>
 			{onRefreshContext && (
 				<div className="flex flex-wrap gap-2">
 					<Button
 						size="sm"
 						disabled={isRefreshingContext}
-						onClick={() => onRefreshContext()}
+						onClick={onRefreshContext}
 					>
 						<Spinner loading={isRefreshingContext} />
 						Refresh context
@@ -85,8 +81,6 @@ export const ContextSyncStatus: FC<{
 	);
 };
 
-// Dimmed "(N.N KiB)" size suffix for a section header, omitted when the
-// section has no measurable size.
 const SectionSize: FC<{ bytes: number }> = ({ bytes }) =>
 	bytes > 0 ? (
 		<span className="ml-1 font-normal text-content-secondary">
@@ -94,13 +88,10 @@ const SectionSize: FC<{ bytes: number }> = ({ bytes }) =>
 		</span>
 	) : null;
 
-// Collapsible branch of the details tree: a disclosure row with a rotating
-// chevron whose children render indented one level below.
 const TreeBranch: FC<{
 	label: ReactNode;
 	icon?: ReactNode;
 	title?: string;
-	// Extra classes for the disclosure row, e.g. section emphasis or tone.
 	className?: string;
 	children: ReactNode;
 }> = ({ label, icon, title, className, children }) => (
@@ -125,8 +116,6 @@ const TreeBranch: FC<{
 	</Collapsible>
 );
 
-// Leaf row of the details tree. When a description is present the row gains
-// a tooltip to its right, matching the compact popover's previous behavior.
 const TreeLeaf: FC<{
 	icon: ReactNode;
 	label: string;
@@ -181,9 +170,6 @@ const renderDirectoryGroups = <T,>(
 		),
 	);
 
-// Full listing of the chat's pinned context resources, opened from the
-// compact context usage popover. Sections, directory groups, and MCP servers
-// are collapsible and default to expanded.
 export const ContextDetailsDialog: FC<{
 	usage: AgentContextUsage;
 	open: boolean;

--- a/site/src/pages/AgentsPage/components/ContextDetailsDialog.tsx
+++ b/site/src/pages/AgentsPage/components/ContextDetailsDialog.tsx
@@ -157,6 +157,30 @@ const TreeLeaf: FC<{
 	);
 };
 
+// Render a section's directory groups: items without a parent directory
+// render as top-level leaves, while grouped items nest under a collapsible
+// directory branch so resources pulled from different roots (for example a
+// repo-root AGENTS.md and a nested one) stay distinguishable.
+const renderDirectoryGroups = <T,>(
+	groups: readonly { readonly dir: string; readonly items: readonly T[] }[],
+	renderItem: (item: T) => ReactNode,
+): ReactNode =>
+	groups.map((group) =>
+		group.dir === "" ? (
+			group.items.map((item) => renderItem(item))
+		) : (
+			<TreeBranch
+				key={group.dir}
+				className="text-content-secondary"
+				icon={<FolderIcon className="size-3 shrink-0" />}
+				label={group.dir}
+				title={group.dir}
+			>
+				{group.items.map((item) => renderItem(item))}
+			</TreeBranch>
+		),
+	);
+
 // Full listing of the chat's pinned context resources, opened from the
 // compact context usage popover. Sections, directory groups, and MCP servers
 // are collapsible and default to expanded.
@@ -171,24 +195,17 @@ export const ContextDetailsDialog: FC<{
 	const isDirty = context?.dirty ?? false;
 	const contextError = context?.error ?? "";
 	const {
-		fileItems,
 		fileGroups,
 		fileBytes,
-		skillItems,
 		skillGroups,
 		skillBytes,
 		mcpConfigItems,
 		mcpServerItems,
 		mcpBytes,
 		issueItems,
+		hasResources,
 	} = normalizeContextResources(context?.resources);
 	const compactionThreshold = getCompactionThresholdPercent(usage);
-	const hasList =
-		fileItems.length > 0 ||
-		skillItems.length > 0 ||
-		mcpConfigItems.length > 0 ||
-		mcpServerItems.length > 0 ||
-		issueItems.length > 0;
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
@@ -202,10 +219,10 @@ export const ContextDetailsDialog: FC<{
 					</DialogDescription>
 				</DialogHeader>
 				<div className="max-h-[60vh] overflow-y-auto">
-					{hasList ? (
+					{hasResources ? (
 						<TooltipProvider delayDuration={300}>
 							<div className="flex flex-col gap-1">
-								{fileItems.length > 0 && (
+								{fileGroups.length > 0 && (
 									<TreeBranch
 										className="font-medium"
 										label={
@@ -215,38 +232,17 @@ export const ContextDetailsDialog: FC<{
 											</>
 										}
 									>
-										{fileGroups.map((group) =>
-											group.dir === "" ? (
-												group.items.map((file) => (
-													<TreeLeaf
-														key={file.path}
-														icon={<FileIcon className="size-3 shrink-0" />}
-														label={getPathBasename(file.path)}
-														title={file.path}
-													/>
-												))
-											) : (
-												<TreeBranch
-													key={group.dir}
-													className="text-content-secondary"
-													icon={<FolderIcon className="size-3 shrink-0" />}
-													label={group.dir}
-													title={group.dir}
-												>
-													{group.items.map((file) => (
-														<TreeLeaf
-															key={file.path}
-															icon={<FileIcon className="size-3 shrink-0" />}
-															label={getPathBasename(file.path)}
-															title={file.path}
-														/>
-													))}
-												</TreeBranch>
-											),
-										)}
+										{renderDirectoryGroups(fileGroups, (file) => (
+											<TreeLeaf
+												key={file.path}
+												icon={<FileIcon className="size-3 shrink-0" />}
+												label={getPathBasename(file.path)}
+												title={file.path}
+											/>
+										))}
 									</TreeBranch>
 								)}
-								{skillItems.length > 0 && (
+								{skillGroups.length > 0 && (
 									<TreeBranch
 										className="font-medium"
 										label={
@@ -256,37 +252,15 @@ export const ContextDetailsDialog: FC<{
 											</>
 										}
 									>
-										{skillGroups.map((group) =>
-											group.dir === "" ? (
-												group.items.map((skill) => (
-													<TreeLeaf
-														key={skill.source}
-														icon={<ZapIcon className="size-3 shrink-0" />}
-														label={skill.name}
-														title={skill.source}
-														description={skill.description}
-													/>
-												))
-											) : (
-												<TreeBranch
-													key={group.dir}
-													className="text-content-secondary"
-													icon={<FolderIcon className="size-3 shrink-0" />}
-													label={group.dir}
-													title={group.dir}
-												>
-													{group.items.map((skill) => (
-														<TreeLeaf
-															key={skill.source}
-															icon={<ZapIcon className="size-3 shrink-0" />}
-															label={skill.name}
-															title={skill.source}
-															description={skill.description}
-														/>
-													))}
-												</TreeBranch>
-											),
-										)}
+										{renderDirectoryGroups(skillGroups, (skill) => (
+											<TreeLeaf
+												key={skill.source}
+												icon={<ZapIcon className="size-3 shrink-0" />}
+												label={skill.name}
+												title={skill.source}
+												description={skill.description}
+											/>
+										))}
 									</TreeBranch>
 								)}
 								{(mcpConfigItems.length > 0 || mcpServerItems.length > 0) && (

--- a/site/src/pages/AgentsPage/components/ContextDetailsDialog.tsx
+++ b/site/src/pages/AgentsPage/components/ContextDetailsDialog.tsx
@@ -35,9 +35,10 @@ import {
 	type AgentContextUsage,
 	countLabel,
 	formatContextUsageLine,
-	getCompactionThresholdPercent,
+	getCompressionThresholdPercent,
 	normalizeContextResources,
 	RESOURCE_KIND_LABELS,
+	RESOURCE_STATUS_LABELS,
 } from "./contextResources";
 
 // Warning (drifted pin) or error (failed snapshot) notice with the refresh
@@ -63,7 +64,7 @@ export const ContextSyncStatus: FC<{
 			<span className="text-content-secondary">
 				{hasContextError
 					? contextError
-					: "The workspace context changed since this chat was pinned."}
+					: "The workspace context changed, so this chat's context files may be outdated."}
 			</span>
 			{onRefreshContext && (
 				<div className="flex flex-wrap gap-2">
@@ -191,7 +192,7 @@ export const ContextDetailsDialog: FC<{
 		issueItems,
 		hasResources,
 	} = normalizeContextResources(context?.resources);
-	const compactionThreshold = getCompactionThresholdPercent(usage);
+	const compressionThreshold = getCompressionThresholdPercent(usage);
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
@@ -200,8 +201,8 @@ export const ContextDetailsDialog: FC<{
 					<DialogTitle>Context details</DialogTitle>
 					<DialogDescription>
 						{formatContextUsageLine(usage)}
-						{compactionThreshold !== null &&
-							` · Compacts at ${compactionThreshold}%`}
+						{compressionThreshold !== null &&
+							` · Compacts at ${compressionThreshold}%`}
 					</DialogDescription>
 				</DialogHeader>
 				<div className="max-h-[60vh] overflow-y-auto">
@@ -316,9 +317,9 @@ export const ContextDetailsDialog: FC<{
 												title={issue.source}
 											>
 												<span className="truncate text-content-primary">
-													{issue.name}{" "}
+													{`${issue.name} `}
 													<span className="text-content-secondary">
-														({RESOURCE_KIND_LABELS[issue.kind]}: {issue.status})
+														{`(${RESOURCE_KIND_LABELS[issue.kind]}: ${RESOURCE_STATUS_LABELS[issue.status]})`}
 													</span>
 												</span>
 												{issue.error && (
@@ -334,7 +335,7 @@ export const ContextDetailsDialog: FC<{
 						</TooltipProvider>
 					) : (
 						<p className="m-0 text-xs text-content-secondary">
-							No context resources pinned.
+							No context resources.
 						</p>
 					)}
 				</div>

--- a/site/src/pages/AgentsPage/components/ContextUsageIndicator.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ContextUsageIndicator.stories.tsx
@@ -39,15 +39,12 @@ export const Clean: Story = {
 		await waitFor(() =>
 			expect(body.getByText("6% - 12K / 200K context used")).toBeVisible(),
 		);
-		// The popover summarizes the pinned resources as counts.
 		expect(body.getByText("1 context file · 1 skill")).toBeVisible();
 		expect(body.getByText("1 MCP config · 1 server · 2 tools")).toBeVisible();
-		// Failed resources surface as an issue count in warning tone.
 		expect(body.getByText("1 issue")).toBeVisible();
 		expect(body.getByText("Click to open full list")).toBeVisible();
 		// The full listing is not rendered inline anymore.
 		expect(body.queryByText("AGENTS.md")).toBeNull();
-		// A clean pin offers no refresh affordance.
 		expect(body.queryByRole("button", { name: "Refresh context" })).toBeNull();
 	},
 };
@@ -126,7 +123,6 @@ export const ManyResources: Story = {
 			expect(body.getByText("2 context files · 3 skills")).toBeVisible(),
 		);
 		expect(body.getByText("2 MCP configs · 1 server · 2 tools")).toBeVisible();
-		// No issues, so no issue count line.
 		expect(body.queryByText("1 issue")).toBeNull();
 	},
 };
@@ -152,8 +148,6 @@ export const OpensDetailsDialog: Story = {
 			await userEvent.click(button);
 			const dialog = await body.findByRole("dialog");
 			expect(within(dialog).getByText("Context details")).toBeInTheDocument();
-			// Smoke check: the dialog carries the full listing.
-			expect(within(dialog).getByText("AGENTS.md")).toBeInTheDocument();
 			// The compact popover has closed.
 			await waitFor(() =>
 				expect(body.queryByText("Click to open full list")).toBeNull(),
@@ -199,7 +193,6 @@ export const Dirty: Story = {
 			expect(body.getByText("Context changed")).toBeVisible(),
 		);
 
-		// Refresh from the popover invokes the handler.
 		await userEvent.click(
 			body.getByRole("button", { name: "Refresh context" }),
 		);

--- a/site/src/pages/AgentsPage/components/ContextUsageIndicator.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ContextUsageIndicator.stories.tsx
@@ -17,8 +17,9 @@ const meta: Meta<typeof ContextUsageIndicator> = {
 export default meta;
 type Story = StoryObj<typeof ContextUsageIndicator>;
 
-// Clean pin: the ring carries no change marker and the popover lists the
-// pinned resources.
+// Clean pin: the ring carries no change marker and hovering shows the compact
+// summary with counts and the full-list affordance. The full listing itself
+// lives in the details dialog (see ContextDetailsDialog stories).
 export const Clean: Story = {
 	args: {
 		usage: {
@@ -35,42 +36,25 @@ export const Clean: Story = {
 
 		await userEvent.hover(button);
 		const body = within(document.body);
-		await waitFor(() => expect(body.getByText("Context files")).toBeVisible());
-		// A single context root still shows its directory header.
-		expect(body.getByText("/home/coder")).toBeVisible();
-		expect(body.getByText("/home/coder/.coder/skills")).toBeVisible();
-		// The list is driven by the pinned resources.
-		expect(body.getByText("AGENTS.md")).toBeVisible();
-		expect(body.getByText("deploy")).toBeVisible();
-		// MCP configs are listed by full path (so multiple .mcp.json files stay
-		// distinct) and servers by name.
-		expect(body.getByText("MCP")).toBeVisible();
-		expect(body.getByText("/home/coder/.mcp.json")).toBeVisible();
-		expect(body.getByText("github")).toBeVisible();
-		// MCP server tools are listed under their server.
-		expect(body.getByText("search_issues")).toBeVisible();
-		expect(body.getByText("create_issue")).toBeVisible();
-		// Each populated category shows its total context size.
-		expect(body.getByText("(0.2 KiB)")).toBeVisible(); // context files
-		expect(body.getByText("(0.1 KiB)")).toBeVisible(); // skills
-		expect(body.getByText("(0.7 KiB)")).toBeVisible(); // MCP
-		// Invalid resources are surfaced as issues with their error, not
-		// silently dropped.
-		expect(body.getByText("Issues")).toBeVisible();
-		expect(
-			body.getByText(
-				'front-matter name "coder-review" does not match directory "moo"',
-			),
-		).toBeVisible();
+		await waitFor(() =>
+			expect(body.getByText("6% - 12K / 200K context used")).toBeVisible(),
+		);
+		// The popover summarizes the pinned resources as counts.
+		expect(body.getByText("1 context file · 1 skill")).toBeVisible();
+		expect(body.getByText("1 MCP config · 1 server · 2 tools")).toBeVisible();
+		// Failed resources surface as an issue count in warning tone.
+		expect(body.getByText("1 issue")).toBeVisible();
+		expect(body.getByText("Click to open full list")).toBeVisible();
+		// The full listing is not rendered inline anymore.
+		expect(body.queryByText("AGENTS.md")).toBeNull();
 		// A clean pin offers no refresh affordance.
 		expect(body.queryByRole("button", { name: "Refresh context" })).toBeNull();
 	},
 };
 
-// Multiple context roots: files and skills are pulled from several
-// directories, so each list groups by its parent directory. Without grouping
-// the two AGENTS.md files would render as identical, ambiguous rows.
-export const MultipleContextRoots: Story = {
+// Plural counts: zero-count segments are omitted and the "MCP" prefix
+// attaches to the first MCP segment present.
+export const ManyResources: Story = {
 	args: {
 		usage: {
 			usedTokens: 48_000,
@@ -96,7 +80,6 @@ export const MultipleContextRoots: Story = {
 						size_bytes: 96,
 						status: "ok",
 						skill_name: "deploy",
-						skill_description: "Deploy the app to staging.",
 					},
 					{
 						source: "/home/coder/.coder/skills/migrate",
@@ -104,7 +87,6 @@ export const MultipleContextRoots: Story = {
 						size_bytes: 120,
 						status: "ok",
 						skill_name: "migrate",
-						skill_description: "Run database migrations.",
 					},
 					{
 						source: "/home/coder/.agents/skills/review",
@@ -112,40 +94,7 @@ export const MultipleContextRoots: Story = {
 						size_bytes: 140,
 						status: "ok",
 						skill_name: "review",
-						skill_description: "Review a pull request.",
 					},
-				],
-			},
-		},
-	},
-	play: async ({ canvasElement }) => {
-		const button = within(canvasElement).getByRole("button");
-		await userEvent.hover(button);
-		const body = within(document.body);
-		// Both directories that contribute instruction files are listed, so the
-		// two AGENTS.md files are no longer ambiguous.
-		await waitFor(() => expect(body.getByText("/home/coder")).toBeVisible());
-		expect(body.getByText("/home/coder/site")).toBeVisible();
-		expect(body.getAllByText("AGENTS.md")).toHaveLength(2);
-		// Skills are grouped under each skill root.
-		expect(body.getByText("/home/coder/.coder/skills")).toBeVisible();
-		expect(body.getByText("/home/coder/.agents/skills")).toBeVisible();
-		expect(body.getByText("deploy")).toBeVisible();
-		expect(body.getByText("migrate")).toBeVisible();
-		expect(body.getByText("review")).toBeVisible();
-	},
-};
-
-// Multiple .mcp.json files: each config is listed by its full path so the two
-// otherwise-identical .mcp.json files stay disambiguated.
-export const MultipleMcpConfigs: Story = {
-	args: {
-		usage: {
-			usedTokens: 20_000,
-			contextLimitTokens: 200_000,
-			context: {
-				dirty: false,
-				resources: [
 					{
 						source: "/home/coder/.mcp.json",
 						kind: "mcp_config",
@@ -158,6 +107,13 @@ export const MultipleMcpConfigs: Story = {
 						size_bytes: 256,
 						status: "ok",
 					},
+					{
+						source: "github",
+						kind: "mcp_server",
+						size_bytes: 512,
+						status: "ok",
+						tools: [{ name: "search_issues" }, { name: "create_issue" }],
+					},
 				],
 			},
 		},
@@ -167,15 +123,62 @@ export const MultipleMcpConfigs: Story = {
 		await userEvent.hover(button);
 		const body = within(document.body);
 		await waitFor(() =>
-			expect(body.getByText("/home/coder/.mcp.json")).toBeVisible(),
+			expect(body.getByText("2 context files · 3 skills")).toBeVisible(),
 		);
-		// The two configs are distinguishable by their full path.
-		expect(body.getByText("/home/coder/project/.mcp.json")).toBeVisible();
+		expect(body.getByText("2 MCP configs · 1 server · 2 tools")).toBeVisible();
+		// No issues, so no issue count line.
+		expect(body.queryByText("1 issue")).toBeNull();
 	},
 };
 
-// Drifted pin: the ring announces a change, and the popover surfaces a refresh
-// affordance to re-pin the chat to the latest snapshot.
+// The details dialog opens from the ring itself and from the popover's link
+// row, and the popover never lingers underneath it.
+export const OpensDetailsDialog: Story = {
+	args: {
+		usage: {
+			usedTokens: 12_000,
+			contextLimitTokens: 200_000,
+			context: MockChatContextClean,
+		},
+	},
+	play: async ({ canvasElement, step }) => {
+		const button = within(canvasElement).getByRole("button");
+		const body = within(document.body);
+		expect(button.getAttribute("aria-label") ?? "").toContain(
+			"Click to open context details.",
+		);
+
+		await step("clicking the ring opens the details dialog", async () => {
+			await userEvent.click(button);
+			const dialog = await body.findByRole("dialog");
+			expect(within(dialog).getByText("Context details")).toBeInTheDocument();
+			// Smoke check: the dialog carries the full listing.
+			expect(within(dialog).getByText("AGENTS.md")).toBeInTheDocument();
+			// The compact popover has closed.
+			await waitFor(() =>
+				expect(body.queryByText("Click to open full list")).toBeNull(),
+			);
+		});
+
+		await step("escape closes the dialog", async () => {
+			await userEvent.keyboard("{Escape}");
+			await waitFor(() => expect(body.queryByRole("dialog")).toBeNull());
+		});
+
+		await step("the popover link row also opens the dialog", async () => {
+			await userEvent.hover(button);
+			const link = await body.findByRole("button", {
+				name: "Click to open full list",
+			});
+			await userEvent.click(link);
+			const dialog = await body.findByRole("dialog");
+			expect(within(dialog).getByText("Context details")).toBeInTheDocument();
+		});
+	},
+};
+
+// Drifted pin: the ring announces a change, and the popover surfaces a
+// refresh affordance to re-pin the chat to the latest snapshot.
 export const Dirty: Story = {
 	args: {
 		usage: {
@@ -226,5 +229,35 @@ export const SnapshotError: Story = {
 		expect(
 			body.getByText("failed to read AGENTS.md: permission denied"),
 		).toBeVisible();
+	},
+};
+
+// No pinned context at all: the popover shows only the usage line, the link
+// row is hidden, and clicking the ring is a no-op.
+export const Empty: Story = {
+	args: {
+		usage: {
+			usedTokens: 12_000,
+			contextLimitTokens: 200_000,
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const button = within(canvasElement).getByRole("button");
+		expect(button.getAttribute("aria-label") ?? "").not.toContain(
+			"Click to open context details.",
+		);
+
+		await userEvent.hover(button);
+		const body = within(document.body);
+		await waitFor(() =>
+			expect(body.getByText("6% - 12K / 200K context used")).toBeVisible(),
+		);
+		expect(body.queryByText("Click to open full list")).toBeNull();
+
+		// Without details, clicking the ring does not open the dialog. The
+		// popover content itself carries role="dialog", so assert on the
+		// details dialog title instead of the role.
+		await userEvent.click(button);
+		expect(body.queryByText("Context details")).toBeNull();
 	},
 };

--- a/site/src/pages/AgentsPage/components/ContextUsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/ContextUsageIndicator.tsx
@@ -89,7 +89,7 @@ export const ContextUsageIndicator: FC<{
 		setOpen(nextOpen);
 	};
 
-	const percentUsed = getPercentUsed(usage ?? null);
+	const percentUsed = getPercentUsed(usage);
 	const hasPercent = percentUsed !== null;
 	const percentLabel =
 		percentUsed === null ? "--" : `${Math.round(percentUsed)}%`;
@@ -97,7 +97,7 @@ export const ContextUsageIndicator: FC<{
 		? Math.min(Math.max(percentUsed, 0), 100)
 		: 100;
 	const toneClassName = getIndicatorToneClassName(percentUsed);
-	const compactionThreshold = getCompactionThresholdPercent(usage ?? null);
+	const compactionThreshold = getCompactionThresholdPercent(usage);
 
 	const context = usage?.context;
 	const isDirty = context?.dirty ?? false;
@@ -111,6 +111,7 @@ export const ContextUsageIndicator: FC<{
 		mcpServerItems,
 		mcpToolCount,
 		issueItems,
+		hasResources,
 	} = normalizeContextResources(context?.resources);
 
 	// Compact count summaries. Zero-count segments are omitted, and the "MCP"
@@ -140,14 +141,7 @@ export const ContextUsageIndicator: FC<{
 
 	// Whether the details dialog has anything to show. When false, the link
 	// row is hidden and clicking the ring is a no-op.
-	const hasDetails =
-		fileItems.length > 0 ||
-		skillItems.length > 0 ||
-		mcpConfigItems.length > 0 ||
-		mcpServerItems.length > 0 ||
-		issueItems.length > 0 ||
-		isDirty ||
-		hasContextError;
+	const hasDetails = hasResources || isDirty || hasContextError;
 
 	const openDetails = () => {
 		if (!hasDetails) {
@@ -173,7 +167,7 @@ export const ContextUsageIndicator: FC<{
 
 	const panelContent = (
 		<div className="text-xs text-content-primary">
-			{formatContextUsageLine(usage ?? null)}
+			{formatContextUsageLine(usage)}
 			{compactionThreshold !== null && (
 				<div className="mt-1 text-content-secondary">
 					{`Compacts at ${compactionThreshold}%`}

--- a/site/src/pages/AgentsPage/components/ContextUsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/ContextUsageIndicator.tsx
@@ -51,9 +51,6 @@ export const ContextUsageIndicator: FC<{
 	isRefreshingContext?: boolean;
 }> = ({ usage, onRefreshContext, isRefreshingContext }) => {
 	const [open, setOpen] = useState(false);
-	// Whether the full-list details dialog is open. The popover and the dialog
-	// are mutually exclusive: opening the dialog closes the popover and blocks
-	// hover from re-opening it underneath the dialog.
 	const [detailsOpen, setDetailsOpen] = useState(false);
 	const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -74,19 +71,7 @@ export const ContextUsageIndicator: FC<{
 
 	const handleMouseEnter = () => {
 		cancelClose();
-		if (!detailsOpen) {
-			setOpen(true);
-		}
-	};
-
-	// Every popover-open path is gated on the dialog being closed so hover or
-	// tap events firing while the dialog opens cannot re-open the popover
-	// underneath it.
-	const handlePopoverOpenChange = (nextOpen: boolean) => {
-		if (nextOpen && detailsOpen) {
-			return;
-		}
-		setOpen(nextOpen);
+		setOpen(true);
 	};
 
 	const percentUsed = getPercentUsed(usage);
@@ -116,28 +101,20 @@ export const ContextUsageIndicator: FC<{
 
 	// Compact count summaries. Zero-count segments are omitted, and the "MCP"
 	// prefix attaches to the first MCP segment present.
-	const fileSkillSegments: string[] = [];
-	if (fileItems.length > 0) {
-		fileSkillSegments.push(countLabel(fileItems.length, "context file"));
-	}
-	if (skillItems.length > 0) {
-		fileSkillSegments.push(countLabel(skillItems.length, "skill"));
-	}
-	const mcpSegments: string[] = [];
-	if (mcpConfigItems.length > 0) {
-		mcpSegments.push(countLabel(mcpConfigItems.length, "MCP config"));
-	}
-	if (mcpServerItems.length > 0) {
-		mcpSegments.push(
+	const fileSkillSegments = [
+		fileItems.length > 0 && countLabel(fileItems.length, "context file"),
+		skillItems.length > 0 && countLabel(skillItems.length, "skill"),
+	].filter((segment): segment is string => segment !== false);
+	const mcpSegments = [
+		mcpConfigItems.length > 0 &&
+			countLabel(mcpConfigItems.length, "MCP config"),
+		mcpServerItems.length > 0 &&
 			countLabel(
 				mcpServerItems.length,
 				mcpConfigItems.length > 0 ? "server" : "MCP server",
 			),
-		);
-	}
-	if (mcpToolCount > 0) {
-		mcpSegments.push(countLabel(mcpToolCount, "tool"));
-	}
+		mcpToolCount > 0 && countLabel(mcpToolCount, "tool"),
+	].filter((segment): segment is string => segment !== false);
 
 	// Whether the details dialog has anything to show. When false, the link
 	// row is hidden and clicking the ring is a no-op.
@@ -254,47 +231,32 @@ export const ContextUsageIndicator: FC<{
 		/>
 	);
 
-	// On mobile, a tap toggles the popover and the link row opens the details
-	// dialog. On desktop, hover opens the popover like a dropdown menu and
-	// clicking the ring (or the link row) opens the details dialog.
-	if (mobile) {
-		return (
-			<>
-				<Popover open={open} onOpenChange={handlePopoverOpenChange}>
-					<PopoverTrigger asChild>{triggerButton}</PopoverTrigger>
-					<PopoverContent
-						side="top"
-						className="mobile-full-width-dropdown mobile-full-width-dropdown-bottom w-auto max-w-72 px-3 py-2"
-						// Keep focus where it is when the popover closes so it cannot
-						// steal focus from the details dialog as it opens.
-						onCloseAutoFocus={(e) => e.preventDefault()}
-					>
-						{panelContent}
-					</PopoverContent>
-				</Popover>
-				{detailsDialog}
-			</>
-		);
-	}
-
 	return (
 		<>
-			<Popover open={open} onOpenChange={handlePopoverOpenChange}>
-				{/* An anchor rather than a trigger: hover alone controls the
-				    popover, leaving click free to open the details dialog. */}
-				<PopoverAnchor asChild>
-					<div onMouseEnter={handleMouseEnter} onMouseLeave={scheduleClose}>
-						{triggerButton}
-					</div>
-				</PopoverAnchor>
+			<Popover open={open} onOpenChange={setOpen}>
+				{mobile ? (
+					<PopoverTrigger asChild>{triggerButton}</PopoverTrigger>
+				) : (
+					// An anchor rather than a trigger: hover alone controls the
+					// popover, leaving click free to open the details dialog.
+					<PopoverAnchor asChild>
+						<div onMouseEnter={handleMouseEnter} onMouseLeave={scheduleClose}>
+							{triggerButton}
+						</div>
+					</PopoverAnchor>
+				)}
 				<PopoverContent
 					side="top"
-					className="w-auto max-w-72 px-3 py-2"
-					onMouseEnter={cancelClose}
-					onMouseLeave={scheduleClose}
+					className={cn(
+						"w-auto max-w-72 px-3 py-2",
+						mobile &&
+							"mobile-full-width-dropdown mobile-full-width-dropdown-bottom",
+					)}
+					onMouseEnter={mobile ? undefined : cancelClose}
+					onMouseLeave={mobile ? undefined : scheduleClose}
 					// Prevent the popover from stealing focus, which would
 					// interfere with the chat input.
-					onOpenAutoFocus={(e) => e.preventDefault()}
+					onOpenAutoFocus={mobile ? undefined : (e) => e.preventDefault()}
 					// Keep focus where it is when the popover closes so it cannot
 					// steal focus from the details dialog as it opens.
 					onCloseAutoFocus={(e) => e.preventDefault()}

--- a/site/src/pages/AgentsPage/components/ContextUsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/ContextUsageIndicator.tsx
@@ -1,132 +1,29 @@
-import {
-	FileIcon,
-	FolderIcon,
-	PlugIcon,
-	TriangleAlertIcon,
-	WrenchIcon,
-	ZapIcon,
-} from "lucide-react";
+import { TriangleAlertIcon } from "lucide-react";
 import { type FC, useRef, useState } from "react";
-import type {
-	ChatContext,
-	ChatContextResource,
-	ChatContextResourceKind,
-	ChatContextResourceStatus,
-	ChatContextTool,
-} from "#/api/typesGenerated";
-import { Button } from "#/components/Button/Button";
 import {
 	Popover,
+	PopoverAnchor,
 	PopoverContent,
 	PopoverTrigger,
 } from "#/components/Popover/Popover";
-import { Spinner } from "#/components/Spinner/Spinner";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipProvider,
-	TooltipTrigger,
-} from "#/components/Tooltip/Tooltip";
 import { cn } from "#/utils/cn";
-import { formatKiB } from "#/utils/fileSize";
 import { isMobileViewport } from "#/utils/mobile";
-import { getPathBasename, getPathDirname } from "../utils/path";
+import {
+	ContextDetailsDialog,
+	ContextSyncStatus,
+} from "./ContextDetailsDialog";
+import {
+	type AgentContextUsage,
+	countLabel,
+	formatContextUsageLine,
+	formatTokenCount,
+	getCompactionThresholdPercent,
+	getPercentUsed,
+	normalizeContextResources,
+} from "./contextResources";
 import { SvgRingProgress } from "./SvgRingProgress";
 
-export interface AgentContextUsage {
-	readonly usedTokens?: number;
-	readonly contextLimitTokens?: number;
-	readonly inputTokens?: number;
-	readonly outputTokens?: number;
-	readonly cacheReadTokens?: number;
-	readonly cacheCreationTokens?: number;
-	readonly reasoningTokens?: number;
-	// Percentage (0-100) at which the context will be compacted.
-	readonly compressionThreshold?: number;
-	// Pinned workspace-context state: the resources the chat is built from and
-	// whether they have drifted from the agent's latest snapshot.
-	readonly context?: ChatContext;
-}
-
-// Normalized popover entries, sourced from the chat's pinned context
-// resources.
-type ContextFileItem = { readonly path: string; readonly dir: string };
-type ContextSkillItem = {
-	readonly source: string;
-	readonly name: string;
-	readonly description?: string;
-	readonly dir: string;
-};
-// MCP configs are file-backed (shown by full path), while MCP servers are
-// keyed by name and carry their tools.
-type ContextMcpConfigItem = { readonly source: string };
-type ContextMcpServerItem = {
-	readonly name: string;
-	readonly source: string;
-	readonly tools: readonly ChatContextTool[];
-};
-// A pinned resource the agent could not use, surfaced with its error so the
-// failure is visible instead of silent.
-type ContextIssueItem = {
-	readonly name: string;
-	readonly kind: ChatContextResourceKind;
-	readonly status: ChatContextResourceStatus;
-	readonly error: string;
-	readonly source: string;
-};
-
-// Human-readable label per resource kind, used in the issues list.
-const RESOURCE_KIND_LABELS: Record<ChatContextResourceKind, string> = {
-	instruction_file: "file",
-	skill: "skill",
-	mcp_config: "MCP config",
-	mcp_server: "MCP server",
-};
-
-const hasFiniteTokenValue = (value: number | undefined): value is number =>
-	typeof value === "number" && Number.isFinite(value) && value >= 0;
-
-const formatTokenCount = (value: number | undefined): string =>
-	hasFiniteTokenValue(value) ? value.toLocaleString() : "--";
-
-const formatTokenCountCompact = (value: number | undefined): string => {
-	if (!hasFiniteTokenValue(value)) {
-		return "--";
-	}
-	if (value >= 1_000_000) {
-		const m = value / 1_000_000;
-		return `${Number.isInteger(m) ? m : m.toFixed(1).replace(/\.0$/, "")}M`;
-	}
-	if (value >= 1_000) {
-		const k = value / 1_000;
-		return `${Number.isInteger(k) ? k : k.toFixed(1).replace(/\.0$/, "")}K`;
-	}
-	return String(value);
-};
-
-// Sum the byte size of the OK resources in the given kinds so each popover
-// section can show how much context it costs. Non-OK resources are excluded
-// because they are not injected into the prompt.
-const sumResourceBytes = (
-	resources: readonly ChatContextResource[],
-	kinds: readonly ChatContextResourceKind[],
-): number =>
-	resources.reduce(
-		(total, resource) =>
-			resource.status === "ok" && kinds.includes(resource.kind)
-				? total + (resource.size_bytes ?? 0)
-				: total,
-		0,
-	);
-
-// Dimmed "(N.N KiB)" size suffix for a section header, omitted when the
-// section has no measurable size.
-const SectionSize: FC<{ bytes: number }> = ({ bytes }) =>
-	bytes > 0 ? (
-		<span className="ml-1 font-normal text-content-secondary">
-			{`(${formatKiB(bytes)})`}
-		</span>
-	) : null;
+export type { AgentContextUsage } from "./contextResources";
 
 const getIndicatorToneClassName = (percentUsed: number | null): string => {
 	if (percentUsed === null) {
@@ -141,34 +38,6 @@ const getIndicatorToneClassName = (percentUsed: number | null): string => {
 	return "text-content-secondary/60";
 };
 
-// A set of context resources that share a parent directory. Lists are grouped
-// by directory so resources pulled from different roots (for example a
-// repo-root AGENTS.md and a nested one) stay distinguishable instead of
-// collapsing to identical basenames.
-type DirectoryGroup<T> = {
-	readonly dir: string;
-	readonly items: readonly T[];
-};
-
-// Group items by their precomputed dir, preserving first-seen order so the
-// popover layout stays stable across renders.
-const groupByDirectory = <T extends { readonly dir: string }>(
-	items: readonly T[],
-): readonly DirectoryGroup<T>[] => {
-	const order: string[] = [];
-	const byDir = new Map<string, T[]>();
-	for (const item of items) {
-		const existing = byDir.get(item.dir);
-		if (existing) {
-			existing.push(item);
-		} else {
-			byDir.set(item.dir, [item]);
-			order.push(item.dir);
-		}
-	}
-	return order.map((dir) => ({ dir, items: byDir.get(dir) ?? [] }));
-};
-
 const RING_SIZE = 18;
 const RING_STROKE = 2.5;
 
@@ -176,24 +45,16 @@ const RING_STROKE = 2.5;
 // the user time to move into the popover content.
 const HOVER_CLOSE_DELAY_MS = 150;
 
-// Dimmed directory header shown above a group of context resources when a
-// section spans more than one directory.
-const ContextDirLabel: FC<{ dir: string }> = ({ dir }) => (
-	<span
-		className="flex items-center gap-1 text-[11px] text-content-secondary"
-		title={dir}
-	>
-		<FolderIcon className="size-3 shrink-0" />
-		<span className="truncate">{dir}</span>
-	</span>
-);
-
 export const ContextUsageIndicator: FC<{
 	usage: AgentContextUsage | null;
 	onRefreshContext?: () => void;
 	isRefreshingContext?: boolean;
 }> = ({ usage, onRefreshContext, isRefreshingContext }) => {
 	const [open, setOpen] = useState(false);
+	// Whether the full-list details dialog is open. The popover and the dialog
+	// are mutually exclusive: opening the dialog closes the popover and blocks
+	// hover from re-opening it underneath the dialog.
+	const [detailsOpen, setDetailsOpen] = useState(false);
 	const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	const cancelClose = () => {
@@ -213,21 +74,22 @@ export const ContextUsageIndicator: FC<{
 
 	const handleMouseEnter = () => {
 		cancelClose();
-		setOpen(true);
+		if (!detailsOpen) {
+			setOpen(true);
+		}
 	};
 
-	const usedTokens = hasFiniteTokenValue(usage?.usedTokens)
-		? usage.usedTokens
-		: undefined;
-	const contextLimitTokens = hasFiniteTokenValue(usage?.contextLimitTokens)
-		? usage.contextLimitTokens
-		: undefined;
-	const percentUsed =
-		usedTokens !== undefined &&
-		contextLimitTokens !== undefined &&
-		contextLimitTokens > 0
-			? (usedTokens / contextLimitTokens) * 100
-			: null;
+	// Every popover-open path is gated on the dialog being closed so hover or
+	// tap events firing while the dialog opens cannot re-open the popover
+	// underneath it.
+	const handlePopoverOpenChange = (nextOpen: boolean) => {
+		if (nextOpen && detailsOpen) {
+			return;
+		}
+		setOpen(nextOpen);
+	};
+
+	const percentUsed = getPercentUsed(usage ?? null);
 	const hasPercent = percentUsed !== null;
 	const percentLabel =
 		percentUsed === null ? "--" : `${Math.round(percentUsed)}%`;
@@ -235,331 +97,133 @@ export const ContextUsageIndicator: FC<{
 		? Math.min(Math.max(percentUsed, 0), 100)
 		: 100;
 	const toneClassName = getIndicatorToneClassName(percentUsed);
+	const compactionThreshold = getCompactionThresholdPercent(usage ?? null);
 
 	const context = usage?.context;
 	const isDirty = context?.dirty ?? false;
 	const contextError = context?.error ?? "";
 	const hasContextError = contextError !== "";
-	const pinnedResources = context?.resources;
 
-	// Drive the listed context from the chat's pinned resources.
-	const fileItems: readonly ContextFileItem[] = (pinnedResources ?? [])
-		.filter(
-			(resource) =>
-				resource.kind === "instruction_file" && resource.status === "ok",
-		)
-		.map((resource) => ({
-			path: resource.source,
-			dir: getPathDirname(resource.source),
-		}))
-		// Drop entries with no usable path so an empty marker never renders as a
-		// nameless "Context files" row.
-		.filter((file) => file.path.trim().length > 0);
-	const skillItems: readonly ContextSkillItem[] = (pinnedResources ?? [])
-		.filter((resource) => resource.kind === "skill" && resource.status === "ok")
-		.map((resource) => ({
-			source: resource.source,
-			name: resource.skill_name || getPathBasename(resource.source),
-			description: resource.skill_description,
-			dir: getPathDirname(resource.source),
-		}))
-		// Drop entries with no usable name so an empty skill marker never renders
-		// as a blank row.
-		.filter((skill) => skill.name.trim().length > 0);
-	// MCP configs are shown by their full path so multiple .mcp.json files
-	// (e.g. ~/.mcp.json and ~/project/.mcp.json) stay disambiguated; servers
-	// are keyed by name and carry their tools.
-	const mcpConfigItems: readonly ContextMcpConfigItem[] = (
-		pinnedResources ?? []
-	)
-		.filter(
-			(resource) => resource.kind === "mcp_config" && resource.status === "ok",
-		)
-		.map((resource) => ({ source: resource.source }))
-		.filter((config) => config.source.trim().length > 0);
-	const mcpServerItems: readonly ContextMcpServerItem[] = (
-		pinnedResources ?? []
-	)
-		.filter(
-			(resource) => resource.kind === "mcp_server" && resource.status === "ok",
-		)
-		.map((resource) => ({
-			name: resource.source,
-			source: resource.source,
-			tools: resource.tools ?? [],
-		}))
-		// Drop entries with no usable name so an empty MCP marker never renders as
-		// a blank row.
-		.filter((server) => server.name.trim().length > 0);
-	const hasMcp = mcpConfigItems.length > 0 || mcpServerItems.length > 0;
-	// Pinned resources the agent could not use (invalid skill, unreadable or
-	// oversize file) are surfaced as issues with their error so the failure is
-	// visible rather than a silent omission.
-	const issueItems: readonly ContextIssueItem[] = (pinnedResources ?? [])
-		.filter((resource) => resource.status !== "ok")
-		.map((resource) => ({
-			name:
-				resource.skill_name ||
-				getPathBasename(resource.source) ||
-				resource.source,
-			kind: resource.kind,
-			status: resource.status,
-			error: resource.error ?? "",
-			source: resource.source,
-		}))
-		.filter((issue) => issue.name.trim().length > 0);
-	const hasContextList =
+	const {
+		fileItems,
+		skillItems,
+		mcpConfigItems,
+		mcpServerItems,
+		mcpToolCount,
+		issueItems,
+	} = normalizeContextResources(context?.resources);
+
+	// Compact count summaries. Zero-count segments are omitted, and the "MCP"
+	// prefix attaches to the first MCP segment present.
+	const fileSkillSegments: string[] = [];
+	if (fileItems.length > 0) {
+		fileSkillSegments.push(countLabel(fileItems.length, "context file"));
+	}
+	if (skillItems.length > 0) {
+		fileSkillSegments.push(countLabel(skillItems.length, "skill"));
+	}
+	const mcpSegments: string[] = [];
+	if (mcpConfigItems.length > 0) {
+		mcpSegments.push(countLabel(mcpConfigItems.length, "MCP config"));
+	}
+	if (mcpServerItems.length > 0) {
+		mcpSegments.push(
+			countLabel(
+				mcpServerItems.length,
+				mcpConfigItems.length > 0 ? "server" : "MCP server",
+			),
+		);
+	}
+	if (mcpToolCount > 0) {
+		mcpSegments.push(countLabel(mcpToolCount, "tool"));
+	}
+
+	// Whether the details dialog has anything to show. When false, the link
+	// row is hidden and clicking the ring is a no-op.
+	const hasDetails =
 		fileItems.length > 0 ||
 		skillItems.length > 0 ||
-		hasMcp ||
-		issueItems.length > 0;
-	const fileBytes = sumResourceBytes(pinnedResources ?? [], [
-		"instruction_file",
-	]);
-	const skillBytes = sumResourceBytes(pinnedResources ?? [], ["skill"]);
-	const mcpBytes = sumResourceBytes(pinnedResources ?? [], [
-		"mcp_config",
-		"mcp_server",
-	]);
+		mcpConfigItems.length > 0 ||
+		mcpServerItems.length > 0 ||
+		issueItems.length > 0 ||
+		isDirty ||
+		hasContextError;
 
-	// Group files and skills by directory so every context root is labeled,
-	// keeping resources pulled from different directories distinguishable.
-	const fileGroups = groupByDirectory(fileItems);
-	const skillGroups = groupByDirectory(skillItems);
+	const openDetails = () => {
+		if (!hasDetails) {
+			return;
+		}
+		cancelClose();
+		setOpen(false);
+		setDetailsOpen(true);
+	};
 
-	const ariaLabel = hasPercent
-		? `Context usage ${percentLabel}. ${formatTokenCount(usedTokens)} of ${formatTokenCount(contextLimitTokens)} tokens used.${isDirty ? " Context changed." : ""}`
-		: isDirty
-			? "Context usage. Context changed."
-			: "Context usage";
+	const ariaLabelParts = [
+		hasPercent
+			? `Context usage ${percentLabel}. ${formatTokenCount(usage?.usedTokens)} of ${formatTokenCount(usage?.contextLimitTokens)} tokens used.`
+			: "Context usage.",
+	];
+	if (isDirty) {
+		ariaLabelParts.push("Context changed.");
+	}
+	if (hasDetails) {
+		ariaLabelParts.push("Click to open context details.");
+	}
+	const ariaLabel = ariaLabelParts.join(" ");
 
 	const panelContent = (
 		<div className="text-xs text-content-primary">
-			{hasPercent
-				? `${percentLabel} - ${formatTokenCountCompact(usedTokens)} / ${formatTokenCountCompact(contextLimitTokens)} context used`
-				: "Context usage unavailable"}
-			{hasPercent &&
-				usage?.compressionThreshold !== undefined &&
-				usage.compressionThreshold > 0 && (
-					<div className="mt-1 text-content-secondary">
-						{`Compacts at ${usage.compressionThreshold}%`}
-					</div>
-				)}
-			{hasContextList && (
-				<div
-					className={cn(
-						"flex flex-col gap-2 text-content-secondary",
-						hasPercent && "mt-2",
-					)}
-				>
-					{fileItems.length > 0 && (
-						<div className="flex flex-col gap-1">
-							<span className="font-medium text-content-primary">
-								<span>Context files</span>
-								<SectionSize bytes={fileBytes} />
-							</span>
-							{fileGroups.map((group) => (
-								<div key={group.dir} className="flex flex-col gap-1">
-									{group.dir !== "" && <ContextDirLabel dir={group.dir} />}
-									<div
-										className={cn(
-											"flex flex-col",
-											group.dir !== "" ? "ml-3.5 gap-0.5" : "gap-1",
-										)}
-									>
-										{group.items.map((file) => (
-											<div
-												key={file.path}
-												className="flex items-center gap-1.5"
-											>
-												<FileIcon className="size-3 shrink-0" />
-												<span className="truncate" title={file.path}>
-													{getPathBasename(file.path)}
-												</span>
-											</div>
-										))}
-									</div>
-								</div>
-							))}
-						</div>
-					)}
-					{skillItems.length > 0 && (
-						<div className="flex flex-col gap-1">
-							<span className="font-medium text-content-primary">
-								<span>Skills</span>
-								<SectionSize bytes={skillBytes} />
-							</span>
-							<TooltipProvider delayDuration={300}>
-								{skillGroups.map((group) => (
-									<div key={group.dir} className="flex flex-col gap-1">
-										{group.dir !== "" && <ContextDirLabel dir={group.dir} />}
-										<div
-											className={cn(
-												"flex flex-col",
-												group.dir !== "" ? "ml-3.5 gap-0.5" : "gap-1",
-											)}
-										>
-											{group.items.map((skill) => {
-												const row = (
-													<div className="flex items-center gap-1.5 rounded px-0.5 py-px transition-colors hover:bg-surface-tertiary">
-														<ZapIcon className="size-3 shrink-0" />
-														<span className="truncate">{skill.name}</span>
-													</div>
-												);
-												if (!skill.description) {
-													return <div key={skill.source}>{row}</div>;
-												}
-												return (
-													<Tooltip key={skill.source}>
-														<TooltipTrigger asChild>
-															<div className="cursor-default">{row}</div>
-														</TooltipTrigger>
-														<TooltipContent
-															side="right"
-															sideOffset={4}
-															className="max-w-48 text-xs"
-														>
-															{skill.description}
-														</TooltipContent>
-													</Tooltip>
-												);
-											})}
-										</div>
-									</div>
-								))}
-							</TooltipProvider>
-						</div>
-					)}
-					{hasMcp && (
-						<div className="flex flex-col gap-1">
-							<span className="font-medium text-content-primary">
-								<span>MCP</span>
-								<SectionSize bytes={mcpBytes} />
-							</span>
-							<TooltipProvider delayDuration={300}>
-								{mcpConfigItems.map((config) => (
-									<div
-										key={config.source}
-										className="flex items-center gap-1.5"
-										title={config.source}
-									>
-										<FileIcon className="size-3 shrink-0" />
-										<span className="truncate">{config.source}</span>
-									</div>
-								))}
-								{mcpServerItems.map((mcp) => (
-									<div key={mcp.source} className="flex flex-col gap-0.5">
-										<div
-											className="flex items-center gap-1.5"
-											title={mcp.source}
-										>
-											<PlugIcon className="size-3 shrink-0" />
-											<span className="truncate">{mcp.name}</span>
-										</div>
-										{mcp.tools.length > 0 && (
-											<div className="ml-4 flex flex-col gap-0.5">
-												{mcp.tools.map((tool) => {
-													const row = (
-														<div className="flex items-center gap-1.5 rounded px-0.5 py-px text-content-secondary transition-colors hover:bg-surface-tertiary">
-															<WrenchIcon className="size-3 shrink-0" />
-															<span className="truncate">{tool.name}</span>
-														</div>
-													);
-													if (!tool.description) {
-														return <div key={tool.name}>{row}</div>;
-													}
-													return (
-														<Tooltip key={tool.name}>
-															<TooltipTrigger asChild>
-																<div className="cursor-default">{row}</div>
-															</TooltipTrigger>
-															<TooltipContent
-																side="right"
-																sideOffset={4}
-																className="max-w-48 text-xs"
-															>
-																{tool.description}
-															</TooltipContent>
-														</Tooltip>
-													);
-												})}
-											</div>
-										)}
-									</div>
-								))}
-							</TooltipProvider>
-						</div>
-					)}
-					{issueItems.length > 0 && (
-						<div className="flex flex-col gap-1">
-							<span className="flex items-center gap-1.5 font-medium text-content-warning">
-								<TriangleAlertIcon className="size-3 shrink-0" />
-								Issues
-							</span>
-							{issueItems.map((issue) => (
-								<div
-									key={issue.source}
-									className="flex flex-col"
-									title={issue.source}
-								>
-									<span className="truncate">
-										{issue.name}{" "}
-										<span className="text-content-secondary">
-											({RESOURCE_KIND_LABELS[issue.kind]}: {issue.status})
-										</span>
-									</span>
-									{issue.error && (
-										<span className="text-content-secondary">
-											{issue.error}
-										</span>
-									)}
-								</div>
-							))}
-						</div>
-					)}
+			{formatContextUsageLine(usage ?? null)}
+			{compactionThreshold !== null && (
+				<div className="mt-1 text-content-secondary">
+					{`Compacts at ${compactionThreshold}%`}
 				</div>
 			)}
+			{(fileSkillSegments.length > 0 || mcpSegments.length > 0) && (
+				<div className="mt-2 flex flex-col gap-0.5 text-content-secondary">
+					{fileSkillSegments.length > 0 && (
+						<div>{fileSkillSegments.join(" · ")}</div>
+					)}
+					{mcpSegments.length > 0 && <div>{mcpSegments.join(" · ")}</div>}
+				</div>
+			)}
+			{issueItems.length > 0 && (
+				<div className="mt-2 flex items-center gap-1.5 font-medium text-content-warning">
+					<TriangleAlertIcon className="size-3 shrink-0" />
+					{countLabel(issueItems.length, "issue")}
+				</div>
+			)}
+			{hasDetails && (
+				<button
+					type="button"
+					onClick={openDetails}
+					className="mt-2 block cursor-pointer border-0 bg-transparent p-0 text-left text-xs text-content-link hover:underline"
+				>
+					Click to open full list
+				</button>
+			)}
 			{(isDirty || hasContextError) && (
-				<div className="mt-2 flex flex-col gap-1.5 border-0 border-t border-solid border-border-default pt-2">
-					{hasContextError ? (
-						<span className="flex items-center gap-1.5 font-medium text-content-destructive">
-							<TriangleAlertIcon className="size-3 shrink-0" />
-							Context error
-						</span>
-					) : (
-						<span className="flex items-center gap-1.5 font-medium text-content-warning">
-							<TriangleAlertIcon className="size-3 shrink-0" />
-							Context changed
-						</span>
-					)}
-					{hasContextError ? (
-						<span className="text-content-secondary">{contextError}</span>
-					) : (
-						<span className="text-content-secondary">
-							The workspace context changed since this chat was pinned.
-						</span>
-					)}
-					{onRefreshContext && (
-						<div className="flex flex-wrap gap-2">
-							<Button
-								size="sm"
-								disabled={isRefreshingContext}
-								onClick={() => onRefreshContext()}
-							>
-								<Spinner loading={isRefreshingContext} />
-								Refresh context
-							</Button>
-						</div>
-					)}
+				<div className="mt-2 border-0 border-t border-solid border-border-default pt-2">
+					<ContextSyncStatus
+						contextError={contextError}
+						onRefreshContext={onRefreshContext}
+						isRefreshingContext={isRefreshingContext}
+					/>
 				</div>
 			)}
 		</div>
 	);
 
+	const mobile = isMobileViewport();
+
+	// On mobile the tap toggles the popover via PopoverTrigger, so the ring
+	// itself gets no click handler there; on desktop clicking the ring opens
+	// the details dialog directly.
 	const triggerButton = (
 		<button
 			type="button"
 			aria-label={ariaLabel}
+			onClick={mobile ? undefined : openDetails}
 			className="relative inline-flex size-7 shrink-0 items-center justify-center rounded-full border-none bg-transparent p-0 outline-none transition-colors hover:bg-surface-secondary/60 focus-visible:ring-2 focus-visible:ring-content-link/40"
 		>
 			<SvgRingProgress
@@ -584,41 +248,67 @@ export const ContextUsageIndicator: FC<{
 		</button>
 	);
 
-	// On mobile, a tap toggles the popover. On desktop, hover opens
-	// it like a dropdown menu and skill descriptions appear as
-	// nested tooltips to the right.
-	if (isMobileViewport()) {
+	// Rendered as a sibling of the popover (never inside its content) so it
+	// survives the popover closing.
+	const detailsDialog = usage && hasDetails && (
+		<ContextDetailsDialog
+			usage={usage}
+			open={detailsOpen}
+			onOpenChange={setDetailsOpen}
+			onRefreshContext={onRefreshContext}
+			isRefreshingContext={isRefreshingContext}
+		/>
+	);
+
+	// On mobile, a tap toggles the popover and the link row opens the details
+	// dialog. On desktop, hover opens the popover like a dropdown menu and
+	// clicking the ring (or the link row) opens the details dialog.
+	if (mobile) {
 		return (
-			<Popover>
-				<PopoverTrigger asChild>{triggerButton}</PopoverTrigger>
-				<PopoverContent
-					side="top"
-					className="mobile-full-width-dropdown mobile-full-width-dropdown-bottom w-auto max-w-72 px-3 py-2"
-				>
-					{panelContent}
-				</PopoverContent>
-			</Popover>
+			<>
+				<Popover open={open} onOpenChange={handlePopoverOpenChange}>
+					<PopoverTrigger asChild>{triggerButton}</PopoverTrigger>
+					<PopoverContent
+						side="top"
+						className="mobile-full-width-dropdown mobile-full-width-dropdown-bottom w-auto max-w-72 px-3 py-2"
+						// Keep focus where it is when the popover closes so it cannot
+						// steal focus from the details dialog as it opens.
+						onCloseAutoFocus={(e) => e.preventDefault()}
+					>
+						{panelContent}
+					</PopoverContent>
+				</Popover>
+				{detailsDialog}
+			</>
 		);
 	}
 
 	return (
-		<Popover open={open} onOpenChange={setOpen}>
-			<PopoverTrigger asChild>
-				<div onMouseEnter={handleMouseEnter} onMouseLeave={scheduleClose}>
-					{triggerButton}
-				</div>
-			</PopoverTrigger>
-			<PopoverContent
-				side="top"
-				className="w-auto max-w-72 px-3 py-2"
-				onMouseEnter={cancelClose}
-				onMouseLeave={scheduleClose}
-				// Prevent the popover from stealing focus, which would
-				// interfere with the chat input.
-				onOpenAutoFocus={(e) => e.preventDefault()}
-			>
-				{panelContent}
-			</PopoverContent>
-		</Popover>
+		<>
+			<Popover open={open} onOpenChange={handlePopoverOpenChange}>
+				{/* An anchor rather than a trigger: hover alone controls the
+				    popover, leaving click free to open the details dialog. */}
+				<PopoverAnchor asChild>
+					<div onMouseEnter={handleMouseEnter} onMouseLeave={scheduleClose}>
+						{triggerButton}
+					</div>
+				</PopoverAnchor>
+				<PopoverContent
+					side="top"
+					className="w-auto max-w-72 px-3 py-2"
+					onMouseEnter={cancelClose}
+					onMouseLeave={scheduleClose}
+					// Prevent the popover from stealing focus, which would
+					// interfere with the chat input.
+					onOpenAutoFocus={(e) => e.preventDefault()}
+					// Keep focus where it is when the popover closes so it cannot
+					// steal focus from the details dialog as it opens.
+					onCloseAutoFocus={(e) => e.preventDefault()}
+				>
+					{panelContent}
+				</PopoverContent>
+			</Popover>
+			{detailsDialog}
+		</>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ContextUsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/ContextUsageIndicator.tsx
@@ -195,9 +195,6 @@ export const ContextUsageIndicator: FC<{
 		</div>
 	);
 
-	// On mobile the tap toggles the popover via PopoverTrigger, so the ring
-	// itself gets no click handler there; on desktop clicking the ring opens
-	// the details dialog directly.
 	const triggerButton = (
 		<button
 			type="button"

--- a/site/src/pages/AgentsPage/components/ContextUsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/ContextUsageIndicator.tsx
@@ -6,8 +6,8 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "#/components/Popover/Popover";
+import { useIsMobileViewport } from "#/hooks/useIsMobileViewport";
 import { cn } from "#/utils/cn";
-import { isMobileViewport } from "#/utils/mobile";
 import {
 	ContextDetailsDialog,
 	ContextSyncStatus,
@@ -17,7 +17,7 @@ import {
 	countLabel,
 	formatContextUsageLine,
 	formatTokenCount,
-	getCompactionThresholdPercent,
+	getCompressionThresholdPercent,
 	getPercentUsed,
 	normalizeContextResources,
 } from "./contextResources";
@@ -50,6 +50,7 @@ export const ContextUsageIndicator: FC<{
 	onRefreshContext?: () => void;
 	isRefreshingContext?: boolean;
 }> = ({ usage, onRefreshContext, isRefreshingContext }) => {
+	const mobile = useIsMobileViewport();
 	const [open, setOpen] = useState(false);
 	const [detailsOpen, setDetailsOpen] = useState(false);
 	const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -82,7 +83,7 @@ export const ContextUsageIndicator: FC<{
 		? Math.min(Math.max(percentUsed, 0), 100)
 		: 100;
 	const toneClassName = getIndicatorToneClassName(percentUsed);
-	const compactionThreshold = getCompactionThresholdPercent(usage);
+	const compressionThreshold = getCompressionThresholdPercent(usage);
 
 	const context = usage?.context;
 	const isDirty = context?.dirty ?? false;
@@ -104,7 +105,7 @@ export const ContextUsageIndicator: FC<{
 	const fileSkillSegments = [
 		fileItems.length > 0 && countLabel(fileItems.length, "context file"),
 		skillItems.length > 0 && countLabel(skillItems.length, "skill"),
-	].filter((segment): segment is string => segment !== false);
+	].filter((segment) => segment !== false);
 	const mcpSegments = [
 		mcpConfigItems.length > 0 &&
 			countLabel(mcpConfigItems.length, "MCP config"),
@@ -114,11 +115,18 @@ export const ContextUsageIndicator: FC<{
 				mcpConfigItems.length > 0 ? "server" : "MCP server",
 			),
 		mcpToolCount > 0 && countLabel(mcpToolCount, "tool"),
-	].filter((segment): segment is string => segment !== false);
+	].filter((segment) => segment !== false);
 
 	// Whether the details dialog has anything to show. When false, the link
 	// row is hidden and clicking the ring is a no-op.
 	const hasDetails = hasResources || isDirty || hasContextError;
+
+	// Reset stale dialog state when the details disappear (for example while
+	// switching chats), so the next chat's details cannot pop the dialog open
+	// without user action.
+	if (detailsOpen && !(usage && hasDetails)) {
+		setDetailsOpen(false);
+	}
 
 	const openDetails = () => {
 		if (!hasDetails) {
@@ -137,7 +145,9 @@ export const ContextUsageIndicator: FC<{
 	if (isDirty) {
 		ariaLabelParts.push("Context changed.");
 	}
-	if (hasDetails) {
+	// On mobile a tap opens the popover, not the dialog, so the click hint
+	// only applies to desktop.
+	if (hasDetails && !mobile) {
 		ariaLabelParts.push("Click to open context details.");
 	}
 	const ariaLabel = ariaLabelParts.join(" ");
@@ -145,9 +155,9 @@ export const ContextUsageIndicator: FC<{
 	const panelContent = (
 		<div className="text-xs text-content-primary">
 			{formatContextUsageLine(usage)}
-			{compactionThreshold !== null && (
+			{compressionThreshold !== null && (
 				<div className="mt-1 text-content-secondary">
-					{`Compacts at ${compactionThreshold}%`}
+					{`Compacts at ${compressionThreshold}%`}
 				</div>
 			)}
 			{(fileSkillSegments.length > 0 || mcpSegments.length > 0) && (
@@ -184,8 +194,6 @@ export const ContextUsageIndicator: FC<{
 			)}
 		</div>
 	);
-
-	const mobile = isMobileViewport();
 
 	// On mobile the tap toggles the popover via PopoverTrigger, so the ring
 	// itself gets no click handler there; on desktop clicking the ring opens
@@ -257,9 +265,10 @@ export const ContextUsageIndicator: FC<{
 					// Prevent the popover from stealing focus, which would
 					// interfere with the chat input.
 					onOpenAutoFocus={mobile ? undefined : (e) => e.preventDefault()}
-					// Keep focus where it is when the popover closes so it cannot
-					// steal focus from the details dialog as it opens.
-					onCloseAutoFocus={(e) => e.preventDefault()}
+					// On desktop, keep focus where it is when the popover closes so
+					// it cannot steal focus from the details dialog as it opens. On
+					// mobile, let Radix restore focus to the trigger.
+					onCloseAutoFocus={mobile ? undefined : (e) => e.preventDefault()}
 				>
 					{panelContent}
 				</PopoverContent>

--- a/site/src/pages/AgentsPage/components/contextResources.test.ts
+++ b/site/src/pages/AgentsPage/components/contextResources.test.ts
@@ -3,7 +3,7 @@ import type { ChatContextResource } from "#/api/typesGenerated";
 import {
 	countLabel,
 	formatContextUsageLine,
-	getCompactionThresholdPercent,
+	getCompressionThresholdPercent,
 	getPercentUsed,
 	normalizeContextResources,
 } from "./contextResources";
@@ -131,7 +131,7 @@ describe("normalizeContextResources", () => {
 
 	it("sums bytes per section from ok resources only", () => {
 		const normalized = normalizeContextResources(resources);
-		// The too_large instruction file is not injected, so it does not count.
+		// The oversize instruction file is not injected, so it does not count.
 		expect(normalized.fileBytes).toBe(500);
 		// The invalid skill does not count either.
 		expect(normalized.skillBytes).toBe(150);
@@ -149,11 +149,13 @@ describe("normalizeContextResources", () => {
 				error: "name mismatch",
 				source: "/home/coder/test/.agents/skills/moo",
 			},
+			// A missing backend error falls back to a status explanation so the
+			// issue row never renders without a diagnosis.
 			{
 				name: "huge.md",
 				kind: "instruction_file",
 				status: "oversize",
-				error: "",
+				error: "File exceeds the context size limit.",
 				source: "/home/coder/huge.md",
 			},
 		]);
@@ -202,20 +204,20 @@ describe("usage formatting", () => {
 
 	it("only reports a compaction threshold alongside a known usage percent", () => {
 		expect(
-			getCompactionThresholdPercent({
+			getCompressionThresholdPercent({
 				usedTokens: 12_000,
 				contextLimitTokens: 200_000,
 				compressionThreshold: 80,
 			}),
 		).toBe(80);
 		expect(
-			getCompactionThresholdPercent({
+			getCompressionThresholdPercent({
 				usedTokens: 12_000,
 				compressionThreshold: 80,
 			}),
 		).toBeNull();
 		expect(
-			getCompactionThresholdPercent({
+			getCompressionThresholdPercent({
 				usedTokens: 12_000,
 				contextLimitTokens: 200_000,
 				compressionThreshold: 0,

--- a/site/src/pages/AgentsPage/components/contextResources.test.ts
+++ b/site/src/pages/AgentsPage/components/contextResources.test.ts
@@ -77,6 +77,7 @@ describe("normalizeContextResources", () => {
 		expect(normalized.mcpServerItems).toEqual([]);
 		expect(normalized.mcpToolCount).toBe(0);
 		expect(normalized.issueItems).toEqual([]);
+		expect(normalized.hasResources).toBe(false);
 	});
 
 	it("normalizes files, skills, and MCP entries from ok resources only", () => {
@@ -105,6 +106,7 @@ describe("normalizeContextResources", () => {
 			},
 		]);
 		expect(normalized.mcpToolCount).toBe(2);
+		expect(normalized.hasResources).toBe(true);
 	});
 
 	it("groups files and skills by directory in first-seen order", () => {

--- a/site/src/pages/AgentsPage/components/contextResources.test.ts
+++ b/site/src/pages/AgentsPage/components/contextResources.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vitest";
+import type { ChatContextResource } from "#/api/typesGenerated";
+import {
+	countLabel,
+	formatContextUsageLine,
+	getCompactionThresholdPercent,
+	getPercentUsed,
+	normalizeContextResources,
+} from "./contextResources";
+
+const resources: ChatContextResource[] = [
+	{
+		source: "/home/coder/AGENTS.md",
+		kind: "instruction_file",
+		size_bytes: 200,
+		status: "ok",
+	},
+	{
+		source: "/home/coder/site/AGENTS.md",
+		kind: "instruction_file",
+		size_bytes: 300,
+		status: "ok",
+	},
+	{
+		source: "/home/coder/.coder/skills/deploy",
+		kind: "skill",
+		size_bytes: 100,
+		status: "ok",
+		skill_name: "deploy",
+		skill_description: "Deploy the app.",
+	},
+	{
+		source: "/home/coder/.agents/skills/review",
+		kind: "skill",
+		size_bytes: 50,
+		status: "ok",
+	},
+	{
+		source: "/home/coder/.mcp.json",
+		kind: "mcp_config",
+		size_bytes: 150,
+		status: "ok",
+	},
+	{
+		source: "github",
+		kind: "mcp_server",
+		size_bytes: 400,
+		status: "ok",
+		tools: [
+			{ name: "search_issues", description: "Search issues." },
+			{ name: "create_issue" },
+		],
+	},
+	{
+		source: "/home/coder/test/.agents/skills/moo",
+		kind: "skill",
+		size_bytes: 75,
+		status: "invalid",
+		error: "name mismatch",
+	},
+	{
+		source: "/home/coder/huge.md",
+		kind: "instruction_file",
+		size_bytes: 9000,
+		status: "oversize",
+	},
+];
+
+describe("normalizeContextResources", () => {
+	it("returns empty entries for undefined resources", () => {
+		const normalized = normalizeContextResources(undefined);
+		expect(normalized.fileItems).toEqual([]);
+		expect(normalized.fileGroups).toEqual([]);
+		expect(normalized.fileBytes).toBe(0);
+		expect(normalized.skillItems).toEqual([]);
+		expect(normalized.mcpConfigItems).toEqual([]);
+		expect(normalized.mcpServerItems).toEqual([]);
+		expect(normalized.mcpToolCount).toBe(0);
+		expect(normalized.issueItems).toEqual([]);
+	});
+
+	it("normalizes files, skills, and MCP entries from ok resources only", () => {
+		const normalized = normalizeContextResources(resources);
+
+		expect(normalized.fileItems).toEqual([
+			{ path: "/home/coder/AGENTS.md", dir: "/home/coder" },
+			{ path: "/home/coder/site/AGENTS.md", dir: "/home/coder/site" },
+		]);
+		// Skill names fall back to the source basename when unnamed.
+		expect(normalized.skillItems.map((skill) => skill.name)).toEqual([
+			"deploy",
+			"review",
+		]);
+		expect(normalized.mcpConfigItems).toEqual([
+			{ source: "/home/coder/.mcp.json" },
+		]);
+		expect(normalized.mcpServerItems).toEqual([
+			{
+				name: "github",
+				source: "github",
+				tools: [
+					{ name: "search_issues", description: "Search issues." },
+					{ name: "create_issue" },
+				],
+			},
+		]);
+		expect(normalized.mcpToolCount).toBe(2);
+	});
+
+	it("groups files and skills by directory in first-seen order", () => {
+		const normalized = normalizeContextResources(resources);
+		expect(normalized.fileGroups).toEqual([
+			{
+				dir: "/home/coder",
+				items: [{ path: "/home/coder/AGENTS.md", dir: "/home/coder" }],
+			},
+			{
+				dir: "/home/coder/site",
+				items: [
+					{ path: "/home/coder/site/AGENTS.md", dir: "/home/coder/site" },
+				],
+			},
+		]);
+		expect(normalized.skillGroups.map((group) => group.dir)).toEqual([
+			"/home/coder/.coder/skills",
+			"/home/coder/.agents/skills",
+		]);
+	});
+
+	it("sums bytes per section from ok resources only", () => {
+		const normalized = normalizeContextResources(resources);
+		// The too_large instruction file is not injected, so it does not count.
+		expect(normalized.fileBytes).toBe(500);
+		// The invalid skill does not count either.
+		expect(normalized.skillBytes).toBe(150);
+		// MCP bytes cover configs and servers.
+		expect(normalized.mcpBytes).toBe(550);
+	});
+
+	it("surfaces non-ok resources as issues", () => {
+		const normalized = normalizeContextResources(resources);
+		expect(normalized.issueItems).toEqual([
+			{
+				name: "moo",
+				kind: "skill",
+				status: "invalid",
+				error: "name mismatch",
+				source: "/home/coder/test/.agents/skills/moo",
+			},
+			{
+				name: "huge.md",
+				kind: "instruction_file",
+				status: "oversize",
+				error: "",
+				source: "/home/coder/huge.md",
+			},
+		]);
+	});
+
+	it("drops entries without a usable name or path", () => {
+		const normalized = normalizeContextResources([
+			{ source: " ", kind: "instruction_file", size_bytes: 0, status: "ok" },
+			{ source: "", kind: "skill", size_bytes: 0, status: "ok" },
+			{ source: "", kind: "mcp_config", size_bytes: 0, status: "ok" },
+			{ source: " ", kind: "mcp_server", size_bytes: 0, status: "ok" },
+		]);
+		expect(normalized.fileItems).toEqual([]);
+		expect(normalized.skillItems).toEqual([]);
+		expect(normalized.mcpConfigItems).toEqual([]);
+		expect(normalized.mcpServerItems).toEqual([]);
+	});
+});
+
+describe("usage formatting", () => {
+	it("formats the usage line from used and limit tokens", () => {
+		expect(
+			formatContextUsageLine({
+				usedTokens: 12_000,
+				contextLimitTokens: 200_000,
+			}),
+		).toBe("6% - 12K / 200K context used");
+	});
+
+	it("falls back when usage is unknown", () => {
+		expect(formatContextUsageLine(null)).toBe("Context usage unavailable");
+		expect(formatContextUsageLine({ usedTokens: 12_000 })).toBe(
+			"Context usage unavailable",
+		);
+	});
+
+	it("computes the percent used", () => {
+		expect(
+			getPercentUsed({ usedTokens: 50_000, contextLimitTokens: 200_000 }),
+		).toBe(25);
+		expect(getPercentUsed({ usedTokens: 50_000 })).toBeNull();
+		expect(
+			getPercentUsed({ usedTokens: 50_000, contextLimitTokens: 0 }),
+		).toBeNull();
+	});
+
+	it("only reports a compaction threshold alongside a known usage percent", () => {
+		expect(
+			getCompactionThresholdPercent({
+				usedTokens: 12_000,
+				contextLimitTokens: 200_000,
+				compressionThreshold: 80,
+			}),
+		).toBe(80);
+		expect(
+			getCompactionThresholdPercent({
+				usedTokens: 12_000,
+				compressionThreshold: 80,
+			}),
+		).toBeNull();
+		expect(
+			getCompactionThresholdPercent({
+				usedTokens: 12_000,
+				contextLimitTokens: 200_000,
+				compressionThreshold: 0,
+			}),
+		).toBeNull();
+	});
+
+	it("pluralizes count labels", () => {
+		expect(countLabel(1, "skill")).toBe("1 skill");
+		expect(countLabel(3, "skill")).toBe("3 skills");
+	});
+});

--- a/site/src/pages/AgentsPage/components/contextResources.ts
+++ b/site/src/pages/AgentsPage/components/contextResources.ts
@@ -5,6 +5,7 @@ import type {
 	ChatContextResourceStatus,
 	ChatContextTool,
 } from "#/api/typesGenerated";
+import { formatTokenCount as formatTokenCountBase } from "#/utils/analytics";
 import { getPathBasename, getPathDirname } from "../utils/path";
 
 export interface AgentContextUsage {
@@ -22,8 +23,6 @@ export interface AgentContextUsage {
 	readonly context?: ChatContext;
 }
 
-// Normalized context entries, sourced from the chat's pinned context
-// resources and shared by the compact usage popover and the details dialog.
 type ContextFileItem = { readonly path: string; readonly dir: string };
 type ContextSkillItem = {
 	readonly source: string;
@@ -56,11 +55,31 @@ export const RESOURCE_KIND_LABELS: Record<ChatContextResourceKind, string> = {
 	mcp_server: "MCP server",
 };
 
+export const RESOURCE_STATUS_LABELS: Record<ChatContextResourceStatus, string> =
+	{
+		ok: "ok",
+		excluded: "excluded",
+		invalid: "invalid",
+		oversize: "too large",
+		unreadable: "unreadable",
+	};
+
+// Explanations shown when the backend omits a per-resource error message, so
+// an issue row never renders without a diagnosis.
+const STATUS_EXPLANATIONS: Partial<Record<ChatContextResourceStatus, string>> =
+	{
+		oversize: "File exceeds the context size limit.",
+		unreadable: "File could not be read.",
+		excluded: "Resource was excluded by configuration.",
+		invalid: "Resource configuration is invalid.",
+	};
+
 const hasFiniteTokenValue = (value: number | undefined): value is number =>
 	typeof value === "number" && Number.isFinite(value) && value >= 0;
 
+// Adds undefined handling on top of the shared token formatter.
 export const formatTokenCount = (value: number | undefined): string =>
-	hasFiniteTokenValue(value) ? value.toLocaleString() : "--";
+	hasFiniteTokenValue(value) ? formatTokenCountBase(value) : "--";
 
 const formatTokenCountCompact = (value: number | undefined): string => {
 	if (!hasFiniteTokenValue(value)) {
@@ -77,8 +96,7 @@ const formatTokenCountCompact = (value: number | undefined): string => {
 	return String(value);
 };
 
-// Percent (0-100) of the context window consumed, or null when either the
-// used tokens or the limit is unknown.
+// Null when either the used tokens or the limit is unknown.
 export const getPercentUsed = (
 	usage: AgentContextUsage | null,
 ): number | null => {
@@ -100,9 +118,8 @@ export const formatContextUsageLine = (
 	return `${Math.round(percent)}% - ${formatTokenCountCompact(usage.usedTokens)} / ${formatTokenCountCompact(usage.contextLimitTokens)} context used`;
 };
 
-// Compaction threshold percent to display, or null when it is unset or the
-// usage percent itself is unknown.
-export const getCompactionThresholdPercent = (
+// Null when the threshold is unset or the usage percent itself is unknown.
+export const getCompressionThresholdPercent = (
 	usage: AgentContextUsage | null,
 ): number | null => {
 	if (
@@ -119,9 +136,8 @@ export const getCompactionThresholdPercent = (
 export const countLabel = (count: number, noun: string): string =>
 	`${count} ${noun}${count === 1 ? "" : "s"}`;
 
-// Sum the byte size of the OK resources in the given kinds so each section
-// can show how much context it costs. Non-OK resources are excluded because
-// they are not injected into the prompt.
+// Non-OK resources are excluded because they are not injected into the
+// prompt.
 const sumResourceBytes = (
 	resources: readonly ChatContextResource[],
 	kinds: readonly ChatContextResourceKind[],
@@ -134,31 +150,21 @@ const sumResourceBytes = (
 		0,
 	);
 
-// A set of context resources that share a parent directory. Lists are grouped
-// by directory so resources pulled from different roots (for example a
-// repo-root AGENTS.md and a nested one) stay distinguishable instead of
+// Grouping by directory keeps resources pulled from different roots (for
+// example a repo-root AGENTS.md and a nested one) distinguishable instead of
 // collapsing to identical basenames.
 type DirectoryGroup<T> = {
 	readonly dir: string;
 	readonly items: readonly T[];
 };
 
-// Group items by their precomputed dir, preserving first-seen order so the
-// list layout stays stable across renders.
 const groupByDirectory = <T extends { readonly dir: string }>(
 	items: readonly T[],
-): readonly DirectoryGroup<T>[] => {
-	const byDir = new Map<string, T[]>();
-	for (const item of items) {
-		const existing = byDir.get(item.dir);
-		if (existing) {
-			existing.push(item);
-		} else {
-			byDir.set(item.dir, [item]);
-		}
-	}
-	return [...byDir.entries()].map(([dir, items]) => ({ dir, items }));
-};
+): readonly DirectoryGroup<T>[] =>
+	[...Map.groupBy(items, (item) => item.dir)].map(([dir, items]) => ({
+		dir,
+		items,
+	}));
 
 interface NormalizedContextResources {
 	readonly fileItems: readonly ContextFileItem[];
@@ -176,8 +182,6 @@ interface NormalizedContextResources {
 	readonly hasResources: boolean;
 }
 
-// Normalize the chat's pinned context resources into the display entries the
-// compact popover (counts) and the details dialog (full tree) are built from.
 export const normalizeContextResources = (
 	resources: readonly ChatContextResource[] | undefined,
 ): NormalizedContextResources => {
@@ -234,7 +238,7 @@ export const normalizeContextResources = (
 				resource.source,
 			kind: resource.kind,
 			status: resource.status,
-			error: resource.error ?? "",
+			error: resource.error || STATUS_EXPLANATIONS[resource.status] || "",
 			source: resource.source,
 		}))
 		.filter((issue) => issue.name.trim().length > 0);

--- a/site/src/pages/AgentsPage/components/contextResources.ts
+++ b/site/src/pages/AgentsPage/components/contextResources.ts
@@ -158,13 +158,22 @@ type DirectoryGroup<T> = {
 	readonly items: readonly T[];
 };
 
+// Manual grouping because Map.groupBy is unavailable in the browserslist
+// targets (Safari 16, Chrome 110). Map iteration preserves first-seen order.
 const groupByDirectory = <T extends { readonly dir: string }>(
 	items: readonly T[],
-): readonly DirectoryGroup<T>[] =>
-	[...Map.groupBy(items, (item) => item.dir)].map(([dir, items]) => ({
-		dir,
-		items,
-	}));
+): readonly DirectoryGroup<T>[] => {
+	const byDir = new Map<string, T[]>();
+	for (const item of items) {
+		const group = byDir.get(item.dir);
+		if (group) {
+			group.push(item);
+		} else {
+			byDir.set(item.dir, [item]);
+		}
+	}
+	return [...byDir].map(([dir, items]) => ({ dir, items }));
+};
 
 interface NormalizedContextResources {
 	readonly fileItems: readonly ContextFileItem[];

--- a/site/src/pages/AgentsPage/components/contextResources.ts
+++ b/site/src/pages/AgentsPage/components/contextResources.ts
@@ -1,0 +1,269 @@
+import type {
+	ChatContext,
+	ChatContextResource,
+	ChatContextResourceKind,
+	ChatContextResourceStatus,
+	ChatContextTool,
+} from "#/api/typesGenerated";
+import { getPathBasename, getPathDirname } from "../utils/path";
+
+export interface AgentContextUsage {
+	readonly usedTokens?: number;
+	readonly contextLimitTokens?: number;
+	readonly inputTokens?: number;
+	readonly outputTokens?: number;
+	readonly cacheReadTokens?: number;
+	readonly cacheCreationTokens?: number;
+	readonly reasoningTokens?: number;
+	// Percentage (0-100) at which the context will be compacted.
+	readonly compressionThreshold?: number;
+	// Pinned workspace-context state: the resources the chat is built from and
+	// whether they have drifted from the agent's latest snapshot.
+	readonly context?: ChatContext;
+}
+
+// Normalized context entries, sourced from the chat's pinned context
+// resources and shared by the compact usage popover and the details dialog.
+type ContextFileItem = { readonly path: string; readonly dir: string };
+type ContextSkillItem = {
+	readonly source: string;
+	readonly name: string;
+	readonly description?: string;
+	readonly dir: string;
+};
+// MCP configs are file-backed (shown by full path), while MCP servers are
+// keyed by name and carry their tools.
+type ContextMcpConfigItem = { readonly source: string };
+type ContextMcpServerItem = {
+	readonly name: string;
+	readonly source: string;
+	readonly tools: readonly ChatContextTool[];
+};
+// A pinned resource the agent could not use, surfaced with its error so the
+// failure is visible instead of silent.
+type ContextIssueItem = {
+	readonly name: string;
+	readonly kind: ChatContextResourceKind;
+	readonly status: ChatContextResourceStatus;
+	readonly error: string;
+	readonly source: string;
+};
+
+// Human-readable label per resource kind, used in the issues list.
+export const RESOURCE_KIND_LABELS: Record<ChatContextResourceKind, string> = {
+	instruction_file: "file",
+	skill: "skill",
+	mcp_config: "MCP config",
+	mcp_server: "MCP server",
+};
+
+const hasFiniteTokenValue = (value: number | undefined): value is number =>
+	typeof value === "number" && Number.isFinite(value) && value >= 0;
+
+export const formatTokenCount = (value: number | undefined): string =>
+	hasFiniteTokenValue(value) ? value.toLocaleString() : "--";
+
+const formatTokenCountCompact = (value: number | undefined): string => {
+	if (!hasFiniteTokenValue(value)) {
+		return "--";
+	}
+	if (value >= 1_000_000) {
+		const m = value / 1_000_000;
+		return `${Number.isInteger(m) ? m : m.toFixed(1).replace(/\.0$/, "")}M`;
+	}
+	if (value >= 1_000) {
+		const k = value / 1_000;
+		return `${Number.isInteger(k) ? k : k.toFixed(1).replace(/\.0$/, "")}K`;
+	}
+	return String(value);
+};
+
+// Percent (0-100) of the context window consumed, or null when either the
+// used tokens or the limit is unknown.
+export const getPercentUsed = (
+	usage: AgentContextUsage | null,
+): number | null => {
+	const used = usage?.usedTokens;
+	const limit = usage?.contextLimitTokens;
+	if (!hasFiniteTokenValue(used) || !hasFiniteTokenValue(limit) || limit <= 0) {
+		return null;
+	}
+	return (used / limit) * 100;
+};
+
+// One-line usage summary shown in both the compact popover and the details
+// dialog header.
+export const formatContextUsageLine = (
+	usage: AgentContextUsage | null,
+): string => {
+	const percent = getPercentUsed(usage);
+	if (usage === null || percent === null) {
+		return "Context usage unavailable";
+	}
+	return `${Math.round(percent)}% - ${formatTokenCountCompact(usage.usedTokens)} / ${formatTokenCountCompact(usage.contextLimitTokens)} context used`;
+};
+
+// Compaction threshold percent to display, or null when it is unset or the
+// usage percent itself is unknown.
+export const getCompactionThresholdPercent = (
+	usage: AgentContextUsage | null,
+): number | null => {
+	if (
+		usage === null ||
+		usage.compressionThreshold === undefined ||
+		usage.compressionThreshold <= 0 ||
+		getPercentUsed(usage) === null
+	) {
+		return null;
+	}
+	return usage.compressionThreshold;
+};
+
+// "1 skill" / "3 skills" count labels for the compact popover summary lines
+// and the per-server tool counts in the details dialog.
+export const countLabel = (count: number, noun: string): string =>
+	`${count} ${noun}${count === 1 ? "" : "s"}`;
+
+// Sum the byte size of the OK resources in the given kinds so each section
+// can show how much context it costs. Non-OK resources are excluded because
+// they are not injected into the prompt.
+const sumResourceBytes = (
+	resources: readonly ChatContextResource[],
+	kinds: readonly ChatContextResourceKind[],
+): number =>
+	resources.reduce(
+		(total, resource) =>
+			resource.status === "ok" && kinds.includes(resource.kind)
+				? total + (resource.size_bytes ?? 0)
+				: total,
+		0,
+	);
+
+// A set of context resources that share a parent directory. Lists are grouped
+// by directory so resources pulled from different roots (for example a
+// repo-root AGENTS.md and a nested one) stay distinguishable instead of
+// collapsing to identical basenames.
+type DirectoryGroup<T> = {
+	readonly dir: string;
+	readonly items: readonly T[];
+};
+
+// Group items by their precomputed dir, preserving first-seen order so the
+// list layout stays stable across renders.
+const groupByDirectory = <T extends { readonly dir: string }>(
+	items: readonly T[],
+): readonly DirectoryGroup<T>[] => {
+	const order: string[] = [];
+	const byDir = new Map<string, T[]>();
+	for (const item of items) {
+		const existing = byDir.get(item.dir);
+		if (existing) {
+			existing.push(item);
+		} else {
+			byDir.set(item.dir, [item]);
+			order.push(item.dir);
+		}
+	}
+	return order.map((dir) => ({ dir, items: byDir.get(dir) ?? [] }));
+};
+
+interface NormalizedContextResources {
+	readonly fileItems: readonly ContextFileItem[];
+	readonly fileGroups: readonly DirectoryGroup<ContextFileItem>[];
+	readonly fileBytes: number;
+	readonly skillItems: readonly ContextSkillItem[];
+	readonly skillGroups: readonly DirectoryGroup<ContextSkillItem>[];
+	readonly skillBytes: number;
+	readonly mcpConfigItems: readonly ContextMcpConfigItem[];
+	readonly mcpServerItems: readonly ContextMcpServerItem[];
+	readonly mcpToolCount: number;
+	readonly mcpBytes: number;
+	readonly issueItems: readonly ContextIssueItem[];
+}
+
+// Normalize the chat's pinned context resources into the display entries the
+// compact popover (counts) and the details dialog (full tree) are built from.
+export const normalizeContextResources = (
+	resources: readonly ChatContextResource[] | undefined,
+): NormalizedContextResources => {
+	const pinned = resources ?? [];
+	const fileItems: readonly ContextFileItem[] = pinned
+		.filter(
+			(resource) =>
+				resource.kind === "instruction_file" && resource.status === "ok",
+		)
+		.map((resource) => ({
+			path: resource.source,
+			dir: getPathDirname(resource.source),
+		}))
+		// Drop entries with no usable path so an empty marker never renders as a
+		// nameless "Context files" row.
+		.filter((file) => file.path.trim().length > 0);
+	const skillItems: readonly ContextSkillItem[] = pinned
+		.filter((resource) => resource.kind === "skill" && resource.status === "ok")
+		.map((resource) => ({
+			source: resource.source,
+			name: resource.skill_name || getPathBasename(resource.source),
+			description: resource.skill_description,
+			dir: getPathDirname(resource.source),
+		}))
+		// Drop entries with no usable name so an empty skill marker never renders
+		// as a blank row.
+		.filter((skill) => skill.name.trim().length > 0);
+	// MCP configs are shown by their full path so multiple .mcp.json files
+	// (e.g. ~/.mcp.json and ~/project/.mcp.json) stay disambiguated; servers
+	// are keyed by name and carry their tools.
+	const mcpConfigItems: readonly ContextMcpConfigItem[] = pinned
+		.filter(
+			(resource) => resource.kind === "mcp_config" && resource.status === "ok",
+		)
+		.map((resource) => ({ source: resource.source }))
+		.filter((config) => config.source.trim().length > 0);
+	const mcpServerItems: readonly ContextMcpServerItem[] = pinned
+		.filter(
+			(resource) => resource.kind === "mcp_server" && resource.status === "ok",
+		)
+		.map((resource) => ({
+			name: resource.source,
+			source: resource.source,
+			tools: resource.tools ?? [],
+		}))
+		// Drop entries with no usable name so an empty MCP marker never renders
+		// as a blank row.
+		.filter((server) => server.name.trim().length > 0);
+	// Pinned resources the agent could not use (invalid skill, unreadable or
+	// oversize file) are surfaced as issues with their error so the failure is
+	// visible rather than a silent omission.
+	const issueItems: readonly ContextIssueItem[] = pinned
+		.filter((resource) => resource.status !== "ok")
+		.map((resource) => ({
+			name:
+				resource.skill_name ||
+				getPathBasename(resource.source) ||
+				resource.source,
+			kind: resource.kind,
+			status: resource.status,
+			error: resource.error ?? "",
+			source: resource.source,
+		}))
+		.filter((issue) => issue.name.trim().length > 0);
+
+	return {
+		fileItems,
+		// Group files and skills by directory so every context root is labeled,
+		// keeping resources pulled from different directories distinguishable.
+		fileGroups: groupByDirectory(fileItems),
+		fileBytes: sumResourceBytes(pinned, ["instruction_file"]),
+		skillItems,
+		skillGroups: groupByDirectory(skillItems),
+		skillBytes: sumResourceBytes(pinned, ["skill"]),
+		mcpConfigItems,
+		mcpServerItems,
+		mcpToolCount: mcpServerItems.reduce(
+			(total, server) => total + server.tools.length,
+			0,
+		),
+		mcpBytes: sumResourceBytes(pinned, ["mcp_config", "mcp_server"]),
+		issueItems,
+	};
+};

--- a/site/src/pages/AgentsPage/components/contextResources.ts
+++ b/site/src/pages/AgentsPage/components/contextResources.ts
@@ -216,9 +216,7 @@ export const normalizeContextResources = (
 			dir: getPathDirname(resource.source),
 		}))
 		.filter((skill) => skill.name.trim().length > 0);
-	// MCP configs are shown by their full path so multiple .mcp.json files
-	// (e.g. ~/.mcp.json and ~/project/.mcp.json) stay disambiguated; servers
-	// are keyed by name and carry their tools.
+	// Full paths disambiguate multiple .mcp.json files.
 	const mcpConfigItems: readonly ContextMcpConfigItem[] = pinned
 		.filter(
 			(resource) => resource.kind === "mcp_config" && resource.status === "ok",
@@ -235,9 +233,6 @@ export const normalizeContextResources = (
 			tools: resource.tools ?? [],
 		}))
 		.filter((server) => server.name.trim().length > 0);
-	// Pinned resources the agent could not use (invalid skill, unreadable or
-	// oversize file) are surfaced as issues with their error so the failure is
-	// visible rather than a silent omission.
 	const issueItems: readonly ContextIssueItem[] = pinned
 		.filter((resource) => resource.status !== "ok")
 		.map((resource) => ({

--- a/site/src/pages/AgentsPage/components/contextResources.ts
+++ b/site/src/pages/AgentsPage/components/contextResources.ts
@@ -153,7 +153,6 @@ type DirectoryGroup<T> = {
 const groupByDirectory = <T extends { readonly dir: string }>(
 	items: readonly T[],
 ): readonly DirectoryGroup<T>[] => {
-	const order: string[] = [];
 	const byDir = new Map<string, T[]>();
 	for (const item of items) {
 		const existing = byDir.get(item.dir);
@@ -161,10 +160,9 @@ const groupByDirectory = <T extends { readonly dir: string }>(
 			existing.push(item);
 		} else {
 			byDir.set(item.dir, [item]);
-			order.push(item.dir);
 		}
 	}
-	return order.map((dir) => ({ dir, items: byDir.get(dir) ?? [] }));
+	return [...byDir.entries()].map(([dir, items]) => ({ dir, items }));
 };
 
 interface NormalizedContextResources {
@@ -179,6 +177,8 @@ interface NormalizedContextResources {
 	readonly mcpToolCount: number;
 	readonly mcpBytes: number;
 	readonly issueItems: readonly ContextIssueItem[];
+	// Whether any entry (including issues) exists to show in a full listing.
+	readonly hasResources: boolean;
 }
 
 // Normalize the chat's pinned context resources into the display entries the
@@ -196,8 +196,8 @@ export const normalizeContextResources = (
 			path: resource.source,
 			dir: getPathDirname(resource.source),
 		}))
-		// Drop entries with no usable path so an empty marker never renders as a
-		// nameless "Context files" row.
+		// Drop entries with no usable path or name (here and below) so an empty
+		// marker never renders as a blank row.
 		.filter((file) => file.path.trim().length > 0);
 	const skillItems: readonly ContextSkillItem[] = pinned
 		.filter((resource) => resource.kind === "skill" && resource.status === "ok")
@@ -207,8 +207,6 @@ export const normalizeContextResources = (
 			description: resource.skill_description,
 			dir: getPathDirname(resource.source),
 		}))
-		// Drop entries with no usable name so an empty skill marker never renders
-		// as a blank row.
 		.filter((skill) => skill.name.trim().length > 0);
 	// MCP configs are shown by their full path so multiple .mcp.json files
 	// (e.g. ~/.mcp.json and ~/project/.mcp.json) stay disambiguated; servers
@@ -228,8 +226,6 @@ export const normalizeContextResources = (
 			source: resource.source,
 			tools: resource.tools ?? [],
 		}))
-		// Drop entries with no usable name so an empty MCP marker never renders
-		// as a blank row.
 		.filter((server) => server.name.trim().length > 0);
 	// Pinned resources the agent could not use (invalid skill, unreadable or
 	// oversize file) are surfaced as issues with their error so the failure is
@@ -250,8 +246,6 @@ export const normalizeContextResources = (
 
 	return {
 		fileItems,
-		// Group files and skills by directory so every context root is labeled,
-		// keeping resources pulled from different directories distinguishable.
 		fileGroups: groupByDirectory(fileItems),
 		fileBytes: sumResourceBytes(pinned, ["instruction_file"]),
 		skillItems,
@@ -265,5 +259,11 @@ export const normalizeContextResources = (
 		),
 		mcpBytes: sumResourceBytes(pinned, ["mcp_config", "mcp_server"]),
 		issueItems,
+		hasResources:
+			fileItems.length > 0 ||
+			skillItems.length > 0 ||
+			mcpConfigItems.length > 0 ||
+			mcpServerItems.length > 0 ||
+			issueItems.length > 0,
 	};
 };

--- a/site/src/pages/AgentsPage/components/contextResources.ts
+++ b/site/src/pages/AgentsPage/components/contextResources.ts
@@ -49,7 +49,6 @@ type ContextIssueItem = {
 	readonly source: string;
 };
 
-// Human-readable label per resource kind, used in the issues list.
 export const RESOURCE_KIND_LABELS: Record<ChatContextResourceKind, string> = {
 	instruction_file: "file",
 	skill: "skill",
@@ -91,8 +90,6 @@ export const getPercentUsed = (
 	return (used / limit) * 100;
 };
 
-// One-line usage summary shown in both the compact popover and the details
-// dialog header.
 export const formatContextUsageLine = (
 	usage: AgentContextUsage | null,
 ): string => {
@@ -119,8 +116,6 @@ export const getCompactionThresholdPercent = (
 	return usage.compressionThreshold;
 };
 
-// "1 skill" / "3 skills" count labels for the compact popover summary lines
-// and the per-server tool counts in the details dialog.
 export const countLabel = (count: number, noun: string): string =>
 	`${count} ${noun}${count === 1 ? "" : "s"}`;
 

--- a/site/src/utils/mobile.ts
+++ b/site/src/utils/mobile.ts
@@ -1,3 +1,5 @@
+export const mobileViewportMediaQuery = "(max-width: 639px)";
+
 /**
  * Returns `true` when the viewport width is at or below the `sm`
  * Tailwind breakpoint (< 640 px), which is a reasonable proxy for a
@@ -5,7 +7,7 @@
  * virtual keyboard to pop up unexpectedly.
  */
 export const isMobileViewport = (): boolean => {
-	return window.matchMedia("(max-width: 639px)").matches;
+	return window.matchMedia(mobileViewportMediaQuery).matches;
 };
 
 export const belowMdViewportMediaQuery = "(max-width: 767px)";


### PR DESCRIPTION
Splits the context usage indicator in the agent chat input into a compact hover popover plus a full "Context details" dialog.

## Changes

- `ContextUsageIndicator.tsx`: the ring now shows a compact summary on hover (usage line, compaction threshold, resource counts, issue count); clicking the ring or the popover link opens the details dialog. Mobile keeps tap-to-toggle. Empty context hides the link and makes the ring click a no-op.
- `ContextDetailsDialog.tsx` (new): collapsible tree of context files, skills, MCP configs/servers/tools, and issues, with per-section byte totals, description tooltips, and the dirty/error refresh footer shared with the popover.
- `contextResources.ts` (new): normalization and formatting helpers shared by the popover and dialog, with unit tests.
- Stories: dialog stories own the exhaustive content assertions; indicator stories cover the compact summary, dialog-open flows, dirty/error, and empty states.

## Testing

- `pnpm check`, `pnpm lint` (tsc, React Compiler, knip)
- `pnpm test contextResources.test.ts` (11 tests)
- `pnpm test:storybook` for both story files (13 tests)

> This PR was created by Mux on behalf of Mike.
