### PR TITLE
fix(site): avoid premium groups fetches

### DIFF
--- a/site/src/api/queries/groups.ts
+++ b/site/src/api/queries/groups.ts
@@ -28,7 +28,7 @@ export const groups = () => {
 	} satisfies UseQueryOptions<Group[]>;
 };
 
-const getGroupsByOrganizationQueryKey = (organization: string) => [
+export const getGroupsByOrganizationQueryKey = (organization: string) => [
 	"organization",
 	organization,
 	"groups",

--- a/site/src/pages/GroupsPage/GroupsPage.stories.tsx
+++ b/site/src/pages/GroupsPage/GroupsPage.stories.tsx
@@ -1,0 +1,96 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, spyOn, within } from "storybook/test";
+import {
+	reactRouterOutlet,
+	reactRouterParameters,
+} from "storybook-addon-remix-react-router";
+import { API } from "#/api/api";
+import { getAuthorizationKey } from "#/api/queries/authCheck";
+import { getGroupsByOrganizationQueryKey } from "#/api/queries/groups";
+import { organizationPermissionChecks } from "#/modules/permissions/organizations";
+import {
+	MockDefaultOrganization,
+	MockGroup,
+	MockOrganizationPermissions,
+} from "#/testHelpers/entities";
+import { withDashboardProvider } from "#/testHelpers/storybook";
+import GroupsPage from "./GroupsPage";
+import GroupsPageProvider from "./GroupsPageProvider";
+
+const organizationPermissionsKey = getAuthorizationKey({
+	checks: Object.fromEntries(
+		Object.entries(
+			organizationPermissionChecks(MockDefaultOrganization.id),
+		).map(([key, value]) => [`${MockDefaultOrganization.id}.${key}`, value]),
+	),
+});
+
+const meta: Meta<typeof GroupsPageProvider> = {
+	title: "pages/OrganizationGroupsPage/GroupsPage",
+	component: GroupsPageProvider,
+	decorators: [withDashboardProvider],
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: {
+				pathParams: {
+					organization: MockDefaultOrganization.name,
+				},
+			},
+			routing: reactRouterOutlet(
+				{ path: "/organizations/:organization/groups" },
+				<GroupsPage />,
+			),
+		}),
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof GroupsPageProvider>;
+
+export const PremiumDisabled: Story = {
+	parameters: {
+		queries: [],
+	},
+	beforeEach: () => {
+		const getGroupsByOrganization = spyOn(
+			API,
+			"getGroupsByOrganization",
+		).mockResolvedValue([MockGroup]);
+		const checkAuthorization = spyOn(
+			API,
+			"checkAuthorization",
+		).mockResolvedValue({});
+
+		return () => {
+			getGroupsByOrganization.mockRestore();
+			checkAuthorization.mockRestore();
+		};
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await canvas.findByRole("heading", { name: "Groups", level: 1 });
+		expect(
+			canvas.getByText(/You need a Premium license to use this feature/i),
+		).toBeVisible();
+		expect(API.getGroupsByOrganization).not.toHaveBeenCalled();
+		expect(API.checkAuthorization).not.toHaveBeenCalled();
+	},
+};
+
+export const PremiumEnabled: Story = {
+	parameters: {
+		features: ["template_rbac"],
+		queries: [
+			{
+				key: organizationPermissionsKey,
+				data: {
+					[MockDefaultOrganization.id]: MockOrganizationPermissions,
+				},
+			},
+			{
+				key: getGroupsByOrganizationQueryKey(MockDefaultOrganization.name),
+				data: [MockGroup],
+			},
+		],
+	},
+};

--- a/site/src/pages/GroupsPage/GroupsPage.tsx
+++ b/site/src/pages/GroupsPage/GroupsPage.tsx
@@ -29,13 +29,14 @@ const GroupsPage: FC = () => {
 	// the cost-control feature is stable.
 	const aibridgeVisible =
 		Boolean(aibridge) && experiments.includes("ai-gateway-cost-control");
+	const queriesEnabled = Boolean(groupsEnabled) && Boolean(organization);
 	const groupsQuery = useQuery({
 		...groupsByOrganization(organization?.name ?? ""),
-		enabled: Boolean(organization),
+		enabled: queriesEnabled,
 	});
 	const permissionsQuery = useQuery({
 		...organizationsPermissions([organization?.id ?? ""]),
-		enabled: Boolean(organization),
+		enabled: queriesEnabled,
 	});
 
 	useEffect(() => {
@@ -64,13 +65,36 @@ const GroupsPage: FC = () => {
 		return <EmptyState message="Organization not found" />;
 	}
 
-	if (permissionsQuery.isLoading) {
+	if (groupsEnabled && permissionsQuery.isLoading) {
 		return <Loader />;
 	}
 
 	const title = <title>{pageTitle("Groups")}</title>;
 
 	const permissions = permissionsQuery.data?.[organization.id];
+
+	if (!groupsEnabled) {
+		return (
+			<div className="w-full max-w-screen-2xl pb-10">
+				{title}
+
+				<SettingsHeader>
+					<SettingsHeaderTitle>Groups</SettingsHeaderTitle>
+					<SettingsHeaderDescription>
+						Manage groups for this{" "}
+						{showOrganizations ? "organization" : "deployment"}.
+					</SettingsHeaderDescription>
+				</SettingsHeader>
+
+				<GroupsPageView
+					groups={undefined}
+					canCreateGroup={false}
+					groupsEnabled={groupsEnabled}
+					showAIBudget={aibridgeVisible}
+				/>
+			</div>
+		);
+	}
 
 	if (!permissions?.viewGroups) {
 		return (


### PR DESCRIPTION
The Groups page now skips groups and organization permission queries when the `template_rbac` feature is not visible, allowing the existing Premium paywall to render without surfacing an unrelated RBAC error toast. Licensed deployments still run the queries before rendering the groups table.

Closes #23898

Validation:
- `pnpm --dir site test:storybook src/pages/GroupsPage/GroupsPage.stories.tsx`
- `pnpm --dir site check src/pages/GroupsPage/GroupsPage.tsx src/pages/GroupsPage/GroupsPage.stories.tsx src/api/queries/groups.ts`
- pre-commit hook

Generated by Coder Agents.
