### PR TITLE
feat: gate chat turns on reported workspace context

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -80,6 +80,12 @@ const (
 	EnvProcOOMScore = "CODER_PROC_OOM_SCORE"
 )
 
+// mcpFirstSyncTimeout bounds how long the startup goroutine waits for
+// the first MCP catalog sync before releasing the context gate. The
+// reload keeps running in the background on timeout, and late-settling
+// servers still re-push via the catalog-change callback.
+const mcpFirstSyncTimeout = 30 * time.Second
+
 var ErrAgentClosing = xerrors.New("agent is closing")
 
 type Options struct {
@@ -1551,19 +1557,24 @@ func (a *agent) handleManifest(manifestOK *checkpoint) func(ctx context.Context,
 				a.metrics.startupScriptSeconds.WithLabelValues(label).Set(dur)
 				a.scriptRunner.StartCron()
 
-				// Startup finished (success or terminal failure): release
-				// the context gate. MCP servers connect below and
-				// re-trigger a push once up, so we don't block readiness
-				// on them.
-				a.contextManager.SetReady()
-
-				// Connect to workspace MCP servers after the
-				// lifecycle transition to avoid delaying Ready.
-				// This runs inside the tracked goroutine so it
-				// is properly awaited on shutdown.
-				if mcpErr := a.mcpManager.Reload(a.gracefulCtx, a.contextConfigAPI.MCPConfigFiles()); mcpErr != nil {
+				// Connect to workspace MCP servers before releasing the
+				// context gate so the first context push already contains
+				// the MCP catalog. The wait is bounded: if the catalog has
+				// not settled within mcpFirstSyncTimeout, the gate is
+				// released anyway while the reload keeps running in the
+				// background. Lifecycle Ready was reported above and is
+				// not delayed by this wait. This runs inside the tracked
+				// goroutine so it is properly awaited on shutdown.
+				if mcpErr := a.mcpManager.ReloadWithTimeout(a.gracefulCtx, a.contextConfigAPI.MCPConfigFiles(), mcpFirstSyncTimeout); mcpErr != nil {
 					a.logger.Warn(ctx, "failed to reload workspace MCP servers", slog.Error(mcpErr))
 				}
+
+				// Startup finished (success or terminal failure): release
+				// the context gate so the first context snapshot resolves
+				// and is pushed. Servers that settle after the bounded
+				// wait above still re-trigger a push via the MCP manager's
+				// catalog-change callback.
+				a.contextManager.SetReady()
 			})
 			if err != nil {
 				return xerrors.Errorf("track conn goroutine: %w", err)

--- a/agent/agent_context_test.go
+++ b/agent/agent_context_test.go
@@ -1,6 +1,9 @@
 package agent_test
 
 import (
+	"bufio"
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -66,5 +69,149 @@ func TestAgent_ContextStatePushed(t *testing.T) {
 	// Subsequent pushes must not be Initial.
 	for _, p := range pushes[1:] {
 		assert.False(t, p.GetInitial(), "only the first push must be Initial")
+	}
+}
+
+// TestAgent_ContextStateFirstPushIncludesMCP verifies the context gate
+// waits for the MCP catalog to settle before the first push: the
+// initial PushContextState (Initial=true) already contains the
+// configured MCP server resource with its tools instead of relying on
+// a follow-up push after the servers connect.
+func TestAgent_ContextStateFirstPushIncludesMCP(t *testing.T) {
+	t.Parallel()
+
+	if os.Getenv("TEST_MCP_FAKE_SERVER") == "1" {
+		// Child process: act as a minimal MCP server over stdio.
+		runFakeMCPStdioServer()
+		return
+	}
+
+	dir := t.TempDir()
+
+	// Point the default .mcp.json at a fake MCP server using the
+	// test binary re-exec pattern: the agent spawns this test
+	// binary, which detects TEST_MCP_FAKE_SERVER and serves MCP
+	// over stdio instead of running tests.
+	testBin, err := os.Executable()
+	require.NoError(t, err)
+	mcpConfig := map[string]any{
+		"mcpServers": map[string]any{
+			"srv": map[string]any{
+				"command": testBin,
+				"args":    []string{"-test.run=^TestAgent_ContextStateFirstPushIncludesMCP$"},
+				"env":     map[string]string{"TEST_MCP_FAKE_SERVER": "1"},
+			},
+		},
+	}
+	data, err := json.Marshal(mcpConfig)
+	require.NoError(t, err)
+	require.NoError(t,
+		os.WriteFile(filepath.Join(dir, ".mcp.json"), data, 0o600))
+
+	//nolint:dogsled // setupAgent returns a wide tuple; we only care about the client.
+	_, client, _, _, _ := setupAgent(t,
+		agentsdk.Manifest{Directory: dir},
+		0,
+		func(_ *agenttest.Client, opts *agent.Options) {
+			opts.ContextConfig = agentcontextconfig.Config{}
+		},
+	)
+
+	var pushes []*agentproto.PushContextStateRequest
+	require.Eventually(t, func() bool {
+		pushes = client.ContextStatePushes()
+		return len(pushes) > 0
+	}, testutil.WaitLong, testutil.IntervalFast,
+		"expected a context snapshot push after startup; got %d pushes", len(pushes))
+
+	first := pushes[0]
+	require.True(t, first.GetInitial(), "first push must carry Initial=true")
+
+	// The gate held until the MCP catalog settled, so the first
+	// push must already contain the server and its tool list.
+	var srv *agentproto.MCPServerBody
+	for _, r := range first.GetResources() {
+		if body := r.GetMcpServer(); body != nil && body.GetServerName() == "srv" {
+			srv = body
+		}
+	}
+	require.NotNil(t, srv,
+		"first push must already contain the MCP server resource")
+	require.Len(t, srv.GetTools(), 1,
+		"first push must already contain the server's tools")
+	assert.Equal(t, "echo", srv.GetTools()[0].GetName())
+}
+
+// runFakeMCPStdioServer implements a minimal JSON-RPC / MCP server
+// over stdin/stdout, just enough for initialize + tools/list. It
+// runs in a re-exec'd copy of the test binary spawned by the agent's
+// MCP manager.
+func runFakeMCPStdioServer() {
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+
+		var req struct {
+			JSONRPC string          `json:"jsonrpc"`
+			ID      json.RawMessage `json:"id"`
+			Method  string          `json:"method"`
+		}
+		if err := json.Unmarshal(line, &req); err != nil {
+			continue
+		}
+
+		var resp any
+		switch req.Method {
+		case "initialize":
+			resp = map[string]any{
+				"jsonrpc": "2.0",
+				"id":      req.ID,
+				"result": map[string]any{
+					"protocolVersion": "2025-03-26",
+					"capabilities": map[string]any{
+						"tools": map[string]any{},
+					},
+					"serverInfo": map[string]any{
+						"name":    "fake-server",
+						"version": "0.0.1",
+					},
+				},
+			}
+		case "notifications/initialized":
+			// No response needed for notifications.
+			continue
+		case "tools/list":
+			resp = map[string]any{
+				"jsonrpc": "2.0",
+				"id":      req.ID,
+				"result": map[string]any{
+					"tools": []map[string]any{
+						{
+							"name":        "echo",
+							"description": "echoes input",
+							"inputSchema": map[string]any{
+								"type":       "object",
+								"properties": map[string]any{},
+							},
+						},
+					},
+				},
+			}
+		default:
+			resp = map[string]any{
+				"jsonrpc": "2.0",
+				"id":      req.ID,
+				"error": map[string]any{
+					"code":    -32601,
+					"message": "method not found",
+				},
+			}
+		}
+
+		out, err := json.Marshal(resp)
+		if err != nil {
+			continue
+		}
+		_, _ = fmt.Fprintf(os.Stdout, "%s\n", out)
 	}
 }

--- a/agent/agentcontext/mcp_internal_test.go
+++ b/agent/agentcontext/mcp_internal_test.go
@@ -152,3 +152,57 @@ func TestBuildMCPServerResources(t *testing.T) {
 		require.Equal(t, StatusOK, got[1].Status)
 	})
 }
+
+// TestAggregateHash_MCPServerState verifies that live MCP server state
+// participates in the aggregate hash: tool changes and connect-state
+// flips change the hash, while identical inputs and tool order
+// permutations do not (buildMCPServerResources sorts tools by name
+// before hashing).
+func TestAggregateHash_MCPServerState(t *testing.T) {
+	t.Parallel()
+
+	hashOf := func(servers []MCPServerStatus) [32]byte {
+		return ComputeAggregateHash(buildMCPServerResources(servers))
+	}
+
+	connected := []MCPServerStatus{
+		{Name: "fs", Connected: true, Tools: []MCPTool{
+			{Name: "read", Description: "Read"},
+			{Name: "write", Description: "Write"},
+		}},
+	}
+	base := hashOf(connected)
+
+	// Identical inputs hash identically.
+	require.Equal(t, base, hashOf(connected))
+
+	// Tool order permutations hash identically because tools are
+	// sorted by name before hashing.
+	permuted := []MCPServerStatus{
+		{Name: "fs", Connected: true, Tools: []MCPTool{
+			{Name: "write", Description: "Write"},
+			{Name: "read", Description: "Read"},
+		}},
+	}
+	require.Equal(t, base, hashOf(permuted))
+
+	// A tool-list change flips the aggregate hash.
+	toolAdded := []MCPServerStatus{
+		{Name: "fs", Connected: true, Tools: []MCPTool{
+			{Name: "read", Description: "Read"},
+			{Name: "write", Description: "Write"},
+			{Name: "stat", Description: "Stat"},
+		}},
+	}
+	require.NotEqual(t, base, hashOf(toolAdded))
+
+	// A connected-to-failed flip changes both the resource status and
+	// its content hash, so the aggregate hash flips too.
+	failed := []MCPServerStatus{
+		{Name: "fs", Connected: false, Err: "connection refused"},
+	}
+	require.NotEqual(t, base, hashOf(failed))
+
+	// A server disappearing entirely flips the aggregate hash.
+	require.NotEqual(t, base, hashOf(nil))
+}

--- a/agent/agentcontext/resolve.go
+++ b/agent/agentcontext/resolve.go
@@ -184,10 +184,10 @@ func (r *Resolver) ResolveContext(ctx context.Context, roots []ScanRoot) Snapsho
 		payloadBytes += uint64(len(r.Payload))
 	}
 
-	// The drift hash covers only pinned prompt content; MCP resources are
-	// excluded (see driftResources). Snapshot.Resources still carries the
-	// full set so MCP servers stay visible in the chat-context snapshot.
-	hash := ComputeAggregateHash(driftResources(resources))
+	// The aggregate hash covers every resource, including MCP config and
+	// live MCP server state, so MCP changes (server added or removed, tool
+	// list changed, connect state changed) surface as chat-context drift.
+	hash := ComputeAggregateHash(resources)
 
 	snap := Snapshot{
 		Resources:     resources,
@@ -959,12 +959,12 @@ type Snapshot struct {
 	// loop withholds.
 	Version uint64
 	// AggregateHash is sha256 over a canonical encoding of
-	// (ID, Kind, Source, ContentHash, Status) for every
-	// drift-relevant resource. MCP resources (KindMCPConfig and
-	// KindMCPServer) are excluded because they describe live,
-	// agent-global runtime capabilities discovered at turn time,
-	// not pinned prompt content; see driftResources. Identical
-	// inputs always produce identical hashes; see
+	// (ID, Kind, Source, ContentHash, Status) for every resource in
+	// the snapshot, including MCP config and live MCP server state.
+	// coderd pins MCP servers and their tools into chat context, so
+	// an MCP change (server added or removed, tool list changed,
+	// connect state changed) surfaces as chat-context drift.
+	// Identical inputs always produce identical hashes; see
 	// ComputeAggregateHash.
 	AggregateHash [32]byte
 	// Resources is sorted by ID for deterministic encoding.
@@ -976,28 +976,6 @@ type Snapshot struct {
 	// string when present (count cap exceeded, watcher
 	// degraded, ENOSPC, etc.). Empty when healthy.
 	SnapshotError string
-}
-
-// driftResources returns the subset of resources that participate in
-// chat-context drift detection. MCP resources (the .mcp.json config and
-// connected MCP servers) are deliberately excluded: an agent connects to
-// its MCP servers asynchronously after startup, and the chat model
-// discovers their tools live at turn time, not from pinned prompt
-// content. Hashing them would dirty an already-hydrated chat the moment
-// a server finished connecting, even though nothing the user pinned
-// changed. Instruction files and skills, whose content is pinned into
-// the chat, stay drift-relevant.
-func driftResources(resources []Resource) []Resource {
-	out := make([]Resource, 0, len(resources))
-	for _, r := range resources {
-		switch r.Kind {
-		case KindMCPConfig, KindMCPServer:
-			continue
-		default:
-			out = append(out, r)
-		}
-	}
-	return out
 }
 
 // ComputeAggregateHash produces the deterministic snapshot

--- a/agent/agentcontext/resolve_test.go
+++ b/agent/agentcontext/resolve_test.go
@@ -498,37 +498,76 @@ func TestResolver_MCPResourcesRespectAggregateByteCap(t *testing.T) {
 	require.NotEmpty(t, snap.SnapshotError, "snapshot must surface the cap breach")
 }
 
-// TestResolver_MCPExcludedFromAggregateHash verifies that MCP resources
-// (config and live servers) are carried in the snapshot but excluded
-// from the drift/aggregate hash, so an MCP server connecting (or its
-// tools changing) does not flip already-hydrated chats to dirty.
-func TestResolver_MCPExcludedFromAggregateHash(t *testing.T) {
+// TestResolver_MCPIncludedInAggregateHash verifies that MCP resources
+// (config and live servers) participate in the aggregate hash. coderd
+// pins MCP servers and their tools into chat context, so a server
+// appearing, its tools changing, or the .mcp.json config changing must
+// all surface as chat-context drift.
+func TestResolver_MCPIncludedInAggregateHash(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	// An instruction file provides drift-relevant pinned content.
 	mustWriteFile(t, filepath.Join(dir, "AGENTS.md"), "workspace rules")
 
 	base := (&agentcontext.Resolver{}).Resolve([]agentcontext.ScanRoot{{Path: dir}})
 
-	mcpRes := agentcontext.Resource{
-		ID:          "mcp_server:github",
-		Kind:        agentcontext.KindMCPServer,
-		Source:      "github",
-		Name:        "github",
-		Status:      agentcontext.StatusOK,
-		ContentHash: sha256.Sum256([]byte("tool-list")),
-		Tools:       []agentcontext.MCPTool{{Name: "search"}},
+	mcpServer := func(contentHash [32]byte) func() []agentcontext.Resource {
+		return func() []agentcontext.Resource {
+			return []agentcontext.Resource{{
+				ID:          "mcp_server:github",
+				Kind:        agentcontext.KindMCPServer,
+				Source:      "github",
+				Name:        "github",
+				Status:      agentcontext.StatusOK,
+				ContentHash: contentHash,
+				Tools:       []agentcontext.MCPTool{{Name: "search"}},
+			}}
+		}
 	}
+	toolsV1 := sha256.Sum256([]byte("tool-list-v1"))
+	toolsV2 := sha256.Sum256([]byte("tool-list-v2"))
+
 	withMCP := (&agentcontext.Resolver{
-		MCPResources: func() []agentcontext.Resource { return []agentcontext.Resource{mcpRes} },
+		MCPResources: mcpServer(toolsV1),
 	}).Resolve([]agentcontext.ScanRoot{{Path: dir}})
 
-	// The MCP server resource is present in the snapshot...
+	// The MCP server resource is present in the snapshot and changes
+	// the aggregate hash relative to a snapshot without it.
 	got := findResource(t, withMCP.Resources, agentcontext.KindMCPServer, "github")
 	require.Len(t, got.Tools, 1)
-	// ...but does not change the drift/aggregate hash.
-	require.Equal(t, base.AggregateHash, withMCP.AggregateHash,
-		"MCP resources must not participate in the drift hash")
+	require.NotEqual(t, base.AggregateHash, withMCP.AggregateHash,
+		"an MCP server appearing must change the aggregate hash")
+
+	// Identical inputs produce an identical hash.
+	sameMCP := (&agentcontext.Resolver{
+		MCPResources: mcpServer(toolsV1),
+	}).Resolve([]agentcontext.ScanRoot{{Path: dir}})
+	require.Equal(t, withMCP.AggregateHash, sameMCP.AggregateHash,
+		"identical inputs must hash identically")
+
+	// A tool-list change (a new content hash) changes the aggregate hash.
+	changedTools := (&agentcontext.Resolver{
+		MCPResources: mcpServer(toolsV2),
+	}).Resolve([]agentcontext.ScanRoot{{Path: dir}})
+	require.NotEqual(t, withMCP.AggregateHash, changedTools.AggregateHash,
+		"an MCP server's tools changing must change the aggregate hash")
+}
+
+// TestResolver_MCPConfigChangesAggregateHash verifies that an .mcp.json
+// config resource participates in the aggregate hash, so editing the
+// config surfaces as chat-context drift.
+func TestResolver_MCPConfigChangesAggregateHash(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".mcp.json")
+
+	mustWriteFile(t, path, `{"mcpServers": {}}`)
+	base := (&agentcontext.Resolver{}).Resolve([]agentcontext.ScanRoot{{Path: dir}})
+	findResource(t, base.Resources, agentcontext.KindMCPConfig, path)
+
+	mustWriteFile(t, path, `{"mcpServers": {"github": {"command": "gh-mcp"}}}`)
+	changed := (&agentcontext.Resolver{}).Resolve([]agentcontext.ScanRoot{{Path: dir}})
+	require.NotEqual(t, base.AggregateHash, changed.AggregateHash,
+		"an MCP config change must change the aggregate hash")
 }
 
 // TestResolver_UnreadableInstructionFile verifies the

--- a/agent/x/agentmcp/manager.go
+++ b/agent/x/agentmcp/manager.go
@@ -177,6 +177,24 @@ func (m *Manager) Reload(ctx context.Context, paths []string) error {
 	return m.waitReload(ctx, ch, 0)
 }
 
+// ReloadWithTimeout behaves like Reload but bounds the caller's wait:
+// it waits up to timeout for the reload to settle and returns a
+// context.DeadlineExceeded-wrapping error if it does not. The reload
+// itself keeps running in the background under the manager context,
+// so a timed-out caller does not cancel it and a later Reload or
+// catalog callback observes the eventual result. A timeout of zero
+// or less waits indefinitely, matching Reload.
+func (m *Manager) ReloadWithTimeout(ctx context.Context, paths []string, timeout time.Duration) error {
+	ch, started, err := m.startReloadIfNeeded(paths)
+	if err != nil {
+		return err
+	}
+	if !started {
+		return nil
+	}
+	return m.waitReload(ctx, ch, timeout)
+}
+
 // SetOnReload registers a callback fired (outside the cache lock) after
 // a reload changes the per-server catalog. The agent wires this to the
 // agentcontext manager's Trigger so discovery re-resolves and re-pushes

--- a/agent/x/agentmcp/manager_internal_test.go
+++ b/agent/x/agentmcp/manager_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -275,6 +276,97 @@ func TestManager_WaitReloadTimeout(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 	assert.Contains(t, err.Error(), "tools reload timed out after 1m0s")
+}
+
+// TestReloadWithTimeout_Settles verifies that ReloadWithTimeout
+// returns nil once the reload settles within the timeout and the
+// catalog reflects the connected server.
+func TestReloadWithTimeout_Settles(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	dir := t.TempDir()
+
+	_, entry := fakeMCPServerConfig(t, "srv")
+	configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
+
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+	t.Cleanup(func() { _ = m.Close() })
+
+	err := m.ReloadWithTimeout(ctx, []string{configPath}, time.Minute)
+	require.NoError(t, err)
+
+	tools := m.connectedTools()
+	require.Len(t, tools, 1)
+	assert.Equal(t, "echo", tools[0].tool)
+
+	// A fresh snapshot short-circuits the next bounded reload.
+	err = m.ReloadWithTimeout(ctx, []string{configPath}, time.Minute)
+	require.NoError(t, err)
+}
+
+// TestReloadWithTimeout_TimesOut verifies that ReloadWithTimeout
+// returns a deadline error when the reload has not settled by the
+// time the timer fires, and that the reload keeps running in the
+// background so the catalog still settles afterwards.
+func TestReloadWithTimeout_TimesOut(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	clock := quartz.NewMock(t)
+	timerTrap := clock.Trap().NewTimer("agentmcp", "tools_reload")
+	defer timerTrap.Close()
+	dir := t.TempDir()
+
+	_, entry := fakeMCPServerConfig(t, "srv")
+	configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
+
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+	m.clock = clock
+	t.Cleanup(func() { _ = m.Close() })
+
+	// Block the reload body in connectAll so it cannot settle
+	// before the timer fires. Release runs on cleanup too, before
+	// Close, so a failed assertion cannot leave the hook blocked.
+	reached := make(chan struct{})
+	release := make(chan struct{})
+	var reachedOnce, releaseOnce sync.Once
+	releaseHook := func() { releaseOnce.Do(func() { close(release) }) }
+	t.Cleanup(releaseHook)
+	m.connectStartedHook = func() {
+		reachedOnce.Do(func() { close(reached) })
+		select {
+		case <-release:
+		case <-ctx.Done():
+		}
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- m.ReloadWithTimeout(ctx, []string{configPath}, time.Minute)
+	}()
+
+	// The reload body is blocked inside the hook while the caller
+	// waits on the bounded timer.
+	testutil.TryReceive(ctx, t, reached)
+	call := timerTrap.MustWait(ctx)
+	require.Equal(t, time.Minute, call.Duration)
+	call.MustRelease(ctx)
+
+	clock.Advance(time.Minute).MustWait(ctx)
+	err := testutil.RequireReceive(ctx, t, done)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+
+	// The reload was not canceled by the timed-out caller: once
+	// unblocked it settles and the catalog contains the server.
+	releaseHook()
+	require.Eventually(t, func() bool {
+		return len(m.connectedTools()) == 1
+	}, testutil.WaitLong, testutil.IntervalFast,
+		"catalog should settle after the timed-out reload completes")
 }
 
 // runFakeMCPServer implements a minimal JSON-RPC / MCP server over

--- a/coderd/agentapi/context_test.go
+++ b/coderd/agentapi/context_test.go
@@ -88,6 +88,45 @@ func TestPushContextState(t *testing.T) {
 		require.True(t, resp.GetAccepted())
 	})
 
+	t.Run("AcceptsEmptyReport", func(t *testing.T) {
+		t.Parallel()
+
+		api, dbm := makeAPI(t)
+		marker := &fakeDirtyMarker{}
+		api.DirtyMarker = marker
+		expectInTx(dbm)
+
+		// A workspace with no instruction files, skills, or MCP servers
+		// still reports: the snapshot row is the "context reported"
+		// signal, and hydration pins waiting chats to the empty set's
+		// hash with zero pinned resources.
+		emptySetHash := []byte{0xe3, 0xb0, 0xc4, 0x42}
+		dbm.EXPECT().GetLatestWorkspaceAgentContextSnapshot(gomock.Any(), agentID).
+			Return(database.WorkspaceAgentContextSnapshot{}, errNoRows())
+		dbm.EXPECT().UpsertWorkspaceAgentContextSnapshot(gomock.Any(), database.UpsertWorkspaceAgentContextSnapshotParams{
+			WorkspaceAgentID: agentID,
+			Version:          1,
+			AggregateHash:    emptySetHash,
+			ReceivedAt:       now,
+		}).Return(database.WorkspaceAgentContextSnapshot{}, nil)
+		// No resource upserts: the report carries zero resources.
+		dbm.EXPECT().DeleteStaleWorkspaceAgentContextResources(gomock.Any(), database.DeleteStaleWorkspaceAgentContextResourcesParams{
+			WorkspaceAgentID: agentID,
+			ActiveSources:    []string{},
+		}).Return(nil)
+
+		resp, err := api.PushContextState(context.Background(), &agentproto.PushContextStateRequest{
+			Version:       1,
+			AggregateHash: emptySetHash,
+			Initial:       true,
+		})
+		require.NoError(t, err)
+		require.True(t, resp.GetAccepted())
+		require.Equal(t, 1, marker.called, "empty reports must still hydrate waiting chats")
+		require.Equal(t, emptySetHash, marker.gotHash)
+		require.Equal(t, 1, marker.published)
+	})
+
 	t.Run("DirtyMarkerInvokedAfterCommit", func(t *testing.T) {
 		t.Parallel()
 

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -16865,7 +16865,7 @@ const docTemplate = `{
                     "$ref": "#/definitions/codersdk.ChatClientType"
                 },
                 "context": {
-                    "description": "Context reports the chat's pinned workspace-context state and\nwhether it has drifted from the agent's latest pushed snapshot.\nNil when the chat has no pinned context yet.",
+                    "description": "Context reports the chat's pinned workspace-context state and\nwhether it has drifted from the agent's latest pushed snapshot.\nPresent for every workspace-bound chat; nil for chats with no\nworkspace and no context remnants.",
                     "allOf": [
                         {
                             "$ref": "#/definitions/codersdk.ChatContext"
@@ -17045,6 +17045,14 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/codersdk.ChatContextResource"
                     }
+                },
+                "state": {
+                    "description": "State reports where the chat stands in the context-reporting\nlifecycle: waiting for the agent's first report or ready (pinned).",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/codersdk.ChatContextState"
+                        }
+                    ]
                 }
             }
         },
@@ -17120,6 +17128,17 @@ const docTemplate = `{
                 "ChatContextResourceStatusUnreadable",
                 "ChatContextResourceStatusInvalid",
                 "ChatContextResourceStatusExcluded"
+            ]
+        },
+        "codersdk.ChatContextState": {
+            "type": "string",
+            "enum": [
+                "waiting",
+                "ready"
+            ],
+            "x-enum-varnames": [
+                "ChatContextStateWaiting",
+                "ChatContextStateReady"
             ]
         },
         "codersdk.ChatContextTool": {
@@ -18090,7 +18109,9 @@ const docTemplate = `{
                 "deleted",
                 "diff_status_change",
                 "action_required",
-                "context_dirty"
+                "context_ready",
+                "context_dirty",
+                "context_error"
             ],
             "x-enum-varnames": [
                 "ChatWatchEventKindStatusChange",
@@ -18100,7 +18121,9 @@ const docTemplate = `{
                 "ChatWatchEventKindDeleted",
                 "ChatWatchEventKindDiffStatusChange",
                 "ChatWatchEventKindActionRequired",
-                "ChatWatchEventKindContextDirty"
+                "ChatWatchEventKindContextReady",
+                "ChatWatchEventKindContextDirty",
+                "ChatWatchEventKindContextError"
             ]
         },
         "codersdk.ClusterConfig": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -15150,7 +15150,7 @@
 					"$ref": "#/definitions/codersdk.ChatClientType"
 				},
 				"context": {
-					"description": "Context reports the chat's pinned workspace-context state and\nwhether it has drifted from the agent's latest pushed snapshot.\nNil when the chat has no pinned context yet.",
+					"description": "Context reports the chat's pinned workspace-context state and\nwhether it has drifted from the agent's latest pushed snapshot.\nPresent for every workspace-bound chat; nil for chats with no\nworkspace and no context remnants.",
 					"allOf": [
 						{
 							"$ref": "#/definitions/codersdk.ChatContext"
@@ -15318,6 +15318,14 @@
 					"items": {
 						"$ref": "#/definitions/codersdk.ChatContextResource"
 					}
+				},
+				"state": {
+					"description": "State reports where the chat stands in the context-reporting\nlifecycle: waiting for the agent's first report or ready (pinned).",
+					"allOf": [
+						{
+							"$ref": "#/definitions/codersdk.ChatContextState"
+						}
+					]
 				}
 			}
 		},
@@ -15383,6 +15391,11 @@
 				"ChatContextResourceStatusInvalid",
 				"ChatContextResourceStatusExcluded"
 			]
+		},
+		"codersdk.ChatContextState": {
+			"type": "string",
+			"enum": ["waiting", "ready"],
+			"x-enum-varnames": ["ChatContextStateWaiting", "ChatContextStateReady"]
 		},
 		"codersdk.ChatContextTool": {
 			"type": "object",
@@ -16322,7 +16335,9 @@
 				"deleted",
 				"diff_status_change",
 				"action_required",
-				"context_dirty"
+				"context_ready",
+				"context_dirty",
+				"context_error"
 			],
 			"x-enum-varnames": [
 				"ChatWatchEventKindStatusChange",
@@ -16332,7 +16347,9 @@
 				"ChatWatchEventKindDeleted",
 				"ChatWatchEventKindDiffStatusChange",
 				"ChatWatchEventKindActionRequired",
-				"ChatWatchEventKindContextDirty"
+				"ChatWatchEventKindContextReady",
+				"ChatWatchEventKindContextDirty",
+				"ChatWatchEventKindContextError"
 			]
 		},
 		"codersdk.ClusterConfig": {

--- a/coderd/database/db2sdk/db2sdk.go
+++ b/coderd/database/db2sdk/db2sdk.go
@@ -1794,12 +1794,21 @@ func Chat(c database.Chat, diffStatus *database.ChatDiffStatus, files []database
 			})
 		}
 	}
-	// Report pinned-context state when the chat is context-tracked
-	// (has a pinned hash), dirty, or carries a snapshot error.
-	if len(c.ContextAggregateHash) > 0 || c.ContextDirtySince.Valid || c.ContextError != "" {
+	// Report pinned-context state when the chat is workspace-bound or
+	// context-tracked (has a pinned hash, is dirty, or carries a snapshot
+	// error). Workspace-bound chats always get a Context so the client can
+	// distinguish waiting (not yet pinned to a reported snapshot) from
+	// ready (pinned).
+	if c.WorkspaceID.Valid || len(c.ContextAggregateHash) > 0 || c.ContextDirtySince.Valid || c.ContextError != "" {
 		chatContext := &codersdk.ChatContext{
 			Dirty: c.ContextDirtySince.Valid,
 			Error: c.ContextError,
+		}
+		switch {
+		case len(c.ContextAggregateHash) > 0:
+			chatContext.State = codersdk.ChatContextStateReady
+		case c.WorkspaceID.Valid:
+			chatContext.State = codersdk.ChatContextStateWaiting
 		}
 		if c.ContextDirtySince.Valid {
 			dirtySince := c.ContextDirtySince.Time

--- a/coderd/database/db2sdk/db2sdk_test.go
+++ b/coderd/database/db2sdk/db2sdk_test.go
@@ -872,6 +872,93 @@ func TestChat_FileMetadataConversion(t *testing.T) {
 	require.NotContains(t, string(data), `"mimetype"`)
 }
 
+// TestChat_ContextState covers when the converter emits a Context and which
+// State it reports: workspace-bound chats always carry one (ready when a
+// pinned hash exists, waiting otherwise), non-workspace chats carry one only
+// when dirty/error remnants exist (with no state), and plain non-workspace
+// chats keep a nil Context.
+func TestChat_ContextState(t *testing.T) {
+	t.Parallel()
+
+	now := dbtime.Now()
+	workspaceID := uuid.NullUUID{UUID: uuid.New(), Valid: true}
+
+	tests := []struct {
+		name        string
+		chat        database.Chat
+		wantContext bool
+		wantState   codersdk.ChatContextState
+		wantDirty   bool
+	}{
+		{
+			name: "WorkspaceBoundPinnedIsReady",
+			chat: database.Chat{
+				WorkspaceID:          workspaceID,
+				ContextAggregateHash: []byte{0x01},
+			},
+			wantContext: true,
+			wantState:   codersdk.ChatContextStateReady,
+		},
+		{
+			name: "WorkspaceBoundUnpinnedIsWaiting",
+			chat: database.Chat{
+				WorkspaceID: workspaceID,
+			},
+			wantContext: true,
+			wantState:   codersdk.ChatContextStateWaiting,
+		},
+		{
+			// A rebind clears the pin to an empty non-NULL hash; the chat
+			// waits again for the new agent's report.
+			name: "WorkspaceBoundRebindClearedIsWaiting",
+			chat: database.Chat{
+				WorkspaceID:          workspaceID,
+				ContextAggregateHash: []byte{},
+			},
+			wantContext: true,
+			wantState:   codersdk.ChatContextStateWaiting,
+		},
+		{
+			name:        "NonWorkspaceStaysNil",
+			chat:        database.Chat{},
+			wantContext: false,
+		},
+		{
+			// A non-workspace chat with dirty remnants keeps its Context
+			// (existing behavior) but reports no lifecycle state.
+			name: "NonWorkspaceDirtyRemnantHasNoState",
+			chat: database.Chat{
+				ContextDirtySince: sql.NullTime{Time: now, Valid: true},
+			},
+			wantContext: true,
+			wantState:   "",
+			wantDirty:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tc.chat.ID = uuid.New()
+			tc.chat.OwnerID = uuid.New()
+			tc.chat.LastModelConfigID = uuid.New()
+			tc.chat.Status = database.ChatStatusWaiting
+			tc.chat.CreatedAt = now
+			tc.chat.UpdatedAt = now
+
+			result := db2sdk.Chat(tc.chat, nil, nil)
+			if !tc.wantContext {
+				require.Nil(t, result.Context)
+				return
+			}
+			require.NotNil(t, result.Context)
+			require.Equal(t, tc.wantState, result.Context.State)
+			require.Equal(t, tc.wantDirty, result.Context.Dirty)
+		})
+	}
+}
+
 func TestChat_NilFilesOmitted(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -7290,6 +7290,17 @@ func (q *querier) UpdateChatByID(ctx context.Context, arg database.UpdateChatByI
 	return q.db.UpdateChatByID(ctx, arg)
 }
 
+func (q *querier) UpdateChatContextError(ctx context.Context, arg database.UpdateChatContextErrorParams) error {
+	chat, err := q.db.GetChatByID(ctx, arg.ID)
+	if err != nil {
+		return err
+	}
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, chat); err != nil {
+		return err
+	}
+	return q.db.UpdateChatContextError(ctx, arg)
+}
+
 func (q *querier) UpdateChatDebugRun(ctx context.Context, arg database.UpdateChatDebugRunParams) (database.ChatDebugRun, error) {
 	chat, err := q.db.GetChatByID(ctx, arg.ChatID)
 	if err != nil {

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -579,6 +579,13 @@ func (s *MethodTestSuite) TestChats() {
 		dbm.EXPECT().SetChatContextSnapshot(gomock.Any(), arg).Return(nil).AnyTimes()
 		check.Args(arg).Asserts(chat, policy.ActionUpdate)
 	}))
+	s.Run("UpdateChatContextError", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		chat := testutil.Fake(s.T(), faker, database.Chat{})
+		arg := database.UpdateChatContextErrorParams{ID: chat.ID, ContextError: "agent context report unavailable"}
+		dbm.EXPECT().GetChatByID(gomock.Any(), chat.ID).Return(chat, nil).AnyTimes()
+		dbm.EXPECT().UpdateChatContextError(gomock.Any(), arg).Return(nil).AnyTimes()
+		check.Args(arg).Asserts(chat, policy.ActionUpdate)
+	}))
 	s.Run("InsertAgentContextResourcesIntoChat", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		chat := testutil.Fake(s.T(), faker, database.Chat{})
 		arg := database.InsertAgentContextResourcesIntoChatParams{ChatID: chat.ID, AgentID: uuid.New()}

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -5185,6 +5185,14 @@ func (m queryMetricsStore) UpdateChatByID(ctx context.Context, arg database.Upda
 	return r0, r1
 }
 
+func (m queryMetricsStore) UpdateChatContextError(ctx context.Context, arg database.UpdateChatContextErrorParams) error {
+	start := time.Now()
+	r0 := m.s.UpdateChatContextError(ctx, arg)
+	m.queryLatencies.WithLabelValues("UpdateChatContextError").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "UpdateChatContextError").Inc()
+	return r0
+}
+
 func (m queryMetricsStore) UpdateChatDebugRun(ctx context.Context, arg database.UpdateChatDebugRunParams) (database.ChatDebugRun, error) {
 	start := time.Now()
 	r0, r1 := m.s.UpdateChatDebugRun(ctx, arg)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -9773,6 +9773,20 @@ func (mr *MockStoreMockRecorder) UpdateChatByID(ctx, arg any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateChatByID", reflect.TypeOf((*MockStore)(nil).UpdateChatByID), ctx, arg)
 }
 
+// UpdateChatContextError mocks base method.
+func (m *MockStore) UpdateChatContextError(ctx context.Context, arg database.UpdateChatContextErrorParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateChatContextError", ctx, arg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateChatContextError indicates an expected call of UpdateChatContextError.
+func (mr *MockStoreMockRecorder) UpdateChatContextError(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateChatContextError", reflect.TypeOf((*MockStore)(nil).UpdateChatContextError), ctx, arg)
+}
+
 // UpdateChatDebugRun mocks base method.
 func (m *MockStore) UpdateChatDebugRun(ctx context.Context, arg database.UpdateChatDebugRunParams) (database.ChatDebugRun, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -1367,6 +1367,11 @@ type sqlcQuerier interface {
 	UpdateChatACLByID(ctx context.Context, arg UpdateChatACLByIDParams) error
 	UpdateChatBuildAgentBinding(ctx context.Context, arg UpdateChatBuildAgentBindingParams) (Chat, error)
 	UpdateChatByID(ctx context.Context, arg UpdateChatByIDParams) (Chat, error)
+	// Written by the chatd context gate when a turn degrades because the
+	// workspace agent's context report is unavailable. The pinned hash is
+	// left untouched so push-side hydration, which is NULL-gated on the
+	// hash, still stamps the chat and replaces this error.
+	UpdateChatContextError(ctx context.Context, arg UpdateChatContextErrorParams) error
 	// Uses COALESCE so that passing NULL from Go means "keep the
 	// existing value." This is intentional: debug rows follow a
 	// write-once-finalize pattern where fields are set at creation

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -11370,6 +11370,26 @@ func (q *sqlQuerier) UpdateChatByID(ctx context.Context, arg UpdateChatByIDParam
 	return i, err
 }
 
+const updateChatContextError = `-- name: UpdateChatContextError :exec
+UPDATE chats
+SET context_error = $1::text
+WHERE id = $2::uuid
+`
+
+type UpdateChatContextErrorParams struct {
+	ContextError string    `db:"context_error" json:"context_error"`
+	ID           uuid.UUID `db:"id" json:"id"`
+}
+
+// Written by the chatd context gate when a turn degrades because the
+// workspace agent's context report is unavailable. The pinned hash is
+// left untouched so push-side hydration, which is NULL-gated on the
+// hash, still stamps the chat and replaces this error.
+func (q *sqlQuerier) UpdateChatContextError(ctx context.Context, arg UpdateChatContextErrorParams) error {
+	_, err := q.db.ExecContext(ctx, updateChatContextError, arg.ContextError, arg.ID)
+	return err
+}
+
 const updateChatExecutionState = `-- name: UpdateChatExecutionState :one
 WITH updated_chat AS (
     UPDATE chats

--- a/coderd/database/queries/chats.sql
+++ b/coderd/database/queries/chats.sql
@@ -1506,6 +1506,15 @@ SET
     context_dirty_since = NULL
 WHERE id = @id::uuid;
 
+-- name: UpdateChatContextError :exec
+-- Written by the chatd context gate when a turn degrades because the
+-- workspace agent's context report is unavailable. The pinned hash is
+-- left untouched so push-side hydration, which is NULL-gated on the
+-- hash, still stamps the chat and replaces this error.
+UPDATE chats
+SET context_error = @context_error::text
+WHERE id = @id::uuid;
+
 -- name: HydrateAgentChatsContext :many
 -- Stamps the pinned hash and error on every not-yet-hydrated chat for
 -- an agent (context_aggregate_hash IS NULL) and copies the agent's

--- a/coderd/x/chatd/ARCHITECTURE.md
+++ b/coderd/x/chatd/ARCHITECTURE.md
@@ -835,6 +835,19 @@ The generation goroutine supports:
 - turn limit after a user message (the LLM shouldn't be able to spin forever in loop)
 - and other things
 
+##### Context report gate
+
+A workspace-bound turn waits for the agent's context report but never fails over it. During generation preparation, before the pinned workspace context is read:
+
+- The chat's agent binding is resolved and, when the workspace has a newer start-transition build than the one the chat is bound to, rebound to the latest build's selected agent. Rebinding re-pins the chat's context (clearing it when the new agent has not pushed a snapshot yet). When the latest build is a stop or delete transition, the existing binding and pinned context are kept.
+- A chat whose context is already pinned proceeds immediately; agent resolution errors are swallowed on that path so pinned chats on stopped (zero-agent) workspaces keep working from their pinned context.
+- An unpinned chat waits on a 1-second poll loop, re-resolving the agent and checking for a pushed snapshot each tick. A push that arrives mid-wait is picked up on the next tick; the gate then pins the chat to it and the turn proceeds with that context. The wait is bounded by a 15-minute ceiling.
+- The gate degrades fast, without burning the ceiling, when a report provably cannot arrive: the workspace's latest build is not a start transition, the bound agent connected with an Agent API below 2.10 (the context-push minimum), or the agent is disconnected (a never-connected agent is not disconnected; the workspace is still starting, so the gate keeps waiting).
+- Degrading never puts the chat in an error state. The reason is recorded on `chats.context_error` (leaving the pinned hash NULL), a `context_error` watch event is published, and the turn runs without workspace context: empty instruction, no workspace skills, no workspace MCP tools. Ceiling expiry degrades the same way.
+- Degrade memory: an unpinned chat whose `context_error` is already non-empty degrades immediately on later turns, keeping the message. An unpinned chat can only carry a non-empty `context_error` from a previous gate degrade (hydration and repin always set the hash and error together), and the rebind-repin clears it on new builds, so the memory is per-build and prevents every message from re-stalling the full ceiling against a wedged agent.
+- Self-heal: because a degrade leaves the pinned hash NULL, a later agent push still hydrates the chat, overwrites the context error, and publishes `context_ready`; subsequent turns proceed pinned.
+- Context cancellation propagates unchanged so interrupts keep working during the wait; an interrupt is not a degrade.
+
 ##### Reasoning effort
 
 Model configs may carry a `reasoning_effort` config (`{default, max}`) inside `chat_model_configs.options`. Users select a per-turn effort when sending or editing a message; the value is stored on `chat_messages.reasoning_effort` and on `chat_queued_messages.reasoning_effort` for queued messages. Queued messages carry the value through promotion, and `chats.last_reasoning_effort` tracks the most recent message that set one, mirroring `last_model_config_id`.

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -195,6 +195,10 @@ type Server struct {
 	streamSyncPoller  *streamSyncPoller
 	recordingSem      chan struct{}
 
+	// contextReportTimeout is the ceiling on how long a turn waits for the
+	// workspace agent's first context report before failing the turn.
+	contextReportTimeout time.Duration
+
 	aibridgeTransportFactory *atomic.Pointer[aibridge.TransportFactory]
 	experiments              codersdk.Experiments
 
@@ -670,17 +674,27 @@ func (c *turnWorkspaceContext) loadWorkspaceAgentLocked(
 		if chatSnapshot.AgentID.Valid {
 			agent, err := c.server.db.GetWorkspaceAgentByID(ctx, chatSnapshot.AgentID.UUID)
 			if err == nil {
-				latestChat, workspaceMatches := c.currentWorkspaceMatches(chatSnapshot.WorkspaceID)
-				if !workspaceMatches {
-					chatSnapshot = latestChat
-					continue
+				stale, staleErr := c.chatBindingStale(ctx, chatSnapshot)
+				if staleErr != nil {
+					return chatSnapshot, database.WorkspaceAgent{}, staleErr
 				}
-				c.agent = agent
-				c.agentLoaded = true
-				c.cachedWorkspaceID = chatSnapshot.WorkspaceID
-				return chatSnapshot, c.agent, nil
-			}
-			if !xerrors.Is(err, sql.ErrNoRows) {
+				if !stale {
+					latestChat, workspaceMatches := c.currentWorkspaceMatches(chatSnapshot.WorkspaceID)
+					if !workspaceMatches {
+						chatSnapshot = latestChat
+						continue
+					}
+					c.agent = agent
+					c.agentLoaded = true
+					c.cachedWorkspaceID = chatSnapshot.WorkspaceID
+					return chatSnapshot, c.agent, nil
+				}
+				// The workspace has a newer start build than the one the chat
+				// is bound to. GetWorkspaceAgentByID keeps resolving agents
+				// from old builds, so fall through to the re-resolve path
+				// below, which rebinds to the latest build's agent and
+				// re-pins the chat's context.
+			} else if !xerrors.Is(err, sql.ErrNoRows) {
 				c.server.logger.Warn(ctx, "agent binding lookup failed, re-resolving",
 					slog.F("agent_id", chatSnapshot.AgentID.UUID),
 					slog.Error(err),
@@ -739,6 +753,38 @@ func (c *turnWorkspaceContext) loadWorkspaceAgentLocked(
 	return chatSnapshot, database.WorkspaceAgent{}, xerrors.New(
 		"chat workspace changed while resolving agent",
 	)
+}
+
+// chatBindingStale reports whether the chat's bound agent belongs to an
+// older build. Rebinding only chases start builds: when the latest build is
+// a stop or delete transition, the chat keeps its existing agent and pinned
+// context so pinned turns still work on a stopped workspace.
+func (c *turnWorkspaceContext) chatBindingStale(
+	ctx context.Context,
+	chatSnapshot database.Chat,
+) (bool, error) {
+	build, err := c.server.db.GetLatestWorkspaceBuildByWorkspaceID(ctx, chatSnapshot.WorkspaceID.UUID)
+	if err != nil {
+		return false, xerrors.Errorf("get latest workspace build: %w", err)
+	}
+	if build.Transition != database.WorkspaceTransitionStart {
+		return false, nil
+	}
+	return !chatSnapshot.BuildID.Valid || chatSnapshot.BuildID.UUID != build.ID, nil
+}
+
+// refreshWorkspaceAgent drops the cached agent and re-resolves it, so the
+// caller observes rebinds performed by loadWorkspaceAgentLocked while the
+// cache would otherwise short-circuit. The cached workspace connection is
+// left alone; the dial path revalidates it on the next use.
+func (c *turnWorkspaceContext) refreshWorkspaceAgent(
+	ctx context.Context,
+) (database.Chat, database.WorkspaceAgent, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.agent = database.WorkspaceAgent{}
+	c.agentLoaded = false
+	return c.loadWorkspaceAgentLocked(ctx)
 }
 
 func (c *turnWorkspaceContext) latestWorkspaceAgentID(
@@ -2991,6 +3037,7 @@ func New(ps pubsub.Pubsub, cfg Config) *Server {
 		agentConnFn:                    cfg.AgentConn,
 		agentInactiveDisconnectTimeout: cfg.AgentInactiveDisconnectTimeout,
 		dialTimeout:                    defaultDialTimeout,
+		contextReportTimeout:           defaultContextReportTimeout,
 		instructionLookupTimeout:       instructionLookupTimeout,
 		createWorkspaceFn:              cfg.CreateWorkspace,
 		startWorkspaceFn:               cfg.StartWorkspace,

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -1277,6 +1277,7 @@ func TestTurnWorkspaceContext_BindingFirstPath(t *testing.T) {
 	workspaceAgent := database.WorkspaceAgent{ID: agentID}
 
 	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).Return(workspaceAgent, nil).Times(1)
+	expectBoundBindingFresh(db, workspaceID)
 
 	chatStateMu := &sync.Mutex{}
 	currentChat := chat
@@ -1364,6 +1365,16 @@ func expectBestEffortContextRepin(db *dbmock.MockStore) {
 		Return(database.WorkspaceAgentContextSnapshot{}, sql.ErrNoRows).AnyTimes()
 	db.EXPECT().SetChatContextSnapshot(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	db.EXPECT().DeleteChatContextResourcesByChatID(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+}
+
+// expectBoundBindingFresh satisfies the bound-agent staleness probe that
+// loadWorkspaceAgentLocked runs before trusting an existing agent binding.
+// The latest build is reported without a start transition, so the probe
+// keeps the chat's bound agent and the test exercises its original flow.
+func expectBoundBindingFresh(db *dbmock.MockStore, workspaceID uuid.UUID) {
+	db.EXPECT().GetLatestWorkspaceBuildByWorkspaceID(gomock.Any(), workspaceID).
+		Return(database.WorkspaceBuild{WorkspaceID: workspaceID}, nil).
+		AnyTimes()
 }
 
 func TestTurnWorkspaceContext_StaleBindingRepair(t *testing.T) {
@@ -1454,7 +1465,6 @@ func TestTurnWorkspaceContextGetWorkspaceConnLazyValidationSwitchesWorkspaceAgen
 	gomock.InOrder(
 		db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), staleAgentID).Return(staleAgent, nil),
 		db.EXPECT().GetWorkspaceAgentsInLatestBuildByWorkspaceID(gomock.Any(), workspaceID).Return([]database.WorkspaceAgent{currentAgent}, nil),
-		db.EXPECT().GetLatestWorkspaceBuildByWorkspaceID(gomock.Any(), workspaceID).Return(database.WorkspaceBuild{ID: buildID}, nil),
 		db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), currentAgentID).Return(currentAgent, nil),
 		db.EXPECT().UpdateChatBuildAgentBinding(gomock.Any(), database.UpdateChatBuildAgentBindingParams{
 			BuildID: uuid.NullUUID{UUID: buildID, Valid: true},
@@ -1462,6 +1472,10 @@ func TestTurnWorkspaceContextGetWorkspaceConnLazyValidationSwitchesWorkspaceAgen
 			ID:      chat.ID,
 		}).Return(updatedChat, nil),
 	)
+	// Serves both the bound-agent staleness probe (the zero transition is
+	// not a start, so the binding is kept) and the post-switch build fetch.
+	db.EXPECT().GetLatestWorkspaceBuildByWorkspaceID(gomock.Any(), workspaceID).
+		Return(database.WorkspaceBuild{ID: buildID}, nil).AnyTimes()
 
 	conn := agentconnmock.NewMockAgentConn(ctrl)
 	conn.EXPECT().SetExtraHeaders(gomock.Any()).Times(1)
@@ -1529,6 +1543,7 @@ func TestTurnWorkspaceContextGetWorkspaceConnFastFailsWithoutCurrentAgent(t *tes
 	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), staleAgentID).
 		Return(staleAgent, nil).
 		Times(1)
+	expectBoundBindingFresh(db, workspaceID)
 	db.EXPECT().GetWorkspaceAgentsInLatestBuildByWorkspaceID(gomock.Any(), workspaceID).
 		Return([]database.WorkspaceAgent{}, nil).
 		Times(1)
@@ -2217,9 +2232,10 @@ func TestGetWorkspaceConn_StaleAgentRecovery(t *testing.T) {
 	// Lazy validation discovers the new agent.
 	db.EXPECT().GetWorkspaceAgentsInLatestBuildByWorkspaceID(gomock.Any(), workspaceID).
 		Return([]database.WorkspaceAgent{newAgent}, nil).Times(1)
-	// Post-switch: persist the new binding.
+	// Serves both the bound-agent staleness probe (the zero transition is
+	// not a start, so the binding is kept) and the post-switch build fetch.
 	db.EXPECT().GetLatestWorkspaceBuildByWorkspaceID(gomock.Any(), workspaceID).
-		Return(database.WorkspaceBuild{ID: buildID}, nil).Times(1)
+		Return(database.WorkspaceBuild{ID: buildID}, nil).AnyTimes()
 	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), newAgentID).
 		Return(newAgent, nil).Times(1)
 
@@ -2325,6 +2341,7 @@ func TestGetWorkspaceConn_SameBuildAgentCrash(t *testing.T) {
 	// ensureWorkspaceAgent fetches the (crashed) agent.
 	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
 		Return(agent, nil).Times(1)
+	expectBoundBindingFresh(db, workspaceID)
 	// Validation finds the same agent in the latest build.
 	db.EXPECT().GetWorkspaceAgentsInLatestBuildByWorkspaceID(gomock.Any(), workspaceID).
 		Return([]database.WorkspaceAgent{agent}, nil).Times(1)
@@ -2634,6 +2651,7 @@ func TestGetWorkspaceConn_DialTimeoutDisconnectedRecoveryThreshold(t *testing.T)
 			db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), boundAgent.ID).
 				Return(boundAgent, nil).
 				Times(1)
+			expectBoundBindingFresh(db, workspaceID)
 			db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), latestAgent.ID).
 				Return(latestAgent, nil).
 				Times(1)
@@ -2750,6 +2768,7 @@ func TestGetWorkspaceConn_DisconnectedStatusDialSuccessDoesNotEscalate(t *testin
 	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
 		Return(disconnectedAgent, nil).
 		Times(1)
+	expectBoundBindingFresh(db, workspaceID)
 
 	server := &Server{
 		db:                             db,
@@ -2819,6 +2838,7 @@ func TestGetWorkspaceConn_CacheHitDisconnectedRetriesDialBeforeEscalating(t *tes
 	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
 		Return(disconnectedAgent, nil).
 		Times(2)
+	expectBoundBindingFresh(db, workspaceID)
 
 	server := &Server{
 		db:                             db,
@@ -2899,6 +2919,7 @@ func TestGetWorkspaceConn_DialTimeout(t *testing.T) {
 	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
 		Return(connectedAgent, nil).
 		Times(2)
+	expectBoundBindingFresh(db, workspaceID)
 	db.EXPECT().GetWorkspaceAgentsInLatestBuildByWorkspaceID(gomock.Any(), workspaceID).
 		Return([]database.WorkspaceAgent{connectedAgent}, nil).
 		Times(1)
@@ -2970,6 +2991,7 @@ func TestGetWorkspaceConn_DialTimeoutParentCanceled(t *testing.T) {
 	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
 		Return(connectedAgent, nil).
 		Times(1)
+	expectBoundBindingFresh(db, workspaceID)
 
 	parentErr := xerrors.New("parent canceled")
 	ctx, cancel := context.WithCancelCause(testutil.Context(t, testutil.WaitShort))
@@ -3050,6 +3072,7 @@ func TestGetWorkspaceConn_PreflightExternalAgentTimedOut(t *testing.T) {
 	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
 		Return(agent, nil).
 		Times(1)
+	expectBoundBindingFresh(db, workspaceID)
 	db.EXPECT().GetWorkspaceAgentsInLatestBuildByWorkspaceID(gomock.Any(), workspaceID).
 		Return([]database.WorkspaceAgent{agent}, nil).
 		Times(1)
@@ -3124,6 +3147,7 @@ func TestGetWorkspaceConn_PreflightExternalAgentConnectingDials(t *testing.T) {
 	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
 		Return(agent, nil).
 		Times(1)
+	expectBoundBindingFresh(db, workspaceID)
 
 	conn := agentconnmock.NewMockAgentConn(ctrl)
 	conn.EXPECT().SetExtraHeaders(gomock.Any()).Times(1)
@@ -3200,6 +3224,7 @@ func TestGetWorkspaceConn_DialErrorNotMisclassifiedAsTimeout(t *testing.T) {
 	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
 		Return(connectedAgent, nil).
 		Times(1)
+	expectBoundBindingFresh(db, workspaceID)
 	// When the initial dial fails immediately, dialWithLazyValidation
 	// calls resolveFastFailure which validates the binding. Mock the
 	// validation to return the same agent, triggering a synchronous

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbfake"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
 	dbpubsub "github.com/coder/coder/v2/coderd/database/pubsub"
 	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/coderd/util/slice"
@@ -4917,6 +4918,11 @@ func TestCreateWorkspaceTool_EndToEnd(t *testing.T) {
 	require.True(t, foundToolResultInSecondCall, "expected second streamed model call to include create_workspace tool output")
 }
 
+// TestStartWorkspaceTool_EndToEnd covers the start_workspace tool through
+// the chat worker on a chat bound to a stopped workspace. The context gate
+// cannot obtain a report from the stopped workspace, so the turn degrades
+// (recording the reason on the chat's context error) and still runs, letting
+// the model call start_workspace.
 func TestStartWorkspaceTool_EndToEnd(t *testing.T) {
 	t.Parallel()
 
@@ -5004,6 +5010,13 @@ func TestStartWorkspaceTool_EndToEnd(t *testing.T) {
 		}
 		require.FailNowf(t, "chat run failed", "last_error=%q", lastError)
 	}
+
+	// The gate degraded the turn instead of failing it: the stopped-workspace
+	// reason is recorded on the chat's context (populated on single-chat GET).
+	require.NotNil(t, chatResult.Context)
+	require.Equal(t, "workspace must be started to report chat context",
+		chatResult.Context.Error,
+		"the degrade reason must surface on the chat's context error")
 
 	// Verify the workspace was started.
 	require.NotNil(t, chatResult.WorkspaceID)
@@ -5125,6 +5138,17 @@ func TestStoppedWorkspaceWithPersistedAgentBindingDoesNotBlockChat(t *testing.T)
 		ID:      chat.ID,
 		BuildID: uuid.NullUUID{UUID: build.ID, Valid: true},
 		AgentID: uuid.NullUUID{UUID: dbAgent.ID, Valid: true},
+	})
+	require.NoError(t, err)
+
+	// The agent reported context while the workspace ran, pinning the chat.
+	// The context-report gate only lets a pinned chat run once the workspace
+	// is stopped below, matching the production sequence this test models.
+	snapshot, err := db.GetLatestWorkspaceAgentContextSnapshot(ctx, dbAgent.ID)
+	require.NoError(t, err)
+	_, err = db.HydrateAgentChatsContext(ctx, database.HydrateAgentChatsContextParams{
+		AgentID:       dbAgent.ID,
+		AggregateHash: snapshot.AggregateHash,
 	})
 	require.NoError(t, err)
 
@@ -9108,7 +9132,18 @@ func seedWorkspaceWithAgent(
 		Version:           "v1.0.0",
 		ExpandedDirectory: "/home/coder/project",
 	}))
-	dbAgent, err := db.GetWorkspaceAgentByID(context.Background(), dbAgent.ID)
+	// The context-report gate blocks workspace turns until the agent has
+	// pushed a context snapshot. Seed an empty snapshot so turns proceed
+	// as they did before the gate; row existence alone marks the agent as
+	// having reported, and an empty snapshot contributes no prompt context.
+	_, err := db.UpsertWorkspaceAgentContextSnapshot(context.Background(), database.UpsertWorkspaceAgentContextSnapshotParams{
+		WorkspaceAgentID: dbAgent.ID,
+		Version:          1,
+		AggregateHash:    []byte{0x01},
+		ReceivedAt:       dbtime.Now(),
+	})
+	require.NoError(t, err)
+	dbAgent, err = db.GetWorkspaceAgentByID(context.Background(), dbAgent.ID)
 	require.NoError(t, err)
 	return ws, dbAgent
 }

--- a/coderd/x/chatd/context_gate.go
+++ b/coderd/x/chatd/context_gate.go
@@ -1,0 +1,357 @@
+package chatd
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/apiversion"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+const (
+	// contextReportPollInterval is how often the context-report gate
+	// re-resolves the chat's agent and re-checks for a pushed snapshot
+	// while a turn waits for the agent's first context report.
+	contextReportPollInterval = time.Second
+	// defaultContextReportTimeout bounds how long a turn waits for the
+	// workspace agent to report its context snapshot before the turn
+	// degrades and runs without workspace context.
+	defaultContextReportTimeout = 15 * time.Minute
+
+	contextReportTickerTag     = "context-report-tick"
+	contextReportTimeoutTag    = "context-report-timeout"
+	contextReportTimerTagGroup = "chatd"
+
+	// Context pushes require Agent API >= 2.10 (PushContextState). Agents
+	// built before that version can never report context, so waiting on
+	// them is pointless.
+	contextReportMinAPIMajor = 2
+	contextReportMinAPIMinor = 10
+)
+
+// Degrade messages recorded on chats.context_error when the gate cannot
+// obtain a context report. They are user-visible in the UI's context
+// indicator, so they name the condition and the remedy where one exists.
+const (
+	chatContextErrWorkspaceNotStarted = "workspace must be started to report chat context"
+	chatContextErrAgentTooOld         = "workspace agent is too old to report chat context; " +
+		"update Coder and rebuild the workspace"
+	chatContextErrAgentDisconnected = "workspace agent is not connected, " +
+		"so it cannot report chat context"
+)
+
+// awaitChatContextReported gives a workspace-bound turn its context report,
+// degrading instead of failing when the report is unavailable. A chat whose
+// current snapshot is already pinned proceeds immediately; agent resolution
+// errors are swallowed on that path so pinned chats on stopped (zero-agent)
+// workspaces keep working. An unpinned chat waits on a poll loop that
+// re-resolves the agent (rebinding to a newer start build when the binding is
+// stale) and exits as soon as the bound agent has any snapshot row, then pins
+// the chat to it.
+//
+// The gate never fails the turn over an unavailable report. When a report
+// provably cannot arrive (the latest build is not a start transition, the
+// agent connected with an Agent API too old to push context, or the agent is
+// disconnected), or when the wait ceiling elapses, the turn degrades: the
+// reason is recorded on chats.context_error, a context_error watch event is
+// published, and the turn runs without workspace context. Context
+// cancellation propagates unchanged so interrupts keep working.
+func (server *Server) awaitChatContextReported(
+	ctx context.Context,
+	workspaceCtx *turnWorkspaceContext,
+	logger slog.Logger,
+) (database.WorkspaceAgent, error) {
+	before := workspaceCtx.currentChatSnapshot()
+	resolvedChat, agent, resolveErr := workspaceCtx.ensureWorkspaceAgent(ctx)
+	if resolveErr == nil &&
+		(!nullUUIDEqual(before.AgentID, resolvedChat.AgentID) ||
+			!nullUUIDEqual(before.BuildID, resolvedChat.BuildID)) {
+		// The resolution rebound the chat to another build's agent and
+		// re-pinned its context in a separate transaction, so the cached
+		// snapshot's pinned fields are stale. Reload before reading them.
+		fresh, err := workspaceCtx.loadChatSnapshot(ctx, resolvedChat.ID)
+		if err != nil {
+			return database.WorkspaceAgent{}, xerrors.Errorf(
+				"reload chat after agent rebind: %w", err)
+		}
+		workspaceCtx.setCurrentChat(fresh)
+	}
+
+	if chatContextPinned(workspaceCtx.currentChatSnapshot()) {
+		// Pinned and, because ensureWorkspaceAgent rebinds stale bindings
+		// and rebinding re-pins, current. Proceed as before the gate
+		// existed: resolveErr is swallowed so a pinned chat on a stopped
+		// workspace with no agents still runs from its pinned context.
+		if resolveErr != nil {
+			logger.Debug(ctx, "context gate: proceeding with pinned context despite agent resolution error",
+				slog.Error(resolveErr))
+		}
+		return agent, nil
+	}
+	if ctx.Err() != nil {
+		return database.WorkspaceAgent{}, ctx.Err()
+	}
+
+	// Degrade memory: an unpinned chat can only carry a non-empty
+	// context_error from a previous gate degrade, because hydration and
+	// repin always set the hash and error together and the rebind-repin
+	// clears the error on new builds. The memory is therefore per-build:
+	// once a turn degraded, later turns on the same build degrade
+	// immediately (keeping/refreshing the message) instead of re-stalling
+	// the full ceiling against a wedged agent.
+	if workspaceCtx.currentChatSnapshot().ContextError != "" {
+		return server.degradeChatContext(ctx, workspaceCtx, logger,
+			workspaceCtx.currentChatSnapshot().ContextError)
+	}
+
+	agent, done, degradeReason, err := server.checkChatContextReported(ctx, workspaceCtx, logger)
+	if err != nil {
+		return database.WorkspaceAgent{}, err
+	}
+	if degradeReason != "" {
+		return server.degradeChatContext(ctx, workspaceCtx, logger, degradeReason)
+	}
+	if done {
+		return agent, nil
+	}
+
+	logger.Info(ctx, "context gate: waiting for workspace agent to report chat context",
+		slog.F("timeout", server.contextReportTimeout))
+
+	timeout := server.clock.NewTimer(server.contextReportTimeout,
+		contextReportTimerTagGroup, contextReportTimeoutTag)
+	defer timeout.Stop()
+	ticker := server.clock.NewTicker(contextReportPollInterval,
+		contextReportTimerTagGroup, contextReportTickerTag)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return database.WorkspaceAgent{}, ctx.Err()
+		case <-timeout.C:
+			return server.degradeChatContext(ctx, workspaceCtx, logger,
+				"workspace agent did not report chat context within "+
+					server.contextReportTimeout.String())
+		case <-ticker.C:
+			agent, done, degradeReason, err := server.checkChatContextReported(ctx, workspaceCtx, logger)
+			if err != nil {
+				return database.WorkspaceAgent{}, err
+			}
+			if degradeReason != "" {
+				return server.degradeChatContext(ctx, workspaceCtx, logger, degradeReason)
+			}
+			if done {
+				return agent, nil
+			}
+		}
+	}
+}
+
+// degradeChatContext records why this turn runs without workspace context on
+// chats.context_error, publishes a context_error watch event with the fresh
+// chat row, and returns the zero-value agent with a nil error so the prepare
+// phase proceeds exactly like the pre-gate code did (empty instruction, no
+// workspace skills, no workspace MCP tools). The pinned hash is left NULL, so
+// a later agent push still hydrates the chat, overwrites the error, and
+// publishes context_ready; the degrade self-heals.
+func (server *Server) degradeChatContext(
+	ctx context.Context,
+	workspaceCtx *turnWorkspaceContext,
+	logger slog.Logger,
+	message string,
+) (database.WorkspaceAgent, error) {
+	chatSnapshot := workspaceCtx.currentChatSnapshot()
+	//nolint:gocritic // Chatd records context degrades on chats it does not own as the daemon subject.
+	err := server.db.UpdateChatContextError(dbauthz.AsChatd(ctx), database.UpdateChatContextErrorParams{
+		ID:           chatSnapshot.ID,
+		ContextError: message,
+	})
+	if err != nil {
+		return database.WorkspaceAgent{}, xerrors.Errorf(
+			"record chat context error: %w", err)
+	}
+	fresh, err := workspaceCtx.loadChatSnapshot(ctx, chatSnapshot.ID)
+	if err != nil {
+		return database.WorkspaceAgent{}, xerrors.Errorf(
+			"reload chat after context degrade: %w", err)
+	}
+	workspaceCtx.setCurrentChat(fresh)
+	server.publishChatPubsubEvents(
+		[]database.Chat{fresh}, codersdk.ChatWatchEventKindContextError)
+	logger.Warn(ctx, "context gate: turn degrades to run without workspace context",
+		slog.F("chat_id", chatSnapshot.ID),
+		slog.F("reason", message))
+	return database.WorkspaceAgent{}, nil
+}
+
+// checkChatContextReported performs one context-gate poll: it re-resolves
+// (and possibly rebinds) the chat's agent, applies the fast-degrade
+// conditions, and reports done=true once the bound agent has a pushed
+// snapshot, at which point the chat is pinned to it. A non-empty
+// degradeReason means the report provably cannot arrive and the caller must
+// degrade the turn. done=false with an empty degradeReason and a nil error
+// means "keep waiting".
+func (server *Server) checkChatContextReported(
+	ctx context.Context,
+	workspaceCtx *turnWorkspaceContext,
+	logger slog.Logger,
+) (agent database.WorkspaceAgent, done bool, degradeReason string, err error) {
+	chatSnapshot, agent, err := workspaceCtx.refreshWorkspaceAgent(ctx)
+	if err != nil {
+		if ctx.Err() != nil {
+			return database.WorkspaceAgent{}, false, "", ctx.Err()
+		}
+		if !xerrors.Is(err, errChatHasNoWorkspaceAgent) {
+			return database.WorkspaceAgent{}, false, "", err
+		}
+		// The latest build has no agent rows. A start build that is still
+		// provisioning will grow them, so keep waiting; any other
+		// transition never will, so degrade immediately.
+		started, buildErr := server.latestBuildIsStart(ctx, chatSnapshot.WorkspaceID)
+		if buildErr != nil {
+			return database.WorkspaceAgent{}, false, "", buildErr
+		}
+		if !started {
+			return database.WorkspaceAgent{}, false, chatContextErrWorkspaceNotStarted, nil
+		}
+		return database.WorkspaceAgent{}, false, "", nil
+	}
+
+	// A resolved binding is kept as-is when the latest build is not a
+	// start transition, so an unpinned chat on a stopped workspace would
+	// otherwise wait the full ceiling for a push that cannot arrive.
+	started, buildErr := server.latestBuildIsStart(ctx, chatSnapshot.WorkspaceID)
+	if buildErr != nil {
+		return database.WorkspaceAgent{}, false, "", buildErr
+	}
+	if !started {
+		return database.WorkspaceAgent{}, false, chatContextErrWorkspaceNotStarted, nil
+	}
+
+	if agentTooOldForContextReport(ctx, agent, logger) {
+		return database.WorkspaceAgent{}, false, chatContextErrAgentTooOld, nil
+	}
+
+	// A disconnected agent cannot push, so waiting on it burns the ceiling
+	// for nothing. This reuses the dial path's disconnect derivation:
+	// agentDisconnectedFor only reports disconnected for agents that
+	// connected at least once, so a never-connected agent (workspace still
+	// starting) remains waitable.
+	if _, disconnected := agentDisconnectedFor(
+		server.clock.Now(), agent, server.agentInactiveDisconnectTimeout,
+	); disconnected {
+		return database.WorkspaceAgent{}, false, chatContextErrAgentDisconnected, nil
+	}
+
+	//nolint:gocritic // Chatd reads the agent's snapshot as the daemon subject.
+	_, _, hasSnapshot, err := latestAgentSnapshot(dbauthz.AsChatd(ctx), server.db, agent.ID)
+	if err != nil {
+		return database.WorkspaceAgent{}, false, "", err
+	}
+	if !hasSnapshot {
+		return database.WorkspaceAgent{}, false, "", nil
+	}
+
+	// The snapshot may have hydrated the chat mid-wait (pushes stamp bound
+	// NULL-hash chats), so reload the row before pinning.
+	fresh, err := workspaceCtx.loadChatSnapshot(ctx, chatSnapshot.ID)
+	if err != nil {
+		return database.WorkspaceAgent{}, false, "", xerrors.Errorf(
+			"reload chat after context report: %w", err)
+	}
+	if !chatContextPinned(fresh) {
+		repinned := false
+		if fresh.ContextAggregateHash == nil {
+			// A never-pinned chat carries a NULL hash, which the push-side
+			// NULL-gated hydrate can stamp; this also never clobbers a
+			// concurrent push that hydrated the chat first. The helper
+			// publishes context_ready for every chat it pins.
+			server.ensureChatContextPinnedOnFirstTurn(ctx, fresh)
+		} else {
+			// A rebind-cleared pin is an empty, non-NULL hash (the postgres
+			// driver encodes the nil clear as an empty bytea), which the
+			// NULL-gated hydrate skips. Re-pin explicitly, mirroring the
+			// refresh endpoint.
+			//nolint:gocritic // Chatd re-pins chats it does not own as the daemon subject.
+			repinCtx := dbauthz.AsChatd(ctx)
+			if err := database.ReadModifyUpdate(server.db, func(tx database.Store) error {
+				return repinChatContext(repinCtx, tx, fresh.ID, fresh.AgentID)
+			}); err != nil {
+				return database.WorkspaceAgent{}, false, "", xerrors.Errorf(
+					"pin chat to reported context: %w", err)
+			}
+			repinned = true
+		}
+		fresh, err = workspaceCtx.loadChatSnapshot(ctx, chatSnapshot.ID)
+		if err != nil {
+			return database.WorkspaceAgent{}, false, "", xerrors.Errorf(
+				"reload chat after context pin: %w", err)
+		}
+		// The repin path commits outside the hydrate helper (which
+		// publishes for the chats it stamps itself), so announce the
+		// freshly pinned context to watchers here.
+		if repinned && chatContextPinned(fresh) {
+			server.publishChatPubsubEvents(
+				[]database.Chat{fresh}, codersdk.ChatWatchEventKindContextReady)
+		}
+	}
+	workspaceCtx.setCurrentChat(fresh)
+	return agent, true, "", nil
+}
+
+// chatContextPinned reports whether the chat carries a meaningful pinned
+// context hash. A NULL hash (never hydrated) and an empty non-NULL hash (a
+// rebind cleared the pin; the postgres driver stores the nil clear as an
+// empty bytea) both count as unpinned.
+func chatContextPinned(chat database.Chat) bool {
+	return len(chat.ContextAggregateHash) > 0
+}
+
+// latestBuildIsStart reports whether the workspace's most recent build is a
+// start transition.
+func (server *Server) latestBuildIsStart(
+	ctx context.Context,
+	workspaceID uuid.NullUUID,
+) (bool, error) {
+	if !workspaceID.Valid {
+		return false, xerrors.New("chat has no workspace")
+	}
+	build, err := server.db.GetLatestWorkspaceBuildByWorkspaceID(ctx, workspaceID.UUID)
+	if err != nil {
+		return false, xerrors.Errorf("get latest workspace build: %w", err)
+	}
+	return build.Transition == database.WorkspaceTransitionStart, nil
+}
+
+// agentTooOldForContextReport reports whether the agent connected with an
+// Agent API version below the context-push minimum. api_version is empty
+// until the agent's first connect, so an agent that has never connected is
+// not considered too old; the gate keeps waiting for it instead. An
+// unparsable version is logged and treated the same way.
+func agentTooOldForContextReport(
+	ctx context.Context,
+	agent database.WorkspaceAgent,
+	logger slog.Logger,
+) bool {
+	if agent.APIVersion == "" {
+		return false
+	}
+	major, minor, err := apiversion.Parse(agent.APIVersion)
+	if err != nil {
+		logger.Warn(ctx, "context gate: unparsable agent api version",
+			slog.F("agent_id", agent.ID),
+			slog.F("api_version", agent.APIVersion),
+			slog.Error(err))
+		return false
+	}
+	if major != contextReportMinAPIMajor {
+		return major < contextReportMinAPIMajor
+	}
+	return minor < contextReportMinAPIMinor
+}

--- a/coderd/x/chatd/context_gate_internal_test.go
+++ b/coderd/x/chatd/context_gate_internal_test.go
@@ -1,0 +1,801 @@
+package chatd
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"cdr.dev/slog/v3/sloggers/slogtest"
+	agentproto "github.com/coder/coder/v2/agent/proto"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
+	coderdpubsub "github.com/coder/coder/v2/coderd/pubsub"
+	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
+	"github.com/coder/coder/v2/coderd/x/chatd/chatprovider"
+	"github.com/coder/coder/v2/coderd/x/chatd/chatstate"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/quartz"
+)
+
+// newGateServer builds a minimal Server for exercising the context-report
+// gate directly against a real database, with a caller-provided clock and
+// wait ceiling. The pubsub carries the context_ready watch events the gate
+// publishes at gate-exit pinning and the context_error events it publishes
+// when a turn degrades.
+func newGateServer(t *testing.T, fix rebindFixture, clk quartz.Clock, ceiling time.Duration) *Server {
+	t.Helper()
+	return &Server{
+		db:                             fix.db,
+		pubsub:                         fix.ps,
+		logger:                         slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		clock:                          clk,
+		contextReportTimeout:           ceiling,
+		agentInactiveDisconnectTimeout: 10 * time.Minute,
+	}
+}
+
+// subscribeChatWatchEvents collects the owner's chat watch events published
+// via pubsub so tests can assert on gate-exit context_ready publishes.
+func subscribeChatWatchEvents(t *testing.T, fix rebindFixture) <-chan codersdk.ChatWatchEvent {
+	t.Helper()
+	events := make(chan codersdk.ChatWatchEvent, 16)
+	cancel, err := fix.ps.Subscribe(
+		coderdpubsub.ChatWatchEventChannel(fix.user.ID),
+		func(_ context.Context, message []byte) {
+			var event codersdk.ChatWatchEvent
+			if err := json.Unmarshal(message, &event); err != nil {
+				return
+			}
+			events <- event
+		})
+	require.NoError(t, err)
+	t.Cleanup(cancel)
+	return events
+}
+
+func newGateTurnContext(t *testing.T, server *Server, chat database.Chat) *turnWorkspaceContext {
+	t.Helper()
+	cur := chat
+	wc := &turnWorkspaceContext{
+		server:           server,
+		chatStateMu:      &sync.Mutex{},
+		currentChat:      &cur,
+		loadChatSnapshot: server.db.GetChatByID,
+	}
+	t.Cleanup(wc.close)
+	return wc
+}
+
+// requireChatDegraded asserts the degrade contract on the chat row: the
+// reason is recorded on context_error, the pinned hash stays NULL (so a
+// later push can still hydrate), and the chat is not in an error state.
+func requireChatDegraded(t *testing.T, fix rebindFixture, chatID uuid.UUID, message string) {
+	t.Helper()
+	post, err := fix.db.GetChatByID(fix.ctx, chatID)
+	require.NoError(t, err)
+	require.Contains(t, post.ContextError, message,
+		"the degrade reason must land on chats.context_error")
+	require.Nil(t, post.ContextAggregateHash,
+		"a degrade must leave the pinned hash NULL so a later push still hydrates")
+	require.NotEqual(t, database.ChatStatusError, post.Status,
+		"a degrade must not put the chat in an error state")
+}
+
+// requireContextErrorEvent asserts the degrade published a context_error
+// watch event carrying the degraded chat's waiting state and error.
+func requireContextErrorEvent(t *testing.T, fix rebindFixture, events <-chan codersdk.ChatWatchEvent, chatID uuid.UUID, message string) {
+	t.Helper()
+	event := testutil.RequireReceive(fix.ctx, t, events)
+	require.Equal(t, codersdk.ChatWatchEventKindContextError, event.Kind,
+		"a degrade publishes a context_error event")
+	require.Equal(t, chatID, event.Chat.ID)
+	require.NotNil(t, event.Chat.Context)
+	require.Equal(t, codersdk.ChatContextStateWaiting, event.Chat.Context.State)
+	require.Contains(t, event.Chat.Context.Error, message)
+}
+
+type gateAwaitResult struct {
+	agent database.WorkspaceAgent
+	err   error
+}
+
+// awaitGateAsync runs awaitChatContextReported in a goroutine so the test can
+// drive the mock clock while the gate waits.
+func awaitGateAsync(ctx context.Context, server *Server, wc *turnWorkspaceContext) <-chan gateAwaitResult {
+	results := make(chan gateAwaitResult, 1)
+	go func() {
+		agent, err := server.awaitChatContextReported(ctx, wc, server.logger)
+		results <- gateAwaitResult{agent: agent, err: err}
+	}()
+	return results
+}
+
+// seedStopBuild appends a stop-transition build so the workspace's latest
+// build is no longer a start.
+func seedStopBuild(t *testing.T, db database.Store, fix rebindFixture) {
+	t.Helper()
+	tv, err := db.GetTemplateVersionByID(fix.ctx, mustLatestBuild(t, db, fix).TemplateVersionID)
+	require.NoError(t, err)
+	job := dbgen.ProvisionerJob(t, db, nil, database.ProvisionerJob{
+		OrganizationID: fix.org.ID,
+		CompletedAt:    sql.NullTime{Valid: true, Time: dbtime.Now()},
+	})
+	dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{
+		WorkspaceID:       fix.ws.ID,
+		TemplateVersionID: tv.ID,
+		JobID:             job.ID,
+		BuildNumber:       mustLatestBuild(t, db, fix).BuildNumber + 1,
+		Transition:        database.WorkspaceTransitionStop,
+	})
+}
+
+// seedStartBuildWithAgent appends a start-transition build carrying a single
+// fresh agent, simulating a workspace rebuild.
+func seedStartBuildWithAgent(t *testing.T, db database.Store, fix rebindFixture) (database.WorkspaceBuild, database.WorkspaceAgent) {
+	t.Helper()
+	tv, err := db.GetTemplateVersionByID(fix.ctx, mustLatestBuild(t, db, fix).TemplateVersionID)
+	require.NoError(t, err)
+	job := dbgen.ProvisionerJob(t, db, nil, database.ProvisionerJob{
+		OrganizationID: fix.org.ID,
+		CompletedAt:    sql.NullTime{Valid: true, Time: dbtime.Now()},
+	})
+	build := dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{
+		WorkspaceID:       fix.ws.ID,
+		TemplateVersionID: tv.ID,
+		JobID:             job.ID,
+		BuildNumber:       mustLatestBuild(t, db, fix).BuildNumber + 1,
+		Transition:        database.WorkspaceTransitionStart,
+	})
+	res := dbgen.WorkspaceResource(t, db, database.WorkspaceResource{
+		Transition: database.WorkspaceTransitionStart,
+		JobID:      job.ID,
+	})
+	agent := dbgen.WorkspaceAgent(t, db, database.WorkspaceAgent{ResourceID: res.ID})
+	return build, agent
+}
+
+func mustLatestBuild(t *testing.T, db database.Store, fix rebindFixture) database.WorkspaceBuild {
+	t.Helper()
+	build, err := db.GetLatestWorkspaceBuildByWorkspaceID(fix.ctx, fix.ws.ID)
+	require.NoError(t, err)
+	return build
+}
+
+func gateChat(t *testing.T, fix rebindFixture, agentID uuid.UUID, buildID uuid.UUID) database.Chat {
+	t.Helper()
+	seed := database.Chat{
+		OwnerID:           fix.user.ID,
+		OrganizationID:    fix.org.ID,
+		LastModelConfigID: fix.model.ID,
+		WorkspaceID:       uuid.NullUUID{UUID: fix.ws.ID, Valid: true},
+		Status:            database.ChatStatusRunning,
+	}
+	if agentID != uuid.Nil {
+		seed.AgentID = uuid.NullUUID{UUID: agentID, Valid: true}
+	}
+	if buildID != uuid.Nil {
+		seed.BuildID = uuid.NullUUID{UUID: buildID, Valid: true}
+	}
+	return dbgen.Chat(t, fix.db, seed)
+}
+
+func TestAwaitChatContextReported(t *testing.T) {
+	t.Parallel()
+
+	// SnapshotAlreadyExists: the bound agent already pushed a snapshot, so
+	// the gate exits on its pre-wait check without any ticker interaction
+	// (the mock clock is never advanced), pins the chat, and announces the
+	// pin with a context_ready watch event.
+	t.Run("SnapshotAlreadyExists", func(t *testing.T) {
+		t.Parallel()
+		fix := newRebindFixture(t)
+		server := newGateServer(t, fix, quartz.NewMock(t), defaultContextReportTimeout)
+		chat := gateChat(t, fix, fix.agentA, fix.buildID)
+		require.Nil(t, chat.ContextAggregateHash)
+		events := subscribeChatWatchEvents(t, fix)
+
+		wc := newGateTurnContext(t, server, chat)
+		agent, err := server.awaitChatContextReported(fix.ctx, wc, server.logger)
+		require.NoError(t, err)
+		require.Equal(t, fix.agentA, agent.ID)
+
+		post, err := fix.db.GetChatByID(fix.ctx, chat.ID)
+		require.NoError(t, err)
+		require.Equal(t, fix.hashA, post.ContextAggregateHash, "gate exit pins the chat to the reported snapshot")
+
+		event := testutil.RequireReceive(fix.ctx, t, events)
+		require.Equal(t, codersdk.ChatWatchEventKindContextReady, event.Kind,
+			"gate-exit pinning publishes a context_ready event")
+		require.Equal(t, chat.ID, event.Chat.ID)
+		require.NotNil(t, event.Chat.Context)
+		require.Equal(t, codersdk.ChatContextStateReady, event.Chat.Context.State)
+	})
+
+	// PinnedSameBuild: a pinned chat whose binding matches the latest start
+	// build skips the gate entirely, even though its agent has no snapshot
+	// row (an entered gate could never exit here).
+	t.Run("PinnedSameBuild", func(t *testing.T) {
+		t.Parallel()
+		fix := newRebindFixture(t)
+		server := newGateServer(t, fix, quartz.NewMock(t), defaultContextReportTimeout)
+		chat := gateChat(t, fix, fix.agentNoSnap, fix.buildID)
+		require.NoError(t, fix.db.SetChatContextSnapshot(fix.ctx, database.SetChatContextSnapshotParams{
+			ID:            chat.ID,
+			AggregateHash: []byte{0xfe},
+		}))
+		chat, err := fix.db.GetChatByID(fix.ctx, chat.ID)
+		require.NoError(t, err)
+		require.NotNil(t, chat.ContextAggregateHash)
+
+		wc := newGateTurnContext(t, server, chat)
+		agent, err := server.awaitChatContextReported(fix.ctx, wc, server.logger)
+		require.NoError(t, err)
+		require.Equal(t, fix.agentNoSnap, agent.ID)
+	})
+
+	// PinnedStopBuild: a pinned chat on a workspace whose latest build is a
+	// stop transition keeps its binding and proceeds from pinned context, as
+	// before the gate existed.
+	t.Run("PinnedStopBuild", func(t *testing.T) {
+		t.Parallel()
+		fix := newRebindFixture(t)
+		server := newGateServer(t, fix, quartz.NewMock(t), defaultContextReportTimeout)
+		chat := gateChat(t, fix, fix.agentA, fix.buildID)
+		_, hydrateErr := fix.db.HydrateAgentChatsContext(fix.ctx, database.HydrateAgentChatsContextParams{
+			AgentID:       fix.agentA,
+			AggregateHash: fix.hashA,
+		})
+		require.NoError(t, hydrateErr)
+		seedStopBuild(t, fix.db, fix)
+
+		chat, err := fix.db.GetChatByID(fix.ctx, chat.ID)
+		require.NoError(t, err)
+		wc := newGateTurnContext(t, server, chat)
+		agent, err := server.awaitChatContextReported(fix.ctx, wc, server.logger)
+		require.NoError(t, err)
+		require.Equal(t, fix.agentA, agent.ID, "the stop build does not steal the binding")
+
+		post, err := fix.db.GetChatByID(fix.ctx, chat.ID)
+		require.NoError(t, err)
+		require.Equal(t, fix.hashA, post.ContextAggregateHash, "pinned context survives the stop build")
+	})
+
+	// StopBuildUnpinned: an unpinned chat cannot receive a context report
+	// from a workspace whose latest build is not a start, so the gate
+	// degrades immediately: the turn proceeds without error, the reason is
+	// recorded on chats.context_error, and a context_error watch event is
+	// published. Covered both when the old agent binding still resolves and
+	// when no agent is bound at all.
+	t.Run("StopBuildUnpinned", func(t *testing.T) {
+		t.Parallel()
+		for _, bound := range []bool{true, false} {
+			name := "Bound"
+			if !bound {
+				name = "Unbound"
+			}
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				fix := newRebindFixture(t)
+				server := newGateServer(t, fix, quartz.NewMock(t), defaultContextReportTimeout)
+				agentID := uuid.Nil
+				buildID := uuid.Nil
+				if bound {
+					agentID = fix.agentNoSnap
+					buildID = fix.buildID
+				}
+				chat := gateChat(t, fix, agentID, buildID)
+				seedStopBuild(t, fix.db, fix)
+				events := subscribeChatWatchEvents(t, fix)
+
+				wc := newGateTurnContext(t, server, chat)
+				agent, err := server.awaitChatContextReported(fix.ctx, wc, server.logger)
+				require.NoError(t, err, "the gate must not fail the turn")
+				require.Equal(t, uuid.Nil, agent.ID, "a degraded turn runs with the zero-value agent")
+
+				requireChatDegraded(t, fix, chat.ID,
+					"workspace must be started to report chat context")
+				requireContextErrorEvent(t, fix, events, chat.ID,
+					"workspace must be started to report chat context")
+			})
+		}
+	})
+
+	// AgentTooOld: an agent that connected with an Agent API below 2.10 can
+	// never push context, so the gate degrades immediately instead of
+	// waiting out the ceiling.
+	t.Run("AgentTooOld", func(t *testing.T) {
+		t.Parallel()
+		fix := newRebindFixture(t)
+		server := newGateServer(t, fix, quartz.NewMock(t), defaultContextReportTimeout)
+		require.NoError(t, fix.db.UpdateWorkspaceAgentStartupByID(fix.ctx, database.UpdateWorkspaceAgentStartupByIDParams{
+			ID:         fix.agentNoSnap,
+			Version:    "v2.0.0",
+			APIVersion: "2.0",
+			Subsystems: []database.WorkspaceAgentSubsystem{},
+		}))
+		chat := gateChat(t, fix, fix.agentNoSnap, fix.buildID)
+		events := subscribeChatWatchEvents(t, fix)
+
+		wc := newGateTurnContext(t, server, chat)
+		agent, err := server.awaitChatContextReported(fix.ctx, wc, server.logger)
+		require.NoError(t, err, "the gate must not fail the turn")
+		require.Equal(t, uuid.Nil, agent.ID)
+
+		requireChatDegraded(t, fix, chat.ID,
+			"workspace agent is too old to report chat context")
+		requireContextErrorEvent(t, fix, events, chat.ID,
+			"workspace agent is too old to report chat context")
+	})
+
+	// DisconnectedAgentDegradesImmediately: an agent that connected once and
+	// then disconnected cannot push, so the gate degrades immediately
+	// instead of waiting out the ceiling. This mirrors the dial path's
+	// disconnect derivation; a never-connected agent stays waitable.
+	t.Run("DisconnectedAgentDegradesImmediately", func(t *testing.T) {
+		t.Parallel()
+		fix := newRebindFixture(t)
+		server := newGateServer(t, fix, quartz.NewMock(t), defaultContextReportTimeout)
+		connectedAt := dbtime.Now().Add(-time.Hour)
+		require.NoError(t, fix.db.UpdateWorkspaceAgentConnectionByID(fix.ctx, database.UpdateWorkspaceAgentConnectionByIDParams{
+			ID:               fix.agentNoSnap,
+			FirstConnectedAt: sql.NullTime{Valid: true, Time: connectedAt},
+			LastConnectedAt:  sql.NullTime{Valid: true, Time: connectedAt},
+			DisconnectedAt:   sql.NullTime{Valid: true, Time: connectedAt.Add(time.Minute)},
+			UpdatedAt:        dbtime.Now(),
+		}))
+		chat := gateChat(t, fix, fix.agentNoSnap, fix.buildID)
+		events := subscribeChatWatchEvents(t, fix)
+
+		wc := newGateTurnContext(t, server, chat)
+		agent, err := server.awaitChatContextReported(fix.ctx, wc, server.logger)
+		require.NoError(t, err, "the gate must not fail the turn")
+		require.Equal(t, uuid.Nil, agent.ID)
+
+		requireChatDegraded(t, fix, chat.ID,
+			"workspace agent is not connected, so it cannot report chat context")
+		requireContextErrorEvent(t, fix, events, chat.ID,
+			"workspace agent is not connected, so it cannot report chat context")
+	})
+
+	// DegradeMemorySkipsWait: an unpinned chat whose context_error is
+	// already non-empty degraded on a previous turn (that is the only way an
+	// unpinned chat gains one), so the gate degrades again immediately,
+	// keeping the message, without any ticker interaction (the mock clock is
+	// never advanced).
+	t.Run("DegradeMemorySkipsWait", func(t *testing.T) {
+		t.Parallel()
+		fix := newRebindFixture(t)
+		server := newGateServer(t, fix, quartz.NewMock(t), defaultContextReportTimeout)
+		chat := gateChat(t, fix, fix.agentNoSnap, fix.buildID)
+		require.NoError(t, fix.db.UpdateChatContextError(fix.ctx, database.UpdateChatContextErrorParams{
+			ID:           chat.ID,
+			ContextError: "workspace agent did not report chat context within 15m0s",
+		}))
+		chat, err := fix.db.GetChatByID(fix.ctx, chat.ID)
+		require.NoError(t, err)
+		events := subscribeChatWatchEvents(t, fix)
+
+		// The workspace is started and the agent is waitable, so without
+		// the degrade memory this call would stall on the ticker; the mock
+		// clock is never advanced, so an immediate return proves the memory
+		// short-circuits the wait.
+		wc := newGateTurnContext(t, server, chat)
+		agent, err := server.awaitChatContextReported(fix.ctx, wc, server.logger)
+		require.NoError(t, err, "the gate must not fail the turn")
+		require.Equal(t, uuid.Nil, agent.ID)
+
+		requireChatDegraded(t, fix, chat.ID,
+			"workspace agent did not report chat context within 15m0s")
+		requireContextErrorEvent(t, fix, events, chat.ID,
+			"workspace agent did not report chat context within 15m0s")
+	})
+
+	// PushAfterDegradeHydratesAndClearsError: a degrade leaves the pinned
+	// hash NULL, so a later agent push still hydrates the chat, overwrites
+	// the context error, and the next gate call proceeds pinned. This is the
+	// self-heal path.
+	t.Run("PushAfterDegradeHydratesAndClearsError", func(t *testing.T) {
+		t.Parallel()
+		fix := newRebindFixture(t)
+		server := newGateServer(t, fix, quartz.NewMock(t), defaultContextReportTimeout)
+		// A too-old agent degrades the first turn immediately.
+		require.NoError(t, fix.db.UpdateWorkspaceAgentStartupByID(fix.ctx, database.UpdateWorkspaceAgentStartupByIDParams{
+			ID:         fix.agentNoSnap,
+			Version:    "v2.0.0",
+			APIVersion: "2.0",
+			Subsystems: []database.WorkspaceAgentSubsystem{},
+		}))
+		chat := gateChat(t, fix, fix.agentNoSnap, fix.buildID)
+
+		wc := newGateTurnContext(t, server, chat)
+		_, err := server.awaitChatContextReported(fix.ctx, wc, server.logger)
+		require.NoError(t, err)
+		requireChatDegraded(t, fix, chat.ID,
+			"workspace agent is too old to report chat context")
+
+		// The agent's push arrives later: the NULL-gated hydrate stamps the
+		// hash and replaces the degrade error in one statement.
+		hash := []byte{0xee}
+		seedAgentContext(fix.ctx, t, fix.db, fix.agentNoSnap, "/home/coder/AGENTS.md", hash,
+			database.WorkspaceAgentContextBodyKindInstructionFile,
+			json.RawMessage(`{"instruction_file":{"content":"healed"}}`))
+		hydrated, err := fix.db.HydrateAgentChatsContext(fix.ctx, database.HydrateAgentChatsContextParams{
+			AgentID:       fix.agentNoSnap,
+			AggregateHash: hash,
+		})
+		require.NoError(t, err)
+		require.Contains(t, hydrated, chat.ID, "the degraded chat is still NULL-hash hydratable")
+
+		post, err := fix.db.GetChatByID(fix.ctx, chat.ID)
+		require.NoError(t, err)
+		require.Equal(t, hash, post.ContextAggregateHash, "the push pins the chat")
+		require.Empty(t, post.ContextError, "the push overwrites the degrade error")
+
+		// The next gate call proceeds pinned, with the agent resolved.
+		wc2 := newGateTurnContext(t, server, post)
+		agent, err := server.awaitChatContextReported(fix.ctx, wc2, server.logger)
+		require.NoError(t, err)
+		require.Equal(t, fix.agentNoSnap, agent.ID)
+	})
+
+	// WaitsForPush: an unpinned chat whose agent has not pushed waits on the
+	// gate ticker; a snapshot that appears mid-wait is picked up on the next
+	// tick, the chat is pinned to it, and the turn proceeds.
+	t.Run("WaitsForPush", func(t *testing.T) {
+		t.Parallel()
+		fix := newRebindFixture(t)
+		mClock := quartz.NewMock(t)
+		trap := mClock.Trap().NewTicker(contextReportTimerTagGroup, contextReportTickerTag)
+		defer trap.Close()
+		server := newGateServer(t, fix, mClock, defaultContextReportTimeout)
+		chat := gateChat(t, fix, fix.agentNoSnap, fix.buildID)
+
+		wc := newGateTurnContext(t, server, chat)
+		results := awaitGateAsync(fix.ctx, server, wc)
+
+		// The gate found no snapshot and started waiting.
+		trap.MustWait(fix.ctx).MustRelease(fix.ctx)
+
+		// One empty tick: still nothing to report.
+		mClock.Advance(contextReportPollInterval).MustWait(fix.ctx)
+		select {
+		case res := <-results:
+			t.Fatalf("gate exited before a snapshot existed: %+v", res)
+		default:
+		}
+
+		// The agent's first push arrives mid-wait; the next tick sees it.
+		hash := []byte{0xcc}
+		seedAgentContext(fix.ctx, t, fix.db, fix.agentNoSnap, "/home/coder/AGENTS.md", hash,
+			database.WorkspaceAgentContextBodyKindInstructionFile,
+			json.RawMessage(`{"instruction_file":{"content":"pushed mid-wait"}}`))
+		mClock.Advance(contextReportPollInterval).MustWait(fix.ctx)
+
+		res := testutil.RequireReceive(fix.ctx, t, results)
+		require.NoError(t, res.err)
+		require.Equal(t, fix.agentNoSnap, res.agent.ID)
+
+		post, err := fix.db.GetChatByID(fix.ctx, chat.ID)
+		require.NoError(t, err)
+		require.Equal(t, hash, post.ContextAggregateHash, "gate exit pins the mid-wait push")
+	})
+
+	// CeilingElapses: an agent that never reports degrades the turn once
+	// the ceiling passes: the turn proceeds without error and the wait is
+	// named in the recorded context error. The ceiling is deliberately not
+	// a multiple of the poll interval so the timeout fires alone.
+	t.Run("CeilingElapses", func(t *testing.T) {
+		t.Parallel()
+		fix := newRebindFixture(t)
+		mClock := quartz.NewMock(t)
+		trap := mClock.Trap().NewTicker(contextReportTimerTagGroup, contextReportTickerTag)
+		defer trap.Close()
+		ceiling := 2500 * time.Millisecond
+		server := newGateServer(t, fix, mClock, ceiling)
+		chat := gateChat(t, fix, fix.agentNoSnap, fix.buildID)
+		events := subscribeChatWatchEvents(t, fix)
+
+		wc := newGateTurnContext(t, server, chat)
+		results := awaitGateAsync(fix.ctx, server, wc)
+		trap.MustWait(fix.ctx).MustRelease(fix.ctx)
+
+		mClock.Advance(contextReportPollInterval).MustWait(fix.ctx)
+		mClock.Advance(contextReportPollInterval).MustWait(fix.ctx)
+		mClock.Advance(ceiling - 2*contextReportPollInterval).MustWait(fix.ctx)
+
+		res := testutil.RequireReceive(fix.ctx, t, results)
+		require.NoError(t, res.err, "the gate must not fail the turn")
+		require.Equal(t, uuid.Nil, res.agent.ID)
+
+		requireChatDegraded(t, fix, chat.ID,
+			"workspace agent did not report chat context within 2.5s")
+		requireContextErrorEvent(t, fix, events, chat.ID,
+			"workspace agent did not report chat context within 2.5s")
+	})
+
+	// InterruptDuringWait: canceling the turn context mid-wait propagates
+	// the cancellation unchanged so the interrupt path sees a plain context
+	// error, not a degrade that would pollute the chat's context state.
+	t.Run("InterruptDuringWait", func(t *testing.T) {
+		t.Parallel()
+		fix := newRebindFixture(t)
+		mClock := quartz.NewMock(t)
+		trap := mClock.Trap().NewTicker(contextReportTimerTagGroup, contextReportTickerTag)
+		defer trap.Close()
+		server := newGateServer(t, fix, mClock, defaultContextReportTimeout)
+		chat := gateChat(t, fix, fix.agentNoSnap, fix.buildID)
+
+		turnCtx, cancel := context.WithCancel(fix.ctx)
+		wc := newGateTurnContext(t, server, chat)
+		results := awaitGateAsync(turnCtx, server, wc)
+		trap.MustWait(fix.ctx).MustRelease(fix.ctx)
+
+		cancel()
+		res := testutil.RequireReceive(fix.ctx, t, results)
+		require.ErrorIs(t, res.err, context.Canceled)
+
+		post, err := fix.db.GetChatByID(fix.ctx, chat.ID)
+		require.NoError(t, err)
+		require.Empty(t, post.ContextError, "an interrupt is not a degrade")
+	})
+
+	// RebindOnNewStartBuild: a pinned chat bound to a previous build's agent
+	// is rebound to the new start build's agent at turn prep. The rebind
+	// re-pins, which clears the pinned context because the new agent has not
+	// pushed, so the gate then waits for the new agent's report and pins the
+	// chat to it.
+	t.Run("RebindOnNewStartBuild", func(t *testing.T) {
+		t.Parallel()
+		fix := newRebindFixture(t)
+		mClock := quartz.NewMock(t)
+		trap := mClock.Trap().NewTicker(contextReportTimerTagGroup, contextReportTickerTag)
+		defer trap.Close()
+		server := newGateServer(t, fix, mClock, defaultContextReportTimeout)
+
+		chat := gateChat(t, fix, fix.agentA, fix.buildID)
+		_, hydrateErr := fix.db.HydrateAgentChatsContext(fix.ctx, database.HydrateAgentChatsContextParams{
+			AgentID:       fix.agentA,
+			AggregateHash: fix.hashA,
+		})
+		require.NoError(t, hydrateErr)
+		newBuild, newAgent := seedStartBuildWithAgent(t, fix.db, fix)
+
+		chat, err := fix.db.GetChatByID(fix.ctx, chat.ID)
+		require.NoError(t, err)
+		require.Equal(t, fix.hashA, chat.ContextAggregateHash, "chat starts pinned to the old agent")
+
+		wc := newGateTurnContext(t, server, chat)
+		results := awaitGateAsync(fix.ctx, server, wc)
+		trap.MustWait(fix.ctx).MustRelease(fix.ctx)
+
+		// The rebind committed before the gate started waiting: the chat now
+		// points at the new build's agent and its stale pin is cleared.
+		mid, err := fix.db.GetChatByID(fix.ctx, chat.ID)
+		require.NoError(t, err)
+		require.Equal(t, newAgent.ID, mid.AgentID.UUID, "prep rebinds to the new build's agent")
+		require.Equal(t, newBuild.ID, mid.BuildID.UUID)
+		require.Empty(t, mid.ContextAggregateHash, "re-pin clears the old agent's pinned context")
+
+		// Subscribe after the rebind so the received event is the gate-exit
+		// re-pin's context_ready, not noise from earlier writes.
+		events := subscribeChatWatchEvents(t, fix)
+
+		hash := []byte{0xdd}
+		seedAgentContext(fix.ctx, t, fix.db, newAgent.ID, "/home/coder/AGENTS.md", hash,
+			database.WorkspaceAgentContextBodyKindInstructionFile,
+			json.RawMessage(`{"instruction_file":{"content":"new build context"}}`))
+		mClock.Advance(contextReportPollInterval).MustWait(fix.ctx)
+
+		res := testutil.RequireReceive(fix.ctx, t, results)
+		require.NoError(t, res.err)
+		require.Equal(t, newAgent.ID, res.agent.ID)
+
+		post, err := fix.db.GetChatByID(fix.ctx, chat.ID)
+		require.NoError(t, err)
+		require.Equal(t, hash, post.ContextAggregateHash, "chat hydrates with the new agent's context")
+		resources, err := fix.db.ListChatContextResourcesByChatID(fix.ctx, chat.ID)
+		require.NoError(t, err)
+		require.Len(t, resources, 1)
+		require.Equal(t, "/home/coder/AGENTS.md", resources[0].Source)
+
+		// The re-pin branch (empty non-NULL hash) publishes context_ready
+		// once the pin commits.
+		event := testutil.RequireReceive(fix.ctx, t, events)
+		require.Equal(t, codersdk.ChatWatchEventKindContextReady, event.Kind,
+			"gate-exit re-pinning publishes a context_ready event")
+		require.Equal(t, chat.ID, event.Chat.ID)
+		require.NotNil(t, event.Chat.Context)
+		require.Equal(t, codersdk.ChatContextStateReady, event.Chat.Context.State)
+	})
+}
+
+// TestPrepareGenerationContextGate proves the gate end to end through
+// prepareGeneration: an unpinned workspace chat blocks until the agent's
+// first push, then the prepared turn carries the pushed context (the
+// instruction lands in the system prompt inputs and the pushed MCP server
+// yields a workspace MCP tool).
+func TestPrepareGenerationContextGate(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	ctx := chatdTestContext(t)
+	mClock := quartz.NewMock(t)
+	trap := mClock.Trap().NewTicker(contextReportTimerTagGroup, contextReportTickerTag)
+	defer trap.Close()
+
+	user := dbgen.User(t, db, database.User{})
+	apiKey, _ := dbgen.APIKey(t, db, database.APIKey{UserID: user.ID})
+	org := dbgen.Organization(t, db, database.Organization{})
+	dbgen.OrganizationMember(t, db, database.OrganizationMember{
+		UserID:         user.ID,
+		OrganizationID: org.ID,
+	})
+	provider := dbgen.AIProviderWithOptionalKey(t, db, database.AIProvider{
+		Type: database.AIProviderTypeOpenai,
+	}, "test-key")
+	modelConfig := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
+		Model:        "gpt-4o-mini",
+		AIProviderID: uuid.NullUUID{UUID: provider.ID, Valid: true},
+	}, func(p *database.InsertChatModelConfigParams) {
+		p.Enabled = true
+	})
+
+	// A workspace whose agent has not pushed any context yet.
+	tv := dbgen.TemplateVersion(t, db, database.TemplateVersion{
+		OrganizationID: org.ID,
+		CreatedBy:      user.ID,
+	})
+	tmpl := dbgen.Template(t, db, database.Template{
+		OrganizationID:  org.ID,
+		ActiveVersionID: tv.ID,
+		CreatedBy:       user.ID,
+	})
+	ws := dbgen.Workspace(t, db, database.WorkspaceTable{
+		OwnerID:        user.ID,
+		OrganizationID: org.ID,
+		TemplateID:     tmpl.ID,
+	})
+	pj := dbgen.ProvisionerJob(t, db, nil, database.ProvisionerJob{
+		OrganizationID: org.ID,
+		CompletedAt:    sql.NullTime{Valid: true, Time: dbtime.Now()},
+	})
+	dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{
+		WorkspaceID:       ws.ID,
+		TemplateVersionID: tv.ID,
+		JobID:             pj.ID,
+		Transition:        database.WorkspaceTransitionStart,
+	})
+	res := dbgen.WorkspaceResource(t, db, database.WorkspaceResource{
+		Transition: database.WorkspaceTransitionStart,
+		JobID:      pj.ID,
+	})
+	agent := dbgen.WorkspaceAgent(t, db, database.WorkspaceAgent{ResourceID: res.ID})
+
+	created, err := chatstate.CreateChat(ctx, db, ps, chatstate.CreateChatInput{
+		OrganizationID:    org.ID,
+		OwnerID:           user.ID,
+		WorkspaceID:       uuid.NullUUID{UUID: ws.ID, Valid: true},
+		LastModelConfigID: modelConfig.ID,
+		Title:             "context gate end to end",
+		ClientType:        database.ChatClientTypeApi,
+		InitialMessages: []chatstate.Message{
+			{
+				Role:           database.ChatMessageRoleUser,
+				Content:        mustMarshalText(t, "hello"),
+				Visibility:     database.ChatMessageVisibilityBoth,
+				ModelConfigID:  uuid.NullUUID{UUID: modelConfig.ID, Valid: true},
+				CreatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
+				ContentVersion: chatprompt.CurrentContentVersion,
+				APIKeyID:       sql.NullString{String: apiKey.ID, Valid: true},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	server := newInternalTestServer(
+		t,
+		db,
+		ps,
+		chatprovider.ProviderAPIKeys{},
+		withInternalTestServerClock(mClock),
+		withInternalTestServerTransportFactory(&aibridgeTestFactory{}),
+	)
+
+	type prepareResult struct {
+		prepared generationPrepared
+		err      error
+	}
+	results := make(chan prepareResult, 1)
+	go func() {
+		prepared, err := server.prepareGeneration(ctx, generationPrepareInput{
+			Chat:     created.Chat,
+			Messages: created.InitialMessages,
+		})
+		results <- prepareResult{prepared: prepared, err: err}
+	}()
+
+	// The gate is waiting: the agent has no snapshot yet.
+	trap.MustWait(ctx).MustRelease(ctx)
+
+	// The agent's first push arrives while the turn waits: an instruction
+	// file and an MCP server with one tool.
+	now := dbtime.Now()
+	hash := []byte{0xab, 0xcd}
+	_, err = db.UpsertWorkspaceAgentContextSnapshot(ctx, database.UpsertWorkspaceAgentContextSnapshotParams{
+		WorkspaceAgentID: agent.ID,
+		Version:          1,
+		AggregateHash:    hash,
+		ReceivedAt:       now,
+	})
+	require.NoError(t, err)
+	instructionBody, err := protojson.Marshal(&agentproto.InstructionFileBody{Content: []byte("gate instruction content")})
+	require.NoError(t, err)
+	_, err = db.UpsertWorkspaceAgentContextResource(ctx, database.UpsertWorkspaceAgentContextResourceParams{
+		WorkspaceAgentID: agent.ID,
+		Source:           "/home/coder/AGENTS.md",
+		BodyKind:         database.WorkspaceAgentContextBodyKindInstructionFile,
+		Body:             instructionBody,
+		ContentHash:      hash,
+		SizeBytes:        int64(len(instructionBody)),
+		Status:           database.WorkspaceAgentContextResourceStatusOk,
+		Now:              now,
+	})
+	require.NoError(t, err)
+	schema, err := structpb.NewStruct(map[string]any{
+		"type":       "object",
+		"properties": map[string]any{"input": map[string]any{"type": "string"}},
+	})
+	require.NoError(t, err)
+	mcpBody, err := protojson.Marshal(&agentproto.MCPServerBody{
+		ServerName: "gatesrv",
+		Tools: []*agentproto.MCPTool{{
+			Name:        "echo",
+			Description: "gate echo tool",
+			InputSchema: schema,
+		}},
+	})
+	require.NoError(t, err)
+	_, err = db.UpsertWorkspaceAgentContextResource(ctx, database.UpsertWorkspaceAgentContextResourceParams{
+		WorkspaceAgentID: agent.ID,
+		Source:           "gatesrv",
+		BodyKind:         database.WorkspaceAgentContextBodyKindMcpServer,
+		Body:             mcpBody,
+		ContentHash:      hash,
+		SizeBytes:        int64(len(mcpBody)),
+		Status:           database.WorkspaceAgentContextResourceStatusOk,
+		Now:              now,
+	})
+	require.NoError(t, err)
+
+	mClock.Advance(contextReportPollInterval).MustWait(ctx)
+
+	result := testutil.RequireReceive(ctx, t, results)
+	require.NoError(t, result.err)
+	t.Cleanup(result.prepared.Cleanup)
+
+	require.Equal(t, agent.ID, result.prepared.Chat.AgentID.UUID, "turn prep bound the chat to the agent")
+
+	// The pushed MCP server surfaces as a workspace MCP tool on the turn.
+	require.NotNil(t, findToolByName(result.prepared.Tools, "gatesrv__echo"),
+		"pushed MCP server must yield a workspace MCP tool")
+
+	// The pushed instruction file lands in the system prompt.
+	promptText := systemPromptText(t, result.prepared.Prompt)
+	require.Contains(t, promptText, "gate instruction content",
+		"pushed instruction file must land in the system prompt")
+
+	post, err := db.GetChatByID(ctx, created.Chat.ID)
+	require.NoError(t, err)
+	require.Equal(t, hash, post.ContextAggregateHash, "the turn pinned the pushed snapshot")
+}

--- a/coderd/x/chatd/context_hydration.go
+++ b/coderd/x/chatd/context_hydration.go
@@ -33,11 +33,12 @@ func latestAgentSnapshot(ctx context.Context, db database.Store, agentID uuid.UU
 // inside the PushContextState transaction: it stamps the pushed snapshot hash
 // on chats for the agent that have not been hydrated yet, then flips
 // already-pinned chats whose hash differs to dirty. It returns a callback
-// that publishes a context watch event for every chat it touched; the caller
-// invokes it only after the transaction commits, and the callback is a no-op
-// when no chat was hydrated or dirtied. Hydrated chats start clean (no dirty
-// marker), but still need the event: watching clients cached their details
-// without pinned resources and refetch only on context events.
+// that publishes the watch events (context_ready for first hydrations,
+// context_dirty for drifted chats); the caller invokes it only after the
+// transaction commits, and the callback is a no-op when no chat was hydrated
+// or dirtied. Hydrated chats start clean (no dirty marker), but still need
+// their event: watching clients cached their details without pinned
+// resources and refetch only on context events.
 //
 // The pinned hash on dirtied chats is intentionally left unchanged; the
 // refresh endpoint re-pins it.
@@ -66,31 +67,36 @@ func (p *Server) HydrateAndMarkChatsDirty(ctx context.Context, tx database.Store
 	}
 	// Hydrated chats had a NULL hash and dirtied chats a non-NULL one, so
 	// the two sets never overlap.
-	touched := make([]uuid.UUID, 0, len(hydrated)+len(dirtied))
-	touched = append(touched, hydrated...)
-	for _, d := range dirtied {
-		touched = append(touched, d.ID)
-	}
-	if len(touched) == 0 {
+	if len(hydrated) == 0 && len(dirtied) == 0 {
 		return func() {}, nil
 	}
 
-	// Read the touched chats inside the transaction and capture their rows so
-	// the post-commit callback needs no database access: the published payload
-	// reflects the just-committed state (no re-read a concurrent refresh
-	// could race), and the callback does not depend on the request-scoped
-	// context surviving past commit. Only the transitioned chats are read.
-	touchedChats := make([]database.Chat, 0, len(touched))
-	for _, id := range touched {
+	// Read the transitioned chats inside the transaction and capture their
+	// rows so the post-commit callback needs no database access: the
+	// published payload reflects the just-committed state (no re-read a
+	// concurrent refresh could race), and the callback does not depend on
+	// the request-scoped context surviving past commit. Only the
+	// transitioned chats are read.
+	readyChats := make([]database.Chat, 0, len(hydrated))
+	for _, id := range hydrated {
 		chat, err := tx.GetChatByID(ctx, id)
 		if err != nil {
-			return nil, xerrors.Errorf("get touched chat %s: %w", id, err)
+			return nil, xerrors.Errorf("get hydrated chat %s: %w", id, err)
 		}
-		touchedChats = append(touchedChats, chat)
+		readyChats = append(readyChats, chat)
+	}
+	dirtyChats := make([]database.Chat, 0, len(dirtied))
+	for _, d := range dirtied {
+		chat, err := tx.GetChatByID(ctx, d.ID)
+		if err != nil {
+			return nil, xerrors.Errorf("get dirtied chat %s: %w", d.ID, err)
+		}
+		dirtyChats = append(dirtyChats, chat)
 	}
 
 	return func() {
-		p.publishChatPubsubEvents(touchedChats, codersdk.ChatWatchEventKindContextDirty)
+		p.publishChatPubsubEvents(readyChats, codersdk.ChatWatchEventKindContextReady)
+		p.publishChatPubsubEvents(dirtyChats, codersdk.ChatWatchEventKindContextDirty)
 	}, nil
 }
 
@@ -160,9 +166,9 @@ func (p *Server) hydrateChatContextOnCreate(ctx context.Context, chat database.C
 // empty state. The NULL-hash gate also leaves dirtied chats alone: their stale
 // pinned hash is non-NULL until the refresh endpoint re-pins. Hydration
 // pins every unpinned chat bound to the agent in one statement, so a
-// context watch event is published for each pinned chat: watching clients
-// cached those chats' details without pinned resources and need to
-// refetch. Best-effort: failures are logged and swallowed so they never
+// context_ready watch event is published for each pinned chat: watching
+// clients cached those chats' details without pinned resources and need
+// to refetch. Best-effort: failures are logged and swallowed so they never
 // fail the turn.
 func (p *Server) ensureChatContextPinnedOnFirstTurn(ctx context.Context, chat database.Chat) {
 	if !chat.AgentID.Valid || chat.ContextAggregateHash != nil {
@@ -191,7 +197,7 @@ func (p *Server) ensureChatContextPinnedOnFirstTurn(ctx context.Context, chat da
 		}
 		pinnedChats = append(pinnedChats, pinned)
 	}
-	p.publishChatPubsubEvents(pinnedChats, codersdk.ChatWatchEventKindContextDirty)
+	p.publishChatPubsubEvents(pinnedChats, codersdk.ChatWatchEventKindContextReady)
 }
 
 // repinChatContext re-pins a single chat to its agent's latest context

--- a/coderd/x/chatd/context_hydration_internal_test.go
+++ b/coderd/x/chatd/context_hydration_internal_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -13,6 +12,7 @@ import (
 	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
 	dbpubsub "github.com/coder/coder/v2/coderd/database/pubsub"
 	coderdpubsub "github.com/coder/coder/v2/coderd/pubsub"
 	"github.com/coder/coder/v2/codersdk"
@@ -90,62 +90,6 @@ func TestHydrateChatContextOnCreate(t *testing.T) {
 	})
 }
 
-// TestHydrateAndMarkChatsDirtyPublishesForHydratedAndDirtied covers the
-// agent-push path: a chat hydrated by the push (first pin, no dirty marker)
-// and a chat flipped to dirty must both get a context watch event, because
-// watching clients refetch pinned resources only on those events.
-func TestHydrateAndMarkChatsDirtyPublishesForHydratedAndDirtied(t *testing.T) {
-	t.Parallel()
-	ctx := testutil.Context(t, testutil.WaitShort)
-	ctrl := gomock.NewController(t)
-	db := dbmock.NewMockStore(ctrl)
-	ps := dbpubsub.NewInMemory()
-	server := &Server{db: db, logger: slogtest.Make(t, nil), pubsub: ps}
-
-	ownerID := uuid.New()
-	agentID := uuid.New()
-	hash := []byte{0x01}
-	now := time.Now()
-
-	hydratedChat := database.Chat{ID: uuid.New(), OwnerID: ownerID, ContextAggregateHash: hash}
-	dirtiedChat := database.Chat{ID: uuid.New(), OwnerID: ownerID, ContextAggregateHash: []byte{0x99}}
-
-	events := make(chan codersdk.ChatWatchEvent, 2)
-	cancelSub, err := ps.SubscribeWithErr(
-		coderdpubsub.ChatWatchEventChannel(ownerID),
-		coderdpubsub.HandleChatWatchEvent(func(_ context.Context, payload codersdk.ChatWatchEvent, err error) {
-			require.NoError(t, err)
-			events <- payload
-		}),
-	)
-	require.NoError(t, err)
-	defer cancelSub()
-
-	db.EXPECT().HydrateAgentChatsContext(gomock.Any(), database.HydrateAgentChatsContextParams{
-		AgentID:       agentID,
-		AggregateHash: hash,
-	}).Return([]uuid.UUID{hydratedChat.ID}, nil)
-	db.EXPECT().MarkChatsContextDirtyByAgent(gomock.Any(), database.MarkChatsContextDirtyByAgentParams{
-		AgentID:       agentID,
-		AggregateHash: hash,
-		DirtySince:    sql.NullTime{Time: now, Valid: true},
-	}).Return([]database.MarkChatsContextDirtyByAgentRow{{ID: dirtiedChat.ID, OwnerID: ownerID}}, nil)
-	db.EXPECT().GetChatByID(gomock.Any(), hydratedChat.ID).Return(hydratedChat, nil)
-	db.EXPECT().GetChatByID(gomock.Any(), dirtiedChat.ID).Return(dirtiedChat, nil)
-
-	publish, err := server.HydrateAndMarkChatsDirty(ctx, db, agentID, hash, "", now)
-	require.NoError(t, err)
-	publish()
-
-	gotChatIDs := make([]uuid.UUID, 0, 2)
-	for range 2 {
-		event := testutil.RequireReceive(ctx, t, events)
-		require.Equal(t, codersdk.ChatWatchEventKindContextDirty, event.Kind)
-		gotChatIDs = append(gotChatIDs, event.Chat.ID)
-	}
-	require.ElementsMatch(t, []uuid.UUID{hydratedChat.ID, dirtiedChat.ID}, gotChatIDs)
-}
-
 // TestEnsureChatContextPinnedOnFirstTurn covers the lazy-bind pinning path. An
 // API-created chat carries no agent at create, binds its agent on the first
 // turn, and must pin the agent's already-pushed snapshot then. This is the
@@ -207,11 +151,11 @@ func TestEnsureChatContextPinnedOnFirstTurn(t *testing.T) {
 		server.ensureChatContextPinnedOnFirstTurn(ctx, chat)
 
 		// Watching clients cached both details without pinned resources, so
-		// every hydrated chat must broadcast a context event.
+		// every hydrated chat must broadcast a context_ready event.
 		gotChatIDs := make([]uuid.UUID, 0, 2)
 		for range 2 {
 			event := testutil.RequireReceive(ctx, t, events)
-			require.Equal(t, codersdk.ChatWatchEventKindContextDirty, event.Kind)
+			require.Equal(t, codersdk.ChatWatchEventKindContextReady, event.Kind)
 			gotChatIDs = append(gotChatIDs, event.Chat.ID)
 		}
 		require.ElementsMatch(t, []uuid.UUID{chat.ID, siblingChat.ID}, gotChatIDs)
@@ -266,4 +210,55 @@ func TestEnsureChatContextPinnedOnFirstTurn(t *testing.T) {
 
 		server.ensureChatContextPinnedOnFirstTurn(ctx, database.Chat{ID: uuid.New()})
 	})
+}
+
+// TestHydrateAndMarkChatsDirtyPublishesEvents proves the push-path fan-out
+// against a real database: the returned post-commit callback publishes
+// context_ready for first hydrations (NULL-hash chats stamped by the push)
+// and context_dirty for already-pinned chats whose hash drifted.
+func TestHydrateAndMarkChatsDirtyPublishesEvents(t *testing.T) {
+	t.Parallel()
+	fix := newRebindFixture(t)
+	server := &Server{db: fix.db, pubsub: fix.ps, logger: slogtest.Make(t, nil)}
+
+	// A never-hydrated chat (NULL hash) and an already-pinned chat whose
+	// hash will drift on the push below.
+	waitingChat := gateChat(t, fix, fix.agentA, fix.buildID)
+	require.Nil(t, waitingChat.ContextAggregateHash)
+	pinnedChat := gateChat(t, fix, fix.agentA, fix.buildID)
+	require.NoError(t, fix.db.SetChatContextSnapshot(fix.ctx, database.SetChatContextSnapshotParams{
+		ID:            pinnedChat.ID,
+		AggregateHash: []byte{0x01},
+	}))
+
+	events := subscribeChatWatchEvents(t, fix)
+
+	hashNew := []byte{0x77, 0x78}
+	var publish func()
+	err := fix.db.InTx(func(tx database.Store) error {
+		var err error
+		publish, err = server.HydrateAndMarkChatsDirty(
+			fix.ctx, tx, fix.agentA, hashNew, "", dbtime.Now())
+		return err
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, publish)
+	publish()
+
+	// One ready event for the hydrated chat and one dirty event for the
+	// drifted chat; delivery order is not guaranteed, so key by chat.
+	kindsByChat := map[uuid.UUID]codersdk.ChatWatchEventKind{}
+	for range 2 {
+		event := testutil.RequireReceive(fix.ctx, t, events)
+		kindsByChat[event.Chat.ID] = event.Kind
+		if event.Chat.ID == waitingChat.ID {
+			require.NotNil(t, event.Chat.Context)
+			require.Equal(t, codersdk.ChatContextStateReady, event.Chat.Context.State,
+				"the ready payload reports the pinned state")
+		}
+	}
+	require.Equal(t, map[uuid.UUID]codersdk.ChatWatchEventKind{
+		waitingChat.ID: codersdk.ChatWatchEventKindContextReady,
+		pinnedChat.ID:  codersdk.ChatWatchEventKindContextDirty,
+	}, kindsByChat)
 }

--- a/coderd/x/chatd/context_integration_test.go
+++ b/coderd/x/chatd/context_integration_test.go
@@ -86,10 +86,14 @@ func TestChatContextDirtyFromAgentPush(t *testing.T) {
 		Status:            database.ChatStatusWaiting,
 	})
 
-	// Before any push there is no pinned context.
+	// Before any push the chat is workspace-bound but unpinned, so the
+	// context reports the waiting state.
 	got, err := expClient.GetChat(ctx, chat.ID)
 	require.NoError(t, err)
-	require.Nil(t, got.Context, "no pinned context before the first push")
+	require.NotNil(t, got.Context, "workspace-bound chats always report context state")
+	require.Equal(t, codersdk.ChatContextStateWaiting, got.Context.State,
+		"unpinned workspace chat is waiting for the agent's report")
+	require.False(t, got.Context.Dirty)
 
 	requireChatContextNil := func(id uuid.UUID, msg string) {
 		t.Helper()
@@ -173,6 +177,8 @@ func TestChatContextDirtyFromAgentPush(t *testing.T) {
 	got, err = expClient.GetChat(ctx, chat.ID)
 	require.NoError(t, err)
 	require.NotNil(t, got.Context, "chat should be hydrated after the initial push")
+	require.Equal(t, codersdk.ChatContextStateReady, got.Context.State,
+		"first hydration flips the chat to ready")
 	require.False(t, got.Context.Dirty, "initial hydration is clean")
 	require.Nil(t, got.Context.DirtySince)
 

--- a/coderd/x/chatd/context_rebind_internal_test.go
+++ b/coderd/x/chatd/context_rebind_internal_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbmock"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/database/pubsub"
 	"github.com/coder/coder/v2/testutil"
 )
 
@@ -196,6 +197,7 @@ func TestPersistBuildAgentBindingRepinsContext(t *testing.T) {
 
 type rebindFixture struct {
 	db          database.Store
+	ps          pubsub.Pubsub
 	ctx         context.Context
 	org         database.Organization
 	user        database.User
@@ -219,7 +221,7 @@ type rebindFixture struct {
 // rebind guard keys on the agent, not the build.
 func newRebindFixture(t *testing.T) rebindFixture {
 	t.Helper()
-	db, _ := dbtestutil.NewDB(t)
+	db, ps := dbtestutil.NewDB(t)
 	ctx := testutil.Context(t, testutil.WaitLong)
 
 	user := dbgen.User(t, db, database.User{})
@@ -260,6 +262,7 @@ func newRebindFixture(t *testing.T) rebindFixture {
 
 	fix := rebindFixture{
 		db:          db,
+		ps:          ps,
 		ctx:         ctx,
 		org:         org,
 		user:        user,

--- a/coderd/x/chatd/generation_preparer.go
+++ b/coderd/x/chatd/generation_preparer.go
@@ -225,25 +225,23 @@ func (server *Server) prepareGeneration(
 	promptRows = server.sanitizeForeignProviderExecutedToolRows(ctx, logger, promptRows, modelConfig.ID)
 
 	if chat.WorkspaceID.Valid {
-		// Resolve the workspace agent so the chat row's AgentID and
-		// BuildID bindings are up to date before the chatworker
-		// decision helper inspects them. ensureWorkspaceAgent does a
-		// DB lookup and lazily calls persistBuildAgentBinding when
-		// the bound agent has changed, so this is a cheap metadata
-		// refresh, not a workspace dial. It must not insert chat
-		// history; only metadata is mutated here.
-		agent, _ := workspaceCtx.getWorkspaceAgent(ctx)
-
-		// API-created chats bind their agent lazily here, after
-		// hydrateChatContextOnCreate ran with no agent. Pin the chat to the
-		// bound agent's pushed snapshot now if it is still unpinned, so the
-		// first turn reads workspace context instead of waiting for the
-		// agent's next push. Idempotent and snapshot-gated; runs before the
-		// pinned context is read below.
-		server.ensureChatContextPinnedOnFirstTurn(ctx, workspaceCtx.currentChatSnapshot())
+		// A workspace turn waits for the chat's agent to report its context
+		// snapshot. awaitChatContextReported resolves the agent (rebinding
+		// stale bindings to the latest start build, which also re-pins the
+		// chat's context), proceeds immediately when the chat is already
+		// pinned, and otherwise blocks until the bound agent has a snapshot,
+		// pinning the chat to it before returning. When the report is
+		// unavailable the turn degrades instead of failing: the reason is
+		// recorded on chats.context_error and the turn runs with the
+		// zero-value agent and no workspace context.
+		agent, gateErr := server.awaitChatContextReported(ctx, &workspaceCtx, logger)
+		if gateErr != nil {
+			cleanup()
+			return generationPrepared{}, gateErr
+		}
 
 		var resolveErr error
-		instruction, workspaceSkills, resolveErr = server.resolveTurnWorkspaceContext(ctx, chat, agent)
+		instruction, workspaceSkills, resolveErr = server.resolveTurnWorkspaceContext(ctx, workspaceCtx.currentChatSnapshot(), agent)
 		if resolveErr != nil {
 			cleanup()
 			return generationPrepared{}, resolveErr

--- a/coderd/x/chatd/subagent_internal_test.go
+++ b/coderd/x/chatd/subagent_internal_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
 	coderdpubsub "github.com/coder/coder/v2/coderd/pubsub"
 	"github.com/coder/coder/v2/coderd/util/ptr"
@@ -592,6 +593,17 @@ func seedWorkspaceBinding(
 		JobID:      job.ID,
 	})
 	agent := dbgen.WorkspaceAgent(t, db, database.WorkspaceAgent{ResourceID: resource.ID})
+	// The context-report gate blocks workspace turns until the agent has
+	// pushed a context snapshot. Seed an empty snapshot so turns proceed
+	// as they did before the gate; row existence alone marks the agent as
+	// having reported, and an empty snapshot contributes no prompt context.
+	_, err := db.UpsertWorkspaceAgentContextSnapshot(context.Background(), database.UpsertWorkspaceAgentContextSnapshotParams{
+		WorkspaceAgentID: agent.ID,
+		Version:          1,
+		AggregateHash:    []byte{0x01},
+		ReceivedAt:       dbtime.Now(),
+	})
+	require.NoError(t, err)
 	return workspace, build, agent
 }
 

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -138,7 +138,8 @@ type Chat struct {
 	HasUnread bool `json:"has_unread"`
 	// Context reports the chat's pinned workspace-context state and
 	// whether it has drifted from the agent's latest pushed snapshot.
-	// Nil when the chat has no pinned context yet.
+	// Present for every workspace-bound chat; nil for chats with no
+	// workspace and no context remnants.
 	Context    *ChatContext   `json:"context,omitempty"`
 	Warnings   []string       `json:"warnings,omitempty"`
 	ClientType ChatClientType `json:"client_type"`
@@ -150,10 +151,26 @@ type Chat struct {
 	Children []Chat `json:"children"`
 }
 
+// ChatContextState describes where a chat stands in the workspace-context
+// reporting lifecycle.
+type ChatContextState string
+
+const (
+	// ChatContextStateWaiting means the chat is workspace-bound but not
+	// yet pinned to a reported snapshot; turns gate on the report.
+	ChatContextStateWaiting ChatContextState = "waiting"
+	// ChatContextStateReady means the chat is pinned to a reported
+	// snapshot.
+	ChatContextStateReady ChatContextState = "ready"
+)
+
 // ChatContext reports a chat's pinned workspace context and whether it has
 // drifted from the agent's latest pushed snapshot. The chat stays usable
 // when dirty; refreshing re-pins it to the latest snapshot.
 type ChatContext struct {
+	// State reports where the chat stands in the context-reporting
+	// lifecycle: waiting for the agent's first report or ready (pinned).
+	State ChatContextState `json:"state,omitempty"`
 	// Dirty is true when the agent's latest snapshot hash differs from the
 	// chat's pinned hash.
 	Dirty bool `json:"dirty"`
@@ -1867,6 +1884,10 @@ const (
 	ChatWatchEventKindDeleted          ChatWatchEventKind = "deleted"
 	ChatWatchEventKindDiffStatusChange ChatWatchEventKind = "diff_status_change"
 	ChatWatchEventKindActionRequired   ChatWatchEventKind = "action_required"
+	// ChatWatchEventKindContextReady signals that the chat was first
+	// hydrated or re-pinned from a reported snapshot, so watchers can
+	// refresh the chat's context state without refetching.
+	ChatWatchEventKindContextReady ChatWatchEventKind = "context_ready"
 	// ChatWatchEventKindContextDirty signals that the chat's pinned
 	// workspace context changed: it drifted from the agent's latest
 	// pushed snapshot, or hydration first populated it (a first-turn
@@ -1874,6 +1895,11 @@ const (
 	// stays usable; a refresh re-pins a drifted chat to the latest
 	// snapshot.
 	ChatWatchEventKindContextDirty ChatWatchEventKind = "context_dirty"
+	// ChatWatchEventKindContextError signals that a turn degraded because
+	// the workspace agent's context report is unavailable; the chat's
+	// Context.Error carries the reason. The chat stays usable and runs
+	// without workspace context until a later report heals it.
+	ChatWatchEventKindContextError ChatWatchEventKind = "context_error"
 )
 
 // ChatWatchEvent represents an event from the global chat watch stream.

--- a/docs/reference/api/chats.md
+++ b/docs/reference/api/chats.md
@@ -58,7 +58,8 @@ Experimental: this endpoint is subject to change.
             }
           ]
         }
-      ]
+      ],
+      "state": "waiting"
     },
     "created_at": "2019-08-24T14:15:22Z",
     "diff_status": {
@@ -150,7 +151,7 @@ Status Code **200**
 | `» build_id`              | string(uuid)                                                                       | false    |              |                                                                                                                                                                                                                                                                            |
 | `» children`              | [codersdk.Chat](schemas.md#codersdkchat)                                           | false    |              | Children holds child (subagent) chats nested under this root chat. Always initialized to an empty slice so the JSON field is present as []. Child chats cannot create their own subagents, so nesting depth is capped at 1 and this slice is always empty for child chats. |
 | `» client_type`           | [codersdk.ChatClientType](schemas.md#codersdkchatclienttype)                       | false    |              |                                                                                                                                                                                                                                                                            |
-| `» context`               | [codersdk.ChatContext](schemas.md#codersdkchatcontext)                             | false    |              | Context reports the chat's pinned workspace-context state and whether it has drifted from the agent's latest pushed snapshot. Nil when the chat has no pinned context yet.                                                                                                 |
+| `» context`               | [codersdk.ChatContext](schemas.md#codersdkchatcontext)                             | false    |              | Context reports the chat's pinned workspace-context state and whether it has drifted from the agent's latest pushed snapshot. Present for every workspace-bound chat; nil for chats with no workspace and no context remnants.                                             |
 | `»» dirty`                | boolean                                                                            | false    |              | Dirty is true when the agent's latest snapshot hash differs from the chat's pinned hash.                                                                                                                                                                                   |
 | `»» dirty_since`          | string(date-time)                                                                  | false    |              | Dirty since is when drift was first detected; nil when not dirty.                                                                                                                                                                                                          |
 | `»» error`                | string                                                                             | false    |              | Error is the snapshot-level error copied from the pinned snapshot (empty when healthy).                                                                                                                                                                                    |
@@ -165,6 +166,7 @@ Status Code **200**
 | `»»» tools`               | array                                                                              | false    |              | Tools lists the tools exposed by an MCP server. Populated only for the mcp_server kind; nil otherwise.                                                                                                                                                                     |
 | `»»»» description`        | string                                                                             | false    |              | Description is the tool's human-readable summary; may be empty.                                                                                                                                                                                                            |
 | `»»»» name`               | string                                                                             | false    |              | Name is the tool name with the "<server>__" prefix the agent adds stripped, so it reads as the server exposes it.                                                                                                                                                          |
+| `»» state`                | [codersdk.ChatContextState](schemas.md#codersdkchatcontextstate)                   | false    |              | State reports where the chat stands in the context-reporting lifecycle: waiting for the agent's first report or ready (pinned).                                                                                                                                            |
 | `» created_at`            | string(date-time)                                                                  | false    |              |                                                                                                                                                                                                                                                                            |
 | `» diff_status`           | [codersdk.ChatDiffStatus](schemas.md#codersdkchatdiffstatus)                       | false    |              |                                                                                                                                                                                                                                                                            |
 | `»» additions`            | integer                                                                            | false    |              |                                                                                                                                                                                                                                                                            |
@@ -230,6 +232,7 @@ Status Code **200**
 | `client_type` | `api`, `ui`                                                                                                                                                                                                                |
 | `kind`        | `auth`, `config`, `content_filter`, `generic`, `instruction_file`, `mcp_config`, `mcp_server`, `missing_key`, `overloaded`, `provider_disabled`, `rate_limit`, `skill`, `stream_silence_timeout`, `timeout`, `usage_limit` |
 | `status`      | `error`, `excluded`, `interrupting`, `invalid`, `ok`, `oversize`, `requires_action`, `running`, `unreadable`, `waiting`                                                                                                    |
+| `state`       | `ready`, `waiting`                                                                                                                                                                                                         |
 | `plan_mode`   | `plan`                                                                                                                                                                                                                     |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
@@ -333,7 +336,8 @@ Experimental: this endpoint is subject to change.
               }
             ]
           }
-        ]
+        ],
+        "state": "waiting"
       },
       "created_at": "2019-08-24T14:15:22Z",
       "diff_status": {
@@ -426,7 +430,8 @@ Experimental: this endpoint is subject to change.
           }
         ]
       }
-    ]
+    ],
+    "state": "waiting"
   },
   "created_at": "2019-08-24T14:15:22Z",
   "diff_status": {
@@ -676,7 +681,8 @@ Experimental: this endpoint is subject to change.
             }
           ]
         }
-      ]
+      ],
+      "state": "waiting"
     },
     "created_at": "2019-08-24T14:15:22Z",
     "diff_status": {
@@ -823,7 +829,8 @@ Experimental: this endpoint is subject to change.
               }
             ]
           }
-        ]
+        ],
+        "state": "waiting"
       },
       "created_at": "2019-08-24T14:15:22Z",
       "diff_status": {
@@ -916,7 +923,8 @@ Experimental: this endpoint is subject to change.
           }
         ]
       }
-    ]
+    ],
+    "state": "waiting"
   },
   "created_at": "2019-08-24T14:15:22Z",
   "diff_status": {
@@ -1100,7 +1108,8 @@ Experimental: this endpoint is subject to change.
               }
             ]
           }
-        ]
+        ],
+        "state": "waiting"
       },
       "created_at": "2019-08-24T14:15:22Z",
       "diff_status": {
@@ -1193,7 +1202,8 @@ Experimental: this endpoint is subject to change.
           }
         ]
       }
-    ]
+    ],
+    "state": "waiting"
   },
   "created_at": "2019-08-24T14:15:22Z",
   "diff_status": {
@@ -1375,7 +1385,8 @@ Experimental: this endpoint is subject to change.
               }
             ]
           }
-        ]
+        ],
+        "state": "waiting"
       },
       "created_at": "2019-08-24T14:15:22Z",
       "diff_status": {
@@ -1468,7 +1479,8 @@ Experimental: this endpoint is subject to change.
           }
         ]
       }
-    ]
+    ],
+    "state": "waiting"
   },
   "created_at": "2019-08-24T14:15:22Z",
   "diff_status": {
@@ -2219,7 +2231,8 @@ Experimental: this endpoint is subject to change.
               }
             ]
           }
-        ]
+        ],
+        "state": "waiting"
       },
       "created_at": "2019-08-24T14:15:22Z",
       "diff_status": {
@@ -2312,7 +2325,8 @@ Experimental: this endpoint is subject to change.
           }
         ]
       }
-    ]
+    ],
+    "state": "waiting"
   },
   "created_at": "2019-08-24T14:15:22Z",
   "diff_status": {
@@ -2819,7 +2833,8 @@ Experimental: this endpoint is subject to change.
               }
             ]
           }
-        ]
+        ],
+        "state": "waiting"
       },
       "created_at": "2019-08-24T14:15:22Z",
       "diff_status": {
@@ -2912,7 +2927,8 @@ Experimental: this endpoint is subject to change.
           }
         ]
       }
-    ]
+    ],
+    "state": "waiting"
   },
   "created_at": "2019-08-24T14:15:22Z",
   "diff_status": {

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2075,7 +2075,8 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
               }
             ]
           }
-        ]
+        ],
+        "state": "waiting"
       },
       "created_at": "2019-08-24T14:15:22Z",
       "diff_status": {
@@ -2168,7 +2169,8 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
           }
         ]
       }
-    ]
+    ],
+    "state": "waiting"
   },
   "created_at": "2019-08-24T14:15:22Z",
   "diff_status": {
@@ -2250,7 +2252,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `build_id`              | string                                                          | false    |              |                                                                                                                                                                                                                                                                            |
 | `children`              | array of [codersdk.Chat](#codersdkchat)                         | false    |              | Children holds child (subagent) chats nested under this root chat. Always initialized to an empty slice so the JSON field is present as []. Child chats cannot create their own subagents, so nesting depth is capped at 1 and this slice is always empty for child chats. |
 | `client_type`           | [codersdk.ChatClientType](#codersdkchatclienttype)              | false    |              |                                                                                                                                                                                                                                                                            |
-| `context`               | [codersdk.ChatContext](#codersdkchatcontext)                    | false    |              | Context reports the chat's pinned workspace-context state and whether it has drifted from the agent's latest pushed snapshot. Nil when the chat has no pinned context yet.                                                                                                 |
+| `context`               | [codersdk.ChatContext](#codersdkchatcontext)                    | false    |              | Context reports the chat's pinned workspace-context state and whether it has drifted from the agent's latest pushed snapshot. Present for every workspace-bound chat; nil for chats with no workspace and no context remnants.                                             |
 | `created_at`            | string                                                          | false    |              |                                                                                                                                                                                                                                                                            |
 | `diff_status`           | [codersdk.ChatDiffStatus](#codersdkchatdiffstatus)              | false    |              |                                                                                                                                                                                                                                                                            |
 | `files`                 | array of [codersdk.ChatFileMetadata](#codersdkchatfilemetadata) | false    |              |                                                                                                                                                                                                                                                                            |
@@ -2399,7 +2401,8 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
         }
       ]
     }
-  ]
+  ],
+  "state": "waiting"
 }
 ```
 
@@ -2411,6 +2414,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `dirty_since` | string                                                                | false    |              | Dirty since is when drift was first detected; nil when not dirty.                                                                                                                                                                          |
 | `error`       | string                                                                | false    |              | Error is the snapshot-level error copied from the pinned snapshot (empty when healthy).                                                                                                                                                    |
 | `resources`   | array of [codersdk.ChatContextResource](#codersdkchatcontextresource) | false    |              | Resources is the chat's pinned context (instruction files and skills) the prompt is built from, metadata only (no bodies). It is populated only on the single-chat GET response; list and watch payloads leave it nil to stay lightweight. |
+| `state`       | [codersdk.ChatContextState](#codersdkchatcontextstate)                | false    |              | State reports where the chat stands in the context-reporting lifecycle: waiting for the agent's first report or ready (pinned).                                                                                                            |
 
 ## codersdk.ChatContextResource
 
@@ -2472,6 +2476,20 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | Value(s)                                              |
 |-------------------------------------------------------|
 | `excluded`, `invalid`, `ok`, `oversize`, `unreadable` |
+
+## codersdk.ChatContextState
+
+```json
+"waiting"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value(s)           |
+|--------------------|
+| `ready`, `waiting` |
 
 ## codersdk.ChatContextTool
 
@@ -3953,7 +3971,8 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
             }
           ]
         }
-      ]
+      ],
+      "state": "waiting"
     },
     "created_at": "2019-08-24T14:15:22Z",
     "diff_status": {
@@ -4053,9 +4072,9 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 #### Enumerated Values
 
-| Value(s)                                                                                                                          |
-|-----------------------------------------------------------------------------------------------------------------------------------|
-| `action_required`, `context_dirty`, `created`, `deleted`, `diff_status_change`, `status_change`, `summary_change`, `title_change` |
+| Value(s)                                                                                                                                                            |
+|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `action_required`, `context_dirty`, `context_error`, `context_ready`, `created`, `deleted`, `diff_status_change`, `status_change`, `summary_change`, `title_change` |
 
 ## codersdk.ClusterConfig
 

--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -2197,6 +2197,99 @@ describe("mergeWatchedChatSummary", () => {
 		});
 	});
 
+	it("applies context_ready state while preserving the pinned resource list", () => {
+		const cachedChat = makeChat("chat-1", {
+			updated_at: "2025-01-01T00:00:00.000Z",
+			context: {
+				state: "waiting",
+				dirty: false,
+				resources: [
+					{
+						source: "/AGENTS.md",
+						kind: "instruction_file",
+						size_bytes: 10,
+						status: "ok",
+					},
+				],
+			},
+		});
+		const watchedChat = makeChat("chat-1", {
+			// Readiness is tracked outside updated_at, so an older event
+			// timestamp still applies the state flip.
+			updated_at: "2024-12-31T00:00:00.000Z",
+			context: { state: "ready", dirty: false },
+		});
+
+		expect(
+			mergeWatchedChatSummary(cachedChat, watchedChat, {
+				eventKind: "context_ready",
+			}).context,
+		).toEqual({
+			state: "ready",
+			dirty: false,
+			// The lightweight watch payload omits resources; the merge keeps the
+			// pinned list a prior single-chat GET populated.
+			resources: [
+				{
+					source: "/AGENTS.md",
+					kind: "instruction_file",
+					size_bytes: 10,
+					status: "ok",
+				},
+			],
+		});
+	});
+
+	it("applies context_error state while preserving the pinned resource list", () => {
+		const cachedChat = makeChat("chat-1", {
+			updated_at: "2025-01-01T00:00:00.000Z",
+			context: {
+				state: "waiting",
+				dirty: false,
+				resources: [
+					{
+						source: "/AGENTS.md",
+						kind: "instruction_file",
+						size_bytes: 10,
+						status: "ok",
+					},
+				],
+			},
+		});
+		const watchedChat = makeChat("chat-1", {
+			// Degrade errors are tracked outside updated_at, so an older event
+			// timestamp still applies the error.
+			updated_at: "2024-12-31T00:00:00.000Z",
+			context: {
+				state: "waiting",
+				dirty: false,
+				error:
+					"workspace agent is not connected, so it cannot report chat context",
+			},
+		});
+
+		expect(
+			mergeWatchedChatSummary(cachedChat, watchedChat, {
+				eventKind: "context_error",
+			}).context,
+		).toEqual({
+			state: "waiting",
+			dirty: false,
+			error:
+				"workspace agent is not connected, so it cannot report chat context",
+			// The lightweight watch payload omits resources; the merge keeps the
+			// pinned list a prior single-chat GET populated.
+			resources: [
+				{
+					source: "/AGENTS.md",
+					kind: "instruction_file",
+					size_bytes: 10,
+					status: "ok",
+				},
+			],
+		});
+	});
+
 	it("leaves context untouched for non-context events", () => {
 		const context = { dirty: true, dirty_since: "2025-01-02T00:00:00.000Z" };
 		const cachedChat = makeChat("chat-1", {

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -422,6 +422,8 @@ export const mergeWatchedChatSummary = (
 	const isSummaryEvent = eventKind === "summary_change";
 	const isDiffStatusEvent = eventKind === "diff_status_change";
 	const isContextDirtyEvent = eventKind === "context_dirty";
+	const isContextReadyEvent = eventKind === "context_ready";
+	const isContextErrorEvent = eventKind === "context_error";
 	const updatedAtComparison = compareUpdatedAtInstants(
 		cachedChat.updated_at,
 		watchedChat.updated_at,
@@ -437,13 +439,16 @@ export const mergeWatchedChatSummary = (
 	const nextDiffStatus = isDiffStatusEvent
 		? watchedChat.diff_status
 		: cachedChat.diff_status;
-	// Context drift is tracked outside chats.updated_at (it is driven by
-	// agent context pushes), so apply context_dirty payloads regardless of
-	// the summary timestamp. Merge rather than replace so the pinned
-	// resources a single-chat GET populated are preserved while the dirty
-	// flags update; the open chat refetches the full detail.
+	// Context drift, readiness, and degrade errors are tracked outside
+	// chats.updated_at (they are driven by agent context pushes and the
+	// context gate), so apply context_dirty, context_ready, and
+	// context_error payloads regardless of the summary timestamp.
+	// Merge rather than replace so the pinned resources a single-chat GET
+	// populated are preserved while the state flags update; the open chat
+	// refetches the full detail.
 	const nextContext =
-		isContextDirtyEvent && watchedChat.context
+		(isContextDirtyEvent || isContextReadyEvent || isContextErrorEvent) &&
+		watchedChat.context
 			? { ...cachedChat.context, ...watchedChat.context }
 			: cachedChat.context;
 	const nextWorkspaceId = isFreshEnough

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1682,7 +1682,8 @@ export interface Chat {
 	/**
 	 * Context reports the chat's pinned workspace-context state and
 	 * whether it has drifted from the agent's latest pushed snapshot.
-	 * Nil when the chat has no pinned context yet.
+	 * Present for every workspace-bound chat; nil for chats with no
+	 * workspace and no context remnants.
 	 */
 	readonly context?: ChatContext;
 	readonly warnings?: readonly string[];
@@ -1788,6 +1789,11 @@ export interface ChatConfig {
  * when dirty; refreshing re-pins it to the latest snapshot.
  */
 export interface ChatContext {
+	/**
+	 * State reports where the chat stands in the context-reporting
+	 * lifecycle: waiting for the agent's first report or ready (pinned).
+	 */
+	readonly state?: ChatContextState;
 	/**
 	 * Dirty is true when the agent's latest snapshot hash differs from the
 	 * chat's pinned hash.
@@ -1904,6 +1910,11 @@ export const ChatContextResourceStatuses: ChatContextResourceStatus[] = [
 	"oversize",
 	"unreadable",
 ];
+
+// From codersdk/chats.go
+export type ChatContextState = "ready" | "waiting";
+
+export const ChatContextStates: ChatContextState[] = ["ready", "waiting"];
 
 // From codersdk/chats.go
 /**
@@ -3417,6 +3428,8 @@ export interface ChatWatchEvent {
 export type ChatWatchEventKind =
 	| "action_required"
 	| "context_dirty"
+	| "context_error"
+	| "context_ready"
 	| "created"
 	| "deleted"
 	| "diff_status_change"
@@ -3427,6 +3440,8 @@ export type ChatWatchEventKind =
 export const ChatWatchEventKinds: ChatWatchEventKind[] = [
 	"action_required",
 	"context_dirty",
+	"context_error",
+	"context_ready",
 	"created",
 	"deleted",
 	"diff_status_change",

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -621,7 +621,11 @@ const AgentsPage: FC = () => {
 						if (shouldInvalidateFilteredChatList(updatedChat, chatEvent.kind)) {
 							void invalidateChatListQueries(queryClient);
 						}
-						if (chatEvent.kind === "context_dirty") {
+						if (
+							chatEvent.kind === "context_dirty" ||
+							chatEvent.kind === "context_ready" ||
+							chatEvent.kind === "context_error"
+						) {
 							// The watch payload carries only the lightweight
 							// context flags (the merge above applies them);
 							// refetch the open chat to pull the pinned

--- a/site/src/pages/AgentsPage/components/ContextUsageIndicator.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ContextUsageIndicator.stories.tsx
@@ -2,7 +2,9 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import {
 	MockChatContextClean,
+	MockChatContextDegraded,
 	MockChatContextDirty,
+	MockChatContextWaiting,
 } from "#/testHelpers/chatEntities";
 import { ContextUsageIndicator } from "./ContextUsageIndicator";
 
@@ -201,6 +203,62 @@ export const Dirty: Story = {
 			body.getByRole("button", { name: "Refresh context" }),
 		);
 		expect(args.onRefreshContext).toHaveBeenCalledTimes(1);
+	},
+};
+
+// Waiting pin: the chat is workspace-bound but the agent has not reported a
+// context snapshot yet, so the indicator shows a subtle spinner and the
+// popover explains the wait. No refresh affordance: there is nothing to
+// re-pin yet.
+export const Waiting: Story = {
+	args: {
+		usage: {
+			context: MockChatContextWaiting,
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const button = within(canvasElement).getByRole("button");
+		expect(button.getAttribute("aria-label") ?? "").toContain(
+			"Waiting for workspace context",
+		);
+
+		await userEvent.hover(button);
+		const body = within(document.body);
+		await waitFor(() =>
+			expect(body.getByText("Waiting for workspace context")).toBeVisible(),
+		);
+		expect(body.queryByRole("button", { name: "Refresh context" })).toBeNull();
+	},
+};
+
+// Degraded pin: the chat is still waiting (unpinned) but a turn degraded
+// because the agent's context report is unavailable, so the indicator
+// renders an error treatment instead of an ongoing wait and the popover
+// surfaces the degrade reason.
+export const Degraded: Story = {
+	args: {
+		usage: {
+			context: MockChatContextDegraded,
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const button = within(canvasElement).getByRole("button");
+		expect(button.getAttribute("aria-label") ?? "").toContain(
+			"Workspace context unavailable",
+		);
+
+		await userEvent.hover(button);
+		const body = within(document.body);
+		await waitFor(() =>
+			expect(body.getByText("Workspace context unavailable")).toBeVisible(),
+		);
+		// The degrade reason is visible, replacing the misleading wait line.
+		expect(
+			body.getByText(
+				"workspace agent is not connected, so it cannot report chat context",
+			),
+		).toBeVisible();
+		expect(body.queryByText("Waiting for workspace context")).toBeNull();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ContextUsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/ContextUsageIndicator.tsx
@@ -238,8 +238,15 @@ export const ContextUsageIndicator: FC<{
 
 	const context = usage?.context;
 	const isDirty = context?.dirty ?? false;
+	// A waiting chat is workspace-bound but not yet pinned to a reported
+	// snapshot; turns gate on the agent's first context report.
+	const isWaiting = context?.state === "waiting";
 	const contextError = context?.error ?? "";
 	const hasContextError = contextError !== "";
+	// A waiting chat with a context error is degraded: the agent's report
+	// is unavailable, so turns run without workspace context until a later
+	// report heals the chat. Rendered as an error, not as an ongoing wait.
+	const isDegraded = isWaiting && hasContextError;
 	const pinnedResources = context?.resources;
 
 	// Drive the listed context from the chat's pinned resources.
@@ -327,14 +334,32 @@ export const ContextUsageIndicator: FC<{
 	const fileGroups = groupByDirectory(fileItems);
 	const skillGroups = groupByDirectory(skillItems);
 
+	const ariaStateSuffix = isDegraded
+		? " Workspace context unavailable."
+		: isWaiting
+			? " Waiting for workspace context."
+			: isDirty
+				? " Context changed."
+				: "";
 	const ariaLabel = hasPercent
-		? `Context usage ${percentLabel}. ${formatTokenCount(usedTokens)} of ${formatTokenCount(contextLimitTokens)} tokens used.${isDirty ? " Context changed." : ""}`
-		: isDirty
-			? "Context usage. Context changed."
-			: "Context usage";
+		? `Context usage ${percentLabel}. ${formatTokenCount(usedTokens)} of ${formatTokenCount(contextLimitTokens)} tokens used.${ariaStateSuffix}`
+		: `Context usage${ariaStateSuffix ? `.${ariaStateSuffix}` : ""}`;
 
 	const panelContent = (
 		<div className="text-xs text-content-primary">
+			{isDegraded ? (
+				<div className="mb-2 flex items-center gap-1.5 font-medium text-content-destructive">
+					<TriangleAlertIcon className="size-3 shrink-0" />
+					<span>Workspace context unavailable</span>
+				</div>
+			) : (
+				isWaiting && (
+					<div className="mb-2 flex items-center gap-1.5 text-content-secondary">
+						<Spinner loading size="sm" className="size-3 shrink-0" />
+						<span>Waiting for workspace context</span>
+					</div>
+				)
+			)}
 			{hasPercent
 				? `${percentLabel} - ${formatTokenCountCompact(usedTokens)} / ${formatTokenCountCompact(contextLimitTokens)} context used`
 				: "Context usage unavailable"}
@@ -570,6 +595,14 @@ export const ContextUsageIndicator: FC<{
 				progressClassName="stroke-current"
 				className={cn("size-icon-sm", toneClassName)}
 			/>
+			{isWaiting && !isDegraded && (
+				<Spinner
+					loading
+					size="sm"
+					aria-hidden
+					className="absolute -right-0.5 -top-0.5 size-3 text-content-secondary"
+				/>
+			)}
 			{(isDirty || hasContextError) && (
 				<TriangleAlertIcon
 					aria-hidden

--- a/site/src/testHelpers/chatEntities.ts
+++ b/site/src/testHelpers/chatEntities.ts
@@ -79,14 +79,32 @@ const MockChatContextResources: ChatContextResource[] = [
 ];
 
 export const MockChatContextClean: ChatContext = {
+	state: "ready",
 	dirty: false,
 	resources: MockChatContextResources,
 };
 
 export const MockChatContextDirty: ChatContext = {
+	state: "ready",
 	dirty: true,
 	dirty_since: "2024-01-02T00:00:00Z",
 	resources: MockChatContextResources,
+};
+
+// A workspace-bound chat that has not been pinned to a reported snapshot
+// yet; turns gate on the agent's first context report.
+export const MockChatContextWaiting: ChatContext = {
+	state: "waiting",
+	dirty: false,
+};
+
+// A workspace-bound chat whose turn degraded: the agent's context report is
+// unavailable, so turns run without workspace context. The chat is still
+// unpinned (waiting) and the degrade reason is recorded on error.
+export const MockChatContextDegraded: ChatContext = {
+	state: "waiting",
+	dirty: false,
+	error: "workspace agent is not connected, so it cannot report chat context",
 };
 
 export const MockMCPServerConfig: MCPServerConfig = {


### PR DESCRIPTION
## Summary

Workspace context (instruction files, skills, MCP tools) reached chats through a race: the agent's first context push almost never contained MCP tools, chats never waited for any push, and MCP was excluded from the drift hash, so chats hydrated from the first push silently missed workspace MCP tools until a manual refresh. This PR replaces that with an explicit readiness contract: the agent's first push is the complete initial context (MCP settled or timed out), a snapshot row is the "context reported" indicator (even when empty), and a workspace-bound turn waits for that report before running.

## Problem

1. `agent/agent.go` released the context gate (`SetReady`) before connecting MCP servers, so the first push carried no tools and a second push followed up to ~60s later.
2. chatd's turn prep pinned context best-effort; a turn against a not-yet-reported agent ran with empty context and no workspace MCP tools.
3. `driftResources` excluded MCP from the aggregate hash on the stale assumption that tools are "discovered live at turn time". They are not: chatd builds workspace MCP tools from the pinned `chat_context_resources` rows. The tool-bearing second push therefore neither re-pinned nor dirtied already-hydrated chats, and the tools were permanently missed.
4. Relatedly, turn prep resolved the bound agent by ID, and old-build agent rows persist, so after a workspace rebuild a chat that never dialed kept the dead agent's binding forever and the new agent's pushes hydrated and dirtied nothing for it.

## Fix

- **agent**: connect workspace MCP servers before releasing the context gate, bounded by a 30s first-sync wait (`agentmcp.ReloadWithTimeout`). `SetReady` runs unconditionally afterwards; late-settling servers still re-push via the catalog-change callback. Lifecycle `Ready` is reported before the wait and is unaffected.
- **agentcontext**: the aggregate hash now covers every resource, including MCP config and live MCP server state, so MCP changes (server added/removed, tool list changed, connect state changed) surface as chat-context drift.
- **chatd**: the context report gates workspace turns. Turn prep rebinds stale bindings to the latest start build (re-pinning context), proceeds immediately for pinned chats, and otherwise waits on a 1s poll up to a 15m ceiling for the agent's first report. The gate never fails the turn: when a report provably cannot arrive (workspace not started, agent predates Agent API 2.10, agent disconnected) it degrades immediately, and on ceiling expiry it degrades too. A degraded turn runs without workspace context, records the reason on `chats.context_error` (visible in the context indicator), and publishes a `context_error` watch event. Degrades self-heal: the pinned hash stays NULL, so the agent's eventual push hydrates the chat, replaces the error, and publishes `context_ready`. A per-build degrade memory keeps later turns from re-stalling against the same wedged agent; a rebuild clears it. Interrupts keep working during the wait.
- **surface**: `ChatContext` gains `state: waiting | ready`, first hydration and gate-exit pinning publish a `context_ready` watch event, degrades publish `context_error`, and the agents UI renders waiting and degraded states.

## Behavior notes

- A fresh chat on a **stopped workspace** degrades immediately (no wait): the turn runs without workspace context, the context indicator shows "workspace must be started to report chat context", and the model can still call `start_workspace`. Once the workspace starts and the agent reports, the error clears itself.
- Chats on **pre-2.10 agents** degrade with "update Coder and rebuild the workspace" in the context indicator instead of silently running without any signal.
- After the agent upgrade, an identical workspace produces a different aggregate hash (MCP now included), so previously pinned chats flip dirty once; a refresh picks up the tools.

<details>
<summary>Implementation plan (as reviewed)</summary>

# Plan: Context-ready gating for /agents workspace context

## Problem

Workspace context reaches chats through a race, and MCP tools lose it.

Current flow on `main`:

1. The workspace agent reports lifecycle `Ready`, then releases the context gate (`contextManager.SetReady()`), and only **then** starts connecting MCP servers (`agent/agent.go:1545-1567`). The first real context push (`initial=true`) therefore almost never contains MCP servers or tools. A second push follows once the MCP catalog settles (up to ~60s later: `connectTimeout` is 30s each for connect and list-tools in `agent/x/agentmcp/manager.go`).
2. chatd never waits for a push. `prepareGeneration` (`coderd/x/chatd/generation_preparer.go:225-249`) does best-effort pinning (`ensureChatContextPinnedOnFirstTurn`); if the agent has not pushed yet, the turn runs with empty context and no workspace MCP tools.
3. MCP config/server resources are deliberately excluded from the aggregate drift hash (`driftResources`, `agent/agentcontext/resolve.go:981-1000`), so the tool-bearing second push neither re-pins nor dirties chats hydrated from the first push. Those chats permanently miss the tools unless the user manually refreshes context.

The `driftResources` exclusion is justified by a stale assumption: its comment says "the chat model discovers their tools live at turn time, not from pinned prompt content". That is no longer true. chatd builds workspace MCP tools from the **pinned** `chat_context_resources` rows (`pinnedWorkspaceMCPTools`, `coderd/x/chatd/chatd.go:445-464`); only execution is proxied live.

## Design

Three coordinated changes plus a UI surface. Together they replace the racy two-push choreography with one explicit readiness contract:

> The agent's first non-gated push is the complete initial context (MCP settled or timed out). A snapshot row in `workspace_agent_context_snapshots` is the "context reported" indicator, even when the context is empty. Chats wait for that indicator before their first turn against an agent.

### A. Agent: first push waits for MCP settle-or-timeout

Reorder the startup sequence in `agent/agent.go` (inside the existing tracked goroutine, after `setLifecycle(Ready)` so workspace readiness is unaffected):

```
before: StartCron -> SetReady -> mcpManager.Reload (unbounded wait)
after:  StartCron -> mcpManager.Reload (bounded wait) -> SetReady (always)
```

- `agentmcp.Manager.Reload` is already synchronous and singleflight; add a bounded-wait entry point (`ReloadWithTimeout`) reusing the existing `waitReload` timeout parameter and quartz clock.
- Gate timeout: 30s constant (aligned with `connectTimeout`). Servers that miss the window keep connecting in the background; the existing `SetOnReload -> contextManager.Trigger` path still emits a follow-up push.
- `SetReady()` runs unconditionally after the bounded wait.
- Failed servers become failed `KindMCPServer` resources, so the first push reflects reality even when servers are broken.
- No proto change.

### B. Agent: include MCP in the aggregate hash (cleanup)

Delete `driftResources` and hash all resources uniformly. MCP tools are pinned prompt/tool content now, so MCP changes are genuine drift. Change A makes this safe: the original reason for the exclusion (the expected connect-after-startup push flipping every fresh chat to dirty) disappears when MCP state is already in the first push.

### C. chatd: gate workspace turns on the context report

A workspace-bound turn waits for its agent's report instead of running with empty context. The gate:

1. **Snapshot exists**: proceed and pin. Pinned chats skip the gate entirely.
2. **Provably never** (workspace not started, agent API < 2.10, agent disconnected): degrade immediately with the reason recorded on the chat's context (`chats.context_error`), never a chat-level error, so the chat loop stays usable.
3. **Wait**: poll on a quartz ticker (1s); each tick re-resolves the agent (rebinding stale bindings) and checks `GetLatestWorkspaceAgentContextSnapshot`. Interrupt keeps working; a 15-minute ceiling degrades with a context error. Degrades self-heal on the agent's eventual push, and a per-build degrade memory prevents repeated stalls.

**Rebind on new builds happens at turn prep, before the gate.** Old-build agent rows persist, so after a restart the stale binding would stick and the pinned short-circuit would pass with the previous build's context; rebind previously happened only on the dial path, so a turn that never dials kept the dead agent's binding forever and the new agent's pushes hydrated and dirtied nothing. Turn prep now detects a newer start build, rebinds via `persistBuildAgentBinding` (which re-pins), and the gate applies to the new agent, so a restart re-gates exactly like a first start. Stop builds keep the old binding and pinned context.

Wait ceiling rationale: the agent pushes only after startup scripts finish (deliberate: scripts clone the repos that contain AGENTS.md and .mcp.json), so first turns against a cold workspace legitimately wait for startup-script duration; a short ceiling is therefore wrong.

### D. Surface the ready state

`codersdk.ChatContext.State` (waiting | ready), `ChatWatchEventKindContextReady` published on first hydration and gate-exit pinning, `ChatWatchEventKindContextError` published on degrades, and the agents UI waiting/degraded indicators with Storybook stories.

## Compatibility

| Agent | coderd | Behavior |
|---|---|---|
| new | new | Single complete first push; chats wait for it; late MCP = dirty |
| new | old (<2.10 API) | Push unimplemented; RunPush exits; no change |
| old (2.10, two-push) | new | Gate waits for first (tool-less) push; second push flips chats dirty via hash change, so tools are visible instead of missed |
| old (<2.10) | new | Turn degrades with an actionable context error; the chat keeps working |

## Risks and mitigations

- Long waits hold chat worker slots: only unpinned chats wait, the wait is a single goroutine on a ticker, provably-dead cases degrade immediately, interrupt always works, the ceiling bounds the rest, and the degrade memory prevents repeated stalls.
- First turns now wait for startup scripts (SetReady semantics): intended correctness tradeoff; the UI waiting state makes it legible.
- Stopped-workspace chats: previously hydrated chats keep working via the pinned short-circuit; never-reported ones degrade with a visible context error and keep working.
- Hash flapping from unstable MCP servers: catalog only changes on reload/config events; a flap is real drift the user should see.

</details>

---

🤖 This PR was generated by Coder Agents on behalf of @kylecarbs.
