### PR TITLE
DNM: feat(coderd/searchquery): parse search filter for chats

### DIFF
--- a/coderd/searchquery/search.go
+++ b/coderd/searchquery/search.go
@@ -519,6 +519,8 @@ func Tasks(ctx context.Context, db database.Store, query string, actorID uuid.UU
 //     ownership scope; created_by_me returns only chats the caller owns,
 //     shared_with_me returns only chats shared with the caller, all returns
 //     both)
+//   - search: full-text search over chat content; single-valued and
+//     mutually exclusive with title, pr_title, and pr
 func Chats(query string) (database.GetChatsParams, []codersdk.ValidationError) {
 	filter := database.GetChatsParams{
 		// Default to hiding archived chats and chats not owned by the caller.
@@ -603,6 +605,38 @@ func Chats(query string) (database.GetChatsParams, []codersdk.ValidationError) {
 			})
 		} else {
 			filter.PrNumber = int32(n)
+		}
+	}
+
+	// search: performs full-text search and cannot be combined with the
+	// substring filters it replaces. Empty values are rejected because
+	// they would match nothing meaningful.
+	if values.Has("search") {
+		search := parser.String(values, "", "search")
+		if search == "" {
+			parser.Errors = append(parser.Errors, codersdk.ValidationError{
+				Field:  "search",
+				Detail: `Query param "search" cannot be empty`,
+			})
+		} else {
+			var conflicts []string
+			if filter.TitleQuery != "" {
+				conflicts = append(conflicts, `"title"`)
+			}
+			if filter.PrTitleQuery != "" {
+				conflicts = append(conflicts, `"pr_title"`)
+			}
+			if filter.PrNumber != 0 {
+				conflicts = append(conflicts, `"pr"`)
+			}
+			if len(conflicts) > 0 {
+				parser.Errors = append(parser.Errors, codersdk.ValidationError{
+					Field:  "search",
+					Detail: fmt.Sprintf(`"search" cannot be combined with %s`, strings.Join(conflicts, ", ")),
+				})
+			} else {
+				filter.Search = search
+			}
 		}
 	}
 

--- a/coderd/searchquery/search.go
+++ b/coderd/searchquery/search.go
@@ -519,8 +519,8 @@ func Tasks(ctx context.Context, db database.Store, query string, actorID uuid.UU
 //     ownership scope; created_by_me returns only chats the caller owns,
 //     shared_with_me returns only chats shared with the caller, all returns
 //     both)
-//   - search: full-text search over chat content; single-valued and
-//     mutually exclusive with title, pr_title, and pr
+//   - search: full-text search over chat content; mutually exclusive
+//     with title, pr_title, and pr
 func Chats(query string) (database.GetChatsParams, []codersdk.ValidationError) {
 	filter := database.GetChatsParams{
 		// Default to hiding archived chats and chats not owned by the caller.
@@ -608,17 +608,10 @@ func Chats(query string) (database.GetChatsParams, []codersdk.ValidationError) {
 		}
 	}
 
-	// search: performs full-text search and cannot be combined with the
-	// substring filters it replaces. Empty values are rejected because
-	// they would match nothing meaningful.
+	// search is mutually exclusive with the substring filters.
 	if values.Has("search") {
-		search := parser.String(values, "", "search")
-		if search == "" {
-			parser.Errors = append(parser.Errors, codersdk.ValidationError{
-				Field:  "search",
-				Detail: `Query param "search" cannot be empty`,
-			})
-		} else {
+		parser.RequiredNotEmpty("search")
+		if search := parser.String(values, "", "search"); search != "" {
 			var conflicts []string
 			if filter.TitleQuery != "" {
 				conflicts = append(conflicts, `"title"`)

--- a/coderd/searchquery/search.go
+++ b/coderd/searchquery/search.go
@@ -608,7 +608,6 @@ func Chats(query string) (database.GetChatsParams, []codersdk.ValidationError) {
 		}
 	}
 
-	// search is mutually exclusive with the substring filters.
 	if values.Has("search") {
 		parser.RequiredNotEmpty("search")
 		if search := parser.String(values, "", "search"); search != "" {

--- a/coderd/searchquery/search_test.go
+++ b/coderd/searchquery/search_test.go
@@ -1238,8 +1238,7 @@ func TestSearchChats(t *testing.T) {
 		Query                 string
 		Expected              database.GetChatsParams
 		ExpectedErrorContains string
-		// ExpectedErrorCount, when non-zero, asserts the exact number of
-		// validation errors.
+		// When non-zero, asserts the exact number of validation errors.
 		ExpectedErrorCount int
 	}{
 		{

--- a/coderd/searchquery/search_test.go
+++ b/coderd/searchquery/search_test.go
@@ -1597,6 +1597,89 @@ func TestSearchChats(t *testing.T) {
 			Query:                 "some random words",
 			ExpectedErrorContains: `unsupported search term: "some random words"`,
 		},
+		{
+			Name:  "Search",
+			Query: "search:foo",
+			Expected: database.GetChatsParams{
+				Archived:  sql.NullBool{Bool: false, Valid: true},
+				OwnedOnly: true,
+				Search:    "foo",
+			},
+		},
+		{
+			Name:  "SearchQuoted",
+			Query: `search:"foo bar"`,
+			Expected: database.GetChatsParams{
+				Archived:  sql.NullBool{Bool: false, Valid: true},
+				OwnedOnly: true,
+				Search:    "foo bar",
+			},
+		},
+		{
+			Name:  "SearchWithStructuralFilters",
+			Query: `repo:coder/coder archived:true search:"foo bar"`,
+			Expected: database.GetChatsParams{
+				Archived:  sql.NullBool{Bool: true, Valid: true},
+				OwnedOnly: true,
+				RepoQuery: "coder/coder",
+				Search:    "foo bar",
+			},
+		},
+		{
+			Name:  "SearchWithAllStructuralFilters",
+			Query: `search:foo archived:true repo:coder/coder diff_url:"https://github.com/coder/coder/pull/1" has_unread:true pr_status:open source:created_by_me`,
+			Expected: database.GetChatsParams{
+				Archived:            sql.NullBool{Bool: true, Valid: true},
+				OwnedOnly:           true,
+				RepoQuery:           "coder/coder",
+				DiffURL:             sql.NullString{String: "https://github.com/coder/coder/pull/1", Valid: true},
+				HasUnread:           sql.NullBool{Bool: true, Valid: true},
+				PullRequestStatuses: []string{"open"},
+				Search:              "foo",
+			},
+		},
+		{
+			Name:                  "SearchRepeated",
+			Query:                 "search:foo search:bar",
+			ExpectedErrorContains: `search: Query param "search" provided more than once`,
+		},
+		{
+			Name:                  "SearchConflictsWithTitle",
+			Query:                 "search:foo title:bar",
+			ExpectedErrorContains: `search: "search" cannot be combined with "title"`,
+		},
+		{
+			Name:                  "SearchConflictsWithPrTitle",
+			Query:                 "search:foo pr_title:bar",
+			ExpectedErrorContains: `search: "search" cannot be combined with "pr_title"`,
+		},
+		{
+			Name:                  "SearchConflictsWithPr",
+			Query:                 "search:foo pr:12",
+			ExpectedErrorContains: `search: "search" cannot be combined with "pr"`,
+		},
+		{
+			Name:                  "SearchConflictOrderIndependent",
+			Query:                 "title:bar search:foo",
+			ExpectedErrorContains: `search: "search" cannot be combined with "title"`,
+		},
+		{
+			Name:                  "SearchConflictsWithMultiple",
+			Query:                 "search:foo title:bar pr:12",
+			ExpectedErrorContains: `search: "search" cannot be combined with "title", "pr"`,
+		},
+		{
+			// A trailing colon is rejected by the tokenizer before the
+			// search filter is parsed.
+			Name:                  "SearchBareKey",
+			Query:                 "search:",
+			ExpectedErrorContains: "cannot start or end with ':'",
+		},
+		{
+			Name:                  "SearchEmptyQuoted",
+			Query:                 `search:""`,
+			ExpectedErrorContains: `search: Query param "search" cannot be empty`,
+		},
 	}
 
 	for _, c := range testCases {

--- a/coderd/searchquery/search_test.go
+++ b/coderd/searchquery/search_test.go
@@ -1238,6 +1238,9 @@ func TestSearchChats(t *testing.T) {
 		Query                 string
 		Expected              database.GetChatsParams
 		ExpectedErrorContains string
+		// ExpectedErrorCount, when non-zero, asserts the exact number of
+		// validation errors.
+		ExpectedErrorCount int
 	}{
 		{
 			Name:  "Empty",
@@ -1642,6 +1645,7 @@ func TestSearchChats(t *testing.T) {
 			Name:                  "SearchRepeated",
 			Query:                 "search:foo search:bar",
 			ExpectedErrorContains: `search: Query param "search" provided more than once`,
+			ExpectedErrorCount:    1,
 		},
 		{
 			Name:                  "SearchConflictsWithTitle",
@@ -1659,7 +1663,7 @@ func TestSearchChats(t *testing.T) {
 			ExpectedErrorContains: `search: "search" cannot be combined with "pr"`,
 		},
 		{
-			Name:                  "SearchConflictOrderIndependent",
+			Name:                  "SearchConflictsOrderIndependent",
 			Query:                 "title:bar search:foo",
 			ExpectedErrorContains: `search: "search" cannot be combined with "title"`,
 		},
@@ -1669,8 +1673,7 @@ func TestSearchChats(t *testing.T) {
 			ExpectedErrorContains: `search: "search" cannot be combined with "title", "pr"`,
 		},
 		{
-			// A trailing colon is rejected by the tokenizer before the
-			// search filter is parsed.
+			// The tokenizer rejects trailing colons before search validation runs.
 			Name:                  "SearchBareKey",
 			Query:                 "search:",
 			ExpectedErrorContains: "cannot start or end with ':'",
@@ -1678,7 +1681,8 @@ func TestSearchChats(t *testing.T) {
 		{
 			Name:                  "SearchEmptyQuoted",
 			Query:                 `search:""`,
-			ExpectedErrorContains: `search: Query param "search" cannot be empty`,
+			ExpectedErrorContains: `search: Query param "search" is required and cannot be empty`,
+			ExpectedErrorCount:    1,
 		},
 	}
 
@@ -1689,6 +1693,9 @@ func TestSearchChats(t *testing.T) {
 			values, errs := searchquery.Chats(c.Query)
 			if c.ExpectedErrorContains != "" {
 				require.True(t, len(errs) > 0, "expect some errors")
+				if c.ExpectedErrorCount > 0 {
+					require.Len(t, errs, c.ExpectedErrorCount, "expected exact error count")
+				}
 				var s strings.Builder
 				for _, err := range errs {
 					_, _ = s.WriteString(fmt.Sprintf("%s: %s\n", err.Field, err.Detail))


### PR DESCRIPTION
Adds `search:` parsing to `searchquery.Chats`, populating `GetChatsParams.Search`. The filter is single-valued, rejects empty values, and is mutually exclusive with `title:`, `pr_title:`, and `pr:` (the substring filters it replaces); the validation error names the conflicting filter(s) regardless of term order. Quoted values reuse the existing tokenizer. Parser only; SQL and handler wiring land separately.

Stack: #26968 <- #26995 <- #27009 <- this.

Refs https://linear.app/codercom/issue/CODAGT-723

<details>
<summary>Implementation plan</summary>

# CODAGT-723: Add `search:` parsing to searchquery.Chats

Issue: https://linear.app/codercom/issue/CODAGT-723
Depends on: `GetChatsParams.Search` generated in CODAGT-724 (PR #27009).
Branch: `cian/codagt-723-add-search-parsing-to-searchquerychats`, stacked on the 724 branch (stack: #26968 <- #26995 <- #27009 <- this).
Deliverable: one draft PR. Parser only; no SQL, no handler, no frontend.

## Requirements

Extend `Chats(query string)` in `coderd/searchquery/search.go` (~:522):

1. Parse `search:<value>` into `params.Search`. Quoted values (`search:"foo bar"`) must work exactly as they do for `title:` (the existing tokenizer handles quoting; reuse it).
2. Single-value rule: repeated `search:` terms return a validation error on field `search` (check how the existing parser reports repeated params; mirror it).
3. Mutual exclusion: `search:` combined with any of `title:`, `pr_title:`, `pr:` returns a validation error on `search` naming the conflicting filter(s). Check after parsing all terms so the error is deterministic regardless of term order.
4. Empty value (`search:` or `search:""`) returns a validation error on `search`.
5. Composes silently with `archived`, `repo`, `diff_url`, `has_unread`, `pr_status`, `source`.
6. Bare terms remain rejected (existing behavior, unchanged).

Out of scope, per ticket: the `websearch_to_tsquery` emptiness preflight (725's handler concern).

## Red: tests first

Table-driven cases in the existing parser test file, mirroring its style:

1. `search:foo` -> Search == "foo", no error.
2. `search:"foo bar"` -> Search == "foo bar".
3. `repo:coder/coder archived:true search:"foo bar"` -> Search set, Repo and Archived set, no error.
4. All structural filters together with `search:` -> no error.
5. `search:foo search:bar` -> validation error on `search`.
6. `search:foo title:bar`, `search:foo pr_title:bar`, `search:foo pr:12` -> validation error each; error message names the conflict.
7. Order independence: `title:bar search:foo` -> same error as 6.
8. `search:` and `search:""` -> validation error on `search`.
9. Regression: existing non-`search:` queries parse identically.

## Green: implementation

1. Add the parse + validations per Requirements; keep the change small and local to `Chats`.
2. `make gen` (expect no diff; parser only), `make fmt`, `make lint`, `make test RUN=<parser tests>`.

## Refactor

- If the mutual-exclusion validation duplicates an existing pattern in the file, align with it.
- Error message wording: match the file's existing voice; no novel phrasing.

## Verification

- Parser tests green; `make lint` clean.
- Draft PR stacked on #27009, plan in collapsible section, Coder Agents disclosure, link CODAGT-723.

</details>

---

Generated by Coder Agents on behalf of @johnstcn.
