### PR TITLE
docs: replace AsSystemRestricted guidance with scoped AsSystemOAuth2

### DIFF
--- a/.claude/docs/AGENT_FAILURES.md
+++ b/.claude/docs/AGENT_FAILURES.md
@@ -136,8 +136,11 @@ Common quick checks:
   request context directly.
 - Reproduce: Call the endpoint without an authenticated user.
 - Diagnose: Trace the authorization context passed to the database operation.
+  A temporarily widened context can confirm a missing permission, but it must
+  never ship.
 - Owner: [OAuth2 Development Guide](OAUTH2.md).
-- Prevent: Use the restricted system context defined by the owner guide.
+- Prevent: Use the scoped OAuth2 system context (`dbauthz.AsSystemOAuth2`)
+  defined by the owner guide, not `dbauthz.AsSystemRestricted`.
 
 ## Symptom: New API endpoint is absent from generated documentation
 

--- a/.claude/docs/OAUTH2.md
+++ b/.claude/docs/OAUTH2.md
@@ -39,18 +39,26 @@ with application behavior. For example, RFC 7591 defaults
 ## Public Endpoints and Database Authorization
 
 A public endpoint has no user authorization context. When it must read or write
-system-owned OAuth2 state, use `dbauthz.AsSystemRestricted(ctx)`:
+system-owned OAuth2 state, use the scoped `dbauthz.AsSystemOAuth2(ctx)` context.
+Every `dbauthz.As*` call needs a justifying comment plus `//nolint:gocritic`
+(enforced by the ruleguard rule in `scripts/rules.go`):
 
 ```go
+//nolint:gocritic // OAuth2 system context: dynamic registration is a public endpoint
 app, err := api.Database.GetOAuth2ProviderAppByClientID(
-    dbauthz.AsSystemRestricted(ctx),
+    dbauthz.AsSystemOAuth2(ctx),
     clientID,
 )
 ```
 
-Do not use an unrestricted system context. Authenticated endpoints should keep
-the caller context unless an established authorization boundary requires
-otherwise.
+`AsSystemOAuth2` covers OAuth2 app, secret, and token resources, API key read
+and delete for revocation, and user and organization reads. Do not use
+`dbauthz.AsSystemRestricted(ctx)` in OAuth2 paths: it is effectively sudo. If a
+query fails under `AsSystemOAuth2` with a permission error, widening the
+context is a diagnostic step only and must never ship; the real fix extends the
+scoped subject in `coderd/database/dbauthz/dbauthz.go` or the RBAC policy.
+Authenticated endpoints keep the caller context unless an established
+authorization boundary requires otherwise.
 
 ## Protocol Safeguards
 

--- a/.claude/docs/WORKFLOWS.md
+++ b/.claude/docs/WORKFLOWS.md
@@ -100,4 +100,4 @@ matches nearby routes. For experimental or unstable API paths, place
 excluded from the published API reference until it stabilizes.
 
 Follow [OAuth2 Development Guide](OAUTH2.md) for protocol errors and public
-endpoints that require restricted system access.
+endpoints that require scoped system access.

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -51,12 +51,15 @@ quality problems.
 ### Authorization Context
 
 ```go
-// Public endpoints needing system access
-dbauthz.AsSystemRestricted(ctx)
+// Public OAuth2 endpoints use the scoped OAuth2 system context
+dbauthz.AsSystemOAuth2(ctx)
 
 // Authenticated endpoints with user context - just use ctx
 api.Database.GetResource(ctx, id)
 ```
+
+Flag any new `dbauthz.AsSystemRestricted` call: it is effectively sudo and
+needs strong justification for why a scoped subject cannot work.
 
 ### Error Handling
 


### PR DESCRIPTION
## Stack Context

Top of a 5-PR stack thinning the agent instruction corpus. Split from #27203.

## Why?

CODAGT-730: agent docs told agents to use `dbauthz.AsSystemRestricted` for public OAuth2 endpoints. That guidance was both dangerous and stale. Dangerous because the subject is effectively sudo and the org goal is to reduce its use; stale because `coderd/oauth2provider/` was already refactored onto the scoped `AsSystemOAuth2` subject (OAuth2 resources, API key read/delete for revocation, user/org reads only). Docs recommending a pattern the code has moved away from teach agents to reintroduce it.

## What?

- Every recommendation now points at `dbauthz.AsSystemOAuth2`; `AsSystemRestricted` appears only as a warning against it.
- `OAUTH2.md` documents the real call-site convention: justifying comment plus `//nolint:gocritic`, enforced by the ruleguard rule in `scripts/rules.go`.
- `AGENT_FAILURES.md` keeps the legitimate diagnostic use (temporarily widening a context to confirm a missing permission) but states it must never ship; the fix is extending the scoped subject or RBAC policy.
- `code-review` skill now flags any new `AsSystemRestricted` call.

> This PR was prepared by Mux (AI agent) on Mike's behalf.


