### PR TITLE
feat(site): add touch clipboard controls to the web terminal

### DIFF
--- a/site/src/hooks/useIsTouchCapable.ts
+++ b/site/src/hooks/useIsTouchCapable.ts
@@ -1,0 +1,12 @@
+import { useSyncExternalStore } from "react";
+import { isTouchCapable, touchCapableMediaQuery } from "#/utils/mobile";
+
+const subscribeTouchCapability = (onStoreChange: () => void) => {
+	const mediaQuery = window.matchMedia(touchCapableMediaQuery);
+	mediaQuery.addEventListener("change", onStoreChange);
+	return () => mediaQuery.removeEventListener("change", onStoreChange);
+};
+
+export const useIsTouchCapable = (): boolean => {
+	return useSyncExternalStore(subscribeTouchCapability, isTouchCapable);
+};

--- a/site/src/modules/terminal/TerminalCopyDialog.tsx
+++ b/site/src/modules/terminal/TerminalCopyDialog.tsx
@@ -1,0 +1,72 @@
+import type { Terminal } from "@xterm/xterm";
+import { Button } from "#/components/Button/Button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "#/components/Dialog/Dialog";
+
+export const getVisibleTerminalText = (terminal: Terminal): string => {
+	const lines: string[] = [];
+	const firstLine = terminal.buffer.active.viewportY;
+	const lastLine = firstLine + terminal.rows;
+
+	for (let index = firstLine; index < lastLine; index++) {
+		lines.push(
+			terminal.buffer.active.getLine(index)?.translateToString(true) ?? "",
+		);
+	}
+
+	while (lines.at(-1) === "") {
+		lines.pop();
+	}
+
+	return lines.join("\n");
+};
+
+type TerminalCopyDialogProps = {
+	open: boolean;
+	text: string;
+	onOpenChange: (open: boolean) => void;
+	onCopy: () => void;
+	onClose: () => void;
+};
+
+export const TerminalCopyDialog = ({
+	open,
+	text,
+	onOpenChange,
+	onCopy,
+	onClose,
+}: TerminalCopyDialogProps) => {
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent
+				onCloseAutoFocus={(event) => {
+					event.preventDefault();
+					onClose();
+				}}
+			>
+				<DialogHeader>
+					<DialogTitle>Copy terminal output</DialogTitle>
+					<DialogDescription>
+						Select text below or copy all visible terminal output.
+					</DialogDescription>
+				</DialogHeader>
+				<textarea
+					aria-label="Visible terminal output"
+					className="min-h-64 w-full resize-y rounded-md border border-solid border-border-default bg-surface-secondary p-3 font-mono text-sm text-content-primary"
+					readOnly
+					spellCheck={false}
+					value={text}
+				/>
+				<DialogFooter>
+					<Button onClick={onCopy}>Copy</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/site/src/modules/terminal/TerminalCopyDialog.tsx
+++ b/site/src/modules/terminal/TerminalCopyDialog.tsx
@@ -13,11 +13,19 @@ export const getVisibleTerminalText = (terminal: Terminal): string => {
 	const lines: string[] = [];
 	const firstLine = terminal.buffer.active.viewportY;
 	const lastLine = firstLine + terminal.rows;
+	let currentLine = "";
 
 	for (let index = firstLine; index < lastLine; index++) {
-		lines.push(
-			terminal.buffer.active.getLine(index)?.translateToString(true) ?? "",
-		);
+		const wrapsToNextLine =
+			terminal.buffer.active.getLine(index + 1)?.isWrapped ?? false;
+		currentLine +=
+			terminal.buffer.active
+				.getLine(index)
+				?.translateToString(!wrapsToNextLine) ?? "";
+		if (!wrapsToNextLine || index === lastLine - 1) {
+			lines.push(currentLine);
+			currentLine = "";
+		}
 	}
 
 	while (lines.at(-1) === "") {

--- a/site/src/modules/terminal/WorkspaceTerminal.stories.tsx
+++ b/site/src/modules/terminal/WorkspaceTerminal.stories.tsx
@@ -4,7 +4,8 @@ import { withWebSocket } from "#/testHelpers/storybook";
 import { touchCapableMediaQuery } from "#/utils/mobile";
 import { WorkspaceTerminal } from "./WorkspaceTerminal";
 
-const visibleOutput = "Visible terminal output\r\nSecond line";
+const wrappedOutput = "Visible-terminal-output-".repeat(8);
+const visibleOutput = `${wrappedOutput}\r\nSecond line`;
 
 const setTouchCapability = (touchCapable: boolean) => {
 	const originalMatchMedia = window.matchMedia;
@@ -104,11 +105,11 @@ export const CopyVisibleOutput: Story = {
 		const output = await body.findByRole("textbox", {
 			name: "Visible terminal output",
 		});
-		expect(output).toHaveValue("Visible terminal output\nSecond line");
+		expect(output).toHaveValue(`${wrappedOutput}\nSecond line`);
 
 		await userEvent.click(body.getByRole("button", { name: "Copy" }));
 		expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-			"Visible terminal output\nSecond line",
+			`${wrappedOutput}\nSecond line`,
 		);
 	},
 };

--- a/site/src/modules/terminal/WorkspaceTerminal.stories.tsx
+++ b/site/src/modules/terminal/WorkspaceTerminal.stories.tsx
@@ -1,0 +1,126 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, spyOn, userEvent, waitFor, within } from "storybook/test";
+import { withWebSocket } from "#/testHelpers/storybook";
+import { touchCapableMediaQuery } from "#/utils/mobile";
+import { WorkspaceTerminal } from "./WorkspaceTerminal";
+
+const visibleOutput = "Visible terminal output\r\nSecond line";
+
+const setTouchCapability = (touchCapable: boolean) => {
+	const originalMatchMedia = window.matchMedia;
+	const originalMaxTouchPoints = Object.getOwnPropertyDescriptor(
+		navigator,
+		"maxTouchPoints",
+	);
+
+	window.matchMedia = (query: string): MediaQueryList => ({
+		matches: query === touchCapableMediaQuery ? touchCapable : false,
+		media: query,
+		onchange: null,
+		addEventListener: () => undefined,
+		removeEventListener: () => undefined,
+		addListener: () => undefined,
+		removeListener: () => undefined,
+		dispatchEvent: () => true,
+	});
+	Object.defineProperty(navigator, "maxTouchPoints", {
+		configurable: true,
+		value: touchCapable ? 1 : 0,
+	});
+
+	return () => {
+		window.matchMedia = originalMatchMedia;
+		if (originalMaxTouchPoints) {
+			Object.defineProperty(
+				navigator,
+				"maxTouchPoints",
+				originalMaxTouchPoints,
+			);
+		} else {
+			Reflect.deleteProperty(navigator, "maxTouchPoints");
+		}
+	};
+};
+
+const meta = {
+	title: "modules/terminal/WorkspaceTerminal",
+	component: WorkspaceTerminal,
+	args: {
+		agentId: "agent-id",
+		autoFocus: false,
+		reconnectionToken: "00000000-0000-4000-8000-000000000000",
+	},
+	parameters: {
+		layout: "centered",
+		pixel: { exclude: true },
+		webSocket: [],
+	},
+	decorators: [
+		withWebSocket,
+		(Story) => (
+			<div style={{ width: 640, height: 480 }}>
+				<Story />
+			</div>
+		),
+	],
+} satisfies Meta<typeof WorkspaceTerminal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const TouchClipboardToolbar: Story = {
+	beforeEach: () => setTouchCapability(true),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const toolbar = await canvas.findByRole("toolbar", {
+			name: "Terminal clipboard",
+		});
+
+		expect(within(toolbar).getByRole("button", { name: "Copy" })).toBeVisible();
+		expect(
+			within(toolbar).getByRole("button", { name: "Paste" }),
+		).toBeVisible();
+	},
+};
+
+export const CopyVisibleOutput: Story = {
+	args: {
+		onContentReady: fn(),
+	},
+	beforeEach: () => {
+		const restoreTouchCapability = setTouchCapability(true);
+		spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
+		return restoreTouchCapability;
+	},
+	parameters: {
+		webSocket: [{ event: "message", data: visibleOutput }],
+	},
+	play: async ({ args, canvasElement }) => {
+		const canvas = within(canvasElement);
+		await waitFor(() => expect(args.onContentReady).toHaveBeenCalled());
+		await userEvent.click(canvas.getByRole("button", { name: "Copy" }));
+
+		const body = within(document.body);
+		const output = await body.findByRole("textbox", {
+			name: "Visible terminal output",
+		});
+		expect(output).toHaveValue("Visible terminal output\nSecond line");
+
+		await userEvent.click(body.getByRole("button", { name: "Copy" }));
+		expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+			"Visible terminal output\nSecond line",
+		);
+	},
+};
+
+export const NonTouchClipboardToolbarHidden: Story = {
+	beforeEach: () => setTouchCapability(false),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await waitFor(() => {
+			expect(
+				canvas.queryByRole("toolbar", { name: "Terminal clipboard" }),
+			).not.toBeInTheDocument();
+		});
+	},
+};

--- a/site/src/modules/terminal/WorkspaceTerminal.tsx
+++ b/site/src/modules/terminal/WorkspaceTerminal.tsx
@@ -5,6 +5,7 @@ import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal } from "@xterm/xterm";
+import { ClipboardPasteIcon, CopyIcon } from "lucide-react";
 import {
 	type Ref,
 	useCallback,
@@ -22,6 +23,7 @@ import {
 	WebsocketBuilder,
 	WebsocketEvent,
 } from "websocket-ts";
+import { Button } from "#/components/Button/Button";
 import {
 	ContextMenu,
 	ContextMenuContent,
@@ -29,9 +31,15 @@ import {
 	ContextMenuTrigger,
 } from "#/components/ContextMenu/ContextMenu";
 import { useClipboard } from "#/hooks/useClipboard";
+import { useIsTouchCapable } from "#/hooks/useIsTouchCapable";
 import { cn } from "#/utils/cn";
+import { isCoarsePointerPrimary } from "#/utils/mobile";
 import { isMac } from "#/utils/platform";
 import { terminalWebsocketUrl } from "#/utils/terminal";
+import {
+	getVisibleTerminalText,
+	TerminalCopyDialog,
+} from "./TerminalCopyDialog";
 import type { ConnectionStatus } from "./types";
 
 export type WorkspaceTerminalHandle = {
@@ -107,6 +115,8 @@ export const WorkspaceTerminal = ({
 	});
 	const [terminal, setTerminal] = useState<Terminal>();
 	const { copyToClipboard, readFromClipboard } = useClipboard();
+	const isTouchCapable = useIsTouchCapable();
+	const [copyDialogText, setCopyDialogText] = useState<string>();
 
 	const [hasSelection, setHasSelection] = useState(false);
 	const handleContextMenuOpenChange = (open: boolean) => {
@@ -134,6 +144,24 @@ export const WorkspaceTerminal = ({
 			console.error(error);
 		} finally {
 			terminal.focus();
+		}
+	};
+
+	const copyFromToolbar = () => {
+		if (!terminal) {
+			return;
+		}
+		if (terminal.hasSelection()) {
+			void copyToClipboard(terminal.getSelection());
+			terminal.focus();
+			return;
+		}
+
+		setCopyDialogText(getVisibleTerminalText(terminal));
+	};
+	const copyVisibleTerminalText = () => {
+		if (copyDialogText !== undefined) {
+			void copyToClipboard(copyDialogText);
 		}
 	};
 
@@ -312,6 +340,9 @@ export const WorkspaceTerminal = ({
 		// selection APIs. Most web terminal users expect Ctrl+V or
 		// right-click paste anyway.
 		nextTerminal.onSelectionChange(() => {
+			if (isCoarsePointerPrimary()) {
+				return;
+			}
 			copySelection();
 		});
 
@@ -610,35 +641,70 @@ export const WorkspaceTerminal = ({
 					background-color: hsl(var(--surface-quaternary));
 				}
 			`}</style>
-			<ContextMenu onOpenChange={handleContextMenuOpenChange}>
-				<ContextMenuTrigger asChild disabled={isMac()}>
-					<div
-						className={cn(
-							"workspace-terminal h-full w-full flex-1 min-h-0 overflow-hidden bg-surface-tertiary",
-							className,
-						)}
-						ref={terminalWrapperRef}
-						data-terminal-scope={scopeId}
-						data-testid={testId}
-					/>
-				</ContextMenuTrigger>
-				<ContextMenuContent
-					onCloseAutoFocus={(event) => {
-						event.preventDefault();
-						terminal?.focus();
-					}}
-				>
-					<ContextMenuItem
-						disabled={!hasSelection}
-						onSelect={copyTerminalSelection}
+			<div
+				className={cn(
+					"relative h-full w-full flex-1 min-h-0 overflow-hidden bg-surface-tertiary",
+					className,
+				)}
+			>
+				<ContextMenu onOpenChange={handleContextMenuOpenChange}>
+					<ContextMenuTrigger asChild disabled={isMac()}>
+						<div
+							className="workspace-terminal h-full w-full"
+							ref={terminalWrapperRef}
+							data-terminal-scope={scopeId}
+							data-testid={testId}
+						/>
+					</ContextMenuTrigger>
+					<ContextMenuContent
+						onCloseAutoFocus={(event) => {
+							event.preventDefault();
+							terminal?.focus();
+						}}
 					>
-						Copy
-					</ContextMenuItem>
-					<ContextMenuItem onSelect={() => void pasteIntoTerminal()}>
-						Paste
-					</ContextMenuItem>
-				</ContextMenuContent>
-			</ContextMenu>
+						<ContextMenuItem
+							disabled={!hasSelection}
+							onSelect={copyTerminalSelection}
+						>
+							Copy
+						</ContextMenuItem>
+						<ContextMenuItem onSelect={() => void pasteIntoTerminal()}>
+							Paste
+						</ContextMenuItem>
+					</ContextMenuContent>
+				</ContextMenu>
+				{isTouchCapable && (
+					<div
+						aria-label="Terminal clipboard"
+						className="absolute right-2 top-2 z-10 flex gap-1 rounded-md bg-surface-primary/80 p-1 shadow-sm backdrop-blur-sm"
+						role="toolbar"
+					>
+						<Button variant="subtle" size="xs" onClick={copyFromToolbar}>
+							<CopyIcon />
+							Copy
+						</Button>
+						<Button
+							variant="subtle"
+							size="xs"
+							onClick={() => void pasteIntoTerminal()}
+						>
+							<ClipboardPasteIcon />
+							Paste
+						</Button>
+					</div>
+				)}
+			</div>
+			<TerminalCopyDialog
+				open={copyDialogText !== undefined}
+				text={copyDialogText ?? ""}
+				onOpenChange={(open) => {
+					if (!open) {
+						setCopyDialogText(undefined);
+					}
+				}}
+				onCopy={copyVisibleTerminalText}
+				onClose={() => terminal?.focus()}
+			/>
 		</>
 	);
 };

--- a/site/src/modules/terminal/WorkspaceTerminal.tsx
+++ b/site/src/modules/terminal/WorkspaceTerminal.tsx
@@ -332,7 +332,7 @@ export const WorkspaceTerminal = ({
 		});
 
 		// Desktop copy-on-select approximates X11 primary selection. Coarse-primary
-		// devices skip it because clipboard writes outside a tap gesture fail.
+		// devices skip it because mobile browsers can reject writes outside a tap.
 		nextTerminal.onSelectionChange(() => {
 			if (isCoarsePointerPrimary()) {
 				return;

--- a/site/src/modules/terminal/WorkspaceTerminal.tsx
+++ b/site/src/modules/terminal/WorkspaceTerminal.tsx
@@ -331,14 +331,8 @@ export const WorkspaceTerminal = ({
 			return true;
 		});
 
-		// Browsers don't support automatic copy to the X11 primary
-		// selection (highlighted text that can be pasted with
-		// middle-click). Instead, copy-on-select writes to the
-		// system clipboard. This means users can't middle-click
-		// paste in the terminal after selecting, but this tradeoff
-		// is necessary because web browsers don't expose primary
-		// selection APIs. Most web terminal users expect Ctrl+V or
-		// right-click paste anyway.
+		// Desktop copy-on-select approximates X11 primary selection. Coarse-primary
+		// devices skip it because clipboard writes outside a tap gesture fail.
 		nextTerminal.onSelectionChange(() => {
 			if (isCoarsePointerPrimary()) {
 				return;

--- a/site/src/utils/mobile.ts
+++ b/site/src/utils/mobile.ts
@@ -8,6 +8,20 @@ export const isMobileViewport = (): boolean => {
 	return window.matchMedia("(max-width: 639px)").matches;
 };
 
+export const touchCapableMediaQuery = "(any-pointer: coarse)";
+const coarsePointerPrimaryMediaQuery = "(pointer: coarse)";
+
+export const isTouchCapable = (): boolean => {
+	return (
+		window.matchMedia(touchCapableMediaQuery).matches ||
+		navigator.maxTouchPoints > 0
+	);
+};
+
+export const isCoarsePointerPrimary = (): boolean => {
+	return window.matchMedia(coarsePointerPrimaryMediaQuery).matches;
+};
+
 export const belowMdViewportMediaQuery = "(max-width: 767px)";
 
 /**


### PR DESCRIPTION
On iPhone Safari the web terminal (the `/agents` Terminal tab and the standalone `/terminal` page) has no working copy or paste: xterm.js offers no touch selection or long-press paste path (upstream xtermjs/xterm.js#3727), the only paste affordance is a right-click context menu that touch cannot open, and auto copy-on-select calls `navigator.clipboard.writeText` outside a user gesture, which iOS blocks.

Fixes CODAGT-477.

## Fix

- Add a small Copy/Paste toolbar overlaid on the terminal, shown only on touch-capable devices (`(any-pointer: coarse)` or `maxTouchPoints > 0`; capability-based, no UA sniffing since iPadOS masquerades as macOS).
- Paste taps the existing clipboard-read path, which invokes `navigator.clipboard.readText()` synchronously inside the tap handler, as iOS requires transient user activation with no async gap before the call.
- Copy copies the current xterm selection when one exists. Since released xterm.js cannot create touch selections on iPhone, Copy otherwise opens a dialog with the visible terminal output in a selectable read-only textarea (native long-press selection works there) plus a copy-all button.
- Skip copy-on-select when the primary pointer is coarse, so touch devices stop surfacing "Failed to copy" errors; desktops, including ones with touchscreens, keep it.

Desktop behavior (context menu, OSC 52, keybindings) is unchanged. Storybook interaction tests cover toolbar visibility gating, the copy dialog content, and clipboard writes; dogfood UAT validated paste into a live PTY and the dialog flow under emulated touch, with a desktop no-regression pass.

> This PR was authored by Mux, an AI coding agent, on Mike's behalf.
