### PR TITLE
feat: stop foreground execute processes when a user interrupts a chat

### DIFF
--- a/agent/agentproc/api.go
+++ b/agent/agentproc/api.go
@@ -60,6 +60,7 @@ func (api *API) Routes() http.Handler {
 	r.Get("/list", api.handleListProcesses)
 	r.Get("/{id}/output", api.handleProcessOutput)
 	r.Post("/{id}/signal", api.handleSignalProcess)
+	r.Post("/signal-by-idempotency-key", api.handleSignalProcessByIdempotencyKey)
 	return r
 }
 
@@ -247,6 +248,96 @@ func (api *API) handleProcessOutput(rw http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleSignalProcessByIdempotencyKey sends a signal to the process
+// started under an idempotency key. It exists so a caller whose start
+// response was lost can still stop the command it asked for: the key
+// identifies the process even when its ID never arrived. The key
+// travels in the body rather than the path so no key value needs URL
+// escaping.
+func (api *API) handleSignalProcessByIdempotencyKey(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var chatID string
+	if chatContext, ok := agentchat.FromContext(ctx); ok {
+		chatID = chatContext.ID.String()
+	}
+
+	var req workspacesdk.SignalProcessByIdempotencyKeyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Request body must be valid JSON.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+	if req.IdempotencyKey == "" {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Idempotency key is required.",
+		})
+		return
+	}
+	if !validateSignal(ctx, rw, req.Signal) {
+		return
+	}
+
+	if err := api.manager.signalByKey(ctx, chatID, req.IdempotencyKey, req.Signal); err != nil {
+		switch {
+		case errors.Is(err, errProcessNotFound):
+			httpapi.Write(ctx, rw, http.StatusNotFound, workspacesdk.ProcessKeyNotFoundError{
+				Code: workspacesdk.ProcessKeyNotFoundCode,
+				Response: codersdk.Response{
+					Message: "No process was started with this idempotency key.",
+				},
+			})
+		case errors.Is(err, errProcessStartPending):
+			httpapi.Write(ctx, rw, http.StatusConflict, workspacesdk.ProcessConflictError{
+				Code: workspacesdk.ProcessConflictStartPending,
+				Response: codersdk.Response{
+					Message: "The start holding this idempotency key has not spawned its process yet.",
+				},
+			})
+		case errors.Is(err, errProcessNotRunning):
+			httpapi.Write(ctx, rw, http.StatusConflict, workspacesdk.ProcessConflictError{
+				Code: workspacesdk.ProcessConflictNotRunning,
+				Response: codersdk.Response{
+					Message: "The process started with this idempotency key is not running.",
+				},
+			})
+		default:
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Failed to signal process.",
+				Detail:  err.Error(),
+			})
+		}
+		return
+	}
+
+	httpapi.Write(ctx, rw, http.StatusOK, codersdk.Response{
+		Message: fmt.Sprintf("Signal %q sent.", req.Signal),
+	})
+}
+
+// validateSignal writes its own error response; false means the caller
+// must stop.
+func validateSignal(ctx context.Context, rw http.ResponseWriter, signal string) bool {
+	if signal == "" {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Signal is required.",
+		})
+		return false
+	}
+	if signal != "kill" && signal != "terminate" {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: fmt.Sprintf(
+				"Unsupported signal %q. Use \"kill\" or \"terminate\".",
+				signal,
+			),
+		})
+		return false
+	}
+	return true
+}
+
 // handleSignalProcess sends a signal to a running process.
 func (api *API) handleSignalProcess(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -272,21 +363,7 @@ func (api *API) handleSignalProcess(rw http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-
-	if req.Signal == "" {
-		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: "Signal is required.",
-		})
-		return
-	}
-
-	if req.Signal != "kill" && req.Signal != "terminate" {
-		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: fmt.Sprintf(
-				"Unsupported signal %q. Use \"kill\" or \"terminate\".",
-				req.Signal,
-			),
-		})
+	if !validateSignal(ctx, rw, req.Signal) {
 		return
 	}
 

--- a/agent/agentproc/api.go
+++ b/agent/agentproc/api.go
@@ -60,6 +60,7 @@ func (api *API) Routes() http.Handler {
 	r.Get("/list", api.handleListProcesses)
 	r.Get("/{id}/output", api.handleProcessOutput)
 	r.Post("/{id}/signal", api.handleSignalProcess)
+	r.Post("/signal-by-idempotency-key", api.handleSignalProcessByIdempotencyKey)
 	return r
 }
 
@@ -246,6 +247,96 @@ func (api *API) handleProcessOutput(rw http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleSignalProcessByIdempotencyKey sends a signal to the process
+// started under an idempotency key. It exists so a caller whose start
+// response was lost can still stop the command it asked for: the key
+// identifies the process even when its ID never arrived. The key
+// travels in the body rather than the path so no key value needs URL
+// escaping.
+func (api *API) handleSignalProcessByIdempotencyKey(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var chatID string
+	if chatContext, ok := agentchat.FromContext(ctx); ok {
+		chatID = chatContext.ID.String()
+	}
+
+	var req workspacesdk.SignalProcessByIdempotencyKeyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Request body must be valid JSON.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+	if req.IdempotencyKey == "" {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Idempotency key is required.",
+		})
+		return
+	}
+	if !validateSignal(ctx, rw, req.Signal) {
+		return
+	}
+
+	if err := api.manager.signalByKey(ctx, chatID, req.IdempotencyKey, req.Signal); err != nil {
+		switch {
+		case errors.Is(err, errProcessNotFound):
+			httpapi.Write(ctx, rw, http.StatusNotFound, workspacesdk.ProcessKeyNotFoundError{
+				Code: workspacesdk.ProcessKeyNotFoundCode,
+				Response: codersdk.Response{
+					Message: "No process was started with this idempotency key.",
+				},
+			})
+		case errors.Is(err, errProcessStartPending):
+			httpapi.Write(ctx, rw, http.StatusConflict, workspacesdk.ProcessConflictError{
+				Code: workspacesdk.ProcessConflictStartPending,
+				Response: codersdk.Response{
+					Message: "The start holding this idempotency key has not spawned its process yet.",
+				},
+			})
+		case errors.Is(err, errProcessNotRunning):
+			httpapi.Write(ctx, rw, http.StatusConflict, workspacesdk.ProcessConflictError{
+				Code: workspacesdk.ProcessConflictNotRunning,
+				Response: codersdk.Response{
+					Message: "The process started with this idempotency key is not running.",
+				},
+			})
+		default:
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Failed to signal process.",
+				Detail:  err.Error(),
+			})
+		}
+		return
+	}
+
+	httpapi.Write(ctx, rw, http.StatusOK, codersdk.Response{
+		Message: fmt.Sprintf("Signal %q sent.", req.Signal),
+	})
+}
+
+// validateSignal writes its own error response; false means the caller
+// must stop.
+func validateSignal(ctx context.Context, rw http.ResponseWriter, signal string) bool {
+	if signal == "" {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Signal is required.",
+		})
+		return false
+	}
+	if signal != "kill" && signal != "terminate" {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: fmt.Sprintf(
+				"Unsupported signal %q. Use \"kill\" or \"terminate\".",
+				signal,
+			),
+		})
+		return false
+	}
+	return true
+}
+
 // handleSignalProcess sends a signal to a running process.
 func (api *API) handleSignalProcess(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -271,21 +362,7 @@ func (api *API) handleSignalProcess(rw http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-
-	if req.Signal == "" {
-		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: "Signal is required.",
-		})
-		return
-	}
-
-	if req.Signal != "kill" && req.Signal != "terminate" {
-		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: fmt.Sprintf(
-				"Unsupported signal %q. Use \"kill\" or \"terminate\".",
-				req.Signal,
-			),
-		})
+	if !validateSignal(ctx, rw, req.Signal) {
 		return
 	}
 

--- a/agent/agentproc/api_test.go
+++ b/agent/agentproc/api_test.go
@@ -116,6 +116,28 @@ func postSignal(t *testing.T, handler http.Handler, id string, req workspacesdk.
 	return w
 }
 
+func postSignalByKey(t *testing.T, handler http.Handler, req workspacesdk.SignalProcessByIdempotencyKeyRequest, headers ...http.Header) *httptest.ResponseRecorder {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	defer cancel()
+
+	body, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(ctx, http.MethodPost, "/signal-by-idempotency-key", bytes.NewReader(body))
+	for _, header := range headers {
+		for key, values := range header {
+			for _, value := range values {
+				r.Header.Add(key, value)
+			}
+		}
+	}
+	handler.ServeHTTP(w, r)
+	return w
+}
+
 // newTestAPI creates a new API with a test logger and default
 // execer, returning the handler and API.
 func newTestAPI(t *testing.T) http.Handler {
@@ -1219,6 +1241,141 @@ func getOutputWithWaitCtx(ctx context.Context, t *testing.T, handler http.Handle
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 	return w
+}
+
+func TestSignalProcessByIdempotencyKey(t *testing.T) {
+	t.Parallel()
+
+	t.Run("KillsProcessStartedUnderKey", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newTestAPI(t)
+		id := startAndGetID(t, handler, workspacesdk.StartProcessRequest{
+			Command:        "sleep 60",
+			IdempotencyKey: "key-1",
+			Background:     true,
+		})
+
+		w := postSignalByKey(t, handler, workspacesdk.SignalProcessByIdempotencyKeyRequest{
+			IdempotencyKey: "key-1",
+			Signal:         "kill",
+		})
+		require.Equal(t, http.StatusOK, w.Code)
+
+		resp := waitForExit(t, handler, id)
+		require.False(t, resp.Running)
+	})
+
+	// Keys carry provider-supplied tool call IDs, so the route must
+	// accept values that would need escaping in a URL path.
+	t.Run("AcceptsKeysNeedingURLEscaping", func(t *testing.T) {
+		t.Parallel()
+
+		for _, key := range []string{"7-a/b", "7-a b", "7-a%b", "7-a?b#c", "7-.."} {
+			t.Run(key, func(t *testing.T) {
+				t.Parallel()
+
+				handler := newTestAPI(t)
+				id := startAndGetID(t, handler, workspacesdk.StartProcessRequest{
+					Command:        "sleep 60",
+					IdempotencyKey: key,
+					Background:     true,
+				})
+
+				w := postSignalByKey(t, handler, workspacesdk.SignalProcessByIdempotencyKeyRequest{
+					IdempotencyKey: key,
+					Signal:         "kill",
+				})
+				require.Equal(t, http.StatusOK, w.Code)
+				require.False(t, waitForExit(t, handler, id).Running)
+			})
+		}
+	})
+
+	t.Run("UnknownKeyNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newTestAPI(t)
+		w := postSignalByKey(t, handler, workspacesdk.SignalProcessByIdempotencyKeyRequest{
+			IdempotencyKey: "key-missing",
+			Signal:         "kill",
+		})
+		require.Equal(t, http.StatusNotFound, w.Code)
+		var notFound workspacesdk.ProcessKeyNotFoundError
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&notFound))
+		require.Equal(t, workspacesdk.ProcessKeyNotFoundCode, notFound.Code)
+	})
+
+	t.Run("ForeignChatKeyNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		// Reservations are chat-scoped, so another chat's key is
+		// simply absent rather than forbidden.
+		handler := newTestAPI(t)
+		headerA := http.Header{}
+		headerA.Set(workspacesdk.CoderChatIDHeader, uuid.New().String())
+		headerB := http.Header{}
+		headerB.Set(workspacesdk.CoderChatIDHeader, uuid.New().String())
+
+		id := startAndGetID(t, handler, workspacesdk.StartProcessRequest{
+			Command:        "sleep 60",
+			IdempotencyKey: "key-1",
+			Background:     true,
+		}, headerA)
+
+		w := postSignalByKey(t, handler, workspacesdk.SignalProcessByIdempotencyKeyRequest{
+			IdempotencyKey: "key-1",
+			Signal:         "kill",
+		}, headerB)
+		require.Equal(t, http.StatusNotFound, w.Code)
+
+		// The process is untouched.
+		w = getOutputWithHeaders(t, handler, id, headerA)
+		require.Equal(t, http.StatusOK, w.Code)
+		var output workspacesdk.ProcessOutputResponse
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&output))
+		require.True(t, output.Running)
+	})
+
+	t.Run("ExitedProcessConflicts", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newTestAPI(t)
+		id := startAndGetID(t, handler, workspacesdk.StartProcessRequest{
+			Command:        "echo hello",
+			IdempotencyKey: "key-1",
+		})
+		waitForExit(t, handler, id)
+
+		w := postSignalByKey(t, handler, workspacesdk.SignalProcessByIdempotencyKeyRequest{
+			IdempotencyKey: "key-1",
+			Signal:         "kill",
+		})
+		// The code must distinguish this from a start conflict, since
+		// callers suppress the kill only for an exited process.
+		requireConflictCode(t, w, workspacesdk.ProcessConflictNotRunning)
+	})
+
+	t.Run("RejectsUnsupportedSignal", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newTestAPI(t)
+		w := postSignalByKey(t, handler, workspacesdk.SignalProcessByIdempotencyKeyRequest{
+			IdempotencyKey: "key-1",
+			Signal:         "hup",
+		})
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("RejectsMissingKey", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newTestAPI(t)
+		w := postSignalByKey(t, handler, workspacesdk.SignalProcessByIdempotencyKeyRequest{
+			Signal: "kill",
+		})
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
 }
 
 func TestSignalProcess(t *testing.T) {

--- a/agent/agentproc/api_test.go
+++ b/agent/agentproc/api_test.go
@@ -116,6 +116,28 @@ func postSignal(t *testing.T, handler http.Handler, id string, req workspacesdk.
 	return w
 }
 
+func postSignalByKey(t *testing.T, handler http.Handler, req workspacesdk.SignalProcessByIdempotencyKeyRequest, headers ...http.Header) *httptest.ResponseRecorder {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	defer cancel()
+
+	body, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(ctx, http.MethodPost, "/signal-by-idempotency-key", bytes.NewReader(body))
+	for _, header := range headers {
+		for key, values := range header {
+			for _, value := range values {
+				r.Header.Add(key, value)
+			}
+		}
+	}
+	handler.ServeHTTP(w, r)
+	return w
+}
+
 // newTestAPI creates a new API with a test logger and default
 // execer, returning the handler and API.
 func newTestAPI(t *testing.T) http.Handler {
@@ -1199,6 +1221,141 @@ func getOutputWithWaitCtx(ctx context.Context, t *testing.T, handler http.Handle
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 	return w
+}
+
+func TestSignalProcessByIdempotencyKey(t *testing.T) {
+	t.Parallel()
+
+	t.Run("KillsProcessStartedUnderKey", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newTestAPI(t)
+		id := startAndGetID(t, handler, workspacesdk.StartProcessRequest{
+			Command:        "sleep 60",
+			IdempotencyKey: "key-1",
+			Background:     true,
+		})
+
+		w := postSignalByKey(t, handler, workspacesdk.SignalProcessByIdempotencyKeyRequest{
+			IdempotencyKey: "key-1",
+			Signal:         "kill",
+		})
+		require.Equal(t, http.StatusOK, w.Code)
+
+		resp := waitForExit(t, handler, id)
+		require.False(t, resp.Running)
+	})
+
+	// Keys carry provider-supplied tool call IDs, so the route must
+	// accept values that would need escaping in a URL path.
+	t.Run("AcceptsKeysNeedingURLEscaping", func(t *testing.T) {
+		t.Parallel()
+
+		for _, key := range []string{"7-a/b", "7-a b", "7-a%b", "7-a?b#c", "7-.."} {
+			t.Run(key, func(t *testing.T) {
+				t.Parallel()
+
+				handler := newTestAPI(t)
+				id := startAndGetID(t, handler, workspacesdk.StartProcessRequest{
+					Command:        "sleep 60",
+					IdempotencyKey: key,
+					Background:     true,
+				})
+
+				w := postSignalByKey(t, handler, workspacesdk.SignalProcessByIdempotencyKeyRequest{
+					IdempotencyKey: key,
+					Signal:         "kill",
+				})
+				require.Equal(t, http.StatusOK, w.Code)
+				require.False(t, waitForExit(t, handler, id).Running)
+			})
+		}
+	})
+
+	t.Run("UnknownKeyNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newTestAPI(t)
+		w := postSignalByKey(t, handler, workspacesdk.SignalProcessByIdempotencyKeyRequest{
+			IdempotencyKey: "key-missing",
+			Signal:         "kill",
+		})
+		require.Equal(t, http.StatusNotFound, w.Code)
+		var notFound workspacesdk.ProcessKeyNotFoundError
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&notFound))
+		require.Equal(t, workspacesdk.ProcessKeyNotFoundCode, notFound.Code)
+	})
+
+	t.Run("ForeignChatKeyNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		// Reservations are chat-scoped, so another chat's key is
+		// simply absent rather than forbidden.
+		handler := newTestAPI(t)
+		headerA := http.Header{}
+		headerA.Set(workspacesdk.CoderChatIDHeader, uuid.New().String())
+		headerB := http.Header{}
+		headerB.Set(workspacesdk.CoderChatIDHeader, uuid.New().String())
+
+		id := startAndGetID(t, handler, workspacesdk.StartProcessRequest{
+			Command:        "sleep 60",
+			IdempotencyKey: "key-1",
+			Background:     true,
+		}, headerA)
+
+		w := postSignalByKey(t, handler, workspacesdk.SignalProcessByIdempotencyKeyRequest{
+			IdempotencyKey: "key-1",
+			Signal:         "kill",
+		}, headerB)
+		require.Equal(t, http.StatusNotFound, w.Code)
+
+		// The process is untouched.
+		w = getOutputWithHeaders(t, handler, id, headerA)
+		require.Equal(t, http.StatusOK, w.Code)
+		var output workspacesdk.ProcessOutputResponse
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&output))
+		require.True(t, output.Running)
+	})
+
+	t.Run("ExitedProcessConflicts", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newTestAPI(t)
+		id := startAndGetID(t, handler, workspacesdk.StartProcessRequest{
+			Command:        "echo hello",
+			IdempotencyKey: "key-1",
+		})
+		waitForExit(t, handler, id)
+
+		w := postSignalByKey(t, handler, workspacesdk.SignalProcessByIdempotencyKeyRequest{
+			IdempotencyKey: "key-1",
+			Signal:         "kill",
+		})
+		// The code must distinguish this from a start conflict, since
+		// callers suppress the kill only for an exited process.
+		requireConflictCode(t, w, workspacesdk.ProcessConflictNotRunning)
+	})
+
+	t.Run("RejectsUnsupportedSignal", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newTestAPI(t)
+		w := postSignalByKey(t, handler, workspacesdk.SignalProcessByIdempotencyKeyRequest{
+			IdempotencyKey: "key-1",
+			Signal:         "hup",
+		})
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("RejectsMissingKey", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newTestAPI(t)
+		w := postSignalByKey(t, handler, workspacesdk.SignalProcessByIdempotencyKeyRequest{
+			Signal: "kill",
+		})
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
 }
 
 func TestSignalProcess(t *testing.T) {

--- a/agent/agentproc/process.go
+++ b/agent/agentproc/process.go
@@ -31,6 +31,11 @@ var (
 	errProcessNotFound   = xerrors.New("process not found")
 	errProcessNotRunning = xerrors.New("process is not running")
 
+	// errProcessStartPending reports a reservation that has not
+	// published its process yet, so the request reached nothing
+	// though the command may still run.
+	errProcessStartPending = xerrors.New("process start is still pending")
+
 	// exitedProcessReapAge is how long an exited process without
 	// an idempotency key is kept before being automatically
 	// removed from the map.
@@ -444,6 +449,24 @@ func (m *manager) signal(id string, sig string) error {
 	}
 
 	return nil
+}
+
+// signalByKey signals the process started under an idempotency key,
+// so a caller that lost the start response can still act on it.
+// Reservations are chat-scoped, so another chat's key is absent here.
+//
+// A reservation that has not spawned yet is the expected state on this
+// path, since it is used precisely when the start response was lost.
+// Waiting within ctx keeps that from reading as a missing process.
+func (m *manager) signalByKey(ctx context.Context, chatID, idempotencyKey, sig string) error {
+	procID, err := m.runOnce.Await(ctx, runOnceKey{chatID: chatID, key: idempotencyKey})
+	if err != nil {
+		if errors.Is(err, agentrunonce.ErrPublicationPending) {
+			return errProcessStartPending
+		}
+		return errProcessNotFound
+	}
+	return m.signal(procID, sig)
 }
 
 // Close kills all running processes and prevents new ones from

--- a/agent/agentproc/process_internal_test.go
+++ b/agent/agentproc/process_internal_test.go
@@ -379,3 +379,96 @@ func TestCloseBeforeSpawnAbortsStart(t *testing.T) {
 		})
 	}
 }
+
+func TestSignalByKeyWaitsForPendingStart(t *testing.T) {
+	t.Parallel()
+
+	gate := newStartGate(t)
+	m := newTestManager(t, gate.option())
+	req := workspacesdk.StartProcessRequest{
+		Command:        "sleep 600",
+		IdempotencyKey: "key-pending",
+		Background:     true,
+	}
+
+	start := startAsync(context.Background(), m, req, "chat-1")
+	gate.waitStalled(t)
+
+	// The reservation exists but names no process yet. This is the
+	// expected state on the by-key path, because that path is used
+	// precisely when the start response was lost.
+	signalErr := make(chan error, 1)
+	go func() {
+		signalErr <- m.signalByKey(context.Background(), "chat-1", "key-pending", "kill")
+	}()
+
+	// Nothing resolves until the start publishes.
+	select {
+	case err := <-signalErr:
+		t.Fatalf("signal resolved before the start published: %v", err)
+	case <-time.After(testutil.IntervalMedium):
+	}
+
+	gate.release()
+	res := awaitStart(t, start)
+	require.NoError(t, res.err)
+
+	select {
+	case err := <-signalErr:
+		require.NoError(t, err)
+	case <-time.After(testutil.WaitShort):
+		t.Fatal("signal did not return after the start published")
+	}
+	<-res.proc.done
+}
+
+func TestSignalByKeyReportsPendingAtDeadline(t *testing.T) {
+	t.Parallel()
+
+	gate := newStartGate(t)
+	m := newTestManager(t, gate.option())
+	req := workspacesdk.StartProcessRequest{
+		Command:        "sleep 600",
+		IdempotencyKey: "key-pending-deadline",
+		Background:     true,
+	}
+
+	start := startAsync(context.Background(), m, req, "chat-1")
+	gate.waitStalled(t)
+
+	// A caller that gives up must not learn "not found", which would
+	// let it record the command as gone while it is about to run.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := m.signalByKey(ctx, "chat-1", "key-pending-deadline", "kill")
+	require.ErrorIs(t, err, errProcessStartPending)
+	require.NotErrorIs(t, err, errProcessNotFound)
+
+	gate.release()
+	require.NoError(t, awaitStart(t, start).err)
+}
+
+func TestSignalByKeyUnknownKeyNotFound(t *testing.T) {
+	t.Parallel()
+
+	m := newTestManager(t)
+	err := m.signalByKey(context.Background(), "chat-1", "key-missing", "kill")
+	require.ErrorIs(t, err, errProcessNotFound)
+}
+
+func TestSignalByKeyIsChatScoped(t *testing.T) {
+	t.Parallel()
+
+	m := newTestManager(t)
+	proc := requireStarted(t, m, workspacesdk.StartProcessRequest{
+		Command:        "sleep 600",
+		IdempotencyKey: "key-1",
+		Background:     true,
+	}, "chat-a")
+
+	require.ErrorIs(t, m.signalByKey(context.Background(), "chat-b", "key-1", "kill"), errProcessNotFound)
+	require.True(t, proc.info().Running)
+
+	require.NoError(t, m.signalByKey(context.Background(), "chat-a", "key-1", "kill"))
+	<-proc.done
+}

--- a/agent/agentrunonce/registry.go
+++ b/agent/agentrunonce/registry.go
@@ -25,6 +25,10 @@ var (
 
 	// ErrClosed reports a new reservation attempt on a closed registry.
 	ErrClosed = xerrors.New("registry is closed")
+
+	// ErrNotReserved reports a key that holds no reservation, because
+	// it was never reserved or its reservation was released or reaped.
+	ErrNotReserved = xerrors.New("key is not reserved")
 )
 
 // entry is one reservation. completedAt starts the retention window,
@@ -143,6 +147,34 @@ func (r *Registry[K, V]) waitForPublication(ctx context.Context, pending *entry[
 		return ErrPublicationPending
 	case <-ctx.Done():
 		return xerrors.Errorf("wait for reservation to be published: %w", errors.Join(ErrPublicationPending, ctx.Err()))
+	}
+}
+
+// Await returns the value published for a key, so callers can act on
+// an operation by its identity rather than by whatever handle it
+// returned. A pending reservation is waited out until ctx ends, so a
+// caller cannot mistake work that has not published yet for work that
+// never happened. It reports ErrNotReserved for an unreserved key and
+// ErrPublicationPending for one still pending at the deadline.
+func (r *Registry[K, V]) Await(ctx context.Context, key K) (V, error) {
+	var zero V
+	for {
+		r.mu.Lock()
+		existing, ok := r.entries[key]
+		if !ok {
+			r.mu.Unlock()
+			return zero, ErrNotReserved
+		}
+		if existing.published {
+			value := existing.value
+			r.mu.Unlock()
+			return value, nil
+		}
+		r.mu.Unlock()
+
+		if err := r.waitForPublication(ctx, existing); err != nil {
+			return zero, err
+		}
 	}
 }
 

--- a/agent/agentrunonce/registry_test.go
+++ b/agent/agentrunonce/registry_test.go
@@ -433,3 +433,83 @@ func TestForgetIgnoresSupersededGeneration(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, fresh.Ticket)
 }
+
+func TestAwaitReportsUnreservedKey(t *testing.T) {
+	t.Parallel()
+
+	registry := agentrunonce.NewRegistry[string, string](testRetention)
+
+	_, err := registry.Await(context.Background(), "key")
+	require.ErrorIs(t, err, agentrunonce.ErrNotReserved)
+}
+
+func TestAwaitReturnsPublishedValue(t *testing.T) {
+	t.Parallel()
+
+	registry := agentrunonce.NewRegistry[string, string](testRetention)
+
+	outcome, err := registry.Reserve(context.Background(), "key", "fp")
+	require.NoError(t, err)
+	outcome.Ticket.Publish("value")
+
+	value, err := registry.Await(context.Background(), "key")
+	require.NoError(t, err)
+	require.Equal(t, "value", value)
+}
+
+func TestAwaitWaitsForPendingReservation(t *testing.T) {
+	t.Parallel()
+
+	registry := agentrunonce.NewRegistry[string, string](testRetention)
+
+	outcome, err := registry.Reserve(context.Background(), "key", "fp")
+	require.NoError(t, err)
+
+	awaited := make(chan string, 1)
+	go func() {
+		value, err := registry.Await(context.Background(), "key")
+		if err == nil {
+			awaited <- value
+		}
+	}()
+
+	require.Never(t, func() bool {
+		return len(awaited) > 0
+	}, testutil.IntervalMedium, testutil.IntervalFast)
+
+	outcome.Ticket.Publish("value")
+	require.Equal(t, "value", testutil.RequireReceive(testutil.Context(t, testutil.WaitShort), t, awaited))
+}
+
+func TestAwaitReportsPendingAtDeadline(t *testing.T) {
+	t.Parallel()
+
+	registry := agentrunonce.NewRegistry[string, string](testRetention)
+
+	_, err := registry.Reserve(context.Background(), "key", "fp")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = registry.Await(ctx, "key")
+	require.ErrorIs(t, err, agentrunonce.ErrPublicationPending)
+	require.NotErrorIs(t, err, agentrunonce.ErrNotReserved)
+}
+
+func TestAwaitTreatsReleasedReservationAsUnreserved(t *testing.T) {
+	t.Parallel()
+
+	registry := agentrunonce.NewRegistry[string, string](testRetention)
+
+	outcome, err := registry.Reserve(context.Background(), "key", "fp")
+	require.NoError(t, err)
+
+	awaited := make(chan error, 1)
+	go func() {
+		_, err := registry.Await(context.Background(), "key")
+		awaited <- err
+	}()
+
+	outcome.Ticket.Release()
+	require.ErrorIs(t, testutil.RequireReceive(testutil.Context(t, testutil.WaitShort), t, awaited), agentrunonce.ErrNotReserved)
+}

--- a/coderd/x/chatd/ARCHITECTURE.md
+++ b/coderd/x/chatd/ARCHITECTURE.md
@@ -1027,6 +1027,27 @@ Attached foreground starts also return the process's original start time. The re
 
 This is at-least-once execution with best-effort deduplication. The registry does not survive agent restarts, reservations are reaped 60 minutes after process exit, and agents that predate the mechanism ignore the key entirely; in all of those cases a replay runs the command again.
 
+### Interrupt kill
+
+When a user action supersedes a running turn (an interrupt, an edit, or a message sent with `busy_behavior=interrupt`), the runner cancels the active task with the `chattool.ErrUserInterrupt` cause. A foreground `execute` call unwinding on that cause sends a best-effort kill signal on a detached, bounded context: the user asked for the work to stop, and the command would otherwise keep running after the turn result is discarded. Background processes are deliberately spared; they are addressable through their handle and the process list.
+
+The kill is armed before the start request, not after it, so it also covers a start whose response never arrived. In that case chatd knows no process ID, but it does know the idempotency key, and the agent can resolve that key to the process it started. The key travels in the request body rather than the URL path, because it carries a provider-supplied tool call ID that may contain characters needing escaping.
+
+A reservation whose start has not spawned yet is the expected state on that path, so the agent waits for it to publish within the request context before signaling. Only two answers prove there is nothing left to kill, and only those suppress the kill:
+
+| Answer | Meaning |
+|---|---|
+| 404 `process_key_not_found` | No reservation holds the key. |
+| 409 `not_running` | The process under the key has exited. |
+| 409 `start_pending` | The start has not spawned yet, so the command may still run. |
+| plain 404 | The agent predates the route, which says nothing about the process. |
+
+The last two are logged rather than treated as success, along with the case where the dispatch never identified the call and there is no key to signal by.
+
+Every other cancellation kills nothing: an attempt timeout, worker shutdown, or runner rebalancing cancels without the interrupt cause, leaving the process running so a retried attempt re-attaches through its idempotency key instead of starting the command again.
+
+The kill is best-effort. If the `StartProcess` response was lost, the agent is unreachable, or the worker dies before unwinding, the process keeps running but stays visible and killable through the process list.
+
 # Lifecycle hooks
 
 When the `agent-lifecycle-hooks` experiment is enabled and a hook URL is configured, chatd sends events to an external consumer at key points in a conversation: session start, prompt submission, tool use, compaction, and turn completion.

--- a/coderd/x/chatd/ARCHITECTURE.md
+++ b/coderd/x/chatd/ARCHITECTURE.md
@@ -921,6 +921,27 @@ Attached foreground starts also return the process's original start time. The re
 
 This is at-least-once execution with best-effort deduplication. The registry does not survive agent restarts, reservations are reaped 60 minutes after process exit, and agents that predate the mechanism ignore the key entirely; in all of those cases a replay runs the command again.
 
+### Interrupt kill
+
+When a user action supersedes a running turn (an interrupt, an edit, or a message sent with `busy_behavior=interrupt`), the runner cancels the active task with the `chattool.ErrUserInterrupt` cause. A foreground `execute` call unwinding on that cause sends a best-effort kill signal on a detached, bounded context: the user asked for the work to stop, and the command would otherwise keep running after the turn result is discarded. Background processes are deliberately spared; they are addressable through their handle and the process list.
+
+The kill is armed before the start request, not after it, so it also covers a start whose response never arrived. In that case chatd knows no process ID, but it does know the idempotency key, and the agent can resolve that key to the process it started. The key travels in the request body rather than the URL path, because it carries a provider-supplied tool call ID that may contain characters needing escaping.
+
+A reservation whose start has not spawned yet is the expected state on that path, so the agent waits for it to publish within the request context before signaling. Only two answers prove there is nothing left to kill, and only those suppress the kill:
+
+| Answer | Meaning |
+|---|---|
+| 404 `process_key_not_found` | No reservation holds the key. |
+| 409 `not_running` | The process under the key has exited. |
+| 409 `start_pending` | The start has not spawned yet, so the command may still run. |
+| plain 404 | The agent predates the route, which says nothing about the process. |
+
+The last two are logged rather than treated as success, along with the case where the dispatch never identified the call and there is no key to signal by.
+
+Every other cancellation kills nothing: an attempt timeout, worker shutdown, or runner rebalancing cancels without the interrupt cause, leaving the process running so a retried attempt re-attaches through its idempotency key instead of starting the command again.
+
+The kill is best-effort. If the `StartProcess` response was lost, the agent is unreachable, or the worker dies before unwinding, the process keeps running but stays visible and killable through the process list.
+
 # Lifecycle hooks
 
 When the `agent-lifecycle-hooks` experiment is enabled and a hook URL is configured, chatd sends events to an external consumer at key points in a conversation: session start, prompt submission, tool use, compaction, and turn completion.

--- a/coderd/x/chatd/chattool/execute.go
+++ b/coderd/x/chatd/chattool/execute.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strings"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 )
 
@@ -33,7 +35,14 @@ const (
 	// early, so a short agent-side wait cannot degenerate into a
 	// zero-delay request loop.
 	processWaitRetryDelay = time.Second
+
+	killSignalTimeout = 5 * time.Second
 )
+
+// ErrUserInterrupt is the cancellation cause chatd uses when a user
+// action supersedes the running turn. Foreground execute kills its
+// process only for this cause.
+var ErrUserInterrupt = xerrors.New("chat turn superseded by a user action")
 
 // idempotencyKeyFromContext derives the idempotency key for the tool
 // call being run, or "" when the dispatch did not identify it, in
@@ -237,6 +246,82 @@ func startProcessResolvingPendingWait(ctx context.Context, conn workspacesdk.Age
 	}
 }
 
+// userInterruptStopper kills a foreground process when a user action
+// supersedes the turn, and does nothing for any other cancellation
+// cause. It is armed before the start request, so a start whose
+// response never arrives cannot leave an unreachable command running.
+//
+// All methods run on the single goroutine executing the tool call.
+type userInterruptStopper struct {
+	conn           workspacesdk.AgentConn
+	logger         slog.Logger
+	idempotencyKey string
+	processID      string
+	disarmed       bool
+}
+
+func (s *userInterruptStopper) observeStart(processID string) {
+	s.processID = processID
+}
+
+func (s *userInterruptStopper) disarm() {
+	s.disarmed = true
+}
+
+// stop signals the process if the turn was superseded, on a detached
+// context because the tool context is already canceled. An unproven
+// failure is logged and dropped, leaving the process killable through
+// the process list.
+func (s *userInterruptStopper) stop(ctx context.Context) {
+	if s.disarmed || !xerrors.Is(context.Cause(ctx), ErrUserInterrupt) {
+		return
+	}
+	killCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), killSignalTimeout)
+	defer cancel()
+
+	var err error
+	switch {
+	case s.processID != "":
+		err = s.conn.SignalProcess(killCtx, s.processID, "kill")
+	case s.idempotencyKey != "":
+		// The start response never arrived, so the key is the only
+		// handle on the process.
+		err = s.conn.SignalProcessByIdempotencyKey(killCtx, s.idempotencyKey, "kill")
+	default:
+		return
+	}
+	if err == nil || isAlreadyGoneError(err) {
+		return
+	}
+	s.logger.Warn(ctx, "failed to kill foreground process on user interrupt",
+		slog.F("process_id", s.processID),
+		slog.F("idempotency_key", s.idempotencyKey),
+		slog.Error(err),
+	)
+}
+
+// isAlreadyGoneError reports a signal answer proving the process no
+// longer needs stopping.
+//
+// The by-key route's other answers do not prove that: an agent without
+// the route answers 404, and a start that has not spawned yet answers
+// 409. Both are logged rather than suppressed.
+func isAlreadyGoneError(err error) bool {
+	var notFound *workspacesdk.ProcessKeyNotFoundError
+	if xerrors.As(err, &notFound) {
+		return true
+	}
+	var conflict *workspacesdk.ProcessConflictError
+	if xerrors.As(err, &conflict) {
+		return conflict.Code == workspacesdk.ProcessConflictNotRunning
+	}
+	var sdkErr *codersdk.Error
+	if !xerrors.As(err, &sdkErr) {
+		return false
+	}
+	return sdkErr.StatusCode() == http.StatusNotFound || sdkErr.StatusCode() == http.StatusConflict
+}
+
 // startConflictResult converts a start conflict into an error result.
 // A parameter mismatch is permanent and started nothing. A
 // start-pending conflict is unresolved: the concurrent start may
@@ -324,6 +409,11 @@ func executeForeground(
 
 	start := time.Now()
 
+	// Armed before the start so an interrupt still stops the command
+	// when the start response is lost.
+	stopper := &userInterruptStopper{conn: conn, logger: options.Logger, idempotencyKey: idempotencyKey}
+	defer func() { stopper.stop(ctx) }()
+
 	resp, err := startProcessResolvingPendingWait(cmdCtx, conn, workspacesdk.StartProcessRequest{
 		Command:        args.Command,
 		WorkDir:        workDir,
@@ -333,10 +423,14 @@ func executeForeground(
 	})
 	if err != nil {
 		if idempotencyKey != "" && isConflictError(err) {
+			// The command belongs to another dispatch, which owns
+			// stopping it.
+			stopper.disarm()
 			return startConflictResult(ctx, options.Logger, idempotencyKey, err)
 		}
 		return errorResult(enrichStartError(fmt.Sprintf("start process: %v", err)))
 	}
+	stopper.observeStart(resp.ID)
 
 	var result ExecuteResult
 	if resp.Attached {
@@ -352,6 +446,10 @@ func executeForeground(
 		}
 	} else {
 		result = waitForProcess(cmdCtx, ctx, conn, resp.ID, timeout)
+	}
+	if result.BackgroundProcessID == "" {
+		// The wait observed the command finish.
+		stopper.disarm()
 	}
 	// An agent clock running ahead can place start in the future;
 	// clamp instead of reporting a negative duration.

--- a/coderd/x/chatd/chattool/execute.go
+++ b/coderd/x/chatd/chattool/execute.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strings"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 )
 
@@ -33,7 +35,14 @@ const (
 	// early, so a short agent-side wait cannot degenerate into a
 	// zero-delay request loop.
 	processWaitRetryDelay = time.Second
+
+	killSignalTimeout = 5 * time.Second
 )
+
+// ErrUserInterrupt is the cancellation cause chatd uses when a user
+// action supersedes the running turn. Foreground execute kills its
+// process only for this cause.
+var ErrUserInterrupt = xerrors.New("chat turn superseded by a user action")
 
 // idempotencyKeyFromContext derives the idempotency key for the tool
 // call being run, or "" when the dispatch did not identify it, in
@@ -227,6 +236,82 @@ func startProcessResolvingPendingWait(ctx context.Context, conn workspacesdk.Age
 	}
 }
 
+// userInterruptStopper kills a foreground process when a user action
+// supersedes the turn, and does nothing for any other cancellation
+// cause. It is armed before the start request, so a start whose
+// response never arrives cannot leave an unreachable command running.
+//
+// All methods run on the single goroutine executing the tool call.
+type userInterruptStopper struct {
+	conn           workspacesdk.AgentConn
+	logger         slog.Logger
+	idempotencyKey string
+	processID      string
+	disarmed       bool
+}
+
+func (s *userInterruptStopper) observeStart(processID string) {
+	s.processID = processID
+}
+
+func (s *userInterruptStopper) disarm() {
+	s.disarmed = true
+}
+
+// stop signals the process if the turn was superseded, on a detached
+// context because the tool context is already canceled. An unproven
+// failure is logged and dropped, leaving the process killable through
+// the process list.
+func (s *userInterruptStopper) stop(ctx context.Context) {
+	if s.disarmed || !xerrors.Is(context.Cause(ctx), ErrUserInterrupt) {
+		return
+	}
+	killCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), killSignalTimeout)
+	defer cancel()
+
+	var err error
+	switch {
+	case s.processID != "":
+		err = s.conn.SignalProcess(killCtx, s.processID, "kill")
+	case s.idempotencyKey != "":
+		// The start response never arrived, so the key is the only
+		// handle on the process.
+		err = s.conn.SignalProcessByIdempotencyKey(killCtx, s.idempotencyKey, "kill")
+	default:
+		return
+	}
+	if err == nil || isAlreadyGoneError(err) {
+		return
+	}
+	s.logger.Warn(ctx, "failed to kill foreground process on user interrupt",
+		slog.F("process_id", s.processID),
+		slog.F("idempotency_key", s.idempotencyKey),
+		slog.Error(err),
+	)
+}
+
+// isAlreadyGoneError reports a signal answer proving the process no
+// longer needs stopping.
+//
+// The by-key route's other answers do not prove that: an agent without
+// the route answers 404, and a start that has not spawned yet answers
+// 409. Both are logged rather than suppressed.
+func isAlreadyGoneError(err error) bool {
+	var notFound *workspacesdk.ProcessKeyNotFoundError
+	if xerrors.As(err, &notFound) {
+		return true
+	}
+	var conflict *workspacesdk.ProcessConflictError
+	if xerrors.As(err, &conflict) {
+		return conflict.Code == workspacesdk.ProcessConflictNotRunning
+	}
+	var sdkErr *codersdk.Error
+	if !xerrors.As(err, &sdkErr) {
+		return false
+	}
+	return sdkErr.StatusCode() == http.StatusNotFound || sdkErr.StatusCode() == http.StatusConflict
+}
+
 // startConflictResult converts a start conflict into an error result.
 // A parameter mismatch is permanent and started nothing. A
 // start-pending conflict is unresolved: the concurrent start may
@@ -313,6 +398,11 @@ func executeForeground(
 
 	start := time.Now()
 
+	// Armed before the start so an interrupt still stops the command
+	// when the start response is lost.
+	stopper := &userInterruptStopper{conn: conn, logger: options.Logger, idempotencyKey: idempotencyKey}
+	defer func() { stopper.stop(ctx) }()
+
 	resp, err := startProcessResolvingPendingWait(cmdCtx, conn, workspacesdk.StartProcessRequest{
 		Command:        args.Command,
 		WorkDir:        workDir,
@@ -322,10 +412,14 @@ func executeForeground(
 	})
 	if err != nil {
 		if idempotencyKey != "" && isConflictError(err) {
+			// The command belongs to another dispatch, which owns
+			// stopping it.
+			stopper.disarm()
 			return startConflictResult(ctx, options.Logger, idempotencyKey, err)
 		}
 		return errorResult(enrichStartError(fmt.Sprintf("start process: %v", err)))
 	}
+	stopper.observeStart(resp.ID)
 
 	var result ExecuteResult
 	if resp.Attached {
@@ -341,6 +435,10 @@ func executeForeground(
 		}
 	} else {
 		result = waitForProcess(cmdCtx, ctx, conn, resp.ID, timeout)
+	}
+	if result.BackgroundProcessID == "" {
+		// The wait observed the command finish.
+		stopper.disarm()
 	}
 	// An agent clock running ahead can place start in the future;
 	// clamp instead of reporting a negative duration.

--- a/coderd/x/chatd/chattool/execute_test.go
+++ b/coderd/x/chatd/chattool/execute_test.go
@@ -1,8 +1,10 @@
 package chattool_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"net/http"
 	"testing"
 	"time"
 
@@ -13,6 +15,8 @@ import (
 	"go.uber.org/mock/gomock"
 	"golang.org/x/xerrors"
 
+	"cdr.dev/slog/v3"
+	"cdr.dev/slog/v3/sloggers/sloghuman"
 	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
@@ -1227,6 +1231,289 @@ func TestExecuteToolIdempotencyKey(t *testing.T) {
 
 		tool := newExecuteTool(t, mockConn)
 		result := runExecute(t, identityCtx(t), tool, "call-1", `{"command":"sleep 100","run_in_background":true}`)
+		assert.True(t, result.Success)
+		assert.Equal(t, "proc-bg", result.BackgroundProcessID)
+	})
+}
+
+func TestExecuteToolInterruptKill(t *testing.T) {
+	t.Parallel()
+
+	// interruptedWait wires StartProcess to succeed and the process
+	// wait (plus its recovery snapshot) to fail after canceling the
+	// tool context with cause.
+	interruptedWait := func(mockConn *agentconnmock.MockAgentConn, cancel context.CancelCauseFunc, cause error) {
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			Return(workspacesdk.StartProcessResponse{ID: "proc-1", Started: true}, nil)
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, _ *workspacesdk.ProcessOutputOptions) (workspacesdk.ProcessOutputResponse, error) {
+				cancel(cause)
+				return workspacesdk.ProcessOutputResponse{}, xerrors.New("request canceled")
+			}).
+			Times(2)
+	}
+	runForeground := func(t *testing.T, ctx context.Context, mockConn *agentconnmock.MockAgentConn) chattool.ExecuteResult {
+		t.Helper()
+		tool := newExecuteTool(t, mockConn)
+		resp, err := tool.Run(ctx, fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "execute",
+			Input: `{"command":"sleep 60"}`,
+		})
+		require.NoError(t, err)
+		var result chattool.ExecuteResult
+		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+		return result
+	}
+	// runForegroundIdentifiedWithLogger supplies the dispatch identity
+	// the dispatcher normally attaches, so the call carries a token.
+	runForegroundIdentifiedWithLogger := func(t *testing.T, ctx context.Context, mockConn *agentconnmock.MockAgentConn, logger slog.Logger) chattool.ExecuteResult {
+		t.Helper()
+		identified := chattool.WithToolCallID(
+			chattool.WithDispatchIdentity(ctx, uuid.New(), 7),
+			"call-1",
+		)
+		tool := chattool.Execute(chattool.ExecuteOptions{
+			GetWorkspaceConn: func(_ context.Context) (workspacesdk.AgentConn, error) {
+				return mockConn, nil
+			},
+			Logger: logger,
+		})
+		resp, err := tool.Run(identified, fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "execute",
+			Input: `{"command":"sleep 60"}`,
+		})
+		require.NoError(t, err)
+		var result chattool.ExecuteResult
+		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+		return result
+	}
+	runForegroundIdentified := func(t *testing.T, ctx context.Context, mockConn *agentconnmock.MockAgentConn) chattool.ExecuteResult {
+		t.Helper()
+		return runForegroundIdentifiedWithLogger(t, ctx, mockConn, slog.Logger{})
+	}
+
+	t.Run("UserInterruptKillsForegroundProcess", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		ctx, cancel := context.WithCancelCause(testutil.Context(t, testutil.WaitMedium))
+		defer cancel(nil)
+
+		interruptedWait(mockConn, cancel, chattool.ErrUserInterrupt)
+		mockConn.EXPECT().
+			SignalProcess(gomock.Any(), "proc-1", "kill").
+			Return(nil)
+
+		result := runForeground(t, ctx, mockConn)
+		assert.False(t, result.Success)
+	})
+
+	t.Run("LostStartResponseKillsByIdempotencyKey", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		ctx, cancel := context.WithCancelCause(testutil.Context(t, testutil.WaitMedium))
+		defer cancel(nil)
+
+		// The agent started the process but the response never
+		// arrived, so no process ID is known. The idempotency key is
+		// still enough to stop the command.
+		var key string
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req workspacesdk.StartProcessRequest) (workspacesdk.StartProcessResponse, error) {
+				key = req.IdempotencyKey
+				cancel(chattool.ErrUserInterrupt)
+				return workspacesdk.StartProcessResponse{}, xerrors.New("request canceled")
+			})
+		signaled := make(chan string, 1)
+		mockConn.EXPECT().
+			SignalProcessByIdempotencyKey(gomock.Any(), gomock.Any(), "kill").
+			DoAndReturn(func(_ context.Context, idempotencyKey string, _ string) error {
+				signaled <- idempotencyKey
+				return nil
+			})
+
+		result := runForegroundIdentified(t, ctx, mockConn)
+		assert.False(t, result.Success)
+		require.NotEmpty(t, key)
+		require.Equal(t, key, testutil.RequireReceive(testutil.Context(t, testutil.WaitShort), t, signaled))
+	})
+
+	t.Run("LostStartResponseWithoutKeySignalsNothing", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		ctx, cancel := context.WithCancelCause(testutil.Context(t, testutil.WaitMedium))
+		defer cancel(nil)
+
+		// An unidentified call has no key, so there is nothing to
+		// address the process by. gomock fails the test on any
+		// unexpected signal call.
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ workspacesdk.StartProcessRequest) (workspacesdk.StartProcessResponse, error) {
+				cancel(chattool.ErrUserInterrupt)
+				return workspacesdk.StartProcessResponse{}, xerrors.New("request canceled")
+			})
+
+		result := runForeground(t, ctx, mockConn)
+		assert.False(t, result.Success)
+	})
+
+	t.Run("OldAgentUnsupportedRouteIsNotTreatedAsGone", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		ctx, cancel := context.WithCancelCause(testutil.Context(t, testutil.WaitMedium))
+		defer cancel(nil)
+
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ workspacesdk.StartProcessRequest) (workspacesdk.StartProcessResponse, error) {
+				cancel(chattool.ErrUserInterrupt)
+				return workspacesdk.StartProcessResponse{}, xerrors.New("request canceled")
+			})
+		mockConn.EXPECT().
+			SignalProcessByIdempotencyKey(gomock.Any(), gomock.Any(), "kill").
+			Return(workspacesdk.ErrProcessKeySignalUnsupported)
+
+		// The agent could not act on the key, so the command may still
+		// be running. This must be reported, not swallowed as "gone".
+		var logs bytes.Buffer
+		logger := slog.Make(sloghuman.Sink(&logs)).Leveled(slog.LevelDebug)
+		result := runForegroundIdentifiedWithLogger(t, ctx, mockConn, logger)
+		assert.False(t, result.Success)
+		assert.Contains(t, logs.String(), "failed to kill foreground process")
+	})
+
+	t.Run("PendingStartIsNotTreatedAsGone", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		ctx, cancel := context.WithCancelCause(testutil.Context(t, testutil.WaitMedium))
+		defer cancel(nil)
+
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ workspacesdk.StartProcessRequest) (workspacesdk.StartProcessResponse, error) {
+				cancel(chattool.ErrUserInterrupt)
+				return workspacesdk.StartProcessResponse{}, xerrors.New("request canceled")
+			})
+		mockConn.EXPECT().
+			SignalProcessByIdempotencyKey(gomock.Any(), gomock.Any(), "kill").
+			Return(&workspacesdk.ProcessConflictError{
+				Code: workspacesdk.ProcessConflictStartPending,
+				Response: codersdk.Response{
+					Message: "The start holding this idempotency key has not spawned its process yet.",
+				},
+			})
+
+		// A concurrent start still holds the key, so the command may
+		// yet run. Reporting it as gone would silently drop the kill.
+		var logs bytes.Buffer
+		logger := slog.Make(sloghuman.Sink(&logs)).Leveled(slog.LevelDebug)
+		result := runForegroundIdentifiedWithLogger(t, ctx, mockConn, logger)
+		assert.False(t, result.Success)
+		assert.Contains(t, logs.String(), "failed to kill foreground process")
+	})
+
+	t.Run("KillByKeyTreatsExitedProcessAsGone", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		ctx, cancel := context.WithCancelCause(testutil.Context(t, testutil.WaitMedium))
+		defer cancel(nil)
+
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ workspacesdk.StartProcessRequest) (workspacesdk.StartProcessResponse, error) {
+				cancel(chattool.ErrUserInterrupt)
+				return workspacesdk.StartProcessResponse{}, xerrors.New("request canceled")
+			})
+		mockConn.EXPECT().
+			SignalProcessByIdempotencyKey(gomock.Any(), gomock.Any(), "kill").
+			Return(&workspacesdk.ProcessConflictError{
+				Code: workspacesdk.ProcessConflictNotRunning,
+				Response: codersdk.Response{
+					Message: "The process started with this idempotency key is not running.",
+				},
+			})
+
+		var logs bytes.Buffer
+		logger := slog.Make(sloghuman.Sink(&logs)).Leveled(slog.LevelDebug)
+		result := runForegroundIdentifiedWithLogger(t, ctx, mockConn, logger)
+		assert.False(t, result.Success)
+		assert.NotContains(t, logs.String(), "failed to kill foreground process")
+	})
+
+	t.Run("KillTreatsExitedProcessAsGone", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		ctx, cancel := context.WithCancelCause(testutil.Context(t, testutil.WaitMedium))
+		defer cancel(nil)
+
+		interruptedWait(mockConn, cancel, chattool.ErrUserInterrupt)
+		// 409 means the process already exited; the kill treats it
+		// as already gone instead of failing.
+		mockConn.EXPECT().
+			SignalProcess(gomock.Any(), "proc-1", "kill").
+			Return(codersdk.NewError(http.StatusConflict, codersdk.Response{
+				Message: "Process is not running.",
+			}))
+
+		result := runForeground(t, ctx, mockConn)
+		assert.False(t, result.Success)
+	})
+
+	t.Run("AttemptTimeoutDoesNotKill", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		ctx, cancel := context.WithCancelCause(testutil.Context(t, testutil.WaitMedium))
+		defer cancel(nil)
+
+		// Any non-interrupt cause (attempt timeout, worker shutdown)
+		// must leave the process running for re-attach, so no
+		// SignalProcess call is expected.
+		interruptedWait(mockConn, cancel, xerrors.New("chatworker task timeout"))
+
+		result := runForeground(t, ctx, mockConn)
+		assert.False(t, result.Success)
+		assert.Equal(t, "proc-1", result.BackgroundProcessID)
+	})
+
+	t.Run("BackgroundProcessSpared", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		ctx, cancel := context.WithCancelCause(testutil.Context(t, testutil.WaitMedium))
+		defer cancel(nil)
+
+		// The user interrupt lands right after the background start;
+		// no SignalProcess call is expected.
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req workspacesdk.StartProcessRequest) (workspacesdk.StartProcessResponse, error) {
+				assert.True(t, req.Background)
+				cancel(chattool.ErrUserInterrupt)
+				return workspacesdk.StartProcessResponse{ID: "proc-bg", Started: true}, nil
+			})
+
+		tool := newExecuteTool(t, mockConn)
+		resp, err := tool.Run(ctx, fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "execute",
+			Input: `{"command":"sleep 60","run_in_background":true}`,
+		})
+		require.NoError(t, err)
+		var result chattool.ExecuteResult
+		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
 		assert.True(t, result.Success)
 		assert.Equal(t, "proc-bg", result.BackgroundProcessID)
 	})

--- a/coderd/x/chatd/chattool/execute_test.go
+++ b/coderd/x/chatd/chattool/execute_test.go
@@ -1,8 +1,10 @@
 package chattool_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"net/http"
 	"testing"
 	"time"
 
@@ -13,6 +15,8 @@ import (
 	"go.uber.org/mock/gomock"
 	"golang.org/x/xerrors"
 
+	"cdr.dev/slog/v3"
+	"cdr.dev/slog/v3/sloggers/sloghuman"
 	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
@@ -1093,6 +1097,289 @@ func TestExecuteToolIdempotencyKey(t *testing.T) {
 
 		tool := newExecuteTool(t, mockConn)
 		result := runExecute(t, identityCtx(t), tool, "call-1", `{"command":"sleep 100","run_in_background":true}`)
+		assert.True(t, result.Success)
+		assert.Equal(t, "proc-bg", result.BackgroundProcessID)
+	})
+}
+
+func TestExecuteToolInterruptKill(t *testing.T) {
+	t.Parallel()
+
+	// interruptedWait wires StartProcess to succeed and the process
+	// wait (plus its recovery snapshot) to fail after canceling the
+	// tool context with cause.
+	interruptedWait := func(mockConn *agentconnmock.MockAgentConn, cancel context.CancelCauseFunc, cause error) {
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			Return(workspacesdk.StartProcessResponse{ID: "proc-1", Started: true}, nil)
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, _ *workspacesdk.ProcessOutputOptions) (workspacesdk.ProcessOutputResponse, error) {
+				cancel(cause)
+				return workspacesdk.ProcessOutputResponse{}, xerrors.New("request canceled")
+			}).
+			Times(2)
+	}
+	runForeground := func(t *testing.T, ctx context.Context, mockConn *agentconnmock.MockAgentConn) chattool.ExecuteResult {
+		t.Helper()
+		tool := newExecuteTool(t, mockConn)
+		resp, err := tool.Run(ctx, fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "execute",
+			Input: `{"command":"sleep 60"}`,
+		})
+		require.NoError(t, err)
+		var result chattool.ExecuteResult
+		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+		return result
+	}
+	// runForegroundIdentifiedWithLogger supplies the dispatch identity
+	// the dispatcher normally attaches, so the call carries a token.
+	runForegroundIdentifiedWithLogger := func(t *testing.T, ctx context.Context, mockConn *agentconnmock.MockAgentConn, logger slog.Logger) chattool.ExecuteResult {
+		t.Helper()
+		identified := chattool.WithToolCallID(
+			chattool.WithDispatchIdentity(ctx, uuid.New(), 7),
+			"call-1",
+		)
+		tool := chattool.Execute(chattool.ExecuteOptions{
+			GetWorkspaceConn: func(_ context.Context) (workspacesdk.AgentConn, error) {
+				return mockConn, nil
+			},
+			Logger: logger,
+		})
+		resp, err := tool.Run(identified, fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "execute",
+			Input: `{"command":"sleep 60"}`,
+		})
+		require.NoError(t, err)
+		var result chattool.ExecuteResult
+		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+		return result
+	}
+	runForegroundIdentified := func(t *testing.T, ctx context.Context, mockConn *agentconnmock.MockAgentConn) chattool.ExecuteResult {
+		t.Helper()
+		return runForegroundIdentifiedWithLogger(t, ctx, mockConn, slog.Logger{})
+	}
+
+	t.Run("UserInterruptKillsForegroundProcess", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		ctx, cancel := context.WithCancelCause(testutil.Context(t, testutil.WaitMedium))
+		defer cancel(nil)
+
+		interruptedWait(mockConn, cancel, chattool.ErrUserInterrupt)
+		mockConn.EXPECT().
+			SignalProcess(gomock.Any(), "proc-1", "kill").
+			Return(nil)
+
+		result := runForeground(t, ctx, mockConn)
+		assert.False(t, result.Success)
+	})
+
+	t.Run("LostStartResponseKillsByIdempotencyKey", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		ctx, cancel := context.WithCancelCause(testutil.Context(t, testutil.WaitMedium))
+		defer cancel(nil)
+
+		// The agent started the process but the response never
+		// arrived, so no process ID is known. The idempotency key is
+		// still enough to stop the command.
+		var key string
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req workspacesdk.StartProcessRequest) (workspacesdk.StartProcessResponse, error) {
+				key = req.IdempotencyKey
+				cancel(chattool.ErrUserInterrupt)
+				return workspacesdk.StartProcessResponse{}, xerrors.New("request canceled")
+			})
+		signaled := make(chan string, 1)
+		mockConn.EXPECT().
+			SignalProcessByIdempotencyKey(gomock.Any(), gomock.Any(), "kill").
+			DoAndReturn(func(_ context.Context, idempotencyKey string, _ string) error {
+				signaled <- idempotencyKey
+				return nil
+			})
+
+		result := runForegroundIdentified(t, ctx, mockConn)
+		assert.False(t, result.Success)
+		require.NotEmpty(t, key)
+		require.Equal(t, key, testutil.RequireReceive(testutil.Context(t, testutil.WaitShort), t, signaled))
+	})
+
+	t.Run("LostStartResponseWithoutKeySignalsNothing", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		ctx, cancel := context.WithCancelCause(testutil.Context(t, testutil.WaitMedium))
+		defer cancel(nil)
+
+		// An unidentified call has no key, so there is nothing to
+		// address the process by. gomock fails the test on any
+		// unexpected signal call.
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ workspacesdk.StartProcessRequest) (workspacesdk.StartProcessResponse, error) {
+				cancel(chattool.ErrUserInterrupt)
+				return workspacesdk.StartProcessResponse{}, xerrors.New("request canceled")
+			})
+
+		result := runForeground(t, ctx, mockConn)
+		assert.False(t, result.Success)
+	})
+
+	t.Run("OldAgentUnsupportedRouteIsNotTreatedAsGone", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		ctx, cancel := context.WithCancelCause(testutil.Context(t, testutil.WaitMedium))
+		defer cancel(nil)
+
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ workspacesdk.StartProcessRequest) (workspacesdk.StartProcessResponse, error) {
+				cancel(chattool.ErrUserInterrupt)
+				return workspacesdk.StartProcessResponse{}, xerrors.New("request canceled")
+			})
+		mockConn.EXPECT().
+			SignalProcessByIdempotencyKey(gomock.Any(), gomock.Any(), "kill").
+			Return(workspacesdk.ErrProcessKeySignalUnsupported)
+
+		// The agent could not act on the key, so the command may still
+		// be running. This must be reported, not swallowed as "gone".
+		var logs bytes.Buffer
+		logger := slog.Make(sloghuman.Sink(&logs)).Leveled(slog.LevelDebug)
+		result := runForegroundIdentifiedWithLogger(t, ctx, mockConn, logger)
+		assert.False(t, result.Success)
+		assert.Contains(t, logs.String(), "failed to kill foreground process")
+	})
+
+	t.Run("PendingStartIsNotTreatedAsGone", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		ctx, cancel := context.WithCancelCause(testutil.Context(t, testutil.WaitMedium))
+		defer cancel(nil)
+
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ workspacesdk.StartProcessRequest) (workspacesdk.StartProcessResponse, error) {
+				cancel(chattool.ErrUserInterrupt)
+				return workspacesdk.StartProcessResponse{}, xerrors.New("request canceled")
+			})
+		mockConn.EXPECT().
+			SignalProcessByIdempotencyKey(gomock.Any(), gomock.Any(), "kill").
+			Return(&workspacesdk.ProcessConflictError{
+				Code: workspacesdk.ProcessConflictStartPending,
+				Response: codersdk.Response{
+					Message: "The start holding this idempotency key has not spawned its process yet.",
+				},
+			})
+
+		// A concurrent start still holds the key, so the command may
+		// yet run. Reporting it as gone would silently drop the kill.
+		var logs bytes.Buffer
+		logger := slog.Make(sloghuman.Sink(&logs)).Leveled(slog.LevelDebug)
+		result := runForegroundIdentifiedWithLogger(t, ctx, mockConn, logger)
+		assert.False(t, result.Success)
+		assert.Contains(t, logs.String(), "failed to kill foreground process")
+	})
+
+	t.Run("KillByKeyTreatsExitedProcessAsGone", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		ctx, cancel := context.WithCancelCause(testutil.Context(t, testutil.WaitMedium))
+		defer cancel(nil)
+
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ workspacesdk.StartProcessRequest) (workspacesdk.StartProcessResponse, error) {
+				cancel(chattool.ErrUserInterrupt)
+				return workspacesdk.StartProcessResponse{}, xerrors.New("request canceled")
+			})
+		mockConn.EXPECT().
+			SignalProcessByIdempotencyKey(gomock.Any(), gomock.Any(), "kill").
+			Return(&workspacesdk.ProcessConflictError{
+				Code: workspacesdk.ProcessConflictNotRunning,
+				Response: codersdk.Response{
+					Message: "The process started with this idempotency key is not running.",
+				},
+			})
+
+		var logs bytes.Buffer
+		logger := slog.Make(sloghuman.Sink(&logs)).Leveled(slog.LevelDebug)
+		result := runForegroundIdentifiedWithLogger(t, ctx, mockConn, logger)
+		assert.False(t, result.Success)
+		assert.NotContains(t, logs.String(), "failed to kill foreground process")
+	})
+
+	t.Run("KillTreatsExitedProcessAsGone", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		ctx, cancel := context.WithCancelCause(testutil.Context(t, testutil.WaitMedium))
+		defer cancel(nil)
+
+		interruptedWait(mockConn, cancel, chattool.ErrUserInterrupt)
+		// 409 means the process already exited; the kill treats it
+		// as already gone instead of failing.
+		mockConn.EXPECT().
+			SignalProcess(gomock.Any(), "proc-1", "kill").
+			Return(codersdk.NewError(http.StatusConflict, codersdk.Response{
+				Message: "Process is not running.",
+			}))
+
+		result := runForeground(t, ctx, mockConn)
+		assert.False(t, result.Success)
+	})
+
+	t.Run("AttemptTimeoutDoesNotKill", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		ctx, cancel := context.WithCancelCause(testutil.Context(t, testutil.WaitMedium))
+		defer cancel(nil)
+
+		// Any non-interrupt cause (attempt timeout, worker shutdown)
+		// must leave the process running for re-attach, so no
+		// SignalProcess call is expected.
+		interruptedWait(mockConn, cancel, xerrors.New("chatworker task timeout"))
+
+		result := runForeground(t, ctx, mockConn)
+		assert.False(t, result.Success)
+		assert.Equal(t, "proc-1", result.BackgroundProcessID)
+	})
+
+	t.Run("BackgroundProcessSpared", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		ctx, cancel := context.WithCancelCause(testutil.Context(t, testutil.WaitMedium))
+		defer cancel(nil)
+
+		// The user interrupt lands right after the background start;
+		// no SignalProcess call is expected.
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req workspacesdk.StartProcessRequest) (workspacesdk.StartProcessResponse, error) {
+				assert.True(t, req.Background)
+				cancel(chattool.ErrUserInterrupt)
+				return workspacesdk.StartProcessResponse{ID: "proc-bg", Started: true}, nil
+			})
+
+		tool := newExecuteTool(t, mockConn)
+		resp, err := tool.Run(ctx, fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "execute",
+			Input: `{"command":"sleep 60","run_in_background":true}`,
+		})
+		require.NoError(t, err)
+		var result chattool.ExecuteResult
+		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
 		assert.True(t, result.Success)
 		assert.Equal(t, "proc-bg", result.BackgroundProcessID)
 	})

--- a/coderd/x/chatd/runner.go
+++ b/coderd/x/chatd/runner.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/coder/coder/v2/coderd/database"
 	coderdpubsub "github.com/coder/coder/v2/coderd/pubsub"
+	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
 )
 
 type taskKind string
@@ -37,7 +38,7 @@ type taskRecord struct {
 	id       taskInstanceID
 	kind     taskKind
 	localKey localWorkKey
-	cancel   context.CancelFunc
+	cancel   context.CancelCauseFunc
 	done     <-chan struct{}
 }
 
@@ -83,7 +84,9 @@ func (r *runner) run() {
 		case state := <-r.rec.stateCh:
 			r.processState(state)
 		case <-r.ctx.Done():
-			r.cancelActiveTask()
+			// Shutdown and rebalancing are not user interrupts, so
+			// tools leave their processes running for a replay.
+			r.cancelActiveTask(nil)
 			r.waitForTasks()
 			r.closeDebugTurn()
 			return
@@ -165,7 +168,10 @@ func (r *runner) processState(state runnerStateUpdate) {
 		return
 	}
 	if r.hasAcceptedState && r.activeTaskSet {
-		r.cancelActiveTask()
+		// A status or history change superseding an active task is
+		// user-driven: an interrupt, an edit, or a promoted queued
+		// message.
+		r.cancelActiveTask(chattool.ErrUserInterrupt)
 	}
 
 	r.spawnForState(state)
@@ -205,7 +211,7 @@ func (r *runner) spawnTaskIfNeeded(kind taskKind, state runnerStateUpdate) {
 	}
 
 	id := taskInstanceID(uuid.New())
-	taskCtx, cancel := context.WithCancel(r.ctx)
+	taskCtx, cancel := context.WithCancelCause(r.ctx)
 	done := make(chan struct{})
 	record := &taskRecord{
 		id:       id,
@@ -276,14 +282,19 @@ func (r *runner) runTask(
 	}
 }
 
-func (r *runner) cancelActiveTask() {
+// cancelActiveTask cancels the active task with cause. State-change
+// cancellations pass chattool.ErrUserInterrupt so tools can tell a
+// user superseding the turn (interrupt, edit, promoted message) from
+// shutdown or timeout; pass nil for cancellations the task should
+// treat as neutral (the work continues elsewhere).
+func (r *runner) cancelActiveTask(cause error) {
 	if !r.activeTaskSet {
 		return
 	}
 	id := r.activeTaskID
 	r.activeTaskSet = false
 	if record := r.tasks[id]; record != nil {
-		record.cancel()
+		record.cancel(cause)
 	}
 }
 

--- a/coderd/x/chatd/runner_test.go
+++ b/coderd/x/chatd/runner_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
 	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
 )
@@ -40,6 +41,7 @@ func TestRunner_CancelsActiveTaskWhenHistoryChanges(t *testing.T) {
 	require.Greater(t, updated.HistoryVersion, first.input.HistoryVersion)
 	requireTaskCanceled(t, first)
 	require.NotErrorIs(t, context.Cause(first.ctx), errTaskTimeout)
+	require.ErrorIs(t, context.Cause(first.ctx), chattool.ErrUserInterrupt)
 	second := starter.waitCall(t, taskKindGeneration, chat.ID)
 	require.Equal(t, updated.HistoryVersion, second.input.HistoryVersion)
 	require.Same(t, first.input.SessionStart, second.input.SessionStart)
@@ -56,6 +58,7 @@ func TestRunner_CancelsActiveTaskWhenStatusChanges(t *testing.T) {
 	updated := interruptChat(t, f, chat.ID)
 	require.Equal(t, database.ChatStatusInterrupting, updated.Status)
 	requireTaskCanceled(t, first)
+	require.ErrorIs(t, context.Cause(first.ctx), chattool.ErrUserInterrupt)
 	second := starter.waitCall(t, taskKindInterrupt, chat.ID)
 	require.Equal(t, updated.HistoryVersion, second.input.HistoryVersion)
 }
@@ -70,6 +73,9 @@ func TestRunner_CleansUpOnOwnershipTakeover(t *testing.T) {
 
 	acquireChat(t, f, chat.ID, uuid.New(), uuid.New())
 	requireTaskCanceled(t, first)
+	// Ownership takeover is not a user interrupt: the chat's work
+	// continues on the new owner, so tools must not kill processes.
+	require.NotErrorIs(t, context.Cause(first.ctx), chattool.ErrUserInterrupt)
 	starter.assertNoCall(t)
 }
 

--- a/codersdk/workspacesdk/agentconn.go
+++ b/codersdk/workspacesdk/agentconn.go
@@ -115,6 +115,7 @@ type AgentConn interface {
 	DeleteDevcontainer(ctx context.Context, devcontainerID string) error
 	RecreateDevcontainer(ctx context.Context, devcontainerID string) (codersdk.Response, error)
 	SignalProcess(ctx context.Context, id string, signal string) error
+	SignalProcessByIdempotencyKey(ctx context.Context, idempotencyKey string, signal string) error
 	StartProcess(ctx context.Context, req StartProcessRequest) (StartProcessResponse, error)
 	LS(ctx context.Context, path string, req LSRequest) (LSResponse, error)
 	ResolvePath(ctx context.Context, path string) (string, error)
@@ -931,6 +932,31 @@ type StartProcessResponse struct {
 	StartedAt int64 `json:"started_at,omitempty"`
 }
 
+// SignalProcessByIdempotencyKeyRequest signals the process started
+// under an idempotency key, for a caller whose start response was lost
+// and which therefore never learned the process ID.
+type SignalProcessByIdempotencyKeyRequest struct {
+	IdempotencyKey string `json:"idempotency_key"`
+	Signal         string `json:"signal"`
+}
+
+// ProcessKeyNotFoundCode marks a 404 from the by-key signal route as a
+// genuine "no process under this key" answer. Agents that predate that
+// route answer 404 too, but without this code, so callers must not
+// read every 404 as proof the process is gone.
+const ProcessKeyNotFoundCode = "process_key_not_found"
+
+// ProcessKeyNotFoundError reports that no process is held under a key.
+type ProcessKeyNotFoundError struct {
+	Code string `json:"code"`
+	codersdk.Response
+}
+
+// ErrProcessKeySignalUnsupported reports a by-key signal answered by an
+// agent that does not implement the route, so the request proves
+// nothing about the process.
+var ErrProcessKeySignalUnsupported = xerrors.New("agent does not support signaling a process by idempotency key")
+
 type ProcessConflictCode string
 
 const (
@@ -943,6 +969,10 @@ const (
 	// key had not published its process before the wait gave up. A
 	// retry may still attach to it.
 	ProcessConflictStartPending ProcessConflictCode = "start_pending"
+
+	// ProcessConflictNotRunning reports a by-key signal whose process
+	// has already exited, so there is nothing left to signal.
+	ProcessConflictNotRunning ProcessConflictCode = "not_running"
 )
 
 // ProcessConflictError is the body of a start request rejected
@@ -1485,6 +1515,56 @@ func (c *agentConn) SignalProcess(ctx context.Context, id string, signal string)
 		return xerrors.Errorf("decode response body: %w", err)
 	}
 	return nil
+}
+
+// SignalProcessByIdempotencyKey sends a signal to the process started
+// under an idempotency key, so a caller that never received the start
+// response can still act on it. The key travels in the body, so no
+// key value needs URL escaping.
+//
+// A 404 carrying ProcessKeyNotFoundCode means no process is held under
+// the key. Any other 404 comes from an agent without this route and is
+// reported as ErrProcessKeySignalUnsupported, because such an answer
+// says nothing about the process.
+func (c *agentConn) SignalProcessByIdempotencyKey(ctx context.Context, idempotencyKey string, signal string) error {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
+	res, err := c.apiRequest(ctx, http.MethodPost, "/api/v0/processes/signal-by-idempotency-key", SignalProcessByIdempotencyKeyRequest{
+		IdempotencyKey: idempotencyKey,
+		Signal:         signal,
+	})
+	if err != nil {
+		return xerrors.Errorf("do request: %w", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode == http.StatusNotFound {
+		return readProcessKeyNotFoundError(res)
+	}
+	if res.StatusCode == http.StatusConflict {
+		return readProcessConflictError(res)
+	}
+	if res.StatusCode != http.StatusOK {
+		return codersdk.ReadBodyAsError(res)
+	}
+	return nil
+}
+
+// readProcessKeyNotFoundError distinguishes "no process under this
+// key" from an agent that does not implement the route.
+func readProcessKeyNotFoundError(res *http.Response) error {
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return xerrors.Errorf("read response body: %w", err)
+	}
+	var notFound ProcessKeyNotFoundError
+	if err := json.Unmarshal(body, &notFound); err == nil && notFound.Code == ProcessKeyNotFoundCode {
+		return &notFound
+	}
+	return ErrProcessKeySignalUnsupported
+}
+
+func (e *ProcessKeyNotFoundError) Error() string {
+	return e.Message
 }
 
 // EditFiles replaces old_text with new_text on one or more files.

--- a/codersdk/workspacesdk/agentconn.go
+++ b/codersdk/workspacesdk/agentconn.go
@@ -115,6 +115,7 @@ type AgentConn interface {
 	DeleteDevcontainer(ctx context.Context, devcontainerID string) error
 	RecreateDevcontainer(ctx context.Context, devcontainerID string) (codersdk.Response, error)
 	SignalProcess(ctx context.Context, id string, signal string) error
+	SignalProcessByIdempotencyKey(ctx context.Context, idempotencyKey string, signal string) error
 	StartProcess(ctx context.Context, req StartProcessRequest) (StartProcessResponse, error)
 	LS(ctx context.Context, path string, req LSRequest) (LSResponse, error)
 	ResolvePath(ctx context.Context, path string) (string, error)
@@ -931,6 +932,31 @@ type StartProcessResponse struct {
 	StartedAt int64 `json:"started_at,omitempty"`
 }
 
+// SignalProcessByIdempotencyKeyRequest signals the process started
+// under an idempotency key, for a caller whose start response was lost
+// and which therefore never learned the process ID.
+type SignalProcessByIdempotencyKeyRequest struct {
+	IdempotencyKey string `json:"idempotency_key"`
+	Signal         string `json:"signal"`
+}
+
+// ProcessKeyNotFoundCode marks a 404 from the by-key signal route as a
+// genuine "no process under this key" answer. Agents that predate that
+// route answer 404 too, but without this code, so callers must not
+// read every 404 as proof the process is gone.
+const ProcessKeyNotFoundCode = "process_key_not_found"
+
+// ProcessKeyNotFoundError reports that no process is held under a key.
+type ProcessKeyNotFoundError struct {
+	Code string `json:"code"`
+	codersdk.Response
+}
+
+// ErrProcessKeySignalUnsupported reports a by-key signal answered by an
+// agent that does not implement the route, so the request proves
+// nothing about the process.
+var ErrProcessKeySignalUnsupported = xerrors.New("agent does not support signaling a process by idempotency key")
+
 type ProcessConflictCode string
 
 const (
@@ -943,6 +969,10 @@ const (
 	// key had not published its process before the wait gave up. A
 	// retry may still attach to it.
 	ProcessConflictStartPending ProcessConflictCode = "start_pending"
+
+	// ProcessConflictNotRunning reports a by-key signal whose process
+	// has already exited, so there is nothing left to signal.
+	ProcessConflictNotRunning ProcessConflictCode = "not_running"
 )
 
 // ProcessConflictError is the body of a start request rejected
@@ -1431,6 +1461,56 @@ func (c *agentConn) SignalProcess(ctx context.Context, id string, signal string)
 		return xerrors.Errorf("decode response body: %w", err)
 	}
 	return nil
+}
+
+// SignalProcessByIdempotencyKey sends a signal to the process started
+// under an idempotency key, so a caller that never received the start
+// response can still act on it. The key travels in the body, so no
+// key value needs URL escaping.
+//
+// A 404 carrying ProcessKeyNotFoundCode means no process is held under
+// the key. Any other 404 comes from an agent without this route and is
+// reported as ErrProcessKeySignalUnsupported, because such an answer
+// says nothing about the process.
+func (c *agentConn) SignalProcessByIdempotencyKey(ctx context.Context, idempotencyKey string, signal string) error {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
+	res, err := c.apiRequest(ctx, http.MethodPost, "/api/v0/processes/signal-by-idempotency-key", SignalProcessByIdempotencyKeyRequest{
+		IdempotencyKey: idempotencyKey,
+		Signal:         signal,
+	})
+	if err != nil {
+		return xerrors.Errorf("do request: %w", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode == http.StatusNotFound {
+		return readProcessKeyNotFoundError(res)
+	}
+	if res.StatusCode == http.StatusConflict {
+		return readProcessConflictError(res)
+	}
+	if res.StatusCode != http.StatusOK {
+		return codersdk.ReadBodyAsError(res)
+	}
+	return nil
+}
+
+// readProcessKeyNotFoundError distinguishes "no process under this
+// key" from an agent that does not implement the route.
+func readProcessKeyNotFoundError(res *http.Response) error {
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return xerrors.Errorf("read response body: %w", err)
+	}
+	var notFound ProcessKeyNotFoundError
+	if err := json.Unmarshal(body, &notFound); err == nil && notFound.Code == ProcessKeyNotFoundCode {
+		return &notFound
+	}
+	return ErrProcessKeySignalUnsupported
+}
+
+func (e *ProcessKeyNotFoundError) Error() string {
+	return e.Message
 }
 
 // EditFiles performs search and replace edits on one or more files.

--- a/codersdk/workspacesdk/agentconn_internal_test.go
+++ b/codersdk/workspacesdk/agentconn_internal_test.go
@@ -58,6 +58,41 @@ func TestReadProcessConflictError(t *testing.T) {
 	})
 }
 
+func TestReadProcessKeyNotFoundError(t *testing.T) {
+	t.Parallel()
+
+	response := func(body string) *http.Response {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}
+	}
+
+	t.Run("coded answer means no process", func(t *testing.T) {
+		t.Parallel()
+
+		res := response(`{"code":"process_key_not_found","message":"No process."}`)
+		defer res.Body.Close()
+		err := readProcessKeyNotFoundError(res)
+		var notFound *ProcessKeyNotFoundError
+		require.ErrorAs(t, err, &notFound)
+		require.NotErrorIs(t, err, ErrProcessKeySignalUnsupported)
+	})
+
+	t.Run("uncoded answer means the route is unsupported", func(t *testing.T) {
+		t.Parallel()
+
+		// An agent without the route answers a plain 404, which proves
+		// nothing about the process, so it must not read as gone.
+		res := response(`{"message":"Not Found."}`)
+		defer res.Body.Close()
+		err := readProcessKeyNotFoundError(res)
+		require.ErrorIs(t, err, ErrProcessKeySignalUnsupported)
+		var notFound *ProcessKeyNotFoundError
+		require.NotErrorAs(t, err, &notFound)
+	})
+}
+
 func TestAgentAPIPath(t *testing.T) {
 	t.Parallel()
 

--- a/codersdk/workspacesdk/agentconnmock/agentconnmock.go
+++ b/codersdk/workspacesdk/agentconnmock/agentconnmock.go
@@ -570,6 +570,20 @@ func (mr *MockAgentConnMockRecorder) SignalProcess(ctx, id, signal any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignalProcess", reflect.TypeOf((*MockAgentConn)(nil).SignalProcess), ctx, id, signal)
 }
 
+// SignalProcessByIdempotencyKey mocks base method.
+func (m *MockAgentConn) SignalProcessByIdempotencyKey(ctx context.Context, idempotencyKey, signal string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SignalProcessByIdempotencyKey", ctx, idempotencyKey, signal)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SignalProcessByIdempotencyKey indicates an expected call of SignalProcessByIdempotencyKey.
+func (mr *MockAgentConnMockRecorder) SignalProcessByIdempotencyKey(ctx, idempotencyKey, signal any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignalProcessByIdempotencyKey", reflect.TypeOf((*MockAgentConn)(nil).SignalProcessByIdempotencyKey), ctx, idempotencyKey, signal)
+}
+
 // Speedtest mocks base method.
 func (m *MockAgentConn) Speedtest(ctx context.Context, direction speedtest.Direction, duration time.Duration) ([]speedtest.Result, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Stack context

Now based on #27370, not #27371. #27371 is parked as a draft while its timeout policy is reworked; this PR never depended on it beyond three prose mentions of "attempt watchdog", which are now "attempt timeout".

Spans `agent/`, `codersdk/`, and `coderd/x/chatd/`, so the title is scopeless.

## What

A user action that replaces the current turn stops unresolved foreground work; an internal retry or worker move leaves it running so the next attempt can recover it.

The runner cancels the active task with an explicit cause (`chattool.ErrUserInterrupt`) when a user interrupt, an edit, or a message sent with `busy_behavior=interrupt` supersedes it. A foreground `execute` call unwinding on that cause stops its process on a detached, bounded context. Runner shutdown, rebalancing, and attempt timeouts cancel without that cause, so their processes keep running and a retried attempt re-attaches through its idempotency key instead of running the command twice. Background processes are deliberately spared; they are addressable through their handle and the process list.

## Cancelling by identity, not by process ID

Requiring the process ID from `StartProcess` leaves nothing to cancel when the agent starts the process but the response does not reach chatd.

The stop is armed before the start request rather than after it. When the response did arrive, the process ID is used. When it did not, chatd still knows the idempotency key, and a chat-scoped route resolves that key to the process it started:

```
POST /api/v0/processes/signal-by-idempotency-key
{"idempotency_key": "...", "signal": "kill"}
```

The key travels in the body rather than the path. It carries a provider-supplied tool call ID, and chi's path handling makes an opaque path segment fiddly: chi routes on `RawPath` when it is set and on `Path` otherwise, so `chi.URLParam` returns an escaped value in the first case and a decoded one in the second. A key containing a literal `%` lands in the second case, where `url.PathUnescape` then fails with `invalid URL escape`. Keeping the key out of the path removes that class of bug rather than handling it. `TestSignalProcessByIdempotencyKey/AcceptsKeysNeedingURLEscaping` covers `/`, `%`, a space, `?`, `#`, and `..`.

The stored reservation does the translation, so process details stay behind the operation that owns them. Reservations are chat-scoped after #27369, so another chat's key is simply absent here rather than needing a separate ownership check.

`SignalProcessByIdempotencyKey` on `AgentConn` is the client side. Agents that predate the route answer a plain 404, which the SDK reports as `ErrProcessKeySignalUnsupported` rather than "not found", because such an answer says nothing about the process.

## Fix: a pending reservation no longer swallows the interrupt

Review asked what distinguishes a pending reservation from a missing one on this path. Traced end to end, the old code lost the kill:

1. the registry reported `false` for both an absent key and a pending one;
2. the manager mapped both to `errProcessNotFound`;
3. the route answered a coded 404;
4. chatd's `isAlreadyGoneError` read that code as "the process is gone" and returned without logging.

The interrupt was dropped silently and the command kept running, which is what this PR exists to prevent. The window is not exotic: the reservation is inserted before the spawn, and the by-key path is used precisely when the start response was lost, so a pending reservation is the expected state there.

The registry now exposes `Await`, which waits out a pending reservation inside the caller's context and distinguishes three outcomes:

| Outcome | Answer |
|---|---|
| Published | Signal the process. |
| Not reserved, or released while waiting | 404 `process_key_not_found`. A genuine not-found. |
| Still pending at the deadline | 409 `start_pending`. chatd logs it instead of treating the command as gone. |

Red-green: removing the wait makes `TestSignalByKeyWaitsForPendingStart` and `TestSignalByKeyReportsPendingAtDeadline` fail, and restoring it makes them pass. `TestExecuteToolInterruptKill/PendingStartIsNotTreatedAsGone` covers the chatd side.

## Other review changes in this revision

- `interruptStopper` is now `userInterruptStopper`: the old name read as stopping interrupts.
- The by-key symbols dropped "token" throughout, matching #27369's `IdempotencyKey` rename.
- `decodeSignalRequest` became `validateSignal`, since the two routes decode different bodies.
- Added comments were shortened and the "keep running behind a result nobody reads" line in `ARCHITECTURE.md` was rewritten.

## Limitations

The stop stays best-effort. An unreachable agent, or a worker crash before unwinding, leaves the process running; it remains visible and killable through the process list. No state needs to survive the workspace agent's lifetime.

> This PR was written and revised by Mux, an AI coding agent, operating on Mike's behalf.
