### PR TITLE
docs(.agents/skills): thin review skills and replace generic references with repo deltas

### DIFF
--- a/.agents/skills/coder-agents-review/SKILL.md
+++ b/.agents/skills/coder-agents-review/SKILL.md
@@ -1,141 +1,68 @@
 ---
 name: coder-agents-review
-description: "Use this skill when a repository already has an open pull request and you need to run the Coder Agents Review loop: request review with `/coder-agents-review` when needed, wait for feedback from the `coder-agents-review` GitHub app, fix issues, and repeat until the app comments `approved`."
+description: "Run the Coder Agents Review loop on an open PR: trigger the GitHub app, fix feedback, and repeat until explicit approval."
 ---
 
 # Coder Agents Review Loop
 
-## Goal
+Drive an existing PR until `coder-agents-review` explicitly approves the current work.
 
-Drive an existing pull request until the GitHub app `coder-agents-review`
-has approved the current work.
+## Completion contract
 
-The loop is:
+Stop only when all conditions hold:
 
-1. if the PR has no existing `coder-agents-review` review, comment, or
-   pending trigger, post `/coder-agents-review`
-2. wait for `coder-agents-review` to respond
-3. fix actionable issues with the smallest safe diff
-4. validate and push
-5. request another review with `/coder-agents-review`
-6. repeat until the app comments `approved`
+- The latest relevant app response says `approved` on a complete status line, case-insensitively, or is an `APPROVED` review from the app.
+- No actionable app thread remains unresolved, unless a reported policy or permission blocker prevents resolution.
+- Relevant validation ran after the last change.
+- The branch is pushed.
 
-## Definition of done
+Never treat silence, old feedback, substring author matches, unpaginated
+activity, or arbitrary uses of the word `approved` as approval.
 
-Only stop when all of these are true:
+## Configuration
 
-- the latest `coder-agents-review` response for the current work says
-  `approved` (case-insensitive), or is a GitHub `APPROVED` review from
-  that app
-- there are no unresolved actionable `coder-agents-review` review threads
-  left from the latest feedback, unless a policy or permission blocker
-  prevents resolution and you reported it
-- local validation relevant to the touched code has been run after the
-  last changes
-- the branch has been pushed
-
-If you stop early, say exactly why.
-
-## Non-negotiable behavior
-
-- Inspect the PR before posting anything.
-- If the PR has no review or comment from `coder-agents-review` and no
-  pending trigger comment, post a top-level PR comment with the exact
-  body `/coder-agents-review`.
-- If `coder-agents-review` activity is already present, start from that
-  feedback instead of posting a duplicate trigger immediately.
-- After every fix push, post `/coder-agents-review` again.
-- Wait indefinitely for the app's first response after each request. Do
-  not treat silence as approval.
-- Fix the app's actionable feedback with the smallest reasonable diff.
-  Avoid unrelated cleanup.
-- Resolve addressed app review threads if you can. If you cannot, reply
-  with a short fix summary and report the blocker.
-- Never create or merge a PR unless the user explicitly asks.
-
-## Defaults and config
-
-Use repository conventions first. Otherwise use these defaults.
-
-- `PR_NUMBER`: PR number to operate on. If unset, infer it from the
-  current branch's open PR.
-- `REVIEW_TRIGGER`: exact request comment.
-
-  ```text
-  /coder-agents-review
-  ```
-
-- `REVIEW_APP_LOGIN_REGEX`: default match for the app author login.
-
-  ```text
-  ^coder-agents-review(\[bot\])?$
-  ```
-
-- `APPROVED_REGEX`: case-insensitive match for an explicit approving
-  status line from the app.
-
-  ```text
-  ^[[:space:]>]*approved[[:space:].!]*$
-  ```
-
-  Apply this only to individual status lines from the app response, not
-  to arbitrary body text. Negative phrases such as `not approved` or
-  `cannot be approved yet` are feedback, not approval.
-
-- `LOCAL_VALIDATE_CMD`: repo-standard validation command.
-- `LOCAL_TEST_CMD`: optional targeted validation for the touched area.
+- `PR_NUMBER`: infer from the current branch when unset.
+- `REVIEW_TRIGGER`: exact body `/coder-agents-review`.
+- `REVIEW_APP_LOGIN_REGEX`: `^coder-agents-review(\[bot\])?$`.
+- `APPROVED_REGEX`: `^[[:space:]>]*approved[[:space:].!]*$`, applied
+  case-insensitively to individual app-response lines. `not approved` and
+  `cannot be approved yet` are not approvals.
+- `LOCAL_VALIDATE_CMD`: repository validation command.
+- `LOCAL_TEST_CMD`: optional targeted validation.
 - `POLL_INTERVAL_SEC`: default `30`.
-- `PAGE_SIZE`: default `100`. Use it for each GitHub pagination
-  request, not as a cap on the total activity fetched.
+- `PAGE_SIZE`: default `100` per page, never a total-activity cap.
 
-If the app login does not match the default regex, discover the exact
-app author login from trusted GitHub activity or metadata, then match
-only that login. Do not guess when the evidence is unclear.
+If observed app activity uses another login, discover the exact app login from
+trusted GitHub activity or metadata. Match only that login. Do not guess.
 
-## Discover PR context
-
-Confirm GitHub auth:
+## Inspect the PR
 
 ```bash
 gh auth status
 ```
-
-Infer the PR number if needed:
 
 ```bash
 PR_NUMBER="${PR_NUMBER:-$(gh pr view --json number --jq .number)}"
 echo "$PR_NUMBER"
 ```
 
-Get basic PR info:
-
 ```bash
 gh pr view "$PR_NUMBER" --json number,title,url,headRefName,headRefOid,isDraft
 ```
-
-Identify owner and repo:
 
 ```bash
 OWNER="$(gh repo view --json owner --jq .owner.login)"
 REPO="$(gh repo view --json name --jq .name)"
 ```
 
-## Collect app activity
+Inspect before posting. If app activity exists, handle it first. Post a trigger
+only when there is no app response to handle and no pending trigger.
 
-Inspect top-level PR comments, PR reviews, and review threads. Fetch all
-pages before deriving review state. GitHub GraphQL connections are
-paginated, so a single `first:100` request can miss newer review-app
-activity on busy PRs.
+## Collect complete app activity
 
-Page these connections until `pageInfo.hasNextPage` is false:
-
-- `comments`, for top-level PR comments
-- `reviews`, for PR reviews
-- `reviewThreads`, for review thread metadata
-- each review thread's `comments`, when its nested comment connection has
-  more pages
-
-Example page query:
+Fetch every page of top-level comments, reviews, review threads, and each
+thread's nested comments before deriving state. Page each connection until
+`pageInfo.hasNextPage` is false.
 
 ```bash
 gh api graphql -f query='query(
@@ -198,63 +125,35 @@ gh api graphql -f query='query(
 -F pageSize="${PAGE_SIZE:-100}"
 ```
 
-If a review thread's nested `comments.pageInfo.hasNextPage` is true,
-fetch that thread by node ID and keep paging its comments before using
-that thread to decide whether feedback remains unresolved.
+If nested thread comments have another page, fetch the thread by node ID and
+page its comments before classifying resolution.
 
-Build these facts from the complete paginated activity set:
+From the complete activity set, derive:
 
-- latest exact trigger comment with body `/coder-agents-review`
-- latest top-level comment from the review app
-- latest PR review from the review app
-- latest review-app approval signal, either a review with state
-  `APPROVED` or a comment body matching `APPROVED_REGEX`
-- unresolved review threads where the latest relevant comment came from
-  the review app
+- Latest exact `/coder-agents-review` trigger.
+- Latest app top-level comment and PR review.
+- Latest app approval signal: `APPROVED` review or complete status line matching
+  `APPROVED_REGEX`.
+- Unresolved threads whose latest relevant comment came from the app.
 
-Treat the app as matched when the author login matches
-`REVIEW_APP_LOGIN_REGEX`, or when it exactly equals a discovered app
-login. Do not treat a substring match as sufficient.
+Match authors only by `REVIEW_APP_LOGIN_REGEX` or the exact discovered login.
 
-## Request rules
+## Request and wait
 
-### First request
-
-If the PR has no review or comment from `coder-agents-review`, and no
-existing `/coder-agents-review` trigger comment that the app has not yet
-responded to, post the exact trigger comment:
+For the first request, post only if no app activity and no unanswered trigger
+exists:
 
 ```bash
 gh pr comment "$PR_NUMBER" --body "/coder-agents-review"
 ```
 
-If a trigger comment already exists but the app has not responded yet,
-skip posting and enter the wait loop.
+If an unanswered trigger exists, do not duplicate it. If existing feedback is
+actionable, fix it before requesting again. If an old approval cannot be tied
+confidently to the current head, request a fresh review after pushing the
+intended changes.
 
-### Existing activity already present
-
-If the PR already has `coder-agents-review` activity, do not post another
-trigger immediately just because the skill started.
-
-Instead:
-
-1. inspect the latest app feedback
-2. if the latest app response is already an approval for the current work,
-   finish
-3. if the latest app response contains actionable feedback, fix that
-   feedback first
-4. after pushing fixes, post `/coder-agents-review` again
-
-If you cannot confidently tell whether an old approval covers the current
-head SHA, do not guess. Push the intended fixes, then request a fresh
-review.
-
-## Wait loop
-
-After every review request, wait until the app responds. Keep polling. Do
-not replace waiting with a timeout.
-
-A minimal loop is:
+After every request, wait indefinitely for an app comment or review newer than
+the trigger. A timeout is not a completion condition.
 
 ```bash
 while :; do
@@ -265,48 +164,28 @@ while :; do
 done
 ```
 
-A response counts when a new `coder-agents-review` comment or review is
-visible after the latest trigger comment.
+## Handle feedback
 
-## Handling feedback
+For each response:
 
-When the app leaves feedback:
+1. Build a worklist from unresolved app threads and actionable top-level app
+   comments.
+2. Classify items as `fix-now`, `already-satisfied`, `blocked`, or
+   `out-of-scope`.
+3. Make the smallest safe in-scope fixes. Avoid unrelated cleanup.
+4. Run validation, fix failures, and push.
+5. Resolve addressed threads. If resolution is blocked, reply with a concise
+   fix summary, leave the thread open, and report the blocker.
+6. Post `/coder-agents-review` again and return to the wait loop.
 
-1. build a worklist from unresolved app review threads and any actionable
-   top-level app comments
-2. classify each item as `fix-now`, `already-satisfied`, `blocked`, or
-   `out-of-scope`
-3. implement the smallest safe in-scope fixes
-4. run local validation
-5. push the branch
-6. resolve the threads you actually fixed, or reply with a concise summary
-   if resolution is blocked
-7. post `/coder-agents-review` again
-8. return to the wait loop
-
-Do not widen scope for opportunistic cleanup.
-
-## Validation
-
-Before every new review request:
-
-1. run the repository's standard validation command, if available
-2. run targeted tests for the touched area, if appropriate
-3. fix failures before pushing
-
-Examples:
+Before every new request:
 
 ```bash
 test -n "${LOCAL_VALIDATE_CMD:-}" && eval "$LOCAL_VALIDATE_CMD"
 test -n "${LOCAL_TEST_CMD:-}" && eval "$LOCAL_TEST_CMD"
 ```
 
-Do not claim success if code changed but relevant validation did not run.
-
-## Resolving review threads
-
-Prefer repository helpers if they exist. Otherwise resolve threads with
-GitHub GraphQL:
+Resolve threads with repository helpers when available, otherwise use:
 
 ```bash
 gh api graphql -f query='mutation($id: ID!) {
@@ -318,50 +197,23 @@ gh api graphql -f query='mutation($id: ID!) {
 }' -F id="<thread_id>"
 ```
 
-If you cannot resolve a fixed thread yourself:
+After every fix push, post the exact trigger again. Never merge or create a PR
+unless the user explicitly asks.
 
-- leave a concise reply describing the fix
-- keep the thread open
-- report the blocker in the final summary
+## Approval and final report
 
-## Completion rule
+A valid approval is an app review with state `APPROVED`, or a top-level app
+comment containing a complete line matching `APPROVED_REGEX`. Split comment
+bodies into lines. If the latest relevant app response is anything else, keep
+iterating.
 
-Only finish when the latest relevant app response is an approval for the
-current work.
+Report:
 
-A valid approval is either:
+- PR number, URL, and current head SHA.
+- Last trigger and app-response times.
+- Exact approval evidence.
+- Remaining unresolved app threads and blockers.
+- Validation run after the final changes.
 
-- a review from the app with state `APPROVED`, or
-- a top-level app comment with an explicit approving status line that
-  matches `APPROVED_REGEX`
-
-When checking `APPROVED_REGEX`, split the comment body into lines and
-match a complete line. Do not search arbitrary prose for the word
-`approved`.
-
-If the latest app response is anything else, keep iterating.
-
-## Final report
-
-When the loop finishes, report:
-
-- PR number and URL
-- current head SHA
-- when `/coder-agents-review` was last requested
-- when `coder-agents-review` last responded
-- the approval evidence, review state or matching comment text
-- whether any app threads remain unresolved, and why
-- what validation was run
-- any blockers if the loop ended early
-
-## Operating rules
-
-- Never post duplicate trigger comments on the same head when the app is
-  already reviewing or has already left feedback you have not handled yet.
-- Never treat silence as approval.
-- Never claim success without explicit app approval evidence.
-- Never accept review-app activity from a substring author match.
-- Never ignore unresolved actionable app feedback.
-- Never skip validation after making changes.
-- Never derive approval or completion from unpaginated PR activity.
-- Prefer `gh` and repo-native helpers over manual browser work.
+If forced to stop before approval, state the concrete blocker. Never claim the
+loop succeeded.

--- a/.agents/skills/deep-review/SKILL.md
+++ b/.agents/skills/deep-review/SKILL.md
@@ -1,315 +1,176 @@
 ---
 name: deep-review
-description: "Multi-reviewer code review. Spawns domain-specific reviewers in parallel, cross-checks findings, posts a single structured GitHub review."
+description: "Multi-reviewer code review that cross-checks domain findings and posts one structured GitHub review."
 ---
 
 # Deep Review
 
-Multi-reviewer code review. Spawns domain-specific reviewers in parallel, cross-checks their findings for contradictions and convergence, then posts a single structured GitHub review with inline comments.
+Run independent domain reviewers in parallel, cross-check their findings, then post one structured GitHub review.
 
-## When to use this skill
+## 0. Check proportionality
 
-- PRs touching 3+ subsystems, >500 lines, or requiring domain-specific expertise (security, concurrency, database).
-- When you want independent perspectives cross-checked against each other, not just a single-pass review.
+Use deep review for changes touching at least three subsystems, more than about 500 lines, or specialized risks such as security, concurrency, or databases.
+If the PR has fewer than three files and fewer than 100 changed lines, and has no specialized risk, use [code-review](../../../.claude/skills/code-review/SKILL.md). For docs-only or
+config-only PRs, use [doc-check](../../../.claude/skills/doc-check/SKILL.md).
+Deep review requires parallel subagents.
 
-Use `.claude/skills/code-review/` for focused single-domain changes or quick single-pass reviews.
-
-**Prerequisite:** This skill requires the ability to spawn parallel subagents. If your agent runtime cannot spawn subagents, use code-review instead.
-
-**Severity scales:** Deep-review uses P0–P4 (consequence-based). Code-review uses 🔴🟡🔵. Both are valid; they serve different review depths. Approximate mapping: P0–P1 ≈ 🔴, P2 ≈ 🟡, P3–P4 ≈ 🔵.
-
-## When NOT to use this skill
-
-- Docs-only or config-only PRs (no code to structurally review). Use `.claude/skills/doc-check/` instead.
-- Single-file changes under ~50 lines.
-- The PR author asked for a quick review.
-
-## 0. Proportionality check
-
-Estimate scope before committing to a deep review. If the PR has fewer than 3 files and fewer than 100 lines changed, suggest code-review instead. If the PR is docs-only, suggest doc-check. Proceed only if the change warrants multi-reviewer analysis.
+Deep-review severity is P0-P4. Approximate code-review mapping: P0-P1 is red, P2 is yellow, and P3-P4 is blue.
 
 ## 1. Scope the change
 
-**Author independence.** Review with the same rigor regardless of who authored the PR. Don't soften findings because the author is the person who invoked this review, a maintainer, or a senior contributor. Don't harden findings because the author is a new contributor. The review's value comes from honest, consistent assessment.
-
-Create the review output directory before anything else:
+Review every author with the same rigor. Create an output directory:
 
 ```sh
 export REVIEW_DIR="/tmp/deep-review/$(date +%s)"
 mkdir -p "$REVIEW_DIR"
 ```
 
-**Re-review detection.** Check if you or a previous agent session already reviewed this PR:
+Check for an earlier agent review:
 
 ```sh
 gh pr view {number} --json reviews --jq '.reviews[] | select(.body | test("P[0-4]|\\*\\*Obs\\*\\*|\\*\\*Nit\\*\\*")) | .submittedAt' | head -1
 ```
 
-If a prior agent review exists, you must produce a prior-findings classification table before proceeding. This is not optional — the table is an input to step 3 (reviewer prompts). Without it, reviewers will re-discover resolved findings.
+For a re-review, read author replies, answer their questions, and inspect changes since the prior review. Write `$REVIEW_DIR/prior-findings.md` with columns for finding, author response, and
+status. Classify each item as:
 
-1. Read every author response since the last review (inline replies, PR comments, commit messages).
-2. Diff the branch to see what changed since the last review.
-3. Engage with any author questions before re-raising findings.
-4. Write `$REVIEW_DIR/prior-findings.md` with this format:
+- **Resolved:** verify the fix and check for regressions.
+- **Acknowledged:** the author agreed but deferred it.
+- **Contested:** preserve the author's argument.
+- **No response:** the author did not address it.
 
-```markdown
-# Prior findings from round {N}
+Carry only Contested and No response findings into the new review. Do not re-raise Resolved or Acknowledged findings.
 
-| Finding | Author response | Status |
-|---------|----------------|--------|
-| P1 `file.go:42` wire-format break | Acknowledged, pushed fix in abc123 | Resolved |
-| P2 `handler.go:15` missing auth check | "Middleware handles this" — see comment | Contested |
-| P3 `db.go:88` naming | Agreed, will fix | Acknowledged |
-```
+Inspect the changed files and surrounding code. Record touched layers, intent, and domain risks. Check whether new files or abstractions duplicate established
+patterns.
 
-Classify each finding as:
+## 2. Select reviewer lanes
 
-- **Resolved**: author pushed a code fix. Verify the fix addresses the finding's specific concern — not just that code changed in the relevant area. Check that the fix doesn't introduce new issues.
-- **Acknowledged**: author agreed but deferred.
-- **Contested**: author disagreed or raised a constraint. Write their argument in the table.
-- **No response**: author didn't address it.
+Always run these structural lanes:
 
-Only **Contested** and **No response** findings carry forward to the new review. Resolved and Acknowledged findings must not be re-raised.
+| Lane | Focus |
+| --- | --- |
+| Test Auditor | Test authenticity, missing cases, readability |
+| Edge Case Analyst | Edge cases, failure paths, hidden connections |
+| Contract Auditor | Contract fidelity, lifecycle completeness, semantic honesty |
 
-**Scope the diff.** Get the file list from the diff, PR, or user. Skim for intent and note which layers are touched (frontend, backend, database, auth, concurrency, tests, docs).
+Add lanes when their domain is touched:
 
-For each changed file, briefly check the surrounding context:
+| Lane | Trigger and focus |
+| --- | --- |
+| Structural Analyst | API or type design, resource lifecycle, class-of-bug removal |
+| Performance Analyst | Hot paths, loops, caches, allocation, resource exhaustion |
+| Database Reviewer | Migrations, queries, schema, indexes, Go and SQL boundaries |
+| Security Reviewer | Auth, endpoints, input handling, tokens, secrets |
+| Product Reviewer | New features, config surfaces, over-engineering |
+| Frontend Reviewer | UI state, render lifecycle, components, API shapes |
+| Duplication Checker | New files, helpers, utilities, types, components |
+| Go Architect | Go packages, API lifecycle, middleware, boundaries |
+| Concurrency Reviewer | Goroutines, channels, locks, cancellation, shutdown |
 
-- Config files (package.json, tsconfig, vite.config, etc.): scan the existing entries for naming conventions and structural patterns.
-- New files: check if an existing file could have been extended instead.
-- Comments in the diff: do they explain why, or just restate what the code does?
+Also run nit lanes:
 
-## 2. Pick reviewers
+- **Modernization Reviewer:** one per language with a non-empty filtered diff.
+  - Go, `*.go`, read [the Go guide](../../../.claude/docs/GO.md).
+  - TypeScript, `*.ts` and `*.tsx`, read [the TypeScript delta](references/typescript.md).
+  - React, `*.tsx` and `*.jsx`, read [the React delta](references/react.md).
+- **Style Reviewer:** `*.go`, `*.ts`, `*.tsx`, `*.py`, and `*.sh`.
 
-Match reviewer roles to layers touched. The Test Auditor, Edge Case Analyst, and Contract Auditor always run. Conditional reviewers activate when their domain is touched.
+Run both TypeScript and React lanes for `.tsx` changes.
 
-### Tier 1 — Structural reviewers
+## 3. Spawn reviewers in parallel
 
-| Role                 | Focus                                                       | When                                                        |
-| -------------------- | ----------------------------------------------------------- | ----------------------------------------------------------- |
-| Test Auditor         | Test authenticity, missing cases, readability               | Always                                                      |
-| Edge Case Analyst    | Chaos testing, edge cases, hidden connections               | Always                                                      |
-| Contract Auditor     | Contract fidelity, lifecycle completeness, semantic honesty | Always                                                      |
-| Structural Analyst   | Implicit assumptions, class-of-bug elimination              | API design, type design, test structure, resource lifecycle |
-| Performance Analyst  | Hot paths, resource exhaustion, allocation patterns         | Hot paths, loops, caches, resource lifecycle                |
-| Database Reviewer    | PostgreSQL, data modeling, Go↔SQL boundary                  | Migrations, queries, schema, indexes                        |
-| Security Reviewer    | Auth, attack surfaces, input handling                       | Auth, new endpoints, input handling, tokens, secrets        |
-| Product Reviewer     | Over-engineering, feature justification                     | New features, new config surfaces                           |
-| Frontend Reviewer    | UI state, render lifecycles, component design               | Frontend changes, UI components, API response shape changes |
-| Duplication Checker  | Existing utilities, code reuse                              | New files, new helpers/utilities, new types or components   |
-| Go Architect         | Package boundaries, API lifecycle, middleware               | Go code, API design, middleware, package boundaries         |
-| Concurrency Reviewer | Goroutines, channels, locks, shutdown                       | Goroutines, channels, locks, context cancellation, shutdown |
+Each reviewer is read-only and fetches the PR or commit diff. It writes findings to `$REVIEW_DIR/{kebab-role}.md`. Name modernization outputs
+`modernization-reviewer-{go|ts|react}.md`. Do not depend on subagent return text.
 
-### Tier 2 — Nit reviewers
-
-| Role                   | Focus                                        | File filter                         |
-| ---------------------- | -------------------------------------------- | ----------------------------------- |
-| Modernization Reviewer | Language-level improvements, stdlib patterns | Per-language (see below)            |
-| Style Reviewer         | Naming, comments, consistency                | `*.go` `*.ts` `*.tsx` `*.py` `*.sh` |
-
-Tier 2 file filters:
-
-- **Modernization Reviewer**: one instance per language present in the diff. Filter by extension:
-  - Go: `*.go` — reference `.claude/docs/GO.md` before reviewing.
-  - TypeScript: `*.ts` `*.tsx`: reference `.agents/skills/deep-review/references/typescript.md` before reviewing.
-  - React: `*.tsx` `*.jsx`: reference `.agents/skills/deep-review/references/react.md` before reviewing.
-
-  `.tsx` files match both TypeScript and React filters. Spawn both instances when the diff contains `.tsx` changes — TS covers language-level patterns; React covers component and hooks patterns. Before spawning, verify each instance's filter produces a non-empty diff. Skip instances whose filtered diff is empty.
-
-- **Style Reviewer**: `*.go` `*.ts` `*.tsx` `*.py` `*.sh`
-
-## 3. Spawn reviewers
-
-Each reviewer writes findings to `$REVIEW_DIR/{role-name}.md` where `{role-name}` is the kebab-cased role name (e.g. `test-auditor`, `go-architect`). For Modernization Reviewer instances, qualify with the language: `modernization-reviewer-go.md`, `modernization-reviewer-ts.md`, `modernization-reviewer-react.md`. The orchestrator does not read reviewer findings from the subagent return text — it reads the files in step 4.
-
-Spawn all Tier 1 and Tier 2 reviewers in parallel. Give each reviewer a reference (PR number, branch name), not the diff content. The reviewer fetches the diff itself. Reviewers are read-only — no worktrees needed.
-
-**Tier 1 prompt:**
+Use this structural prompt:
 
 ```text
-Read `AGENTS.md` in this repository before starting.
-
-You are the {Role Name} reviewer. Read your methodology in
-`.agents/skills/deep-review/roles/{role-name}.md`.
-
-Follow the review instructions in
-`.agents/skills/deep-review/structural-reviewer-prompt.md`.
-
+Read AGENTS.md before starting.
+You are the {Role Name} reviewer. Read
+.agents/skills/deep-review/roles/{role-name}.md and
+.agents/skills/deep-review/structural-reviewer-prompt.md.
 Review: {PR number / branch / commit range}.
 Output file: {REVIEW_DIR}/{role-name}.md
 ```
 
-**Tier 2 prompt:**
+For nit lanes, replace `structural-reviewer-prompt.md` with
+`nit-reviewer-prompt.md`, add the file filter, and add the language reference
+from step 2 for modernization lanes.
+
+For re-reviews, append:
 
 ```text
-Read `AGENTS.md` in this repository before starting.
-
-You are the {Role Name} reviewer. Read your methodology in
-`.agents/skills/deep-review/roles/{role-name}.md`.
-
-Follow the review instructions in
-`.agents/skills/deep-review/nit-reviewer-prompt.md`.
-
-Review: {PR number / branch / commit range}.
-File scope: {filter from step 2}.
-Output file: {REVIEW_DIR}/{role-name}.md
+Read {REVIEW_DIR}/prior-findings.md. Do not re-raise Resolved or Acknowledged findings.
 ```
 
-For Modernization Reviewer instances, add the language reference after the methodology line:
+## 4. Cross-check and deduplicate
 
-- **Go:** `Read .claude/docs/GO.md as your Go language reference before reviewing.`
-- **TypeScript:** `Read .agents/skills/deep-review/references/typescript.md as your TypeScript language reference before reviewing.`
-- **React:** `Read .agents/skills/deep-review/references/react.md as your React language reference before reviewing.`
+Read reviewer files one at a time to preserve attribution. Inventory each
+finding's severity, location, summary, and exact evidence. Record missing or
+failed lanes instead of silently dropping them.
 
-For re-reviews, append to both Tier 1 and Tier 2 prompts:
+Filter Tier 2 nits first. Drop subjective preferences, intentional choices, and
+issues already enforced by tooling. Keep only practical improvements.
 
-> Prior findings and author responses are in {REVIEW_DIR}/prior-findings.md. Read it before reviewing. Do not re-raise Resolved or Acknowledged findings.
+Cross-check structural findings for:
 
-## 4. Cross-check findings
+- **Contradictions:** preserve opposing recommendations and explain the conflict.
+- **Interactions:** link findings that solve or worsen each other.
+- **Convergence:** combine overlapping findings, trace their joint consequence,
+  and reassess severity. Convergence is not a vote count.
+- **Mechanism versus consequence:** restate the user, security, data, or
+  regression impact before accepting severity.
+- **Async chains:** trace the final visible or stateful effect, not only the
+  missing cancellation or late callback.
+- **Evidence:** downgrade or drop claims that are not demonstrated in the diff.
+- **Novelty and duplication:** flag unnecessary new patterns or abstractions.
+- **Scope:** downgrade redesign requests unrelated to the changed behavior.
+- **Structural alternatives:** preserve designs that remove a documented
+  tradeoff, even if the current code works.
+- **Pre-existing behavior:** keep findings when new code now depends on or
+  describes that behavior incorrectly.
 
-### 4a. Read findings from files
+Test every finding and observation for both upgrades and downgrades. Note a
+severity spread greater than one level. A finding independently supported by at
+least two reviewers needs a concrete counterargument before it is dropped.
+Fold a nit into a structural finding when they target the same issue.
 
-Read each reviewer's output file from `$REVIEW_DIR/` one at a time. One file per read — do not batch multiple reviewer files in parallel. Batching causes reviewer voices to blend in the context window, leading to misattribution (grabbing phrasing from one reviewer and attributing it to another).
+Use reviewer evidence as the source of record. Quote it exactly, then add
+orchestrator framing and practical judgment. For convergence, start with the
+sharpest evidence and add only unique evidence from up to two other reviewers.
+Show each credited reviewer's severity. Verify every quote against the diff.
 
-For each file:
+## 5. Post one GitHub review
 
-1. Read the file.
-2. List each finding with its severity, location, and one-line summary.
-3. Note the reviewer's exact evidence line for each finding.
+Post a proper GitHub review with inline comments. Keep the body to two to four
+sentences: summarize the change, mention concrete strong work when present, and count findings. For a
+re-review, summarize what was addressed. Add this sentence for P0 or P1 items:
+`This review contains findings that may need attention before merge.`
 
-If a file says "No findings," record that and move on. If a file is missing (reviewer crashed or timed out), note the gap and proceed — do not stall or silently drop the reviewer's perspective.
-
-After reading all files, you have a finding inventory. Proceed to cross-check.
-
-### 4b. Cross-check
-
-Handle Tier 1 and Tier 2 findings separately before merging.
-
-**Tier 2 nit findings:** Apply a lighter filter. Drop nits that are purely subjective, that duplicate what a linter already enforces, or that the author clearly made intentionally. Keep nits that have a practical benefit (clearer name, better error message, obsolete stdlib usage). Surviving nits stay as Nit.
-
-**Tier 1 structural findings:** Before producing the final review, look across all findings for:
-
-- **Contradictions.** Two reviewers recommending opposite approaches. Flag both and note the conflict.
-- **Interactions.** One finding that solves or worsens another (e.g. a refactor suggestion that addresses a separate cleanup concern). Link them.
-- **Convergence.** Two or more reviewers flagging the same function or component from different angles. Don't just merge at max(severity) and don't treat convergence as headcount ("more reviewers = higher confidence in the same thing"). After listing the convergent findings, trace the consequence chain _across_ them. One reviewer flags a resource leak, another flags an unbounded hang, a third flags infinite retries on reconnect — the combination means a single failure leaves a permanent resource drain with no recovery. That combined consequence may deserve its own finding at higher severity than any individual one.
-- **Async findings.** When a finding mentions setState after unmount, unused cancellation signals, or missing error handling near an await: (1) find the setState or callback, (2) trace what renders or fires as a result, (3) ask "if this fires after the user navigated away, what do they see?" If the answer is "nothing" (a ref update, a console.log), it's P3. If the answer is "a dialog opens" or "state corrupts," upgrade. The severity depends on what's at the END of the async chain, not the start.
-- **Mechanism vs. consequence.** Reviewers describe findings using mechanism vocabulary ("unused parameter", "duplicated code", "test passes by coincidence"), not consequence vocabulary ("dialog opens in wrong view", "attacker can bypass check", "removing this code has no test to catch it"). The Contract Auditor and Structural Analyst tend to frame findings by consequence already — use their framing directly. For mechanism-framed findings from other reviewers, restate the consequence before accepting the severity. Consequences include UX bugs, security gaps, data corruption, and silent regressions — not just things users see on screen.
-- **Weak evidence.** Findings that assert a problem without demonstrating it. Downgrade or drop.
-- **Unnecessary novelty.** New files, new naming patterns, new abstractions where the existing codebase already has a convention. If no reviewer flagged it but you see it, add it. If a reviewer flagged it as an observation, evaluate whether it should be a finding.
-- **Scope creep.** Suggestions that go beyond reviewing what changed into redesigning what exists. Downgrade to P4.
-- **Structural alternatives.** One reviewer proposes a design that eliminates a documented tradeoff, while others have zero findings because the current approach "works." Don't discount this as an outlier or scope creep. A structural alternative that removes the need for a tradeoff can be the highest-value output of the review. Preserve it at its original severity — the author decides whether to adopt it, but they need enough signal to evaluate it.
-- **Pre-existing behavior.** "Pre-existing" doesn't erase severity. Check whether the PR introduced new code (comments, branches, error messages) that describes or depends on the pre-existing behavior incorrectly. The new code is in scope even when the underlying behavior isn't.
-
-For each finding **and observation**, apply the severity test in **both directions**. Observations are not exempt — a reviewer may underrate a convention violation or a missing guarantee as Obs when the consequence warrants P3+:
-
-- Downgrade: "Is this actually less severe than stated?"
-- Upgrade: "Could this be worse than stated?"
-
-When the severity spread among reviewers exceeds one level, note it explicitly. Only credit reviewers at or above the posted severity. A finding that survived 2+ independent reviewers needs an explicit counter-argument to drop. "Low risk" is not a counter when the reviewers already addressed it in their evidence.
-
-Before forwarding a nit, form an independent opinion on whether it improves the code. Before rejecting a nit, verify you can prove it wrong, not just argue it's debatable.
-
-Drop findings that don't survive this check. Adjust severity where the cross-check changes the picture.
-
-After filtering both tiers, check for overlap: a nit that points at the same line as a Tier 1 finding can be folded into that comment rather than posted separately.
-
-### 4c. Quoting discipline
-
-When a finding survives cross-check, the reviewer's technical evidence is the source of record. Do not paraphrase it.
-
-**Convergent findings — sharpest first.** When multiple reviewers flag the same issue:
-
-1. Rank the converging findings by evidence quality.
-2. Start from the sharpest individual finding as the base text.
-3. Layer in only what other reviewers contributed that the base didn't cover (a concrete detail, a preemptive counter, a stronger framing).
-4. Attribute to the 2–3 reviewers with the strongest evidence, not all N who noticed the same thing.
-
-**Single-reviewer findings.** Go back to the reviewer's file and copy the evidence verbatim. The orchestrator owns framing, severity assessment, and practical judgment — those are your words. The technical claim and code-level evidence are the reviewer's words.
-
-A posted finding has two voices:
-
-- **Reviewer voice** (quoted): the specific technical observation and code evidence exactly as the reviewer wrote it.
-- **Orchestrator voice** (original): severity framing, practical judgment ("worth fixing now because..."), scenario building, and conversational tone.
-
-If you need to adjust a finding's scope (e.g. the reviewer said "file.go:42" but the real issue is broader), say so explicitly rather than silently rewriting the evidence.
-
-**Attribution must show severity spread.** When reviewers disagree on severity, the attribution should reflect that — not flatten everyone to the posted severity. Show each reviewer's individual severity: `*(Security Reviewer P1, Concurrency Reviewer P1, Test Auditor P2)*` not `*(Security Reviewer, Concurrency Reviewer, Test Auditor)*`.
-
-**Integrity check.** Before posting, verify that quoted evidence in findings actually corresponds to content in the diff. This guards against garbled cross-references from the file-reading step.
-
-## 5. Post the review
-
-When reviewing a GitHub PR, post findings as a proper GitHub review with inline comments, not a single comment dump.
-
-**Review body.** Open with a short, friendly summary: what the change does well, what the overall impression is, and how many findings follow. Call out good work when you see it. A review that only lists problems teaches authors to dread your comments.
+Inline format:
 
 ```text
-Clean approach to X. The Y handling is particularly well done.
+**P{n}** One-sentence finding *(Reviewer Role P{n})*
 
-A couple things to look at: 1 P2, 1 P3, 3 nits across 5 inline
-comments.
+> Exact reviewer evidence
+
+Practical judgment, consequence, severity reasoning, and a focused fix.
 ```
 
-For re-reviews (round 2+), open with what was addressed:
+Use `**Obs**` or `**Nit**` for those categories. Group co-located nits. For
+convergent findings, credit the strongest two or three reviewers and preserve
+individual severities.
 
-```text
-Thanks for fixing the wire-format break and the naming issue.
-
-Fresh review found one new issue: 1 P2 across 1 inline comment.
-```
-
-Keep the review body to 2–4 sentences. Don't use markdown headers in the body — they render oversized in GitHub's review UI.
-
-**Inline comments.** Every finding is an inline comment, pinned to the most relevant file and line. For findings that span multiple files, pin to the primary file (GitHub supports file-level comments when `position` is omitted or set to 1).
-
-Inline comment format:
-
-```text
-**P{n}** One-sentence finding *(Reviewer Role)*
-
-> Reviewer's evidence quoted verbatim from their file
-
-Orchestrator's practical judgment: is this worth fixing now, or
-is the current tradeoff acceptable? Scenario building, severity
-reasoning, fix suggestions — these are your words.
-```
-
-For convergent findings (multiple reviewers, same issue):
-
-```text
-**P{n}** One-sentence finding *(Performance Analyst P1,
-Contract Auditor P1, Test Auditor P2)*
-
-> Sharpest reviewer's evidence as base text
-
-> *Contract Auditor adds:* Additional detail from their file
-
-Orchestrator's practical judgment.
-```
-
-For observations: `**Obs** One-sentence observation *(Role)* ...` For nits: `**Nit** One-sentence finding *(Role)* ...`
-
-P3 findings and observations can be one-liners. Group multiple nits on the same file into one comment when they're co-located.
-
-**Review event.** Always use `COMMENT`. Never use `REQUEST_CHANGES` — this isn't the norm in this repository. Never use `APPROVE` — approval is a human responsibility.
-
-For P0 or P1 findings, add a note in the review body: "This review contains findings that may need attention before merge."
-
-**Posting via GitHub API.**
-
-The `gh api` endpoint for posting reviews routes through GraphQL by default. Field names differ from the REST API docs:
-
-- Use `position` (diff-relative line number), not `line` + `side`. `side` is not a valid field in the GraphQL schema.
-- `subject_type: "file"` is not recognized. Pin file-level comments to `position: 1` instead.
-- Use `-X POST` with `--input` to force REST API routing.
-
-To compute positions: save the PR diff to a file, then count lines from the first `@@` hunk header of each file's diff section. For new files, position = line number + 1 (the hunk header is position 1, first content line is position 2).
+Always submit event `COMMENT`. Never use `REQUEST_CHANGES` or `APPROVE`.
+Save the diff to calculate diff-relative positions:
 
 ```sh
 gh pr diff {number} > /tmp/pr.diff
 ```
 
-Submit:
+Use REST explicitly. GitHub review comments use `position`, not `line`, `side`,
+or `subject_type`. Pin file-level findings to position 1.
 
 ```sh
 gh api -X POST \
@@ -317,29 +178,21 @@ gh api -X POST \
   --input review.json
 ```
 
-Where `review.json`:
-
 ```json
 {
-    "event": "COMMENT",
-    "body": "Summary of what's good and what to look at.\n1 P2, 1 P3 across 2 inline comments.",
-    "comments": [
-        {
-            "path": "file.go",
-            "position": 42,
-            "body": "**P1** Finding... *(Reviewer Role)*\n\n> Evidence..."
-        },
-        {
-            "path": "other.go",
-            "position": 1,
-            "body": "**P2** Cross-file finding... *(Reviewer Role)*\n\n> Evidence..."
-        }
-    ]
+  "event": "COMMENT",
+  "body": "Short summary and finding count.",
+  "comments": [
+    {"path": "file.go", "position": 42, "body": "**P1** Finding... *(Reviewer Role P1)*\n\n> Exact evidence\n\nPractical judgment."}
+  ]
 }
 ```
 
-**Tone guidance.** Frame design concerns as questions: "Could we use X instead?" — be direct only for correctness issues. Hedge design, not bugs. Build concrete scenarios to make concerns tangible. When uncertain, say so. See `.claude/docs/PR_STYLE_GUIDE.md` for PR conventions.
+Be direct about correctness. Frame design alternatives as questions. Hedge
+uncertainty, not demonstrated bugs. Follow the repository's
+[pull-request conventions](../pull-requests/SKILL.md).
 
-## Follow-up
+## 6. Follow up
 
-After posting the review, monitor the PR for author responses. If the author pushes fixes or responds to findings, consider running a re-review (this skill, starting from step 1 with the re-review detection path). Allow time for the author to address multiple findings before re-reviewing — don't trigger on each individual response.
+Monitor author responses. Re-run from step 1 after a meaningful batch of fixes,
+not after each reply. Preserve the prior-findings classification on every round.

--- a/.agents/skills/deep-review/references/react.md
+++ b/.agents/skills/deep-review/references/react.md
@@ -1,305 +1,54 @@
-# Modern React (18–19.2) + Compiler 1.0 — Reference
-
-Reference for writing idiomatic React. Covers what changed, what it replaced, and what to reach for. Includes React Compiler patterns — what the compiler handles automatically, what it changes semantically, and how to verify its behavior empirically. Scope: client-side SPA patterns only. Server Components, `use server`, and `use client` directives are framework-specific and omitted. Check the project's React version and compiler config before reaching for newer APIs.
-
-## How modern React thinks differently
-
-**Concurrent rendering** (18): React can now pause, interrupt, and resume renders. This is the foundation everything else builds on. Most existing code "just works," but components that produce side effects during render (mutations, subscriptions, network calls in the render body) are unsafe and will misbehave. Concurrent features are opt-in — they only activate when you use a concurrent API like `startTransition` or `useDeferredValue`.
-
-**Urgent vs. non-urgent updates** (18): The `startTransition` / `useTransition` API introduces a formal split between updates that must feel immediate (typing, clicking) and updates that can be interrupted (filtering a large list, navigating to a new screen). Non-urgent updates yield to urgent ones mid-render. Use this instead of `setTimeout` or manual debounce when you want the UI to stay responsive during expensive re-renders.
-
-**Actions** (19): Async functions passed to `startTransition` are called "Actions." They automatically manage pending state, error handling, and optimistic updates as a unit. The `useActionState` hook and `<form action={fn}>` prop are built on this. The pattern replaces the hand-rolled `isPending/setIsPending` + `try/catch` + `setError` boilerplate that was previously necessary for every data mutation.
-
-**Automatic batching** (18): State updates are now batched everywhere — inside `setTimeout`, `Promise.then`, native event handlers, etc. Previously batching only happened inside React-managed event handlers. If you genuinely need a synchronous flush, use `flushSync`.
-
-**Automatic memoization** (Compiler 1.0): React Compiler is a build-time Babel plugin that automatically inserts memoization into components and hooks. It replaces manual `useMemo`, `useCallback`, and `React.memo` — including conditional memoization and memoization after early returns, which manual APIs cannot express. The compiler only processes components and hooks, not standalone functions. It understands data flow and mutability through its own HIR (High-level Intermediate Representation), so it can memoize more granularly than a human would. Projects adopt it incrementally — typically via path-based Babel overrides or the `"use memo"` directive. Components that violate the Rules of React are silently skipped (no build error), so the automated lint tools that check compiler compatibility matter.
-
-## Replace these patterns
-
-The left column reflects patterns common before React 18/19. Write the right column instead. The "Since" column tells you the minimum React version required.
-
-| Old pattern                                                       | Modern replacement                                                             | Since |
-| ----------------------------------------------------------------- | ------------------------------------------------------------------------------ | ----- |
-| `ReactDOM.render(<App />, el)`                                    | `createRoot(el).render(<App />)`                                               | 18    |
-| `ReactDOM.hydrate(<App />, el)`                                   | `hydrateRoot(el, <App />)`                                                     | 18    |
-| `ReactDOM.unmountComponentAtNode(el)`                             | `root.unmount()`                                                               | 18    |
-| `ReactDOM.findDOMNode(this)`                                      | DOM ref: `const ref = useRef(); ref.current`                                   | 18    |
-| `<Context.Provider value={v}>`                                    | `<Context value={v}>`                                                          | 19    |
-| `React.forwardRef((props, ref) => ...)`                           | `function Comp({ ref, ...props }) { ... }` (ref as a regular prop)             | 19    |
-| String ref `ref="input"` in class components                      | Callback ref or `createRef()`                                                  | 19    |
-| `Heading.propTypes = { ... }`                                     | TypeScript / ES6 type annotations                                              | 19    |
-| `Component.defaultProps = { ... }` on function components         | ES6 default parameters `({ text = 'Hi' })`                                     | 19    |
-| Legacy Context: `contextTypes` + `getChildContext`                | `React.createContext()` + `contextType`                                        | 19    |
-| `import { act } from 'react-dom/test-utils'`                      | `import { act } from 'react'`                                                  | 19    |
-| `import ShallowRenderer from 'react-test-renderer/shallow'`       | `import ShallowRenderer from 'react-shallow-renderer'`                         | 19    |
-| Manual `isPending` state around async calls                       | `const [isPending, startTransition] = useTransition()`                         | 18    |
-| Manual optimistic state + revert logic                            | `useOptimistic(currentValue)`                                                  | 19    |
-| `useEffect` to subscribe to external stores                       | `useSyncExternalStore(subscribe, getSnapshot)`                                 | 18    |
-| Hand-rolled unique ID (counter, random, index)                    | `useId()` — SSR-safe, hydration-safe                                           | 18    |
-| `useEffect` to inject `<title>` or `<meta>` / `react-helmet`      | Render `<title>`, `<meta>`, `<link>` directly in components; React hoists them | 19    |
-| `ReactDOM.useFormState(action, initial)` (Canary name)            | `useActionState(action, initial)`                                              | 19    |
-| `useReducer<React.Reducer<State, Action>>(reducer)`               | `useReducer(reducer)` — infers from the reducer function                       | 19    |
-| `<div ref={current => (instance = current)} />` (implicit return) | `<div ref={current => { instance = current }} />` (explicit block body)        | 19    |
-| `useRef<T>()` with no argument                                    | `useRef<T>(undefined)` or `useRef<T \| null>(null)` — argument is now required | 19    |
-| `MutableRefObject<T>` type annotation                             | `RefObject<T>` — all refs are mutable now; `MutableRefObject` is deprecated    | 19    |
-| `React.createFactory('button')`                                   | `<button />` JSX                                                               | 19    |
-| `useMemo(() => expr, [deps])` in compiled components              | `const val = expr;` — compiler memoizes automatically                          | C 1.0 |
-| `useCallback(fn, [deps])` in compiled components                  | `const fn = () => { ... };` — compiler memoizes automatically                  | C 1.0 |
-| `React.memo(Component)` in compiled components                    | Plain component — compiler skips re-render when props are unchanged            | C 1.0 |
-| `eslint-plugin-react-compiler` (standalone)                       | `eslint-plugin-react-hooks@latest` (compiler rules merged into recommended)    | C 1.0 |
-| `useRef` + `useLayoutEffect` for stable callbacks                 | `useEffectEvent(fn)` — compiler handles both, but `useEffectEvent` is clearer  | 19.2  |
-
-## New capabilities
-
-These enable things that weren't practical before. Reach for them in the described situations.
-
-| What                                                                 | Since   | When to use it                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| -------------------------------------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `useTransition()` / `startTransition()`                              | 18      | Mark a state update as non-urgent so React can interrupt it to handle clicks or keystrokes. The `isPending` boolean lets you show a loading indicator without blocking the UI.                                                                                                                                                                                                                                                                                              |
-| `useDeferredValue(value, initialValue?)`                             | 18 / 19 | Defer re-rendering a slow subtree: pass the deferred value as a prop, wrap the expensive child in `memo`. Unlike debounce, uses no fixed timeout — renders as soon as the browser is idle. The `initialValue` arg (19) avoids a flash on first render.                                                                                                                                                                                                                      |
-| `useId()`                                                            | 18      | Generate a stable, SSR-consistent ID for accessibility attributes (`htmlFor`, `aria-describedby`). Do not use for list keys.                                                                                                                                                                                                                                                                                                                                                |
-| `useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot?)`   | 18      | Subscribe to external (non-React) state stores safely under concurrent rendering. Preferred over `useEffect`-based subscriptions in libraries.                                                                                                                                                                                                                                                                                                                              |
-| `useActionState(action, initialState)`                               | 19      | Manage an async mutation: returns `[state, wrappedAction, isPending]`. Handles pending, result, and error state as a unit. Replaces the manual `isPending` + `try/catch` + `setError` pattern.                                                                                                                                                                                                                                                                              |
-| `useOptimistic(currentValue)`                                        | 19      | Show a speculative value while an async Action is in flight. Returns `[optimisticValue, setOptimistic]`. React automatically reverts to `currentValue` when the transition settles.                                                                                                                                                                                                                                                                                         |
-| `use(promiseOrContext)`                                              | 19      | Read a promise or Context value inside a component or custom hook. Unlike hooks, `use` can be called conditionally (after early returns). Promises must come from a cache — do not create them during render.                                                                                                                                                                                                                                                               |
-| `useFormStatus()` (from `react-dom`)                                 | 19      | Read `{ pending, data, method, action }` of the nearest parent `<form>` Action. Works across component boundaries without prop drilling — useful for submit buttons inside design-system components.                                                                                                                                                                                                                                                                        |
-| `useEffectEvent(fn)`                                                 | 19.2    | Extract a non-reactive callback from an effect. The function sees the latest props/state without being listed in deps, and is never stale. Replaces the `useRef`-and-mutate-in-layout-effect workaround for stable event-like callbacks. The compiler has built-in knowledge of this hook and correctly prunes its return value from effect dependency arrays. Both `useEffectEvent` and the old ref workaround compile cleanly; `useEffectEvent` is preferred for clarity. |
-| `<Activity>`                                                         | 19.2    | Hide part of the UI while preserving its state and DOM. React deprioritizes updates to hidden content. Use via framework APIs for route prerendering or tab preservation — not a direct replacement for CSS `visibility`.                                                                                                                                                                                                                                                   |
-| `captureOwnerStack()`                                                | 19.1    | Dev-only API that returns a string showing which components are responsible for rendering the current component (owner stack, not call stack). Useful for custom error overlays. Returns `null` in production.                                                                                                                                                                                                                                                              |
-| `<form action={fn}>`                                                 | 19      | Pass an async function as a form's `action` prop. React handles submission, pending state, and automatic form reset on success. Works with `useActionState` and `useFormStatus`.                                                                                                                                                                                                                                                                                            |
-| Ref cleanup function                                                 | 19      | Return a cleanup function from a ref callback: `ref={el => { ...; return () => cleanup(); }}`. React calls it on unmount. Replaces the pattern of checking `el === null` in the callback.                                                                                                                                                                                                                                                                                   |
-| `<link rel="stylesheet" precedence="default">`                       | 19      | Declare a stylesheet next to the component that needs it. React deduplicates and inserts it in the correct order before revealing Suspense content.                                                                                                                                                                                                                                                                                                                         |
-| `preinit`, `preload`, `prefetchDNS`, `preconnect` (from `react-dom`) | 19      | Imperatively hint the browser to load resources early. Call from render or event handlers. React deduplicates hints across the component tree.                                                                                                                                                                                                                                                                                                                              |
-| React Compiler (`babel-plugin-react-compiler`)                       | C 1.0   | Build-time automatic memoization for components and hooks. Install, add to Babel/Vite pipeline. Projects typically start with path-based overrides to compile a subset of files.                                                                                                                                                                                                                                                                                            |
-| `"use memo"` directive                                               | C 1.0   | Opt a single function into compilation when using `compilationMode: 'annotation'`. Place at the start of the function body. Module-level `"use memo"` at the top of a file compiles all functions in that file.                                                                                                                                                                                                                                                             |
-| `"use no memo"` directive                                            | C 1.0   | Temporary escape hatch — skip compilation for a specific component or hook that causes a runtime regression. Not a permanent solution. Place at the start of the function body.                                                                                                                                                                                                                                                                                             |
-| Compiler-powered ESLint rules                                        | C 1.0   | Rules for purity, refs, set-state-in-render, immutability, etc. now ship in `eslint-plugin-react-hooks` recommended preset. Surface Rules-of-React violations even without the compiler installed. Note: some projects use Biome instead — check project lint config.                                                                                                                                                                                                       |
-
-## Key APIs
-
-### `useTransition` and `startTransition` (18)
-
-`useTransition` returns `[isPending, startTransition]`. Wrap any state update that is not directly tied to the user's current gesture inside `startTransition`. React will render the old UI while computing the new one, and `isPending` is `true` during that window.
-
-In React 19, `startTransition` can accept an async function (an "Action"). React sets `isPending` to `true` for the entire duration of the async work, not just during the synchronous part.
-
-```tsx
-// 18: synchronous transition
-const [isPending, startTransition] = useTransition();
-startTransition(() => setQuery(input));
-
-// 19: async Action — isPending stays true until the await settles
-startTransition(async () => {
-	const err = await updateName(name);
-	if (err) setError(err);
-});
-```
-
-Use `startTransition` (the module-level export) when you cannot use the hook (outside a component, in a router callback, etc.).
-
-### `useDeferredValue` (18 / 19)
-
-Creates a "lagging" copy of a value. Pass it to a memoized, expensive component so that React can render the stale UI while computing the updated one.
-
-```tsx
-// 19: initialValue shows '' on first render; avoids loading flash
-const deferred = useDeferredValue(searchQuery, "");
-return <Results query={deferred} />; // Results wrapped in memo
-```
-
-`deferred !== searchQuery` while the deferred render is in progress — use this to show a "stale" indicator.
-
-### `useActionState` (19)
-
-Replaces the `useState` + `isPending` + `try/catch` + `setError` boilerplate for any async operation that can be retried or submitted as a form.
-
-```tsx
-const [error, submitAction, isPending] = useActionState(
-	async (prevState, formData) => {
-		const err = await updateName(formData.get("name"));
-		if (err) return err; // returned value becomes next state
-		redirect("/profile");
-		return null;
-	},
-	null, // initialState
-);
-
-// Use submitAction as the form's action prop or call it directly
-<form action={submitAction}>
-	<input name="name" />
-	<button disabled={isPending}>Save</button>
-	{error && <p>{error}</p>}
-</form>;
-```
-
-### `useOptimistic` (19)
-
-Shows a speculative value immediately while an async Action is in progress. React automatically reverts to the server-confirmed value when the Action resolves or rejects.
-
-```tsx
-const [optimisticName, setOptimisticName] = useOptimistic(currentName);
-
-const submit = async (formData) => {
-	const newName = formData.get("name");
-	setOptimisticName(newName); // shows immediately
-	await updateName(newName); // reverts if this throws
-};
-```
-
-### `use()` (19)
-
-Unlike hooks, `use` can appear after conditional statements. Two primary uses:
-
-**Reading a promise** (must be stable — from a cache, not created inline):
-
-```tsx
-function Comments({ commentsPromise }) {
-	const comments = use(commentsPromise); // suspends until resolved
-	return comments.map((c) => <p key={c.id}>{c.text}</p>);
-}
-```
-
-**Reading context after an early return** (hooks cannot appear after `return`):
-
-```tsx
-function Heading({ children }) {
-	if (!children) return null;
-	const theme = use(ThemeContext); // valid here; hooks would not be
-	return <h1 style={{ color: theme.color }}>{children}</h1>;
-}
-```
-
-### `useSyncExternalStore` (18)
-
-The correct way for libraries (and app code) to subscribe to non-React state. Prevents tearing under concurrent rendering.
-
-```tsx
-const value = useSyncExternalStore(
-	store.subscribe, // called when store changes
-	store.getSnapshot, // returns current value (must be stable reference if unchanged)
-	store.getServerSnapshot, // optional: for SSR
-);
-```
-
-## Verifying compiler behavior
-
-The compiler is a black box unless you inspect its output. When reviewing code in compiled paths, run the compiler on the specific code to see what it actually does. Do not guess — verify.
-
-**Run the compiler on a code snippet:**
-
-```sh
-cd site && node -e "
-const {transformSync} = require('@babel/core');
-const code = \`<paste component here>\`;
-const diagnostics = [];
-const result = transformSync(code, {
-  plugins: [
-    ['@babel/plugin-syntax-typescript', {isTSX: true}],
-    ['babel-plugin-react-compiler', {
-      logger: {
-        logEvent(_, event) {
-          if (event.kind === 'CompileError' || event.kind === 'CompileSkip') {
-            diagnostics.push(event.detail?.toString?.()?.substring(0, 200));
-          }
-        },
-      },
-    }],
-  ],
-  filename: 'test.tsx',
-});
-console.log('Compiled:', result.code.includes('_c('));
-if (diagnostics.length) console.log('Diagnostics:', diagnostics);
-console.log(result.code);
-"
-```
-
-**Reading compiled output:**
-
-- `const $ = _c(N)` — allocates N memoization cache slots.
-- `if ($[n] !== dep)` — cache invalidation guard. Re-computes when `dep` changes (referential equality).
-- `if ($[n] === Symbol.for("react.memo_cache_sentinel"))` — one-time initialization. Runs once on first render, cached forever after. This is how the compiler handles expressions with no reactive dependencies.
-- `_temp` functions — pure callbacks the compiler hoisted out of the component body.
-
-**Check all compiled files at once:**
-
-```sh
-cd site && pnpm run lint:compiler
-```
-
-This runs the compiler on every file in the compiled paths and reports CompileError / CompileSkip diagnostics. Zero diagnostics means all functions compiled cleanly.
-
-**What the compiler catches vs. what it does not:**
-
-The compiler emits `CompileError` for mutations of props, state, or hook arguments during render, and for `ref.current` access during render. The project's lint pipeline catches these automatically — do not flag them in review.
-
-The compiler does **not** flag impure function calls during render (`Math.random()`, `Date.now()`, `new Date()`). Instead it silently memoizes them with a sentinel guard, freezing the value after first render. This changes semantics without any diagnostic. Verify suspicious calls by running the compiler and checking for sentinel guards in the output.
-
-## Pitfalls
-
-Things that are easy to get wrong even when you know the modern API exists. Check your output against these.
-
-**Effects run twice in development with StrictMode.** React 18 intentionally mounts → unmounts → remounts every component in dev to surface effects that are not resilient to remounting. This is not a bug. If an effect breaks on the second mount, it is missing a cleanup function. Write `return () => cleanup()` from every effect that sets up a subscription, timer, or external resource.
-
-**Concurrent rendering can call render multiple times.** The render function (component body) may be called more than once before React commits to the DOM. Side effects (mutations, subscriptions, logging) in the render body will run multiple times. Move them into `useEffect` or event handlers.
-
-**Do not create promises during render and pass them to `use()`.** A new promise is created every render, causing an infinite suspend-retry loop. Create the promise outside the component (module level), or use a caching library (SWR, React Query, `cache()` from React) to stabilize it.
-
-**`useOptimistic` reverts automatically — do not fight it.** The optimistic value is a presentation layer only. When the Action settles, React replaces it with the real `currentValue` you passed in. Do not try to sync optimistic state back to your real state; let React handle the revert.
-
-**`flushSync` opts out of automatic batching.** If third-party code or a browser API (e.g. `ResizeObserver`) calls `setState` and you need synchronous DOM flushing, wrap with `flushSync(() => setState(...))`. This is a last resort; prefer letting React batch.
-
-**`forwardRef` still works in React 19 but will be deprecated.** Function components accept `ref` as a plain prop now. New code should use the prop directly. Existing `forwardRef` wrappers continue to work without changes; migrate when convenient.
-
-**`<Activity>` does not unmount.** Content inside a hidden `<Activity>` boundary stays mounted. Effects keep running. Use it for preserving scroll position or form state, not for preventing expensive mounts — use lazy loading for that.
-
-**TypeScript: implicit returns from ref callbacks are now type errors.** In React 19, returning anything other than a cleanup function (or nothing) from a ref callback is rejected by the TypeScript types. The most common case is arrow-function refs that implicitly return the DOM node:
-
-```tsx
-// Error in React 19 types:
-<div ref={el => (instance = el)} />
-
-// Fix — use a block body:
-<div ref={el => { instance = el; }} />
-```
-
-**TypeScript: `useRef` now requires an argument.** `useRef<T>()` with no argument is a type error. Pass `undefined` for mutable refs or `null` for DOM refs you initialize on mount: `useRef<T>(undefined)` / `useRef<HTMLDivElement | null>(null)`.
-
-**`useId` output format changed across versions.** React 18 produced `:r0:`. React 19.1 changed it to `«r0»`. React 19.2 changed it again to `_r0`. Do not parse or depend on the specific format — treat it as an opaque string.
-
-**`useFormStatus` reads the nearest parent `<form>` with a function `action`.** It does not reflect native HTML form submissions — only React Actions. A submit button that is a sibling of `<form>` (rather than a descendant) will not see the form's status.
-
-**Context as a provider (`<Context>`) requires React 19; `<Context.Provider>` still works.** Do not use `<Context>` shorthand in a codebase that needs to support React 18. The two forms can coexist during migration.
-
-**Compiler freezes impure expressions silently.** `Math.random()`, `Date.now()`, `new Date()`, and `window.innerWidth` in a component body all compile without diagnostics. The compiler wraps them in a sentinel guard (`Symbol.for("react.memo_cache_sentinel")`) that runs the expression once and caches the result forever. The value never updates on re-render. Fix: move to a `useState` initializer (`useState(() => Math.random())`), `useEffect`, or event handler.
-
-**Component granularity affects compiler optimization.** When one pattern in a component causes a `CompileError` (e.g., a necessary `ref.current` read during render), the compiler skips the **entire** component. If the rest of the component would benefit from compilation, extract the non-compilable pattern into a small child component. This keeps the parent compiled.
-
-**The compiler only memoizes components and hooks.** Standalone utility functions (even expensive ones called during render) are not compiled. If a utility function is truly expensive, it still needs its own caching strategy outside of React (e.g., a module-level cache, `WeakMap`, etc.).
-
-**Changing memoization can shift `useEffect` firing.** A value that was unstable before compilation may become stable after, causing an effect that depended on it to fire less often. Conversely, future compiler changes may alter memoization granularity. Effects that use memoized values as dependencies should be resilient to these changes — they should be true synchronization effects, not "run this when X changes" hacks.
-
-## Behavioral changes that affect code
-
-- **Automatic batching** (18): State updates in `setTimeout`, `Promise.then`, `addEventListener` callbacks, etc. are now batched into a single re-render. Previously only React synthetic event handlers were batched. Code that relied on unbatched updates (reading DOM synchronously after each `setState`) must use `flushSync`.
-
-- **StrictMode double-invoke** (18): In development, every component is mounted → unmounted → remounted with the previous state. Every effect runs cleanup → setup twice on initial mount. `useMemo` and `useCallback` also double-invoke their functions. Production behavior is unchanged. If a test or component breaks under this, the component had a latent cleanup bug.
-
-- **StrictMode ref double-invoke** (19): In development, ref callbacks are also invoked twice on mount (attach → detach → attach). Return a cleanup function from the ref callback to handle detach correctly.
-
-- **StrictMode memoization reuse** (19): During the second pass of double-rendering, `useMemo` and `useCallback` now reuse the cached result from the first pass instead of calling the function again. Components that are already StrictMode-compatible should not notice a difference.
-
-- **Suspense fallback commits immediately** (19): When a component suspends, React now commits the nearest `<Suspense>` fallback without waiting for sibling trees to finish rendering. After the fallback is shown, React "pre-warms" suspended siblings in the background. This makes fallbacks appear faster but changes the order of rendering work.
-
-- **Error re-throwing removed** (19): Errors that are not caught by an Error Boundary are now reported to `window.reportError` (not re-thrown). Errors caught by an Error Boundary go to `console.error` once. If your production monitoring relied on the re-thrown error, add handlers to `createRoot`: `createRoot(el, { onUncaughtError, onCaughtError })`.
-
-- **Transitions in `popstate` are synchronous** (19): Browser back/forward navigation triggers synchronous transition flushing. This ensures the URL and UI update together atomically during history navigation.
-
-- **`useEffect` from discrete events flushes synchronously** (18): Effects triggered by a click or keydown (discrete events) are now flushed synchronously before the browser paints, consistent with `useLayoutEffect` for those cases.
-
-- **Hydration mismatches treated as errors** (18 / improved in 19): Text content mismatches between server HTML and client render revert to client rendering up to the nearest `<Suspense>` boundary. React 19 logs a single diff instead of multiple warnings, making mismatches much easier to diagnose.
-
-- **New JSX transform required** (19): The automatic JSX runtime introduced in 2020 (`react/jsx-runtime`) is now mandatory. The classic transform (which required `import React from 'react'` in every file) is no longer supported. Most toolchains have already shipped the new transform; check your Babel or TypeScript config if you see warnings.
-
-- **UMD builds removed** (19): React no longer ships UMD bundles. Load via npm and a bundler, or use an ESM CDN (`import React from "https://esm.sh/react@19"`).
-
-- **React Compiler automatic memoization** (Compiler 1.0): Build-time Babel plugin that inserts memoization into components and hooks. Components that follow the Rules of React are automatically memoized; components that violate them are silently skipped (no build error, no runtime change). The compiler can memoize conditionally and after early returns — things impossible with manual `useMemo`/`useCallback`. Works with React 17+ via `react-compiler-runtime`; best with React 19+. Projects adopt incrementally via path-based Babel overrides, `compilationMode: 'annotation'`, or the `"use memo"` / `"use no memo"` directives. Check the project's Vite/Babel config to know which paths are compiled. Compiled components show a "Memo ✨" badge in React DevTools.
+# React Review Checks for Coder
+
+[`site/AGENTS.md`](../../../../site/AGENTS.md) is the canonical frontend
+contract. Apply normal React expertise without repeating it here. Check only
+these repository-specific rules.
+
+## Data and API boundaries
+
+- Require React Query for all server state, including reads, mutations, cache
+  invalidation, loading, and error state.
+- Flag components that call API client functions directly. API calls belong in
+  query or mutation definitions under the established API layer.
+- Require generated API types from
+  `site/src/api/typesGenerated.ts`. Flag locally re-declared response, request,
+  enum, or resource types.
+- Match API errors by stable error code or HTTP status. Flag comparisons against
+  human-readable message strings.
+
+## Components and styling
+
+- Prefer existing shadcn/ui components from `site/src/components`. Flag new MUI
+  usage because MUI is deprecated.
+- Require Tailwind for new styling. Flag new Emotion usage because Emotion is
+  deprecated.
+- Check accessibility through semantic roles, accessible names, keyboard
+  behavior, and focus behavior. Do not accept CSS class assertions as evidence
+  of accessible or observable behavior.
+- Require Biome-compatible code and configuration. Do not suggest ESLint or
+  Prettier fixes.
+
+## Tests
+
+- Require Storybook stories for rendered components and pages.
+- Require Storybook `play` functions for interactions, keyboard behavior, focus,
+  accessibility, loading, error, and state-transition coverage.
+- Flag standalone Vitest or React Testing Library files that render components
+  or pages. Plain Vitest is reserved for pure logic, data transformations,
+  non-DOM hooks, and query or cache operations.
+- Refer to the frontend test runner as Vitest, never Jest.
+- Assert behavior through roles, accessible names, visible state, and user
+  interactions. Flag tests coupled to CSS classes or Tailwind output.
+
+## React Compiler
+
+- Read `site/vite.config.mts` before judging compiler behavior. Its include
+  filter is the source of truth for compiled paths.
+- The current compiled directories are `site/src/pages/AgentsPage/` and
+  `site/src/pages/AIBridgePage/`.
+- Inside compiled directories, flag manual `useMemo`, `useCallback`, and
+  `memo()` because the compiler supplies memoization.
+- Allow the repository exception: `memo()` on list-item components rendered
+  inside `.map()`, where React Compiler does not add cross-component memoization.
+- Do not apply compiler-specific restrictions outside the configured include
+  paths.

--- a/.agents/skills/deep-review/references/typescript.md
+++ b/.agents/skills/deep-review/references/typescript.md
@@ -1,199 +1,38 @@
-# Modern TypeScript (5.0–6.0 RC) — Reference
+# TypeScript Review Checks for Coder
 
-Reference for writing idiomatic TypeScript. Covers what changed, what it replaced, and what to reach for. Respect the project's minimum TypeScript version: don't emit features from a version newer than what the project targets. Check `package.json` and `tsconfig.json` before writing code.
+[`site/AGENTS.md`](../../../../site/AGENTS.md) is the canonical frontend
+contract. Apply normal TypeScript expertise without repeating it here. Check
+only these repository-enforced rules.
 
-## How modern TypeScript thinks differently
+## Type safety
 
-The 5.x era resolves years of module system ambiguity and cleans house on legacy options. Three themes dominate:
+- Reject `as unknown as X` double assertions. They bypass structural checking
+  and conceal contract mismatches.
+- Flag non-null assertions such as `value!.field`. Require explicit narrowing,
+  an early return, a default, or a proven invariant expressed in the type.
+- Prefer type guards, discriminated unions, schema validation, and control-flow
+  narrowing over `as` casts.
+- Treat a single `as` cast as a review target. Keep it only when the runtime
+  invariant is established and TypeScript cannot express the narrowing.
+- Reject `// @ts-ignore`. Fix the type or use a narrowly scoped, explained
+  `// @ts-expect-error` only when the error is intentional and unavoidable.
 
-**Module semantics are explicit.** `--verbatimModuleSyntax` (5.0) makes import/export intent visible in source: type imports must carry `type`, value imports stay. Combined with `--module preserve` or `--moduleResolution bundler`, the compiler now accurately models what bundlers and modern runtimes actually do. `import defer` (5.9) extends the model to deferred evaluation.
+## Contracts
 
-**Resource lifetimes are first-class.** `using` and `await using` (5.2) provide deterministic cleanup without `try/finally`. Any object implementing `Symbol.dispose` participates. `DisposableStack` handles ad-hoc multi-resource cleanup in functions where creating a full class is overkill.
+- Make props required when the implementation depends on them. Flag optional
+  props that are dereferenced, rendered, or used for control flow without a
+  real fallback.
+- Require generated API types from
+  `site/src/api/typesGenerated.ts`. Do not re-declare API requests, responses,
+  resources, enums, or error shapes.
+- Preserve generated optionality and nullability. Do not cast generated values
+  into a more convenient local shape.
+- Match API errors by stable error code or HTTP status, never by message text.
 
-**Inference is smarter about what it knows.** Inferred type predicates (5.5) let `.filter(x => x !== undefined)` produce `T[]` instead of `(T | undefined)[]` automatically. `NoInfer<T>` (5.4) gives library authors precise control over which parameters drive inference. Narrowing now survives closures after last assignment, constant indexed accesses, and `switch (true)` patterns.
+## Review discipline
 
-**TypeScript 6.0 is a transition release toward 7.0** (the Go-native port). It turns years of soft deprecations into errors and changes several defaults. Most impactful: `types` defaults to `[]` (must list `@types` packages explicitly), `rootDir` defaults to `.`, `strict` defaults to `true`, `module` defaults to `esnext`. Projects relying on implicit behavior need explicit config. Check the deprecations section before upgrading.
-
-## Replace these patterns
-
-The left column reflects patterns still common before TypeScript 5.x. Write the right column instead. The "Since" column tells you the minimum TypeScript version required.
-
-| Old pattern                                                                                                      | Modern replacement                                                                                                           | Since  |
-| ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------ |
-| `--experimentalDecorators` + legacy decorator signatures                                                         | Standard decorators (TC39): `function dec(target, context: ClassMethodDecoratorContext)` — no flag needed                    | 5.0    |
-| Requiring callers to add `as const` at call sites                                                                | `<const T extends HasNames>(arg: T)` — `const` modifier on type parameter                                                    | 5.0    |
-| `--importsNotUsedAsValues` + `--preserveValueImports`                                                            | `--verbatimModuleSyntax`                                                                                                     | 5.0    |
-| `import { Foo } from "..."` when `Foo` is only used as a type                                                    | `import { type Foo } from "..."` or `import type { Foo } from "..."`                                                         | 5.0    |
-| `"extends": "@tsconfig/strictest/tsconfig.json"` chain                                                           | `"extends": ["@tsconfig/strictest/tsconfig.json", "./tsconfig.base.json"]` (array form)                                      | 5.0    |
-| `try { ... } finally { resource.close(); resource.delete(); }`                                                   | `using resource = acquireResource()` — calls `[Symbol.dispose]()` automatically                                              | 5.2    |
-| `try { ... } finally { await resource.close() }`                                                                 | `await using resource = acquireAsyncResource()`                                                                              | 5.2    |
-| Ad-hoc cleanup with multiple `try/finally` blocks                                                                | `using cleanup = new DisposableStack(); cleanup.defer(() => ...)`                                                            | 5.2    |
-| `import data from "./data.json" assert { type: "json" }`                                                         | `import data from "./data.json" with { type: "json" }`                                                                       | 5.3    |
-| `.filter(Boolean)` or `.filter(x => !!x)` to remove nulls                                                        | `.filter(x => x !== undefined)` or `.filter(x => x !== null)` (infers type predicate)                                        | 5.5    |
-| Extra phantom type param to block inference bleed: `<C extends string, D extends C>`                             | `NoInfer<C>` on the parameter you don't want to drive inference                                                              | 5.4    |
-| `/** @typedef {import("./types").Foo} Foo */` in JS files                                                        | `/** @import { Foo } from "./types" */` (JSDoc `@import` tag)                                                                | 5.5    |
-| `myArray.reverse()` mutating in place                                                                            | `myArray.toReversed()` (returns new array)                                                                                   | 5.2    |
-| `myArray.sort(cmp)` mutating in place                                                                            | `myArray.toSorted(cmp)` (returns new array)                                                                                  | 5.2    |
-| `const copy = [...arr]; copy[i] = v`                                                                             | `arr.with(i, v)` (returns new array)                                                                                         | 5.2    |
-| Manual `has`/`get`/`set` pattern on `Map`                                                                        | `map.getOrInsert(key, defaultValue)` or `getOrInsertComputed(key, fn)`                                                       | 6.0 RC |
-| `new RegExp(str.replace(/[.\*+?^${}()\[\]\\]/g, '\\$&'))`                                                        | `new RegExp(RegExp.escape(str))`                                                                                             | 6.0 RC |
-| `--moduleResolution node` (node10)                                                                               | `--moduleResolution nodenext` (Node.js) or `--moduleResolution bundler` (bundlers/Bun)                                       | 6.0 RC |
-| `"baseUrl": "./src"` + `"@app/*": ["app/*"]` in paths                                                            | Remove `baseUrl`; use `"@app/*": ["./src/app/*"]` in paths directly                                                          | 6.0 RC |
-| `module Foo { export const x = 1; }`                                                                             | `namespace Foo { export const x = 1; }`                                                                                      | 6.0 RC |
-| `export * from "..."` when all re-exported members are types                                                     | `export type * from "..."` (or `export type * as ns from "..."`)                                                             | 5.0    |
-| `function f(): undefined { return undefined; }` — explicit return required in `: undefined`-returning function   | Remove the `return` entirely; `undefined`-returning functions no longer require any return statement                         | 5.1    |
-| Manual type predicate annotation on a simple arrow: `(x: T \| undefined): x is T => x !== undefined`             | Remove the annotation; TypeScript infers `x is T` from `!== null/undefined` and `instanceof` checks automatically            | 5.5    |
-| `const val = obj[key]; if (typeof val === "string") { use(val); }` — extract to const to narrow indexed access   | `if (typeof obj[key] === "string") { obj[key].toUpperCase(); }` directly — both `obj` and `key` must be effectively constant | 5.5    |
-| Copy narrowed `let`/param to a `const`, or restructure code to escape stale closure narrowing after reassignment | Remove the copy; narrowing survives into closures created after the last assignment to the variable                          | 5.4    |
-| `(arr as string[]).filter(...)` or restructure to avoid "not callable" errors on `string[] \| number[]`          | Call `.filter`, `.find`, `.some`, `.every`, `.reduce` directly on union-of-array types                                       | 5.2    |
-| `if`/`else` chain used to work around lack of narrowing inside a `switch (true)` body                            | `switch (true)` — each `case` condition now narrows the tested variable in its clause                                        | 5.3    |
-
-## New capabilities
-
-These enable things that weren't practical before. Reach for them in the described situations.
-
-| What                                            | Since  | When to use it                                                                                                                                                                                                                                |
-| ----------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `using` / `await using` declarations            | 5.2    | Any resource needing deterministic cleanup (file handles, DB connections, locks, event listeners). Object must implement `Symbol.dispose` / `Symbol.asyncDispose`.                                                                            |
-| `DisposableStack` / `AsyncDisposableStack`      | 5.2    | Ad-hoc multi-resource cleanup without creating a class. Call `.defer(fn)` right after acquiring each resource. Stack disposes in LIFO order.                                                                                                  |
-| `const` modifier on type parameters             | 5.0    | Force `const`-like (literal/readonly tuple) inference at call sites without requiring callers to write `as const`. Constraint must use `readonly` arrays.                                                                                     |
-| Decorator metadata (`Symbol.metadata`)          | 5.2    | Attach and read per-class metadata from decorators via `context.metadata`. Retrieved as `MyClass[Symbol.metadata]`. Requires `Symbol.metadata ??= Symbol(...)` polyfill.                                                                      |
-| `NoInfer<T>` utility type                       | 5.4    | Prevent a parameter from contributing inference candidates for `T`. Use when one argument should be the "source of truth" and others should only be checked against it.                                                                       |
-| Inferred type predicates                        | 5.5    | Filter callbacks that test for `!== null` or `instanceof` now automatically produce a type predicate. `Array.prototype.filter` then narrows the result array type.                                                                            |
-| `--isolatedDeclarations`                        | 5.5    | Require explicit return types on exported declarations. Unlocks parallel declaration emit by external tooling (esbuild, oxc, etc.) without needing a full type-checker pass.                                                                  |
-| `${configDir}` in tsconfig paths                | 5.5    | Anchor `typeRoots`, `paths`, `outDir`, etc. in a shared base tsconfig to the _consuming_ project's directory, not the shared file's location.                                                                                                 |
-| Always-truthy/nullish check errors              | 5.6    | Catches regex literals in `if`, arrow functions as comparators, `?? 100` on non-nullable left side, misplaced parentheses. No API to call; existing bugs now surface as errors.                                                               |
-| Iterator helper methods (`IteratorObject`)      | 5.6    | Built-in iterators from `Map`, `Set`, generators, etc. now have `.map()`, `.filter()`, `.take()`, `.drop()`, `.flatMap()`, `.toArray()`, `.reduce()`, etc. Use `Iterator.from(iterable)` to wrap any iterable.                                |
-| `--noUncheckedSideEffectImports`                | 5.6    | Error when a side-effect import (`import "..."`) resolves to nothing. Catches typos in polyfill or CSS imports.                                                                                                                               |
-| `--noCheck`                                     | 5.6    | Skip type checking entirely during emit. Useful for separating "fast emit" from "thorough check" pipeline stages, especially with `--isolatedDeclarations`.                                                                                   |
-| `--rewriteRelativeImportExtensions`             | 5.7    | Rewrite `.ts`→`.js`, `.tsx`→`.jsx`, `.mts`→`.mjs`, `.cts`→`.cjs` in relative imports during emit. Required when writing `.ts` imports for Node.js strip-types mode and still needing `.js` output for library distribution.                   |
-| `--erasableSyntaxOnly`                          | 5.8    | Error on constructs that can't be type-stripped by Node.js `--experimental-strip-types`: `enum`, `namespace` with code, parameter properties, `import =` aliases.                                                                             |
-| `require()` of ESM under `--module nodenext`    | 5.8    | Node.js 22+ allows CJS to `require()` ESM files (no top-level `await`). TypeScript now allows this under `nodenext` without error.                                                                                                            |
-| `import defer * as ns from "..."`               | 5.9    | Defer module _evaluation_ (not loading) until first property access. Module is loaded and verified at import time; side-effects are delayed. Only works with `--module preserve` or `esnext`.                                                 |
-| `Set` algebra methods                           | 5.5    | Non-mutating: `union`, `intersection`, `difference`, `symmetricDifference` → new `Set`. Predicate: `isSubsetOf`, `isSupersetOf`, `isDisjointFrom` → `boolean`. Requires `esnext` or `es2025` lib.                                             |
-| `Object.groupBy` / `Map.groupBy`                | 5.4    | Group an iterable into buckets by key function. Return type has all keys as optional (not every key is guaranteed present). Requires `esnext` or `es2024`+ lib.                                                                               |
-| `Temporal` API types                            | 6.0 RC | `Temporal.Now`, `Temporal.Instant`, `Temporal.PlainDate`, etc. Available under `esnext` or `esnext.temporal` lib. Usable in runtimes that already ship it (V8 118+, SpiderMonkey, etc.).                                                      |
-| `@satisfies` in JSDoc                           | 5.0    | Validates that a JS expression satisfies a type without widening it — the TS `satisfies` operator for `.js` files. Write `/** @satisfies {MyType} */` above the declaration or inline on a parenthesized expression.                          |
-| `@overload` in JSDoc                            | 5.0    | Declare multiple call signatures for a JS function. Each JSDoc comment tagged `@overload` is treated as a distinct overload; the final JSDoc comment (without `@overload`) describes the implementation signature.                            |
-| Getter/setter with completely unrelated types   | 5.1    | `get style(): CSSStyleDeclaration` and `set style(v: string)` can now have fully unrelated types, provided both have explicit type annotations. Previously the getter type was required to be a subtype of the setter type.                   |
-| `instanceof` narrowing via `Symbol.hasInstance` | 5.3    | When a class defines `static [Symbol.hasInstance](val: unknown): val is T`, the `instanceof` operator now narrows to the predicate type `T`, not the class type itself. Useful when the runtime check and the structural type differ.         |
-| Regex literal syntax checking                   | 5.5    | TypeScript validates regex literal syntax: malformed groups, nonexistent backreferences, named capture mismatches, and features not available at the current `--target`. No API needed; existing latent bugs surface as errors automatically. |
-| `--build` continues past intermediate errors    | 5.6    | `tsc --build` no longer stops at the first failing project. All projects are built and errors reported together. Use `--stopOnBuildErrors` to restore the old stop-on-first-error behavior. Useful for monorepos during upgrades.             |
-| `--module node18`                               | 5.8    | Stable `--module` flag for Node.js 18 semantics: disallows `require()` of ESM (unlike `nodenext`) and still allows import assertions. Use when pinned to Node 18 and not ready for `nodenext` behavior changes.                               |
-| `--module node20`                               | 5.9    | Stable `--module` flag for Node.js 20 semantics: permits `require()` of ESM, rejects import assertions. Implies `--target es2023` (unlike `nodenext`, which floats to `esnext`).                                                              |
-
-## Key APIs
-
-### `Disposable` / `AsyncDisposable` / stacks (5.2)
-
-Global types provided by TypeScript's lib (requires `esnext.disposable` or `esnext` in `lib`):
-
-- `Disposable` — `{ [Symbol.dispose](): void }`
-- `AsyncDisposable` — `{ [Symbol.asyncDispose](): PromiseLike<void> }`
-- `DisposableStack` — `defer(fn)`, `use(resource)`, `adopt(value, disposeFn)`, `move()`. Is itself `Disposable`.
-- `AsyncDisposableStack` — async equivalent. Is itself `AsyncDisposable`.
-- `SuppressedError` — thrown when both the scope body and a `[Symbol.dispose]` throw. `.error` holds the dispose-phase error; `.suppressed` holds the original error.
-
-Polyfill the symbols in older runtimes:
-
-```ts
-Symbol.dispose ??= Symbol("Symbol.dispose");
-Symbol.asyncDispose ??= Symbol("Symbol.asyncDispose");
-```
-
-### Decorator context types (5.0)
-
-Each decorator kind receives a typed context object as its second parameter:
-
-- `ClassDecoratorContext`
-- `ClassMethodDecoratorContext`
-- `ClassGetterDecoratorContext`
-- `ClassSetterDecoratorContext`
-- `ClassFieldDecoratorContext`
-- `ClassAccessorDecoratorContext`
-
-All context objects have `.name`, `.kind`, `.static`, `.private`, and `.metadata`. Method/getter/setter/accessor contexts also have `.addInitializer(fn)` for running code at construction time.
-
-### `IteratorObject` (5.6)
-
-`IteratorObject<T, TReturn, TNext>` is the new type for built-in iterable iterators. Key methods: `map`, `filter`, `take`, `drop`, `flatMap`, `forEach`, `reduce`, `some`, `every`, `find`, `toArray`. Not the same as the pre-existing structural `Iterator<T>` protocol.
-
-- Generators produce `Generator<T>` which extends `IteratorObject`.
-- `Map.prototype.entries()` returns `MapIterator<[K, V]>`, `Set.prototype.values()` returns `SetIterator<T>`, etc.
-- `Iterator.from(iterable)` converts any `Iterable` to an `IteratorObject`.
-- `AsyncIteratorObject` exists for async parity.
-- `--strictBuiltinIteratorReturn` (new `--strict`-mode flag in 5.6) makes the return type of `BuiltinIteratorReturn` be `undefined` instead of `any`, catching unchecked `done` access.
-
-### Array copying methods (5.2)
-
-Declared on `Array`, `ReadonlyArray`, and all `TypedArray` types. Use these instead of the mutating variants when you need to preserve the original:
-
-| Mutating                           | Non-mutating copy                     |
-| ---------------------------------- | ------------------------------------- |
-| `arr.sort(cmp)`                    | `arr.toSorted(cmp)`                   |
-| `arr.reverse()`                    | `arr.toReversed()`                    |
-| `arr.splice(start, del, ...items)` | `arr.toSpliced(start, del, ...items)` |
-| `arr[i] = v`                       | `arr.with(i, v)`                      |
-
-## Pitfalls
-
-Things easy to get wrong even when you know the modern API exists. Check your output against these.
-
-**tsconfig defaults changed hard in 6.0.** `types: []` means no `@types/*` packages load implicitly. If you see floods of "cannot find name 'process'" or "cannot find module 'fs'" after upgrading to 6.0, add `"types": ["node"]` (or whatever you need) to `compilerOptions`. `rootDir: "."` means a project with source in `src/` will emit to `dist/src/` instead of `dist/` — add `"rootDir": "./src"` explicitly. `strict: true` by default means projects with loose code see new errors.
-
-**`using` requires a runtime polyfill on older runtimes.** `Symbol.dispose` and `Symbol.asyncDispose` don't exist before Node.js 18.x / Chrome 120. Add the two-line polyfill at your entry point. `DisposableStack` and `AsyncDisposableStack` need a more substantial polyfill (e.g. from `@microsoft/using-polyfill`).
-
-**`using` disposes in LIFO order.** Resources declared later in a scope are disposed first. Declare in the order you want reversed cleanup (acquisition order). `DisposableStack.defer` also runs in LIFO order.
-
-**Inferred type predicates have if-and-only-if semantics.** `x => !!x` does NOT infer `x is NonNullable<T>` because `0`, `""`, and `false` are falsy but not absent. TypeScript correctly refuses the predicate. Use `x => x !== undefined` or `x => x !== null` for precise null/undefined filters. If a predicate isn't being inferred, the false branch is probably ambiguous.
-
-**`--verbatimModuleSyntax` breaks CJS `require` emit.** Under this flag ESM `import`/`export` is emitted verbatim. You cannot produce `require()` calls from standard `import` syntax. For CJS output you must use `import foo = require("foo")` and `export = { ... }` syntax explicitly.
-
-**`NoInfer<T>` doesn't prevent `T` from being resolved, only from being contributed at that position.** Other parameters can still infer `T`. It means "don't use me as an inference candidate", not "block `T` from being resolved".
-
-**`--isolatedDeclarations` requires explicit return types on all exports.** Exported arrow functions, function declarations, and class methods all need annotations if their return type isn't trivially inferrable from a literal or type assertion. Editor quick-fixes can add them automatically.
-
-**Standard decorators are incompatible with `--experimentalDecorators`.** Different type signatures, metadata model, and emit. A decorator written for one will not work with the other. `--emitDecoratorMetadata` is not supported with standard decorators. Don't mix the two systems in one project.
-
-**`import defer` does not downlevel.** TypeScript does not transform `import defer` to polyfill-compatible code. The module is still _loaded_ eagerly (must exist); only _evaluation_ is deferred. Only use it under `--module preserve` or `esnext` with a runtime or bundler that supports it.
-
-**`--erasableSyntaxOnly` prohibits parameter properties.** `constructor(public x: number)` is not allowed. Expand to an explicit field declaration plus assignment in the constructor body.
-
-**Closure narrowing is invalidated if the variable is assigned anywhere in a nested function.** TypeScript cannot know when a nested function will run, so any assignment to a `let`/param inside a nested function — even a no-op like `value = value` — invalidates narrowing for all closures in the outer scope. Only the outer "no further assignments after this point" pattern is safe.
-
-**Constant indexed access narrowing requires both `obj` and `key` to be unmodified between the check and the use.** If either is a `let` that could be reassigned, TypeScript will not narrow `obj[key]`. Extract the value to a `const` in that case.
-
-**`switch (true)` narrowing does not carry across fall-through cases.** In a `switch (true)`, each `case` condition narrows independently. A variable narrowed in `case typeof x === "string":` that falls through to the next case will have its narrowing widened by the next condition, not accumulated from the previous one.
-
-**`const` type parameter modifier falls back when constraint is mutable.** `<const T extends string[]>(args: T)` falls back to `string[]` because `readonly ["a", "b"]` isn't assignable to `string[]`. Use `<const T extends readonly string[]>` for arrays.
-
-**`assert` import syntax errors under `--module nodenext` since 5.8.** Any remaining `import x from "..." assert { ... }` must be updated to `import x from "..." with { ... }`.
-
-**`Array.prototype.filter(x => x !== null)` now narrows to non-null (5.5).** This is almost always correct, but if you intentionally needed the nullable type downstream, add an explicit annotation: `const items: (T | null)[] = arr.filter(x => x !== null)`.
-
-## Behavioral changes that affect code
-
-- **All enums are union enums** (5.0): Every enum member gets its own literal type. Out-of-domain literal assignment to an enum type now errors. Cross-enum assignment between enums with identical names but differing values now errors.
-- **Relational operators no longer allow implicit string/number coercions** (5.0): `ns > 4` where `ns: number | string` is a type error. Use `+ns > 4` to explicitly coerce.
-- **`--module`/`--moduleResolution` must agree on node flavor** (5.2): Mixing `--module nodenext` with `--moduleResolution bundler` is an error. Use `--module nodenext` alone or `--module esnext --moduleResolution bundler`.
-- **Deprecations from 5.0 become hard errors in 5.5**: `--importsNotUsedAsValues`, `--preserveValueImports`, `--target ES3`, `--out`, and several others are fully removed in 5.5. They can no longer be specified, even with `"ignoreDeprecations": "5.0"`. Migrate to `--verbatimModuleSyntax` for the import flags.
-- **Type-only imports conflicting with local values** (5.4): Under `--isolatedModules`, `import { Foo } from "..."` where a local `let Foo` also exists now errors. Use `import type { Foo }` or `import { type Foo }`.
-- **Reference directives no longer synthesized or preserved in declaration emit** (5.5): `/// <reference types="node" />` TypeScript used to add automatically is no longer emitted. User-written directives are dropped unless they carry `preserve="true"`. Update library `tsconfig.json` if you relied on this.
-- **`.mts` files never emit CJS; `.cts` files never emit ESM** (5.6): Regardless of `--module` setting. Previously the extension was ignored in some modes.
-- **JSON imports under `--module nodenext` require `with { type: "json" }`** (5.7): `import data from "./config.json"` without the attribute is now a type error.
-- **`TypedArray`s are now generic** (5.7): `Uint8Array` is `Uint8Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike>`. Code passing `Buffer` (from `@types/node`) to typed-array parameters may see new errors. Update `@types/node` to a version that matches.
-- **`import assert { ... }` is an error under `--module nodenext`** (5.8): Node.js 22 dropped support for the old syntax. Use `with { ... }`.
-- **`types` defaults to `[]` in 6.0**: All implicit `@types/*` loading stops. Add an explicit `"types": ["node"]` or the array will remain empty. Using `"types": ["*"]` restores the 5.x behavior.
-- **`rootDir` defaults to `.` (the tsconfig directory) in 6.0**: Previously inferred from the common ancestor of all source files. Projects with `"include": ["./src"]` and no explicit `rootDir` will now emit into `dist/src/` instead of `dist/`. Add `"rootDir": "./src"` to fix.
-- **`strict` defaults to `true` in 6.0**: Projects that were implicitly not strict will see new errors. Set `"strict": false` explicitly if you're not ready to fix them.
-- **`--baseUrl` deprecated in 6.0** and no longer acts as a module resolution root. Add explicit prefixes to your `paths` entries instead.
-- **`--moduleResolution node` (node10) deprecated in 6.0**: Removed in 7.0. Migrate to `nodenext` or `bundler`.
-- **`amd`, `umd`, `systemjs`, `none` module targets deprecated in 6.0**: Removed in 7.0. Migrate to a bundler.
-- **`--outFile` removed in 6.0**: Use a bundler (esbuild, Rollup, Webpack, etc.).
-- **`module Foo { }` syntax removed in 6.0**: Rename all such declarations to `namespace Foo { }`.
-- **`--esModuleInterop false` and `--allowSyntheticDefaultImports false` removed in 6.0**: Safe interop is now always on. Default imports from CJS modules (`import express from "express"`) are always valid.
-- **Explicit `typeRoots` disables upward `node_modules/@types` fallback** (5.1): When `typeRoots` is specified and a lookup fails in those directories, TypeScript no longer walks parent directories for `@types`. If you relied on the fallback, add `"./node_modules/@types"` explicitly to your `typeRoots` array.
-- **`super.` on instance field properties is a type error** (5.3): Calling `super.foo()` where `foo` is a class field (arrow function assigned in the constructor) rather than a prototype method now errors. Instance fields don't exist on the prototype; `super.field` is `undefined` at runtime.
-- **`--build` always emits `.tsbuildinfo`** (5.6): Previously only written when `--incremental` or `--composite` was set. Now written unconditionally in any `--build` invocation. Update `.gitignore` or CI artifact management if needed.
-- **`.mts`/`.cts` extensions and `package.json` `"type"` respected in all module modes** (5.6): Format-specific extensions and the `"type"` field inside `node_modules` are now honored regardless of `--module` setting (except `amd`, `umd`, `system`). A `.mts` file will never emit CJS output even under `--module commonjs`.
-- **Granular return expression checking** (5.8): Each branch of a conditional expression (`cond ? a : b`) directly inside a `return` statement is now checked individually against the declared return type. Previously an `any`-typed branch could silently suppress type errors in the other branch.
+- Do not propose generic TypeScript modernization unless it fixes a concrete
+  issue in the changed code.
+- Verify proposed types against nearby call sites, generated contracts, and the
+  repository's existing patterns.
+- Keep suppressions and casts local, rare, and justified by a runtime invariant.


### PR DESCRIPTION
## Stack Context

Part of a 7-PR stack thinning the agent instruction corpus. Split from #27203.

## Why?

The review skills carried ~1,000 lines of generic guidance: `deep-review/references/react.md` and `typescript.md` were mostly textbook React/TypeScript advice (rules of hooks, what `unknown` is) rather than anything specific to this repo. Review agents load these files on every review, so the generic bulk cost tokens while diluting the checks that actually catch bugs here.

## What?

- `deep-review` references rewritten as repo-delta review checklists (~90 lines total): compiler-scope rules, React Query boundaries, generated-types discipline, Biome/knip expectations, the double-assertion ban.
- `coder-agents-review` and `deep-review` SKILL.md files thinned to their workflow contracts; generic review prose removed.
- References to the PR style guide now point at the `pull-requests` skill, preparing for the style-guide consolidation upstack.

> This PR was prepared by Mux (AI agent) on Mike's behalf.
