### PR TITLE
feat: add network call badges to AI sessions table

### DIFF
--- a/docs/ai-coder/ai-gateway/audit.md
+++ b/docs/ai-coder/ai-gateway/audit.md
@@ -49,7 +49,12 @@ not just what was called.
 
 The sessions page (`http://<deployment-url>/ai-gateway/sessions`) lists all sessions in
 reverse-chronological order. Each row shows the last prompt, initiator, provider,
-client, token usage, thread count, and timestamp.
+client, token usage, network calls, thread count, and timestamp.
+
+The network calls column reports the total and blocked
+[Agent Firewall](../agent-firewall/index.md) calls for the session. It shows
+`No activity` when the session made no calls, and `Disabled` when the session
+did not pass through Agent Firewall, so no network calls were monitored.
 
 Select one to view its full details.
 

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsPageView.stories.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsPageView.stories.tsx
@@ -106,6 +106,13 @@ export const MultipleSessions: Story = {
 				cache_read_input_tokens: 800 * (i + 1),
 				cache_write_input_tokens: 50 * (i + 1),
 			},
+			network_calls: [
+				{ total: 23, blocked: 2 },
+				{ total: 5, blocked: 1 },
+				{ total: 0, blocked: 0 },
+				undefined,
+				{ total: 150, blocked: 0 },
+			][i],
 		})),
 	},
 };

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsPageView.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsPageView.tsx
@@ -86,6 +86,9 @@ export const ListSessionsPageView: FC<ListSessionsPageViewProps> = ({
 							<TableHead className="text-nowrap">Provider</TableHead>
 							<TableHead className="text-nowrap">Client</TableHead>
 							<TableHead className="text-nowrap">In/Out Tokens</TableHead>
+							<TableHead className="w-40">
+								Total/blocked network calls
+							</TableHead>
 							<TableHead className="flex items-center flex-nowrap gap-1">
 								Threads
 								<ThreadTooltip>

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsPageView.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsPageView.tsx
@@ -86,9 +86,7 @@ export const ListSessionsPageView: FC<ListSessionsPageViewProps> = ({
 							<TableHead className="text-nowrap">Provider</TableHead>
 							<TableHead className="text-nowrap">Client</TableHead>
 							<TableHead className="text-nowrap">In/Out Tokens</TableHead>
-							<TableHead className="w-40">
-								Total/blocked network calls
-							</TableHead>
+							<TableHead className="text-nowrap">Network Calls</TableHead>
 							<TableHead className="flex items-center flex-nowrap gap-1">
 								Threads
 								<ThreadTooltip>

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.stories.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.stories.tsx
@@ -107,3 +107,27 @@ export const LargeTokenCounts: Story = {
 		},
 	},
 };
+
+export const NetworkCallsBlocked: Story = {
+	args: {
+		session: {
+			...MockSession,
+			network_calls: { total: 23, blocked: 2 },
+		},
+	},
+};
+
+export const NoNetworkActivity: Story = {
+	args: {
+		session: {
+			...MockSession,
+			network_calls: { total: 0, blocked: 0 },
+		},
+	},
+};
+
+export const NetworkDisabled: Story = {
+	args: {
+		session: { ...MockSession, network_calls: undefined },
+	},
+};

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
@@ -13,6 +13,7 @@ import {
 import { AIBridgeClientIcon } from "#/pages/AIBridgePage/icons/AIBridgeClientIcon";
 import { AIBridgeProviderIcon } from "#/pages/AIBridgePage/icons/AIBridgeProviderIcon";
 import { DATE_FORMAT, formatDateTime } from "#/utils/time";
+import { NetworkCallBadges } from "../NetworkCallBadges";
 import { TokenBadges } from "../TokenBadges";
 import { getProviderDisplayName } from "../utils";
 
@@ -104,6 +105,9 @@ export const ListSessionsRow: FC<ListSessionsRowProps> = ({
 						outputTokens={session.token_usage_summary.output_tokens}
 					/>
 				</div>
+			</TableCell>
+			<TableCell className="w-40">
+				<NetworkCallBadges summary={session.network_calls} />
 			</TableCell>
 			<TableCell className="w-32">
 				<Badge className="bg-surface-secondary align-end">

--- a/site/src/pages/AIBridgePage/NetworkCallBadges.stories.tsx
+++ b/site/src/pages/AIBridgePage/NetworkCallBadges.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, screen, userEvent, waitFor } from "storybook/test";
 import { NetworkCallBadges } from "./NetworkCallBadges";
 
 const meta: Meta<typeof NetworkCallBadges> = {
@@ -39,16 +40,32 @@ export const LargeCounts: Story = {
 	},
 };
 
-export const SizeXs: Story = {
+// Tabbing to the badges reveals the breakdown tooltip without a mouse.
+export const TotalAndBlockedKeyboard: Story = {
 	args: {
-		size: "xs",
 		summary: { total: 23, blocked: 2 },
+	},
+	play: async () => {
+		await userEvent.tab();
+		await waitFor(() => {
+			const tooltip = screen.getByRole("tooltip");
+			expect(tooltip).toHaveTextContent("Total calls");
+			expect(tooltip).toHaveTextContent("Blocked");
+		});
 	},
 };
 
-export const SizeMd: Story = {
+// Tabbing to the disabled indicator reveals the reason tooltip without a mouse.
+export const DisabledKeyboard: Story = {
 	args: {
-		size: "md",
-		summary: { total: 23, blocked: 2 },
+		summary: undefined,
+	},
+	play: async () => {
+		await userEvent.tab();
+		await waitFor(() =>
+			expect(screen.getByRole("tooltip")).toHaveTextContent(
+				"Network call monitoring was not active for this session.",
+			),
+		);
 	},
 };

--- a/site/src/pages/AIBridgePage/NetworkCallBadges.stories.tsx
+++ b/site/src/pages/AIBridgePage/NetworkCallBadges.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { NetworkCallBadges } from "./NetworkCallBadges";
+
+const meta: Meta<typeof NetworkCallBadges> = {
+	title: "pages/AIBridgePage/NetworkCallBadges",
+	component: NetworkCallBadges,
+};
+
+export default meta;
+type Story = StoryObj<typeof NetworkCallBadges>;
+
+export const TotalAndBlocked: Story = {
+	args: {
+		summary: { total: 23, blocked: 2 },
+	},
+};
+
+export const NoBlocked: Story = {
+	args: {
+		summary: { total: 23, blocked: 0 },
+	},
+};
+
+export const NoActivity: Story = {
+	args: {
+		summary: { total: 0, blocked: 0 },
+	},
+};
+
+export const Disabled: Story = {
+	args: {
+		summary: undefined,
+	},
+};
+
+export const LargeCounts: Story = {
+	args: {
+		summary: { total: 12_480, blocked: 320 },
+	},
+};
+
+export const SizeXs: Story = {
+	args: {
+		size: "xs",
+		summary: { total: 23, blocked: 2 },
+	},
+};
+
+export const SizeMd: Story = {
+	args: {
+		size: "md",
+		summary: { total: 23, blocked: 2 },
+	},
+};

--- a/site/src/pages/AIBridgePage/NetworkCallBadges.stories.tsx
+++ b/site/src/pages/AIBridgePage/NetworkCallBadges.stories.tsx
@@ -55,15 +55,17 @@ export const TotalAndBlockedKeyboard: Story = {
 	},
 };
 
-// Tabbing to the disabled indicator reveals the reason tooltip without a mouse.
+// Tabbing to the disabled indicator's info button and pressing Enter reveals
+// the reason popover without a mouse.
 export const DisabledKeyboard: Story = {
 	args: {
 		summary: undefined,
 	},
 	play: async () => {
 		await userEvent.tab();
+		await userEvent.keyboard("{Enter}");
 		await waitFor(() =>
-			expect(screen.getByRole("tooltip")).toHaveTextContent(
+			expect(screen.getByRole("dialog")).toHaveTextContent(
 				"Network call monitoring was not active for this session.",
 			),
 		);

--- a/site/src/pages/AIBridgePage/NetworkCallBadges.tsx
+++ b/site/src/pages/AIBridgePage/NetworkCallBadges.tsx
@@ -1,7 +1,8 @@
-import { BanIcon, InfoIcon } from "lucide-react";
+import { BanIcon } from "lucide-react";
 import type { FC } from "react";
 import type { AIBridgeSessionNetworkCallSummary } from "#/api/typesGenerated";
 import { Badge } from "#/components/Badge/Badge";
+import { InfoTooltip } from "#/components/InfoTooltip/InfoTooltip";
 import {
 	Tooltip,
 	TooltipContent,
@@ -18,24 +19,10 @@ interface NetworkCallBadgesProps {
 export const NetworkCallBadges: FC<NetworkCallBadgesProps> = ({ summary }) => {
 	if (!summary) {
 		return (
-			<TooltipProvider>
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<span className="inline-flex items-center gap-1 whitespace-nowrap text-content-secondary">
-							Disabled
-							<span className="sr-only">More info</span>
-							<InfoIcon tabIndex={0} className="cursor-pointer size-icon-xs" />
-						</span>
-					</TooltipTrigger>
-					<TooltipContent
-						side="top"
-						align="start"
-						className="max-w-xs text-sm font-normal"
-					>
-						Network call monitoring was not active for this session.
-					</TooltipContent>
-				</Tooltip>
-			</TooltipProvider>
+			<span className="inline-flex items-center gap-1 whitespace-nowrap text-content-secondary">
+				Disabled
+				<InfoTooltip message="Network call monitoring was not active for this session." />
+			</span>
 		);
 	}
 
@@ -51,12 +38,11 @@ export const NetworkCallBadges: FC<NetworkCallBadgesProps> = ({ summary }) => {
 		<TooltipProvider>
 			<Tooltip>
 				<TooltipTrigger asChild>
-					<span
-						tabIndex={0}
-						role="button"
-						className="flex items-center whitespace-nowrap"
+					<button
+						type="button"
+						aria-label="More info"
+						className="flex items-center whitespace-nowrap border-0 bg-transparent p-0 text-inherit"
 					>
-						<span className="sr-only">More info</span>
 						<Badge size="sm" className="rounded-e-none">
 							{summary.total.toLocaleString("en-US")}
 						</Badge>
@@ -68,7 +54,7 @@ export const NetworkCallBadges: FC<NetworkCallBadgesProps> = ({ summary }) => {
 							<BanIcon className="flex-shrink-0" />
 							{summary.blocked.toLocaleString("en-US")}
 						</Badge>
-					</span>
+					</button>
 				</TooltipTrigger>
 				<TooltipContent
 					side="top"

--- a/site/src/pages/AIBridgePage/NetworkCallBadges.tsx
+++ b/site/src/pages/AIBridgePage/NetworkCallBadges.tsx
@@ -10,16 +10,12 @@ import {
 } from "#/components/Tooltip/Tooltip";
 
 interface NetworkCallBadgesProps {
-	size?: "xs" | "sm" | "md";
 	// summary is undefined when network call monitoring was not active for the
 	// session, which renders as "Disabled".
 	summary: AIBridgeSessionNetworkCallSummary | undefined;
 }
 
-export const NetworkCallBadges: FC<NetworkCallBadgesProps> = ({
-	size = "sm",
-	summary,
-}) => {
+export const NetworkCallBadges: FC<NetworkCallBadgesProps> = ({ summary }) => {
 	if (!summary) {
 		return (
 			<TooltipProvider>
@@ -27,7 +23,8 @@ export const NetworkCallBadges: FC<NetworkCallBadgesProps> = ({
 					<TooltipTrigger asChild>
 						<span className="inline-flex items-center gap-1 whitespace-nowrap text-content-secondary">
 							Disabled
-							<InfoIcon className="size-icon-xs" />
+							<span className="sr-only">More info</span>
+							<InfoIcon tabIndex={0} className="cursor-pointer size-icon-xs" />
 						</span>
 					</TooltipTrigger>
 					<TooltipContent
@@ -54,9 +51,20 @@ export const NetworkCallBadges: FC<NetworkCallBadgesProps> = ({
 		<TooltipProvider>
 			<Tooltip>
 				<TooltipTrigger asChild>
-					<span className="flex items-center gap-1 whitespace-nowrap">
-						<Badge size={size}>{summary.total.toLocaleString("en-US")}</Badge>
-						<Badge size={size} svgSize="sm">
+					<span
+						tabIndex={0}
+						role="button"
+						className="flex items-center whitespace-nowrap"
+					>
+						<span className="sr-only">More info</span>
+						<Badge size="sm" className="rounded-e-none">
+							{summary.total.toLocaleString("en-US")}
+						</Badge>
+						<Badge
+							size="sm"
+							svgSize="xs"
+							className="gap-0 bg-surface-tertiary rounded-s-none text-content-warning"
+						>
 							<BanIcon className="flex-shrink-0" />
 							{summary.blocked.toLocaleString("en-US")}
 						</Badge>

--- a/site/src/pages/AIBridgePage/NetworkCallBadges.tsx
+++ b/site/src/pages/AIBridgePage/NetworkCallBadges.tsx
@@ -1,0 +1,84 @@
+import { BanIcon, InfoIcon } from "lucide-react";
+import type { FC } from "react";
+import type { AIBridgeSessionNetworkCallSummary } from "#/api/typesGenerated";
+import { Badge } from "#/components/Badge/Badge";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
+
+interface NetworkCallBadgesProps {
+	size?: "xs" | "sm" | "md";
+	// summary is undefined when network call monitoring was not active for the
+	// session, which renders as "Disabled".
+	summary: AIBridgeSessionNetworkCallSummary | undefined;
+}
+
+export const NetworkCallBadges: FC<NetworkCallBadgesProps> = ({
+	size = "sm",
+	summary,
+}) => {
+	if (!summary) {
+		return (
+			<TooltipProvider>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<span className="inline-flex items-center gap-1 whitespace-nowrap text-content-secondary">
+							Disabled
+							<InfoIcon className="size-icon-xs" />
+						</span>
+					</TooltipTrigger>
+					<TooltipContent
+						side="top"
+						align="start"
+						className="max-w-xs text-sm font-normal"
+					>
+						Network call monitoring was not active for this session.
+					</TooltipContent>
+				</Tooltip>
+			</TooltipProvider>
+		);
+	}
+
+	if (summary.total === 0) {
+		return (
+			<span className="whitespace-nowrap text-content-secondary">
+				No activity
+			</span>
+		);
+	}
+
+	return (
+		<TooltipProvider>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<span className="flex items-center gap-1 whitespace-nowrap">
+						<Badge size={size}>{summary.total.toLocaleString("en-US")}</Badge>
+						<Badge size={size} svgSize="sm">
+							<BanIcon className="flex-shrink-0" />
+							{summary.blocked.toLocaleString("en-US")}
+						</Badge>
+					</span>
+				</TooltipTrigger>
+				<TooltipContent
+					side="top"
+					align="start"
+					className="text-sm font-normal"
+				>
+					<div className="flex flex-col gap-1">
+						<div className="flex items-center justify-between gap-4">
+							<span className="text-content-secondary">Total calls</span>
+							<span>{summary.total.toLocaleString("en-US")}</span>
+						</div>
+						<div className="flex items-center justify-between gap-4">
+							<span className="text-content-secondary">Blocked</span>
+							<span>{summary.blocked.toLocaleString("en-US")}</span>
+						</div>
+					</div>
+				</TooltipContent>
+			</Tooltip>
+		</TooltipProvider>
+	);
+};

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -5523,6 +5523,10 @@ export const MockSession: TypesGen.AIBridgeSession = {
 		cache_read_input_tokens: 980,
 		cache_write_input_tokens: 120,
 	},
+	network_calls: {
+		total: 23,
+		blocked: 2,
+	},
 	last_prompt: "But *can* I really fix it?",
 	last_active_at: "2026-03-09T10:28:15.03152Z",
 };


### PR DESCRIPTION
Surface the total and blocked Agent Firewall network calls on the AI sessions list. Sessions that did not pass through Agent Firewall show as "Disabled".

<img width="2842" height="1366" alt="image" src="https://github.com/user-attachments/assets/2a68b4a9-4d93-454d-a06e-5f0d0b734a33" />
