### PR TITLE
fix(scripts/releaser/v1): scope breaking-change check and drop GPG check

### DIFF
--- a/scripts/releaser/v1/executor.go
+++ b/scripts/releaser/v1/executor.go
@@ -18,8 +18,8 @@ import (
 // here. Safe operations (file writes, fetches, editor) are
 // called directly.
 type ReleaseExecutor interface {
-	// CreateTag creates an annotated (optionally signed) git tag.
-	CreateTag(ctx context.Context, tag, ref, message string, sign bool) error
+	// CreateTag creates an annotated git tag.
+	CreateTag(ctx context.Context, tag, ref, message string) error
 	// PushTag pushes a tag to the origin remote.
 	PushTag(ctx context.Context, tag string) error
 	// TriggerWorkflow dispatches the release.yaml GitHub Actions
@@ -30,14 +30,8 @@ type ReleaseExecutor interface {
 // liveExecutor performs real operations.
 type liveExecutor struct{}
 
-//nolint:revive // sign flag is part of the ReleaseExecutor interface contract.
-func (e *liveExecutor) CreateTag(_ context.Context, tag, ref, message string, sign bool) error {
-	args := []string{"tag", "-a"}
-	if sign {
-		args = append(args, "-s")
-	}
-	args = append(args, tag, "-m", message, ref)
-	return gitRun(args...)
+func (*liveExecutor) CreateTag(_ context.Context, tag, ref, message string) error {
+	return gitRun("tag", "-a", tag, "-m", message, ref)
 }
 
 func (*liveExecutor) PushTag(_ context.Context, tag string) error {
@@ -70,13 +64,8 @@ type dryRunExecutor struct {
 	w io.Writer
 }
 
-//nolint:revive // sign flag is part of the ReleaseExecutor interface contract.
-func (e *dryRunExecutor) CreateTag(_ context.Context, tag, ref, message string, sign bool) error {
-	signFlag := ""
-	if sign {
-		signFlag = "-s "
-	}
-	_, _ = fmt.Fprintf(e.w, "[DRYRUN] would run: git tag %s-a %s -m %q %s\n", signFlag, tag, message, ref)
+func (e *dryRunExecutor) CreateTag(_ context.Context, tag, ref, message string) error {
+	_, _ = fmt.Fprintf(e.w, "[DRYRUN] would run: git tag -a %s -m %q %s\n", tag, message, ref)
 	return nil
 }
 

--- a/scripts/releaser/v1/github.go
+++ b/scripts/releaser/v1/github.go
@@ -73,35 +73,6 @@ func ghListOpenPRs(branch string) ([]ghPR, error) {
 	return prs, nil
 }
 
-// ghListPRsWithLabel returns merged PRs targeting the given branch
-// that have a specific label.
-func ghListPRsWithLabel(branch, label string) ([]ghPR, error) {
-	out, err := ghOutput("pr", "list",
-		"--repo", owner+"/"+repo,
-		"--base", branch,
-		"--state", "merged",
-		"--label", label,
-		"--json", "number,title",
-		"--jq", `.[] | "\(.number)\t\(.title)"`,
-	)
-	if err != nil {
-		return nil, err
-	}
-	if out == "" {
-		return nil, nil
-	}
-	var prs []ghPR
-	for _, line := range strings.Split(out, "\n") {
-		parts := strings.SplitN(line, "\t", 2)
-		if len(parts) < 2 {
-			continue
-		}
-		num, _ := strconv.Atoi(parts[0])
-		prs = append(prs, ghPR{Number: num, Title: parts[1]})
-	}
-	return prs, nil
-}
-
 // prMetadata holds labels and author for a merged PR.
 type prMetadata struct {
 	Labels []string

--- a/scripts/releaser/v1/release.go
+++ b/scripts/releaser/v1/release.go
@@ -19,7 +19,7 @@ import (
 )
 
 //nolint:revive // Long function is fine for a sequential release flow.
-func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseExecutor, ghAvailable, gpgConfigured, dryRun bool) error {
+func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseExecutor, ghAvailable, dryRun bool) error {
 	w := inv.Stderr
 
 	// --- Release landscape ---
@@ -451,43 +451,51 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 		if newVersion.Major == prevVersion.Major && newVersion.Minor == prevVersion.Minor && newVersion.Patch > prevVersion.Patch {
 			infof(w, "Checking for breaking changes in patch release...")
 
+			// Scope the check to commits added since the previous
+			// release on this branch. A change is breaking when the
+			// conventional commit title carries a "!" or the source
+			// PR is labeled release/breaking; both are evaluated over
+			// this same range so breaking changes from earlier
+			// releases are not reported again.
 			commitRange := prevVersion.String() + "..HEAD"
 			commits, err := commitLog(commitRange)
 			if err != nil {
 				return xerrors.Errorf("reading commit log: %w", err)
 			}
 
+			var prMeta *prMetadataMaps
+			if ghAvailable {
+				prMeta, err = ghBuildPRMetadataMap(commits)
+				if err != nil {
+					warnf(w, "Failed to fetch PR metadata: %v", err)
+				}
+			}
+			if prMeta == nil {
+				prMeta = &prMetadataMaps{
+					bySHA:    make(map[string]prMetadata),
+					byNumber: make(map[int]prMetadata),
+				}
+			}
+
 			var breakingCommits []commitEntry
 			for _, c := range commits {
-				if breakingCommitRe.MatchString(c.Title) {
+				meta := prMeta.lookupCommit(c.FullSHA, c.PRCount)
+				// Skip dependabot commits, matching release notes.
+				if meta.Author == "dependabot" || meta.Author == "app/dependabot" {
+					continue
+				}
+				if categorizeCommit(c.Title, meta.Labels) == "breaking" {
 					breakingCommits = append(breakingCommits, c)
 				}
 			}
 
-			// Check PR labels for release/breaking.
-			var breakingPRLabeled []ghPR
-			if ghAvailable {
-				breakingPRLabeled, err = ghListPRsWithLabel(currentBranch, "release/breaking")
-				if err != nil {
-					warnf(w, "Failed to check PR labels: %v", err)
-				}
-			}
-
-			if len(breakingCommits) > 0 || len(breakingPRLabeled) > 0 {
+			if len(breakingCommits) > 0 {
 				fmt.Fprintln(w)
 				warnf(w, "BREAKING CHANGES detected in a PATCH release — this violates semver!")
 				fmt.Fprintln(w)
-				if len(breakingCommits) > 0 {
-					fmt.Fprintln(w, "  Breaking commits (by conventional commit prefix):")
-					for _, c := range breakingCommits {
-						fmt.Fprintf(w, "    - %s %s\n", c.SHA, c.Title)
-					}
-				}
-				if len(breakingPRLabeled) > 0 {
-					fmt.Fprintln(w, "  PRs labeled release/breaking:")
-					for _, pr := range breakingPRLabeled {
-						fmt.Fprintf(w, "    - #%d %s\n", pr.Number, pr.Title)
-					}
+				fmt.Fprintf(w, "  Breaking changes since %s:\n", prevVersion)
+				for _, c := range breakingCommits {
+					fmt.Fprintf(w, "    - %s %s\n", c.SHA, c.Title)
 				}
 				fmt.Fprintln(w)
 				if err := confirmWithDefault(inv, "Continue with patch release despite breaking changes?", cliui.ConfirmNo); err != nil {
@@ -767,7 +775,7 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 		if err := confirm(inv, "Create tag?"); err != nil {
 			return xerrors.New("cannot proceed without a tag")
 		}
-		if err := executor.CreateTag(ctx, newVersion.String(), ref, "Release "+newVersion.String(), gpgConfigured); err != nil {
+		if err := executor.CreateTag(ctx, newVersion.String(), ref, "Release "+newVersion.String()); err != nil {
 			return xerrors.Errorf("creating tag: %w", err)
 		}
 		successf(w, "Tag %s created.", newVersion)

--- a/scripts/releaser/v1/run.go
+++ b/scripts/releaser/v1/run.go
@@ -6,7 +6,6 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/coder/coder/v2/cli/cliui"
 	"github.com/coder/serpent"
 )
 
@@ -18,10 +17,9 @@ const (
 // Run executes the legacy interactive release wizard.
 //
 // It mirrors the behavior of the original standalone releaser tool: it
-// verifies dependencies, warns when GPG signing or the gh CLI are not
-// configured, wires up a live or dry-run executor, and then walks the
-// operator through tagging, pushing, and triggering the release
-// workflow.
+// verifies dependencies, warns when the gh CLI is not configured, wires
+// up a live or dry-run executor, and then walks the operator through
+// tagging, pushing, and triggering the release workflow.
 //
 //nolint:revive // dryRun selects the dry-run executor for the wizard.
 func Run(inv *serpent.Invocation, dryRun bool) error {
@@ -31,19 +29,6 @@ func Run(inv *serpent.Invocation, dryRun bool) error {
 	// --- Check dependencies ---
 	if _, err := exec.LookPath("git"); err != nil {
 		return xerrors.New("git is required but not found in PATH")
-	}
-
-	// --- Check GPG signing ---
-	signingKey, _ := gitOutput("config", "--get", "user.signingkey")
-	gpgFormat, _ := gitOutput("config", "--get", "gpg.format")
-	gpgConfigured := signingKey != "" || gpgFormat != ""
-	if !gpgConfigured {
-		warnf(w, "GPG signing is not configured. Tags will be unsigned, so there will be no way to verify who pushed the tag.")
-		_, _ = fmt.Fprintf(w, "  To fix: set git config user.signingkey or gpg.format\n")
-		if err := confirmWithDefault(inv, "Continue without signing?", cliui.ConfirmNo); err != nil {
-			return err
-		}
-		_, _ = fmt.Fprintln(w)
 	}
 
 	// --- Check gh CLI auth ---
@@ -63,5 +48,5 @@ func Run(inv *serpent.Invocation, dryRun bool) error {
 		executor = &liveExecutor{}
 	}
 
-	return runRelease(ctx, inv, executor, ghAvailable, gpgConfigured, dryRun)
+	return runRelease(ctx, inv, executor, ghAvailable, dryRun)
 }


### PR DESCRIPTION
## What

Two fixes to the legacy interactive release wizard (`releaser --legacy`):

### 1. Fix the patch-release breaking-change check

The check reported breaking changes over the wrong range. It combined:

- git-log title matches over `prevVersion..HEAD` (correctly scoped), and
- `ghListPRsWithLabel(branch, "release/breaking")`, which listed **every**
  merged PR with that label on the branch, with no range or date filter.

The unbounded PR-label query surfaced breaking changes from the entire
branch history instead of only those since the last release on that branch.

Now both title-based and label-based detection are evaluated over
`prevVersion..HEAD` (commits since the last release on the branch). PR
labels for those commits come from `ghBuildPRMetadataMap`, and each commit
is classified with the existing `categorizeCommit` helper. Dependabot
commits are skipped, matching release-note generation. This mirrors the
original `scripts/release/check_commit_metadata.sh`, which scopes both
signals to the commit range.

### 2. Remove the GPG signing check

The pre-flight warned when GPG signing was not configured, prompted the
operator to continue, and threaded a `sign` flag into tag creation (adding
`-s`). Neither the original `scripts/release/tag_version.sh` nor the v2
tooling sign tags; both use plain `git tag -a`. The check and the `sign`
flag are removed. Tags are created with `git tag -a`, which still honors
git's own `tag.gpgSign` config when a maintainer sets it.

## Verification

`go build`, `go vet`, `go test`, `golangci-lint`, and the em-dash lint all
pass for `scripts/releaser/...`.

<details>
<summary>Investigation and decision log</summary>

**Breaking-change check**
- `scripts/release/check_commit_metadata.sh` sets `COMMIT_METADATA_BREAKING`
  only from commits in `from_ref..to_ref`, using both the `!` title
  convention and the `release/breaking` PR label. `from_ref` is the last
  tag before the ref being tagged (`git describe --abbrev=0 "$ref^1"`), i.e.
  the last release.
- In the v1 port, the git-log title scan was already scoped to
  `prevVersion..HEAD`, but `ghListPRsWithLabel` had no range/date bound, so
  it reported label-based breaking changes across the whole branch. That is
  the "really old ref" symptom.
- Fix reuses `ghBuildPRMetadataMap` + `categorizeCommit` (already used by
  release-note generation) so label lookups are limited to the in-range
  commits. `ghListPRsWithLabel` is now unused and was removed.

**GPG signing**
- `tag_version.sh:194` and `v2/prepare.go:56` both run `git tag -a` with no
  `-s`. The v1 GPG detection, warning, prompt, and `-s` threading were
  additions unique to the v1 port, so removing them realigns v1 with the
  original tool and v2.

**Testing note**
- The affected logic lives inside the large interactive `runRelease`
  function, which has no existing unit-test harness. The change reuses
  helpers (`categorizeCommit`) that are already covered by tests, so no new
  unit test was added. Happy to extract and test the breaking-change
  detection separately if preferred.

</details>

---
This PR was generated by Coder Agents on behalf of @f0ssel.
