### PR TITLE
fix: relabel advisor max uses setting from per run to per turn

### DIFF
--- a/docs/ai-coder/agents/platform-controls/advisor.md
+++ b/docs/ai-coder/agents/platform-controls/advisor.md
@@ -34,12 +34,12 @@ Once the experiment is enabled, configure the advisor under **AI Settings** >
 
 | Field             | Default              | Notes                                                                                                                   |
 |-------------------|----------------------|-------------------------------------------------------------------------------------------------------------------------|
-| Max uses per run  | `0` (unlimited)      | Caps how many times the root agent can call the advisor in a single chat run. Must be a non-negative integer.           |
+| Max uses per turn | `0` (unlimited)      | Caps how many times the root agent can call the advisor in a single chat turn. Must be a non-negative integer.          |
 | Max output tokens | `0` (server default) | Caps the advisor model's response length. `0` uses the server default of 16,384 tokens. Must be a non-negative integer. |
 | Advisor model     | Use chat model       | Optional dedicated chat model config for the advisor. When unset, the advisor reuses the root agent's model.            |
 
 The advisor is not available in plan mode or to subagents. Failed advisor
-invocations refund the per-run budget, and advisor calls are not metered
+invocations refund the per-turn budget, and advisor calls are not metered
 against the root chat's usage limit.
 
 The same configuration is available at:

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.stories.tsx
@@ -505,7 +505,7 @@ export const AdvisorSettingsVisible: Story = {
 		const section = await getSection(canvasElement, "Advisor");
 		expect(
 			within(section).getByRole("spinbutton", {
-				name: "Max uses per run",
+				name: "Max uses per turn",
 			}),
 		).toHaveValue(3);
 		expect(
@@ -519,7 +519,7 @@ export const AdvisorSettingsVisible: Story = {
 
 		// Changing a value exposes the Save button.
 		const maxUses = within(section).getByRole("spinbutton", {
-			name: "Max uses per run",
+			name: "Max uses per turn",
 		});
 		await userEvent.clear(maxUses);
 		await userEvent.type(maxUses, "5");
@@ -553,7 +553,7 @@ export const AdvisorClearButton: Story = {
 		await userEvent.click(clearButton);
 		expect(
 			within(section).getByRole("spinbutton", {
-				name: "Max uses per run",
+				name: "Max uses per turn",
 			}),
 		).toHaveValue(0);
 		expect(

--- a/site/src/pages/AgentsPage/components/AdvisorSettings.tsx
+++ b/site/src/pages/AgentsPage/components/AdvisorSettings.tsx
@@ -104,7 +104,7 @@ const validateAdvisorConfig = (values: AdvisorSettingsFormValues) => {
 
 	if (!isNonNegativeIntegerString(values.max_uses_per_run)) {
 		errors.max_uses_per_run =
-			"Max uses per run must be a non-negative integer.";
+			"Max uses per turn must be a non-negative integer.";
 	}
 
 	if (!isNonNegativeIntegerString(values.max_output_tokens)) {
@@ -203,7 +203,7 @@ export const AdvisorSettings: FC<AdvisorSettingsProps> = ({
 	return (
 		<AgentSettingLayout
 			title="Advisor"
-			description="Cap advisor usage per run and optionally use an override model. The advisor provides strategic guidance to root agent chats. Set limits to 0 for unlimited."
+			description="Cap advisor usage per turn and optionally use an override model. The advisor provides strategic guidance to root agent chats. Set limits to 0 for unlimited."
 			showSave={canSave}
 			isSaving={isSavingAdvisorConfig}
 			isSavedVisible={isSavedVisible}
@@ -225,8 +225,8 @@ export const AdvisorSettings: FC<AdvisorSettingsProps> = ({
 			<CompactIntegerField
 				id={maxUsesId}
 				name="max_uses_per_run"
-				label="Uses / run"
-				ariaLabel="Max uses per run"
+				label="Uses / turn"
+				ariaLabel="Max uses per turn"
 				value={form.values.max_uses_per_run}
 				onChange={(value) => void form.setFieldValue("max_uses_per_run", value)}
 				onBlur={form.handleBlur}


### PR DESCRIPTION
Relabels the advisor "Max uses per run" setting to "Max uses per turn" in the Coder Agents settings UI, the validation message, the Storybook queries targeting the field, and the advisor docs.

The limit is enforced within a single chat turn and resets on each new user message, so "per turn" matches the actual behavior. The `max_uses_per_run` API field and internal Go identifiers are unchanged.

Fixes CODAGT-593

> [!NOTE]
> 🤖 Generated by Coder Agents on behalf of @ThomasK33
