### PR TITLE
fix(site): synchronize duration field during render

### DIFF
--- a/site/src/components/DurationField/DurationField.stories.tsx
+++ b/site/src/components/DurationField/DurationField.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useState } from "react";
+import { useArgs } from "storybook/preview-api";
 import { expect, userEvent, within } from "storybook/test";
 import { DurationField } from "./DurationField";
 
@@ -10,12 +10,11 @@ const meta: Meta<typeof DurationField> = {
 		label: "Duration",
 	},
 	render: function RenderComponent(args) {
-		const [value, setValue] = useState<number>(args.valueMs);
+		const [, updateArgs] = useArgs<typeof args>();
 		return (
 			<DurationField
 				{...args}
-				valueMs={value}
-				onChange={(value) => setValue(value)}
+				onChange={(valueMs) => updateArgs({ valueMs })}
 			/>
 		);
 	},
@@ -85,6 +84,27 @@ export const ConvertSmallHoursToDays: Story = {
 
 		// After switching to days, should show 1 day (2 hours rounded up to nearest day)
 		await expect(input).toHaveValue("1");
+	},
+};
+
+export const SyncWithParentValue: Story = {
+	args: {
+		valueMs: hoursToMs(1),
+	},
+	play: async ({ args, mount }) => {
+		const onChange = () => {};
+		let canvas = await mount(<DurationField {...args} onChange={onChange} />);
+		let input = canvas.getByLabelText("Duration");
+		await userEvent.clear(input);
+		await userEvent.type(input, "3");
+		await expect(input).toHaveValue("3");
+
+		canvas = await mount(
+			<DurationField {...args} valueMs={daysToMs(2)} onChange={onChange} />,
+		);
+		input = canvas.getByLabelText("Duration");
+		await expect(input).toHaveValue("2");
+		await expect(canvas.getByLabelText("Time unit")).toHaveTextContent("Days");
 	},
 };
 

--- a/site/src/components/DurationField/DurationField.tsx
+++ b/site/src/components/DurationField/DurationField.tsx
@@ -3,7 +3,7 @@ import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
 import TextField, { type TextFieldProps } from "@mui/material/TextField";
 import { ChevronDownIcon } from "lucide-react";
-import { type FC, useEffect, useReducer } from "react";
+import { type FC, useReducer } from "react";
 import {
 	durationInDays,
 	durationInHours,
@@ -21,6 +21,7 @@ type State = {
 	// Handling empty values as strings in the input simplifies the process,
 	// especially when a user clears the input field.
 	durationFieldValue: string;
+	lastParentValueMs: number;
 };
 
 type Action =
@@ -31,6 +32,12 @@ type Action =
 const reducer = (state: State, action: Action): State => {
 	switch (action.type) {
 		case "SYNC_WITH_PARENT": {
+			if (
+				durationInMs(state.durationFieldValue, state.unit) ===
+				action.parentValueMs
+			) {
+				return { ...state, lastParentValueMs: action.parentValueMs };
+			}
 			return initState(action.parentValueMs);
 		}
 		case "CHANGE_DURATION_FIELD_VALUE": {
@@ -46,6 +53,7 @@ const reducer = (state: State, action: Action): State => {
 			);
 
 			return {
+				...state,
 				unit: action.unit,
 				durationFieldValue:
 					action.unit === "hours"
@@ -69,11 +77,9 @@ export const DurationField: FC<DurationFieldProps> = (props) => {
 	const [state, dispatch] = useReducer(reducer, initState(parentValueMs));
 	const currentDurationMs = durationInMs(state.durationFieldValue, state.unit);
 
-	useEffect(() => {
-		if (parentValueMs !== currentDurationMs) {
-			dispatch({ type: "SYNC_WITH_PARENT", parentValueMs });
-		}
-	}, [currentDurationMs, parentValueMs]);
+	if (state.lastParentValueMs !== parentValueMs) {
+		dispatch({ type: "SYNC_WITH_PARENT", parentValueMs });
+	}
 
 	return (
 		<div>
@@ -156,6 +162,7 @@ function initState(value: number): State {
 	return {
 		unit,
 		durationFieldValue,
+		lastParentValueMs: value,
 	};
 }
 


### PR DESCRIPTION
The shared duration field mirrored its controlled value into local state from an Effect, causing a stale committed render before synchronization.

Track the last parent value in the reducer and synchronize during render only when that prop changes. Add Storybook coverage for parent-driven updates and use Storybook args for the controlled stories.

<details>
<summary>Coder Agents disclosure</summary>

This pull request was generated by Coder Agents.
</details>
