### PR TITLE
fix(.github/workflows): raise docs indexer POST timeout to 300s

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -408,9 +408,14 @@ jobs:
           echo "Action: $ACTION  Ref: $REF  Mode: $MODE"
           RESPONSE=$(mktemp)
           RC=0
+          # A whole-branch reindex fetches and extracts a few hundred
+          # pages server-side and can run past two minutes. Keep
+          # --max-time in step with the docs indexer's server-side
+          # function budget so curl waits for the response instead of
+          # aborting mid-reindex and reporting a false timeout.
           HTTP_STATUS=$(curl --fail-with-body -sS \
             --connect-timeout 10 \
-            --max-time 120 \
+            --max-time 300 \
             -o "$RESPONSE" \
             -w '%{http_code}' \
             -X POST \


### PR DESCRIPTION
## Problem

The `algolia-and-isr` job's "POST to coder.com docs indexer" step aborts at `curl --max-time 120`. A whole-branch docs reindex fetches and extracts a few hundred pages server-side and runs longer than two minutes, so curl gives up before the handler responds:

```
curl: (28) Operation timed out after 120000 milliseconds
```

The step never receives the handler's result even though the server is still processing, so a legitimate reindex is reported as a failure.

## Fix

Raise `--max-time` on that POST from `120` to `300`, matching the indexer's server-side function budget so curl waits for the response instead of aborting mid-reindex.

- Only the Algolia indexer POST is changed.
- The `vercel-rebuild` deploy-hook curl is left at `120` (it returns immediately).
- No behavior change beyond the timeout. Validated with `actionlint`.

<details>
<summary>Rationale &amp; decision log</summary>

- The indexer handler performs an **atomic whole-branch reindex**: fetch the manifest, fetch + extract every navigable page, then replace the index slice. On a large ref that is a few hundred pages at concurrency 8, which comfortably exceeds the old 120s curl budget.
- `300s` aligns curl with the handler's own server-side function ceiling, so the workflow observes the real response (or a real error) instead of a false client-side timeout.
- The deploy-hook POST in `vercel-rebuild` only fires a webhook and returns immediately, so its timeout is intentionally left unchanged.
- If 300s later proves tight, the next levers are raising server-side extract concurrency (bounded by upstream raw-content rate limits) or moving the whole-branch reindex to an async job. Out of scope here.

</details>

---
> Opened as a **draft** by Coder Agents on behalf of @nickvigilante.
