### PR TITLE
feat: unify Coder Agents model pickers

### DIFF
--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -5562,8 +5562,8 @@ func (api *API) getChatAdvisorConfig(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var resp codersdk.AdvisorConfig
-	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+	resp, err := chatd.DecodeAdvisorConfig([]byte(raw))
+	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Stored advisor configuration is invalid.",
 			Detail:  err.Error(),
@@ -5601,16 +5601,19 @@ func (api *API) putChatAdvisorConfig(rw http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	if req.ModelConfigID != uuid.Nil {
-		// Use system context because GetChatModelConfigByID requires
-		// deployment-config read access, which can be broader than the
-		// handler's explicit update check. The lookup only validates that
-		// the referenced model exists before persisting deployment config.
-		//nolint:gocritic // This admin-authorized validation lookup intentionally bypasses read authz.
-		if _, err := api.Database.GetChatModelConfigByID(dbauthz.AsSystemRestricted(ctx), req.ModelConfigID); err != nil {
+	if req.ModelConfigID == uuid.Nil {
+		if req.ReasoningEffort != nil {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "reasoning_effort requires model_config_id.",
+			})
+			return
+		}
+	} else {
+		modelConfig, err := lookupEnabledChatModelConfigByID(ctx, api.Database, req.ModelConfigID)
+		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) || httpapi.Is404Error(err) {
 				httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-					Message: fmt.Sprintf("model_config_id %q does not match any existing model config.", req.ModelConfigID),
+					Message: fmt.Sprintf("model_config_id %q does not match any enabled model config.", req.ModelConfigID),
 				})
 				return
 			}
@@ -5620,9 +5623,13 @@ func (api *API) putChatAdvisorConfig(rw http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
+		if status, resp := validateChatModelOverrideEffort(modelConfig, req.ReasoningEffort); resp != nil {
+			httpapi.Write(ctx, rw, status, resp)
+			return
+		}
 	}
 
-	raw, err := json.Marshal(req)
+	raw, err := chatd.EncodeAdvisorConfig(req)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error encoding advisor configuration.",

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -5613,11 +5613,20 @@ func (api *API) putChatAdvisorConfig(rw http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else {
-		modelConfig, err := lookupEnabledChatModelConfigByID(ctx, api.Database, req.ModelConfigID)
+		// Use system context because GetChatModelConfigByID requires
+		// deployment-config read access, which can be broader than the
+		// handler's explicit update check. Disabled models remain valid
+		// stored overrides so admins can update unrelated advisor limits;
+		// the runtime falls back when the model is unavailable.
+		//nolint:gocritic // This admin-authorized validation lookup intentionally bypasses read authz.
+		modelConfig, err := api.Database.GetChatModelConfigByID(
+			dbauthz.AsSystemRestricted(ctx),
+			req.ModelConfigID,
+		)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) || httpapi.Is404Error(err) {
 				httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-					Message: fmt.Sprintf("model_config_id %q does not match any enabled model config.", req.ModelConfigID),
+					Message: fmt.Sprintf("model_config_id %q does not match any existing model config.", req.ModelConfigID),
 				})
 				return
 			}

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -807,6 +807,10 @@ func chatPersonalModelOverrideResponse(
 	isSet bool,
 ) codersdk.ChatPersonalModelOverride {
 	parsed := parseChatPersonalModelOverrideValue(raw, overrideContext)
+	if overrideContext == codersdk.ChatPersonalModelOverrideContextRoot &&
+		strings.TrimSpace(raw) == string(codersdk.ChatPersonalModelOverrideModeDeploymentDefault) {
+		parsed.Mode = codersdk.ChatPersonalModelOverrideModeDeploymentDefault
+	}
 	modelConfigID := ""
 	var reasoningEffort *string
 	if parsed.Mode == codersdk.ChatPersonalModelOverrideModeModel {

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -13054,7 +13054,7 @@ func TestUserChatPersonalModelOverrides(t *testing.T) {
 
 		resp, err := memberClient.GetUserChatPersonalModelOverrides(ctx)
 		require.NoError(t, err)
-		assertOverride(resp, codersdk.ChatPersonalModelOverrideContextRoot, codersdk.ChatPersonalModelOverrideModeChatDefault, "", true, true)
+		assertOverride(resp, codersdk.ChatPersonalModelOverrideContextRoot, codersdk.ChatPersonalModelOverrideModeDeploymentDefault, "", true, true)
 	})
 }
 
@@ -13165,6 +13165,12 @@ func TestCreateChatPersonalModelOverrideRoot(t *testing.T) {
 	t.Run("MalformedRootFallsBackToDefault", func(t *testing.T) {
 		upsertRootRaw(firstUser.UserID, "garbage")
 		chat := createChat(adminClient, "malformed root falls back", nil)
+		require.Equal(t, defaultModel.ID, chat.LastModelConfigID)
+	})
+
+	t.Run("RootDeploymentDefaultFallsBackToDefault", func(t *testing.T) {
+		upsertRootRaw(firstUser.UserID, string(codersdk.ChatPersonalModelOverrideModeDeploymentDefault))
+		chat := createChat(adminClient, "root deployment default falls back", nil)
 		require.Equal(t, defaultModel.ID, chat.LastModelConfigID)
 	})
 

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -14041,24 +14041,42 @@ func TestChatAdvisorConfig_RejectsUnsupportedReasoningEffort(t *testing.T) {
 	require.Contains(t, sdkErr.Detail, "none, minimal, low, medium")
 }
 
-func TestChatAdvisorConfig_RejectsDisabledModel(t *testing.T) {
+func TestChatAdvisorConfig_AllowsUpdatingLimitsWithDisabledModel(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitLong)
 	adminClient := newChatClient(t)
 	coderdtest.CreateFirstUser(t, adminClient.Client)
-	modelConfig := createDisabledChatModelConfig(
+	modelConfig := createAdditionalChatModelConfigWithReasoningEffort(
 		t,
 		adminClient,
 		coderdtest.TestChatProviderOpenAICompat,
 		"advisor-disabled",
+		codersdk.ChatModelReasoningEffortMedium,
+		codersdk.ChatModelReasoningEffortHigh,
 	)
+	want := codersdk.AdvisorConfig{
+		Enabled:         true,
+		MaxUsesPerRun:   3,
+		MaxOutputTokens: 2048,
+		ModelConfigID:   modelConfig.ID,
+		ReasoningEffort: ptr.Ref(codersdk.ChatModelReasoningEffortHigh),
+	}
+	err := adminClient.UpdateChatAdvisorConfig(ctx, want)
+	require.NoError(t, err)
 
-	err := adminClient.UpdateChatAdvisorConfig(ctx, codersdk.UpdateAdvisorConfigRequest{
-		ModelConfigID: modelConfig.ID,
+	_, err = adminClient.UpdateChatModelConfig(ctx, modelConfig.ID, codersdk.UpdateChatModelConfigRequest{
+		Enabled: ptr.Ref(false),
 	})
-	sdkErr := requireSDKError(t, err, http.StatusBadRequest)
-	require.Contains(t, sdkErr.Message, "enabled model config")
+	require.NoError(t, err)
+
+	want.MaxUsesPerRun = 5
+	err = adminClient.UpdateChatAdvisorConfig(ctx, want)
+	require.NoError(t, err)
+
+	resp, err := adminClient.GetChatAdvisorConfig(ctx)
+	require.NoError(t, err)
+	require.Equal(t, want, resp)
 }
 
 func TestChatAdvisorConfig_InvalidModelConfigID(t *testing.T) {
@@ -14074,7 +14092,7 @@ func TestChatAdvisorConfig_InvalidModelConfigID(t *testing.T) {
 	})
 	sdkErr := requireSDKError(t, err, http.StatusBadRequest)
 	require.Contains(t, sdkErr.Message, unknownID.String())
-	require.Contains(t, sdkErr.Message, "does not match any enabled model config")
+	require.Contains(t, sdkErr.Message, "does not match any existing model config")
 }
 
 func TestChatAdvisorConfig_RoundTripZeroValues(t *testing.T) {

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -13967,6 +13967,94 @@ func TestChatAdvisorConfig_RoundTripModelConfigID(t *testing.T) {
 	require.Equal(t, want, resp)
 }
 
+func TestChatAdvisorConfig_RoundTripReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	adminClient := newChatClient(t)
+	coderdtest.CreateFirstUser(t, adminClient.Client)
+	modelConfig := createAdditionalChatModelConfigWithReasoningEffort(
+		t,
+		adminClient,
+		coderdtest.TestChatProviderOpenAICompat,
+		"advisor-reasoning",
+		codersdk.ChatModelReasoningEffortMedium,
+		codersdk.ChatModelReasoningEffortHigh,
+	)
+	want := codersdk.AdvisorConfig{
+		Enabled:         true,
+		MaxUsesPerRun:   3,
+		MaxOutputTokens: 2048,
+		ModelConfigID:   modelConfig.ID,
+		ReasoningEffort: ptr.Ref(codersdk.ChatModelReasoningEffortHigh),
+	}
+
+	err := adminClient.UpdateChatAdvisorConfig(ctx, want)
+	require.NoError(t, err)
+
+	resp, err := adminClient.GetChatAdvisorConfig(ctx)
+	require.NoError(t, err)
+	require.Equal(t, want, resp)
+}
+
+func TestChatAdvisorConfig_ReasoningEffortRequiresModel(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	adminClient := newChatClient(t)
+	coderdtest.CreateFirstUser(t, adminClient.Client)
+
+	err := adminClient.UpdateChatAdvisorConfig(ctx, codersdk.UpdateAdvisorConfigRequest{
+		ReasoningEffort: ptr.Ref(codersdk.ChatModelReasoningEffortHigh),
+	})
+	sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+	require.Contains(t, sdkErr.Message, "reasoning_effort requires model_config_id")
+}
+
+func TestChatAdvisorConfig_RejectsUnsupportedReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	adminClient := newChatClient(t)
+	coderdtest.CreateFirstUser(t, adminClient.Client)
+	modelConfig := createAdditionalChatModelConfigWithReasoningEffort(
+		t,
+		adminClient,
+		coderdtest.TestChatProviderOpenAICompat,
+		"advisor-limited-reasoning",
+		codersdk.ChatModelReasoningEffortLow,
+		codersdk.ChatModelReasoningEffortMedium,
+	)
+
+	err := adminClient.UpdateChatAdvisorConfig(ctx, codersdk.UpdateAdvisorConfigRequest{
+		ModelConfigID:   modelConfig.ID,
+		ReasoningEffort: ptr.Ref(codersdk.ChatModelReasoningEffortHigh),
+	})
+	sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+	require.Contains(t, sdkErr.Message, "Invalid reasoning_effort value")
+	require.Contains(t, sdkErr.Detail, "none, minimal, low, medium")
+}
+
+func TestChatAdvisorConfig_RejectsDisabledModel(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	adminClient := newChatClient(t)
+	coderdtest.CreateFirstUser(t, adminClient.Client)
+	modelConfig := createDisabledChatModelConfig(
+		t,
+		adminClient,
+		coderdtest.TestChatProviderOpenAICompat,
+		"advisor-disabled",
+	)
+
+	err := adminClient.UpdateChatAdvisorConfig(ctx, codersdk.UpdateAdvisorConfigRequest{
+		ModelConfigID: modelConfig.ID,
+	})
+	sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+	require.Contains(t, sdkErr.Message, "enabled model config")
+}
+
 func TestChatAdvisorConfig_InvalidModelConfigID(t *testing.T) {
 	t.Parallel()
 
@@ -13980,7 +14068,7 @@ func TestChatAdvisorConfig_InvalidModelConfigID(t *testing.T) {
 	})
 	sdkErr := requireSDKError(t, err, http.StatusBadRequest)
 	require.Contains(t, sdkErr.Message, unknownID.String())
-	require.Contains(t, sdkErr.Message, "does not match any existing model config")
+	require.Contains(t, sdkErr.Message, "does not match any enabled model config")
 }
 
 func TestChatAdvisorConfig_RoundTripZeroValues(t *testing.T) {
@@ -14015,13 +14103,21 @@ func TestChatAdvisorConfig_OverwriteClearsPreviousValues(t *testing.T) {
 	adminClient := newChatClient(t)
 	coderdtest.CreateFirstUser(t, adminClient.Client)
 
-	modelConfig := createChatModelConfig(t, adminClient)
+	modelConfig := createAdditionalChatModelConfigWithReasoningEffort(
+		t,
+		adminClient,
+		coderdtest.TestChatProviderOpenAICompat,
+		"advisor-overwrite",
+		codersdk.ChatModelReasoningEffortMedium,
+		codersdk.ChatModelReasoningEffortHigh,
+	)
 
 	rich := codersdk.AdvisorConfig{
 		Enabled:         true,
 		MaxUsesPerRun:   5,
 		MaxOutputTokens: 1024,
 		ModelConfigID:   modelConfig.ID,
+		ReasoningEffort: ptr.Ref(codersdk.ChatModelReasoningEffortHigh),
 	}
 	err := adminClient.UpdateChatAdvisorConfig(ctx, rich)
 	require.NoError(t, err)

--- a/coderd/x/chatd/ARCHITECTURE.md
+++ b/coderd/x/chatd/ARCHITECTURE.md
@@ -717,6 +717,12 @@ State updates processed by the loop come from:
 
 The runner is responsible for subscribing to the `chat:update:{chat_id}` pubsub channel. During bootstrap, it must first subscribe to the channel and then fetch the initial state of the chat from the database to avoid missing any updates.
 
+### Advisor model and reasoning effort resolution
+
+When the advisor is enabled for a root chat turn, generation preparation loads the deployment-wide advisor configuration. An explicit advisor model is resolved from the enabled model and provider configuration at the start of the turn. If the configured model or provider is unavailable, malformed, or cannot be resolved, the advisor uses the outer chat model instead.
+
+A configured advisor `reasoning_effort` applies only when the explicit advisor model resolves successfully. The selected effort is validated against that model's configured selectable values when the advisor configuration is saved. When the advisor uses the outer chat model, including any fallback caused by an unavailable explicit model, the advisor effort is ignored and the outer model's configured default effort applies.
+
 ### Event shape
 
 Every event that the runner loop processes has the following shape:

--- a/coderd/x/chatd/advisor_config.go
+++ b/coderd/x/chatd/advisor_config.go
@@ -1,0 +1,34 @@
+package chatd
+
+import (
+	"encoding/json"
+
+	"github.com/coder/coder/v2/codersdk"
+)
+
+const advisorConfigStorageVersion = 1
+
+type storedAdvisorConfig struct {
+	codersdk.AdvisorConfig
+	Version int `json:"_version,omitempty"`
+}
+
+// EncodeAdvisorConfig encodes advisor configuration for site-config storage.
+func EncodeAdvisorConfig(config codersdk.AdvisorConfig) ([]byte, error) {
+	return json.Marshal(storedAdvisorConfig{
+		AdvisorConfig: config,
+		Version:       advisorConfigStorageVersion,
+	})
+}
+
+// DecodeAdvisorConfig decodes advisor configuration from site-config storage.
+func DecodeAdvisorConfig(data []byte) (codersdk.AdvisorConfig, error) {
+	var stored storedAdvisorConfig
+	if err := json.Unmarshal(data, &stored); err != nil {
+		return codersdk.AdvisorConfig{}, err
+	}
+	if stored.Version != advisorConfigStorageVersion {
+		stored.ReasoningEffort = nil
+	}
+	return stored.AdvisorConfig, nil
+}

--- a/coderd/x/chatd/advisor_config_internal_test.go
+++ b/coderd/x/chatd/advisor_config_internal_test.go
@@ -1,0 +1,44 @@
+package chatd
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/util/ptr"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func TestAdvisorConfigStorage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("RoundTripCurrentVersion", func(t *testing.T) {
+		t.Parallel()
+		want := codersdk.AdvisorConfig{
+			MaxUsesPerRun:   3,
+			MaxOutputTokens: 1024,
+			ModelConfigID:   uuid.New(),
+			ReasoningEffort: ptr.Ref(codersdk.ChatModelReasoningEffortHigh),
+		}
+
+		encoded, err := EncodeAdvisorConfig(want)
+		require.NoError(t, err)
+		require.Contains(t, string(encoded), `"_version":1`)
+
+		got, err := DecodeAdvisorConfig(encoded)
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	})
+
+	t.Run("IgnoresUnversionedReasoningEffort", func(t *testing.T) {
+		t.Parallel()
+		modelConfigID := uuid.New()
+		raw := []byte(`{"model_config_id":"` + modelConfigID.String() + `","reasoning_effort":"high"}`)
+
+		got, err := DecodeAdvisorConfig(raw)
+		require.NoError(t, err)
+		require.Equal(t, modelConfigID, got.ModelConfigID)
+		require.Nil(t, got.ReasoningEffort)
+	})
+}

--- a/coderd/x/chatd/advisor_internal_test.go
+++ b/coderd/x/chatd/advisor_internal_test.go
@@ -112,7 +112,7 @@ func (p *Server) resolveAdvisorModelOverrideOrFallback(
 	modelOpts modelBuildOptions,
 	logger slog.Logger,
 ) (fantasy.LanguageModel, codersdk.ChatModelCallConfig) {
-	model, cfg, err := p.resolveAdvisorModelOverride(
+	model, cfg, _, err := p.resolveAdvisorModelOverride(
 		ctx,
 		chat,
 		advisorCfg,
@@ -435,7 +435,7 @@ func TestResolveAdvisorModelOverridePromotesAIBridgeErrors(t *testing.T) {
 	p := newAdvisorTestServer(ctx, t, store)
 
 	ctx = aibridge.WithDelegatedAPIKeyID(ctx, uuid.NewString())
-	model, _, err := p.resolveAdvisorModelOverride(
+	model, _, _, err := p.resolveAdvisorModelOverride(
 		ctx,
 		database.Chat{ID: uuid.New(), OwnerID: uuid.New()},
 		codersdk.AdvisorConfig{ModelConfigID: configID},
@@ -611,7 +611,7 @@ func TestNewAdvisorRuntime(t *testing.T) {
 			"zero max output tokens must be replaced with defaultAdvisorMaxOutputTokens")
 	})
 
-	t.Run("AppliesReasoningEffortToProviderOptions", func(t *testing.T) {
+	t.Run("FallbackUsesModelDefaultReasoningEffort", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitShort)
 		store := &advisorOverrideStubStore{}
@@ -624,6 +624,7 @@ func TestNewAdvisorRuntime(t *testing.T) {
 				Enabled:         true,
 				MaxUsesPerRun:   3,
 				MaxOutputTokens: 16384,
+				ReasoningEffort: ptr.Ref(codersdk.ChatModelReasoningEffortLow),
 			},
 			fallbackModel,
 			codersdk.ChatModelCallConfig{
@@ -644,5 +645,57 @@ func TestNewAdvisorRuntime(t *testing.T) {
 		providerOptions := rt.ProviderOptions()[fantasyopenai.Name].(*fantasyopenai.ResponsesProviderOptions)
 		require.Equal(t, "advisor-user", *providerOptions.User)
 		require.Equal(t, fantasyopenai.ReasoningEffortHigh, *providerOptions.ReasoningEffort)
+	})
+
+	t.Run("ExplicitModelUsesConfiguredReasoningEffort", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
+		configID := uuid.New()
+		providerID := uuid.New()
+		rawOptions, err := json.Marshal(codersdk.ChatModelCallConfig{
+			ReasoningEffort: &codersdk.ChatModelReasoningEffortConfig{
+				Default: ptr.Ref(codersdk.ChatModelReasoningEffortMedium),
+				Max:     ptr.Ref(codersdk.ChatModelReasoningEffortHigh),
+			},
+		})
+		require.NoError(t, err)
+		store := &advisorOverrideStubStore{
+			getEnabledChatModelConfigByID: func(context.Context, uuid.UUID) (database.ChatModelConfig, error) {
+				return database.ChatModelConfig{
+					ID:           configID,
+					Model:        "gpt-5.2",
+					Enabled:      true,
+					Options:      rawOptions,
+					DisplayName:  "gpt-5.2",
+					AIProviderID: uuid.NullUUID{UUID: providerID, Valid: true},
+				}, nil
+			},
+			getAIProviderByID: func(context.Context, uuid.UUID) (database.AIProvider, error) {
+				return aibridgeTestAIProvider(providerID, "primary-openai", database.AIProviderTypeOpenai), nil
+			},
+		}
+		p := newAdvisorTestServer(ctx, t, store)
+		p.aibridgeTransportFactory = aibridgeTestFactoryPointer(&aibridgeTestFactory{rt: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+		})})
+
+		rt := p.newAdvisorRuntimeOrFallback(
+			ctx,
+			database.Chat{},
+			codersdk.AdvisorConfig{
+				Enabled:         true,
+				MaxUsesPerRun:   3,
+				MaxOutputTokens: 16384,
+				ModelConfigID:   configID,
+				ReasoningEffort: ptr.Ref(codersdk.ChatModelReasoningEffortLow),
+			},
+			fallbackModel,
+			fallbackCallConfig,
+			modelBuildOptions{ActiveAPIKeyID: uuid.NewString()},
+			logger,
+		)
+		require.NotNil(t, rt)
+		providerOptions := rt.ProviderOptions()[fantasyopenai.Name].(*fantasyopenai.ResponsesProviderOptions)
+		require.Equal(t, fantasyopenai.ReasoningEffortLow, *providerOptions.ReasoningEffort)
 	})
 }

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -272,9 +272,9 @@ func (p *Server) resolveAdvisorModelOverride(
 	fallbackCallConfig codersdk.ChatModelCallConfig,
 	modelOpts modelBuildOptions,
 	logger slog.Logger,
-) (fantasy.LanguageModel, codersdk.ChatModelCallConfig, error) {
+) (fantasy.LanguageModel, codersdk.ChatModelCallConfig, bool, error) {
 	if advisorCfg.ModelConfigID == uuid.Nil {
-		return fallbackModel, fallbackCallConfig, nil
+		return fallbackModel, fallbackCallConfig, false, nil
 	}
 
 	// Re-read the override instead of using the cache so disabled models
@@ -290,7 +290,7 @@ func (p *Server) resolveAdvisorModelOverride(
 				"advisor model config is disabled or unavailable, continuing with chat model",
 				slog.F("model_config_id", advisorCfg.ModelConfigID),
 			)
-			return fallbackModel, fallbackCallConfig, nil
+			return fallbackModel, fallbackCallConfig, false, nil
 		}
 		logger.Warn(
 			ctx,
@@ -298,7 +298,7 @@ func (p *Server) resolveAdvisorModelOverride(
 			slog.F("model_config_id", advisorCfg.ModelConfigID),
 			slog.Error(err),
 		)
-		return fallbackModel, fallbackCallConfig, nil
+		return fallbackModel, fallbackCallConfig, false, nil
 	}
 
 	overrideCallConfig := codersdk.ChatModelCallConfig{}
@@ -310,7 +310,7 @@ func (p *Server) resolveAdvisorModelOverride(
 				slog.F("model_config_id", advisorCfg.ModelConfigID),
 				slog.Error(err),
 			)
-			return fallbackModel, fallbackCallConfig, nil
+			return fallbackModel, fallbackCallConfig, false, nil
 		}
 	}
 
@@ -321,7 +321,7 @@ func (p *Server) resolveAdvisorModelOverride(
 	)
 	if err != nil {
 		if overrideConfig.AIProviderID.Valid {
-			return nil, codersdk.ChatModelCallConfig{}, xerrors.Errorf("resolve advisor override route: %w", err)
+			return nil, codersdk.ChatModelCallConfig{}, false, xerrors.Errorf("resolve advisor override route: %w", err)
 		}
 		logger.Warn(
 			ctx,
@@ -329,7 +329,7 @@ func (p *Server) resolveAdvisorModelOverride(
 			slog.F("model_config_id", advisorCfg.ModelConfigID),
 			slog.Error(err),
 		)
-		return fallbackModel, fallbackCallConfig, nil
+		return fallbackModel, fallbackCallConfig, false, nil
 	}
 	overrideModel, err := p.newModel(ctx, modelClientRequest{
 		Chat:         chat,
@@ -339,7 +339,7 @@ func (p *Server) resolveAdvisorModelOverride(
 	}, route, modelOpts)
 	if err != nil {
 		if overrideConfig.AIProviderID.Valid {
-			return nil, codersdk.ChatModelCallConfig{}, xerrors.Errorf("create advisor override model: %w", err)
+			return nil, codersdk.ChatModelCallConfig{}, false, xerrors.Errorf("create advisor override model: %w", err)
 		}
 		logger.Warn(
 			ctx,
@@ -347,10 +347,10 @@ func (p *Server) resolveAdvisorModelOverride(
 			slog.F("model_config_id", advisorCfg.ModelConfigID),
 			slog.Error(err),
 		)
-		return fallbackModel, fallbackCallConfig, nil
+		return fallbackModel, fallbackCallConfig, false, nil
 	}
 
-	return overrideModel, overrideCallConfig, nil
+	return overrideModel, overrideCallConfig, true, nil
 }
 
 func (p *Server) newAdvisorRuntime(
@@ -362,7 +362,7 @@ func (p *Server) newAdvisorRuntime(
 	modelOpts modelBuildOptions,
 	logger slog.Logger,
 ) (*chatadvisor.Runtime, error) {
-	advisorModel, advisorCallConfig, err := p.resolveAdvisorModelOverride(
+	advisorModel, advisorCallConfig, overrideResolved, err := p.resolveAdvisorModelOverride(
 		ctx,
 		chat,
 		advisorCfg,
@@ -398,10 +398,12 @@ func (p *Server) newAdvisorRuntime(
 	}
 
 	advisorCallConfig.MaxOutputTokens = ptr.Ref(maxOutputTokens)
-	// The advisor has no per-turn effort selection; its model config's
-	// default effort applies.
+	var requestedReasoningEffort *string
+	if overrideResolved {
+		requestedReasoningEffort = advisorCfg.ReasoningEffort
+	}
 	advisorReasoningEffort := chatprovider.ResolveReasoningEffort(
-		nil,
+		requestedReasoningEffort,
 		advisorCallConfig.ReasoningEffort,
 	)
 	providerOptions := chatprovider.ProviderOptionsFromChatModelConfig(

--- a/coderd/x/chatd/configcache.go
+++ b/coderd/x/chatd/configcache.go
@@ -3,7 +3,6 @@ package chatd
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -463,8 +462,8 @@ func (c *chatConfigCache) AdvisorConfig(ctx context.Context) (codersdk.AdvisorCo
 			if err != nil {
 				return codersdk.AdvisorConfig{}, err
 			}
-			var cfg codersdk.AdvisorConfig
-			if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+			cfg, err := DecodeAdvisorConfig([]byte(raw))
+			if err != nil {
 				return codersdk.AdvisorConfig{}, err
 			}
 			c.storeAdvisorConfig(generation, cfg)

--- a/coderd/x/chatd/configcache_internal_test.go
+++ b/coderd/x/chatd/configcache_internal_test.go
@@ -994,7 +994,7 @@ func TestConfigCache_AdvisorConfig_CacheHit(t *testing.T) {
 
 	ctx := testutil.Context(t, testutil.WaitShort)
 	clock := quartz.NewMock(t)
-	const raw = `{"enabled":true,"max_uses_per_run":3,"max_output_tokens":16384}`
+	const raw = `{"enabled":true,"max_uses_per_run":3,"max_output_tokens":16384,"model_config_id":"00000000-0000-0000-0000-000000000001","reasoning_effort":"high","_version":1}`
 	store := &stubChatConfigStore{
 		getChatAdvisorConfig: func(context.Context) (string, error) {
 			return raw, nil
@@ -1010,6 +1010,8 @@ func TestConfigCache_AdvisorConfig_CacheHit(t *testing.T) {
 	require.True(t, first.Enabled)
 	require.Equal(t, 3, first.MaxUsesPerRun)
 	require.Equal(t, int64(16384), first.MaxOutputTokens)
+	require.NotNil(t, first.ReasoningEffort)
+	require.Equal(t, codersdk.ChatModelReasoningEffortHigh, *first.ReasoningEffort)
 	require.Equal(t, first, second)
 	require.Equal(t, int32(1), store.advisorConfigCalls.Load(),
 		"second lookup must be served from cache")
@@ -1099,6 +1101,23 @@ func TestConfigCache_AdvisorConfig_EmptyJSONYieldsZeroValue(t *testing.T) {
 	cfg, err := cache.AdvisorConfig(ctx)
 	require.NoError(t, err)
 	require.Equal(t, codersdk.AdvisorConfig{}, cfg)
+}
+
+func TestConfigCache_AdvisorConfig_IgnoresUnversionedReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	clock := quartz.NewMock(t)
+	store := &stubChatConfigStore{
+		getChatAdvisorConfig: func(context.Context) (string, error) {
+			return `{"reasoning_effort":"high"}`, nil
+		},
+	}
+	cache := newChatConfigCache(ctx, store, clock)
+
+	cfg, err := cache.AdvisorConfig(ctx)
+	require.NoError(t, err)
+	require.Nil(t, cfg.ReasoningEffort)
 }
 
 // Guards the pubsub-driven invalidation path. Without this, an admin

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -906,6 +906,9 @@ type AdvisorConfig struct {
 	// resolved (e.g. the referenced model config was soft-deleted or
 	// its provider was disabled after the admin saved this config).
 	ModelConfigID uuid.UUID `json:"model_config_id" format:"uuid"`
+	// ReasoningEffort overrides the selected advisor model's configured
+	// default. It is ignored when ModelConfigID is uuid.Nil or unavailable.
+	ReasoningEffort *string `json:"reasoning_effort,omitempty"`
 }
 
 // UpdateAdvisorConfigRequest is the request body for updating advisor

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1063,6 +1063,11 @@ export interface AdvisorConfig {
 	 * its provider was disabled after the admin saved this config).
 	 */
 	readonly model_config_id: string;
+	/**
+	 * ReasoningEffort overrides the selected advisor model's configured
+	 * default. It is ignored when ModelConfigID is uuid.Nil or unavailable.
+	 */
+	readonly reasoning_effort?: string;
 }
 
 // From codersdk/users.go
@@ -9007,6 +9012,11 @@ export interface UpdateAdvisorConfigRequest {
 	 * its provider was disabled after the admin saved this config).
 	 */
 	readonly model_config_id: string;
+	/**
+	 * ReasoningEffort overrides the selected advisor model's configured
+	 * default. It is ignored when ModelConfigID is uuid.Nil or unavailable.
+	 */
+	readonly reasoning_effort?: string;
 }
 
 // From codersdk/deployment.go

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.stories.tsx
@@ -55,6 +55,17 @@ const claudeSonnetModelConfig = buildModelConfig({
 	context_limit: 200_000,
 });
 
+const advisorReasoningModelConfig = buildModelConfig({
+	id: "model-advisor-gpt-5",
+	model: "gpt-5",
+	display_name: "GPT-5 Advisor",
+	context_limit: 400_000,
+	model_config: {
+		reasoning_effort: { default: "medium", max: "high" },
+	},
+	reasoning_efforts: ["none", "minimal", "low", "medium", "high"],
+});
+
 const titleModelConfig = buildModelConfig({
 	id: "model-title-gpt-4o-mini",
 	model: "gpt-4o-mini",
@@ -97,6 +108,7 @@ const exploreDisabledModelConfig = buildModelConfig({
 const allModelConfigs: TypesGen.ChatModelConfig[] = [
 	generalModelConfig,
 	claudeSonnetModelConfig,
+	advisorReasoningModelConfig,
 	titleModelConfig,
 	exploreFallbackModelConfig,
 	generalDisabledModelConfig,
@@ -534,6 +546,102 @@ export const AdvisorSettingsVisible: Story = {
 				expect.anything(),
 			);
 		});
+	},
+};
+
+export const AdvisorReasoningEffort: Story = {
+	args: buildArgs({
+		showAdvisorSettings: true,
+		advisorConfigData: {
+			enabled: true,
+			max_uses_per_run: 3,
+			max_output_tokens: 16384,
+			model_config_id: advisorReasoningModelConfig.id,
+		},
+	}),
+	play: async ({ canvasElement, args }) => {
+		const section = await getSection(canvasElement, "Advisor");
+		const body = within(canvasElement.ownerDocument.body);
+		const trigger = within(section).getByRole("combobox", {
+			name: "Advisor model",
+		});
+		await userEvent.click(trigger);
+		const slider = await within(body.getByRole("dialog")).findByRole("slider");
+		expect(slider).toHaveAttribute("aria-valuenow", "3");
+		await userEvent.click(slider);
+		await userEvent.keyboard("{ArrowRight}");
+		await waitFor(() => {
+			expect(slider).toHaveAttribute("aria-valuenow", "4");
+		});
+		await userEvent.click(trigger);
+		const saveButton = within(section).getByRole("button", { name: "Save" });
+		await userEvent.click(saveButton);
+		await waitFor(() => {
+			expect(args.onSaveAdvisorConfig).toHaveBeenCalledWith(
+				expect.objectContaining({
+					model_config_id: advisorReasoningModelConfig.id,
+					reasoning_effort: "high",
+				}),
+				expect.anything(),
+			);
+		});
+
+		await userEvent.click(trigger);
+		await userEvent.type(
+			body.getByPlaceholderText("Search..."),
+			"Use chat model",
+		);
+		await userEvent.keyboard("{Enter}");
+		expect(body.queryByRole("slider")).not.toBeInTheDocument();
+		await userEvent.click(saveButton);
+		await waitFor(() => {
+			expect(args.onSaveAdvisorConfig).toHaveBeenLastCalledWith(
+				expect.not.objectContaining({ reasoning_effort: expect.anything() }),
+				expect.anything(),
+			);
+		});
+	},
+};
+
+export const AdvisorUnavailableModel: Story = {
+	args: buildArgs({
+		showAdvisorSettings: true,
+		advisorConfigData: {
+			enabled: true,
+			max_uses_per_run: 3,
+			max_output_tokens: 16384,
+			model_config_id: generalDisabledModelConfig.id,
+			reasoning_effort: "high",
+		},
+	}),
+	play: async ({ canvasElement }) => {
+		const section = await getSection(canvasElement, "Advisor");
+		expect(
+			within(section).getByRole("combobox", { name: "Advisor model" }),
+		).toHaveTextContent("Unavailable: GPT 4.1 Legacy");
+		expect(within(section).queryByRole("slider")).not.toBeInTheDocument();
+	},
+};
+
+export const AdvisorModelWithoutReasoningEffort: Story = {
+	args: buildArgs({
+		showAdvisorSettings: true,
+		advisorConfigData: {
+			enabled: true,
+			max_uses_per_run: 3,
+			max_output_tokens: 16384,
+			model_config_id: generalModelConfig.id,
+		},
+	}),
+	play: async ({ canvasElement }) => {
+		const section = await getSection(canvasElement, "Advisor");
+		const trigger = within(section).getByRole("combobox", {
+			name: "Advisor model",
+		});
+		await userEvent.click(trigger);
+		expect(
+			within(canvasElement.ownerDocument.body).queryByRole("slider"),
+		).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.tsx
@@ -201,6 +201,7 @@ export const CoderAgentsPageView: FC<CoderAgentsPageViewProps> = ({
 						isAdvisorConfigFetching={isAdvisorConfigFetching}
 						isAdvisorConfigLoadError={isAdvisorConfigLoadError}
 						modelConfigs={modelConfigsData ?? []}
+						providerInfoByID={providerInfoByID}
 						modelConfigsError={modelConfigsError}
 						isLoadingModelConfigs={isLoadingModelConfigs}
 						isFetchingModelConfigs={isFetchingModelConfigs}

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/components/SubagentModelOverrideSettings.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/components/SubagentModelOverrideSettings.tsx
@@ -5,7 +5,10 @@ import { Button } from "#/components/Button/Button";
 import { useTemporarySavedState } from "#/components/TemporarySavedState/TemporarySavedState";
 import { ModelSelector } from "#/pages/AgentsPage/components/ChatElements/ModelSelector";
 import { ModelOverrideAlerts } from "#/pages/AgentsPage/components/ModelOverrideAlerts";
-import type { ProviderInfo } from "#/pages/AgentsPage/utils/modelOptions";
+import {
+	modelSelectorOptionFromConfig,
+	type ProviderInfo,
+} from "#/pages/AgentsPage/utils/modelOptions";
 import { pickReasoningEffort } from "#/pages/AgentsPage/utils/reasoningEffort";
 import { AgentSettingLayout } from "./AgentSettingLayout";
 
@@ -66,25 +69,12 @@ export const SubagentModelOverrideSettings: FC<
 	const { isSavedVisible, showSavedState } = useTemporarySavedState();
 	const hasLoadedModelOverride = modelOverrideData !== undefined;
 	const isMalformedOverride = modelOverrideData?.is_malformed ?? false;
-	const enabledModelOptions = enabledModelConfigs.map((modelConfig) => {
-		const providerInfo = providerInfoByID.get(modelConfig.ai_provider_id);
-		const reasoningEffort = modelConfig.model_config?.reasoning_effort;
-		const reasoningEfforts = modelConfig.reasoning_efforts ?? [];
-		return {
-			id: modelConfig.id,
-			provider: providerInfo?.provider ?? "",
-			providerId: modelConfig.ai_provider_id,
-			providerLabel: providerInfo?.displayName,
-			providerIcon: providerInfo?.icon,
-			model: modelConfig.model,
-			displayName: modelConfig.display_name.trim() || modelConfig.model,
-			contextLimit: modelConfig.context_limit,
-			...(reasoningEffort?.default
-				? { reasoningEffortDefault: reasoningEffort.default }
-				: {}),
-			...(reasoningEfforts.length > 0 ? { reasoningEfforts } : {}),
-		};
-	});
+	const enabledModelOptions = enabledModelConfigs.map((modelConfig) =>
+		modelSelectorOptionFromConfig(
+			modelConfig,
+			providerInfoByID.get(modelConfig.ai_provider_id),
+		),
+	);
 
 	const form = useFormik({
 		enableReinitialize: true,

--- a/site/src/pages/AgentsPage/AgentSettingsUserAgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsUserAgentsPageView.stories.tsx
@@ -70,6 +70,17 @@ const claudeModelConfig = buildModelConfig({
 	context_limit: 200_000,
 });
 
+const reasoningModelConfig = buildModelConfig({
+	id: "model-gpt-5",
+	model: "gpt-5",
+	display_name: "GPT-5",
+	context_limit: 400_000,
+	model_config: {
+		reasoning_effort: { default: "medium", max: "high" },
+	},
+	reasoning_efforts: ["none", "minimal", "low", "medium", "high"],
+});
+
 const disabledModelConfig = buildModelConfig({
 	id: "model-disabled",
 	model: "gpt-4.1-legacy",
@@ -87,6 +98,7 @@ const inaccessibleModelConfig = buildModelConfig({
 const modelConfigs = [
 	defaultModelConfig,
 	claudeModelConfig,
+	reasoningModelConfig,
 	disabledModelConfig,
 	inaccessibleModelConfig,
 ];
@@ -98,6 +110,15 @@ const modelOptions: ModelSelectorOption[] = [
 		model: defaultModelConfig.model,
 		displayName: defaultModelConfig.display_name,
 		contextLimit: defaultModelConfig.context_limit,
+	},
+	{
+		id: reasoningModelConfig.id,
+		provider: "openai",
+		model: reasoningModelConfig.model,
+		displayName: reasoningModelConfig.display_name,
+		contextLimit: reasoningModelConfig.context_limit,
+		reasoningEffortDefault: "medium",
+		reasoningEfforts: reasoningModelConfig.reasoning_efforts,
 	},
 	{
 		id: claudeModelConfig.id,
@@ -275,6 +296,76 @@ export const EnabledWithSavedValues: Story = {
 				expect.anything(),
 			);
 		});
+	},
+};
+
+export const ReasoningEffortForAllAgentTypes: Story = {
+	args: buildArgs({
+		overridesData: buildOverridesResponse({
+			root: buildOverride("root", {
+				mode: "model",
+				model_config_id: reasoningModelConfig.id,
+				is_set: true,
+			}),
+			general: buildOverride("general", {
+				mode: "model",
+				model_config_id: reasoningModelConfig.id,
+				is_set: true,
+			}),
+			explore: buildOverride("explore", {
+				mode: "model",
+				model_config_id: reasoningModelConfig.id,
+				is_set: true,
+			}),
+		}),
+	}),
+	play: async ({ canvasElement, args }) => {
+		const body = within(canvasElement.ownerDocument.body);
+		const cases = [
+			{
+				title: "Root agent model",
+				onSave: args.onSaveRootModelOverride,
+			},
+			{
+				title: "General subagent model",
+				onSave: args.onSaveGeneralModelOverride,
+			},
+			{
+				title: "Explore subagent model",
+				onSave: args.onSaveExploreModelOverride,
+			},
+		];
+
+		for (const testCase of cases) {
+			const section = await getSection(canvasElement, testCase.title);
+			const trigger = within(section).getByRole("combobox", {
+				name: `${testCase.title} behavior`,
+			});
+			await userEvent.click(trigger);
+			const slider = await within(body.getByRole("dialog")).findByRole(
+				"slider",
+			);
+			expect(slider).toHaveAttribute("aria-valuenow", "3");
+			await userEvent.click(slider);
+			await userEvent.keyboard("{ArrowRight}");
+			await waitFor(() => {
+				expect(slider).toHaveAttribute("aria-valuenow", "4");
+			});
+			await userEvent.click(trigger);
+			await userEvent.click(
+				within(section).getByRole("button", { name: "Save" }),
+			);
+			await waitFor(() => {
+				expect(testCase.onSave).toHaveBeenCalledWith(
+					{
+						mode: "model",
+						model_config_id: reasoningModelConfig.id,
+						reasoning_effort: "high",
+					},
+					expect.anything(),
+				);
+			});
+		}
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/AdvisorSettings.tsx
+++ b/site/src/pages/AgentsPage/components/AdvisorSettings.tsx
@@ -7,20 +7,19 @@ import type {
 	UpdateAdvisorConfigRequest,
 } from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "#/components/Select/Select";
 import { useTemporarySavedState } from "#/components/TemporarySavedState/TemporarySavedState";
 import { AgentSettingLayout } from "#/pages/AISettingsPage/CoderAgentsPage/components/AgentSettingLayout";
 import { cn } from "#/utils/cn";
+import type { ProviderInfo } from "../utils/modelOptions";
+import { pickReasoningEffort } from "../utils/reasoningEffort";
+import {
+	ModelSelector,
+	type ModelSelectorOption,
+	type ModelSelectorSpecialOption,
+} from "./ChatElements";
 
 const nilUUID = "00000000-0000-0000-0000-000000000000";
 const chatModelFallbackValue = "__use-chat-model__";
-const unavailableModelValue = "__unavailable-model__";
 
 interface MutationCallbacks {
 	onSuccess?: () => void;
@@ -33,6 +32,7 @@ interface AdvisorSettingsProps {
 	isAdvisorConfigFetching: boolean;
 	isAdvisorConfigLoadError: boolean;
 	modelConfigs: readonly ChatModelConfig[];
+	providerInfoByID: ReadonlyMap<string, ProviderInfo>;
 	modelConfigsError: unknown;
 	isLoadingModelConfigs: boolean;
 	isFetchingModelConfigs: boolean;
@@ -49,6 +49,7 @@ type AdvisorSettingsFormValues = {
 	max_uses_per_run: string;
 	max_output_tokens: string;
 	model_config_id: string;
+	reasoning_effort: string;
 };
 
 const isUnsetModelConfigId = (id: string): boolean =>
@@ -78,6 +79,8 @@ const normalizeAdvisorConfig = (
 		!isUnsetModelConfigId(config.model_config_id)
 			? config.model_config_id
 			: "",
+	reasoning_effort:
+		typeof config?.reasoning_effort === "string" ? config.reasoning_effort : "",
 });
 
 const toAdvisorConfigRequest = (
@@ -89,6 +92,9 @@ const toAdvisorConfigRequest = (
 	model_config_id: isUnsetModelConfigId(values.model_config_id)
 		? nilUUID
 		: values.model_config_id,
+	...(!isUnsetModelConfigId(values.model_config_id) && values.reasoning_effort
+		? { reasoning_effort: values.reasoning_effort }
+		: {}),
 });
 
 const isNonNegativeIntegerString = (value: string): boolean => {
@@ -124,6 +130,7 @@ export const AdvisorSettings: FC<AdvisorSettingsProps> = ({
 	isAdvisorConfigFetching,
 	isAdvisorConfigLoadError,
 	modelConfigs,
+	providerInfoByID,
 	modelConfigsError,
 	isLoadingModelConfigs,
 	isFetchingModelConfigs,
@@ -137,6 +144,27 @@ export const AdvisorSettings: FC<AdvisorSettingsProps> = ({
 	const { isSavedVisible, showSavedState } = useTemporarySavedState();
 	const hasLoadedAdvisorConfig = advisorConfigData !== undefined;
 	const enabledModelConfigs = modelConfigs.filter((config) => config.enabled);
+	const modelOptions: ModelSelectorOption[] = enabledModelConfigs.map(
+		(modelConfig) => {
+			const providerInfo = providerInfoByID.get(modelConfig.ai_provider_id);
+			const reasoningEffort = modelConfig.model_config?.reasoning_effort;
+			const reasoningEfforts = modelConfig.reasoning_efforts ?? [];
+			return {
+				id: modelConfig.id,
+				provider: providerInfo?.provider ?? "",
+				providerId: modelConfig.ai_provider_id,
+				providerLabel: providerInfo?.displayName,
+				providerIcon: providerInfo?.icon,
+				model: modelConfig.model,
+				displayName: getModelDisplayName(modelConfig),
+				contextLimit: modelConfig.context_limit,
+				...(reasoningEffort?.default
+					? { reasoningEffortDefault: reasoningEffort.default }
+					: {}),
+				...(reasoningEfforts.length > 0 ? { reasoningEfforts } : {}),
+			};
+		},
+	);
 
 	const form = useFormik<AdvisorSettingsFormValues>({
 		enableReinitialize: true,
@@ -157,7 +185,17 @@ export const AdvisorSettings: FC<AdvisorSettingsProps> = ({
 				!modelConfigsError &&
 				!modelConfigs.some((config) => config.id === source.model_config_id)
 			) {
-				source = { ...source, model_config_id: "" };
+				source = { ...source, model_config_id: "", reasoning_effort: "" };
+			}
+			const selectedOption = modelOptions.find(
+				(option) => option.id === source.model_config_id,
+			);
+			if (
+				source.reasoning_effort &&
+				selectedOption &&
+				!selectedOption.reasoningEfforts?.includes(source.reasoning_effort)
+			) {
+				source = { ...source, reasoning_effort: "" };
 			}
 			const request = toAdvisorConfigRequest(source);
 			onSaveAdvisorConfig(request, {
@@ -186,18 +224,45 @@ export const AdvisorSettings: FC<AdvisorSettingsProps> = ({
 	const selectedModelConfig = modelConfigs.find(
 		(config) => config.id === form.values.model_config_id,
 	);
-	const selectedModelLabel = isUnsetModelConfigId(form.values.model_config_id)
-		? "Use chat model"
-		: isLoadingModelConfigs
-			? "Loading..."
-			: selectedModelConfig
-				? getModelDisplayName(selectedModelConfig)
-				: `Unavailable model (${form.values.model_config_id})`;
+	const selectedModelOption = modelOptions.find(
+		(option) => option.id === form.values.model_config_id,
+	);
+	const selectedReasoningEffort = selectedModelOption
+		? pickReasoningEffort(
+				form.values.reasoning_effort,
+				selectedModelOption.reasoningEfforts ?? [],
+				selectedModelOption.reasoningEffortDefault,
+			)
+		: undefined;
 	const selectedModelValue = isUnsetModelConfigId(form.values.model_config_id)
 		? chatModelFallbackValue
-		: hasUnavailableSelectedModel
-			? unavailableModelValue
-			: form.values.model_config_id;
+		: form.values.model_config_id;
+	const specialOptions: ModelSelectorSpecialOption[] = [
+		{
+			value: chatModelFallbackValue,
+			dropdownLabel: "Use chat model",
+			description: "Use the model selected for the current chat",
+		},
+	];
+	if (
+		!isUnsetModelConfigId(form.values.model_config_id) &&
+		isLoadingModelConfigs
+	) {
+		specialOptions.push({
+			value: form.values.model_config_id,
+			dropdownLabel: "Loading...",
+			disabled: true,
+		});
+	} else if (hasUnavailableSelectedModel) {
+		const unavailableLabel = selectedModelConfig
+			? `Unavailable: ${getModelDisplayName(selectedModelConfig)}`
+			: `Unavailable model (${form.values.model_config_id})`;
+		specialOptions.push({
+			value: form.values.model_config_id,
+			dropdownLabel: unavailableLabel,
+			disabled: true,
+		});
+	}
 	const canSave = hasLoadedAdvisorConfig && form.dirty && form.isValid;
 
 	return (
@@ -248,42 +313,50 @@ export const AdvisorSettings: FC<AdvisorSettingsProps> = ({
 				disabled={isFormDisabled}
 				className="w-36"
 			/>
-			<Select
+			<ModelSelector
+				options={modelOptions}
+				specialOptions={specialOptions}
 				value={selectedModelValue}
 				onValueChange={(value) => {
 					if (value === chatModelFallbackValue) {
-						void form.setFieldValue("model_config_id", "");
+						void form.setValues({
+							...form.values,
+							model_config_id: "",
+							reasoning_effort: "",
+						});
 						return;
 					}
-					if (value === unavailableModelValue) {
-						return;
+					const option = modelOptions.find((option) => option.id === value);
+					let reasoningEffort = "";
+					if (option) {
+						reasoningEffort =
+							pickReasoningEffort(
+								"",
+								option.reasoningEfforts ?? [],
+								option.reasoningEffortDefault,
+							) ?? "";
 					}
-					void form.setFieldValue("model_config_id", value);
+					void form.setValues({
+						...form.values,
+						model_config_id: value,
+						reasoning_effort: reasoningEffort,
+					});
 				}}
 				disabled={isModelSelectDisabled}
-			>
-				<SelectTrigger
-					className="h-10 w-[22rem] max-w-full justify-between rounded-md border border-border border-solid bg-transparent px-3 text-sm shadow-none"
-					aria-label="Advisor model"
-				>
-					<SelectValue placeholder="Use chat model">
-						{selectedModelLabel}
-					</SelectValue>
-				</SelectTrigger>
-				<SelectContent>
-					{hasUnavailableSelectedModel && (
-						<SelectItem value={unavailableModelValue}>
-							{selectedModelLabel}
-						</SelectItem>
-					)}
-					<SelectItem value={chatModelFallbackValue}>Use chat model</SelectItem>
-					{enabledModelConfigs.map((config) => (
-						<SelectItem key={config.id} value={config.id}>
-							{getModelDisplayName(config)}
-						</SelectItem>
-					))}
-				</SelectContent>
-			</Select>
+				ariaLabel="Advisor model"
+				placeholder="Use chat model"
+				emptyMessage={
+					isLoadingModelConfigs
+						? "Loading models..."
+						: "No enabled models found."
+				}
+				className="h-10 w-[22rem] max-w-full justify-between rounded-md border border-border border-solid bg-transparent px-3 text-sm shadow-none"
+				contentClassName="min-w-[18rem]"
+				reasoningEffort={selectedReasoningEffort}
+				onReasoningEffortChange={(value) =>
+					void form.setFieldValue("reasoning_effort", value)
+				}
+			/>
 			<Button
 				size="lg"
 				variant="outline"
@@ -293,6 +366,7 @@ export const AdvisorSettings: FC<AdvisorSettingsProps> = ({
 						max_uses_per_run: "0",
 						max_output_tokens: "0",
 						model_config_id: "",
+						reasoning_effort: "",
 					});
 				}}
 				disabled={isFormDisabled}

--- a/site/src/pages/AgentsPage/components/AdvisorSettings.tsx
+++ b/site/src/pages/AgentsPage/components/AdvisorSettings.tsx
@@ -10,13 +10,12 @@ import { Button } from "#/components/Button/Button";
 import { useTemporarySavedState } from "#/components/TemporarySavedState/TemporarySavedState";
 import { AgentSettingLayout } from "#/pages/AISettingsPage/CoderAgentsPage/components/AgentSettingLayout";
 import { cn } from "#/utils/cn";
-import type { ProviderInfo } from "../utils/modelOptions";
-import { pickReasoningEffort } from "../utils/reasoningEffort";
 import {
-	ModelSelector,
-	type ModelSelectorOption,
-	type ModelSelectorSpecialOption,
-} from "./ChatElements";
+	modelSelectorOptionFromConfig,
+	type ProviderInfo,
+} from "../utils/modelOptions";
+import { pickReasoningEffort } from "../utils/reasoningEffort";
+import { ModelSelector, type ModelSelectorSpecialOption } from "./ChatElements";
 
 const nilUUID = "00000000-0000-0000-0000-000000000000";
 const chatModelFallbackValue = "__use-chat-model__";
@@ -121,9 +120,6 @@ const validateAdvisorConfig = (values: AdvisorSettingsFormValues) => {
 	return errors;
 };
 
-const getModelDisplayName = (config: ChatModelConfig): string =>
-	config.display_name.trim() || config.model;
-
 export const AdvisorSettings: FC<AdvisorSettingsProps> = ({
 	advisorConfigData,
 	isAdvisorConfigLoading,
@@ -144,26 +140,11 @@ export const AdvisorSettings: FC<AdvisorSettingsProps> = ({
 	const { isSavedVisible, showSavedState } = useTemporarySavedState();
 	const hasLoadedAdvisorConfig = advisorConfigData !== undefined;
 	const enabledModelConfigs = modelConfigs.filter((config) => config.enabled);
-	const modelOptions: ModelSelectorOption[] = enabledModelConfigs.map(
-		(modelConfig) => {
-			const providerInfo = providerInfoByID.get(modelConfig.ai_provider_id);
-			const reasoningEffort = modelConfig.model_config?.reasoning_effort;
-			const reasoningEfforts = modelConfig.reasoning_efforts ?? [];
-			return {
-				id: modelConfig.id,
-				provider: providerInfo?.provider ?? "",
-				providerId: modelConfig.ai_provider_id,
-				providerLabel: providerInfo?.displayName,
-				providerIcon: providerInfo?.icon,
-				model: modelConfig.model,
-				displayName: getModelDisplayName(modelConfig),
-				contextLimit: modelConfig.context_limit,
-				...(reasoningEffort?.default
-					? { reasoningEffortDefault: reasoningEffort.default }
-					: {}),
-				...(reasoningEfforts.length > 0 ? { reasoningEfforts } : {}),
-			};
-		},
+	const modelOptions = enabledModelConfigs.map((modelConfig) =>
+		modelSelectorOptionFromConfig(
+			modelConfig,
+			providerInfoByID.get(modelConfig.ai_provider_id),
+		),
 	);
 
 	const form = useFormik<AdvisorSettingsFormValues>({
@@ -255,7 +236,7 @@ export const AdvisorSettings: FC<AdvisorSettingsProps> = ({
 		});
 	} else if (hasUnavailableSelectedModel) {
 		const unavailableLabel = selectedModelConfig
-			? `Unavailable: ${getModelDisplayName(selectedModelConfig)}`
+			? `Unavailable: ${selectedModelConfig.display_name.trim() || selectedModelConfig.model}`
 			: `Unavailable model (${form.values.model_config_id})`;
 		specialOptions.push({
 			value: form.values.model_config_id,

--- a/site/src/pages/AgentsPage/components/AdvisorSettings.tsx
+++ b/site/src/pages/AgentsPage/components/AdvisorSettings.tsx
@@ -327,15 +327,13 @@ export const AdvisorSettings: FC<AdvisorSettingsProps> = ({
 						return;
 					}
 					const option = modelOptions.find((option) => option.id === value);
-					let reasoningEffort = "";
-					if (option) {
-						reasoningEffort =
-							pickReasoningEffort(
+					const reasoningEffort = option
+						? (pickReasoningEffort(
 								"",
 								option.reasoningEfforts ?? [],
 								option.reasoningEffortDefault,
-							) ?? "";
-					}
+							) ?? "")
+						: "";
 					void form.setValues({
 						...form.values,
 						model_config_id: value,

--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.stories.tsx
@@ -177,6 +177,68 @@ export const MultipleProviderInstances: Story = {
 	},
 };
 
+export const SpecialOptions: Story = {
+	args: {
+		options: [...allModels, effortModel],
+		specialOptions: [
+			{
+				value: "chat-default",
+				dropdownLabel: "Chat default",
+				selectedLabel: "Chat default: GPT-4o",
+				description: "Use the model selected for the current chat",
+			},
+			{
+				value: "invalid-default",
+				dropdownLabel: "Invalid deployment default",
+				description: "Choose another value to replace it",
+				disabled: true,
+			},
+		],
+		value: "chat-default",
+		reasoningEffort: "medium",
+		onReasoningEffortChange: fn(),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(document.body);
+		const trigger = canvas.getByRole("combobox", {
+			name: "Chat default: GPT-4o",
+		});
+		expect(trigger).toHaveTextContent("Chat default: GPT-4o");
+
+		await userEvent.click(trigger);
+		const listbox = await body.findByRole("listbox");
+		expect(
+			within(listbox).getByRole("option", { name: /Chat default/ }),
+		).toBeInTheDocument();
+		expect(
+			within(listbox).getByText("Use the model selected for the current chat"),
+		).toBeInTheDocument();
+		expect(
+			within(listbox).getByRole("option", {
+				name: /Invalid deployment default/,
+			}),
+		).toHaveAttribute("data-disabled");
+		expect(body.queryByRole("slider")).not.toBeInTheDocument();
+
+		const search = body.getByPlaceholderText("Search...");
+		await userEvent.type(search, "replace it");
+		await waitFor(() => {
+			expect(
+				within(listbox).getByRole("option", {
+					name: /Invalid deployment default/,
+				}),
+			).toBeVisible();
+			expect(
+				within(listbox).queryByRole("option", { name: /Chat default/ }),
+			).not.toBeInTheDocument();
+			expect(
+				within(listbox).queryByRole("option", { name: /GPT-4o Mini/ }),
+			).not.toBeInTheDocument();
+		});
+	},
+};
+
 // ---------------------------------------------------------------------------
 // Empty state
 // ---------------------------------------------------------------------------

--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
@@ -39,11 +39,21 @@ export interface ModelSelectorOption {
 	reasoningEfforts?: readonly string[];
 }
 
+export interface ModelSelectorSpecialOption {
+	value: string;
+	dropdownLabel: string;
+	selectedLabel?: string;
+	description?: string;
+	disabled?: boolean;
+}
+
 interface ModelSelectorProps {
 	options: readonly ModelSelectorOption[];
+	specialOptions?: readonly ModelSelectorSpecialOption[];
 	value: string;
 	onValueChange: (value: string) => void;
 	disabled?: boolean;
+	ariaLabel?: string;
 	placeholder?: string;
 	emptyMessage?: string;
 	formatProviderLabel?: (provider: string) => string;
@@ -82,11 +92,23 @@ const getSearchText = (option: ModelSelectorOption, providerLabel: string) =>
 		.join(" ")
 		.toLowerCase();
 
+const getSpecialOptionSearchText = (option: ModelSelectorSpecialOption) =>
+	[
+		option.value,
+		option.dropdownLabel,
+		option.selectedLabel ?? "",
+		option.description ?? "",
+	]
+		.join(" ")
+		.toLowerCase();
+
 export const ModelSelector: FC<ModelSelectorProps> = ({
 	options,
+	specialOptions = [],
 	value,
 	onValueChange,
 	disabled = false,
+	ariaLabel,
 	placeholder = "Select model",
 	emptyMessage = "No models found.",
 	formatProviderLabel = defaultFormatProviderLabel,
@@ -108,8 +130,20 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
 		setOpen(nextOpen);
 	};
 	const selectedModel = options.find((option) => option.id === value);
-	const isDisabled = disabled || options.length === 0;
+	const selectedSpecialOption = specialOptions.find(
+		(option) => option.value === value,
+	);
+	const selectedLabel = selectedModel
+		? selectedModel.displayName
+		: (selectedSpecialOption?.selectedLabel ??
+			selectedSpecialOption?.dropdownLabel ??
+			placeholder);
+	const isDisabled =
+		disabled || (options.length === 0 && specialOptions.length === 0);
 	const query = search.trim().toLowerCase();
+	const filteredSpecialOptions = specialOptions.filter(
+		(option) => !query || getSpecialOptionSearchText(option).includes(query),
+	);
 	const optionsByProvider = (() => {
 		const grouped = new Map<string, ModelSelectorOption[]>();
 
@@ -135,7 +169,7 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
 		<Popover open={open} onOpenChange={handleOpenChange}>
 			<PopoverTrigger asChild disabled={isDisabled}>
 				<Button
-					aria-label={selectedModel ? selectedModel.displayName : placeholder}
+					aria-label={ariaLabel ?? selectedLabel}
 					aria-expanded={open}
 					aria-haspopup="listbox"
 					disabled={isDisabled}
@@ -148,13 +182,13 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
 					)}
 					onTouchStart={onTriggerTouchStart}
 				>
-					<span className="truncate">
-						{selectedModel ? selectedModel.displayName : placeholder}
-					</span>
+					<span className="truncate">{selectedLabel}</span>
 					<ChevronDownIcon open={open} className="size-icon-sm" />
 				</Button>
 			</PopoverTrigger>
 			<PopoverContent
+				forceMount
+				hidden={!open}
 				side={dropdownSide}
 				align={dropdownAlign}
 				className={cn(
@@ -196,6 +230,21 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
 						<CommandEmpty className="py-3 text-xs font-normal leading-[18px] text-content-secondary">
 							{emptyMessage}
 						</CommandEmpty>
+						{filteredSpecialOptions.length > 0 && (
+							<CommandGroup className="p-1">
+								{filteredSpecialOptions.map((option) => (
+									<SpecialOptionItem
+										key={option.value}
+										option={option}
+										isSelected={option.value === value}
+										onSelect={() => {
+											onValueChange(option.value);
+											handleOpenChange(false);
+										}}
+									/>
+								))}
+							</CommandGroup>
+						)}
 						{optionsByProvider.map(([providerKey, providerOptions], index) => {
 							const firstOption = providerOptions[0];
 							const providerLabel = getProviderLabel(
@@ -217,7 +266,7 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
 									}
 									className={cn(
 										"p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:leading-[18px] [&_[cmdk-group-heading]]:text-content-secondary",
-										index > 0 &&
+										(index > 0 || filteredSpecialOptions.length > 0) &&
 											"border-0 border-t border-solid border-border-default",
 									)}
 								>
@@ -313,6 +362,42 @@ const ReasoningEffortRow: FC<ReasoningEffortRowProps> = ({
 		</div>
 	);
 };
+
+interface SpecialOptionItemProps {
+	option: ModelSelectorSpecialOption;
+	isSelected: boolean;
+	onSelect: () => void;
+}
+
+const SpecialOptionItem: FC<SpecialOptionItemProps> = ({
+	option,
+	isSelected,
+	onSelect,
+}) => (
+	<CommandItem
+		value={option.value}
+		disabled={option.disabled}
+		onSelect={onSelect}
+		className={cn(
+			"gap-2 px-2 py-1 font-medium text-content-secondary data-[selected=true]:bg-surface-tertiary",
+			isSelected && "bg-surface-secondary",
+		)}
+	>
+		<span className="flex min-w-0 flex-col text-left">
+			<span className="truncate text-xs font-medium leading-[18px] text-content-secondary">
+				{option.dropdownLabel}
+			</span>
+			{option.description && (
+				<span className="truncate text-xs font-normal leading-[18px] text-content-secondary">
+					{option.description}
+				</span>
+			)}
+		</span>
+		<CheckIcon
+			className={cn("ml-auto size-4 shrink-0", !isSelected && "opacity-0")}
+		/>
+	</CommandItem>
+);
 
 interface ModelOptionItemProps {
 	option: ModelSelectorOption;

--- a/site/src/pages/AgentsPage/components/ChatElements/index.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/index.ts
@@ -1,7 +1,10 @@
 export { CompactOrgSelector } from "./CompactOrgSelector";
 export { ConversationItem } from "./Conversation";
 export { Message, MessageContent } from "./Message";
-export type { ModelSelectorOption } from "./ModelSelector";
+export type {
+	ModelSelectorOption,
+	ModelSelectorSpecialOption,
+} from "./ModelSelector";
 export { ModelSelector } from "./ModelSelector";
 export { Response } from "./Response";
 export { Shimmer } from "./Shimmer";

--- a/site/src/pages/AgentsPage/components/PersonalModelOverrideRow.tsx
+++ b/site/src/pages/AgentsPage/components/PersonalModelOverrideRow.tsx
@@ -278,15 +278,13 @@ export const PersonalModelOverrideRow: FC<PersonalModelOverrideRowProps> = ({
 							return;
 						}
 						const option = modelOptions.find((option) => option.id === value);
-						let reasoningEffort = "";
-						if (option) {
-							reasoningEffort =
-								pickReasoningEffort(
+						const reasoningEffort = option
+							? (pickReasoningEffort(
 									"",
 									option.reasoningEfforts ?? [],
 									option.reasoningEffortDefault,
-								) ?? "";
-						}
+								) ?? "")
+							: "";
 						void form.setValues({
 							mode: "model",
 							model_config_id: value,

--- a/site/src/pages/AgentsPage/components/PersonalModelOverrideRow.tsx
+++ b/site/src/pages/AgentsPage/components/PersonalModelOverrideRow.tsx
@@ -1,23 +1,14 @@
 import { useFormik } from "formik";
-import { Select as SelectPrimitive } from "radix-ui";
 import type { FC } from "react";
 import type * as TypesGen from "#/api/typesGenerated";
 import { Alert, AlertDescription } from "#/components/Alert/Alert";
 import { Button } from "#/components/Button/Button";
+import { pickReasoningEffort } from "../utils/reasoningEffort";
 import {
-	Select,
-	SelectContent,
-	SelectGroup,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "#/components/Select/Select";
-import { Slider } from "#/components/Slider/Slider";
-import {
-	formatReasoningEffort,
-	pickReasoningEffort,
-} from "../utils/reasoningEffort";
-import type { ModelSelectorOption } from "./ChatElements";
+	ModelSelector,
+	type ModelSelectorOption,
+	type ModelSelectorSpecialOption,
+} from "./ChatElements";
 import { ModelOverrideAlerts } from "./ModelOverrideAlerts";
 import { SectionHeader } from "./SectionHeader";
 
@@ -107,10 +98,6 @@ const getModelConfigLabel = (modelConfig: TypesGen.ChatModelConfig): string => {
 	return modelConfig.display_name.trim() || modelConfig.model || modelConfig.id;
 };
 
-const getModelOptionLabel = (option: ModelSelectorOption): string => {
-	return option.displayName.trim() || option.model || option.id;
-};
-
 const getModelConfigLabelByID = (
 	modelConfigID: string,
 	modelConfigs: readonly TypesGen.ChatModelConfig[],
@@ -173,61 +160,6 @@ const getDeploymentDefaultDescription = (
 	);
 };
 
-const getSelectionLabel = ({
-	context,
-	deploymentDefault,
-	isInvalidRootDeploymentDefault,
-	modelConfigs,
-	modelOptions,
-	values,
-}: {
-	context: PersonalOverrideContext;
-	deploymentDefault?: TypesGen.ChatModelOverrideResponse;
-	isInvalidRootDeploymentDefault: boolean;
-	modelConfigs: readonly TypesGen.ChatModelConfig[];
-	modelOptions: readonly ModelSelectorOption[];
-	values: PersonalOverrideFormValues;
-}): string => {
-	if (isInvalidRootDeploymentDefault) {
-		return "Invalid deployment default";
-	}
-
-	switch (values.mode) {
-		case "chat_default":
-			return `Chat default: ${getChatDefaultDescription(context, modelConfigs)}`;
-		case "deployment_default":
-			return `Deployment default: ${getDeploymentDefaultDescription(
-				deploymentDefault,
-				modelConfigs,
-			)}`;
-		case "model": {
-			const modelConfigID = values.model_config_id.trim();
-			const modelOption = modelOptions.find(
-				(option) => option.id === modelConfigID,
-			);
-			if (modelOption) {
-				return getModelOptionLabel(modelOption);
-			}
-			return modelConfigID === ""
-				? "Select..."
-				: getUnavailableModelLabel(modelConfigID, modelConfigs);
-		}
-	}
-};
-
-const isDefaultModeOption = (
-	value: string,
-): value is Exclude<PersonalOverrideMode, "model"> => {
-	return value === "chat_default" || value === "deployment_default";
-};
-
-// Local separator for use inside SelectContent. Defined here instead of
-// in the core Select component so the styling stays scoped to this
-// feature until a shared design lands.
-const SelectSeparator: FC = () => (
-	<SelectPrimitive.Separator className="-mx-1 my-1 h-px bg-border" />
-);
-
 export const PersonalModelOverrideRow: FC<PersonalModelOverrideRowProps> = ({
 	context,
 	title,
@@ -271,8 +203,11 @@ export const PersonalModelOverrideRow: FC<PersonalModelOverrideRowProps> = ({
 		form.values.mode === "model" &&
 		form.values.model_config_id.trim() !== "" &&
 		!modelOptions.some((option) => option.id === form.values.model_config_id);
-	const selectionValue =
-		form.values.mode === "model"
+	const isShowingInvalidRootDeploymentDefault =
+		isInvalidRootDeploymentDefault && !form.dirty;
+	const selectionValue = isShowingInvalidRootDeploymentDefault
+		? "deployment_default"
+		: form.values.mode === "model"
 			? form.values.model_config_id
 			: form.values.mode;
 	const selectedModelOption = modelOptions.find(
@@ -286,14 +221,39 @@ export const PersonalModelOverrideRow: FC<PersonalModelOverrideRowProps> = ({
 					selectedModelOption.reasoningEffortDefault,
 				)
 			: undefined;
-	const selectionLabel = getSelectionLabel({
-		context,
-		deploymentDefault,
-		isInvalidRootDeploymentDefault,
-		modelConfigs,
-		modelOptions,
-		values: form.values,
-	});
+	const specialOptions: ModelSelectorSpecialOption[] = [];
+	if (isShowingInvalidRootDeploymentDefault) {
+		specialOptions.push({
+			value: "deployment_default",
+			dropdownLabel: "Invalid deployment default",
+			disabled: true,
+		});
+	}
+	for (const mode of defaultModeOptions) {
+		const label =
+			mode === "deployment_default" ? "Deployment default" : "Chat default";
+		const defaultDescription =
+			mode === "deployment_default"
+				? getDeploymentDefaultDescription(deploymentDefault, modelConfigs)
+				: getChatDefaultDescription(context, modelConfigs);
+		specialOptions.push({
+			value: mode,
+			dropdownLabel: label,
+			selectedLabel: `${label}: ${defaultDescription}`,
+			description: defaultDescription,
+		});
+	}
+	if (isUnavailableSelectedModel) {
+		const unavailableLabel = getUnavailableModelLabel(
+			form.values.model_config_id,
+			modelConfigs,
+		);
+		specialOptions.push({
+			value: form.values.model_config_id,
+			dropdownLabel: unavailableLabel,
+			disabled: true,
+		});
+	}
 	const canSaveSelection =
 		canSave &&
 		(form.values.mode !== "model" ||
@@ -304,10 +264,12 @@ export const PersonalModelOverrideRow: FC<PersonalModelOverrideRowProps> = ({
 		<section aria-label={title} className="flex flex-col gap-3">
 			<SectionHeader label={title} description={description} level="section" />
 			<form className="flex flex-col gap-3" onSubmit={form.handleSubmit}>
-				<Select
+				<ModelSelector
+					options={modelOptions}
+					specialOptions={specialOptions}
 					value={selectionValue}
 					onValueChange={(value) => {
-						if (isDefaultModeOption(value)) {
+						if (value === "chat_default" || value === "deployment_default") {
 							void form.setValues({
 								mode: value,
 								model_config_id: "",
@@ -316,83 +278,34 @@ export const PersonalModelOverrideRow: FC<PersonalModelOverrideRowProps> = ({
 							return;
 						}
 						const option = modelOptions.find((option) => option.id === value);
-						const reasoningEffortDefault = option
-							? option.reasoningEffortDefault
-							: undefined;
+						let reasoningEffort = "";
+						if (option) {
+							reasoningEffort =
+								pickReasoningEffort(
+									"",
+									option.reasoningEfforts ?? [],
+									option.reasoningEffortDefault,
+								) ?? "";
+						}
 						void form.setValues({
 							mode: "model",
 							model_config_id: value,
-							reasoning_effort:
-								pickReasoningEffort(
-									"",
-									option?.reasoningEfforts ?? [],
-									reasoningEffortDefault,
-								) ?? "",
+							reasoning_effort: reasoningEffort,
 						});
 					}}
 					disabled={isFormDisabled}
-				>
-					<SelectTrigger
-						aria-label={`${title} behavior`}
-						className="h-10 w-full justify-between rounded-md border border-border border-solid bg-transparent px-3 text-sm shadow-sm md:w-[18rem]"
-					>
-						<SelectValue placeholder="Select...">{selectionLabel}</SelectValue>
-					</SelectTrigger>
-					<SelectContent className="min-w-[18rem]">
-						{isInvalidRootDeploymentDefault && (
-							<>
-								<SelectItem value="deployment_default" disabled>
-									Invalid deployment default
-								</SelectItem>
-								<SelectSeparator />
-							</>
-						)}
-						<SelectGroup>
-							{defaultModeOptions.map((mode) => (
-								<DefaultModeSelectItem
-									key={mode}
-									mode={mode}
-									context={context}
-									deploymentDefault={deploymentDefault}
-									modelConfigs={modelConfigs}
-								/>
-							))}
-						</SelectGroup>
-						<SelectSeparator />
-						{isUnavailableSelectedModel && (
-							<>
-								<SelectItem value={form.values.model_config_id} disabled>
-									{getUnavailableModelLabel(
-										form.values.model_config_id,
-										modelConfigs,
-									)}
-								</SelectItem>
-								<SelectSeparator />
-							</>
-						)}
-						<SelectGroup>
-							{modelOptions.map((option) => (
-								<SelectItem key={option.id} value={option.id}>
-									{getModelOptionLabel(option)}
-								</SelectItem>
-							))}
-							{modelOptions.length === 0 && (
-								<SelectItem value="__empty_models__" disabled>
-									{isLoading ? "Loading models..." : "No enabled models found."}
-								</SelectItem>
-							)}
-						</SelectGroup>
-					</SelectContent>
-				</Select>
-				{selectedReasoningEffort !== undefined && selectedModelOption && (
-					<PersonalReasoningEffortRow
-						option={selectedModelOption}
-						value={selectedReasoningEffort}
-						onChange={(value) =>
-							void form.setFieldValue("reasoning_effort", value)
-						}
-					/>
-				)}
+					ariaLabel={`${title} behavior`}
+					placeholder="Select..."
+					emptyMessage={
+						isLoading ? "Loading models..." : "No enabled models found."
+					}
+					className="h-10 w-full justify-between rounded-md border border-border border-solid bg-transparent px-3 text-sm shadow-sm md:w-[18rem]"
+					contentClassName="min-w-[18rem]"
+					reasoningEffort={selectedReasoningEffort}
+					onReasoningEffortChange={(value) =>
+						void form.setFieldValue("reasoning_effort", value)
+					}
+				/>
 				<ModelOverrideAlerts
 					isUnavailableSavedModel={isUnavailableSavedModel}
 					unavailableMessage="The saved model is unavailable and will be ignored until you choose a valid model override."
@@ -426,78 +339,5 @@ export const PersonalModelOverrideRow: FC<PersonalModelOverrideRowProps> = ({
 				)}
 			</form>
 		</section>
-	);
-};
-
-interface PersonalReasoningEffortRowProps {
-	option: ModelSelectorOption;
-	value: string;
-	onChange: (value: string) => void;
-}
-
-const PersonalReasoningEffortRow: FC<PersonalReasoningEffortRowProps> = ({
-	option,
-	value,
-	onChange,
-}) => {
-	const selectableEfforts = option.reasoningEfforts ?? [];
-	if (selectableEfforts.length === 0) {
-		return null;
-	}
-	const valueIndex = selectableEfforts.indexOf(value);
-	const effortIndex = valueIndex >= 0 ? valueIndex : 0;
-
-	return (
-		<div className="flex items-center gap-3 md:w-[18rem]">
-			<span className="shrink-0 text-content-secondary text-sm">Effort</span>
-			<Slider
-				aria-label={`${option.displayName} reasoning effort`}
-				value={[effortIndex]}
-				onValueChange={([index]) => {
-					const nextEffort = selectableEfforts[index];
-					if (nextEffort && nextEffort !== value) {
-						onChange(nextEffort);
-					}
-				}}
-				min={0}
-				max={selectableEfforts.length - 1}
-				step={1}
-			/>
-			<span className="shrink-0 rounded bg-surface-secondary px-1.5 py-0.5 text-content-secondary text-xs font-medium leading-[18px]">
-				{formatReasoningEffort(value)}
-			</span>
-		</div>
-	);
-};
-
-interface DefaultModeSelectItemProps {
-	mode: Exclude<PersonalOverrideMode, "model">;
-	context: PersonalOverrideContext;
-	deploymentDefault?: TypesGen.ChatModelOverrideResponse;
-	modelConfigs: readonly TypesGen.ChatModelConfig[];
-}
-
-const DefaultModeSelectItem: FC<DefaultModeSelectItemProps> = ({
-	mode,
-	context,
-	deploymentDefault,
-	modelConfigs,
-}) => {
-	const label =
-		mode === "deployment_default" ? "Deployment default" : "Chat default";
-	const description =
-		mode === "deployment_default"
-			? getDeploymentDefaultDescription(deploymentDefault, modelConfigs)
-			: getChatDefaultDescription(context, modelConfigs);
-
-	return (
-		<SelectItem value={mode}>
-			<span className="flex min-w-0 flex-col">
-				<span className="truncate text-content-primary">{label}</span>
-				<span className="truncate text-content-secondary text-xs leading-tight">
-					{description}
-				</span>
-			</span>
-		</SelectItem>
 	);
 };

--- a/site/src/pages/AgentsPage/utils/modelOptions.test.ts
+++ b/site/src/pages/AgentsPage/utils/modelOptions.test.ts
@@ -16,6 +16,7 @@ import {
 	getUnsupportedProviderNames,
 	hasConfiguredProviderConfigs,
 	hasUserFixableProviders,
+	modelSelectorOptionFromConfig,
 	providerInfoByIDFromConfigs,
 	providerInfoByIDFromUserConfigs,
 	providerTypeByIDFromConfigs,
@@ -277,6 +278,39 @@ describe("resolveModelOptionId", () => {
 
 	it("returns an empty string when no option matches", () => {
 		expect(resolveModelOptionId("openai:gpt-5", modelOptions)).toBe("");
+	});
+});
+
+describe("modelSelectorOptionFromConfig", () => {
+	it("projects model config and provider metadata", () => {
+		const config = createConfig({
+			id: "config-id",
+			ai_provider_id: "provider-id",
+			model: "model-id",
+			display_name: "  Display name  ",
+			context_limit: 128_000,
+			model_config: { reasoning_effort: { default: "medium" } },
+			reasoning_efforts: ["low", "medium", "high"],
+		});
+
+		expect(
+			modelSelectorOptionFromConfig(config, {
+				provider: "provider",
+				displayName: "Provider",
+				icon: "icon",
+			}),
+		).toEqual({
+			id: "config-id",
+			provider: "provider",
+			providerId: "provider-id",
+			providerLabel: "Provider",
+			providerIcon: "icon",
+			model: "model-id",
+			displayName: "Display name",
+			contextLimit: 128_000,
+			reasoningEffortDefault: "medium",
+			reasoningEfforts: ["low", "medium", "high"],
+		});
 	});
 });
 

--- a/site/src/pages/AgentsPage/utils/modelOptions.ts
+++ b/site/src/pages/AgentsPage/utils/modelOptions.ts
@@ -164,6 +164,28 @@ export type ProviderInfo = {
 	readonly icon: string;
 };
 
+export const modelSelectorOptionFromConfig = (
+	config: TypesGen.ChatModelConfig,
+	providerInfo: ProviderInfo | undefined,
+): ModelSelectorOption => {
+	const reasoningEffort = config.model_config?.reasoning_effort;
+	const reasoningEfforts = config.reasoning_efforts ?? [];
+	return {
+		id: config.id,
+		provider: providerInfo?.provider ?? "",
+		providerId: config.ai_provider_id,
+		providerLabel: providerInfo?.displayName,
+		providerIcon: providerInfo?.icon,
+		model: config.model,
+		displayName: config.display_name.trim() || config.model,
+		contextLimit: config.context_limit,
+		...(reasoningEffort?.default
+			? { reasoningEffortDefault: reasoningEffort.default }
+			: {}),
+		...(reasoningEfforts.length > 0 ? { reasoningEfforts } : {}),
+	};
+};
+
 // providerInfoByIDFromConfigs and providerInfoByIDFromUserConfigs build
 // the ai_provider_id -> provider metadata lookup that
 // getModelOptionsFromConfigs needs. The admin and user provider endpoints


### PR DESCRIPTION
Unifies Coder Agents model selection on the shared searchable `ModelSelector`, including personal root and subagent overrides plus advisor settings. Advisor model overrides can now select a supported reasoning effort while preserving fallback, unavailable, malformed, and disabled states.

Adds versioned advisor configuration storage so legacy unversioned reasoning settings remain ignored, validates effort against the selected model, and applies it only when the explicit advisor model resolves. Dogfood UAT passed across advisor, personal override, create-chat, and active-chat picker flows.

> Mux implemented this change on Mike's behalf.
