### PR TITLE
fix(site): scope chat detail models by org

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -13,17 +13,19 @@ import {
 	chatDiffContentsKey,
 	chatKey,
 	chatMessagesKey,
-	chatModelConfigs,
 	chatModelsKey,
 	chatPromptsKey,
 	chatsKey,
 	mcpServerConfigsKey,
+	organizationChatModelConfigsKey,
+	organizationChatModelsKey,
 } from "#/api/queries/chats";
 import { workspaceByIdKey } from "#/api/queries/workspaces";
 import type * as TypesGen from "#/api/typesGenerated";
 import { MockChatMessage } from "#/testHelpers/chatEntities";
 import { MockChatModelConfig } from "#/testHelpers/chatModels";
 import {
+	MockDefaultOrganization,
 	MockGroup,
 	MockOrganizationMember,
 	MockOrganizationMember2,
@@ -80,6 +82,7 @@ const AgentChatPageLayout: FC = () => {
 // Shared mock data
 // ---------------------------------------------------------------------------
 const CHAT_ID = "chat-1";
+const CHAT_ORGANIZATION_ID = "chat-organization-id";
 const MODEL_CONFIG_ID = "model-config-1";
 
 const mockWorkspace: TypesGen.Workspace = {
@@ -133,7 +136,7 @@ const mockModelConfigs: TypesGen.ChatModelConfig[] = [
 ];
 
 const baseChatFields = {
-	organization_id: "test-org-id",
+	organization_id: CHAT_ORGANIZATION_ID,
 	owner_id: MockUserOwner.id,
 	owner_username: MockUserOwner.username,
 	owner_name: MockUserOwner.name,
@@ -232,7 +235,7 @@ const buildChatAuthorizationQuery = (
 const buildQueries = (
 	chat: TypesGen.Chat,
 	messagesData: TypesGen.ChatMessagesResponse,
-	opts?: { diffUrl?: string },
+	opts?: { diffUrl?: string; seedModelDiscovery?: boolean },
 ) => {
 	const diffStatus: TypesGen.ChatDiffStatus = {
 		chat_id: CHAT_ID,
@@ -273,8 +276,18 @@ const buildQueries = (
 			key: workspaceByIdKey(mockWorkspace.id),
 			data: mockWorkspace,
 		},
-		{ key: chatModelsKey, data: mockModelCatalog },
-		{ key: chatModelConfigs().queryKey, data: mockModelConfigs },
+		...(opts?.seedModelDiscovery === false
+			? []
+			: [
+					{
+						key: organizationChatModelsKey(chat.organization_id),
+						data: mockModelCatalog,
+					},
+					{
+						key: organizationChatModelConfigsKey(chat.organization_id),
+						data: mockModelConfigs,
+					},
+				]),
 		{ key: mcpServerConfigsKey, data: [] },
 		buildChatAuthorizationQuery(chat, {
 			canShareChat: {
@@ -1301,6 +1314,74 @@ export const RootChatShareActionAvailable: Story = {
 		await waitFor(() => {
 			expect(body.getByText("No shared members or groups yet")).toBeVisible();
 		});
+	},
+};
+
+/** A loaded chat discovers models from its own non-default organization. */
+export const NonDefaultOrganizationModelDiscovery: Story = {
+	parameters: {
+		organizations: [
+			MockDefaultOrganization,
+			{
+				...MockDefaultOrganization,
+				id: CHAT_ORGANIZATION_ID,
+				name: "chat-organization",
+				display_name: "Chat Organization",
+				is_default: false,
+			},
+		],
+		queries: [
+			...buildQueries(
+				{
+					id: CHAT_ID,
+					...baseChatFields,
+					title: "Non-default organization chat",
+					status: "waiting",
+				},
+				{ messages: [], queued_messages: [], has_more: false },
+				{ seedModelDiscovery: false },
+			),
+			{
+				key: chatModelsKey,
+				data: { providers: [], unsupported_providers: [] },
+			},
+		],
+	},
+	beforeEach: () => {
+		spyOn(API.experimental, "getOrganizationChatModels").mockResolvedValue(
+			mockModelCatalog,
+		);
+		spyOn(
+			API.experimental,
+			"getOrganizationChatModelConfigs",
+		).mockResolvedValue(mockModelConfigs);
+		spyOn(API.experimental, "getChatModels").mockResolvedValue(
+			mockModelCatalog,
+		);
+		spyOn(API.experimental, "getChatModelConfigs").mockResolvedValue(
+			mockModelConfigs,
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await canvas.findByText("Non-default organization chat");
+
+		await waitFor(() => {
+			expect(API.experimental.getOrganizationChatModels).toHaveBeenCalledWith(
+				CHAT_ORGANIZATION_ID,
+			);
+			expect(
+				API.experimental.getOrganizationChatModelConfigs,
+			).toHaveBeenCalledWith(CHAT_ORGANIZATION_ID);
+		});
+		expect(API.experimental.getOrganizationChatModels).not.toHaveBeenCalledWith(
+			MockDefaultOrganization.id,
+		);
+		expect(
+			API.experimental.getOrganizationChatModelConfigs,
+		).not.toHaveBeenCalledWith(MockDefaultOrganization.id);
+		expect(API.experimental.getChatModels).not.toHaveBeenCalled();
+		expect(API.experimental.getChatModelConfigs).not.toHaveBeenCalled();
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -28,14 +28,14 @@ import {
 	chat,
 	chatKey,
 	chatMessagesForInfiniteScroll,
-	chatModelConfigs,
-	chatModels,
 	chatProviderConfigs,
 	createChatMessage,
 	deleteChatQueuedMessage,
 	editChatMessage,
 	interruptChat,
 	mcpServerConfigs,
+	organizationChatModelConfigs,
+	organizationChatModels,
 	promoteChatQueuedMessage,
 	updateChatPlanMode,
 	updateChatWorkspace,
@@ -778,8 +778,15 @@ const AgentChatPage: FC = () => {
 	});
 	const workspace = workspaceQuery.data;
 
-	const chatModelsQuery = useQuery(chatModels());
-	const chatModelConfigsQuery = useQuery(chatModelConfigs());
+	const organizationID = chatQuery.data?.organization_id;
+	const chatModelsQuery = useQuery({
+		...organizationChatModels(organizationID ?? ""),
+		enabled: Boolean(organizationID),
+	});
+	const chatModelConfigsQuery = useQuery({
+		...organizationChatModelConfigs(organizationID ?? ""),
+		enabled: Boolean(organizationID),
+	});
 	const chatProviderConfigsQuery = useQuery({
 		...chatProviderConfigs(),
 		enabled: permissions.editDeploymentConfig,


### PR DESCRIPTION
## Why

The chat detail page already knows the chat's organization. Using that resource scope for model discovery prevents a non-default organization chat from reading a default or deployment-wide model cache after the organization-owned data cutover.

This stack layer changes only the existing chat detail consumer. It depends on #27337 and does not add settings UI, organization selection, or model-management behavior.

## Verification

- TypeScript typecheck
- focused organization discovery Storybook test
- frontend unit tests, 3,050 passed
- frontend lint
- production site build
- mandatory pre-commit hook

The full story file retains an inherited `WithMessageHistory` failure that reproduces on the parent commit. It is being investigated independently on `mathias/fix-chat-storybook-tests`.

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
