### PR TITLE
feat: expose org MCP server APIs

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -23233,7 +23233,7 @@ const docTemplate = `{
                 "ResourceIdpsyncSettings",
                 "ResourceInboxNotification",
                 "ResourceLicense",
-                "ResourceMcpServerConfig",
+                "ResourceMCPServerConfig",
                 "ResourceNotificationMessage",
                 "ResourceNotificationPreference",
                 "ResourceNotificationTemplate",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -21278,7 +21278,7 @@
 				"ResourceIdpsyncSettings",
 				"ResourceInboxNotification",
 				"ResourceLicense",
-				"ResourceMcpServerConfig",
+				"ResourceMCPServerConfig",
 				"ResourceNotificationMessage",
 				"ResourceNotificationPreference",
 				"ResourceNotificationTemplate",

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1320,6 +1320,15 @@ func New(options *Options) *API {
 			r.Get("/acl", api.getChatModelConfigACL)
 			r.Patch("/acl", api.patchChatModelConfigACL)
 		})
+		r.Route("/mcp-servers/{mcpServer}", func(r chi.Router) {
+			r.Use(apiKeyMiddleware)
+			r.Get("/", api.getMCPServerConfig)
+			r.Patch("/", api.updateMCPServerConfig)
+			r.Delete("/", api.deleteMCPServerConfig)
+			r.Get("/oauth2/connect", api.mcpServerOAuth2Connect)
+			r.Get("/oauth2/callback", api.mcpServerOAuth2Callback)
+			r.Delete("/oauth2/disconnect", api.mcpServerOAuth2Disconnect)
+		})
 		r.Route("/organizations/{organization}", func(r chi.Router) {
 			r.Use(
 				apiKeyMiddleware,
@@ -1327,6 +1336,8 @@ func New(options *Options) *API {
 			)
 			r.Get("/chat-model-configs", api.listChatModelConfigs)
 			r.Post("/chat-model-configs", api.createChatModelConfig)
+			r.Get("/mcp-servers", api.listMCPServerConfigs)
+			r.Post("/mcp-servers", api.createMCPServerConfig)
 			r.Route("/chats", func(r chi.Router) {
 				r.Get("/models", api.listChatModels)
 				r.Route("/config", func(r chi.Router) {
@@ -1464,20 +1475,6 @@ func New(options *Options) *API {
 			r.Use(
 				apiKeyMiddleware,
 			)
-			// MCP server configuration endpoints.
-			r.Route("/servers", func(r chi.Router) {
-				r.Get("/", api.listMCPServerConfigs)
-				r.Post("/", api.createMCPServerConfig)
-				r.Route("/{mcpServer}", func(r chi.Router) {
-					r.Get("/", api.getMCPServerConfig)
-					r.Patch("/", api.updateMCPServerConfig)
-					r.Delete("/", api.deleteMCPServerConfig)
-					// OAuth2 user flow
-					r.Get("/oauth2/connect", api.mcpServerOAuth2Connect)
-					r.Get("/oauth2/callback", api.mcpServerOAuth2Callback)
-					r.Delete("/oauth2/disconnect", api.mcpServerOAuth2Disconnect)
-				})
-			})
 			// MCP HTTP transport endpoint with mandatory authentication
 			r.Route("/http", func(r chi.Router) {
 				r.Use(httpmw.RequireExperimentWithDevBypass(api.Experiments, codersdk.ExperimentOAuth2, codersdk.ExperimentMCPServerHTTP))

--- a/coderd/mcp.go
+++ b/coderd/mcp.go
@@ -148,19 +148,18 @@ func shouldRefreshOIDCToken(link database.UserLink) (bool, time.Time) {
 func (api *API) listMCPServerConfigs(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
+	organization := httpmw.OrganizationParam(r)
 
-	// Admin users can see all MCP server configs (including disabled
-	// ones) for management purposes. Non-admin users see only enabled
-	// configs, which is sufficient for using the chat feature.
-	isAdmin := api.Authorize(r, policy.ActionRead, rbac.ResourceDeploymentConfig)
+	// Organization admins can see disabled configs and management fields.
+	// Other members see enabled configs with management fields redacted.
+	isAdmin := api.Authorize(r, policy.ActionUpdate, rbac.ResourceMCPServerConfig.InOrg(organization.ID))
 
 	var configs []database.MCPServerConfig
 	var err error
 	if isAdmin {
-		configs, err = api.Database.GetMCPServerConfigs(ctx)
+		configs, err = api.Database.GetMCPServerConfigs(ctx, organization.ID)
 	} else {
-		//nolint:gocritic // All authenticated users need to read enabled MCP server configs to use the chat feature.
-		configs, err = api.Database.GetEnabledMCPServerConfigs(dbauthz.AsSystemRestricted(ctx))
+		configs, err = api.Database.GetEnabledMCPServerConfigs(ctx, organization.ID)
 	}
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
@@ -173,8 +172,16 @@ func (api *API) listMCPServerConfigs(rw http.ResponseWriter, r *http.Request) {
 	// Look up the calling user's OAuth2 tokens so we can populate
 	// auth_connected per server. Attempt to refresh expired tokens
 	// so the status is accurate and the token is ready for use.
-	//nolint:gocritic // Need to check user tokens across all servers.
-	userTokens, err := api.Database.GetMCPServerUserTokensByUserID(dbauthz.AsSystemRestricted(ctx), apiKey.UserID)
+	configIDs := make([]uuid.UUID, 0, len(configs))
+	for _, config := range configs {
+		configIDs = append(configIDs, config.ID)
+	}
+	//nolint:gocritic // Token status is loaded for the organization-scoped response.
+	userTokens, err := api.Database.GetMCPServerUserTokensByUserID(dbauthz.AsSystemRestricted(ctx), database.GetMCPServerUserTokensByUserIDParams{
+		UserID:             apiKey.UserID,
+		OrganizationID:     organization.ID,
+		McpServerConfigIds: configIDs,
+	})
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Failed to get user tokens.",
@@ -223,7 +230,8 @@ func (api *API) listMCPServerConfigs(rw http.ResponseWriter, r *http.Request) {
 func (api *API) createMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
-	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
+	organization := httpmw.OrganizationParam(r)
+	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceMCPServerConfig.InOrg(organization.ID)) {
 		httpapi.Forbidden(rw)
 		return
 	}
@@ -267,6 +275,7 @@ func (api *API) createMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 			}
 
 			inserted, err := api.Database.InsertMCPServerConfig(ctx, database.InsertMCPServerConfigParams{
+				OrganizationID:          organization.ID,
 				DisplayName:             strings.TrimSpace(req.DisplayName),
 				Slug:                    strings.TrimSpace(req.Slug),
 				Description:             strings.TrimSpace(req.Description),
@@ -320,7 +329,7 @@ func (api *API) createMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 			}
 
 			// Now build the callback URL with the actual ID.
-			callbackURL := fmt.Sprintf("%s/api/experimental/mcp/servers/%s/oauth2/callback", api.AccessURL.String(), inserted.ID)
+			callbackURL := fmt.Sprintf("%s/api/experimental/mcp-servers/%s/oauth2/callback", api.AccessURL.String(), inserted.ID)
 			httpClient := api.HTTPClient
 			if httpClient == nil {
 				httpClient = &http.Client{Timeout: 30 * time.Second}
@@ -328,7 +337,9 @@ func (api *API) createMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 			result, err := discoverAndRegisterMCPOAuth2(ctx, httpClient, strings.TrimSpace(req.URL), callbackURL)
 			if err != nil {
 				// Clean up: delete the partially created config.
-				deleteErr := api.Database.DeleteMCPServerConfigByID(ctx, inserted.ID)
+				deleteErr := api.Database.DeleteMCPServerConfigByID(ctx, database.DeleteMCPServerConfigByIDParams{
+					ID: inserted.ID, OrganizationID: inserted.OrganizationID,
+				})
 				if deleteErr != nil {
 					api.Logger.Warn(ctx, "failed to clean up MCP server config after OAuth2 discovery failure",
 						slog.F("config_id", inserted.ID),
@@ -373,6 +384,7 @@ func (api *API) createMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 			// Update the record with discovered OAuth2 credentials.
 			updated, err := api.Database.UpdateMCPServerConfig(ctx, database.UpdateMCPServerConfigParams{
 				ID:                      inserted.ID,
+				OrganizationID:          inserted.OrganizationID,
 				DisplayName:             inserted.DisplayName,
 				Slug:                    inserted.Slug,
 				Description:             inserted.Description,
@@ -444,6 +456,7 @@ func (api *API) createMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	inserted, err := api.Database.InsertMCPServerConfig(ctx, database.InsertMCPServerConfigParams{
+		OrganizationID:          organization.ID,
 		DisplayName:             strings.TrimSpace(req.DisplayName),
 		Slug:                    strings.TrimSpace(req.Slug),
 		Description:             strings.TrimSpace(req.Description),
@@ -513,20 +526,8 @@ func (api *API) getMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	isAdmin := api.Authorize(r, policy.ActionRead, rbac.ResourceDeploymentConfig)
-
-	var config database.MCPServerConfig
-	var err error
-	if isAdmin {
-		config, err = api.Database.GetMCPServerConfigByID(ctx, mcpServerID)
-	} else {
-		//nolint:gocritic // All authenticated users can view enabled MCP server configs.
-		config, err = api.Database.GetMCPServerConfigByID(dbauthz.AsSystemRestricted(ctx), mcpServerID)
-		if err == nil && !config.Enabled {
-			httpapi.ResourceNotFound(rw)
-			return
-		}
-	}
+	//nolint:gocritic // The item must be loaded to derive its organization before authorization.
+	config, err := api.Database.GetMCPServerConfigByID(dbauthz.AsSystemRestricted(ctx), mcpServerID)
 	if err != nil {
 		if httpapi.Is404Error(err) {
 			httpapi.ResourceNotFound(rw)
@@ -536,6 +537,16 @@ func (api *API) getMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 			Message: "Failed to get MCP server config.",
 			Detail:  err.Error(),
 		})
+		return
+	}
+
+	if !api.Authorize(r, policy.ActionRead, config) {
+		httpapi.ResourceNotFound(rw)
+		return
+	}
+	isAdmin := api.Authorize(r, policy.ActionUpdate, config)
+	if !isAdmin && !config.Enabled {
+		httpapi.ResourceNotFound(rw)
 		return
 	}
 
@@ -549,8 +560,12 @@ func (api *API) getMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 	// Populate AuthConnected for the calling user. Attempt to
 	// refresh the token so the status is accurate.
 	if config.AuthType == "oauth2" {
-		//nolint:gocritic // Need to check user token for this server.
-		userTokens, err := api.Database.GetMCPServerUserTokensByUserID(dbauthz.AsSystemRestricted(ctx), apiKey.UserID)
+		//nolint:gocritic // Token status is loaded for this organization-owned config.
+		userTokens, err := api.Database.GetMCPServerUserTokensByUserID(dbauthz.AsSystemRestricted(ctx), database.GetMCPServerUserTokensByUserIDParams{
+			UserID:             apiKey.UserID,
+			OrganizationID:     config.OrganizationID,
+			McpServerConfigIds: []uuid.UUID{config.ID},
+		})
 		if err != nil {
 			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 				Message: "Failed to get user tokens.",
@@ -569,6 +584,29 @@ func (api *API) getMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 	httpapi.Write(ctx, rw, http.StatusOK, sdkConfig)
 }
 
+func (api *API) getMCPServerConfigForMutation(rw http.ResponseWriter, r *http.Request, action policy.Action) (database.MCPServerConfig, bool) {
+	ctx := r.Context()
+	mcpServerID, ok := parseMCPServerConfigID(rw, r)
+	if !ok {
+		return database.MCPServerConfig{}, false
+	}
+	//nolint:gocritic // The item must be loaded to derive its organization before authorization.
+	config, err := api.Database.GetMCPServerConfigByID(dbauthz.AsSystemRestricted(ctx), mcpServerID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) || httpapi.Is404Error(err) {
+			httpapi.ResourceNotFound(rw)
+			return database.MCPServerConfig{}, false
+		}
+		httpapi.InternalServerError(rw, err)
+		return database.MCPServerConfig{}, false
+	}
+	if !api.Authorize(r, action, config) {
+		httpapi.ResourceNotFound(rw)
+		return database.MCPServerConfig{}, false
+	}
+	return config, true
+}
+
 // @Summary Update MCP server config
 // @x-apidocgen {"skip": true}
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
@@ -577,12 +615,7 @@ func (api *API) getMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 func (api *API) updateMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
-	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
-		httpapi.Forbidden(rw)
-		return
-	}
-
-	mcpServerID, ok := parseMCPServerConfigID(rw, r)
+	existing, ok := api.getMCPServerConfigForMutation(rw, r, policy.ActionUpdate)
 	if !ok {
 		return
 	}
@@ -631,11 +664,6 @@ func (api *API) updateMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 
 	var updated database.MCPServerConfig
 	err := api.Database.InTx(func(tx database.Store) error {
-		existing, err := tx.GetMCPServerConfigByID(ctx, mcpServerID)
-		if err != nil {
-			return err
-		}
-
 		displayName := existing.DisplayName
 		if req.DisplayName != nil {
 			displayName = strings.TrimSpace(*req.DisplayName)
@@ -852,6 +880,7 @@ func (api *API) updateMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 			ForwardCoderHeaders:     forwardCoderHeaders,
 			UpdatedBy:               apiKey.UserID,
 			ID:                      existing.ID,
+			OrganizationID:          existing.OrganizationID,
 		})
 		return err
 	}, nil)
@@ -889,29 +918,14 @@ func (api *API) updateMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
 func (api *API) deleteMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
-		httpapi.Forbidden(rw)
-		return
-	}
-
-	mcpServerID, ok := parseMCPServerConfigID(rw, r)
+	config, ok := api.getMCPServerConfigForMutation(rw, r, policy.ActionDelete)
 	if !ok {
 		return
 	}
 
-	if _, err := api.Database.GetMCPServerConfigByID(ctx, mcpServerID); err != nil {
-		if httpapi.Is404Error(err) {
-			httpapi.ResourceNotFound(rw)
-			return
-		}
-		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Failed to get MCP server config.",
-			Detail:  err.Error(),
-		})
-		return
-	}
-
-	if err := api.Database.DeleteMCPServerConfigByID(ctx, mcpServerID); err != nil {
+	if err := api.Database.DeleteMCPServerConfigByID(ctx, database.DeleteMCPServerConfigByIDParams{
+		ID: config.ID, OrganizationID: config.OrganizationID,
+	}); err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Failed to delete MCP server config.",
 			Detail:  err.Error(),
@@ -931,22 +945,8 @@ func (api *API) deleteMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 func (api *API) mcpServerOAuth2Connect(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	mcpServerID, ok := parseMCPServerConfigID(rw, r)
+	config, ok := api.getMCPServerConfigForMutation(rw, r, policy.ActionRead)
 	if !ok {
-		return
-	}
-
-	//nolint:gocritic // Any authenticated user can initiate OAuth2 for an enabled MCP server.
-	config, err := api.Database.GetMCPServerConfigByID(dbauthz.AsSystemRestricted(ctx), mcpServerID)
-	if err != nil {
-		if httpapi.Is404Error(err) {
-			httpapi.ResourceNotFound(rw)
-			return
-		}
-		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Failed to get MCP server config.",
-			Detail:  err.Error(),
-		})
 		return
 	}
 
@@ -975,7 +975,7 @@ func (api *API) mcpServerOAuth2Connect(rw http.ResponseWriter, r *http.Request) 
 	// The callback URL is on our server; after the exchange we store
 	// the token and close the popup.
 	state := uuid.New().String()
-	callbackPath := fmt.Sprintf("/api/experimental/mcp/servers/%s/oauth2/callback", config.ID)
+	callbackPath := fmt.Sprintf("/api/experimental/mcp-servers/%s/oauth2/callback", config.ID)
 	http.SetCookie(rw, api.DeploymentValues.HTTPCookies.Apply(&http.Cookie{
 		Name:     "mcp_oauth2_state_" + config.ID.String(),
 		Value:    state,
@@ -1026,22 +1026,8 @@ func (api *API) mcpServerOAuth2Callback(rw http.ResponseWriter, r *http.Request)
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
 
-	mcpServerID, ok := parseMCPServerConfigID(rw, r)
+	config, ok := api.getMCPServerConfigForMutation(rw, r, policy.ActionRead)
 	if !ok {
-		return
-	}
-
-	//nolint:gocritic // Any authenticated user can complete OAuth2 for an enabled MCP server.
-	config, err := api.Database.GetMCPServerConfigByID(dbauthz.AsSystemRestricted(ctx), mcpServerID)
-	if err != nil {
-		if httpapi.Is404Error(err) {
-			httpapi.ResourceNotFound(rw)
-			return
-		}
-		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Failed to get MCP server config.",
-			Detail:  err.Error(),
-		})
 		return
 	}
 
@@ -1094,7 +1080,7 @@ func (api *API) mcpServerOAuth2Callback(rw http.ResponseWriter, r *http.Request)
 		return
 	}
 	// Clear the state cookie.
-	callbackPath := fmt.Sprintf("/api/experimental/mcp/servers/%s/oauth2/callback", config.ID)
+	callbackPath := fmt.Sprintf("/api/experimental/mcp-servers/%s/oauth2/callback", config.ID)
 	http.SetCookie(rw, api.DeploymentValues.HTTPCookies.Apply(&http.Cookie{
 		Name:     "mcp_oauth2_state_" + config.ID.String(),
 		Value:    "",
@@ -1165,7 +1151,7 @@ func (api *API) mcpServerOAuth2Callback(rw http.ResponseWriter, r *http.Request)
 
 	//nolint:gocritic // Users store their own tokens.
 	_, err = api.Database.UpsertMCPServerUserToken(dbauthz.AsSystemRestricted(ctx), database.UpsertMCPServerUserTokenParams{
-		MCPServerConfigID: mcpServerID,
+		MCPServerConfigID: config.ID,
 		UserID:            apiKey.UserID,
 		AccessToken:       token.AccessToken,
 		AccessTokenKeyID:  sql.NullString{},
@@ -1205,39 +1191,29 @@ func (api *API) mcpServerOAuth2Disconnect(rw http.ResponseWriter, r *http.Reques
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
 
-	mcpServerID, ok := parseMCPServerConfigID(rw, r)
+	config, ok := api.getMCPServerConfigForMutation(rw, r, policy.ActionRead)
 	if !ok {
 		return
 	}
 
 	//nolint:gocritic // Users manage their own tokens.
 	systemCtx := dbauthz.AsSystemRestricted(ctx)
-	var (
-		config database.MCPServerConfig
-		token  database.MCPServerUserToken
-	)
+	var token database.MCPServerUserToken
 	// Serializable isolation keeps the revoked token aligned with the row deleted locally.
 	err := api.Database.InTx(func(tx database.Store) error {
 		dbToken, err := tx.GetMCPServerUserToken(systemCtx, database.GetMCPServerUserTokenParams{
-			MCPServerConfigID: mcpServerID,
+			MCPServerConfigID: config.ID,
 			UserID:            apiKey.UserID,
 		})
 		if err != nil {
 			return err
 		}
-		// Load the config only after the token is found so callers
-		// without a token cannot probe which config IDs exist.
-		dbConfig, err := tx.GetMCPServerConfigByID(systemCtx, mcpServerID)
-		if err != nil {
-			return err
-		}
 		if err := tx.DeleteMCPServerUserToken(systemCtx, database.DeleteMCPServerUserTokenParams{
-			MCPServerConfigID: mcpServerID,
+			MCPServerConfigID: config.ID,
 			UserID:            apiKey.UserID,
 		}); err != nil {
 			return err
 		}
-		config = dbConfig
 		token = dbToken
 		return nil
 	}, &database.TxOptions{Isolation: sql.LevelSerializable})
@@ -1432,11 +1408,12 @@ func parseMCPServerConfigID(rw http.ResponseWriter, r *http.Request) (uuid.UUID,
 // Admin-only fields (OAuth2 client ID, auth URLs, etc.) are included.
 func convertMCPServerConfig(config database.MCPServerConfig) codersdk.MCPServerConfig {
 	return codersdk.MCPServerConfig{
-		ID:          config.ID,
-		DisplayName: config.DisplayName,
-		Slug:        config.Slug,
-		Description: config.Description,
-		IconURL:     config.IconURL,
+		ID:             config.ID,
+		OrganizationID: config.OrganizationID,
+		DisplayName:    config.DisplayName,
+		Slug:           config.Slug,
+		Description:    config.Description,
+		IconURL:        config.IconURL,
 
 		Transport: config.Transport,
 		URL:       config.Url,

--- a/coderd/mcp_test.go
+++ b/coderd/mcp_test.go
@@ -46,11 +46,11 @@ func newMCPClient(t testing.TB) *codersdk.Client {
 
 // createMCPServerConfig is a helper that creates a minimal enabled
 // MCP server config with auth_type=none.
-func createMCPServerConfig(t testing.TB, client *codersdk.Client, slug string, enabled bool) codersdk.MCPServerConfig {
+func createMCPServerConfig(t testing.TB, client *codersdk.Client, organizationID uuid.UUID, slug string, enabled bool) codersdk.MCPServerConfig {
 	t.Helper()
 
 	ctx := testutil.Context(t, testutil.WaitLong)
-	config, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+	config, err := client.CreateMCPServerConfig(ctx, organizationID, codersdk.CreateMCPServerConfigRequest{
 		DisplayName:   "Test Server " + slug,
 		Slug:          slug,
 		Description:   "A test MCP server.",
@@ -67,16 +67,36 @@ func createMCPServerConfig(t testing.TB, client *codersdk.Client, slug string, e
 	return config
 }
 
+func TestMCPServerConfigLegacyRoutesRemoved(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client := newMCPClient(t)
+	firstUser := coderdtest.CreateFirstUser(t, client)
+	config := createMCPServerConfig(t, client, firstUser.OrganizationID, "legacy-route-test", true)
+
+	for _, path := range []string{
+		"/api/experimental/mcp/servers",
+		"/api/experimental/mcp/servers/" + config.ID.String(),
+		"/api/experimental/mcp/servers/" + config.ID.String() + "/oauth2/connect",
+	} {
+		res, err := client.Request(ctx, http.MethodGet, path, nil)
+		require.NoError(t, err)
+		res.Body.Close()
+		require.Equal(t, http.StatusNotFound, res.StatusCode, path)
+	}
+}
+
 func TestMCPServerConfigsCRUD(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitLong)
 	client := newMCPClient(t)
-	_ = coderdtest.CreateFirstUser(t, client)
+	firstUser := coderdtest.CreateFirstUser(t, client)
 
 	// Create a config with all fields populated including OAuth2
 	// secrets so we can verify they are not leaked.
-	created, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+	created, err := client.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 		DisplayName:        "My MCP Server",
 		Slug:               "my-mcp-server",
 		Description:        "Integration test server.",
@@ -96,6 +116,7 @@ func TestMCPServerConfigsCRUD(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotEqual(t, uuid.Nil, created.ID)
+	require.Equal(t, firstUser.OrganizationID, created.OrganizationID)
 	require.Equal(t, "My MCP Server", created.DisplayName)
 	require.Equal(t, "my-mcp-server", created.Slug)
 	require.Equal(t, "Integration test server.", created.Description)
@@ -112,7 +133,7 @@ func TestMCPServerConfigsCRUD(t *testing.T) {
 	require.True(t, created.HasOAuth2Secret)
 
 	// Verify the config appears in the list and direct get responses.
-	configs, err := client.MCPServerConfigs(ctx)
+	configs, err := client.MCPServerConfigs(ctx, firstUser.OrganizationID)
 	require.NoError(t, err)
 	require.Len(t, configs, 1)
 	require.Equal(t, created.ID, configs[0].ID)
@@ -148,7 +169,7 @@ func TestMCPServerConfigsCRUD(t *testing.T) {
 	require.Equal(t, "oauth2", updated.AuthType)
 
 	// Verify the update took effect through the list and direct get.
-	configs, err = client.MCPServerConfigs(ctx)
+	configs, err = client.MCPServerConfigs(ctx, firstUser.OrganizationID)
 	require.NoError(t, err)
 	require.Len(t, configs, 1)
 	require.Equal(t, "Renamed Server", configs[0].DisplayName)
@@ -166,7 +187,7 @@ func TestMCPServerConfigsCRUD(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify it's gone.
-	configs, err = client.MCPServerConfigs(ctx)
+	configs, err = client.MCPServerConfigs(ctx, firstUser.OrganizationID)
 	require.NoError(t, err)
 	require.Empty(t, configs)
 }
@@ -180,16 +201,16 @@ func TestMCPServerConfigsNonAdmin(t *testing.T) {
 	memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
 
 	// Admin creates two configs: one enabled, one disabled.
-	_ = createMCPServerConfig(t, adminClient, "enabled-server", true)
-	_ = createMCPServerConfig(t, adminClient, "disabled-server", false)
+	_ = createMCPServerConfig(t, adminClient, firstUser.OrganizationID, "enabled-server", true)
+	_ = createMCPServerConfig(t, adminClient, firstUser.OrganizationID, "disabled-server", false)
 
 	// Admin sees both.
-	adminConfigs, err := adminClient.MCPServerConfigs(ctx)
+	adminConfigs, err := adminClient.MCPServerConfigs(ctx, firstUser.OrganizationID)
 	require.NoError(t, err)
 	require.Len(t, adminConfigs, 2)
 
 	// Regular user sees only the enabled one.
-	memberConfigs, err := memberClient.MCPServerConfigs(ctx)
+	memberConfigs, err := memberClient.MCPServerConfigs(ctx, firstUser.OrganizationID)
 	require.NoError(t, err)
 	require.Len(t, memberConfigs, 1)
 	require.Equal(t, "enabled-server", memberConfigs[0].Slug)
@@ -209,7 +230,7 @@ func TestMCPServerConfigsSecretsNeverLeaked(t *testing.T) {
 	memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
 
 	// Create a config with ALL secret fields populated.
-	created, err := adminClient.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+	created, err := adminClient.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 		DisplayName:         "Secrets Test",
 		Slug:                "secrets-test",
 		Transport:           "streamable_http",
@@ -258,7 +279,7 @@ func TestMCPServerConfigsSecretsNeverLeaked(t *testing.T) {
 	require.True(t, created.HasCustomHeaders, "HasCustomHeaders should be true")
 
 	// Admin list endpoint.
-	adminConfigs, err := adminClient.MCPServerConfigs(ctx)
+	adminConfigs, err := adminClient.MCPServerConfigs(ctx, firstUser.OrganizationID)
 	require.NoError(t, err)
 	require.NotEmpty(t, adminConfigs)
 	for _, cfg := range adminConfigs {
@@ -271,7 +292,7 @@ func TestMCPServerConfigsSecretsNeverLeaked(t *testing.T) {
 	assertNoSecrets(t, "admin get-by-id", adminSingle)
 
 	// Non-admin list endpoint.
-	memberConfigs, err := memberClient.MCPServerConfigs(ctx)
+	memberConfigs, err := memberClient.MCPServerConfigs(ctx, firstUser.OrganizationID)
 	require.NoError(t, err)
 	require.NotEmpty(t, memberConfigs)
 	for _, cfg := range memberConfigs {
@@ -309,7 +330,7 @@ func TestMCPServerConfigsAuthConnected(t *testing.T) {
 	memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
 
 	// Create an oauth2 server config (enabled).
-	created, err := adminClient.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+	created, err := adminClient.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 		DisplayName:    "OAuth Server",
 		Slug:           "oauth-server",
 		Transport:      "streamable_http",
@@ -327,7 +348,7 @@ func TestMCPServerConfigsAuthConnected(t *testing.T) {
 
 	// Regular user lists configs — auth_connected should be false
 	// because no token has been stored.
-	memberConfigs, err := memberClient.MCPServerConfigs(ctx)
+	memberConfigs, err := memberClient.MCPServerConfigs(ctx, firstUser.OrganizationID)
 	require.NoError(t, err)
 	require.Len(t, memberConfigs, 1)
 	require.Equal(t, created.ID, memberConfigs[0].ID)
@@ -335,12 +356,12 @@ func TestMCPServerConfigsAuthConnected(t *testing.T) {
 
 	// Also create a non-oauth server. It should report
 	// auth_connected=true because no auth is needed.
-	_ = createMCPServerConfig(t, adminClient, "no-auth-server", true)
+	_ = createMCPServerConfig(t, adminClient, firstUser.OrganizationID, "no-auth-server", true)
 
 	// And a user_oidc server. user_oidc never requires a per-user
 	// connect step, so auth_connected is always true regardless of
 	// whether the calling user has an OIDC link.
-	_, err = adminClient.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+	_, err = adminClient.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 		DisplayName:   "User OIDC Server",
 		Slug:          "user-oidc-server",
 		Transport:     "streamable_http",
@@ -353,7 +374,7 @@ func TestMCPServerConfigsAuthConnected(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	memberConfigs, err = memberClient.MCPServerConfigs(ctx)
+	memberConfigs, err = memberClient.MCPServerConfigs(ctx, firstUser.OrganizationID)
 	require.NoError(t, err)
 	require.Len(t, memberConfigs, 3)
 	for _, cfg := range memberConfigs {
@@ -371,12 +392,12 @@ func TestMCPServerConfigsUserOIDCClearsFields(t *testing.T) {
 
 	ctx := testutil.Context(t, testutil.WaitLong)
 	client := newMCPClient(t)
-	_ = coderdtest.CreateFirstUser(t, client)
+	firstUser := coderdtest.CreateFirstUser(t, client)
 
 	// Start with an oauth2 config that has a client secret, then
 	// switch the auth_type to user_oidc and verify all auth-specific
 	// fields are cleared.
-	created, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+	created, err := client.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 		DisplayName:         "Switch Server",
 		Slug:                "switch-server",
 		Transport:           "streamable_http",
@@ -422,7 +443,7 @@ func TestMCPServerConfigsUserOIDCClearsFields(t *testing.T) {
 	require.ErrorAs(t, err, &sdkErr)
 	require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
 
-	_, err = client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+	_, err = client.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 		DisplayName:         "Plaintext Revoke",
 		Slug:                "plaintext-revoke",
 		Transport:           "streamable_http",
@@ -478,9 +499,9 @@ func TestMCPServerConfigsUserOIDCDirect(t *testing.T) {
 	// while no auth-specific fields are persisted on the row.
 	ctx := testutil.Context(t, testutil.WaitLong)
 	client := newMCPClient(t)
-	_ = coderdtest.CreateFirstUser(t, client)
+	firstUser := coderdtest.CreateFirstUser(t, client)
 
-	created, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+	created, err := client.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 		DisplayName:   "User OIDC Direct",
 		Slug:          "user-oidc-direct",
 		Transport:     "streamable_http",
@@ -502,7 +523,7 @@ func TestMCPServerConfigsAvailability(t *testing.T) {
 	t.Parallel()
 
 	client := newMCPClient(t)
-	_ = coderdtest.CreateFirstUser(t, client)
+	firstUser := coderdtest.CreateFirstUser(t, client)
 
 	validValues := []string{"force_on", "default_on", "default_off"}
 	for _, av := range validValues {
@@ -510,7 +531,7 @@ func TestMCPServerConfigsAvailability(t *testing.T) {
 		t.Run(av, func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.Context(t, testutil.WaitLong)
-			created, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+			created, err := client.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 				DisplayName:   "Server " + av,
 				Slug:          "server-" + av,
 				Transport:     "streamable_http",
@@ -529,7 +550,7 @@ func TestMCPServerConfigsAvailability(t *testing.T) {
 	t.Run("InvalidAvailability", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
-		_, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+		_, err := client.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 			DisplayName:   "Bad Availability",
 			Slug:          "bad-avail",
 			Transport:     "streamable_http",
@@ -552,9 +573,9 @@ func TestMCPServerConfigsUniqueSlug(t *testing.T) {
 
 	ctx := testutil.Context(t, testutil.WaitLong)
 	client := newMCPClient(t)
-	_ = coderdtest.CreateFirstUser(t, client)
+	firstUser := coderdtest.CreateFirstUser(t, client)
 
-	_, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+	_, err := client.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 		DisplayName:   "First",
 		Slug:          "test-server",
 		Transport:     "streamable_http",
@@ -568,7 +589,7 @@ func TestMCPServerConfigsUniqueSlug(t *testing.T) {
 	require.NoError(t, err)
 
 	// Attempt to create another config with the same slug.
-	_, err = client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+	_, err = client.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 		DisplayName:   "Second",
 		Slug:          "test-server",
 		Transport:     "streamable_http",
@@ -600,7 +621,7 @@ func TestMCPServerConfigsOAuth2Disconnect(t *testing.T) {
 		firstUser := coderdtest.CreateFirstUser(t, adminClient)
 		memberClient, member := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
 
-		created, err := adminClient.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+		created, err := adminClient.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 			DisplayName:         "OAuth Disconnect " + slug,
 			Slug:                slug,
 			Transport:           "streamable_http",
@@ -658,45 +679,6 @@ func TestMCPServerConfigsOAuth2Disconnect(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, resp.TokenRevoked)
 		require.Empty(t, resp.TokenRevocationError)
-	})
-
-	t.Run("DoesNotRevealHiddenConfigs", func(t *testing.T) {
-		t.Parallel()
-
-		ctx := testutil.Context(t, testutil.WaitLong)
-		providerKeys := coderdtest.FakeOpenAICompatProviderAPIKeys(t)
-		adminClient, _ := coderdtest.NewWithDatabase(t, &coderdtest.Options{
-			DeploymentValues:    mcpDeploymentValues(t),
-			ChatProviderAPIKeys: &providerKeys,
-		})
-		firstUser := coderdtest.CreateFirstUser(t, adminClient)
-		memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
-
-		created, err := adminClient.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
-			DisplayName:    "OAuth Disconnect Hidden",
-			Slug:           "disc-hidden",
-			Transport:      "streamable_http",
-			URL:            "https://mcp.example.com/disc-hidden",
-			AuthType:       "oauth2",
-			OAuth2ClientID: "cid",
-			OAuth2AuthURL:  "https://auth.example.com/authorize",
-			OAuth2TokenURL: "https://auth.example.com/token",
-			Availability:   "default_on",
-			Enabled:        false,
-			ToolAllowList:  []string{},
-			ToolDenyList:   []string{},
-		})
-		require.NoError(t, err)
-
-		// Disconnecting a disabled config the member cannot see must be
-		// indistinguishable from disconnecting a nonexistent config ID.
-		hiddenResp, err := memberClient.MCPServerOAuth2DisconnectWithResponse(ctx, created.ID)
-		require.NoError(t, err)
-		missingResp, err := memberClient.MCPServerOAuth2DisconnectWithResponse(ctx, uuid.New())
-		require.NoError(t, err)
-		require.Equal(t, missingResp, hiddenResp)
-		require.False(t, hiddenResp.TokenRevoked)
-		require.Empty(t, hiddenResp.TokenRevocationError)
 	})
 
 	t.Run("RevokesAtProvider", func(t *testing.T) {
@@ -757,7 +739,7 @@ func TestMCPServerConfigsOAuth2Disconnect(t *testing.T) {
 		firstUser := coderdtest.CreateFirstUser(t, adminClient)
 		memberClient, member := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
 
-		created, err := adminClient.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+		created, err := adminClient.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 			DisplayName:    "OAuth Disconnect Refresh Race",
 			Slug:           "disc-refresh-race",
 			Transport:      "streamable_http",
@@ -790,7 +772,7 @@ func TestMCPServerConfigsOAuth2Disconnect(t *testing.T) {
 		}
 		result := make(chan configResult, 1)
 		go func() {
-			configs, listErr := memberClient.MCPServerConfigs(ctx)
+			configs, listErr := memberClient.MCPServerConfigs(ctx, firstUser.OrganizationID)
 			result <- configResult{configs: configs, err: listErr}
 		}()
 
@@ -866,7 +848,7 @@ func TestMCPServerConfigsOAuth2Disconnect(t *testing.T) {
 		memberClient, member := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
 		otherClient, other := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
 
-		created, err := adminClient.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+		created, err := adminClient.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 			DisplayName:    "OAuth Disconnect Isolation",
 			Slug:           "disc-isolation",
 			Transport:      "streamable_http",
@@ -896,7 +878,7 @@ func TestMCPServerConfigsOAuth2Disconnect(t *testing.T) {
 
 		requireAuthConnected := func(client *codersdk.Client, want bool) {
 			t.Helper()
-			configs, err := client.MCPServerConfigs(ctx)
+			configs, err := client.MCPServerConfigs(ctx, firstUser.OrganizationID)
 			require.NoError(t, err)
 			require.Len(t, configs, 1)
 			require.Equal(t, want, configs[0].AuthConnected)
@@ -974,11 +956,11 @@ func TestMCPServerConfigsOAuth2AutoDiscovery(t *testing.T) {
 		t.Cleanup(mcpServer.Close)
 
 		client := newMCPClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client)
 
 		// Create config with auth_type=oauth2 but no OAuth2 fields —
 		// the server should auto-discover them.
-		created, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+		created, err := client.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 			DisplayName:   "Auto-Discovery Server",
 			Slug:          "auto-discovery",
 			Transport:     "streamable_http",
@@ -998,7 +980,7 @@ func TestMCPServerConfigsOAuth2AutoDiscovery(t *testing.T) {
 		require.Equal(t, "read write", created.OAuth2Scopes)
 
 		// An explicit revocation URL wins over the discovered one.
-		overridden, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+		overridden, err := client.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 			DisplayName:         "Auto-Discovery Override",
 			Slug:                "auto-discovery-override",
 			Transport:           "streamable_http",
@@ -1109,9 +1091,9 @@ func TestMCPServerConfigsOAuth2AutoDiscovery(t *testing.T) {
 		t.Cleanup(mcpServer.Close)
 
 		client := newMCPClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client)
 
-		created, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+		created, err := client.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 			DisplayName:   "Priority Test",
 			Slug:          "priority-test",
 			Transport:     "streamable_http",
@@ -1185,9 +1167,9 @@ func TestMCPServerConfigsOAuth2AutoDiscovery(t *testing.T) {
 		t.Cleanup(mcpServer.Close)
 
 		client := newMCPClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client)
 
-		created, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+		created, err := client.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 			DisplayName:   "Root Fallback Server",
 			Slug:          "root-fallback",
 			Transport:     "streamable_http",
@@ -1263,9 +1245,9 @@ func TestMCPServerConfigsOAuth2AutoDiscovery(t *testing.T) {
 		t.Cleanup(mcpServer.Close)
 
 		client := newMCPClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client)
 
-		created, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+		created, err := client.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 			DisplayName:   "Path-Aware Auth",
 			Slug:          "path-aware-auth",
 			Transport:     "streamable_http",
@@ -1359,11 +1341,11 @@ func TestMCPServerConfigsOAuth2AutoDiscovery(t *testing.T) {
 		t.Cleanup(mcpServer.Close)
 
 		client := newMCPClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client)
 
 		// Create config with auth_type=oauth2 but no OAuth2 fields to
 		// trigger auto-discovery and dynamic client registration.
-		created, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+		created, err := client.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 			DisplayName:   "Redirect URI Test",
 			Slug:          "redirect-uri-test",
 			Transport:     "streamable_http",
@@ -1401,7 +1383,7 @@ func TestMCPServerConfigsOAuth2AutoDiscovery(t *testing.T) {
 
 		// Sanity-check the full path structure.
 		require.Contains(t, redirectURI,
-			"/api/experimental/mcp/servers/"+created.ID.String()+"/oauth2/callback",
+			"/api/experimental/mcp-servers/"+created.ID.String()+"/oauth2/callback",
 			"redirect URI should have the expected callback path")
 
 		// Double-check that the ID segment is a valid UUID (not some
@@ -1425,10 +1407,10 @@ func TestMCPServerConfigsOAuth2AutoDiscovery(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newMCPClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client)
 
 		// Provide client_id but omit auth_url and token_url.
-		_, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+		_, err := client.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 			DisplayName:    "Partial Fields",
 			Slug:           "partial-oauth2",
 			Transport:      "streamable_http",
@@ -1461,9 +1443,9 @@ func TestMCPServerConfigsOAuth2AutoDiscovery(t *testing.T) {
 		t.Cleanup(mcpServer.Close)
 
 		client := newMCPClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client)
 
-		_, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+		_, err := client.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 			DisplayName:   "Will Fail",
 			Slug:          "discovery-fail",
 			Transport:     "streamable_http",
@@ -1486,10 +1468,10 @@ func TestMCPServerConfigsOAuth2AutoDiscovery(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newMCPClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client)
 
 		// Providing all three OAuth2 fields bypasses discovery entirely.
-		created, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+		created, err := client.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 			DisplayName:    "Manual Config",
 			Slug:           "manual-oauth2",
 			Transport:      "streamable_http",
@@ -1523,7 +1505,7 @@ func TestMCPServerOAuth2PKCE(t *testing.T) {
 		memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
 
 		// Create an OAuth2 MCP server config.
-		created, err := adminClient.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+		created, err := adminClient.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 			DisplayName:    "PKCE Test",
 			Slug:           "pkce-test",
 			Transport:      "streamable_http",
@@ -1546,7 +1528,7 @@ func TestMCPServerOAuth2PKCE(t *testing.T) {
 		}
 
 		connectURL, err := memberClient.URL.Parse(
-			"/api/experimental/mcp/servers/" + created.ID.String() + "/oauth2/connect",
+			"/api/experimental/mcp-servers/" + created.ID.String() + "/oauth2/connect",
 		)
 		require.NoError(t, err)
 
@@ -1620,7 +1602,7 @@ func TestMCPServerOAuth2PKCE(t *testing.T) {
 		firstUser := coderdtest.CreateFirstUser(t, adminClient)
 		memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
 
-		created, err := adminClient.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+		created, err := adminClient.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 			DisplayName:    "PKCE Callback Test",
 			Slug:           "pkce-callback",
 			Transport:      "streamable_http",
@@ -1645,7 +1627,7 @@ func TestMCPServerOAuth2PKCE(t *testing.T) {
 		verifier := "test-verifier-value-that-is-at-least-43-chars-long-for-pkce-spec"
 
 		callbackURL, err := memberClient.URL.Parse(
-			"/api/experimental/mcp/servers/" + created.ID.String() + "/oauth2/callback",
+			"/api/experimental/mcp-servers/" + created.ID.String() + "/oauth2/callback",
 		)
 		require.NoError(t, err)
 		q := callbackURL.Query()
@@ -1717,7 +1699,7 @@ func TestMCPServerOAuth2PKCE(t *testing.T) {
 		firstUser := coderdtest.CreateFirstUser(t, adminClient)
 		memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
 
-		created, err := adminClient.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+		created, err := adminClient.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 			DisplayName:    "No PKCE Callback",
 			Slug:           "no-pkce-callback",
 			Transport:      "streamable_http",
@@ -1741,7 +1723,7 @@ func TestMCPServerOAuth2PKCE(t *testing.T) {
 		// backwards compatibility with providers that don't use PKCE.
 		state := "test-state-no-pkce"
 		callbackURL, err := memberClient.URL.Parse(
-			"/api/experimental/mcp/servers/" + created.ID.String() + "/oauth2/callback",
+			"/api/experimental/mcp-servers/" + created.ID.String() + "/oauth2/callback",
 		)
 		require.NoError(t, err)
 		q := callbackURL.Query()
@@ -1783,8 +1765,8 @@ func TestChatWithMCPServerIDs(t *testing.T) {
 	_ = createChatModelConfigForMCP(t, expClient)
 
 	// Create enabled MCP server configs.
-	mcpConfigA := createMCPServerConfig(t, client, "chat-mcp-server-a", true)
-	mcpConfigB := createMCPServerConfig(t, client, "chat-mcp-server-b", true)
+	mcpConfigA := createMCPServerConfig(t, client, firstUser.OrganizationID, "chat-mcp-server-a", true)
+	mcpConfigB := createMCPServerConfig(t, client, firstUser.OrganizationID, "chat-mcp-server-b", true)
 
 	// Create a chat referencing the MCP servers.
 	chat, err := expClient.CreateChat(ctx, codersdk.CreateChatRequest{
@@ -1886,9 +1868,9 @@ func TestMCPOAuth2DiscoveryEdgeCases(t *testing.T) {
 			t.Cleanup(mcpServer.Close)
 
 			client := newMCPClient(t)
-			_ = coderdtest.CreateFirstUser(t, client)
+			firstUser := coderdtest.CreateFirstUser(t, client)
 
-			created, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+			created, err := client.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 				DisplayName:   "Empty Auth Servers Fallback",
 				Slug:          "empty-as-fallback",
 				Transport:     "streamable_http",
@@ -1929,9 +1911,9 @@ func TestMCPOAuth2DiscoveryEdgeCases(t *testing.T) {
 			t.Cleanup(mcpServer.Close)
 
 			client := newMCPClient(t)
-			_ = coderdtest.CreateFirstUser(t, client)
+			firstUser := coderdtest.CreateFirstUser(t, client)
 
-			_, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+			_, err := client.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 				DisplayName:   "Both Empty",
 				Slug:          "both-empty-as",
 				Transport:     "streamable_http",
@@ -2005,9 +1987,9 @@ func TestMCPOAuth2DiscoveryEdgeCases(t *testing.T) {
 		t.Cleanup(mcpServer.Close)
 
 		client := newMCPClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client)
 
-		created, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+		created, err := client.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 			DisplayName:   "Malformed JSON Fallback",
 			Slug:          "malformed-json",
 			Transport:     "streamable_http",
@@ -2088,9 +2070,9 @@ func TestMCPOAuth2DiscoveryEdgeCases(t *testing.T) {
 		t.Cleanup(mcpServer.Close)
 
 		client := newMCPClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client)
 
-		created, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+		created, err := client.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 			DisplayName:   "Missing Endpoints Fallback",
 			Slug:          "missing-endpoints",
 			Transport:     "streamable_http",
@@ -2164,9 +2146,9 @@ func TestMCPOAuth2DiscoveryEdgeCases(t *testing.T) {
 		t.Cleanup(mcpServer.Close)
 
 		client := newMCPClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client)
 
-		created, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+		created, err := client.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 			DisplayName:   "OIDC Fallback",
 			Slug:          "oidc-fallback",
 			Transport:     "streamable_http",
@@ -2236,9 +2218,9 @@ func TestMCPOAuth2DiscoveryEdgeCases(t *testing.T) {
 		t.Cleanup(mcpServer.Close)
 
 		client := newMCPClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client)
 
-		_, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+		_, err := client.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 			DisplayName:   "Missing Client ID",
 			Slug:          "missing-client-id",
 			Transport:     "streamable_http",
@@ -2310,11 +2292,11 @@ func TestMCPOAuth2DiscoveryEdgeCases(t *testing.T) {
 		t.Cleanup(mcpServer.Close)
 
 		client := newMCPClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client)
 
 		// URL has a trailing slash, matching the GitHub Copilot URL
 		// pattern: https://api.githubcopilot.com/mcp/
-		created, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+		created, err := client.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 			DisplayName:   "Trailing Slash",
 			Slug:          "trailing-slash",
 			Transport:     "streamable_http",
@@ -2352,7 +2334,7 @@ func TestMCPServerConfigsRevokedGrant(t *testing.T) {
 	}))
 	t.Cleanup(tokenSrv.Close)
 
-	created, err := adminClient.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+	created, err := adminClient.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 		DisplayName:    "Revoked Server",
 		Slug:           "revoked-server",
 		Transport:      "streamable_http",
@@ -2384,7 +2366,7 @@ func TestMCPServerConfigsRevokedGrant(t *testing.T) {
 
 	// First list: the refresh fails permanently, so the server is
 	// reported as not connected and the failure is persisted.
-	configs, err := memberClient.MCPServerConfigs(ctx)
+	configs, err := memberClient.MCPServerConfigs(ctx, firstUser.OrganizationID)
 	require.NoError(t, err)
 	require.Len(t, configs, 1)
 	require.False(t, configs[0].AuthConnected)
@@ -2406,7 +2388,7 @@ func TestMCPServerConfigsRevokedGrant(t *testing.T) {
 
 	// Second list: the cached failure short-circuits, so the provider
 	// is not called again.
-	configs, err = memberClient.MCPServerConfigs(ctx)
+	configs, err = memberClient.MCPServerConfigs(ctx, firstUser.OrganizationID)
 	require.NoError(t, err)
 	require.Len(t, configs, 1)
 	require.False(t, configs[0].AuthConnected)
@@ -2447,7 +2429,7 @@ func TestMCPServerConfigsRevokedGrant(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	configs, err = memberClient.MCPServerConfigs(ctx)
+	configs, err = memberClient.MCPServerConfigs(ctx, firstUser.OrganizationID)
 	require.NoError(t, err)
 	require.Len(t, configs, 1)
 	require.True(t, configs[0].AuthConnected)
@@ -2472,7 +2454,7 @@ func TestMCPServerConfigsTransientRefreshFailure(t *testing.T) {
 	}))
 	t.Cleanup(tokenSrv.Close)
 
-	created, err := adminClient.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+	created, err := adminClient.CreateMCPServerConfig(ctx, firstUser.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 		DisplayName:    "Flaky Server",
 		Slug:           "flaky-server",
 		Transport:      "streamable_http",
@@ -2499,7 +2481,7 @@ func TestMCPServerConfigsTransientRefreshFailure(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	configs, err := memberClient.MCPServerConfigs(ctx)
+	configs, err := memberClient.MCPServerConfigs(ctx, firstUser.OrganizationID)
 	require.NoError(t, err)
 	require.Len(t, configs, 1)
 	require.False(t, configs[0].AuthConnected)

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -384,7 +384,7 @@ func TestPlanModeSubagentChatExcludesAskUserQuestion(t *testing.T) {
 	mcpTS := httptest.NewServer(mcpserver.NewStreamableHTTPServer(mcpSrv))
 	t.Cleanup(mcpTS.Close)
 
-	mcpConfig, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+	mcpConfig, err := client.CreateMCPServerConfig(ctx, user.OrganizationID, codersdk.CreateMCPServerConfigRequest{
 		DisplayName:     "Plan Root MCP",
 		Slug:            "plan-root-mcp",
 		Transport:       "streamable_http",

--- a/codersdk/mcp.go
+++ b/codersdk/mcp.go
@@ -14,7 +14,7 @@ import (
 // start the OAuth2 flow for an MCP server. The frontend opens this
 // in a new window/popup.
 func (c *Client) MCPServerOAuth2ConnectURL(id uuid.UUID) string {
-	return fmt.Sprintf("%s/api/experimental/mcp/servers/%s/oauth2/connect", c.URL.String(), id)
+	return fmt.Sprintf("%s/api/experimental/mcp-servers/%s/oauth2/connect", c.URL.String(), id)
 }
 
 // MCPServerOAuth2DisconnectResponse reports whether the removed token
@@ -35,7 +35,7 @@ func (c *Client) MCPServerOAuth2Disconnect(ctx context.Context, id uuid.UUID) er
 // MCPServerOAuth2DisconnectWithResponse removes the user's OAuth2
 // token for an MCP server and reports the provider revocation outcome.
 func (c *Client) MCPServerOAuth2DisconnectWithResponse(ctx context.Context, id uuid.UUID) (MCPServerOAuth2DisconnectResponse, error) {
-	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/experimental/mcp/servers/%s/oauth2/disconnect", id), nil)
+	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/experimental/mcp-servers/%s/oauth2/disconnect", id), nil)
 	if err != nil {
 		return MCPServerOAuth2DisconnectResponse{}, err
 	}
@@ -53,11 +53,12 @@ func (c *Client) MCPServerOAuth2DisconnectWithResponse(ctx context.Context, id u
 
 // MCPServerConfig represents an admin-configured MCP server.
 type MCPServerConfig struct {
-	ID          uuid.UUID `json:"id" format:"uuid"`
-	DisplayName string    `json:"display_name"`
-	Slug        string    `json:"slug"`
-	Description string    `json:"description"`
-	IconURL     string    `json:"icon_url"`
+	ID             uuid.UUID `json:"id" format:"uuid"`
+	OrganizationID uuid.UUID `json:"organization_id" format:"uuid"`
+	DisplayName    string    `json:"display_name"`
+	Slug           string    `json:"slug"`
+	Description    string    `json:"description"`
+	IconURL        string    `json:"icon_url"`
 
 	Transport string `json:"transport"` // "streamable_http" or "sse"
 	URL       string `json:"url"`
@@ -174,8 +175,8 @@ type UpdateMCPServerConfigRequest struct {
 	ForwardCoderHeaders *bool `json:"forward_coder_headers,omitempty"`
 }
 
-func (c *Client) MCPServerConfigs(ctx context.Context) ([]MCPServerConfig, error) {
-	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/mcp/servers", nil)
+func (c *Client) MCPServerConfigs(ctx context.Context, organizationID uuid.UUID) ([]MCPServerConfig, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/organizations/%s/mcp-servers", organizationID), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +189,7 @@ func (c *Client) MCPServerConfigs(ctx context.Context) ([]MCPServerConfig, error
 }
 
 func (c *Client) MCPServerConfigByID(ctx context.Context, id uuid.UUID) (MCPServerConfig, error) {
-	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/mcp/servers/%s", id), nil)
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/mcp-servers/%s", id), nil)
 	if err != nil {
 		return MCPServerConfig{}, err
 	}
@@ -200,8 +201,8 @@ func (c *Client) MCPServerConfigByID(ctx context.Context, id uuid.UUID) (MCPServ
 	return config, json.NewDecoder(res.Body).Decode(&config)
 }
 
-func (c *Client) CreateMCPServerConfig(ctx context.Context, req CreateMCPServerConfigRequest) (MCPServerConfig, error) {
-	res, err := c.Request(ctx, http.MethodPost, "/api/experimental/mcp/servers", req)
+func (c *Client) CreateMCPServerConfig(ctx context.Context, organizationID uuid.UUID, req CreateMCPServerConfigRequest) (MCPServerConfig, error) {
+	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/experimental/organizations/%s/mcp-servers", organizationID), req)
 	if err != nil {
 		return MCPServerConfig{}, err
 	}
@@ -214,7 +215,7 @@ func (c *Client) CreateMCPServerConfig(ctx context.Context, req CreateMCPServerC
 }
 
 func (c *Client) UpdateMCPServerConfig(ctx context.Context, id uuid.UUID, req UpdateMCPServerConfigRequest) (MCPServerConfig, error) {
-	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/experimental/mcp/servers/%s", id), req)
+	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/experimental/mcp-servers/%s", id), req)
 	if err != nil {
 		return MCPServerConfig{}, err
 	}
@@ -227,7 +228,7 @@ func (c *Client) UpdateMCPServerConfig(ctx context.Context, id uuid.UUID, req Up
 }
 
 func (c *Client) DeleteMCPServerConfig(ctx context.Context, id uuid.UUID) error {
-	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/experimental/mcp/servers/%s", id), nil)
+	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/experimental/mcp-servers/%s", id), nil)
 	if err != nil {
 		return err
 	}

--- a/enterprise/coderd/mcp_test.go
+++ b/enterprise/coderd/mcp_test.go
@@ -1,0 +1,127 @@
+package coderd_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/util/ptr"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
+	"github.com/coder/coder/v2/enterprise/coderd/license"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func createMCPServerConfigForOrganization(
+	t testing.TB,
+	client *codersdk.Client,
+	organizationID uuid.UUID,
+	slug string,
+) codersdk.MCPServerConfig {
+	t.Helper()
+
+	config, err := client.CreateMCPServerConfig(
+		testutil.Context(t, testutil.WaitLong),
+		organizationID,
+		codersdk.CreateMCPServerConfigRequest{
+			DisplayName:   slug,
+			Slug:          slug,
+			Transport:     "streamable_http",
+			URL:           "https://mcp.example.com/" + slug,
+			AuthType:      "none",
+			Availability:  "default_on",
+			Enabled:       true,
+			ToolAllowList: []string{},
+			ToolDenyList:  []string{},
+		},
+	)
+	require.NoError(t, err)
+	return config
+}
+
+func requireMCPServerConfigRequestStatus(
+	t *testing.T,
+	client *codersdk.Client,
+	method string,
+	configID uuid.UUID,
+	pathSuffix string,
+	body any,
+	wantStatus int,
+) {
+	t.Helper()
+
+	res, err := client.Request(
+		testutil.Context(t, testutil.WaitLong),
+		method,
+		"/api/experimental/mcp-servers/"+configID.String()+pathSuffix,
+		body,
+	)
+	require.NoError(t, err)
+	defer res.Body.Close()
+	require.Equal(t, wantStatus, res.StatusCode)
+}
+
+func TestMCPServerConfigCollectionOrganizationIsolation(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client, firstUser := coderdenttest.New(t, &coderdenttest.Options{
+		LicenseOptions: &coderdenttest.LicenseOptions{
+			Features: license.Features{
+				codersdk.FeatureMultipleOrganizations: 1,
+			},
+		},
+	})
+	secondOrg := coderdenttest.CreateOrganization(t, client, coderdenttest.CreateOrganizationOptions{})
+	firstConfig := createMCPServerConfigForOrganization(t, client, firstUser.OrganizationID, "org-one-mcp")
+	secondConfig := createMCPServerConfigForOrganization(t, client, secondOrg.ID, "org-two-mcp")
+
+	firstConfigs, err := client.MCPServerConfigs(ctx, firstUser.OrganizationID)
+	require.NoError(t, err)
+	require.Len(t, firstConfigs, 1)
+	require.Equal(t, firstConfig.ID, firstConfigs[0].ID)
+	require.Equal(t, firstUser.OrganizationID, firstConfigs[0].OrganizationID)
+
+	secondConfigs, err := client.MCPServerConfigs(ctx, secondOrg.ID)
+	require.NoError(t, err)
+	require.Len(t, secondConfigs, 1)
+	require.Equal(t, secondConfig.ID, secondConfigs[0].ID)
+	require.Equal(t, secondOrg.ID, secondConfigs[0].OrganizationID)
+}
+
+func TestMCPServerConfigItemCrossOrganizationConcealment(t *testing.T) {
+	t.Parallel()
+
+	client, firstUser := coderdenttest.New(t, &coderdenttest.Options{
+		LicenseOptions: &coderdenttest.LicenseOptions{
+			Features: license.Features{
+				codersdk.FeatureMultipleOrganizations: 1,
+			},
+		},
+	})
+	secondOrg := coderdenttest.CreateOrganization(t, client, coderdenttest.CreateOrganizationOptions{})
+	otherClient, _ := coderdtest.CreateAnotherUser(t, client, secondOrg.ID)
+	config := createMCPServerConfigForOrganization(t, client, firstUser.OrganizationID, "private-org-one-mcp")
+
+	for _, test := range []struct {
+		name       string
+		method     string
+		pathSuffix string
+		body       any
+	}{
+		{name: "Get", method: http.MethodGet},
+		{name: "Patch", method: http.MethodPatch, body: codersdk.UpdateMCPServerConfigRequest{DisplayName: ptr.Ref("cross-org")}},
+		{name: "Delete", method: http.MethodDelete},
+		{name: "OAuthConnect", method: http.MethodGet, pathSuffix: "/oauth2/connect"},
+		{name: "OAuthCallback", method: http.MethodGet, pathSuffix: "/oauth2/callback"},
+		{name: "OAuthDisconnect", method: http.MethodDelete, pathSuffix: "/oauth2/disconnect"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			requireMCPServerConfigRequestStatus(t, otherClient, test.method, config.ID, test.pathSuffix, test.body, http.StatusNotFound)
+		})
+	}
+}

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -5722,6 +5722,7 @@ export interface LoginWithPasswordResponse {
  */
 export interface MCPServerConfig {
 	readonly id: string;
+	readonly organization_id: string;
 	readonly display_name: string;
 	readonly slug: string;
 	readonly description: string;


### PR DESCRIPTION
Review-only slice 3 of 5. This PR must not merge separately. Expected intermediate CI failures may be resolved by later stack units.

Moves MCP collection APIs under organizations and hard-cuts SDK callers to organization-aware contracts. Item and OAuth operations derive the owning organization and conceal unauthorized IDs without compatibility routes or fallback behavior. Frontend caller migration remains in the coordinated frontend units.

Parent: #27381
Next: #27383
Base: `mathias/codagt-711-mcp-rbac`

<details>
<summary>Coordinated stack direction</summary>

The stack first establishes organization-owned MCP data, then adds organization RBAC, organization-scoped API and OAuth contracts, ACL sharing, and chat selection/runtime enforcement. Coordinated frontend follow-ups, including CODAGT-714, own organization selection and migration of MCP page callers after the backend contracts are complete. No compatibility routes, optional organization arguments, global fallback, dual reads, or per-turn ACL revocation checks are introduced.

</details>

Refs CODAGT-711

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
