### PR TITLE
test(coderd): make TestTemplateVersionDryRun/ImportNotFinished deterministic

### DIFF
--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -1538,17 +1538,12 @@ func TestTemplateVersionDryRun(t *testing.T) {
 
 	t.Run("ImportNotFinished", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		// No provisioner daemon is running, so the import job is never
+		// acquired and stays pending. This guarantees the job can neither
+		// complete nor fail before the dry-run request below.
+		client := coderdtest.New(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
-		// This import job will never finish
-		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
-			Parse: echo.ParseComplete,
-			ProvisionPlan: []*proto.Response{{
-				Type: &proto.Response_Log{
-					Log: &proto.Log{},
-				},
-			}},
-		})
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()


### PR DESCRIPTION
Closes PLAT-334 / [coder/internal#1221](https://github.com/coder/internal/issues/1221).

The subtest asserts HTTP 425 while the import job is unfinished, but it ran a real provisioner daemon. Any failure in an early import phase (init, parse, update job) sets `CompletedAt`, which is all `postTemplateVersionDryRun` checks, so the endpoint could return 201 and flake.

Run the subtest without a provisioner daemon: the job is never acquired, stays pending, and the 425 is deterministic.

> Generated by Coder Agents on behalf of @Emyrk.