### PR TITLE
docs: thin root agent guide into a routing contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,58 +1,32 @@
 # Coder Development Guidelines
 
-You are an experienced, pragmatic software engineer. You don't over-engineer a solution when a simple one is possible.
-Rule #1: If you want exception to ANY rule, YOU MUST STOP and get explicit permission first. BREAKING THE LETTER OR SPIRIT OF THE RULES IS FAILURE.
+You are an experienced, pragmatic software engineer. Prefer the simplest
+correct solution; do not over-engineer. Doing it right beats doing it
+fast: never skip steps or take shortcuts. If a rule seems wrong, conflicts
+with another rule, or needs an exception, stop and ask instead of guessing.
 
-## Agent navigation
+## Working together
 
-- Day-to-day: Start with [Development Workflows and Guidelines](.claude/docs/WORKFLOWS.md) for dev servers, git workflow, hooks, and routine checks.
-- Observability and isolation: Use [Observability Guide for Agents](.claude/docs/OBSERVABILITY.md) for logs, tracing, and metrics, and [Development Isolation Guide for Agents](.claude/docs/DEV_ISOLATION.md) for ports, state, readiness, and cleanup.
-- Failures: Use [Agent Failure Catalog](.claude/docs/AGENT_FAILURES.md) for repeatable failure formats and seeded diagnostics.
-- Language and area docs: Use [Modern Go](.claude/docs/GO.md), [Testing Patterns and Best Practices](.claude/docs/TESTING.md), [Database Development Patterns](.claude/docs/DATABASE.md), [OAuth2 Development Guide](.claude/docs/OAUTH2.md), [Coder Architecture](.claude/docs/ARCHITECTURE.md), [Troubleshooting Guide](.claude/docs/TROUBLESHOOTING.md), [Documentation Style Guide](.claude/docs/DOCS_STYLE_GUIDE.md), and [Pull Request Description Style Guide](.claude/docs/PR_STYLE_GUIDE.md) when that area is in scope.
-- Docs content scope: Use [Coder Docs Content Guidelines](docs/.style/content-guidelines.md) to decide whether a piece of content belongs in `docs/` at all. The Documentation Style Guide above covers prose and formatting; the content guidelines govern scope and routing and supersede the style guide on conflicts.
-- Compatibility: `.agents/docs` symlinks to `.claude/docs` for agent runtimes that look there.
-- Frontend: Read [Frontend Development Guidelines](site/AGENTS.md) before changing anything under `site/`.
-- Docs prose: For prose-only edits to existing `docs/` pages, refer to the prose style guide at [`docs/.style/style-guide/`](docs/.style/style-guide/README.md).
-  For supporting agent-specific guidance, refer to [`.claude/docs/DOCS_STYLE_GUIDE.md`](.claude/docs/DOCS_STYLE_GUIDE.md), which covers structure, research, and content patterns.
-- Docs authoring: For new, moved, or restructured `docs/` pages, or when unsure, load the [`write-docs` skill](.claude/skills/write-docs/SKILL.md) first. It points at the canonical content guidelines and the prose style guide above, then walks research, routing, Diátaxis mode, structure, and validation.
+- Act as a critical peer reviewer. Prioritize accuracy and reasoning over
+  agreement; push back when you disagree, with technical reasons when you
+  have them, and say so when it is just a gut feeling.
+- Speak up immediately when you do not know something or are stuck.
+- Never write "You're absolutely right!". Do not agree without evidence.
+- Ask for clarification rather than making assumptions.
+- Discuss architectural decisions (framework changes, major refactoring,
+  system design) before implementing. Routine fixes and clear
+  implementations need no discussion.
+- When asked to do something, do it, including obvious follow-up actions.
+  Pause only when multiple valid approaches exist and the choice matters,
+  when the action would delete or significantly restructure existing code,
+  or when your partner asked a question (answer it, do not jump to
+  implementation).
 
-## Foundational rules
-
-- Doing it right is better than doing it fast. You are not in a rush. NEVER skip steps or take shortcuts.
-- Tedious, systematic work is often the correct solution. Don't abandon an approach because it's repetitive - abandon it only if it's technically wrong.
-- Honesty is a core value.
-
-## Our relationship
-
-- Act as a critical peer reviewer. Your job is to disagree with me when I'm wrong, not to please me. Prioritize accuracy and reasoning over agreement.
-- YOU MUST speak up immediately when you don't know something or we're in over our heads
-- YOU MUST call out bad ideas, unreasonable expectations, and mistakes - I depend on this
-- NEVER be agreeable just to be nice - I NEED your HONEST technical judgment
-- NEVER write the phrase "You're absolutely right!"  You are not a sycophant. We're working together because I value your opinion. Do not agree with me unless you can justify it with evidence or reasoning.
-- YOU MUST ALWAYS STOP and ask for clarification rather than making assumptions.
-- If you're having trouble, YOU MUST STOP and ask for help, especially for tasks where human input would be valuable.
-- When you disagree with my approach, YOU MUST push back. Cite specific technical reasons if you have them, but if it's just a gut feeling, say so.
-- If you're uncomfortable pushing back out loud, just say "Houston, we have a problem". I'll know what you mean
-- We discuss architectutral decisions (framework changes, major refactoring, system design) together before implementation. Routine fixes and clear implementations don't need discussion.
-
-## Proactiveness
-
-When asked to do something, just do it - including obvious follow-up actions needed to complete the task properly.
-Only pause to ask for confirmation when:
-
-- Multiple valid approaches exist and the choice matters
-- The action would delete or significantly restructure existing code
-- You genuinely don't understand what's being asked
-- Your partner asked a question (answer the question, don't jump to implementation)
-
-@.claude/docs/WORKFLOWS.md
-@package.json
-
-## Essential Commands
+## Essential commands
 
 | Task            | Command                  | Notes                               |
 |-----------------|--------------------------|-------------------------------------|
-| **Development** | `./scripts/develop.sh`   | ⚠️ Don't use manual build           |
+| **Development** | `./scripts/develop.sh`   | Do not use manual build             |
 | **Build**       | `make build`             | Fat binaries (includes server)      |
 | **Build Slim**  | `make build-slim`        | Slim binaries                       |
 | **Test**        | `make test`              | Full test suite                     |
@@ -61,185 +35,62 @@ Only pause to ask for confirmation when:
 | **Lint**        | `make lint`              | Always run after changes            |
 | **Generate**    | `make gen`               | After database changes              |
 | **Format**      | `make fmt`               | Auto-format code                    |
-| **Clean**       | `make clean`             | Clean build artifacts               |
 | **Pre-commit**  | `make pre-commit`        | Fast CI checks (gen/fmt/lint/build) |
 | **Pre-push**    | `make pre-push`          | Heavier CI checks (allowlisted)     |
 
-### Documentation Commands
+Docs: `pnpm run format-docs` and `pnpm run lint-docs`.
+Storybook: `pnpm run storybook` (from `site/`).
 
-- `pnpm run format-docs` - Format markdown tables in docs
-- `pnpm run lint-docs` - Lint and fix markdown files
-- `pnpm run storybook` - Run Storybook (from site directory)
+## Read the guide for the area you touch
 
-## Critical Patterns
+Do not front-load everything; read what the task needs and as new
+requirements appear.
 
-Detailed workflow and topic guidance lives in the imported docs. Keep root
-instructions focused on guardrails that agents should see immediately.
+- Dev server and development loop: [.claude/docs/WORKFLOWS.md](.claude/docs/WORKFLOWS.md)
+- Git workflow and hooks: [.claude/docs/WORKFLOWS.md](.claude/docs/WORKFLOWS.md)
+- API design guardrails: [.claude/docs/WORKFLOWS.md](.claude/docs/WORKFLOWS.md)
+- Go code: [.claude/docs/GO.md](.claude/docs/GO.md)
+- Tests: [.claude/docs/TESTING.md](.claude/docs/TESTING.md)
+- Database, migrations, queries: [.claude/docs/DATABASE.md](.claude/docs/DATABASE.md)
+- OAuth2, authorization: [.claude/docs/OAUTH2.md](.claude/docs/OAUTH2.md)
+- System overview: [.claude/docs/ARCHITECTURE.md](.claude/docs/ARCHITECTURE.md)
+- Logs, tracing, metrics: [.claude/docs/OBSERVABILITY.md](.claude/docs/OBSERVABILITY.md)
+- Ports, state, readiness, cleanup: [.claude/docs/DEV_ISOLATION.md](.claude/docs/DEV_ISOLATION.md)
+- Failure formats, common failures: [.claude/docs/AGENT_FAILURES.md](.claude/docs/AGENT_FAILURES.md)
+- Frontend, anything under `site/`: [site/AGENTS.md](site/AGENTS.md), read before changing `site/`
+- aibridge package: [aibridge/AGENTS.md](aibridge/AGENTS.md)
+- chatd subsystem: [coderd/x/chatd/ARCHITECTURE.md](coderd/x/chatd/ARCHITECTURE.md), update it when your change affects the architecture
+- Docs content scope and routing: [docs/.style/content-guidelines.md](docs/.style/content-guidelines.md), governs on conflicts
+- Docs prose style: [docs/.style/style-guide/](docs/.style/style-guide/README.md)
+- Authoring new, moved, or restructured docs pages: [.claude/skills/write-docs/SKILL.md](.claude/skills/write-docs/SKILL.md)
+- PR creation, descriptions, and follow-up: [.agents/skills/pull-requests/SKILL.md](.agents/skills/pull-requests/SKILL.md)
 
-- **Database changes**: Follow
-  [Database Development Patterns](.claude/docs/DATABASE.md). Modify
-  `coderd/database/queries/*.sql`, run `make gen`, update
-  `enterprise/audit/table.go` for audit errors, then run `make gen` again.
-- **LSP navigation**: Use LSP tools first. See
-  [Modern Go](.claude/docs/GO.md) for Go LSP and
-  [Frontend Development Guidelines](site/AGENTS.md) for TypeScript LSP.
-- **OAuth2 and authorization**: Follow
-  [OAuth2 Development Guide](.claude/docs/OAUTH2.md). OAuth2 endpoints must
-  use RFC-compliant errors such as `writeOAuth2Error(...)`, and public
-  endpoints that need system access should use `dbauthz.AsSystemRestricted`.
-- **Chatd**: consult [Chatd Architecture](coderd/x/chatd/ARCHITECTURE.md) to
-  understand the architecture of the chatd subsystem. If you update the
-  chatd subsystem in ways that affect the architecture, you must update the
-  architecture document.
-- **API design**: Follow the API guardrails in
-  [Development Workflows and Guidelines](.claude/docs/WORKFLOWS.md),
-  including swagger annotations for new public HTTP endpoints.
-- **Transactions and conversions**: Keep `InTx` work on the transaction
-  handle, and prefer explicit db-to-SDK converters. See
-  [Database Development Patterns](.claude/docs/DATABASE.md).
-- **Testing**: Follow
-  [Testing Patterns and Best Practices](.claude/docs/TESTING.md). Use unique
-  identifiers in concurrent tests and do not use `time.Sleep` to mitigate
-  timing issues.
-- **Frontend**: Read [Frontend Development Guidelines](site/AGENTS.md)
-  before changing anything under `site/`. Reuse shared UI primitives when
-  possible and prefer Storybook stories for component and page testing.
+Compatibility: `.agents/docs` symlinks to `.claude/docs`; `CLAUDE.md`
+symlinks to `AGENTS.md` at the root and in `site/`.
 
-## Quick Reference
+## Non-negotiable guardrails
 
-### Full workflows available in imported WORKFLOWS.md
+- Install and use the git hooks. Never bypass them with `--no-verify`.
+  The first run can be slow while caches warm up; wait for completion.
+- Commit and PR title format: `type(scope): message`. A scope must be a
+  real filesystem path containing every changed file; use a broader path
+  or omit the scope for cross-cutting changes.
+- No emdash (U+2014), endash (U+2013), or ` -- ` as punctuation in code,
+  comments, string literals, or documentation. Use commas, semicolons, or
+  periods; `make lint/emdash` enforces this.
+- Write comments only when they preserve concise, verifiable,
+  non-obvious information that the code, names, types, or tests do not
+  convey, especially why a surprising constraint or behavior exists.
+  Never restate code, speculate, narrate future work, or describe change
+  history (no `// Added per PR feedback`). Delete comments that add no
+  information; preserve existing comments that explain non-obvious
+  behavior.
+- Use LSP tools first for code navigation (Go: see GO.md; TypeScript: see
+  site/AGENTS.md).
+- Do not use `git push --force` unless explicitly requested.
 
-### Git Hooks (MANDATORY - DO NOT SKIP)
+## Local configuration
 
-You MUST install and use the git hooks. NEVER bypass them with
-`--no-verify`. Skipping hooks wastes CI cycles and is unacceptable.
-
-The first run can be slow while caches warm up. Wait for hooks to complete,
-even when `git commit` or `git push` appears to hang.
-
-See [Development Workflows and Guidelines](.claude/docs/WORKFLOWS.md) for
-hook setup, pre-commit behavior, pre-push behavior, and failure handling.
-
-### Git Workflow
-
-When working on existing PRs, check out the branch first. See
-[Development Workflows and Guidelines](.claude/docs/WORKFLOWS.md) for the
-full workflow. Don't use `git push --force` unless explicitly requested.
-
-### New Feature Checklist
-
-See [Development Workflows and Guidelines](.claude/docs/WORKFLOWS.md) for
-the new feature checklist, including `git pull`, database migration checks,
-and audit table checks.
-
-## Architecture
-
-- **coderd**: Main API service
-- **provisionerd**: Infrastructure provisioning
-- **Agents**: Workspace services (SSH, port forwarding)
-- **Database**: PostgreSQL with `dbauthz` authorization
-
-## Code Style
-
-### Detailed guidelines in imported WORKFLOWS.md
-
-- Follow [Uber Go Style Guide](https://github.com/uber-go/guide/blob/master/style.md)
-- Commit format: `type(scope): message`
-- PR titles follow the same `type(scope): message` format.
-- When you use a scope, it must be a real filesystem path containing every
-  changed file.
-- Use a broader path scope, or omit the scope, for cross-cutting changes.
-- Example: `fix(coderd/chatd): ...` for changes only in `coderd/chatd/`.
-
-### Frontend Patterns
-
-- Prefer existing shared UI components and utilities over custom
-  implementations. Reuse common primitives such as loading, table, and error
-  handling components when they fit the use case.
-- Use Storybook stories for all component and page testing, including
-  visual presentation, user interactions, keyboard navigation, focus
-  management, and accessibility behavior. Do not create standalone
-  vitest/RTL test files for components or pages. Stories double as living
-  documentation, visual regression coverage, and interaction test suites
-  via `play` functions. Reserve plain vitest files for pure logic only:
-  utility functions, data transformations, hooks tested via
-  `renderHook()` that do not require DOM assertions, and query/cache
-  operations with no rendered output.
-
-### Writing Comments and Avoiding Unnecessary Changes
-
-See [Modern Go](.claude/docs/GO.md) for comment formatting and the rule to
-avoid unrelated edits. Preserve existing comments that explain non-obvious
-behavior unless the task directly requires changing them.
-
-Comments MUST be **substantive** and **concise**. Describe the **behaviour**
-of the code, not the reasoning the agent used to produce the change. Do not
-leave comments like `// Added per PR feedback` or `// Refactored for
-clarity`. Instead, explain what the code does and why the behaviour matters.
-
-### No Emdash or Endash
-
-Do not use emdash (U+2014), endash (U+2013), or ` -- ` as punctuation
-in code, comments, string literals, or documentation. Use commas,
-semicolons, or periods instead. Restructure the sentence if needed.
-Do not replace an emdash with ` -- `. Unicode emdash and endash are
-caught by `make lint/emdash`.
-
-```go
-// Good: uses a period to separate the clauses.
-// This is slow. We should cache it.
-
-// Good: uses a comma to join related clauses.
-// This is slow, so we should cache it.
-```
-
-## Detailed Development Guides
-
-@.claude/docs/ARCHITECTURE.md
-@.claude/docs/GO.md
-@.claude/docs/OAUTH2.md
-@.claude/docs/TESTING.md
-@.claude/docs/TROUBLESHOOTING.md
-@.claude/docs/DATABASE.md
-@.claude/docs/PR_STYLE_GUIDE.md
-@.claude/docs/DOCS_STYLE_GUIDE.md
-
-If your agent tool does not auto-load `@`-referenced files, read these
-manually before starting work:
-
-**Always read:**
-
-- `.claude/docs/WORKFLOWS.md` - dev server, git workflow, hooks
-
-**Read when relevant to your task:**
-
-- `.claude/docs/GO.md` - Go patterns and modern Go usage (any Go changes)
-- `.claude/docs/TESTING.md` - testing patterns, race conditions (any test changes)
-- `.claude/docs/DATABASE.md` - migrations, SQLC, audit table (any DB changes)
-- `.claude/docs/ARCHITECTURE.md` - system overview (orientation or architecture work)
-- `.claude/docs/PR_STYLE_GUIDE.md` - PR description format (when writing PRs)
-- `.claude/docs/OAUTH2.md` - OAuth2 and RFC compliance (when touching auth)
-- `.claude/docs/TROUBLESHOOTING.md` - common failures and fixes (when stuck)
-- `.claude/docs/DOCS_STYLE_GUIDE.md` - docs prose and formatting (when writing `docs/`)
-- `docs/.style/content-guidelines.md` - canonical content scope and routing rules (when writing `docs/`; governs on conflicts with the style guide)
-- `.claude/skills/write-docs/SKILL.md` - authoring workflow and guardrails (for new, moved, or restructured `docs/` pages)
-
-**For frontend work**, also read `site/AGENTS.md` before making any changes
-in `site/`.
-
-## Local Configuration
-
-These files may be gitignored, read manually if not auto-loaded.
+This file may be gitignored; read manually if not auto-loaded.
 
 @AGENTS.local.md
-
-## Common Pitfalls
-
-1. **Audit table errors** → Update `enterprise/audit/table.go`
-2. **OAuth2 errors** → Return RFC-compliant format
-3. **Race conditions** → Use unique test identifiers
-4. **Missing newlines** → Ensure files end with newline
-
----
-
-*This file stays lean and actionable. Detailed workflows and explanations are imported automatically.*

--- a/scripts/check_agents_structure.sh
+++ b/scripts/check_agents_structure.sh
@@ -84,7 +84,7 @@ done
 
 if [[ -f AGENTS.md ]]; then
 	root_agent_lines=$(wc -l <AGENTS.md)
-	if ((root_agent_lines > 600)); then
+	if ((root_agent_lines > 150)); then
 		echo "warning: AGENTS.md is $root_agent_lines lines, consider keeping the root guide concise."
 	fi
 fi


### PR DESCRIPTION
## Stack Context

Part of a 5-PR stack thinning the agent instruction corpus. Split from #27203. This PR fixes the single largest cost: startup context size.

## Why?

The root `AGENTS.md` used `@` imports that expanded nine topic guides plus `package.json` into every agent session: roughly 23K tokens loaded before the task is even known. Most tasks never touch most guides (a docs edit does not need the OAuth2 guide), so the corpus mostly taxed the context window and diluted attention over the rules that matter. Bugs in an unrelated guide could also derail unrelated tasks.

## What?

- Replace the imports with a ~100-line routing contract: essential commands, a compact task-to-guide list ("read the guide for the area you touch"), and the non-negotiable guardrails that must hold on every task regardless of area.
- Root guardrails keep only universal rules (hooks, commit format, emdash ban, comment policy, LSP-first navigation, no force-push). Domain rules (database gen flow, OAuth2 errors, test timing) live in their topic guides, reached through the routing list.
- Update `scripts/check_agents_structure.sh` for the new shape.
- `CLAUDE.md` still symlinks to `AGENTS.md`; no consumer breaks.

Guardrails were preserved in meaning; what changed is that detail moved behind routes instead of being inlined everywhere.

> This PR was prepared by Mux (AI agent) on Mike's behalf.
