### PR TITLE
feat(site): add claude-fable-5 and claude-mythos-5 known model defaults

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/anthropic.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/anthropic.test.ts
@@ -22,6 +22,8 @@ describe("anthropicKnownModels", () => {
 				(knownModel) => knownModel.modelIdentifier,
 			),
 		).toEqual([
+			"claude-fable-5",
+			"claude-mythos-5",
 			"claude-opus-4-8",
 			"claude-opus-4-7",
 			"claude-opus-4-6",
@@ -33,6 +35,8 @@ describe("anthropicKnownModels", () => {
 
 	it("declares Anthropic reasoning defaults by API support", () => {
 		for (const modelIdentifier of [
+			"claude-fable-5",
+			"claude-mythos-5",
 			"claude-opus-4-8",
 			"claude-opus-4-7",
 			"claude-opus-4-6",
@@ -59,6 +63,8 @@ describe("anthropicKnownModels", () => {
 		expect(
 			anthropicKnownModels.map((knownModel) => knownModel.modelIdentifier),
 		).toEqual([
+			"claude-fable-5",
+			"claude-mythos-5",
 			"claude-opus-4-8",
 			"claude-opus-4-7",
 			"claude-opus-4-6",

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/anthropic.ts
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/anthropic.ts
@@ -10,8 +10,8 @@ import type { KnownModel } from "./types";
 // catalog and should be reviewed when the catalog is refreshed.
 //
 // Reasoning configuration is split per model based on Anthropic API support:
-// models that support adaptive thinking (Opus 4.8, Opus 4.7, Opus 4.6,
-// Sonnet 4.6) carry `reasoningEffort`, which Coder maps to
+// models that support adaptive thinking (Fable 5, Mythos 5, Opus 4.8,
+// Opus 4.7, Opus 4.6, Sonnet 4.6) carry `reasoningEffort`, which Coder maps to
 // `thinking.type: "adaptive"` with the `effort` parameter. Models that do not
 // (Haiku 4.5, Sonnet 4.5)
 // carry `thinkingBudgetTokens` instead, which Coder maps to the legacy
@@ -19,6 +19,45 @@ import type { KnownModel } from "./types";
 // the legacy path produces an "adaptive thinking is not supported on this
 // model" HTTP 400 from Anthropic.
 export const anthropicKnownModels = [
+	{
+		provider: "anthropic",
+		modelIdentifier: "claude-fable-5",
+		displayName: "Claude Fable 5",
+		aliases: [],
+		contextLimit: 1_000_000,
+		maxOutputTokens: 128_000,
+		reasoningEffort: "high",
+		inputCost: 10,
+		outputCost: 50,
+		cacheReadCost: 1,
+		cacheWriteCost: 12.5,
+		sourceMetadata: {
+			sourceName: "models.dev",
+			sourceRetrievedAt: "2026-07-09",
+			lastUpdated: "2026-06-09",
+		},
+	},
+	// models.dev does not list claude-mythos-5. Anthropic documents that
+	// Mythos 5 shares Fable 5's specs and pricing, so this entry mirrors
+	// the claude-fable-5 models.dev entry.
+	{
+		provider: "anthropic",
+		modelIdentifier: "claude-mythos-5",
+		displayName: "Claude Mythos 5",
+		aliases: [],
+		contextLimit: 1_000_000,
+		maxOutputTokens: 128_000,
+		reasoningEffort: "high",
+		inputCost: 10,
+		outputCost: 50,
+		cacheReadCost: 1,
+		cacheWriteCost: 12.5,
+		sourceMetadata: {
+			sourceName: "models.dev",
+			sourceRetrievedAt: "2026-07-09",
+			lastUpdated: "2026-06-09",
+		},
+	},
 	{
 		provider: "anthropic",
 		modelIdentifier: "claude-opus-4-8",


### PR DESCRIPTION
Adds `claude-fable-5` and `claude-mythos-5` to the frontend Known Models catalog so the Chat Model admin panel can autofill defaults (context limit, max output tokens, reasoning effort, and pricing) for both models.

## Changes

- Add `claude-fable-5` and `claude-mythos-5` entries to `anthropicKnownModels`, ordered ahead of the existing Opus/Sonnet/Haiku entries. Both carry a 1M context limit, 128k max output tokens, `reasoningEffort: "high"` (adaptive thinking path), and $10/$50 per million input/output token pricing with $1/$12.50 cache read/write.
- Update the header comment listing which Anthropic models use adaptive thinking.
- Extend `anthropic.test.ts` expectations for catalog order and reasoning defaults.

## Data sourcing

`claude-fable-5` values are taken from models.dev (retrieved 2026-07-09, last updated 2026-06-09). models.dev does not list `claude-mythos-5` (limited release via Project Glasswing), but Anthropic documents that it shares Claude Fable 5's specs and pricing, so its entry mirrors the fable-5 values. This caveat is documented as a code comment on the entry.

## Validation

- `pnpm test src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels`: 45/45 tests pass
- `biome check` on the changed directory: clean
- `tsc --noEmit` on `site/`: clean

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_
