### PR TITLE
fix(site/src/pages/TemplateBuilder): allow TemplateCard to be selected if it has no variables

### DIFF
--- a/site/src/pages/TemplateBuilder/BaseInfraSelectStep.tsx
+++ b/site/src/pages/TemplateBuilder/BaseInfraSelectStep.tsx
@@ -23,7 +23,7 @@ function toSelectedBaseMeta(base: TemplateBuilderBase): SelectedBaseMeta {
 		iconUrl: base.icon,
 		os: base.os,
 		hasParameters:
-			base.variables.length > 0 && base.variables.some((v) => !v.sensitive),
+			base.variables?.length > 0 && base.variables?.some((v) => !v.sensitive),
 		hasPrerequisites: Boolean(base.prerequisites?.length),
 	};
 }


### PR DESCRIPTION
Fixes a bug where if `base.variables` is not defined, clicking a `TemplateCard` fails (no base template gets selected) and this error gets logged:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'length')
```

<img width="1840" height="1191" alt="image" src="https://github.com/user-attachments/assets/b51a1f05-ab58-4b17-a126-350604f9832b" />