### PR TITLE
feat: improve the image management experience with template builder 

### DIFF
--- a/coderd/templatebuilder/bases/docker/README.md
+++ b/coderd/templatebuilder/bases/docker/README.md
@@ -26,7 +26,9 @@ Some options to consider:
 - [`codercom/example-base:ubuntu`](https://github.com/coder/images/tree/main/images/base) (default): minimal and lightweight, but may not include many tools developers expect by default
 - [`codercom/example-universal:ubuntu`](https://github.com/coder/images/tree/main/images/universal): catch-all image with many languages and tools available, but larger and slower to pull
 
-More language-specific images (Go, Java, Node.js, and more) are available in [coder/images](https://github.com/coder/images), and the [devcontainers/images](https://github.com/devcontainers/images) collection is another good source of ready-made development images. You can also build your own image to pre-bake the exact tools your team needs. See [Coder's image management docs](https://coder.com/docs/admin/templates/managing-templates/image-management) for additional guidance.
+More language-specific images (Go, Java, Node.js, and more) are available in [coder/images](https://github.com/coder/images), and the [devcontainers/images](https://github.com/devcontainers/images) collection is another good source of ready-made development images.
+You can also build your own image to pre-bake the exact tools your team needs.
+Visit [Coder's image management docs](https://coder.com/docs/admin/templates/managing-templates/image-management) for additional guidance.
 
 ### Infrastructure
 

--- a/coderd/templatebuilder/bases/docker/README.md
+++ b/coderd/templatebuilder/bases/docker/README.md
@@ -17,6 +17,17 @@ Provision Docker containers as [Coder workspaces](https://coder.com/docs/user-gu
 
 ## Prerequisites
 
+### Workspace image
+
+The container image determines what tools, languages, and runtimes are available in the workspace out of the box, so it has a major impact on the developer experience.
+
+Some options to consider:
+
+- [`codercom/example-base:ubuntu`](https://github.com/coder/images/tree/main/images/base) (default): minimal and lightweight, but may not include many tools developers expect by default
+- [`codercom/example-universal:ubuntu`](https://github.com/coder/images/tree/main/images/universal): catch-all image with many languages and tools available, but larger and slower to pull
+
+More language-specific images (Go, Java, Node.js, and more) are available in [coder/images](https://github.com/coder/images), and the [devcontainers/images](https://github.com/devcontainers/images) collection is another good source of ready-made development images. You can also build your own image to pre-bake the exact tools your team needs. See [Coder's image management docs](https://coder.com/docs/admin/templates/managing-templates/image-management) for additional guidance.
+
 ### Infrastructure
 
 The VM you run Coder on must have a running Docker socket and the `coder` user must be added to the Docker group:

--- a/coderd/templatebuilder/bases/docker/base.json
+++ b/coderd/templatebuilder/bases/docker/base.json
@@ -3,6 +3,6 @@
 	"display_name": "Docker",
 	"os": "linux",
 	"default_context": {
-		"container_image": "codercom/enterprise-base:ubuntu"
+		"container_image": "codercom/example-base:ubuntu"
 	}
 }

--- a/coderd/templatebuilder/bases/docker/base.json
+++ b/coderd/templatebuilder/bases/docker/base.json
@@ -4,5 +4,16 @@
 	"os": "linux",
 	"default_context": {
 		"container_image": "codercom/example-base:ubuntu"
-	}
+	},
+	"variables": [
+		{
+			"name": "container_image",
+			"type": "string",
+			"description": "Container image for workspaces. The image determines which tools and languages are available in the workspace by default. See the template README for guidance on choosing an image.",
+			"default": "codercom/example-base:ubuntu",
+			"required": false,
+			"sensitive": false,
+			"computed": false
+		}
+	]
 }

--- a/coderd/templatebuilder/bases/docker/main.tf.tmpl
+++ b/coderd/templatebuilder/bases/docker/main.tf.tmpl
@@ -166,7 +166,7 @@ resource "docker_container" "workspace" {
   {{- if .ImageOptions }}
   image = data.coder_parameter.container_image.value
   {{- else }}
-  image = "{{ .ContainerImage }}"
+  image = {{ .Variables.container_image }}
   {{- end }}
   # Uses lower() to avoid Docker restriction on container names.
   name = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}"

--- a/coderd/templatebuilder/bases/kubernetes/README.md
+++ b/coderd/templatebuilder/bases/kubernetes/README.md
@@ -30,7 +30,9 @@ Some options to consider:
 - [`codercom/example-base:ubuntu`](https://github.com/coder/images/tree/main/images/base) (default): minimal and lightweight, but may not include many tools developers expect by default
 - [`codercom/example-universal:ubuntu`](https://github.com/coder/images/tree/main/images/universal): catch-all image with many languages and tools available, but larger and slower to pull
 
-More language-specific images (Go, Java, Node.js, and more) are available in [coder/images](https://github.com/coder/images), and the [devcontainers/images](https://github.com/devcontainers/images) collection is another good source of ready-made development images. You can also build your own image to pre-bake the exact tools your team needs. See [Coder's image management docs](https://coder.com/docs/admin/templates/managing-templates/image-management) for additional guidance.
+More language-specific images (Go, Java, Node.js, and more) are available in [coder/images](https://github.com/coder/images), and the [devcontainers/images](https://github.com/devcontainers/images) collection is another good source of ready-made development images.
+You can also build your own image to pre-bake the exact tools your team needs.
+Visit [Coder's image management docs](https://coder.com/docs/admin/templates/managing-templates/image-management) for additional guidance.
 
 ### Authentication
 

--- a/coderd/templatebuilder/bases/kubernetes/README.md
+++ b/coderd/templatebuilder/bases/kubernetes/README.md
@@ -21,7 +21,16 @@ Provision Kubernetes Pods as [Coder workspaces](https://coder.com/docs/user-guid
 
 **Cluster**: This template requires an existing Kubernetes cluster
 
-**Container Image**: This template uses the [codercom/enterprise-base:ubuntu image](https://github.com/coder/enterprise-images/tree/main/images/base) with some dev tools preinstalled. To add additional tools, extend this image or build it yourself.
+### Workspace image
+
+The container image determines what tools, languages, and runtimes are available in the workspace out of the box, so it has a major impact on the developer experience.
+
+Some options to consider:
+
+- [`codercom/example-base:ubuntu`](https://github.com/coder/images/tree/main/images/base) (default): minimal and lightweight, but may not include many tools developers expect by default
+- [`codercom/example-universal:ubuntu`](https://github.com/coder/images/tree/main/images/universal): catch-all image with many languages and tools available, but larger and slower to pull
+
+More language-specific images (Go, Java, Node.js, and more) are available in [coder/images](https://github.com/coder/images), and the [devcontainers/images](https://github.com/devcontainers/images) collection is another good source of ready-made development images. You can also build your own image to pre-bake the exact tools your team needs. See [Coder's image management docs](https://coder.com/docs/admin/templates/managing-templates/image-management) for additional guidance.
 
 ### Authentication
 

--- a/coderd/templatebuilder/bases/kubernetes/base.json
+++ b/coderd/templatebuilder/bases/kubernetes/base.json
@@ -3,7 +3,7 @@
 	"display_name": "Kubernetes",
 	"os": "linux",
 	"default_context": {
-		"container_image": "codercom/enterprise-base:ubuntu"
+		"container_image": "codercom/example-base:ubuntu"
 	},
 	"variables": [
 		{

--- a/coderd/templatebuilder/bases/kubernetes/base.json
+++ b/coderd/templatebuilder/bases/kubernetes/base.json
@@ -7,6 +7,15 @@
 	},
 	"variables": [
 		{
+			"name": "container_image",
+			"type": "string",
+			"description": "Container image for workspaces. The image determines which tools and languages are available in the workspace by default. See the template README for guidance on choosing an image.",
+			"default": "codercom/example-base:ubuntu",
+			"required": false,
+			"sensitive": false,
+			"computed": false
+		},
+		{
 			"name": "use_kubeconfig",
 			"type": "bool",
 			"description": "Use host kubeconfig. Set to true if the Coder host is running outside the Kubernetes cluster for workspaces.",

--- a/coderd/templatebuilder/bases/kubernetes/main.tf.tmpl
+++ b/coderd/templatebuilder/bases/kubernetes/main.tf.tmpl
@@ -260,7 +260,7 @@ resource "kubernetes_deployment_v1" "main" {
           {{- if .ImageOptions }}
           image             = data.coder_parameter.container_image.value
           {{- else }}
-          image             = "{{ .ContainerImage }}"
+          image             = {{ .Variables.container_image }}
           {{- end }}
           image_pull_policy = "Always"
           command           = ["sh", "-c", coder_agent.main.init_script]

--- a/coderd/templatebuilder/bases_test.go
+++ b/coderd/templatebuilder/bases_test.go
@@ -65,14 +65,14 @@ func TestDefaultBaseRenderContext(t *testing.T) {
 	t.Run("Docker", func(t *testing.T) {
 		t.Parallel()
 		rc := templatebuilder.DefaultBaseRenderContext("docker")
-		require.Equal(t, "codercom/enterprise-base:ubuntu", rc.ContainerImage)
+		require.Equal(t, "codercom/example-base:ubuntu", rc.ContainerImage)
 		require.Nil(t, rc.ImageOptions)
 	})
 
 	t.Run("Kubernetes", func(t *testing.T) {
 		t.Parallel()
 		rc := templatebuilder.DefaultBaseRenderContext("kubernetes")
-		require.Equal(t, "codercom/enterprise-base:ubuntu", rc.ContainerImage)
+		require.Equal(t, "codercom/example-base:ubuntu", rc.ContainerImage)
 		require.Nil(t, rc.ImageOptions)
 	})
 

--- a/coderd/templatebuilder/compose_test.go
+++ b/coderd/templatebuilder/compose_test.go
@@ -290,6 +290,60 @@ func TestCompose(t *testing.T) {
 		require.Contains(t, err.Error(), "interpolation")
 	})
 
+	t.Run("DockerDefaultContainerImage", func(t *testing.T) {
+		t.Parallel()
+		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
+			BaseTemplateID: "docker",
+			RegistryURL:    "https://registry.coder.com",
+		})
+		require.NoError(t, err)
+		require.Contains(t, string(result.MainTF), `"codercom/example-base:ubuntu"`)
+	})
+
+	t.Run("DockerCustomContainerImage", func(t *testing.T) {
+		t.Parallel()
+		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
+			BaseTemplateID: "docker",
+			RegistryURL:    "https://registry.coder.com",
+			BaseVariableValues: map[string]string{
+				"container_image": "myregistry/myimage:v2",
+			},
+		})
+		require.NoError(t, err)
+		mainTF := string(result.MainTF)
+		require.Contains(t, mainTF, `"myregistry/myimage:v2"`)
+		require.NotContains(t, mainTF, `codercom/example-base:ubuntu`)
+	})
+
+	t.Run("KubernetesDefaultContainerImage", func(t *testing.T) {
+		t.Parallel()
+		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
+			BaseTemplateID: "kubernetes",
+			RegistryURL:    "https://registry.coder.com",
+			BaseVariableValues: map[string]string{
+				"namespace": "default",
+			},
+		})
+		require.NoError(t, err)
+		require.Contains(t, string(result.MainTF), `"codercom/example-base:ubuntu"`)
+	})
+
+	t.Run("KubernetesCustomContainerImage", func(t *testing.T) {
+		t.Parallel()
+		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
+			BaseTemplateID: "kubernetes",
+			RegistryURL:    "https://registry.coder.com",
+			BaseVariableValues: map[string]string{
+				"namespace":       "default",
+				"container_image": "custom/workspace:latest",
+			},
+		})
+		require.NoError(t, err)
+		mainTF := string(result.MainTF)
+		require.Contains(t, mainTF, `"custom/workspace:latest"`)
+		require.NotContains(t, mainTF, `codercom/example-base:ubuntu`)
+	})
+
 	t.Run("MissingRequiredVariable", func(t *testing.T) {
 		t.Parallel()
 		// git-clone has a required "url" variable with no default.

--- a/coderd/templatebuilder/testdata/docker.tf.golden
+++ b/coderd/templatebuilder/testdata/docker.tf.golden
@@ -150,7 +150,7 @@ resource "docker_volume" "home_volume" {
 
 resource "docker_container" "workspace" {
   count = data.coder_workspace.me.start_count
-  image = "codercom/enterprise-base:ubuntu"
+  image = "codercom/example-base:ubuntu"
   # Uses lower() to avoid Docker restriction on container names.
   name = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}"
   # Hostname makes the shell more user friendly: coder@my-workspace:~$

--- a/coderd/templatebuilder/testdata/kubernetes.tf.golden
+++ b/coderd/templatebuilder/testdata/kubernetes.tf.golden
@@ -244,7 +244,7 @@ resource "kubernetes_deployment_v1" "main" {
 
         container {
           name              = "dev"
-          image             = "codercom/enterprise-base:ubuntu"
+          image             = "codercom/example-base:ubuntu"
           image_pull_policy = "Always"
           command           = ["sh", "-c", coder_agent.main.init_script]
           security_context {

--- a/coderd/templatebuilder_handler_test.go
+++ b/coderd/templatebuilder_handler_test.go
@@ -45,13 +45,14 @@ func TestTemplateBuilderBases(t *testing.T) {
 			{
 				id:           "docker",
 				expectedOS:   "linux",
-				hasVariables: false,
+				hasVariables: true,
+				expectedVars: []string{"container_image"},
 			},
 			{
 				id:           "kubernetes",
 				expectedOS:   "linux",
 				hasVariables: true,
-				expectedVars: []string{"namespace", "use_kubeconfig"},
+				expectedVars: []string{"container_image", "namespace", "use_kubeconfig"},
 			},
 			{
 				id:           "aws-linux",

--- a/docs/admin/templates/managing-templates/image-management.md
+++ b/docs/admin/templates/managing-templates/image-management.md
@@ -1,10 +1,10 @@
 # Image Management
 
 While Coder provides example
-[base container images](https://github.com/coder/images) for
-workspaces, it's often best to create custom images that matches the needs of
-your users. This document serves a guide to operational maturity with some best
-practices around managing workspaces images for Coder.
+[container images](https://github.com/coder/images) for
+workspaces, it's often best to create custom images that match the needs of
+your users. This document serves as a guide to operational maturity with some
+best practices around managing workspace images for Coder.
 
 1. Create a minimal base image
 2. Create golden image(s) with standard tooling
@@ -13,12 +13,13 @@ practices around managing workspaces images for Coder.
 
 An image is just one of the many properties defined within the template.
 Templates can pull images from a public image registry (e.g. Docker Hub) or an
-internal one, thanks to Terraform.
+internal one, thanks to Terraform. Each image reference below can be dropped
+directly into a template's image variable or parameter.
 
 ## Create a minimal base image
 
 While you may not use this directly in Coder templates, it's useful to have a
-minimal base image is a small image that contains only the necessary
+minimal base image: a small image that contains only the necessary
 dependencies to work in your network and work with Coder. Here are some things
 to consider:
 
@@ -33,16 +34,16 @@ to consider:
 
 Examples:
 
-- [Coder's minimal image](https://github.com/coder/images/tree/main/images/minimal): only the necessary dependencies for a Coder workspace to bootstrap
-- [Coder's base image](https://github.com/coder/images/tree/main/images/base): a slightly more padded starting point with common utilities preinstalled
+- [`codercom/example-minimal:ubuntu`](https://github.com/coder/images/tree/main/images/minimal): only the necessary dependencies for a Coder workspace to bootstrap
+- [`codercom/example-base:ubuntu`](https://github.com/coder/images/tree/main/images/base): a slightly more padded starting point with common utilities preinstalled
 
-## Create general-purpose golden image(s) with standard tooling
+## Create golden image(s) with standard tooling
 
-It's often practical to have a few golden images that contain standard tooling
-for developers. These images should contain a number of languages (e.g. Python,
-Java, TypeScript), IDEs (VS Code, JetBrains, PyCharm), and other tools (e.g.
-`docker`). Unlike project-specific images (which are also important), general
-purpose images are great for:
+Building on the base image, it's often practical to have a few golden images
+that contain standard tooling for developers. These images should contain a
+number of languages (e.g. Python, Java, TypeScript), IDEs (VS Code, JetBrains,
+PyCharm), and other tools (e.g. `docker`). Unlike project-specific images
+(which are also important), general purpose images are great for:
 
 - **Scripting:** Developers may just want to hop in a Coder workspace to run
   basic scripts or queries.
@@ -62,8 +63,8 @@ most cases) with a well-defined scope.
 
 Examples:
 
-- [Coder's Universal Image](https://github.com/coder/images/tree/main/images/universal): a catch-all image with many languages and tools preinstalled. Runs as the `coder` user, so it works with Coder templates out of the box. See [coder/images](https://github.com/coder/images) for more example images, including language-specific ones.
-- [Universal Dev Containers Image](https://github.com/devcontainers/images/tree/main/src/universal)
+- [`codercom/example-universal:ubuntu`](https://github.com/coder/images/tree/main/images/universal): a catch-all image with many languages and tools preinstalled. Runs as the `coder` user, so it works with Coder templates out of the box.
+- [`mcr.microsoft.com/devcontainers/universal`](https://github.com/devcontainers/images/tree/main/src/universal): the Universal Dev Containers image
 
 ## Create project-specific images for common use cases
 
@@ -74,12 +75,14 @@ give each team exactly the tooling they need.
 
 Examples:
 
-- [coder/images](https://github.com/coder/images): Coder's example
-  language-specific images (Go, Java, Node.js, and more), all running as the
-  `coder` user
-- [Coder's dogfood image](https://github.com/coder/coder/tree/main/dogfood):
+- [`codercom/example-golang:ubuntu`](https://github.com/coder/images/tree/main/images/golang),
+  [`codercom/example-java:ubuntu`](https://github.com/coder/images/tree/main/images/java),
+  [`codercom/example-node:ubuntu`](https://github.com/coder/images/tree/main/images/node):
+  Coder's example language-specific images, all running as the `coder` user.
+  See [coder/images](https://github.com/coder/images) for the full list.
+- [`codercom/oss-dogfood:latest`](https://github.com/coder/coder/tree/main/dogfood):
   the image Coder's own engineers use to develop Coder. A good reference for a
-  project-specific image tailored to a specific team or monorepo setup
+  project-specific image tailored to a specific team or monorepo setup.
 
 ## Let developers customize their own environment
 

--- a/docs/admin/templates/managing-templates/image-management.md
+++ b/docs/admin/templates/managing-templates/image-management.md
@@ -8,7 +8,8 @@ practices around managing workspaces images for Coder.
 
 1. Create a minimal base image
 2. Create golden image(s) with standard tooling
-3. Allow developers to bring their own images and customizations with Dev
+3. Create project-specific images for common use cases
+4. Allow developers to bring their own images and customizations with Dev
    Containers
 
 An image is just one of the many properties defined within the template.
@@ -63,6 +64,22 @@ Examples:
 
 - [Coder's Universal Image](https://github.com/coder/images/tree/main/images/universal): a catch-all image with many languages and tools preinstalled. Runs as the `coder` user, so it works with Coder templates out of the box. See [coder/images](https://github.com/coder/images) for more example images, including language-specific ones.
 - [Universal Dev Containers Image](https://github.com/devcontainers/images/tree/main/src/universal)
+
+## Create project-specific images for common use cases
+
+Beyond golden images, create images scoped to a specific project, language, or
+use case (e.g. a Go backend, a Node.js frontend, or a data science stack).
+These images stay smaller and faster to pull than a kitchen-sink image, and
+give each team exactly the tooling they need.
+
+Examples:
+
+- [coder/images](https://github.com/coder/images): Coder's example
+  language-specific images (Go, Java, Node.js, and more), all running as the
+  `coder` user
+- [Dev Containers image catalog](https://hub.docker.com/r/microsoft/devcontainers):
+  browsable catalog of language and framework-specific images maintained in
+  [devcontainers/images](https://github.com/devcontainers/images)
 
 ## Allow developers to bring their own images and customizations with Dev Containers
 

--- a/docs/admin/templates/managing-templates/image-management.md
+++ b/docs/admin/templates/managing-templates/image-management.md
@@ -77,9 +77,9 @@ Examples:
 - [coder/images](https://github.com/coder/images): Coder's example
   language-specific images (Go, Java, Node.js, and more), all running as the
   `coder` user
-- [Dev Containers image catalog](https://hub.docker.com/r/microsoft/devcontainers):
-  browsable catalog of language and framework-specific images maintained in
-  [devcontainers/images](https://github.com/devcontainers/images)
+- Rather than baking every tool into the image, you can also layer tools onto
+  a smaller image with [mise](https://mise.jdx.dev/). See the
+  [install command-line tools guide](../../../get-started/customize-your-template/install-command-line-tools.md)
 
 ## Allow developers to bring their own images and customizations with Dev Containers
 
@@ -88,5 +88,4 @@ specific tooling for their projects. The [Dev Container](https://containers.dev)
 specification allows developers to define their projects dependencies within a
 `devcontainer.json` in their Git repository.
 
-- [Configure a template for Dev Containers](../../integrations/devcontainers/integration.md) (recommended)
-- [Learn about Envbuilder](../../integrations/devcontainers/envbuilder/index.md) (alternative for environments without Docker)
+- [Configure a template for Dev Containers](../../integrations/devcontainers/integration.md)

--- a/docs/admin/templates/managing-templates/image-management.md
+++ b/docs/admin/templates/managing-templates/image-management.md
@@ -9,8 +9,7 @@ practices around managing workspaces images for Coder.
 1. Create a minimal base image
 2. Create golden image(s) with standard tooling
 3. Create project-specific images for common use cases
-4. Allow developers to bring their own images and customizations with Dev
-   Containers
+4. Let developers customize their own environment
 
 An image is just one of the many properties defined within the template.
 Templates can pull images from a public image registry (e.g. Docker Hub) or an
@@ -82,15 +81,17 @@ Examples:
   the image Coder's own engineers use to develop Coder. A good reference for a
   project-specific image tailored to a specific team or monorepo setup
 
-## Allow developers to bring their own images and customizations with Dev Containers
+## Let developers customize their own environment
 
-While golden images are great for general use cases, developers will often need
-specific tooling for their projects. The [Dev Container](https://containers.dev)
-specification allows developers to define their projects dependencies within a
-`devcontainer.json` in their Git repository.
+Even with well-scoped images, developers will often need tooling that is
+specific to their project or personal workflow. Instead of maintaining an
+image for every combination, let developers layer their own customizations
+on top of a smaller image:
 
-- [Configure a template for Dev Containers](../../integrations/devcontainers/integration.md)
-
-Alternatively, rather than baking every tool into the image, developers can
-layer tools onto a smaller image with [mise](https://mise.jdx.dev/). See the
-[install command-line tools guide](../../../get-started/customize-your-template/install-command-line-tools.md).
+- [Dev Containers](https://containers.dev): developers define their project's
+  dependencies in a `devcontainer.json` in their Git repository, and Coder
+  builds the environment on top of your base image. See
+  [configure a template for Dev Containers](../../integrations/devcontainers/integration.md).
+- [mise](https://mise.jdx.dev/): developers install and pin language runtimes
+  and CLI tools at workspace startup without rebuilding the image. See the
+  [install command-line tools guide](../../../get-started/customize-your-template/install-command-line-tools.md).

--- a/docs/admin/templates/managing-templates/image-management.md
+++ b/docs/admin/templates/managing-templates/image-management.md
@@ -1,7 +1,7 @@
 # Image Management
 
 While Coder provides example
-[base container images](https://github.com/coder/enterprise-images) for
+[base container images](https://github.com/coder/images) for
 workspaces, it's often best to create custom images that matches the needs of
 your users. This document serves a guide to operational maturity with some best
 practices around managing workspaces images for Coder.
@@ -32,7 +32,7 @@ to consider:
 - Consider creating (and starting the container with) a non-root user
 
 See Coder's
-[example base image](https://github.com/coder/enterprise-images/tree/main/images/minimal)
+[example base image](https://github.com/coder/images/tree/main/images/minimal)
 for reference.
 
 ## Create general-purpose golden image(s) with standard tooling
@@ -61,6 +61,7 @@ most cases) with a well-defined scope.
 
 Examples:
 
+- [Coder's Universal Image](https://github.com/coder/images/tree/main/images/universal): a catch-all image with many languages and tools preinstalled. Runs as the `coder` user, so it works with Coder templates out of the box. See [coder/images](https://github.com/coder/images) for more example images, including language-specific ones.
 - [Universal Dev Containers Image](https://github.com/devcontainers/images/tree/main/src/universal)
 
 ## Allow developers to bring their own images and customizations with Dev Containers

--- a/docs/admin/templates/managing-templates/image-management.md
+++ b/docs/admin/templates/managing-templates/image-management.md
@@ -32,11 +32,10 @@ to consider:
   `docker`, `bash`, `jq`, and/or internal tooling
 - Consider creating (and starting the container with) a non-root user
 
-See Coder's
-[example minimal image](https://github.com/coder/images/tree/main/images/minimal)
-for reference, or the
-[example base image](https://github.com/coder/images/tree/main/images/base)
-for a slightly more padded starting point with common utilities preinstalled.
+Examples:
+
+- [Coder's minimal image](https://github.com/coder/images/tree/main/images/minimal): only the necessary dependencies for a Coder workspace to bootstrap
+- [Coder's base image](https://github.com/coder/images/tree/main/images/base): a slightly more padded starting point with common utilities preinstalled
 
 ## Create general-purpose golden image(s) with standard tooling
 
@@ -82,9 +81,6 @@ Examples:
 - [Coder's dogfood image](https://github.com/coder/coder/tree/main/dogfood):
   the image Coder's own engineers use to develop Coder. A good reference for a
   project-specific image tailored to a specific team or monorepo setup
-- Rather than baking every tool into the image, you can also layer tools onto
-  a smaller image with [mise](https://mise.jdx.dev/). See the
-  [install command-line tools guide](../../../get-started/customize-your-template/install-command-line-tools.md)
 
 ## Allow developers to bring their own images and customizations with Dev Containers
 
@@ -94,3 +90,7 @@ specification allows developers to define their projects dependencies within a
 `devcontainer.json` in their Git repository.
 
 - [Configure a template for Dev Containers](../../integrations/devcontainers/integration.md)
+
+Alternatively, rather than baking every tool into the image, developers can
+layer tools onto a smaller image with [mise](https://mise.jdx.dev/). See the
+[install command-line tools guide](../../../get-started/customize-your-template/install-command-line-tools.md).

--- a/docs/admin/templates/managing-templates/image-management.md
+++ b/docs/admin/templates/managing-templates/image-management.md
@@ -6,10 +6,12 @@ workspaces, it's often best to create custom images that match the needs of
 your users. This document serves as a guide to operational maturity with some
 best practices around managing workspace images for Coder.
 
-1. Create a minimal base image
-2. Create golden image(s) with standard tooling
-3. Create project-specific images for common use cases
-4. Let developers customize their own environment
+After following this tutorial, you'll accomplish the following:
+
+1. Create a minimal base image.
+2. Create golden images with standard tooling.
+3. Create project-specific images for common use cases.
+4. Let developers customize their own environment.
 
 An image is just one of the many properties defined within the template.
 Templates can pull images from a public image registry (e.g. Docker Hub) or an
@@ -19,7 +21,7 @@ directly into a template's image variable or parameter.
 ## Create a minimal base image
 
 While you may not use this directly in Coder templates, it's useful to have a
-minimal base image: a small image that contains only the necessary
+minimal base image as a small image that contains only the necessary
 dependencies to work in your network and work with Coder. Here are some things
 to consider:
 
@@ -37,7 +39,7 @@ Examples:
 - [`codercom/example-minimal:ubuntu`](https://github.com/coder/images/tree/main/images/minimal): only the necessary dependencies for a Coder workspace to bootstrap
 - [`codercom/example-base:ubuntu`](https://github.com/coder/images/tree/main/images/base): a slightly more padded starting point with common utilities preinstalled
 
-## Create golden image(s) with standard tooling
+## Create golden images with standard tooling
 
 Building on the base image, it's often practical to have a few golden images
 that contain standard tooling for developers. These images should contain a
@@ -69,9 +71,8 @@ Examples:
 ## Create project-specific images for common use cases
 
 Beyond golden images, create images scoped to a specific project, language, or
-use case (e.g. a Go backend, a Node.js frontend, or a data science stack).
-These images stay smaller and faster to pull than a kitchen-sink image, and
-give each team exactly the tooling they need.
+use case (e.g., a Go backend, a Node.js frontend, or a data science stack).
+These images stay smaller and faster to pull than one larger image that tries to install all dependencies.
 
 Examples:
 
@@ -79,7 +80,7 @@ Examples:
   [`codercom/example-java:ubuntu`](https://github.com/coder/images/tree/main/images/java),
   [`codercom/example-node:ubuntu`](https://github.com/coder/images/tree/main/images/node):
   Coder's example language-specific images, all running as the `coder` user.
-  See [coder/images](https://github.com/coder/images) for the full list.
+  Refer to [coder/images](https://github.com/coder/images) for the full list.
 - [`codercom/oss-dogfood:latest`](https://github.com/coder/coder/tree/main/dogfood):
   the image Coder's own engineers use to develop Coder. A good reference for a
   project-specific image tailored to a specific team or monorepo setup.
@@ -88,13 +89,13 @@ Examples:
 
 Even with well-scoped images, developers will often need tooling that is
 specific to their project or personal workflow. Instead of maintaining an
-image for every combination, let developers layer their own customizations
+image for every combination, developers can layer their own customizations
 on top of a smaller image:
 
 - [Dev Containers](https://containers.dev): developers define their project's
   dependencies in a `devcontainer.json` in their Git repository, and Coder
-  builds the environment on top of your base image. See
+  builds the environment on top of your base image. Visit
   [configure a template for Dev Containers](../../integrations/devcontainers/integration.md).
 - [mise](https://mise.jdx.dev/): developers install and pin language runtimes
-  and CLI tools at workspace startup without rebuilding the image. See the
+  and CLI tools at workspace startup without rebuilding the image. Visit the
   [install command-line tools guide](../../../get-started/customize-your-template/install-command-line-tools.md).

--- a/docs/admin/templates/managing-templates/image-management.md
+++ b/docs/admin/templates/managing-templates/image-management.md
@@ -33,8 +33,10 @@ to consider:
 - Consider creating (and starting the container with) a non-root user
 
 See Coder's
-[example base image](https://github.com/coder/images/tree/main/images/minimal)
-for reference.
+[example minimal image](https://github.com/coder/images/tree/main/images/minimal)
+for reference, or the
+[example base image](https://github.com/coder/images/tree/main/images/base)
+for a slightly more padded starting point with common utilities preinstalled.
 
 ## Create general-purpose golden image(s) with standard tooling
 
@@ -77,6 +79,9 @@ Examples:
 - [coder/images](https://github.com/coder/images): Coder's example
   language-specific images (Go, Java, Node.js, and more), all running as the
   `coder` user
+- [Coder's dogfood image](https://github.com/coder/coder/tree/main/dogfood):
+  the image Coder's own engineers use to develop Coder. A good reference for a
+  project-specific image tailored to a specific team or monorepo setup
 - Rather than baking every tool into the image, you can also layer tools onto
   a smaller image with [mise](https://mise.jdx.dev/). See the
   [install command-line tools guide](../../../get-started/customize-your-template/install-command-line-tools.md)


### PR DESCRIPTION
Makes it easier to pick the right workspace image, both in the template builder and in the docs.

- Template builder: the Docker and Kubernetes bases now expose a `container_image` variable in the wizard (freeform text, defaults to `codercom/example-base:ubuntu`), and their prerequisites explain why image choice matters, with tradeoffs between `codercom/example-base:ubuntu` (minimal) and `codercom/example-universal:ubuntu` (catch-all), plus pointers to [coder/images](https://github.com/coder/images) and the image management docs.
- Docs: reworked [image management](https://coder.com/docs/@ben%2Fdevrel-201-image-guidance-prereqs/admin/templates/managing-templates/image-management) into a clearer maturity ladder (minimal → golden → project-specific → developer customization), with pullable image references in every example, `codercom/oss-dogfood` as a project-specific example, and Dev Containers + [mise](https://mise.jdx.dev/) as ways to customize without new images.

Companion PR for the starter templates: coder/registry#943

Part of DEVREL-201.

🤖 Generated with Coder Agents using Claude, on behalf of @bpmct (wizard variable by @jeremyruppel in #27024)