### PR TITLE
feat: make docker and kubernetes base template image configurable

### DIFF
--- a/coderd/templatebuilder/bases/docker/base.json
+++ b/coderd/templatebuilder/bases/docker/base.json
@@ -4,5 +4,16 @@
 	"os": "linux",
 	"default_context": {
 		"container_image": "codercom/example-base:ubuntu"
-	}
+	},
+	"variables": [
+		{
+			"name": "container_image",
+			"type": "string",
+			"description": "Container image for workspaces. The image determines which tools and languages are available in the workspace by default. See the template README for guidance on choosing an image.",
+			"default": "codercom/example-base:ubuntu",
+			"required": false,
+			"sensitive": false,
+			"computed": false
+		}
+	]
 }

--- a/coderd/templatebuilder/bases/docker/main.tf.tmpl
+++ b/coderd/templatebuilder/bases/docker/main.tf.tmpl
@@ -166,7 +166,7 @@ resource "docker_container" "workspace" {
   {{- if .ImageOptions }}
   image = data.coder_parameter.container_image.value
   {{- else }}
-  image = "{{ .ContainerImage }}"
+  image = {{ .Variables.container_image }}
   {{- end }}
   # Uses lower() to avoid Docker restriction on container names.
   name = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}"

--- a/coderd/templatebuilder/bases/kubernetes/base.json
+++ b/coderd/templatebuilder/bases/kubernetes/base.json
@@ -7,6 +7,15 @@
 	},
 	"variables": [
 		{
+			"name": "container_image",
+			"type": "string",
+			"description": "Container image for workspaces. The image determines which tools and languages are available in the workspace by default. See the template README for guidance on choosing an image.",
+			"default": "codercom/example-base:ubuntu",
+			"required": false,
+			"sensitive": false,
+			"computed": false
+		},
+		{
 			"name": "use_kubeconfig",
 			"type": "bool",
 			"description": "Use host kubeconfig. Set to true if the Coder host is running outside the Kubernetes cluster for workspaces.",

--- a/coderd/templatebuilder/bases/kubernetes/main.tf.tmpl
+++ b/coderd/templatebuilder/bases/kubernetes/main.tf.tmpl
@@ -260,7 +260,7 @@ resource "kubernetes_deployment_v1" "main" {
           {{- if .ImageOptions }}
           image             = data.coder_parameter.container_image.value
           {{- else }}
-          image             = "{{ .ContainerImage }}"
+          image             = {{ .Variables.container_image }}
           {{- end }}
           image_pull_policy = "Always"
           command           = ["sh", "-c", coder_agent.main.init_script]

--- a/coderd/templatebuilder/compose_test.go
+++ b/coderd/templatebuilder/compose_test.go
@@ -290,6 +290,60 @@ func TestCompose(t *testing.T) {
 		require.Contains(t, err.Error(), "interpolation")
 	})
 
+	t.Run("DockerDefaultContainerImage", func(t *testing.T) {
+		t.Parallel()
+		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
+			BaseTemplateID: "docker",
+			RegistryURL:    "https://registry.coder.com",
+		})
+		require.NoError(t, err)
+		require.Contains(t, string(result.MainTF), `"codercom/example-base:ubuntu"`)
+	})
+
+	t.Run("DockerCustomContainerImage", func(t *testing.T) {
+		t.Parallel()
+		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
+			BaseTemplateID: "docker",
+			RegistryURL:    "https://registry.coder.com",
+			BaseVariableValues: map[string]string{
+				"container_image": "myregistry/myimage:v2",
+			},
+		})
+		require.NoError(t, err)
+		mainTF := string(result.MainTF)
+		require.Contains(t, mainTF, `"myregistry/myimage:v2"`)
+		require.NotContains(t, mainTF, `codercom/example-base:ubuntu`)
+	})
+
+	t.Run("KubernetesDefaultContainerImage", func(t *testing.T) {
+		t.Parallel()
+		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
+			BaseTemplateID: "kubernetes",
+			RegistryURL:    "https://registry.coder.com",
+			BaseVariableValues: map[string]string{
+				"namespace": "default",
+			},
+		})
+		require.NoError(t, err)
+		require.Contains(t, string(result.MainTF), `"codercom/example-base:ubuntu"`)
+	})
+
+	t.Run("KubernetesCustomContainerImage", func(t *testing.T) {
+		t.Parallel()
+		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
+			BaseTemplateID: "kubernetes",
+			RegistryURL:    "https://registry.coder.com",
+			BaseVariableValues: map[string]string{
+				"namespace":       "default",
+				"container_image": "custom/workspace:latest",
+			},
+		})
+		require.NoError(t, err)
+		mainTF := string(result.MainTF)
+		require.Contains(t, mainTF, `"custom/workspace:latest"`)
+		require.NotContains(t, mainTF, `codercom/example-base:ubuntu`)
+	})
+
 	t.Run("MissingRequiredVariable", func(t *testing.T) {
 		t.Parallel()
 		// git-clone has a required "url" variable with no default.

--- a/coderd/templatebuilder_handler_test.go
+++ b/coderd/templatebuilder_handler_test.go
@@ -45,13 +45,14 @@ func TestTemplateBuilderBases(t *testing.T) {
 			{
 				id:           "docker",
 				expectedOS:   "linux",
-				hasVariables: false,
+				hasVariables: true,
+				expectedVars: []string{"container_image"},
 			},
 			{
 				id:           "kubernetes",
 				expectedOS:   "linux",
 				hasVariables: true,
-				expectedVars: []string{"namespace", "use_kubeconfig"},
+				expectedVars: []string{"container_image", "namespace", "use_kubeconfig"},
 			},
 			{
 				id:           "aws-linux",


### PR DESCRIPTION
Adds a `container_image` variable to the Docker and Kubernetes base templates so admins can override the default container image via the Template Builder wizard. The field appears as a freeform text input with `codercom/enterprise-base:ubuntu` as the default placeholder.

The templates reference the variable via `{{ .Variables.container_image }}`, the same pattern kubernetes already uses for `namespace` and `use_kubeconfig`. No special-case logic in the compose pipeline; the variable flows through `mergeBaseVariables` like any other base variable.

No frontend, API, or SDK changes are needed. The existing `variableToField()` in `BaseTemplateParametersStep.tsx` automatically renders non-sensitive string variables as text fields, and Docker now shows the base parameters step (previously skipped because it had no variables).

> [!NOTE]
> This PR was authored by Coder Agents on behalf of @jeremyruppel.

<img width="1298" height="998" alt="Screenshot 2026-07-06 at 4 14 46 PM" src="https://github.com/user-attachments/assets/62833f3c-0e7a-4400-a314-5652935af6ce" />

<details>
<summary>Implementation plan</summary>

## Approach

Use the variable the same way the kubernetes template already uses `namespace` and `use_kubeconfig`: declare it in `base.json`, and reference it in the `.tf.tmpl` via `{{ .Variables.container_image }}`. The variable flows through `mergeBaseVariables` which HCL-quotes string values, so the template just emits the value directly (no manual quoting). No special handling in `compose.go` or `renderBase()`.

### Why this works

`mergeBaseVariables` converts string variable defaults and caller-supplied values into HCL-quoted strings (e.g. `"codercom/enterprise-base:ubuntu"`). The kubernetes template already relies on this for `namespace`:

```hcl
namespace = {{ .Variables.namespace }}
```

The same pattern works for `container_image`:

```hcl
image = {{ .Variables.container_image }}
```

No variable has special meaning. No Go-side override logic.

### RFC context: ImageOptions

The RFC describes `ImageOptions` as a curated list that renders into a `coder_parameter` dropdown for developers at workspace creation time. This task is complementary: it makes the static image configurable by the admin at template creation time. When `ImageOptions` is eventually wired up, the admin's chosen image would become the `default` of that `coder_parameter` dropdown.

</details>
