### PR TITLE
fix(coderd/x/chatd): keep task attempts alive while execute tools make progress

### DIFF
--- a/coderd/x/chatd/ARCHITECTURE.md
+++ b/coderd/x/chatd/ARCHITECTURE.md
@@ -792,6 +792,13 @@ Retriable conditions include, but are not limited to:
 - database connection error;
 - LLM API request error, with the exception of hitting the generation attempt limit, which is considered to be a successful completion of the operation the goroutine was meant to perform.
 
+#### Task attempt watchdog
+
+Every attempt of a runner goroutine runs under two watchdog timers. Both cancel the attempt with a timeout error that the retry wrapper classifies as retryable:
+
+- An **idle window** (15 minutes). Only the `execute` and `process_output` tools reset it, after every successful process-API round-trip: process starts, blocking output polls (including rounds where the process is still running), and `process_output` retrievals. Long-running `execute` calls therefore survive as long as the workspace agent keeps responding, and the re-attach path resumes them across retries. This scoping is deliberate: other workspace tools finish well within the idle window, and letting quick tools extend an attempt would change how long a stuck attempt can live without real command progress. The window is attempt-scoped, so a progressing `execute` also extends sibling tools running in the same step; a stuck sibling is then canceled 15 minutes after the last kick instead of 15 minutes after the step started, bounded by the execute timeout clamp plus one idle window rather than the 24-hour cap. Sibling tools that block on model-supplied durations are bounded per call instead of riding the attempt: a single `wait_agent` block is clamped to 10 minutes, below the idle window so its resumable timeout result commits before the watchdog cancels the attempt, and a single `computer` wait action is clamped to 30 seconds (the model repeats the action for longer settles). The reset function travels in the attempt context and resetting is a safe no-op once the attempt has ended. Streaming code never resets the watchdog, so the idle window stays above chatloop's 10 minute stream-silence guard and silent provider streams keep failing through chat-specific retry handling before the attempt times out.
+- An **absolute cap** (24 hours) that is never reset. It bounds a single attempt regardless of tool progress.
+
 #### Generation goroutine
 
 The generation goroutine is responsible for calling the LLM API and executing tools. It is spawned when the event indicates the core state machine is in `R0` or `R1` (status is `running`).
@@ -936,7 +943,7 @@ The immediate post-interrupt pass ignores the task context's cancellation (the r
 
 ### Retention
 
-Rows are never deleted at resolution time; they stay diagnostically useful. `dbpurge` deletes rows older than 7 days, but only rows whose tool result was committed: an uncommitted row still guards dedup for a call a future retry may re-execute. `cancel_requested` rows are kept regardless of age: the cancelling transaction stamps `result_committed_at` on them, but they still carry the only stored identity of a process the sweep must kill. Uncommitted rows are reaped on a separate 30-day horizon anchored on `updated_at`: a row idle that long belongs to a turn that will never rerun (a crashed turn, a terminal task failure, an unclaimed `reserved` intent), and without this horizon it would only ever be reaped by chat retention, which many deployments leave unset. Deletion only discards ledger history: a still-running detached process is unaffected and stays addressable through the process handle in its committed tool result.
+Rows are never deleted at resolution time; they stay diagnostically useful. `dbpurge` deletes rows older than 7 days, but only rows whose tool result was committed: an uncommitted row still guards dedup for a call a future retry may re-execute. `cancel_requested` rows are kept regardless of age: the cancelling transaction stamps `result_committed_at` on them, but they still carry the only stored identity of a process the sweep must kill. Uncommitted rows are reaped on a separate 30-day horizon anchored on `updated_at`: a row idle that long belongs to a turn that will never rerun (a crashed turn, a terminal task failure, an unclaimed `reserved` intent), and without this horizon it would only ever be reaped by chat retention, which many deployments leave unset. Deletion only discards ledger history: a still-running detached process is unaffected and stays addressable through the process handle in its committed tool result, and the 4-hour timeout clamp plus the 24-hour attempt cap mean no attempt can still be re-executing a call that old.
 
 # Stream loop
 

--- a/coderd/x/chatd/chatloop/chatloop.go
+++ b/coderd/x/chatd/chatloop/chatloop.go
@@ -28,6 +28,7 @@ import (
 	"github.com/coder/coder/v2/coderd/x/chatd/chatretry"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatsanitize"
 	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
+	"github.com/coder/coder/v2/coderd/x/chatd/internal/watchdog"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/quartz"
 )
@@ -643,65 +644,16 @@ type guardedAttempt struct {
 	finish  func(error) error
 }
 
-// streamSilenceGuard arbitrates whether an attempt times out while
-// waiting for the next stream part. Exactly one outcome wins: the
-// timer cancels the attempt, or release disarms the timer.
-type streamSilenceGuard struct {
-	mu      sync.Mutex
-	timer   *quartz.Timer
-	cancel  context.CancelCauseFunc
-	timeout time.Duration
-	settled bool
-}
-
+// newStreamSilenceGuard arms the watchdog that arbitrates whether an
+// attempt times out while waiting for the next stream part. Exactly
+// one outcome wins: the timer cancels the attempt, or Disarm stops
+// the timer.
 func newStreamSilenceGuard(
 	clock quartz.Clock,
 	timeout time.Duration,
 	cancel context.CancelCauseFunc,
-) *streamSilenceGuard {
-	guard := &streamSilenceGuard{
-		cancel:  cancel,
-		timeout: timeout,
-	}
-	guard.timer = clock.AfterFunc(
-		timeout,
-		guard.onTimeout,
-		streamSilenceGuardTimerTag,
-	)
-	return guard
-}
-
-func (g *streamSilenceGuard) settle() bool {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	if g.settled {
-		return false
-	}
-	g.settled = true
-	return true
-}
-
-func (g *streamSilenceGuard) onTimeout() {
-	if !g.settle() {
-		return
-	}
-	g.cancel(errStreamSilenceTimeout)
-}
-
-func (g *streamSilenceGuard) Reset() {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	if g.settled {
-		return
-	}
-	g.timer.Reset(g.timeout, streamSilenceGuardTimerTag)
-}
-
-func (g *streamSilenceGuard) Disarm() {
-	if !g.settle() {
-		return
-	}
-	g.timer.Stop()
+) *watchdog.Timer {
+	return watchdog.New(clock, timeout, cancel, errStreamSilenceTimeout, streamSilenceGuardTimerTag)
 }
 
 func classifyStreamSilenceTimeout(

--- a/coderd/x/chatd/chatloop/chatloop_run_internal_test.go
+++ b/coderd/x/chatd/chatloop/chatloop_run_internal_test.go
@@ -3,9 +3,7 @@ package chatloop
 import (
 	"context"
 	"encoding/base64"
-	"errors"
 	"iter"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -91,43 +89,10 @@ func toolResultContentToPart(toolResult fantasy.ToolResultContent) fantasy.ToolR
 	}
 }
 
-func TestStreamSilenceGuard_DisarmAndFireRace(t *testing.T) {
-	t.Parallel()
-
-	for range 128 {
-		var cancels atomic.Int32
-		guard := newStreamSilenceGuard(quartz.NewReal(), time.Hour, func(err error) {
-			if errors.Is(err, errStreamSilenceTimeout) {
-				cancels.Add(1)
-			}
-		})
-
-		start := make(chan struct{})
-		var wg sync.WaitGroup
-		wg.Add(2)
-
-		go func() {
-			defer wg.Done()
-			<-start
-			guard.onTimeout()
-		}()
-
-		go func() {
-			defer wg.Done()
-			<-start
-			guard.Disarm()
-		}()
-
-		close(start)
-		wg.Wait()
-
-		guard.onTimeout()
-		guard.Disarm()
-
-		require.LessOrEqual(t, cancels.Load(), int32(1))
-	}
-}
-
+// The disarm-versus-late-fire race itself is covered by the shared
+// watchdog package tests; this test pins the chatloop-level
+// consequence: a disarmed guard leaves no timeout cause, so a
+// permanent stream error keeps its own classification.
 func TestStreamSilenceGuard_DisarmPreservesPermanentError(t *testing.T) {
 	t.Parallel()
 
@@ -136,7 +101,6 @@ func TestStreamSilenceGuard_DisarmPreservesPermanentError(t *testing.T) {
 
 	guard := newStreamSilenceGuard(quartz.NewReal(), time.Hour, cancelAttempt)
 	guard.Disarm()
-	guard.onTimeout()
 
 	classified := chaterror.Classify(classifyStreamSilenceTimeout(
 		attemptCtx,

--- a/coderd/x/chatd/chattool/computeruse.go
+++ b/coderd/x/chatd/chattool/computeruse.go
@@ -322,12 +322,20 @@ func (*computerUseTool) desktopAction(
 	}
 }
 
+// maxComputerWait caps a single model-supplied wait action. Without
+// it, an oversized wait could ride an attempt whose watchdog a
+// concurrently progressing execute keeps kicking, far past the
+// attempt idle window. The model repeats the wait action when a UI
+// needs longer to settle.
+const maxComputerWait = 30 * time.Second
+
 func (t *computerUseTool) wait(ctx context.Context, durationMillis int64) {
-	d := durationMillis
+	d := time.Duration(durationMillis) * time.Millisecond
 	if d <= 0 {
-		d = 1000
+		d = time.Second
 	}
-	timer := t.clock.NewTimer(time.Duration(d)*time.Millisecond, "computeruse", "wait")
+	d = min(d, maxComputerWait)
+	timer := t.clock.NewTimer(d, "computeruse", "wait")
 	defer timer.Stop()
 	select {
 	case <-ctx.Done():

--- a/coderd/x/chatd/chattool/computeruse_test.go
+++ b/coderd/x/chatd/chattool/computeruse_test.go
@@ -442,6 +442,60 @@ func TestComputerUseTool_Run_Wait(t *testing.T) {
 	assert.Empty(t, attachments)
 }
 
+func TestComputerUseTool_Run_WaitClamped(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	ctrl := gomock.NewController(t)
+	mockConn := agentconnmock.NewMockAgentConn(ctrl)
+	geometry := workspacesdk.DefaultDesktopGeometry()
+	mClock := quartz.NewMock(t)
+	followUpScreenshot := base64.StdEncoding.EncodeToString([]byte("after-wait"))
+
+	mockConn.EXPECT().ExecuteDesktopAction(
+		gomock.Any(),
+		gomock.AssignableToTypeOf(workspacesdk.DesktopAction{}),
+	).Return(workspacesdk.DesktopActionResponse{
+		Output:           "screenshot",
+		ScreenshotData:   followUpScreenshot,
+		ScreenshotWidth:  geometry.DeclaredWidth,
+		ScreenshotHeight: geometry.DeclaredHeight,
+	}, nil).Times(1)
+
+	trap := mClock.Trap().NewTimer("computeruse", "wait")
+	tool := chattool.NewComputerUseTool(codersdk.ChatComputerUseProviderAnthropic, geometry.DeclaredWidth, geometry.DeclaredHeight, func(_ context.Context) (workspacesdk.AgentConn, error) {
+		return mockConn, nil
+	}, nil, mClock, slogtest.Make(t, nil))
+
+	type toolResult struct {
+		resp fantasy.ToolResponse
+		err  error
+	}
+	resultCh := make(chan toolResult, 1)
+	go func() {
+		resp, err := tool.Run(ctx, fantasy.ToolCall{
+			ID:   "test-wait-clamp",
+			Name: "computer",
+			// 10 hours in milliseconds.
+			Input: `{"action":"wait","duration":36000000}`,
+		})
+		resultCh <- toolResult{resp: resp, err: err}
+	}()
+
+	// An oversized model-supplied wait is clamped to the per-call
+	// cap instead of blocking the tool batch for hours.
+	call := trap.MustWait(ctx)
+	assert.Equal(t, 30*time.Second, call.Duration)
+	call.MustRelease(ctx)
+	trap.Close()
+	mClock.Advance(30 * time.Second).MustWait(ctx)
+
+	result := testutil.RequireReceive(ctx, t, resultCh)
+	require.NoError(t, result.err)
+	assert.Equal(t, "image", result.resp.Type)
+	assert.False(t, result.resp.IsError)
+}
+
 func TestComputerUseTool_Run_ScreenshotDataIsDecodedBinary(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/x/chatd/chattool/execute.go
+++ b/coderd/x/chatd/chattool/execute.go
@@ -1175,6 +1175,7 @@ func reattachProcess(
 			rec.ProcessID,
 		), nil
 	}
+	KickAttemptKeepalive(ctx)
 
 	if !resp.Running {
 		// The process finished while no attempt was watching.
@@ -1246,6 +1247,7 @@ func executeBackground(
 	if err != nil {
 		return startFailureResponse(ctx, options, toolCallID, rec.ClaimEpoch, claimKind, "start background process", err)
 	}
+	KickAttemptKeepalive(ctx)
 	logStartIdempotency(ctx, options.Logger, resp, toolCallID)
 	startedAt := time.Now()
 	if resp.Attached && !rec.ClaimedAt.IsZero() {
@@ -1360,6 +1362,7 @@ func executeForeground(
 	if err != nil {
 		return startFailureResponse(ctx, options, toolCallID, rec.ClaimEpoch, claimKind, "start process", err)
 	}
+	KickAttemptKeepalive(ctx)
 	logStartIdempotency(ctx, options.Logger, resp, toolCallID)
 	startedAt := time.Now()
 	if resp.Attached && !rec.ClaimedAt.IsZero() {
@@ -1475,6 +1478,9 @@ func waitForProcess(
 		resp, err := conn.ProcessOutput(ctx, processID, &workspacesdk.ProcessOutputOptions{
 			Wait: true,
 		})
+		if err == nil {
+			KickAttemptKeepalive(parentCtx)
+		}
 		if err == nil && resp.Running && ctx.Err() == nil {
 			// The server-side wait can return before the process
 			// exits when its maximum wait is shorter than the
@@ -1559,6 +1565,8 @@ func resolveProcessWait(
 				BackgroundProcessID: processID,
 			}, false
 		}
+
+		KickAttemptKeepalive(parentCtx)
 
 		// Snapshot succeeded. If the process finished, return
 		// its real result (transparent recovery).
@@ -1710,6 +1718,11 @@ func ProcessOutput(options ProcessToolOptions) fantasy.AgentTool {
 			}
 			resp, err := conn.ProcessOutput(ctx, args.ProcessID, opts)
 			for err == nil && opts != nil && resp.Running && ctx.Err() == nil {
+				// Each successful poll is agent progress, so kick
+				// the attempt keepalive like waitForProcess does:
+				// a wait longer than the attempt idle window must
+				// not trip the watchdog while the agent responds.
+				KickAttemptKeepalive(parentCtx)
 				// The agent bounds each blocking wait below the
 				// requested timeout, so an early running response
 				// is not the wait's end. Re-issue the wait with
@@ -1748,6 +1761,7 @@ func ProcessOutput(options ProcessToolOptions) fantasy.AgentTool {
 				}
 				// Fall through to normal response handling below.
 			}
+			KickAttemptKeepalive(parentCtx)
 			result := completedResult(resp)
 			if resp.Running {
 				// Process is still running, success is not

--- a/coderd/x/chatd/chattool/execute_test.go
+++ b/coderd/x/chatd/chattool/execute_test.go
@@ -240,6 +240,83 @@ func TestExecuteTool(t *testing.T) {
 		assert.Equal(t, "true", capturedReq.Env["CODER_CHAT_AGENT"])
 	})
 
+	t.Run("KeepaliveKickedOnAgentRoundTrips", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			Return(workspacesdk.StartProcessResponse{ID: "proc-1"}, nil)
+		exitCode := 0
+		gomock.InOrder(
+			// The server-side wait returns while the process is
+			// still running, then a second poll sees it exit.
+			mockConn.EXPECT().
+				ProcessOutput(gomock.Any(), "proc-1", gomock.Any()).
+				Return(workspacesdk.ProcessOutputResponse{Running: true}, nil),
+			mockConn.EXPECT().
+				ProcessOutput(gomock.Any(), "proc-1", gomock.Any()).
+				Return(workspacesdk.ProcessOutputResponse{
+					Running:  false,
+					ExitCode: &exitCode,
+					Output:   "done",
+				}, nil),
+		)
+
+		kicks := 0
+		ctx := chattool.WithAttemptKeepalive(
+			testutil.Context(t, testutil.WaitMedium),
+			func() { kicks++ },
+		)
+		tool := newExecuteTool(t, mockConn)
+		resp, err := tool.Run(ctx, fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "execute",
+			Input: `{"command":"sleep 1"}`,
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.IsError)
+		// One kick for the successful start, one per successful
+		// poll round, including the round where the process was
+		// still running.
+		assert.Equal(t, 3, kicks)
+	})
+
+	t.Run("ProcessOutputToolKicksKeepalive", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+
+		exitCode := 0
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Any()).
+			Return(workspacesdk.ProcessOutputResponse{
+				Running:  false,
+				ExitCode: &exitCode,
+				Output:   "done",
+			}, nil)
+
+		kicks := 0
+		ctx := chattool.WithAttemptKeepalive(
+			testutil.Context(t, testutil.WaitMedium),
+			func() { kicks++ },
+		)
+		tool := chattool.ProcessOutput(chattool.ProcessToolOptions{
+			GetWorkspaceConn: func(_ context.Context) (workspacesdk.AgentConn, error) {
+				return mockConn, nil
+			},
+		})
+		resp, err := tool.Run(ctx, fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "process_output",
+			Input: `{"process_id":"proc-1"}`,
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.IsError)
+		assert.Equal(t, 1, kicks)
+	})
+
 	t.Run("ModelIntentIgnoredByExecution", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
@@ -1115,7 +1192,11 @@ func TestExecuteToolRecorder(t *testing.T) {
 			}, nil)
 
 		tool := newRecordedExecuteTool(t, mockConn, recorder)
-		ctx := testutil.Context(t, testutil.WaitMedium)
+		kicks := 0
+		ctx := chattool.WithAttemptKeepalive(
+			testutil.Context(t, testutil.WaitMedium),
+			func() { kicks++ },
+		)
 		resp, err := tool.Run(ctx, fantasy.ToolCall{
 			ID:    "call-1",
 			Name:  "execute",
@@ -1131,6 +1212,9 @@ func TestExecuteToolRecorder(t *testing.T) {
 		assert.Equal(t, "build failed", result.Output)
 		assert.Empty(t, result.BackgroundProcessID)
 		assert.Equal(t, chattool.ExecutionStatusExited, recorder.record("call-1").Status)
+		// The successful re-attach snapshot is an agent round-trip
+		// and must reset the attempt idle watchdog.
+		assert.Equal(t, 1, kicks)
 	})
 
 	t.Run("ReattachRunningPastDeadline", func(t *testing.T) {
@@ -3130,6 +3214,53 @@ func TestExecuteWaitRetriesEarlyServerReturn(t *testing.T) {
 	assert.True(t, result.Success)
 	assert.Equal(t, "done", result.Output)
 	assert.Equal(t, 3, calls)
+}
+
+// TestProcessOutputToolKicksKeepalivePerPoll asserts that a long
+// blocking wait resets the attempt idle watchdog on every
+// successful poll: the agent bounds each request well below the
+// requested wait, so waiting only for the final response would
+// trip the watchdog while the agent is demonstrably responsive.
+func TestProcessOutputToolKicksKeepalivePerPoll(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockConn := agentconnmock.NewMockAgentConn(ctrl)
+
+	exitCode := 0
+	calls := 0
+	mockConn.EXPECT().
+		ProcessOutput(gomock.Any(), "proc-1", gomock.Any()).
+		Times(3).
+		DoAndReturn(func(_ context.Context, _ string, _ *workspacesdk.ProcessOutputOptions) (workspacesdk.ProcessOutputResponse, error) {
+			calls++
+			if calls < 3 {
+				return workspacesdk.ProcessOutputResponse{Running: true, Output: "partial"}, nil
+			}
+			return workspacesdk.ProcessOutputResponse{Running: false, ExitCode: &exitCode, Output: "done"}, nil
+		})
+
+	tool := chattool.ProcessOutput(chattool.ProcessToolOptions{
+		GetWorkspaceConn: func(_ context.Context) (workspacesdk.AgentConn, error) {
+			return mockConn, nil
+		},
+	})
+	kicks := 0
+	ctx := chattool.WithAttemptKeepalive(
+		testutil.Context(t, testutil.WaitMedium),
+		func() { kicks++ },
+	)
+	resp, err := tool.Run(ctx, fantasy.ToolCall{
+		ID:    "call-1",
+		Name:  "process_output",
+		Input: `{"process_id":"proc-1","wait_timeout":"30s"}`,
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.IsError)
+	assert.Equal(t, 3, calls)
+	// Two in-loop kicks for the early running responses plus the
+	// final kick for the terminal response.
+	assert.Equal(t, 3, kicks)
 }
 
 func TestProcessOutputToolRejectsNegativeWaitTimeout(t *testing.T) {

--- a/coderd/x/chatd/chattool/keepalive.go
+++ b/coderd/x/chatd/chattool/keepalive.go
@@ -1,0 +1,31 @@
+package chattool
+
+import "context"
+
+// attemptKeepaliveKey carries the task attempt keepalive kick
+// function through tool execution contexts.
+type attemptKeepaliveKey struct{}
+
+// WithAttemptKeepalive returns a context carrying kick, a function
+// that resets the owning task attempt's idle watchdog. Only the
+// execute and process_output tools call KickAttemptKeepalive, after
+// each successful process-API round-trip, to signal that a
+// potentially long-running command is making progress. Other
+// workspace tools finish well within the idle window and
+// deliberately do not extend it.
+func WithAttemptKeepalive(ctx context.Context, kick func()) context.Context {
+	if kick == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, attemptKeepaliveKey{}, kick)
+}
+
+// KickAttemptKeepalive resets the task attempt idle watchdog carried
+// by ctx. It is a no-op when the context carries no keepalive or the
+// attempt already ended, so callers never need to guard the call.
+func KickAttemptKeepalive(ctx context.Context) {
+	kick, _ := ctx.Value(attemptKeepaliveKey{}).(func())
+	if kick != nil {
+		kick()
+	}
+}

--- a/coderd/x/chatd/internal/watchdog/watchdog.go
+++ b/coderd/x/chatd/internal/watchdog/watchdog.go
@@ -1,0 +1,97 @@
+// Package watchdog provides the settle-once cancellation timer
+// shared by chatd's stream-silence and task-attempt watchdogs.
+package watchdog
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/coder/quartz"
+)
+
+// Timer cancels an operation with a fixed cause when its window
+// elapses without a Reset. Exactly one outcome wins: the timer
+// fires and cancels the operation, or Disarm stops it. Reset and
+// a late fire are safe no-ops once either outcome has settled.
+type Timer struct {
+	mu      sync.Mutex
+	clock   quartz.Clock
+	timer   *quartz.Timer
+	cancel  context.CancelCauseFunc
+	cause   error
+	timeout time.Duration
+	tags    []string
+	// deadline is when the current window elapses; Reset moves it
+	// forward. A fire that observes now before the deadline is
+	// stale: a Reset re-armed the timer while the callback was
+	// waiting on mu, and the re-armed timer fires later.
+	deadline time.Time
+	settled  bool
+}
+
+// New arms a watchdog that calls cancel(cause) once timeout
+// elapses without a Reset. tags label the underlying quartz
+// timer so tests can trap it.
+func New(
+	clock quartz.Clock,
+	timeout time.Duration,
+	cancel context.CancelCauseFunc,
+	cause error,
+	tags ...string,
+) *Timer {
+	t := &Timer{
+		clock:    clock,
+		cancel:   cancel,
+		cause:    cause,
+		timeout:  timeout,
+		tags:     tags,
+		deadline: clock.Now().Add(timeout),
+	}
+	t.timer = clock.AfterFunc(timeout, t.onTimeout, tags...)
+	return t
+}
+
+func (t *Timer) settle() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.settled {
+		return false
+	}
+	t.settled = true
+	return true
+}
+
+func (t *Timer) onTimeout() {
+	t.mu.Lock()
+	if t.settled || t.clock.Now().Before(t.deadline) {
+		// Settled, or a Reset re-armed the timer while this
+		// callback waited on the lock; the re-armed timer owns
+		// the new deadline.
+		t.mu.Unlock()
+		return
+	}
+	t.settled = true
+	t.mu.Unlock()
+	t.cancel(t.cause)
+}
+
+// Reset restarts the window. It is a no-op once the timer fired
+// or Disarm was called.
+func (t *Timer) Reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.settled {
+		return
+	}
+	t.deadline = t.clock.Now().Add(t.timeout)
+	t.timer.Reset(t.timeout, t.tags...)
+}
+
+// Disarm stops the timer permanently.
+func (t *Timer) Disarm() {
+	if !t.settle() {
+		return
+	}
+	t.timer.Stop()
+}

--- a/coderd/x/chatd/internal/watchdog/watchdog_internal_test.go
+++ b/coderd/x/chatd/internal/watchdog/watchdog_internal_test.go
@@ -1,0 +1,118 @@
+package watchdog
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/quartz"
+)
+
+var errTestTimeout = xerrors.New("watchdog test timeout")
+
+func TestTimer_FiresWithCause(t *testing.T) {
+	t.Parallel()
+
+	clock := quartz.NewMock(t)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	_ = New(clock, time.Minute, cancel, errTestTimeout, "test-watchdog")
+	clock.Advance(time.Minute).MustWait(context.Background())
+	require.ErrorIs(t, context.Cause(ctx), errTestTimeout)
+}
+
+func TestTimer_ResetRestartsWindow(t *testing.T) {
+	t.Parallel()
+
+	clock := quartz.NewMock(t)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	timer := New(clock, time.Minute, cancel, errTestTimeout, "test-watchdog")
+	clock.Advance(30 * time.Second).MustWait(context.Background())
+	timer.Reset()
+	clock.Advance(59 * time.Second).MustWait(context.Background())
+	require.NoError(t, ctx.Err())
+	clock.Advance(time.Second).MustWait(context.Background())
+	require.ErrorIs(t, context.Cause(ctx), errTestTimeout)
+}
+
+func TestTimer_DisarmAndFireRace(t *testing.T) {
+	t.Parallel()
+
+	for range 128 {
+		var cancels atomic.Int32
+		timer := New(quartz.NewReal(), time.Hour, func(err error) {
+			if errors.Is(err, errTestTimeout) {
+				cancels.Add(1)
+			}
+		}, errTestTimeout)
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			<-start
+			timer.onTimeout()
+		}()
+
+		go func() {
+			defer wg.Done()
+			<-start
+			timer.Disarm()
+		}()
+
+		close(start)
+		wg.Wait()
+
+		timer.onTimeout()
+		timer.Disarm()
+
+		require.LessOrEqual(t, cancels.Load(), int32(1))
+	}
+}
+
+func TestTimer_DisarmPreservesCause(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	timer := New(quartz.NewReal(), time.Hour, cancel, errTestTimeout)
+	timer.Disarm()
+	// A late fire after Disarm must not cancel the context.
+	timer.onTimeout()
+	require.NoError(t, ctx.Err())
+	require.Nil(t, context.Cause(ctx))
+}
+
+func TestTimer_StaleFireAfterResetIsIgnored(t *testing.T) {
+	t.Parallel()
+
+	clock := quartz.NewMock(t)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	wd := New(clock, time.Minute, cancel, errTestTimeout, "test-watchdog")
+
+	// Simulate the boundary race: the timeout callback was
+	// dispatched but a Reset re-armed the timer before the
+	// callback acquired the lock. The stale fire must not settle
+	// or cancel; the re-armed window owns the outcome.
+	wd.Reset()
+	wd.onTimeout()
+	require.NoError(t, context.Cause(ctx))
+
+	// The re-armed window still fires when it truly elapses.
+	clock.Advance(time.Minute).MustWait(context.Background())
+	require.ErrorIs(t, context.Cause(ctx), errTestTimeout)
+}

--- a/coderd/x/chatd/subagent.go
+++ b/coderd/x/chatd/subagent.go
@@ -72,6 +72,15 @@ const (
 	subagentAwaitPollInterval  = 200 * time.Millisecond
 	subagentAwaitFallbackPoll  = 5 * time.Second
 	defaultSubagentWaitTimeout = 5 * time.Minute
+	// maxSubagentWaitTimeout caps a single wait_agent block. Without
+	// it, a model-supplied timeout could ride an attempt whose
+	// watchdog a concurrently progressing execute keeps kicking, far
+	// past the attempt idle window. It must stay clearly below
+	// defaultTaskTimeout: nothing kicks the idle watchdog while
+	// wait_agent blocks, so the resumable timeout result has to
+	// commit before the watchdog cancels the attempt. A timeout is
+	// not a failure; the model resumes with another wait_agent call.
+	maxSubagentWaitTimeout = 10 * time.Minute
 
 	defaultListAgentsLimit       = 10
 	maxListAgentsLimit           = 50
@@ -624,7 +633,8 @@ func (p *Server) subagentTools(
 			"Wait until a spawned child agent finishes its task. "+
 				"Returns the agent's response and status. A timeout is not "+
 				"a failure: the agent is still running. Call wait_agent again "+
-				"or use list_agents to check its status.",
+				"or use list_agents to check its status. timeout_seconds is "+
+				"capped at 10 minutes per call.",
 			func(ctx context.Context, args waitAgentArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
 				if currentChat == nil {
 					return fantasy.NewTextErrorResponse("subagent callbacks are not configured"), nil
@@ -1263,6 +1273,7 @@ func (p *Server) awaitSubagentCompletion(
 	if timeout <= 0 {
 		timeout = defaultSubagentWaitTimeout
 	}
+	timeout = min(timeout, maxSubagentWaitTimeout)
 	timer := p.clock.NewTimer(timeout, "chatd", "subagent_await")
 	defer timer.Stop()
 

--- a/coderd/x/chatd/subagent_internal_test.go
+++ b/coderd/x/chatd/subagent_internal_test.go
@@ -3755,6 +3755,41 @@ func TestAwaitSubagentCompletion(t *testing.T) {
 		assert.Contains(t, result.err.Error(), "timed out waiting for delegated subagent completion")
 	})
 
+	t.Run("TimeoutClamped", func(t *testing.T) {
+		t.Parallel()
+
+		db, ps := dbtestutil.NewDB(t)
+		mClock := quartz.NewMock(t)
+		server := newInternalTestServer(t, db, ps, chatprovider.ProviderAPIKeys{}, withInternalTestServerClock(mClock))
+		ctx := chatdTestContext(t)
+		user, org, model := seedInternalChatDeps(t, db)
+
+		parent, child := createParentChildChats(ctx, t, server, user, org, model)
+
+		timerTrap := mClock.Trap().NewTimer("chatd", "subagent_await")
+
+		awaitCtx, cancelAwait := context.WithCancel(ctx)
+		defer cancelAwait()
+		resultCh := make(chan error, 1)
+		go func() {
+			_, _, err := server.awaitSubagentCompletion(
+				awaitCtx, parent.ID, child.ID, 10*time.Hour,
+			)
+			resultCh <- err
+		}()
+
+		// An oversized model-supplied timeout is clamped to the
+		// per-call cap instead of blocking the attempt for hours.
+		call := timerTrap.MustWait(ctx)
+		assert.Equal(t, maxSubagentWaitTimeout, call.Duration)
+		call.MustRelease(ctx)
+		timerTrap.Close()
+
+		cancelAwait()
+		err := testutil.RequireReceive(ctx, t, resultCh)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
 	t.Run("ContextCanceled", func(t *testing.T) {
 		t.Parallel()
 

--- a/coderd/x/chatd/tasks.go
+++ b/coderd/x/chatd/tasks.go
@@ -20,6 +20,7 @@ import (
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatstate"
 	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
+	"github.com/coder/coder/v2/coderd/x/chatd/internal/watchdog"
 	"github.com/coder/coder/v2/coderd/x/chatd/messagepartbuffer"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
@@ -28,10 +29,16 @@ import (
 
 const (
 	postCommitWatchPublishTimeout = 10 * time.Second
-	// defaultTaskTimeout must exceed chatloop's stream-silence guard so
-	// silent provider streams fail through chat-specific retry handling
-	// before the runner retries the whole task.
+	// defaultTaskTimeout is the attempt idle window: how long an
+	// attempt may run without a keepalive kick before it is canceled.
+	// It must exceed chatloop's stream-silence guard so silent
+	// provider streams fail through chat-specific retry handling
+	// before the runner retries the whole task; streaming code never
+	// kicks the watchdog.
 	defaultTaskTimeout = 15 * time.Minute
+	// maxTaskAttemptDuration is the absolute cap on a single task
+	// attempt. It is never reset by keepalive kicks.
+	maxTaskAttemptDuration = 24 * time.Hour
 )
 
 var (
@@ -157,13 +164,20 @@ func runTaskWithRetry(
 	}
 }
 
+// taskAttemptContext bounds a single task attempt with two watchdogs:
+// a resettable idle window kicked by tools after successful agent
+// round-trips, and a non-resettable absolute cap.
 func taskAttemptContext(ctx context.Context, clock quartz.Clock, kind taskKind) (context.Context, func()) {
 	attemptCtx, cancelCause := context.WithCancelCause(ctx)
-	timer := clock.AfterFunc(defaultTaskTimeout, func() {
+	idle := watchdog.New(clock, defaultTaskTimeout, cancelCause, errTaskTimeout,
+		"chatworker", "task-timeout-"+string(kind))
+	capTimer := clock.AfterFunc(maxTaskAttemptDuration, func() {
 		cancelCause(errTaskTimeout)
-	}, "chatworker", "task-timeout-"+string(kind))
+	}, "chatworker", "task-attempt-cap-"+string(kind))
+	attemptCtx = chattool.WithAttemptKeepalive(attemptCtx, idle.Reset)
 	return attemptCtx, func() {
-		timer.Stop()
+		idle.Disarm()
+		capTimer.Stop()
 		cancelCause(nil)
 	}
 }

--- a/coderd/x/chatd/tasks_test.go
+++ b/coderd/x/chatd/tasks_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatretry"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatstate"
+	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
 	"github.com/coder/coder/v2/coderd/x/chatd/messagepartbuffer"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
@@ -197,6 +198,74 @@ func TestRetryWrapper_ContextCancellationDoesNotRetryOrLog(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, calls)
 	require.Empty(t, entriesWithMessage(sink, "chatworker task retrying"))
+}
+
+func TestTaskAttemptContext_KeepaliveExtendsIdleWindow(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	clock := quartz.NewMock(t)
+	attemptCtx, cancelAttempt := taskAttemptContext(ctx, clock, taskKindGeneration)
+	defer cancelAttempt()
+
+	// Each kick restarts the idle window, so the attempt outlives
+	// several multiples of defaultTaskTimeout.
+	for range 4 {
+		clock.Advance(defaultTaskTimeout - time.Minute).MustWait(ctx)
+		require.NoError(t, attemptCtx.Err())
+		chattool.KickAttemptKeepalive(attemptCtx)
+	}
+
+	// Without further kicks the idle window expires.
+	clock.Advance(defaultTaskTimeout).MustWait(ctx)
+	require.ErrorIs(t, context.Cause(attemptCtx), errTaskTimeout)
+
+	// Kicking after the timeout fired is a safe no-op.
+	chattool.KickAttemptKeepalive(attemptCtx)
+}
+
+func TestTaskAttemptContext_AbsoluteCapIgnoresKicks(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	clock := quartz.NewMock(t)
+	attemptCtx, cancelAttempt := taskAttemptContext(ctx, clock, taskKindGeneration)
+	defer cancelAttempt()
+
+	step := defaultTaskTimeout / 2
+	for elapsed := time.Duration(0); elapsed < maxTaskAttemptDuration; elapsed += step {
+		require.NoError(t, attemptCtx.Err())
+		clock.Advance(step).MustWait(ctx)
+		chattool.KickAttemptKeepalive(attemptCtx)
+	}
+	require.ErrorIs(t, context.Cause(attemptCtx), errTaskTimeout)
+}
+
+func TestTaskAttemptContext_NoKickTimesOutAtIdleWindow(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	clock := quartz.NewMock(t)
+	attemptCtx, cancelAttempt := taskAttemptContext(ctx, clock, taskKindGeneration)
+	defer cancelAttempt()
+
+	clock.Advance(defaultTaskTimeout - time.Second).MustWait(ctx)
+	require.NoError(t, attemptCtx.Err())
+	clock.Advance(time.Second).MustWait(ctx)
+	require.ErrorIs(t, context.Cause(attemptCtx), errTaskTimeout)
+}
+
+func TestTaskAttemptContext_KickAfterCancelIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	clock := quartz.NewMock(t)
+	attemptCtx, cancelAttempt := taskAttemptContext(ctx, clock, taskKindGeneration)
+	cancelAttempt()
+
+	chattool.KickAttemptKeepalive(attemptCtx)
+	require.ErrorIs(t, attemptCtx.Err(), context.Canceled)
+	require.NotErrorIs(t, context.Cause(attemptCtx), errTaskTimeout)
 }
 
 func TestNormalizeTaskErrors_ContextCancellationIsExpectedExit(t *testing.T) {


### PR DESCRIPTION
Keeps chat task attempts alive while execute tools make progress, so a long-running command does not trip the attempt watchdog.

Part 9/9 of the CODAGT-757 execution ledger stack (base: #08). Supersedes #27103; the combined stack covers its reviewed scope (minus an accidental workflow orchestration file) plus fixes from subsequent review rounds.

## Changes

- `internal/watchdog`: a small keepalive-kickable countdown used by the attempt loop.
- Execute and process-output tools kick the attempt keepalive on observable progress (dispatch, output, wait milestones), replacing the fixed attempt deadline for these tools.
- ARCHITECTURE.md scoped to reality: keepalive kicks exist in the execute/process_output paths, not all workspace tools.

> This PR was authored by Mux, an AI coding agent, on Mike's behalf. The stack recomposes the previously reviewed #27100/#27102/#27103 into reviewable pieces, plus fixes from subsequent review rounds.