### PR TITLE
chore: bump coder/fantasy for gpt-5.6 Responses routing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -104,8 +104,12 @@ replace github.com/spf13/afero => github.com/aslilac/afero v0.0.0-20250403163713
 // 14) coder/fantasy bedrock: mirror the request region when prefixing
 //     cross-region inference profiles so the model-ID prefix matches the
 //     region the request is actually signed for.
-// See: https://github.com/coder/fantasy/commits/2e3ddbca75dd
-replace charm.land/fantasy => github.com/coder/fantasy v0.0.0-20260617050554-2e3ddbca75dd
+// 15) coder/fantasy#41, surface Anthropic refusal stop_reason as
+//     content-filter.
+// 16) coder/fantasy#46, route the gpt-5.6 family (sol, terra, luna)
+//     through the OpenAI Responses API.
+// See: https://github.com/coder/fantasy/commits/6da0c3b10237
+replace charm.land/fantasy => github.com/coder/fantasy v0.0.0-20260709180403-6da0c3b10237
 
 // coder/coder uses a fork of charmbracelet's fork of the Anthropic Go SDK
 // with performance improvements and Bedrock header cleanup.

--- a/go.sum
+++ b/go.sum
@@ -324,8 +324,8 @@ github.com/coder/bubbletea v1.2.2-0.20241212190825-007a1cdb2c41 h1:SBN/DA63+ZHwu
 github.com/coder/bubbletea v1.2.2-0.20241212190825-007a1cdb2c41/go.mod h1:I9ULxr64UaOSUv7hcb3nX4kowodJCVS7vt7VVJk/kW4=
 github.com/coder/clistat v1.2.1 h1:P9/10njXMyj5cWzIU5wkRsSy5LVQH49+tcGMsAgWX0w=
 github.com/coder/clistat v1.2.1/go.mod h1:m7SC0uj88eEERgvF8Kn6+w6XF21BeSr+15f7GoLAw0A=
-github.com/coder/fantasy v0.0.0-20260617050554-2e3ddbca75dd h1:PWOW1JxcPi2MfNawFWdECvKuL+pgx1dtYF9vXlaW8rc=
-github.com/coder/fantasy v0.0.0-20260617050554-2e3ddbca75dd/go.mod h1:/1tM8tL1viuF1COpWPwbcUl4s1kAnjSruzo9wAdg4z0=
+github.com/coder/fantasy v0.0.0-20260709180403-6da0c3b10237 h1:DyIn89F5RErX8Z6BKtzQBg5PvDTasjX8+PXkdJUxK3Q=
+github.com/coder/fantasy v0.0.0-20260709180403-6da0c3b10237/go.mod h1:/1tM8tL1viuF1COpWPwbcUl4s1kAnjSruzo9wAdg4z0=
 github.com/coder/flog v1.1.0 h1:kbAes1ai8fIS5OeV+QAnKBQE22ty1jRF/mcAwHpLBa4=
 github.com/coder/flog v1.1.0/go.mod h1:UQlQvrkJBvnRGo69Le8E24Tcl5SJleAAR7gYEHzAmdQ=
 github.com/coder/go-httpstat v0.0.0-20230801153223-321c88088322 h1:m0lPZjlQ7vdVpRBPKfYIFlmgevoTkBxB10wv6l2gOaU=


### PR DESCRIPTION
gpt-5.6 models were unusable with agents: fantasy's Responses allowlist did not include the new family, so `IsResponsesModel` returned false and chatd fell back to the Chat Completions path (no reasoning params, no encrypted reasoning continuity).

## Changes

- Bump the `charm.land/fantasy` replace pin to coder/fantasy `6da0c3b10237` (coder_2_33), pulling in:
  - coder/fantasy#46: route `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` through the OpenAI Responses API as reasoning models.
  - coder/fantasy#41: surface Anthropic refusal stop_reason as content-filter (already on coder_2_33, rides along with the bump).
- Update the fork changelog comment in go.mod.

## Verification

- Probed all three gpt-5.6 models through the ai-gateway: `/v1/responses` with `reasoning.effort`, `include: ["reasoning.encrypted_content"]`, and `store: false` completes for each.
- `go build ./coderd/...` and `go test ./coderd/x/chatd/chatopenai/ ./coderd/x/chatd/chatprovider/` pass against the new pin.

> This PR was authored by Mux on Mike's behalf.
