### PR TITLE
docs(docs/ai-coder/ai-gateway): fix bmcp_ described as suffix instead of prefix

### DIFF
--- a/docs/ai-coder/ai-gateway/mcp.md
+++ b/docs/ai-coder/ai-gateway/mcp.md
@@ -64,7 +64,7 @@ AI Gateway marks automatically injected tools with a prefix `bmcp_` ("bridged MC
 
 ## Tool Injection
 
-If a model decides to invoke a tool and it has a `bmcp_` suffix and AI Gateway has a connection with the related MCP server, it will invoke the tool. The tool result will be passed back to the upstream AI provider, and this will loop until the model has all of its required data. These inner loops are not relayed back to the client; all it sees is the result of this loop. See [Implementation Details](./reference.md#implementation-details).
+If a model decides to invoke a tool and it has a `bmcp_` prefix and AI Gateway has a connection with the related MCP server, it will invoke the tool. The tool result will be passed back to the upstream AI provider, and this will loop until the model has all of its required data. These inner loops are not relayed back to the client; all it sees is the result of this loop. See [Implementation Details](./reference.md#implementation-details).
 
 In contrast, tools which are defined by the client (i.e. the [`Bash` tool](https://docs.claude.com/en/docs/claude-code/settings#tools-available-to-claude) defined by _Claude Code_) cannot be invoked by AI Gateway, and the tool call from the model will be relayed to the client, after which it will invoke the tool.
 


### PR DESCRIPTION
The Tool Injection section of the AI Gateway MCP doc called `bmcp_` a suffix, directly contradicting the correct description one section earlier on the same page and the `aibridge` implementation, where `injectedToolPrefix` is prepended to every bridged MCP tool name (`aibridge/mcp/tool.go`).

Reported by a customer who read the suffix wording and assumed `bmcp` in a tool name like `bmcp_github_list_gists` was a typo.

---
🤖 Built with AI assistance.