### PR TITLE
fix(coderd/x/chatd): drop stale APIKeyID from CreateOptions test literal

### DIFF
--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -3591,16 +3591,16 @@ func TestResolveFallbackModelConfigID(t *testing.T) {
 		db, ps := dbtestutil.NewDB(t)
 		ctx := testutil.Context(t, testutil.WaitShort)
 
+		owner := dbgen.User(t, db, database.User{})
 		disabledProvider := newProvider(t, db, false)
 		model := newModelConfig(t, db, disabledProvider.ID, false)
 		server := newInternalTestServer(t, db, ps, chatprovider.ProviderAPIKeys{})
 
 		_, err := server.CreateChat(ctx, CreateOptions{
 			OrganizationID: uuid.New(),
-			OwnerID:        uuid.New(),
+			OwnerID:        owner.ID,
 			Title:          "provider disabled create",
 			ModelConfigID:  model.ID,
-			APIKeyID:       "test-api-key-id",
 			InitialUserContent: []codersdk.ChatMessagePart{
 				codersdk.ChatMessageText("hello"),
 			},


### PR DESCRIPTION
> Mux is working on behalf of Mike.

Closes coder/internal#1622 (ENG-3061).

## Problem

`main` is broken: the chatd test package fails to compile, taking down `lint`, `test-go-pg`, `test-go-pg-17`, and `test-go-race-pg`.

This was a semantic merge conflict between two individually green PRs:

- #27170 removed `APIKeyID` from `chatd.CreateOptions` (chatd now mints a synthetic gateway key from the chat owner).
- #27070 branched before that merge and added the `CreateChatProviderDisabledRejected` test, which sets `APIKeyID` in a `CreateOptions` literal. Its CI ran against the old base and passed.

Merged together: `unknown field APIKeyID in struct literal of type CreateOptions`.

## Fix

Two lines in the test:

- Drop the stale `APIKeyID` field from the `CreateOptions` literal.
- Create the chat owner with `dbgen.User` instead of a random `uuid.New()`. On current `main`, `CreateChat` resolves the owner's synthetic API key before the model-config recheck, so a nonexistent owner fails with `sql: no rows` instead of reaching the `ErrInvalidModelConfigID` assertion.

## Validation

- `go build ./...`
- `go test ./coderd/x/chatd/...` (full package, passes)
- pre-commit hooks (lint/go, lint/ts)
