### PR TITLE
fix(site): align React Compiler check scope with vite.config.mts

### DIFF
--- a/site/scripts/check-compiler.mjs
+++ b/site/scripts/check-compiler.mjs
@@ -16,10 +16,11 @@ import { transformSync } from "@babel/core";
 // Resolve the site/ directory (ESM equivalent of __dirname + "..").
 const siteDir = new URL("..", import.meta.url).pathname;
 
-// Only AgentsPage is currently opted in to React Compiler. Add new
-// directories here as more pages are migrated.
+// Directories opted in to React Compiler. Keep this list in sync with
+// the include filter in vite.config.mts.
 const targetDirs = [
 	"src/pages/AgentsPage",
+	"src/pages/AIBridgePage",
 ];
 
 const skipPatterns = [".test.", ".stories.", ".jest."];

--- a/site/vite.config.mts
+++ b/site/vite.config.mts
@@ -17,6 +17,7 @@ const compilerPreset = reactCompilerPreset();
 compilerPreset.rolldown.filter = {
 	...compilerPreset.rolldown.filter,
 	id: {
+		// Keep in sync with targetDirs in scripts/check-compiler.mjs.
 		include: [/src\/pages\/AgentsPage\//, /src\/pages\/AIBridgePage\//],
 	},
 };


### PR DESCRIPTION
## Stack Context

First PR of a 6-PR stack that thins the agent instruction corpus (~4,800 lines down to ~2,800) by removing startup bloat, assigning each procedure one canonical owner, and fixing rules that drifted from reality. Split from #27203 for reviewability.

## Why?

`site/vite.config.mts` compiles `src/pages/AIBridgePage/` with the React Compiler, but `site/scripts/check-compiler.mjs` did not include that directory. Compiler regressions in AIBridgePage were invisible to CI: code could silently bail out of compilation with no signal. The two lists had already drifted once, which is exactly how this class of bug recurs.

## What?

- Add `src/pages/AIBridgePage/` to the check-compiler scope. Verified all 381 functions in scope compile cleanly.
- Cross-reference the two lists with comments so the next person who edits one finds the other.

This is the only behavioral (non-docs) change in the stack, which is why it sits at the bottom.

> This PR was prepared by Mux (AI agent) on Mike's behalf.

