### PR TITLE
feat: add a run-once reservation mechanism to the workspace agent process API

### DIFF
--- a/agent/agentproc/api.go
+++ b/agent/agentproc/api.go
@@ -17,6 +17,7 @@ import (
 	"github.com/coder/coder/v2/agent/agentchat"
 	"github.com/coder/coder/v2/agent/agentexec"
 	"github.com/coder/coder/v2/agent/agentgit"
+	"github.com/coder/coder/v2/agent/agentrunonce"
 	"github.com/coder/coder/v2/agent/usershell"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/codersdk"
@@ -87,8 +88,30 @@ func (api *API) handleStartProcess(rw http.ResponseWriter, r *http.Request) {
 		chatID = chatContext.ID.String()
 	}
 
-	proc, err := api.manager.start(req, chatID)
+	proc, attached, err := api.manager.start(ctx, req, chatID)
 	if err != nil {
+		if errors.Is(err, agentrunonce.ErrInputMismatch) {
+			httpapi.Write(ctx, rw, http.StatusConflict, workspacesdk.ProcessConflictError{
+				Code: workspacesdk.ProcessConflictInputMismatch,
+				Response: codersdk.Response{
+					Message: "Idempotency key was already used to start a process with different parameters.",
+					Detail:  err.Error(),
+				},
+			})
+			return
+		}
+		if errors.Is(err, agentrunonce.ErrPublicationPending) {
+			// The concurrent start may still publish a process under
+			// this key; 409 keeps the dispatch recoverable.
+			httpapi.Write(ctx, rw, http.StatusConflict, workspacesdk.ProcessConflictError{
+				Code: workspacesdk.ProcessConflictStartPending,
+				Response: codersdk.Response{
+					Message: "Timed out waiting for the concurrent start that holds this idempotency key.",
+					Detail:  err.Error(),
+				},
+			})
+			return
+		}
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Failed to start process.",
 			Detail:  err.Error(),
@@ -99,7 +122,9 @@ func (api *API) handleStartProcess(rw http.ResponseWriter, r *http.Request) {
 	// Notify git watchers after the process finishes so that
 	// file changes made by the command are visible in the scan.
 	// If a workdir is provided, track it as a path as well.
-	if api.pathStore != nil {
+	// An attached process already has a watcher from the request
+	// that started it.
+	if api.pathStore != nil && !attached {
 		if chatContext, ok := agentchat.FromContext(ctx); ok {
 			allIDs := append([]uuid.UUID{chatContext.ID}, chatContext.AncestorIDs...)
 			go func() {
@@ -114,8 +139,11 @@ func (api *API) handleStartProcess(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	httpapi.Write(ctx, rw, http.StatusOK, workspacesdk.StartProcessResponse{
-		ID:      proc.id,
-		Started: true,
+		ID:             proc.id,
+		Started:        !attached,
+		IdempotencyKey: req.IdempotencyKey,
+		Attached:       attached,
+		StartedAt:      proc.info().StartedAt,
 	})
 }
 

--- a/agent/agentproc/api_test.go
+++ b/agent/agentproc/api_test.go
@@ -533,6 +533,205 @@ func TestStartProcess(t *testing.T) {
 	})
 }
 
+// requireConflictCode keeps conflict assertions off the error text.
+func requireConflictCode(t *testing.T, w *httptest.ResponseRecorder, want workspacesdk.ProcessConflictCode) {
+	t.Helper()
+
+	require.Equal(t, http.StatusConflict, w.Code)
+	var conflict workspacesdk.ProcessConflictError
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&conflict))
+	require.Equal(t, want, conflict.Code)
+	require.NotEmpty(t, conflict.Message)
+}
+
+func TestStartProcessIdempotencyKey(t *testing.T) {
+	t.Parallel()
+
+	t.Run("SameKeyAttaches", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newTestAPI(t)
+		req := workspacesdk.StartProcessRequest{
+			Command:        "echo hello",
+			IdempotencyKey: "key-1",
+		}
+
+		w := postStart(t, handler, req)
+		require.Equal(t, http.StatusOK, w.Code)
+		var first workspacesdk.StartProcessResponse
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&first))
+		require.True(t, first.Started)
+		require.False(t, first.Attached)
+		require.Equal(t, "key-1", first.IdempotencyKey)
+		require.NotZero(t, first.StartedAt)
+
+		w2 := postStart(t, handler, req)
+		require.Equal(t, http.StatusOK, w2.Code)
+		var second workspacesdk.StartProcessResponse
+		require.NoError(t, json.NewDecoder(w2.Body).Decode(&second))
+		require.Equal(t, first.ID, second.ID)
+		require.False(t, second.Started)
+		require.True(t, second.Attached)
+		require.Equal(t, "key-1", second.IdempotencyKey)
+		require.Equal(t, first.StartedAt, second.StartedAt)
+	})
+
+	t.Run("SameKeyDifferentCommandConflicts", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newTestAPI(t)
+		w := postStart(t, handler, workspacesdk.StartProcessRequest{
+			Command:        "echo hello",
+			IdempotencyKey: "key-1",
+		})
+		require.Equal(t, http.StatusOK, w.Code)
+
+		w2 := postStart(t, handler, workspacesdk.StartProcessRequest{
+			Command:        "echo goodbye",
+			IdempotencyKey: "key-1",
+		})
+		requireConflictCode(t, w2, workspacesdk.ProcessConflictInputMismatch)
+	})
+
+	t.Run("SameKeyWaiterTimeoutConflicts", func(t *testing.T) {
+		t.Parallel()
+
+		release := make(chan struct{})
+		releaseOnce := sync.OnceFunc(func() { close(release) })
+		t.Cleanup(releaseOnce)
+		firstStalled := make(chan struct{})
+		firstStalledOnce := sync.OnceFunc(func() { close(firstStalled) })
+		// Block the owning start after it reserves the token;
+		// updateEnv runs only for spawning starts, so it also
+		// signals that the reservation is held.
+		handler := newTestAPIWithUpdateEnv(t, func(current []string) ([]string, error) {
+			firstStalledOnce()
+			<-release
+			return current, nil
+		})
+		req := workspacesdk.StartProcessRequest{
+			Command:        "echo hello",
+			IdempotencyKey: "key-wait",
+		}
+
+		firstDone := make(chan *httptest.ResponseRecorder, 1)
+		go func() {
+			body, err := json.Marshal(req)
+			assert.NoError(t, err)
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodPost, "/start", bytes.NewReader(body))
+			handler.ServeHTTP(w, r)
+			firstDone <- w
+		}()
+		select {
+		case <-firstStalled:
+		case <-time.After(testutil.WaitShort):
+			t.Fatal("first start never reserved the key")
+		}
+
+		// The waiter's request context expires while the owner is
+		// blocked; the recoverable 409 is required, not a 500.
+		body, err := json.Marshal(req)
+		require.NoError(t, err)
+		waitCtx, cancelWait := context.WithCancel(context.Background())
+		cancelWait()
+		w := httptest.NewRecorder()
+		r := httptest.NewRequestWithContext(waitCtx, http.MethodPost, "/start", bytes.NewReader(body))
+		handler.ServeHTTP(w, r)
+		requireConflictCode(t, w, workspacesdk.ProcessConflictStartPending)
+
+		releaseOnce()
+		select {
+		case w := <-firstDone:
+			require.Equal(t, http.StatusOK, w.Code)
+		case <-time.After(testutil.WaitLong):
+			t.Fatal("first start request did not return")
+		}
+	})
+
+	t.Run("SameKeyDifferentBackgroundConflicts", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newTestAPI(t)
+		w := postStart(t, handler, workspacesdk.StartProcessRequest{
+			Command:        "echo hello",
+			IdempotencyKey: "key-1",
+		})
+		require.Equal(t, http.StatusOK, w.Code)
+
+		w2 := postStart(t, handler, workspacesdk.StartProcessRequest{
+			Command:        "echo hello",
+			Background:     true,
+			IdempotencyKey: "key-1",
+		})
+		requireConflictCode(t, w2, workspacesdk.ProcessConflictInputMismatch)
+	})
+
+	t.Run("SameKeyDifferentEnvConflicts", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newTestAPI(t)
+		w := postStart(t, handler, workspacesdk.StartProcessRequest{
+			Command:        "echo hello",
+			Env:            map[string]string{"FOO": "bar"},
+			IdempotencyKey: "key-1",
+		})
+		require.Equal(t, http.StatusOK, w.Code)
+
+		w2 := postStart(t, handler, workspacesdk.StartProcessRequest{
+			Command:        "echo hello",
+			Env:            map[string]string{"FOO": "baz"},
+			IdempotencyKey: "key-1",
+		})
+		requireConflictCode(t, w2, workspacesdk.ProcessConflictInputMismatch)
+	})
+
+	t.Run("SameKeyDifferentChatsStartIndependently", func(t *testing.T) {
+		t.Parallel()
+
+		// Reservations are scoped to the chat that supplied the key,
+		// so one chat reusing another's key value starts its own
+		// process instead of attaching or conflicting.
+		handler := newTestAPI(t)
+		req := workspacesdk.StartProcessRequest{
+			Command:        "echo hello",
+			IdempotencyKey: "key-1",
+		}
+		headerA := http.Header{}
+		headerA.Set(workspacesdk.CoderChatIDHeader, uuid.New().String())
+		headerB := http.Header{}
+		headerB.Set(workspacesdk.CoderChatIDHeader, uuid.New().String())
+
+		idA := startAndGetID(t, handler, req, headerA)
+		idB := startAndGetID(t, handler, req, headerB)
+		require.NotEqual(t, idA, idB)
+	})
+
+	t.Run("NoKeyAlwaysStartsNew", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newTestAPI(t)
+		req := workspacesdk.StartProcessRequest{
+			Command: "echo hello",
+		}
+
+		w := postStart(t, handler, req)
+		require.Equal(t, http.StatusOK, w.Code)
+		var first workspacesdk.StartProcessResponse
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&first))
+		require.True(t, first.Started)
+		require.False(t, first.Attached)
+		require.Empty(t, first.IdempotencyKey)
+
+		w2 := postStart(t, handler, req)
+		require.Equal(t, http.StatusOK, w2.Code)
+		var second workspacesdk.StartProcessResponse
+		require.NoError(t, json.NewDecoder(w2.Body).Decode(&second))
+		require.True(t, second.Started)
+		require.NotEqual(t, first.ID, second.ID)
+	})
+}
+
 func TestListProcesses(t *testing.T) {
 	t.Parallel()
 

--- a/agent/agentproc/process.go
+++ b/agent/agentproc/process.go
@@ -2,9 +2,15 @@ package agentproc
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
+	"slices"
+	"strconv"
 	"sync"
 	"syscall"
 	"time"
@@ -15,6 +21,7 @@ import (
 
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/agent/agentexec"
+	"github.com/coder/coder/v2/agent/agentrunonce"
 	"github.com/coder/coder/v2/agent/usershell"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 	"github.com/coder/quartz"
@@ -24,10 +31,43 @@ var (
 	errProcessNotFound   = xerrors.New("process not found")
 	errProcessNotRunning = xerrors.New("process is not running")
 
-	// exitedProcessReapAge is how long an exited process is
-	// kept before being automatically removed from the map.
+	// exitedProcessReapAge is how long an exited process without
+	// an idempotency key is kept before being automatically
+	// removed from the map.
 	exitedProcessReapAge = 5 * time.Minute
+
+	// keyedProcessReapAge is how long a process started under an
+	// idempotency key stays retrievable after it exits, so a retried
+	// dispatch can still read the result.
+	keyedProcessReapAge = 60 * time.Minute
 )
+
+// runOnceKey scopes an idempotency key to the chat that supplied it,
+// so two chats reusing one key value get independent reservations.
+type runOnceKey struct {
+	chatID string
+	key    string
+}
+
+// startFingerprint digests the request fields that decide what gets
+// spawned. The workdir is taken as requested rather than resolved, so
+// an identical retry attaches even when the default directory
+// resolves differently between the two.
+func startFingerprint(req workspacesdk.StartProcessRequest) string {
+	h := sha256.New()
+	// Length-prefix every field so no combination of values can
+	// serialize to the same bytes as a different combination.
+	write := func(values ...string) {
+		for _, v := range values {
+			_, _ = fmt.Fprintf(h, "%d:%s", len(v), v)
+		}
+	}
+	write(req.Command, req.WorkDir, strconv.FormatBool(req.Background))
+	for _, k := range slices.Sorted(maps.Keys(req.Env)) {
+		write(k, req.Env[k])
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
 
 // process represents a running or completed process.
 type process struct {
@@ -37,15 +77,18 @@ type process struct {
 	workDir    string
 	background bool
 	chatID     string
-	cmd        *exec.Cmd
-	cancel     context.CancelFunc
-	buf        *HeadTailBuffer
-	logger     slog.Logger
-	running    bool
-	exitCode   *int
-	startedAt  int64
-	exitedAt   *int64
-	done       chan struct{} // closed when process exits
+	// keyed marks a process started under an idempotency key. Reaping
+	// leaves those to the registry, which retains them longer.
+	keyed     bool
+	cmd       *exec.Cmd
+	cancel    context.CancelFunc
+	buf       *HeadTailBuffer
+	logger    slog.Logger
+	running   bool
+	exitCode  *int
+	startedAt int64
+	exitedAt  *int64
+	done      chan struct{} // closed when process exits
 }
 
 // info returns a snapshot of the process state.
@@ -73,12 +116,15 @@ func (p *process) output() (string, *workspacesdk.ProcessTruncation) {
 
 // manager tracks processes spawned by the agent.
 type manager struct {
-	mu         sync.Mutex
-	logger     slog.Logger
-	execer     agentexec.Execer
-	fs         afero.Fs
-	clock      quartz.Clock
-	procs      map[string]*process
+	mu     sync.Mutex
+	logger slog.Logger
+	execer agentexec.Execer
+	fs     afero.Fs
+	clock  quartz.Clock
+	procs  map[string]*process
+	// runOnce reserves idempotency keys so a retried start attaches
+	// to the process the first one spawned. It holds process IDs.
+	runOnce    *agentrunonce.Registry[runOnceKey, string]
 	closed     bool
 	updateEnv  func(current []string) (updated []string, err error)
 	workingDir func() string
@@ -99,6 +145,7 @@ func newManager(logger slog.Logger, execer agentexec.Execer, fs afero.Fs, envInf
 		fs:         fs,
 		clock:      quartz.NewReal(),
 		procs:      make(map[string]*process),
+		runOnce:    agentrunonce.NewRegistry[runOnceKey, string](keyedProcessReapAge),
 		updateEnv:  updateEnv,
 		workingDir: workingDir,
 		envInfo:    envInfo,
@@ -109,13 +156,51 @@ func newManager(logger slog.Logger, execer agentexec.Execer, fs afero.Fs, envInf
 // processes use a long-lived context so the process survives
 // the HTTP request lifecycle. The background flag only affects
 // client-side polling behavior.
-func (m *manager) start(req workspacesdk.StartProcessRequest, chatID string) (*process, error) {
+//
+// A request whose idempotency key already started a process returns
+// that process with attached true. Reusing a key within one chat with
+// different parameters fails with agentrunonce.ErrInputMismatch. The
+// context only bounds the wait for a concurrent start holding the
+// same key; it does not cancel the spawned process.
+func (m *manager) start(ctx context.Context, req workspacesdk.StartProcessRequest, chatID string) (*process, bool, error) {
+	workDir := m.resolveWorkingDirectory(req.WorkDir)
+
 	m.mu.Lock()
-	if m.closed {
-		m.mu.Unlock()
-		return nil, xerrors.New("manager is closed")
-	}
+	m.reapExitedLocked(m.clock.Now())
 	m.mu.Unlock()
+
+	var (
+		key      *runOnceKey
+		reserved *agentrunonce.Ticket[runOnceKey, string]
+	)
+	if req.IdempotencyKey != "" {
+		key = &runOnceKey{chatID: chatID, key: req.IdempotencyKey}
+	}
+	for key != nil {
+		outcome, err := m.runOnce.Reserve(ctx, *key, startFingerprint(req))
+		if err != nil {
+			if errors.Is(err, agentrunonce.ErrClosed) {
+				return nil, false, xerrors.New("manager is closed")
+			}
+			if errors.Is(err, agentrunonce.ErrPublicationPending) && m.isClosed() {
+				return nil, false, xerrors.Errorf("manager is closed: %w", err)
+			}
+			return nil, false, err
+		}
+		if outcome.Ticket != nil {
+			reserved = outcome.Ticket
+			break
+		}
+		m.mu.Lock()
+		existing, ok := m.procs[outcome.Value]
+		m.mu.Unlock()
+		if ok {
+			return existing, true, nil
+		}
+		// Reaping removed the process after the reservation resolved.
+		// Forget only the observed generation, then reserve again.
+		m.runOnce.Forget(*key, outcome.Generation)
+	}
 
 	id := uuid.New().String()
 	logger := m.logger
@@ -128,7 +213,7 @@ func (m *manager) start(req workspacesdk.StartProcessRequest, chatID string) (*p
 	// the process is not tied to any HTTP request.
 	ctx, cancel := context.WithCancel(context.Background())
 	cmd := m.execer.CommandContext(ctx, "sh", "-c", req.Command)
-	cmd.Dir = m.resolveWorkingDirectory(req.WorkDir)
+	cmd.Dir = workDir
 	cmd.Stdin = nil
 	cmd.SysProcAttr = procSysProcAttr()
 
@@ -171,9 +256,21 @@ func (m *manager) start(req workspacesdk.StartProcessRequest, chatID string) (*p
 		cmd.Env = append(cmd.Env, fmt.Sprintf("CODER_CHAT_ID=%s", chatID))
 	}
 
-	if err := cmd.Start(); err != nil {
+	// Spawn, insert and publish in one critical section with the
+	// closed check, so every spawned process is visible to Close's
+	// kill pass and to every attaching caller.
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
 		cancel()
-		return nil, xerrors.Errorf("start process: %w", err)
+		releaseReservation(reserved)
+		return nil, false, xerrors.New("manager is closed")
+	}
+	if err := cmd.Start(); err != nil {
+		m.mu.Unlock()
+		cancel()
+		releaseReservation(reserved)
+		return nil, false, xerrors.Errorf("start process: %w", err)
 	}
 
 	now := m.clock.Now().Unix()
@@ -183,6 +280,7 @@ func (m *manager) start(req workspacesdk.StartProcessRequest, chatID string) (*p
 		workDir:    cmd.Dir,
 		background: req.Background,
 		chatID:     chatID,
+		keyed:      key != nil,
 		cmd:        cmd,
 		cancel:     cancel,
 		buf:        buf,
@@ -192,16 +290,10 @@ func (m *manager) start(req workspacesdk.StartProcessRequest, chatID string) (*p
 		done:       make(chan struct{}),
 	}
 
-	m.mu.Lock()
-	if m.closed {
-		m.mu.Unlock()
-		// Manager closed between our check and now. Kill the
-		// process we just started.
-		cancel()
-		_ = cmd.Wait()
-		return nil, xerrors.New("manager is closed")
-	}
 	m.procs[id] = proc
+	if reserved != nil {
+		reserved.Publish(id)
+	}
 	m.mu.Unlock()
 
 	go func() {
@@ -231,13 +323,35 @@ func (m *manager) start(req workspacesdk.StartProcessRequest, chatID string) (*p
 		proc.exitCode = &code
 		proc.mu.Unlock()
 
+		// Retention runs from exit, so a retry can still read this
+		// result until the reservation is reaped.
+		if key != nil {
+			m.runOnce.Complete(*key, m.clock.Now())
+		}
+
 		// Wake any waiters blocked on new output or
 		// process exit before closing the done channel.
 		proc.buf.Close()
 		close(proc.done)
 	}()
 
-	return proc, nil
+	return proc, false, nil
+}
+
+// releaseReservation frees a reservation that will never publish a
+// process, so waiting callers reserve the key again.
+func releaseReservation(reserved *agentrunonce.Ticket[runOnceKey, string]) {
+	if reserved == nil {
+		return
+	}
+	reserved.Release()
+}
+
+func (m *manager) isClosed() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.closed
 }
 
 // get returns a process by ID.
@@ -248,34 +362,49 @@ func (m *manager) get(id string) (*process, bool) {
 	return proc, ok
 }
 
-// list returns info about all tracked processes. Exited
-// processes older than exitedProcessReapAge are removed.
-// If chatID is non-empty, only processes belonging to that
-// chat are returned.
+// list returns info about all tracked processes, reaping exited ones
+// past their retention age first. If chatID is non-empty, only
+// processes belonging to that chat are returned.
 func (m *manager) list(chatID string) []workspacesdk.ProcessInfo {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	now := m.clock.Now()
+	m.reapExitedLocked(m.clock.Now())
+
 	infos := make([]workspacesdk.ProcessInfo, 0, len(m.procs))
-	for id, proc := range m.procs {
-		info := proc.info()
-		// Reap processes that exited more than 5 minutes ago
-		// to prevent unbounded map growth.
-		if !info.Running && info.ExitedAt != nil {
-			exitedAt := time.Unix(*info.ExitedAt, 0)
-			if now.Sub(exitedAt) > exitedProcessReapAge {
-				delete(m.procs, id)
-				continue
-			}
-		}
+	for _, proc := range m.procs {
 		// Filter by chatID if provided.
 		if chatID != "" && proc.chatID != chatID {
 			continue
 		}
-		infos = append(infos, info)
+		infos = append(infos, proc.info())
 	}
 	return infos
+}
+
+// reapExitedLocked removes exited processes past their retention age
+// to prevent unbounded map growth. Keyed processes are retained by
+// the reservation registry instead, and for longer. The manager mutex
+// must be held.
+func (m *manager) reapExitedLocked(now time.Time) {
+	// Remove the reservation and process together so every retained
+	// reservation still points to a tracked process.
+	for _, id := range m.runOnce.Reap(now) {
+		delete(m.procs, id)
+	}
+	for id, proc := range m.procs {
+		if proc.keyed {
+			continue
+		}
+		info := proc.info()
+		if info.Running || info.ExitedAt == nil {
+			continue
+		}
+		if now.Sub(time.Unix(*info.ExitedAt, 0)) <= exitedProcessReapAge {
+			continue
+		}
+		delete(m.procs, id)
+	}
 }
 
 // signal sends a signal to a running process. It returns
@@ -328,6 +457,9 @@ func (m *manager) Close() error {
 		return nil
 	}
 	m.closed = true
+	m.runOnce.Close()
+	// The spawn path inserts under the same lock that checks closed,
+	// so this snapshot is complete.
 	procs := make([]*process, 0, len(m.procs))
 	for _, p := range m.procs {
 		procs = append(procs, p)

--- a/agent/agentproc/process_internal_test.go
+++ b/agent/agentproc/process_internal_test.go
@@ -1,0 +1,381 @@
+package agentproc
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"cdr.dev/slog/v3"
+	"cdr.dev/slog/v3/sloggers/slogtest"
+	"github.com/coder/coder/v2/agent/agentexec"
+	"github.com/coder/coder/v2/agent/agentrunonce"
+	"github.com/coder/coder/v2/codersdk/workspacesdk"
+	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/quartz"
+)
+
+type managerOption func(*manager)
+
+func withUpdateEnv(fn func(current []string) (updated []string, err error)) managerOption {
+	return func(m *manager) { m.updateEnv = fn }
+}
+
+func withWorkingDir(fn func() string) managerOption {
+	return func(m *manager) { m.workingDir = fn }
+}
+
+func withMockClock(clock quartz.Clock) managerOption {
+	return func(m *manager) { m.clock = clock }
+}
+
+func newTestManager(t *testing.T, opts ...managerOption) *manager {
+	t.Helper()
+
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	m := newManager(logger, agentexec.DefaultExecer, nil, nil, nil, nil)
+	for _, opt := range opts {
+		opt(m)
+	}
+	t.Cleanup(func() {
+		_ = m.Close()
+	})
+	return m
+}
+
+// startGate stalls the first start between its reservation and the
+// spawn, so a test can act while that reservation is pending. Later
+// starts pass through.
+type startGate struct {
+	stalled  chan struct{}
+	released chan struct{}
+	first    atomic.Bool
+	release  func()
+}
+
+func newStartGate(t *testing.T) *startGate {
+	t.Helper()
+
+	g := &startGate{
+		stalled:  make(chan struct{}),
+		released: make(chan struct{}),
+	}
+	g.release = sync.OnceFunc(func() { close(g.released) })
+	t.Cleanup(g.release)
+	return g
+}
+
+func (g *startGate) option() managerOption {
+	return withUpdateEnv(func(current []string) ([]string, error) {
+		if g.first.CompareAndSwap(false, true) {
+			close(g.stalled)
+			<-g.released
+		}
+		return current, nil
+	})
+}
+
+func (g *startGate) waitStalled(t *testing.T) {
+	t.Helper()
+
+	select {
+	case <-g.stalled:
+	case <-time.After(testutil.WaitShort):
+		t.Fatal("no start reached the gate")
+	}
+}
+
+type startResult struct {
+	proc     *process
+	attached bool
+	err      error
+}
+
+func startAsync(ctx context.Context, m *manager, req workspacesdk.StartProcessRequest, chatID string) <-chan startResult {
+	results := make(chan startResult, 1)
+	go func() {
+		proc, attached, err := m.start(ctx, req, chatID)
+		results <- startResult{proc: proc, attached: attached, err: err}
+	}()
+	return results
+}
+
+func awaitStart(t *testing.T, results <-chan startResult) startResult {
+	t.Helper()
+
+	select {
+	case res := <-results:
+		return res
+	case <-time.After(testutil.WaitShort):
+		t.Fatal("start did not return")
+		return startResult{}
+	}
+}
+
+func requireStarted(t *testing.T, m *manager, req workspacesdk.StartProcessRequest, chatID string) *process {
+	t.Helper()
+
+	proc, attached, err := m.start(context.Background(), req, chatID)
+	require.NoError(t, err)
+	require.False(t, attached)
+	return proc
+}
+
+func requireAttached(t *testing.T, m *manager, req workspacesdk.StartProcessRequest, chatID string) *process {
+	t.Helper()
+
+	proc, attached, err := m.start(context.Background(), req, chatID)
+	require.NoError(t, err)
+	require.True(t, attached)
+	return proc
+}
+
+func requireTracked(t *testing.T, m *manager, id string) bool {
+	t.Helper()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	_, ok := m.procs[id]
+	return ok
+}
+
+func TestReapFreesKeyedReservation(t *testing.T) {
+	t.Parallel()
+
+	mClock := quartz.NewMock(t)
+	m := newTestManager(t, withMockClock(mClock))
+
+	req := workspacesdk.StartProcessRequest{
+		Command:        "echo hello",
+		IdempotencyKey: "key-1",
+	}
+	proc := requireStarted(t, m, req, "chat-1")
+	<-proc.done
+
+	// The key keeps attaching to the exited process until the reap
+	// age passes, so a retried start still sees the result.
+	require.Equal(t, proc.id, requireAttached(t, m, req, "chat-1").id)
+
+	mClock.Advance(keyedProcessReapAge + time.Minute)
+
+	// The sweep on start reaps the exited process, frees its
+	// reservation, and the same key starts fresh.
+	fresh := requireStarted(t, m, req, "chat-1")
+	require.NotEqual(t, proc.id, fresh.id)
+	require.False(t, requireTracked(t, m, proc.id))
+	require.Equal(t, 1, m.runOnce.Len())
+	<-fresh.done
+}
+
+func TestKeyedRetryIgnoresDefaultWorkdirDrift(t *testing.T) {
+	t.Parallel()
+
+	// The default directory resolves differently across starts, like
+	// an agent whose manifest loads between a dispatch and its retry.
+	dirs := make(chan string, 2)
+	dirs <- ""
+	dirs <- t.TempDir()
+	m := newTestManager(t, withWorkingDir(func() string { return <-dirs }))
+
+	req := workspacesdk.StartProcessRequest{
+		Command:        "echo hello",
+		IdempotencyKey: "key-dir-drift",
+	}
+	proc := requireStarted(t, m, req, "chat-1")
+	<-proc.done
+
+	require.Equal(t, proc.id, requireAttached(t, m, req, "chat-1").id)
+}
+
+func TestUnkeyedProcessesReapSooner(t *testing.T) {
+	t.Parallel()
+
+	mClock := quartz.NewMock(t)
+	m := newTestManager(t, withMockClock(mClock))
+
+	plain := requireStarted(t, m, workspacesdk.StartProcessRequest{
+		Command: "echo hello",
+	}, "chat-1")
+	<-plain.done
+
+	keyed := requireStarted(t, m, workspacesdk.StartProcessRequest{
+		Command:        "echo hello",
+		IdempotencyKey: "key-1",
+	}, "chat-1")
+	<-keyed.done
+
+	// Past exitedProcessReapAge but within keyedProcessReapAge.
+	mClock.Advance(exitedProcessReapAge + time.Minute)
+	m.mu.Lock()
+	m.reapExitedLocked(mClock.Now())
+	m.mu.Unlock()
+
+	require.False(t, requireTracked(t, m, plain.id))
+	require.True(t, requireTracked(t, m, keyed.id))
+}
+
+func TestConcurrentSameKeyStartsOnce(t *testing.T) {
+	t.Parallel()
+
+	m := newTestManager(t)
+	req := workspacesdk.StartProcessRequest{
+		Command:        "echo hello",
+		IdempotencyKey: "key-race",
+	}
+
+	const workers = 8
+	results := make([]<-chan startResult, 0, workers)
+	for range workers {
+		results = append(results, startAsync(context.Background(), m, req, "chat-1"))
+	}
+
+	ids := make(map[string]struct{})
+	attaches := 0
+	for _, result := range results {
+		res := awaitStart(t, result)
+		require.NoError(t, res.err)
+		ids[res.proc.id] = struct{}{}
+		if res.attached {
+			attaches++
+		}
+	}
+	require.Len(t, ids, 1)
+	require.Equal(t, workers-1, attaches)
+
+	m.mu.Lock()
+	procCount := len(m.procs)
+	m.mu.Unlock()
+	require.Equal(t, 1, procCount)
+}
+
+func TestSameKeyWaiterHonorsCancellation(t *testing.T) {
+	t.Parallel()
+
+	gate := newStartGate(t)
+	m := newTestManager(t, gate.option())
+	req := workspacesdk.StartProcessRequest{
+		Command:        "echo hello",
+		IdempotencyKey: "key-cancel",
+	}
+
+	firstStart := startAsync(context.Background(), m, req, "chat-1")
+	gate.waitStalled(t)
+
+	waiterCtx, cancelWaiter := context.WithCancel(context.Background())
+	waiter := startAsync(waiterCtx, m, req, "chat-1")
+	cancelWaiter()
+
+	res := awaitStart(t, waiter)
+	require.ErrorIs(t, res.err, context.Canceled)
+	// The sentinel routes the failure to a 409: the stalled start may
+	// still publish a process, so callers must not treat the dispatch
+	// as failed.
+	require.ErrorIs(t, res.err, agentrunonce.ErrPublicationPending)
+
+	// The stalled start is unaffected by the waiter's cancellation.
+	gate.release()
+	require.NoError(t, awaitStart(t, firstStart).err)
+
+	proc := requireAttached(t, m, req, "chat-1")
+	<-proc.done
+}
+
+func TestSameKeyInDifferentChatsStartsIndependently(t *testing.T) {
+	t.Parallel()
+
+	gate := newStartGate(t)
+	m := newTestManager(t, gate.option())
+	req := workspacesdk.StartProcessRequest{
+		Command:        "echo hello",
+		IdempotencyKey: "key-cross-chat",
+	}
+
+	chatA := startAsync(context.Background(), m, req, "chat-a")
+	gate.waitStalled(t)
+
+	// Chat B reserves its own key even while chat A's reservation is
+	// pending, rather than waiting on it or conflicting with it.
+	procB := requireStarted(t, m, req, "chat-b")
+
+	gate.release()
+	resA := awaitStart(t, chatA)
+	require.NoError(t, resA.err)
+	require.False(t, resA.attached)
+	require.NotEqual(t, procB.id, resA.proc.id)
+	require.Equal(t, 2, m.runOnce.Len())
+}
+
+func TestSameKeyWaiterUnblocksOnClose(t *testing.T) {
+	t.Parallel()
+
+	gate := newStartGate(t)
+	m := newTestManager(t, gate.option())
+	req := workspacesdk.StartProcessRequest{
+		Command:        "echo hello",
+		IdempotencyKey: "key-close",
+	}
+
+	firstStart := startAsync(context.Background(), m, req, "chat-1")
+	gate.waitStalled(t)
+	waiter := startAsync(context.Background(), m, req, "chat-1")
+
+	require.NoError(t, m.Close())
+
+	res := awaitStart(t, waiter)
+	require.ErrorContains(t, res.err, "manager is closed")
+	require.ErrorIs(t, res.err, agentrunonce.ErrPublicationPending)
+
+	// The stalled start never reached the spawn, so it reports the
+	// close instead of dispatching a command after shutdown.
+	gate.release()
+	require.ErrorContains(t, awaitStart(t, firstStart).err, "manager is closed")
+}
+
+func TestCloseBeforeSpawnAbortsStart(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		req  workspacesdk.StartProcessRequest
+	}{
+		{
+			name: "Keyed",
+			req: workspacesdk.StartProcessRequest{
+				Command:        "sleep 600",
+				IdempotencyKey: "key-close-race",
+			},
+		},
+		{
+			name: "Unkeyed",
+			req:  workspacesdk.StartProcessRequest{Command: "sleep 600"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gate := newStartGate(t)
+			m := newTestManager(t, gate.option())
+
+			start := startAsync(context.Background(), m, tc.req, "chat-1")
+			gate.waitStalled(t)
+			require.NoError(t, m.Close())
+			gate.release()
+
+			// A start that loses the race to Close never runs the
+			// command, and leaves no process or reservation behind.
+			res := awaitStart(t, start)
+			require.ErrorContains(t, res.err, "manager is closed")
+			require.Nil(t, res.proc)
+
+			m.mu.Lock()
+			published := len(m.procs)
+			m.mu.Unlock()
+			require.Zero(t, published)
+			require.Zero(t, m.runOnce.Len())
+		})
+	}
+}

--- a/agent/agentrunonce/registry.go
+++ b/agent/agentrunonce/registry.go
@@ -1,0 +1,236 @@
+// Package agentrunonce provides keyed reservations that let one caller
+// perform an operation while later callers presenting the same input
+// attach to the value it published. Values are never interpreted, so
+// any kind of operation can use the same rule.
+package agentrunonce
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"golang.org/x/xerrors"
+)
+
+var (
+	// ErrInputMismatch reports a key reserved earlier with a
+	// different input fingerprint. Retrying cannot resolve it.
+	ErrInputMismatch = xerrors.New("key was already reserved with a different input")
+
+	// ErrPublicationPending reports a reservation that was still
+	// pending when the wait ended. The outcome is unresolved rather
+	// than failed.
+	ErrPublicationPending = xerrors.New("gave up waiting for the reservation to be published")
+
+	// ErrClosed reports a new reservation attempt on a closed registry.
+	ErrClosed = xerrors.New("registry is closed")
+)
+
+// entry is one reservation. completedAt starts the retention window,
+// so a zero completedAt keeps the entry indefinitely.
+type entry[V any] struct {
+	fingerprint string
+	value       V
+	published   bool
+	completedAt time.Time
+	done        chan struct{}
+	// generation numbers successive reservations of one key. Forget
+	// uses it to avoid deleting a replacement reservation.
+	generation uint64
+}
+
+// Registry tracks reservations for one kind of operation.
+type Registry[K comparable, V any] struct {
+	mu         sync.Mutex
+	retention  time.Duration
+	entries    map[K]*entry[V]
+	generation uint64
+	closed     bool
+	// closeCh releases waiting callers on shutdown instead of
+	// stranding them until their own contexts expire.
+	closeCh chan struct{}
+}
+
+func NewRegistry[K comparable, V any](retention time.Duration) *Registry[K, V] {
+	return &Registry[K, V]{
+		retention: retention,
+		entries:   make(map[K]*entry[V]),
+		closeCh:   make(chan struct{}),
+	}
+}
+
+// Outcome reports how a reservation attempt resolved. Either Ticket is
+// set, meaning this caller must perform the operation, or Value came
+// from a caller that already did.
+type Outcome[K comparable, V any] struct {
+	Ticket *Ticket[K, V]
+	Value  V
+	// Generation identifies the reservation Value came from. Pass it
+	// back to Forget so a stale value cannot evict a newer one.
+	Generation uint64
+}
+
+// Ticket is the handle to a pending reservation. Its holder must call
+// Publish or Release; whichever lands first decides the outcome.
+type Ticket[K comparable, V any] struct {
+	registry *Registry[K, V]
+	key      K
+	entry    *entry[V]
+}
+
+// Reserve resolves a key to either a ticket for a new reservation or
+// the value already published for the same fingerprint. The context
+// only limits how long a caller waits for a pending reservation. It
+// does not bound the operation itself.
+func (r *Registry[K, V]) Reserve(ctx context.Context, key K, fingerprint string) (Outcome[K, V], error) {
+	var zero Outcome[K, V]
+	for {
+		outcome, pending, err := r.tryReserve(key, fingerprint)
+		if err != nil {
+			return zero, err
+		}
+		if pending == nil {
+			return outcome, nil
+		}
+		if err := r.waitForPublication(ctx, pending); err != nil {
+			return zero, err
+		}
+	}
+}
+
+// tryReserve takes a free key, and otherwise reports either the
+// resolved outcome or the pending entry to wait on.
+func (r *Registry[K, V]) tryReserve(key K, fingerprint string) (Outcome[K, V], *entry[V], error) {
+	var zero Outcome[K, V]
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	existing, ok := r.entries[key]
+	if !ok {
+		if r.closed {
+			return zero, nil, ErrClosed
+		}
+		r.generation++
+		reserved := &entry[V]{
+			fingerprint: fingerprint,
+			done:        make(chan struct{}),
+			generation:  r.generation,
+		}
+		r.entries[key] = reserved
+		return Outcome[K, V]{
+			Ticket:     &Ticket[K, V]{registry: r, key: key, entry: reserved},
+			Generation: reserved.generation,
+		}, nil, nil
+	}
+	if existing.fingerprint != fingerprint {
+		return zero, nil, ErrInputMismatch
+	}
+	if existing.published {
+		return Outcome[K, V]{Value: existing.value, Generation: existing.generation}, nil, nil
+	}
+	return zero, existing, nil
+}
+
+// waitForPublication blocks until the reservation is published or
+// released. It must be called without holding r.mu.
+func (r *Registry[K, V]) waitForPublication(ctx context.Context, pending *entry[V]) error {
+	select {
+	case <-pending.done:
+		return nil
+	case <-r.closeCh:
+		return ErrPublicationPending
+	case <-ctx.Done():
+		return xerrors.Errorf("wait for reservation to be published: %w", errors.Join(ErrPublicationPending, ctx.Err()))
+	}
+}
+
+func (r *Registry[K, V]) Len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return len(r.entries)
+}
+
+// Complete starts a published reservation's retention window.
+func (r *Registry[K, V]) Complete(key K, now time.Time) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if existing, ok := r.entries[key]; ok && existing.published {
+		existing.completedAt = now
+	}
+}
+
+// Forget drops the published reservation identified by generation,
+// whose value the caller found unusable, so the next reservation for
+// that key starts fresh. Deleting by key alone could evict a newer
+// reservation that replaced it and let its operation run twice.
+// Pending reservations are never dropped.
+func (r *Registry[K, V]) Forget(key K, generation uint64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if existing, ok := r.entries[key]; ok && existing.published && existing.generation == generation {
+		delete(r.entries, key)
+	}
+}
+
+// Reap removes reservations whose retention window has elapsed and
+// returns their values so the caller can release what they refer to.
+func (r *Registry[K, V]) Reap(now time.Time) []V {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var evicted []V
+	for key, existing := range r.entries {
+		if existing.completedAt.IsZero() || now.Sub(existing.completedAt) <= r.retention {
+			continue
+		}
+		delete(r.entries, key)
+		evicted = append(evicted, existing.value)
+	}
+	return evicted
+}
+
+// Close releases waiting callers and refuses new reservations. Already
+// published reservations keep serving their value.
+func (r *Registry[K, V]) Close() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.closed {
+		return
+	}
+	r.closed = true
+	close(r.closeCh)
+}
+
+// Publish records the value later callers attach to and wakes waiters.
+func (t *Ticket[K, V]) Publish(value V) {
+	t.registry.mu.Lock()
+	defer t.registry.mu.Unlock()
+
+	if t.entry.published {
+		return
+	}
+	t.entry.value = value
+	t.entry.published = true
+	close(t.entry.done)
+}
+
+// Release abandons an unpublished reservation so another caller can
+// take over the key.
+func (t *Ticket[K, V]) Release() {
+	t.registry.mu.Lock()
+	defer t.registry.mu.Unlock()
+
+	if t.entry.published {
+		return
+	}
+	if t.registry.entries[t.key] == t.entry {
+		delete(t.registry.entries, t.key)
+	}
+	close(t.entry.done)
+}

--- a/agent/agentrunonce/registry_test.go
+++ b/agent/agentrunonce/registry_test.go
@@ -1,0 +1,435 @@
+package agentrunonce_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/agent/agentrunonce"
+	"github.com/coder/coder/v2/testutil"
+)
+
+const testRetention = time.Hour
+
+type reserveResult struct {
+	outcome agentrunonce.Outcome[string, string]
+	err     error
+}
+
+func TestReserveOwnsThenAttaches(t *testing.T) {
+	t.Parallel()
+
+	registry := agentrunonce.NewRegistry[string, string](testRetention)
+
+	outcome, err := registry.Reserve(context.Background(), "key", "fp")
+	require.NoError(t, err)
+	require.NotNil(t, outcome.Ticket)
+
+	outcome.Ticket.Publish("value")
+
+	again, err := registry.Reserve(context.Background(), "key", "fp")
+	require.NoError(t, err)
+	require.Nil(t, again.Ticket)
+	require.Equal(t, "value", again.Value)
+}
+
+func TestReserveRejectsDifferentInputWhilePending(t *testing.T) {
+	t.Parallel()
+
+	registry := agentrunonce.NewRegistry[string, string](testRetention)
+
+	outcome, err := registry.Reserve(context.Background(), "key", "fp")
+	require.NoError(t, err)
+	require.NotNil(t, outcome.Ticket)
+
+	// Answered without waiting out the pending reservation.
+	_, err = registry.Reserve(context.Background(), "key", "other")
+	require.ErrorIs(t, err, agentrunonce.ErrInputMismatch)
+
+	outcome.Ticket.Publish("value")
+
+	_, err = registry.Reserve(context.Background(), "key", "other")
+	require.ErrorIs(t, err, agentrunonce.ErrInputMismatch)
+}
+
+func TestReserveWaitsForPublish(t *testing.T) {
+	t.Parallel()
+
+	registry := agentrunonce.NewRegistry[string, string](testRetention)
+
+	held, err := registry.Reserve(context.Background(), "key", "fp")
+	require.NoError(t, err)
+
+	attached := make(chan reserveResult, 1)
+	go func() {
+		outcome, err := registry.Reserve(context.Background(), "key", "fp")
+		attached <- reserveResult{outcome: outcome, err: err}
+	}()
+
+	held.Ticket.Publish("value")
+
+	got := testutil.RequireReceive(testutil.Context(t, testutil.WaitShort), t, attached)
+	require.NoError(t, got.err)
+	require.Equal(t, "value", got.outcome.Value)
+}
+
+func TestReserveTakesOverReleasedReservation(t *testing.T) {
+	t.Parallel()
+
+	registry := agentrunonce.NewRegistry[string, string](testRetention)
+
+	held, err := registry.Reserve(context.Background(), "key", "fp")
+	require.NoError(t, err)
+
+	second := make(chan reserveResult, 1)
+	go func() {
+		outcome, err := registry.Reserve(context.Background(), "key", "fp")
+		second <- reserveResult{outcome: outcome, err: err}
+	}()
+
+	// The operation never got underway, so the waiter must take over
+	// the key rather than attach to a value that will never exist.
+	held.Ticket.Release()
+
+	got := testutil.RequireReceive(testutil.Context(t, testutil.WaitShort), t, second)
+	require.NoError(t, got.err)
+	require.NotNil(t, got.outcome.Ticket)
+}
+
+func TestReserveWaitHonorsCancellation(t *testing.T) {
+	t.Parallel()
+
+	registry := agentrunonce.NewRegistry[string, string](testRetention)
+
+	_, err := registry.Reserve(context.Background(), "key", "fp")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	waiter := make(chan error, 1)
+	go func() {
+		_, err := registry.Reserve(ctx, "key", "fp")
+		waiter <- err
+	}()
+	cancel()
+
+	err = testutil.RequireReceive(testutil.Context(t, testutil.WaitShort), t, waiter)
+	require.ErrorIs(t, err, agentrunonce.ErrPublicationPending)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestCloseUnblocksWaiterAndRefusesNewKeys(t *testing.T) {
+	t.Parallel()
+
+	registry := agentrunonce.NewRegistry[string, string](testRetention)
+
+	_, err := registry.Reserve(context.Background(), "key", "fp")
+	require.NoError(t, err)
+
+	waiter := make(chan error, 1)
+	go func() {
+		_, err := registry.Reserve(context.Background(), "key", "fp")
+		waiter <- err
+	}()
+
+	registry.Close()
+
+	err = testutil.RequireReceive(testutil.Context(t, testutil.WaitShort), t, waiter)
+	require.ErrorIs(t, err, agentrunonce.ErrPublicationPending)
+
+	_, err = registry.Reserve(context.Background(), "other", "fp")
+	require.ErrorIs(t, err, agentrunonce.ErrClosed)
+}
+
+func TestConcurrentReserveIssuesOneTicket(t *testing.T) {
+	t.Parallel()
+
+	registry := agentrunonce.NewRegistry[string, string](testRetention)
+
+	const callers = 8
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		tickets int
+		values  []string
+		errs    []error
+		publish = make(chan struct{})
+	)
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			outcome, err := registry.Reserve(context.Background(), "key", "fp")
+			mu.Lock()
+			switch {
+			case err != nil:
+				errs = append(errs, err)
+			case outcome.Ticket != nil:
+				tickets++
+			default:
+				values = append(values, outcome.Value)
+			}
+			mu.Unlock()
+			if err == nil && outcome.Ticket != nil {
+				<-publish
+				outcome.Ticket.Publish("value")
+			}
+		}()
+	}
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return tickets == 1
+	}, testutil.WaitShort, testutil.IntervalFast)
+	close(publish)
+	wg.Wait()
+
+	require.Empty(t, errs)
+	require.Equal(t, 1, tickets)
+	require.Len(t, values, callers-1)
+	for _, value := range values {
+		require.Equal(t, "value", value)
+	}
+}
+
+func TestRetentionEvictsCompletedReservations(t *testing.T) {
+	t.Parallel()
+
+	registry := agentrunonce.NewRegistry[string, string](testRetention)
+	start := time.Now()
+
+	outcome, err := registry.Reserve(context.Background(), "key", "fp")
+	require.NoError(t, err)
+	outcome.Ticket.Publish("value")
+
+	// A published reservation whose operation is still in flight is
+	// retained regardless of age: retention starts at completion.
+	require.Empty(t, registry.Reap(start.Add(testRetention*2)))
+	require.Equal(t, 1, registry.Len())
+
+	registry.Complete("key", start)
+	require.Empty(t, registry.Reap(start.Add(testRetention)))
+
+	require.Equal(t, []string{"value"}, registry.Reap(start.Add(testRetention).Add(time.Second)))
+	require.Zero(t, registry.Len())
+
+	fresh, err := registry.Reserve(context.Background(), "key", "fp")
+	require.NoError(t, err)
+	require.NotNil(t, fresh.Ticket)
+}
+
+func TestCompleteIgnoresPendingReservation(t *testing.T) {
+	t.Parallel()
+
+	registry := agentrunonce.NewRegistry[string, string](testRetention)
+	start := time.Now()
+
+	_, err := registry.Reserve(context.Background(), "key", "fp")
+	require.NoError(t, err)
+
+	registry.Complete("key", start)
+	registry.Complete("missing", start)
+
+	require.Empty(t, registry.Reap(start.Add(testRetention*2)))
+	require.Equal(t, 1, registry.Len())
+}
+
+func TestForgetDropsPublishedButKeepsPending(t *testing.T) {
+	t.Parallel()
+
+	registry := agentrunonce.NewRegistry[string, string](testRetention)
+
+	pending, err := registry.Reserve(context.Background(), "pending", "fp")
+	require.NoError(t, err)
+
+	published, err := registry.Reserve(context.Background(), "published", "fp")
+	require.NoError(t, err)
+	published.Ticket.Publish("value")
+
+	// Dropping a pending reservation would let a second caller
+	// perform an operation another caller is already performing.
+	registry.Forget("pending", pending.Generation)
+	registry.Forget("published", published.Generation)
+
+	require.Equal(t, 1, registry.Len())
+
+	outcome, err := registry.Reserve(context.Background(), "published", "fp")
+	require.NoError(t, err)
+	require.NotNil(t, outcome.Ticket)
+
+	pending.Ticket.Release()
+}
+
+// The two adapters below exercise the seam the registry exists for:
+// one operation publishes a handle to a live resource it keeps
+// managing, another publishes a plain response value. Neither shape
+// is known to the registry.
+
+type fakeProcess struct {
+	id      string
+	running bool
+}
+
+type fakeProcessAdapter struct {
+	registry *agentrunonce.Registry[string, string]
+	mu       sync.Mutex
+	procs    map[string]*fakeProcess
+	spawns   int
+}
+
+func newFakeProcessAdapter() *fakeProcessAdapter {
+	return &fakeProcessAdapter{
+		registry: agentrunonce.NewRegistry[string, string](testRetention),
+		procs:    map[string]*fakeProcess{},
+	}
+}
+
+func (a *fakeProcessAdapter) start(ctx context.Context, key, command string) (*fakeProcess, bool, error) {
+	outcome, err := a.registry.Reserve(ctx, key, command)
+	if err != nil {
+		return nil, false, err
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if outcome.Ticket == nil {
+		return a.procs[outcome.Value], true, nil
+	}
+	a.spawns++
+	proc := &fakeProcess{id: command + "-proc", running: true}
+	a.procs[proc.id] = proc
+	outcome.Ticket.Publish(proc.id)
+	return proc, false, nil
+}
+
+func (a *fakeProcessAdapter) exit(key, id string, now time.Time) {
+	a.mu.Lock()
+	a.procs[id].running = false
+	a.mu.Unlock()
+	a.registry.Complete(key, now)
+}
+
+func TestAdapterPublishingLiveHandle(t *testing.T) {
+	t.Parallel()
+
+	adapter := newFakeProcessAdapter()
+	start := time.Now()
+
+	proc, attached, err := adapter.start(context.Background(), "key", "run")
+	require.NoError(t, err)
+	require.False(t, attached)
+
+	again, attached, err := adapter.start(context.Background(), "key", "run")
+	require.NoError(t, err)
+	require.True(t, attached)
+	require.Same(t, proc, again)
+	require.Equal(t, 1, adapter.spawns)
+
+	// The handle stays attachable after the resource stops, so a
+	// repeated caller still observes the outcome it missed.
+	adapter.exit("key", proc.id, start)
+	exited, attached, err := adapter.start(context.Background(), "key", "run")
+	require.NoError(t, err)
+	require.True(t, attached)
+	require.False(t, exited.running)
+	require.Equal(t, 1, adapter.spawns)
+
+	for _, id := range adapter.registry.Reap(start.Add(testRetention).Add(time.Second)) {
+		delete(adapter.procs, id)
+	}
+	_, attached, err = adapter.start(context.Background(), "key", "run")
+	require.NoError(t, err)
+	require.False(t, attached)
+	require.Equal(t, 2, adapter.spawns)
+}
+
+type fakeEditResult struct {
+	paths []string
+}
+
+type fakeEditAdapter struct {
+	registry *agentrunonce.Registry[string, fakeEditResult]
+	mu       sync.Mutex
+	applied  int
+}
+
+func TestAdapterPublishingPlainValue(t *testing.T) {
+	t.Parallel()
+
+	adapter := &fakeEditAdapter{registry: agentrunonce.NewRegistry[string, fakeEditResult](testRetention)}
+	start := time.Now()
+
+	edit := func(key, fingerprint string) (fakeEditResult, error) {
+		outcome, err := adapter.registry.Reserve(context.Background(), key, fingerprint)
+		if err != nil {
+			return fakeEditResult{}, err
+		}
+		if outcome.Ticket == nil {
+			return outcome.Value, nil
+		}
+		adapter.mu.Lock()
+		adapter.applied++
+		adapter.mu.Unlock()
+		result := fakeEditResult{paths: []string{"main.go"}}
+		outcome.Ticket.Publish(result)
+		// A value operation is terminal as soon as it produces its
+		// result, unlike a process that stays live after publishing.
+		adapter.registry.Complete(key, start)
+		return result, nil
+	}
+
+	first, err := edit("key", "fp")
+	require.NoError(t, err)
+	require.Equal(t, []string{"main.go"}, first.paths)
+
+	// The replayed call returns the recorded result rather than
+	// applying an edit whose original text no longer matches.
+	replay, err := edit("key", "fp")
+	require.NoError(t, err)
+	require.Equal(t, first, replay)
+	require.Equal(t, 1, adapter.applied)
+
+	_, err = edit("key", "different")
+	require.ErrorIs(t, err, agentrunonce.ErrInputMismatch)
+	require.Equal(t, 1, adapter.applied)
+}
+
+func TestForgetIgnoresSupersededGeneration(t *testing.T) {
+	t.Parallel()
+
+	registry := agentrunonce.NewRegistry[string, string](testRetention)
+	start := time.Now()
+
+	first, err := registry.Reserve(context.Background(), "key", "fp")
+	require.NoError(t, err)
+	first.Ticket.Publish("first")
+
+	stale, err := registry.Reserve(context.Background(), "key", "fp")
+	require.NoError(t, err)
+	require.Equal(t, "first", stale.Value)
+
+	// The reservation the stale observation came from is reaped and the
+	// key reserved and published again.
+	registry.Complete("key", start)
+	require.Equal(t, []string{"first"}, registry.Reap(start.Add(testRetention).Add(time.Second)))
+	second, err := registry.Reserve(context.Background(), "key", "fp")
+	require.NoError(t, err)
+	require.NotNil(t, second.Ticket)
+	second.Ticket.Publish("second")
+
+	// Forgetting with the stale generation must not evict the newer
+	// reservation, or its operation would run a second time.
+	registry.Forget("key", stale.Generation)
+
+	outcome, err := registry.Reserve(context.Background(), "key", "fp")
+	require.NoError(t, err)
+	require.Nil(t, outcome.Ticket)
+	require.Equal(t, "second", outcome.Value)
+
+	registry.Forget("key", second.Generation)
+	fresh, err := registry.Reserve(context.Background(), "key", "fp")
+	require.NoError(t, err)
+	require.NotNil(t, fresh.Ticket)
+}

--- a/codersdk/workspacesdk/agentconn.go
+++ b/codersdk/workspacesdk/agentconn.go
@@ -911,12 +911,52 @@ type StartProcessRequest struct {
 	WorkDir    string            `json:"workdir,omitempty"`
 	Env        map[string]string `json:"env,omitempty"`
 	Background bool              `json:"background,omitempty"`
+	// IdempotencyKey makes the start idempotent: a repeated key with
+	// matching inputs attaches to the process it already started,
+	// and a mismatch is refused.
+	IdempotencyKey string `json:"idempotency_key,omitempty"`
 }
 
 // StartProcessResponse is returned when a process is started.
 type StartProcessResponse struct {
-	ID      string `json:"id"`
-	Started bool   `json:"started"`
+	ID             string `json:"id"`
+	Started        bool   `json:"started"`
+	IdempotencyKey string `json:"idempotency_key,omitempty"`
+	// Attached reports that ID names a process an earlier start
+	// created, so this request spawned nothing. Agents that predate
+	// idempotent starts omit it, along with the two fields around it.
+	Attached bool `json:"attached,omitempty"`
+	// StartedAt is when the process originally started, in unix
+	// seconds, so a replay waits out only the budget that remains.
+	StartedAt int64 `json:"started_at,omitempty"`
+}
+
+type ProcessConflictCode string
+
+const (
+	// ProcessConflictInputMismatch reports a key already used to
+	// start a process with different parameters. Retrying cannot
+	// resolve it.
+	ProcessConflictInputMismatch ProcessConflictCode = "input_mismatch"
+
+	// ProcessConflictStartPending reports that the start holding the
+	// key had not published its process before the wait gave up. A
+	// retry may still attach to it.
+	ProcessConflictStartPending ProcessConflictCode = "start_pending"
+)
+
+// ProcessConflictError is the body of a start request rejected
+// because its idempotency key belongs to another start.
+type ProcessConflictError struct {
+	Code ProcessConflictCode `json:"code"`
+	codersdk.Response
+}
+
+func (e *ProcessConflictError) Error() string {
+	if e.Detail == "" {
+		return e.Message
+	}
+	return fmt.Sprintf("%s: %s", e.Message, e.Detail)
 }
 
 // ListProcessesResponse contains information about tracked
@@ -1327,11 +1367,35 @@ func (c *agentConn) StartProcess(ctx context.Context, req StartProcessRequest) (
 		return StartProcessResponse{}, xerrors.Errorf("do request: %w", err)
 	}
 	defer res.Body.Close()
+	if res.StatusCode == http.StatusConflict {
+		return StartProcessResponse{}, readProcessConflictError(res)
+	}
 	if res.StatusCode != http.StatusOK {
 		return StartProcessResponse{}, codersdk.ReadBodyAsError(res)
 	}
 	var resp StartProcessResponse
 	return resp, decodeAgentJSON(res, &resp)
+}
+
+func readProcessConflictError(res *http.Response) error {
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return xerrors.Errorf("read response body: %w", err)
+	}
+	// Restore the body so the fallback can read it too.
+	res.Body = io.NopCloser(bytes.NewReader(body))
+
+	var conflict ProcessConflictError
+	if err := json.Unmarshal(body, &conflict); err != nil || conflict.Message == "" {
+		return codersdk.ReadBodyAsError(res)
+	}
+	if conflict.Code == "" {
+		// Treat an unrecognized conflict as permanent: reporting an
+		// unresolved start as permanent costs an error result, while
+		// the reverse risks running the command twice.
+		conflict.Code = ProcessConflictInputMismatch
+	}
+	return &conflict
 }
 
 // ListProcesses returns information about tracked processes on the agent.

--- a/codersdk/workspacesdk/agentconn.go
+++ b/codersdk/workspacesdk/agentconn.go
@@ -911,12 +911,52 @@ type StartProcessRequest struct {
 	WorkDir    string            `json:"workdir,omitempty"`
 	Env        map[string]string `json:"env,omitempty"`
 	Background bool              `json:"background,omitempty"`
+	// IdempotencyKey makes the start idempotent: a repeated key with
+	// matching inputs attaches to the process it already started,
+	// and a mismatch is refused.
+	IdempotencyKey string `json:"idempotency_key,omitempty"`
 }
 
 // StartProcessResponse is returned when a process is started.
 type StartProcessResponse struct {
-	ID      string `json:"id"`
-	Started bool   `json:"started"`
+	ID             string `json:"id"`
+	Started        bool   `json:"started"`
+	IdempotencyKey string `json:"idempotency_key,omitempty"`
+	// Attached reports that ID names a process an earlier start
+	// created, so this request spawned nothing. Agents that predate
+	// idempotent starts omit it, along with the two fields around it.
+	Attached bool `json:"attached,omitempty"`
+	// StartedAt is when the process originally started, in unix
+	// seconds, so a replay waits out only the budget that remains.
+	StartedAt int64 `json:"started_at,omitempty"`
+}
+
+type ProcessConflictCode string
+
+const (
+	// ProcessConflictInputMismatch reports a key already used to
+	// start a process with different parameters. Retrying cannot
+	// resolve it.
+	ProcessConflictInputMismatch ProcessConflictCode = "input_mismatch"
+
+	// ProcessConflictStartPending reports that the start holding the
+	// key had not published its process before the wait gave up. A
+	// retry may still attach to it.
+	ProcessConflictStartPending ProcessConflictCode = "start_pending"
+)
+
+// ProcessConflictError is the body of a start request rejected
+// because its idempotency key belongs to another start.
+type ProcessConflictError struct {
+	Code ProcessConflictCode `json:"code"`
+	codersdk.Response
+}
+
+func (e *ProcessConflictError) Error() string {
+	if e.Detail == "" {
+		return e.Message
+	}
+	return fmt.Sprintf("%s: %s", e.Message, e.Detail)
 }
 
 // ListProcessesResponse contains information about tracked
@@ -1273,11 +1313,35 @@ func (c *agentConn) StartProcess(ctx context.Context, req StartProcessRequest) (
 		return StartProcessResponse{}, xerrors.Errorf("do request: %w", err)
 	}
 	defer res.Body.Close()
+	if res.StatusCode == http.StatusConflict {
+		return StartProcessResponse{}, readProcessConflictError(res)
+	}
 	if res.StatusCode != http.StatusOK {
 		return StartProcessResponse{}, codersdk.ReadBodyAsError(res)
 	}
 	var resp StartProcessResponse
 	return resp, json.NewDecoder(res.Body).Decode(&resp)
+}
+
+func readProcessConflictError(res *http.Response) error {
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return xerrors.Errorf("read response body: %w", err)
+	}
+	// Restore the body so the fallback can read it too.
+	res.Body = io.NopCloser(bytes.NewReader(body))
+
+	var conflict ProcessConflictError
+	if err := json.Unmarshal(body, &conflict); err != nil || conflict.Message == "" {
+		return codersdk.ReadBodyAsError(res)
+	}
+	if conflict.Code == "" {
+		// Treat an unrecognized conflict as permanent: reporting an
+		// unresolved start as permanent costs an error result, while
+		// the reverse risks running the command twice.
+		conflict.Code = ProcessConflictInputMismatch
+	}
+	return &conflict
 }
 
 // ListProcesses returns information about tracked processes on the agent.

--- a/codersdk/workspacesdk/agentconn_internal_test.go
+++ b/codersdk/workspacesdk/agentconn_internal_test.go
@@ -1,12 +1,62 @@
 package workspacesdk
 
 import (
+	"io"
+	"net/http"
 	neturl "net/url"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestReadProcessConflictError(t *testing.T) {
+	t.Parallel()
+
+	response := func(body string) *http.Response {
+		return &http.Response{
+			StatusCode: http.StatusConflict,
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}
+	}
+
+	t.Run("decodes coded conflict", func(t *testing.T) {
+		t.Parallel()
+
+		res := response(`{"code":"start_pending","message":"Timed out.","detail":"owner pending"}`)
+		defer res.Body.Close()
+		err := readProcessConflictError(res)
+		var conflict *ProcessConflictError
+		require.ErrorAs(t, err, &conflict)
+		require.Equal(t, ProcessConflictStartPending, conflict.Code)
+		require.Equal(t, "Timed out.: owner pending", conflict.Error())
+	})
+
+	t.Run("treats uncoded conflict as permanent", func(t *testing.T) {
+		t.Parallel()
+
+		// Reporting an unrecognized conflict as permanent costs an
+		// error result; the reverse risks running the command twice.
+		res := response(`{"message":"Conflict."}`)
+		defer res.Body.Close()
+		err := readProcessConflictError(res)
+		var conflict *ProcessConflictError
+		require.ErrorAs(t, err, &conflict)
+		require.Equal(t, ProcessConflictInputMismatch, conflict.Code)
+	})
+
+	t.Run("falls back when body is not a conflict", func(t *testing.T) {
+		t.Parallel()
+
+		res := response(`not json`)
+		defer res.Body.Close()
+		err := readProcessConflictError(res)
+		var conflict *ProcessConflictError
+		require.NotErrorAs(t, err, &conflict)
+		require.Error(t, err)
+	})
+}
 
 func TestAgentAPIPath(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Stack context

Part 1 of the CODAGT-757 stack. Replaces the earlier "idempotent start tokens" version of this PR after review: the reservation rule now lives in its own mechanism rather than inside process management.

## Why

A chat that resumes after a crash replays tool calls history still shows as unresolved. For `execute` that means running the shell command a second time. Preventing it needs a rule the agent can apply to a repeated request: perform the operation once, and answer a repeat with what the first attempt produced.

That rule is not specific to starting processes. `edit_files` is the clearest second candidate: replaying it is actively harmful, because the text it searched for has already been replaced, so the retry either fails or matches a changed file differently.

## What

`agent/agentrunonce` holds the rule and nothing else:

- reserve a key before doing any work, so a concurrent caller waits instead of repeating it;
- attach later callers presenting the same input fingerprint to the value that was published;
- refuse a key reused with a different fingerprint;
- release a reservation whose operation never got underway, so a waiter takes it over;
- retain completed reservations for a while, then evict them.

The registry is generic over both the key and the published value, and never interprets either. That is what lets operations with unlike results share the rule: this PR's adapter publishes a handle to a live process that the process manager keeps managing, while a future `edit_files` adapter would publish a plain response value. Both fake adapters are covered in the registry's own tests.

Process starts are the only adapter here. The process manager still owns output buffers, exit state, signals, and git-watcher registration.

## Reservations are scoped to the chat

Following review, the registry key is a composite of the chat and the idempotency key, so two chats that send the same key value get independent reservations instead of colliding. Chat is therefore no longer part of the fingerprint, and cross-chat reuse no longer produces a false conflict.

The fingerprint covers only what decides what gets spawned: command, requested workdir, env, and the background flag. Display intent and how long the caller waits are excluded, since neither changes the process.

Two behavioral notes:

- Recording the fingerprint when the key is reserved means a mismatched retry is refused immediately, without first waiting out the concurrent start it could never attach to.
- A reservation becomes attachable when the process spawns, but its retention starts when the process exits. Those are deliberately separate events; starting retention at publication would evict long-running processes mid-flight.

## Machine-readable conflicts

Start conflicts carry a code, so callers do not classify them by matching error text:

| Code | Meaning |
|---|---|
| `input_mismatch` | The key was used within the same chat with different parameters. Permanent; retrying cannot resolve it. |
| `start_pending` | The start holding the key had not published its process yet. Unresolved; a retry may attach. |

The code rides a route-specific `ProcessConflictError` rather than a new field on the global `codersdk.Response`, following the existing `WatchError` precedent. Agents that predate this never answered 409 here, so an uncoded conflict is reported as permanent: treating an unresolved start as permanent costs an error result, while the reverse risks running the command twice.

## Review changes in this revision

- Registry keys are `{chatID, idempotencyKey}` composites; the cross-chat conflict test became a cross-chat independence test.
- `ClientToken` is now `IdempotencyKey` on the wire (`idempotency_key`) and in Go. No `client_token` reference existed anywhere at merge-base, so there is no compatibility cost.
- `ErrOwnerPending` is now `ErrPublicationPending`, and `Outcome.Owner` is now `Outcome.Ticket`, so the API no longer uses "owner" for a concept the reviewer found unclear.
- The unlock-then-wait section of `Reserve` moved into `tryReserve` plus `waitForPublication`, so no method unlocks a mutex it did not take.
- `process_internal_test.go` was rewritten around shared helpers (`newTestManager`, `startGate`, `startAsync`, `awaitStart`), and the two close-before-spawn tests collapsed into one table.
- Added comments were cut roughly in half and rewritten in plain English.

> This PR was written and revised by Mux, an AI coding agent, operating on Mike's behalf.
