### PR TITLE
feat(site/src): rewrite localhost URLs in agent chat tool cards and shell output

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -16,7 +16,6 @@ import {
 } from "react-query";
 import { useOutletContext, useParams } from "react-router";
 import { toast } from "sonner";
-import type { UrlTransform } from "streamdown";
 import {
 	type ChatPlanModeOrClear,
 	type CreateChatMessageRequestWithClearablePlanMode,
@@ -103,6 +102,7 @@ import {
 	saveMCPSelection,
 } from "./components/MCPServerPicker";
 import { getModelSelectorHelp } from "./components/ModelSelectorHelp";
+import type { ChatUrlTransform } from "./context/ChatUrlTransformContext";
 import { useGitWatcher } from "./hooks/useGitWatcher";
 import { getAgentChatSendShortcut } from "./utils/agentChatSendShortcut";
 import { type ParsedDraft, parseStoredDraft } from "./utils/draftStorage";
@@ -1546,7 +1546,7 @@ const AgentChatPage: FC = () => {
 	const agentName = workspaceAgent?.name;
 	const wsName = workspace?.name;
 	const wsOwner = workspace?.owner_name;
-	const urlTransform: UrlTransform = (url) => {
+	const urlTransform: ChatUrlTransform = (url) => {
 		if (!proxyHost || !agentName || !wsName || !wsOwner) {
 			return url;
 		}

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -15,7 +15,6 @@ import {
 } from "react-query";
 import { useOutletContext, useParams } from "react-router";
 import { toast } from "sonner";
-import type { UrlTransform } from "streamdown";
 import {
 	type ChatPlanModeOrClear,
 	type CreateChatMessageRequestWithClearablePlanMode,
@@ -92,6 +91,7 @@ import {
 	saveMCPSelection,
 } from "./components/MCPServerPicker";
 import { getModelSelectorHelp } from "./components/ModelSelectorHelp";
+import type { ChatUrlTransform } from "./context/ChatUrlTransformContext";
 import { useGitWatcher } from "./hooks/useGitWatcher";
 import { getAgentChatSendShortcut } from "./utils/agentChatSendShortcut";
 import { type ParsedDraft, parseStoredDraft } from "./utils/draftStorage";
@@ -1381,7 +1381,7 @@ const AgentChatPage: FC = () => {
 	const agentName = workspaceAgent?.name;
 	const wsName = workspace?.name;
 	const wsOwner = workspace?.owner_name;
-	const urlTransform: UrlTransform = (url) => {
+	const urlTransform: ChatUrlTransform = (url) => {
 		if (!proxyHost || !agentName || !wsName || !wsOwner) {
 			return url;
 		}

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -9,7 +9,6 @@ import {
 	useState,
 } from "react";
 import { useQueryClient } from "react-query";
-import type { UrlTransform } from "streamdown";
 import { v4 as uuidv4 } from "uuid";
 import { invalidateChatDiffContents } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
@@ -57,6 +56,10 @@ import { RightPanel } from "./components/RightPanel/RightPanel";
 import { RightPanelAddTabControl } from "./components/RightPanel/RightPanelAddTabControl";
 import { getWorkspaceStatus, StatusIcon } from "./components/StatusIcon";
 import { TerminalPanel } from "./components/TerminalPanel";
+import {
+	type ChatUrlTransform,
+	ChatUrlTransformContext,
+} from "./context/ChatUrlTransformContext";
 import { ChatWorkspaceContext } from "./context/ChatWorkspaceContext";
 import { chatWidthClass, useChatFullWidth } from "./hooks/useChatFullWidth";
 import {
@@ -215,7 +218,7 @@ interface AgentChatPageViewProps {
 	onFetchMoreMessages: () => void;
 	messageCount: number;
 
-	urlTransform?: UrlTransform;
+	urlTransform?: ChatUrlTransform;
 
 	// MCP server state.
 	mcpServers: readonly TypesGen.MCPServerConfig[];
@@ -924,26 +927,27 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 							messageCount={messageCount}
 						>
 							<div className="px-4" data-chat-scroll-content>
-								<ChatPageTimeline
-									store={store}
-									persistedError={persistedError}
-									onEditUserMessage={
-										isOtherUserReadOnly
-											? undefined
-											: editing.handleEditUserMessage
-									}
-									editingMessageId={editing.editingMessageId}
-									urlTransform={urlTransform}
-									mcpServers={mcpServers}
-									onImplementPlan={
-										isOtherUserReadOnly ? undefined : onImplementPlan
-									}
-									onSendAskUserQuestionResponse={
-										isOtherUserReadOnly
-											? undefined
-											: canSendAskUserQuestionResponse
-									}
-								/>
+								<ChatUrlTransformContext value={urlTransform}>
+									<ChatPageTimeline
+										store={store}
+										persistedError={persistedError}
+										onEditUserMessage={
+											isOtherUserReadOnly
+												? undefined
+												: editing.handleEditUserMessage
+										}
+										editingMessageId={editing.editingMessageId}
+										mcpServers={mcpServers}
+										onImplementPlan={
+											isOtherUserReadOnly ? undefined : onImplementPlan
+										}
+										onSendAskUserQuestionResponse={
+											isOtherUserReadOnly
+												? undefined
+												: canSendAskUserQuestionResponse
+										}
+									/>
+								</ChatUrlTransformContext>
 							</div>
 						</ChatScrollContainer>
 						<div className="shrink-0 overflow-y-auto px-4 pb-3 md:pb-0 [scrollbar-gutter:stable] [scrollbar-width:thin]">

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -9,7 +9,6 @@ import {
 	useState,
 } from "react";
 import { useQueryClient } from "react-query";
-import type { UrlTransform } from "streamdown";
 import { v4 as uuidv4 } from "uuid";
 import { chatDiffContentsKey } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
@@ -52,6 +51,10 @@ import { RightPanel } from "./components/RightPanel/RightPanel";
 import { RightPanelAddTabControl } from "./components/RightPanel/RightPanelAddTabControl";
 import { getWorkspaceStatus, StatusIcon } from "./components/StatusIcon";
 import { TerminalPanel } from "./components/TerminalPanel";
+import {
+	type ChatUrlTransform,
+	ChatUrlTransformContext,
+} from "./context/ChatUrlTransformContext";
 import { ChatWorkspaceContext } from "./context/ChatWorkspaceContext";
 import { chatWidthClass, useChatFullWidth } from "./hooks/useChatFullWidth";
 import {
@@ -211,7 +214,7 @@ interface AgentChatPageViewProps {
 	onFetchMoreMessages: () => void;
 	messageCount: number;
 
-	urlTransform?: UrlTransform;
+	urlTransform?: ChatUrlTransform;
 
 	// MCP server state.
 	mcpServers: readonly TypesGen.MCPServerConfig[];
@@ -811,215 +814,220 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 		<ChatWorkspaceContext
 			value={{ workspaceId: workspace?.id, buildId: chatBuildId }}
 		>
-			<DesktopPanelContext value={desktopPanelCtx}>
-				<div
-					className={cn(
-						"relative flex min-h-0 min-w-0 flex-1 sm:[--agents-chat-panel-min-width:360px]",
-						shouldShowSidebar && !visualExpanded && "flex-row",
-					)}
-				>
-					{titleElement}
+			<ChatUrlTransformContext value={urlTransform}>
+				<DesktopPanelContext value={desktopPanelCtx}>
 					<div
-						data-testid="agents-chat-panel"
 						className={cn(
-							"relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden sm:min-w-[var(--agents-chat-panel-min-width,0px)]",
-							visualExpanded && "hidden",
-							shouldShowSidebar && "max-lg:hidden",
+							"relative flex min-h-0 min-w-0 flex-1 sm:[--agents-chat-panel-min-width:360px]",
+							shouldShowSidebar && !visualExpanded && "flex-row",
 						)}
 					>
-						<div className="relative z-10 shrink-0 overflow-visible">
-							{" "}
-							<ChatTopBar
-								chatTitle={chatTitle}
-								parentChat={parentChat}
-								panel={{
-									showSidebarPanel,
-									onToggleSidebar: () => onSetShowSidebarPanel((prev) => !prev),
-								}}
-								onArchiveAgent={handleArchiveAgentAction}
-								onUnarchiveAgent={handleUnarchiveAgentAction}
-								onArchiveAndDeleteWorkspace={
-									handleArchiveAndDeleteWorkspaceAction
-								}
-								onPinAgent={handlePinAgentAction}
-								onUnpinAgent={handleUnpinAgentAction}
-								onOpenRenameDialog={handleOpenRenameDialogAction}
-								isPinned={isPinned}
-								isChildChat={isChildChat}
-								isArchiving={isArchivingThisChat}
-								hasWorkspace={Boolean(workspace)}
-								isArchived={isArchived}
-								diffStatusData={diffStatusData}
-								isSharedChat={isSharedChat}
-								isSidebarCollapsed={isSidebarCollapsed}
-								onToggleSidebarCollapsed={onToggleSidebarCollapsed}
-								renderChatSharingContent={
-									canOpenChatSharing
-										? (open) => (
-												<ChatSharingPopoverContent
-													chatId={agentId}
-													organizationId={organizationId}
-													open={open}
-												/>
-											)
-										: undefined
-								}
-							/>
-							{chatOwnerWarning && (
-								<div
-									role="status"
-									aria-live="polite"
-									className="flex shrink-0 items-center gap-2 border-b border-border-warning bg-surface-orange px-4 py-2 text-xs text-content-primary"
-								>
-									<TriangleAlertIcon className="size-4 shrink-0 text-content-warning" />
-									{chatOwnerWarning}
-								</div>
+						{titleElement}
+						<div
+							data-testid="agents-chat-panel"
+							className={cn(
+								"relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden sm:min-w-[var(--agents-chat-panel-min-width,0px)]",
+								visualExpanded && "hidden",
+								shouldShowSidebar && "max-lg:hidden",
 							)}
-							{isArchived && (
-								<div className="flex shrink-0 items-center gap-2 border-b border-border-default bg-surface-secondary px-4 py-2 text-xs text-content-secondary">
-									<ArchiveIcon className="size-4 shrink-0" />
-									This agent has been archived and is read-only.
-								</div>
-							)}
-							<div
-								aria-hidden
-								className="pointer-events-none absolute inset-x-0 top-full z-10 h-3 sm:h-6 bg-surface-primary"
-								style={{
-									maskImage:
-										"linear-gradient(to bottom, black 0%, rgba(0,0,0,0.6) 40%, rgba(0,0,0,0.2) 70%, transparent 100%)",
-									WebkitMaskImage:
-										"linear-gradient(to bottom, black 0%, rgba(0,0,0,0.6) 40%, rgba(0,0,0,0.2) 70%, transparent 100%)",
-								}}
-							/>
-						</div>
-						<ChatScrollContainer
-							key={agentId}
-							scrollContainerRef={scrollContainerRef}
-							scrollToBottomRef={effectiveScrollToBottomRef}
-							isFetchingMoreMessages={isFetchingMoreMessages}
-							hasMoreMessages={hasMoreMessages}
-							onFetchMoreMessages={onFetchMoreMessages}
-							messageCount={messageCount}
 						>
-							<div className="px-4" data-chat-scroll-content>
-								<ChatPageTimeline
-									store={store}
-									persistedError={persistedError}
-									onEditUserMessage={
-										isOtherUserReadOnly
-											? undefined
-											: editing.handleEditUserMessage
+							<div className="relative z-10 shrink-0 overflow-visible">
+								{" "}
+								<ChatTopBar
+									chatTitle={chatTitle}
+									parentChat={parentChat}
+									panel={{
+										showSidebarPanel,
+										onToggleSidebar: () =>
+											onSetShowSidebarPanel((prev) => !prev),
+									}}
+									onArchiveAgent={handleArchiveAgentAction}
+									onUnarchiveAgent={handleUnarchiveAgentAction}
+									onArchiveAndDeleteWorkspace={
+										handleArchiveAndDeleteWorkspaceAction
 									}
-									editingMessageId={editing.editingMessageId}
-									urlTransform={urlTransform}
-									mcpServers={mcpServers}
-									onImplementPlan={
-										isOtherUserReadOnly ? undefined : onImplementPlan
+									onPinAgent={handlePinAgentAction}
+									onUnpinAgent={handleUnpinAgentAction}
+									onOpenRenameDialog={handleOpenRenameDialogAction}
+									isPinned={isPinned}
+									isChildChat={isChildChat}
+									isArchiving={isArchivingThisChat}
+									hasWorkspace={Boolean(workspace)}
+									isArchived={isArchived}
+									diffStatusData={diffStatusData}
+									isSharedChat={isSharedChat}
+									isSidebarCollapsed={isSidebarCollapsed}
+									onToggleSidebarCollapsed={onToggleSidebarCollapsed}
+									renderChatSharingContent={
+										canOpenChatSharing
+											? (open) => (
+													<ChatSharingPopoverContent
+														chatId={agentId}
+														organizationId={organizationId}
+														open={open}
+													/>
+												)
+											: undefined
 									}
-									onSendAskUserQuestionResponse={
-										isOtherUserReadOnly
-											? undefined
-											: canSendAskUserQuestionResponse
-									}
+								/>
+								{chatOwnerWarning && (
+									<div
+										role="status"
+										aria-live="polite"
+										className="flex shrink-0 items-center gap-2 border-b border-border-warning bg-surface-orange px-4 py-2 text-xs text-content-primary"
+									>
+										<TriangleAlertIcon className="size-4 shrink-0 text-content-warning" />
+										{chatOwnerWarning}
+									</div>
+								)}
+								{isArchived && (
+									<div className="flex shrink-0 items-center gap-2 border-b border-border-default bg-surface-secondary px-4 py-2 text-xs text-content-secondary">
+										<ArchiveIcon className="size-4 shrink-0" />
+										This agent has been archived and is read-only.
+									</div>
+								)}
+								<div
+									aria-hidden
+									className="pointer-events-none absolute inset-x-0 top-full z-10 h-3 sm:h-6 bg-surface-primary"
+									style={{
+										maskImage:
+											"linear-gradient(to bottom, black 0%, rgba(0,0,0,0.6) 40%, rgba(0,0,0,0.2) 70%, transparent 100%)",
+										WebkitMaskImage:
+											"linear-gradient(to bottom, black 0%, rgba(0,0,0,0.6) 40%, rgba(0,0,0,0.2) 70%, transparent 100%)",
+									}}
 								/>
 							</div>
-						</ChatScrollContainer>
-						<div className="shrink-0 overflow-y-auto px-4 pb-3 md:pb-0 [scrollbar-gutter:stable] [scrollbar-width:thin]">
-							<ChatPageInput
-								organizationId={organizationId}
-								sendShortcut={sendShortcut}
-								store={store}
-								compressionThreshold={compressionThreshold}
-								onSend={editing.handleSendFromInput}
-								onDeleteQueuedMessage={handleDeleteQueuedMessage}
-								onPromoteQueuedMessage={handlePromoteQueuedMessage}
-								onInterrupt={handleInterrupt}
-								isInputDisabled={isInputDisabled}
-								isSendPending={isSubmissionPending}
-								isInterruptPending={isInterruptPending}
-								hasModelOptions={hasModelOptions}
-								canConfigureAgentSetup={canConfigureAgentSetup}
-								providerCount={providerCount}
-								modelCount={modelCount}
-								unsupportedProviderNames={unsupportedProviderNames}
-								aiGatewayDisabled={aiGatewayDisabled}
-								selectedModel={effectiveSelectedModel}
-								onModelChange={setSelectedModel}
-								modelOptions={modelOptions}
-								modelSelectorPlaceholder={modelSelectorPlaceholder}
-								modelSelectorHelp={modelSelectorHelp}
-								reasoningEffort={reasoningEffort}
-								onReasoningEffortChange={onReasoningEffortChange}
-								planModeEnabled={planModeEnabled}
-								onPlanModeToggle={onPlanModeToggle}
-								isModelCatalogLoading={isModelCatalogLoading}
-								workspaceOptions={workspaceOptions}
-								chatOrganizationId={organizationId}
-								selectedWorkspaceId={selectedWorkspaceId}
-								onWorkspaceChange={onWorkspaceChange}
-								isWorkspaceLoading={isWorkspaceLoading}
-								inputRef={editing.chatInputRef}
-								initialValue={editing.editorInitialValue}
-								initialEditorState={editing.initialEditorState}
-								remountKey={editing.remountKey}
-								onContentChange={editing.handleContentChange}
-								isEditing={isEditing}
-								editingQueuedMessageID={editing.editingQueuedMessageID}
-								onStartQueueEdit={editing.handleStartQueueEdit}
-								onCancelQueueEdit={editing.handleCancelQueueEdit}
-								isEditingHistoryMessage={editing.editingMessageId !== null}
-								onCancelHistoryEdit={editing.handleCancelHistoryEdit}
-								editingFileBlocks={editing.editingFileBlocks}
-								mcpServers={mcpServers}
-								selectedMCPServerIds={selectedMCPServerIds}
-								onMCPSelectionChange={onMCPSelectionChange}
-								onMCPAuthComplete={onMCPAuthComplete}
-								chatContext={chatContext}
-								workspaceSkills={workspaceSkills}
-								workspace={workspace}
-								workspaceAgent={workspaceAgent}
-								chatId={agentId}
-								sshCommand={sshCommand}
-								attachedWorkspace={attachedWorkspace}
-								folder={preferredFolder}
-							/>
-						</div>
-					</div>
-					<RightPanel
-						isOpen={shouldShowSidebar}
-						isExpanded={isRightPanelExpanded}
-						onToggleExpanded={() => setIsRightPanelExpanded((prev) => !prev)}
-						onClose={() => onSetShowSidebarPanel(false)}
-						onVisualExpandedChange={setDragVisualExpanded}
-						isSidebarCollapsed={isSidebarCollapsed}
-						onToggleSidebarCollapsed={onToggleSidebarCollapsed}
-					>
-						<SidebarTabView
-							effectiveTabId={effectiveSidebarTabId}
-							onActiveTabChange={handleActiveTabChange}
-							tabs={sidebarTabs}
-							addTabControl={
-								<RightPanelAddTabControl
+							<ChatScrollContainer
+								key={agentId}
+								scrollContainerRef={scrollContainerRef}
+								scrollToBottomRef={effectiveScrollToBottomRef}
+								isFetchingMoreMessages={isFetchingMoreMessages}
+								hasMoreMessages={hasMoreMessages}
+								onFetchMoreMessages={onFetchMoreMessages}
+								messageCount={messageCount}
+							>
+								<div className="px-4" data-chat-scroll-content>
+									<ChatPageTimeline
+										store={store}
+										persistedError={persistedError}
+										onEditUserMessage={
+											isOtherUserReadOnly
+												? undefined
+												: editing.handleEditUserMessage
+										}
+										editingMessageId={editing.editingMessageId}
+										urlTransform={urlTransform}
+										mcpServers={mcpServers}
+										onImplementPlan={
+											isOtherUserReadOnly ? undefined : onImplementPlan
+										}
+										onSendAskUserQuestionResponse={
+											isOtherUserReadOnly
+												? undefined
+												: canSendAskUserQuestionResponse
+										}
+									/>
+								</div>
+							</ChatScrollContainer>
+							<div className="shrink-0 overflow-y-auto px-4 pb-3 md:pb-0 [scrollbar-gutter:stable] [scrollbar-width:thin]">
+								<ChatPageInput
+									organizationId={organizationId}
+									sendShortcut={sendShortcut}
+									store={store}
+									compressionThreshold={compressionThreshold}
+									onSend={editing.handleSendFromInput}
+									onDeleteQueuedMessage={handleDeleteQueuedMessage}
+									onPromoteQueuedMessage={handlePromoteQueuedMessage}
+									onInterrupt={handleInterrupt}
+									isInputDisabled={isInputDisabled}
+									isSendPending={isSubmissionPending}
+									isInterruptPending={isInterruptPending}
+									hasModelOptions={hasModelOptions}
+									canConfigureAgentSetup={canConfigureAgentSetup}
+									providerCount={providerCount}
+									modelCount={modelCount}
+									unsupportedProviderNames={unsupportedProviderNames}
+									aiGatewayDisabled={aiGatewayDisabled}
+									selectedModel={effectiveSelectedModel}
+									onModelChange={setSelectedModel}
+									modelOptions={modelOptions}
+									modelSelectorPlaceholder={modelSelectorPlaceholder}
+									modelSelectorHelp={modelSelectorHelp}
+									reasoningEffort={reasoningEffort}
+									onReasoningEffortChange={onReasoningEffortChange}
+									planModeEnabled={planModeEnabled}
+									onPlanModeToggle={onPlanModeToggle}
+									isModelCatalogLoading={isModelCatalogLoading}
+									workspaceOptions={workspaceOptions}
+									chatOrganizationId={organizationId}
+									selectedWorkspaceId={selectedWorkspaceId}
+									onWorkspaceChange={onWorkspaceChange}
+									isWorkspaceLoading={isWorkspaceLoading}
+									inputRef={editing.chatInputRef}
+									initialValue={editing.editorInitialValue}
+									initialEditorState={editing.initialEditorState}
+									remountKey={editing.remountKey}
+									onContentChange={editing.handleContentChange}
+									isEditing={isEditing}
+									editingQueuedMessageID={editing.editingQueuedMessageID}
+									onStartQueueEdit={editing.handleStartQueueEdit}
+									onCancelQueueEdit={editing.handleCancelQueueEdit}
+									isEditingHistoryMessage={editing.editingMessageId !== null}
+									onCancelHistoryEdit={editing.handleCancelHistoryEdit}
+									editingFileBlocks={editing.editingFileBlocks}
+									mcpServers={mcpServers}
+									selectedMCPServerIds={selectedMCPServerIds}
+									onMCPSelectionChange={onMCPSelectionChange}
+									onMCPAuthComplete={onMCPAuthComplete}
+									chatContext={chatContext}
+									workspaceSkills={workspaceSkills}
 									workspace={workspace}
-									agent={workspaceAgent}
-									host={wildcardHostname}
-									isRunning={workspace?.latest_build.status === "running"}
-									onNewTerminal={handleAddTerminalTab}
-									onOpenWorkspaceApp={handleOpenWorkspaceAppTab}
-									onOpenCommandApp={handleOpenCommandAppTab}
-									onOpenPort={handleOpenPortTab}
+									workspaceAgent={workspaceAgent}
+									chatId={agentId}
+									sshCommand={sshCommand}
+									attachedWorkspace={attachedWorkspace}
+									folder={preferredFolder}
 								/>
-							}
-							onClose={() => onSetShowSidebarPanel(false)}
-							isExpanded={visualExpanded}
+							</div>
+						</div>
+						<RightPanel
+							isOpen={shouldShowSidebar}
+							isExpanded={isRightPanelExpanded}
 							onToggleExpanded={() => setIsRightPanelExpanded((prev) => !prev)}
+							onClose={() => onSetShowSidebarPanel(false)}
+							onVisualExpandedChange={setDragVisualExpanded}
 							isSidebarCollapsed={isSidebarCollapsed}
 							onToggleSidebarCollapsed={onToggleSidebarCollapsed}
-							chatTitle={chatTitle}
-						/>
-					</RightPanel>
-				</div>
-			</DesktopPanelContext>
+						>
+							<SidebarTabView
+								effectiveTabId={effectiveSidebarTabId}
+								onActiveTabChange={handleActiveTabChange}
+								tabs={sidebarTabs}
+								addTabControl={
+									<RightPanelAddTabControl
+										workspace={workspace}
+										agent={workspaceAgent}
+										host={wildcardHostname}
+										isRunning={workspace?.latest_build.status === "running"}
+										onNewTerminal={handleAddTerminalTab}
+										onOpenWorkspaceApp={handleOpenWorkspaceAppTab}
+										onOpenCommandApp={handleOpenCommandAppTab}
+										onOpenPort={handleOpenPortTab}
+									/>
+								}
+								onClose={() => onSetShowSidebarPanel(false)}
+								isExpanded={visualExpanded}
+								onToggleExpanded={() =>
+									setIsRightPanelExpanded((prev) => !prev)
+								}
+								isSidebarCollapsed={isSidebarCollapsed}
+								onToggleSidebarCollapsed={onToggleSidebarCollapsed}
+								chatTitle={chatTitle}
+							/>
+						</RightPanel>
+					</div>
+				</DesktopPanelContext>
+			</ChatUrlTransformContext>
 		</ChatWorkspaceContext>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -10,6 +10,7 @@ import {
 	within,
 } from "storybook/test";
 import type * as TypesGen from "#/api/typesGenerated";
+import { ChatUrlTransformContext } from "../../context/ChatUrlTransformContext";
 import { getChatFileURL } from "../../utils/chatAttachments";
 import { encodeInlineTextAttachment } from "../../utils/fetchTextAttachment";
 import { ConversationTimeline } from "./ConversationTimeline";
@@ -466,10 +467,19 @@ export const SystemMessageWithoutHookNotice: Story = {
 };
 
 export const LifecycleHookNoticeOnUserMessage: Story = {
+	decorators: [
+		(Story) => (
+			<ChatUrlTransformContext
+				value={(url) =>
+					url.replace("http://localhost:3000", "https://proxy.example.com")
+				}
+			>
+				<Story />
+			</ChatUrlTransformContext>
+		),
+	],
 	args: {
 		...defaultArgs,
-		urlTransform: (url) =>
-			url.replace("http://localhost:3000", "https://proxy.example.com"),
 		parsedMessages: buildMessages([
 			{
 				...baseMessage,

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -15,11 +15,9 @@ import {
 } from "react";
 
 import { useQuery } from "react-query";
-import type { UrlTransform } from "streamdown";
 import { preferenceSettings } from "#/api/queries/users";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ThinkingDisplayMode } from "#/api/typesGenerated";
-
 import { AlertTitle } from "#/components/Alert/Alert";
 import { Button } from "#/components/Button/Button";
 import { CopyButton } from "#/components/CopyButton/CopyButton";
@@ -89,112 +87,94 @@ const ReasoningDisclosure = memo<{
 	id: string;
 	text: string;
 	isStreaming?: boolean;
-	urlTransform?: UrlTransform;
 	thinkingDisplayMode?: ThinkingDisplayMode;
-}>(
-	({
-		id,
-		text,
-		isStreaming = false,
-		urlTransform,
-		thinkingDisplayMode: mode = "auto",
-	}) => {
-		const [manualToggle, setManualToggle] = useState<boolean | null>(null);
+}>(({ id, text, isStreaming = false, thinkingDisplayMode: mode = "auto" }) => {
+	const [manualToggle, setManualToggle] = useState<boolean | null>(null);
 
-		// Reset manual override on streaming transitions so
-		// auto/preview modes collapse when streaming stops.
-		const [prevStreaming, setPrevStreaming] = useState(isStreaming);
-		if (prevStreaming !== isStreaming) {
-			setPrevStreaming(isStreaming);
-			if (mode === "auto" || mode === "preview") {
-				setManualToggle(null);
+	// Reset manual override on streaming transitions so
+	// auto/preview modes collapse when streaming stops.
+	const [prevStreaming, setPrevStreaming] = useState(isStreaming);
+	if (prevStreaming !== isStreaming) {
+		setPrevStreaming(isStreaming);
+		if (mode === "auto" || mode === "preview") {
+			setManualToggle(null);
+		}
+	}
+
+	const autoExpanded = (() => {
+		switch (mode) {
+			case "always_expanded":
+				return true;
+			case "always_collapsed":
+				return false;
+			case "auto":
+			case "preview":
+				return isStreaming;
+			default: {
+				const _exhaustive: never = mode;
+				return _exhaustive;
 			}
 		}
+	})();
 
-		const autoExpanded = (() => {
-			switch (mode) {
-				case "always_expanded":
-					return true;
-				case "always_collapsed":
-					return false;
-				case "auto":
-				case "preview":
-					return isStreaming;
-				default: {
-					const _exhaustive: never = mode;
-					return _exhaustive;
-				}
-			}
-		})();
+	const expanded = manualToggle ?? autoExpanded;
 
-		const expanded = manualToggle ?? autoExpanded;
+	const isPreviewConstrained =
+		mode === "preview" && isStreaming && manualToggle === null;
 
-		const isPreviewConstrained =
-			mode === "preview" && isStreaming && manualToggle === null;
+	const previewScrollRef = useRef<HTMLDivElement>(null);
 
-		const previewScrollRef = useRef<HTMLDivElement>(null);
+	const { visibleText } = useSmoothStreamingText({
+		fullText: text,
+		isStreaming,
+		bypassSmoothing: !isStreaming,
+		streamKey: id,
+	});
+	const displayText = isStreaming ? visibleText : text;
+	const { title, body } = getThinkingDisclosureDisplay(displayText);
+	const hasText = body.trim().length > 0;
 
-		const { visibleText } = useSmoothStreamingText({
-			fullText: text,
-			isStreaming,
-			bypassSmoothing: !isStreaming,
-			streamKey: id,
-		});
-		const displayText = isStreaming ? visibleText : text;
-		const { title, body } = getThinkingDisclosureDisplay(displayText);
-		const hasText = body.trim().length > 0;
+	// Auto-scroll the preview container to the bottom as new
+	// thinking content streams in. useLayoutEffect avoids a
+	// visible frame where content has grown but not scrolled.
+	const displayTextLength = body.length;
+	useLayoutEffect(() => {
+		if (displayTextLength && isPreviewConstrained && previewScrollRef.current) {
+			previewScrollRef.current.scrollTop =
+				previewScrollRef.current.scrollHeight;
+		}
+	}, [displayTextLength, isPreviewConstrained]);
 
-		// Auto-scroll the preview container to the bottom as new
-		// thinking content streams in. useLayoutEffect avoids a
-		// visible frame where content has grown but not scrolled.
-		const displayTextLength = body.length;
-		useLayoutEffect(() => {
-			if (
-				displayTextLength &&
-				isPreviewConstrained &&
-				previewScrollRef.current
-			) {
-				previewScrollRef.current.scrollTop =
-					previewScrollRef.current.scrollHeight;
-			}
-		}, [displayTextLength, isPreviewConstrained]);
-
-		return (
-			<div data-transcript-row="">
-				<ToolCall.Root
-					className="w-full"
-					status={isStreaming ? "running" : "completed"}
-					hasContent={hasText}
-					expanded={expanded}
-					onExpandedChange={(open) => setManualToggle(open)}
-				>
-					<ToolCall.Header
-						iconName="thinking"
-						label={title}
-						showStatus={false}
-					/>
-					<ToolCall.Content>
-						<div
-							ref={previewScrollRef}
-							className={cn(
-								"mt-1.5",
-								isPreviewConstrained && "max-h-24 overflow-y-auto",
-							)}
+	return (
+		<div data-transcript-row="">
+			<ToolCall.Root
+				className="w-full"
+				status={isStreaming ? "running" : "completed"}
+				hasContent={hasText}
+				expanded={expanded}
+				onExpandedChange={(open) => setManualToggle(open)}
+			>
+				<ToolCall.Header iconName="thinking" label={title} showStatus={false} />
+				<ToolCall.Content>
+					<div
+						ref={previewScrollRef}
+						className={cn(
+							"mt-1.5",
+							isPreviewConstrained && "max-h-24 overflow-y-auto",
+						)}
+					>
+						<Response
+							className="text-[11px] text-content-secondary"
+							streaming={isStreaming}
 						>
-							<Response
-								className="text-[11px] text-content-secondary"
-								urlTransform={urlTransform}
-								streaming={isStreaming}
-							>
-								{body}
-							</Response>
-						</div>
-					</ToolCall.Content>
-				</ToolCall.Root>
-			</div>
-		);
-	},
-);
+							{body}
+						</Response>
+					</div>
+				</ToolCall.Content>
+			</ToolCall.Root>
+		</div>
+	);
+});
 
 // Wrapper that runs the smooth-streaming jitter buffer on a single
 // response block. Only used during live streaming — historical
@@ -202,19 +182,14 @@ const ReasoningDisclosure = memo<{
 const SmoothedResponse = memo<{
 	text: string;
 	streamKey: string;
-	urlTransform?: UrlTransform;
-}>(({ text, streamKey, urlTransform }) => {
+}>(({ text, streamKey }) => {
 	const { visibleText } = useSmoothStreamingText({
 		fullText: text,
 		isStreaming: true,
 		bypassSmoothing: false,
 		streamKey,
 	});
-	return (
-		<Response streaming urlTransform={urlTransform}>
-			{visibleText}
-		</Response>
-	);
+	return <Response streaming>{visibleText}</Response>;
 });
 
 const ReadFileTimelineBlock = memo<{
@@ -270,7 +245,6 @@ export const BlockList: FC<{
 	latestAskUserQuestionToolId?: string;
 	askUserQuestionResponseTextByToolId?: ReadonlyMap<string, string>;
 	hasUserResponseAfterAskQuestion?: boolean;
-	urlTransform?: UrlTransform;
 }> = ({
 	blocks,
 	tools,
@@ -289,7 +263,6 @@ export const BlockList: FC<{
 	latestAskUserQuestionToolId,
 	askUserQuestionResponseTextByToolId,
 	hasUserResponseAfterAskQuestion = false,
-	urlTransform,
 }) => {
 	const prefQuery = useQuery(preferenceSettings());
 	const thinkingDisplayMode: ThinkingDisplayMode =
@@ -335,13 +308,9 @@ export const BlockList: FC<{
 								key={`${keyPrefix}-response-${index}`}
 								text={block.text}
 								streamKey={keyPrefix}
-								urlTransform={urlTransform}
 							/>
 						) : (
-							<Response
-								key={`${keyPrefix}-response-${index}`}
-								urlTransform={urlTransform}
-							>
+							<Response key={`${keyPrefix}-response-${index}`}>
 								{block.text}
 							</Response>
 						);
@@ -362,7 +331,6 @@ export const BlockList: FC<{
 									lastDisplayBlockIsThinking &&
 									index === displayBlocks.length - 1
 								}
-								urlTransform={urlTransform}
 								thinkingDisplayMode={thinkingDisplayMode}
 							/>
 						);
@@ -535,12 +503,11 @@ const TimelineNotice: FC<{ children?: ReactNode }> = ({ children }) => (
 
 const LifecycleHookNotice: FC<{
 	children: string;
-	urlTransform?: UrlTransform;
-}> = ({ children, urlTransform }) => (
+}> = ({ children }) => (
 	<TimelineNotice>
 		<div className="flex flex-col gap-1">
 			<AlertTitle>Lifecycle hook</AlertTitle>
-			<Response urlTransform={urlTransform}>{children}</Response>
+			<Response>{children}</Response>
 		</div>
 	</TimelineNotice>
 );
@@ -569,7 +536,6 @@ const ChatMessageItem = memo<{
 	// overlay to indicate truncated content.
 	fadeFromBottom?: boolean;
 	onImplementPlan?: () => Promise<void> | void;
-	urlTransform?: UrlTransform;
 	mcpServers?: readonly TypesGen.MCPServerConfig[];
 	subagentTitles?: Map<string, string>;
 	subagentVariants?: Map<string, SubagentVariant>;
@@ -604,7 +570,6 @@ const ChatMessageItem = memo<{
 		nextUserMessageId,
 		onJumpToUserMessage,
 
-		urlTransform,
 		mcpServers,
 		subagentTitles,
 		subagentVariants,
@@ -636,16 +601,13 @@ const ChatMessageItem = memo<{
 				>
 					{parsed.hookNotices.length > 0 ? (
 						parsed.hookNotices.map((notice, index) => (
-							<LifecycleHookNotice
-								key={`${message.id}-hook-notice-${index}`}
-								urlTransform={urlTransform}
-							>
+							<LifecycleHookNotice key={`${message.id}-hook-notice-${index}`}>
 								{notice}
 							</LifecycleHookNotice>
 						))
 					) : (
 						<TimelineNotice>
-							<Response urlTransform={urlTransform}>{parsed.markdown}</Response>
+							<Response>{parsed.markdown}</Response>
 						</TimelineNotice>
 					)}
 				</div>
@@ -700,7 +662,6 @@ const ChatMessageItem = memo<{
 										}
 										onImageClick={setPreviewImage}
 										onTextFileClick={setPreviewText}
-										urlTransform={urlTransform}
 										mcpServers={mcpServers}
 									/>
 								</div>
@@ -709,10 +670,7 @@ const ChatMessageItem = memo<{
 					)}
 				</ConversationItem>
 				{parsed.hookNotices.map((notice, index) => (
-					<LifecycleHookNotice
-						key={`${message.id}-hook-notice-${index}`}
-						urlTransform={urlTransform}
-					>
+					<LifecycleHookNotice key={`${message.id}-hook-notice-${index}`}>
 						{notice}
 					</LifecycleHookNotice>
 				))}
@@ -848,7 +806,6 @@ const StickyUserMessage = memo<{
 	nextUserMessageId?: number;
 	onJumpToUserMessage?: (messageId: number) => void;
 	registerSentinel?: (messageId: number, el: HTMLDivElement | null) => void;
-	urlTransform?: UrlTransform;
 }>(
 	({
 		message,
@@ -860,7 +817,6 @@ const StickyUserMessage = memo<{
 		nextUserMessageId,
 		onJumpToUserMessage,
 		registerSentinel,
-		urlTransform,
 	}) => {
 		const [isStuck, setIsStuck] = useState(false);
 		const [isReady, setIsReady] = useState(false);
@@ -1104,7 +1060,6 @@ const StickyUserMessage = memo<{
 							prevUserMessageId={prevUserMessageId}
 							nextUserMessageId={nextUserMessageId}
 							onJumpToUserMessage={onJumpToUserMessage}
-							urlTransform={urlTransform}
 						/>
 					</div>
 
@@ -1150,7 +1105,6 @@ const StickyUserMessage = memo<{
 									prevUserMessageId={prevUserMessageId}
 									nextUserMessageId={nextUserMessageId}
 									onJumpToUserMessage={onJumpToUserMessage}
-									urlTransform={urlTransform}
 									fadeFromBottom
 								/>
 							</div>
@@ -1194,7 +1148,6 @@ interface ConversationTimelineProps {
 	onImplementPlan?: () => Promise<void> | void;
 	onSendAskUserQuestionResponse?: (message: string) => Promise<void> | void;
 	isChatCompleted?: boolean;
-	urlTransform?: UrlTransform;
 	mcpServers?: readonly TypesGen.MCPServerConfig[];
 	showDesktopPreviews?: boolean;
 	hasActiveStream?: boolean;
@@ -1211,7 +1164,6 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 		onImplementPlan,
 		onSendAskUserQuestionResponse,
 		isChatCompleted,
-		urlTransform,
 		mcpServers,
 		showDesktopPreviews,
 		hasActiveStream,
@@ -1349,7 +1301,6 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 									nextUserMessageId={userNeighborsById.get(message.id)?.nextId}
 									onJumpToUserMessage={jumpToUserMessage}
 									registerSentinel={registerSentinel}
-									urlTransform={urlTransform}
 								/>
 							);
 						}
@@ -1372,7 +1323,6 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 								hasUserResponseAfterAskQuestion={
 									hasUserResponseAfterAskQuestion
 								}
-								urlTransform={urlTransform}
 								isAfterEditingMessage={afterEditingMessageIds.has(message.id)}
 								hideActions={!isLastInChain}
 								hasActiveStream={Boolean(hasActiveStream)}

--- a/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
@@ -1,4 +1,3 @@
-import type { UrlTransform } from "streamdown";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { SubagentVariant } from "../ChatElements/tools/subagentDescriptor";
 import { ChatStatusCallout } from "./ChatStatusCallout";
@@ -35,7 +34,6 @@ interface LiveStreamTailContentProps {
 	subagentTitles: Map<string, string>;
 	subagentVariants?: Map<string, SubagentVariant>;
 	subagentStatusOverrides: Map<string, TypesGen.ChatStatus>;
-	urlTransform?: UrlTransform;
 	mcpServers?: readonly TypesGen.MCPServerConfig[];
 }
 
@@ -47,7 +45,6 @@ export const LiveStreamTailContent = ({
 	subagentTitles,
 	subagentVariants,
 	subagentStatusOverrides,
-	urlTransform,
 	mcpServers,
 }: LiveStreamTailContentProps) => {
 	const shouldRenderStreamSection = shouldRenderStreamingSection(liveStatus);
@@ -84,7 +81,6 @@ export const LiveStreamTailContent = ({
 					subagentTitles={subagentTitles}
 					subagentVariants={subagentVariants}
 					subagentStatusOverrides={subagentStatusOverrides}
-					urlTransform={urlTransform}
 					mcpServers={mcpServers}
 				/>
 			)}
@@ -99,7 +95,6 @@ interface LiveStreamTailProps {
 	isTranscriptEmpty: boolean;
 	subagentTitles: Map<string, string>;
 	subagentVariants?: Map<string, SubagentVariant>;
-	urlTransform?: UrlTransform;
 	mcpServers?: readonly TypesGen.MCPServerConfig[];
 }
 
@@ -109,7 +104,6 @@ export const LiveStreamTail = ({
 	isTranscriptEmpty,
 	subagentTitles,
 	subagentVariants,
-	urlTransform,
 	mcpServers,
 }: LiveStreamTailProps) => {
 	const streamState = useChatSelector(store, selectStreamState);
@@ -146,7 +140,6 @@ export const LiveStreamTail = ({
 			subagentTitles={subagentTitles}
 			subagentVariants={subagentVariants}
 			subagentStatusOverrides={subagentStatusOverrides}
-			urlTransform={urlTransform}
 			mcpServers={mcpServers}
 		/>
 	);

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -1,5 +1,4 @@
 import type { FC } from "react";
-import type { UrlTransform } from "streamdown";
 import type * as TypesGen from "#/api/typesGenerated";
 import {
 	ConversationItem,
@@ -37,7 +36,6 @@ export const StreamingOutput: FC<{
 	subagentVariants?: Map<string, SubagentVariant>;
 	subagentStatusOverrides?: Map<string, TypesGen.ChatStatus>;
 	liveStatus: LiveStatusModel;
-	urlTransform?: UrlTransform;
 	mcpServers?: readonly TypesGen.MCPServerConfig[];
 }> = ({
 	streamState,
@@ -46,7 +44,6 @@ export const StreamingOutput: FC<{
 	subagentVariants,
 	subagentStatusOverrides,
 	liveStatus,
-	urlTransform,
 	mcpServers,
 }) => {
 	if (liveStatus.phase === "idle") {
@@ -80,7 +77,6 @@ export const StreamingOutput: FC<{
 								subagentTitles={subagentTitles}
 								subagentVariants={subagentVariants}
 								subagentStatusOverrides={subagentStatusOverrides}
-								urlTransform={urlTransform}
 								mcpServers={mcpServers}
 							/>
 						)}

--- a/site/src/pages/AgentsPage/components/ChatElements/LinkifiedText.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/LinkifiedText.tsx
@@ -1,0 +1,28 @@
+import type React from "react";
+import { Fragment } from "react";
+import { useChatUrlTransform } from "../../context/ChatUrlTransformContext";
+import { splitTextForLinks } from "./linkify";
+
+export const LinkifiedText: React.FC<{ text: string }> = ({ text }) => {
+	const transform = useChatUrlTransform();
+	const segments = splitTextForLinks(text);
+	if (!segments.some((segment) => segment.kind === "url")) {
+		return text;
+	}
+	return segments.map((segment, index) => {
+		if (segment.kind === "text") {
+			return <Fragment key={index}>{segment.value}</Fragment>;
+		}
+		return (
+			<a
+				key={index}
+				href={transform ? transform(segment.value) : segment.value}
+				target="_blank"
+				rel="noopener noreferrer"
+				className="font-[inherit] text-content-link underline underline-offset-2 hover:no-underline"
+			>
+				{segment.value}
+			</a>
+		);
+	});
+};

--- a/site/src/pages/AgentsPage/components/ChatElements/LinkifiedText.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/LinkifiedText.tsx
@@ -1,0 +1,33 @@
+import type React from "react";
+import { Fragment } from "react";
+import { useChatUrlTransform } from "../../context/ChatUrlTransformContext";
+import { splitTextForLinks } from "./linkify";
+
+/**
+ * Renders plain text with http(s) URLs as anchors, routing hrefs
+ * through the chat URL transform so localhost URLs open via the
+ * workspace port-forward subdomain.
+ */
+export const LinkifiedText: React.FC<{ text: string }> = ({ text }) => {
+	const transform = useChatUrlTransform();
+	const segments = splitTextForLinks(text);
+	if (!segments.some((segment) => segment.kind === "url")) {
+		return text;
+	}
+	return segments.map((segment, index) => {
+		if (segment.kind === "text") {
+			return <Fragment key={index}>{segment.value}</Fragment>;
+		}
+		return (
+			<a
+				key={index}
+				href={transform ? transform(segment.value) : segment.value}
+				target="_blank"
+				rel="noreferrer"
+				className="font-[inherit] text-content-link underline underline-offset-2 hover:no-underline"
+			>
+				{segment.value}
+			</a>
+		);
+	});
+};

--- a/site/src/pages/AgentsPage/components/ChatElements/Response.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/Response.stories.tsx
@@ -1,5 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { type FC, useState } from "react";
 import { expect, userEvent, waitFor, within } from "storybook/test";
+import { rewriteLocalhostURL } from "#/utils/portForward";
+import {
+	type ChatUrlTransform,
+	ChatUrlTransformContext,
+} from "../../context/ChatUrlTransformContext";
 import { Response } from "./Response";
 
 const sampleMarkdown = `
@@ -229,6 +235,74 @@ export const ExternalImageConsentGate: Story = {
 	},
 };
 
+const chatUrlTransform = (url: string) =>
+	rewriteLocalhostURL(url, "*.proxy.example.com", "main", "my-ws", "alice");
+
+export const LocalhostLinkFromChatContext: Story = {
+	decorators: [
+		(Story) => (
+			<ChatUrlTransformContext value={chatUrlTransform}>
+				<Story />
+			</ChatUrlTransformContext>
+		),
+	],
+	args: {
+		children:
+			"Open [the preview](http://localhost:3000/apps?tab=1) or [the docs](https://coder.com/docs).",
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const preview = await canvas.findByRole("link", { name: "the preview" });
+		expect(preview).toHaveAttribute(
+			"href",
+			"http://3000--main--my-ws--alice.proxy.example.com/apps?tab=1",
+		);
+		const docs = canvas.getByRole("link", { name: "the docs" });
+		expect(docs).toHaveAttribute("href", "https://coder.com/docs");
+	},
+};
+
+const TransformArrivesAfterRender: FC<{ children: string }> = ({
+	children,
+}) => {
+	const [transform, setTransform] = useState<ChatUrlTransform | undefined>(
+		undefined,
+	);
+	return (
+		<ChatUrlTransformContext value={transform}>
+			<button
+				type="button"
+				onClick={() => setTransform(() => chatUrlTransform)}
+			>
+				Load workspace data
+			</button>
+			<Response streaming>{children}</Response>
+		</ChatUrlTransformContext>
+	);
+};
+
+export const LocalhostLinkRewrittenMidStream: Story = {
+	render: () => (
+		<TransformArrivesAfterRender>
+			Open [the preview](http://localhost:3000/apps?tab=1) now.
+		</TransformArrivesAfterRender>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const preview = await canvas.findByRole("link", { name: "the preview" });
+		expect(preview).toHaveAttribute("href", "http://localhost:3000/apps?tab=1");
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Load workspace data" }),
+		);
+		await waitFor(() => {
+			expect(canvas.getByRole("link", { name: "the preview" })).toHaveAttribute(
+				"href",
+				"http://3000--main--my-ws--alice.proxy.example.com/apps?tab=1",
+			);
+		});
+	},
+};
+
 // data: image sources are stripped by the sanitize plugin, so they
 // render as nothing: no <img>, no consent gate, no request.
 export const DataImageStrippedBySanitizer: Story = {
@@ -272,6 +346,88 @@ export const StreamingExternalImageConsentGate: Story = {
 		});
 		expect(loadButton).toBeInTheDocument();
 		expect(canvasElement.querySelector("img")).toBeNull();
+	},
+};
+
+const TransformSwitchesWorkspace: FC = () => {
+	const [workspace, setWorkspace] = useState("ws-a");
+	const transform = (url: string) =>
+		rewriteLocalhostURL(url, "*.proxy.example.com", "main", workspace, "alice");
+	return (
+		<ChatUrlTransformContext value={transform}>
+			<button type="button" onClick={() => setWorkspace("ws-b")}>
+				Switch workspace
+			</button>
+			<Response>Open [the preview](http://localhost:3000/).</Response>
+		</ChatUrlTransformContext>
+	);
+};
+
+export const LocalhostLinkRetargetsOnWorkspaceChange: Story = {
+	render: () => <TransformSwitchesWorkspace />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const preview = await canvas.findByRole("link", { name: "the preview" });
+		expect(preview).toHaveAttribute(
+			"href",
+			"http://3000--main--ws-a--alice.proxy.example.com/",
+		);
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Switch workspace" }),
+		);
+		await waitFor(() => {
+			expect(canvas.getByRole("link", { name: "the preview" })).toHaveAttribute(
+				"href",
+				"http://3000--main--ws-b--alice.proxy.example.com/",
+			);
+		});
+	},
+};
+
+export const LocalhostImageRewrittenFromChatContext: Story = {
+	decorators: [
+		(Story) => (
+			<ChatUrlTransformContext value={chatUrlTransform}>
+				<Story />
+			</ChatUrlTransformContext>
+		),
+	],
+	args: {
+		children: "![preview shot](http://localhost:3000/screenshot.png)",
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// The rewritten source is cross-origin, so the external-image
+		// consent gate applies to the transformed URL, not the raw
+		// localhost one.
+		const loadButton = await canvas.findByRole("button", {
+			name: /load external image from 3000--main--my-ws--alice\.proxy\.example\.com/i,
+		});
+		await userEvent.click(loadButton);
+		const image = await canvas.findByRole("img", { name: "preview shot" });
+		expect(image).toHaveAttribute(
+			"src",
+			"http://3000--main--my-ws--alice.proxy.example.com/screenshot.png",
+		);
+	},
+};
+
+export const ExplicitUrlTransformWinsOverContext: Story = {
+	decorators: [
+		(Story) => (
+			<ChatUrlTransformContext value={chatUrlTransform}>
+				<Story />
+			</ChatUrlTransformContext>
+		),
+	],
+	args: {
+		children: "Open [the preview](http://localhost:3000/).",
+		urlTransform: () => "https://prop-wins.example.com/",
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const preview = await canvas.findByRole("link", { name: "the preview" });
+		expect(preview).toHaveAttribute("href", "https://prop-wins.example.com/");
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatElements/Response.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/Response.stories.tsx
@@ -412,25 +412,6 @@ export const LocalhostImageRewrittenFromChatContext: Story = {
 	},
 };
 
-export const ExplicitUrlTransformWinsOverContext: Story = {
-	decorators: [
-		(Story) => (
-			<ChatUrlTransformContext value={chatUrlTransform}>
-				<Story />
-			</ChatUrlTransformContext>
-		),
-	],
-	args: {
-		children: "Open [the preview](http://localhost:3000/).",
-		urlTransform: () => "https://prop-wins.example.com/",
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const preview = await canvas.findByRole("link", { name: "the preview" });
-		expect(preview).toHaveAttribute("href", "https://prop-wins.example.com/");
-	},
-};
-
 // Verifies that streaming mode closes incomplete inline markdown via
 // remend so the user never sees raw syntax during the reveal animation.
 export const StreamingInlineMarkdown: Story = {

--- a/site/src/pages/AgentsPage/components/ChatElements/Response.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/Response.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, waitFor, within } from "storybook/test";
+import { rewriteLocalhostURL } from "#/utils/portForward";
+import { ChatUrlTransformContext } from "../../context/ChatUrlTransformContext";
 import { Response } from "./Response";
 
 const sampleMarkdown = `
@@ -188,6 +190,52 @@ export const JsxInProse: Story = {
 		expect(marker).toBeInTheDocument();
 		const marker2 = await canvas.findByText(/commentBox=\{commentBox\}/);
 		expect(marker2).toBeInTheDocument();
+	},
+};
+
+const chatUrlTransform = (url: string) =>
+	rewriteLocalhostURL(url, "*.proxy.example.com", "main", "my-ws", "alice");
+
+export const LocalhostLinkFromChatContext: Story = {
+	decorators: [
+		(Story) => (
+			<ChatUrlTransformContext value={chatUrlTransform}>
+				<Story />
+			</ChatUrlTransformContext>
+		),
+	],
+	args: {
+		children:
+			"Open [the preview](http://localhost:3000/apps?tab=1) or [the docs](https://coder.com/docs).",
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const preview = await canvas.findByRole("link", { name: "the preview" });
+		expect(preview).toHaveAttribute(
+			"href",
+			"http://3000--main--my-ws--alice.proxy.example.com/apps?tab=1",
+		);
+		const docs = canvas.getByRole("link", { name: "the docs" });
+		expect(docs).toHaveAttribute("href", "https://coder.com/docs");
+	},
+};
+
+export const ExplicitUrlTransformWinsOverContext: Story = {
+	decorators: [
+		(Story) => (
+			<ChatUrlTransformContext value={chatUrlTransform}>
+				<Story />
+			</ChatUrlTransformContext>
+		),
+	],
+	args: {
+		children: "Open [the preview](http://localhost:3000/).",
+		urlTransform: () => "https://prop-wins.example.com/",
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const preview = await canvas.findByRole("link", { name: "the preview" });
+		expect(preview).toHaveAttribute("href", "https://prop-wins.example.com/");
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatElements/Response.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/Response.tsx
@@ -7,16 +7,11 @@ import type { ComponentPropsWithRef, ReactNode } from "react";
 import { type Components, defaultRehypePlugins, Streamdown } from "streamdown";
 import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
 import { cn } from "#/utils/cn";
-import {
-	type ChatUrlTransform,
-	ChatUrlTransformContext,
-	useChatUrlTransform,
-} from "../../context/ChatUrlTransformContext";
+import { useChatUrlTransform } from "../../context/ChatUrlTransformContext";
 import { MarkdownImage } from "./MarkdownImage";
 
 interface ResponseProps extends Omit<ComponentPropsWithRef<"div">, "children"> {
 	children: string;
-	urlTransform?: ChatUrlTransform;
 	/** Enable streaming-mode Streamdown with incomplete-markdown
 	 * preprocessing (remend) and useTransition-based render
 	 * scheduling. Pass true only for live-streaming output. */
@@ -282,7 +277,6 @@ export const Response = ({
 	className,
 	children,
 	ref,
-	urlTransform,
 	streaming,
 	...props
 }: ResponseProps) => {
@@ -290,21 +284,6 @@ export const Response = ({
 	const fileViewerThemeType: FileViewerThemeType =
 		theme.palette.mode === "dark" ? "dark" : "light";
 	const components = componentsByTheme[fileViewerThemeType];
-
-	// Streamdown caches rendered blocks by content, so URLs must stay
-	// raw here and get rewritten at render time by MarkdownAnchor and
-	// ChatMarkdownImage, which read the transform from context.
-	const markdown = (
-		<Streamdown
-			controls={false}
-			components={components}
-			rehypePlugins={chatRehypePlugins}
-			mode={streaming ? "streaming" : "static"}
-			parseIncompleteMarkdown={streaming}
-		>
-			{children}
-		</Streamdown>
-	);
 
 	return (
 		<div
@@ -315,13 +294,19 @@ export const Response = ({
 			)}
 			{...props}
 		>
-			{urlTransform ? (
-				<ChatUrlTransformContext value={urlTransform}>
-					{markdown}
-				</ChatUrlTransformContext>
-			) : (
-				markdown
-			)}
+			{/* Streamdown caches rendered blocks by content, so URLs must
+			    stay raw here and get rewritten at render time by
+			    MarkdownAnchor and ChatMarkdownImage, which read the
+			    transform from context. */}
+			<Streamdown
+				controls={false}
+				components={components}
+				rehypePlugins={chatRehypePlugins}
+				mode={streaming ? "streaming" : "static"}
+				parseIncompleteMarkdown={streaming}
+			>
+				{children}
+			</Streamdown>
 		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/Response.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/Response.tsx
@@ -4,19 +4,19 @@ import {
 	type SupportedLanguages,
 } from "@pierre/diffs/react";
 import type { ComponentPropsWithRef, ReactNode } from "react";
-import {
-	type Components,
-	defaultRehypePlugins,
-	Streamdown,
-	type UrlTransform,
-} from "streamdown";
+import { type Components, defaultRehypePlugins, Streamdown } from "streamdown";
 import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
 import { cn } from "#/utils/cn";
+import {
+	type ChatUrlTransform,
+	ChatUrlTransformContext,
+	useChatUrlTransform,
+} from "../../context/ChatUrlTransformContext";
 import { MarkdownImage } from "./MarkdownImage";
 
 interface ResponseProps extends Omit<ComponentPropsWithRef<"div">, "children"> {
 	children: string;
-	urlTransform?: UrlTransform;
+	urlTransform?: ChatUrlTransform;
 	/** Enable streaming-mode Streamdown with incomplete-markdown
 	 * preprocessing (remend) and useTransition-based render
 	 * scheduling. Pass true only for live-streaming output. */
@@ -103,21 +103,33 @@ const markdownFileViewerStyle = {
 	"--diffs-line-height": "20px",
 };
 
+const MarkdownAnchor = ({ href, children }: MarkdownComponentProps) => {
+	const transform = useChatUrlTransform();
+	return (
+		<a
+			href={href && transform ? transform(href) : href}
+			target="_blank"
+			rel="noopener noreferrer"
+			className="text-content-link no-underline hover:underline hover:decoration-content-link"
+		>
+			{children}
+		</a>
+	);
+};
+
+const ChatMarkdownImage = ({ src, alt }: MarkdownComponentProps) => {
+	const transform = useChatUrlTransform();
+	return (
+		<MarkdownImage src={src && transform ? transform(src) : src} alt={alt} />
+	);
+};
+
 const createComponents = (
 	fileViewerThemeType: FileViewerThemeType,
 	viewerTheme: (typeof fileViewerTheme)[FileViewerThemeType],
 ): Components => {
 	return {
-		a: ({ href, children }: MarkdownComponentProps) => (
-			<a
-				href={href}
-				target="_blank"
-				rel="noopener noreferrer"
-				className="text-content-link no-underline hover:underline hover:decoration-content-link"
-			>
-				{children}
-			</a>
-		),
+		a: MarkdownAnchor,
 		// Headings scaled for a 13px base using a tight,
 		// Apple-like progression.
 		h1: ({ children }: MarkdownComponentProps) => (
@@ -190,9 +202,9 @@ const createComponents = (
 		// Gate externally hosted images behind viewer consent so
 		// rendering a chat never discloses the viewer's IP address
 		// to an attacker-controlled host (Cure53 CDM-02-006).
-		img: ({ src, alt }: MarkdownComponentProps) => (
-			<MarkdownImage src={src} alt={alt} />
-		),
+		// ChatMarkdownImage rewrites localhost sources first, so the
+		// consent check runs on the URL the browser would fetch.
+		img: ChatMarkdownImage,
 		// Horizontal rule: reset browser default inset/ridge border
 		// (preflight is disabled) to a clean 1px solid line.
 		hr: () => (
@@ -279,6 +291,21 @@ export const Response = ({
 		theme.palette.mode === "dark" ? "dark" : "light";
 	const components = componentsByTheme[fileViewerThemeType];
 
+	// Streamdown caches rendered blocks by content, so URLs must stay
+	// raw here and get rewritten at render time by MarkdownAnchor and
+	// ChatMarkdownImage, which read the transform from context.
+	const markdown = (
+		<Streamdown
+			controls={false}
+			components={components}
+			rehypePlugins={chatRehypePlugins}
+			mode={streaming ? "streaming" : "static"}
+			parseIncompleteMarkdown={streaming}
+		>
+			{children}
+		</Streamdown>
+	);
+
 	return (
 		<div
 			ref={ref}
@@ -288,16 +315,13 @@ export const Response = ({
 			)}
 			{...props}
 		>
-			<Streamdown
-				controls={false}
-				components={components}
-				urlTransform={urlTransform}
-				rehypePlugins={chatRehypePlugins}
-				mode={streaming ? "streaming" : "static"}
-				parseIncompleteMarkdown={streaming}
-			>
-				{children}
-			</Streamdown>
+			{urlTransform ? (
+				<ChatUrlTransformContext value={urlTransform}>
+					{markdown}
+				</ChatUrlTransformContext>
+			) : (
+				markdown
+			)}
 		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/Response.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/Response.tsx
@@ -12,6 +12,7 @@ import {
 } from "streamdown";
 import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
 import { cn } from "#/utils/cn";
+import { useChatUrlTransform } from "../../context/ChatUrlTransformContext";
 
 interface ResponseProps extends Omit<ComponentPropsWithRef<"div">, "children"> {
 	children: string;
@@ -269,6 +270,7 @@ export const Response = ({
 	const fileViewerThemeType: FileViewerThemeType =
 		theme.palette.mode === "dark" ? "dark" : "light";
 	const components = componentsByTheme[fileViewerThemeType];
+	const chatUrlTransform = useChatUrlTransform();
 
 	return (
 		<div
@@ -282,7 +284,7 @@ export const Response = ({
 			<Streamdown
 				controls={false}
 				components={components}
-				urlTransform={urlTransform}
+				urlTransform={urlTransform ?? chatUrlTransform}
 				rehypePlugins={chatRehypePlugins}
 				mode={streaming ? "streaming" : "static"}
 				parseIncompleteMarkdown={streaming}

--- a/site/src/pages/AgentsPage/components/ChatElements/linkify.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/linkify.test.ts
@@ -1,0 +1,118 @@
+import { splitTextForLinks } from "./linkify";
+
+describe("splitTextForLinks", () => {
+	it("returns a single text segment when there are no URLs", () => {
+		expect(splitTextForLinks("compiled 12 files in 340ms")).toEqual([
+			{ kind: "text", value: "compiled 12 files in 340ms" },
+		]);
+	});
+
+	it("extracts a bare URL surrounded by text", () => {
+		expect(splitTextForLinks("Local: http://localhost:3000/ ready")).toEqual([
+			{ kind: "text", value: "Local: " },
+			{ kind: "url", value: "http://localhost:3000/" },
+			{ kind: "text", value: " ready" },
+		]);
+	});
+
+	it("extracts multiple URLs and preserves whitespace between them", () => {
+		expect(
+			splitTextForLinks(
+				"  ➜  Local:   http://localhost:5173/\n  ➜  Network: http://127.0.0.1:5173/\n",
+			),
+		).toEqual([
+			{ kind: "text", value: "  ➜  Local:   " },
+			{ kind: "url", value: "http://localhost:5173/" },
+			{ kind: "text", value: "\n  ➜  Network: " },
+			{ kind: "url", value: "http://127.0.0.1:5173/" },
+			{ kind: "text", value: "\n" },
+		]);
+	});
+
+	it("keeps ports, paths, and query strings", () => {
+		expect(
+			splitTextForLinks("see https://localhost:8080/api/v2?q=1&x=2 now"),
+		).toEqual([
+			{ kind: "text", value: "see " },
+			{ kind: "url", value: "https://localhost:8080/api/v2?q=1&x=2" },
+			{ kind: "text", value: " now" },
+		]);
+	});
+
+	it("excludes trailing sentence punctuation from the URL", () => {
+		expect(splitTextForLinks("Open http://localhost:3000.")).toEqual([
+			{ kind: "text", value: "Open " },
+			{ kind: "url", value: "http://localhost:3000" },
+			{ kind: "text", value: "." },
+		]);
+		expect(splitTextForLinks("Ready at http://localhost:3000!?")).toEqual([
+			{ kind: "text", value: "Ready at " },
+			{ kind: "url", value: "http://localhost:3000" },
+			{ kind: "text", value: "!?" },
+		]);
+	});
+
+	it("excludes a closing parenthesis that is not part of the URL", () => {
+		expect(splitTextForLinks("(listening on http://localhost:3000)")).toEqual([
+			{ kind: "text", value: "(listening on " },
+			{ kind: "url", value: "http://localhost:3000" },
+			{ kind: "text", value: ")" },
+		]);
+	});
+
+	it("keeps a balanced closing parenthesis inside the URL", () => {
+		expect(
+			splitTextForLinks("docs at https://example.com/wiki/Foo_(bar)"),
+		).toEqual([
+			{ kind: "text", value: "docs at " },
+			{ kind: "url", value: "https://example.com/wiki/Foo_(bar)" },
+		]);
+	});
+
+	it("does not linkify non-http schemes", () => {
+		expect(splitTextForLinks("ftp://host ws://host file:///tmp/x")).toEqual([
+			{ kind: "text", value: "ftp://host ws://host file:///tmp/x" },
+		]);
+	});
+
+	it("trims an unmatched closing bracket wrapping the URL", () => {
+		expect(splitTextForLinks("Open [http://localhost:3000] now")).toEqual([
+			{ kind: "text", value: "Open [" },
+			{ kind: "url", value: "http://localhost:3000" },
+			{ kind: "text", value: "] now" },
+		]);
+	});
+
+	it("trims an unmatched closing bracket after a path", () => {
+		expect(splitTextForLinks("[http://localhost:3000/app]")).toEqual([
+			{ kind: "text", value: "[" },
+			{ kind: "url", value: "http://localhost:3000/app" },
+			{ kind: "text", value: "]" },
+		]);
+	});
+
+	it("keeps IPv6 host brackets while trimming a wrapper bracket", () => {
+		expect(splitTextForLinks("[http://[::1]:8080/]")).toEqual([
+			{ kind: "text", value: "[" },
+			{ kind: "url", value: "http://[::1]:8080/" },
+			{ kind: "text", value: "]" },
+		]);
+	});
+
+	it("stops the URL at ANSI escape sequences", () => {
+		expect(
+			splitTextForLinks("\u001b[32mhttp://localhost:3000/\u001b[39m done"),
+		).toEqual([
+			{ kind: "text", value: "\u001b[32m" },
+			{ kind: "url", value: "http://localhost:3000/" },
+			{ kind: "text", value: "\u001b[39m done" },
+		]);
+	});
+
+	it("stops the URL at other ASCII control characters", () => {
+		expect(splitTextForLinks("http://localhost:3000/a\u0007bell")).toEqual([
+			{ kind: "url", value: "http://localhost:3000/a" },
+			{ kind: "text", value: "\u0007bell" },
+		]);
+	});
+});

--- a/site/src/pages/AgentsPage/components/ChatElements/linkify.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/linkify.test.ts
@@ -1,0 +1,77 @@
+import { splitTextForLinks } from "./linkify";
+
+describe("splitTextForLinks", () => {
+	it("returns a single text segment when there are no URLs", () => {
+		expect(splitTextForLinks("compiled 12 files in 340ms")).toEqual([
+			{ kind: "text", value: "compiled 12 files in 340ms" },
+		]);
+	});
+
+	it("extracts a bare URL surrounded by text", () => {
+		expect(splitTextForLinks("Local: http://localhost:3000/ ready")).toEqual([
+			{ kind: "text", value: "Local: " },
+			{ kind: "url", value: "http://localhost:3000/" },
+			{ kind: "text", value: " ready" },
+		]);
+	});
+
+	it("extracts multiple URLs and preserves whitespace between them", () => {
+		expect(
+			splitTextForLinks(
+				"  ➜  Local:   http://localhost:5173/\n  ➜  Network: http://127.0.0.1:5173/\n",
+			),
+		).toEqual([
+			{ kind: "text", value: "  ➜  Local:   " },
+			{ kind: "url", value: "http://localhost:5173/" },
+			{ kind: "text", value: "\n  ➜  Network: " },
+			{ kind: "url", value: "http://127.0.0.1:5173/" },
+			{ kind: "text", value: "\n" },
+		]);
+	});
+
+	it("keeps ports, paths, and query strings", () => {
+		expect(
+			splitTextForLinks("see https://localhost:8080/api/v2?q=1&x=2 now"),
+		).toEqual([
+			{ kind: "text", value: "see " },
+			{ kind: "url", value: "https://localhost:8080/api/v2?q=1&x=2" },
+			{ kind: "text", value: " now" },
+		]);
+	});
+
+	it("excludes trailing sentence punctuation from the URL", () => {
+		expect(splitTextForLinks("Open http://localhost:3000.")).toEqual([
+			{ kind: "text", value: "Open " },
+			{ kind: "url", value: "http://localhost:3000" },
+			{ kind: "text", value: "." },
+		]);
+		expect(splitTextForLinks("Ready at http://localhost:3000!?")).toEqual([
+			{ kind: "text", value: "Ready at " },
+			{ kind: "url", value: "http://localhost:3000" },
+			{ kind: "text", value: "!?" },
+		]);
+	});
+
+	it("excludes a closing parenthesis that is not part of the URL", () => {
+		expect(splitTextForLinks("(listening on http://localhost:3000)")).toEqual([
+			{ kind: "text", value: "(listening on " },
+			{ kind: "url", value: "http://localhost:3000" },
+			{ kind: "text", value: ")" },
+		]);
+	});
+
+	it("keeps a balanced closing parenthesis inside the URL", () => {
+		expect(
+			splitTextForLinks("docs at https://example.com/wiki/Foo_(bar)"),
+		).toEqual([
+			{ kind: "text", value: "docs at " },
+			{ kind: "url", value: "https://example.com/wiki/Foo_(bar)" },
+		]);
+	});
+
+	it("does not linkify non-http schemes", () => {
+		expect(splitTextForLinks("ftp://host ws://host file:///tmp/x")).toEqual([
+			{ kind: "text", value: "ftp://host ws://host file:///tmp/x" },
+		]);
+	});
+});

--- a/site/src/pages/AgentsPage/components/ChatElements/linkify.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/linkify.ts
@@ -1,0 +1,71 @@
+type LinkSegment =
+	| { kind: "text"; value: string }
+	| { kind: "url"; value: string };
+
+// Control characters must end URLs so ANSI escapes cannot become part of them.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional
+const URL_PATTERN = /https?:\/\/[^\s<>"'`\u0000-\u001f\u007f]+/g;
+
+// Characters that end a sentence around a URL far more often than
+// they end the URL itself.
+const TRAILING_PUNCTUATION = new Set([".", ",", ";", ":", "!", "?"]);
+
+const trimTrailingPunctuation = (url: string): string => {
+	let parenBalance = 0;
+	let bracketBalance = 0;
+	for (const char of url) {
+		if (char === "(") {
+			parenBalance += 1;
+		} else if (char === ")") {
+			parenBalance -= 1;
+		} else if (char === "[") {
+			bracketBalance += 1;
+		} else if (char === "]") {
+			bracketBalance -= 1;
+		}
+	}
+	let end = url.length;
+	while (end > 0) {
+		const char = url[end - 1];
+		if (TRAILING_PUNCTUATION.has(char)) {
+			end -= 1;
+			continue;
+		}
+		// Preserve balanced URL parentheses while trimming unmatched closers.
+		if (char === ")" && parenBalance < 0) {
+			parenBalance += 1;
+			end -= 1;
+			continue;
+		}
+		// Same for brackets, so "[http://x]" sheds its wrapper while IPv6
+		// hosts like http://[::1]:8080/ keep theirs.
+		if (char === "]" && bracketBalance < 0) {
+			bracketBalance += 1;
+			end -= 1;
+			continue;
+		}
+		break;
+	}
+	return url.slice(0, end);
+};
+
+/** Concatenating the returned segment values reproduces the input. */
+export const splitTextForLinks = (text: string): LinkSegment[] => {
+	const segments: LinkSegment[] = [];
+	let lastIndex = 0;
+	for (const match of text.matchAll(URL_PATTERN)) {
+		const url = trimTrailingPunctuation(match[0]);
+		if (match.index > lastIndex) {
+			segments.push({
+				kind: "text",
+				value: text.slice(lastIndex, match.index),
+			});
+		}
+		segments.push({ kind: "url", value: url });
+		lastIndex = match.index + url.length;
+	}
+	if (lastIndex < text.length) {
+		segments.push({ kind: "text", value: text.slice(lastIndex) });
+	}
+	return segments;
+};

--- a/site/src/pages/AgentsPage/components/ChatElements/linkify.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/linkify.ts
@@ -1,0 +1,58 @@
+type LinkSegment =
+	| { kind: "text"; value: string }
+	| { kind: "url"; value: string };
+
+const URL_PATTERN = /https?:\/\/[^\s<>"'`]+/g;
+
+// Characters that end a sentence around a URL far more often than
+// they end the URL itself.
+const TRAILING_PUNCTUATION = new Set([".", ",", ";", ":", "!", "?"]);
+
+const trimTrailingPunctuation = (url: string): string => {
+	let end = url.length;
+	while (end > 0) {
+		const char = url[end - 1];
+		if (TRAILING_PUNCTUATION.has(char)) {
+			end -= 1;
+			continue;
+		}
+		if (char === ")") {
+			const candidate = url.slice(0, end);
+			const opens = candidate.split("(").length - 1;
+			const closes = candidate.split(")").length - 1;
+			if (closes > opens) {
+				end -= 1;
+				continue;
+			}
+		}
+		break;
+	}
+	return url.slice(0, end);
+};
+
+/**
+ * Concatenating the returned segment values reproduces the input, so
+ * whitespace in preformatted output is preserved.
+ */
+export const splitTextForLinks = (text: string): LinkSegment[] => {
+	const segments: LinkSegment[] = [];
+	let lastIndex = 0;
+	for (const match of text.matchAll(URL_PATTERN)) {
+		const url = trimTrailingPunctuation(match[0]);
+		if (url.length === 0) {
+			continue;
+		}
+		if (match.index > lastIndex) {
+			segments.push({
+				kind: "text",
+				value: text.slice(lastIndex, match.index),
+			});
+		}
+		segments.push({ kind: "url", value: url });
+		lastIndex = match.index + url.length;
+	}
+	if (lastIndex < text.length) {
+		segments.push({ kind: "text", value: text.slice(lastIndex) });
+	}
+	return segments;
+};

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/AdvisorTool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/AdvisorTool.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, userEvent, within } from "storybook/test";
+import { rewriteLocalhostURL } from "#/utils/portForward";
+import { ChatUrlTransformContext } from "../../../context/ChatUrlTransformContext";
 import { Tool } from "./Tool";
 
 const sampleQuestion =
@@ -370,5 +372,44 @@ export const LongAdviceLongQuestion: Story = {
 		expect(toggle).toHaveAttribute("aria-expanded", "true");
 		expect(question.getBoundingClientRect().height).toBeGreaterThan(40);
 		expect(await canvas.findByText("Follow-up questions")).toBeInTheDocument();
+	},
+};
+
+export const LocalhostLinkInAdvice: Story = {
+	decorators: [
+		(Story) => (
+			<ChatUrlTransformContext
+				value={(url) =>
+					rewriteLocalhostURL(
+						url,
+						"*.proxy.example.com",
+						"main",
+						"my-ws",
+						"alice",
+					)
+				}
+			>
+				<Story />
+			</ChatUrlTransformContext>
+		),
+	],
+	args: {
+		status: "completed",
+		args: { question: "Where is the dev server running?" },
+		result: {
+			type: "advice",
+			advice:
+				"Open [the preview](http://localhost:3000/apps?tab=1) or read [the docs](https://coder.com/docs).",
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const preview = await canvas.findByRole("link", { name: "the preview" });
+		expect(preview).toHaveAttribute(
+			"href",
+			"http://3000--main--my-ws--alice.proxy.example.com/apps?tab=1",
+		);
+		const docs = canvas.getByRole("link", { name: "the docs" });
+		expect(docs).toHaveAttribute("href", "https://coder.com/docs");
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/AskUserQuestionTool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/AskUserQuestionTool.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, fn, userEvent, within } from "storybook/test";
+import { rewriteLocalhostURL } from "#/utils/portForward";
+import { ChatUrlTransformContext } from "../../../context/ChatUrlTransformContext";
 import { Tool } from "./Tool";
 
 const runningPayload = {
@@ -175,6 +177,55 @@ export const InteractiveSingleQuestion: Story = {
 		expect(
 			canvas.queryByRole("button", { name: "Submit" }),
 		).not.toBeInTheDocument();
+	},
+};
+
+export const QuestionLocalhostLinkRewritten: Story = {
+	decorators: [
+		(Story) => (
+			<ChatUrlTransformContext
+				value={(url) =>
+					rewriteLocalhostURL(
+						url,
+						"*.proxy.example.com",
+						"main",
+						"my-ws",
+						"alice",
+					)
+				}
+			>
+				<Story />
+			</ChatUrlTransformContext>
+		),
+	],
+	args: {
+		status: "completed",
+		result: JSON.stringify({
+			questions: [
+				{
+					header: "Preview Check",
+					question:
+						"Open http://localhost:3000/apps?tab=1 and confirm the layout looks right.",
+					options: [
+						{ label: "Looks good", description: "" },
+						{ label: "Needs changes", description: "" },
+					],
+				},
+			],
+		}),
+		isChatCompleted: true,
+		isLatestAskUserQuestion: true,
+		onSendAskUserQuestionResponse: fn(),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const link = await canvas.findByRole("link", {
+			name: "http://localhost:3000/apps?tab=1",
+		});
+		expect(link).toHaveAttribute(
+			"href",
+			"http://3000--main--my-ws--alice.proxy.example.com/apps?tab=1",
+		);
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/AskUserQuestionTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/AskUserQuestionTool.tsx
@@ -9,6 +9,7 @@ import { Button } from "#/components/Button/Button";
 import { Input } from "#/components/Input/Input";
 import { RadioGroup, RadioGroupItem } from "#/components/RadioGroup/RadioGroup";
 import { cn } from "#/utils/cn";
+import { LinkifiedText } from "../LinkifiedText";
 import { ToolCall } from "./ToolCall";
 import type { ToolStatus } from "./utils";
 
@@ -302,7 +303,9 @@ const QuestionStep: FC<QuestionStepProps> = ({
 						{questionHeader}
 					</span>
 					<span aria-hidden="true">Asking: </span>
-					<span>{questionText}</span>
+					<span>
+						<LinkifiedText text={questionText} />
+					</span>
 				</p>
 			</div>
 			<div className="rounded-md border border-solid border-border-default px-3 py-1">
@@ -362,7 +365,9 @@ const AnsweredQuestionText: FC<AnsweredQuestionTextProps> = ({
 				className="m-0 min-w-0 flex-1 whitespace-pre-wrap text-[13px]"
 			>
 				<span aria-hidden="true">Asked: </span>
-				<span>{getQuestionText(question)}</span>
+				<span>
+					<LinkifiedText text={getQuestionText(question)} />
+				</span>
 			</p>
 		</div>
 	);

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, userEvent, within } from "storybook/test";
+import { rewriteLocalhostURL } from "#/utils/portForward";
+import { ChatUrlTransformContext } from "../../../context/ChatUrlTransformContext";
 import { ExecuteTool } from "./ExecuteTool";
 
 const longCommand =
@@ -197,6 +199,69 @@ export const ParsedCommandsWithIntent: Story = {
 			["cd", "/repo"],
 			["go", "test"],
 		],
+	},
+};
+
+const devServerOutput = [
+	"  ➜  Local:   http://localhost:3000/",
+	"  ➜  Network: http://127.0.0.1:3000/",
+	"Docs at https://vite.dev/guide/.",
+].join("\n");
+
+export const LocalhostUrlInOutput: Story = {
+	decorators: [
+		(Story) => (
+			<ChatUrlTransformContext
+				value={(url) =>
+					rewriteLocalhostURL(
+						url,
+						"*.proxy.example.com",
+						"main",
+						"my-ws",
+						"alice",
+					)
+				}
+			>
+				<Story />
+			</ChatUrlTransformContext>
+		),
+	],
+	args: {
+		command: "pnpm dev",
+		transcriptBlocks: [{ kind: "output", text: devServerOutput }],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const local = await canvas.findByRole("link", {
+			name: "http://localhost:3000/",
+		});
+		expect(local).toHaveAttribute(
+			"href",
+			"http://3000--main--my-ws--alice.proxy.example.com/",
+		);
+		const network = canvas.getByRole("link", {
+			name: "http://127.0.0.1:3000/",
+		});
+		expect(network).toHaveAttribute(
+			"href",
+			"http://3000--main--my-ws--alice.proxy.example.com/",
+		);
+		const docs = canvas.getByRole("link", { name: "https://vite.dev/guide/" });
+		expect(docs).toHaveAttribute("href", "https://vite.dev/guide/");
+	},
+};
+
+export const LocalhostUrlInOutputWithoutTransform: Story = {
+	args: {
+		command: "pnpm dev",
+		transcriptBlocks: [{ kind: "output", text: devServerOutput }],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const local = await canvas.findByRole("link", {
+			name: "http://localhost:3000/",
+		});
+		expect(local).toHaveAttribute("href", "http://localhost:3000/");
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, userEvent, within } from "storybook/test";
+import { rewriteLocalhostURL } from "#/utils/portForward";
+import { ChatUrlTransformContext } from "../../../context/ChatUrlTransformContext";
 import { ExecuteTool } from "./ExecuteTool";
 
 const longCommand =
@@ -205,6 +207,69 @@ export const ParsedCommandsWithIntent: Story = {
 			["cd", "/repo"],
 			["go", "test"],
 		],
+	},
+};
+
+const devServerOutput = [
+	"  ➜  Local:   http://localhost:3000/",
+	"  ➜  Network: http://127.0.0.1:3000/",
+	"Docs at https://vite.dev/guide/.",
+].join("\n");
+
+export const LocalhostUrlInOutput: Story = {
+	decorators: [
+		(Story) => (
+			<ChatUrlTransformContext
+				value={(url) =>
+					rewriteLocalhostURL(
+						url,
+						"*.proxy.example.com",
+						"main",
+						"my-ws",
+						"alice",
+					)
+				}
+			>
+				<Story />
+			</ChatUrlTransformContext>
+		),
+	],
+	args: {
+		command: "pnpm dev",
+		transcriptBlocks: [{ kind: "output", text: devServerOutput }],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const local = await canvas.findByRole("link", {
+			name: "http://localhost:3000/",
+		});
+		expect(local).toHaveAttribute(
+			"href",
+			"http://3000--main--my-ws--alice.proxy.example.com/",
+		);
+		const network = canvas.getByRole("link", {
+			name: "http://127.0.0.1:3000/",
+		});
+		expect(network).toHaveAttribute(
+			"href",
+			"http://3000--main--my-ws--alice.proxy.example.com/",
+		);
+		const docs = canvas.getByRole("link", { name: "https://vite.dev/guide/" });
+		expect(docs).toHaveAttribute("href", "https://vite.dev/guide/");
+	},
+};
+
+export const LocalhostUrlInOutputWithoutTransform: Story = {
+	args: {
+		command: "pnpm dev",
+		transcriptBlocks: [{ kind: "output", text: devServerOutput }],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const local = await canvas.findByRole("link", {
+			name: "http://localhost:3000/",
+		});
+		expect(local).toHaveAttribute("href", "http://localhost:3000/");
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
@@ -9,6 +9,7 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { cn } from "#/utils/cn";
+import { LinkifiedText } from "../LinkifiedText";
 import {
 	type AgentDisplayState,
 	resolveAgentDisplayState,
@@ -207,7 +208,7 @@ const ShellTranscriptBody: React.FC<{
 								: "text-content-secondary",
 						)}
 					>
-						{block.text}
+						<LinkifiedText text={block.text} />
 					</pre>
 				))}
 			</div>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
@@ -17,6 +17,7 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { cn } from "#/utils/cn";
+import { LinkifiedText } from "../LinkifiedText";
 import {
 	type AgentDisplayState,
 	resolveAgentDisplayState,
@@ -209,7 +210,7 @@ const ShellTranscriptBody: React.FC<{
 								: "text-content-secondary",
 						)}
 					>
-						{block.text}
+						<LinkifiedText text={block.text} />
 					</pre>
 				))}
 			</div>
@@ -270,7 +271,7 @@ export const ExecuteAuthRequiredTool: React.FC<{
 					scrollBarClassName="w-1.5"
 				>
 					<pre className="m-0 whitespace-pre-wrap break-all border-0 bg-transparent px-3 py-2 font-mono text-xs text-content-secondary">
-						{output}
+						<LinkifiedText text={output} />
 					</pre>
 				</ScrollArea>
 			)}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessOutputTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessOutputTool.tsx
@@ -10,6 +10,7 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { cn } from "#/utils/cn";
+import { LinkifiedText } from "../LinkifiedText";
 import {
 	type AgentDisplayState,
 	isAgentDisplayFullyExpanded,
@@ -78,6 +79,26 @@ const ProcessOutputToolInner: React.FC<ProcessOutputToolInnerProps> = ({
 	const toggleOutputExpansion = () => {
 		setOutputFullyExpanded((expanded) => !expanded);
 	};
+	// Browsers may scroll clipped output to reveal focus, so scrollTop detects hidden links.
+	const handleTranscriptFocus = (event: React.FocusEvent<HTMLPreElement>) => {
+		if (outputFullyExpanded || !overflows) {
+			return;
+		}
+		const pre = event.currentTarget;
+		const target = event.target;
+		const focusInClippedArea =
+			pre.scrollTop > 0 ||
+			target.getBoundingClientRect().bottom >
+				pre.getBoundingClientRect().bottom;
+		if (focusInClippedArea) {
+			pre.scrollTop = 0;
+			setOutputFullyExpanded(true);
+			// The focused link may remain off-screen after the expanded layout commits.
+			requestAnimationFrame(() => {
+				target.scrollIntoView({ block: "nearest" });
+			});
+		}
+	};
 	const hasHeaderActions = Boolean(killedBySignal) || showExitCode || hasOutput;
 
 	return (
@@ -134,6 +155,7 @@ const ProcessOutputToolInner: React.FC<ProcessOutputToolInnerProps> = ({
 				>
 					<pre
 						ref={measureRef}
+						onFocus={handleTranscriptFocus}
 						style={
 							outputFullyExpanded
 								? undefined
@@ -144,7 +166,7 @@ const ProcessOutputToolInner: React.FC<ProcessOutputToolInnerProps> = ({
 							isError ? "text-content-destructive" : "text-content-secondary",
 						)}
 					>
-						{output}
+						<LinkifiedText text={output} />
 					</pre>
 				</ScrollArea>
 				{overflows && (

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessOutputTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessOutputTool.tsx
@@ -10,6 +10,7 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { cn } from "#/utils/cn";
+import { LinkifiedText } from "../LinkifiedText";
 import {
 	type AgentDisplayState,
 	isAgentDisplayFullyExpanded,
@@ -144,7 +145,7 @@ const ProcessOutputToolInner: React.FC<ProcessOutputToolInnerProps> = ({
 							isError ? "text-content-destructive" : "text-content-secondary",
 						)}
 					>
-						{output}
+						<LinkifiedText text={output} />
 					</pre>
 				</ScrollArea>
 				{overflows && (

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -729,11 +729,23 @@ export const ProcessOutputFocusExpandsClippedLink: Story = {
 			).toHaveAttribute("aria-expanded", "true");
 		});
 		expect(link.checkVisibility()).toBe(true);
-		// checkVisibility ignores scroll position, so viewport scrollTop is
-		// the only assertion that fails if the scroll-reveal regresses.
-		const viewport = link.closest("[data-radix-scroll-area-viewport]");
+		// checkVisibility ignores scroll position, so the reveal is only
+		// observable as a scrolled ancestor. Walking ancestors avoids
+		// assuming which container implements the scrolling.
+		const scrolledAncestor = () => {
+			for (
+				let node = link.parentElement;
+				node && node !== canvasElement;
+				node = node.parentElement
+			) {
+				if (node.scrollTop > 0) {
+					return node;
+				}
+			}
+			return undefined;
+		};
 		await waitFor(() => {
-			expect(viewport?.scrollTop).toBeGreaterThan(0);
+			expect(scrolledAncestor()).toBeDefined();
 		});
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -7,6 +7,8 @@ import { workspaceByIdKey } from "#/api/queries/workspaces";
 import type * as TypesGen from "#/api/typesGenerated";
 import { MockChatModelConfig } from "#/testHelpers/chatModels";
 import { MockWorkspace, MockWorkspaceBuild } from "#/testHelpers/entities";
+import { rewriteLocalhostURL } from "#/utils/portForward";
+import { ChatUrlTransformContext } from "../../../context/ChatUrlTransformContext";
 import { ChatWorkspaceContext } from "../../../context/ChatWorkspaceContext";
 import { BlockList } from "../../ChatConversation/ConversationTimeline";
 import { DesktopPanelContext } from "./DesktopPanelContext";
@@ -659,6 +661,79 @@ export const ProcessOutputAlwaysExpanded: Story = {
 					name: "Collapse full process output",
 				}),
 			).toHaveAttribute("aria-expanded", "true");
+		});
+	},
+};
+
+export const ProcessOutputLocalhostLinkRewritten: Story = {
+	decorators: [
+		(Story) => (
+			<ChatUrlTransformContext
+				value={(url) =>
+					rewriteLocalhostURL(
+						url,
+						"*.proxy.example.com",
+						"main",
+						"my-ws",
+						"alice",
+					)
+				}
+			>
+				<Story />
+			</ChatUrlTransformContext>
+		),
+	],
+	args: {
+		name: "process_output",
+		status: "completed",
+		shellToolDisplayMode: "always_expanded",
+		result: {
+			output: "Server ready at http://localhost:3000/apps?tab=1\ndone",
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const link = await canvas.findByRole("link", {
+			name: "http://localhost:3000/apps?tab=1",
+		});
+		expect(link).toHaveAttribute(
+			"href",
+			"http://3000--main--my-ws--alice.proxy.example.com/apps?tab=1",
+		);
+	},
+};
+
+export const ProcessOutputFocusExpandsClippedLink: Story = {
+	args: {
+		name: "process_output",
+		status: "completed",
+		result: {
+			output: [
+				...Array.from({ length: 40 }, (_, index) => `line ${index + 1}`),
+				"Server at http://localhost:3000/",
+			].join("\n"),
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const link = await canvas.findByRole("link", {
+			name: "http://localhost:3000/",
+		});
+		expect(
+			canvas.getByRole("button", { name: "Expand full process output" }),
+		).toHaveAttribute("aria-expanded", "false");
+		link.focus();
+		await waitFor(() => {
+			expect(
+				canvas.getByRole("button", { name: "Collapse full process output" }),
+			).toHaveAttribute("aria-expanded", "true");
+		});
+		expect(link.checkVisibility()).toBe(true);
+		// checkVisibility ignores scroll position, so viewport scrollTop is
+		// the only assertion that fails if the scroll-reveal regresses.
+		const viewport = link.closest("[data-radix-scroll-area-viewport]");
+		await waitFor(() => {
+			expect(viewport?.scrollTop).toBeGreaterThan(0);
 		});
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -1,7 +1,6 @@
 import { type FC, Profiler, type ReactNode, useEffect, useRef } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { toast } from "sonner";
-import type { UrlTransform } from "streamdown";
 import { chatPromptsQuery, refreshChatContext } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { AgentChatSendShortcut } from "#/api/typesGenerated";
@@ -86,7 +85,6 @@ interface ChatPageTimelineProps {
 	editingMessageId?: number | null;
 	onImplementPlan?: () => Promise<void> | void;
 	onSendAskUserQuestionResponse?: (message: string) => Promise<void> | void;
-	urlTransform?: UrlTransform;
 	mcpServers?: readonly TypesGen.MCPServerConfig[];
 }
 
@@ -97,7 +95,6 @@ export const ChatPageTimeline: FC<ChatPageTimelineProps> = ({
 	editingMessageId,
 	onImplementPlan,
 	onSendAskUserQuestionResponse,
-	urlTransform,
 	mcpServers,
 }) => {
 	const [chatFullWidth] = useChatFullWidth();
@@ -157,7 +154,6 @@ export const ChatPageTimeline: FC<ChatPageTimelineProps> = ({
 					isChatCompleted={isChatCompleted}
 					hasActiveStream={hasStream}
 					isAwaitingFirstStreamChunk={isAwaitingFirstStreamChunk}
-					urlTransform={urlTransform}
 					mcpServers={mcpServers}
 					showDesktopPreviews={false}
 				/>
@@ -167,7 +163,6 @@ export const ChatPageTimeline: FC<ChatPageTimelineProps> = ({
 					isTranscriptEmpty={parsedMessages.length === 0}
 					subagentTitles={subagentTitles}
 					subagentVariants={subagentVariants}
-					urlTransform={urlTransform}
 					mcpServers={mcpServers}
 				/>
 			</div>

--- a/site/src/pages/AgentsPage/context/ChatUrlTransformContext.tsx
+++ b/site/src/pages/AgentsPage/context/ChatUrlTransformContext.tsx
@@ -1,0 +1,11 @@
+import { createContext, useContext } from "react";
+
+export type ChatUrlTransform = (url: string) => string;
+
+const ChatUrlTransformContext = createContext<ChatUrlTransform | undefined>(
+	undefined,
+);
+
+export const useChatUrlTransform = () => useContext(ChatUrlTransformContext);
+
+export { ChatUrlTransformContext };

--- a/site/src/pages/AgentsPage/context/ChatUrlTransformContext.tsx
+++ b/site/src/pages/AgentsPage/context/ChatUrlTransformContext.tsx
@@ -1,0 +1,16 @@
+import { createContext, useContext } from "react";
+
+/**
+ * The single-argument shape (vs streamdown's UrlTransform) lets
+ * plain-text surfaces call it with just a URL while staying assignable
+ * to Streamdown's urlTransform prop.
+ */
+export type ChatUrlTransform = (url: string) => string;
+
+const ChatUrlTransformContext = createContext<ChatUrlTransform | undefined>(
+	undefined,
+);
+
+export const useChatUrlTransform = () => useContext(ChatUrlTransformContext);
+
+export { ChatUrlTransformContext };

--- a/site/src/utils/portForward.test.ts
+++ b/site/src/utils/portForward.test.ts
@@ -168,6 +168,32 @@ describe("rewriteLocalhostURL", () => {
 		);
 	});
 
+	it("rewrites [::1]", () => {
+		const result = rewriteLocalhostURL(
+			"http://[::1]:8080/",
+			proxyHost,
+			agent,
+			workspace,
+			username,
+		);
+		expect(result).toEqual(
+			"http://8080--my-agent--my-workspace--my-username.proxy-host.tld/",
+		);
+	});
+
+	it("returns an already rewritten URL unchanged", () => {
+		const rewritten = rewriteLocalhostURL(
+			"http://localhost:3000/app",
+			proxyHost,
+			agent,
+			workspace,
+			username,
+		);
+		expect(
+			rewriteLocalhostURL(rewritten, proxyHost, agent, workspace, username),
+		).toEqual(rewritten);
+	});
+
 	it("preserves query params", () => {
 		const result = rewriteLocalhostURL(
 			"http://localhost:3000/path?key=value",
@@ -178,6 +204,19 @@ describe("rewriteLocalhostURL", () => {
 		);
 		expect(result).toEqual(
 			"http://3000--my-agent--my-workspace--my-username.proxy-host.tld/path?key=value",
+		);
+	});
+
+	it("preserves hash fragments", () => {
+		const result = rewriteLocalhostURL(
+			"http://localhost:3000/#/settings",
+			proxyHost,
+			agent,
+			workspace,
+			username,
+		);
+		expect(result).toEqual(
+			"http://3000--my-agent--my-workspace--my-username.proxy-host.tld/#/settings",
 		);
 	});
 

--- a/site/src/utils/portForward.test.ts
+++ b/site/src/utils/portForward.test.ts
@@ -181,6 +181,19 @@ describe("rewriteLocalhostURL", () => {
 		);
 	});
 
+	it("preserves hash fragments", () => {
+		const result = rewriteLocalhostURL(
+			"http://localhost:3000/#/settings",
+			proxyHost,
+			agent,
+			workspace,
+			username,
+		);
+		expect(result).toEqual(
+			"http://3000--my-agent--my-workspace--my-username.proxy-host.tld/#/settings",
+		);
+	});
+
 	it("returns non-localhost URLs unchanged", () => {
 		const url = "https://example.com/page";
 		expect(

--- a/site/src/utils/portForward.ts
+++ b/site/src/utils/portForward.ts
@@ -1,6 +1,7 @@
 import type { WorkspaceAgentPortShareProtocol } from "#/api/typesGenerated";
 
-const localHosts = new Set(["localhost", "127.0.0.1", "0.0.0.0"]);
+// URL.hostname keeps the brackets around IPv6 addresses ("[::1]").
+const localHosts = new Set(["localhost", "127.0.0.1", "0.0.0.0", "[::1]"]);
 
 /**
  * Parse a port string from a URL, falling back to the protocol default
@@ -31,6 +32,7 @@ export const portForwardURL = (
 	protocol: WorkspaceAgentPortShareProtocol,
 	pathname?: string,
 	search?: string,
+	hash?: string,
 ): string => {
 	const { location } = window;
 	const suffix = protocol === "https" ? "s" : "";
@@ -45,6 +47,9 @@ export const portForwardURL = (
 		}
 		if (search) {
 			url.search = search;
+		}
+		if (hash) {
+			url.hash = hash;
 		}
 		return url.toString();
 	} catch {
@@ -84,6 +89,7 @@ export const rewriteLocalhostURL = (
 			protocol,
 			parsed.pathname,
 			parsed.search,
+			parsed.hash,
 		);
 	} catch {
 		return url;

--- a/site/src/utils/portForward.ts
+++ b/site/src/utils/portForward.ts
@@ -31,6 +31,7 @@ export const portForwardURL = (
 	protocol: WorkspaceAgentPortShareProtocol,
 	pathname?: string,
 	search?: string,
+	hash?: string,
 ): string => {
 	const { location } = window;
 	const suffix = protocol === "https" ? "s" : "";
@@ -45,6 +46,9 @@ export const portForwardURL = (
 		}
 		if (search) {
 			url.search = search;
+		}
+		if (hash) {
+			url.hash = hash;
 		}
 		return url.toString();
 	} catch {
@@ -84,6 +88,7 @@ export const rewriteLocalhostURL = (
 			protocol,
 			parsed.pathname,
 			parsed.search,
+			parsed.hash,
 		);
 	} catch {
 		return url;


### PR DESCRIPTION
Closes coder/coder#25193 ([CODAGT-397](https://linear.app/codercom/issue/CODAGT-397/redirect-localhost-urls-to-workspace-port-urls)).

## Problem

Agent chat surfaces localhost URLs that point at the user's machine instead of the workspace. Ordinary assistant markdown already rewrites hrefs via `rewriteLocalhostURL`, but the transform stopped at the tool boundary:

* Markdown inside tool cards (sub-agent reports, plans, advisor output, summaries, skills) rendered `<Response>` without a `urlTransform`, so localhost hrefs stayed unrewritten.
* Shell-style output (`execute`, `process_output`) and `ask_user_question` text rendered plain text with no links at all, unlike the web terminal, which linkifies URLs and routes localhost ones through the port-forward subdomain.
* Links rendered before workspace data finished loading kept their localhost hrefs until a page refresh: Streamdown memoizes rendered blocks by content and ignores later `urlTransform` changes.

## Changes

* New `ChatUrlTransformContext`, provided around the chat timeline from the existing chat `urlTransform`. Markdown anchors read the transform through context at render time (`MarkdownAnchor`), so hrefs pick up workspace data as soon as it loads, mid-stream, without a remount, and retarget if the chat is rebound to another workspace. Streamdown receives only a src-only transform (for images), keeping cached hrefs raw.
* The transform is context-only inside the chat: the old `urlTransform` prop threading through `ChatPageTimeline`, `ConversationTimeline`, `LiveStreamTail`, and `StreamingOutput` is removed. `Response` keeps an optional `urlTransform` prop override for standalone use, and an explicit prop still wins over context.
* New pure `splitTextForLinks` helper plus a `LinkifiedText` component that renders http(s) URLs in plain-text agent output as anchors (original text preserved, trailing punctuation, unmatched bracket wrappers, and ANSI escapes excluded), with hrefs routed through the chat transform. Wired into `ExecuteTool` transcript/output, `ProcessOutputTool` output, and `ask_user_question` question text.
* `rewriteLocalhostURL` also recognizes `[::1]` and preserves hash fragments.
* Coverage: vitest unit tests for the linkify helper and portForward; Storybook play tests for tool-card rewrite, shell-output links in `execute` and `process_output`, question-text links, context fallback, prop-wins-over-context, a mid-stream story that flips the context after render, and a workspace-rebind story that switches the transform and asserts hrefs retarget.

## Validation

* `tsc`, biome, and formatting pass on the touched files.
* `vitest --project=unit`: linkify + portForward tests pass (29 tests).
* `vitest --project=storybook`: all touched story files pass. The pre-existing `MCP Tool Completed` failure reproduces identically on clean `origin/main` and is unrelated.
* Red-green verified for each guard story: mid-stream rewrite, process-output linkification, question-text linkification, and workspace retargeting each fail with their fix removed.
* Remote dogfood UAT on [dev.coder.com](<http://dev.coder.com>): PASS. Mid-stream rewrite verified live on a fresh workspace (links flipped in place without refresh, identical after reload), full URL-shape matrix verified in markdown and shell output, rewritten port-forward link returned HTTP 200 end to end.

> This PR was created by Mux, an AI coding agent, on Mike's behalf.