### PR TITLE
fix(site): pass all properties of a multi-select dynamic parameter option to MultiSelectCombobox defaultOptions

### DIFF
--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
@@ -373,17 +373,14 @@ const ParameterField: FC<ParameterFieldProps> = ({
 				disable: false,
 			}));
 
-			const optionMap = new Map(
-				parameter.options.map((opt) => [opt.value.value, opt.name]),
+			const selectedOptions: Option[] = parsedValues.values.map(
+				(val) =>
+					options.find((o) => o.value === val) ?? {
+						value: val,
+						label: val,
+						disable: false,
+					},
 			);
-
-			const selectedOptions: Option[] = parsedValues.values.map((val) => {
-				return {
-					value: val,
-					label: optionMap.get(val) || val,
-					disable: false,
-				};
-			});
 
 			return (
 				<MultiSelectCombobox


### PR DESCRIPTION
fixes DEVEX-463

Previously, a dynamic parameter of `form_type = "multi-select"` with default options selected would only pass in these 3 properties for each option fed into `MultiSelectCombobox`'s `defaultOptions`:

- `value`
- `label`
- `disable` 

`defaultOptions` are used as the initial value of `MultiSelectCombobox`'s `selected` array of `Option`s. If the `icon` property is missing from a selected option, then no icon is shown:

https://github.com/coder/coder/blob/e59a67d63fd522d1e95b42e57d4fbfe7d2bc5fef/site/src/components/MultiSelectCombobox/MultiSelectCombobox.tsx#L501-L502

Now `icon` and `description` are included among those properties passed to default selected options, when a default option's value can be found among the parameter's available options in the Terraform template. This fixes the bug where icons wouldn't display for default selected options.

If no corresponding option is found, then we fall back to the old partial option object (`{ value, label, disable }`).

<img width="1840" height="1191" alt="Screenshot 2026-07-09 at 10 08 54 PM" src="https://github.com/user-attachments/assets/91be4aaf-9016-46d6-871b-344c8f2504cb" />