### PR TITLE
feat: add idempotent start tokens to the workspace agent process API

### DIFF
--- a/agent/agentproc/api.go
+++ b/agent/agentproc/api.go
@@ -57,9 +57,38 @@ func (api *API) Routes() http.Handler {
 	r := chi.NewRouter()
 	r.Post("/start", api.handleStartProcess)
 	r.Get("/list", api.handleListProcesses)
+	r.Get("/tokens", api.handleProcessByToken)
 	r.Get("/{id}/output", api.handleProcessOutput)
 	r.Post("/{id}/signal", api.handleSignalProcess)
 	return r
+}
+
+// handleProcessByToken reports whether an idempotency token has a
+// process attached. It always answers 200 for a known route, so an
+// HTTP 404 unambiguously identifies an agent that predates the
+// endpoint. The token travels as a query parameter because it is
+// an opaque string that can contain any byte: query decoding is a
+// single well-defined unescape, while a path segment's decoding
+// depends on how the router matched it.
+func (api *API) handleProcessByToken(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	token := r.URL.Query().Get("token")
+	var chatID string
+	if chatContext, chatOK := agentchat.FromContext(ctx); chatOK {
+		chatID = chatContext.ID.String()
+	}
+	proc, pending, ok := api.manager.byToken(token, chatID)
+
+	resp := workspacesdk.ProcessByTokenResponse{
+		Found:           ok,
+		Pending:         pending,
+		TokenIndexAgeMS: api.manager.tokenIndexAge().Milliseconds(),
+	}
+	if ok {
+		resp.ProcessID = proc.id
+	}
+	httpapi.Write(ctx, rw, http.StatusOK, resp)
 }
 
 // handleStartProcess starts a new process.
@@ -87,8 +116,26 @@ func (api *API) handleStartProcess(rw http.ResponseWriter, r *http.Request) {
 		chatID = chatContext.ID.String()
 	}
 
-	proc, err := api.manager.start(req, chatID)
+	proc, attached, err := api.manager.start(ctx, req, chatID)
 	if err != nil {
+		if errors.Is(err, errClientTokenMismatch) {
+			httpapi.Write(ctx, rw, http.StatusConflict, codersdk.Response{
+				Message: "Client token was already used to start a process with different parameters.",
+				Detail:  err.Error(),
+			})
+			return
+		}
+		if errors.Is(err, errTokenWaitAborted) {
+			// The reservation owner may still publish a process
+			// under this token, so the outcome is unresolved. 409
+			// tells callers to keep the dispatch recoverable
+			// instead of treating it as failed-before-spawn.
+			httpapi.Write(ctx, rw, http.StatusConflict, codersdk.Response{
+				Message: "Timed out waiting for the concurrent start that owns this client token.",
+				Detail:  err.Error(),
+			})
+			return
+		}
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Failed to start process.",
 			Detail:  err.Error(),
@@ -99,7 +146,9 @@ func (api *API) handleStartProcess(rw http.ResponseWriter, r *http.Request) {
 	// Notify git watchers after the process finishes so that
 	// file changes made by the command are visible in the scan.
 	// If a workdir is provided, track it as a path as well.
-	if api.pathStore != nil {
+	// Attaching returns a process whose watcher was already
+	// registered by the request that started it.
+	if api.pathStore != nil && !attached {
 		if chatContext, ok := agentchat.FromContext(ctx); ok {
 			allIDs := append([]uuid.UUID{chatContext.ID}, chatContext.AncestorIDs...)
 			go func() {
@@ -114,8 +163,10 @@ func (api *API) handleStartProcess(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	httpapi.Write(ctx, rw, http.StatusOK, workspacesdk.StartProcessResponse{
-		ID:      proc.id,
-		Started: true,
+		ID:          proc.id,
+		Started:     !attached,
+		ClientToken: req.ClientToken,
+		Attached:    attached,
 	})
 }
 

--- a/agent/agentproc/api_test.go
+++ b/agent/agentproc/api_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -530,6 +531,290 @@ func TestStartProcess(t *testing.T) {
 		// value. Since req.Env is appended after the hook,
 		// the request value wins.
 		require.Contains(t, strings.TrimSpace(resp.Output), reqVal)
+	})
+}
+
+func TestStartProcessClientToken(t *testing.T) {
+	t.Parallel()
+
+	t.Run("SameTokenAttaches", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newTestAPI(t)
+		req := workspacesdk.StartProcessRequest{
+			Command:     "echo hello",
+			ClientToken: "tok-1",
+		}
+
+		w := postStart(t, handler, req)
+		require.Equal(t, http.StatusOK, w.Code)
+		var first workspacesdk.StartProcessResponse
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&first))
+		require.True(t, first.Started)
+		require.False(t, first.Attached)
+		require.Equal(t, "tok-1", first.ClientToken)
+
+		w2 := postStart(t, handler, req)
+		require.Equal(t, http.StatusOK, w2.Code)
+		var second workspacesdk.StartProcessResponse
+		require.NoError(t, json.NewDecoder(w2.Body).Decode(&second))
+		require.Equal(t, first.ID, second.ID)
+		require.False(t, second.Started)
+		require.True(t, second.Attached)
+		require.Equal(t, "tok-1", second.ClientToken)
+	})
+
+	t.Run("SameTokenDifferentCommandConflicts", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newTestAPI(t)
+		w := postStart(t, handler, workspacesdk.StartProcessRequest{
+			Command:     "echo hello",
+			ClientToken: "tok-1",
+		})
+		require.Equal(t, http.StatusOK, w.Code)
+
+		w2 := postStart(t, handler, workspacesdk.StartProcessRequest{
+			Command:     "echo goodbye",
+			ClientToken: "tok-1",
+		})
+		require.Equal(t, http.StatusConflict, w2.Code)
+	})
+
+	t.Run("SameTokenWaiterTimeoutConflicts", func(t *testing.T) {
+		t.Parallel()
+
+		release := make(chan struct{})
+		releaseOnce := sync.OnceFunc(func() { close(release) })
+		t.Cleanup(releaseOnce)
+		ownerBlocked := make(chan struct{})
+		ownerBlockedOnce := sync.OnceFunc(func() { close(ownerBlocked) })
+		// Block the owning start after it reserves the token;
+		// updateEnv runs only for spawning starts, so it also
+		// signals that the reservation is held.
+		handler := newTestAPIWithUpdateEnv(t, func(current []string) ([]string, error) {
+			ownerBlockedOnce()
+			<-release
+			return current, nil
+		})
+		req := workspacesdk.StartProcessRequest{
+			Command:     "echo hello",
+			ClientToken: "tok-wait",
+		}
+
+		ownerDone := make(chan *httptest.ResponseRecorder, 1)
+		go func() {
+			body, err := json.Marshal(req)
+			assert.NoError(t, err)
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodPost, "/start", bytes.NewReader(body))
+			handler.ServeHTTP(w, r)
+			ownerDone <- w
+		}()
+		select {
+		case <-ownerBlocked:
+		case <-time.After(testutil.WaitShort):
+			t.Fatal("owner start never reserved the token")
+		}
+
+		// The waiter's request context expires while the owner is
+		// blocked. The result must be 409, not 500: the owner may
+		// still publish a process under this token, so callers
+		// must keep the dispatch recoverable.
+		body, err := json.Marshal(req)
+		require.NoError(t, err)
+		waitCtx, cancelWait := context.WithCancel(context.Background())
+		cancelWait()
+		w := httptest.NewRecorder()
+		r := httptest.NewRequestWithContext(waitCtx, http.MethodPost, "/start", bytes.NewReader(body))
+		handler.ServeHTTP(w, r)
+		require.Equal(t, http.StatusConflict, w.Code)
+
+		releaseOnce()
+		select {
+		case w := <-ownerDone:
+			require.Equal(t, http.StatusOK, w.Code)
+		case <-time.After(testutil.WaitLong):
+			t.Fatal("owner request did not return")
+		}
+	})
+
+	t.Run("SameTokenDifferentBackgroundConflicts", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newTestAPI(t)
+		w := postStart(t, handler, workspacesdk.StartProcessRequest{
+			Command:     "echo hello",
+			ClientToken: "tok-1",
+		})
+		require.Equal(t, http.StatusOK, w.Code)
+
+		w2 := postStart(t, handler, workspacesdk.StartProcessRequest{
+			Command:     "echo hello",
+			Background:  true,
+			ClientToken: "tok-1",
+		})
+		require.Equal(t, http.StatusConflict, w2.Code)
+	})
+
+	t.Run("SameTokenDifferentEnvConflicts", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newTestAPI(t)
+		w := postStart(t, handler, workspacesdk.StartProcessRequest{
+			Command:     "echo hello",
+			Env:         map[string]string{"FOO": "bar"},
+			ClientToken: "tok-1",
+		})
+		require.Equal(t, http.StatusOK, w.Code)
+
+		w2 := postStart(t, handler, workspacesdk.StartProcessRequest{
+			Command:     "echo hello",
+			Env:         map[string]string{"FOO": "baz"},
+			ClientToken: "tok-1",
+		})
+		require.Equal(t, http.StatusConflict, w2.Code)
+	})
+
+	t.Run("SameTokenDifferentChatsConflicts", func(t *testing.T) {
+		t.Parallel()
+
+		// The token index is keyed by the bare token, so reuse
+		// from a different chat is a parameter mismatch rather
+		// than an isolated re-start.
+		handler := newTestAPI(t)
+		req := workspacesdk.StartProcessRequest{
+			Command:     "echo hello",
+			ClientToken: "tok-1",
+		}
+		headerA := http.Header{}
+		headerA.Set(workspacesdk.CoderChatIDHeader, uuid.New().String())
+		headerB := http.Header{}
+		headerB.Set(workspacesdk.CoderChatIDHeader, uuid.New().String())
+
+		_ = startAndGetID(t, handler, req, headerA)
+
+		w := postStart(t, handler, req, headerB)
+		require.Equal(t, http.StatusConflict, w.Code)
+	})
+
+	t.Run("NoTokenAlwaysStartsNew", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newTestAPI(t)
+		req := workspacesdk.StartProcessRequest{
+			Command: "echo hello",
+		}
+
+		w := postStart(t, handler, req)
+		require.Equal(t, http.StatusOK, w.Code)
+		var first workspacesdk.StartProcessResponse
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&first))
+		require.True(t, first.Started)
+		require.False(t, first.Attached)
+		require.Empty(t, first.ClientToken)
+
+		w2 := postStart(t, handler, req)
+		require.Equal(t, http.StatusOK, w2.Code)
+		var second workspacesdk.StartProcessResponse
+		require.NoError(t, json.NewDecoder(w2.Body).Decode(&second))
+		require.True(t, second.Started)
+		require.NotEqual(t, first.ID, second.ID)
+	})
+}
+
+func TestProcessByToken(t *testing.T) {
+	t.Parallel()
+
+	probe := func(t *testing.T, handler http.Handler, token string, headers ...http.Header) workspacesdk.ProcessByTokenResponse {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+		w := httptest.NewRecorder()
+		r := httptest.NewRequestWithContext(ctx, http.MethodGet, "/tokens?token="+url.QueryEscape(token), nil)
+		for _, h := range headers {
+			for k, vals := range h {
+				for _, v := range vals {
+					r.Header.Add(k, v)
+				}
+			}
+		}
+		handler.ServeHTTP(w, r)
+		require.Equal(t, http.StatusOK, w.Code)
+		var resp workspacesdk.ProcessByTokenResponse
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+		return resp
+	}
+
+	t.Run("Found", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newTestAPI(t)
+		id := startAndGetID(t, handler, workspacesdk.StartProcessRequest{
+			Command:     "echo hello",
+			ClientToken: "tok-1",
+		})
+
+		resp := probe(t, handler, "tok-1")
+		require.True(t, resp.Found)
+		require.Equal(t, id, resp.ProcessID)
+	})
+
+	t.Run("NotFound", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newTestAPI(t)
+		resp := probe(t, handler, "tok-missing")
+		require.False(t, resp.Found)
+		require.Empty(t, resp.ProcessID)
+		// The index age lets coderd reject absent-token answers
+		// from freshly restarted agents.
+		require.GreaterOrEqual(t, resp.TokenIndexAgeMS, int64(0))
+	})
+
+	t.Run("EscapedToken", func(t *testing.T) {
+		t.Parallel()
+
+		// Tokens are opaque strings, so reserved bytes and literal
+		// percent escapes must round-trip through the probe URL
+		// without double-decoding.
+		for _, token := range []string{
+			"tok/with reserved?bytes",
+			"abc%2Fdef",
+		} {
+			handler := newTestAPI(t)
+			id := startAndGetID(t, handler, workspacesdk.StartProcessRequest{
+				Command:     "echo hello",
+				ClientToken: token,
+			})
+
+			resp := probe(t, handler, token)
+			require.True(t, resp.Found)
+			require.Equal(t, id, resp.ProcessID)
+		}
+	})
+
+	t.Run("ChatIsolation", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newTestAPI(t)
+		headerA := http.Header{}
+		headerA.Set(workspacesdk.CoderChatIDHeader, uuid.New().String())
+		headerB := http.Header{}
+		headerB.Set(workspacesdk.CoderChatIDHeader, uuid.New().String())
+
+		id := startAndGetID(t, handler, workspacesdk.StartProcessRequest{
+			Command:     "echo hello",
+			ClientToken: "tok-1",
+		}, headerA)
+
+		own := probe(t, handler, "tok-1", headerA)
+		require.True(t, own.Found)
+		require.Equal(t, id, own.ProcessID)
+
+		other := probe(t, handler, "tok-1", headerB)
+		require.False(t, other.Found)
+		require.Empty(t, other.ProcessID)
 	})
 }
 

--- a/agent/agentproc/process.go
+++ b/agent/agentproc/process.go
@@ -2,7 +2,9 @@ package agentproc
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
 	"sync"
@@ -21,31 +23,73 @@ import (
 )
 
 var (
-	errProcessNotFound   = xerrors.New("process not found")
-	errProcessNotRunning = xerrors.New("process is not running")
+	errProcessNotFound     = xerrors.New("process not found")
+	errProcessNotRunning   = xerrors.New("process is not running")
+	errClientTokenMismatch = xerrors.New("client token was already used to start a process with different parameters")
 
-	// exitedProcessReapAge is how long an exited process is
-	// kept before being automatically removed from the map.
+	// errTokenWaitAborted wraps failures to wait out a concurrent
+	// start owning the same client token. The reservation owner
+	// may still publish a process, so callers must treat the
+	// dispatch as unresolved rather than failed.
+	errTokenWaitAborted = xerrors.New("aborted waiting for the concurrent start owning this client token")
+
+	// exitedProcessReapAge is how long an exited process without
+	// an idempotency token is kept before being automatically
+	// removed from the map.
 	exitedProcessReapAge = 5 * time.Minute
+
+	// tokenedProcessReapAge is the retention for exited processes
+	// started under an idempotency token. It bounds how long the
+	// token keeps deduplicating starts (and serving the exited
+	// result) after the process exits; it should comfortably
+	// cover the callers' retry window.
+	tokenedProcessReapAge = 60 * time.Minute
 )
+
+// tokenEntry tracks the process that owns an idempotency token.
+// A reservation is inserted under the manager lock before the
+// owning start drops it, so a concurrent start with the same
+// token waits on done instead of spawning a duplicate. done is
+// closed when the owning start completes; procID is set on
+// success and err on failure.
+type tokenEntry struct {
+	procID string
+	// chatID scopes a still-pending reservation to the chat that
+	// created it, mirroring process-level isolation: other chats
+	// must not learn that a token has an in-flight start.
+	chatID string
+	err    error
+	done   chan struct{}
+}
 
 // process represents a running or completed process.
 type process struct {
-	mu         sync.Mutex
-	id         string
-	command    string
-	workDir    string
+	mu      sync.Mutex
+	id      string
+	command string
+	workDir string
+	// reqWorkDir is the workdir as requested, before default
+	// resolution. Token mismatch checks compare it instead of the
+	// resolved workDir: the default directory can resolve
+	// differently across retries (e.g. before and after the agent
+	// manifest loads), and an identical retry must attach, not 409.
+	reqWorkDir string
 	background bool
+	env        map[string]string
 	chatID     string
-	cmd        *exec.Cmd
-	cancel     context.CancelFunc
-	buf        *HeadTailBuffer
-	logger     slog.Logger
-	running    bool
-	exitCode   *int
-	startedAt  int64
-	exitedAt   *int64
-	done       chan struct{} // closed when process exits
+	// tokenKey is the manager token-index key this process was
+	// started under, or empty when no idempotency token was
+	// supplied. It lets reaping free the index entry.
+	tokenKey  string
+	cmd       *exec.Cmd
+	cancel    context.CancelFunc
+	buf       *HeadTailBuffer
+	logger    slog.Logger
+	running   bool
+	exitCode  *int
+	startedAt int64
+	exitedAt  *int64
+	done      chan struct{} // closed when process exits
 }
 
 // info returns a snapshot of the process state.
@@ -73,13 +117,28 @@ func (p *process) output() (string, *workspacesdk.ProcessTruncation) {
 
 // manager tracks processes spawned by the agent.
 type manager struct {
-	mu         sync.Mutex
-	logger     slog.Logger
-	execer     agentexec.Execer
-	fs         afero.Fs
-	clock      quartz.Clock
-	procs      map[string]*process
-	closed     bool
+	mu     sync.Mutex
+	logger slog.Logger
+	execer agentexec.Execer
+	fs     afero.Fs
+	clock  quartz.Clock
+	procs  map[string]*process
+	// tokens maps an idempotency token to the entry of the
+	// process it started (or is starting), so retried start
+	// requests attach to the existing process instead of
+	// spawning a duplicate. Entries are freed when the process
+	// is reaped.
+	tokens map[string]*tokenEntry
+	// tokenIndexBirth is when this in-memory token index was
+	// created. The index does not survive agent restarts, so a
+	// caller can only trust a "token not found" answer if the
+	// index already existed when the token was first dispatched.
+	tokenIndexBirth time.Time
+	closed          bool
+	// closeCh is closed by Close so starts blocked waiting on a
+	// concurrent same-token reservation unblock at shutdown
+	// instead of waiting for their request contexts to expire.
+	closeCh    chan struct{}
 	updateEnv  func(current []string) (updated []string, err error)
 	workingDir func() string
 	envInfo    usershell.EnvInfoer
@@ -93,29 +152,120 @@ func newManager(logger slog.Logger, execer agentexec.Execer, fs afero.Fs, envInf
 	if envInfo == nil {
 		envInfo = &usershell.SystemEnvInfo{}
 	}
+	clock := quartz.NewReal()
 	return &manager{
-		logger:     logger,
-		execer:     execer,
-		fs:         fs,
-		clock:      quartz.NewReal(),
-		procs:      make(map[string]*process),
-		updateEnv:  updateEnv,
-		workingDir: workingDir,
-		envInfo:    envInfo,
+		logger:          logger,
+		execer:          execer,
+		fs:              fs,
+		clock:           clock,
+		procs:           make(map[string]*process),
+		tokens:          make(map[string]*tokenEntry),
+		tokenIndexBirth: clock.Now(),
+		closeCh:         make(chan struct{}),
+		updateEnv:       updateEnv,
+		workingDir:      workingDir,
+		envInfo:         envInfo,
 	}
+}
+
+// tokenIndexAge is how long the in-memory token index has existed.
+func (m *manager) tokenIndexAge() time.Duration {
+	return m.clock.Now().Sub(m.tokenIndexBirth)
 }
 
 // start spawns a new process. Both foreground and background
 // processes use a long-lived context so the process survives
 // the HTTP request lifecycle. The background flag only affects
 // client-side polling behavior.
-func (m *manager) start(req workspacesdk.StartProcessRequest, chatID string) (*process, error) {
-	m.mu.Lock()
-	if m.closed {
+//
+// When the request carries a client token that already started a
+// process, the existing process is returned with attached true
+// instead of spawning a duplicate. A repeated token with
+// different parameters (including a different chat) fails with
+// errClientTokenMismatch.
+//
+// ctx bounds only the wait for a concurrent start that owns the
+// same token; the spawned process itself is never tied to it.
+func (m *manager) start(ctx context.Context, req workspacesdk.StartProcessRequest, chatID string) (*process, bool, error) {
+	workDir := m.resolveWorkingDirectory(req.WorkDir)
+
+	// The index is keyed by the bare client token; chat identity
+	// participates in the parameter mismatch check, so cross-chat
+	// reuse of a token conflicts instead of attaching.
+	tokenKey := req.ClientToken
+
+	var reserved *tokenEntry
+	for {
+		m.mu.Lock()
+		if m.closed {
+			_, tokenOwned := m.tokens[tokenKey]
+			m.mu.Unlock()
+			if tokenKey != "" && tokenOwned {
+				// Another start owns this token, and its outcome
+				// is unknown to this request: it may have
+				// published a process before the shutdown.
+				return nil, false, xerrors.Errorf("manager is closed: %w", errTokenWaitAborted)
+			}
+			return nil, false, xerrors.New("manager is closed")
+		}
+		// Sweep exited processes on start as well as on list so
+		// the token index cannot grow unbounded between list
+		// calls.
+		m.reapExitedLocked(m.clock.Now())
+		if tokenKey == "" {
+			m.mu.Unlock()
+			break
+		}
+		entry, ok := m.tokens[tokenKey]
+		if !ok {
+			// Reserve the token before dropping the lock so a
+			// concurrent start with the same token waits for
+			// this attempt instead of spawning a duplicate.
+			reserved = &tokenEntry{done: make(chan struct{}), chatID: chatID}
+			m.tokens[tokenKey] = reserved
+			m.mu.Unlock()
+			break
+		}
+		if entry.chatID != chatID {
+			// Another chat owns this token. Waiting on its start
+			// would stall this caller behind a foreign dispatch
+			// only to fail the same check afterwards.
+			m.mu.Unlock()
+			return nil, false, errClientTokenMismatch
+		}
 		m.mu.Unlock()
-		return nil, xerrors.New("manager is closed")
+
+		// Another start owns this token. Wait for it to finish
+		// and attach to its process.
+		select {
+		case <-entry.done:
+		case <-m.closeCh:
+			return nil, false, xerrors.Errorf("manager is closed: %w", errTokenWaitAborted)
+		case <-ctx.Done():
+			// Join keeps the context error visible to callers
+			// alongside the sentinel; xerrors wraps only one
+			// trailing %w.
+			return nil, false, xerrors.Errorf("wait for concurrent start with the same token: %w", errors.Join(errTokenWaitAborted, ctx.Err()))
+		}
+		m.mu.Lock()
+		if entry.err != nil {
+			// The owning start failed and released the token.
+			// Retry the reservation.
+			m.mu.Unlock()
+			continue
+		}
+		existing, ok := m.procs[entry.procID]
+		m.mu.Unlock()
+		if !ok {
+			// The process was reaped after the owning start
+			// finished. Retry the reservation.
+			continue
+		}
+		if existing.command != req.Command || existing.reqWorkDir != req.WorkDir || existing.background != req.Background || !maps.Equal(existing.env, req.Env) || existing.chatID != chatID {
+			return nil, false, errClientTokenMismatch
+		}
+		return existing, true, nil
 	}
-	m.mu.Unlock()
 
 	id := uuid.New().String()
 	logger := m.logger
@@ -128,7 +278,7 @@ func (m *manager) start(req workspacesdk.StartProcessRequest, chatID string) (*p
 	// the process is not tied to any HTTP request.
 	ctx, cancel := context.WithCancel(context.Background())
 	cmd := m.execer.CommandContext(ctx, "sh", "-c", req.Command)
-	cmd.Dir = m.resolveWorkingDirectory(req.WorkDir)
+	cmd.Dir = workDir
 	cmd.Stdin = nil
 	cmd.SysProcAttr = procSysProcAttr()
 
@@ -171,9 +321,26 @@ func (m *manager) start(req workspacesdk.StartProcessRequest, chatID string) (*p
 		cmd.Env = append(cmd.Env, fmt.Sprintf("CODER_CHAT_ID=%s", chatID))
 	}
 
-	if err := cmd.Start(); err != nil {
+	// Spawn and publish in one critical section with the closed
+	// check: once Close sets closed, no process can spawn, and
+	// every spawned process is visible to Close's kill pass.
+	// Close therefore never returns around a live process, and a
+	// start that loses the race spawns nothing, so its error (and
+	// a released token) truthfully report that no command ran.
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
 		cancel()
-		return nil, xerrors.Errorf("start process: %w", err)
+		err := xerrors.New("manager is closed")
+		m.releaseToken(tokenKey, reserved, err)
+		return nil, false, err
+	}
+	if err := cmd.Start(); err != nil {
+		m.mu.Unlock()
+		cancel()
+		err = xerrors.Errorf("start process: %w", err)
+		m.releaseToken(tokenKey, reserved, err)
+		return nil, false, err
 	}
 
 	now := m.clock.Now().Unix()
@@ -181,8 +348,11 @@ func (m *manager) start(req workspacesdk.StartProcessRequest, chatID string) (*p
 		id:         id,
 		command:    req.Command,
 		workDir:    cmd.Dir,
+		reqWorkDir: req.WorkDir,
 		background: req.Background,
+		env:        req.Env,
 		chatID:     chatID,
+		tokenKey:   tokenKey,
 		cmd:        cmd,
 		cancel:     cancel,
 		buf:        buf,
@@ -192,16 +362,11 @@ func (m *manager) start(req workspacesdk.StartProcessRequest, chatID string) (*p
 		done:       make(chan struct{}),
 	}
 
-	m.mu.Lock()
-	if m.closed {
-		m.mu.Unlock()
-		// Manager closed between our check and now. Kill the
-		// process we just started.
-		cancel()
-		_ = cmd.Wait()
-		return nil, xerrors.New("manager is closed")
-	}
 	m.procs[id] = proc
+	if reserved != nil {
+		reserved.procID = id
+		close(reserved.done)
+	}
 	m.mu.Unlock()
 
 	go func() {
@@ -237,7 +402,21 @@ func (m *manager) start(req workspacesdk.StartProcessRequest, chatID string) (*p
 		close(proc.done)
 	}()
 
-	return proc, nil
+	return proc, false, nil
+}
+
+// releaseToken frees a token reservation after a failed start so
+// waiters retry the reservation instead of attaching to nothing.
+// It is a no-op when no token was reserved.
+func (m *manager) releaseToken(tokenKey string, reserved *tokenEntry, err error) {
+	if reserved == nil {
+		return
+	}
+	m.mu.Lock()
+	reserved.err = err
+	delete(m.tokens, tokenKey)
+	close(reserved.done)
+	m.mu.Unlock()
 }
 
 // get returns a process by ID.
@@ -248,6 +427,45 @@ func (m *manager) get(id string) (*process, bool) {
 	return proc, ok
 }
 
+// byToken returns the process started under an idempotency token.
+// Exited processes past the reap age are swept first, so a
+// probe-only caller sees the same trust horizon as start and list
+// instead of a token the index would no longer honor. It is
+// non-blocking: a token whose start is still in flight (the
+// reservation exists but no process is published yet) reports
+// pending instead of found, so callers never mistake an in-flight
+// dispatch for proof that nothing started. A non-empty chatID
+// enforces chat isolation like the other process routes: entries
+// owned by a different chat are reported as absent, including
+// pending reservations, so a token leaks nothing across chats at
+// any point in its lifecycle.
+func (m *manager) byToken(token string, chatID string) (proc *process, pending bool, found bool) {
+	if token == "" {
+		return nil, false, false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.reapExitedLocked(m.clock.Now())
+	entry, ok := m.tokens[token]
+	if !ok {
+		return nil, false, false
+	}
+	if entry.procID == "" {
+		if chatID != "" && entry.chatID != "" && entry.chatID != chatID {
+			return nil, false, false
+		}
+		return nil, true, false
+	}
+	proc, ok = m.procs[entry.procID]
+	if !ok {
+		return nil, false, false
+	}
+	if chatID != "" && proc.chatID != "" && proc.chatID != chatID {
+		return nil, false, false
+	}
+	return proc, false, true
+}
+
 // list returns info about all tracked processes. Exited
 // processes older than exitedProcessReapAge are removed.
 // If chatID is non-empty, only processes belonging to that
@@ -256,26 +474,43 @@ func (m *manager) list(chatID string) []workspacesdk.ProcessInfo {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	now := m.clock.Now()
+	m.reapExitedLocked(m.clock.Now())
+
 	infos := make([]workspacesdk.ProcessInfo, 0, len(m.procs))
-	for id, proc := range m.procs {
-		info := proc.info()
-		// Reap processes that exited more than 5 minutes ago
-		// to prevent unbounded map growth.
-		if !info.Running && info.ExitedAt != nil {
-			exitedAt := time.Unix(*info.ExitedAt, 0)
-			if now.Sub(exitedAt) > exitedProcessReapAge {
-				delete(m.procs, id)
-				continue
-			}
-		}
+	for _, proc := range m.procs {
 		// Filter by chatID if provided.
 		if chatID != "" && proc.chatID != chatID {
 			continue
 		}
-		infos = append(infos, info)
+		infos = append(infos, proc.info())
 	}
 	return infos
+}
+
+// reapExitedLocked removes exited processes past their retention
+// age, together with their idempotency token index entries, to
+// prevent unbounded map growth. Tokened processes are kept longer
+// because their entries back start dedup and exited-result
+// recovery for retried dispatches. The manager mutex must be
+// held.
+func (m *manager) reapExitedLocked(now time.Time) {
+	for id, proc := range m.procs {
+		info := proc.info()
+		if info.Running || info.ExitedAt == nil {
+			continue
+		}
+		reapAge := exitedProcessReapAge
+		if proc.tokenKey != "" {
+			reapAge = tokenedProcessReapAge
+		}
+		if now.Sub(time.Unix(*info.ExitedAt, 0)) <= reapAge {
+			continue
+		}
+		delete(m.procs, id)
+		if proc.tokenKey != "" {
+			delete(m.tokens, proc.tokenKey)
+		}
+	}
 }
 
 // signal sends a signal to a running process. It returns
@@ -328,6 +563,10 @@ func (m *manager) Close() error {
 		return nil
 	}
 	m.closed = true
+	close(m.closeCh)
+	// The spawn path publishes into m.procs in the same critical
+	// section that checks closed, so this snapshot is complete: no
+	// process can spawn after this point.
 	procs := make([]*process, 0, len(m.procs))
 	for _, p := range m.procs {
 		procs = append(procs, p)

--- a/agent/agentproc/process_internal_test.go
+++ b/agent/agentproc/process_internal_test.go
@@ -1,0 +1,553 @@
+package agentproc
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"cdr.dev/slog/v3"
+	"cdr.dev/slog/v3/sloggers/slogtest"
+	"github.com/coder/coder/v2/agent/agentexec"
+	"github.com/coder/coder/v2/codersdk/workspacesdk"
+	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/quartz"
+)
+
+func TestReapFreesClientTokenIndex(t *testing.T) {
+	t.Parallel()
+
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	m := newManager(logger, agentexec.DefaultExecer, nil, nil, nil, nil)
+	t.Cleanup(func() {
+		_ = m.Close()
+	})
+	mClock := quartz.NewMock(t)
+	m.clock = mClock
+
+	req := workspacesdk.StartProcessRequest{
+		Command:     "echo hello",
+		ClientToken: "tok-1",
+	}
+	proc, attached, err := m.start(context.Background(), req, "chat-1")
+	require.NoError(t, err)
+	require.False(t, attached)
+	<-proc.done
+
+	// The token keeps attaching to the exited process until the
+	// reap age passes, so a retried start still sees the result.
+	again, attached, err := m.start(context.Background(), req, "chat-1")
+	require.NoError(t, err)
+	require.True(t, attached)
+	require.Equal(t, proc.id, again.id)
+
+	mClock.Advance(tokenedProcessReapAge + time.Minute)
+
+	// The sweep on start reaps the exited process, frees its
+	// token index entry, and the same token starts fresh.
+	fresh, attached, err := m.start(context.Background(), req, "chat-1")
+	require.NoError(t, err)
+	require.False(t, attached)
+	require.NotEqual(t, proc.id, fresh.id)
+
+	m.mu.Lock()
+	_, tracked := m.procs[proc.id]
+	tokenCount := len(m.tokens)
+	m.mu.Unlock()
+	require.False(t, tracked)
+	require.Equal(t, 1, tokenCount)
+	<-fresh.done
+}
+
+func TestByTokenReapsExitedProcesses(t *testing.T) {
+	t.Parallel()
+
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	m := newManager(logger, agentexec.DefaultExecer, nil, nil, nil, nil)
+	t.Cleanup(func() {
+		_ = m.Close()
+	})
+	mClock := quartz.NewMock(t)
+	m.clock = mClock
+
+	proc, attached, err := m.start(context.Background(), workspacesdk.StartProcessRequest{
+		Command:     "echo hello",
+		ClientToken: "tok-1",
+	}, "chat-1")
+	require.NoError(t, err)
+	require.False(t, attached)
+	<-proc.done
+
+	found, _, ok := m.byToken("tok-1", "chat-1")
+	require.True(t, ok)
+	require.Equal(t, proc.id, found.id)
+
+	mClock.Advance(tokenedProcessReapAge + time.Minute)
+
+	// A probe-only caller must not see a token entry the index
+	// would no longer honor: the probe itself reaps the exited
+	// process and its token.
+	_, pending, ok := m.byToken("tok-1", "chat-1")
+	require.False(t, ok)
+	require.False(t, pending)
+
+	m.mu.Lock()
+	_, tracked := m.procs[proc.id]
+	tokenCount := len(m.tokens)
+	m.mu.Unlock()
+	require.False(t, tracked)
+	require.Zero(t, tokenCount)
+}
+
+func TestTokenRetryIgnoresDefaultWorkdirDrift(t *testing.T) {
+	t.Parallel()
+
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	// The default directory resolves differently across starts,
+	// like an agent whose manifest loads between the original
+	// dispatch and its retry.
+	dirs := make(chan string, 2)
+	dirs <- ""
+	dirs <- t.TempDir()
+	m := newManager(logger, agentexec.DefaultExecer, nil, nil, nil, func() string { return <-dirs })
+	t.Cleanup(func() {
+		_ = m.Close()
+	})
+
+	req := workspacesdk.StartProcessRequest{
+		Command:     "echo hello",
+		ClientToken: "tok-dir-drift",
+	}
+	proc, attached, err := m.start(context.Background(), req, "chat-1")
+	require.NoError(t, err)
+	require.False(t, attached)
+	<-proc.done
+
+	// An identical retry must attach even though the resolved
+	// default directory changed; the request said the same thing
+	// both times.
+	again, attached, err := m.start(context.Background(), req, "chat-1")
+	require.NoError(t, err)
+	require.True(t, attached)
+	require.Equal(t, proc.id, again.id)
+}
+
+func TestUntokenedProcessesReapSooner(t *testing.T) {
+	t.Parallel()
+
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	m := newManager(logger, agentexec.DefaultExecer, nil, nil, nil, nil)
+	t.Cleanup(func() {
+		_ = m.Close()
+	})
+	mClock := quartz.NewMock(t)
+	m.clock = mClock
+
+	plain, attached, err := m.start(context.Background(), workspacesdk.StartProcessRequest{
+		Command: "echo hello",
+	}, "chat-1")
+	require.NoError(t, err)
+	require.False(t, attached)
+	<-plain.done
+
+	tokened, attached, err := m.start(context.Background(), workspacesdk.StartProcessRequest{
+		Command:     "echo hello",
+		ClientToken: "tok-1",
+	}, "chat-1")
+	require.NoError(t, err)
+	require.False(t, attached)
+	<-tokened.done
+
+	// Past the untokened retention but within the tokened one:
+	// the plain process and its output buffer are freed, while
+	// the tokened process stays to back dedup and result
+	// recovery for retried dispatches.
+	mClock.Advance(exitedProcessReapAge + time.Minute)
+	m.mu.Lock()
+	m.reapExitedLocked(mClock.Now())
+	_, plainTracked := m.procs[plain.id]
+	_, tokenedTracked := m.procs[tokened.id]
+	m.mu.Unlock()
+	require.False(t, plainTracked)
+	require.True(t, tokenedTracked)
+}
+
+func TestByTokenPendingReservation(t *testing.T) {
+	t.Parallel()
+
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	m := newManager(logger, agentexec.DefaultExecer, nil, nil, nil, nil)
+	t.Cleanup(func() {
+		_ = m.Close()
+	})
+
+	// A reservation whose start has not published a process yet
+	// must report pending, never a definitive not-found.
+	m.mu.Lock()
+	m.tokens["tok-pending"] = &tokenEntry{done: make(chan struct{}), chatID: "chat-1"}
+	m.mu.Unlock()
+
+	proc, pending, found := m.byToken("tok-pending", "")
+	require.Nil(t, proc)
+	require.True(t, pending)
+	require.False(t, found)
+
+	proc, pending, found = m.byToken("tok-pending", "chat-1")
+	require.Nil(t, proc)
+	require.True(t, pending)
+	require.False(t, found)
+
+	// Another chat's probe must not learn that a reservation for
+	// this token exists.
+	proc, pending, found = m.byToken("tok-pending", "chat-2")
+	require.Nil(t, proc)
+	require.False(t, pending)
+	require.False(t, found)
+
+	_, pending, found = m.byToken("tok-absent", "")
+	require.False(t, pending)
+	require.False(t, found)
+}
+
+func TestConcurrentSameTokenStartsOnce(t *testing.T) {
+	t.Parallel()
+
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	m := newManager(logger, agentexec.DefaultExecer, nil, nil, nil, nil)
+	t.Cleanup(func() {
+		_ = m.Close()
+	})
+
+	req := workspacesdk.StartProcessRequest{
+		Command:     "echo hello",
+		ClientToken: "tok-race",
+	}
+
+	const workers = 8
+	var (
+		wg       sync.WaitGroup
+		mu       sync.Mutex
+		ids      = make(map[string]struct{})
+		attaches int
+		errs     []error
+	)
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			proc, attached, err := m.start(context.Background(), req, "chat-1")
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				errs = append(errs, err)
+				return
+			}
+			ids[proc.id] = struct{}{}
+			if attached {
+				attaches++
+			}
+		}()
+	}
+	wg.Wait()
+	require.Empty(t, errs)
+
+	// Every concurrent start with the same token must resolve to
+	// the same single process, with exactly one actual spawn.
+	require.Len(t, ids, 1)
+	require.Equal(t, workers-1, attaches)
+
+	m.mu.Lock()
+	procCount := len(m.procs)
+	m.mu.Unlock()
+	require.Equal(t, 1, procCount)
+}
+
+func TestSameTokenWaiterHonorsCancellation(t *testing.T) {
+	t.Parallel()
+
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	release := make(chan struct{})
+	releaseOnce := sync.OnceFunc(func() { close(release) })
+	t.Cleanup(releaseOnce)
+	// Block the owning start after it reserves the token so a
+	// concurrent waiter is stuck behind it.
+	updateEnv := func(current []string) ([]string, error) {
+		<-release
+		return current, nil
+	}
+	m := newManager(logger, agentexec.DefaultExecer, nil, nil, updateEnv, nil)
+	t.Cleanup(func() {
+		_ = m.Close()
+	})
+
+	req := workspacesdk.StartProcessRequest{
+		Command:     "echo hello",
+		ClientToken: "tok-cancel",
+	}
+
+	ownerErr := make(chan error, 1)
+	go func() {
+		_, _, err := m.start(context.Background(), req, "chat-1")
+		ownerErr <- err
+	}()
+	require.Eventually(t, func() bool {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		return len(m.tokens) == 1
+	}, testutil.WaitShort, testutil.IntervalFast)
+
+	// A canceled waiter must return promptly instead of blocking
+	// until the owner finishes.
+	waiterCtx, cancelWaiter := context.WithCancel(context.Background())
+	waiterErr := make(chan error, 1)
+	go func() {
+		_, _, err := m.start(waiterCtx, req, "chat-1")
+		waiterErr <- err
+	}()
+	cancelWaiter()
+	select {
+	case err := <-waiterErr:
+		require.ErrorIs(t, err, context.Canceled)
+		// The wait-abort sentinel routes the failure to a 409:
+		// the reservation owner may still publish a process, so
+		// callers must not treat the dispatch as failed.
+		require.ErrorIs(t, err, errTokenWaitAborted)
+	case <-time.After(testutil.WaitShort):
+		t.Fatal("waiter did not return after cancellation")
+	}
+
+	// The owner is unaffected by the waiter's cancellation.
+	releaseOnce()
+	select {
+	case err := <-ownerErr:
+		require.NoError(t, err)
+	case <-time.After(testutil.WaitShort):
+		t.Fatal("owner start did not finish")
+	}
+
+	proc, attached, err := m.start(context.Background(), req, "chat-1")
+	require.NoError(t, err)
+	require.True(t, attached)
+	<-proc.done
+}
+
+func TestCrossChatPendingTokenRejectedWithoutWaiting(t *testing.T) {
+	t.Parallel()
+
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	release := make(chan struct{})
+	releaseOnce := sync.OnceFunc(func() { close(release) })
+	t.Cleanup(releaseOnce)
+	// Keep chat A's start pending so its reservation is the only
+	// thing chat B can observe.
+	updateEnv := func(current []string) ([]string, error) {
+		<-release
+		return current, nil
+	}
+	m := newManager(logger, agentexec.DefaultExecer, nil, nil, updateEnv, nil)
+
+	req := workspacesdk.StartProcessRequest{
+		Command:     "echo hello",
+		ClientToken: "tok-cross-chat",
+	}
+
+	ownerErr := make(chan error, 1)
+	go func() {
+		_, _, err := m.start(context.Background(), req, "chat-a")
+		ownerErr <- err
+	}()
+	require.Eventually(t, func() bool {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		return len(m.tokens) == 1
+	}, testutil.WaitShort, testutil.IntervalFast)
+
+	// Chat B must fail fast instead of stalling behind chat A's
+	// in-flight start only to hit the same mismatch afterwards.
+	_, _, err := m.start(context.Background(), req, "chat-b")
+	require.ErrorIs(t, err, errClientTokenMismatch)
+
+	releaseOnce()
+	select {
+	case err := <-ownerErr:
+		require.NoError(t, err)
+	case <-time.After(testutil.WaitShort):
+		t.Fatal("owner start did not finish")
+	}
+}
+
+func TestSameTokenWaiterUnblocksOnClose(t *testing.T) {
+	t.Parallel()
+
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	release := make(chan struct{})
+	releaseOnce := sync.OnceFunc(func() { close(release) })
+	t.Cleanup(releaseOnce)
+	// Block the owning start after it reserves the token so a
+	// concurrent waiter is stuck behind it when Close runs.
+	updateEnv := func(current []string) ([]string, error) {
+		<-release
+		return current, nil
+	}
+	m := newManager(logger, agentexec.DefaultExecer, nil, nil, updateEnv, nil)
+
+	req := workspacesdk.StartProcessRequest{
+		Command:     "echo hello",
+		ClientToken: "tok-close",
+	}
+
+	ownerErr := make(chan error, 1)
+	go func() {
+		_, _, err := m.start(context.Background(), req, "chat-1")
+		ownerErr <- err
+	}()
+	require.Eventually(t, func() bool {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		return len(m.tokens) == 1
+	}, testutil.WaitShort, testutil.IntervalFast)
+
+	waiterErr := make(chan error, 1)
+	go func() {
+		_, _, err := m.start(context.Background(), req, "chat-1")
+		waiterErr <- err
+	}()
+
+	require.NoError(t, m.Close())
+
+	// The waiter must not stay stuck behind the blocked owner
+	// after the manager shut down.
+	select {
+	case err := <-waiterErr:
+		require.ErrorContains(t, err, "manager is closed")
+		require.ErrorIs(t, err, errTokenWaitAborted)
+	case <-time.After(testutil.WaitShort):
+		t.Fatal("waiter did not return after Close")
+	}
+
+	// The owner never reached the spawn before Close, so it
+	// reports the close instead of dispatching a command after
+	// shutdown.
+	releaseOnce()
+	select {
+	case err := <-ownerErr:
+		require.ErrorContains(t, err, "manager is closed")
+	case <-time.After(testutil.WaitShort):
+		t.Fatal("owner start did not finish")
+	}
+}
+
+func TestCloseBeforeSpawnAbortsTokenedStart(t *testing.T) {
+	t.Parallel()
+
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	release := make(chan struct{})
+	releaseOnce := sync.OnceFunc(func() { close(release) })
+	t.Cleanup(releaseOnce)
+	closeManager := make(chan struct{})
+	// Block the start between its token reservation and the
+	// spawn so Close lands first.
+	updateEnv := func(current []string) ([]string, error) {
+		close(closeManager)
+		<-release
+		return current, nil
+	}
+	m := newManager(logger, agentexec.DefaultExecer, nil, nil, updateEnv, nil)
+
+	req := workspacesdk.StartProcessRequest{
+		Command:     "sleep 600",
+		ClientToken: "tok-close-race",
+	}
+
+	type startResult struct {
+		proc *process
+		err  error
+	}
+	ownerDone := make(chan startResult, 1)
+	go func() {
+		proc, _, err := m.start(context.Background(), req, "chat-1")
+		ownerDone <- startResult{proc: proc, err: err}
+	}()
+
+	<-closeManager
+	require.NoError(t, m.Close())
+	releaseOnce()
+
+	var res startResult
+	select {
+	case res = <-ownerDone:
+	case <-time.After(testutil.WaitShort):
+		t.Fatal("start did not return after Close")
+	}
+	// The spawn happens in the same critical section as the
+	// closed check, so a start that loses the race to Close never
+	// runs the command: the error truthfully reports that nothing
+	// was dispatched.
+	require.Error(t, res.err)
+	require.ErrorContains(t, res.err, "manager is closed")
+	require.Nil(t, res.proc)
+
+	// Nothing spawned, so nothing may be published and the token
+	// must be released: a probe's trusted absence ("nothing
+	// started") is accurate, not a green light for a duplicate of
+	// something that ran.
+	m.mu.Lock()
+	published := len(m.procs)
+	_, tokenHeld := m.tokens["tok-close-race"]
+	m.mu.Unlock()
+	require.Zero(t, published)
+	require.False(t, tokenHeld)
+}
+
+// TestCloseBeforeSpawnAbortsUntokenedStart is the untokened variant:
+// the caller sees the close error and nothing is published.
+func TestCloseBeforeSpawnAbortsUntokenedStart(t *testing.T) {
+	t.Parallel()
+
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	release := make(chan struct{})
+	releaseOnce := sync.OnceFunc(func() { close(release) })
+	t.Cleanup(releaseOnce)
+	closeManager := make(chan struct{})
+	updateEnv := func(current []string) ([]string, error) {
+		close(closeManager)
+		<-release
+		return current, nil
+	}
+	m := newManager(logger, agentexec.DefaultExecer, nil, nil, updateEnv, nil)
+
+	req := workspacesdk.StartProcessRequest{
+		Command: "sleep 600",
+	}
+
+	type startResult struct {
+		proc *process
+		err  error
+	}
+	ownerDone := make(chan startResult, 1)
+	go func() {
+		proc, _, err := m.start(context.Background(), req, "chat-1")
+		ownerDone <- startResult{proc: proc, err: err}
+	}()
+
+	<-closeManager
+	require.NoError(t, m.Close())
+	releaseOnce()
+
+	var res startResult
+	select {
+	case res = <-ownerDone:
+	case <-time.After(testutil.WaitShort):
+		t.Fatal("start did not return after Close")
+	}
+	require.Error(t, res.err)
+	require.ErrorContains(t, res.err, "manager is closed")
+	require.Nil(t, res.proc)
+
+	m.mu.Lock()
+	published := len(m.procs)
+	m.mu.Unlock()
+	require.Zero(t, published)
+}

--- a/codersdk/workspacesdk/agentconn.go
+++ b/codersdk/workspacesdk/agentconn.go
@@ -78,6 +78,13 @@ func (c *wrappedAgentConn) Close() error {
 	return c.closeErr
 }
 
+// ProcessByToken forwards the optional token probe capability of
+// the wrapped connection, which interface embedding alone would
+// hide from callers asserting ProcessTokenProber.
+func (c *wrappedAgentConn) ProcessByToken(ctx context.Context, token string) (ProcessByTokenResponse, error) {
+	return ProbeProcessToken(ctx, c.AgentConn, token)
+}
+
 const (
 	// CoderChatIDHeader is the HTTP header containing the current
 	// chat ID. Set by coderd on agentconn requests originating
@@ -134,6 +141,32 @@ type AgentConn interface {
 	ExecuteDesktopAction(ctx context.Context, action DesktopAction) (DesktopActionResponse, error)
 	StartDesktopRecording(ctx context.Context, req StartDesktopRecordingRequest) error
 	StopDesktopRecording(ctx context.Context, req StopDesktopRecordingRequest) (StopDesktopRecordingResponse, error)
+}
+
+// ProcessTokenProber is an optional capability of AgentConn
+// implementations: probing whether an idempotency token has a
+// process attached on the agent. It is kept off the AgentConn
+// contract so existing out-of-tree implementations keep compiling.
+// Probe through ProbeProcessToken, which degrades a missing
+// implementation to ErrProcessTokenProbeUnsupported.
+// @typescript-ignore ProcessTokenProber
+type ProcessTokenProber interface {
+	ProcessByToken(ctx context.Context, token string) (ProcessByTokenResponse, error)
+}
+
+// ErrProcessTokenProbeUnsupported reports an AgentConn
+// implementation without the token probe capability. Like an HTTP
+// 404 from an agent that predates the probe endpoint, it is a
+// definite capability gap, not a transient failure.
+var ErrProcessTokenProbeUnsupported = xerrors.New("agent connection does not support process token probes")
+
+// ProbeProcessToken probes token ownership when conn supports it.
+func ProbeProcessToken(ctx context.Context, conn AgentConn, token string) (ProcessByTokenResponse, error) {
+	prober, ok := conn.(ProcessTokenProber)
+	if !ok {
+		return ProcessByTokenResponse{}, ErrProcessTokenProbeUnsupported
+	}
+	return prober.ProcessByToken(ctx, token)
 }
 
 // AgentConn represents a connection to a workspace agent.
@@ -911,12 +944,48 @@ type StartProcessRequest struct {
 	WorkDir    string            `json:"workdir,omitempty"`
 	Env        map[string]string `json:"env,omitempty"`
 	Background bool              `json:"background,omitempty"`
+	// ClientToken is an optional idempotency token. When a
+	// process was already started with the same token for the
+	// same chat, the agent returns that process instead of
+	// starting a duplicate. A repeated token with different
+	// command, workdir, env, or background parameters is
+	// rejected. The token index is in-memory and time-limited:
+	// it is lost on agent restart, and entries are reaped with
+	// their exited processes, so a retry after that window
+	// starts a new process.
+	ClientToken string `json:"client_token,omitempty"`
 }
 
 // StartProcessResponse is returned when a process is started.
 type StartProcessResponse struct {
-	ID      string `json:"id"`
-	Started bool   `json:"started"`
+	ID string `json:"id"`
+	// Started is true when this request started a new process.
+	Started bool `json:"started"`
+	// ClientToken echoes the accepted idempotency token. Agents
+	// that predate idempotent starts omit it, which tells the
+	// caller no agent-side deduplication happened.
+	ClientToken string `json:"client_token,omitempty"`
+	// Attached is true when an existing process started with the
+	// same token was returned instead of starting a new one.
+	Attached bool `json:"attached,omitempty"`
+}
+
+// ProcessByTokenResponse reports whether an idempotency token has
+// a process attached on the agent. The route always answers 200,
+// so an HTTP 404 unambiguously identifies an agent that predates
+// the token probe endpoint.
+type ProcessByTokenResponse struct {
+	Found bool `json:"found"`
+	// Pending reports that a start owning this token is still in
+	// flight: no process is published yet, but Found=false must
+	// not be read as proof that nothing started.
+	Pending   bool   `json:"pending,omitempty"`
+	ProcessID string `json:"process_id,omitempty"`
+	// TokenIndexAgeMS is how long the agent's in-memory token
+	// index has existed. The index does not survive agent
+	// restarts, so Found=false only proves nothing started if
+	// the index predates the token's first dispatch.
+	TokenIndexAgeMS int64 `json:"token_index_age_ms"`
 }
 
 // ListProcessesResponse contains information about tracked
@@ -1327,6 +1396,33 @@ func (c *agentConn) CallMCPTool(ctx context.Context, req CallMCPToolRequest) (Ca
 		return CallMCPToolResponse{}, codersdk.ReadBodyAsError(res)
 	}
 	var resp CallMCPToolResponse
+	return resp, json.NewDecoder(res.Body).Decode(&resp)
+}
+
+// ProcessByToken reports whether an idempotency token has a
+// process attached on the agent.
+func (c *agentConn) ProcessByToken(ctx context.Context, token string) (ProcessByTokenResponse, error) {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
+	// Tokens are opaque caller-chosen strings, carried as a query
+	// parameter so the value round-trips through exactly one
+	// escape/unescape regardless of its bytes.
+	res, err := c.apiRequest(ctx, http.MethodGet, "/api/v0/processes/tokens?token="+neturl.QueryEscape(token), nil)
+	if err != nil {
+		return ProcessByTokenResponse{}, xerrors.Errorf("do request: %w", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode == http.StatusNotFound {
+		// An unknown token still answers 200 with found=false, so a
+		// 404 can only mean the route itself is missing: the agent
+		// predates the probe endpoint. Surface the documented
+		// sentinel so callers take their unsupported-probe fallback.
+		return ProcessByTokenResponse{}, xerrors.Errorf("agent does not serve the process token probe route: %w", ErrProcessTokenProbeUnsupported)
+	}
+	if res.StatusCode != http.StatusOK {
+		return ProcessByTokenResponse{}, codersdk.ReadBodyAsError(res)
+	}
+	var resp ProcessByTokenResponse
 	return resp, json.NewDecoder(res.Body).Decode(&resp)
 }
 

--- a/codersdk/workspacesdk/agentconn_internal_test.go
+++ b/codersdk/workspacesdk/agentconn_internal_test.go
@@ -1,12 +1,53 @@
 package workspacesdk
 
 import (
+	"context"
 	neturl "net/url"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+type fakeProberConn struct {
+	AgentConn
+	probed string
+}
+
+func (c *fakeProberConn) ProcessByToken(_ context.Context, token string) (ProcessByTokenResponse, error) {
+	c.probed = token
+	return ProcessByTokenResponse{Found: true, ProcessID: "proc-1"}, nil
+}
+
+func TestProbeProcessToken(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unsupported connection degrades", func(t *testing.T) {
+		t.Parallel()
+		// A bare interface embed satisfies AgentConn without the
+		// optional prober capability.
+		conn := struct{ AgentConn }{}
+		_, err := ProbeProcessToken(context.Background(), conn, "tok")
+		require.ErrorIs(t, err, ErrProcessTokenProbeUnsupported)
+	})
+
+	t.Run("wrapping preserves the capability", func(t *testing.T) {
+		t.Parallel()
+		inner := &fakeProberConn{}
+		wrapped := WrapAgentConn(inner, nil)
+		resp, err := ProbeProcessToken(context.Background(), wrapped, "tok")
+		require.NoError(t, err)
+		require.True(t, resp.Found)
+		require.Equal(t, "tok", inner.probed)
+	})
+
+	t.Run("wrapping an unsupported connection degrades", func(t *testing.T) {
+		t.Parallel()
+		wrapped := WrapAgentConn(struct{ AgentConn }{}, nil)
+		_, err := ProbeProcessToken(context.Background(), wrapped, "tok")
+		require.ErrorIs(t, err, ErrProcessTokenProbeUnsupported)
+	})
+}
 
 func TestAgentAPIPath(t *testing.T) {
 	t.Parallel()

--- a/codersdk/workspacesdk/agentconnmock/prober.go
+++ b/codersdk/workspacesdk/agentconnmock/prober.go
@@ -1,0 +1,29 @@
+package agentconnmock
+
+import (
+	"context"
+	"reflect"
+
+	gomock "go.uber.org/mock/gomock"
+
+	"github.com/coder/coder/v2/codersdk/workspacesdk"
+)
+
+var _ workspacesdk.ProcessTokenProber = (*MockAgentConn)(nil)
+
+// ProcessByToken mocks the optional ProcessTokenProber capability.
+// Hand-written because mockgen only generates the AgentConn
+// contract, which deliberately excludes the probe.
+func (m *MockAgentConn) ProcessByToken(ctx context.Context, token string) (workspacesdk.ProcessByTokenResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ProcessByToken", ctx, token)
+	ret0, _ := ret[0].(workspacesdk.ProcessByTokenResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ProcessByToken indicates an expected call of ProcessByToken.
+func (mr *MockAgentConnMockRecorder) ProcessByToken(ctx, token any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessByToken", reflect.TypeOf((*MockAgentConn)(nil).ProcessByToken), ctx, token)
+}


### PR DESCRIPTION
Adds idempotent start tokens to the workspace agent process API: a client-supplied opaque token makes process starts exactly-once per token and addressable by token.

Part 6/9 of the CODAGT-757 execution ledger stack (base: #05). Agent and SDK surface only; chatd adopts it in the next two PRs. Supersedes the agent portion of #27102.

## Changes

- `StartProcessRequest.ClientToken`: the manager reserves the token before spawning, echoes it on the response, and returns the existing process (env-matched) for a duplicate token instead of starting a second process. Concurrent same-token starts collapse to one spawn; waiters honor cancellation and unblock on close.
- `GET /api/v0/processes/tokens/{token}`: token probe returning the process (or pending reservation) owning a token.
- Token index lifecycle: reaped with exited processes on the 60-minute horizon; `tokenIndexAge` exposes staleness so callers can decide whether an absent token is trustworthy.
- `workspacesdk`: `ProcessByToken` on `AgentConn`, `ProbeProcessToken` helper, mock support.

> This PR was authored by Mux, an AI coding agent, on Mike's behalf. The stack recomposes the previously reviewed #27100/#27102/#27103 into reviewable pieces, plus fixes from subsequent review rounds.