### PR TITLE
fix(site/src/pages/OrganizationSettingsPage): paywall provisioner jobs without a license

### DIFF
--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPage.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPage.tsx
@@ -2,11 +2,13 @@ import type { FC } from "react";
 import { useQuery } from "react-query";
 import { useSearchParams } from "react-router";
 import { provisionerJobs } from "#/api/queries/organizations";
+import { useDashboard } from "#/modules/dashboard/useDashboard";
 import { useOrganizationSettings } from "#/modules/management/OrganizationSettingsLayout";
 import OrganizationProvisionerJobsPageView from "./OrganizationProvisionerJobsPageView";
 
 const OrganizationProvisionerJobsPage: FC = () => {
 	const { organization } = useOrganizationSettings();
+	const { entitlements } = useDashboard();
 	const [searchParams, setSearchParams] = useSearchParams();
 	const filter = {
 		status: searchParams.get("status") ?? "",
@@ -30,6 +32,7 @@ const OrganizationProvisionerJobsPage: FC = () => {
 			filter={filter}
 			organization={organization}
 			error={isLoadingError}
+			showPaywall={!entitlements.features.multiple_organizations.enabled}
 			onRetry={refetch}
 			onFilterChange={setSearchParams}
 		/>

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.stories.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.stories.tsx
@@ -31,6 +31,17 @@ type Story = StoryObj<typeof OrganizationProvisionerJobsPageView>;
 
 export const Default: Story = {};
 
+export const Paywall: Story = {
+	args: {
+		showPaywall: true,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await canvas.findByText("Learn about Premium");
+		expect(canvas.queryByTestId("status-filter")).not.toBeInTheDocument();
+	},
+};
+
 export const OrganizationNotFound: Story = {
 	args: {
 		organization: undefined,

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.tsx
@@ -10,6 +10,7 @@ import { Button } from "#/components/Button/Button";
 import { EmptyState } from "#/components/EmptyState/EmptyState";
 import { Link } from "#/components/Link/Link";
 import { Loader } from "#/components/Loader/Loader";
+import { PaywallPremium } from "#/components/Paywall/PaywallPremium";
 import {
 	Select,
 	SelectContent,
@@ -78,13 +79,22 @@ type OrganizationProvisionerJobsPageViewProps = {
 	organization: Organization | undefined;
 	error: unknown;
 	filter: JobProvisionersFilter;
+	showPaywall: boolean | undefined;
 	onRetry: () => void;
 	onFilterChange: (filter: JobProvisionersFilter) => void;
 };
 
 const OrganizationProvisionerJobsPageView: FC<
 	OrganizationProvisionerJobsPageViewProps
-> = ({ jobs, organization, error, filter, onFilterChange, onRetry }) => {
+> = ({
+	jobs,
+	organization,
+	error,
+	filter,
+	showPaywall,
+	onFilterChange,
+	onRetry,
+}) => {
 	if (!organization) {
 		return (
 			<>
@@ -114,111 +124,124 @@ const OrganizationProvisionerJobsPageView: FC<
 					</SettingsHeaderDescription>
 				</SettingsHeader>
 
-				<div className="flex items-center gap-2">
-					{filter.ids && (
-						<div className="relative">
-							<Badge className="h-10 text-sm pl-3 pr-10 font-mono">
-								{filter.ids}
-							</Badge>
-							<div className="size-10 flex items-center justify-center absolute top-0 right-0">
-								<Tooltip>
-									<TooltipTrigger asChild>
-										<Button
-											size="icon"
-											variant="subtle"
-											onClick={() => {
-												onFilterChange({ ...filter, ids: "" });
-											}}
-										>
-											<span className="sr-only">Clear ID</span>
-											<XIcon />
-										</Button>
-									</TooltipTrigger>
-									<TooltipContent>Clear ID</TooltipContent>
-								</Tooltip>
-							</div>
+				{showPaywall ? (
+					<PaywallPremium
+						message="Provisioners"
+						description="Provisioners run your Terraform to create templates and workspaces. You need a Premium license to use this feature for multiple organizations."
+						documentationLink={docs("/admin/provisioners")}
+					/>
+				) : (
+					<>
+						<div className="flex items-center gap-2">
+							{filter.ids && (
+								<div className="relative">
+									<Badge className="h-10 text-sm pl-3 pr-10 font-mono">
+										{filter.ids}
+									</Badge>
+									<div className="size-10 flex items-center justify-center absolute top-0 right-0">
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<Button
+													size="icon"
+													variant="subtle"
+													onClick={() => {
+														onFilterChange({ ...filter, ids: "" });
+													}}
+												>
+													<span className="sr-only">Clear ID</span>
+													<XIcon />
+												</Button>
+											</TooltipTrigger>
+											<TooltipContent>Clear ID</TooltipContent>
+										</Tooltip>
+									</div>
+								</div>
+							)}
+
+							<Select
+								value={filter.status}
+								onValueChange={(status) => {
+									onFilterChange({
+										...filter,
+										status,
+									});
+								}}
+							>
+								<SelectTrigger
+									className="w-[180px]"
+									data-testid="status-filter"
+								>
+									<SelectValue placeholder="All statuses" />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectGroup>
+										{StatusFilters.map((status) => (
+											<SelectItem key={status} value={status}>
+												<StatusIndicator variant={variantByStatus[status]}>
+													<StatusIndicatorDot />
+													<span className="block first-letter:uppercase">
+														{status}
+													</span>
+												</StatusIndicator>
+											</SelectItem>
+										))}
+									</SelectGroup>
+								</SelectContent>
+							</Select>
 						</div>
-					)}
 
-					<Select
-						value={filter.status}
-						onValueChange={(status) => {
-							onFilterChange({
-								...filter,
-								status,
-							});
-						}}
-					>
-						<SelectTrigger className="w-[180px]" data-testid="status-filter">
-							<SelectValue placeholder="All statuses" />
-						</SelectTrigger>
-						<SelectContent>
-							<SelectGroup>
-								{StatusFilters.map((status) => (
-									<SelectItem key={status} value={status}>
-										<StatusIndicator variant={variantByStatus[status]}>
-											<StatusIndicatorDot />
-											<span className="block first-letter:uppercase">
-												{status}
-											</span>
-										</StatusIndicator>
-									</SelectItem>
-								))}
-							</SelectGroup>
-						</SelectContent>
-					</Select>
-				</div>
-
-				<Table className="mt-6">
-					<TableHeader>
-						<TableRow>
-							<TableHead>Created</TableHead>
-							<TableHead>Type</TableHead>
-							<TableHead>Template</TableHead>
-							<TableHead>Tags</TableHead>
-							<TableHead>Status</TableHead>
-							<TableHead />
-						</TableRow>
-					</TableHeader>
-					<TableBody>
-						{jobs ? (
-							jobs.length > 0 ? (
-								jobs.map((j) => (
-									<JobRow
-										defaultIsOpen={filter.ids.includes(j.id)}
-										key={j.id}
-										job={j}
-									/>
-								))
-							) : (
+						<Table className="mt-6">
+							<TableHeader>
 								<TableRow>
-									<TableCell colSpan={999}>
-										<EmptyState message="No provisioner jobs found" />
-									</TableCell>
+									<TableHead>Created</TableHead>
+									<TableHead>Type</TableHead>
+									<TableHead>Template</TableHead>
+									<TableHead>Tags</TableHead>
+									<TableHead>Status</TableHead>
+									<TableHead />
 								</TableRow>
-							)
-						) : error ? (
-							<TableRow>
-								<TableCell colSpan={999}>
-									<EmptyState
-										message="Error loading the provisioner jobs"
-										cta={
-											<Button size="sm" onClick={onRetry}>
-												Retry
-											</Button>
-										}
-									/>
-								</TableCell>
-							</TableRow>
-						) : (
-							<TableRow>
-								<TableCell colSpan={999}>
-									<Loader />
-								</TableCell>
-							</TableRow>
-						)}
-					</TableBody>
-				</Table>
+							</TableHeader>
+							<TableBody>
+								{jobs ? (
+									jobs.length > 0 ? (
+										jobs.map((j) => (
+											<JobRow
+												defaultIsOpen={filter.ids.includes(j.id)}
+												key={j.id}
+												job={j}
+											/>
+										))
+									) : (
+										<TableRow>
+											<TableCell colSpan={999}>
+												<EmptyState message="No provisioner jobs found" />
+											</TableCell>
+										</TableRow>
+									)
+								) : error ? (
+									<TableRow>
+										<TableCell colSpan={999}>
+											<EmptyState
+												message="Error loading the provisioner jobs"
+												cta={
+													<Button size="sm" onClick={onRetry}>
+														Retry
+													</Button>
+												}
+											/>
+										</TableCell>
+									</TableRow>
+								) : (
+									<TableRow>
+										<TableCell colSpan={999}>
+											<Loader />
+										</TableCell>
+									</TableRow>
+								)}
+							</TableBody>
+						</Table>
+					</>
+				)}
 			</section>
 		</div>
 	);


### PR DESCRIPTION
Provisioner Jobs (org settings) showed its table even without a Premium license. Provisioners and Provisioner Keys right next to it already paywall when `multiple_organizations` isn't entitled, so Jobs just got missed. It doesn't work without the entitlement anyway (backend ignores it), it just didn't say so.

Now it shows the same `PaywallPremium` the sibling pages use, plus a `Paywall` story to cover it.

Scoped to Jobs since that's the obvious gap. The issue hints the other org pages should paywall too, happy to do those (Settings especially) in a follow-up. Checked in Storybook, no licensed deployment handy.

Before / after:

<img src="https://raw.githubusercontent.com/apoorva-01/coder/assets/25108-screenshots/jobs-default.png" width="900" alt="Provisioner Jobs page showing the jobs table without a license" />

<img src="https://raw.githubusercontent.com/apoorva-01/coder/assets/25108-screenshots/jobs-paywall.png" width="900" alt="Provisioner Jobs page showing the premium paywall without a license" />

Refs #25108

AI disclosure: N/A
