### PR TITLE
feat(offlinedocs): prefer front-matter title, fall back to manifest

### DIFF
--- a/offlinedocs/pages/[[...slug]].tsx
+++ b/offlinedocs/pages/[[...slug]].tsx
@@ -216,17 +216,29 @@ export const getStaticProps: GetStaticProps = (context) => {
 	const routes = mapRoutes(manifest);
 	const urlPath = slug.join("/");
 	const route = routes[urlPath];
-	const { body } = fm(readContentFile(route.path));
+	const { attributes, body } = fm<{ title?: string }>(
+		readContentFile(route.path),
+	);
 	// Serialize MDX to support custom components
 	const content = sanitizeHtml(body);
 	const navigation = getNavigation(manifest);
 	const version = manifest.versions[0];
+
+	// Prefer a front-matter title, falling back to the manifest nav
+	// label. Keeps the offline docs renderer in step with the hosted
+	// docs renderer (front matter -> manifest title) as pages migrate to
+	// front-matter titles, so exactly one H1 is shown.
+	const title =
+		typeof attributes.title === "string" && attributes.title.trim() !== ""
+			? attributes.title
+			: route.title;
 
 	return {
 		props: {
 			content,
 			navigation,
 			route,
+			title,
 			version,
 		},
 	};
@@ -369,12 +381,13 @@ const DocsPage: NextPage<{
 	content: string;
 	navigation: Nav;
 	route: Route;
+	title: string;
 	version: string;
-}> = ({ content, navigation, route, version }) => {
+}> = ({ content, navigation, route, title, version }) => {
 	return (
 		<>
 			<Head>
-				<title>{route.title}</title>
+				<title>{title}</title>
 				<meta name="source" content={route.path} />
 			</Head>
 			<Box
@@ -411,7 +424,7 @@ const DocsPage: NextPage<{
 								// Hide this title if the doc has the title already
 								sx={{ "& + h1": { display: "none" } }}
 							>
-								{route.title}
+								{title}
 							</Heading>
 
 							<ReactMarkdown


### PR DESCRIPTION
## Summary

Part of the docs front-matter title migration (Linear DOCS-482).

`offlinedocs` now prefers a front-matter `title` for a page and falls back to the
manifest nav label when the page has no front matter. This keeps the offline docs
renderer aligned with the hosted docs renderer as docs pages migrate to front-matter
titles.

No `docs/**` page has front matter today, so every page renders exactly as before.
The existing `& + h1` dedup is kept, so exactly one H1 renders.

## Changes

- `offlinedocs/pages/[[...slug]].tsx`
  - `getStaticProps` reads `attributes` from `front-matter` and passes a resolved
    `title` (front matter, else manifest label) through props.
  - The `<title>` and the injected page `<Heading>` render the resolved title.

## Verification

Built offlinedocs (`pnpm build`): 455/455 static pages generated. Temporarily added a
front-matter title to one page to confirm precedence, then reverted:

| State | `<title>` | page `<h1>` |
|---|---|---|
| Before (no front matter) | `Administration` | `Administration` |
| After (`title: "FM Proof: Administration Console"`) | `FM Proof: Administration Console` | `FM Proof: Administration Console` |

The body `# Administration` stayed hidden by the `& + h1` dedup, so exactly one H1
rendered in both cases. `pnpm lint` (`tsc --noEmit`) and `prettier --check` both pass.

## AI disclosure

This PR was generated by Coder Agents and opened on behalf of @nickvigilante, who is
accountable for its contents. Manual verification evidence is included above per the
[AI contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING).
