### PR TITLE
feat: add Coder Quickstart base to the template builder

### DIFF
--- a/coderd/templatebuilder/bases.go
+++ b/coderd/templatebuilder/bases.go
@@ -265,11 +265,9 @@ func BaseVariables(exampleID string) []ModuleVariable {
 	return bases[exampleID].Manifest.Variables
 }
 
-// BaseIncludedModules returns the catalog module IDs that the given base
-// template already declares in its own Terraform. Compose uses these to
-// reject a wizard-selected module that would collide with a module the
-// base already renders. Returns nil if the base is unknown or declares
-// none.
+// BaseIncludedModules returns the catalog module IDs the given base declares
+// in its own Terraform (see BaseManifest.IncludedModules). Returns nil if the
+// base is unknown or declares none.
 func BaseIncludedModules(exampleID string) []string {
 	bases, err := loadBases()
 	if err != nil || bases[exampleID] == nil {

--- a/coderd/templatebuilder/bases.go
+++ b/coderd/templatebuilder/bases.go
@@ -44,6 +44,11 @@ type BaseManifest struct {
 	OS             string             `json:"os"`
 	DefaultContext BaseDefaultContext `json:"default_context"`
 	Variables      []ModuleVariable   `json:"variables"`
+	// IncludedModules lists the catalog module IDs this base already
+	// declares in its own Terraform (e.g. "git-clone"). Compose treats
+	// these names as occupied so a wizard-selected module cannot collide
+	// with one the base already renders.
+	IncludedModules []string `json:"included_modules,omitempty"`
 }
 
 // BaseDefaultContext holds default render values stored in base.json.
@@ -258,6 +263,19 @@ func BaseVariables(exampleID string) []ModuleVariable {
 		return nil
 	}
 	return bases[exampleID].Manifest.Variables
+}
+
+// BaseIncludedModules returns the catalog module IDs that the given base
+// template already declares in its own Terraform. Compose uses these to
+// reject a wizard-selected module that would collide with a module the
+// base already renders. Returns nil if the base is unknown or declares
+// none.
+func BaseIncludedModules(exampleID string) []string {
+	bases, err := loadBases()
+	if err != nil || bases[exampleID] == nil {
+		return nil
+	}
+	return bases[exampleID].Manifest.IncludedModules
 }
 
 // BaseTemplateFS returns a filesystem rooted at the given base template

--- a/coderd/templatebuilder/bases.go
+++ b/coderd/templatebuilder/bases.go
@@ -44,11 +44,6 @@ type BaseManifest struct {
 	OS             string             `json:"os"`
 	DefaultContext BaseDefaultContext `json:"default_context"`
 	Variables      []ModuleVariable   `json:"variables"`
-	// IncludedModules lists the catalog module IDs this base already
-	// declares in its own Terraform (e.g. "git-clone"). Compose treats
-	// these names as occupied so a wizard-selected module cannot collide
-	// with one the base already renders.
-	IncludedModules []string `json:"included_modules,omitempty"`
 }
 
 // BaseDefaultContext holds default render values stored in base.json.
@@ -265,15 +260,58 @@ func BaseVariables(exampleID string) []ModuleVariable {
 	return bases[exampleID].Manifest.Variables
 }
 
-// BaseIncludedModules returns the catalog module IDs the given base declares
-// in its own Terraform (see BaseManifest.IncludedModules). Returns nil if the
-// base is unknown or declares none.
-func BaseIncludedModules(exampleID string) []string {
+// baseIncludedModules derives, for each base, the catalog module IDs the base
+// declares in its own rendered Terraform (e.g. "git-clone"). It renders each
+// base's main.tf.tmpl once and extracts the module block labels, caching the
+// result. Compose treats these names as occupied so a wizard-selected module
+// cannot collide with one the base already renders.
+//
+// Caveat: derivation uses DefaultBaseRenderContext, so a `module` block gated
+// behind a base variable would not be detected. No base declares variables
+// today, so this is not currently reachable; revisit if that changes.
+var baseIncludedModules = sync.OnceValues(func() (map[string][]string, error) {
 	bases, err := loadBases()
-	if err != nil || bases[exampleID] == nil {
+	if err != nil {
+		return nil, err
+	}
+	catalog, err := loadCatalogMap()
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string][]string, len(bases))
+	for id := range bases {
+		// Only bases that render a main.tf.tmpl can declare modules.
+		if _, ok := bases[id].Templates["main.tf.tmpl"]; !ok {
+			continue
+		}
+		mainTF, err := RenderBaseTemplate(id, "main.tf.tmpl", DefaultBaseRenderContext(id))
+		if err != nil {
+			return nil, xerrors.Errorf("render base %q: %w", id, err)
+		}
+		// Keep only catalog-named module blocks: those are the module IDs a
+		// wizard-selected module could collide with. Non-catalog blocks a base
+		// renders (e.g. the azure_region helper) are never offered by the
+		// wizard, so they cannot collide and are not reserved.
+		var included []string
+		for _, name := range ExtractModuleNames(mainTF) {
+			if _, ok := catalog[name]; ok {
+				included = append(included, name)
+			}
+		}
+		out[id] = included
+	}
+	return out, nil
+})
+
+// BaseIncludedModules returns the catalog module IDs the given base declares in
+// its own rendered Terraform. Returns nil if the base is unknown or declares
+// none.
+func BaseIncludedModules(exampleID string) []string {
+	all, err := baseIncludedModules()
+	if err != nil {
 		return nil
 	}
-	return bases[exampleID].Manifest.IncludedModules
+	return all[exampleID]
 }
 
 // BaseTemplateFS returns a filesystem rooted at the given base template

--- a/coderd/templatebuilder/bases/quickstart/README.md
+++ b/coderd/templatebuilder/bases/quickstart/README.md
@@ -46,7 +46,7 @@ This template provisions:
 - **Docker container** (ephemeral) running Ubuntu with the Coder agent
 - **Docker volume** (persistent) mounted at `/home/coder`
 
-Files in your home directory (`/home/coder`) persist across workspace restarts. The selected languages are reinstalled on every start by a script that blocks login until it finishes: most language tools install into the workspace container rather than your home directory, so they do not persist and are fetched from the network each time the workspace starts.
+Files in your home directory (`/home/coder`) persist across workspace restarts. The language install script runs on every start and blocks login until it finishes. Most toolchains install into the ephemeral workspace container rather than your home directory, so they are reinstalled from the network on each start; the exception is Rust, whose toolchain lives under `~/.cargo` in your home directory and is detected and reused.
 
 ## Presets
 

--- a/coderd/templatebuilder/bases/quickstart/README.md
+++ b/coderd/templatebuilder/bases/quickstart/README.md
@@ -46,7 +46,7 @@ This template provisions:
 - **Docker container** (ephemeral) running Ubuntu with the Coder agent
 - **Docker volume** (persistent) mounted at `/home/coder`
 
-Files in your home directory persist across workspace restarts. Selected languages are installed on first start and cached for subsequent starts.
+Files in your home directory (`/home/coder`) persist across workspace restarts. The selected languages are reinstalled on every start by a script that blocks login until it finishes: most language tools install into the workspace container rather than your home directory, so they do not persist and are fetched from the network each time the workspace starts.
 
 ## Presets
 

--- a/coderd/templatebuilder/bases/quickstart/README.md
+++ b/coderd/templatebuilder/bases/quickstart/README.md
@@ -1,6 +1,6 @@
 ---
 display_name: Coder Quickstart
-description: Get started with Coder by picking your languages, editors, and a repo
+description: Get started with Coder by picking your languages and a repo
 icon: ../../../site/static/icon/coder.svg
 maintainer_github: coder
 verified: true
@@ -9,15 +9,14 @@ tags: [docker, quickstart]
 
 # Coder Quickstart
 
-Get up and running with Coder in minutes. Choose your programming languages, pick your preferred editors, optionally clone a Git repository, and start coding.
+Get up and running with Coder in minutes. Choose your programming languages, optionally clone a Git repository, and start coding.
 
 ## How It Works
 
 When you create a workspace from this template, you select:
 
 1. **Languages** to pre-install (Python, Node.js, Go, Rust, Java, C/C++)
-2. **Editors** to connect (VS Code in the browser, Cursor, JetBrains, Zed, Windsurf)
-3. **A Git repository** to clone (optional)
+2. **A Git repository** to clone (optional)
 
 Coder provisions a workspace with your selections and you can start developing immediately.
 
@@ -51,19 +50,15 @@ Files in your home directory persist across workspace restarts. Selected languag
 
 ## Presets
 
-Select a preset to auto-fill languages and editors for common workflows:
+Select a preset to auto-fill languages for common workflows:
 
-| Preset              | Languages           | Editors                             |
-| ------------------- | ------------------- | ----------------------------------- |
-| **Web Development** | Python, Node.js     | VS Code (Browser)                   |
-| **Backend (Go)**    | Go                  | VS Code (Browser), JetBrains GoLand |
-| **Data Science**    | Python              | VS Code (Browser)                   |
-| **Full Stack**      | Python, Node.js, Go | VS Code (Browser), Cursor           |
+| Preset              | Languages           |
+| ------------------- | ------------------- |
+| **Web Development** | Python, Node.js     |
+| **Backend (Go)**    | Go                  |
+| **Data Science**    | Python              |
+| **Full Stack**      | Python, Node.js, Go |
 
-## IDE Notes
+## Editors
 
-- **VS Code (Browser)**: Opens directly in your browser with no local install required.
-- **VS Code Desktop**: Available on every workspace by default (Coder enables the VS Code Desktop display app automatically), so it is not listed as a separate editor option.
-- **Cursor, Windsurf**: Require the desktop application installed on your local machine. Coder opens them via protocol handler.
-- **JetBrains IDEs**: Filtered by your language selection (e.g. PyCharm for Python, GoLand for Go). Requires JetBrains Toolbox or Gateway on your local machine.
-- **Zed**: Connects over SSH. Requires Zed installed on your local machine.
+VS Code Desktop is available on every workspace by default (Coder enables the VS Code Desktop display app automatically). To add more editors (VS Code in the browser, Cursor, JetBrains, Zed, Windsurf) or other tools, add them as modules in the next step of the template builder.

--- a/coderd/templatebuilder/bases/quickstart/README.md
+++ b/coderd/templatebuilder/bases/quickstart/README.md
@@ -1,0 +1,69 @@
+---
+display_name: Coder Quickstart
+description: Get started with Coder by picking your languages, editors, and a repo
+icon: ../../../site/static/icon/coder.svg
+maintainer_github: coder
+verified: true
+tags: [docker, quickstart]
+---
+
+# Coder Quickstart
+
+Get up and running with Coder in minutes. Choose your programming languages, pick your preferred editors, optionally clone a Git repository, and start coding.
+
+## How It Works
+
+When you create a workspace from this template, you select:
+
+1. **Languages** to pre-install (Python, Node.js, Go, Rust, Java, C/C++)
+2. **Editors** to connect (VS Code in the browser, Cursor, JetBrains, Zed, Windsurf)
+3. **A Git repository** to clone (optional)
+
+Coder provisions a workspace with your selections and you can start developing immediately.
+
+<!-- prerequisites:start -->
+
+## Prerequisites
+
+The host running Coder must have a Docker daemon accessible to the `coder` user:
+
+```sh
+# Add coder user to Docker group
+sudo adduser coder docker
+
+# Restart Coder server
+sudo systemctl restart coder
+
+# Verify access
+sudo -u coder docker ps
+```
+
+<!-- prerequisites:end -->
+
+## Architecture
+
+This template provisions:
+
+- **Docker container** (ephemeral) running Ubuntu with the Coder agent
+- **Docker volume** (persistent) mounted at `/home/coder`
+
+Files in your home directory persist across workspace restarts. Selected languages are installed on first start and cached for subsequent starts.
+
+## Presets
+
+Select a preset to auto-fill languages and editors for common workflows:
+
+| Preset              | Languages           | Editors                             |
+| ------------------- | ------------------- | ----------------------------------- |
+| **Web Development** | Python, Node.js     | VS Code (Browser)                   |
+| **Backend (Go)**    | Go                  | VS Code (Browser), JetBrains GoLand |
+| **Data Science**    | Python              | VS Code (Browser)                   |
+| **Full Stack**      | Python, Node.js, Go | VS Code (Browser), Cursor           |
+
+## IDE Notes
+
+- **VS Code (Browser)**: Opens directly in your browser with no local install required.
+- **VS Code Desktop**: Available on every workspace by default (Coder enables the VS Code Desktop display app automatically), so it is not listed as a separate editor option.
+- **Cursor, Windsurf**: Require the desktop application installed on your local machine. Coder opens them via protocol handler.
+- **JetBrains IDEs**: Filtered by your language selection (e.g. PyCharm for Python, GoLand for Go). Requires JetBrains Toolbox or Gateway on your local machine.
+- **Zed**: Connects over SSH. Requires Zed installed on your local machine.

--- a/coderd/templatebuilder/bases/quickstart/base.json
+++ b/coderd/templatebuilder/bases/quickstart/base.json
@@ -1,0 +1,6 @@
+{
+	"id": "quickstart",
+	"display_name": "Coder Quickstart",
+	"os": "linux",
+	"default_context": {}
+}

--- a/coderd/templatebuilder/bases/quickstart/base.json
+++ b/coderd/templatebuilder/bases/quickstart/base.json
@@ -2,6 +2,5 @@
 	"id": "quickstart",
 	"display_name": "Coder Quickstart",
 	"os": "linux",
-	"default_context": {},
-	"included_modules": ["git-clone"]
+	"default_context": {}
 }

--- a/coderd/templatebuilder/bases/quickstart/base.json
+++ b/coderd/templatebuilder/bases/quickstart/base.json
@@ -2,5 +2,6 @@
 	"id": "quickstart",
 	"display_name": "Coder Quickstart",
 	"os": "linux",
-	"default_context": {}
+	"default_context": {},
+	"included_modules": ["git-clone"]
 }

--- a/coderd/templatebuilder/bases/quickstart/install-languages.sh.tftpl
+++ b/coderd/templatebuilder/bases/quickstart/install-languages.sh.tftpl
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -e
+
+LANGUAGES="${LANGUAGES}"
+APT_UPDATED=false
+
+apt_update() {
+  if [ "$APT_UPDATED" = "false" ]; then
+    sudo apt-get update -qq
+    APT_UPDATED=true
+  fi
+}
+
+if echo "$LANGUAGES" | grep -q "python"; then
+  if command -v python3 >/dev/null 2>&1; then
+    echo "Python: $(python3 --version)"
+  else
+    echo "Installing Python..."
+    apt_update
+    sudo apt-get install -y -qq python3 python3-pip python3-venv
+    echo "Installed Python: $(python3 --version)"
+  fi
+fi
+
+if echo "$LANGUAGES" | grep -q "nodejs"; then
+  if command -v node >/dev/null 2>&1; then
+    echo "Node.js: $(node --version)"
+  else
+    echo "Installing Node.js 22..."
+    curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+    sudo apt-get install -y -qq nodejs
+    echo "Installed Node.js: $(node --version)"
+  fi
+fi
+
+if echo "$LANGUAGES" | grep -q "go"; then
+  if command -v /usr/local/go/bin/go >/dev/null 2>&1; then
+    echo "Go: $(/usr/local/go/bin/go version)"
+  else
+    echo "Installing Go..."
+    ARCH=$(uname -m)
+    case $ARCH in
+      x86_64)  GOARCH="amd64" ;;
+      aarch64) GOARCH="arm64" ;;
+      *)       echo "Unsupported architecture: $ARCH"; exit 1 ;;
+    esac
+    GO_VERSION=$(curl -fsSL "https://go.dev/VERSION?m=text" | head -1)
+    curl -fsSL "https://go.dev/dl/$${GO_VERSION}.linux-$${GOARCH}.tar.gz" | sudo tar -C /usr/local -xz
+    echo 'export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin' | sudo tee /etc/profile.d/go.sh >/dev/null
+    echo "Installed Go: $(/usr/local/go/bin/go version)"
+  fi
+fi
+
+if echo "$LANGUAGES" | grep -q "rust"; then
+  if command -v rustc >/dev/null 2>&1 || [ -f "$HOME/.cargo/bin/rustc" ]; then
+    RUSTC=$${HOME}/.cargo/bin/rustc
+    command -v rustc >/dev/null 2>&1 && RUSTC=rustc
+    echo "Rust: $($RUSTC --version)"
+  else
+    echo "Installing Rust..."
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    echo "Installed Rust: $($HOME/.cargo/bin/rustc --version)"
+  fi
+fi
+
+if echo "$LANGUAGES" | grep -q "java"; then
+  if command -v java >/dev/null 2>&1; then
+    echo "Java: $(java --version 2>&1 | head -1)"
+  else
+    echo "Installing Java (OpenJDK 21)..."
+    apt_update
+    sudo apt-get install -y -qq openjdk-21-jdk
+    echo "Installed Java: $(java --version 2>&1 | head -1)"
+  fi
+fi
+
+if echo "$LANGUAGES" | grep -q "cpp"; then
+  if command -v gcc >/dev/null 2>&1; then
+    echo "C/C++: $(gcc --version | head -1)"
+  else
+    echo "Installing C/C++ toolchain..."
+    apt_update
+    sudo apt-get install -y -qq gcc g++ make cmake
+    echo "Installed C/C++: $(gcc --version | head -1)"
+  fi
+fi
+
+echo "Language setup complete."

--- a/coderd/templatebuilder/bases/quickstart/install-languages.sh.tftpl
+++ b/coderd/templatebuilder/bases/quickstart/install-languages.sh.tftpl
@@ -11,7 +11,17 @@ apt_update() {
   fi
 }
 
-if echo "$LANGUAGES" | grep -q "python"; then
+# has_language reports whether NAME is one of the selected languages. It matches
+# whole comma-separated entries, so a value can never partially match another
+# (guards against a future language whose name contains an existing one).
+has_language() {
+  case ",$LANGUAGES," in
+    *",$1,"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if has_language python; then
   if command -v python3 >/dev/null 2>&1; then
     echo "Python: $(python3 --version)"
   else
@@ -22,7 +32,7 @@ if echo "$LANGUAGES" | grep -q "python"; then
   fi
 fi
 
-if echo "$LANGUAGES" | grep -q "nodejs"; then
+if has_language nodejs; then
   if command -v node >/dev/null 2>&1; then
     echo "Node.js: $(node --version)"
   else
@@ -33,7 +43,7 @@ if echo "$LANGUAGES" | grep -q "nodejs"; then
   fi
 fi
 
-if echo "$LANGUAGES" | grep -q "go"; then
+if has_language go; then
   if command -v /usr/local/go/bin/go >/dev/null 2>&1; then
     echo "Go: $(/usr/local/go/bin/go version)"
   else
@@ -51,7 +61,7 @@ if echo "$LANGUAGES" | grep -q "go"; then
   fi
 fi
 
-if echo "$LANGUAGES" | grep -q "rust"; then
+if has_language rust; then
   if command -v rustc >/dev/null 2>&1 || [ -f "$HOME/.cargo/bin/rustc" ]; then
     RUSTC=$${HOME}/.cargo/bin/rustc
     command -v rustc >/dev/null 2>&1 && RUSTC=rustc
@@ -63,7 +73,7 @@ if echo "$LANGUAGES" | grep -q "rust"; then
   fi
 fi
 
-if echo "$LANGUAGES" | grep -q "java"; then
+if has_language java; then
   if command -v java >/dev/null 2>&1; then
     echo "Java: $(java --version 2>&1 | head -1)"
   else
@@ -74,7 +84,7 @@ if echo "$LANGUAGES" | grep -q "java"; then
   fi
 fi
 
-if echo "$LANGUAGES" | grep -q "cpp"; then
+if has_language cpp; then
   if command -v gcc >/dev/null 2>&1; then
     echo "C/C++: $(gcc --version | head -1)"
   else

--- a/coderd/templatebuilder/bases/quickstart/main.tf.tmpl
+++ b/coderd/templatebuilder/bases/quickstart/main.tf.tmpl
@@ -151,6 +151,11 @@ resource "coder_script" "install_languages" {
 }
 
 # --- Git clone ---
+# NOTE: base templates render their module sources verbatim, so this pins the
+# public registry (registry.coder.com). Unlike wizard-composed modules, a
+# base-embedded module does not yet honor a deployment's configured module
+# registry mirror; threading that registry through base rendering is tracked as
+# a follow-up.
 
 module "git-clone" {
   count    = data.coder_workspace.me.start_count * (data.coder_parameter.git_repo.value != "" ? 1 : 0)

--- a/coderd/templatebuilder/bases/quickstart/main.tf.tmpl
+++ b/coderd/templatebuilder/bases/quickstart/main.tf.tmpl
@@ -1,0 +1,437 @@
+terraform {
+  required_providers {
+    coder = {
+      source = "coder/coder"
+    }
+    docker = {
+      source = "kreuzwerker/docker"
+    }
+    external = {
+      source = "hashicorp/external"
+    }
+  }
+}
+
+variable "docker_socket" {
+  default     = ""
+  description = "(Optional) Docker socket URI"
+  type        = string
+}
+
+provider "docker" {
+  host = var.docker_socket != "" ? var.docker_socket : null
+}
+
+data "coder_provisioner" "me" {}
+data "coder_workspace" "me" {}
+data "coder_workspace_owner" "me" {}
+
+# --- Parameters ---
+
+data "coder_parameter" "languages" {
+  name         = "languages"
+  display_name = "Programming Languages"
+  description  = "Select the languages to pre-install in your workspace"
+  type         = "list(string)"
+  form_type    = "multi-select"
+  default      = jsonencode(["python"])
+  mutable      = true
+  icon         = "/icon/code.svg"
+  order        = 1
+
+  option {
+    name  = "Python"
+    value = "python"
+    icon  = "/icon/python.svg"
+  }
+  option {
+    name  = "Node.js"
+    value = "nodejs"
+    icon  = "/icon/nodejs.svg"
+  }
+  option {
+    name  = "Go"
+    value = "go"
+    icon  = "/icon/go.svg"
+  }
+  option {
+    name  = "Rust"
+    value = "rust"
+    icon  = "/icon/rust.svg"
+  }
+  option {
+    name  = "Java"
+    value = "java"
+    icon  = "/icon/java.svg"
+  }
+  option {
+    name  = "C/C++"
+    value = "cpp"
+    icon  = "/icon/cpp.svg"
+  }
+}
+
+data "coder_parameter" "ides" {
+  name         = "ides"
+  display_name = "IDEs & Editors"
+  description  = "Select the development environments for your workspace"
+  type         = "list(string)"
+  form_type    = "multi-select"
+  default      = jsonencode(["code-server"])
+  mutable      = true
+  icon         = "/icon/code.svg"
+  order        = 2
+
+  option {
+    name  = "VS Code (Browser)"
+    value = "code-server"
+    icon  = "/icon/code.svg"
+  }
+  option {
+    name  = "Cursor"
+    value = "cursor"
+    icon  = "/icon/cursor.svg"
+  }
+  option {
+    name  = "JetBrains IDEs"
+    value = "jetbrains"
+    icon  = "/icon/jetbrains.svg"
+  }
+  option {
+    name  = "Zed"
+    value = "zed"
+    icon  = "/icon/zed.svg"
+  }
+  option {
+    name  = "Windsurf"
+    value = "windsurf"
+    icon  = "/icon/windsurf.svg"
+  }
+}
+
+# Shown only when "JetBrains IDEs" is selected in the IDEs parameter.
+# Pre-selects IDEs that match the chosen languages.
+data "coder_parameter" "jetbrains_ides" {
+  count        = contains(local.ides, "jetbrains") ? 1 : 0
+  name         = "jetbrains_ides"
+  display_name = "JetBrains IDEs"
+  description  = "Select the JetBrains IDEs to install"
+  type         = "list(string)"
+  form_type    = "multi-select"
+  default      = jsonencode(local.jetbrains_ides_from_languages)
+  mutable      = true
+  icon         = "/icon/jetbrains.svg"
+  order        = 3
+
+  option {
+    name  = "IntelliJ IDEA"
+    value = "IU"
+    icon  = "/icon/intellij.svg"
+  }
+  option {
+    name  = "PyCharm"
+    value = "PY"
+    icon  = "/icon/pycharm.svg"
+  }
+  option {
+    name  = "GoLand"
+    value = "GO"
+    icon  = "/icon/goland.svg"
+  }
+  option {
+    name  = "WebStorm"
+    value = "WS"
+    icon  = "/icon/webstorm.svg"
+  }
+  option {
+    name  = "RustRover"
+    value = "RR"
+    icon  = "/icon/rustrover.svg"
+  }
+  option {
+    name  = "CLion"
+    value = "CL"
+    icon  = "/icon/clion.svg"
+  }
+  option {
+    name  = "PhpStorm"
+    value = "PS"
+    icon  = "/icon/phpstorm.svg"
+  }
+  option {
+    name  = "RubyMine"
+    value = "RM"
+    icon  = "/icon/rubymine.svg"
+  }
+  option {
+    name  = "Rider"
+    value = "RD"
+    icon  = "/icon/rider.svg"
+  }
+}
+
+data "coder_parameter" "git_repo" {
+  name         = "git_repo"
+  display_name = "Git Repository (Optional)"
+  description  = "URL of a Git repository to clone into your workspace (leave empty to skip)"
+  type         = "string"
+  default      = ""
+  mutable      = true
+  icon         = "/icon/git.svg"
+  order        = 4
+}
+
+# --- Locals ---
+
+locals {
+  username  = data.coder_workspace_owner.me.name
+  languages = jsondecode(data.coder_parameter.languages.value)
+  ides      = jsondecode(data.coder_parameter.ides.value)
+
+  # Map selected languages to the relevant JetBrains IDE product codes.
+  # Used as the default for the JetBrains IDE selector parameter.
+  jetbrains_by_language = {
+    python = ["PY"]
+    go     = ["GO"]
+    java   = ["IU"]
+    nodejs = ["WS"]
+    rust   = ["RR"]
+    cpp    = ["CL"]
+  }
+  jetbrains_ides_from_languages = distinct(flatten([
+    for lang in local.languages : lookup(local.jetbrains_by_language, lang, [])
+  ]))
+
+  # The actual JetBrains IDEs to install, from the user's selection
+  # in the conditional JetBrains parameter (or empty if not shown).
+  jetbrains_selected = contains(local.ides, "jetbrains") ? jsondecode(data.coder_parameter.jetbrains_ides[0].value) : []
+}
+
+# --- Agent ---
+
+resource "coder_agent" "main" {
+  arch           = data.coder_provisioner.me.arch
+  os             = "linux"
+  startup_script = <<-EOT
+    set -e
+    if [ ! -f ~/.init_done ]; then
+      cp -rT /etc/skel ~
+      touch ~/.init_done
+    fi
+  EOT
+
+  env = {
+    GIT_AUTHOR_NAME     = coalesce(data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
+    GIT_AUTHOR_EMAIL    = "${data.coder_workspace_owner.me.email}"
+    GIT_COMMITTER_NAME  = coalesce(data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
+    GIT_COMMITTER_EMAIL = "${data.coder_workspace_owner.me.email}"
+  }
+
+  metadata {
+    display_name = "CPU Usage"
+    key          = "0_cpu_usage"
+    script       = "coder stat cpu"
+    interval     = 10
+    timeout      = 1
+  }
+
+  metadata {
+    display_name = "RAM Usage"
+    key          = "1_ram_usage"
+    script       = "coder stat mem"
+    interval     = 10
+    timeout      = 1
+  }
+
+  metadata {
+    display_name = "Home Disk"
+    key          = "3_home_disk"
+    script       = "coder stat disk --path $${HOME}"
+    interval     = 60
+    timeout      = 1
+  }
+}
+
+# --- Language installation ---
+# All languages install in a single script to avoid apt-get lock
+# conflicts (coder_script resources run in parallel).
+
+resource "coder_script" "install_languages" {
+  count              = length(local.languages) > 0 ? 1 : 0
+  agent_id           = coder_agent.main.id
+  display_name       = "Install Languages"
+  icon               = "/icon/code.svg"
+  run_on_start       = true
+  start_blocks_login = true
+  script = templatefile("${path.module}/install-languages.sh.tftpl", {
+    LANGUAGES = join(",", local.languages)
+  })
+}
+
+# --- IDE modules ---
+
+module "code-server" {
+  count    = data.coder_workspace.me.start_count * (contains(local.ides, "code-server") ? 1 : 0)
+  source   = "registry.coder.com/coder/code-server/coder"
+  version  = "~> 1.0"
+  agent_id = coder_agent.main.id
+  order    = 1
+}
+
+
+module "cursor" {
+  count    = data.coder_workspace.me.start_count * (contains(local.ides, "cursor") ? 1 : 0)
+  source   = "registry.coder.com/coder/cursor/coder"
+  version  = "~> 1.0"
+  agent_id = coder_agent.main.id
+  folder   = "/home/coder"
+  order    = 3
+}
+
+# TODO: Re-add the coder/jetbrains module once Coder's dynamic
+# parameter system respects module count for parameter visibility.
+# The module's internal coder_parameter appears even when count = 0,
+# creating a ghost parameter in the workspace creation form.
+# module "jetbrains" {
+#   count    = data.coder_workspace.me.start_count * (contains(local.ides, "jetbrains") && length(local.jetbrains_selected) > 0 ? 1 : 0)
+#   source   = "registry.coder.com/coder/jetbrains/coder"
+#   version  = "~> 1.0"
+#   agent_id = coder_agent.main.id
+#   folder   = "/home/coder"
+#   default  = toset(local.jetbrains_selected)
+# }
+
+module "zed" {
+  count    = data.coder_workspace.me.start_count * (contains(local.ides, "zed") ? 1 : 0)
+  source   = "registry.coder.com/coder/zed/coder"
+  version  = "~> 1.0"
+  agent_id = coder_agent.main.id
+  folder   = "/home/coder"
+  order    = 5
+}
+
+module "windsurf" {
+  count    = data.coder_workspace.me.start_count * (contains(local.ides, "windsurf") ? 1 : 0)
+  source   = "registry.coder.com/coder/windsurf/coder"
+  version  = "~> 1.0"
+  agent_id = coder_agent.main.id
+  folder   = "/home/coder"
+  order    = 6
+}
+
+# --- Git clone ---
+
+module "git-clone" {
+  count    = data.coder_workspace.me.start_count * (data.coder_parameter.git_repo.value != "" ? 1 : 0)
+  source   = "registry.coder.com/coder/git-clone/coder"
+  version  = "~> 2.0"
+  agent_id = coder_agent.main.id
+  url      = data.coder_parameter.git_repo.value
+}
+
+# --- Presets ---
+
+data "coder_workspace_preset" "web_dev" {
+  name = "Web Development"
+  icon = "/icon/nodejs.svg"
+  parameters = {
+    languages = jsonencode(["python", "nodejs"])
+    ides      = jsonencode(["code-server"])
+    git_repo  = ""
+  }
+}
+
+data "coder_workspace_preset" "backend_go" {
+  name = "Backend (Go)"
+  icon = "/icon/go.svg"
+  parameters = {
+    languages      = jsonencode(["go"])
+    ides           = jsonencode(["code-server", "jetbrains"])
+    jetbrains_ides = jsonencode(["GO"])
+    git_repo       = ""
+  }
+}
+
+data "coder_workspace_preset" "data_science" {
+  name = "Data Science"
+  icon = "/icon/python.svg"
+  parameters = {
+    languages = jsonencode(["python"])
+    ides      = jsonencode(["code-server"])
+    git_repo  = ""
+  }
+}
+
+data "coder_workspace_preset" "full_stack" {
+  name = "Full Stack"
+  icon = "/icon/code.svg"
+  parameters = {
+    languages = jsonencode(["python", "nodejs", "go"])
+    ides      = jsonencode(["code-server", "cursor"])
+    git_repo  = ""
+  }
+}
+
+# --- Docker resources ---
+
+resource "docker_volume" "home_volume" {
+  name = "coder-${data.coder_workspace.me.id}-home"
+  lifecycle {
+    ignore_changes = all
+  }
+  labels {
+    label = "coder.owner"
+    value = data.coder_workspace_owner.me.name
+  }
+  labels {
+    label = "coder.owner_id"
+    value = data.coder_workspace_owner.me.id
+  }
+  labels {
+    label = "coder.workspace_id"
+    value = data.coder_workspace.me.id
+  }
+  labels {
+    label = "coder.workspace_name_at_creation"
+    value = data.coder_workspace.me.name
+  }
+  depends_on = []
+}
+
+resource "docker_container" "workspace" {
+  count    = data.coder_workspace.me.start_count
+  image    = "codercom/enterprise-base:ubuntu"
+  name     = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}"
+  hostname = data.coder_workspace.me.name
+  entrypoint = [
+    "sh", "-c",
+    replace(coder_agent.main.init_script, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal"),
+  ]
+  env = ["CODER_AGENT_TOKEN=${coder_agent.main.token}"]
+  host {
+    host = "host.docker.internal"
+    ip   = "host-gateway"
+  }
+  volumes {
+    container_path = "/home/coder"
+    volume_name    = docker_volume.home_volume.name
+    read_only      = false
+  }
+  labels {
+    label = "coder.owner"
+    value = data.coder_workspace_owner.me.name
+  }
+  labels {
+    label = "coder.owner_id"
+    value = data.coder_workspace_owner.me.id
+  }
+  labels {
+    label = "coder.workspace_id"
+    value = data.coder_workspace.me.id
+  }
+  labels {
+    label = "coder.workspace_name"
+    value = data.coder_workspace.me.name
+  }
+  depends_on = []
+}

--- a/coderd/templatebuilder/bases/quickstart/main.tf.tmpl
+++ b/coderd/templatebuilder/bases/quickstart/main.tf.tmpl
@@ -71,105 +71,6 @@ data "coder_parameter" "languages" {
   }
 }
 
-data "coder_parameter" "ides" {
-  name         = "ides"
-  display_name = "IDEs & Editors"
-  description  = "Select the development environments for your workspace"
-  type         = "list(string)"
-  form_type    = "multi-select"
-  default      = jsonencode(["code-server"])
-  mutable      = true
-  icon         = "/icon/code.svg"
-  order        = 2
-
-  option {
-    name  = "VS Code (Browser)"
-    value = "code-server"
-    icon  = "/icon/code.svg"
-  }
-  option {
-    name  = "Cursor"
-    value = "cursor"
-    icon  = "/icon/cursor.svg"
-  }
-  option {
-    name  = "JetBrains IDEs"
-    value = "jetbrains"
-    icon  = "/icon/jetbrains.svg"
-  }
-  option {
-    name  = "Zed"
-    value = "zed"
-    icon  = "/icon/zed.svg"
-  }
-  option {
-    name  = "Windsurf"
-    value = "windsurf"
-    icon  = "/icon/windsurf.svg"
-  }
-}
-
-# Shown only when "JetBrains IDEs" is selected in the IDEs parameter.
-# Pre-selects IDEs that match the chosen languages.
-data "coder_parameter" "jetbrains_ides" {
-  count        = contains(local.ides, "jetbrains") ? 1 : 0
-  name         = "jetbrains_ides"
-  display_name = "JetBrains IDEs"
-  description  = "Select the JetBrains IDEs to install"
-  type         = "list(string)"
-  form_type    = "multi-select"
-  default      = jsonencode(local.jetbrains_ides_from_languages)
-  mutable      = true
-  icon         = "/icon/jetbrains.svg"
-  order        = 3
-
-  option {
-    name  = "IntelliJ IDEA"
-    value = "IU"
-    icon  = "/icon/intellij.svg"
-  }
-  option {
-    name  = "PyCharm"
-    value = "PY"
-    icon  = "/icon/pycharm.svg"
-  }
-  option {
-    name  = "GoLand"
-    value = "GO"
-    icon  = "/icon/goland.svg"
-  }
-  option {
-    name  = "WebStorm"
-    value = "WS"
-    icon  = "/icon/webstorm.svg"
-  }
-  option {
-    name  = "RustRover"
-    value = "RR"
-    icon  = "/icon/rustrover.svg"
-  }
-  option {
-    name  = "CLion"
-    value = "CL"
-    icon  = "/icon/clion.svg"
-  }
-  option {
-    name  = "PhpStorm"
-    value = "PS"
-    icon  = "/icon/phpstorm.svg"
-  }
-  option {
-    name  = "RubyMine"
-    value = "RM"
-    icon  = "/icon/rubymine.svg"
-  }
-  option {
-    name  = "Rider"
-    value = "RD"
-    icon  = "/icon/rider.svg"
-  }
-}
-
 data "coder_parameter" "git_repo" {
   name         = "git_repo"
   display_name = "Git Repository (Optional)"
@@ -178,7 +79,7 @@ data "coder_parameter" "git_repo" {
   default      = ""
   mutable      = true
   icon         = "/icon/git.svg"
-  order        = 4
+  order        = 2
 }
 
 # --- Locals ---
@@ -186,25 +87,6 @@ data "coder_parameter" "git_repo" {
 locals {
   username  = data.coder_workspace_owner.me.name
   languages = jsondecode(data.coder_parameter.languages.value)
-  ides      = jsondecode(data.coder_parameter.ides.value)
-
-  # Map selected languages to the relevant JetBrains IDE product codes.
-  # Used as the default for the JetBrains IDE selector parameter.
-  jetbrains_by_language = {
-    python = ["PY"]
-    go     = ["GO"]
-    java   = ["IU"]
-    nodejs = ["WS"]
-    rust   = ["RR"]
-    cpp    = ["CL"]
-  }
-  jetbrains_ides_from_languages = distinct(flatten([
-    for lang in local.languages : lookup(local.jetbrains_by_language, lang, [])
-  ]))
-
-  # The actual JetBrains IDEs to install, from the user's selection
-  # in the conditional JetBrains parameter (or empty if not shown).
-  jetbrains_selected = contains(local.ides, "jetbrains") ? jsondecode(data.coder_parameter.jetbrains_ides[0].value) : []
 }
 
 # --- Agent ---
@@ -268,57 +150,6 @@ resource "coder_script" "install_languages" {
   })
 }
 
-# --- IDE modules ---
-
-module "code-server" {
-  count    = data.coder_workspace.me.start_count * (contains(local.ides, "code-server") ? 1 : 0)
-  source   = "registry.coder.com/coder/code-server/coder"
-  version  = "~> 1.0"
-  agent_id = coder_agent.main.id
-  order    = 1
-}
-
-
-module "cursor" {
-  count    = data.coder_workspace.me.start_count * (contains(local.ides, "cursor") ? 1 : 0)
-  source   = "registry.coder.com/coder/cursor/coder"
-  version  = "~> 1.0"
-  agent_id = coder_agent.main.id
-  folder   = "/home/coder"
-  order    = 3
-}
-
-# TODO: Re-add the coder/jetbrains module once Coder's dynamic
-# parameter system respects module count for parameter visibility.
-# The module's internal coder_parameter appears even when count = 0,
-# creating a ghost parameter in the workspace creation form.
-# module "jetbrains" {
-#   count    = data.coder_workspace.me.start_count * (contains(local.ides, "jetbrains") && length(local.jetbrains_selected) > 0 ? 1 : 0)
-#   source   = "registry.coder.com/coder/jetbrains/coder"
-#   version  = "~> 1.0"
-#   agent_id = coder_agent.main.id
-#   folder   = "/home/coder"
-#   default  = toset(local.jetbrains_selected)
-# }
-
-module "zed" {
-  count    = data.coder_workspace.me.start_count * (contains(local.ides, "zed") ? 1 : 0)
-  source   = "registry.coder.com/coder/zed/coder"
-  version  = "~> 1.0"
-  agent_id = coder_agent.main.id
-  folder   = "/home/coder"
-  order    = 5
-}
-
-module "windsurf" {
-  count    = data.coder_workspace.me.start_count * (contains(local.ides, "windsurf") ? 1 : 0)
-  source   = "registry.coder.com/coder/windsurf/coder"
-  version  = "~> 1.0"
-  agent_id = coder_agent.main.id
-  folder   = "/home/coder"
-  order    = 6
-}
-
 # --- Git clone ---
 
 module "git-clone" {
@@ -336,7 +167,6 @@ data "coder_workspace_preset" "web_dev" {
   icon = "/icon/nodejs.svg"
   parameters = {
     languages = jsonencode(["python", "nodejs"])
-    ides      = jsonencode(["code-server"])
     git_repo  = ""
   }
 }
@@ -345,10 +175,8 @@ data "coder_workspace_preset" "backend_go" {
   name = "Backend (Go)"
   icon = "/icon/go.svg"
   parameters = {
-    languages      = jsonencode(["go"])
-    ides           = jsonencode(["code-server", "jetbrains"])
-    jetbrains_ides = jsonencode(["GO"])
-    git_repo       = ""
+    languages = jsonencode(["go"])
+    git_repo  = ""
   }
 }
 
@@ -357,7 +185,6 @@ data "coder_workspace_preset" "data_science" {
   icon = "/icon/python.svg"
   parameters = {
     languages = jsonencode(["python"])
-    ides      = jsonencode(["code-server"])
     git_repo  = ""
   }
 }
@@ -367,7 +194,6 @@ data "coder_workspace_preset" "full_stack" {
   icon = "/icon/code.svg"
   parameters = {
     languages = jsonencode(["python", "nodejs", "go"])
-    ides      = jsonencode(["code-server", "cursor"])
     git_repo  = ""
   }
 }

--- a/coderd/templatebuilder/bases_test.go
+++ b/coderd/templatebuilder/bases_test.go
@@ -18,6 +18,7 @@ var allBaseIDs = []string{
 	"gcp-linux",
 	"gcp-windows",
 	"kubernetes",
+	"quickstart",
 	"scratch",
 }
 
@@ -26,7 +27,7 @@ func TestBaseTemplateOS(t *testing.T) {
 
 	linuxBases := []string{
 		"aws-linux", "azure-linux", "digitalocean-linux",
-		"docker", "gcp-linux", "kubernetes", "scratch",
+		"docker", "gcp-linux", "kubernetes", "quickstart", "scratch",
 	}
 	for _, id := range linuxBases {
 		t.Run(id, func(t *testing.T) {

--- a/coderd/templatebuilder/bases_test.go
+++ b/coderd/templatebuilder/bases_test.go
@@ -164,3 +164,23 @@ func TestBasePrerequisites(t *testing.T) {
 		require.Empty(t, templatebuilder.BasePrerequisites("nonexistent"))
 	})
 }
+
+// TestBaseIncludedModules asserts the derived catalog-module list per base. The
+// values are derived from each base's rendered main.tf.tmpl, so this locks in
+// which module blocks each base bundles.
+func TestBaseIncludedModules(t *testing.T) {
+	t.Parallel()
+
+	// Quickstart renders a single `module "git-clone"` block.
+	require.Equal(t, []string{"git-clone"}, templatebuilder.BaseIncludedModules("quickstart"))
+
+	// The docker base bundles no module blocks of its own.
+	require.Empty(t, templatebuilder.BaseIncludedModules("docker"))
+
+	// Bases that render only non-catalog module blocks (e.g. the azure_region
+	// helper) bundle no catalog modules, so nothing is reserved.
+	require.Empty(t, templatebuilder.BaseIncludedModules("azure-linux"))
+
+	// Unknown IDs derive nothing.
+	require.Nil(t, templatebuilder.BaseIncludedModules("some-unknown-id"))
+}

--- a/coderd/templatebuilder/compose.go
+++ b/coderd/templatebuilder/compose.go
@@ -79,7 +79,8 @@ func Compose(req ComposeRequest) (*ComposeResult, error) {
 	}
 
 	baseOS := BaseTemplateOS(req.BaseTemplateID)
-	if err := validateModules(req.Modules, catalog, baseOS); err != nil {
+	baseModules := BaseIncludedModules(req.BaseTemplateID)
+	if err := validateModules(req.Modules, catalog, baseOS, baseModules); err != nil {
 		return nil, err
 	}
 
@@ -199,10 +200,25 @@ func loadCatalogMap() (map[string]ModuleManifest, error) {
 }
 
 // validateModules checks that all requested modules exist, are
-// OS-compatible, have no duplicates, and have no conflicts.
-func validateModules(requested []ComposeModule, catalog map[string]ModuleManifest, baseOS BaseOS) error {
-	seen := make(map[string]bool, len(requested))
+// OS-compatible, have no duplicates, do not collide with a module the
+// base template already includes, and have no conflicts. baseModules
+// lists the catalog module IDs the base declares in its own Terraform;
+// requesting one of them would render a duplicate module block, so it is
+// rejected here.
+func validateModules(requested []ComposeModule, catalog map[string]ModuleManifest, baseOS BaseOS, baseModules []string) error {
+	// Seed the seen-set with the modules the base already declares so the
+	// base and wizard-selected modules occupy a disjoint namespace.
+	seen := make(map[string]bool, len(requested)+len(baseModules))
+	baseIncluded := make(map[string]bool, len(baseModules))
+	for _, id := range baseModules {
+		seen[id] = true
+		baseIncluded[id] = true
+	}
+
 	for _, cm := range requested {
+		if baseIncluded[cm.ID] {
+			return xerrors.Errorf("module %q is already included by this base template", cm.ID)
+		}
 		if seen[cm.ID] {
 			return xerrors.Errorf("duplicate module %q", cm.ID)
 		}

--- a/coderd/templatebuilder/compose.go
+++ b/coderd/templatebuilder/compose.go
@@ -201,7 +201,7 @@ func loadCatalogMap() (map[string]ModuleManifest, error) {
 
 // validateModules checks that all requested modules exist, are
 // OS-compatible, have no duplicates, do not collide with a module the base
-// already includes (see BaseManifest.IncludedModules), and have no conflicts.
+// already includes (see BaseIncludedModules), and have no conflicts.
 func validateModules(requested []ComposeModule, catalog map[string]ModuleManifest, baseOS BaseOS, baseModules []string) error {
 	// Seed the seen-set with the modules the base already declares so the
 	// base and wizard-selected modules occupy a disjoint namespace.

--- a/coderd/templatebuilder/compose.go
+++ b/coderd/templatebuilder/compose.go
@@ -200,11 +200,8 @@ func loadCatalogMap() (map[string]ModuleManifest, error) {
 }
 
 // validateModules checks that all requested modules exist, are
-// OS-compatible, have no duplicates, do not collide with a module the
-// base template already includes, and have no conflicts. baseModules
-// lists the catalog module IDs the base declares in its own Terraform;
-// requesting one of them would render a duplicate module block, so it is
-// rejected here.
+// OS-compatible, have no duplicates, do not collide with a module the base
+// already includes (see BaseManifest.IncludedModules), and have no conflicts.
 func validateModules(requested []ComposeModule, catalog map[string]ModuleManifest, baseOS BaseOS, baseModules []string) error {
 	// Seed the seen-set with the modules the base already declares so the
 	// base and wizard-selected modules occupy a disjoint namespace.
@@ -233,7 +230,11 @@ func validateModules(requested []ComposeModule, catalog map[string]ModuleManifes
 		}
 	}
 
-	// Check conflicts bidirectionally so that order does not matter.
+	// Reject a requested module whose ConflictsWith names an already-seen
+	// module. Every requested module is in `seen` by now, so order does not
+	// matter, and base-included modules seed `seen` too. A base-included
+	// module's own ConflictsWith list is not consulted, which is safe because
+	// base modules are curated.
 	for _, cm := range requested {
 		manifest := catalog[cm.ID]
 		for _, conflict := range manifest.ConflictsWith {

--- a/coderd/templatebuilder/compose_test.go
+++ b/coderd/templatebuilder/compose_test.go
@@ -553,51 +553,12 @@ func TestBundleTar(t *testing.T) {
 	})
 }
 
-// TestBaseIncludedModulesMatchRendered enforces that each base's
-// included_modules manifest field exactly lists the catalog modules the base
-// actually renders. This keeps the collision guard's seen-set in sync with the
-// base's Terraform: if a base adds a `module "<catalog-id>"` block without
-// listing it (or lists one it no longer renders), this test fails instead of
-// silently re-opening the duplicate-module hazard the guard exists to prevent.
-//
-// This renders with DefaultBaseRenderContext, which applies no variable
-// overlay. A base that gated a catalog `module` block on a variable would not
-// render that block here, so the guard could be evaded; that is dormant today
-// because no base declares variables. When bases gain variables, extend this to
-// also render with representative variable contexts.
-func TestBaseIncludedModulesMatchRendered(t *testing.T) {
-	t.Parallel()
-
-	manifests, err := templatebuilder.LoadModules()
-	require.NoError(t, err)
-	catalogIDs := make(map[string]bool, len(manifests))
-	for _, m := range manifests {
-		catalogIDs[m.ID] = true
-	}
-
-	for _, id := range templatebuilder.BaseTemplateIDs() {
-		t.Run(id, func(t *testing.T) {
-			t.Parallel()
-
-			mainTF, err := templatebuilder.RenderBaseTemplate(
-				id, "main.tf.tmpl", templatebuilder.DefaultBaseRenderContext(id))
-			require.NoError(t, err)
-
-			// Only catalog-named module blocks can collide with a
-			// wizard-selected module, so ignore any non-catalog modules a base
-			// renders (e.g. region helpers that are not in the catalog).
-			var renderedCatalog []string
-			for _, name := range templatebuilder.ExtractModuleNames(mainTF) {
-				if catalogIDs[name] {
-					renderedCatalog = append(renderedCatalog, name)
-				}
-			}
-
-			require.ElementsMatch(t, templatebuilder.BaseIncludedModules(id), renderedCatalog,
-				"base %q: included_modules must match the catalog modules it renders", id)
-		})
-	}
-}
+// optionValuePattern matches a quoted `value = "..."` assignment. In the
+// quickstart base such a quoted literal only appears inside the languages
+// selector's option {} blocks: Docker labels assign `value = data....` and
+// presets assign `languages = jsonencode(...)`, neither of which is a quoted
+// `value = "..."`.
+var optionValuePattern = regexp.MustCompile(`(?m)^\s*value\s*=\s*"([^"]+)"`)
 
 // hasLanguageDispatchPattern matches the `if has_language <name>` call sites in
 // the quickstart language-install script (not the has_language definition).
@@ -615,7 +576,11 @@ func TestQuickstartLanguageSelectorMatchesInstallScript(t *testing.T) {
 	mainTF, err := templatebuilder.RenderBaseTemplate(
 		"quickstart", "main.tf.tmpl", templatebuilder.DefaultBaseRenderContext("quickstart"))
 	require.NoError(t, err)
-	selectorValues := templatebuilder.ExtractParameterOptionValues(mainTF, "languages")
+
+	var selectorValues []string
+	for _, m := range optionValuePattern.FindAllSubmatch(mainTF, -1) {
+		selectorValues = append(selectorValues, string(m[1]))
+	}
 	require.NotEmpty(t, selectorValues,
 		"expected the quickstart languages selector to declare options")
 
@@ -633,72 +598,6 @@ func TestQuickstartLanguageSelectorMatchesInstallScript(t *testing.T) {
 
 	require.ElementsMatch(t, selectorValues, dispatchNames,
 		"quickstart languages selector options must match the install script's has_language branches")
-
-	// The workspace presets declare `languages` a third time. Assert every
-	// preset's languages are a subset of the selector options, so a preset can
-	// never offer a value the selector and install script do not support.
-	presetLangs := templatebuilder.ExtractPresetParameterValues(mainTF, "languages")
-	presetNames := templatebuilder.ExtractPresetNames(mainTF)
-	require.NotEmpty(t, presetNames, "expected the quickstart base to declare presets")
-	// Every preset must contribute a statically decodable languages list, so a
-	// preset that set languages to a non-literal (a var ref, concat(...)) would
-	// drop out of presetLangs and fail here instead of silently evading the
-	// subset check below.
-	require.Len(t, presetLangs, len(presetNames),
-		"every quickstart preset must set languages to a static list")
-	for i, langs := range presetLangs {
-		require.NotEmpty(t, langs, "preset #%d set an empty languages list", i)
-		require.Subset(t, selectorValues, langs,
-			"preset #%d languages %v must be a subset of selector options %v", i, langs, selectorValues)
-	}
-}
-
-// TestExtractHCLHelpers verifies the HCL extraction helpers on crafted input
-// whose shape stresses their boundaries: a brace inside a parameter
-// description string, a commented-out option block, a module block, and a
-// preset whose languages list is wrapped in jsonencode(...). It asserts the
-// option values skip the commented option and the in-string brace, the module
-// names list the real block, and the preset languages are unwrapped.
-func TestExtractHCLHelpers(t *testing.T) {
-	t.Parallel()
-
-	src := []byte(`
-data "coder_parameter" "languages" {
-  description = "Pick languages { with braces } in prose"
-  option {
-    name  = "Python"
-    value = "python"
-  }
-  # option {
-  #   name  = "Commented"
-  #   value = "commented"
-  # }
-  option {
-    name  = "Go"
-    value = "go"
-  }
-}
-
-module "git-clone" {
-  source = "registry.coder.com/coder/git-clone/coder"
-}
-
-data "coder_workspace_preset" "web" {
-  parameters = {
-    languages = jsonencode(["python", "go"])
-    git_repo  = ""
-  }
-}
-`)
-
-	require.Equal(t, []string{"python", "go"},
-		templatebuilder.ExtractParameterOptionValues(src, "languages"),
-		"must skip the commented option and ignore braces inside the description string")
-	require.Equal(t, []string{"git-clone"}, templatebuilder.ExtractModuleNames(src))
-	require.Equal(t, [][]string{{"python", "go"}},
-		templatebuilder.ExtractPresetParameterValues(src, "languages"),
-		"must unwrap jsonencode(...) in preset parameters")
-	require.Nil(t, templatebuilder.ExtractParameterOptionValues(src, "nonexistent"))
 }
 
 // extractTar reads a tar archive and returns a map of filename to content.

--- a/coderd/templatebuilder/compose_test.go
+++ b/coderd/templatebuilder/compose_test.go
@@ -634,11 +634,18 @@ func TestQuickstartLanguageSelectorMatchesInstallScript(t *testing.T) {
 	require.ElementsMatch(t, selectorValues, dispatchNames,
 		"quickstart languages selector options must match the install script's has_language branches")
 
-	// CRF-25: the workspace presets declare `languages` a third time. Assert
-	// each preset's languages are a subset of the selector options, so a preset
-	// can never offer a value the selector and install script do not support.
+	// The workspace presets declare `languages` a third time. Assert every
+	// preset's languages are a subset of the selector options, so a preset can
+	// never offer a value the selector and install script do not support.
 	presetLangs := templatebuilder.ExtractPresetParameterValues(mainTF, "languages")
-	require.NotEmpty(t, presetLangs, "expected the quickstart presets to set languages")
+	presetNames := templatebuilder.ExtractPresetNames(mainTF)
+	require.NotEmpty(t, presetNames, "expected the quickstart base to declare presets")
+	// Every preset must contribute a statically decodable languages list, so a
+	// preset that set languages to a non-literal (a var ref, concat(...)) would
+	// drop out of presetLangs and fail here instead of silently evading the
+	// subset check below.
+	require.Len(t, presetLangs, len(presetNames),
+		"every quickstart preset must set languages to a static list")
 	for i, langs := range presetLangs {
 		require.NotEmpty(t, langs, "preset #%d set an empty languages list", i)
 		require.Subset(t, selectorValues, langs,
@@ -646,9 +653,12 @@ func TestQuickstartLanguageSelectorMatchesInstallScript(t *testing.T) {
 	}
 }
 
-// TestExtractHCLHelpers exercises the HCL extraction helpers on crafted input
-// with the edge cases the previous regex/brace-scan approach mishandled: braces
-// inside a string, and a commented-out option block.
+// TestExtractHCLHelpers verifies the HCL extraction helpers on crafted input
+// whose shape stresses their boundaries: a brace inside a parameter
+// description string, a commented-out option block, a module block, and a
+// preset whose languages list is wrapped in jsonencode(...). It asserts the
+// option values skip the commented option and the in-string brace, the module
+// names list the real block, and the preset languages are unwrapped.
 func TestExtractHCLHelpers(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/templatebuilder/compose_test.go
+++ b/coderd/templatebuilder/compose_test.go
@@ -195,6 +195,37 @@ func TestCompose(t *testing.T) {
 		require.Contains(t, err.Error(), `duplicate module "code-server"`)
 	})
 
+	t.Run("BaseIncludedModuleCollisionError", func(t *testing.T) {
+		t.Parallel()
+		// The quickstart base already declares module "git-clone"; selecting
+		// the catalog git-clone module in the wizard would render a duplicate
+		// module block, so compose must reject it.
+		_, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
+			BaseTemplateID: "quickstart",
+			RegistryURL:    "https://registry.coder.com",
+			Modules: []templatebuilder.ComposeModule{
+				{ID: "git-clone"},
+			},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `module "git-clone" is already included by this base template`)
+	})
+
+	t.Run("BaseAllowsNonIncludedModule", func(t *testing.T) {
+		t.Parallel()
+		// Quickstart only includes git-clone; other catalog modules such as
+		// code-server compose normally on top of it.
+		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
+			BaseTemplateID: "quickstart",
+			RegistryURL:    "https://registry.coder.com",
+			Modules: []templatebuilder.ComposeModule{
+				{ID: "code-server"},
+			},
+		})
+		require.NoError(t, err)
+		require.Contains(t, string(result.ModulesTF), `module "code-server"`)
+	})
+
 	t.Run("ConflictingModuleError", func(t *testing.T) {
 		t.Parallel()
 		_, err := templatebuilder.Compose(templatebuilder.ComposeRequest{

--- a/coderd/templatebuilder/compose_test.go
+++ b/coderd/templatebuilder/compose_test.go
@@ -5,6 +5,8 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"io/fs"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -557,6 +559,12 @@ func TestBundleTar(t *testing.T) {
 // base's Terraform: if a base adds a `module "<catalog-id>"` block without
 // listing it (or lists one it no longer renders), this test fails instead of
 // silently re-opening the duplicate-module hazard the guard exists to prevent.
+//
+// This renders with DefaultBaseRenderContext, which applies no variable
+// overlay. A base that gated a catalog `module` block on a variable would not
+// render that block here, so the guard could be evaded; that is dormant today
+// because no base declares variables. When bases gain variables, extend this to
+// also render with representative variable contexts.
 func TestBaseIncludedModulesMatchRendered(t *testing.T) {
 	t.Parallel()
 
@@ -589,6 +597,42 @@ func TestBaseIncludedModulesMatchRendered(t *testing.T) {
 				"base %q: included_modules must match the catalog modules it renders", id)
 		})
 	}
+}
+
+// hasLanguageDispatchPattern matches the `if has_language <name>` call sites in
+// the quickstart language-install script (not the has_language definition).
+var hasLanguageDispatchPattern = regexp.MustCompile(`(?m)^\s*if has_language (\S+?);`)
+
+// TestQuickstartLanguageSelectorMatchesInstallScript enforces that the
+// quickstart "languages" selector options and the language-install script's
+// has_language dispatch branches describe the same set of languages. They are
+// two hand-maintained lists with nothing else binding them: if one gains or
+// loses a language without the other, a selected language would silently
+// install nothing (or a branch would be dead). This test fails on that drift.
+func TestQuickstartLanguageSelectorMatchesInstallScript(t *testing.T) {
+	t.Parallel()
+
+	mainTF, err := templatebuilder.RenderBaseTemplate(
+		"quickstart", "main.tf.tmpl", templatebuilder.DefaultBaseRenderContext("quickstart"))
+	require.NoError(t, err)
+	selectorValues := templatebuilder.ExtractParameterOptionValues(mainTF, "languages")
+	require.NotEmpty(t, selectorValues,
+		"expected the quickstart languages selector to declare options")
+
+	fsys, err := templatebuilder.BaseTemplateFS("quickstart")
+	require.NoError(t, err)
+	script, err := fs.ReadFile(fsys, "install-languages.sh.tftpl")
+	require.NoError(t, err)
+
+	var dispatchNames []string
+	for _, m := range hasLanguageDispatchPattern.FindAllSubmatch(script, -1) {
+		dispatchNames = append(dispatchNames, string(m[1]))
+	}
+	require.NotEmpty(t, dispatchNames,
+		"expected the install script to dispatch on has_language")
+
+	require.ElementsMatch(t, selectorValues, dispatchNames,
+		"quickstart languages selector options must match the install script's has_language branches")
 }
 
 // extractTar reads a tar archive and returns a map of filename to content.

--- a/coderd/templatebuilder/compose_test.go
+++ b/coderd/templatebuilder/compose_test.go
@@ -633,6 +633,62 @@ func TestQuickstartLanguageSelectorMatchesInstallScript(t *testing.T) {
 
 	require.ElementsMatch(t, selectorValues, dispatchNames,
 		"quickstart languages selector options must match the install script's has_language branches")
+
+	// CRF-25: the workspace presets declare `languages` a third time. Assert
+	// each preset's languages are a subset of the selector options, so a preset
+	// can never offer a value the selector and install script do not support.
+	presetLangs := templatebuilder.ExtractPresetParameterValues(mainTF, "languages")
+	require.NotEmpty(t, presetLangs, "expected the quickstart presets to set languages")
+	for i, langs := range presetLangs {
+		require.NotEmpty(t, langs, "preset #%d set an empty languages list", i)
+		require.Subset(t, selectorValues, langs,
+			"preset #%d languages %v must be a subset of selector options %v", i, langs, selectorValues)
+	}
+}
+
+// TestExtractHCLHelpers exercises the HCL extraction helpers on crafted input
+// with the edge cases the previous regex/brace-scan approach mishandled: braces
+// inside a string, and a commented-out option block.
+func TestExtractHCLHelpers(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`
+data "coder_parameter" "languages" {
+  description = "Pick languages { with braces } in prose"
+  option {
+    name  = "Python"
+    value = "python"
+  }
+  # option {
+  #   name  = "Commented"
+  #   value = "commented"
+  # }
+  option {
+    name  = "Go"
+    value = "go"
+  }
+}
+
+module "git-clone" {
+  source = "registry.coder.com/coder/git-clone/coder"
+}
+
+data "coder_workspace_preset" "web" {
+  parameters = {
+    languages = jsonencode(["python", "go"])
+    git_repo  = ""
+  }
+}
+`)
+
+	require.Equal(t, []string{"python", "go"},
+		templatebuilder.ExtractParameterOptionValues(src, "languages"),
+		"must skip the commented option and ignore braces inside the description string")
+	require.Equal(t, []string{"git-clone"}, templatebuilder.ExtractModuleNames(src))
+	require.Equal(t, [][]string{{"python", "go"}},
+		templatebuilder.ExtractPresetParameterValues(src, "languages"),
+		"must unwrap jsonencode(...) in preset parameters")
+	require.Nil(t, templatebuilder.ExtractParameterOptionValues(src, "nonexistent"))
 }
 
 // extractTar reads a tar archive and returns a map of filename to content.

--- a/coderd/templatebuilder/compose_test.go
+++ b/coderd/templatebuilder/compose_test.go
@@ -551,6 +551,46 @@ func TestBundleTar(t *testing.T) {
 	})
 }
 
+// TestBaseIncludedModulesMatchRendered enforces that each base's
+// included_modules manifest field exactly lists the catalog modules the base
+// actually renders. This keeps the collision guard's seen-set in sync with the
+// base's Terraform: if a base adds a `module "<catalog-id>"` block without
+// listing it (or lists one it no longer renders), this test fails instead of
+// silently re-opening the duplicate-module hazard the guard exists to prevent.
+func TestBaseIncludedModulesMatchRendered(t *testing.T) {
+	t.Parallel()
+
+	manifests, err := templatebuilder.LoadModules()
+	require.NoError(t, err)
+	catalogIDs := make(map[string]bool, len(manifests))
+	for _, m := range manifests {
+		catalogIDs[m.ID] = true
+	}
+
+	for _, id := range templatebuilder.BaseTemplateIDs() {
+		t.Run(id, func(t *testing.T) {
+			t.Parallel()
+
+			mainTF, err := templatebuilder.RenderBaseTemplate(
+				id, "main.tf.tmpl", templatebuilder.DefaultBaseRenderContext(id))
+			require.NoError(t, err)
+
+			// Only catalog-named module blocks can collide with a
+			// wizard-selected module, so ignore any non-catalog modules a base
+			// renders (e.g. region helpers that are not in the catalog).
+			var renderedCatalog []string
+			for _, name := range templatebuilder.ExtractModuleNames(mainTF) {
+				if catalogIDs[name] {
+					renderedCatalog = append(renderedCatalog, name)
+				}
+			}
+
+			require.ElementsMatch(t, templatebuilder.BaseIncludedModules(id), renderedCatalog,
+				"base %q: included_modules must match the catalog modules it renders", id)
+		})
+	}
+}
+
 // extractTar reads a tar archive and returns a map of filename to content.
 func extractTar(t *testing.T, data []byte) map[string]string {
 	t.Helper()

--- a/coderd/templatebuilder/render.go
+++ b/coderd/templatebuilder/render.go
@@ -3,7 +3,6 @@ package templatebuilder
 import (
 	"bytes"
 	"io/fs"
-	"regexp"
 	"text/template"
 
 	"github.com/hashicorp/hcl/v2"
@@ -102,41 +101,49 @@ func renderTemplate(fsys fs.FS, templatePath string, data any) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// agentResourcePattern matches `resource "coder_agent" "<name>"` in HCL.
-var agentResourcePattern = regexp.MustCompile(`resource\s+"coder_agent"\s+"(\w+)"`)
-
-// agentCountPattern detects whether a coder_agent block uses count or
-// for_each, which means references to it require an index (e.g. [0]).
-var agentCountPattern = regexp.MustCompile(
-	`resource\s+"coder_agent"\s+"\w+"\s*\{[^}]*\b(?:count|for_each)\s*=`,
-)
-
 // ExtractAgentResourceName finds the coder_agent resource declaration in
 // rendered HCL and returns the reference form to use in module templates.
 // When the agent uses count or for_each, the returned name includes an
 // index suffix (e.g. "dev[0]") so that module templates can reference it
 // as coder_agent.<name>.id. Returns an error unless exactly one
 // coder_agent resource is found; the builder only supports single-agent
-// templates. The input is expected to be rendered output from our own
-// curated base templates, not arbitrary user HCL.
+// templates. Parsing with hclsyntax means count/for_each is detected
+// wherever it appears in the block, not only before the first closing brace.
+// The input is expected to be rendered output from our own curated base
+// templates, not arbitrary user HCL.
 func ExtractAgentResourceName(hclSrc []byte) (string, error) {
-	matches := agentResourcePattern.FindAllSubmatch(hclSrc, -1)
-	switch len(matches) {
+	body := parseHCLBody(hclSrc)
+	if body == nil {
+		return "", xerrors.New("no coder_agent resource found in rendered template")
+	}
+
+	var names []string
+	counted := false
+	for _, block := range body.Blocks {
+		if block.Type != "resource" || len(block.Labels) != 2 || block.Labels[0] != "coder_agent" {
+			continue
+		}
+		names = append(names, block.Labels[1])
+		if _, ok := block.Body.Attributes["count"]; ok {
+			counted = true
+		}
+		if _, ok := block.Body.Attributes["for_each"]; ok {
+			counted = true
+		}
+	}
+
+	switch len(names) {
 	case 0:
 		return "", xerrors.New("no coder_agent resource found in rendered template")
 	case 1:
-		name := string(matches[0][1])
-		if agentCountPattern.Match(hclSrc) {
+		name := names[0]
+		if counted {
 			name += "[0]"
 		}
 		return name, nil
 	default:
-		names := make([]string, 0, len(matches))
-		for _, m := range matches {
-			names = append(names, string(m[1]))
-		}
 		return "", xerrors.Errorf("expected exactly one coder_agent resource, found %d: %v",
-			len(matches), names)
+			len(names), names)
 	}
 }
 
@@ -239,6 +246,25 @@ func ExtractPresetParameterValues(hclSrc []byte, paramName string) [][]string {
 		}
 	}
 	return out
+}
+
+// ExtractPresetNames returns the labels of every top-level
+// `data "coder_workspace_preset"` block in rendered HCL, in declaration order.
+// The input is expected to be rendered output from our own curated base
+// templates.
+func ExtractPresetNames(hclSrc []byte) []string {
+	body := parseHCLBody(hclSrc)
+	if body == nil {
+		return nil
+	}
+	var names []string
+	for _, block := range body.Blocks {
+		if block.Type == "data" && len(block.Labels) == 2 &&
+			block.Labels[0] == "coder_workspace_preset" {
+			names = append(names, block.Labels[1])
+		}
+	}
+	return names
 }
 
 // staticString evaluates an expression expected to be a constant string (no

--- a/coderd/templatebuilder/render.go
+++ b/coderd/templatebuilder/render.go
@@ -107,10 +107,8 @@ func renderTemplate(fsys fs.FS, templatePath string, data any) ([]byte, error) {
 // index suffix (e.g. "dev[0]") so that module templates can reference it
 // as coder_agent.<name>.id. Returns an error unless exactly one
 // coder_agent resource is found; the builder only supports single-agent
-// templates. Parsing with hclsyntax means count/for_each is detected
-// wherever it appears in the block, not only before the first closing brace.
-// The input is expected to be rendered output from our own curated base
-// templates, not arbitrary user HCL.
+// templates. The input is expected to be rendered output from our own
+// curated base templates, not arbitrary user HCL.
 func ExtractAgentResourceName(hclSrc []byte) (string, error) {
 	body := parseHCLBody(hclSrc)
 	if body == nil {
@@ -149,9 +147,11 @@ func ExtractAgentResourceName(hclSrc []byte) (string, error) {
 
 // parseHCLBody parses rendered HCL from one of our curated base templates and
 // returns its top-level body. The input is expected to be valid HCL produced by
-// our own templates; on a parse error it returns nil so callers fail safe (they
-// yield an empty result, which trips the NotEmpty/match assertions in the tests
-// that consume them rather than passing silently).
+// our own templates; on a parse error it returns nil so callers fail safe. The
+// test-only extractors turn a nil body into an empty result, which trips their
+// NotEmpty/match assertions rather than passing silently; the one production
+// caller, ExtractAgentResourceName, turns it into an error rather than emitting a
+// broken agent reference.
 func parseHCLBody(hclSrc []byte) *hclsyntax.Body {
 	file, diags := hclsyntax.ParseConfig(hclSrc, "rendered.tf", hcl.InitialPos)
 	if diags.HasErrors() || file == nil {
@@ -224,7 +224,7 @@ func ExtractPresetParameterValues(hclSrc []byte, paramName string) [][]string {
 	}
 	var out [][]string
 	for _, block := range body.Blocks {
-		if block.Type != "data" || len(block.Labels) < 1 ||
+		if block.Type != "data" || len(block.Labels) != 2 ||
 			block.Labels[0] != "coder_workspace_preset" {
 			continue
 		}

--- a/coderd/templatebuilder/render.go
+++ b/coderd/templatebuilder/render.go
@@ -6,6 +6,9 @@ import (
 	"regexp"
 	"text/template"
 
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
 	"golang.org/x/xerrors"
 )
 
@@ -116,14 +119,14 @@ var agentCountPattern = regexp.MustCompile(
 // coder_agent resource is found; the builder only supports single-agent
 // templates. The input is expected to be rendered output from our own
 // curated base templates, not arbitrary user HCL.
-func ExtractAgentResourceName(hcl []byte) (string, error) {
-	matches := agentResourcePattern.FindAllSubmatch(hcl, -1)
+func ExtractAgentResourceName(hclSrc []byte) (string, error) {
+	matches := agentResourcePattern.FindAllSubmatch(hclSrc, -1)
 	switch len(matches) {
 	case 0:
 		return "", xerrors.New("no coder_agent resource found in rendered template")
 	case 1:
 		name := string(matches[0][1])
-		if agentCountPattern.Match(hcl) {
+		if agentCountPattern.Match(hclSrc) {
 			name += "[0]"
 		}
 		return name, nil
@@ -137,78 +140,147 @@ func ExtractAgentResourceName(hcl []byte) (string, error) {
 	}
 }
 
-// moduleBlockPattern matches a `module "<name>"` block declaration anchored to
-// the start of a line in HCL.
-var moduleBlockPattern = regexp.MustCompile(`(?m)^[ \t]*module[ \t]+"([^"]+)"`)
+// parseHCLBody parses rendered HCL from one of our curated base templates and
+// returns its top-level body. The input is expected to be valid HCL produced by
+// our own templates; on a parse error it returns nil so callers fail safe (they
+// yield an empty result, which trips the NotEmpty/match assertions in the tests
+// that consume them rather than passing silently).
+func parseHCLBody(hclSrc []byte) *hclsyntax.Body {
+	file, diags := hclsyntax.ParseConfig(hclSrc, "rendered.tf", hcl.InitialPos)
+	if diags.HasErrors() || file == nil {
+		return nil
+	}
+	body, ok := file.Body.(*hclsyntax.Body)
+	if !ok {
+		return nil
+	}
+	return body
+}
 
-// ExtractModuleNames returns the labels of every module block declared in
-// rendered HCL, in declaration order. Matching is anchored to the start of a
-// line so commented-out references or string literals are ignored. The input
+// ExtractModuleNames returns the labels of every top-level `module` block in
+// rendered HCL, in declaration order. Parsing with hclsyntax means commented-out
+// blocks and module-like text inside strings or heredocs are ignored. The input
 // is expected to be rendered output from our own curated base templates, not
 // arbitrary user HCL.
-func ExtractModuleNames(hcl []byte) []string {
-	matches := moduleBlockPattern.FindAllSubmatch(hcl, -1)
-	names := make([]string, 0, len(matches))
-	for _, m := range matches {
-		names = append(names, string(m[1]))
+func ExtractModuleNames(hclSrc []byte) []string {
+	body := parseHCLBody(hclSrc)
+	if body == nil {
+		return nil
+	}
+	var names []string
+	for _, block := range body.Blocks {
+		if block.Type == "module" && len(block.Labels) > 0 {
+			names = append(names, block.Labels[0])
+		}
 	}
 	return names
 }
 
-// coderParameterOpenPattern matches the opening of a `data "coder_parameter"
-// "<name>"` block and captures the parameter name.
-var coderParameterOpenPattern = regexp.MustCompile(`data\s+"coder_parameter"\s+"([^"]+)"\s*\{`)
-
-// coderParameterOptionValuePattern matches the `value = "<v>"` assignment inside
-// an `option { ... }` block. Option blocks in our curated bases contain no
-// nested braces, so [^{}] keeps each match within a single option.
-var coderParameterOptionValuePattern = regexp.MustCompile(`(?s)option\s*\{[^{}]*?\bvalue\s*=\s*"([^"]+)"`)
-
-// ExtractParameterOptionValues returns the value of every option block declared
-// inside the `data "coder_parameter" "<paramName>"` block in rendered HCL, in
-// declaration order. It scopes to that one parameter by scanning from its
-// opening brace to the matching close, so option values from other parameters
-// are not included. Returns nil if the parameter is absent. The input is
-// expected to be rendered output from our own curated base templates, not
-// arbitrary user HCL.
-func ExtractParameterOptionValues(hcl []byte, paramName string) []string {
-	start := -1
-	for _, m := range coderParameterOpenPattern.FindAllSubmatchIndex(hcl, -1) {
-		// m[2]:m[3] bounds the captured name; m[1] is just past the opening brace.
-		if string(hcl[m[2]:m[3]]) == paramName {
-			start = m[1] - 1 // index of the opening '{'
-			break
-		}
-	}
-	if start == -1 {
+// ExtractParameterOptionValues returns the value of every `option` block inside
+// the `data "coder_parameter" "<paramName>"` block in rendered HCL, in
+// declaration order. Returns nil if the parameter is absent. The input is
+// expected to be rendered output from our own curated base templates.
+func ExtractParameterOptionValues(hclSrc []byte, paramName string) []string {
+	body := parseHCLBody(hclSrc)
+	if body == nil {
 		return nil
 	}
-
-	// Walk from the parameter's opening brace to its matching close, tracking
-	// nesting depth, so we only read option values that belong to it.
-	depth := 0
-	end := -1
-scan:
-	for i := start; i < len(hcl); i++ {
-		switch hcl[i] {
-		case '{':
-			depth++
-		case '}':
-			depth--
-			if depth == 0 {
-				end = i
-				break scan
+	var values []string
+	for _, block := range body.Blocks {
+		if block.Type != "data" || len(block.Labels) != 2 ||
+			block.Labels[0] != "coder_parameter" || block.Labels[1] != paramName {
+			continue
+		}
+		for _, option := range block.Body.Blocks {
+			if option.Type != "option" {
+				continue
+			}
+			if attr, ok := option.Body.Attributes["value"]; ok {
+				if s, ok := staticString(attr.Expr); ok {
+					values = append(values, s)
+				}
 			}
 		}
 	}
-	if end == -1 {
+	return values
+}
+
+// ExtractPresetParameterValues returns, for every `data "coder_workspace_preset"`
+// block in rendered HCL, the string list assigned to paramName in its
+// `parameters` object (e.g. "languages"). A value written as jsonencode([...])
+// is unwrapped. Presets that do not set the key are skipped. The input is
+// expected to be rendered output from our own curated base templates.
+func ExtractPresetParameterValues(hclSrc []byte, paramName string) [][]string {
+	body := parseHCLBody(hclSrc)
+	if body == nil {
 		return nil
 	}
-
-	matches := coderParameterOptionValuePattern.FindAllSubmatch(hcl[start:end+1], -1)
-	values := make([]string, 0, len(matches))
-	for _, m := range matches {
-		values = append(values, string(m[1]))
+	var out [][]string
+	for _, block := range body.Blocks {
+		if block.Type != "data" || len(block.Labels) < 1 ||
+			block.Labels[0] != "coder_workspace_preset" {
+			continue
+		}
+		params, ok := block.Body.Attributes["parameters"]
+		if !ok {
+			continue
+		}
+		pairs, diags := hcl.ExprMap(params.Expr)
+		if diags.HasErrors() {
+			continue
+		}
+		for _, pair := range pairs {
+			if exprKeyString(pair.Key) != paramName {
+				continue
+			}
+			if list, ok := staticStringList(pair.Value); ok {
+				out = append(out, list)
+			}
+		}
 	}
-	return values
+	return out
+}
+
+// staticString evaluates an expression expected to be a constant string (no
+// variables or functions) and reports whether it produced one.
+func staticString(expr hcl.Expression) (string, bool) {
+	val, diags := expr.Value(nil)
+	if diags.HasErrors() || val.IsNull() || val.Type() != cty.String {
+		return "", false
+	}
+	return val.AsString(), true
+}
+
+// staticStringList evaluates an expression expected to be a constant list of
+// strings, unwrapping a single jsonencode(...) call, and reports whether it
+// produced one.
+func staticStringList(expr hcl.Expression) ([]string, bool) {
+	if call, ok := expr.(*hclsyntax.FunctionCallExpr); ok && call.Name == "jsonencode" && len(call.Args) == 1 {
+		expr = call.Args[0]
+	}
+	val, diags := expr.Value(nil)
+	if diags.HasErrors() || val.IsNull() || !val.CanIterateElements() {
+		return nil, false
+	}
+	out := make([]string, 0, val.LengthInt())
+	for it := val.ElementIterator(); it.Next(); {
+		_, ev := it.Element()
+		if ev.Type() != cty.String {
+			return nil, false
+		}
+		out = append(out, ev.AsString())
+	}
+	return out, true
+}
+
+// exprKeyString returns the string key of an object-construction key
+// expression, handling bare identifier keys (e.g. `languages = ...`).
+func exprKeyString(key hcl.Expression) string {
+	if kw := hcl.ExprAsKeyword(key); kw != "" {
+		return kw
+	}
+	if val, diags := key.Value(nil); !diags.HasErrors() && val.Type() == cty.String {
+		return val.AsString()
+	}
+	return ""
 }

--- a/coderd/templatebuilder/render.go
+++ b/coderd/templatebuilder/render.go
@@ -154,3 +154,61 @@ func ExtractModuleNames(hcl []byte) []string {
 	}
 	return names
 }
+
+// coderParameterOpenPattern matches the opening of a `data "coder_parameter"
+// "<name>"` block and captures the parameter name.
+var coderParameterOpenPattern = regexp.MustCompile(`data\s+"coder_parameter"\s+"([^"]+)"\s*\{`)
+
+// coderParameterOptionValuePattern matches the `value = "<v>"` assignment inside
+// an `option { ... }` block. Option blocks in our curated bases contain no
+// nested braces, so [^{}] keeps each match within a single option.
+var coderParameterOptionValuePattern = regexp.MustCompile(`(?s)option\s*\{[^{}]*?\bvalue\s*=\s*"([^"]+)"`)
+
+// ExtractParameterOptionValues returns the value of every option block declared
+// inside the `data "coder_parameter" "<paramName>"` block in rendered HCL, in
+// declaration order. It scopes to that one parameter by scanning from its
+// opening brace to the matching close, so option values from other parameters
+// are not included. Returns nil if the parameter is absent. The input is
+// expected to be rendered output from our own curated base templates, not
+// arbitrary user HCL.
+func ExtractParameterOptionValues(hcl []byte, paramName string) []string {
+	start := -1
+	for _, m := range coderParameterOpenPattern.FindAllSubmatchIndex(hcl, -1) {
+		// m[2]:m[3] bounds the captured name; m[1] is just past the opening brace.
+		if string(hcl[m[2]:m[3]]) == paramName {
+			start = m[1] - 1 // index of the opening '{'
+			break
+		}
+	}
+	if start == -1 {
+		return nil
+	}
+
+	// Walk from the parameter's opening brace to its matching close, tracking
+	// nesting depth, so we only read option values that belong to it.
+	depth := 0
+	end := -1
+scan:
+	for i := start; i < len(hcl); i++ {
+		switch hcl[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				end = i
+				break scan
+			}
+		}
+	}
+	if end == -1 {
+		return nil
+	}
+
+	matches := coderParameterOptionValuePattern.FindAllSubmatch(hcl[start:end+1], -1)
+	values := make([]string, 0, len(matches))
+	for _, m := range matches {
+		values = append(values, string(m[1]))
+	}
+	return values
+}

--- a/coderd/templatebuilder/render.go
+++ b/coderd/templatebuilder/render.go
@@ -136,3 +136,21 @@ func ExtractAgentResourceName(hcl []byte) (string, error) {
 			len(matches), names)
 	}
 }
+
+// moduleBlockPattern matches a `module "<name>"` block declaration anchored to
+// the start of a line in HCL.
+var moduleBlockPattern = regexp.MustCompile(`(?m)^[ \t]*module[ \t]+"([^"]+)"`)
+
+// ExtractModuleNames returns the labels of every module block declared in
+// rendered HCL, in declaration order. Matching is anchored to the start of a
+// line so commented-out references or string literals are ignored. The input
+// is expected to be rendered output from our own curated base templates, not
+// arbitrary user HCL.
+func ExtractModuleNames(hcl []byte) []string {
+	matches := moduleBlockPattern.FindAllSubmatch(hcl, -1)
+	names := make([]string, 0, len(matches))
+	for _, m := range matches {
+		names = append(names, string(m[1]))
+	}
+	return names
+}

--- a/coderd/templatebuilder/render.go
+++ b/coderd/templatebuilder/render.go
@@ -3,11 +3,9 @@ package templatebuilder
 import (
 	"bytes"
 	"io/fs"
+	"regexp"
 	"text/template"
 
-	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/hclsyntax"
-	"github.com/zclconf/go-cty/cty"
 	"golang.org/x/xerrors"
 )
 
@@ -101,6 +99,15 @@ func renderTemplate(fsys fs.FS, templatePath string, data any) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// agentResourcePattern matches `resource "coder_agent" "<name>"` in HCL.
+var agentResourcePattern = regexp.MustCompile(`resource\s+"coder_agent"\s+"(\w+)"`)
+
+// agentCountPattern detects whether a coder_agent block uses count or
+// for_each, which means references to it require an index (e.g. [0]).
+var agentCountPattern = regexp.MustCompile(
+	`resource\s+"coder_agent"\s+"\w+"\s*\{[^}]*\b(?:count|for_each)\s*=`,
+)
+
 // ExtractAgentResourceName finds the coder_agent resource declaration in
 // rendered HCL and returns the reference form to use in module templates.
 // When the agent uses count or for_each, the returned name includes an
@@ -109,204 +116,41 @@ func renderTemplate(fsys fs.FS, templatePath string, data any) ([]byte, error) {
 // coder_agent resource is found; the builder only supports single-agent
 // templates. The input is expected to be rendered output from our own
 // curated base templates, not arbitrary user HCL.
-func ExtractAgentResourceName(hclSrc []byte) (string, error) {
-	body := parseHCLBody(hclSrc)
-	if body == nil {
-		return "", xerrors.New("no coder_agent resource found in rendered template")
-	}
-
-	var names []string
-	counted := false
-	for _, block := range body.Blocks {
-		if block.Type != "resource" || len(block.Labels) != 2 || block.Labels[0] != "coder_agent" {
-			continue
-		}
-		names = append(names, block.Labels[1])
-		if _, ok := block.Body.Attributes["count"]; ok {
-			counted = true
-		}
-		if _, ok := block.Body.Attributes["for_each"]; ok {
-			counted = true
-		}
-	}
-
-	switch len(names) {
+func ExtractAgentResourceName(hcl []byte) (string, error) {
+	matches := agentResourcePattern.FindAllSubmatch(hcl, -1)
+	switch len(matches) {
 	case 0:
 		return "", xerrors.New("no coder_agent resource found in rendered template")
 	case 1:
-		name := names[0]
-		if counted {
+		name := string(matches[0][1])
+		if agentCountPattern.Match(hcl) {
 			name += "[0]"
 		}
 		return name, nil
 	default:
+		names := make([]string, 0, len(matches))
+		for _, m := range matches {
+			names = append(names, string(m[1]))
+		}
 		return "", xerrors.Errorf("expected exactly one coder_agent resource, found %d: %v",
-			len(names), names)
+			len(matches), names)
 	}
 }
 
-// parseHCLBody parses rendered HCL from one of our curated base templates and
-// returns its top-level body. The input is expected to be valid HCL produced by
-// our own templates; on a parse error it returns nil so callers fail safe. The
-// test-only extractors turn a nil body into an empty result, which trips their
-// NotEmpty/match assertions rather than passing silently; the one production
-// caller, ExtractAgentResourceName, turns it into an error rather than emitting a
-// broken agent reference.
-func parseHCLBody(hclSrc []byte) *hclsyntax.Body {
-	file, diags := hclsyntax.ParseConfig(hclSrc, "rendered.tf", hcl.InitialPos)
-	if diags.HasErrors() || file == nil {
-		return nil
-	}
-	body, ok := file.Body.(*hclsyntax.Body)
-	if !ok {
-		return nil
-	}
-	return body
-}
+// moduleBlockPattern matches a `module "<name>"` block declaration anchored to
+// the start of a line in HCL.
+var moduleBlockPattern = regexp.MustCompile(`(?m)^[ \t]*module[ \t]+"([^"]+)"`)
 
-// ExtractModuleNames returns the labels of every top-level `module` block in
-// rendered HCL, in declaration order. Parsing with hclsyntax means commented-out
-// blocks and module-like text inside strings or heredocs are ignored. The input
+// ExtractModuleNames returns the labels of every module block declared in
+// rendered HCL, in declaration order. Matching is anchored to the start of a
+// line so commented-out references or string literals are ignored. The input
 // is expected to be rendered output from our own curated base templates, not
 // arbitrary user HCL.
-func ExtractModuleNames(hclSrc []byte) []string {
-	body := parseHCLBody(hclSrc)
-	if body == nil {
-		return nil
-	}
-	var names []string
-	for _, block := range body.Blocks {
-		if block.Type == "module" && len(block.Labels) > 0 {
-			names = append(names, block.Labels[0])
-		}
+func ExtractModuleNames(hcl []byte) []string {
+	matches := moduleBlockPattern.FindAllSubmatch(hcl, -1)
+	names := make([]string, 0, len(matches))
+	for _, m := range matches {
+		names = append(names, string(m[1]))
 	}
 	return names
-}
-
-// ExtractParameterOptionValues returns the value of every `option` block inside
-// the `data "coder_parameter" "<paramName>"` block in rendered HCL, in
-// declaration order. Returns nil if the parameter is absent. The input is
-// expected to be rendered output from our own curated base templates.
-func ExtractParameterOptionValues(hclSrc []byte, paramName string) []string {
-	body := parseHCLBody(hclSrc)
-	if body == nil {
-		return nil
-	}
-	var values []string
-	for _, block := range body.Blocks {
-		if block.Type != "data" || len(block.Labels) != 2 ||
-			block.Labels[0] != "coder_parameter" || block.Labels[1] != paramName {
-			continue
-		}
-		for _, option := range block.Body.Blocks {
-			if option.Type != "option" {
-				continue
-			}
-			if attr, ok := option.Body.Attributes["value"]; ok {
-				if s, ok := staticString(attr.Expr); ok {
-					values = append(values, s)
-				}
-			}
-		}
-	}
-	return values
-}
-
-// ExtractPresetParameterValues returns, for every `data "coder_workspace_preset"`
-// block in rendered HCL, the string list assigned to paramName in its
-// `parameters` object (e.g. "languages"). A value written as jsonencode([...])
-// is unwrapped. Presets that do not set the key are skipped. The input is
-// expected to be rendered output from our own curated base templates.
-func ExtractPresetParameterValues(hclSrc []byte, paramName string) [][]string {
-	body := parseHCLBody(hclSrc)
-	if body == nil {
-		return nil
-	}
-	var out [][]string
-	for _, block := range body.Blocks {
-		if block.Type != "data" || len(block.Labels) != 2 ||
-			block.Labels[0] != "coder_workspace_preset" {
-			continue
-		}
-		params, ok := block.Body.Attributes["parameters"]
-		if !ok {
-			continue
-		}
-		pairs, diags := hcl.ExprMap(params.Expr)
-		if diags.HasErrors() {
-			continue
-		}
-		for _, pair := range pairs {
-			if exprKeyString(pair.Key) != paramName {
-				continue
-			}
-			if list, ok := staticStringList(pair.Value); ok {
-				out = append(out, list)
-			}
-		}
-	}
-	return out
-}
-
-// ExtractPresetNames returns the labels of every top-level
-// `data "coder_workspace_preset"` block in rendered HCL, in declaration order.
-// The input is expected to be rendered output from our own curated base
-// templates.
-func ExtractPresetNames(hclSrc []byte) []string {
-	body := parseHCLBody(hclSrc)
-	if body == nil {
-		return nil
-	}
-	var names []string
-	for _, block := range body.Blocks {
-		if block.Type == "data" && len(block.Labels) == 2 &&
-			block.Labels[0] == "coder_workspace_preset" {
-			names = append(names, block.Labels[1])
-		}
-	}
-	return names
-}
-
-// staticString evaluates an expression expected to be a constant string (no
-// variables or functions) and reports whether it produced one.
-func staticString(expr hcl.Expression) (string, bool) {
-	val, diags := expr.Value(nil)
-	if diags.HasErrors() || val.IsNull() || val.Type() != cty.String {
-		return "", false
-	}
-	return val.AsString(), true
-}
-
-// staticStringList evaluates an expression expected to be a constant list of
-// strings, unwrapping a single jsonencode(...) call, and reports whether it
-// produced one.
-func staticStringList(expr hcl.Expression) ([]string, bool) {
-	if call, ok := expr.(*hclsyntax.FunctionCallExpr); ok && call.Name == "jsonencode" && len(call.Args) == 1 {
-		expr = call.Args[0]
-	}
-	val, diags := expr.Value(nil)
-	if diags.HasErrors() || val.IsNull() || !val.CanIterateElements() {
-		return nil, false
-	}
-	out := make([]string, 0, val.LengthInt())
-	for it := val.ElementIterator(); it.Next(); {
-		_, ev := it.Element()
-		if ev.Type() != cty.String {
-			return nil, false
-		}
-		out = append(out, ev.AsString())
-	}
-	return out, true
-}
-
-// exprKeyString returns the string key of an object-construction key
-// expression, handling bare identifier keys (e.g. `languages = ...`).
-func exprKeyString(key hcl.Expression) string {
-	if kw := hcl.ExprAsKeyword(key); kw != "" {
-		return kw
-	}
-	if val, diags := key.Value(nil); !diags.HasErrors() && val.Type() == cty.String {
-		return val.AsString()
-	}
-	return ""
 }

--- a/coderd/templatebuilder/render_test.go
+++ b/coderd/templatebuilder/render_test.go
@@ -344,6 +344,7 @@ func TestBaseTemplateSnapshot(t *testing.T) {
 		{exampleID: "digitalocean-linux"},
 		{exampleID: "gcp-linux"},
 		{exampleID: "gcp-windows"},
+		{exampleID: "quickstart"},
 		{exampleID: "scratch"},
 	}
 

--- a/coderd/templatebuilder/render_test.go
+++ b/coderd/templatebuilder/render_test.go
@@ -250,6 +250,21 @@ func TestExtractAgentResourceName(t *testing.T) {
 		require.Equal(t, "myagent[0]", name)
 	})
 
+	t.Run("CountAfterNestedBlock", func(t *testing.T) {
+		t.Parallel()
+		// count is declared after a nested metadata block; a brace-depth scan
+		// that stopped at the first "}" would miss it and drop the [0] suffix.
+		hcl := []byte(`resource "coder_agent" "dev" {
+  metadata {
+    key = "cpu"
+  }
+  count = data.coder_workspace.me.start_count
+}`)
+		name, err := templatebuilder.ExtractAgentResourceName(hcl)
+		require.NoError(t, err)
+		require.Equal(t, "dev[0]", name)
+	})
+
 	t.Run("UncountedAgent", func(t *testing.T) {
 		t.Parallel()
 		hcl := []byte(`resource "coder_agent" "main" {

--- a/coderd/templatebuilder/render_test.go
+++ b/coderd/templatebuilder/render_test.go
@@ -250,21 +250,6 @@ func TestExtractAgentResourceName(t *testing.T) {
 		require.Equal(t, "myagent[0]", name)
 	})
 
-	t.Run("CountAfterNestedBlock", func(t *testing.T) {
-		t.Parallel()
-		// count is declared after a nested metadata block; a brace-depth scan
-		// that stopped at the first "}" would miss it and drop the [0] suffix.
-		hcl := []byte(`resource "coder_agent" "dev" {
-  metadata {
-    key = "cpu"
-  }
-  count = data.coder_workspace.me.start_count
-}`)
-		name, err := templatebuilder.ExtractAgentResourceName(hcl)
-		require.NoError(t, err)
-		require.Equal(t, "dev[0]", name)
-	})
-
 	t.Run("UncountedAgent", func(t *testing.T) {
 		t.Parallel()
 		hcl := []byte(`resource "coder_agent" "main" {
@@ -306,6 +291,47 @@ resource "coder_agent" "second" {}
 		_, err := templatebuilder.ExtractAgentResourceName([]byte{})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no coder_agent")
+	})
+}
+
+// TestExtractModuleNames covers the regex-based module block extractor on the
+// shapes it must handle for our curated templates: real blocks in declaration
+// order, and commented-out blocks (whose line starts with `#`) ignored because
+// matching is anchored to the start of a line.
+func TestExtractModuleNames(t *testing.T) {
+	t.Parallel()
+
+	t.Run("MultipleInOrder", func(t *testing.T) {
+		t.Parallel()
+		src := []byte(`module "git-clone" {
+  source = "registry.coder.com/coder/git-clone/coder"
+}
+
+module "code-server" {
+  source = "registry.coder.com/coder/code-server/coder"
+}
+`)
+		require.Equal(t, []string{"git-clone", "code-server"},
+			templatebuilder.ExtractModuleNames(src))
+	})
+
+	t.Run("IgnoresCommentedBlock", func(t *testing.T) {
+		t.Parallel()
+		src := []byte(`module "git-clone" {
+  source = "registry.coder.com/coder/git-clone/coder"
+}
+
+# module "commented" {
+#   source = "registry.coder.com/coder/commented/coder"
+# }
+`)
+		require.Equal(t, []string{"git-clone"}, templatebuilder.ExtractModuleNames(src))
+	})
+
+	t.Run("NoModules", func(t *testing.T) {
+		t.Parallel()
+		require.Empty(t, templatebuilder.ExtractModuleNames(
+			[]byte(`resource "coder_agent" "main" {}`)))
 	})
 }
 

--- a/coderd/templatebuilder/testdata/quickstart.tf.golden
+++ b/coderd/templatebuilder/testdata/quickstart.tf.golden
@@ -151,6 +151,11 @@ resource "coder_script" "install_languages" {
 }
 
 # --- Git clone ---
+# NOTE: base templates render their module sources verbatim, so this pins the
+# public registry (registry.coder.com). Unlike wizard-composed modules, a
+# base-embedded module does not yet honor a deployment's configured module
+# registry mirror; threading that registry through base rendering is tracked as
+# a follow-up.
 
 module "git-clone" {
   count    = data.coder_workspace.me.start_count * (data.coder_parameter.git_repo.value != "" ? 1 : 0)

--- a/coderd/templatebuilder/testdata/quickstart.tf.golden
+++ b/coderd/templatebuilder/testdata/quickstart.tf.golden
@@ -1,0 +1,437 @@
+terraform {
+  required_providers {
+    coder = {
+      source = "coder/coder"
+    }
+    docker = {
+      source = "kreuzwerker/docker"
+    }
+    external = {
+      source = "hashicorp/external"
+    }
+  }
+}
+
+variable "docker_socket" {
+  default     = ""
+  description = "(Optional) Docker socket URI"
+  type        = string
+}
+
+provider "docker" {
+  host = var.docker_socket != "" ? var.docker_socket : null
+}
+
+data "coder_provisioner" "me" {}
+data "coder_workspace" "me" {}
+data "coder_workspace_owner" "me" {}
+
+# --- Parameters ---
+
+data "coder_parameter" "languages" {
+  name         = "languages"
+  display_name = "Programming Languages"
+  description  = "Select the languages to pre-install in your workspace"
+  type         = "list(string)"
+  form_type    = "multi-select"
+  default      = jsonencode(["python"])
+  mutable      = true
+  icon         = "/icon/code.svg"
+  order        = 1
+
+  option {
+    name  = "Python"
+    value = "python"
+    icon  = "/icon/python.svg"
+  }
+  option {
+    name  = "Node.js"
+    value = "nodejs"
+    icon  = "/icon/nodejs.svg"
+  }
+  option {
+    name  = "Go"
+    value = "go"
+    icon  = "/icon/go.svg"
+  }
+  option {
+    name  = "Rust"
+    value = "rust"
+    icon  = "/icon/rust.svg"
+  }
+  option {
+    name  = "Java"
+    value = "java"
+    icon  = "/icon/java.svg"
+  }
+  option {
+    name  = "C/C++"
+    value = "cpp"
+    icon  = "/icon/cpp.svg"
+  }
+}
+
+data "coder_parameter" "ides" {
+  name         = "ides"
+  display_name = "IDEs & Editors"
+  description  = "Select the development environments for your workspace"
+  type         = "list(string)"
+  form_type    = "multi-select"
+  default      = jsonencode(["code-server"])
+  mutable      = true
+  icon         = "/icon/code.svg"
+  order        = 2
+
+  option {
+    name  = "VS Code (Browser)"
+    value = "code-server"
+    icon  = "/icon/code.svg"
+  }
+  option {
+    name  = "Cursor"
+    value = "cursor"
+    icon  = "/icon/cursor.svg"
+  }
+  option {
+    name  = "JetBrains IDEs"
+    value = "jetbrains"
+    icon  = "/icon/jetbrains.svg"
+  }
+  option {
+    name  = "Zed"
+    value = "zed"
+    icon  = "/icon/zed.svg"
+  }
+  option {
+    name  = "Windsurf"
+    value = "windsurf"
+    icon  = "/icon/windsurf.svg"
+  }
+}
+
+# Shown only when "JetBrains IDEs" is selected in the IDEs parameter.
+# Pre-selects IDEs that match the chosen languages.
+data "coder_parameter" "jetbrains_ides" {
+  count        = contains(local.ides, "jetbrains") ? 1 : 0
+  name         = "jetbrains_ides"
+  display_name = "JetBrains IDEs"
+  description  = "Select the JetBrains IDEs to install"
+  type         = "list(string)"
+  form_type    = "multi-select"
+  default      = jsonencode(local.jetbrains_ides_from_languages)
+  mutable      = true
+  icon         = "/icon/jetbrains.svg"
+  order        = 3
+
+  option {
+    name  = "IntelliJ IDEA"
+    value = "IU"
+    icon  = "/icon/intellij.svg"
+  }
+  option {
+    name  = "PyCharm"
+    value = "PY"
+    icon  = "/icon/pycharm.svg"
+  }
+  option {
+    name  = "GoLand"
+    value = "GO"
+    icon  = "/icon/goland.svg"
+  }
+  option {
+    name  = "WebStorm"
+    value = "WS"
+    icon  = "/icon/webstorm.svg"
+  }
+  option {
+    name  = "RustRover"
+    value = "RR"
+    icon  = "/icon/rustrover.svg"
+  }
+  option {
+    name  = "CLion"
+    value = "CL"
+    icon  = "/icon/clion.svg"
+  }
+  option {
+    name  = "PhpStorm"
+    value = "PS"
+    icon  = "/icon/phpstorm.svg"
+  }
+  option {
+    name  = "RubyMine"
+    value = "RM"
+    icon  = "/icon/rubymine.svg"
+  }
+  option {
+    name  = "Rider"
+    value = "RD"
+    icon  = "/icon/rider.svg"
+  }
+}
+
+data "coder_parameter" "git_repo" {
+  name         = "git_repo"
+  display_name = "Git Repository (Optional)"
+  description  = "URL of a Git repository to clone into your workspace (leave empty to skip)"
+  type         = "string"
+  default      = ""
+  mutable      = true
+  icon         = "/icon/git.svg"
+  order        = 4
+}
+
+# --- Locals ---
+
+locals {
+  username  = data.coder_workspace_owner.me.name
+  languages = jsondecode(data.coder_parameter.languages.value)
+  ides      = jsondecode(data.coder_parameter.ides.value)
+
+  # Map selected languages to the relevant JetBrains IDE product codes.
+  # Used as the default for the JetBrains IDE selector parameter.
+  jetbrains_by_language = {
+    python = ["PY"]
+    go     = ["GO"]
+    java   = ["IU"]
+    nodejs = ["WS"]
+    rust   = ["RR"]
+    cpp    = ["CL"]
+  }
+  jetbrains_ides_from_languages = distinct(flatten([
+    for lang in local.languages : lookup(local.jetbrains_by_language, lang, [])
+  ]))
+
+  # The actual JetBrains IDEs to install, from the user's selection
+  # in the conditional JetBrains parameter (or empty if not shown).
+  jetbrains_selected = contains(local.ides, "jetbrains") ? jsondecode(data.coder_parameter.jetbrains_ides[0].value) : []
+}
+
+# --- Agent ---
+
+resource "coder_agent" "main" {
+  arch           = data.coder_provisioner.me.arch
+  os             = "linux"
+  startup_script = <<-EOT
+    set -e
+    if [ ! -f ~/.init_done ]; then
+      cp -rT /etc/skel ~
+      touch ~/.init_done
+    fi
+  EOT
+
+  env = {
+    GIT_AUTHOR_NAME     = coalesce(data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
+    GIT_AUTHOR_EMAIL    = "${data.coder_workspace_owner.me.email}"
+    GIT_COMMITTER_NAME  = coalesce(data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
+    GIT_COMMITTER_EMAIL = "${data.coder_workspace_owner.me.email}"
+  }
+
+  metadata {
+    display_name = "CPU Usage"
+    key          = "0_cpu_usage"
+    script       = "coder stat cpu"
+    interval     = 10
+    timeout      = 1
+  }
+
+  metadata {
+    display_name = "RAM Usage"
+    key          = "1_ram_usage"
+    script       = "coder stat mem"
+    interval     = 10
+    timeout      = 1
+  }
+
+  metadata {
+    display_name = "Home Disk"
+    key          = "3_home_disk"
+    script       = "coder stat disk --path $${HOME}"
+    interval     = 60
+    timeout      = 1
+  }
+}
+
+# --- Language installation ---
+# All languages install in a single script to avoid apt-get lock
+# conflicts (coder_script resources run in parallel).
+
+resource "coder_script" "install_languages" {
+  count              = length(local.languages) > 0 ? 1 : 0
+  agent_id           = coder_agent.main.id
+  display_name       = "Install Languages"
+  icon               = "/icon/code.svg"
+  run_on_start       = true
+  start_blocks_login = true
+  script = templatefile("${path.module}/install-languages.sh.tftpl", {
+    LANGUAGES = join(",", local.languages)
+  })
+}
+
+# --- IDE modules ---
+
+module "code-server" {
+  count    = data.coder_workspace.me.start_count * (contains(local.ides, "code-server") ? 1 : 0)
+  source   = "registry.coder.com/coder/code-server/coder"
+  version  = "~> 1.0"
+  agent_id = coder_agent.main.id
+  order    = 1
+}
+
+
+module "cursor" {
+  count    = data.coder_workspace.me.start_count * (contains(local.ides, "cursor") ? 1 : 0)
+  source   = "registry.coder.com/coder/cursor/coder"
+  version  = "~> 1.0"
+  agent_id = coder_agent.main.id
+  folder   = "/home/coder"
+  order    = 3
+}
+
+# TODO: Re-add the coder/jetbrains module once Coder's dynamic
+# parameter system respects module count for parameter visibility.
+# The module's internal coder_parameter appears even when count = 0,
+# creating a ghost parameter in the workspace creation form.
+# module "jetbrains" {
+#   count    = data.coder_workspace.me.start_count * (contains(local.ides, "jetbrains") && length(local.jetbrains_selected) > 0 ? 1 : 0)
+#   source   = "registry.coder.com/coder/jetbrains/coder"
+#   version  = "~> 1.0"
+#   agent_id = coder_agent.main.id
+#   folder   = "/home/coder"
+#   default  = toset(local.jetbrains_selected)
+# }
+
+module "zed" {
+  count    = data.coder_workspace.me.start_count * (contains(local.ides, "zed") ? 1 : 0)
+  source   = "registry.coder.com/coder/zed/coder"
+  version  = "~> 1.0"
+  agent_id = coder_agent.main.id
+  folder   = "/home/coder"
+  order    = 5
+}
+
+module "windsurf" {
+  count    = data.coder_workspace.me.start_count * (contains(local.ides, "windsurf") ? 1 : 0)
+  source   = "registry.coder.com/coder/windsurf/coder"
+  version  = "~> 1.0"
+  agent_id = coder_agent.main.id
+  folder   = "/home/coder"
+  order    = 6
+}
+
+# --- Git clone ---
+
+module "git-clone" {
+  count    = data.coder_workspace.me.start_count * (data.coder_parameter.git_repo.value != "" ? 1 : 0)
+  source   = "registry.coder.com/coder/git-clone/coder"
+  version  = "~> 2.0"
+  agent_id = coder_agent.main.id
+  url      = data.coder_parameter.git_repo.value
+}
+
+# --- Presets ---
+
+data "coder_workspace_preset" "web_dev" {
+  name = "Web Development"
+  icon = "/icon/nodejs.svg"
+  parameters = {
+    languages = jsonencode(["python", "nodejs"])
+    ides      = jsonencode(["code-server"])
+    git_repo  = ""
+  }
+}
+
+data "coder_workspace_preset" "backend_go" {
+  name = "Backend (Go)"
+  icon = "/icon/go.svg"
+  parameters = {
+    languages      = jsonencode(["go"])
+    ides           = jsonencode(["code-server", "jetbrains"])
+    jetbrains_ides = jsonencode(["GO"])
+    git_repo       = ""
+  }
+}
+
+data "coder_workspace_preset" "data_science" {
+  name = "Data Science"
+  icon = "/icon/python.svg"
+  parameters = {
+    languages = jsonencode(["python"])
+    ides      = jsonencode(["code-server"])
+    git_repo  = ""
+  }
+}
+
+data "coder_workspace_preset" "full_stack" {
+  name = "Full Stack"
+  icon = "/icon/code.svg"
+  parameters = {
+    languages = jsonencode(["python", "nodejs", "go"])
+    ides      = jsonencode(["code-server", "cursor"])
+    git_repo  = ""
+  }
+}
+
+# --- Docker resources ---
+
+resource "docker_volume" "home_volume" {
+  name = "coder-${data.coder_workspace.me.id}-home"
+  lifecycle {
+    ignore_changes = all
+  }
+  labels {
+    label = "coder.owner"
+    value = data.coder_workspace_owner.me.name
+  }
+  labels {
+    label = "coder.owner_id"
+    value = data.coder_workspace_owner.me.id
+  }
+  labels {
+    label = "coder.workspace_id"
+    value = data.coder_workspace.me.id
+  }
+  labels {
+    label = "coder.workspace_name_at_creation"
+    value = data.coder_workspace.me.name
+  }
+  depends_on = []
+}
+
+resource "docker_container" "workspace" {
+  count    = data.coder_workspace.me.start_count
+  image    = "codercom/enterprise-base:ubuntu"
+  name     = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}"
+  hostname = data.coder_workspace.me.name
+  entrypoint = [
+    "sh", "-c",
+    replace(coder_agent.main.init_script, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal"),
+  ]
+  env = ["CODER_AGENT_TOKEN=${coder_agent.main.token}"]
+  host {
+    host = "host.docker.internal"
+    ip   = "host-gateway"
+  }
+  volumes {
+    container_path = "/home/coder"
+    volume_name    = docker_volume.home_volume.name
+    read_only      = false
+  }
+  labels {
+    label = "coder.owner"
+    value = data.coder_workspace_owner.me.name
+  }
+  labels {
+    label = "coder.owner_id"
+    value = data.coder_workspace_owner.me.id
+  }
+  labels {
+    label = "coder.workspace_id"
+    value = data.coder_workspace.me.id
+  }
+  labels {
+    label = "coder.workspace_name"
+    value = data.coder_workspace.me.name
+  }
+  depends_on = []
+}

--- a/coderd/templatebuilder/testdata/quickstart.tf.golden
+++ b/coderd/templatebuilder/testdata/quickstart.tf.golden
@@ -71,105 +71,6 @@ data "coder_parameter" "languages" {
   }
 }
 
-data "coder_parameter" "ides" {
-  name         = "ides"
-  display_name = "IDEs & Editors"
-  description  = "Select the development environments for your workspace"
-  type         = "list(string)"
-  form_type    = "multi-select"
-  default      = jsonencode(["code-server"])
-  mutable      = true
-  icon         = "/icon/code.svg"
-  order        = 2
-
-  option {
-    name  = "VS Code (Browser)"
-    value = "code-server"
-    icon  = "/icon/code.svg"
-  }
-  option {
-    name  = "Cursor"
-    value = "cursor"
-    icon  = "/icon/cursor.svg"
-  }
-  option {
-    name  = "JetBrains IDEs"
-    value = "jetbrains"
-    icon  = "/icon/jetbrains.svg"
-  }
-  option {
-    name  = "Zed"
-    value = "zed"
-    icon  = "/icon/zed.svg"
-  }
-  option {
-    name  = "Windsurf"
-    value = "windsurf"
-    icon  = "/icon/windsurf.svg"
-  }
-}
-
-# Shown only when "JetBrains IDEs" is selected in the IDEs parameter.
-# Pre-selects IDEs that match the chosen languages.
-data "coder_parameter" "jetbrains_ides" {
-  count        = contains(local.ides, "jetbrains") ? 1 : 0
-  name         = "jetbrains_ides"
-  display_name = "JetBrains IDEs"
-  description  = "Select the JetBrains IDEs to install"
-  type         = "list(string)"
-  form_type    = "multi-select"
-  default      = jsonencode(local.jetbrains_ides_from_languages)
-  mutable      = true
-  icon         = "/icon/jetbrains.svg"
-  order        = 3
-
-  option {
-    name  = "IntelliJ IDEA"
-    value = "IU"
-    icon  = "/icon/intellij.svg"
-  }
-  option {
-    name  = "PyCharm"
-    value = "PY"
-    icon  = "/icon/pycharm.svg"
-  }
-  option {
-    name  = "GoLand"
-    value = "GO"
-    icon  = "/icon/goland.svg"
-  }
-  option {
-    name  = "WebStorm"
-    value = "WS"
-    icon  = "/icon/webstorm.svg"
-  }
-  option {
-    name  = "RustRover"
-    value = "RR"
-    icon  = "/icon/rustrover.svg"
-  }
-  option {
-    name  = "CLion"
-    value = "CL"
-    icon  = "/icon/clion.svg"
-  }
-  option {
-    name  = "PhpStorm"
-    value = "PS"
-    icon  = "/icon/phpstorm.svg"
-  }
-  option {
-    name  = "RubyMine"
-    value = "RM"
-    icon  = "/icon/rubymine.svg"
-  }
-  option {
-    name  = "Rider"
-    value = "RD"
-    icon  = "/icon/rider.svg"
-  }
-}
-
 data "coder_parameter" "git_repo" {
   name         = "git_repo"
   display_name = "Git Repository (Optional)"
@@ -178,7 +79,7 @@ data "coder_parameter" "git_repo" {
   default      = ""
   mutable      = true
   icon         = "/icon/git.svg"
-  order        = 4
+  order        = 2
 }
 
 # --- Locals ---
@@ -186,25 +87,6 @@ data "coder_parameter" "git_repo" {
 locals {
   username  = data.coder_workspace_owner.me.name
   languages = jsondecode(data.coder_parameter.languages.value)
-  ides      = jsondecode(data.coder_parameter.ides.value)
-
-  # Map selected languages to the relevant JetBrains IDE product codes.
-  # Used as the default for the JetBrains IDE selector parameter.
-  jetbrains_by_language = {
-    python = ["PY"]
-    go     = ["GO"]
-    java   = ["IU"]
-    nodejs = ["WS"]
-    rust   = ["RR"]
-    cpp    = ["CL"]
-  }
-  jetbrains_ides_from_languages = distinct(flatten([
-    for lang in local.languages : lookup(local.jetbrains_by_language, lang, [])
-  ]))
-
-  # The actual JetBrains IDEs to install, from the user's selection
-  # in the conditional JetBrains parameter (or empty if not shown).
-  jetbrains_selected = contains(local.ides, "jetbrains") ? jsondecode(data.coder_parameter.jetbrains_ides[0].value) : []
 }
 
 # --- Agent ---
@@ -268,57 +150,6 @@ resource "coder_script" "install_languages" {
   })
 }
 
-# --- IDE modules ---
-
-module "code-server" {
-  count    = data.coder_workspace.me.start_count * (contains(local.ides, "code-server") ? 1 : 0)
-  source   = "registry.coder.com/coder/code-server/coder"
-  version  = "~> 1.0"
-  agent_id = coder_agent.main.id
-  order    = 1
-}
-
-
-module "cursor" {
-  count    = data.coder_workspace.me.start_count * (contains(local.ides, "cursor") ? 1 : 0)
-  source   = "registry.coder.com/coder/cursor/coder"
-  version  = "~> 1.0"
-  agent_id = coder_agent.main.id
-  folder   = "/home/coder"
-  order    = 3
-}
-
-# TODO: Re-add the coder/jetbrains module once Coder's dynamic
-# parameter system respects module count for parameter visibility.
-# The module's internal coder_parameter appears even when count = 0,
-# creating a ghost parameter in the workspace creation form.
-# module "jetbrains" {
-#   count    = data.coder_workspace.me.start_count * (contains(local.ides, "jetbrains") && length(local.jetbrains_selected) > 0 ? 1 : 0)
-#   source   = "registry.coder.com/coder/jetbrains/coder"
-#   version  = "~> 1.0"
-#   agent_id = coder_agent.main.id
-#   folder   = "/home/coder"
-#   default  = toset(local.jetbrains_selected)
-# }
-
-module "zed" {
-  count    = data.coder_workspace.me.start_count * (contains(local.ides, "zed") ? 1 : 0)
-  source   = "registry.coder.com/coder/zed/coder"
-  version  = "~> 1.0"
-  agent_id = coder_agent.main.id
-  folder   = "/home/coder"
-  order    = 5
-}
-
-module "windsurf" {
-  count    = data.coder_workspace.me.start_count * (contains(local.ides, "windsurf") ? 1 : 0)
-  source   = "registry.coder.com/coder/windsurf/coder"
-  version  = "~> 1.0"
-  agent_id = coder_agent.main.id
-  folder   = "/home/coder"
-  order    = 6
-}
-
 # --- Git clone ---
 
 module "git-clone" {
@@ -336,7 +167,6 @@ data "coder_workspace_preset" "web_dev" {
   icon = "/icon/nodejs.svg"
   parameters = {
     languages = jsonencode(["python", "nodejs"])
-    ides      = jsonencode(["code-server"])
     git_repo  = ""
   }
 }
@@ -345,10 +175,8 @@ data "coder_workspace_preset" "backend_go" {
   name = "Backend (Go)"
   icon = "/icon/go.svg"
   parameters = {
-    languages      = jsonencode(["go"])
-    ides           = jsonencode(["code-server", "jetbrains"])
-    jetbrains_ides = jsonencode(["GO"])
-    git_repo       = ""
+    languages = jsonencode(["go"])
+    git_repo  = ""
   }
 }
 
@@ -357,7 +185,6 @@ data "coder_workspace_preset" "data_science" {
   icon = "/icon/python.svg"
   parameters = {
     languages = jsonencode(["python"])
-    ides      = jsonencode(["code-server"])
     git_repo  = ""
   }
 }
@@ -367,7 +194,6 @@ data "coder_workspace_preset" "full_stack" {
   icon = "/icon/code.svg"
   parameters = {
     languages = jsonencode(["python", "nodejs", "go"])
-    ides      = jsonencode(["code-server", "cursor"])
     git_repo  = ""
   }
 }

--- a/coderd/templatebuilder_handler.go
+++ b/coderd/templatebuilder_handler.go
@@ -86,10 +86,8 @@ func (api *API) templateBuilderBases(rw http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	// Order bases alphabetically by display name, then group the Coder
-	// Quickstart base directly before the Docker base. Quickstart is a
-	// Docker-based "start here" template, so it belongs next to Docker rather
-	// than in its default alphabetical slot.
+	// Order bases alphabetically by display name, then group Quickstart next to
+	// Docker (see groupQuickstartBeforeDocker for the rationale).
 	slices.SortFunc(bases, func(a, b codersdk.TemplateBuilderBase) int {
 		// Tiebreak on ID so the order is total and deterministic even if two
 		// bases ever share a display name.

--- a/coderd/templatebuilder_handler.go
+++ b/coderd/templatebuilder_handler.go
@@ -86,17 +86,14 @@ func (api *API) templateBuilderBases(rw http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	// Order bases alphabetically by display name, then group Quickstart next to
-	// Docker (see groupQuickstartBeforeDocker for the rationale).
+	// Order bases by display name, tiebreaking on ID so the order is total and
+	// deterministic even if two bases ever share a display name.
 	slices.SortFunc(bases, func(a, b codersdk.TemplateBuilderBase) int {
-		// Tiebreak on ID so the order is total and deterministic even if two
-		// bases ever share a display name.
 		return cmp.Or(
 			cmp.Compare(a.Name, b.Name),
 			cmp.Compare(a.ID, b.ID),
 		)
 	})
-	bases = groupQuickstartBeforeDocker(bases)
 
 	httpapi.Write(ctx, rw, http.StatusOK, codersdk.TemplateBuilderBasesResponse{
 		Bases: bases,
@@ -121,37 +118,6 @@ func baseVariablesToSDK(vars []templatebuilder.ModuleVariable) []codersdk.Templa
 		})
 	}
 	return out
-}
-
-const (
-	quickstartBaseID = "quickstart"
-	dockerBaseID     = "docker"
-)
-
-// groupQuickstartBeforeDocker returns bases reordered so the Coder Quickstart
-// base sits immediately before the Docker base, preserving the relative order
-// of all other bases. Quickstart is a Docker-based starter template, so it is
-// grouped next to Docker rather than left in its default alphabetical slot.
-// The input is returned unchanged if either base is absent.
-func groupQuickstartBeforeDocker(bases []codersdk.TemplateBuilderBase) []codersdk.TemplateBuilderBase {
-	qsIdx := slices.IndexFunc(bases, func(b codersdk.TemplateBuilderBase) bool {
-		return b.ID == quickstartBaseID
-	})
-	if qsIdx == -1 {
-		return bases
-	}
-	quickstart := bases[qsIdx]
-
-	// Remove quickstart from a copy, then reinsert it directly before docker.
-	rest := slices.Delete(slices.Clone(bases), qsIdx, qsIdx+1)
-	dockerIdx := slices.IndexFunc(rest, func(b codersdk.TemplateBuilderBase) bool {
-		return b.ID == dockerBaseID
-	})
-	if dockerIdx == -1 {
-		// Docker base not present; leave quickstart in its sorted position.
-		return bases
-	}
-	return slices.Insert(rest, dockerIdx, quickstart)
 }
 
 // @Summary List template builder modules
@@ -205,7 +171,7 @@ func (api *API) templateBuilderModules(rw http.ResponseWriter, r *http.Request) 
 		if filterOS != "" && !m.CompatibleWithOS(string(filterOS)) {
 			continue
 		}
-		// Skip modules the base already includes (see BaseManifest.IncludedModules).
+		// Skip modules the base already includes (see BaseIncludedModules).
 		if baseModules[m.ID] {
 			continue
 		}

--- a/coderd/templatebuilder_handler.go
+++ b/coderd/templatebuilder_handler.go
@@ -95,7 +95,12 @@ func (api *API) templateBuilderBases(rw http.ResponseWriter, r *http.Request) {
 		if iQuickstart != jQuickstart {
 			return iQuickstart
 		}
-		return bases[i].Name < bases[j].Name
+		if bases[i].Name != bases[j].Name {
+			return bases[i].Name < bases[j].Name
+		}
+		// Tiebreak on ID so the order is total and deterministic even if two
+		// bases ever share a display name.
+		return bases[i].ID < bases[j].ID
 	})
 
 	httpapi.Write(ctx, rw, http.StatusOK, codersdk.TemplateBuilderBasesResponse{

--- a/coderd/templatebuilder_handler.go
+++ b/coderd/templatebuilder_handler.go
@@ -85,16 +85,11 @@ func (api *API) templateBuilderBases(rw http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	// The Coder Quickstart base is surfaced first as the recommended starting
-	// point (mirroring its position in the registry); the remaining bases follow
-	// alphabetically by name.
-	const quickstartBaseID = "quickstart"
+	// Order bases alphabetically by display name, then group the Coder
+	// Quickstart base directly before the Docker base. Quickstart is a
+	// Docker-based "start here" template, so it belongs next to Docker rather
+	// than in its default alphabetical slot.
 	sort.Slice(bases, func(i, j int) bool {
-		iQuickstart := bases[i].ID == quickstartBaseID
-		jQuickstart := bases[j].ID == quickstartBaseID
-		if iQuickstart != jQuickstart {
-			return iQuickstart
-		}
 		if bases[i].Name != bases[j].Name {
 			return bases[i].Name < bases[j].Name
 		}
@@ -102,6 +97,7 @@ func (api *API) templateBuilderBases(rw http.ResponseWriter, r *http.Request) {
 		// bases ever share a display name.
 		return bases[i].ID < bases[j].ID
 	})
+	bases = groupQuickstartBeforeDocker(bases)
 
 	httpapi.Write(ctx, rw, http.StatusOK, codersdk.TemplateBuilderBasesResponse{
 		Bases: bases,
@@ -125,6 +121,52 @@ func baseVariablesToSDK(vars []templatebuilder.ModuleVariable) []codersdk.Templa
 			Sensitive:   v.Sensitive,
 		})
 	}
+	return out
+}
+
+const (
+	quickstartBaseID = "quickstart"
+	dockerBaseID     = "docker"
+)
+
+// groupQuickstartBeforeDocker returns bases reordered so the Coder Quickstart
+// base sits immediately before the Docker base, preserving the relative order
+// of all other bases. Quickstart is a Docker-based starter template, so it is
+// grouped next to Docker rather than left in its default alphabetical slot.
+// The input is returned unchanged if either base is absent.
+func groupQuickstartBeforeDocker(bases []codersdk.TemplateBuilderBase) []codersdk.TemplateBuilderBase {
+	var (
+		quickstart     codersdk.TemplateBuilderBase
+		haveQuickstart bool
+	)
+	rest := make([]codersdk.TemplateBuilderBase, 0, len(bases))
+	for _, b := range bases {
+		if b.ID == quickstartBaseID {
+			quickstart, haveQuickstart = b, true
+			continue
+		}
+		rest = append(rest, b)
+	}
+	if !haveQuickstart {
+		return bases
+	}
+
+	dockerIdx := -1
+	for i, b := range rest {
+		if b.ID == dockerBaseID {
+			dockerIdx = i
+			break
+		}
+	}
+	if dockerIdx == -1 {
+		// Docker base not present; leave quickstart in its sorted position.
+		return bases
+	}
+
+	out := make([]codersdk.TemplateBuilderBase, 0, len(bases))
+	out = append(out, rest[:dockerIdx]...)
+	out = append(out, quickstart)
+	out = append(out, rest[dockerIdx:]...)
 	return out
 }
 

--- a/coderd/templatebuilder_handler.go
+++ b/coderd/templatebuilder_handler.go
@@ -1,6 +1,7 @@
 package coderd
 
 import (
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"database/sql"
@@ -8,7 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -89,13 +90,13 @@ func (api *API) templateBuilderBases(rw http.ResponseWriter, r *http.Request) {
 	// Quickstart base directly before the Docker base. Quickstart is a
 	// Docker-based "start here" template, so it belongs next to Docker rather
 	// than in its default alphabetical slot.
-	sort.Slice(bases, func(i, j int) bool {
-		if bases[i].Name != bases[j].Name {
-			return bases[i].Name < bases[j].Name
-		}
+	slices.SortFunc(bases, func(a, b codersdk.TemplateBuilderBase) int {
 		// Tiebreak on ID so the order is total and deterministic even if two
 		// bases ever share a display name.
-		return bases[i].ID < bases[j].ID
+		return cmp.Or(
+			cmp.Compare(a.Name, b.Name),
+			cmp.Compare(a.ID, b.ID),
+		)
 	})
 	bases = groupQuickstartBeforeDocker(bases)
 
@@ -135,39 +136,24 @@ const (
 // grouped next to Docker rather than left in its default alphabetical slot.
 // The input is returned unchanged if either base is absent.
 func groupQuickstartBeforeDocker(bases []codersdk.TemplateBuilderBase) []codersdk.TemplateBuilderBase {
-	var (
-		quickstart     codersdk.TemplateBuilderBase
-		haveQuickstart bool
-	)
-	rest := make([]codersdk.TemplateBuilderBase, 0, len(bases))
-	for _, b := range bases {
-		if b.ID == quickstartBaseID {
-			quickstart, haveQuickstart = b, true
-			continue
-		}
-		rest = append(rest, b)
-	}
-	if !haveQuickstart {
+	qsIdx := slices.IndexFunc(bases, func(b codersdk.TemplateBuilderBase) bool {
+		return b.ID == quickstartBaseID
+	})
+	if qsIdx == -1 {
 		return bases
 	}
+	quickstart := bases[qsIdx]
 
-	dockerIdx := -1
-	for i, b := range rest {
-		if b.ID == dockerBaseID {
-			dockerIdx = i
-			break
-		}
-	}
+	// Remove quickstart from a copy, then reinsert it directly before docker.
+	rest := slices.Delete(slices.Clone(bases), qsIdx, qsIdx+1)
+	dockerIdx := slices.IndexFunc(rest, func(b codersdk.TemplateBuilderBase) bool {
+		return b.ID == dockerBaseID
+	})
 	if dockerIdx == -1 {
 		// Docker base not present; leave quickstart in its sorted position.
 		return bases
 	}
-
-	out := make([]codersdk.TemplateBuilderBase, 0, len(bases))
-	out = append(out, rest[:dockerIdx]...)
-	out = append(out, quickstart)
-	out = append(out, rest[dockerIdx:]...)
-	return out
+	return slices.Insert(rest, dockerIdx, quickstart)
 }
 
 // @Summary List template builder modules
@@ -221,8 +207,7 @@ func (api *API) templateBuilderModules(rw http.ResponseWriter, r *http.Request) 
 		if filterOS != "" && !m.CompatibleWithOS(string(filterOS)) {
 			continue
 		}
-		// Skip modules the base template already includes; selecting one
-		// would collide with the base's own module block.
+		// Skip modules the base already includes (see BaseManifest.IncludedModules).
 		if baseModules[m.ID] {
 			continue
 		}

--- a/coderd/templatebuilder_handler.go
+++ b/coderd/templatebuilder_handler.go
@@ -195,8 +195,11 @@ func (api *API) templateBuilderModules(rw http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Resolve OS filter from the base query param.
-	var filterOS templatebuilder.BaseOS
+	// Resolve OS filter and base-included modules from the base query param.
+	var (
+		filterOS    templatebuilder.BaseOS
+		baseModules map[string]bool
+	)
 	if base := r.URL.Query().Get("base"); base != "" {
 		filterOS = templatebuilder.BaseTemplateOS(base)
 		if filterOS == "" {
@@ -206,11 +209,21 @@ func (api *API) templateBuilderModules(rw http.ResponseWriter, r *http.Request) 
 			})
 			return
 		}
+		included := templatebuilder.BaseIncludedModules(base)
+		baseModules = make(map[string]bool, len(included))
+		for _, id := range included {
+			baseModules[id] = true
+		}
 	}
 
 	modules := make([]codersdk.TemplateBuilderModule, 0, len(manifests))
 	for _, m := range manifests {
 		if filterOS != "" && !m.CompatibleWithOS(string(filterOS)) {
+			continue
+		}
+		// Skip modules the base template already includes; selecting one
+		// would collide with the base's own module block.
+		if baseModules[m.ID] {
 			continue
 		}
 		modules = append(modules, m.ToSDK())

--- a/coderd/templatebuilder_handler.go
+++ b/coderd/templatebuilder_handler.go
@@ -85,7 +85,16 @@ func (api *API) templateBuilderBases(rw http.ResponseWriter, r *http.Request) {
 		})
 	}
 
+	// The Coder Quickstart base is surfaced first as the recommended starting
+	// point (mirroring its position in the registry); the remaining bases follow
+	// alphabetically by name.
+	const quickstartBaseID = "quickstart"
 	sort.Slice(bases, func(i, j int) bool {
+		iQuickstart := bases[i].ID == quickstartBaseID
+		jQuickstart := bases[j].ID == quickstartBaseID
+		if iQuickstart != jQuickstart {
+			return iQuickstart
+		}
 		return bases[i].Name < bases[j].Name
 	})
 

--- a/coderd/templatebuilder_handler.go
+++ b/coderd/templatebuilder_handler.go
@@ -94,7 +94,12 @@ func (api *API) templateBuilderBases(rw http.ResponseWriter, r *http.Request) {
 		if iQuickstart != jQuickstart {
 			return iQuickstart
 		}
-		return bases[i].Name < bases[j].Name
+		if bases[i].Name != bases[j].Name {
+			return bases[i].Name < bases[j].Name
+		}
+		// Tiebreak on ID so the order is total and deterministic even if two
+		// bases ever share a display name.
+		return bases[i].ID < bases[j].ID
 	})
 
 	httpapi.Write(ctx, rw, http.StatusOK, codersdk.TemplateBuilderBasesResponse{

--- a/coderd/templatebuilder_handler.go
+++ b/coderd/templatebuilder_handler.go
@@ -194,8 +194,11 @@ func (api *API) templateBuilderModules(rw http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Resolve OS filter from the base query param.
-	var filterOS templatebuilder.BaseOS
+	// Resolve OS filter and base-included modules from the base query param.
+	var (
+		filterOS    templatebuilder.BaseOS
+		baseModules map[string]bool
+	)
 	if base := r.URL.Query().Get("base"); base != "" {
 		filterOS = templatebuilder.BaseTemplateOS(base)
 		if filterOS == "" {
@@ -205,11 +208,21 @@ func (api *API) templateBuilderModules(rw http.ResponseWriter, r *http.Request) 
 			})
 			return
 		}
+		included := templatebuilder.BaseIncludedModules(base)
+		baseModules = make(map[string]bool, len(included))
+		for _, id := range included {
+			baseModules[id] = true
+		}
 	}
 
 	modules := make([]codersdk.TemplateBuilderModule, 0, len(manifests))
 	for _, m := range manifests {
 		if filterOS != "" && !m.CompatibleWithOS(string(filterOS)) {
+			continue
+		}
+		// Skip modules the base template already includes; selecting one
+		// would collide with the base's own module block.
+		if baseModules[m.ID] {
 			continue
 		}
 		modules = append(modules, m.ToSDK())

--- a/coderd/templatebuilder_handler.go
+++ b/coderd/templatebuilder_handler.go
@@ -84,7 +84,16 @@ func (api *API) templateBuilderBases(rw http.ResponseWriter, r *http.Request) {
 		})
 	}
 
+	// The Coder Quickstart base is surfaced first as the recommended starting
+	// point (mirroring its position in the registry); the remaining bases follow
+	// alphabetically by name.
+	const quickstartBaseID = "quickstart"
 	sort.Slice(bases, func(i, j int) bool {
+		iQuickstart := bases[i].ID == quickstartBaseID
+		jQuickstart := bases[j].ID == quickstartBaseID
+		if iQuickstart != jQuickstart {
+			return iQuickstart
+		}
 		return bases[i].Name < bases[j].Name
 	})
 

--- a/coderd/templatebuilder_handler.go
+++ b/coderd/templatebuilder_handler.go
@@ -84,16 +84,11 @@ func (api *API) templateBuilderBases(rw http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	// The Coder Quickstart base is surfaced first as the recommended starting
-	// point (mirroring its position in the registry); the remaining bases follow
-	// alphabetically by name.
-	const quickstartBaseID = "quickstart"
+	// Order bases alphabetically by display name, then group the Coder
+	// Quickstart base directly before the Docker base. Quickstart is a
+	// Docker-based "start here" template, so it belongs next to Docker rather
+	// than in its default alphabetical slot.
 	sort.Slice(bases, func(i, j int) bool {
-		iQuickstart := bases[i].ID == quickstartBaseID
-		jQuickstart := bases[j].ID == quickstartBaseID
-		if iQuickstart != jQuickstart {
-			return iQuickstart
-		}
 		if bases[i].Name != bases[j].Name {
 			return bases[i].Name < bases[j].Name
 		}
@@ -101,6 +96,7 @@ func (api *API) templateBuilderBases(rw http.ResponseWriter, r *http.Request) {
 		// bases ever share a display name.
 		return bases[i].ID < bases[j].ID
 	})
+	bases = groupQuickstartBeforeDocker(bases)
 
 	httpapi.Write(ctx, rw, http.StatusOK, codersdk.TemplateBuilderBasesResponse{
 		Bases: bases,
@@ -124,6 +120,52 @@ func baseVariablesToSDK(vars []templatebuilder.ModuleVariable) []codersdk.Templa
 			Sensitive:   v.Sensitive,
 		})
 	}
+	return out
+}
+
+const (
+	quickstartBaseID = "quickstart"
+	dockerBaseID     = "docker"
+)
+
+// groupQuickstartBeforeDocker returns bases reordered so the Coder Quickstart
+// base sits immediately before the Docker base, preserving the relative order
+// of all other bases. Quickstart is a Docker-based starter template, so it is
+// grouped next to Docker rather than left in its default alphabetical slot.
+// The input is returned unchanged if either base is absent.
+func groupQuickstartBeforeDocker(bases []codersdk.TemplateBuilderBase) []codersdk.TemplateBuilderBase {
+	var (
+		quickstart     codersdk.TemplateBuilderBase
+		haveQuickstart bool
+	)
+	rest := make([]codersdk.TemplateBuilderBase, 0, len(bases))
+	for _, b := range bases {
+		if b.ID == quickstartBaseID {
+			quickstart, haveQuickstart = b, true
+			continue
+		}
+		rest = append(rest, b)
+	}
+	if !haveQuickstart {
+		return bases
+	}
+
+	dockerIdx := -1
+	for i, b := range rest {
+		if b.ID == dockerBaseID {
+			dockerIdx = i
+			break
+		}
+	}
+	if dockerIdx == -1 {
+		// Docker base not present; leave quickstart in its sorted position.
+		return bases
+	}
+
+	out := make([]codersdk.TemplateBuilderBase, 0, len(bases))
+	out = append(out, rest[:dockerIdx]...)
+	out = append(out, quickstart)
+	out = append(out, rest[dockerIdx:]...)
 	return out
 }
 

--- a/coderd/templatebuilder_handler_test.go
+++ b/coderd/templatebuilder_handler_test.go
@@ -44,6 +44,14 @@ func TestTemplateBuilderBases(t *testing.T) {
 
 		specs := []baseSpec{
 			{
+				// Quickstart exposes no builder variables today: its base.json
+				// declares none. Locking that here flags drift if it changes,
+				// e.g. if it later exposes a container_image selector.
+				id:           "quickstart",
+				expectedOS:   "linux",
+				hasVariables: false,
+			},
+			{
 				id:           "docker",
 				expectedOS:   "linux",
 				hasVariables: true,

--- a/coderd/templatebuilder_handler_test.go
+++ b/coderd/templatebuilder_handler_test.go
@@ -117,33 +117,11 @@ func TestTemplateBuilderBases(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, resp.Bases)
 
-		// The Coder Quickstart base is grouped immediately before the Docker
-		// base; every other base is ordered alphabetically by name.
-		quickstartIdx, dockerIdx := -1, -1
-		for i, b := range resp.Bases {
-			switch b.ID {
-			case "quickstart":
-				quickstartIdx = i
-			case "docker":
-				dockerIdx = i
-			}
-		}
-		require.NotEqual(t, -1, quickstartIdx, "quickstart base should be present")
-		require.NotEqual(t, -1, dockerIdx, "docker base should be present")
-		require.Equal(t, dockerIdx-1, quickstartIdx,
-			"quickstart base should be immediately before the docker base")
-
-		// The remaining bases (excluding quickstart) are sorted by name.
-		var names []string
-		for _, b := range resp.Bases {
-			if b.ID == "quickstart" {
-				continue
-			}
-			names = append(names, b.Name)
-		}
-		for i := 1; i < len(names); i++ {
-			require.LessOrEqual(t, names[i-1], names[i],
-				"non-quickstart bases should be sorted by name")
+		// Bases are returned sorted by display name (with ID as a deterministic
+		// tiebreak), so the whole list is in non-decreasing name order.
+		for i := 1; i < len(resp.Bases); i++ {
+			require.LessOrEqual(t, resp.Bases[i-1].Name, resp.Bases[i].Name,
+				"bases should be sorted by display name")
 		}
 	})
 

--- a/coderd/templatebuilder_handler_test.go
+++ b/coderd/templatebuilder_handler_test.go
@@ -107,10 +107,15 @@ func TestTemplateBuilderBases(t *testing.T) {
 
 		resp, err := client.TemplateBuilderBases(ctx)
 		require.NoError(t, err)
+		require.NotEmpty(t, resp.Bases)
 
-		for i := 1; i < len(resp.Bases); i++ {
+		// The Coder Quickstart base is pinned first as the recommended
+		// starting point; the remaining bases are sorted by name.
+		require.Equal(t, "quickstart", resp.Bases[0].ID,
+			"quickstart base should be pinned first")
+		for i := 2; i < len(resp.Bases); i++ {
 			require.LessOrEqual(t, resp.Bases[i-1].Name, resp.Bases[i].Name,
-				"bases should be sorted by name")
+				"bases after quickstart should be sorted by name")
 		}
 	})
 

--- a/coderd/templatebuilder_handler_test.go
+++ b/coderd/templatebuilder_handler_test.go
@@ -117,13 +117,33 @@ func TestTemplateBuilderBases(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, resp.Bases)
 
-		// The Coder Quickstart base is pinned first as the recommended
-		// starting point; the remaining bases are sorted by name.
-		require.Equal(t, "quickstart", resp.Bases[0].ID,
-			"quickstart base should be pinned first")
-		for i := 2; i < len(resp.Bases); i++ {
-			require.LessOrEqual(t, resp.Bases[i-1].Name, resp.Bases[i].Name,
-				"bases after quickstart should be sorted by name")
+		// The Coder Quickstart base is grouped immediately before the Docker
+		// base; every other base is ordered alphabetically by name.
+		quickstartIdx, dockerIdx := -1, -1
+		for i, b := range resp.Bases {
+			switch b.ID {
+			case "quickstart":
+				quickstartIdx = i
+			case "docker":
+				dockerIdx = i
+			}
+		}
+		require.NotEqual(t, -1, quickstartIdx, "quickstart base should be present")
+		require.NotEqual(t, -1, dockerIdx, "docker base should be present")
+		require.Equal(t, dockerIdx-1, quickstartIdx,
+			"quickstart base should be immediately before the docker base")
+
+		// The remaining bases (excluding quickstart) are sorted by name.
+		var names []string
+		for _, b := range resp.Bases {
+			if b.ID == "quickstart" {
+				continue
+			}
+			names = append(names, b.Name)
+		}
+		for i := 1; i < len(names); i++ {
+			require.LessOrEqual(t, names[i-1], names[i],
+				"non-quickstart bases should be sorted by name")
 		}
 	})
 

--- a/coderd/templatebuilder_handler_test.go
+++ b/coderd/templatebuilder_handler_test.go
@@ -209,6 +209,37 @@ func TestTemplateBuilderModules(t *testing.T) {
 		}
 	})
 
+	t.Run("BaseExcludesIncludedModules", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		// The quickstart base bundles the git-clone module, so the module
+		// list for that base must omit git-clone to avoid a collision. The
+		// docker base does not bundle it, so it stays available there.
+		quickstartResp, err := client.TemplateBuilderModules(ctx, "quickstart")
+		require.NoError(t, err)
+		for _, m := range quickstartResp.Modules {
+			require.NotEqual(t, "git-clone", m.ID,
+				"git-clone should be excluded for the quickstart base")
+		}
+
+		dockerResp, err := client.TemplateBuilderModules(ctx, "docker")
+		require.NoError(t, err)
+		var dockerHasGitClone bool
+		for _, m := range dockerResp.Modules {
+			if m.ID == "git-clone" {
+				dockerHasGitClone = true
+				break
+			}
+		}
+		require.True(t, dockerHasGitClone,
+			"git-clone should remain available for bases that do not bundle it")
+	})
+
 	t.Run("ComputedVariablesExcluded", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, nil)

--- a/coderd/templatebuilder_handler_test.go
+++ b/coderd/templatebuilder_handler_test.go
@@ -222,6 +222,8 @@ func TestTemplateBuilderModules(t *testing.T) {
 		// docker base does not bundle it, so it stays available there.
 		quickstartResp, err := client.TemplateBuilderModules(ctx, "quickstart")
 		require.NoError(t, err)
+		require.NotEmpty(t, quickstartResp.Modules,
+			"quickstart should still offer modules other than the ones it bundles")
 		for _, m := range quickstartResp.Modules {
 			require.NotEqual(t, "git-clone", m.ID,
 				"git-clone should be excluded for the quickstart base")

--- a/coderd/templatebuilder_handler_test.go
+++ b/coderd/templatebuilder_handler_test.go
@@ -106,10 +106,15 @@ func TestTemplateBuilderBases(t *testing.T) {
 
 		resp, err := client.TemplateBuilderBases(ctx)
 		require.NoError(t, err)
+		require.NotEmpty(t, resp.Bases)
 
-		for i := 1; i < len(resp.Bases); i++ {
+		// The Coder Quickstart base is pinned first as the recommended
+		// starting point; the remaining bases are sorted by name.
+		require.Equal(t, "quickstart", resp.Bases[0].ID,
+			"quickstart base should be pinned first")
+		for i := 2; i < len(resp.Bases); i++ {
 			require.LessOrEqual(t, resp.Bases[i-1].Name, resp.Bases[i].Name,
-				"bases should be sorted by name")
+				"bases after quickstart should be sorted by name")
 		}
 	})
 

--- a/coderd/templatebuilder_handler_test.go
+++ b/coderd/templatebuilder_handler_test.go
@@ -43,6 +43,14 @@ func TestTemplateBuilderBases(t *testing.T) {
 
 		specs := []baseSpec{
 			{
+				// Quickstart exposes no builder variables today: its base.json
+				// declares none. Locking that here flags drift if it changes,
+				// e.g. if it later exposes a container_image selector.
+				id:           "quickstart",
+				expectedOS:   "linux",
+				hasVariables: false,
+			},
+			{
 				id:           "docker",
 				expectedOS:   "linux",
 				hasVariables: true,

--- a/coderd/templatebuilder_handler_test.go
+++ b/coderd/templatebuilder_handler_test.go
@@ -208,6 +208,37 @@ func TestTemplateBuilderModules(t *testing.T) {
 		}
 	})
 
+	t.Run("BaseExcludesIncludedModules", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		// The quickstart base bundles the git-clone module, so the module
+		// list for that base must omit git-clone to avoid a collision. The
+		// docker base does not bundle it, so it stays available there.
+		quickstartResp, err := client.TemplateBuilderModules(ctx, "quickstart")
+		require.NoError(t, err)
+		for _, m := range quickstartResp.Modules {
+			require.NotEqual(t, "git-clone", m.ID,
+				"git-clone should be excluded for the quickstart base")
+		}
+
+		dockerResp, err := client.TemplateBuilderModules(ctx, "docker")
+		require.NoError(t, err)
+		var dockerHasGitClone bool
+		for _, m := range dockerResp.Modules {
+			if m.ID == "git-clone" {
+				dockerHasGitClone = true
+				break
+			}
+		}
+		require.True(t, dockerHasGitClone,
+			"git-clone should remain available for bases that do not bundle it")
+	})
+
 	t.Run("ComputedVariablesExcluded", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, nil)

--- a/coderd/templatebuilder_handler_test.go
+++ b/coderd/templatebuilder_handler_test.go
@@ -116,13 +116,33 @@ func TestTemplateBuilderBases(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, resp.Bases)
 
-		// The Coder Quickstart base is pinned first as the recommended
-		// starting point; the remaining bases are sorted by name.
-		require.Equal(t, "quickstart", resp.Bases[0].ID,
-			"quickstart base should be pinned first")
-		for i := 2; i < len(resp.Bases); i++ {
-			require.LessOrEqual(t, resp.Bases[i-1].Name, resp.Bases[i].Name,
-				"bases after quickstart should be sorted by name")
+		// The Coder Quickstart base is grouped immediately before the Docker
+		// base; every other base is ordered alphabetically by name.
+		quickstartIdx, dockerIdx := -1, -1
+		for i, b := range resp.Bases {
+			switch b.ID {
+			case "quickstart":
+				quickstartIdx = i
+			case "docker":
+				dockerIdx = i
+			}
+		}
+		require.NotEqual(t, -1, quickstartIdx, "quickstart base should be present")
+		require.NotEqual(t, -1, dockerIdx, "docker base should be present")
+		require.Equal(t, dockerIdx-1, quickstartIdx,
+			"quickstart base should be immediately before the docker base")
+
+		// The remaining bases (excluding quickstart) are sorted by name.
+		var names []string
+		for _, b := range resp.Bases {
+			if b.ID == "quickstart" {
+				continue
+			}
+			names = append(names, b.Name)
+		}
+		for i := 1; i < len(names); i++ {
+			require.LessOrEqual(t, names[i-1], names[i],
+				"non-quickstart bases should be sorted by name")
 		}
 	})
 

--- a/site/src/pages/TemplateBuilder/BaseInfraSelectStep.tsx
+++ b/site/src/pages/TemplateBuilder/BaseInfraSelectStep.tsx
@@ -7,6 +7,7 @@ import {
 	TemplateBuilderSubtitle,
 	TemplateBuilderTitle,
 } from "#/pages/TemplateBuilder/TemplateBuilderHeader";
+import { sortByPriority } from "./sortByPriority";
 import { TemplateCard } from "./TemplateCard";
 import { type SelectedBaseMeta, toSelectedBaseMeta } from "./wizardState";
 
@@ -18,6 +19,12 @@ interface BaseInfraSelectStepProps {
 function detailsUrl(baseId: string): string {
 	return `https://registry.coder.com/templates/${baseId}`;
 }
+
+// Preferred display order for base templates. Bases listed here appear first, in
+// this order; unlisted bases follow in the order the API returns them (sorted by
+// display name). Quickstart and Docker are the featured Docker-based starters,
+// mirroring the client-side module prioritization in ModuleSelectStep.
+const BASE_PRIORITY: readonly string[] = ["quickstart", "docker"];
 
 export const BaseInfraSelectStep: FC<BaseInfraSelectStepProps> = ({
 	selectedBaseId,
@@ -33,7 +40,7 @@ export const BaseInfraSelectStep: FC<BaseInfraSelectStepProps> = ({
 		return <ErrorAlert error={error} />;
 	}
 
-	const bases = data?.bases ?? [];
+	const bases = sortByPriority(data?.bases ?? [], BASE_PRIORITY);
 
 	return (
 		<div role="radiogroup" aria-label="Base infrastructure templates">

--- a/site/src/pages/TemplateBuilder/ModuleSelectStep.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleSelectStep.tsx
@@ -18,6 +18,7 @@ import {
 	TemplateBuilderTitle,
 } from "#/pages/TemplateBuilder/TemplateBuilderHeader";
 import { ModuleCard } from "./ModuleCard";
+import { sortByPriority } from "./sortByPriority";
 import {
 	moduleHasConfigurableVars,
 	type SelectedModuleMeta,
@@ -90,19 +91,6 @@ const MODULE_PRIORITY: readonly string[] = [
 	"filebrowser",
 	"kasmvnc",
 ];
-
-function sortByPriority<T extends { id: string }>(
-	items: readonly T[],
-	priority: readonly string[],
-): T[] {
-	const indexMap = new Map(priority.map((id, i) => [id, i]));
-	const fallback = priority.length;
-	return [...items].sort((a, b) => {
-		const ai = indexMap.get(a.id) ?? fallback;
-		const bi = indexMap.get(b.id) ?? fallback;
-		return ai - bi;
-	});
-}
 
 export const ModuleSelectStep: FC<ModuleSelectStepProps> = ({
 	baseId,

--- a/site/src/pages/TemplateBuilder/sortByPriority.test.ts
+++ b/site/src/pages/TemplateBuilder/sortByPriority.test.ts
@@ -1,0 +1,58 @@
+import { sortByPriority } from "./sortByPriority";
+
+describe("sortByPriority", () => {
+	it("moves prioritized ids to the front in priority order", () => {
+		const items = [
+			{ id: "aws-linux" },
+			{ id: "docker" },
+			{ id: "kubernetes" },
+			{ id: "quickstart" },
+		];
+		const sorted = sortByPriority(items, ["quickstart", "docker"]);
+		expect(sorted.map((item) => item.id)).toEqual([
+			"quickstart",
+			"docker",
+			"aws-linux",
+			"kubernetes",
+		]);
+	});
+
+	it("keeps unlisted items in their original relative order", () => {
+		const items = [{ id: "b" }, { id: "a" }, { id: "c" }];
+		const sorted = sortByPriority(items, []);
+		expect(sorted.map((item) => item.id)).toEqual(["b", "a", "c"]);
+	});
+
+	it("orders prioritized items first and is stable among the unlisted", () => {
+		const items = [
+			{ id: "first-unlisted" },
+			{ id: "docker" },
+			{ id: "second-unlisted" },
+			{ id: "quickstart" },
+		];
+		const sorted = sortByPriority(items, ["quickstart", "docker"]);
+		expect(sorted.map((item) => item.id)).toEqual([
+			"quickstart",
+			"docker",
+			"first-unlisted",
+			"second-unlisted",
+		]);
+	});
+
+	it("ignores priority ids that are not present in items", () => {
+		const items = [{ id: "a" }, { id: "quickstart" }];
+		const sorted = sortByPriority(items, ["missing", "quickstart"]);
+		expect(sorted.map((item) => item.id)).toEqual(["quickstart", "a"]);
+	});
+
+	it("does not mutate the input array", () => {
+		const items = [{ id: "docker" }, { id: "quickstart" }];
+		const snapshot = items.map((item) => item.id);
+		sortByPriority(items, ["quickstart"]);
+		expect(items.map((item) => item.id)).toEqual(snapshot);
+	});
+
+	it("returns an empty array unchanged", () => {
+		expect(sortByPriority([], ["quickstart"])).toEqual([]);
+	});
+});

--- a/site/src/pages/TemplateBuilder/sortByPriority.ts
+++ b/site/src/pages/TemplateBuilder/sortByPriority.ts
@@ -1,0 +1,16 @@
+// sortByPriority returns a new array ordered so that items whose id appears in
+// `priority` come first, in the order given by `priority`. Items not listed keep
+// their original relative order after the prioritized ones. Array.prototype.sort
+// is stable, so equal-priority items are never reordered relative to each other.
+export function sortByPriority<T extends { id: string }>(
+	items: readonly T[],
+	priority: readonly string[],
+): T[] {
+	const indexMap = new Map(priority.map((id, i) => [id, i]));
+	const fallback = priority.length;
+	return [...items].sort((a, b) => {
+		const ai = indexMap.get(a.id) ?? fallback;
+		const bi = indexMap.get(b.id) ?? fallback;
+		return ai - bi;
+	});
+}


### PR DESCRIPTION
## Summary

Adds the **Coder Quickstart** template as a selectable base in the [template builder](coderd/templatebuilder) guided wizard. It is a Docker-based starter that lets a user pick languages and optionally clone a repo.

## What changed

- **New base package** `coderd/templatebuilder/bases/quickstart/`:
  - `base.json`: `id: "quickstart"`, `display_name: "Coder Quickstart"`, `os: "linux"`.
  - `main.tf.tmpl`: a Docker workspace with a language selector, a single language-install script, an optional Git clone, and workspace presets. Editors are added via the builder's module step rather than baked into the base.
  - `install-languages.sh.tftpl` and `README.md` (with prerequisites markers so the builder can extract the prerequisites section).
- **Placement**: the bases endpoint returns a plain list sorted by display name (with ID as a deterministic tiebreak). The wizard's base-infra select step prioritizes the Quickstart and Docker starters to the front on the client, mirroring the existing client-side module prioritization in `ModuleSelectStep` (shared `sortByPriority` helper).
- **Base/module collision guard**: a base's bundled catalog modules are derived from its rendered Terraform (`ExtractModuleNames`, cached with `sync.OnceValues` and filtered to catalog IDs). `validateModules` seeds its seen-set from that derived set, so a wizard-selected module the base already renders is rejected with a clear error, and the modules endpoint omits it so the wizard never offers a colliding module. The base's Terraform is the single source of truth, so there is no separate manifest list that can drift.

## Testing

- `go test ./coderd/` (template builder handler: bases ordering, the `baseSpec` table, the modules-endpoint base filter): pass.
- `go test ./coderd/templatebuilder/` (all-bases render/snapshot, the collision guard, `TestBaseIncludedModules`, the selector/install-script drift test): pass.
- `gofmt`, `go vet`, `golangci-lint`: clean.
- Frontend `tsc`, `biome`, and `knip`: clean.

## Review decisions

- **Template scope**: trimmed to infrastructure, a language selector, and an optional Git clone. The IDE selector was removed; editors are added via the builder's module step.
- **Placement**: base ordering is presentational, so it lives on the client base-infra select step rather than in the API.
- **git-clone in the base**: kept for the build-time clone affordance. The base renders its module source verbatim, so it currently pins the public registry and does not yet honor a deployment's registry mirror; that fix is tracked in DOCS-610 and delivered as a stacked follow-up PR (an in-code note documents the current behavior).
- **Container image**: left hardcoded (`codercom/enterprise-base:ubuntu`). The quickstart base is the opinionated path; the Docker base covers custom images. Revisiting a `container_image` variable is tracked in DOCS-611.

## Review updates (@jeremyruppel)

- **Ordering moved to the client**: deleted the server-side Quickstart-before-Docker grouping (and its position test); the base-infra select step now prioritizes bases client-side via a shared `sortByPriority` helper, following the `ModuleSelectStep` precedent. The API just returns a stable, name-sorted list.
- **Derive included modules from render**: dropped the `included_modules` manifest field and the `IncludedModules` struct field; `BaseIncludedModules` now derives from the rendered base (single source of truth). Removed `TestBaseIncludedModulesMatchRendered` and added a direct `TestBaseIncludedModules`.
- **Kept the PR scoped to "add quickstart base"**: reverted `ExtractAgentResourceName`/`ExtractModuleNames` to the pre-`hclsyntax` regex extraction and removed the option/preset HCL extractor family; the selector↔install-script drift test now uses a small regex. The broader templatebuilder HCL migration and the preset-language subset guard are tracked in DOCS-735.
- Branch rebased onto `origin/main` (no content changes beyond the above).

---

Linear: [DOCS-558](https://linear.app/codercom/issue/DOCS-558/add-coder-quickstart-template-to-template-builder)

> This PR was created with AI assistance (Coder Agents).
