### PR TITLE
feat: add reasoning effort to model overrides

### DIFF
--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -520,24 +520,40 @@ func validateChatPlanMode(mode codersdk.ChatPlanMode) bool {
 	}
 }
 
-func parseChatModelOverride(raw string) (*uuid.UUID, error) {
-	trimmed := strings.TrimSpace(raw)
-	if trimmed == "" {
-		//nolint:nilnil // Empty site-config value means the override is unset.
-		return nil, nil
-	}
-	modelConfigID, err := uuid.Parse(trimmed)
-	if err != nil {
-		return nil, xerrors.Errorf("parse chat model override: %w", err)
-	}
-	return &modelConfigID, nil
+type parsedChatModelOverride struct {
+	modelConfigID   *uuid.UUID
+	reasoningEffort *string
 }
 
-func formatChatModelOverride(id *uuid.UUID) string {
+func parseChatModelOverride(raw string) (parsedChatModelOverride, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return parsedChatModelOverride{}, nil
+	}
+	rawID, rawEffort, hasEffort := strings.Cut(trimmed, ":")
+	modelConfigID, err := uuid.Parse(rawID)
+	if err != nil {
+		return parsedChatModelOverride{}, xerrors.Errorf("parse chat model override: %w", err)
+	}
+	if hasEffort && rawEffort == "" {
+		return parsedChatModelOverride{}, xerrors.New("parse chat model override: reasoning effort is empty")
+	}
+	parsed := parsedChatModelOverride{modelConfigID: &modelConfigID}
+	if hasEffort {
+		parsed.reasoningEffort = &rawEffort
+	}
+	return parsed, nil
+}
+
+func formatChatModelOverride(id *uuid.UUID, effort *string) string {
 	if id == nil {
 		return ""
 	}
-	return id.String()
+	formatted := id.String()
+	if effort != nil {
+		formatted += ":" + *effort
+	}
+	return formatted
 }
 
 func lookupEnabledChatModelConfigByID(
@@ -550,12 +566,65 @@ func lookupEnabledChatModelConfigByID(
 	return db.GetEnabledChatModelConfigByID(dbauthz.AsChatd(ctx), id)
 }
 
-func validateChatModelOverrideID(
+func parseChatModelCallConfig(options json.RawMessage) (*codersdk.ChatModelCallConfig, error) {
+	callConfig := &codersdk.ChatModelCallConfig{}
+	if len(options) == 0 {
+		return callConfig, nil
+	}
+	if err := json.Unmarshal(options, callConfig); err != nil {
+		return nil, err
+	}
+	return callConfig, nil
+}
+
+func validateChatModelOverrideEffort(
+	modelConfig database.ChatModelConfig,
+	effort *string,
+) (int, *codersdk.Response) {
+	if effort == nil {
+		return 0, nil
+	}
+	if !chatprovider.IsValidReasoningEffort(*effort) {
+		return http.StatusBadRequest, &codersdk.Response{
+			Message: "Invalid reasoning_effort value.",
+			Detail:  "Must be one of none, minimal, low, medium, high, xhigh, max.",
+		}
+	}
+	callConfig, err := parseChatModelCallConfig(modelConfig.Options)
+	if err != nil {
+		return http.StatusInternalServerError, &codersdk.Response{
+			Message: "Internal error validating reasoning effort.",
+			Detail:  err.Error(),
+		}
+	}
+	selectableEfforts := chatprovider.SelectableReasoningEfforts(callConfig.ReasoningEffort)
+	if len(selectableEfforts) == 0 {
+		return http.StatusBadRequest, &codersdk.Response{
+			Message: "Invalid reasoning_effort value.",
+			Detail:  "This model does not support reasoning effort.",
+		}
+	}
+	if !slices.Contains(selectableEfforts, *effort) {
+		return http.StatusBadRequest, &codersdk.Response{
+			Message: "Invalid reasoning_effort value.",
+			Detail:  "Must be one of " + strings.Join(selectableEfforts, ", ") + ".",
+		}
+	}
+	return 0, nil
+}
+
+func validateChatModelOverride(
 	ctx context.Context,
 	db database.Store,
 	id *uuid.UUID,
+	effort *string,
 ) (int, *codersdk.Response) {
 	if id == nil {
+		if effort != nil {
+			return http.StatusBadRequest, &codersdk.Response{
+				Message: "reasoning_effort requires model_config_id.",
+			}
+		}
 		return 0, nil
 	}
 	if *id == uuid.Nil {
@@ -563,31 +632,31 @@ func validateChatModelOverrideID(
 			Message: "Invalid model_config_id.",
 		}
 	}
-	_, err := lookupEnabledChatModelConfigByID(ctx, db, *id)
-	if err == nil {
-		return 0, nil
-	}
-	if xerrors.Is(err, sql.ErrNoRows) {
-		return http.StatusBadRequest, &codersdk.Response{
-			Message: "Invalid model_config_id.",
+	modelConfig, err := lookupEnabledChatModelConfigByID(ctx, db, *id)
+	if err != nil {
+		if xerrors.Is(err, sql.ErrNoRows) {
+			return http.StatusBadRequest, &codersdk.Response{
+				Message: "Invalid model_config_id.",
+			}
+		}
+		return http.StatusInternalServerError, &codersdk.Response{
+			Message: "Internal error validating model config override.",
+			Detail:  err.Error(),
 		}
 	}
-	return http.StatusInternalServerError, &codersdk.Response{
-		Message: "Internal error validating model config override.",
-		Detail:  err.Error(),
-	}
+	return validateChatModelOverrideEffort(modelConfig, effort)
 }
 
 func (api *API) getChatModelOverrideConfig(
 	ctx context.Context,
 	settingName string,
 	getter func(context.Context) (string, error),
-) (*uuid.UUID, bool, error) {
+) (*uuid.UUID, *string, bool, error) {
 	raw, err := getter(ctx)
 	if err != nil {
-		return nil, false, xerrors.Errorf("get %s model override: %w", settingName, err)
+		return nil, nil, false, xerrors.Errorf("get %s model override: %w", settingName, err)
 	}
-	id, err := parseChatModelOverride(raw)
+	parsed, err := parseChatModelOverride(raw)
 	if err != nil {
 		// Degrade malformed values to unset so the admin settings page
 		// remains accessible and the bad value can be cleared.
@@ -598,9 +667,9 @@ func (api *API) getChatModelOverrideConfig(
 			slog.F("raw_value", raw),
 			slog.Error(err),
 		)
-		return nil, true, nil
+		return nil, nil, true, nil
 	}
-	return id, false, nil
+	return parsed.modelConfigID, parsed.reasoningEffort, false, nil
 }
 
 func parseChatModelOverrideContext(raw string) (codersdk.ChatModelOverrideContext, error) {
@@ -650,25 +719,26 @@ func (api *API) chatModelOverrideSiteConfig(
 func (api *API) readChatModelOverrideConfig(
 	ctx context.Context,
 	overrideContext codersdk.ChatModelOverrideContext,
-) (*uuid.UUID, bool, string, error) {
+) (*uuid.UUID, *string, bool, string, error) {
 	siteConfig, err := api.chatModelOverrideSiteConfig(overrideContext)
 	if err != nil {
-		return nil, false, "", err
+		return nil, nil, false, "", err
 	}
-	id, isMalformed, err := api.getChatModelOverrideConfig(ctx, siteConfig.label, siteConfig.getter)
-	return id, isMalformed, siteConfig.label, err
+	id, effort, isMalformed, err := api.getChatModelOverrideConfig(ctx, siteConfig.label, siteConfig.getter)
+	return id, effort, isMalformed, siteConfig.label, err
 }
 
 func (api *API) upsertChatModelOverrideConfig(
 	ctx context.Context,
 	overrideContext codersdk.ChatModelOverrideContext,
 	modelConfigID *uuid.UUID,
+	reasoningEffort *string,
 ) (string, error) {
 	siteConfig, err := api.chatModelOverrideSiteConfig(overrideContext)
 	if err != nil {
 		return "", err
 	}
-	return siteConfig.label, siteConfig.upsert(ctx, formatChatModelOverride(modelConfigID))
+	return siteConfig.label, siteConfig.upsert(ctx, formatChatModelOverride(modelConfigID, reasoningEffort))
 }
 
 var chatPersonalModelOverrideContexts = []codersdk.ChatPersonalModelOverrideContext{
@@ -718,9 +788,14 @@ func parseChatPersonalModelOverrideValue(
 func formatChatPersonalModelOverrideValue(
 	mode codersdk.ChatPersonalModelOverrideMode,
 	modelConfigID string,
+	reasoningEffort *string,
 ) string {
 	if mode == codersdk.ChatPersonalModelOverrideModeModel {
-		return string(mode) + ":" + strings.TrimSpace(modelConfigID)
+		value := string(mode) + ":" + strings.TrimSpace(modelConfigID)
+		if reasoningEffort != nil {
+			value += ":" + *reasoningEffort
+		}
+		return value
 	}
 	return string(mode)
 }
@@ -732,15 +807,18 @@ func chatPersonalModelOverrideResponse(
 ) codersdk.ChatPersonalModelOverride {
 	parsed := parseChatPersonalModelOverrideValue(raw, overrideContext)
 	modelConfigID := ""
+	var reasoningEffort *string
 	if parsed.Mode == codersdk.ChatPersonalModelOverrideModeModel {
 		modelConfigID = parsed.ModelConfigID.String()
+		reasoningEffort = parsed.ReasoningEffort
 	}
 	return codersdk.ChatPersonalModelOverride{
-		Context:       overrideContext,
-		Mode:          parsed.Mode,
-		ModelConfigID: modelConfigID,
-		IsSet:         isSet,
-		IsMalformed:   parsed.Malformed,
+		Context:         overrideContext,
+		Mode:            parsed.Mode,
+		ModelConfigID:   modelConfigID,
+		ReasoningEffort: reasoningEffort,
+		IsSet:           isSet,
+		IsMalformed:     parsed.Malformed,
 	}
 }
 
@@ -752,7 +830,7 @@ func (api *API) chatPersonalModelOverrideDeploymentDefaultResponse(
 	// resources. Users may read these values here because the personal settings
 	// UI must explain what deployment_default resolves to.
 	//nolint:gocritic // System context is required to read deployment config.
-	modelConfigID, isMalformed, _, err := api.readChatModelOverrideConfig(
+	modelConfigID, reasoningEffort, isMalformed, _, err := api.readChatModelOverrideConfig(
 		dbauthz.AsSystemRestricted(ctx),
 		overrideContext,
 	)
@@ -760,9 +838,10 @@ func (api *API) chatPersonalModelOverrideDeploymentDefaultResponse(
 		return codersdk.ChatModelOverrideResponse{}, err
 	}
 	return codersdk.ChatModelOverrideResponse{
-		Context:       overrideContext,
-		ModelConfigID: formatChatModelOverride(modelConfigID),
-		IsMalformed:   isMalformed,
+		Context:         overrideContext,
+		ModelConfigID:   formatChatModelOverride(modelConfigID, nil),
+		ReasoningEffort: reasoningEffort,
+		IsMalformed:     isMalformed,
 	}, nil
 }
 
@@ -947,9 +1026,9 @@ func (api *API) userCanUseChatModelConfig(
 	ctx context.Context,
 	userID uuid.UUID,
 	modelConfigID uuid.UUID,
-) (chatModelConfigUnavailableReason, error) {
+) (database.ChatModelConfig, chatModelConfigUnavailableReason, error) {
 	if modelConfigID == uuid.Nil {
-		return chatModelConfigUnavailableModelNotFoundOrDisabled, nil
+		return database.ChatModelConfig{}, chatModelConfigUnavailableModelNotFoundOrDisabled, nil
 	}
 	//nolint:gocritic // Non-admin users need deployment config validation.
 	model, err := api.Database.GetChatModelConfigByID(
@@ -958,63 +1037,63 @@ func (api *API) userCanUseChatModelConfig(
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) || httpapi.Is404Error(err) {
-			return chatModelConfigUnavailableModelNotFoundOrDisabled, nil
+			return database.ChatModelConfig{}, chatModelConfigUnavailableModelNotFoundOrDisabled, nil
 		}
-		return chatModelConfigAvailable, err
+		return database.ChatModelConfig{}, chatModelConfigAvailable, err
 	}
 	if !model.Enabled {
-		return chatModelConfigUnavailableModelNotFoundOrDisabled, nil
+		return database.ChatModelConfig{}, chatModelConfigUnavailableModelNotFoundOrDisabled, nil
 	}
 
 	availability, err := api.getUserChatProviderAvailability(ctx, userID)
 	if err != nil {
-		return chatModelConfigAvailable, err
+		return database.ChatModelConfig{}, chatModelConfigAvailable, err
 	}
 	if model.AIProviderID.Valid {
 		providerID := model.AIProviderID.UUID
 		if _, ok := availability.enabledProviderIDs[providerID]; !ok {
-			return chatModelConfigUnavailableProviderDisabled, nil
+			return database.ChatModelConfig{}, chatModelConfigUnavailableProviderDisabled, nil
 		}
 		providerStatus, ok := availability.providerStatusByID[providerID]
 		if !ok {
-			return chatModelConfigUnavailableProviderDisabled, nil
+			return database.ChatModelConfig{}, chatModelConfigUnavailableProviderDisabled, nil
 		}
 		if !providerStatus.Available {
-			return chatModelConfigUnavailableCredentialsMissing, nil
+			return database.ChatModelConfig{}, chatModelConfigUnavailableCredentialsMissing, nil
 		}
-		return chatModelConfigAvailable, nil
+		return model, chatModelConfigAvailable, nil
 	}
 	// Active configs always carry a provider FK (CHECK
 	// chat_model_configs_ai_provider_required_when_active), so an unset FK
 	// means the config is not usable.
-	return chatModelConfigUnavailableModelNotFoundOrDisabled, nil
+	return database.ChatModelConfig{}, chatModelConfigUnavailableModelNotFoundOrDisabled, nil
 }
 
 func (api *API) validateUserChatModelConfigAvailable(
 	ctx context.Context,
 	userID uuid.UUID,
 	modelConfigID uuid.UUID,
-) (int, *codersdk.Response) {
-	reason, err := api.userCanUseChatModelConfig(ctx, userID, modelConfigID)
+) (database.ChatModelConfig, int, *codersdk.Response) {
+	modelConfig, reason, err := api.userCanUseChatModelConfig(ctx, userID, modelConfigID)
 	if err != nil {
-		return http.StatusInternalServerError, &codersdk.Response{
+		return database.ChatModelConfig{}, http.StatusInternalServerError, &codersdk.Response{
 			Message: "Internal error validating model config override.",
 			Detail:  err.Error(),
 		}
 	}
 	switch reason {
 	case chatModelConfigAvailable:
-		return 0, nil
+		return modelConfig, 0, nil
 	case chatModelConfigUnavailableModelNotFoundOrDisabled:
-		return http.StatusBadRequest, &codersdk.Response{
+		return database.ChatModelConfig{}, http.StatusBadRequest, &codersdk.Response{
 			Message: "Invalid model_config_id: model config not found or disabled.",
 		}
 	case chatModelConfigUnavailableCredentialsMissing:
-		return http.StatusBadRequest, &codersdk.Response{
+		return database.ChatModelConfig{}, http.StatusBadRequest, &codersdk.Response{
 			Message: "Invalid model_config_id: provider credentials unavailable for this model.",
 		}
 	case chatModelConfigUnavailableProviderDisabled:
-		return http.StatusBadRequest, &codersdk.Response{
+		return database.ChatModelConfig{}, http.StatusBadRequest, &codersdk.Response{
 			Message: "Invalid model_config_id: provider is not enabled for this model.",
 		}
 	default:
@@ -1024,7 +1103,7 @@ func (api *API) validateUserChatModelConfigAvailable(
 			slog.F("model_config_id", modelConfigID),
 			slog.F("reason", reason),
 		)
-		return http.StatusBadRequest, &codersdk.Response{
+		return database.ChatModelConfig{}, http.StatusBadRequest, &codersdk.Response{
 			Message: "Invalid model_config_id.",
 		}
 	}
@@ -1121,7 +1200,7 @@ func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 
 	title := chatTitleFromMessage(titleSource)
 
-	modelConfigID, modelConfigStatus, modelConfigError := api.resolveCreateChatModelConfigID(ctx, apiKey.UserID, req)
+	modelConfigID, personalOverrideEffort, modelConfigStatus, modelConfigError := api.resolveCreateChatModelConfigID(ctx, apiKey.UserID, req)
 	if modelConfigError != nil {
 		httpapi.Write(ctx, rw, modelConfigStatus, *modelConfigError)
 		return
@@ -1238,6 +1317,9 @@ func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	reasoningEffort := req.ReasoningEffort
+	if reasoningEffort == nil {
+		reasoningEffort = personalOverrideEffort
+	}
 	if reasoningEffort != nil && !chatprovider.IsValidReasoningEffort(*reasoningEffort) {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, invalidReasoningEffortResponse(*reasoningEffort))
 		return
@@ -4637,25 +4719,26 @@ func (api *API) resolveCreateChatModelConfigID(
 	ctx context.Context,
 	userID uuid.UUID,
 	req codersdk.CreateChatRequest,
-) (uuid.UUID, int, *codersdk.Response) {
+) (uuid.UUID, *string, int, *codersdk.Response) {
 	if req.ModelConfigID != nil {
 		if *req.ModelConfigID == uuid.Nil {
-			return uuid.Nil, http.StatusBadRequest, &codersdk.Response{
+			return uuid.Nil, nil, http.StatusBadRequest, &codersdk.Response{
 				Message: "Invalid model config ID.",
 			}
 		}
-		return *req.ModelConfigID, 0, nil
+		return *req.ModelConfigID, nil, 0, nil
 	}
 
 	personalOverridesEnabled, err := api.Database.GetChatPersonalModelOverridesEnabled(ctx)
 	if err != nil {
-		return uuid.Nil, http.StatusInternalServerError, &codersdk.Response{
+		return uuid.Nil, nil, http.StatusInternalServerError, &codersdk.Response{
 			Message: "Failed to resolve chat model config.",
 			Detail:  err.Error(),
 		}
 	}
 	if !personalOverridesEnabled {
-		return api.defaultCreateChatModelConfigID(ctx)
+		id, status, resp := api.defaultCreateChatModelConfigID(ctx)
+		return id, nil, status, resp
 	}
 
 	raw, err := api.Database.GetUserChatPersonalModelOverride(ctx, database.GetUserChatPersonalModelOverrideParams{
@@ -4663,7 +4746,7 @@ func (api *API) resolveCreateChatModelConfigID(
 		Key:    chatd.ChatPersonalModelOverrideKey(codersdk.ChatPersonalModelOverrideContextRoot),
 	})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return uuid.Nil, http.StatusInternalServerError, &codersdk.Response{
+		return uuid.Nil, nil, http.StatusInternalServerError, &codersdk.Response{
 			Message: "Failed to resolve chat model config.",
 			Detail:  err.Error(),
 		}
@@ -4686,19 +4769,19 @@ func (api *API) resolveCreateChatModelConfigID(
 			// For root context, chat_default and the defensive default
 			// case both fall through to the deployment default model below.
 		case codersdk.ChatPersonalModelOverrideModeModel:
-			reason, err := api.userCanUseChatModelConfig(
+			_, reason, err := api.userCanUseChatModelConfig(
 				ctx,
 				userID,
 				parsed.ModelConfigID,
 			)
 			if err != nil {
-				return uuid.Nil, http.StatusInternalServerError, &codersdk.Response{
+				return uuid.Nil, nil, http.StatusInternalServerError, &codersdk.Response{
 					Message: "Failed to resolve chat model config.",
 					Detail:  err.Error(),
 				}
 			}
 			if reason == chatModelConfigAvailable {
-				return parsed.ModelConfigID, 0, nil
+				return parsed.ModelConfigID, parsed.ReasoningEffort, 0, nil
 			}
 			api.Logger.Debug(
 				ctx,
@@ -4717,7 +4800,8 @@ func (api *API) resolveCreateChatModelConfigID(
 		}
 	}
 
-	return api.defaultCreateChatModelConfigID(ctx)
+	id, status, resp := api.defaultCreateChatModelConfigID(ctx)
+	return id, nil, status, resp
 }
 
 func (api *API) defaultCreateChatModelConfigID(
@@ -4945,7 +5029,7 @@ func (api *API) getChatModelOverride(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	modelConfigID, isMalformed, label, err := api.readChatModelOverrideConfig(ctx, overrideContext)
+	modelConfigID, reasoningEffort, isMalformed, label, err := api.readChatModelOverrideConfig(ctx, overrideContext)
 	if err != nil {
 		if label == "" {
 			label = string(overrideContext)
@@ -4958,9 +5042,10 @@ func (api *API) getChatModelOverride(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := codersdk.ChatModelOverrideResponse{
-		Context:       overrideContext,
-		ModelConfigID: formatChatModelOverride(modelConfigID),
-		IsMalformed:   isMalformed,
+		Context:         overrideContext,
+		ModelConfigID:   formatChatModelOverride(modelConfigID, nil),
+		ReasoningEffort: reasoningEffort,
+		IsMalformed:     isMalformed,
 	}
 
 	httpapi.Write(ctx, rw, http.StatusOK, resp)
@@ -4983,22 +5068,34 @@ func (api *API) putChatModelOverride(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	modelConfigID, err := parseChatModelOverride(req.ModelConfigID)
-	if err != nil {
-		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: "Invalid model_config_id.",
-			Detail:  fmt.Sprintf("Value %q is not a valid UUID.", req.ModelConfigID),
-		})
-		return
+	var modelConfigID *uuid.UUID
+	trimmedModelConfigID := strings.TrimSpace(req.ModelConfigID)
+	if trimmedModelConfigID != "" {
+		if strings.Contains(trimmedModelConfigID, ":") {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "Invalid model_config_id.",
+				Detail:  fmt.Sprintf("Value %q is not a valid UUID.", req.ModelConfigID),
+			})
+			return
+		}
+		parsedModelConfigID, err := uuid.Parse(trimmedModelConfigID)
+		if err != nil {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "Invalid model_config_id.",
+				Detail:  fmt.Sprintf("Value %q is not a valid UUID.", req.ModelConfigID),
+			})
+			return
+		}
+		modelConfigID = &parsedModelConfigID
 	}
 
-	status, resp := validateChatModelOverrideID(ctx, api.Database, modelConfigID)
+	status, resp := validateChatModelOverride(ctx, api.Database, modelConfigID, req.ReasoningEffort)
 	if resp != nil {
 		httpapi.Write(ctx, rw, status, *resp)
 		return
 	}
 
-	label, err := api.upsertChatModelOverrideConfig(ctx, overrideContext, modelConfigID)
+	label, err := api.upsertChatModelOverrideConfig(ctx, overrideContext, modelConfigID, req.ReasoningEffort)
 	if err != nil {
 		if label == "" {
 			label = string(overrideContext)
@@ -5176,12 +5273,19 @@ func (api *API) putUserChatPersonalModelOverride(rw http.ResponseWriter, r *http
 	}
 
 	modelConfigID := ""
+	reasoningEffort := req.ReasoningEffort
 	rawModelConfigID := strings.TrimSpace(req.ModelConfigID)
 	switch req.Mode {
 	case codersdk.ChatPersonalModelOverrideModeChatDefault:
 		if rawModelConfigID != "" {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 				Message: "model_config_id must be empty unless mode is model.",
+			})
+			return
+		}
+		if reasoningEffort != nil {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "reasoning_effort requires mode model.",
 			})
 			return
 		}
@@ -5195,6 +5299,12 @@ func (api *API) putUserChatPersonalModelOverride(rw http.ResponseWriter, r *http
 		if rawModelConfigID != "" {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 				Message: "model_config_id must be empty unless mode is model.",
+			})
+			return
+		}
+		if reasoningEffort != nil {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "reasoning_effort requires mode model.",
 			})
 			return
 		}
@@ -5219,7 +5329,12 @@ func (api *API) putUserChatPersonalModelOverride(rw http.ResponseWriter, r *http
 			})
 			return
 		}
-		status, resp := api.validateUserChatModelConfigAvailable(ctx, apiKey.UserID, parsedModelConfigID)
+		modelConfig, status, resp := api.validateUserChatModelConfigAvailable(ctx, apiKey.UserID, parsedModelConfigID)
+		if resp != nil {
+			httpapi.Write(ctx, rw, status, *resp)
+			return
+		}
+		status, resp = validateChatModelOverrideEffort(modelConfig, reasoningEffort)
 		if resp != nil {
 			httpapi.Write(ctx, rw, status, *resp)
 			return
@@ -5235,7 +5350,7 @@ func (api *API) putUserChatPersonalModelOverride(rw http.ResponseWriter, r *http
 	if err := api.Database.UpsertUserChatPersonalModelOverride(ctx, database.UpsertUserChatPersonalModelOverrideParams{
 		UserID: apiKey.UserID,
 		Key:    chatd.ChatPersonalModelOverrideKey(overrideContext),
-		Value:  formatChatPersonalModelOverrideValue(req.Mode, modelConfigID),
+		Value:  formatChatPersonalModelOverrideValue(req.Mode, modelConfigID, reasoningEffort),
 	}); err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error updating user personal model override.",

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -3897,8 +3897,11 @@ func TestCreateChatModelConfig(t *testing.T) {
 		})
 		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
 		require.Equal(t, "Invalid model config.", sdkErr.Message)
-		require.Contains(t, sdkErr.Detail, `reasoning_effort.default " HIGH "`)
-		require.Contains(t, sdkErr.Detail, "must be one of none, minimal, low, medium, high, xhigh, max")
+		require.Equal(
+			t,
+			`reasoning_effort.default " HIGH " must be one of none, minimal, low, medium, high, xhigh, max`,
+			sdkErr.Detail,
+		)
 	})
 
 	t.Run("ReasoningEffortRejectsDefaultAboveMax", func(t *testing.T) {
@@ -7029,8 +7032,9 @@ func TestSendMessageQueuesEffectiveModelConfigID(t *testing.T) {
 			Type: codersdk.ChatInputPartTypeText,
 			Text: "queue this with model b",
 		}},
-		ModelConfigID: ptr.Ref(modelConfigB.ID),
-		BusyBehavior:  codersdk.ChatBusyBehaviorQueue,
+		ModelConfigID:   ptr.Ref(modelConfigB.ID),
+		ReasoningEffort: ptr.Ref("high"),
+		BusyBehavior:    codersdk.ChatBusyBehaviorQueue,
 	})
 	require.NoError(t, err)
 	require.True(t, resp.Queued)
@@ -7043,10 +7047,13 @@ func TestSendMessageQueuesEffectiveModelConfigID(t *testing.T) {
 	require.Len(t, queuedMessages, 1)
 	require.True(t, queuedMessages[0].ModelConfigID.Valid)
 	require.Equal(t, modelConfigB.ID, queuedMessages[0].ModelConfigID.UUID)
+	require.True(t, queuedMessages[0].ReasoningEffort.Valid)
+	require.Equal(t, database.ChatReasoningEffortHigh, queuedMessages[0].ReasoningEffort.ChatReasoningEffort)
 
 	storedChat, err := db.GetChatByID(dbauthz.AsSystemRestricted(ctx), chat.ID)
 	require.NoError(t, err)
 	require.Equal(t, modelConfigA.ID, storedChat.LastModelConfigID)
+	require.False(t, storedChat.LastReasoningEffort.Valid)
 }
 
 func TestQueuedMessageWithoutOverrideCapturesEnqueueTimeModel(t *testing.T) {

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -11466,6 +11466,34 @@ func createAdditionalChatModelConfig(
 	model string,
 ) codersdk.ChatModelConfig {
 	t.Helper()
+	return createAdditionalChatModelConfigWithModelConfig(t, client, provider, model, nil)
+}
+
+func createAdditionalChatModelConfigWithReasoningEffort(
+	t *testing.T,
+	client *codersdk.ExperimentalClient,
+	provider string,
+	model string,
+	defaultEffort string,
+	maxEffort string,
+) codersdk.ChatModelConfig {
+	t.Helper()
+	return createAdditionalChatModelConfigWithModelConfig(t, client, provider, model, &codersdk.ChatModelCallConfig{
+		ReasoningEffort: &codersdk.ChatModelReasoningEffortConfig{
+			Default: ptr.Ref(defaultEffort),
+			Max:     ptr.Ref(maxEffort),
+		},
+	})
+}
+
+func createAdditionalChatModelConfigWithModelConfig(
+	t *testing.T,
+	client *codersdk.ExperimentalClient,
+	provider string,
+	model string,
+	modelCallConfig *codersdk.ChatModelCallConfig,
+) codersdk.ChatModelConfig {
+	t.Helper()
 
 	ctx := testutil.Context(t, testutil.WaitLong)
 	aiProvider := createAIProviderForTest(t, client, provider, "test-api-key")
@@ -11476,6 +11504,7 @@ func createAdditionalChatModelConfig(
 		Model:        model,
 		ContextLimit: &contextLimit,
 		IsDefault:    &isDefault,
+		ModelConfig:  modelCallConfig,
 	})
 	require.NoError(t, err)
 	return modelConfig
@@ -12041,9 +12070,10 @@ func TestChatModelOverrides(t *testing.T) {
 	t.Parallel()
 
 	type overrideResponse struct {
-		context       codersdk.ChatModelOverrideContext
-		modelConfigID string
-		isMalformed   bool
+		context         codersdk.ChatModelOverrideContext
+		modelConfigID   string
+		reasoningEffort *string
+		isMalformed     bool
 	}
 
 	type settingTest struct {
@@ -12067,23 +12097,36 @@ func TestChatModelOverrides(t *testing.T) {
 			return overrideResponse{}, err
 		}
 		return overrideResponse{
-			context:       resp.Context,
-			modelConfigID: resp.ModelConfigID,
-			isMalformed:   resp.IsMalformed,
+			context:         resp.Context,
+			modelConfigID:   resp.ModelConfigID,
+			reasoningEffort: resp.ReasoningEffort,
+			isMalformed:     resp.IsMalformed,
 		}, nil
 	}
 
+	putOverrideWithEffort := func(
+		ctx context.Context,
+		client *codersdk.ExperimentalClient,
+		overrideContext codersdk.ChatModelOverrideContext,
+		modelConfigID string,
+		reasoningEffort *string,
+	) error {
+		return client.UpdateChatModelOverride(
+			ctx,
+			overrideContext,
+			codersdk.UpdateChatModelOverrideRequest{
+				ModelConfigID:   modelConfigID,
+				ReasoningEffort: reasoningEffort,
+			},
+		)
+	}
 	putOverride := func(
 		ctx context.Context,
 		client *codersdk.ExperimentalClient,
 		overrideContext codersdk.ChatModelOverrideContext,
 		modelConfigID string,
 	) error {
-		return client.UpdateChatModelOverride(
-			ctx,
-			overrideContext,
-			codersdk.UpdateChatModelOverrideRequest{ModelConfigID: modelConfigID},
-		)
+		return putOverrideWithEffort(ctx, client, overrideContext, modelConfigID, nil)
 	}
 
 	settings := []settingTest{
@@ -12129,6 +12172,14 @@ func TestChatModelOverrides(t *testing.T) {
 				adminClient,
 				coderdtest.TestChatProviderOpenAICompat,
 				"gpt-4.1-mini-"+string(setting.context),
+			)
+			reasoningModel := createAdditionalChatModelConfigWithReasoningEffort(
+				t,
+				adminClient,
+				coderdtest.TestChatProviderOpenAICompat,
+				"gpt-4.1-reasoning-"+string(setting.context),
+				"medium",
+				"high",
 			)
 			disabledModel := createDisabledChatModelConfig(
 				t,
@@ -12181,6 +12232,62 @@ func TestChatModelOverrides(t *testing.T) {
 				require.Equal(t, setting.context, resp.context)
 				require.Empty(t, resp.modelConfigID)
 				require.False(t, resp.isMalformed)
+			})
+
+			t.Run("AdminCanSetReasoningEffort", func(t *testing.T) {
+				ctx := testutil.Context(t, testutil.WaitLong)
+
+				err := putOverrideWithEffort(ctx, adminClient, setting.context, reasoningModel.ID.String(), ptr.Ref("high"))
+				require.NoError(t, err)
+
+				raw, err := setting.dbGet(ctx, db)
+				require.NoError(t, err)
+				require.Equal(t, reasoningModel.ID.String()+":high", raw)
+
+				resp, err := getOverride(ctx, adminClient, setting.context)
+				require.NoError(t, err)
+				require.Equal(t, reasoningModel.ID.String(), resp.modelConfigID)
+				require.Equal(t, ptr.Ref("high"), resp.reasoningEffort)
+				require.False(t, resp.isMalformed)
+
+				err = putOverride(ctx, adminClient, setting.context, "")
+				require.NoError(t, err)
+			})
+
+			t.Run("PUTRejectsEncodedModelConfigID", func(t *testing.T) {
+				ctx := testutil.Context(t, testutil.WaitLong)
+
+				encodedModelConfigID := reasoningModel.ID.String() + ":high"
+				err := putOverride(ctx, adminClient, setting.context, encodedModelConfigID)
+				sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+				require.Equal(t, "Invalid model_config_id.", sdkErr.Message)
+				require.Equal(t, "Value "+strconv.Quote(encodedModelConfigID)+" is not a valid UUID.", sdkErr.Detail)
+			})
+
+			t.Run("ReasoningEffortRequiresModel", func(t *testing.T) {
+				ctx := testutil.Context(t, testutil.WaitLong)
+
+				err := putOverrideWithEffort(ctx, adminClient, setting.context, "", ptr.Ref("high"))
+				sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+				require.Equal(t, "reasoning_effort requires model_config_id.", sdkErr.Message)
+			})
+
+			t.Run("ReasoningEffortMustBeSelectable", func(t *testing.T) {
+				ctx := testutil.Context(t, testutil.WaitLong)
+
+				err := putOverrideWithEffort(ctx, adminClient, setting.context, reasoningModel.ID.String(), ptr.Ref("xhigh"))
+				sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+				require.Equal(t, "Invalid reasoning_effort value.", sdkErr.Message)
+				require.Equal(t, "Must be one of none, minimal, low, medium, high.", sdkErr.Detail)
+			})
+
+			t.Run("ReasoningEffortUnsupportedModel", func(t *testing.T) {
+				ctx := testutil.Context(t, testutil.WaitLong)
+
+				err := putOverrideWithEffort(ctx, adminClient, setting.context, openAIModel.ID.String(), ptr.Ref("high"))
+				sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+				require.Equal(t, "Invalid reasoning_effort value.", sdkErr.Message)
+				require.Equal(t, "This model does not support reasoning effort.", sdkErr.Detail)
 			})
 
 			t.Run("MalformedStoredOverrideIsReportedAndCanBeCleared", func(t *testing.T) {
@@ -12352,11 +12459,21 @@ func TestUserChatPersonalModelOverrides(t *testing.T) {
 	})
 	require.NoError(t, err)
 	contextLimit := int64(4096)
-	modelConfig, err := adminClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+	modelConfigRequest := codersdk.CreateChatModelConfigRequest{
 		AIProviderID: &modelProvider.ID,
 		Model:        "claude-personal-" + uuid.NewString(),
 		ContextLimit: &contextLimit,
-	})
+	}
+	modelConfig, err := adminClient.CreateChatModelConfig(ctx, modelConfigRequest)
+	require.NoError(t, err)
+	modelConfigRequest.Model = "claude-personal-reasoning-" + uuid.NewString()
+	modelConfigRequest.ModelConfig = &codersdk.ChatModelCallConfig{
+		ReasoningEffort: &codersdk.ChatModelReasoningEffortConfig{
+			Default: ptr.Ref("medium"),
+			Max:     ptr.Ref("high"),
+		},
+	}
+	reasoningModelConfig, err := adminClient.CreateChatModelConfig(ctx, modelConfigRequest)
 	require.NoError(t, err)
 	err = adminClient.UpdateChatModelOverride(ctx, codersdk.ChatModelOverrideContextGeneral, codersdk.UpdateChatModelOverrideRequest{
 		ModelConfigID: modelConfig.ID.String(),
@@ -12406,6 +12523,24 @@ func TestUserChatPersonalModelOverrides(t *testing.T) {
 			return codersdk.ChatPersonalModelOverride{}
 		}
 	}
+	assertOverrideWithEffort := func(
+		resp codersdk.UserChatPersonalModelOverridesResponse,
+		overrideContext codersdk.ChatPersonalModelOverrideContext,
+		mode codersdk.ChatPersonalModelOverrideMode,
+		modelConfigID string,
+		reasoningEffort *string,
+		isSet bool,
+		isMalformed bool,
+	) {
+		t.Helper()
+		override := personalOverride(resp, overrideContext)
+		require.Equal(t, overrideContext, override.Context)
+		require.Equal(t, mode, override.Mode)
+		require.Equal(t, modelConfigID, override.ModelConfigID)
+		require.Equal(t, reasoningEffort, override.ReasoningEffort)
+		require.Equal(t, isSet, override.IsSet)
+		require.Equal(t, isMalformed, override.IsMalformed)
+	}
 	assertOverride := func(
 		resp codersdk.UserChatPersonalModelOverridesResponse,
 		overrideContext codersdk.ChatPersonalModelOverrideContext,
@@ -12415,17 +12550,13 @@ func TestUserChatPersonalModelOverrides(t *testing.T) {
 		isMalformed bool,
 	) {
 		t.Helper()
-		override := personalOverride(resp, overrideContext)
-		require.Equal(t, overrideContext, override.Context)
-		require.Equal(t, mode, override.Mode)
-		require.Equal(t, modelConfigID, override.ModelConfigID)
-		require.Equal(t, isSet, override.IsSet)
-		require.Equal(t, isMalformed, override.IsMalformed)
+		assertOverrideWithEffort(resp, overrideContext, mode, modelConfigID, nil, isSet, isMalformed)
 	}
 	assertDeploymentDefault := func(
 		resp codersdk.UserChatPersonalModelOverridesResponse,
 		overrideContext codersdk.ChatModelOverrideContext,
 		modelConfigID string,
+		reasoningEffort *string,
 		isMalformed bool,
 	) {
 		t.Helper()
@@ -12440,6 +12571,7 @@ func TestUserChatPersonalModelOverrides(t *testing.T) {
 		}
 		require.Equal(t, overrideContext, override.Context)
 		require.Equal(t, modelConfigID, override.ModelConfigID)
+		require.Equal(t, reasoningEffort, override.ReasoningEffort)
 		require.Equal(t, isMalformed, override.IsMalformed)
 	}
 	upsertRaw := func(
@@ -12496,8 +12628,20 @@ func TestUserChatPersonalModelOverrides(t *testing.T) {
 	t.Run("GETIncludesDeploymentDefaults", func(t *testing.T) {
 		resp, err := memberClient.GetUserChatPersonalModelOverrides(ctx)
 		require.NoError(t, err)
-		assertDeploymentDefault(resp, codersdk.ChatModelOverrideContextGeneral, modelConfig.ID.String(), false)
-		assertDeploymentDefault(resp, codersdk.ChatModelOverrideContextExplore, defaultModelConfig.ID.String(), false)
+		assertDeploymentDefault(resp, codersdk.ChatModelOverrideContextGeneral, modelConfig.ID.String(), nil, false)
+		assertDeploymentDefault(resp, codersdk.ChatModelOverrideContextExplore, defaultModelConfig.ID.String(), nil, false)
+	})
+
+	t.Run("GETIncludesDeploymentDefaultReasoningEffort", func(t *testing.T) {
+		err := adminClient.UpdateChatModelOverride(ctx, codersdk.ChatModelOverrideContextGeneral, codersdk.UpdateChatModelOverrideRequest{
+			ModelConfigID:   reasoningModelConfig.ID.String(),
+			ReasoningEffort: ptr.Ref("high"),
+		})
+		require.NoError(t, err)
+
+		resp, err := memberClient.GetUserChatPersonalModelOverrides(ctx)
+		require.NoError(t, err)
+		assertDeploymentDefault(resp, codersdk.ChatModelOverrideContextGeneral, reasoningModelConfig.ID.String(), ptr.Ref("high"), false)
 	})
 
 	t.Run("PUTDisabledReturns403AndPreservesRows", func(t *testing.T) {
@@ -12606,6 +12750,57 @@ func TestUserChatPersonalModelOverrides(t *testing.T) {
 		for _, overrideContext := range contexts {
 			assertOverride(resp, overrideContext, codersdk.ChatPersonalModelOverrideModeModel, modelConfig.ID.String(), true, false)
 		}
+	})
+
+	t.Run("PUTModelRoundTripsReasoningEffort", func(t *testing.T) {
+		err := memberClient.UpdateUserChatPersonalModelOverride(ctx, codersdk.ChatPersonalModelOverrideContextGeneral, codersdk.UpdateUserChatPersonalModelOverrideRequest{
+			Mode:            codersdk.ChatPersonalModelOverrideModeModel,
+			ModelConfigID:   reasoningModelConfig.ID.String(),
+			ReasoningEffort: ptr.Ref("high"),
+		})
+		require.NoError(t, err)
+
+		require.Equal(t, "model:"+reasoningModelConfig.ID.String()+":high", getRaw(codersdk.ChatPersonalModelOverrideContextGeneral))
+		resp, err := memberClient.GetUserChatPersonalModelOverrides(ctx)
+		require.NoError(t, err)
+		assertOverrideWithEffort(resp, codersdk.ChatPersonalModelOverrideContextGeneral, codersdk.ChatPersonalModelOverrideModeModel, reasoningModelConfig.ID.String(), ptr.Ref("high"), true, false)
+	})
+
+	t.Run("PUTReasoningEffortRejectsNonModelMode", func(t *testing.T) {
+		rawBefore := getRaw(codersdk.ChatPersonalModelOverrideContextGeneral)
+		err := memberClient.UpdateUserChatPersonalModelOverride(ctx, codersdk.ChatPersonalModelOverrideContextGeneral, codersdk.UpdateUserChatPersonalModelOverrideRequest{
+			Mode:            codersdk.ChatPersonalModelOverrideModeDeploymentDefault,
+			ReasoningEffort: ptr.Ref("high"),
+		})
+		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+		require.Equal(t, "reasoning_effort requires mode model.", sdkErr.Message)
+		require.Equal(t, rawBefore, getRaw(codersdk.ChatPersonalModelOverrideContextGeneral))
+	})
+
+	t.Run("PUTReasoningEffortMustBeSelectable", func(t *testing.T) {
+		rawBefore := getRaw(codersdk.ChatPersonalModelOverrideContextGeneral)
+		err := memberClient.UpdateUserChatPersonalModelOverride(ctx, codersdk.ChatPersonalModelOverrideContextGeneral, codersdk.UpdateUserChatPersonalModelOverrideRequest{
+			Mode:            codersdk.ChatPersonalModelOverrideModeModel,
+			ModelConfigID:   reasoningModelConfig.ID.String(),
+			ReasoningEffort: ptr.Ref("xhigh"),
+		})
+		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+		require.Equal(t, "Invalid reasoning_effort value.", sdkErr.Message)
+		require.Equal(t, "Must be one of none, minimal, low, medium, high.", sdkErr.Detail)
+		require.Equal(t, rawBefore, getRaw(codersdk.ChatPersonalModelOverrideContextGeneral))
+	})
+
+	t.Run("PUTReasoningEffortUnsupportedModel", func(t *testing.T) {
+		rawBefore := getRaw(codersdk.ChatPersonalModelOverrideContextGeneral)
+		err := memberClient.UpdateUserChatPersonalModelOverride(ctx, codersdk.ChatPersonalModelOverrideContextGeneral, codersdk.UpdateUserChatPersonalModelOverrideRequest{
+			Mode:            codersdk.ChatPersonalModelOverrideModeModel,
+			ModelConfigID:   modelConfig.ID.String(),
+			ReasoningEffort: ptr.Ref("high"),
+		})
+		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+		require.Equal(t, "Invalid reasoning_effort value.", sdkErr.Message)
+		require.Equal(t, "This model does not support reasoning effort.", sdkErr.Detail)
+		require.Equal(t, rawBefore, getRaw(codersdk.ChatPersonalModelOverrideContextGeneral))
 	})
 
 	t.Run("PUTModelRejectsInvalidModels", func(t *testing.T) {
@@ -12823,6 +13018,31 @@ func TestCreateChatPersonalModelOverrideRoot(t *testing.T) {
 
 		chat := createChat(adminClient, "root model override uses saved model", nil)
 		require.Equal(t, overrideModel.ID, chat.LastModelConfigID)
+	})
+
+	t.Run("RootModelOverrideUsesSavedReasoningEffort", func(t *testing.T) {
+		reasoningModel, err := adminClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+			AIProviderID: &overrideProvider.ID,
+			Model:        "claude-root-personal-reasoning-" + uuid.NewString(),
+			ContextLimit: &contextLimit,
+			ModelConfig: &codersdk.ChatModelCallConfig{
+				ReasoningEffort: &codersdk.ChatModelReasoningEffortConfig{
+					Default: ptr.Ref("medium"),
+					Max:     ptr.Ref("high"),
+				},
+			},
+		})
+		require.NoError(t, err)
+		err = adminClient.UpdateUserChatPersonalModelOverride(ctx, codersdk.ChatPersonalModelOverrideContextRoot, codersdk.UpdateUserChatPersonalModelOverrideRequest{
+			Mode:            codersdk.ChatPersonalModelOverrideModeModel,
+			ModelConfigID:   reasoningModel.ID.String(),
+			ReasoningEffort: ptr.Ref("high"),
+		})
+		require.NoError(t, err)
+
+		chat := createChat(adminClient, "root model override uses saved reasoning effort", nil)
+		require.Equal(t, reasoningModel.ID, chat.LastModelConfigID)
+		require.Equal(t, ptr.Ref("high"), chat.LastReasoningEffort)
 	})
 
 	t.Run("UnavailableRootModelFallsBackToDefault", func(t *testing.T) {

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -2888,7 +2888,6 @@ type chatMessage struct {
 	contextLimit        int64
 	totalCostMicros     int64
 	runtimeMs           int64
-	reasoningEffort     string
 }
 
 type userChatMessage struct {
@@ -2949,7 +2948,7 @@ func appendMessageFields(
 	params.CreatedBy = append(params.CreatedBy, msg.createdBy)
 	params.APIKeyID = append(params.APIKeyID, apiKeyID)
 	params.ModelConfigID = append(params.ModelConfigID, msg.modelConfigID)
-	params.ReasoningEffort = append(params.ReasoningEffort, msg.reasoningEffort)
+	params.ReasoningEffort = append(params.ReasoningEffort, "")
 	params.Role = append(params.Role, msg.role)
 	params.Content = append(params.Content, string(msg.content.RawMessage))
 	params.ContentVersion = append(params.ContentVersion, msg.contentVersion)

--- a/coderd/x/chatd/personal_model_override.go
+++ b/coderd/x/chatd/personal_model_override.go
@@ -26,9 +26,10 @@ func ChatPersonalModelOverrideKey(
 // When Malformed is true, Mode is the provided default and ModelConfigID is
 // uuid.Nil.
 type ParsedChatPersonalModelOverride struct {
-	Mode          codersdk.ChatPersonalModelOverrideMode
-	ModelConfigID uuid.UUID
-	Malformed     bool
+	Mode            codersdk.ChatPersonalModelOverrideMode
+	ModelConfigID   uuid.UUID
+	ReasoningEffort *string
+	Malformed       bool
 }
 
 // ParseChatPersonalModelOverride parses a stored personal model override.
@@ -61,15 +62,20 @@ func ParseChatPersonalModelOverride(
 			Malformed: true,
 		}
 	}
-	modelConfigID, err := uuid.Parse(rawModelConfigID)
-	if err != nil {
+	rawID, rawEffort, hasEffort := strings.Cut(rawModelConfigID, ":")
+	modelConfigID, err := uuid.Parse(rawID)
+	if err != nil || (hasEffort && rawEffort == "") {
 		return ParsedChatPersonalModelOverride{
 			Mode:      defaultMode,
 			Malformed: true,
 		}
 	}
-	return ParsedChatPersonalModelOverride{
+	parsed := ParsedChatPersonalModelOverride{
 		Mode:          codersdk.ChatPersonalModelOverrideModeModel,
 		ModelConfigID: modelConfigID,
 	}
+	if hasEffort {
+		parsed.ReasoningEffort = &rawEffort
+	}
+	return parsed
 }

--- a/coderd/x/chatd/personal_model_override_test.go
+++ b/coderd/x/chatd/personal_model_override_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/coderd/x/chatd"
 	"github.com/coder/coder/v2/codersdk"
 )
@@ -61,6 +62,25 @@ func TestParseChatPersonalModelOverride(t *testing.T) {
 			want: chatd.ParsedChatPersonalModelOverride{
 				Mode:          codersdk.ChatPersonalModelOverrideModeModel,
 				ModelConfigID: modelConfigID,
+			},
+		},
+		{
+			name:        "ModelWithReasoningEffort",
+			raw:         "model:" + modelConfigID.String() + ":high",
+			defaultMode: codersdk.ChatPersonalModelOverrideModeDeploymentDefault,
+			want: chatd.ParsedChatPersonalModelOverride{
+				Mode:            codersdk.ChatPersonalModelOverrideModeModel,
+				ModelConfigID:   modelConfigID,
+				ReasoningEffort: ptr.Ref("high"),
+			},
+		},
+		{
+			name:        "ModelWithEmptyReasoningEffort",
+			raw:         "model:" + modelConfigID.String() + ":",
+			defaultMode: codersdk.ChatPersonalModelOverrideModeDeploymentDefault,
+			want: chatd.ParsedChatPersonalModelOverride{
+				Mode:      codersdk.ChatPersonalModelOverrideModeDeploymentDefault,
+				Malformed: true,
 			},
 		},
 		{

--- a/coderd/x/chatd/subagent.go
+++ b/coderd/x/chatd/subagent.go
@@ -192,48 +192,46 @@ func (p *Server) resolveConfiguredModelOverride(
 	resolveModelConfig modelOverrideConfigResolver,
 	resolveProviderKeys modelOverrideProviderKeysResolver,
 	failureMode modelOverrideFailureMode,
-) (database.ChatModelConfig, bool, error) {
-	trimmed := strings.TrimSpace(raw)
-	if trimmed == "" {
-		return database.ChatModelConfig{}, false, nil
-	}
-	configuredModelConfigID, err := uuid.Parse(trimmed)
-	if err != nil {
+) (database.ChatModelConfig, *string, bool, error) {
+	parsed, ok := parseModelOverride(raw)
+	if !ok {
 		p.logger.Info(ctx,
 			"invalid model override, ignoring",
 			slog.F("override_context", overrideContext),
-			slog.F("raw_model_config_id", trimmed),
-			slog.Error(err),
+			slog.F("raw_model_config_id", strings.TrimSpace(raw)),
 		)
-		return database.ChatModelConfig{}, false, nil
+		return database.ChatModelConfig{}, nil, false, nil
+	}
+	if parsed.modelConfigID == uuid.Nil {
+		return database.ChatModelConfig{}, nil, false, nil
 	}
 
 	modelConfig, providerName, err := resolveModelConfig(
 		ctx,
-		configuredModelConfigID,
+		parsed.modelConfigID,
 	)
 	if err != nil {
 		if failureMode == modelOverrideFailureModeHard {
 			label := modelOverrideErrorLabel(overrideContext)
 			switch {
 			case errors.Is(err, sql.ErrNoRows):
-				return database.ChatModelConfig{}, true, xerrors.Errorf(
+				return database.ChatModelConfig{}, parsed.reasoningEffort, true, xerrors.Errorf(
 					"%s model override is unavailable: %s",
 					label,
-					configuredModelConfigID,
+					parsed.modelConfigID,
 				)
 			case errors.Is(err, errInvalidModelOverrideMetadata):
-				return database.ChatModelConfig{}, true, xerrors.Errorf(
+				return database.ChatModelConfig{}, parsed.reasoningEffort, true, xerrors.Errorf(
 					"%s model override metadata is invalid for %s: %w",
 					label,
-					configuredModelConfigID,
+					parsed.modelConfigID,
 					err,
 				)
 			default:
-				return database.ChatModelConfig{}, true, xerrors.Errorf(
+				return database.ChatModelConfig{}, parsed.reasoningEffort, true, xerrors.Errorf(
 					"resolve %s model override %s: %w",
 					label,
-					configuredModelConfigID,
+					parsed.modelConfigID,
 					err,
 				)
 			}
@@ -244,36 +242,36 @@ func (p *Server) resolveConfiguredModelOverride(
 			p.logger.Info(ctx,
 				"model override is unavailable, ignoring",
 				slog.F("override_context", overrideContext),
-				slog.F("model_config_id", configuredModelConfigID),
+				slog.F("model_config_id", parsed.modelConfigID),
 			)
 		case errors.Is(err, errInvalidModelOverrideMetadata):
 			p.logger.Info(ctx,
 				"model override metadata is invalid, ignoring",
 				slog.F("override_context", overrideContext),
-				slog.F("model_config_id", configuredModelConfigID),
+				slog.F("model_config_id", parsed.modelConfigID),
 				slog.Error(err),
 			)
 		default:
 			p.logger.Warn(ctx,
 				"failed to resolve model override, ignoring",
 				slog.F("override_context", overrideContext),
-				slog.F("model_config_id", configuredModelConfigID),
+				slog.F("model_config_id", parsed.modelConfigID),
 				slog.Error(err),
 			)
 		}
-		return database.ChatModelConfig{}, false, nil
+		return database.ChatModelConfig{}, nil, false, nil
 	}
 
 	providerKeys, err := resolveProviderKeys(ctx, ownerID, modelConfigAIProviderID(modelConfig))
 	if err != nil {
-		return database.ChatModelConfig{}, false, xerrors.Errorf(
+		return database.ChatModelConfig{}, nil, false, xerrors.Errorf(
 			"resolve provider API keys: %w",
 			err,
 		)
 	}
 	if !userCanUseProviderKeys(providerKeys, providerName) {
 		if failureMode == modelOverrideFailureModeHard {
-			return database.ChatModelConfig{}, true, xerrors.Errorf(
+			return database.ChatModelConfig{}, parsed.reasoningEffort, true, xerrors.Errorf(
 				"%s model override credentials are unavailable for provider %q",
 				modelOverrideErrorLabel(overrideContext),
 				providerName,
@@ -283,22 +281,22 @@ func (p *Server) resolveConfiguredModelOverride(
 		p.logger.Info(ctx,
 			"model override credentials are unavailable, ignoring",
 			slog.F("override_context", overrideContext),
-			slog.F("model_config_id", configuredModelConfigID),
+			slog.F("model_config_id", parsed.modelConfigID),
 			slog.F("provider", providerName),
 		)
-		return database.ChatModelConfig{}, false, nil
+		return database.ChatModelConfig{}, nil, false, nil
 	}
-	return modelConfig, true, nil
+	return modelConfig, parsed.reasoningEffort, true, nil
 }
 
 func (p *Server) resolvePersonalSubagentModelConfigID(
 	ctx context.Context,
 	ownerID uuid.UUID,
 	overrideContext codersdk.ChatModelOverrideContext,
-) (uuid.UUID, bool, error) {
+) (uuid.UUID, *string, bool, error) {
 	personalContext, err := personalModelOverrideContextForSubagent(overrideContext)
 	if err != nil {
-		return uuid.Nil, false, err
+		return uuid.Nil, nil, false, err
 	}
 	raw, err := p.db.GetUserChatPersonalModelOverride(
 		ctx,
@@ -309,7 +307,7 @@ func (p *Server) resolvePersonalSubagentModelConfigID(
 	)
 	if err != nil {
 		if !xerrors.Is(err, sql.ErrNoRows) {
-			return uuid.Nil, false, xerrors.Errorf(
+			return uuid.Nil, nil, false, xerrors.Errorf(
 				"get %s personal model override: %w",
 				subagentModelOverrideLogLabel(overrideContext),
 				err,
@@ -332,7 +330,7 @@ func (p *Server) resolvePersonalSubagentModelConfigID(
 	}
 	switch parsed.Mode {
 	case codersdk.ChatPersonalModelOverrideModeChatDefault:
-		return uuid.Nil, true, nil
+		return uuid.Nil, nil, true, nil
 	case codersdk.ChatPersonalModelOverrideModeDeploymentDefault:
 	case codersdk.ChatPersonalModelOverrideModeModel:
 		modelConfig, ok, err := p.resolvePersonalModelOverride(
@@ -342,10 +340,10 @@ func (p *Server) resolvePersonalSubagentModelConfigID(
 			parsed.ModelConfigID,
 		)
 		if err != nil {
-			return uuid.Nil, false, err
+			return uuid.Nil, nil, false, err
 		}
 		if ok {
-			return modelConfig.ID, true, nil
+			return modelConfig.ID, parsed.ReasoningEffort, true, nil
 		}
 	default:
 		p.logger.Warn(ctx,
@@ -356,7 +354,7 @@ func (p *Server) resolvePersonalSubagentModelConfigID(
 		)
 	}
 
-	return uuid.Nil, false, nil
+	return uuid.Nil, nil, false, nil
 }
 
 func (p *Server) resolvePersonalModelOverride(
@@ -417,43 +415,75 @@ func (p *Server) resolvePersonalModelOverride(
 	return modelConfig, true, nil
 }
 
+func withResolvedReasoningEffort(
+	modelConfig database.ChatModelConfig,
+	reasoningEffort *string,
+) database.ChatModelConfig {
+	if reasoningEffort == nil {
+		return modelConfig
+	}
+	callConfig := codersdk.ChatModelCallConfig{}
+	if len(modelConfig.Options) > 0 {
+		if err := json.Unmarshal(modelConfig.Options, &callConfig); err != nil {
+			return modelConfig
+		}
+	}
+	resolvedEffort := chatprovider.ResolveReasoningEffort(
+		reasoningEffort,
+		callConfig.ReasoningEffort,
+	)
+	if resolvedEffort == nil {
+		return modelConfig
+	}
+	callConfig.ReasoningEffort = &codersdk.ChatModelReasoningEffortConfig{
+		Default: resolvedEffort,
+		Max:     resolvedEffort,
+	}
+	options, err := json.Marshal(callConfig)
+	if err != nil {
+		return modelConfig
+	}
+	modelConfig.Options = options
+	return modelConfig
+}
+
 func (p *Server) resolveSubagentModelConfigID(
 	ctx context.Context,
 	ownerID uuid.UUID,
 	overrideContext codersdk.ChatModelOverrideContext,
-) (uuid.UUID, error) {
+) (uuid.UUID, *string, error) {
 	//nolint:gocritic // Chatd needs its scoped config and user-data access here.
 	chatdCtx := dbauthz.AsChatd(ctx)
 	personalOverridesEnabled, err := p.db.GetChatPersonalModelOverridesEnabled(chatdCtx)
 	if err != nil {
-		return uuid.Nil, xerrors.Errorf(
+		return uuid.Nil, nil, xerrors.Errorf(
 			"get chat personal model overrides enabled: %w",
 			err,
 		)
 	}
 	if personalOverridesEnabled {
-		modelConfigID, resolved, err := p.resolvePersonalSubagentModelConfigID(
+		modelConfigID, reasoningEffort, resolved, err := p.resolvePersonalSubagentModelConfigID(
 			chatdCtx,
 			ownerID,
 			overrideContext,
 		)
 		if err != nil {
-			return uuid.Nil, err
+			return uuid.Nil, nil, err
 		}
 		if resolved {
-			return modelConfigID, nil
+			return modelConfigID, reasoningEffort, nil
 		}
 	}
 
 	raw, err := readSubagentModelOverride(chatdCtx, p.db, overrideContext)
 	if err != nil {
-		return uuid.Nil, xerrors.Errorf(
+		return uuid.Nil, nil, xerrors.Errorf(
 			"get %s model override: %w",
 			subagentModelOverrideLogLabel(overrideContext),
 			err,
 		)
 	}
-	modelConfig, ok, err := p.resolveConfiguredModelOverride(
+	modelConfig, reasoningEffort, ok, err := p.resolveConfiguredModelOverride(
 		chatdCtx,
 		string(overrideContext),
 		raw,
@@ -463,12 +493,12 @@ func (p *Server) resolveSubagentModelConfigID(
 		modelOverrideFailureModeSoft,
 	)
 	if err != nil {
-		return uuid.Nil, err
+		return uuid.Nil, nil, err
 	}
 	if !ok {
-		return uuid.Nil, nil
+		return uuid.Nil, nil, nil
 	}
-	return modelConfig.ID, nil
+	return modelConfig.ID, reasoningEffort, nil
 }
 
 func modelConfigAIProviderID(modelConfig database.ChatModelConfig) uuid.UUID {
@@ -932,17 +962,18 @@ func parseSubagentToolChatID(raw string) (uuid.UUID, error) {
 }
 
 // childSubagentChatOptions carries per-child overrides for subagent chat
-// creation. modelConfigIDOverride and planModeOverride apply to any
-// subagent. inheritedMCPServerIDs is an Explore-only snapshot of the
-// spawning parent turn's effective external MCP entitlement.
-// resolveExploreToolSnapshot computes and persists it on the child chat.
-// Non-Explore children ignore this field.
+// creation. modelConfigIDOverride, reasoningEffortOverride, and
+// planModeOverride apply to any subagent. inheritedMCPServerIDs is an
+// Explore-only snapshot of the spawning parent turn's effective external MCP
+// entitlement. resolveExploreToolSnapshot computes and persists it on the
+// child chat. Non-Explore children ignore this field.
 type childSubagentChatOptions struct {
-	chatMode              database.NullChatMode
-	systemPrompt          string
-	modelConfigIDOverride *uuid.UUID
-	planModeOverride      *database.NullChatPlanMode
-	inheritedMCPServerIDs []uuid.UUID
+	chatMode                database.NullChatMode
+	systemPrompt            string
+	modelConfigIDOverride   *uuid.UUID
+	reasoningEffortOverride *string
+	planModeOverride        *database.NullChatPlanMode
+	inheritedMCPServerIDs   []uuid.UUID
 }
 
 // resolveExploreToolSnapshot computes the child chat's inherited MCP
@@ -1118,7 +1149,7 @@ func (p *Server) createChildSubagentChatWithOptions(
 	// workspace context the same way a top-level chat does: pinned from the
 	// agent's latest snapshot (see hydrateChatContextOnCreate below). The
 	// parent's context is not copied into child history.
-	initialMessages = append(initialMessages, userMessageWithAPIKeyID(userContent, modelConfigID, parent.OwnerID, childAPIKeyID, nil))
+	initialMessages = append(initialMessages, userMessageWithAPIKeyID(userContent, modelConfigID, parent.OwnerID, childAPIKeyID, opts.reasoningEffortOverride))
 
 	publisher := p.pubsub
 	if publisher == nil {

--- a/coderd/x/chatd/subagent_catalog.go
+++ b/coderd/x/chatd/subagent_catalog.go
@@ -56,7 +56,7 @@ func allSubagentDefinitions() []subagentDefinition {
 			id:          subagentTypeGeneral,
 			description: "substantial delegated research, analysis, reasoning, review, planning support, and implementation",
 			buildOptions: func(ctx context.Context, p *Server, parent database.Chat, _ database.Chat, _ uuid.UUID, _ string) (childSubagentChatOptions, error) {
-				modelConfigID, err := p.resolveSubagentModelConfigID(
+				modelConfigID, reasoningEffort, err := p.resolveSubagentModelConfigID(
 					ctx,
 					parent.OwnerID,
 					codersdk.ChatModelOverrideContextGeneral,
@@ -67,6 +67,7 @@ func allSubagentDefinitions() []subagentDefinition {
 				options := childSubagentChatOptions{}
 				if modelConfigID != uuid.Nil {
 					options.modelConfigIDOverride = &modelConfigID
+					options.reasoningEffortOverride = reasoningEffort
 				}
 				return options, nil
 			},
@@ -75,7 +76,7 @@ func allSubagentDefinitions() []subagentDefinition {
 			id:          subagentTypeExplore,
 			description: "narrow repository-local read-only code discovery and code tracing",
 			buildOptions: func(ctx context.Context, p *Server, _ database.Chat, turnParent database.Chat, currentModelConfigID uuid.UUID, _ string) (childSubagentChatOptions, error) {
-				modelConfigID, err := p.resolveSubagentModelConfigID(
+				modelConfigID, reasoningEffort, err := p.resolveSubagentModelConfigID(
 					ctx,
 					turnParent.OwnerID,
 					codersdk.ChatModelOverrideContextExplore,
@@ -101,9 +102,10 @@ func allSubagentDefinitions() []subagentDefinition {
 						ChatMode: database.ChatModeExplore,
 						Valid:    true,
 					},
-					modelConfigIDOverride: &modelConfigID,
-					planModeOverride:      &clearPlanMode,
-					inheritedMCPServerIDs: inheritedMCPServerIDs,
+					modelConfigIDOverride:   &modelConfigID,
+					reasoningEffortOverride: reasoningEffort,
+					planModeOverride:        &clearPlanMode,
+					inheritedMCPServerIDs:   inheritedMCPServerIDs,
 				}, nil
 			},
 		},

--- a/coderd/x/chatd/subagent_internal_test.go
+++ b/coderd/x/chatd/subagent_internal_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
 	coderdpubsub "github.com/coder/coder/v2/coderd/pubsub"
+	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatloop"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprovider"
@@ -1489,7 +1490,7 @@ func TestResolveConfiguredModelOverride_AcceptsAmbientCredentialsProvider(
 		Enabled:     true,
 	}
 
-	resolvedModelConfig, ok, err := server.resolveConfiguredModelOverride(
+	resolvedModelConfig, reasoningEffort, ok, err := server.resolveConfiguredModelOverride(
 		ctx,
 		"plan",
 		modelConfig.ID.String(),
@@ -1514,12 +1515,83 @@ func TestResolveConfiguredModelOverride_AcceptsAmbientCredentialsProvider(
 		modelOverrideFailureModeSoft,
 	)
 	require.NoError(t, err)
+	require.Nil(t, reasoningEffort)
 	require.True(t, ok)
 	require.Equal(t, modelConfig, resolvedModelConfig)
 	require.Empty(t, logSink.entriesAtLevelWithMessage(
 		slog.LevelInfo,
 		"model override credentials are unavailable, ignoring",
 	))
+}
+
+func TestWithResolvedReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	baseOptions, err := json.Marshal(codersdk.ChatModelCallConfig{
+		MaxOutputTokens: ptr.Ref(int64(123)),
+		ReasoningEffort: &codersdk.ChatModelReasoningEffortConfig{
+			Default: ptr.Ref(codersdk.ChatModelReasoningEffortLow),
+			Max:     ptr.Ref(codersdk.ChatModelReasoningEffortHigh),
+		},
+	})
+	require.NoError(t, err)
+
+	t.Run("NilEffortReturnsOriginalConfig", func(t *testing.T) {
+		t.Parallel()
+		modelConfig := database.ChatModelConfig{Options: baseOptions}
+		require.Equal(t, modelConfig, withResolvedReasoningEffort(modelConfig, nil))
+	})
+
+	t.Run("InvalidJSONReturnsOriginalConfig", func(t *testing.T) {
+		t.Parallel()
+		modelConfig := database.ChatModelConfig{Options: []byte(`{`)}
+		require.Equal(t, modelConfig, withResolvedReasoningEffort(modelConfig, ptr.Ref(codersdk.ChatModelReasoningEffortHigh)))
+	})
+
+	t.Run("NoReasoningConfigReturnsOriginalConfig", func(t *testing.T) {
+		t.Parallel()
+		modelConfig := database.ChatModelConfig{Options: []byte(`{"max_output_tokens":123}`)}
+		require.Equal(t, modelConfig, withResolvedReasoningEffort(modelConfig, ptr.Ref(codersdk.ChatModelReasoningEffortHigh)))
+	})
+
+	t.Run("ClampsRequestedEffortAndPreservesOtherOptions", func(t *testing.T) {
+		t.Parallel()
+		modelConfig := database.ChatModelConfig{Options: baseOptions}
+
+		got := withResolvedReasoningEffort(modelConfig, ptr.Ref(codersdk.ChatModelReasoningEffortXHigh))
+
+		var callConfig codersdk.ChatModelCallConfig
+		require.NoError(t, json.Unmarshal(got.Options, &callConfig))
+		require.Equal(t, ptr.Ref(int64(123)), callConfig.MaxOutputTokens)
+		require.Equal(t, ptr.Ref(codersdk.ChatModelReasoningEffortHigh), callConfig.ReasoningEffort.Default)
+		require.Equal(t, ptr.Ref(codersdk.ChatModelReasoningEffortHigh), callConfig.ReasoningEffort.Max)
+	})
+}
+
+func TestCreateChildSubagentChat_StoresReasoningEffortOverride(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	server := newInternalTestServer(t, db, ps, chatprovider.ProviderAPIKeys{})
+
+	ctx := chatdTestContext(t)
+	user, org, model := seedInternalChatDeps(t, db)
+	parentChat := createInternalParentChat(
+		ctx, t, server, db, org.ID, user.ID, model.ID, "parent-effort-override",
+	)
+	ctx = aibridge.WithDelegatedAPIKeyID(ctx, testAPIKeyID(t, server.db, parentChat.OwnerID))
+	child, err := server.createChildSubagentChatWithOptions(
+		ctx,
+		parentChat,
+		"delegate work",
+		"",
+		childSubagentChatOptions{reasoningEffortOverride: ptr.Ref("high")},
+	)
+	require.NoError(t, err)
+
+	childChat, err := db.GetChatByID(ctx, child.ID)
+	require.NoError(t, err)
+	require.Equal(t, database.NullChatReasoningEffort{ChatReasoningEffort: database.ChatReasoningEffortHigh, Valid: true}, childChat.LastReasoningEffort)
 }
 
 func TestCreateChildSubagentChat_OverrideWorksWhenParentHasNoModel(t *testing.T) {

--- a/coderd/x/chatd/title_override.go
+++ b/coderd/x/chatd/title_override.go
@@ -2,6 +2,7 @@ package chatd
 
 import (
 	"context"
+	"strings"
 
 	"charm.land/fantasy"
 	"github.com/google/uuid"
@@ -13,6 +14,28 @@ import (
 )
 
 const titleGenerationOverrideContext = "title_generation"
+
+type parsedModelOverride struct {
+	modelConfigID   uuid.UUID
+	reasoningEffort *string
+}
+
+func parseModelOverride(raw string) (parsedModelOverride, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return parsedModelOverride{}, true
+	}
+	rawID, rawEffort, hasEffort := strings.Cut(trimmed, ":")
+	modelConfigID, err := uuid.Parse(rawID)
+	if err != nil || (hasEffort && rawEffort == "") {
+		return parsedModelOverride{}, false
+	}
+	parsed := parsedModelOverride{modelConfigID: modelConfigID}
+	if hasEffort {
+		parsed.reasoningEffort = &rawEffort
+	}
+	return parsed, true
+}
 
 func readTitleGenerationModelOverride(
 	ctx context.Context,
@@ -47,7 +70,7 @@ func (p *Server) resolveTitleGenerationModelOverride(
 		)
 	}
 
-	modelConfig, overrideSet, err := p.resolveConfiguredModelOverride(
+	modelConfig, overrideEffort, overrideSet, err := p.resolveConfiguredModelOverride(
 		ctx,
 		titleGenerationOverrideContext,
 		raw,
@@ -64,6 +87,7 @@ func (p *Server) resolveTitleGenerationModelOverride(
 	if !overrideSet {
 		return database.ChatModelConfig{}, nil, aiGatewayModelRoute{}, false, nil
 	}
+	modelConfig = withResolvedReasoningEffort(modelConfig, overrideEffort)
 
 	//nolint:gocritic // Title overrides need chatd-scoped provider reads for user-owned chats.
 	route, err := p.resolveModelRouteForConfig(dbauthz.AsChatd(ctx), chat.OwnerID, modelConfig)

--- a/coderd/x/chatd/title_override_internal_test.go
+++ b/coderd/x/chatd/title_override_internal_test.go
@@ -3,6 +3,7 @@ package chatd
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strconv"
@@ -11,6 +12,7 @@ import (
 	"testing"
 
 	"charm.land/fantasy"
+	fantasyopenai "charm.land/fantasy/providers/openai"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -21,6 +23,7 @@ import (
 	"github.com/coder/coder/v2/coderd/aibridge"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
+	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/coderd/x/chatd/chattest"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
@@ -183,16 +186,29 @@ func TestMaybeGenerateChatTitle_TitleGenerationOverrideSetUsable(t *testing.T) {
 	db := dbmock.NewMockStore(ctrl)
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
 	chat, messages := titleOverrideTestChatAndMessages(t)
-	overrideConfig := titleOverrideModelConfig("gpt-4.1", true)
+	overrideConfig := titleOverrideModelConfig("gpt-5", true)
 	providerID := uuid.New()
 	overrideConfig.AIProviderID = uuid.NullUUID{UUID: providerID, Valid: true}
+	options, err := json.Marshal(codersdk.ChatModelCallConfig{
+		ReasoningEffort: &codersdk.ChatModelReasoningEffortConfig{
+			Default: ptr.Ref(codersdk.ChatModelReasoningEffortLow),
+			Max:     ptr.Ref(codersdk.ChatModelReasoningEffortHigh),
+		},
+	})
+	require.NoError(t, err)
+	overrideConfig.Options = options
 	wantTitle := "Override title"
 
 	var requestCount atomic.Int32
 	factory := &aibridgeTestFactory{rt: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		requestCount.Add(1)
+		bodyBytes, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		var raw map[string]any
+		require.NoError(t, json.Unmarshal(bodyBytes, &raw))
+		require.Equal(t, string(fantasyopenai.ReasoningEffortHigh), raw["reasoning"].(map[string]any)["effort"])
 		text := strconv.Quote(`{"title":"` + wantTitle + `"}`)
-		body := `{"id":"resp_test","object":"response","created_at":0,"status":"completed","model":"gpt-4.1","output":[{"id":"msg_test","type":"message","role":"assistant","content":[{"type":"output_text","text":` + text + `}]}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`
+		body := `{"id":"resp_test","object":"response","created_at":0,"status":"completed","model":"gpt-5","output":[{"id":"msg_test","type":"message","role":"assistant","content":[{"type":"output_text","text":` + text + `}]}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header{"Content-Type": []string{"application/json"}},
@@ -213,7 +229,7 @@ func TestMaybeGenerateChatTitle_TitleGenerationOverrideSetUsable(t *testing.T) {
 		},
 	}
 
-	db.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return(overrideConfig.ID.String(), nil)
+	db.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return(overrideConfig.ID.String()+":xhigh", nil)
 	db.EXPECT().GetChatModelConfigByID(gomock.Any(), overrideConfig.ID).Return(overrideConfig, nil)
 	db.EXPECT().GetAIProviderByID(gomock.Any(), providerID).Return(provider, nil).AnyTimes()
 	db.EXPECT().GetAIProviderKeysByProviderID(gomock.Any(), providerID).Return([]database.AIProviderKey{{
@@ -658,6 +674,41 @@ func TestResolveManualTitleModel_TitleGenerationOverrideSetUnusable(t *testing.T
 	require.ErrorContains(t, err, "title generation model override is unavailable")
 	require.Nil(t, model)
 	require.Equal(t, database.ChatModelConfig{}, gotConfig)
+}
+
+func TestParseModelOverride(t *testing.T) {
+	t.Parallel()
+
+	modelConfigID := uuid.New()
+	tests := []struct {
+		name       string
+		raw        string
+		wantID     uuid.UUID
+		wantEffort *string
+		wantOK     bool
+	}{
+		{name: "Empty", raw: "", wantOK: true},
+		{name: "Whitespace", raw: " \t\n ", wantOK: true},
+		{name: "IDOnly", raw: modelConfigID.String(), wantID: modelConfigID, wantOK: true},
+		{name: "IDWithEffort", raw: modelConfigID.String() + ":high", wantID: modelConfigID, wantEffort: ptr.Ref("high"), wantOK: true},
+		{name: "IDEmptyEffort", raw: modelConfigID.String() + ":", wantOK: false},
+		{name: "OuterWhitespace", raw: " \t" + modelConfigID.String() + ":high\n ", wantID: modelConfigID, wantEffort: ptr.Ref("high"), wantOK: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := parseModelOverride(tt.raw)
+
+			require.Equal(t, tt.wantOK, ok)
+			if !tt.wantOK {
+				return
+			}
+			require.Equal(t, tt.wantID, got.modelConfigID)
+			require.Equal(t, tt.wantEffort, got.reasoningEffort)
+		})
+	}
 }
 
 func titleOverrideTestChatAndMessages(t *testing.T) (database.Chat, []database.ChatMessage) {

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -780,15 +780,17 @@ func AllChatModelOverrideContexts() []ChatModelOverrideContext {
 // ChatModelOverrideResponse is the response body for the chat model override
 // configuration endpoint.
 type ChatModelOverrideResponse struct {
-	Context       ChatModelOverrideContext `json:"context"`
-	ModelConfigID string                   `json:"model_config_id"`
-	IsMalformed   bool                     `json:"is_malformed"`
+	Context         ChatModelOverrideContext `json:"context"`
+	ModelConfigID   string                   `json:"model_config_id"`
+	ReasoningEffort *string                  `json:"reasoning_effort,omitempty"`
+	IsMalformed     bool                     `json:"is_malformed"`
 }
 
 // UpdateChatModelOverrideRequest is the request body for updating the chat
 // model override configuration endpoint.
 type UpdateChatModelOverrideRequest struct {
-	ModelConfigID string `json:"model_config_id"`
+	ModelConfigID   string  `json:"model_config_id"`
+	ReasoningEffort *string `json:"reasoning_effort,omitempty"`
 }
 
 // ChatPersonalModelOverrideContext identifies which chat context the user
@@ -813,11 +815,12 @@ const (
 
 // ChatPersonalModelOverride is a resolved user personal model override.
 type ChatPersonalModelOverride struct {
-	Context       ChatPersonalModelOverrideContext `json:"context"`
-	Mode          ChatPersonalModelOverrideMode    `json:"mode"`
-	ModelConfigID string                           `json:"model_config_id"`
-	IsSet         bool                             `json:"is_set"`
-	IsMalformed   bool                             `json:"is_malformed"`
+	Context         ChatPersonalModelOverrideContext `json:"context"`
+	Mode            ChatPersonalModelOverrideMode    `json:"mode"`
+	ModelConfigID   string                           `json:"model_config_id"`
+	ReasoningEffort *string                          `json:"reasoning_effort,omitempty"`
+	IsSet           bool                             `json:"is_set"`
+	IsMalformed     bool                             `json:"is_malformed"`
 }
 
 // ChatPersonalModelOverrideDeploymentDefaults describes the deployment-level
@@ -840,8 +843,9 @@ type UserChatPersonalModelOverridesResponse struct {
 // UpdateUserChatPersonalModelOverrideRequest is the request body for updating
 // a user personal model override.
 type UpdateUserChatPersonalModelOverrideRequest struct {
-	Mode          ChatPersonalModelOverrideMode `json:"mode"`
-	ModelConfigID string                        `json:"model_config_id"`
+	Mode            ChatPersonalModelOverrideMode `json:"mode"`
+	ModelConfigID   string                        `json:"model_config_id"`
+	ReasoningEffort *string                       `json:"reasoning_effort,omitempty"`
 }
 
 // ChatPersonalModelOverridesAdminSettings describes whether users may manage

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2636,6 +2636,7 @@ export const ChatModelOverrideContexts: ChatModelOverrideContext[] = [
 export interface ChatModelOverrideResponse {
 	readonly context: ChatModelOverrideContext;
 	readonly model_config_id: string;
+	readonly reasoning_effort?: string;
 	readonly is_malformed: boolean;
 }
 
@@ -2785,6 +2786,7 @@ export interface ChatPersonalModelOverride {
 	readonly context: ChatPersonalModelOverrideContext;
 	readonly mode: ChatPersonalModelOverrideMode;
 	readonly model_config_id: string;
+	readonly reasoning_effort?: string;
 	readonly is_set: boolean;
 	readonly is_malformed: boolean;
 }
@@ -9010,6 +9012,7 @@ export interface UpdateChatModelConfigRequest {
  */
 export interface UpdateChatModelOverrideRequest {
 	readonly model_config_id: string;
+	readonly reasoning_effort?: string;
 }
 
 // From codersdk/chats.go
@@ -9379,6 +9382,7 @@ export interface UpdateUserChatDebugLoggingRequest {
 export interface UpdateUserChatPersonalModelOverrideRequest {
 	readonly mode: ChatPersonalModelOverrideMode;
 	readonly model_config_id: string;
+	readonly reasoning_effort?: string;
 }
 
 // From codersdk/notifications.go

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.tsx
@@ -19,7 +19,7 @@ import {
 } from "./components/SubagentModelOverrideSettings";
 
 type SaveModelOverride = (
-	req: { readonly model_config_id: string },
+	req: TypesGen.UpdateChatModelOverrideRequest,
 	options?: MutationCallbacks,
 ) => void;
 

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/components/SubagentModelOverrideSettings.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/components/SubagentModelOverrideSettings.tsx
@@ -6,6 +6,7 @@ import { useTemporarySavedState } from "#/components/TemporarySavedState/Tempora
 import { ModelSelector } from "#/pages/AgentsPage/components/ChatElements/ModelSelector";
 import { ModelOverrideAlerts } from "#/pages/AgentsPage/components/ModelOverrideAlerts";
 import type { ProviderInfo } from "#/pages/AgentsPage/utils/modelOptions";
+import { pickReasoningEffort } from "#/pages/AgentsPage/utils/reasoningEffort";
 import { AgentSettingLayout } from "./AgentSettingLayout";
 
 export interface MutationCallbacks {
@@ -15,11 +16,13 @@ export interface MutationCallbacks {
 
 interface ModelOverrideData {
 	readonly model_config_id: string;
+	readonly reasoning_effort?: string;
 	readonly is_malformed: boolean;
 }
 
 interface UpdateModelOverrideRequest {
 	readonly model_config_id: string;
+	readonly reasoning_effort?: string;
 }
 
 interface SubagentModelOverrideSettingsProps {
@@ -65,6 +68,8 @@ export const SubagentModelOverrideSettings: FC<
 	const isMalformedOverride = modelOverrideData?.is_malformed ?? false;
 	const enabledModelOptions = enabledModelConfigs.map((modelConfig) => {
 		const providerInfo = providerInfoByID.get(modelConfig.ai_provider_id);
+		const reasoningEffort = modelConfig.model_config?.reasoning_effort;
+		const reasoningEfforts = modelConfig.reasoning_efforts ?? [];
 		return {
 			id: modelConfig.id,
 			provider: providerInfo?.provider ?? "",
@@ -74,6 +79,10 @@ export const SubagentModelOverrideSettings: FC<
 			model: modelConfig.model,
 			displayName: modelConfig.display_name.trim() || modelConfig.model,
 			contextLimit: modelConfig.context_limit,
+			...(reasoningEffort?.default
+				? { reasoningEffortDefault: reasoningEffort.default }
+				: {}),
+			...(reasoningEfforts.length > 0 ? { reasoningEfforts } : {}),
 		};
 	});
 
@@ -81,11 +90,15 @@ export const SubagentModelOverrideSettings: FC<
 		enableReinitialize: true,
 		initialValues: {
 			model_config_id: modelOverrideData?.model_config_id ?? "",
+			reasoning_effort: modelOverrideData?.reasoning_effort ?? "",
 		},
 		onSubmit: (values, { resetForm }) => {
 			onSaveModelOverride(
 				{
 					model_config_id: values.model_config_id,
+					...(values.reasoning_effort
+						? { reasoning_effort: values.reasoning_effort }
+						: {}),
 				},
 				{
 					onSuccess: () => {
@@ -101,11 +114,18 @@ export const SubagentModelOverrideSettings: FC<
 	const canSave =
 		hasLoadedModelOverride && !disabled && (form.dirty || isMalformedOverride);
 
+	const selectedModelOption = enabledModelOptions.find(
+		(option) => option.id === form.values.model_config_id,
+	);
+	const selectedReasoningEffort = selectedModelOption
+		? pickReasoningEffort(
+				form.values.reasoning_effort,
+				selectedModelOption.reasoningEfforts ?? [],
+				selectedModelOption.reasoningEffortDefault,
+			)
+		: undefined;
 	const isUnavailableSavedModel =
-		form.values.model_config_id !== "" &&
-		!enabledModelOptions.some(
-			(option) => option.id === form.values.model_config_id,
-		);
+		form.values.model_config_id !== "" && selectedModelOption === undefined;
 
 	return (
 		<AgentSettingLayout
@@ -124,9 +144,20 @@ export const SubagentModelOverrideSettings: FC<
 				<ModelSelector
 					options={enabledModelOptions}
 					value={form.values.model_config_id}
-					onValueChange={(value) =>
-						void form.setFieldValue("model_config_id", value)
-					}
+					onValueChange={(value) => {
+						const option = enabledModelOptions.find(
+							(option) => option.id === value,
+						);
+						void form.setValues({
+							model_config_id: value,
+							reasoning_effort:
+								pickReasoningEffort(
+									"",
+									option?.reasoningEfforts ?? [],
+									option?.reasoningEffortDefault,
+								) ?? "",
+						});
+					}}
 					disabled={isFormDisabled}
 					placeholder={
 						isUnavailableSavedModel ? "Unavailable model" : unsetPlaceholder
@@ -136,6 +167,10 @@ export const SubagentModelOverrideSettings: FC<
 					}
 					className="h-10 w-full justify-between rounded-md border border-border border-solid bg-transparent px-3 text-sm"
 					contentClassName="min-w-[18rem]"
+					reasoningEffort={selectedReasoningEffort}
+					onReasoningEffortChange={(value) =>
+						void form.setFieldValue("reasoning_effort", value)
+					}
 				/>
 				<ModelOverrideAlerts
 					isUnavailableSavedModel={isUnavailableSavedModel}
@@ -150,7 +185,10 @@ export const SubagentModelOverrideSettings: FC<
 				variant="outline"
 				type="button"
 				onClick={() => {
-					void form.setFieldValue("model_config_id", "");
+					void form.setValues({
+						model_config_id: "",
+						reasoning_effort: "",
+					});
 				}}
 				disabled={isFormDisabled}
 				className="h-10"

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -21,6 +21,7 @@ import {
 } from "#/api/queries/chats";
 import { workspaceByIdKey } from "#/api/queries/workspaces";
 import type * as TypesGen from "#/api/typesGenerated";
+import { MockChatMessage } from "#/testHelpers/chatEntities";
 import { MockChatModelConfig } from "#/testHelpers/chatModels";
 import {
 	MockGroup,
@@ -122,6 +123,10 @@ const mockModelConfigs: TypesGen.ChatModelConfig[] = [
 		model: "gpt-4o",
 		display_name: "GPT-4o",
 		is_default: true,
+		model_config: {
+			reasoning_effort: { default: "medium", max: "high" },
+		},
+		reasoning_efforts: ["low", "medium", "high"],
 		created_at: "2026-02-18T00:00:00.000Z",
 		updated_at: "2026-02-18T00:00:00.000Z",
 	},
@@ -1189,8 +1194,38 @@ export const WithMessageHistory: Story = {
 			{ diffUrl: undefined },
 		),
 	},
+	beforeEach: () => {
+		spyOn(API.experimental, "getChat").mockResolvedValue({
+			id: CHAT_ID,
+			...baseChatFields,
+			title: "Markdown rendering showcase",
+			status: "waiting",
+		});
+		spyOn(API.experimental, "editChatMessage").mockResolvedValue({
+			message: {
+				...MockChatMessage,
+				id: 5,
+				created_at: "2026-02-18T00:03:00.000Z",
+			},
+		});
+	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
+		const body = within(document.body);
+		const user = userEvent.setup();
+		const changeReasoningEffort = async (key: string) => {
+			const modelSelector = canvas.getByRole("combobox", { name: "GPT-4o" });
+			await user.click(modelSelector);
+			const slider = await body.findByRole("slider");
+			slider.focus();
+			await user.keyboard(key);
+			await user.click(modelSelector);
+		};
+		const editLastMessage = async () => {
+			const buttons = canvas.getAllByRole("button", { name: "Edit message" });
+			await user.click(buttons[buttons.length - 1]);
+		};
+
 		expect(
 			await canvas.findByText("Markdown rendering showcase"),
 		).toBeVisible();
@@ -1199,6 +1234,35 @@ export const WithMessageHistory: Story = {
 				canvas.queryByText(/^This chat is owned by/),
 			).not.toBeInTheDocument();
 		});
+
+		await changeReasoningEffort("{ArrowRight}");
+		await editLastMessage();
+		await user.click(canvas.getByRole("button", { name: "Save Edit" }));
+		await waitFor(() => {
+			expect(API.experimental.editChatMessage).toHaveBeenCalledTimes(1);
+			expect(
+				canvas.getByRole("textbox", { name: "Chat message" }),
+			).toBeEnabled();
+		});
+
+		await editLastMessage();
+		await changeReasoningEffort("{ArrowLeft}");
+		await user.click(canvas.getByRole("button", { name: "Save Edit" }));
+		await waitFor(() => {
+			expect(API.experimental.editChatMessage).toHaveBeenCalledTimes(2);
+		});
+		expect(API.experimental.editChatMessage).toHaveBeenNthCalledWith(
+			1,
+			CHAT_ID,
+			5,
+			expect.not.objectContaining({ reasoning_effort: expect.anything() }),
+		);
+		expect(API.experimental.editChatMessage).toHaveBeenNthCalledWith(
+			2,
+			CHAT_ID,
+			5,
+			expect.objectContaining({ reasoning_effort: "medium" }),
+		);
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -96,6 +96,7 @@ import {
 	resolveModelSelector,
 } from "./utils/modelOptions";
 import { parsePullRequestUrl } from "./utils/pullRequest";
+import { pickReasoningEffort } from "./utils/reasoningEffort";
 import {
 	type ChatDetailError,
 	formatUsageLimitMessage,
@@ -720,6 +721,8 @@ const AgentChatPage: FC = () => {
 	const { organizations, experiments } = useDashboard();
 	const organizationName = getDefaultOrganizationName(organizations);
 	const [selectedModel, setSelectedModel] = useState("");
+	const [selectedReasoningEffort, setSelectedReasoningEffort] = useState("");
+	const isEditReasoningEffortDirtyRef = useRef(false);
 	const scrollToBottomRef = useRef<(() => void) | null>(null);
 	const chatInputRef = useRef<ChatMessageInputRef | null>(null);
 	const inputValueRef = useRef(
@@ -1133,6 +1136,17 @@ const AgentChatPage: FC = () => {
 		return modelOptions[0]?.id ?? "";
 	})();
 
+	const effectiveModelOption = modelOptions.find(
+		(option) => option.id === effectiveSelectedModel,
+	);
+	const effectiveReasoningEffort = effectiveModelOption
+		? pickReasoningEffort(
+				selectedReasoningEffort || chatRecord?.last_reasoning_effort,
+				effectiveModelOption.reasoningEfforts ?? [],
+				effectiveModelOption.reasoningEffortDefault,
+			)
+		: undefined;
+
 	const compressionThreshold = resolveCompactionThreshold(
 		chatLastModelConfigID,
 		userThresholdsQuery.data?.thresholds,
@@ -1257,6 +1271,12 @@ const AgentChatPage: FC = () => {
 		chatInputRef,
 		inputValueRef,
 	});
+	const handleEditUserMessage = (
+		...args: Parameters<typeof editing.handleEditUserMessage>
+	) => {
+		isEditReasoningEffortDirtyRef.current = false;
+		editing.handleEditUserMessage(...args);
+	};
 
 	const chatTitle = chatQuery.data?.title;
 
@@ -1453,9 +1473,13 @@ const AgentChatPage: FC = () => {
 				pickerModelConfigID !== originalModelConfigID
 					? pickerModelConfigID
 					: undefined;
+			// Omit so the backend preserves the original effort.
 			const request: TypesGen.EditChatMessageRequest = {
 				content,
 				model_config_id: editSelectedModelConfigID,
+				reasoning_effort: isEditReasoningEffortDirtyRef.current
+					? effectiveReasoningEffort
+					: undefined,
 			};
 			const optimisticMessage = originalEditedMessage
 				? buildOptimisticEditedMessage({
@@ -1498,6 +1522,7 @@ const AgentChatPage: FC = () => {
 		const request: CreateChatMessageRequestWithClearablePlanMode = {
 			content,
 			model_config_id: selectedModelConfigID,
+			reasoning_effort: effectiveReasoningEffort,
 			mcp_server_ids:
 				effectiveMCPServerIds.length > 0
 					? [...effectiveMCPServerIds]
@@ -1643,12 +1668,19 @@ const AgentChatPage: FC = () => {
 			workspaceAgent={workspaceAgent}
 			chatBuildId={chatQuery.data?.build_id}
 			store={store}
-			editing={editing}
+			editing={{ ...editing, handleEditUserMessage }}
 			effectiveSelectedModel={effectiveSelectedModel}
 			setSelectedModel={setSelectedModel}
 			modelOptions={modelOptions}
 			modelSelectorPlaceholder={modelSelectorPlaceholder}
 			modelSelectorHelp={modelSelectorHelp}
+			reasoningEffort={effectiveReasoningEffort}
+			onReasoningEffortChange={(value) => {
+				setSelectedReasoningEffort(value);
+				if (editing.editingMessageId !== null) {
+					isEditReasoningEffortDirtyRef.current = true;
+				}
+			}}
 			canConfigureAgentSetup={permissions.editDeploymentConfig}
 			providerCount={providerCount}
 			modelCount={modelCount}

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -136,6 +136,8 @@ interface AgentChatPageViewProps {
 	modelOptions: readonly ModelSelectorOption[];
 	modelSelectorPlaceholder: string;
 	modelSelectorHelp?: ReactNode;
+	reasoningEffort?: string;
+	onReasoningEffortChange?: (value: string) => void;
 	canConfigureAgentSetup: boolean;
 	providerCount?: number;
 	modelCount?: number;
@@ -328,6 +330,8 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	modelOptions,
 	modelSelectorPlaceholder,
 	modelSelectorHelp,
+	reasoningEffort,
+	onReasoningEffortChange,
 	canConfigureAgentSetup,
 	providerCount,
 	modelCount,
@@ -941,6 +945,8 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 								modelOptions={modelOptions}
 								modelSelectorPlaceholder={modelSelectorPlaceholder}
 								modelSelectorHelp={modelSelectorHelp}
+								reasoningEffort={reasoningEffort}
+								onReasoningEffortChange={onReasoningEffortChange}
 								planModeEnabled={planModeEnabled}
 								onPlanModeToggle={onPlanModeToggle}
 								isModelCatalogLoading={isModelCatalogLoading}

--- a/site/src/pages/AgentsPage/AgentCreatePage.tsx
+++ b/site/src/pages/AgentsPage/AgentCreatePage.tsx
@@ -88,6 +88,7 @@ const AgentCreatePage: FC = () => {
 		fileIDs,
 		workspaceId,
 		model,
+		reasoningEffort,
 		mcpServerIds,
 		organizationId,
 		planMode,
@@ -110,6 +111,7 @@ const AgentCreatePage: FC = () => {
 			plan_mode: planMode === "plan" ? "plan" : undefined,
 			client_type: "ui",
 			...(model ? { model_config_id: model } : {}),
+			...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
 		};
 		const createdChat = await createMutation.mutateAsync(createRequest);
 

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -119,6 +119,8 @@ interface AgentChatInputProps {
 	modelOptions: readonly ModelSelectorOption[];
 	modelSelectorPlaceholder: string;
 	hasModelOptions: boolean;
+	reasoningEffort?: string;
+	onReasoningEffortChange?: (value: string) => void;
 	planModeEnabled?: boolean;
 	onPlanModeToggle?: (enabled: boolean) => void;
 	isModelCatalogLoading?: boolean;
@@ -354,6 +356,8 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	modelOptions,
 	modelSelectorPlaceholder,
 	hasModelOptions,
+	reasoningEffort,
+	onReasoningEffortChange,
 	planModeEnabled = false,
 	onPlanModeToggle,
 	isModelCatalogLoading = false,
@@ -1428,6 +1432,8 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 								dropdownSide="top"
 								dropdownAlign="start"
 								enableMobileFullWidthDropdown
+								reasoningEffort={reasoningEffort}
+								onReasoningEffortChange={onReasoningEffortChange}
 							/>
 						)}
 						{planModeEnabled && !shouldOverflowPlanningBadge && (

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -157,6 +157,7 @@ const getCreateOptions = (onCreateChat: unknown): CreateChatSubmission => {
 
 type CreateChatSubmission = {
 	model?: string;
+	reasoningEffort?: string;
 };
 
 export const RootPersonalModelOverrideModelSelected: Story = {
@@ -302,6 +303,64 @@ export const ManualSelectionOverridesRootChatDefault: Story = {
 			expect(args.onCreateChat).toHaveBeenCalled();
 		});
 		expect(getCreateOptions(args.onCreateChat).model).toBe(claudeModelConfigID);
+	},
+};
+
+// Model options with reasoning effort bounds configured. GPT-4o uses the
+// full global scale; Claude is capped at medium.
+const effortModelOptions = [
+	{
+		...modelOptions[0],
+		reasoningEffortDefault: "medium",
+		reasoningEfforts: [
+			"none",
+			"minimal",
+			"low",
+			"medium",
+			"high",
+			"xhigh",
+			"max",
+		],
+	},
+	{
+		...modelOptions[1],
+		reasoningEffortDefault: "low",
+		reasoningEfforts: ["low", "medium"],
+	},
+] as const;
+
+export const SubmitsReasoningEffort: Story = {
+	args: {
+		...defaultArgs,
+		onCreateChat: fn().mockResolvedValue(undefined),
+		modelOptions: [...effortModelOptions],
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		const body = within(canvasElement.ownerDocument.body);
+
+		// Open the model selector; the effort row shows the model default.
+		await userEvent.click(canvas.getByRole("combobox", { name: "GPT-4o" }));
+		const slider = await body.findByRole("slider");
+		// "medium" is the fourth of seven selectable efforts.
+		expect(slider).toHaveAttribute("aria-valuenow", "3");
+
+		// Bump the effort to "high" with the keyboard, then close.
+		await userEvent.tab();
+		expect(slider).toHaveFocus();
+		await userEvent.keyboard("{ArrowRight}");
+		await waitFor(() => {
+			expect(slider).toHaveAttribute("aria-valuenow", "4");
+		});
+		await userEvent.keyboard("{Escape}");
+
+		await submitMessage(canvasElement, "create with reasoning effort");
+		await waitFor(() => {
+			expect(args.onCreateChat).toHaveBeenCalled();
+		});
+		const options = getCreateOptions(args.onCreateChat);
+		expect(options.model).toBe(modelConfigID);
+		expect(options.reasoningEffort).toBe("high");
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -20,6 +20,7 @@ import {
 	hasConfiguredModelsInCatalog,
 	hasUserFixableProviders,
 } from "../utils/modelOptions";
+import { pickReasoningEffort } from "../utils/reasoningEffort";
 import {
 	formatUsageLimitMessage,
 	isChatUsageLimitExceededResponse,
@@ -47,6 +48,7 @@ export type CreateChatOptions = {
 	fileIDs?: string[];
 	workspaceId?: string;
 	model?: string;
+	reasoningEffort?: string;
 	mcpServerIds?: string[];
 	organizationId: string;
 	planMode?: TypesGen.ChatPlanMode;
@@ -238,6 +240,17 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		}
 		return selectedModel || undefined;
 	})();
+	const [selectedReasoningEffort, setSelectedReasoningEffort] = useState("");
+	const selectedModelOption = modelOptions.find(
+		(option) => option.id === selectedModel,
+	);
+	const effectiveReasoningEffort = selectedModelOption
+		? pickReasoningEffort(
+				selectedReasoningEffort,
+				selectedModelOption.reasoningEfforts ?? [],
+				selectedModelOption.reasoningEffortDefault,
+			)
+		: undefined;
 	const initialOrg =
 		organizations.find((o) => o.is_default) ?? organizations[0];
 	const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(
@@ -367,6 +380,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 			fileIDs,
 			workspaceId: effectiveWorkspaceId ?? undefined,
 			model: submittedModel,
+			reasoningEffort: effectiveReasoningEffort,
 			organizationId,
 			mcpServerIds:
 				effectiveMCPServerIds.length > 0
@@ -529,6 +543,8 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						onModelChange={handleModelChange}
 						modelOptions={modelOptions}
 						modelSelectorPlaceholder={modelSelectorPlaceholder}
+						reasoningEffort={effectiveReasoningEffort}
+						onReasoningEffortChange={setSelectedReasoningEffort}
 						isModelCatalogLoading={isModelCatalogLoading}
 						hasModelOptions={hasModelOptions}
 						planModeEnabled={planModeEnabled}

--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, userEvent, waitFor, within } from "storybook/test";
+import { useState } from "react";
+import { expect, fn, screen, userEvent, waitFor, within } from "storybook/test";
 import { ModelSelector, type ModelSelectorOption } from "./ModelSelector";
 import { MockModelSelectorOption } from "./modelSelectorFixtures";
 
@@ -47,6 +48,24 @@ const anthropicModels: ModelSelectorOption[] = [
 ];
 
 const allModels: ModelSelectorOption[] = [...openAIModels, ...anthropicModels];
+
+const effortModel: ModelSelectorOption = {
+	...MockModelSelectorOption,
+	id: "openai/gpt-5",
+	model: "gpt-5",
+	displayName: "GPT-5",
+	contextLimit: 400_000,
+	reasoningEffortDefault: "medium",
+	reasoningEfforts: [
+		"none",
+		"minimal",
+		"low",
+		"medium",
+		"high",
+		"xhigh",
+		"max",
+	],
+};
 
 const meta: Meta<typeof ModelSelector> = {
 	title: "pages/AgentsPage/ChatElements/ModelSelector",
@@ -252,5 +271,140 @@ export const FiltersModels: Story = {
 		expect(args.onValueChange).toHaveBeenCalledWith(
 			"anthropic/claude-haiku-3.5",
 		);
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Reasoning effort row
+// ---------------------------------------------------------------------------
+
+export const EffortRowHiddenWithoutConfig: Story = {
+	args: {
+		options: openAIModels,
+		value: "openai/gpt-4o",
+		reasoningEffort: "medium",
+		onReasoningEffortChange: fn(),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(document.body);
+
+		await userEvent.click(canvas.getByRole("combobox"));
+		await body.findByRole("listbox");
+
+		expect(body.queryByRole("slider")).not.toBeInTheDocument();
+		expect(body.queryByText("Effort")).not.toBeInTheDocument();
+	},
+};
+
+const EffortRowStory = ({
+	onReasoningEffortChange,
+}: {
+	onReasoningEffortChange: (value: string) => void;
+}) => {
+	const [effort, setEffort] = useState("medium");
+	return (
+		<ModelSelector
+			options={[...openAIModels, effortModel]}
+			value="openai/gpt-5"
+			onValueChange={fn()}
+			reasoningEffort={effort}
+			onReasoningEffortChange={(value) => {
+				onReasoningEffortChange(value);
+				setEffort(value);
+			}}
+		/>
+	);
+};
+
+export const EffortRow: Story = {
+	args: {
+		onReasoningEffortChange: fn(),
+	},
+	render: (args) => (
+		<EffortRowStory
+			onReasoningEffortChange={(value) => args.onReasoningEffortChange?.(value)}
+		/>
+	),
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		const body = within(document.body);
+
+		await userEvent.click(canvas.getByRole("combobox", { name: "GPT-5" }));
+		await body.findByRole("listbox");
+
+		// The row is visible with one discrete step per selectable effort.
+		await waitFor(() => {
+			expect(body.getByText("Effort")).toBeVisible();
+		});
+		const slider = await body.findByRole("slider");
+		expect(slider).toHaveAttribute("aria-valuemin", "0");
+		expect(slider).toHaveAttribute("aria-valuemax", "6");
+		// "medium" is the fourth of seven selectable efforts.
+		expect(slider).toHaveAttribute("aria-valuenow", "3");
+		expect(body.getByText("Medium")).toBeVisible();
+
+		const infoTrigger = body.getByRole("button", {
+			name: "About reasoning effort",
+		});
+		await userEvent.tab();
+		expect(infoTrigger).toHaveFocus();
+		expect(await screen.findByRole("tooltip")).toHaveTextContent(
+			"Controls how much reasoning the model performs before responding.",
+		);
+
+		await userEvent.tab();
+		expect(slider).toHaveFocus();
+
+		await userEvent.keyboard("{ArrowRight}");
+		await waitFor(() => {
+			expect(slider).toHaveAttribute("aria-valuenow", "4");
+		});
+		expect(args.onReasoningEffortChange).toHaveBeenCalledWith("high");
+		expect(body.getByText("High")).toBeVisible();
+
+		await userEvent.keyboard("{ArrowRight}{ArrowRight}");
+		await waitFor(() => {
+			expect(slider).toHaveAttribute("aria-valuenow", "6");
+		});
+		expect(args.onReasoningEffortChange).toHaveBeenCalledWith("max");
+		expect(body.getByText("Max")).toBeVisible();
+
+		await userEvent.keyboard("{ArrowLeft}{ArrowLeft}{ArrowLeft}{ArrowLeft}");
+		await waitFor(() => {
+			expect(slider).toHaveAttribute("aria-valuenow", "2");
+		});
+		expect(args.onReasoningEffortChange).toHaveBeenCalledWith("low");
+		expect(body.getByText("Low")).toBeVisible();
+	},
+};
+
+export const EffortRowClampedToMax: Story = {
+	args: {
+		options: [
+			{
+				...effortModel,
+				reasoningEffortDefault: "low",
+				reasoningEfforts: ["none", "minimal", "low", "medium"],
+			},
+		],
+		value: "openai/gpt-5",
+		reasoningEffort: "low",
+		onReasoningEffortChange: fn(),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(document.body);
+
+		await userEvent.click(canvas.getByRole("combobox"));
+		await body.findByRole("listbox");
+
+		// Selectable efforts stop at the configured max.
+		const slider = await body.findByRole("slider");
+		expect(slider).toHaveAttribute("aria-valuemax", "3");
+		expect(slider).toHaveAttribute("aria-valuenow", "2");
+		await waitFor(() => {
+			expect(body.getByText("Low")).toBeVisible();
+		});
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
@@ -1,4 +1,4 @@
-import { CheckIcon } from "lucide-react";
+import { CheckIcon, InfoIcon } from "lucide-react";
 import { type FC, useState } from "react";
 import { ChevronDownIcon } from "#/components/AnimatedIcons/ChevronDown";
 import { Button } from "#/components/Button/Button";
@@ -15,9 +15,16 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "#/components/Popover/Popover";
+import { Slider } from "#/components/Slider/Slider";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
 import { ProviderIcon } from "#/pages/AISettingsPage/ProvidersPage/components/ProviderIcon";
 import { formatProviderLabel as defaultFormatProviderLabel } from "#/utils/aiProviders";
 import { cn } from "#/utils/cn";
+import { formatReasoningEffort } from "../../utils/reasoningEffort";
 
 export interface ModelSelectorOption {
 	id: string;
@@ -28,6 +35,8 @@ export interface ModelSelectorOption {
 	model: string;
 	displayName: string;
 	contextLimit?: number;
+	reasoningEffortDefault?: string;
+	reasoningEfforts?: readonly string[];
 }
 
 interface ModelSelectorProps {
@@ -44,6 +53,8 @@ interface ModelSelectorProps {
 	contentClassName?: string;
 	onTriggerTouchStart?: () => void;
 	enableMobileFullWidthDropdown?: boolean;
+	reasoningEffort?: string;
+	onReasoningEffortChange?: (value: string) => void;
 }
 
 const formatContextLimit = (tokens: number): string => {
@@ -85,6 +96,8 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
 	contentClassName,
 	onTriggerTouchStart,
 	enableMobileFullWidthDropdown = false,
+	reasoningEffort,
+	onReasoningEffortChange,
 }) => {
 	const [open, setOpen] = useState(false);
 	const [search, setSearch] = useState("");
@@ -224,8 +237,80 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
 						})}
 					</CommandList>
 				</Command>
+				{selectedModel &&
+					reasoningEffort !== undefined &&
+					onReasoningEffortChange && (
+						<ReasoningEffortRow
+							option={selectedModel}
+							value={reasoningEffort}
+							onChange={onReasoningEffortChange}
+						/>
+					)}
 			</PopoverContent>
 		</Popover>
+	);
+};
+
+interface ReasoningEffortRowProps {
+	option: ModelSelectorOption;
+	value: string;
+	onChange: (value: string) => void;
+}
+
+// Effort row pinned below the model list. Lives outside the Command
+// so it stays visible while the list scrolls and cmdk's arrow-key
+// navigation does not capture the slider's keyboard interaction.
+const ReasoningEffortRow: FC<ReasoningEffortRowProps> = ({
+	option,
+	value,
+	onChange,
+}) => {
+	const selectableEfforts = option.reasoningEfforts ?? [];
+	if (selectableEfforts.length === 0) {
+		return null;
+	}
+	const valueIndex = selectableEfforts.indexOf(value);
+	const effortIndex = valueIndex >= 0 ? valueIndex : 0;
+
+	return (
+		<div className="flex items-center gap-3 border-0 border-t border-solid border-border-default px-3 py-2">
+			<div className="flex shrink-0 items-center gap-1">
+				<span className="text-xs font-medium leading-[18px] text-content-secondary">
+					Effort
+				</span>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<button
+							type="button"
+							aria-label="About reasoning effort"
+							className="inline-flex size-3 items-center justify-center rounded-sm border-none bg-transparent p-0 text-content-secondary outline-none focus-visible:ring-2 focus-visible:ring-content-link"
+						>
+							<InfoIcon aria-hidden="true" className="size-3" />
+						</button>
+					</TooltipTrigger>
+					<TooltipContent side="top" className="max-w-[240px]">
+						Controls how much reasoning the model performs before responding.
+						Higher effort can improve quality but is slower and costs more.
+					</TooltipContent>
+				</Tooltip>
+			</div>
+			<Slider
+				aria-label="Reasoning effort"
+				value={[effortIndex]}
+				onValueChange={([index]) => {
+					const nextEffort = selectableEfforts[index];
+					if (nextEffort && nextEffort !== value) {
+						onChange(nextEffort);
+					}
+				}}
+				min={0}
+				max={selectableEfforts.length - 1}
+				step={1}
+			/>
+			<span className="shrink-0 rounded bg-surface-secondary px-1.5 py-0.5 text-xs font-medium leading-[18px] text-content-secondary">
+				{formatReasoningEffort(value)}
+			</span>
+		</div>
 	);
 };
 

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -173,6 +173,8 @@ interface ChatPageInputProps {
 	modelOptions: readonly ModelSelectorOption[];
 	modelSelectorPlaceholder: string;
 	modelSelectorHelp?: ReactNode;
+	reasoningEffort?: string;
+	onReasoningEffortChange?: (value: string) => void;
 	canConfigureAgentSetup: boolean;
 	providerCount?: number;
 	modelCount?: number;
@@ -244,6 +246,8 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	modelOptions,
 	modelSelectorPlaceholder,
 	modelSelectorHelp,
+	reasoningEffort,
+	onReasoningEffortChange,
 	canConfigureAgentSetup,
 	providerCount,
 	modelCount,
@@ -504,6 +508,8 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 			onModelChange={onModelChange}
 			modelOptions={modelOptions}
 			modelSelectorPlaceholder={modelSelectorPlaceholder}
+			reasoningEffort={reasoningEffort}
+			onReasoningEffortChange={onReasoningEffortChange}
 			planModeEnabled={planModeEnabled}
 			onPlanModeToggle={onPlanModeToggle}
 			isModelCatalogLoading={isModelCatalogLoading}

--- a/site/src/pages/AgentsPage/components/PersonalModelOverrideRow.tsx
+++ b/site/src/pages/AgentsPage/components/PersonalModelOverrideRow.tsx
@@ -12,6 +12,11 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "#/components/Select/Select";
+import { Slider } from "#/components/Slider/Slider";
+import {
+	formatReasoningEffort,
+	pickReasoningEffort,
+} from "../utils/reasoningEffort";
 import type { ModelSelectorOption } from "./ChatElements";
 import { ModelOverrideAlerts } from "./ModelOverrideAlerts";
 import { SectionHeader } from "./SectionHeader";
@@ -35,6 +40,7 @@ export type SavePersonalOverride = (
 interface PersonalOverrideFormValues {
 	mode: PersonalOverrideMode;
 	model_config_id: string;
+	reasoning_effort: string;
 }
 
 interface PersonalModelOverrideRowProps {
@@ -65,12 +71,20 @@ const toFormValues = (
 	context: PersonalOverrideContext,
 ): PersonalOverrideFormValues => {
 	if (!overrideData || overrideData.is_malformed) {
-		return { mode: getDefaultMode(context), model_config_id: "" };
+		return {
+			mode: getDefaultMode(context),
+			model_config_id: "",
+			reasoning_effort: "",
+		};
 	}
 	return {
 		mode: overrideData.mode,
 		model_config_id:
 			overrideData.mode === "model" ? overrideData.model_config_id : "",
+		reasoning_effort:
+			overrideData.mode === "model"
+				? (overrideData.reasoning_effort ?? "")
+				: "",
 	};
 };
 
@@ -81,6 +95,9 @@ const toUpdateRequest = (
 		return {
 			mode: "model",
 			model_config_id: values.model_config_id,
+			...(values.reasoning_effort
+				? { reasoning_effort: values.reasoning_effort }
+				: {}),
 		};
 	}
 	return { mode: values.mode, model_config_id: "" };
@@ -258,6 +275,17 @@ export const PersonalModelOverrideRow: FC<PersonalModelOverrideRowProps> = ({
 		form.values.mode === "model"
 			? form.values.model_config_id
 			: form.values.mode;
+	const selectedModelOption = modelOptions.find(
+		(option) => option.id === form.values.model_config_id,
+	);
+	const selectedReasoningEffort =
+		form.values.mode === "model" && selectedModelOption
+			? pickReasoningEffort(
+					form.values.reasoning_effort,
+					selectedModelOption.reasoningEfforts ?? [],
+					selectedModelOption.reasoningEffortDefault,
+				)
+			: undefined;
 	const selectionLabel = getSelectionLabel({
 		context,
 		deploymentDefault,
@@ -280,10 +308,27 @@ export const PersonalModelOverrideRow: FC<PersonalModelOverrideRowProps> = ({
 					value={selectionValue}
 					onValueChange={(value) => {
 						if (isDefaultModeOption(value)) {
-							void form.setValues({ mode: value, model_config_id: "" });
+							void form.setValues({
+								mode: value,
+								model_config_id: "",
+								reasoning_effort: "",
+							});
 							return;
 						}
-						void form.setValues({ mode: "model", model_config_id: value });
+						const option = modelOptions.find((option) => option.id === value);
+						const reasoningEffortDefault = option
+							? option.reasoningEffortDefault
+							: undefined;
+						void form.setValues({
+							mode: "model",
+							model_config_id: value,
+							reasoning_effort:
+								pickReasoningEffort(
+									"",
+									option?.reasoningEfforts ?? [],
+									reasoningEffortDefault,
+								) ?? "",
+						});
 					}}
 					disabled={isFormDisabled}
 				>
@@ -339,6 +384,15 @@ export const PersonalModelOverrideRow: FC<PersonalModelOverrideRowProps> = ({
 						</SelectGroup>
 					</SelectContent>
 				</Select>
+				{selectedReasoningEffort !== undefined && selectedModelOption && (
+					<PersonalReasoningEffortRow
+						option={selectedModelOption}
+						value={selectedReasoningEffort}
+						onChange={(value) =>
+							void form.setFieldValue("reasoning_effort", value)
+						}
+					/>
+				)}
 				<ModelOverrideAlerts
 					isUnavailableSavedModel={isUnavailableSavedModel}
 					unavailableMessage="The saved model is unavailable and will be ignored until you choose a valid model override."
@@ -372,6 +426,47 @@ export const PersonalModelOverrideRow: FC<PersonalModelOverrideRowProps> = ({
 				)}
 			</form>
 		</section>
+	);
+};
+
+interface PersonalReasoningEffortRowProps {
+	option: ModelSelectorOption;
+	value: string;
+	onChange: (value: string) => void;
+}
+
+const PersonalReasoningEffortRow: FC<PersonalReasoningEffortRowProps> = ({
+	option,
+	value,
+	onChange,
+}) => {
+	const selectableEfforts = option.reasoningEfforts ?? [];
+	if (selectableEfforts.length === 0) {
+		return null;
+	}
+	const valueIndex = selectableEfforts.indexOf(value);
+	const effortIndex = valueIndex >= 0 ? valueIndex : 0;
+
+	return (
+		<div className="flex items-center gap-3 md:w-[18rem]">
+			<span className="shrink-0 text-content-secondary text-sm">Effort</span>
+			<Slider
+				aria-label={`${option.displayName} reasoning effort`}
+				value={[effortIndex]}
+				onValueChange={([index]) => {
+					const nextEffort = selectableEfforts[index];
+					if (nextEffort && nextEffort !== value) {
+						onChange(nextEffort);
+					}
+				}}
+				min={0}
+				max={selectableEfforts.length - 1}
+				step={1}
+			/>
+			<span className="shrink-0 rounded bg-surface-secondary px-1.5 py-0.5 text-content-secondary text-xs font-medium leading-[18px]">
+				{formatReasoningEffort(value)}
+			</span>
+		</div>
 	);
 };
 

--- a/site/src/pages/AgentsPage/utils/modelOptions.test.ts
+++ b/site/src/pages/AgentsPage/utils/modelOptions.test.ts
@@ -323,6 +323,58 @@ describe("getModelOptionsFromConfigs", () => {
 		]);
 	});
 
+	it("populates reasoning effort bounds from the model config", () => {
+		const configs = [
+			createConfig({
+				id: "config-effort",
+				ai_provider_id: "prov-openai",
+				model: "gpt-5",
+				display_name: "GPT-5",
+				model_config: {
+					reasoning_effort: { default: "medium", max: "xhigh" },
+				},
+				reasoning_efforts: ["minimal", "low", "medium", "high", "xhigh"],
+			}),
+			createConfig({
+				id: "config-no-effort",
+				ai_provider_id: "prov-openai",
+				model: "gpt-4o",
+				display_name: "GPT-4o",
+				model_config: {},
+			}),
+		];
+		const catalog = createCatalog([
+			{ provider: "openai", available: true, models: [] },
+		]);
+
+		expect(
+			getModelOptionsFromConfigs(configs, catalog, providerInfoByID),
+		).toEqual([
+			{
+				id: "config-no-effort",
+				provider: "openai",
+				providerId: "prov-openai",
+				providerLabel: "OpenAI",
+				providerIcon: "",
+				model: "gpt-4o",
+				displayName: "GPT-4o",
+				contextLimit: 0,
+			},
+			{
+				id: "config-effort",
+				provider: "openai",
+				providerId: "prov-openai",
+				providerLabel: "OpenAI",
+				providerIcon: "",
+				model: "gpt-5",
+				displayName: "GPT-5",
+				contextLimit: 0,
+				reasoningEffortDefault: "medium",
+				reasoningEfforts: ["minimal", "low", "medium", "high", "xhigh"],
+			},
+		]);
+	});
+
 	it("excludes configs whose providers are unavailable", () => {
 		const configs = [
 			createConfig({

--- a/site/src/pages/AgentsPage/utils/modelOptions.ts
+++ b/site/src/pages/AgentsPage/utils/modelOptions.ts
@@ -253,6 +253,9 @@ export const getModelOptionsFromConfigs = (
 
 		const displayName = config.display_name.trim() || model;
 		const contextLimit = asNumber(config.context_limit);
+		const reasoningEffort = config.model_config?.reasoning_effort;
+		const reasoningEffortDefault = asString(reasoningEffort?.default).trim();
+		const reasoningEfforts = config.reasoning_efforts ?? [];
 		options.push({
 			id: configID,
 			provider,
@@ -262,6 +265,8 @@ export const getModelOptionsFromConfigs = (
 			model,
 			displayName,
 			...(contextLimit !== undefined ? { contextLimit } : {}),
+			...(reasoningEffortDefault ? { reasoningEffortDefault } : {}),
+			...(reasoningEfforts.length > 0 ? { reasoningEfforts } : {}),
 		});
 	}
 

--- a/site/src/pages/AgentsPage/utils/reasoningEffort.ts
+++ b/site/src/pages/AgentsPage/utils/reasoningEffort.ts
@@ -2,7 +2,7 @@
 export const formatReasoningEffort = (value: string): string =>
 	value.charAt(0).toUpperCase() + value.slice(1);
 
-/** Chooses requested effort, then default effort, then the highest effort. */
+/** Chooses requested effort, then default effort, then the last selectable effort. */
 export const pickReasoningEffort = (
 	value: string | undefined,
 	efforts: readonly string[],


### PR DESCRIPTION
## Summary

- add optional reasoning_effort to deployment and personal model override API payloads
- preserve legacy stored override formats while supporting encoded override efforts
- apply override reasoning effort for root personal chats, title generation, and child subagent chats
- wire reasoning effort selection into deployment and personal model override UI

## Validation

- pnpm -C site exec tsc -p .
- go test ./coderd -run 'TestChatModelOverrides|TestUserChatPersonalModelOverrides|TestCreateChatPersonalModelOverrideRoot' -count=1
- go test ./coderd/x/chatd -run 'TestCreateChildSubagentChat_StoresReasoningEffortOverride|TestResolveConfiguredModelOverride_AcceptsAmbientCredentialsProvider|TestResolveManualTitleModel|TestMaybeGenerateChatTitle|TestParseChatPersonalModelOverride' -count=1
- go test ./coderd/x/chatd/... -count=1
- make lint

Generated by Coder Agents.
