### PR TITLE
test(coderd/externalauth): fix RevokeTokenRFC_Timeout flake

### DIFF
--- a/coderd/externalauth/externalauth_test.go
+++ b/coderd/externalauth/externalauth_test.go
@@ -1083,40 +1083,65 @@ func TestRevokeToken(t *testing.T) {
 
 	t.Run("RevokeTokenRFC_Timeout", func(t *testing.T) {
 		t.Parallel()
+		// These channels are buffered so the handler goroutine can
+		// always complete its sends even if the test returns
+		// early. An unbuffered send with no receiver would leak the
+		// goroutine.
 		revokeExited := make(chan bool, 1)
-		testTimeout := make(chan bool, 1)
-		handlerDone := make(chan bool)
-
-		go func() {
-			time.Sleep(5 * time.Second)
-			testTimeout <- true
-		}()
+		handlerStarted := make(chan bool, 1)
+		handlerDone := make(chan bool, 1)
+		t.Cleanup(func() {
+			select {
+			case revokeExited <- true:
+			default:
+			}
+		})
 
 		fake, config, link := setupOauth2Test(t, testConfig{
 			FakeIDPOpts: []oidctest.FakeIDPOpt{
 				oidctest.WithRevokeTokenRFC(func() (int, error) {
+					handlerStarted <- true
 					defer func() {
 						handlerDone <- true
 					}()
 
-					select {
-					case <-testTimeout:
-						t.Error("test timeout reached before context timeout")
-						return http.StatusOK, nil
-					case <-revokeExited:
-						return http.StatusOK, nil
-					}
+					<-revokeExited
+					return http.StatusOK, nil
 				}),
 				oidctest.WithServing(),
 			},
 		})
 
 		ctx := oidc.ClientContext(testutil.Context(t, testutil.WaitLong), fake.HTTPClient(nil))
-		config.RevokeTimeout = time.Millisecond * 10
-		revoked, err := config.RevokeToken(ctx, link)
+		// A short timeout forces the request's deadline to fire while
+		// the handler is blocked in-flight, exercising the revoke
+		// timeout path.
+		config.RevokeTimeout = 100 * time.Millisecond
+		type revokeResult struct {
+			revoked bool
+			err     error
+		}
+		resultCh := make(chan revokeResult, 1)
+		go func() {
+			revoked, err := config.RevokeToken(ctx, link)
+			resultCh <- revokeResult{revoked: revoked, err: err}
+		}()
+		// Wait until the request has reached the server and the
+		// handler is running before asserting. This anchors the
+		// assertions to the in-flight state and turns a slow scheduler
+		// under CI load into a fast, labeled failure instead of a 25s
+		// RequireReceive hang.
+		select {
+		case <-handlerStarted:
+		case result := <-resultCh:
+			t.Fatalf("RevokeToken returned before revoke handler started: %v", result.err)
+		case <-ctx.Done():
+			t.Fatal("timed out waiting for revoke handler to start")
+		}
+		result := testutil.RequireReceive(ctx, t, resultCh)
 		revokeExited <- true
-		require.ErrorIs(t, err, context.DeadlineExceeded)
-		require.False(t, revoked)
+		require.ErrorIs(t, result.err, context.DeadlineExceeded)
+		require.False(t, result.revoked)
 		_ = testutil.RequireReceive(ctx, t, handlerDone)
 	})
 

--- a/coderd/externalauth/externalauth_test.go
+++ b/coderd/externalauth/externalauth_test.go
@@ -1083,28 +1083,13 @@ func TestRevokeToken(t *testing.T) {
 
 	t.Run("RevokeTokenRFC_Timeout", func(t *testing.T) {
 		t.Parallel()
-		// These channels are buffered so the handler goroutine can
-		// always complete its sends even if the test returns
-		// early. An unbuffered send with no receiver would leak the
-		// goroutine.
-		revokeExited := make(chan bool, 1)
 		handlerStarted := make(chan bool, 1)
-		handlerDone := make(chan bool, 1)
-		t.Cleanup(func() {
-			select {
-			case revokeExited <- true:
-			default:
-			}
-		})
+		revokeExited := make(chan bool, 1)
 
 		fake, config, link := setupOauth2Test(t, testConfig{
 			FakeIDPOpts: []oidctest.FakeIDPOpt{
 				oidctest.WithRevokeTokenRFC(func() (int, error) {
 					handlerStarted <- true
-					defer func() {
-						handlerDone <- true
-					}()
-
 					<-revokeExited
 					return http.StatusOK, nil
 				}),
@@ -1112,37 +1097,31 @@ func TestRevokeToken(t *testing.T) {
 			},
 		})
 
+		// Always unblock the handler so it can return. Must be
+		// registered after setupOauth2Test so LIFO runs it first.
+		t.Cleanup(func() {
+			select {
+			case revokeExited <- true:
+			default:
+			}
+		})
+
 		ctx := oidc.ClientContext(testutil.Context(t, testutil.WaitLong), fake.HTTPClient(nil))
 		// A short timeout forces the request's deadline to fire while
 		// the handler is blocked in-flight, exercising the revoke
 		// timeout path.
 		config.RevokeTimeout = 100 * time.Millisecond
-		type revokeResult struct {
-			revoked bool
-			err     error
-		}
-		resultCh := make(chan revokeResult, 1)
-		go func() {
-			revoked, err := config.RevokeToken(ctx, link)
-			resultCh <- revokeResult{revoked: revoked, err: err}
-		}()
-		// Wait until the request has reached the server and the
-		// handler is running before asserting. This anchors the
-		// assertions to the in-flight state and turns a slow scheduler
-		// under CI load into a fast, labeled failure instead of a 25s
-		// RequireReceive hang.
+		revoked, err := config.RevokeToken(ctx, link)
+		// Make sure request has reached the handler before asserting.
+		// NOTE: if this flakes again, increase config.RevokeTimeout.
 		select {
 		case <-handlerStarted:
-		case result := <-resultCh:
-			t.Fatalf("RevokeToken returned before revoke handler started: %v", result.err)
-		case <-ctx.Done():
-			t.Fatal("timed out waiting for revoke handler to start")
+		default:
+			t.Fatal("RevokeToken returned before revoke handler started")
 		}
-		result := testutil.RequireReceive(ctx, t, resultCh)
 		revokeExited <- true
-		require.ErrorIs(t, result.err, context.DeadlineExceeded)
-		require.False(t, result.revoked)
-		_ = testutil.RequireReceive(ctx, t, handlerDone)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.False(t, revoked)
 	})
 
 	t.Run("RevokeTokenGitHub_OK", func(t *testing.T) {


### PR DESCRIPTION
Under CI load the request's 10ms revoke timeout could expire before
the request reached the FakeIDP revoke handler. The handler never
ran, so the test's wait for it to finish blocked until the 25s test
context expired instead of passing quickly.

Raise `RevokeTimeout` to 100ms so the request has ~10x more headroom to
reach the handler under load. After RevokeToken returns, check a
`handlerStarted` signal before asserting: this anchors the
`DeadlineExceeded` assertion to a request that was actually in flight,
and turns any residual scheduling race into a fast, labeled failure
instead of a hang.

Unblock the handler on the early-exit path with a `t.Cleanup`. It must
be registered after the FakeIDP setup so LIFO runs it before the
server's `Close()`; otherwise a handler that dispatched late would
block `Close()` and hang teardown until the test timeout. Drop the
previous `time.Sleep` watchdog and the handler-done channel, since the
FakeIDP server's `Close()` already joins the in-flight handler.

Refs: https://linear.app/codercom/issue/PLAT-317