### PR TITLE
chore: add @coder/docs as a CODEOWNER for docs content and tooling

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -40,3 +40,21 @@ coderd/database/queries/ai_provider_keys.sql @ibetitsmike @johnstcn
 coderd/database/queries/aicostcontrol.sql @ibetitsmike @johnstcn
 codersdk/aiproviders.go @ibetitsmike @johnstcn
 codersdk/aiproviders_bedrock.go @ibetitsmike @johnstcn
+
+# Documentation content and docs-specific tooling are owned by the docs team so
+# that @coder/docs is automatically requested for review on documentation
+# changes. Paths are anchored to the repo root.
+/docs/ @coder/docs
+
+# Prose and Markdown linting configuration.
+/.vale.ini @coder/docs
+/.markdownlint.jsonc @coder/docs
+/.markdownlint-cli2.jsonc @coder/docs
+
+# Reference-docs generators (CLI, API, audit log, and Prometheus metrics docs)
+# and their shared helper.
+scripts/clidocgen/ @coder/docs
+scripts/apidocgen/ @coder/docs
+scripts/auditdocgen/ @coder/docs
+scripts/metricsdocgen/ @coder/docs
+scripts/docgenenv/ @coder/docs

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -45,6 +45,7 @@ codersdk/aiproviders_bedrock.go @ibetitsmike @johnstcn
 # that @coder/docs is automatically requested for review on documentation
 # changes. Paths are anchored to the repo root.
 /docs/ @coder/docs
+/offlinedocs/ @coder/docs
 
 # Prose and Markdown linting configuration.
 /.vale.ini @coder/docs
@@ -58,3 +59,11 @@ scripts/apidocgen/ @coder/docs
 scripts/auditdocgen/ @coder/docs
 scripts/metricsdocgen/ @coder/docs
 scripts/docgenenv/ @coder/docs
+
+# Docs-specific CI workflows. These sit under .github/ (owned above by
+# @jdomeracki-coder), so the docs team is added as a co-owner to keep both
+# parties notified of changes.
+.github/workflows/doc-check.yaml @jdomeracki-coder @coder/docs
+.github/workflows/docs-preview.yaml @jdomeracki-coder @coder/docs
+.github/workflows/deploy-docs.yaml @jdomeracki-coder @coder/docs
+.github/workflows/weekly-docs.yaml @jdomeracki-coder @coder/docs


### PR DESCRIPTION
Linked Linear issue: [DOCS-571](https://linear.app/codercom/issue/DOCS-571/add-coderdocs-as-a-codeowner-for-docs-content-and-tooling-in)

## What

Adds `@coder/docs` as a CODEOWNER for documentation content and docs-specific tooling, so the docs team is automatically requested for review (and notified) whenever these paths change.

## Paths added

- `/docs/` — documentation content
- `/offlinedocs/` — offline docs app
- `/.vale.ini`, `/.markdownlint.jsonc`, `/.markdownlint-cli2.jsonc` — prose/Markdown lint config
- `scripts/clidocgen/`, `scripts/apidocgen/`, `scripts/auditdocgen/`, `scripts/metricsdocgen/`, `scripts/docgenenv/` — reference-docs generators + shared helper
- Docs CI workflows, **co-owned with `@jdomeracki-coder`**: `.github/workflows/doc-check.yaml`, `docs-preview.yaml`, `deploy-docs.yaml`, `weekly-docs.yaml`

Patterns are root-anchored and appended after the existing entries. The workflow lines co-own with `@jdomeracki-coder` (who owns `.github/`), so no existing ownership is removed.

## Out of scope

- `.swaggo` (API swagger-gen config) — intentionally left with its current default ownership.

## Notes

- Intended as **notify-only**: auto-requests `@coder/docs` for review on these paths. `main` does not enforce required code-owner review, so this does not gate merges.
- Takes effect once merged to `main`, and only if `@coder/docs` has write access to this repo.

_Opened as a draft._