### PR TITLE
test(agent/x/agentmcp): fix flaky snapshot-change detection tests

### DIFF
--- a/agent/x/agentmcp/reload_internal_test.go
+++ b/agent/x/agentmcp/reload_internal_test.go
@@ -19,7 +19,23 @@ import (
 	"github.com/coder/coder/v2/agent/agentexec"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/quartz"
 )
+
+// freezeWatcher installs a mock clock on the Manager so the
+// fsnotify config watcher's debounce timer never fires on its own.
+// Tests that mutate a config file and then synchronously assert on
+// SnapshotChanged (or drive Reload manually) use this to keep the
+// assertion deterministic: a real-clock watcher can otherwise fire a
+// background reload that refreshes the snapshot before the assertion
+// runs, masking the change. Must be called before the first Reload
+// arms the watcher.
+func freezeWatcher(t *testing.T, m *Manager) {
+	t.Helper()
+	m.mu.Lock()
+	m.clock = quartz.NewMock(t)
+	m.mu.Unlock()
+}
 
 // catalogTool is a flattened (server, tool) pair taken from the
 // Manager's per-server catalog. Tests assert on these pairs instead of
@@ -191,6 +207,7 @@ func TestSnapshotChanged(t *testing.T) {
 			paths := tc.setup(t, dir)
 
 			m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+			freezeWatcher(t, m)
 			t.Cleanup(func() { _ = m.Close() })
 
 			err := m.Reload(ctx, paths)
@@ -232,6 +249,7 @@ func TestSnapshotChanged_MultipleConfigFiles(t *testing.T) {
 	paths := []string{path1, path2}
 
 	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+	freezeWatcher(t, m)
 	t.Cleanup(func() { _ = m.Close() })
 
 	// Initial reload with both config files.
@@ -369,6 +387,7 @@ func TestReload(t *testing.T) {
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv1": entry1})
 
 		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+		freezeWatcher(t, m)
 		t.Cleanup(func() { _ = m.Close() })
 
 		// First reload.


### PR DESCRIPTION
## Summary

Fixes the flaky tests `TestSnapshotChanged_MultipleConfigFiles` and `TestReload/SequentialReloadsDiffDetect` in `agent/x/agentmcp` (ENG-3022 / coder/internal#1616).

## Root cause

`Manager` arms a live fsnotify config watcher on the first `Reload`, with a 250ms real-clock debounce (`defaultWatchDebounce`). The affected tests rewrite a `.mcp.json` file and then **synchronously** assert `SnapshotChanged(...) == true`. That write also triggers the watcher.

On a loaded CI machine, if more than ~250ms elapses between the file rewrite and the assertion, the watcher's debounce fires first and runs a background `Reload`. That reload calls `captureSnapshot`, refreshing the stored snapshot to reflect the mutated file. The subsequent `SnapshotChanged` then compares the mutated file against the already-updated snapshot and returns `false`, failing the assertion with `Should be true` / `snapshot should change when second file is mutated`.

This explains the reported `MultipleConfigFiles` failure specifically: its rewrite changes the file size (`srv2` -> `srv2b`), so mtime granularity cannot be the cause; only the racing background reload can mask the change.

### Reproduction

Shrinking the debounce and adding a delay before the assertion reproduces the exact CI failure, with the log line `reloading due to config change trigger=fsnotify` immediately preceding it.

## Fix

Add a test-only helper `freezeWatcher` that installs a quartz mock clock on the `Manager` before the first `Reload`. The watcher's debounce `AfterFunc` never fires on its own (the mock clock is never advanced), so no background reload races with the deterministic snapshot/diff-detection assertions. In these tests `m.clock` only drives the watcher debounce (`waitReload` uses it only when `timeout > 0`, and `Reload` passes `0`), so freezing the clock has no other effect.

Applied to `TestSnapshotChanged`, `TestSnapshotChanged_MultipleConfigFiles`, and `TestReload/SequentialReloadsDiffDetect`. The watcher's own behavior remains covered by `configwatcher_internal_test.go`.

## Testing

- `go test ./agent/x/agentmcp/ -count=1` passes.
- `go test ./agent/x/agentmcp/ -race -count=5 -run 'TestSnapshotChanged|TestReload'` passes.
- A race-proof variant with a 500ms delay after the rewrite now passes with `freezeWatcher` (and fails without it).

<details>
<summary>Investigation notes</summary>

- `SnapshotChanged` compares `os.Stat` mtime+size against `m.snapshot`, which is populated by `captureSnapshot` during `doReload`.
- `startReloadIfNeeded` calls `armWatcher(paths)`, which lazily creates the fsnotify `configWatcher` and syncs the watched dirs. A subsequent file write schedules a debounced `handleWatchedConfigChange` -> `Reload` -> `doReload` -> `captureSnapshot`.
- The existing watcher-focused tests already handle this asynchrony via `useFastDebounce` + `awaitTools`/`Eventually`; the snapshot/diff unit tests did not account for the live watcher.

</details>

---

Generated by Coder Agents.
