### PR TITLE
ci(.github): allowlist npmjs.com in linkspector link check

### DIFF
--- a/.github/.linkspector.yml
+++ b/.github/.linkspector.yml
@@ -36,5 +36,9 @@ ignorePatterns:
   - pattern: "openai.com"
   # merriam-webster.com returns 403 from GitHub runner IPs
   - pattern: "merriam-webster.com"
+  # npmjs.com returns 403 to CI/datacenter IPs (incl. GitHub runners)
+  # regardless of user agent. The npm registry API is the authoritative
+  # existence check for these packages.
+  - pattern: "npmjs.com"
 aliveStatusCodes:
   - 200

--- a/.github/.linkspector.yml
+++ b/.github/.linkspector.yml
@@ -36,9 +36,7 @@ ignorePatterns:
   - pattern: "openai.com"
   # merriam-webster.com returns 403 from GitHub runner IPs
   - pattern: "merriam-webster.com"
-  # npmjs.com returns 403 to CI/datacenter IPs (incl. GitHub runners)
-  # regardless of user agent. The npm registry API is the authoritative
-  # existence check for these packages.
+  # npmjs.com returns 403 from GitHub runner IPs
   - pattern: "npmjs.com"
 aliveStatusCodes:
   - 200


### PR DESCRIPTION
## What

`npmjs.com` package pages return **HTTP 403** to automated link checkers and datacenter IPs (including GitHub Actions runners), regardless of user agent. This makes the scheduled `weekly-docs` Linkspector check fail on a valid link and fire a false-positive Slack alert every Monday. On PRs it can also red-X any change that touches the affected file.

This adds `npmjs.com` to `ignorePatterns` in `.github/.linkspector.yml`, consistent with how the repo already allowlists other sites that block runner IPs (for example `merriam-webster.com`, `code.visualstudio.com`, `dotnet.microsoft.com`).

## Affected link

Both occurrences are in `docs/about/contributing/frontend.md` (lines 43 and 293) and point to the same page, `https://www.npmjs.com/package/@coder/pixel-storybook`. These are the only `npmjs` links under `docs/`.

Failing run: https://github.com/coder/coder/actions/runs/28785524667

## Verification

The link is valid; the failure is IP/environment-specific bot-blocking, not a dead link.

```text
# Linkspector on the GitHub runner (from the failing run):
Cannot reach https://www.npmjs.com/package/@coder/pixel-storybook Status: 403   (x2)

# curl from a datacenter IP (HEAD, GET, and browser User-Agent all 403):
HEAD (default UA):        403
GET  (default UA):        403
GET  (Chrome UA):         403

# npm registry API (authoritative existence check):
GET registry.npmjs.org/@coder%2Fpixel-storybook   200
```

Running Linkspector locally against `frontend.md` (browser path, non-runner IP) reports the link as valid, confirming the 403 is specific to blocked runner IPs. The edited config parses and runs cleanly under Linkspector, with `npmjs.com` present in `ignorePatterns` (25 patterns total).

## AI disclosure

This change was generated by **Coder Agents** (an AI assistant) and reviewed by @nickvigilante before submission, per [`AI_CONTRIBUTING.md`](https://github.com/coder/coder/blob/main/docs/about/contributing/AI_CONTRIBUTING.md).

<details>
<summary>Investigation &amp; decision log</summary>

1. **Reproduced the report.** The scheduled `weekly-docs` run failed at the "Check Markdown links" step. `gh run view --log-failed` showed exactly two Linkspector errors, both `Cannot reach https://www.npmjs.com/package/@coder/pixel-storybook Status: 403`, in `docs/about/contributing/frontend.md` (lines 43, 293).
2. **Confirmed it is a false positive.** `curl` from a datacenter IP returns 403 for HEAD, GET, and a real Chrome User-Agent, while the npm registry API returns 200 for the package. So the package page exists and works in normal browsers; npmjs.com just blocks automated/runner traffic.
3. **Scoped the change.** `git grep npmjs docs/` returns only those two links, both on `www.npmjs.com`. A domain-level `npmjs.com` pattern is a substring match that covers both and future npm links.
4. **Chose the established fix.** `.github/.linkspector.yml` already allowlists ~10 sites that 403 runner IPs. Added `npmjs.com` alongside them with an explanatory comment, matching the existing `merriam-webster.com` style.
5. **Validated.** YAML parses; Linkspector accepts the updated config; `npmjs.com` is present in `ignorePatterns`.

</details>
