### PR TITLE
fix(site): redesign provider tri-state controls

### DIFF
--- a/site/src/pages/AISettingsPage/ModelsPage/components/ModelForm.stories.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ModelForm.stories.tsx
@@ -218,18 +218,24 @@ export const EditUpdateDisabledUntilDirty: Story = {
 	},
 };
 
-export const ReasoningEffortVisibleWithoutExpanding: Story = {
+export const ReasoningEffortInProviderConfiguration: Story = {
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
 
-		const defaultSelect = canvas.getByRole("combobox", {
-			name: /default reasoning effort/i,
-		});
+		await userEvent.click(
+			canvas.getByRole("button", { name: /provider configuration/i }),
+		);
 		const maxSelect = canvas.getByRole("combobox", {
 			name: /max reasoning effort/i,
 		});
-		await expect(defaultSelect).toBeVisible();
+		const defaultSelect = canvas.getByRole("combobox", {
+			name: /default reasoning effort/i,
+		});
 		await expect(maxSelect).toBeVisible();
+		await expect(defaultSelect).toBeVisible();
+		await expect(maxSelect.compareDocumentPosition(defaultSelect)).toBe(
+			Node.DOCUMENT_POSITION_FOLLOWING,
+		);
 		await expect(defaultSelect).toHaveTextContent("Not set");
 		await expect(maxSelect).toHaveTextContent("Not set");
 
@@ -271,6 +277,9 @@ export const ReasoningEffortVisibleWithoutExpanding: Story = {
 export const ReasoningEffortValidationError: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
+		await userEvent.click(
+			canvas.getByRole("button", { name: /provider configuration/i }),
+		);
 		const defaultSelect = canvas.getByRole("combobox", {
 			name: /default reasoning effort/i,
 		});

--- a/site/src/pages/AISettingsPage/ModelsPage/components/ModelForm.stories.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ModelForm.stories.tsx
@@ -219,12 +219,16 @@ export const EditUpdateDisabledUntilDirty: Story = {
 };
 
 export const ReasoningEffortInProviderConfiguration: Story = {
+	args: {
+		selectedProviderState: MockAnthropicProviderState,
+	},
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
 
 		await userEvent.click(
 			canvas.getByRole("button", { name: /provider configuration/i }),
 		);
+		const thinkingBudget = canvas.getByLabelText(/thinking budget tokens/i);
 		const maxSelect = canvas.getByRole("combobox", {
 			name: /max reasoning effort/i,
 		});
@@ -233,6 +237,9 @@ export const ReasoningEffortInProviderConfiguration: Story = {
 		});
 		await expect(maxSelect).toBeVisible();
 		await expect(defaultSelect).toBeVisible();
+		await expect(thinkingBudget.compareDocumentPosition(maxSelect)).toBe(
+			Node.DOCUMENT_POSITION_FOLLOWING,
+		);
 		await expect(maxSelect.compareDocumentPosition(defaultSelect)).toBe(
 			Node.DOCUMENT_POSITION_FOLLOWING,
 		);

--- a/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormFields.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormFields.tsx
@@ -240,12 +240,6 @@ export const ModelFormFields: FC<{
 							</InputGroupAddon>
 						</InputGroup>
 					</div>
-					<ReasoningEffortConfigFields
-						provider={selectedProviderState.provider}
-						form={form}
-						fieldErrors={modelConfigFormBuildResult.fieldErrors}
-						disabled={isSaving}
-					/>
 				</div>
 
 				<div className="overflow-hidden rounded-lg border border-solid border-border">
@@ -278,7 +272,14 @@ export const ModelFormFields: FC<{
 								form={form}
 								fieldErrors={modelConfigFormBuildResult.fieldErrors}
 								disabled={isSaving}
-							/>
+							>
+								<ReasoningEffortConfigFields
+									provider={selectedProviderState.provider}
+									form={form}
+									fieldErrors={modelConfigFormBuildResult.fieldErrors}
+									disabled={isSaving}
+								/>
+							</ModelConfigFields>
 						</CollapsibleSection>
 					)}
 

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelConfigFields.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelConfigFields.tsx
@@ -43,8 +43,9 @@ import {
 } from "./pricingFields";
 
 const booleanFieldOptions = [
-	{ label: "On", value: "true" },
 	{ label: "Off", value: "false" },
+	{ label: "On", value: "true" },
+	{ label: "Default", value: "" },
 ] as const;
 
 /** Sentinel value for Select components to represent "no selection". */
@@ -325,13 +326,12 @@ const SegmentedField: FC<
 	const currentValue = (getIn(form.values, fieldKey) as string) || "";
 
 	return (
-		<div className="flex min-w-0 flex-col gap-1.5">
-			<FieldLabel htmlFor={fieldKey} label={label} description={description} />
+		<div className="flex min-w-0 flex-wrap items-center gap-2 self-stretch">
 			<div
 				role="radiogroup"
 				aria-label={label}
 				className={cn(
-					"flex h-9 items-stretch rounded-md border border-solid border-border p-0.5",
+					"flex items-center gap-0.75 rounded-lg border border-solid border-border p-2",
 					fieldError && "border-content-destructive",
 				)}
 			>
@@ -345,23 +345,34 @@ const SegmentedField: FC<
 							aria-checked={isActive}
 							disabled={disabled}
 							className={cn(
-								"h-8 flex-1 cursor-pointer rounded-[5px] border-0 px-3 text-[13px] font-medium transition-colors",
+								"flex h-6 cursor-pointer items-center justify-center gap-2.5 rounded-xl border-0 px-2 pb-px text-sm font-normal leading-6 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring",
 								isActive
-									? "bg-surface-secondary text-content-primary"
+									? "rounded bg-surface-tertiary text-content-primary"
 									: "bg-transparent text-content-secondary hover:text-content-primary",
 								disabled && "pointer-events-none opacity-60",
 							)}
-							onClick={() =>
-								void form.setFieldValue(fieldKey, isActive ? "" : opt.value)
-							}
+							onClick={() => void form.setFieldValue(fieldKey, opt.value)}
 						>
 							{opt.label}
 						</button>
 					);
 				})}
 			</div>
+			<div className="flex items-center gap-1 text-sm font-normal leading-6 text-content-primary">
+				<span>{label}</span>
+				{description && (
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<InfoIcon className="size-3 text-content-secondary" />
+						</TooltipTrigger>
+						<TooltipContent side="top" className="max-w-[240px]">
+							{description}
+						</TooltipContent>
+					</Tooltip>
+				)}
+			</div>
 			{fieldError && (
-				<p id={errorId} className="m-0 text-xs text-content-destructive">
+				<p id={errorId} className="m-0 w-full text-xs text-content-destructive">
 					{fieldError}
 				</p>
 			)}
@@ -518,18 +529,14 @@ const SchemaField: FC<SchemaFieldProps> = ({
 
 /**
  * How many grid columns a field should span in the 3-col layout.
- *   1 = default (inputs, booleans, small enums)
- *   3 = full-width (large enums, json textareas)
+ *   1 = default (inputs, small enums)
+ *   3 = full-width (booleans, large enums, json textareas)
  */
 function colSpan(field: FieldSchema): 1 | 3 {
-	if (field.input_type === "json") {
+	if (field.type === "boolean" || field.input_type === "json") {
 		return 3;
 	}
-	if (
-		field.input_type === "select" &&
-		field.type !== "boolean" &&
-		(field.enum?.length ?? 0) > 3
-	) {
+	if (field.input_type === "select" && (field.enum?.length ?? 0) > 3) {
 		return 3;
 	}
 	return 1;

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelConfigFields.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelConfigFields.tsx
@@ -1,6 +1,6 @@
 import { type FormikContextType, getIn } from "formik";
 import { InfoIcon } from "lucide-react";
-import type { FC, ReactNode } from "react";
+import { type FC, Fragment, type ReactNode } from "react";
 import {
 	type FieldSchema,
 	getVisibleGeneralFields,
@@ -584,25 +584,29 @@ export const ModelConfigFields: FC<ModelConfigFieldsProps> = ({
 
 	return (
 		<div className="grid min-w-0 gap-3 sm:grid-cols-3">
-			{children}
 			{sorted.map((field) => {
 				const fieldKey = `config.${toFormFieldKey(resolved, field.json_name)}`;
 				const errorKey = toFormFieldKey(resolved, field.json_name);
 				return (
-					<div key={fieldKey} className={colSpanClass[colSpan(field)]}>
-						<SchemaField
-							field={field}
-							fieldKey={fieldKey}
-							errorKey={errorKey}
-							form={form}
-							fieldErrors={fieldErrors}
-							disabled={
-								disabled || isFieldConflictDisabled(field, fieldValueByName)
-							}
-						/>
-					</div>
+					<Fragment key={fieldKey}>
+						<div className={colSpanClass[colSpan(field)]}>
+							<SchemaField
+								field={field}
+								fieldKey={fieldKey}
+								errorKey={errorKey}
+								form={form}
+								fieldErrors={fieldErrors}
+								disabled={
+									disabled || isFieldConflictDisabled(field, fieldValueByName)
+								}
+							/>
+						</div>
+						{field.json_name === "thinking.budget_tokens" && children}
+					</Fragment>
 				);
 			})}
+			{!sorted.some((field) => field.json_name === "thinking.budget_tokens") &&
+				children}
 		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelConfigFields.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelConfigFields.tsx
@@ -1,6 +1,6 @@
 import { type FormikContextType, getIn } from "formik";
 import { InfoIcon } from "lucide-react";
-import type { FC } from "react";
+import type { FC, ReactNode } from "react";
 import {
 	type FieldSchema,
 	getVisibleGeneralFields,
@@ -275,7 +275,10 @@ const SelectField: FC<
 			>
 				<SelectTrigger
 					id={fieldKey}
-					className={cn("min-w-0", fieldError && "border-content-destructive")}
+					className={cn(
+						"min-w-0 shadow-none",
+						fieldError && "border-content-destructive",
+					)}
 					aria-invalid={Boolean(fieldError)}
 					aria-describedby={fieldError ? errorId : undefined}
 				>
@@ -542,6 +545,7 @@ interface ModelConfigFieldsProps {
 	form: FormikContextType<ModelFormValues>;
 	fieldErrors: ModelConfigFormBuildResult["fieldErrors"];
 	disabled: boolean;
+	children?: ReactNode;
 }
 
 /**
@@ -556,6 +560,7 @@ export const ModelConfigFields: FC<ModelConfigFieldsProps> = ({
 	form,
 	fieldErrors,
 	disabled,
+	children,
 }) => {
 	const normalized = normalizeProvider(provider);
 	const resolved = resolveProvider(normalized);
@@ -579,6 +584,7 @@ export const ModelConfigFields: FC<ModelConfigFieldsProps> = ({
 
 	return (
 		<div className="grid min-w-0 gap-3 sm:grid-cols-3">
+			{children}
 			{sorted.map((field) => {
 				const fieldKey = `config.${toFormFieldKey(resolved, field.json_name)}`;
 				const errorKey = toFormFieldKey(resolved, field.json_name);
@@ -668,9 +674,9 @@ export const ReasoningEffortConfigFields: FC<ModelConfigFieldsProps> = ({
 	disabled,
 }) => {
 	const ctx: FieldRenderContext = { form, fieldErrors, disabled };
-	const fields = getVisibleGeneralFields().filter(({ json_name }) =>
-		isReasoningEffortField(json_name),
-	);
+	const fields = getVisibleGeneralFields()
+		.filter(({ json_name }) => isReasoningEffortField(json_name))
+		.reverse();
 
 	return (
 		<>


### PR DESCRIPTION
Redesigns provider configuration boolean controls as full-width Off, On, and Default tri-state rows.

Default explicitly clears the provider override, and the control layout matches the updated AI Settings design.