### PR TITLE
feat: add chat-single-system-message experiment to squash system prompts

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -19619,12 +19619,14 @@ const docTemplate = `{
                 "minimum-implicit-member",
                 "ai-gateway-cost-control",
                 "chat-advisor",
-                "chat-virtual-desktop"
+                "chat-virtual-desktop",
+                "chat-single-system-message"
             ],
             "x-enum-comments": {
                 "ExperimentAIGatewayCostControl": "Enables AI Gateway cost control functionality.",
                 "ExperimentAutoFillParameters": "This should not be taken out of experiments until we have redesigned the feature.",
                 "ExperimentChatAdvisor": "Enables the advisor tool for root agent chats.",
+                "ExperimentChatSingleSystemMessage": "Squashes chat system messages into one for models that only support a single system message.",
                 "ExperimentChatVirtualDesktop": "Enables virtual desktop and computer use provider for agents.",
                 "ExperimentExample": "This isn't used for anything.",
                 "ExperimentMCPServerHTTP": "Enables the MCP HTTP server functionality.",
@@ -19647,7 +19649,8 @@ const docTemplate = `{
                 "Allows organizations to deviate from the default organization-member roles, in support of Gateway Accounts.",
                 "Enables AI Gateway cost control functionality.",
                 "Enables the advisor tool for root agent chats.",
-                "Enables virtual desktop and computer use provider for agents."
+                "Enables virtual desktop and computer use provider for agents.",
+                "Squashes chat system messages into one for models that only support a single system message."
             ],
             "x-enum-varnames": [
                 "ExperimentExample",
@@ -19661,7 +19664,8 @@ const docTemplate = `{
                 "ExperimentMinimumImplicitMember",
                 "ExperimentAIGatewayCostControl",
                 "ExperimentChatAdvisor",
-                "ExperimentChatVirtualDesktop"
+                "ExperimentChatVirtualDesktop",
+                "ExperimentChatSingleSystemMessage"
             ]
         },
         "codersdk.ExternalAPIKeyScopes": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -17812,12 +17812,14 @@
 				"minimum-implicit-member",
 				"ai-gateway-cost-control",
 				"chat-advisor",
-				"chat-virtual-desktop"
+				"chat-virtual-desktop",
+				"chat-single-system-message"
 			],
 			"x-enum-comments": {
 				"ExperimentAIGatewayCostControl": "Enables AI Gateway cost control functionality.",
 				"ExperimentAutoFillParameters": "This should not be taken out of experiments until we have redesigned the feature.",
 				"ExperimentChatAdvisor": "Enables the advisor tool for root agent chats.",
+				"ExperimentChatSingleSystemMessage": "Squashes chat system messages into one for models that only support a single system message.",
 				"ExperimentChatVirtualDesktop": "Enables virtual desktop and computer use provider for agents.",
 				"ExperimentExample": "This isn't used for anything.",
 				"ExperimentMCPServerHTTP": "Enables the MCP HTTP server functionality.",
@@ -17840,7 +17842,8 @@
 				"Allows organizations to deviate from the default organization-member roles, in support of Gateway Accounts.",
 				"Enables AI Gateway cost control functionality.",
 				"Enables the advisor tool for root agent chats.",
-				"Enables virtual desktop and computer use provider for agents."
+				"Enables virtual desktop and computer use provider for agents.",
+				"Squashes chat system messages into one for models that only support a single system message."
 			],
 			"x-enum-varnames": [
 				"ExperimentExample",
@@ -17854,7 +17857,8 @@
 				"ExperimentMinimumImplicitMember",
 				"ExperimentAIGatewayCostControl",
 				"ExperimentChatAdvisor",
-				"ExperimentChatVirtualDesktop"
+				"ExperimentChatVirtualDesktop",
+				"ExperimentChatSingleSystemMessage"
 			]
 		},
 		"codersdk.ExternalAPIKeyScopes": {

--- a/coderd/x/chatd/chatprompt/chatprompt.go
+++ b/coderd/x/chatd/chatprompt/chatprompt.go
@@ -271,6 +271,38 @@ func InsertSystem(prompt []fantasy.Message, instruction string) []fantasy.Messag
 	return out
 }
 
+// SquashSystem merges the leading contiguous block of system messages
+// into a single system message, for models that only accept one system
+// message per request. Text parts are joined with blank lines; the rest
+// of the prompt is returned unchanged.
+func SquashSystem(prompt []fantasy.Message) []fantasy.Message {
+	systemEnd := 0
+	for systemEnd < len(prompt) && prompt[systemEnd].Role == fantasy.MessageRoleSystem {
+		systemEnd++
+	}
+	if systemEnd <= 1 {
+		return prompt
+	}
+
+	texts := make([]string, 0, systemEnd)
+	for _, message := range prompt[:systemEnd] {
+		for _, part := range message.Content {
+			if textPart, ok := fantasy.AsMessagePart[fantasy.TextPart](part); ok {
+				texts = append(texts, textPart.Text)
+			}
+		}
+	}
+
+	out := make([]fantasy.Message, 0, len(prompt)-systemEnd+1)
+	out = append(out, fantasy.Message{
+		Role: fantasy.MessageRoleSystem,
+		Content: []fantasy.MessagePart{
+			fantasy.TextPart{Text: strings.Join(texts, "\n\n")},
+		},
+	})
+	return append(out, prompt[systemEnd:]...)
+}
+
 const (
 	// ContentVersionV0 is the legacy content format. Parsing uses
 	// role-aware heuristics to distinguish fantasy envelope format

--- a/coderd/x/chatd/chatprompt/chatprompt_test.go
+++ b/coderd/x/chatd/chatprompt/chatprompt_test.go
@@ -3323,3 +3323,29 @@ func TestPartFromContent_ExecuteToolParsedCommands(t *testing.T) {
 		})
 	}
 }
+
+func TestSquashSystem(t *testing.T) {
+	t.Parallel()
+
+	text := func(role fantasy.MessageRole, s string) fantasy.Message {
+		return fantasy.Message{Role: role, Content: []fantasy.MessagePart{fantasy.TextPart{Text: s}}}
+	}
+
+	prompt := []fantasy.Message{
+		text(fantasy.MessageRoleSystem, "one"),
+		text(fantasy.MessageRoleSystem, "two"),
+		text(fantasy.MessageRoleSystem, "three"),
+		text(fantasy.MessageRoleUser, "hello"),
+	}
+	got := chatprompt.SquashSystem(prompt)
+	require.Len(t, got, 2)
+	require.Equal(t, fantasy.MessageRoleSystem, got[0].Role)
+	require.Equal(t, "one\n\ntwo\n\nthree", got[0].Content[0].(fantasy.TextPart).Text)
+	require.Equal(t, fantasy.MessageRoleUser, got[1].Role)
+
+	// A single (or zero) system message is returned unchanged.
+	single := []fantasy.Message{text(fantasy.MessageRoleSystem, "one"), text(fantasy.MessageRoleUser, "hi")}
+	require.Equal(t, single, chatprompt.SquashSystem(single))
+	empty := []fantasy.Message{}
+	require.Equal(t, empty, chatprompt.SquashSystem(empty))
+}

--- a/coderd/x/chatd/generation_preparer.go
+++ b/coderd/x/chatd/generation_preparer.go
@@ -359,6 +359,11 @@ func (server *Server) prepareGeneration(
 	}
 	prompt = renderPlanPathPrompt(prompt, planPathBlock)
 	setAdvisorPromptSnapshot(prompt)
+	// Squash after the advisor snapshot so stripAdvisorGuidanceBlock can
+	// still match the guidance block as a whole message.
+	if server.experiments.Enabled(codersdk.ExperimentChatSingleSystemMessage) {
+		prompt = chatprompt.SquashSystem(prompt)
+	}
 
 	storeChatAttachment := server.newStoreChatAttachmentFunc(&workspaceCtx)
 	tools := []fantasy.AgentTool{

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -5213,18 +5213,19 @@ type Experiment string
 
 const (
 	// Add new experiments here!
-	ExperimentExample               Experiment = "example"                 // This isn't used for anything.
-	ExperimentAutoFillParameters    Experiment = "auto-fill-parameters"    // This should not be taken out of experiments until we have redesigned the feature.
-	ExperimentNotifications         Experiment = "notifications"           // Sends notifications via SMTP and webhooks following certain events.
-	ExperimentWorkspaceUsage        Experiment = "workspace-usage"         // Enables the new workspace usage tracking.
-	ExperimentOAuth2                Experiment = "oauth2"                  // Enables OAuth2 provider functionality.
-	ExperimentMCPServerHTTP         Experiment = "mcp-server-http"         // Enables the MCP HTTP server functionality.
-	ExperimentWorkspaceBuildUpdates Experiment = "workspace-build-updates" // Enables publishing workspace build updates to the all builds pubsub channel.
-	ExperimentNATSPubsub            Experiment = "nats_pubsub"             // Enables embedded NATS pubsub.
-	ExperimentMinimumImplicitMember Experiment = "minimum-implicit-member" // Allows organizations to deviate from the default organization-member roles, in support of Gateway Accounts.
-	ExperimentAIGatewayCostControl  Experiment = "ai-gateway-cost-control" // Enables AI Gateway cost control functionality.
-	ExperimentChatAdvisor           Experiment = "chat-advisor"            // Enables the advisor tool for root agent chats.
-	ExperimentChatVirtualDesktop    Experiment = "chat-virtual-desktop"    // Enables virtual desktop and computer use provider for agents.
+	ExperimentExample                 Experiment = "example"                    // This isn't used for anything.
+	ExperimentAutoFillParameters      Experiment = "auto-fill-parameters"       // This should not be taken out of experiments until we have redesigned the feature.
+	ExperimentNotifications           Experiment = "notifications"              // Sends notifications via SMTP and webhooks following certain events.
+	ExperimentWorkspaceUsage          Experiment = "workspace-usage"            // Enables the new workspace usage tracking.
+	ExperimentOAuth2                  Experiment = "oauth2"                     // Enables OAuth2 provider functionality.
+	ExperimentMCPServerHTTP           Experiment = "mcp-server-http"            // Enables the MCP HTTP server functionality.
+	ExperimentWorkspaceBuildUpdates   Experiment = "workspace-build-updates"    // Enables publishing workspace build updates to the all builds pubsub channel.
+	ExperimentNATSPubsub              Experiment = "nats_pubsub"                // Enables embedded NATS pubsub.
+	ExperimentMinimumImplicitMember   Experiment = "minimum-implicit-member"    // Allows organizations to deviate from the default organization-member roles, in support of Gateway Accounts.
+	ExperimentAIGatewayCostControl    Experiment = "ai-gateway-cost-control"    // Enables AI Gateway cost control functionality.
+	ExperimentChatAdvisor             Experiment = "chat-advisor"               // Enables the advisor tool for root agent chats.
+	ExperimentChatVirtualDesktop      Experiment = "chat-virtual-desktop"       // Enables virtual desktop and computer use provider for agents.
+	ExperimentChatSingleSystemMessage Experiment = "chat-single-system-message" // Squashes chat system messages into one for models that only support a single system message.
 )
 
 func (e Experiment) DisplayName() string {
@@ -5253,6 +5254,8 @@ func (e Experiment) DisplayName() string {
 		return "Chat Advisor"
 	case ExperimentChatVirtualDesktop:
 		return "Chat Virtual Desktop"
+	case ExperimentChatSingleSystemMessage:
+		return "Chat Single System Message"
 	default:
 		// Split on hyphen and convert to title case
 		// e.g. "mcp-server-http" -> "Mcp Server Http"
@@ -5275,6 +5278,7 @@ var ExperimentsKnown = Experiments{
 	ExperimentAIGatewayCostControl,
 	ExperimentChatAdvisor,
 	ExperimentChatVirtualDesktop,
+	ExperimentChatSingleSystemMessage,
 }
 
 // ExperimentsSafe should include all experiments that are safe for

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -7093,9 +7093,9 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 
 #### Enumerated Values
 
-| Value(s)                                                                                                                                                                                                                                   |
-|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `ai-gateway-cost-control`, `auto-fill-parameters`, `chat-advisor`, `chat-virtual-desktop`, `example`, `mcp-server-http`, `minimum-implicit-member`, `nats_pubsub`, `notifications`, `oauth2`, `workspace-build-updates`, `workspace-usage` |
+| Value(s)                                                                                                                                                                                                                                                                 |
+|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `ai-gateway-cost-control`, `auto-fill-parameters`, `chat-advisor`, `chat-single-system-message`, `chat-virtual-desktop`, `example`, `mcp-server-http`, `minimum-implicit-member`, `nats_pubsub`, `notifications`, `oauth2`, `workspace-build-updates`, `workspace-usage` |
 
 ## codersdk.ExternalAPIKeyScopes
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -4597,6 +4597,7 @@ export type Experiment =
 	| "ai-gateway-cost-control"
 	| "auto-fill-parameters"
 	| "chat-advisor"
+	| "chat-single-system-message"
 	| "chat-virtual-desktop"
 	| "example"
 	| "mcp-server-http"
@@ -4611,6 +4612,7 @@ export const Experiments: Experiment[] = [
 	"ai-gateway-cost-control",
 	"auto-fill-parameters",
 	"chat-advisor",
+	"chat-single-system-message",
 	"chat-virtual-desktop",
 	"example",
 	"mcp-server-http",


### PR DESCRIPTION
Adds the `chat-single-system-message` experiment. When enabled, chatd merges the leading contiguous block of system messages into a single system message before sending the prompt to the model, for models such as Qwen 3.5 that only accept one system message per request.

## Changes

- `codersdk/deployment.go`: new `ExperimentChatSingleSystemMessage` (+ display name, `ExperimentsKnown`)
- `coderd/x/chatd/chatprompt`: new `SquashSystem` helper that joins leading system-message text parts with blank lines
- `coderd/x/chatd/generation_preparer.go`: squash the prompt when the experiment is enabled, after the advisor snapshot so `stripAdvisorGuidanceBlock` still matches whole messages; the squashed prompt flows to both generation and compaction
- Generated artifacts via `make gen`

Persisted chat history is untouched; squashing happens at send time only, so the experiment can be toggled freely.

<details><summary>Notes / skipped</summary>

- Skipped squashing in `chatadvisor/handoff.go` and `quickgen.go`; those paths build their own short message lists and can adopt `SquashSystem` if they need to run against single-system-message models.
- A per-model-config option may be the better long-term home if mixed fleets (Qwen alongside Claude/GPT) need this per model; the experiment keeps the first iteration deployment-wide and minimal.

</details>

---

_This PR was generated by Coder Agents on behalf of @DanielleMaywood._