### PR TITLE
fix(coderd): serialize chat model config default election with advisory lock

### DIFF
--- a/coderd/database/lock.go
+++ b/coderd/database/lock.go
@@ -16,7 +16,7 @@ const (
 	LockIDReconcileSystemRoles
 	LockIDBoundaryUsageStats
 	LockIDAIProvidersEnvSeed
-	LockIDChatModelConfigDefault
+	LockIDChatModelConfigWrites
 )
 
 // GenLockID generates a unique and consistent lock ID from a given string.

--- a/coderd/database/lock.go
+++ b/coderd/database/lock.go
@@ -16,6 +16,7 @@ const (
 	LockIDReconcileSystemRoles
 	LockIDBoundaryUsageStats
 	LockIDAIProvidersEnvSeed
+	LockIDChatModelConfigDefault
 )
 
 // GenLockID generates a unique and consistent lock ID from a given string.

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -7039,15 +7039,14 @@ func validateChatModelConfigProviderModel(aiProvider database.AIProvider, model 
 	return nil
 }
 
-// inChatModelConfigTx runs fn in a transaction holding the advisory lock that
-// serializes default elections. Electing a default reads the table before
-// promoting a row, so without the lock two concurrent writers could both
-// self-promote and trip idx_chat_model_configs_single_default. The lock makes
-// the whole election run one at a time, so the index is never contended.
-func (api *API) inChatModelConfigTx(ctx context.Context, fn func(tx database.Store) error) error {
+// inChatModelConfigWriteTx runs fn in a transaction that holds the advisory
+// lock serializing chat model config writes. All writes to the table must go
+// through this helper so concurrent writers cannot act on stale reads and
+// violate the idx_chat_model_configs_single_default unique index.
+func (api *API) inChatModelConfigWriteTx(ctx context.Context, fn func(tx database.Store) error) error {
 	return api.Database.InTx(func(tx database.Store) error {
-		if err := tx.AcquireLock(ctx, database.LockIDChatModelConfigDefault); err != nil {
-			return xerrors.Errorf("acquire chat model config lock: %w", err)
+		if err := tx.AcquireLock(ctx, database.LockIDChatModelConfigWrites); err != nil {
+			return xerrors.Errorf("acquire chat model config write lock: %w", err)
 		}
 		return fn(tx)
 	}, nil)
@@ -7155,7 +7154,7 @@ func (api *API) createChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	var inserted database.ChatModelConfig
-	err = api.inChatModelConfigTx(ctx, func(tx database.Store) error {
+	err = api.inChatModelConfigWriteTx(ctx, func(tx database.Store) error {
 		//nolint:gocritic // The route already authorized chat model config updates.
 		lockedAIProvider, err := tx.GetAIProviderByIDForReferenceLock(dbauthz.AsChatd(ctx), insertParams.AIProviderID.UUID)
 		if err != nil {
@@ -7364,7 +7363,7 @@ func (api *API) updateChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 	// Re-derive the provider type under lock when the model or provider changes.
 	revalidateProviderModel := updateParams.AIProviderID.Valid && (req.AIProviderID != nil || strings.TrimSpace(req.Model) != "")
 	var updated database.ChatModelConfig
-	err = api.inChatModelConfigTx(ctx, func(tx database.Store) error {
+	err = api.inChatModelConfigWriteTx(ctx, func(tx database.Store) error {
 		if revalidateProviderModel {
 			//nolint:gocritic // The route already authorized chat model config updates.
 			aiProvider, err := tx.GetAIProviderByIDForReferenceLock(dbauthz.AsChatd(ctx), updateParams.AIProviderID.UUID)
@@ -7480,7 +7479,7 @@ func (api *API) deleteChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := api.inChatModelConfigTx(ctx, func(tx database.Store) error {
+	if err := api.inChatModelConfigWriteTx(ctx, func(tx database.Store) error {
 		if err := tx.DeleteChatModelConfigByID(ctx, modelConfigID); err != nil {
 			return err
 		}

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -7039,6 +7039,23 @@ func validateChatModelConfigProviderModel(aiProvider database.AIProvider, model 
 	return nil
 }
 
+// inChatModelConfigTx runs a default-election transaction, retrying when it
+// loses the single-default unique index race. Electing a default reads the
+// table then promotes a row, so concurrent writers can both self-promote and
+// one trips idx_chat_model_configs_single_default. Rerunning re-reads
+// committed state, so the loser sees the winner's default and no longer
+// self-promotes. fn must be safe to re-run from scratch.
+func (api *API) inChatModelConfigTx(fn func(tx database.Store) error) error {
+	var err error
+	for range 3 {
+		err = api.Database.InTx(fn, nil)
+		if !database.IsUniqueViolation(err, database.UniqueIndexChatModelConfigsSingleDefault) {
+			return err
+		}
+	}
+	return err
+}
+
 func (api *API) createChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
@@ -7141,7 +7158,7 @@ func (api *API) createChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	var inserted database.ChatModelConfig
-	err = api.Database.InTx(func(tx database.Store) error {
+	err = api.inChatModelConfigTx(func(tx database.Store) error {
 		//nolint:gocritic // The route already authorized chat model config updates.
 		lockedAIProvider, err := tx.GetAIProviderByIDForReferenceLock(dbauthz.AsChatd(ctx), insertParams.AIProviderID.UUID)
 		if err != nil {
@@ -7193,7 +7210,7 @@ func (api *API) createChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 		}
 		inserted = refreshedConfig
 		return nil
-	}, nil)
+	})
 	if err != nil {
 		var providerModelErr *chatModelConfigProviderModelError
 		switch {
@@ -7350,7 +7367,7 @@ func (api *API) updateChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 	// Re-derive the provider type under lock when the model or provider changes.
 	revalidateProviderModel := updateParams.AIProviderID.Valid && (req.AIProviderID != nil || strings.TrimSpace(req.Model) != "")
 	var updated database.ChatModelConfig
-	err = api.Database.InTx(func(tx database.Store) error {
+	err = api.inChatModelConfigTx(func(tx database.Store) error {
 		if revalidateProviderModel {
 			//nolint:gocritic // The route already authorized chat model config updates.
 			aiProvider, err := tx.GetAIProviderByIDForReferenceLock(dbauthz.AsChatd(ctx), updateParams.AIProviderID.UUID)
@@ -7406,7 +7423,7 @@ func (api *API) updateChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 		}
 		updated = refreshedConfig
 		return nil
-	}, nil)
+	})
 	if err != nil {
 		var providerModelErr *chatModelConfigProviderModelError
 		switch {
@@ -7466,12 +7483,12 @@ func (api *API) deleteChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := api.Database.InTx(func(tx database.Store) error {
+	if err := api.inChatModelConfigTx(func(tx database.Store) error {
 		if err := tx.DeleteChatModelConfigByID(ctx, modelConfigID); err != nil {
 			return err
 		}
 		return ensureDefaultChatModelConfig(ctx, tx)
-	}, nil); err != nil {
+	}); err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Failed to delete chat model config.",
 			Detail:  err.Error(),

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -7041,8 +7041,9 @@ func validateChatModelConfigProviderModel(aiProvider database.AIProvider, model 
 
 // inChatModelConfigWriteTx runs fn in a transaction that holds the advisory
 // lock serializing chat model config writes. All writes to the table must go
-// through this helper so concurrent writers cannot act on stale reads and
-// violate the idx_chat_model_configs_single_default unique index.
+// through this helper so concurrent writers cannot act on stale reads, e.g.
+// two creates on an empty deployment both self-promoting to default and
+// violating the idx_chat_model_configs_single_default unique index.
 func (api *API) inChatModelConfigWriteTx(ctx context.Context, fn func(tx database.Store) error) error {
 	return api.Database.InTx(func(tx database.Store) error {
 		if err := tx.AcquireLock(ctx, database.LockIDChatModelConfigWrites); err != nil {

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -7039,21 +7039,18 @@ func validateChatModelConfigProviderModel(aiProvider database.AIProvider, model 
 	return nil
 }
 
-// inChatModelConfigTx runs a default-election transaction, retrying when it
-// loses the single-default unique index race. Electing a default reads the
-// table then promotes a row, so concurrent writers can both self-promote and
-// one trips idx_chat_model_configs_single_default. Rerunning re-reads
-// committed state, so the loser sees the winner's default and no longer
-// self-promotes. fn must be safe to re-run from scratch.
-func (api *API) inChatModelConfigTx(fn func(tx database.Store) error) error {
-	var err error
-	for range 3 {
-		err = api.Database.InTx(fn, nil)
-		if !database.IsUniqueViolation(err, database.UniqueIndexChatModelConfigsSingleDefault) {
-			return err
+// inChatModelConfigTx runs fn in a transaction holding the advisory lock that
+// serializes default elections. Electing a default reads the table before
+// promoting a row, so without the lock two concurrent writers could both
+// self-promote and trip idx_chat_model_configs_single_default. The lock makes
+// the whole election run one at a time, so the index is never contended.
+func (api *API) inChatModelConfigTx(ctx context.Context, fn func(tx database.Store) error) error {
+	return api.Database.InTx(func(tx database.Store) error {
+		if err := tx.AcquireLock(ctx, database.LockIDChatModelConfigDefault); err != nil {
+			return xerrors.Errorf("acquire chat model config lock: %w", err)
 		}
-	}
-	return err
+		return fn(tx)
+	}, nil)
 }
 
 func (api *API) createChatModelConfig(rw http.ResponseWriter, r *http.Request) {
@@ -7158,7 +7155,7 @@ func (api *API) createChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	var inserted database.ChatModelConfig
-	err = api.inChatModelConfigTx(func(tx database.Store) error {
+	err = api.inChatModelConfigTx(ctx, func(tx database.Store) error {
 		//nolint:gocritic // The route already authorized chat model config updates.
 		lockedAIProvider, err := tx.GetAIProviderByIDForReferenceLock(dbauthz.AsChatd(ctx), insertParams.AIProviderID.UUID)
 		if err != nil {
@@ -7367,7 +7364,7 @@ func (api *API) updateChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 	// Re-derive the provider type under lock when the model or provider changes.
 	revalidateProviderModel := updateParams.AIProviderID.Valid && (req.AIProviderID != nil || strings.TrimSpace(req.Model) != "")
 	var updated database.ChatModelConfig
-	err = api.inChatModelConfigTx(func(tx database.Store) error {
+	err = api.inChatModelConfigTx(ctx, func(tx database.Store) error {
 		if revalidateProviderModel {
 			//nolint:gocritic // The route already authorized chat model config updates.
 			aiProvider, err := tx.GetAIProviderByIDForReferenceLock(dbauthz.AsChatd(ctx), updateParams.AIProviderID.UUID)
@@ -7483,7 +7480,7 @@ func (api *API) deleteChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := api.inChatModelConfigTx(func(tx database.Store) error {
+	if err := api.inChatModelConfigTx(ctx, func(tx database.Store) error {
 		if err := tx.DeleteChatModelConfigByID(ctx, modelConfigID); err != nil {
 			return err
 		}

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/shopspring/decimal"
 	"github.com/sqlc-dev/pqtype"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3/sloggers/slogtest"
@@ -3787,6 +3788,46 @@ func TestCreateChatModelConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, configs, 1)
 		requireChatModelPricing(t, configs[0].ModelConfig, pricing)
+	})
+
+	t.Run("ConcurrentCreatesElectSingleDefault", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newChatClient(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+
+		aiProvider := createAIProviderForTest(t, client, "openai", "test-api-key")
+
+		// All creators race to become the default on an empty deployment.
+		// Without the election retry the losers hit the single-default
+		// unique index and surface as 409s. 10 creators mirrors Terraform's
+		// default parallelism, where this was hit in practice.
+		const creators = 10
+		contextLimit := int64(4096)
+		var eg errgroup.Group
+		for i := range creators {
+			eg.Go(func() error {
+				_, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+					AIProviderID: &aiProvider.ID,
+					Model:        fmt.Sprintf("gpt-4o-mini-%d", i),
+					ContextLimit: &contextLimit,
+				})
+				return err
+			})
+		}
+		require.NoError(t, eg.Wait())
+
+		configs, err := client.ListChatModelConfigs(ctx)
+		require.NoError(t, err)
+		require.Len(t, configs, creators)
+		defaults := 0
+		for _, cfg := range configs {
+			if cfg.IsDefault {
+				defaults++
+			}
+		}
+		require.Equal(t, 1, defaults)
 	})
 
 	t.Run("RejectsNegativePricing", func(t *testing.T) {

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -3800,9 +3800,10 @@ func TestCreateChatModelConfig(t *testing.T) {
 		aiProvider := createAIProviderForTest(t, client, "openai", "test-api-key")
 
 		// All creators race to become the default on an empty deployment.
-		// Without the election retry the losers hit the single-default
-		// unique index and surface as 409s. 10 creators mirrors Terraform's
-		// default parallelism, where this was hit in practice.
+		// The advisory lock serializes the elections so only one wins;
+		// without it the losers hit the single-default unique index and
+		// surface as 409s. 10 creators mirrors Terraform's default
+		// parallelism, where this was hit in practice.
 		const creators = 10
 		contextLimit := int64(4096)
 		var eg errgroup.Group

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -3799,15 +3799,17 @@ func TestCreateChatModelConfig(t *testing.T) {
 
 		aiProvider := createAIProviderForTest(t, client, "openai", "test-api-key")
 
-		// All creators race to become the default on an empty deployment.
-		// The advisory lock serializes the elections so only one wins;
-		// without it the losers hit the single-default unique index and
-		// surface as 409s. 10 creators mirrors Terraform's default
+		// All creators race to become the default on an empty deployment,
+		// with one explicitly claiming it. Config writes are serialized, so
+		// only one self-promotes and the explicit claim demotes any interim
+		// winner; without that the losers hit the single-default unique
+		// index and surface as 409s. 10 creators mirrors Terraform's default
 		// parallelism, where this was hit in practice.
 		const creators = 10
 		contextLimit := int64(4096)
+		var claimed codersdk.ChatModelConfig
 		var eg errgroup.Group
-		for i := range creators {
+		for i := range creators - 1 {
 			eg.Go(func() error {
 				_, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
 					AIProviderID: &aiProvider.ID,
@@ -3817,18 +3819,28 @@ func TestCreateChatModelConfig(t *testing.T) {
 				return err
 			})
 		}
+		eg.Go(func() error {
+			var err error
+			claimed, err = client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+				AIProviderID: &aiProvider.ID,
+				Model:        "gpt-4o",
+				ContextLimit: &contextLimit,
+				IsDefault:    ptr.Ref(true),
+			})
+			return err
+		})
 		require.NoError(t, eg.Wait())
 
 		configs, err := client.ListChatModelConfigs(ctx)
 		require.NoError(t, err)
 		require.Len(t, configs, creators)
-		defaults := 0
+		var defaults []uuid.UUID
 		for _, cfg := range configs {
 			if cfg.IsDefault {
-				defaults++
+				defaults = append(defaults, cfg.ID)
 			}
 		}
-		require.Equal(t, 1, defaults)
+		require.Equal(t, []uuid.UUID{claimed.ID}, defaults)
 	})
 
 	t.Run("RejectsNegativePricing", func(t *testing.T) {

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -3799,12 +3799,9 @@ func TestCreateChatModelConfig(t *testing.T) {
 
 		aiProvider := createAIProviderForTest(t, client, "openai", "test-api-key")
 
-		// All creators race to become the default on an empty deployment,
-		// with one explicitly claiming it. Config writes are serialized, so
-		// only one self-promotes and the explicit claim demotes any interim
-		// winner; without that the losers hit the single-default unique
-		// index and surface as 409s. 10 creators mirrors Terraform's default
-		// parallelism, where this was hit in practice.
+		// Concurrent creators race to self-elect a default while one claims
+		// it via a follow-up update, mirroring a terraform apply. Unserialized,
+		// the losers 409 on the single-default unique index.
 		const creators = 10
 		contextLimit := int64(4096)
 		var claimed codersdk.ChatModelConfig
@@ -3820,14 +3817,21 @@ func TestCreateChatModelConfig(t *testing.T) {
 			})
 		}
 		eg.Go(func() error {
-			var err error
-			claimed, err = client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+			created, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
 				AIProviderID: &aiProvider.ID,
 				Model:        "gpt-4o",
 				ContextLimit: &contextLimit,
-				IsDefault:    ptr.Ref(true),
 			})
-			return err
+			if err != nil {
+				return xerrors.Errorf("create claimed config: %w", err)
+			}
+			claimed, err = client.UpdateChatModelConfig(ctx, created.ID, codersdk.UpdateChatModelConfigRequest{
+				IsDefault: ptr.Ref(true),
+			})
+			if err != nil {
+				return xerrors.Errorf("promote claimed config: %w", err)
+			}
+			return nil
 		})
 		require.NoError(t, eg.Wait())
 


### PR DESCRIPTION
Closes CODAGT-736

Concurrent chat model config writes on a deployment with no default all elect themselves default: at READ COMMITTED neither transaction sees the other's uncommitted default, so both self-promote and `idx_chat_model_configs_single_default` rejects the loser as a spurious 409. The coderd Terraform provider hits this routinely, since a single `terraform apply` creates or deletes many configs in parallel by design.

The fix serializes the election with a transaction-scoped advisory lock: the create, update, and delete handlers run their default election inside a transaction that first takes `pg_advisory_xact_lock` on a dedicated `LockIDChatModelConfigDefault`, so elections run one at a time and the index is never contended. The partial unique index stays in place as the schema-level invariant, and the existing 409 mapping remains as a backstop for any writer that bypasses the lock.

We considered a singleton pointer table (one row holding a `model_config_id` FK, making a second default unrepresentable), which would remove the race outright, but it needs a migration, new queries, dbauthz rules, and handler/read-path rework. Not proportionate for an experimental endpoint.
