### PR TITLE
feat: add platform-cookie auth bridge and admin-only dashboard

### DIFF
--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -559,6 +559,38 @@ disableWorkspaceSharing: false
 # their chats.
 # (default: <unset>, type: bool)
 disableChatSharing: false
+platformAuth:
+  # Enable the platform-cookie authentication bridge. When enabled, opening a
+  # workspace app with a valid platform session cookie logs the user in via the
+  # external backend and skips the login page.
+  # (default: true, type: bool)
+  enable: true
+  # Name of the platform session cookie that Coder reads and forwards to the backend
+  # for validation.
+  # (default: access_token, type: string)
+  cookieName: access_token
+  # Ordered list of backend endpoints that validate the platform cookie and return
+  # the owning user's email as JSON. Each may contain a literal "{env}" placeholder,
+  # replaced with the environment derived from the workspace name suffix. When one
+  # Coder deployment serves multiple platform environments, list one endpoint per
+  # environment; Coder tries them in order and the first to accept the cookie wins.
+  # (default: <unset>, type: string-array)
+  validateURLs: []
+  # Allowed environment suffixes. A workspace whose name does not end in one of
+  # these (after the final "-") is not bridged.
+  # (default: dev,uat,prod, type: string-array)
+  envs:
+    - dev
+    - uat
+    - prod
+  # Timeout for the backend validation request.
+  # (default: 5s, type: duration)
+  requestTimeout: 5s
+  # Where to redirect an unauthenticated workspace-app request instead of the Coder
+  # login page, so the user re-authenticates with the platform. A literal
+  # "{redirect}" placeholder is replaced with the URL-encoded original app URL.
+  # (default: <unset>, type: string)
+  loginRedirectURL: ""
 # These options change the behavior of how clients interact with the Coder.
 # Clients include the Coder CLI, Coder Desktop, IDE extensions, and the web UI.
 client:

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1039,6 +1039,10 @@ func New(options *Options) *API {
 		}),
 		singleSlashMW,
 		rolestore.CustomRoleMW,
+		// Bridge platform-cookie auth into a Coder session before the API key is
+		// prechecked, so opening a workspace app with a valid platform cookie
+		// authenticates the request without a login redirect.
+		api.platformAuthBridgeMW,
 		// Validate API key on every request (if present) and store
 		// the result in context. The rate limiter reads this to key
 		// by user ID, and downstream ExtractAPIKeyMW reuses it to
@@ -1083,6 +1087,10 @@ func New(options *Options) *API {
 	r.Get("/latency-check", tracing.StatusWriterMiddleware(prometheusMW(LatencyCheck())).ServeHTTP)
 
 	r.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("OK")) })
+
+	// Redirects non-admin users from the dashboard to the platform login. Public
+	// so it works before any Coder session exists.
+	r.Get("/platform-login", api.platformLoginRedirect)
 
 	// Attach workspace apps routes.
 	r.Group(func(r chi.Router) {

--- a/coderd/platformauth/platformauth.go
+++ b/coderd/platformauth/platformauth.go
@@ -1,0 +1,157 @@
+// Package platformauth contains helpers for the platform-cookie authentication
+// bridge: deriving the environment from a workspace name, extracting the
+// workspace name from an incoming request, and validating a platform session
+// cookie against the external backend.
+//
+// Coder performs no token verification of its own. The backend is the sole
+// authority: it is handed the raw platform cookie and, on success, returns the
+// owning user's email.
+package platformauth
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"regexp"
+	"slices"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/workspaceapps/appurl"
+)
+
+// ErrInvalidToken is returned by Validate when the backend rejects the cookie
+// (HTTP 401/403). The caller treats it the same as any other failure: fall
+// through to the normal login flow.
+var ErrInvalidToken = xerrors.New("platform token rejected by backend")
+
+// maxResponseBytes bounds how much of the backend response we read to guard
+// against a misbehaving or hostile endpoint.
+const maxResponseBytes = 1 << 16
+
+// pathAppRe matches the workspace name in a path-based app request:
+// /@{user}/{workspace}[.{agent}]/apps/{slug}. The "@" may be percent-encoded.
+// Workspace and user names are alphanumeric with single hyphens, so the
+// workspace capture stops at the first "." (the agent separator) or "/".
+var pathAppRe = regexp.MustCompile(`^/(?:@|%40)[^/]+/([^/.]+)(?:\.[^/]+)?/apps(?:/|$)`)
+
+// EnvFromWorkspaceName returns the environment encoded as the final "-"
+// delimited segment of the workspace name (e.g. "my-project-dev" -> "dev"). It
+// returns ok=false when the suffix is not one of the allowed environments.
+func EnvFromWorkspaceName(name string, allowed []string) (string, bool) {
+	idx := strings.LastIndex(name, "-")
+	if idx < 0 || idx == len(name)-1 {
+		return "", false
+	}
+	env := name[idx+1:]
+	if !slices.Contains(allowed, env) {
+		return "", false
+	}
+	return env, true
+}
+
+// WorkspaceNameFromRequest extracts the workspace name from a workspace-app
+// request, handling both path-based apps and subdomain-based apps. It returns
+// ok=false when the request is not an app request we can parse.
+func WorkspaceNameFromRequest(r *http.Request) (string, bool) {
+	if m := pathAppRe.FindStringSubmatch(r.URL.Path); m != nil {
+		return m[1], true
+	}
+
+	// Subdomain apps: the first DNS label encodes
+	// {slug}--{agent}--{workspace}--{user}. ParseSubdomainAppURL rejects any
+	// label that does not match, so a bare dashboard host is safely ignored.
+	host := r.Host
+	if host == "" {
+		host = r.URL.Host
+	}
+	label, _, found := strings.Cut(host, ".")
+	if !found || label == "" {
+		return "", false
+	}
+	app, err := appurl.ParseSubdomainAppURL(label)
+	if err != nil || app.WorkspaceName == "" {
+		return "", false
+	}
+	return app.WorkspaceName, true
+}
+
+// CandidateURLs returns the ordered list of validation endpoints to try for a
+// request. Each configured URL may contain a "{env}" placeholder. When the
+// environment is known it is substituted directly; when it is unknown, the URL
+// is expanded once per configured environment (in order) so the caller can
+// fall back across environments. URLs without a placeholder are used as-is.
+// Duplicates are removed while preserving order.
+func CandidateURLs(urls []string, env string, envOK bool, allEnvs []string) []string {
+	var out []string
+	seen := make(map[string]struct{})
+	add := func(u string) {
+		if _, ok := seen[u]; ok {
+			return
+		}
+		seen[u] = struct{}{}
+		out = append(out, u)
+	}
+	for _, u := range urls {
+		if !strings.Contains(u, "{env}") {
+			add(u)
+			continue
+		}
+		if envOK {
+			add(strings.ReplaceAll(u, "{env}", env))
+			continue
+		}
+		for _, e := range allEnvs {
+			add(strings.ReplaceAll(u, "{env}", e))
+		}
+	}
+	return out
+}
+
+// Validate asks the backend at the given (already-resolved) URL to validate the
+// platform cookie. On success it returns the email of the user the cookie
+// belongs to.
+func Validate(ctx context.Context, client *http.Client, url, cookieName, token string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", xerrors.Errorf("build validate request: %w", err)
+	}
+	// Forward only the platform cookie, never Coder's own session cookie.
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: token})
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", xerrors.Errorf("call backend: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return "", ErrInvalidToken
+	default:
+		return "", xerrors.Errorf("backend returned status %d", resp.StatusCode)
+	}
+
+	// The backend wraps its payload as {"data": {"email": ...}, "status": ...}.
+	// A top-level "email" is also accepted for flexibility.
+	var body struct {
+		Email string `json:"email"`
+		Data  struct {
+			Email string `json:"email"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseBytes)).Decode(&body); err != nil {
+		return "", xerrors.Errorf("decode backend response: %w", err)
+	}
+	email := body.Data.Email
+	if email == "" {
+		email = body.Email
+	}
+	if email == "" {
+		return "", xerrors.New("backend response missing email")
+	}
+	return email, nil
+}

--- a/coderd/platformauth/platformauth_test.go
+++ b/coderd/platformauth/platformauth_test.go
@@ -1,0 +1,209 @@
+package platformauth_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/platformauth"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestEnvFromWorkspaceName(t *testing.T) {
+	t.Parallel()
+
+	allowed := []string{"dev", "uat", "prod"}
+	cases := []struct {
+		name    string
+		ws      string
+		wantEnv string
+		wantOK  bool
+	}{
+		{"simple", "proj-dev", "dev", true},
+		{"multi hyphen", "my-cool-project-prod", "prod", true},
+		{"uat", "x-uat", "uat", true},
+		{"no hyphen", "project", "", false},
+		{"trailing hyphen", "project-", "", false},
+		{"unknown env", "project-staging", "", false},
+		{"empty", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			env, ok := platformauth.EnvFromWorkspaceName(tc.ws, allowed)
+			require.Equal(t, tc.wantOK, ok)
+			require.Equal(t, tc.wantEnv, env)
+		})
+	}
+}
+
+func TestWorkspaceNameFromRequest(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		method string
+		target string
+		host   string
+		wantWS string
+		wantOK bool
+	}{
+		{"path with agent", http.MethodGet, "/@alice/my-ws-dev.main/apps/code-server/", "coder.example.com", "my-ws-dev", true},
+		{"path without agent", http.MethodGet, "/@alice/my-ws-dev/apps/code-server/", "coder.example.com", "my-ws-dev", true},
+		{"encoded at", http.MethodGet, "/%40alice/my-ws-dev.main/apps/code-server/", "coder.example.com", "my-ws-dev", true},
+		{"non-app path", http.MethodGet, "/api/v2/users/me", "coder.example.com", "", false},
+		{"dashboard root", http.MethodGet, "/", "coder.example.com", "", false},
+		{"subdomain app", http.MethodGet, "/", "code-server--main--my-ws-dev--alice.apps.example.com", "my-ws-dev", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := httptest.NewRequest(tc.method, tc.target, nil)
+			r.Host = tc.host
+			ws, ok := platformauth.WorkspaceNameFromRequest(r)
+			require.Equal(t, tc.wantOK, ok)
+			require.Equal(t, tc.wantWS, ws)
+		})
+	}
+}
+
+func TestCandidateURLs(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		urls    []string
+		env     string
+		envOK   bool
+		allEnvs []string
+		want    []string
+	}{
+		{
+			name:  "known env substitutes once",
+			urls:  []string{"https://a/{env}/v"},
+			env:   "dev",
+			envOK: true,
+			want:  []string{"https://a/dev/v"},
+		},
+		{
+			name:    "unknown env expands across all envs in order",
+			urls:    []string{"https://a/{env}/v"},
+			envOK:   false,
+			allEnvs: []string{"uat", "dev", "prod"},
+			want:    []string{"https://a/uat/v", "https://a/dev/v", "https://a/prod/v"},
+		},
+		{
+			name:  "non-templated urls are fallback list",
+			urls:  []string{"https://uat/v", "https://dev/v"},
+			envOK: false,
+			want:  []string{"https://uat/v", "https://dev/v"},
+		},
+		{
+			name:  "duplicates removed preserving order",
+			urls:  []string{"https://a/{env}", "https://a/{env}"},
+			env:   "dev",
+			envOK: true,
+			want:  []string{"https://a/dev"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, platformauth.CandidateURLs(tc.urls, tc.env, tc.envOK, tc.allEnvs))
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+		var gotCookie, gotPath string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotCookie = r.Header.Get("Cookie")
+			gotPath = r.URL.Path
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"email":"user@example.com"}`))
+		}))
+		defer srv.Close()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		email, err := platformauth.Validate(ctx, srv.Client(), srv.URL+"/dev/validate", "access_token", "tok-123")
+		require.NoError(t, err)
+		require.Equal(t, "user@example.com", email)
+		// Only the platform cookie is forwarded.
+		require.Equal(t, "access_token=tok-123", gotCookie)
+		require.Equal(t, "/dev/validate", gotPath)
+	})
+
+	t.Run("SuccessDataEnvelope", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{"email":"user@example.com"},"status":"SUCCESS"}`))
+		}))
+		defer srv.Close()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		email, err := platformauth.Validate(ctx, srv.Client(), srv.URL, "access_token", "tok")
+		require.NoError(t, err)
+		require.Equal(t, "user@example.com", email)
+	})
+
+	t.Run("Unauthorized", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer srv.Close()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		_, err := platformauth.Validate(ctx, srv.Client(), srv.URL, "access_token", "bad")
+		require.ErrorIs(t, err, platformauth.ErrInvalidToken)
+	})
+
+	t.Run("ServerError", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		_, err := platformauth.Validate(ctx, srv.Client(), srv.URL, "access_token", "tok")
+		require.Error(t, err)
+		require.NotErrorIs(t, err, platformauth.ErrInvalidToken)
+	})
+
+	t.Run("MissingEmail", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}))
+		defer srv.Close()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		_, err := platformauth.Validate(ctx, srv.Client(), srv.URL, "access_token", "tok")
+		require.Error(t, err)
+	})
+
+	t.Run("Timeout", func(t *testing.T) {
+		t.Parallel()
+		blocked := make(chan struct{})
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			<-blocked
+		}))
+		defer srv.Close()
+		defer close(blocked)
+
+		client := &http.Client{Timeout: time.Millisecond}
+		_, err := platformauth.Validate(context.Background(), client, srv.URL, "access_token", "tok")
+		require.Error(t, err)
+	})
+}

--- a/coderd/platformauthbridge.go
+++ b/coderd/platformauthbridge.go
@@ -1,0 +1,241 @@
+package coderd
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/coderd/apikey"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/httpmw"
+	"github.com/coder/coder/v2/coderd/platformauth"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+// platformAuthBridgeMW authenticates a user opening a workspace app via the
+// platform session cookie, so they land directly in the app instead of the
+// login page.
+//
+// It must run before httpmw.PrecheckAPIKey: on success it mints a Coder session
+// and injects the cookie into the current request so the downstream API-key
+// validation authenticates it. It only acts on GET/HEAD requests to a workspace
+// app URL that carry the platform cookie and have no existing Coder session,
+// bounding session minting to roughly once per platform session. Any failure is
+// a passthrough to the normal login flow; it never rejects a request.
+func (api *API) platformAuthBridgeMW(next http.Handler) http.Handler {
+	cfg := api.DeploymentValues.PlatformAuth
+	// Zero per-request overhead when the feature is off.
+	if !cfg.Enable.Value() {
+		return next
+	}
+
+	var (
+		client        = &http.Client{Timeout: cfg.RequestTimeout.Value()}
+		cookieName    = cfg.CookieName.Value()
+		validateURLs  = cfg.ValidateURLs.Value()
+		envs          = cfg.Envs.Value()
+		loginRedirect = cfg.LoginRedirectURL.Value()
+	)
+
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		// Leave non-navigations and already-authenticated requests alone. GET/HEAD
+		// only avoids colliding with the CSRF middleware, which runs later and
+		// would reject a freshly set session cookie on an unsafe method.
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			next.ServeHTTP(rw, r)
+			return
+		}
+		if httpmw.APITokenFromRequest(r) != "" {
+			next.ServeHTTP(rw, r)
+			return
+		}
+
+		// Engage on two kinds of request:
+		//   1. Workspace-app links (the direct IDE open).
+		//   2. Top-level dashboard page navigations (e.g. a member landing on
+		//      /workspaces), so they get a session and are then shown the
+		//      access-restricted screen instead of Coder's login.
+		// Sec-Fetch-Dest=document identifies a real page navigation, which
+		// excludes the SPA's XHR/asset sub-requests so we don't call the backend
+		// on every one of them. Everything else is left untouched so admins and
+		// non-browser clients still use Coder's own auth.
+		wsName, isAppURL := platformauth.WorkspaceNameFromRequest(r)
+		isPageNav := r.Header.Get("Sec-Fetch-Dest") == "document"
+		if !isAppURL && !isPageNav {
+			next.ServeHTTP(rw, r)
+			return
+		}
+
+		ctx := r.Context()
+		api.Logger.Debug(ctx, "platform auth bridge: handling request",
+			slog.F("workspace", wsName), slog.F("path", r.URL.Path), slog.F("app_url", isAppURL))
+
+		// Try to bridge the platform cookie into a Coder session.
+		if api.tryPlatformBridge(rw, r, client, cookieName, validateURLs, envs, wsName) {
+			next.ServeHTTP(rw, r)
+			return
+		}
+
+		// Could not bridge (missing/invalid platform cookie, unknown user, admin).
+		// For a workspace-app link, send the user to the platform login so they
+		// re-authenticate there. For a dashboard page nav, fall through to Coder's
+		// own login so admins (who have no platform cookie or are not bridgeable)
+		// are unaffected.
+		if isAppURL && loginRedirect != "" {
+			target := strings.ReplaceAll(loginRedirect, "{redirect}", url.QueryEscape(currentURL(r)))
+			api.Logger.Info(ctx, "platform auth bridge: unauthenticated app request, redirecting to platform login",
+				slog.F("workspace", wsName), slog.F("redirect_to", target))
+			http.Redirect(rw, r, target, http.StatusSeeOther)
+			return
+		}
+		api.Logger.Debug(ctx, "platform auth bridge: not bridged, falling through to default auth",
+			slog.F("path", r.URL.Path), slog.F("app_url", isAppURL))
+		next.ServeHTTP(rw, r)
+	})
+}
+
+// tryPlatformBridge validates the platform cookie for a workspace-app request
+// and, on success, mints a Coder session and injects it into the current
+// request. It reports whether the request is now authenticated.
+func (api *API) tryPlatformBridge(rw http.ResponseWriter, r *http.Request, client *http.Client, cookieName string, validateURLs, envs []string, wsName string) bool {
+	ctx := r.Context()
+
+	if len(validateURLs) == 0 {
+		api.Logger.Warn(ctx, "platform auth bridge: enabled but no validate URLs configured")
+		return false
+	}
+	cookie, err := r.Cookie(cookieName)
+	if err != nil || cookie.Value == "" {
+		api.Logger.Debug(ctx, "platform auth bridge: no platform cookie on request",
+			slog.F("cookie_name", cookieName), slog.F("workspace", wsName))
+		return false
+	}
+
+	// The workspace name suffix selects the environment when present; otherwise
+	// every configured environment endpoint is tried as a fallback.
+	env, envOK := platformauth.EnvFromWorkspaceName(wsName, envs)
+	candidates := platformauth.CandidateURLs(validateURLs, env, envOK, envs)
+	api.Logger.Debug(ctx, "platform auth bridge: validating platform cookie",
+		slog.F("workspace", wsName), slog.F("env", env), slog.F("env_matched", envOK),
+		slog.F("candidate_count", len(candidates)))
+
+	// Try each backend in order; the first to accept the cookie wins.
+	var email string
+	for _, candidate := range candidates {
+		e, err := platformauth.Validate(ctx, client, candidate, cookieName, cookie.Value)
+		if err != nil {
+			api.Logger.Debug(ctx, "platform auth bridge: candidate rejected cookie",
+				slog.F("url", candidate), slog.Error(err))
+			continue
+		}
+		email = e
+		api.Logger.Debug(ctx, "platform auth bridge: backend validated cookie",
+			slog.F("url", candidate), slog.F("email", email))
+		break
+	}
+	if email == "" {
+		api.Logger.Info(ctx, "platform auth bridge: no backend accepted the platform cookie",
+			slog.F("workspace", wsName), slog.F("candidate_count", len(candidates)))
+		return false
+	}
+
+	// System context: we are authenticating the user before they hold a Coder
+	// session, so there is no actor to authorize the lookup/mint.
+	//nolint:gocritic
+	sysCtx := dbauthz.AsSystemRestricted(ctx)
+	user, err := api.Database.GetUserByEmailOrUsername(sysCtx, database.GetUserByEmailOrUsernameParams{
+		Email: email,
+	})
+	if err != nil {
+		api.Logger.Info(ctx, "platform auth bridge: no Coder user matches the platform email",
+			slog.F("email", email), slog.Error(err))
+		return false
+	}
+
+	// Never bridge suspended users, and never bridge accounts that can reach
+	// admin surfaces (admins authenticate with a password). Dormant users are
+	// allowed: minting and using a session reactivates them, mirroring a normal
+	// login, which is required because API-provisioned users start dormant.
+	if user.Status == database.UserStatusSuspended {
+		api.Logger.Info(ctx, "platform auth bridge: refusing suspended user",
+			slog.F("email", email), slog.F("username", user.Username))
+		return false
+	}
+	if !platformUserBridgeable(user.RBACRoles) {
+		api.Logger.Info(ctx, "platform auth bridge: refusing non-member (admins use password login)",
+			slog.F("email", email), slog.F("username", user.Username), slog.F("roles", user.RBACRoles))
+		return false
+	}
+
+	//nolint:gocritic // See sysCtx rationale above.
+	sessionCookie, _, err := api.createAPIKey(sysCtx, apikey.CreateParams{
+		UserID:          user.ID,
+		LoginType:       database.LoginTypePassword,
+		DefaultLifetime: api.DeploymentValues.Sessions.DefaultDuration.Value(),
+		RemoteAddr:      r.RemoteAddr,
+	})
+	if err != nil {
+		api.Logger.Warn(ctx, "platform auth bridge: failed to mint session", slog.Error(err))
+		return false
+	}
+
+	api.Logger.Info(ctx, "platform auth bridge: minted session for member",
+		slog.F("email", email), slog.F("username", user.Username),
+		slog.F("workspace", wsName), slog.F("status", user.Status))
+
+	http.SetCookie(rw, sessionCookie)
+	// Authenticate the current request. The un-prefixed cookie name is resolved
+	// by APITokenFromRequest regardless of any __Host- prefix, which is only
+	// applied to the Set-Cookie response header.
+	r.AddCookie(&http.Cookie{Name: codersdk.SessionTokenCookie, Value: sessionCookie.Value})
+	return true
+}
+
+// platformLoginRedirect sends the browser to the configured platform login,
+// carrying the "next" query value as the post-login return target. The frontend
+// dashboard guard navigates here for non-admin users so the per-environment
+// platform URL stays in server config instead of the SPA bundle. When no
+// platform login is configured it falls back to the Coder access page.
+func (api *API) platformLoginRedirect(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	target := api.DeploymentValues.PlatformAuth.LoginRedirectURL.Value()
+	if target == "" {
+		// No platform login configured. Render a message rather than redirect to
+		// /access, which links back here and would create a click-loop.
+		api.Logger.Warn(ctx, "platform login redirect requested but CODER_PLATFORM_AUTH_LOGIN_REDIRECT_URL is not set")
+		rw.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		rw.WriteHeader(http.StatusNotFound)
+		_, _ = rw.Write([]byte("Platform login is not configured. Contact your administrator."))
+		return
+	}
+	target = strings.ReplaceAll(target, "{redirect}", url.QueryEscape(r.URL.Query().Get("next")))
+	api.Logger.Debug(ctx, "platform login redirect", slog.F("redirect_to", target))
+	http.Redirect(rw, r, target, http.StatusSeeOther)
+}
+
+// currentURL reconstructs the absolute URL of the incoming request so the
+// platform can redirect the user back after re-authentication.
+func currentURL(r *http.Request) string {
+	scheme := "https"
+	if r.TLS == nil {
+		scheme = "http"
+	}
+	if fp := r.Header.Get("X-Forwarded-Proto"); fp != "" {
+		scheme = fp
+	}
+	return scheme + "://" + r.Host + r.URL.RequestURI()
+}
+
+// platformUserBridgeable reports whether a user may be logged in via the
+// platform cookie. Only plain members qualify; any elevated or custom site
+// role must authenticate through the normal login flow.
+func platformUserBridgeable(roles []string) bool {
+	for _, role := range roles {
+		if role != codersdk.RoleMember {
+			return false
+		}
+	}
+	return true
+}

--- a/coderd/platformauthbridge_test.go
+++ b/coderd/platformauthbridge_test.go
@@ -1,0 +1,176 @@
+package coderd_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/serpent"
+)
+
+// setupBridge starts a Coder deployment with the platform-auth bridge configured
+// against a stub backend. The returned setEmail controls which email the stub
+// returns; an empty email makes the stub reject the cookie with 401.
+func setupBridge(t *testing.T, enable bool) (*codersdk.Client, func(string)) {
+	t.Helper()
+
+	var (
+		mu    sync.Mutex
+		email string
+	)
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		e := email
+		mu.Unlock()
+		if e == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]string{"email": e})
+	}))
+	t.Cleanup(stub.Close)
+
+	dv := coderdtest.DeploymentValues(t)
+	dv.PlatformAuth.Enable = serpent.Bool(enable)
+	dv.PlatformAuth.CookieName = "access_token"
+	dv.PlatformAuth.ValidateURLs = serpent.StringArray{stub.URL + "/{env}/validate"}
+	dv.PlatformAuth.Envs = serpent.StringArray{"dev"}
+	dv.PlatformAuth.RequestTimeout = serpent.Duration(testutil.WaitShort)
+
+	client := coderdtest.New(t, &coderdtest.Options{DeploymentValues: dv})
+	return client, func(e string) {
+		mu.Lock()
+		defer mu.Unlock()
+		email = e
+	}
+}
+
+// openApp performs an unauthenticated GET to a workspace app URL carrying only
+// the platform cookie, and reports whether a Coder session cookie was minted.
+func mintedSession(t *testing.T, client *codersdk.Client, username, workspace string) bool {
+	t.Helper()
+	ctx := testutil.Context(t, testutil.WaitLong)
+
+	reqURL := fmt.Sprintf("%s/@%s/%s.main/apps/code-server/", client.URL.String(), username, workspace)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	require.NoError(t, err)
+	req.AddCookie(&http.Cookie{Name: "access_token", Value: "platform-token"})
+
+	hc := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	resp, err := hc.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	for _, c := range resp.Cookies() {
+		if c.Name == codersdk.SessionTokenCookie && c.Value != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPlatformAuthBridge(t *testing.T) {
+	t.Parallel()
+
+	t.Run("MemberBridged", func(t *testing.T) {
+		t.Parallel()
+		client, setEmail := setupBridge(t, true)
+		owner := coderdtest.CreateFirstUser(t, client)
+		_, member := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+		setEmail(member.Email)
+
+		require.True(t, mintedSession(t, client, member.Username, "proj-dev"))
+	})
+
+	t.Run("AdminNotBridged", func(t *testing.T) {
+		t.Parallel()
+		client, setEmail := setupBridge(t, true)
+		coderdtest.CreateFirstUser(t, client)
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		ownerUser, err := client.User(ctx, codersdk.Me)
+		require.NoError(t, err)
+		setEmail(ownerUser.Email)
+
+		require.False(t, mintedSession(t, client, ownerUser.Username, "proj-dev"))
+	})
+
+	t.Run("Disabled", func(t *testing.T) {
+		t.Parallel()
+		client, setEmail := setupBridge(t, false)
+		owner := coderdtest.CreateFirstUser(t, client)
+		_, member := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+		setEmail(member.Email)
+
+		require.False(t, mintedSession(t, client, member.Username, "proj-dev"))
+	})
+
+	t.Run("SuspendedNotBridged", func(t *testing.T) {
+		t.Parallel()
+		client, setEmail := setupBridge(t, true)
+		owner := coderdtest.CreateFirstUser(t, client)
+		_, member := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+		setEmail(member.Email)
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		_, err := client.UpdateUserStatus(ctx, member.ID.String(), codersdk.UserStatusSuspended)
+		require.NoError(t, err)
+
+		require.False(t, mintedSession(t, client, member.Username, "proj-dev"))
+	})
+
+	t.Run("FallbackAcrossEndpoints", func(t *testing.T) {
+		t.Parallel()
+
+		// First endpoint always rejects; the second returns the member email.
+		reject := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		t.Cleanup(reject.Close)
+
+		var (
+			mu    sync.Mutex
+			email string
+		)
+		accept := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			e := email
+			mu.Unlock()
+			if e == "" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"email": e})
+		}))
+		t.Cleanup(accept.Close)
+
+		dv := coderdtest.DeploymentValues(t)
+		dv.PlatformAuth.Enable = serpent.Bool(true)
+		dv.PlatformAuth.CookieName = "access_token"
+		dv.PlatformAuth.ValidateURLs = serpent.StringArray{reject.URL + "/validate", accept.URL + "/validate"}
+		dv.PlatformAuth.Envs = serpent.StringArray{"dev"}
+		dv.PlatformAuth.RequestTimeout = serpent.Duration(testutil.WaitShort)
+
+		client := coderdtest.New(t, &coderdtest.Options{DeploymentValues: dv})
+		owner := coderdtest.CreateFirstUser(t, client)
+		_, member := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+		mu.Lock()
+		email = member.Email
+		mu.Unlock()
+
+		// The first endpoint rejects, so the bridge falls back to the second.
+		require.True(t, mintedSession(t, client, member.Username, "proj-dev"))
+	})
+}

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -661,6 +661,7 @@ type DeploymentValues struct {
 	DisablePathApps                         serpent.Bool                         `json:"disable_path_apps,omitempty" typescript:",notnull"`
 	Sessions                                SessionLifetime                      `json:"session_lifetime,omitempty" typescript:",notnull"`
 	DisablePasswordAuth                     serpent.Bool                         `json:"disable_password_auth,omitempty" typescript:",notnull"`
+	PlatformAuth                            PlatformAuthConfig                   `json:"platform_auth,omitempty" typescript:",notnull"`
 	Support                                 SupportConfig                        `json:"support,omitempty" typescript:",notnull"`
 	EnableAuthzRecording                    serpent.Bool                         `json:"enable_authz_recording,omitempty" typescript:",notnull"`
 	ExternalAuthConfigs                     serpent.Struct[[]ExternalAuthConfig] `json:"external_auth,omitempty" typescript:",notnull"`
@@ -979,6 +980,34 @@ type OIDCConfig struct {
 	// brokers that do not issue a stable `sub` for the same user across
 	// connections.
 	EmailFallback serpent.Bool `json:"email_fallback" typescript:",notnull"`
+}
+
+// PlatformAuthConfig configures the platform-cookie authentication bridge. When
+// enabled, a request to open a workspace app that carries the platform session
+// cookie is validated against an external backend, which returns the owning
+// user's email. Coder then mints a session for that user so they land directly
+// in the app without seeing the login page. Coder performs no token
+// verification itself; the backend is the sole authority.
+type PlatformAuthConfig struct {
+	Enable     serpent.Bool   `json:"enable" typescript:",notnull"`
+	CookieName serpent.String `json:"cookie_name" typescript:",notnull"`
+	// ValidateURLs is the ordered list of backend endpoints that validate the
+	// platform cookie. Each may contain a literal "{env}" placeholder, replaced
+	// with the environment derived from the workspace name suffix (e.g. "dev",
+	// "prod"). When a single Coder deployment serves multiple platform
+	// environments, list one endpoint per environment; Coder tries them in
+	// order and the first to accept the cookie wins.
+	ValidateURLs serpent.StringArray `json:"validate_urls" typescript:",notnull"`
+	// Envs is the set of allowed environment suffixes. A workspace name whose
+	// final "-" delimited segment is not in this set is not bridged.
+	Envs           serpent.StringArray `json:"envs" typescript:",notnull"`
+	RequestTimeout serpent.Duration    `json:"request_timeout" typescript:",notnull"`
+	// LoginRedirectURL, when set, is where an unauthenticated workspace-app
+	// request is redirected instead of the Coder login page, so users
+	// re-authenticate with the platform rather than seeing Coder's own login.
+	// A literal "{redirect}" placeholder is replaced with the URL-encoded
+	// original app URL so the platform can send the user back after login.
+	LoginRedirectURL serpent.String `json:"login_redirect_url" typescript:",notnull"`
 }
 
 type TelemetryConfig struct {
@@ -1522,6 +1551,10 @@ communicating directly.`,
 		deploymentGroupOIDC = serpent.Group{
 			Name: "OIDC",
 			YAML: "oidc",
+		}
+		deploymentGroupPlatformAuth = serpent.Group{
+			Name: "Platform Auth",
+			YAML: "platformAuth",
 		}
 		deploymentGroupTelemetry = serpent.Group{
 			Name: "Telemetry",
@@ -3710,6 +3743,65 @@ communicating directly.`,
 			Value: &c.DisablePasswordAuth,
 			Group: &deploymentGroupNetworkingHTTP,
 			YAML:  "disablePasswordAuth",
+		},
+		// Platform Auth settings.
+		{
+			Name:        "Platform Auth Enable",
+			Description: "Enable the platform-cookie authentication bridge. When enabled, opening a workspace app with a valid platform session cookie logs the user in via the external backend and skips the login page.",
+			Flag:        "platform-auth-enable",
+			Env:         "CODER_PLATFORM_AUTH_ENABLE",
+			Default:     "true",
+			Value:       &c.PlatformAuth.Enable,
+			Group:       &deploymentGroupPlatformAuth,
+			YAML:        "enable",
+		},
+		{
+			Name:        "Platform Auth Cookie Name",
+			Description: "Name of the platform session cookie that Coder reads and forwards to the backend for validation.",
+			Flag:        "platform-auth-cookie-name",
+			Env:         "CODER_PLATFORM_AUTH_COOKIE_NAME",
+			Default:     "access_token",
+			Value:       &c.PlatformAuth.CookieName,
+			Group:       &deploymentGroupPlatformAuth,
+			YAML:        "cookieName",
+		},
+		{
+			Name:        "Platform Auth Validate URLs",
+			Description: "Ordered list of backend endpoints that validate the platform cookie and return the owning user's email as JSON. Each may contain a literal \"{env}\" placeholder, replaced with the environment derived from the workspace name suffix. When one Coder deployment serves multiple platform environments, list one endpoint per environment; Coder tries them in order and the first to accept the cookie wins.",
+			Flag:        "platform-auth-validate-urls",
+			Env:         "CODER_PLATFORM_AUTH_VALIDATE_URLS",
+			Value:       &c.PlatformAuth.ValidateURLs,
+			Group:       &deploymentGroupPlatformAuth,
+			YAML:        "validateURLs",
+		},
+		{
+			Name:        "Platform Auth Environments",
+			Description: "Allowed environment suffixes. A workspace whose name does not end in one of these (after the final \"-\") is not bridged.",
+			Flag:        "platform-auth-envs",
+			Env:         "CODER_PLATFORM_AUTH_ENVS",
+			Default:     "dev,uat,prod",
+			Value:       &c.PlatformAuth.Envs,
+			Group:       &deploymentGroupPlatformAuth,
+			YAML:        "envs",
+		},
+		{
+			Name:        "Platform Auth Request Timeout",
+			Description: "Timeout for the backend validation request.",
+			Flag:        "platform-auth-request-timeout",
+			Env:         "CODER_PLATFORM_AUTH_REQUEST_TIMEOUT",
+			Default:     (5 * time.Second).String(),
+			Value:       &c.PlatformAuth.RequestTimeout,
+			Group:       &deploymentGroupPlatformAuth,
+			YAML:        "requestTimeout",
+		},
+		{
+			Name:        "Platform Auth Login Redirect URL",
+			Description: "Where to redirect an unauthenticated workspace-app request instead of the Coder login page, so the user re-authenticates with the platform. A literal \"{redirect}\" placeholder is replaced with the URL-encoded original app URL.",
+			Flag:        "platform-auth-login-redirect-url",
+			Env:         "CODER_PLATFORM_AUTH_LOGIN_REDIRECT_URL",
+			Value:       &c.PlatformAuth.LoginRedirectURL,
+			Group:       &deploymentGroupPlatformAuth,
+			YAML:        "loginRedirectURL",
 		},
 		{
 			Name:          "Config Path",

--- a/scripts/platform-auth-local-test.sh
+++ b/scripts/platform-auth-local-test.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# platform-auth-local-test.sh
+#
+# Spins up a local, patched Coder server wired to TWO dummy validation
+# endpoints (a fallback list) to test the platform-cookie auth bridge, and
+# optionally a real Docker workspace so you can open code-server directly by
+# presenting the platform cookie.
+#
+#   ./scripts/platform-auth-local-test.sh up     # build + start everything
+#   ./scripts/platform-auth-local-test.sh down    # stop everything
+#   ./scripts/platform-auth-local-test.sh curl    # re-run the headless bridge check
+#
+# Requirements: Go (to build), python3. Docker is OPTIONAL: without it the
+# script still proves the auth bridge via curl, but cannot build a real
+# workspace for you to open in a browser.
+set -euo pipefail
+
+# ------------------------------------------------------------------ config ---
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="${WORK:-${TMPDIR:-/tmp}/coder-platform-test}"
+CODER_BIN="${CODER_BIN:-$WORK/coder}"
+ACCESS_URL="${ACCESS_URL:-http://127.0.0.1:3000}"
+PORT_A=9998            # dummy endpoint A: always rejects (401)
+PORT_B=9999            # dummy endpoint B: accepts, returns member email
+ADMIN_EMAIL="admin@coder.com"
+ADMIN_PASS="SecurePass123!"
+MEMBER_EMAIL="member@example.com"
+MEMBER_USER="member"
+WS_NAME="${WS_NAME:-proj-dev}"          # NB: the "-dev" suffix drives env selection
+COOKIE_NAME="access_token"
+# Template used to build the member's workspace. Defaults to the Docker port of
+# the production AKS template (same coder_app "code-server", share = "owner").
+# Override TEMPLATE_DIR to test with a different template.
+TEMPLATE_DIR="${TEMPLATE_DIR:-$REPO/scripts/platform-auth-testdata/docker-workspace}"
+TEMPLATE_NAME="platform-test"
+# Where a member with no valid platform session is sent (instead of Coder's
+# login page). {redirect} is replaced with the original app URL.
+PLATFORM_LOGIN_URL="${PLATFORM_LOGIN_URL:-https://app.trumio.ai/login?next={redirect}}"
+PIDS="$WORK/pids"
+
+mkdir -p "$WORK"
+jqget() { python3 -c "import sys,json;print(json.load(sys.stdin).get('$1',''))"; }
+say() { printf '\n\033[1;36m==> %s\033[0m\n' "$*"; }
+
+# ------------------------------------------------------------------- down ---
+down() {
+  say "Stopping everything"
+  [ -f "$PIDS" ] && while read -r p; do kill "$p" 2>/dev/null || true; done < "$PIDS"
+  pkill -f "coder-platform-test/coder server" 2>/dev/null || true
+  pkill -f "platform_auth_dummy" 2>/dev/null || true
+  [ -d "$WORK/pgdata" ] && pg_ctl -D "$WORK/pgdata" stop >/dev/null 2>&1 || true
+  rm -f "$PIDS"
+  echo "stopped."
+}
+
+# --------------------------------------------------------------- dummies ---
+start_dummies() {
+  say "Starting two dummy validation endpoints (A rejects, B accepts)"
+  ACCEPT_EMAIL="$MEMBER_EMAIL" PORT_A="$PORT_A" PORT_B="$PORT_B" python3 - <<'PY' > "$WORK/dummy.log" 2>&1 &
+# platform_auth_dummy
+import http.server, json, threading, time, os
+email = os.environ["ACCEPT_EMAIL"]
+pa, pb = int(os.environ["PORT_A"]), int(os.environ["PORT_B"])
+def make(name, status, em=None):
+    class H(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            print(f"HIT endpoint={name} path={self.path} cookie={self.headers.get('Cookie','')}", flush=True)
+            if status == 200:
+                self.send_response(200); self.send_header("Content-Type","application/json"); self.end_headers()
+                # Mirror the real backend envelope exactly: {"status":"SUCCESS","data":{"email":...}}.
+                # Coder reads .data.email, so this is a faithful test of the parser.
+                self.wfile.write(json.dumps({"status": "SUCCESS", "data": {"email": em}}).encode())
+            else:
+                self.send_response(status); self.end_headers()
+        def log_message(self, *a): pass
+    return H
+threading.Thread(target=http.server.HTTPServer(("127.0.0.1", pa), make("A-reject", 401)).serve_forever, daemon=True).start()
+threading.Thread(target=http.server.HTTPServer(("127.0.0.1", pb), make("B-accept", 200, email)).serve_forever, daemon=True).start()
+print(f"dummies up: A(reject)=:{pa}  B(accept, {email})=:{pb}", flush=True)
+while True: time.sleep(3600)
+PY
+  echo $! >> "$PIDS"
+  sleep 1
+}
+
+# --------------------------------------------------------------- postgres ---
+# Prefer Coder's built-in Postgres. If that binary is the wrong arch (some
+# environments ship a stale cache), set CODER_PG_CONNECTION_URL to an external
+# Postgres and this block is skipped.
+start_postgres() {
+  if [ -n "${CODER_PG_CONNECTION_URL:-}" ]; then
+    say "Using external Postgres from CODER_PG_CONNECTION_URL"; return
+  fi
+  if command -v initdb >/dev/null 2>&1; then
+    say "Starting a native Postgres (127.0.0.1:5433)"
+    if [ ! -d "$WORK/pgdata" ]; then
+      initdb -U coder -A trust -D "$WORK/pgdata" --encoding=UTF8 >/dev/null
+    fi
+    pg_ctl -D "$WORK/pgdata" -o "-p 5433 -k /tmp -c listen_addresses=127.0.0.1" -l "$WORK/pg.log" start >/dev/null
+    sleep 2
+    createdb -h 127.0.0.1 -p 5433 -U coder coder 2>/dev/null || true
+    export CODER_PG_CONNECTION_URL="postgres://coder@127.0.0.1:5433/coder?sslmode=disable"
+  else
+    say "No native Postgres found; relying on Coder's built-in Postgres"
+  fi
+}
+
+# ------------------------------------------------------------------ server ---
+build_server() {
+  if [ "${BUILD_UI:-0}" = "1" ]; then
+    if [ ! -f "$REPO/site/out/index.html" ] || [ "${FORCE_SPA:-0}" = "1" ]; then
+      say "Building the web UI (pnpm --dir site build) -- slow first time"
+      ( cd "$REPO" && pnpm --dir site build )
+    else
+      echo "web UI already built ($REPO/site/out); set FORCE_SPA=1 to rebuild"
+    fi
+    # The workspace agent downloads itself from the server at
+    # /bin/coder-linux-<arch>. A plain build does not populate site/out/bin, so
+    # cross-compile the agent for the Docker daemon's architecture, otherwise
+    # the workspace hangs retrying the download and code-server never starts.
+    local darch
+    darch=$(docker version --format '{{.Server.Arch}}' 2>/dev/null || echo "")
+    darch="${darch:-arm64}"
+    if [ ! -f "$REPO/site/out/bin/coder-linux-$darch" ] || [ "${FORCE_AGENT:-0}" = "1" ]; then
+      say "Cross-compiling the workspace agent (linux/$darch) into site/out/bin"
+      ( cd "$REPO" && GOOS=linux GOARCH="$darch" go build -tags slim -o "site/out/bin/coder-linux-$darch" ./cmd/coder )
+    else
+      echo "agent binary already built (site/out/bin/coder-linux-$darch)"
+    fi
+    say "Building patched Coder WITH embedded UI (-tags embed) -> $CODER_BIN"
+    ( cd "$REPO" && go build -tags embed -o "$CODER_BIN" ./cmd/coder )
+  else
+    say "Building patched Coder binary (API only) -> $CODER_BIN"
+    ( cd "$REPO" && go build -o "$CODER_BIN" ./cmd/coder )
+  fi
+}
+
+start_server() {
+  say "Starting patched Coder server with the fallback endpoint list"
+  CODER_CONFIG_DIR="$WORK/coderv2" \
+  CODER_OAUTH2_GITHUB_DEFAULT_PROVIDER_ENABLE=false \
+  CODER_PLATFORM_AUTH_ENABLE=true \
+  CODER_PLATFORM_AUTH_COOKIE_NAME="$COOKIE_NAME" \
+  CODER_PLATFORM_AUTH_VALIDATE_URLS="http://127.0.0.1:$PORT_A/validate,http://127.0.0.1:$PORT_B/validate" \
+  CODER_PLATFORM_AUTH_ENVS="dev,uat,prod" \
+  CODER_PLATFORM_AUTH_LOGIN_REDIRECT_URL="$PLATFORM_LOGIN_URL" \
+    nohup "$CODER_BIN" server --access-url "$ACCESS_URL" --http-address 127.0.0.1:3000 \
+    > "$WORK/coder.log" 2>&1 &
+  echo $! >> "$PIDS"
+  for i in $(seq 1 90); do
+    [ "$(curl -s -o /dev/null -w '%{http_code}' "$ACCESS_URL/healthz" 2>/dev/null)" = "200" ] && { echo "server ready (${i}s)"; return; }
+    sleep 1
+  done
+  echo "server did not become ready; see $WORK/coder.log"; tail -20 "$WORK/coder.log"; exit 1
+}
+
+# --------------------------------------------------------------- provision ---
+seed_users() {
+  say "Creating admin + member (member@example.com)"
+  local first org
+  first=$(curl -s -X POST "$ACCESS_URL/api/v2/users/first" -H 'Content-Type: application/json' \
+    -d "{\"email\":\"$ADMIN_EMAIL\",\"username\":\"admin\",\"password\":\"$ADMIN_PASS\",\"name\":\"Admin\",\"trial\":false}")
+  org=$(echo "$first" | jqget organization_id)
+  ADMIN_TOKEN=$(curl -s -X POST "$ACCESS_URL/api/v2/users/login" -H 'Content-Type: application/json' \
+    -d "{\"email\":\"$ADMIN_EMAIL\",\"password\":\"$ADMIN_PASS\"}" | jqget session_token)
+  curl -s -X POST "$ACCESS_URL/api/v2/users" -H "Coder-Session-Token: $ADMIN_TOKEN" -H 'Content-Type: application/json' \
+    -d "{\"email\":\"$MEMBER_EMAIL\",\"username\":\"$MEMBER_USER\",\"login_type\":\"none\",\"organization_ids\":[\"$org\"]}" >/dev/null
+  # Mint a member session token (admin acting on the member) so we can create a
+  # member-OWNED workspace, mirroring how your platform provisions workspaces.
+  MEMBER_TOKEN=$(curl -s -X POST "$ACCESS_URL/api/v2/users/$MEMBER_USER/keys/tokens" \
+    -H "Coder-Session-Token: $ADMIN_TOKEN" -H 'Content-Type: application/json' -d '{}' | jqget key)
+  ORG_ID="$org"
+  echo "admin + member ready."
+}
+
+build_workspace() {
+  if ! docker info >/dev/null 2>&1; then
+    say "Docker is NOT running -> skipping real workspace build"
+    echo "The auth bridge is still fully testable via 'curl' below; you just"
+    echo "won't have a live code-server to open in a browser."
+    return 1
+  fi
+  say "Pushing template ($TEMPLATE_DIR) and creating a MEMBER-owned workspace via the admin API"
+  CODER_URL="$ACCESS_URL" CODER_SESSION_TOKEN="$ADMIN_TOKEN" \
+    "$CODER_BIN" templates push "$TEMPLATE_NAME" -d "$TEMPLATE_DIR" -y >/dev/null
+  local tid
+  tid=$(curl -s -H "Coder-Session-Token: $ADMIN_TOKEN" \
+    "$ACCESS_URL/api/v2/organizations/$ORG_ID/templates/$TEMPLATE_NAME" | jqget id)
+  # Admin creates the workspace ON BEHALF OF the member -- exactly how your
+  # platform provisions workspaces with an admin token.
+  curl -s -X POST "$ACCESS_URL/api/v2/users/$MEMBER_USER/workspaces" \
+    -H "Coder-Session-Token: $ADMIN_TOKEN" -H 'Content-Type: application/json' \
+    -d "{\"template_id\":\"$tid\",\"name\":\"$WS_NAME\"}" \
+    | python3 -c "import sys,json;d=json.load(sys.stdin);print('created workspace:',d.get('name'),'owner=',d.get('owner_name'))"
+  echo "waiting for the agent to connect..."
+  for i in $(seq 1 80); do
+    st=$(curl -s -H "Coder-Session-Token: $ADMIN_TOKEN" \
+      "$ACCESS_URL/api/v2/users/$MEMBER_USER/workspace/$WS_NAME" \
+      | python3 -c "import sys,json;print(json.load(sys.stdin).get('latest_build',{}).get('status',''))" 2>/dev/null)
+    [ "$st" = "running" ] && { echo "workspace running"; return 0; }
+    sleep 3
+  done
+  echo "workspace not running yet; check: CODER_SESSION_TOKEN=$MEMBER_TOKEN $CODER_BIN list"; return 0
+}
+
+rbac_check() {
+  say "Data-layer access: MEMBER is row-scoped, ADMIN sees everything"
+  code() { curl -s -o /dev/null -w "%{http_code}" -H "Coder-Session-Token: $2" "$ACCESS_URL$1"; }
+  cnt() { curl -s -H "Coder-Session-Token: $2" "$ACCESS_URL$1" | jqget count; }
+  echo "  MEMBER  /deployment/config -> $(code /api/v2/deployment/config "$MEMBER_TOKEN")   (403 = blocked)"
+  echo "  MEMBER  /users  (visible)  -> $(cnt /api/v2/users "$MEMBER_TOKEN")   (only self)"
+  echo "  MEMBER  /workspaces        -> $(cnt /api/v2/workspaces "$MEMBER_TOKEN")   (only own)"
+  echo "  ADMIN   /deployment/config -> $(code /api/v2/deployment/config "$ADMIN_TOKEN")   (200)"
+  echo "  ADMIN   /users  (visible)  -> $(cnt /api/v2/users "$ADMIN_TOKEN")   (all)"
+  echo "  ADMIN   /workspaces        -> $(cnt /api/v2/workspaces "$ADMIN_TOKEN")   (all)"
+}
+
+curl_check() {
+  say "Headless bridge check (fallback: endpoint A rejected, B accepted)"
+  : > "$WORK/dummy.log"; sleep 0.3
+  local hdrs
+  hdrs=$(curl -s -D - -o /dev/null --cookie "$COOKIE_NAME=platform-token-xyz" \
+    "$ACCESS_URL/@$MEMBER_USER/$WS_NAME.main/apps/code-server/")
+  echo "$hdrs" | grep -iE "^HTTP/|^set-cookie|^location" || true
+  echo "--- dummy endpoint hits (proves fallback order) ---"
+  grep -a HIT "$WORK/dummy.log" || echo "(no hits logged)"
+  local tok
+  tok=$(echo "$hdrs" | sed -n "s/.*coder_session_token=\([^;]*\).*/\1/p" | head -1)
+  if [ -n "$tok" ]; then
+    echo "--- minted session identity ---"
+    curl -s -H "Coder-Session-Token: $tok" "$ACCESS_URL/api/v2/users/me" \
+      | python3 -c "import sys,json;d=json.load(sys.stdin);print('  authenticated as:',d.get('username'),d.get('email'),'status=',d.get('status'))"
+    echo "  => bridge authenticated the request with NO login page."
+  else
+    echo "  => no session minted (unexpected)."
+  fi
+}
+
+print_browser_help() {
+  if [ "${BUILD_UI:-0}" != "1" ]; then
+    cat <<EOF
+
+This 'up' run serves the API only (no dashboard). The auth + RBAC checks above
+already prove the bridge. To eyeball the dashboard pages in a browser, run:
+    ./scripts/platform-auth-local-test.sh ui
+which serves the full web UI on $ACCESS_URL.
+EOF
+    return
+  fi
+  say "Browser checks -- open these in a real browser (dashboard is on $ACCESS_URL)"
+  cat <<EOF
+IMPORTANT (local testing only): a cookie is scoped to ONE host. "localhost" and
+"127.0.0.1" are DIFFERENT origins, so set the cookie and open the app URL on the
+SAME host. These steps use $ACCESS_URL throughout. (In prod this is a non-issue:
+your platform sets the cookie on the shared parent domain, e.g. .trumio.ai.)
+
+CHECK 1 - member opens the IDE directly via the cookie:
+  a. Open $ACCESS_URL/login  (Coder's login page loads without redirecting; you
+     cannot set the cookie on the app URL because it redirects you away first).
+  b. In the DevTools console ON THAT PAGE, set the cookie:
+       document.cookie = "$COOKIE_NAME=platform-token-xyz; path=/";
+  c. Navigate to:  $ACCESS_URL/@$MEMBER_USER/$WS_NAME.main/apps/code-server/
+     Expect: lands straight in code-server -- no login page, no GitHub.
+
+CHECK 2 - member cannot reach any Coder page:
+  Still holding the member cookie (no admin login), visit $ACCESS_URL/workspaces
+  (or /templates, /deployment, /settings). Expect: redirected to the PLATFORM
+  login ($PLATFORM_LOGIN_URL) via /platform-login. A non-admin never sees any
+  Coder dashboard page. (Locally the platform URL may 502; that just proves the
+  redirect fired. In prod it is your real platform login.)
+
+CHECK 3 - admin sees all pages + workspaces:
+  Open $ACCESS_URL with NO platform cookie, log in with the password form
+  ($ADMIN_EMAIL / $ADMIN_PASS; GitHub button is gone). Expect: full dashboard --
+  Workspaces (all), Templates, and the admin menu (Deployment, Users, etc.).
+
+CHECK 4 - member with NO/expired platform session goes to the PLATFORM login:
+  In incognito (no cookie set), open the app URL:
+    $ACCESS_URL/@$MEMBER_USER/$WS_NAME.main/apps/code-server/
+  Expect: redirected to $PLATFORM_LOGIN_URL (your platform's login), NOT Coder's
+  login page. The member re-authenticates on the platform and comes back.
+
+Logs:   server=$WORK/coder.log   dummies=$WORK/dummy.log
+Stop:   ./scripts/platform-auth-local-test.sh down
+EOF
+}
+
+# -------------------------------------------------------------------- main ---
+case "${1:-up}" in
+  up)
+    : > "$PIDS"
+    build_server
+    start_dummies
+    start_postgres
+    start_server
+    seed_users
+    build_workspace || true
+    curl_check
+    rbac_check
+    print_browser_help
+    ;;
+  ui)
+    # Full setup with the embedded dashboard on one port, for BROWSER testing.
+    # Bypasses ./scripts/develop.sh (which needs GNU tools + a working embedded
+    # Postgres). Uses a separate binary so it does not clobber the API-only one.
+    BUILD_UI=1
+    CODER_BIN="$WORK/coder-ui"
+    : > "$PIDS"
+    build_server
+    start_dummies
+    start_postgres
+    start_server
+    seed_users
+    build_workspace || true
+    curl_check
+    rbac_check
+    print_browser_help
+    ;;
+  curl)  curl_check ;;
+  down)  down ;;
+  *) echo "usage: $0 {up|ui|curl|down}   (up=headless, ui=with dashboard for browser)"; exit 1 ;;
+esac

--- a/scripts/platform-auth-testdata/docker-workspace/main.tf
+++ b/scripts/platform-auth-testdata/docker-workspace/main.tf
@@ -1,0 +1,136 @@
+# Docker port of the AKS/Kubernetes workspace template, for LOCAL testing of the
+# platform-cookie auth bridge. It preserves the pieces that matter for that
+# test and matches the production template's shape:
+#
+#   * a coder_agent "main" that installs and runs code-server on :13337
+#   * a coder_app "code-server" with share = "owner"  (path app, subdomain = false)
+#   * git user config sourced from the workspace owner
+#
+# Deliberately TRIMMED from the production template because it is AKS/backend
+# specific and would hang or fail on a laptop (and is irrelevant to the auth
+# test):
+#   * the kubernetes provider / Deployment / PVC   -> replaced with docker
+#   * the git credential helper that calls BACKEND_BASE_URL
+#   * the GitHub CLI wrapper and docker-in-docker (dockerd) install
+#   * the VS Code extension download (which also carried a hardcoded GitHub
+#     PAT in the production template -- that token should be revoked and moved
+#     to a secret regardless of this file)
+#   * repository cloning (needs the backend token; skipped locally)
+
+terraform {
+  required_providers {
+    coder  = { source = "coder/coder" }
+    docker = { source = "kreuzwerker/docker" }
+  }
+}
+
+variable "docker_socket" {
+  default     = ""
+  description = "(Optional) Docker socket URI"
+  type        = string
+}
+
+provider "docker" {
+  host = var.docker_socket != "" ? var.docker_socket : null
+}
+
+provider "coder" {}
+
+data "coder_provisioner" "me" {}
+data "coder_workspace" "me" {}
+data "coder_workspace_owner" "me" {}
+
+# Optional, mirrors the production template so the opened folder matches.
+data "coder_parameter" "github_repo" {
+  name         = "github_repo"
+  display_name = "GitHub Repository"
+  description  = "Folder to open in code-server (cloning is skipped in the local port)."
+  type         = "string"
+  mutable      = true
+  default      = ""
+}
+
+resource "coder_agent" "main" {
+  os   = "linux"
+  arch = data.coder_provisioner.me.arch
+
+  display_apps {
+    web_terminal = false
+    ssh_helper   = false
+  }
+
+  startup_script = <<-EOT
+    set -e
+
+    # Git identity from the workspace owner (same as the production template).
+    git config --global user.name  "${data.coder_workspace_owner.me.name}"
+    git config --global user.email "${data.coder_workspace_owner.me.email}"
+    git config --global init.defaultBranch main
+
+    # Install and launch code-server on :13337, matching the production template.
+    echo "=== Code-server ==="
+    curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server
+
+    /tmp/code-server/bin/code-server \
+      --auth none --host 127.0.0.1 --port 13337 \
+      >/tmp/code-server.log 2>&1 &
+  EOT
+
+  metadata {
+    display_name = "CPU Usage"
+    key          = "0_cpu_usage"
+    script       = "coder stat cpu"
+    interval     = 10
+    timeout      = 1
+  }
+  metadata {
+    display_name = "RAM Usage"
+    key          = "1_ram_usage"
+    script       = "coder stat mem"
+    interval     = 10
+    timeout      = 1
+  }
+}
+
+# code-server, owner-shared -- this is what the auth bridge must let the owning
+# member reach directly. Identical shape to the production template.
+resource "coder_app" "code-server" {
+  agent_id     = coder_agent.main.id
+  slug         = "code-server"
+  display_name = "code-server"
+  icon         = "/icon/code.svg"
+  url          = "http://localhost:13337?folder=${data.coder_parameter.github_repo.value != "" ? "/home/coder/${data.coder_parameter.github_repo.value}" : "/home/coder"}"
+  subdomain    = false
+  share        = "owner"
+
+  healthcheck {
+    url       = "http://localhost:13337/healthz"
+    interval  = 3
+    threshold = 10
+  }
+}
+
+resource "docker_volume" "home_volume" {
+  name = "coder-${data.coder_workspace.me.id}-home"
+  lifecycle {
+    ignore_changes = all
+  }
+}
+
+resource "docker_container" "workspace" {
+  count      = data.coder_workspace.me.start_count
+  image      = "codercom/enterprise-base:ubuntu"
+  name       = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}"
+  hostname   = data.coder_workspace.me.name
+  entrypoint = ["sh", "-c", replace(coder_agent.main.init_script, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal")]
+  env        = ["CODER_AGENT_TOKEN=${coder_agent.main.token}"]
+  host {
+    host = "host.docker.internal"
+    ip   = "host-gateway"
+  }
+  volumes {
+    container_path = "/home/coder"
+    volume_name    = docker_volume.home_volume.name
+    read_only      = false
+  }
+}

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -4360,6 +4360,7 @@ export interface DeploymentValues {
 	readonly disable_path_apps?: boolean;
 	readonly session_lifetime?: SessionLifetime;
 	readonly disable_password_auth?: boolean;
+	readonly platform_auth?: PlatformAuthConfig;
 	readonly support?: SupportConfig;
 	readonly enable_authz_recording?: boolean;
 	readonly external_auth?: SerpentStruct<ExternalAuthConfig[]>;
@@ -6575,6 +6576,43 @@ export interface Permission {
 	readonly negate: boolean;
 	readonly resource_type: RBACResource;
 	readonly action: RBACAction;
+}
+
+// From codersdk/deployment.go
+/**
+ * PlatformAuthConfig configures the platform-cookie authentication bridge. When
+ * enabled, a request to open a workspace app that carries the platform session
+ * cookie is validated against an external backend, which returns the owning
+ * user's email. Coder then mints a session for that user so they land directly
+ * in the app without seeing the login page. Coder performs no token
+ * verification itself; the backend is the sole authority.
+ */
+export interface PlatformAuthConfig {
+	readonly enable: boolean;
+	readonly cookie_name: string;
+	/**
+	 * ValidateURLs is the ordered list of backend endpoints that validate the
+	 * platform cookie. Each may contain a literal "{env}" placeholder, replaced
+	 * with the environment derived from the workspace name suffix (e.g. "dev",
+	 * "prod"). When a single Coder deployment serves multiple platform
+	 * environments, list one endpoint per environment; Coder tries them in
+	 * order and the first to accept the cookie wins.
+	 */
+	readonly validate_urls: string;
+	/**
+	 * Envs is the set of allowed environment suffixes. A workspace name whose
+	 * final "-" delimited segment is not in this set is not bridged.
+	 */
+	readonly envs: string;
+	readonly request_timeout: number;
+	/**
+	 * LoginRedirectURL, when set, is where an unauthenticated workspace-app
+	 * request is redirected instead of the Coder login page, so users
+	 * re-authenticate with the platform rather than seeing Coder's own login.
+	 * A literal "{redirect}" placeholder is replaced with the URL-encoded
+	 * original app URL so the platform can send the user back after login.
+	 */
+	readonly login_redirect_url: string;
 }
 
 // From codersdk/oauth2.go

--- a/site/src/modules/dashboard/DashboardLayout.tsx
+++ b/site/src/modules/dashboard/DashboardLayout.tsx
@@ -2,12 +2,13 @@ import Link from "@mui/material/Link";
 import Snackbar from "@mui/material/Snackbar";
 import { InfoIcon } from "lucide-react";
 import { type FC, type HTMLAttributes, Suspense } from "react";
-import { Outlet } from "react-router";
+import { Navigate, Outlet } from "react-router";
 import { Button } from "#/components/Button/Button";
 import { Loader } from "#/components/Loader/Loader";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
 import { AnnouncementBanners } from "#/modules/dashboard/AnnouncementBanners/AnnouncementBanners";
 import { LicenseBanner } from "#/modules/dashboard/LicenseBanner/LicenseBanner";
+import { canViewDashboard } from "#/modules/permissions";
 import { cn } from "#/utils/cn";
 import { docs } from "#/utils/docs";
 import { DeploymentBanner } from "./DeploymentBanner/DeploymentBanner";
@@ -18,6 +19,12 @@ export const DashboardLayout: FC = () => {
 	const { permissions } = useAuthenticated();
 	const updateCheck = useUpdateCheck(permissions.viewDeploymentConfig);
 	const canViewDeployment = Boolean(permissions.viewDeploymentConfig);
+
+	// The dashboard is admin-only. Non-admins (e.g. platform members) are sent
+	// to the standalone /access page, which links back to the platform.
+	if (!canViewDashboard(permissions)) {
+		return <Navigate to="/access" replace />;
+	}
 
 	return (
 		<>

--- a/site/src/modules/dashboard/Navbar/MobileMenu.stories.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { FC } from "react";
-import { fn, userEvent, within } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
 import {
 	MockPrimaryWorkspaceProxy,
 	MockProxyLatencies,
@@ -40,6 +40,7 @@ const meta: Meta<typeof MobileMenu> = {
 		supportLinks: MockSupportLinks,
 		onSignOut: fn(),
 		isDefaultOpen: true,
+		canViewDashboard: true,
 		canViewAuditLog: true,
 		canViewDeployment: true,
 		canViewHealth: true,
@@ -90,6 +91,26 @@ export const Member: Story = {
 		canViewDeployment: false,
 		canViewHealth: false,
 		canViewOrganizations: false,
+	},
+};
+
+export const NonAdmin: Story = {
+	args: {
+		user: MockUserMember,
+		canViewDashboard: false,
+		canViewAuditLog: false,
+		canViewDeployment: false,
+		canViewHealth: false,
+		canViewOrganizations: false,
+	},
+	play: async ({ canvasElement }) => {
+		const body = within(canvasElement.ownerDocument.body);
+		await expect(
+			body.queryByRole("menuitem", { name: /workspaces/i }),
+		).toBeNull();
+		await expect(
+			body.queryByRole("menuitem", { name: /templates/i }),
+		).toBeNull();
 	},
 };
 

--- a/site/src/modules/dashboard/Navbar/MobileMenu.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.tsx
@@ -47,6 +47,7 @@ type MobileMenuProps = MobileMenuPermissions & {
 	user?: TypesGen.User;
 	supportLinks?: readonly TypesGen.LinkConfig[];
 	onSignOut: () => void;
+	canViewDashboard: boolean;
 	isDefaultOpen?: boolean; // Useful for storybook
 };
 
@@ -56,6 +57,7 @@ export const MobileMenu: FC<MobileMenuProps> = ({
 	user,
 	supportLinks,
 	onSignOut,
+	canViewDashboard,
 	...permissions
 }) => {
 	const [open, setOpen] = useState(isDefaultOpen);
@@ -79,12 +81,16 @@ export const MobileMenu: FC<MobileMenuProps> = ({
 				className="w-screen border-0 border-b border-solid p-0 py-2"
 				sideOffset={17}
 			>
-				<DropdownMenuItem asChild className={itemStyles.default}>
-					<Link to="/workspaces">Workspaces</Link>
-				</DropdownMenuItem>
-				<DropdownMenuItem asChild className={itemStyles.default}>
-					<Link to="/templates">Templates</Link>
-				</DropdownMenuItem>
+				{canViewDashboard && (
+					<>
+						<DropdownMenuItem asChild className={itemStyles.default}>
+							<Link to="/workspaces">Workspaces</Link>
+						</DropdownMenuItem>
+						<DropdownMenuItem asChild className={itemStyles.default}>
+							<Link to="/templates">Templates</Link>
+						</DropdownMenuItem>
+					</>
+				)}
 				<DropdownMenuItem asChild className={itemStyles.default}>
 					<Link to="/agents">Agents</Link>
 				</DropdownMenuItem>

--- a/site/src/modules/dashboard/Navbar/Navbar.tsx
+++ b/site/src/modules/dashboard/Navbar/Navbar.tsx
@@ -6,7 +6,10 @@ import { useProxy } from "#/contexts/ProxyContext";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
 import { useEmbeddedMetadata } from "#/hooks/useEmbeddedMetadata";
 import { useDashboard } from "#/modules/dashboard/useDashboard";
-import { canViewDeploymentSettings } from "#/modules/permissions";
+import {
+	canViewDashboard,
+	canViewDeploymentSettings,
+} from "#/modules/permissions";
 import { useFeatureVisibility } from "../useFeatureVisibility";
 import { NavbarView } from "./NavbarView";
 
@@ -19,6 +22,7 @@ export const Navbar: FC = () => {
 	const proxyContextValue = useProxy();
 
 	const canViewDeployment = canViewDeploymentSettings(permissions);
+	const canViewDashboardLinks = canViewDashboard(permissions);
 	const canViewOrganizations = canViewOrganizationSettings;
 	const canViewHealth = permissions.viewDebugInfo;
 	const canViewAuditLog =
@@ -45,6 +49,7 @@ export const Navbar: FC = () => {
 			buildInfo={buildInfoQuery.data}
 			supportLinks={Array.from(uniqueLinks.values())}
 			onSignOut={signOut}
+			canViewDashboard={canViewDashboardLinks}
 			canViewDeployment={canViewDeployment}
 			canViewOrganizations={canViewOrganizations}
 			canViewHealth={canViewHealth}

--- a/site/src/modules/dashboard/Navbar/NavbarView.stories.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { userEvent, within } from "storybook/test";
+import { expect, userEvent, within } from "storybook/test";
 import type { TasksFilter } from "#/api/typesGenerated";
 import { chromaticWithTablet } from "#/testHelpers/chromatic";
 import {
@@ -30,6 +30,7 @@ const meta: Meta<typeof NavbarView> = {
 	component: NavbarView,
 	args: {
 		user: MockUserOwner,
+		canViewDashboard: true,
 		canViewAuditLog: true,
 		canViewDeployment: true,
 		canViewHealth: true,
@@ -112,6 +113,26 @@ export const ForMember: Story = {
 		canViewAISettings: false,
 		canViewOrganizations: false,
 		canCreateChat: false,
+	},
+};
+
+export const NonAdmin: Story = {
+	args: {
+		user: MockUserMember,
+		canViewDashboard: false,
+		canViewAuditLog: false,
+		canViewDeployment: false,
+		canViewHealth: false,
+		canViewAISettings: false,
+		canViewOrganizations: false,
+		canCreateChat: false,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.queryByRole("link", { name: /workspaces/i }),
+		).toBeNull();
+		await expect(canvas.queryByRole("link", { name: /templates/i })).toBeNull();
 	},
 };
 

--- a/site/src/modules/dashboard/Navbar/NavbarView.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.tsx
@@ -27,6 +27,7 @@ interface NavbarViewProps {
 	buildInfo?: TypesGen.BuildInfoResponse;
 	supportLinks: readonly TypesGen.LinkConfig[];
 	onSignOut: () => void;
+	canViewDashboard: boolean;
 	canViewDeployment: boolean;
 	canViewOrganizations: boolean;
 	canViewAuditLog: boolean;
@@ -49,6 +50,7 @@ export const NavbarView: FC<NavbarViewProps> = ({
 	buildInfo,
 	supportLinks,
 	onSignOut,
+	canViewDashboard,
 	canViewDeployment,
 	canViewOrganizations,
 	canViewHealth,
@@ -88,6 +90,7 @@ export const NavbarView: FC<NavbarViewProps> = ({
 			<NavItems
 				className="ml-4 hidden md:flex"
 				user={user}
+				canViewDashboard={canViewDashboard}
 				canCreateChat={canCreateChat}
 			/>
 
@@ -162,6 +165,7 @@ export const NavbarView: FC<NavbarViewProps> = ({
 						user={user}
 						supportLinks={supportLinks}
 						onSignOut={onSignOut}
+						canViewDashboard={canViewDashboard}
 						canViewAuditLog={canViewAuditLog}
 						canViewConnectionLog={canViewConnectionLog}
 						canViewOrganizations={canViewOrganizations}
@@ -177,33 +181,43 @@ export const NavbarView: FC<NavbarViewProps> = ({
 interface NavItemsProps {
 	className?: string;
 	user: TypesGen.User;
+	canViewDashboard: boolean;
 	canCreateChat: boolean;
 }
 
-const NavItems: FC<NavItemsProps> = ({ className, user, canCreateChat }) => {
+const NavItems: FC<NavItemsProps> = ({
+	className,
+	user,
+	canViewDashboard,
+	canCreateChat,
+}) => {
 	const location = useLocation();
 
 	return (
 		<nav className={cn("flex items-center gap-4 h-full", className)}>
-			<NavLink
-				className={({ isActive }) => {
-					if (location.pathname.startsWith("/@")) {
-						isActive = true;
-					}
-					return cn(linkStyles.default, { [linkStyles.active]: isActive });
-				}}
-				to="/workspaces"
-			>
-				Workspaces
-			</NavLink>
-			<NavLink
-				className={({ isActive }) => {
-					return cn(linkStyles.default, { [linkStyles.active]: isActive });
-				}}
-				to="/templates"
-			>
-				Templates
-			</NavLink>
+			{canViewDashboard && (
+				<>
+					<NavLink
+						className={({ isActive }) => {
+							if (location.pathname.startsWith("/@")) {
+								isActive = true;
+							}
+							return cn(linkStyles.default, { [linkStyles.active]: isActive });
+						}}
+						to="/workspaces"
+					>
+						Workspaces
+					</NavLink>
+					<NavLink
+						className={({ isActive }) => {
+							return cn(linkStyles.default, { [linkStyles.active]: isActive });
+						}}
+						to="/templates"
+					>
+						Templates
+					</NavLink>
+				</>
+			)}
 			<TasksNavItem user={user} />
 			<AgentsNavItem canCreateChat={canCreateChat} />
 		</nav>

--- a/site/src/modules/permissions/index.ts
+++ b/site/src/modules/permissions/index.ts
@@ -47,3 +47,33 @@ export const canViewAnyOrganization = (
 			permissions.editAnySettings)
 	);
 };
+
+/**
+ * Checks if the user has any administrative capability that grants access to
+ * the dashboard. Users without any of these capabilities are redirected away
+ * from dashboard pages.
+ *
+ * Note: this intentionally does NOT use canViewAnyOrganization, because that
+ * helper treats viewAnyMembers as sufficient, and ordinary organization
+ * members hold viewAnyMembers (they can see who else is in their org). The
+ * genuine org-admin capabilities (editAnySettings, assignAnyRoles,
+ * editAnyGroups, viewAnyIdpSyncSettings) are checked directly instead so that
+ * a plain member is correctly denied dashboard access.
+ */
+export const canViewDashboard = (permissions: Permissions): boolean => {
+	// Field accesses come before the canViewDeploymentSettings type-guard call:
+	// that guard narrows `permissions` to `never` for any operands after it in
+	// the || chain, which would break the trailing field accesses.
+	return (
+		permissions.viewAnyAuditLog ||
+		permissions.viewAnyConnectionLog ||
+		permissions.viewDebugInfo ||
+		permissions.createTemplates ||
+		permissions.updateTemplates ||
+		permissions.editAnySettings ||
+		permissions.assignAnyRoles ||
+		permissions.editAnyGroups ||
+		permissions.viewAnyIdpSyncSettings ||
+		canViewDeploymentSettings(permissions)
+	);
+};

--- a/site/src/pages/AccessPage/AccessPage.stories.tsx
+++ b/site/src/pages/AccessPage/AccessPage.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
+import { MockUserMember } from "#/testHelpers/entities";
+import { withAuthProvider } from "#/testHelpers/storybook";
+import AccessPage from "./AccessPage";
+
+const meta: Meta<typeof AccessPage> = {
+	title: "pages/AccessPage",
+	component: AccessPage,
+	decorators: [withAuthProvider],
+	parameters: {
+		user: MockUserMember,
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof AccessPage>;
+
+export const Default: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("heading", { name: /access restricted/i }),
+		).toBeInTheDocument();
+		await expect(
+			canvas.getByRole("button", { name: /return to platform/i }),
+		).toBeInTheDocument();
+		await expect(
+			canvas.queryByRole("button", { name: /sign out/i }),
+		).not.toBeInTheDocument();
+	},
+};

--- a/site/src/pages/AccessPage/AccessPage.tsx
+++ b/site/src/pages/AccessPage/AccessPage.tsx
@@ -1,0 +1,35 @@
+import type { FC } from "react";
+import { Button } from "#/components/Button/Button";
+import { ProductLogo } from "#/components/Icons/ProductLogo";
+import { getApplicationName } from "#/utils/appearance";
+
+const AccessPage: FC = () => {
+	const applicationName = getApplicationName();
+
+	// Full-page navigation to the server-side redirect, which knows the
+	// configured platform URL. Kept out of the SPA so it stays per-environment.
+	const goToPlatform = () => {
+		location.href = "/platform-login";
+	};
+
+	return (
+		<>
+			<title>{`Access restricted - ${applicationName}`}</title>
+			<div className="p-6 flex items-center justify-center min-h-full text-center">
+				<div className="w-full max-w-sm flex flex-col items-center gap-4">
+					<ProductLogo />
+					<h1 className="text-xl font-semibold m-0">Access restricted</h1>
+					<p className="text-sm text-content-secondary m-0">
+						Your account does not have access to the {applicationName}{" "}
+						dashboard. Open your workspace from the platform instead.
+					</p>
+					<Button size="lg" className="w-full" onClick={goToPlatform}>
+						Return to platform
+					</Button>
+				</div>
+			</div>
+		</>
+	);
+};
+
+export default AccessPage;

--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -14,6 +14,7 @@ import { Loader } from "./components/Loader/Loader";
 import { RequireAuth } from "./contexts/auth/RequireAuth";
 import { useAuthenticated } from "./hooks/useAuthenticated";
 import { DashboardLayout } from "./modules/dashboard/DashboardLayout";
+import AccessPage from "./pages/AccessPage/AccessPage";
 import AuditPage from "./pages/AuditPage/AuditPage";
 import ConnectionLogPage from "./pages/ConnectionLogPage/ConnectionLogPage";
 import { HealthLayout } from "./pages/HealthPage/HealthLayout";
@@ -571,6 +572,10 @@ export const router = createBrowserRouter(
 
 			{/* Dashboard routes */}
 			<Route element={<RequireAuth />}>
+				{/* Standalone page for non-admins denied the dashboard. Outside
+				    DashboardLayout so the admin guard there cannot redirect-loop. */}
+				<Route path="access" element={<AccessPage />} />
+
 				<Route element={<DashboardLayout />}>
 					<Route index element={<Navigate to="/workspaces" replace />} />
 


### PR DESCRIPTION
Authenticate workspace-app access from an external platform session cookie: when a request carries the configured cookie and has no Coder session, validate it against the platform backend (with per-environment fallback), map the returned email to a Coder user, and mint a session so members open their IDE directly. Admins are never bridged and continue to use password login.

Restrict the dashboard to admins: non-admin users are redirected to a standalone access page that links back to the platform. Unauthenticated workspace-app requests without a valid cookie are sent to the platform login instead of Coder's login page.

Add CODER_PLATFORM_AUTH_* options for enablement, cookie name, validation URLs, environments, request timeout, and the platform login redirect.

<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->
