### PR TITLE
feat: add organization-aware chat model discovery

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -1026,6 +1026,85 @@ const docTemplate = `{
                 ]
             }
         },
+        "/api/experimental/organizations/{organization}/chat-model-configs": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "List organization chat model configs",
+                "operationId": "list-organization-chat-model-configs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization ID or name",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/codersdk.ChatModelConfig"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/experimental/organizations/{organization}/chats/models": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "List organization chat models",
+                "operationId": "list-organization-chat-models",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization ID or name",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatModelsResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
         "/api/experimental/users/{user}/skills": {
             "get": {
                 "produces": [
@@ -17575,6 +17654,341 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.ChatModelAnthropicProviderOptions": {
+            "type": "object",
+            "properties": {
+                "allowed_domains": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "blocked_domains": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "context_1m_enabled": {
+                    "type": "boolean"
+                },
+                "disable_parallel_tool_use": {
+                    "type": "boolean"
+                },
+                "send_reasoning": {
+                    "type": "boolean"
+                },
+                "thinking": {
+                    "$ref": "#/definitions/codersdk.ChatModelAnthropicThinkingOptions"
+                },
+                "thinking_display": {
+                    "type": "string"
+                },
+                "web_search_enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "codersdk.ChatModelAnthropicThinkingOptions": {
+            "type": "object",
+            "properties": {
+                "budget_tokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "codersdk.ChatModelCallConfig": {
+            "type": "object",
+            "properties": {
+                "cost": {
+                    "$ref": "#/definitions/codersdk.ModelCostConfig"
+                },
+                "frequency_penalty": {
+                    "type": "number"
+                },
+                "max_output_tokens": {
+                    "type": "integer"
+                },
+                "presence_penalty": {
+                    "type": "number"
+                },
+                "provider_options": {
+                    "$ref": "#/definitions/codersdk.ChatModelProviderOptions"
+                },
+                "reasoning_effort": {
+                    "$ref": "#/definitions/codersdk.ChatModelReasoningEffortConfig"
+                },
+                "temperature": {
+                    "type": "number"
+                },
+                "top_k": {
+                    "type": "integer"
+                },
+                "top_p": {
+                    "type": "number"
+                }
+            }
+        },
+        "codersdk.ChatModelConfig": {
+            "type": "object",
+            "properties": {
+                "ai_provider_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "compression_threshold": {
+                    "type": "integer"
+                },
+                "context_limit": {
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "is_default": {
+                    "type": "boolean"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "model_config": {
+                    "$ref": "#/definitions/codersdk.ChatModelCallConfig"
+                },
+                "reasoning_efforts": {
+                    "description": "ReasoningEfforts lists selectable reasoning effort values through\nthe model's configured maximum.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            }
+        },
+        "codersdk.ChatModelGoogleProviderOptions": {
+            "type": "object",
+            "properties": {
+                "cached_content": {
+                    "type": "string"
+                },
+                "safety_settings": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.ChatModelGoogleSafetySetting"
+                    }
+                },
+                "thinking_config": {
+                    "$ref": "#/definitions/codersdk.ChatModelGoogleThinkingConfig"
+                },
+                "threshold": {
+                    "type": "string"
+                },
+                "web_search_enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "codersdk.ChatModelGoogleSafetySetting": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "threshold": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.ChatModelGoogleThinkingConfig": {
+            "type": "object",
+            "properties": {
+                "include_thoughts": {
+                    "type": "boolean"
+                },
+                "thinking_budget": {
+                    "type": "integer"
+                }
+            }
+        },
+        "codersdk.ChatModelOpenAICompatProviderOptions": {
+            "type": "object",
+            "properties": {
+                "user": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.ChatModelOpenAIProviderOptions": {
+            "type": "object",
+            "properties": {
+                "allowed_domains": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "include": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "instructions": {
+                    "type": "string"
+                },
+                "log_probs": {
+                    "type": "boolean"
+                },
+                "logit_bias": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                },
+                "max_completion_tokens": {
+                    "type": "integer"
+                },
+                "max_tool_calls": {
+                    "type": "integer"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "parallel_tool_calls": {
+                    "type": "boolean"
+                },
+                "prediction": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "prompt_cache_key": {
+                    "type": "string"
+                },
+                "reasoning_summary": {
+                    "type": "string"
+                },
+                "safety_identifier": {
+                    "type": "string"
+                },
+                "search_context_size": {
+                    "type": "string"
+                },
+                "service_tier": {
+                    "type": "string"
+                },
+                "store": {
+                    "type": "boolean"
+                },
+                "strict_json_schema": {
+                    "type": "boolean"
+                },
+                "structured_outputs": {
+                    "type": "boolean"
+                },
+                "text_verbosity": {
+                    "type": "string"
+                },
+                "top_log_probs": {
+                    "type": "integer"
+                },
+                "user": {
+                    "type": "string"
+                },
+                "web_search_enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "codersdk.ChatModelOpenRouterProvider": {
+            "type": "object",
+            "properties": {
+                "allow_fallbacks": {
+                    "type": "boolean"
+                },
+                "data_collection": {
+                    "type": "string"
+                },
+                "ignore": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "only": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "order": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "quantizations": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "require_parameters": {
+                    "type": "boolean"
+                },
+                "sort": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.ChatModelOpenRouterProviderOptions": {
+            "type": "object",
+            "properties": {
+                "extra_body": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "include_usage": {
+                    "type": "boolean"
+                },
+                "log_probs": {
+                    "type": "boolean"
+                },
+                "logit_bias": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                },
+                "parallel_tool_calls": {
+                    "type": "boolean"
+                },
+                "provider": {
+                    "$ref": "#/definitions/codersdk.ChatModelOpenRouterProvider"
+                },
+                "reasoning": {
+                    "$ref": "#/definitions/codersdk.ChatModelReasoningOptions"
+                },
+                "user": {
+                    "type": "string"
+                }
+            }
+        },
         "codersdk.ChatModelProvider": {
             "type": "object",
             "properties": {
@@ -17595,6 +18009,29 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.ChatModelProviderOptions": {
+            "type": "object",
+            "properties": {
+                "anthropic": {
+                    "$ref": "#/definitions/codersdk.ChatModelAnthropicProviderOptions"
+                },
+                "google": {
+                    "$ref": "#/definitions/codersdk.ChatModelGoogleProviderOptions"
+                },
+                "openai": {
+                    "$ref": "#/definitions/codersdk.ChatModelOpenAIProviderOptions"
+                },
+                "openaicompat": {
+                    "$ref": "#/definitions/codersdk.ChatModelOpenAICompatProviderOptions"
+                },
+                "openrouter": {
+                    "$ref": "#/definitions/codersdk.ChatModelOpenRouterProviderOptions"
+                },
+                "vercel": {
+                    "$ref": "#/definitions/codersdk.ChatModelVercelProviderOptions"
+                }
+            }
+        },
         "codersdk.ChatModelProviderUnavailableReason": {
             "type": "string",
             "enum": [
@@ -17607,6 +18044,82 @@ const docTemplate = `{
                 "ChatModelProviderUnavailableFetchFailed",
                 "ChatModelProviderUnavailableReasonUserAPIKeyRequired"
             ]
+        },
+        "codersdk.ChatModelReasoningEffortConfig": {
+            "type": "object",
+            "properties": {
+                "default": {
+                    "type": "string"
+                },
+                "max": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.ChatModelReasoningOptions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "exclude": {
+                    "type": "boolean"
+                },
+                "max_tokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "codersdk.ChatModelVercelGatewayProviderOptions": {
+            "type": "object",
+            "properties": {
+                "models": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "order": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "codersdk.ChatModelVercelProviderOptions": {
+            "type": "object",
+            "properties": {
+                "extra_body": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "logit_bias": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                },
+                "logprobs": {
+                    "type": "boolean"
+                },
+                "parallel_tool_calls": {
+                    "type": "boolean"
+                },
+                "providerOptions": {
+                    "$ref": "#/definitions/codersdk.ChatModelVercelGatewayProviderOptions"
+                },
+                "reasoning": {
+                    "$ref": "#/definitions/codersdk.ChatModelReasoningOptions"
+                },
+                "top_logprobs": {
+                    "type": "integer"
+                },
+                "user": {
+                    "type": "string"
+                }
+            }
         },
         "codersdk.ChatModelsResponse": {
             "type": "object",
@@ -20664,6 +21177,23 @@ const docTemplate = `{
                 },
                 "username": {
                     "type": "string"
+                }
+            }
+        },
+        "codersdk.ModelCostConfig": {
+            "type": "object",
+            "properties": {
+                "cache_read_price_per_million_tokens": {
+                    "type": "number"
+                },
+                "cache_write_price_per_million_tokens": {
+                    "type": "number"
+                },
+                "input_price_per_million_tokens": {
+                    "type": "number"
+                },
+                "output_price_per_million_tokens": {
+                    "type": "number"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -907,6 +907,77 @@
 				]
 			}
 		},
+		"/api/experimental/organizations/{organization}/chat-model-configs": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "List organization chat model configs",
+				"operationId": "list-organization-chat-model-configs",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization ID or name",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/codersdk.ChatModelConfig"
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/experimental/organizations/{organization}/chats/models": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "List organization chat models",
+				"operationId": "list-organization-chat-models",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization ID or name",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatModelsResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
 		"/api/experimental/users/{user}/skills": {
 			"get": {
 				"produces": ["application/json"],
@@ -15838,6 +15909,341 @@
 				}
 			}
 		},
+		"codersdk.ChatModelAnthropicProviderOptions": {
+			"type": "object",
+			"properties": {
+				"allowed_domains": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"blocked_domains": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"context_1m_enabled": {
+					"type": "boolean"
+				},
+				"disable_parallel_tool_use": {
+					"type": "boolean"
+				},
+				"send_reasoning": {
+					"type": "boolean"
+				},
+				"thinking": {
+					"$ref": "#/definitions/codersdk.ChatModelAnthropicThinkingOptions"
+				},
+				"thinking_display": {
+					"type": "string"
+				},
+				"web_search_enabled": {
+					"type": "boolean"
+				}
+			}
+		},
+		"codersdk.ChatModelAnthropicThinkingOptions": {
+			"type": "object",
+			"properties": {
+				"budget_tokens": {
+					"type": "integer"
+				}
+			}
+		},
+		"codersdk.ChatModelCallConfig": {
+			"type": "object",
+			"properties": {
+				"cost": {
+					"$ref": "#/definitions/codersdk.ModelCostConfig"
+				},
+				"frequency_penalty": {
+					"type": "number"
+				},
+				"max_output_tokens": {
+					"type": "integer"
+				},
+				"presence_penalty": {
+					"type": "number"
+				},
+				"provider_options": {
+					"$ref": "#/definitions/codersdk.ChatModelProviderOptions"
+				},
+				"reasoning_effort": {
+					"$ref": "#/definitions/codersdk.ChatModelReasoningEffortConfig"
+				},
+				"temperature": {
+					"type": "number"
+				},
+				"top_k": {
+					"type": "integer"
+				},
+				"top_p": {
+					"type": "number"
+				}
+			}
+		},
+		"codersdk.ChatModelConfig": {
+			"type": "object",
+			"properties": {
+				"ai_provider_id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"compression_threshold": {
+					"type": "integer"
+				},
+				"context_limit": {
+					"type": "integer"
+				},
+				"created_at": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"display_name": {
+					"type": "string"
+				},
+				"enabled": {
+					"type": "boolean"
+				},
+				"id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"is_default": {
+					"type": "boolean"
+				},
+				"model": {
+					"type": "string"
+				},
+				"model_config": {
+					"$ref": "#/definitions/codersdk.ChatModelCallConfig"
+				},
+				"reasoning_efforts": {
+					"description": "ReasoningEfforts lists selectable reasoning effort values through\nthe model's configured maximum.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"updated_at": {
+					"type": "string",
+					"format": "date-time"
+				}
+			}
+		},
+		"codersdk.ChatModelGoogleProviderOptions": {
+			"type": "object",
+			"properties": {
+				"cached_content": {
+					"type": "string"
+				},
+				"safety_settings": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.ChatModelGoogleSafetySetting"
+					}
+				},
+				"thinking_config": {
+					"$ref": "#/definitions/codersdk.ChatModelGoogleThinkingConfig"
+				},
+				"threshold": {
+					"type": "string"
+				},
+				"web_search_enabled": {
+					"type": "boolean"
+				}
+			}
+		},
+		"codersdk.ChatModelGoogleSafetySetting": {
+			"type": "object",
+			"properties": {
+				"category": {
+					"type": "string"
+				},
+				"threshold": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.ChatModelGoogleThinkingConfig": {
+			"type": "object",
+			"properties": {
+				"include_thoughts": {
+					"type": "boolean"
+				},
+				"thinking_budget": {
+					"type": "integer"
+				}
+			}
+		},
+		"codersdk.ChatModelOpenAICompatProviderOptions": {
+			"type": "object",
+			"properties": {
+				"user": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.ChatModelOpenAIProviderOptions": {
+			"type": "object",
+			"properties": {
+				"allowed_domains": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"include": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"instructions": {
+					"type": "string"
+				},
+				"log_probs": {
+					"type": "boolean"
+				},
+				"logit_bias": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "integer",
+						"format": "int64"
+					}
+				},
+				"max_completion_tokens": {
+					"type": "integer"
+				},
+				"max_tool_calls": {
+					"type": "integer"
+				},
+				"metadata": {
+					"type": "object",
+					"additionalProperties": {}
+				},
+				"parallel_tool_calls": {
+					"type": "boolean"
+				},
+				"prediction": {
+					"type": "object",
+					"additionalProperties": {}
+				},
+				"prompt_cache_key": {
+					"type": "string"
+				},
+				"reasoning_summary": {
+					"type": "string"
+				},
+				"safety_identifier": {
+					"type": "string"
+				},
+				"search_context_size": {
+					"type": "string"
+				},
+				"service_tier": {
+					"type": "string"
+				},
+				"store": {
+					"type": "boolean"
+				},
+				"strict_json_schema": {
+					"type": "boolean"
+				},
+				"structured_outputs": {
+					"type": "boolean"
+				},
+				"text_verbosity": {
+					"type": "string"
+				},
+				"top_log_probs": {
+					"type": "integer"
+				},
+				"user": {
+					"type": "string"
+				},
+				"web_search_enabled": {
+					"type": "boolean"
+				}
+			}
+		},
+		"codersdk.ChatModelOpenRouterProvider": {
+			"type": "object",
+			"properties": {
+				"allow_fallbacks": {
+					"type": "boolean"
+				},
+				"data_collection": {
+					"type": "string"
+				},
+				"ignore": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"only": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"order": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"quantizations": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"require_parameters": {
+					"type": "boolean"
+				},
+				"sort": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.ChatModelOpenRouterProviderOptions": {
+			"type": "object",
+			"properties": {
+				"extra_body": {
+					"type": "object",
+					"additionalProperties": {}
+				},
+				"include_usage": {
+					"type": "boolean"
+				},
+				"log_probs": {
+					"type": "boolean"
+				},
+				"logit_bias": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "integer",
+						"format": "int64"
+					}
+				},
+				"parallel_tool_calls": {
+					"type": "boolean"
+				},
+				"provider": {
+					"$ref": "#/definitions/codersdk.ChatModelOpenRouterProvider"
+				},
+				"reasoning": {
+					"$ref": "#/definitions/codersdk.ChatModelReasoningOptions"
+				},
+				"user": {
+					"type": "string"
+				}
+			}
+		},
 		"codersdk.ChatModelProvider": {
 			"type": "object",
 			"properties": {
@@ -15858,6 +16264,29 @@
 				}
 			}
 		},
+		"codersdk.ChatModelProviderOptions": {
+			"type": "object",
+			"properties": {
+				"anthropic": {
+					"$ref": "#/definitions/codersdk.ChatModelAnthropicProviderOptions"
+				},
+				"google": {
+					"$ref": "#/definitions/codersdk.ChatModelGoogleProviderOptions"
+				},
+				"openai": {
+					"$ref": "#/definitions/codersdk.ChatModelOpenAIProviderOptions"
+				},
+				"openaicompat": {
+					"$ref": "#/definitions/codersdk.ChatModelOpenAICompatProviderOptions"
+				},
+				"openrouter": {
+					"$ref": "#/definitions/codersdk.ChatModelOpenRouterProviderOptions"
+				},
+				"vercel": {
+					"$ref": "#/definitions/codersdk.ChatModelVercelProviderOptions"
+				}
+			}
+		},
 		"codersdk.ChatModelProviderUnavailableReason": {
 			"type": "string",
 			"enum": ["missing_api_key", "fetch_failed", "user_api_key_required"],
@@ -15866,6 +16295,82 @@
 				"ChatModelProviderUnavailableFetchFailed",
 				"ChatModelProviderUnavailableReasonUserAPIKeyRequired"
 			]
+		},
+		"codersdk.ChatModelReasoningEffortConfig": {
+			"type": "object",
+			"properties": {
+				"default": {
+					"type": "string"
+				},
+				"max": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.ChatModelReasoningOptions": {
+			"type": "object",
+			"properties": {
+				"enabled": {
+					"type": "boolean"
+				},
+				"exclude": {
+					"type": "boolean"
+				},
+				"max_tokens": {
+					"type": "integer"
+				}
+			}
+		},
+		"codersdk.ChatModelVercelGatewayProviderOptions": {
+			"type": "object",
+			"properties": {
+				"models": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"order": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			}
+		},
+		"codersdk.ChatModelVercelProviderOptions": {
+			"type": "object",
+			"properties": {
+				"extra_body": {
+					"type": "object",
+					"additionalProperties": {}
+				},
+				"logit_bias": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "integer",
+						"format": "int64"
+					}
+				},
+				"logprobs": {
+					"type": "boolean"
+				},
+				"parallel_tool_calls": {
+					"type": "boolean"
+				},
+				"providerOptions": {
+					"$ref": "#/definitions/codersdk.ChatModelVercelGatewayProviderOptions"
+				},
+				"reasoning": {
+					"$ref": "#/definitions/codersdk.ChatModelReasoningOptions"
+				},
+				"top_logprobs": {
+					"type": "integer"
+				},
+				"user": {
+					"type": "string"
+				}
+			}
 		},
 		"codersdk.ChatModelsResponse": {
 			"type": "object",
@@ -18791,6 +19296,23 @@
 				},
 				"username": {
 					"type": "string"
+				}
+			}
+		},
+		"codersdk.ModelCostConfig": {
+			"type": "object",
+			"properties": {
+				"cache_read_price_per_million_tokens": {
+					"type": "number"
+				},
+				"cache_write_price_per_million_tokens": {
+					"type": "number"
+				},
+				"input_price_per_million_tokens": {
+					"type": "number"
+				},
+				"output_price_per_million_tokens": {
+					"type": "number"
 				}
 			}
 		},

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1312,6 +1312,14 @@ func New(options *Options) *API {
 				r.Delete("/", api.deleteUserAIProviderKey)
 			})
 		})
+		r.Route("/organizations/{organization}", func(r chi.Router) {
+			r.Use(
+				apiKeyMiddleware,
+				httpmw.AsAuthzSystem(httpmw.ExtractOrganizationParam(options.Database)),
+			)
+			r.Get("/chats/models", api.listOrganizationChatModels)
+			r.Get("/chat-model-configs", api.listOrganizationChatModelConfigs)
+		})
 		r.Route("/chats", func(r chi.Router) {
 			r.Use(
 				apiKeyMiddleware,

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -1529,6 +1529,29 @@ func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 // @Router /api/experimental/chats/models [get]
 // @Description Experimental: this endpoint is subject to change.
 func (api *API) listChatModels(rw http.ResponseWriter, r *http.Request) {
+	api.writeChatModels(rw, r)
+}
+
+// EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary List organization chat models
+// @ID list-organization-chat-models
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Param organization path string true "Organization ID or name"
+// @Success 200 {object} codersdk.ChatModelsResponse
+// @Router /api/experimental/organizations/{organization}/chats/models [get]
+// @x-apidocgen {"skip": true}
+// @Description Experimental: this endpoint is subject to change.
+func (api *API) listOrganizationChatModels(rw http.ResponseWriter, r *http.Request) {
+	if !api.requireRequestedOrganizationMembership(rw, r) {
+		return
+	}
+	api.writeChatModels(rw, r)
+}
+
+func (api *API) writeChatModels(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
 	availability, err := api.getUserChatProviderAvailability(ctx, apiKey.UserID)
@@ -7133,6 +7156,45 @@ func (*API) upsertUserChatProviderKey(rw http.ResponseWriter, r *http.Request) {
 
 func (*API) deleteUserChatProviderKey(rw http.ResponseWriter, r *http.Request) {
 	writeLegacyChatProviderGone(rw, r)
+}
+
+// EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary List organization chat model configs
+// @ID list-organization-chat-model-configs
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Param organization path string true "Organization ID or name"
+// @Success 200 {array} codersdk.ChatModelConfig
+// @Router /api/experimental/organizations/{organization}/chat-model-configs [get]
+// @x-apidocgen {"skip": true}
+// @Description Experimental: this endpoint is subject to change.
+func (api *API) listOrganizationChatModelConfigs(rw http.ResponseWriter, r *http.Request) {
+	if !api.requireRequestedOrganizationMembership(rw, r) {
+		return
+	}
+	api.listChatModelConfigs(rw, r)
+}
+
+func (*API) requireRequestedOrganizationMembership(rw http.ResponseWriter, r *http.Request) bool {
+	ctx := r.Context()
+	organization := httpmw.OrganizationParam(r)
+	isMember, err := httpmw.UserAuthorization(ctx).HasOrganizationMembership(organization.ID)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to validate organization membership.",
+			Detail:  xerrors.Errorf("check organization membership: %w", err).Error(),
+		})
+		return false
+	}
+	if !isMember {
+		httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
+			Message: "You are not a member of the specified organization.",
+		})
+		return false
+	}
+	return true
 }
 
 func (api *API) listChatModelConfigs(rw http.ResponseWriter, r *http.Request) {

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/coderd/util/ptr"
+	"github.com/coder/coder/v2/coderd/util/slice"
 	"github.com/coder/coder/v2/coderd/x/chatd"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprovider"
@@ -2073,6 +2074,92 @@ func TestListChatModels(t *testing.T) {
 		models, err = client.ListChatModels(ctx)
 		require.NoError(t, err)
 		require.Empty(t, models.Providers)
+	})
+}
+
+func TestOrganizationChatModelDiscovery(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Models", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		adminClient, db := newChatClientWithDatabase(t)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
+		modelConfig := createChatModelConfig(t, adminClient)
+		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
+		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
+
+		models, err := memberClient.ListOrganizationChatModels(ctx, firstUser.OrganizationID.String())
+		require.NoError(t, err)
+		require.True(t, slices.ContainsFunc(models.Providers, func(provider codersdk.ChatModelProvider) bool {
+			return slices.ContainsFunc(provider.Models, func(model codersdk.ChatModel) bool {
+				return model.Model == modelConfig.Model
+			})
+		}))
+
+		otherOrganization := dbgen.Organization(t, db, database.Organization{})
+		_, err = memberClient.ListOrganizationChatModels(ctx, otherOrganization.ID.String())
+		requireSDKError(t, err, http.StatusForbidden)
+
+		_, err = memberClient.ListOrganizationChatModels(ctx, uuid.NewString())
+		requireSDKError(t, err, http.StatusNotFound)
+
+		unauthenticatedClient := codersdk.NewExperimentalClient(codersdk.New(adminClient.URL))
+		_, err = unauthenticatedClient.ListOrganizationChatModels(ctx, firstUser.OrganizationID.String())
+		requireSDKError(t, err, http.StatusUnauthorized)
+
+		legacyModels, err := memberClient.ListChatModels(ctx)
+		require.NoError(t, err)
+		require.Equal(t, models, legacyModels)
+	})
+
+	t.Run("ModelConfigs", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		adminClient, db := newChatClientWithDatabase(t)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
+		enabledConfig := createChatModelConfig(t, adminClient)
+		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
+		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
+
+		contextLimit := int64(4096)
+		enabled := false
+		disabledConfig, err := adminClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+			AIProviderID: &enabledConfig.AIProviderID,
+			Model:        "organization-disabled-model",
+			Enabled:      &enabled,
+			ContextLimit: &contextLimit,
+		})
+		require.NoError(t, err)
+
+		adminConfigs, err := adminClient.ListOrganizationChatModelConfigs(ctx, firstUser.OrganizationID.String())
+		require.NoError(t, err)
+		require.True(t, slices.ContainsFunc(adminConfigs, func(config codersdk.ChatModelConfig) bool {
+			return config.ID == disabledConfig.ID
+		}))
+
+		memberConfigs, err := memberClient.ListOrganizationChatModelConfigs(ctx, firstUser.OrganizationID.String())
+		require.NoError(t, err)
+		require.Equal(t, []uuid.UUID{enabledConfig.ID}, slice.List(memberConfigs, func(config codersdk.ChatModelConfig) uuid.UUID {
+			return config.ID
+		}))
+
+		otherOrganization := dbgen.Organization(t, db, database.Organization{})
+		_, err = memberClient.ListOrganizationChatModelConfigs(ctx, otherOrganization.ID.String())
+		requireSDKError(t, err, http.StatusForbidden)
+
+		_, err = memberClient.ListOrganizationChatModelConfigs(ctx, uuid.NewString())
+		requireSDKError(t, err, http.StatusNotFound)
+
+		unauthenticatedClient := codersdk.NewExperimentalClient(codersdk.New(adminClient.URL))
+		_, err = unauthenticatedClient.ListOrganizationChatModelConfigs(ctx, firstUser.OrganizationID.String())
+		requireSDKError(t, err, http.StatusUnauthorized)
+
+		legacyConfigs, err := memberClient.ListChatModelConfigs(ctx)
+		require.NoError(t, err)
+		require.Equal(t, memberConfigs, legacyConfigs)
 	})
 }
 

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -2304,6 +2304,21 @@ func (c *ExperimentalClient) ListChatModels(ctx context.Context) (ChatModelsResp
 	return catalog, json.NewDecoder(res.Body).Decode(&catalog)
 }
 
+// ListOrganizationChatModels returns the available chat model catalog for an organization member.
+func (c *ExperimentalClient) ListOrganizationChatModels(ctx context.Context, organization string) (ChatModelsResponse, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/organizations/%s/chats/models", url.PathEscape(organization)), nil)
+	if err != nil {
+		return ChatModelsResponse{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return ChatModelsResponse{}, ReadBodyAsError(res)
+	}
+
+	var catalog ChatModelsResponse
+	return catalog, json.NewDecoder(res.Body).Decode(&catalog)
+}
+
 // ListChatProviders returns admin-managed chat provider configs.
 func (c *ExperimentalClient) ListChatProviders(ctx context.Context) ([]ChatProviderConfig, error) {
 	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/providers", nil)
@@ -2451,6 +2466,21 @@ func (c *ExperimentalClient) DeleteUserChatProviderKey(ctx context.Context, prov
 // ListChatModelConfigs returns admin-managed chat model configs.
 func (c *ExperimentalClient) ListChatModelConfigs(ctx context.Context) ([]ChatModelConfig, error) {
 	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/model-configs", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, ReadBodyAsError(res)
+	}
+
+	var configs []ChatModelConfig
+	return configs, json.NewDecoder(res.Body).Decode(&configs)
+}
+
+// ListOrganizationChatModelConfigs returns chat model configs for an organization member.
+func (c *ExperimentalClient) ListOrganizationChatModelConfigs(ctx context.Context, organization string) ([]ChatModelConfig, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/organizations/%s/chat-model-configs", url.PathEscape(organization)), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/codersdk/chats_test.go
+++ b/codersdk/chats_test.go
@@ -19,6 +19,57 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 )
 
+func TestOrganizationChatModelDiscoveryPaths(t *testing.T) {
+	t.Parallel()
+
+	organization := "example/org name"
+	tests := []struct {
+		name     string
+		path     string
+		response string
+		request  func(context.Context, *codersdk.ExperimentalClient) error
+	}{
+		{
+			name:     "Models",
+			path:     "/api/experimental/organizations/example%2Forg%20name/chats/models",
+			response: `{"providers":[]}`,
+			request: func(ctx context.Context, client *codersdk.ExperimentalClient) error {
+				_, err := client.ListOrganizationChatModels(ctx, organization)
+				return err
+			},
+		},
+		{
+			name:     "ModelConfigs",
+			path:     "/api/experimental/organizations/example%2Forg%20name/chat-model-configs",
+			response: `[]`,
+			request: func(ctx context.Context, client *codersdk.ExperimentalClient) error {
+				_, err := client.ListOrganizationChatModelConfigs(ctx, organization)
+				return err
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodGet, r.Method)
+				require.Equal(t, test.path, r.URL.EscapedPath())
+				rw.Header().Set("Content-Type", "application/json")
+				_, err := rw.Write([]byte(test.response))
+				require.NoError(t, err)
+			}))
+			defer srv.Close()
+
+			serverURL, err := url.Parse(srv.URL)
+			require.NoError(t, err)
+			client := codersdk.NewExperimentalClient(codersdk.New(serverURL))
+			require.NoError(t, test.request(context.Background(), client))
+		})
+	}
+}
+
 func TestChatModelProviderOptions_MarshalJSON_UsesPlainProviderPayload(t *testing.T) {
 	t.Parallel()
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -3161,6 +3161,661 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `model`        | string | false    |              |             |
 | `provider`     | string | false    |              |             |
 
+## codersdk.ChatModelAnthropicProviderOptions
+
+```json
+{
+  "allowed_domains": [
+    "string"
+  ],
+  "blocked_domains": [
+    "string"
+  ],
+  "context_1m_enabled": true,
+  "disable_parallel_tool_use": true,
+  "send_reasoning": true,
+  "thinking": {
+    "budget_tokens": 0
+  },
+  "thinking_display": "string",
+  "web_search_enabled": true
+}
+```
+
+### Properties
+
+| Name                        | Type                                                                                     | Required | Restrictions | Description |
+|-----------------------------|------------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `allowed_domains`           | array of string                                                                          | false    |              |             |
+| `blocked_domains`           | array of string                                                                          | false    |              |             |
+| `context_1m_enabled`        | boolean                                                                                  | false    |              |             |
+| `disable_parallel_tool_use` | boolean                                                                                  | false    |              |             |
+| `send_reasoning`            | boolean                                                                                  | false    |              |             |
+| `thinking`                  | [codersdk.ChatModelAnthropicThinkingOptions](#codersdkchatmodelanthropicthinkingoptions) | false    |              |             |
+| `thinking_display`          | string                                                                                   | false    |              |             |
+| `web_search_enabled`        | boolean                                                                                  | false    |              |             |
+
+## codersdk.ChatModelAnthropicThinkingOptions
+
+```json
+{
+  "budget_tokens": 0
+}
+```
+
+### Properties
+
+| Name            | Type    | Required | Restrictions | Description |
+|-----------------|---------|----------|--------------|-------------|
+| `budget_tokens` | integer | false    |              |             |
+
+## codersdk.ChatModelCallConfig
+
+```json
+{
+  "cost": {
+    "cache_read_price_per_million_tokens": 0,
+    "cache_write_price_per_million_tokens": 0,
+    "input_price_per_million_tokens": 0,
+    "output_price_per_million_tokens": 0
+  },
+  "frequency_penalty": 0,
+  "max_output_tokens": 0,
+  "presence_penalty": 0,
+  "provider_options": {
+    "anthropic": {
+      "allowed_domains": [
+        "string"
+      ],
+      "blocked_domains": [
+        "string"
+      ],
+      "context_1m_enabled": true,
+      "disable_parallel_tool_use": true,
+      "send_reasoning": true,
+      "thinking": {
+        "budget_tokens": 0
+      },
+      "thinking_display": "string",
+      "web_search_enabled": true
+    },
+    "google": {
+      "cached_content": "string",
+      "safety_settings": [
+        {
+          "category": "string",
+          "threshold": "string"
+        }
+      ],
+      "thinking_config": {
+        "include_thoughts": true,
+        "thinking_budget": 0
+      },
+      "threshold": "string",
+      "web_search_enabled": true
+    },
+    "openai": {
+      "allowed_domains": [
+        "string"
+      ],
+      "include": [
+        "string"
+      ],
+      "instructions": "string",
+      "log_probs": true,
+      "logit_bias": {
+        "property1": 0,
+        "property2": 0
+      },
+      "max_completion_tokens": 0,
+      "max_tool_calls": 0,
+      "metadata": {
+        "property1": null,
+        "property2": null
+      },
+      "parallel_tool_calls": true,
+      "prediction": {
+        "property1": null,
+        "property2": null
+      },
+      "prompt_cache_key": "string",
+      "reasoning_summary": "string",
+      "safety_identifier": "string",
+      "search_context_size": "string",
+      "service_tier": "string",
+      "store": true,
+      "strict_json_schema": true,
+      "structured_outputs": true,
+      "text_verbosity": "string",
+      "top_log_probs": 0,
+      "user": "string",
+      "web_search_enabled": true
+    },
+    "openaicompat": {
+      "user": "string"
+    },
+    "openrouter": {
+      "extra_body": {
+        "property1": null,
+        "property2": null
+      },
+      "include_usage": true,
+      "log_probs": true,
+      "logit_bias": {
+        "property1": 0,
+        "property2": 0
+      },
+      "parallel_tool_calls": true,
+      "provider": {
+        "allow_fallbacks": true,
+        "data_collection": "string",
+        "ignore": [
+          "string"
+        ],
+        "only": [
+          "string"
+        ],
+        "order": [
+          "string"
+        ],
+        "quantizations": [
+          "string"
+        ],
+        "require_parameters": true,
+        "sort": "string"
+      },
+      "reasoning": {
+        "enabled": true,
+        "exclude": true,
+        "max_tokens": 0
+      },
+      "user": "string"
+    },
+    "vercel": {
+      "extra_body": {
+        "property1": null,
+        "property2": null
+      },
+      "logit_bias": {
+        "property1": 0,
+        "property2": 0
+      },
+      "logprobs": true,
+      "parallel_tool_calls": true,
+      "providerOptions": {
+        "models": [
+          "string"
+        ],
+        "order": [
+          "string"
+        ]
+      },
+      "reasoning": {
+        "enabled": true,
+        "exclude": true,
+        "max_tokens": 0
+      },
+      "top_logprobs": 0,
+      "user": "string"
+    }
+  },
+  "reasoning_effort": {
+    "default": "string",
+    "max": "string"
+  },
+  "temperature": 0,
+  "top_k": 0,
+  "top_p": 0
+}
+```
+
+### Properties
+
+| Name                | Type                                                                               | Required | Restrictions | Description |
+|---------------------|------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `cost`              | [codersdk.ModelCostConfig](#codersdkmodelcostconfig)                               | false    |              |             |
+| `frequency_penalty` | number                                                                             | false    |              |             |
+| `max_output_tokens` | integer                                                                            | false    |              |             |
+| `presence_penalty`  | number                                                                             | false    |              |             |
+| `provider_options`  | [codersdk.ChatModelProviderOptions](#codersdkchatmodelprovideroptions)             | false    |              |             |
+| `reasoning_effort`  | [codersdk.ChatModelReasoningEffortConfig](#codersdkchatmodelreasoningeffortconfig) | false    |              |             |
+| `temperature`       | number                                                                             | false    |              |             |
+| `top_k`             | integer                                                                            | false    |              |             |
+| `top_p`             | number                                                                             | false    |              |             |
+
+## codersdk.ChatModelConfig
+
+```json
+{
+  "ai_provider_id": "5a3b8ff9-20e7-4c37-ba1a-5b433e355819",
+  "compression_threshold": 0,
+  "context_limit": 0,
+  "created_at": "2019-08-24T14:15:22Z",
+  "display_name": "string",
+  "enabled": true,
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "is_default": true,
+  "model": "string",
+  "model_config": {
+    "cost": {
+      "cache_read_price_per_million_tokens": 0,
+      "cache_write_price_per_million_tokens": 0,
+      "input_price_per_million_tokens": 0,
+      "output_price_per_million_tokens": 0
+    },
+    "frequency_penalty": 0,
+    "max_output_tokens": 0,
+    "presence_penalty": 0,
+    "provider_options": {
+      "anthropic": {
+        "allowed_domains": [
+          "string"
+        ],
+        "blocked_domains": [
+          "string"
+        ],
+        "context_1m_enabled": true,
+        "disable_parallel_tool_use": true,
+        "send_reasoning": true,
+        "thinking": {
+          "budget_tokens": 0
+        },
+        "thinking_display": "string",
+        "web_search_enabled": true
+      },
+      "google": {
+        "cached_content": "string",
+        "safety_settings": [
+          {
+            "category": "string",
+            "threshold": "string"
+          }
+        ],
+        "thinking_config": {
+          "include_thoughts": true,
+          "thinking_budget": 0
+        },
+        "threshold": "string",
+        "web_search_enabled": true
+      },
+      "openai": {
+        "allowed_domains": [
+          "string"
+        ],
+        "include": [
+          "string"
+        ],
+        "instructions": "string",
+        "log_probs": true,
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "max_completion_tokens": 0,
+        "max_tool_calls": 0,
+        "metadata": {
+          "property1": null,
+          "property2": null
+        },
+        "parallel_tool_calls": true,
+        "prediction": {
+          "property1": null,
+          "property2": null
+        },
+        "prompt_cache_key": "string",
+        "reasoning_summary": "string",
+        "safety_identifier": "string",
+        "search_context_size": "string",
+        "service_tier": "string",
+        "store": true,
+        "strict_json_schema": true,
+        "structured_outputs": true,
+        "text_verbosity": "string",
+        "top_log_probs": 0,
+        "user": "string",
+        "web_search_enabled": true
+      },
+      "openaicompat": {
+        "user": "string"
+      },
+      "openrouter": {
+        "extra_body": {
+          "property1": null,
+          "property2": null
+        },
+        "include_usage": true,
+        "log_probs": true,
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "parallel_tool_calls": true,
+        "provider": {
+          "allow_fallbacks": true,
+          "data_collection": "string",
+          "ignore": [
+            "string"
+          ],
+          "only": [
+            "string"
+          ],
+          "order": [
+            "string"
+          ],
+          "quantizations": [
+            "string"
+          ],
+          "require_parameters": true,
+          "sort": "string"
+        },
+        "reasoning": {
+          "enabled": true,
+          "exclude": true,
+          "max_tokens": 0
+        },
+        "user": "string"
+      },
+      "vercel": {
+        "extra_body": {
+          "property1": null,
+          "property2": null
+        },
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "logprobs": true,
+        "parallel_tool_calls": true,
+        "providerOptions": {
+          "models": [
+            "string"
+          ],
+          "order": [
+            "string"
+          ]
+        },
+        "reasoning": {
+          "enabled": true,
+          "exclude": true,
+          "max_tokens": 0
+        },
+        "top_logprobs": 0,
+        "user": "string"
+      }
+    },
+    "reasoning_effort": {
+      "default": "string",
+      "max": "string"
+    },
+    "temperature": 0,
+    "top_k": 0,
+    "top_p": 0
+  },
+  "reasoning_efforts": [
+    "string"
+  ],
+  "updated_at": "2019-08-24T14:15:22Z"
+}
+```
+
+### Properties
+
+| Name                    | Type                                                         | Required | Restrictions | Description                                                                                        |
+|-------------------------|--------------------------------------------------------------|----------|--------------|----------------------------------------------------------------------------------------------------|
+| `ai_provider_id`        | string                                                       | false    |              |                                                                                                    |
+| `compression_threshold` | integer                                                      | false    |              |                                                                                                    |
+| `context_limit`         | integer                                                      | false    |              |                                                                                                    |
+| `created_at`            | string                                                       | false    |              |                                                                                                    |
+| `display_name`          | string                                                       | false    |              |                                                                                                    |
+| `enabled`               | boolean                                                      | false    |              |                                                                                                    |
+| `id`                    | string                                                       | false    |              |                                                                                                    |
+| `is_default`            | boolean                                                      | false    |              |                                                                                                    |
+| `model`                 | string                                                       | false    |              |                                                                                                    |
+| `model_config`          | [codersdk.ChatModelCallConfig](#codersdkchatmodelcallconfig) | false    |              |                                                                                                    |
+| `reasoning_efforts`     | array of string                                              | false    |              | Reasoning efforts lists selectable reasoning effort values through the model's configured maximum. |
+| `updated_at`            | string                                                       | false    |              |                                                                                                    |
+
+## codersdk.ChatModelGoogleProviderOptions
+
+```json
+{
+  "cached_content": "string",
+  "safety_settings": [
+    {
+      "category": "string",
+      "threshold": "string"
+    }
+  ],
+  "thinking_config": {
+    "include_thoughts": true,
+    "thinking_budget": 0
+  },
+  "threshold": "string",
+  "web_search_enabled": true
+}
+```
+
+### Properties
+
+| Name                 | Type                                                                                    | Required | Restrictions | Description |
+|----------------------|-----------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `cached_content`     | string                                                                                  | false    |              |             |
+| `safety_settings`    | array of [codersdk.ChatModelGoogleSafetySetting](#codersdkchatmodelgooglesafetysetting) | false    |              |             |
+| `thinking_config`    | [codersdk.ChatModelGoogleThinkingConfig](#codersdkchatmodelgooglethinkingconfig)        | false    |              |             |
+| `threshold`          | string                                                                                  | false    |              |             |
+| `web_search_enabled` | boolean                                                                                 | false    |              |             |
+
+## codersdk.ChatModelGoogleSafetySetting
+
+```json
+{
+  "category": "string",
+  "threshold": "string"
+}
+```
+
+### Properties
+
+| Name        | Type   | Required | Restrictions | Description |
+|-------------|--------|----------|--------------|-------------|
+| `category`  | string | false    |              |             |
+| `threshold` | string | false    |              |             |
+
+## codersdk.ChatModelGoogleThinkingConfig
+
+```json
+{
+  "include_thoughts": true,
+  "thinking_budget": 0
+}
+```
+
+### Properties
+
+| Name               | Type    | Required | Restrictions | Description |
+|--------------------|---------|----------|--------------|-------------|
+| `include_thoughts` | boolean | false    |              |             |
+| `thinking_budget`  | integer | false    |              |             |
+
+## codersdk.ChatModelOpenAICompatProviderOptions
+
+```json
+{
+  "user": "string"
+}
+```
+
+### Properties
+
+| Name   | Type   | Required | Restrictions | Description |
+|--------|--------|----------|--------------|-------------|
+| `user` | string | false    |              |             |
+
+## codersdk.ChatModelOpenAIProviderOptions
+
+```json
+{
+  "allowed_domains": [
+    "string"
+  ],
+  "include": [
+    "string"
+  ],
+  "instructions": "string",
+  "log_probs": true,
+  "logit_bias": {
+    "property1": 0,
+    "property2": 0
+  },
+  "max_completion_tokens": 0,
+  "max_tool_calls": 0,
+  "metadata": {
+    "property1": null,
+    "property2": null
+  },
+  "parallel_tool_calls": true,
+  "prediction": {
+    "property1": null,
+    "property2": null
+  },
+  "prompt_cache_key": "string",
+  "reasoning_summary": "string",
+  "safety_identifier": "string",
+  "search_context_size": "string",
+  "service_tier": "string",
+  "store": true,
+  "strict_json_schema": true,
+  "structured_outputs": true,
+  "text_verbosity": "string",
+  "top_log_probs": 0,
+  "user": "string",
+  "web_search_enabled": true
+}
+```
+
+### Properties
+
+| Name                    | Type            | Required | Restrictions | Description |
+|-------------------------|-----------------|----------|--------------|-------------|
+| `allowed_domains`       | array of string | false    |              |             |
+| `include`               | array of string | false    |              |             |
+| `instructions`          | string          | false    |              |             |
+| `log_probs`             | boolean         | false    |              |             |
+| `logit_bias`            | object          | false    |              |             |
+| » `[any property]`      | integer         | false    |              |             |
+| `max_completion_tokens` | integer         | false    |              |             |
+| `max_tool_calls`        | integer         | false    |              |             |
+| `metadata`              | object          | false    |              |             |
+| » `[any property]`      | any             | false    |              |             |
+| `parallel_tool_calls`   | boolean         | false    |              |             |
+| `prediction`            | object          | false    |              |             |
+| » `[any property]`      | any             | false    |              |             |
+| `prompt_cache_key`      | string          | false    |              |             |
+| `reasoning_summary`     | string          | false    |              |             |
+| `safety_identifier`     | string          | false    |              |             |
+| `search_context_size`   | string          | false    |              |             |
+| `service_tier`          | string          | false    |              |             |
+| `store`                 | boolean         | false    |              |             |
+| `strict_json_schema`    | boolean         | false    |              |             |
+| `structured_outputs`    | boolean         | false    |              |             |
+| `text_verbosity`        | string          | false    |              |             |
+| `top_log_probs`         | integer         | false    |              |             |
+| `user`                  | string          | false    |              |             |
+| `web_search_enabled`    | boolean         | false    |              |             |
+
+## codersdk.ChatModelOpenRouterProvider
+
+```json
+{
+  "allow_fallbacks": true,
+  "data_collection": "string",
+  "ignore": [
+    "string"
+  ],
+  "only": [
+    "string"
+  ],
+  "order": [
+    "string"
+  ],
+  "quantizations": [
+    "string"
+  ],
+  "require_parameters": true,
+  "sort": "string"
+}
+```
+
+### Properties
+
+| Name                 | Type            | Required | Restrictions | Description |
+|----------------------|-----------------|----------|--------------|-------------|
+| `allow_fallbacks`    | boolean         | false    |              |             |
+| `data_collection`    | string          | false    |              |             |
+| `ignore`             | array of string | false    |              |             |
+| `only`               | array of string | false    |              |             |
+| `order`              | array of string | false    |              |             |
+| `quantizations`      | array of string | false    |              |             |
+| `require_parameters` | boolean         | false    |              |             |
+| `sort`               | string          | false    |              |             |
+
+## codersdk.ChatModelOpenRouterProviderOptions
+
+```json
+{
+  "extra_body": {
+    "property1": null,
+    "property2": null
+  },
+  "include_usage": true,
+  "log_probs": true,
+  "logit_bias": {
+    "property1": 0,
+    "property2": 0
+  },
+  "parallel_tool_calls": true,
+  "provider": {
+    "allow_fallbacks": true,
+    "data_collection": "string",
+    "ignore": [
+      "string"
+    ],
+    "only": [
+      "string"
+    ],
+    "order": [
+      "string"
+    ],
+    "quantizations": [
+      "string"
+    ],
+    "require_parameters": true,
+    "sort": "string"
+  },
+  "reasoning": {
+    "enabled": true,
+    "exclude": true,
+    "max_tokens": 0
+  },
+  "user": "string"
+}
+```
+
+### Properties
+
+| Name                  | Type                                                                         | Required | Restrictions | Description |
+|-----------------------|------------------------------------------------------------------------------|----------|--------------|-------------|
+| `extra_body`          | object                                                                       | false    |              |             |
+| » `[any property]`    | any                                                                          | false    |              |             |
+| `include_usage`       | boolean                                                                      | false    |              |             |
+| `log_probs`           | boolean                                                                      | false    |              |             |
+| `logit_bias`          | object                                                                       | false    |              |             |
+| » `[any property]`    | integer                                                                      | false    |              |             |
+| `parallel_tool_calls` | boolean                                                                      | false    |              |             |
+| `provider`            | [codersdk.ChatModelOpenRouterProvider](#codersdkchatmodelopenrouterprovider) | false    |              |             |
+| `reasoning`           | [codersdk.ChatModelReasoningOptions](#codersdkchatmodelreasoningoptions)     | false    |              |             |
+| `user`                | string                                                                       | false    |              |             |
+
 ## codersdk.ChatModelProvider
 
 ```json
@@ -3188,6 +3843,159 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `provider`           | string                                                                                     | false    |              |             |
 | `unavailable_reason` | [codersdk.ChatModelProviderUnavailableReason](#codersdkchatmodelproviderunavailablereason) | false    |              |             |
 
+## codersdk.ChatModelProviderOptions
+
+```json
+{
+  "anthropic": {
+    "allowed_domains": [
+      "string"
+    ],
+    "blocked_domains": [
+      "string"
+    ],
+    "context_1m_enabled": true,
+    "disable_parallel_tool_use": true,
+    "send_reasoning": true,
+    "thinking": {
+      "budget_tokens": 0
+    },
+    "thinking_display": "string",
+    "web_search_enabled": true
+  },
+  "google": {
+    "cached_content": "string",
+    "safety_settings": [
+      {
+        "category": "string",
+        "threshold": "string"
+      }
+    ],
+    "thinking_config": {
+      "include_thoughts": true,
+      "thinking_budget": 0
+    },
+    "threshold": "string",
+    "web_search_enabled": true
+  },
+  "openai": {
+    "allowed_domains": [
+      "string"
+    ],
+    "include": [
+      "string"
+    ],
+    "instructions": "string",
+    "log_probs": true,
+    "logit_bias": {
+      "property1": 0,
+      "property2": 0
+    },
+    "max_completion_tokens": 0,
+    "max_tool_calls": 0,
+    "metadata": {
+      "property1": null,
+      "property2": null
+    },
+    "parallel_tool_calls": true,
+    "prediction": {
+      "property1": null,
+      "property2": null
+    },
+    "prompt_cache_key": "string",
+    "reasoning_summary": "string",
+    "safety_identifier": "string",
+    "search_context_size": "string",
+    "service_tier": "string",
+    "store": true,
+    "strict_json_schema": true,
+    "structured_outputs": true,
+    "text_verbosity": "string",
+    "top_log_probs": 0,
+    "user": "string",
+    "web_search_enabled": true
+  },
+  "openaicompat": {
+    "user": "string"
+  },
+  "openrouter": {
+    "extra_body": {
+      "property1": null,
+      "property2": null
+    },
+    "include_usage": true,
+    "log_probs": true,
+    "logit_bias": {
+      "property1": 0,
+      "property2": 0
+    },
+    "parallel_tool_calls": true,
+    "provider": {
+      "allow_fallbacks": true,
+      "data_collection": "string",
+      "ignore": [
+        "string"
+      ],
+      "only": [
+        "string"
+      ],
+      "order": [
+        "string"
+      ],
+      "quantizations": [
+        "string"
+      ],
+      "require_parameters": true,
+      "sort": "string"
+    },
+    "reasoning": {
+      "enabled": true,
+      "exclude": true,
+      "max_tokens": 0
+    },
+    "user": "string"
+  },
+  "vercel": {
+    "extra_body": {
+      "property1": null,
+      "property2": null
+    },
+    "logit_bias": {
+      "property1": 0,
+      "property2": 0
+    },
+    "logprobs": true,
+    "parallel_tool_calls": true,
+    "providerOptions": {
+      "models": [
+        "string"
+      ],
+      "order": [
+        "string"
+      ]
+    },
+    "reasoning": {
+      "enabled": true,
+      "exclude": true,
+      "max_tokens": 0
+    },
+    "top_logprobs": 0,
+    "user": "string"
+  }
+}
+```
+
+### Properties
+
+| Name           | Type                                                                                           | Required | Restrictions | Description |
+|----------------|------------------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `anthropic`    | [codersdk.ChatModelAnthropicProviderOptions](#codersdkchatmodelanthropicprovideroptions)       | false    |              |             |
+| `google`       | [codersdk.ChatModelGoogleProviderOptions](#codersdkchatmodelgoogleprovideroptions)             | false    |              |             |
+| `openai`       | [codersdk.ChatModelOpenAIProviderOptions](#codersdkchatmodelopenaiprovideroptions)             | false    |              |             |
+| `openaicompat` | [codersdk.ChatModelOpenAICompatProviderOptions](#codersdkchatmodelopenaicompatprovideroptions) | false    |              |             |
+| `openrouter`   | [codersdk.ChatModelOpenRouterProviderOptions](#codersdkchatmodelopenrouterprovideroptions)     | false    |              |             |
+| `vercel`       | [codersdk.ChatModelVercelProviderOptions](#codersdkchatmodelvercelprovideroptions)             | false    |              |             |
+
 ## codersdk.ChatModelProviderUnavailableReason
 
 ```json
@@ -3201,6 +4009,107 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | Value(s)                                                   |
 |------------------------------------------------------------|
 | `fetch_failed`, `missing_api_key`, `user_api_key_required` |
+
+## codersdk.ChatModelReasoningEffortConfig
+
+```json
+{
+  "default": "string",
+  "max": "string"
+}
+```
+
+### Properties
+
+| Name      | Type   | Required | Restrictions | Description |
+|-----------|--------|----------|--------------|-------------|
+| `default` | string | false    |              |             |
+| `max`     | string | false    |              |             |
+
+## codersdk.ChatModelReasoningOptions
+
+```json
+{
+  "enabled": true,
+  "exclude": true,
+  "max_tokens": 0
+}
+```
+
+### Properties
+
+| Name         | Type    | Required | Restrictions | Description |
+|--------------|---------|----------|--------------|-------------|
+| `enabled`    | boolean | false    |              |             |
+| `exclude`    | boolean | false    |              |             |
+| `max_tokens` | integer | false    |              |             |
+
+## codersdk.ChatModelVercelGatewayProviderOptions
+
+```json
+{
+  "models": [
+    "string"
+  ],
+  "order": [
+    "string"
+  ]
+}
+```
+
+### Properties
+
+| Name     | Type            | Required | Restrictions | Description |
+|----------|-----------------|----------|--------------|-------------|
+| `models` | array of string | false    |              |             |
+| `order`  | array of string | false    |              |             |
+
+## codersdk.ChatModelVercelProviderOptions
+
+```json
+{
+  "extra_body": {
+    "property1": null,
+    "property2": null
+  },
+  "logit_bias": {
+    "property1": 0,
+    "property2": 0
+  },
+  "logprobs": true,
+  "parallel_tool_calls": true,
+  "providerOptions": {
+    "models": [
+      "string"
+    ],
+    "order": [
+      "string"
+    ]
+  },
+  "reasoning": {
+    "enabled": true,
+    "exclude": true,
+    "max_tokens": 0
+  },
+  "top_logprobs": 0,
+  "user": "string"
+}
+```
+
+### Properties
+
+| Name                  | Type                                                                                             | Required | Restrictions | Description |
+|-----------------------|--------------------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `extra_body`          | object                                                                                           | false    |              |             |
+| » `[any property]`    | any                                                                                              | false    |              |             |
+| `logit_bias`          | object                                                                                           | false    |              |             |
+| » `[any property]`    | integer                                                                                          | false    |              |             |
+| `logprobs`            | boolean                                                                                          | false    |              |             |
+| `parallel_tool_calls` | boolean                                                                                          | false    |              |             |
+| `providerOptions`     | [codersdk.ChatModelVercelGatewayProviderOptions](#codersdkchatmodelvercelgatewayprovideroptions) | false    |              |             |
+| `reasoning`           | [codersdk.ChatModelReasoningOptions](#codersdkchatmodelreasoningoptions)                         | false    |              |             |
+| `top_logprobs`        | integer                                                                                          | false    |              |             |
+| `user`                | string                                                                                           | false    |              |             |
 
 ## codersdk.ChatModelsResponse
 
@@ -8201,6 +9110,26 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 | `id`         | string | true     |              |             |
 | `name`       | string | false    |              |             |
 | `username`   | string | true     |              |             |
+
+## codersdk.ModelCostConfig
+
+```json
+{
+  "cache_read_price_per_million_tokens": 0,
+  "cache_write_price_per_million_tokens": 0,
+  "input_price_per_million_tokens": 0,
+  "output_price_per_million_tokens": 0
+}
+```
+
+### Properties
+
+| Name                                   | Type   | Required | Restrictions | Description |
+|----------------------------------------|--------|----------|--------------|-------------|
+| `cache_read_price_per_million_tokens`  | number | false    |              |             |
+| `cache_write_price_per_million_tokens` | number | false    |              |             |
+| `input_price_per_million_tokens`       | number | false    |              |             |
+| `output_price_per_million_tokens`      | number | false    |              |             |
 
 ## codersdk.NotificationMethodsResponse
 

--- a/site/src/api/api.test.ts
+++ b/site/src/api/api.test.ts
@@ -373,6 +373,8 @@ describe("api.ts", () => {
 	});
 
 	describe("chat configuration endpoints", () => {
+		const organization = "example/org name";
+
 		it.each<[string, () => Promise<unknown>, unknown]>([
 			[
 				"/api/experimental/chats/models",
@@ -384,6 +386,16 @@ describe("api.ts", () => {
 			[
 				"/api/experimental/chats/model-configs",
 				() => API.experimental.getChatModelConfigs(),
+				[],
+			],
+			[
+				"/api/experimental/organizations/example%2Forg%20name/chats/models",
+				() => API.experimental.getOrganizationChatModels(organization),
+				{ providers: [] },
+			],
+			[
+				"/api/experimental/organizations/example%2Forg%20name/chat-model-configs",
+				() => API.experimental.getOrganizationChatModelConfigs(organization),
 				[],
 			],
 		])("returns response data for %s", async (path, request, responseData) => {
@@ -405,6 +417,14 @@ describe("api.ts", () => {
 			[
 				"/api/experimental/chats/model-configs",
 				() => API.experimental.getChatModelConfigs(),
+			],
+			[
+				"/api/experimental/organizations/example%2Forg%20name/chats/models",
+				() => API.experimental.getOrganizationChatModels(organization),
+			],
+			[
+				"/api/experimental/organizations/example%2Forg%20name/chat-model-configs",
+				() => API.experimental.getOrganizationChatModelConfigs(organization),
 			],
 		])("rethrows axios errors for %s", async (path, request) => {
 			const expectedError = new Error("request failed");

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -3509,6 +3509,15 @@ class ExperimentalApiMethods {
 		return response.data;
 	};
 
+	getOrganizationChatModels = async (
+		organization: string,
+	): Promise<TypesGen.ChatModelsResponse> => {
+		const response = await this.axios.get<TypesGen.ChatModelsResponse>(
+			`/api/experimental/organizations/${encodeURIComponent(organization)}/chats/models`,
+		);
+		return response.data;
+	};
+
 	listAIProviders = async (): Promise<TypesGen.AIProvider[]> => {
 		const response = await this.axios.get<TypesGen.AIProvider[]>(
 			aiProviderConfigsPath,
@@ -3913,6 +3922,15 @@ class ExperimentalApiMethods {
 	getChatModelConfigs = async (): Promise<TypesGen.ChatModelConfig[]> => {
 		const response =
 			await this.axios.get<TypesGen.ChatModelConfig[]>(chatModelConfigsPath);
+		return response.data;
+	};
+
+	getOrganizationChatModelConfigs = async (
+		organization: string,
+	): Promise<TypesGen.ChatModelConfig[]> => {
+		const response = await this.axios.get<TypesGen.ChatModelConfig[]>(
+			`/api/experimental/organizations/${encodeURIComponent(organization)}/chat-model-configs`,
+		);
 		return response.data;
 	};
 

--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -33,6 +33,10 @@ import {
 	invalidateChatListQueries,
 	mergeWatchedChatIntoCaches,
 	mergeWatchedChatSummary,
+	organizationChatModelConfigs,
+	organizationChatModelConfigsKey,
+	organizationChatModels,
+	organizationChatModelsKey,
 	paginatedChatCostUsers,
 	pinChat,
 	prependToInfiniteChatsCache,
@@ -67,6 +71,8 @@ vi.mock("#/api/api", () => ({
 			promoteChatQueuedMessage: vi.fn(),
 			proposeChatTitle: vi.fn(),
 			getChatAdvisorConfig: vi.fn(),
+			getOrganizationChatModels: vi.fn(),
+			getOrganizationChatModelConfigs: vi.fn(),
 			updateChatAdvisorConfig: vi.fn(),
 			getChatACL: vi.fn(),
 			updateChatACL: vi.fn(),
@@ -140,6 +146,49 @@ const createTestQueryClient = (): QueryClient =>
 			},
 		},
 	});
+
+describe("organization chat model query factories", () => {
+	it("uses distinct organization-scoped keys and API calls", async () => {
+		const organizationA = "organization-a";
+		const organizationB = "organization-b";
+		const models: TypesGen.ChatModelsResponse = {
+			providers: [],
+			unsupported_providers: [],
+		};
+		const configs: TypesGen.ChatModelConfig[] = [];
+		vi.mocked(API.experimental.getOrganizationChatModels).mockResolvedValue(
+			models,
+		);
+		vi.mocked(
+			API.experimental.getOrganizationChatModelConfigs,
+		).mockResolvedValue(configs);
+
+		const modelsA = organizationChatModels(organizationA);
+		const modelsB = organizationChatModels(organizationB);
+		const configsA = organizationChatModelConfigs(organizationA);
+		const configsB = organizationChatModelConfigs(organizationB);
+
+		expect(modelsA.queryKey).toEqual(organizationChatModelsKey(organizationA));
+		expect(modelsB.queryKey).toEqual(organizationChatModelsKey(organizationB));
+		expect(modelsA.queryKey).not.toEqual(modelsB.queryKey);
+		expect(configsA.queryKey).toEqual(
+			organizationChatModelConfigsKey(organizationA),
+		);
+		expect(configsB.queryKey).toEqual(
+			organizationChatModelConfigsKey(organizationB),
+		);
+		expect(configsA.queryKey).not.toEqual(configsB.queryKey);
+
+		await expect(modelsA.queryFn()).resolves.toEqual(models);
+		await expect(configsA.queryFn()).resolves.toEqual(configs);
+		expect(API.experimental.getOrganizationChatModels).toHaveBeenCalledWith(
+			organizationA,
+		);
+		expect(
+			API.experimental.getOrganizationChatModelConfigs,
+		).toHaveBeenCalledWith(organizationA);
+	});
+});
 
 describe("advisor config query factories", () => {
 	it("builds the advisor config query and delegates to the API", async () => {

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -1781,6 +1781,15 @@ export const chatModels = () => ({
 		API.experimental.getChatModels(),
 });
 
+export const organizationChatModelsKey = (organization: string) =>
+	["organization", organization, "chat-models"] as const;
+
+export const organizationChatModels = (organization: string) => ({
+	queryKey: organizationChatModelsKey(organization),
+	queryFn: (): Promise<TypesGen.ChatModelsResponse> =>
+		API.experimental.getOrganizationChatModels(organization),
+});
+
 const chatProviderConfigsKey = ["chat-provider-configs"] as const;
 
 const toChatProviderConfig = (
@@ -1815,6 +1824,15 @@ export const chatModelConfigs = () => ({
 	queryKey: chatModelConfigsKey,
 	queryFn: (): Promise<TypesGen.ChatModelConfig[]> =>
 		API.experimental.getChatModelConfigs(),
+});
+
+export const organizationChatModelConfigsKey = (organization: string) =>
+	["organization", organization, "chat-model-configs"] as const;
+
+export const organizationChatModelConfigs = (organization: string) => ({
+	queryKey: organizationChatModelConfigsKey(organization),
+	queryFn: (): Promise<TypesGen.ChatModelConfig[]> =>
+		API.experimental.getOrganizationChatModelConfigs(organization),
 });
 
 export const userChatProviderConfigsKey = [


### PR DESCRIPTION
## Why

Organization-owned chat model configs need an organization-qualified read contract before the destructive clone-and-remap migration can land safely. This expansion PR adds that contract while preserving every existing global route and caller.

The requested organization is an eligibility boundary during the expansion phase. Members receive the existing global catalog behavior, and deployment configuration readers retain visibility of disabled configs. Later stacked PRs can migrate consumers before organization ownership is activated.

## Verification

- `make fmt`
- `make gen`
- focused `coderd` and `codersdk` tests
- focused site API and React Query tests, 140 passed
- `make lint`
- `make build`
- mandatory pre-commit hook

The mandatory pre-push Storybook phase has inherited failures that reproduce on `origin/main`. They are being investigated independently on `mathias/fix-chat-storybook-tests`; this PR does not change the failing stories or components.

<details>
<summary>Approved implementation plan</summary>

# CODAGT-709: reviewable expansion-first stack for organization-scoped chat model configs

## Direction for approval

Replace the previous hard-cut implementation with an expansion-first stack. The existing global `chat_model_configs` rows remain authoritative until every supported consumer can supply a concrete organization. New organization-qualified read contracts are additive and preserve the legacy global behavior while source data is still global. The clone, remap, ACL activation, cache cutover, and removal of global routes occur only in the final cutover PR after all supported callers use organization-qualified contracts.

This sequencing is required for correctness. The final migration creates a distinct model-config ID for every legacy-config and organization pair. After that point, an unscoped request has no correct answer for both an existing chat in a non-default organization and a new chat created in a selected non-default organization. A default-organization legacy adapter would return the wrong cloned rows for one of those flows.

The current staged diff is discarded and rebuilt as the stack below. CODAGT-714 remains separate. It owns selected-organization settings and model-management UI work. CODAGT-709 includes only contract migrations in the existing Agents creation and chat-detail flows where the organization is already an existing resource property or the existing form selector state.

### Observable end state

- `chat_model_configs` is organization-owned, with one non-deleted default per organization.
- Every legacy config has one new-ID clone per active organization before the legacy global row is removed.
- Chats, messages, queued messages, and debug runs reference the clone belonging to their chat organization.
- Model-bearing configuration, personal overrides, compaction thresholds, runtime resolution, and cache entries are organization-isolated.
- ACL grants use `read` only. The organization Everyone group has `read` on migrated configs.
- The organization-qualified API is deployed and used before the data cutover. No supported unscoped caller remains when global rows and global routes are removed.
- CODAGT-714 is not implemented, stacked, or included in a CODAGT-709 PR.

### Settled decisions

- The legacy global model rows remain the only writable source until the final migration. Expansion PRs do not create organization-owned rows, dual-write model configs, or expose ACL management against a shadow resource.
- New organization-qualified read endpoints require authentication and membership in the requested organization. While rows remain global, they preserve legacy visibility rules after that eligibility check:
  - the model catalog returns global enabled models subject to the caller's existing provider availability logic;
  - model-config list returns all global configs to deployment-config readers and enabled global configs to other eligible members.
- Legacy routes and existing SDK methods remain unchanged during the expansion phase.
- New SDK methods use distinct organization-qualified names. Go does not support signature overloads.
- New TypeScript API and React Query helpers require an explicit organization. Their cache keys include organization from the first additive PR.
- Existing-chat UI uses `chat.organization_id`, never a deployment default.
- The existing new-chat form uses its existing selected organization. Moving its model-related reads into the component that already owns selection is contract wiring, not CODAGT-714 picker work.
- Settings and model-management pages that need a selected organization remain outside CODAGT-709. CODAGT-714 owns their selected-organization UI migration. They continue using legacy global routes until their migration lands.
- The final migration retains the previously approved clone, remap, setting migration, ACL, default, and down-migration semantics without modification.
- The final cutover PR is opened only after the route-consumer stack and CODAGT-714 have merged, the repository has no legacy route callers, and the preceding release has deployed the new client contracts. It removes global rows and global routes in the same release boundary. No default-organization compatibility adapter is retained after clone-and-remap.

### Ruled out

- A default-organization adapter after clone-and-remap. It returns an incorrect clone for non-default chat and selected-organization flows.
- A global route that aggregates all organization clones. It leaks model configuration across organization boundaries and does not preserve the old resource contract.
- A shadow org model table or dual writes before cutover. It adds conflict resolution and migration risk without enabling a consumer that cannot already use the additive read contract.
- Changing existing model visibility or authorization in the expansion route. New model ACL resource permissions activate only with the final org-owned data cutover.
- Folding CODAGT-714's settings, sharing, or picker UI into CODAGT-709.
- Splitting the destructive data migration from the runtime, database interface, RBAC, and server cutover. Those are one atomic application boundary because the migration removes global IDs and configuration keys.

### Constraints and risks

- **Release ordering:** The final cutover depends on consumer migration. Trigger: any supported caller still invokes an unscoped route. Response: do not open or merge the cutover PR.
- **Temporary semantic overlap:** Before cutover, different organization-qualified reads return the same global source data. This is intentional compatibility behavior. Trigger: a consumer assumes a unique per-org ID before cutover. Response: consumers treat the new route as a scoped contract but do not persist a new org-specific model ID until the final migration.
- **External experimental API consumers:** Existing routes remain available through the expansion phase. The final removal is a documented experimental breaking change coordinated with the release containing all in-repo client migrations.
- **CODAGT-714 dependency:** The final cutover cannot happen before its selected-organization settings pages are merged. CODAGT-709 does not implement that ticket.

## Reviewable PR stack

### PR 1: additive organization-qualified discovery contract

**Title:** `feat(coderd): add organization-aware chat model discovery`

**Purpose:** Establish a merge-safe contract that can be consumed before model rows become organization-owned.

**Include:**

- Add `GET /api/experimental/organizations/{organization}/chats/models`.
- Add `GET /api/experimental/organizations/{organization}/chat-model-configs`.
- Resolve the organization with `httpmw.ExtractOrganizationParam` and require `httpmw.UserAuthorization(ctx).HasOrganizationMembership(organization.ID)`.
- Delegate to the existing global catalog and config-list implementations after membership authorization. Do not add database columns, model ACLs, new resource policy, cache changes, or model mutation routes.
- Preserve `GET /api/experimental/chats/models` and `GET /api/experimental/chats/model-configs` unchanged.
- Add named SDK methods such as `ListChatModelsForOrganization` and `ListChatModelConfigsForOrganization`; retain the existing methods and signatures.
- Add explicit TypeScript API methods and React Query factories taking organization. Organization is part of the query key.
- Add API, SDK, and query tests for route shape, organization resolution, non-member rejection, ordinary-member visibility, deployment-config-reader visibility, and organization-isolated cache keys.
- Update generated API references only for the additive endpoints and methods.

**Exclude:**

- all migrations and schema changes;
- model-config create, update, delete, and ACL endpoints;
- chatd, pubsub, telemetry, CLI, scaletest, or site page changes;
- any change to legacy routes or method signatures.

**Invariants:**

- Every legacy request has its current path, method, response shape, and visibility behavior.
- New organization-qualified reads cannot be called by a non-member.
- A new organization-qualified read is global-data compatible until the cutover, not prematurely ACL-filtered.

**Verification:**

- focused `coderd` endpoint tests for both legacy and additive endpoints;
- focused `codersdk` URL and response tests;
- TypeScript API and React Query factory tests;
- `make gen`, `make fmt`, `make lint`, relevant Go package tests, and `git diff --check`.

### PR 2: existing chat detail consumes its resource organization

**Title:** `feat(site/AgentsPage): scope chat model reads to the chat organization`

**Purpose:** Migrate the existing-chat flow to the additive read contract without adding UI state.

**Include:**

- `AgentChatPage` requests catalog, model configs, and user compaction thresholds using `chat.organization_id`.
- Story query seeds use organization-keyed cache keys.
- Model-related React Query invalidation uses the matching organization key.
- Tests prove a chat in a non-default organization requests that organization, not the dashboard default.

**Exclude:**

- creation-form changes;
- settings pages;
- model-management and sharing UI;
- database, runtime, and server mutations.

**Invariants:**

- Existing chat pages never derive model scope from a default organization or current membership ordering.
- The PR remains correct before and after final clone-and-remap because its scope source is the persisted chat organization.

**Verification:**

- targeted API-query tests;
- Agent chat Storybook coverage for a non-default-organization chat;
- `pnpm lint:types`, relevant site tests, and `git diff --check`.

### PR 3: existing new-chat form consumes its selected organization

**Title:** `feat(site/AgentsPage): scope new chat model reads to selected organization`

**Purpose:** Migrate the existing form's model-dependent reads to the organization selector it already owns.

**Include:**

- Move only catalog, model-config, and personal-override reads from `AgentCreatePage` into `AgentCreateForm`, which already owns `selectedOrg` and sends `organization_id` with the create request.
- Query organization-qualified discovery helpers using the selected organization.
- Preserve the current organization selector, workspace filtering, model selection precedence, and create request behavior.
- Update form stories to seed organization-specific query data and prove switching the existing selector refreshes model options from the selected organization.

**Exclude:**

- a new organization picker or any new picker behavior;
- model management, ACL sharing, settings pages, or AI Settings work;
- database, runtime, or mutation contract changes.

**Invariants:**

- A selected non-default organization never receives catalog data from the default organization.
- The form continues to use existing selection state. No CODAGT-714 UI is introduced.

**Verification:**

- targeted form stories and interaction coverage;
- TypeScript typecheck and relevant site tests;
- `git diff --check`.

### PR 4: CODAGT-714 consumer migration, owned separately

**Purpose:** Migrate selected-organization settings and model-management callers to the additive contract.

**Owner and scope:** CODAGT-714, not CODAGT-709. This is a dependency record only. CODAGT-709 does not create this PR or change its files without a separate assignment and approved plan.

**Required result before final cutover:**

- AI Settings model and Coder Agents pages, Agent Settings API keys, compaction, and user-agent pages use an explicit selected organization.
- All model-bearing settings reads and mutations pass organization and use organization-keyed caches.
- The repository has no caller for a legacy global model or model-bearing settings endpoint.

### PR 5: atomic data, authorization, runtime, and API cutover

**Title:** `feat(coderd): scope chat model configs to organizations`

**Purpose:** Activate organization ownership only after the contract consumers are ready.

**Include as one coherent review boundary:**

- The final migration pair and fixtures:
  - add `organization_id`, `user_acl`, and `group_acl` to `chat_model_configs`;
  - clone every legacy config, including soft-deleted historical configs, to every non-deleted organization using a fresh UUID per source-config and organization pair;
  - seed each clone with empty user ACL and Everyone-group `read` ACL;
  - remap chat, message, queued-message, and debug-run model IDs by chat organization;
  - add child organization IDs and same-org composite foreign keys;
  - migrate model-bearing site settings and user settings to organization-keyed forms;
  - delete legacy global rows and global setting keys only after remapping;
  - preserve the approved down-migration collapse behavior.
- Database queries and generated code for organization-owned rows.
- `ResourceChatModelConfig` with create, read, update, delete, and share. No `ActionUse`. Direct user and group ACL roles map only to `read`.
- RegoSQL, dbauthz, role, and ACL endpoint behavior, including Template RBAC entitlement behavior and item 404 concealment.
- Organization-scoped model-config mutation and model-bearing settings routes.
- Removal of all legacy model and model-bearing settings routes and legacy SDK methods after the consumer gate has passed.
- Chatd, pubsub, cache, and telemetry organization isolation.
- CLI, scaletest, SDK, generated API output, and remaining operational caller migration to the final scoped contract.

**Invariants:**

- A model ID, model-bearing setting, cache entry, or query result cannot cross organization boundaries.
- Each organization has at most one non-deleted default. Disabled defaults remain allowed.
- A direct user or group grant provides `read`, not mutation or share authority.
- Existing chats continue with their remapped model clone. No per-turn ACL revocation behavior is introduced.
- The final PR has no default-organization legacy adapter and no global fallback for model-bearing settings.

**Verification:**

- migration fixture and up/down migration execution;
- same-org foreign-key assertions and cross-org rejection;
- organization defaults, ACL user and group behavior, Template RBAC, and item concealment;
- API, SDK, CLI, scaletest, and frontend cross-org request tests;
- chatd default, override, advisor, personal override, compaction threshold, cache key, invalidation, and singleflight isolation tests;
- `make gen`, `make fmt`, `make lint`, relevant package tests, and build entry points;
- a repository-wide search proving no legacy endpoint or old SDK method caller remains before route removal.

## Dependencies and implementation order

1. PR 1 merges first. It introduces the scoped discovery contract without changing data ownership.
2. PR 2 and PR 3 stack on PR 1 and may be reviewed independently. They migrate only the resource-aware Agents flows.
3. CODAGT-714 migrates the selected-organization settings and model-management UI in separate PRs.
4. PR 5 starts only when PRs 1 through 3 and CODAGT-714 have merged, the supported release has the scoped clients deployed, and repository search confirms legacy callers are gone.
5. PR 5 is atomic across migration, database interfaces, RBAC, runtime, and removal. It is intentionally not split because any intermediate deployment would see cloned IDs and missing global model-bearing settings with an application still reading global state.

## Evidence

- The current migration clones IDs per organization and deletes global rows. Therefore a post-migration unscoped request cannot be correct for every organization.
- Existing `AgentChatPage` has `chat.organization_id`; the resource organization is already available without UI work.
- Existing `AgentCreateForm` owns `selectedOrg` and sends `organization_id`; the required source already exists without adding a picker.
- Existing global catalog and config-list handlers have different visibility behavior for ordinary users and deployment-config readers. PR 1 preserves it behind organization membership rather than prematurely activating new ACL behavior.
- Existing `httpmw.ExtractOrganizationParam` is the established route resolver for organization-qualified APIs.
- Go SDK method signatures cannot be overloaded, so new scoped methods must have distinct names until the final removal.


</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
