### PR TITLE
fix(coderd/x/chatd): bound task attempts by progress instead of a fixed deadline

### DIFF
--- a/coderd/x/chatd/ARCHITECTURE.md
+++ b/coderd/x/chatd/ARCHITECTURE.md
@@ -853,6 +853,13 @@ Retriable conditions include, but are not limited to:
 - database connection error;
 - LLM API request error, with the exception of hitting the generation attempt limit, which is considered to be a successful completion of the operation the goroutine was meant to perform.
 
+#### Task attempt watchdog
+
+Every attempt of a runner goroutine runs under two watchdog timers. Both cancel the attempt with a timeout error that the retry wrapper classifies as retryable:
+
+- An **idle window** (15 minutes). Only the `execute` and `process_output` tools reset it, after every successful process-API round-trip: process starts, blocking output polls (including rounds where the process is still running), and `process_output` retrievals. Long-running `execute` calls therefore survive as long as the workspace agent keeps responding, and the re-attach path resumes them across retries. This scoping is deliberate: other workspace tools finish well within the idle window, and letting quick tools extend an attempt would change how long a stuck attempt can live without real command progress. The window is attempt-scoped, so a progressing `execute` also extends sibling tools running in the same step; a stuck sibling is then canceled 15 minutes after the last kick instead of 15 minutes after the step started. Sibling tools that block on model-supplied durations are bounded per call instead of riding the attempt: a single `wait_agent` block is clamped to 10 minutes, below the idle window so its resumable timeout result commits before the watchdog cancels the attempt, and a single `computer` wait action is clamped to 30 seconds (the model repeats the action for longer settles). The reset function travels in the attempt context and resetting is a safe no-op once the attempt has ended. Streaming code never resets the watchdog, so the idle window stays above chatloop's 10 minute stream-silence guard and silent provider streams keep failing through chat-specific retry handling before the attempt times out.
+- An **absolute cap** (24 hours) that is never reset. It bounds a single attempt regardless of tool progress.
+
 #### Generation goroutine
 
 The generation goroutine is responsible for calling the LLM API and executing tools. It is spawned when the event indicates the core state machine is in `R0` or `R1` (status is `running`).

--- a/coderd/x/chatd/ARCHITECTURE.md
+++ b/coderd/x/chatd/ARCHITECTURE.md
@@ -813,6 +813,13 @@ Retriable conditions include, but are not limited to:
 - database connection error;
 - LLM API request error, with the exception of hitting the generation attempt limit, which is considered to be a successful completion of the operation the goroutine was meant to perform.
 
+#### Task attempt watchdog
+
+Every attempt of a runner goroutine runs under two watchdog timers. Both cancel the attempt with a timeout error that the retry wrapper classifies as retryable:
+
+- An **idle window** (15 minutes). Only the `execute` and `process_output` tools reset it, after every successful process-API round-trip: process starts, blocking output polls (including rounds where the process is still running), and `process_output` retrievals. Long-running `execute` calls therefore survive as long as the workspace agent keeps responding, and the re-attach path resumes them across retries. This scoping is deliberate: other workspace tools finish well within the idle window, and letting quick tools extend an attempt would change how long a stuck attempt can live without real command progress. The window is attempt-scoped, so a progressing `execute` also extends sibling tools running in the same step; a stuck sibling is then canceled 15 minutes after the last kick instead of 15 minutes after the step started. Sibling tools that block on model-supplied durations are bounded per call instead of riding the attempt: a single `wait_agent` block is clamped to 10 minutes, below the idle window so its resumable timeout result commits before the watchdog cancels the attempt, and a single `computer` wait action is clamped to 30 seconds (the model repeats the action for longer settles). The reset function travels in the attempt context and resetting is a safe no-op once the attempt has ended. Streaming code never resets the watchdog, so the idle window stays above chatloop's 10 minute stream-silence guard and silent provider streams keep failing through chat-specific retry handling before the attempt times out.
+- An **absolute cap** (24 hours) that is never reset. It bounds a single attempt regardless of tool progress.
+
 #### Generation goroutine
 
 The generation goroutine is responsible for calling the LLM API and executing tools. It is spawned when the event indicates the core state machine is in `R0` or `R1` (status is `running`).

--- a/coderd/x/chatd/chatloop/chatloop.go
+++ b/coderd/x/chatd/chatloop/chatloop.go
@@ -28,6 +28,7 @@ import (
 	"github.com/coder/coder/v2/coderd/x/chatd/chatretry"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatsanitize"
 	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
+	"github.com/coder/coder/v2/coderd/x/chatd/internal/watchdog"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/quartz"
 )
@@ -802,65 +803,16 @@ type guardedAttempt struct {
 	finish  func(error) error
 }
 
-// streamSilenceGuard arbitrates whether an attempt times out while
-// waiting for the next stream part. Exactly one outcome wins: the
-// timer cancels the attempt, or release disarms the timer.
-type streamSilenceGuard struct {
-	mu      sync.Mutex
-	timer   *quartz.Timer
-	cancel  context.CancelCauseFunc
-	timeout time.Duration
-	settled bool
-}
-
+// newStreamSilenceGuard arms the watchdog that arbitrates whether an
+// attempt times out while waiting for the next stream part. Exactly
+// one outcome wins: the timer cancels the attempt, or Disarm stops
+// the timer.
 func newStreamSilenceGuard(
 	clock quartz.Clock,
 	timeout time.Duration,
 	cancel context.CancelCauseFunc,
-) *streamSilenceGuard {
-	guard := &streamSilenceGuard{
-		cancel:  cancel,
-		timeout: timeout,
-	}
-	guard.timer = clock.AfterFunc(
-		timeout,
-		guard.onTimeout,
-		streamSilenceGuardTimerTag,
-	)
-	return guard
-}
-
-func (g *streamSilenceGuard) settle() bool {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	if g.settled {
-		return false
-	}
-	g.settled = true
-	return true
-}
-
-func (g *streamSilenceGuard) onTimeout() {
-	if !g.settle() {
-		return
-	}
-	g.cancel(errStreamSilenceTimeout)
-}
-
-func (g *streamSilenceGuard) Reset() {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	if g.settled {
-		return
-	}
-	g.timer.Reset(g.timeout, streamSilenceGuardTimerTag)
-}
-
-func (g *streamSilenceGuard) Disarm() {
-	if !g.settle() {
-		return
-	}
-	g.timer.Stop()
+) *watchdog.Timer {
+	return watchdog.New(clock, timeout, cancel, errStreamSilenceTimeout, streamSilenceGuardTimerTag)
 }
 
 func classifyStreamSilenceTimeout(

--- a/coderd/x/chatd/chatloop/chatloop.go
+++ b/coderd/x/chatd/chatloop/chatloop.go
@@ -28,6 +28,7 @@ import (
 	"github.com/coder/coder/v2/coderd/x/chatd/chatretry"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatsanitize"
 	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
+	"github.com/coder/coder/v2/coderd/x/chatd/internal/watchdog"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/quartz"
 )
@@ -672,65 +673,16 @@ type guardedAttempt struct {
 	finish  func(error) error
 }
 
-// streamSilenceGuard arbitrates whether an attempt times out while
-// waiting for the next stream part. Exactly one outcome wins: the
-// timer cancels the attempt, or release disarms the timer.
-type streamSilenceGuard struct {
-	mu      sync.Mutex
-	timer   *quartz.Timer
-	cancel  context.CancelCauseFunc
-	timeout time.Duration
-	settled bool
-}
-
+// newStreamSilenceGuard arms the watchdog that arbitrates whether an
+// attempt times out while waiting for the next stream part. Exactly
+// one outcome wins: the timer cancels the attempt, or Disarm stops
+// the timer.
 func newStreamSilenceGuard(
 	clock quartz.Clock,
 	timeout time.Duration,
 	cancel context.CancelCauseFunc,
-) *streamSilenceGuard {
-	guard := &streamSilenceGuard{
-		cancel:  cancel,
-		timeout: timeout,
-	}
-	guard.timer = clock.AfterFunc(
-		timeout,
-		guard.onTimeout,
-		streamSilenceGuardTimerTag,
-	)
-	return guard
-}
-
-func (g *streamSilenceGuard) settle() bool {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	if g.settled {
-		return false
-	}
-	g.settled = true
-	return true
-}
-
-func (g *streamSilenceGuard) onTimeout() {
-	if !g.settle() {
-		return
-	}
-	g.cancel(errStreamSilenceTimeout)
-}
-
-func (g *streamSilenceGuard) Reset() {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	if g.settled {
-		return
-	}
-	g.timer.Reset(g.timeout, streamSilenceGuardTimerTag)
-}
-
-func (g *streamSilenceGuard) Disarm() {
-	if !g.settle() {
-		return
-	}
-	g.timer.Stop()
+) *watchdog.Timer {
+	return watchdog.New(clock, timeout, cancel, errStreamSilenceTimeout, streamSilenceGuardTimerTag)
 }
 
 func classifyStreamSilenceTimeout(

--- a/coderd/x/chatd/chatloop/chatloop_run_internal_test.go
+++ b/coderd/x/chatd/chatloop/chatloop_run_internal_test.go
@@ -3,7 +3,6 @@ package chatloop
 import (
 	"context"
 	"encoding/base64"
-	"errors"
 	"iter"
 	"runtime"
 	"slices"
@@ -93,43 +92,10 @@ func toolResultContentToPart(toolResult fantasy.ToolResultContent) fantasy.ToolR
 	}
 }
 
-func TestStreamSilenceGuard_DisarmAndFireRace(t *testing.T) {
-	t.Parallel()
-
-	for range 128 {
-		var cancels atomic.Int32
-		guard := newStreamSilenceGuard(quartz.NewReal(), time.Hour, func(err error) {
-			if errors.Is(err, errStreamSilenceTimeout) {
-				cancels.Add(1)
-			}
-		})
-
-		start := make(chan struct{})
-		var wg sync.WaitGroup
-		wg.Add(2)
-
-		go func() {
-			defer wg.Done()
-			<-start
-			guard.onTimeout()
-		}()
-
-		go func() {
-			defer wg.Done()
-			<-start
-			guard.Disarm()
-		}()
-
-		close(start)
-		wg.Wait()
-
-		guard.onTimeout()
-		guard.Disarm()
-
-		require.LessOrEqual(t, cancels.Load(), int32(1))
-	}
-}
-
+// The disarm-versus-late-fire race itself is covered by the shared
+// watchdog package tests; this test pins the chatloop-level
+// consequence: a disarmed guard leaves no timeout cause, so a
+// permanent stream error keeps its own classification.
 func TestStreamSilenceGuard_DisarmPreservesPermanentError(t *testing.T) {
 	t.Parallel()
 
@@ -138,7 +104,6 @@ func TestStreamSilenceGuard_DisarmPreservesPermanentError(t *testing.T) {
 
 	guard := newStreamSilenceGuard(quartz.NewReal(), time.Hour, cancelAttempt)
 	guard.Disarm()
-	guard.onTimeout()
 
 	classified := chaterror.Classify(classifyStreamSilenceTimeout(
 		attemptCtx,

--- a/coderd/x/chatd/chatloop/chatloop_run_internal_test.go
+++ b/coderd/x/chatd/chatloop/chatloop_run_internal_test.go
@@ -3,9 +3,7 @@ package chatloop
 import (
 	"context"
 	"encoding/base64"
-	"errors"
 	"iter"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -91,43 +89,10 @@ func toolResultContentToPart(toolResult fantasy.ToolResultContent) fantasy.ToolR
 	}
 }
 
-func TestStreamSilenceGuard_DisarmAndFireRace(t *testing.T) {
-	t.Parallel()
-
-	for range 128 {
-		var cancels atomic.Int32
-		guard := newStreamSilenceGuard(quartz.NewReal(), time.Hour, func(err error) {
-			if errors.Is(err, errStreamSilenceTimeout) {
-				cancels.Add(1)
-			}
-		})
-
-		start := make(chan struct{})
-		var wg sync.WaitGroup
-		wg.Add(2)
-
-		go func() {
-			defer wg.Done()
-			<-start
-			guard.onTimeout()
-		}()
-
-		go func() {
-			defer wg.Done()
-			<-start
-			guard.Disarm()
-		}()
-
-		close(start)
-		wg.Wait()
-
-		guard.onTimeout()
-		guard.Disarm()
-
-		require.LessOrEqual(t, cancels.Load(), int32(1))
-	}
-}
-
+// The disarm-versus-late-fire race itself is covered by the shared
+// watchdog package tests; this test pins the chatloop-level
+// consequence: a disarmed guard leaves no timeout cause, so a
+// permanent stream error keeps its own classification.
 func TestStreamSilenceGuard_DisarmPreservesPermanentError(t *testing.T) {
 	t.Parallel()
 
@@ -136,7 +101,6 @@ func TestStreamSilenceGuard_DisarmPreservesPermanentError(t *testing.T) {
 
 	guard := newStreamSilenceGuard(quartz.NewReal(), time.Hour, cancelAttempt)
 	guard.Disarm()
-	guard.onTimeout()
 
 	classified := chaterror.Classify(classifyStreamSilenceTimeout(
 		attemptCtx,

--- a/coderd/x/chatd/chattool/computeruse.go
+++ b/coderd/x/chatd/chattool/computeruse.go
@@ -213,7 +213,9 @@ func (t *computerUseTool) runAnthropicComputerUse(
 		action.Text = &input.Text
 	}
 	if input.Duration > 0 {
-		d := int(input.Duration)
+		// The agent blocks for forwarded durations (hold_key), so
+		// bound them like local waits.
+		d := int(min(input.Duration, int64(maxComputerWait/time.Millisecond)))
 		action.Duration = &d
 	}
 	if input.ScrollAmount > 0 {
@@ -325,12 +327,22 @@ func (*computerUseTool) desktopAction(
 	}
 }
 
+// maxComputerWait caps a single model-supplied wait action. Without
+// it, an oversized wait could ride an attempt whose watchdog a
+// concurrently progressing execute keeps kicking, far past the
+// attempt idle window. The model repeats the wait action when a UI
+// needs longer to settle.
+const maxComputerWait = 30 * time.Second
+
 func (t *computerUseTool) wait(ctx context.Context, durationMillis int64) {
-	d := durationMillis
-	if d <= 0 {
-		d = 1000
+	if durationMillis <= 0 {
+		durationMillis = int64(time.Second / time.Millisecond)
 	}
-	timer := t.clock.NewTimer(time.Duration(d)*time.Millisecond, "computeruse", "wait")
+	// Clamp before converting so an oversized model-supplied value
+	// cannot overflow time.Duration and dodge the cap.
+	durationMillis = min(durationMillis, int64(maxComputerWait/time.Millisecond))
+	d := time.Duration(durationMillis) * time.Millisecond
+	timer := t.clock.NewTimer(d, "computeruse", "wait")
 	defer timer.Stop()
 	select {
 	case <-ctx.Done():

--- a/coderd/x/chatd/chattool/computeruse.go
+++ b/coderd/x/chatd/chattool/computeruse.go
@@ -210,7 +210,9 @@ func (t *computerUseTool) runAnthropicComputerUse(
 		action.Text = &input.Text
 	}
 	if input.Duration > 0 {
-		d := int(input.Duration)
+		// The agent blocks for forwarded durations (hold_key), so
+		// bound them like local waits.
+		d := int(min(input.Duration, int64(maxComputerWait/time.Millisecond)))
 		action.Duration = &d
 	}
 	if input.ScrollAmount > 0 {
@@ -322,12 +324,22 @@ func (*computerUseTool) desktopAction(
 	}
 }
 
+// maxComputerWait caps a single model-supplied wait action. Without
+// it, an oversized wait could ride an attempt whose watchdog a
+// concurrently progressing execute keeps kicking, far past the
+// attempt idle window. The model repeats the wait action when a UI
+// needs longer to settle.
+const maxComputerWait = 30 * time.Second
+
 func (t *computerUseTool) wait(ctx context.Context, durationMillis int64) {
-	d := durationMillis
-	if d <= 0 {
-		d = 1000
+	if durationMillis <= 0 {
+		durationMillis = int64(time.Second / time.Millisecond)
 	}
-	timer := t.clock.NewTimer(time.Duration(d)*time.Millisecond, "computeruse", "wait")
+	// Clamp before converting so an oversized model-supplied value
+	// cannot overflow time.Duration and dodge the cap.
+	durationMillis = min(durationMillis, int64(maxComputerWait/time.Millisecond))
+	d := time.Duration(durationMillis) * time.Millisecond
+	timer := t.clock.NewTimer(d, "computeruse", "wait")
 	defer timer.Stop()
 	select {
 	case <-ctx.Done():

--- a/coderd/x/chatd/chattool/computeruse_test.go
+++ b/coderd/x/chatd/chattool/computeruse_test.go
@@ -392,6 +392,54 @@ func TestComputerUseTool_Run_LeftClick(t *testing.T) {
 	assert.Empty(t, attachments)
 }
 
+func TestComputerUseTool_Run_HoldKeyDurationClamped(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockConn := agentconnmock.NewMockAgentConn(ctrl)
+	geometry := workspacesdk.DefaultDesktopGeometry()
+	screenshot := base64.StdEncoding.EncodeToString([]byte("after-hold"))
+
+	mockConn.EXPECT().ExecuteDesktopAction(
+		gomock.Any(),
+		gomock.AssignableToTypeOf(workspacesdk.DesktopAction{}),
+	).DoAndReturn(func(_ context.Context, action workspacesdk.DesktopAction) (workspacesdk.DesktopActionResponse, error) {
+		assert.Equal(t, "hold_key", action.Action)
+		// An oversized model-supplied duration is clamped before
+		// being forwarded to the agent, which blocks for it.
+		require.NotNil(t, action.Duration)
+		assert.Equal(t, 30000, *action.Duration)
+		return workspacesdk.DesktopActionResponse{Output: "hold_key action performed"}, nil
+	})
+	mockConn.EXPECT().ExecuteDesktopAction(
+		gomock.Any(),
+		gomock.AssignableToTypeOf(workspacesdk.DesktopAction{}),
+	).DoAndReturn(func(_ context.Context, action workspacesdk.DesktopAction) (workspacesdk.DesktopActionResponse, error) {
+		assert.Equal(t, "screenshot", action.Action)
+		return workspacesdk.DesktopActionResponse{
+			Output:           "screenshot",
+			ScreenshotData:   screenshot,
+			ScreenshotWidth:  geometry.DeclaredWidth,
+			ScreenshotHeight: geometry.DeclaredHeight,
+		}, nil
+	})
+
+	tool := chattool.NewComputerUseTool(codersdk.ChatComputerUseProviderAnthropic, geometry.DeclaredWidth, geometry.DeclaredHeight, func(_ context.Context) (workspacesdk.AgentConn, error) {
+		return mockConn, nil
+	}, nil, quartz.NewReal(), slogtest.Make(t, nil))
+
+	call := fantasy.ToolCall{
+		ID:   "test-hold-clamp",
+		Name: "computer",
+		// 10 hours in milliseconds.
+		Input: `{"action":"hold_key","text":"shift","duration":36000000}`,
+	}
+
+	resp, err := tool.Run(context.Background(), call)
+	require.NoError(t, err)
+	assert.Equal(t, "image", resp.Type)
+}
+
 func TestComputerUseTool_Run_Wait(t *testing.T) {
 	t.Parallel()
 
@@ -440,6 +488,60 @@ func TestComputerUseTool_Run_Wait(t *testing.T) {
 	attachments, err := chattool.AttachmentsFromMetadata(resp.Metadata)
 	require.NoError(t, err)
 	assert.Empty(t, attachments)
+}
+
+func TestComputerUseTool_Run_WaitClamped(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	ctrl := gomock.NewController(t)
+	mockConn := agentconnmock.NewMockAgentConn(ctrl)
+	geometry := workspacesdk.DefaultDesktopGeometry()
+	mClock := quartz.NewMock(t)
+	followUpScreenshot := base64.StdEncoding.EncodeToString([]byte("after-wait"))
+
+	mockConn.EXPECT().ExecuteDesktopAction(
+		gomock.Any(),
+		gomock.AssignableToTypeOf(workspacesdk.DesktopAction{}),
+	).Return(workspacesdk.DesktopActionResponse{
+		Output:           "screenshot",
+		ScreenshotData:   followUpScreenshot,
+		ScreenshotWidth:  geometry.DeclaredWidth,
+		ScreenshotHeight: geometry.DeclaredHeight,
+	}, nil).Times(1)
+
+	trap := mClock.Trap().NewTimer("computeruse", "wait")
+	tool := chattool.NewComputerUseTool(codersdk.ChatComputerUseProviderAnthropic, geometry.DeclaredWidth, geometry.DeclaredHeight, func(_ context.Context) (workspacesdk.AgentConn, error) {
+		return mockConn, nil
+	}, nil, mClock, slogtest.Make(t, nil))
+
+	type toolResult struct {
+		resp fantasy.ToolResponse
+		err  error
+	}
+	resultCh := make(chan toolResult, 1)
+	go func() {
+		resp, err := tool.Run(ctx, fantasy.ToolCall{
+			ID:   "test-wait-clamp",
+			Name: "computer",
+			// 10 hours in milliseconds.
+			Input: `{"action":"wait","duration":36000000}`,
+		})
+		resultCh <- toolResult{resp: resp, err: err}
+	}()
+
+	// An oversized model-supplied wait is clamped to the per-call
+	// cap instead of blocking the tool batch for hours.
+	call := trap.MustWait(ctx)
+	assert.Equal(t, 30*time.Second, call.Duration)
+	call.MustRelease(ctx)
+	trap.Close()
+	mClock.Advance(30 * time.Second).MustWait(ctx)
+
+	result := testutil.RequireReceive(ctx, t, resultCh)
+	require.NoError(t, result.err)
+	assert.Equal(t, "image", result.resp.Type)
+	assert.False(t, result.resp.IsError)
 }
 
 func TestComputerUseTool_Run_ScreenshotDataIsDecodedBinary(t *testing.T) {

--- a/coderd/x/chatd/chattool/execute.go
+++ b/coderd/x/chatd/chattool/execute.go
@@ -281,6 +281,7 @@ func executeBackground(
 		}
 		return errorResult(enrichStartError(fmt.Sprintf("start background process: %v", err)))
 	}
+	KickAttemptKeepalive(ctx)
 
 	result := ExecuteResult{
 		Success:             true,
@@ -337,6 +338,7 @@ func executeForeground(
 		}
 		return errorResult(enrichStartError(fmt.Sprintf("start process: %v", err)))
 	}
+	KickAttemptKeepalive(ctx)
 
 	var result ExecuteResult
 	if resp.Attached {
@@ -403,6 +405,7 @@ func resumeAttachedProcess(
 				BackgroundProcessID: processID,
 			}
 		}
+		KickAttemptKeepalive(ctx)
 		if resp.Running {
 			return timedOutRunningResult(resp, timeout, processID)
 		}
@@ -466,6 +469,9 @@ func waitForProcess(
 		resp, err := conn.ProcessOutput(ctx, processID, &workspacesdk.ProcessOutputOptions{
 			Wait: true,
 		})
+		if err == nil {
+			KickAttemptKeepalive(parentCtx)
+		}
 		if err == nil && resp.Running && ctx.Err() == nil {
 			// The server-side wait can return before the process
 			// exits when its maximum wait is shorter than the
@@ -540,6 +546,8 @@ func resolveProcessWait(
 				BackgroundProcessID: processID,
 			}
 		}
+
+		KickAttemptKeepalive(parentCtx)
 
 		// Snapshot succeeded. If the process finished, return
 		// its real result (transparent recovery).
@@ -678,6 +686,10 @@ func ProcessOutput(options ProcessToolOptions) fantasy.AgentTool {
 				}
 				// Fall through to normal response handling below.
 			}
+			// Each successful poll proves the agent is responsive;
+			// a wait longer than the attempt idle window must not
+			// trip the watchdog while the agent responds.
+			KickAttemptKeepalive(parentCtx)
 			output := truncateOutput(resp.Output)
 			exitCode := 0
 			if resp.ExitCode != nil {

--- a/coderd/x/chatd/chattool/execute.go
+++ b/coderd/x/chatd/chattool/execute.go
@@ -271,6 +271,7 @@ func executeBackground(
 		}
 		return errorResult(enrichStartError(fmt.Sprintf("start background process: %v", err)))
 	}
+	KickAttemptKeepalive(ctx)
 
 	result := ExecuteResult{
 		Success:             true,
@@ -326,6 +327,7 @@ func executeForeground(
 		}
 		return errorResult(enrichStartError(fmt.Sprintf("start process: %v", err)))
 	}
+	KickAttemptKeepalive(ctx)
 
 	var result ExecuteResult
 	if resp.Attached {
@@ -392,6 +394,7 @@ func resumeAttachedProcess(
 				BackgroundProcessID: processID,
 			}
 		}
+		KickAttemptKeepalive(ctx)
 		if resp.Running {
 			return timedOutRunningResult(resp, timeout, processID)
 		}
@@ -455,6 +458,9 @@ func waitForProcess(
 		resp, err := conn.ProcessOutput(ctx, processID, &workspacesdk.ProcessOutputOptions{
 			Wait: true,
 		})
+		if err == nil {
+			KickAttemptKeepalive(parentCtx)
+		}
 		if err == nil && resp.Running && ctx.Err() == nil {
 			// The server-side wait can return before the process
 			// exits when its maximum wait is shorter than the
@@ -529,6 +535,8 @@ func resolveProcessWait(
 				BackgroundProcessID: processID,
 			}
 		}
+
+		KickAttemptKeepalive(parentCtx)
 
 		// Snapshot succeeded. If the process finished, return
 		// its real result (transparent recovery).
@@ -666,6 +674,10 @@ func ProcessOutput(options ProcessToolOptions) fantasy.AgentTool {
 				}
 				// Fall through to normal response handling below.
 			}
+			// Each successful poll proves the agent is responsive;
+			// a wait longer than the attempt idle window must not
+			// trip the watchdog while the agent responds.
+			KickAttemptKeepalive(parentCtx)
 			output := truncateOutput(resp.Output)
 			exitCode := 0
 			if resp.ExitCode != nil {

--- a/coderd/x/chatd/chattool/execute_test.go
+++ b/coderd/x/chatd/chattool/execute_test.go
@@ -271,6 +271,83 @@ func TestExecuteTool(t *testing.T) {
 		assert.Equal(t, "chat-123", capturedReq.Env["AGENT_BROWSER_SESSION"])
 	})
 
+	t.Run("KeepaliveKickedOnAgentRoundTrips", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			Return(workspacesdk.StartProcessResponse{ID: "proc-1"}, nil)
+		exitCode := 0
+		gomock.InOrder(
+			// The server-side wait returns while the process is
+			// still running, then a second poll sees it exit.
+			mockConn.EXPECT().
+				ProcessOutput(gomock.Any(), "proc-1", gomock.Any()).
+				Return(workspacesdk.ProcessOutputResponse{Running: true}, nil),
+			mockConn.EXPECT().
+				ProcessOutput(gomock.Any(), "proc-1", gomock.Any()).
+				Return(workspacesdk.ProcessOutputResponse{
+					Running:  false,
+					ExitCode: &exitCode,
+					Output:   "done",
+				}, nil),
+		)
+
+		kicks := 0
+		ctx := chattool.WithAttemptKeepalive(
+			testutil.Context(t, testutil.WaitMedium),
+			func() { kicks++ },
+		)
+		tool := newExecuteTool(t, mockConn)
+		resp, err := tool.Run(ctx, fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "execute",
+			Input: `{"command":"sleep 1"}`,
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.IsError)
+		// One kick for the successful start, one per successful
+		// poll round, including the round where the process was
+		// still running.
+		assert.Equal(t, 3, kicks)
+	})
+
+	t.Run("ProcessOutputToolKicksKeepalive", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+
+		exitCode := 0
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Any()).
+			Return(workspacesdk.ProcessOutputResponse{
+				Running:  false,
+				ExitCode: &exitCode,
+				Output:   "done",
+			}, nil)
+
+		kicks := 0
+		ctx := chattool.WithAttemptKeepalive(
+			testutil.Context(t, testutil.WaitMedium),
+			func() { kicks++ },
+		)
+		tool := chattool.ProcessOutput(chattool.ProcessToolOptions{
+			GetWorkspaceConn: func(_ context.Context) (workspacesdk.AgentConn, error) {
+				return mockConn, nil
+			},
+		})
+		resp, err := tool.Run(ctx, fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "process_output",
+			Input: `{"process_id":"proc-1"}`,
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.IsError)
+		assert.Equal(t, 1, kicks)
+	})
+
 	t.Run("ModelIntentIgnoredByExecution", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)

--- a/coderd/x/chatd/chattool/execute_test.go
+++ b/coderd/x/chatd/chattool/execute_test.go
@@ -233,6 +233,83 @@ func TestExecuteTool(t *testing.T) {
 		assert.Equal(t, "true", capturedReq.Env["CODER_CHAT_AGENT"])
 	})
 
+	t.Run("KeepaliveKickedOnAgentRoundTrips", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			Return(workspacesdk.StartProcessResponse{ID: "proc-1"}, nil)
+		exitCode := 0
+		gomock.InOrder(
+			// The server-side wait returns while the process is
+			// still running, then a second poll sees it exit.
+			mockConn.EXPECT().
+				ProcessOutput(gomock.Any(), "proc-1", gomock.Any()).
+				Return(workspacesdk.ProcessOutputResponse{Running: true}, nil),
+			mockConn.EXPECT().
+				ProcessOutput(gomock.Any(), "proc-1", gomock.Any()).
+				Return(workspacesdk.ProcessOutputResponse{
+					Running:  false,
+					ExitCode: &exitCode,
+					Output:   "done",
+				}, nil),
+		)
+
+		kicks := 0
+		ctx := chattool.WithAttemptKeepalive(
+			testutil.Context(t, testutil.WaitMedium),
+			func() { kicks++ },
+		)
+		tool := newExecuteTool(t, mockConn)
+		resp, err := tool.Run(ctx, fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "execute",
+			Input: `{"command":"sleep 1"}`,
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.IsError)
+		// One kick for the successful start, one per successful
+		// poll round, including the round where the process was
+		// still running.
+		assert.Equal(t, 3, kicks)
+	})
+
+	t.Run("ProcessOutputToolKicksKeepalive", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+
+		exitCode := 0
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Any()).
+			Return(workspacesdk.ProcessOutputResponse{
+				Running:  false,
+				ExitCode: &exitCode,
+				Output:   "done",
+			}, nil)
+
+		kicks := 0
+		ctx := chattool.WithAttemptKeepalive(
+			testutil.Context(t, testutil.WaitMedium),
+			func() { kicks++ },
+		)
+		tool := chattool.ProcessOutput(chattool.ProcessToolOptions{
+			GetWorkspaceConn: func(_ context.Context) (workspacesdk.AgentConn, error) {
+				return mockConn, nil
+			},
+		})
+		resp, err := tool.Run(ctx, fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "process_output",
+			Input: `{"process_id":"proc-1"}`,
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.IsError)
+		assert.Equal(t, 1, kicks)
+	})
+
 	t.Run("ModelIntentIgnoredByExecution", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)

--- a/coderd/x/chatd/chattool/keepalive.go
+++ b/coderd/x/chatd/chattool/keepalive.go
@@ -1,0 +1,31 @@
+package chattool
+
+import "context"
+
+// attemptKeepaliveKey carries the task attempt keepalive kick
+// function through tool execution contexts.
+type attemptKeepaliveKey struct{}
+
+// WithAttemptKeepalive returns a context carrying kick, a function
+// that resets the owning task attempt's idle watchdog. Only the
+// execute and process_output tools call KickAttemptKeepalive, after
+// each successful process-API round-trip, to signal that the agent
+// is still responsive while a potentially long-running command
+// runs. Other workspace tools deliberately do not extend the idle
+// window.
+func WithAttemptKeepalive(ctx context.Context, kick func()) context.Context {
+	if kick == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, attemptKeepaliveKey{}, kick)
+}
+
+// KickAttemptKeepalive resets the task attempt idle watchdog carried
+// by ctx. It is a no-op when the context carries no keepalive or the
+// attempt already ended, so callers never need to guard the call.
+func KickAttemptKeepalive(ctx context.Context) {
+	kick, _ := ctx.Value(attemptKeepaliveKey{}).(func())
+	if kick != nil {
+		kick()
+	}
+}

--- a/coderd/x/chatd/internal/watchdog/watchdog.go
+++ b/coderd/x/chatd/internal/watchdog/watchdog.go
@@ -1,0 +1,97 @@
+// Package watchdog provides the settle-once cancellation timer
+// shared by chatd's stream-silence and task-attempt watchdogs.
+package watchdog
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/coder/quartz"
+)
+
+// Timer cancels an operation with a fixed cause when its window
+// elapses without a Reset. Exactly one outcome wins: the timer
+// fires and cancels the operation, or Disarm stops it. Reset and
+// a late fire are safe no-ops once either outcome has settled.
+type Timer struct {
+	mu      sync.Mutex
+	clock   quartz.Clock
+	timer   *quartz.Timer
+	cancel  context.CancelCauseFunc
+	cause   error
+	timeout time.Duration
+	tags    []string
+	// deadline is when the current window elapses; Reset moves it
+	// forward. A fire that observes now before the deadline is
+	// stale: a Reset re-armed the timer while the callback was
+	// waiting on mu, and the re-armed timer fires later.
+	deadline time.Time
+	settled  bool
+}
+
+// New arms a watchdog that calls cancel(cause) once timeout
+// elapses without a Reset. tags label the underlying quartz
+// timer so tests can trap it.
+func New(
+	clock quartz.Clock,
+	timeout time.Duration,
+	cancel context.CancelCauseFunc,
+	cause error,
+	tags ...string,
+) *Timer {
+	t := &Timer{
+		clock:    clock,
+		cancel:   cancel,
+		cause:    cause,
+		timeout:  timeout,
+		tags:     tags,
+		deadline: clock.Now().Add(timeout),
+	}
+	t.timer = clock.AfterFunc(timeout, t.onTimeout, tags...)
+	return t
+}
+
+func (t *Timer) settle() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.settled {
+		return false
+	}
+	t.settled = true
+	return true
+}
+
+func (t *Timer) onTimeout() {
+	t.mu.Lock()
+	if t.settled || t.clock.Now().Before(t.deadline) {
+		// Settled, or a Reset re-armed the timer while this
+		// callback waited on the lock; the re-armed timer owns
+		// the new deadline.
+		t.mu.Unlock()
+		return
+	}
+	t.settled = true
+	t.mu.Unlock()
+	t.cancel(t.cause)
+}
+
+// Reset restarts the window. It is a no-op once the timer fired
+// or Disarm was called.
+func (t *Timer) Reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.settled {
+		return
+	}
+	t.deadline = t.clock.Now().Add(t.timeout)
+	t.timer.Reset(t.timeout, t.tags...)
+}
+
+// Disarm stops the timer permanently.
+func (t *Timer) Disarm() {
+	if !t.settle() {
+		return
+	}
+	t.timer.Stop()
+}

--- a/coderd/x/chatd/internal/watchdog/watchdog_internal_test.go
+++ b/coderd/x/chatd/internal/watchdog/watchdog_internal_test.go
@@ -1,0 +1,118 @@
+package watchdog
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/quartz"
+)
+
+var errTestTimeout = xerrors.New("watchdog test timeout")
+
+func TestTimer_FiresWithCause(t *testing.T) {
+	t.Parallel()
+
+	clock := quartz.NewMock(t)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	_ = New(clock, time.Minute, cancel, errTestTimeout, "test-watchdog")
+	clock.Advance(time.Minute).MustWait(context.Background())
+	require.ErrorIs(t, context.Cause(ctx), errTestTimeout)
+}
+
+func TestTimer_ResetRestartsWindow(t *testing.T) {
+	t.Parallel()
+
+	clock := quartz.NewMock(t)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	timer := New(clock, time.Minute, cancel, errTestTimeout, "test-watchdog")
+	clock.Advance(30 * time.Second).MustWait(context.Background())
+	timer.Reset()
+	clock.Advance(59 * time.Second).MustWait(context.Background())
+	require.NoError(t, ctx.Err())
+	clock.Advance(time.Second).MustWait(context.Background())
+	require.ErrorIs(t, context.Cause(ctx), errTestTimeout)
+}
+
+func TestTimer_DisarmAndFireRace(t *testing.T) {
+	t.Parallel()
+
+	for range 128 {
+		var cancels atomic.Int32
+		timer := New(quartz.NewReal(), time.Hour, func(err error) {
+			if errors.Is(err, errTestTimeout) {
+				cancels.Add(1)
+			}
+		}, errTestTimeout)
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			<-start
+			timer.onTimeout()
+		}()
+
+		go func() {
+			defer wg.Done()
+			<-start
+			timer.Disarm()
+		}()
+
+		close(start)
+		wg.Wait()
+
+		timer.onTimeout()
+		timer.Disarm()
+
+		require.LessOrEqual(t, cancels.Load(), int32(1))
+	}
+}
+
+func TestTimer_DisarmPreservesCause(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	timer := New(quartz.NewReal(), time.Hour, cancel, errTestTimeout)
+	timer.Disarm()
+	// A late fire after Disarm must not cancel the context.
+	timer.onTimeout()
+	require.NoError(t, ctx.Err())
+	require.Nil(t, context.Cause(ctx))
+}
+
+func TestTimer_StaleFireAfterResetIsIgnored(t *testing.T) {
+	t.Parallel()
+
+	clock := quartz.NewMock(t)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	wd := New(clock, time.Minute, cancel, errTestTimeout, "test-watchdog")
+
+	// Simulate the boundary race: the timeout callback was
+	// dispatched but a Reset re-armed the timer before the
+	// callback acquired the lock. The stale fire must not settle
+	// or cancel; the re-armed window owns the outcome.
+	wd.Reset()
+	wd.onTimeout()
+	require.NoError(t, context.Cause(ctx))
+
+	// The re-armed window still fires when it truly elapses.
+	clock.Advance(time.Minute).MustWait(context.Background())
+	require.ErrorIs(t, context.Cause(ctx), errTestTimeout)
+}

--- a/coderd/x/chatd/subagent.go
+++ b/coderd/x/chatd/subagent.go
@@ -99,6 +99,12 @@ const (
 	subagentAwaitPollInterval  = 200 * time.Millisecond
 	subagentAwaitFallbackPoll  = 5 * time.Second
 	defaultSubagentWaitTimeout = 5 * time.Minute
+	// maxSubagentWaitTimeout caps a single wait_agent block. It must
+	// stay clearly below defaultTaskTimeout: wait_agent never kicks
+	// the idle watchdog, so the resumable timeout result has to
+	// commit before the watchdog cancels the attempt. A timeout is
+	// not a failure; the model resumes with another wait_agent call.
+	maxSubagentWaitTimeout = 10 * time.Minute
 
 	defaultListAgentsLimit       = 10
 	maxListAgentsLimit           = 50
@@ -932,7 +938,8 @@ func (p *Server) subagentTools(
 			"Wait for a spawned child agent to finish and return its response "+
 				"and status. Returns immediately when the agent finishes, even if "+
 				"a longer timeout is set. A timeout does not stop the agent; call "+
-				"wait_agent again or use list_agents to check its status.",
+				"wait_agent again or use list_agents to check its status. "+
+				"timeout_seconds is capped at 10 minutes per call.",
 			func(ctx context.Context, args waitAgentArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
 				if currentChat == nil {
 					return fantasy.NewTextErrorResponse("subagent callbacks are not configured"), nil
@@ -1582,6 +1589,7 @@ func (p *Server) awaitSubagentCompletion(
 	if timeout <= 0 {
 		timeout = defaultSubagentWaitTimeout
 	}
+	timeout = min(timeout, maxSubagentWaitTimeout)
 	timer := p.clock.NewTimer(timeout, "chatd", "subagent_await")
 	defer timer.Stop()
 

--- a/coderd/x/chatd/subagent.go
+++ b/coderd/x/chatd/subagent.go
@@ -73,6 +73,12 @@ const (
 	subagentAwaitPollInterval  = 200 * time.Millisecond
 	subagentAwaitFallbackPoll  = 5 * time.Second
 	defaultSubagentWaitTimeout = 5 * time.Minute
+	// maxSubagentWaitTimeout caps a single wait_agent block. It must
+	// stay clearly below defaultTaskTimeout: wait_agent never kicks
+	// the idle watchdog, so the resumable timeout result has to
+	// commit before the watchdog cancels the attempt. A timeout is
+	// not a failure; the model resumes with another wait_agent call.
+	maxSubagentWaitTimeout = 10 * time.Minute
 
 	defaultListAgentsLimit       = 10
 	maxListAgentsLimit           = 50
@@ -826,7 +832,8 @@ func (p *Server) subagentTools(
 			"Wait for a spawned child agent to finish and return its response "+
 				"and status. Returns immediately when the agent finishes, even if "+
 				"a longer timeout is set. A timeout does not stop the agent; call "+
-				"wait_agent again or use list_agents to check its status.",
+				"wait_agent again or use list_agents to check its status. "+
+				"timeout_seconds is capped at 10 minutes per call.",
 			func(ctx context.Context, args waitAgentArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
 				if currentChat == nil {
 					return fantasy.NewTextErrorResponse("subagent callbacks are not configured"), nil
@@ -1480,6 +1487,7 @@ func (p *Server) awaitSubagentCompletion(
 	if timeout <= 0 {
 		timeout = defaultSubagentWaitTimeout
 	}
+	timeout = min(timeout, maxSubagentWaitTimeout)
 	timer := p.clock.NewTimer(timeout, "chatd", "subagent_await")
 	defer timer.Stop()
 

--- a/coderd/x/chatd/subagent_internal_test.go
+++ b/coderd/x/chatd/subagent_internal_test.go
@@ -4207,6 +4207,41 @@ func TestAwaitSubagentCompletion(t *testing.T) {
 		assert.Contains(t, result.err.Error(), "timed out waiting for delegated subagent completion")
 	})
 
+	t.Run("TimeoutClamped", func(t *testing.T) {
+		t.Parallel()
+
+		db, ps := dbtestutil.NewDB(t)
+		mClock := quartz.NewMock(t)
+		server := newInternalTestServer(t, db, ps, chatprovider.ProviderAPIKeys{}, withInternalTestServerClock(mClock))
+		ctx := chatdTestContext(t)
+		user, org, model := seedInternalChatDeps(t, db)
+
+		parent, child := createParentChildChats(ctx, t, server, user, org, model)
+
+		timerTrap := mClock.Trap().NewTimer("chatd", "subagent_await")
+
+		awaitCtx, cancelAwait := context.WithCancel(ctx)
+		defer cancelAwait()
+		resultCh := make(chan error, 1)
+		go func() {
+			_, _, err := server.awaitSubagentCompletion(
+				awaitCtx, parent.ID, child.ID, 10*time.Hour,
+			)
+			resultCh <- err
+		}()
+
+		// An oversized model-supplied timeout is clamped to the
+		// per-call cap instead of blocking the attempt for hours.
+		call := timerTrap.MustWait(ctx)
+		assert.Equal(t, maxSubagentWaitTimeout, call.Duration)
+		call.MustRelease(ctx)
+		timerTrap.Close()
+
+		cancelAwait()
+		err := testutil.RequireReceive(ctx, t, resultCh)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
 	t.Run("ContextCanceled", func(t *testing.T) {
 		t.Parallel()
 

--- a/coderd/x/chatd/subagent_internal_test.go
+++ b/coderd/x/chatd/subagent_internal_test.go
@@ -4178,6 +4178,41 @@ func TestAwaitSubagentCompletion(t *testing.T) {
 		assert.Contains(t, result.err.Error(), "timed out waiting for delegated subagent completion")
 	})
 
+	t.Run("TimeoutClamped", func(t *testing.T) {
+		t.Parallel()
+
+		db, ps := dbtestutil.NewDB(t)
+		mClock := quartz.NewMock(t)
+		server := newInternalTestServer(t, db, ps, chatprovider.ProviderAPIKeys{}, withInternalTestServerClock(mClock))
+		ctx := chatdTestContext(t)
+		user, org, model := seedInternalChatDeps(t, db)
+
+		parent, child := createParentChildChats(ctx, t, server, user, org, model)
+
+		timerTrap := mClock.Trap().NewTimer("chatd", "subagent_await")
+
+		awaitCtx, cancelAwait := context.WithCancel(ctx)
+		defer cancelAwait()
+		resultCh := make(chan error, 1)
+		go func() {
+			_, _, err := server.awaitSubagentCompletion(
+				awaitCtx, parent.ID, child.ID, 10*time.Hour,
+			)
+			resultCh <- err
+		}()
+
+		// An oversized model-supplied timeout is clamped to the
+		// per-call cap instead of blocking the attempt for hours.
+		call := timerTrap.MustWait(ctx)
+		assert.Equal(t, maxSubagentWaitTimeout, call.Duration)
+		call.MustRelease(ctx)
+		timerTrap.Close()
+
+		cancelAwait()
+		err := testutil.RequireReceive(ctx, t, resultCh)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
 	t.Run("ContextCanceled", func(t *testing.T) {
 		t.Parallel()
 

--- a/coderd/x/chatd/tasks.go
+++ b/coderd/x/chatd/tasks.go
@@ -18,6 +18,8 @@ import (
 	"github.com/coder/coder/v2/coderd/x/chatd/chatloop"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatstate"
+	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
+	"github.com/coder/coder/v2/coderd/x/chatd/internal/watchdog"
 	"github.com/coder/coder/v2/coderd/x/chatd/messagepartbuffer"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/quartz"
@@ -25,10 +27,16 @@ import (
 
 const (
 	postCommitWatchPublishTimeout = 10 * time.Second
-	// defaultTaskTimeout must exceed chatloop's stream-silence guard so
-	// silent provider streams fail through chat-specific retry handling
-	// before the runner retries the whole task.
+	// defaultTaskTimeout is the attempt idle window: how long an
+	// attempt may run without a keepalive kick before it is canceled.
+	// It must exceed chatloop's stream-silence guard so silent
+	// provider streams fail through chat-specific retry handling
+	// before the runner retries the whole task; streaming code never
+	// kicks the watchdog.
 	defaultTaskTimeout = 15 * time.Minute
+	// maxTaskAttemptDuration is the absolute cap on a single task
+	// attempt. It is never reset by keepalive kicks.
+	maxTaskAttemptDuration = 24 * time.Hour
 )
 
 var (
@@ -154,13 +162,20 @@ func runTaskWithRetry(
 	}
 }
 
+// taskAttemptContext bounds a single task attempt with two watchdogs:
+// a resettable idle window kicked by tools after successful agent
+// round-trips, and a non-resettable absolute cap.
 func taskAttemptContext(ctx context.Context, clock quartz.Clock, kind taskKind) (context.Context, func()) {
 	attemptCtx, cancelCause := context.WithCancelCause(ctx)
-	timer := clock.AfterFunc(defaultTaskTimeout, func() {
+	idle := watchdog.New(clock, defaultTaskTimeout, cancelCause, errTaskTimeout,
+		"chatworker", "task-timeout-"+string(kind))
+	capTimer := clock.AfterFunc(maxTaskAttemptDuration, func() {
 		cancelCause(errTaskTimeout)
-	}, "chatworker", "task-timeout-"+string(kind))
+	}, "chatworker", "task-attempt-cap-"+string(kind))
+	attemptCtx = chattool.WithAttemptKeepalive(attemptCtx, idle.Reset)
 	return attemptCtx, func() {
-		timer.Stop()
+		idle.Disarm()
+		capTimer.Stop()
 		cancelCause(nil)
 	}
 }

--- a/coderd/x/chatd/tasks.go
+++ b/coderd/x/chatd/tasks.go
@@ -17,6 +17,8 @@ import (
 	"github.com/coder/coder/v2/coderd/x/chatd/chatdebug"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatstate"
+	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
+	"github.com/coder/coder/v2/coderd/x/chatd/internal/watchdog"
 	"github.com/coder/coder/v2/coderd/x/chatd/messagepartbuffer"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/quartz"
@@ -24,10 +26,16 @@ import (
 
 const (
 	postCommitWatchPublishTimeout = 10 * time.Second
-	// defaultTaskTimeout must exceed chatloop's stream-silence guard so
-	// silent provider streams fail through chat-specific retry handling
-	// before the runner retries the whole task.
+	// defaultTaskTimeout is the attempt idle window: how long an
+	// attempt may run without a keepalive kick before it is canceled.
+	// It must exceed chatloop's stream-silence guard so silent
+	// provider streams fail through chat-specific retry handling
+	// before the runner retries the whole task; streaming code never
+	// kicks the watchdog.
 	defaultTaskTimeout = 15 * time.Minute
+	// maxTaskAttemptDuration is the absolute cap on a single task
+	// attempt. It is never reset by keepalive kicks.
+	maxTaskAttemptDuration = 24 * time.Hour
 )
 
 var (
@@ -153,13 +161,20 @@ func runTaskWithRetry(
 	}
 }
 
+// taskAttemptContext bounds a single task attempt with two watchdogs:
+// a resettable idle window kicked by tools after successful agent
+// round-trips, and a non-resettable absolute cap.
 func taskAttemptContext(ctx context.Context, clock quartz.Clock, kind taskKind) (context.Context, func()) {
 	attemptCtx, cancelCause := context.WithCancelCause(ctx)
-	timer := clock.AfterFunc(defaultTaskTimeout, func() {
+	idle := watchdog.New(clock, defaultTaskTimeout, cancelCause, errTaskTimeout,
+		"chatworker", "task-timeout-"+string(kind))
+	capTimer := clock.AfterFunc(maxTaskAttemptDuration, func() {
 		cancelCause(errTaskTimeout)
-	}, "chatworker", "task-timeout-"+string(kind))
+	}, "chatworker", "task-attempt-cap-"+string(kind))
+	attemptCtx = chattool.WithAttemptKeepalive(attemptCtx, idle.Reset)
 	return attemptCtx, func() {
-		timer.Stop()
+		idle.Disarm()
+		capTimer.Stop()
 		cancelCause(nil)
 	}
 }

--- a/coderd/x/chatd/tasks_test.go
+++ b/coderd/x/chatd/tasks_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatretry"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatstate"
+	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
 	"github.com/coder/coder/v2/coderd/x/chatd/messagepartbuffer"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
@@ -197,6 +198,115 @@ func TestRetryWrapper_ContextCancellationDoesNotRetryOrLog(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, calls)
 	require.Empty(t, entriesWithMessage(sink, "chatworker task retrying"))
+}
+
+func TestTaskAttemptContext_KeepaliveExtendsIdleWindow(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	clock := quartz.NewMock(t)
+	attemptCtx, cancelAttempt := taskAttemptContext(ctx, clock, taskKindGeneration)
+	defer cancelAttempt()
+
+	// Each kick restarts the idle window, so the attempt outlives
+	// several multiples of defaultTaskTimeout.
+	for range 4 {
+		clock.Advance(defaultTaskTimeout - time.Minute).MustWait(ctx)
+		require.NoError(t, attemptCtx.Err())
+		chattool.KickAttemptKeepalive(attemptCtx)
+	}
+
+	// Without further kicks the idle window expires.
+	clock.Advance(defaultTaskTimeout).MustWait(ctx)
+	require.ErrorIs(t, context.Cause(attemptCtx), errTaskTimeout)
+
+	// Kicking after the timeout fired is a safe no-op.
+	chattool.KickAttemptKeepalive(attemptCtx)
+}
+
+func TestTaskAttemptContext_AbsoluteCapIgnoresKicks(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	clock := quartz.NewMock(t)
+	attemptCtx, cancelAttempt := taskAttemptContext(ctx, clock, taskKindGeneration)
+	defer cancelAttempt()
+
+	step := defaultTaskTimeout / 2
+	for elapsed := time.Duration(0); elapsed < maxTaskAttemptDuration; elapsed += step {
+		require.NoError(t, attemptCtx.Err())
+		clock.Advance(step).MustWait(ctx)
+		chattool.KickAttemptKeepalive(attemptCtx)
+	}
+	require.ErrorIs(t, context.Cause(attemptCtx), errTaskTimeout)
+}
+
+func TestTaskAttemptContext_NoKickTimesOutAtIdleWindow(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	clock := quartz.NewMock(t)
+	attemptCtx, cancelAttempt := taskAttemptContext(ctx, clock, taskKindGeneration)
+	defer cancelAttempt()
+
+	clock.Advance(defaultTaskTimeout - time.Second).MustWait(ctx)
+	require.NoError(t, attemptCtx.Err())
+	clock.Advance(time.Second).MustWait(ctx)
+	require.ErrorIs(t, context.Cause(attemptCtx), errTaskTimeout)
+}
+
+// TestTaskAttemptContext_KicksExtendTheWindowSiblingToolsShare records
+// why tools that block on a model-supplied duration need their own
+// per-call caps. Tool calls in one batch run concurrently against a
+// single attempt context, so a kick from a progressing execute call
+// extends the deadline every sibling was relying on.
+func TestTaskAttemptContext_KicksExtendTheWindowSiblingToolsShare(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	clock := quartz.NewMock(t)
+	attemptCtx, cancelAttempt := taskAttemptContext(ctx, clock, taskKindGeneration)
+	defer cancelAttempt()
+
+	// A sibling tool call that never kicks, holding the same context.
+	siblingDone := make(chan struct{})
+	go func() {
+		<-attemptCtx.Done()
+		close(siblingDone)
+	}()
+
+	for range 3 {
+		clock.Advance(defaultTaskTimeout - time.Minute).MustWait(ctx)
+		chattool.KickAttemptKeepalive(attemptCtx)
+	}
+
+	// Well past the idle window, the sibling is still running purely
+	// because another call kept the shared attempt alive. Its own wait
+	// is therefore only as bounded as its per-call cap makes it.
+	require.NoError(t, attemptCtx.Err())
+	select {
+	case <-siblingDone:
+		t.Fatal("sibling ended while the attempt was still alive")
+	default:
+	}
+
+	// It ends only once the kicks stop, not on any schedule of its own.
+	clock.Advance(defaultTaskTimeout).MustWait(ctx)
+	testutil.TryReceive(ctx, t, siblingDone)
+	require.ErrorIs(t, context.Cause(attemptCtx), errTaskTimeout)
+}
+
+func TestTaskAttemptContext_KickAfterCancelIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	clock := quartz.NewMock(t)
+	attemptCtx, cancelAttempt := taskAttemptContext(ctx, clock, taskKindGeneration)
+	cancelAttempt()
+
+	chattool.KickAttemptKeepalive(attemptCtx)
+	require.ErrorIs(t, attemptCtx.Err(), context.Canceled)
+	require.NotErrorIs(t, context.Cause(attemptCtx), errTaskTimeout)
 }
 
 func TestNormalizeTaskErrors_ContextCancellationIsExpectedExit(t *testing.T) {


### PR DESCRIPTION
## Stack context

Part 3 of a 4-PR stack (CODAGT-757). Retitled and reframed after review; the description previously listed the per-tool caps without saying why they belong here.

## The narrow problem

While a foreground command runs, chatd repeatedly asks the agent for process output. Each successful response proves the agent is reachable and the task is progressing. The fixed per-attempt deadline treated that valid wait as a stuck task, so a command could not outlive it.

This PR implements exactly the behavior asked for in review:

- a successful process-output response counts as progress;
- a silent or unreachable agent does not;
- the timeout the model gave `execute` still controls how long chatd waits for that command;
- the model stream keeps its existing silence timeout, and streaming code never resets the attempt window.

## Why the caps are part of this change, not extra policy

Converting an absolute attempt deadline into a progress-based one removes the only bound sibling tool calls had.

Tool calls in one batch fan out as a goroutine per call under a single `sync.WaitGroup`, all sharing one attempt context. Before this PR, every one of them was bounded by the fixed attempt deadline. Once `execute` can reset that deadline, a long command keeps the attempt alive and a sibling `wait_agent` or `computer` wait inherits the extension for as long as the command runs.

So tools that block on a model-supplied duration are bounded per call instead: a single `wait_agent` block to 10 minutes, a `computer` wait action to 30 seconds (clamped before the millisecond conversion, so an oversized value cannot overflow). An absolute cap still bounds a single attempt regardless of progress.

`TestTaskAttemptContext_KicksExtendTheWindowSiblingToolsShare` demonstrates the mechanism: a sibling holding the shared attempt context outlives multiple idle windows purely because another call kept kicking, and ends only once the kicks stop.

`process_output` is unchanged in behavior. It only reads output the process manager already holds, so chatd can call it repeatedly without repeating the command.

Attempt-watchdog cancellations classify as retryable, and the replay from #27370 re-attaches to the still-running process rather than starting it again.

## If the caps still read as out of scope

I would rather split them into a follow-up than drop them, since removing them leaves sibling waits unbounded once the idle window lands. Happy to do that if you prefer.

> This PR was written by Mux, an AI coding agent, operating on Mike's behalf.
