### PR TITLE
feat: wire up Template Builder session telemetry endpoint

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -24820,6 +24820,10 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "session_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
                 "success": {
                     "type": "boolean"
                 }

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -24794,7 +24794,8 @@ const docTemplate = `{
         "codersdk.TemplateBuilderSessionRequest": {
             "type": "object",
             "required": [
-                "event_type"
+                "event_type",
+                "session_id"
             ],
             "properties": {
                 "base_template_id": {

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -7810,6 +7810,39 @@ const docTemplate = `{
                 ]
             }
         },
+        "/api/v2/templatebuilder/sessions": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "TemplateBuilder"
+                ],
+                "summary": "Report a template builder session event",
+                "operationId": "report-template-builder-session-event",
+                "parameters": [
+                    {
+                        "description": "Session event",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.TemplateBuilderSessionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
         "/api/v2/templates": {
             "get": {
                 "description": "Returns a list of templates.\nBy default, only non-deprecated templates are returned.\nTo include deprecated templates, specify ` + "`" + `deprecated:true` + "`" + ` in the search query.",
@@ -24744,6 +24777,51 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/codersdk.TemplateBuilderModule"
                     }
+                }
+            }
+        },
+        "codersdk.TemplateBuilderSessionEventType": {
+            "type": "string",
+            "enum": [
+                "wizard_entry",
+                "compose_completion"
+            ],
+            "x-enum-varnames": [
+                "TemplateBuilderSessionEventWizardEntry",
+                "TemplateBuilderSessionEventComposeCompletion"
+            ]
+        },
+        "codersdk.TemplateBuilderSessionRequest": {
+            "type": "object",
+            "required": [
+                "event_type"
+            ],
+            "properties": {
+                "base_template_id": {
+                    "type": "string"
+                },
+                "duration_seconds": {
+                    "type": "number"
+                },
+                "event_type": {
+                    "enum": [
+                        "wizard_entry",
+                        "compose_completion"
+                    ],
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/codersdk.TemplateBuilderSessionEventType"
+                        }
+                    ]
+                },
+                "module_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "success": {
+                    "type": "boolean"
                 }
             }
         },

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -7819,7 +7819,7 @@ const docTemplate = `{
                     "TemplateBuilder"
                 ],
                 "summary": "Report a template builder session event",
-                "operationId": "report-template-builder-session-event",
+                "operationId": "report-a-template-builder-session-event",
                 "parameters": [
                     {
                         "description": "Session event",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -6933,6 +6933,35 @@
 				]
 			}
 		},
+		"/api/v2/templatebuilder/sessions": {
+			"post": {
+				"consumes": ["application/json"],
+				"tags": ["TemplateBuilder"],
+				"summary": "Report a template builder session event",
+				"operationId": "report-template-builder-session-event",
+				"parameters": [
+					{
+						"description": "Session event",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.TemplateBuilderSessionRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
 		"/api/v2/templates": {
 			"get": {
 				"description": "Returns a list of templates.\nBy default, only non-deprecated templates are returned.\nTo include deprecated templates, specify `deprecated:true` in the search query.",
@@ -22726,6 +22755,43 @@
 					"items": {
 						"$ref": "#/definitions/codersdk.TemplateBuilderModule"
 					}
+				}
+			}
+		},
+		"codersdk.TemplateBuilderSessionEventType": {
+			"type": "string",
+			"enum": ["wizard_entry", "compose_completion"],
+			"x-enum-varnames": [
+				"TemplateBuilderSessionEventWizardEntry",
+				"TemplateBuilderSessionEventComposeCompletion"
+			]
+		},
+		"codersdk.TemplateBuilderSessionRequest": {
+			"type": "object",
+			"required": ["event_type"],
+			"properties": {
+				"base_template_id": {
+					"type": "string"
+				},
+				"duration_seconds": {
+					"type": "number"
+				},
+				"event_type": {
+					"enum": ["wizard_entry", "compose_completion"],
+					"allOf": [
+						{
+							"$ref": "#/definitions/codersdk.TemplateBuilderSessionEventType"
+						}
+					]
+				},
+				"module_ids": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"success": {
+					"type": "boolean"
 				}
 			}
 		},

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -6938,7 +6938,7 @@
 				"consumes": ["application/json"],
 				"tags": ["TemplateBuilder"],
 				"summary": "Report a template builder session event",
-				"operationId": "report-template-builder-session-event",
+				"operationId": "report-a-template-builder-session-event",
 				"parameters": [
 					{
 						"description": "Session event",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -22768,7 +22768,7 @@
 		},
 		"codersdk.TemplateBuilderSessionRequest": {
 			"type": "object",
-			"required": ["event_type"],
+			"required": ["event_type", "session_id"],
 			"properties": {
 				"base_template_id": {
 					"type": "string"

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -22790,6 +22790,10 @@
 						"type": "string"
 					}
 				},
+				"session_id": {
+					"type": "string",
+					"format": "uuid"
+				},
 				"success": {
 					"type": "boolean"
 				}

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1704,6 +1704,7 @@ func New(options *Options) *API {
 				r.Get("/modules", api.templateBuilderModules)
 				r.Post("/compose", api.templateBuilderCompose)
 				r.Post("/compose/template", api.templateBuilderCreateTemplate)
+				r.Post("/sessions", api.templateBuilderSession)
 			})
 		}
 

--- a/coderd/templatebuilder_handler.go
+++ b/coderd/templatebuilder_handler.go
@@ -654,7 +654,7 @@ func (api *API) waitForProvisionerJob(
 }
 
 // @Summary Report a template builder session event
-// @ID report-template-builder-session-event
+// @ID report-a-template-builder-session-event
 // @Security CoderSessionToken
 // @Accept json
 // @Tags TemplateBuilder

--- a/coderd/templatebuilder_handler.go
+++ b/coderd/templatebuilder_handler.go
@@ -677,15 +677,10 @@ func (api *API) templateBuilderSession(rw http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	sessionID := req.SessionID
-	if sessionID == uuid.Nil {
-		sessionID = uuid.New()
-	}
-
 	api.Telemetry.Report(&telemetry.Snapshot{
 		TemplateBuilderSessions: []telemetry.TemplateBuilderSession{
 			{
-				ID:              sessionID,
+				ID:              req.SessionID,
 				EventType:       string(req.EventType),
 				UserID:          apiKey.UserID,
 				BaseTemplateID:  req.BaseTemplateID,

--- a/coderd/templatebuilder_handler.go
+++ b/coderd/templatebuilder_handler.go
@@ -665,6 +665,8 @@ func (api *API) templateBuilderSession(rw http.ResponseWriter, r *http.Request) 
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
 
+	// Only template admins should be able to use this flow and submit
+	// session telemetry, matching the compose endpoint's authorization.
 	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceTemplate.AnyOrganization()) {
 		httpapi.ResourceNotFound(rw)
 		return

--- a/coderd/templatebuilder_handler.go
+++ b/coderd/templatebuilder_handler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/coderd/schedule"
+	"github.com/coder/coder/v2/coderd/telemetry"
 	"github.com/coder/coder/v2/coderd/templatebuilder"
 	"github.com/coder/coder/v2/coderd/tracing"
 	"github.com/coder/coder/v2/coderd/util/namesgenerator"
@@ -650,4 +651,44 @@ func (api *API) waitForProvisionerJob(
 			return job, nil
 		}
 	}
+}
+
+// @Summary Report a template builder session event
+// @ID report-template-builder-session-event
+// @Security CoderSessionToken
+// @Accept json
+// @Tags TemplateBuilder
+// @Param request body codersdk.TemplateBuilderSessionRequest true "Session event"
+// @Success 204
+// @Router /api/v2/templatebuilder/sessions [post]
+func (api *API) templateBuilderSession(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	apiKey := httpmw.APIKey(r)
+
+	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceTemplate.AnyOrganization()) {
+		httpapi.ResourceNotFound(rw)
+		return
+	}
+
+	var req codersdk.TemplateBuilderSessionRequest
+	if !httpapi.Read(ctx, rw, r, &req) {
+		return
+	}
+
+	api.Telemetry.Report(&telemetry.Snapshot{
+		TemplateBuilderSessions: []telemetry.TemplateBuilderSession{
+			{
+				ID:              uuid.New(),
+				EventType:       string(req.EventType),
+				UserID:          apiKey.UserID,
+				BaseTemplateID:  req.BaseTemplateID,
+				ModuleIDs:       req.ModuleIDs,
+				DurationSeconds: req.DurationSeconds,
+				Success:         req.Success,
+				CreatedAt:       dbtime.Now(),
+			},
+		},
+	})
+
+	rw.WriteHeader(http.StatusNoContent)
 }

--- a/coderd/templatebuilder_handler.go
+++ b/coderd/templatebuilder_handler.go
@@ -677,10 +677,15 @@ func (api *API) templateBuilderSession(rw http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	sessionID := req.SessionID
+	if sessionID == uuid.Nil {
+		sessionID = uuid.New()
+	}
+
 	api.Telemetry.Report(&telemetry.Snapshot{
 		TemplateBuilderSessions: []telemetry.TemplateBuilderSession{
 			{
-				ID:              uuid.New(),
+				ID:              sessionID,
 				EventType:       string(req.EventType),
 				UserID:          apiKey.UserID,
 				BaseTemplateID:  req.BaseTemplateID,

--- a/coderd/templatebuilder_handler_test.go
+++ b/coderd/templatebuilder_handler_test.go
@@ -238,3 +238,100 @@ func TestTemplateBuilderModules(t *testing.T) {
 		require.Equal(t, http.StatusNotFound, sdkErr.StatusCode())
 	})
 }
+
+func TestTemplateBuilderSession(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WizardEntry", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		err := client.TemplateBuilderSession(ctx, codersdk.TemplateBuilderSessionRequest{
+			EventType: codersdk.TemplateBuilderSessionEventWizardEntry,
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("ComposeCompletion", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		err := client.TemplateBuilderSession(ctx, codersdk.TemplateBuilderSessionRequest{
+			EventType:       codersdk.TemplateBuilderSessionEventComposeCompletion,
+			BaseTemplateID:  "docker",
+			ModuleIDs:       []string{"code-server", "git-clone"},
+			DurationSeconds: 42.5,
+			Success:         true,
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("InvalidEventType", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		err := client.TemplateBuilderSession(ctx, codersdk.TemplateBuilderSessionRequest{
+			EventType: "invalid_event",
+		})
+		require.Error(t, err)
+
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
+	})
+
+	t.Run("DisabledReturns404", func(t *testing.T) {
+		t.Parallel()
+		dv := coderdtest.DeploymentValues(t)
+		dv.TemplateBuilder.Disabled = true
+
+		client := coderdtest.New(t, &coderdtest.Options{
+			DeploymentValues: dv,
+		})
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		err := client.TemplateBuilderSession(ctx, codersdk.TemplateBuilderSessionRequest{
+			EventType: codersdk.TemplateBuilderSessionEventWizardEntry,
+		})
+		require.Error(t, err)
+
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusNotFound, sdkErr.StatusCode())
+	})
+
+	t.Run("MemberCannotSubmit", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		admin := coderdtest.CreateFirstUser(t, client)
+
+		memberClient, _ := coderdtest.CreateAnotherUser(t, client, admin.OrganizationID)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		err := memberClient.TemplateBuilderSession(ctx, codersdk.TemplateBuilderSessionRequest{
+			EventType: codersdk.TemplateBuilderSessionEventWizardEntry,
+		})
+		require.Error(t, err)
+
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusNotFound, sdkErr.StatusCode())
+	})
+}

--- a/coderd/templatebuilder_handler_test.go
+++ b/coderd/templatebuilder_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
@@ -251,6 +252,7 @@ func TestTemplateBuilderSession(t *testing.T) {
 		defer cancel()
 
 		err := client.TemplateBuilderSession(ctx, codersdk.TemplateBuilderSessionRequest{
+			SessionID: uuid.New(),
 			EventType: codersdk.TemplateBuilderSessionEventWizardEntry,
 		})
 		require.NoError(t, err)
@@ -265,6 +267,7 @@ func TestTemplateBuilderSession(t *testing.T) {
 		defer cancel()
 
 		err := client.TemplateBuilderSession(ctx, codersdk.TemplateBuilderSessionRequest{
+			SessionID:       uuid.New(),
 			EventType:       codersdk.TemplateBuilderSessionEventComposeCompletion,
 			BaseTemplateID:  "docker",
 			ModuleIDs:       []string{"code-server", "git-clone"},
@@ -272,6 +275,24 @@ func TestTemplateBuilderSession(t *testing.T) {
 			Success:         true,
 		})
 		require.NoError(t, err)
+	})
+
+	t.Run("MissingSessionID", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		err := client.TemplateBuilderSession(ctx, codersdk.TemplateBuilderSessionRequest{
+			EventType: codersdk.TemplateBuilderSessionEventWizardEntry,
+		})
+		require.Error(t, err)
+
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
 	})
 
 	t.Run("InvalidEventType", func(t *testing.T) {

--- a/codersdk/templatebuilder.go
+++ b/codersdk/templatebuilder.go
@@ -150,6 +150,39 @@ type TemplateBuilderCreateTemplateResponse struct {
 	Template Template `json:"template"`
 }
 
+// TemplateBuilderSessionEventType enumerates the event types for
+// template builder session telemetry.
+type TemplateBuilderSessionEventType string
+
+const (
+	TemplateBuilderSessionEventWizardEntry       TemplateBuilderSessionEventType = "wizard_entry"
+	TemplateBuilderSessionEventComposeCompletion TemplateBuilderSessionEventType = "compose_completion"
+)
+
+// TemplateBuilderSessionRequest is the request body for
+// POST /api/v2/templatebuilder/sessions.
+type TemplateBuilderSessionRequest struct {
+	EventType       TemplateBuilderSessionEventType `json:"event_type" validate:"required,oneof=wizard_entry compose_completion"`
+	BaseTemplateID  string                          `json:"base_template_id,omitempty"`
+	ModuleIDs       []string                        `json:"module_ids,omitempty"`
+	DurationSeconds float64                         `json:"duration_seconds,omitempty"`
+	Success         bool                            `json:"success,omitempty"`
+}
+
+// TemplateBuilderSession reports a template builder session event for
+// telemetry purposes.
+func (c *Client) TemplateBuilderSession(ctx context.Context, req TemplateBuilderSessionRequest) error {
+	res, err := c.Request(ctx, http.MethodPost, "/api/v2/templatebuilder/sessions", req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusNoContent {
+		return ReadBodyAsError(res)
+	}
+	return nil
+}
+
 // TemplateBuilderCreateTemplate composes a template from a base and modules,
 // validates it via a provisioner import job, and creates the template.
 func (c *Client) TemplateBuilderCreateTemplate(ctx context.Context, req TemplateBuilderCreateTemplateRequest) (TemplateBuilderCreateTemplateResponse, error) {

--- a/codersdk/templatebuilder.go
+++ b/codersdk/templatebuilder.go
@@ -162,7 +162,7 @@ const (
 // TemplateBuilderSessionRequest is the request body for
 // POST /api/v2/templatebuilder/sessions.
 type TemplateBuilderSessionRequest struct {
-	SessionID       uuid.UUID                       `json:"session_id,omitempty" format:"uuid"`
+	SessionID       uuid.UUID                       `json:"session_id" format:"uuid" validate:"required"`
 	EventType       TemplateBuilderSessionEventType `json:"event_type" validate:"required,oneof=wizard_entry compose_completion"`
 	BaseTemplateID  string                          `json:"base_template_id,omitempty"`
 	ModuleIDs       []string                        `json:"module_ids,omitempty"`

--- a/codersdk/templatebuilder.go
+++ b/codersdk/templatebuilder.go
@@ -162,6 +162,7 @@ const (
 // TemplateBuilderSessionRequest is the request body for
 // POST /api/v2/templatebuilder/sessions.
 type TemplateBuilderSessionRequest struct {
+	SessionID       uuid.UUID                       `json:"session_id,omitempty" format:"uuid"`
 	EventType       TemplateBuilderSessionEventType `json:"event_type" validate:"required,oneof=wizard_entry compose_completion"`
 	BaseTemplateID  string                          `json:"base_template_id,omitempty"`
 	ModuleIDs       []string                        `json:"module_ids,omitempty"`

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -12651,7 +12651,7 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 | `duration_seconds` | number                                                                               | false    |              |             |
 | `event_type`       | [codersdk.TemplateBuilderSessionEventType](#codersdktemplatebuildersessioneventtype) | true     |              |             |
 | `module_ids`       | array of string                                                                      | false    |              |             |
-| `session_id`       | string                                                                               | false    |              |             |
+| `session_id`       | string                                                                               | true     |              |             |
 | `success`          | boolean                                                                              | false    |              |             |
 
 #### Enumerated Values

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -12614,6 +12614,50 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 |-----------|---------------------------------------------------------------------------|----------|--------------|-------------|
 | `modules` | array of [codersdk.TemplateBuilderModule](#codersdktemplatebuildermodule) | false    |              |             |
 
+## codersdk.TemplateBuilderSessionEventType
+
+```json
+"wizard_entry"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value(s)                             |
+|--------------------------------------|
+| `compose_completion`, `wizard_entry` |
+
+## codersdk.TemplateBuilderSessionRequest
+
+```json
+{
+  "base_template_id": "string",
+  "duration_seconds": 0,
+  "event_type": "wizard_entry",
+  "module_ids": [
+    "string"
+  ],
+  "success": true
+}
+```
+
+### Properties
+
+| Name               | Type                                                                                 | Required | Restrictions | Description |
+|--------------------|--------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `base_template_id` | string                                                                               | false    |              |             |
+| `duration_seconds` | number                                                                               | false    |              |             |
+| `event_type`       | [codersdk.TemplateBuilderSessionEventType](#codersdktemplatebuildersessioneventtype) | true     |              |             |
+| `module_ids`       | array of string                                                                      | false    |              |             |
+| `success`          | boolean                                                                              | false    |              |             |
+
+#### Enumerated Values
+
+| Property     | Value(s)                             |
+|--------------|--------------------------------------|
+| `event_type` | `compose_completion`, `wizard_entry` |
+
 ## codersdk.TemplateBuilderVariableType
 
 ```json

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -12638,6 +12638,7 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
   "module_ids": [
     "string"
   ],
+  "session_id": "1ffd059c-17ea-40a8-8aef-70fd0307db82",
   "success": true
 }
 ```
@@ -12650,6 +12651,7 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 | `duration_seconds` | number                                                                               | false    |              |             |
 | `event_type`       | [codersdk.TemplateBuilderSessionEventType](#codersdktemplatebuildersessioneventtype) | true     |              |             |
 | `module_ids`       | array of string                                                                      | false    |              |             |
+| `session_id`       | string                                                                               | false    |              |             |
 | `success`          | boolean                                                                              | false    |              |             |
 
 #### Enumerated Values

--- a/docs/reference/api/templatebuilder.md
+++ b/docs/reference/api/templatebuilder.md
@@ -290,3 +290,44 @@ curl -X GET http://coder-server:8080/api/v2/templatebuilder/modules \
 | 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.TemplateBuilderModulesResponse](schemas.md#codersdktemplatebuildermodulesresponse) |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Report a template builder session event
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X POST http://coder-server:8080/api/v2/templatebuilder/sessions \
+  -H 'Content-Type: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`POST /api/v2/templatebuilder/sessions`
+
+> Body parameter
+
+```json
+{
+  "base_template_id": "string",
+  "duration_seconds": 0,
+  "event_type": "wizard_entry",
+  "module_ids": [
+    "string"
+  ],
+  "success": true
+}
+```
+
+### Parameters
+
+| Name   | In   | Type                                                                                       | Required | Description   |
+|--------|------|--------------------------------------------------------------------------------------------|----------|---------------|
+| `body` | body | [codersdk.TemplateBuilderSessionRequest](schemas.md#codersdktemplatebuildersessionrequest) | true     | Session event |
+
+### Responses
+
+| Status | Meaning                                                         | Description | Schema |
+|--------|-----------------------------------------------------------------|-------------|--------|
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).

--- a/docs/reference/api/templatebuilder.md
+++ b/docs/reference/api/templatebuilder.md
@@ -314,6 +314,7 @@ curl -X POST http://coder-server:8080/api/v2/templatebuilder/sessions \
   "module_ids": [
     "string"
   ],
+  "session_id": "1ffd059c-17ea-40a8-8aef-70fd0307db82",
   "success": true
 }
 ```

--- a/docs/reference/api/templatebuilder.md
+++ b/docs/reference/api/templatebuilder.md
@@ -295,7 +295,7 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ### Code samples
 
-```shell
+```sh
 # Example request using curl
 curl -X POST http://coder-server:8080/api/v2/templatebuilder/sessions \
   -H 'Content-Type: application/json' \

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2612,6 +2612,12 @@ class ApiMethods {
 		return response.data;
 	};
 
+	recordTemplateBuilderSession = async (
+		req: TypesGen.TemplateBuilderSessionRequest,
+	): Promise<void> => {
+		await this.axios.post("/api/v2/templatebuilder/sessions", req);
+	};
+
 	uploadFile = async (file: File): Promise<TypesGen.UploadResponse> => {
 		const response = await this.axios.post("/api/v2/files", file, {
 			headers: { "Content-Type": file.type },

--- a/site/src/api/queries/templateBuilder.ts
+++ b/site/src/api/queries/templateBuilder.ts
@@ -14,3 +14,7 @@ export const templateBuilderModules = (base?: string) => ({
 export const createTemplateFromBuilder = () => ({
 	mutationFn: API.createTemplateFromBuilder,
 });
+
+export const recordTemplateBuilderSession = () => ({
+	mutationFn: API.recordTemplateBuilderSession,
+});

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -8820,7 +8820,7 @@ export const TemplateBuilderSessionEventTypes: TemplateBuilderSessionEventType[]
  * POST /api/v2/templatebuilder/sessions.
  */
 export interface TemplateBuilderSessionRequest {
-	readonly session_id?: string;
+	readonly session_id: string;
 	readonly event_type: TemplateBuilderSessionEventType;
 	readonly base_template_id?: string;
 	readonly module_ids?: readonly string[];

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -8807,6 +8807,27 @@ export interface TemplateBuilderModulesResponse {
 }
 
 // From codersdk/templatebuilder.go
+export type TemplateBuilderSessionEventType =
+	| "compose_completion"
+	| "wizard_entry";
+
+export const TemplateBuilderSessionEventTypes: TemplateBuilderSessionEventType[] =
+	["compose_completion", "wizard_entry"];
+
+// From codersdk/templatebuilder.go
+/**
+ * TemplateBuilderSessionRequest is the request body for
+ * POST /api/v2/templatebuilder/sessions.
+ */
+export interface TemplateBuilderSessionRequest {
+	readonly event_type: TemplateBuilderSessionEventType;
+	readonly base_template_id?: string;
+	readonly module_ids?: readonly string[];
+	readonly duration_seconds?: number;
+	readonly success?: boolean;
+}
+
+// From codersdk/templatebuilder.go
 export type TemplateBuilderVariableType = "bool" | "number" | "string";
 
 export const TemplateBuilderVariableTypes: TemplateBuilderVariableType[] = [

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -8820,6 +8820,7 @@ export const TemplateBuilderSessionEventTypes: TemplateBuilderSessionEventType[]
  * POST /api/v2/templatebuilder/sessions.
  */
 export interface TemplateBuilderSessionRequest {
+	readonly session_id?: string;
 	readonly event_type: TemplateBuilderSessionEventType;
 	readonly base_template_id?: string;
 	readonly module_ids?: readonly string[];

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPage.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPage.tsx
@@ -4,6 +4,7 @@ import { Navigate, useNavigate, useSearchParams } from "react-router";
 import { deploymentConfig } from "#/api/queries/deployment";
 import {
 	createTemplateFromBuilder,
+	recordTemplateBuilderSession,
 	templateBuilderBases,
 } from "#/api/queries/templateBuilder";
 import { Loader } from "#/components/Loader/Loader";
@@ -24,12 +25,24 @@ const TemplateBuilderPage: FC = () => {
 	const [searchParams, setSearchParams] = useSearchParams();
 	const { data, error, isLoading } = useQuery(deploymentConfig());
 	const createMutation = useMutation(createTemplateFromBuilder());
+	const sessionMutation = useMutation(recordTemplateBuilderSession());
 
 	const builderDisabled = data?.config?.template_builder?.disabled ?? false;
+	const wizardReady =
+		!builderDisabled && !isLoading && permissions.createTemplates;
+
+	// Report wizard_entry once the builder is ready and accessible.
+	const reportSession = sessionMutation.mutate;
+	useEffect(() => {
+		if (!wizardReady) {
+			return;
+		}
+		reportSession({ event_type: "wizard_entry" });
+	}, [wizardReady, reportSession]);
 
 	const basesQuery = useQuery({
 		...templateBuilderBases(),
-		enabled: !builderDisabled && !isLoading && permissions.createTemplates,
+		enabled: wizardReady,
 	});
 
 	// ?base= is the only search param accepted on entry. It is consumed
@@ -66,13 +79,31 @@ const TemplateBuilderPage: FC = () => {
 
 	const handleCreate = (state: TemplateBuilderWizardState) => {
 		const req = toCreateTemplateRequest(state);
+		const durationSeconds = (Date.now() - state.enteredAt) / 1000;
+
 		createMutation.mutate(req, {
 			onSuccess: (resp) => {
+				sessionMutation.mutate({
+					event_type: "compose_completion",
+					base_template_id: state.baseTemplateId ?? undefined,
+					module_ids: state.modules.map((m) => m.id),
+					duration_seconds: durationSeconds,
+					success: true,
+				});
 				const t = resp.template;
 				navigate(
 					`${getLink(linkToTemplate(t.organization_name, t.name))}/files`,
 					{ state: { justCreated: true } },
 				);
+			},
+			onError: () => {
+				sessionMutation.mutate({
+					event_type: "compose_completion",
+					base_template_id: state.baseTemplateId ?? undefined,
+					module_ids: state.modules.map((m) => m.id),
+					duration_seconds: durationSeconds,
+					success: false,
+				});
 			},
 		});
 	};

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPage.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPage.tsx
@@ -43,6 +43,27 @@ const TemplateBuilderPage: FC = () => {
 		});
 	}, [sessionMutation.mutate, sessionId]);
 
+	// Report compose_completion when the create request settles. Duration
+	// is captured at submit time so it measures wizard usage, not the
+	// create request round trip.
+	const reportCompletion = useCallback(
+		(
+			state: TemplateBuilderWizardState,
+			success: boolean,
+			durationSeconds: number,
+		) => {
+			sessionMutation.mutate({
+				session_id: state.sessionId,
+				event_type: "compose_completion",
+				base_template_id: state.baseTemplateId ?? undefined,
+				module_ids: state.modules.map((m) => m.id),
+				duration_seconds: durationSeconds,
+				success,
+			});
+		},
+		[sessionMutation.mutate],
+	);
+
 	useEffect(() => {
 		if (!wizardReady) {
 			return;
@@ -91,20 +112,9 @@ const TemplateBuilderPage: FC = () => {
 		const req = toCreateTemplateRequest(state);
 		const durationSeconds = (Date.now() - state.enteredAt) / 1000;
 
-		const reportCompletion = (success: boolean) => {
-			sessionMutation.mutate({
-				session_id: state.sessionId,
-				event_type: "compose_completion",
-				base_template_id: state.baseTemplateId ?? undefined,
-				module_ids: state.modules.map((m) => m.id),
-				duration_seconds: durationSeconds,
-				success,
-			});
-		};
-
 		createMutation.mutate(req, {
 			onSuccess: (resp) => {
-				reportCompletion(true);
+				reportCompletion(state, true, durationSeconds);
 				const t = resp.template;
 				navigate(
 					`${getLink(linkToTemplate(t.organization_name, t.name))}/files`,
@@ -112,7 +122,7 @@ const TemplateBuilderPage: FC = () => {
 				);
 			},
 			onError: () => {
-				reportCompletion(false);
+				reportCompletion(state, false, durationSeconds);
 			},
 		});
 	};

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPage.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPage.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect, useMemo, useState } from "react";
+import { type FC, useCallback, useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery } from "react-query";
 import { Navigate, useNavigate, useSearchParams } from "react-router";
 import { deploymentConfig } from "#/api/queries/deployment";
@@ -36,15 +36,19 @@ const TemplateBuilderPage: FC = () => {
 		!builderDisabled && !isLoading && permissions.createTemplates;
 
 	// Report wizard_entry once the builder is ready and accessible.
-	useEffect(() => {
-		if (!wizardReady) {
-			return;
-		}
+	const reportEntry = useCallback(() => {
 		sessionMutation.mutate({
 			session_id: sessionId,
 			event_type: "wizard_entry",
 		});
-	}, [wizardReady, sessionMutation.mutate, sessionId]);
+	}, [sessionMutation.mutate, sessionId]);
+
+	useEffect(() => {
+		if (!wizardReady) {
+			return;
+		}
+		reportEntry();
+	}, [wizardReady, reportEntry]);
 
 	const basesQuery = useQuery({
 		...templateBuilderBases(),

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPage.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPage.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect, useState } from "react";
+import { type FC, useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery } from "react-query";
 import { Navigate, useNavigate, useSearchParams } from "react-router";
 import { deploymentConfig } from "#/api/queries/deployment";
@@ -27,6 +27,10 @@ const TemplateBuilderPage: FC = () => {
 	const createMutation = useMutation(createTemplateFromBuilder());
 	const sessionMutation = useMutation(recordTemplateBuilderSession());
 
+	// Stable session ID for the lifetime of this page mount, shared
+	// across wizard_entry and compose_completion telemetry events.
+	const sessionId = useMemo(() => crypto.randomUUID(), []);
+
 	const builderDisabled = data?.config?.template_builder?.disabled ?? false;
 	const wizardReady =
 		!builderDisabled && !isLoading && permissions.createTemplates;
@@ -37,8 +41,8 @@ const TemplateBuilderPage: FC = () => {
 		if (!wizardReady) {
 			return;
 		}
-		reportSession({ event_type: "wizard_entry" });
-	}, [wizardReady, reportSession]);
+		reportSession({ session_id: sessionId, event_type: "wizard_entry" });
+	}, [wizardReady, reportSession, sessionId]);
 
 	const basesQuery = useQuery({
 		...templateBuilderBases(),
@@ -84,6 +88,7 @@ const TemplateBuilderPage: FC = () => {
 		createMutation.mutate(req, {
 			onSuccess: (resp) => {
 				sessionMutation.mutate({
+					session_id: state.sessionId,
 					event_type: "compose_completion",
 					base_template_id: state.baseTemplateId ?? undefined,
 					module_ids: state.modules.map((m) => m.id),
@@ -98,6 +103,7 @@ const TemplateBuilderPage: FC = () => {
 			},
 			onError: () => {
 				sessionMutation.mutate({
+					session_id: state.sessionId,
 					event_type: "compose_completion",
 					base_template_id: state.baseTemplateId ?? undefined,
 					module_ids: state.modules.map((m) => m.id),
@@ -119,6 +125,7 @@ const TemplateBuilderPage: FC = () => {
 				createError={createMutation.error}
 				isCreating={createMutation.isPending || createMutation.isSuccess}
 				onClearCreateError={() => createMutation.reset()}
+				sessionId={sessionId}
 			/>
 		</>
 	);

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPage.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPage.tsx
@@ -36,13 +36,15 @@ const TemplateBuilderPage: FC = () => {
 		!builderDisabled && !isLoading && permissions.createTemplates;
 
 	// Report wizard_entry once the builder is ready and accessible.
-	const reportSession = sessionMutation.mutate;
 	useEffect(() => {
 		if (!wizardReady) {
 			return;
 		}
-		reportSession({ session_id: sessionId, event_type: "wizard_entry" });
-	}, [wizardReady, reportSession, sessionId]);
+		sessionMutation.mutate({
+			session_id: sessionId,
+			event_type: "wizard_entry",
+		});
+	}, [wizardReady, sessionMutation.mutate, sessionId]);
 
 	const basesQuery = useQuery({
 		...templateBuilderBases(),
@@ -85,16 +87,20 @@ const TemplateBuilderPage: FC = () => {
 		const req = toCreateTemplateRequest(state);
 		const durationSeconds = (Date.now() - state.enteredAt) / 1000;
 
+		const reportCompletion = (success: boolean) => {
+			sessionMutation.mutate({
+				session_id: state.sessionId,
+				event_type: "compose_completion",
+				base_template_id: state.baseTemplateId ?? undefined,
+				module_ids: state.modules.map((m) => m.id),
+				duration_seconds: durationSeconds,
+				success,
+			});
+		};
+
 		createMutation.mutate(req, {
 			onSuccess: (resp) => {
-				sessionMutation.mutate({
-					session_id: state.sessionId,
-					event_type: "compose_completion",
-					base_template_id: state.baseTemplateId ?? undefined,
-					module_ids: state.modules.map((m) => m.id),
-					duration_seconds: durationSeconds,
-					success: true,
-				});
+				reportCompletion(true);
 				const t = resp.template;
 				navigate(
 					`${getLink(linkToTemplate(t.organization_name, t.name))}/files`,
@@ -102,14 +108,7 @@ const TemplateBuilderPage: FC = () => {
 				);
 			},
 			onError: () => {
-				sessionMutation.mutate({
-					session_id: state.sessionId,
-					event_type: "compose_completion",
-					base_template_id: state.baseTemplateId ?? undefined,
-					module_ids: state.modules.map((m) => m.id),
-					duration_seconds: durationSeconds,
-					success: false,
-				});
+				reportCompletion(false);
 			},
 		});
 	};

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
@@ -62,6 +62,7 @@ interface TemplateBuilderPageViewProps {
 	createError: Error | null;
 	isCreating: boolean;
 	onClearCreateError?: () => void;
+	sessionId: string;
 }
 
 export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
@@ -72,10 +73,11 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 	createError,
 	isCreating,
 	onClearCreateError,
+	sessionId,
 }) => {
 	const [state, dispatch] = useReducer(
 		wizardReducer,
-		preselectedBase,
+		{ sessionId, preselectedBase },
 		initWizardState,
 	);
 	const [searchParams, setSearchParams] = useSearchParams();

--- a/site/src/pages/TemplateBuilder/wizardState.test.ts
+++ b/site/src/pages/TemplateBuilder/wizardState.test.ts
@@ -614,9 +614,9 @@ describe("baseCustomizationDefaults", () => {
 describe("initWizardState", () => {
 	it("returns the initial state without a preselected base", () => {
 		const state = initWizardState({ sessionId: "test-session-id" });
-		expect(state).toEqual({
+		expect(state).toMatchObject({
 			...initialWizardState,
-			enteredAt: state.enteredAt,
+			enteredAt: expect.any(Number),
 			sessionId: "test-session-id",
 		});
 		expect(state.enteredAt).toBeGreaterThan(0);

--- a/site/src/pages/TemplateBuilder/wizardState.test.ts
+++ b/site/src/pages/TemplateBuilder/wizardState.test.ts
@@ -613,17 +613,26 @@ describe("baseCustomizationDefaults", () => {
 
 describe("initWizardState", () => {
 	it("returns the initial state without a preselected base", () => {
-		expect(initWizardState()).toEqual(initialWizardState);
+		const state = initWizardState({ sessionId: "test-session-id" });
+		expect(state).toEqual({
+			...initialWizardState,
+			enteredAt: state.enteredAt,
+			sessionId: "test-session-id",
+		});
+		expect(state.enteredAt).toBeGreaterThan(0);
 	});
 
 	it("seeds base and customization defaults from a preselected base", () => {
 		const state = initWizardState({
-			id: "docker",
-			name: "Docker Containers",
-			description: "Docker",
-			iconUrl: "/icon/docker.png",
-			hasParameters: false,
-			hasPrerequisites: false,
+			sessionId: "test-session-id",
+			preselectedBase: {
+				id: "docker",
+				name: "Docker Containers",
+				description: "Docker",
+				iconUrl: "/icon/docker.png",
+				hasParameters: false,
+				hasPrerequisites: false,
+			},
 		});
 		expect(state.baseTemplateId).toBe("docker");
 		expect(state.selectedBase?.id).toBe("docker");
@@ -631,5 +640,6 @@ describe("initWizardState", () => {
 		expect(state.displayName).toBe("Docker Containers");
 		expect(state.description).toBe("Docker");
 		expect(state.icon).toBe("/icon/docker.png");
+		expect(state.sessionId).toBe("test-session-id");
 	});
 });

--- a/site/src/pages/TemplateBuilder/wizardState.ts
+++ b/site/src/pages/TemplateBuilder/wizardState.ts
@@ -81,6 +81,8 @@ export type TemplateBuilderWizardState = {
 	selectedModules: SelectedModuleMeta[];
 	/** Epoch millis when the wizard was entered, used for telemetry duration. */
 	enteredAt: number;
+	/** Stable ID shared across wizard_entry and compose_completion events. */
+	sessionId: string;
 };
 
 export const initialWizardState: TemplateBuilderWizardState = {
@@ -94,24 +96,31 @@ export const initialWizardState: TemplateBuilderWizardState = {
 	icon: "",
 	selectedBase: null,
 	selectedModules: [],
-	enteredAt: Date.now(),
+	enteredAt: 0,
+	sessionId: "",
 };
 
 /**
- * Builds the initial wizard state, optionally preselecting a base
- * template.
+ * Builds the initial wizard state with a fresh telemetry session,
+ * optionally preselecting a base template.
  */
-export function initWizardState(
-	preselectedBase?: SelectedBaseMeta,
-): TemplateBuilderWizardState {
-	if (!preselectedBase) {
-		return initialWizardState;
+export function initWizardState(init: {
+	sessionId: string;
+	preselectedBase?: SelectedBaseMeta;
+}): TemplateBuilderWizardState {
+	const state: TemplateBuilderWizardState = {
+		...initialWizardState,
+		enteredAt: Date.now(),
+		sessionId: init.sessionId,
+	};
+	if (!init.preselectedBase) {
+		return state;
 	}
 	return {
-		...initialWizardState,
-		baseTemplateId: preselectedBase.id,
-		selectedBase: preselectedBase,
-		...baseCustomizationDefaults(preselectedBase),
+		...state,
+		baseTemplateId: init.preselectedBase.id,
+		selectedBase: init.preselectedBase,
+		...baseCustomizationDefaults(init.preselectedBase),
 	};
 }
 

--- a/site/src/pages/TemplateBuilder/wizardState.ts
+++ b/site/src/pages/TemplateBuilder/wizardState.ts
@@ -100,14 +100,19 @@ export const initialWizardState: TemplateBuilderWizardState = {
 	sessionId: "",
 };
 
+/** Arguments for building a fresh wizard state on mount. */
+type WizardInit = {
+	/** Optional base template to preselect (from the ?base= param). */
+	preselectedBase?: SelectedBaseMeta;
+	/** Stable session ID shared across telemetry events for this mount. */
+	sessionId: string;
+};
+
 /**
  * Builds the initial wizard state with a fresh telemetry session,
  * optionally preselecting a base template.
  */
-export function initWizardState(init: {
-	sessionId: string;
-	preselectedBase?: SelectedBaseMeta;
-}): TemplateBuilderWizardState {
+export function initWizardState(init: WizardInit): TemplateBuilderWizardState {
 	const state: TemplateBuilderWizardState = {
 		...initialWizardState,
 		enteredAt: Date.now(),

--- a/site/src/pages/TemplateBuilder/wizardState.ts
+++ b/site/src/pages/TemplateBuilder/wizardState.ts
@@ -79,6 +79,8 @@ export type TemplateBuilderWizardState = {
 	icon: string;
 	selectedBase: SelectedBaseMeta | null;
 	selectedModules: SelectedModuleMeta[];
+	/** Epoch millis when the wizard was entered, used for telemetry duration. */
+	enteredAt: number;
 };
 
 export const initialWizardState: TemplateBuilderWizardState = {
@@ -92,6 +94,7 @@ export const initialWizardState: TemplateBuilderWizardState = {
 	icon: "",
 	selectedBase: null,
 	selectedModules: [],
+	enteredAt: Date.now(),
 };
 
 /**


### PR DESCRIPTION
`TemplateBuilderSession` telemetry types and telemetry-server ingestion were added in earlier PRs (#25082, coder/coder-telemetry-server#41), but no code ever produced session events. This adds the missing producer.

**Backend**: `POST /api/v2/templatebuilder/sessions` reports wizard entry and compose completion events directly via `api.Telemetry.Report()`, using the same inline pattern as `NetworkEvents` and `UserTailnetConnections`. No database migration or `createSnapshot()` changes needed. RBAC requires `policy.ActionCreate` on `ResourceTemplate.AnyOrganization()`, matching the compose endpoint.

**Frontend**: The template builder wizard fires `wizard_entry` on page mount and `compose_completion` on create success or failure. A client-generated session ID (UUID) correlates the two events for the same wizard visit, enabling precise funnel analysis and abandonment detection in BigQuery. Duration is tracked via `Date.now()` in the wizard state.

Closes https://linear.app/codercom/issue/DEVEX-599

<details>
<summary>Implementation plan</summary>

## Root Cause Analysis

The DEVEX-599 ticket diagnosis suggested missing DB tables, queries, and `eg.Go` blocks. That diagnosis assumes the DB-backed periodic snapshot path is required. It is not. Investigation shows two telemetry reporting patterns in the codebase:

1. **DB-backed periodic snapshots** (`createSnapshot()` with `eg.Go` blocks): Used for durable entities like workspaces, templates, users.
2. **Direct inline reporting** (`api.Telemetry.Report(&telemetry.Snapshot{...})`): Used for ephemeral events like `NetworkEvents`, `UserTailnetConnections`, `CLIInvocations`.

Template builder sessions are ephemeral events, so the direct inline reporting pattern is the correct fit.

## Backend Changes

- `codersdk/templatebuilder.go`: `TemplateBuilderSessionRequest` type with `SessionID`, `EventType` enum, `TemplateBuilderSession()` client method
- `coderd/coderd.go`: Route registration in `/templatebuilder` group
- `coderd/templatebuilder_handler.go`: Handler with RBAC check, request validation, session ID fallback, and inline telemetry report
- `coderd/templatebuilder_handler_test.go`: Tests for wizard entry, compose completion, invalid event type, disabled feature, and member RBAC rejection

## Frontend Changes

- `site/src/api/api.ts`: `recordTemplateBuilderSession` API method
- `site/src/api/queries/templateBuilder.ts`: React Query mutation
- `site/src/pages/TemplateBuilder/wizardState.ts`: `sessionId` and `enteredAt` fields, `createWizardState()` factory for per-mount initialization
- `site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx`: `sessionId` prop, `useReducer` initializer form
- `site/src/pages/TemplateBuilder/TemplateBuilderPage.tsx`: Telemetry calls for wizard entry (on mount) and compose completion (on create success/failure)

</details>

> 🤖 Generated by Coder Agents