### PR TITLE
fix(site/src/modules/workspaces): hide empty script timing row

### DIFF
--- a/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.stories.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.stories.tsx
@@ -409,6 +409,11 @@ export const MultipleAgents: Story = {
 
 // A template with no agent scripts.
 export const NoAgentScripts: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await canvas.findByText("agent (main)");
+		expect(canvas.queryByText("run startup scripts")).not.toBeInTheDocument();
+	},
 	args: {
 		provisionerTimings: [
 			{

--- a/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.tsx
@@ -83,12 +83,15 @@ export const WorkspaceTimings: FC<WorkspaceTimingsProps> = ({
 
 	const stages = [
 		...provisioningStages,
-		...agents.flatMap((agent) =>
-			agentStages(
+		...agents.flatMap((agent) => {
+			const hasScripts = uniqScriptTimings.some(
+				(t) => t.workspace_agent_id === agent.workspace_agent_id,
+			);
+			return agentStages(
 				`agent (${agent.workspace_agent_name})`,
 				agent.workspace_agent_id,
-			),
-		),
+			).filter((stage) => hasScripts || stage.name !== "start");
+		}),
 	];
 
 	const displayProvisioningTime = () => {


### PR DESCRIPTION
Workspace timing no longer shows an empty “run startup scripts” stage for agents without startup script timings. Agents with script timings keep the stage, and the story now covers the no-script case.

Closes #15464

Validation:
- `pnpm --dir site test:storybook src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.stories.tsx`
- `pnpm --dir site check src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.tsx src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.stories.tsx`
- pre-commit hook

Generated by Coder Agents.
