### PR TITLE
fix(site/src/pages/AISettingsPage): match Formik onSubmit args in Bedrock story

### DIFF
--- a/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderForm.stories.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderForm.stories.tsx
@@ -93,6 +93,9 @@ export const AddBedrockWithoutStaticCredentials: Story = {
 					accessKey: "",
 					accessKeySecret: "",
 				}),
+				// Formik invokes onSubmit as (values, formikHelpers), so the
+				// second argument must be matched for the assertion to pass.
+				expect.anything(),
 			),
 		);
 	},


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Test-only fix for `release/2.34`.

### Problem

The `AddBedrockWithoutStaticCredentials` interaction test in `ProviderForm.stories.tsx` asserts:

```ts
expect(args.onSubmit).toHaveBeenCalledWith(expect.objectContaining({ type: "bedrock", ... }))
```

Formik invokes `onSubmit(values, formikHelpers)` with **two** arguments, so `toHaveBeenCalledWith` never matches and the storybook/Chromatic interaction test fails deterministically. This breaks storybook CI for **any** PR targeting `release/2.34` (e.g. the #27083 backport in #27144).

`main` and `release/2.35` don't hit this because #25848 refactored the story there to forward only `values` to the spy; that refactor was never backported to 2.34.

### Fix

Match the second argument with `expect.anything()` so the assertion reflects Formik's actual call signature. Test-only, minimal, no product code change.

Verified on 2.34: `ProviderForm` storybook stories (13) pass; lint clean.
