### PR TITLE
feat(coderd/x/chatd): map edited-away executions into the cancel sweep

### DIFF
--- a/coderd/x/chatd/chatstate/synthetic_cancellation_ledger_test.go
+++ b/coderd/x/chatd/chatstate/synthetic_cancellation_ledger_test.go
@@ -30,6 +30,410 @@ func seedLedgerWorkspaceAgent(t *testing.T, f *testFixture) database.WorkspaceAg
 	return dbgen.WorkspaceAgent(t, f.DB, database.WorkspaceAgent{ResourceID: res.ID})
 }
 
+// TestEditMessage_MapsExecutionLedgerBeforeHistoryDelete asserts
+// that editing a message whose deleted suffix carries in-flight
+// execute calls still maps the ledger: the deleted turn gets no
+// synthetic history results, so nothing can carry a background
+// handle back to the user and both the foreground and background
+// rows must become cancel_requested for the sweep to kill, with
+// result_committed_at stamped.
+func TestEditMessage_MapsExecutionLedgerBeforeHistoryDelete(t *testing.T) {
+	t.Parallel()
+	f := newTestFixture(t)
+	ctx := testutil.Context(t, testutil.WaitShort)
+	created := createTestChat(t, f)
+	m := chatstate.NewChatMachine(f.DB, f.Pub, created.Chat.ID)
+	agent := seedLedgerWorkspaceAgent(t, f)
+
+	fgCallID := "call_fg_" + uuid.NewString()
+	bgCallID := "call_bg_" + uuid.NewString()
+	raw, err := chatprompt.MarshalParts([]codersdk.ChatMessagePart{
+		{
+			Type:       codersdk.ChatMessagePartTypeToolCall,
+			ToolCallID: fgCallID,
+			ToolName:   "execute",
+			Args:       json.RawMessage(`{}`),
+		},
+		{
+			Type:       codersdk.ChatMessagePartTypeToolCall,
+			ToolCallID: bgCallID,
+			ToolName:   "execute",
+			Args:       json.RawMessage(`{}`),
+		},
+	})
+	require.NoError(t, err)
+	// The edited user message precedes the in-flight assistant
+	// message, so the edit soft-deletes the assistant message too.
+	var step chatstate.CommitStepResult
+	require.NoError(t, m.Update(ctx, func(tx *chatstate.Tx, store database.Store) error {
+		var err error
+		step, err = tx.CommitStep(chatstate.CommitStepInput{Messages: []chatstate.Message{
+			userTextMessage("first user", f.User.ID, f.Model.ID),
+			{
+				Role:           database.ChatMessageRoleAssistant,
+				Content:        raw,
+				Visibility:     database.ChatMessageVisibilityBoth,
+				ContentVersion: chatprompt.CurrentContentVersion,
+				ModelConfigID:  uuid.NullUUID{UUID: f.Model.ID, Valid: true},
+			},
+		}})
+		return err
+	}))
+	require.Len(t, step.InsertedMessages, 2)
+	firstUserID := step.InsertedMessages[0].ID
+	assistantID := step.InsertedMessages[1].ID
+
+	claim := func(toolCallID string, background bool) database.ChatToolCallExecution {
+		row, err := f.DB.ClaimChatToolCallExecution(ctx, database.ClaimChatToolCallExecutionParams{
+			ID:                 uuid.New(),
+			ChatID:             created.Chat.ID,
+			AssistantMessageID: assistantID,
+			ToolCallID:         toolCallID,
+			InputSha256:        "hash-" + toolCallID,
+			Command:            "sleep 600",
+			Background:         background,
+			TimeoutSecs:        600,
+			Now:                dbtime.Now(),
+			StaleBefore:        time.Time{},
+		})
+		require.NoError(t, err)
+		return row
+	}
+	recordProcess := func(row database.ChatToolCallExecution, processID string) {
+		_, err := f.DB.UpdateChatToolCallExecutionProcess(ctx, database.UpdateChatToolCallExecutionProcessParams{
+			ChatID:             created.Chat.ID,
+			AssistantMessageID: assistantID,
+			ToolCallID:         row.ToolCallID,
+			ClaimEpoch:         row.ClaimEpoch,
+			ProcessID:          processID,
+			WorkspaceAgentID:   agent.ID,
+			StartedAt:          dbtime.Now(),
+		})
+		require.NoError(t, err)
+	}
+	recordProcess(claim(fgCallID, false), "proc-fg")
+	recordProcess(claim(bgCallID, true), "proc-bg")
+
+	var edit chatstate.EditMessageResult
+	editedContent := mustMarshalParts(t, []codersdk.ChatMessagePart{
+		codersdk.ChatMessageText("edited"),
+	})
+	require.NoError(t, m.Update(ctx, func(tx *chatstate.Tx, store database.Store) error {
+		var err error
+		edit, err = tx.EditMessage(chatstate.EditMessageInput{
+			MessageID: firstUserID,
+			CreatedBy: f.User.ID,
+			Content:   editedContent,
+			APIKeyID:  f.apiKeyID(),
+		})
+		return err
+	}))
+	require.Empty(t, edit.CancellationMessages,
+		"the deleted turn gets no synthetic history results")
+
+	fgRow, err := f.DB.GetChatToolCallExecution(ctx, database.GetChatToolCallExecutionParams{
+		ChatID:             created.Chat.ID,
+		AssistantMessageID: assistantID,
+		ToolCallID:         fgCallID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, database.ChatToolCallExecutionStatusCancelRequested, fgRow.Status,
+		"the dispatched foreground row is left for the sweep to kill")
+	require.True(t, fgRow.ResultCommittedAt.Valid)
+
+	bgRow, err := f.DB.GetChatToolCallExecution(ctx, database.GetChatToolCallExecutionParams{
+		ChatID:             created.Chat.ID,
+		AssistantMessageID: assistantID,
+		ToolCallID:         bgCallID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, database.ChatToolCallExecutionStatusCancelRequested, bgRow.Status,
+		"no committed result can carry the handle, so the background row is killed, not spared")
+	require.True(t, bgRow.ResultCommittedAt.Valid)
+}
+
+// TestEditMessage_KillsPriorDetachedExecutions asserts that editing
+// a message routes previously detached rows anchored in the deleted
+// suffix to cancel_requested: the interrupt-spared synthetic result
+// was the only carrier of the process handle and the edit deletes
+// it, so the process must be killed, not left alive and
+// unaddressable. A detached row anchored before the edited message
+// keeps its carrier and must survive.
+func TestEditMessage_KillsPriorDetachedExecutions(t *testing.T) {
+	t.Parallel()
+
+	// Builds a chat whose first turn holds a background execute
+	// spared to detached by a new-user-message cancellation, exactly
+	// the CODAGT-757 orphan shape: user1, assistant(bg call),
+	// process recorded, turn finished, user2 sent (maps the row
+	// detached and commits the handle-carrying synthetic result).
+	setup := func(t *testing.T) (f *testFixture, m *chatstate.ChatMachine, chatID uuid.UUID, user1ID, assistantID, user2ID int64, bgCallID string) {
+		f = newTestFixture(t)
+		ctx := testutil.Context(t, testutil.WaitShort)
+		created := createTestChat(t, f)
+		m = chatstate.NewChatMachine(f.DB, f.Pub, created.Chat.ID)
+		agent := seedLedgerWorkspaceAgent(t, f)
+
+		bgCallID = "call_bg_" + uuid.NewString()
+		raw, err := chatprompt.MarshalParts([]codersdk.ChatMessagePart{{
+			Type:       codersdk.ChatMessagePartTypeToolCall,
+			ToolCallID: bgCallID,
+			ToolName:   "execute",
+			Args:       json.RawMessage(`{}`),
+		}})
+		require.NoError(t, err)
+		var step chatstate.CommitStepResult
+		require.NoError(t, m.Update(ctx, func(tx *chatstate.Tx, store database.Store) error {
+			var err error
+			step, err = tx.CommitStep(chatstate.CommitStepInput{Messages: []chatstate.Message{
+				userTextMessage("first user", f.User.ID, f.Model.ID),
+				{
+					Role:           database.ChatMessageRoleAssistant,
+					Content:        raw,
+					Visibility:     database.ChatMessageVisibilityBoth,
+					ContentVersion: chatprompt.CurrentContentVersion,
+					ModelConfigID:  uuid.NullUUID{UUID: f.Model.ID, Valid: true},
+				},
+			}})
+			return err
+		}))
+		require.Len(t, step.InsertedMessages, 2)
+		user1ID = step.InsertedMessages[0].ID
+		assistantID = step.InsertedMessages[1].ID
+
+		row, err := f.DB.ClaimChatToolCallExecution(ctx, database.ClaimChatToolCallExecutionParams{
+			ID:                 uuid.New(),
+			ChatID:             created.Chat.ID,
+			AssistantMessageID: assistantID,
+			ToolCallID:         bgCallID,
+			InputSha256:        "hash-" + bgCallID,
+			Command:            "sleep 600",
+			Background:         true,
+			TimeoutSecs:        600,
+			Now:                dbtime.Now(),
+			StaleBefore:        time.Time{},
+		})
+		require.NoError(t, err)
+		_, err = f.DB.UpdateChatToolCallExecutionProcess(ctx, database.UpdateChatToolCallExecutionProcessParams{
+			ChatID:             created.Chat.ID,
+			AssistantMessageID: assistantID,
+			ToolCallID:         bgCallID,
+			ClaimEpoch:         row.ClaimEpoch,
+			ProcessID:          "proc-bg",
+			WorkspaceAgentID:   agent.ID,
+			StartedAt:          dbtime.Now(),
+		})
+		require.NoError(t, err)
+
+		landInW(t, f, m)
+
+		var send chatstate.SendMessageResult
+		require.NoError(t, m.Update(ctx, func(tx *chatstate.Tx, store database.Store) error {
+			var err error
+			send, err = tx.SendMessage(chatstate.SendMessageInput{
+				Message:      userTextMessage("second user", f.User.ID, f.Model.ID),
+				BusyBehavior: chatstate.BusyBehaviorQueue,
+			})
+			return err
+		}))
+		require.Len(t, send.InsertedMessages, 2, "synthetic spare + new user")
+		for _, msg := range send.InsertedMessages {
+			if msg.Role == database.ChatMessageRoleUser {
+				user2ID = msg.ID
+			}
+		}
+		require.NotZero(t, user2ID)
+
+		bgRow, err := f.DB.GetChatToolCallExecution(ctx, database.GetChatToolCallExecutionParams{
+			ChatID:             created.Chat.ID,
+			AssistantMessageID: assistantID,
+			ToolCallID:         bgCallID,
+		})
+		require.NoError(t, err)
+		require.Equal(t, database.ChatToolCallExecutionStatusDetached, bgRow.Status,
+			"precondition: the background row was spared to detached")
+		return f, m, created.Chat.ID, user1ID, assistantID, user2ID, bgCallID
+	}
+
+	edit := func(t *testing.T, f *testFixture, m *chatstate.ChatMachine, messageID int64) {
+		ctx := testutil.Context(t, testutil.WaitShort)
+		require.NoError(t, m.Update(ctx, func(tx *chatstate.Tx, store database.Store) error {
+			_, err := tx.EditMessage(chatstate.EditMessageInput{
+				MessageID: messageID,
+				CreatedBy: f.User.ID,
+				Content:   mustMarshalParts(t, []codersdk.ChatMessagePart{codersdk.ChatMessageText("edited")}),
+				APIKeyID:  f.apiKeyID(),
+			})
+			return err
+		}))
+	}
+
+	t.Run("DeletedCarrierIsKilled", func(t *testing.T) {
+		t.Parallel()
+		f, m, chatID, user1ID, assistantID, _, bgCallID := setup(t)
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		preEdit, err := f.DB.GetChatToolCallExecution(ctx, database.GetChatToolCallExecutionParams{
+			ChatID:             chatID,
+			AssistantMessageID: assistantID,
+			ToolCallID:         bgCallID,
+		})
+		require.NoError(t, err)
+		require.True(t, preEdit.ResultCommittedAt.Valid)
+
+		// Editing user1 deletes the whole suffix including the
+		// synthetic result that carried the detached row's handle.
+		edit(t, f, m, user1ID)
+
+		bgRow, err := f.DB.GetChatToolCallExecution(ctx, database.GetChatToolCallExecutionParams{
+			ChatID:             chatID,
+			AssistantMessageID: assistantID,
+			ToolCallID:         bgCallID,
+		})
+		require.NoError(t, err)
+		require.Equal(t, database.ChatToolCallExecutionStatusCancelRequested, bgRow.Status,
+			"the deleted suffix carried the handle, so the detached row is killed")
+		require.True(t, bgRow.ResultCommittedAt.Valid)
+		require.True(t, bgRow.ResultCommittedAt.Time.After(preEdit.ResultCommittedAt.Time),
+			"the give-up anchor restarts at the edit so the sweep gets its full kill budget")
+	})
+
+	t.Run("SurvivingCarrierIsSpared", func(t *testing.T) {
+		t.Parallel()
+		f, m, chatID, _, assistantID, user2ID, bgCallID := setup(t)
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		// Editing user2 keeps the first turn, including the
+		// synthetic result carrying the detached row's handle.
+		edit(t, f, m, user2ID)
+
+		bgRow, err := f.DB.GetChatToolCallExecution(ctx, database.GetChatToolCallExecutionParams{
+			ChatID:             chatID,
+			AssistantMessageID: assistantID,
+			ToolCallID:         bgCallID,
+		})
+		require.NoError(t, err)
+		require.Equal(t, database.ChatToolCallExecutionStatusDetached, bgRow.Status,
+			"the handle carrier survives the edit, so the detached row stays spared")
+	})
+}
+
+// TestEditMessage_KillsRunningRowWhoseDetachWriteFailed asserts the
+// edit rescue matches the interrupt map's process-bearing coverage:
+// a background row whose best-effort detach write failed stays
+// running with a recorded handle while its committed result carries
+// background_process_id. The result makes the call not outstanding,
+// so only the history-delete query can catch it; the old
+// detached-only filter missed it and the edit orphaned the process.
+func TestEditMessage_KillsRunningRowWhoseDetachWriteFailed(t *testing.T) {
+	t.Parallel()
+	f := newTestFixture(t)
+	ctx := testutil.Context(t, testutil.WaitShort)
+	created := createTestChat(t, f)
+	m := chatstate.NewChatMachine(f.DB, f.Pub, created.Chat.ID)
+	agent := seedLedgerWorkspaceAgent(t, f)
+
+	bgCallID := "call_bg_" + uuid.NewString()
+	callRaw, err := chatprompt.MarshalParts([]codersdk.ChatMessagePart{{
+		Type:       codersdk.ChatMessagePartTypeToolCall,
+		ToolCallID: bgCallID,
+		ToolName:   "execute",
+		Args:       json.RawMessage(`{}`),
+	}})
+	require.NoError(t, err)
+	resultRaw, err := chatprompt.MarshalParts([]codersdk.ChatMessagePart{{
+		Type:       codersdk.ChatMessagePartTypeToolResult,
+		ToolCallID: bgCallID,
+		ToolName:   "execute",
+		Result:     json.RawMessage(`{"background_process_id":"proc-bg"}`),
+	}})
+	require.NoError(t, err)
+
+	var step chatstate.CommitStepResult
+	require.NoError(t, m.Update(ctx, func(tx *chatstate.Tx, store database.Store) error {
+		var err error
+		step, err = tx.CommitStep(chatstate.CommitStepInput{Messages: []chatstate.Message{
+			userTextMessage("first user", f.User.ID, f.Model.ID),
+			{
+				Role:           database.ChatMessageRoleAssistant,
+				Content:        callRaw,
+				Visibility:     database.ChatMessageVisibilityBoth,
+				ContentVersion: chatprompt.CurrentContentVersion,
+				ModelConfigID:  uuid.NullUUID{UUID: f.Model.ID, Valid: true},
+			},
+		}})
+		return err
+	}))
+	require.Len(t, step.InsertedMessages, 2)
+	user1ID := step.InsertedMessages[0].ID
+	assistantID := step.InsertedMessages[1].ID
+
+	row, err := f.DB.ClaimChatToolCallExecution(ctx, database.ClaimChatToolCallExecutionParams{
+		ID:                 uuid.New(),
+		ChatID:             created.Chat.ID,
+		AssistantMessageID: assistantID,
+		ToolCallID:         bgCallID,
+		InputSha256:        "hash-" + bgCallID,
+		Command:            "sleep 600",
+		Background:         true,
+		TimeoutSecs:        600,
+		Now:                dbtime.Now(),
+		StaleBefore:        time.Time{},
+	})
+	require.NoError(t, err)
+	_, err = f.DB.UpdateChatToolCallExecutionProcess(ctx, database.UpdateChatToolCallExecutionProcessParams{
+		ChatID:             created.Chat.ID,
+		AssistantMessageID: assistantID,
+		ToolCallID:         bgCallID,
+		ClaimEpoch:         row.ClaimEpoch,
+		ProcessID:          "proc-bg",
+		WorkspaceAgentID:   agent.ID,
+		StartedAt:          dbtime.Now(),
+	})
+	require.NoError(t, err)
+	// The detach write failed, so the row stays running while the
+	// result commits.
+	require.NoError(t, m.Update(ctx, func(tx *chatstate.Tx, store database.Store) error {
+		_, err := tx.CommitStep(chatstate.CommitStepInput{Messages: []chatstate.Message{{
+			Role:           database.ChatMessageRoleTool,
+			Content:        resultRaw,
+			Visibility:     database.ChatMessageVisibilityBoth,
+			ContentVersion: chatprompt.CurrentContentVersion,
+			ModelConfigID:  uuid.NullUUID{UUID: f.Model.ID, Valid: true},
+		}}})
+		return err
+	}))
+
+	pre, err := f.DB.GetChatToolCallExecution(ctx, database.GetChatToolCallExecutionParams{
+		ChatID:             created.Chat.ID,
+		AssistantMessageID: assistantID,
+		ToolCallID:         bgCallID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, database.ChatToolCallExecutionStatusRunning, pre.Status,
+		"precondition: the detach write failed, so the row is still running")
+
+	require.NoError(t, m.Update(ctx, func(tx *chatstate.Tx, store database.Store) error {
+		_, err := tx.EditMessage(chatstate.EditMessageInput{
+			MessageID: user1ID,
+			CreatedBy: f.User.ID,
+			Content:   mustMarshalParts(t, []codersdk.ChatMessagePart{codersdk.ChatMessageText("edited")}),
+			APIKeyID:  f.apiKeyID(),
+		})
+		return err
+	}))
+
+	bgRow, err := f.DB.GetChatToolCallExecution(ctx, database.GetChatToolCallExecutionParams{
+		ChatID:             created.Chat.ID,
+		AssistantMessageID: assistantID,
+		ToolCallID:         bgCallID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, database.ChatToolCallExecutionStatusCancelRequested, bgRow.Status,
+		"a running row with a recorded handle loses its carrier to the edit and must be killed")
+	require.True(t, bgRow.ResultCommittedAt.Valid)
+}
+
 // TestSyntheticCancellation_MapsExecutionLedger asserts that a
 // non-interrupt cancellation transition (a new user message during a
 // run) maps the execution ledger exactly like the interrupt commit:

--- a/coderd/x/chatd/chatstate/synthetics.go
+++ b/coderd/x/chatd/chatstate/synthetics.go
@@ -225,6 +225,75 @@ func SparedBackgroundResult(row database.ChatToolCallExecution) (json.RawMessage
 	return payload, true, nil
 }
 
+// mapExecutionsForHistoryDelete maps the execution ledger rows whose
+// processes an edit would otherwise orphan. EditMessage calls it
+// before soft-deleting the history suffix starting at
+// fromMessageID: after the delete the assistant message is invisible
+// to the pending scan, so mapping afterwards would orphan a live
+// process behind an uncommitted row no sweep can claim.
+//
+// Two kinds of rows lose their process carrier to the delete:
+//
+//   - Outstanding calls on the last assistant message. The deleted
+//     turn gets no synthetic history results, so nothing can carry a
+//     background handle back to the user and backgrounds are not
+//     spared: every dispatched row becomes cancel_requested.
+//   - Rows anchored in the deleted suffix that may carry a live
+//     process: running and detached rows (background starts,
+//     timed-out foregrounds, interrupt-spared backgrounds, and rows
+//     whose best-effort detach write failed) plus starting claims
+//     whose dispatch may have published a process that never got
+//     recorded. Their committed results were the only carriers of
+//     their process handles and are deleted with the suffix, so
+//     they are routed to cancel_requested as well, with
+//     result_committed_at re-stamped so the sweep's give-up clock
+//     starts at the edit.
+//
+// Both arms leave a fresh give-up anchor, through complementary
+// mechanisms: arm 1's MarkChatToolCallExecutionsResultCommitted
+// stamps only NULL result_committed_at, which every outstanding row
+// has, while arm 2 re-stamps unconditionally because its rows
+// committed results earlier. Consolidating the arms or dropping arm
+// 1's stamp would reopen the zero-kill-budget orphan for an
+// outstanding row claimed longer ago than the sweep's give-up bound.
+//
+// The sweep kills every cancel_requested row's process.
+func mapExecutionsForHistoryDelete(ctx context.Context, store database.Store, chat database.Chat, fromMessageID int64) error {
+	assistantMessageID, pending, err := pendingAllToolCallIDs(ctx, store, chat)
+	if err != nil {
+		// Arm 1 needs to parse the last assistant message, but a
+		// malformed assistant message must not make the deleting
+		// edit fail forever: the edit is the only way to discard
+		// the bad suffix. Skip arm 1 (its reserved rows are
+		// reaped as abandoned) and keep arm 2, which maps every
+		// dispatched row by status without parsing content.
+		pending = nil
+	}
+	// Arm 1 owns only assistants inside the deleted suffix. A
+	// surviving last assistant keeps its outstanding calls for the
+	// post-delete synthetic cancellation, which commits results and
+	// spares recorded background handles; mapping it here with no
+	// sparing would strip that recovery.
+	if len(pending) > 0 && assistantMessageID >= fromMessageID {
+		toolCallIDs := make([]string, 0, len(pending))
+		for id := range pending {
+			toolCallIDs = append(toolCallIDs, id)
+		}
+		if _, err := mapCanceledExecutions(ctx, store, chat.ID, assistantMessageID, toolCallIDs, false); err != nil {
+			return err
+		}
+	}
+	_, err = store.MarkChatToolCallExecutionsCancelRequestedForHistoryDelete(ctx, database.MarkChatToolCallExecutionsCancelRequestedForHistoryDeleteParams{
+		ChatID:        chat.ID,
+		FromMessageID: fromMessageID,
+		UpdatedAt:     dbtime.Now(),
+	})
+	if err != nil {
+		return xerrors.Errorf("mark executions cancel requested for history delete: %w", err)
+	}
+	return nil
+}
+
 // pendingDynamicToolCallIDs returns the dynamic tool-call IDs on the
 // chat's last assistant message that do not yet have a matching
 // tool-result message in active history. The returned map is keyed by

--- a/coderd/x/chatd/chatstate/synthetics_internal_test.go
+++ b/coderd/x/chatd/chatstate/synthetics_internal_test.go
@@ -1,0 +1,137 @@
+package chatstate
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sqlc-dev/pqtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
+)
+
+// TestMapExecutionsForHistoryDeleteMalformedAssistant asserts that
+// an unparseable last assistant message cannot wedge the deleting
+// edit: the pending-call scan is skipped and the broad status-based
+// mapping still routes dispatched rows to the sweep.
+func TestMapExecutionsForHistoryDeleteMalformedAssistant(t *testing.T) {
+	t.Parallel()
+	db, _ := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user := dbgen.User(t, db, database.User{})
+	org := dbgen.Organization(t, db, database.Organization{})
+	_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{UserID: user.ID, OrganizationID: org.ID})
+	_ = dbgen.ChatProvider(t, db, database.ChatProvider{Provider: "openai", DisplayName: "OpenAI"})
+	mc := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{Model: "test-model", ContextLimit: 8192})
+	chat := dbgen.Chat(t, db, database.Chat{
+		OrganizationID:    org.ID,
+		OwnerID:           user.ID,
+		LastModelConfigID: mc.ID,
+		Title:             "malformed-edit",
+	})
+	msg := dbgen.ChatMessage(t, db, database.ChatMessage{
+		ChatID:  chat.ID,
+		Role:    database.ChatMessageRoleAssistant,
+		Content: pqtype.NullRawMessage{RawMessage: json.RawMessage(`{"not": "parts"}`), Valid: true},
+	})
+
+	claimed, err := db.ClaimChatToolCallExecution(ctx, database.ClaimChatToolCallExecutionParams{
+		ID:                 uuid.New(),
+		ChatID:             chat.ID,
+		AssistantMessageID: msg.ID,
+		ToolCallID:         "edit-call",
+		InputSha256:        "hash",
+		Command:            "sleep 600",
+		TimeoutSecs:        600,
+		Now:                dbtime.Now(),
+		StaleBefore:        time.Time{},
+	})
+	require.NoError(t, err)
+	require.Equal(t, database.ChatToolCallExecutionStatusStarting, claimed.Status)
+
+	require.NoError(t, mapExecutionsForHistoryDelete(ctx, db, chat, msg.ID))
+
+	row, err := db.GetChatToolCallExecution(ctx, database.GetChatToolCallExecutionParams{
+		ChatID:             chat.ID,
+		AssistantMessageID: msg.ID,
+		ToolCallID:         "edit-call",
+	})
+	require.NoError(t, err)
+	require.Equal(t, database.ChatToolCallExecutionStatusCancelRequested, row.Status)
+}
+
+// TestMapExecutionsForHistoryDeleteSurvivingAssistant asserts that
+// arm 1 skips a last assistant message that survives the deletion:
+// its outstanding calls belong to the post-delete synthetic
+// cancellation, which can still spare recorded background handles.
+func TestMapExecutionsForHistoryDeleteSurvivingAssistant(t *testing.T) {
+	t.Parallel()
+	db, _ := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user := dbgen.User(t, db, database.User{})
+	org := dbgen.Organization(t, db, database.Organization{})
+	_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{UserID: user.ID, OrganizationID: org.ID})
+	_ = dbgen.ChatProvider(t, db, database.ChatProvider{Provider: "openai", DisplayName: "OpenAI"})
+	mc := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{Model: "test-model", ContextLimit: 8192})
+	chat := dbgen.Chat(t, db, database.Chat{
+		OrganizationID:    org.ID,
+		OwnerID:           user.ID,
+		LastModelConfigID: mc.ID,
+		Title:             "surviving-assistant-edit",
+	})
+	assistantParts := []codersdk.ChatMessagePart{{
+		Type:       codersdk.ChatMessagePartTypeToolCall,
+		ToolCallID: "surviving-call",
+		ToolName:   "execute",
+		Args:       json.RawMessage(`{"command":"sleep 600","run_in_background":true}`),
+	}}
+	assistantContent, err := chatprompt.MarshalParts(assistantParts)
+	require.NoError(t, err)
+	assistant := dbgen.ChatMessage(t, db, database.ChatMessage{
+		ChatID:         chat.ID,
+		Role:           database.ChatMessageRoleAssistant,
+		Content:        assistantContent,
+		ContentVersion: chatprompt.CurrentContentVersion,
+	})
+	// The edit targets a later user message; the assistant above
+	// survives the deletion.
+	edited := dbgen.ChatMessage(t, db, database.ChatMessage{
+		ChatID: chat.ID,
+		Role:   database.ChatMessageRoleUser,
+	})
+
+	claimed, err := db.ClaimChatToolCallExecution(ctx, database.ClaimChatToolCallExecutionParams{
+		ID:                 uuid.New(),
+		ChatID:             chat.ID,
+		AssistantMessageID: assistant.ID,
+		ToolCallID:         "surviving-call",
+		InputSha256:        "hash",
+		Command:            "sleep 600",
+		Background:         true,
+		TimeoutSecs:        0,
+		Now:                dbtime.Now(),
+		StaleBefore:        time.Time{},
+	})
+	require.NoError(t, err)
+	require.Equal(t, database.ChatToolCallExecutionStatusStarting, claimed.Status)
+
+	require.NoError(t, mapExecutionsForHistoryDelete(ctx, db, chat, edited.ID))
+
+	// The surviving assistant's row is untouched: the post-delete
+	// synthetic cancellation owns its resolution.
+	row, err := db.GetChatToolCallExecution(ctx, database.GetChatToolCallExecutionParams{
+		ChatID:             chat.ID,
+		AssistantMessageID: assistant.ID,
+		ToolCallID:         "surviving-call",
+	})
+	require.NoError(t, err)
+	require.Equal(t, database.ChatToolCallExecutionStatusStarting, row.Status)
+}

--- a/coderd/x/chatd/chatstate/transitions.go
+++ b/coderd/x/chatd/chatstate/transitions.go
@@ -544,6 +544,12 @@ func (tx *Tx) EditMessage(input EditMessageInput) (EditMessageResult, error) {
 		}
 	}
 
+	// Must run before the soft-deletes below; see
+	// mapExecutionsForHistoryDelete.
+	if err := mapExecutionsForHistoryDelete(tx.ctx, tx.store, chat, target.ID); err != nil {
+		return EditMessageResult{}, err
+	}
+
 	if err := tx.store.SoftDeleteChatMessageByID(tx.ctx, target.ID); err != nil {
 		return EditMessageResult{}, xerrors.Errorf("soft-delete target: %w", err)
 	}


### PR DESCRIPTION
Maps execution ledger rows into the cancel sweep when a history edit deletes the messages that carried their results.

Part 5/9 of the CODAGT-757 execution ledger stack (base: #04, interrupt mapping and sweep).

## Changes

- `mapExecutionsForHistoryDelete` marks unresolved executions whose tool results live in an edited-away suffix as `cancel_requested` (`MarkChatToolCallExecutionsCancelRequestedForHistoryDelete`), restarting their give-up clock, so the sweep from #04 kills their processes instead of leaving them orphaned with no addressable handle.
- `Tx.EditMessage` runs the mapping before soft-deleting the suffix, in the same transaction.
- Detached background rows are mapped too: their spared handle lived in the deleted result, so nothing can re-attach to them after the edit.

> This PR was authored by Mux, an AI coding agent, on Mike's behalf. The stack recomposes the previously reviewed #27100/#27102/#27103 into reviewable pieces, plus fixes from subsequent review rounds.
