### PR TITLE
docs: Agent Firewal log retention

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -876,16 +876,16 @@ that data type.
           user tries to use an expired key. Set to 0 to disable automatic
           deletion of expired keys.
 
+      --agent-firewall-logs-retention duration, $CODER_AGENT_FIREWALL_LOGS_RETENTION (default: 0)
+          How long agent firewall audit log entries are retained. Agent firewall
+          logs record HTTP requests processed by an Agent Firewall instance. Set
+          to 0 to disable automatic deletion (keep indefinitely). Adjust to
+          match your organization's regulatory requirements.
+
       --audit-logs-retention duration, $CODER_AUDIT_LOGS_RETENTION (default: 0)
           How long audit log entries are retained. Set to 0 to disable (keep
           indefinitely). We advise keeping audit logs for at least a year, and
           in accordance with your compliance requirements.
-
-      --boundary-log-retention duration, $CODER_BOUNDARY_LOG_RETENTION (default: 0)
-          How long boundary audit log entries are retained. Boundary logs record
-          HTTP requests processed by a Boundary confinement proxy. Set to 0 to
-          disable automatic deletion (keep indefinitely). Adjust to match your
-          organization's regulatory requirements.
 
       --connection-logs-retention duration, $CODER_CONNECTION_LOGS_RETENTION (default: 0)
           How long connection log entries are retained. Set to 0 to disable

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -1158,6 +1158,12 @@ retention:
   # regulatory requirements.
   # (default: 0, type: duration)
   boundary_logs: 0s
+  # How long agent firewall audit log entries are retained. Agent firewall logs
+  # record HTTP requests processed by an Agent Firewall instance. Set to 0 to
+  # disable automatic deletion (keep indefinitely). Adjust to match your
+  # organization's regulatory requirements.
+  # (default: 0, type: duration)
+  agent_firewall_logs: 0s
 templateBuilder:
   # Disable the template builder feature for guided template creation. When
   # disabled, all /api/v2/templatebuilder/* endpoints return 404.

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -23216,7 +23216,7 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "boundary_logs": {
-                    "description": "BoundaryLogs controls how long boundary audit log entries are\nretained. Boundary logs record every HTTP request processed by\na Boundary confinement proxy. Set to 0 to disable automatic\ndeletion (keep indefinitely). Adjust to match your\norganization's regulatory requirements.",
+                    "description": "AgentFirewallLogs controls how long boundary audit log entries are\nretained. Boundary logs record every HTTP request processed by\na Boundary confinement proxy. Set to 0 to disable automatic\ndeletion (keep indefinitely). Adjust to match your\norganization's regulatory requirements.",
                     "type": "integer"
                 },
                 "connection_logs": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -21267,7 +21267,7 @@
 					"type": "integer"
 				},
 				"boundary_logs": {
-					"description": "BoundaryLogs controls how long boundary audit log entries are\nretained. Boundary logs record every HTTP request processed by\na Boundary confinement proxy. Set to 0 to disable automatic\ndeletion (keep indefinitely). Adjust to match your\norganization's regulatory requirements.",
+					"description": "AgentFirewallLogs controls how long boundary audit log entries are\nretained. Boundary logs record every HTTP request processed by\na Boundary confinement proxy. Set to 0 to disable automatic\ndeletion (keep indefinitely). Adjust to match your\norganization's regulatory requirements.",
 					"type": "integer"
 				},
 				"connection_logs": {

--- a/coderd/database/dbpurge/dbpurge.go
+++ b/coderd/database/dbpurge/dbpurge.go
@@ -261,7 +261,7 @@ func (i *instance) purgeTick(ctx context.Context, db database.Store, start time.
 		}
 
 		var purgedBoundaryLogs, purgedBoundarySessions int64
-		boundaryLogsRetention := i.vals.Retention.BoundaryLogs.Value()
+		boundaryLogsRetention := i.vals.Retention.AgentFirewallLogs.Value()
 		if boundaryLogsRetention > 0 {
 			deleteBoundaryLogsBefore := start.Add(-boundaryLogsRetention)
 			purgedBoundaryLogs, err = tx.DeleteOldBoundaryLogs(ctx, database.DeleteOldBoundaryLogsParams{

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -1837,7 +1837,7 @@ func TestDeleteOldBoundaryLogs(t *testing.T) {
 		{
 			name: "RetentionEnabled",
 			retentionConfig: codersdk.RetentionConfig{
-				BoundaryLogs: serpent.Duration(retentionPeriod),
+				AgentFirewallLogs: serpent.Duration(retentionPeriod),
 			},
 			oldLogTime:            beforeThreshold,
 			recentLogTime:         &afterThreshold,
@@ -1847,7 +1847,7 @@ func TestDeleteOldBoundaryLogs(t *testing.T) {
 		{
 			name: "RetentionDisabled",
 			retentionConfig: codersdk.RetentionConfig{
-				BoundaryLogs: serpent.Duration(0),
+				AgentFirewallLogs: serpent.Duration(0),
 			},
 			oldLogTime:            now.Add(-365 * 24 * time.Hour), // 1 year ago
 			recentLogTime:         nil,
@@ -1857,7 +1857,7 @@ func TestDeleteOldBoundaryLogs(t *testing.T) {
 		{
 			name: "RetentionNegative",
 			retentionConfig: codersdk.RetentionConfig{
-				BoundaryLogs: serpent.Duration(-retentionPeriod),
+				AgentFirewallLogs: serpent.Duration(-retentionPeriod),
 			},
 			oldLogTime:            now.Add(-365 * 24 * time.Hour), // 1 year ago
 			recentLogTime:         nil,
@@ -1976,7 +1976,7 @@ func TestDeleteOldBoundarySessions(t *testing.T) {
 		{
 			name: "SessionDeletedWhenAllLogsExpired",
 			retentionConfig: codersdk.RetentionConfig{
-				BoundaryLogs: serpent.Duration(retentionPeriod),
+				AgentFirewallLogs: serpent.Duration(retentionPeriod),
 			},
 			sessionUpdatedAt:     oldTime,
 			logTime:              &oldTime, // log is old; will be purged first, leaving session empty
@@ -1985,7 +1985,7 @@ func TestDeleteOldBoundarySessions(t *testing.T) {
 		{
 			name: "SessionKeptWhenRecentLogExists",
 			retentionConfig: codersdk.RetentionConfig{
-				BoundaryLogs: serpent.Duration(retentionPeriod),
+				AgentFirewallLogs: serpent.Duration(retentionPeriod),
 			},
 			sessionUpdatedAt:     oldTime,
 			logTime:              &recentTime, // recent log survives log purge, so session kept
@@ -1994,7 +1994,7 @@ func TestDeleteOldBoundarySessions(t *testing.T) {
 		{
 			name: "SessionKeptWhenRetentionDisabled",
 			retentionConfig: codersdk.RetentionConfig{
-				BoundaryLogs: serpent.Duration(0),
+				AgentFirewallLogs: serpent.Duration(0),
 			},
 			sessionUpdatedAt:     oldTime,
 			logTime:              &oldTime,
@@ -2003,7 +2003,7 @@ func TestDeleteOldBoundarySessions(t *testing.T) {
 		{
 			name: "SessionKeptWhenRetentionNegative",
 			retentionConfig: codersdk.RetentionConfig{
-				BoundaryLogs: serpent.Duration(-retentionPeriod),
+				AgentFirewallLogs: serpent.Duration(-retentionPeriod),
 			},
 			sessionUpdatedAt:     oldTime,
 			logTime:              &oldTime,
@@ -2012,7 +2012,7 @@ func TestDeleteOldBoundarySessions(t *testing.T) {
 		{
 			name: "SessionKeptWhenUpdatedAtRecent",
 			retentionConfig: codersdk.RetentionConfig{
-				BoundaryLogs: serpent.Duration(retentionPeriod),
+				AgentFirewallLogs: serpent.Duration(retentionPeriod),
 			},
 			sessionUpdatedAt:     recentTime, // session itself is recent. NOT eligible for session purge
 			logTime:              nil,        // no logs; but updated_at guard keeps it

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -1226,12 +1226,12 @@ type RetentionConfig struct {
 	// Logs from the latest build are always retained regardless of age.
 	// Defaults to 7 days to preserve existing behavior.
 	WorkspaceAgentLogs serpent.Duration `json:"workspace_agent_logs" typescript:",notnull"`
-	// BoundaryLogs controls how long boundary audit log entries are
+	// AgentFirewallLogs controls how long boundary audit log entries are
 	// retained. Boundary logs record every HTTP request processed by
 	// a Boundary confinement proxy. Set to 0 to disable automatic
 	// deletion (keep indefinitely). Adjust to match your
 	// organization's regulatory requirements.
-	BoundaryLogs serpent.Duration `json:"boundary_logs" typescript:",notnull"`
+	AgentFirewallLogs serpent.Duration `json:"boundary_logs" typescript:",notnull"`
 }
 
 type NotificationsConfig struct {
@@ -4809,10 +4809,28 @@ Write out the current server config as YAML to stdout.`,
 			Description: "How long boundary audit log entries are retained. Boundary logs record HTTP requests processed by a Boundary confinement proxy. Set to 0 to disable automatic deletion (keep indefinitely). Adjust to match your organization's regulatory requirements.",
 			Flag:        "boundary-log-retention",
 			Env:         "CODER_BOUNDARY_LOG_RETENTION",
-			Value:       &c.Retention.BoundaryLogs,
+			Value:       &c.Retention.AgentFirewallLogs,
 			Default:     "0",
 			Group:       &deploymentGroupRetention,
 			YAML:        "boundary_logs",
+			Hidden:      true,
+			UseInstead: serpent.OptionSet{
+				{
+					Flag: "agent-firewall-logs-retention",
+					Env:  "CODER_AGENT_FIREWALL_LOGS_RETENTION",
+				},
+			},
+			Annotations: serpent.Annotations{}.Mark(annotationFormatDuration, "true"),
+		},
+		{
+			Name:        "Agent Firewall Log Retention",
+			Description: "How long agent firewall audit log entries are retained. Agent firewall logs record HTTP requests processed by an Agent Firewall instance. Set to 0 to disable automatic deletion (keep indefinitely). Adjust to match your organization's regulatory requirements.",
+			Flag:        "agent-firewall-logs-retention",
+			Env:         "CODER_AGENT_FIREWALL_LOGS_RETENTION",
+			Value:       &c.Retention.AgentFirewallLogs,
+			Default:     "0",
+			Group:       &deploymentGroupRetention,
+			YAML:        "agent_firewall_logs",
 			Annotations: serpent.Annotations{}.Mark(annotationFormatDuration, "true"),
 		},
 		{

--- a/docs/admin/setup/data-retention.md
+++ b/docs/admin/setup/data-retention.md
@@ -1,9 +1,9 @@
 # Data Retention
 
 Coder supports configurable retention policies that automatically purge old
-Audit Logs, Connection Logs, Workspace Agent Logs, API keys, and AI Gateway
-records. These policies help manage database growth by removing records older
-than a specified duration.
+Audit Logs, Connection Logs, Workspace Agent Logs, API keys, AI Gateway
+records, and Agent Firewall boundary logs. These policies help manage database
+growth by removing records older than a specified duration.
 
 ## Overview
 
@@ -31,6 +31,7 @@ a YAML configuration file.
 |----------------------|------------------------------------|----------------------------------------|----------------|-----------------------------------------|
 | Audit Logs           | `--audit-logs-retention`           | `CODER_AUDIT_LOGS_RETENTION`           | `0` (disabled) | How long to retain Audit Log entries    |
 | Connection Logs      | `--connection-logs-retention`      | `CODER_CONNECTION_LOGS_RETENTION`      | `0` (disabled) | How long to retain Connection Logs      |
+| Boundary Logs        | `--boundary-log-retention`         | `CODER_BOUNDARY_LOG_RETENTION`         | `0` (disabled) | How long to retain Agent Firewall boundary logs |
 | API Keys             | `--api-keys-retention`             | `CODER_API_KEYS_RETENTION`             | `7d`           | How long to retain expired API keys     |
 | Workspace Agent Logs | `--workspace-agent-logs-retention` | `CODER_WORKSPACE_AGENT_LOGS_RETENTION` | `7d`           | How long to retain workspace agent logs |
 | AI Gateway           | `--ai-gateway-retention`           | `CODER_AI_GATEWAY_RETENTION`           | `60d`          | How long to retain AI Gateway records   |
@@ -57,6 +58,7 @@ Go duration units (`h`, `m`, `s`):
 coder server \
   --audit-logs-retention=365d \
   --connection-logs-retention=90d \
+  --boundary-log-retention=90d \
   --api-keys-retention=7d \
   --workspace-agent-logs-retention=7d \
   --ai-gateway-retention=60d
@@ -67,6 +69,7 @@ coder server \
 ```bash
 export CODER_AUDIT_LOGS_RETENTION=365d
 export CODER_CONNECTION_LOGS_RETENTION=90d
+export CODER_BOUNDARY_LOG_RETENTION=90d
 export CODER_API_KEYS_RETENTION=7d
 export CODER_WORKSPACE_AGENT_LOGS_RETENTION=7d
 export CODER_AI_GATEWAY_RETENTION=60d
@@ -78,6 +81,7 @@ export CODER_AI_GATEWAY_RETENTION=60d
 retention:
   audit_logs: 365d
   connection_logs: 90d
+  boundary_logs: 90d
   api_keys: 7d
   workspace_agent_logs: 7d
 
@@ -139,6 +143,18 @@ For details on what data is retained, see the
 [AI Gateway Data Retention](../../ai-coder/ai-gateway/setup.md#data-retention)
 documentation.
 
+### Boundary Logs Behavior
+
+<!-- SKELETON: expand each topic sentence below into a full paragraph. -->
+
+Boundary log retention controls how long Agent Firewall boundary logs, which record the HTTP requests processed by the Agent Firewall confinement proxy, are kept before deletion.
+
+Boundary session records are purged only after all of their associated logs have been deleted and the session itself has aged past the retention window.
+
+Boundary log retention is disabled by default (`0`), so boundary logs are kept indefinitely until an administrator configures a retention period.
+
+For details on the Agent Firewall feature that produces these logs, see [Agent Firewall](../../ai-coder/agent-firewall/index.md).
+
 ## Best Practices
 
 ### Recommended Starting Configuration
@@ -149,6 +165,7 @@ For most deployments, we recommend:
 retention:
   audit_logs: 365d
   connection_logs: 90d
+  boundary_logs: 90d
   api_keys: 7d
   workspace_agent_logs: 7d
 
@@ -195,6 +212,7 @@ To keep data indefinitely for any data type, set its retention value to `0`:
 retention:
   audit_logs: 0s           # Keep audit logs forever
   connection_logs: 0s      # Keep connection logs forever
+  boundary_logs: 0s        # Keep Agent Firewall boundary logs forever
   api_keys: 0s             # Keep expired API keys forever
   workspace_agent_logs: 0s # Keep workspace agent logs forever
 
@@ -206,7 +224,8 @@ ai_gateway:
 
 The purge process logs deletion counts at the `DEBUG` level. To monitor
 retention activity, enable debug logging or search your logs for entries
-containing the table name (e.g., `audit_logs`, `connection_logs`, `api_keys`).
+containing the table name (e.g., `audit_logs`, `connection_logs`,
+`boundary_logs`, `api_keys`).
 
 ## Related Documentation
 
@@ -214,6 +233,8 @@ containing the table name (e.g., `audit_logs`, `connection_logs`, `api_keys`).
   purge procedures.
 - [Connection Logs](../monitoring/connection-logs.md): Learn about Connection
   Logs and monitoring.
+- [Agent Firewall](../../ai-coder/agent-firewall/index.md): Learn about Agent
+  Firewall and the boundary logs it produces.
 - [AI Gateway](../../ai-coder/ai-gateway/index.md): Learn about AI Gateway for
   centralized LLM and MCP proxy management.
 - [AI Gateway Setup](../../ai-coder/ai-gateway/setup.md#data-retention): Configure

--- a/docs/admin/setup/data-retention.md
+++ b/docs/admin/setup/data-retention.md
@@ -27,14 +27,14 @@ a YAML configuration file.
 
 ### Settings
 
-| Setting              | CLI Flag                           | Environment Variable                   | Default        | Description                             |
-|----------------------|------------------------------------|----------------------------------------|----------------|-----------------------------------------|
-| Audit Logs           | `--audit-logs-retention`           | `CODER_AUDIT_LOGS_RETENTION`           | `0` (disabled) | How long to retain Audit Log entries    |
-| Connection Logs      | `--connection-logs-retention`      | `CODER_CONNECTION_LOGS_RETENTION`      | `0` (disabled) | How long to retain Connection Logs      |
-| Boundary Logs        | `--boundary-log-retention`         | `CODER_BOUNDARY_LOG_RETENTION`         | `0` (disabled) | How long to retain Agent Firewall boundary logs |
-| API Keys             | `--api-keys-retention`             | `CODER_API_KEYS_RETENTION`             | `7d`           | How long to retain expired API keys     |
-| Workspace Agent Logs | `--workspace-agent-logs-retention` | `CODER_WORKSPACE_AGENT_LOGS_RETENTION` | `7d`           | How long to retain workspace agent logs |
-| AI Gateway           | `--ai-gateway-retention`           | `CODER_AI_GATEWAY_RETENTION`           | `60d`          | How long to retain AI Gateway records   |
+| Setting              | CLI Flag                           | Environment Variable                   | Default        | Description                                     |
+|----------------------|------------------------------------|----------------------------------------|----------------|-------------------------------------------------|
+| Audit Logs           | `--audit-logs-retention`           | `CODER_AUDIT_LOGS_RETENTION`           | `0` (disabled) | How long to retain Audit Log entries            |
+| Connection Logs      | `--connection-logs-retention`      | `CODER_CONNECTION_LOGS_RETENTION`      | `0` (disabled) | How long to retain Connection Logs              |
+| Boundary Logs        | `--agent-firewall-logs-retention`  | `CODER_BOUNDARY_LOG_RETENTION`         | `0` (disabled) | How long to retain Agent Firewall boundary logs |
+| API Keys             | `--api-keys-retention`             | `CODER_API_KEYS_RETENTION`             | `7d`           | How long to retain expired API keys             |
+| Workspace Agent Logs | `--workspace-agent-logs-retention` | `CODER_WORKSPACE_AGENT_LOGS_RETENTION` | `7d`           | How long to retain workspace agent logs         |
+| AI Gateway           | `--ai-gateway-retention`           | `CODER_AI_GATEWAY_RETENTION`           | `60d`          | How long to retain AI Gateway records           |
 
 > [!NOTE]
 > AI Gateway retention is configured separately from other retention settings.
@@ -58,7 +58,7 @@ Go duration units (`h`, `m`, `s`):
 coder server \
   --audit-logs-retention=365d \
   --connection-logs-retention=90d \
-  --boundary-log-retention=90d \
+  --agent-firewall-logs-retention=90d \
   --api-keys-retention=7d \
   --workspace-agent-logs-retention=7d \
   --ai-gateway-retention=60d

--- a/docs/ai-coder/agent-firewall/index.md
+++ b/docs/ai-coder/agent-firewall/index.md
@@ -233,3 +233,21 @@ Example of an allowed request (assuming stderr):
 ```console
 2026-01-16 00:11:40.564 [info]  coderd.agentrpc: boundary_request owner=joe  workspace_name=some-task-c88d agent_name=dev  decision=allow  workspace_id=f2bd4e9f-7e27-49fc-961e-be4d1c2aa987  http_method=GET http_url=https://coder.example.com  event_time=2026-01-16T00:11:39.388607657Z  matched_rule=domain=coder.example.com request_id=9f30d667-1fc9-47ba-b9e5-8eac46e0abef trace=478b2b45577307c4fd1bcfc64fad6ffb span=9ece4bc70c311edb
 ```
+
+## Data Retention
+
+<!-- SKELETON: expand each topic sentence below into a full paragraph. Headings, table, and links are final. -->
+
+Coder can automatically purge Agent Firewall boundary logs from the control plane database after a configurable retention period so the table does not grow unbounded.
+
+| Setting                | CLI Flag                   | Environment Variable           | YAML                      | Default        |
+|------------------------|----------------------------|--------------------------------|---------------------------|----------------|
+| Boundary log retention | `--boundary-log-retention` | `CODER_BOUNDARY_LOG_RETENTION` | `retention.boundary_logs` | `0` (disabled) |
+
+When retention is left at the default of `0`, boundary logs are retained indefinitely.
+
+Boundary session records are removed only after all of their associated logs have been purged and the session has aged past the retention window.
+
+Retention is enforced by Coder's background purge process, which runs on a fixed interval and deletes eligible records in batches shared with the other retention policies.
+
+For configuration syntax, supported duration formats, and how boundary log retention relates to Coder's other retention settings, see [Data Retention](../../admin/setup/data-retention.md).

--- a/docs/ai-coder/agent-firewall/index.md
+++ b/docs/ai-coder/agent-firewall/index.md
@@ -238,16 +238,6 @@ Example of an allowed request (assuming stderr):
 
 <!-- SKELETON: expand each topic sentence below into a full paragraph. Headings, table, and links are final. -->
 
-Coder can automatically purge Agent Firewall boundary logs from the control plane database after a configurable retention period so the table does not grow unbounded.
+Coder can automatically purge Agent Firewall logs from the control plane database after a configurable retention period to avoid unbounded database growth. When retention is left at the default of `0`, boundary logs are retained indefinitely.
 
-| Setting                | CLI Flag                   | Environment Variable           | YAML                      | Default        |
-|------------------------|----------------------------|--------------------------------|---------------------------|----------------|
-| Boundary log retention | `--boundary-log-retention` | `CODER_BOUNDARY_LOG_RETENTION` | `retention.boundary_logs` | `0` (disabled) |
-
-When retention is left at the default of `0`, boundary logs are retained indefinitely.
-
-Boundary session records are removed only after all of their associated logs have been purged and the session has aged past the retention window.
-
-Retention is enforced by Coder's background purge process, which runs on a fixed interval and deletes eligible records in batches shared with the other retention policies.
-
-For configuration syntax, supported duration formats, and how boundary log retention relates to Coder's other retention settings, see [Data Retention](../../admin/setup/data-retention.md).
+For configuration syntax, supported duration formats, and how agent firewall log retention relates to Coder's other retention settings, see [Data Retention](../../admin/setup/data-retention.md).

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -2111,16 +2111,16 @@ How long expired API keys are retained before being deleted. Keeping expired key
 
 How long workspace agent logs are retained. Logs from non-latest builds are deleted if the agent hasn't connected within this period. Logs from the latest build are always retained. Set to 0 to disable automatic deletion.
 
-### --boundary-log-retention
+### --agent-firewall-logs-retention
 
-|             |                                            |
-|-------------|--------------------------------------------|
-| Type        | <code>duration</code>                      |
-| Environment | <code>$CODER_BOUNDARY_LOG_RETENTION</code> |
-| YAML        | <code>retention.boundary_logs</code>       |
-| Default     | <code>0</code>                             |
+|             |                                                   |
+|-------------|---------------------------------------------------|
+| Type        | <code>duration</code>                             |
+| Environment | <code>$CODER_AGENT_FIREWALL_LOGS_RETENTION</code> |
+| YAML        | <code>retention.agent_firewall_logs</code>        |
+| Default     | <code>0</code>                                    |
 
-How long boundary audit log entries are retained. Boundary logs record HTTP requests processed by a Boundary confinement proxy. Set to 0 to disable automatic deletion (keep indefinitely). Adjust to match your organization's regulatory requirements.
+How long agent firewall audit log entries are retained. Agent firewall logs record HTTP requests processed by an Agent Firewall instance. Set to 0 to disable automatic deletion (keep indefinitely). Adjust to match your organization's regulatory requirements.
 
 ### --disable-template-builder
 

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -877,16 +877,16 @@ that data type.
           user tries to use an expired key. Set to 0 to disable automatic
           deletion of expired keys.
 
+      --agent-firewall-logs-retention duration, $CODER_AGENT_FIREWALL_LOGS_RETENTION (default: 0)
+          How long agent firewall audit log entries are retained. Agent firewall
+          logs record HTTP requests processed by an Agent Firewall instance. Set
+          to 0 to disable automatic deletion (keep indefinitely). Adjust to
+          match your organization's regulatory requirements.
+
       --audit-logs-retention duration, $CODER_AUDIT_LOGS_RETENTION (default: 0)
           How long audit log entries are retained. Set to 0 to disable (keep
           indefinitely). We advise keeping audit logs for at least a year, and
           in accordance with your compliance requirements.
-
-      --boundary-log-retention duration, $CODER_BOUNDARY_LOG_RETENTION (default: 0)
-          How long boundary audit log entries are retained. Boundary logs record
-          HTTP requests processed by a Boundary confinement proxy. Set to 0 to
-          disable automatic deletion (keep indefinitely). Adjust to match your
-          organization's regulatory requirements.
 
       --connection-logs-retention duration, $CODER_CONNECTION_LOGS_RETENTION (default: 0)
           How long connection log entries are retained. Set to 0 to disable

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -7503,7 +7503,7 @@ export interface RetentionConfig {
 	 */
 	readonly workspace_agent_logs: number;
 	/**
-	 * BoundaryLogs controls how long boundary audit log entries are
+	 * AgentFirewallLogs controls how long boundary audit log entries are
 	 * retained. Boundary logs record every HTTP request processed by
 	 * a Boundary confinement proxy. Set to 0 to disable automatic
 	 * deletion (keep indefinitely). Adjust to match your


### PR DESCRIPTION
Document log retention configuration for Agent Firewall.
Rename `--boundary-log-retention` to remain consistent with rebranding guidelines and existing naming conventions.