### PR TITLE
fix: discover dev container configs in .devcontainer sub-folders

### DIFF
--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -481,6 +481,30 @@ func (api *API) discoverDevcontainerProjects() error {
 	return nil
 }
 
+// matchDevcontainerConfigPath reports whether configPath is a dev
+// container configuration file and, if so, returns the workspace
+// folder it configures along with the precedence of its location.
+// Lower precedence values take priority when multiple configuration
+// files resolve to the same workspace folder, mirroring the lookup
+// order from the dev container spec.
+func matchDevcontainerConfigPath(configPath string) (workspaceFolder string, precedence int, ok bool) {
+	if folder, found := strings.CutSuffix(configPath, "/.devcontainer/devcontainer.json"); found {
+		return folder, 0, true
+	}
+	if folder, found := strings.CutSuffix(configPath, "/.devcontainer.json"); found {
+		return folder, 1, true
+	}
+	// The spec also allows one configuration file per sub-folder of
+	// `.devcontainer`, e.g. `.devcontainer/<folder>/devcontainer.json`,
+	// so that a single project can define multiple configurations.
+	if filepath.Base(configPath) == "devcontainer.json" {
+		if devcontainerDir := filepath.Dir(filepath.Dir(configPath)); filepath.Base(devcontainerDir) == ".devcontainer" {
+			return filepath.Dir(devcontainerDir), 2, true
+		}
+	}
+	return "", 0, false
+}
+
 func (api *API) discoverDevcontainersInProject(projectPath string) error {
 	logger := api.logger.
 		Named("project-discovery").
@@ -498,12 +522,18 @@ func (api *API) discoverDevcontainersInProject(projectPath string) error {
 
 	matcher := gitignore.NewMatcher(append(globalPatterns, patterns...))
 
-	devcontainerConfigPaths := []string{
-		"/.devcontainer/devcontainer.json",
-		"/.devcontainer.json",
+	type discoveredConfig struct {
+		configPath string
+		precedence int
 	}
 
-	return afero.Walk(api.fs, projectPath, func(path string, info fs.FileInfo, err error) error {
+	// `knownDevcontainers` is keyed by workspace folder and can only
+	// hold one configuration per folder, so we collect configuration
+	// files during the walk and keep the lowest precedence value for
+	// each workspace folder before registering it.
+	discoveredConfigs := map[string]discoveredConfig{}
+
+	err = afero.Walk(api.fs, projectPath, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
 			logger.Error(api.ctx, "encountered error while walking for dev container projects",
 				slog.F("path", path),
@@ -528,53 +558,76 @@ func (api *API) discoverDevcontainersInProject(projectPath string) error {
 			return nil
 		}
 
-		for _, relativeConfigPath := range devcontainerConfigPaths {
-			if !strings.HasSuffix(path, relativeConfigPath) {
-				continue
-			}
-
-			workspaceFolder := strings.TrimSuffix(path, relativeConfigPath)
-
-			logger := logger.With(slog.F("workspace_folder", workspaceFolder))
-			logger.Debug(api.ctx, "discovered dev container project")
-
-			api.mu.Lock()
-			if _, found := api.knownDevcontainers[workspaceFolder]; !found {
-				logger.Debug(api.ctx, "adding dev container project")
-
-				dc := codersdk.WorkspaceAgentDevcontainer{
-					ID:              uuid.New(),
-					Name:            "", // Updated later based on container state.
-					WorkspaceFolder: workspaceFolder,
-					ConfigPath:      path,
-					Status:          codersdk.WorkspaceAgentDevcontainerStatusStopped,
-					Dirty:           false, // Updated later based on config file changes.
-					Container:       nil,
-				}
-
-				if api.discoveryAutostart {
-					config, err := api.dccli.ReadConfig(api.ctx, workspaceFolder, path, []string{})
-					if err != nil {
-						logger.Error(api.ctx, "read project configuration", slog.Error(err))
-					} else if config.Configuration.Customizations.Coder.AutoStart {
-						dc.Status = codersdk.WorkspaceAgentDevcontainerStatusStarting
-					}
-				}
-
-				api.knownDevcontainers[workspaceFolder] = dc
-				api.broadcastUpdatesLocked()
-
-				if dc.Status == codersdk.WorkspaceAgentDevcontainerStatusStarting {
-					api.asyncWg.Go(func() {
-						_ = api.CreateDevcontainer(dc.WorkspaceFolder, dc.ConfigPath)
-					})
-				}
-			}
-			api.mu.Unlock()
+		workspaceFolder, precedence, ok := matchDevcontainerConfigPath(path)
+		if !ok {
+			return nil
 		}
+
+		logger := logger.With(slog.F("workspace_folder", workspaceFolder))
+		logger.Debug(api.ctx, "discovered dev container project", slog.F("config_path", path))
+
+		if existing, found := discoveredConfigs[workspaceFolder]; found {
+			// The walk visits files in lexical order, so on equal
+			// precedence we keep the configuration discovered first.
+			ignoredConfigPath := path
+			if precedence < existing.precedence {
+				ignoredConfigPath = existing.configPath
+				discoveredConfigs[workspaceFolder] = discoveredConfig{configPath: path, precedence: precedence}
+			}
+			logger.Warn(api.ctx, "multiple dev container config files for workspace folder",
+				slog.F("config_path", discoveredConfigs[workspaceFolder].configPath),
+				slog.F("ignored_config_path", ignoredConfigPath))
+			return nil
+		}
+		discoveredConfigs[workspaceFolder] = discoveredConfig{configPath: path, precedence: precedence}
 
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	for _, workspaceFolder := range slices.Sorted(maps.Keys(discoveredConfigs)) {
+		configPath := discoveredConfigs[workspaceFolder].configPath
+
+		logger := logger.With(slog.F("workspace_folder", workspaceFolder))
+
+		api.mu.Lock()
+		if _, found := api.knownDevcontainers[workspaceFolder]; !found {
+			logger.Debug(api.ctx, "adding dev container project")
+
+			dc := codersdk.WorkspaceAgentDevcontainer{
+				ID:              uuid.New(),
+				Name:            "", // Updated later based on container state.
+				WorkspaceFolder: workspaceFolder,
+				ConfigPath:      configPath,
+				Status:          codersdk.WorkspaceAgentDevcontainerStatusStopped,
+				Dirty:           false, // Updated later based on config file changes.
+				Container:       nil,
+			}
+
+			if api.discoveryAutostart {
+				config, err := api.dccli.ReadConfig(api.ctx, workspaceFolder, configPath, []string{})
+				if err != nil {
+					logger.Error(api.ctx, "read project configuration", slog.Error(err))
+				} else if config.Configuration.Customizations.Coder.AutoStart {
+					dc.Status = codersdk.WorkspaceAgentDevcontainerStatusStarting
+				}
+			}
+
+			api.knownDevcontainers[workspaceFolder] = dc
+			api.broadcastUpdatesLocked()
+
+			if dc.Status == codersdk.WorkspaceAgentDevcontainerStatusStarting {
+				api.asyncWg.Go(func() {
+					_ = api.CreateDevcontainer(dc.WorkspaceFolder, dc.ConfigPath)
+				})
+			}
+		}
+		api.mu.Unlock()
+	}
+
+	return nil
 }
 
 func (api *API) watcherLoop() {

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -4623,6 +4623,104 @@ func TestDevcontainerDiscovery(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "SubfolderConfig/SingleConfig",
+			agentDir: "/home/coder",
+			fs: map[string]string{
+				"/home/coder/.git/HEAD":                              "",
+				"/home/coder/.devcontainer/python/devcontainer.json": "",
+			},
+			expected: []codersdk.WorkspaceAgentDevcontainer{
+				{
+					WorkspaceFolder: "/home/coder",
+					ConfigPath:      "/home/coder/.devcontainer/python/devcontainer.json",
+					Status:          codersdk.WorkspaceAgentDevcontainerStatusStopped,
+				},
+			},
+		},
+		{
+			name:     "SubfolderConfig/FirstSubfolderWins",
+			agentDir: "/home/coder",
+			fs: map[string]string{
+				"/home/coder/.git/HEAD":                              "",
+				"/home/coder/.devcontainer/go/devcontainer.json":     "",
+				"/home/coder/.devcontainer/python/devcontainer.json": "",
+			},
+			expected: []codersdk.WorkspaceAgentDevcontainer{
+				{
+					WorkspaceFolder: "/home/coder",
+					ConfigPath:      "/home/coder/.devcontainer/go/devcontainer.json",
+					Status:          codersdk.WorkspaceAgentDevcontainerStatusStopped,
+				},
+			},
+		},
+		{
+			name:     "SubfolderConfig/DevcontainerDirConfigWins",
+			agentDir: "/home/coder",
+			fs: map[string]string{
+				"/home/coder/.git/HEAD":                              "",
+				"/home/coder/.devcontainer/devcontainer.json":        "",
+				"/home/coder/.devcontainer/python/devcontainer.json": "",
+			},
+			expected: []codersdk.WorkspaceAgentDevcontainer{
+				{
+					WorkspaceFolder: "/home/coder",
+					ConfigPath:      "/home/coder/.devcontainer/devcontainer.json",
+					Status:          codersdk.WorkspaceAgentDevcontainerStatusStopped,
+				},
+			},
+		},
+		{
+			name:     "SubfolderConfig/RootDotfileConfigWins",
+			agentDir: "/home/coder",
+			fs: map[string]string{
+				"/home/coder/.git/HEAD":                              "",
+				"/home/coder/.devcontainer.json":                     "",
+				"/home/coder/.devcontainer/python/devcontainer.json": "",
+			},
+			expected: []codersdk.WorkspaceAgentDevcontainer{
+				{
+					WorkspaceFolder: "/home/coder",
+					ConfigPath:      "/home/coder/.devcontainer.json",
+					Status:          codersdk.WorkspaceAgentDevcontainerStatusStopped,
+				},
+			},
+		},
+		{
+			name:     "SubfolderConfig/IgnoreNonsenseNamesAndNesting",
+			agentDir: "/home/coder",
+			fs: map[string]string{
+				"/home/coder/.git/HEAD": "",
+
+				"/home/coder/.devcontainer/python/devcontainer.json.bak": "",
+				"/home/coder/.devcontainer/python/notdevcontainer.json":  "",
+				"/home/coder/.devcontainer/a/b/devcontainer.json":        "",
+				"/home/coder/.devcontainer/python/devcontainer.json":     "",
+			},
+			expected: []codersdk.WorkspaceAgentDevcontainer{
+				{
+					WorkspaceFolder: "/home/coder",
+					ConfigPath:      "/home/coder/.devcontainer/python/devcontainer.json",
+					Status:          codersdk.WorkspaceAgentDevcontainerStatusStopped,
+				},
+			},
+		},
+		{
+			name:     "ConfigPrecedence/DevcontainerDirWinsOverDotfile",
+			agentDir: "/home/coder",
+			fs: map[string]string{
+				"/home/coder/.git/HEAD":                       "",
+				"/home/coder/.devcontainer/devcontainer.json": "",
+				"/home/coder/.devcontainer.json":              "",
+			},
+			expected: []codersdk.WorkspaceAgentDevcontainer{
+				{
+					WorkspaceFolder: "/home/coder",
+					ConfigPath:      "/home/coder/.devcontainer/devcontainer.json",
+					Status:          codersdk.WorkspaceAgentDevcontainerStatusStopped,
+				},
+			},
+		},
 	}
 
 	initFS := func(t *testing.T, files map[string]string) afero.Fs {


### PR DESCRIPTION
Closes #26363

Project discovery only matches `.devcontainer/devcontainer.json` and `.devcontainer.json`, so configurations at `.devcontainer/<folder>/devcontainer.json` (the third location from the dev container spec, and one the Coder docs list for monorepos) never show up as dev container cards. Containers started manually with `devcontainer up --config` for those configs are picked up fine via the container label, which leaves monorepo users with configs that work from the CLI but are invisible in the dashboard.

This extends the matching in `discoverDevcontainersInProject` to also accept `devcontainer.json` files one directory below `.devcontainer`. Since `knownDevcontainers` is keyed by workspace folder and can only hold one config per folder, config files are now collected during the walk and registered afterwards, with the conventional locations taking precedence over sub-folder configs and a warning logged for the configs that lose out. Representing multiple configurations per project as separate cards would need that keying reworked, so this sticks to the minimal fix from the issue and leaves that as a follow-up.

One side effect worth calling out: the precedence between `.devcontainer/devcontainer.json` and `.devcontainer.json` used to fall out of walk order, and now follows the spec's lookup order explicitly. There is a new test pinning that.

## Testing

New table cases in `TestDevcontainerDiscovery` cover the repro from the issue (a repo with only a sub-folder config), both conventional locations winning over sub-folder configs, a deterministic pick when only multiple sub-folder configs exist, and non-config files inside `.devcontainer` sub-folders staying ignored.

```
$ go test ./agent/agentcontainers/ -run 'TestDevcontainerDiscovery/SubfolderConfig|TestDevcontainerDiscovery/ConfigPrecedence' -count=1 -v
=== RUN   TestDevcontainerDiscovery
=== RUN   TestDevcontainerDiscovery/SubfolderConfig/SingleConfig
=== RUN   TestDevcontainerDiscovery/SubfolderConfig/FirstSubfolderWins
=== RUN   TestDevcontainerDiscovery/SubfolderConfig/DevcontainerDirConfigWins
=== RUN   TestDevcontainerDiscovery/SubfolderConfig/RootDotfileConfigWins
=== RUN   TestDevcontainerDiscovery/SubfolderConfig/IgnoreNonsenseNamesAndNesting
=== RUN   TestDevcontainerDiscovery/ConfigPrecedence/DevcontainerDirWinsOverDotfile
--- PASS: TestDevcontainerDiscovery (0.00s)
PASS
ok      github.com/coder/coder/v2/agent/agentcontainers        0.474s
```

The full `agent/agentcontainers` suite and `golangci-lint` pass locally as well. The new sub-folder test cases fail on `main` before this change (discovery finds nothing), which matches the reported behavior.

Per the [AI contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING): parts of this PR were written with AI assistance. I reviewed the change and ran the verification above myself.
