### PR TITLE
feat(coderd/x/chatd/chatloop): retain user constraints in compaction summaries

### DIFF
--- a/coderd/x/chatd/chatloop/compaction.go
+++ b/coderd/x/chatd/chatloop/compaction.go
@@ -29,6 +29,20 @@ const (
 		"Summarize the conversation so a new assistant can seamlessly " +
 		"continue the work in progress.\n\n" +
 		"Include:\n" +
+		"- User constraints, corrections, and prohibitions: rules, " +
+		"scope limits, style rules, and process corrections stated by " +
+		"the user. Quote or closely paraphrase the user's wording; do " +
+		"not soften, merge, or truncate them. Constraints are standing " +
+		"until the user revokes them; they do not become stale when " +
+		"the task moves on. When the user corrected the assistant's " +
+		"behavior, record the correction itself, not only the " +
+		"corrected outcome. Include only constraints the user stated " +
+		"in conversation; do not place rules from system prompts, " +
+		"AGENTS.md, or other configuration files in this section. " +
+		"Those rules may appear elsewhere in the summary with their " +
+		"true source named. When in doubt whether a rule originated " +
+		"from the user, name its source or omit the attribution " +
+		"rather than defaulting to user.\n" +
 		"- The user's overall goal and current task\n" +
 		"- Key decisions made and their rationale\n" +
 		"- Concrete technical details: file paths, function names, " +

--- a/coderd/x/chatd/chatloop/compaction.go
+++ b/coderd/x/chatd/chatloop/compaction.go
@@ -29,6 +29,10 @@ const (
 		"Summarize the conversation so a new assistant can seamlessly " +
 		"continue the work in progress.\n\n" +
 		"Include:\n" +
+		// The constraints bullet below is deliberately verbose: offline replay
+		// of production chats showed compaction summaries dropping or softening
+		// user-stated constraints, and this wording measurably improved their
+		// survival (see PR #27230). Reword only with re-validation.
 		"- User constraints, corrections, and prohibitions: rules, " +
 		"scope limits, style rules, and process corrections stated by " +
 		"the user. Quote or closely paraphrase the user's wording; do " +


### PR DESCRIPTION
When a chat grows past its context budget, chatd compacts older history into a summary produced by `defaultCompactionSummaryPrompt` (coderd/x/chatd/chatloop). In production transcripts these summaries often drop or soften constraints the user stated ("do not push and do not create a PR" surviving only as "no push"), so after compaction the assistant repeats behavior the user already corrected. This PR adds one bullet to the prompt telling the summarizer to keep user constraints, corrections, and prohibitions in the user's wording, treat them as standing until revoked, record corrections to the assistant's behavior rather than only the corrected outcome, and label rules by their true source instead of attributing config-file rules to the user.

Improves per-compaction retention, validated on unseen human chats (holdout P1 +0.175, arbitrated); does not and cannot fix deep-chain correction loss.

## How the result was measured

37 real compaction events from production chats were replayed offline: for each event, the recorded history up to the compaction point was summarized twice, once with the new prompt and once with the current one, and both summaries were scored 0 to 1 on a pre-registered checklist of retention properties. Scoring is LLM-based with controls: a fresh judge per event, a second cross-family judge on a sample, a third model arbitrating disagreements (arbitrated numbers are primary), and an audit pass that excludes claims a summary invented. The pass/fail rules were fixed before the run.

Two metrics appear below:

- P1, constraint retention: user constraints and corrections preserved with their original force. Softened wording scores as failure, not partial credit.
- Correction-capture (P10): when the user corrected the assistant's behavior, the correction itself survives into the summary.

Two test sets: 18 events from human chats never used while developing the prompt (holdout), and 19 events from one long chat, cfeca7ba, that was compacted many times and is the known worst case for corrections getting lost across compaction rounds.

| Test set | Result | Numbers (arbitrated) |
|---|---|---|
| Holdout (18 unseen human chats) | PASS | P1 +0.1747 mean delta, 13/18 cases improve; regressions at chance level (30/157 property comparisons beyond 1 sd, one-sided binomial p=0.169); attribution guard -0.0278, within the -0.10 allowance |
| cfeca7ba (19-event deep chain) | FAIL | correction-capture 0.4365 (new) vs 0.4675 (current); regressions at chance level (9/41, p=0.200) |

Unarbitrated scores agree in direction: holdout P1 +0.1599 (PASS), cfeca7ba 0.3638 vs 0.3808 (FAIL).

## Impact and scope

For human chats, a single compaction now retains materially more of what the user constrained and corrected. The deep-chain criterion failed: on the repeatedly compacted chat, the new prompt did not improve correction survival. The operator explicitly waived that criterion and scoped the claim accordingly. The limitation is structural: each compaction summarizes the previous summary, so anything one round drops is unrecoverable in later rounds; no wording change to a single-round summary prompt can fix that. Deep-chain loss stays an open problem.

The retention gain costs summary length: holdout summaries average 11% more tokens (ratio 1.106).

<details>
<summary>Supporting context for reviewers</summary>

### Judging pipeline

Primary judge: one fresh single-event agent per (event, summary), because a judge scoring events sequentially accumulates context and measurably degrades (55.8% vs 77.9% weakened-constraint detection on identical events). Secondary judge from a different model family on a 20% sample plus all high-stakes runs; a third model arbitrates disagreement cells. A separate assertion audit filters phantom claims (content the summary invented) before scoring. A control smoke test passed 10/10. The regression clause is binomial because roughly 16% of paired comparisons exceed 1 sd downward under pure noise, so a "no case regresses" clause can never pass; the gate instead requires the regression count not to significantly exceed chance.

Generalization: the holdout is all human-user chats with no sub-agent events, so the validation supports human chats only.

### Holdout per-case results (arbitrated)

New prompt is internally called variant h001b; "default" is the current prompt.

| case | P1 new | P1 default | P1 delta | P3 delta | len ratio |
|---|---|---|---|---|---|
| 038720e9-4800712 | 1.0 | 0.7222 | +0.2778 | +0.25 | 1.255 |
| 2f255e80-3925976 | 1.0 | 0.6667 | +0.3333 | 0.0 | 0.969 |
| 2f255e80-3931754 | 1.0 | 0.9583 | +0.0417 | 0.0 | 0.947 |
| 2f255e80-3978443 | 1.0 | 0.8333 | +0.1667 | +0.25 | 1.205 |
| 2f255e80-3981940 | 1.0 | 0.7692 | +0.2308 | 0.0 | 0.989 |
| 2f255e80-4004831 | 1.0 | 0.75 | +0.25 | 0.0 | 0.971 |
| 5be78e2f-4687738 | 0.9375 | 0.9375 | 0.0 | +0.25 | 1.006 |
| 5be78e2f-4692890 | 1.0 | 0.3571 | +0.6429 | +0.25 | 1.005 |
| 5be78e2f-4697135 | 0.9 | 0.6 | +0.3 | -0.5 | 1.073 |
| 5be78e2f-4704300 | 0.8 | 0.8 | 0.0 | -0.75 | 1.157 |
| 7f935b17-4312693 | 1.0 | 1.0 | 0.0 | +0.25 | 0.91 |
| 824b9027-4119671 | 0.625 | 0.7708 | -0.1458 | -0.25 | 1.472 |
| a7f79a37-4621079 | 1.0 | 0.9 | +0.1 | +0.5 | 1.219 |
| a7f79a37-4621902 | 1.0 | 0.7143 | +0.2857 | 0.0 | 0.971 |
| a7f79a37-4625020 | 0.9211 | 0.5263 | +0.3948 | 0.0 | 1.211 |
| a7f79a37-4644948 | 1.0 | 1.0 | 0.0 | -0.25 | 1.261 |
| a7f79a37-4681550 | 0.5312 | 0.3438 | +0.1874 | 0.0 | 1.26 |
| ddf249d0-4782753 | 0.74 | 0.66 | +0.08 | -0.5 | 1.027 |
| **mean** | | | **+0.1747** | **-0.0278** | **1.1059** |

P3 is attribution quality: rules labeled by origin (user-stated, agent-decided, agent-inferred), guarded so the constraint-retention gain does not come from attributing everything to the user.

### cfeca7ba deep-chain results (arbitrated)

Per-compaction correction-capture (P10) mean delta over the 19 chain events is -0.031 (0.4365 vs 0.4675), so the new prompt does not improve retention on this chat and the criterion fails. Arbitration widened the primary-only gap (-0.017 to -0.031), so the earlier apparent flip was judge noise. The only chain-level evidence available is a one-hop substitution result (candidate config 0.450 vs production 0.356 pooled constraint survival), which cannot speak to full chain dynamics; those are only measurable live.

### Process note: pre-push hook bypass

The local pre-push hook was bypassed once (`git push --no-verify`) with explicit operator authorization. Grounds: `make test-storybook` fails on the base commit 55b06f14a3 itself in the dev environment (three AgentsPage stories, verified on a clean detached checkout), the diff is 14 added lines in a Go string constant that does not touch site/, and GitHub check runs on the base sha report no failures (7 success, 23 skipped).

</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
