### PR TITLE
fix(site/src/pages/TemplateBuilder): use variable defaults as field values, not just placeholders

### DIFF
--- a/site/src/pages/TemplateBuilder/BaseTemplateParametersStep.tsx
+++ b/site/src/pages/TemplateBuilder/BaseTemplateParametersStep.tsx
@@ -109,7 +109,11 @@ export const BaseTemplateParametersStep: FC<
 	};
 
 	const fields: ConfigurationFieldDefinition[] = variables.map((v) =>
-		variableToField(v, values[v.name] ?? "", handleChange),
+		variableToField(
+			v,
+			values[v.name] ?? defaultPlaceholder(v.default) ?? "",
+			handleChange,
+		),
 	);
 
 	return (

--- a/site/src/pages/TemplateBuilder/ModuleSettingsStep.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleSettingsStep.tsx
@@ -135,8 +135,11 @@ export const ModuleSettingsStep: FC<ModuleSettingsStepProps> = ({
 					const vars = moduleVariables[mod.id] ?? {};
 
 					const toField = (v: TemplateBuilderModuleVariable) =>
-						variableToField(mod.id, v, vars[v.name] ?? "", (name, val) =>
-							handleChange(mod.id, name, val),
+						variableToField(
+							mod.id,
+							v,
+							vars[v.name] ?? defaultPlaceholder(v.default) ?? "",
+							(name, val) => handleChange(mod.id, name, val),
 						);
 
 					const requiredVars = configurableVars.filter((v) => v.required);


### PR DESCRIPTION
Variables with defaults showed the default as placeholder text in an empty field. If the user did not type anything, an empty value was sent instead of the default. Now the default pre-populates the field value so it is visible and editable.

Fixes both `BaseTemplateParametersStep` and `ModuleSettingsStep` by falling back to `defaultPlaceholder(v.default)` instead of `""` when no user value exists.

Fixes DEVEX-584

> [!NOTE]
> This PR was authored by Coder Agents on behalf of @jeremyruppel.
