### PR TITLE
chore: unify admin settings menu items

### DIFF
--- a/site/src/modules/dashboard/Navbar/DeploymentDropdown.tsx
+++ b/site/src/modules/dashboard/Navbar/DeploymentDropdown.tsx
@@ -8,38 +8,22 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "#/components/DropdownMenu/DropdownMenu";
-import { linkToAuditing } from "#/modules/navigation";
+import {
+	type AdminSettingsPermissions,
+	canViewAdminSettings,
+	getAdminSettingsItems,
+} from "./adminSettings";
 
-interface DeploymentDropdownProps {
-	canViewDeployment: boolean;
-	canViewOrganizations: boolean;
-	canViewAuditLog: boolean;
-	canViewConnectionLog: boolean;
-	canViewAIBridge: boolean;
-	canViewAISettings: boolean;
-	canViewHealth: boolean;
-}
+type DeploymentDropdownProps = AdminSettingsPermissions;
 
-export const DeploymentDropdown: FC<DeploymentDropdownProps> = ({
-	canViewDeployment,
-	canViewOrganizations,
-	canViewAuditLog,
-	canViewConnectionLog,
-	canViewAIBridge,
-	canViewAISettings,
-	canViewHealth,
-}) => {
-	if (
-		!canViewAuditLog &&
-		!canViewConnectionLog &&
-		!canViewDeployment &&
-		!canViewOrganizations &&
-		!canViewAIBridge &&
-		!canViewAISettings &&
-		!canViewHealth
-	) {
+export const DeploymentDropdown: FC<DeploymentDropdownProps> = (
+	permissions,
+) => {
+	if (!canViewAdminSettings(permissions)) {
 		return null;
 	}
+
+	const items = getAdminSettingsItems(permissions);
 
 	return (
 		<DropdownMenu>
@@ -51,63 +35,14 @@ export const DeploymentDropdown: FC<DeploymentDropdownProps> = ({
 			</DropdownMenuTrigger>
 
 			<DropdownMenuContent align="end" className="w-[180px] min-w-auto">
-				<DeploymentDropdownContent
-					canViewDeployment={canViewDeployment}
-					canViewOrganizations={canViewOrganizations}
-					canViewAuditLog={canViewAuditLog}
-					canViewConnectionLog={canViewConnectionLog}
-					canViewAIBridge={canViewAIBridge}
-					canViewAISettings={canViewAISettings}
-					canViewHealth={canViewHealth}
-				/>
+				<nav>
+					{items.map((item) => (
+						<DropdownMenuItem key={item.to} asChild>
+							<Link to={item.to}>{item.label}</Link>
+						</DropdownMenuItem>
+					))}
+				</nav>
 			</DropdownMenuContent>
 		</DropdownMenu>
-	);
-};
-
-const DeploymentDropdownContent: FC<DeploymentDropdownProps> = ({
-	canViewDeployment,
-	canViewAuditLog,
-	canViewConnectionLog,
-	canViewAIBridge,
-	canViewAISettings,
-	canViewHealth,
-}) => {
-	return (
-		<nav>
-			{canViewDeployment && (
-				<DropdownMenuItem asChild>
-					<Link to="/deployment">Deployment</Link>
-				</DropdownMenuItem>
-			)}
-			<DropdownMenuItem asChild>
-				<Link to="/organizations">Organizations</Link>
-			</DropdownMenuItem>
-			{canViewAISettings && (
-				<DropdownMenuItem asChild>
-					<Link to="/ai/settings">AI</Link>
-				</DropdownMenuItem>
-			)}
-			{canViewAuditLog && (
-				<DropdownMenuItem asChild>
-					<Link to={linkToAuditing}>Audit logs</Link>
-				</DropdownMenuItem>
-			)}
-			{canViewConnectionLog && (
-				<DropdownMenuItem asChild>
-					<Link to="/connectionlog">Connection logs</Link>
-				</DropdownMenuItem>
-			)}
-			{canViewAIBridge && (
-				<DropdownMenuItem asChild>
-					<Link to="/ai-gateway/sessions">AI sessions</Link>
-				</DropdownMenuItem>
-			)}
-			{canViewHealth && (
-				<DropdownMenuItem asChild>
-					<Link to="/health">Healthcheck</Link>
-				</DropdownMenuItem>
-			)}
-		</nav>
 	);
 };

--- a/site/src/modules/dashboard/Navbar/MobileMenu.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.tsx
@@ -26,6 +26,10 @@ import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
 import { Latency } from "#/components/Latency/Latency";
 import type { ProxyContextValue } from "#/contexts/ProxyContext";
 import { cn } from "#/utils/cn";
+import {
+	type AdminSettingsPermissions,
+	getAdminSettingsItems,
+} from "./adminSettings";
 import { sortProxiesByLatency } from "./proxyUtils";
 
 const itemStyles = {
@@ -34,17 +38,7 @@ const itemStyles = {
 	open: "text-content-primary",
 };
 
-type MobileMenuPermissions = {
-	canViewDeployment: boolean;
-	canViewOrganizations: boolean;
-	canViewAuditLog: boolean;
-	canViewConnectionLog: boolean;
-	canViewAIBridge: boolean;
-	canViewAISettings: boolean;
-	canViewHealth: boolean;
-};
-
-type MobileMenuProps = MobileMenuPermissions & {
+type MobileMenuProps = AdminSettingsPermissions & {
 	proxyContextValue?: ProxyContextValue;
 	user?: TypesGen.User;
 	supportLinks?: readonly TypesGen.LinkConfig[];
@@ -208,15 +202,9 @@ const ProxySettingsSub: FC<ProxySettingsSubProps> = ({ proxyContextValue }) => {
 	);
 };
 
-const AdminSettingsSub: FC<MobileMenuPermissions> = ({
-	canViewDeployment,
-	canViewAuditLog,
-	canViewConnectionLog,
-	canViewAIBridge,
-	canViewAISettings,
-	canViewHealth,
-}) => {
+const AdminSettingsSub: FC<AdminSettingsPermissions> = (permissions) => {
 	const [open, setOpen] = useState(false);
+	const items = getAdminSettingsItems(permissions);
 
 	return (
 		<Collapsible open={open} onOpenChange={setOpen}>
@@ -235,60 +223,15 @@ const AdminSettingsSub: FC<MobileMenuPermissions> = ({
 				</DropdownMenuItem>
 			</CollapsibleTrigger>
 			<CollapsibleContent>
-				{canViewDeployment && (
+				{items.map((item) => (
 					<DropdownMenuItem
+						key={item.to}
 						asChild
 						className={cn(itemStyles.default, itemStyles.sub)}
 					>
-						<Link to="/deployment">Deployment</Link>
+						<Link to={item.to}>{item.label}</Link>
 					</DropdownMenuItem>
-				)}
-				<DropdownMenuItem
-					asChild
-					className={cn(itemStyles.default, itemStyles.sub)}
-				>
-					<Link to="/organizations">Organizations</Link>
-				</DropdownMenuItem>
-				{canViewAISettings && (
-					<DropdownMenuItem
-						asChild
-						className={cn(itemStyles.default, itemStyles.sub)}
-					>
-						<Link to="/ai/settings">AI</Link>
-					</DropdownMenuItem>
-				)}
-				{canViewAuditLog && (
-					<DropdownMenuItem
-						asChild
-						className={cn(itemStyles.default, itemStyles.sub)}
-					>
-						<Link to="/audit">Audit logs</Link>
-					</DropdownMenuItem>
-				)}
-				{canViewConnectionLog && (
-					<DropdownMenuItem
-						asChild
-						className={cn(itemStyles.default, itemStyles.sub)}
-					>
-						<Link to="/connectionlog">Connection logs</Link>
-					</DropdownMenuItem>
-				)}
-				{canViewAIBridge && (
-					<DropdownMenuItem
-						asChild
-						className={cn(itemStyles.default, itemStyles.sub)}
-					>
-						<Link to="/ai-gateway/sessions">AI sessions</Link>
-					</DropdownMenuItem>
-				)}
-				{canViewHealth && (
-					<DropdownMenuItem
-						asChild
-						className={cn(itemStyles.default, itemStyles.sub)}
-					>
-						<Link to="/health">Healthcheck</Link>
-					</DropdownMenuItem>
-				)}
+				))}
 			</CollapsibleContent>
 		</Collapsible>
 	);

--- a/site/src/modules/dashboard/Navbar/adminSettings.ts
+++ b/site/src/modules/dashboard/Navbar/adminSettings.ts
@@ -15,7 +15,7 @@ export type AdminSettingsPermissions = {
 	canViewHealth: boolean;
 };
 
-export type AdminSettingsItem = {
+type AdminSettingsItem = {
 	label: string;
 	to: string;
 };

--- a/site/src/modules/dashboard/Navbar/adminSettings.ts
+++ b/site/src/modules/dashboard/Navbar/adminSettings.ts
@@ -1,0 +1,55 @@
+import { linkToAuditing } from "#/modules/navigation";
+
+/**
+ * Permissions that determine which items appear in the Admin settings menu.
+ * Shared by the desktop `DeploymentDropdown` and the mobile `MobileMenu` so
+ * both surfaces render the same set of items from a single source of truth.
+ */
+export type AdminSettingsPermissions = {
+	canViewDeployment: boolean;
+	canViewOrganizations: boolean;
+	canViewAuditLog: boolean;
+	canViewConnectionLog: boolean;
+	canViewAIBridge: boolean;
+	canViewAISettings: boolean;
+	canViewHealth: boolean;
+};
+
+export type AdminSettingsItem = {
+	label: string;
+	to: string;
+};
+
+/**
+ * Builds the ordered list of Admin settings menu items for the given
+ * permissions. Organizations is always available; the rest are gated behind
+ * their respective permissions.
+ */
+export const getAdminSettingsItems = ({
+	canViewDeployment,
+	canViewAuditLog,
+	canViewConnectionLog,
+	canViewAIBridge,
+	canViewAISettings,
+	canViewHealth,
+}: AdminSettingsPermissions): AdminSettingsItem[] => [
+	...(canViewDeployment ? [{ label: "Deployment", to: "/deployment" }] : []),
+	{ label: "Organizations", to: "/organizations" },
+	...(canViewAISettings ? [{ label: "AI", to: "/ai/settings" }] : []),
+	...(canViewAuditLog ? [{ label: "Audit logs", to: linkToAuditing }] : []),
+	...(canViewConnectionLog
+		? [{ label: "Connection logs", to: "/connectionlog" }]
+		: []),
+	...(canViewAIBridge
+		? [{ label: "AI sessions", to: "/ai-gateway/sessions" }]
+		: []),
+	...(canViewHealth ? [{ label: "Healthcheck", to: "/health" }] : []),
+];
+
+/**
+ * Whether the user has any permission that should surface the Admin settings
+ * menu. Organizations alone does not gate visibility, matching prior behavior.
+ */
+export const canViewAdminSettings = (
+	permissions: AdminSettingsPermissions,
+): boolean => Object.values(permissions).some((canView) => canView);


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

## Problem

#27191 fixed the mobile menu missing the **AI** / **AI sessions** items, but did so by duplicating the item list. The desktop `DeploymentDropdown` and mobile `MobileMenu` each hardcode the same Admin settings links and permission gates. That duplication is exactly why the two drifted out of sync in the first place, and it will happen again the next time an item is added.

## Fix

Extract a single source of truth in `adminSettings.ts`:

- `AdminSettingsPermissions` type shared by both surfaces.
- `getAdminSettingsItems(permissions)` builds the ordered item list using conditional spreads, e.g.

  ```ts
  ...(canViewAISettings ? [{ label: "AI", to: "/ai/settings" }] : []),
  ```

- `canViewAdminSettings(permissions)` for the desktop visibility gate.

`DeploymentDropdown` and `MobileMenu` now just `.map()` over the shared list, so adding or changing an item is a one-line edit in one place.

No backend, permission, routing, or user-visible behavior changes. Item labels, links, and order match the current desktop dropdown (mobile now inherits the same `linkToAuditing` constant instead of a hardcoded `/audit`, same value).

<details>
<summary>Rationale / approach</summary>

Following Larry Wall's virtues: laziness (one list to maintain, not two), impatience (kill the class of bug where the two menus silently diverge), and hubris (leave a shared module nobody has to apologize for).

Kept `canViewOrganizations` in the permission type and visibility gate even though Organizations always renders, preserving prior behavior rather than changing it as part of a refactor.

Validated with `biome check` and `tsc --noEmit`; existing `MobileMenu.stories.tsx` args already cover the Admin / Auditor / OrgAdmin / Member permission matrices.

</details>