### PR TITLE
fix(site): remember reasoning effort per model on new chat

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -1359,9 +1359,10 @@ export const RemembersReasoningEffortAcrossModels: Story = {
 		// effort even without touching the slider.
 		await user.click(canvas.getByRole("button", { name: "Edit message" }));
 
-		// Changing the slider during a history edit is scoped to that
-		// edit and does not overwrite the remembered default. Close the
-		// popover with the trigger; Escape would cancel the edit.
+		// Changing the slider during a history edit does not overwrite
+		// the persisted per-model default; it does update the shared
+		// session value. Close the popover with the trigger; Escape
+		// would cancel the edit.
 		await user.click(canvas.getByRole("combobox", { name: "Claude Sonnet 4" }));
 		const editSlider = await body.findByRole("slider");
 		editSlider.focus();

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -1283,6 +1283,7 @@ export const RemembersReasoningEffortAcrossModels: Story = {
 					...baseChatFields,
 					title: "Cross-model effort restore",
 					status: "waiting",
+					last_reasoning_effort: "high",
 				},
 				{
 					messages: [
@@ -1335,8 +1336,15 @@ export const RemembersReasoningEffortAcrossModels: Story = {
 
 		expect(await canvas.findByText("Cross-model effort restore")).toBeVisible();
 
-		// CRF-1: switching models restores the persisted effort.
+		// The chat's own effort shows for the chat's model.
 		await user.click(canvas.getByRole("combobox", { name: "GPT-4o" }));
+		expect(await body.findByRole("slider")).toHaveAttribute(
+			"aria-valuenow",
+			"2",
+		);
+
+		// Switching models restores that model's persisted effort rather
+		// than leaking the chat's effort.
 		await user.click(
 			await body.findByRole("option", { name: /Claude Sonnet 4/i }),
 		);
@@ -1347,9 +1355,21 @@ export const RemembersReasoningEffortAcrossModels: Story = {
 		);
 		await user.keyboard("{Escape}");
 
-		// CRF-2: editing after switching models sends the new model's
-		// effective effort even without touching the slider.
+		// Editing after switching models sends the new model's effective
+		// effort even without touching the slider.
 		await user.click(canvas.getByRole("button", { name: "Edit message" }));
+
+		// Changing the slider during a history edit is scoped to that
+		// edit and does not overwrite the remembered default. Close the
+		// popover with the trigger; Escape would cancel the edit.
+		await user.click(canvas.getByRole("combobox", { name: "Claude Sonnet 4" }));
+		const editSlider = await body.findByRole("slider");
+		editSlider.focus();
+		await user.keyboard("{ArrowLeft}");
+		await waitFor(() => {
+			expect(editSlider).toHaveAttribute("aria-valuenow", "0");
+		});
+		await user.click(canvas.getByRole("combobox", { name: "Claude Sonnet 4" }));
 		await user.click(canvas.getByRole("button", { name: "Save Edit" }));
 		await waitFor(() => {
 			expect(API.experimental.editChatMessage).toHaveBeenCalledTimes(1);
@@ -1359,9 +1379,27 @@ export const RemembersReasoningEffortAcrossModels: Story = {
 			1,
 			expect.objectContaining({
 				model_config_id: SECOND_MODEL_CONFIG_ID,
-				reasoning_effort: "medium",
+				reasoning_effort: "low",
 			}),
 		);
+		expect(getReasoningEffortForModel(SECOND_MODEL_CONFIG_ID)).toBe("medium");
+
+		// Outside an edit, changing the slider persists the new default.
+		// Wait for edit mode to exit first so the save is not gated.
+		await waitFor(() => {
+			expect(
+				canvas.getByRole("textbox", { name: "Chat message" }),
+			).toBeEnabled();
+		});
+		await user.click(canvas.getByRole("combobox", { name: "Claude Sonnet 4" }));
+		const slider = await body.findByRole("slider");
+		slider.focus();
+		await user.keyboard("{ArrowRight}");
+		await user.keyboard("{ArrowLeft}");
+		await waitFor(() => {
+			expect(getReasoningEffortForModel(SECOND_MODEL_CONFIG_ID)).toBe("low");
+		});
+		await user.keyboard("{Escape}");
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -1355,8 +1355,8 @@ export const RemembersReasoningEffortAcrossModels: Story = {
 		);
 		await user.keyboard("{Escape}");
 
-		// Editing after switching models sends the new model's effective
-		// effort even without touching the slider.
+		// Editing after switching models, then moving the slider, scopes
+		// the change to the edit.
 		await user.click(canvas.getByRole("button", { name: "Edit message" }));
 
 		// Changing the slider during a history edit does not overwrite
@@ -1401,6 +1401,91 @@ export const RemembersReasoningEffortAcrossModels: Story = {
 			expect(getReasoningEffortForModel(SECOND_MODEL_CONFIG_ID)).toBe("low");
 		});
 		await user.keyboard("{Escape}");
+	},
+};
+
+export const EditWithModelSwitchSendsModelEffort: Story = {
+	parameters: {
+		queries: [
+			...buildQueries(
+				{
+					id: CHAT_ID,
+					...baseChatFields,
+					title: "Edit with model switch",
+					status: "waiting",
+				},
+				{
+					messages: [
+						{
+							...MockChatMessage,
+							id: 1,
+							chat_id: CHAT_ID,
+							role: "user",
+							model_config_id: MODEL_CONFIG_ID,
+							content: [{ type: "text", text: "Switch models and edit." }],
+						},
+					],
+					queued_messages: [],
+					has_more: false,
+				},
+				{ diffUrl: undefined },
+			),
+			{
+				key: chatModelConfigs().queryKey,
+				data: [
+					...mockModelConfigs,
+					{
+						...MockChatModelConfig,
+						id: SECOND_MODEL_CONFIG_ID,
+						model: "claude-sonnet-4",
+						display_name: "Claude Sonnet 4",
+						model_config: {
+							reasoning_effort: { default: "low", max: "medium" },
+						},
+						reasoning_efforts: ["low", "medium"],
+					},
+				],
+			},
+		],
+	},
+	beforeEach: () => {
+		localStorage.clear();
+		saveReasoningEffortForModel(SECOND_MODEL_CONFIG_ID, "medium");
+		spyOn(API.experimental, "editChatMessage").mockResolvedValue({
+			message: {
+				...MockChatMessage,
+				id: 1,
+			},
+		});
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(document.body);
+		const user = userEvent.setup();
+
+		expect(await canvas.findByText("Edit with model switch")).toBeVisible();
+
+		// Switch models without touching the effort slider.
+		await user.click(canvas.getByRole("combobox", { name: "GPT-4o" }));
+		await user.click(
+			await body.findByRole("option", { name: /Claude Sonnet 4/i }),
+		);
+
+		// Saving the edit sends the new model's effective effort via the
+		// model-switch branch alone; the slider was never touched.
+		await user.click(canvas.getByRole("button", { name: "Edit message" }));
+		await user.click(canvas.getByRole("button", { name: "Save Edit" }));
+		await waitFor(() => {
+			expect(API.experimental.editChatMessage).toHaveBeenCalled();
+		});
+		expect(API.experimental.editChatMessage).toHaveBeenCalledWith(
+			CHAT_ID,
+			1,
+			expect.objectContaining({
+				model_config_id: SECOND_MODEL_CONFIG_ID,
+				reasoning_effort: "medium",
+			}),
+		);
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -41,6 +41,10 @@ import {
 } from "#/testHelpers/storybook";
 import AgentChatPage, { RIGHT_PANEL_OPEN_KEY } from "./AgentChatPage";
 import type { AgentsPageOutletContext } from "./AgentsPageLayout";
+import {
+	getReasoningEffortForModel,
+	saveReasoningEffortForModel,
+} from "./utils/reasoningEffort";
 
 // ---------------------------------------------------------------------------
 // Layout wrapper: provides outlet context for the child route.
@@ -84,6 +88,7 @@ const AgentChatPageLayout: FC = () => {
 // ---------------------------------------------------------------------------
 const CHAT_ID = "chat-1";
 const MODEL_CONFIG_ID = "model-config-1";
+const SECOND_MODEL_CONFIG_ID = "model-config-2";
 
 const mockWorkspace: TypesGen.Workspace = {
 	...MockWorkspace,
@@ -1265,6 +1270,97 @@ export const WithMessageHistory: Story = {
 			CHAT_ID,
 			5,
 			expect.objectContaining({ reasoning_effort: "medium" }),
+		);
+	},
+};
+
+export const RemembersReasoningEffortAcrossModels: Story = {
+	parameters: {
+		queries: [
+			...buildQueries(
+				{
+					id: CHAT_ID,
+					...baseChatFields,
+					title: "Cross-model effort restore",
+					status: "waiting",
+				},
+				{
+					messages: [
+						{
+							...MockChatMessage,
+							id: 1,
+							chat_id: CHAT_ID,
+							role: "user",
+							model_config_id: MODEL_CONFIG_ID,
+							content: [{ type: "text", text: "Restore effort per model." }],
+						},
+					],
+					queued_messages: [],
+					has_more: false,
+				},
+				{ diffUrl: undefined },
+			),
+			{
+				key: chatModelConfigs().queryKey,
+				data: [
+					...mockModelConfigs,
+					{
+						...MockChatModelConfig,
+						id: SECOND_MODEL_CONFIG_ID,
+						model: "claude-sonnet-4",
+						display_name: "Claude Sonnet 4",
+						model_config: {
+							reasoning_effort: { default: "low", max: "medium" },
+						},
+						reasoning_efforts: ["low", "medium"],
+					},
+				],
+			},
+		],
+	},
+	beforeEach: () => {
+		localStorage.clear();
+		saveReasoningEffortForModel(SECOND_MODEL_CONFIG_ID, "medium");
+		spyOn(API.experimental, "editChatMessage").mockResolvedValue({
+			message: {
+				...MockChatMessage,
+				id: 1,
+			},
+		});
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(document.body);
+		const user = userEvent.setup();
+
+		expect(await canvas.findByText("Cross-model effort restore")).toBeVisible();
+
+		// CRF-1: switching models restores the persisted effort.
+		await user.click(canvas.getByRole("combobox", { name: "GPT-4o" }));
+		await user.click(
+			await body.findByRole("option", { name: /Claude Sonnet 4/i }),
+		);
+		await user.click(canvas.getByRole("combobox", { name: "Claude Sonnet 4" }));
+		expect(await body.findByRole("slider")).toHaveAttribute(
+			"aria-valuenow",
+			"1",
+		);
+		await user.keyboard("{Escape}");
+
+		// CRF-2: editing after switching models sends the new model's
+		// effective effort even without touching the slider.
+		await user.click(canvas.getByRole("button", { name: "Edit message" }));
+		await user.click(canvas.getByRole("button", { name: "Save Edit" }));
+		await waitFor(() => {
+			expect(API.experimental.editChatMessage).toHaveBeenCalledTimes(1);
+		});
+		expect(API.experimental.editChatMessage).toHaveBeenCalledWith(
+			CHAT_ID,
+			1,
+			expect.objectContaining({
+				model_config_id: SECOND_MODEL_CONFIG_ID,
+				reasoning_effort: "medium",
+			}),
 		);
 	},
 };

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -106,7 +106,11 @@ import {
 	resolveModelSelector,
 } from "./utils/modelOptions";
 import { parsePullRequestUrl } from "./utils/pullRequest";
-import { pickReasoningEffort } from "./utils/reasoningEffort";
+import {
+	getReasoningEffortForModel,
+	pickReasoningEffort,
+	saveReasoningEffortForModel,
+} from "./utils/reasoningEffort";
 import {
 	COMPACT_SLASH_COMMAND,
 	chatSlashCommandTriggerText,
@@ -741,7 +745,9 @@ const AgentChatPage: FC = () => {
 	const { organizations, experiments } = useDashboard();
 	const organizationName = getDefaultOrganizationName(organizations);
 	const [selectedModel, setSelectedModel] = useState("");
-	const [selectedReasoningEffort, setSelectedReasoningEffort] = useState("");
+	const [selectedReasoningEfforts, setSelectedReasoningEfforts] = useState<
+		Record<string, string>
+	>({});
 	const isEditReasoningEffortDirtyRef = useRef(false);
 	const scrollToBottomRef = useRef<(() => void) | null>(null);
 	const chatInputRef = useRef<ChatMessageInputRef | null>(null);
@@ -1158,6 +1164,10 @@ const AgentChatPage: FC = () => {
 	// Compute an effective selected model by validating the user's
 	// explicit choice against the current model options, falling
 	// back to the chat's last model or the first available option.
+	const resolvedChatModel = resolveModelOptionId(
+		chatLastModelConfigID,
+		modelOptions,
+	);
 	const effectiveSelectedModel = (() => {
 		const resolvedSelectedModel = resolveModelOptionId(
 			selectedModel,
@@ -1167,10 +1177,6 @@ const AgentChatPage: FC = () => {
 			return resolvedSelectedModel;
 		}
 
-		const resolvedChatModel = resolveModelOptionId(
-			chatLastModelConfigID,
-			modelOptions,
-		);
 		if (resolvedChatModel) {
 			return resolvedChatModel;
 		}
@@ -1183,7 +1189,10 @@ const AgentChatPage: FC = () => {
 	);
 	const effectiveReasoningEffort = effectiveModelOption
 		? pickReasoningEffort(
-				selectedReasoningEffort || chatRecord?.last_reasoning_effort,
+				selectedReasoningEfforts[effectiveSelectedModel] ??
+					(effectiveSelectedModel === resolvedChatModel
+						? chatRecord?.last_reasoning_effort
+						: getReasoningEffortForModel(effectiveSelectedModel)),
 				effectiveModelOption.reasoningEfforts ?? [],
 				effectiveModelOption.reasoningEffortDefault,
 			)
@@ -1566,9 +1575,10 @@ const AgentChatPage: FC = () => {
 			const request: TypesGen.EditChatMessageRequest = {
 				content,
 				model_config_id: editSelectedModelConfigID,
-				reasoning_effort: isEditReasoningEffortDirtyRef.current
-					? effectiveReasoningEffort
-					: undefined,
+				reasoning_effort:
+					isEditReasoningEffortDirtyRef.current || editSelectedModelConfigID
+						? effectiveReasoningEffort
+						: undefined,
 			};
 			const optimisticMessage = originalEditedMessage
 				? buildOptimisticEditedMessage({
@@ -1765,7 +1775,14 @@ const AgentChatPage: FC = () => {
 			modelSelectorHelp={modelSelectorHelp}
 			reasoningEffort={effectiveReasoningEffort}
 			onReasoningEffortChange={(value) => {
-				setSelectedReasoningEffort(value);
+				if (!effectiveSelectedModel) {
+					return;
+				}
+				setSelectedReasoningEfforts((current) => ({
+					...current,
+					[effectiveSelectedModel]: value,
+				}));
+				saveReasoningEffortForModel(effectiveSelectedModel, value);
 				if (editing.editingMessageId !== null) {
 					isEditReasoningEffortDirtyRef.current = true;
 				}

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -1161,13 +1161,13 @@ const AgentChatPage: FC = () => {
 	);
 	const prNumber =
 		chatQuery.data?.diff_status?.pr_number ?? (parsedPrNumber || undefined);
-	// Compute an effective selected model by validating the user's
-	// explicit choice against the current model options, falling
-	// back to the chat's last model or the first available option.
 	const resolvedChatModel = resolveModelOptionId(
 		chatLastModelConfigID,
 		modelOptions,
 	);
+	// Compute an effective selected model by validating the user's
+	// explicit choice against the current model options, falling
+	// back to the chat's last model or the first available option.
 	const effectiveSelectedModel = (() => {
 		const resolvedSelectedModel = resolveModelOptionId(
 			selectedModel,
@@ -1786,8 +1786,9 @@ const AgentChatPage: FC = () => {
 					...current,
 					[effectiveSelectedModel]: value,
 				}));
-				// Editing a historical message scopes the effort to that
-				// edit; do not make it the remembered default.
+				// Editing a historical message does not overwrite the
+				// persisted default; the session map still tracks the
+				// latest explicit choice so the slider stays responsive.
 				if (editing.editingMessageId === null) {
 					saveReasoningEffortForModel(effectiveSelectedModel, value);
 				} else {

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -1190,7 +1190,9 @@ const AgentChatPage: FC = () => {
 	const effectiveReasoningEffort = effectiveModelOption
 		? pickReasoningEffort(
 				selectedReasoningEfforts[effectiveSelectedModel] ??
-					chatRecord?.last_reasoning_effort ??
+					(effectiveSelectedModel === resolvedChatModel
+						? chatRecord?.last_reasoning_effort
+						: undefined) ??
 					getReasoningEffortForModel(effectiveSelectedModel),
 				effectiveModelOption.reasoningEfforts ?? [],
 				effectiveModelOption.reasoningEffortDefault,

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -1572,10 +1572,8 @@ const AgentChatPage: FC = () => {
 				pickerModelConfigID !== originalModelConfigID
 					? pickerModelConfigID
 					: undefined;
-			// Omit both so the backend preserves the original model and
-			// effort; send the effective effort when the user changed it or
-			// the model changed, so the old model's effort is not carried
-			// onto a different model.
+			// Omit both so the backend preserves the originals; send the
+			// effective effort when it or the model changed.
 			const request: TypesGen.EditChatMessageRequest = {
 				content,
 				model_config_id: editSelectedModelConfigID,
@@ -1786,9 +1784,8 @@ const AgentChatPage: FC = () => {
 					...current,
 					[effectiveSelectedModel]: value,
 				}));
-				// Editing a historical message does not overwrite the
-				// persisted default; the session map still tracks the
-				// latest explicit choice so the slider stays responsive.
+				// Edits do not overwrite the persisted default; the
+				// session map still tracks the latest choice.
 				if (editing.editingMessageId === null) {
 					saveReasoningEffortForModel(effectiveSelectedModel, value);
 				} else {

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -1190,9 +1190,8 @@ const AgentChatPage: FC = () => {
 	const effectiveReasoningEffort = effectiveModelOption
 		? pickReasoningEffort(
 				selectedReasoningEfforts[effectiveSelectedModel] ??
-					(effectiveSelectedModel === resolvedChatModel
-						? chatRecord?.last_reasoning_effort
-						: getReasoningEffortForModel(effectiveSelectedModel)),
+					chatRecord?.last_reasoning_effort ??
+					getReasoningEffortForModel(effectiveSelectedModel),
 				effectiveModelOption.reasoningEfforts ?? [],
 				effectiveModelOption.reasoningEffortDefault,
 			)
@@ -1571,7 +1570,10 @@ const AgentChatPage: FC = () => {
 				pickerModelConfigID !== originalModelConfigID
 					? pickerModelConfigID
 					: undefined;
-			// Omit so the backend preserves the original effort.
+			// Omit both so the backend preserves the original model and
+			// effort; send the effective effort when the user changed it or
+			// the model changed, so the old model's effort is not carried
+			// onto a different model.
 			const request: TypesGen.EditChatMessageRequest = {
 				content,
 				model_config_id: editSelectedModelConfigID,
@@ -1782,8 +1784,11 @@ const AgentChatPage: FC = () => {
 					...current,
 					[effectiveSelectedModel]: value,
 				}));
-				saveReasoningEffortForModel(effectiveSelectedModel, value);
-				if (editing.editingMessageId !== null) {
+				// Editing a historical message scopes the effort to that
+				// edit; do not make it the remembered default.
+				if (editing.editingMessageId === null) {
+					saveReasoningEffortForModel(effectiveSelectedModel, value);
+				} else {
 					isEditReasoningEffortDirtyRef.current = true;
 				}
 			}}

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -378,7 +378,7 @@ export const RemembersReasoningEffortByModel: Story = {
 	},
 };
 
-export const RootOverrideReasoningEffortTakesPrecedence: Story = {
+export const PersistedReasoningEffortOutranksRootOverride: Story = {
 	args: {
 		...defaultArgs,
 		onCreateChat: fn().mockResolvedValue(undefined),
@@ -393,6 +393,41 @@ export const RootOverrideReasoningEffortTakesPrecedence: Story = {
 	beforeEach: () => {
 		localStorage.clear();
 		saveReasoningEffortForModel(modelConfigID, "low");
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		const body = within(canvasElement.ownerDocument.body);
+
+		// The persisted per-model value wins over the root override.
+		await userEvent.click(canvas.getByRole("combobox", { name: "GPT-4o" }));
+		expect(await body.findByRole("slider")).toHaveAttribute(
+			"aria-valuenow",
+			"2",
+		);
+		await userEvent.keyboard("{Escape}");
+
+		await submitMessage(canvasElement, "create with persisted effort");
+		await waitFor(() => {
+			expect(args.onCreateChat).toHaveBeenCalled();
+		});
+		expect(getCreateOptions(args.onCreateChat).reasoningEffort).toBe("low");
+	},
+};
+
+export const RootOverrideReasoningEffortAppliesWithoutPersistedValue: Story = {
+	args: {
+		...defaultArgs,
+		onCreateChat: fn().mockResolvedValue(undefined),
+		modelOptions: [...effortModelOptions],
+		modelConfigs: defaultModelConfigs,
+		rootPersonalModelOverride: buildRootPersonalModelOverride({
+			mode: "model",
+			model_config_id: modelConfigID,
+			reasoning_effort: "high",
+		}),
+	},
+	beforeEach: () => {
+		localStorage.clear();
 	},
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -448,6 +448,49 @@ export const RootOverrideReasoningEffortAppliesWithoutPersistedValue: Story = {
 	},
 };
 
+export const StalePersistedEffortFallsThroughToRootOverride: Story = {
+	args: {
+		...defaultArgs,
+		onCreateChat: fn().mockResolvedValue(undefined),
+		modelOptions: [
+			{
+				...modelOptions[0],
+				reasoningEffortDefault: "low",
+				reasoningEfforts: ["low", "medium"],
+			},
+		],
+		modelConfigs: defaultModelConfigs,
+		rootPersonalModelOverride: buildRootPersonalModelOverride({
+			mode: "model",
+			model_config_id: modelConfigID,
+			reasoning_effort: "medium",
+		}),
+	},
+	beforeEach: () => {
+		localStorage.clear();
+		saveReasoningEffortForModel(modelConfigID, "max");
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		const body = within(canvasElement.ownerDocument.body);
+
+		// The stored "max" is no longer valid for this model, so the
+		// root override's "medium" applies instead of the default "low".
+		await userEvent.click(canvas.getByRole("combobox", { name: "GPT-4o" }));
+		expect(await body.findByRole("slider")).toHaveAttribute(
+			"aria-valuenow",
+			"1",
+		);
+		await userEvent.keyboard("{Escape}");
+
+		await submitMessage(canvasElement, "create with stale persisted effort");
+		await waitFor(() => {
+			expect(args.onCreateChat).toHaveBeenCalled();
+		});
+		expect(getCreateOptions(args.onCreateChat).reasoningEffort).toBe("medium");
+	},
+};
+
 export const SubmitsReasoningEffort: Story = {
 	args: {
 		...defaultArgs,

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -18,6 +18,10 @@ import {
 	MockWorkspace,
 } from "#/testHelpers/entities";
 import { withDashboardProvider } from "#/testHelpers/storybook";
+import {
+	getReasoningEffortForModel,
+	saveReasoningEffortForModel,
+} from "../utils/reasoningEffort";
 import { AgentCreateForm } from "./AgentCreateForm";
 
 // Query key used by permittedOrganizations() in the form.
@@ -329,6 +333,86 @@ const effortModelOptions = [
 	},
 ] as const;
 
+export const RemembersReasoningEffortByModel: Story = {
+	args: {
+		...defaultArgs,
+		modelOptions: [...effortModelOptions],
+	},
+	beforeEach: () => {
+		localStorage.clear();
+		saveReasoningEffortForModel(modelConfigID, "high");
+		saveReasoningEffortForModel(claudeModelConfigID, "medium");
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(canvasElement.ownerDocument.body);
+		const modelSelector = canvas.getByRole("combobox", { name: "GPT-4o" });
+
+		await userEvent.click(modelSelector);
+		expect(await body.findByRole("slider")).toHaveAttribute(
+			"aria-valuenow",
+			"4",
+		);
+		await userEvent.click(
+			await body.findByRole("option", { name: /Claude Sonnet 4/i }),
+		);
+
+		await userEvent.click(
+			canvas.getByRole("combobox", { name: "Claude Sonnet 4" }),
+		);
+		expect(await body.findByRole("slider")).toHaveAttribute(
+			"aria-valuenow",
+			"1",
+		);
+		await userEvent.click(await body.findByRole("option", { name: /GPT-4o/i }));
+
+		await userEvent.click(canvas.getByRole("combobox", { name: "GPT-4o" }));
+		const restoredSlider = await body.findByRole("slider");
+		expect(restoredSlider).toHaveAttribute("aria-valuenow", "4");
+		restoredSlider.focus();
+		await userEvent.keyboard("{ArrowRight}");
+		await waitFor(() => {
+			expect(getReasoningEffortForModel(modelConfigID)).toBe("xhigh");
+		});
+		await userEvent.keyboard("{Escape}");
+	},
+};
+
+export const RootOverrideReasoningEffortTakesPrecedence: Story = {
+	args: {
+		...defaultArgs,
+		onCreateChat: fn().mockResolvedValue(undefined),
+		modelOptions: [...effortModelOptions],
+		modelConfigs: defaultModelConfigs,
+		rootPersonalModelOverride: buildRootPersonalModelOverride({
+			mode: "model",
+			model_config_id: modelConfigID,
+			reasoning_effort: "high",
+		}),
+	},
+	beforeEach: () => {
+		localStorage.clear();
+		saveReasoningEffortForModel(modelConfigID, "low");
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		const body = within(canvasElement.ownerDocument.body);
+
+		await userEvent.click(canvas.getByRole("combobox", { name: "GPT-4o" }));
+		expect(await body.findByRole("slider")).toHaveAttribute(
+			"aria-valuenow",
+			"4",
+		);
+		await userEvent.keyboard("{Escape}");
+
+		await submitMessage(canvasElement, "create with root override effort");
+		await waitFor(() => {
+			expect(args.onCreateChat).toHaveBeenCalled();
+		});
+		expect(getCreateOptions(args.onCreateChat).reasoningEffort).toBe("high");
+	},
+};
+
 export const SubmitsReasoningEffort: Story = {
 	args: {
 		...defaultArgs,
@@ -346,8 +430,7 @@ export const SubmitsReasoningEffort: Story = {
 		expect(slider).toHaveAttribute("aria-valuenow", "3");
 
 		// Bump the effort to "high" with the keyboard, then close.
-		await userEvent.tab();
-		expect(slider).toHaveFocus();
+		slider.focus();
 		await userEvent.keyboard("{ArrowRight}");
 		await waitFor(() => {
 			expect(slider).toHaveAttribute("aria-valuenow", "4");

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -430,7 +430,13 @@ export const SubmitsReasoningEffort: Story = {
 		expect(slider).toHaveAttribute("aria-valuenow", "3");
 
 		// Bump the effort to "high" with the keyboard, then close.
-		slider.focus();
+		// The info button precedes the slider in tab order.
+		await userEvent.tab();
+		expect(
+			body.getByRole("button", { name: "About reasoning effort" }),
+		).toHaveFocus();
+		await userEvent.tab();
+		expect(slider).toHaveFocus();
 		await userEvent.keyboard("{ArrowRight}");
 		await waitFor(() => {
 			expect(slider).toHaveAttribute("aria-valuenow", "4");

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -250,6 +250,8 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	const selectedModelOption = modelOptions.find(
 		(option) => option.id === selectedModel,
 	);
+	// A root personal model override intentionally outranks the persisted
+	// per-model value while it supplies the selected model.
 	const rootOverrideReasoningEffort =
 		!hasValidUserSelectedModel && selectedModel === rootOverrideModelID
 			? rootPersonalModelOverride?.reasoning_effort
@@ -364,6 +366,9 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	};
 
 	const handleReasoningEffortChange = (value: string) => {
+		if (!selectedModel) {
+			return;
+		}
 		setSelectedReasoningEfforts((current) => ({
 			...current,
 			[selectedModel]: value,

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -252,14 +252,21 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	);
 	// The persisted per-model value outranks a root personal model
 	// override: the user's own most recent choice wins across sessions.
+	// A stored value that is no longer valid for the model is ignored so
+	// the override still applies instead of falling to the model default.
 	const rootOverrideReasoningEffort =
 		!hasValidUserSelectedModel && selectedModel === rootOverrideModelID
 			? rootPersonalModelOverride?.reasoning_effort
 			: undefined;
+	const persistedReasoningEffort = (() => {
+		const stored = getReasoningEffortForModel(selectedModel);
+		const efforts = selectedModelOption?.reasoningEfforts;
+		return stored && efforts?.includes(stored) ? stored : undefined;
+	})();
 	const effectiveReasoningEffort = selectedModelOption
 		? pickReasoningEffort(
 				selectedReasoningEfforts[selectedModel] ??
-					getReasoningEffortForModel(selectedModel) ??
+					persistedReasoningEffort ??
 					rootOverrideReasoningEffort,
 				selectedModelOption.reasoningEfforts ?? [],
 				selectedModelOption.reasoningEffortDefault,

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -250,8 +250,8 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	const selectedModelOption = modelOptions.find(
 		(option) => option.id === selectedModel,
 	);
-	// A root personal model override intentionally outranks the persisted
-	// per-model value while it supplies the selected model.
+	// The persisted per-model value outranks a root personal model
+	// override: the user's own most recent choice wins across sessions.
 	const rootOverrideReasoningEffort =
 		!hasValidUserSelectedModel && selectedModel === rootOverrideModelID
 			? rootPersonalModelOverride?.reasoning_effort
@@ -259,8 +259,8 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	const effectiveReasoningEffort = selectedModelOption
 		? pickReasoningEffort(
 				selectedReasoningEfforts[selectedModel] ??
-					rootOverrideReasoningEffort ??
-					getReasoningEffortForModel(selectedModel),
+					getReasoningEffortForModel(selectedModel) ??
+					rootOverrideReasoningEffort,
 				selectedModelOption.reasoningEfforts ?? [],
 				selectedModelOption.reasoningEffortDefault,
 			)

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -250,10 +250,8 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	const selectedModelOption = modelOptions.find(
 		(option) => option.id === selectedModel,
 	);
-	// The persisted per-model value outranks a root personal model
-	// override: the user's own most recent choice wins across sessions.
-	// A stored value that is no longer valid for the model is ignored so
-	// the override still applies instead of falling to the model default.
+	// Persisted per-model choice wins over a root override; a stale
+	// stored value is ignored so the override still applies.
 	const rootOverrideReasoningEffort =
 		!hasValidUserSelectedModel && selectedModel === rootOverrideModelID
 			? rootPersonalModelOverride?.reasoning_effort

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -20,7 +20,11 @@ import {
 	hasConfiguredModelsInCatalog,
 	hasUserFixableProviders,
 } from "../utils/modelOptions";
-import { pickReasoningEffort } from "../utils/reasoningEffort";
+import {
+	getReasoningEffortForModel,
+	pickReasoningEffort,
+	saveReasoningEffortForModel,
+} from "../utils/reasoningEffort";
 import {
 	formatUsageLimitMessage,
 	isChatUsageLimitExceededResponse,
@@ -240,13 +244,21 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		}
 		return selectedModel || undefined;
 	})();
-	const [selectedReasoningEffort, setSelectedReasoningEffort] = useState("");
+	const [selectedReasoningEfforts, setSelectedReasoningEfforts] = useState<
+		Record<string, string>
+	>({});
 	const selectedModelOption = modelOptions.find(
 		(option) => option.id === selectedModel,
 	);
+	const rootOverrideReasoningEffort =
+		!hasValidUserSelectedModel && selectedModel === rootOverrideModelID
+			? rootPersonalModelOverride?.reasoning_effort
+			: undefined;
 	const effectiveReasoningEffort = selectedModelOption
 		? pickReasoningEffort(
-				selectedReasoningEffort,
+				selectedReasoningEfforts[selectedModel] ??
+					rootOverrideReasoningEffort ??
+					getReasoningEffortForModel(selectedModel),
 				selectedModelOption.reasoningEfforts ?? [],
 				selectedModelOption.reasoningEffortDefault,
 			)
@@ -349,6 +361,14 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	const handleModelChange = (value: string) => {
 		setHasUserSelectedModel(true);
 		setUserSelectedModel(value);
+	};
+
+	const handleReasoningEffortChange = (value: string) => {
+		setSelectedReasoningEfforts((current) => ({
+			...current,
+			[selectedModel]: value,
+		}));
+		saveReasoningEffortForModel(selectedModel, value);
 	};
 
 	const isForbidden = !canCreateChat;
@@ -544,7 +564,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						modelOptions={modelOptions}
 						modelSelectorPlaceholder={modelSelectorPlaceholder}
 						reasoningEffort={effectiveReasoningEffort}
-						onReasoningEffortChange={setSelectedReasoningEffort}
+						onReasoningEffortChange={handleReasoningEffortChange}
 						isModelCatalogLoading={isModelCatalogLoading}
 						hasModelOptions={hasModelOptions}
 						planModeEnabled={planModeEnabled}

--- a/site/src/pages/AgentsPage/utils/reasoningEffort.test.ts
+++ b/site/src/pages/AgentsPage/utils/reasoningEffort.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	formatReasoningEffort,
 	getReasoningEffortForModel,
@@ -9,6 +9,9 @@ import {
 describe("reasoning effort storage", () => {
 	beforeEach(() => {
 		localStorage.clear();
+	});
+
+	afterEach(() => {
 		vi.restoreAllMocks();
 	});
 

--- a/site/src/pages/AgentsPage/utils/reasoningEffort.test.ts
+++ b/site/src/pages/AgentsPage/utils/reasoningEffort.test.ts
@@ -1,5 +1,38 @@
-import { describe, expect, it } from "vitest";
-import { formatReasoningEffort, pickReasoningEffort } from "./reasoningEffort";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	formatReasoningEffort,
+	getReasoningEffortForModel,
+	pickReasoningEffort,
+	saveReasoningEffortForModel,
+} from "./reasoningEffort";
+
+describe("reasoning effort storage", () => {
+	beforeEach(() => {
+		localStorage.clear();
+		vi.restoreAllMocks();
+	});
+
+	it("stores the latest effort independently for each model", () => {
+		saveReasoningEffortForModel("model-a", "high");
+		saveReasoningEffortForModel("model-b", "medium");
+		saveReasoningEffortForModel("model-a", "low");
+
+		expect(getReasoningEffortForModel("model-a")).toBe("low");
+		expect(getReasoningEffortForModel("model-b")).toBe("medium");
+	});
+
+	it("handles unavailable storage", () => {
+		vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+			throw new DOMException("Storage unavailable", "SecurityError");
+		});
+		expect(getReasoningEffortForModel("model-a")).toBeUndefined();
+
+		vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+			throw new DOMException("Storage full", "QuotaExceededError");
+		});
+		expect(() => saveReasoningEffortForModel("model-a", "high")).not.toThrow();
+	});
+});
 
 describe("formatReasoningEffort", () => {
 	it("formats xhigh", () => {

--- a/site/src/pages/AgentsPage/utils/reasoningEffort.ts
+++ b/site/src/pages/AgentsPage/utils/reasoningEffort.ts
@@ -3,6 +3,7 @@ const reasoningEffortStorageKeyPrefix = "agents.reasoning-effort.";
 const reasoningEffortStorageKey = (modelID: string) =>
 	`${reasoningEffortStorageKeyPrefix}${modelID}`;
 
+/** Reads the persisted effort for a model, or undefined when none is stored or storage is unavailable. */
 export const getReasoningEffortForModel = (
 	modelID: string,
 ): string | undefined => {
@@ -15,6 +16,7 @@ export const getReasoningEffortForModel = (
 	}
 };
 
+/** Persists the effort for a model. Silently keeps only the in-memory selection when storage is unavailable (private mode, quota). */
 export const saveReasoningEffortForModel = (
 	modelID: string,
 	reasoningEffort: string,

--- a/site/src/pages/AgentsPage/utils/reasoningEffort.ts
+++ b/site/src/pages/AgentsPage/utils/reasoningEffort.ts
@@ -1,28 +1,32 @@
 const reasoningEffortStorageKeyPrefix = "agents.reasoning-effort.";
 
-const reasoningEffortStorageKey = (modelID: string) =>
-	`${reasoningEffortStorageKeyPrefix}${modelID}`;
+const reasoningEffortStorageKey = (modelConfigID: string) =>
+	`${reasoningEffortStorageKeyPrefix}${modelConfigID}`;
 
 /** Reads the persisted effort for a model, or undefined when none is stored or storage is unavailable. */
 export const getReasoningEffortForModel = (
-	modelID: string,
+	modelConfigID: string,
 ): string | undefined => {
 	try {
 		return (
-			localStorage.getItem(reasoningEffortStorageKey(modelID)) ?? undefined
+			localStorage.getItem(reasoningEffortStorageKey(modelConfigID)) ??
+			undefined
 		);
 	} catch {
 		return undefined;
 	}
 };
 
-/** Persists the effort for a model. Silently keeps only the in-memory selection when storage is unavailable (private mode, quota). */
+/** Persists the effort for a model. Swallows storage errors (private mode, quota) so the caller's in-memory selection is unaffected. */
 export const saveReasoningEffortForModel = (
-	modelID: string,
+	modelConfigID: string,
 	reasoningEffort: string,
 ): void => {
 	try {
-		localStorage.setItem(reasoningEffortStorageKey(modelID), reasoningEffort);
+		localStorage.setItem(
+			reasoningEffortStorageKey(modelConfigID),
+			reasoningEffort,
+		);
 	} catch {
 		// Keep the in-memory selection when storage is unavailable.
 	}

--- a/site/src/pages/AgentsPage/utils/reasoningEffort.ts
+++ b/site/src/pages/AgentsPage/utils/reasoningEffort.ts
@@ -1,3 +1,31 @@
+const reasoningEffortStorageKeyPrefix = "agents.reasoning-effort.";
+
+const reasoningEffortStorageKey = (modelID: string) =>
+	`${reasoningEffortStorageKeyPrefix}${modelID}`;
+
+export const getReasoningEffortForModel = (
+	modelID: string,
+): string | undefined => {
+	try {
+		return (
+			localStorage.getItem(reasoningEffortStorageKey(modelID)) ?? undefined
+		);
+	} catch {
+		return undefined;
+	}
+};
+
+export const saveReasoningEffortForModel = (
+	modelID: string,
+	reasoningEffort: string,
+): void => {
+	try {
+		localStorage.setItem(reasoningEffortStorageKey(modelID), reasoningEffort);
+	} catch {
+		// Keep the in-memory selection when storage is unavailable.
+	}
+};
+
 /** Display label for an effort value, e.g. "xhigh" renders as "Xhigh". */
 export const formatReasoningEffort = (value: string): string =>
 	value.charAt(0).toUpperCase() + value.slice(1);


### PR DESCRIPTION
When we split the reasoning (thinking) effort selector out of the model config, the New chat page never remembered the previously used effort for a model. The effort was held in a single transient state value: it reset to the model default on every mount and leaked across models, so selecting "high" for model A and "medium" for model B showed "medium" when switching back to A.

Effort is now persisted per model config ID in localStorage (`agents.reasoning-effort.<id>`), read on both the New chat form and the existing chat page, and restored when switching models. The persisted per-model value takes precedence over a root personal model override's `reasoning_effort` (the user's own most recent choice wins across sessions); the override still applies when nothing is persisted for that model, and a chat's `last_reasoning_effort` still wins for the model that chat was last run with. A stored value that is no longer valid for the model's current effort set is ignored so it cannot shadow the override. Storage failures (private mode, quota) degrade gracefully to in-memory-only memory.

Also sends the effective effort on edit when the picker model changes, so the backend does not preserve the old model's effort against a different model.

Refs CODAGT-799

<details>
<summary>Implementation plan and review notes</summary>

### Root cause

`AgentCreateForm` and `AgentChatPage` each kept one `selectedReasoningEffort` string applied to whichever model was selected. Nothing was persisted: remounting the New chat page always reset the effort to the model default, and a single shared value bled across models when both supported it.

### Changes

- `site/src/pages/AgentsPage/utils/reasoningEffort.ts`: per-model localStorage helpers (try/catch guarded) alongside the existing `pickReasoningEffort`/`formatReasoningEffort`.
- `AgentCreateForm`: per-model effort state with precedence user pick > persisted per-model value > root override effort > model default; persists on slider change. Stored values invalid for the model's current effort set are ignored so the override still applies.
- `AgentChatPage`: per-model state with precedence user pick > chat's `last_reasoning_effort` (for the chat's model) > persisted value > model default; edit requests include effort when dirty or when the model changes. Edit-time slider changes are scoped to the edit and do not overwrite the persisted default.
- Tests: storage unit tests (per-model isolation, unavailable storage) and Storybook stories (per-model restore + write, persisted-beats-override, override-when-unpersisted, stale persisted falls through to override, chat cross-model restore + edit-with-model-switch).

### Review passes

Multiple delegated review rounds caught and fixed: cross-model bleed, root override precedence (initially inverted, corrected after live dev-server reproduction), storage exceptions (private mode/quota), shared-map cross-tab race (now per-model keys), edit-time model-switch effort desync, chat-specific effort leaking to other models, edit-time slider changes overwriting the persisted default, a stale persisted value shadowing the override, and stale comments/docs. A ponytail (over-engineering) review's cuts that would have reintroduced those bugs were rejected; safe cuts applied.
</details>

> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood
