### PR TITLE
feat(site): collapsible sidebar navigation for deployment and AI settings

### DIFF
--- a/site/src/components/Sidebar/CollapsibleSidebar.tsx
+++ b/site/src/components/Sidebar/CollapsibleSidebar.tsx
@@ -82,7 +82,7 @@ export const CollapsibleSidebar: FC<CollapsibleSidebarProps> = ({
 				<div
 					ref={containerRef}
 					data-sidebar-container
-					className="relative flex-shrink-0 sticky top-0 h-screen w-16 z-30"
+					className="relative flex-shrink-0 sticky top-[72px] h-[calc(100vh-72px)] w-16 z-30"
 					onPointerDown={cancelPeek}
 				>
 					<div
@@ -116,7 +116,7 @@ export const CollapsibleSidebar: FC<CollapsibleSidebarProps> = ({
 			    lives here so it isn't clipped by overflow-hidden. */}
 			<div
 				data-sidebar-container
-				className="relative flex-shrink-0 sticky top-0 h-screen transition-[width] duration-150 ease-in-out"
+				className="relative flex-shrink-0 sticky top-[72px] h-[calc(100vh-72px)] transition-[width] duration-150 ease-in-out"
 				style={{ width }}
 			>
 				{/* Clipping container for the nav content. */}

--- a/site/src/components/Sidebar/CollapsibleSidebar.tsx
+++ b/site/src/components/Sidebar/CollapsibleSidebar.tsx
@@ -82,7 +82,7 @@ export const CollapsibleSidebar: FC<CollapsibleSidebarProps> = ({
 				<div
 					ref={containerRef}
 					data-sidebar-container
-					className="relative flex-shrink-0 sticky top-0 h-screen w-16"
+					className="relative flex-shrink-0 sticky top-0 h-screen w-16 z-30"
 					onPointerDown={cancelPeek}
 				>
 					<div

--- a/site/src/components/Sidebar/CollapsibleSidebar.tsx
+++ b/site/src/components/Sidebar/CollapsibleSidebar.tsx
@@ -1,4 +1,4 @@
-import { type FC, type ReactNode, useMemo } from "react";
+import { type FC, type ReactNode, useEffect, useMemo, useRef } from "react";
 import { cn } from "#/utils/cn";
 import { SidebarContext } from "./SidebarContext";
 import { SidebarResizeHandle } from "./SidebarResizeHandle";
@@ -8,20 +8,107 @@ interface CollapsibleSidebarProps {
 	children: ReactNode;
 	className?: string;
 	storageKey?: string;
+	/**
+	 * When set, the sidebar only occupies its collapsed width in
+	 * layout flow; the expanded panel renders as a flyout over the
+	 * adjacent content instead of pushing it. Clicking outside the
+	 * panel or pressing Escape collapses it.
+	 */
+	overlay?: boolean;
+	/**
+	 * When set, briefly expand the sidebar on mount to show the menu,
+	 * then auto-collapse. Skipped when the user previously left the
+	 * sidebar expanded. Only meaningful together with overlay.
+	 */
+	peekOnMount?: boolean;
 }
 
 export const CollapsibleSidebar: FC<CollapsibleSidebarProps> = ({
 	children,
 	className,
 	storageKey = "sidebar-width",
+	overlay = false,
+	peekOnMount = false,
 }) => {
-	const { width, collapsed, expand, toggle, onDragStart } =
-		useSidebarResize(storageKey);
+	const {
+		width,
+		collapsed,
+		expand,
+		collapse,
+		toggle,
+		cancelPeek,
+		onDragStart,
+	} = useSidebarResize(storageKey, { peekOnMount });
+	const containerRef = useRef<HTMLDivElement>(null);
 
 	const contextValue = useMemo(
-		() => ({ collapsed, expand, toggle }),
-		[collapsed, expand, toggle],
+		() => ({ collapsed, expand, collapse, toggle }),
+		[collapsed, expand, collapse, toggle],
 	);
+
+	// In overlay mode the expanded panel covers content, so dismiss it
+	// when the user clicks outside or presses Escape. Listeners are
+	// only attached while the overlay is expanded.
+	useEffect(() => {
+		if (!overlay || collapsed) {
+			return;
+		}
+
+		const handlePointerDown = (event: PointerEvent) => {
+			const container = containerRef.current;
+			if (container && !container.contains(event.target as Node)) {
+				collapse();
+			}
+		};
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (event.key === "Escape") {
+				collapse();
+			}
+		};
+
+		document.addEventListener("pointerdown", handlePointerDown);
+		document.addEventListener("keydown", handleKeyDown);
+		return () => {
+			document.removeEventListener("pointerdown", handlePointerDown);
+			document.removeEventListener("keydown", handleKeyDown);
+		};
+	}, [overlay, collapsed, collapse]);
+
+	if (overlay) {
+		return (
+			<SidebarContext.Provider value={contextValue}>
+				{/* The container holds only the collapsed rail width in
+				    layout flow; the panel expands over the content. */}
+				<div
+					ref={containerRef}
+					data-sidebar-container
+					className="relative flex-shrink-0 sticky top-0 h-screen w-16"
+					onPointerDown={cancelPeek}
+				>
+					<div
+						className={cn(
+							"absolute left-0 top-0 h-full z-20 overflow-hidden",
+							"bg-surface-primary transition-[width] duration-150 ease-in-out",
+							!collapsed &&
+								"border-0 border-r border-solid border-border shadow-lg",
+						)}
+						style={{ width }}
+					>
+						<nav
+							className={cn(
+								"h-full w-[240px] overflow-y-auto",
+								"flex flex-col",
+								"px-3 pt-6 pb-6",
+								className,
+							)}
+						>
+							{children}
+						</nav>
+					</div>
+				</div>
+			</SidebarContext.Provider>
+		);
+	}
 
 	return (
 		<SidebarContext.Provider value={contextValue}>

--- a/site/src/components/Sidebar/CollapsibleSidebar.tsx
+++ b/site/src/components/Sidebar/CollapsibleSidebar.tsx
@@ -1,0 +1,54 @@
+import { type FC, type ReactNode, useMemo } from "react";
+import { cn } from "#/utils/cn";
+import { SidebarContext } from "./SidebarContext";
+import { SidebarResizeHandle } from "./SidebarResizeHandle";
+import { useSidebarResize } from "./useSidebarResize";
+
+interface CollapsibleSidebarProps {
+	children: ReactNode;
+	className?: string;
+	storageKey?: string;
+}
+
+export const CollapsibleSidebar: FC<CollapsibleSidebarProps> = ({
+	children,
+	className,
+	storageKey = "sidebar-width",
+}) => {
+	const { width, collapsed, expand, toggle, onDragStart } =
+		useSidebarResize(storageKey);
+
+	const contextValue = useMemo(
+		() => ({ collapsed, expand, toggle }),
+		[collapsed, expand, toggle],
+	);
+
+	return (
+		<SidebarContext.Provider value={contextValue}>
+			{/* Non-clipping wrapper for positioning. The resize handle
+			    lives here so it isn't clipped by overflow-hidden. */}
+			<div
+				data-sidebar-container
+				className="relative flex-shrink-0 sticky top-0 h-screen transition-[width] duration-150 ease-in-out"
+				style={{ width }}
+			>
+				{/* Clipping container for the nav content. */}
+				<div className="h-full overflow-hidden">
+					<nav
+						className={cn(
+							"h-full w-[240px] overflow-y-auto",
+							"flex flex-col",
+							"px-3 pt-6 pb-6",
+							className,
+						)}
+					>
+						{children}
+					</nav>
+				</div>
+				{/* Handle sits outside the overflow-hidden div so
+				    its right half isn't clipped. */}
+				<SidebarResizeHandle onDragStart={onDragStart} />
+			</div>
+		</SidebarContext.Provider>
+	);
+};

--- a/site/src/components/Sidebar/SidebarAccordion.tsx
+++ b/site/src/components/Sidebar/SidebarAccordion.tsx
@@ -1,0 +1,104 @@
+import type { ElementType, FC, ReactNode } from "react";
+import { Link } from "react-router";
+import { ChevronDownIcon } from "#/components/AnimatedIcons/ChevronDown";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "#/components/Collapsible/Collapsible";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
+import { cn } from "#/utils/cn";
+import { useSidebarContext } from "./SidebarContext";
+
+interface SidebarAccordionProps {
+	icon: ElementType;
+	label: string;
+	children: ReactNode;
+	open: boolean;
+	onToggle: () => void;
+	/** URL to navigate to when clicking the icon in collapsed mode. */
+	href?: string;
+	/** Whether this section contains the current route. */
+	active?: boolean;
+}
+
+export const SidebarAccordion: FC<SidebarAccordionProps> = ({
+	icon: Icon,
+	label,
+	children,
+	open,
+	onToggle,
+	href,
+	active = false,
+}) => {
+	const { collapsed, expand } = useSidebarContext();
+
+	// Icon and label highlight when this section owns the current
+	// route, regardless of whether the accordion is expanded.
+	const iconClass = cn(
+		"size-4 flex-shrink-0 text-content-secondary",
+		active && "text-content-primary",
+	);
+	const labelClass = cn(
+		"text-sm font-medium text-content-secondary whitespace-nowrap",
+		active && "text-content-primary",
+	);
+
+	if (collapsed) {
+		return (
+			<TooltipProvider>
+				<Tooltip delayDuration={0}>
+					<TooltipTrigger asChild>
+						{href ? (
+							<Link
+								to={href}
+								onClick={expand}
+								className="flex items-center justify-center w-10 h-10 rounded-md no-underline hover:bg-surface-secondary"
+							>
+								<Icon className={iconClass} />
+							</Link>
+						) : (
+							<button
+								type="button"
+								onClick={() => {
+									expand();
+									onToggle();
+								}}
+								className="flex items-center justify-center w-10 h-10 rounded-md cursor-pointer bg-transparent border-none hover:bg-surface-secondary"
+							>
+								<Icon className={iconClass} />
+							</button>
+						)}
+					</TooltipTrigger>
+					<TooltipContent side="right">{label}</TooltipContent>
+				</Tooltip>
+			</TooltipProvider>
+		);
+	}
+
+	return (
+		<Collapsible open={open} onOpenChange={onToggle}>
+			<CollapsibleTrigger asChild>
+				<button
+					type="button"
+					className="flex w-full items-center gap-2 px-3 py-2 h-10 rounded-md cursor-pointer bg-transparent border-none hover:bg-surface-secondary transition-colors"
+				>
+					<Icon className={iconClass} />
+					<span className={labelClass}>{label}</span>
+					<ChevronDownIcon
+						open={open}
+						className="size-4 text-content-secondary ml-auto flex-shrink-0"
+					/>
+				</button>
+			</CollapsibleTrigger>
+			<CollapsibleContent>
+				<div className="pl-6">{children}</div>
+			</CollapsibleContent>
+		</Collapsible>
+	);
+};

--- a/site/src/components/Sidebar/SidebarContext.tsx
+++ b/site/src/components/Sidebar/SidebarContext.tsx
@@ -4,6 +4,8 @@ interface SidebarState {
 	collapsed: boolean;
 	/** Force the sidebar to expand. */
 	expand: () => void;
+	/** Force the sidebar to collapse. */
+	collapse: () => void;
 	/** Toggle collapsed/expanded state. */
 	toggle: () => void;
 }
@@ -11,6 +13,7 @@ interface SidebarState {
 export const SidebarContext = createContext<SidebarState>({
 	collapsed: false,
 	expand: () => {},
+	collapse: () => {},
 	toggle: () => {},
 });
 

--- a/site/src/components/Sidebar/SidebarContext.tsx
+++ b/site/src/components/Sidebar/SidebarContext.tsx
@@ -1,0 +1,17 @@
+import { createContext, useContext } from "react";
+
+interface SidebarState {
+	collapsed: boolean;
+	/** Force the sidebar to expand. */
+	expand: () => void;
+	/** Toggle collapsed/expanded state. */
+	toggle: () => void;
+}
+
+export const SidebarContext = createContext<SidebarState>({
+	collapsed: false,
+	expand: () => {},
+	toggle: () => {},
+});
+
+export const useSidebarContext = () => useContext(SidebarContext);

--- a/site/src/components/Sidebar/SidebarResizeHandle.tsx
+++ b/site/src/components/Sidebar/SidebarResizeHandle.tsx
@@ -1,0 +1,65 @@
+import { type FC, useCallback, useState } from "react";
+
+interface SidebarResizeHandleProps {
+	onDragStart: (e: React.PointerEvent) => undefined | (() => void);
+}
+
+/**
+ * An invisible hit area on the sidebar's right edge. On hover,
+ * a 2px line appears spanning the full height of the border.
+ * The line stays visible while dragging.
+ */
+export const SidebarResizeHandle: FC<SidebarResizeHandleProps> = ({
+	onDragStart,
+}) => {
+	const [hovered, setHovered] = useState(false);
+	const [dragging, setDragging] = useState(false);
+
+	const handleMouseEnter = useCallback(() => {
+		setHovered(true);
+	}, []);
+
+	const handleMouseLeave = useCallback(() => {
+		setHovered(false);
+	}, []);
+
+	const handlePointerDown = useCallback(
+		(e: React.PointerEvent) => {
+			setDragging(true);
+
+			const onPointerUp = () => {
+				setDragging(false);
+				setHovered(false);
+				document.removeEventListener("pointerup", onPointerUp);
+			};
+
+			document.addEventListener("pointerup", onPointerUp);
+			onDragStart(e);
+		},
+		[onDragStart],
+	);
+
+	const visible = hovered || dragging;
+
+	return (
+		<div
+			role="separator"
+			aria-label="Resize sidebar"
+			aria-valuenow={0}
+			tabIndex={0}
+			onPointerDown={handlePointerDown}
+			onMouseEnter={handleMouseEnter}
+			onMouseLeave={handleMouseLeave}
+			className="absolute top-0 -right-2 h-full w-4 cursor-col-resize z-10"
+		>
+			<div
+				className="absolute top-0 h-full w-[2px] rounded-full bg-border"
+				style={{
+					left: 7,
+					opacity: visible ? 1 : 0,
+					transition: "opacity 150ms",
+				}}
+			/>
+		</div>
+	);
+};

--- a/site/src/components/Sidebar/useSidebarResize.ts
+++ b/site/src/components/Sidebar/useSidebarResize.ts
@@ -1,0 +1,138 @@
+import { useCallback, useState } from "react";
+
+const EXPANDED_WIDTH = 240;
+// Icon center sits at nav-pl(12) + btn-px(12) + icon/2(8) = 32px.
+// Double that so the icon is horizontally centered when collapsed.
+const COLLAPSED_WIDTH = 64;
+
+function readCollapsed(key: string): boolean {
+	try {
+		return localStorage.getItem(key) === "collapsed";
+	} catch {
+		return false;
+	}
+}
+
+function persistCollapsed(key: string, collapsed: boolean): void {
+	try {
+		localStorage.setItem(key, collapsed ? "collapsed" : "expanded");
+	} catch {
+		// Silently ignore write failures.
+	}
+}
+
+interface UseSidebarResizeReturn {
+	width: number;
+	collapsed: boolean;
+	/** Force the sidebar to expand. */
+	expand: () => void;
+	/** Toggle collapsed/expanded state. */
+	toggle: () => void;
+	onDragStart: (e: React.PointerEvent) => () => void;
+}
+
+/**
+ * Two-state sidebar that drags smoothly by writing directly to the
+ * DOM during pointermove. A 3px dead zone distinguishes clicks from
+ * drags. Clicks toggle via React state (CSS transition animates),
+ * drags manipulate the DOM directly then snap on release.
+ */
+export function useSidebarResize(
+	storageKey = "sidebar-width",
+): UseSidebarResizeReturn {
+	const [collapsed, setCollapsed] = useState(() => readCollapsed(storageKey));
+
+	const expand = useCallback(() => {
+		setCollapsed(false);
+		persistCollapsed(storageKey, false);
+	}, [storageKey]);
+
+	const toggle = useCallback(() => {
+		setCollapsed((prev) => {
+			const next = !prev;
+			persistCollapsed(storageKey, next);
+			return next;
+		});
+	}, [storageKey]);
+
+	const onDragStart = useCallback(
+		(e: React.PointerEvent): (() => void) => {
+			e.preventDefault();
+
+			const container =
+				(e.currentTarget as HTMLElement).closest<HTMLElement>(
+					"[data-sidebar-container]",
+				) ?? (e.currentTarget as HTMLElement).parentElement;
+			if (!container) {
+				return () => {};
+			}
+
+			const startLeft = container.getBoundingClientRect().left;
+			const startWidth = container.getBoundingClientRect().width;
+			const startX = e.clientX;
+
+			const CLICK_DEAD_ZONE = 3;
+			let dragging = false;
+
+			const handlePointerMove = (moveEvent: PointerEvent) => {
+				const dx = Math.abs(moveEvent.clientX - startX);
+
+				if (!dragging && dx >= CLICK_DEAD_ZONE) {
+					dragging = true;
+					// Only kill the transition once we know it's a real
+					// drag, not a click. This keeps the CSS transition
+					// intact for click-to-toggle.
+					container.style.transition = "none";
+				}
+
+				if (dragging) {
+					const rawWidth = moveEvent.clientX - startLeft;
+					const clamped = Math.max(
+						COLLAPSED_WIDTH,
+						Math.min(rawWidth, EXPANDED_WIDTH),
+					);
+					container.style.width = `${clamped}px`;
+				}
+			};
+
+			const cleanup = () => {
+				document.removeEventListener("pointermove", handlePointerMove);
+				document.removeEventListener("pointerup", cleanup);
+				document.body.style.cursor = "";
+				document.body.style.userSelect = "";
+
+				if (!dragging) {
+					// Click: toggle via React state. The existing CSS
+					// transition on the container animates the change.
+					const next = !collapsed;
+					setCollapsed(next);
+					persistCollapsed(storageKey, next);
+				} else {
+					// Drag: snap based on direction.
+					const finalWidth = container.getBoundingClientRect().width;
+					const shouldCollapse = finalWidth < startWidth;
+					const snapWidth = shouldCollapse ? COLLAPSED_WIDTH : EXPANDED_WIDTH;
+
+					// Re-enable transition for the snap animation.
+					container.style.transition = "";
+					container.style.width = `${snapWidth}px`;
+
+					setCollapsed(shouldCollapse);
+					persistCollapsed(storageKey, shouldCollapse);
+				}
+			};
+
+			document.body.style.cursor = "col-resize";
+			document.body.style.userSelect = "none";
+			document.addEventListener("pointermove", handlePointerMove);
+			document.addEventListener("pointerup", cleanup);
+
+			return cleanup;
+		},
+		[collapsed, storageKey],
+	);
+
+	const width = collapsed ? COLLAPSED_WIDTH : EXPANDED_WIDTH;
+
+	return { width, collapsed, expand, toggle, onDragStart };
+}

--- a/site/src/components/Sidebar/useSidebarResize.ts
+++ b/site/src/components/Sidebar/useSidebarResize.ts
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useIsBelowLgViewport } from "#/hooks/useIsBelowLgViewport";
+import { isBelowLgViewport } from "#/utils/mobile";
 
 const EXPANDED_WIDTH = 240;
 // Icon center sits at nav-pl(12) + btn-px(12) + icon/2(8) = 32px.
@@ -61,8 +63,13 @@ export function useSidebarResize(
 	storageKey = "sidebar-width",
 	{ peekOnMount = false }: UseSidebarResizeOptions = {},
 ): UseSidebarResizeReturn {
-	const [collapsed, setCollapsed] = useState(() => readCollapsed(storageKey));
+	// Start collapsed on narrow viewports regardless of the persisted
+	// preference, so page content is not cut off on load.
+	const [collapsed, setCollapsed] = useState(
+		() => isBelowLgViewport() || readCollapsed(storageKey),
+	);
 	const peekTimerRef = useRef<number | undefined>(undefined);
+	const isNarrowViewport = useIsBelowLgViewport();
 
 	const cancelPeek = useCallback(() => {
 		if (peekTimerRef.current !== undefined) {
@@ -71,11 +78,35 @@ export function useSidebarResize(
 		}
 	}, []);
 
-	// Peek: expand on mount, then collapse after a delay. Skipped when
-	// the user explicitly left the sidebar expanded. Neither the
-	// expansion nor the auto-collapse is persisted.
+	// Auto-collapse when the viewport shrinks below the lg breakpoint
+	// and restore the persisted preference when it grows back. Forced
+	// collapses are environmental, not user choices, so they are never
+	// persisted. The ref limits this to actual crossings; the initial
+	// narrow state is handled by the state initializer above.
+	const prevNarrowRef = useRef(isNarrowViewport);
 	useEffect(() => {
-		if (!peekOnMount || readPersisted(storageKey) === "expanded") {
+		if (prevNarrowRef.current === isNarrowViewport) {
+			return;
+		}
+		prevNarrowRef.current = isNarrowViewport;
+		if (isNarrowViewport) {
+			cancelPeek();
+			setCollapsed(true);
+		} else {
+			setCollapsed(readCollapsed(storageKey));
+		}
+	}, [isNarrowViewport, storageKey, cancelPeek]);
+
+	// Peek: expand on mount, then collapse after a delay. Skipped when
+	// the user explicitly left the sidebar expanded, and on narrow
+	// viewports where the expansion would cover or squish content.
+	// Neither the expansion nor the auto-collapse is persisted.
+	useEffect(() => {
+		if (
+			!peekOnMount ||
+			isBelowLgViewport() ||
+			readPersisted(storageKey) === "expanded"
+		) {
 			return;
 		}
 		setCollapsed(false);

--- a/site/src/components/Sidebar/useSidebarResize.ts
+++ b/site/src/components/Sidebar/useSidebarResize.ts
@@ -1,16 +1,20 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 const EXPANDED_WIDTH = 240;
 // Icon center sits at nav-pl(12) + btn-px(12) + icon/2(8) = 32px.
 // Double that so the icon is horizontally centered when collapsed.
 const COLLAPSED_WIDTH = 64;
 
-function readCollapsed(key: string): boolean {
+function readPersisted(key: string): string | null {
 	try {
-		return localStorage.getItem(key) === "collapsed";
+		return localStorage.getItem(key);
 	} catch {
-		return false;
+		return null;
 	}
+}
+
+function readCollapsed(key: string): boolean {
+	return readPersisted(key) === "collapsed";
 }
 
 function persistCollapsed(key: string, collapsed: boolean): void {
@@ -21,15 +25,31 @@ function persistCollapsed(key: string, collapsed: boolean): void {
 	}
 }
 
+interface UseSidebarResizeOptions {
+	/**
+	 * On mount, briefly expand the sidebar then collapse it after a
+	 * short delay, unless the user previously left it expanded. The
+	 * peek expansion is never persisted; any user interaction cancels
+	 * the pending collapse.
+	 */
+	peekOnMount?: boolean;
+}
+
 interface UseSidebarResizeReturn {
 	width: number;
 	collapsed: boolean;
 	/** Force the sidebar to expand. */
 	expand: () => void;
+	/** Force the sidebar to collapse. */
+	collapse: () => void;
 	/** Toggle collapsed/expanded state. */
 	toggle: () => void;
+	/** Cancel a pending peek-on-mount auto-collapse, if any. */
+	cancelPeek: () => void;
 	onDragStart: (e: React.PointerEvent) => () => void;
 }
+
+const PEEK_COLLAPSE_DELAY_MS = 1500;
 
 /**
  * Two-state sidebar that drags smoothly by writing directly to the
@@ -39,21 +59,53 @@ interface UseSidebarResizeReturn {
  */
 export function useSidebarResize(
 	storageKey = "sidebar-width",
+	{ peekOnMount = false }: UseSidebarResizeOptions = {},
 ): UseSidebarResizeReturn {
 	const [collapsed, setCollapsed] = useState(() => readCollapsed(storageKey));
+	const peekTimerRef = useRef<number | undefined>(undefined);
+
+	const cancelPeek = useCallback(() => {
+		if (peekTimerRef.current !== undefined) {
+			window.clearTimeout(peekTimerRef.current);
+			peekTimerRef.current = undefined;
+		}
+	}, []);
+
+	// Peek: expand on mount, then collapse after a delay. Skipped when
+	// the user explicitly left the sidebar expanded. Neither the
+	// expansion nor the auto-collapse is persisted.
+	useEffect(() => {
+		if (!peekOnMount || readPersisted(storageKey) === "expanded") {
+			return;
+		}
+		setCollapsed(false);
+		peekTimerRef.current = window.setTimeout(() => {
+			peekTimerRef.current = undefined;
+			setCollapsed(true);
+		}, PEEK_COLLAPSE_DELAY_MS);
+		return cancelPeek;
+	}, [peekOnMount, storageKey, cancelPeek]);
 
 	const expand = useCallback(() => {
+		cancelPeek();
 		setCollapsed(false);
 		persistCollapsed(storageKey, false);
-	}, [storageKey]);
+	}, [storageKey, cancelPeek]);
+
+	const collapse = useCallback(() => {
+		cancelPeek();
+		setCollapsed(true);
+		persistCollapsed(storageKey, true);
+	}, [storageKey, cancelPeek]);
 
 	const toggle = useCallback(() => {
+		cancelPeek();
 		setCollapsed((prev) => {
 			const next = !prev;
 			persistCollapsed(storageKey, next);
 			return next;
 		});
-	}, [storageKey]);
+	}, [storageKey, cancelPeek]);
 
 	const onDragStart = useCallback(
 		(e: React.PointerEvent): (() => void) => {
@@ -134,5 +186,13 @@ export function useSidebarResize(
 
 	const width = collapsed ? COLLAPSED_WIDTH : EXPANDED_WIDTH;
 
-	return { width, collapsed, expand, toggle, onDragStart };
+	return {
+		width,
+		collapsed,
+		expand,
+		collapse,
+		toggle,
+		cancelPeek,
+		onDragStart,
+	};
 }

--- a/site/src/hooks/useIsBelowLgViewport.ts
+++ b/site/src/hooks/useIsBelowLgViewport.ts
@@ -1,0 +1,12 @@
+import { useSyncExternalStore } from "react";
+import { belowLgViewportMediaQuery, isBelowLgViewport } from "#/utils/mobile";
+
+const subscribeBelowLgViewport = (onStoreChange: () => void) => {
+	const mediaQuery = window.matchMedia(belowLgViewportMediaQuery);
+	mediaQuery.addEventListener("change", onStoreChange);
+	return () => mediaQuery.removeEventListener("change", onStoreChange);
+};
+
+export const useIsBelowLgViewport = (): boolean => {
+	return useSyncExternalStore(subscribeBelowLgViewport, isBelowLgViewport);
+};

--- a/site/src/modules/dashboard/DeploymentBanner/DeploymentBannerView.tsx
+++ b/site/src/modules/dashboard/DeploymentBanner/DeploymentBannerView.tsx
@@ -102,7 +102,7 @@ export const DeploymentBannerView: FC<DeploymentBannerViewProps> = ({
 
 	return (
 		<div
-			className="sticky bottom-0 z-[1] flex h-9 w-full items-center gap-8
+			className="sticky bottom-0 z-40 flex h-9 w-full items-center gap-8
 		 		overflow-x-auto overflow-y-hidden whitespace-nowrap border-0 border-t border-solid border-border
 				bg-surface-primary pr-4 font-mono text-xs leading-none"
 		>

--- a/site/src/modules/dashboard/Navbar/DeploymentDropdown.tsx
+++ b/site/src/modules/dashboard/Navbar/DeploymentDropdown.tsx
@@ -6,13 +6,12 @@ import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
-	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "#/components/DropdownMenu/DropdownMenu";
 import {
 	type AdminSettingsPermissions,
 	canViewAdminSettings,
-	getAdminSettingsSections,
+	getAdminSettingsItems,
 } from "./adminSettings";
 
 type DeploymentDropdownProps = AdminSettingsPermissions;
@@ -24,7 +23,7 @@ export const DeploymentDropdown: FC<DeploymentDropdownProps> = (
 		return null;
 	}
 
-	const sections = getAdminSettingsSections(permissions);
+	const items = getAdminSettingsItems(permissions);
 
 	return (
 		<DropdownMenu>
@@ -37,20 +36,10 @@ export const DeploymentDropdown: FC<DeploymentDropdownProps> = (
 
 			<DropdownMenuContent align="end" className="w-[180px] min-w-auto">
 				<nav>
-					{sections.map((section, index) => (
-						<div key={section.label ?? section.items[0].to}>
-							{index > 0 && <DropdownMenuSeparator />}
-							{section.label && (
-								<div className="px-2 py-1.5 text-xs font-medium text-content-secondary">
-									{section.label}
-								</div>
-							)}
-							{section.items.map((item) => (
-								<DropdownMenuItem key={item.to} asChild>
-									<Link to={item.to}>{item.label}</Link>
-								</DropdownMenuItem>
-							))}
-						</div>
+					{items.map((item) => (
+						<DropdownMenuItem key={item.to} asChild>
+							<Link to={item.to}>{item.label}</Link>
+						</DropdownMenuItem>
 					))}
 				</nav>
 			</DropdownMenuContent>

--- a/site/src/modules/dashboard/Navbar/DeploymentDropdown.tsx
+++ b/site/src/modules/dashboard/Navbar/DeploymentDropdown.tsx
@@ -6,12 +6,13 @@ import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
+	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "#/components/DropdownMenu/DropdownMenu";
 import {
 	type AdminSettingsPermissions,
 	canViewAdminSettings,
-	getAdminSettingsItems,
+	getAdminSettingsSections,
 } from "./adminSettings";
 
 type DeploymentDropdownProps = AdminSettingsPermissions;
@@ -23,7 +24,7 @@ export const DeploymentDropdown: FC<DeploymentDropdownProps> = (
 		return null;
 	}
 
-	const items = getAdminSettingsItems(permissions);
+	const sections = getAdminSettingsSections(permissions);
 
 	return (
 		<DropdownMenu>
@@ -36,10 +37,20 @@ export const DeploymentDropdown: FC<DeploymentDropdownProps> = (
 
 			<DropdownMenuContent align="end" className="w-[180px] min-w-auto">
 				<nav>
-					{items.map((item) => (
-						<DropdownMenuItem key={item.to} asChild>
-							<Link to={item.to}>{item.label}</Link>
-						</DropdownMenuItem>
+					{sections.map((section, index) => (
+						<div key={section.label ?? section.items[0].to}>
+							{index > 0 && <DropdownMenuSeparator />}
+							{section.label && (
+								<div className="px-2 py-1.5 text-xs font-medium text-content-secondary">
+									{section.label}
+								</div>
+							)}
+							{section.items.map((item) => (
+								<DropdownMenuItem key={item.to} asChild>
+									<Link to={item.to}>{item.label}</Link>
+								</DropdownMenuItem>
+							))}
+						</div>
 					))}
 				</nav>
 			</DropdownMenuContent>

--- a/site/src/modules/dashboard/Navbar/MobileMenu.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.tsx
@@ -28,7 +28,7 @@ import type { ProxyContextValue } from "#/contexts/ProxyContext";
 import { cn } from "#/utils/cn";
 import {
 	type AdminSettingsPermissions,
-	getAdminSettingsItems,
+	getAdminSettingsSections,
 } from "./adminSettings";
 import { sortProxiesByLatency } from "./proxyUtils";
 
@@ -204,7 +204,7 @@ const ProxySettingsSub: FC<ProxySettingsSubProps> = ({ proxyContextValue }) => {
 
 const AdminSettingsSub: FC<AdminSettingsPermissions> = (permissions) => {
 	const [open, setOpen] = useState(false);
-	const items = getAdminSettingsItems(permissions);
+	const sections = getAdminSettingsSections(permissions);
 
 	return (
 		<Collapsible open={open} onOpenChange={setOpen}>
@@ -223,14 +223,29 @@ const AdminSettingsSub: FC<AdminSettingsPermissions> = (permissions) => {
 				</DropdownMenuItem>
 			</CollapsibleTrigger>
 			<CollapsibleContent>
-				{items.map((item) => (
-					<DropdownMenuItem
-						key={item.to}
-						asChild
-						className={cn(itemStyles.default, itemStyles.sub)}
-					>
-						<Link to={item.to}>{item.label}</Link>
-					</DropdownMenuItem>
+				{sections.map((section) => (
+					<div key={section.label ?? section.items[0].to}>
+						{section.label && (
+							<div
+								className={cn(
+									itemStyles.default,
+									itemStyles.sub,
+									"flex items-center text-xs font-medium text-content-secondary",
+								)}
+							>
+								{section.label}
+							</div>
+						)}
+						{section.items.map((item) => (
+							<DropdownMenuItem
+								key={item.to}
+								asChild
+								className={cn(itemStyles.default, itemStyles.sub)}
+							>
+								<Link to={item.to}>{item.label}</Link>
+							</DropdownMenuItem>
+						))}
+					</div>
 				))}
 			</CollapsibleContent>
 		</Collapsible>

--- a/site/src/modules/dashboard/Navbar/MobileMenu.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.tsx
@@ -28,7 +28,7 @@ import type { ProxyContextValue } from "#/contexts/ProxyContext";
 import { cn } from "#/utils/cn";
 import {
 	type AdminSettingsPermissions,
-	getAdminSettingsSections,
+	getAdminSettingsItems,
 } from "./adminSettings";
 import { sortProxiesByLatency } from "./proxyUtils";
 
@@ -204,7 +204,7 @@ const ProxySettingsSub: FC<ProxySettingsSubProps> = ({ proxyContextValue }) => {
 
 const AdminSettingsSub: FC<AdminSettingsPermissions> = (permissions) => {
 	const [open, setOpen] = useState(false);
-	const sections = getAdminSettingsSections(permissions);
+	const items = getAdminSettingsItems(permissions);
 
 	return (
 		<Collapsible open={open} onOpenChange={setOpen}>
@@ -223,29 +223,14 @@ const AdminSettingsSub: FC<AdminSettingsPermissions> = (permissions) => {
 				</DropdownMenuItem>
 			</CollapsibleTrigger>
 			<CollapsibleContent>
-				{sections.map((section) => (
-					<div key={section.label ?? section.items[0].to}>
-						{section.label && (
-							<div
-								className={cn(
-									itemStyles.default,
-									itemStyles.sub,
-									"flex items-center text-xs font-medium text-content-secondary",
-								)}
-							>
-								{section.label}
-							</div>
-						)}
-						{section.items.map((item) => (
-							<DropdownMenuItem
-								key={item.to}
-								asChild
-								className={cn(itemStyles.default, itemStyles.sub)}
-							>
-								<Link to={item.to}>{item.label}</Link>
-							</DropdownMenuItem>
-						))}
-					</div>
+				{items.map((item) => (
+					<DropdownMenuItem
+						key={item.to}
+						asChild
+						className={cn(itemStyles.default, itemStyles.sub)}
+					>
+						<Link to={item.to}>{item.label}</Link>
+					</DropdownMenuItem>
 				))}
 			</CollapsibleContent>
 		</Collapsible>

--- a/site/src/modules/dashboard/Navbar/adminSettings.ts
+++ b/site/src/modules/dashboard/Navbar/adminSettings.ts
@@ -20,31 +20,56 @@ type AdminSettingsItem = {
 	to: string;
 };
 
+type AdminSettingsSection = {
+	/** Optional heading rendered above the section's items. */
+	label?: string;
+	items: AdminSettingsItem[];
+};
+
 /**
- * Builds the ordered list of Admin settings menu items for the given
- * permissions. Organizations is always available; the rest are gated behind
- * their respective permissions.
+ * Builds the ordered, sectioned list of Admin settings menu items for the
+ * given permissions. Organizations is always available; the rest are gated
+ * behind their respective permissions. Sections with no visible items are
+ * omitted.
  */
-export const getAdminSettingsItems = ({
+export const getAdminSettingsSections = ({
 	canViewDeployment,
 	canViewAuditLog,
 	canViewConnectionLog,
 	canViewAIBridge,
 	canViewAISettings,
 	canViewHealth,
-}: AdminSettingsPermissions): AdminSettingsItem[] => [
-	...(canViewDeployment ? [{ label: "Deployment", to: "/deployment" }] : []),
-	{ label: "Organizations", to: "/organizations" },
-	...(canViewAISettings ? [{ label: "AI", to: "/ai/settings" }] : []),
-	...(canViewAuditLog ? [{ label: "Audit logs", to: linkToAuditing }] : []),
-	...(canViewConnectionLog
-		? [{ label: "Connection logs", to: "/connectionlog" }]
-		: []),
-	...(canViewAIBridge
-		? [{ label: "AI sessions", to: "/ai-gateway/sessions" }]
-		: []),
-	...(canViewHealth ? [{ label: "Healthcheck", to: "/health" }] : []),
-];
+}: AdminSettingsPermissions): AdminSettingsSection[] => {
+	const sections: AdminSettingsSection[] = [
+		{
+			items: [
+				...(canViewDeployment
+					? [{ label: "Deployment", to: "/deployment" }]
+					: []),
+				{ label: "Organizations", to: "/organizations" },
+				...(canViewAISettings ? [{ label: "AI", to: "/ai/settings" }] : []),
+			],
+		},
+		{
+			label: "Logs",
+			items: [
+				...(canViewAuditLog
+					? [{ label: "Audit logs", to: linkToAuditing }]
+					: []),
+				...(canViewConnectionLog
+					? [{ label: "Connection logs", to: "/connectionlog" }]
+					: []),
+				...(canViewAIBridge
+					? [{ label: "AI session logs", to: "/ai-gateway/sessions" }]
+					: []),
+			],
+		},
+		{
+			items: canViewHealth ? [{ label: "Healthcheck", to: "/health" }] : [],
+		},
+	];
+	return sections.filter((section) => section.items.length > 0);
+};
 
 /**
  * Whether the user has any permission that should surface the Admin settings

--- a/site/src/modules/dashboard/Navbar/adminSettings.ts
+++ b/site/src/modules/dashboard/Navbar/adminSettings.ts
@@ -1,5 +1,3 @@
-import { linkToAuditing } from "#/modules/navigation";
-
 /**
  * Permissions that determine which items appear in the Admin settings menu.
  * Shared by the desktop `DeploymentDropdown` and the mobile `MobileMenu` so
@@ -20,56 +18,28 @@ type AdminSettingsItem = {
 	to: string;
 };
 
-type AdminSettingsSection = {
-	/** Optional heading rendered above the section's items. */
-	label?: string;
-	items: AdminSettingsItem[];
-};
-
 /**
- * Builds the ordered, sectioned list of Admin settings menu items for the
- * given permissions. Organizations is always available; the rest are gated
- * behind their respective permissions. Sections with no visible items are
- * omitted.
+ * Builds the ordered list of Admin settings menu items for the given
+ * permissions. Organizations is always available; the rest are gated behind
+ * their respective permissions. Logs appears when the user can view any of
+ * the log pages; the logs section's own sidebar handles per-page gating.
  */
-export const getAdminSettingsSections = ({
+export const getAdminSettingsItems = ({
 	canViewDeployment,
 	canViewAuditLog,
 	canViewConnectionLog,
 	canViewAIBridge,
 	canViewAISettings,
 	canViewHealth,
-}: AdminSettingsPermissions): AdminSettingsSection[] => {
-	const sections: AdminSettingsSection[] = [
-		{
-			items: [
-				...(canViewDeployment
-					? [{ label: "Deployment", to: "/deployment" }]
-					: []),
-				{ label: "Organizations", to: "/organizations" },
-				...(canViewAISettings ? [{ label: "AI", to: "/ai/settings" }] : []),
-			],
-		},
-		{
-			label: "Logs",
-			items: [
-				...(canViewAuditLog
-					? [{ label: "Audit logs", to: linkToAuditing }]
-					: []),
-				...(canViewConnectionLog
-					? [{ label: "Connection logs", to: "/connectionlog" }]
-					: []),
-				...(canViewAIBridge
-					? [{ label: "AI session logs", to: "/ai-gateway/sessions" }]
-					: []),
-			],
-		},
-		{
-			items: canViewHealth ? [{ label: "Healthcheck", to: "/health" }] : [],
-		},
-	];
-	return sections.filter((section) => section.items.length > 0);
-};
+}: AdminSettingsPermissions): AdminSettingsItem[] => [
+	...(canViewDeployment ? [{ label: "Deployment", to: "/deployment" }] : []),
+	{ label: "Organizations", to: "/organizations" },
+	...(canViewAISettings ? [{ label: "AI", to: "/ai/settings" }] : []),
+	...(canViewAuditLog || canViewConnectionLog || canViewAIBridge
+		? [{ label: "Logs", to: "/logs" }]
+		: []),
+	...(canViewHealth ? [{ label: "Healthcheck", to: "/health" }] : []),
+];
 
 /**
  * Whether the user has any permission that should surface the Admin settings

--- a/site/src/modules/management/AISettingsSidebar.tsx
+++ b/site/src/modules/management/AISettingsSidebar.tsx
@@ -1,11 +1,18 @@
 import type { FC } from "react";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
 import AISettingsSidebarView from "#/modules/management/AISettingsSidebarView";
+import { useActiveAISection } from "#/modules/management/useActiveAISection";
 
 /**
  * A sidebar for AI settings.
  */
 export const AISettingsSidebar: FC = () => {
 	const { permissions } = useAuthenticated();
-	return <AISettingsSidebarView permissions={permissions} />;
+	const activeSection = useActiveAISection();
+	return (
+		<AISettingsSidebarView
+			permissions={permissions}
+			activeSection={activeSection}
+		/>
+	);
 };

--- a/site/src/modules/management/AISettingsSidebarView.stories.tsx
+++ b/site/src/modules/management/AISettingsSidebarView.stories.tsx
@@ -102,7 +102,12 @@ export const Collapsed: Story = {
 	decorators: [
 		(Story) => (
 			<SidebarContext.Provider
-				value={{ collapsed: true, expand: () => {}, toggle: () => {} }}
+				value={{
+					collapsed: true,
+					expand: () => {},
+					collapse: () => {},
+					toggle: () => {},
+				}}
 			>
 				<Story />
 			</SidebarContext.Provider>

--- a/site/src/modules/management/AISettingsSidebarView.stories.tsx
+++ b/site/src/modules/management/AISettingsSidebarView.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
+import { SidebarContext } from "#/components/Sidebar/SidebarContext";
 import { MockNoPermissions, MockPermissions } from "#/testHelpers/entities";
 import AISettingsSidebarView from "./AISettingsSidebarView";
 
@@ -8,6 +9,7 @@ const meta: Meta<typeof AISettingsSidebarView> = {
 	component: AISettingsSidebarView,
 	args: {
 		permissions: MockPermissions,
+		activeSection: "coder-agents",
 	},
 	parameters: {
 		reactRouter: reactRouterParameters({
@@ -60,13 +62,52 @@ export const LifecycleActive: Story = {
 	},
 };
 
+export const GovernanceActive: Story = {
+	args: {
+		activeSection: "governance",
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: { path: "/ai/settings/governance" },
+			routing: [{ path: "/ai/settings/governance", useStoryElement: true }],
+		}),
+	},
+};
+
+export const GatewayKeysActive: Story = {
+	args: {
+		activeSection: "gateway-keys",
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: { path: "/ai/settings/gateway-keys" },
+			routing: [{ path: "/ai/settings/gateway-keys", useStoryElement: true }],
+		}),
+	},
+};
+
 export const ProvidersActive: Story = {
+	args: {
+		activeSection: "providers",
+	},
 	parameters: {
 		reactRouter: reactRouterParameters({
 			location: { path: "/ai/settings/providers" },
 			routing: [{ path: "/ai/settings/providers", useStoryElement: true }],
 		}),
 	},
+};
+
+export const Collapsed: Story = {
+	decorators: [
+		(Story) => (
+			<SidebarContext.Provider
+				value={{ collapsed: true, expand: () => {}, toggle: () => {} }}
+			>
+				<Story />
+			</SidebarContext.Provider>
+		),
+	],
 };
 
 export const NoDeploymentConfig: Story = {

--- a/site/src/modules/management/AISettingsSidebarView.tsx
+++ b/site/src/modules/management/AISettingsSidebarView.tsx
@@ -1,78 +1,195 @@
-import type { FC, ReactNode } from "react";
-import { NavLink } from "react-router";
 import {
-	Sidebar as BaseSidebar,
-	SettingsSidebarNavItem as SidebarNavItem,
-} from "#/components/Sidebar/Sidebar";
+	BotIcon,
+	KeyIcon,
+	PanelLeftIcon,
+	ShieldCheckIcon,
+	StoreIcon,
+} from "lucide-react";
+import { type FC, useCallback, useEffect, useState } from "react";
+import { Link, NavLink } from "react-router";
+import { SettingsSidebarNavItem as SidebarNavItem } from "#/components/Sidebar/Sidebar";
+import { SidebarAccordion } from "#/components/Sidebar/SidebarAccordion";
+import { useSidebarContext } from "#/components/Sidebar/SidebarContext";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
 import type { Permissions } from "#/modules/permissions";
 import { cn } from "#/utils/cn";
+import type { AISection } from "./useActiveAISection";
 
 interface AISettingsSidebarViewProps {
 	/** Site-wide permissions. */
 	permissions: Permissions;
+	/** Which section is active based on the current route. */
+	activeSection: AISection;
 }
 
-const SubNavItem: FC<{ href: string; children?: ReactNode }> = ({
-	href,
-	children,
-}) => (
-	<NavLink
-		to={href}
-		className={({ isActive }) =>
-			cn(
-				"relative -ml-px text-sm text-content-secondary no-underline font-medium py-2 pl-4 pr-3 transition-colors",
-				"border-0 border-solid border-l border-l-transparent hover:text-content-primary",
-				isActive &&
-					"border-l-content-primary font-semibold text-content-primary",
-			)
-		}
-	>
-		{children}
-	</NavLink>
-);
+interface TopLevelNavItemProps {
+	label: string;
+	href: string;
+	icon: FC<{ className?: string }>;
+	active: boolean;
+}
 
+/**
+ * A flat icon+label link. In collapsed mode it renders as an icon
+ * with a tooltip; clicking it navigates and re-expands the sidebar.
+ */
+const TopLevelNavItem: FC<TopLevelNavItemProps> = ({
+	label,
+	href,
+	icon: Icon,
+	active,
+}) => {
+	const { collapsed, expand } = useSidebarContext();
+
+	if (collapsed) {
+		return (
+			<TooltipProvider>
+				<Tooltip delayDuration={0}>
+					<TooltipTrigger asChild>
+						<Link
+							to={href}
+							onClick={expand}
+							className="flex items-center justify-center w-10 h-10 rounded-md no-underline hover:bg-surface-secondary"
+						>
+							<Icon
+								className={cn(
+									"size-4 flex-shrink-0 text-content-secondary",
+									active && "text-content-primary",
+								)}
+							/>
+						</Link>
+					</TooltipTrigger>
+					<TooltipContent side="right">{label}</TooltipContent>
+				</Tooltip>
+			</TooltipProvider>
+		);
+	}
+
+	return (
+		<NavLink
+			to={href}
+			className={({ isActive }) =>
+				cn(
+					"flex items-center gap-2 px-3 py-2 h-10 rounded-md no-underline text-sm font-medium text-content-secondary hover:bg-surface-secondary transition-colors",
+					isActive && "text-content-primary font-semibold",
+				)
+			}
+		>
+			<Icon className="size-4 flex-shrink-0" />
+			{label}
+		</NavLink>
+	);
+};
+
+/**
+ * Displays navigation for the AI settings section. Top-level items
+ * are rendered as flat icon+label links, while the Coder Agents
+ * section uses an accordion with sub-items.
+ */
 const AISettingsSidebarView: FC<AISettingsSidebarViewProps> = ({
 	permissions,
+	activeSection,
 }) => {
+	const { collapsed, toggle } = useSidebarContext();
+
+	const [agentsOpen, setAgentsOpen] = useState(
+		() => activeSection === "coder-agents",
+	);
+
+	// When navigation changes the active section, open the Coder
+	// Agents accordion only when its section is active.
+	useEffect(() => {
+		setAgentsOpen(activeSection === "coder-agents");
+	}, [activeSection]);
+
+	const toggleAgents = useCallback(() => {
+		setAgentsOpen((prev) => !prev);
+	}, []);
+
 	return (
-		<BaseSidebar>
-			<div className="flex flex-col gap-1">
-				{permissions.viewDeploymentConfig && (
-					<SidebarNavItem href="/ai/settings/governance">
-						AI Governance
-					</SidebarNavItem>
+		<div className="flex flex-col gap-1">
+			<button
+				type="button"
+				onClick={toggle}
+				className={cn(
+					"group flex items-center bg-transparent border-none cursor-pointer mb-1 p-0",
+					collapsed
+						? "w-10 h-10 justify-center rounded-md"
+						: "w-full px-3 rounded-md h-10",
 				)}
-				{permissions.viewAIGatewayKeys && (
-					<SidebarNavItem href="/ai/settings/gateway-keys">
-						AI Gateway keys
-					</SidebarNavItem>
+			>
+				{!collapsed && (
+					<span className="text-sm text-content-secondary">AI</span>
 				)}
-				{permissions.viewAnyAIProvider && (
-					<SidebarNavItem href="/ai/settings/providers">
-						Providers
-					</SidebarNavItem>
-				)}
-				{permissions.editDeploymentConfig && (
-					<>
+				<PanelLeftIcon
+					className={cn(
+						"size-4 text-content-secondary group-hover:text-content-primary transition-colors",
+						!collapsed && "ml-auto",
+					)}
+				/>
+			</button>
+
+			{permissions.viewDeploymentConfig && (
+				<TopLevelNavItem
+					label="AI Governance"
+					href="/ai/settings/governance"
+					icon={ShieldCheckIcon}
+					active={activeSection === "governance"}
+				/>
+			)}
+			{permissions.viewAIGatewayKeys && (
+				<TopLevelNavItem
+					label="AI Gateway keys"
+					href="/ai/settings/gateway-keys"
+					icon={KeyIcon}
+					active={activeSection === "gateway-keys"}
+				/>
+			)}
+			{permissions.viewAnyAIProvider && (
+				<TopLevelNavItem
+					label="Providers"
+					href="/ai/settings/providers"
+					icon={StoreIcon}
+					active={activeSection === "providers"}
+				/>
+			)}
+
+			{permissions.editDeploymentConfig && (
+				<SidebarAccordion
+					icon={BotIcon}
+					label="Coder Agents"
+					href="/ai/settings/coder-agents"
+					open={agentsOpen}
+					onToggle={toggleAgents}
+					active={activeSection === "coder-agents"}
+				>
+					<div className="flex flex-col gap-1">
 						<SidebarNavItem href="/ai/settings/coder-agents">
 							Coder Agents
 						</SidebarNavItem>
-						<div className="flex flex-col gap-1 ml-3 border-0 border-solid border-l border-l-border">
-							<SubNavItem href="/ai/settings/models">Models</SubNavItem>
-							<SubNavItem href="/ai/settings/mcp-servers">
-								MCP servers
-							</SubNavItem>
-							<SubNavItem href="/ai/settings/templates">Templates</SubNavItem>
-							<SubNavItem href="/ai/settings/spend">Spend</SubNavItem>
-							<SubNavItem href="/ai/settings/instructions">
-								Instructions
-							</SubNavItem>
-							<SubNavItem href="/ai/settings/lifecycle">Lifecycle</SubNavItem>
-						</div>
-					</>
-				)}
-			</div>
-		</BaseSidebar>
+						<SidebarNavItem href="/ai/settings/models">Models</SidebarNavItem>
+						<SidebarNavItem href="/ai/settings/mcp-servers">
+							MCP servers
+						</SidebarNavItem>
+						<SidebarNavItem href="/ai/settings/templates">
+							Templates
+						</SidebarNavItem>
+						<SidebarNavItem href="/ai/settings/spend">Spend</SidebarNavItem>
+						<SidebarNavItem href="/ai/settings/instructions">
+							Instructions
+						</SidebarNavItem>
+						<SidebarNavItem href="/ai/settings/lifecycle">
+							Lifecycle
+						</SidebarNavItem>
+					</div>
+				</SidebarAccordion>
+			)}
+		</div>
 	);
 };
 

--- a/site/src/modules/management/AISettingsSidebarView.tsx
+++ b/site/src/modules/management/AISettingsSidebarView.tsx
@@ -5,18 +5,12 @@ import {
 	StoreIcon,
 } from "lucide-react";
 import { type FC, useCallback, useEffect, useState } from "react";
-import { Link, NavLink } from "react-router";
 import { SettingsSidebarNavItem as SidebarNavItem } from "#/components/Sidebar/Sidebar";
 import { SidebarAccordion } from "#/components/Sidebar/SidebarAccordion";
 import { useSidebarContext } from "#/components/Sidebar/SidebarContext";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipProvider,
-	TooltipTrigger,
-} from "#/components/Tooltip/Tooltip";
 import type { Permissions } from "#/modules/permissions";
 import { cn } from "#/utils/cn";
+import { SidebarTopLevelNavItem } from "./SidebarTopLevelNavItem";
 import type { AISection } from "./useActiveAISection";
 
 interface AISettingsSidebarViewProps {
@@ -25,65 +19,6 @@ interface AISettingsSidebarViewProps {
 	/** Which section is active based on the current route. */
 	activeSection: AISection;
 }
-
-interface TopLevelNavItemProps {
-	label: string;
-	href: string;
-	icon: FC<{ className?: string }>;
-	active: boolean;
-}
-
-/**
- * A flat icon+label link. In collapsed mode it renders as an icon
- * with a tooltip; clicking it navigates and re-expands the sidebar.
- */
-const TopLevelNavItem: FC<TopLevelNavItemProps> = ({
-	label,
-	href,
-	icon: Icon,
-	active,
-}) => {
-	const { collapsed, expand } = useSidebarContext();
-
-	if (collapsed) {
-		return (
-			<TooltipProvider>
-				<Tooltip delayDuration={0}>
-					<TooltipTrigger asChild>
-						<Link
-							to={href}
-							onClick={expand}
-							className="flex items-center justify-center w-10 h-10 rounded-md no-underline hover:bg-surface-secondary"
-						>
-							<Icon
-								className={cn(
-									"size-4 flex-shrink-0 text-content-secondary",
-									active && "text-content-primary",
-								)}
-							/>
-						</Link>
-					</TooltipTrigger>
-					<TooltipContent side="right">{label}</TooltipContent>
-				</Tooltip>
-			</TooltipProvider>
-		);
-	}
-
-	return (
-		<NavLink
-			to={href}
-			className={({ isActive }) =>
-				cn(
-					"flex items-center gap-2 px-3 py-2 h-10 rounded-md no-underline text-sm font-medium text-content-secondary hover:bg-surface-secondary transition-colors",
-					isActive && "text-content-primary font-semibold",
-				)
-			}
-		>
-			<Icon className="size-4 flex-shrink-0" />
-			{label}
-		</NavLink>
-	);
-};
 
 /**
  * Displays navigation for the AI settings section. Providers renders
@@ -171,7 +106,7 @@ const AISettingsSidebarView: FC<AISettingsSidebarViewProps> = ({
 				</SidebarAccordion>
 			)}
 			{permissions.viewAnyAIProvider && (
-				<TopLevelNavItem
+				<SidebarTopLevelNavItem
 					label="Providers"
 					href="/ai/settings/providers"
 					icon={StoreIcon}

--- a/site/src/modules/management/AISettingsSidebarView.tsx
+++ b/site/src/modules/management/AISettingsSidebarView.tsx
@@ -170,7 +170,7 @@ const AISettingsSidebarView: FC<AISettingsSidebarViewProps> = ({
 				>
 					<div className="flex flex-col gap-1">
 						<SidebarNavItem href="/ai/settings/coder-agents">
-							Coder Agents
+							General
 						</SidebarNavItem>
 						<SidebarNavItem href="/ai/settings/models">Models</SidebarNavItem>
 						<SidebarNavItem href="/ai/settings/mcp-servers">

--- a/site/src/modules/management/AISettingsSidebarView.tsx
+++ b/site/src/modules/management/AISettingsSidebarView.tsx
@@ -1,6 +1,5 @@
 import {
 	BotIcon,
-	KeyIcon,
 	PanelLeftIcon,
 	ShieldCheckIcon,
 	StoreIcon,
@@ -87,9 +86,9 @@ const TopLevelNavItem: FC<TopLevelNavItemProps> = ({
 };
 
 /**
- * Displays navigation for the AI settings section. Top-level items
- * are rendered as flat icon+label links, while the Coder Agents
- * section uses an accordion with sub-items.
+ * Displays navigation for the AI settings section. Providers renders
+ * as a flat icon+label link, while the AI Governance and Coder Agents
+ * sections use accordions with sub-items.
  */
 const AISettingsSidebarView: FC<AISettingsSidebarViewProps> = ({
 	permissions,
@@ -100,15 +99,25 @@ const AISettingsSidebarView: FC<AISettingsSidebarViewProps> = ({
 	const [agentsOpen, setAgentsOpen] = useState(
 		() => activeSection === "coder-agents",
 	);
+	const governanceActive =
+		activeSection === "governance" || activeSection === "gateway-keys";
+	const [governanceOpen, setGovernanceOpen] = useState(governanceActive);
 
-	// When navigation changes the active section, open the Coder
-	// Agents accordion only when its section is active.
+	// When navigation changes the active section, open only the
+	// accordion that owns the active route.
 	useEffect(() => {
 		setAgentsOpen(activeSection === "coder-agents");
+		setGovernanceOpen(
+			activeSection === "governance" || activeSection === "gateway-keys",
+		);
 	}, [activeSection]);
 
 	const toggleAgents = useCallback(() => {
 		setAgentsOpen((prev) => !prev);
+	}, []);
+
+	const toggleGovernance = useCallback(() => {
+		setGovernanceOpen((prev) => !prev);
 	}, []);
 
 	return (
@@ -134,21 +143,32 @@ const AISettingsSidebarView: FC<AISettingsSidebarViewProps> = ({
 				/>
 			</button>
 
-			{permissions.viewDeploymentConfig && (
-				<TopLevelNavItem
-					label="AI Governance"
-					href="/ai/settings/governance"
+			{(permissions.viewDeploymentConfig || permissions.viewAIGatewayKeys) && (
+				<SidebarAccordion
 					icon={ShieldCheckIcon}
-					active={activeSection === "governance"}
-				/>
-			)}
-			{permissions.viewAIGatewayKeys && (
-				<TopLevelNavItem
-					label="AI Gateway keys"
-					href="/ai/settings/gateway-keys"
-					icon={KeyIcon}
-					active={activeSection === "gateway-keys"}
-				/>
+					label="AI Governance"
+					href={
+						permissions.viewDeploymentConfig
+							? "/ai/settings/governance"
+							: "/ai/settings/gateway-keys"
+					}
+					open={governanceOpen}
+					onToggle={toggleGovernance}
+					active={governanceActive}
+				>
+					<div className="flex flex-col gap-1">
+						{permissions.viewDeploymentConfig && (
+							<SidebarNavItem href="/ai/settings/governance">
+								AI Gateway
+							</SidebarNavItem>
+						)}
+						{permissions.viewAIGatewayKeys && (
+							<SidebarNavItem href="/ai/settings/gateway-keys">
+								AI Gateway keys
+							</SidebarNavItem>
+						)}
+					</div>
+				</SidebarAccordion>
 			)}
 			{permissions.viewAnyAIProvider && (
 				<TopLevelNavItem

--- a/site/src/modules/management/DeploymentSettingsLayout.tsx
+++ b/site/src/modules/management/DeploymentSettingsLayout.tsx
@@ -1,13 +1,7 @@
 import { type FC, Suspense } from "react";
 import { Navigate, Outlet, useLocation } from "react-router";
-import {
-	Breadcrumb,
-	BreadcrumbItem,
-	BreadcrumbList,
-	BreadcrumbPage,
-	BreadcrumbSeparator,
-} from "#/components/Breadcrumb/Breadcrumb";
 import { Loader } from "#/components/Loader/Loader";
+import { CollapsibleSidebar } from "#/components/Sidebar/CollapsibleSidebar";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
 import { canViewDeploymentSettings } from "#/modules/permissions";
 import { RequirePermission } from "#/modules/permissions/RequirePermission";
@@ -36,31 +30,19 @@ const DeploymentSettingsLayout: FC = () => {
 
 	return (
 		<RequirePermission isFeatureVisible={canViewDeploymentSettingsPage}>
-			<div>
-				<Breadcrumb>
-					<BreadcrumbList>
-						<BreadcrumbItem>
-							<BreadcrumbPage>Admin Settings</BreadcrumbPage>
-						</BreadcrumbItem>
-						<BreadcrumbSeparator />
-						<BreadcrumbItem>
-							<BreadcrumbPage className="text-content-primary">
-								Deployment
-							</BreadcrumbPage>
-						</BreadcrumbItem>
-					</BreadcrumbList>
-				</Breadcrumb>
-				<div className="h-px border-none bg-border" />
-				<section className="px-10 max-w-screen-2xl mx-auto">
-					<div className="flex flex-row gap-28 py-10">
+			<div className="flex flex-row min-h-screen">
+				<div className="border-0 border-r border-solid border-border">
+					<CollapsibleSidebar storageKey="deployment-sidebar-width">
 						<DeploymentSidebar />
-						<div className="grow">
-							<Suspense fallback={<Loader />}>
-								<Outlet />
-							</Suspense>
-						</div>
+					</CollapsibleSidebar>
+				</div>
+				<div className="flex-1 min-w-0 pt-6 pb-10 px-10">
+					<div className="max-w-screen-2xl mx-auto">
+						<Suspense fallback={<Loader />}>
+							<Outlet />
+						</Suspense>
 					</div>
-				</section>
+				</div>
 			</div>
 		</RequirePermission>
 	);

--- a/site/src/modules/management/DeploymentSidebar.tsx
+++ b/site/src/modules/management/DeploymentSidebar.tsx
@@ -2,9 +2,11 @@ import type { FC } from "react";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
 import { useDashboard } from "#/modules/dashboard/useDashboard";
 import { DeploymentSidebarView } from "./DeploymentSidebarView";
+import { useActiveDeploymentSection } from "./useActiveDeploymentSection";
 
 /**
- * A sidebar for deployment settings.
+ * A sidebar for deployment settings. Wraps the view with data from
+ * authentication and dashboard context.
  */
 export const DeploymentSidebar: FC = () => {
 	const { permissions } = useAuthenticated();
@@ -12,6 +14,7 @@ export const DeploymentSidebar: FC = () => {
 		useDashboard();
 	const hasPremiumLicense =
 		entitlements.features.multiple_organizations.enabled;
+	const activeSection = useActiveDeploymentSection();
 
 	return (
 		<DeploymentSidebarView
@@ -20,6 +23,7 @@ export const DeploymentSidebar: FC = () => {
 			hasPremiumLicense={hasPremiumLicense}
 			experiments={experiments}
 			buildInfo={buildInfo}
+			activeSection={activeSection}
 		/>
 	);
 };

--- a/site/src/modules/management/DeploymentSidebarView.stories.tsx
+++ b/site/src/modules/management/DeploymentSidebarView.stories.tsx
@@ -42,7 +42,12 @@ export const Collapsed: Story = {
 	decorators: [
 		(Story) => (
 			<SidebarContext.Provider
-				value={{ collapsed: true, expand: () => {}, toggle: () => {} }}
+				value={{
+					collapsed: true,
+					expand: () => {},
+					collapse: () => {},
+					toggle: () => {},
+				}}
 			>
 				<Story />
 			</SidebarContext.Provider>

--- a/site/src/modules/management/DeploymentSidebarView.stories.tsx
+++ b/site/src/modules/management/DeploymentSidebarView.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SidebarContext } from "#/components/Sidebar/SidebarContext";
 import {
 	MockBuildInfo,
 	MockNoPermissions,
@@ -16,11 +17,38 @@ const meta: Meta<typeof DeploymentSidebarView> = {
 		permissions: MockPermissions,
 		experiments: [],
 		buildInfo: MockBuildInfo,
+		activeSection: "general",
 	},
 };
 
 export default meta;
 type Story = StoryObj<typeof DeploymentSidebarView>;
+
+export const GeneralOpen: Story = {};
+
+export const InfrastructureOpen: Story = {
+	args: {
+		activeSection: "infrastructure",
+	},
+};
+
+export const AuthenticationOpen: Story = {
+	args: {
+		activeSection: "authentication",
+	},
+};
+
+export const Collapsed: Story = {
+	decorators: [
+		(Story) => (
+			<SidebarContext.Provider
+				value={{ collapsed: true, expand: () => {}, toggle: () => {} }}
+			>
+				<Story />
+			</SidebarContext.Provider>
+		),
+	],
+};
 
 export const NoViewUsers: Story = {
 	args: {

--- a/site/src/modules/management/DeploymentSidebarView.stories.tsx
+++ b/site/src/modules/management/DeploymentSidebarView.stories.tsx
@@ -1,4 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, waitFor, within } from "storybook/test";
+import { CollapsibleSidebar } from "#/components/Sidebar/CollapsibleSidebar";
 import { SidebarContext } from "#/components/Sidebar/SidebarContext";
 import {
 	MockBuildInfo,
@@ -95,5 +97,34 @@ export const NoDeploymentValues: Story = {
 export const NoPermissions: Story = {
 	args: {
 		permissions: MockNoPermissions,
+	},
+};
+
+// Renders inside a real CollapsibleSidebar at a narrow viewport. Even
+// though the persisted preference is "expanded", the sidebar must
+// auto-collapse to the icon rail below the lg breakpoint.
+export const NarrowViewportAutoCollapse: Story = {
+	decorators: [
+		(Story) => {
+			localStorage.setItem("story-deployment-narrow", "expanded");
+			return (
+				<CollapsibleSidebar storageKey="story-deployment-narrow">
+					<Story />
+				</CollapsibleSidebar>
+			);
+		},
+	],
+	parameters: {
+		viewport: { defaultViewport: "iphone12" },
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// Collapsed accordions render icon-only triggers, so the labeled
+		// "General" trigger must not exist at a narrow viewport.
+		await waitFor(() => {
+			expect(
+				canvas.queryByRole("button", { name: /general/i }),
+			).not.toBeInTheDocument();
+		});
 	},
 };

--- a/site/src/modules/management/DeploymentSidebarView.tsx
+++ b/site/src/modules/management/DeploymentSidebarView.tsx
@@ -1,12 +1,19 @@
-import { ArrowUpRightIcon } from "lucide-react";
-import type { FC } from "react";
-import type { BuildInfoResponse, Experiment } from "#/api/typesGenerated";
 import {
-	Sidebar as BaseSidebar,
-	SettingsSidebarNavItem as SidebarNavItem,
-} from "#/components/Sidebar/Sidebar";
+	ArrowUpRightIcon,
+	HardDriveIcon,
+	PanelLeftIcon,
+	SettingsIcon,
+	UserLockIcon,
+} from "lucide-react";
+import { type FC, useCallback, useEffect, useState } from "react";
+import type { BuildInfoResponse, Experiment } from "#/api/typesGenerated";
+import { SettingsSidebarNavItem as SidebarNavItem } from "#/components/Sidebar/Sidebar";
+import { SidebarAccordion } from "#/components/Sidebar/SidebarAccordion";
+import { useSidebarContext } from "#/components/Sidebar/SidebarContext";
 import type { Permissions } from "#/modules/permissions";
 import { getPrereleaseFlag } from "#/utils/buildInfo";
+import { cn } from "#/utils/cn";
+import type { DeploymentSection } from "./useActiveDeploymentSection";
 
 interface DeploymentSidebarViewProps {
 	/** Site-wide permissions. */
@@ -15,11 +22,15 @@ interface DeploymentSidebarViewProps {
 	hasPremiumLicense: boolean;
 	experiments: Experiment[];
 	buildInfo: BuildInfoResponse;
+	/** Which accordion section is active based on the current route. */
+	activeSection: DeploymentSection;
 }
 
 /**
- * Displays navigation for deployment settings.  If active, highlight the main
- * menu heading.
+ * Displays navigation for deployment settings grouped into accordion
+ * sections. Section headers toggle freely, so multiple sections can be
+ * open at once. Clicking a sub-item link collapses all other sections
+ * so only the active section stays open after navigation.
  */
 export const DeploymentSidebarView: FC<DeploymentSidebarViewProps> = ({
 	permissions,
@@ -27,81 +38,165 @@ export const DeploymentSidebarView: FC<DeploymentSidebarViewProps> = ({
 	hasPremiumLicense,
 	experiments,
 	buildInfo,
+	activeSection,
 }) => {
+	const { collapsed, toggle } = useSidebarContext();
+
+	// Track which sections are open as a Set so multiple can be
+	// expanded at the same time via the accordion headers.
+	const [openSections, setOpenSections] = useState<Set<DeploymentSection>>(
+		() => new Set([activeSection]),
+	);
+
+	// When a sub-item link is clicked (route changes), collapse
+	// everything except the newly active section.
+	useEffect(() => {
+		setOpenSections(new Set([activeSection]));
+	}, [activeSection]);
+
+	const toggleSection = useCallback((section: DeploymentSection) => {
+		setOpenSections((prev) => {
+			const next = new Set(prev);
+			if (next.has(section)) {
+				next.delete(section);
+			} else {
+				next.add(section);
+			}
+			return next;
+		});
+	}, []);
+
 	return (
-		<BaseSidebar>
-			<div className="flex flex-col gap-1">
-				{permissions.viewDeploymentConfig && (
-					<SidebarNavItem href="/deployment/overview">Overview</SidebarNavItem>
+		<div className="flex flex-col gap-1">
+			<button
+				type="button"
+				onClick={toggle}
+				className={cn(
+					"group flex items-center bg-transparent border-none cursor-pointer mb-1 p-0",
+					collapsed
+						? "w-10 h-10 justify-center rounded-md"
+						: "w-full px-3 rounded-md h-10",
 				)}
-				{permissions.viewAllLicenses && (
-					<SidebarNavItem href="/deployment/licenses">Licenses</SidebarNavItem>
+			>
+				{!collapsed && (
+					<span className="text-sm text-content-secondary">Deployment</span>
 				)}
-				{permissions.editDeploymentConfig && (
-					<SidebarNavItem href="/deployment/appearance">
-						Appearance
-					</SidebarNavItem>
-				)}
-				{permissions.viewDeploymentConfig && (
-					<SidebarNavItem href="/deployment/userauth">
-						User Authentication
-					</SidebarNavItem>
-				)}
-				{permissions.viewDeploymentConfig && (
-					<SidebarNavItem href="/deployment/external-auth">
-						External Authentication
-					</SidebarNavItem>
-				)}
-				{permissions.viewDeploymentConfig &&
-					(experiments.includes("oauth2") ||
-						getPrereleaseFlag(buildInfo) === "devel") && (
-						<SidebarNavItem href="/deployment/oauth2-provider/apps">
-							OAuth2 Applications
+				<PanelLeftIcon
+					className={cn(
+						"size-4 text-content-secondary group-hover:text-content-primary transition-colors",
+						!collapsed && "ml-auto",
+					)}
+				/>
+			</button>
+
+			<SidebarAccordion
+				icon={SettingsIcon}
+				label="General"
+				href="/deployment/overview"
+				open={openSections.has("general")}
+				onToggle={() => toggleSection("general")}
+				active={activeSection === "general"}
+			>
+				<div className="flex flex-col gap-1">
+					{permissions.viewDeploymentConfig && (
+						<SidebarNavItem href="/deployment/overview">
+							Overview
 						</SidebarNavItem>
 					)}
-				{permissions.viewDeploymentConfig && (
-					<SidebarNavItem href="/deployment/network">Network</SidebarNavItem>
-				)}
-				{permissions.readWorkspaceProxies && (
-					<SidebarNavItem href="/deployment/workspace-proxies">
-						Workspace Proxies
-					</SidebarNavItem>
-				)}
-				{permissions.viewDeploymentConfig && (
-					<SidebarNavItem href="/deployment/security">Security</SidebarNavItem>
-				)}
-				{permissions.viewDeploymentConfig && (
-					<SidebarNavItem href="/deployment/observability">
-						Observability
-					</SidebarNavItem>
-				)}
+					{permissions.viewAllLicenses && (
+						<SidebarNavItem href="/deployment/licenses">
+							Licenses
+						</SidebarNavItem>
+					)}
+					{permissions.editDeploymentConfig && (
+						<SidebarNavItem href="/deployment/appearance">
+							Appearance
+						</SidebarNavItem>
+					)}
+					{permissions.viewAllUsers && (
+						<SidebarNavItem href="/deployment/users">Users</SidebarNavItem>
+					)}
+					{permissions.viewAnyGroup && (
+						<SidebarNavItem href="/deployment/groups">
+							<div className="flex flex-row items-center gap-1">
+								Groups {showOrganizations && <ArrowUpRightIcon size={16} />}
+							</div>
+						</SidebarNavItem>
+					)}
+					{permissions.viewNotificationTemplate && (
+						<SidebarNavItem href="/deployment/notifications">
+							Notifications
+						</SidebarNavItem>
+					)}
+					{!hasPremiumLicense && (
+						<SidebarNavItem href="/deployment/premium">Premium</SidebarNavItem>
+					)}
+				</div>
+			</SidebarAccordion>
 
-				{permissions.viewAllUsers && (
-					<SidebarNavItem href="/deployment/users">Users</SidebarNavItem>
-				)}
-				{permissions.viewAnyGroup && (
-					<SidebarNavItem href="/deployment/groups">
-						<div className="flex flex-row items-center gap-1">
-							Groups {showOrganizations && <ArrowUpRightIcon size={16} />}
-						</div>
-					</SidebarNavItem>
-				)}
-				{permissions.viewOrganizationIDPSyncSettings && (
-					<SidebarNavItem href="/deployment/idp-org-sync">
-						IdP Organization Sync
-					</SidebarNavItem>
-				)}
-				{permissions.viewNotificationTemplate && (
-					<SidebarNavItem href="/deployment/notifications">
-						<div className="flex flex-row items-center gap-2">
-							<span>Notifications</span>
-						</div>
-					</SidebarNavItem>
-				)}
-				{!hasPremiumLicense && (
-					<SidebarNavItem href="/deployment/premium">Premium</SidebarNavItem>
-				)}
-			</div>
-		</BaseSidebar>
+			<SidebarAccordion
+				icon={HardDriveIcon}
+				label="Infrastructure"
+				href="/deployment/security"
+				open={openSections.has("infrastructure")}
+				onToggle={() => toggleSection("infrastructure")}
+				active={activeSection === "infrastructure"}
+			>
+				<div className="flex flex-col gap-1">
+					{permissions.viewDeploymentConfig && (
+						<SidebarNavItem href="/deployment/security">
+							Security
+						</SidebarNavItem>
+					)}
+					{permissions.viewDeploymentConfig && (
+						<SidebarNavItem href="/deployment/observability">
+							Observability
+						</SidebarNavItem>
+					)}
+					{permissions.readWorkspaceProxies && (
+						<SidebarNavItem href="/deployment/workspace-proxies">
+							Workspace proxies
+						</SidebarNavItem>
+					)}
+					{permissions.viewDeploymentConfig && (
+						<SidebarNavItem href="/deployment/network">Network</SidebarNavItem>
+					)}
+				</div>
+			</SidebarAccordion>
+
+			<SidebarAccordion
+				icon={UserLockIcon}
+				label="Authentication"
+				href="/deployment/userauth"
+				open={openSections.has("authentication")}
+				onToggle={() => toggleSection("authentication")}
+				active={activeSection === "authentication"}
+			>
+				<div className="flex flex-col gap-1">
+					{permissions.viewDeploymentConfig && (
+						<SidebarNavItem href="/deployment/userauth">
+							User authentication
+						</SidebarNavItem>
+					)}
+					{permissions.viewDeploymentConfig && (
+						<SidebarNavItem href="/deployment/external-auth">
+							External authentication
+						</SidebarNavItem>
+					)}
+					{permissions.viewDeploymentConfig &&
+						(experiments.includes("oauth2") ||
+							getPrereleaseFlag(buildInfo) === "devel") && (
+							<SidebarNavItem href="/deployment/oauth2-provider/apps">
+								OAuth2 applications
+							</SidebarNavItem>
+						)}
+					{permissions.viewOrganizationIDPSyncSettings && (
+						<SidebarNavItem href="/deployment/idp-org-sync">
+							IdP organization sync
+						</SidebarNavItem>
+					)}
+				</div>
+			</SidebarAccordion>
+		</div>
 	);
 };

--- a/site/src/modules/management/LogsSidebar.tsx
+++ b/site/src/modules/management/LogsSidebar.tsx
@@ -1,0 +1,30 @@
+import type { FC } from "react";
+import { useAuthenticated } from "#/hooks/useAuthenticated";
+import { useFeatureVisibility } from "#/modules/dashboard/useFeatureVisibility";
+import LogsSidebarView from "./LogsSidebarView";
+import { useActiveLogsSection } from "./useActiveLogsSection";
+
+/**
+ * A sidebar for the logs section. Derives page visibility from
+ * entitlement features and site-wide permissions.
+ */
+export const LogsSidebar: FC = () => {
+	const { permissions } = useAuthenticated();
+	const featureVisibility = useFeatureVisibility();
+	const activeSection = useActiveLogsSection();
+
+	return (
+		<LogsSidebarView
+			canViewAuditLog={
+				featureVisibility.audit_log && permissions.viewAnyAuditLog
+			}
+			canViewConnectionLog={
+				featureVisibility.connection_log && permissions.viewAnyConnectionLog
+			}
+			canViewAIBridge={
+				featureVisibility.aibridge && permissions.viewAnyAIBridgeInterception
+			}
+			activeSection={activeSection}
+		/>
+	);
+};

--- a/site/src/modules/management/LogsSidebarView.stories.tsx
+++ b/site/src/modules/management/LogsSidebarView.stories.tsx
@@ -1,4 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+import { reactRouterParameters } from "storybook-addon-remix-react-router";
+import { CollapsibleSidebar } from "#/components/Sidebar/CollapsibleSidebar";
 import { SidebarContext } from "#/components/Sidebar/SidebarContext";
 import LogsSidebarView from "./LogsSidebarView";
 
@@ -34,7 +37,12 @@ export const Collapsed: Story = {
 	decorators: [
 		(Story) => (
 			<SidebarContext.Provider
-				value={{ collapsed: true, expand: () => {}, toggle: () => {} }}
+				value={{
+					collapsed: true,
+					expand: () => {},
+					collapse: () => {},
+					toggle: () => {},
+				}}
 			>
 				<Story />
 			</SidebarContext.Provider>
@@ -64,5 +72,91 @@ export const AuditOnly: Story = {
 	args: {
 		canViewConnectionLog: false,
 		canViewAIBridge: false,
+	},
+};
+
+// Overlay stories render the view inside a real CollapsibleSidebar in
+// overlay mode, next to a fake content column, so the flyout behavior
+// can be exercised. Each story uses its own storage key, seeded by a
+// decorator, so interactions cannot leak between stories.
+const withOverlaySidebar =
+	(storageKey: string, persisted?: "collapsed" | "expanded", peek?: boolean) =>
+	(Story: React.ComponentType) => {
+		if (persisted === undefined) {
+			localStorage.removeItem(storageKey);
+		} else {
+			localStorage.setItem(storageKey, persisted);
+		}
+		return (
+			<div className="flex flex-row h-[400px]">
+				<div className="border-0 border-r border-solid border-border">
+					<CollapsibleSidebar
+						storageKey={storageKey}
+						overlay
+						peekOnMount={peek}
+					>
+						<Story />
+					</CollapsibleSidebar>
+				</div>
+				<div className="flex-1 min-w-0 p-6 text-sm text-content-secondary">
+					Wide table content that the expanded sidebar overlays instead of
+					pushing aside.
+				</div>
+			</div>
+		);
+	};
+
+const overlayRouting = reactRouterParameters({
+	location: { path: "/audit" },
+	routing: [
+		{ path: "/audit", useStoryElement: true },
+		{ path: "/connectionlog", useStoryElement: true },
+		{ path: "/ai-gateway/sessions", useStoryElement: true },
+	],
+});
+
+export const OverlayExpanded: Story = {
+	decorators: [withOverlaySidebar("story-logs-overlay-expanded", "expanded")],
+	parameters: { reactRouter: overlayRouting },
+};
+
+export const OverlayCollapsed: Story = {
+	decorators: [withOverlaySidebar("story-logs-overlay-collapsed", "collapsed")],
+	parameters: { reactRouter: overlayRouting },
+};
+
+export const OverlayNavItemClickCollapses: Story = {
+	decorators: [withOverlaySidebar("story-logs-overlay-click", "expanded")],
+	parameters: { reactRouter: overlayRouting },
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const link = await canvas.findByRole("link", { name: "Connection logs" });
+		await userEvent.click(link);
+		// Collapsed mode replaces labeled links with icon-only links, so
+		// the accessible name disappears once the sidebar collapses.
+		await waitFor(() => {
+			expect(
+				canvas.queryByRole("link", { name: "Connection logs" }),
+			).not.toBeInTheDocument();
+		});
+	},
+};
+
+export const OverlayPeekOnMount: Story = {
+	decorators: [withOverlaySidebar("story-logs-overlay-peek", undefined, true)],
+	parameters: { reactRouter: overlayRouting },
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// The peek starts expanded, showing labeled links.
+		await canvas.findByRole("link", { name: "Audit logs" });
+		// After the peek delay the sidebar auto-collapses to icons.
+		await waitFor(
+			() => {
+				expect(
+					canvas.queryByRole("link", { name: "Audit logs" }),
+				).not.toBeInTheDocument();
+			},
+			{ timeout: 3000 },
+		);
 	},
 };

--- a/site/src/modules/management/LogsSidebarView.stories.tsx
+++ b/site/src/modules/management/LogsSidebarView.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SidebarContext } from "#/components/Sidebar/SidebarContext";
+import LogsSidebarView from "./LogsSidebarView";
+
+const meta: Meta<typeof LogsSidebarView> = {
+	title: "modules/management/LogsSidebarView",
+	component: LogsSidebarView,
+	args: {
+		canViewAuditLog: true,
+		canViewConnectionLog: true,
+		canViewAIBridge: true,
+		activeSection: "audit",
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof LogsSidebarView>;
+
+export const AuditActive: Story = {};
+
+export const ConnectionActive: Story = {
+	args: {
+		activeSection: "connection",
+	},
+};
+
+export const AISessionsActive: Story = {
+	args: {
+		activeSection: "ai-sessions",
+	},
+};
+
+export const Collapsed: Story = {
+	decorators: [
+		(Story) => (
+			<SidebarContext.Provider
+				value={{ collapsed: true, expand: () => {}, toggle: () => {} }}
+			>
+				<Story />
+			</SidebarContext.Provider>
+		),
+	],
+};
+
+export const NoAuditLog: Story = {
+	args: {
+		canViewAuditLog: false,
+	},
+};
+
+export const NoConnectionLog: Story = {
+	args: {
+		canViewConnectionLog: false,
+	},
+};
+
+export const NoAIBridge: Story = {
+	args: {
+		canViewAIBridge: false,
+	},
+};
+
+export const AuditOnly: Story = {
+	args: {
+		canViewConnectionLog: false,
+		canViewAIBridge: false,
+	},
+};

--- a/site/src/modules/management/LogsSidebarView.tsx
+++ b/site/src/modules/management/LogsSidebarView.tsx
@@ -28,7 +28,7 @@ const LogsSidebarView: FC<LogsSidebarViewProps> = ({
 	canViewAIBridge,
 	activeSection,
 }) => {
-	const { collapsed, toggle } = useSidebarContext();
+	const { collapsed, collapse, toggle } = useSidebarContext();
 
 	return (
 		<div className="flex flex-col gap-1">
@@ -59,6 +59,8 @@ const LogsSidebarView: FC<LogsSidebarViewProps> = ({
 					href={linkToAuditing}
 					icon={ScrollTextIcon}
 					active={activeSection === "audit"}
+					onNavigate={collapse}
+					expandOnCollapsedClick={false}
 				/>
 			)}
 			{canViewConnectionLog && (
@@ -67,6 +69,8 @@ const LogsSidebarView: FC<LogsSidebarViewProps> = ({
 					href="/connectionlog"
 					icon={CableIcon}
 					active={activeSection === "connection"}
+					onNavigate={collapse}
+					expandOnCollapsedClick={false}
 				/>
 			)}
 			{canViewAIBridge && (
@@ -75,6 +79,8 @@ const LogsSidebarView: FC<LogsSidebarViewProps> = ({
 					href="/ai-gateway/sessions"
 					icon={BotMessageSquareIcon}
 					active={activeSection === "ai-sessions"}
+					onNavigate={collapse}
+					expandOnCollapsedClick={false}
 				/>
 			)}
 		</div>

--- a/site/src/modules/management/LogsSidebarView.tsx
+++ b/site/src/modules/management/LogsSidebarView.tsx
@@ -1,0 +1,84 @@
+import {
+	BotMessageSquareIcon,
+	CableIcon,
+	PanelLeftIcon,
+	ScrollTextIcon,
+} from "lucide-react";
+import type { FC } from "react";
+import { useSidebarContext } from "#/components/Sidebar/SidebarContext";
+import { linkToAuditing } from "#/modules/navigation";
+import { cn } from "#/utils/cn";
+import { SidebarTopLevelNavItem } from "./SidebarTopLevelNavItem";
+import type { LogsSection } from "./useActiveLogsSection";
+
+interface LogsSidebarViewProps {
+	canViewAuditLog: boolean;
+	canViewConnectionLog: boolean;
+	canViewAIBridge: boolean;
+	/** Which section is active based on the current route. */
+	activeSection: LogsSection;
+}
+
+/**
+ * Displays navigation for the logs section as flat icon+label links.
+ */
+const LogsSidebarView: FC<LogsSidebarViewProps> = ({
+	canViewAuditLog,
+	canViewConnectionLog,
+	canViewAIBridge,
+	activeSection,
+}) => {
+	const { collapsed, toggle } = useSidebarContext();
+
+	return (
+		<div className="flex flex-col gap-1">
+			<button
+				type="button"
+				onClick={toggle}
+				className={cn(
+					"group flex items-center bg-transparent border-none cursor-pointer mb-1 p-0",
+					collapsed
+						? "w-10 h-10 justify-center rounded-md"
+						: "w-full px-3 rounded-md h-10",
+				)}
+			>
+				{!collapsed && (
+					<span className="text-sm text-content-secondary">Logs</span>
+				)}
+				<PanelLeftIcon
+					className={cn(
+						"size-4 text-content-secondary group-hover:text-content-primary transition-colors",
+						!collapsed && "ml-auto",
+					)}
+				/>
+			</button>
+
+			{canViewAuditLog && (
+				<SidebarTopLevelNavItem
+					label="Audit logs"
+					href={linkToAuditing}
+					icon={ScrollTextIcon}
+					active={activeSection === "audit"}
+				/>
+			)}
+			{canViewConnectionLog && (
+				<SidebarTopLevelNavItem
+					label="Connection logs"
+					href="/connectionlog"
+					icon={CableIcon}
+					active={activeSection === "connection"}
+				/>
+			)}
+			{canViewAIBridge && (
+				<SidebarTopLevelNavItem
+					label="AI session logs"
+					href="/ai-gateway/sessions"
+					icon={BotMessageSquareIcon}
+					active={activeSection === "ai-sessions"}
+				/>
+			)}
+		</div>
+	);
+};
+
+export default LogsSidebarView;

--- a/site/src/modules/management/OrganizationSettingsLayout.tsx
+++ b/site/src/modules/management/OrganizationSettingsLayout.tsx
@@ -4,14 +4,6 @@ import { Outlet, useParams } from "react-router";
 import { organizationsPermissions } from "#/api/queries/organizations";
 import type { Organization } from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
-import { Avatar } from "#/components/Avatar/Avatar";
-import {
-	Breadcrumb,
-	BreadcrumbItem,
-	BreadcrumbList,
-	BreadcrumbPage,
-	BreadcrumbSeparator,
-} from "#/components/Breadcrumb/Breadcrumb";
 import { Loader } from "#/components/Loader/Loader";
 import { useDashboard } from "#/modules/dashboard/useDashboard";
 import {
@@ -91,41 +83,9 @@ const OrganizationSettingsLayout: FC = () => {
 				organizationPermissions,
 			}}
 		>
-			<div>
-				<Breadcrumb>
-					<BreadcrumbList>
-						<BreadcrumbItem>
-							<BreadcrumbPage>Admin Settings</BreadcrumbPage>
-						</BreadcrumbItem>
-						<BreadcrumbSeparator />
-						<BreadcrumbItem>
-							<BreadcrumbPage className="flex items-center gap-2">
-								Organizations
-							</BreadcrumbPage>
-						</BreadcrumbItem>
-						{organization && (
-							<>
-								<BreadcrumbSeparator />
-								<BreadcrumbItem>
-									<BreadcrumbPage className="text-content-primary">
-										<Avatar
-											key={organization.id}
-											size="sm"
-											fallback={organization.display_name}
-											src={organization.icon}
-										/>
-										{organization.display_name}
-									</BreadcrumbPage>
-								</BreadcrumbItem>
-							</>
-						)}
-					</BreadcrumbList>
-				</Breadcrumb>
-				<div className="h-px border-none bg-border" />
-				<Suspense fallback={<Loader />}>
-					<Outlet />
-				</Suspense>
-			</div>
+			<Suspense fallback={<Loader />}>
+				<Outlet />
+			</Suspense>
 		</OrganizationSettingsContext.Provider>
 	);
 };

--- a/site/src/modules/management/OrganizationSidebar.tsx
+++ b/site/src/modules/management/OrganizationSidebar.tsx
@@ -1,11 +1,10 @@
 import type { FC } from "react";
-import { Sidebar as BaseSidebar } from "#/components/Sidebar/Sidebar";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
 import { useOrganizationSettings } from "#/modules/management/OrganizationSettingsLayout";
 import { OrganizationSidebarView } from "./OrganizationSidebarView";
 
 /**
- * Sidebar for the OrganizationSettingsLayout
+ * Sidebar for the OrganizationSidebarLayout
  */
 export const OrganizationSidebar: FC = () => {
 	const { permissions } = useAuthenticated();
@@ -13,13 +12,11 @@ export const OrganizationSidebar: FC = () => {
 		useOrganizationSettings();
 
 	return (
-		<BaseSidebar>
-			<OrganizationSidebarView
-				activeOrganization={organization}
-				orgPermissions={organizationPermissions}
-				organizations={organizations}
-				permissions={permissions}
-			/>
-		</BaseSidebar>
+		<OrganizationSidebarView
+			activeOrganization={organization}
+			orgPermissions={organizationPermissions}
+			organizations={organizations}
+			permissions={permissions}
+		/>
 	);
 };

--- a/site/src/modules/management/OrganizationSidebarLayout.tsx
+++ b/site/src/modules/management/OrganizationSidebarLayout.tsx
@@ -1,20 +1,25 @@
 import { type FC, Suspense } from "react";
 import { Outlet } from "react-router";
 import { Loader } from "#/components/Loader/Loader";
+import { CollapsibleSidebar } from "#/components/Sidebar/CollapsibleSidebar";
 import { OrganizationSidebar } from "./OrganizationSidebar";
 
 const OrganizationSidebarLayout: FC = () => {
 	return (
-		<section className="px-10 max-w-screen-2xl mx-auto">
-			<div className="flex flex-row gap-28 py-10">
-				<OrganizationSidebar />
-				<div className="grow">
+		<div className="flex flex-row min-h-screen">
+			<div className="relative border-0 border-r border-solid border-border">
+				<CollapsibleSidebar storageKey="organizations-sidebar-width">
+					<OrganizationSidebar />
+				</CollapsibleSidebar>
+			</div>
+			<div className="flex-1 min-w-0 pt-6 pb-10 px-10">
+				<div className="max-w-screen-2xl mx-auto">
 					<Suspense fallback={<Loader />}>
 						<Outlet />
 					</Suspense>
 				</div>
 			</div>
-		</section>
+		</div>
 	);
 };
 

--- a/site/src/modules/management/OrganizationSidebarView.stories.tsx
+++ b/site/src/modules/management/OrganizationSidebarView.stories.tsx
@@ -184,6 +184,24 @@ export const Collapsed: Story = {
 	],
 };
 
+export const ProvisionersAccordion: Story = {
+	args: {
+		activeOrganization: MockOrganization,
+		orgPermissions: MockOrganizationPermissions,
+		organizations: [MockOrganization],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(
+			canvas.getByRole("button", { name: /Provisioners/i }),
+		);
+		await waitFor(() =>
+			expect(canvas.getByRole("link", { name: "Keys" })).toBeVisible(),
+		);
+		await expect(canvas.getByRole("link", { name: "Jobs" })).toBeVisible();
+	},
+};
+
 export const AllPermissions: Story = {
 	args: {
 		activeOrganization: MockOrganization,

--- a/site/src/modules/management/OrganizationSidebarView.stories.tsx
+++ b/site/src/modules/management/OrganizationSidebarView.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, userEvent, waitFor, within } from "storybook/test";
 import type { Organization } from "#/api/typesGenerated";
+import { SidebarContext } from "#/components/Sidebar/SidebarContext";
 import {
 	MockNoOrganizationPermissions,
 	MockNoPermissions,
@@ -159,6 +160,28 @@ export const NoPermissions: Story = {
 		orgPermissions: MockNoOrganizationPermissions,
 		permissions: MockNoPermissions,
 	},
+};
+
+export const Collapsed: Story = {
+	args: {
+		activeOrganization: MockOrganization,
+		orgPermissions: MockOrganizationPermissions,
+		organizations: [MockOrganization],
+	},
+	decorators: [
+		(Story) => (
+			<SidebarContext.Provider
+				value={{
+					collapsed: true,
+					expand: () => {},
+					collapse: () => {},
+					toggle: () => {},
+				}}
+			>
+				<Story />
+			</SidebarContext.Provider>
+		),
+	],
 };
 
 export const AllPermissions: Story = {

--- a/site/src/modules/management/OrganizationSidebarView.tsx
+++ b/site/src/modules/management/OrganizationSidebarView.tsx
@@ -1,6 +1,18 @@
-import { CheckIcon, PlusIcon } from "lucide-react";
+import {
+	CheckIcon,
+	FolderSyncIcon,
+	HammerIcon,
+	KeyIcon,
+	ListChecksIcon,
+	PanelLeftIcon,
+	PlusIcon,
+	SettingsIcon,
+	ShieldIcon,
+	UsersIcon,
+	UsersRoundIcon,
+} from "lucide-react";
 import { type FC, useState } from "react";
-import { useNavigate } from "react-router";
+import { NavLink, useNavigate } from "react-router";
 import type { Organization } from "#/api/typesGenerated";
 import { ChevronDownIcon } from "#/components/AnimatedIcons/ChevronDown";
 import { Avatar } from "#/components/Avatar/Avatar";
@@ -20,8 +32,16 @@ import {
 	PopoverTrigger,
 } from "#/components/Popover/Popover";
 import { SettingsSidebarNavItem } from "#/components/Sidebar/Sidebar";
+import { useSidebarContext } from "#/components/Sidebar/SidebarContext";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
 import type { Permissions } from "#/modules/permissions";
 import type { OrganizationPermissions } from "#/modules/permissions/organizations";
+import { cn } from "#/utils/cn";
 
 interface OrganizationsSettingsNavigationProps {
 	/** The organization selected from the dropdown */
@@ -43,6 +63,7 @@ interface OrganizationsSettingsNavigationProps {
 export const OrganizationSidebarView: FC<
 	OrganizationsSettingsNavigationProps
 > = ({ activeOrganization, orgPermissions, organizations, permissions }) => {
+	const { collapsed, expand, toggle } = useSidebarContext();
 	const sortedOrganizations = [...organizations].sort((a, b) => {
 		// active org first
 		if (a.id === activeOrganization?.id) return -1;
@@ -57,87 +78,135 @@ export const OrganizationSidebarView: FC<
 	const navigate = useNavigate();
 
 	return (
-		<>
-			<Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
-				<PopoverTrigger asChild>
-					<Button
-						variant="outline"
-						aria-expanded={isPopoverOpen}
-						className="w-60 gap-2 justify-start"
-					>
-						{activeOrganization ? (
-							<>
-								<Avatar
-									size="sm"
-									src={activeOrganization.icon}
-									fallback={activeOrganization.display_name}
-								/>
-								<span className="truncate">
-									{activeOrganization.display_name || activeOrganization.name}
-								</span>
-							</>
-						) : (
-							<span className="truncate">No organization selected</span>
-						)}
-						<ChevronDownIcon className="ml-auto !size-icon-sm" />
-					</Button>
-				</PopoverTrigger>
-				<PopoverContent align="start" className="w-60">
-					<Command loop>
-						<CommandInput placeholder="Find organization" />
-						<CommandList>
-							<CommandEmpty>No organization found.</CommandEmpty>
-							<CommandGroup className="pb-2">
-								<div className="flex flex-col max-h-[260px] overflow-y-auto">
-									{sortedOrganizations.map((organization) => (
-										<CommandItem
-											key={organization.id}
-											value={`${organization.display_name} ${organization.name}`}
-											onSelect={() => {
-												setIsPopoverOpen(false);
-												navigate(urlForSubpage(organization.name));
-											}}
-											// There is currently an issue with the cmdk component for keyboard navigation
-											// https://github.com/pacocoursey/cmdk/issues/322
-											tabIndex={0}
-										>
-											<Avatar
-												size="sm"
-												src={organization.icon}
-												fallback={organization.display_name}
-											/>
-											<span className="truncate">
-												{organization?.display_name || organization?.name}
-											</span>
-											{activeOrganization?.name === organization.name && (
-												<CheckIcon className="ml-auto" />
-											)}
-										</CommandItem>
-									))}
-								</div>
-							</CommandGroup>
-							{permissions.createOrganization && (
+		<div className="flex flex-col gap-1">
+			<button
+				type="button"
+				onClick={toggle}
+				className={cn(
+					"group flex items-center bg-transparent border-none cursor-pointer mb-1 p-0",
+					collapsed
+						? "w-10 h-10 justify-center rounded-md"
+						: "w-full px-3 rounded-md h-10",
+				)}
+			>
+				{!collapsed && (
+					<span className="text-sm text-content-secondary">Organizations</span>
+				)}
+				<PanelLeftIcon
+					className={cn(
+						"size-4 text-content-secondary group-hover:text-content-primary transition-colors",
+						!collapsed && "ml-auto",
+					)}
+				/>
+			</button>
+
+			{collapsed ? (
+				activeOrganization && (
+					<TooltipProvider>
+						<Tooltip delayDuration={0}>
+							<TooltipTrigger asChild>
+								{/* The full combobox does not fit the icon rail, so
+								    expand the sidebar to let the user switch orgs. */}
+								<button
+									type="button"
+									onClick={expand}
+									className="flex items-center justify-center w-10 h-10 rounded-md cursor-pointer bg-transparent border-none hover:bg-surface-secondary"
+								>
+									<Avatar
+										size="sm"
+										src={activeOrganization.icon}
+										fallback={activeOrganization.display_name}
+									/>
+								</button>
+							</TooltipTrigger>
+							<TooltipContent side="right">
+								{activeOrganization.display_name || activeOrganization.name}
+							</TooltipContent>
+						</Tooltip>
+					</TooltipProvider>
+				)
+			) : (
+				<Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
+					<PopoverTrigger asChild>
+						<Button
+							variant="outline"
+							aria-expanded={isPopoverOpen}
+							className="w-full gap-2 justify-start"
+						>
+							{activeOrganization ? (
 								<>
-									{organizations.length > 1 && <CommandSeparator />}
-									<CommandGroup>
-										<CommandItem
-											className="flex justify-center data-[selected=true]:bg-transparent"
-											onSelect={() => {
-												setIsPopoverOpen(false);
-												setTimeout(() => {
-													navigate("/organizations/new");
-												}, 200);
-											}}
-										>
-											<PlusIcon /> Create Organization
-										</CommandItem>
-									</CommandGroup>
+									<Avatar
+										size="sm"
+										src={activeOrganization.icon}
+										fallback={activeOrganization.display_name}
+									/>
+									<span className="truncate">
+										{activeOrganization.display_name || activeOrganization.name}
+									</span>
 								</>
+							) : (
+								<span className="truncate">No organization selected</span>
 							)}
-						</CommandList>
-					</Command>
-				</PopoverContent>
-			</Popover>
+							<ChevronDownIcon className="ml-auto !size-icon-sm" />
+						</Button>
+					</PopoverTrigger>
+					<PopoverContent align="start" className="w-60">
+						<Command loop>
+							<CommandInput placeholder="Find organization" />
+							<CommandList>
+								<CommandEmpty>No organization found.</CommandEmpty>
+								<CommandGroup className="pb-2">
+									<div className="flex flex-col max-h-[260px] overflow-y-auto">
+										{sortedOrganizations.map((organization) => (
+											<CommandItem
+												key={organization.id}
+												value={`${organization.display_name} ${organization.name}`}
+												onSelect={() => {
+													setIsPopoverOpen(false);
+													navigate(urlForSubpage(organization.name));
+												}}
+												// There is currently an issue with the cmdk component for keyboard navigation
+												// https://github.com/pacocoursey/cmdk/issues/322
+												tabIndex={0}
+											>
+												<Avatar
+													size="sm"
+													src={organization.icon}
+													fallback={organization.display_name}
+												/>
+												<span className="truncate">
+													{organization?.display_name || organization?.name}
+												</span>
+												{activeOrganization?.name === organization.name && (
+													<CheckIcon className="ml-auto" />
+												)}
+											</CommandItem>
+										))}
+									</div>
+								</CommandGroup>
+								{permissions.createOrganization && (
+									<>
+										{organizations.length > 1 && <CommandSeparator />}
+										<CommandGroup>
+											<CommandItem
+												className="flex justify-center data-[selected=true]:bg-transparent"
+												onSelect={() => {
+													setIsPopoverOpen(false);
+													setTimeout(() => {
+														navigate("/organizations/new");
+													}, 200);
+												}}
+											>
+												<PlusIcon /> Create Organization
+											</CommandItem>
+										</CommandGroup>
+									</>
+								)}
+							</CommandList>
+						</Command>
+					</PopoverContent>
+				</Popover>
+			)}
 			{activeOrganization && orgPermissions && (
 				<OrganizationSettingsNavigation
 					key={activeOrganization.id}
@@ -145,7 +214,7 @@ export const OrganizationSidebarView: FC<
 					orgPermissions={orgPermissions}
 				/>
 			)}
-		</>
+		</div>
 	);
 };
 
@@ -155,6 +224,52 @@ function urlForSubpage(organizationName: string, subpage = ""): string {
 		.join("/");
 }
 
+interface CollapsedNavItemProps {
+	label: string;
+	href: string;
+	icon: FC<{ className?: string }>;
+	end?: boolean;
+}
+
+/**
+ * Icon-only nav link with a tooltip for collapsed mode. Clicking it
+ * navigates and re-expands the sidebar, matching the other push-mode
+ * settings sections.
+ */
+const CollapsedNavItem: FC<CollapsedNavItemProps> = ({
+	label,
+	href,
+	icon: Icon,
+	end,
+}) => {
+	const { expand } = useSidebarContext();
+
+	return (
+		<TooltipProvider>
+			<Tooltip delayDuration={0}>
+				<TooltipTrigger asChild>
+					<NavLink
+						end={end}
+						to={href}
+						onClick={expand}
+						className="flex items-center justify-center w-10 h-10 rounded-md no-underline hover:bg-surface-secondary"
+					>
+						{({ isActive }) => (
+							<Icon
+								className={cn(
+									"size-4 flex-shrink-0 text-content-secondary",
+									isActive && "text-content-primary",
+								)}
+							/>
+						)}
+					</NavLink>
+				</TooltipTrigger>
+				<TooltipContent side="right">{label}</TooltipContent>
+			</Tooltip>
+		</TooltipProvider>
+	);
+};
+
 interface OrganizationSettingsNavigationProps {
 	organization: Organization;
 	orgPermissions: OrganizationPermissions;
@@ -163,59 +278,86 @@ interface OrganizationSettingsNavigationProps {
 const OrganizationSettingsNavigation: FC<
 	OrganizationSettingsNavigationProps
 > = ({ organization, orgPermissions }) => {
+	const { collapsed } = useSidebarContext();
+
+	const navItems = [
+		{
+			label: "Members",
+			href: urlForSubpage(organization.name),
+			icon: UsersIcon,
+			end: true,
+			visible: true,
+		},
+		{
+			label: "Groups",
+			href: urlForSubpage(organization.name, "groups"),
+			icon: UsersRoundIcon,
+			visible: orgPermissions.viewGroups,
+		},
+		{
+			label: "Roles",
+			href: urlForSubpage(organization.name, "roles"),
+			icon: ShieldIcon,
+			visible: orgPermissions.viewOrgRoles,
+		},
+		{
+			label: "Provisioners",
+			href: urlForSubpage(organization.name, "provisioners"),
+			icon: HammerIcon,
+			visible:
+				orgPermissions.viewProvisioners && orgPermissions.viewProvisionerJobs,
+		},
+		{
+			label: "Provisioner Keys",
+			href: urlForSubpage(organization.name, "provisioner-keys"),
+			icon: KeyIcon,
+			visible:
+				orgPermissions.viewProvisioners && orgPermissions.viewProvisionerJobs,
+		},
+		{
+			label: "Provisioner Jobs",
+			href: urlForSubpage(organization.name, "provisioner-jobs"),
+			icon: ListChecksIcon,
+			visible:
+				orgPermissions.viewProvisioners && orgPermissions.viewProvisionerJobs,
+		},
+		{
+			label: "IdP Sync",
+			href: urlForSubpage(organization.name, "idp-sync"),
+			icon: FolderSyncIcon,
+			visible: orgPermissions.viewIdpSyncSettings,
+		},
+		{
+			label: "Settings",
+			href: urlForSubpage(organization.name, "settings"),
+			icon: SettingsIcon,
+			visible: orgPermissions.editSettings,
+		},
+	];
+
 	return (
 		<div className="flex flex-col gap-1 my-2">
-			<SettingsSidebarNavItem end href={urlForSubpage(organization.name)}>
-				Members
-			</SettingsSidebarNavItem>
-			{orgPermissions.viewGroups && (
-				<SettingsSidebarNavItem
-					href={urlForSubpage(organization.name, "groups")}
-				>
-					Groups
-				</SettingsSidebarNavItem>
-			)}
-			{orgPermissions.viewOrgRoles && (
-				<SettingsSidebarNavItem
-					href={urlForSubpage(organization.name, "roles")}
-				>
-					Roles
-				</SettingsSidebarNavItem>
-			)}
-			{orgPermissions.viewProvisioners &&
-				orgPermissions.viewProvisionerJobs && (
-					<>
+			{navItems
+				.filter((item) => item.visible)
+				.map((item) =>
+					collapsed ? (
+						<CollapsedNavItem
+							key={item.href}
+							label={item.label}
+							href={item.href}
+							icon={item.icon}
+							end={item.end}
+						/>
+					) : (
 						<SettingsSidebarNavItem
-							href={urlForSubpage(organization.name, "provisioners")}
+							key={item.href}
+							href={item.href}
+							end={item.end}
 						>
-							Provisioners
+							{item.label}
 						</SettingsSidebarNavItem>
-						<SettingsSidebarNavItem
-							href={urlForSubpage(organization.name, "provisioner-keys")}
-						>
-							Provisioner Keys
-						</SettingsSidebarNavItem>
-						<SettingsSidebarNavItem
-							href={urlForSubpage(organization.name, "provisioner-jobs")}
-						>
-							Provisioner Jobs
-						</SettingsSidebarNavItem>
-					</>
+					),
 				)}
-			{orgPermissions.viewIdpSyncSettings && (
-				<SettingsSidebarNavItem
-					href={urlForSubpage(organization.name, "idp-sync")}
-				>
-					IdP Sync
-				</SettingsSidebarNavItem>
-			)}
-			{orgPermissions.editSettings && (
-				<SettingsSidebarNavItem
-					href={urlForSubpage(organization.name, "settings")}
-				>
-					Settings
-				</SettingsSidebarNavItem>
-			)}
 		</div>
 	);
 };

--- a/site/src/modules/management/OrganizationSidebarView.tsx
+++ b/site/src/modules/management/OrganizationSidebarView.tsx
@@ -1,18 +1,16 @@
 import {
 	CheckIcon,
-	FolderSyncIcon,
-	HammerIcon,
-	KeyIcon,
-	ListChecksIcon,
+	NetworkIcon,
 	PanelLeftIcon,
 	PlusIcon,
+	RepeatIcon,
 	SettingsIcon,
 	ShieldIcon,
-	UsersIcon,
-	UsersRoundIcon,
+	UserIcon,
+	WebhookIcon,
 } from "lucide-react";
-import { type FC, useState } from "react";
-import { NavLink, useNavigate } from "react-router";
+import { type FC, useCallback, useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router";
 import type { Organization } from "#/api/typesGenerated";
 import { ChevronDownIcon } from "#/components/AnimatedIcons/ChevronDown";
 import { Avatar } from "#/components/Avatar/Avatar";
@@ -32,6 +30,7 @@ import {
 	PopoverTrigger,
 } from "#/components/Popover/Popover";
 import { SettingsSidebarNavItem } from "#/components/Sidebar/Sidebar";
+import { SidebarAccordion } from "#/components/Sidebar/SidebarAccordion";
 import { useSidebarContext } from "#/components/Sidebar/SidebarContext";
 import {
 	Tooltip,
@@ -42,6 +41,7 @@ import {
 import type { Permissions } from "#/modules/permissions";
 import type { OrganizationPermissions } from "#/modules/permissions/organizations";
 import { cn } from "#/utils/cn";
+import { SidebarTopLevelNavItem } from "./SidebarTopLevelNavItem";
 
 interface OrganizationsSettingsNavigationProps {
 	/** The organization selected from the dropdown */
@@ -224,51 +224,12 @@ function urlForSubpage(organizationName: string, subpage = ""): string {
 		.join("/");
 }
 
-interface CollapsedNavItemProps {
-	label: string;
-	href: string;
-	icon: FC<{ className?: string }>;
-	end?: boolean;
+function isRouteActive(pathname: string, url: string, end = false): boolean {
+	if (end) {
+		return pathname === url;
+	}
+	return pathname === url || pathname.startsWith(`${url}/`);
 }
-
-/**
- * Icon-only nav link with a tooltip for collapsed mode. Clicking it
- * navigates and re-expands the sidebar, matching the other push-mode
- * settings sections.
- */
-const CollapsedNavItem: FC<CollapsedNavItemProps> = ({
-	label,
-	href,
-	icon: Icon,
-	end,
-}) => {
-	const { expand } = useSidebarContext();
-
-	return (
-		<TooltipProvider>
-			<Tooltip delayDuration={0}>
-				<TooltipTrigger asChild>
-					<NavLink
-						end={end}
-						to={href}
-						onClick={expand}
-						className="flex items-center justify-center w-10 h-10 rounded-md no-underline hover:bg-surface-secondary"
-					>
-						{({ isActive }) => (
-							<Icon
-								className={cn(
-									"size-4 flex-shrink-0 text-content-secondary",
-									isActive && "text-content-primary",
-								)}
-							/>
-						)}
-					</NavLink>
-				</TooltipTrigger>
-				<TooltipContent side="right">{label}</TooltipContent>
-			</Tooltip>
-		</TooltipProvider>
-	);
-};
 
 interface OrganizationSettingsNavigationProps {
 	organization: Organization;
@@ -278,86 +239,107 @@ interface OrganizationSettingsNavigationProps {
 const OrganizationSettingsNavigation: FC<
 	OrganizationSettingsNavigationProps
 > = ({ organization, orgPermissions }) => {
-	const { collapsed } = useSidebarContext();
+	const { pathname } = useLocation();
 
-	const navItems = [
-		{
-			label: "Members",
-			href: urlForSubpage(organization.name),
-			icon: UsersIcon,
-			end: true,
-			visible: true,
-		},
-		{
-			label: "Groups",
-			href: urlForSubpage(organization.name, "groups"),
-			icon: UsersRoundIcon,
-			visible: orgPermissions.viewGroups,
-		},
-		{
-			label: "Roles",
-			href: urlForSubpage(organization.name, "roles"),
-			icon: ShieldIcon,
-			visible: orgPermissions.viewOrgRoles,
-		},
-		{
-			label: "Provisioners",
-			href: urlForSubpage(organization.name, "provisioners"),
-			icon: HammerIcon,
-			visible:
-				orgPermissions.viewProvisioners && orgPermissions.viewProvisionerJobs,
-		},
-		{
-			label: "Provisioner Keys",
-			href: urlForSubpage(organization.name, "provisioner-keys"),
-			icon: KeyIcon,
-			visible:
-				orgPermissions.viewProvisioners && orgPermissions.viewProvisionerJobs,
-		},
-		{
-			label: "Provisioner Jobs",
-			href: urlForSubpage(organization.name, "provisioner-jobs"),
-			icon: ListChecksIcon,
-			visible:
-				orgPermissions.viewProvisioners && orgPermissions.viewProvisionerJobs,
-		},
-		{
-			label: "IdP Sync",
-			href: urlForSubpage(organization.name, "idp-sync"),
-			icon: FolderSyncIcon,
-			visible: orgPermissions.viewIdpSyncSettings,
-		},
-		{
-			label: "Settings",
-			href: urlForSubpage(organization.name, "settings"),
-			icon: SettingsIcon,
-			visible: orgPermissions.editSettings,
-		},
-	];
+	const membersUrl = urlForSubpage(organization.name);
+	const groupsUrl = urlForSubpage(organization.name, "groups");
+	const rolesUrl = urlForSubpage(organization.name, "roles");
+	const provisionersUrl = urlForSubpage(organization.name, "provisioners");
+	const provisionerKeysUrl = urlForSubpage(
+		organization.name,
+		"provisioner-keys",
+	);
+	const provisionerJobsUrl = urlForSubpage(
+		organization.name,
+		"provisioner-jobs",
+	);
+	const idpSyncUrl = urlForSubpage(organization.name, "idp-sync");
+	const settingsUrl = urlForSubpage(organization.name, "settings");
+
+	// The accordion owns the current route when any provisioner page
+	// is open.
+	const provisionersActive = [
+		provisionersUrl,
+		provisionerKeysUrl,
+		provisionerJobsUrl,
+	].some((url) => isRouteActive(pathname, url));
+
+	const [provisionersOpen, setProvisionersOpen] = useState(provisionersActive);
+
+	// When navigation changes the active route, open the accordion
+	// only when one of its pages is active, close otherwise.
+	useEffect(() => {
+		setProvisionersOpen(provisionersActive);
+	}, [provisionersActive]);
+
+	const toggleProvisioners = useCallback(() => {
+		setProvisionersOpen((prev) => !prev);
+	}, []);
 
 	return (
 		<div className="flex flex-col gap-1 my-2">
-			{navItems
-				.filter((item) => item.visible)
-				.map((item) =>
-					collapsed ? (
-						<CollapsedNavItem
-							key={item.href}
-							label={item.label}
-							href={item.href}
-							icon={item.icon}
-							end={item.end}
-						/>
-					) : (
-						<SettingsSidebarNavItem
-							key={item.href}
-							href={item.href}
-							end={item.end}
-						>
-							{item.label}
-						</SettingsSidebarNavItem>
-					),
+			{orgPermissions.viewGroups && (
+				<SidebarTopLevelNavItem
+					label="Groups"
+					href={groupsUrl}
+					icon={NetworkIcon}
+					active={isRouteActive(pathname, groupsUrl)}
+				/>
+			)}
+			<SidebarTopLevelNavItem
+				label="Members"
+				href={membersUrl}
+				icon={UserIcon}
+				end
+				active={isRouteActive(pathname, membersUrl, true)}
+			/>
+			{orgPermissions.viewOrgRoles && (
+				<SidebarTopLevelNavItem
+					label="Roles"
+					href={rolesUrl}
+					icon={ShieldIcon}
+					active={isRouteActive(pathname, rolesUrl)}
+				/>
+			)}
+			{orgPermissions.viewProvisioners &&
+				orgPermissions.viewProvisionerJobs && (
+					<SidebarAccordion
+						icon={WebhookIcon}
+						label="Provisioners"
+						href={provisionersUrl}
+						open={provisionersOpen}
+						onToggle={toggleProvisioners}
+						active={provisionersActive}
+					>
+						<div className="flex flex-col gap-1">
+							<SettingsSidebarNavItem end href={provisionersUrl}>
+								Provisioners
+							</SettingsSidebarNavItem>
+							<SettingsSidebarNavItem href={provisionerKeysUrl}>
+								Keys
+							</SettingsSidebarNavItem>
+							<SettingsSidebarNavItem href={provisionerJobsUrl}>
+								Jobs
+							</SettingsSidebarNavItem>
+						</div>
+					</SidebarAccordion>
 				)}
+			{orgPermissions.viewIdpSyncSettings && (
+				<SidebarTopLevelNavItem
+					label="IdP sync"
+					href={idpSyncUrl}
+					icon={RepeatIcon}
+					active={isRouteActive(pathname, idpSyncUrl)}
+				/>
+			)}
+			{orgPermissions.editSettings && (
+				<SidebarTopLevelNavItem
+					label="Settings"
+					href={settingsUrl}
+					icon={SettingsIcon}
+					active={isRouteActive(pathname, settingsUrl)}
+				/>
+			)}
 		</div>
 	);
 };

--- a/site/src/modules/management/SidebarTopLevelNavItem.tsx
+++ b/site/src/modules/management/SidebarTopLevelNavItem.tsx
@@ -14,6 +14,8 @@ interface SidebarTopLevelNavItemProps {
 	href: string;
 	icon: FC<{ className?: string }>;
 	active: boolean;
+	/** Match the route exactly instead of by prefix (NavLink end). */
+	end?: boolean;
 	/** Called after the link is clicked, in both collapsed and expanded modes. */
 	onNavigate?: () => void;
 	/**
@@ -34,6 +36,7 @@ export const SidebarTopLevelNavItem: FC<SidebarTopLevelNavItemProps> = ({
 	href,
 	icon: Icon,
 	active,
+	end,
 	onNavigate,
 	expandOnCollapsedClick = true,
 }) => {
@@ -71,6 +74,7 @@ export const SidebarTopLevelNavItem: FC<SidebarTopLevelNavItemProps> = ({
 	return (
 		<NavLink
 			to={href}
+			end={end}
 			onClick={onNavigate}
 			className={({ isActive }) =>
 				cn(

--- a/site/src/modules/management/SidebarTopLevelNavItem.tsx
+++ b/site/src/modules/management/SidebarTopLevelNavItem.tsx
@@ -1,0 +1,70 @@
+import type { FC } from "react";
+import { Link, NavLink } from "react-router";
+import { useSidebarContext } from "#/components/Sidebar/SidebarContext";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
+import { cn } from "#/utils/cn";
+
+interface SidebarTopLevelNavItemProps {
+	label: string;
+	href: string;
+	icon: FC<{ className?: string }>;
+	active: boolean;
+}
+
+/**
+ * A flat icon+label link for collapsible settings sidebars. In
+ * collapsed mode it renders as an icon with a tooltip; clicking it
+ * navigates and re-expands the sidebar.
+ */
+export const SidebarTopLevelNavItem: FC<SidebarTopLevelNavItemProps> = ({
+	label,
+	href,
+	icon: Icon,
+	active,
+}) => {
+	const { collapsed, expand } = useSidebarContext();
+
+	if (collapsed) {
+		return (
+			<TooltipProvider>
+				<Tooltip delayDuration={0}>
+					<TooltipTrigger asChild>
+						<Link
+							to={href}
+							onClick={expand}
+							className="flex items-center justify-center w-10 h-10 rounded-md no-underline hover:bg-surface-secondary"
+						>
+							<Icon
+								className={cn(
+									"size-4 flex-shrink-0 text-content-secondary",
+									active && "text-content-primary",
+								)}
+							/>
+						</Link>
+					</TooltipTrigger>
+					<TooltipContent side="right">{label}</TooltipContent>
+				</Tooltip>
+			</TooltipProvider>
+		);
+	}
+
+	return (
+		<NavLink
+			to={href}
+			className={({ isActive }) =>
+				cn(
+					"flex items-center gap-2 px-3 py-2 h-10 rounded-md no-underline text-sm font-medium text-content-secondary hover:bg-surface-secondary transition-colors",
+					isActive && "text-content-primary font-semibold",
+				)
+			}
+		>
+			<Icon className="size-4 flex-shrink-0" />
+			{label}
+		</NavLink>
+	);
+};

--- a/site/src/modules/management/SidebarTopLevelNavItem.tsx
+++ b/site/src/modules/management/SidebarTopLevelNavItem.tsx
@@ -14,6 +14,14 @@ interface SidebarTopLevelNavItemProps {
 	href: string;
 	icon: FC<{ className?: string }>;
 	active: boolean;
+	/** Called after the link is clicked, in both collapsed and expanded modes. */
+	onNavigate?: () => void;
+	/**
+	 * Whether clicking the collapsed icon re-expands the sidebar.
+	 * Overlay sidebars pass false so navigation does not pop the
+	 * flyout back open.
+	 */
+	expandOnCollapsedClick?: boolean;
 }
 
 /**
@@ -26,6 +34,8 @@ export const SidebarTopLevelNavItem: FC<SidebarTopLevelNavItemProps> = ({
 	href,
 	icon: Icon,
 	active,
+	onNavigate,
+	expandOnCollapsedClick = true,
 }) => {
 	const { collapsed, expand } = useSidebarContext();
 
@@ -36,7 +46,12 @@ export const SidebarTopLevelNavItem: FC<SidebarTopLevelNavItemProps> = ({
 					<TooltipTrigger asChild>
 						<Link
 							to={href}
-							onClick={expand}
+							onClick={() => {
+								if (expandOnCollapsedClick) {
+									expand();
+								}
+								onNavigate?.();
+							}}
 							className="flex items-center justify-center w-10 h-10 rounded-md no-underline hover:bg-surface-secondary"
 						>
 							<Icon
@@ -56,6 +71,7 @@ export const SidebarTopLevelNavItem: FC<SidebarTopLevelNavItemProps> = ({
 	return (
 		<NavLink
 			to={href}
+			onClick={onNavigate}
 			className={({ isActive }) =>
 				cn(
 					"flex items-center gap-2 px-3 py-2 h-10 rounded-md no-underline text-sm font-medium text-content-secondary hover:bg-surface-secondary transition-colors",

--- a/site/src/modules/management/useActiveAISection.ts
+++ b/site/src/modules/management/useActiveAISection.ts
@@ -1,0 +1,45 @@
+import { useLocation } from "react-router";
+
+export type AISection =
+	| "governance"
+	| "gateway-keys"
+	| "providers"
+	| "coder-agents";
+
+// Route-prefix-to-section mapping. Order matters: first match wins.
+const SECTION_ROUTES: Array<[string[], AISection]> = [
+	[["/ai/settings/governance"], "governance"],
+	[["/ai/settings/gateway-keys"], "gateway-keys"],
+	[["/ai/settings/providers"], "providers"],
+	[
+		[
+			"/ai/settings/coder-agents",
+			"/ai/settings/models",
+			"/ai/settings/mcp-servers",
+			"/ai/settings/templates",
+			"/ai/settings/spend",
+			"/ai/settings/instructions",
+			"/ai/settings/lifecycle",
+		],
+		"coder-agents",
+	],
+];
+
+/**
+ * Derives the active sidebar section from the current route so the
+ * correct item or accordion can be highlighted on navigation.
+ */
+export function useActiveAISection(): AISection {
+	const { pathname } = useLocation();
+
+	for (const [routes, section] of SECTION_ROUTES) {
+		for (const route of routes) {
+			if (pathname === route || pathname.startsWith(`${route}/`)) {
+				return section;
+			}
+		}
+	}
+
+	// Fall back to "coder-agents" for unknown AI settings routes.
+	return "coder-agents";
+}

--- a/site/src/modules/management/useActiveDeploymentSection.ts
+++ b/site/src/modules/management/useActiveDeploymentSection.ts
@@ -1,0 +1,56 @@
+import { useLocation } from "react-router";
+
+export type DeploymentSection = "general" | "infrastructure" | "authentication";
+
+// Route-prefix-to-section mapping. Order matters: first match wins.
+const SECTION_ROUTES: Array<[string[], DeploymentSection]> = [
+	[
+		[
+			"/deployment/overview",
+			"/deployment/licenses",
+			"/deployment/appearance",
+			"/deployment/users",
+			"/deployment/groups",
+			"/deployment/notifications",
+			"/deployment/premium",
+		],
+		"general",
+	],
+	[
+		[
+			"/deployment/security",
+			"/deployment/observability",
+			"/deployment/workspace-proxies",
+			"/deployment/network",
+		],
+		"infrastructure",
+	],
+	[
+		[
+			"/deployment/userauth",
+			"/deployment/external-auth",
+			"/deployment/oauth2-provider",
+			"/deployment/idp-org-sync",
+		],
+		"authentication",
+	],
+];
+
+/**
+ * Derives the active sidebar section from the current route so the
+ * correct accordion can be opened on navigation.
+ */
+export function useActiveDeploymentSection(): DeploymentSection {
+	const { pathname } = useLocation();
+
+	for (const [routes, section] of SECTION_ROUTES) {
+		for (const route of routes) {
+			if (pathname === route || pathname.startsWith(`${route}/`)) {
+				return section;
+			}
+		}
+	}
+
+	// Fall back to "general" for unknown deployment routes.
+	return "general";
+}

--- a/site/src/modules/management/useActiveLogsSection.ts
+++ b/site/src/modules/management/useActiveLogsSection.ts
@@ -1,0 +1,29 @@
+import { useLocation } from "react-router";
+
+export type LogsSection = "audit" | "connection" | "ai-sessions";
+
+// Route-prefix-to-section mapping. Order matters: first match wins.
+const SECTION_ROUTES: Array<[string[], LogsSection]> = [
+	[["/audit"], "audit"],
+	[["/connectionlog"], "connection"],
+	[["/ai-gateway/sessions"], "ai-sessions"],
+];
+
+/**
+ * Derives the active sidebar section from the current route so the
+ * correct item can be highlighted on navigation.
+ */
+export function useActiveLogsSection(): LogsSection {
+	const { pathname } = useLocation();
+
+	for (const [routes, section] of SECTION_ROUTES) {
+		for (const route of routes) {
+			if (pathname === route || pathname.startsWith(`${route}/`)) {
+				return section;
+			}
+		}
+	}
+
+	// Fall back to "audit" for unknown logs routes.
+	return "audit";
+}

--- a/site/src/pages/AISettingsPage/AISettingsLayout.tsx
+++ b/site/src/pages/AISettingsPage/AISettingsLayout.tsx
@@ -1,20 +1,25 @@
 import { Suspense } from "react";
 import { Outlet } from "react-router";
 import { Loader } from "#/components/Loader/Loader";
+import { CollapsibleSidebar } from "#/components/Sidebar/CollapsibleSidebar";
 import { AISettingsSidebar } from "#/modules/management/AISettingsSidebar";
 
 const AISettingsLayout = () => {
 	return (
-		<section className="px-10 w-full max-w-screen-2xl mx-auto">
-			<div className="flex flex-row gap-28 py-10">
-				<AISettingsSidebar />
-				<div className="grow">
+		<div className="flex flex-row min-h-screen">
+			<div className="border-0 border-r border-solid border-border">
+				<CollapsibleSidebar storageKey="ai-sidebar-width">
+					<AISettingsSidebar />
+				</CollapsibleSidebar>
+			</div>
+			<div className="flex-1 min-w-0 pt-6 pb-10 px-10">
+				<div className="max-w-screen-2xl mx-auto">
 					<Suspense fallback={<Loader />}>
 						<Outlet />
 					</Suspense>
 				</div>
 			</div>
-		</section>
+		</div>
 	);
 };
 

--- a/site/src/pages/LogsPage/LogsLayout.tsx
+++ b/site/src/pages/LogsPage/LogsLayout.tsx
@@ -34,7 +34,7 @@ const LogsLayout = () => {
 	return (
 		<div className="flex flex-row min-h-screen">
 			<div className="border-0 border-r border-solid border-border">
-				<CollapsibleSidebar storageKey="logs-sidebar-width">
+				<CollapsibleSidebar storageKey="logs-sidebar-width" overlay peekOnMount>
 					<LogsSidebar />
 				</CollapsibleSidebar>
 			</div>

--- a/site/src/pages/LogsPage/LogsLayout.tsx
+++ b/site/src/pages/LogsPage/LogsLayout.tsx
@@ -1,0 +1,52 @@
+import { Suspense } from "react";
+import { Navigate, Outlet, useLocation } from "react-router";
+import { Loader } from "#/components/Loader/Loader";
+import { CollapsibleSidebar } from "#/components/Sidebar/CollapsibleSidebar";
+import { useAuthenticated } from "#/hooks/useAuthenticated";
+import { useFeatureVisibility } from "#/modules/dashboard/useFeatureVisibility";
+import { LogsSidebar } from "#/modules/management/LogsSidebar";
+import { linkToAuditing } from "#/modules/navigation";
+
+const LogsLayout = () => {
+	const { permissions } = useAuthenticated();
+	const featureVisibility = useFeatureVisibility();
+	const location = useLocation();
+
+	if (location.pathname === "/logs") {
+		const canViewAuditLog =
+			featureVisibility.audit_log && permissions.viewAnyAuditLog;
+		const canViewConnectionLog =
+			featureVisibility.connection_log && permissions.viewAnyConnectionLog;
+		return (
+			<Navigate
+				to={
+					canViewAuditLog
+						? linkToAuditing
+						: canViewConnectionLog
+							? "/connectionlog"
+							: "/ai-gateway/sessions"
+				}
+				replace
+			/>
+		);
+	}
+
+	return (
+		<div className="flex flex-row min-h-screen">
+			<div className="border-0 border-r border-solid border-border">
+				<CollapsibleSidebar storageKey="logs-sidebar-width">
+					<LogsSidebar />
+				</CollapsibleSidebar>
+			</div>
+			<div className="flex-1 min-w-0 pt-6 pb-10 px-10">
+				<div className="max-w-screen-2xl mx-auto">
+					<Suspense fallback={<Loader />}>
+						<Outlet />
+					</Suspense>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default LogsLayout;

--- a/site/src/pages/LogsPage/LogsLayout.tsx
+++ b/site/src/pages/LogsPage/LogsLayout.tsx
@@ -33,7 +33,7 @@ const LogsLayout = () => {
 
 	return (
 		<div className="flex flex-row min-h-screen">
-			<div className="border-0 border-r border-solid border-border">
+			<div className="relative z-30 border-0 border-r border-solid border-border">
 				<CollapsibleSidebar storageKey="logs-sidebar-width" overlay peekOnMount>
 					<LogsSidebar />
 				</CollapsibleSidebar>

--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -416,6 +416,8 @@ const AIBridgeSessionThreadsPage = lazy(
 	() => import("./pages/AIBridgePage/SessionThreadsPage/SessionThreadsPage"),
 );
 
+const LogsLayout = lazy(() => import("./pages/LogsPage/LogsLayout"));
+
 const AISettingsLayout = lazy(
 	() => import("./pages/AISettingsPage/AISettingsLayout"),
 );
@@ -606,9 +608,26 @@ export const router = createBrowserRouter(
 						element={<Navigate to="/deployment/groups" replace />}
 					/>
 
-					<Route path="/audit" element={<AuditPage />} />
+					<Route element={<LogsLayout />}>
+						{/* /logs only redirects to the first permitted log page;
+						    the layout handles it before rendering the outlet. */}
+						<Route path="/logs" element={null} />
 
-					<Route path="/connectionlog" element={<ConnectionLogPage />} />
+						<Route path="/audit" element={<AuditPage />} />
+
+						<Route path="/connectionlog" element={<ConnectionLogPage />} />
+
+						<Route
+							path="/ai-gateway/sessions"
+							element={<AIBridgeSessionsLayout />}
+						>
+							<Route index element={<AIBridgeListSessionsPage />} />
+							<Route
+								path=":sessionId"
+								element={<AIBridgeSessionThreadsPage />}
+							/>
+						</Route>
+					</Route>
 
 					<Route path="/tasks" element={<TasksPage />} />
 
@@ -732,14 +751,6 @@ export const router = createBrowserRouter(
 							index
 							element={<Navigate to="/ai-gateway/sessions" replace />}
 						/>
-					</Route>
-
-					<Route
-						path="/ai-gateway/sessions"
-						element={<AIBridgeSessionsLayout />}
-					>
-						<Route index element={<AIBridgeListSessionsPage />} />
-						<Route path=":sessionId" element={<AIBridgeSessionThreadsPage />} />
 					</Route>
 
 					{/* Legacy /aibridge routes redirect to /ai-gateway */}

--- a/site/src/utils/mobile.ts
+++ b/site/src/utils/mobile.ts
@@ -21,3 +21,14 @@ export const belowMdViewportMediaQuery = "(max-width: 767px)";
 export const isBelowMdViewport = (): boolean => {
 	return window.matchMedia(belowMdViewportMediaQuery).matches;
 };
+
+export const belowLgViewportMediaQuery = "(max-width: 1023px)";
+
+/**
+ * Returns `true` when the viewport width is below the `lg` Tailwind
+ * breakpoint (< 1024 px). Settings sidebars auto-collapse to their
+ * icon rail at this width so page content is not cut off.
+ */
+export const isBelowLgViewport = (): boolean => {
+	return window.matchMedia(belowLgViewportMediaQuery).matches;
+};


### PR DESCRIPTION
Resurrects the collapsible sidebar navigation from #25450, ported fresh onto current `main` and adapted to the structure that landed since (notably #25582, which promoted AI settings to `/ai/settings`).

## What changed

### New shared sidebar system (`site/src/components/Sidebar/`)
- `CollapsibleSidebar`, `SidebarContext`, `SidebarResizeHandle`, `useSidebarResize`, `SidebarAccordion`
- Two-state model: 240px expanded / 64px collapsed, persisted in localStorage per `storageKey`
- Drag-to-resize writes width directly to the DOM (no re-render stutter) with a 3px click dead zone; click-to-toggle and snap use a CSS transition
- Nav always renders at 240px inside an `overflow-hidden` clipper, so content never reflows during collapse
- Accordion sections render icon-only with tooltips when collapsed

### Deployment settings (`/deployment`)
- Sidebar grouped into 3 accordions: General, Infrastructure, Authentication, with a "Deployment" header row + PanelLeft toggle
- Every existing nav item and permission gate is preserved (including Groups, Notifications, Premium, and the OAuth2 experiments gate), unlike the original PR which dropped some
- Labels moved to sentence case ("Workspace proxies", "User authentication", ...)
- Breadcrumb header replaced by the collapsible layout

### AI settings (`/ai/settings`)
- Same collapsible layout treatment
- Top-level icon links: AI Governance, AI Gateway keys, Providers; "Coder Agents" becomes an accordion containing Models, MCP servers, Templates, Spend, Instructions, Lifecycle
- All hrefs and permission gates unchanged

## Deliberately not ported from #25450
- Mock AI pages (real Providers/Models pages landed via the DEVEX-355 stack)
- `index.css` changes (would have reverted colorblind themes and the mobile dropdown CSS now on main)
- `DeploymentDropdown` edits (superseded by the shared `adminSettings.ts` from #27209)
- Pagination styling cherry-pick and Vite checker tweak

## Testing
- `pnpm lint`, `pnpm format` clean
- `pnpm test:storybook` on `DeploymentSidebarView.stories.tsx` and `AISettingsSidebarView.stories.tsx`: 19/19 pass, with new stories for each active section and collapsed mode

> This PR was created by Coder Agents on behalf of @tracyjohnsonux and needs a human review.