### PR TITLE
feat(dogfood/coder): add opt-in /dev/kvm device mapping

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -191,6 +191,14 @@ data "coder_parameter" "devcontainer_autostart" {
   mutable     = true
 }
 
+data "coder_parameter" "enable_kvm" {
+  type        = "bool"
+  name        = "Expose /dev/kvm to the workspace"
+  default     = false
+  description = "If enabled, the host's /dev/kvm device is mapped into the workspace container to allow hardware-accelerated VMs. Only works when the underlying host exposes /dev/kvm; leave disabled otherwise."
+  mutable     = true
+}
+
 # dogfood/main.tf injects this value from a GH Actions secret;
 # `coderd_template.dogfood` passes the value injected by .github/workflows/dogfood.yaml in `TF_VAR_CODER_DOGFOOD_ANTHROPIC_API_KEY` and `TF_VAR_CODER_DOGFOOD_OPENAI_API_KEY`.
 # Currently unused since AI Gateway is always enabled, but kept for emergency fallback.
@@ -879,6 +887,15 @@ resource "docker_container" "workspace" {
   }
   capabilities {
     add = ["CAP_NET_ADMIN", "CAP_SYS_NICE"]
+  }
+  # Gated behind a parameter because mapping /dev/kvm fails container creation
+  # on hosts that do not expose it.
+  dynamic "devices" {
+    for_each = data.coder_parameter.enable_kvm.value ? [1] : []
+    content {
+      host_path      = "/dev/kvm"
+      container_path = "/dev/kvm"
+    }
   }
   # Add labels in Docker to keep track of orphan resources.
   labels {


### PR DESCRIPTION
## Summary

Adds an opt-in **"Expose /dev/kvm to the workspace"** bool parameter (default `false`) to the dogfood template. When enabled, the host's `/dev/kvm` device is mapped into the workspace container so it can run hardware-accelerated VMs (e.g. nested microVM runtimes).

## Details

- New `coder_parameter` `enable_kvm` (bool, default off, mutable).
- A `dynamic "devices"` block on `docker_container.workspace` that maps `/dev/kvm` only when the parameter is enabled.

It is gated behind a parameter on purpose: dogfood runs on GKE, where most nodes do not expose `/dev/kvm`, and mapping a missing device fails container creation. Keeping it off by default means existing workspaces are unaffected; only users on a KVM-capable host opt in.

## Verifying KVM passthrough on a host

```bash
docker run --rm --runtime=sysbox-runc --device=/dev/kvm alpine sh -c \
  '[ -c /dev/kvm ] && [ -r /dev/kvm ] && [ -w /dev/kvm ] && echo OK || echo FAIL'
```

## Notes

- No effect unless the host actually provides `/dev/kvm` and the workspace user has access to it.
- Draft: still validating end-to-end on a KVM-capable host.