### PR TITLE
feat: identify chat stream connections for error correlation

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -17714,6 +17714,15 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.ChatStreamConnected": {
+            "type": "object",
+            "properties": {
+                "stream_id": {
+                    "type": "string",
+                    "format": "uuid"
+                }
+            }
+        },
         "codersdk.ChatStreamEvent": {
             "type": "object",
             "properties": {
@@ -17745,6 +17754,9 @@ const docTemplate = `{
                 "status": {
                     "$ref": "#/definitions/codersdk.ChatStreamStatus"
                 },
+                "stream_connected": {
+                    "$ref": "#/definitions/codersdk.ChatStreamConnected"
+                },
                 "type": {
                     "$ref": "#/definitions/codersdk.ChatStreamEventType"
                 }
@@ -17761,7 +17773,8 @@ const docTemplate = `{
                 "retry",
                 "action_required",
                 "preview_reset",
-                "history_reset"
+                "history_reset",
+                "stream_connected"
             ],
             "x-enum-varnames": [
                 "ChatStreamEventTypeMessagePart",
@@ -17772,7 +17785,8 @@ const docTemplate = `{
                 "ChatStreamEventTypeRetry",
                 "ChatStreamEventTypeActionRequired",
                 "ChatStreamEventTypePreviewReset",
-                "ChatStreamEventTypeHistoryReset"
+                "ChatStreamEventTypeHistoryReset",
+                "ChatStreamEventTypeStreamConnected"
             ]
         },
         "codersdk.ChatStreamMessagePart": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -15963,6 +15963,15 @@
 				}
 			}
 		},
+		"codersdk.ChatStreamConnected": {
+			"type": "object",
+			"properties": {
+				"stream_id": {
+					"type": "string",
+					"format": "uuid"
+				}
+			}
+		},
 		"codersdk.ChatStreamEvent": {
 			"type": "object",
 			"properties": {
@@ -15994,6 +16003,9 @@
 				"status": {
 					"$ref": "#/definitions/codersdk.ChatStreamStatus"
 				},
+				"stream_connected": {
+					"$ref": "#/definitions/codersdk.ChatStreamConnected"
+				},
 				"type": {
 					"$ref": "#/definitions/codersdk.ChatStreamEventType"
 				}
@@ -16010,7 +16022,8 @@
 				"retry",
 				"action_required",
 				"preview_reset",
-				"history_reset"
+				"history_reset",
+				"stream_connected"
 			],
 			"x-enum-varnames": [
 				"ChatStreamEventTypeMessagePart",
@@ -16021,7 +16034,8 @@
 				"ChatStreamEventTypeRetry",
 				"ChatStreamEventTypeActionRequired",
 				"ChatStreamEventTypePreviewReset",
-				"ChatStreamEventTypeHistoryReset"
+				"ChatStreamEventTypeHistoryReset",
+				"ChatStreamEventTypeStreamConnected"
 			]
 		},
 		"codersdk.ChatStreamMessagePart": {

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -3564,7 +3564,15 @@ func (api *API) streamChat(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	chat := httpmw.ChatParam(r)
 	chatID := chat.ID
-	logger := api.Logger.Named("chat_streamer").With(slog.F("chat_id", chatID))
+	// streamID identifies this stream connection. It is logged with every
+	// server-side stream log line and sent to the client as the first
+	// stream event so client error reports can be correlated with server
+	// logs for the exact connection.
+	streamID := uuid.New()
+	logger := api.Logger.Named("chat_streamer").With(
+		slog.F("chat_id", chatID),
+		slog.F("stream_id", streamID),
+	)
 
 	if !api.requireChatDaemon(ctx, rw) {
 		return
@@ -3630,6 +3638,16 @@ func (api *API) streamChat(rw http.ResponseWriter, r *http.Request) {
 			return nil
 		}
 		return encoder.Encode(batch)
+	}
+
+	logger.Debug(ctx, "chat stream connected")
+	if err := sendChatStreamBatch([]codersdk.ChatStreamEvent{{
+		Type:            codersdk.ChatStreamEventTypeStreamConnected,
+		ChatID:          chatID,
+		StreamConnected: &codersdk.ChatStreamConnected{StreamID: streamID},
+	}}); err != nil {
+		logger.Debug(ctx, "failed to send chat stream connected event", slog.Error(err))
+		return
 	}
 
 	drainChatStreamBatch := func(

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -8305,6 +8305,44 @@ func TestPatchChatMessage(t *testing.T) {
 func TestStreamChat(t *testing.T) {
 	t.Parallel()
 
+	t.Run("StreamConnectedFirst", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newChatClient(t)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
+		_ = createChatModelConfig(t, client)
+
+		chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
+			OrganizationID: firstUser.OrganizationID,
+			Content: []codersdk.ChatInputPart{
+				{
+					Type: codersdk.ChatInputPartTypeText,
+					Text: "stream connected initial message",
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		events, closer, err := client.StreamChat(ctx, chat.ID, nil)
+		require.NoError(t, err)
+		defer closer.Close()
+
+		// The stream_connected event must be the very first event on
+		// every connection so clients always know the stream ID before
+		// anything can go wrong.
+		select {
+		case <-ctx.Done():
+			require.FailNow(t, "timed out waiting for first stream event")
+		case event, ok := <-events:
+			require.True(t, ok, "stream closed before first event")
+			require.Equal(t, codersdk.ChatStreamEventTypeStreamConnected, event.Type)
+			require.Equal(t, chat.ID, event.ChatID)
+			require.NotNil(t, event.StreamConnected)
+			require.NotEqual(t, uuid.Nil, event.StreamConnected.StreamID)
+		}
+	})
+
 	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
 

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -1578,15 +1578,16 @@ func IsChatGitWatchFallbackMessage(msg string) bool {
 type ChatStreamEventType string
 
 const (
-	ChatStreamEventTypeMessagePart    ChatStreamEventType = "message_part"
-	ChatStreamEventTypeMessage        ChatStreamEventType = "message"
-	ChatStreamEventTypeStatus         ChatStreamEventType = "status"
-	ChatStreamEventTypeError          ChatStreamEventType = "error"
-	ChatStreamEventTypeQueueUpdate    ChatStreamEventType = "queue_update"
-	ChatStreamEventTypeRetry          ChatStreamEventType = "retry"
-	ChatStreamEventTypeActionRequired ChatStreamEventType = "action_required"
-	ChatStreamEventTypePreviewReset   ChatStreamEventType = "preview_reset"
-	ChatStreamEventTypeHistoryReset   ChatStreamEventType = "history_reset"
+	ChatStreamEventTypeMessagePart     ChatStreamEventType = "message_part"
+	ChatStreamEventTypeMessage         ChatStreamEventType = "message"
+	ChatStreamEventTypeStatus          ChatStreamEventType = "status"
+	ChatStreamEventTypeError           ChatStreamEventType = "error"
+	ChatStreamEventTypeQueueUpdate     ChatStreamEventType = "queue_update"
+	ChatStreamEventTypeRetry           ChatStreamEventType = "retry"
+	ChatStreamEventTypeActionRequired  ChatStreamEventType = "action_required"
+	ChatStreamEventTypePreviewReset    ChatStreamEventType = "preview_reset"
+	ChatStreamEventTypeHistoryReset    ChatStreamEventType = "history_reset"
+	ChatStreamEventTypeStreamConnected ChatStreamEventType = "stream_connected"
 )
 
 // ChatQueuedMessage represents a queued message waiting to be processed.
@@ -1610,6 +1611,14 @@ type ChatStreamMessagePart struct {
 // ChatStreamStatus represents an updated chat status.
 type ChatStreamStatus struct {
 	Status ChatStatus `json:"status"`
+}
+
+// ChatStreamConnected identifies a single server-side stream connection.
+// It is the first event on every stream so that clients can reference the
+// connection in error reports and correlate them with server logs, which
+// include the same stream ID.
+type ChatStreamConnected struct {
+	StreamID uuid.UUID `json:"stream_id" format:"uuid"`
 }
 
 // ChatErrorKind classifies chat errors for consistent client rendering.
@@ -1793,15 +1802,16 @@ type ChatWatchEvent struct {
 
 // ChatStreamEvent represents a real-time update for chat streaming.
 type ChatStreamEvent struct {
-	Type           ChatStreamEventType       `json:"type"`
-	ChatID         uuid.UUID                 `json:"chat_id" format:"uuid"`
-	Message        *ChatMessage              `json:"message,omitempty"`
-	MessagePart    *ChatStreamMessagePart    `json:"message_part,omitempty"`
-	Status         *ChatStreamStatus         `json:"status,omitempty"`
-	Error          *ChatError                `json:"error,omitempty"`
-	Retry          *ChatStreamRetry          `json:"retry,omitempty"`
-	QueuedMessages []ChatQueuedMessage       `json:"queued_messages,omitempty"`
-	ActionRequired *ChatStreamActionRequired `json:"action_required,omitempty"`
+	Type            ChatStreamEventType       `json:"type"`
+	ChatID          uuid.UUID                 `json:"chat_id" format:"uuid"`
+	Message         *ChatMessage              `json:"message,omitempty"`
+	MessagePart     *ChatStreamMessagePart    `json:"message_part,omitempty"`
+	Status          *ChatStreamStatus         `json:"status,omitempty"`
+	Error           *ChatError                `json:"error,omitempty"`
+	Retry           *ChatStreamRetry          `json:"retry,omitempty"`
+	QueuedMessages  []ChatQueuedMessage       `json:"queued_messages,omitempty"`
+	ActionRequired  *ChatStreamActionRequired `json:"action_required,omitempty"`
+	StreamConnected *ChatStreamConnected      `json:"stream_connected,omitempty"`
 }
 
 // ChatCostSummaryOptions are optional query parameters for GetChatCostSummary.

--- a/docs/reference/api/chats.md
+++ b/docs/reference/api/chats.md
@@ -2655,6 +2655,9 @@ Experimental: this endpoint is subject to change.
   "status": {
     "status": "waiting"
   },
+  "stream_connected": {
+    "stream_id": "173fd1b7-72c4-44c4-9244-55a0a167a352"
+  },
   "type": "message_part"
 }
 ```

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -3421,6 +3421,20 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 |--------------|---------------------------------------------------------------------|----------|--------------|-------------|
 | `tool_calls` | array of [codersdk.ChatStreamToolCall](#codersdkchatstreamtoolcall) | false    |              |             |
 
+## codersdk.ChatStreamConnected
+
+```json
+{
+  "stream_id": "173fd1b7-72c4-44c4-9244-55a0a167a352"
+}
+```
+
+### Properties
+
+| Name        | Type   | Required | Restrictions | Description |
+|-------------|--------|----------|--------------|-------------|
+| `stream_id` | string | false    |              |             |
+
 ## codersdk.ChatStreamEvent
 
 ```json
@@ -3676,23 +3690,27 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
   "status": {
     "status": "waiting"
   },
+  "stream_connected": {
+    "stream_id": "173fd1b7-72c4-44c4-9244-55a0a167a352"
+  },
   "type": "message_part"
 }
 ```
 
 ### Properties
 
-| Name              | Type                                                                   | Required | Restrictions | Description |
-|-------------------|------------------------------------------------------------------------|----------|--------------|-------------|
-| `action_required` | [codersdk.ChatStreamActionRequired](#codersdkchatstreamactionrequired) | false    |              |             |
-| `chat_id`         | string                                                                 | false    |              |             |
-| `error`           | [codersdk.ChatError](#codersdkchaterror)                               | false    |              |             |
-| `message`         | [codersdk.ChatMessage](#codersdkchatmessage)                           | false    |              |             |
-| `message_part`    | [codersdk.ChatStreamMessagePart](#codersdkchatstreammessagepart)       | false    |              |             |
-| `queued_messages` | array of [codersdk.ChatQueuedMessage](#codersdkchatqueuedmessage)      | false    |              |             |
-| `retry`           | [codersdk.ChatStreamRetry](#codersdkchatstreamretry)                   | false    |              |             |
-| `status`          | [codersdk.ChatStreamStatus](#codersdkchatstreamstatus)                 | false    |              |             |
-| `type`            | [codersdk.ChatStreamEventType](#codersdkchatstreameventtype)           | false    |              |             |
+| Name               | Type                                                                   | Required | Restrictions | Description |
+|--------------------|------------------------------------------------------------------------|----------|--------------|-------------|
+| `action_required`  | [codersdk.ChatStreamActionRequired](#codersdkchatstreamactionrequired) | false    |              |             |
+| `chat_id`          | string                                                                 | false    |              |             |
+| `error`            | [codersdk.ChatError](#codersdkchaterror)                               | false    |              |             |
+| `message`          | [codersdk.ChatMessage](#codersdkchatmessage)                           | false    |              |             |
+| `message_part`     | [codersdk.ChatStreamMessagePart](#codersdkchatstreammessagepart)       | false    |              |             |
+| `queued_messages`  | array of [codersdk.ChatQueuedMessage](#codersdkchatqueuedmessage)      | false    |              |             |
+| `retry`            | [codersdk.ChatStreamRetry](#codersdkchatstreamretry)                   | false    |              |             |
+| `status`           | [codersdk.ChatStreamStatus](#codersdkchatstreamstatus)                 | false    |              |             |
+| `stream_connected` | [codersdk.ChatStreamConnected](#codersdkchatstreamconnected)           | false    |              |             |
+| `type`             | [codersdk.ChatStreamEventType](#codersdkchatstreameventtype)           | false    |              |             |
 
 ## codersdk.ChatStreamEventType
 
@@ -3704,9 +3722,9 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 #### Enumerated Values
 
-| Value(s)                                                                                                                   |
-|----------------------------------------------------------------------------------------------------------------------------|
-| `action_required`, `error`, `history_reset`, `message`, `message_part`, `preview_reset`, `queue_update`, `retry`, `status` |
+| Value(s)                                                                                                                                       |
+|------------------------------------------------------------------------------------------------------------------------------------------------|
+| `action_required`, `error`, `history_reset`, `message`, `message_part`, `preview_reset`, `queue_update`, `retry`, `status`, `stream_connected` |
 
 ## codersdk.ChatStreamMessagePart
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2971,6 +2971,17 @@ export interface ChatStreamActionRequired {
 
 // From codersdk/chats.go
 /**
+ * ChatStreamConnected identifies a single server-side stream connection.
+ * It is the first event on every stream so that clients can reference the
+ * connection in error reports and correlate them with server logs, which
+ * include the same stream ID.
+ */
+export interface ChatStreamConnected {
+	readonly stream_id: string;
+}
+
+// From codersdk/chats.go
+/**
  * ChatStreamEvent represents a real-time update for chat streaming.
  */
 export interface ChatStreamEvent {
@@ -2983,6 +2994,7 @@ export interface ChatStreamEvent {
 	readonly retry?: ChatStreamRetry;
 	readonly queued_messages?: readonly ChatQueuedMessage[];
 	readonly action_required?: ChatStreamActionRequired;
+	readonly stream_connected?: ChatStreamConnected;
 }
 
 // From codersdk/chats.go
@@ -2995,7 +3007,8 @@ export type ChatStreamEventType =
 	| "preview_reset"
 	| "queue_update"
 	| "retry"
-	| "status";
+	| "status"
+	| "stream_connected";
 
 export const ChatStreamEventTypes: ChatStreamEventType[] = [
 	"action_required",
@@ -3007,6 +3020,7 @@ export const ChatStreamEventTypes: ChatStreamEventType[] = [
 	"queue_update",
 	"retry",
 	"status",
+	"stream_connected",
 ];
 
 // From codersdk/chats.go

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -5227,9 +5227,79 @@ describe("parse errors", () => {
 			expect.objectContaining({ message: "bad json" }),
 			{
 				chatId: chatID,
+				streamId: "unknown",
 				frameSnippet: "{ not valid json",
 				frameLength: "16",
 			},
+		);
+	});
+
+	it("includes the server stream ID in parse error reports", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-parse-report-stream-id";
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const wrapper = createWrapper(queryClient);
+		const setChatErrorReason = vi.fn();
+		const clearChatErrorReason = vi.fn();
+
+		const { result } = renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [],
+					chatRecord: buildChat(chatID),
+					chatMessagesData: {
+						messages: [],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason,
+					clearChatErrorReason,
+				});
+				return {
+					streamError: useChatSelector(store, selectStreamError),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
+		});
+
+		// The server sends stream_connected as the first event on every
+		// connection.
+		const streamID = "b7a7ae12-5f8e-4a5a-9e0e-2f9f8a3d1c4b";
+		act(() => {
+			mockSocket.emitData({
+				type: "stream_connected",
+				chat_id: chatID,
+				stream_connected: { stream_id: streamID },
+			});
+		});
+
+		act(() => {
+			mockSocket.emitParseError("garbage frame");
+		});
+
+		await waitFor(() => {
+			expect(result.current.streamError).toEqual({
+				kind: "generic",
+				message: "Failed to parse chat stream update.",
+			});
+		});
+
+		expect(reportClientError).toHaveBeenLastCalledWith(
+			expect.objectContaining({ message: "bad json" }),
+			expect.objectContaining({
+				chatId: chatID,
+				streamId: streamID,
+			}),
 		);
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -388,6 +388,13 @@ export const useChatStore = (
 		let historyResetPending = false;
 		const historyReplacementBuf: TypesGen.ChatMessage[] = [];
 
+		// ID of the current server-side stream connection, taken from
+		// the stream_connected event the server sends first on every
+		// connection (including reconnects). Included in error reports
+		// so they can be correlated with server logs, which carry the
+		// same stream ID.
+		let serverStreamID: string | undefined;
+
 		const shouldApplyMessagePart = (): boolean => {
 			const currentStatus = store.getSnapshot().chatStatus;
 			return currentStatus !== "pending" && currentStatus !== "waiting";
@@ -457,6 +464,7 @@ export const useChatStore = (
 						new Error("chat stream frame parsed to a falsy value"),
 					{
 						chatId: chatID,
+						streamId: serverStreamID ?? "unknown",
 						frameSnippet: frameText,
 						frameLength: String(frameText.length),
 					},
@@ -496,6 +504,10 @@ export const useChatStore = (
 			// are notified exactly once at the end, not per event.
 			store.batch(() => {
 				for (const streamEvent of streamEvents) {
+					if (streamEvent.type === "stream_connected") {
+						serverStreamID = streamEvent.stream_connected?.stream_id;
+						continue;
+					}
 					if (streamEvent.type === "message_part") {
 						if (streamEvent.chat_id && streamEvent.chat_id !== chatID) {
 							continue;


### PR DESCRIPTION
Stacked on #27096. When the dashboard reports a chat stream error (such as the parse failure that motivated the reporting seam), there is still no way to find the exact server-side connection that produced the bad frame: browsers cannot attach or read headers on WebSocket upgrades, so trace propagation is unavailable for this path.

This change assigns each chat stream connection a server-generated UUID. coderd includes it in every stream log line and sends it in-band as the first event on the stream (`stream_connected`). The dashboard records the ID and attaches it to client error reports, so a report can be matched to the exact connection in server logs.

Adding an event type is additive and safe for existing consumers: the frontend event loop ignores unknown types, and the scaletest chat client's switch has no default case. Event types have been added the same way before (`history_reset`, `action_required`).

<details>
<summary>Design notes</summary>

- Trace propagation is impossible for browser WebSocket upgrades (custom headers cannot be set or read), so an in-band per-connection ID is the reliable alternative.
- The server sends the ID as the first event on every connection, including reconnects, so the client knows the current connection's ID before any frame can fail to parse.
- The `chat_streamer` logger carries `stream_id` alongside `chat_id` on every line, so a report's `streamId` locates the exact connection, not just the chat.
- The frontend keeps the ID in effect scope and reports `"unknown"` when a parse error arrives before `stream_connected`, for example when the very first frame is the one that fails.

</details>

---

🤖 This PR was generated by Coder Agents on behalf of @jaaydenh.
