### PR TITLE
fix(dogfood/coder): stop setting FIPS crypto-policies in workspace images

### DIFF
--- a/dogfood/coder/ubuntu-22.04/Dockerfile.base
+++ b/dogfood/coder/ubuntu-22.04/Dockerfile.base
@@ -42,7 +42,6 @@ RUN sed -i 's|http://archive.ubuntu.com/ubuntu/|http://mirrors.edge.kernel.org/u
 	build-essential \
 	ca-certificates \
 	containerd.io \
-	crypto-policies \
 	curl \
 	docker-ce \
 	docker-ce-cli \
@@ -107,9 +106,7 @@ RUN sed -i 's|http://archive.ubuntu.com/ubuntu/|http://mirrors.edge.kernel.org/u
 	zsh \
 	zstd && \
 	# Delete package cache to avoid consuming space in layer
-	apt-get clean && \
-	# Configure FIPS-compliant policies
-	update-crypto-policies --set FIPS
+	apt-get clean
 
 # Install Google Chrome directly from Google. Ubuntu 22.04 ships
 # chromium-browser as a snap-only package, which does not work in

--- a/dogfood/coder/ubuntu-26.04/Dockerfile.base
+++ b/dogfood/coder/ubuntu-26.04/Dockerfile.base
@@ -41,7 +41,6 @@ RUN sed -i 's|http://archive.ubuntu.com/ubuntu/|http://mirrors.edge.kernel.org/u
 	build-essential \
 	ca-certificates \
 	containerd.io \
-	crypto-policies \
 	curl \
 	docker-ce \
 	docker-ce-cli \
@@ -115,9 +114,7 @@ RUN sed -i 's|http://archive.ubuntu.com/ubuntu/|http://mirrors.edge.kernel.org/u
 		docker-ce-cli \
 		docker-compose-plugin && \
 	# Delete package cache to avoid consuming space in layer
-	apt-get clean && \
-	# Configure FIPS-compliant policies
-	update-crypto-policies --set FIPS
+	apt-get clean
 
 # Install Google Chrome directly from Google. Ubuntu 26.04 ships
 # chromium-browser as a snap-only package, which does not work in


### PR DESCRIPTION
## Problem

The dogfood workspace images run `update-crypto-policies --set FIPS` at build time. On Ubuntu 22.04 this had no effect on OpenSSH, but on Ubuntu 26.04 crypto-policies ships an OpenSSH client drop-in (`/etc/ssh/ssh_config.d/99-openssh-crypto-policies.conf`) that the client now honors. The FIPS policy excludes `ssh-ed25519` from `PubkeyAcceptedAlgorithms`, so ED25519 SSH keys are silently skipped inside 26.04 workspaces.

## Change

Remove the `update-crypto-policies --set FIPS` step and the `crypto-policies` package from both the ubuntu-26.04 and ubuntu-22.04 `Dockerfile.base`.

The line dates back to the original dogfood image and only configures the workspace's system crypto policy. It has no bearing on how Coder release artifacts are built: FIPS builds use the Go toolchain (`GOEXPERIMENT=boringcrypto` via `scripts/build_go.sh --boringcrypto`), and the Ironbank image configures its own crypto policies in `scripts/ironbank/Dockerfile`.

## Verification

- 26.04 image before: `ssh -G <host>` shows `pubkeyacceptedalgorithms` without `ssh-ed25519`; after: default OpenSSH list including `ssh-ed25519`.
- `update-crypto-policies --show` no longer reports `FIPS`.

---

_Generated by Coder Agents on behalf of @johnstcn._