### PR TITLE
feat: scope chat model runtime to orgs

### DIFF
--- a/cli/exp_scaletest_chat.go
+++ b/cli/exp_scaletest_chat.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/xerrors"
@@ -77,9 +78,18 @@ func (r *RootCmd) scaletestChat() *serpent.Command {
 			}
 
 			logger := inv.Logger
-			modelConfigID, err := chat.EnsureScaletestModelConfig(ctx, client, logger, llmMockURL, providerPropagationWait)
-			if err != nil {
-				return err
+			modelConfigIDs := make(map[uuid.UUID]uuid.UUID)
+			for _, workspace := range workspaces {
+				if _, ok := modelConfigIDs[workspace.OrganizationID]; ok {
+					continue
+				}
+				modelConfigID, err := chat.EnsureScaletestModelConfig(
+					ctx, client, logger, workspace.OrganizationID, llmMockURL, providerPropagationWait,
+				)
+				if err != nil {
+					return err
+				}
+				modelConfigIDs[workspace.OrganizationID] = modelConfigID
 			}
 
 			// Start metrics and tracing before creating runners.
@@ -128,7 +138,7 @@ func (r *RootCmd) scaletestChat() *serpent.Command {
 						OrganizationID:          targetWorkspace.OrganizationID,
 						WorkspaceID:             targetWorkspace.ID,
 						Prompt:                  prompt,
-						ModelConfigID:           modelConfigID,
+						ModelConfigID:           modelConfigIDs[targetWorkspace.OrganizationID],
 						Turns:                   int(turns),
 						TurnStartDelay:          turnStartDelay,
 						TurnStartReadyWaitGroup: turnStartReadyWaitGroup,

--- a/cli/exp_scaletest_chat_test.go
+++ b/cli/exp_scaletest_chat_test.go
@@ -35,7 +35,7 @@ func TestScaleTestChat(t *testing.T) {
 		DeploymentValues: values,
 	})
 	aibridgedtest.StartTestAIBridgeDaemon(t.Context(), t, api, nil)
-	coderdtest.CreateFirstUser(t, client)
+	firstUser := coderdtest.CreateFirstUser(t, client)
 
 	server := new(llmmock.Server)
 	require.NoError(t, server.Start(context.Background(), llmmock.Config{
@@ -77,7 +77,7 @@ func TestScaleTestChat(t *testing.T) {
 	require.Equal(t, mockURL, provider.BaseURL)
 
 	expClient := codersdk.NewExperimentalClient(client)
-	configs, err := expClient.ListChatModelConfigs(ctx)
+	configs, err := expClient.ListChatModelConfigs(ctx, firstUser.OrganizationID)
 	require.NoError(t, err)
 	matchingConfigs := scaletestModelConfigsForProvider(configs, provider.ID)
 	require.Len(t, matchingConfigs, 1)

--- a/coderd/coderdtest/chat.go
+++ b/coderd/coderdtest/chat.go
@@ -70,9 +70,13 @@ func CreateOpenAICompatChatModelConfig(
 		APIKeys: []string{TestChatProviderAPIKey},
 	})
 	require.NoError(t, err)
+	user, err := client.User(ctx, codersdk.Me)
+	require.NoError(t, err)
+	require.NotEmpty(t, user.OrganizationIDs)
+
 	contextLimit := int64(4096)
 	isDefault := true
-	modelConfig, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+	modelConfig, err := client.CreateChatModelConfig(ctx, user.OrganizationIDs[0], codersdk.CreateChatModelConfigRequest{
 		AIProviderID: &provider.ID,
 		Model:        TestChatModelOpenAICompat,
 		ContextLimit: &contextLimit,

--- a/coderd/pubsub/chatconfigevent.go
+++ b/coderd/pubsub/chatconfigevent.go
@@ -37,6 +37,8 @@ func HandleChatConfigEvent(cb func(ctx context.Context, payload ChatConfigEvent,
 // updates). Subscribers use this to invalidate their local caches.
 type ChatConfigEvent struct {
 	Kind ChatConfigEventKind `json:"kind"`
+	// OrganizationID scopes model and advisor invalidations to one organization.
+	OrganizationID uuid.UUID `json:"organization_id"`
 	// EntityID carries context for the invalidation:
 	//   - For model configs: the specific config ID.
 	//   - For user prompts: the user ID.

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -2317,12 +2317,13 @@ func ConvertChatMessageSummary(dbRow database.GetChatMessageSummariesPerChatRow)
 // telemetry ChatModelConfig.
 func ConvertChatModelConfig(dbRow database.GetChatModelConfigsForTelemetryRow) ChatModelConfig {
 	return ChatModelConfig{
-		ID:           dbRow.ID,
-		Provider:     dbRow.Provider,
-		Model:        dbRow.Model,
-		ContextLimit: dbRow.ContextLimit,
-		Enabled:      dbRow.Enabled,
-		IsDefault:    dbRow.IsDefault,
+		ID:             dbRow.ID,
+		OrganizationID: dbRow.OrganizationID,
+		Provider:       dbRow.Provider,
+		Model:          dbRow.Model,
+		ContextLimit:   dbRow.ContextLimit,
+		Enabled:        dbRow.Enabled,
+		IsDefault:      dbRow.IsDefault,
 	}
 }
 
@@ -2377,11 +2378,16 @@ type AgentsComputerUseTelemetry struct {
 // AgentsAdvisorTelemetry is the value shape for the advisor entry in
 // Deployment.AgentsExperiments.
 type AgentsAdvisorTelemetry struct {
-	Enabled         bool   `json:"enabled"`
-	MaxUsesPerRun   int    `json:"max_uses_per_run"`
-	MaxOutputTokens int64  `json:"max_output_tokens"`
-	Provider        string `json:"provider"`
-	Model           string `json:"model"`
+	Enabled       bool                                 `json:"enabled"`
+	Organizations []AgentsAdvisorOrganizationTelemetry `json:"organizations"`
+}
+
+type AgentsAdvisorOrganizationTelemetry struct {
+	OrganizationID  uuid.UUID `json:"organization_id"`
+	MaxUsesPerRun   int       `json:"max_uses_per_run"`
+	MaxOutputTokens int64     `json:"max_output_tokens"`
+	Provider        string    `json:"provider"`
+	Model           string    `json:"model"`
 }
 
 // CollectAgentsVirtualDesktop collects the virtual_desktop entry in
@@ -2417,20 +2423,30 @@ func CollectAgentsVirtualDesktop(ctx context.Context, opts Options) json.RawMess
 // Deployment.AgentsExperiments.
 func CollectAgentsAdvisor(ctx context.Context, opts Options) json.RawMessage {
 	payload := AgentsAdvisorTelemetry{
-		Enabled:  opts.Experiments.Enabled(codersdk.ExperimentChatAdvisor),
-		Provider: AgentsExperimentUnknown,
-		Model:    AgentsExperimentUnknown,
+		Enabled: opts.Experiments.Enabled(codersdk.ExperimentChatAdvisor),
 	}
-	var cfg codersdk.AdvisorConfig
-	raw, err := opts.Database.GetChatAdvisorConfig(ctx)
+	organizations, err := opts.Database.GetOrganizations(ctx, database.GetOrganizationsParams{})
 	if err != nil {
-		opts.Logger.Warn(ctx, "get chat advisor config for telemetry", slog.Error(err))
-	} else if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
-		opts.Logger.Warn(ctx, "parse chat advisor config for telemetry", slog.Error(err))
-	} else {
-		payload.MaxUsesPerRun = max(cfg.MaxUsesPerRun, 0)
-		payload.MaxOutputTokens = max(cfg.MaxOutputTokens, 0)
-		payload.Provider, payload.Model = advisorModelTelemetry(ctx, opts.Database, opts.Logger, cfg.ModelConfigID)
+		opts.Logger.Warn(ctx, "get organizations for chat advisor telemetry", slog.Error(err))
+	}
+	for _, organization := range organizations {
+		entry := AgentsAdvisorOrganizationTelemetry{
+			OrganizationID: organization.ID,
+			Provider:       AgentsExperimentUnknown,
+			Model:          AgentsExperimentUnknown,
+		}
+		var cfg codersdk.AdvisorConfig
+		raw, err := opts.Database.GetChatAdvisorConfigForOrganization(ctx, organization.ID)
+		if err != nil {
+			opts.Logger.Warn(ctx, "get chat advisor config for telemetry", slog.F("organization_id", organization.ID), slog.Error(err))
+		} else if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+			opts.Logger.Warn(ctx, "parse chat advisor config for telemetry", slog.F("organization_id", organization.ID), slog.Error(err))
+		} else {
+			entry.MaxUsesPerRun = max(cfg.MaxUsesPerRun, 0)
+			entry.MaxOutputTokens = max(cfg.MaxOutputTokens, 0)
+			entry.Provider, entry.Model = advisorModelTelemetry(ctx, opts.Database, opts.Logger, cfg.ModelConfigID)
+		}
+		payload.Organizations = append(payload.Organizations, entry)
 	}
 	val, err := json.Marshal(payload)
 	if err != nil {
@@ -2445,7 +2461,19 @@ func advisorModelTelemetry(ctx context.Context, db database.Store, log slog.Logg
 		return AgentsExperimentAdvisorReuseChatModel, AgentsExperimentAdvisorReuseChatModel
 	}
 
-	cfg, err := db.GetEnabledChatModelConfigByID(ctx, id)
+	modelConfig, err := db.GetChatModelConfigByIDForAuthorization(ctx, id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return AgentsExperimentAdvisorReuseChatModel, AgentsExperimentAdvisorReuseChatModel
+	}
+	if err != nil {
+		log.Warn(ctx, "resolve chat advisor model config organization for telemetry", slog.Error(err))
+		return AgentsExperimentUnknown, AgentsExperimentUnknown
+	}
+
+	cfg, err := db.GetEnabledChatModelConfigByID(ctx, database.GetEnabledChatModelConfigByIDParams{
+		ID:             id,
+		OrganizationID: modelConfig.OrganizationID,
+	})
 	if errors.Is(err, sql.ErrNoRows) {
 		// An inactive override; the runtime falls back to the chat model.
 		return AgentsExperimentAdvisorReuseChatModel, AgentsExperimentAdvisorReuseChatModel
@@ -2611,12 +2639,13 @@ type ChatMessageSummary struct {
 // ChatModelConfig contains model configuration metadata for
 // telemetry. Sensitive fields like API keys are excluded.
 type ChatModelConfig struct {
-	ID           uuid.UUID `json:"id"`
-	Provider     string    `json:"provider"`
-	Model        string    `json:"model"`
-	ContextLimit int64     `json:"context_limit"`
-	Enabled      bool      `json:"enabled"`
-	IsDefault    bool      `json:"is_default"`
+	ID             uuid.UUID `json:"id"`
+	OrganizationID uuid.UUID `json:"organization_id"`
+	Provider       string    `json:"provider"`
+	Model          string    `json:"model"`
+	ContextLimit   int64     `json:"context_limit"`
+	Enabled        bool      `json:"enabled"`
+	IsDefault      bool      `json:"is_default"`
 }
 
 // ChatDiffStatusSummary contains aggregate PR counts across all

--- a/coderd/telemetry/telemetry_test.go
+++ b/coderd/telemetry/telemetry_test.go
@@ -1610,6 +1610,8 @@ func TestChatsTelemetry(t *testing.T) {
 	db, _ := dbtestutil.NewDB(t)
 
 	user := dbgen.User(t, db, database.User{})
+	org, err := db.GetDefaultOrganization(ctx)
+	require.NoError(t, err)
 
 	// Create chat providers (required FK for model configs).
 	anthropicProvider := dbgen.ChatProvider(t, db, database.ChatProvider{
@@ -1623,33 +1625,37 @@ func TestChatsTelemetry(t *testing.T) {
 
 	// Create a model config.
 	modelCfg := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-		AIProviderID: uuid.NullUUID{UUID: anthropicProvider.ID, Valid: true},
-		Model:        "claude-sonnet-4-20250514",
-		DisplayName:  "Claude Sonnet",
-		IsDefault:    true,
-		ContextLimit: 200000,
+		AIProviderID:   uuid.NullUUID{UUID: anthropicProvider.ID, Valid: true},
+		Model:          "claude-sonnet-4-20250514",
+		DisplayName:    "Claude Sonnet",
+		IsDefault:      true,
+		ContextLimit:   200000,
+		OrganizationID: org.ID,
 	})
 
 	// Create a second model config to test full dump.
 	modelCfg2 := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-		AIProviderID: uuid.NullUUID{UUID: openaiProvider.ID, Valid: true},
-		Model:        "gpt-4o",
-		DisplayName:  "GPT-4o",
+		AIProviderID:   uuid.NullUUID{UUID: openaiProvider.ID, Valid: true},
+		Model:          "gpt-4o",
+		DisplayName:    "GPT-4o",
+		OrganizationID: org.ID,
 	})
 
 	// Create a soft-deleted model config — should NOT appear in telemetry.
 	deletedCfg := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-		AIProviderID: uuid.NullUUID{UUID: anthropicProvider.ID, Valid: true},
-		Model:        "claude-deleted",
-		DisplayName:  "Deleted Model",
-		ContextLimit: 100000,
+		AIProviderID:   uuid.NullUUID{UUID: anthropicProvider.ID, Valid: true},
+		Model:          "claude-deleted",
+		DisplayName:    "Deleted Model",
+		ContextLimit:   100000,
+		OrganizationID: org.ID,
 	})
-	err := db.DeleteChatModelConfigByID(ctx, deletedCfg.ID)
+	err = db.DeleteChatModelConfigByID(ctx, database.DeleteChatModelConfigByIDParams{
+		ID:             deletedCfg.ID,
+		OrganizationID: deletedCfg.OrganizationID,
+	})
 	require.NoError(t, err)
 
 	// Create a root chat with a workspace.
-	org, err := db.GetDefaultOrganization(ctx)
-	require.NoError(t, err)
 	job := dbgen.ProvisionerJob(t, db, nil, database.ProvisionerJob{
 		OrganizationID: org.ID,
 		Type:           database.ProvisionerJobTypeTemplateVersionDryRun,
@@ -1966,11 +1972,12 @@ func TestChatDiffStatusSummaryTelemetry(t *testing.T) {
 	})
 
 	modelCfg := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-		AIProviderID: uuid.NullUUID{UUID: anthropicProvider.ID, Valid: true},
-		Model:        "claude-sonnet-4-20250514",
-		DisplayName:  "Claude Sonnet",
-		IsDefault:    true,
-		ContextLimit: 200000,
+		AIProviderID:   uuid.NullUUID{UUID: anthropicProvider.ID, Valid: true},
+		Model:          "claude-sonnet-4-20250514",
+		DisplayName:    "Claude Sonnet",
+		IsDefault:      true,
+		ContextLimit:   200000,
+		OrganizationID: org.ID,
 	})
 
 	// Helper to create a chat and upsert its diff status.
@@ -2361,20 +2368,25 @@ func TestCollectAgentsAdvisor(t *testing.T) {
 		require.NoError(t, err)
 		return string(raw)
 	}
+	organization := database.Organization{ID: uuid.New()}
 
 	t.Run("ReuseChatModel", func(t *testing.T) {
 		t.Parallel()
 
 		db := dbmock.NewMockStore(gomock.NewController(t))
-		db.EXPECT().GetChatAdvisorConfig(gomock.Any()).
+		db.EXPECT().GetOrganizations(gomock.Any(), database.GetOrganizationsParams{}).Return([]database.Organization{organization}, nil)
+		db.EXPECT().GetChatAdvisorConfigForOrganization(gomock.Any(), organization.ID).
 			Return(marshalConfig(t, codersdk.AdvisorConfig{}), nil)
 
 		payload := collect(t, telemetry.Options{Database: db, Logger: testutil.Logger(t)})
 		require.False(t, payload.Enabled)
-		require.Zero(t, payload.MaxUsesPerRun)
-		require.Zero(t, payload.MaxOutputTokens)
-		require.Equal(t, telemetry.AgentsExperimentAdvisorReuseChatModel, payload.Provider)
-		require.Equal(t, telemetry.AgentsExperimentAdvisorReuseChatModel, payload.Model)
+		require.Len(t, payload.Organizations, 1)
+		entry := payload.Organizations[0]
+		require.Equal(t, organization.ID, entry.OrganizationID)
+		require.Zero(t, entry.MaxUsesPerRun)
+		require.Zero(t, entry.MaxOutputTokens)
+		require.Equal(t, telemetry.AgentsExperimentAdvisorReuseChatModel, entry.Provider)
+		require.Equal(t, telemetry.AgentsExperimentAdvisorReuseChatModel, entry.Model)
 	})
 
 	t.Run("ModelOverride", func(t *testing.T) {
@@ -2383,13 +2395,20 @@ func TestCollectAgentsAdvisor(t *testing.T) {
 		modelID := uuid.New()
 		providerID := uuid.New()
 		db := dbmock.NewMockStore(gomock.NewController(t))
-		db.EXPECT().GetChatAdvisorConfig(gomock.Any()).Return(marshalConfig(t, codersdk.AdvisorConfig{
+		db.EXPECT().GetOrganizations(gomock.Any(), database.GetOrganizationsParams{}).Return([]database.Organization{organization}, nil)
+		db.EXPECT().GetChatAdvisorConfigForOrganization(gomock.Any(), organization.ID).Return(marshalConfig(t, codersdk.AdvisorConfig{
 			Enabled:         true,
 			MaxUsesPerRun:   7,
 			MaxOutputTokens: 2048,
 			ModelConfigID:   modelID,
 		}), nil)
-		db.EXPECT().GetEnabledChatModelConfigByID(gomock.Any(), modelID).Return(database.ChatModelConfig{
+		db.EXPECT().GetChatModelConfigByIDForAuthorization(gomock.Any(), modelID).Return(database.ChatModelConfig{
+			OrganizationID: organization.ID,
+		}, nil)
+		db.EXPECT().GetEnabledChatModelConfigByID(gomock.Any(), database.GetEnabledChatModelConfigByIDParams{
+			ID:             modelID,
+			OrganizationID: organization.ID,
+		}).Return(database.ChatModelConfig{
 			Model:        "gpt-6-preview",
 			AIProviderID: uuid.NullUUID{UUID: providerID, Valid: true},
 		}, nil)
@@ -2397,126 +2416,53 @@ func TestCollectAgentsAdvisor(t *testing.T) {
 			Type: database.AIProviderTypeOpenai,
 		}, nil)
 
-		payload := collect(t, telemetry.Options{Database: db, Logger: testutil.Logger(t)})
-		// Stored enabled is ignored; the chat-advisor experiment gates it.
-		require.False(t, payload.Enabled)
-		require.Equal(t, 7, payload.MaxUsesPerRun)
-		require.Equal(t, int64(2048), payload.MaxOutputTokens)
-		require.Equal(t, string(database.AIProviderTypeOpenai), payload.Provider)
-		require.Equal(t, "gpt-6-preview", payload.Model)
-	})
-
-	t.Run("ExperimentEnabled", func(t *testing.T) {
-		t.Parallel()
-
-		db := dbmock.NewMockStore(gomock.NewController(t))
-		db.EXPECT().GetChatAdvisorConfig(gomock.Any()).
-			Return(marshalConfig(t, codersdk.AdvisorConfig{}), nil)
-
 		payload := collect(t, telemetry.Options{
 			Database:    db,
 			Logger:      testutil.Logger(t),
 			Experiments: codersdk.Experiments{codersdk.ExperimentChatAdvisor},
 		})
 		require.True(t, payload.Enabled)
+		require.Len(t, payload.Organizations, 1)
+		entry := payload.Organizations[0]
+		require.Equal(t, 7, entry.MaxUsesPerRun)
+		require.Equal(t, int64(2048), entry.MaxOutputTokens)
+		require.Equal(t, string(database.AIProviderTypeOpenai), entry.Provider)
+		require.Equal(t, "gpt-6-preview", entry.Model)
 	})
 
-	t.Run("MalformedJSON", func(t *testing.T) {
+	t.Run("MalformedOrganizationConfig", func(t *testing.T) {
 		t.Parallel()
 
 		db := dbmock.NewMockStore(gomock.NewController(t))
-		db.EXPECT().GetChatAdvisorConfig(gomock.Any()).Return("not-json", nil)
+		db.EXPECT().GetOrganizations(gomock.Any(), database.GetOrganizationsParams{}).Return([]database.Organization{organization}, nil)
+		db.EXPECT().GetChatAdvisorConfigForOrganization(gomock.Any(), organization.ID).Return("not-json", nil)
 
 		payload := collect(t, telemetry.Options{Database: db, Logger: testutil.Logger(t)})
-		require.Equal(t, telemetry.AgentsExperimentUnknown, payload.Provider)
-		require.Equal(t, telemetry.AgentsExperimentUnknown, payload.Model)
+		require.Len(t, payload.Organizations, 1)
+		require.Equal(t, telemetry.AgentsExperimentUnknown, payload.Organizations[0].Provider)
+		require.Equal(t, telemetry.AgentsExperimentUnknown, payload.Organizations[0].Model)
 	})
 
-	t.Run("PartialParse", func(t *testing.T) {
+	t.Run("OrganizationConfigFetchError", func(t *testing.T) {
 		t.Parallel()
 
 		db := dbmock.NewMockStore(gomock.NewController(t))
-		db.EXPECT().GetChatAdvisorConfig(gomock.Any()).
-			Return(`{"max_uses_per_run": 42, "model_config_id": "not-a-uuid"}`, nil)
+		db.EXPECT().GetOrganizations(gomock.Any(), database.GetOrganizationsParams{}).Return([]database.Organization{organization}, nil)
+		db.EXPECT().GetChatAdvisorConfigForOrganization(gomock.Any(), organization.ID).Return("", sql.ErrConnDone)
 
 		payload := collect(t, telemetry.Options{Database: db, Logger: testutil.Logger(t)})
-		require.Zero(t, payload.MaxUsesPerRun)
-		require.Zero(t, payload.MaxOutputTokens)
-		require.Equal(t, telemetry.AgentsExperimentUnknown, payload.Provider)
-		require.Equal(t, telemetry.AgentsExperimentUnknown, payload.Model)
+		require.Len(t, payload.Organizations, 1)
+		require.Equal(t, telemetry.AgentsExperimentUnknown, payload.Organizations[0].Provider)
+		require.Equal(t, telemetry.AgentsExperimentUnknown, payload.Organizations[0].Model)
 	})
 
-	t.Run("ClampsNegativeLimits", func(t *testing.T) {
+	t.Run("OrganizationListError", func(t *testing.T) {
 		t.Parallel()
 
 		db := dbmock.NewMockStore(gomock.NewController(t))
-		db.EXPECT().GetChatAdvisorConfig(gomock.Any()).
-			Return(`{"max_uses_per_run": -3, "max_output_tokens": -99}`, nil)
+		db.EXPECT().GetOrganizations(gomock.Any(), database.GetOrganizationsParams{}).Return(nil, sql.ErrConnDone)
 
 		payload := collect(t, telemetry.Options{Database: db, Logger: testutil.Logger(t)})
-		require.Zero(t, payload.MaxUsesPerRun)
-		require.Zero(t, payload.MaxOutputTokens)
-	})
-
-	t.Run("InactiveModelConfig", func(t *testing.T) {
-		t.Parallel()
-
-		modelID := uuid.New()
-		db := dbmock.NewMockStore(gomock.NewController(t))
-		db.EXPECT().GetChatAdvisorConfig(gomock.Any()).
-			Return(marshalConfig(t, codersdk.AdvisorConfig{ModelConfigID: modelID}), nil)
-		db.EXPECT().GetEnabledChatModelConfigByID(gomock.Any(), modelID).
-			Return(database.ChatModelConfig{}, sql.ErrNoRows)
-
-		payload := collect(t, telemetry.Options{Database: db, Logger: testutil.Logger(t)})
-		require.Equal(t, telemetry.AgentsExperimentAdvisorReuseChatModel, payload.Provider)
-		require.Equal(t, telemetry.AgentsExperimentAdvisorReuseChatModel, payload.Model)
-	})
-
-	t.Run("ConfigFetchError", func(t *testing.T) {
-		t.Parallel()
-
-		db := dbmock.NewMockStore(gomock.NewController(t))
-		db.EXPECT().GetChatAdvisorConfig(gomock.Any()).Return("", sql.ErrConnDone)
-
-		payload := collect(t, telemetry.Options{Database: db, Logger: testutil.Logger(t)})
-		require.Equal(t, telemetry.AgentsExperimentUnknown, payload.Provider)
-		require.Equal(t, telemetry.AgentsExperimentUnknown, payload.Model)
-	})
-
-	t.Run("ModelResolveError", func(t *testing.T) {
-		t.Parallel()
-
-		modelID := uuid.New()
-		db := dbmock.NewMockStore(gomock.NewController(t))
-		db.EXPECT().GetChatAdvisorConfig(gomock.Any()).
-			Return(marshalConfig(t, codersdk.AdvisorConfig{ModelConfigID: modelID}), nil)
-		db.EXPECT().GetEnabledChatModelConfigByID(gomock.Any(), modelID).
-			Return(database.ChatModelConfig{}, sql.ErrConnDone)
-
-		payload := collect(t, telemetry.Options{Database: db, Logger: testutil.Logger(t)})
-		require.Equal(t, telemetry.AgentsExperimentUnknown, payload.Provider)
-		require.Equal(t, telemetry.AgentsExperimentUnknown, payload.Model)
-	})
-
-	t.Run("ProviderResolveError", func(t *testing.T) {
-		t.Parallel()
-
-		modelID := uuid.New()
-		providerID := uuid.New()
-		db := dbmock.NewMockStore(gomock.NewController(t))
-		db.EXPECT().GetChatAdvisorConfig(gomock.Any()).
-			Return(marshalConfig(t, codersdk.AdvisorConfig{ModelConfigID: modelID}), nil)
-		db.EXPECT().GetEnabledChatModelConfigByID(gomock.Any(), modelID).Return(database.ChatModelConfig{
-			Model:        "gpt-6-preview",
-			AIProviderID: uuid.NullUUID{UUID: providerID, Valid: true},
-		}, nil)
-		db.EXPECT().GetAIProviderByID(gomock.Any(), providerID).
-			Return(database.AIProvider{}, sql.ErrConnDone)
-
-		payload := collect(t, telemetry.Options{Database: db, Logger: testutil.Logger(t)})
-		// The provider is unknown, but the already-resolved model still ships.
-		require.Equal(t, telemetry.AgentsExperimentUnknown, payload.Provider)
-		require.Equal(t, "gpt-6-preview", payload.Model)
+		require.Empty(t, payload.Organizations)
 	})
 }

--- a/coderd/x/chatd/ARCHITECTURE.md
+++ b/coderd/x/chatd/ARCHITECTURE.md
@@ -855,7 +855,7 @@ During generation preparation, the effective effort is resolved as the chat's `l
 
 Compaction is an auxiliary LLM call: when the conversation approaches the context limit, the generation goroutine asks a model to summarize the history, commits the summary as a compressed boundary, and continues the turn on the chat model.
 
-By default the summary is generated with the chat model. Admins can override the compaction model deployment-wide via the `compaction` context of the chat model override API (`/api/experimental/chats/config/model-override/{context}`, stored in the `agents_chat_compaction_model_override` site config). The override affects only the summary call; thresholds, compressed-message storage, and the post-compaction assistant generation keep using the chat model.
+By default the summary is generated with the chat model. Admins can override the compaction model for an organization via the `compaction` context of the organization chat model override API. The override affects only the summary call; thresholds, compressed-message storage, and the post-compaction assistant generation keep using the chat model.
 
 Details that follow from the override:
 

--- a/coderd/x/chatd/advisor_internal_test.go
+++ b/coderd/x/chatd/advisor_internal_test.go
@@ -33,7 +33,7 @@ import (
 type advisorOverrideStubStore struct {
 	database.Store
 
-	getEnabledChatModelConfigByID  func(context.Context, uuid.UUID) (database.ChatModelConfig, error)
+	getEnabledChatModelConfigByID  func(context.Context, database.GetEnabledChatModelConfigByIDParams) (database.ChatModelConfig, error)
 	getAIProviderByID              func(context.Context, uuid.UUID) (database.AIProvider, error)
 	getAIProviders                 func(context.Context, database.GetAIProvidersParams) ([]database.AIProvider, error)
 	getAIProviderKeysByProviderID  func(context.Context, uuid.UUID) ([]database.AIProviderKey, error)
@@ -42,12 +42,12 @@ type advisorOverrideStubStore struct {
 
 func (s *advisorOverrideStubStore) GetEnabledChatModelConfigByID(
 	ctx context.Context,
-	id uuid.UUID,
+	arg database.GetEnabledChatModelConfigByIDParams,
 ) (database.ChatModelConfig, error) {
 	if s.getEnabledChatModelConfigByID == nil {
 		return database.ChatModelConfig{}, xerrors.New("unexpected GetEnabledChatModelConfigByID call")
 	}
-	return s.getEnabledChatModelConfigByID(ctx, id)
+	return s.getEnabledChatModelConfigByID(ctx, arg)
 }
 
 func (s *advisorOverrideStubStore) GetAIProviderByID(
@@ -187,7 +187,7 @@ func TestResolveAdvisorModelOverride(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitShort)
 		store := &advisorOverrideStubStore{
-			getEnabledChatModelConfigByID: func(context.Context, uuid.UUID) (database.ChatModelConfig, error) {
+			getEnabledChatModelConfigByID: func(context.Context, database.GetEnabledChatModelConfigByIDParams) (database.ChatModelConfig, error) {
 				return database.ChatModelConfig{}, xerrors.New("lookup failed")
 			},
 		}
@@ -216,7 +216,7 @@ func TestResolveAdvisorModelOverride(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitShort)
 		store := &advisorOverrideStubStore{
-			getEnabledChatModelConfigByID: func(context.Context, uuid.UUID) (database.ChatModelConfig, error) {
+			getEnabledChatModelConfigByID: func(context.Context, database.GetEnabledChatModelConfigByIDParams) (database.ChatModelConfig, error) {
 				return database.ChatModelConfig{}, sql.ErrNoRows
 			},
 		}
@@ -240,7 +240,7 @@ func TestResolveAdvisorModelOverride(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitShort)
 		configID := uuid.New()
 		store := &advisorOverrideStubStore{
-			getEnabledChatModelConfigByID: func(context.Context, uuid.UUID) (database.ChatModelConfig, error) {
+			getEnabledChatModelConfigByID: func(context.Context, database.GetEnabledChatModelConfigByIDParams) (database.ChatModelConfig, error) {
 				return database.ChatModelConfig{
 					ID:          configID,
 					Model:       "gpt-5.2",
@@ -273,7 +273,7 @@ func TestResolveAdvisorModelOverride(t *testing.T) {
 		configID := uuid.New()
 		providerID := uuid.New()
 		store := &advisorOverrideStubStore{
-			getEnabledChatModelConfigByID: func(context.Context, uuid.UUID) (database.ChatModelConfig, error) {
+			getEnabledChatModelConfigByID: func(context.Context, database.GetEnabledChatModelConfigByIDParams) (database.ChatModelConfig, error) {
 				return database.ChatModelConfig{
 					ID:          configID,
 					Model:       "gpt-5.2",
@@ -323,7 +323,7 @@ func TestResolveAdvisorModelOverride(t *testing.T) {
 		})
 		require.NoError(t, err)
 		store := &advisorOverrideStubStore{
-			getEnabledChatModelConfigByID: func(context.Context, uuid.UUID) (database.ChatModelConfig, error) {
+			getEnabledChatModelConfigByID: func(context.Context, database.GetEnabledChatModelConfigByIDParams) (database.ChatModelConfig, error) {
 				return database.ChatModelConfig{
 					ID:           configID,
 					Model:        "gpt-5.2",
@@ -376,7 +376,7 @@ func TestResolveAdvisorModelOverride(t *testing.T) {
 		configID := uuid.New()
 		providerID := uuid.New()
 		store := &advisorOverrideStubStore{
-			getEnabledChatModelConfigByID: func(context.Context, uuid.UUID) (database.ChatModelConfig, error) {
+			getEnabledChatModelConfigByID: func(context.Context, database.GetEnabledChatModelConfigByIDParams) (database.ChatModelConfig, error) {
 				return database.ChatModelConfig{
 					ID:           configID,
 					Model:        "gpt-5.2",
@@ -426,7 +426,7 @@ func TestResolveAdvisorModelOverridePromotesAIBridgeErrors(t *testing.T) {
 	configID := uuid.New()
 	providerID := uuid.New()
 	store := &advisorOverrideStubStore{
-		getEnabledChatModelConfigByID: func(context.Context, uuid.UUID) (database.ChatModelConfig, error) {
+		getEnabledChatModelConfigByID: func(context.Context, database.GetEnabledChatModelConfigByIDParams) (database.ChatModelConfig, error) {
 			return database.ChatModelConfig{
 				ID:           configID,
 				Model:        "gpt-5.2",

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -235,8 +235,8 @@ func (p *Server) chatTemplateAllowlist() map[uuid.UUID]bool {
 	return m
 }
 
-func (p *Server) loadAdvisorConfig(ctx context.Context, logger slog.Logger) codersdk.AdvisorConfig {
-	cfg, err := p.configCache.AdvisorConfig(ctx)
+func (p *Server) loadAdvisorConfig(ctx context.Context, organizationID uuid.UUID, logger slog.Logger) codersdk.AdvisorConfig {
+	cfg, err := p.configCache.AdvisorConfig(ctx, organizationID)
 	if err != nil {
 		logger.Warn(ctx, "failed to load advisor config", slog.Error(err))
 		return codersdk.AdvisorConfig{}
@@ -285,10 +285,10 @@ func (p *Server) resolveAdvisorModelOverride(
 
 	// Re-read the override instead of using the cache so disabled models
 	// or providers stop routing advisor prompts immediately.
-	overrideConfig, err := p.db.GetEnabledChatModelConfigByID(
-		ctx,
-		advisorCfg.ModelConfigID,
-	)
+	overrideConfig, err := p.db.GetEnabledChatModelConfigByID(ctx, database.GetEnabledChatModelConfigByIDParams{
+		OrganizationID: chat.OrganizationID,
+		ID:             advisorCfg.ModelConfigID,
+	})
 	if err != nil {
 		if xerrors.Is(err, sql.ErrNoRows) {
 			logger.Warn(
@@ -1290,12 +1290,6 @@ func (p *Server) CreateChat(ctx context.Context, opts CreateOptions) (database.C
 		return database.Chat{}, limitErr
 	}
 
-	if opts.ModelConfigID != uuid.Nil {
-		if err := requireEnabledChatModelConfig(ctx, p.db, opts.ModelConfigID); err != nil {
-			return database.Chat{}, err
-		}
-	}
-
 	labelsJSON, err := json.Marshal(opts.Labels)
 	if err != nil {
 		return database.Chat{}, xerrors.Errorf("marshal labels: %w", err)
@@ -1338,6 +1332,12 @@ func (p *Server) CreateChat(ctx context.Context, opts CreateOptions) (database.C
 	}
 	initialMessages = append(initialMessages, systemMessage(workspaceAwarenessContent, opts.ModelConfigID))
 	initialMessages = append(initialMessages, userMessage(userContent, opts.ModelConfigID, opts.OwnerID, opts.ReasoningEffort))
+
+	if opts.ModelConfigID != uuid.Nil {
+		if err := requireEnabledChatModelConfig(ctx, p.db, opts.OrganizationID, opts.ModelConfigID); err != nil {
+			return database.Chat{}, err
+		}
+	}
 
 	result, err := chatstate.CreateChat(ctx, p.db, p.pubsub, chatstate.CreateChatInput{
 		OrganizationID:    opts.OrganizationID,
@@ -1556,10 +1556,10 @@ func resolveSendMessageModelConfigID(
 	requested uuid.UUID,
 ) (uuid.UUID, error) {
 	if requested == uuid.Nil {
-		return resolveFallbackModelConfigID(ctx, store, chat.LastModelConfigID)
+		return resolveFallbackModelConfigID(ctx, store, chat.OrganizationID, chat.LastModelConfigID)
 	}
 
-	if err := requireEnabledChatModelConfig(ctx, store, requested); err != nil {
+	if err := requireEnabledChatModelConfig(ctx, store, chat.OrganizationID, requested); err != nil {
 		return uuid.Nil, err
 	}
 	return requested, nil
@@ -1570,10 +1570,11 @@ func resolveSendMessageModelConfigID(
 func requireEnabledChatModelConfig(
 	ctx context.Context,
 	store database.Store,
+	organizationID uuid.UUID,
 	modelConfigID uuid.UUID,
 ) error {
 	chatdCtx := chatdModelConfigLookupContext(ctx)
-	if _, err := store.GetEnabledChatModelConfigByID(chatdCtx, modelConfigID); err != nil {
+	if _, err := store.GetEnabledChatModelConfigByID(chatdCtx, database.GetEnabledChatModelConfigByIDParams{OrganizationID: organizationID, ID: modelConfigID}); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return xerrors.Errorf(
 				"%w: %s",
@@ -1593,11 +1594,12 @@ func requireEnabledChatModelConfig(
 func resolveFallbackModelConfigID(
 	ctx context.Context,
 	store database.Store,
+	organizationID uuid.UUID,
 	modelConfigID uuid.UUID,
 ) (uuid.UUID, error) {
 	chatdCtx := chatdModelConfigLookupContext(ctx)
 	if modelConfigID != uuid.Nil {
-		if _, err := store.GetEnabledChatModelConfigByID(chatdCtx, modelConfigID); err == nil {
+		if _, err := store.GetEnabledChatModelConfigByID(chatdCtx, database.GetEnabledChatModelConfigByIDParams{OrganizationID: organizationID, ID: modelConfigID}); err == nil {
 			return modelConfigID, nil
 		} else if !errors.Is(err, sql.ErrNoRows) {
 			return uuid.Nil, xerrors.Errorf(
@@ -1608,7 +1610,7 @@ func resolveFallbackModelConfigID(
 		}
 	}
 
-	defaultConfig, err := store.GetDefaultChatModelConfig(chatdCtx)
+	defaultConfig, err := store.GetDefaultChatModelConfig(chatdCtx, organizationID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return uuid.Nil, ErrNoDefaultChatModelConfig
@@ -1616,7 +1618,7 @@ func resolveFallbackModelConfigID(
 		return uuid.Nil, xerrors.Errorf("get default chat model config: %w", err)
 	}
 	// The default may itself be disabled or under a disabled provider.
-	if _, err := store.GetEnabledChatModelConfigByID(chatdCtx, defaultConfig.ID); err != nil {
+	if _, err := store.GetEnabledChatModelConfigByID(chatdCtx, database.GetEnabledChatModelConfigByIDParams{OrganizationID: organizationID, ID: defaultConfig.ID}); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return uuid.Nil, xerrors.Errorf(
 				"%w: default model config %s or its provider is disabled",
@@ -1655,6 +1657,7 @@ func (p *Server) EditMessage(
 	if err != nil {
 		return EditMessageResult{}, xerrors.Errorf("marshal message content: %w", err)
 	}
+
 	var (
 		result        EditMessageResult
 		editedMsg     database.ChatMessage
@@ -1693,7 +1696,7 @@ func (p *Server) EditMessage(
 		// foreign-key error from the message-insert path.
 		var modelOverride uuid.NullUUID
 		if opts.ModelConfigID != uuid.Nil {
-			if err := requireEnabledChatModelConfig(ctx, store, opts.ModelConfigID); err != nil {
+			if err := requireEnabledChatModelConfig(ctx, store, lockedChat.OrganizationID, opts.ModelConfigID); err != nil {
 				return err
 			}
 			modelOverride = uuid.NullUUID{UUID: opts.ModelConfigID, Valid: true}
@@ -1705,7 +1708,7 @@ func (p *Server) EditMessage(
 			if target.ModelConfigID.Valid {
 				preserved = target.ModelConfigID.UUID
 			}
-			resolved, err := resolveFallbackModelConfigID(ctx, store, preserved)
+			resolved, err := resolveFallbackModelConfigID(ctx, store, lockedChat.OrganizationID, preserved)
 			if err != nil {
 				return err
 			}
@@ -2651,7 +2654,7 @@ func (p *Server) resolveManualTitleModel(
 		return overrideModel, overrideConfig, nil
 	}
 
-	configs, err := store.GetEnabledChatModelConfigs(ctx)
+	configs, err := store.GetEnabledChatModelConfigs(ctx, chat.OrganizationID)
 	if err != nil {
 		p.logger.Debug(ctx, "failed to list manual title model configs",
 			slog.F("chat_id", chat.ID),
@@ -3056,11 +3059,11 @@ func New(ps pubsub.Pubsub, cfg Config) *Server {
 			}
 			switch ev.Kind {
 			case coderdpubsub.ChatConfigEventModelConfig:
-				p.configCache.InvalidateModelConfig(ev.EntityID)
+				p.configCache.InvalidateModelConfig(ev.EntityID, ev.OrganizationID)
 			case coderdpubsub.ChatConfigEventUserPrompt:
 				p.configCache.InvalidateUserPrompt(ev.EntityID)
 			case coderdpubsub.ChatConfigEventAdvisorConfig:
-				p.configCache.InvalidateAdvisorConfig()
+				p.configCache.InvalidateAdvisorConfig(ev.OrganizationID)
 			}
 		}),
 	)
@@ -4149,7 +4152,7 @@ func (p *Server) resolveModelConfig(
 ) (database.ChatModelConfig, error) {
 	if chat.LastModelConfigID != uuid.Nil {
 		modelConfig, err := p.configCache.ModelConfigByID(
-			ctx, chat.LastModelConfigID,
+			ctx, chat.OrganizationID, chat.LastModelConfigID,
 		)
 		if err == nil {
 			return modelConfig, nil
@@ -4163,7 +4166,7 @@ func (p *Server) resolveModelConfig(
 		// Model config was deleted, fall through to default.
 	}
 
-	defaultConfig, err := p.configCache.DefaultModelConfig(ctx)
+	defaultConfig, err := p.configCache.DefaultModelConfig(ctx, chat.OrganizationID)
 	if err != nil {
 		if xerrors.Is(err, sql.ErrNoRows) {
 			return database.ChatModelConfig{}, ErrNoDefaultChatModelConfig
@@ -4195,11 +4198,14 @@ func refreshChatWorkspaceSnapshot(
 // resolveUserCompactionThreshold looks up the user's per-model
 // compaction threshold override. Returns the override value and
 // true if one exists and is valid, or 0 and false otherwise.
-func (p *Server) resolveUserCompactionThreshold(ctx context.Context, userID uuid.UUID, modelConfigID uuid.UUID) (int32, bool) {
-	raw, err := p.db.GetUserChatCompactionThreshold(ctx, database.GetUserChatCompactionThresholdParams{
-		UserID: userID,
-		Key:    codersdk.CompactionThresholdKey(modelConfigID),
-	})
+func (p *Server) resolveUserCompactionThreshold(ctx context.Context, userID, organizationID uuid.UUID, modelConfigID uuid.UUID) (int32, bool) {
+	raw, err := getUserChatCompactionThresholdForOrganization(
+		ctx,
+		p.db,
+		userID,
+		organizationID,
+		modelConfigID,
+	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return 0, false
 	}

--- a/coderd/x/chatd/chatd_helpers_test.go
+++ b/coderd/x/chatd/chatd_helpers_test.go
@@ -64,9 +64,10 @@ func seedAnthropicChatDependencies(t *testing.T, db database.Store, baseURL stri
 	})
 	dbgen.AIProviderKey(t, db, database.AIProviderKey{ProviderID: provider.ID})
 	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-		Model:        "claude-sonnet-4-20250514",
-		IsDefault:    true,
-		AIProviderID: uuid.NullUUID{UUID: provider.ID, Valid: true},
+		OrganizationID: org.ID,
+		Model:          "claude-sonnet-4-20250514",
+		IsDefault:      true,
+		AIProviderID:   uuid.NullUUID{UUID: provider.ID, Valid: true},
 	})
 	return user, org, model
 }

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -836,7 +836,7 @@ func TestRegenerateChatTitle_PersistsAndBroadcasts(t *testing.T) {
 		aibridgeTransportFactory: aibridgeTestFactoryPointer(factory),
 	}
 
-	db.EXPECT().GetChatModelConfigByID(gomock.Any(), modelConfigID).Return(modelConfig, nil)
+	db.EXPECT().GetChatModelConfigByID(gomock.Any(), gomock.Any()).Return(modelConfig, nil)
 	db.EXPECT().GetAIProviderByID(gomock.Any(), providerID).Return(database.AIProvider{
 		ID:      providerID,
 		Name:    "primary-openai",
@@ -883,8 +883,8 @@ func TestRegenerateChatTitle_PersistsAndBroadcasts(t *testing.T) {
 			LimitVal: manualTitleMessageWindowLimit,
 		},
 	).Return(nil, nil)
-	db.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return("", nil)
-	db.EXPECT().GetEnabledChatModelConfigs(gomock.Any()).Return(nil, nil)
+	db.EXPECT().GetChatTitleGenerationModelOverrideForOrganization(gomock.Any(), chat.OrganizationID).Return("", nil)
+	db.EXPECT().GetEnabledChatModelConfigs(gomock.Any(), gomock.Any()).Return(nil, nil)
 
 	db.EXPECT().InTx(gomock.Any(), nil).DoAndReturn(
 		func(fn func(database.Store) error, opts *database.TxOptions) error {
@@ -989,7 +989,7 @@ func TestRegenerateChatTitle_SkipsPersistWhenTitleChangedConcurrently(t *testing
 		aibridgeTransportFactory: aibridgeTestFactoryPointer(factory),
 	}
 
-	db.EXPECT().GetChatModelConfigByID(gomock.Any(), modelConfigID).Return(modelConfig, nil)
+	db.EXPECT().GetChatModelConfigByID(gomock.Any(), gomock.Any()).Return(modelConfig, nil)
 	db.EXPECT().GetAIProviderByID(gomock.Any(), providerID).Return(database.AIProvider{
 		ID:      providerID,
 		Name:    "primary-openai",
@@ -1029,8 +1029,8 @@ func TestRegenerateChatTitle_SkipsPersistWhenTitleChangedConcurrently(t *testing
 			LimitVal: manualTitleMessageWindowLimit,
 		},
 	).Return(nil, nil)
-	db.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return("", nil)
-	db.EXPECT().GetEnabledChatModelConfigs(gomock.Any()).Return(nil, nil)
+	db.EXPECT().GetChatTitleGenerationModelOverrideForOrganization(gomock.Any(), chat.OrganizationID).Return("", nil)
+	db.EXPECT().GetEnabledChatModelConfigs(gomock.Any(), gomock.Any()).Return(nil, nil)
 
 	db.EXPECT().InTx(gomock.Any(), nil).DoAndReturn(
 		func(fn func(database.Store) error, _ *database.TxOptions) error {
@@ -1730,7 +1730,7 @@ func TestResolveUserCompactionThreshold(t *testing.T) {
 
 	userID := uuid.New()
 	modelConfigID := uuid.New()
-	expectedKey := codersdk.CompactionThresholdKey(modelConfigID)
+	organizationID := uuid.New()
 
 	tests := []struct {
 		name        string
@@ -1783,12 +1783,13 @@ func TestResolveUserCompactionThreshold(t *testing.T) {
 				logger: sink.Logger(),
 			}
 
-			mockDB.EXPECT().GetUserChatCompactionThreshold(gomock.Any(), database.GetUserChatCompactionThresholdParams{
-				UserID: userID,
-				Key:    expectedKey,
+			mockDB.EXPECT().GetUserChatCompactionThresholdForOrganization(gomock.Any(), database.GetUserChatCompactionThresholdForOrganizationParams{
+				UserID:         userID,
+				OrganizationID: organizationID,
+				ModelConfigID:  modelConfigID,
 			}).Return(tc.dbReturn, tc.dbErr)
 
-			val, ok := srv.resolveUserCompactionThreshold(context.Background(), userID, modelConfigID)
+			val, ok := srv.resolveUserCompactionThreshold(context.Background(), userID, organizationID, modelConfigID)
 			require.Equal(t, tc.wantVal, val)
 			require.Equal(t, tc.wantOK, ok)
 
@@ -3255,7 +3256,7 @@ func TestGetWorkspaceConnBumpsWorkspaceUsage(t *testing.T) {
 
 	user := dbgen.User(t, db, database.User{})
 	org := dbgen.Organization(t, db, database.Organization{})
-	modelConfig := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{})
+	modelConfig := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{OrganizationID: org.ID})
 
 	// Create a workspace with a full build chain so we can verify
 	// both last_used_at (dormancy) and deadline (autostop) bumps.
@@ -3491,10 +3492,11 @@ func TestResolveFallbackModelConfigID(t *testing.T) {
 			p.Enabled = enabled
 		})
 	}
-	newModelConfig := func(t *testing.T, db database.Store, providerID uuid.UUID, isDefault bool) database.ChatModelConfig {
+	newModelConfig := func(t *testing.T, db database.Store, organizationID, providerID uuid.UUID, isDefault bool) database.ChatModelConfig {
 		return dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-			AIProviderID: uuid.NullUUID{UUID: providerID, Valid: true},
-			IsDefault:    isDefault,
+			OrganizationID: organizationID,
+			AIProviderID:   uuid.NullUUID{UUID: providerID, Valid: true},
+			IsDefault:      isDefault,
 		})
 	}
 
@@ -3502,11 +3504,12 @@ func TestResolveFallbackModelConfigID(t *testing.T) {
 		t.Parallel()
 		db, _ := dbtestutil.NewDB(t)
 		ctx := testutil.Context(t, testutil.WaitShort)
+		organization := dbgen.Organization(t, db, database.Organization{})
 
 		provider := newProvider(t, db, true)
-		lastModel := newModelConfig(t, db, provider.ID, false)
+		lastModel := newModelConfig(t, db, organization.ID, provider.ID, false)
 
-		resolved, err := resolveFallbackModelConfigID(ctx, db, lastModel.ID)
+		resolved, err := resolveFallbackModelConfigID(ctx, db, organization.ID, lastModel.ID)
 		require.NoError(t, err)
 		require.Equal(t, lastModel.ID, resolved)
 	})
@@ -3515,13 +3518,14 @@ func TestResolveFallbackModelConfigID(t *testing.T) {
 		t.Parallel()
 		db, _ := dbtestutil.NewDB(t)
 		ctx := testutil.Context(t, testutil.WaitShort)
+		organization := dbgen.Organization(t, db, database.Organization{})
 
 		disabledProvider := newProvider(t, db, false)
-		lastModel := newModelConfig(t, db, disabledProvider.ID, false)
+		lastModel := newModelConfig(t, db, organization.ID, disabledProvider.ID, false)
 		enabledProvider := newProvider(t, db, true)
-		defaultModel := newModelConfig(t, db, enabledProvider.ID, true)
+		defaultModel := newModelConfig(t, db, organization.ID, enabledProvider.ID, true)
 
-		resolved, err := resolveFallbackModelConfigID(ctx, db, lastModel.ID)
+		resolved, err := resolveFallbackModelConfigID(ctx, db, organization.ID, lastModel.ID)
 		require.NoError(t, err)
 		require.Equal(t, defaultModel.ID, resolved)
 	})
@@ -3530,11 +3534,12 @@ func TestResolveFallbackModelConfigID(t *testing.T) {
 		t.Parallel()
 		db, _ := dbtestutil.NewDB(t)
 		ctx := testutil.Context(t, testutil.WaitShort)
+		organization := dbgen.Organization(t, db, database.Organization{})
 
 		provider := newProvider(t, db, true)
-		defaultModel := newModelConfig(t, db, provider.ID, true)
+		defaultModel := newModelConfig(t, db, organization.ID, provider.ID, true)
 
-		resolved, err := resolveFallbackModelConfigID(ctx, db, uuid.Nil)
+		resolved, err := resolveFallbackModelConfigID(ctx, db, organization.ID, uuid.Nil)
 		require.NoError(t, err)
 		require.Equal(t, defaultModel.ID, resolved)
 	})
@@ -3543,12 +3548,13 @@ func TestResolveFallbackModelConfigID(t *testing.T) {
 		t.Parallel()
 		db, _ := dbtestutil.NewDB(t)
 		ctx := testutil.Context(t, testutil.WaitShort)
+		organization := dbgen.Organization(t, db, database.Organization{})
 
 		disabledProvider := newProvider(t, db, false)
-		lastModel := newModelConfig(t, db, disabledProvider.ID, false)
-		newModelConfig(t, db, disabledProvider.ID, true)
+		lastModel := newModelConfig(t, db, organization.ID, disabledProvider.ID, false)
+		newModelConfig(t, db, organization.ID, disabledProvider.ID, true)
 
-		_, err := resolveFallbackModelConfigID(ctx, db, lastModel.ID)
+		_, err := resolveFallbackModelConfigID(ctx, db, organization.ID, lastModel.ID)
 		require.ErrorIs(t, err, ErrNoDefaultChatModelConfig)
 	})
 
@@ -3556,11 +3562,12 @@ func TestResolveFallbackModelConfigID(t *testing.T) {
 		t.Parallel()
 		db, _ := dbtestutil.NewDB(t)
 		ctx := testutil.Context(t, testutil.WaitShort)
+		organization := dbgen.Organization(t, db, database.Organization{})
 
 		provider := newProvider(t, db, true)
-		model := newModelConfig(t, db, provider.ID, false)
+		model := newModelConfig(t, db, organization.ID, provider.ID, false)
 
-		resolved, err := resolveSendMessageModelConfigID(ctx, db, database.Chat{}, model.ID)
+		resolved, err := resolveSendMessageModelConfigID(ctx, db, database.Chat{OrganizationID: organization.ID}, model.ID)
 		require.NoError(t, err)
 		require.Equal(t, model.ID, resolved)
 	})
@@ -3571,11 +3578,12 @@ func TestResolveFallbackModelConfigID(t *testing.T) {
 		t.Parallel()
 		db, _ := dbtestutil.NewDB(t)
 		ctx := testutil.Context(t, testutil.WaitShort)
+		organization := dbgen.Organization(t, db, database.Organization{})
 
 		disabledProvider := newProvider(t, db, false)
-		model := newModelConfig(t, db, disabledProvider.ID, false)
+		model := newModelConfig(t, db, organization.ID, disabledProvider.ID, false)
 
-		_, err := resolveSendMessageModelConfigID(ctx, db, database.Chat{}, model.ID)
+		_, err := resolveSendMessageModelConfigID(ctx, db, database.Chat{OrganizationID: organization.ID}, model.ID)
 		require.ErrorIs(t, err, ErrInvalidModelConfigID)
 	})
 
@@ -3585,14 +3593,15 @@ func TestResolveFallbackModelConfigID(t *testing.T) {
 		t.Parallel()
 		db, ps := dbtestutil.NewDB(t)
 		ctx := testutil.Context(t, testutil.WaitShort)
+		organization := dbgen.Organization(t, db, database.Organization{})
 
 		owner := dbgen.User(t, db, database.User{})
 		disabledProvider := newProvider(t, db, false)
-		model := newModelConfig(t, db, disabledProvider.ID, false)
+		model := newModelConfig(t, db, organization.ID, disabledProvider.ID, false)
 		server := newInternalTestServer(t, db, ps, chatprovider.ProviderAPIKeys{})
 
 		_, err := server.CreateChat(ctx, CreateOptions{
-			OrganizationID: uuid.New(),
+			OrganizationID: organization.ID,
 			OwnerID:        owner.ID,
 			Title:          "provider disabled create",
 			ModelConfigID:  model.ID,

--- a/coderd/x/chatd/chatd_retry_test.go
+++ b/coderd/x/chatd/chatd_retry_test.go
@@ -104,10 +104,11 @@ func TestActiveServer_RetryStreamSilenceTimeoutAndClassification(t *testing.T) {
 		})
 		user, org, _ := seedChatDependenciesWithProvider(t, db, "openai", openAIURL)
 		model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-			Model:     "gpt-4o",
-			Enabled:   true,
-			CreatedBy: uuid.NullUUID{UUID: user.ID, Valid: true},
-			UpdatedBy: uuid.NullUUID{UUID: user.ID, Valid: true},
+			OrganizationID: org.ID,
+			Model:          "gpt-4o",
+			Enabled:        true,
+			CreatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
+			UpdatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
 		})
 		factory := chattest.NewMockAIBridgeTransport(t, openAIURL)
 		server := newActiveTestServer(t, db, ps, func(cfg *chatd.Config) {

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -722,6 +722,7 @@ func TestExploreChatUsesPersistedMCPSnapshot(t *testing.T) {
 	webSearchModel := insertChatModelConfigWithCallConfig(
 		t,
 		db,
+		org.ID,
 		user.ID,
 		"openai",
 		"gpt-4o",
@@ -962,6 +963,7 @@ func TestRootExploreChatExcludesWebSearchProviderToolAtRuntime(t *testing.T) {
 	webSearchModel := insertChatModelConfigWithCallConfig(
 		t,
 		db,
+		org.ID,
 		user.ID,
 		"openai",
 		"gpt-4o",
@@ -1979,6 +1981,7 @@ func TestAutoPromoteQueuedMessagesPreservesPerTurnModelOrder(t *testing.T) {
 	modelConfigB := insertChatModelConfigWithCallConfig(
 		t,
 		db,
+		org.ID,
 		user.ID,
 		"openai-compat",
 		"gpt-4o-mini-queue-b-"+uuid.NewString(),
@@ -1987,6 +1990,7 @@ func TestAutoPromoteQueuedMessagesPreservesPerTurnModelOrder(t *testing.T) {
 	modelConfigC := insertChatModelConfigWithCallConfig(
 		t,
 		db,
+		org.ID,
 		user.ID,
 		"openai-compat",
 		"gpt-4o-mini-queue-c-"+uuid.NewString(),
@@ -5976,9 +5980,10 @@ func TestActiveServer_CompactionModelOverride(t *testing.T) {
 	seedOverrideModel := func(ctx context.Context, t *testing.T, db database.Store, chatModel database.ChatModelConfig, modelName, effort string, contextLimit int64) database.ChatModelConfig {
 		t.Helper()
 		overrideModel := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-			Model:        modelName,
-			AIProviderID: chatModel.AIProviderID,
-			ContextLimit: contextLimit,
+			OrganizationID: chatModel.OrganizationID,
+			Model:          modelName,
+			AIProviderID:   chatModel.AIProviderID,
+			ContextLimit:   contextLimit,
 		})
 		overrideModel = updateChatModelCallConfig(t, db, overrideModel, codersdk.ChatModelCallConfig{
 			ReasoningEffort: &codersdk.ChatModelReasoningEffortConfig{
@@ -5986,7 +5991,10 @@ func TestActiveServer_CompactionModelOverride(t *testing.T) {
 				Max:     &effort,
 			},
 		})
-		require.NoError(t, db.UpsertChatCompactionModelOverride(ctx, overrideModel.ID.String()))
+		require.NoError(t, db.UpsertChatCompactionModelOverrideForOrganization(ctx, database.UpsertChatCompactionModelOverrideForOrganizationParams{
+			OrganizationID: chatModel.OrganizationID,
+			ModelConfigID:  overrideModel.ID.String(),
+		}))
 		return overrideModel
 	}
 
@@ -7745,7 +7753,7 @@ func TestActiveServer_ExclusiveToolPolicy(t *testing.T) {
 			return chattest.OpenAIStreamingResponse(chattest.OpenAITextChunks("done")...)
 		})
 		user, org, model := seedChatDependenciesWithProvider(t, db, "openai-compat", openAIURL)
-		seedAdvisorConfig(ctx, t, db, codersdk.AdvisorConfig{Enabled: true, MaxUsesPerRun: 3, MaxOutputTokens: 1024})
+		seedAdvisorConfig(ctx, t, db, org.ID, codersdk.AdvisorConfig{Enabled: true, MaxUsesPerRun: 3, MaxOutputTokens: 1024})
 		ws, dbAgent := seedWorkspaceWithAgent(t, db, user.ID)
 
 		ctrl := gomock.NewController(t)
@@ -7805,7 +7813,7 @@ func TestActiveServer_ExclusiveToolPolicy(t *testing.T) {
 			return chattest.OpenAIStreamingResponse(chattest.OpenAITextChunks("done")...)
 		})
 		user, org, model := seedChatDependenciesWithProvider(t, db, "openai-compat", openAIURL)
-		seedAdvisorConfig(ctx, t, db, codersdk.AdvisorConfig{Enabled: true, MaxUsesPerRun: 3, MaxOutputTokens: 1024})
+		seedAdvisorConfig(ctx, t, db, org.ID, codersdk.AdvisorConfig{Enabled: true, MaxUsesPerRun: 3, MaxOutputTokens: 1024})
 		dynamicToolsJSON, err := json.Marshal([]mcpgo.Tool{{
 			Name:        "mcp_tool",
 			Description: "dynamic test tool",
@@ -7862,7 +7870,7 @@ func TestActiveServer_ExclusiveToolPolicy(t *testing.T) {
 			}
 		})
 		user, org, model := seedChatDependenciesWithProvider(t, db, "openai-compat", openAIURL)
-		seedAdvisorConfig(ctx, t, db, codersdk.AdvisorConfig{Enabled: true, MaxUsesPerRun: 3, MaxOutputTokens: 1024})
+		seedAdvisorConfig(ctx, t, db, org.ID, codersdk.AdvisorConfig{Enabled: true, MaxUsesPerRun: 3, MaxOutputTokens: 1024})
 		server := newActiveTestServer(t, db, ps, func(cfg *chatd.Config) {
 			cfg.AIBridgeTransportFactory = chatAIGatewayTransportFactoryPointer(chattest.NewMockAIBridgeTransport(t, openAIURL))
 		})
@@ -7907,7 +7915,7 @@ func TestActiveServer_ExclusiveToolPolicy(t *testing.T) {
 				OpenAI: &codersdk.ChatModelOpenAIProviderOptions{WebSearchEnabled: &webSearchEnabled},
 			},
 		})
-		seedAdvisorConfig(ctx, t, db, codersdk.AdvisorConfig{Enabled: true, MaxUsesPerRun: 3, MaxOutputTokens: 1024})
+		seedAdvisorConfig(ctx, t, db, org.ID, codersdk.AdvisorConfig{Enabled: true, MaxUsesPerRun: 3, MaxOutputTokens: 1024})
 		server := newActiveTestServer(t, db, ps, func(cfg *chatd.Config) {
 			cfg.AIBridgeTransportFactory = chatAIGatewayTransportFactoryPointer(chattest.NewMockAIBridgeTransport(t, openAIURL))
 		})
@@ -8286,6 +8294,7 @@ func updateChatModelCompressionThreshold(t *testing.T, db database.Store, model 
 	model.CompressionThreshold = threshold
 	updated, err := db.UpdateChatModelConfig(context.Background(), database.UpdateChatModelConfigParams{
 		ID:                   model.ID,
+		OrganizationID:       model.OrganizationID,
 		DisplayName:          model.DisplayName,
 		Model:                model.Model,
 		Enabled:              model.Enabled,
@@ -8302,6 +8311,7 @@ func updateChatModelContextLimit(t *testing.T, db database.Store, model database
 	t.Helper()
 	updated, err := db.UpdateChatModelConfig(context.Background(), database.UpdateChatModelConfigParams{
 		ID:                   model.ID,
+		OrganizationID:       model.OrganizationID,
 		DisplayName:          model.DisplayName,
 		Model:                model.Model,
 		Enabled:              model.Enabled,
@@ -8320,6 +8330,7 @@ func updateChatModelCallConfig(t *testing.T, db database.Store, model database.C
 	require.NoError(t, err)
 	updated, err := db.UpdateChatModelConfig(context.Background(), database.UpdateChatModelConfigParams{
 		ID:                   model.ID,
+		OrganizationID:       model.OrganizationID,
 		DisplayName:          model.DisplayName,
 		Model:                model.Model,
 		Enabled:              model.Enabled,
@@ -8946,8 +8957,9 @@ func seedChatDependenciesWithProvider(
 		BaseUrl:     baseURL,
 	})
 	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-		AIProviderID: uuid.NullUUID{UUID: providerConfig.ID, Valid: true},
-		IsDefault:    true,
+		OrganizationID: org.ID,
+		AIProviderID:   uuid.NullUUID{UUID: providerConfig.ID, Valid: true},
+		IsDefault:      true,
 	})
 	return user, org, model
 }
@@ -8984,8 +8996,9 @@ func seedChatDependenciesWithProviderPolicy(
 	})
 
 	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-		AIProviderID: uuid.NullUUID{UUID: providerConfig.ID, Valid: true},
-		IsDefault:    true,
+		OrganizationID: org.ID,
+		AIProviderID:   uuid.NullUUID{UUID: providerConfig.ID, Valid: true},
+		IsDefault:      true,
 	})
 
 	return user, org, providerConfig, model
@@ -9033,6 +9046,7 @@ func waitForTerminalChat(
 func insertChatModelConfigWithCallConfig(
 	t *testing.T,
 	db database.Store,
+	organizationID uuid.UUID,
 	userID uuid.UUID,
 	provider string,
 	model string,
@@ -9063,12 +9077,13 @@ func insertChatModelConfigWithCallConfig(
 		})
 	}
 	return dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-		AIProviderID: uuid.NullUUID{UUID: aiProvider.ID, Valid: true},
-		Model:        model,
-		DisplayName:  model,
-		CreatedBy:    uuid.NullUUID{UUID: userID, Valid: true},
-		UpdatedBy:    uuid.NullUUID{UUID: userID, Valid: true},
-		Options:      options,
+		OrganizationID: organizationID,
+		AIProviderID:   uuid.NullUUID{UUID: aiProvider.ID, Valid: true},
+		Model:          model,
+		DisplayName:    model,
+		CreatedBy:      uuid.NullUUID{UUID: userID, Valid: true},
+		UpdatedBy:      uuid.NullUUID{UUID: userID, Valid: true},
+		Options:        options,
 	})
 }
 
@@ -10267,9 +10282,10 @@ func seedAIGatewayOpenAITestDependencies(
 		BaseUrl: openAIURL,
 	})
 	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-		Model:        "gpt-4o-mini",
-		IsDefault:    true,
-		AIProviderID: uuid.NullUUID{UUID: provider.ID, Valid: true},
+		OrganizationID: org.ID,
+		Model:          "gpt-4o-mini",
+		IsDefault:      true,
+		AIProviderID:   uuid.NullUUID{UUID: provider.ID, Valid: true},
 	})
 	_, err := db.UpsertUserAIProviderKey(context.Background(), database.UpsertUserAIProviderKeyParams{
 		ID:           uuid.New(),
@@ -12016,6 +12032,7 @@ func TestEditMessageWithModelConfigOverride(t *testing.T) {
 	modelB := insertChatModelConfigWithCallConfig(
 		t,
 		db,
+		org.ID,
 		user.ID,
 		"openai",
 		"gpt-4o-mini-edit-"+uuid.NewString(),
@@ -12284,7 +12301,7 @@ func TestAdvisorGating_ExperimentDisabled(t *testing.T) {
 	})
 
 	user, org, model := seedChatDependenciesWithProvider(t, db, "openai-compat", openAIURL)
-	seedAdvisorConfig(ctx, t, db, codersdk.AdvisorConfig{
+	seedAdvisorConfig(ctx, t, db, org.ID, codersdk.AdvisorConfig{
 		Enabled:         true,
 		MaxUsesPerRun:   3,
 		MaxOutputTokens: 16384,
@@ -12388,7 +12405,7 @@ func TestAdvisorGating_RootChat(t *testing.T) {
 	})
 
 	user, org, model := seedChatDependenciesWithProvider(t, db, "openai-compat", openAIURL)
-	seedAdvisorConfig(ctx, t, db, codersdk.AdvisorConfig{
+	seedAdvisorConfig(ctx, t, db, org.ID, codersdk.AdvisorConfig{
 		Enabled:         true,
 		MaxUsesPerRun:   3,
 		MaxOutputTokens: 16384,
@@ -12566,7 +12583,7 @@ func TestAdvisorHappyPath_RootChat(t *testing.T) {
 	})
 
 	user, org, model := seedChatDependenciesWithProvider(t, db, "openai-compat", openAIURL)
-	seedAdvisorConfig(ctx, t, db, codersdk.AdvisorConfig{
+	seedAdvisorConfig(ctx, t, db, org.ID, codersdk.AdvisorConfig{
 		Enabled:         true,
 		MaxUsesPerRun:   3,
 		MaxOutputTokens: 16384,
@@ -12746,7 +12763,7 @@ func TestAdvisorGating_ChildChat(t *testing.T) {
 	})
 
 	user, org, model := seedChatDependenciesWithProvider(t, db, "openai-compat", openAIURL)
-	seedAdvisorConfig(ctx, t, db, codersdk.AdvisorConfig{
+	seedAdvisorConfig(ctx, t, db, org.ID, codersdk.AdvisorConfig{
 		Enabled:         true,
 		MaxUsesPerRun:   3,
 		MaxOutputTokens: 16384,
@@ -12841,7 +12858,7 @@ func TestAdvisorGating_PlanMode(t *testing.T) {
 	})
 
 	user, org, model := seedChatDependenciesWithProvider(t, db, "openai-compat", openAIURL)
-	seedAdvisorConfig(ctx, t, db, codersdk.AdvisorConfig{
+	seedAdvisorConfig(ctx, t, db, org.ID, codersdk.AdvisorConfig{
 		Enabled:         true,
 		MaxUsesPerRun:   3,
 		MaxOutputTokens: 16384,
@@ -12924,7 +12941,7 @@ func TestAdvisorGating_ExploreSubagent(t *testing.T) {
 	})
 
 	user, org, model := seedChatDependenciesWithProvider(t, db, "openai-compat", openAIURL)
-	seedAdvisorConfig(ctx, t, db, codersdk.AdvisorConfig{
+	seedAdvisorConfig(ctx, t, db, org.ID, codersdk.AdvisorConfig{
 		Enabled:         true,
 		MaxUsesPerRun:   3,
 		MaxOutputTokens: 16384,
@@ -13025,16 +13042,18 @@ func TestProviderSwitchSanitizesAndRestoresPEToolHistory(t *testing.T) {
 	})
 
 	mA := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-		Model:        "gpt-4o-mini",
-		DisplayName:  "Model A",
-		Enabled:      true,
-		AIProviderID: uuid.NullUUID{UUID: cpA.ID, Valid: true},
+		OrganizationID: org.ID,
+		Model:          "gpt-4o-mini",
+		DisplayName:    "Model A",
+		Enabled:        true,
+		AIProviderID:   uuid.NullUUID{UUID: cpA.ID, Valid: true},
 	})
 	mB := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-		Model:        "gpt-4o-mini",
-		DisplayName:  "Model B",
-		Enabled:      true,
-		AIProviderID: uuid.NullUUID{UUID: cpB.ID, Valid: true},
+		OrganizationID: org.ID,
+		Model:          "gpt-4o-mini",
+		DisplayName:    "Model B",
+		Enabled:        true,
+		AIProviderID:   uuid.NullUUID{UUID: cpB.ID, Valid: true},
 	})
 
 	server := newActiveTestServer(t, db, ps, func(cfg *chatd.Config) {
@@ -13156,15 +13175,19 @@ func seedAdvisorConfig(
 	ctx context.Context,
 	t *testing.T,
 	db database.Store,
+	organizationID uuid.UUID,
 	cfg codersdk.AdvisorConfig,
 ) {
 	t.Helper()
 
 	data, err := json.Marshal(cfg)
 	require.NoError(t, err)
-	err = db.UpsertChatAdvisorConfig(
+	err = db.UpsertChatAdvisorConfigForOrganization(
 		dbauthz.AsSystemRestricted(ctx),
-		string(data),
+		database.UpsertChatAdvisorConfigForOrganizationParams{
+			OrganizationID: organizationID,
+			AdvisorConfig:  string(data),
+		},
 	)
 	require.NoError(t, err)
 }

--- a/coderd/x/chatd/chatstate/family_test.go
+++ b/coderd/x/chatd/chatstate/family_test.go
@@ -211,7 +211,8 @@ func seedFamilyDeps(t *testing.T, db database.Store) (database.User, database.Or
 		BaseUrl:     "http://example.invalid",
 	})
 	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-		IsDefault: true,
+		OrganizationID: org.ID,
+		IsDefault:      true,
 	})
 	return user, org, model
 }

--- a/coderd/x/chatd/chatstate/machine_test.go
+++ b/coderd/x/chatd/chatstate/machine_test.go
@@ -50,7 +50,8 @@ func newTestFixture(t *testing.T) *testFixture {
 		BaseUrl:     "http://example.invalid",
 	})
 	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-		IsDefault: true,
+		OrganizationID: org.ID,
+		IsDefault:      true,
 	})
 	pub := newRecordingPubsub()
 	return &testFixture{

--- a/coderd/x/chatd/chatstate/trigger_test.go
+++ b/coderd/x/chatd/chatstate/trigger_test.go
@@ -38,7 +38,8 @@ func newTriggerFixture(t *testing.T) *triggerFixture {
 		BaseUrl:     "http://example.invalid",
 	})
 	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-		IsDefault: true,
+		OrganizationID: org.ID,
+		IsDefault:      true,
 	})
 	f := &testFixture{
 		DB:     db,
@@ -94,9 +95,9 @@ func TestMessageInsertAssignsRevisionAndHistoryVersion(t *testing.T) {
 	// history_version.
 	content := userMessageContent(t, "hello-after-bump")
 	_, err = tf.sqlDB.ExecContext(ctx, `
-		INSERT INTO chat_messages (chat_id, role, content, content_version, visibility)
-		VALUES ($1, 'assistant', $2::jsonb, $3, 'both')
-	`, created.Chat.ID, string(content), int(chatprompt.CurrentContentVersion))
+		INSERT INTO chat_messages (chat_id, role, content, content_version, visibility, organization_id)
+		VALUES ($1, 'assistant', $2::jsonb, $3, 'both', $4)
+	`, created.Chat.ID, string(content), int(chatprompt.CurrentContentVersion), created.Chat.OrganizationID)
 	require.NoError(t, err)
 
 	// History version equals snapshot_version, generation_attempt resets.
@@ -523,9 +524,9 @@ func TestNonQueueUpdateDoesNotUpdateQueueVersion(t *testing.T) {
 
 	content := userMessageContent(t, "non-queue mutation")
 	_, err = tf.sqlDB.ExecContext(ctx, `
-		INSERT INTO chat_messages (chat_id, role, content, content_version, visibility)
-		VALUES ($1, 'assistant', $2::jsonb, $3, 'both')
-	`, created.Chat.ID, string(content), int(chatprompt.CurrentContentVersion))
+		INSERT INTO chat_messages (chat_id, role, content, content_version, visibility, organization_id)
+		VALUES ($1, 'assistant', $2::jsonb, $3, 'both', $4)
+	`, created.Chat.ID, string(content), int(chatprompt.CurrentContentVersion), created.Chat.OrganizationID)
 	require.NoError(t, err)
 
 	after, err := f.DB.GetChatByID(ctx, created.Chat.ID)
@@ -686,9 +687,9 @@ func TestHistoryChangeClearsRetryState(t *testing.T) {
 	require.NoError(t, err)
 	content := userMessageContent(t, "history clears retry state")
 	_, err = tf.sqlDB.ExecContext(ctx, `
-		INSERT INTO chat_messages (chat_id, role, content, content_version, visibility)
-		VALUES ($1, 'assistant', $2::jsonb, $3, 'both')
-	`, created.Chat.ID, string(content), int(chatprompt.CurrentContentVersion))
+		INSERT INTO chat_messages (chat_id, role, content, content_version, visibility, organization_id)
+		VALUES ($1, 'assistant', $2::jsonb, $3, 'both', $4)
+	`, created.Chat.ID, string(content), int(chatprompt.CurrentContentVersion), created.Chat.OrganizationID)
 	require.NoError(t, err)
 
 	after, err := f.DB.GetChatByID(ctx, created.Chat.ID)

--- a/coderd/x/chatd/chattool/listtemplates_test.go
+++ b/coderd/x/chatd/chattool/listtemplates_test.go
@@ -844,7 +844,9 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 		t.Run("Allowed", func(t *testing.T) {
 			// CreateWorkspace requires a real chat row so the existing
 			// workspace lookup can fall through to creation.
-			model := seedModelConfig(t, db)
+			model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
+				OrganizationID: org.ID,
+			})
 			chat, err := db.InsertChat(ctx, database.InsertChatParams{
 				OrganizationID:    org.ID,
 				OwnerID:           user.ID,

--- a/coderd/x/chatd/compaction_override.go
+++ b/coderd/x/chatd/compaction_override.go
@@ -19,10 +19,11 @@ const compactionOverrideContext = "compaction"
 func readCompactionModelOverride(
 	ctx context.Context,
 	db database.Store,
+	organizationID uuid.UUID,
 ) (string, error) {
 	//nolint:gocritic // Chatd is internal, not a user, so this read uses AsChatd.
 	chatdCtx := dbauthz.AsChatd(ctx)
-	raw, err := db.GetChatCompactionModelOverride(chatdCtx)
+	raw, err := getChatModelOverrideForOrganization(chatdCtx, db, organizationID, compactionOverrideContext)
 	if err != nil {
 		return "", xerrors.Errorf(
 			"get chat compaction model override: %w",
@@ -67,7 +68,7 @@ func (p *Server) resolveCompactionOverrideConfig(
 	ctx context.Context,
 	chat database.Chat,
 ) (*resolvedCompactionOverride, error) {
-	raw, err := readCompactionModelOverride(ctx, p.db)
+	raw, err := readCompactionModelOverride(ctx, p.db, chat.OrganizationID)
 	if err != nil {
 		return nil, xerrors.Errorf(
 			"read compaction model override: %w",
@@ -80,7 +81,9 @@ func (p *Server) resolveCompactionOverrideConfig(
 		compactionOverrideContext,
 		raw,
 		chat.OwnerID,
-		p.resolveModelConfigAndNormalizedProvider,
+		func(ctx context.Context, modelConfigID uuid.UUID) (database.ChatModelConfig, string, error) {
+			return p.resolveModelConfigAndNormalizedProvider(ctx, chat.OrganizationID, modelConfigID)
+		},
 		func(ctx context.Context, ownerID uuid.UUID, aiProviderID uuid.UUID) (chatprovider.ProviderAPIKeys, error) {
 			return p.resolveUserProviderAPIKeys(ctx, ownerID, aiProviderID)
 		},

--- a/coderd/x/chatd/compaction_override_internal_test.go
+++ b/coderd/x/chatd/compaction_override_internal_test.go
@@ -64,7 +64,7 @@ func TestResolveCompactionOverrideConfig_Unset(t *testing.T) {
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
 	chat, _ := titleOverrideTestChatAndMessages(t)
 
-	db.EXPECT().GetChatCompactionModelOverride(gomock.Any()).Return("", nil)
+	db.EXPECT().GetChatCompactionModelOverrideForOrganization(gomock.Any(), chat.OrganizationID).Return("", nil)
 
 	server := titleOverrideTestServer(db, logger)
 	override, err := server.resolveCompactionOverrideConfig(ctx, chat)
@@ -81,7 +81,7 @@ func TestResolveCompactionOverrideConfig_ReadDBError(t *testing.T) {
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
 	chat, _ := titleOverrideTestChatAndMessages(t)
 
-	db.EXPECT().GetChatCompactionModelOverride(gomock.Any()).Return("", sql.ErrConnDone)
+	db.EXPECT().GetChatCompactionModelOverrideForOrganization(gomock.Any(), chat.OrganizationID).Return("", sql.ErrConnDone)
 
 	server := titleOverrideTestServer(db, logger)
 	override, err := server.resolveCompactionOverrideConfig(ctx, chat)
@@ -99,7 +99,7 @@ func TestResolveCompactionOverrideConfig_MalformedFallsBack(t *testing.T) {
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
 	chat, _ := titleOverrideTestChatAndMessages(t)
 
-	db.EXPECT().GetChatCompactionModelOverride(gomock.Any()).Return("not-a-uuid", nil)
+	db.EXPECT().GetChatCompactionModelOverrideForOrganization(gomock.Any(), chat.OrganizationID).Return("not-a-uuid", nil)
 
 	server := titleOverrideTestServer(db, logger)
 	override, err := server.resolveCompactionOverrideConfig(ctx, chat)
@@ -117,8 +117,8 @@ func TestResolveCompactionOverrideConfig_DeletedConfigFallsBack(t *testing.T) {
 	chat, _ := titleOverrideTestChatAndMessages(t)
 	missingID := uuid.New()
 
-	db.EXPECT().GetChatCompactionModelOverride(gomock.Any()).Return(missingID.String(), nil)
-	db.EXPECT().GetChatModelConfigByID(gomock.Any(), missingID).Return(database.ChatModelConfig{}, sql.ErrNoRows)
+	db.EXPECT().GetChatCompactionModelOverrideForOrganization(gomock.Any(), chat.OrganizationID).Return(missingID.String(), nil)
+	db.EXPECT().GetChatModelConfigByID(gomock.Any(), gomock.Any()).Return(database.ChatModelConfig{}, sql.ErrNoRows)
 
 	server := titleOverrideTestServer(db, logger)
 	override, err := server.resolveCompactionOverrideConfig(ctx, chat)
@@ -136,8 +136,8 @@ func TestResolveCompactionOverrideConfig_DisabledConfigFallsBack(t *testing.T) {
 	chat, _ := titleOverrideTestChatAndMessages(t)
 	overrideConfig := titleOverrideModelConfig("gpt-4.1", false)
 
-	db.EXPECT().GetChatCompactionModelOverride(gomock.Any()).Return(overrideConfig.ID.String(), nil)
-	db.EXPECT().GetChatModelConfigByID(gomock.Any(), overrideConfig.ID).Return(overrideConfig, nil)
+	db.EXPECT().GetChatCompactionModelOverrideForOrganization(gomock.Any(), chat.OrganizationID).Return(overrideConfig.ID.String(), nil)
+	db.EXPECT().GetChatModelConfigByID(gomock.Any(), gomock.Any()).Return(overrideConfig, nil)
 
 	server := titleOverrideTestServer(db, logger)
 	override, err := server.resolveCompactionOverrideConfig(ctx, chat)
@@ -157,8 +157,8 @@ func TestResolveCompactionOverrideConfig_MissingCredentialsFallsBack(t *testing.
 	providerID := uuid.New()
 	overrideConfig.AIProviderID = uuid.NullUUID{UUID: providerID, Valid: true}
 
-	db.EXPECT().GetChatCompactionModelOverride(gomock.Any()).Return(overrideConfig.ID.String(), nil)
-	db.EXPECT().GetChatModelConfigByID(gomock.Any(), overrideConfig.ID).Return(overrideConfig, nil)
+	db.EXPECT().GetChatCompactionModelOverrideForOrganization(gomock.Any(), chat.OrganizationID).Return(overrideConfig.ID.String(), nil)
+	db.EXPECT().GetChatModelConfigByID(gomock.Any(), gomock.Any()).Return(overrideConfig, nil)
 	db.EXPECT().GetAIProviderByID(gomock.Any(), providerID).Return(database.AIProvider{
 		ID:      providerID,
 		Type:    database.AIProviderTypeOpenai,
@@ -184,8 +184,8 @@ func TestCompactionOverride_SetUsable(t *testing.T) {
 	providerID := uuid.New()
 	overrideConfig.AIProviderID = uuid.NullUUID{UUID: providerID, Valid: true}
 
-	db.EXPECT().GetChatCompactionModelOverride(gomock.Any()).Return(overrideConfig.ID.String(), nil)
-	db.EXPECT().GetChatModelConfigByID(gomock.Any(), overrideConfig.ID).Return(overrideConfig, nil)
+	db.EXPECT().GetChatCompactionModelOverrideForOrganization(gomock.Any(), chat.OrganizationID).Return(overrideConfig.ID.String(), nil)
+	db.EXPECT().GetChatModelConfigByID(gomock.Any(), gomock.Any()).Return(overrideConfig, nil)
 	db.EXPECT().GetAIProviderByID(gomock.Any(), providerID).Return(aibridgeTestAIProvider(providerID, "primary-openai", database.AIProviderTypeOpenai), nil).AnyTimes()
 	db.EXPECT().GetAIProviderKeysByProviderID(gomock.Any(), providerID).Return([]database.AIProviderKey{{
 		ProviderID: providerID,

--- a/coderd/x/chatd/configcache.go
+++ b/coderd/x/chatd/configcache.go
@@ -44,6 +44,11 @@ type cachedModelConfig struct {
 	expiresAt time.Time
 }
 
+type modelConfigCacheKey struct {
+	organizationID uuid.UUID
+	modelConfigID  uuid.UUID
+}
+
 type modelConfigSnapshot struct {
 	epoch      uint64
 	generation uint64
@@ -77,13 +82,14 @@ type chatConfigCache struct {
 	providerFetches    singleflight.Group[string, []database.AIProvider]
 
 	// Model configs (keyed by ID).
-	modelTopologyEpoch uint64
-	modelConfigs       map[uuid.UUID]cachedModelConfig
-	modelConfigFetches singleflight.Group[string, database.ChatModelConfig]
+	modelTopologyEpoch    uint64
+	modelConfigs          map[modelConfigCacheKey]cachedModelConfig
+	modelConfigGeneration map[modelConfigCacheKey]uint64
+	modelConfigFetches    singleflight.Group[string, database.ChatModelConfig]
 
-	// Default model config (singleton).
-	defaultModelConfig           *cachedModelConfig
-	defaultModelConfigGeneration uint64
+	// Default model config (keyed by organization ID).
+	defaultModelConfigs          map[uuid.UUID]cachedModelConfig
+	defaultModelConfigGeneration map[uuid.UUID]uint64
 	defaultModelConfigFetches    singleflight.Group[string, database.ChatModelConfig]
 
 	// User custom prompts (keyed by user ID).
@@ -91,18 +97,23 @@ type chatConfigCache struct {
 	userPrompts       *tlru.Cache[uuid.UUID, string]
 	userPromptFetches singleflight.Group[string, string]
 
-	// Advisor configuration (singleton).
-	advisorConfig           *cachedAdvisorConfig
-	advisorConfigGeneration uint64
+	// Advisor configuration (keyed by organization ID).
+	advisorConfigs          map[uuid.UUID]cachedAdvisorConfig
+	advisorConfigGeneration map[uuid.UUID]uint64
 	advisorConfigFetches    singleflight.Group[string, codersdk.AdvisorConfig]
 }
 
 func newChatConfigCache(ctx context.Context, db database.Store, clock quartz.Clock) *chatConfigCache {
 	return &chatConfigCache{
-		db:           db,
-		clock:        clock,
-		ctx:          ctx,
-		modelConfigs: make(map[uuid.UUID]cachedModelConfig),
+		db:                           db,
+		clock:                        clock,
+		ctx:                          ctx,
+		modelConfigs:                 make(map[modelConfigCacheKey]cachedModelConfig),
+		modelConfigGeneration:        make(map[modelConfigCacheKey]uint64),
+		defaultModelConfigs:          make(map[uuid.UUID]cachedModelConfig),
+		defaultModelConfigGeneration: make(map[uuid.UUID]uint64),
+		advisorConfigs:               make(map[uuid.UUID]cachedAdvisorConfig),
+		advisorConfigGeneration:      make(map[uuid.UUID]uint64),
 		userPrompts: tlru.New[uuid.UUID](
 			tlru.ConstantCost[string],
 			chatConfigUserPromptEntryLimit,
@@ -210,27 +221,32 @@ func (c *chatConfigCache) InvalidateProviders() {
 	// provider existence, so flush all model-config state.
 	clear(c.modelConfigs)
 	c.modelTopologyEpoch++
-	c.defaultModelConfig = nil
-	c.defaultModelConfigGeneration++
+	clear(c.defaultModelConfigs)
+	for organizationID := range c.defaultModelConfigGeneration {
+		c.defaultModelConfigGeneration[organizationID]++
+	}
 	c.mu.Unlock()
 }
 
-func (c *chatConfigCache) ModelConfigByID(ctx context.Context, id uuid.UUID) (database.ChatModelConfig, error) {
-	if config, ok := c.cachedModelConfig(id); ok {
+func (c *chatConfigCache) ModelConfigByID(ctx context.Context, organizationID, id uuid.UUID) (database.ChatModelConfig, error) {
+	if config, ok := c.cachedModelConfig(organizationID, id); ok {
 		return config, nil
 	}
 
-	snap := c.modelConfigSnapshot()
-	config, err := singleflightDoChan(ctx, &c.modelConfigFetches, fmt.Sprintf("%d:%s", snap.epoch, id), func() (database.ChatModelConfig, error) {
-		if cached, ok := c.cachedModelConfig(id); ok {
+	snap := c.modelConfigSnapshot(organizationID, id)
+	config, err := singleflightDoChan(ctx, &c.modelConfigFetches, fmt.Sprintf("%d:%d:%s:%s", snap.epoch, snap.generation, organizationID, id), func() (database.ChatModelConfig, error) {
+		if cached, ok := c.cachedModelConfig(organizationID, id); ok {
 			return cached, nil
 		}
 
-		fetched, err := c.db.GetChatModelConfigByID(c.ctx, id)
+		fetched, err := c.db.GetChatModelConfigByID(c.ctx, database.GetChatModelConfigByIDParams{
+			OrganizationID: organizationID,
+			ID:             id,
+		})
 		if err != nil {
 			return database.ChatModelConfig{}, err
 		}
-		c.storeModelConfig(snap, fetched)
+		c.storeModelConfig(organizationID, snap, fetched)
 		return cloneModelConfig(fetched), nil
 	})
 	if err != nil {
@@ -240,9 +256,10 @@ func (c *chatConfigCache) ModelConfigByID(ctx context.Context, id uuid.UUID) (da
 	return config, nil
 }
 
-func (c *chatConfigCache) cachedModelConfig(id uuid.UUID) (database.ChatModelConfig, bool) {
+func (c *chatConfigCache) cachedModelConfig(organizationID, id uuid.UUID) (database.ChatModelConfig, bool) {
 	c.mu.RLock()
-	entry, ok := c.modelConfigs[id]
+	key := modelConfigCacheKey{organizationID: organizationID, modelConfigID: id}
+	entry, ok := c.modelConfigs[key]
 	c.mu.RUnlock()
 	if !ok {
 		return database.ChatModelConfig{}, false
@@ -252,51 +269,56 @@ func (c *chatConfigCache) cachedModelConfig(id uuid.UUID) (database.ChatModelCon
 	}
 
 	c.mu.Lock()
-	if current, ok := c.modelConfigs[id]; ok && !c.clock.Now().Before(current.expiresAt) {
-		delete(c.modelConfigs, id)
+	if current, ok := c.modelConfigs[key]; ok && !c.clock.Now().Before(current.expiresAt) {
+		delete(c.modelConfigs, key)
 	}
 	c.mu.Unlock()
 
 	return database.ChatModelConfig{}, false
 }
 
-func (c *chatConfigCache) modelConfigSnapshot() modelConfigSnapshot {
+func (c *chatConfigCache) modelConfigSnapshot(organizationID, modelConfigID uuid.UUID) modelConfigSnapshot {
+	key := modelConfigCacheKey{organizationID: organizationID, modelConfigID: modelConfigID}
 	c.mu.RLock()
-	snap := modelConfigSnapshot{epoch: c.modelTopologyEpoch}
+	snap := modelConfigSnapshot{epoch: c.modelTopologyEpoch, generation: c.modelConfigGeneration[key]}
 	c.mu.RUnlock()
 	return snap
 }
 
-func (c *chatConfigCache) storeModelConfig(snap modelConfigSnapshot, config database.ChatModelConfig) {
+func (c *chatConfigCache) storeModelConfig(organizationID uuid.UUID, snap modelConfigSnapshot, config database.ChatModelConfig) {
+	key := modelConfigCacheKey{organizationID: organizationID, modelConfigID: config.ID}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	if c.modelTopologyEpoch != snap.epoch {
 		return
 	}
+	if c.modelConfigGeneration[key] != snap.generation {
+		return
+	}
 
-	c.modelConfigs[config.ID] = cachedModelConfig{
+	c.modelConfigs[key] = cachedModelConfig{
 		config:    cloneModelConfig(config),
 		expiresAt: c.clock.Now().Add(chatConfigModelConfigTTL),
 	}
 }
 
-func (c *chatConfigCache) DefaultModelConfig(ctx context.Context) (database.ChatModelConfig, error) {
-	if config, ok := c.cachedDefaultModelConfig(); ok {
+func (c *chatConfigCache) DefaultModelConfig(ctx context.Context, organizationID uuid.UUID) (database.ChatModelConfig, error) {
+	if config, ok := c.cachedDefaultModelConfig(organizationID); ok {
 		return config, nil
 	}
 
-	snap := c.defaultModelConfigSnapshot()
-	config, err := singleflightDoChan(ctx, &c.defaultModelConfigFetches, fmt.Sprintf("%d:default", snap.epoch), func() (database.ChatModelConfig, error) {
-		if cached, ok := c.cachedDefaultModelConfig(); ok {
+	snap := c.defaultModelConfigSnapshot(organizationID)
+	config, err := singleflightDoChan(ctx, &c.defaultModelConfigFetches, fmt.Sprintf("%d:%d:%s:default", snap.epoch, snap.generation, organizationID), func() (database.ChatModelConfig, error) {
+		if cached, ok := c.cachedDefaultModelConfig(organizationID); ok {
 			return cached, nil
 		}
 
-		fetched, err := c.db.GetDefaultChatModelConfig(c.ctx)
+		fetched, err := c.db.GetDefaultChatModelConfig(c.ctx, organizationID)
 		if err != nil {
 			return database.ChatModelConfig{}, err
 		}
-		c.storeDefaultModelConfig(snap, fetched)
+		c.storeDefaultModelConfig(organizationID, snap, fetched)
 		return cloneModelConfig(fetched), nil
 	})
 	if err != nil {
@@ -306,11 +328,11 @@ func (c *chatConfigCache) DefaultModelConfig(ctx context.Context) (database.Chat
 	return config, nil
 }
 
-func (c *chatConfigCache) cachedDefaultModelConfig() (database.ChatModelConfig, bool) {
+func (c *chatConfigCache) cachedDefaultModelConfig(organizationID uuid.UUID) (database.ChatModelConfig, bool) {
 	c.mu.RLock()
-	entry := c.defaultModelConfig
+	entry, ok := c.defaultModelConfigs[organizationID]
 	c.mu.RUnlock()
-	if entry == nil {
+	if !ok {
 		return database.ChatModelConfig{}, false
 	}
 	if c.clock.Now().Before(entry.expiresAt) {
@@ -318,36 +340,36 @@ func (c *chatConfigCache) cachedDefaultModelConfig() (database.ChatModelConfig, 
 	}
 
 	c.mu.Lock()
-	if current := c.defaultModelConfig; current != nil && !c.clock.Now().Before(current.expiresAt) {
-		c.defaultModelConfig = nil
+	if current, ok := c.defaultModelConfigs[organizationID]; ok && !c.clock.Now().Before(current.expiresAt) {
+		delete(c.defaultModelConfigs, organizationID)
 	}
 	c.mu.Unlock()
 
 	return database.ChatModelConfig{}, false
 }
 
-func (c *chatConfigCache) defaultModelConfigSnapshot() modelConfigSnapshot {
+func (c *chatConfigCache) defaultModelConfigSnapshot(organizationID uuid.UUID) modelConfigSnapshot {
 	c.mu.RLock()
 	snap := modelConfigSnapshot{
 		epoch:      c.modelTopologyEpoch,
-		generation: c.defaultModelConfigGeneration,
+		generation: c.defaultModelConfigGeneration[organizationID],
 	}
 	c.mu.RUnlock()
 	return snap
 }
 
-func (c *chatConfigCache) storeDefaultModelConfig(snap modelConfigSnapshot, config database.ChatModelConfig) {
+func (c *chatConfigCache) storeDefaultModelConfig(organizationID uuid.UUID, snap modelConfigSnapshot, config database.ChatModelConfig) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	if c.modelTopologyEpoch != snap.epoch {
 		return
 	}
-	if c.defaultModelConfigGeneration != snap.generation {
+	if c.defaultModelConfigGeneration[organizationID] != snap.generation {
 		return
 	}
 
-	c.defaultModelConfig = &cachedModelConfig{
+	c.defaultModelConfigs[organizationID] = cachedModelConfig{
 		config:    cloneModelConfig(config),
 		expiresAt: c.clock.Now().Add(chatConfigModelConfigTTL),
 	}
@@ -408,12 +430,13 @@ func (c *chatConfigCache) storeUserPrompt(epoch uint64, userID uuid.UUID, prompt
 	c.userPrompts.Set(userID, prompt, chatConfigUserPromptTTL)
 }
 
-func (c *chatConfigCache) InvalidateModelConfig(id uuid.UUID) {
+func (c *chatConfigCache) InvalidateModelConfig(id uuid.UUID, organizationID uuid.UUID) {
 	c.mu.Lock()
-	delete(c.modelConfigs, id)
-	c.modelTopologyEpoch++
-	c.defaultModelConfig = nil
-	c.defaultModelConfigGeneration++
+	key := modelConfigCacheKey{organizationID: organizationID, modelConfigID: id}
+	delete(c.modelConfigs, key)
+	c.modelConfigGeneration[key]++
+	delete(c.defaultModelConfigs, organizationID)
+	c.defaultModelConfigGeneration[organizationID]++
 	c.mu.Unlock()
 }
 
@@ -424,42 +447,33 @@ func (c *chatConfigCache) InvalidateUserPrompt(userID uuid.UUID) {
 	c.mu.Unlock()
 }
 
-// InvalidateAdvisorConfig drops the cached advisor configuration so the
-// next AdvisorConfig call re-fetches from the database. Called from the
-// ChatConfigEvent subscriber after an admin writes
-// PUT /api/experimental/chats/config/advisor; without this the cache
-// could serve stale enabled/model/limits for up to
-// chatConfigAdvisorConfigTTL. Bumping the generation counter also
-// discards any in-flight fill started before the invalidation, so a
-// stale DB read cannot re-cache the pre-update value.
-func (c *chatConfigCache) InvalidateAdvisorConfig() {
+// InvalidateAdvisorConfig drops the cached advisor configuration for one
+// organization. Bumping its generation rejects a stale in-flight fill without
+// invalidating other organizations' entries.
+func (c *chatConfigCache) InvalidateAdvisorConfig(organizationID uuid.UUID) {
 	c.mu.Lock()
-	c.advisorConfig = nil
-	c.advisorConfigGeneration++
+	delete(c.advisorConfigs, organizationID)
+	c.advisorConfigGeneration[organizationID]++
 	c.mu.Unlock()
 }
 
-// AdvisorConfig returns the deployment-wide advisor configuration. The
-// underlying site-config row changes on the order of hours or days, so
-// this cache saves a per-turn DB round trip on chats that reference the
-// advisor. Parse errors and lookup errors are surfaced to the caller;
-// callers that prefer silent fallback handle that at the call site.
-func (c *chatConfigCache) AdvisorConfig(ctx context.Context) (codersdk.AdvisorConfig, error) {
-	if config, ok := c.cachedAdvisorConfig(); ok {
+// AdvisorConfig returns the advisor configuration for organizationID.
+func (c *chatConfigCache) AdvisorConfig(ctx context.Context, organizationID uuid.UUID) (codersdk.AdvisorConfig, error) {
+	if config, ok := c.cachedAdvisorConfig(organizationID); ok {
 		return config, nil
 	}
 
-	generation := c.advisorConfigGenerationSnapshot()
+	generation := c.advisorConfigGenerationSnapshot(organizationID)
 	config, err := singleflightDoChan(
 		ctx,
 		&c.advisorConfigFetches,
-		fmt.Sprintf("%d:advisor", generation),
+		fmt.Sprintf("%d:%s:advisor", generation, organizationID),
 		func() (codersdk.AdvisorConfig, error) {
-			if cached, ok := c.cachedAdvisorConfig(); ok {
+			if cached, ok := c.cachedAdvisorConfig(organizationID); ok {
 				return cached, nil
 			}
 
-			raw, err := c.db.GetChatAdvisorConfig(c.ctx)
+			raw, err := c.db.GetChatAdvisorConfigForOrganization(c.ctx, organizationID)
 			if err != nil {
 				return codersdk.AdvisorConfig{}, err
 			}
@@ -467,7 +481,7 @@ func (c *chatConfigCache) AdvisorConfig(ctx context.Context) (codersdk.AdvisorCo
 			if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
 				return codersdk.AdvisorConfig{}, err
 			}
-			c.storeAdvisorConfig(generation, cfg)
+			c.storeAdvisorConfig(organizationID, generation, cfg)
 			return cfg, nil
 		},
 	)
@@ -477,11 +491,11 @@ func (c *chatConfigCache) AdvisorConfig(ctx context.Context) (codersdk.AdvisorCo
 	return config, nil
 }
 
-func (c *chatConfigCache) cachedAdvisorConfig() (codersdk.AdvisorConfig, bool) {
+func (c *chatConfigCache) cachedAdvisorConfig(organizationID uuid.UUID) (codersdk.AdvisorConfig, bool) {
 	c.mu.RLock()
-	entry := c.advisorConfig
+	entry, ok := c.advisorConfigs[organizationID]
 	c.mu.RUnlock()
-	if entry == nil {
+	if !ok {
 		return codersdk.AdvisorConfig{}, false
 	}
 	if c.clock.Now().Before(entry.expiresAt) {
@@ -489,30 +503,30 @@ func (c *chatConfigCache) cachedAdvisorConfig() (codersdk.AdvisorConfig, bool) {
 	}
 
 	c.mu.Lock()
-	if current := c.advisorConfig; current != nil && !c.clock.Now().Before(current.expiresAt) {
-		c.advisorConfig = nil
+	if current, ok := c.advisorConfigs[organizationID]; ok && !c.clock.Now().Before(current.expiresAt) {
+		delete(c.advisorConfigs, organizationID)
 	}
 	c.mu.Unlock()
 
 	return codersdk.AdvisorConfig{}, false
 }
 
-func (c *chatConfigCache) advisorConfigGenerationSnapshot() uint64 {
+func (c *chatConfigCache) advisorConfigGenerationSnapshot(organizationID uuid.UUID) uint64 {
 	c.mu.RLock()
-	generation := c.advisorConfigGeneration
+	generation := c.advisorConfigGeneration[organizationID]
 	c.mu.RUnlock()
 	return generation
 }
 
-func (c *chatConfigCache) storeAdvisorConfig(generation uint64, config codersdk.AdvisorConfig) {
+func (c *chatConfigCache) storeAdvisorConfig(organizationID uuid.UUID, generation uint64, config codersdk.AdvisorConfig) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if c.advisorConfigGeneration != generation {
+	if c.advisorConfigGeneration[organizationID] != generation {
 		return
 	}
 
-	c.advisorConfig = &cachedAdvisorConfig{
+	c.advisorConfigs[organizationID] = cachedAdvisorConfig{
 		config:    config,
 		expiresAt: c.clock.Now().Add(chatConfigAdvisorConfigTTL),
 	}

--- a/coderd/x/chatd/configcache_internal_test.go
+++ b/coderd/x/chatd/configcache_internal_test.go
@@ -25,11 +25,14 @@ import (
 type stubChatConfigStore struct {
 	database.Store
 
-	getAIProviders            func(context.Context) ([]database.AIProvider, error)
-	getChatModelConfigByID    func(context.Context, uuid.UUID) (database.ChatModelConfig, error)
-	getDefaultChatModelConfig func(context.Context) (database.ChatModelConfig, error)
-	getUserChatCustomPrompt   func(context.Context, uuid.UUID) (string, error)
-	getChatAdvisorConfig      func(context.Context) (string, error)
+	getAIProviders                        func(context.Context) ([]database.AIProvider, error)
+	getChatModelConfigByID                func(context.Context, uuid.UUID) (database.ChatModelConfig, error)
+	getChatModelConfigByIDForOrganization func(context.Context, uuid.UUID, uuid.UUID) (database.ChatModelConfig, error)
+	getDefaultChatModelConfig             func(context.Context) (database.ChatModelConfig, error)
+	getDefaultModelConfigForOrganization  func(context.Context, uuid.UUID) (database.ChatModelConfig, error)
+	getUserChatCustomPrompt               func(context.Context, uuid.UUID) (string, error)
+	getChatAdvisorConfig                  func(context.Context) (string, error)
+	getChatAdvisorConfigForOrganization   func(context.Context, uuid.UUID) (string, error)
 
 	enabledProvidersCalls  atomic.Int32
 	modelConfigByIDCalls   atomic.Int32
@@ -46,20 +49,45 @@ func (s *stubChatConfigStore) GetAIProviders(ctx context.Context, _ database.Get
 	return s.getAIProviders(ctx)
 }
 
-func (s *stubChatConfigStore) GetChatModelConfigByID(ctx context.Context, id uuid.UUID) (database.ChatModelConfig, error) {
+func (s *stubChatConfigStore) GetChatModelConfigByIDForOrganization(ctx context.Context, organizationID, id uuid.UUID) (database.ChatModelConfig, error) {
 	s.modelConfigByIDCalls.Add(1)
+	if s.getChatModelConfigByIDForOrganization != nil {
+		return s.getChatModelConfigByIDForOrganization(ctx, organizationID, id)
+	}
 	if s.getChatModelConfigByID == nil {
-		panic("unexpected GetChatModelConfigByID call")
+		panic("unexpected GetChatModelConfigByIDForOrganization call")
 	}
 	return s.getChatModelConfigByID(ctx, id)
 }
 
-func (s *stubChatConfigStore) GetDefaultChatModelConfig(ctx context.Context) (database.ChatModelConfig, error) {
+func (s *stubChatConfigStore) GetDefaultChatModelConfigForOrganization(ctx context.Context, organizationID uuid.UUID) (database.ChatModelConfig, error) {
 	s.defaultModelConfigCall.Add(1)
+	if s.getDefaultModelConfigForOrganization != nil {
+		return s.getDefaultModelConfigForOrganization(ctx, organizationID)
+	}
 	if s.getDefaultChatModelConfig == nil {
-		panic("unexpected GetDefaultChatModelConfig call")
+		panic("unexpected GetDefaultChatModelConfigForOrganization call")
 	}
 	return s.getDefaultChatModelConfig(ctx)
+}
+
+func (s *stubChatConfigStore) GetChatAdvisorConfigForOrganization(ctx context.Context, organizationID uuid.UUID) (string, error) {
+	s.advisorConfigCalls.Add(1)
+	if s.getChatAdvisorConfigForOrganization != nil {
+		return s.getChatAdvisorConfigForOrganization(ctx, organizationID)
+	}
+	if s.getChatAdvisorConfig == nil {
+		panic("unexpected GetChatAdvisorConfigForOrganization call")
+	}
+	return s.getChatAdvisorConfig(ctx)
+}
+
+func (s *stubChatConfigStore) GetChatModelConfigByID(ctx context.Context, arg database.GetChatModelConfigByIDParams) (database.ChatModelConfig, error) {
+	return s.GetChatModelConfigByIDForOrganization(ctx, arg.OrganizationID, arg.ID)
+}
+
+func (s *stubChatConfigStore) GetDefaultChatModelConfig(ctx context.Context, organizationID uuid.UUID) (database.ChatModelConfig, error) {
+	return s.GetDefaultChatModelConfigForOrganization(ctx, organizationID)
 }
 
 func (s *stubChatConfigStore) GetUserChatCustomPrompt(ctx context.Context, userID uuid.UUID) (string, error) {
@@ -70,13 +98,7 @@ func (s *stubChatConfigStore) GetUserChatCustomPrompt(ctx context.Context, userI
 	return s.getUserChatCustomPrompt(ctx, userID)
 }
 
-func (s *stubChatConfigStore) GetChatAdvisorConfig(ctx context.Context) (string, error) {
-	s.advisorConfigCalls.Add(1)
-	if s.getChatAdvisorConfig == nil {
-		panic("unexpected GetChatAdvisorConfig call")
-	}
-	return s.getChatAdvisorConfig(ctx)
-}
+var cacheTestOrganizationID = uuid.MustParse("00000000-0000-0000-0000-000000000001")
 
 func TestConfigCache_EnabledProviders_CacheHit(t *testing.T) {
 	t.Parallel()
@@ -159,9 +181,9 @@ func TestConfigCache_ModelConfigByID_CacheHit(t *testing.T) {
 	}
 	cache := newChatConfigCache(ctx, store, clock)
 
-	first, err := cache.ModelConfigByID(ctx, configID)
+	first, err := cache.ModelConfigByID(ctx, cacheTestOrganizationID, configID)
 	require.NoError(t, err)
-	second, err := cache.ModelConfigByID(ctx, configID)
+	second, err := cache.ModelConfigByID(ctx, cacheTestOrganizationID, configID)
 	require.NoError(t, err)
 
 	require.Equal(t, config, first)
@@ -186,18 +208,18 @@ func TestConfigCache_ModelConfigByID_ClonesOptionsForCache(t *testing.T) {
 	cache := newChatConfigCache(ctx, store, clock)
 
 	// First call populates cache via singleflight.
-	first, err := cache.ModelConfigByID(ctx, configID)
+	first, err := cache.ModelConfigByID(ctx, cacheTestOrganizationID, configID)
 	require.NoError(t, err)
 	first.Options[0] = 'x' // mutate singleflight return
 
 	// Second call is a cache hit.
-	second, err := cache.ModelConfigByID(ctx, configID)
+	second, err := cache.ModelConfigByID(ctx, cacheTestOrganizationID, configID)
 	require.NoError(t, err)
 	require.Equal(t, options, string(second.Options))
 	second.Options[0] = 'y' // mutate cache-hit return
 
 	// Third call is another cache hit — must be unaffected.
-	third, err := cache.ModelConfigByID(ctx, configID)
+	third, err := cache.ModelConfigByID(ctx, cacheTestOrganizationID, configID)
 	require.NoError(t, err)
 	require.Equal(t, options, string(third.Options))
 }
@@ -215,13 +237,13 @@ func TestConfigCache_ModelConfigByID_NotFound(t *testing.T) {
 	}
 	cache := newChatConfigCache(ctx, store, clock)
 
-	_, err := cache.ModelConfigByID(ctx, configID)
+	_, err := cache.ModelConfigByID(ctx, cacheTestOrganizationID, configID)
 	require.ErrorIs(t, err, sql.ErrNoRows)
-	_, err = cache.ModelConfigByID(ctx, configID)
+	_, err = cache.ModelConfigByID(ctx, cacheTestOrganizationID, configID)
 	require.ErrorIs(t, err, sql.ErrNoRows)
 
 	require.Equal(t, int32(2), store.modelConfigByIDCalls.Load())
-	_, ok := cache.modelConfigs[configID]
+	_, ok := cache.modelConfigs[modelConfigCacheKey{organizationID: cacheTestOrganizationID, modelConfigID: configID}]
 	require.False(t, ok)
 }
 
@@ -242,15 +264,16 @@ func TestConfigCache_InvalidateModelConfig_CascadesToDefault(t *testing.T) {
 	}
 	cache := newChatConfigCache(ctx, store, clock)
 
-	_, err := cache.ModelConfigByID(ctx, configID)
+	_, err := cache.ModelConfigByID(ctx, cacheTestOrganizationID, configID)
 	require.NoError(t, err)
-	firstDefault, err := cache.DefaultModelConfig(ctx)
+	firstDefault, err := cache.DefaultModelConfig(ctx, cacheTestOrganizationID)
 	require.NoError(t, err)
 
-	cache.InvalidateModelConfig(configID)
-	require.Nil(t, cache.defaultModelConfig)
+	cache.InvalidateModelConfig(configID, cacheTestOrganizationID)
+	_, ok := cache.defaultModelConfigs[cacheTestOrganizationID]
+	require.False(t, ok)
 
-	secondDefault, err := cache.DefaultModelConfig(ctx)
+	secondDefault, err := cache.DefaultModelConfig(ctx, cacheTestOrganizationID)
 	require.NoError(t, err)
 
 	require.NotEqual(t, firstDefault, secondDefault)
@@ -570,10 +593,10 @@ func TestConfigCache_InvalidateProviders_CascadesToModelConfigs(t *testing.T) {
 	}
 	cache := newChatConfigCache(ctx, store, clock)
 
-	first, err := cache.ModelConfigByID(ctx, configID)
+	first, err := cache.ModelConfigByID(ctx, cacheTestOrganizationID, configID)
 	require.NoError(t, err)
 	cache.InvalidateProviders()
-	second, err := cache.ModelConfigByID(ctx, configID)
+	second, err := cache.ModelConfigByID(ctx, cacheTestOrganizationID, configID)
 	require.NoError(t, err)
 
 	require.NotEqual(t, first, second)
@@ -592,10 +615,10 @@ func TestConfigCache_InvalidateProviders_CascadesToDefaultModelConfig(t *testing
 	}
 	cache := newChatConfigCache(ctx, store, clock)
 
-	first, err := cache.DefaultModelConfig(ctx)
+	first, err := cache.DefaultModelConfig(ctx, cacheTestOrganizationID)
 	require.NoError(t, err)
 	cache.InvalidateProviders()
-	second, err := cache.DefaultModelConfig(ctx)
+	second, err := cache.DefaultModelConfig(ctx, cacheTestOrganizationID)
 	require.NoError(t, err)
 
 	require.NotEqual(t, first, second)
@@ -638,7 +661,7 @@ func TestConfigCache_InvalidateProviders_BlocksStaleInFlightModelConfig(t *testi
 
 	firstResult := make(chan result, 1)
 	go func() {
-		config, err := cache.ModelConfigByID(ctx, configID)
+		config, err := cache.ModelConfigByID(ctx, cacheTestOrganizationID, configID)
 		firstResult <- result{config: config, err: err}
 	}()
 
@@ -647,7 +670,7 @@ func TestConfigCache_InvalidateProviders_BlocksStaleInFlightModelConfig(t *testi
 
 	secondResult := make(chan result, 1)
 	go func() {
-		config, err := cache.ModelConfigByID(ctx, configID)
+		config, err := cache.ModelConfigByID(ctx, cacheTestOrganizationID, configID)
 		secondResult <- result{config: config, err: err}
 	}()
 
@@ -656,7 +679,7 @@ func TestConfigCache_InvalidateProviders_BlocksStaleInFlightModelConfig(t *testi
 	first := <-firstResult
 	require.NoError(t, first.err)
 	require.Equal(t, staleConfig, first.config)
-	_, ok := cache.modelConfigs[configID]
+	_, ok := cache.modelConfigs[modelConfigCacheKey{organizationID: cacheTestOrganizationID, modelConfigID: configID}]
 	require.False(t, ok)
 
 	close(releaseSecond)
@@ -665,7 +688,7 @@ func TestConfigCache_InvalidateProviders_BlocksStaleInFlightModelConfig(t *testi
 	require.Equal(t, freshConfig, second.config)
 	require.Equal(t, int32(2), store.modelConfigByIDCalls.Load())
 
-	third, err := cache.ModelConfigByID(ctx, configID)
+	third, err := cache.ModelConfigByID(ctx, cacheTestOrganizationID, configID)
 	require.NoError(t, err)
 	require.Equal(t, freshConfig, third)
 	require.Equal(t, int32(2), store.modelConfigByIDCalls.Load())
@@ -787,7 +810,7 @@ func TestConfigCache_CallerCancellation(t *testing.T) {
 				}
 			},
 			call: func(ctx context.Context, cache *chatConfigCache) error {
-				_, err := cache.ModelConfigByID(ctx, configID)
+				_, err := cache.ModelConfigByID(ctx, cacheTestOrganizationID, configID)
 				return err
 			},
 			storeCalls: func(store *stubChatConfigStore) int32 {
@@ -817,7 +840,7 @@ func TestConfigCache_CallerCancellation(t *testing.T) {
 				}
 			},
 			call: func(ctx context.Context, cache *chatConfigCache) error {
-				_, err := cache.DefaultModelConfig(ctx)
+				_, err := cache.DefaultModelConfig(ctx, cacheTestOrganizationID)
 				return err
 			},
 			storeCalls: func(store *stubChatConfigStore) int32 {
@@ -1002,9 +1025,9 @@ func TestConfigCache_AdvisorConfig_CacheHit(t *testing.T) {
 	}
 	cache := newChatConfigCache(ctx, store, clock)
 
-	first, err := cache.AdvisorConfig(ctx)
+	first, err := cache.AdvisorConfig(ctx, cacheTestOrganizationID)
 	require.NoError(t, err)
-	second, err := cache.AdvisorConfig(ctx)
+	second, err := cache.AdvisorConfig(ctx, cacheTestOrganizationID)
 	require.NoError(t, err)
 
 	require.True(t, first.Enabled)
@@ -1027,10 +1050,10 @@ func TestConfigCache_AdvisorConfig_TTLExpiry(t *testing.T) {
 	}
 	cache := newChatConfigCache(ctx, store, clock)
 
-	first, err := cache.AdvisorConfig(ctx)
+	first, err := cache.AdvisorConfig(ctx, cacheTestOrganizationID)
 	require.NoError(t, err)
 	clock.Advance(chatConfigAdvisorConfigTTL).MustWait(ctx)
-	second, err := cache.AdvisorConfig(ctx)
+	second, err := cache.AdvisorConfig(ctx, cacheTestOrganizationID)
 	require.NoError(t, err)
 
 	require.NotEqual(t, first.MaxUsesPerRun, second.MaxUsesPerRun,
@@ -1051,9 +1074,9 @@ func TestConfigCache_AdvisorConfig_DBErrorNotCached(t *testing.T) {
 	}
 	cache := newChatConfigCache(ctx, store, clock)
 
-	_, err := cache.AdvisorConfig(ctx)
+	_, err := cache.AdvisorConfig(ctx, cacheTestOrganizationID)
 	require.ErrorIs(t, err, expected)
-	_, err = cache.AdvisorConfig(ctx)
+	_, err = cache.AdvisorConfig(ctx, cacheTestOrganizationID)
 	require.ErrorIs(t, err, expected)
 
 	require.Equal(t, int32(2), store.advisorConfigCalls.Load(),
@@ -1072,9 +1095,9 @@ func TestConfigCache_AdvisorConfig_InvalidJSONNotCached(t *testing.T) {
 	}
 	cache := newChatConfigCache(ctx, store, clock)
 
-	_, err := cache.AdvisorConfig(ctx)
+	_, err := cache.AdvisorConfig(ctx, cacheTestOrganizationID)
 	require.Error(t, err, "malformed JSON must surface as an error")
-	_, err = cache.AdvisorConfig(ctx)
+	_, err = cache.AdvisorConfig(ctx, cacheTestOrganizationID)
 	require.Error(t, err)
 
 	require.Equal(t, int32(2), store.advisorConfigCalls.Load(),
@@ -1096,13 +1119,13 @@ func TestConfigCache_AdvisorConfig_EmptyJSONYieldsZeroValue(t *testing.T) {
 	}
 	cache := newChatConfigCache(ctx, store, clock)
 
-	cfg, err := cache.AdvisorConfig(ctx)
+	cfg, err := cache.AdvisorConfig(ctx, cacheTestOrganizationID)
 	require.NoError(t, err)
 	require.Equal(t, codersdk.AdvisorConfig{}, cfg)
 }
 
 // Guards the pubsub-driven invalidation path. Without this, an admin
-// writing PUT /api/experimental/chats/config/advisor could keep every
+// writing an organization advisor configuration could keep every
 // replica serving stale enabled/model/limits for up to
 // chatConfigAdvisorConfigTTL, which defeats the subscriber in chatd.go.
 func TestConfigCache_InvalidateAdvisorConfig(t *testing.T) {
@@ -1117,12 +1140,12 @@ func TestConfigCache_InvalidateAdvisorConfig(t *testing.T) {
 	}
 	cache := newChatConfigCache(ctx, store, clock)
 
-	first, err := cache.AdvisorConfig(ctx)
+	first, err := cache.AdvisorConfig(ctx, cacheTestOrganizationID)
 	require.NoError(t, err)
 
-	cache.InvalidateAdvisorConfig()
+	cache.InvalidateAdvisorConfig(cacheTestOrganizationID)
 
-	second, err := cache.AdvisorConfig(ctx)
+	second, err := cache.AdvisorConfig(ctx, cacheTestOrganizationID)
 	require.NoError(t, err)
 
 	require.NotEqual(t, first.MaxUsesPerRun, second.MaxUsesPerRun,
@@ -1169,16 +1192,16 @@ func TestConfigCache_InvalidateAdvisorConfig_BlocksStaleInFlight(t *testing.T) {
 
 	firstResult := make(chan result, 1)
 	go func() {
-		config, err := cache.AdvisorConfig(ctx)
+		config, err := cache.AdvisorConfig(ctx, cacheTestOrganizationID)
 		firstResult <- result{config: config, err: err}
 	}()
 
 	waitForSignal(t, firstStarted)
-	cache.InvalidateAdvisorConfig()
+	cache.InvalidateAdvisorConfig(cacheTestOrganizationID)
 
 	secondResult := make(chan result, 1)
 	go func() {
-		config, err := cache.AdvisorConfig(ctx)
+		config, err := cache.AdvisorConfig(ctx, cacheTestOrganizationID)
 		secondResult <- result{config: config, err: err}
 	}()
 
@@ -1187,8 +1210,8 @@ func TestConfigCache_InvalidateAdvisorConfig_BlocksStaleInFlight(t *testing.T) {
 	first := <-firstResult
 	require.NoError(t, first.err)
 	require.EqualValues(t, 1, first.config.MaxUsesPerRun)
-	require.Nil(t, cache.advisorConfig,
-		"stale fill must not re-cache after invalidation")
+	_, ok := cache.advisorConfigs[cacheTestOrganizationID]
+	require.False(t, ok, "stale fill must not re-cache after invalidation")
 
 	close(releaseSecond)
 	second := <-secondResult
@@ -1196,7 +1219,7 @@ func TestConfigCache_InvalidateAdvisorConfig_BlocksStaleInFlight(t *testing.T) {
 	require.EqualValues(t, 2, second.config.MaxUsesPerRun)
 	require.Equal(t, int32(2), store.advisorConfigCalls.Load())
 
-	third, err := cache.AdvisorConfig(ctx)
+	third, err := cache.AdvisorConfig(ctx, cacheTestOrganizationID)
 	require.NoError(t, err)
 	require.EqualValues(t, 2, third.MaxUsesPerRun)
 	require.Equal(t, int32(2), store.advisorConfigCalls.Load())
@@ -1216,4 +1239,155 @@ func TestConfigCache_InvalidatesProvidersOnAIProvidersChangedEvent(t *testing.T)
 	require.Eventually(t, func() bool {
 		return server.configCache.providersGeneration() > gen
 	}, testutil.WaitShort, testutil.IntervalFast)
+}
+
+func TestConfigCache_DefaultModelConfig_OrganizationIsolation(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	clock := quartz.NewMock(t)
+	organizationA := uuid.New()
+	organizationB := uuid.New()
+	store := &stubChatConfigStore{
+		getDefaultModelConfigForOrganization: func(_ context.Context, organizationID uuid.UUID) (database.ChatModelConfig, error) {
+			switch organizationID {
+			case organizationA:
+				return testChatModelConfig(uuid.New(), "model-a"), nil
+			case organizationB:
+				return testChatModelConfig(uuid.New(), "model-b"), nil
+			default:
+				return database.ChatModelConfig{}, xerrors.New("unexpected organization")
+			}
+		},
+	}
+	cache := newChatConfigCache(ctx, store, clock)
+
+	firstA, err := cache.DefaultModelConfig(ctx, organizationA)
+	require.NoError(t, err)
+	firstB, err := cache.DefaultModelConfig(ctx, organizationB)
+	require.NoError(t, err)
+	secondA, err := cache.DefaultModelConfig(ctx, organizationA)
+	require.NoError(t, err)
+
+	require.Equal(t, "model-a", firstA.Model)
+	require.Equal(t, "model-b", firstB.Model)
+	require.Equal(t, firstA, secondA)
+	require.Equal(t, int32(2), store.defaultModelConfigCall.Load())
+}
+
+func TestConfigCache_InvalidateModelConfig_ScopesDefaultToOrganization(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	clock := quartz.NewMock(t)
+	organizationA := uuid.New()
+	organizationB := uuid.New()
+	modelA := testChatModelConfig(uuid.New(), "model-a")
+	modelB := testChatModelConfig(uuid.New(), "model-b")
+	store := &stubChatConfigStore{
+		getDefaultModelConfigForOrganization: func(_ context.Context, organizationID uuid.UUID) (database.ChatModelConfig, error) {
+			if organizationID == organizationA {
+				return modelA, nil
+			}
+			return modelB, nil
+		},
+	}
+	cache := newChatConfigCache(ctx, store, clock)
+
+	_, err := cache.DefaultModelConfig(ctx, organizationA)
+	require.NoError(t, err)
+	_, err = cache.DefaultModelConfig(ctx, organizationB)
+	require.NoError(t, err)
+
+	cache.InvalidateModelConfig(modelA.ID, organizationA)
+
+	_, err = cache.DefaultModelConfig(ctx, organizationA)
+	require.NoError(t, err)
+	_, err = cache.DefaultModelConfig(ctx, organizationB)
+	require.NoError(t, err)
+	require.Equal(t, int32(3), store.defaultModelConfigCall.Load())
+}
+
+func TestConfigCache_DefaultModelConfig_SingleflightDoesNotCrossOrganizations(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	clock := quartz.NewMock(t)
+	organizationA := uuid.New()
+	organizationB := uuid.New()
+	startedA := make(chan struct{})
+	startedB := make(chan struct{})
+	releaseA := make(chan struct{})
+	releaseB := make(chan struct{})
+	store := &stubChatConfigStore{
+		getDefaultModelConfigForOrganization: func(_ context.Context, organizationID uuid.UUID) (database.ChatModelConfig, error) {
+			switch organizationID {
+			case organizationA:
+				close(startedA)
+				<-releaseA
+				return testChatModelConfig(uuid.New(), "model-a"), nil
+			case organizationB:
+				close(startedB)
+				<-releaseB
+				return testChatModelConfig(uuid.New(), "model-b"), nil
+			default:
+				return database.ChatModelConfig{}, xerrors.New("unexpected organization")
+			}
+		},
+	}
+	cache := newChatConfigCache(ctx, store, clock)
+
+	results := make(chan error, 2)
+	go func() {
+		_, err := cache.DefaultModelConfig(ctx, organizationA)
+		results <- err
+	}()
+	go func() {
+		_, err := cache.DefaultModelConfig(ctx, organizationB)
+		results <- err
+	}()
+	waitForSignal(t, startedA)
+	waitForSignal(t, startedB)
+	close(releaseA)
+	close(releaseB)
+	require.NoError(t, <-results)
+	require.NoError(t, <-results)
+	require.Equal(t, int32(2), store.defaultModelConfigCall.Load())
+}
+
+func TestConfigCache_AdvisorConfig_OrganizationIsolation(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	clock := quartz.NewMock(t)
+	organizationA := uuid.New()
+	organizationB := uuid.New()
+	store := &stubChatConfigStore{
+		getChatAdvisorConfigForOrganization: func(_ context.Context, organizationID uuid.UUID) (string, error) {
+			switch organizationID {
+			case organizationA:
+				return `{"max_uses_per_run":1}`, nil
+			case organizationB:
+				return `{"max_uses_per_run":2}`, nil
+			default:
+				return "", xerrors.New("unexpected organization")
+			}
+		},
+	}
+	cache := newChatConfigCache(ctx, store, clock)
+
+	configA, err := cache.AdvisorConfig(ctx, organizationA)
+	require.NoError(t, err)
+	configB, err := cache.AdvisorConfig(ctx, organizationB)
+	require.NoError(t, err)
+	cache.InvalidateAdvisorConfig(organizationA)
+	_, err = cache.AdvisorConfig(ctx, organizationA)
+	require.NoError(t, err)
+	cachedB, err := cache.AdvisorConfig(ctx, organizationB)
+	require.NoError(t, err)
+
+	require.EqualValues(t, 1, configA.MaxUsesPerRun)
+	require.EqualValues(t, 2, configB.MaxUsesPerRun)
+	require.Equal(t, configB, cachedB)
+	require.Equal(t, int32(3), store.advisorConfigCalls.Load())
 }

--- a/coderd/x/chatd/configscope.go
+++ b/coderd/x/chatd/configscope.go
@@ -1,0 +1,51 @@
+package chatd
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func getChatModelOverrideForOrganization(ctx context.Context, store database.Store, organizationID uuid.UUID, overrideContext string) (string, error) {
+	switch overrideContext {
+	case string(codersdk.ChatModelOverrideContextGeneral):
+		return store.GetChatGeneralModelOverrideForOrganization(ctx, organizationID)
+	case string(codersdk.ChatModelOverrideContextExplore):
+		return store.GetChatExploreModelOverrideForOrganization(ctx, organizationID)
+	case titleGenerationOverrideContext:
+		return store.GetChatTitleGenerationModelOverrideForOrganization(ctx, organizationID)
+	case compactionOverrideContext:
+		return store.GetChatCompactionModelOverrideForOrganization(ctx, organizationID)
+	default:
+		return "", xerrors.Errorf("unsupported chat model override context %q", overrideContext)
+	}
+}
+
+func getUserChatPersonalModelOverrideForOrganization(
+	ctx context.Context,
+	store database.Store,
+	userID, organizationID uuid.UUID,
+	overrideContext codersdk.ChatPersonalModelOverrideContext,
+) (string, error) {
+	return store.GetUserChatPersonalModelOverrideForOrganization(ctx, database.GetUserChatPersonalModelOverrideForOrganizationParams{
+		UserID:         userID,
+		OrganizationID: organizationID,
+		Context:        string(overrideContext),
+	})
+}
+
+func getUserChatCompactionThresholdForOrganization(
+	ctx context.Context,
+	store database.Store,
+	userID, organizationID, modelConfigID uuid.UUID,
+) (string, error) {
+	return store.GetUserChatCompactionThresholdForOrganization(ctx, database.GetUserChatCompactionThresholdForOrganizationParams{
+		UserID:         userID,
+		OrganizationID: organizationID,
+		ModelConfigID:  modelConfigID,
+	})
+}

--- a/coderd/x/chatd/context_integration_test.go
+++ b/coderd/x/chatd/context_integration_test.go
@@ -66,7 +66,7 @@ func TestChatContextDirtyFromAgentPush(t *testing.T) {
 	// so the test exercises the context flow rather than turn resolution.
 	// dbgen.ChatModelConfig provisions an AI provider as needed so the chat's
 	// last_model_config_id foreign key is satisfied.
-	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{})
+	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{OrganizationID: user.OrganizationID})
 	chat := dbgen.Chat(t, db, database.Chat{
 		OrganizationID:    user.OrganizationID,
 		OwnerID:           user.UserID,
@@ -318,7 +318,7 @@ func TestChatContextRefreshFromAgentToken(t *testing.T) {
 
 	// A chat bound to the agent, plus an unrelated chat bound to no agent that
 	// must stay untouched by the agent-scoped refresh.
-	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{})
+	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{OrganizationID: user.OrganizationID})
 	chat := dbgen.Chat(t, db, database.Chat{
 		OrganizationID:    user.OrganizationID,
 		OwnerID:           user.UserID,

--- a/coderd/x/chatd/context_prompt_internal_test.go
+++ b/coderd/x/chatd/context_prompt_internal_test.go
@@ -377,7 +377,7 @@ func TestPinnedWorkspaceContextFromHydratedPin(t *testing.T) {
 		OperatingSystem: "linux",
 		Directory:       "/home/coder/ws",
 	})
-	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{})
+	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{OrganizationID: org.ID})
 
 	hash := []byte{0x01, 0x02, 0x03}
 	seedAgentContext(ctx, t, db, agent.ID, "/home/coder/ws/AGENTS.md", hash,

--- a/coderd/x/chatd/context_rebind_internal_test.go
+++ b/coderd/x/chatd/context_rebind_internal_test.go
@@ -256,7 +256,7 @@ func newRebindFixture(t *testing.T) rebindFixture {
 	agentB := dbgen.WorkspaceAgent(t, db, database.WorkspaceAgent{ResourceID: res.ID})
 	// A third agent that never pushes a snapshot, for the clear-only re-pin path.
 	agentNoSnap := dbgen.WorkspaceAgent(t, db, database.WorkspaceAgent{ResourceID: res.ID})
-	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{})
+	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{OrganizationID: org.ID})
 
 	fix := rebindFixture{
 		db:          db,

--- a/coderd/x/chatd/generation_preparer.go
+++ b/coderd/x/chatd/generation_preparer.go
@@ -117,7 +117,7 @@ func (server *Server) prepareGeneration(
 	}
 
 	planModeInstructions := server.loadPlanModeInstructions(ctx, currentPlanMode, logger)
-	advisorCfg := server.loadAdvisorConfig(ctx, logger)
+	advisorCfg := server.loadAdvisorConfig(ctx, chat.OrganizationID, logger)
 	// Force Enabled from the experiment; the stored DB value is ignored.
 	advisorCfg.Enabled = server.experiments.Enabled(codersdk.ExperimentChatAdvisor)
 
@@ -222,7 +222,7 @@ func (server *Server) prepareGeneration(
 	// (e.g. Bedrock and Anthropic) can still reject the other's
 	// provider-executed blocks, so a mid-chat provider switch must not replay
 	// them.
-	promptRows = server.sanitizeForeignProviderExecutedToolRows(ctx, logger, promptRows, modelConfig.ID)
+	promptRows = server.sanitizeForeignProviderExecutedToolRows(ctx, logger, promptRows, chat.OrganizationID, modelConfig.ID)
 
 	if chat.WorkspaceID.Valid {
 		// Resolve the workspace agent so the chat row's AgentID and
@@ -579,7 +579,7 @@ func (server *Server) prepareGeneration(
 
 	compactionToolCallID := "chat_summarized_" + uuid.NewString()
 	effectiveThreshold := modelConfig.CompressionThreshold
-	if override, ok := server.resolveUserCompactionThreshold(ctx, chat.OwnerID, modelConfig.ID); ok {
+	if override, ok := server.resolveUserCompactionThreshold(ctx, chat.OwnerID, chat.OrganizationID, modelConfig.ID); ok {
 		effectiveThreshold = override
 	}
 	// The compaction trigger uses the stricter of the chat and override

--- a/coderd/x/chatd/generation_preparer_internal_test.go
+++ b/coderd/x/chatd/generation_preparer_internal_test.go
@@ -108,9 +108,10 @@ func TestPrepareGenerationClampsRequestedReasoningEffortToMax(t *testing.T) {
 	})
 	require.NoError(t, err)
 	modelConfig := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-		Model:        "gpt-4o-mini",
-		Options:      modelConfigRaw,
-		AIProviderID: uuid.NullUUID{UUID: provider.ID, Valid: true},
+		OrganizationID: org.ID,
+		Model:          "gpt-4o-mini",
+		Options:        modelConfigRaw,
+		AIProviderID:   uuid.NullUUID{UUID: provider.ID, Valid: true},
 	}, func(p *database.InsertChatModelConfigParams) {
 		p.Enabled = true
 	})
@@ -173,8 +174,9 @@ func TestPrepareGenerationSubagentUsesOwnerSyntheticAPIKey(t *testing.T) {
 		Type: database.AIProviderTypeOpenai,
 	}, "test-key")
 	modelConfig := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-		Model:        "gpt-4o-mini",
-		AIProviderID: uuid.NullUUID{UUID: provider.ID, Valid: true},
+		OrganizationID: org.ID,
+		Model:          "gpt-4o-mini",
+		AIProviderID:   uuid.NullUUID{UUID: provider.ID, Valid: true},
 	}, func(p *database.InsertChatModelConfigParams) {
 		p.Enabled = true
 	})
@@ -254,9 +256,10 @@ func TestDeriveFinalTurnRunResult(t *testing.T) {
 			CreatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
 		})
 		modelCfg := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-			Model:       "gpt-4o-mini",
-			DisplayName: "gpt-4o-mini",
-			Options:     json.RawMessage(`{}`),
+			OrganizationID: org.ID,
+			Model:          "gpt-4o-mini",
+			DisplayName:    "gpt-4o-mini",
+			Options:        json.RawMessage(`{}`),
 		}, func(p *database.InsertChatModelConfigParams) {
 			p.Enabled = true
 			p.IsDefault = true
@@ -373,9 +376,10 @@ func TestDeriveFinalTurnRunResult(t *testing.T) {
 		// degraded path that still returns the re-derived text and IDs.
 		provider := insertInternalAIProvider(t, db, database.AIProviderTypeOpenai, "provider-api-key", false)
 		modelCfg := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-			Model:        "gpt-4o-mini",
-			DisplayName:  "gpt-4o-mini",
-			AIProviderID: uuid.NullUUID{UUID: provider.ID, Valid: true},
+			OrganizationID: org.ID,
+			Model:          "gpt-4o-mini",
+			DisplayName:    "gpt-4o-mini",
+			AIProviderID:   uuid.NullUUID{UUID: provider.ID, Valid: true},
 		})
 
 		created, err := chatstate.CreateChat(ctx, db, ps, chatstate.CreateChatInput{

--- a/coderd/x/chatd/helpers_test.go
+++ b/coderd/x/chatd/helpers_test.go
@@ -125,7 +125,8 @@ func newWorkerTestFixture(t *testing.T) *workerTestFixture {
 		BaseUrl:     "http://example.invalid",
 	})
 	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-		IsDefault: true,
+		OrganizationID: org.ID,
+		IsDefault:      true,
 	})
 	apiKey, _ := dbgen.APIKey(t, db, database.APIKey{UserID: user.ID})
 	return &workerTestFixture{db: db, pubsub: ps, sqlDB: sqlDB, user: user, org: org, model: model, apiKey: apiKey}

--- a/coderd/x/chatd/integration_responses_test.go
+++ b/coderd/x/chatd/integration_responses_test.go
@@ -63,7 +63,7 @@ func TestOpenAIResponsesNoStaleWebSearchReplay(t *testing.T) {
 	})
 
 	user, org, _ := seedChatDependenciesWithProvider(t, db, "openai", openAIURL)
-	model := insertOpenAIResponsesModelConfig(t, db, user.ID, false, true)
+	model := insertOpenAIResponsesModelConfig(t, db, org.ID, user.ID, false, true)
 	factory := chattest.NewMockAIBridgeTransport(t, openAIURL)
 	server := newOpenAIResponsesTestServer(t, db, ps, func(cfg *chatd.Config) {
 		cfg.AIBridgeTransportFactory = chatAIGatewayTransportFactoryPointer(factory)
@@ -147,8 +147,8 @@ func TestOpenAIResponsesFullReplayPairsReasoningAndWebSearch(t *testing.T) {
 	})
 
 	user, org, _ := seedChatDependenciesWithProvider(t, db, "openai", openAIURL)
-	firstModel := insertOpenAIResponsesModelConfig(t, db, user.ID, true, true)
-	secondModel := insertOpenAIResponsesModelConfig(t, db, user.ID, true, true)
+	firstModel := insertOpenAIResponsesModelConfig(t, db, org.ID, user.ID, true, true)
+	secondModel := insertOpenAIResponsesModelConfig(t, db, org.ID, user.ID, true, true)
 	factory := chattest.NewMockAIBridgeTransport(t, openAIURL)
 	server := newOpenAIResponsesTestServer(t, db, ps, func(cfg *chatd.Config) {
 		cfg.AIBridgeTransportFactory = chatAIGatewayTransportFactoryPointer(factory)
@@ -242,6 +242,7 @@ func newOpenAIResponsesTestServer(
 func insertOpenAIResponsesModelConfig(
 	t *testing.T,
 	db database.Store,
+	organizationID uuid.UUID,
 	userID uuid.UUID,
 	store bool,
 	webSearchEnabled bool,
@@ -250,6 +251,7 @@ func insertOpenAIResponsesModelConfig(
 	return insertChatModelConfigWithCallConfig(
 		t,
 		db,
+		organizationID,
 		userID,
 		"openai",
 		"gpt-4o",

--- a/coderd/x/chatd/integration_test.go
+++ b/coderd/x/chatd/integration_test.go
@@ -97,7 +97,7 @@ func TestAnthropicWebSearchRoundTrip(t *testing.T) {
 	// Create a model config that enables web_search.
 	contextLimit := int64(200000)
 	isDefault := true
-	_, err := expClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+	_, err := expClient.CreateChatModelConfig(ctx, user.OrganizationID, codersdk.CreateChatModelConfigRequest{
 		AIProviderID: &provider.ID,
 		Model:        "claude-sonnet-4-20250514",
 		ContextLimit: &contextLimit,
@@ -355,7 +355,7 @@ func TestOpenAIReasoningRoundTrip(t *testing.T) {
 	contextLimit := int64(200000)
 	isDefault := true
 	reasoningSummary := "auto"
-	_, err := expClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+	_, err := expClient.CreateChatModelConfig(ctx, user.OrganizationID, codersdk.CreateChatModelConfigRequest{
 		AIProviderID: &provider.ID,
 		Model:        "o4-mini",
 		ContextLimit: &contextLimit,
@@ -504,7 +504,7 @@ func TestOpenAIReasoningRoundTripStoreFalse(t *testing.T) {
 	contextLimit := int64(200000)
 	isDefault := true
 	reasoningSummary := "auto"
-	_, err := expClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+	_, err := expClient.CreateChatModelConfig(ctx, user.OrganizationID, codersdk.CreateChatModelConfigRequest{
 		AIProviderID: &provider.ID,
 		Model:        "o4-mini",
 		ContextLimit: &contextLimit,

--- a/coderd/x/chatd/personal_model_override.go
+++ b/coderd/x/chatd/personal_model_override.go
@@ -9,18 +9,10 @@ import (
 )
 
 // ChatPersonalModelOverrideKeyPrefix is the user config key prefix for
-// chat personal model overrides. Values under this prefix should be parsed
-// with ParseChatPersonalModelOverride so malformed values use one fallback.
+// organization-scoped chat personal model overrides. Values under this prefix
+// should be parsed with ParseChatPersonalModelOverride so malformed values use
+// one fallback.
 const ChatPersonalModelOverrideKeyPrefix = "chat_personal_model_override:"
-
-// ChatPersonalModelOverrideKey returns the user config key for a chat
-// personal model override context. Values stored at the returned key should
-// use ParseChatPersonalModelOverride so malformed values fall back safely.
-func ChatPersonalModelOverrideKey(
-	overrideContext codersdk.ChatPersonalModelOverrideContext,
-) string {
-	return ChatPersonalModelOverrideKeyPrefix + string(overrideContext)
-}
 
 // ParsedChatPersonalModelOverride is a parsed personal model override value.
 // When Malformed is true, Mode is the provided default and ModelConfigID is

--- a/coderd/x/chatd/personal_model_override_test.go
+++ b/coderd/x/chatd/personal_model_override_test.go
@@ -11,16 +11,6 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 )
 
-func TestChatPersonalModelOverrideKey(t *testing.T) {
-	t.Parallel()
-
-	require.Equal(
-		t,
-		"chat_personal_model_override:root",
-		chatd.ChatPersonalModelOverrideKey(codersdk.ChatPersonalModelOverrideContextRoot),
-	)
-}
-
 func TestParseChatPersonalModelOverride(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/x/chatd/provider_switch_sanitize.go
+++ b/coderd/x/chatd/provider_switch_sanitize.go
@@ -105,9 +105,10 @@ func (server *Server) sanitizeForeignProviderExecutedToolRows(
 	ctx context.Context,
 	logger slog.Logger,
 	rows []database.ChatMessage,
+	organizationID uuid.UUID,
 	modelConfigID uuid.UUID,
 ) []database.ChatMessage {
-	targetCfg, targetProvider, err := server.resolveModelConfigAndNormalizedProvider(ctx, modelConfigID)
+	targetCfg, targetProvider, err := server.resolveModelConfigAndNormalizedProvider(ctx, organizationID, modelConfigID)
 	if err != nil || targetProvider == "" {
 		logger.Debug(ctx, "skipping provider-switch sanitization: target provider unresolved",
 			slog.F("model_config_id", modelConfigID),
@@ -125,7 +126,7 @@ func (server *Server) sanitizeForeignProviderExecutedToolRows(
 		if identity, seen := cache[id.UUID]; seen {
 			return identity, identity != ""
 		}
-		originCfg, provider, rErr := server.resolveModelConfigAndNormalizedProvider(ctx, id.UUID)
+		originCfg, provider, rErr := server.resolveModelConfigAndNormalizedProvider(ctx, organizationID, id.UUID)
 		if rErr != nil {
 			logger.Debug(ctx, "provider-switch sanitization: origin provider unresolved, treating as foreign",
 				slog.F("model_config_id", id.UUID),

--- a/coderd/x/chatd/quickgen_internal_test.go
+++ b/coderd/x/chatd/quickgen_internal_test.go
@@ -545,7 +545,8 @@ func TestMaybeGenerateChatTitlePreservesUpdatedAt(t *testing.T) {
 		CentralApiKeyEnabled: true,
 	})
 	modelConfig := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-		Model: "test-model",
+		OrganizationID: org.ID,
+		Model:          "test-model",
 	})
 
 	userPrompt := "summarize failed workspace build logs"
@@ -642,7 +643,7 @@ func TestMaybeGenerateChatTitleAppliesModelConfigReasoningEffort(t *testing.T) {
 	}
 
 	db := dbmock.NewMockStore(gomock.NewController(t))
-	db.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return("", nil)
+	db.EXPECT().GetChatTitleGenerationModelOverrideForOrganization(gomock.Any(), chat.OrganizationID).Return("", nil)
 	db.EXPECT().UpdateChatTitleByID(gomock.Any(), database.UpdateChatTitleByIDParams{
 		ID:    chat.ID,
 		Title: "Reasoning title",

--- a/coderd/x/chatd/subagent.go
+++ b/coderd/x/chatd/subagent.go
@@ -129,19 +129,10 @@ func subagentModelOverrideLogLabel(
 func readSubagentModelOverride(
 	ctx context.Context,
 	db database.Store,
+	organizationID uuid.UUID,
 	overrideContext codersdk.ChatModelOverrideContext,
 ) (string, error) {
-	switch overrideContext {
-	case codersdk.ChatModelOverrideContextGeneral:
-		return db.GetChatGeneralModelOverride(ctx)
-	case codersdk.ChatModelOverrideContextExplore:
-		return db.GetChatExploreModelOverride(ctx)
-	default:
-		return "", xerrors.Errorf(
-			"unsupported subagent model override context %q",
-			overrideContext,
-		)
-	}
+	return getChatModelOverrideForOrganization(ctx, db, organizationID, string(overrideContext))
 }
 
 func personalModelOverrideContextForSubagent(
@@ -291,6 +282,7 @@ func (p *Server) resolveConfiguredModelOverride(
 
 func (p *Server) resolvePersonalSubagentModelConfigID(
 	ctx context.Context,
+	organizationID uuid.UUID,
 	ownerID uuid.UUID,
 	overrideContext codersdk.ChatModelOverrideContext,
 ) (uuid.UUID, *string, bool, error) {
@@ -298,12 +290,12 @@ func (p *Server) resolvePersonalSubagentModelConfigID(
 	if err != nil {
 		return uuid.Nil, nil, false, err
 	}
-	raw, err := p.db.GetUserChatPersonalModelOverride(
+	raw, err := getUserChatPersonalModelOverrideForOrganization(
 		ctx,
-		database.GetUserChatPersonalModelOverrideParams{
-			UserID: ownerID,
-			Key:    ChatPersonalModelOverrideKey(personalContext),
-		},
+		p.db,
+		ownerID,
+		organizationID,
+		personalContext,
 	)
 	if err != nil {
 		if !xerrors.Is(err, sql.ErrNoRows) {
@@ -335,6 +327,7 @@ func (p *Server) resolvePersonalSubagentModelConfigID(
 	case codersdk.ChatPersonalModelOverrideModeModel:
 		modelConfig, ok, err := p.resolvePersonalModelOverride(
 			ctx,
+			organizationID,
 			overrideContext,
 			ownerID,
 			parsed.ModelConfigID,
@@ -359,12 +352,14 @@ func (p *Server) resolvePersonalSubagentModelConfigID(
 
 func (p *Server) resolvePersonalModelOverride(
 	ctx context.Context,
+	organizationID uuid.UUID,
 	overrideContext codersdk.ChatModelOverrideContext,
 	ownerID uuid.UUID,
 	modelConfigID uuid.UUID,
 ) (database.ChatModelConfig, bool, error) {
 	modelConfig, providerName, err := p.resolveModelConfigAndNormalizedProvider(
 		ctx,
+		organizationID,
 		modelConfigID,
 	)
 	if err != nil {
@@ -449,6 +444,7 @@ func withResolvedReasoningEffort(
 
 func (p *Server) resolveSubagentModelConfigID(
 	ctx context.Context,
+	organizationID uuid.UUID,
 	ownerID uuid.UUID,
 	overrideContext codersdk.ChatModelOverrideContext,
 ) (uuid.UUID, *string, error) {
@@ -464,6 +460,7 @@ func (p *Server) resolveSubagentModelConfigID(
 	if personalOverridesEnabled {
 		modelConfigID, reasoningEffort, resolved, err := p.resolvePersonalSubagentModelConfigID(
 			chatdCtx,
+			organizationID,
 			ownerID,
 			overrideContext,
 		)
@@ -475,7 +472,7 @@ func (p *Server) resolveSubagentModelConfigID(
 		}
 	}
 
-	raw, err := readSubagentModelOverride(chatdCtx, p.db, overrideContext)
+	raw, err := readSubagentModelOverride(chatdCtx, p.db, organizationID, overrideContext)
 	if err != nil {
 		return uuid.Nil, nil, xerrors.Errorf(
 			"get %s model override: %w",
@@ -488,7 +485,9 @@ func (p *Server) resolveSubagentModelConfigID(
 		string(overrideContext),
 		raw,
 		ownerID,
-		p.resolveModelConfigAndNormalizedProvider,
+		func(ctx context.Context, modelConfigID uuid.UUID) (database.ChatModelConfig, string, error) {
+			return p.resolveModelConfigAndNormalizedProvider(ctx, organizationID, modelConfigID)
+		},
 		p.resolveUserProviderAPIKeys,
 		modelOverrideFailureModeSoft,
 	)
@@ -510,12 +509,13 @@ func modelConfigAIProviderID(modelConfig database.ChatModelConfig) uuid.UUID {
 
 func (p *Server) resolveModelConfigAndNormalizedProvider(
 	ctx context.Context,
+	organizationID uuid.UUID,
 	modelConfigID uuid.UUID,
 ) (database.ChatModelConfig, string, error) {
 	if modelConfigID == uuid.Nil {
 		return database.ChatModelConfig{}, "", sql.ErrNoRows
 	}
-	modelConfig, err := p.configCache.ModelConfigByID(ctx, modelConfigID)
+	modelConfig, err := p.configCache.ModelConfigByID(ctx, organizationID, modelConfigID)
 	if err != nil {
 		return database.ChatModelConfig{}, "", err
 	}

--- a/coderd/x/chatd/subagent_catalog.go
+++ b/coderd/x/chatd/subagent_catalog.go
@@ -58,6 +58,7 @@ func allSubagentDefinitions() []subagentDefinition {
 			buildOptions: func(ctx context.Context, p *Server, parent database.Chat, _ database.Chat, _ uuid.UUID, _ string) (childSubagentChatOptions, error) {
 				modelConfigID, reasoningEffort, err := p.resolveSubagentModelConfigID(
 					ctx,
+					parent.OrganizationID,
 					parent.OwnerID,
 					codersdk.ChatModelOverrideContextGeneral,
 				)
@@ -78,6 +79,7 @@ func allSubagentDefinitions() []subagentDefinition {
 			buildOptions: func(ctx context.Context, p *Server, _ database.Chat, turnParent database.Chat, currentModelConfigID uuid.UUID, _ string) (childSubagentChatOptions, error) {
 				modelConfigID, reasoningEffort, err := p.resolveSubagentModelConfigID(
 					ctx,
+					turnParent.OrganizationID,
 					turnParent.OwnerID,
 					codersdk.ChatModelOverrideContextExplore,
 				)

--- a/coderd/x/chatd/subagent_internal_test.go
+++ b/coderd/x/chatd/subagent_internal_test.go
@@ -227,8 +227,9 @@ func seedInternalChatDeps(
 	})
 
 	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-		AIProviderID: uuid.NullUUID{UUID: provider.ID, Valid: true},
-		IsDefault:    true,
+		OrganizationID: org.ID,
+		AIProviderID:   uuid.NullUUID{UUID: provider.ID, Valid: true},
+		IsDefault:      true,
 	})
 
 	return user, org, model
@@ -374,7 +375,8 @@ func TestResolveChatModel_AIProviderDisabled(t *testing.T) {
 	user, org, _ := seedInternalChatDeps(t, db)
 	provider := insertInternalAIProvider(t, db, database.AIProviderTypeOpenai, "provider-api-key", false)
 	modelConfig := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-		Model: "gpt-4o-mini",
+		OrganizationID: org.ID,
+		Model:          "gpt-4o-mini",
 		AIProviderID: uuid.NullUUID{
 			UUID:  provider.ID,
 			Valid: true,
@@ -439,12 +441,14 @@ func TestResolveUserProviderAPIKeys_PreservesAnthropicKeyFromDBProvider(t *testi
 func insertInternalChatModelConfig(
 	t *testing.T,
 	db database.Store,
+	organizationID uuid.UUID,
 	model string,
 	enabled bool,
 ) database.ChatModelConfig {
 	return insertInternalChatModelConfigForProvider(
 		t,
 		db,
+		organizationID,
 		"openai",
 		model,
 		enabled,
@@ -481,6 +485,7 @@ func insertInternalChatProvider(
 func insertInternalChatModelConfigForProvider(
 	t *testing.T,
 	db database.Store,
+	organizationID uuid.UUID,
 	provider string,
 	model string,
 	enabled bool,
@@ -489,6 +494,7 @@ func insertInternalChatModelConfigForProvider(
 	return insertInternalChatModelConfigWithOptions(
 		t,
 		db,
+		organizationID,
 		provider,
 		model,
 		enabled,
@@ -499,6 +505,7 @@ func insertInternalChatModelConfigForProvider(
 func insertInternalChatModelConfigWithOptions(
 	t *testing.T,
 	db database.Store,
+	organizationID uuid.UUID,
 	provider string,
 	model string,
 	enabled bool,
@@ -526,10 +533,11 @@ func insertInternalChatModelConfigWithOptions(
 		})
 	}
 	modelConfig := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-		AIProviderID: uuid.NullUUID{UUID: aiProvider.ID, Valid: true},
-		Model:        model,
-		DisplayName:  model,
-		Options:      options,
+		OrganizationID: organizationID,
+		AIProviderID:   uuid.NullUUID{UUID: aiProvider.ID, Valid: true},
+		Model:          model,
+		DisplayName:    model,
+		Options:        options,
 	}, func(p *database.InsertChatModelConfigParams) {
 		p.Enabled = enabled
 	})
@@ -634,18 +642,20 @@ func upsertInternalUserChatPersonalModelOverride(
 	t *testing.T,
 	db database.Store,
 	userID uuid.UUID,
+	organizationID uuid.UUID,
 	overrideContext codersdk.ChatPersonalModelOverrideContext,
 	raw string,
 ) {
 	t.Helper()
 	require.NoError(
 		t,
-		db.UpsertUserChatPersonalModelOverride(
+		db.UpsertUserChatPersonalModelOverrideForOrganization(
 			systemRestrictedTestContext(t),
-			database.UpsertUserChatPersonalModelOverrideParams{
-				UserID: userID,
-				Key:    ChatPersonalModelOverrideKey(overrideContext),
-				Value:  raw,
+			database.UpsertUserChatPersonalModelOverrideForOrganizationParams{
+				UserID:         userID,
+				OrganizationID: organizationID,
+				Context:        string(overrideContext),
+				Value:          raw,
 			},
 		),
 	)
@@ -891,9 +901,9 @@ func TestSpawnAgent_GeneralUsesConfiguredModelOverride(t *testing.T) {
 	ctx := chatdTestContext(t)
 	user, org, model := seedInternalChatDeps(t, db)
 	overrideModel := insertInternalChatModelConfig(
-		t, db, "general-override-"+uuid.NewString(), true,
+		t, db, org.ID, "general-override-"+uuid.NewString(), true,
 	)
-	require.NoError(t, db.UpsertChatGeneralModelOverride(ctx, overrideModel.ID.String()))
+	require.NoError(t, db.UpsertChatGeneralModelOverrideForOrganization(ctx, database.UpsertChatGeneralModelOverrideForOrganizationParams{OrganizationID: org.ID, ModelConfigID: overrideModel.ID.String()}))
 	parentChat := createInternalParentChat(
 		ctx, t, server, db, org.ID, user.ID, model.ID, "parent-general-override",
 	)
@@ -917,7 +927,7 @@ func TestSpawnAgent_GeneralHonorsPersonalModelOverrides(t *testing.T) {
 		name                   string
 		enablePersonalOverride bool
 		personalRaw            func(database.ChatModelConfig) string
-		personalModel          func(context.Context, *testing.T, database.Store, uuid.UUID) database.ChatModelConfig
+		personalModel          func(context.Context, *testing.T, database.Store, uuid.UUID, uuid.UUID) database.ChatModelConfig
 		wantModelID            func(
 			database.ChatModelConfig,
 			database.ChatModelConfig,
@@ -979,10 +989,12 @@ func TestSpawnAgent_GeneralHonorsPersonalModelOverrides(t *testing.T) {
 				t *testing.T,
 				db database.Store,
 				userID uuid.UUID,
+				organizationID uuid.UUID,
 			) database.ChatModelConfig {
 				return insertInternalChatModelConfig(
 					t,
 					db,
+					organizationID,
 					"general-personal-disabled-"+uuid.NewString(),
 					false,
 				)
@@ -1003,6 +1015,7 @@ func TestSpawnAgent_GeneralHonorsPersonalModelOverrides(t *testing.T) {
 				t *testing.T,
 				db database.Store,
 				userID uuid.UUID,
+				organizationID uuid.UUID,
 			) database.ChatModelConfig {
 				insertInternalChatProvider(
 					t,
@@ -1017,6 +1030,7 @@ func TestSpawnAgent_GeneralHonorsPersonalModelOverrides(t *testing.T) {
 				return insertInternalChatModelConfigForProvider(
 					t,
 					db,
+					organizationID,
 					"openai-compat",
 					"gpt-4o-mini",
 					true,
@@ -1054,18 +1068,20 @@ func TestSpawnAgent_GeneralHonorsPersonalModelOverrides(t *testing.T) {
 			deploymentModel := insertInternalChatModelConfig(
 				t,
 				db,
+				org.ID,
 				"general-deployment-"+uuid.NewString(),
 				true,
 			)
-			require.NoError(t, db.UpsertChatGeneralModelOverride(ctx, deploymentModel.ID.String()))
+			require.NoError(t, db.UpsertChatGeneralModelOverrideForOrganization(ctx, database.UpsertChatGeneralModelOverrideForOrganizationParams{OrganizationID: org.ID, ModelConfigID: deploymentModel.ID.String()}))
 			personalModel := insertInternalChatModelConfig(
 				t,
 				db,
+				org.ID,
 				"general-personal-"+uuid.NewString(),
 				true,
 			)
 			if tt.personalModel != nil {
-				personalModel = tt.personalModel(ctx, t, db, user.ID)
+				personalModel = tt.personalModel(ctx, t, db, user.ID, org.ID)
 			}
 			if tt.enablePersonalOverride {
 				enableInternalChatPersonalModelOverrides(t, db)
@@ -1075,6 +1091,7 @@ func TestSpawnAgent_GeneralHonorsPersonalModelOverrides(t *testing.T) {
 					t,
 					db,
 					user.ID,
+					org.ID,
 					codersdk.ChatPersonalModelOverrideContextGeneral,
 					tt.personalRaw(personalModel),
 				)
@@ -1132,11 +1149,12 @@ func TestSpawnAgent_GeneralOverrideLogsAndFallsBackWhenCredentialsUnavailable(t 
 	overrideModel := insertInternalChatModelConfigForProvider(
 		t,
 		db,
+		org.ID,
 		"openai-compat",
 		"gpt-4o-mini",
 		true,
 	)
-	require.NoError(t, db.UpsertChatGeneralModelOverride(ctx, overrideModel.ID.String()))
+	require.NoError(t, db.UpsertChatGeneralModelOverrideForOrganization(ctx, database.UpsertChatGeneralModelOverrideForOrganizationParams{OrganizationID: org.ID, ModelConfigID: overrideModel.ID.String()}))
 	parent, err := server.CreateChat(ctx, CreateOptions{
 		OrganizationID: org.ID,
 		OwnerID:        user.ID,
@@ -1201,11 +1219,12 @@ func TestSpawnAgent_GeneralOverrideLogsAndFallsBackWhenProviderDisabled(t *testi
 	overrideModel := insertInternalChatModelConfigForProvider(
 		t,
 		db,
+		org.ID,
 		"openai-compat",
 		"gpt-4o-mini",
 		true,
 	)
-	require.NoError(t, db.UpsertChatGeneralModelOverride(ctx, overrideModel.ID.String()))
+	require.NoError(t, db.UpsertChatGeneralModelOverrideForOrganization(ctx, database.UpsertChatGeneralModelOverrideForOrganizationParams{OrganizationID: org.ID, ModelConfigID: overrideModel.ID.String()}))
 	parent, err := server.CreateChat(ctx, CreateOptions{
 		OrganizationID: org.ID,
 		OwnerID:        user.ID,
@@ -1364,7 +1383,7 @@ func TestCreateChildSubagentChat_OverrideWorksWhenParentHasNoModel(t *testing.T)
 	ctx := chatdTestContext(t)
 	user, org, model := seedInternalChatDeps(t, db)
 	overrideModel := insertInternalChatModelConfig(
-		t, db, "override-no-parent-model-"+uuid.NewString(), true,
+		t, db, org.ID, "override-no-parent-model-"+uuid.NewString(), true,
 	)
 	parentChat := createInternalParentChat(
 		ctx, t, server, db, org.ID, user.ID, model.ID, "parent-no-model",
@@ -1396,9 +1415,9 @@ func TestSpawnAgent_ExploreUsesConfiguredModelOverride(t *testing.T) {
 	ctx := chatdTestContext(t)
 	user, org, model := seedInternalChatDeps(t, db)
 	overrideModel := insertInternalChatModelConfig(
-		t, db, "explore-override-"+uuid.NewString(), true,
+		t, db, org.ID, "explore-override-"+uuid.NewString(), true,
 	)
-	require.NoError(t, db.UpsertChatExploreModelOverride(ctx, overrideModel.ID.String()))
+	require.NoError(t, db.UpsertChatExploreModelOverrideForOrganization(ctx, database.UpsertChatExploreModelOverrideForOrganizationParams{OrganizationID: org.ID, ModelConfigID: overrideModel.ID.String()}))
 	parentChat := createInternalParentChat(
 		ctx, t, server, db, org.ID, user.ID, model.ID, "parent-explore-override",
 	)
@@ -1434,7 +1453,7 @@ func TestSpawnAgent_ExploreFallsBackToCurrentTurnModel(t *testing.T) {
 	ctx := chatdTestContext(t)
 	user, org, parentModel := seedInternalChatDeps(t, db)
 	currentTurnModel := insertInternalChatModelConfig(
-		t, db, "explore-current-turn-"+uuid.NewString(), true,
+		t, db, org.ID, "explore-current-turn-"+uuid.NewString(), true,
 	)
 	parentChat := createInternalParentChat(
 		ctx, t, server, db, org.ID, user.ID, parentModel.ID, "parent-explore-fallback",
@@ -1464,7 +1483,7 @@ func TestSpawnAgent_ExploreHonorsPersonalModelOverrides(t *testing.T) {
 		name                   string
 		enablePersonalOverride bool
 		personalRaw            func(database.ChatModelConfig) string
-		personalModel          func(context.Context, *testing.T, database.Store, uuid.UUID) database.ChatModelConfig
+		personalModel          func(context.Context, *testing.T, database.Store, uuid.UUID, uuid.UUID) database.ChatModelConfig
 		wantModelID            func(
 			database.ChatModelConfig,
 			database.ChatModelConfig,
@@ -1527,10 +1546,12 @@ func TestSpawnAgent_ExploreHonorsPersonalModelOverrides(t *testing.T) {
 				t *testing.T,
 				db database.Store,
 				userID uuid.UUID,
+				organizationID uuid.UUID,
 			) database.ChatModelConfig {
 				return insertInternalChatModelConfig(
 					t,
 					db,
+					organizationID,
 					"explore-personal-disabled-"+uuid.NewString(),
 					false,
 				)
@@ -1551,6 +1572,7 @@ func TestSpawnAgent_ExploreHonorsPersonalModelOverrides(t *testing.T) {
 				t *testing.T,
 				db database.Store,
 				userID uuid.UUID,
+				organizationID uuid.UUID,
 			) database.ChatModelConfig {
 				insertInternalChatProvider(
 					t,
@@ -1565,6 +1587,7 @@ func TestSpawnAgent_ExploreHonorsPersonalModelOverrides(t *testing.T) {
 				return insertInternalChatModelConfigForProvider(
 					t,
 					db,
+					organizationID,
 					"openai-compat",
 					"gpt-4o-mini",
 					true,
@@ -1602,24 +1625,27 @@ func TestSpawnAgent_ExploreHonorsPersonalModelOverrides(t *testing.T) {
 			currentTurnModel := insertInternalChatModelConfig(
 				t,
 				db,
+				org.ID,
 				"explore-current-turn-"+uuid.NewString(),
 				true,
 			)
 			deploymentModel := insertInternalChatModelConfig(
 				t,
 				db,
+				org.ID,
 				"explore-deployment-"+uuid.NewString(),
 				true,
 			)
-			require.NoError(t, db.UpsertChatExploreModelOverride(ctx, deploymentModel.ID.String()))
+			require.NoError(t, db.UpsertChatExploreModelOverrideForOrganization(ctx, database.UpsertChatExploreModelOverrideForOrganizationParams{OrganizationID: org.ID, ModelConfigID: deploymentModel.ID.String()}))
 			personalModel := insertInternalChatModelConfig(
 				t,
 				db,
+				org.ID,
 				"explore-personal-"+uuid.NewString(),
 				true,
 			)
 			if tt.personalModel != nil {
-				personalModel = tt.personalModel(ctx, t, db, user.ID)
+				personalModel = tt.personalModel(ctx, t, db, user.ID, org.ID)
 			}
 			if tt.enablePersonalOverride {
 				enableInternalChatPersonalModelOverrides(t, db)
@@ -1629,6 +1655,7 @@ func TestSpawnAgent_ExploreHonorsPersonalModelOverrides(t *testing.T) {
 					t,
 					db,
 					user.ID,
+					org.ID,
 					codersdk.ChatPersonalModelOverrideContextExplore,
 					tt.personalRaw(personalModel),
 				)
@@ -1909,9 +1936,9 @@ func TestSpawnAgent_ExploreFallsBackOnInvalidUUID(t *testing.T) {
 	ctx := chatdTestContext(t)
 	user, org, parentModel := seedInternalChatDeps(t, db)
 	currentTurnModel := insertInternalChatModelConfig(
-		t, db, "explore-invalid-override-"+uuid.NewString(), true,
+		t, db, org.ID, "explore-invalid-override-"+uuid.NewString(), true,
 	)
-	require.NoError(t, db.UpsertChatExploreModelOverride(ctx, "not-a-uuid"))
+	require.NoError(t, db.UpsertChatExploreModelOverrideForOrganization(ctx, database.UpsertChatExploreModelOverrideForOrganizationParams{OrganizationID: org.ID, ModelConfigID: "not-a-uuid"}))
 	parentChat := createInternalParentChat(
 		ctx, t, server, db, org.ID, user.ID, parentModel.ID, "parent-explore-invalid-override",
 	)
@@ -1941,12 +1968,12 @@ func TestSpawnAgent_ExploreFallsBackWhenOverrideIsUnavailable(t *testing.T) {
 	ctx := chatdTestContext(t)
 	user, org, parentModel := seedInternalChatDeps(t, db)
 	currentTurnModel := insertInternalChatModelConfig(
-		t, db, "explore-fallback-current-"+uuid.NewString(), true,
+		t, db, org.ID, "explore-fallback-current-"+uuid.NewString(), true,
 	)
 	disabledModel := insertInternalChatModelConfig(
-		t, db, "explore-disabled-"+uuid.NewString(), false,
+		t, db, org.ID, "explore-disabled-"+uuid.NewString(), false,
 	)
-	require.NoError(t, db.UpsertChatExploreModelOverride(ctx, disabledModel.ID.String()))
+	require.NoError(t, db.UpsertChatExploreModelOverrideForOrganization(ctx, database.UpsertChatExploreModelOverrideForOrganizationParams{OrganizationID: org.ID, ModelConfigID: disabledModel.ID.String()}))
 	parentChat := createInternalParentChat(
 		ctx, t, server, db, org.ID, user.ID, parentModel.ID, "parent-explore-disabled",
 	)
@@ -1976,7 +2003,7 @@ func TestSpawnAgent_ExploreFallsBackWhenOverrideCredentialsAreUnavailable(t *tes
 	ctx := chatdTestContext(t)
 	user, org, parentModel := seedInternalChatDeps(t, db)
 	currentTurnModel := insertInternalChatModelConfig(
-		t, db, "explore-missing-user-key-current-"+uuid.NewString(), true,
+		t, db, org.ID, "explore-missing-user-key-current-"+uuid.NewString(), true,
 	)
 	overrideProvider := dbgen.ChatProvider(t, db, database.ChatProvider{
 		Provider:    "openai-compat",
@@ -1989,11 +2016,12 @@ func TestSpawnAgent_ExploreFallsBackWhenOverrideCredentialsAreUnavailable(t *tes
 	})
 
 	overrideModel := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-		AIProviderID: uuid.NullUUID{UUID: overrideProvider.ID, Valid: true},
-		Model:        "gpt-4o-mini",
-		DisplayName:  "Explore Override Missing User Key",
+		OrganizationID: org.ID,
+		AIProviderID:   uuid.NullUUID{UUID: overrideProvider.ID, Valid: true},
+		Model:          "gpt-4o-mini",
+		DisplayName:    "Explore Override Missing User Key",
 	})
-	require.NoError(t, db.UpsertChatExploreModelOverride(ctx, overrideModel.ID.String()))
+	require.NoError(t, db.UpsertChatExploreModelOverrideForOrganization(ctx, database.UpsertChatExploreModelOverrideForOrganizationParams{OrganizationID: org.ID, ModelConfigID: overrideModel.ID.String()}))
 	parentChat := createInternalParentChat(
 		ctx, t, server, db, org.ID, user.ID, parentModel.ID, "parent-explore-missing-user-key",
 	)
@@ -2260,6 +2288,7 @@ func TestSpawnAgent_ComputerUseRejectsMissingConfiguredProvider(t *testing.T) {
 	model := insertInternalChatModelConfigForProvider(
 		t,
 		db,
+		org.ID,
 		string(codersdk.ChatComputerUseProviderOpenAI),
 		"gpt-4o-mini",
 		true,
@@ -3527,8 +3556,9 @@ func TestAwaitSubagentCompletion(t *testing.T) {
 			BaseUrl:     providerServer.URL,
 		})
 		model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-			Model:        "gpt-4o-mini",
-			AIProviderID: uuid.NullUUID{UUID: provider.ID, Valid: true},
+			OrganizationID: org.ID,
+			Model:          "gpt-4o-mini",
+			AIProviderID:   uuid.NullUUID{UUID: provider.ID, Valid: true},
 		})
 
 		parent, child := createParentChildChats(ctx, t, server, user, org, model)

--- a/coderd/x/chatd/synthetickey_internal_test.go
+++ b/coderd/x/chatd/synthetickey_internal_test.go
@@ -207,7 +207,7 @@ func TestSyntheticAPIKeyDeletionDoesNotMutateChatState(t *testing.T) {
 			db, _ := dbtestutil.NewDB(t)
 			user := dbgen.User(t, db, database.User{})
 			org := dbgen.Organization(t, db, database.Organization{})
-			model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{})
+			model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{OrganizationID: org.ID})
 			server := &Server{db: db, clock: quartz.NewReal()}
 			syntheticID, err := server.ensureSyntheticAPIKeyID(t.Context(), user.ID)
 			require.NoError(t, err)

--- a/coderd/x/chatd/tasks_test.go
+++ b/coderd/x/chatd/tasks_test.go
@@ -874,7 +874,10 @@ func newTaskTestFixture(t *testing.T) *taskTestFixture {
 		DisplayName: "openai",
 		BaseUrl:     "http://example.invalid",
 	})
-	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{IsDefault: true})
+	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
+		OrganizationID: org.ID,
+		IsDefault:      true,
+	})
 	apiKey, _ := dbgen.APIKey(t, db, database.APIKey{UserID: user.ID})
 	return &taskTestFixture{db: db, pubsub: newTaskRecordingPubsub(ps), rawPS: ps, sqlDB: sqlDB, user: user, org: org, model: model, apiKey: apiKey}
 }

--- a/coderd/x/chatd/title_override.go
+++ b/coderd/x/chatd/title_override.go
@@ -40,10 +40,11 @@ func parseModelOverride(raw string) (parsedModelOverride, bool) {
 func readTitleGenerationModelOverride(
 	ctx context.Context,
 	db database.Store,
+	organizationID uuid.UUID,
 ) (string, error) {
 	//nolint:gocritic // Chatd is internal, not a user, so this read uses AsChatd.
 	chatdCtx := dbauthz.AsChatd(ctx)
-	raw, err := db.GetChatTitleGenerationModelOverride(chatdCtx)
+	raw, err := getChatModelOverrideForOrganization(chatdCtx, db, organizationID, titleGenerationOverrideContext)
 	if err != nil {
 		return "", xerrors.Errorf(
 			"get chat title generation model override: %w",
@@ -62,7 +63,7 @@ func (p *Server) resolveTitleGenerationModelOverride(
 	chat database.Chat,
 	modelOpts modelBuildOptions,
 ) (database.ChatModelConfig, fantasy.LanguageModel, aiGatewayModelRoute, bool, error) {
-	raw, err := readTitleGenerationModelOverride(ctx, p.db)
+	raw, err := readTitleGenerationModelOverride(ctx, p.db, chat.OrganizationID)
 	if err != nil {
 		return database.ChatModelConfig{}, nil, aiGatewayModelRoute{}, false, xerrors.Errorf(
 			"read title generation model override: %w",
@@ -75,7 +76,9 @@ func (p *Server) resolveTitleGenerationModelOverride(
 		titleGenerationOverrideContext,
 		raw,
 		chat.OwnerID,
-		p.resolveModelConfigAndNormalizedProvider,
+		func(ctx context.Context, modelConfigID uuid.UUID) (database.ChatModelConfig, string, error) {
+			return p.resolveModelConfigAndNormalizedProvider(ctx, chat.OrganizationID, modelConfigID)
+		},
 		func(ctx context.Context, ownerID uuid.UUID, aiProviderID uuid.UUID) (chatprovider.ProviderAPIKeys, error) {
 			return p.resolveUserProviderAPIKeys(ctx, ownerID, aiProviderID)
 		},

--- a/coderd/x/chatd/title_override_internal_test.go
+++ b/coderd/x/chatd/title_override_internal_test.go
@@ -55,7 +55,7 @@ func TestMaybeGenerateChatTitle_TitleGenerationOverrideUnset(t *testing.T) {
 			},
 		}
 
-		db.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return("", nil)
+		db.EXPECT().GetChatTitleGenerationModelOverrideForOrganization(gomock.Any(), chat.OrganizationID).Return("", nil)
 		db.EXPECT().UpdateChatTitleByID(gomock.Any(), database.UpdateChatTitleByIDParams{
 			ID:    chat.ID,
 			Title: wantTitle,
@@ -105,7 +105,7 @@ func TestMaybeGenerateChatTitle_TitleGenerationOverrideReadDBError(t *testing.T)
 		},
 	}
 
-	db.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return("", sql.ErrConnDone)
+	db.EXPECT().GetChatTitleGenerationModelOverrideForOrganization(gomock.Any(), chat.OrganizationID).Return("", sql.ErrConnDone)
 	db.EXPECT().UpdateChatTitleByID(gomock.Any(), database.UpdateChatTitleByIDParams{
 		ID:    chat.ID,
 		Title: wantTitle,
@@ -154,7 +154,7 @@ func TestMaybeGenerateChatTitle_TitleGenerationOverrideMalformedFallsThrough(t *
 		},
 	}
 
-	db.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return("not-a-uuid", nil)
+	db.EXPECT().GetChatTitleGenerationModelOverrideForOrganization(gomock.Any(), chat.OrganizationID).Return("not-a-uuid", nil)
 	db.EXPECT().UpdateChatTitleByID(gomock.Any(), database.UpdateChatTitleByIDParams{
 		ID:    chat.ID,
 		Title: wantTitle,
@@ -234,8 +234,8 @@ func TestMaybeGenerateChatTitle_TitleGenerationOverrideSetUsable(t *testing.T) {
 		},
 	}
 
-	db.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return(overrideConfig.ID.String()+":xhigh", nil)
-	db.EXPECT().GetChatModelConfigByID(gomock.Any(), overrideConfig.ID).Return(overrideConfig, nil)
+	db.EXPECT().GetChatTitleGenerationModelOverrideForOrganization(gomock.Any(), chat.OrganizationID).Return(overrideConfig.ID.String()+":xhigh", nil)
+	db.EXPECT().GetChatModelConfigByID(gomock.Any(), gomock.Any()).Return(overrideConfig, nil)
 	db.EXPECT().GetAIProviderByID(gomock.Any(), providerID).Return(provider, nil).AnyTimes()
 	db.EXPECT().GetAIProviderKeysByProviderID(gomock.Any(), providerID).Return([]database.AIProviderKey{{
 		ProviderID: providerID,
@@ -286,8 +286,8 @@ func TestMaybeGenerateChatTitle_TitleGenerationOverrideSetUnusableSkips(t *testi
 		},
 	}
 
-	db.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return(overrideConfig.ID.String(), nil)
-	db.EXPECT().GetChatModelConfigByID(gomock.Any(), overrideConfig.ID).Return(overrideConfig, nil)
+	db.EXPECT().GetChatTitleGenerationModelOverrideForOrganization(gomock.Any(), chat.OrganizationID).Return(overrideConfig.ID.String(), nil)
+	db.EXPECT().GetChatModelConfigByID(gomock.Any(), gomock.Any()).Return(overrideConfig, nil)
 
 	generated := &generatedChatTitle{}
 	server := titleOverrideTestServer(db, logger)
@@ -334,8 +334,8 @@ func TestMaybeGenerateChatTitle_TitleGenerationOverrideCallFailureSkipsFallback(
 		},
 	}
 
-	db.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return(overrideConfig.ID.String(), nil)
-	db.EXPECT().GetChatModelConfigByID(gomock.Any(), overrideConfig.ID).Return(overrideConfig, nil)
+	db.EXPECT().GetChatTitleGenerationModelOverrideForOrganization(gomock.Any(), chat.OrganizationID).Return(overrideConfig.ID.String(), nil)
+	db.EXPECT().GetChatModelConfigByID(gomock.Any(), gomock.Any()).Return(overrideConfig, nil)
 	db.EXPECT().GetAIProviderByID(gomock.Any(), providerID).Return(aibridgeTestAIProvider(providerID, "primary-openai", database.AIProviderTypeOpenai), nil).AnyTimes()
 	db.EXPECT().GetAIProviderKeysByProviderID(gomock.Any(), providerID).Return([]database.AIProviderKey{{
 		ProviderID: providerID,
@@ -381,8 +381,8 @@ func TestResolveManualTitleModel_TitleGenerationOverrideUnset(t *testing.T) {
 		Enabled:      true,
 	}
 
-	db.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return("", nil)
-	db.EXPECT().GetEnabledChatModelConfigs(gomock.Any()).Return([]database.GetEnabledChatModelConfigsRow{
+	db.EXPECT().GetChatTitleGenerationModelOverrideForOrganization(gomock.Any(), chat.OrganizationID).Return("", nil)
+	db.EXPECT().GetEnabledChatModelConfigs(gomock.Any(), chat.OrganizationID).Return([]database.GetEnabledChatModelConfigsRow{
 		{ChatModelConfig: database.ChatModelConfig{Model: "gpt-4.1", Enabled: true}, Provider: "openai"},
 		{ChatModelConfig: preferredConfig, Provider: preferredTitleModels[1].provider},
 	}, nil)
@@ -427,8 +427,8 @@ func TestResolveManualTitleModel_TitleGenerationOverrideUnsetAIProvider(t *testi
 		BaseUrl: serverURL,
 	}
 
-	db.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return("", nil)
-	db.EXPECT().GetEnabledChatModelConfigs(gomock.Any()).Return([]database.GetEnabledChatModelConfigsRow{
+	db.EXPECT().GetChatTitleGenerationModelOverrideForOrganization(gomock.Any(), chat.OrganizationID).Return("", nil)
+	db.EXPECT().GetEnabledChatModelConfigs(gomock.Any(), chat.OrganizationID).Return([]database.GetEnabledChatModelConfigsRow{
 		{ChatModelConfig: preferredConfig, Provider: preferredTitleModels[1].provider},
 	}, nil)
 	db.EXPECT().GetAIProviderByID(gomock.Any(), providerID).Return(provider, nil)
@@ -465,8 +465,8 @@ func TestResolveManualTitleModel_TitleGenerationOverrideReadDBError(t *testing.T
 		Enabled:      true,
 	}
 
-	db.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return("", sql.ErrConnDone)
-	db.EXPECT().GetEnabledChatModelConfigs(gomock.Any()).Return([]database.GetEnabledChatModelConfigsRow{
+	db.EXPECT().GetChatTitleGenerationModelOverrideForOrganization(gomock.Any(), chat.OrganizationID).Return("", sql.ErrConnDone)
+	db.EXPECT().GetEnabledChatModelConfigs(gomock.Any(), chat.OrganizationID).Return([]database.GetEnabledChatModelConfigsRow{
 		{ChatModelConfig: database.ChatModelConfig{Model: "gpt-4.1", Enabled: true}, Provider: "openai"},
 		{ChatModelConfig: preferredConfig, Provider: preferredTitleModels[1].provider},
 	}, nil)
@@ -496,8 +496,8 @@ func TestResolveManualTitleModel_TitleGenerationOverrideSetUsable(t *testing.T) 
 	providerID := uuid.New()
 	overrideConfig.AIProviderID = uuid.NullUUID{UUID: providerID, Valid: true}
 
-	db.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return(overrideConfig.ID.String(), nil)
-	db.EXPECT().GetChatModelConfigByID(gomock.Any(), overrideConfig.ID).Return(overrideConfig, nil)
+	db.EXPECT().GetChatTitleGenerationModelOverrideForOrganization(gomock.Any(), chat.OrganizationID).Return(overrideConfig.ID.String(), nil)
+	db.EXPECT().GetChatModelConfigByID(gomock.Any(), gomock.Any()).Return(overrideConfig, nil)
 	db.EXPECT().GetAIProviderByID(gomock.Any(), providerID).Return(aibridgeTestAIProvider(providerID, "primary-openai", database.AIProviderTypeOpenai), nil).AnyTimes()
 	db.EXPECT().GetAIProviderKeysByProviderID(gomock.Any(), providerID).Return([]database.AIProviderKey{{
 		ProviderID: providerID,
@@ -533,8 +533,8 @@ func TestResolveManualTitleModel_TitleGenerationOverrideMissingCredentials(t *te
 		Enabled: true,
 	}
 
-	db.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return(overrideConfig.ID.String(), nil)
-	db.EXPECT().GetChatModelConfigByID(gomock.Any(), overrideConfig.ID).Return(overrideConfig, nil)
+	db.EXPECT().GetChatTitleGenerationModelOverrideForOrganization(gomock.Any(), chat.OrganizationID).Return(overrideConfig.ID.String(), nil)
+	db.EXPECT().GetChatModelConfigByID(gomock.Any(), gomock.Any()).Return(overrideConfig, nil)
 	db.EXPECT().GetAIProviderByID(gomock.Any(), providerID).Return(provider, nil).AnyTimes()
 	db.EXPECT().GetAIProviderKeysByProviderID(gomock.Any(), providerID).Return(nil, nil).AnyTimes()
 
@@ -605,8 +605,8 @@ func TestGenerateManualTitleCandidate_UsesSyntheticAPIKey(t *testing.T) {
 		UserID:    chat.OwnerID,
 		ExpiresAt: time.Now().Add(48 * time.Hour),
 	}, nil)
-	db.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return(overrideConfig.ID.String(), nil)
-	db.EXPECT().GetChatModelConfigByID(gomock.Any(), overrideConfig.ID).Return(overrideConfig, nil)
+	db.EXPECT().GetChatTitleGenerationModelOverrideForOrganization(gomock.Any(), chat.OrganizationID).Return(overrideConfig.ID.String(), nil)
+	db.EXPECT().GetChatModelConfigByID(gomock.Any(), gomock.Any()).Return(overrideConfig, nil)
 	db.EXPECT().GetAIProviderByID(gomock.Any(), providerID).Return(provider, nil).AnyTimes()
 	db.EXPECT().GetAIProviderKeysByProviderID(gomock.Any(), providerID).Return([]database.AIProviderKey{{
 		ProviderID: providerID,
@@ -632,8 +632,8 @@ func TestResolveManualTitleModel_TitleGenerationOverrideSetUnusable(t *testing.T
 	chat, _ := titleOverrideTestChatAndMessages(t)
 	overrideConfig := titleOverrideModelConfig("gpt-4.1", false)
 
-	db.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return(overrideConfig.ID.String(), nil)
-	db.EXPECT().GetChatModelConfigByID(gomock.Any(), overrideConfig.ID).Return(overrideConfig, nil)
+	db.EXPECT().GetChatTitleGenerationModelOverrideForOrganization(gomock.Any(), chat.OrganizationID).Return(overrideConfig.ID.String(), nil)
+	db.EXPECT().GetChatModelConfigByID(gomock.Any(), gomock.Any()).Return(overrideConfig, nil)
 
 	server := titleOverrideTestServer(db, logger)
 	model, gotConfig, err := server.resolveManualTitleModel(

--- a/coderd/x/chatd/turn_summary_internal_test.go
+++ b/coderd/x/chatd/turn_summary_internal_test.go
@@ -40,6 +40,7 @@ func TestUpdateLastTurnSummaryRejectsStaleWrites(t *testing.T) {
 	})
 
 	modelCfg, err := db.InsertChatModelConfig(ctx, database.InsertChatModelConfigParams{
+		OrganizationID:       org.ID,
 		AIProviderID:         uuid.NullUUID{UUID: provider.ID, Valid: true},
 		Model:                "test-model",
 		DisplayName:          "Test Model",
@@ -132,6 +133,7 @@ func TestSuccessfulChildChatOutcomeSkipsSummaryAndWebPush(t *testing.T) {
 	})
 
 	modelCfg, err := db.InsertChatModelConfig(ctx, database.InsertChatModelConfigParams{
+		OrganizationID:       org.ID,
 		AIProviderID:         uuid.NullUUID{UUID: provider.ID, Valid: true},
 		Model:                "test-model",
 		DisplayName:          "Test Model",

--- a/docs/ai-coder/agents/tasks-to-chats-migration.md
+++ b/docs/ai-coder/agents/tasks-to-chats-migration.md
@@ -57,7 +57,7 @@ The table below maps each Tasks API endpoint to its Chats API equivalent.
 | Resume            | `POST /api/v2/tasks/{user}/{task}/resume` | `POST /api/experimental/chats/{chat}/messages` (send a new message) |
 | Watch all         | n/a                                       | `GET /api/experimental/chats/watch` (WebSocket)                     |
 | Get messages      | n/a                                       | `GET /api/experimental/chats/{chat}/messages`                       |
-| List models       | n/a                                       | `GET /api/experimental/chats/models`                                |
+| List models       | n/a                                       | `GET /api/experimental/organizations/{organization}/chats/models`   |
 | Upload file       | n/a                                       | `POST /api/experimental/chats/files`                                |
 
 ## Migration steps
@@ -510,8 +510,8 @@ List available models to verify at least one provider is configured and
 reachable:
 
 ```sh
-curl -s https://coder.example.com/api/experimental/chats/models \
-  -H "Coder-Session-Token: $CODER_SESSION_TOKEN" | jq '.[].display_name'
+curl -s "https://coder.example.com/api/experimental/organizations/$CODER_ORGANIZATION/chats/models" \
+  -H "Coder-Session-Token: $CODER_SESSION_TOKEN" | jq '.providers[].models[].display_name'
 ```
 
 If this returns an empty list or an error, revisit

--- a/scaletest/chat/client.go
+++ b/scaletest/chat/client.go
@@ -22,8 +22,8 @@ type chatClient interface {
 var _ chatClient = (*codersdk.ExperimentalClient)(nil)
 
 type chatModelConfigClient interface {
-	ListChatModelConfigs(ctx context.Context) ([]codersdk.ChatModelConfig, error)
-	CreateChatModelConfig(ctx context.Context, req codersdk.CreateChatModelConfigRequest) (codersdk.ChatModelConfig, error)
+	ListChatModelConfigs(ctx context.Context, organizationID uuid.UUID) ([]codersdk.ChatModelConfig, error)
+	CreateChatModelConfig(ctx context.Context, organizationID uuid.UUID, req codersdk.CreateChatModelConfigRequest) (codersdk.ChatModelConfig, error)
 }
 
 var _ chatModelConfigClient = (*codersdk.ExperimentalClient)(nil)

--- a/scaletest/chat/provider.go
+++ b/scaletest/chat/provider.go
@@ -42,7 +42,7 @@ const (
 // config used by chat scaletests. When the provider was created or updated,
 // it sleeps for propagationWait so every coderd replica's cached provider
 // config expires before chats start.
-func EnsureScaletestModelConfig(ctx context.Context, client *codersdk.Client, logger slog.Logger, llmMockURL string, propagationWait time.Duration) (uuid.UUID, error) {
+func EnsureScaletestModelConfig(ctx context.Context, client *codersdk.Client, logger slog.Logger, organizationID uuid.UUID, llmMockURL string, propagationWait time.Duration) (uuid.UUID, error) {
 	expClient := codersdk.NewExperimentalClient(client)
 
 	logger.Info(ctx, "bootstrapping mock LLM provider", slog.F("llm_mock_url", llmMockURL))
@@ -72,7 +72,7 @@ func EnsureScaletestModelConfig(ctx context.Context, client *codersdk.Client, lo
 		)
 	}
 
-	modelConfigID, err := ensureScaletestChatModelConfig(ctx, expClient, logger, provider)
+	modelConfigID, err := ensureScaletestChatModelConfig(ctx, expClient, logger, organizationID, provider)
 	if err != nil {
 		return uuid.Nil, err
 	}
@@ -92,8 +92,8 @@ func EnsureScaletestModelConfig(ctx context.Context, client *codersdk.Client, lo
 	return modelConfigID, nil
 }
 
-func ensureScaletestChatModelConfig(ctx context.Context, client chatModelConfigClient, logger slog.Logger, provider codersdk.AIProvider) (uuid.UUID, error) {
-	modelConfigs, err := client.ListChatModelConfigs(ctx)
+func ensureScaletestChatModelConfig(ctx context.Context, client chatModelConfigClient, logger slog.Logger, organizationID uuid.UUID, provider codersdk.AIProvider) (uuid.UUID, error) {
+	modelConfigs, err := client.ListChatModelConfigs(ctx, organizationID)
 	if err != nil {
 		return uuid.Nil, xerrors.Errorf("list chat model configs: %w", err)
 	}
@@ -115,7 +115,7 @@ func ensureScaletestChatModelConfig(ctx context.Context, client chatModelConfigC
 	enabled := true
 	isDefault := false
 	contextLimit := scaletestModelContextLimit
-	created, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+	created, err := client.CreateChatModelConfig(ctx, organizationID, codersdk.CreateChatModelConfigRequest{
 		AIProviderID: &provider.ID,
 		Model:        scaletestModelName,
 		DisplayName:  scaletestModelDisplayName,


### PR DESCRIPTION
## Review boundary

Review slice 4 of CODAGT-709. **Do not merge this PR separately.** The full dependent stack will be reviewed, squashed into one commit, reverified, and merged atomically to `main`.

This slice owns organization-aware chat runtime selection, cache and singleflight isolation, pubsub invalidation, telemetry, CLI, scaletest, and non-site caller migrations.

**Depends on:** #27356

The final site review slice is preserved separately and will be based on this PR. It is blocked because seven CODAGT-714-owned settings and model-management pages still need organization context, and repository hooks typecheck the complete site. No fallback or compatibility behavior was added.

## Verification

- focused chatd, cache, CLI, scaletest, telemetry, and integration tests
- combined backend head: 28,050 tests passed, 57 skipped
- `make gen`, `make fmt`, `make lint`, `make build`, and `git diff --check`

<details>
<summary>Complete CODAGT-709 stack plan</summary>

# CODAGT-709: review-only hard-cut stack for organization-scoped chat model configs

## Direction for approval

Implement CODAGT-709 as one atomic hard cut, decomposed into stacked PRs only to make review manageable. The PRs are not independently deployable or mergeable to `main`. Each PR depends on the complete behavior introduced by later layers. After all layers are reviewed and the stack head passes verification, squash the full stack into one commit and merge it atomically to `main`.

The atomic change adds organization ownership, clones and remaps existing data, activates RBAC and ACLs, replaces global APIs and settings with organization-qualified contracts, scopes chat runtime and caches, migrates every supported caller, and removes the legacy contracts. There is no compatibility period and no intermediate production state.

CODAGT-714 remains separate. CODAGT-709 supplies the organization-scoped model CRUD, settings, and ACL APIs that CODAGT-714 will consume, but does not implement the organization picker, model-management UI migration, settings UI migration, empty-state UI, or sharing UI.

### Observable end state

- `chat_model_configs` is organization-owned and `organization_id` is non-null.
- Every legacy config, including soft-deleted history, is cloned once for every non-deleted organization with a fresh UUID.
- Chats, messages, queued messages, and debug runs reference the clone belonging to their chat organization.
- Each organization has at most one non-deleted default. A disabled model may remain default.
- Model-bearing site settings and user settings are organization-qualified and reference organization model IDs.
- `ResourceChatModelConfig` supports create, read, update, delete, and share. There is no `ActionUse`.
- Direct user and group ACL grants provide `read` only.
- Migrated configs grant the organization's Everyone group `read` and have an empty user ACL.
- Organization-qualified discovery, CRUD, ACL, settings, SDK, frontend query, runtime, cache, CLI, scaletest, and telemetry behavior is active.
- Global model and model-bearing settings routes, SDK methods, query helpers, storage keys, and runtime fallbacks are removed.
- Existing chats continue using their remapped model clone. ACL access is not re-evaluated on every turn.
- CODAGT-714 UI is not included.

## Settled decisions

### Stack and merge model

- PR boundaries exist only for review.
- PR 1 is based on `main`; every later PR is based on the previous PR branch.
- No individual stack layer is merged to `main`.
- No layer is required to support deployment, rollback, or mixed-version operation by itself.
- The final stack head must compile, pass all tests, and implement the complete hard cut.
- After review, squash the complete stack and merge the squash commit atomically to `main`.
- Review comments are amended in the layer that owns the affected behavior, then all descendants are rebased.

### Migration

The up migration performs the original hard cut in one transaction:

1. Add nullable `organization_id`, `user_acl`, and `group_acl` to `chat_model_configs`.
2. Drop the deployment-wide default index.
3. Build a temporary mapping from every legacy config and every non-deleted organization to a fresh model-config UUID.
4. Clone every legacy config, including soft-deleted historical configs, to every non-deleted organization.
5. Preserve all model fields, provider references, creator and updater values, timestamps, deleted state, enabled state, options, context limit, compression threshold, and default state.
6. Seed each clone with an empty user ACL and `read` for the organization's Everyone group, keyed by organization ID.
7. Remap `chats.last_model_config_id` through the chat's organization.
8. Add `organization_id` to `chat_messages`, backfill it from the parent chat, and remap `model_config_id` through that organization.
9. Add `organization_id` to `chat_queued_messages`, backfill it from the parent chat, and remap `model_config_id` through that organization.
10. Remap `chat_debug_runs.model_config_id` through the debug run's chat organization.
11. Clone model-bearing site settings once per non-deleted organization and replace valid legacy model IDs with the matching clone ID.
12. Clone user personal model overrides and compaction thresholds only for active organization memberships and replace valid legacy model IDs with the matching clone ID.
13. Preserve malformed or historically unmappable setting values according to the original migration behavior rather than inventing a replacement.
14. Delete legacy global site and user setting keys.
15. Delete legacy global model rows.
16. Make model, message, and queued-message organization columns non-null.
17. Add unique `(id, organization_id)` keys for model configs and chats.
18. Replace model and chat foreign keys with same-organization composite foreign keys for chats, messages, and queued messages.
19. Add an organization index on model configs.
20. Add a partial unique index on `organization_id` where `is_default = true AND deleted = false`.

No compatibility, coexistence, inheritance metadata, synchronization, fallback, or shadow rows are added.

### Downgrade

The down migration preserves the original deterministic collapse behavior:

- Keep all organization model IDs and historical references while removing organization ownership from the schema.
- Select the default organization as the restore source. If it is unavailable, select the earliest non-deleted organization by creation time and ID.
- Restore global model overrides and advisor configuration from the restore-source organization.
- Restore one personal override per user and context, preferring the default organization and then the earliest active membership that has the setting.
- Restore one compaction threshold per user and model key with the same preference order.
- Clear active defaults outside the restore-source organization so the restored global schema has one non-deleted default.
- Restore the original non-organization foreign keys.
- Drop child organization columns, model organization and ACL columns, composite keys, organization indexes, and organization default uniqueness.
- Recreate the singleton deployment-wide default index.

The downgrade is intentionally lossy with respect to organization-specific settings and defaults, but it preserves model rows and references.

### RBAC and ACLs

- Add `ResourceChatModelConfig` as an organization-scoped resource.
- Supported actions are create, read, update, delete, and share.
- Do not add `ActionUse`.
- Implement `ChatModelConfig.RBACObject()` with organization, identifier, user ACL, and group ACL.
- Add `ChatModelConfigConverter` for RegoSQL.
- Add authorized list queries for enabled and administrative model-config views.
- Replace `ResourceDeploymentConfig` checks on model CRUD with the new resource.
- Organization-qualified list and discovery use `ActionRead` authorization filtering.
- Item GET requires read. Item PATCH requires update. Item DELETE requires delete. ACL GET and PATCH require share.
- Item and ACL authorization failures return 404 to conceal existence.
- Direct user and group ACL roles map only to `read`. Reject other ACL actions.
- Organization Everyone-group `read` grants make migrated configs available to organization members.
- Template RBAC entitlement behavior follows the existing ACL-backed resource pattern and is covered by enterprise tests.
- Organization administrators and applicable site roles receive management permissions through the existing role definitions.
- Existing chats do not add per-turn ACL revocation. New selections and user-configured overrides require read access when selected.

### Defaults and writes

- Model create and list are organization-qualified.
- Create inserts the requested organization ID, empty user ACL, and Everyone-group `read` ACL.
- If an organization has no non-deleted default, its first created model becomes default.
- Setting a model as default clears the prior default only in the same organization.
- Updating or deleting a model repairs the default only in the same organization.
- Each organization has at most one non-deleted default.
- A disabled model may remain default.
- Provider deletion soft-deletes dependent model configs across organizations through an explicitly authorized database path.
- Model IDs supplied to organization settings or chat creation must belong to the same organization.
- Cross-organization identifiers are rejected without exposing the foreign resource.

### API

Replace the legacy model routes with the hard-cut organization contract:

- `GET /api/experimental/organizations/{organization}/chats/models`
- `GET /api/experimental/organizations/{organization}/chat-model-configs`
- `POST /api/experimental/organizations/{organization}/chat-model-configs`
- `GET /api/experimental/chat-model-configs/{modelConfig}`
- `PATCH /api/experimental/chat-model-configs/{modelConfig}`
- `DELETE /api/experimental/chat-model-configs/{modelConfig}`
- `GET /api/experimental/chat-model-configs/{modelConfig}/acl`
- `PATCH /api/experimental/chat-model-configs/{modelConfig}/acl`

Replace model-bearing settings routes with organization-qualified routes under:

```text
/api/experimental/organizations/{organization}/chats/config
```

The scoped settings are:

- General, explore, title-generation, and compaction model overrides.
- Advisor configuration.
- User personal model overrides.
- User compaction thresholds.

The deployment-wide personal-model-overrides enablement flag remains deployment-scoped because it is not model-bearing.

All legacy global model discovery, model CRUD, ACL, and model-bearing settings routes are removed. Do not retain gone handlers, redirects, default-organization adapters, or fallback routes.

### Settings storage

- Site-config model override keys are prefixed with organization ID.
- Advisor configuration keys are prefixed with organization ID.
- Personal override keys include organization ID before context.
- Compaction threshold keys include organization ID and model-config ID.
- All setting reads and writes require a concrete organization.
- Runtime does not fall back to global keys.
- API validation requires selected model IDs to belong to the requested organization.
- Malformed stored settings retain the original handler and runtime error behavior established by the complete implementation.

### Chat model selection and runtime

- Chat creation requires `organization_id` and resolves every model choice in that organization.
- An explicit `model_config_id` must identify an enabled, readable config in the requested organization.
- If no explicit model is supplied, resolve the user's organization-scoped personal override when enabled, otherwise resolve the organization's default.
- Existing-chat send, edit, retry, queued-message, title generation, compaction, advisor, subagent, and quick-generation paths take organization from the persisted chat.
- All model lookups include organization.
- Messages, queued messages, and debug runs persist the same organization as their chat and a model ID from that organization.
- Same-organization database constraints provide the final enforcement boundary.
- Runtime does not consult a deployment default organization or global model setting.
- Existing chats continue with the model clone selected by migration. No per-turn ACL revocation is introduced.

### Cache and pubsub

- Model-config cache keys include organization ID and model-config ID.
- Default-model cache keys use organization ID.
- Advisor cache keys use organization ID.
- Singleflight keys include organization ID.
- Model and advisor pubsub events include organization ID.
- Model mutation invalidates the model and default entries for the affected organization.
- Advisor mutation invalidates only the affected organization.
- Provider topology invalidation may clear model state globally because AI providers remain deployment-scoped.
- Generation counters reject stale in-flight fills after invalidation.

### SDK, frontend, CLI, scaletest, and telemetry

- Replace legacy Go SDK methods with organization-qualified methods. Go methods use distinct signatures or names as required; no legacy method remains at the stack head.
- TypeScript API methods require organization for discovery and model-bearing settings.
- React Query keys include organization for every organization-owned model and setting.
- Existing chat detail uses `chat.organization_id`.
- New-chat model discovery uses the existing `selectedOrg` in `AgentCreateForm`.
- New-chat personal override reads also use the selected organization after the scoped settings API exists.
- CLI and scaletest callers supply organization and create or select a config per organization.
- Telemetry reports organization-owned model configs without collapsing them into deployment-global resources.
- Generated OpenAPI, SDK types, RBAC resources, mocks, database code, and docs reflect only the final hard-cut contract.

### CODAGT-714 exclusion

CODAGT-709 does not implement:

- A new organization picker.
- Model or MCP settings page picker integration.
- Model-management page migration.
- Model sharing UI.
- Empty-organization UI.
- CODAGT-714 Storybook coverage.

CODAGT-714 consumes the final organization CRUD, ACL, and settings APIs after CODAGT-709 merges atomically.

## Ruled-out directions

- Independently deployable expansion PRs.
- Compatibility or coexistence periods.
- Global and organization rows existing as supported runtime resources at the same deployed revision.
- Inheritance metadata or one-way synchronization.
- Shadow tables or shadow rows.
- Global settings fallback.
- Legacy server routes, gone handlers, redirects, or aliases.
- Default-organization compatibility adapters.
- Aggregating organization rows through a global route.
- Folding CODAGT-714 UI into CODAGT-709.
- Splitting the final reviewed stack across multiple merges to `main`.

## Review-only PR stack

The active stack begins at #27354. Closed PRs #27337, #27338, and #27340 are not stack layers and provide no merge dependency.

### PR 1, #27354: database hard cut

**Branch:** `mathias/codagt-709-database`

**Base:** `main`.

**Review focus:** Schema, migration correctness, organization-qualified storage, same-organization constraints, defaults, and generated database interfaces.

**Boundary:**

- Complete up and down migrations and migration fixtures.
- Clone and remap model configs, chats, messages, queued messages, debug runs, site settings, and user settings.
- Organization and ACL fields on model configs.
- Organization fields on messages and queued messages.
- Same-organization keys and foreign keys.
- Per-organization default index.
- Organization-qualified model and model-bearing settings queries.
- ACL queries and authorized-query source hooks required by the RBAC layer.
- Generated database, mock, metrics, constraint, dump, and test artifacts.
- Database, migration, default, downgrade, and cross-organization constraint tests.

### PR 2, #27355: RBAC and dbauthz

**Branch:** `mathias/codagt-709-rbac`

**Base:** #27354.

**Review focus:** Resource policy, ACL-backed authorization, authorized SQL filtering, role behavior, and database authorization coverage.

**Boundary:**

- `ResourceChatModelConfig` with create, read, update, delete, and share.
- `ChatModelConfig.RBACObject()` and generated RBAC objects and SDK resources.
- RegoSQL converter and authorized list compilation.
- dbauthz methods for every changed or added model-config query.
- Role and Template RBAC entitlement behavior.
- User and group ACL read-only semantics.
- Authorization, role, RegoSQL, dbauthz, and concealment prerequisites and tests.

### PR 3, #27356: API, SDK, and organization settings

**Branch:** `mathias/codagt-709-api`

**Base:** #27355.

**Review focus:** Hard-cut HTTP contracts, SDK contracts, model CRUD, ACL validation, defaults, organization-scoped settings, and item concealment.

**Boundary:**

- Organization-qualified model catalog, list, and create handlers.
- Item GET, PATCH, DELETE and ACL GET, PATCH.
- Organization-qualified model overrides, advisor configuration, personal overrides, and compaction thresholds.
- Removal of global model and model-bearing settings server routes.
- Final Go SDK methods and tests with no legacy methods retained at the stack head.
- Model validation, default repair, provider deletion integration, ACL validation, and 404 concealment.
- API, SDK, enterprise RBAC, settings, malformed-value, default, ACL, and cross-organization tests.
- Generated API references and documentation for the hard-cut contract.

### PR 4, #27357: runtime and backend callers

**Branch:** `mathias/codagt-709-runtime`

**Base:** #27356.

**Review focus:** End-to-end backend organization isolation and migration of every non-site caller.

**Boundary:**

- Organization-aware model resolution for chat creation and all existing-chat runtime paths.
- Organization-scoped defaults, personal overrides, model overrides, advisor, and compaction thresholds.
- Model, default, and advisor cache keying, invalidation, generation, and singleflight isolation.
- Organization-scoped pubsub events.
- Chat message, queued-message, and debug-run organization persistence.
- CLI, scaletest, telemetry, test helpers, and other backend caller migrations.
- Chatd architecture update.
- Chatd, cache, concurrency, CLI, scaletest, telemetry, and backend integration tests.
- Removal of remaining backend global-query callers and runtime fallbacks.

### Pending site slice: frontend callers and final stack-head verification

**Base:** #27357.

**Status:** Preserved but not opened as an active PR. It is blocked until separately owned CODAGT-714 supplies organization context to all seven settings and model-management pages listed below. Repository hooks typecheck the complete site, so the site slice cannot pass required hooks while those pages still call the hard-cut organization-required API without an organization.

The seven blocking pages are:

1. `site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPage.tsx`
2. `site/src/pages/AISettingsPage/ModelsPage/AddModelPage/AddModelPage.tsx`
3. `site/src/pages/AISettingsPage/ModelsPage/ModelsPage.tsx`
4. `site/src/pages/AISettingsPage/ModelsPage/UpdateModelPage/UpdateModelPage.tsx`
5. `site/src/pages/AgentsPage/AgentSettingsAPIKeysPage.tsx`
6. `site/src/pages/AgentsPage/AgentSettingsCompactionPage.tsx`
7. `site/src/pages/AgentsPage/AgentSettingsUserAgentsPage.tsx`

CODAGT-714 owns adding organization context, picker behavior, model-management UI migration, settings UI migration, sharing UI, empty-organization UI, and its Storybook coverage. CODAGT-709 does not implement those behaviors.

After CODAGT-714 supplies organization context, the pending site slice contains only CODAGT-709 caller migration and verification work:

- TypeScript API methods and React Query helpers for the final organization-qualified contracts.
- Organization-keyed query and invalidation keys.
- Existing chat detail model and setting reads scoped by `chat.organization_id`.
- New-chat catalog, model config, and personal override reads scoped by `AgentCreateForm.selectedOrg.id`.
- Migration of remaining non-CODAGT-714 site callers to required organization arguments.
- Removal of legacy frontend API methods, query helpers, and unscoped cache keys.
- Storybook and frontend tests for chat detail and new-chat organization isolation.
- Repository-wide no-legacy-caller checks and full stack-head verification.

## Stack dependencies and atomic merge procedure

1. #27354 targets `main` for review context.
2. #27355 targets #27354's branch.
3. #27356 targets #27355's branch.
4. #27357 targets #27356's branch.
5. The pending site slice is based on #27357 and remains blocked until CODAGT-714 supplies organization context to the seven pages above.
6. Review each active PR against its immediate base so reviewers see only that boundary.
7. Apply review fixes in the owning PR and rebase every descendant.
8. Do not merge #27354, #27355, #27356, #27357, or the site slice individually to `main`.
9. After the site slice is unblocked, run the complete verification suite on the full stack head and confirm its diff against `main` contains the complete hard cut.
10. Squash the full `main...stack-head` diff into one commit on a final integration branch.
11. Re-run required hooks and verification on the exact squash commit.
12. Merge that single squash commit atomically to `main`.
13. Close the review-only stacked PRs as superseded by the atomic squash merge, preserving their review history.

## Full-stack invariants

- The stack head contains no global model row, global model-bearing setting, legacy route, legacy SDK method, global query helper, or fallback runtime path.
- Every model lookup and model-bearing setting lookup has a concrete organization.
- Every chat, message, queued message, and debug-run model reference belongs to the same organization as its chat.
- Direct ACL grants provide read only.
- Unauthorized item access is concealed with 404.
- Each organization has at most one non-deleted default.
- Existing chats use the remapped clone for their organization.
- No per-turn ACL revocation is added.
- CODAGT-714 UI is absent.
- The squash commit is the only CODAGT-709 commit merged to `main`.

## Verification at the stack head and squash commit

Run all checks on both the reviewed PR 7 head and the exact final squash commit:

- Migration fixture and full up and down migration execution.
- Clone count and fresh-ID assertions for every legacy-config and active-organization pair, including soft-deleted history.
- Correct remap of chats, messages, queued messages, debug runs, site settings, and user settings.
- Same-organization foreign-key enforcement and cross-organization rejection.
- Per-organization defaults, default repair, and disabled-default behavior.
- User ACL, group ACL, Everyone group, share authority, non-read action rejection, Template RBAC, and 404 concealment.
- Organization model CRUD, discovery, settings, and SDK tests.
- Chat creation explicit/default/personal selection and all existing-chat runtime model paths.
- Advisor, title, explore, compaction, and subagent organization isolation.
- Cache key, invalidation, generation, and singleflight concurrency tests with unique organization IDs and no timing sleeps.
- CLI, scaletest, telemetry, frontend query, Storybook, and integration coverage.
- Repository-wide search proving no legacy route, method, global settings key usage, unscoped model query, or default-organization fallback remains.
- `make gen`.
- `make fmt`.
- `make lint`.
- Relevant Go and frontend test targets.
- Storybook tests and build for changed stories.
- Production site build.
- `make build` or the repository's required final build entry point.
- Mandatory pre-commit and pre-push hooks.
- `git diff --check`.

A failure in any layer is a failure of the complete stack. Do not merge a partial layer or add compatibility behavior to make an intermediate PR independently deployable.

## References

- CODAGT-709 requirements: organization-owned model configs, per-organization defaults, group and user ACL, migration explosion, hard-cut experimental APIs, and organization-keyed chatd defaults.
- CODAGT-714 exclusion and dependency: it separately owns organization context for the seven settings and model-management pages, picker behavior, settings and management UI migration, sharing UI, empty-organization UI, and Storybook coverage.
- Preserved complete implementation: `/home/coder/.coder/plans/CODAGT-709-full-implementation.patch`.
- Active hard-cut review stack: #27354 database, #27355 RBAC and dbauthz, #27356 API, SDK, and settings, #27357 runtime and backend callers, then the pending site slice based on #27357.
- Closed PRs #27337, #27338, and #27340 are not active stack layers and are not merge dependencies.


</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
