### PR TITLE
fix: keep chat-pinned MCP tools in sync with agent context pushes

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1565,6 +1565,13 @@ func (a *agent) handleManifest(manifestOK *checkpoint) func(ctx context.Context,
 				if mcpErr := a.mcpManager.Reload(a.gracefulCtx, a.contextConfigAPI.MCPConfigFiles()); mcpErr != nil {
 					a.logger.Warn(ctx, "failed to reload workspace MCP servers", slog.Error(mcpErr))
 				}
+				// The reload fires the catalog-change callback (wired to
+				// Trigger) only when it observes a change. Trigger once
+				// more explicitly so the pushed context always includes a
+				// resolve that ran after the first MCP sync settled, even
+				// if the callback fired while the first post-ready resolve
+				// was already past its catalog read.
+				a.contextManager.Trigger()
 			})
 			if err != nil {
 				return xerrors.Errorf("track conn goroutine: %w", err)

--- a/agent/agentcontext/manager_test.go
+++ b/agent/agentcontext/manager_test.go
@@ -469,6 +469,43 @@ func TestManager_SetReadyIsIdempotent(t *testing.T) {
 	require.Len(t, snap.Resources, 1)
 }
 
+// TestManager_TriggerBeforeReadyResolvesAfterReady locks in the gate's
+// re-signal invariant on the Run-loop path: a Trigger that lands while
+// collection is still gated (the MCP engine's reload callback can fire
+// before startup scripts finish) must not suppress the first ready
+// resolve. Whether the Run loop consumes the pre-ready trigger before
+// or after SetReady, a resolve must follow, because SetReady re-signals
+// after opening the gate. A regression here leaves the agent's context
+// permanently unpushed until an unrelated filesystem change.
+func TestManager_TriggerBeforeReadyResolvesAfterReady(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "AGENTS.md"), "rules")
+
+	m := newPendingTestManager(t, agentcontext.ManagerOptions{
+		WorkingDir: func() string { return dir },
+	})
+	ctx := testutil.Context(t, testutil.WaitLong)
+	go func() { _ = m.Run(ctx) }()
+	select {
+	case <-agentcontext.ManagerStarted(m):
+	case <-ctx.Done():
+		t.Fatalf("manager never started: %v", ctx.Err())
+	}
+
+	// While gated, the Run loop consumes trigger tokens and drops them
+	// without resolving.
+	m.Trigger()
+	require.Zero(t, m.Snapshot().Version, "gated trigger must not resolve")
+
+	m.SetReady()
+
+	testutil.Eventually(ctx, t, func(context.Context) bool {
+		snap := m.Snapshot()
+		return snap.Version > 0 && len(snap.Resources) == 1
+	}, testutil.IntervalFast)
+}
+
 func TestManager_CloseIsIdempotent(t *testing.T) {
 	t.Parallel()
 	m := newTestManager(t, agentcontext.ManagerOptions{

--- a/agent/x/agentmcp/manager.go
+++ b/agent/x/agentmcp/manager.go
@@ -39,6 +39,13 @@ const ToolNameSep = "__"
 // to start its transport and complete initialization.
 const connectTimeout = 30 * time.Second
 
+// partialCatalogDelay is how long a reload waits for every server to
+// finish connecting before publishing a partial catalog covering the
+// servers that already settled. One slow or hanging server (bounded by
+// connectTimeout) then delays only its own appearance in the catalog,
+// not the tools of every server that connected promptly.
+const partialCatalogDelay = 5 * time.Second
+
 // toolCallTimeout bounds how long a single tool invocation may
 // take before being canceled.
 const toolCallTimeout = 60 * time.Second
@@ -124,6 +131,12 @@ type Manager struct {
 	// in-flight reload (for example, to verify Close()'s
 	// shutdown ordering does not stall on a stuck connect).
 	connectStartedHook func()
+
+	// connectSettledHook is a test hook invoked by connectAll each
+	// time a server's connect attempt settles (success or failure).
+	// Production code leaves this nil; tests set it to order the
+	// partial-catalog timer against specific connect outcomes.
+	connectSettledHook func(name string)
 }
 
 // serverEntry pairs a server config with its connected client.
@@ -438,9 +451,9 @@ func (m *Manager) doReload(ctx context.Context, mcpConfigFiles []string) error {
 		return err
 	}
 
-	connected := m.connectAll(ctx, diff.toConnect)
+	connected, partialInstalled := m.connectAll(ctx, wanted, diff)
 
-	replaced, err := m.installServers(wanted, diff, connected, snap)
+	replaced, err := m.installServers(wanted, diff, connected, snap, partialInstalled)
 	if err != nil {
 		return err
 	}
@@ -548,22 +561,36 @@ func (m *Manager) classifyServers(wanted map[string]ServerConfig) (*serverDiff, 
 	return diff, nil
 }
 
-// connectAll runs connectServer in parallel for the given configs.
-// Failed connects are logged and skipped.
-func (m *Manager) connectAll(ctx context.Context, toConnect []ServerConfig) []connectedServer {
+// connectAll runs connectServer in parallel for the servers in
+// diff.toConnect and returns the successful connections. Failed
+// connects are logged and skipped.
+//
+// When some connects are still pending after partialCatalogDelay, the
+// servers that already settled are installed and published as a partial
+// catalog so their tools become visible and callable without waiting
+// for the slowest connect (bounded by connectTimeout). The returned set
+// names the servers installed early; installServers uses it to keep
+// client ownership single-homed when the manager closes mid-reload.
+func (m *Manager) connectAll(ctx context.Context, wanted map[string]ServerConfig, diff *serverDiff) ([]connectedServer, map[string]struct{}) {
 	logger := m.logger.With(agentchat.Fields(ctx)...)
 
 	if hook := m.connectStartedHook; hook != nil {
 		hook()
 	}
+	if len(diff.toConnect) == 0 {
+		return nil, nil
+	}
 
-	var (
-		mu        sync.Mutex
-		connected []connectedServer
-	)
-	var eg errgroup.Group
-	for _, cfg := range toConnect {
-		eg.Go(func() error {
+	type connectOutcome struct {
+		name   string
+		server connectedServer
+		ok     bool
+	}
+	// Buffered to the goroutine count so every connect can deliver its
+	// outcome and exit even after the collection loop has moved on.
+	outcomes := make(chan connectOutcome, len(diff.toConnect))
+	for _, cfg := range diff.toConnect {
+		go func() {
 			c, err := m.connectServer(ctx, cfg)
 			if err != nil {
 				logger.Warn(ctx, "skipping MCP server",
@@ -571,35 +598,132 @@ func (m *Manager) connectAll(ctx context.Context, toConnect []ServerConfig) []co
 					slog.F("transport", cfg.Transport),
 					slog.Error(err),
 				)
-				return nil // Don't fail the group.
+				outcomes <- connectOutcome{name: cfg.Name}
+				return
 			}
-			mu.Lock()
-			connected = append(connected, connectedServer{
-				name: cfg.Name, config: cfg, client: c,
-			})
-			mu.Unlock()
-			return nil
-		})
+			outcomes <- connectOutcome{
+				name: cfg.Name,
+				ok:   true,
+				server: connectedServer{
+					name: cfg.Name, config: cfg, client: c,
+				},
+			}
+		}()
 	}
-	_ = eg.Wait()
-	return connected
+
+	timer := m.clock.NewTimer(partialCatalogDelay, "agentmcp", "partial_catalog")
+	defer timer.Stop()
+
+	var (
+		connected        []connectedServer
+		partialInstalled map[string]struct{}
+		settled          = make(map[string]struct{}, len(diff.toConnect))
+		timerC           = timer.C
+	)
+	for len(settled) < len(diff.toConnect) {
+		select {
+		case out := <-outcomes:
+			settled[out.name] = struct{}{}
+			if out.ok {
+				connected = append(connected, out.server)
+			}
+			if hook := m.connectSettledHook; hook != nil {
+				hook(out.name)
+			}
+		case <-timerC:
+			// At most one partial catalog per reload; the final
+			// refresh in doReload publishes the complete picture.
+			timerC = nil
+			partialInstalled = m.publishPartialCatalog(ctx, wanted, diff, connected, settled)
+		}
+	}
+	return connected, partialInstalled
+}
+
+// publishPartialCatalog surfaces the servers whose connect settled
+// before the partial-catalog window elapsed, without waiting for the
+// rest. Connections for genuinely new server names are installed so
+// tool calls resolve as soon as the catalog announces them; a
+// connection that replaces an existing entry is deferred to the final
+// install so the replaced client keeps serving until then and is closed
+// exactly once by doReload's standard path. The published catalog
+// covers settled servers only: a server still connecting is omitted
+// (pending) rather than reported as failed. Returns the names it
+// installed, or nil when nothing settled yet or the manager closed.
+func (m *Manager) publishPartialCatalog(ctx context.Context, wanted map[string]ServerConfig, diff *serverDiff, connected []connectedServer, settled map[string]struct{}) map[string]struct{} {
+	if len(settled) == 0 {
+		return nil
+	}
+
+	installed := make(map[string]struct{}, len(connected))
+	m.mu.Lock()
+	if m.closed {
+		// Ownership of every connected client stays with the final
+		// installServers call, which closes them all on the closed
+		// branch.
+		m.mu.Unlock()
+		return nil
+	}
+	for _, cs := range connected {
+		if _, replaces := diff.prev[cs.name]; replaces {
+			continue
+		}
+		m.servers[cs.name] = &serverEntry{config: cs.config, client: cs.client}
+		installed[cs.name] = struct{}{}
+	}
+	if len(installed) > 0 {
+		// Invalidate the snapshot of any concurrently running
+		// refreshCatalog from an older generation.
+		m.serverGen++
+	}
+	m.mu.Unlock()
+
+	// Restrict the catalog to servers whose connect settled; the ones
+	// still connecting stay absent until the final refresh instead of
+	// surfacing as spurious "failed to connect" entries.
+	stillConnecting := make(map[string]struct{}, len(diff.toConnect))
+	for _, cfg := range diff.toConnect {
+		if _, ok := settled[cfg.Name]; !ok {
+			stillConnecting[cfg.Name] = struct{}{}
+		}
+	}
+	settledWanted := make(map[string]ServerConfig, len(wanted))
+	for name, cfg := range wanted {
+		if _, pending := stillConnecting[name]; !pending {
+			settledWanted[name] = cfg
+		}
+	}
+	if m.refreshCatalog(ctx, settledWanted) {
+		m.fireOnChange()
+	}
+	return installed
 }
 
 // installServers builds the new server map from diff.keep and the
 // connected list, falling back to diff.prev when a connect failed.
-// Returns old entries replaced by successful connects (caller
-// closes them). Acquires and releases m.mu.
+// partialInstalled names the connections publishPartialCatalog already
+// installed; when the manager closed mid-reload those clients belong to
+// the server map Close tears down, so only the rest are closed here.
+// Returns old entries replaced by successful connects (caller closes
+// them). Acquires and releases m.mu.
 func (m *Manager) installServers(
 	wanted map[string]ServerConfig,
 	diff *serverDiff,
 	connected []connectedServer,
 	snap map[string]fileSnapshot,
+	partialInstalled map[string]struct{},
 ) ([]*serverEntry, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if m.closed {
 		for _, cs := range connected {
+			if _, owned := partialInstalled[cs.name]; owned {
+				// Already installed into m.servers, so Close (which
+				// marked us closed) closed this client; closing it
+				// again here would double-close.
+				continue
+			}
 			_ = cs.client.Close()
 		}
 		return nil, ErrManagerClosed

--- a/agent/x/agentmcp/reload_internal_test.go
+++ b/agent/x/agentmcp/reload_internal_test.go
@@ -3,6 +3,7 @@ package agentmcp
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -19,6 +20,7 @@ import (
 	"github.com/coder/coder/v2/agent/agentexec"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/quartz"
 )
 
 // catalogTool is a flattened (server, tool) pair taken from the
@@ -749,4 +751,109 @@ func TestClose_SuppressesSubprocessExitError(t *testing.T) {
 	// suppress the "signal: killed" error.
 	err = m.Close()
 	assert.NoError(t, err, "Close should not propagate subprocess kill errors")
+}
+
+// TestReload_PartialCatalogPublishesSettledServers verifies that one
+// hanging server does not hold every other server's tools hostage for
+// the full connectTimeout: once the partial-catalog window elapses, the
+// servers that already settled are installed, published, and announced
+// via the reload callback while the reload is still waiting on the
+// hanging connect. The still-connecting server must be absent from the
+// partial catalog rather than reported as failed.
+func TestReload_PartialCatalogPublishesSettledServers(t *testing.T) {
+	if os.Getenv("TEST_MCP_HANG_SERVER") == "1" {
+		// Child process: a stdio MCP server that starts but never
+		// answers the initialize request, simulating a hung server
+		// binary. It exits when the parent kills it or closes stdin.
+		_, _ = io.Copy(io.Discard, os.Stdin)
+		return
+	}
+	if os.Getenv("TEST_MCP_FAKE_SERVER") == "1" {
+		runFakeMCPServer()
+		return
+	}
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	dir := t.TempDir()
+
+	testBin, err := os.Executable()
+	require.NoError(t, err)
+
+	_, fastEntry := fakeMCPServerConfig(t, "fast")
+	hangEntry := mcpServerEntry{
+		Command: testBin,
+		Args:    []string{"-test.run=^TestReload_PartialCatalogPublishesSettledServers$"},
+		Env:     map[string]string{"TEST_MCP_HANG_SERVER": "1"},
+	}
+	configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{
+		"fast": fastEntry,
+		"hang": hangEntry,
+	})
+
+	clock := quartz.NewMock(t)
+	timerTrap := clock.Trap().NewTimer("agentmcp", "partial_catalog")
+	defer timerTrap.Close()
+
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+	m.clock = clock
+	t.Cleanup(func() { _ = m.Close() })
+
+	// Observe settle order so the partial window deterministically fires
+	// after the fast server settled and before the hanging one does.
+	settledCh := make(chan string, 2)
+	m.connectSettledHook = func(name string) { settledCh <- name }
+
+	onChangeCh := make(chan struct{}, 2)
+	m.SetOnReload(func() {
+		select {
+		case onChangeCh <- struct{}{}:
+		default:
+		}
+	})
+
+	reloadDone := make(chan error, 1)
+	go func() { reloadDone <- m.Reload(ctx, []string{configPath}) }()
+
+	// The reload arms the partial-catalog timer before collecting
+	// outcomes.
+	call := timerTrap.MustWait(ctx)
+	require.Equal(t, partialCatalogDelay, call.Duration)
+	call.MustRelease(ctx)
+
+	// The fast server settles; the hanging one never does on its own.
+	require.Equal(t, "fast", testutil.RequireReceive(ctx, t, settledCh))
+
+	// Elapse the partial window: the settled server must be published
+	// and announced while the reload is still in flight.
+	clock.Advance(partialCatalogDelay).MustWait(ctx)
+
+	testutil.RequireReceive(ctx, t, onChangeCh)
+	tools := m.connectedTools()
+	require.Len(t, tools, 1, "partial catalog carries the settled server's tools")
+	require.Equal(t, catalogTool{server: "fast", tool: "echo"}, tools[0])
+	for _, s := range m.Catalog() {
+		require.NotEqual(t, "hang", s.Name,
+			"still-connecting server must be absent from the partial catalog, not failed")
+	}
+
+	// The settled server is installed, so its tools are callable before
+	// the reload finishes.
+	m.mu.RLock()
+	_, installed := m.servers["fast"]
+	m.mu.RUnlock()
+	require.True(t, installed, "partially published server must be installed for tool calls")
+
+	select {
+	case reloadErr := <-reloadDone:
+		t.Fatalf("reload finished before the hanging connect settled: %v", reloadErr)
+	default:
+	}
+
+	// Close cancels the manager context, which fails the hanging connect
+	// and lets the reload settle.
+	_ = m.Close()
+	err = testutil.RequireReceive(ctx, t, reloadDone)
+	require.Error(t, err, "reload interrupted by Close must not report success")
 }

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -7032,6 +7032,16 @@ func (q *querier) SoftDeleteWorkspaceAgentsByWorkspaceID(ctx context.Context, wo
 	return q.db.SoftDeleteWorkspaceAgentsByWorkspaceID(ctx, workspaceID)
 }
 
+func (q *querier) SyncChatContextMCPResourcesByAgent(ctx context.Context, arg database.SyncChatContextMCPResourcesByAgentParams) error {
+	// System-level operation: an agent context push fans the MCP resource
+	// sync out across every clean chat pinned to the pushed snapshot, so
+	// it authorizes at the resource level rather than per-chat.
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceChat); err != nil {
+		return err
+	}
+	return q.db.SyncChatContextMCPResourcesByAgent(ctx, arg)
+}
+
 func (q *querier) TouchChatDebugRunUpdatedAt(ctx context.Context, arg database.TouchChatDebugRunUpdatedAtParams) error {
 	chat, err := q.db.GetChatByID(ctx, arg.ChatID)
 	if err != nil {

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -548,6 +548,11 @@ func (s *MethodTestSuite) TestChats() {
 		dbm.EXPECT().MarkChatsContextDirtyByAgent(gomock.Any(), arg).Return(rows, nil).AnyTimes()
 		check.Args(arg).Asserts(rbac.ResourceChat, policy.ActionUpdate).Returns(rows)
 	}))
+	s.Run("SyncChatContextMCPResourcesByAgent", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		arg := database.SyncChatContextMCPResourcesByAgentParams{AgentID: uuid.New()}
+		dbm.EXPECT().SyncChatContextMCPResourcesByAgent(gomock.Any(), arg).Return(nil).AnyTimes()
+		check.Args(arg).Asserts(rbac.ResourceChat, policy.ActionUpdate)
+	}))
 	s.Run("SetChatContextSnapshot", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		chat := testutil.Fake(s.T(), faker, database.Chat{})
 		arg := database.SetChatContextSnapshotParams{ID: chat.ID}

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -4985,6 +4985,14 @@ func (m queryMetricsStore) SoftDeleteWorkspaceAgentsByWorkspaceID(ctx context.Co
 	return r0
 }
 
+func (m queryMetricsStore) SyncChatContextMCPResourcesByAgent(ctx context.Context, arg database.SyncChatContextMCPResourcesByAgentParams) error {
+	start := time.Now()
+	r0 := m.s.SyncChatContextMCPResourcesByAgent(ctx, arg)
+	m.queryLatencies.WithLabelValues("SyncChatContextMCPResourcesByAgent").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "SyncChatContextMCPResourcesByAgent").Inc()
+	return r0
+}
+
 func (m queryMetricsStore) TouchChatDebugRunUpdatedAt(ctx context.Context, arg database.TouchChatDebugRunUpdatedAtParams) error {
 	start := time.Now()
 	r0 := m.s.TouchChatDebugRunUpdatedAt(ctx, arg)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -9405,6 +9405,20 @@ func (mr *MockStoreMockRecorder) SoftDeleteWorkspaceAgentsByWorkspaceID(ctx, wor
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SoftDeleteWorkspaceAgentsByWorkspaceID", reflect.TypeOf((*MockStore)(nil).SoftDeleteWorkspaceAgentsByWorkspaceID), ctx, workspaceID)
 }
 
+// SyncChatContextMCPResourcesByAgent mocks base method.
+func (m *MockStore) SyncChatContextMCPResourcesByAgent(ctx context.Context, arg database.SyncChatContextMCPResourcesByAgentParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SyncChatContextMCPResourcesByAgent", ctx, arg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SyncChatContextMCPResourcesByAgent indicates an expected call of SyncChatContextMCPResourcesByAgent.
+func (mr *MockStoreMockRecorder) SyncChatContextMCPResourcesByAgent(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncChatContextMCPResourcesByAgent", reflect.TypeOf((*MockStore)(nil).SyncChatContextMCPResourcesByAgent), ctx, arg)
+}
+
 // TouchChatDebugRunUpdatedAt mocks base method.
 func (m *MockStore) TouchChatDebugRunUpdatedAt(ctx context.Context, arg database.TouchChatDebugRunUpdatedAtParams) error {
 	m.ctrl.T.Helper()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -1270,6 +1270,21 @@ type sqlcQuerier interface {
 	// Agent context rows are hard-deleted for the same reason as in
 	// SoftDeletePriorWorkspaceAgents.
 	SoftDeleteWorkspaceAgentsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) error
+	// Keeps the pinned MCP rows (mcp_config and mcp_server) of clean chats
+	// in step with the agent's latest pushed snapshot. MCP resources
+	// describe live runtime capabilities and are excluded from the drift
+	// hash, so a push that only changes them (servers finishing their
+	// connect after boot, a tool list changing) leaves pinned hashes
+	// untouched and never dirties a chat; without this sync a chat pinned
+	// before the agent's MCP servers connected would keep an empty pinned
+	// tool set until an unrelated drift forced a refresh. Only chats
+	// pinned to exactly the pushed hash and not already dirty are touched,
+	// and only their MCP-kind rows: pinned prompt content (instruction
+	// files, skills) still changes hands exclusively through the
+	// dirty-then-refresh flow. Stale MCP rows are deleted and current ones
+	// upserted; the upsert rewrites a row only when its content actually
+	// differs so updated_at is not churned by every push.
+	SyncChatContextMCPResourcesByAgent(ctx context.Context, arg SyncChatContextMCPResourcesByAgentParams) error
 	// Overrides updated_at on the parent run without touching any
 	// other column. Used by tests that need to stamp a run with a
 	// specific timestamp after the InsertChatDebugStep CTE has

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -10589,6 +10589,91 @@ func (q *sqlQuerier) SoftDeleteContextFileMessages(ctx context.Context, chatID u
 	return err
 }
 
+const syncChatContextMCPResourcesByAgent = `-- name: SyncChatContextMCPResourcesByAgent :exec
+WITH eligible AS (
+    SELECT c.id
+    FROM chats c
+    WHERE c.agent_id = $1::uuid
+        AND c.archived = false
+        AND c.context_dirty_since IS NULL
+        AND c.context_aggregate_hash = $2
+),
+current_mcp AS (
+    SELECT r.source, r.body_kind, r.body, r.content_hash, r.size_bytes, r.status, r.error, r.source_path
+    FROM workspace_agent_context_resources r
+    WHERE r.workspace_agent_id = $1::uuid
+        AND r.body_kind IN ('mcp_config', 'mcp_server')
+),
+deleted AS (
+    -- Both sub-statements see the same snapshot, so this delete and the
+    -- insert below never target the same (chat_id, source): the delete
+    -- matches only sources absent from current_mcp.
+    DELETE FROM chat_context_resources ccr
+    USING eligible e
+    WHERE ccr.chat_id = e.id
+        AND ccr.body_kind IN ('mcp_config', 'mcp_server')
+        AND NOT EXISTS (SELECT 1 FROM current_mcp m WHERE m.source = ccr.source)
+)
+INSERT INTO chat_context_resources (
+    chat_id, source, body_kind, body, content_hash, size_bytes, status, error, source_path
+)
+SELECT
+    e.id, m.source, m.body_kind, m.body, m.content_hash,
+    m.size_bytes, m.status, m.error, m.source_path
+FROM eligible e
+CROSS JOIN current_mcp m
+ON CONFLICT (chat_id, source) DO UPDATE SET
+    body_kind = EXCLUDED.body_kind,
+    body = EXCLUDED.body,
+    content_hash = EXCLUDED.content_hash,
+    size_bytes = EXCLUDED.size_bytes,
+    status = EXCLUDED.status,
+    error = EXCLUDED.error,
+    source_path = EXCLUDED.source_path,
+    updated_at = now()
+WHERE (
+    chat_context_resources.body_kind,
+    chat_context_resources.body,
+    chat_context_resources.content_hash,
+    chat_context_resources.size_bytes,
+    chat_context_resources.status,
+    chat_context_resources.error,
+    chat_context_resources.source_path
+) IS DISTINCT FROM (
+    EXCLUDED.body_kind,
+    EXCLUDED.body,
+    EXCLUDED.content_hash,
+    EXCLUDED.size_bytes,
+    EXCLUDED.status,
+    EXCLUDED.error,
+    EXCLUDED.source_path
+)
+`
+
+type SyncChatContextMCPResourcesByAgentParams struct {
+	AgentID       uuid.UUID `db:"agent_id" json:"agent_id"`
+	AggregateHash []byte    `db:"aggregate_hash" json:"aggregate_hash"`
+}
+
+// Keeps the pinned MCP rows (mcp_config and mcp_server) of clean chats
+// in step with the agent's latest pushed snapshot. MCP resources
+// describe live runtime capabilities and are excluded from the drift
+// hash, so a push that only changes them (servers finishing their
+// connect after boot, a tool list changing) leaves pinned hashes
+// untouched and never dirties a chat; without this sync a chat pinned
+// before the agent's MCP servers connected would keep an empty pinned
+// tool set until an unrelated drift forced a refresh. Only chats
+// pinned to exactly the pushed hash and not already dirty are touched,
+// and only their MCP-kind rows: pinned prompt content (instruction
+// files, skills) still changes hands exclusively through the
+// dirty-then-refresh flow. Stale MCP rows are deleted and current ones
+// upserted; the upsert rewrites a row only when its content actually
+// differs so updated_at is not churned by every push.
+func (q *sqlQuerier) SyncChatContextMCPResourcesByAgent(ctx context.Context, arg SyncChatContextMCPResourcesByAgentParams) error {
+	_, err := q.db.ExecContext(ctx, syncChatContextMCPResourcesByAgent, arg.AgentID, arg.AggregateHash)
+	return err
+}
+
 const unarchiveChatByID = `-- name: UnarchiveChatByID :many
 WITH updated_chats AS (
     UPDATE chats SET

--- a/coderd/database/queries/chats.sql
+++ b/coderd/database/queries/chats.sql
@@ -1457,6 +1457,80 @@ WHERE agent_id = @agent_id::uuid
     AND context_dirty_since IS NULL
 RETURNING id, owner_id;
 
+-- name: SyncChatContextMCPResourcesByAgent :exec
+-- Keeps the pinned MCP rows (mcp_config and mcp_server) of clean chats
+-- in step with the agent's latest pushed snapshot. MCP resources
+-- describe live runtime capabilities and are excluded from the drift
+-- hash, so a push that only changes them (servers finishing their
+-- connect after boot, a tool list changing) leaves pinned hashes
+-- untouched and never dirties a chat; without this sync a chat pinned
+-- before the agent's MCP servers connected would keep an empty pinned
+-- tool set until an unrelated drift forced a refresh. Only chats
+-- pinned to exactly the pushed hash and not already dirty are touched,
+-- and only their MCP-kind rows: pinned prompt content (instruction
+-- files, skills) still changes hands exclusively through the
+-- dirty-then-refresh flow. Stale MCP rows are deleted and current ones
+-- upserted; the upsert rewrites a row only when its content actually
+-- differs so updated_at is not churned by every push.
+WITH eligible AS (
+    SELECT c.id
+    FROM chats c
+    WHERE c.agent_id = @agent_id::uuid
+        AND c.archived = false
+        AND c.context_dirty_since IS NULL
+        AND c.context_aggregate_hash = @aggregate_hash
+),
+current_mcp AS (
+    SELECT r.source, r.body_kind, r.body, r.content_hash, r.size_bytes, r.status, r.error, r.source_path
+    FROM workspace_agent_context_resources r
+    WHERE r.workspace_agent_id = @agent_id::uuid
+        AND r.body_kind IN ('mcp_config', 'mcp_server')
+),
+deleted AS (
+    -- Both sub-statements see the same snapshot, so this delete and the
+    -- insert below never target the same (chat_id, source): the delete
+    -- matches only sources absent from current_mcp.
+    DELETE FROM chat_context_resources ccr
+    USING eligible e
+    WHERE ccr.chat_id = e.id
+        AND ccr.body_kind IN ('mcp_config', 'mcp_server')
+        AND NOT EXISTS (SELECT 1 FROM current_mcp m WHERE m.source = ccr.source)
+)
+INSERT INTO chat_context_resources (
+    chat_id, source, body_kind, body, content_hash, size_bytes, status, error, source_path
+)
+SELECT
+    e.id, m.source, m.body_kind, m.body, m.content_hash,
+    m.size_bytes, m.status, m.error, m.source_path
+FROM eligible e
+CROSS JOIN current_mcp m
+ON CONFLICT (chat_id, source) DO UPDATE SET
+    body_kind = EXCLUDED.body_kind,
+    body = EXCLUDED.body,
+    content_hash = EXCLUDED.content_hash,
+    size_bytes = EXCLUDED.size_bytes,
+    status = EXCLUDED.status,
+    error = EXCLUDED.error,
+    source_path = EXCLUDED.source_path,
+    updated_at = now()
+WHERE (
+    chat_context_resources.body_kind,
+    chat_context_resources.body,
+    chat_context_resources.content_hash,
+    chat_context_resources.size_bytes,
+    chat_context_resources.status,
+    chat_context_resources.error,
+    chat_context_resources.source_path
+) IS DISTINCT FROM (
+    EXCLUDED.body_kind,
+    EXCLUDED.body,
+    EXCLUDED.content_hash,
+    EXCLUDED.size_bytes,
+    EXCLUDED.status,
+    EXCLUDED.error,
+    EXCLUDED.source_path
+);
+
 -- name: InsertAgentContextResourcesIntoChat :exec
 -- Copies an agent's current context resources onto a single chat. Pair
 -- with DeleteChatContextResourcesByChatID (clear-then-copy, in a

--- a/coderd/x/chatd/context_hydration.go
+++ b/coderd/x/chatd/context_hydration.go
@@ -54,6 +54,20 @@ func (p *Server) HydrateAndMarkChatsDirty(ctx context.Context, tx database.Store
 		return nil, xerrors.Errorf("hydrate agent chats context: %w", err)
 	}
 
+	// MCP resources are excluded from the drift hash, so a push that only
+	// changes them (servers finishing their connect after boot, a tool
+	// list changing) matches the pinned hash of already-hydrated chats and
+	// dirties nothing. Sync the pinned MCP rows of chats that are clean on
+	// the pushed hash so their tool set tracks the agent without a dirty
+	// badge or an explicit refresh. Chats hydrated above are included but
+	// unchanged: their rows were just copied from the same snapshot.
+	if err := tx.SyncChatContextMCPResourcesByAgent(ctx, database.SyncChatContextMCPResourcesByAgentParams{
+		AgentID:       agentID,
+		AggregateHash: aggregateHash,
+	}); err != nil {
+		return nil, xerrors.Errorf("sync chat context mcp resources: %w", err)
+	}
+
 	dirtied, err := tx.MarkChatsContextDirtyByAgent(ctx, database.MarkChatsContextDirtyByAgentParams{
 		AgentID:       agentID,
 		AggregateHash: aggregateHash,

--- a/coderd/x/chatd/context_integration_test.go
+++ b/coderd/x/chatd/context_integration_test.go
@@ -406,6 +406,258 @@ func TestChatContextRefreshFromAgentToken(t *testing.T) {
 	require.Equal(t, 0, refresh.Refreshed, "nothing left to refresh")
 }
 
+// TestChatContextMCPSyncFromAgentPush covers the MCP resource sync that runs
+// on every accepted push. MCP resources (mcp_config, mcp_server) are excluded
+// from the drift hash: an agent that boots pushes its first snapshot before
+// its MCP servers finish connecting, and the follow-up push that adds them
+// carries the same aggregate hash, so it can neither hydrate (hash already
+// pinned) nor dirty (hash unchanged) the chat. The sync must copy MCP rows
+// onto clean chats pinned to the pushed hash, keep them updated as tool lists
+// change, and remove them when servers disappear, all without a dirty event.
+// Pinned prompt content (instruction files) and dirty chats must stay
+// untouched: prompt drift still flows exclusively through dirty-then-refresh.
+func TestChatContextMCPSyncFromAgentPush(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client, _, api := coderdtest.NewWithAPI(t, &coderdtest.Options{
+		DeploymentValues:         coderdtest.DeploymentValues(t),
+		IncludeProvisionerDaemon: true,
+	})
+	db := api.Database
+	aibridgedtest.StartTestAIBridgeDaemon(t.Context(), t, api, nil)
+	user := coderdtest.CreateFirstUser(t, client)
+	expClient := codersdk.NewExperimentalClient(client)
+
+	// Build a workspace with an agent via the echo provisioner.
+	agentToken := uuid.NewString()
+	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
+		Parse:          echo.ParseComplete,
+		ProvisionPlan:  echo.PlanComplete,
+		ProvisionApply: echo.ApplyComplete,
+		ProvisionGraph: echo.ProvisionGraphWithAgent(agentToken),
+	})
+	coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+	template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+	workspace := coderdtest.CreateWorkspace(t, client, template.ID)
+	coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
+
+	ws, err := client.Workspace(ctx, workspace.ID)
+	require.NoError(t, err)
+	require.Len(t, ws.LatestBuild.Resources, 1)
+	require.Len(t, ws.LatestBuild.Resources[0].Agents, 1)
+	agentID := ws.LatestBuild.Resources[0].Agents[0].ID
+
+	// A chat bound to the agent, plus an agent-less chat that the
+	// agent-scoped sync must never touch.
+	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{})
+	chat := dbgen.Chat(t, db, database.Chat{
+		OrganizationID:    user.OrganizationID,
+		OwnerID:           user.UserID,
+		WorkspaceID:       uuid.NullUUID{UUID: workspace.ID, Valid: true},
+		AgentID:           uuid.NullUUID{UUID: agentID, Valid: true},
+		LastModelConfigID: model.ID,
+		Status:            database.ChatStatusWaiting,
+	})
+	otherChat := dbgen.Chat(t, db, database.Chat{
+		OrganizationID:    user.OrganizationID,
+		OwnerID:           user.UserID,
+		LastModelConfigID: model.ID,
+		Status:            database.ChatStatusWaiting,
+	})
+
+	agentsSource := "/home/coder/workspace/AGENTS.md"
+	mcpConfigSource := "/home/coder/workspace/.mcp.json"
+	mcpServerSource := "srv"
+	instrHash := []byte{0x11}
+	cfgHash := []byte{0x21}
+	srvHashV1 := []byte{0x31}
+	srvHashV2 := []byte{0x32}
+
+	instructionResource := func() *agentproto.ContextResource {
+		return &agentproto.ContextResource{
+			Source:      agentsSource,
+			ContentHash: instrHash,
+			SizeBytes:   8,
+			Status:      agentproto.ContextResource_OK,
+			Body: &agentproto.ContextResource_InstructionFile{
+				InstructionFile: &agentproto.InstructionFileBody{Content: []byte("hello-v1")},
+			},
+		}
+	}
+	mcpConfigResource := func() *agentproto.ContextResource {
+		return &agentproto.ContextResource{
+			Source:      mcpConfigSource,
+			ContentHash: cfgHash,
+			SizeBytes:   2,
+			Status:      agentproto.ContextResource_OK,
+			Body:        &agentproto.ContextResource_McpConfig{McpConfig: &agentproto.MCPConfigBody{}},
+		}
+	}
+	mcpServerResource := func(hash []byte, toolNames ...string) *agentproto.ContextResource {
+		tools := make([]*agentproto.MCPTool, 0, len(toolNames))
+		for _, name := range toolNames {
+			tools = append(tools, &agentproto.MCPTool{Name: name, Description: name + " tool"})
+		}
+		return &agentproto.ContextResource{
+			Source:      mcpServerSource,
+			ContentHash: hash,
+			SizeBytes:   32,
+			Status:      agentproto.ContextResource_OK,
+			Body: &agentproto.ContextResource_McpServer{
+				McpServer: &agentproto.MCPServerBody{ServerName: mcpServerSource, Tools: tools},
+			},
+		}
+	}
+	pinnedResources := func(id uuid.UUID) map[string]database.ChatContextResource {
+		t.Helper()
+		//nolint:gocritic // Test reads the chat-owned rows as the chatd subject; ctx carries no per-user actor.
+		rows, lerr := db.ListChatContextResourcesByChatID(dbauthz.AsChatd(ctx), id)
+		require.NoError(t, lerr)
+		out := make(map[string]database.ChatContextResource, len(rows))
+		for _, r := range rows {
+			out[r.Source] = r
+		}
+		return out
+	}
+
+	agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(agentToken))
+	aAPI, _, err := agentClient.ConnectRPC210(ctx)
+	require.NoError(t, err)
+	defer func() { _ = aAPI.DRPCConn().Close() }()
+
+	// Push 1: the boot snapshot, before any MCP server connected. The chat
+	// pins hashA with just the instruction file.
+	hashA := []byte{0x01}
+	resp, err := aAPI.PushContextState(ctx, &agentproto.PushContextStateRequest{
+		Version:       1,
+		Initial:       true,
+		AggregateHash: hashA,
+		Resources:     []*agentproto.ContextResource{instructionResource()},
+	})
+	require.NoError(t, err)
+	require.True(t, resp.GetAccepted())
+
+	got, err := expClient.GetChat(ctx, chat.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.Context)
+	require.False(t, got.Context.Dirty)
+	require.Len(t, pinnedResources(chat.ID), 1)
+
+	// Push 2: the MCP servers finished connecting. Only MCP resources were
+	// added, so the drift hash is unchanged; the sync must copy the MCP
+	// rows onto the clean chat without dirtying it.
+	resp, err = aAPI.PushContextState(ctx, &agentproto.PushContextStateRequest{
+		Version:       2,
+		AggregateHash: hashA,
+		Resources: []*agentproto.ContextResource{
+			instructionResource(),
+			mcpConfigResource(),
+			mcpServerResource(srvHashV1, "echo"),
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, resp.GetAccepted())
+
+	got, err = expClient.GetChat(ctx, chat.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.Context)
+	require.False(t, got.Context.Dirty, "an MCP-only change must not dirty the chat")
+
+	pinned := pinnedResources(chat.ID)
+	require.Len(t, pinned, 3, "MCP rows are synced onto the clean chat")
+	require.Equal(t, database.WorkspaceAgentContextBodyKindMcpConfig, pinned[mcpConfigSource].BodyKind)
+	require.Equal(t, database.WorkspaceAgentContextBodyKindMcpServer, pinned[mcpServerSource].BodyKind)
+	require.Equal(t, srvHashV1, pinned[mcpServerSource].ContentHash)
+	require.Equal(t, instrHash, pinned[agentsSource].ContentHash, "pinned prompt content is untouched")
+	require.Empty(t, pinnedResources(otherChat.ID), "agent-less chat stays untouched")
+
+	// The GET surfaces the synced MCP rows alongside the pinned prompt.
+	kinds := make(map[string]codersdk.ChatContextResourceKind, len(got.Context.Resources))
+	for _, r := range got.Context.Resources {
+		kinds[r.Source] = r.Kind
+	}
+	require.Equal(t, codersdk.ChatContextResourceKindMCPServer, kinds[mcpServerSource])
+	require.Equal(t, codersdk.ChatContextResourceKindMCPConfig, kinds[mcpConfigSource])
+
+	// Push 3: the server's tool list changed (still hash-neutral). The
+	// pinned MCP row must track the new content.
+	resp, err = aAPI.PushContextState(ctx, &agentproto.PushContextStateRequest{
+		Version:       3,
+		AggregateHash: hashA,
+		Resources: []*agentproto.ContextResource{
+			instructionResource(),
+			mcpConfigResource(),
+			mcpServerResource(srvHashV2, "echo", "search"),
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, resp.GetAccepted())
+
+	pinned = pinnedResources(chat.ID)
+	require.Len(t, pinned, 3)
+	require.Equal(t, srvHashV2, pinned[mcpServerSource].ContentHash, "tool list change updates the pinned row")
+
+	got, err = expClient.GetChat(ctx, chat.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.Context)
+	require.False(t, got.Context.Dirty)
+
+	// Push 4: the MCP servers disappeared (config removed, still
+	// hash-neutral). The pinned MCP rows must be deleted.
+	resp, err = aAPI.PushContextState(ctx, &agentproto.PushContextStateRequest{
+		Version:       4,
+		AggregateHash: hashA,
+		Resources:     []*agentproto.ContextResource{instructionResource()},
+	})
+	require.NoError(t, err)
+	require.True(t, resp.GetAccepted())
+
+	pinned = pinnedResources(chat.ID)
+	require.Len(t, pinned, 1, "removed MCP rows are deleted from the chat")
+	require.Equal(t, instrHash, pinned[agentsSource].ContentHash)
+
+	// Push 5: real prompt drift (different hash) dirties the chat and, as
+	// before, does not touch its pinned rows.
+	hashB := []byte{0x02}
+	resp, err = aAPI.PushContextState(ctx, &agentproto.PushContextStateRequest{
+		Version:       5,
+		AggregateHash: hashB,
+		Resources: []*agentproto.ContextResource{
+			instructionResource(),
+			mcpServerResource(srvHashV1, "echo"),
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, resp.GetAccepted())
+
+	got, err = expClient.GetChat(ctx, chat.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.Context)
+	require.True(t, got.Context.Dirty)
+	require.Len(t, pinnedResources(chat.ID), 1, "dirty marking does not copy resources")
+
+	// Push 6: the agent reverts to the pinned hash while the chat is still
+	// dirty. A dirty chat is awaiting an explicit refresh, so the sync
+	// must leave its pinned rows alone even though the hash matches.
+	resp, err = aAPI.PushContextState(ctx, &agentproto.PushContextStateRequest{
+		Version:       6,
+		AggregateHash: hashA,
+		Resources: []*agentproto.ContextResource{
+			instructionResource(),
+			mcpServerResource(srvHashV1, "echo"),
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, resp.GetAccepted())
+
+	got, err = expClient.GetChat(ctx, chat.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.Context)
+	require.True(t, got.Context.Dirty, "the chat stays dirty until refreshed")
+	require.Len(t, pinnedResources(chat.ID), 1, "dirty chats are not MCP-synced")
+}
+
 // agentMCPToolContext specifies an mcp_server tool to seed into an agent's
 // pushed context snapshot.
 type agentMCPToolContext struct {


### PR DESCRIPTION
## Problem

A customer reported fresh workspaces whose chats pin a context with zero `mcp_server` resources even though MCP servers (`CODER_AGENT_EXP_MCP_CONFIG_FILES`) are configured, reachable, and visible in the agent's own snapshot. The state persists indefinitely and is silent: no dirty badge, nothing to refresh. Touching the MCP config file recovers.

Root cause: MCP resources (`mcp_config`, `mcp_server`) are deliberately excluded from the context drift hash (#26533), so the follow-up push that adds them once the agent's MCP servers finish connecting carries the same aggregate hash as the boot snapshot. Such a push can neither hydrate a chat (`HydrateAgentChatsContext` only touches NULL-hash chats) nor dirty one (`MarkChatsContextDirtyByAgent` requires a hash difference). Since #26599 made the pinned `chat_context_resources` rows the sole source of chat MCP tools, any chat hydrated during the connect window keeps an empty pinned tool set forever.

A secondary aggravator: `doReload` waited for **all** servers to settle before committing any catalog, so one hanging server (bounded by the 30s connect timeout) delayed every healthy server's tools, widening the window in which chats pin MCP-less snapshots.

## Fix

1. **coderd: sync MCP rows into clean chats on push.** New `SyncChatContextMCPResourcesByAgent` query, wired into `HydrateAndMarkChatsDirty` inside the `PushContextState` transaction. For chats that are clean on exactly the pushed hash, it deletes stale MCP-kind pinned rows and upserts current ones (only when content actually differs). Pinned prompt content (instruction files, skills) and dirty chats stay untouched; prompt drift still flows exclusively through dirty-then-refresh.

2. **agentmcp: partial catalog publish.** If some servers are still connecting 5s into a reload, the servers that already settled are installed and published (and the reload callback fired) so their tools become visible and callable immediately. Still-connecting servers are omitted from the partial catalog rather than reported as failed; the final refresh publishes the complete picture. Connections replacing an existing entry defer to the final install so the replaced client is closed exactly once.

3. **agent: explicit re-resolve after the first MCP reload.** `handleManifest` now triggers a context re-resolve after `mcpManager.Reload` returns, so the pushed context always includes a resolve that ran after the initial connects settled, independent of catalog-change callback timing.

Regression tests: `TestChatContextMCPSyncFromAgentPush` (end-to-end push flow: sync, update, delete, dirty-chat and agent-less-chat isolation), `TestReload_PartialCatalogPublishesSettledServers` (quartz-clock-driven partial publish with a hanging stdio server), and `TestManager_TriggerBeforeReadyResolvesAfterReady` (pre-ready trigger is not lost).

<details>
<summary>Decision log</summary>

- **Sync on push instead of including MCP in the drift hash.** Including `mcp_server` in the aggregate hash would dirty every hydrated chat the moment a server finished connecting, spamming the dirty badge for something the user never pinned (the original rationale for excluding it in #26533). Server-side row sync keeps the hash semantics (prompt drift = explicit refresh) while making live-capability rows track the agent silently.
- **Eligibility: `context_aggregate_hash = pushed hash AND context_dirty_since IS NULL AND NOT archived`.** Dirty chats are awaiting an explicit refresh; mutating their pinned rows out from under the badge would blur the "pinned" contract. Chats pinned to an older hash are handled by the existing dirty/refresh flow. Freshly hydrated chats in the same transaction are included but the difference-guarded upsert makes them a no-op.
- **Delete scoped to `body_kind IN ('mcp_config','mcp_server')` on both sides**, so the statement can never remove or rewrite prompt rows. The single-statement CTE (delete + upsert) relies on both sub-statements seeing the same snapshot; they are disjoint by source.
- **Partial publish installs only genuinely new server names** (not in `diff.prev`). Replacement connections defer to the final install so the previous client keeps serving until then and is closed exactly once. `installServers` learns which clients the partial publish already installed so the manager-closed branch does not double-close them.
- **Partial catalog passes only settled servers to `refreshCatalog`**, so a still-connecting server is absent (pending) instead of a spurious `failed to connect` entry that would be pinned into chats.
- **One partial publish per reload**, timer on the manager's quartz clock for deterministic tests. Worst case adds one extra `ListTools` round per reload; median case cuts tool availability from ~30s (hanging-server bound) to ~5s.
- **Dropped two hardening ideas from the original plan** (a `pendingTrigger` flag and a post-publish catalog re-compare in agentcontext): analysis at HEAD showed the trigger-channel semantics plus `SetReady`'s unconditional re-signal already guarantee a post-change resolve in every interleaving. The guarantee is now locked in by `TestManager_TriggerBeforeReadyResolvesAfterReady` and the explicit `Trigger()` in `agent.go` instead of by redundant state.

</details>

---

🤖 This PR was generated by Coder Agents on behalf of @kylecarbs.