### PR TITLE
fix: correct invalid inline HTML in hand-written docs

### DIFF
--- a/docs/admin/integrations/devcontainers/envbuilder/add-envbuilder.md
+++ b/docs/admin/integrations/devcontainers/envbuilder/add-envbuilder.md
@@ -84,7 +84,7 @@ choose a template from the
 To set variables such as the namespace, go to the template in your Coder
 dashboard and select **Settings** from the **⋮** (vertical ellipsis) menu:
 
-<Image height="255px" src="../../../../images/templates/template-menu-settings.png" alt="Choose Settings from the template's menu" align="center" />
+<img height="255px" src="../../../../images/templates/template-menu-settings.png" alt="Choose Settings from the template's menu" align="center" />
 
 ## Envbuilder Terraform provider
 

--- a/docs/admin/users/idp-sync.md
+++ b/docs/admin/users/idp-sync.md
@@ -206,7 +206,7 @@ You can limit which groups from your identity provider can log in to Coder with
 [CODER_OIDC_ALLOWED_GROUPS](../../reference/cli/server.md#--oidc-allowed-groups).
 Users who are not in a matching group will see the following error:
 
-<Image height="412px" src="../../images/admin/group-allowlist.png" alt="Unauthorized group error" align="center" />
+<img height="412px" src="../../images/admin/group-allowlist.png" alt="Unauthorized group error" align="center" />
 
 ## Role Sync
 

--- a/docs/admin/users/idp-sync.md
+++ b/docs/admin/users/idp-sync.md
@@ -575,6 +575,8 @@ Steps to troubleshoot.
      groups claim field.
      Use [this answer from Stack Overflow](https://stackoverflow.com/a/55570286) for an example.
 
+</div>
+
 ## Next Steps
 
 - [Configure OIDC Refresh Tokens](./oidc-auth/refresh-tokens.md)

--- a/docs/admin/users/organizations.md
+++ b/docs/admin/users/organizations.md
@@ -27,7 +27,7 @@ are added to this organization by default.
 To edit the organization details, select **Admin settings** from the top bar, then
 **Organizations**:
 
-<Image height="255px" src="../../images/admin/users/organizations/admin-settings-orgs.png" alt="Organizations Menu" align="center" />
+<img height="255px" src="../../images/admin/users/organizations/admin-settings-orgs.png" alt="Organizations Menu" align="center" />
 
 From there, you can manage the name, icon, description, users, and groups:
 
@@ -59,11 +59,11 @@ To create a new organization:
 
 1. Select the current organization to expand the organizations dropdown, then select **Create Organization**:
 
-   <Image height="212px" src="../../images/admin/users/organizations/org-dropdown-create.png" alt="Organizations dropdown and Create Organization" align="center" />
+   <img height="212px" src="../../images/admin/users/organizations/org-dropdown-create.png" alt="Organizations dropdown and Create Organization" align="center" />
 
 1. Enter the details and select **Save** to continue:
 
-   <Image height="579px" src="../../images/admin/users/organizations/new-organization.png" alt="New Organization" align="center" />
+   <img height="579px" src="../../images/admin/users/organizations/new-organization.png" alt="New Organization" align="center" />
 
 In this example, we'll create the `data-platform` org.
 
@@ -111,7 +111,7 @@ From **Admin settings**, select **Organizations**, then **Members** to add membe
 your organization. Once added, members will be able to see the
 organization-specific templates.
 
-<Image height="365px" src="../../images/admin/users/organizations/organization-members.png" alt="Add members" align="center" />
+<img height="365px" src="../../images/admin/users/organizations/organization-members.png" alt="Add members" align="center" />
 
 ### 5. Create a workspace
 

--- a/docs/user-guides/workspace-access/antigravity.md
+++ b/docs/user-guides/workspace-access/antigravity.md
@@ -34,7 +34,7 @@ Antigravity connects to your Coder workspaces using the Coder extension:
       Alternatively:
 
       1. Open the Command Palette
-         (<kdb>Ctrl</kdb>+<kdb>Shift</kdb>+<kdb>P</kdb> or <kdb>Cmd</kdb>+<kdb>Shift</kdb>+<kdb>P</kdb>) and search for `vsix`.
+         (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> or <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>) and search for `vsix`.
 
       1. Select **Extensions: Install from VSIX** and select the vscode-coder extension you downloaded.
 
@@ -42,7 +42,7 @@ Antigravity connects to your Coder workspaces using the Coder extension:
 
 ## Open a workspace in Antigravity
 
-1. From the Antigravity Command Palette (<kdb>Ctrl</kdb>+<kdb>Shift</kdb>+<kdb>P</kdb> or <kdb>Cmd</kdb>+<kdb>Shift</kdb>+<kdb>P</kdb>),
+1. From the Antigravity Command Palette (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> or <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>),
    enter `coder` and select **Coder: Login**.
 
 1. Follow the prompts to login and copy your session token.

--- a/docs/user-guides/workspace-access/cursor.md
+++ b/docs/user-guides/workspace-access/cursor.md
@@ -38,7 +38,7 @@ Cursor can connect to a Coder workspace using the Coder extension:
       Alternatively:
 
       1. Open the Command Palette
-   (<kdb>Ctrl</kdb>+<kdb>Shift</kdb>+<kdb>P</kdb> or <kdb>Cmd</kdb>+<kdb>Shift</kdb>+<kdb>P</kdb>)
+   (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> or <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>)
    and search for `vsix`.
 
       1. Select **Extensions: Install from VSIX** and select the vscode-coder extension you downloaded.
@@ -52,7 +52,7 @@ Cursor can connect to a Coder workspace using the Coder extension:
 ## Open a workspace in Cursor
 
 1. From the Cursor Command Palette
-(<kdb>Ctrl</kdb>+<kdb>Shift</kdb>+<kdb>P</kdb> or <kdb>Cmd</kdb>+<kdb>Shift</kdb>+<kdb>P</kdb>),
+(<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> or <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>),
 enter `coder` and select **Coder: Login**.
 
 1. Follow the prompts to login and copy your session token.

--- a/docs/user-guides/workspace-access/windsurf.md
+++ b/docs/user-guides/workspace-access/windsurf.md
@@ -42,7 +42,7 @@ Windsurf can connect to your Coder workspaces via SSH:
       Alternatively:
 
       1. Open the Command Palette
-         (<kdb>Ctrl</kdb>+<kdb>Shift</kdb>+<kdb>P</kdb> or <kdb>Cmd</kdb>+<kdb>Shift</kdb>+<kdb>P</kdb>) and search for `vsix`.
+         (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> or <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>) and search for `vsix`.
 
       1. Select **Extensions: Install from VSIX** and select the vscode-coder extension you downloaded.
 
@@ -50,7 +50,7 @@ Windsurf can connect to your Coder workspaces via SSH:
 
 ## Open a workspace in Windsurf
 
-1. From the Windsurf Command Palette (<kdb>Ctrl</kdb>+<kdb>Shift</kdb>+<kdb>P</kdb> or <kdb>Cmd</kdb>+<kdb>Shift</kdb>+<kdb>P</kdb>),
+1. From the Windsurf Command Palette (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> or <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>),
    enter `coder` and select **Coder: Login**.
 
 1. Follow the prompts to login and copy your session token.


### PR DESCRIPTION
## What

Fixes three classes of invalid inline HTML in **hand-written** docs, all of
which render incorrectly (or only by accident) today. Found via a systematic,
markdown-aware audit of every `.md` under `docs/`.

## Changes

1. **`<kdb>` → `<kbd>` (72 tags).** The keyboard element is `<kbd>`; `<kdb>` is a
   typo that is not a real element, so renderers drop/mangle it and the
   keystrokes lose their styling. Corrected across the Cursor, Windsurf, and
   Antigravity IDE guides.
2. **Unclosed `<div class="tabs">` in `docs/admin/users/idp-sync.md`.** The
   "Provider-Specific Guides" section opened a `.tabs` container that was never
   closed, so the wrapper leaked over the rest of the page. Added the missing
   `</div>` before `## Next Steps`.
3. **`<Image>` → `<img>` (6 tags).** `<Image>` is not a registered docs
   component — it renders only because the HTML5 parser rewrites the legacy
   `<image>` tag to `<img>`. Converted to lowercase `<img>`; rendering is
   unchanged. (`organizations.md`, `idp-sync.md`, `add-envbuilder.md`.)

## Scope

Hand-written fixes only, so this stays small and quick to review. The companion
PR #27399 adds the CI linter (`docshtmlcheck`) that prevents these from
regressing and fixes the remaining **generated**-doc placeholders at their
source. The `<b>Resource<b>` audit-logs fix landed separately in #27293.
`<children>` is an intentional renderer component and is left as-is (the linter
still balance-checks it).

## Verification

- `markdownlint-cli2` and `markdown-table-formatter --check`: clean.
- The `docshtmlcheck` linter from #27399, run against a tree with these changes:
  0 findings (the same pages are its only findings without them).

## Linear

DOCS-581: https://linear.app/codercom/issue/DOCS-581/audit-and-fix-all-invalid-html-across-the-docs

> This PR was created with AI assistance (Coder Agents).
