### PR TITLE
feat: add opt-in dashboard client error reporting via Sentry

### DIFF
--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -600,6 +600,15 @@ client:
   # Hide AI tasks from the dashboard.
   # (default: false, type: bool)
   hideAITasks: false
+  # Internal and unsupported: Sentry DSN for dashboard client error reporting. When
+  # empty, client error reporting is disabled and no reporting code is loaded by the
+  # dashboard.
+  # (default: <unset>, type: string)
+  dashboardSentryDSN: ""
+  # Internal and unsupported: Sentry environment tag for dashboard client error
+  # reporting. Has no effect unless a dashboard Sentry DSN is configured.
+  # (default: <unset>, type: string)
+  dashboardSentryEnvironment: ""
 # Support links to display in the top right drop down menu.
 # (default: <unset>, type: struct[[]codersdk.LinkConfig])
 supportLinks: []

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -19343,6 +19343,12 @@ const docTemplate = `{
                 "dangerous": {
                     "$ref": "#/definitions/codersdk.DangerousConfig"
                 },
+                "dashboard_sentry_dsn": {
+                    "type": "string"
+                },
+                "dashboard_sentry_environment": {
+                    "type": "string"
+                },
                 "derp": {
                     "$ref": "#/definitions/codersdk.DERP"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -17532,6 +17532,12 @@
 				"dangerous": {
 					"$ref": "#/definitions/codersdk.DangerousConfig"
 				},
+				"dashboard_sentry_dsn": {
+					"type": "string"
+				},
+				"dashboard_sentry_environment": {
+					"type": "string"
+				},
 				"derp": {
 					"$ref": "#/definitions/codersdk.DERP"
 				},

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -716,6 +716,8 @@ func New(options *Options) *API {
 		Logger:            options.Logger.Named("site"),
 		HideAITasks:       options.DeploymentValues.HideAITasks.Value(),
 		AIGatewayEnabled:  options.DeploymentValues.AI.BridgeConfig.Enabled.Value(),
+		SentryDSN:         options.DeploymentValues.DashboardSentryDSN.String(),
+		SentryEnvironment: options.DeploymentValues.DashboardSentryEnvironment.String(),
 	})
 	if err != nil {
 		options.Logger.Fatal(ctx, "failed to initialize site handler", slog.Error(err))
@@ -2154,6 +2156,20 @@ func New(options *Options) *API {
 	additionalCSPHeaders[httpmw.CSPDirectiveImgSrc] = append(
 		additionalCSPHeaders[httpmw.CSPDirectiveImgSrc], "blob:",
 	)
+	// Allow the dashboard to deliver client error reports to the configured
+	// Sentry ingest origin. Deployments without a DSN keep the default CSP,
+	// which blocks any such egress.
+	if dsn := api.DeploymentValues.DashboardSentryDSN.String(); dsn != "" {
+		if origin, err := sentryIngestOrigin(dsn); err != nil {
+			api.Logger.Error(context.Background(),
+				"parsing dashboard Sentry DSN for CSP, client error reports may be blocked",
+				slog.Error(err))
+		} else {
+			additionalCSPHeaders[httpmw.CSPDirectiveConnectSrc] = append(
+				additionalCSPHeaders[httpmw.CSPDirectiveConnectSrc], origin,
+			)
+		}
+	}
 	// Add CSP headers to all static assets and pages. CSP headers only affect
 	// browsers, so these don't make sense on api routes.
 	cspProxyHosts := func() []*proxyhealth.ProxyHost {
@@ -2446,6 +2462,23 @@ func compressHandler(h http.Handler) http.Handler {
 	}
 
 	return cmp.Handler(h)
+}
+
+// sentryIngestOrigin returns the scheme and host of a Sentry DSN so it can
+// be added to the connect-src CSP directive. A DSN has the shape
+// https://<key>@<host>/<project-id>; events are delivered to the host.
+func sentryIngestOrigin(dsn string) (string, error) {
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return "", xerrors.Errorf("parse DSN: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", xerrors.Errorf("DSN scheme %q is not http or https", u.Scheme)
+	}
+	if u.Host == "" {
+		return "", xerrors.New("DSN has no host")
+	}
+	return u.Scheme + "://" + u.Host, nil
 }
 
 type MemoryProvisionerDaemonOption func(*memoryProvisionerDaemonOptions)

--- a/coderd/coderd_internal_test.go
+++ b/coderd/coderd_internal_test.go
@@ -78,3 +78,54 @@ func TestChatDaemonPublishDiffStatusChangeFunc(t *testing.T) {
 	fn := chatDaemonPublishDiffStatusChangeFunc(nil)
 	require.Nil(t, fn, "func value must be a true nil, not a bound method on a nil receiver")
 }
+
+func TestSentryIngestOrigin(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		dsn     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "HTTPSWithKey",
+			dsn:  "https://abc123@o450.ingest.sentry.example/42",
+			want: "https://o450.ingest.sentry.example",
+		},
+		{
+			name: "HTTPSelfHosted",
+			dsn:  "http://key@sentry.internal:9000/1",
+			want: "http://sentry.internal:9000",
+		},
+		{
+			name:    "NonHTTPScheme",
+			dsn:     "ftp://key@host/1",
+			wantErr: true,
+		},
+		{
+			name:    "NoHost",
+			dsn:     "https:///1",
+			wantErr: true,
+		},
+		{
+			name:    "NotAURL",
+			dsn:     "::not-a-url",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := sentryIngestOrigin(tt.dsn)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/coderd/coderd_test.go
+++ b/coderd/coderd_test.go
@@ -263,6 +263,49 @@ func TestHealthz(t *testing.T) {
 	assert.Equal(t, "OK", string(body))
 }
 
+func TestDashboardSentryCSP(t *testing.T) {
+	t.Parallel()
+
+	fetchCSP := func(t *testing.T, client *codersdk.Client) string {
+		res, err := client.Request(context.Background(), http.MethodGet, "/", nil)
+		require.NoError(t, err)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		return res.Header.Get("Content-Security-Policy")
+	}
+
+	t.Run("DisabledByDefault", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, nil)
+		csp := fetchCSP(t, client)
+		require.NotEmpty(t, csp)
+		require.NotContains(t, csp, "sentry")
+	})
+
+	t.Run("ConnectSrcIncludesIngestOrigin", func(t *testing.T) {
+		t.Parallel()
+
+		dv := coderdtest.DeploymentValues(t)
+		dv.DashboardSentryDSN = "https://key@o1.ingest.sentry.example/1"
+		client := coderdtest.New(t, &coderdtest.Options{
+			DeploymentValues: dv,
+		})
+
+		csp := fetchCSP(t, client)
+		require.Contains(t, csp, "https://o1.ingest.sentry.example")
+		connectSrc := ""
+		for _, directive := range strings.Split(csp, ";") {
+			if strings.Contains(directive, "connect-src") {
+				connectSrc = directive
+				break
+			}
+		}
+		require.Contains(t, connectSrc, "https://o1.ingest.sentry.example",
+			"ingest origin must be part of connect-src")
+	})
+}
+
 // TestAIGatewayDisabledStartupAndShutdown verifies the server starts and
 // shuts down cleanly when the AI Gateway is disabled, leaving api.chatDaemon
 // nil. It exercises the startup path (git sync worker callback binding, see

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -684,6 +684,8 @@ type DeploymentValues struct {
 	WorkspaceHostnameSuffix                 serpent.String                       `json:"workspace_hostname_suffix,omitempty" typescript:",notnull"`
 	Prebuilds                               PrebuildsConfig                      `json:"workspace_prebuilds,omitempty" typescript:",notnull"`
 	HideAITasks                             serpent.Bool                         `json:"hide_ai_tasks,omitempty" typescript:",notnull"`
+	DashboardSentryDSN                      serpent.String                       `json:"dashboard_sentry_dsn,omitempty" typescript:",notnull"`
+	DashboardSentryEnvironment              serpent.String                       `json:"dashboard_sentry_environment,omitempty" typescript:",notnull"`
 	AI                                      AIConfig                             `json:"ai,omitempty"`
 	StatsCollection                         StatsCollectionConfig                `json:"stats_collection,omitempty" typescript:",notnull"`
 	TemplateBuilder                         TemplateBuilderConfig                `json:"template_builder,omitempty"`
@@ -4251,6 +4253,28 @@ Write out the current server config as YAML to stdout.`,
 			Value:       &c.HideAITasks,
 			Group:       &deploymentGroupClient,
 			YAML:        "hideAITasks",
+		},
+		{
+			Name:        "Dashboard Sentry DSN",
+			Description: "Internal and unsupported: Sentry DSN for dashboard client error reporting. When empty, client error reporting is disabled and no reporting code is loaded by the dashboard.",
+			Flag:        "dashboard-sentry-dsn",
+			Env:         "CODER_DASHBOARD_SENTRY_DSN",
+			Default:     "",
+			Value:       &c.DashboardSentryDSN,
+			Group:       &deploymentGroupClient,
+			YAML:        "dashboardSentryDSN",
+			Hidden:      true,
+		},
+		{
+			Name:        "Dashboard Sentry Environment",
+			Description: "Internal and unsupported: Sentry environment tag for dashboard client error reporting. Has no effect unless a dashboard Sentry DSN is configured.",
+			Flag:        "dashboard-sentry-environment",
+			Env:         "CODER_DASHBOARD_SENTRY_ENVIRONMENT",
+			Default:     "",
+			Value:       &c.DashboardSentryEnvironment,
+			Group:       &deploymentGroupClient,
+			YAML:        "dashboardSentryEnvironment",
+			Hidden:      true,
 		},
 		// Chat Options
 		{

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -248,6 +248,8 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
       "allow_path_app_sharing": true,
       "allow_path_app_site_owner_access": true
     },
+    "dashboard_sentry_dsn": "string",
+    "dashboard_sentry_environment": "string",
     "derp": {
       "config": {
         "block_direct": true,

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -5693,6 +5693,8 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
       "allow_path_app_sharing": true,
       "allow_path_app_site_owner_access": true
     },
+    "dashboard_sentry_dsn": "string",
+    "dashboard_sentry_environment": "string",
     "derp": {
       "config": {
         "block_direct": true,
@@ -6302,6 +6304,8 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "allow_path_app_sharing": true,
     "allow_path_app_site_owner_access": true
   },
+  "dashboard_sentry_dsn": "string",
+  "dashboard_sentry_environment": "string",
   "derp": {
     "config": {
       "block_direct": true,
@@ -6725,6 +6729,8 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `config`                                       | string                                                                                               | false    |              |                                                                    |
 | `config_ssh`                                   | [codersdk.SSHConfig](#codersdksshconfig)                                                             | false    |              |                                                                    |
 | `dangerous`                                    | [codersdk.DangerousConfig](#codersdkdangerousconfig)                                                 | false    |              |                                                                    |
+| `dashboard_sentry_dsn`                         | string                                                                                               | false    |              |                                                                    |
+| `dashboard_sentry_environment`                 | string                                                                                               | false    |              |                                                                    |
 | `derp`                                         | [codersdk.DERP](#codersdkderp)                                                                       | false    |              |                                                                    |
 | `disable_chat_sharing`                         | boolean                                                                                              | false    |              |                                                                    |
 | `disable_owner_workspace_exec`                 | boolean                                                                                              | false    |              |                                                                    |

--- a/site/index.html
+++ b/site/index.html
@@ -30,6 +30,7 @@
 	<meta property="logo-url" content="{{ .LogoURL }}" />
 	<meta property="tasks-tab-visible" content="{{ .TasksTabVisible }}" />
 	<meta property="ai-gateway-enabled" content="{{ .AIGatewayEnabled }}" />
+	<meta property="sentry-config" content="{{ .SentryConfig }}" />
 	<meta property="permissions" content="{{ .Permissions }}" />
 	<meta property="organizations" content="{{ .Organizations }}" />
 	<link

--- a/site/package.json
+++ b/site/package.json
@@ -60,6 +60,7 @@
 		"@novnc/novnc": "^1.5.0",
 		"@pierre/diffs": "1.2.7",
 		"@pierre/trees": "1.0.0-beta.4",
+		"@sentry/react": "10.64.0",
 		"@tanstack/react-query-devtools": "5.77.0",
 		"@xterm/addon-canvas": "0.7.0",
 		"@xterm/addon-fit": "0.11.0",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       '@pierre/trees':
         specifier: 1.0.0-beta.4
         version: 1.0.0-beta.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@sentry/react':
+        specifier: 10.64.0
+        version: 10.64.0(react@19.2.6)
       '@tanstack/react-query-devtools':
         specifier: 5.77.0
         version: 5.77.0(@tanstack/react-query@5.77.0(react@19.2.6))(react@19.2.6)
@@ -2411,6 +2414,40 @@ packages:
     peerDependenciesMeta:
       rollup:
         optional: true
+
+  '@sentry/browser-utils@10.64.0':
+    resolution: {integrity: sha512-qXvUpsZdE0+6SovhDZvjN4JkqQEpzeYsrOF5g63wMsqJWWv2vW/pQZIlJs0F6C0t4q5AHZL4fl5rNkvpVqFdKA==, tarball: https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.64.0.tgz}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@10.64.0':
+    resolution: {integrity: sha512-CHZ7+79evh8knBtVHjW/XqV3mRaWs2TdjX7i55zpFe9vcNngQHV++0ss8ird/xfMY1mfCDtbyAN+Z6XY2o5aJA==, tarball: https://registry.npmjs.org/@sentry/browser/-/browser-10.64.0.tgz}
+    engines: {node: '>=18'}
+
+  '@sentry/conventions@0.15.1':
+    resolution: {integrity: sha512-ZLP8bRdMON3prWE2tJyImuYscCxdcJeIPIhrOs/rgyFm3C1nCh1B6gdvPj3AZ5zW08oSFFCsq7T+tYEW3h8MNA==, tarball: https://registry.npmjs.org/@sentry/conventions/-/conventions-0.15.1.tgz}
+    engines: {node: '>=14'}
+
+  '@sentry/core@10.64.0':
+    resolution: {integrity: sha512-HjojJcXD1l2qZ1AXje2s0XY/nYsaUt00wsM1HMBImA8vAClyPisFE/CC0/UD6pEvsGFhVgi8Dcxo7EN41uyeFw==, tarball: https://registry.npmjs.org/@sentry/core/-/core-10.64.0.tgz}
+    engines: {node: '>=18'}
+
+  '@sentry/feedback@10.64.0':
+    resolution: {integrity: sha512-YrmKwRoAto+nwo26DoAhnpNmhkrVkuQFIAXqlTD8ipERjhcSNUYJAkAB+nH4w1KIgm9QQZE1sTq3iNQdPl1XMQ==, tarball: https://registry.npmjs.org/@sentry/feedback/-/feedback-10.64.0.tgz}
+    engines: {node: '>=18'}
+
+  '@sentry/react@10.64.0':
+    resolution: {integrity: sha512-oShEKcosBKdm0kgan8suFb6Jj8poccEyDz2qiflonq/5/hUDyzdVeKfFzf0b1MmdjWSn9k3hfrLNFfPNCuEt7Q==, tarball: https://registry.npmjs.org/@sentry/react/-/react-10.64.0.tgz}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.14.0 || 17.x || 18.x || 19.x
+
+  '@sentry/replay-canvas@10.64.0':
+    resolution: {integrity: sha512-EioBwcnnhtPiXzTZJTbZKaMEg3qNM5YZlX1VanoXomPATqfJD62cb/M27zhgiWXXJ7e8/NGVHvwNDYGrqsN39g==, tarball: https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.64.0.tgz}
+    engines: {node: '>=18'}
+
+  '@sentry/replay@10.64.0':
+    resolution: {integrity: sha512-q8nke2GDSwEiu1zYoctDDvnSNTjHWoVAKo2JXTleD0nwOO6IlAgUYmsm3qEQiSW7BVla9W1TRbW6ChFAUXYZbw==, tarball: https://registry.npmjs.org/@sentry/replay/-/replay-10.64.0.tgz}
+    engines: {node: '>=18'}
 
   '@shikijs/core@3.23.0':
     resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==, tarball: https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz}
@@ -8513,6 +8550,44 @@ snapshots:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.4
+
+  '@sentry/browser-utils@10.64.0':
+    dependencies:
+      '@sentry/core': 10.64.0
+
+  '@sentry/browser@10.64.0':
+    dependencies:
+      '@sentry/browser-utils': 10.64.0
+      '@sentry/core': 10.64.0
+      '@sentry/feedback': 10.64.0
+      '@sentry/replay': 10.64.0
+      '@sentry/replay-canvas': 10.64.0
+
+  '@sentry/conventions@0.15.1': {}
+
+  '@sentry/core@10.64.0':
+    dependencies:
+      '@sentry/conventions': 0.15.1
+
+  '@sentry/feedback@10.64.0':
+    dependencies:
+      '@sentry/core': 10.64.0
+
+  '@sentry/react@10.64.0(react@19.2.6)':
+    dependencies:
+      '@sentry/browser': 10.64.0
+      '@sentry/core': 10.64.0
+      react: 19.2.6
+
+  '@sentry/replay-canvas@10.64.0':
+    dependencies:
+      '@sentry/core': 10.64.0
+      '@sentry/replay': 10.64.0
+
+  '@sentry/replay@10.64.0':
+    dependencies:
+      '@sentry/browser-utils': 10.64.0
+      '@sentry/core': 10.64.0
 
   '@shikijs/core@3.23.0':
     dependencies:

--- a/site/site.go
+++ b/site/site.go
@@ -84,6 +84,10 @@ type Options struct {
 	Logger            slog.Logger
 	HideAITasks       bool
 	AIGatewayEnabled  bool
+	// SentryDSN enables dashboard client error reporting when non-empty.
+	// Internal and unsupported; used only by Coder-operated deployments.
+	SentryDSN         string
+	SentryEnvironment string
 }
 
 func New(opts *Options) (*Handler, error) {
@@ -130,6 +134,17 @@ func New(opts *Options) (*Handler, error) {
 	handler.buildInfoJSON = html.EscapeString(string(buildInfoResponse))
 	handler.handler = mux.ServeHTTP
 
+	if opts.SentryDSN != "" {
+		sentryConfigResponse, err := json.Marshal(sentryConfig{
+			DSN:         opts.SentryDSN,
+			Environment: opts.SentryEnvironment,
+		})
+		if err != nil {
+			return nil, xerrors.Errorf("failed to marshal sentry config: %w", err)
+		}
+		handler.sentryConfigJSON = html.EscapeString(string(sentryConfigResponse))
+	}
+
 	handler.installScript, err = parseInstallScript(opts.SiteFS, opts.BuildInfo)
 	if err != nil {
 		opts.Logger.Warn(context.Background(), "could not parse install.sh, it will be unavailable", slog.Error(err))
@@ -145,7 +160,10 @@ type Handler struct {
 	handler       http.HandlerFunc
 	htmlTemplates *template.Template
 	buildInfoJSON string
-	installScript []byte
+	// sentryConfigJSON is the pre-escaped sentry-config metadata payload,
+	// or empty when client error reporting is disabled.
+	sentryConfigJSON string
+	installScript    []byte
 
 	// RegionsFetcher will attempt to fetch the more detailed WorkspaceProxy data, but will fall back to the
 	// regions if the user does not have the correct permissions.
@@ -170,6 +188,9 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		CSRF:      csrfState{Token: nosurf.Token(r)},
 		BuildInfo: h.buildInfoJSON,
 		DocsURL:   h.opts.DocsURL,
+		// Empty for deployments that have not opted in to client error
+		// reporting, in which case the dashboard loads no reporting code.
+		SentryConfig: h.sentryConfigJSON,
 	}
 
 	// First check if it's a file we have in our templates
@@ -269,12 +290,20 @@ type htmlState struct {
 
 	TasksTabVisible  string
 	AIGatewayEnabled string
+	SentryConfig     string
 	Permissions      string
 	Organizations    string
 }
 
 type csrfState struct {
 	Token string
+}
+
+// sentryConfig is the payload of the sentry-config metadata tag consumed
+// by the dashboard to initialize client error reporting.
+type sentryConfig struct {
+	DSN         string `json:"dsn"`
+	Environment string `json:"environment,omitempty"`
 }
 
 func ShouldCacheFile(reqFile string) bool {

--- a/site/site_test.go
+++ b/site/site_test.go
@@ -159,6 +159,61 @@ func TestInjection(t *testing.T) {
 	require.Equal(t, db2sdk.User(user, []uuid.UUID{}), got)
 }
 
+func TestInjectionSentryConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		dsn         string
+		environment string
+		want        string
+	}{
+		{
+			name: "DisabledByDefault",
+			want: "",
+		},
+		{
+			name:        "DSNAndEnvironment",
+			dsn:         "https://key@ingest.sentry.example/1",
+			environment: "dogfood",
+			want:        `{"dsn":"https://key@ingest.sentry.example/1","environment":"dogfood"}`,
+		},
+		{
+			name: "DSNOnlyOmitsEnvironment",
+			dsn:  "https://key@ingest.sentry.example/1",
+			want: `{"dsn":"https://key@ingest.sentry.example/1"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			siteFS := fstest.MapFS{
+				"index.html": &fstest.MapFile{
+					Data: []byte("{{ .SentryConfig }}"),
+				},
+			}
+			db, _ := dbtestutil.NewDB(t)
+			handler, err := site.New(&site.Options{
+				Telemetry:         telemetry.NewNoop(),
+				Database:          db,
+				SiteFS:            siteFS,
+				SentryDSN:         tt.dsn,
+				SentryEnvironment: tt.environment,
+			})
+			require.NoError(t, err)
+
+			r := httptest.NewRequest("GET", "/", nil)
+			rw := httptest.NewRecorder()
+
+			handler.ServeHTTP(rw, r)
+			require.Equal(t, http.StatusOK, rw.Code)
+			require.Equal(t, tt.want, html.UnescapeString(rw.Body.String()))
+		})
+	}
+}
+
 func TestInjectionUserAppearance(t *testing.T) {
 	t.Parallel()
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -4447,6 +4447,8 @@ export interface DeploymentValues {
 	readonly workspace_hostname_suffix?: string;
 	readonly workspace_prebuilds?: PrebuildsConfig;
 	readonly hide_ai_tasks?: boolean;
+	readonly dashboard_sentry_dsn?: string;
+	readonly dashboard_sentry_environment?: string;
 	readonly ai?: AIConfig;
 	readonly stats_collection?: StatsCollectionConfig;
 	readonly template_builder?: TemplateBuilderConfig;

--- a/site/src/hooks/useEmbeddedMetadata.test.ts
+++ b/site/src/hooks/useEmbeddedMetadata.test.ts
@@ -4,6 +4,7 @@ import {
 	MockAIGatewayEnabled,
 	MockAppearanceConfig,
 	MockBuildInfo,
+	MockClientErrorReportingConfig,
 	MockEntitlements,
 	MockExperiments,
 	MockOrganization,
@@ -47,6 +48,7 @@ const mockDataForTags = {
 	regions: MockRegions,
 	"tasks-tab-visible": MockTasksTabVisible,
 	"ai-gateway-enabled": MockAIGatewayEnabled,
+	"sentry-config": MockClientErrorReportingConfig,
 	permissions: MockPermissions,
 	organizations: [MockOrganization],
 } as const satisfies Record<MetadataKey, MetadataValue>;
@@ -85,6 +87,10 @@ const emptyMetadata: RuntimeHtmlMetadata = {
 		value: undefined,
 	},
 	"ai-gateway-enabled": {
+		available: false,
+		value: undefined,
+	},
+	"sentry-config": {
 		available: false,
 		value: undefined,
 	},
@@ -134,6 +140,10 @@ const populatedMetadata: RuntimeHtmlMetadata = {
 	"ai-gateway-enabled": {
 		available: true,
 		value: MockAIGatewayEnabled,
+	},
+	"sentry-config": {
+		available: true,
+		value: MockClientErrorReportingConfig,
 	},
 	permissions: {
 		available: true,

--- a/site/src/hooks/useEmbeddedMetadata.ts
+++ b/site/src/hooks/useEmbeddedMetadata.ts
@@ -13,6 +13,16 @@ import type { Permissions } from "#/modules/permissions";
 export const DEFAULT_METADATA_KEY = "property";
 
 /**
+ * Configuration for dashboard client error reporting, rendered by the Go
+ * server only when a deployment explicitly opts in. Absent for all other
+ * deployments, in which case no reporting code is loaded.
+ */
+export interface ClientErrorReportingConfig {
+	readonly dsn: string;
+	readonly environment?: string;
+}
+
+/**
  * This is the set of values that are currently being exposed to the React
  * application during production. These values are embedded via the Go server,
  * so they will never exist when using a JavaScript runtime for the backend
@@ -33,6 +43,7 @@ type AvailableMetadata = Readonly<{
 	"build-info": BuildInfoResponse;
 	"tasks-tab-visible": boolean;
 	"ai-gateway-enabled": boolean;
+	"sentry-config": ClientErrorReportingConfig;
 	permissions: Permissions;
 	organizations: Organization[];
 }>;
@@ -98,6 +109,8 @@ export class MetadataManager implements MetadataManagerApi {
 			regions: this.registerRegionValue(),
 			"tasks-tab-visible": this.registerValue<boolean>("tasks-tab-visible"),
 			"ai-gateway-enabled": this.registerValue<boolean>("ai-gateway-enabled"),
+			"sentry-config":
+				this.registerValue<ClientErrorReportingConfig>("sentry-config"),
 			permissions: this.registerValue<Permissions>("permissions"),
 			organizations: this.registerValue<Organization[]>("organizations"),
 		};

--- a/site/src/index.tsx
+++ b/site/src/index.tsx
@@ -1,6 +1,7 @@
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import { App } from "./App";
+import { defaultMetadataManager } from "./hooks/useEmbeddedMetadata";
 
 console.info(`      -#######          +######-      ########+       ##########  ########+.      ###########
    +#####--######    +#####--#####+   ############    ##########  ####+++#####-   ###########
@@ -30,6 +31,20 @@ window.addEventListener("vite:preloadError", () => {
 const element = document.getElementById("root");
 if (element === null) {
 	throw new Error("root element is null");
+}
+
+// Client error reporting is opt-in per deployment. The Sentry chunk is
+// only fetched when the server rendered a sentry-config metadata tag;
+// every other deployment loads no reporting code at all.
+const embeddedMetadata = defaultMetadataManager.getMetadata();
+const clientErrorReportingConfig = embeddedMetadata["sentry-config"].value;
+if (clientErrorReportingConfig) {
+	const buildInfo = embeddedMetadata["build-info"].value;
+	void import("./telemetry/sentry")
+		.then((sentry) => sentry.init(clientErrorReportingConfig, buildInfo))
+		.catch(() => {
+			// Reporting is best-effort and must never block boot.
+		});
 }
 
 // The service worker handles push notifications.

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -36,6 +36,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type * as TypesGen from "#/api/typesGenerated";
 import { MockChat } from "#/testHelpers/chatEntities";
 import { createTestQueryClient } from "#/testHelpers/renderHelpers";
+import { reportClientError } from "#/utils/clientErrorReporting";
 import type { OneWayMessageEvent } from "#/utils/OneWayWebSocket";
 import {
 	selectChatStatus,
@@ -56,6 +57,10 @@ vi.mock("#/api/api", () => ({
 	watchChat: vi.fn(),
 }));
 
+vi.mock("#/utils/clientErrorReporting", () => ({
+	reportClientError: vi.fn(),
+}));
+
 type MessageListener = (
 	payload: OneWayMessageEvent<TypesGen.ChatStreamEvent[]>,
 ) => void;
@@ -69,7 +74,7 @@ type MockSocketHelpers = {
 	emitOpen: () => void;
 	emitData: (event: TypesGen.ChatStreamEvent) => void;
 	emitDataBatch: (events: readonly TypesGen.ChatStreamEvent[]) => void;
-	emitParseError: () => void;
+	emitParseError: (rawFrame?: string) => void;
 	emitError: () => void;
 	emitClose: () => void;
 };
@@ -165,9 +170,9 @@ const createMockSocket = (): MockSocket => {
 				listener(payload);
 			}
 		},
-		emitParseError: () => {
+		emitParseError: (rawFrame?: string) => {
 			const payload: OneWayMessageEvent<TypesGen.ChatStreamEvent[]> = {
-				sourceEvent: {} as MessageEvent<string>,
+				sourceEvent: { data: rawFrame } as MessageEvent<string>,
 				parseError: new Error("bad json"),
 				parsedMessage: undefined,
 			};
@@ -5167,5 +5172,64 @@ describe("parse errors", () => {
 			kind: "generic",
 			message: "Failed to parse chat stream update.",
 		});
+	});
+
+	it("reports parse errors with the raw frame for investigation", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-parse-report";
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const wrapper = createWrapper(queryClient);
+		const setChatErrorReason = vi.fn();
+		const clearChatErrorReason = vi.fn();
+
+		const { result } = renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [],
+					chatRecord: buildChat(chatID),
+					chatMessagesData: {
+						messages: [],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason,
+					clearChatErrorReason,
+				});
+				return {
+					streamError: useChatSelector(store, selectStreamError),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
+		});
+
+		act(() => {
+			mockSocket.emitParseError("{ not valid json");
+		});
+
+		await waitFor(() => {
+			expect(result.current.streamError).toEqual({
+				kind: "generic",
+				message: "Failed to parse chat stream update.",
+			});
+		});
+
+		expect(reportClientError).toHaveBeenLastCalledWith(
+			expect.objectContaining({ message: "bad json" }),
+			{
+				chatId: chatID,
+				frameSnippet: "{ not valid json",
+				frameLength: "16",
+			},
+		);
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -13,6 +13,7 @@ import {
 	updateInfiniteChatsCache,
 } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
+import { reportClientError } from "#/utils/clientErrorReporting";
 import type { OneWayMessageEvent } from "#/utils/OneWayWebSocket";
 import { createReconnectingWebSocket } from "#/utils/reconnectingWebSocket";
 import type { ChatDetailError } from "../../utils/usageLimitMessage";
@@ -446,6 +447,20 @@ export const useChatStore = (
 				return;
 			}
 			if (payload.parseError || !payload.parsedMessage) {
+				console.error("Failed to parse chat stream update", payload.parseError);
+				// The event data is typed as string, but binary frames
+				// surface as Blob at runtime; normalize for reporting.
+				const frame: unknown = payload.sourceEvent.data;
+				const frameText = typeof frame === "string" ? frame : String(frame);
+				reportClientError(
+					payload.parseError ??
+						new Error("chat stream frame parsed to a falsy value"),
+					{
+						chatId: chatID,
+						frameSnippet: frameText,
+						frameLength: String(frameText.length),
+					},
+				);
 				store.setStreamError({
 					kind: "generic",
 					message: "Failed to parse chat stream update.",

--- a/site/src/telemetry/sentry.ts
+++ b/site/src/telemetry/sentry.ts
@@ -1,0 +1,43 @@
+/**
+ * Sentry-backed sink for client error reporting. This module is loaded
+ * exclusively via dynamic import, and only when the deployment renders a
+ * sentry-config metadata tag. Deployments without the config never fetch
+ * this chunk or the Sentry SDK.
+ */
+import * as Sentry from "@sentry/react";
+import type { BuildInfoResponse } from "#/api/typesGenerated";
+import type { ClientErrorReportingConfig } from "#/hooks/useEmbeddedMetadata";
+import { registerClientErrorSink } from "#/utils/clientErrorReporting";
+
+// Integrations that capture uncaught exceptions and instrument browser
+// APIs globally. Reporting is intentionally limited to explicit
+// reportClientError call sites, so these are removed from the defaults.
+const GLOBAL_CAPTURE_INTEGRATIONS = ["GlobalHandlers", "BrowserApiErrors"];
+
+export const init = (
+	config: ClientErrorReportingConfig,
+	buildInfo?: BuildInfoResponse,
+): void => {
+	Sentry.init({
+		dsn: config.dsn,
+		environment: config.environment,
+		release: buildInfo?.version,
+		// No user identification, request bodies, or headers.
+		sendDefaultPii: false,
+		// Errors only: no tracing, no session replay.
+		tracesSampleRate: 0,
+		integrations: (defaults) =>
+			defaults.filter(
+				(integration) =>
+					!GLOBAL_CAPTURE_INTEGRATIONS.includes(integration.name),
+			),
+		// Console breadcrumbs can contain chat content; drop them entirely.
+		beforeBreadcrumb: (breadcrumb) =>
+			breadcrumb.category === "console" ? null : breadcrumb,
+		maxValueLength: 2048,
+	});
+
+	registerClientErrorSink((error, context) => {
+		Sentry.captureException(error, { extra: context });
+	});
+};

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -621,6 +621,10 @@ export const MockUserSecrets: TypesGen.UserSecret[] = [
 
 export const MockTasksTabVisible: boolean = false;
 export const MockAIGatewayEnabled: boolean = true;
+export const MockClientErrorReportingConfig = {
+	dsn: "https://mock-key@mock.ingest.sentry.example/1",
+	environment: "mock",
+} as const;
 
 export const MockOrganizationMember: TypesGen.OrganizationMemberWithUserData = {
 	organization_id: MockOrganization.id,

--- a/site/src/utils/clientErrorReporting.test.ts
+++ b/site/src/utils/clientErrorReporting.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	registerClientErrorSink,
+	reportClientError,
+} from "./clientErrorReporting";
+
+describe("reportClientError", () => {
+	afterEach(() => {
+		// Unregister by installing a throwaway sink so tests stay isolated.
+		registerClientErrorSink(() => {});
+	});
+
+	it("is a no-op when no sink is registered", () => {
+		// Nothing to assert beyond "does not throw"; the module starts
+		// without a sink in production until the telemetry chunk loads.
+		expect(() => reportClientError(new Error("boom"))).not.toThrow();
+	});
+
+	it("forwards the error and context to the registered sink", () => {
+		const sink = vi.fn();
+		registerClientErrorSink(sink);
+
+		const error = new Error("boom");
+		reportClientError(error, { chatId: "chat-1" });
+
+		expect(sink).toHaveBeenCalledWith(error, { chatId: "chat-1" });
+	});
+
+	it("truncates oversized context values", () => {
+		const sink = vi.fn();
+		registerClientErrorSink(sink);
+
+		const oversized = "x".repeat(5000);
+		reportClientError(new Error("boom"), { frameSnippet: oversized });
+
+		const [, context] = sink.mock.calls[0];
+		expect(context.frameSnippet).toHaveLength(2048 + "...[truncated]".length);
+		expect(context.frameSnippet.endsWith("...[truncated]")).toBe(true);
+	});
+
+	it("swallows sink failures", () => {
+		registerClientErrorSink(() => {
+			throw new Error("sink exploded");
+		});
+
+		expect(() => reportClientError(new Error("boom"))).not.toThrow();
+	});
+});

--- a/site/src/utils/clientErrorReporting.ts
+++ b/site/src/utils/clientErrorReporting.ts
@@ -1,0 +1,45 @@
+/**
+ * Client error reporting seam. `reportClientError` is safe to call from
+ * anywhere in the app: it forwards to a sink registered by the lazily
+ * loaded telemetry module and is a no-op when no sink is registered,
+ * which is the case for every deployment that has not opted in to
+ * client error reporting.
+ */
+
+const MAX_CONTEXT_VALUE_LENGTH = 2048;
+
+type ClientErrorContext = Readonly<Record<string, string>>;
+
+type ClientErrorSink = (error: unknown, context: ClientErrorContext) => void;
+
+let sink: ClientErrorSink | undefined;
+
+export const registerClientErrorSink = (newSink: ClientErrorSink): void => {
+	sink = newSink;
+};
+
+/**
+ * Forwards an error and its context to the registered sink, truncating
+ * context values so oversized payloads (e.g. raw stream frames) never
+ * leave the browser in full.
+ */
+export const reportClientError = (
+	error: unknown,
+	context: ClientErrorContext = {},
+): void => {
+	if (!sink) {
+		return;
+	}
+	const truncated: Record<string, string> = {};
+	for (const [key, value] of Object.entries(context)) {
+		truncated[key] =
+			value.length > MAX_CONTEXT_VALUE_LENGTH
+				? `${value.slice(0, MAX_CONTEXT_VALUE_LENGTH)}...[truncated]`
+				: value;
+	}
+	try {
+		sink(error, truncated);
+	} catch {
+		// Reporting must never break the app.
+	}
+};


### PR DESCRIPTION
Adds opt-in client-side error reporting for the dashboard via Sentry, gated per deployment at runtime. Investigating a "Failed to parse chat stream update" error in the agent chat UI hit a dead end because the frontend discards the parse error and the offending WebSocket frame; nothing is recorded anywhere a developer can look at later. This change gives Coder-operated deployments (e.g. dogfood) a way to capture that evidence.

Two hidden deployment values control it: `CODER_DASHBOARD_SENTRY_DSN` (empty = disabled, the default) and `CODER_DASHBOARD_SENTRY_ENVIRONMENT`. When a DSN is set, coderd renders a `sentry-config` metadata tag into `index.html` and appends the DSN's ingest origin to the `connect-src` CSP directive. The dashboard bootstrap dynamically imports the Sentry module only when that metadata is present, so disabled deployments never fetch the chunk (verified: Sentry lands in a separate 85 kB lazy chunk, absent from the main bundle) and their unchanged CSP structurally blocks any egress. No flag, no docs entry, no settings UI: customers see no product-surface change.

Reporting is limited to explicit `reportClientError()` call sites; global exception handlers, tracing, session replay, and console breadcrumbs are disabled, PII is off, and all context values are truncated. The first instrumented site is the chat stream parse-error branch, which now also logs to the console and reports the failing frame snippet plus chat ID.

<details>
<summary>Implementation plan</summary>

## Background

Investigating a "Request failed: Failed to parse chat stream update." banner in the agent chat UI hit a dead end: the frontend (`useChatStore.ts`) discards the parse error and the offending WebSocket frame, and no client-side evidence is recorded anywhere. Server logs cannot explain it because the write succeeds from coderd's perspective.

Decision: add client-side error reporting via Sentry, activated per deployment at runtime. In practice only Coder's own deployments enable it. Customers must see no product-surface change: when disabled there is no bundle download, no data egress, and no Sentry project required.

## Goals

- Capture handled UI errors (starting with the chat stream parse error) with enough context to investigate later: error message, truncated raw frame snippet, chat ID, release version.
- Zero cost when disabled: Sentry chunk never fetched, no network egress, CSP unchanged, nothing in `coder server --help` or generated docs.
- One small, reusable `reportClientError()` seam so future call sites do not couple to Sentry directly.

## Non-goals

- Global uncaught-exception capture, tracing, session replay (all off).
- A customer-facing feature: no docs, no settings UI, no entitlement.
- Source map upload to Sentry (follow-up; errors still group by message).
- First-party log-ingestion endpoint (rejected earlier in favor of Sentry).

## Design

1. Hidden deployment values (both `Hidden: true`, out of `--help` and docs):
   - `CODER_DASHBOARD_SENTRY_DSN` (default empty). Empty means disabled.
   - `CODER_DASHBOARD_SENTRY_ENVIRONMENT` (default empty). Deployments set their own value (e.g. `dogfood`); multiple Coder-operated environments can share one Sentry project and be distinguished by this tag.
2. coderd passes both to the site handler; `site/index.html` gets a single `<meta property="sentry-config">` tag containing `{ "dsn": string, "environment": string }` (HTML-escaped, empty for customers).
3. `useEmbeddedMetadata` registers `"sentry-config"`; absence resolves to `{ value: undefined, available: false }`.
4. App bootstrap checks the metadata and only then dynamically imports the Sentry module. Vite code-splits it; disabled deployments never fetch the chunk.
5. CSP: when (and only when) the DSN is configured, coderd appends the DSN's ingest origin to `connect-src`. Customer deployments keep today's CSP, so egress is structurally blocked even in the presence of bugs.
6. `reportClientError()` no-op sink in the main bundle; the lazy Sentry module registers itself as the sink on init. `useChatStore` calls it from the parse-error branch and also logs to the console.

## Privacy rules

- Never attach full chat payloads; only truncated frame snippets, and only for the parse-error path where content is by definition malformed.
- `sendDefaultPii: false`; no user identification.
- Console breadcrumbs disabled; no request/response bodies.

## Rollout (ops, outside this repo)

- Create one Sentry project owned by Coder; restrict allowed domains to the enabled deployments' hostnames and set rate limits.
- Set `CODER_DASHBOARD_SENTRY_DSN` and `CODER_DASHBOARD_SENTRY_ENVIRONMENT` on dev.coder.com.
- Follow-up (separate): upload source maps from the build dogfood runs for readable stack traces.

## Decision log

- Sentry over first-party endpoint: investigation UX (grouping, history, alerting) outweighs building/maintaining ingestion, given only Coder-operated deployments use it.
- Runtime gate over build-time exclusion: dogfood runs `main` preview builds; divergent builds would leak into preview images anyway and add CI complexity. Dynamic import gives the same "no bundle when off" property.
- CSP derived from DSN rather than requiring `--additional-csp-policy`: removes a silent-breakage failure mode where events are dropped by CSP.
- Sentry environment comes from config, not hardcoded: multiple Coder-operated environments exist, and one shared Sentry project with an environment tag per deployment is simpler than one project each.

## Accepted caveats

- coder/coder is public: the code and the unused lazy chunk in release assets are visible in source. Invisible in product surfaces only.
- The DSN appears in enabled deployments' page source; DSNs are public client keys, mitigated by allowed domains + rate limits.
- Admins can technically see the empty config knob via the deployment config API; it is undocumented and defaults off.

</details>

---

🤖 This PR was generated by Coder Agents on behalf of @jaaydenh.
