### PR TITLE
fix: close chat lifecycle hook enforcement gaps

### DIFF
--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -94,7 +94,7 @@ func Chat(t testing.TB, db database.Store, seed database.Chat) database.Chat {
 
 	chat, err := db.InsertChat(genCtx, database.InsertChatParams{
 		ID:                uuid.NullUUID{},
-		HookAllowedTools:  pqtype.NullRawMessage{},
+		HookAllowedTools:  seed.HookAllowedTools,
 		OrganizationID:    takeFirst(seed.OrganizationID, uuid.New()),
 		OwnerID:           takeFirst(seed.OwnerID, uuid.New()),
 		WorkspaceID:       seed.WorkspaceID,

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -1943,10 +1943,13 @@ CREATE TABLE chat_hook_dispatches (
     end_chat boolean,
     error text,
     decision_reason text,
-    effects_applied_at timestamp with time zone
+    effects_applied_at timestamp with time zone,
+    tool_name text
 );
 
 COMMENT ON TABLE chat_hook_dispatches IS 'One row per lifecycle hook webhook dispatch; id is the wire-protocol dispatch_id (JWT jti).';
+
+COMMENT ON COLUMN chat_hook_dispatches.tool_name IS 'Tool name reviewed by a pre_tool_use or post_tool_use dispatch. NULL for other events and for rows recorded before decision reuse was bound to the tool identity.';
 
 CREATE TABLE chat_messages (
     id bigint NOT NULL,

--- a/coderd/database/migrations/000549_chat_hook_dispatch_tool_name.down.sql
+++ b/coderd/database/migrations/000549_chat_hook_dispatch_tool_name.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE chat_hook_dispatches DROP COLUMN tool_name;

--- a/coderd/database/migrations/000549_chat_hook_dispatch_tool_name.up.sql
+++ b/coderd/database/migrations/000549_chat_hook_dispatch_tool_name.up.sql
@@ -1,0 +1,11 @@
+-- Bind persisted pre_tool_use decisions to the tool they reviewed.
+-- Decision reuse additionally matches the effective reviewed input
+-- (input_override when present, original_input otherwise), so a
+-- decision recorded for one tool call can never be replayed for a
+-- different tool or different input that reuses the same tool-use ID.
+-- Pre-existing rows keep tool_name NULL and never match reuse; the
+-- next attempt dispatches fresh, which is safe under the documented
+-- at-least-once delivery contract.
+ALTER TABLE chat_hook_dispatches ADD COLUMN tool_name text;
+
+COMMENT ON COLUMN chat_hook_dispatches.tool_name IS 'Tool name reviewed by a pre_tool_use or post_tool_use dispatch. NULL for other events and for rows recorded before decision reuse was bound to the tool identity.';

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -5121,6 +5121,8 @@ type ChatHookDispatch struct {
 	Error            sql.NullString        `db:"error" json:"error"`
 	DecisionReason   sql.NullString        `db:"decision_reason" json:"decision_reason"`
 	EffectsAppliedAt sql.NullTime          `db:"effects_applied_at" json:"effects_applied_at"`
+	// Tool name reviewed by a pre_tool_use or post_tool_use dispatch. NULL for other events and for rows recorded before decision reuse was bound to the tool identity.
+	ToolName sql.NullString `db:"tool_name" json:"tool_name"`
 }
 
 type ChatMessage struct {

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -433,6 +433,14 @@ type sqlcQuerier interface {
 	GetChatFilesByIDs(ctx context.Context, ids []uuid.UUID) ([]ChatFile, error)
 	GetChatGeneralModelOverride(ctx context.Context) (string, error)
 	GetChatHeartbeat(ctx context.Context, arg GetChatHeartbeatParams) (ChatHeartbeat, error)
+	// A decision is only reusable for the exact tool call it reviewed:
+	// the tool name must match and the effective reviewed input
+	// (input_override when the hook rewrote it, original_input otherwise)
+	// must be semantically equal to the input being retried. Persisted
+	// assistant tool-call args already carry the override, so crash
+	// retries match; a different tool or different input that reuses the
+	// same tool-use ID dispatches fresh instead of inheriting a stale
+	// decision. Rows recorded before tool_name existed never match.
 	GetChatHookDispatchDecision(ctx context.Context, arg GetChatHookDispatchDecisionParams) (ChatHookDispatch, error)
 	// GetChatIncludeDefaultSystemPrompt preserves the legacy default
 	// for deployments created before the explicit include-default toggle.

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -5232,7 +5232,7 @@ SET
 WHERE id = $13::uuid
 	AND chat_id = $14::uuid
 	AND owner_id = $15::uuid
-RETURNING id, chat_id, event, turn_id, tool_use_id, owner_id, workspace_id, started_at, finished_at, result, http_status, decision, input_override, original_input, model_context, user_message, allowed_tools, end_chat, error, decision_reason, effects_applied_at
+RETURNING id, chat_id, event, turn_id, tool_use_id, owner_id, workspace_id, started_at, finished_at, result, http_status, decision, input_override, original_input, model_context, user_message, allowed_tools, end_chat, error, decision_reason, effects_applied_at, tool_name
 `
 
 type FinalizeChatHookDispatchParams struct {
@@ -5294,20 +5294,23 @@ func (q *sqlQuerier) FinalizeChatHookDispatch(ctx context.Context, arg FinalizeC
 		&i.Error,
 		&i.DecisionReason,
 		&i.EffectsAppliedAt,
+		&i.ToolName,
 	)
 	return i, err
 }
 
 const getChatHookDispatchDecision = `-- name: GetChatHookDispatchDecision :one
 SELECT
-	id, chat_id, event, turn_id, tool_use_id, owner_id, workspace_id, started_at, finished_at, result, http_status, decision, input_override, original_input, model_context, user_message, allowed_tools, end_chat, error, decision_reason, effects_applied_at
+	id, chat_id, event, turn_id, tool_use_id, owner_id, workspace_id, started_at, finished_at, result, http_status, decision, input_override, original_input, model_context, user_message, allowed_tools, end_chat, error, decision_reason, effects_applied_at, tool_name
 FROM
 	chat_hook_dispatches
 WHERE
 	chat_id = $1::uuid
 	AND event = 'pre_tool_use'
 	AND tool_use_id = $2::text
-	AND turn_id IS NOT DISTINCT FROM $3::uuid
+	AND tool_name = $3::text
+	AND COALESCE(input_override, original_input) = $4::jsonb
+	AND turn_id IS NOT DISTINCT FROM $5::uuid
 	AND decision IS NOT NULL
 	AND result IN ('ok', 'denied')
 ORDER BY
@@ -5317,13 +5320,29 @@ LIMIT 1
 `
 
 type GetChatHookDispatchDecisionParams struct {
-	ChatID    uuid.UUID     `db:"chat_id" json:"chat_id"`
-	ToolUseID string        `db:"tool_use_id" json:"tool_use_id"`
-	TurnID    uuid.NullUUID `db:"turn_id" json:"turn_id"`
+	ChatID    uuid.UUID       `db:"chat_id" json:"chat_id"`
+	ToolUseID string          `db:"tool_use_id" json:"tool_use_id"`
+	ToolName  string          `db:"tool_name" json:"tool_name"`
+	ToolInput json.RawMessage `db:"tool_input" json:"tool_input"`
+	TurnID    uuid.NullUUID   `db:"turn_id" json:"turn_id"`
 }
 
+// A decision is only reusable for the exact tool call it reviewed:
+// the tool name must match and the effective reviewed input
+// (input_override when the hook rewrote it, original_input otherwise)
+// must be semantically equal to the input being retried. Persisted
+// assistant tool-call args already carry the override, so crash
+// retries match; a different tool or different input that reuses the
+// same tool-use ID dispatches fresh instead of inheriting a stale
+// decision. Rows recorded before tool_name existed never match.
 func (q *sqlQuerier) GetChatHookDispatchDecision(ctx context.Context, arg GetChatHookDispatchDecisionParams) (ChatHookDispatch, error) {
-	row := q.db.QueryRowContext(ctx, getChatHookDispatchDecision, arg.ChatID, arg.ToolUseID, arg.TurnID)
+	row := q.db.QueryRowContext(ctx, getChatHookDispatchDecision,
+		arg.ChatID,
+		arg.ToolUseID,
+		arg.ToolName,
+		arg.ToolInput,
+		arg.TurnID,
+	)
 	var i ChatHookDispatch
 	err := row.Scan(
 		&i.ID,
@@ -5347,6 +5366,7 @@ func (q *sqlQuerier) GetChatHookDispatchDecision(ctx context.Context, arg GetCha
 		&i.Error,
 		&i.DecisionReason,
 		&i.EffectsAppliedAt,
+		&i.ToolName,
 	)
 	return i, err
 }
@@ -5358,6 +5378,7 @@ INSERT INTO chat_hook_dispatches (
 	event,
 	turn_id,
 	tool_use_id,
+	tool_name,
 	owner_id,
 	workspace_id,
 	started_at
@@ -5367,11 +5388,12 @@ INSERT INTO chat_hook_dispatches (
 	$3::text,
 	$4::uuid,
 	$5::text,
-	$6::uuid,
+	$6::text,
 	$7::uuid,
-	$8::timestamptz
+	$8::uuid,
+	$9::timestamptz
 )
-RETURNING id, chat_id, event, turn_id, tool_use_id, owner_id, workspace_id, started_at, finished_at, result, http_status, decision, input_override, original_input, model_context, user_message, allowed_tools, end_chat, error, decision_reason, effects_applied_at
+RETURNING id, chat_id, event, turn_id, tool_use_id, owner_id, workspace_id, started_at, finished_at, result, http_status, decision, input_override, original_input, model_context, user_message, allowed_tools, end_chat, error, decision_reason, effects_applied_at, tool_name
 `
 
 type InsertChatHookDispatchParams struct {
@@ -5380,6 +5402,7 @@ type InsertChatHookDispatchParams struct {
 	Event       string         `db:"event" json:"event"`
 	TurnID      uuid.NullUUID  `db:"turn_id" json:"turn_id"`
 	ToolUseID   sql.NullString `db:"tool_use_id" json:"tool_use_id"`
+	ToolName    sql.NullString `db:"tool_name" json:"tool_name"`
 	OwnerID     uuid.UUID      `db:"owner_id" json:"owner_id"`
 	WorkspaceID uuid.NullUUID  `db:"workspace_id" json:"workspace_id"`
 	StartedAt   time.Time      `db:"started_at" json:"started_at"`
@@ -5392,6 +5415,7 @@ func (q *sqlQuerier) InsertChatHookDispatch(ctx context.Context, arg InsertChatH
 		arg.Event,
 		arg.TurnID,
 		arg.ToolUseID,
+		arg.ToolName,
 		arg.OwnerID,
 		arg.WorkspaceID,
 		arg.StartedAt,
@@ -5419,13 +5443,14 @@ func (q *sqlQuerier) InsertChatHookDispatch(ctx context.Context, arg InsertChatH
 		&i.Error,
 		&i.DecisionReason,
 		&i.EffectsAppliedAt,
+		&i.ToolName,
 	)
 	return i, err
 }
 
 const listChatHookDispatchesByChatID = `-- name: ListChatHookDispatchesByChatID :many
 SELECT
-	id, chat_id, event, turn_id, tool_use_id, owner_id, workspace_id, started_at, finished_at, result, http_status, decision, input_override, original_input, model_context, user_message, allowed_tools, end_chat, error, decision_reason, effects_applied_at
+	id, chat_id, event, turn_id, tool_use_id, owner_id, workspace_id, started_at, finished_at, result, http_status, decision, input_override, original_input, model_context, user_message, allowed_tools, end_chat, error, decision_reason, effects_applied_at, tool_name
 FROM
 	chat_hook_dispatches
 WHERE
@@ -5466,6 +5491,7 @@ func (q *sqlQuerier) ListChatHookDispatchesByChatID(ctx context.Context, chatID 
 			&i.Error,
 			&i.DecisionReason,
 			&i.EffectsAppliedAt,
+			&i.ToolName,
 		); err != nil {
 			return nil, err
 		}

--- a/coderd/database/queries/chathooks.sql
+++ b/coderd/database/queries/chathooks.sql
@@ -5,6 +5,7 @@ INSERT INTO chat_hook_dispatches (
 	event,
 	turn_id,
 	tool_use_id,
+	tool_name,
 	owner_id,
 	workspace_id,
 	started_at
@@ -14,6 +15,7 @@ INSERT INTO chat_hook_dispatches (
 	@event::text,
 	sqlc.narg('turn_id')::uuid,
 	sqlc.narg('tool_use_id')::text,
+	sqlc.narg('tool_name')::text,
 	@owner_id::uuid,
 	sqlc.narg('workspace_id')::uuid,
 	@started_at::timestamptz
@@ -81,6 +83,14 @@ WHERE
 	AND tool_use_id = ANY(@tool_use_ids::text[]);
 
 -- name: GetChatHookDispatchDecision :one
+-- A decision is only reusable for the exact tool call it reviewed:
+-- the tool name must match and the effective reviewed input
+-- (input_override when the hook rewrote it, original_input otherwise)
+-- must be semantically equal to the input being retried. Persisted
+-- assistant tool-call args already carry the override, so crash
+-- retries match; a different tool or different input that reuses the
+-- same tool-use ID dispatches fresh instead of inheriting a stale
+-- decision. Rows recorded before tool_name existed never match.
 SELECT
 	*
 FROM
@@ -89,6 +99,8 @@ WHERE
 	chat_id = @chat_id::uuid
 	AND event = 'pre_tool_use'
 	AND tool_use_id = @tool_use_id::text
+	AND tool_name = @tool_name::text
+	AND COALESCE(input_override, original_input) = @tool_input::jsonb
 	AND turn_id IS NOT DISTINCT FROM sqlc.narg('turn_id')::uuid
 	AND decision IS NOT NULL
 	AND result IN ('ok', 'denied')

--- a/coderd/x/chatd/chathooks/dispatcher.go
+++ b/coderd/x/chatd/chathooks/dispatcher.go
@@ -60,13 +60,16 @@ type store interface {
 
 // Event contains a lifecycle event and its dispatch metadata.
 type Event struct {
-	Type        agenthooks.EventType
-	ChatID      uuid.UUID
-	OwnerID     uuid.UUID
-	WorkspaceID *uuid.UUID
-	TurnID      *uuid.UUID
-	ToolUseID   *string
-	Data        any
+	Type         agenthooks.EventType
+	ChatID       uuid.UUID
+	OwnerID      uuid.UUID
+	WorkspaceID  *uuid.UUID
+	TurnID       *uuid.UUID
+	ParentChatID *uuid.UUID
+	RootChatID   *uuid.UUID
+	ToolUseID    *string
+	ToolName     *string
+	Data         any
 }
 
 // DispatchError identifies a failed lifecycle hook dispatch.
@@ -214,7 +217,8 @@ func (d *Dispatcher) insert(ctx context.Context, event Event, dispatchID uuid.UU
 		ChatID:      event.ChatID,
 		Event:       string(event.Type),
 		TurnID:      nullUUID(event.TurnID),
-		ToolUseID:   nullToolUseID(event.ToolUseID),
+		ToolUseID:   nullStringPtr(event.ToolUseID),
+		ToolName:    nullStringPtr(event.ToolName),
 		OwnerID:     event.OwnerID,
 		WorkspaceID: nullUUID(event.WorkspaceID),
 		StartedAt:   startedAt,
@@ -244,6 +248,8 @@ func (d *Dispatcher) prepareAndPost(ctx context.Context, event Event, dispatchID
 			OwnerID:       event.OwnerID,
 			WorkspaceID:   event.WorkspaceID,
 			TurnID:        event.TurnID,
+			ParentChatID:  event.ParentChatID,
+			RootChatID:    event.RootChatID,
 		},
 		Data: data,
 	}
@@ -316,8 +322,11 @@ func (d *Dispatcher) post(
 			if isTimeoutError(attemptErr) || isTimeoutError(requestErr) || errors.Is(requestErr, context.Canceled) {
 				return agenthooks.Response{}, sql.NullInt32{}, resultTimeout, xerrors.Errorf("post lifecycle hook: %w", requestErr)
 			}
+			// Non-connection transport failures (TLS validation, malformed
+			// URLs, protocol violations) are deterministic, so retrying
+			// cannot help; classify them as protocol errors and return.
 			if !isConnectionError(requestErr) {
-				return agenthooks.Response{}, sql.NullInt32{}, resultConnectionError, xerrors.Errorf("post lifecycle hook: %w", requestErr)
+				return agenthooks.Response{}, sql.NullInt32{}, resultProtocolError, xerrors.Errorf("post lifecycle hook: %w", requestErr)
 			}
 			if attempt == 1 {
 				return agenthooks.Response{}, sql.NullInt32{}, resultConnectionError, xerrors.Errorf("post lifecycle hook: %w", requestErr)
@@ -564,7 +573,7 @@ func nullUUID(value *uuid.UUID) uuid.NullUUID {
 	return uuid.NullUUID{UUID: *value, Valid: true}
 }
 
-func nullToolUseID(value *string) sql.NullString {
+func nullStringPtr(value *string) sql.NullString {
 	if value == nil {
 		return sql.NullString{}
 	}

--- a/coderd/x/chatd/chatstate/hook_prefix_test.go
+++ b/coderd/x/chatd/chatstate/hook_prefix_test.go
@@ -123,3 +123,125 @@ func TestQueuedHookAllowedToolsDeferredUntilPromotion(t *testing.T) {
 	require.True(t, chat.HookAllowedTools.Valid, "promotion applies the queued prompt's tool policy")
 	require.JSONEq(t, `["read_file"]`, string(chat.HookAllowedTools.RawMessage))
 }
+
+// The hook tool policy is monotonic: an established policy only ever
+// narrows, so neither a live hook response nor a stale queued snapshot
+// can re-widen a restricted chat.
+func TestNarrowHookAllowedTools(t *testing.T) {
+	t.Parallel()
+
+	valid := func(tools string) pqtype.NullRawMessage {
+		return pqtype.NullRawMessage{RawMessage: []byte(tools), Valid: true}
+	}
+
+	tests := []struct {
+		name     string
+		current  pqtype.NullRawMessage
+		incoming pqtype.NullRawMessage
+		want     string
+		wantNull bool
+	}{
+		{
+			name:     "NoIncomingKeepsCurrent",
+			current:  valid(`["a"]`),
+			incoming: pqtype.NullRawMessage{},
+			want:     `["a"]`,
+		},
+		{
+			name:     "NoPolicyAdoptsIncoming",
+			current:  pqtype.NullRawMessage{},
+			incoming: valid(`["a","b"]`),
+			want:     `["a","b"]`,
+		},
+		{
+			name:     "BothNullStaysNull",
+			current:  pqtype.NullRawMessage{},
+			incoming: pqtype.NullRawMessage{},
+			wantNull: true,
+		},
+		{
+			name:     "IncomingNarrows",
+			current:  valid(`["a","b","c"]`),
+			incoming: valid(`["b","c","d"]`),
+			want:     `["b","c"]`,
+		},
+		{
+			name:     "WideningIsIgnored",
+			current:  valid(`["a"]`),
+			incoming: valid(`["a","b","c"]`),
+			want:     `["a"]`,
+		},
+		{
+			name:     "EmptyPolicyStaysEmpty",
+			current:  valid(`[]`),
+			incoming: valid(`["a","b"]`),
+			want:     `[]`,
+		},
+		{
+			name:     "IncomingEmptyRestrictsAll",
+			current:  valid(`["a","b"]`),
+			incoming: valid(`[]`),
+			want:     `[]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := chatstate.NarrowHookAllowedTools(tt.current, tt.incoming)
+			require.NoError(t, err)
+			if tt.wantNull {
+				require.False(t, got.Valid)
+				return
+			}
+			require.True(t, got.Valid)
+			require.JSONEq(t, tt.want, string(got.RawMessage))
+		})
+	}
+}
+
+// A queued prompt snapshot captured while the policy was wide must not
+// replace a narrower policy that landed before promotion.
+func TestQueuedHookPolicyCannotWidenOnPromotion(t *testing.T) {
+	t.Parallel()
+	f := newTestFixture(t)
+	ctx := testutil.Context(t, testutil.WaitShort)
+
+	created := createTestChat(t, f)
+	m := chatstate.NewChatMachine(f.DB, f.Pub, created.Chat.ID)
+
+	// Queue a prompt whose snapshot allows a wide tool set.
+	prompt := userTextMessage("queued prompt", f.User.ID, f.Model.ID)
+	prompt.TurnID = uuid.NullUUID{UUID: uuid.New(), Valid: true}
+	var send chatstate.SendMessageResult
+	require.NoError(t, m.Update(ctx, func(tx *chatstate.Tx, store database.Store) error {
+		var err error
+		send, err = tx.SendMessage(chatstate.SendMessageInput{
+			Message:          prompt,
+			HookAllowedTools: pqtype.NullRawMessage{RawMessage: []byte(`["read_file","execute"]`), Valid: true},
+			BusyBehavior:     chatstate.BusyBehaviorQueue,
+		})
+		return err
+	}))
+	require.NotNil(t, send.QueuedMessage)
+
+	// A newer hook response narrows the live policy before promotion.
+	require.NoError(t, m.Update(ctx, func(tx *chatstate.Tx, store database.Store) error {
+		return store.UpdateChatHookAllowedTools(ctx, database.UpdateChatHookAllowedToolsParams{
+			HookAllowedTools: pqtype.NullRawMessage{RawMessage: []byte(`["read_file"]`), Valid: true},
+			ID:               created.Chat.ID,
+		})
+	}))
+
+	require.NoError(t, m.Update(ctx, func(tx *chatstate.Tx, store database.Store) error {
+		_, err := tx.FinishTurn(chatstate.FinishTurnInput{})
+		return err
+	}))
+
+	chat, err := f.DB.GetChatByID(ctx, created.Chat.ID)
+	require.NoError(t, err)
+	require.True(t, chat.HookAllowedTools.Valid)
+	require.JSONEq(t, `["read_file"]`, string(chat.HookAllowedTools.RawMessage),
+		"promotion must intersect with the narrower live policy, not replace it")
+}

--- a/coderd/x/chatd/chatstate/transitions.go
+++ b/coderd/x/chatd/chatstate/transitions.go
@@ -277,20 +277,69 @@ func (tx *Tx) insertQueuedMessage(ownerFallback uuid.UUID, m Message, hookPrefix
 	})
 }
 
-// applyHookAllowedTools copies a prompt's hook tool policy onto the
-// chat. Invalid means the hook expressed no policy, which leaves the
-// current chat policy untouched.
+// applyHookAllowedTools narrows the chat's hook tool policy with a
+// prompt's snapshot. Invalid means the hook expressed no policy, which
+// leaves the current chat policy untouched. The policy is monotonic:
+// a queued snapshot captured before a newer, narrower policy landed
+// intersects with it instead of replacing it, so promotion can never
+// re-widen a restricted chat.
 func (tx *Tx) applyHookAllowedTools(allowedTools pqtype.NullRawMessage) error {
 	if !allowedTools.Valid {
 		return nil
 	}
+	chat, err := tx.store.GetChatByID(tx.ctx, tx.chatID)
+	if err != nil {
+		return xerrors.Errorf("load chat for hook allowed tools: %w", err)
+	}
+	narrowed, err := NarrowHookAllowedTools(chat.HookAllowedTools, allowedTools)
+	if err != nil {
+		return err
+	}
 	if err := tx.store.UpdateChatHookAllowedTools(tx.ctx, database.UpdateChatHookAllowedToolsParams{
-		HookAllowedTools: allowedTools,
+		HookAllowedTools: narrowed,
 		ID:               tx.chatID,
 	}); err != nil {
 		return xerrors.Errorf("apply hook allowed tools: %w", err)
 	}
 	return nil
+}
+
+// NarrowHookAllowedTools intersects an incoming hook tool policy with
+// the current one. A NULL current policy adopts the incoming value; a
+// non-NULL current policy only ever shrinks. A consumer cannot
+// re-widen a restricted chat, and replaying an older, wider policy
+// (for example a queued prompt snapshot) cannot undo a newer,
+// narrower one.
+func NarrowHookAllowedTools(current, incoming pqtype.NullRawMessage) (pqtype.NullRawMessage, error) {
+	if !incoming.Valid {
+		return current, nil
+	}
+	var incomingTools []string
+	if err := json.Unmarshal(incoming.RawMessage, &incomingTools); err != nil {
+		return pqtype.NullRawMessage{}, xerrors.Errorf("decode incoming hook allowed tools: %w", err)
+	}
+	if !current.Valid {
+		return incoming, nil
+	}
+	var currentTools []string
+	if err := json.Unmarshal(current.RawMessage, &currentTools); err != nil {
+		return pqtype.NullRawMessage{}, xerrors.Errorf("decode current hook allowed tools: %w", err)
+	}
+	allowed := make(map[string]struct{}, len(currentTools))
+	for _, tool := range currentTools {
+		allowed[tool] = struct{}{}
+	}
+	intersection := make([]string, 0, len(incomingTools))
+	for _, tool := range incomingTools {
+		if _, ok := allowed[tool]; ok {
+			intersection = append(intersection, tool)
+		}
+	}
+	encoded, err := json.Marshal(intersection)
+	if err != nil {
+		return pqtype.NullRawMessage{}, xerrors.Errorf("marshal narrowed hook allowed tools: %w", err)
+	}
+	return pqtype.NullRawMessage{RawMessage: encoded, Valid: true}, nil
 }
 
 // queuedHookPrefixMessage is the persisted shape of one lifecycle hook

--- a/coderd/x/chatd/hooks.go
+++ b/coderd/x/chatd/hooks.go
@@ -61,13 +61,23 @@ func lifecycleHookEvent(
 	if chat.WorkspaceID.Valid {
 		workspaceID = &chat.WorkspaceID.UUID
 	}
+	var parentChatID *uuid.UUID
+	if chat.ParentChatID.Valid {
+		parentChatID = &chat.ParentChatID.UUID
+	}
+	var rootChatID *uuid.UUID
+	if chat.RootChatID.Valid {
+		rootChatID = &chat.RootChatID.UUID
+	}
 	return chathooks.Event{
-		Type:        eventType,
-		ChatID:      chat.ID,
-		OwnerID:     chat.OwnerID,
-		WorkspaceID: workspaceID,
-		TurnID:      turnID,
-		Data:        data,
+		Type:         eventType,
+		ChatID:       chat.ID,
+		OwnerID:      chat.OwnerID,
+		WorkspaceID:  workspaceID,
+		TurnID:       turnID,
+		ParentChatID: parentChatID,
+		RootChatID:   rootChatID,
+		Data:         data,
 	}
 }
 
@@ -118,12 +128,14 @@ func (p *Server) dispatchPreToolUse(
 	toolCall fantasy.ToolCallContent,
 ) (agenthooks.Response, error) {
 	toolUseID := toolCall.ToolCallID
+	toolName := toolCall.ToolName
 	event := lifecycleHookEvent(chat, turnID, agenthooks.EventPreToolUse, agenthooks.PreToolUseData{
 		ToolUseID: toolUseID,
-		ToolName:  toolCall.ToolName,
+		ToolName:  toolName,
 		ToolInput: json.RawMessage(toolCall.Input),
 	})
 	event.ToolUseID = &toolUseID
+	event.ToolName = &toolName
 	return p.hookDispatcher.Dispatch(ctx, event)
 }
 
@@ -134,8 +146,10 @@ func (p *Server) dispatchPostToolUseData(
 	data agenthooks.PostToolUseData,
 ) (agenthooks.Response, error) {
 	toolUseID := data.ToolUseID
+	toolName := data.ToolName
 	event := lifecycleHookEvent(chat, turnID, agenthooks.EventPostToolUse, data)
 	event.ToolUseID = &toolUseID
+	event.ToolName = &toolName
 	return p.hookDispatcher.Dispatch(ctx, event)
 }
 
@@ -203,6 +217,9 @@ func (p *Server) preflightToolCalls(
 	if p.hookDispatcher == nil || !p.hookDispatcher.Enabled() {
 		return result, nil
 	}
+	if err := rejectDuplicateToolUseIDs(toolCalls); err != nil {
+		return preToolUseResult{}, err
+	}
 
 	for _, toolCall := range toolCalls {
 		if toolCall.ProviderExecuted {
@@ -219,6 +236,26 @@ func (p *Server) preflightToolCalls(
 		result.ToolUseIDs = append(result.ToolUseIDs, toolCall.ToolCallID)
 	}
 	return result, nil
+}
+
+// rejectDuplicateToolUseIDs fails closed when one generated batch
+// carries the same tool-use ID twice. Persisted pre_tool_use decisions
+// are keyed by tool-use ID within a turn, so duplicate IDs would let
+// the newest decision shadow the other call's review. Providers
+// generate unique IDs; only misbehaving OpenAI-compatible backends
+// that let the model author its own IDs can collide here.
+func rejectDuplicateToolUseIDs(toolCalls []fantasy.ToolCallContent) error {
+	seen := make(map[string]struct{}, len(toolCalls))
+	for _, toolCall := range toolCalls {
+		if toolCall.ProviderExecuted {
+			continue
+		}
+		if _, ok := seen[toolCall.ToolCallID]; ok {
+			return xerrors.Errorf("duplicate tool use ID %q in one step; lifecycle hook decisions cannot be attributed unambiguously", toolCall.ToolCallID)
+		}
+		seen[toolCall.ToolCallID] = struct{}{}
+	}
+	return nil
 }
 
 type preToolUseExecutionResult struct {
@@ -243,13 +280,27 @@ func (p *Server) preflightPendingToolCalls(
 		result.Allowed = append(result.Allowed, toolCalls...)
 		return result, nil
 	}
+	if err := rejectDuplicateToolUseIDs(toolCalls); err != nil {
+		return preToolUseExecutionResult{}, err
+	}
 
 	for _, toolCall := range toolCalls {
-		row, err := p.db.GetChatHookDispatchDecision(ctx, database.GetChatHookDispatchDecisionParams{
-			ChatID:    chat.ID,
-			ToolUseID: toolCall.ToolCallID,
-			TurnID:    hookTurnID(turnID),
-		})
+		// The persisted assistant args already carry any accepted
+		// input override, so the stored effective input matches
+		// toolCall.Input on crash retries and mismatches whenever the
+		// same ID is reused for different input. Input that is not
+		// valid JSON cannot be compared as jsonb, so it skips reuse
+		// and dispatches fresh, which is always safe.
+		row, err := database.ChatHookDispatch{}, sql.ErrNoRows
+		if json.Valid([]byte(toolCall.Input)) {
+			row, err = p.db.GetChatHookDispatchDecision(ctx, database.GetChatHookDispatchDecisionParams{
+				ChatID:    chat.ID,
+				ToolUseID: toolCall.ToolCallID,
+				ToolName:  toolCall.ToolName,
+				ToolInput: json.RawMessage(toolCall.Input),
+				TurnID:    hookTurnID(turnID),
+			})
+		}
 		if err == nil {
 			// Reuse the recorded decision without re-dispatching. When
 			// the worker died after finalizing the dispatch but before
@@ -818,8 +869,16 @@ func applyHookAllowedTools(ctx context.Context, store database.Store, chatID uui
 	if !allowedTools.Valid {
 		return nil
 	}
+	chat, err := store.GetChatByID(ctx, chatID)
+	if err != nil {
+		return xerrors.Errorf("load chat for hook allowed tools: %w", err)
+	}
+	narrowed, err := chatstate.NarrowHookAllowedTools(chat.HookAllowedTools, allowedTools)
+	if err != nil {
+		return err
+	}
 	if err := store.UpdateChatHookAllowedTools(ctx, database.UpdateChatHookAllowedToolsParams{
-		HookAllowedTools: allowedTools,
+		HookAllowedTools: narrowed,
 		ID:               chatID,
 	}); err != nil {
 		return xerrors.Errorf("update hook allowed tools: %w", err)

--- a/coderd/x/chatd/pre_tool_use_test.go
+++ b/coderd/x/chatd/pre_tool_use_test.go
@@ -481,7 +481,7 @@ func TestPreToolUseHookRecordedEndChatSkipsExecution(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, messages[0].TurnID.Valid)
 	turnID := messages[0].TurnID.UUID
-	recordPreToolUseResponse(ctx, t, db, chatID, user.ID, turnID, "call_recorded_end_chat", agenthooks.PermissionAllow, "", nil, agenthooks.Response{
+	recordPreToolUseResponse(ctx, t, db, chatID, user.ID, turnID, "call_recorded_end_chat", "read_file", json.RawMessage(`{"path":"/tmp/end.txt"}`), agenthooks.PermissionAllow, "", nil, agenthooks.Response{
 		EndChat: true,
 	})
 
@@ -531,6 +531,8 @@ func TestPreToolUseHookRecordedEndChatSkipsExecution(t *testing.T) {
 	row, err := db.GetChatHookDispatchDecision(ctx, database.GetChatHookDispatchDecisionParams{
 		ChatID:    chatID,
 		ToolUseID: "call_recorded_end_chat",
+		ToolName:  "read_file",
+		ToolInput: json.RawMessage(`{"path":"/tmp/end.txt"}`),
 		TurnID:    uuid.NullUUID{UUID: turnID, Valid: true},
 	})
 	require.NoError(t, err)
@@ -724,8 +726,8 @@ func TestPreToolUseHookResumeRecordedDeny(t *testing.T) {
 	messages, err := db.GetChatMessagesForPromptByChatID(ctx, chatID)
 	require.NoError(t, err)
 	require.True(t, messages[0].TurnID.Valid)
-	recordPreToolUseDecision(ctx, t, db, chatID, user.ID, uuid.New(), "call_recorded_deny", agenthooks.PermissionAllow, "", nil)
-	recordPreToolUseDecision(ctx, t, db, chatID, user.ID, messages[0].TurnID.UUID, "call_recorded_deny", agenthooks.PermissionDeny, "recorded policy reason", nil)
+	recordPreToolUseDecision(ctx, t, db, chatID, user.ID, uuid.New(), "call_recorded_deny", "read_file", json.RawMessage(`{"path":"/tmp/secret.txt"}`), agenthooks.PermissionAllow, "", nil)
+	recordPreToolUseDecision(ctx, t, db, chatID, user.ID, messages[0].TurnID.UUID, "call_recorded_deny", "read_file", json.RawMessage(`{"path":"/tmp/secret.txt"}`), agenthooks.PermissionDeny, "recorded policy reason", nil)
 
 	var hookCalls atomic.Int32
 	consumer := preToolUseConsumer(t, func(agenthooks.PreToolUseData) string {
@@ -753,6 +755,70 @@ func TestPreToolUseHookResumeRecordedDeny(t *testing.T) {
 	require.Contains(t, string(result.Result), "DENIED: recorded policy reason")
 }
 
+// A recorded decision binds to the exact tool call it reviewed. When a
+// pending call reuses the same tool-use ID with different input, the
+// stale decision must not be replayed; the call dispatches fresh.
+func TestPreToolUseHookRecordedDecisionRequiresMatchingInput(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, ps := dbtestutil.NewDB(t)
+	openAIURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
+		if !req.Stream {
+			return chattest.OpenAINonStreamingResponse("title")
+		}
+		return chattest.OpenAIStreamingResponse(chattest.OpenAITextChunks("done")...)
+	})
+	user, org, model := seedChatDependenciesWithProvider(t, db, "openai-compat", openAIURL)
+	ws, dbAgent := seedWorkspaceWithAgent(t, db, user.ID)
+	chatID := seedPendingToolCall(ctx, t, db, ps, pendingToolCallSeed{
+		OrganizationID: org.ID,
+		OwnerID:        user.ID,
+		WorkspaceID:    ws.ID,
+		AgentID:        dbAgent.ID,
+		ModelConfigID:  model.ID,
+		APIKeyID:       testAPIKeyID(t, db, user.ID),
+		ToolCallID:     "call_input_mismatch",
+		ToolName:       "read_file",
+		ToolInput:      `{"path":"/tmp/harmless.txt"}`,
+	})
+	messages, err := db.GetChatMessagesForPromptByChatID(ctx, chatID)
+	require.NoError(t, err)
+	require.True(t, messages[0].TurnID.Valid)
+	// The recorded deny reviewed different input under the same
+	// tool-use ID and turn; it must not transfer to the pending call.
+	recordPreToolUseDecision(ctx, t, db, chatID, user.ID, messages[0].TurnID.UUID, "call_input_mismatch", "read_file", json.RawMessage(`{"path":"/tmp/secret.txt"}`), agenthooks.PermissionDeny, "stale decision", nil)
+
+	var hookCalls atomic.Int32
+	consumer := preToolUseConsumer(t, func(data agenthooks.PreToolUseData) string {
+		hookCalls.Add(1)
+		require.JSONEq(t, `{"path":"/tmp/harmless.txt"}`, string(data.ToolInput))
+		return `{}`
+	})
+	ctrl := gomock.NewController(t)
+	mockConn := agentconnmock.NewMockAgentConn(ctrl)
+	setupToolExecutionAgentConn(t, mockConn)
+	mockConn.EXPECT().ReadFileLines(gomock.Any(), "/tmp/harmless.txt", int64(1), int64(0), gomock.Any()).
+		Return(workspacesdk.ReadFileLinesResponse{
+			Success: true, FileSize: 4, TotalLines: 1, LinesRead: 1, Content: "data",
+		}, nil).
+		Times(1)
+	server := newTestServer(t, db, ps, uuid.New(), func(cfg *chatd.Config) {
+		cfg.AIBridgeTransportFactory = chatAIGatewayTransportFactoryPointer(chattest.NewMockAIBridgeTransport(t, openAIURL))
+		cfg.HookDispatcher = newHookDispatcher(t, db, consumer)
+		cfg.AgentConn = func(_ context.Context, agentID uuid.UUID) (workspacesdk.AgentConn, func(), error) {
+			require.Equal(t, dbAgent.ID, agentID)
+			return mockConn, func() {}, nil
+		}
+	})
+	server.Start()
+	waitForChatStatus(ctx, t, db, chatID, database.ChatStatusWaiting)
+
+	require.Positive(t, hookCalls.Load(), "mismatched input must dispatch a fresh pre_tool_use review")
+	result := requireToolResultPart(t, chatToolParts(ctx, t, db, chatID), "read_file")
+	require.False(t, result.IsError, "the stale deny must not apply to the fresh call")
+}
+
 func recordPreToolUseDecision(
 	ctx context.Context,
 	t *testing.T,
@@ -761,12 +827,14 @@ func recordPreToolUseDecision(
 	ownerID uuid.UUID,
 	turnID uuid.UUID,
 	toolUseID string,
+	toolName string,
+	toolInput json.RawMessage,
 	decision agenthooks.PermissionDecision,
 	reason string,
 	override json.RawMessage,
 ) {
 	t.Helper()
-	recordPreToolUseResponse(ctx, t, db, chatID, ownerID, turnID, toolUseID, decision, reason, override, agenthooks.Response{})
+	recordPreToolUseResponse(ctx, t, db, chatID, ownerID, turnID, toolUseID, toolName, toolInput, decision, reason, override, agenthooks.Response{})
 }
 
 func recordPreToolUseResponse(
@@ -777,6 +845,8 @@ func recordPreToolUseResponse(
 	ownerID uuid.UUID,
 	turnID uuid.UUID,
 	toolUseID string,
+	toolName string,
+	toolInput json.RawMessage,
 	decision agenthooks.PermissionDecision,
 	reason string,
 	override json.RawMessage,
@@ -796,6 +866,7 @@ func recordPreToolUseResponse(
 		Event:     string(agenthooks.EventPreToolUse),
 		TurnID:    uuid.NullUUID{UUID: turnID, Valid: true},
 		ToolUseID: sql.NullString{String: toolUseID, Valid: true},
+		ToolName:  sql.NullString{String: toolName, Valid: toolName != ""},
 		OwnerID:   ownerID,
 		StartedAt: time.Now(),
 	})
@@ -806,6 +877,7 @@ func recordPreToolUseResponse(
 		Decision:       sql.NullString{String: string(decision), Valid: true},
 		DecisionReason: sql.NullString{String: reason, Valid: reason != ""},
 		InputOverride:  nullRawMessage(override),
+		OriginalInput:  nullRawMessage(toolInput),
 		ModelContext:   sql.NullString{String: response.ModelContext, Valid: response.ModelContext != ""},
 		UserMessage:    sql.NullString{String: response.UserMessage, Valid: response.UserMessage != ""},
 		AllowedTools:   nullRawMessage(allowedTools),
@@ -848,7 +920,7 @@ func TestPreToolUseHookReplaysUnappliedEffects(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, messages[0].TurnID.Valid)
 	allowed := []string{"read_file"}
-	recordPreToolUseResponse(ctx, t, db, chatID, user.ID, messages[0].TurnID.UUID, "call_replay_effects", agenthooks.PermissionAllow, "", nil, agenthooks.Response{
+	recordPreToolUseResponse(ctx, t, db, chatID, user.ID, messages[0].TurnID.UUID, "call_replay_effects", "read_file", json.RawMessage(`{"path":"/tmp/a.txt"}`), agenthooks.PermissionAllow, "", nil, agenthooks.Response{
 		ModelContext: "recorded context",
 		UserMessage:  "recorded notice",
 		AllowedTools: &allowed,
@@ -941,7 +1013,7 @@ func TestPreToolUseHookSkipsAppliedEffects(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, messages[0].TurnID.Valid)
 	allowed := []string{"read_file"}
-	recordPreToolUseResponse(ctx, t, db, chatID, user.ID, messages[0].TurnID.UUID, "call_applied_effects", agenthooks.PermissionAllow, "", nil, agenthooks.Response{
+	recordPreToolUseResponse(ctx, t, db, chatID, user.ID, messages[0].TurnID.UUID, "call_applied_effects", "read_file", json.RawMessage(`{"path":"/tmp/a.txt"}`), agenthooks.PermissionAllow, "", nil, agenthooks.Response{
 		ModelContext: "recorded context",
 		AllowedTools: &allowed,
 	})

--- a/coderd/x/chatd/subagent.go
+++ b/coderd/x/chatd/subagent.go
@@ -26,6 +26,7 @@ import (
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprovider"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatstate"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/codersdk/agenthooks"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 )
 
@@ -609,6 +610,13 @@ func (p *Server) subagentTools(
 					options,
 				)
 				if err != nil {
+					// A lifecycle hook denial carries the consumer's
+					// user-facing reason; surface it so the model can
+					// adjust instead of retrying the same prompt.
+					var denied *UserPromptDeniedError
+					if errors.As(err, &denied) && denied.UserMessage != "" {
+						return fantasy.NewTextErrorResponse(err.Error() + ": " + denied.UserMessage), nil
+					}
 					return fantasy.NewTextErrorResponse(err.Error()), nil
 				}
 
@@ -1058,7 +1066,8 @@ func (p *Server) createChildSubagentChatWithOptions(
 	}
 
 	title = strings.TrimSpace(title)
-	if title == "" {
+	titleDerivedFromPrompt := title == ""
+	if titleDerivedFromPrompt {
 		title = subagentFallbackChatTitle(prompt)
 	}
 
@@ -1109,6 +1118,48 @@ func (p *Server) createChildSubagentChatWithOptions(
 		return database.Chat{}, limitErr
 	}
 
+	// Child prompts are governed like every other user prompt: the
+	// user_prompt_submit hook reviews the spawn prompt before any
+	// child state persists, and can deny it, rewrite it, attach
+	// messages, restrict tools, or refuse the spawn outright. The
+	// parent's gated spawn_agent call is not a substitute because a
+	// consumer implementing prompt policy never sees spawn prompts as
+	// prompts.
+	childChatID := uuid.New()
+	var childTurnID *uuid.UUID
+	var hookResponse agenthooks.Response
+	if p.hookDispatcher != nil && p.hookDispatcher.Enabled() {
+		mintedTurnID := uuid.New()
+		childTurnID = &mintedTurnID
+		hookChat := database.Chat{}
+		hookChat.ID = childChatID
+		hookChat.OwnerID = parent.OwnerID
+		hookChat.WorkspaceID = parent.WorkspaceID
+		hookChat.ParentChatID = uuid.NullUUID{UUID: parent.ID, Valid: true}
+		hookChat.RootChatID = uuid.NullUUID{UUID: rootChatID, Valid: true}
+		hookResponse, err = p.dispatchUserPromptSubmit(ctx, hookChat, mintedTurnID, []codersdk.ChatMessagePart{codersdk.ChatMessageText(prompt)})
+		if err != nil {
+			return database.Chat{}, err
+		}
+		// There is no child chat to end yet, so end_chat refuses the
+		// spawn, mirroring end_chat during top-level chat creation.
+		if hookResponse.EndChat {
+			return database.Chat{}, &UserPromptDeniedError{UserMessage: hookResponse.UserMessage}
+		}
+		override, overridden, overrideErr := userPromptOverride(hookResponse)
+		if overrideErr != nil {
+			return database.Chat{}, overrideErr
+		}
+		if overridden {
+			prompt = override
+			// Recompute derived titles so a redacted prompt does not
+			// leak through the child title.
+			if titleDerivedFromPrompt {
+				title = subagentFallbackChatTitle(prompt)
+			}
+		}
+	}
+
 	workspaceAwareness := workspaceDetachedNoCreateAwareness
 	if parent.WorkspaceID.Valid {
 		workspaceAwareness = workspaceAttachedAwareness
@@ -1145,17 +1196,41 @@ func (p *Server) createChildSubagentChatWithOptions(
 	}
 	initialMessages = append(initialMessages, systemMessage(workspaceAwarenessContent, modelConfigID))
 
+	prefixMessages, err := hookPrefixMessages(hookResponse, modelConfigID, childTurnID)
+	if err != nil {
+		return database.Chat{}, err
+	}
+	initialMessages = append(initialMessages, prefixMessages...)
+
 	// The child shares the parent's workspace and agent, so it inherits
 	// workspace context the same way a top-level chat does: pinned from the
 	// agent's latest snapshot (see hydrateChatContextOnCreate below). The
 	// parent's context is not copied into child history.
-	initialMessages = append(initialMessages, userMessageWithAPIKeyID(userContent, modelConfigID, parent.OwnerID, childAPIKeyID, opts.reasoningEffortOverride))
+	childUserMessage := userMessageWithAPIKeyID(userContent, modelConfigID, parent.OwnerID, childAPIKeyID, opts.reasoningEffortOverride)
+	if childTurnID != nil {
+		childUserMessage.TurnID = uuid.NullUUID{UUID: *childTurnID, Valid: true}
+	}
+	initialMessages = append(initialMessages, childUserMessage)
+
+	// The child's hook tool policy starts as the parent policy
+	// narrowed by any policy in the hook response, so a restricted
+	// parent can never spawn a less restricted child. This holds even
+	// while dispatch is disabled: the parent policy alone carries
+	// over.
+	responseTools, err := hookAllowedTools(hookResponse)
+	if err != nil {
+		return database.Chat{}, err
+	}
+	childPolicy, err := chatstate.NarrowHookAllowedTools(parent.HookAllowedTools, responseTools)
+	if err != nil {
+		return database.Chat{}, err
+	}
 
 	publisher := p.pubsub
 	if publisher == nil {
 		publisher = dbpubsub.NewInMemory()
 	}
-	result, err := chatstate.CreateChat(ctx, p.db, publisher, chatstate.CreateChatInput{
+	result, err := chatstate.CreateChatWithID(ctx, p.db, publisher, childChatID, childPolicy, chatstate.CreateChatInput{
 		OrganizationID:    parent.OrganizationID,
 		OwnerID:           parent.OwnerID,
 		WorkspaceID:       parent.WorkspaceID,

--- a/coderd/x/chatd/subagent_internal_test.go
+++ b/coderd/x/chatd/subagent_internal_test.go
@@ -15,6 +15,7 @@ import (
 
 	"charm.land/fantasy"
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sqlc-dev/pqtype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,6 +31,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/pubsub"
 	coderdpubsub "github.com/coder/coder/v2/coderd/pubsub"
 	"github.com/coder/coder/v2/coderd/util/ptr"
+	"github.com/coder/coder/v2/coderd/x/chatd/chathooks"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatloop"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprovider"
@@ -302,6 +304,148 @@ func TestCreateChildSubagentChatPropagatesActiveTurnAPIKeyID(t *testing.T) {
 	require.NotZero(t, childUserMessage.ID)
 	require.True(t, childUserMessage.APIKeyID.Valid)
 	require.Equal(t, apiKey.ID, childUserMessage.APIKeyID.String)
+}
+
+// Spawn prompts are governed like every other user prompt: the hook
+// reviews them before any child state persists, its rewrite lands as
+// the child's initial message, and the child policy starts as the
+// parent policy narrowed by the response.
+func TestCreateChildSubagentChatDispatchesUserPromptSubmit(t *testing.T) {
+	t.Parallel()
+
+	newFixture := func(t *testing.T, handler http.HandlerFunc) (context.Context, database.Store, database.Chat, *Server) {
+		t.Helper()
+		ctx := testutil.Context(t, testutil.WaitShort)
+		db, _ := dbtestutil.NewDB(t)
+		user := dbgen.User(t, db, database.User{})
+		org := dbgen.Organization(t, db, database.Organization{})
+		dbgen.OrganizationMember(t, db, database.OrganizationMember{UserID: user.ID, OrganizationID: org.ID})
+		model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{})
+		parent := dbgen.Chat(t, db, database.Chat{
+			OrganizationID:    org.ID,
+			OwnerID:           user.ID,
+			LastModelConfigID: model.ID,
+			HookAllowedTools:  pqtype.NullRawMessage{RawMessage: []byte(`["read_file","spawn_agent"]`), Valid: true},
+		})
+		apiKey, _ := dbgen.APIKey(t, db, database.APIKey{UserID: user.ID})
+		ctx = aibridge.WithDelegatedAPIKeyID(ctx, apiKey.ID)
+
+		consumer := httptest.NewServer(handler)
+		t.Cleanup(consumer.Close)
+		server := &Server{
+			db:     db,
+			logger: slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+			hookDispatcher: chathooks.New(
+				slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+				db,
+				consumer.Client(),
+				consumer.URL,
+				"test-hook-secret-32-bytes-minimum!!",
+				time.Second,
+				"test-deployment",
+				"test-version",
+				prometheus.NewRegistry(),
+			),
+		}
+		return ctx, db, parent, server
+	}
+
+	t.Run("RewriteAndPolicyIntersection", func(t *testing.T) {
+		t.Parallel()
+
+		var meta struct {
+			sync.Mutex
+			parentChatID string
+			prompt       string
+		}
+		ctx, db, parent, server := newFixture(t, func(rw http.ResponseWriter, r *http.Request) {
+			var request struct {
+				Type string `json:"type"`
+				Meta struct {
+					ParentChatID *uuid.UUID `json:"parent_chat_id"`
+				} `json:"meta"`
+				Data struct {
+					Prompt string `json:"prompt"`
+				} `json:"data"`
+			}
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+			require.Equal(t, "user_prompt_submit", request.Type)
+			meta.Lock()
+			if request.Meta.ParentChatID != nil {
+				meta.parentChatID = request.Meta.ParentChatID.String()
+			}
+			meta.prompt = request.Data.Prompt
+			meta.Unlock()
+			rw.Header().Set("Content-Type", "application/json")
+			_, _ = rw.Write([]byte(`{
+				"permission": {"decision": "allow", "input_override": {"prompt": "REVIEWED: inspect"}},
+				"allowed_tools": ["read_file", "execute"]
+			}`))
+		})
+
+		child, err := server.createChildSubagentChat(ctx, parent, "inspect the workspace", "")
+		require.NoError(t, err)
+
+		meta.Lock()
+		require.Equal(t, parent.ID.String(), meta.parentChatID, "spawn dispatch must identify the parent chat")
+		require.Equal(t, "inspect the workspace", meta.prompt)
+		meta.Unlock()
+
+		messages, err := db.GetChatMessagesByChatID(ctx, database.GetChatMessagesByChatIDParams{ChatID: child.ID})
+		require.NoError(t, err)
+		var childUserMessage database.ChatMessage
+		for _, message := range messages {
+			if message.Role == database.ChatMessageRoleUser {
+				childUserMessage = message
+				break
+			}
+		}
+		require.NotZero(t, childUserMessage.ID)
+		require.True(t, childUserMessage.Content.Valid)
+		require.Contains(t, string(childUserMessage.Content.RawMessage), "REVIEWED: inspect",
+			"the hook rewrite must land as the child's initial prompt")
+		require.NotContains(t, string(childUserMessage.Content.RawMessage), "inspect the workspace")
+		require.True(t, childUserMessage.TurnID.Valid, "the gated spawn prompt starts the child's first turn")
+
+		require.True(t, child.HookAllowedTools.Valid)
+		require.JSONEq(t, `["read_file"]`, string(child.HookAllowedTools.RawMessage),
+			"child policy is the parent policy narrowed by the response")
+	})
+
+	t.Run("DenyRefusesSpawn", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, db, parent, server := newFixture(t, func(rw http.ResponseWriter, _ *http.Request) {
+			rw.Header().Set("Content-Type", "application/json")
+			_, _ = rw.Write([]byte(`{"permission": {"decision": "deny", "reason": "spawn blocked"}, "user_message": "not allowed"}`))
+		})
+
+		_, err := server.createChildSubagentChat(ctx, parent, "exfiltrate secrets", "")
+		var denied *UserPromptDeniedError
+		require.ErrorAs(t, err, &denied)
+		require.Equal(t, "not allowed", denied.UserMessage)
+
+		chats, err := db.GetChildChatsByParentIDs(ctx, database.GetChildChatsByParentIDsParams{
+			ParentIds: []uuid.UUID{parent.ID},
+		})
+		require.NoError(t, err)
+		require.Empty(t, chats, "a denied spawn must not create a child chat")
+	})
+
+	t.Run("ParentPolicyInheritedWithoutResponsePolicy", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, _, parent, server := newFixture(t, func(rw http.ResponseWriter, _ *http.Request) {
+			rw.Header().Set("Content-Type", "application/json")
+			_, _ = rw.Write([]byte(`{}`))
+		})
+
+		child, err := server.createChildSubagentChat(ctx, parent, "inspect the workspace", "")
+		require.NoError(t, err)
+		require.True(t, child.HookAllowedTools.Valid)
+		require.JSONEq(t, `["read_file","spawn_agent"]`, string(child.HookAllowedTools.RawMessage),
+			"a restricted parent must not spawn an unrestricted child")
+	})
 }
 
 func TestSendSubagentMessagePropagatesActiveTurnAPIKeyID(t *testing.T) {

--- a/codersdk/agenthooks/types.go
+++ b/codersdk/agenthooks/types.go
@@ -68,6 +68,13 @@ type Meta struct {
 	OwnerID       uuid.UUID  `json:"owner_id"`
 	WorkspaceID   *uuid.UUID `json:"workspace_id,omitempty"`
 	TurnID        *uuid.UUID `json:"turn_id,omitempty"`
+	// ParentChatID identifies the chat whose spawn_agent call created
+	// this chat. Unset for top-level chats.
+	ParentChatID *uuid.UUID `json:"parent_chat_id,omitempty"`
+	// RootChatID identifies the top-level ancestor of a subagent
+	// chat, so consumers can correlate a whole subagent subtree with
+	// the user-facing conversation. Unset for top-level chats.
+	RootChatID *uuid.UUID `json:"root_chat_id,omitempty"`
 }
 
 // SessionStartData describes the start or resumption of a chat session.

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -5082,6 +5082,13 @@ func (c *DeploymentValues) Validate() error {
 			if c.AI.Chat.HookSecret.Value() == "" {
 				return xerrors.New("chat hook secret is required when chat hook URL is set; set --chat-hook-secret")
 			}
+			// HS256 requires a key at least as long as the digest.
+			// go-jose enforces this at signing time, so a shorter
+			// secret would otherwise pass startup and then fail every
+			// dispatch at runtime.
+			if len(c.AI.Chat.HookSecret.Value()) < 32 {
+				return xerrors.New("chat hook secret must be at least 32 bytes of cryptographically random data; set --chat-hook-secret to a longer value")
+			}
 		}
 
 		hookTimeout := c.AI.Chat.HookTimeout.Value()

--- a/codersdk/deployment_test.go
+++ b/codersdk/deployment_test.go
@@ -801,13 +801,13 @@ func TestDeploymentValues_Validate_ChatHooks(t *testing.T) {
 		{
 			name:    "Valid",
 			url:     "https://hooks.example.com/agent",
-			secret:  "secret",
+			secret:  "0123456789abcdef0123456789abcdef",
 			timeout: 5 * time.Second,
 		},
 		{
 			name:    "HTTPURL",
 			url:     "http://hooks.example.com/agent",
-			secret:  "secret",
+			secret:  "0123456789abcdef0123456789abcdef",
 			timeout: 1500 * time.Millisecond,
 			wantErr: "chat hook URL must use HTTPS",
 		},
@@ -816,6 +816,16 @@ func TestDeploymentValues_Validate_ChatHooks(t *testing.T) {
 			url:     "https://hooks.example.com/agent",
 			timeout: 1500 * time.Millisecond,
 			wantErr: "chat hook secret is required",
+		},
+		{
+			// go-jose refuses to sign HS256 with a key shorter than
+			// the digest, so a short secret would fail every dispatch
+			// at runtime; reject it at startup instead.
+			name:    "ShortSecret",
+			url:     "https://hooks.example.com/agent",
+			secret:  "0123456789abcdef0123456789abcde",
+			timeout: 1500 * time.Millisecond,
+			wantErr: "chat hook secret must be at least 32 bytes",
 		},
 		{
 			name:    "ZeroTimeout",

--- a/docs/admin/setup/chat-lifecycle-hooks.md
+++ b/docs/admin/setup/chat-lifecycle-hooks.md
@@ -14,37 +14,41 @@ The configured consumer can observe all 7 lifecycle events, add model or user co
 
 Set the following deployment options on `coder server`.
 
-| Environment variable      | CLI flag              | Default | Requirement                                                                          |
-|---------------------------|-----------------------|---------|--------------------------------------------------------------------------------------|
-| `CODER_CHAT_HOOK_URL`     | `--chat-hook-url`     | Empty   | Use an `https` URL. Hooks are inactive when this value is empty.                     |
-| `CODER_CHAT_HOOK_SECRET`  | `--chat-hook-secret`  | Empty   | Required when the hook URL is set. Coder uses this shared secret to sign HS256 JWTs. |
-| `CODER_CHAT_HOOK_TIMEOUT` | `--chat-hook-timeout` | `1.5s`  | Must be greater than `0` and no more than `5s`. The timeout applies to each request. |
-| `CODER_CHAT_HOOK_ENABLED` | `--chat-hook-enabled` | `true`  | Set to `false` to stop dispatching without removing the URL or secret.               |
+| Environment variable      | CLI flag              | Default | Requirement                                                                                                                              |
+|---------------------------|-----------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------|
+| `CODER_CHAT_HOOK_URL`     | `--chat-hook-url`     | Empty   | Use an `https` URL. Hooks are inactive when this value is empty.                                                                         |
+| `CODER_CHAT_HOOK_SECRET`  | `--chat-hook-secret`  | Empty   | Required when the hook URL is set, at least 32 bytes of cryptographically random data. Coder uses this shared secret to sign HS256 JWTs. |
+| `CODER_CHAT_HOOK_TIMEOUT` | `--chat-hook-timeout` | `1.5s`  | Must be greater than `0` and no more than `5s`. The timeout applies to each request.                                                     |
+| `CODER_CHAT_HOOK_ENABLED` | `--chat-hook-enabled` | `true`  | Set to `false` to stop dispatching without removing the URL or secret.                                                                   |
 
 Treat `CODER_CHAT_HOOK_ENABLED=false` as the break-glass control.
 Changing deployment options requires the normal `coder server` configuration rollout for your installation.
 
 Use a dedicated secret and rotate it through your existing secret-management process.
+Rotation is a hard cutover: Coder signs with exactly one secret, so dispatches fail until the consumer accepts the new value.
+Rotate during a maintenance window, or temporarily set `CODER_CHAT_HOOK_ENABLED=false` for the cutover if blocked chats are worse than unreviewed ones for your deployment.
 Coder requires the configured URL to use HTTPS.
 A TLS terminator can forward the request to a consumer over plain HTTP on a trusted local network.
 It must set `X-Forwarded-Proto: https` and either preserve the original `Host` header or carry it in `X-Forwarded-Host` for the SDK handler's audience check.
+The SDK trusts those forwarded headers, so the audience check is only as strong as that proxy boundary: the proxy must strip or overwrite client-supplied forwarded headers, and the consumer must not be reachable except through the proxy.
 
 ## Handle lifecycle events
 
 Coder sends an HTTP `POST` request for each event.
 The JSON body contains `type`, `meta`, and event-specific `data`.
 The `meta` object includes `dispatch_id`, `schema_version`, `chat_id`, `owner_id`, and optional workspace and turn IDs.
+Events from subagent chats also carry `parent_chat_id` and `root_chat_id` so a consumer can correlate a subagent subtree with the user-facing conversation and apply the parent's policy context.
 The current `schema_version` is `1`.
 
-| Event                | When Coder sends it                        | Decision-relevant data                                                 |
-|----------------------|--------------------------------------------|------------------------------------------------------------------------|
-| `session_start`      | A chat session starts, resumes, or clears  | `source` (`startup`, `resume`, or `clear`)                             |
-| `user_prompt_submit` | A user submits a prompt                    | `prompt` and `parts`                                                   |
-| `pre_tool_use`       | Before a non-provider-executed tool runs   | `tool_use_id`, `tool_name`, and `tool_input`                           |
-| `post_tool_use`      | After a non-provider-executed tool returns | `tool_use_id`, `tool_name`, and either `tool_response` or `tool_error` |
-| `pre_compact`        | Before Coder compacts chat context         | No event-specific fields                                               |
-| `post_compact`       | After Coder compacts chat context          | No event-specific fields                                               |
-| `stop`               | The model stops a turn                     | No event-specific fields                                               |
+| Event                | When Coder sends it                                                 | Decision-relevant data                                                 |
+|----------------------|---------------------------------------------------------------------|------------------------------------------------------------------------|
+| `session_start`      | A chat session starts, resumes, or clears                           | `source` (`startup`, `resume`, or `clear`)                             |
+| `user_prompt_submit` | A user submits a prompt, or `spawn_agent` submits a subagent prompt | `prompt` and `parts`                                                   |
+| `pre_tool_use`       | Before a non-provider-executed tool runs                            | `tool_use_id`, `tool_name`, and `tool_input`                           |
+| `post_tool_use`      | After a non-provider-executed tool returns                          | `tool_use_id`, `tool_name`, and either `tool_response` or `tool_error` |
+| `pre_compact`        | Before Coder compacts chat context                                  | No event-specific fields                                               |
+| `post_compact`       | After Coder compacts chat context                                   | No event-specific fields                                               |
+| `stop`               | The model stops a turn                                              | No event-specific fields                                               |
 
 Provider-executed tools don't produce `pre_tool_use` or `post_tool_use` events because the provider executes them outside Coder's tool runtime.
 
@@ -67,7 +71,8 @@ A consumer must apply all of the following checks before it uses the body:
 
 The Go consumer SDK in `codersdk/agenthooks` implements the wire types, JWT verification, body binding, audience checks, and event routing.
 Use `agenthooks.NewHTTPHandler` to build an `http.Handler` from callbacks for the events your consumer handles.
-Use a secret dedicated to the expected deployment, or add an issuer check when you implement JWT verification directly.
+`NewHTTPHandler` does not enforce a configured issuer: it accepts any non-empty `iss` signed with the shared secret.
+Use a secret dedicated to one deployment, and add your own `iss` check against `meta` or the verified claims if the same secret can reach consumers for more than one deployment.
 
 ### Return a response
 
@@ -75,13 +80,13 @@ Return any `2xx` status with an empty body for a no-op response.
 An empty JSON object has the same effect.
 If the response has a body, return a JSON object with these optional fields.
 
-| Field           | Effect                                                                                                                                                                                                                                                                                                                                                       |
-|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `permission`    | Allows or denies mutable input for `user_prompt_submit` and `pre_tool_use` only.                                                                                                                                                                                                                                                                             |
-| `model_context` | Adds text visible to the model. The value is limited to 16&nbsp;KiB.                                                                                                                                                                                                                                                                                         |
-| `user_message`  | Adds a system message visible to the user.                                                                                                                                                                                                                                                                                                                   |
-| `allowed_tools` | Replaces the chat's hook tool policy. Omit the field to preserve the policy, return `[]` to restrict all tools, or return names to allow only those tools. The policy applies from the next generation step onward, and a call to an excluded tool fails as inactive.                                                                                        |
-| `end_chat`      | Ends the chat when `true`. Ending a chat archives the chat identified by `meta.chat_id` together with any subagent chats it spawned. For an event from a subagent chat, this ends that subagent subtree and its parent chat continues. A `pre_tool_use` `end_chat` ends the chat before the tool runs, and the pending calls become synthetic cancellations. |
+| Field           | Effect                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+|-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `permission`    | Allows or denies mutable input for `user_prompt_submit` and `pre_tool_use` only.                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `model_context` | Adds text visible to the model. The value is limited to 16&nbsp;KiB. The text never appears in the user's transcript, so users cannot tell that the consumer steered the model; the only record is the dispatch audit row.                                                                                                                                                                                                                                                                                                            |
+| `user_message`  | Adds a system message visible to the user.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `allowed_tools` | Narrows the chat's hook tool policy. Omit the field to preserve the policy. The first non-omitted value initializes the policy; later values intersect with it, so an established policy only ever shrinks and `[]` permanently restricts all tools. To restore wider access, end the chat and start a new one. The policy applies from the next generation step onward, and a call to an excluded tool fails as inactive. A subagent chat starts with its parent's policy intersected with any policy returned for the spawn prompt. |
+| `end_chat`      | Ends the chat when `true`. Ending a chat archives the chat identified by `meta.chat_id` together with any subagent chats it spawned. For an event from a subagent chat, this ends that subagent subtree and its parent chat continues. A `pre_tool_use` `end_chat` ends the chat before the tool runs, and the pending calls become synthetic cancellations.                                                                                                                                                                          |
 
 The `permission.decision` value supports `allow` and `deny`.
 The `ask` value isn't supported and causes the dispatch to fail closed.
@@ -92,6 +97,7 @@ Permission rules depend on the event:
   Coder stores and sends the replacement prompt instead of the original prompt.
 - For `pre_tool_use`, `allow` requires `input_override` containing the replacement tool input.
   Coder persists the replacement with the tool call and executes the tool with it.
+  Nothing marks the call as rewritten in the chat, so the model may misattribute the changed behavior; a consumer that rewrites input should also return `user_message` explaining the change.
 - For either event, `deny` blocks the input.
   A denied prompt isn't persisted, and a denied tool call becomes a synthetic error result so the model can choose another action.
   A `user_prompt_submit` denial that also sets `end_chat` rejects the prompt and ends the existing chat. During chat creation there is no chat to end.
@@ -112,6 +118,10 @@ Dispatch precedes persistence, so a delivered event doesn't guarantee that the o
 Coder checks admission before dispatching, but concurrent requests can still fail admission afterward, for example two sends racing for the last queue slot or duplicate submissions of the same tool results.
 The consumer then observes an event for a request that Coder rejects, and the rejected request doesn't persist a prompt or tool result.
 Treat events as attempt notifications rather than proof of a committed operation, and key idempotent tool-event processing on `tool_use_id`.
+
+Delivery is at least once.
+Coder retries one connection failure per dispatch with the same JWT, so the consumer can receive the same `dispatch_id` more than once, and `session_start` response effects can repeat when a runner or process is replaced mid-turn.
+A side-effectful consumer must deduplicate durably by `dispatch_id` and replay its previous response for a duplicate; rejecting duplicates breaks Coder's own retries.
 
 After the consumer is healthy, send another message to an existing errored chat to resume it.
 Coder emits `session_start` with `source` set to `resume` when the agent loop starts again.
@@ -157,5 +167,7 @@ Each row includes the event, chat and turn identifiers, tool-use ID when present
 Use the `dispatch_id` from the request or chat error as the row ID when correlating consumer logs with Coder state.
 
 The table can contain prompts, tool input, response context, and user messages.
+When a response rewrites a prompt or tool input, the row keeps the original value alongside the override, so rewriting doesn't remove the original content from the deployment.
+Rows have no foreign key to chats: they can outlive deleted chats, and denied create attempts leave rows for chats that never existed.
 Apply the same access controls and database protection that you use for other sensitive chat data.
-The `dbpurge` service removes dispatch rows after 90 days to bound table growth.
+The `dbpurge` service removes dispatch rows after 90 days to bound table growth; the retention period isn't configurable.

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1239,6 +1239,17 @@ export interface AgentHookMeta {
 	readonly owner_id: string;
 	readonly workspace_id?: string;
 	readonly turn_id?: string;
+	/**
+	 * ParentChatID identifies the chat whose spawn_agent call created
+	 * this chat. Unset for top-level chats.
+	 */
+	readonly parent_chat_id?: string;
+	/**
+	 * RootChatID identifies the top-level ancestor of a subagent
+	 * chat, so consumers can correlate a whole subagent subtree with
+	 * the user-facing conversation. Unset for top-level chats.
+	 */
+	readonly root_chat_id?: string;
 }
 
 // From agenthooks/types.go


### PR DESCRIPTION
Closes three enforcement gaps and two hardening items found while security-dogfooding this branch with an adversarial hook consumer, plus the documentation the triage called out as release-blocking. Targets `mike/chat-lifecycle-hooks` so the fixes land with the feature.

## Enforcement fixes

**Subagent spawn prompts now dispatch `user_prompt_submit`.** Previously `spawn_agent` persisted the child chat's initial prompt with no hook review and an empty tool policy, so a consumer implementing prompt policy never saw spawn prompts and a tool-restricted parent could spawn an unrestricted child. The spawn path now mirrors chat creation: the hook reviews the prompt before any child state persists and can deny (the `spawn_agent` call fails with the consumer's reason), rewrite the prompt (derived child titles are recomputed so redacted content does not leak), attach `model_context`/`user_message`, restrict tools, or refuse the spawn via `end_chat`. The child's policy starts as the parent policy intersected with any policy in the response, and hook `meta` now carries `parent_chat_id`/`root_chat_id` so consumers can correlate subagent subtrees.

**Persisted pre-tool decisions bind to the reviewed call.** `GetChatHookDispatchDecision` matched only `(chat, turn, tool_use_id)`, so a backend that lets the model author its own tool-call IDs could collide IDs within a turn and replay a decision recorded for one call against a different tool or input. Reuse now also requires the tool name and the effective reviewed input (`input_override` when the hook rewrote it, `original_input` otherwise) to match as `jsonb`, duplicate tool-use IDs within one step fail closed, and rows recorded before the binding existed never match (the next attempt dispatches fresh, which is safe under the documented at-least-once contract). Migration `000549` adds `chat_hook_dispatches.tool_name`.

**`allowed_tools` is now monotonic.** The policy was replace-on-write: a later accepted response could re-widen a restricted chat, and a queued prompt's enqueue-time snapshot overwrote a narrower policy that landed before promotion. The first non-omitted value initializes the policy and later values intersect with it, in both the live-response path and queued promotion. This intentionally changes the documented contract from "replaces" to "narrows"; restoring wider access now requires a new chat.

## Hardening

- Non-connection transport failures (TLS validation, malformed URLs) were labeled `connection_error`; they are deterministic, so they now classify as `protocol_error` and skip the retry.
- The hook secret must be at least 32 bytes at startup. go-jose refuses to sign HS256 with a shorter key, so a short secret previously passed validation and then failed every dispatch at runtime as an opaque `protocol_error`.

## Documentation

Operator docs now state the at-least-once delivery contract (dedupe by `dispatch_id` and replay the cached response; rejecting duplicates breaks Coder's own connection retries), that `NewHTTPHandler` does not enforce a configured issuer, the trusted-proxy requirements behind the forwarded-header audience check, that originals persist in dispatch rows after rewrites and can outlive deleted chats (fixed 90-day retention), that secret rotation is a hard cutover, that `model_context` is invisible to the chat owner, and that consumers rewriting tool input should pair the override with a `user_message` because nothing marks the call as modified (dogfooding showed the model confabulating explanations for rewritten commands).

## Validation

- `coderd/x/chatd` full package, `chatstate`, `chathooks`, `codersdk/agenthooks`, `codersdk`, `coderd` hook integration tests (worked example, prompt-override file links), `dbpurge`, and the migrations suite all pass against Postgres.
- New regression tests: policy narrowing unit + queued-promotion-cannot-widen, spawn gating (rewrite/policy intersection, deny refuses spawn, parent policy inherited), and stale-decision-requires-matching-input.
- `dbgen.Chat` now honors a seeded `HookAllowedTools` (was silently dropped), which the new tests rely on.

Found and validated via two rounds of adversarial dogfooding on this branch (replay/oversize/garbage/redirect consumers, 300-way over-capacity, live workspace-agent command rewriting).
