### PR TITLE
feat(site): show compaction threshold in context ring

### DIFF
--- a/site/src/pages/AgentsPage/components/ContextUsageIndicator.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ContextUsageIndicator.stories.tsx
@@ -24,11 +24,15 @@ export const Clean: Story = {
 		usage: {
 			usedTokens: 12_000,
 			contextLimitTokens: 200_000,
+			compressionThreshold: 90,
 			context: MockChatContextClean,
 		},
 	},
 	play: async ({ canvasElement }) => {
 		const button = within(canvasElement).getByRole("button");
+		expect(button.getAttribute("aria-label") ?? "").toContain(
+			"Compacts at 90%",
+		);
 		expect(button.getAttribute("aria-label") ?? "").not.toContain(
 			"Context changed",
 		);
@@ -36,6 +40,7 @@ export const Clean: Story = {
 		await userEvent.hover(button);
 		const body = within(document.body);
 		await waitFor(() => expect(body.getByText("Context files")).toBeVisible());
+		expect(body.getByText("Compacts at 90%")).toBeVisible();
 		// A single context root still shows its directory header.
 		expect(body.getByText("/home/coder")).toBeVisible();
 		expect(body.getByText("/home/coder/.coder/skills")).toBeVisible();

--- a/site/src/pages/AgentsPage/components/ContextUsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/ContextUsageIndicator.tsx
@@ -327,8 +327,14 @@ export const ContextUsageIndicator: FC<{
 	const fileGroups = groupByDirectory(fileItems);
 	const skillGroups = groupByDirectory(skillItems);
 
+	const compactionThreshold =
+		typeof usage?.compressionThreshold === "number" &&
+		Number.isFinite(usage.compressionThreshold) &&
+		usage.compressionThreshold > 0
+			? usage.compressionThreshold
+			: undefined;
 	const ariaLabel = hasPercent
-		? `Context usage ${percentLabel}. ${formatTokenCount(usedTokens)} of ${formatTokenCount(contextLimitTokens)} tokens used.${isDirty ? " Context changed." : ""}`
+		? `Context usage ${percentLabel}. ${formatTokenCount(usedTokens)} of ${formatTokenCount(contextLimitTokens)} tokens used.${compactionThreshold !== undefined ? ` Compacts at ${compactionThreshold}%.` : ""}${isDirty ? " Context changed." : ""}`
 		: isDirty
 			? "Context usage. Context changed."
 			: "Context usage";
@@ -338,13 +344,11 @@ export const ContextUsageIndicator: FC<{
 			{hasPercent
 				? `${percentLabel} - ${formatTokenCountCompact(usedTokens)} / ${formatTokenCountCompact(contextLimitTokens)} context used`
 				: "Context usage unavailable"}
-			{hasPercent &&
-				usage?.compressionThreshold !== undefined &&
-				usage.compressionThreshold > 0 && (
-					<div className="mt-1 text-content-secondary">
-						{`Compacts at ${usage.compressionThreshold}%`}
-					</div>
-				)}
+			{hasPercent && compactionThreshold !== undefined && (
+				<div className="mt-1 text-content-secondary">
+					{`Compacts at ${compactionThreshold}%`}
+				</div>
+			)}
 			{hasContextList && (
 				<div
 					className={cn(
@@ -566,6 +570,7 @@ export const ContextUsageIndicator: FC<{
 				size={RING_SIZE}
 				strokeWidth={RING_STROKE}
 				percent={clampedPercent}
+				markerPercent={compactionThreshold}
 				trackClassName="stroke-content-secondary/25"
 				progressClassName="stroke-current"
 				className={cn("size-icon-sm", toneClassName)}

--- a/site/src/pages/AgentsPage/components/SvgRingProgress.tsx
+++ b/site/src/pages/AgentsPage/components/SvgRingProgress.tsx
@@ -13,20 +13,31 @@ export const SvgRingProgress: FC<{
 	size: number;
 	strokeWidth: number;
 	percent: number;
+	markerPercent?: number;
 	trackClassName?: string;
 	progressClassName?: string;
+	markerClassName?: string;
 	className?: string;
 }> = ({
 	size,
 	strokeWidth,
 	percent,
+	markerPercent,
 	trackClassName = "stroke-surface-tertiary",
 	progressClassName = "stroke-current",
+	markerClassName = "stroke-current",
 	className,
 }) => {
 	const radius = (size - strokeWidth) / 2;
 	const circumference = 2 * Math.PI * radius;
 	const clamped = Math.min(Math.max(percent, 0), 100);
+	const clampedMarker =
+		typeof markerPercent === "number" &&
+		Number.isFinite(markerPercent) &&
+		markerPercent > 0 &&
+		markerPercent < 100
+			? markerPercent
+			: undefined;
 	const offset = circumference * (1 - clamped / 100);
 
 	return (
@@ -61,6 +72,18 @@ export const SvgRingProgress: FC<{
 					strokeDashoffset: offset,
 				}}
 			/>
+			{clampedMarker !== undefined && (
+				<line
+					x1={size - strokeWidth}
+					y1={size / 2}
+					x2={size}
+					y2={size / 2}
+					strokeWidth={1.25}
+					strokeLinecap="butt"
+					className={markerClassName}
+					transform={`rotate(${clampedMarker * 3.6} ${size / 2} ${size / 2})`}
+				/>
+			)}
 		</svg>
 	);
 };


### PR DESCRIPTION
Show the resolved compaction threshold as a same-color tick in the context-usage ring. The threshold remains available in the context popover and its value is included in the indicator's accessible label.

Generated with Coder Agents.
