### PR TITLE
feat(site): support workspace file uploads from the new chat page

### DIFF
--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -1344,6 +1344,29 @@ export const createChatMessage = (
 	},
 });
 
+// Variant of createChatMessage for callers that only learn the chat ID
+// at mutate time, such as the new-chat page sending the first message
+// right after creating the chat.
+export const createChatMessageByChatId = (queryClient: QueryClient) => ({
+	mutationFn: ({
+		chatId,
+		req,
+	}: {
+		chatId: string;
+		req: TypesGen.CreateChatMessageRequest;
+	}) => API.experimental.createChatMessage(chatId, req),
+	onSuccess: (
+		_: TypesGen.CreateChatMessageResponse,
+		{ chatId }: { chatId: string; req: TypesGen.CreateChatMessageRequest },
+	) => {
+		void invalidateChatDebugRuns(queryClient, chatId);
+		void queryClient.invalidateQueries({
+			queryKey: chatPromptsKey(chatId),
+			exact: true,
+		});
+	},
+});
+
 type EditChatMessageMutationArgs = {
 	messageId: number;
 	optimisticMessage?: TypesGen.ChatMessage;

--- a/site/src/pages/AgentsPage/AgentCreatePage.tsx
+++ b/site/src/pages/AgentsPage/AgentCreatePage.tsx
@@ -28,6 +28,7 @@ import { AgentPageHeader } from "./components/AgentPageHeader";
 import { ChimeButton } from "./components/ChimeButton";
 import { WebPushButton } from "./components/WebPushButton";
 import { getAgentChatSendShortcut } from "./utils/agentChatSendShortcut";
+import { isAbortError } from "./utils/chatAttachments";
 import { getChimeEnabled, setChimeEnabled } from "./utils/chime";
 import {
 	countConfiguredProviderConfigs,
@@ -135,9 +136,11 @@ const AgentCreatePage: FC = () => {
 				// The empty chat never started generating, so archiving it
 				// right away is the cleanup path; retry creates a fresh one.
 				void archiveMutation.mutateAsync(createdChat.id).catch(() => {});
-				toast.error(
-					getErrorMessage(error, "Failed to upload files to the workspace."),
-				);
+				if (!isAbortError(error)) {
+					toast.error(
+						getErrorMessage(error, "Failed to upload files to the workspace."),
+					);
+				}
 				throw error;
 			}
 			const failedCount = uploaded.filter(

--- a/site/src/pages/AgentsPage/AgentCreatePage.tsx
+++ b/site/src/pages/AgentsPage/AgentCreatePage.tsx
@@ -4,10 +4,12 @@ import { useLocation, useNavigate } from "react-router";
 import { toast } from "sonner";
 import { getErrorMessage } from "#/api/errors";
 import {
+	archiveChat,
 	chatModelConfigs,
 	chatModels,
 	chatProviderConfigs,
 	createChat,
+	createChatMessageByChatId,
 	mcpServerConfigs,
 	userChatPersonalModelOverrides,
 	userChatProviderConfigs,
@@ -57,6 +59,10 @@ const AgentCreatePage: FC = () => {
 	const mcpServersQuery = useQuery(mcpServerConfigs());
 	const workspacesQuery = useQuery(workspaces({ q: "owner:me", limit: 0 }));
 	const createMutation = useMutation(createChat(queryClient));
+	const sendFirstMessageMutation = useMutation(
+		createChatMessageByChatId(queryClient),
+	);
+	const archiveMutation = useMutation(archiveChat(queryClient));
 	const webPush = useWebpushNotifications();
 	const [chimeEnabled, setChimeEnabledState] = useState(getChimeEnabled);
 
@@ -91,6 +97,7 @@ const AgentCreatePage: FC = () => {
 		mcpServerIds,
 		organizationId,
 		planMode,
+		uploadWorkspaceFiles,
 	}: CreateChatOptions) => {
 		const content: TypesGen.ChatInputPart[] = [];
 		if (message.trim()) {
@@ -103,7 +110,10 @@ const AgentCreatePage: FC = () => {
 		}
 		const createRequest: TypesGen.CreateChatRequest = {
 			organization_id: organizationId,
-			content,
+			// Workspace files need the chat ID to upload, so the chat is
+			// created idle without content and the first message follows
+			// after the uploads land.
+			content: uploadWorkspaceFiles ? [] : content,
 			workspace_id: workspaceId,
 			mcp_server_ids:
 				mcpServerIds && mcpServerIds.length > 0 ? mcpServerIds : undefined,
@@ -116,6 +126,73 @@ const AgentCreatePage: FC = () => {
 		if (model) {
 			localStorage.setItem(lastModelConfigIDStorageKey, model);
 		}
+
+		if (uploadWorkspaceFiles) {
+			let uploaded: Awaited<ReturnType<typeof uploadWorkspaceFiles>>;
+			try {
+				uploaded = await uploadWorkspaceFiles(createdChat.id);
+			} catch (error) {
+				// The empty chat never started generating, so archiving it
+				// right away is the cleanup path; retry creates a fresh one.
+				void archiveMutation.mutateAsync(createdChat.id).catch(() => {});
+				toast.error(
+					getErrorMessage(error, "Failed to upload files to the workspace."),
+				);
+				throw error;
+			}
+			const failedCount = uploaded.filter(
+				(upload) => upload.status !== "uploaded" || !upload.response,
+			).length;
+			if (failedCount > 0) {
+				void archiveMutation.mutateAsync(createdChat.id).catch(() => {});
+				toast.error(
+					`${failedCount} file${failedCount > 1 ? "s" : ""} failed to upload to the workspace. Remove or retry the failed files, then send again.`,
+				);
+				throw new Error("workspace file upload failed");
+			}
+			for (const upload of uploaded) {
+				if (!upload.response) {
+					continue;
+				}
+				content.push({
+					type: "workspace-file-reference",
+					workspace_file_path: upload.response.path,
+					workspace_file_name: upload.response.name,
+					workspace_file_size: upload.response.size,
+					workspace_file_media_type:
+						upload.response.media_type || "application/octet-stream",
+					workspace_file_workspace_id: upload.response.workspace_id,
+				});
+			}
+			// All entries removed mid-upload leaves nothing to say; the
+			// idle chat behaves like a plain empty create.
+			if (content.length > 0) {
+				// Built outside the try block: React Compiler does not
+				// support value blocks inside try/catch.
+				const firstMessageReq: TypesGen.CreateChatMessageRequest = {
+					content,
+					mcp_server_ids:
+						mcpServerIds && mcpServerIds.length > 0 ? mcpServerIds : undefined,
+					plan_mode: planMode === "plan" ? "plan" : undefined,
+					...(model ? { model_config_id: model } : {}),
+				};
+				const firstMessage = {
+					chatId: createdChat.id,
+					req: firstMessageReq,
+				};
+				try {
+					await sendFirstMessageMutation.mutateAsync(firstMessage);
+				} catch (error) {
+					// Without the message the fresh chat is an empty shell,
+					// so archive it and stay on the composer with the draft
+					// intact; a retry re-creates the chat and re-uploads.
+					void archiveMutation.mutateAsync(createdChat.id).catch(() => {});
+					toast.error(getErrorMessage(error, "Failed to send the message."));
+					throw error;
+				}
+			}
+		}
+
 		navigate({
 			pathname: buildAgentChatPath({ chatId: createdChat.id }),
 			search: location.search,

--- a/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
@@ -1316,6 +1316,55 @@ export const WorkspaceUploadRefusedWhileDisabled: Story = {
 	},
 };
 
+export const DeferredErrorChipKeepsSendEnabled: Story = {
+	args: {
+		workspaceUploads: {
+			uploads: [
+				{
+					id: "wf-err",
+					file: createMockFile("dataset.zip", "application/zip"),
+					status: "error",
+					error: "upload failed",
+				},
+			],
+			onAttach: fn(),
+			onRemove: fn(),
+			deferred: true,
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// Deferred submits re-upload failed entries, so a failed chip
+		// alone must keep the retry path available.
+		await waitFor(() => {
+			expect(canvas.getByRole("button", { name: "Send" })).toBeEnabled();
+		});
+	},
+};
+
+export const ErrorChipAloneKeepsSendDisabled: Story = {
+	args: {
+		workspaceUploads: {
+			uploads: [
+				{
+					id: "wf-err",
+					file: createMockFile("dataset.zip", "application/zip"),
+					status: "error",
+					error: "upload failed",
+				},
+			],
+			onAttach: fn(),
+			onRemove: fn(),
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// Outside deferred mode a failed upload is not retried by
+		// sending, so it contributes no sendable content.
+		expect(canvas.getByRole("button", { name: "Send" })).toBeDisabled();
+	},
+};
+
 export const PasteRefusedFileFallsBackToText: Story = {
 	args: {
 		onAttach: fn(),

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -102,6 +102,14 @@ interface WorkspaceUploadsProps {
 	// connected agent; its absence hides the whole affordance.
 	onAttach?: (files: File[]) => void;
 	onRemove: (id: string) => void;
+	// Toast shown when a workspace-routed file arrives while onAttach
+	// is unavailable. Overridden on the new-chat page, where the fix
+	// is selecting a workspace rather than attaching one to the chat.
+	unavailableMessage?: string;
+	// Deferred mode (new-chat page): entries upload during submit and
+	// every entry re-uploads on the next send after a failure, so
+	// error chips still count as sendable content.
+	deferred?: boolean;
 }
 
 const workspaceRequiredAttachmentMessage =
@@ -791,7 +799,10 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 			}
 		}
 		if (dropped > 0) {
-			toast.error(workspaceRequiredAttachmentMessage);
+			toast.error(
+				workspaceUploads?.unavailableMessage ??
+					workspaceRequiredAttachmentMessage,
+			);
 		}
 		if (attachable.length === 0 && forWorkspace.length === 0) {
 			return false;
@@ -908,9 +919,18 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	const hasActiveUploads =
 		attachments.some((file) => isUploadInProgress(uploadStates?.get(file))) ||
 		workspaceUploadEntries.some((upload) => upload.status === "uploading");
+	// Queued workspace entries upload during submit (deferred mode),
+	// so they count as sendable content just like finished uploads. In
+	// deferred mode failed entries stay sendable too: the next send
+	// re-uploads them against the fresh chat.
 	const hasUploadedAttachments =
 		attachments.some((f) => uploadStates?.get(f)?.status === "uploaded") ||
-		workspaceUploadEntries.some((upload) => upload.status === "uploaded");
+		workspaceUploadEntries.some(
+			(upload) =>
+				upload.status === "uploaded" ||
+				upload.status === "queued" ||
+				(workspaceUploads?.deferred === true && upload.status === "error"),
+		);
 	const hasDraftContext =
 		hasContent ||
 		attachments.length > 0 ||

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -16,8 +16,9 @@ import {
 	MockDefaultOrganization,
 	MockOrganization2,
 	MockWorkspace,
+	MockWorkspaceAgent,
 } from "#/testHelpers/entities";
-import { withDashboardProvider } from "#/testHelpers/storybook";
+import { withDashboardProvider, withToaster } from "#/testHelpers/storybook";
 import { AgentCreateForm } from "./AgentCreateForm";
 
 // Query key used by permittedOrganizations() in the form.
@@ -827,5 +828,310 @@ export const PermittedOrgsResolvesToSubset: Story = {
 			throw new Error("Expected onCreateChat to receive options");
 		}
 		expect(options.organizationId).toBe(MockOrganization2.id);
+	},
+};
+
+// Deferred workspace uploads: with a workspace selected, files that
+// cannot ride the attachment pipeline (e.g. zips) queue locally and
+// upload during submit, after the chat is created.
+
+const attachZipFile = async (canvasElement: HTMLElement) => {
+	const fileInput =
+		canvasElement.querySelector<HTMLInputElement>('input[type="file"]');
+	if (!fileInput) {
+		throw new Error("Expected the hidden attachment file input.");
+	}
+	const zip = new File([new Uint8Array([0x50, 0x4b, 3, 4])], "bundle.zip", {
+		type: "application/zip",
+	});
+	// Without a workspace the input's accept attribute excludes zips;
+	// bypass it to exercise the routing logic like a drag-and-drop
+	// would.
+	await userEvent.upload(fileInput, zip, { applyAccept: false });
+};
+
+export const WorkspaceFileQueuedForDeferredUpload: Story = {
+	args: {
+		workspaceOptions: mockWorkspaces,
+		workspaceCount: mockWorkspaces.length,
+	},
+	beforeEach: () => {
+		localStorage.clear();
+		localStorage.setItem("agents.selected-workspace-id", "ws-1");
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await attachZipFile(canvasElement);
+		// The zip queues locally instead of erroring: no chat exists
+		// yet, so the upload happens during submit.
+		await waitFor(() => {
+			expect(canvas.getByText("bundle.zip")).toBeInTheDocument();
+			expect(canvas.getByText("Uploads when sent")).toBeInTheDocument();
+		});
+	},
+};
+
+export const WorkspaceFileWithDisconnectedAgentShowsSelectToast: Story = {
+	args: {
+		workspaceOptions: [
+			{
+				...MockWorkspace,
+				id: "ws-stopped",
+				latest_build: {
+					...MockWorkspace.latest_build,
+					status: "stopped" as const,
+					resources: [
+						{
+							...MockWorkspace.latest_build.resources[0],
+							agents: [
+								{ ...MockWorkspaceAgent, status: "disconnected" as const },
+							],
+						},
+					],
+				},
+			},
+		],
+		workspaceCount: 1,
+	},
+	decorators: [withToaster],
+	beforeEach: () => {
+		localStorage.clear();
+		localStorage.setItem("agents.selected-workspace-id", "ws-stopped");
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(canvasElement.ownerDocument.body);
+		await attachZipFile(canvasElement);
+		// A selected but stopped workspace cannot accept uploads (the
+		// agent endpoint rejects unless connected), so the zip must not
+		// queue for a send that is guaranteed to fail.
+		await waitFor(() => {
+			expect(
+				body.getByText(
+					"This file type is uploaded into the chat's workspace. Select a running workspace, then try again.",
+				),
+			).toBeInTheDocument();
+		});
+		expect(canvas.queryByText("bundle.zip")).not.toBeInTheDocument();
+	},
+};
+
+export const WorkspaceFileWithoutWorkspaceShowsSelectToast: Story = {
+	args: {
+		workspaceOptions: mockWorkspaces,
+		workspaceCount: mockWorkspaces.length,
+	},
+	decorators: [withToaster],
+	beforeEach: () => {
+		localStorage.clear();
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(canvasElement.ownerDocument.body);
+		await attachZipFile(canvasElement);
+		// Without a selected workspace the zip cannot upload anywhere;
+		// the toast says to select one (not "attach to the chat",
+		// which is the existing-chat copy).
+		await waitFor(() => {
+			expect(
+				body.getByText(
+					"This file type is uploaded into the chat's workspace. Select a running workspace, then try again.",
+				),
+			).toBeInTheDocument();
+		});
+		expect(canvas.queryByText("bundle.zip")).not.toBeInTheDocument();
+	},
+};
+
+export const QueuedWorkspaceFileSubmitsWithUploadCallback: Story = {
+	args: {
+		onCreateChat: fn().mockResolvedValue(undefined),
+		workspaceOptions: mockWorkspaces,
+		workspaceCount: mockWorkspaces.length,
+	},
+	beforeEach: () => {
+		localStorage.clear();
+		localStorage.setItem("agents.selected-workspace-id", "ws-1");
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		await attachZipFile(canvasElement);
+		await waitFor(() => {
+			expect(canvas.getByText("Uploads when sent")).toBeInTheDocument();
+		});
+		await submitMessage(canvasElement, "inspect this archive");
+		await waitFor(() => {
+			expect(args.onCreateChat).toHaveBeenCalled();
+		});
+		const options = (args.onCreateChat as ReturnType<typeof fn>).mock
+			.calls[0]?.[0] as
+			| { workspaceId?: string; uploadWorkspaceFiles?: unknown }
+			| undefined;
+		if (!options) {
+			throw new Error("Expected onCreateChat to receive options.");
+		}
+		// The page uses the callback's presence to switch to the
+		// create-empty -> upload -> first-message sequence.
+		expect(options.workspaceId).toBe("ws-1");
+		expect(typeof options.uploadWorkspaceFiles).toBe("function");
+	},
+};
+
+export const TextOnlySubmitSkipsUploadCallback: Story = {
+	args: {
+		onCreateChat: fn().mockResolvedValue(undefined),
+		workspaceOptions: mockWorkspaces,
+		workspaceCount: mockWorkspaces.length,
+	},
+	beforeEach: () => {
+		localStorage.clear();
+		localStorage.setItem("agents.selected-workspace-id", "ws-1");
+	},
+	play: async ({ canvasElement, args }) => {
+		await submitMessage(canvasElement, "plain text message");
+		await waitFor(() => {
+			expect(args.onCreateChat).toHaveBeenCalled();
+		});
+		const options = (args.onCreateChat as ReturnType<typeof fn>).mock
+			.calls[0]?.[0] as { uploadWorkspaceFiles?: unknown } | undefined;
+		expect(options?.uploadWorkspaceFiles).toBeUndefined();
+	},
+};
+
+export const DetachingWorkspaceDropsQueuedFiles: Story = {
+	args: {
+		workspaceOptions: mockWorkspaces,
+		workspaceCount: mockWorkspaces.length,
+	},
+	decorators: [withToaster],
+	beforeEach: () => {
+		localStorage.clear();
+		localStorage.setItem("agents.selected-workspace-id", "ws-1");
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(canvasElement.ownerDocument.body);
+		await attachZipFile(canvasElement);
+		await waitFor(() => {
+			expect(canvas.getByText("bundle.zip")).toBeInTheDocument();
+		});
+		// Detach the workspace via its composer badge; the queued file
+		// has nowhere to upload, so it is dropped with a notice.
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Remove workspace my-project" }),
+		);
+		await waitFor(() => {
+			expect(canvas.queryByText("bundle.zip")).not.toBeInTheDocument();
+		});
+		await waitFor(() => {
+			expect(
+				body.getByText("Removed 1 file that uploads to the workspace"),
+			).toBeInTheDocument();
+		});
+	},
+};
+
+export const OrgChangeWithQueuedWorkspaceFilesAsksConfirmation: Story = {
+	parameters: {
+		showOrganizations: true,
+		organizations: [MockDefaultOrganization, MockOrganization2],
+		queries: [
+			{
+				key: permittedOrgsKey,
+				data: [MockDefaultOrganization, MockOrganization2],
+			},
+		],
+	},
+	args: {
+		workspaceOptions: mockWorkspaces,
+		workspaceCount: mockWorkspaces.length,
+	},
+	beforeEach: () => {
+		localStorage.clear();
+		localStorage.setItem("agents.selected-workspace-id", "ws-1");
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await attachZipFile(canvasElement);
+		await waitFor(() => {
+			expect(canvas.getByText("bundle.zip")).toBeInTheDocument();
+		});
+		// Switching orgs clears the workspace selection, which drops
+		// queued workspace files, so it must ask for the same
+		// confirmation DB attachments get instead of discarding them.
+		await userEvent.click(canvas.getByTestId("compact-org-selector"));
+		const option = await screen.findByText("My Organization 2");
+		await userEvent.click(option);
+		const dialog = await screen.findByRole("dialog");
+		expect(
+			within(dialog).getByText("Change organization?"),
+		).toBeInTheDocument();
+		// Cancelling keeps the queued file.
+		await userEvent.click(
+			within(dialog).getByRole("button", { name: /cancel/i }),
+		);
+		await waitFor(() => {
+			expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+		});
+		expect(canvas.getByText("bundle.zip")).toBeInTheDocument();
+	},
+};
+
+export const SwitchingToStoppedWorkspaceDropsQueuedFiles: Story = {
+	args: {
+		workspaceOptions: [
+			mockWorkspaces[0],
+			{
+				...MockWorkspace,
+				id: "ws-stopped",
+				name: "stopped-project",
+				owner_name: "johndoe",
+				owner_id: "user-1",
+				latest_build: {
+					...MockWorkspace.latest_build,
+					status: "stopped" as const,
+					resources: [
+						{
+							...MockWorkspace.latest_build.resources[0],
+							agents: [
+								{ ...MockWorkspaceAgent, status: "disconnected" as const },
+							],
+						},
+					],
+				},
+			},
+		],
+		workspaceCount: 2,
+	},
+	decorators: [withToaster],
+	beforeEach: () => {
+		localStorage.clear();
+		localStorage.setItem("agents.selected-workspace-id", "ws-1");
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(canvasElement.ownerDocument.body);
+		await attachZipFile(canvasElement);
+		await waitFor(() => {
+			expect(canvas.getByText("bundle.zip")).toBeInTheDocument();
+		});
+		// Switch the picker to a stopped workspace. Its agent cannot
+		// accept uploads, so keeping the queued file would doom the
+		// submit; it drops with the same notice as a deselect.
+		await userEvent.click(canvas.getByRole("button", { name: "More options" }));
+		const attachWorkspaceButton = (
+			await body.findByText("Attach workspace")
+		).closest("button");
+		if (!(attachWorkspaceButton instanceof HTMLButtonElement)) {
+			throw new Error("Expected Attach workspace to be a button.");
+		}
+		await userEvent.click(attachWorkspaceButton);
+		await userEvent.click(await body.findByText("stopped-project"));
+		await waitFor(() => {
+			expect(
+				body.getByText("Removed 1 file that uploads to the workspace"),
+			).toBeInTheDocument();
+		});
+		expect(canvas.queryByText("bundle.zip")).not.toBeInTheDocument();
 	},
 };

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -977,6 +977,50 @@ export const QueuedWorkspaceFileSubmitsWithUploadCallback: Story = {
 	},
 };
 
+export const WorkspaceFileSubmissionLocksScopeControls: Story = {
+	parameters: {
+		showOrganizations: true,
+		organizations: [MockDefaultOrganization, MockOrganization2],
+		queries: [
+			{
+				key: permittedOrgsKey,
+				data: [MockDefaultOrganization, MockOrganization2],
+			},
+		],
+	},
+	args: {
+		onCreateChat: fn(),
+		workspaceOptions: mockWorkspaces,
+		workspaceCount: mockWorkspaces.length,
+	},
+	beforeEach: () => {
+		localStorage.clear();
+		localStorage.setItem("agents.selected-workspace-id", "ws-1");
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		(args.onCreateChat as ReturnType<typeof fn>).mockImplementation(
+			() => new Promise<void>(() => {}),
+		);
+		await attachZipFile(canvasElement);
+		await submitMessage(canvasElement, "inspect this archive");
+		await waitFor(() => {
+			expect(args.onCreateChat).toHaveBeenCalled();
+		});
+
+		await waitFor(() => {
+			expect(canvas.getByTestId("compact-org-selector")).toBeDisabled();
+			expect(
+				canvas.getByRole("button", { name: "More options" }),
+			).toBeDisabled();
+			expect(canvas.getByRole("textbox")).toHaveAttribute(
+				"aria-disabled",
+				"true",
+			);
+		});
+	},
+};
+
 export const TextOnlySubmitSkipsUploadCallback: Story = {
 	args: {
 		onCreateChat: fn().mockResolvedValue(undefined),

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -13,6 +13,10 @@ import { ConfirmDialog } from "#/components/Dialogs/ConfirmDialog/ConfirmDialog"
 import { useDashboard } from "#/modules/dashboard/useDashboard";
 import { docs } from "#/utils/docs";
 import { useFileAttachments } from "../hooks/useFileAttachments";
+import {
+	useWorkspaceFileUploads,
+	type WorkspaceFileUpload,
+} from "../hooks/useWorkspaceFileUploads";
 import { parseStoredDraft } from "../utils/draftStorage";
 import {
 	getModelSelectorPlaceholder,
@@ -26,6 +30,7 @@ import {
 } from "../utils/usageLimitMessage";
 import { AgentChatInput } from "./AgentChatInput";
 import { ChatAccessDeniedAlert } from "./ChatAccessDeniedAlert";
+import { getWorkspaceAgent } from "./ChatConversation/chatHelpers";
 import type { ModelSelectorOption } from "./ChatElements";
 import { CompactOrgSelector } from "./ChatElements";
 import {
@@ -50,6 +55,13 @@ export type CreateChatOptions = {
 	mcpServerIds?: string[];
 	organizationId: string;
 	planMode?: TypesGen.ChatPlanMode;
+	// When present, the submit carries files destined for the chat's
+	// workspace. The page creates the chat without content, runs this
+	// callback to upload against the new chat ID, then sends the first
+	// message with the returned references.
+	uploadWorkspaceFiles?: (
+		chatId: string,
+	) => Promise<readonly WorkspaceFileUpload[]>;
 };
 
 /**
@@ -360,7 +372,22 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 			? selectedWorkspaceId
 			: null;
 
-	const handleSend = async (message: string, fileIDs?: string[]) => {
+	// Deferred uploads eventually hit the same agent endpoint as the
+	// chat view, which rejects unless the agent is connected. Gate the
+	// affordance on the agent the server would pick (no chat exists to
+	// bind one yet) so a stopped workspace fails at attach time instead
+	// of after creating a chat destined for an upload failure.
+	const selectedWorkspace = filteredWorkspaces.find(
+		(ws) => ws.id === effectiveWorkspaceId,
+	);
+	const canUploadWorkspaceFiles =
+		getWorkspaceAgent(selectedWorkspace, undefined)?.status === "connected";
+
+	const handleSend = async (
+		message: string,
+		fileIDs?: string[],
+		uploadWorkspaceFiles?: CreateChatOptions["uploadWorkspaceFiles"],
+	) => {
 		submitDraft();
 		await onCreateChat({
 			message,
@@ -373,6 +400,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 					? [...effectiveMCPServerIds]
 					: undefined,
 			planMode: planModeEnabled ? "plan" : undefined,
+			uploadWorkspaceFiles,
 		}).catch((err) => {
 			resetDraft();
 			throw err;
@@ -391,6 +419,39 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		persist: true,
 		provider: getProviderForModelOption(modelOptions, selectedModel),
 	});
+
+	// Deferred workspace uploads: no chat exists yet, so files queue
+	// locally and upload during submit against the just-created chat.
+	// Scope arguments stay undefined so workspace switches never drop
+	// the queue; queued files carry no uploaded bytes and target
+	// whichever workspace is bound at submit time.
+	const workspaceUploads = useWorkspaceFileUploads(undefined, undefined);
+	const {
+		uploads: workspaceUploadEntries,
+		reset: resetWorkspaceUploads,
+		uploadQueued: uploadQueuedWorkspaceFiles,
+	} = workspaceUploads;
+	// Locks the composer across the whole create/upload/send sequence,
+	// which spans more than the create mutation's pending window.
+	const [isUploadSubmitPending, setIsUploadSubmitPending] = useState(false);
+
+	// Workspace files can only upload into a workspace whose agent is
+	// connected. Losing that (deselecting, an org change, or switching
+	// to a stopped workspace) drops the queued files; keeping them
+	// would let a submit create an idle chat whose uploads are
+	// guaranteed to fail.
+	const workspaceUploadCount = workspaceUploadEntries.length;
+	useEffect(() => {
+		if (canUploadWorkspaceFiles || workspaceUploadCount === 0) {
+			return;
+		}
+		resetWorkspaceUploads();
+		toast.warning(
+			workspaceUploadCount === 1
+				? "Removed 1 file that uploads to the workspace"
+				: `Removed ${workspaceUploadCount} files that upload to the workspace`,
+		);
+	}, [canUploadWorkspaceFiles, workspaceUploadCount, resetWorkspaceUploads]);
 
 	const handleSendWithAttachments = async (message: string) => {
 		const fileIds: string[] = [];
@@ -411,12 +472,30 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 			);
 		}
 		const fileArg = fileIds.length > 0 ? fileIds : undefined;
-		try {
-			await handleSend(message, fileArg);
-			resetAttachments();
-		} catch {
-			// Attachments preserved for retry on failure.
+		if (workspaceUploadEntries.length === 0) {
+			try {
+				await handleSend(message, fileArg);
+				resetAttachments();
+			} catch {
+				// Attachments preserved for retry on failure.
+			}
+			return;
 		}
+		// Deferred workspace files ride along: hand the page an upload
+		// callback bound to this hook. It re-uploads every entry, so a
+		// retry after failure targets the fresh chat. The catch
+		// swallows every error (state is preserved for retry), so the
+		// pending flag always clears below; React Compiler does not
+		// support try/finally.
+		setIsUploadSubmitPending(true);
+		try {
+			await handleSend(message, fileArg, uploadQueuedWorkspaceFiles);
+			resetAttachments();
+			resetWorkspaceUploads();
+		} catch {
+			// Attachments and queued files preserved for retry.
+		}
+		setIsUploadSubmitPending(false);
 	};
 
 	const permittedOrgsQuery = useQuery({
@@ -499,7 +578,14 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 							options={permittedOrgs}
 							onChange={(newOrg) => {
 								const orgChanged = newOrg.id !== selectedOrg?.id;
-								if (orgChanged && attachments.length > 0) {
+								// Queued workspace files are dropped alongside DB
+								// attachments when the org changes (the workspace
+								// deselect effect clears them), so they get the
+								// same confirmation.
+								if (
+									orgChanged &&
+									(attachments.length > 0 || workspaceUploadCount > 0)
+								) {
 									setPendingOrgChange(newOrg);
 									return;
 								}
@@ -516,12 +602,13 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						placeholder="Ask Coder to build, fix bugs, or explore your project..."
 						isDisabled={
 							isCreating ||
+							isUploadSubmitPending ||
 							isForbidden ||
 							isPersonalModelOverridesLoading ||
 							!hasModelOptions ||
 							Boolean(aiGatewayDisabled)
 						}
-						isLoading={isCreating}
+						isLoading={isCreating || isUploadSubmitPending}
 						initialValue={initialInputValue}
 						initialEditorState={initialEditorState}
 						onContentChange={handleContentChange}
@@ -539,6 +626,16 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						uploadStates={uploadStates}
 						previewUrls={previewUrls}
 						textContents={textContents}
+						workspaceUploads={{
+							uploads: workspaceUploadEntries,
+							onAttach: canUploadWorkspaceFiles
+								? workspaceUploads.attach
+								: undefined,
+							onRemove: workspaceUploads.remove,
+							unavailableMessage:
+								"This file type is uploaded into the chat's workspace. Select a running workspace, then try again.",
+							deferred: true,
+						}}
 						mcpServers={mcpServers}
 						selectedMCPServerIds={effectiveMCPServerIds}
 						onMCPSelectionChange={(ids) => {

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -434,6 +434,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	// Locks the composer across the whole create/upload/send sequence,
 	// which spans more than the create mutation's pending window.
 	const [isUploadSubmitPending, setIsUploadSubmitPending] = useState(false);
+	const isSubmitPending = isCreating || isUploadSubmitPending;
 
 	// Workspace files can only upload into a workspace whose agent is
 	// connected. Losing that (deselecting, an org change, or switching
@@ -576,6 +577,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						<CompactOrgSelector
 							value={selectedOrg}
 							options={permittedOrgs}
+							disabled={isSubmitPending}
 							onChange={(newOrg) => {
 								const orgChanged = newOrg.id !== selectedOrg?.id;
 								// Queued workspace files are dropped alongside DB
@@ -601,14 +603,13 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						sendShortcut={sendShortcut}
 						placeholder="Ask Coder to build, fix bugs, or explore your project..."
 						isDisabled={
-							isCreating ||
-							isUploadSubmitPending ||
+							isSubmitPending ||
 							isForbidden ||
 							isPersonalModelOverridesLoading ||
 							!hasModelOptions ||
 							Boolean(aiGatewayDisabled)
 						}
-						isLoading={isCreating || isUploadSubmitPending}
+						isLoading={isSubmitPending}
 						initialValue={initialInputValue}
 						initialEditorState={initialEditorState}
 						onContentChange={handleContentChange}
@@ -645,7 +646,9 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						onMCPAuthComplete={onMCPAuthComplete}
 						workspaceOptions={filteredWorkspaces}
 						selectedWorkspaceId={effectiveWorkspaceId}
-						onWorkspaceChange={handleWorkspaceChange}
+						onWorkspaceChange={
+							isSubmitPending ? undefined : handleWorkspaceChange
+						}
 						isWorkspaceLoading={isWorkspacesLoading}
 						canConfigureAgentSetup={canConfigureAgentSetup}
 						providerCount={providerCount}

--- a/site/src/pages/AgentsPage/components/WorkspaceUploadPreview.stories.tsx
+++ b/site/src/pages/AgentsPage/components/WorkspaceUploadPreview.stories.tsx
@@ -39,6 +39,22 @@ export const Uploaded: Story = {
 	},
 };
 
+export const Queued: Story = {
+	args: {
+		uploads: [
+			{
+				id: "queued-1",
+				file: createMockFile("bundle.zip", "application/zip"),
+				status: "queued",
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("Uploads when sent")).toBeInTheDocument();
+	},
+};
+
 export const Uploading: Story = {
 	args: {
 		uploads: [

--- a/site/src/pages/AgentsPage/components/WorkspaceUploadPreview.tsx
+++ b/site/src/pages/AgentsPage/components/WorkspaceUploadPreview.tsx
@@ -13,6 +13,8 @@ import type { WorkspaceFileUpload } from "../hooks/useWorkspaceFileUploads";
 
 const uploadStatusLabel = (upload: WorkspaceFileUpload): string => {
 	switch (upload.status) {
+		case "queued":
+			return "Uploads when sent";
 		case "uploading":
 			return "Uploading to workspace...";
 		case "uploaded":
@@ -88,7 +90,9 @@ export const WorkspaceUploadPreview: FC<{
 							<TooltipContent side="top">
 								{upload.status === "uploaded"
 									? "Removes the reference. Uploaded bytes stay in the workspace."
-									: "Cancel this upload"}
+									: upload.status === "queued"
+										? "Remove this file"
+										: "Cancel this upload"}
 							</TooltipContent>
 						</Tooltip>
 					</div>

--- a/site/src/pages/AgentsPage/hooks/useWorkspaceFileUploads.test.ts
+++ b/site/src/pages/AgentsPage/hooks/useWorkspaceFileUploads.test.ts
@@ -117,6 +117,92 @@ describe("useWorkspaceFileUploads", () => {
 		);
 	});
 
+	it("does not upload an entry removed before a deferred callback runs", async () => {
+		uploadMock.mockResolvedValue(okResponse);
+		const { result } = renderHook(() =>
+			useWorkspaceFileUploads(undefined, undefined),
+		);
+
+		act(() => {
+			result.current.attach([makeFile()]);
+		});
+		const uploadQueued = result.current.uploadQueued;
+		const [entry] = result.current.uploads;
+
+		act(() => {
+			result.current.remove(entry.id);
+		});
+
+		let settled: readonly { status: string }[] = [];
+		await act(async () => {
+			settled = await uploadQueued("chat-9");
+		});
+
+		expect(settled).toHaveLength(0);
+		expect(uploadMock).not.toHaveBeenCalled();
+	});
+
+	it("rejects a deferred callback invalidated before it runs", async () => {
+		uploadMock.mockResolvedValue(okResponse);
+		const { result } = renderHook(() =>
+			useWorkspaceFileUploads(undefined, undefined),
+		);
+
+		act(() => {
+			result.current.attach([makeFile()]);
+		});
+		const uploadQueued = result.current.uploadQueued;
+
+		act(() => {
+			result.current.reset();
+		});
+
+		await expect(uploadQueued("chat-9")).rejects.toMatchObject({
+			name: "AbortError",
+		});
+		expect(uploadMock).not.toHaveBeenCalled();
+	});
+
+	it("rejects uploadQueued when reset cancels an in-flight submission", async () => {
+		let capturedSignal: AbortSignal | undefined;
+		uploadMock.mockImplementationOnce(
+			(_chatId: string, _file: File, signal?: AbortSignal) => {
+				capturedSignal = signal;
+				return new Promise((_resolve, reject) => {
+					signal?.addEventListener(
+						"abort",
+						() => reject(new DOMException("aborted", "AbortError")),
+						{ once: true },
+					);
+				});
+			},
+		);
+		const { result } = renderHook(() =>
+			useWorkspaceFileUploads(undefined, undefined),
+		);
+
+		act(() => {
+			result.current.attach([makeFile()]);
+		});
+		const settledPromise = result.current.uploadQueued("chat-9");
+		await waitFor(() => {
+			expect(uploadMock).toHaveBeenCalledOnce();
+		});
+
+		let settledError: unknown;
+		await act(async () => {
+			result.current.reset();
+			try {
+				await settledPromise;
+			} catch (error) {
+				settledError = error;
+			}
+		});
+
+		expect(settledError).toMatchObject({ name: "AbortError" });
+		expect(capturedSignal?.aborted).toBe(true);
+	});
+
 	it("uploadQueued reports per-file failures and keeps chips in error state", async () => {
 		uploadMock
 			.mockResolvedValueOnce(okResponse)

--- a/site/src/pages/AgentsPage/hooks/useWorkspaceFileUploads.test.ts
+++ b/site/src/pages/AgentsPage/hooks/useWorkspaceFileUploads.test.ts
@@ -84,17 +84,169 @@ describe("useWorkspaceFileUploads", () => {
 		expect(result.current.uploads[0].error).toBeTruthy();
 	});
 
-	it("errors immediately without a chat id", () => {
+	it("queues entries without a chat id until uploadQueued runs them", async () => {
+		uploadMock.mockResolvedValue(okResponse);
 		const { result } = renderHook(() =>
-			useWorkspaceFileUploads(undefined, "ws-1"),
+			useWorkspaceFileUploads(undefined, undefined),
+		);
+
+		act(() => {
+			result.current.attach([makeFile("a.tar"), makeFile("b.tar")]);
+		});
+
+		expect(result.current.uploads).toHaveLength(2);
+		expect(result.current.uploads.every((u) => u.status === "queued")).toBe(
+			true,
+		);
+		expect(uploadMock).not.toHaveBeenCalled();
+
+		let settled: readonly { status: string }[] = [];
+		await act(async () => {
+			settled = await result.current.uploadQueued("chat-9");
+		});
+
+		expect(settled).toHaveLength(2);
+		expect(settled.every((u) => u.status === "uploaded")).toBe(true);
+		expect(result.current.uploads.every((u) => u.status === "uploaded")).toBe(
+			true,
+		);
+		expect(uploadMock).toHaveBeenCalledWith(
+			"chat-9",
+			expect.any(File),
+			expect.any(AbortSignal),
+		);
+	});
+
+	it("uploadQueued reports per-file failures and keeps chips in error state", async () => {
+		uploadMock
+			.mockResolvedValueOnce(okResponse)
+			.mockRejectedValueOnce(new Error("boom"));
+		const { result } = renderHook(() =>
+			useWorkspaceFileUploads(undefined, undefined),
+		);
+
+		act(() => {
+			result.current.attach([makeFile("a.tar"), makeFile("b.tar")]);
+		});
+
+		let settled: readonly { status: string }[] = [];
+		await act(async () => {
+			settled = await result.current.uploadQueued("chat-9");
+		});
+
+		expect(settled).toHaveLength(2);
+		expect(settled.filter((u) => u.status === "uploaded")).toHaveLength(1);
+		expect(settled.filter((u) => u.status === "error")).toHaveLength(1);
+		expect(
+			result.current.uploads.filter((u) => u.status === "error"),
+		).toHaveLength(1);
+	});
+
+	it("uploadQueued re-uploads every entry on retry", async () => {
+		uploadMock
+			.mockRejectedValueOnce(new Error("boom"))
+			.mockResolvedValue(okResponse);
+		const { result } = renderHook(() =>
+			useWorkspaceFileUploads(undefined, undefined),
 		);
 
 		act(() => {
 			result.current.attach([makeFile()]);
 		});
 
+		await act(async () => {
+			await result.current.uploadQueued("chat-1");
+		});
 		expect(result.current.uploads[0].status).toBe("error");
-		expect(uploadMock).not.toHaveBeenCalled();
+
+		// The retry targets a fresh chat, so the failed entry uploads
+		// again rather than being skipped.
+		let settled: readonly { status: string }[] = [];
+		await act(async () => {
+			settled = await result.current.uploadQueued("chat-2");
+		});
+
+		expect(settled).toHaveLength(1);
+		expect(settled[0].status).toBe("uploaded");
+		expect(uploadMock).toHaveBeenLastCalledWith(
+			"chat-2",
+			expect.any(File),
+			expect.any(AbortSignal),
+		);
+	});
+
+	it("uploadQueued excludes entries removed mid-upload", async () => {
+		let resolveUpload: ((value: unknown) => void) | undefined;
+		uploadMock.mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					resolveUpload = resolve;
+				}),
+		);
+		uploadMock.mockResolvedValueOnce(okResponse);
+		const { result } = renderHook(() =>
+			useWorkspaceFileUploads(undefined, undefined),
+		);
+
+		act(() => {
+			result.current.attach([makeFile("a.tar"), makeFile("b.tar")]);
+		});
+		const [first] = result.current.uploads;
+
+		let settledPromise: Promise<readonly { status: string }[]> | undefined;
+		act(() => {
+			settledPromise = result.current.uploadQueued("chat-1");
+		});
+		act(() => {
+			result.current.remove(first.id);
+		});
+		resolveUpload?.(okResponse);
+
+		const settled = await settledPromise;
+		expect(settled).toHaveLength(1);
+		expect(settled?.[0].status).toBe("uploaded");
+		expect(result.current.uploads).toHaveLength(1);
+	});
+
+	it("uploadQueued excludes entries removed after their upload completed", async () => {
+		let resolveSecond: ((value: unknown) => void) | undefined;
+		uploadMock.mockResolvedValueOnce(okResponse);
+		uploadMock.mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					resolveSecond = resolve;
+				}),
+		);
+		const { result } = renderHook(() =>
+			useWorkspaceFileUploads(undefined, undefined),
+		);
+
+		act(() => {
+			result.current.attach([makeFile("a.tar"), makeFile("b.tar")]);
+		});
+		const [first] = result.current.uploads;
+
+		let settledPromise:
+			| Promise<readonly { id: string; status: string }[]>
+			| undefined;
+		act(() => {
+			settledPromise = result.current.uploadQueued("chat-1");
+		});
+		// The first file settles as uploaded while the second is still
+		// in flight; removing its chip now must drop it from the final
+		// results even though its settle promise already resolved.
+		await waitFor(() => {
+			expect(result.current.uploads[0]?.status).toBe("uploaded");
+		});
+		act(() => {
+			result.current.remove(first.id);
+		});
+		resolveSecond?.(okResponse);
+
+		const settled = await settledPromise;
+		expect(settled).toHaveLength(1);
+		expect(settled?.[0].id).not.toBe(first.id);
+		expect(result.current.uploads).toHaveLength(1);
 	});
 
 	it("remove aborts an in-flight upload and drops the entry", async () => {

--- a/site/src/pages/AgentsPage/hooks/useWorkspaceFileUploads.ts
+++ b/site/src/pages/AgentsPage/hooks/useWorkspaceFileUploads.ts
@@ -5,7 +5,7 @@ import type { UploadChatWorkspaceFileResponse } from "#/api/typesGenerated";
 import { renameChatFileForUpload } from "../utils/chatAttachments";
 import { formatAgentAttachmentUploadError } from "../utils/fileAttachmentLimits";
 
-type WorkspaceFileUploadStatus = "uploading" | "uploaded" | "error";
+type WorkspaceFileUploadStatus = "queued" | "uploading" | "uploaded" | "error";
 
 export type WorkspaceFileUpload = {
 	id: string;
@@ -22,6 +22,13 @@ interface UseWorkspaceFileUploadsReturn {
 	attach: (files: File[]) => void;
 	remove: (id: string) => void;
 	reset: () => void;
+	// Uploads every entry into the given chat and resolves with the
+	// settled per-file results (entries removed mid-flight are
+	// excluded). Used by the deferred mode, where files queue before
+	// the chat exists. Prior results are discarded: a retry targets a
+	// fresh chat, so paths uploaded for an abandoned one are unusable.
+	// Must not run concurrently with itself.
+	uploadQueued: (chatId: string) => Promise<readonly WorkspaceFileUpload[]>;
 }
 
 // Workspace uploads have no size cap, so bound the number of parallel
@@ -39,13 +46,16 @@ const createUploadId = (): string => {
 };
 
 /**
- * Manages eager uploads of files into the chat's workspace filesystem
- * via POST /api/experimental/chats/{chat}/workspace-files.
+ * Manages uploads of files into the chat's workspace filesystem via
+ * POST /api/experimental/chats/{chat}/workspace-files.
  *
- * Uploads start as soon as files are attached, bounded to a small
- * number of concurrent streams. Removing an entry aborts its in-flight
- * upload, but bytes that already reached the workspace stay there;
- * removal only drops the composer reference.
+ * With a chat ID, uploads start eagerly as soon as files are attached,
+ * bounded to a small number of concurrent streams. Without a chat ID,
+ * attached files queue locally (deferred mode, used by the new-chat
+ * page) until `uploadQueued` runs them against a just-created chat.
+ * Removing an entry aborts its in-flight upload, but bytes that
+ * already reached the workspace stay there; removal only drops the
+ * composer reference.
  *
  * Uploads are scoped to the chat and its bound workspace: switching
  * either one resets the pending set, because already-uploaded bytes
@@ -60,11 +70,20 @@ export function useWorkspaceFileUploads(
 	const abortControllersRef = useRef(new Map<string, AbortController>());
 	const pendingQueueRef = useRef<{ id: string; file: File }[]>([]);
 	const activeCountRef = useRef(0);
+	// Per-entry settle callbacks for uploadQueued. Entries resolve with
+	// the final upload record, or null when removed/aborted mid-flight.
+	const settleCallbacksRef = useRef(
+		new Map<string, (result: WorkspaceFileUpload | null) => void>(),
+	);
 	// Incremented whenever pending uploads are aborted (reset or scope
 	// switch). Workers spawned under an older generation must not
 	// consume entries queued after the abort: they carry a stale chat
 	// ID and their slot accounting was already zeroed.
 	const generationRef = useRef(0);
+	// Ids removed since the last reset. A chip removed after its file
+	// already settled cannot un-resolve that settle promise, so
+	// uploadQueued drops these ids from its final results instead.
+	const removedIdsRef = useRef(new Set<string>());
 	const scopeKey = `${chatId ?? ""}/${workspaceId ?? ""}`;
 	const previousScopeKeyRef = useRef(scopeKey);
 
@@ -81,6 +100,14 @@ export function useWorkspaceFileUploads(
 	});
 	const { mutateAsync: uploadFile } = uploadMutation;
 
+	const settleUpload = (id: string, result: WorkspaceFileUpload | null) => {
+		const settle = settleCallbacksRef.current.get(id);
+		if (settle) {
+			settleCallbacksRef.current.delete(id);
+			settle(result);
+		}
+	};
+
 	const abortAllUploads = () => {
 		generationRef.current++;
 		for (const controller of abortControllersRef.current.values()) {
@@ -89,6 +116,13 @@ export function useWorkspaceFileUploads(
 		abortControllersRef.current.clear();
 		pendingQueueRef.current = [];
 		activeCountRef.current = 0;
+		// Settle any outstanding uploadQueued waiters so callers never
+		// hang across a reset or scope switch.
+		for (const settle of settleCallbacksRef.current.values()) {
+			settle(null);
+		}
+		settleCallbacksRef.current.clear();
+		removedIdsRef.current.clear();
 	};
 
 	const reset = () => {
@@ -140,15 +174,32 @@ export function useWorkspaceFileUploads(
 						signal: controller.signal,
 					});
 					setUploadResult(next.id, { status: "uploaded", response });
+					settleUpload(next.id, {
+						id: next.id,
+						file: next.file,
+						status: "uploaded",
+						response,
+					});
 				} catch (error: unknown) {
 					if (!controller.signal.aborted) {
+						const message = formatAgentAttachmentUploadError(error);
 						setUploadResult(next.id, {
 							status: "error",
-							error: formatAgentAttachmentUploadError(error),
+							error: message,
 						});
+						settleUpload(next.id, {
+							id: next.id,
+							file: next.file,
+							status: "error",
+							error: message,
+						});
+					} else {
+						settleUpload(next.id, null);
 					}
 				}
 				abortControllersRef.current.delete(next.id);
+			} else {
+				settleUpload(next.id, null);
 			}
 			if (generationRef.current !== generation) {
 				// An abort invalidated this worker mid-upload. Entries
@@ -161,17 +212,14 @@ export function useWorkspaceFileUploads(
 		activeCountRef.current--;
 	};
 
-	const pumpQueue = () => {
-		if (!chatId) {
-			return;
-		}
+	const pumpQueue = (uploadChatId: string) => {
 		// Workers shift their first queue entry synchronously, so this
 		// loop spawns at most one worker per pending file.
 		while (
 			activeCountRef.current < maxConcurrentWorkspaceUploads &&
 			pendingQueueRef.current.length > 0
 		) {
-			void runUploadWorker(chatId);
+			void runUploadWorker(uploadChatId);
 		}
 	};
 
@@ -179,35 +227,74 @@ export function useWorkspaceFileUploads(
 		const entries = incoming.map((file) => ({
 			id: createUploadId(),
 			file: renameChatFileForUpload(file),
-			status: "uploading" as const,
 		}));
 		if (!chatId) {
+			// Deferred mode: no chat exists yet, so entries queue
+			// locally until uploadQueued runs them.
 			setUploads((prev) => [
 				...prev,
-				...entries.map((entry) => ({
-					...entry,
-					status: "error" as const,
-					error: "Cannot upload: no active chat. Open or start a chat first.",
-				})),
+				...entries.map((entry) => ({ ...entry, status: "queued" as const })),
 			]);
 			return;
 		}
-		setUploads((prev) => [...prev, ...entries]);
+		setUploads((prev) => [
+			...prev,
+			...entries.map((entry) => ({
+				...entry,
+				status: "uploading" as const,
+			})),
+		]);
 		for (const entry of entries) {
 			abortControllersRef.current.set(entry.id, new AbortController());
 			pendingQueueRef.current.push({ id: entry.id, file: entry.file });
 		}
-		pumpQueue();
+		pumpQueue(chatId);
+	};
+
+	const uploadQueued = async (
+		uploadChatId: string,
+	): Promise<readonly WorkspaceFileUpload[]> => {
+		// Entry ids and files are immutable, so the render-time
+		// snapshot is safe here even though statuses may be stale.
+		const entries = uploads;
+		if (entries.length === 0) {
+			return [];
+		}
+		const settled = entries.map(
+			(entry) =>
+				new Promise<WorkspaceFileUpload | null>((resolve) => {
+					settleCallbacksRef.current.set(entry.id, resolve);
+				}),
+		);
+		setUploads((prev) =>
+			prev.map((upload) => ({
+				id: upload.id,
+				file: upload.file,
+				status: "uploading" as const,
+			})),
+		);
+		for (const entry of entries) {
+			abortControllersRef.current.set(entry.id, new AbortController());
+			pendingQueueRef.current.push({ id: entry.id, file: entry.file });
+		}
+		pumpQueue(uploadChatId);
+		const results = await Promise.all(settled);
+		return results.filter(
+			(result): result is WorkspaceFileUpload =>
+				result !== null && !removedIdsRef.current.has(result.id),
+		);
 	};
 
 	const remove = (id: string) => {
+		removedIdsRef.current.add(id);
 		abortControllersRef.current.get(id)?.abort();
 		abortControllersRef.current.delete(id);
 		pendingQueueRef.current = pendingQueueRef.current.filter(
 			(entry) => entry.id !== id,
 		);
+		settleUpload(id, null);
 		setUploads((prev) => prev.filter((upload) => upload.id !== id));
 	};
 
-	return { uploads, attach, remove, reset };
+	return { uploads, attach, remove, reset, uploadQueued };
 }

--- a/site/src/pages/AgentsPage/hooks/useWorkspaceFileUploads.ts
+++ b/site/src/pages/AgentsPage/hooks/useWorkspaceFileUploads.ts
@@ -45,6 +45,12 @@ const createUploadId = (): string => {
 	return `upload-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 };
 
+const createUploadCancellationError = (): Error => {
+	const error = new Error("Workspace file upload canceled.");
+	error.name = "AbortError";
+	return error;
+};
+
 /**
  * Manages uploads of files into the chat's workspace filesystem via
  * POST /api/experimental/chats/{chat}/workspace-files.
@@ -67,19 +73,26 @@ export function useWorkspaceFileUploads(
 	workspaceId: string | undefined,
 ): UseWorkspaceFileUploadsReturn {
 	const [uploads, setUploads] = useState<readonly WorkspaceFileUpload[]>([]);
+	const uploadsRef = useRef<readonly WorkspaceFileUpload[]>([]);
+	const generationRef = useRef(0);
+	// Deferred callbacks capture this render's generation. A reset
+	// updates the state after incrementing the ref, so callbacks from
+	// an older render reject instead of operating on the new queue.
+	const [queueGeneration, setQueueGeneration] = useState(0);
 	const abortControllersRef = useRef(new Map<string, AbortController>());
 	const pendingQueueRef = useRef<{ id: string; file: File }[]>([]);
 	const activeCountRef = useRef(0);
-	// Per-entry settle callbacks for uploadQueued. Entries resolve with
-	// the final upload record, or null when removed/aborted mid-flight.
+	// Per-entry settle callbacks for uploadQueued. Explicit removal
+	// resolves with null; reset and scope cancellation reject the batch.
 	const settleCallbacksRef = useRef(
-		new Map<string, (result: WorkspaceFileUpload | null) => void>(),
+		new Map<
+			string,
+			{
+				resolve: (result: WorkspaceFileUpload | null) => void;
+				reject: (error: Error) => void;
+			}
+		>(),
 	);
-	// Incremented whenever pending uploads are aborted (reset or scope
-	// switch). Workers spawned under an older generation must not
-	// consume entries queued after the abort: they carry a stale chat
-	// ID and their slot accounting was already zeroed.
-	const generationRef = useRef(0);
 	// Ids removed since the last reset. A chip removed after its file
 	// already settled cannot un-resolve that settle promise, so
 	// uploadQueued drops these ids from its final results instead.
@@ -100,11 +113,21 @@ export function useWorkspaceFileUploads(
 	});
 	const { mutateAsync: uploadFile } = uploadMutation;
 
+	const updateUploads = (
+		update: (
+			current: readonly WorkspaceFileUpload[],
+		) => readonly WorkspaceFileUpload[],
+	) => {
+		const next = update(uploadsRef.current);
+		uploadsRef.current = next;
+		setUploads(next);
+	};
+
 	const settleUpload = (id: string, result: WorkspaceFileUpload | null) => {
 		const settle = settleCallbacksRef.current.get(id);
 		if (settle) {
 			settleCallbacksRef.current.delete(id);
-			settle(result);
+			settle.resolve(result);
 		}
 	};
 
@@ -116,10 +139,9 @@ export function useWorkspaceFileUploads(
 		abortControllersRef.current.clear();
 		pendingQueueRef.current = [];
 		activeCountRef.current = 0;
-		// Settle any outstanding uploadQueued waiters so callers never
-		// hang across a reset or scope switch.
+		const cancellationError = createUploadCancellationError();
 		for (const settle of settleCallbacksRef.current.values()) {
-			settle(null);
+			settle.reject(cancellationError);
 		}
 		settleCallbacksRef.current.clear();
 		removedIdsRef.current.clear();
@@ -127,7 +149,8 @@ export function useWorkspaceFileUploads(
 
 	const reset = () => {
 		abortAllUploads();
-		setUploads([]);
+		setQueueGeneration(generationRef.current);
+		updateUploads(() => []);
 	};
 
 	// Abort any in-flight uploads when the composer unmounts.
@@ -150,8 +173,8 @@ export function useWorkspaceFileUploads(
 		id: string,
 		result: Partial<WorkspaceFileUpload>,
 	) => {
-		setUploads((prev) =>
-			prev.map((upload) =>
+		updateUploads((current) =>
+			current.map((upload) =>
 				upload.id === id ? { ...upload, ...result } : upload,
 			),
 		);
@@ -231,14 +254,14 @@ export function useWorkspaceFileUploads(
 		if (!chatId) {
 			// Deferred mode: no chat exists yet, so entries queue
 			// locally until uploadQueued runs them.
-			setUploads((prev) => [
-				...prev,
+			updateUploads((current) => [
+				...current,
 				...entries.map((entry) => ({ ...entry, status: "queued" as const })),
 			]);
 			return;
 		}
-		setUploads((prev) => [
-			...prev,
+		updateUploads((current) => [
+			...current,
 			...entries.map((entry) => ({
 				...entry,
 				status: "uploading" as const,
@@ -254,20 +277,21 @@ export function useWorkspaceFileUploads(
 	const uploadQueued = async (
 		uploadChatId: string,
 	): Promise<readonly WorkspaceFileUpload[]> => {
-		// Entry ids and files are immutable, so the render-time
-		// snapshot is safe here even though statuses may be stale.
-		const entries = uploads;
+		if (generationRef.current !== queueGeneration) {
+			throw createUploadCancellationError();
+		}
+		const entries = uploadsRef.current;
 		if (entries.length === 0) {
 			return [];
 		}
 		const settled = entries.map(
 			(entry) =>
-				new Promise<WorkspaceFileUpload | null>((resolve) => {
-					settleCallbacksRef.current.set(entry.id, resolve);
+				new Promise<WorkspaceFileUpload | null>((resolve, reject) => {
+					settleCallbacksRef.current.set(entry.id, { resolve, reject });
 				}),
 		);
-		setUploads((prev) =>
-			prev.map((upload) => ({
+		updateUploads((current) =>
+			current.map((upload) => ({
 				id: upload.id,
 				file: upload.file,
 				status: "uploading" as const,
@@ -279,6 +303,9 @@ export function useWorkspaceFileUploads(
 		}
 		pumpQueue(uploadChatId);
 		const results = await Promise.all(settled);
+		if (generationRef.current !== queueGeneration) {
+			throw createUploadCancellationError();
+		}
 		return results.filter(
 			(result): result is WorkspaceFileUpload =>
 				result !== null && !removedIdsRef.current.has(result.id),
@@ -293,7 +320,7 @@ export function useWorkspaceFileUploads(
 			(entry) => entry.id !== id,
 		);
 		settleUpload(id, null);
-		setUploads((prev) => prev.filter((upload) => upload.id !== id));
+		updateUploads((current) => current.filter((upload) => upload.id !== id));
 	};
 
 	return { uploads, attach, remove, reset, uploadQueued };


### PR DESCRIPTION
> Written by Mux on behalf of Mike.

## What

Workspace-routed files, such as zip archives, can now be attached on the new-chat page when a running workspace is selected. Previously the upload endpoint required a chat ID that did not exist yet, so the landing page rejected these files with a misleading toast.

## How

- Queue workspace files locally until submit, then create an idle chat, upload the queued files, send the first message with workspace-file references, and navigate after the message succeeds.
- Keep retries and partial failures safe by re-uploading into a fresh chat, archiving failed shell chats, and preserving the draft.
- Ignore files explicitly removed before or during upload, but treat reset, scope changes, and unmount as cancellation so the flow cannot continue with stale or partial workspace files.
- Lock the organization, workspace, and composer controls for the complete create, upload, and send sequence.
- Show landing-page copy that asks the user to select a running workspace.

## Follow-ups

- The create page gates workspace uploads on any connected root agent; the server picks the agent with `agentselect.FindChatAgent`, so a multi-root-agent workspace with a disconnected chat-suffixed agent passes the gate and fails on upload (error toast, draft preserved, shell chat archived). An exact probe needs the selection exposed by the API.
- Freeze regular attachment add/remove controls while the deferred workspace upload runs; the message is sent with the attachment IDs snapshotted at submit time, and `AttachmentPreview`/`AgentChatInput` currently have no read-only mode (the same window exists on the chat page while a send is pending).
- Skip the final navigation when the user leaves the page while the deferred first-message request is in flight (needs an unmounted signal through the page; the regular create path on main has the same window).
- Route a failed deferred first message through the form's inline hook-failure presentation (with the lifecycle-hook dispatch detail) instead of the toast; needs the send mutation state lifted into the form.
- Port the `AgentCreateForm` story `play` assertions (including the deferred-submit ones added here) to Vitest once the form has a test harness; the file's existing stories follow the same pattern.

## Notes

Queued `File` objects do not survive a page reload. A browser closing mid-sequence can leave an idle, archivable chat after an explicit submit.

