### PR TITLE
fix: use fake timers in edit workspace test

### DIFF
--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.test.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.test.tsx
@@ -8,9 +8,6 @@ import {
 	MockPreviewParameter2,
 	MockPreviewParameter4,
 	MockPreviewParameter7,
-	MockTemplateVersionParameter1,
-	MockTemplateVersionParameter4,
-	MockTemplateVersionParameter7,
 	MockWorkspace,
 	MockWorkspaceBuildParameter1,
 	MockWorkspaceBuildParameter4,
@@ -50,11 +47,6 @@ describe("WorkspaceParametersPage", () => {
 		vi.spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValueOnce(
 			MockWorkspace,
 		);
-		vi.spyOn(API, "getTemplateVersionRichParameters").mockResolvedValueOnce([
-			MockTemplateVersionParameter1, // a mutable string
-			MockTemplateVersionParameter4, // an immutable string
-			MockTemplateVersionParameter7, // optional string
-		]);
 		vi.spyOn(API, "postWorkspaceBuild").mockRejectedValueOnce(
 			new Error("not implemented"),
 		);
@@ -328,6 +320,12 @@ describe("WorkspaceParametersPage", () => {
 			MockPreviewParameter4,
 			MockPreviewParameter7,
 		);
+
+		// Make the debounce fire after each macrotask, to avoid the waitFor() calls
+		// timing out.  As the edits come in and are (sometimes slowly) processed on
+		// top of the 500ms debounce, this can trip waitFor()'s 1000ms timeout.
+		vi.useFakeTimers();
+		vi.setTimerTickMode("nextTimerAsync");
 
 		// Blank out one field and fill out another.
 		const editedParameters = [

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -1903,20 +1903,19 @@ export const MockTemplateVersionParameter3: TypesGen.TemplateVersionParameter =
 		ephemeral: false,
 	};
 
-export const MockTemplateVersionParameter4: TypesGen.TemplateVersionParameter =
-	{
-		name: "fourth_parameter",
-		type: "string",
-		form_type: "input",
-		description: "This is fourth parameter",
-		description_plaintext: "Markdown: This is fourth parameter",
-		default_value: "def",
-		mutable: false,
-		icon: "/icon/database.svg",
-		options: [],
-		required: true,
-		ephemeral: false,
-	};
+const MockTemplateVersionParameter4: TypesGen.TemplateVersionParameter = {
+	name: "fourth_parameter",
+	type: "string",
+	form_type: "input",
+	description: "This is fourth parameter",
+	description_plaintext: "Markdown: This is fourth parameter",
+	default_value: "def",
+	mutable: false,
+	icon: "/icon/database.svg",
+	options: [],
+	required: true,
+	ephemeral: false,
+};
 
 const MockTemplateVersionParameter5: TypesGen.TemplateVersionParameter = {
 	name: "fifth_parameter",
@@ -1951,23 +1950,22 @@ export const MockTemplateVersionParameter6: TypesGen.TemplateVersionParameter =
 	};
 
 // Not required and the default is a blank string.
-export const MockTemplateVersionParameter7: TypesGen.TemplateVersionParameter =
-	{
-		name: "seventh_parameter",
-		type: "string",
-		form_type: "input",
-		description: "This is seventh parameter",
-		description_plaintext: "Markdown: This is seventh parameter",
-		default_value: "",
-		mutable: true,
-		icon: "/icon/folder.svg",
-		options: [],
-		validation_min: 1,
-		validation_max: 10,
-		validation_monotonic: "decreasing",
-		required: false,
-		ephemeral: false,
-	};
+const MockTemplateVersionParameter7: TypesGen.TemplateVersionParameter = {
+	name: "seventh_parameter",
+	type: "string",
+	form_type: "input",
+	description: "This is seventh parameter",
+	description_plaintext: "Markdown: This is seventh parameter",
+	default_value: "",
+	mutable: true,
+	icon: "/icon/folder.svg",
+	options: [],
+	validation_min: 1,
+	validation_max: 10,
+	validation_monotonic: "decreasing",
+	required: false,
+	ephemeral: false,
+};
 
 export const MockTemplateVersionVariable1: TypesGen.TemplateVersionVariable = {
 	name: "first_variable",


### PR DESCRIPTION
This was a bit confusing, but turns out after the fields are edited and we enter the `waitFor()` loop, the `onChange` handlers are still firing (whether this is the browser being slow or React or both, idk).  This delay plus the 500ms debounce time can push it over the 1s default timeout for `waitFor()`.  Using fake timers removes the 500ms delay so I think this should stop flaking, but depending on how slow those edits are, we might have to revisit and increase the `waitFor()` timeout as well.

One potential worry is that if the debounce is firing more quickly, we could get multiple messages from the client.  The test currently assumes one message.  I ran it thousands of times with no issues though so I am leaving it for now (I guess all the change events must be happening within the same macrotask queue).  We can come back and make it check > 0  instead of 1 (and use the last item instead of [0]) if the length check flakes.

Also remove the mocked rich parameters call; it is not used.

Closes https://linear.app/codercom/issue/DEVEX-537/flake-workspaceparameterspageexperimental-does-not-clobber-edited
