### PR TITLE
chore: rename agent firewall flags

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -100,25 +100,25 @@ type Options struct {
 	IgnorePorts map[int]string
 	// ListeningPortsGetter is used to get the list of listening ports. Only
 	// tests should set this. If unset, a default that queries the OS will be used.
-	ListeningPortsGetter         ListeningPortsGetter
-	SSHMaxTimeout                time.Duration
-	TailnetListenPort            uint16
-	Subsystems                   []codersdk.AgentSubsystem
-	PrometheusRegistry           *prometheus.Registry
-	ReportMetadataInterval       time.Duration
-	ServiceBannerRefreshInterval time.Duration
-	BlockFileTransfer            bool
-	BlockReversePortForwarding   bool
-	BlockLocalPortForwarding     bool
-	Execer                       agentexec.Execer
-	Devcontainers                bool
-	DevcontainerAPIOptions       []agentcontainers.Option // Enable Devcontainers for these to be effective.
-	GitAPIOptions                []agentgit.Option
-	Clock                        quartz.Clock
-	SocketServerEnabled          bool
-	SocketPath                   string // Path for the agent socket server socket
-	BoundaryLogProxySocketPath   string
-	ContextConfig                agentcontextconfig.Config
+	ListeningPortsGetter            ListeningPortsGetter
+	SSHMaxTimeout                   time.Duration
+	TailnetListenPort               uint16
+	Subsystems                      []codersdk.AgentSubsystem
+	PrometheusRegistry              *prometheus.Registry
+	ReportMetadataInterval          time.Duration
+	ServiceBannerRefreshInterval    time.Duration
+	BlockFileTransfer               bool
+	BlockReversePortForwarding      bool
+	BlockLocalPortForwarding        bool
+	Execer                          agentexec.Execer
+	Devcontainers                   bool
+	DevcontainerAPIOptions          []agentcontainers.Option // Enable Devcontainers for these to be effective.
+	GitAPIOptions                   []agentgit.Option
+	Clock                           quartz.Clock
+	SocketServerEnabled             bool
+	SocketPath                      string // Path for the agent socket server socket
+	AgentFirewallLogProxySocketPath string
+	ContextConfig                   agentcontextconfig.Config
 	// DERPTLSConfig is an optional TLS config for DERP connections.
 	DERPTLSConfig *tls.Config
 	// StatsReportInterval is the interval for the connstats callback
@@ -253,14 +253,14 @@ func New(options Options) Agent {
 		metrics:            newAgentMetrics(prometheusRegistry),
 		execer:             options.Execer,
 
-		devcontainers:              options.Devcontainers,
-		containerAPIOptions:        options.DevcontainerAPIOptions,
-		gitAPIOptions:              options.GitAPIOptions,
-		socketPath:                 options.SocketPath,
-		socketServerEnabled:        options.SocketServerEnabled,
-		boundaryLogProxySocketPath: options.BoundaryLogProxySocketPath,
-		contextConfig:              options.ContextConfig,
-		derpTLSConfig:              options.DERPTLSConfig,
+		devcontainers:                   options.Devcontainers,
+		containerAPIOptions:             options.DevcontainerAPIOptions,
+		gitAPIOptions:                   options.GitAPIOptions,
+		socketPath:                      options.SocketPath,
+		socketServerEnabled:             options.SocketServerEnabled,
+		agentFirewallLogProxySocketPath: options.AgentFirewallLogProxySocketPath,
+		contextConfig:                   options.ContextConfig,
+		derpTLSConfig:                   options.DERPTLSConfig,
 	}
 	// Initially, we have a closed channel, reflecting the fact that we are not initially connected.
 	// Each time we connect we replace the channel (while holding the closeMutex) with a new one
@@ -337,11 +337,11 @@ type agent struct {
 
 	logSender *agentsdk.LogSender
 
-	// boundaryLogProxy is a socket server that forwards boundary audit logs to coderd.
+	// agentFirewallLogProxy is a socket server that forwards Agent Firewall audit logs to coderd.
 	// It may be nil if there is a problem starting the server.
-	boundaryLogProxy           *boundarylogproxy.Server
-	boundaryLogProxySocketPath string
-	contextConfig              agentcontextconfig.Config
+	agentFirewallLogProxy           *boundarylogproxy.Server
+	agentFirewallLogProxySocketPath string
+	contextConfig                   agentcontextconfig.Config
 
 	prometheusRegistry *prometheus.Registry
 	// metrics are prometheus registered metrics that will be collected and
@@ -540,7 +540,7 @@ func (a *agent) init() {
 	)
 
 	a.initSocketServer()
-	a.startBoundaryLogProxyServer()
+	a.startAgentFirewallLogProxyServer()
 
 	// Start the agentcontext manager's resolver/watcher loop.
 	// It runs for the lifetime of the agent and is closed in
@@ -576,22 +576,21 @@ func (a *agent) initSocketServer() {
 	a.logger.Debug(a.hardCtx, "socket server started", slog.F("path", a.socketPath))
 }
 
-// startBoundaryLogProxyServer starts the boundary log proxy socket server.
-func (a *agent) startBoundaryLogProxyServer() {
-	if a.boundaryLogProxySocketPath == "" {
-		a.logger.Warn(a.hardCtx, "boundary log proxy socket path not defined; not starting proxy")
+func (a *agent) startAgentFirewallLogProxyServer() {
+	if a.agentFirewallLogProxySocketPath == "" {
+		a.logger.Warn(a.hardCtx, "agent firewall log proxy socket path not defined; not starting proxy")
 		return
 	}
 
-	proxy := boundarylogproxy.NewServer(a.logger, a.boundaryLogProxySocketPath, a.prometheusRegistry)
+	proxy := boundarylogproxy.NewServer(a.logger, a.agentFirewallLogProxySocketPath, a.prometheusRegistry)
 	if err := proxy.Start(); err != nil {
-		a.logger.Warn(a.hardCtx, "failed to start boundary log proxy", slog.Error(err))
+		a.logger.Warn(a.hardCtx, "failed to start agent firewall log proxy", slog.Error(err))
 		return
 	}
 
-	a.boundaryLogProxy = proxy
-	a.logger.Info(a.hardCtx, "boundary log proxy server started",
-		slog.F("socket_path", a.boundaryLogProxySocketPath))
+	a.agentFirewallLogProxy = proxy
+	a.logger.Info(a.hardCtx, "agent firewall log proxy server started",
+		slog.F("socket_path", a.agentFirewallLogProxySocketPath))
 }
 
 // runLoop attempts to start the agent in a retry loop.
@@ -1229,13 +1228,13 @@ func (a *agent) run() (retErr error) {
 			return err
 		})
 
-	// Forward boundary audit logs to coderd if boundary log forwarding is enabled.
+	// Forward Agent Firewall audit logs to coderd if agent firewall log forwarding is enabled.
 	// These are audit logs so they should continue during graceful shutdown.
-	if a.boundaryLogProxy != nil {
+	if a.agentFirewallLogProxy != nil {
 		proxyFunc := func(ctx context.Context, aAPI proto.DRPCAgentClient28) error {
-			return a.boundaryLogProxy.RunForwarder(ctx, aAPI)
+			return a.agentFirewallLogProxy.RunForwarder(ctx, aAPI)
 		}
-		connMan.startAgentAPI("boundary log proxy", gracefulShutdownBehaviorRemain, proxyFunc)
+		connMan.startAgentAPI("agent firewall log proxy", gracefulShutdownBehaviorRemain, proxyFunc)
 	}
 
 	// part of graceful shut down is reporting the final lifecycle states, e.g "ShuttingDown" so the
@@ -2414,10 +2413,10 @@ func (a *agent) Close() error {
 		a.logger.Error(a.hardCtx, "agentcontext manager close", slog.Error(err))
 	}
 
-	if a.boundaryLogProxy != nil {
-		err = a.boundaryLogProxy.Close()
+	if a.agentFirewallLogProxy != nil {
+		err = a.agentFirewallLogProxy.Close()
 		if err != nil {
-			a.logger.Warn(context.Background(), "close boundary log proxy", slog.Error(err))
+			a.logger.Warn(context.Background(), "close agent firewall log proxy", slog.Error(err))
 		}
 	}
 

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -42,28 +42,28 @@ import (
 
 func workspaceAgent() *serpent.Command {
 	var (
-		logDir                         string
-		scriptDataDir                  string
-		pprofAddress                   string
-		noReap                         bool
-		sshMaxTimeout                  time.Duration
-		tailnetListenPort              int64
-		prometheusAddress              string
-		debugAddress                   string
-		slogHumanPath                  string
-		slogJSONPath                   string
-		slogStackdriverPath            string
-		blockFileTransfer              bool
-		blockReversePortForwarding     bool
-		blockLocalPortForwarding       bool
-		agentHeaderCommand             string
-		agentHeader                    []string
-		devcontainers                  bool
-		devcontainerProjectDiscovery   bool
-		devcontainerDiscoveryAutostart bool
-		socketServerEnabled            bool
-		socketPath                     string
-		boundaryLogProxySocketPath     string
+		logDir                          string
+		scriptDataDir                   string
+		pprofAddress                    string
+		noReap                          bool
+		sshMaxTimeout                   time.Duration
+		tailnetListenPort               int64
+		prometheusAddress               string
+		debugAddress                    string
+		slogHumanPath                   string
+		slogJSONPath                    string
+		slogStackdriverPath             string
+		blockFileTransfer               bool
+		blockReversePortForwarding      bool
+		blockLocalPortForwarding        bool
+		agentHeaderCommand              string
+		agentHeader                     []string
+		devcontainers                   bool
+		devcontainerProjectDiscovery    bool
+		devcontainerDiscoveryAutostart  bool
+		socketServerEnabled             bool
+		socketPath                      string
+		agentFirewallLogProxySocketPath string
 	)
 	agentAuth := &AgentAuth{}
 	cmd := &serpent.Command{
@@ -337,10 +337,10 @@ func workspaceAgent() *serpent.Command {
 						agentcontainers.WithProjectDiscovery(devcontainerProjectDiscovery),
 						agentcontainers.WithDiscoveryAutostart(devcontainerDiscoveryAutostart),
 					},
-					SocketPath:                 socketPath,
-					SocketServerEnabled:        socketServerEnabled,
-					BoundaryLogProxySocketPath: boundaryLogProxySocketPath,
-					ContextConfig:              contextConfig,
+					SocketPath:                      socketPath,
+					SocketServerEnabled:             socketServerEnabled,
+					AgentFirewallLogProxySocketPath: agentFirewallLogProxySocketPath,
+					ContextConfig:                   contextConfig,
 				})
 
 				if debugAddress != "" {
@@ -556,7 +556,21 @@ func workspaceAgent() *serpent.Command {
 			Default:     boundarylogproxy.DefaultSocketPath(),
 			Env:         "CODER_AGENT_BOUNDARY_LOG_PROXY_SOCKET_PATH",
 			Description: "The path for the boundary log proxy server Unix socket. Boundary should write audit logs to this socket.",
-			Value:       serpent.StringOf(&boundaryLogProxySocketPath),
+			Value:       serpent.StringOf(&agentFirewallLogProxySocketPath),
+			Hidden:      true,
+			UseInstead: []serpent.Option{
+				{
+					Flag: "agent-firewall-log-proxy-socket-path",
+					Env:  "CODER_AGENT_FIREWALL_LOG_PROXY_SOCKET_PATH",
+				},
+			},
+		},
+		{
+			Flag:        "agent-firewall-log-proxy-socket-path",
+			Default:     boundarylogproxy.DefaultSocketPath(),
+			Env:         "CODER_AGENT_FIREWALL_LOG_PROXY_SOCKET_PATH",
+			Description: "The path for the agent firewall log proxy server Unix socket. Agent firewall should write audit logs to this socket.",
+			Value:       serpent.StringOf(&agentFirewallLogProxySocketPath),
 		},
 	}
 	agentAuth.AttachOptions(cmd, false)

--- a/cli/testdata/coder_agent_--help.golden
+++ b/cli/testdata/coder_agent_--help.golden
@@ -31,6 +31,10 @@ OPTIONS:
       --log-stackdriver string, $CODER_AGENT_LOGGING_STACKDRIVER
           Output Stackdriver compatible logs to a given file.
 
+      --agent-firewall-log-proxy-socket-path string, $CODER_AGENT_FIREWALL_LOG_PROXY_SOCKET_PATH (default: /tmp/boundary-audit.sock)
+          The path for the agent firewall log proxy server Unix socket. Agent
+          firewall should write audit logs to this socket.
+
       --agent-header string-array, $CODER_AGENT_HEADER
           Additional HTTP headers added to all requests. Provide as key=value.
           Can be specified multiple times.
@@ -48,10 +52,6 @@ OPTIONS:
 
       --block-reverse-port-forwarding bool, $CODER_AGENT_BLOCK_REVERSE_PORT_FORWARDING (default: false)
           Block reverse port forwarding through the SSH server (ssh -R).
-
-      --boundary-log-proxy-socket-path string, $CODER_AGENT_BOUNDARY_LOG_PROXY_SOCKET_PATH (default: /tmp/boundary-audit.sock)
-          The path for the boundary log proxy server Unix socket. Boundary
-          should write audit logs to this socket.
 
       --debug-address string, $CODER_AGENT_DEBUG_ADDRESS (default: 127.0.0.1:2113)
           The bind address to serve a debug HTTP server.


### PR DESCRIPTION
* Alias --boundary-log-proxy-socket-path to --agent-firewall-log-proxy-socket-path
* Also alias CODER_AGENT_BOUNDARY_LOG_PROXY_SOCKET_PATH to CODER_AGENT_FIREWALL_LOG_PROXY_SOCKET_PATH 
* Also Rename related variables and symbols to reflect the new name.

<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->
