### PR TITLE
fix(site): stop popover heading from overlapping provisioner tag fields

### DIFF
--- a/site/src/pages/TemplateVersionEditorPage/ProvisionerTagsPopover.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ProvisionerTagsPopover.tsx
@@ -49,6 +49,10 @@ export const ProvisionerTagsPopover: FC<ProvisionerTagsPopoverProps> = ({
 							// lg:flex-col counters the default FormContext
 							// direction ("horizontal") which adds lg:flex-row.
 							root: "flex-col lg:flex-col gap-4 lg:gap-4",
+							// The horizontal direction also adds lg:sticky, which
+							// pins the title to the viewport inside the popover and
+							// overlaps the tag fields.
+							sectionInfo: "lg:static",
 						}}
 						title="Provisioner Tags"
 						description={

--- a/site/src/pages/TemplateVersionEditorPage/ProvisionerTagsPopover.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ProvisionerTagsPopover.tsx
@@ -3,7 +3,7 @@ import useTheme from "@mui/system/useTheme";
 import type { FC } from "react";
 import type { ProvisionerDaemon } from "#/api/typesGenerated";
 import { ChevronDownIcon } from "#/components/AnimatedIcons/ChevronDown";
-import { FormSection } from "#/components/Form/Form";
+import { FormSection, VerticalForm } from "#/components/Form/Form";
 import { TopbarButton } from "#/components/FullPageLayout/Topbar";
 import {
 	Popover,
@@ -43,34 +43,32 @@ export const ProvisionerTagsPopover: FC<ProvisionerTagsPopoverProps> = ({
 						borderBottom: `1px solid ${theme.palette.divider}`,
 					}}
 				>
-					<FormSection
-						classes={{
-							// Override lg:gap-6 from FormSection defaults. The
-							// lg:flex-col counters the default FormContext
-							// direction ("horizontal") which adds lg:flex-row.
-							root: "flex-col lg:flex-col gap-4 lg:gap-4",
-							// The horizontal direction also adds lg:sticky, which
-							// pins the title to the viewport inside the popover and
-							// overlaps the tag fields.
-							sectionInfo: "lg:static",
-						}}
-						title="Provisioner Tags"
-						description={
-							<>
-								Tags are a way to control which provisioner daemons complete
-								which build jobs.&nbsp;
-								<Link
-									href={docs("/admin/provisioners")}
-									target="_blank"
-									rel="noreferrer"
-								>
-									Learn more...
-								</Link>
-							</>
-						}
-					>
-						<ProvisionerTagsField value={tags} onChange={onTagsChange} />
-					</FormSection>
+					<VerticalForm>
+						<FormSection
+							classes={{
+								// Override lg:gap-6 from FormSection defaults. The
+								// lg:flex-col counters the default FormContext
+								// direction ("horizontal") which adds lg:flex-row.
+								root: "flex-col lg:flex-col gap-4 lg:gap-4",
+							}}
+							title="Provisioner Tags"
+							description={
+								<>
+									Tags are a way to control which provisioner daemons complete
+									which build jobs.&nbsp;
+									<Link
+										href={docs("/admin/provisioners")}
+										target="_blank"
+										rel="noreferrer"
+									>
+										Learn more...
+									</Link>
+								</>
+							}
+						>
+							<ProvisionerTagsField value={tags} onChange={onTagsChange} />
+						</FormSection>
+					</VerticalForm>
 				</div>
 			</PopoverContent>
 		</Popover>


### PR DESCRIPTION
#26907 had site-wide repercussions on sticky positioning, including the `FormSection` heading in the provisioner tags popover pins itself to the viewport and was landing on top of the tags, because it used `FormSection` (which defaults to the horizontal direction, which adds `lg:sticky`, and the popover uses it outside a `Form`). forcing it to use a vertical form direction fixes it. 🙃 chromatic/pixel's default snapshot size is too small to hit the breakpoint that allows this, which is an interesting thing for me to ponder on.

<table>
<tbody>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>
<img width="333" height="281" alt="Screenshot 2026-07-07 at 6 20 47 PM" src="https://github.com/user-attachments/assets/3f893934-fb0c-4273-ab89-207fe35fed61" />
</td>
<td>
<img width="318" height="262" alt="Screenshot 2026-07-08 at 1 54 13 PM" src="https://github.com/user-attachments/assets/d941ac89-b76c-418e-a60d-542eac8ccac9" />
</td>
</tr>
</tbody>
</table>
