### PR TITLE
feat(site/src/pages/AISettingsPage): add WIF fields to Anthropic provider form

### DIFF
--- a/site/src/pages/AISettingsPage/ProvidersPage/UpdateProviderPage/UpdateProviderPageView.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/UpdateProviderPage/UpdateProviderPageView.tsx
@@ -27,6 +27,7 @@ import {
 	getProviderDisplayType,
 	hasBedrockStoredCredentials,
 	isBedrockProvider,
+	isWIFProvider,
 	providerFormValuesToUpdate,
 } from "../components/providerFormApiMap";
 
@@ -45,11 +46,13 @@ const UpdateProviderPageView: React.FC = () => {
 	});
 
 	const provider = providerQuery.data;
-	// Copilot has no stored credential, and Bedrock keeps its secrets in
-	// settings, so only the remaining types surface the api_keys UI.
+	// Copilot has no stored credential, Bedrock keeps its secrets in
+	// settings, and WIF authenticates via a federation token, so only the
+	// remaining types surface the api_keys UI.
 	const providerUsesApiKeys =
 		provider !== undefined &&
 		!isBedrockProvider(provider) &&
+		!isWIFProvider(provider) &&
 		provider.type !== "copilot";
 
 	const updateMutation = useMutation(

--- a/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderForm.stories.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderForm.stories.tsx
@@ -390,6 +390,92 @@ export const EditOpenAiAnthropicNoSavedKey: Story = {
 	},
 };
 
+// Selecting WIF on an Anthropic provider hides the API key field and
+// reveals the federation inputs, and the create payload carries them.
+export const AddAnthropicWIF: Story = {
+	args: {
+		initialValues: { type: "anthropic" },
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+
+		// The API key field shows by default.
+		await canvas.findByRole("textbox", { name: /api key/i });
+
+		const wifRadio = canvas.getByRole("radio", {
+			name: /workload identity federation/i,
+		});
+		await userEvent.click(wifRadio);
+
+		// The API key field is replaced by the WIF inputs.
+		expect(
+			canvas.queryByRole("textbox", { name: /api key/i }),
+		).not.toBeInTheDocument();
+		await userEvent.type(
+			canvas.getByLabelText(/federation rule id/i),
+			"fdrl_01ABCDEFGHIJKLMNOPQRSTUV",
+		);
+		await userEvent.type(
+			canvas.getByLabelText(/organization id/i),
+			"11111111-2222-3333-4444-555555555555",
+		);
+		await userEvent.type(
+			canvas.getByLabelText(/identity token file/i),
+			"/var/run/secrets/anthropic/token",
+		);
+
+		const submitButton = canvas.getByRole("button", {
+			name: /add provider/i,
+		});
+		await waitFor(() => expect(submitButton).toBeEnabled());
+		await userEvent.click(submitButton);
+
+		await waitFor(() =>
+			expect(args.onSubmit).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: "anthropic",
+					wifEnabled: true,
+					federationRuleId: "fdrl_01ABCDEFGHIJKLMNOPQRSTUV",
+					organizationId: "11111111-2222-3333-4444-555555555555",
+					identityTokenFile: "/var/run/secrets/anthropic/token",
+				}),
+			),
+		);
+	},
+};
+
+// Editing a stored WIF provider seeds the federation inputs and never
+// shows the API key field.
+export const EditAnthropicWIF: Story = {
+	args: {
+		editing: true,
+		initialValues: {
+			type: "anthropic",
+			wifEnabled: true,
+			name: "anthropic-wif",
+			displayName: "Anthropic WIF",
+			baseUrl: "https://api.anthropic.com",
+			federationRuleId: "fdrl_01ABCDEFGHIJKLMNOPQRSTUV",
+			organizationId: "11111111-2222-3333-4444-555555555555",
+			identityTokenFile: "/var/run/secrets/anthropic/token",
+			serviceAccountId: "svac_01ABCDEFGHIJKLMNOPQRSTUV",
+			enabled: true,
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const federationRuleId =
+			await canvas.findByLabelText(/federation rule id/i);
+		expect(federationRuleId).toHaveValue("fdrl_01ABCDEFGHIJKLMNOPQRSTUV");
+		expect(canvas.getByLabelText(/identity token file/i)).toHaveValue(
+			"/var/run/secrets/anthropic/token",
+		);
+		expect(
+			canvas.queryByRole("textbox", { name: /api key/i }),
+		).not.toBeInTheDocument();
+	},
+};
+
 export const Submitting: Story = {
 	args: {
 		isLoading: true,
@@ -428,7 +514,9 @@ export const CredentialFocusClear: Story = {
 	},
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
-		const apiKeyInput = await canvas.findByLabelText(/api key/i);
+		const apiKeyInput = await canvas.findByRole("textbox", {
+			name: /api key/i,
+		});
 
 		expect(apiKeyInput).toHaveProperty("type", "text");
 		expect(apiKeyInput).toHaveValue("sk-ant-***\u2026***ABCD");
@@ -492,7 +580,9 @@ export const FailedSubmitKeepsCredential: Story = {
 	},
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
-		const apiKeyInput = await canvas.findByLabelText(/api key/i);
+		const apiKeyInput = await canvas.findByRole("textbox", {
+			name: /api key/i,
+		});
 
 		await userEvent.click(apiKeyInput);
 		await waitFor(() => expect(apiKeyInput).toHaveValue(""));
@@ -547,7 +637,9 @@ export const ExternalLoadingKeepsCredential: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		const apiKeyInput = await canvas.findByLabelText(/api key/i);
+		const apiKeyInput = await canvas.findByRole("textbox", {
+			name: /api key/i,
+		});
 		const submitButton = canvas.getByRole("button", {
 			name: /update provider/i,
 		});

--- a/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderForm.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderForm.tsx
@@ -12,6 +12,7 @@ import { Form, FormFields } from "#/components/Form/Form";
 import { FormField } from "#/components/FormField/FormField";
 import { Label } from "#/components/Label/Label";
 import { Link as DocsLink } from "#/components/Link/Link";
+import { RadioGroup, RadioGroupItem } from "#/components/RadioGroup/RadioGroup";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { useUnsavedChangesPrompt } from "#/hooks/useUnsavedChangesPrompt";
 import { IconPickerField } from "#/pages/AISettingsPage/MCPServersPage/components/IconPickerField";
@@ -31,6 +32,14 @@ export type ProviderFormValues = {
 	accessKeySecret: string;
 	roleArn: string;
 	apiKey: string;
+	// wifEnabled selects Workload Identity Federation for an Anthropic
+	// provider instead of a static API key. Ignored for other types.
+	wifEnabled: boolean;
+	federationRuleId: string;
+	organizationId: string;
+	identityTokenFile: string;
+	serviceAccountId: string;
+	workspaceId: string;
 	enabled: boolean;
 };
 
@@ -74,6 +83,12 @@ const defaultInitialValues: ProviderFormValues = {
 	accessKeySecret: "",
 	roleArn: "",
 	apiKey: "",
+	wifEnabled: false,
+	federationRuleId: "",
+	organizationId: "",
+	identityTokenFile: "",
+	serviceAccountId: "",
+	workspaceId: "",
 	enabled: true,
 };
 
@@ -146,6 +161,65 @@ const makeOpenAiAnthropicSchema = (editing: boolean) =>
 		enabled: Yup.boolean(),
 	});
 
+// WIF exchanges the OIDC identity token and minted access token over the
+// endpoint, so cleartext http is refused except for loopback hosts. This
+// mirrors codersdk.ValidateAIProviderWIFBaseURL so a form that validates
+// here is not rejected by the server.
+const WIF_INSECURE_URL_MESSAGE =
+	"WIF requires an https endpoint; http is allowed for loopback hosts only.";
+
+const isSecureWIFUrl = (raw: string | undefined): boolean => {
+	if (!raw || raw.trim() === "") {
+		// The required rule reports the empty case.
+		return true;
+	}
+	let parsed: URL;
+	try {
+		parsed = new URL(raw.trim());
+	} catch {
+		// The url() rule reports malformed input.
+		return true;
+	}
+	if (parsed.protocol === "https:") {
+		return true;
+	}
+	if (parsed.protocol === "http:") {
+		const host = parsed.hostname.toLowerCase();
+		return host === "localhost" || host === "127.0.0.1" || host === "::1";
+	}
+	return false;
+};
+
+// Anthropic Workload Identity Federation replaces the API key with a
+// federation rule reference plus the path to the OIDC identity token
+// file. federation_rule_id, organization_id, and identity_token_file are
+// required (matching codersdk.AIProviderWIFSettings.IsConfigured); the
+// service account and workspace IDs are optional.
+const makeAnthropicWIFSchema = (editing: boolean) =>
+	Yup.object({
+		type: Yup.string()
+			.oneOf(["anthropic"] as const)
+			.required(),
+		name: makeNameSchema(editing),
+		displayName: makeDisplayNameSchema(editing),
+		icon: Yup.string(),
+		baseUrl: Yup.string()
+			.url("Endpoint must be a valid URL")
+			.matches(HTTP_SCHEME_REGEX, "Endpoint must use http or https.")
+			.test("wif-secure-url", WIF_INSECURE_URL_MESSAGE, isSecureWIFUrl)
+			.required("Endpoint is required"),
+		federationRuleId: Yup.string()
+			.trim()
+			.required("Federation rule ID is required"),
+		organizationId: Yup.string().trim().required("Organization ID is required"),
+		identityTokenFile: Yup.string()
+			.trim()
+			.required("Identity token file is required"),
+		serviceAccountId: Yup.string(),
+		workspaceId: Yup.string(),
+		enabled: Yup.boolean(),
+	});
+
 const credentialFilled = (value: string | undefined): boolean => {
 	if (!value) return false;
 	const trimmed = value.trim();
@@ -213,38 +287,43 @@ const makeCopilotSchema = (editing: boolean) =>
 	});
 
 const getProviderFormSchema = (editing: boolean) =>
-	Yup.lazy((value: { type?: AIProviderType } | undefined) => {
-		switch (value?.type) {
-			case "openai":
-			case "anthropic":
-			case "azure":
-			case "google":
-			case "openai-compat":
-			case "openrouter":
-			case "vercel":
-				return makeOpenAiAnthropicSchema(editing);
-			case "bedrock":
-				return makeBedrockSchema(editing);
-			case "copilot":
-				return makeCopilotSchema(editing);
-			default:
-				return Yup.object({
-					type: Yup.string()
-						.oneOf([
-							"openai",
-							"anthropic",
-							"bedrock",
-							"azure",
-							"copilot",
-							"google",
-							"openai-compat",
-							"openrouter",
-							"vercel",
-						])
-						.required(),
-				});
-		}
-	});
+	Yup.lazy(
+		(value: { type?: AIProviderType; wifEnabled?: boolean } | undefined) => {
+			switch (value?.type) {
+				case "anthropic":
+					return value?.wifEnabled
+						? makeAnthropicWIFSchema(editing)
+						: makeOpenAiAnthropicSchema(editing);
+				case "openai":
+				case "azure":
+				case "google":
+				case "openai-compat":
+				case "openrouter":
+				case "vercel":
+					return makeOpenAiAnthropicSchema(editing);
+				case "bedrock":
+					return makeBedrockSchema(editing);
+				case "copilot":
+					return makeCopilotSchema(editing);
+				default:
+					return Yup.object({
+						type: Yup.string()
+							.oneOf([
+								"openai",
+								"anthropic",
+								"bedrock",
+								"azure",
+								"copilot",
+								"google",
+								"openai-compat",
+								"openrouter",
+								"vercel",
+							])
+							.required(),
+					});
+			}
+		},
+	);
 
 type ProviderFormProps = {
 	editing?: boolean;
@@ -458,6 +537,99 @@ export const ProviderForm: FC<ProviderFormProps> = ({
 								requires a GitHub external authentication provider to be
 								configured.
 							</p>
+						) : typeSelectValue === "anthropic" ? (
+							<>
+								<div className="flex flex-col gap-2">
+									<Label htmlFor="wif-auth-method">Authentication method</Label>
+									<RadioGroup
+										id="wif-auth-method"
+										value={form.values.wifEnabled ? "wif" : "apikey"}
+										onValueChange={(value) => {
+											void form.setFieldValue("wifEnabled", value === "wif");
+										}}
+									>
+										<label
+											htmlFor="wif-auth-apikey"
+											className="flex items-center gap-2 text-sm"
+										>
+											<RadioGroupItem value="apikey" id="wif-auth-apikey" />
+											API key
+										</label>
+										<label
+											htmlFor="wif-auth-wif"
+											className="flex items-center gap-2 text-sm"
+										>
+											<RadioGroupItem value="wif" id="wif-auth-wif" />
+											Workload Identity Federation
+										</label>
+									</RadioGroup>
+								</div>
+								{form.values.wifEnabled ? (
+									<>
+										<div className="grid grid-cols-2 items-start gap-4">
+											<FormField
+												required
+												field={getFieldHelpers("federationRuleId")}
+												label="Federation rule ID"
+												className="w-full"
+												placeholder="fdrl_..."
+											/>
+											<FormField
+												required
+												field={getFieldHelpers("organizationId")}
+												label="Organization ID"
+												className="w-full"
+												placeholder="00000000-0000-0000-0000-000000000000"
+											/>
+										</div>
+										<FormField
+											required
+											field={getFieldHelpers("identityTokenFile")}
+											label="Identity token file"
+											description="Absolute path to the file holding the OIDC identity token (JWT). Re-read on every token exchange."
+											className="w-full"
+											placeholder="/var/run/secrets/anthropic/token"
+										/>
+										<div className="grid grid-cols-2 items-start gap-4">
+											<FormField
+												field={getFieldHelpers("serviceAccountId")}
+												label="Service account ID"
+												className="w-full"
+												placeholder="svac_..."
+											/>
+											<FormField
+												field={getFieldHelpers("workspaceId")}
+												label="Workspace ID"
+												className="w-full"
+												placeholder="wrkspc_... or default"
+											/>
+										</div>
+										<p className="text-xs text-content-secondary m-0">
+											Service account ID is required for SERVICE_ACCOUNT-target
+											federation rules. Workspace ID is required when the rule
+											is enabled for more than one workspace.{" "}
+											<DocsLink
+												size="sm"
+												href={docs("/ai-coder/ai-gateway/providers")}
+												target="_blank"
+												rel="noreferrer"
+											>
+												View docs
+											</DocsLink>
+										</p>
+									</>
+								) : (
+									<CredentialField
+										required
+										label="API key"
+										helpers={getFieldHelpers("apiKey")}
+										onBlur={() => handleCredentialBlur("apiKey")}
+										onFocus={() => handleCredentialFocus("apiKey")}
+										autoComplete="new-password"
+										placeholder={apiKeyPlaceholder(form.values.type)}
+									/>
+								)}
+							</>
 						) : (
 							<CredentialField
 								required

--- a/site/src/pages/AISettingsPage/ProvidersPage/components/providerFormApiMap.test.ts
+++ b/site/src/pages/AISettingsPage/ProvidersPage/components/providerFormApiMap.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { AIProvider } from "#/api/typesGenerated";
 import {
 	MockAIProviderAnthropic,
+	MockAIProviderAnthropicWIF,
 	MockAIProviderBedrock,
 	MockAIProviderCopilot,
 	MockAIProviderOpenAI,
@@ -17,9 +18,19 @@ import {
 	getProviderDisplayType,
 	hasBedrockStoredCredentials,
 	isBedrockProvider,
+	isWIFProvider,
 	providerFormValuesToCreate,
 	providerFormValuesToUpdate,
 } from "./providerFormApiMap";
+
+const wifFields = {
+	wifEnabled: false,
+	federationRuleId: "",
+	organizationId: "",
+	identityTokenFile: "",
+	serviceAccountId: "",
+	workspaceId: "",
+};
 
 const baseOpenAIFormValues: ProviderFormValues = {
 	type: "openai",
@@ -33,6 +44,7 @@ const baseOpenAIFormValues: ProviderFormValues = {
 	accessKeySecret: "",
 	roleArn: "",
 	apiKey: "sk-test",
+	...wifFields,
 	enabled: true,
 };
 
@@ -48,6 +60,7 @@ const baseBedrockFormValues: ProviderFormValues = {
 	accessKeySecret: "secret",
 	roleArn: "",
 	apiKey: "",
+	...wifFields,
 	enabled: true,
 };
 
@@ -63,6 +76,28 @@ const baseCopilotFormValues: ProviderFormValues = {
 	accessKeySecret: "",
 	roleArn: "",
 	apiKey: "",
+	...wifFields,
+	enabled: true,
+};
+
+const baseAnthropicWIFFormValues: ProviderFormValues = {
+	type: "anthropic",
+	name: "anthropic-wif",
+	displayName: "Anthropic WIF",
+	icon: "",
+	baseUrl: "https://api.anthropic.com",
+	model: "",
+	smallFastModel: "",
+	accessKey: "",
+	accessKeySecret: "",
+	roleArn: "",
+	apiKey: "",
+	wifEnabled: true,
+	federationRuleId: "fdrl_01ABCDEFGHIJKLMNOPQRSTUV",
+	organizationId: "11111111-2222-3333-4444-555555555555",
+	identityTokenFile: "/var/run/secrets/anthropic/token",
+	serviceAccountId: "svac_01ABCDEFGHIJKLMNOPQRSTUV",
+	workspaceId: "",
 	enabled: true,
 };
 
@@ -176,6 +211,28 @@ describe("isBedrockProvider", () => {
 			settings: settings({ _type: "copilot", _version: 1 }),
 		};
 		expect(isBedrockProvider(provider)).toBe(false);
+	});
+});
+
+describe("isWIFProvider", () => {
+	it("recognises an anthropic provider with wif settings", () => {
+		expect(isWIFProvider(MockAIProviderAnthropicWIF)).toBe(true);
+	});
+
+	it("rejects an anthropic provider whose settings are null", () => {
+		expect(isWIFProvider(MockAIProviderAnthropic)).toBe(false);
+	});
+
+	it("rejects a bedrock-typed provider", () => {
+		expect(isWIFProvider(MockAIProviderBedrock)).toBe(false);
+	});
+
+	it("rejects an anthropic provider carrying a different discriminator", () => {
+		const provider: AIProvider = {
+			...MockAIProviderAnthropic,
+			settings: settings({ _type: "bedrock", _version: 1 }),
+		};
+		expect(isWIFProvider(provider)).toBe(false);
 	});
 });
 
@@ -514,6 +571,63 @@ describe("providerFormValuesToCreate", () => {
 			expect(req.display_name).toBeUndefined();
 		});
 	});
+
+	describe("Anthropic WIF", () => {
+		it("maps to anthropic with wif settings and no api_keys", () => {
+			const req = providerFormValuesToCreate(baseAnthropicWIFFormValues);
+			expect(req.type).toBe("anthropic");
+			expect(req.api_keys).toBeUndefined();
+			const s = req.settings as unknown as Record<string, unknown>;
+			expect(s._type).toBe("wif");
+			expect(s._version).toBe(1);
+			expect(s.federation_rule_id).toBe("fdrl_01ABCDEFGHIJKLMNOPQRSTUV");
+			expect(s.organization_id).toBe("11111111-2222-3333-4444-555555555555");
+			expect(s.identity_token_file).toBe("/var/run/secrets/anthropic/token");
+			expect(s.service_account_id).toBe("svac_01ABCDEFGHIJKLMNOPQRSTUV");
+		});
+
+		it("omits the optional workspace and service account when blank", () => {
+			const req = providerFormValuesToCreate({
+				...baseAnthropicWIFFormValues,
+				serviceAccountId: "",
+				workspaceId: "",
+			});
+			const s = req.settings as unknown as Record<string, unknown>;
+			expect(s.service_account_id).toBeUndefined();
+			expect(s.workspace_id).toBeUndefined();
+		});
+
+		it("includes the workspace ID when provided", () => {
+			const req = providerFormValuesToCreate({
+				...baseAnthropicWIFFormValues,
+				workspaceId: "wrkspc_01ABCDEFGHIJKLMNOPQRSTUV",
+			});
+			const s = req.settings as unknown as Record<string, unknown>;
+			expect(s.workspace_id).toBe("wrkspc_01ABCDEFGHIJKLMNOPQRSTUV");
+		});
+
+		it("trims whitespace around the WIF fields", () => {
+			const req = providerFormValuesToCreate({
+				...baseAnthropicWIFFormValues,
+				federationRuleId: "  fdrl_trim  ",
+				identityTokenFile: "  /tmp/token  ",
+			});
+			const s = req.settings as unknown as Record<string, unknown>;
+			expect(s.federation_rule_id).toBe("fdrl_trim");
+			expect(s.identity_token_file).toBe("/tmp/token");
+		});
+
+		it("falls back to the api key path when wifEnabled is false", () => {
+			const req = providerFormValuesToCreate({
+				...baseAnthropicWIFFormValues,
+				wifEnabled: false,
+				apiKey: "sk-ant-test",
+			});
+			expect(req.type).toBe("anthropic");
+			expect(req.settings).toBeUndefined();
+			expect(req.api_keys).toEqual(["sk-ant-test"]);
+		});
+	});
 });
 
 describe("providerFormValuesToUpdate", () => {
@@ -687,6 +801,34 @@ describe("providerFormValuesToUpdate", () => {
 			expect(req.base_url).toBe("https://api.business.githubcopilot.com");
 		});
 	});
+
+	describe("Anthropic WIF", () => {
+		it("patches wif settings and never sends api_keys", () => {
+			const req = providerFormValuesToUpdate(
+				baseAnthropicWIFFormValues,
+				MockAIProviderAnthropicWIF,
+			);
+			expect(req.api_keys).toBeUndefined();
+			const s = req.settings as unknown as Record<string, unknown>;
+			expect(s._type).toBe("wif");
+			expect(s.federation_rule_id).toBe("fdrl_01ABCDEFGHIJKLMNOPQRSTUV");
+			expect(s.identity_token_file).toBe("/var/run/secrets/anthropic/token");
+		});
+
+		it("clears settings and sets api_keys when migrating WIF back to a key", () => {
+			const req = providerFormValuesToUpdate(
+				{
+					...baseAnthropicWIFFormValues,
+					wifEnabled: false,
+					apiKey: "sk-ant-new",
+				},
+				MockAIProviderAnthropicWIF,
+			);
+			expect(req.api_keys).toEqual([{ api_key: "sk-ant-new" }]);
+			// The empty-object clear form drops the stored WIF settings.
+			expect(req.settings).toEqual({});
+		});
+	});
 });
 
 describe("aiProviderToFormValues", () => {
@@ -777,6 +919,17 @@ describe("aiProviderToFormValues", () => {
 		expect(values.name).toBe(MockAIProviderCopilot.name);
 		expect(values.baseUrl).toBe(MockAIProviderCopilot.base_url);
 		expect(values.apiKey).toBeUndefined();
+	});
+
+	it("seeds WIF form values from settings", () => {
+		const values = aiProviderToFormValues(MockAIProviderAnthropicWIF);
+		expect(values.type).toBe("anthropic");
+		expect(values.wifEnabled).toBe(true);
+		expect(values.federationRuleId).toBe("fdrl_01ABCDEFGHIJKLMNOPQRSTUV");
+		expect(values.organizationId).toBe("11111111-2222-3333-4444-555555555555");
+		expect(values.identityTokenFile).toBe("/var/run/secrets/anthropic/token");
+		expect(values.serviceAccountId).toBe("svac_01ABCDEFGHIJKLMNOPQRSTUV");
+		expect(values.workspaceId).toBe("");
 	});
 
 	it("falls back to the slug when display_name is empty", () => {

--- a/site/src/pages/AISettingsPage/ProvidersPage/components/providerFormApiMap.ts
+++ b/site/src/pages/AISettingsPage/ProvidersPage/components/providerFormApiMap.ts
@@ -4,6 +4,7 @@ import type {
 	AIProviderKeyMutation,
 	AIProviderSettings,
 	AIProviderType,
+	AIProviderWIFSettings,
 	CreateAIProviderRequest,
 	UpdateAIProviderRequest,
 } from "#/api/typesGenerated";
@@ -34,13 +35,23 @@ const sanitizeCredential = (
 const BEDROCK_SETTINGS_TYPE = "bedrock";
 const BEDROCK_SETTINGS_VERSION = 1;
 
+// WIF settings share the same discriminated-envelope shape as Bedrock.
+const WIF_SETTINGS_TYPE = "wif";
+const WIF_SETTINGS_VERSION = 1;
+
 type BedrockSettingsWire = AIProviderBedrockSettings & {
 	_type: typeof BEDROCK_SETTINGS_TYPE;
 	_version: typeof BEDROCK_SETTINGS_VERSION;
 };
 
+type WifSettingsWire = AIProviderWIFSettings & {
+	_type: typeof WIF_SETTINGS_TYPE;
+	_version: typeof WIF_SETTINGS_VERSION;
+};
+
 type SettingsWire = AIProviderSettings &
-	Partial<AIProviderBedrockSettings> & {
+	Partial<AIProviderBedrockSettings> &
+	Partial<AIProviderWIFSettings> & {
 		_type?: string;
 		_version?: number;
 	};
@@ -54,6 +65,17 @@ export const isBedrockProvider = (provider: AIProvider): boolean => {
 	}
 	const s = provider.settings as SettingsWire | null;
 	return s !== null && s._type === BEDROCK_SETTINGS_TYPE;
+};
+
+// WIF providers are anthropic rows identified by the settings
+// discriminator. As with Bedrock, the generated type marks settings as
+// non-null but Go serializes zero settings as JSON `null`.
+export const isWIFProvider = (provider: AIProvider): boolean => {
+	if (provider.type !== "anthropic") {
+		return false;
+	}
+	const s = provider.settings as SettingsWire | null;
+	return s !== null && s._type === WIF_SETTINGS_TYPE;
 };
 
 // Server-generated STS external ID; read-only.
@@ -131,6 +153,22 @@ const buildBedrockSettings = (
 	...(roleArn ? { role_arn: roleArn } : {}),
 });
 
+const buildWIFSettings = (
+	federationRuleId: string,
+	organizationId: string,
+	identityTokenFile: string,
+	serviceAccountId: string,
+	workspaceId: string,
+): WifSettingsWire => ({
+	_type: WIF_SETTINGS_TYPE,
+	_version: WIF_SETTINGS_VERSION,
+	federation_rule_id: federationRuleId,
+	organization_id: organizationId,
+	identity_token_file: identityTokenFile,
+	...(serviceAccountId ? { service_account_id: serviceAccountId } : {}),
+	...(workspaceId ? { workspace_id: workspaceId } : {}),
+});
+
 // Bedrock credentials live in `settings`; openai/anthropic keys go in
 // `api_keys`. `display_name` is omitted when blank so the server stores
 // NULL and the UI falls back to `name`.
@@ -168,6 +206,21 @@ export const providerFormValuesToCreate = (
 		return { type: "copilot", ...base };
 	}
 
+	if (values.type === "anthropic" && values.wifEnabled) {
+		const settings = buildWIFSettings(
+			values.federationRuleId.trim(),
+			values.organizationId.trim(),
+			values.identityTokenFile.trim(),
+			values.serviceAccountId.trim(),
+			values.workspaceId.trim(),
+		);
+		return {
+			type: "anthropic",
+			...base,
+			settings: settings as AIProviderSettings,
+		};
+	}
+
 	const apiKey = sanitizeCredential(values.apiKey);
 	// `""` is unreachable here (Yup blocks it, Bedrock and Copilot branched
 	// out), but the union still includes it; narrow so TS stays honest.
@@ -200,6 +253,17 @@ export const providerFormValuesToUpdate = (
 		return base;
 	}
 
+	if (values.type === "anthropic" && values.wifEnabled) {
+		const settings = buildWIFSettings(
+			values.federationRuleId.trim(),
+			values.organizationId.trim(),
+			values.identityTokenFile.trim(),
+			values.serviceAccountId.trim(),
+			values.workspaceId.trim(),
+		);
+		return { ...base, settings: settings as AIProviderSettings };
+	}
+
 	if (values.type !== "bedrock") {
 		// If the user didn't touch the input, the form still holds the seeded
 		// mask and sanitizes to `""` (no rotation).
@@ -212,6 +276,16 @@ export const providerFormValuesToUpdate = (
 			newApiKey === ""
 				? existingProvider.api_keys.map((k) => ({ id: k.id }))
 				: [{ api_key: newApiKey }];
+		// Migrating a stored WIF provider back to a bearer key clears the
+		// type-specific settings. A literal {} is the explicit-clear form the
+		// server distinguishes from "leave untouched" (omitted/null).
+		if (isWIFProvider(existingProvider)) {
+			return {
+				...base,
+				api_keys: apiKeys,
+				settings: {} as AIProviderSettings,
+			};
+		}
 		return { ...base, api_keys: apiKeys };
 	}
 
@@ -244,6 +318,23 @@ export const aiProviderToFormValues = (
 	provider: AIProvider,
 ): Partial<ProviderFormValues> => {
 	const displayName = provider.display_name || provider.name;
+	if (isWIFProvider(provider)) {
+		const s = (provider.settings as SettingsWire | null) ?? {};
+		return {
+			type: "anthropic",
+			wifEnabled: true,
+			name: provider.name,
+			displayName,
+			icon: provider.icon || (getProviderIcon("anthropic") ?? ""),
+			baseUrl: provider.base_url,
+			federationRuleId: s.federation_rule_id ?? "",
+			organizationId: s.organization_id ?? "",
+			identityTokenFile: s.identity_token_file ?? "",
+			serviceAccountId: s.service_account_id ?? "",
+			workspaceId: s.workspace_id ?? "",
+			enabled: provider.enabled,
+		};
+	}
 	if (isBedrockProvider(provider)) {
 		const s = (provider.settings as SettingsWire | null) ?? {};
 		return {

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -5616,6 +5616,33 @@ export const MockAIProviderCopilot: TypesGen.AIProvider = {
 	updated_at: "2026-05-14T10:00:00Z",
 };
 
+/**
+ * WIF providers come over the wire with `type: "anthropic"` and a
+ * `settings._type: "wif"` discriminator. `isWIFProvider` checks both the
+ * type and the settings discriminator. The federation config is not
+ * secret, so it round-trips back to the edit form.
+ */
+export const MockAIProviderAnthropicWIF: TypesGen.AIProvider = {
+	id: "d4a1f6b2-9c3e-4f58-8a17-2c6e0b9d4e51",
+	type: "anthropic",
+	name: "anthropic-wif",
+	display_name: "Anthropic WIF",
+	icon: "",
+	base_url: "https://api.anthropic.com",
+	enabled: true,
+	api_keys: [],
+	settings: {
+		_type: "wif",
+		_version: 1,
+		federation_rule_id: "fdrl_01ABCDEFGHIJKLMNOPQRSTUV",
+		organization_id: "11111111-2222-3333-4444-555555555555",
+		identity_token_file: "/var/run/secrets/anthropic/token",
+		service_account_id: "svac_01ABCDEFGHIJKLMNOPQRSTUV",
+	} as unknown as TypesGen.AIProviderSettings,
+	created_at: "2026-05-14T10:00:00Z",
+	updated_at: "2026-05-14T10:00:00Z",
+};
+
 export const MockAIProviders: TypesGen.AIProvider[] = [
 	MockAIProviderOpenAI,
 	MockAIProviderAnthropic,


### PR DESCRIPTION
## Problem

On this branch, an Anthropic provider configured for Workload Identity Federation shows up in the AI provider settings page as a plain `anthropic` type, and the form only renders name / endpoint / API key. There is no way to set the WIF fields through the UI, even though the backend, `codersdk`, and request validation already support WIF via `AIProviderSettings.WIF`.

## Change

Add an **Authentication method** selector to the Anthropic provider form:

- **API key** (default) keeps the existing behavior.
- **Workload Identity Federation** hides the API key field and reveals:
  - `federation_rule_id`, `organization_id`, `identity_token_file` (required)
  - `service_account_id`, `workspace_id` (optional)

The form wires Yup validation (including the https-only base URL rule mirroring `codersdk.ValidateAIProviderWIFBaseURL`) and maps values to/from `settings.WIF`, following the existing Bedrock settings-mapping pattern in `providerFormApiMap.ts`. Switching a stored WIF provider back to an API key clears the stored settings using the explicit empty-object form, and the edit page no longer surfaces the API-key masking UI for WIF providers.

This is a frontend-only change; no new provider card is added because the picker `value` is typed as `AIProviderType` and WIF has no separate type (it is anthropic-only).

## Tests

- `providerFormApiMap.test.ts`: WIF detection, create/update mapping, optional-field omission, whitespace trimming, WIF→key migration clear, and form seeding (101 unit tests pass).
- `ProviderForm.stories.tsx`: `AddAnthropicWIF` (switch to WIF, fill fields, submit) and `EditAnthropicWIF` (seeded fields, no API key field). All 18 stories pass.
- Added `MockAIProviderAnthropicWIF` test entity.

Local checks: `biome check`, `tsc -p .`, `vitest --project=unit`, `vitest --project=storybook`, circular-deps, and knip all pass.

<details>
<summary>Implementation notes</summary>

- The auth-method radio option "API key" shares an accessible name with the API key input; the touched stories query the input via `getByRole("textbox", { name: /api key/i })` to disambiguate.
- WIF fields are non-secret config (the secret is the on-disk token file), so they round-trip back into the edit form unlike Bedrock/OpenAI credentials.
- `providerFormValuesToUpdate` sends `settings: {}` (the SDK's explicit-clear form) only when migrating an existing WIF provider back to an API key.

</details>

Generated by Coder Agents on behalf of @Shelnutt2.