### PR TITLE
fix(site/src/pages/AISettingsPage/ProvidersPage): allow editing Bedrock providers with empty settings

### DIFF
--- a/site/src/pages/AISettingsPage/ProvidersPage/UpdateProviderPage/UpdateProviderPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/UpdateProviderPage/UpdateProviderPageView.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, screen, userEvent, within } from "storybook/test";
+import { expect, screen, userEvent, waitFor, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import type { AIProvider } from "#/api/typesGenerated";
 import {
@@ -57,6 +57,52 @@ export const Bedrock: Story = {
 			`/ai/settings/providers/${MockAIProviderBedrock.name}`,
 		),
 		...seed(MockAIProviderBedrock),
+	},
+};
+
+// Regression coverage for AIGOV-482. A Bedrock provider migrated from
+// chat_providers (migrations 000504/000505) arrives as `type=bedrock` with
+// `settings=null` and, for env-var deployments, a blank base_url. The edit
+// form must recognise it as Bedrock, fill the endpoint and model defaults,
+// and stay submittable once the operator makes an edit.
+const MockAIProviderBedrockMigrated: AIProvider = {
+	...MockAIProviderBedrock,
+	name: "agents-bedrock",
+	display_name: "",
+	base_url: "",
+	api_keys: [],
+	settings: null as unknown as AIProvider["settings"],
+};
+
+export const BedrockMigratedEmptySettings: Story = {
+	parameters: {
+		reactRouter: routingFor(
+			`/ai/settings/providers/${MockAIProviderBedrockMigrated.name}`,
+		),
+		...seed(MockAIProviderBedrockMigrated),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// The Bedrock fields render (not the generic API-key layout) and the
+		// endpoint/model defaults are pre-filled from the form defaults.
+		const endpoint = await canvas.findByLabelText(/endpoint/i);
+		expect(endpoint).toHaveValue(
+			"https://bedrock-runtime.us-east-2.amazonaws.com",
+		);
+		expect(canvas.queryByLabelText(/api key/i)).not.toBeInTheDocument();
+		const model = await canvas.findByLabelText(/^model\s*\*?$/i);
+		expect(model).toHaveValue(
+			"global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+		);
+
+		// Making an edit enables the Update button: the form is valid despite
+		// the migrated null settings and blank base_url.
+		const displayName = canvas.getByLabelText(/display name/i);
+		await userEvent.type(displayName, "Migrated Bedrock");
+		const submitButton = canvas.getByRole("button", {
+			name: /update provider/i,
+		});
+		await waitFor(() => expect(submitButton).toBeEnabled());
 	},
 };
 

--- a/site/src/pages/AISettingsPage/ProvidersPage/components/providerFormApiMap.test.ts
+++ b/site/src/pages/AISettingsPage/ProvidersPage/components/providerFormApiMap.test.ts
@@ -159,6 +159,18 @@ describe("isBedrockProvider", () => {
 		expect(isBedrockProvider(provider)).toBe(true);
 	});
 
+	it("recognises a bedrock-typed provider whose settings are null", () => {
+		// Migrated `agents-bedrock` rows (migrations 000504/000505) carry the
+		// dedicated `type=bedrock` with `settings=null`; the type alone is
+		// authoritative, so the provider must still be treated as Bedrock.
+		const provider: AIProvider = {
+			...MockAIProviderBedrock,
+			type: "bedrock",
+			settings: null as unknown as AIProvider["settings"],
+		};
+		expect(isBedrockProvider(provider)).toBe(true);
+	});
+
 	it("rejects an OpenAI provider", () => {
 		expect(isBedrockProvider(MockAIProviderOpenAI)).toBe(false);
 	});
@@ -190,6 +202,17 @@ describe("hasBedrockStoredCredentials", () => {
 	it("is false for non-Bedrock providers", () => {
 		expect(hasBedrockStoredCredentials(MockAIProviderOpenAI)).toBe(false);
 		expect(hasBedrockStoredCredentials(MockAIProviderAnthropic)).toBe(false);
+	});
+
+	it("is false for a migrated Bedrock provider whose settings are null", () => {
+		// A migrated `agents-bedrock` row has no persisted settings blob and
+		// therefore no stored credentials; the form must not seed masked
+		// placeholders that imply credentials are on file.
+		const provider: AIProvider = {
+			...MockAIProviderBedrock,
+			settings: null as unknown as AIProvider["settings"],
+		};
+		expect(hasBedrockStoredCredentials(provider)).toBe(false);
 	});
 });
 
@@ -788,13 +811,41 @@ describe("aiProviderToFormValues", () => {
 	});
 
 	it("handles a Bedrock provider whose settings are null", () => {
-		// `isBedrockProvider` will return false, so the provider falls
-		// through to the generic branch. The helper must not throw.
+		// A migrated `agents-bedrock` row carries `type=bedrock` with null
+		// settings. The helper must recognise it as Bedrock and omit the
+		// model fields so ProviderForm's Bedrock defaults fill them, keeping
+		// the edit form valid and submittable.
 		const provider: AIProvider = {
 			...MockAIProviderBedrock,
 			settings: null as unknown as AIProvider["settings"],
 		};
 		const values = aiProviderToFormValues(provider);
 		expect(values.type).toBe("bedrock");
+		expect(values.model).toBeUndefined();
+		expect(values.smallFastModel).toBeUndefined();
+		expect(values.roleArn).toBe("");
+	});
+
+	it("omits a blank base_url so the Bedrock form default fills it", () => {
+		// Env-var deployments migrate with a blank base_url; omitting it lets
+		// ProviderForm seed the canonical endpoint rather than leave the
+		// required Endpoint field empty (which blocks submission).
+		const provider: AIProvider = {
+			...MockAIProviderBedrock,
+			base_url: "",
+			settings: null as unknown as AIProvider["settings"],
+		};
+		expect(aiProviderToFormValues(provider).baseUrl).toBeUndefined();
+	});
+
+	it("keeps a non-blank stored base_url on a null-settings provider", () => {
+		const provider: AIProvider = {
+			...MockAIProviderBedrock,
+			base_url: "https://bedrock-runtime.us-east-1.amazonaws.com",
+			settings: null as unknown as AIProvider["settings"],
+		};
+		expect(aiProviderToFormValues(provider).baseUrl).toBe(
+			"https://bedrock-runtime.us-east-1.amazonaws.com",
+		);
 	});
 });

--- a/site/src/pages/AISettingsPage/ProvidersPage/components/providerFormApiMap.ts
+++ b/site/src/pages/AISettingsPage/ProvidersPage/components/providerFormApiMap.ts
@@ -45,11 +45,18 @@ type SettingsWire = AIProviderSettings &
 		_version?: number;
 	};
 
-// Bedrock providers are identified by the settings discriminator. The
-// generated type marks settings as non-null, but Go serializes zero settings
-// as JSON `null`.
+// Bedrock providers are identified by the dedicated `bedrock` type, which is
+// authoritative on its own: rows migrated from chat_providers (see migrations
+// 000504/000505) carry `type=bedrock` with `settings=null`, so the settings
+// discriminator cannot be required. Legacy rows predating the dedicated type
+// are stored as `type=anthropic` and are recognised via the settings
+// discriminator instead. The generated type marks settings as non-null, but
+// Go serializes zero settings as JSON `null`.
 export const isBedrockProvider = (provider: AIProvider): boolean => {
-	if (provider.type !== "anthropic" && provider.type !== "bedrock") {
+	if (provider.type === "bedrock") {
+		return true;
+	}
+	if (provider.type !== "anthropic") {
 		return false;
 	}
 	const s = provider.settings as SettingsWire | null;
@@ -69,9 +76,11 @@ export const hasBedrockStoredCredentials = (provider: AIProvider): boolean => {
 	if (!isBedrockProvider(provider)) {
 		return false;
 	}
-	// Bedrock secrets are write-only. The server only persists Bedrock
-	// settings if credentials were supplied, so presence implies "on file".
-	return true;
+	// Bedrock secrets are write-only. The server only persists a Bedrock
+	// settings blob when configuration was supplied, so a present blob implies
+	// credentials are "on file". A migrated provider carries null settings and
+	// therefore has no stored credentials to mask.
+	return (provider.settings as SettingsWire | null) !== null;
 };
 
 const parseProviderHost = (url: string): string => {
@@ -246,14 +255,19 @@ export const aiProviderToFormValues = (
 	const displayName = provider.display_name || provider.name;
 	if (isBedrockProvider(provider)) {
 		const s = (provider.settings as SettingsWire | null) ?? {};
+		// Migrated providers (migrations 000504/000505) carry null settings and
+		// may carry a blank base_url. Omit the blank fields so ProviderForm's
+		// Bedrock type defaults fill them (the canonical endpoint and the
+		// deployment default models), keeping the edit form valid and
+		// submittable. A non-blank stored value always wins over the default.
 		return {
 			type: "bedrock",
 			name: provider.name,
 			displayName,
 			icon: provider.icon || (getProviderIcon("bedrock") ?? ""),
-			baseUrl: provider.base_url,
-			model: s.model ?? "",
-			smallFastModel: s.small_fast_model ?? "",
+			...(provider.base_url ? { baseUrl: provider.base_url } : {}),
+			...(s.model ? { model: s.model } : {}),
+			...(s.small_fast_model ? { smallFastModel: s.small_fast_model } : {}),
 			accessKey: "",
 			accessKeySecret: "",
 			roleArn: s.role_arn ?? "",


### PR DESCRIPTION
## Summary

Fixes [AIGOV-482](https://linear.app/codercom/issue/AIGOV-482/provider-form-cannot-be-submitted-for-bedrock-with-empty-settings): the AI provider edit form could not be submitted for a Bedrock provider with empty settings (the migrated `agents-bedrock`).

Bedrock providers migrated from `chat_providers` (migrations `000504`/`000505`) arrive as `type=bedrock` with `settings=NULL`, and for env-var deployments with a blank `base_url` (`chat_providers` has no model/region columns; models live in `chat_model_configs`). `isBedrockProvider()` required the `settings._type` discriminator, so these rows were not recognised as Bedrock: the edit form fell through to the generic branch and left the required **Endpoint** field empty, permanently disabling the submit button.

## Changes (frontend only)

- **`isBedrockProvider`**: treat the dedicated `type=bedrock` as authoritative regardless of settings, keeping the legacy `type=anthropic` + discriminator path for pre-dedicated-type rows.
- **`aiProviderToFormValues`**: seed the form from whatever settings exist and omit blank `base_url`/`model`/`smallFastModel` so `ProviderForm`'s Bedrock defaults fill them (canonical endpoint + deployment default models). A non-blank stored value still wins. On save the provider persists a proper settings blob, healing the row.
- **`hasBedrockStoredCredentials`**: only report stored credentials when a settings blob is actually present, so migrated providers do not show fake masked credentials.

No migration or backend changes: the `NULL` settings are inherent to the source data, and the existing PATCH path decodes `NULL` settings gracefully and heals the row on save.

## Testing

- `providerFormApiMap.test.ts`: added regression coverage for `isBedrockProvider`, `hasBedrockStoredCredentials`, and `aiProviderToFormValues` against the migrated row shape (`settings=null`, blank and non-blank `base_url`).
- `UpdateProviderPageView.stories.tsx`: added `BedrockMigratedEmptySettings`, which drives the real page and asserts the Bedrock fields render, defaults pre-fill, and the **Update** button enables after an edit. Confirmed this story **fails on the pre-fix code** (empty Endpoint) and passes after the fix.
- Biome check clean; TypeScript reports 0 errors.

## Notes

- The secondary report ("Bedrock created in the UI stored as `type=Anthropic`") is already resolved on `main`: `providerFormValuesToCreate` sends `type: "bedrock"`.
- Possible follow-up (larger blast radius, out of scope here): normalise `type=bedrock, settings=null` into a `{_type:"bedrock"}` blob in the API response layer so all clients (not just the web UI) get consistent detection.

<details>
<summary>Decision log</summary>

- **Root cause**: `isBedrockProvider()` keyed off the `settings._type` discriminator, which is `null` for rows migrated by `000504`/`000505`. A genuine `type=bedrock` provider therefore was not detected as Bedrock, cascading into: the generic (API-key) form branch, a blank required Endpoint field, and `providerUsesApiKeys` incorrectly returning true.
- **Layer choice**: fixed in the frontend rather than the migration/backend. The migration cannot populate `settings.model`/`region` because that data never existed in `chat_providers` (models are managed via `chat_model_configs`), so backfilling would fabricate data. The dedicated `type` column being authoritative over a settings discriminator is also the correct model.
- **Why omit blanks instead of injecting defaults directly**: `ProviderForm` already layers `defaults < type prefills < initialValues`. Omitting blank fields lets the existing Bedrock type defaults apply (mirroring the create flow), while any non-blank stored value still overrides them.
- **Round-trip heals the row**: submitting the edited form serialises a proper Bedrock settings blob; the backend `PATCH` handler decodes prior `NULL` settings as empty, merges, and persists, so subsequent loads take the normal path.
- **Consumer audit**: all readers of `isBedrockProvider`/`settings` are localised to `providerFormApiMap.ts` (null-guarded) and `UpdateProviderPageView` (via the helpers); no raw `settings.*` dereferences elsewhere.

</details>

---
🤖 This pull request was generated by Coder Agents on behalf of @dannykopping.
