### PR TITLE
feat(coderd/x/chatd): persist execute tool intents and result commits in the execution ledger

### DIFF
--- a/coderd/x/chatd/ARCHITECTURE.md
+++ b/coderd/x/chatd/ARCHITECTURE.md
@@ -871,6 +871,47 @@ When the manager cleans up a runner, the runner must cancel all goroutines it ha
 
 The worker periodically archives old, unused chats.
 
+## Execute tool execution ledger
+
+Task retries re-read the committed history and re-execute unresolved tool calls. Without extra state, every retry of an in-flight `execute` tool call would start another OS process in the workspace, leaving orphaned duplicates. The `chat_tool_call_executions` table is a durable execution ledger that prevents this. It owns the external process lifecycle, while the core state machine keeps owning chat semantics.
+
+**Invariant:** one logical local tool call creates at most one external process. Later attempts re-attach, observe, reconcile cancellation, or return a stable unknown-outcome result. They never silently start another process.
+
+### Identity and lineage
+
+Each row's primary key `id` is the execution ID, a UUID generated when the intent is persisted. It is the stable identity of the (at most one) external process for this call. Rows are unique on the lineage key `(chat_id, assistant_message_id, tool_call_id)`. The assistant message ID is part of the key because provider tool call IDs are not unique across history regenerations: an edited history that regenerates an assistant message reusing a tool call ID gets a new ledger row, and the old row keeps its process identity instead of being reset.
+
+`input_sha256` hashes the persisted tool input. A claim asserts it, so an attempt whose input does not match the row's refuses to dispatch against stale lineage.
+
+### Status model
+
+The `status` column tracks the external process lifecycle:
+
+| Status | Meaning |
+|---|---|
+| `reserved` | Intent persisted with the assistant message; nothing dispatched. |
+| `starting` | A runner claimed the row (`claim_epoch` advanced, `claimed_at` set); dispatch may be in flight. |
+| `running` | Process identity recorded (`process_id`, `workspace_agent_id`, `started_at`). |
+| `exited` | The tool observed the process exit (fresh wait or re-attach snapshot). |
+| `detached` | The chat moved on and the process was deliberately left alive: background start, timed-out foreground, or interrupted background. |
+| `cancel_requested` | An interrupt resolved the call in chat, but process termination is unconfirmed. `cancel_signal_sent_at` records a delivered kill signal. |
+| `canceled` | Termination confirmed, or nothing was ever dispatched. |
+| `unknown` | The command may have run; the outcome is unobservable. Terminal for auto-restart. |
+| `no_effect` | Validation failed before any external dispatch. |
+
+Lifecycle status is orthogonal to chat-result commitment. `result_committed_at` is set in the same transaction that commits the call's tool result (real, synthetic-unknown, validation-error, or interrupt-synthetic). Diagnostic states like `cancel_requested` and `unknown` keep their lifecycle truth after the chat has moved on, which is what a later reconciler needs.
+
+### Atomicity points
+
+Ledger writes that must agree with chat state run inside the same `ChatMachine.Update` transaction as the corresponding message commit, via the transaction-scoped store:
+
+- The assistant-step commit inserts one `reserved` intent per `execute` tool call in the step. A replayed commit conflicts on the lineage key and is a no-op.
+- The tool-result commit sets `result_committed_at` for the executed calls.
+
+### Retention
+
+Rows are never deleted at resolution time; they stay diagnostically useful. `dbpurge` deletes rows older than 7 days, but only rows whose tool result was committed: an uncommitted row still guards dedup for a call a future retry may re-execute. `cancel_requested` rows are kept regardless of age: the cancelling transaction stamps `result_committed_at` on them, but they still carry the only stored identity of a process the sweep must kill. Uncommitted rows are reaped on a separate 30-day horizon anchored on `updated_at`: a row idle that long belongs to a turn that will never rerun (a crashed turn, a terminal task failure, an unclaimed `reserved` intent), and without this horizon it would only ever be reaped by chat retention, which many deployments leave unset. Deletion only discards ledger history: a still-running detached process is unaffected and stays addressable through the process handle in its committed tool result.
+
 # Stream loop
 
 The stream loop powers the `GET /api/experimental/chats/{chat}/stream` endpoint. It is scoped to one chat and one client WebSocket. It's responsible for delivering a stream of chat updates to the client, including:

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbfake"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
 	dbpubsub "github.com/coder/coder/v2/coderd/database/pubsub"
 	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/coderd/util/slice"
@@ -13064,4 +13065,479 @@ func setupWorkspaceContextAgentConn(
 		Return(workspacesdk.LSResponse{AbsolutePathString: "/home/coder"}, nil).AnyTimes()
 	mockConn.EXPECT().ReadFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(io.NopCloser(strings.NewReader("")), "", nil).AnyTimes()
+}
+
+// TestChatToolCallExecutionLedgerQueries exercises the ledger's
+// compare-and-set semantics at the query level: claim ownership,
+// lineage isolation across regenerated assistant messages, the
+// input hash guard, guarded status transitions, and the interrupt
+// mapping.
+func TestChatToolCallExecutionLedgerQueries(t *testing.T) {
+	t.Parallel()
+
+	newLedgerFixture := func(t *testing.T) (context.Context, database.Store, database.Chat, database.ChatMessage) {
+		t.Helper()
+		db, _ := dbtestutil.NewDB(t)
+		ctx := testutil.Context(t, testutil.WaitLong)
+		user := dbgen.User(t, db, database.User{})
+		org := dbgen.Organization(t, db, database.Organization{})
+		_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{UserID: user.ID, OrganizationID: org.ID})
+		_ = dbgen.ChatProvider(t, db, database.ChatProvider{Provider: "openai", DisplayName: "OpenAI"})
+		mc := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{Model: "test-model", ContextLimit: 8192})
+		chat := dbgen.Chat(t, db, database.Chat{
+			OrganizationID:    org.ID,
+			OwnerID:           user.ID,
+			LastModelConfigID: mc.ID,
+			Title:             "ledger-queries",
+		})
+		msg := dbgen.ChatMessage(t, db, database.ChatMessage{
+			ChatID: chat.ID,
+			Role:   database.ChatMessageRoleAssistant,
+		})
+		return ctx, db, chat, msg
+	}
+
+	insertIntent := func(ctx context.Context, t *testing.T, db database.Store, chat database.Chat, msg database.ChatMessage, callID, hash string) {
+		t.Helper()
+		err := db.InsertChatToolCallExecutionIntent(ctx, database.InsertChatToolCallExecutionIntentParams{
+			ID:                 uuid.New(),
+			ChatID:             chat.ID,
+			AssistantMessageID: msg.ID,
+			ToolCallID:         callID,
+			InputSha256:        hash,
+			CreatedAt:          dbtime.Now(),
+		})
+		require.NoError(t, err)
+	}
+
+	claimParams := func(chat database.Chat, msg database.ChatMessage, callID, hash string, staleBefore time.Time) database.ClaimChatToolCallExecutionParams {
+		return database.ClaimChatToolCallExecutionParams{
+			ID:                 uuid.New(),
+			ChatID:             chat.ID,
+			AssistantMessageID: msg.ID,
+			ToolCallID:         callID,
+			InputSha256:        hash,
+			Command:            "echo hi",
+			TimeoutSecs:        60,
+			Now:                dbtime.Now(),
+			StaleBefore:        staleBefore,
+		}
+	}
+
+	t.Run("ClaimCAS", func(t *testing.T) {
+		t.Parallel()
+		ctx, db, chat, msg := newLedgerFixture(t)
+		insertIntent(ctx, t, db, chat, msg, "call-1", "hash")
+
+		claimed, err := db.ClaimChatToolCallExecution(ctx, claimParams(chat, msg, "call-1", "hash", time.Time{}))
+		require.NoError(t, err)
+		require.Equal(t, database.ChatToolCallExecutionStatusStarting, claimed.Status)
+		require.EqualValues(t, 1, claimed.ClaimEpoch)
+
+		// The intent's execution identity survives the claim; the
+		// insert arm's fresh UUID is discarded on conflict.
+		intentRow, err := db.GetChatToolCallExecution(ctx, database.GetChatToolCallExecutionParams{ChatID: chat.ID, AssistantMessageID: msg.ID, ToolCallID: "call-1"})
+		require.NoError(t, err)
+		require.Equal(t, intentRow.ID, claimed.ID)
+
+		// A fresh claim is not claimable again.
+		_, err = db.ClaimChatToolCallExecution(ctx, claimParams(chat, msg, "call-1", "hash", time.Time{}))
+		require.ErrorIs(t, err, sql.ErrNoRows)
+
+		// A stale takeover without a verified epoch matches
+		// nothing: only the reserved arm claims without evidence.
+		_, err = db.ClaimChatToolCallExecution(ctx, claimParams(chat, msg, "call-1", "hash", dbtime.Now().Add(time.Minute)))
+		require.ErrorIs(t, err, sql.ErrNoRows)
+
+		// A takeover fenced to a superseded epoch matches nothing:
+		// evidence gathered against one claim cannot take over a
+		// newer one.
+		fencedParams := claimParams(chat, msg, "call-1", "hash", dbtime.Now().Add(time.Minute))
+		fencedParams.StaleEpoch = sql.NullInt64{Int64: 99, Valid: true}
+		_, err = db.ClaimChatToolCallExecution(ctx, fencedParams)
+		require.ErrorIs(t, err, sql.ErrNoRows)
+
+		// A stale claim is claimable once stale_before passes its
+		// claimed_at, and the takeover advances the epoch. Fencing
+		// to the observed epoch succeeds.
+		fencedParams.StaleEpoch = sql.NullInt64{Int64: claimed.ClaimEpoch, Valid: true}
+		retaken, err := db.ClaimChatToolCallExecution(ctx, fencedParams)
+		require.NoError(t, err)
+		require.EqualValues(t, 2, retaken.ClaimEpoch)
+		require.Equal(t, claimed.ID, retaken.ID)
+	})
+
+	t.Run("ClaimRefusedAfterResultCommitted", func(t *testing.T) {
+		t.Parallel()
+		ctx, db, chat, msg := newLedgerFixture(t)
+		insertIntent(ctx, t, db, chat, msg, "call-committed", "hash")
+		err := db.MarkChatToolCallExecutionsResultCommitted(ctx, database.MarkChatToolCallExecutionsResultCommittedParams{
+			ChatID:             chat.ID,
+			AssistantMessageID: msg.ID,
+			ToolCallIds:        []string{"call-committed"},
+			ResultCommittedAt:  dbtime.Now(),
+		})
+		require.NoError(t, err)
+
+		// The call is resolved in chat, so the row is never
+		// claimable again: re-dispatching could run the command
+		// twice.
+		_, err = db.ClaimChatToolCallExecution(ctx, claimParams(chat, msg, "call-committed", "hash", time.Time{}))
+		require.ErrorIs(t, err, sql.ErrNoRows)
+		row, err := db.GetChatToolCallExecution(ctx, database.GetChatToolCallExecutionParams{ChatID: chat.ID, AssistantMessageID: msg.ID, ToolCallID: "call-committed"})
+		require.NoError(t, err)
+		require.Equal(t, database.ChatToolCallExecutionStatusReserved, row.Status)
+	})
+
+	t.Run("ClaimMissingRowInserts", func(t *testing.T) {
+		t.Parallel()
+		ctx, db, chat, msg := newLedgerFixture(t)
+
+		claimed, err := db.ClaimChatToolCallExecution(ctx, claimParams(chat, msg, "call-preledger", "hash", time.Time{}))
+		require.NoError(t, err)
+		require.Equal(t, database.ChatToolCallExecutionStatusStarting, claimed.Status)
+		require.EqualValues(t, 1, claimed.ClaimEpoch)
+	})
+
+	t.Run("ClaimInputHashGuard", func(t *testing.T) {
+		t.Parallel()
+		ctx, db, chat, msg := newLedgerFixture(t)
+		insertIntent(ctx, t, db, chat, msg, "call-1", "hash-a")
+
+		_, err := db.ClaimChatToolCallExecution(ctx, claimParams(chat, msg, "call-1", "hash-b", time.Time{}))
+		require.ErrorIs(t, err, sql.ErrNoRows)
+
+		row, err := db.GetChatToolCallExecution(ctx, database.GetChatToolCallExecutionParams{ChatID: chat.ID, AssistantMessageID: msg.ID, ToolCallID: "call-1"})
+		require.NoError(t, err)
+		require.Equal(t, database.ChatToolCallExecutionStatusReserved, row.Status)
+	})
+
+	t.Run("LineageIsolation", func(t *testing.T) {
+		t.Parallel()
+		ctx, db, chat, msg := newLedgerFixture(t)
+		regenerated := dbgen.ChatMessage(t, db, database.ChatMessage{
+			ChatID: chat.ID,
+			Role:   database.ChatMessageRoleAssistant,
+		})
+
+		// A regenerated assistant message reusing a provider tool
+		// call ID gets its own row; the old row keeps its state.
+		insertIntent(ctx, t, db, chat, msg, "call-1", "hash-old")
+		claimed, err := db.ClaimChatToolCallExecution(ctx, claimParams(chat, msg, "call-1", "hash-old", time.Time{}))
+		require.NoError(t, err)
+		insertIntent(ctx, t, db, chat, regenerated, "call-1", "hash-new")
+
+		oldRow, err := db.GetChatToolCallExecution(ctx, database.GetChatToolCallExecutionParams{ChatID: chat.ID, AssistantMessageID: msg.ID, ToolCallID: "call-1"})
+		require.NoError(t, err)
+		require.Equal(t, database.ChatToolCallExecutionStatusStarting, oldRow.Status)
+		require.Equal(t, claimed.ID, oldRow.ID)
+
+		newRow, err := db.GetChatToolCallExecution(ctx, database.GetChatToolCallExecutionParams{ChatID: chat.ID, AssistantMessageID: regenerated.ID, ToolCallID: "call-1"})
+		require.NoError(t, err)
+		require.Equal(t, database.ChatToolCallExecutionStatusReserved, newRow.Status)
+		require.NotEqual(t, oldRow.ID, newRow.ID)
+	})
+
+	t.Run("IntentReplayIsNoop", func(t *testing.T) {
+		t.Parallel()
+		ctx, db, chat, msg := newLedgerFixture(t)
+		insertIntent(ctx, t, db, chat, msg, "call-1", "hash")
+		claimed, err := db.ClaimChatToolCallExecution(ctx, claimParams(chat, msg, "call-1", "hash", time.Time{}))
+		require.NoError(t, err)
+
+		// A replayed intent insert conflicts on lineage and must
+		// not reset the claimed row.
+		insertIntent(ctx, t, db, chat, msg, "call-1", "hash")
+		row, err := db.GetChatToolCallExecution(ctx, database.GetChatToolCallExecutionParams{ChatID: chat.ID, AssistantMessageID: msg.ID, ToolCallID: "call-1"})
+		require.NoError(t, err)
+		require.Equal(t, database.ChatToolCallExecutionStatusStarting, row.Status)
+		require.Equal(t, claimed.ID, row.ID)
+	})
+
+	t.Run("ProcessUpdateEpochGuard", func(t *testing.T) {
+		t.Parallel()
+		ctx, db, chat, msg := newLedgerFixture(t)
+		_, agent := seedWorkspaceWithAgent(t, db, chat.OwnerID)
+		agentID := agent.ID
+		insertIntent(ctx, t, db, chat, msg, "call-1", "hash")
+		claimed, err := db.ClaimChatToolCallExecution(ctx, claimParams(chat, msg, "call-1", "hash", time.Time{}))
+		require.NoError(t, err)
+
+		_, err = db.UpdateChatToolCallExecutionProcess(ctx, database.UpdateChatToolCallExecutionProcessParams{
+			ChatID:             chat.ID,
+			AssistantMessageID: msg.ID,
+			ToolCallID:         "call-1",
+			ClaimEpoch:         claimed.ClaimEpoch + 1,
+			ProcessID:          "proc-stale",
+			WorkspaceAgentID:   agentID,
+			StartedAt:          dbtime.Now(),
+		})
+		require.ErrorIs(t, err, sql.ErrNoRows)
+
+		row, err := db.UpdateChatToolCallExecutionProcess(ctx, database.UpdateChatToolCallExecutionProcessParams{
+			ChatID:             chat.ID,
+			AssistantMessageID: msg.ID,
+			ToolCallID:         "call-1",
+			ClaimEpoch:         claimed.ClaimEpoch,
+			ProcessID:          "proc-1",
+			WorkspaceAgentID:   agentID,
+			StartedAt:          dbtime.Now(),
+		})
+		require.NoError(t, err)
+		require.Equal(t, database.ChatToolCallExecutionStatusRunning, row.Status)
+	})
+
+	t.Run("ProcessUpdateAfterInterrupt", func(t *testing.T) {
+		t.Parallel()
+		ctx, db, chat, msg := newLedgerFixture(t)
+		_, agent := seedWorkspaceWithAgent(t, db, chat.OwnerID)
+		agentID := agent.ID
+		insertIntent(ctx, t, db, chat, msg, "call-1", "hash")
+		claimed, err := db.ClaimChatToolCallExecution(ctx, claimParams(chat, msg, "call-1", "hash", time.Time{}))
+		require.NoError(t, err)
+
+		// The interrupt lands while the dispatch is in flight.
+		interruptedAt := dbtime.Now()
+		_, err = db.MarkChatToolCallExecutionsInterrupted(ctx, database.MarkChatToolCallExecutionsInterruptedParams{
+			ChatID:             chat.ID,
+			AssistantMessageID: msg.ID,
+			ToolCallIds:        []string{"call-1"},
+			SpareBackground:    true,
+			UpdatedAt:          interruptedAt,
+		})
+		require.NoError(t, err)
+
+		// The handle write still lands on the interrupt-owned row
+		// without reverting its status, so the reconciler can kill
+		// the process instead of resolving it unknown.
+		row, err := db.UpdateChatToolCallExecutionProcess(ctx, database.UpdateChatToolCallExecutionProcessParams{
+			ChatID:             chat.ID,
+			AssistantMessageID: msg.ID,
+			ToolCallID:         "call-1",
+			ClaimEpoch:         claimed.ClaimEpoch,
+			ProcessID:          "proc-late",
+			WorkspaceAgentID:   agentID,
+			StartedAt:          interruptedAt.Add(-time.Hour),
+		})
+		require.NoError(t, err)
+		require.Equal(t, database.ChatToolCallExecutionStatusCancelRequested, row.Status)
+		require.Equal(t, "proc-late", row.ProcessID.String)
+		// A handle write anchored before the interrupt must not
+		// move the sweep lease backward.
+		require.False(t, row.UpdatedAt.Before(interruptedAt))
+	})
+
+	t.Run("StatusTransitionGuard", func(t *testing.T) {
+		t.Parallel()
+		ctx, db, chat, msg := newLedgerFixture(t)
+		insertIntent(ctx, t, db, chat, msg, "call-1", "hash")
+
+		// exited is not reachable from reserved.
+		_, err := db.UpdateChatToolCallExecutionStatus(ctx, database.UpdateChatToolCallExecutionStatusParams{
+			ChatID:             chat.ID,
+			AssistantMessageID: msg.ID,
+			ToolCallID:         "call-1",
+			Status:             database.ChatToolCallExecutionStatusExited,
+			FromStatuses:       []database.ChatToolCallExecutionStatus{database.ChatToolCallExecutionStatusStarting, database.ChatToolCallExecutionStatusRunning},
+			UpdatedAt:          dbtime.Now(),
+		})
+		require.ErrorIs(t, err, sql.ErrNoRows)
+
+		// no_effect is.
+		row, err := db.UpdateChatToolCallExecutionStatus(ctx, database.UpdateChatToolCallExecutionStatusParams{
+			ChatID:             chat.ID,
+			AssistantMessageID: msg.ID,
+			ToolCallID:         "call-1",
+			Status:             database.ChatToolCallExecutionStatusNoEffect,
+			FromStatuses:       []database.ChatToolCallExecutionStatus{database.ChatToolCallExecutionStatusReserved},
+			UpdatedAt:          dbtime.Now(),
+		})
+		require.NoError(t, err)
+		require.Equal(t, database.ChatToolCallExecutionStatusNoEffect, row.Status)
+	})
+
+	t.Run("InterruptMapping", func(t *testing.T) {
+		t.Parallel()
+		ctx, db, chat, msg := newLedgerFixture(t)
+		_, agent := seedWorkspaceWithAgent(t, db, chat.OwnerID)
+		agentID := agent.ID
+
+		// reserved: nothing dispatched.
+		insertIntent(ctx, t, db, chat, msg, "call-reserved", "hash")
+		// starting: claimed but no process recorded.
+		insertIntent(ctx, t, db, chat, msg, "call-starting", "hash")
+		_, err := db.ClaimChatToolCallExecution(ctx, claimParams(chat, msg, "call-starting", "hash", time.Time{}))
+		require.NoError(t, err)
+		// running: claimed with a recorded process.
+		insertIntent(ctx, t, db, chat, msg, "call-running", "hash")
+		claimed, err := db.ClaimChatToolCallExecution(ctx, claimParams(chat, msg, "call-running", "hash", time.Time{}))
+		require.NoError(t, err)
+		_, err = db.UpdateChatToolCallExecutionProcess(ctx, database.UpdateChatToolCallExecutionProcessParams{
+			ChatID:             chat.ID,
+			AssistantMessageID: msg.ID,
+			ToolCallID:         "call-running",
+			ClaimEpoch:         claimed.ClaimEpoch,
+			ProcessID:          "proc-running",
+			WorkspaceAgentID:   agentID,
+			StartedAt:          dbtime.Now(),
+		})
+		require.NoError(t, err)
+		// background with a recorded handle: detached by the
+		// interrupt instead of cancel_requested.
+		bgParams := claimParams(chat, msg, "call-bg", "hash", time.Time{})
+		bgParams.Background = true
+		bgClaimed, err := db.ClaimChatToolCallExecution(ctx, bgParams)
+		require.NoError(t, err)
+		_, err = db.UpdateChatToolCallExecutionProcess(ctx, database.UpdateChatToolCallExecutionProcessParams{
+			ChatID:             chat.ID,
+			AssistantMessageID: msg.ID,
+			ToolCallID:         "call-bg",
+			ClaimEpoch:         bgClaimed.ClaimEpoch,
+			ProcessID:          "proc-bg",
+			WorkspaceAgentID:   agentID,
+			StartedAt:          dbtime.Now(),
+		})
+		require.NoError(t, err)
+		// background whose start is still in flight (no handle):
+		// must not be terminalized as detached with nothing to
+		// re-attach to; the reconciler resolves it once the handle
+		// lands.
+		bgPendingParams := claimParams(chat, msg, "call-bg-pending", "hash", time.Time{})
+		bgPendingParams.Background = true
+		_, err = db.ClaimChatToolCallExecution(ctx, bgPendingParams)
+		require.NoError(t, err)
+		// foreground detached by a timed-out wait whose result never
+		// committed: the model never got the handle, so the
+		// interrupt reopens it as cancel_requested for the kill.
+		fgDetachedClaimed, err := db.ClaimChatToolCallExecution(ctx, claimParams(chat, msg, "call-fg-detached", "hash", time.Time{}))
+		require.NoError(t, err)
+		_, err = db.UpdateChatToolCallExecutionProcess(ctx, database.UpdateChatToolCallExecutionProcessParams{
+			ChatID:             chat.ID,
+			AssistantMessageID: msg.ID,
+			ToolCallID:         "call-fg-detached",
+			ClaimEpoch:         fgDetachedClaimed.ClaimEpoch,
+			ProcessID:          "proc-fg-detached",
+			WorkspaceAgentID:   agentID,
+			StartedAt:          dbtime.Now(),
+		})
+		require.NoError(t, err)
+		_, err = db.UpdateChatToolCallExecutionStatus(ctx, database.UpdateChatToolCallExecutionStatusParams{
+			ChatID:             chat.ID,
+			AssistantMessageID: msg.ID,
+			ToolCallID:         "call-fg-detached",
+			Status:             database.ChatToolCallExecutionStatusDetached,
+			FromStatuses:       []database.ChatToolCallExecutionStatus{database.ChatToolCallExecutionStatusRunning},
+			UpdatedAt:          dbtime.Now(),
+		})
+		require.NoError(t, err)
+		// background with a recorded handle whose dispatch agent is
+		// deleted: the process died with its workspace, so sparing
+		// would hand the model an unusable handle; the row routes to
+		// the cancel path instead.
+		_, deletedAgent := seedWorkspaceWithAgent(t, db, chat.OwnerID)
+		bgGoneParams := claimParams(chat, msg, "call-bg-agent-gone", "hash", time.Time{})
+		bgGoneParams.Background = true
+		bgGoneClaimed, err := db.ClaimChatToolCallExecution(ctx, bgGoneParams)
+		require.NoError(t, err)
+		_, err = db.UpdateChatToolCallExecutionProcess(ctx, database.UpdateChatToolCallExecutionProcessParams{
+			ChatID:             chat.ID,
+			AssistantMessageID: msg.ID,
+			ToolCallID:         "call-bg-agent-gone",
+			ClaimEpoch:         bgGoneClaimed.ClaimEpoch,
+			ProcessID:          "proc-bg-agent-gone",
+			WorkspaceAgentID:   deletedAgent.ID,
+			StartedAt:          dbtime.Now(),
+		})
+		require.NoError(t, err)
+		goneWs, err := db.GetWorkspaceByAgentID(ctx, deletedAgent.ID)
+		require.NoError(t, err)
+		require.NoError(t, db.SoftDeleteWorkspaceAgentsByWorkspaceID(ctx, goneWs.ID))
+
+		// background already detached with a handle: stays detached.
+		bgDetachedParams := claimParams(chat, msg, "call-bg-detached", "hash", time.Time{})
+		bgDetachedParams.Background = true
+		bgDetachedClaimed, err := db.ClaimChatToolCallExecution(ctx, bgDetachedParams)
+		require.NoError(t, err)
+		_, err = db.UpdateChatToolCallExecutionProcess(ctx, database.UpdateChatToolCallExecutionProcessParams{
+			ChatID:             chat.ID,
+			AssistantMessageID: msg.ID,
+			ToolCallID:         "call-bg-detached",
+			ClaimEpoch:         bgDetachedClaimed.ClaimEpoch,
+			ProcessID:          "proc-bg-detached",
+			WorkspaceAgentID:   agentID,
+			StartedAt:          dbtime.Now(),
+		})
+		require.NoError(t, err)
+		_, err = db.UpdateChatToolCallExecutionStatus(ctx, database.UpdateChatToolCallExecutionStatusParams{
+			ChatID:             chat.ID,
+			AssistantMessageID: msg.ID,
+			ToolCallID:         "call-bg-detached",
+			Status:             database.ChatToolCallExecutionStatusDetached,
+			FromStatuses:       []database.ChatToolCallExecutionStatus{database.ChatToolCallExecutionStatusRunning},
+			UpdatedAt:          dbtime.Now(),
+		})
+		require.NoError(t, err)
+
+		callIDs := []string{"call-reserved", "call-starting", "call-running", "call-bg", "call-bg-pending", "call-fg-detached", "call-bg-detached", "call-bg-agent-gone"}
+		rows, err := db.MarkChatToolCallExecutionsInterrupted(ctx, database.MarkChatToolCallExecutionsInterruptedParams{
+			ChatID:             chat.ID,
+			AssistantMessageID: msg.ID,
+			ToolCallIds:        callIDs,
+			SpareBackground:    true,
+			UpdatedAt:          dbtime.Now(),
+		})
+		require.NoError(t, err)
+		byCall := make(map[string]database.ChatToolCallExecution, len(rows))
+		for _, row := range rows {
+			byCall[row.ToolCallID] = row
+		}
+		require.Equal(t, database.ChatToolCallExecutionStatusCanceled, byCall["call-reserved"].Status)
+		require.Equal(t, database.ChatToolCallExecutionStatusCancelRequested, byCall["call-starting"].Status)
+		require.Equal(t, database.ChatToolCallExecutionStatusCancelRequested, byCall["call-running"].Status)
+		require.Equal(t, database.ChatToolCallExecutionStatusDetached, byCall["call-bg"].Status)
+		require.Equal(t, database.ChatToolCallExecutionStatusCancelRequested, byCall["call-bg-pending"].Status)
+		require.Equal(t, database.ChatToolCallExecutionStatusCancelRequested, byCall["call-fg-detached"].Status)
+		require.Equal(t, database.ChatToolCallExecutionStatusDetached, byCall["call-bg-detached"].Status)
+		require.Equal(t, database.ChatToolCallExecutionStatusCancelRequested, byCall["call-bg-agent-gone"].Status)
+		// The cancel_requested rows keep their process identity for
+		// the reconciler.
+		require.Equal(t, "proc-running", byCall["call-running"].ProcessID.String)
+		require.Equal(t, "proc-fg-detached", byCall["call-fg-detached"].ProcessID.String)
+		require.Equal(t, "proc-bg-agent-gone", byCall["call-bg-agent-gone"].ProcessID.String)
+
+		err = db.MarkChatToolCallExecutionsResultCommitted(ctx, database.MarkChatToolCallExecutionsResultCommittedParams{
+			ChatID:             chat.ID,
+			AssistantMessageID: msg.ID,
+			ToolCallIds:        callIDs,
+			ResultCommittedAt:  dbtime.Now(),
+		})
+		require.NoError(t, err)
+		for _, callID := range callIDs {
+			row, getErr := db.GetChatToolCallExecution(ctx, database.GetChatToolCallExecutionParams{ChatID: chat.ID, AssistantMessageID: msg.ID, ToolCallID: callID})
+			require.NoError(t, getErr)
+			require.True(t, row.ResultCommittedAt.Valid, "result commit stamp for %s", callID)
+		}
+
+		// The cancel outcome CAS resolves only cancel_requested
+		// rows.
+		resolved, err := db.UpdateChatToolCallExecutionCancelOutcome(ctx, database.UpdateChatToolCallExecutionCancelOutcomeParams{
+			ChatID:             chat.ID,
+			AssistantMessageID: msg.ID,
+			ToolCallID:         "call-running",
+			Status:             database.ChatToolCallExecutionStatusCanceled,
+			CancelSignalSentAt: sql.NullTime{Time: dbtime.Now(), Valid: true},
+			UpdatedAt:          dbtime.Now(),
+		})
+		require.NoError(t, err)
+		require.Equal(t, database.ChatToolCallExecutionStatusCanceled, resolved.Status)
+		require.True(t, resolved.CancelSignalSentAt.Valid)
+		_, err = db.UpdateChatToolCallExecutionCancelOutcome(ctx, database.UpdateChatToolCallExecutionCancelOutcomeParams{
+			ChatID:             chat.ID,
+			AssistantMessageID: msg.ID,
+			ToolCallID:         "call-bg",
+			Status:             database.ChatToolCallExecutionStatusCanceled,
+			UpdatedAt:          dbtime.Now(),
+		})
+		require.ErrorIs(t, err, sql.ErrNoRows)
+	})
 }

--- a/coderd/x/chatd/chattool/execute.go
+++ b/coderd/x/chatd/chattool/execute.go
@@ -2,6 +2,8 @@ package chattool
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"regexp"
@@ -12,6 +14,17 @@ import (
 
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 )
+
+// HashToolInput returns the hex SHA-256 of a tool call's raw
+// persisted input. The intent writer and the claiming tool hash the
+// same persisted bytes, so a mismatch proves stale lineage. Callers
+// must pass the persisted bytes verbatim: any re-encoding (JSON
+// re-marshaling, key reordering, whitespace changes) would fail
+// every replayed claim closed with ErrExecutionInputMismatch.
+func HashToolInput(input string) string {
+	sum := sha256.Sum256([]byte(input))
+	return hex.EncodeToString(sum[:])
+}
 
 const (
 	// defaultTimeout is the default timeout for command

--- a/coderd/x/chatd/execution_ledger_internal_test.go
+++ b/coderd/x/chatd/execution_ledger_internal_test.go
@@ -1,0 +1,42 @@
+package chatd
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
+	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+// TestExecutionIntentHashRoundTrip pins the byte-preservation
+// property the input_sha256 lineage guard depends on: the persisted
+// tool-call args must come back from ParseContent byte-identical,
+// or every replayed claim would fail closed with
+// ErrExecutionInputMismatch.
+func TestExecutionIntentHashRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// Non-alphabetical key order must survive the round trip.
+	input := `{"workdir":"/tmp","command":"echo hi"}`
+	content, err := chatprompt.MarshalParts([]codersdk.ChatMessagePart{{
+		Type:       codersdk.ChatMessagePartTypeToolCall,
+		ToolCallID: "call-1",
+		ToolName:   chattool.ExecuteToolName,
+		Args:       json.RawMessage(input),
+	}})
+	require.NoError(t, err)
+
+	parts, err := chatprompt.ParseContent(database.ChatMessage{
+		Role:           database.ChatMessageRoleAssistant,
+		Content:        content,
+		ContentVersion: chatprompt.CurrentContentVersion,
+	})
+	require.NoError(t, err)
+	require.Len(t, parts, 1)
+	require.Equal(t, input, string(parts[0].Args))
+	require.Equal(t, chattool.HashToolInput(input), chattool.HashToolInput(string(parts[0].Args)))
+}

--- a/coderd/x/chatd/generation.go
+++ b/coderd/x/chatd/generation.go
@@ -14,12 +14,14 @@ import (
 
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatdebug"
 	"github.com/coder/coder/v2/coderd/x/chatd/chaterror"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatloop"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatretry"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatstate"
+	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
 	"github.com/coder/coder/v2/coderd/x/chatd/messagepartbuffer"
 	"github.com/coder/coder/v2/codersdk"
 )
@@ -129,8 +131,11 @@ var errCompactionStillOverLimit = chaterror.WithClassification(
 )
 
 type generationDecision struct {
-	kind                    generationActionKind
-	localToolCalls          []fantasy.ToolCallContent
+	kind           generationActionKind
+	localToolCalls []fantasy.ToolCallContent
+	// assistantMessageID is the message that issued
+	// localToolCalls; it anchors execution ledger lineage.
+	assistantMessageID      int64
 	pendingDynamicToolCalls []pendingDynamicToolCall
 	finishReason            generationFinishReason
 	promotedMessageID       int64
@@ -183,7 +188,7 @@ type generationDecisionInput struct {
 }
 
 func decideGenerationAction(input generationDecisionInput) (generationDecision, error) {
-	localCalls, dynamicCalls, err := unresolvedToolCallsFromHistory(input.messages, input.dynamicToolNames)
+	assistantMessageID, localCalls, dynamicCalls, err := unresolvedToolCallsFromHistory(input.messages, input.dynamicToolNames)
 	if err != nil {
 		return generationDecision{}, err
 	}
@@ -198,7 +203,12 @@ func decideGenerationAction(input generationDecisionInput) (generationDecision, 
 			}
 			dynamicCalls = nil
 		}
-		return generationDecision{kind: generationActionExecuteLocalTools, localToolCalls: localCalls, pendingDynamicToolCalls: dynamicCalls}, nil
+		return generationDecision{
+			kind:                    generationActionExecuteLocalTools,
+			localToolCalls:          localCalls,
+			assistantMessageID:      assistantMessageID,
+			pendingDynamicToolCalls: dynamicCalls,
+		}, nil
 	}
 	if len(dynamicCalls) > 0 {
 		return generationDecision{kind: generationActionEnterRequiresAction, pendingDynamicToolCalls: dynamicCalls}, nil
@@ -258,23 +268,26 @@ func generationCompactionContextLimit(compaction *generationCompaction) int64 {
 	return compaction.Options.ContextLimit
 }
 
+// unresolvedToolCallsFromHistory returns the ID of the latest
+// assistant message together with its tool calls that have no
+// result yet, split into locally executed and dynamic calls.
 func unresolvedToolCallsFromHistory(
 	messages []database.ChatMessage,
 	dynamicToolNames map[string]bool,
-) ([]fantasy.ToolCallContent, []pendingDynamicToolCall, error) {
+) (int64, []fantasy.ToolCallContent, []pendingDynamicToolCall, error) {
 	assistantIndex := lastMessageIndex(messages, func(msg database.ChatMessage) bool {
 		return msg.Role == database.ChatMessageRoleAssistant
 	})
 	if assistantIndex == -1 {
-		return nil, nil, nil
+		return 0, nil, nil, nil
 	}
 	assistantParts, err := chatprompt.ParseContent(messages[assistantIndex])
 	if err != nil {
-		return nil, nil, xerrors.Errorf("parse assistant message: %w", err)
+		return 0, nil, nil, xerrors.Errorf("parse assistant message: %w", err)
 	}
 	handled, err := handledToolCallIDs(messages[assistantIndex+1:])
 	if err != nil {
-		return nil, nil, err
+		return 0, nil, nil, err
 	}
 	localCalls := make([]fantasy.ToolCallContent, 0)
 	dynamicCalls := make([]pendingDynamicToolCall, 0)
@@ -297,7 +310,7 @@ func unresolvedToolCallsFromHistory(
 			ProviderExecuted: part.ProviderExecuted,
 		})
 	}
-	return localCalls, dynamicCalls, nil
+	return messages[assistantIndex].ID, localCalls, dynamicCalls, nil
 }
 
 func hasExclusiveToolCall(toolCalls []fantasy.ToolCallContent, exclusiveToolNames map[string]bool) bool {
@@ -630,7 +643,7 @@ func (s *taskStarter) generateAssistant(
 	if err != nil {
 		return s.finishGenerationError(ctx, machine, input, err, requireGenerationAttempt(attempt.number))
 	}
-	return s.commitGenerationStep(ctx, machine, input, attempt.number, generationActionGenerateAssistant, messages)
+	return s.commitGenerationStep(ctx, machine, input, attempt.number, generationActionGenerateAssistant, messages, nil)
 }
 
 func (s *taskStarter) executeLocalTools(
@@ -686,7 +699,24 @@ func (s *taskStarter) executeLocalTools(
 	if err != nil {
 		return s.finishGenerationError(ctx, machine, input, err, requireGenerationAttempt(attempt.number))
 	}
-	return s.commitGenerationStep(ctx, machine, input, attempt.number, generationActionExecuteLocalTools, messages)
+	return s.commitGenerationStep(ctx, machine, input, attempt.number, generationActionExecuteLocalTools, messages, &stepResultCommit{
+		assistantMessageID: decision.assistantMessageID,
+		toolCallIDs:        localToolCallIDs(decision.localToolCalls),
+	})
+}
+
+// localToolCallIDs returns the IDs of locally executed tool calls.
+// The result-committed ledger update matches only execute calls;
+// other IDs match no ledger rows.
+func localToolCallIDs(toolCalls []fantasy.ToolCallContent) []string {
+	ids := make([]string, 0, len(toolCalls))
+	for _, call := range toolCalls {
+		if call.ProviderExecuted {
+			continue
+		}
+		ids = append(ids, call.ToolCallID)
+	}
+	return ids
 }
 
 func (s *taskStarter) generateCompaction(
@@ -758,7 +788,7 @@ func (s *taskStarter) generateCompaction(
 	err = s.commitGenerationStep(ctx, machine, input, attempt.number, generationActionCompact, stepMessagesForCommit{
 		Messages:       messages.Messages,
 		VisibleIndexes: visibleMessageIndexes(messages.Messages),
-	})
+	}, nil)
 	s.server.metrics.RecordCompaction(metricProvider, metricModel, err == nil, err)
 	if err != nil {
 		return xerrors.Errorf("commit generation step: %w", err)
@@ -846,6 +876,14 @@ func (s *taskStarter) beginGenerationAttempt(
 	}, nil
 }
 
+// stepResultCommit identifies tool calls whose results are being
+// committed by a generation step, so their ledger rows can be marked
+// result-committed in the same transaction.
+type stepResultCommit struct {
+	assistantMessageID int64
+	toolCallIDs        []string
+}
+
 func (s *taskStarter) commitGenerationStep(
 	ctx context.Context,
 	machine *chatstate.ChatMachine,
@@ -853,6 +891,7 @@ func (s *taskStarter) commitGenerationStep(
 	attempt int64,
 	kind generationActionKind,
 	messages stepMessagesForCommit,
+	resultCommit *stepResultCommit,
 ) error {
 	if len(messages.Messages) == 0 {
 		return s.finishGenerationTurn(ctx, machine, input, generationDecision{kind: generationActionFinishTurn, finishReason: generationFinishReasonComplete}, requireGenerationAttempt(attempt))
@@ -866,6 +905,21 @@ func (s *taskStarter) commitGenerationStep(
 		commitResult, err := tx.CommitStep(chatstate.CommitStepInput{Messages: messages.Messages})
 		if err != nil {
 			return xerrors.Errorf("tx.CommitStep: %w", err)
+		}
+		now := dbtime.Now()
+		if err := insertExecutionIntents(ctx, store, input.ChatID, commitResult.InsertedMessages, now); err != nil {
+			return xerrors.Errorf("insert execution intents: %w", err)
+		}
+		if resultCommit != nil && len(resultCommit.toolCallIDs) > 0 {
+			err := store.MarkChatToolCallExecutionsResultCommitted(ctx, database.MarkChatToolCallExecutionsResultCommittedParams{
+				ChatID:             input.ChatID,
+				AssistantMessageID: resultCommit.assistantMessageID,
+				ToolCallIds:        resultCommit.toolCallIDs,
+				ResultCommittedAt:  now,
+			})
+			if err != nil {
+				return xerrors.Errorf("mark tool call executions result committed: %w", err)
+			}
 		}
 		insertedMessages = make([]runnerActionMessage, 0, len(commitResult.InsertedMessages))
 		for _, msg := range commitResult.InsertedMessages {
@@ -886,6 +940,47 @@ func (s *taskStarter) commitGenerationStep(
 		Kind:             runnerActionKind(kind),
 		InsertedMessages: insertedMessages,
 	})
+}
+
+// insertExecutionIntents persists an execution ledger intent for
+// every execute tool call in the just-committed assistant messages.
+// Running in the commit transaction makes the intent durable exactly
+// when the assistant message is: a rolled-back step leaves no row,
+// and a replayed commit hits the lineage conflict and changes
+// nothing.
+func insertExecutionIntents(ctx context.Context, store database.Store, chatID uuid.UUID, inserted []database.ChatMessage, now time.Time) error {
+	for _, msg := range inserted {
+		if msg.Role != database.ChatMessageRoleAssistant {
+			continue
+		}
+		parts, err := chatprompt.ParseContent(msg)
+		if err != nil {
+			return xerrors.Errorf("parse assistant message %d: %w", msg.ID, err)
+		}
+		for _, part := range parts {
+			if part.Type != codersdk.ChatMessagePartTypeToolCall || part.ProviderExecuted || part.ToolName != chattool.ExecuteToolName {
+				continue
+			}
+			// Rows are addressed by tool call ID; the execute tool
+			// refuses ID-less calls, so an intent row keyed by the
+			// empty ID would only alias such calls together.
+			if part.ToolCallID == "" {
+				continue
+			}
+			err := store.InsertChatToolCallExecutionIntent(ctx, database.InsertChatToolCallExecutionIntentParams{
+				ID:                 uuid.New(),
+				ChatID:             chatID,
+				AssistantMessageID: msg.ID,
+				ToolCallID:         part.ToolCallID,
+				InputSha256:        chattool.HashToolInput(string(part.Args)),
+				CreatedAt:          now,
+			})
+			if err != nil {
+				return xerrors.Errorf("insert execution intent for tool call %s: %w", part.ToolCallID, err)
+			}
+		}
+	}
+	return nil
 }
 
 func (s *taskStarter) enterRequiresAction(

--- a/coderd/x/chatd/generation_internal_test.go
+++ b/coderd/x/chatd/generation_internal_test.go
@@ -1,15 +1,19 @@
 package chatd //nolint:testpackage // Exercises unexported generation helpers.
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
+	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatdebug"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatloop"
+	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatstate"
 	"github.com/coder/coder/v2/coderd/x/chatd/chattest"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
 )
 
@@ -49,6 +53,43 @@ func TestGenerationCompactionContextLimit(t *testing.T) {
 		Options: chatloop.GenerateCompactionOptions{ContextLimit: 50_000},
 	}
 	require.EqualValues(t, 50_000, generationCompactionContextLimit(compaction))
+}
+
+// TestUnresolvedToolCallsPartialResults asserts that a partially
+// committed tool step (an aborted batch persisted its completed
+// sibling results) leaves only the result-less calls unresolved, so
+// the retry never re-runs a sibling whose side effect already
+// happened.
+func TestUnresolvedToolCallsPartialResults(t *testing.T) {
+	t.Parallel()
+
+	messageFromParts := func(id int64, role database.ChatMessageRole, parts []codersdk.ChatMessagePart) database.ChatMessage {
+		content, err := chatprompt.MarshalParts(parts)
+		require.NoError(t, err)
+		return database.ChatMessage{
+			ID:             id,
+			Role:           role,
+			Content:        content,
+			ContentVersion: chatprompt.CurrentContentVersion,
+		}
+	}
+
+	messages := []database.ChatMessage{
+		messageFromParts(1, database.ChatMessageRoleAssistant, []codersdk.ChatMessagePart{
+			{Type: codersdk.ChatMessagePartTypeToolCall, ToolCallID: "call-exec", ToolName: "execute", Args: json.RawMessage(`{"command":"echo hi"}`)},
+			{Type: codersdk.ChatMessagePartTypeToolCall, ToolCallID: "call-edit", ToolName: "edit_files", Args: json.RawMessage(`{}`)},
+		}),
+		messageFromParts(2, database.ChatMessageRoleTool, []codersdk.ChatMessagePart{
+			{Type: codersdk.ChatMessagePartTypeToolResult, ToolCallID: "call-edit", ToolName: "edit_files", Result: json.RawMessage(`"ok"`)},
+		}),
+	}
+
+	msgID, localCalls, dynamicCalls, err := unresolvedToolCallsFromHistory(messages, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), msgID)
+	require.Empty(t, dynamicCalls)
+	require.Len(t, localCalls, 1)
+	require.Equal(t, "call-exec", localCalls[0].ToolCallID)
 }
 
 func TestRecordGenerationFinishFailure(t *testing.T) {

--- a/coderd/x/chatd/stream_loop.go
+++ b/coderd/x/chatd/stream_loop.go
@@ -212,7 +212,7 @@ func (*streamLoop) actionRequiredFromHistory(chat database.Chat, messages []data
 	if err != nil {
 		return nil, xerrors.Errorf("parse dynamic tools for stream: %w", err)
 	}
-	_, pending, err := unresolvedToolCallsFromHistory(messages, dynamicToolNames)
+	_, _, pending, err := unresolvedToolCallsFromHistory(messages, dynamicToolNames)
 	if err != nil {
 		return nil, xerrors.Errorf("derive pending dynamic tool calls: %w", err)
 	}

--- a/coderd/x/chatd/tasks.go
+++ b/coderd/x/chatd/tasks.go
@@ -684,7 +684,7 @@ func committedPendingLocalToolCancellationMessages(
 	if err != nil {
 		return nil, xerrors.Errorf("load committed messages for interruption: %w", err)
 	}
-	localCalls, _, err := unresolvedToolCallsFromHistory(messages, dynamicToolNamesFromChat(chat))
+	_, localCalls, _, err := unresolvedToolCallsFromHistory(messages, dynamicToolNamesFromChat(chat))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Starts writing the execution ledger from chatd's chat-semantics transactions: every execute tool call gets a `reserved` intent row when its assistant message commits, and gets `result_committed_at` stamped in the same transaction that commits its tool result.

Part 2/9 of the CODAGT-757 execution ledger stack (base: #01, ledger schema).

## Changes

- `commitGenerationStep` inserts one intent row per execute tool call in the just-committed assistant messages, inside the commit transaction: a rolled-back step leaves no row, a replayed commit no-ops on the lineage conflict.
- The tool-result commit marks the executed calls result-committed in the same transaction. Interrupt-synthetic results are stamped by the interrupt transaction in PR 4 (#27320), which owns the interrupt status mapping for ledger rows.
- `executionRecorder` (minimal): per-chat handle binding ledger writes to the assistant message that issued the calls.
- `chattool.HashToolInput`: SHA-256 over the raw persisted tool input, the lineage guard later claim validation depends on.
- `unresolvedToolCallsFromHistory` now also returns the assistant message ID that issued the unresolved calls, anchoring ledger lineage.

Rows are only created and stamped here; claiming, dispatch, and status transitions land in the next PR. Interrupt handling for ledger rows (status mapping, synthetic-result stamping, kill reconciliation) lands in PR 4 (#27320); the periodic retry sweep lands in PR 5 (#27321).

> This PR was authored by Mux, an AI coding agent, on Mike's behalf. The stack recomposes the previously reviewed #27100/#27102/#27103 into reviewable pieces, plus fixes from subsequent review rounds.