### PR TITLE
feat(site/src/pages/AgentsPage): wire chat search box to full-text search

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchDialog.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchDialog.stories.tsx
@@ -195,7 +195,7 @@ export const Results: Story = {
 		await waitFor(() => {
 			expect(API.experimental.getChats).toHaveBeenCalledWith({
 				limit: CHAT_SEARCH_LIMIT,
-				q: 'title:"Fix"',
+				q: 'search:"Fix"',
 			});
 		});
 		await expect(
@@ -263,7 +263,7 @@ export const OverflowResults: Story = {
 		await waitFor(() => {
 			expect(API.experimental.getChats).toHaveBeenCalledWith({
 				limit: CHAT_SEARCH_LIMIT,
-				q: 'title:"review"',
+				q: 'search:"review"',
 			});
 		});
 
@@ -299,7 +299,7 @@ export const CappedResults: Story = {
 		await waitFor(() => {
 			expect(API.experimental.getChats).toHaveBeenCalledWith({
 				limit: CHAT_SEARCH_LIMIT,
-				q: 'title:"Fix"',
+				q: 'search:"Fix"',
 			});
 		});
 		await expect(
@@ -367,7 +367,7 @@ export const NoResults: Story = {
 			"none",
 		);
 		await expect(
-			await body.findByText("No matching chats"),
+			await body.findByText("No matching chats", { exact: false }),
 		).toBeInTheDocument();
 	},
 };
@@ -633,7 +633,7 @@ export const CombinedFilterAndText: Story = {
 		await waitFor(() => {
 			expect(API.experimental.getChats).toHaveBeenCalledWith({
 				limit: CHAT_SEARCH_LIMIT,
-				q: 'has_unread:true title:"Fix"',
+				q: 'has_unread:true search:"Fix"',
 			});
 		});
 	},

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchDialog.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchDialog.tsx
@@ -132,7 +132,8 @@ type ChatSearchDialogContentProps = Omit<
 };
 
 // Build a raw query string from structured filters + freeform text, then
-// normalize it through the existing parser that the backend expects.
+// normalize it through the existing parser that the backend expects. Freeform
+// text becomes the backend's FTS `search:` filter.
 const buildQuery = (
 	filters: readonly SearchFilter[],
 	freeText: string,
@@ -193,7 +194,7 @@ const ChatSearchDialogContent: FC<ChatSearchDialogContentProps> = ({
 		SEARCH_DEBOUNCE_MS,
 	);
 	// When typing into an incomplete filter, only send the filter (not
-	// freeText as bare title search).
+	// freeText as bare full-text search).
 	// When freeText is cleared (e.g. after committing a filter), zero
 	// queryFreeText immediately instead of waiting for the debounce to
 	// flush. Otherwise the stale debouncedFreeText leaks into the query.

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchResults.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchResults.tsx
@@ -195,8 +195,11 @@ const ChatSearchResultsList: FC<ChatSearchResultsListProps> = ({
 
 	if ((chats?.length ?? 0) === 0) {
 		return (
-			<div className="flex h-[300px] items-center justify-center">
-				<p className="text-sm text-content-secondary">No matching chats</p>
+			<div className="flex h-[300px] items-center justify-center px-6 text-center">
+				<p className="text-sm text-content-secondary">
+					No matching chats. Message content is indexed periodically, so very
+					recent messages may not be searchable yet.
+				</p>
 			</div>
 		);
 	}

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/searchQuery.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/searchQuery.test.ts
@@ -41,52 +41,74 @@ describe("normalizeChatSearchInput", () => {
 		);
 	});
 
-	it("converts bare search text into a title filter", () => {
-		expect(normalizeChatSearchInput("Fix")).toBe('title:"Fix"');
+	it("converts bare search text into a quoted FTS search filter", () => {
+		expect(normalizeChatSearchInput("Fix")).toBe('search:"Fix"');
 		expect(normalizeChatSearchInput("fix auth middleware")).toBe(
-			'title:"fix auth middleware"',
+			'search:"fix auth middleware"',
 		);
-		expect(normalizeChatSearchInput("fix:lint")).toBe('title:"fix:lint"');
+		expect(normalizeChatSearchInput("hello world")).toBe(
+			'search:"hello world"',
+		);
+		expect(normalizeChatSearchInput("fix:lint")).toBe('search:"fix:lint"');
 	});
 
-	it("combines key:value filters with a title fallback for bare text", () => {
+	it("combines key:value filters with an FTS search fallback for bare text", () => {
 		expect(normalizeChatSearchInput("has_unread:true fix auth")).toBe(
-			'has_unread:true title:"fix auth"',
+			'has_unread:true search:"fix auth"',
 		);
 		expect(normalizeChatSearchInput("archived:true fix:lint")).toBe(
-			'archived:true title:"fix:lint"',
+			'archived:true search:"fix:lint"',
 		);
 		expect(normalizeChatSearchInput("fix has_unread:true auth")).toBe(
-			'has_unread:true title:"fix auth"',
+			'has_unread:true search:"fix auth"',
 		);
 		expect(
 			normalizeChatSearchInput(
 				"diff_url:https://github.com/coder/coder/pull/26016 fix",
 			),
-		).toBe('diff_url:"https://github.com/coder/coder/pull/26016" title:"fix"');
+		).toBe('diff_url:"https://github.com/coder/coder/pull/26016" search:"fix"');
 		expect(
 			normalizeChatSearchInput('archived:true title:"chat title" fix'),
-		).toBe('archived:true title:"chat title fix"');
+		).toBe('archived:true search:"chat title fix"');
 	});
 
-	it("combines duplicate title filters into one title filter", () => {
+	it("combines duplicate title filters into one search filter", () => {
 		expect(normalizeChatSearchInput("title:Fix title:Race")).toBe(
-			'title:"Fix Race"',
+			'search:"Fix Race"',
 		);
 		expect(
 			normalizeChatSearchInput('has_unread:true title:"chat title" title:Race'),
-		).toBe('has_unread:true title:"chat title Race"');
+		).toBe('has_unread:true search:"chat title Race"');
 	});
 
-	it("strips quotes from bare text", () => {
+	it("preserves quoted websearch phrases in bare text", () => {
+		// A leading/trailing quote pair is passed through so websearch_to_tsquery
+		// can interpret it as a quoted phrase.
+		expect(normalizeChatSearchInput('"fix race condition"')).toBe(
+			'search:"fix race condition"',
+		);
 		expect(normalizeChatSearchInput('Fix "auth" middleware')).toBe(
-			'title:"Fix auth middleware"',
+			'search:Fix "auth" middleware',
 		);
 	});
 
-	it("treats a trailing-colon filter as bare title text", () => {
-		// `title:` is not a well-formed key:value pair, so it should be searched
-		// for as a literal title substring.
-		expect(normalizeChatSearchInput("title:")).toBe('title:"title:"');
+	it("preserves websearch operators alongside a quoted phrase", () => {
+		expect(normalizeChatSearchInput('"fix race" OR deadlock -timeout')).toBe(
+			'search:"fix race" OR deadlock -timeout',
+		);
+	});
+
+	it("strips stray quotes from bare text before wrapping", () => {
+		// Unbalanced quotes would break the backend's query parser, which has no
+		// escape handling for embedded quotes.
+		expect(normalizeChatSearchInput("it's a \"test")).toBe(
+			'search:"it\'s a test"',
+		);
+	});
+
+	it("treats a trailing-colon filter as bare search text", () => {
+		// `title:` is not a well-formed key:value pair, so it is wrapped as an
+		// FTS phrase.
+		expect(normalizeChatSearchInput("title:")).toBe('search:"title:"');
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/searchQuery.ts
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/searchQuery.ts
@@ -1,7 +1,8 @@
 // The backend's search-query parser toggles its quoted-state on every `"` and
 // has no backslash-escape handling, so escaping quotes here would produce a
-// query the backend cannot parse. Stripping quotes from bare text keeps the
-// resulting `title:"..."` filter well-formed for the backend.
+// query the backend cannot parse. Stripping quotes from structured filter
+// values keeps the resulting `key:"..."` token well-formed for the backend.
+// Bare free text is not sanitized this way so that FTS quoted phrases survive.
 const sanitizeChatSearchValue = (value: string): string => {
 	return value.replaceAll('"', "");
 };
@@ -10,9 +11,32 @@ const addDefaultURLScheme = (value: string): string => {
 	return /^[a-z][a-z\d+\-.]*:\/\//i.test(value) ? value : `https://${value}`;
 };
 
+// Bare free text may contain websearch operators (quoted phrases, OR,
+// -negation). Detect a leading/trailing quote pair so those pass through
+// unmodified; everything else gets wrapped in a single quoted phrase.
+const hasWebSearchQuotes = (value: string): boolean => {
+	const first = value.indexOf('"');
+	const last = value.lastIndexOf('"');
+	return (
+		first !== -1 && last > first && /\S/.test(value.slice(first + 1, last))
+	);
+};
+
+// Wrap bare free text in a quoted phrase so multi-word input reaches the
+// backend's FTS filter as a single token. Quotes are stripped first because
+// the backend's query parser has no escape handling for embedded quotes.
+const toSearchPhrase = (terms: string): string => {
+	const joined = terms.trim();
+	if (hasWebSearchQuotes(joined)) {
+		return joined;
+	}
+	return `"${sanitizeChatSearchValue(joined)}"`;
+};
+
 // Filter keys that may pass through to the backend unchanged. `title` is not
 // listed here because bare text and `title:` filters are merged into a single
-// title filter; see the title-handling branch in normalizeChatSearchInput.
+// FTS `search:` filter; see the search-handling branch in
+// normalizeChatSearchInput.
 const passthroughChatSearchFilterKeys = new Set([
 	"archived",
 	"diff_url",
@@ -107,7 +131,7 @@ const normalizePassthroughChatSearchFilter = ({
 /**
  * Normalizes raw search input into a query string the chat search API accepts.
  *
- * Bare text and `title:` filters are merged into a single `title:"..."`
+ * Bare text and `title:` filters are merged into a single `search:` FTS
  * filter (the backend rejects a parameter that appears more than once).
  * Recognized `key:value` filters are normalized for backend syntax.
  */
@@ -122,26 +146,26 @@ export const normalizeChatSearchInput = (
 	const tokens = splitSearchInput(trimmedInput);
 	const passthroughFilters: string[] = [];
 	const normalizedTokens: string[] = [];
-	const titleTerms: string[] = [];
-	let hasBareTitleText = false;
+	const searchTerms: string[] = [];
+	let hasBareSearchText = false;
 
 	for (const token of tokens) {
 		const keyValuePair = getKeyValuePair(token);
 		if (!keyValuePair) {
-			titleTerms.push(token);
-			hasBareTitleText = true;
+			searchTerms.push(token);
+			hasBareSearchText = true;
 			continue;
 		}
 
 		if (keyValuePair.key === "title") {
 			normalizedTokens.push(token);
-			titleTerms.push(keyValuePair.value);
+			searchTerms.push(keyValuePair.value);
 			continue;
 		}
 
 		if (!passthroughChatSearchFilterKeys.has(keyValuePair.key)) {
-			titleTerms.push(token);
-			hasBareTitleText = true;
+			searchTerms.push(token);
+			hasBareSearchText = true;
 			continue;
 		}
 
@@ -150,18 +174,20 @@ export const normalizeChatSearchInput = (
 		normalizedTokens.push(normalizedFilter);
 	}
 
-	// Multiple title values must be merged into a single title filter because
+	// Multiple search values must be merged into a single search filter because
 	// the backend's query parser rejects the same key appearing more than once.
-	if (titleTerms.length > 1) {
-		hasBareTitleText = true;
+	if (searchTerms.length > 1) {
+		hasBareSearchText = true;
 	}
 
-	if (!hasBareTitleText) {
+	if (!hasBareSearchText) {
 		return normalizedTokens.join(" ");
 	}
 
+	// Free text defaults to the backend's full-text search filter, which
+	// matches chat titles, PR titles, and message bodies.
 	return [
 		...passthroughFilters,
-		`title:"${sanitizeChatSearchValue(titleTerms.join(" "))}"`,
+		`search:${toSearchPhrase(searchTerms.join(" "))}`,
 	].join(" ");
 };


### PR DESCRIPTION
Wires the Coder Agents chat search box up to the backend full-text search filter. Bare free text previously produced a `title:"..."` substring filter; it now produces a `search:` filter, so free text matches chat titles, PR titles, PR numbers, and message bodies via the FTS index added in #27126.

Bare free text is wrapped in a quoted phrase by default because the backend query tokenizer requires the `search` value to be a single token (multi-word input like `hello world` otherwise fails). Websearch operators (quoted phrases, `OR`, `-negation) still pass through when the user supplies a properly quoted phrase. The empty state notes that message content is indexed periodically, so very recent messages may not be searchable yet.

Refs CODAGT-726
Depends on #27126

> Implemented by Coder Agents, reviewed and tested by a human.

<details>
<summary>Implementation notes</summary>

- Core change is `normalizeChatSearchInput` in `site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/searchQuery.ts`: bare text and typed `title:` terms are merged into a single `search:` FTS filter instead of a `title:` ILIKE filter.
- Added `toSearchPhrase`/`hasWebSearchQuotes` helpers: free text with a leading/trailing quote pair (websearch phrase syntax) passes through unchanged; everything else is wrapped in `search:"..."` with stray quotes stripped (the backend parser has no escape handling for embedded quotes).
- Structured filter pills (`has_unread`, `archived`, `pr_status`, `diff_url`) are unchanged and remain compatible with `search:`.
- `ChatSearchResults.tsx` empty state updated to mention the periodic indexing lag (dbpurge sweep populates `search_tsv`).
- Updated `searchQuery.test.ts` (10 unit tests) and `ChatSearchDialog.stories.tsx` (20 interaction stories) for the new emitted syntax; error-state stories now use `pr_status:badvalue` since `title:` no longer produces an invalid query.

</details>
