### PR TITLE
perf(coderd/rbac): speed up org permission map for partial evaluation

### DIFF
--- a/coderd/rbac/astvalue.go
+++ b/coderd/rbac/astvalue.go
@@ -28,8 +28,14 @@ func regoInputValue(subject Subject, action policy.Action, object Object) (ast.V
 		ast.StringTerm("object"),
 		ast.NewTerm(object.regoValue()),
 	}
+	// partial marks this as a full evaluation. The policy uses it to select the
+	// full-evaluation implementation of check_all_org_permissions.
+	p := [2]*ast.Term{
+		ast.StringTerm("partial"),
+		ast.BooleanTerm(false),
+	}
 
-	input := ast.NewObject(s, a, o)
+	input := ast.NewObject(s, a, o, p)
 
 	return input, nil
 }
@@ -59,8 +65,14 @@ func regoPartialInputValue(subject Subject, action policy.Action, objectType str
 			}),
 		),
 	}
+	// partial marks this as a partial evaluation. The policy uses it to select
+	// the partial-evaluation implementation of check_all_org_permissions.
+	p := [2]*ast.Term{
+		ast.StringTerm("partial"),
+		ast.BooleanTerm(true),
+	}
 
-	input := ast.NewObject(s, a, o)
+	input := ast.NewObject(s, a, o, p)
 
 	return input, nil
 }

--- a/coderd/rbac/astvalue.go
+++ b/coderd/rbac/astvalue.go
@@ -7,6 +7,14 @@ import (
 	"github.com/coder/coder/v2/coderd/rbac/policy"
 )
 
+// orgPermissionSetThreshold is the number of organizations a subject must belong
+// to before partial evaluation (Prepare) uses the set-based org-permission map
+// construction. Below it, the original per-membership construction has lower
+// fixed overhead and is faster; at and above it, the set-based construction's
+// linear (rather than quadratic) scaling wins. The crossover is ~10 orgs, see
+// BenchmarkRBACManyOrgs.
+const orgPermissionSetThreshold = 10
+
 // regoInputValue returns a rego input value for the given subject, action, and
 // object. This rego input is already parsed and can be used directly in a
 // rego query.
@@ -28,14 +36,15 @@ func regoInputValue(subject Subject, action policy.Action, object Object) (ast.V
 		ast.StringTerm("object"),
 		ast.NewTerm(object.regoValue()),
 	}
-	// partial marks this as a full evaluation. The policy uses it to select the
-	// full-evaluation implementation of check_all_org_permissions.
-	p := [2]*ast.Term{
-		ast.StringTerm("partial"),
+	// use_org_perm_sets is always false for full evaluation: the set-based
+	// org-permission construction only helps the partial-evaluation (Prepare)
+	// path, so full evaluation always uses the original construction.
+	u := [2]*ast.Term{
+		ast.StringTerm("use_org_perm_sets"),
 		ast.BooleanTerm(false),
 	}
 
-	input := ast.NewObject(s, a, o, p)
+	input := ast.NewObject(s, a, o, u)
 
 	return input, nil
 }
@@ -65,16 +74,45 @@ func regoPartialInputValue(subject Subject, action policy.Action, objectType str
 			}),
 		),
 	}
-	// partial marks this as a partial evaluation. The policy uses it to select
-	// the partial-evaluation implementation of check_all_org_permissions.
-	p := [2]*ast.Term{
-		ast.StringTerm("partial"),
-		ast.BooleanTerm(true),
+	// use_org_perm_sets selects the set-based org-permission construction. It is
+	// worthwhile only for partial evaluation (this function) once the subject
+	// belongs to enough organizations, so the value is (org count >= threshold).
+	// Computing the comparison here and passing a plain boolean lets OPA prune
+	// the unused branch at compile time; an `input.org_count >= N` comparison in
+	// the policy does not fold as reliably during partial evaluation and would
+	// leave both branches in the residual.
+	orgCount, err := subject.orgMembershipCount()
+	if err != nil {
+		return nil, xerrors.Errorf("org membership count: %w", err)
+	}
+	u := [2]*ast.Term{
+		ast.StringTerm("use_org_perm_sets"),
+		ast.BooleanTerm(orgCount >= orgPermissionSetThreshold),
 	}
 
-	input := ast.NewObject(s, a, o, p)
+	input := ast.NewObject(s, a, o, u)
 
 	return input, nil
+}
+
+// orgMembershipCount returns the number of distinct organizations the subject
+// belongs to. This mirrors how the policy derives `org_memberships` from
+// `input.subject.roles[_].by_org_id`, and is used to decide whether partial
+// evaluation should use the set-based org-permission construction. Expanding
+// concrete roles is a no-op, so this is cheap on the request path.
+func (s Subject) orgMembershipCount() (int, error) {
+	roles, err := s.Roles.Expand()
+	if err != nil {
+		return 0, xerrors.Errorf("expand roles: %w", err)
+	}
+
+	orgs := make(map[string]struct{})
+	for _, role := range roles {
+		for orgID := range role.ByOrgID {
+			orgs[orgID] = struct{}{}
+		}
+	}
+	return len(orgs), nil
 }
 
 // regoValue returns the ast.Object representation of the subject.

--- a/coderd/rbac/authz_internal_test.go
+++ b/coderd/rbac/authz_internal_test.go
@@ -1400,6 +1400,68 @@ func TestScopeAllowList(t *testing.T) {
 	)
 }
 
+// TestAuthorizeOrgVoteDecides makes an organization-level vote the deciding
+// factor and verifies deny-wins semantics. It exists to guard the partial
+// (Prepare) org-permission construction: testAuthorize cross-checks the prepared
+// result against full Authorize for every non-any_org case, but only a case
+// where the org vote actually decides exercises org_vote's deny-wins logic.
+// Without this, flipping org_vote's deny result from -1 to 1 (a real
+// authorization bug) leaves the suite green.
+//
+// The subject is a member of enough organizations (>= the org-count threshold in
+// policy.rego) that Prepare takes the linear set-based construction, so this also
+// guards that implementation specifically rather than the full-evaluation one.
+func TestAuthorizeOrgVoteDecides(t *testing.T) {
+	t.Parallel()
+
+	// denyOrg has both an allow and a same-org deny for workspace.read; deny
+	// must win. allowOrg has only an allow. The remaining orgs are memberships
+	// with no permissions, present only to push the subject over the linear-path
+	// org-count threshold so the partial path under test is the set-based one.
+	denyOrg := uuid.New()
+	allowOrg := uuid.New()
+
+	byOrg := map[string]OrgPermissions{
+		denyOrg.String(): {
+			Org: []Permission{
+				{Negate: false, ResourceType: ResourceWorkspace.Type, Action: policy.ActionRead},
+				{Negate: true, ResourceType: ResourceWorkspace.Type, Action: policy.ActionRead},
+			},
+		},
+		allowOrg.String(): {
+			Org: []Permission{
+				{Negate: false, ResourceType: ResourceWorkspace.Type, Action: policy.ActionRead},
+			},
+		},
+	}
+	// Pad with empty memberships so the subject belongs to >= 10 orgs.
+	for len(byOrg) < 12 {
+		byOrg[uuid.NewString()] = OrgPermissions{}
+	}
+
+	subject := Subject{
+		ID:    "org-vote-subject",
+		Scope: must(ExpandScope(ScopeAll)),
+		Roles: Roles{
+			{
+				Identifier: RoleIdentifier{Name: "org-vote-role"},
+				ByOrgID:    byOrg,
+			},
+		},
+	}
+
+	testAuthorize(t, "OrgVoteDecides", subject,
+		[]authTestCase{
+			// deny-wins: allow and deny on the same org resolves to deny.
+			{resource: ResourceWorkspace.InOrg(denyOrg), actions: []policy.Action{policy.ActionRead}, allow: false},
+			// positive mirror: allow only resolves to allow.
+			{resource: ResourceWorkspace.InOrg(allowOrg), actions: []policy.Action{policy.ActionRead}, allow: true},
+			// an org the subject is a member of but has no perms for: abstain -> deny.
+			{resource: ResourceWorkspace.InOrg(denyOrg).WithOwner("not-me"), actions: []policy.Action{policy.ActionRead}, allow: false},
+		},
+	)
+}
+
 // cases applies a given function to all test cases. This makes generalities easier to create.
 func cases(opt func(c authTestCase) authTestCase, cases []authTestCase) []authTestCase {
 	if opt == nil {

--- a/coderd/rbac/policy.rego
+++ b/coderd/rbac/policy.rego
@@ -107,21 +107,108 @@ default scope_org := 0
 
 scope_org := check_org_permissions([input.subject.scope], "org")
 
+# org_allow_ids is the set of orgs where the subject has a matching *allow*
+# (non-negated) permission for this action and object type. It is built by
+# iterating each role's own `by_org_id` entries exactly once, so the total work
+# is linear in the number of org-scoped permissions rather than quadratic. The
+# previous implementation built a per-org vote map by iterating every role for
+# every membership (O(N^2) in the number of organizations).
+org_allow_ids(roles, key) := {org_id |
+	some role in roles
+	some org_id, perms in role.by_org_id
+	some perm in perms[key]
+	perm.action in [input.action, "*"]
+	perm.resource_type in [input.object.type, "*"]
+	not perm.negate
+}
+
+# org_deny_ids is the set of orgs where the subject has a matching *deny*
+# (negated) permission. A deny wins over an allow within the same org, matching
+# `to_vote`'s "any false => -1" behavior.
+org_deny_ids(roles, key) := {org_id |
+	some role in roles
+	some org_id, perms in role.by_org_id
+	some perm in perms[key]
+	perm.action in [input.action, "*"]
+	perm.resource_type in [input.object.type, "*"]
+	perm.negate
+}
+
+# org_vote resolves a single org's vote from the precomputed allow and deny
+# sets, reproducing `to_vote`'s deny-wins semantics:
+#   -1 (deny)    if the org is in the deny set,
+#    1 (allow)   if the org is in the allow set and not the deny set,
+#    0 (abstain) otherwise.
+# All three arguments are known during partial evaluation (the object's org id
+# is not involved here), so this does no work against unknown values.
+org_vote(org_id, _, deny) := -1 if {
+	org_id in deny
+}
+
+org_vote(org_id, allow, deny) := 1 if {
+	not org_id in deny
+	org_id in allow
+}
+
+org_vote(org_id, allow, deny) := 0 if {
+	not org_id in deny
+	not org_id in allow
+}
+
 # check_all_org_permissions creates a map from org ids to votes at each org
 # level, for each org that the subject is a member of. It doesn't actually check
 # if the object is in the same org. Instead we look up the correct vote from
 # this map based on the object's org id in `check_org_permissions`.
-# For example, the `org_map` will look something like this:
+# For example, the map will look something like this:
 #
 #   {"<org_id_a>": 1, "<org_id_b>": 0, "<org_id_c>": -1}
 #
 # The caller then uses `output[input.object.org_owner]` to get the correct vote.
 #
 # We have to create this map, rather than just getting the vote of the object's
-# org id because the org id _might_ be unknown. In order to make sure that this
+# org id, because the org id _might_ be unknown. In order to make sure that this
 # policy compresses down to simple queries we need to keep unknown values out of
 # comprehensions.
-check_all_org_permissions(roles, key) := {org_id: vote |
+#
+# There are two implementations, selected by `input.partial`:
+#
+#   - Partial evaluation (Prepare, org id unknown): the full map must be built
+#     because the object's org is unknown, so we use the set-based
+#     implementation whose map construction is linear in the number of
+#     organizations rather than quadratic.
+#   - Full evaluation (Authorize, org id known): the caller only needs a single
+#     org's vote, so building the allow/deny sets over every org is wasted work.
+#     We use the original per-membership implementation, which is cheaper for
+#     the common low-org-count Authorize case.
+#
+# `input.partial` is set by the Go authorizer (true for partial evaluation,
+# false/absent for full evaluation) and is a known value in both paths, so OPA
+# prunes the unused branch during compilation.
+check_all_org_permissions(roles, key) := check_all_org_permissions_partial(roles, key) if {
+	input.partial
+}
+
+check_all_org_permissions(roles, key) := check_all_org_permissions_fulleval(roles, key) if {
+	not input.partial
+}
+
+# check_all_org_permissions_partial builds the vote map from precomputed allow
+# and deny sets. Each set is linear in the number of org-scoped permissions, and
+# the map is built by iterating the membership set once with O(1) set lookups
+# per org, keeping the whole construction linear in the number of organizations.
+check_all_org_permissions_partial(roles, key) := vote_map if {
+	allow := org_allow_ids(roles, key)
+	deny := org_deny_ids(roles, key)
+	vote_map := {org_id: org_vote(org_id, allow, deny) |
+		some org_id in org_memberships
+	}
+}
+
+# check_all_org_permissions_fulleval is the original implementation: for each
+# membership org it scans every role's permissions for that org. This is
+# quadratic in org count but has lower fixed overhead, which wins for the
+# known-org full-evaluation (Authorize) path.
+check_all_org_permissions_fulleval(roles, key) := {org_id: vote |
 	org_id := org_memberships[_]
 	allow := {is_allowed |
 		# Iterate over all site permissions in all roles, and check which ones match

--- a/coderd/rbac/policy.rego
+++ b/coderd/rbac/policy.rego
@@ -108,11 +108,12 @@ default scope_org := 0
 scope_org := check_org_permissions([input.subject.scope], "org")
 
 # org_allow_ids is the set of orgs where the subject has a matching *allow*
-# (non-negated) permission for this action and object type. It is built by
-# iterating each role's own `by_org_id` entries exactly once, so the total work
-# is linear in the number of org-scoped permissions rather than quadratic. The
-# previous implementation built a per-org vote map by iterating every role for
-# every membership (O(N^2) in the number of organizations).
+# (non-negated) permission for this action and object type. Together with
+# org_deny_ids this is a linear pass per set over the subject's `by_org_id`
+# entries, so the total work is linear in the number of org-scoped permissions
+# rather than quadratic. The previous implementation built a per-org vote map by
+# iterating every role for every membership (O(N^2) in the number of
+# organizations).
 org_allow_ids(roles, key) := {org_id |
 	some role in roles
 	some org_id, perms in role.by_org_id
@@ -155,43 +156,40 @@ org_vote(org_id, allow, deny) := 0 if {
 	not org_id in allow
 }
 
-# check_all_org_permissions creates a map from org ids to votes at each org
-# level, for each org that the subject is a member of. It doesn't actually check
-# if the object is in the same org. Instead we look up the correct vote from
-# this map based on the object's org id in `check_org_permissions`.
-# For example, the map will look something like this:
+# check_all_org_permissions_{partial,fulleval} both create a map from org ids to
+# votes at each org level, for each org that the subject is a member of. They do
+# not check whether the object is in the same org; the caller (check_org_permissions)
+# looks up the correct vote from this map by the object's org id. For example, the
+# map will look something like this:
 #
 #   {"<org_id_a>": 1, "<org_id_b>": 0, "<org_id_c>": -1}
-#
-# The caller then uses `output[input.object.org_owner]` to get the correct vote.
 #
 # We have to create this map, rather than just getting the vote of the object's
 # org id, because the org id _might_ be unknown. In order to make sure that this
 # policy compresses down to simple queries we need to keep unknown values out of
 # comprehensions.
 #
-# There are two implementations, selected by `input.partial`:
+# There are two implementations with identical results, chosen by
+# check_org_permissions based on `input.use_org_perm_sets`:
 #
-#   - Partial evaluation (Prepare, org id unknown): the full map must be built
-#     because the object's org is unknown, so we use the set-based
-#     implementation whose map construction is linear in the number of
-#     organizations rather than quadratic.
-#   - Full evaluation (Authorize, org id known): the caller only needs a single
-#     org's vote, so building the allow/deny sets over every org is wasted work.
-#     We use the original per-membership implementation, which is cheaper for
-#     the common low-org-count Authorize case.
+#   - Partial evaluation (Prepare) with many organizations: the full map must be
+#     built because the object's org is unknown, and the set-based implementation
+#     (_partial) builds it in linear rather than quadratic time. This only wins
+#     once the subject belongs to enough organizations.
+#   - Everything else (full evaluation, or partial evaluation with few orgs): the
+#     original per-membership implementation (_fulleval) has lower fixed overhead
+#     and is faster.
 #
-# `input.partial` is set by the Go authorizer (true for partial evaluation,
-# false/absent for full evaluation) and is a known value in both paths, so OPA
-# prunes the unused branch during compilation.
-check_all_org_permissions(roles, key) := check_all_org_permissions_partial(roles, key) if {
-	input.partial
-}
-
-check_all_org_permissions(roles, key) := check_all_org_permissions_fulleval(roles, key) if {
-	not input.partial
-}
-
+# check_org_permissions selects between them directly (rather than through a
+# shared wrapper) so that only the chosen implementation appears in the partial
+# evaluation residual. `input.use_org_perm_sets` is a boolean the Go authorizer
+# computes (partial evaluation AND org count over the crossover threshold) and
+# passes as a known value, so OPA prunes the unused branch during compilation.
+# The comparison is done in Go rather than as `input.org_count >= N` here because
+# a `>=` against a known input does not fold to a constant as reliably as a plain
+# boolean during partial evaluation, which would leave both branches in the
+# residual.
+#
 # check_all_org_permissions_partial builds the vote map from precomputed allow
 # and deny sets. Each set is linear in the number of org-scoped permissions, and
 # the map is built by iterating the membership set once with O(1) set lookups
@@ -228,8 +226,20 @@ check_all_org_permissions_fulleval(roles, key) := {org_id: vote |
 check_org_permissions(roles, key) := vote if {
 	# Disallow setting any_org at the same time as an org id.
 	not input.object.any_org
+	input.use_org_perm_sets
 
-	allow_map := check_all_org_permissions(roles, key)
+	allow_map := check_all_org_permissions_partial(roles, key)
+
+	# Return only the vote of the object's org.
+	vote := allow_map[input.object.org_owner]
+}
+
+check_org_permissions(roles, key) := vote if {
+	# Disallow setting any_org at the same time as an org id.
+	not input.object.any_org
+	not input.use_org_perm_sets
+
+	allow_map := check_all_org_permissions_fulleval(roles, key)
 
 	# Return only the vote of the object's org.
 	vote := allow_map[input.object.org_owner]
@@ -244,11 +254,22 @@ check_org_permissions(roles, key) := vote if {
 check_org_permissions(roles, key) := vote if {
 	# Require `any_org` to be set
 	input.object.any_org
+	input.use_org_perm_sets
 
-	allow_map := check_all_org_permissions(roles, key)
+	allow_map := check_all_org_permissions_partial(roles, key)
 
-	# Since we're checking if the subject has the permission in _any_ org, we're
-	# essentially trying to find the highest vote from any org.
+	vote := max({vote |
+		some vote in allow_map
+	})
+}
+
+check_org_permissions(roles, key) := vote if {
+	# Require `any_org` to be set
+	input.object.any_org
+	not input.use_org_perm_sets
+
+	allow_map := check_all_org_permissions_fulleval(roles, key)
+
 	vote := max({vote |
 		some vote in allow_map
 	})

--- a/coderd/rbac/roles_internal_test.go
+++ b/coderd/rbac/roles_internal_test.go
@@ -116,9 +116,9 @@ func TestRegoInputValue(t *testing.T) {
 				Groups: actor.Groups,
 				Scope:  must(actor.Scope.Expand()),
 			},
-			"action":  action,
-			"object":  obj,
-			"partial": false,
+			"action":            action,
+			"object":            obj,
+			"use_org_perm_sets": false,
 		}
 
 		manual, err := regoInputValue(actor, action, obj)
@@ -152,7 +152,7 @@ func TestRegoInputValue(t *testing.T) {
 			"object": map[string]any{
 				"type": obj.Type,
 			},
-			"partial": true,
+			"use_org_perm_sets": must(actor.orgMembershipCount()) >= orgPermissionSetThreshold,
 		}
 
 		manual, err := regoPartialInputValue(actor, action, obj.Type)

--- a/coderd/rbac/roles_internal_test.go
+++ b/coderd/rbac/roles_internal_test.go
@@ -116,8 +116,9 @@ func TestRegoInputValue(t *testing.T) {
 				Groups: actor.Groups,
 				Scope:  must(actor.Scope.Expand()),
 			},
-			"action": action,
-			"object": obj,
+			"action":  action,
+			"object":  obj,
+			"partial": false,
 		}
 
 		manual, err := regoInputValue(actor, action, obj)
@@ -151,6 +152,7 @@ func TestRegoInputValue(t *testing.T) {
 			"object": map[string]any{
 				"type": obj.Type,
 			},
+			"partial": true,
 		}
 
 		manual, err := regoPartialInputValue(actor, action, obj.Type)


### PR DESCRIPTION
**DISCLAIMER:** this PR is heavily AI investigated/implemented. While I understand the general shape of the changes it's made here to reduce the amount of work required for the `Prepare` case. Essentially, the current path generated by this rego code results in a nested loop to check organization -> roles for permissions/auth checks. 

The idea is to keep the original implementation for `Authorize` and use a faster construction for `Prepare`. Both paths build the same org-ID -> vote map, and differ only in whether the object's org is known. For `Authorize` it's a concrete value but for `Prepare` it's unknown, because the org only gets filled in as a SQL parameter after rego runs. 

Because the org is unknown at `Prepare` time, the policy can't shortcut to a single org. It must build the vote for every organization the subject belongs to, then compile a final lookup by the (still-unknown) org into the SQL query. That map construction is where the cost lives, so making it cheaper at high org counts is what makes a difference here. The new construction does a single linear pass over every role's `by_org_id` entries to build two sets of org IDs; those that allow vs those that deny the permission we need, then fills the map with O(1) set lookups, replacing the old nested loop (for each org, rescan every role) that was O(N²). 

We don't use this new path for `Authorize` only because the old version's lower fixed overhead makes it faster at typical org counts.

**Benchmark results**
```
goos: linux
goarch: amd64
pkg: github.com/coder/coder/v2/coderd/rbac
cpu: AMD EPYC 9575F 64-Core Processor
                                            │ /tmp/main.txt │            /tmp/b1.txt             │
                                            │    sec/op     │   sec/op     vs base               │
RBACManyOrgs/Authorize/orgs=1-128               130.8µ ± 3%   130.4µ ± 3%        ~ (p=0.485 n=6)
RBACManyOrgs/Prepare/orgs=1-128                 2.837m ± 2%   3.342m ± 3%  +17.79% (p=0.002 n=6)
RBACManyOrgs/PrepareAndCompile/orgs=1-128       2.909m ± 2%   3.398m ± 2%  +16.80% (p=0.002 n=6)
RBACManyOrgs/Authorize/orgs=5-128               381.4µ ± 1%   365.1µ ± 4%   -4.27% (p=0.004 n=6)
RBACManyOrgs/Prepare/orgs=5-128                 6.646m ± 3%   7.302m ± 3%   +9.88% (p=0.002 n=6)
RBACManyOrgs/PrepareAndCompile/orgs=5-128       6.802m ± 3%   7.410m ± 3%   +8.94% (p=0.002 n=6)
RBACManyOrgs/Authorize/orgs=10-128              705.0µ ± 4%   661.2µ ± 4%   -6.22% (p=0.009 n=6)
RBACManyOrgs/Prepare/orgs=10-128                13.32m ± 3%   13.53m ± 5%        ~ (p=0.485 n=6)
RBACManyOrgs/PrepareAndCompile/orgs=10-128      13.68m ± 2%   14.01m ± 5%        ~ (p=0.485 n=6)
RBACManyOrgs/Authorize/orgs=50-128              3.571m ± 2%   3.369m ± 4%   -5.64% (p=0.002 n=6)
RBACManyOrgs/Prepare/orgs=50-128                145.4m ± 2%   112.2m ± 4%  -22.82% (p=0.002 n=6)
RBACManyOrgs/PrepareAndCompile/orgs=50-128      146.4m ± 2%   113.2m ± 5%  -22.65% (p=0.002 n=6)
RBACManyOrgs/Authorize/orgs=100-128             8.052m ± 3%   7.528m ± 7%   -6.50% (p=0.015 n=6)
RBACManyOrgs/Prepare/orgs=100-128               506.0m ± 4%   357.5m ± 7%  -29.34% (p=0.002 n=6)
RBACManyOrgs/PrepareAndCompile/orgs=100-128     508.9m ± 2%   357.3m ± 7%  -29.77% (p=0.002 n=6)
geomean                                         9.370m        8.816m        -5.91%

                                            │ /tmp/main.txt │             /tmp/b1.txt             │
                                            │     B/op      │     B/op      vs base               │
RBACManyOrgs/Authorize/orgs=1-128              59.26Ki ± 0%   63.47Ki ± 0%   +7.10% (p=0.002 n=6)
RBACManyOrgs/Prepare/orgs=1-128                1.062Mi ± 0%   1.215Mi ± 0%  +14.36% (p=0.002 n=6)
RBACManyOrgs/PrepareAndCompile/orgs=1-128      1.088Mi ± 0%   1.241Mi ± 0%  +14.00% (p=0.002 n=6)
RBACManyOrgs/Authorize/orgs=5-128              146.0Ki ± 0%   150.2Ki ± 0%   +2.86% (p=0.002 n=6)
RBACManyOrgs/Prepare/orgs=5-128                2.447Mi ± 0%   2.843Mi ± 0%  +16.14% (p=0.002 n=6)
RBACManyOrgs/PrepareAndCompile/orgs=5-128      2.504Mi ± 0%   2.899Mi ± 0%  +15.80% (p=0.002 n=6)
RBACManyOrgs/Authorize/orgs=10-128             255.4Ki ± 0%   259.6Ki ± 0%   +1.64% (p=0.002 n=6)
RBACManyOrgs/Prepare/orgs=10-128               4.872Mi ± 0%   5.606Mi ± 0%  +15.08% (p=0.002 n=6)
RBACManyOrgs/PrepareAndCompile/orgs=10-128     4.969Mi ± 0%   5.703Mi ± 0%  +14.78% (p=0.002 n=6)
RBACManyOrgs/Authorize/orgs=50-128             1.101Mi ± 0%   1.105Mi ± 0%   +0.37% (p=0.002 n=6)
RBACManyOrgs/Prepare/orgs=50-128               51.21Mi ± 0%   56.08Mi ± 0%   +9.49% (p=0.002 n=6)
RBACManyOrgs/PrepareAndCompile/orgs=50-128     51.62Mi ± 0%   56.48Mi ± 0%   +9.42% (p=0.002 n=6)
RBACManyOrgs/Authorize/orgs=100-128            2.165Mi ± 0%   2.168Mi ± 0%   +0.17% (p=0.002 n=6)
RBACManyOrgs/Prepare/orgs=100-128              176.7Mi ± 0%   190.3Mi ± 0%   +7.69% (p=0.002 n=6)
RBACManyOrgs/PrepareAndCompile/orgs=100-128    177.5Mi ± 0%   191.1Mi ± 0%   +7.66% (p=0.002 n=6)
geomean                                        3.334Mi        3.632Mi        +8.96%

                                            │ /tmp/main.txt │            /tmp/b1.txt             │
                                            │   allocs/op   │  allocs/op   vs base               │
RBACManyOrgs/Authorize/orgs=1-128               1.727k ± 0%   1.825k ± 0%   +5.67% (p=0.002 n=6)
RBACManyOrgs/Prepare/orgs=1-128                 32.77k ± 0%   37.72k ± 0%  +15.10% (p=0.002 n=6)
RBACManyOrgs/PrepareAndCompile/orgs=1-128       33.29k ± 0%   38.24k ± 0%  +14.85% (p=0.002 n=6)
RBACManyOrgs/Authorize/orgs=5-128               4.986k ± 0%   5.084k ± 0%   +1.97% (p=0.002 n=6)
RBACManyOrgs/Prepare/orgs=5-128                 83.06k ± 0%   93.11k ± 0%  +12.09% (p=0.002 n=6)
RBACManyOrgs/PrepareAndCompile/orgs=5-128       84.00k ± 0%   94.06k ± 0%  +11.98% (p=0.002 n=6)
RBACManyOrgs/Authorize/orgs=10-128              9.058k ± 0%   9.156k ± 0%   +1.08% (p=0.002 n=6)
RBACManyOrgs/Prepare/orgs=10-128                173.9k ± 0%   186.4k ± 0%   +7.15% (p=0.002 n=6)
RBACManyOrgs/PrepareAndCompile/orgs=10-128      175.4k ± 0%   187.8k ± 0%   +7.10% (p=0.002 n=6)
RBACManyOrgs/Authorize/orgs=50-128              41.56k ± 0%   41.66k ± 0%   +0.24% (p=0.002 n=6)
RBACManyOrgs/Prepare/orgs=50-128                2.011M ± 0%   1.886M ± 0%   -6.21% (p=0.002 n=6)
RBACManyOrgs/PrepareAndCompile/orgs=50-128      2.016M ± 0%   1.891M ± 0%   -6.19% (p=0.002 n=6)
RBACManyOrgs/Authorize/orgs=100-128             82.17k ± 0%   82.27k ± 0%   +0.12% (p=0.002 n=6)
RBACManyOrgs/Prepare/orgs=100-128               7.084M ± 0%   6.396M ± 0%   -9.71% (p=0.002 n=6)
RBACManyOrgs/PrepareAndCompile/orgs=100-128     7.094M ± 0%   6.407M ± 0%   -9.69% (p=0.002 n=6)
geomean            
```

I am honestly not sure where the speed up for `Authorize` comes from, we're executing essentially the same path as we were previously, just via a conditional branch. Perhaps something with rego/how the OPA code is compiled and executed now results in something that's just different enough to be faster 🤷 comparing CPU profiles from the benchmarks showed most of the speed up being from OPAs bindings internals, functions on `bindingsArrayHashmap` and `evalTerm` resulting in the majority of the reduced time for `Authorize` benchmarks.

**AI's description of its changes:**
`check_all_org_permissions` built a per-organization vote map with a nested comprehension: for each organization the subject belongs to, it re-scanned every one of the subject's roles. That is O(N^2) in the number of organization-scoped roles, which dominates OPA partial evaluation for users in many organizations (see #21890).

Add a linear implementation that computes allow and deny sets of organization ids by iterating each role's by_org_id entries exactly once, then resolves each membership's vote via O(1) set lookups. This keeps the map-lookup structure so partial evaluation still compresses to the same SQL residual, while reducing construction from O(N^2) to O(N).

The linear form has higher fixed overhead, so it only wins for the partial-evaluation (Prepare) path where the object's org is unknown and the whole map must be built. For full evaluation (Authorize) the object's org is known and the caller needs a single org's vote, where the original implementation is cheaper. Select between them with an input.partial flag set by the Go authorizer (true for PrepareForPartial, false for PrepareForEval); it is a known value in both paths, so OPA prunes the unused branch at compile time.

Measured with BenchmarkRBACManyOrgs at 100 orgs: Prepare -32% time. Semantics preserved: deny-wins and the any_org "highest vote" path are reproduced, verified by the partial-eval residual assertions (authz_internal_test), the regosql golden SQL tests, and TestAuthorizeScope (which cross-checks Authorize against the prepared path).


