### PR TITLE
🤖 feat(site): add Truncate component and adopt for URL/path surfaces

### DIFF
--- a/site/src/components/Truncate/Truncate.stories.tsx
+++ b/site/src/components/Truncate/Truncate.stories.tsx
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Truncate } from "./Truncate";
+
+const meta: Meta<typeof Truncate> = {
+	title: "components/Truncate",
+	component: Truncate,
+	args: {
+		children:
+			"bedrock-runtime.us-east-2.amazonaws.com/model/anthropic.claude-3-5-sonnet-20241022-v2:0/invoke",
+	},
+	decorators: [
+		(Story) => (
+			<div className="max-w-96 rounded border border-solid border-border-default bg-surface-primary p-3 text-xs text-content-primary">
+				<Story />
+			</div>
+		),
+	],
+};
+
+export default meta;
+type Story = StoryObj<typeof Truncate>;
+
+export const End: Story = {
+	args: { position: "end" },
+};
+
+export const Middle: Story = {
+	args: { position: "middle" },
+};
+
+export const Start: Story = {
+	args: { position: "start" },
+};
+
+export const Short: Story = {
+	args: { position: "middle", children: "short" },
+};
+
+export const Empty: Story = {
+	args: { position: "middle", children: "" },
+};
+
+export const CustomEllipsis: Story = {
+	args: { position: "middle", ellipsis: " ... " },
+};
+
+// Multi-code-unit characters (emoji, combined marks) must never be cut in
+// half. The binary search operates on grapheme clusters, so the ellipsis
+// only ever lands between clusters.
+export const Emoji: Story = {
+	args: {
+		position: "middle",
+		children:
+			"👨‍👩‍👧‍👦 family emoji is one grapheme, followed by more text that will need to be truncated 👨‍👩‍👧‍👦",
+	},
+};
+
+export const Narrow: Story = {
+	decorators: [
+		(Story) => (
+			<div className="max-w-24 rounded border border-solid border-border-default bg-surface-primary p-3 text-xs text-content-primary">
+				<Story />
+			</div>
+		),
+	],
+	args: { position: "middle" },
+};
+
+// When even the ellipsis will not fit, Truncate renders the empty string
+// rather than overflowing the container.
+export const TooNarrowForEllipsis: Story = {
+	decorators: [
+		(Story) => (
+			<div
+				className="rounded border border-solid border-border-default bg-surface-primary p-3 text-xs text-content-primary"
+				style={{ width: "8px" }}
+			>
+				<Story />
+			</div>
+		),
+	],
+	args: { position: "middle" },
+};
+
+// Common shape: an icon plus a filepath/URL inside a fixed-width container.
+// The Truncate consumes the flex slack so the icon stays visible.
+export const InFlexRow: Story = {
+	render: (args) => (
+		<div className="flex items-center gap-2 min-w-0">
+			<span
+				aria-hidden
+				className="inline-block h-3 w-3 shrink-0 rounded-sm bg-content-link"
+			/>
+			<Truncate {...args} />
+		</div>
+	),
+	args: {
+		position: "middle",
+		children:
+			"/very/long/monorepo/path/site/src/pages/AgentsPage/components/ChatElements/tools/DiffFileHeader.tsx",
+	},
+};

--- a/site/src/components/Truncate/Truncate.tsx
+++ b/site/src/components/Truncate/Truncate.tsx
@@ -1,0 +1,178 @@
+import {
+	type FC,
+	type HTMLAttributes,
+	useCallback,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from "react";
+import { cn } from "#/utils/cn";
+
+type TruncatePosition = "start" | "middle" | "end";
+
+type TruncateProps = Omit<
+	HTMLAttributes<HTMLSpanElement>,
+	"children" | "title"
+> & {
+	children: string;
+	position?: TruncatePosition;
+	ellipsis?: string;
+	/**
+	 * Tooltip shown on hover. Defaults to the full, untruncated value so the
+	 * complete string is always recoverable. Pass `false` to omit the title.
+	 */
+	title?: string | false;
+};
+
+// Split into grapheme clusters so multi-code-unit characters (emoji,
+// combining marks) are never cut in half when truncating.
+const toGraphemes = (value: string): string[] => {
+	if ("Segmenter" in Intl) {
+		const segmenter = new Intl.Segmenter(undefined, {
+			granularity: "grapheme",
+		});
+		return Array.from(segmenter.segment(value), ({ segment }) => segment);
+	}
+	return Array.from(value);
+};
+
+const buildCandidate = (
+	graphemes: string[],
+	kept: number,
+	position: TruncatePosition,
+	ellipsis: string,
+): string => {
+	switch (position) {
+		case "start":
+			return ellipsis + graphemes.slice(graphemes.length - kept).join("");
+		case "end":
+			return graphemes.slice(0, kept).join("") + ellipsis;
+		case "middle": {
+			const startLength = Math.ceil(kept / 2);
+			const endLength = Math.floor(kept / 2);
+			const start = graphemes.slice(0, startLength).join("");
+			const end =
+				endLength > 0
+					? graphemes.slice(graphemes.length - endLength).join("")
+					: "";
+			return `${start}${ellipsis}${end}`;
+		}
+	}
+};
+
+/**
+ * Truncates a single line of text to fit its container, inserting an ellipsis
+ * at the start, middle, or end. Unlike the CSS `truncate` utility, middle
+ * truncation keeps both ends of the string visible, which matters for file
+ * paths, URLs, and opaque identifiers where the leading and trailing
+ * characters both carry meaning.
+ *
+ * The visible text is measured against the rendered container width, so it
+ * reflows on container resize and when web fonts finish loading. The full
+ * value is exposed on hover through the `title` attribute (pass `title={false}`
+ * to opt out).
+ *
+ * The container fills its parent's width, so constrain it through the parent
+ * (for example a flex item with `min-w-0`, or a fixed-width cell).
+ */
+export const Truncate: FC<TruncateProps> = ({
+	children,
+	position = "end",
+	ellipsis = "…",
+	title = children,
+	className,
+	...props
+}) => {
+	const containerRef = useRef<HTMLSpanElement>(null);
+	const measurementRef = useRef<HTMLSpanElement>(null);
+	const [displayValue, setDisplayValue] = useState(children);
+
+	const recalculate = useCallback(() => {
+		const container = containerRef.current;
+		const measurement = measurementRef.current;
+		if (!container || !measurement) {
+			return;
+		}
+
+		try {
+			const computedStyle = getComputedStyle(container);
+			const horizontalPadding =
+				Number.parseFloat(computedStyle.paddingLeft) +
+				Number.parseFloat(computedStyle.paddingRight);
+			const availableWidth = container.clientWidth - horizontalPadding;
+
+			const fits = (value: string): boolean => {
+				measurement.textContent = value;
+				// Allow half a pixel of slack to absorb sub-pixel rounding.
+				return (
+					measurement.getBoundingClientRect().width <= availableWidth + 0.5
+				);
+			};
+
+			if (fits(children)) {
+				setDisplayValue(children);
+				return;
+			}
+			if (!fits(ellipsis)) {
+				setDisplayValue("");
+				return;
+			}
+
+			// Binary search for the largest grapheme count that still fits.
+			const graphemes = toGraphemes(children);
+			let minimum = 0;
+			let maximum = graphemes.length;
+			let bestMatch = ellipsis;
+			while (minimum <= maximum) {
+				const kept = Math.floor((minimum + maximum) / 2);
+				const candidate = buildCandidate(graphemes, kept, position, ellipsis);
+				if (fits(candidate)) {
+					bestMatch = candidate;
+					minimum = kept + 1;
+				} else {
+					maximum = kept - 1;
+				}
+			}
+			setDisplayValue(bestMatch);
+		} finally {
+			// The measurement span sits in the DOM alongside the visible text.
+			// Leaving the last-tested value in it would duplicate the string in
+			// `textContent`, corrupting copy-paste and confusing text queries.
+			measurement.textContent = "";
+		}
+	}, [children, ellipsis, position]);
+
+	useLayoutEffect(() => {
+		const container = containerRef.current;
+		if (!container) {
+			return;
+		}
+		const resizeObserver = new ResizeObserver(recalculate);
+		resizeObserver.observe(container);
+		document.fonts?.addEventListener("loadingdone", recalculate);
+		recalculate();
+		return () => {
+			resizeObserver.disconnect();
+			document.fonts?.removeEventListener("loadingdone", recalculate);
+		};
+	}, [recalculate]);
+
+	return (
+		<span
+			{...props}
+			ref={containerRef}
+			title={title === false ? undefined : title}
+			className={cn(
+				"relative block w-full min-w-0 overflow-hidden whitespace-nowrap",
+				className,
+			)}
+		>
+			{displayValue}
+			<span
+				ref={measurementRef}
+				aria-hidden
+				className="pointer-events-none invisible absolute w-max whitespace-pre"
+			/>
+		</span>
+	);
+};

--- a/site/src/modules/resources/ResourceCard.tsx
+++ b/site/src/modules/resources/ResourceCard.tsx
@@ -9,6 +9,7 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
+import { Truncate } from "#/components/Truncate/Truncate";
 import { ResourceAvatar } from "./ResourceAvatar";
 import { SensitiveValue } from "./SensitiveValue";
 
@@ -88,9 +89,10 @@ export const ResourceCard: FC<ResourceCardProps> = ({ resource, agentRow }) => {
 															(child) => typeof child === "string",
 														)
 													) {
+														const value = childrens.join("");
 														return (
-															<CopyableValue value={childrens.join("")}>
-																{children}
+															<CopyableValue value={value} className="block">
+																<Truncate position="middle">{value}</Truncate>
 															</CopyableValue>
 														);
 													}

--- a/site/src/modules/templates/TemplateFiles/TemplateFileTree.tsx
+++ b/site/src/modules/templates/TemplateFiles/TemplateFileTree.tsx
@@ -18,6 +18,7 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "#/components/DropdownMenu/DropdownMenu";
+import { Truncate } from "#/components/Truncate/Truncate";
 import { cn } from "#/utils/cn";
 import type { FileTree } from "#/utils/filetree";
 import { getTemplateFileIcon } from "./TemplateFileIcon";
@@ -165,6 +166,19 @@ const nodeClasses =
 	"border-none bg-transparent px-4 text-[13px] text-left " +
 	"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link focus-visible:ring-inset";
 
+// A `Label` prop can render arbitrary JSX (e.g. a decorated label with a
+// modified marker), which the measured Truncate component cannot handle.
+// Only string labels get middle-truncated; JSX labels fall back to CSS
+// end-truncation so their internal layout is preserved.
+const TreeNodeLabel: FC<{ label: React.ReactNode }> = ({ label }) =>
+	typeof label === "string" ? (
+		<Truncate position="middle" className="text-inherit">
+			{label}
+		</Truncate>
+	) : (
+		<span className="truncate">{label}</span>
+	);
+
 const FileNode: FC<TreeNodeProps> = ({
 	label,
 	icon,
@@ -194,7 +208,7 @@ const FileNode: FC<TreeNodeProps> = ({
 				onClick={onClick}
 			>
 				{icon}
-				<span className="truncate">{label}</span>
+				<TreeNodeLabel label={label} />
 			</button>
 			<MoreMenu onRename={onRename} onDelete={onDelete} />
 		</div>
@@ -243,7 +257,7 @@ const FolderNode: FC<FolderNodeProps> = ({
 						) : (
 							<FolderIcon className="size-3 shrink-0 text-current" />
 						)}
-						<span className="truncate">{label}</span>
+						<TreeNodeLabel label={label} />
 					</button>
 				</CollapsibleTrigger>
 				<MoreMenu onRename={onRename} onDelete={onDelete} />

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/ToolCallTable.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/ToolCallTable.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react";
 import { CopyButton } from "#/components/CopyButton/CopyButton";
+import { Truncate } from "#/components/Truncate/Truncate";
 import { cn } from "#/utils/cn";
 import { formatDate } from "#/utils/time";
 import { TokenBadges } from "../../TokenBadges";
@@ -46,9 +47,11 @@ export const ToolCallTable: FC<ToolCallTableProps> = ({
 				</span>
 			</div>
 			{serverURL && (
-				<div className="flex items-center justify-between">
-					<span className="pr-4 whitespace-nowrap">MCP server</span>
-					<span className="font-mono truncate">{serverURL}</span>
+				<div className="flex items-center justify-between gap-2">
+					<span className="whitespace-nowrap">MCP server</span>
+					<Truncate position="middle" className="font-mono">
+						{serverURL}
+					</Truncate>
 					<CopyButton text={serverURL} label="Copy MCP server URL" />
 				</div>
 			)}

--- a/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderRow.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderRow.tsx
@@ -7,6 +7,7 @@ import { Avatar } from "#/components/Avatar/Avatar";
 import { AvatarData } from "#/components/Avatar/AvatarData";
 import { Badge } from "#/components/Badge/Badge";
 import { TableCell, TableRow } from "#/components/Table/Table";
+import { Truncate } from "#/components/Truncate/Truncate";
 import { useClickableTableRow } from "#/hooks/useClickableTableRow";
 import { ProviderIcon } from "./ProviderIcon";
 import { getProviderDisplayType } from "./providerFormApiMap";
@@ -44,12 +45,9 @@ export const ProviderRow: React.FC<ProviderRowProps> = ({
 				/>
 			</TableCell>
 			<TableCell className="min-w-0">
-				<span
-					className="block truncate text-content-secondary"
-					title={provider.base_url}
-				>
+				<Truncate position="middle" className="text-content-secondary">
 					{provider.base_url}
-				</span>
+				</Truncate>
 			</TableCell>
 			<TableCell>
 				<div className="flex flex-wrap items-center gap-1">

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/DiffFileHeader.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/DiffFileHeader.tsx
@@ -1,4 +1,5 @@
 import type { FileContents, FileDiffMetadata } from "@pierre/diffs";
+import { Truncate } from "#/components/Truncate/Truncate";
 import { cn } from "#/utils/cn";
 import { countChangedLines } from "../../../utils/countChangedLines";
 import { changeColor, changeLabel } from "../../../utils/diffColors";
@@ -25,13 +26,19 @@ export function DiffFileHeader({
 					</span>
 				)}
 				{isDiff && file.prevName && file.prevName !== file.name && (
-					<span className="truncate text-xs text-content-secondary">
+					<Truncate
+						position="middle"
+						className="text-xs text-content-secondary"
+					>
 						{file.prevName}
-					</span>
+					</Truncate>
 				)}
-				<span className="truncate text-xs font-medium text-content-primary">
+				<Truncate
+					position="middle"
+					className="text-xs font-medium text-content-primary"
+				>
 					{file.name}
-				</span>
+				</Truncate>
 			</div>
 			{stats && (stats.additions > 0 || stats.deletions > 0) && (
 				<span className="inline-flex shrink-0 flex-row-reverse items-stretch overflow-hidden rounded-[3px] border border-solid border-border-default font-mono text-xs font-medium leading-5">

--- a/site/src/pages/AgentsPage/components/ContextUsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/ContextUsageIndicator.tsx
@@ -27,6 +27,7 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
+import { Truncate } from "#/components/Truncate/Truncate";
 import { cn } from "#/utils/cn";
 import { formatKiB } from "#/utils/fileSize";
 import { isMobileViewport } from "#/utils/mobile";
@@ -441,20 +442,16 @@ export const ContextUsageIndicator: FC<{
 									<div
 										key={config.source}
 										className="flex items-center gap-1.5"
-										title={config.source}
 									>
 										<FileIcon className="size-3 shrink-0" />
-										<span className="truncate">{config.source}</span>
+										<Truncate position="middle">{config.source}</Truncate>
 									</div>
 								))}
 								{mcpServerItems.map((mcp) => (
 									<div key={mcp.source} className="flex flex-col gap-0.5">
-										<div
-											className="flex items-center gap-1.5"
-											title={mcp.source}
-										>
+										<div className="flex items-center gap-1.5">
 											<PlugIcon className="size-3 shrink-0" />
-											<span className="truncate">{mcp.name}</span>
+											<Truncate position="middle">{mcp.name}</Truncate>
 										</div>
 										{mcp.tools.length > 0 && (
 											<div className="ml-4 flex flex-col gap-0.5">

--- a/site/src/pages/AgentsPage/components/DiffViewer/DiffViewer.tsx
+++ b/site/src/pages/AgentsPage/components/DiffViewer/DiffViewer.tsx
@@ -22,6 +22,7 @@ import {
 } from "react";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Skeleton } from "#/components/Skeleton/Skeleton";
+import { Truncate } from "#/components/Truncate/Truncate";
 import { cn } from "#/utils/cn";
 import { countChangedLines } from "../../utils/countChangedLines";
 import { changeColor, changeLabel } from "../../utils/diffColors";
@@ -218,13 +219,19 @@ function HeaderContent({ fileDiff }: { fileDiff: FileDiffMetadata }) {
 					{changeLabel(fileDiff.type)}
 				</span>
 				{fileDiff.prevName && fileDiff.prevName !== fileDiff.name && (
-					<span className="truncate text-xs text-content-secondary">
+					<Truncate
+						position="middle"
+						className="text-xs text-content-secondary"
+					>
 						{fileDiff.prevName}
-					</span>
+					</Truncate>
 				)}
-				<span className="truncate text-xs font-medium text-content-primary">
+				<Truncate
+					position="middle"
+					className="text-xs font-medium text-content-primary"
+				>
 					{fileDiff.name}
-				</span>
+				</Truncate>
 			</div>
 			{(additions > 0 || deletions > 0) && (
 				<span className="inline-flex shrink-0 flex-row-reverse items-stretch overflow-hidden rounded-[3px] border border-solid border-border-default font-mono text-xs font-medium leading-5">

--- a/site/src/pages/WorkspacePage/WorkspaceTopbar.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceTopbar.tsx
@@ -26,6 +26,7 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
+import { Truncate } from "#/components/Truncate/Truncate";
 import { useDashboard } from "#/modules/dashboard/useDashboard";
 import { linkToTemplate, useLinks } from "#/modules/navigation";
 import { WorkspaceStatusIndicator } from "#/modules/workspaces/WorkspaceStatusIndicator/WorkspaceStatusIndicator";
@@ -41,7 +42,6 @@ const BREADCRUMB_SEGMENT_CLASS = cn(
 	"flex items-center flex-row flex-nowrap gap-2",
 	"max-w-40 whitespace-nowrap cursor-default",
 );
-const BREADCRUMB_TEXT_CLASS = "overflow-x-hidden text-ellipsis";
 
 interface WorkspaceTopbarProps {
 	isUpdating: boolean;
@@ -271,7 +271,7 @@ const OwnerBreadcrumb: FC<OwnerBreadcrumbProps> = ({
 			<HelpPopoverTrigger asChild>
 				<span className={BREADCRUMB_SEGMENT_CLASS}>
 					<Avatar size="sm" fallback={ownerName} src={ownerAvatarUrl} />
-					<span className={BREADCRUMB_TEXT_CLASS}>{ownerName}</span>
+					<Truncate position="middle">{ownerName}</Truncate>
 				</span>
 			</HelpPopoverTrigger>
 
@@ -303,7 +303,7 @@ const OrganizationBreadcrumb: FC<OrganizationBreadcrumbProps> = ({
 						src={orgIconUrl}
 						fallback={orgName}
 					/>
-					<span className={BREADCRUMB_TEXT_CLASS}>{orgName}</span>
+					<Truncate position="middle">{orgName}</Truncate>
 				</span>
 			</HelpPopoverTrigger>
 
@@ -367,9 +367,9 @@ const WorkspaceBreadcrumb: FC<WorkspaceBreadcrumbProps> = ({
 							fallback={templateDisplayName}
 						/>
 
-						<span className={cn(BREADCRUMB_TEXT_CLASS, "font-medium")}>
+						<Truncate position="middle" className="font-medium">
 							{workspaceName}
-						</span>
+						</Truncate>
 					</span>
 				</HelpPopoverTrigger>
 


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Add a shared `Truncate` component and adopt middle truncation on the surfaces where both ends of a value carry meaning.

## What

- New `Truncate` component under `site/src/components/Truncate/`, with stories.
- Migrates end-only CSS truncation to measured middle truncation on the surfaces listed below.

Middle truncation keeps the beginning and end of a URL, path, or opaque identifier visible; CSS `truncate` drops the end entirely, hiding the discriminating part of ARNs, PR paths, endpoint routes, etc.

## Surfaces migrated

| Surface | Why both ends matter |
| --- | --- |
| Provider base URLs (`ProviderRow`) | Host/region vs API path (`bedrock-runtime.us-east-2.amazonaws.com/…`) |
| MCP server URLs (`ToolCallTable`, `ContextUsageIndicator` MCP entries) | Origin + endpoint path |
| Template file tree (`TemplateFileTree`) | Folder prefix + filename in narrow editor sidebar |
| Resource metadata (`ResourceCard` / `CopyableValue`) | ARNs, image IDs, connection strings |
| Diff file headers (`DiffViewer`, `DiffFileHeader`) | Rename pairs, long monorepo paths |
| Workspace breadcrumbs (`WorkspaceTopbar`) | `owner / template / workspace` in `max-w-40` segments |

## Notable behaviour

- Splits input into grapheme clusters via `Intl.Segmenter` so multi-code-unit characters (emoji, combining marks) are never cut in half.
- Recalculates on container `ResizeObserver` and on `document.fonts` `loadingdone`, so it reflows on resize and after web fonts finish loading.
- Uses an off-screen measurement `<span>` and binary search over grapheme count; clears the measurement after each pass so it does not leak into `textContent` (this also keeps copy-paste and `getByText`-style queries clean).
- Full value is exposed on hover through the `title` attribute; pass `title={false}` to opt out.
- `TemplateFileTree` supports both string and JSX labels (via its `Label` prop). Middle truncation only applies to string labels; JSX labels keep the existing CSS truncation so their internal layout is preserved.
- `ResourceCard` values are rendered through Markdown, so `Truncate` is only wired in on the plain-string branch that also gets `CopyableValue`; markdown that contains inline formatting keeps the outer CSS fallback.

## Verification

- `pnpm check`, `pnpm lint:types`, `pnpm lint` clean.
- `pnpm test:storybook` for the affected story files (Truncate, ProviderRow, ToolCallTable, TemplateFileTree, ResourceCard, DiffViewer, WorkspaceTopbar): all 57 tests pass.
- Manual visual pass in Storybook for each surface. Truncate stories and `ResourceCard` "Bunch Of Metadata" story confirm middle truncation renders with the tooltip on hover. Other stories are laid out with short sample data, so truncation is not exercised visually there.

<details>
<summary>Design notes</summary>

The component follows the JSDoc contract on the container: it fills its parent's width, so callers constrain it through the parent (a flex item with `min-w-0`, a `max-w-*` cell, a grid track with `minmax(0, 1fr)`, etc.). This matches how every migrated surface already sized its content.

Why `title` and not `aria-label`:

- Biome's `useAriaPropsSupportedByRole` correctly flags `aria-label` on a plain `<span>` because the generic role does not support it.
- The alternative (a `sr-only` full-text sibling) duplicated the string in `textContent`, which broke existing `getByText` queries in `WorkspaceTopbar.stories.tsx`.
- `title` is what the original design specified and is enough here: the full value is always recoverable on hover and, on most screen readers, on focus.

</details>
