### PR TITLE
feat: log tailnet tunnels to the connection log

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -17931,7 +17931,7 @@ const docTemplate = `{
                     "$ref": "#/definitions/codersdk.ConnectionType"
                 },
                 "web_info": {
-                    "description": "WebInfo is only set when ` + "`" + `type` + "`" + ` is one of:\n- ` + "`" + `ConnectionTypePortForwarding` + "`" + `\n- ` + "`" + `ConnectionTypeWorkspaceApp` + "`" + `",
+                    "description": "WebInfo is only set when ` + "`" + `type` + "`" + ` is one of:\n- ` + "`" + `ConnectionTypePortForwarding` + "`" + `\n- ` + "`" + `ConnectionTypeWorkspaceApp` + "`" + `\n- ` + "`" + `ConnectionTypeTailnet` + "`" + `",
                     "allOf": [
                         {
                             "$ref": "#/definitions/codersdk.ConnectionLogWebInfo"
@@ -18024,7 +18024,8 @@ const docTemplate = `{
                 "jetbrains",
                 "reconnecting_pty",
                 "workspace_app",
-                "port_forwarding"
+                "port_forwarding",
+                "tailnet"
             ],
             "x-enum-varnames": [
                 "ConnectionTypeSSH",
@@ -18032,7 +18033,8 @@ const docTemplate = `{
                 "ConnectionTypeJetBrains",
                 "ConnectionTypeReconnectingPTY",
                 "ConnectionTypeWorkspaceApp",
-                "ConnectionTypePortForwarding"
+                "ConnectionTypePortForwarding",
+                "ConnectionTypeTailnet"
             ]
         },
         "codersdk.ConvertLoginRequest": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -16182,7 +16182,7 @@
 					"$ref": "#/definitions/codersdk.ConnectionType"
 				},
 				"web_info": {
-					"description": "WebInfo is only set when `type` is one of:\n- `ConnectionTypePortForwarding`\n- `ConnectionTypeWorkspaceApp`",
+					"description": "WebInfo is only set when `type` is one of:\n- `ConnectionTypePortForwarding`\n- `ConnectionTypeWorkspaceApp`\n- `ConnectionTypeTailnet`",
 					"allOf": [
 						{
 							"$ref": "#/definitions/codersdk.ConnectionLogWebInfo"
@@ -16275,7 +16275,8 @@
 				"jetbrains",
 				"reconnecting_pty",
 				"workspace_app",
-				"port_forwarding"
+				"port_forwarding",
+				"tailnet"
 			],
 			"x-enum-varnames": [
 				"ConnectionTypeSSH",
@@ -16283,7 +16284,8 @@
 				"ConnectionTypeJetBrains",
 				"ConnectionTypeReconnectingPTY",
 				"ConnectionTypeWorkspaceApp",
-				"ConnectionTypePortForwarding"
+				"ConnectionTypePortForwarding",
+				"ConnectionTypeTailnet"
 			]
 		},
 		"codersdk.ConvertLoginRequest": {

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -357,7 +357,8 @@ CREATE TYPE connection_type AS ENUM (
     'jetbrains',
     'reconnecting_pty',
     'workspace_app',
-    'port_forwarding'
+    'port_forwarding',
+    'tailnet'
 );
 
 CREATE TYPE cors_behavior AS ENUM (
@@ -2181,9 +2182,9 @@ CREATE TABLE connection_logs (
 
 COMMENT ON COLUMN connection_logs.code IS 'Either the HTTP status code of the web request, or the exit code of an SSH connection. For non-web connections, this is Null until we receive a disconnect event for the same connection_id.';
 
-COMMENT ON COLUMN connection_logs.user_agent IS 'Null for SSH events. For web connections, this is the User-Agent header from the request.';
+COMMENT ON COLUMN connection_logs.user_agent IS 'Null for agent-reported (SSH) events. For HTTP-initiated connections (workspace_app, port_forwarding, tailnet), this is the User-Agent header from the request.';
 
-COMMENT ON COLUMN connection_logs.user_id IS 'Null for SSH events. For web connections, this is the ID of the user that made the request.';
+COMMENT ON COLUMN connection_logs.user_id IS 'Null for agent-reported (SSH) events. For HTTP-initiated connections (workspace_app, port_forwarding, tailnet), this is the ID of the user that made the request.';
 
 COMMENT ON COLUMN connection_logs.slug_or_port IS 'Null for SSH events. For web connections, this is the slug of the app or the port number being forwarded.';
 

--- a/coderd/database/migrations/000539_connection_type_tailnet.down.sql
+++ b/coderd/database/migrations/000539_connection_type_tailnet.down.sql
@@ -1,0 +1,6 @@
+-- Postgres does not support removing enum values, so the down
+-- migration for the `tailnet` connection_type is a no-op.
+
+COMMENT ON COLUMN connection_logs.user_agent IS 'Null for SSH events. For web connections, this is the User-Agent header from the request.';
+
+COMMENT ON COLUMN connection_logs.user_id IS 'Null for SSH events. For web connections, this is the ID of the user that made the request.';

--- a/coderd/database/migrations/000539_connection_type_tailnet.up.sql
+++ b/coderd/database/migrations/000539_connection_type_tailnet.up.sql
@@ -1,0 +1,5 @@
+ALTER TYPE connection_type ADD VALUE IF NOT EXISTS 'tailnet';
+
+COMMENT ON COLUMN connection_logs.user_agent IS 'Null for agent-reported (SSH) events. For HTTP-initiated connections (workspace_app, port_forwarding, tailnet), this is the User-Agent header from the request.';
+
+COMMENT ON COLUMN connection_logs.user_id IS 'Null for agent-reported (SSH) events. For HTTP-initiated connections (workspace_app, port_forwarding, tailnet), this is the ID of the user that made the request.';

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -1703,6 +1703,7 @@ const (
 	ConnectionTypeReconnectingPty ConnectionType = "reconnecting_pty"
 	ConnectionTypeWorkspaceApp    ConnectionType = "workspace_app"
 	ConnectionTypePortForwarding  ConnectionType = "port_forwarding"
+	ConnectionTypeTailnet         ConnectionType = "tailnet"
 )
 
 func (e *ConnectionType) Scan(src interface{}) error {
@@ -1747,7 +1748,8 @@ func (e ConnectionType) Valid() bool {
 		ConnectionTypeJetbrains,
 		ConnectionTypeReconnectingPty,
 		ConnectionTypeWorkspaceApp,
-		ConnectionTypePortForwarding:
+		ConnectionTypePortForwarding,
+		ConnectionTypeTailnet:
 		return true
 	}
 	return false
@@ -1761,6 +1763,7 @@ func AllConnectionTypeValues() []ConnectionType {
 		ConnectionTypeReconnectingPty,
 		ConnectionTypeWorkspaceApp,
 		ConnectionTypePortForwarding,
+		ConnectionTypeTailnet,
 	}
 }
 
@@ -5067,9 +5070,9 @@ type ConnectionLog struct {
 	Ip               pqtype.Inet    `db:"ip" json:"ip"`
 	// Either the HTTP status code of the web request, or the exit code of an SSH connection. For non-web connections, this is Null until we receive a disconnect event for the same connection_id.
 	Code sql.NullInt32 `db:"code" json:"code"`
-	// Null for SSH events. For web connections, this is the User-Agent header from the request.
+	// Null for agent-reported (SSH) events. For HTTP-initiated connections (workspace_app, port_forwarding, tailnet), this is the User-Agent header from the request.
 	UserAgent sql.NullString `db:"user_agent" json:"user_agent"`
-	// Null for SSH events. For web connections, this is the ID of the user that made the request.
+	// Null for agent-reported (SSH) events. For HTTP-initiated connections (workspace_app, port_forwarding, tailnet), this is the ID of the user that made the request.
 	UserID uuid.NullUUID `db:"user_id" json:"user_id"`
 	// Null for SSH events. For web connections, this is the slug of the app or the port number being forwarded.
 	SlugOrPort sql.NullString `db:"slug_or_port" json:"slug_or_port"`

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -13067,7 +13067,7 @@ SELECT COUNT(*) AS count FROM (
 				(($13 = 'ongoing' AND disconnect_time IS NULL) OR
 				($13 = 'completed' AND disconnect_time IS NOT NULL)) AND
 				-- Exclude web events, since we don't know their close time.
-				"type" NOT IN ('workspace_app', 'port_forwarding')
+				"type" NOT IN ('workspace_app', 'port_forwarding', 'tailnet')
 			ELSE true
 		END
 		-- Authorize Filter clause will be injected below in
@@ -13261,7 +13261,7 @@ WHERE
 			(($13 = 'ongoing' AND disconnect_time IS NULL) OR
 			($13 = 'completed' AND disconnect_time IS NOT NULL)) AND
 			-- Exclude web events, since we don't know their close time.
-			"type" NOT IN ('workspace_app', 'port_forwarding')
+			"type" NOT IN ('workspace_app', 'port_forwarding', 'tailnet')
 		ELSE true
 	END
 	-- Authorize Filter clause will be injected below in

--- a/coderd/database/queries/connectionlogs.sql
+++ b/coderd/database/queries/connectionlogs.sql
@@ -116,7 +116,7 @@ WHERE
 			((@status = 'ongoing' AND disconnect_time IS NULL) OR
 			(@status = 'completed' AND disconnect_time IS NOT NULL)) AND
 			-- Exclude web events, since we don't know their close time.
-			"type" NOT IN ('workspace_app', 'port_forwarding')
+			"type" NOT IN ('workspace_app', 'port_forwarding', 'tailnet')
 		ELSE true
 	END
 	-- Authorize Filter clause will be injected below in
@@ -231,7 +231,7 @@ SELECT COUNT(*) AS count FROM (
 				((@status = 'ongoing' AND disconnect_time IS NULL) OR
 				(@status = 'completed' AND disconnect_time IS NOT NULL)) AND
 				-- Exclude web events, since we don't know their close time.
-				"type" NOT IN ('workspace_app', 'port_forwarding')
+				"type" NOT IN ('workspace_app', 'port_forwarding', 'tailnet')
 			ELSE true
 		END
 		-- Authorize Filter clause will be injected below in

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -1367,6 +1367,52 @@ func (api *API) workspaceAgentClientCoordinate(rw http.ResponseWriter, r *http.R
 		})
 		return
 	}
+
+	// Record a connection log entry for this tunnel so that enterprise
+	// auditors can attribute subsequent SSH/IDE activity inside the
+	// workspace back to the Coder user and client that established it.
+	// The agent-reported SSH connection log rows do not have this
+	// information (see coderd/agentapi/connectionlog.go). We only log
+	// when the caller is an authenticated user; requests proxied by a
+	// workspace proxy carry no API key on this route.
+	if apiKey, ok := httpmw.APIKeyOptional(r); ok {
+		userAgent := r.UserAgent()
+		connLogger := *api.ConnectionLogger.Load()
+		err := connLogger.Upsert(ctx, database.UpsertConnectionLogParams{
+			ID:               uuid.New(),
+			Time:             dbtime.Now(),
+			OrganizationID:   waws.WorkspaceTable.OrganizationID,
+			WorkspaceOwnerID: waws.WorkspaceTable.OwnerID,
+			WorkspaceID:      waws.WorkspaceTable.ID,
+			WorkspaceName:    waws.WorkspaceTable.Name,
+			AgentName:        waws.WorkspaceAgent.Name,
+			Type:             database.ConnectionTypeTailnet,
+			IP:               database.ParseIP(r.RemoteAddr),
+			Code: sql.NullInt32{
+				Int32: http.StatusSwitchingProtocols,
+				Valid: true,
+			},
+			UserAgent: sql.NullString{String: userAgent, Valid: userAgent != ""},
+			UserID:    uuid.NullUUID{UUID: apiKey.UserID, Valid: true},
+			// ConnectionID is intentionally left unset so that each
+			// handshake produces its own row. Reusing peerID here
+			// would cause resume_token reconnects to upsert into the
+			// existing row without updating ip/user_agent.
+			ConnectionID:     uuid.NullUUID{},
+			ConnectionStatus: database.ConnectionStatusConnected,
+			// N/A
+			SlugOrPort:       sql.NullString{},
+			DisconnectReason: sql.NullString{},
+		})
+		if err != nil {
+			api.Logger.Error(ctx, "upsert tailnet connection log failed",
+				slog.F("workspace_id", waws.WorkspaceTable.ID),
+				slog.F("user_id", apiKey.UserID),
+				slog.Error(err),
+			)
+		}
+	}
+
 	ctx, wsNetConn := codersdk.WebsocketNetConn(ctx, conn, websocket.MessageBinary)
 	defer wsNetConn.Close()
 

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/coder/coder/v2/coderd/agentapi/metadatabatcher"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/coderdtest/oidctest"
+	"github.com/coder/coder/v2/coderd/connectionlog"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
@@ -914,6 +915,49 @@ func TestWorkspaceAgentTailnet(t *testing.T) {
 	_ = sshClient.Close()
 	_ = conn.Close()
 	require.Equal(t, "test", strings.TrimSpace(string(output)))
+}
+
+func TestWorkspaceAgentClientCoordinate_ConnectionLog(t *testing.T) {
+	t.Parallel()
+	connLogger := connectionlog.NewFake()
+	client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{
+		ConnectionLogger: connLogger,
+	})
+	user := coderdtest.CreateFirstUser(t, client)
+
+	r := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+		OrganizationID: user.OrganizationID,
+		OwnerID:        user.UserID,
+	}).WithAgent().Do()
+
+	_ = agenttest.New(t, client.URL, r.AgentToken)
+	resources := coderdtest.AwaitWorkspaceAgents(t, client, r.Workspace.ID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	defer cancel()
+
+	conn, err := workspacesdk.New(client).
+		DialAgent(ctx, resources[0].Agents[0].ID, &workspacesdk.DialAgentOptions{
+			Logger: testutil.Logger(t).Named("client"),
+		})
+	require.NoError(t, err)
+	defer conn.Close()
+	conn.AwaitReachable(ctx)
+
+	require.Eventually(t, func() bool {
+		return connLogger.Contains(t, database.UpsertConnectionLogParams{
+			OrganizationID:   user.OrganizationID,
+			WorkspaceOwnerID: user.UserID,
+			WorkspaceID:      r.Workspace.ID,
+			WorkspaceName:    r.Workspace.Name,
+			AgentName:        resources[0].Agents[0].Name,
+			Type:             database.ConnectionTypeTailnet,
+			UserID: uuid.NullUUID{
+				UUID:  user.UserID,
+				Valid: true,
+			},
+		})
+	}, testutil.WaitShort, testutil.IntervalFast)
 }
 
 func TestWorkspaceAgentClientCoordinate_BadVersion(t *testing.T) {

--- a/codersdk/connectionlog.go
+++ b/codersdk/connectionlog.go
@@ -26,6 +26,7 @@ type ConnectionLog struct {
 	// WebInfo is only set when `type` is one of:
 	// - `ConnectionTypePortForwarding`
 	// - `ConnectionTypeWorkspaceApp`
+	// - `ConnectionTypeTailnet`
 	WebInfo *ConnectionLogWebInfo `json:"web_info,omitempty"`
 
 	// SSHInfo is only set when `type` is one of:
@@ -46,6 +47,12 @@ const (
 	ConnectionTypeReconnectingPTY ConnectionType = "reconnecting_pty"
 	ConnectionTypeWorkspaceApp    ConnectionType = "workspace_app"
 	ConnectionTypePortForwarding  ConnectionType = "port_forwarding"
+	// ConnectionTypeTailnet is recorded when a client establishes a
+	// tailnet tunnel to a workspace agent via the coordinate endpoint.
+	// Unlike the SSH-family types above (which are reported by the
+	// agent and cannot identify the connecting user), this event is
+	// written by coderd and carries the authenticated user's identity.
+	ConnectionTypeTailnet ConnectionType = "tailnet"
 )
 
 // ConnectionLogStatus is the status of a connection log entry.

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -4109,7 +4109,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `organization`             | [codersdk.MinimalOrganization](#codersdkminimalorganization)   | false    |              |                                                                                                                                                          |
 | `ssh_info`                 | [codersdk.ConnectionLogSSHInfo](#codersdkconnectionlogsshinfo) | false    |              | Ssh info is only set when `type` is one of: - `ConnectionTypeSSH` - `ConnectionTypeReconnectingPTY` - `ConnectionTypeVSCode` - `ConnectionTypeJetBrains` |
 | `type`                     | [codersdk.ConnectionType](#codersdkconnectiontype)             | false    |              |                                                                                                                                                          |
-| `web_info`                 | [codersdk.ConnectionLogWebInfo](#codersdkconnectionlogwebinfo) | false    |              | Web info is only set when `type` is one of: - `ConnectionTypePortForwarding` - `ConnectionTypeWorkspaceApp`                                              |
+| `web_info`                 | [codersdk.ConnectionLogWebInfo](#codersdkconnectionlogwebinfo) | false    |              | Web info is only set when `type` is one of: - `ConnectionTypePortForwarding` - `ConnectionTypeWorkspaceApp` - `ConnectionTypeTailnet`                    |
 | `workspace_id`             | string                                                         | false    |              |                                                                                                                                                          |
 | `workspace_name`           | string                                                         | false    |              |                                                                                                                                                          |
 | `workspace_owner_id`       | string                                                         | false    |              |                                                                                                                                                          |
@@ -4261,9 +4261,9 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 #### Enumerated Values
 
-| Value(s)                                                                             |
-|--------------------------------------------------------------------------------------|
-| `jetbrains`, `port_forwarding`, `reconnecting_pty`, `ssh`, `vscode`, `workspace_app` |
+| Value(s)                                                                                        |
+|-------------------------------------------------------------------------------------------------|
+| `jetbrains`, `port_forwarding`, `reconnecting_pty`, `ssh`, `tailnet`, `vscode`, `workspace_app` |
 
 ## codersdk.ConvertLoginRequest
 

--- a/enterprise/coderd/connectionlog.go
+++ b/enterprise/coderd/connectionlog.go
@@ -134,7 +134,8 @@ func convertConnectionLog(dblog database.GetConnectionLogsOffsetRow) codersdk.Co
 
 	switch dblog.ConnectionLog.Type {
 	case database.ConnectionTypeWorkspaceApp,
-		database.ConnectionTypePortForwarding:
+		database.ConnectionTypePortForwarding,
+		database.ConnectionTypeTailnet:
 		webInfo = &codersdk.ConnectionLogWebInfo{
 			UserAgent:  dblog.ConnectionLog.UserAgent.String,
 			User:       user,

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -3429,6 +3429,7 @@ export type ConnectionType =
 	| "port_forwarding"
 	| "reconnecting_pty"
 	| "ssh"
+	| "tailnet"
 	| "vscode"
 	| "workspace_app";
 
@@ -3437,6 +3438,7 @@ export const ConnectionTypes: ConnectionType[] = [
 	"port_forwarding",
 	"reconnecting_pty",
 	"ssh",
+	"tailnet",
 	"vscode",
 	"workspace_app",
 ];

--- a/site/src/pages/ConnectionLogPage/ConnectionLogRow/ConnectionLogDescription/ConnectionLogDescription.stories.tsx
+++ b/site/src/pages/ConnectionLogPage/ConnectionLogRow/ConnectionLogDescription/ConnectionLogDescription.stories.tsx
@@ -95,6 +95,15 @@ export const JetBrains: Story = {
 	},
 };
 
+export const Tailnet: Story = {
+	args: {
+		connectionLog: {
+			...MockWebConnectionLog,
+			type: "tailnet",
+		},
+	},
+};
+
 export const WebTerminal: Story = {
 	args: {
 		connectionLog: {

--- a/site/src/pages/ConnectionLogPage/ConnectionLogRow/ConnectionLogDescription/ConnectionLogDescription.tsx
+++ b/site/src/pages/ConnectionLogPage/ConnectionLogRow/ConnectionLogDescription/ConnectionLogDescription.tsx
@@ -89,5 +89,25 @@ export const ConnectionLogDescription: FC<ConnectionLogDescriptionProps> = ({
 				</span>
 			);
 		}
+
+		case "tailnet": {
+			if (!web_info) return null;
+			const { user } = web_info;
+			const isOwnWorkspace = user
+				? workspace_owner_username === user.username
+				: false;
+			return (
+				<span>
+					{user ? user.username : "Unauthenticated user"} established a tailnet
+					tunnel to {isOwnWorkspace ? "their" : `${workspace_owner_username}'s`}{" "}
+					<Link asChild showExternalIcon={false} className="text-base">
+						<RouterLink to={`/@${workspace_owner_username}/${workspace_name}`}>
+							<strong>{workspace_name}</strong>
+						</RouterLink>
+					</Link>{" "}
+					workspace
+				</span>
+			);
+		}
 	}
 };

--- a/site/src/utils/connection.ts
+++ b/site/src/utils/connection.ts
@@ -14,13 +14,16 @@ export const connectionTypeToFriendlyName = (type: ConnectionType): string => {
 			return "Port Forwarding";
 		case "workspace_app":
 			return "Workspace App";
+		case "tailnet":
+			return "Tailnet";
 	}
 };
 
 export const connectionTypeIsWeb = (type: ConnectionType): boolean => {
 	switch (type) {
 		case "port_forwarding":
-		case "workspace_app": {
+		case "workspace_app":
+		case "tailnet": {
 			return true;
 		}
 		case "reconnecting_pty":


### PR DESCRIPTION
Closes #27006.

### Summary

Today the connection log has no user attribution for SSH / IDE sessions. The
agent reports `ssh` / `vscode` / `jetbrains` / `reconnecting_pty` rows, but by
the time the connection reaches the agent the Coder user identity is gone — see
the comment in `coderd/agentapi/connectionlog.go`:

> `// It's not possible to tell which user connected. Once we have the
> // capability, this may be reported by the agent.`

As a result `connection_logs.user_id` is always NULL for those rows, and there
is no way to answer "which Coder user opened an SSH session into workspace X"
from the connection log alone. For enterprise audit use-cases (cross-user
workspace access, long-lived-token misuse) that's a significant gap.

Every such session is carried over a tailnet tunnel that the client opens via
`GET /api/v2/workspaceagents/{id}/coordinate`. That request is made with the
user's API key, so coderd *does* know who is connecting at that moment.

This PR adds a new `connection_type` value `tailnet` and writes one connection
log row from `workspaceAgentClientCoordinate` each time a client successfully
upgrades the coordinate WebSocket. The row carries:

- `user_id` — from `httpmw.APIKeyOptional(r)`
- `ip` / `user_agent` — from the HTTP request (real client IP once
  `CODER_PROXY_TRUSTED_*` is configured)
- `workspace_id` / `agent_name` — the tunnel target

The event is treated like the other coderd-originated connection types
(`workspace_app`, `port_forwarding`): it's a point-in-time authorization event
with no `disconnect_time`, so it's excluded from the `status:` filter and
rendered via `WebInfo` (which already surfaces the connecting user in the
dashboard).

### Why not fill `user_id` on the existing SSH rows?

Those rows are emitted by the agent over `ReportConnection`, which doesn't have
access to the Coder user or API key (the comment above is still accurate).
Plumbing identity down to the agent would be a protocol change; this approach
gets the same attribution without touching the agent API.

### What about `/api/v2/tailnet` (Coder Desktop)?

`tailnetRPCConn` is user-scoped rather than workspace-scoped, so it doesn't
have a single target workspace to log against. It already reports
`UserTailnetConnection` telemetry. I've left it out of this PR to keep the
change small; happy to follow up if there's interest in logging it too.

### Notes

- Volume: this fires once per client tunnel (not per SSH exec), so it's the
  same order of magnitude as coordinator handshakes — typically far below the
  workspace-app rate.
- Requests that arrive via workspace-proxy auth (no API key on the route) are
  skipped.
- `api_key_id` isn't recorded because `connection_logs` has no column for it;
  `user_id` + `user_agent` + `ip` is what the existing web types store too.
  I'd like to add an `api_key_id` column in a follow-up (or here, if preferred)
  so these rows — and potentially `workspace_app` / `port_forwarding` rows —
  can also record which key was used; it's available at both write sites.
- This fires for every `DialAgent` caller (`coder ssh`, `coder port-forward`,
  the VS Code extension, `coder ping`, `coder speedtest`, etc.), so a `tailnet`
  row means "user opened a tunnel to this agent", not "user ran SSH". There is
  currently no debounce on reconnect; if volume turns out to be a concern the
  same `workspace_app_audit_sessions` pattern could be applied here.
- Happy to rename `tailnet` → `tunnel` (or similar) if that reads better.

