### PR TITLE
test(cli): tolerate stray requests in fake agent API

### DIFF
--- a/cli/task_test.go
+++ b/cli/task_test.go
@@ -3,6 +3,8 @@ package cli_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -533,6 +535,14 @@ func startFakeAgentAPI(t *testing.T, handlers map[string]http.HandlerFunc) *fake
 
 	mux := http.NewServeMux()
 
+	// requestDetail records method, path, User-Agent, and a bounded view of
+	// the request body so unexpected traffic can be attributed without
+	// unbounded logging.
+	requestDetail := func(r *http.Request) string {
+		body, _ := io.ReadAll(io.LimitReader(r.Body, 4<<10))
+		return fmt.Sprintf("method=%s path=%s user-agent=%q body=%q", r.Method, r.URL.Path, r.UserAgent(), body)
+	}
+
 	// Register all provided handlers with call tracking
 	for path, handler := range handlers {
 		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -543,18 +553,27 @@ func startFakeAgentAPI(t *testing.T, handlers map[string]http.HandlerFunc) *fake
 		})
 	}
 
+	// Known agentapi endpoints without a handler fail the test: a coderd
+	// regression that calls an endpoint the test did not stub must be
+	// caught. The 404 also gives the client a well-formed response instead
+	// of leaving it hanging.
 	knownEndpoints := []string{"/status", "/messages", "/message"}
 	for _, endpoint := range knownEndpoints {
 		if handlers[endpoint] == nil {
 			endpoint := endpoint // capture loop variable
 			mux.HandleFunc(endpoint, func(w http.ResponseWriter, r *http.Request) {
-				t.Fatalf("unexpected call to %s %s - no handler defined", r.Method, endpoint)
+				t.Errorf("unexpected call to agentapi endpoint %s with no handler defined: %s", endpoint, requestDetail(r))
+				w.WriteHeader(http.StatusNotFound)
 			})
 		}
 	}
-	// Default handler for unknown endpoints should cause the test to fail.
+	// Unknown paths get a 404 and a log line, but do not fail the test.
+	// Stray traffic can arrive here, most likely from another test's
+	// lingering client whose closed server's ephemeral port was reused by
+	// this one, so failing on unknown paths would create false flakes.
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		t.Fatalf("unexpected call to %s %s - no handler defined", r.Method, r.URL.Path)
+		t.Logf("unexpected request to unknown path, likely cross-test chatter from a reused ephemeral port: %s", requestDetail(r))
+		w.WriteHeader(http.StatusNotFound)
 	})
 
 	fake.server = httptest.NewServer(mux)


### PR DESCRIPTION
`Test_TaskSend` kept flaking after two fixes because CODAGT-482 was actually two distinct failure modes. The remaining one is test infrastructure, not product code: the fake agent API called `t.Fatalf` from an HTTP handler goroutine on any unexpected request, so a single stray `POST /chat/completions` (most likely another test's lingering client after ephemeral port reuse) failed the test even when the command under test behaved correctly.

Unknown paths now get a 404 plus a log line with method, path, User-Agent, and a bounded body so the traffic can be attributed if it recurs. Unstubbed known agentapi endpoints (`/status`, `/message`, `/messages`) still fail the test, via goroutine-safe `t.Errorf`, so a coderd regression calling an endpoint the test did not stub is still caught.

Not done here: the `tasks_with_status` view maps in-flight stop builds to `'unknown'` (the original May failure mode, mode A below). That production gap is intentionally out of scope; the existing mock-clock synchronization from #25858 keeps it out of this test.

Closes coder/internal#1547
Closes coder/internal#1609

<details>
<summary>Root-cause analysis</summary>

**Mode A (May 26/28/29, macos):** `tasks_with_status` has no CASE branch for `(stop|delete, pending|running)` builds and falls to `ELSE 'unknown'`; `waitForTaskIdle` treats `TaskStatusUnknown` as fatal. A poll racing the in-flight stop build returned `unknown` instead of `paused`. #25811 added a mock clock but closed the ticker-reset trap after the first poll, leaving the second poll racy (hence the May 29 re-flake). #25858 fixed the trap lifecycle; mode A has not recurred since June 1.

**Mode B (June 18, ubuntu, run 27772818901):** the command produced the expected "was paused" error, yet the test failed at the fake agent API's catch-all: `task_test.go:557: unexpected call to POST /chat/completions`. No code in this repo posts `/chat/completions` to a sidebar app URL (agentapi-sdk-go only uses `/message`, `/messages`, `/status`), and the request arrived mid-stop-build during setup. Best supported explanation: a fake-LLM client from a concurrently running test binary (chatd/aibridge fakes serve exactly `POST /chat/completions`) retried against its closed server's address after the ephemeral port had been reused by this test's `httptest` server. coder/internal#1609 (`WaitsForInitializingTask`, June 25) shows the identical failure line and is fixed by the same change. Attribution is not provable from the June 18 log because the old handler recorded nothing; the new logging makes it provable on the next occurrence.

`t.Fatalf` from a handler goroutine also violates the testing package contract (Fatalf must run on the test goroutine) and left the HTTP client without a response.

**Verification:** `make test-race TEST_PACKAGES="./cli..." RUN='Test_TaskSend' TEST_COUNT=20` passed (280 tests, 0 failures, 0 races); both new handler paths were exercised once via a throwaway test (stray unknown path logs and passes; unstubbed known endpoint fails via `t.Errorf`); `make fmt` and `make lint` clean.
</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
