### PR TITLE
feat(site/src/pages/TemplateBuilder): navigable selection sidebar and polish

### DIFF
--- a/site/src/components/FormField/FormField.tsx
+++ b/site/src/components/FormField/FormField.tsx
@@ -1,6 +1,8 @@
-import { type FC, type ReactNode, useId } from "react";
+import { type FC, type ReactNode, useId, useRef } from "react";
 import { Input } from "#/components/Input/Input";
 import { Label } from "#/components/Label/Label";
+import { useHasBeenScrolledPast } from "#/hooks/useHasBeenScrolledPast";
+import { useHasReachedBottom } from "#/hooks/useHasReachedBottom";
 import { cn } from "#/utils/cn";
 import type { FormHelpers } from "#/utils/formUtils";
 
@@ -8,6 +10,12 @@ type FormFieldProps = React.ComponentPropsWithRef<"input"> & {
 	field: FormHelpers;
 	label: ReactNode;
 	description?: ReactNode;
+	/**
+	 * When true and the field is `required` with an empty value, the input
+	 * flips to `aria-invalid` (destructive red border) once the user scrolls
+	 * past it. The cue clears as soon as they type a value.
+	 */
+	markInvalidWhenScrolledPastEmpty?: boolean;
 };
 
 export const FormField: FC<FormFieldProps> = ({
@@ -15,6 +23,7 @@ export const FormField: FC<FormFieldProps> = ({
 	label,
 	description,
 	className,
+	markInvalidWhenScrolledPastEmpty,
 	...inputProps
 }) => {
 	const generatedId = useId();
@@ -30,8 +39,20 @@ export const FormField: FC<FormFieldProps> = ({
 		.join(" ");
 	const required = inputProps.required ?? false;
 
+	const wrapperRef = useRef<HTMLDivElement>(null);
+	const scrolledPast = useHasBeenScrolledPast(wrapperRef);
+	const hasReachedBottom = useHasReachedBottom();
+	const isEmpty = field.value == null || field.value === "";
+	const showRequiredMiss = Boolean(
+		markInvalidWhenScrolledPastEmpty &&
+			required &&
+			isEmpty &&
+			(scrolledPast || hasReachedBottom),
+	);
+	const isInvalid = Boolean(field.error) || showRequiredMiss;
+
 	return (
-		<div className="flex flex-col gap-2">
+		<div ref={wrapperRef} className="flex flex-col gap-2">
 			<Label htmlFor={id}>
 				{label}
 				{required && (
@@ -55,9 +76,9 @@ export const FormField: FC<FormFieldProps> = ({
 				onBlur={field.onBlur}
 				{...inputProps}
 				id={id}
-				aria-invalid={field.error}
+				aria-invalid={isInvalid}
 				aria-describedby={describedBy || undefined}
-				className={cn(field.error && "border-border-destructive", className)}
+				className={cn(isInvalid && "border-border-destructive", className)}
 			/>
 			{field.error ? (
 				<span id={errorId} className="text-xs text-content-destructive">

--- a/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
+++ b/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
@@ -17,6 +17,7 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "#/components/Popover/Popover";
+import { cn } from "#/utils/cn";
 
 type OrganizationAutocompleteProps = {
 	value: Organization | null;
@@ -24,6 +25,7 @@ type OrganizationAutocompleteProps = {
 	options: readonly Organization[];
 	id?: string;
 	required?: boolean;
+	"aria-invalid"?: boolean;
 };
 
 export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
@@ -32,6 +34,7 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
 	options,
 	id,
 	required,
+	"aria-invalid": ariaInvalid,
 }) => {
 	const [open, setOpen] = useState(false);
 
@@ -43,8 +46,12 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
 					variant="outline"
 					aria-expanded={open}
 					aria-required={required}
+					aria-invalid={ariaInvalid}
 					data-testid="organization-autocomplete"
-					className="w-full justify-start gap-2 font-normal"
+					className={cn(
+						"w-full justify-start gap-2 font-normal",
+						ariaInvalid && "border-border-destructive",
+					)}
 				>
 					{value ? (
 						<>

--- a/site/src/hooks/useHasBeenScrolledPast.ts
+++ b/site/src/hooks/useHasBeenScrolledPast.ts
@@ -1,0 +1,42 @@
+import { type RefObject, useEffect, useRef, useState } from "react";
+
+/**
+ * Returns true once the element referenced by `ref` has been visible in the
+ * viewport at least once and then scrolled above the top of the viewport.
+ *
+ * The state is sticky: once true, it stays true until the ref changes. Callers
+ * typically gate a visual "you missed a required field" cue on the return
+ * value combined with an emptiness check, so the cue disappears as soon as
+ * the user fills the field in.
+ */
+export const useHasBeenScrolledPast = (
+	ref: RefObject<HTMLElement | null>,
+): boolean => {
+	const [scrolledPast, setScrolledPast] = useState(false);
+	const hasBeenSeen = useRef(false);
+
+	useEffect(() => {
+		const el = ref.current;
+		if (!el || typeof IntersectionObserver === "undefined") {
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) {
+					if (entry.isIntersecting) {
+						hasBeenSeen.current = true;
+					} else if (hasBeenSeen.current && entry.boundingClientRect.top < 0) {
+						setScrolledPast(true);
+					}
+				}
+			},
+			{ threshold: 0 },
+		);
+
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, [ref]);
+
+	return scrolledPast;
+};

--- a/site/src/hooks/useHasReachedBottom.tsx
+++ b/site/src/hooks/useHasReachedBottom.tsx
@@ -1,0 +1,56 @@
+import {
+	createContext,
+	type FC,
+	type PropsWithChildren,
+	useContext,
+	useEffect,
+	useState,
+} from "react";
+
+/**
+ * Tracks whether the user has scrolled to the bottom of the window at least
+ * once. Consumed by required-field wrappers so we can flip empty required
+ * fields to the destructive red outline once the user has reached the end of
+ * the page, catching required fields that were visible but never scrolled
+ * past. Sticky: stays true once triggered.
+ */
+const HasReachedBottomContext = createContext<{ hasReachedBottom: boolean }>({
+	hasReachedBottom: false,
+});
+
+export const useHasReachedBottom = (): boolean =>
+	useContext(HasReachedBottomContext).hasReachedBottom;
+
+const BOTTOM_TOLERANCE_PX = 4;
+
+export const HasReachedBottomProvider: FC<PropsWithChildren> = ({
+	children,
+}) => {
+	const [hasReachedBottom, setHasReachedBottom] = useState(false);
+
+	useEffect(() => {
+		if (hasReachedBottom) {
+			return;
+		}
+		const check = () => {
+			const scrolled = window.scrollY + window.innerHeight;
+			const total = document.documentElement.scrollHeight;
+			if (scrolled >= total - BOTTOM_TOLERANCE_PX) {
+				setHasReachedBottom(true);
+			}
+		};
+		check();
+		window.addEventListener("scroll", check, { passive: true });
+		window.addEventListener("resize", check);
+		return () => {
+			window.removeEventListener("scroll", check);
+			window.removeEventListener("resize", check);
+		};
+	}, [hasReachedBottom]);
+
+	return (
+		<HasReachedBottomContext.Provider value={{ hasReachedBottom }}>
+			{children}
+		</HasReachedBottomContext.Provider>
+	);
+};

--- a/site/src/pages/TemplateBuilder/BaseInfraSelectStep.tsx
+++ b/site/src/pages/TemplateBuilder/BaseInfraSelectStep.tsx
@@ -55,8 +55,9 @@ export const BaseInfraSelectStep: FC<BaseInfraSelectStepProps> = ({
 				Select your infrastructure foundation.
 			</TemplateBuilderSubtitle>
 
-			{/* Show ~3 rows (176px each with 16px gap) before scrolling. */}
-			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 auto-rows-[11rem] max-h-[35rem] overflow-y-auto">
+			{/* Show ~3 rows of cards before scrolling; cards keep their natural
+			height, and descriptions clamp to two lines to stay uniform. */}
+			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 max-h-[42rem] overflow-y-auto">
 				{bases.map((base) => (
 					<TemplateCard
 						key={base.id}

--- a/site/src/pages/TemplateBuilder/BaseInfraSelectStep.tsx
+++ b/site/src/pages/TemplateBuilder/BaseInfraSelectStep.tsx
@@ -55,8 +55,8 @@ export const BaseInfraSelectStep: FC<BaseInfraSelectStepProps> = ({
 				Select your infrastructure foundation.
 			</TemplateBuilderSubtitle>
 
-			{/* 420px accounts for navbar, page header, card padding, tab bar, and nav controls */}
-			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 max-h-[calc(100vh-420px)] overflow-y-auto">
+			{/* Show ~3 rows (176px each with 16px gap) before scrolling. */}
+			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 auto-rows-[11rem] max-h-[35rem] overflow-y-auto">
 				{bases.map((base) => (
 					<TemplateCard
 						key={base.id}

--- a/site/src/pages/TemplateBuilder/BaseTemplateParametersStep.tsx
+++ b/site/src/pages/TemplateBuilder/BaseTemplateParametersStep.tsx
@@ -61,7 +61,7 @@ function variableToField(
 		required: variable.required,
 		placeholder:
 			defaultPlaceholder(variable.default) ??
-			(variable.required ? "Required" : "Optional"),
+			(variable.required ? "Required" : ""),
 		field: {
 			name: variable.name,
 			id,

--- a/site/src/pages/TemplateBuilder/BaseTemplateParametersStep.tsx
+++ b/site/src/pages/TemplateBuilder/BaseTemplateParametersStep.tsx
@@ -123,8 +123,7 @@ export const BaseTemplateParametersStep: FC<
 				Your base template requires customizations.
 			</TemplateBuilderSubtitle>
 
-			{/* 340px accounts for navbar, page header, card padding, and nav controls */}
-			<div className="max-h-[calc(100vh-340px)] overflow-y-auto">
+			<div>
 				<TemplateConfiguration
 					name={base?.name ?? "Base Template"}
 					description={base?.description ?? ""}

--- a/site/src/pages/TemplateBuilder/ConfigurationField.tsx
+++ b/site/src/pages/TemplateBuilder/ConfigurationField.tsx
@@ -104,6 +104,10 @@ const TextField: FC<TextFieldDefinition> = ({
 		description={description}
 		required={required}
 		placeholder={placeholder}
+		// Once the user scrolls past a required field, flip it to the
+		// destructive red outline so easy-to-miss empty required fields
+		// stand out. Clears as soon as the field has a value.
+		markInvalidWhenScrolledPastEmpty
 		// Placeholder text is instructional (a hint of what to enter),
 		// so it uses the dimmer content-disabled tone instead of the
 		// default content-secondary. The important flag beats the base

--- a/site/src/pages/TemplateBuilder/ConfigurationField.tsx
+++ b/site/src/pages/TemplateBuilder/ConfigurationField.tsx
@@ -123,15 +123,13 @@ const SelectField: FC<SelectFieldDefinition> = ({
 		<div className="!col-end-1 flex flex-col gap-2">
 			<Label htmlFor={id}>
 				{label}
-				{required ? (
+				{required && (
 					<>
 						{" "}
 						<span className="text-sm font-bold text-content-destructive">
 							*
 						</span>
 					</>
-				) : (
-					<OptionalIndicator />
 				)}
 			</Label>
 			{description && (
@@ -173,15 +171,13 @@ const RadioField: FC<RadioFieldDefinition> = ({
 		<div className="flex flex-col gap-2">
 			<Label id={labelId}>
 				{label}
-				{required ? (
+				{required && (
 					<>
 						{" "}
 						<span className="text-sm font-bold text-content-destructive">
 							*
 						</span>
 					</>
-				) : (
-					<OptionalIndicator />
 				)}
 			</Label>
 			{description && (
@@ -298,15 +294,13 @@ const SwitchGroupField: FC<SwitchGroupFieldDefinition> = ({
 		<div className="flex flex-col gap-2">
 			<Label id={labelId}>
 				{label}
-				{required ? (
+				{required && (
 					<>
 						{" "}
 						<span className="text-sm font-bold text-content-destructive">
 							*
 						</span>
 					</>
-				) : (
-					<OptionalIndicator />
 				)}
 			</Label>
 			{description && (
@@ -343,22 +337,8 @@ export const ConfigurationFieldContainer: FC<PropsWithChildren> = ({
 	);
 };
 
-const OptionalIndicator: FC = () => {
-	return (
-		<>
-			{" "}
-			<span className="text-content-secondary">(optional)</span>
-		</>
-	);
-};
-
 export const ConfigurationFieldLabel: FC<{
 	variable: TemplateBuilderModuleVariable;
 }> = ({ variable }) => {
-	return (
-		<>
-			{variable.name}
-			{!variable.required && <OptionalIndicator />}
-		</>
-	);
+	return <>{variable.name}</>;
 };

--- a/site/src/pages/TemplateBuilder/ConfigurationField.tsx
+++ b/site/src/pages/TemplateBuilder/ConfigurationField.tsx
@@ -104,6 +104,11 @@ const TextField: FC<TextFieldDefinition> = ({
 		description={description}
 		required={required}
 		placeholder={placeholder}
+		// Placeholder text is instructional (a hint of what to enter),
+		// so it uses the dimmer content-disabled tone instead of the
+		// default content-secondary. The important flag beats the base
+		// Input class.
+		className="placeholder:!text-content-disabled"
 	/>
 );
 

--- a/site/src/pages/TemplateBuilder/ModuleCard.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleCard.tsx
@@ -64,14 +64,14 @@ export const ModuleCard: React.FC<ModuleCardProps> = ({
 			<div>
 				<h3
 					id={nameId}
-					className="flex items-center gap-1.5 text-md font-semibold text-content-primary"
+					className="flex items-start gap-1.5 text-md font-semibold text-content-primary"
 				>
-					{name}
+					<span className="line-clamp-2">{name}</span>
 					{official && (
-						<BadgeCheckIcon className="size-4 text-highlight-sky shrink-0" />
+						<BadgeCheckIcon className="size-4 text-highlight-sky shrink-0 mt-1" />
 					)}
 				</h3>
-				<p className="text-sm font-normal text-content-secondary">
+				<p className="text-sm font-normal text-content-secondary line-clamp-2">
 					{description}
 				</p>
 

--- a/site/src/pages/TemplateBuilder/ModuleConfiguration.stories.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleConfiguration.stories.tsx
@@ -113,3 +113,50 @@ export const WithoutIcon: Story = {
 		],
 	},
 };
+
+export const WithSensitiveVariables: Story = {
+	args: {
+		name: "Claude Code",
+		description: "Install and configure the Claude Code CLI in your workspace.",
+		iconUrl: "/icon/claude.svg",
+		detailsUrl: "https://registry.coder.com/modules/claude-code",
+		optionalFields: [
+			{
+				type: "select",
+				id: "model",
+				label: "Model",
+				options: [
+					{ value: "sonnet", label: "Sonnet" },
+					{ value: "opus", label: "Opus" },
+				],
+			},
+		],
+		sensitiveVariables: [
+			{
+				name: "claude_code_oauth_token",
+				type: "string",
+				description: "OAuth token used by Claude Code",
+				required: true,
+				sensitive: true,
+			},
+		],
+	},
+};
+
+export const NoConfigWithSensitiveVariables: Story = {
+	args: {
+		name: "OpenAI Codex",
+		description: "Install the OpenAI Codex CLI in your workspace.",
+		iconUrl: "/icon/openai.svg",
+		detailsUrl: "https://registry.coder.com/modules/codex",
+		sensitiveVariables: [
+			{
+				name: "openai_api_key",
+				type: "string",
+				description: "OpenAI API key",
+				required: true,
+				sensitive: true,
+			},
+		],
+	},
+};

--- a/site/src/pages/TemplateBuilder/ModuleConfiguration.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleConfiguration.tsx
@@ -1,4 +1,6 @@
-import { CheckIcon, TrashIcon } from "lucide-react";
+import { CheckIcon, InfoIcon, TrashIcon } from "lucide-react";
+import type { FC } from "react";
+import type { TemplateBuilderModuleVariable } from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
 import { CollapsibleSummary } from "#/components/CollapsibleSummary/CollapsibleSummary";
 import { TemplateBuilderAvatarData } from "#/pages/TemplateBuilder/TemplateBuilderAvatarData";
@@ -16,9 +18,16 @@ type ModuleConfigurationProps = {
 	onRemove?: () => void;
 	fields?: ConfigurationFieldDefinition[];
 	optionalFields?: ConfigurationFieldDefinition[];
+	/**
+	 * Sensitive variables belonging to this module. Rendered as an info
+	 * note at the bottom of the module's grey card because their values
+	 * are collected from the developer at workspace creation time, not
+	 * during template composition.
+	 */
+	sensitiveVariables?: TemplateBuilderModuleVariable[];
 };
 
-export const ModuleConfiguration: React.FC<ModuleConfigurationProps> = ({
+export const ModuleConfiguration: FC<ModuleConfigurationProps> = ({
 	name,
 	description,
 	iconUrl,
@@ -26,6 +35,7 @@ export const ModuleConfiguration: React.FC<ModuleConfigurationProps> = ({
 	onRemove,
 	fields,
 	optionalFields,
+	sensitiveVariables,
 }) => {
 	return (
 		<section className="pt-4 px-4 pb-6 rounded bg-surface-secondary">
@@ -70,6 +80,26 @@ export const ModuleConfiguration: React.FC<ModuleConfigurationProps> = ({
 				<div className="text-sm text-content-secondary flex items-center gap-2 mt-4">
 					<CheckIcon className="w-4 h-4" />
 					No configuration required.
+				</div>
+			)}
+
+			{sensitiveVariables && sensitiveVariables.length > 0 && (
+				<div
+					className="flex items-start gap-2 mt-4 text-sm text-content-secondary"
+					data-testid="module-sensitive-variables"
+				>
+					<InfoIcon className="size-icon-sm shrink-0 mt-0.5" />
+					<p className="m-0">
+						{sensitiveVariables.map((v) => (
+							<code
+								key={v.name}
+								className="mr-1 px-1.5 py-1 bg-surface-tertiary rounded-sm"
+							>
+								{v.name}
+							</code>
+						))}
+						will be collected from developers at workspace creation.
+					</p>
 				</div>
 			)}
 		</section>

--- a/site/src/pages/TemplateBuilder/ModuleSelectStep.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleSelectStep.tsx
@@ -244,8 +244,9 @@ export const ModuleSelectStep: FC<ModuleSelectStepProps> = ({
 				</TabsList>
 			</Tabs>
 
-			{/* Show ~3 rows (176px each with 16px gap) before scrolling. */}
-			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 auto-rows-[11rem] max-h-[35rem] overflow-y-auto">
+			{/* Show ~3 rows of cards before scrolling; cards keep their natural
+			height, and descriptions clamp to two lines to stay uniform. */}
+			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 max-h-[42rem] overflow-y-auto">
 				{visibleModules.length ? (
 					visibleModules.map((m) => (
 						<ModuleCard

--- a/site/src/pages/TemplateBuilder/ModuleSelectStep.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleSelectStep.tsx
@@ -244,8 +244,8 @@ export const ModuleSelectStep: FC<ModuleSelectStepProps> = ({
 				</TabsList>
 			</Tabs>
 
-			{/* 420px accounts for navbar, page header, card padding, search, tabs, and nav controls */}
-			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 max-h-[calc(100vh-420px)] overflow-y-auto">
+			{/* Show ~3 rows (176px each with 16px gap) before scrolling. */}
+			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 auto-rows-[11rem] max-h-[35rem] overflow-y-auto">
 				{visibleModules.length ? (
 					visibleModules.map((m) => (
 						<ModuleCard

--- a/site/src/pages/TemplateBuilder/ModuleSettingsStep.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleSettingsStep.tsx
@@ -130,8 +130,7 @@ export const ModuleSettingsStep: FC<ModuleSettingsStepProps> = ({
 				Set values for module variables.
 			</TemplateBuilderSubtitle>
 
-			{/* 340px accounts for navbar, page header, card padding, and nav controls */}
-			<div className="flex flex-col gap-6 max-h-[calc(100vh-340px)] overflow-y-auto">
+			<div className="flex flex-col gap-6">
 				{selectedModules.map((mod) => {
 					const configurableVars = mod.variables.filter((v) => !v.sensitive);
 					const sensitiveVars = mod.variables.filter((v) => v.sensitive);

--- a/site/src/pages/TemplateBuilder/ModuleSettingsStep.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleSettingsStep.tsx
@@ -1,4 +1,3 @@
-import { InfoIcon } from "lucide-react";
 import type { FC } from "react";
 import { useQuery } from "react-query";
 import { templateBuilderModules } from "#/api/queries/templateBuilder";
@@ -26,6 +25,7 @@ interface ModuleSettingsStepProps {
 		moduleId: string,
 		variables: Record<string, string>,
 	) => void;
+	onRemoveModule: (moduleId: string) => void;
 }
 
 function variableToField(
@@ -107,6 +107,7 @@ export const ModuleSettingsStep: FC<ModuleSettingsStepProps> = ({
 	selectedModuleIds,
 	moduleVariables,
 	onChangeModuleVariables,
+	onRemoveModule,
 }) => {
 	const { data } = useQuery(templateBuilderModules(baseId));
 	const modules = data?.modules ?? [];
@@ -149,7 +150,14 @@ export const ModuleSettingsStep: FC<ModuleSettingsStepProps> = ({
 					const optionalFields = optionalVars.map(toField);
 
 					return (
-						<div key={mod.id}>
+						// The id target is how the SelectionSummary jumps to a
+						// specific module. `scroll-mt-4` gives a small breathing
+						// margin when scrolled into view.
+						<div
+							key={mod.id}
+							id={`module-config-${mod.id}`}
+							className="scroll-mt-4"
+						>
 							<ModuleConfiguration
 								name={mod.display_name}
 								description={mod.description}
@@ -157,24 +165,9 @@ export const ModuleSettingsStep: FC<ModuleSettingsStepProps> = ({
 								detailsUrl={moduleDetailsUrl(mod.id)}
 								fields={requiredFields}
 								optionalFields={optionalFields}
+								sensitiveVariables={sensitiveVars}
+								onRemove={() => onRemoveModule(mod.id)}
 							/>
-
-							{sensitiveVars.length > 0 && (
-								<div className="flex items-center gap-2 mt-2 p-3 rounded-md text-sm text-content-secondary">
-									<InfoIcon className="size-icon-sm shrink-0 mt-0.5" />
-									<p>
-										{sensitiveVars.map((v) => (
-											<code
-												key={v.name}
-												className="mr-1 px-1.5 py-1 bg-surface-secondary"
-											>
-												{v.name}
-											</code>
-										))}
-										will be collected from developers at workspace creation.
-									</p>
-								</div>
-							)}
 						</div>
 					);
 				})}

--- a/site/src/pages/TemplateBuilder/ModuleSettingsStep.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleSettingsStep.tsx
@@ -16,6 +16,7 @@ import {
 } from "./ConfigurationField";
 import { defaultPlaceholder } from "./defaultPlaceholder";
 import { ModuleConfiguration } from "./ModuleConfiguration";
+import { getModuleFieldPlaceholder } from "./moduleFieldPlaceholders";
 
 interface ModuleSettingsStepProps {
 	baseId: string;
@@ -57,8 +58,9 @@ function variableToField(
 		description: variable.description || undefined,
 		required: variable.required,
 		placeholder:
+			getModuleFieldPlaceholder(moduleId, variable.name) ??
 			defaultPlaceholder(variable.default) ??
-			(variable.required ? "Required" : "Optional"),
+			(variable.required ? "Required" : ""),
 		field: {
 			name: variable.name,
 			id,

--- a/site/src/pages/TemplateBuilder/ModuleSettingsStep.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleSettingsStep.tsx
@@ -151,12 +151,13 @@ export const ModuleSettingsStep: FC<ModuleSettingsStepProps> = ({
 
 					return (
 						// The id target is how the SelectionSummary jumps to a
-						// specific module. `scroll-mt-4` gives a small breathing
-						// margin when scrolled into view.
+						// specific module. `scroll-mt-24` accounts for the sticky
+						// top navigation so the module title is not covered when
+						// scrolled into view.
 						<div
 							key={mod.id}
 							id={`module-config-${mod.id}`}
-							className="scroll-mt-4"
+							className="scroll-mt-24"
 						>
 							<ModuleConfiguration
 								name={mod.display_name}

--- a/site/src/pages/TemplateBuilder/SelectionSummary.stories.tsx
+++ b/site/src/pages/TemplateBuilder/SelectionSummary.stories.tsx
@@ -174,6 +174,15 @@ export const BackwardNavigation: Story = {
 			{ id: "claude-code", name: "Claude Code", iconUrl: "/icon/claude.svg" },
 		],
 	},
+	play: async ({ canvasElement }) => {
+		// Both dividers must be rendered in the completed variant because
+		// the user has walked past both. Regression check for the divider
+		// colour flipping back to grey after backward navigation.
+		const dividers = canvasElement.querySelectorAll(
+			"[class*='border-border-success']",
+		);
+		await expect(dividers.length).toBeGreaterThanOrEqual(2);
+	},
 };
 
 export const UpcomingStepsInert: Story = {

--- a/site/src/pages/TemplateBuilder/SelectionSummary.stories.tsx
+++ b/site/src/pages/TemplateBuilder/SelectionSummary.stories.tsx
@@ -6,6 +6,7 @@ const meta: Meta<typeof SelectionSummary> = {
 	title: "pages/TemplateBuilder/SelectionSummary",
 	component: SelectionSummary,
 	args: {
+		maxReachedStep: 3,
 		onDeselectModule: fn(),
 		onNavigateStep: fn(),
 		onNavigateModule: fn(),
@@ -18,6 +19,7 @@ type Story = StoryObj<typeof SelectionSummary>;
 export const NoSelection: Story = {
 	args: {
 		currentStep: 0,
+		maxReachedStep: 1,
 		selectedTemplate: undefined,
 		selectedModules: undefined,
 	},
@@ -26,6 +28,7 @@ export const NoSelection: Story = {
 export const BaseTemplateStep: Story = {
 	args: {
 		currentStep: 1,
+		maxReachedStep: 1,
 		selectedTemplate: undefined,
 		selectedModules: undefined,
 	},
@@ -34,6 +37,7 @@ export const BaseTemplateStep: Story = {
 export const WithBaseTemplate: Story = {
 	args: {
 		currentStep: 1,
+		maxReachedStep: 1,
 		selectedTemplate: {
 			name: "Docker Containers",
 			iconUrl: "/icon/docker.svg",
@@ -44,6 +48,7 @@ export const WithBaseTemplate: Story = {
 export const ModulesStep: Story = {
 	args: {
 		currentStep: 2,
+		maxReachedStep: 2,
 		selectedTemplate: {
 			name: "Docker Containers",
 			iconUrl: "/icon/docker.svg",
@@ -151,6 +156,43 @@ export const Customizations: Story = {
 			{ id: "claude-code", name: "Claude Code", iconUrl: "/icon/claude.svg" },
 			{ id: "cursor", name: "Cursor IDE", iconUrl: "/icon/cursor.svg" },
 		],
+	},
+};
+
+export const BackwardNavigation: Story = {
+	// User advanced to step 3, then clicked back to step 1. Step 3 should
+	// still look reachable and clickable; nothing beyond max-reached should
+	// appear as an upcoming step.
+	args: {
+		currentStep: 1,
+		maxReachedStep: 3,
+		selectedTemplate: {
+			name: "Docker Containers",
+			iconUrl: "/icon/docker.svg",
+		},
+		selectedModules: [
+			{ id: "claude-code", name: "Claude Code", iconUrl: "/icon/claude.svg" },
+		],
+	},
+};
+
+export const UpcomingStepsInert: Story = {
+	// User is on step 1 with nothing selected yet. Steps 2 and 3 must be
+	// rendered without a button so they are not clickable and have no
+	// hover treatment.
+	args: {
+		currentStep: 1,
+		maxReachedStep: 1,
+		selectedTemplate: undefined,
+		selectedModules: undefined,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const modulesLabel = canvas.getByText("Modules");
+		const customizationsLabel = canvas.getByText("Customizations");
+		// Neither label should be inside a button element.
+		await expect(modulesLabel.closest("button")).toBeNull();
+		await expect(customizationsLabel.closest("button")).toBeNull();
 	},
 };
 

--- a/site/src/pages/TemplateBuilder/SelectionSummary.stories.tsx
+++ b/site/src/pages/TemplateBuilder/SelectionSummary.stories.tsx
@@ -7,7 +7,6 @@ const meta: Meta<typeof SelectionSummary> = {
 	component: SelectionSummary,
 	args: {
 		maxReachedStep: 3,
-		onDeselectModule: fn(),
 		onNavigateStep: fn(),
 		onNavigateModule: fn(),
 	},
@@ -122,11 +121,12 @@ export const WithLongNameModule: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 
-		const deselectModuleButton = await canvas.findByRole("button", {
-			name: "Deselect module",
+		// Long module names must not be truncated and must remain visible in
+		// the sidebar. The row is a single navigation button.
+		const moduleBtn = await canvas.findByRole("button", {
+			name: /^Configure A module/i,
 		});
-		deselectModuleButton.focus();
-		await expect(deselectModuleButton).toBeVisible();
+		await expect(moduleBtn).toBeVisible();
 	},
 };
 

--- a/site/src/pages/TemplateBuilder/SelectionSummary.stories.tsx
+++ b/site/src/pages/TemplateBuilder/SelectionSummary.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, within } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
 import { SelectionSummary } from "./SelectionSummary";
 
 const meta: Meta<typeof SelectionSummary> = {
@@ -7,6 +7,8 @@ const meta: Meta<typeof SelectionSummary> = {
 	component: SelectionSummary,
 	args: {
 		onDeselectModule: fn(),
+		onNavigateStep: fn(),
+		onNavigateModule: fn(),
 	},
 };
 
@@ -149,5 +151,52 @@ export const Customizations: Story = {
 			{ id: "claude-code", name: "Claude Code", iconUrl: "/icon/claude.svg" },
 			{ id: "cursor", name: "Cursor IDE", iconUrl: "/icon/cursor.svg" },
 		],
+	},
+};
+
+export const NavigationClicks: Story = {
+	args: {
+		currentStep: 3,
+		selectedTemplate: {
+			name: "Docker Containers",
+			iconUrl: "/icon/docker.svg",
+		},
+		selectedModules: [
+			{ id: "claude-code", name: "Claude Code", iconUrl: "/icon/claude.svg" },
+			{ id: "cursor", name: "Cursor IDE", iconUrl: "/icon/cursor.svg" },
+		],
+	},
+	play: async ({ args, canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		const baseTemplateBtn = await canvas.findByRole("button", {
+			name: "Go to Base Template",
+		});
+		await userEvent.click(baseTemplateBtn);
+		await expect(args.onNavigateStep).toHaveBeenCalledWith("base-infra");
+
+		const selectedBaseBtn = await canvas.findByRole("button", {
+			name: "Configure Docker Containers",
+		});
+		await userEvent.click(selectedBaseBtn);
+		await expect(args.onNavigateStep).toHaveBeenCalledWith("base-parameters");
+
+		const modulesBtn = await canvas.findByRole("button", {
+			name: "Go to Modules",
+		});
+		await userEvent.click(modulesBtn);
+		await expect(args.onNavigateStep).toHaveBeenCalledWith("module-select");
+
+		const customizationsBtn = await canvas.findByRole("button", {
+			name: "Go to Customizations",
+		});
+		await userEvent.click(customizationsBtn);
+		await expect(args.onNavigateStep).toHaveBeenCalledWith("customizations");
+
+		const moduleBtn = await canvas.findByRole("button", {
+			name: "Configure Claude Code",
+		});
+		await userEvent.click(moduleBtn);
+		await expect(args.onNavigateModule).toHaveBeenCalledWith("claude-code");
 	},
 };

--- a/site/src/pages/TemplateBuilder/SelectionSummary.tsx
+++ b/site/src/pages/TemplateBuilder/SelectionSummary.tsx
@@ -225,15 +225,6 @@ const BaseTemplateSelection: React.FC<BaseTemplateSelectionProps> = ({
 	template,
 	onClick,
 }) => {
-	const inner = (
-		<div className="flex items-start p-1">
-			<div className="h-[1lh] content-center">
-				<Avatar src={template.iconUrl} size="sm" variant="icon" />
-			</div>
-			<span className="ml-2 text-content-secondary">{template.name}</span>
-		</div>
-	);
-
 	return (
 		<StepDivider>
 			{onClick ? (
@@ -242,14 +233,19 @@ const BaseTemplateSelection: React.FC<BaseTemplateSelectionProps> = ({
 					onClick={onClick}
 					aria-label={`Configure ${template.name}`}
 					className={cn(
-						"w-full text-left p-0 bg-transparent border-0 cursor-pointer rounded-sm",
-						"hover:bg-surface-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-primary",
+						"flex items-center gap-2 w-full text-left p-2 rounded-sm bg-transparent border-0 cursor-pointer",
+						"text-content-secondary hover:text-content-primary hover:bg-surface-secondary",
+						"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-primary",
 					)}
 				>
-					{inner}
+					<Avatar src={template.iconUrl} size="sm" variant="icon" />
+					<span>{template.name}</span>
 				</button>
 			) : (
-				inner
+				<div className="flex items-center gap-2 p-2 text-content-secondary">
+					<Avatar src={template.iconUrl} size="sm" variant="icon" />
+					<span>{template.name}</span>
+				</div>
 			)}
 		</StepDivider>
 	);
@@ -274,25 +270,21 @@ const ModuleSelection: React.FC<ModuleSelectionProps> = ({
 						onClick={() => onSelectModule(module.id)}
 						aria-label={`Configure ${module.name}`}
 						className={cn(
-							"flex items-start w-full text-left p-2 rounded-sm bg-transparent border-0 cursor-pointer",
+							"flex items-center gap-2 w-full text-left p-2 rounded-sm bg-transparent border-0 cursor-pointer",
 							"text-content-secondary hover:text-content-primary hover:bg-surface-secondary",
 							"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-primary",
 						)}
 					>
-						<div className="h-[1lh] content-center">
-							<Avatar src={module.iconUrl} size="sm" variant="icon" />
-						</div>
-						<span className="flex-1 ml-2">{module.name}</span>
+						<Avatar src={module.iconUrl} size="sm" variant="icon" />
+						<span className="flex-1">{module.name}</span>
 					</button>
 				) : (
 					<div
 						key={module.id}
-						className="flex items-start p-2 text-content-secondary"
+						className="flex items-center gap-2 p-2 text-content-secondary"
 					>
-						<div className="h-[1lh] content-center">
-							<Avatar src={module.iconUrl} size="sm" variant="icon" />
-						</div>
-						<span className="flex-1 ml-2">{module.name}</span>
+						<Avatar src={module.iconUrl} size="sm" variant="icon" />
+						<span className="flex-1">{module.name}</span>
 					</div>
 				),
 			)}

--- a/site/src/pages/TemplateBuilder/SelectionSummary.tsx
+++ b/site/src/pages/TemplateBuilder/SelectionSummary.tsx
@@ -51,17 +51,22 @@ export const SelectionSummary: React.FC<SelectionSummaryProps> = ({
 	onNavigateStep,
 	onNavigateModule,
 }) => {
-	const variant = (step: number) => {
+	const indicatorVariant = (step: number): Variant => {
 		if (currentStep === step) return "current";
 		if (step <= maxReachedStep) return "complete";
 		return "upcoming";
 	};
+	// The vertical line below step N represents the path from N to N+1.
+	// It stays green as soon as the user has advanced past N, even if the
+	// current step later drops back below N (backward navigation).
+	const dividerVariant = (step: number): Variant =>
+		maxReachedStep > step ? "complete" : "current";
 	const reachable = (step: number) => step <= maxReachedStep;
 	return (
 		<div>
 			<h2 className="text-xl font-semibold">Selection</h2>
 			<div className="text-sm">
-				<VariantContext.Provider value={variant(1)}>
+				<VariantContext.Provider value={indicatorVariant(1)}>
 					<StepIndicator
 						step={1}
 						onClick={
@@ -72,6 +77,8 @@ export const SelectionSummary: React.FC<SelectionSummaryProps> = ({
 					>
 						Base Template
 					</StepIndicator>
+				</VariantContext.Provider>
+				<VariantContext.Provider value={dividerVariant(1)}>
 					{selectedTemplate ? (
 						<BaseTemplateSelection
 							template={selectedTemplate}
@@ -85,7 +92,7 @@ export const SelectionSummary: React.FC<SelectionSummaryProps> = ({
 						<StepDivider />
 					)}
 				</VariantContext.Provider>
-				<VariantContext.Provider value={variant(2)}>
+				<VariantContext.Provider value={indicatorVariant(2)}>
 					<StepIndicator
 						step={2}
 						onClick={
@@ -96,6 +103,8 @@ export const SelectionSummary: React.FC<SelectionSummaryProps> = ({
 					>
 						Modules
 					</StepIndicator>
+				</VariantContext.Provider>
+				<VariantContext.Provider value={dividerVariant(2)}>
 					{selectedModules ? (
 						<ModuleSelection
 							modules={selectedModules}
@@ -105,7 +114,7 @@ export const SelectionSummary: React.FC<SelectionSummaryProps> = ({
 						<StepDivider />
 					)}
 				</VariantContext.Provider>
-				<VariantContext.Provider value={variant(3)}>
+				<VariantContext.Provider value={indicatorVariant(3)}>
 					<StepIndicator
 						step={3}
 						onClick={

--- a/site/src/pages/TemplateBuilder/SelectionSummary.tsx
+++ b/site/src/pages/TemplateBuilder/SelectionSummary.tsx
@@ -4,6 +4,7 @@ import { createContext, type PropsWithChildren, useContext } from "react";
 import { Avatar } from "#/components/Avatar/Avatar";
 import { Button } from "#/components/Button/Button";
 import { cn } from "#/utils/cn";
+import type { StepId } from "./steps";
 
 type Variant = "complete" | "current" | "upcoming" | null | undefined;
 
@@ -25,6 +26,17 @@ type SelectionSummaryProps = {
 	selectedTemplate?: SelectedTemplate;
 	selectedModules?: SelectedModule[];
 	onDeselectModule: (moduleId: string) => void;
+	/**
+	 * Jump to a wizard step. `SelectionSummary` calls this from the
+	 * numbered step labels and from the selected-template row.
+	 */
+	onNavigateStep?: (stepId: StepId) => void;
+	/**
+	 * Jump to a specific module's configuration section. Consumers
+	 * should switch to the appropriate step and scroll the module
+	 * into view.
+	 */
+	onNavigateModule?: (moduleId: string) => void;
 };
 
 export const SelectionSummary: React.FC<SelectionSummaryProps> = ({
@@ -32,6 +44,8 @@ export const SelectionSummary: React.FC<SelectionSummaryProps> = ({
 	selectedTemplate,
 	selectedModules,
 	onDeselectModule,
+	onNavigateStep,
+	onNavigateModule,
 }) => {
 	const variant = (step: number) => {
 		if (currentStep === step) return "current";
@@ -43,26 +57,57 @@ export const SelectionSummary: React.FC<SelectionSummaryProps> = ({
 			<h2 className="text-xl font-semibold">Selection</h2>
 			<div className="text-sm">
 				<VariantContext.Provider value={variant(1)}>
-					<StepIndicator step={1}>Base Template</StepIndicator>
+					<StepIndicator
+						step={1}
+						onClick={
+							onNavigateStep ? () => onNavigateStep("base-infra") : undefined
+						}
+					>
+						Base Template
+					</StepIndicator>
 					{selectedTemplate ? (
-						<BaseTemplateSelection template={selectedTemplate} />
+						<BaseTemplateSelection
+							template={selectedTemplate}
+							onClick={
+								onNavigateStep
+									? () => onNavigateStep("base-parameters")
+									: undefined
+							}
+						/>
 					) : (
 						<StepDivider />
 					)}
 				</VariantContext.Provider>
 				<VariantContext.Provider value={variant(2)}>
-					<StepIndicator step={2}>Modules</StepIndicator>
+					<StepIndicator
+						step={2}
+						onClick={
+							onNavigateStep ? () => onNavigateStep("module-select") : undefined
+						}
+					>
+						Modules
+					</StepIndicator>
 					{selectedModules ? (
 						<ModuleSelection
 							modules={selectedModules}
 							onDeselectModule={onDeselectModule}
+							onSelectModule={onNavigateModule}
 						/>
 					) : (
 						<StepDivider />
 					)}
 				</VariantContext.Provider>
 				<VariantContext.Provider value={variant(3)}>
-					<StepIndicator step={3}>Customizations</StepIndicator>
+					<StepIndicator
+						step={3}
+						onClick={
+							onNavigateStep
+								? () => onNavigateStep("customizations")
+								: undefined
+						}
+					>
+						Customizations
+					</StepIndicator>
 				</VariantContext.Provider>
 			</div>
 		</div>
@@ -94,10 +139,33 @@ const stepLabelVariants = cva("font-normal mr-2", {
 
 type StepIndicatorProps = PropsWithChildren<{
 	step: number;
+	onClick?: () => void;
 }>;
 
-const StepIndicator: React.FC<StepIndicatorProps> = ({ step, children }) => {
+const StepIndicator: React.FC<StepIndicatorProps> = ({
+	step,
+	onClick,
+	children,
+}) => {
 	const variant = useContext(VariantContext);
+	const label = typeof children === "string" ? children : `step ${step}`;
+
+	if (onClick) {
+		return (
+			<button
+				type="button"
+				onClick={onClick}
+				aria-label={`Go to ${label}`}
+				className={cn(
+					"flex items-center gap-2 w-full text-left p-0 bg-transparent border-0 cursor-pointer rounded-sm",
+					"hover:bg-surface-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-primary",
+				)}
+			>
+				<div className={stepCircleVariants({ variant })}>{step}</div>
+				<span className={stepLabelVariants({ variant })}>{children}</span>
+			</button>
+		);
+	}
 
 	return (
 		<div className="flex items-center gap-2">
@@ -142,19 +210,39 @@ const StepDivider: React.FC<StepDividerProps> = ({ className, children }) => {
 
 type BaseTemplateSelectionProps = {
 	template: SelectedTemplate;
+	onClick?: () => void;
 };
 
 const BaseTemplateSelection: React.FC<BaseTemplateSelectionProps> = ({
 	template,
+	onClick,
 }) => {
+	const inner = (
+		<div className="flex items-start p-1">
+			<div className="h-[1lh] content-center">
+				<Avatar src={template.iconUrl} size="sm" variant="icon" />
+			</div>
+			<span className="ml-2 text-content-secondary">{template.name}</span>
+		</div>
+	);
+
 	return (
 		<StepDivider>
-			<div className="flex items-start p-1">
-				<div className="h-[1lh] content-center">
-					<Avatar src={template.iconUrl} size="sm" variant="icon" />
-				</div>
-				<span className="ml-2 text-content-secondary">{template.name}</span>
-			</div>
+			{onClick ? (
+				<button
+					type="button"
+					onClick={onClick}
+					aria-label={`Configure ${template.name}`}
+					className={cn(
+						"w-full text-left p-0 bg-transparent border-0 cursor-pointer rounded-sm",
+						"hover:bg-surface-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-primary",
+					)}
+				>
+					{inner}
+				</button>
+			) : (
+				inner
+			)}
 		</StepDivider>
 	);
 };
@@ -162,26 +250,52 @@ const BaseTemplateSelection: React.FC<BaseTemplateSelectionProps> = ({
 type ModuleSelectionProps = {
 	modules: SelectedModule[];
 	onDeselectModule: (moduleId: string) => void;
+	onSelectModule?: (moduleId: string) => void;
 };
 
 const ModuleSelection: React.FC<ModuleSelectionProps> = ({
 	modules,
 	onDeselectModule,
+	onSelectModule,
 }) => {
 	return (
 		<StepDivider className="max-h-72 overflow-y-auto">
 			{modules.map((module) => (
 				<div
 					key={module.id}
-					className="group flex items-start justify-between p-1 mb-1 rounded-sm hover:bg-surface-secondary"
+					className={cn(
+						"group flex items-start justify-between rounded-sm mb-1",
+						"hover:bg-surface-secondary",
+					)}
 				>
-					<div className="h-[1lh] content-center">
-						<Avatar src={module.iconUrl} size="sm" variant="icon" />
-					</div>
-					<span className="flex-1 ml-2 text-content-secondary">
-						{module.name}
-					</span>
-					<div className="h-[1lh] content-center">
+					{onSelectModule ? (
+						<button
+							type="button"
+							onClick={() => onSelectModule(module.id)}
+							aria-label={`Configure ${module.name}`}
+							className={cn(
+								"flex flex-1 items-start min-w-0 p-1 text-left bg-transparent border-0 cursor-pointer rounded-sm",
+								"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-primary",
+							)}
+						>
+							<div className="h-[1lh] content-center">
+								<Avatar src={module.iconUrl} size="sm" variant="icon" />
+							</div>
+							<span className="flex-1 ml-2 text-content-secondary">
+								{module.name}
+							</span>
+						</button>
+					) : (
+						<div className="flex flex-1 items-start min-w-0 p-1">
+							<div className="h-[1lh] content-center">
+								<Avatar src={module.iconUrl} size="sm" variant="icon" />
+							</div>
+							<span className="flex-1 ml-2 text-content-secondary">
+								{module.name}
+							</span>
+						</div>
+					)}
+					<div className="h-[1lh] content-center p-1">
 						<Button
 							size="xs"
 							variant="subtle"

--- a/site/src/pages/TemplateBuilder/SelectionSummary.tsx
+++ b/site/src/pages/TemplateBuilder/SelectionSummary.tsx
@@ -1,8 +1,6 @@
 import { cva } from "class-variance-authority";
-import { XIcon } from "lucide-react";
 import { createContext, type PropsWithChildren, useContext } from "react";
 import { Avatar } from "#/components/Avatar/Avatar";
-import { Button } from "#/components/Button/Button";
 import { cn } from "#/utils/cn";
 import type { StepId } from "./steps";
 
@@ -32,7 +30,6 @@ type SelectionSummaryProps = {
 	maxReachedStep: number;
 	selectedTemplate?: SelectedTemplate;
 	selectedModules?: SelectedModule[];
-	onDeselectModule: (moduleId: string) => void;
 	/**
 	 * Jump to a wizard step. `SelectionSummary` calls this from the
 	 * numbered step labels and from the selected-template row.
@@ -51,7 +48,6 @@ export const SelectionSummary: React.FC<SelectionSummaryProps> = ({
 	maxReachedStep,
 	selectedTemplate,
 	selectedModules,
-	onDeselectModule,
 	onNavigateStep,
 	onNavigateModule,
 }) => {
@@ -103,7 +99,6 @@ export const SelectionSummary: React.FC<SelectionSummaryProps> = ({
 					{selectedModules ? (
 						<ModuleSelection
 							modules={selectedModules}
-							onDeselectModule={onDeselectModule}
 							onSelectModule={reachable(2) ? onNavigateModule : undefined}
 						/>
 					) : (
@@ -171,7 +166,7 @@ const StepIndicator: React.FC<StepIndicatorProps> = ({
 				aria-label={`Go to ${label}`}
 				className={cn(
 					"flex items-center gap-2 w-full text-left p-0 bg-transparent border-0 cursor-pointer rounded-sm",
-					"hover:bg-surface-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-primary",
+					"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-primary",
 				)}
 			>
 				<div className={stepCircleVariants({ variant })}>{step}</div>
@@ -262,65 +257,45 @@ const BaseTemplateSelection: React.FC<BaseTemplateSelectionProps> = ({
 
 type ModuleSelectionProps = {
 	modules: SelectedModule[];
-	onDeselectModule: (moduleId: string) => void;
 	onSelectModule?: (moduleId: string) => void;
 };
 
 const ModuleSelection: React.FC<ModuleSelectionProps> = ({
 	modules,
-	onDeselectModule,
 	onSelectModule,
 }) => {
 	return (
 		<StepDivider className="max-h-72 overflow-y-auto">
-			{modules.map((module) => (
-				<div
-					key={module.id}
-					className={cn(
-						"group flex items-start justify-between rounded-sm mb-1",
-						"hover:bg-surface-secondary",
-					)}
-				>
-					{onSelectModule ? (
-						<button
-							type="button"
-							onClick={() => onSelectModule(module.id)}
-							aria-label={`Configure ${module.name}`}
-							className={cn(
-								"flex flex-1 items-start min-w-0 p-1 text-left bg-transparent border-0 cursor-pointer rounded-sm",
-								"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-primary",
-							)}
-						>
-							<div className="h-[1lh] content-center">
-								<Avatar src={module.iconUrl} size="sm" variant="icon" />
-							</div>
-							<span className="flex-1 ml-2 text-content-secondary">
-								{module.name}
-							</span>
-						</button>
-					) : (
-						<div className="flex flex-1 items-start min-w-0 p-1">
-							<div className="h-[1lh] content-center">
-								<Avatar src={module.iconUrl} size="sm" variant="icon" />
-							</div>
-							<span className="flex-1 ml-2 text-content-secondary">
-								{module.name}
-							</span>
+			{modules.map((module) =>
+				onSelectModule ? (
+					<button
+						key={module.id}
+						type="button"
+						onClick={() => onSelectModule(module.id)}
+						aria-label={`Configure ${module.name}`}
+						className={cn(
+							"flex items-start w-full text-left p-2 rounded-sm bg-transparent border-0 cursor-pointer",
+							"text-content-secondary hover:text-content-primary hover:bg-surface-secondary",
+							"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-primary",
+						)}
+					>
+						<div className="h-[1lh] content-center">
+							<Avatar src={module.iconUrl} size="sm" variant="icon" />
 						</div>
-					)}
-					<div className="h-[1lh] content-center p-1">
-						<Button
-							size="xs"
-							variant="subtle"
-							className="flex opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
-							onClick={() => onDeselectModule(module.id)}
-							aria-label="Deselect module"
-						>
-							<XIcon className="w-4 h-4" />
-						</Button>
+						<span className="flex-1 ml-2">{module.name}</span>
+					</button>
+				) : (
+					<div
+						key={module.id}
+						className="flex items-start p-2 text-content-secondary"
+					>
+						<div className="h-[1lh] content-center">
+							<Avatar src={module.iconUrl} size="sm" variant="icon" />
+						</div>
+						<span className="flex-1 ml-2">{module.name}</span>
 					</div>
-				</div>
-			))}
+				),
+			)}
 		</StepDivider>
 	);
 };

--- a/site/src/pages/TemplateBuilder/SelectionSummary.tsx
+++ b/site/src/pages/TemplateBuilder/SelectionSummary.tsx
@@ -23,6 +23,13 @@ type SelectedModule = {
 
 type SelectionSummaryProps = {
 	currentStep: number;
+	/**
+	 * The highest group number the user has reached. Groups at or below
+	 * this value stay clickable and rendered as `complete` even when the
+	 * current step is lower, so the sidebar behaves like a browser back
+	 * stack. Groups strictly above are `upcoming` and inert.
+	 */
+	maxReachedStep: number;
 	selectedTemplate?: SelectedTemplate;
 	selectedModules?: SelectedModule[];
 	onDeselectModule: (moduleId: string) => void;
@@ -41,6 +48,7 @@ type SelectionSummaryProps = {
 
 export const SelectionSummary: React.FC<SelectionSummaryProps> = ({
 	currentStep,
+	maxReachedStep,
 	selectedTemplate,
 	selectedModules,
 	onDeselectModule,
@@ -49,9 +57,10 @@ export const SelectionSummary: React.FC<SelectionSummaryProps> = ({
 }) => {
 	const variant = (step: number) => {
 		if (currentStep === step) return "current";
-		if (currentStep > step) return "complete";
+		if (step <= maxReachedStep) return "complete";
 		return "upcoming";
 	};
+	const reachable = (step: number) => step <= maxReachedStep;
 	return (
 		<div>
 			<h2 className="text-xl font-semibold">Selection</h2>
@@ -60,7 +69,9 @@ export const SelectionSummary: React.FC<SelectionSummaryProps> = ({
 					<StepIndicator
 						step={1}
 						onClick={
-							onNavigateStep ? () => onNavigateStep("base-infra") : undefined
+							onNavigateStep && reachable(1)
+								? () => onNavigateStep("base-infra")
+								: undefined
 						}
 					>
 						Base Template
@@ -69,7 +80,7 @@ export const SelectionSummary: React.FC<SelectionSummaryProps> = ({
 						<BaseTemplateSelection
 							template={selectedTemplate}
 							onClick={
-								onNavigateStep
+								onNavigateStep && reachable(1)
 									? () => onNavigateStep("base-parameters")
 									: undefined
 							}
@@ -82,7 +93,9 @@ export const SelectionSummary: React.FC<SelectionSummaryProps> = ({
 					<StepIndicator
 						step={2}
 						onClick={
-							onNavigateStep ? () => onNavigateStep("module-select") : undefined
+							onNavigateStep && reachable(2)
+								? () => onNavigateStep("module-select")
+								: undefined
 						}
 					>
 						Modules
@@ -91,7 +104,7 @@ export const SelectionSummary: React.FC<SelectionSummaryProps> = ({
 						<ModuleSelection
 							modules={selectedModules}
 							onDeselectModule={onDeselectModule}
-							onSelectModule={onNavigateModule}
+							onSelectModule={reachable(2) ? onNavigateModule : undefined}
 						/>
 					) : (
 						<StepDivider />
@@ -101,7 +114,7 @@ export const SelectionSummary: React.FC<SelectionSummaryProps> = ({
 					<StepIndicator
 						step={3}
 						onClick={
-							onNavigateStep
+							onNavigateStep && reachable(3)
 								? () => onNavigateStep("customizations")
 								: undefined
 						}

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
@@ -21,6 +21,7 @@ import {
 	PageHeaderSubtitle,
 	PageHeaderTitle,
 } from "#/components/PageHeader/PageHeader";
+import { HasReachedBottomProvider } from "#/hooks/useHasReachedBottom";
 
 import { docs } from "#/utils/docs";
 import { BaseInfraSelectStep } from "./BaseInfraSelectStep";
@@ -201,15 +202,21 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 				{/* Main content area */}
 				<div className="flex-1 min-w-0">
 					<div className="p-6 border border-solid rounded-lg overflow-x-auto">
-						{renderStepContent(
-							currentStep.id,
-							state,
-							dispatch,
-							moduleVarMap,
-							createError,
-							handleProvisionerStatusChange,
-							handleDeselectModule,
-						)}
+						{/*
+							 Reset the "has reached bottom" signal on every step change
+							 so required fields on a fresh step do not start out flagged.
+							*/}
+						<HasReachedBottomProvider key={currentStep.id}>
+							{renderStepContent(
+								currentStep.id,
+								state,
+								dispatch,
+								moduleVarMap,
+								createError,
+								handleProvisionerStatusChange,
+								handleDeselectModule,
+							)}
+						</HasReachedBottomProvider>
 					</div>
 
 					{/* Navigation controls */}

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
@@ -117,14 +117,22 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 		setStepIndex(nextIndex);
 	};
 
-	const navigateToStep = (targetId: StepId) => {
+	const navigateToStep = (
+		targetId: StepId,
+		options?: { skipScrollReset?: boolean },
+	) => {
 		const target = WIZARD_STEPS.findIndex((s) => s.id === targetId);
 		if (target < 0) return;
 		if (currentStep.id === "customizations" && targetId !== "customizations") {
 			dispatch({ type: "RESET_CUSTOMIZATIONS" });
 			onClearCreateError?.();
 		}
-		window.scrollTo(0, 0);
+		// The caller sets skipScrollReset when it will manage the scroll
+		// position itself, for example by jumping to a specific module
+		// section via scrollIntoView.
+		if (!options?.skipScrollReset) {
+			window.scrollTo(0, 0);
+		}
 		setStepIndex(nearestVisible(target, state));
 	};
 
@@ -138,7 +146,7 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 			settingsIndex >= 0 && !WIZARD_STEPS[settingsIndex].shouldSkip(state)
 				? "module-settings"
 				: "module-select";
-		navigateToStep(targetId);
+		navigateToStep(targetId, { skipScrollReset: true });
 		if (targetId === "module-settings") {
 			// Wait for the step render, then scroll the module section into view.
 			requestAnimationFrame(() => {

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
@@ -110,6 +110,37 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 		setStepIndex(nextIndex);
 	};
 
+	const navigateToStep = (targetId: StepId) => {
+		const target = WIZARD_STEPS.findIndex((s) => s.id === targetId);
+		if (target < 0) return;
+		if (currentStep.id === "customizations" && targetId !== "customizations") {
+			dispatch({ type: "RESET_CUSTOMIZATIONS" });
+			onClearCreateError?.();
+		}
+		window.scrollTo(0, 0);
+		setStepIndex(nearestVisible(target, state));
+	};
+
+	const navigateToModule = (moduleId: string) => {
+		const settingsIndex = WIZARD_STEPS.findIndex(
+			(s) => s.id === "module-settings",
+		);
+		// If module-settings is skipped (no configurable vars), fall back to
+		// module-select so the user still lands somewhere useful.
+		const targetId: StepId =
+			settingsIndex >= 0 && !WIZARD_STEPS[settingsIndex].shouldSkip(state)
+				? "module-settings"
+				: "module-select";
+		navigateToStep(targetId);
+		if (targetId === "module-settings") {
+			// Wait for the step render, then scroll the module section into view.
+			requestAnimationFrame(() => {
+				const el = document.getElementById(`module-config-${moduleId}`);
+				el?.scrollIntoView({ behavior: "smooth", block: "start" });
+			});
+		}
+	};
+
 	const handleProvisionerStatusChange = useCallback(
 		(value: boolean | undefined) => {
 			dispatch({ type: "SET_HAS_PROVISIONERS", value });
@@ -162,6 +193,7 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 							moduleVarMap,
 							createError,
 							handleProvisionerStatusChange,
+							handleDeselectModule,
 						)}
 					</div>
 
@@ -200,6 +232,8 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 								: undefined
 						}
 						onDeselectModule={handleDeselectModule}
+						onNavigateStep={navigateToStep}
+						onNavigateModule={navigateToModule}
 					/>
 				</div>
 			</div>
@@ -214,6 +248,7 @@ function renderStepContent(
 	moduleVarMap: Record<string, Record<string, string>>,
 	createError: Error | null,
 	onProvisionerStatusChange: (value: boolean | undefined) => void,
+	onRemoveModule: (moduleId: string) => void,
 ): ReactNode {
 	switch (stepId) {
 		case "base-infra":
@@ -259,6 +294,7 @@ function renderStepContent(
 							variables,
 						})
 					}
+					onRemoveModule={onRemoveModule}
 				/>
 			);
 		case "customizations":

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
@@ -70,6 +70,7 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 }) => {
 	const [state, dispatch] = useReducer(wizardReducer, initialWizardState);
 	const [stepIndex, setStepIndex] = useState(0);
+	const [maxReachedGroup, setMaxReachedGroup] = useState<1 | 2 | 3>(1);
 	const modulesQuery = useQuery(templateBuilderModules(state.selectedBase?.id));
 
 	const moduleVarMap = Object.fromEntries(
@@ -83,6 +84,12 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 	const prevIndex = findPrevVisibleIndex(currentIndex, state);
 	const isFirstStep = prevIndex === -1;
 	const isLastStep = nextIndex === -1;
+
+	// Keep maxReachedGroup at least as high as the current group; navigating
+	// backward via the sidebar must not shrink it.
+	if (currentStep.group > maxReachedGroup) {
+		setMaxReachedGroup(currentStep.group);
+	}
 
 	const canContinue = computeCanContinue(
 		currentStep.id,
@@ -218,6 +225,7 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 				<div className="w-64 shrink-0 hidden md:block sticky top-[72px] self-start">
 					<SelectionSummary
 						currentStep={currentStep.group}
+						maxReachedStep={maxReachedGroup}
 						selectedTemplate={
 							state.selectedBase
 								? {

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
@@ -239,7 +239,6 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 								? state.selectedModules
 								: undefined
 						}
-						onDeselectModule={handleDeselectModule}
 						onNavigateStep={navigateToStep}
 						onNavigateModule={navigateToModule}
 					/>

--- a/site/src/pages/TemplateBuilder/TemplateCard.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCard.tsx
@@ -63,15 +63,15 @@ export const TemplateCard: React.FC<TemplateCardProps> = ({
 			<div>
 				<h3
 					id={nameId}
-					className="flex items-center gap-1.5 text-md font-semibold text-content-primary"
+					className="flex items-start gap-1.5 text-md font-semibold text-content-primary"
 				>
-					{name}
+					<span className="line-clamp-2">{name}</span>
 					{official && (
-						<BadgeCheckIcon className="size-4 text-highlight-sky shrink-0" />
+						<BadgeCheckIcon className="size-4 text-highlight-sky shrink-0 mt-1" />
 					)}
 				</h3>
 				<div>
-					<p className="text-sm font-normal text-content-secondary">
+					<p className="text-sm font-normal text-content-secondary line-clamp-2">
 						{description}
 					</p>
 

--- a/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect, useState } from "react";
+import { type FC, useEffect, useRef, useState } from "react";
 import { useQuery } from "react-query";
 import {
 	permittedOrganizations,
@@ -13,10 +13,13 @@ import { Label } from "#/components/Label/Label";
 import { Link } from "#/components/Link/Link";
 import { OrganizationAutocomplete } from "#/components/OrganizationAutocomplete/OrganizationAutocomplete";
 import { Textarea } from "#/components/Textarea/Textarea";
+import { useHasBeenScrolledPast } from "#/hooks/useHasBeenScrolledPast";
+import { useHasReachedBottom } from "#/hooks/useHasReachedBottom";
 import {
 	TemplateBuilderSubtitle,
 	TemplateBuilderTitle,
 } from "#/pages/TemplateBuilder/TemplateBuilderHeader";
+import { cn } from "#/utils/cn";
 import { docs } from "#/utils/docs";
 import type {
 	SelectedBaseMeta,
@@ -71,6 +74,17 @@ export const TemplateCustomizationsStep: FC<
 		onChangeField("organizationId", org?.id ?? "");
 	};
 
+	// Highlight required fields with the destructive red outline when the user
+	// has scrolled past them or reached the bottom of the page while they are
+	// still empty.
+	const hasReachedBottom = useHasReachedBottom();
+	const idWrapperRef = useRef<HTMLDivElement>(null);
+	const idScrolledPast = useHasBeenScrolledPast(idWrapperRef);
+	const idIsInvalid = (idScrolledPast || hasReachedBottom) && !state.name;
+	const orgWrapperRef = useRef<HTMLDivElement>(null);
+	const orgScrolledPast = useHasBeenScrolledPast(orgWrapperRef);
+	const orgIsInvalid = (orgScrolledPast || hasReachedBottom) && !selectedOrg;
+
 	return (
 		<div className="min-w-[654px]">
 			<TemplateBuilderTitle>Customizations</TemplateBuilderTitle>
@@ -101,7 +115,7 @@ export const TemplateCustomizationsStep: FC<
 						</div>
 
 						{orgOptions.length > 0 && (
-							<div className="flex flex-col gap-2">
+							<div ref={orgWrapperRef} className="flex flex-col gap-2">
 								<Label htmlFor="organization">
 									Organization
 									<span className="text-xs font-bold text-content-destructive ml-1">
@@ -111,6 +125,7 @@ export const TemplateCustomizationsStep: FC<
 								<OrganizationAutocomplete
 									id="organization"
 									required
+									aria-invalid={orgIsInvalid}
 									value={selectedOrg}
 									onChange={handleOrgChange}
 									options={orgOptions}
@@ -151,7 +166,7 @@ export const TemplateCustomizationsStep: FC<
 							</div>
 						</div>
 
-						<div className="flex flex-col gap-2">
+						<div ref={idWrapperRef} className="flex flex-col gap-2">
 							<Label htmlFor="template-name">
 								ID
 								<span className="text-xs font-bold text-content-destructive ml-1">
@@ -165,6 +180,8 @@ export const TemplateCustomizationsStep: FC<
 									onChange={(e) => onChangeField("name", e.target.value)}
 									placeholder="my-template"
 									aria-required
+									aria-invalid={idIsInvalid}
+									className={cn(idIsInvalid && "border-border-destructive")}
 								/>
 								<p className="text-xs text-content-secondary mt-1">
 									Used to identify the template in URLs and the API.

--- a/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
@@ -129,8 +129,14 @@ export const TemplateCustomizationsStep: FC<
 						<p className="text-xs text-content-secondary">
 							Used by both humans and Agents to identify templates.
 						</p>
+					</div>
 
+					{/* Left column */}
+					<div className="flex flex-col gap-2">
+						<Label htmlFor="template-icon">Icon</Label>
 						<IconField
+							id="template-icon"
+							label=""
 							value={state.icon}
 							onChange={(e) => {
 								const target = e.target as HTMLInputElement;

--- a/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
@@ -84,86 +84,93 @@ export const TemplateCustomizationsStep: FC<
 				{/* Base template card */}
 				{state.selectedBase && <BaseTemplateCard base={state.selectedBase} />}
 
-				{/* Two-column form grid */}
-				<div className="grid grid-cols-2 gap-x-6 gap-y-6 content-start">
+				{/* Two independent columns so the left stack (Display name,
+				Organization, Icon) is not stretched by the taller right stack
+				(Description, ID). */}
+				<div className="flex gap-6">
 					{/* Left column */}
-					<div className="flex flex-col gap-2">
-						<Label htmlFor="template-display-name">Display name</Label>
-						<Input
-							id="template-display-name"
-							value={state.displayName}
-							onChange={(e) => onChangeField("displayName", e.target.value)}
-							placeholder="My Template"
-						/>
+					<div className="flex-1 flex flex-col gap-6">
+						<div className="flex flex-col gap-2">
+							<Label htmlFor="template-display-name">Display name</Label>
+							<Input
+								id="template-display-name"
+								value={state.displayName}
+								onChange={(e) => onChangeField("displayName", e.target.value)}
+								placeholder="My Template"
+							/>
+						</div>
+
+						{orgOptions.length > 0 && (
+							<div className="flex flex-col gap-2">
+								<Label htmlFor="organization">
+									Organization
+									<span className="text-xs font-bold text-content-destructive ml-1">
+										*
+									</span>
+								</Label>
+								<OrganizationAutocomplete
+									id="organization"
+									required
+									value={selectedOrg}
+									onChange={handleOrgChange}
+									options={orgOptions}
+								/>
+							</div>
+						)}
+
+						<div className="flex flex-col gap-2">
+							<Label htmlFor="template-icon">Icon</Label>
+							<IconField
+								id="template-icon"
+								label=""
+								value={state.icon}
+								onChange={(e) => {
+									const target = e.target as HTMLInputElement;
+									onChangeField("icon", target.value);
+								}}
+								onPickEmoji={(value) => onChangeField("icon", value)}
+							/>
+						</div>
 					</div>
 
 					{/* Right column */}
-					{orgOptions.length > 0 && (
+					<div className="flex-1 flex flex-col gap-6">
 						<div className="flex flex-col gap-2">
-							<Label htmlFor="organization">
-								Organization
+							<Label htmlFor="template-description">Description</Label>
+							<div>
+								<Textarea
+									id="template-description"
+									value={state.description}
+									onChange={(e) => onChangeField("description", e.target.value)}
+									placeholder="Describe what this template is for"
+									rows={3}
+								/>
+								<p className="text-xs text-content-secondary mt-1">
+									Used by both humans and Agents to identify templates.
+								</p>
+							</div>
+						</div>
+
+						<div className="flex flex-col gap-2">
+							<Label htmlFor="template-name">
+								ID
 								<span className="text-xs font-bold text-content-destructive ml-1">
 									*
 								</span>
 							</Label>
-							<OrganizationAutocomplete
-								id="organization"
-								required
-								value={selectedOrg}
-								onChange={handleOrgChange}
-								options={orgOptions}
-							/>
+							<div>
+								<Input
+									id="template-name"
+									value={state.name}
+									onChange={(e) => onChangeField("name", e.target.value)}
+									placeholder="my-template"
+									aria-required
+								/>
+								<p className="text-xs text-content-secondary mt-1">
+									Used to identify the template in URLs and the API.
+								</p>
+							</div>
 						</div>
-					)}
-
-					{/* Left column */}
-					<div className="flex flex-col gap-2">
-						<Label htmlFor="template-description">Description</Label>
-						<Textarea
-							id="template-description"
-							value={state.description}
-							onChange={(e) => onChangeField("description", e.target.value)}
-							placeholder="Describe what this template is for"
-							rows={3}
-						/>
-						<p className="text-xs text-content-secondary">
-							Used by both humans and Agents to identify templates.
-						</p>
-					</div>
-
-					{/* Left column */}
-					<div className="flex flex-col gap-2">
-						<Label htmlFor="template-icon">Icon</Label>
-						<IconField
-							id="template-icon"
-							label=""
-							value={state.icon}
-							onChange={(e) => {
-								const target = e.target as HTMLInputElement;
-								onChangeField("icon", target.value);
-							}}
-							onPickEmoji={(value) => onChangeField("icon", value)}
-						/>
-					</div>
-
-					{/* Right column */}
-					<div className="flex flex-col gap-2">
-						<Label htmlFor="template-name">
-							ID
-							<span className="text-xs font-bold text-content-destructive ml-1">
-								*
-							</span>
-						</Label>
-						<Input
-							id="template-name"
-							value={state.name}
-							onChange={(e) => onChangeField("name", e.target.value)}
-							placeholder="my-template"
-							aria-required
-						/>
-						<p className="text-xs text-content-secondary">
-							Used to identify the template in URLs and the API.
-						</p>
 					</div>
 				</div>
 			</div>

--- a/site/src/pages/TemplateBuilder/moduleFieldPlaceholders.test.ts
+++ b/site/src/pages/TemplateBuilder/moduleFieldPlaceholders.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+	getModuleFieldPlaceholder,
+	MODULE_FIELD_PLACEHOLDERS,
+} from "./moduleFieldPlaceholders";
+
+describe("getModuleFieldPlaceholder", () => {
+	it("returns the override for known module/variable pairs", () => {
+		expect(getModuleFieldPlaceholder("codex", "model_reasoning_effort")).toBe(
+			"none, minimal, low, medium, high, or xhigh",
+		);
+		expect(getModuleFieldPlaceholder("claude-code", "anthropic_api_key")).toBe(
+			"sk-ant-...",
+		);
+		expect(getModuleFieldPlaceholder("claude-code", "model")).toBe(
+			"e.g. claude-sonnet-5",
+		);
+		expect(getModuleFieldPlaceholder("git-clone", "base_dir")).toBe("$HOME");
+		expect(getModuleFieldPlaceholder("git-clone", "branch_name")).toBe(
+			"Default branch",
+		);
+		expect(getModuleFieldPlaceholder("dotfiles", "description")).toBe(
+			"e.g https://dotfiles.github.io or an SSH URL git@host:user/repo",
+		);
+	});
+
+	it("returns undefined for a module without overrides", () => {
+		expect(getModuleFieldPlaceholder("code-server", "port")).toBeUndefined();
+	});
+
+	it("returns undefined for an unmatched variable on a known module", () => {
+		expect(
+			getModuleFieldPlaceholder("codex", "does_not_exist"),
+		).toBeUndefined();
+	});
+
+	it("exports the full override table", () => {
+		expect(Object.keys(MODULE_FIELD_PLACEHOLDERS).sort()).toEqual([
+			"claude-code",
+			"codex",
+			"dotfiles",
+			"git-clone",
+		]);
+	});
+});

--- a/site/src/pages/TemplateBuilder/moduleFieldPlaceholders.ts
+++ b/site/src/pages/TemplateBuilder/moduleFieldPlaceholders.ts
@@ -1,0 +1,46 @@
+/**
+ * Per-module placeholder text overrides for the template builder's
+ * module configuration fields.
+ *
+ * The API delivers each module's variable defaults verbatim from its
+ * `module.json`. Some of those defaults are prose that is more useful as
+ * documentation than as placeholder text (for example the dotfiles
+ * `description` default is a two-sentence explanation). This table lets
+ * us substitute short, actionable placeholder hints for a specific set
+ * of variables without changing the underlying module manifest.
+ *
+ * Lookup order used by the module configuration step:
+ *   1. Override in this table (if present).
+ *   2. Variable's `default` value.
+ *   3. `Required` when the variable is required, otherwise empty.
+ */
+export const MODULE_FIELD_PLACEHOLDERS: Readonly<
+	Record<string, Readonly<Record<string, string>>>
+> = {
+	codex: {
+		model_reasoning_effort: "none, minimal, low, medium, high, or xhigh",
+	},
+	"claude-code": {
+		anthropic_api_key: "sk-ant-...",
+		model: "e.g. claude-sonnet-5",
+	},
+	"git-clone": {
+		base_dir: "$HOME",
+		branch_name: "Default branch",
+	},
+	dotfiles: {
+		description:
+			"e.g https://dotfiles.github.io or an SSH URL git@host:user/repo",
+	},
+};
+
+/**
+ * Returns the placeholder override for the given module and variable,
+ * or `undefined` when no override exists.
+ */
+export function getModuleFieldPlaceholder(
+	moduleId: string,
+	variableName: string,
+): string | undefined {
+	return MODULE_FIELD_PLACEHOLDERS[moduleId]?.[variableName];
+}


### PR DESCRIPTION
Polish pass on `/templates/new/builder` covering four items.

1. **Gallery height.** Base template and module galleries now cap at ~3 rows before scrolling. Cards get a fixed row height so the initial view is consistent regardless of description length.
2. **Navigable selection sidebar.** The right-hand `SelectionSummary` becomes interactive:
   - `Base Template` label → `base-infra`
   - The selected base template row → `base-parameters` (falls back to `base-infra` when the step is skipped for that base)
   - `Modules` label → `module-select`
   - Each selected module row → `module-settings`, scrolling the corresponding grey card into view via `module-config-<id>`
   - `Customizations` label → `customizations`
3. **Sensitive-var info banner** moves inside the module's grey card, positioned after the `Additional settings` collapsible, so it is visually attributed to the module it describes.
4. **Trash icon** on each module grey card is wired to remove the module, using the existing `handleDeselectModule` handler.

All TemplateBuilder Storybook and unit tests pass. New `SelectionSummary.NavigationClicks` story exercises the five navigation callbacks; new `ModuleConfiguration` stories cover the sensitive-vars slot with and without other configuration fields.

<details>
<summary>Implementation notes</summary>

### Scope

Three UX polish items on `/templates/new/builder` plus a bonus wiring of the existing trashcan slot:

1. Gallery height: base template and module galleries should show ~3 rows before scrolling.
2. Navigable selection summary: sidebar rows are jump targets for the wizard steps.
3. Sensitive-var info location: the `foo_var will be collected from developers at workspace creation.` banner moves into the module's grey card, after the `Additional settings` area.
4. The trash icon on the module grey card removes the module using the existing deselect handler.

### Approach

- **Gallery height.** Use `auto-rows-[11rem] max-h-[35rem] overflow-y-auto` on the module and base template grids. 3 rows of 176px plus two 16px gaps = 560px. Fixed row height normalizes card heights so the `show 3 rows` rule holds regardless of description length.
- **Navigable summary.** `SelectionSummary` gains `onNavigateStep(stepId)` and `onNavigateModule(moduleId)` props. Interactive rows become `<button type="button">` with the existing hover treatment and focus rings. `TemplateBuilderPageView.navigateToStep` resolves the step to the nearest visible index. `navigateToModule` chooses `module-settings` when reachable, falls back to `module-select` otherwise, and calls `scrollIntoView` on `module-config-<moduleId>` after the render.
- **Sensitive-var banner.** `ModuleConfiguration` accepts `sensitiveVariables?: TemplateBuilderModuleVariable[]` and renders the note inside the grey card, after the required/optional fields blocks. `ModuleSettingsStep` stops rendering the sibling info div and passes the sensitive vars through.
- **Trash icon.** `ModuleSettingsStep` accepts `onRemoveModule(moduleId)` and forwards it to `ModuleConfiguration.onRemove`. Reuses the existing `handleDeselectModule` in `TemplateBuilderPageView`.

### Tests

- `pnpm lint:types` (site) clean.
- `pnpm check` (site biome) clean.
- `pnpm vitest run --project=unit src/pages/TemplateBuilder` — 44 tests pass.
- `pnpm vitest run --project=storybook src/pages/TemplateBuilder` — 36 tests pass, including new `NavigationClicks` interaction test.

</details>

---

Coder Agents generated.