### PR TITLE
docs(docs/admin/users): document `login_type=none` deprecation and password conversion

### DIFF
--- a/docs/admin/users/headless-auth.md
+++ b/docs/admin/users/headless-auth.md
@@ -36,3 +36,53 @@ Navigate to **Deployment** > **Users** > **Create user**, then select
 
 To make API or CLI requests on behalf of the headless user, learn how to
 [generate API tokens on behalf of a user](./sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-another-user).
+
+## Deprecation of `login_type=none`
+
+Older Coder versions created passwordless machine users with
+`coder users create --login-type none` or the `--disable-login` flag. Creating
+these accounts is no longer supported. Use service accounts for
+machine-to-machine access instead.
+
+Coder rejects these requests at creation:
+
+- `coder users create --login-type none` fails unless you also pass
+  `--service-account`:
+
+  ```text
+  Login type 'none' requires --service-account.
+  ```
+
+- `--disable-login` is rejected:
+
+  ```text
+  --disable-login is deprecated. Use --service-account for machine-to-machine access.
+  ```
+
+- `POST /users` returns `400 Bad Request` for `login_type: "none"` without a
+  service account:
+
+  ```text
+  Login type 'none' requires a service account.
+  ```
+
+Service accounts require a [Premium license](https://coder.com/pricing). On
+OSS deployments, create a regular user with password, GitHub, or OIDC
+authentication for automation instead. See
+[Test templates through CI/CD](../../tutorials/testing-templates.md) for an
+example.
+
+### Upgrade behavior
+
+When you upgrade, Coder converts existing non-system `login_type=none` users to
+password authentication (`login_type=password`). Their email addresses and
+existing API tokens are **preserved**, so token-based automation keeps working
+unchanged. System users are not affected.
+
+These accounts have no password set, so an admin must
+[reset the password](./index.md#reset-a-password) before the account can log in
+through the web UI. Machine access through existing tokens is unaffected.
+
+> [!NOTE]
+> This conversion is one-way. Coder does not record which users previously had
+> `login_type=none`, so a downgrade cannot restore it.


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Docs follow-up for #26851 ([DEVEX-226]). Documents the deprecation of `login_type=none` and the conversion of existing accounts. Merge **after** #26851, since it describes that PR's behavior.

> Replaces #27292, which auto-closed when its base branch (the closed #27182) was deleted.

## What this does

Updates `docs/admin/users/headless-auth.md`:

- **Creation is rejected.** Documents that `coder users create --login-type none` (and the deprecated `--disable-login`) now error unless `--service-account` is passed, and that `POST /users` returns `400` for `login_type: "none"` without a service account. Uses the exact error strings from `cli/usercreate.go` and `coderd/users.go`.
- **Premium / OSS split.** Notes that service accounts require Premium and points OSS deployments at regular users (password/GitHub/OIDC), linking the existing CI/CD tutorial.
- **Upgrade behavior.** Documents that upgrading converts existing non-system `login_type=none` users to `password` login, **preserving** their email and existing API tokens (matching #26851). An admin must reset the password before web-UI login; token automation is unaffected. One-way conversion.

No new pages, so no `manifest.json` change.

## Verification

- Error strings copied verbatim from the code in #26851 (`cli/usercreate.go`, `coderd/users.go`); upgrade behavior matches `000548_legacy_none_login_to_password.up.sql`.
- `make lint/emdash`, `markdownlint-cli2`, and `vale` all pass on the edited page.

[DEVEX-226]: https://linear.app/issue/DEVEX-226