### PR TITLE
feat: gate workspace ACL grants on matching member capability

### DIFF
--- a/coderd/rbac/POLICY.md
+++ b/coderd/rbac/POLICY.md
@@ -87,6 +87,41 @@ For example, you may have a scope like...
 
 The final policy decision is determined by evaluating each of these checks in their proper precedence order from the `allow` rule.
 
+## ACL capability precondition
+
+Conceptually, the precondition is a subject-side mask over incoming ACL
+grants: ACL entries describe what other subjects have granted *to* you,
+and the mask decides which of them apply. It is per-action and
+deliberately member-scoped, because it is a statement about the subject
+in that org, not about any particular object. Role-derived access
+(site/org/member keys) is never masked; only the ACL path is.
+
+ACL grants on gated resource types only take effect per action: the
+subject must hold the granted action (or the wildcard) at the member
+level in the object's organization (`acl_use_precondition` /
+`acl_action_orgs`). A resource type is gated if and only if its policy
+permission definition sets `GatedACL`
+(`coderd/rbac/policy/policy.go`); the flag reaches the policy as the
+derived input field `input.object.acl_use_gated`, computed from the
+object type in Go (`rbac.ACLUseGated`), so it is known even in partial
+evaluations and no per-type rego edits are needed.
+
+Currently gated: `workspace` and `workspace_dormant`, whose member-level
+actions travel with the `organization-workspace-access` role (and, while
+`MinimumImplicitMember` is off, with the elevation bundled into
+`organization-member`). Revoking a subject's workspace access roles
+therefore also revokes any access they were granted through sharing,
+evaluated live on every authorization. A subject whose roles carry only
+some of an entry's actions receives partial effect. Org inclusion in
+`acl_action_orgs` follows standard vote semantics: a negated matching
+permission removes the org even when a positive grant exists.
+
+Types that are not gated (templates, chats) keep ACL-only grants:
+templates in particular rely on the Everyone-group ACL for baseline
+access. Opting a type in later is a one-line `GatedACL: true` on its
+permission definition, plus roles granting the member-level actions its
+recipients should be able to receive.
+
 ## Unknown values
 
 This policy is specifically constructed to compress to a set of queries if 'input.object.owner' and 'input.object.org_owner' are unknown. There is no specific set of rules that will guarantee that this policy has this property, however, there are some tricks. We have tests that enforce this property, so any changes that pass the tests will be okay.

--- a/coderd/rbac/astvalue.go
+++ b/coderd/rbac/astvalue.go
@@ -56,6 +56,14 @@ func regoPartialInputValue(subject Subject, action policy.Action, objectType str
 			[2]*ast.Term{
 				ast.StringTerm("type"),
 				ast.StringTerm(objectType),
+			},
+			// acl_use_gated is derived from the object type, so it is known
+			// even in partial evaluations. Including it here lets the ACL
+			// capability precondition resolve at prepare time instead of
+			// leaking into the residual queries.
+			[2]*ast.Term{
+				ast.StringTerm("acl_use_gated"),
+				ast.BooleanTerm(ACLUseGated(objectType)),
 			}),
 		),
 	}
@@ -131,6 +139,12 @@ func (z Object) regoValue() ast.Value {
 		[2]*ast.Term{
 			ast.StringTerm("type"),
 			ast.StringTerm(z.Type),
+		},
+		// acl_use_gated is derived from the object type via the policy
+		// action sets, not stored on the object. See ACLUseGated.
+		[2]*ast.Term{
+			ast.StringTerm("acl_use_gated"),
+			ast.BooleanTerm(ACLUseGated(z.Type)),
 		},
 		[2]*ast.Term{
 			ast.StringTerm("acl_user_list"),

--- a/coderd/rbac/authz_internal_test.go
+++ b/coderd/rbac/authz_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/open-policy-agent/opa/v1/rego"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -909,6 +910,114 @@ func TestAuthorizeACLCapabilityPrecondition(t *testing.T) {
 			allow:   true,
 		},
 	})
+}
+
+// TestAuthorizeACLGatedFieldAbsent evaluates the policy with raw JSON
+// input that omits the acl_use_gated object field, which every Go input
+// construction path normally injects. The precondition must then treat
+// every type as gated: ACL grants on ungated types are denied unless the
+// subject's member-level permissions carry the action, and grants on
+// gated types keep working for subjects whose permissions do. The field
+// being absent may narrow access but must never widen it.
+func TestAuthorizeACLGatedFieldAbsent(t *testing.T) {
+	t.Parallel()
+
+	query, err := rego.New(
+		rego.Query("data.authz.allow"),
+		rego.Module("policy.rego", regoPolicy),
+	).PrepareForEval(context.Background())
+	require.NoError(t, err)
+
+	// rawObject drops Object's MarshalJSON, so the encoded object carries
+	// only the struct fields and no acl_use_gated.
+	type rawObject Object
+
+	evalAllow := func(t *testing.T, subject Subject, action policy.Action, object any) bool {
+		t.Helper()
+		d, err := json.Marshal(map[string]any{
+			"subject": authSubject{
+				ID:     subject.ID,
+				Roles:  must(subject.Roles.Expand()),
+				Groups: subject.Groups,
+				Scope:  must(subject.Scope.Expand()),
+			},
+			"action": action,
+			"object": object,
+		})
+		require.NoError(t, err)
+		var input any
+		require.NoError(t, json.Unmarshal(d, &input))
+
+		results, err := query.Eval(context.Background(), rego.EvalInput(input))
+		require.NoError(t, err)
+		return results.Allowed()
+	}
+
+	orgID := uuid.New()
+	member := Subject{
+		ID:     "member",
+		Scope:  must(ExpandScope(ScopeAll)),
+		Groups: []string{},
+		Roles: Roles{
+			must(RoleByName(RoleMember())),
+			orgMemberRole(orgID),
+		},
+	}
+
+	// Template ACL grants require no role permissions because the type is
+	// ungated. The raw encoding must not contain the field; the guard
+	// below keeps the test honest if Object's encoding changes.
+	template := ResourceTemplate.InOrg(orgID).WithACLUserList(map[string][]policy.Action{
+		member.ID: {policy.ActionUpdate},
+	})
+	rawTemplate, err := json.Marshal(rawObject(template))
+	require.NoError(t, err)
+	require.NotContains(t, string(rawTemplate), "acl_use_gated")
+
+	// Control: with the field present (normal encoding), the ungated
+	// template ACL grant applies.
+	require.True(t, evalAllow(t, member, policy.ActionUpdate, template))
+	// With the field absent, the type is treated as gated and the member
+	// holds no template actions, so the same grant is denied.
+	require.False(t, evalAllow(t, member, policy.ActionUpdate, rawObject(template)))
+
+	// A gated type is unaffected by the field's absence when the subject
+	// holds the matching member-level action: the acl_action_orgs rule
+	// satisfies the precondition without consulting the field.
+	capable := Subject{
+		ID:     "capable",
+		Scope:  must(ExpandScope(ScopeAll)),
+		Groups: []string{},
+		Roles: Roles{
+			must(RoleByName(RoleMember())),
+			must(RoleByName(ScopedRoleOrgWorkspaceAccess(orgID))),
+		},
+	}
+	workspace := ResourceWorkspace.WithID(uuid.New()).InOrg(orgID).
+		WithOwner(uuid.NewString()).
+		WithACLUserList(map[string][]policy.Action{
+			capable.ID: {policy.ActionSSH},
+		})
+	require.True(t, evalAllow(t, capable, policy.ActionSSH, rawObject(workspace)))
+	// And a floor-only org member (no workspace actions at the member
+	// level) stays denied.
+	floor := Subject{
+		ID:     "floor",
+		Scope:  must(ExpandScope(ScopeAll)),
+		Groups: []string{},
+		Roles: Roles{
+			must(RoleByName(RoleMember())),
+			{
+				Identifier: RoleIdentifier{Name: "org-floor", OrganizationID: orgID},
+				ByOrgID: map[string]OrgPermissions{
+					orgID.String(): {},
+				},
+			},
+		},
+	}
+	require.False(t, evalAllow(t, floor, policy.ActionSSH, rawObject(workspace.WithACLUserList(map[string][]policy.Action{
+		floor.ID: {policy.ActionSSH},
+	}))))
 }
 
 // TestAuthorizeLevels ensures level overrides are acting appropriately

--- a/coderd/rbac/authz_internal_test.go
+++ b/coderd/rbac/authz_internal_test.go
@@ -1121,7 +1121,7 @@ func TestAuthorizeLevels(t *testing.T) {
 
 	testAuthorize(t, "OrgAllowAll", user,
 		cases(func(c authTestCase) authTestCase {
-			// SSH, app connect, and shared use are not implied here.
+			// SSH, app connect, and ACL-granted access are not implied here.
 			c.actions = slice.Omit(ResourceWorkspace.AvailableActions(), policy.ActionApplicationConnect, policy.ActionSSH)
 			return c
 		}, []authTestCase{

--- a/coderd/rbac/authz_internal_test.go
+++ b/coderd/rbac/authz_internal_test.go
@@ -817,6 +817,100 @@ func TestAuthorizeUserACLOrgMembership(t *testing.T) {
 	})
 }
 
+// TestAuthorizeACLCapabilityPrecondition runs the acl_use_precondition
+// through the testAuthorize harness, which exercises the direct, partial,
+// and SQL-compile evaluation paths. An ACL entry action on a gated type
+// only applies while the subject holds that same action at the member
+// level in the object's organization, so entries have per-action partial
+// effect.
+func TestAuthorizeACLCapabilityPrecondition(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	shared := ResourceWorkspace.WithID(uuid.New()).InOrg(orgID).WithOwner(uuid.NewString())
+
+	// Org member with no member-level permissions at all: no ACL entry
+	// action can match a held action.
+	floorMember := Subject{
+		ID:    "floor-member",
+		Scope: must(ExpandScope(ScopeAll)),
+		Roles: Roles{
+			must(RoleByName(RoleMember())),
+			{
+				Identifier: RoleIdentifier{Name: "org-floor", OrganizationID: orgID},
+				ByOrgID: map[string]OrgPermissions{
+					orgID.String(): {},
+				},
+			},
+		},
+	}
+	testAuthorize(t, "ACLNoCapability", floorMember, []authTestCase{
+		{
+			resource: shared.WithACLUserList(map[string][]policy.Action{
+				floorMember.ID: {policy.ActionSSH},
+			}),
+			actions: []policy.Action{policy.ActionSSH},
+			allow:   false,
+		},
+		{
+			// A wildcard ACL entry does not bypass the precondition.
+			resource: shared.WithACLUserList(map[string][]policy.Action{
+				floorMember.ID: {policy.WildcardSymbol},
+			}),
+			actions: []policy.Action{policy.ActionSSH},
+			allow:   false,
+		},
+	})
+
+	// Member whose roles carry only read: an entry granting read and ssh
+	// has partial effect. The read grant applies; the ssh grant does not.
+	readOnlyMember := Subject{
+		ID:    "read-only-member",
+		Scope: must(ExpandScope(ScopeAll)),
+		Roles: Roles{
+			must(RoleByName(RoleMember())),
+			{
+				Identifier: RoleIdentifier{Name: "org-read-only", OrganizationID: orgID},
+				ByOrgID: map[string]OrgPermissions{
+					orgID.String(): {
+						Member: []Permission{{
+							ResourceType: ResourceWorkspace.Type,
+							Action:       policy.ActionRead,
+						}},
+					},
+				},
+			},
+		},
+	}
+	readSSHEntry := shared.WithACLUserList(map[string][]policy.Action{
+		readOnlyMember.ID: {policy.ActionRead, policy.ActionSSH},
+	})
+	testAuthorize(t, "ACLPartialCapability", readOnlyMember, []authTestCase{
+		{resource: readSSHEntry, actions: []policy.Action{policy.ActionRead}, allow: true},
+		{resource: readSSHEntry, actions: []policy.Action{policy.ActionSSH}, allow: false},
+	})
+
+	// The workspace-access role carries every workspace action at the
+	// member level, so the full entry applies.
+	elevatedMember := Subject{
+		ID:    "elevated-member",
+		Scope: must(ExpandScope(ScopeAll)),
+		Roles: Roles{
+			must(RoleByName(RoleMember())),
+			must(RoleByName(ScopedRoleOrgWorkspaceAccess(orgID))),
+		},
+	}
+	testAuthorize(t, "ACLFullCapability", elevatedMember, []authTestCase{
+		{
+			resource: shared.WithACLUserList(map[string][]policy.Action{
+				elevatedMember.ID: {policy.ActionRead, policy.ActionSSH},
+			}),
+			actions: []policy.Action{policy.ActionRead, policy.ActionSSH},
+			allow:   true,
+		},
+	})
+}
+
 // TestAuthorizeLevels ensures level overrides are acting appropriately
 func TestAuthorizeLevels(t *testing.T) {
 	t.Parallel()
@@ -918,7 +1012,7 @@ func TestAuthorizeLevels(t *testing.T) {
 
 	testAuthorize(t, "OrgAllowAll", user,
 		cases(func(c authTestCase) authTestCase {
-			// SSH and app connect are not implied here.
+			// SSH, app connect, and shared use are not implied here.
 			c.actions = slice.Omit(ResourceWorkspace.AvailableActions(), policy.ActionApplicationConnect, policy.ActionSSH)
 			return c
 		}, []authTestCase{

--- a/coderd/rbac/object.go
+++ b/coderd/rbac/object.go
@@ -18,13 +18,10 @@ func ResourceUserObject(userID uuid.UUID) Object {
 	return ResourceUser.WithID(userID).WithOwner(userID.String())
 }
 
-// aclUseGatedTypes is the set of resource types whose ACL grants are
-// capability-gated: an ACL entry granting action X only takes effect
-// while the subject holds X (or the wildcard) at the member level in the
-// object's organization. A resource type opts in via GatedACL in its
-// policy permission definition; no policy.rego changes are required. The
-// flag is delivered to the rego policy as the derived input field
-// `input.object.acl_use_gated` (see astvalue.go).
+// aclUseGatedTypes is the set of resource types marked GatedACL in their
+// policy permission definition. The flag is delivered to the rego policy
+// as the derived input field `input.object.acl_use_gated` (see
+// astvalue.go); no per-type rego edits are required.
 var aclUseGatedTypes = func() map[string]struct{} {
 	gated := make(map[string]struct{})
 	for typeName, def := range policy.RBACPermissions {

--- a/coderd/rbac/object.go
+++ b/coderd/rbac/object.go
@@ -1,6 +1,7 @@
 package rbac
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync/atomic"
@@ -15,6 +16,31 @@ import (
 // ResourceUserObject is a helper function to create a user object for authz checks.
 func ResourceUserObject(userID uuid.UUID) Object {
 	return ResourceUser.WithID(userID).WithOwner(userID.String())
+}
+
+// aclUseGatedTypes is the set of resource types whose ACL grants are
+// capability-gated: an ACL entry granting action X only takes effect
+// while the subject holds X (or the wildcard) at the member level in the
+// object's organization. A resource type opts in via GatedACL in its
+// policy permission definition; no policy.rego changes are required. The
+// flag is delivered to the rego policy as the derived input field
+// `input.object.acl_use_gated` (see astvalue.go).
+var aclUseGatedTypes = func() map[string]struct{} {
+	gated := make(map[string]struct{})
+	for typeName, def := range policy.RBACPermissions {
+		if def.GatedACL {
+			gated[typeName] = struct{}{}
+		}
+	}
+	return gated
+}()
+
+// ACLUseGated returns true if ACL grants on objects of the given type
+// require the subject to hold the granted actions at the member level in
+// the object's organization.
+func ACLUseGated(objectType string) bool {
+	_, ok := aclUseGatedTypes[objectType]
+	return ok
 }
 
 // Object is used to create objects for authz checks when you have none in
@@ -40,6 +66,21 @@ type Object struct {
 
 	ACLUserList  map[string][]policy.Action ` json:"acl_user_list"`
 	ACLGroupList map[string][]policy.Action ` json:"acl_group_list"`
+}
+
+// MarshalJSON includes the derived acl_use_gated field so that generic
+// JSON-based rego inputs stay consistent with the AST fast path in
+// astvalue.go. The field is computed from the object type and never
+// stored.
+func (z Object) MarshalJSON() ([]byte, error) {
+	type alias Object
+	return json.Marshal(struct {
+		alias
+		ACLUseGated bool `json:"acl_use_gated"`
+	}{
+		alias:       alias(z),
+		ACLUseGated: ACLUseGated(z.Type),
+	})
 }
 
 // String is not perfect, but decent enough for human display

--- a/coderd/rbac/policy.rego
+++ b/coderd/rbac/policy.rego
@@ -331,17 +331,13 @@ object_is_included_in_scope_allow_list if {
 # acl_action_orgs is the set of organizations in which the subject holds
 # the requested action on the object's type at the member level. ACL
 # grants on gated resource types (input.object.acl_use_gated) only take
-# effect in these orgs: the subject may receive an action on others'
-# objects only where their roles grant that same action on their own.
-# Revoking the roles that carry an action therefore also revokes it on
-# everything shared with the subject. The member key is read directly
-# rather than through the org_member vote, so object ownership is
-# irrelevant. Each org's inclusion follows the same vote semantics as
-# the other levels: a matching negated permission removes the org even
-# when a positive grant exists. The set derives from subject roles, the
-# object type, and the action, all known at prepare time, keeping
-# unknown object attributes out of the comprehensions for partial
-# evaluation.
+# effect in these orgs. The member key is read directly rather than
+# through the org_member vote, so object ownership is irrelevant. Org
+# inclusion follows the same vote semantics as the other levels: a
+# matching negated permission removes the org even when a positive grant
+# exists. The set derives from subject roles, the object type, and the
+# action, all known at prepare time, keeping unknown object attributes
+# out of the comprehensions for partial evaluation.
 acl_action_orgs := {org_id |
 	org_id := org_memberships[_]
 	allow := {is_allowed |

--- a/coderd/rbac/policy.rego
+++ b/coderd/rbac/policy.rego
@@ -328,11 +328,55 @@ object_is_included_in_scope_allow_list if {
 # ACL rules                                                                    #
 #==============================================================================#
 
+# acl_action_orgs is the set of organizations in which the subject holds
+# the requested action on the object's type at the member level. ACL
+# grants on gated resource types (input.object.acl_use_gated) only take
+# effect in these orgs: the subject may receive an action on others'
+# objects only where their roles grant that same action on their own.
+# Revoking the roles that carry an action therefore also revokes it on
+# everything shared with the subject. The member key is read directly
+# rather than through the org_member vote, so object ownership is
+# irrelevant. Each org's inclusion follows the same vote semantics as
+# the other levels: a matching negated permission removes the org even
+# when a positive grant exists. The set derives from subject roles, the
+# object type, and the action, all known at prepare time, keeping
+# unknown object attributes out of the comprehensions for partial
+# evaluation.
+acl_action_orgs := {org_id |
+	org_id := org_memberships[_]
+	allow := {is_allowed |
+		perm := input.subject.roles[_].by_org_id[org_id].member[_]
+		perm.resource_type in [input.object.type, "*"]
+		perm.action in [input.action, "*"]
+		is_allowed := bool_flip(perm.negate)
+	}
+	to_vote(allow) == 1
+}
+
+# acl_use_precondition gates ACL grants on resource types marked GatedACL
+# in their policy permission definition. The flag is derived from the
+# object type in Go (rbac.ACLUseGated) and passed as a known input
+# field; every input construction path must supply it. Types that are
+# not gated rely on ACL-only grants by design and are unaffected.
+# The comparison is an explicit == false rather than a truthiness check:
+# when the field is absent this rule is undefined instead of true, and
+# only the acl_action_orgs rule below can satisfy the precondition. A
+# missing field therefore treats every type as gated (denying ACL
+# actions the subject's roles do not carry); it never widens access.
+acl_use_precondition if {
+	input.object.acl_use_gated == false
+}
+
+acl_use_precondition if {
+	input.object.org_owner in acl_action_orgs
+}
+
 # ACL for users
 acl_allow if {
 	# The subject must be a member of the object's organization for a
 	# user ACL grant to apply.
 	is_org_member
+	acl_use_precondition
 	perms := input.object.acl_user_list[input.subject.id]
 
 	# Check if either the action or * is allowed
@@ -345,6 +389,7 @@ acl_allow if {
 	# If there is no organization owner, the object cannot be owned by an
 	# org-scoped group.
 	is_org_member
+	acl_use_precondition
 	some group in input.subject.groups
 	perms := input.object.acl_group_list[group]
 
@@ -358,6 +403,7 @@ acl_allow if {
 	# If there is no organization owner, the object cannot be owned by an
 	# org-scoped group.
 	is_org_member
+	acl_use_precondition
 	perms := input.object.acl_group_list[input.object.org_owner]
 
 	# Check if either the action or * is allowed

--- a/coderd/rbac/policy/policy.go
+++ b/coderd/rbac/policy/policy.go
@@ -39,6 +39,12 @@ type PermissionDefinition struct {
 	// should represent. The key in the actions map is the verb to use
 	// in the rbac policy.
 	Actions map[Action]ActionDefinition
+	// GatedACL marks the resource type's ACL grants as capability-gated:
+	// an ACL entry granting action X only takes effect while the subject
+	// holds X (or the wildcard) at the member level in the object's
+	// organization. Ungated types rely on ACL-only grants (e.g. the
+	// template Everyone-group baseline).
+	GatedACL bool
 	// Comment is additional text to include in the generated object comment.
 	Comment string
 }
@@ -106,7 +112,8 @@ var RBACPermissions = map[string]PermissionDefinition{
 		},
 	},
 	"workspace": {
-		Actions: workspaceActions,
+		Actions:  workspaceActions,
+		GatedACL: true,
 	},
 	"task": {
 		Actions: taskActions,
@@ -116,7 +123,8 @@ var RBACPermissions = map[string]PermissionDefinition{
 	},
 	// Dormant workspaces have the same perms as workspaces.
 	"workspace_dormant": {
-		Actions: workspaceActions,
+		Actions:  workspaceActions,
+		GatedACL: true,
 	},
 	"prebuilt_workspace": {
 		// Prebuilt_workspace actions currently apply only to delete operations.

--- a/coderd/rbac/roles_internal_test.go
+++ b/coderd/rbac/roles_internal_test.go
@@ -149,7 +149,8 @@ func TestRegoInputValue(t *testing.T) {
 			},
 			"action": action,
 			"object": map[string]any{
-				"type": obj.Type,
+				"type":          obj.Type,
+				"acl_use_gated": ACLUseGated(obj.Type),
 			},
 		}
 

--- a/coderd/rbac/roles_test.go
+++ b/coderd/rbac/roles_test.go
@@ -167,6 +167,64 @@ func TestChatSharingPermissions(t *testing.T) {
 	})
 }
 
+// TestACLActionNegation verifies that acl_action_orgs follows vote
+// semantics: a negated member-level permission for an action removes the
+// org from the set for that action even when a positive grant exists, so
+// ACL-granted access to that action is denied while other granted
+// actions keep working.
+func TestACLActionNegation(t *testing.T) {
+	t.Parallel()
+
+	auth := rbac.NewStrictAuthorizer(prometheus.NewRegistry())
+	orgID := uuid.New()
+	userID := uuid.New()
+
+	workspaceAccess, err := rbac.RoleByName(rbac.ScopedRoleOrgWorkspaceAccess(orgID))
+	require.NoError(t, err)
+
+	negation := rbac.Role{
+		Identifier: rbac.RoleIdentifier{Name: "ssh-ban", OrganizationID: orgID},
+		ByOrgID: map[string]rbac.OrgPermissions{
+			orgID.String(): {
+				Member: []rbac.Permission{{
+					Negate:       true,
+					ResourceType: rbac.ResourceWorkspace.Type,
+					Action:       policy.ActionSSH,
+				}},
+			},
+		},
+	}
+
+	shared := rbac.ResourceWorkspace.WithID(uuid.New()).InOrg(orgID).
+		WithOwner(uuid.NewString()).
+		WithACLUserList(map[string][]policy.Action{
+			userID.String(): {policy.ActionSSH, policy.ActionRead},
+		})
+
+	// With matching member-level actions, the ACL grant applies.
+	err = auth.Authorize(context.Background(), rbac.Subject{
+		ID:    userID.String(),
+		Roles: rbac.Roles{workspaceAccess},
+		Scope: rbac.ScopeAll,
+	}, policy.ActionSSH, shared)
+	require.NoError(t, err)
+
+	bannedSubject := rbac.Subject{
+		ID:    userID.String(),
+		Roles: rbac.Roles{workspaceAccess, negation},
+		Scope: rbac.ScopeAll,
+	}
+
+	// A negated member-level ssh permission vetoes the org for ssh, so
+	// the ACL ssh grant no longer applies.
+	err = auth.Authorize(context.Background(), bannedSubject, policy.ActionSSH, shared)
+	require.ErrorAs(t, err, &rbac.UnauthorizedError{})
+
+	// Other granted actions are unaffected by the ssh ban.
+	err = auth.Authorize(context.Background(), bannedSubject, policy.ActionRead, shared)
+	require.NoError(t, err)
+}
+
 //nolint:tparallel,paralleltest
 func TestOwnerExec(t *testing.T) {
 	owner := rbac.Subject{
@@ -463,6 +521,25 @@ func TestRolePermissions(t *testing.T) {
 			AuthorizeMap: map[bool][]hasAuthSubjects{
 				true:  {owner, orgWorkspaceAccessUser},
 				false: {setOtherOrg, setOrgNotMe, memberMe, agentsAccessUser, templateAdmin, userAdmin},
+			},
+		},
+		{
+			// A workspace owned by another org member, shared with
+			// currentUser through the ACL. Each granted action only takes
+			// effect for subjects holding that action at the member level
+			// in the org (acl_use_precondition), so revoking workspace
+			// access roles also revokes shared access.
+			Name:    "SharedWorkspaceACLUse",
+			Actions: []policy.Action{policy.ActionSSH, policy.ActionApplicationConnect},
+			Resource: rbac.ResourceWorkspace.WithID(workspaceID).InOrg(orgID).WithOwner(uuid.NewString()).WithACLUserList(map[string][]policy.Action{
+				currentUser.String(): {policy.ActionSSH, policy.ActionApplicationConnect},
+			}),
+			AuthorizeMap: map[bool][]hasAuthSubjects{
+				true: {owner, orgWorkspaceAccessUser},
+				false: {
+					setOtherOrg, setOrgNotMe, memberMe, agentsAccessUser,
+					templateAdmin, userAdmin,
+				},
 			},
 		},
 		{

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -2542,6 +2542,80 @@ func (api *API) patchWorkspaceACL(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	validErrs := acl.Validate(ctx, api.Database, WorkspaceACLUpdateValidator(req))
+
+	// ACL grants on workspaces are capability-gated: each granted action
+	// only takes effect while the recipient's roles carry that action at
+	// the member level in this organization (acl_use_precondition in the
+	// RBAC policy). Simulate the grant against the workspace's RBAC
+	// object with the proposed ACL entry attached and reject recipients
+	// for whom no granted action would authorize, so shares don't
+	// silently grant nothing. A recipient whose roles carry only some of
+	// the granted actions is accepted with partial effect, matching the
+	// per-action access-time enforcement.
+	//
+	// Group entries are intentionally not validated here: group membership
+	// changes after the share, so eligibility is enforced per-member at
+	// access time only. A share to a group whose members all lack the
+	// granted actions is accepted and grants nothing until a member gains
+	// them.
+	for idStr, role := range req.UserRoles {
+		if role == codersdk.WorkspaceRoleDeleted {
+			continue
+		}
+		id, err := uuid.Parse(idStr)
+		if err != nil {
+			// acl.Validate reports malformed IDs.
+			continue
+		}
+		// UserRBACSubject resolves roles for soft-deleted users too, so
+		// check existence the same way acl.Validate does; it already
+		// reported nonexistent users and a capability error for them
+		// would be misleading noise.
+		//nolint:gocritic // Existence and role resolution for the
+		// recipient require system access; the requester's own
+		// authorization was already enforced on the workspace above.
+		existence, err := api.Database.ValidateUserIDs(dbauthz.AsSystemRestricted(ctx), []uuid.UUID{id})
+		if err == nil && !existence.Ok {
+			continue
+		}
+		if err != nil {
+			validErrs = append(validErrs, codersdk.ValidationError{
+				Field:  "user_roles",
+				Detail: fmt.Sprintf("could not verify workspace access for user %q", idStr),
+			})
+			continue
+		}
+		//nolint:gocritic // See above.
+		subject, _, err := httpmw.UserRBACSubject(dbauthz.AsSystemRestricted(ctx), api.Database, id, rbac.ScopeAll)
+		if err != nil {
+			// The user exists but their roles could not be resolved.
+			// Fail closed: an unverifiable recipient must not produce a
+			// silently inert share.
+			validErrs = append(validErrs, codersdk.ValidationError{
+				Field:  "user_roles",
+				Detail: fmt.Sprintf("could not verify workspace access for user %q", idStr),
+			})
+			continue
+		}
+		actions := db2sdk.WorkspaceRoleActions(role)
+		simulated := workspace.RBACObject().WithACLUserList(map[string][]policy.Action{
+			idStr: actions,
+		})
+		effective := false
+		for _, action := range actions {
+			if api.Authorizer.Authorize(ctx, subject, action, simulated) == nil {
+				effective = true
+				break
+			}
+		}
+		if !effective {
+			validErrs = append(validErrs, codersdk.ValidationError{
+				Field:  "user_roles",
+				Detail: fmt.Sprintf("user %q does not have workspace access in this organization, so the workspace cannot be shared with them", idStr),
+			})
+		}
+	}
+
 	if len(validErrs) > 0 {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message:     "Invalid request to update workspace ACL",

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -1306,6 +1306,10 @@ func (api *API) putWorkspaceAutostart(rw http.ResponseWriter, r *http.Request) {
 		AutostartSchedule: dbSched,
 		NextStartAt:       nextStartAt,
 	})
+	if httpapi.Is404Error(err) {
+		httpapi.ResourceNotFound(rw)
+		return
+	}
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error updating workspace autostart schedule.",

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -2547,21 +2547,17 @@ func (api *API) patchWorkspaceACL(rw http.ResponseWriter, r *http.Request) {
 
 	validErrs := acl.Validate(ctx, api.Database, WorkspaceACLUpdateValidator(req))
 
-	// ACL grants on workspaces are capability-gated: each granted action
-	// only takes effect while the recipient's roles carry that action at
-	// the member level in this organization (acl_use_precondition in the
-	// RBAC policy). Simulate the grant against the workspace's RBAC
-	// object with the proposed ACL entry attached and reject recipients
-	// for whom no granted action would authorize, so shares don't
-	// silently grant nothing. A recipient whose roles carry only some of
-	// the granted actions is accepted with partial effect, matching the
-	// per-action access-time enforcement.
+	// ACL grants on workspaces only take effect per action while the
+	// recipient's member-level permissions in this organization carry
+	// that action (acl_use_precondition in the RBAC policy). Simulate
+	// the grant against the workspace's RBAC object with the proposed
+	// entry attached and reject recipients for whom no granted action
+	// would authorize, so shares don't silently grant nothing. Partial
+	// capability is accepted with partial effect.
 	//
-	// Group entries are intentionally not validated here: group membership
-	// changes after the share, so eligibility is enforced per-member at
-	// access time only. A share to a group whose members all lack the
-	// granted actions is accepted and grants nothing until a member gains
-	// them.
+	// Group entries are not validated here: group membership changes
+	// after the share, so eligibility is enforced per-member at access
+	// time only.
 	for idStr, role := range req.UserRoles {
 		if role == codersdk.WorkspaceRoleDeleted {
 			continue

--- a/coderd/workspaces_internal_test.go
+++ b/coderd/workspaces_internal_test.go
@@ -1,0 +1,37 @@
+package coderd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database/db2sdk"
+	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
+	"github.com/coder/coder/v2/coderd/util/slice"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func TestConvertToWorkspaceRole(t *testing.T) {
+	t.Parallel()
+
+	// Round-trip: the exact action sets produced for each role must
+	// resolve back to that role.
+	require.Equal(t, codersdk.WorkspaceRoleAdmin,
+		convertToWorkspaceRole(db2sdk.WorkspaceRoleActions(codersdk.WorkspaceRoleAdmin)))
+	require.Equal(t, codersdk.WorkspaceRoleUse,
+		convertToWorkspaceRole(db2sdk.WorkspaceRoleActions(codersdk.WorkspaceRoleUse)))
+
+	// Stored admin ACL entries never contain delete. This derivation must
+	// stay an exact-set match for WorkspaceRoleAdmin: if
+	// WorkspaceRoleActions ever drops or gains an action, stored entries
+	// would stop matching and degrade to WorkspaceRoleDeleted.
+	storedAdmin := slice.Omit(rbac.ResourceWorkspace.AvailableActions(),
+		policy.ActionDelete)
+	require.Equal(t, codersdk.WorkspaceRoleAdmin, convertToWorkspaceRole(storedAdmin))
+
+	// Action sets matching no role resolve to deleted.
+	require.Equal(t, codersdk.WorkspaceRoleDeleted,
+		convertToWorkspaceRole([]policy.Action{policy.ActionRead}))
+	require.Equal(t, codersdk.WorkspaceRoleDeleted, convertToWorkspaceRole(nil))
+}

--- a/enterprise/coderd/license/usercount.go
+++ b/enterprise/coderd/license/usercount.go
@@ -13,15 +13,16 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/rbac"
-	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/coderd/rbac/rolestore"
 )
 
 // CountWorkspaceCapableUsers returns the number of active users the RBAC
-// engine authorizes to create a workspace, either in one of the
-// organizations they belong to or in any organization via a site-wide
-// role such as owner. System users and service accounts are excluded by
-// the underlying query, matching GetActiveUserCount.
+// engine authorizes to use workspaces: creating one of their own, or
+// holding any workspace action that makes ACL shares granting it
+// effective, either in one of the organizations they belong to or in any
+// organization via a site-wide role such as owner. System users and
+// service accounts are excluded by the underlying query, matching
+// GetActiveUserCount.
 func CountWorkspaceCapableUsers(ctx context.Context, logger slog.Logger, db database.Store, authorizer rbac.Authorizer) (int64, error) {
 	start := time.Now()
 
@@ -54,9 +55,9 @@ func CountWorkspaceCapableUsers(ctx context.Context, logger slog.Logger, db data
 		sig := authorizationSignature(row)
 		capable, ok := capableBySignature[sig]
 		if !ok {
-			capable, err = canCreateWorkspace(ctx, logger, db, authorizer, row)
+			capable, err = canUseWorkspaces(ctx, logger, db, authorizer, row)
 			if err != nil {
-				return 0, xerrors.Errorf("evaluate workspace-create for user %s: %w", row.ID, err)
+				return 0, xerrors.Errorf("evaluate workspace capability for user %s: %w", row.ID, err)
 			}
 			capableBySignature[sig] = capable
 		}
@@ -76,15 +77,25 @@ func CountWorkspaceCapableUsers(ctx context.Context, logger slog.Logger, db data
 	return count, nil
 }
 
-// canCreateWorkspace reports whether the RBAC engine authorizes the user
-// to create a workspace they own, checked against every organization the
-// user is a member of plus the any-organization form that site-wide roles
-// satisfy regardless of org membership.
-func canCreateWorkspace(ctx context.Context, logger slog.Logger, db database.Store, authorizer rbac.Authorizer, row database.GetActiveUsersAuthorizationRolesRow) (bool, error) {
+// workspaceCapableActions are the actions whose grant makes a user
+// workspace-capable for seat counting: the full workspace action set.
+// ActionCreate covers owning workspaces. Any other member-level action
+// makes ACL shares granting it effective, since the policy gates each
+// shared action on the recipient holding that same action. All are
+// probed on an object owned by the user themselves so that member-level
+// org permissions apply, the same level the ACL precondition reads.
+var workspaceCapableActions = rbac.ResourceWorkspace.AvailableActions()
+
+// canUseWorkspaces reports whether the RBAC engine authorizes the user
+// for any workspace-capable action on a workspace they own, checked
+// against every organization the user is a member of plus the
+// any-organization form that site-wide roles satisfy regardless of org
+// membership.
+func canUseWorkspaces(ctx context.Context, logger slog.Logger, db database.Store, authorizer rbac.Authorizer, row database.GetActiveUsersAuthorizationRolesRow) (bool, error) {
 	roleNames, err := row.RoleNames()
 	if err != nil {
 		// A stored role string that fails to parse grants nothing:
-		// authorization fails closed on it, so this user cannot create a
+		// authorization fails closed on it, so this user cannot use a
 		// workspace. Treat the user as not capable instead of failing the
 		// entire count. Logged once per unique role set due to the
 		// signature dedupe.
@@ -112,12 +123,14 @@ func canCreateWorkspace(ctx context.Context, logger slog.Logger, db database.Sto
 		Scope: rbac.ScopeAll,
 	}.WithCachedASTValue()
 
-	// Site-wide grants (e.g. the owner role) authorize workspace creation
-	// in any organization, independent of org membership. This also covers
+	// Site-wide grants (e.g. the owner role) authorize workspace use in
+	// any organization, independent of org membership. This also covers
 	// users who belong to zero organizations.
-	if authorizer.Authorize(ctx, subject, policy.ActionCreate,
-		rbac.ResourceWorkspace.AnyOrganization().WithOwner(subject.ID)) == nil {
-		return true, nil
+	for _, action := range workspaceCapableActions {
+		if authorizer.Authorize(ctx, subject, action,
+			rbac.ResourceWorkspace.AnyOrganization().WithOwner(subject.ID)) == nil {
+			return true, nil
+		}
 	}
 
 	seen := make(map[uuid.UUID]struct{})
@@ -130,9 +143,11 @@ func canCreateWorkspace(ctx context.Context, logger slog.Logger, db database.Sto
 			continue
 		}
 		seen[orgID] = struct{}{}
-		if authorizer.Authorize(ctx, subject, policy.ActionCreate,
-			rbac.ResourceWorkspace.InOrg(orgID).WithOwner(subject.ID)) == nil {
-			return true, nil
+		for _, action := range workspaceCapableActions {
+			if authorizer.Authorize(ctx, subject, action,
+				rbac.ResourceWorkspace.InOrg(orgID).WithOwner(subject.ID)) == nil {
+				return true, nil
+			}
 		}
 	}
 	return false, nil
@@ -140,7 +155,7 @@ func canCreateWorkspace(ctx context.Context, logger slog.Logger, db database.Sto
 
 // authorizationSignature returns a canonical key for the user's role set.
 // Two users with equal signatures are interchangeable for
-// workspace-create evaluation.
+// workspace-capability evaluation.
 func authorizationSignature(row database.GetActiveUsersAuthorizationRolesRow) string {
 	roles := make([]string, len(row.Roles))
 	copy(roles, row.Roles)

--- a/enterprise/coderd/license/usercount_test.go
+++ b/enterprise/coderd/license/usercount_test.go
@@ -23,8 +23,9 @@ import (
 )
 
 // TestCountWorkspaceCapableUsers verifies permission-based license seat
-// counting: only users the RBAC engine authorizes to create workspaces
-// consume seats, so members without workspace-create ("gateway accounts")
+// counting: only users the RBAC engine authorizes to use workspaces
+// (create their own, or hold member-level workspace actions that make
+// ACL shares effective) consume seats; members with neither capability
 // are excluded.
 //
 // The subtests toggle the global builtin roles via ReloadBuiltinRoles, so
@@ -126,8 +127,9 @@ func TestCountWorkspaceCapableUsers(t *testing.T) {
 		wsUser := activeUser(t, db, database.User{})
 		member(t, db, org.ID, wsUser, rbac.RoleOrgWorkspaceAccess())
 
-		// The creation ban negates workspace-create even when the
-		// workspace-access role is present. Not counted.
+		// The creation ban negates workspace-create, but not the other
+		// workspace actions: the user keeps their existing workspaces and
+		// can receive shares, so they still consume a seat.
 		banned := activeUser(t, db, database.User{})
 		member(t, db, org.ID, banned, rbac.RoleOrgWorkspaceAccess(), rbac.RoleOrgWorkspaceCreationBan())
 
@@ -147,7 +149,7 @@ func TestCountWorkspaceCapableUsers(t *testing.T) {
 
 		count, err := license.CountWorkspaceCapableUsers(ctx, testutil.Logger(t), db, authorizer)
 		require.NoError(t, err)
-		require.Equal(t, int64(4), count)
+		require.Equal(t, int64(5), count)
 	})
 
 	t.Run("MultiOrgSplitCapability", func(t *testing.T) {
@@ -213,6 +215,21 @@ func TestCountWorkspaceCapableUsers(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		// Member-key permissions are only storable on system roles
+		// (dbauthz customRoleCheck); this raw insert mirrors how such
+		// roles are provisioned.
+		sharedRole, err := db.InsertCustomRole(ctx, database.InsertCustomRoleParams{
+			Name:           "share-recipient",
+			DisplayName:    "Share Recipient",
+			OrganizationID: uuid.NullUUID{UUID: org.ID, Valid: true},
+			IsSystem:       true,
+			MemberPermissions: []database.CustomRolePermission{{
+				ResourceType: rbac.ResourceWorkspace.Type,
+				Action:       policy.ActionSSH,
+			}},
+		})
+		require.NoError(t, err)
+
 		// Custom org role with workspace-create. Counted.
 		creator := activeUser(t, db, database.User{})
 		member(t, db, org.ID, creator, creatorRole.Name)
@@ -221,9 +238,15 @@ func TestCountWorkspaceCapableUsers(t *testing.T) {
 		reader := activeUser(t, db, database.User{})
 		member(t, db, org.ID, reader, auditRole.Name)
 
+		// Role carrying only member-level ssh: ACL shares granting ssh
+		// are effective for the user, so they consume a seat even though
+		// they cannot create workspaces.
+		recipient := activeUser(t, db, database.User{})
+		member(t, db, org.ID, recipient, sharedRole.Name)
+
 		count, err := license.CountWorkspaceCapableUsers(ctx, testutil.Logger(t), db, authorizer)
 		require.NoError(t, err)
-		require.Equal(t, int64(1), count)
+		require.Equal(t, int64(2), count)
 	})
 
 	t.Run("MalformedRoleNotCounted", func(t *testing.T) {

--- a/enterprise/coderd/workspacesharing_test.go
+++ b/enterprise/coderd/workspacesharing_test.go
@@ -2,6 +2,7 @@ package coderd_test
 
 import (
 	"net/http"
+	"slices"
 	"testing"
 
 	"github.com/google/uuid"
@@ -511,4 +512,161 @@ func TestWorkspaceSharingDisabled(t *testing.T) {
 		require.Len(t, acl.Users, 1)
 		require.Equal(t, sharedUser.ID, acl.Users[0].ID)
 	})
+}
+
+// TestWorkspaceSharingDormancySurvivesACL asserts the DESIRED behavior
+// for shared workspaces that go dormant: ACL recipients keep access to
+// the dormant workspace (bounded by the dormant action set), an
+// admin-role recipient can wake it, and the list and direct-access
+// views agree.
+//
+// The test is skipped because DormantRBAC()
+// (coderd/database/modelmethods.go) currently attaches no ACLs, so ACL
+// recipients get 404 on direct access and on wake attempts while the
+// dormant workspace still appears in their list (the list filter is
+// prepared against the non-dormant workspace type and matches the
+// row's intact ACL columns). See
+// finding-dormant-workspace-acl-dropped.md in coder/scott-misc
+// rfcs/gateway-accounts. Remove the skip when DormantRBAC() carries
+// the workspace ACLs.
+func TestWorkspaceSharingDormancySurvivesACL(t *testing.T) {
+	t.Parallel()
+	t.Skip("known bug: DormantRBAC() drops ACLs; see finding-dormant-workspace-acl-dropped.md (scott-misc rfcs/gateway-accounts)")
+
+	client, db, owner := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
+		LicenseOptions: &coderdenttest.LicenseOptions{
+			Features: license.Features{
+				codersdk.FeatureMultipleOrganizations: 1,
+			},
+		},
+	})
+	ctx := testutil.Context(t, testutil.WaitMedium)
+
+	wsOwnerClient, wsOwner := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+	ws := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+		OwnerID:        wsOwner.ID,
+		OrganizationID: owner.OrganizationID,
+	}).Do().Workspace
+
+	recipientClient, recipient := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+
+	// Share with the admin role, the strongest ACL grant.
+	err := wsOwnerClient.UpdateWorkspaceACL(ctx, ws.ID, codersdk.UpdateWorkspaceACL{
+		UserRoles: map[string]codersdk.WorkspaceRole{
+			recipient.ID.String(): codersdk.WorkspaceRoleAdmin,
+		},
+	})
+	require.NoError(t, err)
+
+	// The recipient can access the active workspace.
+	_, err = recipientClient.Workspace(ctx, ws.ID)
+	require.NoError(t, err)
+
+	// The owner marks the workspace dormant.
+	err = wsOwnerClient.UpdateWorkspaceDormancy(ctx, ws.ID, codersdk.UpdateWorkspaceDormancy{Dormant: true})
+	require.NoError(t, err)
+
+	// The recipient keeps read access to the dormant workspace, matching
+	// what the list already shows them.
+	_, err = recipientClient.Workspace(ctx, ws.ID)
+	require.NoError(t, err)
+	listed, err := recipientClient.Workspaces(ctx, codersdk.WorkspaceFilter{})
+	require.NoError(t, err)
+	require.True(t, slices.ContainsFunc(listed.Workspaces, func(w codersdk.Workspace) bool {
+		return w.ID == ws.ID
+	}), "dormant shared workspace should appear in the recipient's list")
+
+	// An admin-role recipient holds update, so they can wake the
+	// workspace before the dormancy policy deletes it.
+	err = recipientClient.UpdateWorkspaceDormancy(ctx, ws.ID, codersdk.UpdateWorkspaceDormancy{Dormant: false})
+	require.NoError(t, err)
+
+	_, err = recipientClient.Workspace(ctx, ws.ID)
+	require.NoError(t, err)
+}
+
+// TestWorkspaceSharingCapabilityPrecondition verifies that workspace ACL
+// grants require the recipient's roles to carry the granted actions at
+// the member level in the workspace's organization: recipients with no
+// matching actions are rejected at share time, and losing the actions
+// later revokes the shared access even though the ACL entry remains.
+//
+// The recipient without capability is a member of a different org: the
+// same-org gateway-account scenario depends on the MinimumImplicitMember
+// experiment, whose rbac global is reset by any concurrently constructed
+// coderd test server, so it is covered deterministically by the rbac
+// package (TestAuthorizeACLCapabilityPrecondition) instead.
+func TestWorkspaceSharingCapabilityPrecondition(t *testing.T) {
+	t.Parallel()
+
+	client, db, owner := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
+		LicenseOptions: &coderdenttest.LicenseOptions{
+			Features: license.Features{
+				codersdk.FeatureMultipleOrganizations: 1,
+			},
+		},
+	})
+	ctx := testutil.Context(t, testutil.WaitMedium)
+
+	secondOrg := coderdenttest.CreateOrganization(t, client, coderdenttest.CreateOrganizationOptions{})
+
+	wsOwnerClient, wsOwner := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+	ws := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+		OwnerID:        wsOwner.ID,
+		OrganizationID: owner.OrganizationID,
+	}).Do().Workspace
+
+	// A member of another org holds no member-level workspace actions in
+	// the workspace's org.
+	_, otherOrgUser := coderdtest.CreateAnotherUser(t, client, secondOrg.ID)
+	fullClient, fullUser := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+
+	// Sharing with a recipient holding no workspace actions in this org
+	// is rejected at share time.
+	err := wsOwnerClient.UpdateWorkspaceACL(ctx, ws.ID, codersdk.UpdateWorkspaceACL{
+		UserRoles: map[string]codersdk.WorkspaceRole{
+			otherOrgUser.ID.String(): codersdk.WorkspaceRoleUse,
+		},
+	})
+	var apiErr *codersdk.Error
+	require.ErrorAs(t, err, &apiErr)
+	require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
+	require.Contains(t, apiErr.Message, "Invalid request to update workspace ACL")
+
+	// Sharing with a workspace-capable member succeeds and grants access.
+	err = wsOwnerClient.UpdateWorkspaceACL(ctx, ws.ID, codersdk.UpdateWorkspaceACL{
+		UserRoles: map[string]codersdk.WorkspaceRole{
+			fullUser.ID.String(): codersdk.WorkspaceRoleUse,
+		},
+	})
+	require.NoError(t, err)
+	_, err = fullClient.Workspace(ctx, ws.ID)
+	require.NoError(t, err)
+	// The list endpoint authorizes via the compiled SQL filter rather
+	// than per-object checks; the shared workspace must appear there too.
+	listed, err := fullClient.Workspaces(ctx, codersdk.WorkspaceFilter{})
+	require.NoError(t, err)
+	require.True(t, slices.ContainsFunc(listed.Workspaces, func(w codersdk.Workspace) bool {
+		return w.ID == ws.ID
+	}), "shared workspace should appear in the recipient's list")
+
+	// Removing the recipient from the organization removes their
+	// member-level actions there, revoking the shared access at
+	// authorization time; the ACL entry remains but is inert.
+	// Membership in the second org keeps the account otherwise valid.
+	_, err = client.PostOrganizationMember(ctx, secondOrg.ID, fullUser.ID.String())
+	require.NoError(t, err)
+	//nolint:gocritic // Only owners can remove org members.
+	err = client.DeleteOrganizationMember(ctx, owner.OrganizationID, fullUser.ID.String())
+	require.NoError(t, err)
+
+	_, err = fullClient.Workspace(ctx, ws.ID)
+	require.ErrorAs(t, err, &apiErr)
+	require.Equal(t, http.StatusNotFound, apiErr.StatusCode())
+	// The SQL filter must exclude it as well.
+	listed, err = fullClient.Workspaces(ctx, codersdk.WorkspaceFilter{})
+	require.NoError(t, err)
+	require.False(t, slices.ContainsFunc(listed.Workspaces, func(w codersdk.Workspace) bool {
+		return w.ID == ws.ID
+	}), "workspace should not appear in the list after the capability is revoked")
 }

--- a/enterprise/coderd/workspacesharing_test.go
+++ b/enterprise/coderd/workspacesharing_test.go
@@ -11,10 +11,12 @@ import (
 	"github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbfake"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/rbac/policy"
+	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
 	"github.com/coder/coder/v2/enterprise/coderd/license"
@@ -582,6 +584,99 @@ func TestWorkspaceSharingDormancySurvivesACL(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = recipientClient.Workspace(ctx, ws.ID)
+	require.NoError(t, err)
+}
+
+// TestWorkspaceSharingPartialCapability verifies that a share to a
+// recipient whose roles carry only some of the granted actions is
+// accepted, and that the entry then has per-action effect: actions the
+// recipient's member-level permissions carry work, the rest are denied
+// at access time.
+//
+// The partial recipient is a regular org member with a custom role that
+// negates workspace update at the member level. Negation is used instead
+// of the MinimumImplicitMember experiment because the experiment's rbac
+// global is reset by concurrently constructed coderd test servers.
+func TestWorkspaceSharingPartialCapability(t *testing.T) {
+	t.Parallel()
+
+	client, db, owner := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
+		LicenseOptions: &coderdenttest.LicenseOptions{
+			Features: license.Features{
+				codersdk.FeatureMultipleOrganizations: 1,
+			},
+		},
+	})
+	ctx := testutil.Context(t, testutil.WaitMedium)
+
+	wsOwnerClient, wsOwner := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+	ws := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+		OwnerID:        wsOwner.ID,
+		OrganizationID: owner.OrganizationID,
+	}).Do().Workspace
+
+	recipientClient, recipient := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+
+	// A member-level negation vetoes the org for that action in the ACL
+	// precondition, so the recipient's capability set is every workspace
+	// action except update. Member-key permissions are only storable on
+	// system roles (dbauthz customRoleCheck), so the ban is inserted as
+	// one, mirroring how workspace capability roles are provisioned.
+	//nolint:gocritic // Inserting the custom role directly requires system access.
+	sysCtx := dbauthz.AsSystemRestricted(ctx)
+	updateBan, err := db.InsertCustomRole(sysCtx, database.InsertCustomRoleParams{
+		Name:           "workspace-update-ban",
+		DisplayName:    "Workspace Update Ban",
+		OrganizationID: uuid.NullUUID{UUID: owner.OrganizationID, Valid: true},
+		IsSystem:       true,
+		MemberPermissions: []database.CustomRolePermission{{
+			Negate:       true,
+			ResourceType: rbac.ResourceWorkspace.Type,
+			Action:       policy.ActionUpdate,
+		}},
+	})
+	require.NoError(t, err)
+	_, err = db.UpdateMemberRoles(sysCtx, database.UpdateMemberRolesParams{
+		GrantedRoles: []string{updateBan.Name},
+		UserID:       recipient.ID,
+		OrgID:        owner.OrganizationID,
+	})
+	require.NoError(t, err)
+
+	// The admin role's action set includes update, which the recipient
+	// cannot receive. The share is still accepted because the remaining
+	// actions are effective.
+	err = wsOwnerClient.UpdateWorkspaceACL(ctx, ws.ID, codersdk.UpdateWorkspaceACL{
+		UserRoles: map[string]codersdk.WorkspaceRole{
+			recipient.ID.String(): codersdk.WorkspaceRoleAdmin,
+		},
+	})
+	require.NoError(t, err)
+
+	// Granted actions the recipient's roles carry are effective.
+	_, err = recipientClient.Workspace(ctx, ws.ID)
+	require.NoError(t, err)
+	listed, err := recipientClient.Workspaces(ctx, codersdk.WorkspaceFilter{})
+	require.NoError(t, err)
+	require.True(t, slices.ContainsFunc(listed.Workspaces, func(w codersdk.Workspace) bool {
+		return w.ID == ws.ID
+	}), "shared workspace should appear in the recipient's list")
+
+	// The banned action is denied at access time even though the ACL
+	// entry grants it. Autostart updates are gated on workspace update
+	// alone.
+	err = recipientClient.UpdateWorkspaceAutostart(ctx, ws.ID, codersdk.UpdateWorkspaceAutostartRequest{
+		Schedule: ptr.Ref("CRON_TZ=UTC 30 9 * * 1-5"),
+	})
+	var apiErr *codersdk.Error
+	require.ErrorAs(t, err, &apiErr)
+	require.Equal(t, http.StatusNotFound, apiErr.StatusCode())
+
+	// The workspace owner's own update capability is unaffected; the
+	// denial above is the recipient's negation, not an endpoint problem.
+	err = wsOwnerClient.UpdateWorkspaceAutostart(ctx, ws.ID, codersdk.UpdateWorkspaceAutostartRequest{
+		Schedule: ptr.Ref("CRON_TZ=UTC 30 9 * * 1-5"),
+	})
 	require.NoError(t, err)
 }
 

--- a/enterprise/coderd/workspacesharing_test.go
+++ b/enterprise/coderd/workspacesharing_test.go
@@ -523,17 +523,15 @@ func TestWorkspaceSharingDisabled(t *testing.T) {
 // views agree.
 //
 // The test is skipped because DormantRBAC()
-// (coderd/database/modelmethods.go) currently attaches no ACLs, so ACL
+// (coderd/database/modelmethods.go) currently attaches no ACLs: ACL
 // recipients get 404 on direct access and on wake attempts while the
-// dormant workspace still appears in their list (the list filter is
-// prepared against the non-dormant workspace type and matches the
-// row's intact ACL columns). See
-// finding-dormant-workspace-acl-dropped.md in coder/scott-misc
-// rfcs/gateway-accounts. Remove the skip when DormantRBAC() carries
-// the workspace ACLs.
+// dormant workspace still appears in their list, which is filtered
+// against the non-dormant workspace type and the row's intact ACL
+// columns. Remove the skip when DormantRBAC() carries the workspace
+// ACLs.
 func TestWorkspaceSharingDormancySurvivesACL(t *testing.T) {
 	t.Parallel()
-	t.Skip("known bug: DormantRBAC() drops ACLs; see finding-dormant-workspace-acl-dropped.md (scott-misc rfcs/gateway-accounts)")
+	t.Skip("known bug: DormantRBAC() attaches no ACLs, so shared access does not survive dormancy")
 
 	client, db, owner := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 		LicenseOptions: &coderdenttest.LicenseOptions{
@@ -686,11 +684,12 @@ func TestWorkspaceSharingPartialCapability(t *testing.T) {
 // matching actions are rejected at share time, and losing the actions
 // later revokes the shared access even though the ACL entry remains.
 //
-// The recipient without capability is a member of a different org: the
-// same-org gateway-account scenario depends on the MinimumImplicitMember
-// experiment, whose rbac global is reset by any concurrently constructed
-// coderd test server, so it is covered deterministically by the rbac
-// package (TestAuthorizeACLCapabilityPrecondition) instead.
+// The recipient without capability is a member of a different org: a
+// same-org member without workspace actions requires the
+// MinimumImplicitMember experiment, whose rbac global is reset by any
+// concurrently constructed coderd test server, so that scenario is
+// covered by the rbac package (TestAuthorizeACLCapabilityPrecondition)
+// instead.
 func TestWorkspaceSharingCapabilityPrecondition(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Gates workspace ACL entries on a per-action capability precondition: the rego policy only grants an ACL entry's action while the subject holds that same action (or the wildcard) at the member level in the object's organization. This prevents sharing workspaces with users who lack workspace capabilities (such as AI-Gateway-only accounts) and revokes shared access live when the capability is revoked, without deleting the ACL entry; regaining the capability restores the share. Subjects whose roles carry only some of an entry's actions receive partial effect.

There is no new action or schema change: the precondition matches the granted action itself against the recipient's member-level permissions ("you may receive X on others' workspaces only where your roles grant you X on your own"), so capability and receipt cannot drift apart. Design discussion and alternatives considered (binary `use_shared` sentinel, separate incoming-mask permission key, universal matching) are written up in coder-internal `scott-misc:rfcs/gateway-accounts/design-acl-capability-gating.md`; an earlier sentinel-based implementation is preserved on `scott/gateway-3-use-shared-v1`.

## Mechanism

Opt-in per type via an explicit `GatedACL bool` on the policy `PermissionDefinition`; no per-type rego edits. The flag is derived from the object type in Go (`rbac.ACLUseGated`) and passed as the input field `input.object.acl_use_gated`, using an explicit `== false` comparison so input paths that omit the field fail closed. Because `acl_action_orgs` depends only on subject roles, object type, and the action — all known at prepare time — the precondition resolves during partial evaluation and list-query SQL filters enforce it; residual queries and the regosql conversion are unaffected. The field is included in the AST fast path, the partial input, and `Object`'s JSON encoding so all input paths stay consistent.

Currently gated: `workspace` and `workspace_dormant`. Member-level workspace actions travel with `organization-workspace-access` and, while `MinimumImplicitMember` is off, with the elevation bundled into `organization-member`, so default deployments see no behavior change. `acl_action_orgs` follows standard vote semantics: a negated member-level permission for an action removes the org for that action even when a positive grant exists, while other granted actions keep working. Ungated types (templates, chats) keep ACL-only grants.

## API surface

- `PATCH /workspaces/:id/acl` validates user recipients by simulating the grant: each granted action is authorized against the workspace's RBAC object with the proposed entry attached, and recipients for whom no action would authorize are rejected with a validation error, so shares don't silently grant nothing. Partial capability is accepted with partial effect. Recipient existence and role resolution run as system and fail closed when roles cannot be resolved. Group entries are intentionally not validated at share time (membership changes after the share); eligibility is enforced per-member at access time.
- License seat counting (`user_limit` under permission-based licensing) counts users holding any member-level workspace action, since such users can operate workspaces shared with them even without workspace-create.

Includes a skipped desired-behavior test (`TestWorkspaceSharingDormancySurvivesACL`) documenting a pre-existing bug where `DormantRBAC()` drops ACLs; the precondition neither causes nor fixes it. Documented in `coderd/rbac/POLICY.md`.

Part of the gateway-accounts feature.

## Stack

Part 3 of the gateway-accounts stack. Each PR builds on the previous:

1. **#27279**: permission-based license seat counting. Behind the `permission-based-licensing` experiment and gated on the AI Governance add-on, `user_limit` counts only users the RBAC engine authorizes to create workspaces.
2. **#27280**: adds the `organization-ai-gateway-access` org role carrying the AI Bridge interception permissions (extracted from the member floors, backfilled into org default roles by migration) and enforces it at AI Gateway authentication; bridge usage stops claiming AI Governance seats under the experiment.
3. **#27281 (this PR)**: gates workspace ACL grants on matching member-level capability, so workspace sharing is ineffective for (and rejected toward) users without workspace capabilities, evaluated live on every authorization.

Related but independent: **#27278** hides the Workspaces page create CTAs for users without workspace-create permission.
