### PR TITLE
fix(.mcp.json): use pnpm dlx for typescript-language-server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -25,8 +25,9 @@
 				"-workspace",
 				"./site/",
 				"-lsp",
-				"pnpx",
+				"pnpm",
 				"--",
+				"dlx",
 				"typescript-language-server",
 				"--stdio"
 			],


### PR DESCRIPTION
## Problem

The `typescript-language-server` MCP server in `.mcp.json` launched the language server via `pnpx`, but `pnpx` is not installed in the workspace (only `pnpm` is available). As a result the server failed to start and appeared inactive/broken.

## Fix

Swap `pnpx` for the pnpm equivalent, `pnpm dlx`, so the language server is fetched and run correctly:

```diff
 "-lsp",
-"pnpx",
+"pnpm",
 "--",
+"dlx",
 "typescript-language-server",
 "--stdio"
```

## Verification

- `pnpm dlx typescript-language-server@latest --version` returns `5.3.0`.
- Ran the full chain `go run github.com/isaacphi/mcp-language-server@latest -workspace ./site/ -lsp pnpm -- dlx typescript-language-server --stdio`. It logged `Successfully registered all MCP tools` and stayed up cleanly until terminated.

---

_This PR was generated by Coder Agents on behalf of @jeremyruppel._
