### PR TITLE
fix(site): create workspace form width

### DIFF
--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -404,7 +404,7 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 					Go back
 				</button>
 			</div>
-			<div className="flex flex-col gap-6 max-w-screen-md mx-auto pb-96">
+			<div className="flex flex-col gap-6 w-full max-w-screen-md mx-auto pb-96">
 				<header className="flex flex-col items-start gap-3 mt-10">
 					<div className="flex items-center gap-2 justify-between w-full">
 						<span className="flex items-center gap-2">


### PR DESCRIPTION
The create-workspace form container was missing `w-full` alongside its `max-w-screen-md mx-auto` classes. When a template has no `coder_parameter`s (less content in the flex column), the container doesn't consistently fill up to its max-width on wide screens. Other pages (e.g. `TaskPage`) use the `w-full max-w-* mx-auto` pattern; this brings the create-workspace page in line with that.

Generated by Coder Agents on behalf of aslilac.