### PR TITLE
feat(helm/coder): make HTTPS redirect status code configurable

### DIFF
--- a/helm/coder/templates/httproute.yaml
+++ b/helm/coder/templates/httproute.yaml
@@ -1,5 +1,11 @@
-{{- if and .Values.coder.httproute.enable .Values.coder.httproute.httpsRedirect.enable (empty .Values.coder.httproute.httpsRedirect.parentRefs) -}}
+{{- if and .Values.coder.httproute.enable .Values.coder.httproute.httpsRedirect.enable -}}
+{{- if empty .Values.coder.httproute.httpsRedirect.parentRefs -}}
 {{- fail "coder.httproute.httpsRedirect.parentRefs is required when coder.httproute.httpsRedirect.enable=true" -}}
+{{- end -}}
+{{- $httpsRedirectStatusCode := toString .Values.coder.httproute.httpsRedirect.statusCode -}}
+{{- if not (regexMatch "^(301|302|303|307|308)$" $httpsRedirectStatusCode) -}}
+{{- fail "coder.httproute.httpsRedirect.statusCode must be one of 301, 302, 303, 307, or 308." -}}
+{{- end -}}
 {{- end -}}
 
 {{- if .Values.coder.httproute.enable }}
@@ -29,6 +35,7 @@ spec:
     - {{ . | quote }}
     {{- end }}
   {{- if .Values.coder.httproute.httpsRedirect.enable }}
+{{- $httpsRedirectStatusCode := toString .Values.coder.httproute.httpsRedirect.statusCode }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -48,7 +55,7 @@ spec:
     - filters:
       - requestRedirect:
           scheme: https
-          statusCode: 308
+          statusCode: {{ $httpsRedirectStatusCode }}
         type: RequestRedirect
       matches:
       - path:

--- a/helm/coder/tests/testdata/listenerset_redirect.golden
+++ b/helm/coder/tests/testdata/listenerset_redirect.golden
@@ -253,7 +253,7 @@ spec:
     - filters:
       - requestRedirect:
           scheme: https
-          statusCode: 308
+          statusCode: 301
         type: RequestRedirect
       matches:
       - path:

--- a/helm/coder/tests/testdata/listenerset_redirect.yaml
+++ b/helm/coder/tests/testdata/listenerset_redirect.yaml
@@ -9,6 +9,7 @@ coder:
     host: coder.example.com
     httpsRedirect:
       enable: true
+      statusCode: 301
       parentRefs:
       - name: fake-gateway
         port: 80

--- a/helm/coder/tests/testdata/listenerset_redirect_coder.golden
+++ b/helm/coder/tests/testdata/listenerset_redirect_coder.golden
@@ -253,7 +253,7 @@ spec:
     - filters:
       - requestRedirect:
           scheme: https
-          statusCode: 308
+          statusCode: 301
         type: RequestRedirect
       matches:
       - path:

--- a/helm/coder/values.yaml
+++ b/helm/coder/values.yaml
@@ -513,6 +513,9 @@ coder:
       enable: false
       # coder.httproute.httpsRedirect.annotations -- The redirect HTTPRoute annotations.
       annotations: {}
+      # coder.httproute.httpsRedirect.statusCode -- The redirect response status code.
+      # Supported values are 301, 302, 303, 307, and 308.
+      statusCode: 308
       # coder.httproute.httpsRedirect.parentRefs -- the parentRefs to bind the route to
       # - kind: ListenerSet
       #   name: coder


### PR DESCRIPTION
Add coder.httproute.httpsRedirect.statusCode to configure the HTTPRoute redirect response code, defaulting to 308. Validate that the value is one of 301, 302, 303, 307, or 308.

<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->
