### PR TITLE
feat(site): route non-attachment chat files to workspace uploads

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -450,6 +450,16 @@ const userAIProviderKeysPath = (user = "me") =>
 	`/api/experimental/users/${encodeURIComponent(user)}/ai-provider-keys`;
 const mcpServerConfigsPath = "/api/experimental/mcp/servers";
 
+// Headers for chat file upload endpoints that stream the raw File as
+// the request body. The filename travels in Content-Disposition using
+// RFC 5987 encoding to support non-ASCII characters; placing the raw
+// name directly in the header causes XMLHttpRequest to throw because
+// HTTP headers only allow ISO-8859-1 code points.
+const chatFileUploadHeaders = (file: File) => ({
+	"Content-Type": file.type || "application/octet-stream",
+	"Content-Disposition": `attachment; filename="file"; filename*=UTF-8''${encodeURIComponent(file.name)}`,
+});
+
 type ChatCostDateParams = {
 	start_date?: string;
 	end_date?: string;
@@ -3323,6 +3333,22 @@ class ExperimentalApiMethods {
 		return res.data;
 	};
 
+	uploadChatWorkspaceFile = async (
+		chatId: string,
+		file: File,
+		signal?: AbortSignal,
+	): Promise<TypesGen.UploadChatWorkspaceFileResponse> => {
+		const response = await this.axios.post(
+			`/api/experimental/chats/${chatId}/workspace-files`,
+			file,
+			{
+				headers: chatFileUploadHeaders(file),
+				signal,
+			},
+		);
+		return response.data;
+	};
+
 	uploadChatFile = async (
 		file: File,
 		organizationId: string,
@@ -3331,14 +3357,7 @@ class ExperimentalApiMethods {
 			`/api/experimental/chats/files?organization=${organizationId}`,
 			file,
 			{
-				headers: {
-					"Content-Type": file.type || "application/octet-stream",
-					// Use RFC 5987 encoding for the filename to support
-					// non-ASCII characters. Placing the raw name directly in
-					// the header causes XMLHttpRequest to throw because HTTP
-					// headers only allow ISO-8859-1 code points.
-					"Content-Disposition": `attachment; filename="file"; filename*=UTF-8''${encodeURIComponent(file.name)}`,
-				},
+				headers: chatFileUploadHeaders(file),
 			},
 		);
 		return response.data;

--- a/site/src/api/queries/chatMessageEdits.ts
+++ b/site/src/api/queries/chatMessageEdits.ts
@@ -30,6 +30,16 @@ const buildOptimisticEditedContent = ({
 				content: part.content ?? "",
 			};
 		}
+		if (part.type === "workspace-file-reference") {
+			return {
+				type: "workspace-file-reference",
+				workspace_file_path: part.workspace_file_path ?? "",
+				workspace_file_name: part.workspace_file_name ?? "",
+				workspace_file_size: part.workspace_file_size ?? 0,
+				workspace_file_media_type: part.workspace_file_media_type,
+				workspace_file_workspace_id: part.workspace_file_workspace_id ?? "",
+			};
+		}
 		const fileId = part.file_id ?? "";
 		return (
 			existingFilePartsByID.get(fileId) ?? {

--- a/site/src/pages/AgentsPage/AgentChatPage.test.ts
+++ b/site/src/pages/AgentsPage/AgentChatPage.test.ts
@@ -534,7 +534,7 @@ describe("useConversationEditingState", () => {
 		expect(result.current.remountKey).toBe(remountKeyBefore + 1);
 
 		await act(async () => {
-			await result.current.handleSendFromInput("hello");
+			await result.current.handleSendFromInput({ message: "hello" });
 		});
 
 		const remountKeyAfterSend = result.current.remountKey;
@@ -547,7 +547,12 @@ describe("useConversationEditingState", () => {
 		// the same text, so the editor is forced to reinitialize.
 		expect(result.current.remountKey).toBe(remountKeyAfterSend + 1);
 		expect(result.current.editorInitialValue).toBe("hello");
-		expect(onSend).toHaveBeenCalledWith("hello", undefined, 7);
+		expect(onSend).toHaveBeenCalledWith({
+			message: "hello",
+			attachments: undefined,
+			workspaceUploads: undefined,
+			editedMessageID: 7,
+		});
 		unmount();
 	});
 
@@ -562,10 +567,18 @@ describe("useConversationEditingState", () => {
 		});
 
 		await act(async () => {
-			await result.current.handleSendFromInput("hello", attachments);
+			await result.current.handleSendFromInput({
+				message: "hello",
+				attachments,
+			});
 		});
 
-		expect(onSend).toHaveBeenCalledWith("hello", attachments, 7);
+		expect(onSend).toHaveBeenCalledWith({
+			message: "hello",
+			attachments,
+			workspaceUploads: undefined,
+			editedMessageID: 7,
+		});
 		unmount();
 	});
 
@@ -596,7 +609,7 @@ describe("useConversationEditingState", () => {
 
 		await act(async () => {
 			await expect(
-				result.current.handleSendFromInput("edited message"),
+				result.current.handleSendFromInput({ message: "edited message" }),
 			).rejects.toThrow("boom");
 		});
 
@@ -620,9 +633,9 @@ describe("useConversationEditingState", () => {
 		});
 
 		await act(async () => {
-			await expect(result.current.handleSendFromInput("hello")).rejects.toThrow(
-				"boom",
-			);
+			await expect(
+				result.current.handleSendFromInput({ message: "hello" }),
+			).rejects.toThrow("boom");
 		});
 
 		expect(mockInput.clear).not.toHaveBeenCalled();
@@ -639,10 +652,15 @@ describe("useConversationEditingState", () => {
 		result.current.chatInputRef.current = mockInput.handle;
 
 		await act(async () => {
-			await result.current.handleSendFromInput("hello");
+			await result.current.handleSendFromInput({ message: "hello" });
 		});
 
-		expect(onSend).toHaveBeenCalledWith("hello", undefined, undefined);
+		expect(onSend).toHaveBeenCalledWith({
+			message: "hello",
+			attachments: undefined,
+			workspaceUploads: undefined,
+			editedMessageID: undefined,
+		});
 		expect(mockInput.clear).toHaveBeenCalled();
 		expect(mockInput.focus).toHaveBeenCalled();
 		expect(localStorage.getItem(expectedKey)).toBeNull();
@@ -683,9 +701,14 @@ describe("useConversationEditingState", () => {
 		result.current.chatInputRef.current = mockInputRef;
 
 		await act(async () => {
-			result.current.handleSendFromInput("hello");
+			result.current.handleSendFromInput({ message: "hello" });
 			await vi.waitFor(() => {
-				expect(onSend).toHaveBeenCalledWith("hello", undefined, undefined);
+				expect(onSend).toHaveBeenCalledWith({
+					message: "hello",
+					attachments: undefined,
+					workspaceUploads: undefined,
+					editedMessageID: undefined,
+				});
 			});
 		});
 
@@ -720,7 +743,7 @@ describe("useConversationEditingState", () => {
 		expect(localStorage.getItem(expectedKey)).toBe("draft to clear");
 
 		await act(async () => {
-			result.current.handleSendFromInput("hello");
+			result.current.handleSendFromInput({ message: "hello" });
 			await vi.waitFor(() => {
 				expect(localStorage.getItem(expectedKey)).toBeNull();
 			});

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -77,7 +77,11 @@ import {
 	useChatStore,
 } from "./components/ChatConversation/chatStore";
 import { useChatToolInvalidations } from "./components/ChatConversation/useChatToolInvalidations";
-import type { PendingAttachment } from "./components/ChatPageContent";
+import type {
+	PendingAttachment,
+	PendingWorkspaceUpload,
+	SendChatMessageOptions,
+} from "./components/ChatPageContent";
 import {
 	getDefaultMCPSelection,
 	getSavedMCPSelection,
@@ -313,14 +317,14 @@ const buildAttachmentMediaTypes = (
 	);
 };
 
+export type SendChatTurnOptions = SendChatMessageOptions & {
+	editedMessageID?: number;
+};
+
 /** @internal Exported for testing. */
 export function useConversationEditingState(deps: {
 	chatID: string | undefined;
-	onSend: (
-		message: string,
-		attachments?: readonly PendingAttachment[],
-		editedMessageID?: number,
-	) => Promise<void>;
+	onSend: (options: SendChatTurnOptions) => Promise<void>;
 	onDeleteQueuedMessage: (id: number) => Promise<void>;
 	chatInputRef: React.RefObject<ChatMessageInputRef | null>;
 	inputValueRef: React.RefObject<string>;
@@ -514,14 +518,20 @@ export function useConversationEditingState(deps: {
 
 	// Wraps the parent onSend to clear local input/editing state
 	// and handle queue-edit deletion.
-	const handleSendFromInput = async (
-		message: string,
-		attachments?: readonly PendingAttachment[],
-	) => {
+	const handleSendFromInput = async ({
+		message,
+		attachments,
+		workspaceUploads,
+	}: SendChatMessageOptions) => {
 		const editedMessageID =
 			editingMessageId !== null ? editingMessageId : undefined;
 		const queueEditID = editingQueuedMessageID;
-		const sendPromise = onSend(message, attachments, editedMessageID);
+		const sendPromise = onSend({
+			message,
+			attachments,
+			workspaceUploads,
+			editedMessageID,
+		});
 
 		// For history edits, clear input immediately and prepare
 		// a rollback in case the send fails.
@@ -833,6 +843,16 @@ const AgentChatPage: FC = () => {
 		chatModelsQuery.data,
 	);
 
+	// The chat's bound agent is the one uploads and exec paths target
+	// on the backend, so agent-dependent UI must track it rather than
+	// the workspace's first agent. The ref lets the workspace watch
+	// below read the current binding without resubscribing.
+	const chatAgentId = chatQuery.data?.agent_id;
+	const chatAgentIdRef = useRef(chatAgentId);
+	useEffect(() => {
+		chatAgentIdRef.current = chatAgentId;
+	}, [chatAgentId]);
+
 	// Subscribe to live workspace updates so that agent status changes
 	// (e.g. connected/disconnected) are reflected without a page refresh.
 	useEffect(() => {
@@ -855,8 +875,14 @@ const AgentChatPage: FC = () => {
 								// reads has changed. This prevents react-query
 								// from notifying subscribers and avoids a full
 								// AgentChatPage re-render on every heartbeat.
-								const prevAgent = getWorkspaceAgent(prev, undefined);
-								const nextAgent = getWorkspaceAgent(next, undefined);
+								const prevAgent = getWorkspaceAgent(
+									prev,
+									chatAgentIdRef.current,
+								);
+								const nextAgent = getWorkspaceAgent(
+									next,
+									chatAgentIdRef.current,
+								);
 								if (
 									prev &&
 									prev.latest_build.status === next.latest_build.status &&
@@ -891,7 +917,7 @@ const AgentChatPage: FC = () => {
 		});
 	}, [workspaceId, queryClient]);
 	const sshConfigQuery = useQuery(deploymentSSHConfig());
-	const workspaceAgent = getWorkspaceAgent(workspace, undefined);
+	const workspaceAgent = getWorkspaceAgent(workspace, chatAgentId);
 	const { proxy } = useProxy();
 
 	const chatRecord = chatQuery.data;
@@ -1359,10 +1385,12 @@ const AgentChatPage: FC = () => {
 	function buildChatInputContent({
 		message,
 		attachments,
+		workspaceUploads,
 		useComposerContent = true,
 	}: {
 		message: string;
 		attachments?: readonly PendingAttachment[];
+		workspaceUploads?: readonly PendingWorkspaceUpload[];
 		useComposerContent?: boolean;
 	}): { content: TypesGen.ChatInputPart[]; hasContent: boolean } {
 		const content: TypesGen.ChatInputPart[] = [];
@@ -1406,18 +1434,34 @@ const AgentChatPage: FC = () => {
 			}
 		}
 
+		if (workspaceUploads && workspaceUploads.length > 0) {
+			for (const upload of workspaceUploads) {
+				content.push({
+					type: "workspace-file-reference",
+					workspace_file_path: upload.path,
+					workspace_file_name: upload.name,
+					workspace_file_size: upload.size,
+					workspace_file_media_type:
+						upload.mediaType || "application/octet-stream",
+					workspace_file_workspace_id: upload.workspaceId,
+				});
+			}
+		}
+
 		return { content, hasContent: content.length > 0 };
 	}
 
 	async function submitChatTurn({
 		message,
 		attachments,
+		workspaceUploads,
 		editedMessageID,
 		useComposerContent = true,
 		planModeSwitch,
 	}: {
 		message: string;
 		attachments?: readonly PendingAttachment[];
+		workspaceUploads?: readonly PendingWorkspaceUpload[];
 		editedMessageID?: number;
 		useComposerContent?: boolean;
 		planModeSwitch?: PlanModeSwitch;
@@ -1425,6 +1469,7 @@ const AgentChatPage: FC = () => {
 		const { content, hasContent } = buildChatInputContent({
 			message,
 			attachments,
+			workspaceUploads,
 			useComposerContent,
 		});
 		if (!hasContent || isSubmissionPending || !agentId || !hasModelOptions) {
@@ -1560,14 +1605,16 @@ const AgentChatPage: FC = () => {
 		}
 	}
 
-	async function handleSend(
-		message: string,
-		attachments?: readonly PendingAttachment[],
-		editedMessageID?: number,
-	) {
+	async function handleSend({
+		message,
+		attachments,
+		workspaceUploads,
+		editedMessageID,
+	}: SendChatTurnOptions) {
 		await submitChatTurn({
 			message,
 			attachments,
+			workspaceUploads,
 			editedMessageID,
 		});
 	}

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -36,7 +36,7 @@ import {
 import type { useChatStore } from "./components/ChatConversation/chatStore";
 import type { ModelSelectorOption } from "./components/ChatElements";
 import { DesktopPanelContext } from "./components/ChatElements/tools/DesktopPanelContext";
-import type { PendingAttachment } from "./components/ChatPageContent";
+import type { SendChatMessageOptions } from "./components/ChatPageContent";
 import { ChatPageInput, ChatPageTimeline } from "./components/ChatPageContent";
 import { ChatScrollContainer } from "./components/ChatScrollContainer";
 import { ChatSharingPopoverContent } from "./components/ChatSharingPopover";
@@ -97,10 +97,7 @@ interface EditingState {
 		fileBlocks: readonly ChatMessagePart[],
 	) => void;
 	handleCancelQueueEdit: () => void;
-	handleSendFromInput: (
-		message: string,
-		attachments?: readonly PendingAttachment[],
-	) => void;
+	handleSendFromInput: (options: SendChatMessageOptions) => void;
 	handleContentChange: (
 		content: string,
 		serializedEditorState: string,

--- a/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
@@ -1265,3 +1265,91 @@ export const LongWorkspaceNameMobile: Story = {
 		}
 	},
 };
+
+const dropFileOnComposer = (canvasElement: HTMLElement, file: File) => {
+	const composer = within(canvasElement).getByTestId("chat-composer");
+	const dataTransfer = new DataTransfer();
+	dataTransfer.items.add(file);
+	// Dispatch a native DragEvent: fireEvent cannot attach dataTransfer
+	// to drag events in a real browser.
+	composer.dispatchEvent(
+		new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer }),
+	);
+};
+
+export const WorkspaceUploadRoutedOnDrop: Story = {
+	args: {
+		onAttach: fn(),
+		workspaceUploads: {
+			uploads: [],
+			onAttach: fn(),
+			onRemove: fn(),
+		},
+	},
+	play: async ({ canvasElement, args }) => {
+		const file = createMockFile("dataset.zip", "application/zip");
+		dropFileOnComposer(canvasElement, file);
+		await waitFor(() => {
+			expect(args.workspaceUploads?.onAttach).toHaveBeenCalledWith([file]);
+		});
+		expect(args.onAttach).not.toHaveBeenCalled();
+	},
+};
+
+export const WorkspaceUploadRefusedWhileDisabled: Story = {
+	args: {
+		isDisabled: true,
+		onAttach: fn(),
+		workspaceUploads: {
+			uploads: [],
+			onAttach: fn(),
+			onRemove: fn(),
+		},
+	},
+	play: async ({ canvasElement, args }) => {
+		const file = createMockFile("dataset.zip", "application/zip");
+		dropFileOnComposer(canvasElement, file);
+		// Drop routing is synchronous; WorkspaceUploadRoutedOnDrop proves
+		// this simulation reaches the routing path when enabled.
+		expect(args.workspaceUploads?.onAttach).not.toHaveBeenCalled();
+		expect(args.onAttach).not.toHaveBeenCalled();
+	},
+};
+
+export const PasteRefusedFileFallsBackToText: Story = {
+	args: {
+		onAttach: fn(),
+		onRemoveAttachment: fn(),
+	},
+	parameters: {
+		pixel: { exclude: true },
+	},
+	play: async ({ canvasElement, args }) => {
+		const target = getPasteTarget(canvasElement);
+		await waitFor(() => {
+			expect(target.getAttribute("contenteditable")).toBe("true");
+		});
+		target.focus();
+
+		// Clipboard carrying both a file and a text payload. Without
+		// workspaceUploads the zip cannot be routed anywhere, so the
+		// paste must fall back to inserting the clipboard text.
+		const dataTransfer = new DataTransfer();
+		dataTransfer.items.add(createMockFile("dataset.zip", "application/zip"));
+		dataTransfer.setData("text/plain", "notes about the archive");
+		const event = new ClipboardEvent("paste", {
+			bubbles: true,
+			cancelable: true,
+		});
+		Object.defineProperty(event, "clipboardData", {
+			value: dataTransfer,
+			writable: false,
+		});
+		target.dispatchEvent(event);
+
+		await waitFor(() => {
+			expect(target.textContent).toContain("notes about the archive");
+		});
+		expect(args.onAttach).not.toHaveBeenCalled();
+	},
+};

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -21,6 +21,7 @@ import {
 	useState,
 } from "react";
 import { Link } from "react-router";
+import { toast } from "sonner";
 import type * as TypesGen from "#/api/typesGenerated";
 import type {
 	AgentChatSendShortcut,
@@ -58,6 +59,7 @@ import { isBelowMdViewport, isMobileViewport } from "#/utils/mobile";
 import { chatWidthClass, useChatFullWidth } from "../hooks/useChatFullWidth";
 import { useOverflowCount } from "../hooks/useOverflowCount";
 import { useSpeechRecognition } from "../hooks/useSpeechRecognition";
+import type { WorkspaceFileUpload } from "../hooks/useWorkspaceFileUploads";
 import {
 	DEFAULT_AGENT_CHAT_SEND_SHORTCUT,
 	MODIFIER_AGENT_CHAT_SEND_SHORTCUT,
@@ -65,6 +67,7 @@ import {
 import {
 	chatAttachmentAcceptAttribute,
 	isChatAttachmentFile,
+	shouldRouteFileToWorkspace,
 } from "../utils/chatAttachments";
 import { AgentSetupNotice } from "./AgentSetupNotice";
 import {
@@ -83,6 +86,7 @@ import { ImageLightbox } from "./ImageLightbox";
 import { QueuedMessagesList } from "./QueuedMessagesList";
 import { TextPreviewDialog } from "./TextPreviewDialog";
 import { WorkspacePill } from "./WorkspacePill";
+import { WorkspaceUploadPreview } from "./WorkspaceUploadPreview";
 
 export {
 	ImageThumbnail,
@@ -91,6 +95,17 @@ export {
 } from "./AttachmentPreview";
 export type { ChatMessageInputRef } from "./ChatMessageInput/ChatMessageInput";
 export type { AgentContextUsage } from "./ContextUsageIndicator";
+
+interface WorkspaceUploadsProps {
+	uploads: readonly WorkspaceFileUpload[];
+	// Present only when the chat has a bound workspace with a
+	// connected agent; its absence hides the whole affordance.
+	onAttach?: (files: File[]) => void;
+	onRemove: (id: string) => void;
+}
+
+const workspaceRequiredAttachmentMessage =
+	"This file type is uploaded into the chat's workspace. Attach a running workspace to the chat, then try again.";
 
 interface AgentChatInputProps {
 	onSend: (message: string) => void;
@@ -172,6 +187,7 @@ interface AgentChatInputProps {
 	uploadStates?: Map<File, UploadState>;
 	previewUrls?: Map<File, string>;
 	textContents?: Map<File, string>;
+	workspaceUploads?: WorkspaceUploadsProps;
 	onTextPreview?: (
 		content: string,
 		fileName: string,
@@ -383,6 +399,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	uploadStates,
 	previewUrls,
 	textContents,
+	workspaceUploads,
 	onTextPreview,
 	mcpServers,
 	selectedMCPServerIds,
@@ -752,19 +769,52 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 		};
 	}, [composerElement]);
 
+	// Workspace uploads eagerly write bytes into the workspace, so a
+	// disabled (read-only) composer must not route files to them.
+	const onWorkspaceAttach = isDisabled ? undefined : workspaceUploads?.onAttach;
+
+	// Splits files between the attachment pipeline and the workspace
+	// upload path by declared MIME type. Unknown or octet-stream files
+	// stay on the attachment path where the server classifies bytes.
+	// Returns whether any file was routed.
+	const routeFiles = (files: File[]): boolean => {
+		const attachable: File[] = [];
+		const forWorkspace: File[] = [];
+		let dropped = 0;
+		for (const file of files) {
+			if (onWorkspaceAttach && shouldRouteFileToWorkspace(file)) {
+				forWorkspace.push(file);
+			} else if (isChatAttachmentFile(file)) {
+				attachable.push(file);
+			} else {
+				dropped++;
+			}
+		}
+		if (dropped > 0) {
+			toast.error(workspaceRequiredAttachmentMessage);
+		}
+		if (attachable.length === 0 && forWorkspace.length === 0) {
+			return false;
+		}
+		resetPromptCycle();
+		if (attachable.length > 0) {
+			onAttach?.(attachable);
+		}
+		if (forWorkspace.length > 0) {
+			onWorkspaceAttach?.(forWorkspace);
+		}
+		return true;
+	};
+
 	const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
-		if (e.target.files && onAttach) {
-			resetPromptCycle();
-			onAttach(Array.from(e.target.files));
+		if (e.target.files?.length) {
+			routeFiles(Array.from(e.target.files));
 		}
 		// Reset so the same file can be selected again.
 		e.target.value = "";
 	};
 
-	const handleFilePaste = (file: File) => {
-		resetPromptCycle();
-		onAttach?.([file]);
-	};
+	const handleFilePaste = (file: File) => routeFiles([file]);
 
 	const handleInlineText = (file: File, nextContent?: string) => {
 		const content = nextContent ?? textContents?.get(file);
@@ -809,13 +859,8 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	const handleDrop = (e: React.DragEvent) => {
 		e.preventDefault();
 		setIsDragging(false);
-		if (!onAttach || !e.dataTransfer.files.length) return;
-		const attachable = Array.from(e.dataTransfer.files).filter(
-			isChatAttachmentFile,
-		);
-		if (attachable.length === 0) return;
-		resetPromptCycle();
-		onAttach(attachable);
+		if (!e.dataTransfer.files.length) return;
+		routeFiles(Array.from(e.dataTransfer.files));
 	};
 
 	// Track whether the editor has content so we can gate the
@@ -859,14 +904,18 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 			internalRef.current?.focus();
 		}
 	}, [isLoading]);
-	const hasActiveUploads = attachments.some((file) =>
-		isUploadInProgress(uploadStates?.get(file)),
-	);
-	const hasUploadedAttachments = attachments.some(
-		(f) => uploadStates?.get(f)?.status === "uploaded",
-	);
+	const workspaceUploadEntries = workspaceUploads?.uploads ?? [];
+	const hasActiveUploads =
+		attachments.some((file) => isUploadInProgress(uploadStates?.get(file))) ||
+		workspaceUploadEntries.some((upload) => upload.status === "uploading");
+	const hasUploadedAttachments =
+		attachments.some((f) => uploadStates?.get(f)?.status === "uploaded") ||
+		workspaceUploadEntries.some((upload) => upload.status === "uploaded");
 	const hasDraftContext =
-		hasContent || attachments.length > 0 || hasFileReferences;
+		hasContent ||
+		attachments.length > 0 ||
+		workspaceUploadEntries.length > 0 ||
+		hasFileReferences;
 	const isComposerEffectivelyEmpty = !hasDraftContext;
 	const hasSendableContent =
 		hasContent || hasUploadedAttachments || hasFileReferences;
@@ -1163,6 +1212,12 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 						onInlineText={handleInlineText}
 					/>
 				)}
+				{workspaceUploads && (
+					<WorkspaceUploadPreview
+						uploads={workspaceUploads.uploads}
+						onRemove={workspaceUploads.onRemove}
+					/>
+				)}
 				<ChatMessageInput
 					ref={internalRef}
 					onFilePaste={onAttach ? handleFilePaste : undefined}
@@ -1200,13 +1255,18 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 						</Alert>
 					</div>
 				)}
-				{/* Hidden file input for attaching any server-accepted file type. */}
+				{/* Hidden file input for attaching files. When workspace
+				uploads are available every file type is selectable:
+				non-allowlisted types stream into the workspace instead
+				of the attachment pipeline. */}
 				{onAttach && (
 					<input
 						ref={fileInputRef}
 						type="file"
 						multiple
-						accept={chatAttachmentAcceptAttribute}
+						accept={
+							onWorkspaceAttach ? undefined : chatAttachmentAcceptAttribute
+						}
 						onChange={handleFileSelect}
 						className="hidden"
 					/>

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -2915,10 +2915,8 @@ export const UserMessageWithWorkspaceFileReference: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		expect(canvas.getByText("Unzip this in my workspace")).toBeVisible();
-		expect(
-			canvas.getByText(
-				"Workspace file attached. Display support is coming soon.",
-			),
-		).toBeVisible();
+		// Rendered as a WorkspaceFileChip with name and size.
+		expect(canvas.getByText("dataset.zip")).toBeVisible();
+		expect(canvas.getByText("4.1 kB")).toBeVisible();
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -588,12 +588,7 @@ const ChatMessageItem = memo<{
 			hasActiveStream,
 			isAwaitingFirstStreamChunk,
 		});
-		// Editing rebuilds the message from text + attachments and would
-		// drop workspace file references, so such messages are read-only.
-		const canEditUserMessage =
-			isUser &&
-			Boolean(onEditUserMessage) &&
-			!displayState.hasWorkspaceFileReferences;
+		const canEditUserMessage = isUser && Boolean(onEditUserMessage);
 
 		if (displayState.shouldHide) {
 			return null;
@@ -680,16 +675,9 @@ const ChatMessageItem = memo<{
 											className="size-6"
 											aria-label="Edit message"
 											onClick={() => {
-												const editablePayload =
+												const { text, fileBlocks } =
 													getEditableUserMessagePayload(message);
-												if (!editablePayload) {
-													return;
-												}
-												onEditUserMessage?.(
-													message.id,
-													editablePayload.text,
-													editablePayload.fileBlocks,
-												);
+												onEditUserMessage?.(message.id, text, fileBlocks);
 											}}
 										>
 											<PencilIcon />

--- a/site/src/pages/AgentsPage/components/ChatConversation/UserMessageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/UserMessageContent.tsx
@@ -15,6 +15,7 @@ import type {
 	MessageDisplayState,
 	UserInlineRenderBlock,
 } from "./messageHelpers";
+import { WorkspaceFileChip } from "./WorkspaceFileChip";
 
 const getInlineParts = (
 	blocks: readonly UserInlineRenderBlock[],
@@ -56,11 +57,6 @@ const renderUserInlineContent = (blocks: readonly UserInlineRenderBlock[]) => {
 		renderUserInlineBlock(inlineParts, block, index),
 	);
 };
-
-const workspaceFilePlaceholderText = (count: number): string =>
-	count === 1
-		? "Workspace file attached. Display support is coming soon."
-		: `${count} workspace files attached. Display support is coming soon.`;
 
 export const UserMessageContent: FC<{
 	displayState: MessageDisplayState;
@@ -121,10 +117,20 @@ export const UserMessageContent: FC<{
 						</div>
 					)}
 					{displayState.hasWorkspaceFileReferences && (
-						<div className="rounded-md border border-border-default bg-surface-tertiary px-2.5 py-1.5 text-xs text-content-secondary">
-							{workspaceFilePlaceholderText(
-								displayState.workspaceFileReferenceCount,
+						<div
+							className={cn(
+								displayState.hasUserMessageBody && "mt-2",
+								"flex flex-wrap gap-2",
 							)}
+						>
+							{displayState.workspaceFileBlocks.map((block, index) => (
+								<WorkspaceFileChip
+									key={`workspace-file-${block.workspace_file_path}-${index}`}
+									name={block.workspace_file_name}
+									path={block.workspace_file_path}
+									size={block.workspace_file_size}
+								/>
+							))}
 						</div>
 					)}
 					{fadeFromBottom && (

--- a/site/src/pages/AgentsPage/components/ChatConversation/WorkspaceFileChip.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/WorkspaceFileChip.tsx
@@ -1,0 +1,42 @@
+import { HardDriveIcon } from "lucide-react";
+import prettyBytes from "pretty-bytes";
+import type { FC } from "react";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
+
+/**
+ * Timeline chip for a workspace-file-reference message part. The
+ * bytes live on the workspace filesystem, so unlike attachments there
+ * is nothing to preview or download here; the tooltip surfaces the
+ * absolute path the agent can read.
+ */
+export const WorkspaceFileChip: FC<{
+	name: string;
+	path: string;
+	size: number;
+}> = ({ name, path, size }) => (
+	<Tooltip>
+		<TooltipTrigger asChild>
+			<div className="flex max-w-64 items-center gap-1.5 rounded-md border border-solid border-border-default bg-surface-tertiary px-2.5 py-1.5 text-xs">
+				<HardDriveIcon
+					aria-hidden="true"
+					className="size-3.5 shrink-0 text-content-secondary"
+				/>
+				<span className="truncate font-medium text-content-primary">
+					{name}
+				</span>
+				{size > 0 && (
+					<span className="shrink-0 text-content-secondary">
+						{prettyBytes(size)}
+					</span>
+				)}
+			</div>
+		</TooltipTrigger>
+		<TooltipContent side="top">
+			<p className="max-w-xs break-all font-mono text-xs">{path}</p>
+		</TooltipContent>
+	</Tooltip>
+);

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatHelpers.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatHelpers.test.ts
@@ -207,7 +207,11 @@ describe("resolveModelFromChatConfig", () => {
 
 describe("getWorkspaceAgent", () => {
 	const buildAgent = (id: string): TypesGen.WorkspaceAgent =>
-		({ id, name: `agent-${id}` }) as TypesGen.WorkspaceAgent;
+		({
+			id,
+			name: `agent-${id}`,
+			display_order: 0,
+		}) as TypesGen.WorkspaceAgent;
 
 	const buildWorkspace = (
 		agents: TypesGen.WorkspaceAgent[],
@@ -270,6 +274,111 @@ describe("getWorkspaceAgent", () => {
 		} as unknown as TypesGen.Workspace;
 		expect(getWorkspaceAgent(ws, "a1")).toEqual(
 			expect.objectContaining({ id: "a1" }),
+		);
+	});
+
+	// The unbound fallback mirrors the backend's
+	// agentselect.FindChatAgent so upload gating and SSH affordances
+	// target the agent the server will actually pick.
+	const buildNamedAgent = (
+		id: string,
+		name: string,
+		parentId: string | null = null,
+		displayOrder = 0,
+	): TypesGen.WorkspaceAgent =>
+		({
+			id,
+			name,
+			parent_id: parentId,
+			display_order: displayOrder,
+		}) as TypesGen.WorkspaceAgent;
+
+	it("prefers the -coderd-chat suffixed root agent when unbound", () => {
+		const ws = buildWorkspace([
+			buildNamedAgent("a1", "alpha"),
+			buildNamedAgent("a2", "zeta-coderd-chat"),
+		]);
+		expect(getWorkspaceAgent(ws, undefined)).toEqual(
+			expect.objectContaining({ id: "a2" }),
+		);
+	});
+
+	it("matches the chat suffix case-insensitively", () => {
+		const ws = buildWorkspace([
+			buildNamedAgent("a1", "alpha"),
+			buildNamedAgent("a2", "main-Coderd-Chat"),
+		]);
+		expect(getWorkspaceAgent(ws, undefined)).toEqual(
+			expect.objectContaining({ id: "a2" }),
+		);
+	});
+
+	it("re-sorts root agents with the backend comparator when unbound", () => {
+		// The API sorts agents per resource, so agents on different
+		// resources can arrive out of global order. FindChatAgent
+		// sorts all root agents globally by name.
+		const ws = {
+			latest_build: {
+				resources: [
+					{ agents: [buildNamedAgent("a1", "zeta")] },
+					{ agents: [buildNamedAgent("a2", "alpha")] },
+				],
+			},
+		} as unknown as TypesGen.Workspace;
+		expect(getWorkspaceAgent(ws, undefined)).toEqual(
+			expect.objectContaining({ id: "a2" }),
+		);
+	});
+
+	it("prioritizes display_order over name like the backend", () => {
+		const ws = buildWorkspace([
+			buildNamedAgent("a1", "alpha", null, 2),
+			buildNamedAgent("a2", "zeta", null, 1),
+		]);
+		expect(getWorkspaceAgent(ws, undefined)).toEqual(
+			expect.objectContaining({ id: "a2" }),
+		);
+	});
+
+	it("compares names case-insensitively before case-sensitively", () => {
+		// Case-sensitive byte order would put "Zeta" (uppercase Z)
+		// before "alpha"; the backend compares lowercased names first.
+		const ws = buildWorkspace([
+			buildNamedAgent("a1", "Zeta"),
+			buildNamedAgent("a2", "alpha"),
+		]);
+		expect(getWorkspaceAgent(ws, undefined)).toEqual(
+			expect.objectContaining({ id: "a2" }),
+		);
+	});
+
+	it("never falls back to child agents", () => {
+		const ws = buildWorkspace([
+			buildNamedAgent("child", "aaa-sub", "a1"),
+			buildNamedAgent("a1", "zeta"),
+		]);
+		expect(getWorkspaceAgent(ws, undefined)).toEqual(
+			expect.objectContaining({ id: "a1" }),
+		);
+	});
+
+	it("still resolves child agents by explicit id", () => {
+		const ws = buildWorkspace([
+			buildNamedAgent("child", "aaa-sub", "a1"),
+			buildNamedAgent("a1", "zeta"),
+		]);
+		expect(getWorkspaceAgent(ws, "child")).toEqual(
+			expect.objectContaining({ id: "child" }),
+		);
+	});
+
+	it("picks the first sorted match when several agents use the suffix", () => {
+		const ws = buildWorkspace([
+			buildNamedAgent("a1", "zeta-coderd-chat"),
+			buildNamedAgent("a2", "alpha-coderd-chat"),
+		]);
+		expect(getWorkspaceAgent(ws, undefined)).toEqual(
+			expect.objectContaining({ id: "a2" }),
 		);
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatHelpers.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatHelpers.ts
@@ -92,6 +92,57 @@ export const resolveModelFromChatConfig = (
 	return modelOptions[0]?.id ?? "";
 };
 
+// Chat-designated agents use this naming convention; mirrors
+// agentselect.Suffix on the backend.
+const chatAgentSuffix = "-coderd-chat";
+
+// compareChatAgents replicates the backend comparator in
+// agentselect.FindChatAgent: display_order ASC, then case-insensitive
+// name, then name, then id. Plain string comparisons (not
+// localeCompare) match Go's byte-order string compare on these
+// ASCII-only fields.
+const compareChatAgents = (
+	a: TypesGen.WorkspaceAgent,
+	b: TypesGen.WorkspaceAgent,
+): number => {
+	if (a.display_order !== b.display_order) {
+		return a.display_order - b.display_order;
+	}
+	const aLower = a.name.toLowerCase();
+	const bLower = b.name.toLowerCase();
+	if (aLower !== bLower) {
+		return aLower < bLower ? -1 : 1;
+	}
+	if (a.name !== b.name) {
+		return a.name < b.name ? -1 : 1;
+	}
+	if (a.id !== b.id) {
+		return a.id < b.id ? -1 : 1;
+	}
+	return 0;
+};
+
+// selectChatAgent mirrors the backend's agentselect.FindChatAgent so
+// affordances gate on the agent the server will actually use before a
+// chat binds one: root agents only, re-sorted globally with the
+// backend's comparator (the API response is also sorted, but only
+// within each resource, so flattened order can diverge), preferring a
+// `-coderd-chat` suffixed agent. When several agents carry the suffix
+// the backend refuses to auto-select; the first match keeps the
+// affordance visible so the server's actionable error surfaces on use.
+const selectChatAgent = (
+	agents: readonly TypesGen.WorkspaceAgent[],
+): TypesGen.WorkspaceAgent | undefined => {
+	const rootAgents = agents
+		.filter((agent) => !agent.parent_id)
+		.sort(compareChatAgents);
+	return (
+		rootAgents.find((agent) =>
+			agent.name.toLowerCase().endsWith(chatAgentSuffix),
+		) ?? rootAgents[0]
+	);
+};
+
 export const getWorkspaceAgent = (
 	workspace: TypesGen.Workspace | undefined,
 	workspaceAgentId: string | undefined,
@@ -103,5 +154,8 @@ export const getWorkspaceAgent = (
 	if (agents.length === 0) {
 		return undefined;
 	}
-	return agents.find((agent) => agent.id === workspaceAgentId) ?? agents[0];
+	return (
+		agents.find((agent) => agent.id === workspaceAgentId) ??
+		selectChatAgent(agents)
+	);
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.ts
@@ -20,6 +20,7 @@ export type MessageDisplayState = {
 	shouldHide: boolean;
 	userInlineContent: UserInlineRenderBlock[];
 	userFileBlocks: FileRenderBlock[];
+	workspaceFileBlocks: WorkspaceFileReferenceBlock[];
 	workspaceFileReferenceCount: number;
 	hasUserMessageBody: boolean;
 	hasFileBlocks: boolean;
@@ -154,9 +155,10 @@ export const deriveMessageDisplayState = ({
 		? parsed.blocks.filter(isUserInlineRenderBlock)
 		: [];
 	const userFileBlocks = isUser ? parsed.blocks.filter(isFileRenderBlock) : [];
-	const workspaceFileReferenceCount = isUser
-		? parsed.blocks.filter(isWorkspaceFileReferenceBlock).length
-		: 0;
+	const workspaceFileBlocks = isUser
+		? parsed.blocks.filter(isWorkspaceFileReferenceBlock)
+		: [];
+	const workspaceFileReferenceCount = workspaceFileBlocks.length;
 	const hasWorkspaceFileReferences = workspaceFileReferenceCount > 0;
 	const hasFileAttachments = parsed.blocks.some(isFileRenderBlock);
 	const hasUserMessageBody =
@@ -184,6 +186,7 @@ export const deriveMessageDisplayState = ({
 		shouldHide: shouldHideTimelineEntry({ message, parsed }),
 		userInlineContent,
 		userFileBlocks,
+		workspaceFileBlocks,
 		workspaceFileReferenceCount,
 		hasUserMessageBody,
 		hasFileBlocks,

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageParsing.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageParsing.test.ts
@@ -154,25 +154,25 @@ describe("getEditableUserMessagePayload", () => {
 		}
 	});
 
-	it("returns undefined for messages with workspace file references", () => {
+	it("preserves workspace file references as editable file blocks", () => {
+		const workspacePart = {
+			type: "workspace-file-reference",
+			workspace_file_path: "/home/coder/.coder/chats/chat-1/files/data.csv",
+			workspace_file_name: "data.csv",
+			workspace_file_size: 42,
+			workspace_file_workspace_id: "ws-1",
+		} as const;
 		const message: ChatMessage = {
 			id: 1,
 			chat_id: "chat-1",
 			created_at: "2026-04-21T00:00:00.000Z",
 			role: "user",
-			content: [
-				{ type: "text", text: "Please use this file." },
-				{
-					type: "workspace-file-reference",
-					workspace_file_path: "/home/coder/.coder/chats/chat-1/files/data.csv",
-					workspace_file_name: "data.csv",
-					workspace_file_size: 42,
-					workspace_file_workspace_id: "ws-1",
-				},
-			],
+			content: [{ type: "text", text: "Please use this file." }, workspacePart],
 		};
 
-		expect(getEditableUserMessagePayload(message)).toBeUndefined();
+		const payload = getEditableUserMessagePayload(message);
+		expect(payload?.text).toBe("Please use this file.");
+		expect(payload?.fileBlocks).toEqual([workspacePart]);
 	});
 
 	it("preserves whitespace-only text parts when concatenating", () => {

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageParsing.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageParsing.ts
@@ -306,13 +306,6 @@ export const parseMessageContent = (
 	return parsed;
 };
 
-const messageHasWorkspaceFileReferences = (
-	message: TypesGen.ChatMessage,
-): boolean =>
-	(message.content ?? []).some(
-		(part) => part.type === "workspace-file-reference",
-	);
-
 const isEditableAttachmentMediaType = (mediaType: string): boolean =>
 	mediaType.startsWith("image/") ||
 	mediaType === "text/plain" ||
@@ -323,25 +316,18 @@ const isEditableAttachmentMediaType = (mediaType: string): boolean =>
 
 const isEditableUserMessageFileBlock = (
 	block: RenderBlock,
-): block is TypesGen.ChatFilePart =>
-	block.type === "file" && isEditableAttachmentMediaType(block.media_type);
+): block is TypesGen.ChatFilePart | TypesGen.ChatWorkspaceFileReferencePart =>
+	(block.type === "file" && isEditableAttachmentMediaType(block.media_type)) ||
+	// Workspace file bytes already live in the workspace; editing
+	// preserves the reference (or drops it when the chip is removed).
+	block.type === "workspace-file-reference";
 
 export const getEditableUserMessagePayload = (
 	message: TypesGen.ChatMessage,
-):
-	| {
-			text: string;
-			fileBlocks: readonly TypesGen.ChatMessagePart[] | undefined;
-	  }
-	| undefined => {
-	// Editing rebuilds the message from text + editable attachment
-	// blocks, which would silently drop workspace file references.
-	// Until the edit flow preserves them, such messages are not
-	// editable.
-	if (messageHasWorkspaceFileReferences(message)) {
-		return undefined;
-	}
-
+): {
+	text: string;
+	fileBlocks: readonly TypesGen.ChatMessagePart[] | undefined;
+} => {
 	// Concatenate text parts verbatim to match the server-side string_agg in
 	// GetChatUserPromptsByChatID; parseMessageContent/appendText is for streaming and drops whitespace-only chunks.
 	const text = (message.content ?? [])

--- a/site/src/pages/AgentsPage/components/ChatMessageInput/ChatMessageInput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatMessageInput/ChatMessageInput.tsx
@@ -41,7 +41,6 @@ import {
 	DEFAULT_AGENT_CHAT_SEND_SHORTCUT,
 	MODIFIER_AGENT_CHAT_SEND_SHORTCUT,
 } from "../../utils/agentChatSendShortcut";
-import { isChatAttachmentFile } from "../../utils/chatAttachments";
 import {
 	filterPersonalSkills,
 	isPersonalSkillTriggerToken,
@@ -148,7 +147,7 @@ function replacePlainTextInEditor(editor: LexicalEditor, text: string) {
 // user intent to paste inline, so the large-paste-to-attachment
 // conversion is bypassed for that shortcut.
 const PasteSanitizationPlugin: FC<{
-	onFilePaste?: (file: File) => void;
+	onFilePaste?: (file: File) => boolean;
 	allowTextAttachmentPaste?: boolean;
 }> = function PasteSanitizationPlugin({
 	onFilePaste,
@@ -223,20 +222,25 @@ const PasteSanitizationPlugin: FC<{
 					}
 					// Native paste event (ClipboardEvent).
 
-					// Check for attachable files in the clipboard (e.g.
-					// pasted screenshots). Forward them to the parent
-					// via callback instead of inserting text.
+					// Check for files in the clipboard, such as pasted
+					// screenshots or archives. Forward all files to the
+					// parent, which routes each one to the attachment
+					// pipeline or a workspace upload by MIME type.
 					if (onFilePaste && dataTransfer?.files.length) {
-						const attachable = Array.from(dataTransfer.files).filter(
-							isChatAttachmentFile,
-						);
-						if (attachable.length > 0) {
-							event.preventDefault();
-							for (const file of attachable) {
-								onFilePaste(file);
+						let routed = false;
+						for (const file of Array.from(dataTransfer.files)) {
+							if (onFilePaste(file)) {
+								routed = true;
 							}
+						}
+						if (routed) {
+							event.preventDefault();
 							return true;
 						}
+						// Every file was refused (for example an archive
+						// pasted while workspace uploads are unavailable).
+						// Fall through so accompanying clipboard text still
+						// pastes.
 					}
 
 					const text = getPastedPlainText(event, dataTransfer);
@@ -497,7 +501,10 @@ interface ChatMessageInputProps
 	rows?: number;
 	onEnter?: () => void;
 	sendShortcut?: TypesGen.AgentChatSendShortcut;
-	onFilePaste?: (file: File) => void;
+	// Returns whether the file was routed anywhere (attachment or
+	// workspace upload). Refused files let the paste fall back to
+	// the clipboard's text payload.
+	onFilePaste?: (file: File) => boolean;
 	allowTextAttachmentPaste?: boolean;
 	disabled?: boolean;
 	autoFocus?: boolean;

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -1,4 +1,11 @@
-import { type FC, Profiler, type ReactNode, useEffect, useRef } from "react";
+import {
+	type FC,
+	Profiler,
+	type ReactNode,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { toast } from "sonner";
 import type { UrlTransform } from "streamdown";
@@ -9,7 +16,14 @@ import { cn } from "#/utils/cn";
 import { useChatDraftAttachments } from "../hooks/useChatDraftAttachments";
 import { chatWidthClass, useChatFullWidth } from "../hooks/useChatFullWidth";
 import { useFileAttachments } from "../hooks/useFileAttachments";
-import { getChatFileURL } from "../utils/chatAttachments";
+import {
+	useWorkspaceFileUploads,
+	type WorkspaceFileUpload,
+} from "../hooks/useWorkspaceFileUploads";
+import {
+	getChatFileURL,
+	isWorkspaceFileReferencePart,
+} from "../utils/chatAttachments";
 import { getProviderForModelOption } from "../utils/modelOptions";
 import type { ChatDetailError } from "../utils/usageLimitMessage";
 import {
@@ -151,15 +165,28 @@ export type PendingAttachment = {
 	mediaType: string;
 };
 
+export type PendingWorkspaceUpload = {
+	path: string;
+	name: string;
+	size: number;
+	mediaType: string;
+	// The workspace whose filesystem holds the bytes, echoed back to
+	// the server which rejects references from a stale binding.
+	workspaceId: string;
+};
+
+export type SendChatMessageOptions = {
+	message: string;
+	attachments?: readonly PendingAttachment[];
+	workspaceUploads?: readonly PendingWorkspaceUpload[];
+};
+
 interface ChatPageInputProps {
 	// Organization that owns this chat. Used to scope file uploads.
 	organizationId: string | undefined;
 	store: ChatStoreHandle;
 	compressionThreshold: number | undefined;
-	onSend: (
-		message: string,
-		attachments?: readonly PendingAttachment[],
-	) => Promise<void> | void;
+	onSend: (options: SendChatMessageOptions) => Promise<void> | void;
 	sendShortcut: AgentChatSendShortcut;
 	onDeleteQueuedMessage: (id: number) => Promise<void>;
 	onPromoteQueuedMessage: (id: number) => Promise<void>;
@@ -328,6 +355,23 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	const composeAttachments = useChatDraftAttachments(organizationId, chatId, {
 		provider: getProviderForModelOption(modelOptions, selectedModel),
 	});
+	// Scope on the chat's bound workspace ID (known with the chat
+	// record) rather than the async-loaded workspace object, so a
+	// rebind resets immediately and query resolution never does.
+	const composeWorkspaceUploads = useWorkspaceFileUploads(
+		chatId,
+		selectedWorkspaceId ?? undefined,
+	);
+	const editWorkspaceUploads = useWorkspaceFileUploads(
+		chatId,
+		selectedWorkspaceId ?? undefined,
+	);
+	// Workspace file references preserved from the message being
+	// edited. They are already uploaded; editing only re-references
+	// them (or drops them when the chip is removed).
+	const [preservedWorkspaceUploads, setPreservedWorkspaceUploads] = useState<
+		readonly WorkspaceFileUpload[]
+	>([]);
 	const editAttachments = useFileAttachments(organizationId, {
 		provider: getProviderForModelOption(modelOptions, selectedModel),
 	});
@@ -352,6 +396,8 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	// draft. Clear them when navigation changes the chat scope.
 	const editScopeRef = useRef({ organizationId, chatId });
 
+	const { reset: resetEditWorkspaceUploads } = editWorkspaceUploads;
+
 	useEffect(() => {
 		const previous = editScopeRef.current;
 		const scopeChanged =
@@ -359,15 +405,89 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 		editScopeRef.current = { organizationId, chatId };
 		if (scopeChanged) {
 			resetEditAttachments();
+			setPreservedWorkspaceUploads([]);
 		}
 	}, [organizationId, chatId, resetEditAttachments]);
 
+	// Preserved references point at files inside the bound workspace's
+	// filesystem. Rebinding or clearing the workspace mid-edit makes
+	// them unreadable for the agent, so drop them (regular attachments
+	// are chat files and survive workspace changes). Scope tracks the
+	// chat's bound workspace ID, not the async-loaded workspace
+	// object, which resolves after mount without a rebind.
+	const editWorkspaceScopeRef = useRef(selectedWorkspaceId);
+	useEffect(() => {
+		if (editWorkspaceScopeRef.current === selectedWorkspaceId) {
+			return;
+		}
+		editWorkspaceScopeRef.current = selectedWorkspaceId;
+		setPreservedWorkspaceUploads([]);
+	}, [selectedWorkspaceId]);
+
 	// Pre-populate the edit bucket from existing file blocks only
-	// while explicitly editing a message.
+	// while explicitly editing a message. Hydration is keyed on the
+	// blocks reference plus the workspace binding: a failed edit
+	// submission restores the same array on rollback (same key, no
+	// re-hydration, so uploads added mid-edit survive), while
+	// rebinding the workspace away and back re-runs preservation so
+	// references valid for the restored binding reappear. Editing a
+	// different message passes a fresh array and re-hydrates.
+	const hydratedEditBlocksRef = useRef<{
+		blocks: readonly TypesGen.ChatMessagePart[] | null;
+		workspaceId: string | null;
+	} | null>(null);
 	useEffect(() => {
 		if (!isEditing) {
 			return;
 		}
+		if (
+			hydratedEditBlocksRef.current !== null &&
+			hydratedEditBlocksRef.current.blocks === (editingFileBlocks ?? null) &&
+			hydratedEditBlocksRef.current.workspaceId === selectedWorkspaceId
+		) {
+			return;
+		}
+		hydratedEditBlocksRef.current = {
+			blocks: editingFileBlocks ?? null,
+			workspaceId: selectedWorkspaceId,
+		};
+		// Workspace file references from the edited message become
+		// preserved (already-uploaded) entries so they survive the
+		// edit unless explicitly removed. Only references uploaded to
+		// the currently bound workspace qualify: after a rebind the
+		// old paths are unreadable for the agent and the server
+		// rejects them. Compare against the chat's bound workspace ID
+		// (available with the chat record) rather than the
+		// async-loaded workspace object, whose late resolution would
+		// otherwise drop references hydrated before it arrived.
+		resetEditWorkspaceUploads();
+		setPreservedWorkspaceUploads(
+			(editingFileBlocks ?? [])
+				.filter(isWorkspaceFileReferencePart)
+				.filter(
+					(part) =>
+						selectedWorkspaceId !== null &&
+						part.workspace_file_workspace_id === selectedWorkspaceId,
+				)
+				.map(
+					(part, i): WorkspaceFileUpload => ({
+						id: `preserved-${i}-${part.workspace_file_path}`,
+						file: new File([], part.workspace_file_name, {
+							type:
+								part.workspace_file_media_type || "application/octet-stream",
+						}),
+						status: "uploaded",
+						response: {
+							path: part.workspace_file_path,
+							name: part.workspace_file_name,
+							size: part.workspace_file_size,
+							media_type:
+								part.workspace_file_media_type || "application/octet-stream",
+							workspace_id: part.workspace_file_workspace_id,
+						},
+					}),
+				),
+		);
 		if (!editingFileBlocks || editingFileBlocks.length === 0) {
 			setEditAttachments([]);
 			setEditUploadStates(new Map());
@@ -404,30 +524,81 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	}, [
 		isEditing,
 		editingFileBlocks,
+		selectedWorkspaceId,
 		setEditAttachments,
 		setEditPreviewUrls,
 		setEditUploadStates,
+		resetEditWorkspaceUploads,
 	]);
 
 	// Exiting edit mode should only clear the edit bucket. Compose draft
 	// attachments must survive canceling or completing an edit.
 	useEffect(() => {
-		if (wasEditingRef.current && !isEditing) {
-			resetEditAttachments();
+		if (isEditing) {
+			wasEditingRef.current = true;
+			return;
 		}
-		wasEditingRef.current = isEditing;
-	}, [isEditing, resetEditAttachments]);
+		if (!wasEditingRef.current) {
+			return;
+		}
+		// History edits clear isEditing before the edit mutation
+		// settles and restore it on failure. Defer cleanup until the
+		// submission resolves so a failed edit keeps its uploads and
+		// attachments for retry.
+		if (isSendPending) {
+			return;
+		}
+		wasEditingRef.current = false;
+		hydratedEditBlocksRef.current = null;
+		resetEditAttachments();
+		resetEditWorkspaceUploads();
+		setPreservedWorkspaceUploads([]);
+	}, [
+		isEditing,
+		isSendPending,
+		resetEditAttachments,
+		resetEditWorkspaceUploads,
+	]);
 
 	const isStreaming =
 		hasStreamState || chatStatus === "running" || chatStatus === "pending";
+
+	// The workspace upload affordance requires an existing chat bound
+	// to a workspace whose agent is connected; the agent writes the
+	// bytes into its home directory.
+	const canUploadWorkspaceFiles = Boolean(
+		chatId && workspace && workspaceAgent?.status === "connected",
+	);
+	const modeWorkspaceUploads = isEditing
+		? editWorkspaceUploads
+		: composeWorkspaceUploads;
+	const visibleWorkspaceUploads = isEditing
+		? [...preservedWorkspaceUploads, ...editWorkspaceUploads.uploads]
+		: composeWorkspaceUploads.uploads;
+	const handleRemoveWorkspaceUpload = (id: string) => {
+		if (
+			isEditing &&
+			preservedWorkspaceUploads.some((upload) => upload.id === id)
+		) {
+			setPreservedWorkspaceUploads((current) =>
+				current.filter((upload) => upload.id !== id),
+			);
+			return;
+		}
+		modeWorkspaceUploads.remove(id);
+	};
 
 	const inputElement = (
 		<AgentChatInput
 			onSend={(message) => {
 				void (async () => {
-					const hasActiveUploads = attachments.some((file) =>
-						isUploadInProgress(uploadStates.get(file)),
-					);
+					const hasActiveUploads =
+						attachments.some((file) =>
+							isUploadInProgress(uploadStates.get(file)),
+						) ||
+						visibleWorkspaceUploads.some(
+							(upload) => upload.status === "uploading",
+						);
 					if (hasActiveUploads) {
 						toast.warning("Wait for file uploads to finish before sending.");
 						return;
@@ -450,23 +621,56 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 							});
 						}
 					}
+					const pendingWorkspaceUploads: PendingWorkspaceUpload[] = [];
+					let skippedWorkspaceErrors = 0;
+					for (const upload of visibleWorkspaceUploads) {
+						if (upload.status === "error") {
+							skippedWorkspaceErrors++;
+							continue;
+						}
+						if (upload.status === "uploaded" && upload.response) {
+							pendingWorkspaceUploads.push({
+								path: upload.response.path,
+								name: upload.response.name,
+								size: upload.response.size,
+								mediaType: upload.response.media_type,
+								workspaceId: upload.response.workspace_id,
+							});
+						}
+					}
 					if (skippedErrors > 0) {
 						toast.warning(
 							`${skippedErrors} attachment${skippedErrors > 1 ? "s" : ""} could not be sent (upload failed)`,
 						);
 					}
-					const attachmentArg =
+					if (skippedWorkspaceErrors > 0) {
+						toast.warning(
+							`${skippedWorkspaceErrors} workspace file${skippedWorkspaceErrors > 1 ? "s" : ""} could not be sent (upload failed)`,
+						);
+					}
+					const attachmentsArg =
 						pendingAttachments.length > 0 ? pendingAttachments : undefined;
+					const workspaceUploadsArg =
+						pendingWorkspaceUploads.length > 0
+							? pendingWorkspaceUploads
+							: undefined;
 					try {
-						await onSend(message, attachmentArg);
+						await onSend({
+							message,
+							attachments: attachmentsArg,
+							workspaceUploads: workspaceUploadsArg,
+						});
 					} catch {
 						// Attachments preserved for retry on failure.
 						return;
 					}
 					if (isEditing) {
 						editAttachments.resetAttachments();
+						resetEditWorkspaceUploads();
+						setPreservedWorkspaceUploads([]);
 					} else {
 						composeAttachments.resetAttachments();
+						composeWorkspaceUploads.reset();
 					}
 				})();
 			}}
@@ -477,6 +681,13 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 			uploadStates={uploadStates}
 			previewUrls={previewUrls}
 			textContents={textContents}
+			workspaceUploads={{
+				uploads: visibleWorkspaceUploads,
+				onAttach: canUploadWorkspaceFiles
+					? modeWorkspaceUploads.attach
+					: undefined,
+				onRemove: handleRemoveWorkspaceUpload,
+			}}
 			inputRef={inputRef}
 			initialValue={initialValue}
 			initialEditorState={initialEditorState}

--- a/site/src/pages/AgentsPage/components/QueuedMessagesList.tsx
+++ b/site/src/pages/AgentsPage/components/QueuedMessagesList.tsx
@@ -1,7 +1,7 @@
 import {
 	ArrowUpIcon,
 	CornerDownLeftIcon,
-	ImageIcon,
+	PaperclipIcon,
 	PencilIcon,
 	Trash2Icon,
 } from "lucide-react";
@@ -40,7 +40,9 @@ export const getQueuedMessageInfo = (
 	message: ChatQueuedMessage,
 ): QueuedMessageInfo => {
 	const { content } = message;
-	const fileBlocks = content.filter((p) => p.type === "file");
+	const fileBlocks = content.filter(
+		(p) => p.type === "file" || p.type === "workspace-file-reference",
+	);
 	const textParts: string[] = [];
 	for (const part of content) {
 		if (part.type === "text" && part.text?.trim()) {
@@ -207,10 +209,10 @@ export const QueuedMessagesList: FC<QueuedMessagesListProps> = ({
 							{item.attachmentCount > 0 && (
 								<span
 									role="img"
-									aria-label={`${item.attachmentCount} image attachment${item.attachmentCount !== 1 ? "s" : ""}`}
+									aria-label={`${item.attachmentCount} attachment${item.attachmentCount !== 1 ? "s" : ""}`}
 									className="flex shrink-0 items-center gap-1 text-xs text-content-secondary"
 								>
-									<ImageIcon className="size-3" aria-hidden="true" />
+									<PaperclipIcon className="size-3" aria-hidden="true" />
 									<span aria-hidden="true">{item.attachmentCount}</span>
 								</span>
 							)}

--- a/site/src/pages/AgentsPage/components/WorkspaceUploadPreview.stories.tsx
+++ b/site/src/pages/AgentsPage/components/WorkspaceUploadPreview.stories.tsx
@@ -1,0 +1,108 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+import { createMockFile } from "#/testHelpers/files";
+import type { WorkspaceFileUpload } from "../hooks/useWorkspaceFileUploads";
+import { WorkspaceUploadPreview } from "./WorkspaceUploadPreview";
+
+const uploadedEntry = (name: string, size = 4096): WorkspaceFileUpload => ({
+	id: `uploaded-${name}`,
+	file: createMockFile(name, "application/zip"),
+	status: "uploaded",
+	response: {
+		path: `/home/coder/.coder/chats/chat-1/files/${name}`,
+		name,
+		size,
+		media_type: "application/zip",
+		workspace_id: "ws-1",
+	},
+});
+
+const meta: Meta<typeof WorkspaceUploadPreview> = {
+	title: "pages/AgentsPage/WorkspaceUploadPreview",
+	component: WorkspaceUploadPreview,
+	args: {
+		onRemove: fn(),
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof WorkspaceUploadPreview>;
+
+export const Uploaded: Story = {
+	args: {
+		uploads: [uploadedEntry("design-handoff.zip")],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("design-handoff.zip")).toBeInTheDocument();
+		expect(canvas.getByText("4.1 kB in workspace")).toBeInTheDocument();
+	},
+};
+
+export const Uploading: Story = {
+	args: {
+		uploads: [
+			{
+				id: "uploading-1",
+				file: createMockFile("dataset.tar.gz", "application/gzip"),
+				status: "uploading",
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("Uploading to workspace...")).toBeInTheDocument();
+	},
+};
+
+export const UploadError: Story = {
+	args: {
+		uploads: [
+			{
+				id: "error-1",
+				file: createMockFile("broken.zip", "application/zip"),
+				status: "error",
+				error: "Failed to upload file to workspace agent.",
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByText("Failed to upload file to workspace agent."),
+		).toBeInTheDocument();
+	},
+};
+
+export const MixedStates: Story = {
+	args: {
+		uploads: [
+			uploadedEntry("release.zip", 2 * 1024 * 1024),
+			{
+				id: "uploading-2",
+				file: createMockFile("video.mp4", "video/mp4"),
+				status: "uploading",
+			},
+			{
+				id: "error-2",
+				file: createMockFile("huge.iso", "application/x-iso9660-image"),
+				status: "error",
+				error: "Upload failed",
+			},
+		],
+	},
+};
+
+export const RemoveUploadedKeepsBytesCopy: Story = {
+	args: {
+		uploads: [uploadedEntry("design-handoff.zip")],
+	},
+	play: async ({ args, canvasElement }) => {
+		const canvas = within(canvasElement);
+		const removeButton = canvas.getByRole("button", {
+			name: "Remove design-handoff.zip",
+		});
+		await userEvent.click(removeButton);
+		expect(args.onRemove).toHaveBeenCalledWith("uploaded-design-handoff.zip");
+	},
+};

--- a/site/src/pages/AgentsPage/components/WorkspaceUploadPreview.tsx
+++ b/site/src/pages/AgentsPage/components/WorkspaceUploadPreview.tsx
@@ -1,0 +1,99 @@
+import { HardDriveUploadIcon, XIcon } from "lucide-react";
+import prettyBytes from "pretty-bytes";
+import type { FC } from "react";
+import { Button } from "#/components/Button/Button";
+import { Spinner } from "#/components/Spinner/Spinner";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
+import { cn } from "#/utils/cn";
+import type { WorkspaceFileUpload } from "../hooks/useWorkspaceFileUploads";
+
+const uploadStatusLabel = (upload: WorkspaceFileUpload): string => {
+	switch (upload.status) {
+		case "uploading":
+			return "Uploading to workspace...";
+		case "uploaded":
+			return upload.response
+				? `${prettyBytes(upload.response.size)} in workspace`
+				: "In workspace";
+		case "error":
+			return upload.error ?? "Upload failed";
+	}
+};
+
+/**
+ * Composer chip strip for files streamed into the chat's workspace
+ * filesystem. Uploads are eager, so removing a chip only detaches the
+ * reference from the draft message; bytes already written stay in the
+ * workspace.
+ */
+export const WorkspaceUploadPreview: FC<{
+	uploads: readonly WorkspaceFileUpload[];
+	onRemove: (id: string) => void;
+}> = ({ uploads, onRemove }) => {
+	if (uploads.length === 0) {
+		return null;
+	}
+	return (
+		<div className="flex flex-wrap gap-2 px-3 pt-3">
+			{uploads.map((upload) => {
+				const name = upload.response?.name ?? upload.file.name;
+				return (
+					<div
+						key={upload.id}
+						className="flex max-w-64 items-center gap-2 rounded-md border border-solid border-border-default bg-surface-tertiary px-2.5 py-1.5 text-xs"
+					>
+						{upload.status === "uploading" ? (
+							<Spinner
+								className="size-3.5 shrink-0 text-content-secondary"
+								loading
+							/>
+						) : (
+							<HardDriveUploadIcon
+								aria-hidden="true"
+								className="size-3.5 shrink-0 text-content-secondary"
+							/>
+						)}
+						<div className="min-w-0 flex-1">
+							<div className="truncate font-medium text-content-primary">
+								{name}
+							</div>
+							<div
+								className={cn(
+									"truncate text-2xs",
+									upload.status === "error"
+										? "text-content-destructive"
+										: "text-content-secondary",
+								)}
+							>
+								{uploadStatusLabel(upload)}
+							</div>
+						</div>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									type="button"
+									variant="subtle"
+									size="icon"
+									className="size-5 shrink-0 text-content-secondary hover:text-content-primary"
+									aria-label={`Remove ${name}`}
+									onClick={() => onRemove(upload.id)}
+								>
+									<XIcon className="size-3.5" />
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent side="top">
+								{upload.status === "uploaded"
+									? "Removes the reference. Uploaded bytes stay in the workspace."
+									: "Cancel this upload"}
+							</TooltipContent>
+						</Tooltip>
+					</div>
+				);
+			})}
+		</div>
+	);
+};

--- a/site/src/pages/AgentsPage/hooks/useWorkspaceFileUploads.test.ts
+++ b/site/src/pages/AgentsPage/hooks/useWorkspaceFileUploads.test.ts
@@ -1,0 +1,271 @@
+import { renderHook as renderHookBase, waitFor } from "@testing-library/react";
+import { act, createElement, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useWorkspaceFileUploads } from "./useWorkspaceFileUploads";
+
+vi.mock("#/api/api", () => ({
+	API: {
+		experimental: {
+			uploadChatWorkspaceFile: vi.fn(),
+		},
+	},
+}));
+
+const { API } = await import("#/api/api");
+const uploadMock = API.experimental.uploadChatWorkspaceFile as ReturnType<
+	typeof vi.fn
+>;
+
+const makeFile = (name = "doc.bin", type = "application/x-tar"): File =>
+	new File([new Uint8Array(16)], name, { type });
+
+const okResponse = {
+	path: "/home/coder/.coder/chats/chat-1/files/doc.bin",
+	name: "doc.bin",
+	size: 16,
+	media_type: "application/x-tar",
+	workspace_id: "ws-1",
+};
+
+const renderHook: typeof renderHookBase = (callback, options) => {
+	const queryClient = new QueryClient({
+		defaultOptions: { mutations: { retry: false } },
+	});
+	return renderHookBase(callback, {
+		...options,
+		wrapper: ({ children }: { children: ReactNode }) =>
+			createElement(QueryClientProvider, { client: queryClient }, children),
+	});
+};
+
+describe("useWorkspaceFileUploads", () => {
+	beforeEach(() => {
+		uploadMock.mockReset();
+	});
+
+	it("transitions an upload from uploading to uploaded", async () => {
+		uploadMock.mockResolvedValueOnce(okResponse);
+		const { result } = renderHook(() =>
+			useWorkspaceFileUploads("chat-1", "ws-1"),
+		);
+
+		act(() => {
+			result.current.attach([makeFile()]);
+		});
+
+		expect(result.current.uploads).toHaveLength(1);
+		expect(result.current.uploads[0].status).toBe("uploading");
+
+		await waitFor(() => {
+			expect(result.current.uploads[0].status).toBe("uploaded");
+		});
+		expect(result.current.uploads[0].response).toEqual(okResponse);
+		expect(uploadMock).toHaveBeenCalledWith(
+			"chat-1",
+			expect.any(File),
+			expect.any(AbortSignal),
+		);
+	});
+
+	it("records an error when the upload fails", async () => {
+		uploadMock.mockRejectedValueOnce(new Error("boom"));
+		const { result } = renderHook(() =>
+			useWorkspaceFileUploads("chat-1", "ws-1"),
+		);
+
+		act(() => {
+			result.current.attach([makeFile()]);
+		});
+
+		await waitFor(() => {
+			expect(result.current.uploads[0].status).toBe("error");
+		});
+		expect(result.current.uploads[0].error).toBeTruthy();
+	});
+
+	it("errors immediately without a chat id", () => {
+		const { result } = renderHook(() =>
+			useWorkspaceFileUploads(undefined, "ws-1"),
+		);
+
+		act(() => {
+			result.current.attach([makeFile()]);
+		});
+
+		expect(result.current.uploads[0].status).toBe("error");
+		expect(uploadMock).not.toHaveBeenCalled();
+	});
+
+	it("remove aborts an in-flight upload and drops the entry", async () => {
+		let capturedSignal: AbortSignal | undefined;
+		uploadMock.mockImplementationOnce(
+			(_chatId: string, _file: File, signal?: AbortSignal) => {
+				capturedSignal = signal;
+				return new Promise(() => {
+					// Never resolves; the abort is what ends it.
+				});
+			},
+		);
+		const { result } = renderHook(() =>
+			useWorkspaceFileUploads("chat-1", "ws-1"),
+		);
+
+		act(() => {
+			result.current.attach([makeFile()]);
+		});
+		const [entry] = result.current.uploads;
+
+		act(() => {
+			result.current.remove(entry.id);
+		});
+
+		expect(result.current.uploads).toHaveLength(0);
+		await waitFor(() => {
+			expect(capturedSignal?.aborted).toBe(true);
+		});
+	});
+
+	it("keeps uploaded entries when another entry is removed", async () => {
+		uploadMock.mockResolvedValue(okResponse);
+		const { result } = renderHook(() =>
+			useWorkspaceFileUploads("chat-1", "ws-1"),
+		);
+
+		act(() => {
+			result.current.attach([makeFile("a.tar"), makeFile("b.tar")]);
+		});
+
+		await waitFor(() => {
+			expect(result.current.uploads.every((u) => u.status === "uploaded")).toBe(
+				true,
+			);
+		});
+
+		act(() => {
+			result.current.remove(result.current.uploads[0].id);
+		});
+
+		expect(result.current.uploads).toHaveLength(1);
+		expect(result.current.uploads[0].file.name).toBe("b.tar");
+	});
+
+	it("resets pending uploads when the chat changes", async () => {
+		uploadMock.mockResolvedValue(okResponse);
+		const { result, rerender } = renderHook(
+			({ chatId }: { chatId: string }) =>
+				useWorkspaceFileUploads(chatId, "ws-1"),
+			{ initialProps: { chatId: "chat-1" } },
+		);
+
+		act(() => {
+			result.current.attach([makeFile()]);
+		});
+		await waitFor(() => {
+			expect(result.current.uploads[0].status).toBe("uploaded");
+		});
+
+		rerender({ chatId: "chat-2" });
+
+		await waitFor(() => {
+			expect(result.current.uploads).toHaveLength(0);
+		});
+	});
+
+	it("resets uploads when the bound workspace changes", async () => {
+		uploadMock.mockResolvedValue(okResponse);
+		const { result, rerender } = renderHook(
+			({ workspaceId }: { workspaceId: string | undefined }) =>
+				useWorkspaceFileUploads("chat-1", workspaceId),
+			{ initialProps: { workspaceId: "ws-1" as string | undefined } },
+		);
+
+		act(() => {
+			result.current.attach([makeFile()]);
+		});
+		await waitFor(() => {
+			expect(result.current.uploads[0].status).toBe("uploaded");
+		});
+
+		rerender({ workspaceId: "ws-2" });
+
+		await waitFor(() => {
+			expect(result.current.uploads).toHaveLength(0);
+		});
+	});
+
+	it("uploads to the new chat while stale uploads are still settling", async () => {
+		// Saturate all worker slots with chat-1 uploads that never
+		// settle, so stale workers still hold slots when chat-2 files
+		// arrive. Without generation-scoped slot accounting the chat-2
+		// upload would never start (or a stale chat-1 worker would
+		// steal it).
+		uploadMock.mockImplementation((chatId: string) => {
+			if (chatId === "chat-1") {
+				return new Promise(() => {
+					// Never resolves; the abort is what ends it.
+				});
+			}
+			return Promise.resolve(okResponse);
+		});
+		const { result, rerender } = renderHook(
+			({ chatId }: { chatId: string }) =>
+				useWorkspaceFileUploads(chatId, "ws-1"),
+			{ initialProps: { chatId: "chat-1" } },
+		);
+
+		act(() => {
+			result.current.attach([
+				makeFile("a.tar"),
+				makeFile("b.tar"),
+				makeFile("c.tar"),
+			]);
+		});
+		await waitFor(() => {
+			expect(uploadMock).toHaveBeenCalledTimes(3);
+		});
+
+		rerender({ chatId: "chat-2" });
+		await waitFor(() => {
+			expect(result.current.uploads).toHaveLength(0);
+		});
+
+		act(() => {
+			result.current.attach([makeFile("new.tar")]);
+		});
+
+		await waitFor(() => {
+			expect(result.current.uploads[0]?.status).toBe("uploaded");
+		});
+		expect(uploadMock).toHaveBeenLastCalledWith(
+			"chat-2",
+			expect.any(File),
+			expect.any(AbortSignal),
+		);
+	});
+
+	it("aborts in-flight uploads on unmount", async () => {
+		let capturedSignal: AbortSignal | undefined;
+		uploadMock.mockImplementationOnce(
+			(_chatId: string, _file: File, signal?: AbortSignal) => {
+				capturedSignal = signal;
+				return new Promise(() => {
+					// Never resolves; the abort is what ends it.
+				});
+			},
+		);
+		const { result, unmount } = renderHook(() =>
+			useWorkspaceFileUploads("chat-1", "ws-1"),
+		);
+
+		act(() => {
+			result.current.attach([makeFile()]);
+		});
+
+		unmount();
+
+		await waitFor(() => {
+			expect(capturedSignal?.aborted).toBe(true);
+		});
+	});
+});

--- a/site/src/pages/AgentsPage/hooks/useWorkspaceFileUploads.ts
+++ b/site/src/pages/AgentsPage/hooks/useWorkspaceFileUploads.ts
@@ -1,0 +1,213 @@
+import { useEffect, useRef, useState } from "react";
+import { useMutation } from "react-query";
+import { API } from "#/api/api";
+import type { UploadChatWorkspaceFileResponse } from "#/api/typesGenerated";
+import { renameChatFileForUpload } from "../utils/chatAttachments";
+import { formatAgentAttachmentUploadError } from "../utils/fileAttachmentLimits";
+
+type WorkspaceFileUploadStatus = "uploading" | "uploaded" | "error";
+
+export type WorkspaceFileUpload = {
+	id: string;
+	file: File;
+	status: WorkspaceFileUploadStatus;
+	error?: string;
+	// Set once status is "uploaded". Carries the final path, name,
+	// size, and media type reported by the workspace agent.
+	response?: UploadChatWorkspaceFileResponse;
+};
+
+interface UseWorkspaceFileUploadsReturn {
+	uploads: readonly WorkspaceFileUpload[];
+	attach: (files: File[]) => void;
+	remove: (id: string) => void;
+	reset: () => void;
+}
+
+// Workspace uploads have no size cap, so bound the number of parallel
+// streams instead of relying on the browser's per-host connection
+// limits alone.
+const maxConcurrentWorkspaceUploads = 3;
+
+const createUploadId = (): string => {
+	const cryptoObject =
+		typeof globalThis.crypto !== "undefined" ? globalThis.crypto : undefined;
+	if (cryptoObject?.randomUUID) {
+		return cryptoObject.randomUUID();
+	}
+	return `upload-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+};
+
+/**
+ * Manages eager uploads of files into the chat's workspace filesystem
+ * via POST /api/experimental/chats/{chat}/workspace-files.
+ *
+ * Uploads start as soon as files are attached, bounded to a small
+ * number of concurrent streams. Removing an entry aborts its in-flight
+ * upload, but bytes that already reached the workspace stay there;
+ * removal only drops the composer reference.
+ *
+ * Uploads are scoped to the chat and its bound workspace: switching
+ * either one resets the pending set, because already-uploaded bytes
+ * live in the previous workspace and their references would be
+ * unreadable for the new one.
+ */
+export function useWorkspaceFileUploads(
+	chatId: string | undefined,
+	workspaceId: string | undefined,
+): UseWorkspaceFileUploadsReturn {
+	const [uploads, setUploads] = useState<readonly WorkspaceFileUpload[]>([]);
+	const abortControllersRef = useRef(new Map<string, AbortController>());
+	const pendingQueueRef = useRef<{ id: string; file: File }[]>([]);
+	const activeCountRef = useRef(0);
+	// Incremented whenever pending uploads are aborted (reset or scope
+	// switch). Workers spawned under an older generation must not
+	// consume entries queued after the abort: they carry a stale chat
+	// ID and their slot accounting was already zeroed.
+	const generationRef = useRef(0);
+	const scopeKey = `${chatId ?? ""}/${workspaceId ?? ""}`;
+	const previousScopeKeyRef = useRef(scopeKey);
+
+	const uploadMutation = useMutation({
+		mutationFn: ({
+			uploadChatId,
+			file,
+			signal,
+		}: {
+			uploadChatId: string;
+			file: File;
+			signal: AbortSignal;
+		}) => API.experimental.uploadChatWorkspaceFile(uploadChatId, file, signal),
+	});
+	const { mutateAsync: uploadFile } = uploadMutation;
+
+	const abortAllUploads = () => {
+		generationRef.current++;
+		for (const controller of abortControllersRef.current.values()) {
+			controller.abort();
+		}
+		abortControllersRef.current.clear();
+		pendingQueueRef.current = [];
+		activeCountRef.current = 0;
+	};
+
+	const reset = () => {
+		abortAllUploads();
+		setUploads([]);
+	};
+
+	// Abort any in-flight uploads when the composer unmounts.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: abortAllUploads touches only refs; React Compiler memoizes it (no manual useCallback here per site/AGENTS.md).
+	useEffect(() => abortAllUploads, [abortAllUploads]);
+
+	// Uploads target a specific chat's directory in a specific
+	// workspace, so navigating to a different chat or rebinding the
+	// workspace invalidates the pending set.
+	useEffect(() => {
+		if (previousScopeKeyRef.current === scopeKey) {
+			return;
+		}
+		previousScopeKeyRef.current = scopeKey;
+		reset();
+		// biome-ignore lint/correctness/useExhaustiveDependencies: reset composes stable refs and setState; React Compiler memoizes it (no manual useCallback here per site/AGENTS.md).
+	}, [scopeKey, reset]);
+
+	const setUploadResult = (
+		id: string,
+		result: Partial<WorkspaceFileUpload>,
+	) => {
+		setUploads((prev) =>
+			prev.map((upload) =>
+				upload.id === id ? { ...upload, ...result } : upload,
+			),
+		);
+	};
+
+	// Each worker pulls queued files until the queue drains, so a
+	// completed upload immediately frees its slot for the next file.
+	const runUploadWorker = async (uploadChatId: string) => {
+		const generation = generationRef.current;
+		activeCountRef.current++;
+		let next = pendingQueueRef.current.shift();
+		while (next) {
+			// A removed entry has no abort controller anymore; skip it.
+			const controller = abortControllersRef.current.get(next.id);
+			if (controller) {
+				try {
+					const response = await uploadFile({
+						uploadChatId,
+						file: next.file,
+						signal: controller.signal,
+					});
+					setUploadResult(next.id, { status: "uploaded", response });
+				} catch (error: unknown) {
+					if (!controller.signal.aborted) {
+						setUploadResult(next.id, {
+							status: "error",
+							error: formatAgentAttachmentUploadError(error),
+						});
+					}
+				}
+				abortControllersRef.current.delete(next.id);
+			}
+			if (generationRef.current !== generation) {
+				// An abort invalidated this worker mid-upload. Entries
+				// queued since belong to workers of the new generation,
+				// which also owns the slot accounting.
+				return;
+			}
+			next = pendingQueueRef.current.shift();
+		}
+		activeCountRef.current--;
+	};
+
+	const pumpQueue = () => {
+		if (!chatId) {
+			return;
+		}
+		// Workers shift their first queue entry synchronously, so this
+		// loop spawns at most one worker per pending file.
+		while (
+			activeCountRef.current < maxConcurrentWorkspaceUploads &&
+			pendingQueueRef.current.length > 0
+		) {
+			void runUploadWorker(chatId);
+		}
+	};
+
+	const attach = (incoming: File[]) => {
+		const entries = incoming.map((file) => ({
+			id: createUploadId(),
+			file: renameChatFileForUpload(file),
+			status: "uploading" as const,
+		}));
+		if (!chatId) {
+			setUploads((prev) => [
+				...prev,
+				...entries.map((entry) => ({
+					...entry,
+					status: "error" as const,
+					error: "Cannot upload: no active chat. Open or start a chat first.",
+				})),
+			]);
+			return;
+		}
+		setUploads((prev) => [...prev, ...entries]);
+		for (const entry of entries) {
+			abortControllersRef.current.set(entry.id, new AbortController());
+			pendingQueueRef.current.push({ id: entry.id, file: entry.file });
+		}
+		pumpQueue();
+	};
+
+	const remove = (id: string) => {
+		abortControllersRef.current.get(id)?.abort();
+		abortControllersRef.current.delete(id);
+		pendingQueueRef.current = pendingQueueRef.current.filter(
+			(entry) => entry.id !== id,
+		);
+		setUploads((prev) => prev.filter((upload) => upload.id !== id));
+	};
+
+	return { uploads, attach, remove, reset };
+}

--- a/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
@@ -3,6 +3,7 @@ import {
 	isChatAttachmentFile,
 	renameChatFileForUpload,
 	sanitizeChatFileName,
+	shouldRouteFileToWorkspace,
 } from "./chatAttachments";
 
 describe("isChatAttachmentFile", () => {
@@ -32,6 +33,36 @@ describe("isChatAttachmentFile", () => {
 		});
 
 		expect(isChatAttachmentFile(file)).toBe(false);
+	});
+});
+
+describe("shouldRouteFileToWorkspace", () => {
+	it("keeps allowlisted MIME types on the attachment path", () => {
+		const file = new File(["png"], "image.png", { type: "image/png" });
+
+		expect(shouldRouteFileToWorkspace(file)).toBe(false);
+	});
+
+	it("keeps files with an empty MIME type on the attachment path", () => {
+		const file = new File(["markdown"], "notes.md");
+
+		expect(shouldRouteFileToWorkspace(file)).toBe(false);
+	});
+
+	it("keeps application/octet-stream files on the attachment path", () => {
+		const file = new File(["unknown"], "attachment.bin", {
+			type: "application/octet-stream",
+		});
+
+		expect(shouldRouteFileToWorkspace(file)).toBe(false);
+	});
+
+	it("routes declared non-allowlisted MIME types to the workspace", () => {
+		const file = new File(["zip"], "archive.zip", {
+			type: "application/zip",
+		});
+
+		expect(shouldRouteFileToWorkspace(file)).toBe(true);
 	});
 });
 

--- a/site/src/pages/AgentsPage/utils/chatAttachments.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.ts
@@ -1,4 +1,5 @@
 import { isApiErrorResponse } from "#/api/errors";
+import type * as TypesGen from "#/api/typesGenerated";
 import { ChatAttachmentMediaTypes } from "#/api/typesGenerated";
 
 const undisplayableAttachmentDetail = "File exists but could not be displayed.";
@@ -98,6 +99,21 @@ export const isChatAttachmentFile = (file: File): boolean => {
 	}
 	return ChatAttachmentMediaTypes.some((mediaType) => mediaType === file.type);
 };
+
+/**
+ * Returns true for files that should stream into the chat's workspace
+ * filesystem instead of the attachment pipeline: any file whose
+ * declared MIME type is not on the attachment allowlist. Files with an
+ * unknown type (empty or application/octet-stream) stay on the
+ * attachment path where the server classifies the bytes.
+ */
+export const shouldRouteFileToWorkspace = (file: File): boolean =>
+	!isChatAttachmentFile(file);
+
+export const isWorkspaceFileReferencePart = (
+	part: TypesGen.ChatMessagePart,
+): part is TypesGen.ChatWorkspaceFileReferencePart =>
+	part.type === "workspace-file-reference";
 
 // Matches characters that commonly cause trouble downstream: bracketing
 // punctuation, quotes, shell or URL or path metacharacters, path


### PR DESCRIPTION
## What

Frontend for chat workspace uploads:

- Files whose declared MIME type is outside the attachment allowlist are automatically routed to the workspace upload endpoint (picker, drag-drop, and paste). Empty/`application/octet-stream` types stay on the attachment path so the server can sniff bytes.
- `useWorkspaceFileUploads`: react-query mutation with eager upload on select, bounded to 3 concurrent streams, per-entry abort (removing a chip cancels its in-flight request), and generation-scoped workers so switching chats mid-upload cannot leak a stale upload into the new chat.
- Composer chips (`WorkspaceUploadPreview`) show uploading/uploaded/error states; removal copy makes explicit that already-uploaded bytes stay in the workspace.
- Timeline chips (`WorkspaceFileChip`) render `workspace-file-reference` parts with name/size and the absolute path in a tooltip.
- References survive message edits and queued-message edits.
- The affordance is gated on a bound workspace with a connected agent; otherwise the input falls back to attachments only. A disabled (read-only) composer refuses workspace routing entirely. The target agent is the one the server resolves for the chat binding (main now enriches the binding server-side), so the frontend no longer mirrors `agentselect.FindChatAgent`.
- Message edits only rehydrate `workspace-file-reference` parts whose `workspace_file_workspace_id` matches the currently bound workspace; references from a previous binding are dropped from the edit draft (the server also rejects them).

## Why

Completes CODAGT-211: dropping a `.zip`/`.tar.gz`/dataset whose MIME type is outside the attachment allowlist into chat lands it at `~/.coder/chats/<chat-id>/files/` where the agent can act on it, without pushing bytes through the LLM context.

## How tested

- `pnpm vitest` for the upload hook (including a chat-switch race regression test), routing predicate, message parsing/helpers; Storybook interaction tests for the chip states; `tsc`, biome, React Compiler check, and knip all clean.

## Follow-ups

- Persist workspace-upload metadata per chat so composer chips survive a failed workspace rebind and navigating away from and back to a chat. Today the hook resets when the chat or bound workspace changes (the server rejects references from a previous binding) and the upload list is client state only, so the chips are dropped even though the bytes stay in the workspace.

- Expose workspace-upload availability from the backend (the agent `agentselect.FindChatAgent` would pick) instead of the client gating on the bound agent or, when the chat has none yet, on any connected root agent; a multi-root-agent workspace whose selected agent is disconnected currently gets the server's 409 on upload.
- Reset or re-validate composer chips when `repairChatAgentIDs` replaces the bound agent after a workspace rebuild (the hooks scope on chat and workspace ID only); belongs with the upload-metadata persistence above.
- Render timeline chips whose `workspace_file_workspace_id` differs from the chat's current binding in a stale/unavailable state (the prompt already renders such references as unavailable); needs the current binding threaded into the timeline and a chip variant.
- Files with an unknown MIME type (empty or `application/octet-stream`, for example a random `.bin`) stay on the attachment path by design, where the server classifies the bytes and rejects them with "Unsupported file type"; routing that rejection to the workspace upload instead is a follow-up. `text/csv` is an allowlisted attachment type and stays inline (UAT finding).

Part of CODAGT-211. Stack: agent API -> coderd endpoint -> UI (this PR).

> This PR was authored by Mux (AI) working on Mike's behalf.

