### PR TITLE
feat: scope MCP chat runtime

### DIFF
--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -1320,34 +1320,8 @@ func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate MCP server IDs exist.
-	if len(req.MCPServerIDs) > 0 {
-		//nolint:gocritic // Need to validate MCP server IDs exist.
-		existingConfigs, err := api.Database.GetMCPServerConfigsByIDs(dbauthz.AsSystemRestricted(ctx), req.MCPServerIDs)
-		if err != nil {
-			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-				Message: "Failed to validate MCP server IDs.",
-				Detail:  err.Error(),
-			})
-			return
-		}
-		if len(existingConfigs) != len(req.MCPServerIDs) {
-			found := make(map[uuid.UUID]struct{}, len(existingConfigs))
-			for _, c := range existingConfigs {
-				found[c.ID] = struct{}{}
-			}
-			var missing []string
-			for _, id := range req.MCPServerIDs {
-				if _, ok := found[id]; !ok {
-					missing = append(missing, id.String())
-				}
-			}
-			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-				Message: "One or more MCP server IDs are invalid.",
-				Detail:  fmt.Sprintf("Invalid IDs: %s", strings.Join(missing, ", ")),
-			})
-			return
-		}
+	if !api.validateMCPServerSelection(rw, r, req.OrganizationID, req.MCPServerIDs) {
+		return
 	}
 
 	mcpServerIDs := req.MCPServerIDs
@@ -3275,6 +3249,51 @@ func writeCommonChatMutationError(ctx context.Context, rw http.ResponseWriter, e
 	return true
 }
 
+func (api *API) validateMCPServerSelection(rw http.ResponseWriter, r *http.Request, organizationID uuid.UUID, requestedIDs []uuid.UUID) bool {
+	if len(requestedIDs) == 0 {
+		return true
+	}
+
+	distinctIDs := make([]uuid.UUID, 0, len(requestedIDs))
+	seen := make(map[uuid.UUID]struct{}, len(requestedIDs))
+	for _, id := range requestedIDs {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		distinctIDs = append(distinctIDs, id)
+	}
+
+	ctx := r.Context()
+	//nolint:gocritic // Rows are loaded system-restricted so authorization can be checked against each ACL-bearing object.
+	configs, err := api.Database.GetMCPServerConfigsByIDs(dbauthz.AsSystemRestricted(ctx), database.GetMCPServerConfigsByIDsParams{
+		OrganizationID: organizationID,
+		IDs:            distinctIDs,
+	})
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to validate MCP server IDs.",
+			Detail:  err.Error(),
+		})
+		return false
+	}
+	if len(configs) != len(distinctIDs) {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "One or more MCP server IDs are invalid.",
+		})
+		return false
+	}
+	for _, config := range configs {
+		if !config.Enabled || !api.Authorize(r, policy.ActionRead, config) {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "One or more MCP server IDs are invalid.",
+			})
+			return false
+		}
+	}
+	return true
+}
+
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
 //
 // @Summary Send chat message
@@ -3339,34 +3358,8 @@ func (api *API) postChatMessages(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate MCP server IDs exist.
-	if req.MCPServerIDs != nil && len(*req.MCPServerIDs) > 0 {
-		//nolint:gocritic // Need to validate MCP server IDs exist.
-		existingConfigs, err := api.Database.GetMCPServerConfigsByIDs(dbauthz.AsSystemRestricted(ctx), *req.MCPServerIDs)
-		if err != nil {
-			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-				Message: "Failed to validate MCP server IDs.",
-				Detail:  err.Error(),
-			})
-			return
-		}
-		if len(existingConfigs) != len(*req.MCPServerIDs) {
-			found := make(map[uuid.UUID]struct{}, len(existingConfigs))
-			for _, c := range existingConfigs {
-				found[c.ID] = struct{}{}
-			}
-			var missing []string
-			for _, id := range *req.MCPServerIDs {
-				if _, ok := found[id]; !ok {
-					missing = append(missing, id.String())
-				}
-			}
-			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-				Message: "One or more MCP server IDs are invalid.",
-				Detail:  fmt.Sprintf("Invalid IDs: %s", strings.Join(missing, ", ")),
-			})
-			return
-		}
+	if req.MCPServerIDs != nil && !api.validateMCPServerSelection(rw, r, chat.OrganizationID, *req.MCPServerIDs) {
+		return
 	}
 
 	if req.PlanMode != nil {

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -736,18 +736,20 @@ func TestExploreChatUsesPersistedMCPSnapshot(t *testing.T) {
 		},
 	)
 	mcpConfig := dbgen.MCPServerConfig(t, db, database.MCPServerConfig{
-		DisplayName: "External Snapshot MCP",
-		Slug:        "external-snapshot-mcp",
-		Url:         externalMCPServer.URL,
-		CreatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
-		UpdatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
+		DisplayName:    "External Snapshot MCP",
+		OrganizationID: org.ID,
+		Slug:           "external-snapshot-mcp",
+		Url:            externalMCPServer.URL,
+		CreatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
+		UpdatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
 	})
 	dbgen.MCPServerConfig(t, db, database.MCPServerConfig{
-		DisplayName: "Second MCP",
-		Slug:        "second-mcp",
-		Url:         secondMCPServer.URL,
-		CreatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
-		UpdatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
+		DisplayName:    "Second MCP",
+		OrganizationID: org.ID,
+		Slug:           "second-mcp",
+		Url:            secondMCPServer.URL,
+		CreatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
+		UpdatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
 	})
 
 	ws, dbAgent := seedWorkspaceWithAgent(t, db, user.ID)
@@ -881,11 +883,12 @@ func TestRootExploreChatStaysBuiltinOnlyAtRuntime(t *testing.T) {
 
 	user, org, model := seedChatDependenciesWithProvider(t, db, "openai-compat", openAIURL)
 	mcpConfig := dbgen.MCPServerConfig(t, db, database.MCPServerConfig{
-		DisplayName: "Root Explore Runtime MCP",
-		Slug:        "root-explore-runtime-mcp",
-		Url:         externalMCPServer.URL,
-		CreatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
-		UpdatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
+		DisplayName:    "Root Explore Runtime MCP",
+		OrganizationID: org.ID,
+		Slug:           "root-explore-runtime-mcp",
+		Url:            externalMCPServer.URL,
+		CreatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
+		UpdatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
 	})
 
 	factory := chattest.NewMockAIBridgeTransport(t, openAIURL)
@@ -1089,18 +1092,20 @@ func TestExploreChatSendMessageCannotMutateMCPSnapshot(t *testing.T) {
 
 	user, org, model := seedChatDependenciesWithProvider(t, db, "openai-compat", openAIURL)
 	parentConfig := dbgen.MCPServerConfig(t, db, database.MCPServerConfig{
-		DisplayName: "Runtime Parent MCP",
-		Slug:        "runtime-parent-mcp",
-		Url:         parentTS.URL,
-		CreatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
-		UpdatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
+		DisplayName:    "Runtime Parent MCP",
+		OrganizationID: org.ID,
+		Slug:           "runtime-parent-mcp",
+		Url:            parentTS.URL,
+		CreatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
+		UpdatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
 	})
 	injectedConfig := dbgen.MCPServerConfig(t, db, database.MCPServerConfig{
-		DisplayName: "Runtime Injected MCP",
-		Slug:        "runtime-injected-mcp",
-		Url:         injectedTS.URL,
-		CreatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
-		UpdatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
+		DisplayName:    "Runtime Injected MCP",
+		OrganizationID: org.ID,
+		Slug:           "runtime-injected-mcp",
+		Url:            injectedTS.URL,
+		CreatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
+		UpdatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
 	})
 
 	factory := chattest.NewMockAIBridgeTransport(t, openAIURL)
@@ -1257,6 +1262,7 @@ func TestPlanModeRootChatAllowsApprovedExternalMCPTools(t *testing.T) {
 
 	approvedConfig := dbgen.MCPServerConfig(t, db, database.MCPServerConfig{
 		DisplayName:     "Plan Approved MCP",
+		OrganizationID:  org.ID,
 		Slug:            "plan-approved-mcp",
 		Url:             echoTS.URL,
 		AllowInPlanMode: true,
@@ -1265,15 +1271,17 @@ func TestPlanModeRootChatAllowsApprovedExternalMCPTools(t *testing.T) {
 	})
 
 	blockedConfig := dbgen.MCPServerConfig(t, db, database.MCPServerConfig{
-		DisplayName: "Plan Blocked MCP",
-		Slug:        "plan-blocked-mcp",
-		Url:         echoTS.URL,
-		CreatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
-		UpdatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
+		DisplayName:    "Plan Blocked MCP",
+		OrganizationID: org.ID,
+		Slug:           "plan-blocked-mcp",
+		Url:            echoTS.URL,
+		CreatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
+		UpdatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
 	})
 
 	filteredConfig := dbgen.MCPServerConfig(t, db, database.MCPServerConfig{
 		DisplayName:     "Plan Filtered MCP",
+		OrganizationID:  org.ID,
 		Slug:            "plan-filtered-mcp",
 		Url:             filteredTS.URL,
 		AllowInPlanMode: true,
@@ -10690,11 +10698,12 @@ func TestMCPServerToolInvocation(t *testing.T) {
 	// happen after seedChatDependencies so user.ID exists for
 	// the foreign key.
 	mcpConfig := dbgen.MCPServerConfig(t, db, database.MCPServerConfig{
-		DisplayName: "Test MCP",
-		Slug:        "test-mcp",
-		Url:         mcpTS.URL,
-		CreatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
-		UpdatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
+		DisplayName:    "Test MCP",
+		OrganizationID: org.ID,
+		Slug:           "test-mcp",
+		Url:            mcpTS.URL,
+		CreatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
+		UpdatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
 	})
 
 	ws, dbAgent := seedWorkspaceWithAgent(t, db, user.ID)
@@ -10864,6 +10873,7 @@ func TestPlanModeRootChatApprovedExternalMCPToolInvocation(t *testing.T) {
 
 	mcpConfig := dbgen.MCPServerConfig(t, db, database.MCPServerConfig{
 		DisplayName:     "Plan Mode MCP",
+		OrganizationID:  org.ID,
 		Slug:            "plan-mode-mcp",
 		Url:             mcpTS.URL,
 		AllowInPlanMode: true,
@@ -10974,6 +10984,7 @@ func TestPlanModeRootChatApprovedExternalMCPWorkflowCanReachProposePlan(t *testi
 
 	mcpConfig := dbgen.MCPServerConfig(t, db, database.MCPServerConfig{
 		DisplayName:     "Plan Workflow MCP",
+		OrganizationID:  org.ID,
 		Slug:            "plan-workflow-mcp",
 		Url:             mcpTS.URL,
 		AllowInPlanMode: true,
@@ -11185,6 +11196,7 @@ func TestMCPServerOAuth2TokenRefresh(t *testing.T) {
 	// mock token endpoint.
 	mcpConfig := dbgen.MCPServerConfig(t, db, database.MCPServerConfig{
 		DisplayName:    "Authed MCP",
+		OrganizationID: org.ID,
 		Slug:           "authed-mcp",
 		Url:            mcpTS.URL,
 		AuthType:       "oauth2",
@@ -11312,6 +11324,7 @@ func TestMCPServerOAuth2TokenRefreshFailureGraceful(t *testing.T) {
 
 	mcpConfig := dbgen.MCPServerConfig(t, db, database.MCPServerConfig{
 		DisplayName:    "Broken MCP",
+		OrganizationID: org.ID,
 		Slug:           "broken-mcp",
 		Url:            "http://127.0.0.1:0/does-not-exist",
 		AuthType:       "oauth2",

--- a/coderd/x/chatd/generation_preparer.go
+++ b/coderd/x/chatd/generation_preparer.go
@@ -61,15 +61,23 @@ func (server *Server) prepareGeneration(
 	if len(chat.MCPServerIDs) > 0 {
 		g.Go(func() error {
 			var err error
-			mcpConfigs, err = server.db.GetMCPServerConfigsByIDs(ctx, chat.MCPServerIDs)
+			mcpConfigs, err = server.db.GetMCPServerConfigsByIDs(ctx, database.GetMCPServerConfigsByIDsParams{
+				OrganizationID: chat.OrganizationID,
+				IDs:            chat.MCPServerIDs,
+			})
 			if err != nil {
 				logger.Warn(ctx, "failed to load MCP server configs", slog.Error(err))
+				return nil
 			}
-			return nil
-		})
-		g.Go(func() error {
-			var err error
-			mcpTokens, err = server.db.GetMCPServerUserTokensByUserID(ctx, chat.OwnerID)
+			configIDs := make([]uuid.UUID, 0, len(mcpConfigs))
+			for _, config := range mcpConfigs {
+				configIDs = append(configIDs, config.ID)
+			}
+			mcpTokens, err = server.db.GetMCPServerUserTokensByUserID(ctx, database.GetMCPServerUserTokensByUserIDParams{
+				UserID:             chat.OwnerID,
+				OrganizationID:     chat.OrganizationID,
+				McpServerConfigIds: configIDs,
+			})
 			if err != nil {
 				logger.Warn(ctx, "failed to load MCP user tokens", slog.Error(err))
 			}

--- a/coderd/x/chatd/subagent.go
+++ b/coderd/x/chatd/subagent.go
@@ -991,7 +991,7 @@ func (p *Server) resolveExploreToolSnapshot(
 ) ([]uuid.UUID, error) {
 	inheritedMCPServerIDs := []uuid.UUID{}
 	if len(parent.MCPServerIDs) > 0 {
-		configs, err := p.db.GetMCPServerConfigsByIDs(ctx, parent.MCPServerIDs)
+		configs, err := p.db.GetMCPServerConfigsByIDs(ctx, database.GetMCPServerConfigsByIDsParams{OrganizationID: parent.OrganizationID, IDs: parent.MCPServerIDs})
 		if err != nil {
 			return nil, xerrors.Errorf("get parent MCP server configs for chat %s: %w", parent.ID, err)
 		}

--- a/coderd/x/chatd/subagent_internal_test.go
+++ b/coderd/x/chatd/subagent_internal_test.go
@@ -548,6 +548,7 @@ func insertInternalChatModelConfigWithOptions(
 func insertInternalMCPServerConfig(
 	t *testing.T,
 	db database.Store,
+	organizationID uuid.UUID,
 	userID uuid.UUID,
 	slug string,
 	allowInPlanMode bool,
@@ -555,6 +556,7 @@ func insertInternalMCPServerConfig(
 	t.Helper()
 
 	return dbgen.MCPServerConfig(t, db, database.MCPServerConfig{
+		OrganizationID:  organizationID,
 		DisplayName:     slug,
 		Slug:            slug,
 		Url:             "https://" + slug + ".example.com",
@@ -1729,12 +1731,12 @@ func TestResolveExploreToolSnapshot(t *testing.T) {
 	db, ps := dbtestutil.NewDB(t)
 	server := newInternalTestServer(t, db, ps, chatprovider.ProviderAPIKeys{})
 
-	user, _, _ := seedInternalChatDeps(t, db)
+	user, org, _ := seedInternalChatDeps(t, db)
 	approvedMCP := insertInternalMCPServerConfig(
-		t, db, user.ID, "approved-"+uuid.NewString(), true,
+		t, db, org.ID, user.ID, "approved-"+uuid.NewString(), true,
 	)
 	blockedMCP := insertInternalMCPServerConfig(
-		t, db, user.ID, "blocked-"+uuid.NewString(), false,
+		t, db, org.ID, user.ID, "blocked-"+uuid.NewString(), false,
 	)
 
 	// Build parent chats in memory rather than via server.CreateChat.
@@ -1746,11 +1748,13 @@ func TestResolveExploreToolSnapshot(t *testing.T) {
 	// side effects were the root cause of the flake tracked in
 	// CODAGT-367.
 	askParent := database.Chat{
-		ID:           uuid.New(),
-		MCPServerIDs: []uuid.UUID{approvedMCP.ID, blockedMCP.ID},
+		ID:             uuid.New(),
+		OrganizationID: org.ID,
+		MCPServerIDs:   []uuid.UUID{approvedMCP.ID, blockedMCP.ID},
 	}
 	planParent := database.Chat{
-		ID: uuid.New(),
+		ID:             uuid.New(),
+		OrganizationID: org.ID,
 		PlanMode: database.NullChatPlanMode{
 			ChatPlanMode: database.ChatPlanModePlan,
 			Valid:        true,
@@ -1823,7 +1827,7 @@ func TestCreateChildSubagentChatWithOptions_ExplorePersistsMCPSnapshot(t *testin
 		ctx, t, server, db, org.ID, user.ID, model.ID, "parent-explore-snapshot",
 	)
 	mcpCfg := insertInternalMCPServerConfig(
-		t, db, user.ID, "snapshot-"+uuid.NewString(), false,
+		t, db, org.ID, user.ID, "snapshot-"+uuid.NewString(), false,
 	)
 
 	child, err := server.createChildSubagentChatWithOptions(
@@ -1855,10 +1859,10 @@ func TestSpawnAgent_ExploreSnapshotsTurnStateParentState(t *testing.T) {
 	ctx := chatdTestContext(t)
 	user, org, model := seedInternalChatDeps(t, db)
 	turnStartConfig := insertInternalMCPServerConfig(
-		t, db, user.ID, "turn-start-"+uuid.NewString(), false,
+		t, db, org.ID, user.ID, "turn-start-"+uuid.NewString(), false,
 	)
 	mutatedConfig := insertInternalMCPServerConfig(
-		t, db, user.ID, "mutated-"+uuid.NewString(), true,
+		t, db, org.ID, user.ID, "mutated-"+uuid.NewString(), true,
 	)
 
 	parent, err := server.CreateChat(ctx, CreateOptions{
@@ -2711,11 +2715,12 @@ func TestSpawnAgent_ComputerUseInheritsMCPServerIDs(t *testing.T) {
 	insertEnabledAnthropicProvider(t, db, user.ID)
 
 	mcpCfg := dbgen.MCPServerConfig(t, db, database.MCPServerConfig{
-		DisplayName: "MCP Test",
-		Slug:        "mcp-test",
-		Url:         "https://mcp.example.com",
-		CreatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
-		UpdatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
+		OrganizationID: org.ID,
+		DisplayName:    "MCP Test",
+		Slug:           "mcp-test",
+		Url:            "https://mcp.example.com",
+		CreatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
+		UpdatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
 	})
 
 	parentMCPIDs := []uuid.UUID{mcpCfg.ID}
@@ -2762,19 +2767,21 @@ func TestCreateChildSubagentChat_InheritsMCPServerIDs(t *testing.T) {
 	// Insert two MCP server configs so we can verify both are
 	// inherited by the child chat.
 	mcpA := dbgen.MCPServerConfig(t, db, database.MCPServerConfig{
-		DisplayName: "MCP A",
-		Slug:        "mcp-a",
-		Url:         "https://mcp-a.example.com",
-		CreatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
-		UpdatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
+		OrganizationID: org.ID,
+		DisplayName:    "MCP A",
+		Slug:           "mcp-a",
+		Url:            "https://mcp-a.example.com",
+		CreatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
+		UpdatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
 	})
 
 	mcpB := dbgen.MCPServerConfig(t, db, database.MCPServerConfig{
-		DisplayName: "MCP B",
-		Slug:        "mcp-b",
-		Url:         "https://mcp-b.example.com",
-		CreatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
-		UpdatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
+		OrganizationID: org.ID,
+		DisplayName:    "MCP B",
+		Slug:           "mcp-b",
+		Url:            "https://mcp-b.example.com",
+		CreatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
+		UpdatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
 	})
 
 	parentMCPIDs := []uuid.UUID{mcpA.ID, mcpB.ID}

--- a/enterprise/coderd/mcp_test.go
+++ b/enterprise/coderd/mcp_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
@@ -212,4 +213,87 @@ func TestMCPServerConfigACLRequiresTemplateRBAC(t *testing.T) {
 	var sdkErr *codersdk.Error
 	require.ErrorAs(t, err, &sdkErr)
 	require.Equal(t, http.StatusNotFound, sdkErr.StatusCode())
+}
+
+func TestChatMCPServerSelection(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client, firstUser := coderdenttest.New(t, &coderdenttest.Options{
+		LicenseOptions: &coderdenttest.LicenseOptions{
+			Features: license.Features{
+				codersdk.FeatureMultipleOrganizations: 1,
+				codersdk.FeatureTemplateRBAC:          1,
+			},
+		},
+	})
+	expClient := codersdk.NewExperimentalClient(client)
+	provider := createOpenAIProviderForTest(ctx, t, expClient, "test-key", "https://example.com")
+	_ = createChatModelConfigForOrganization(ctx, t, expClient, firstUser.OrganizationID, provider.ID, "mcp-selection-model", true)
+
+	allowed := createMCPServerConfigForOrganization(t, client, firstUser.OrganizationID, "selection-allowed")
+	disabled := createMCPServerConfigForOrganization(t, client, firstUser.OrganizationID, "selection-disabled")
+	//nolint:gocritic // The owner prepares a disabled configuration for selection validation.
+	_, err := client.UpdateMCPServerConfig(ctx, disabled.ID, codersdk.UpdateMCPServerConfigRequest{Enabled: ptr.Ref(false)})
+	require.NoError(t, err)
+	denied := createMCPServerConfigForOrganization(t, client, firstUser.OrganizationID, "selection-denied")
+	err = client.UpdateMCPServerConfigACL(ctx, denied.ID, codersdk.UpdateMCPServerConfigACL{
+		GroupRoles: map[string]codersdk.MCPServerConfigRole{
+			firstUser.OrganizationID.String(): codersdk.MCPServerConfigRoleDeleted,
+		},
+	})
+	require.NoError(t, err)
+	secondOrg := coderdenttest.CreateOrganization(t, client, coderdenttest.CreateOrganizationOptions{})
+	otherOrganization := createMCPServerConfigForOrganization(t, client, secondOrg.ID, "selection-other-org")
+
+	memberClientRaw, _ := coderdtest.CreateAnotherUser(
+		t, client, firstUser.OrganizationID,
+		rbac.ScopedRoleAgentsAccess(firstUser.OrganizationID),
+	)
+	memberClient := codersdk.NewExperimentalClient(memberClientRaw)
+	create := func(ids []uuid.UUID) (codersdk.Chat, error) {
+		return memberClient.CreateChat(ctx, codersdk.CreateChatRequest{
+			OrganizationID: firstUser.OrganizationID,
+			Content: []codersdk.ChatInputPart{{
+				Type: codersdk.ChatInputPartTypeText,
+				Text: "MCP selection",
+			}},
+			MCPServerIDs: ids,
+		})
+	}
+
+	wantIDs := []uuid.UUID{allowed.ID, allowed.ID}
+	chat, err := create(wantIDs)
+	require.NoError(t, err)
+	require.Equal(t, wantIDs, chat.MCPServerIDs)
+
+	for _, test := range []struct {
+		name string
+		id   uuid.UUID
+	}{
+		{name: "Disabled", id: disabled.ID},
+		{name: "NoACL", id: denied.ID},
+		{name: "OtherOrganization", id: otherOrganization.ID},
+		{name: "Unknown", id: uuid.New()},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := create([]uuid.UUID{test.id})
+			sdkErr := requireSDKErrorStatus(t, err, http.StatusBadRequest)
+			require.Equal(t, "One or more MCP server IDs are invalid.", sdkErr.Message)
+			require.Empty(t, sdkErr.Detail)
+		})
+	}
+
+	invalidReplacement := []uuid.UUID{denied.ID}
+	_, err = memberClient.CreateChatMessage(ctx, chat.ID, codersdk.CreateChatMessageRequest{
+		Content: []codersdk.ChatInputPart{{
+			Type: codersdk.ChatInputPartTypeText,
+			Text: "Replace MCP selection",
+		}},
+		MCPServerIDs: &invalidReplacement,
+	})
+	sdkErr := requireSDKErrorStatus(t, err, http.StatusBadRequest)
+	require.Equal(t, "One or more MCP server IDs are invalid.", sdkErr.Message)
+	require.Empty(t, sdkErr.Detail)
 }


### PR DESCRIPTION
Review-only slice 5 of 5. This PR must not merge separately. Expected intermediate CI failures may be resolved by later stack units.

Enforces organization ownership, enabled state, and current ACL when chat MCP IDs are selected or replaced. Runtime configuration and token loading become organization-scoped while existing chats retain the accepted behavior of not rechecking ACL revocation on every turn.

Parent: #27383
Base: `mathias/codagt-712-mcp-acl`

<details>
<summary>Coordinated stack direction</summary>

The stack first establishes organization-owned MCP data, then adds organization RBAC, organization-scoped API and OAuth contracts, ACL sharing, and chat selection/runtime enforcement. Coordinated frontend follow-ups, including CODAGT-714, own organization selection and migration of MCP page callers after the backend contracts are complete. No compatibility routes, optional organization arguments, global fallback, dual reads, or per-turn ACL revocation checks are introduced.

</details>

Refs CODAGT-711

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
