### PR TITLE
feat: scope AI resources by organization

### DIFF
--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -7975,6 +7975,7 @@ func convertChatModelConfig(config database.ChatModelConfig) codersdk.ChatModelC
 	// chat_model_configs_ai_provider_required_when_active).
 	return codersdk.ChatModelConfig{
 		ID:                   config.ID,
+		OrganizationID:       config.OrganizationID,
 		AIProviderID:         config.AIProviderID.UUID,
 		Model:                config.Model,
 		DisplayName:          config.DisplayName,

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -1281,6 +1281,7 @@ type CreateUserChatProviderKeyRequest struct {
 // ChatModelConfig is an admin-managed model configuration.
 type ChatModelConfig struct {
 	ID                   uuid.UUID            `json:"id" format:"uuid"`
+	OrganizationID       uuid.UUID            `json:"organization_id" format:"uuid"`
 	AIProviderID         uuid.UUID            `json:"ai_provider_id" format:"uuid"`
 	Model                string               `json:"model"`
 	DisplayName          string               `json:"display_name"`

--- a/enterprise/coderd/mcp_test.go
+++ b/enterprise/coderd/mcp_test.go
@@ -1,6 +1,7 @@
 package coderd_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -251,7 +252,7 @@ func TestChatMCPServerSelection(t *testing.T) {
 		rbac.ScopedRoleAgentsAccess(firstUser.OrganizationID),
 	)
 	memberClient := codersdk.NewExperimentalClient(memberClientRaw)
-	create := func(ids []uuid.UUID) (codersdk.Chat, error) {
+	create := func(ctx context.Context, ids []uuid.UUID) (codersdk.Chat, error) {
 		return memberClient.CreateChat(ctx, codersdk.CreateChatRequest{
 			OrganizationID: firstUser.OrganizationID,
 			Content: []codersdk.ChatInputPart{{
@@ -263,7 +264,7 @@ func TestChatMCPServerSelection(t *testing.T) {
 	}
 
 	wantIDs := []uuid.UUID{allowed.ID, allowed.ID}
-	chat, err := create(wantIDs)
+	chat, err := create(ctx, wantIDs)
 	require.NoError(t, err)
 	require.Equal(t, wantIDs, chat.MCPServerIDs)
 
@@ -278,7 +279,8 @@ func TestChatMCPServerSelection(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := create([]uuid.UUID{test.id})
+			ctx := testutil.Context(t, testutil.WaitLong)
+			_, err := create(ctx, []uuid.UUID{test.id})
 			sdkErr := requireSDKErrorStatus(t, err, http.StatusBadRequest)
 			require.Equal(t, "One or more MCP server IDs are invalid.", sdkErr.Message)
 			require.Empty(t, sdkErr.Detail)

--- a/site/permissions.json
+++ b/site/permissions.json
@@ -107,6 +107,14 @@
 		"object": { "resource_type": "ai_provider" },
 		"action": "read"
 	},
+	"viewAnyChatModelConfig": {
+		"object": { "resource_type": "chat_model_config", "any_org": true },
+		"action": "read"
+	},
+	"viewAnyMCPServerConfig": {
+		"object": { "resource_type": "mcp_server_config", "any_org": true },
+		"action": "read"
+	},
 	"viewAIGatewayKeys": {
 		"object": { "resource_type": "ai_gateway_key" },
 		"action": "read"

--- a/site/src/api/api.test.ts
+++ b/site/src/api/api.test.ts
@@ -372,46 +372,227 @@ describe("api.ts", () => {
 		});
 	});
 
-	describe("chat configuration endpoints", () => {
+	describe("organization chat resource endpoints", () => {
+		const organization = "org/name";
+		const modelConfigId = "model/id";
+		const serverId = "server/id";
+		const organizationPath = "/api/experimental/organizations/org%2Fname";
+		const modelConfigPath = "/api/experimental/chat-model-configs/model%2Fid";
+		const serverPath = "/api/experimental/mcp-servers/server%2Fid";
+
 		it.each<[string, () => Promise<unknown>, unknown]>([
 			[
-				"/api/experimental/chats/models",
-				() => API.experimental.getChatModels(),
-				{
-					providers: [],
-				},
+				`${organizationPath}/chats/models`,
+				() => API.experimental.getChatModels(organization),
+				{ providers: [] },
 			],
 			[
-				"/api/experimental/chats/model-configs",
-				() => API.experimental.getChatModelConfigs(),
+				`${organizationPath}/chat-model-configs`,
+				() => API.experimental.getChatModelConfigs(organization),
 				[],
 			],
-		])("returns response data for %s", async (path, request, responseData) => {
-			vi.spyOn(axiosInstance, "get").mockResolvedValueOnce({
-				data: responseData,
-			});
+			[
+				modelConfigPath,
+				() => API.experimental.getChatModelConfig(modelConfigId),
+				{ id: modelConfigId },
+			],
+			[
+				`${modelConfigPath}/acl`,
+				() => API.experimental.getChatModelConfigACL(modelConfigId),
+				{ users: [], groups: [] },
+			],
+			[
+				`${organizationPath}/mcp-servers`,
+				() => API.experimental.getMCPServerConfigs(organization),
+				[],
+			],
+			[
+				serverPath,
+				() => API.experimental.getMCPServerConfig(serverId),
+				{ id: serverId },
+			],
+			[
+				`${serverPath}/acl`,
+				() => API.experimental.getMCPServerConfigACL(serverId),
+				{ users: [], groups: [] },
+			],
+			[
+				`${organizationPath}/chats/config/model-override/general`,
+				() => API.experimental.getChatModelOverride(organization, "general"),
+				{},
+			],
+			[
+				`${organizationPath}/chats/config/user-personal-model-overrides`,
+				() => API.experimental.getUserChatPersonalModelOverrides(organization),
+				{},
+			],
+			[
+				`${organizationPath}/chats/config/advisor`,
+				() => API.experimental.getChatAdvisorConfig(organization),
+				{},
+			],
+			[
+				`${organizationPath}/chats/config/user-compaction-thresholds`,
+				() => API.experimental.getUserChatCompactionThresholds(organization),
+				{},
+			],
+		])("gets %s and returns response data", async (path, request, data) => {
+			vi.spyOn(axiosInstance, "get").mockResolvedValueOnce({ data });
 
-			const result = await request();
-
+			await expect(request()).resolves.toStrictEqual(data);
 			expect(axiosInstance.get).toHaveBeenCalledWith(path);
-			expect(result).toStrictEqual(responseData);
+		});
+
+		it("builds the item OAuth connect URL", () => {
+			expect(API.experimental.getMCPServerOAuth2ConnectURL(serverId)).toBe(
+				`${serverPath}/oauth2/connect`,
+			);
 		});
 
 		it.each<[string, () => Promise<unknown>]>([
 			[
-				"/api/experimental/chats/models",
-				() => API.experimental.getChatModels(),
+				`${organizationPath}/chats/models`,
+				() => API.experimental.getChatModels(organization),
 			],
 			[
-				"/api/experimental/chats/model-configs",
-				() => API.experimental.getChatModelConfigs(),
+				`${organizationPath}/chat-model-configs`,
+				() => API.experimental.getChatModelConfigs(organization),
 			],
+			[
+				modelConfigPath,
+				() => API.experimental.getChatModelConfig(modelConfigId),
+			],
+			[
+				`${organizationPath}/mcp-servers`,
+				() => API.experimental.getMCPServerConfigs(organization),
+			],
+			[serverPath, () => API.experimental.getMCPServerConfig(serverId)],
 		])("rethrows axios errors for %s", async (path, request) => {
 			const expectedError = new Error("request failed");
 			vi.spyOn(axiosInstance, "get").mockRejectedValueOnce(expectedError);
 
 			await expect(request()).rejects.toBe(expectedError);
 			expect(axiosInstance.get).toHaveBeenCalledWith(path);
+		});
+
+		it("creates organization model and MCP configs", async () => {
+			const modelRequest = {} as TypesGen.CreateChatModelConfigRequest;
+			const serverRequest = {} as TypesGen.CreateMCPServerConfigRequest;
+			vi.spyOn(axiosInstance, "post")
+				.mockResolvedValueOnce({ data: { id: modelConfigId } })
+				.mockResolvedValueOnce({ data: { id: serverId } });
+
+			await API.experimental.createChatModelConfig(organization, modelRequest);
+			await API.experimental.createMCPServerConfig(organization, serverRequest);
+
+			expect(axiosInstance.post).toHaveBeenNthCalledWith(
+				1,
+				`${organizationPath}/chat-model-configs`,
+				modelRequest,
+			);
+			expect(axiosInstance.post).toHaveBeenNthCalledWith(
+				2,
+				`${organizationPath}/mcp-servers`,
+				serverRequest,
+			);
+		});
+
+		it("updates item, ACL, and organization model-bearing settings routes", async () => {
+			const modelRequest = {} as TypesGen.UpdateChatModelConfigRequest;
+			const serverRequest = {} as TypesGen.UpdateMCPServerConfigRequest;
+			const modelACLRequest = {} as TypesGen.UpdateChatModelConfigACL;
+			const serverACLRequest = {} as TypesGen.UpdateMCPServerConfigACL;
+			const overrideRequest = {} as TypesGen.UpdateChatModelOverrideRequest;
+			const personalRequest =
+				{} as TypesGen.UpdateUserChatPersonalModelOverrideRequest;
+			const advisorRequest = {} as TypesGen.UpdateAdvisorConfigRequest;
+			const thresholdRequest =
+				{} as TypesGen.UpdateUserChatCompactionThresholdRequest;
+			vi.spyOn(axiosInstance, "patch").mockResolvedValue({ data: {} });
+
+			await API.experimental.updateChatModelConfig(modelConfigId, modelRequest);
+			await API.experimental.updateChatModelConfigACL(
+				modelConfigId,
+				modelACLRequest,
+			);
+			await API.experimental.updateMCPServerConfig(serverId, serverRequest);
+			await API.experimental.updateMCPServerConfigACL(
+				serverId,
+				serverACLRequest,
+			);
+			await API.experimental.updateChatModelOverride(
+				organization,
+				"general",
+				overrideRequest,
+			);
+			await API.experimental.updateUserChatPersonalModelOverride(
+				organization,
+				"root",
+				personalRequest,
+			);
+			await API.experimental.updateChatAdvisorConfig(
+				organization,
+				advisorRequest,
+			);
+			await API.experimental.updateUserChatCompactionThreshold(
+				organization,
+				modelConfigId,
+				thresholdRequest,
+			);
+
+			expect(axiosInstance.patch).toHaveBeenCalledWith(
+				modelConfigPath,
+				modelRequest,
+			);
+			expect(axiosInstance.patch).toHaveBeenCalledWith(
+				`${modelConfigPath}/acl`,
+				modelACLRequest,
+			);
+			expect(axiosInstance.patch).toHaveBeenCalledWith(
+				serverPath,
+				serverRequest,
+			);
+			expect(axiosInstance.patch).toHaveBeenCalledWith(
+				`${serverPath}/acl`,
+				serverACLRequest,
+			);
+			expect(axiosInstance.patch).toHaveBeenCalledWith(
+				`${organizationPath}/chats/config/model-override/general`,
+				overrideRequest,
+			);
+			expect(axiosInstance.patch).toHaveBeenCalledWith(
+				`${organizationPath}/chats/config/user-personal-model-overrides/root`,
+				personalRequest,
+			);
+			expect(axiosInstance.patch).toHaveBeenCalledWith(
+				`${organizationPath}/chats/config/advisor`,
+				advisorRequest,
+			);
+			expect(axiosInstance.patch).toHaveBeenCalledWith(
+				`${organizationPath}/chats/config/user-compaction-thresholds/model%2Fid`,
+				thresholdRequest,
+			);
+		});
+
+		it("deletes item, OAuth, and organization threshold routes", async () => {
+			vi.spyOn(axiosInstance, "delete").mockResolvedValue({ data: {} });
+
+			await API.experimental.deleteChatModelConfig(modelConfigId);
+			await API.experimental.deleteMCPServerConfig(serverId);
+			await API.experimental.disconnectMCPServerOAuth2(serverId);
+			await API.experimental.deleteUserChatCompactionThreshold(
+				organization,
+				modelConfigId,
+			);
+
+			expect(axiosInstance.delete).toHaveBeenCalledWith(modelConfigPath);
+			expect(axiosInstance.delete).toHaveBeenCalledWith(serverPath);
+			expect(axiosInstance.delete).toHaveBeenCalledWith(
+				`${serverPath}/oauth2/disconnect`,
+			);
+			expect(axiosInstance.delete).toHaveBeenCalledWith(
+				`${organizationPath}/chats/config/user-compaction-thresholds/model%2Fid`,
+			);
 		});
 	});
 

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -432,14 +432,24 @@ export type DeploymentConfig = Readonly<{
 
 const aiProviderConfigsPath = "/api/v2/ai/providers";
 const aiGatewayPath = "/api/v2/ai-gateway";
-const chatModelConfigsPath = "/api/experimental/chats/model-configs";
+const organizationExperimentalPath = (organization: string) =>
+	`/api/experimental/organizations/${encodeURIComponent(organization)}`;
+const chatModelConfigsPath = (organization: string) =>
+	`${organizationExperimentalPath(organization)}/chat-model-configs`;
+const chatModelConfigPath = (modelConfigId: string) =>
+	`/api/experimental/chat-model-configs/${encodeURIComponent(modelConfigId)}`;
+const organizationChatConfigPath = (organization: string) =>
+	`${organizationExperimentalPath(organization)}/chats/config`;
 const userSkillsPath = (user: string) =>
 	`/api/experimental/users/${encodeURIComponent(user)}/skills`;
 const userSkillPath = (user: string, name: string) =>
 	`${userSkillsPath(user)}/${encodeURIComponent(name)}`;
 const userAIProviderKeysPath = (user = "me") =>
 	`/api/experimental/users/${encodeURIComponent(user)}/ai-provider-keys`;
-const mcpServerConfigsPath = "/api/experimental/mcp/servers";
+const mcpServerConfigsPath = (organization: string) =>
+	`${organizationExperimentalPath(organization)}/mcp-servers`;
+const mcpServerConfigPath = (serverId: string) =>
+	`/api/experimental/mcp-servers/${encodeURIComponent(serverId)}`;
 
 type ChatCostDateParams = {
 	start_date?: string;
@@ -3514,9 +3524,11 @@ class ExperimentalApiMethods {
 		return response.data;
 	};
 
-	getChatModels = async (): Promise<TypesGen.ChatModelsResponse> => {
+	getChatModels = async (
+		organization: string,
+	): Promise<TypesGen.ChatModelsResponse> => {
 		const response = await this.axios.get<TypesGen.ChatModelsResponse>(
-			"/api/experimental/chats/models",
+			`${organizationExperimentalPath(organization)}/chats/models`,
 		);
 		return response.data;
 	};
@@ -3614,20 +3626,22 @@ class ExperimentalApiMethods {
 	};
 
 	getChatModelOverride = async (
+		organization: string,
 		context: TypesGen.ChatModelOverrideContext,
 	): Promise<TypesGen.ChatModelOverrideResponse> => {
 		const response = await this.axios.get<TypesGen.ChatModelOverrideResponse>(
-			`/api/experimental/chats/config/model-override/${encodeURIComponent(context)}`,
+			`${organizationChatConfigPath(organization)}/model-override/${encodeURIComponent(context)}`,
 		);
 		return response.data;
 	};
 
 	updateChatModelOverride = async (
+		organization: string,
 		context: TypesGen.ChatModelOverrideContext,
 		req: TypesGen.UpdateChatModelOverrideRequest,
 	): Promise<void> => {
-		await this.axios.put(
-			`/api/experimental/chats/config/model-override/${encodeURIComponent(context)}`,
+		await this.axios.patch(
+			`${organizationChatConfigPath(organization)}/model-override/${encodeURIComponent(context)}`,
 			req,
 		);
 	};
@@ -3683,21 +3697,23 @@ class ExperimentalApiMethods {
 		);
 	};
 
-	getUserChatPersonalModelOverrides =
-		async (): Promise<TypesGen.UserChatPersonalModelOverridesResponse> => {
-			const response =
-				await this.axios.get<TypesGen.UserChatPersonalModelOverridesResponse>(
-					"/api/experimental/chats/config/user-personal-model-overrides",
-				);
-			return response.data;
-		};
+	getUserChatPersonalModelOverrides = async (
+		organization: string,
+	): Promise<TypesGen.UserChatPersonalModelOverridesResponse> => {
+		const response =
+			await this.axios.get<TypesGen.UserChatPersonalModelOverridesResponse>(
+				`${organizationChatConfigPath(organization)}/user-personal-model-overrides`,
+			);
+		return response.data;
+	};
 
 	updateUserChatPersonalModelOverride = async (
+		organization: string,
 		context: TypesGen.ChatPersonalModelOverrideContext,
 		req: TypesGen.UpdateUserChatPersonalModelOverrideRequest,
 	): Promise<void> => {
-		await this.axios.put(
-			`/api/experimental/chats/config/user-personal-model-overrides/${encodeURIComponent(context)}`,
+		await this.axios.patch(
+			`${organizationChatConfigPath(organization)}/user-personal-model-overrides/${encodeURIComponent(context)}`,
 			req,
 		);
 	};
@@ -3721,17 +3737,23 @@ class ExperimentalApiMethods {
 		return response.data;
 	};
 
-	getChatAdvisorConfig = async (): Promise<AdvisorConfig> => {
+	getChatAdvisorConfig = async (
+		organization: string,
+	): Promise<AdvisorConfig> => {
 		const response = await this.axios.get<AdvisorConfig>(
-			"/api/experimental/chats/config/advisor",
+			`${organizationChatConfigPath(organization)}/advisor`,
 		);
 		return response.data;
 	};
 
 	updateChatAdvisorConfig = async (
+		organization: string,
 		req: UpdateAdvisorConfigRequest,
 	): Promise<void> => {
-		await this.axios.put("/api/experimental/chats/config/advisor", req);
+		await this.axios.patch(
+			`${organizationChatConfigPath(organization)}/advisor`,
+			req,
+		);
 	};
 
 	getChatComputerUseProvider =
@@ -3896,44 +3918,63 @@ class ExperimentalApiMethods {
 		await this.axios.delete(userSkillPath(user, name));
 	};
 
-	getUserChatCompactionThresholds =
-		async (): Promise<TypesGen.UserChatCompactionThresholds> => {
-			const response =
-				await this.axios.get<TypesGen.UserChatCompactionThresholds>(
-					"/api/experimental/chats/config/user-compaction-thresholds",
-				);
-			return response.data;
-		};
+	getUserChatCompactionThresholds = async (
+		organization: string,
+	): Promise<TypesGen.UserChatCompactionThresholds> => {
+		const response =
+			await this.axios.get<TypesGen.UserChatCompactionThresholds>(
+				`${organizationChatConfigPath(organization)}/user-compaction-thresholds`,
+			);
+		return response.data;
+	};
+
 	updateUserChatCompactionThreshold = async (
+		organization: string,
 		modelConfigId: string,
 		req: TypesGen.UpdateUserChatCompactionThresholdRequest,
 	): Promise<TypesGen.UserChatCompactionThreshold> => {
-		const response = await this.axios.put<TypesGen.UserChatCompactionThreshold>(
-			`/api/experimental/chats/config/user-compaction-thresholds/${encodeURIComponent(modelConfigId)}`,
-			req,
-		);
+		const response =
+			await this.axios.patch<TypesGen.UserChatCompactionThreshold>(
+				`${organizationChatConfigPath(organization)}/user-compaction-thresholds/${encodeURIComponent(modelConfigId)}`,
+				req,
+			);
 		return response.data;
 	};
+
 	deleteUserChatCompactionThreshold = async (
+		organization: string,
 		modelConfigId: string,
 	): Promise<void> => {
 		await this.axios.delete(
-			`/api/experimental/chats/config/user-compaction-thresholds/${encodeURIComponent(modelConfigId)}`,
+			`${organizationChatConfigPath(organization)}/user-compaction-thresholds/${encodeURIComponent(modelConfigId)}`,
 		);
 	};
 
-	getChatModelConfigs = async (): Promise<TypesGen.ChatModelConfig[]> => {
-		const response =
-			await this.axios.get<TypesGen.ChatModelConfig[]>(chatModelConfigsPath);
+	getChatModelConfigs = async (
+		organization: string,
+	): Promise<TypesGen.ChatModelConfig[]> => {
+		const response = await this.axios.get<TypesGen.ChatModelConfig[]>(
+			chatModelConfigsPath(organization),
+		);
 		return response.data;
 	};
 
 	createChatModelConfig = async (
+		organization: string,
 		req: TypesGen.CreateChatModelConfigRequest,
 	): Promise<TypesGen.ChatModelConfig> => {
 		const response = await this.axios.post<TypesGen.ChatModelConfig>(
-			chatModelConfigsPath,
+			chatModelConfigsPath(organization),
 			req,
+		);
+		return response.data;
+	};
+
+	getChatModelConfig = async (
+		modelConfigId: string,
+	): Promise<TypesGen.ChatModelConfig> => {
+		const response = await this.axios.get<TypesGen.ChatModelConfig>(
+			chatModelConfigPath(modelConfigId),
 		);
 		return response.data;
 	};
@@ -3943,57 +3984,101 @@ class ExperimentalApiMethods {
 		req: TypesGen.UpdateChatModelConfigRequest,
 	): Promise<TypesGen.ChatModelConfig> => {
 		const response = await this.axios.patch<TypesGen.ChatModelConfig>(
-			`${chatModelConfigsPath}/${encodeURIComponent(modelConfigId)}`,
+			chatModelConfigPath(modelConfigId),
 			req,
 		);
 		return response.data;
 	};
 
 	deleteChatModelConfig = async (modelConfigId: string): Promise<void> => {
-		await this.axios.delete(
-			`${chatModelConfigsPath}/${encodeURIComponent(modelConfigId)}`,
-		);
+		await this.axios.delete(chatModelConfigPath(modelConfigId));
 	};
 
-	getMCPServerConfigs = async (): Promise<TypesGen.MCPServerConfig[]> => {
-		const response =
-			await this.axios.get<TypesGen.MCPServerConfig[]>(mcpServerConfigsPath);
+	getChatModelConfigACL = async (
+		modelConfigId: string,
+	): Promise<TypesGen.ChatModelConfigACL> => {
+		const response = await this.axios.get<TypesGen.ChatModelConfigACL>(
+			`${chatModelConfigPath(modelConfigId)}/acl`,
+		);
+		return response.data;
+	};
+
+	updateChatModelConfigACL = async (
+		modelConfigId: string,
+		req: TypesGen.UpdateChatModelConfigACL,
+	): Promise<void> => {
+		await this.axios.patch(`${chatModelConfigPath(modelConfigId)}/acl`, req);
+	};
+
+	getMCPServerConfigs = async (
+		organization: string,
+	): Promise<TypesGen.MCPServerConfig[]> => {
+		const response = await this.axios.get<TypesGen.MCPServerConfig[]>(
+			mcpServerConfigsPath(organization),
+		);
 		return response.data;
 	};
 
 	createMCPServerConfig = async (
+		organization: string,
 		req: TypesGen.CreateMCPServerConfigRequest,
 	): Promise<TypesGen.MCPServerConfig> => {
 		const response = await this.axios.post<TypesGen.MCPServerConfig>(
-			mcpServerConfigsPath,
+			mcpServerConfigsPath(organization),
 			req,
+		);
+		return response.data;
+	};
+
+	getMCPServerConfig = async (
+		serverId: string,
+	): Promise<TypesGen.MCPServerConfig> => {
+		const response = await this.axios.get<TypesGen.MCPServerConfig>(
+			mcpServerConfigPath(serverId),
 		);
 		return response.data;
 	};
 
 	updateMCPServerConfig = async (
-		id: string,
+		serverId: string,
 		req: TypesGen.UpdateMCPServerConfigRequest,
 	): Promise<TypesGen.MCPServerConfig> => {
 		const response = await this.axios.patch<TypesGen.MCPServerConfig>(
-			`${mcpServerConfigsPath}/${encodeURIComponent(id)}`,
+			mcpServerConfigPath(serverId),
 			req,
 		);
 		return response.data;
 	};
 
-	deleteMCPServerConfig = async (id: string): Promise<void> => {
-		await this.axios.delete(
-			`${mcpServerConfigsPath}/${encodeURIComponent(id)}`,
-		);
+	deleteMCPServerConfig = async (serverId: string): Promise<void> => {
+		await this.axios.delete(mcpServerConfigPath(serverId));
 	};
 
+	getMCPServerConfigACL = async (
+		serverId: string,
+	): Promise<TypesGen.MCPServerConfigACL> => {
+		const response = await this.axios.get<TypesGen.MCPServerConfigACL>(
+			`${mcpServerConfigPath(serverId)}/acl`,
+		);
+		return response.data;
+	};
+
+	updateMCPServerConfigACL = async (
+		serverId: string,
+		req: TypesGen.UpdateMCPServerConfigACL,
+	): Promise<void> => {
+		await this.axios.patch(`${mcpServerConfigPath(serverId)}/acl`, req);
+	};
+
+	getMCPServerOAuth2ConnectURL = (serverId: string): string =>
+		`${mcpServerConfigPath(serverId)}/oauth2/connect`;
+
 	disconnectMCPServerOAuth2 = async (
-		id: string,
+		serverId: string,
 	): Promise<TypesGen.MCPServerOAuth2DisconnectResponse> => {
 		const response =
 			await this.axios.delete<TypesGen.MCPServerOAuth2DisconnectResponse>(
-				`${mcpServerConfigsPath}/${encodeURIComponent(id)}/oauth2/disconnect`,
+				`${mcpServerConfigPath(serverId)}/oauth2/disconnect`,
 			);
 		return response.data;
 	};

--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -21,16 +21,39 @@ import {
 	chatDiffContentsKey,
 	chatKey,
 	chatMessagesKey,
+	chatModelConfig,
+	chatModelConfigACL,
+	chatModelConfigACLKey,
+	chatModelConfigKey,
+	chatModelConfigs,
+	chatModelConfigsKey,
+	chatModelOverride,
+	chatModelOverrideKey,
+	chatModels,
+	chatModelsKey,
 	chatSearch,
 	chatsKey,
 	createChat,
 	createChatMessage,
+	createChatModelConfig,
+	createMCPServerConfig,
+	deleteChatModelConfig,
 	deleteChatQueuedMessage,
+	deleteMCPServerConfig,
+	deleteUserCompactionThreshold,
+	disconnectMCPServerOAuth2,
 	editChatMessage,
 	infiniteChats,
 	infiniteChatsKey,
 	interruptChat,
 	invalidateChatListQueries,
+	invalidateChatProviderDependentQueries,
+	mcpServerConfig,
+	mcpServerConfigACL,
+	mcpServerConfigACLKey,
+	mcpServerConfigKey,
+	mcpServerConfigs,
+	mcpServerConfigsKey,
 	mergeWatchedChatIntoCaches,
 	mergeWatchedChatSummary,
 	paginatedChatCostUsers,
@@ -46,10 +69,21 @@ import {
 	unarchiveChat,
 	unpinChat,
 	updateChatAdvisorConfig,
+	updateChatModelConfig,
+	updateChatModelConfigACL,
+	updateChatModelOverride,
 	updateChatPlanMode,
 	updateChatTitle,
 	updateChildInParentCache,
 	updateInfiniteChatsCache,
+	updateMCPServerConfig,
+	updateMCPServerConfigACL,
+	updateUserChatPersonalModelOverride,
+	updateUserCompactionThreshold,
+	userChatPersonalModelOverrides,
+	userChatPersonalModelOverridesKey,
+	userCompactionThresholds,
+	userCompactionThresholdsKey,
 } from "./chats";
 
 vi.mock("#/api/api", () => ({
@@ -68,6 +102,29 @@ vi.mock("#/api/api", () => ({
 			proposeChatTitle: vi.fn(),
 			getChatAdvisorConfig: vi.fn(),
 			updateChatAdvisorConfig: vi.fn(),
+			getChatModels: vi.fn(),
+			getChatModelConfigs: vi.fn(),
+			getChatModelConfig: vi.fn(),
+			getChatModelConfigACL: vi.fn(),
+			createChatModelConfig: vi.fn(),
+			updateChatModelConfig: vi.fn(),
+			deleteChatModelConfig: vi.fn(),
+			updateChatModelConfigACL: vi.fn(),
+			getChatModelOverride: vi.fn(),
+			updateChatModelOverride: vi.fn(),
+			getMCPServerConfigs: vi.fn(),
+			getMCPServerConfig: vi.fn(),
+			getMCPServerConfigACL: vi.fn(),
+			createMCPServerConfig: vi.fn(),
+			updateMCPServerConfig: vi.fn(),
+			deleteMCPServerConfig: vi.fn(),
+			updateMCPServerConfigACL: vi.fn(),
+			disconnectMCPServerOAuth2: vi.fn(),
+			getUserChatPersonalModelOverrides: vi.fn(),
+			updateUserChatPersonalModelOverride: vi.fn(),
+			getUserChatCompactionThresholds: vi.fn(),
+			updateUserChatCompactionThreshold: vi.fn(),
+			deleteUserChatCompactionThreshold: vi.fn(),
 			getChatACL: vi.fn(),
 			updateChatACL: vi.fn(),
 		},
@@ -142,6 +199,8 @@ const createTestQueryClient = (): QueryClient =>
 	});
 
 describe("advisor config query factories", () => {
+	const organization = "test-org";
+
 	it("builds the advisor config query and delegates to the API", async () => {
 		const advisorConfig: TypesGen.AdvisorConfig = {
 			enabled: true,
@@ -153,16 +212,18 @@ describe("advisor config query factories", () => {
 			advisorConfig,
 		);
 
-		const query = chatAdvisorConfig();
+		const query = chatAdvisorConfig(organization);
 
-		expect(query.queryKey).toEqual(chatAdvisorConfigKey);
+		expect(query.queryKey).toEqual(chatAdvisorConfigKey(organization));
 		await expect(query.queryFn()).resolves.toEqual(advisorConfig);
-		expect(API.experimental.getChatAdvisorConfig).toHaveBeenCalled();
+		expect(API.experimental.getChatAdvisorConfig).toHaveBeenCalledWith(
+			organization,
+		);
 	});
 
 	it("sends the update request and invalidates the advisor config cache", async () => {
 		const queryClient = createTestQueryClient();
-		queryClient.setQueryData(chatAdvisorConfigKey, {
+		queryClient.setQueryData(chatAdvisorConfigKey(organization), {
 			enabled: false,
 			max_uses_per_run: 0,
 			max_output_tokens: 0,
@@ -178,13 +239,486 @@ describe("advisor config query factories", () => {
 		vi.mocked(API.experimental.updateChatAdvisorConfig).mockResolvedValue();
 
 		const mutation = updateChatAdvisorConfig(queryClient);
-		await mutation.mutationFn(req);
-		expect(API.experimental.updateChatAdvisorConfig).toHaveBeenCalledWith(req);
-
-		await mutation.onSuccess?.();
-		expect(queryClient.getQueryState(chatAdvisorConfigKey)?.isInvalidated).toBe(
-			true,
+		const variables = { organization, req };
+		await mutation.mutationFn(variables);
+		expect(API.experimental.updateChatAdvisorConfig).toHaveBeenCalledWith(
+			organization,
+			req,
 		);
+
+		await mutation.onSuccess?.(undefined, variables);
+		expect(
+			queryClient.getQueryState(chatAdvisorConfigKey(organization))
+				?.isInvalidated,
+		).toBe(true);
+	});
+});
+
+describe("organization resource query factories", () => {
+	const organization = "test-org";
+	const otherOrganization = "other-org";
+	const modelConfigId = "model-config-id";
+	const serverId = "server-id";
+
+	it("keys list and model-bearing settings queries by organization", async () => {
+		vi.mocked(API.experimental.getChatModels).mockResolvedValue({
+			providers: [],
+			unsupported_providers: [],
+		});
+		vi.mocked(API.experimental.getChatModelConfigs).mockResolvedValue([]);
+		vi.mocked(API.experimental.getChatModelOverride).mockResolvedValue(
+			{} as TypesGen.ChatModelOverrideResponse,
+		);
+		vi.mocked(API.experimental.getMCPServerConfigs).mockResolvedValue([]);
+
+		const modelsQuery = chatModels(organization);
+		const modelConfigsQuery = chatModelConfigs(organization);
+		const overrideQuery = chatModelOverride(organization, "general");
+		const mcpConfigsQuery = mcpServerConfigs(organization);
+
+		expect(modelsQuery.queryKey).toEqual(chatModelsKey(organization));
+		expect(modelConfigsQuery.queryKey).toEqual(
+			chatModelConfigsKey(organization),
+		);
+		expect(overrideQuery.queryKey).toEqual(
+			chatModelOverrideKey(organization, "general"),
+		);
+		expect(mcpConfigsQuery.queryKey).toEqual(mcpServerConfigsKey(organization));
+		await modelsQuery.queryFn();
+		await modelConfigsQuery.queryFn();
+		await overrideQuery.queryFn();
+		await mcpConfigsQuery.queryFn();
+		expect(API.experimental.getChatModels).toHaveBeenCalledWith(organization);
+		expect(API.experimental.getChatModelConfigs).toHaveBeenCalledWith(
+			organization,
+		);
+		expect(API.experimental.getChatModelOverride).toHaveBeenCalledWith(
+			organization,
+			"general",
+		);
+		expect(API.experimental.getMCPServerConfigs).toHaveBeenCalledWith(
+			organization,
+		);
+	});
+
+	it("keys model and MCP item and ACL queries by ID", async () => {
+		vi.mocked(API.experimental.getChatModelConfig).mockResolvedValue(
+			{} as TypesGen.ChatModelConfig,
+		);
+		vi.mocked(API.experimental.getChatModelConfigACL).mockResolvedValue({
+			users: [],
+			groups: [],
+		});
+		vi.mocked(API.experimental.getMCPServerConfig).mockResolvedValue(
+			{} as TypesGen.MCPServerConfig,
+		);
+		vi.mocked(API.experimental.getMCPServerConfigACL).mockResolvedValue({
+			users: [],
+			groups: [],
+		});
+
+		const modelQuery = chatModelConfig(modelConfigId);
+		const modelACLQuery = chatModelConfigACL(modelConfigId);
+		const serverQuery = mcpServerConfig(serverId);
+		const serverACLQuery = mcpServerConfigACL(serverId);
+
+		expect(modelQuery.queryKey).toEqual(chatModelConfigKey(modelConfigId));
+		expect(modelACLQuery.queryKey).toEqual(
+			chatModelConfigACLKey(modelConfigId),
+		);
+		expect(serverQuery.queryKey).toEqual(mcpServerConfigKey(serverId));
+		expect(serverACLQuery.queryKey).toEqual(mcpServerConfigACLKey(serverId));
+		await modelQuery.queryFn();
+		await modelACLQuery.queryFn();
+		await serverQuery.queryFn();
+		await serverACLQuery.queryFn();
+		expect(API.experimental.getChatModelConfig).toHaveBeenCalledWith(
+			modelConfigId,
+		);
+		expect(API.experimental.getChatModelConfigACL).toHaveBeenCalledWith(
+			modelConfigId,
+		);
+		expect(API.experimental.getMCPServerConfig).toHaveBeenCalledWith(serverId);
+		expect(API.experimental.getMCPServerConfigACL).toHaveBeenCalledWith(
+			serverId,
+		);
+	});
+
+	it("invalidates only the selected organization after model creation", async () => {
+		const queryClient = createTestQueryClient();
+		queryClient.setQueryData(chatModelConfigsKey(organization), []);
+		queryClient.setQueryData(chatModelsKey(organization), { providers: [] });
+		queryClient.setQueryData(chatModelConfigsKey(otherOrganization), []);
+		queryClient.setQueryData(chatModelsKey(otherOrganization), {
+			providers: [],
+		});
+		vi.mocked(API.experimental.createChatModelConfig).mockResolvedValue(
+			{} as TypesGen.ChatModelConfig,
+		);
+		const req = {} as TypesGen.CreateChatModelConfigRequest;
+		const variables = { organization, req };
+		const mutation = createChatModelConfig(queryClient);
+
+		await mutation.mutationFn(variables);
+		await mutation.onSuccess?.({} as TypesGen.ChatModelConfig, variables);
+
+		expect(API.experimental.createChatModelConfig).toHaveBeenCalledWith(
+			organization,
+			req,
+		);
+		expect(
+			queryClient.getQueryState(chatModelConfigsKey(organization))
+				?.isInvalidated,
+		).toBe(true);
+		expect(
+			queryClient.getQueryState(chatModelsKey(organization))?.isInvalidated,
+		).toBe(true);
+		expect(
+			queryClient.getQueryState(chatModelConfigsKey(otherOrganization))
+				?.isInvalidated,
+		).not.toBe(true);
+		expect(
+			queryClient.getQueryState(chatModelsKey(otherOrganization))
+				?.isInvalidated,
+		).not.toBe(true);
+	});
+
+	it("uses ID APIs and invalidates model item, organization list, and discovery", async () => {
+		const queryClient = createTestQueryClient();
+		queryClient.setQueryData(chatModelConfigKey(modelConfigId), {});
+		queryClient.setQueryData(chatModelConfigsKey(organization), []);
+		queryClient.setQueryData(chatModelsKey(organization), { providers: [] });
+		const req = {} as TypesGen.UpdateChatModelConfigRequest;
+		const updateVariables = { organization, modelConfigId, req };
+		vi.mocked(API.experimental.updateChatModelConfig).mockResolvedValue(
+			{} as TypesGen.ChatModelConfig,
+		);
+
+		const updateMutation = updateChatModelConfig(queryClient);
+		await updateMutation.mutationFn(updateVariables);
+		await updateMutation.onSuccess?.(
+			{} as TypesGen.ChatModelConfig,
+			updateVariables,
+		);
+
+		expect(API.experimental.updateChatModelConfig).toHaveBeenCalledWith(
+			modelConfigId,
+			req,
+		);
+		expect(
+			queryClient.getQueryState(chatModelConfigKey(modelConfigId))
+				?.isInvalidated,
+		).toBe(true);
+		expect(
+			queryClient.getQueryState(chatModelConfigsKey(organization))
+				?.isInvalidated,
+		).toBe(true);
+		expect(
+			queryClient.getQueryState(chatModelsKey(organization))?.isInvalidated,
+		).toBe(true);
+
+		const deleteVariables = { organization, modelConfigId };
+		vi.mocked(API.experimental.deleteChatModelConfig).mockResolvedValue();
+		const deleteMutation = deleteChatModelConfig(queryClient);
+		await deleteMutation.mutationFn(deleteVariables);
+		expect(API.experimental.deleteChatModelConfig).toHaveBeenCalledWith(
+			modelConfigId,
+		);
+	});
+
+	it("invalidates ACL item and organization list after model ACL update", async () => {
+		const queryClient = createTestQueryClient();
+		queryClient.setQueryData(chatModelConfigACLKey(modelConfigId), {});
+		queryClient.setQueryData(chatModelConfigsKey(organization), []);
+		const req: TypesGen.UpdateChatModelConfigACL = {
+			user_roles: { "user-id": "read" },
+		};
+		const variables = { organization, modelConfigId, req };
+		vi.mocked(API.experimental.updateChatModelConfigACL).mockResolvedValue();
+		const mutation = updateChatModelConfigACL(queryClient);
+
+		await mutation.mutationFn(variables);
+		await mutation.onSuccess?.(undefined, variables);
+
+		expect(API.experimental.updateChatModelConfigACL).toHaveBeenCalledWith(
+			modelConfigId,
+			req,
+		);
+		expect(
+			queryClient.getQueryState(chatModelConfigACLKey(modelConfigId))
+				?.isInvalidated,
+		).toBe(true);
+		expect(
+			queryClient.getQueryState(chatModelConfigsKey(organization))
+				?.isInvalidated,
+		).toBe(true);
+	});
+
+	it("uses ID APIs and invalidates MCP item and organization list", async () => {
+		const queryClient = createTestQueryClient();
+		queryClient.setQueryData(mcpServerConfigKey(serverId), {});
+		queryClient.setQueryData(mcpServerConfigsKey(organization), []);
+		const req = {} as TypesGen.UpdateMCPServerConfigRequest;
+		const variables = { organization, serverId, req };
+		vi.mocked(API.experimental.updateMCPServerConfig).mockResolvedValue(
+			{} as TypesGen.MCPServerConfig,
+		);
+		const mutation = updateMCPServerConfig(queryClient);
+
+		await mutation.mutationFn(variables);
+		await mutation.onSuccess?.({} as TypesGen.MCPServerConfig, variables);
+
+		expect(API.experimental.updateMCPServerConfig).toHaveBeenCalledWith(
+			serverId,
+			req,
+		);
+		expect(
+			queryClient.getQueryState(mcpServerConfigKey(serverId))?.isInvalidated,
+		).toBe(true);
+		expect(
+			queryClient.getQueryState(mcpServerConfigsKey(organization))
+				?.isInvalidated,
+		).toBe(true);
+
+		const deleteVariables = { organization, serverId };
+		vi.mocked(API.experimental.deleteMCPServerConfig).mockResolvedValue();
+		const deleteMutation = deleteMCPServerConfig(queryClient);
+		await deleteMutation.mutationFn(deleteVariables);
+		expect(API.experimental.deleteMCPServerConfig).toHaveBeenCalledWith(
+			serverId,
+		);
+	});
+
+	it("invalidates ACL item and organization list after MCP ACL update", async () => {
+		const queryClient = createTestQueryClient();
+		queryClient.setQueryData(mcpServerConfigACLKey(serverId), {});
+		queryClient.setQueryData(mcpServerConfigsKey(organization), []);
+		const req: TypesGen.UpdateMCPServerConfigACL = {
+			group_roles: { "group-id": "read" },
+		};
+		const variables = { organization, serverId, req };
+		vi.mocked(API.experimental.updateMCPServerConfigACL).mockResolvedValue();
+		const mutation = updateMCPServerConfigACL(queryClient);
+
+		await mutation.mutationFn(variables);
+		await mutation.onSuccess?.(undefined, variables);
+
+		expect(API.experimental.updateMCPServerConfigACL).toHaveBeenCalledWith(
+			serverId,
+			req,
+		);
+		expect(
+			queryClient.getQueryState(mcpServerConfigACLKey(serverId))?.isInvalidated,
+		).toBe(true);
+		expect(
+			queryClient.getQueryState(mcpServerConfigsKey(organization))
+				?.isInvalidated,
+		).toBe(true);
+	});
+
+	it("invalidates only the selected organization after MCP creation", async () => {
+		const queryClient = createTestQueryClient();
+		queryClient.setQueryData(mcpServerConfigsKey(organization), []);
+		queryClient.setQueryData(mcpServerConfigsKey(otherOrganization), []);
+		vi.mocked(API.experimental.createMCPServerConfig).mockResolvedValue(
+			{} as TypesGen.MCPServerConfig,
+		);
+		const req = {} as TypesGen.CreateMCPServerConfigRequest;
+		const variables = { organization, req };
+		const mutation = createMCPServerConfig(queryClient);
+
+		await mutation.mutationFn(variables);
+		await mutation.onSuccess?.({} as TypesGen.MCPServerConfig, variables);
+
+		expect(API.experimental.createMCPServerConfig).toHaveBeenCalledWith(
+			organization,
+			req,
+		);
+		expect(
+			queryClient.getQueryState(mcpServerConfigsKey(organization))
+				?.isInvalidated,
+		).toBe(true);
+		expect(
+			queryClient.getQueryState(mcpServerConfigsKey(otherOrganization))
+				?.isInvalidated,
+		).not.toBe(true);
+	});
+
+	it("invalidates every organization model descendant after provider changes", async () => {
+		const queryClient = createTestQueryClient();
+		queryClient.setQueryData(chatModelConfigsKey(organization), []);
+		queryClient.setQueryData(chatModelsKey(organization), { providers: [] });
+		queryClient.setQueryData(chatModelConfigsKey(otherOrganization), []);
+		queryClient.setQueryData(chatModelsKey(otherOrganization), {
+			providers: [],
+		});
+
+		await invalidateChatProviderDependentQueries(queryClient);
+
+		for (const queryKey of [
+			chatModelConfigsKey(organization),
+			chatModelsKey(organization),
+			chatModelConfigsKey(otherOrganization),
+			chatModelsKey(otherOrganization),
+		]) {
+			expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(true);
+		}
+	});
+
+	it("keys and updates personal model overrides by organization", async () => {
+		const queryClient = createTestQueryClient();
+		vi.mocked(
+			API.experimental.getUserChatPersonalModelOverrides,
+		).mockResolvedValue({} as TypesGen.UserChatPersonalModelOverridesResponse);
+		const query = userChatPersonalModelOverrides(organization);
+		expect(query.queryKey).toEqual(
+			userChatPersonalModelOverridesKey(organization),
+		);
+		await query.queryFn();
+		expect(
+			API.experimental.getUserChatPersonalModelOverrides,
+		).toHaveBeenCalledWith(organization);
+
+		queryClient.setQueryData(
+			userChatPersonalModelOverridesKey(organization),
+			{},
+		);
+		queryClient.setQueryData(
+			userChatPersonalModelOverridesKey(otherOrganization),
+			{},
+		);
+		const req = {} as TypesGen.UpdateUserChatPersonalModelOverrideRequest;
+		const variables = { organization, context: "root" as const, req };
+		vi.mocked(
+			API.experimental.updateUserChatPersonalModelOverride,
+		).mockResolvedValue();
+		const mutation = updateUserChatPersonalModelOverride(queryClient);
+		await mutation.mutationFn(variables);
+		await mutation.onSuccess?.(undefined, variables);
+
+		expect(
+			API.experimental.updateUserChatPersonalModelOverride,
+		).toHaveBeenCalledWith(organization, "root", req);
+		expect(
+			queryClient.getQueryState(userChatPersonalModelOverridesKey(organization))
+				?.isInvalidated,
+		).toBe(true);
+		expect(
+			queryClient.getQueryState(
+				userChatPersonalModelOverridesKey(otherOrganization),
+			)?.isInvalidated,
+		).not.toBe(true);
+	});
+
+	it("keys and mutates compaction thresholds by organization", async () => {
+		const queryClient = createTestQueryClient();
+		vi.mocked(
+			API.experimental.getUserChatCompactionThresholds,
+		).mockResolvedValue({} as TypesGen.UserChatCompactionThresholds);
+		const query = userCompactionThresholds(organization);
+		expect(query.queryKey).toEqual(userCompactionThresholdsKey(organization));
+		await query.queryFn();
+		expect(
+			API.experimental.getUserChatCompactionThresholds,
+		).toHaveBeenCalledWith(organization);
+
+		queryClient.setQueryData(userCompactionThresholdsKey(organization), {});
+		queryClient.setQueryData(
+			userCompactionThresholdsKey(otherOrganization),
+			{},
+		);
+		const req = {} as TypesGen.UpdateUserChatCompactionThresholdRequest;
+		const updateVariables = { organization, modelConfigId, req };
+		vi.mocked(
+			API.experimental.updateUserChatCompactionThreshold,
+		).mockResolvedValue({} as TypesGen.UserChatCompactionThreshold);
+		const updateMutation = updateUserCompactionThreshold(queryClient);
+		await updateMutation.mutationFn(updateVariables);
+		await updateMutation.onSuccess?.(
+			{} as TypesGen.UserChatCompactionThreshold,
+			updateVariables,
+		);
+		expect(
+			API.experimental.updateUserChatCompactionThreshold,
+		).toHaveBeenCalledWith(organization, modelConfigId, req);
+
+		const deleteVariables = { organization, modelConfigId };
+		vi.mocked(
+			API.experimental.deleteUserChatCompactionThreshold,
+		).mockResolvedValue();
+		const deleteMutation = deleteUserCompactionThreshold(queryClient);
+		await deleteMutation.mutationFn(deleteVariables);
+		await deleteMutation.onSuccess?.(undefined, deleteVariables);
+		expect(
+			API.experimental.deleteUserChatCompactionThreshold,
+		).toHaveBeenCalledWith(organization, modelConfigId);
+		expect(
+			queryClient.getQueryState(userCompactionThresholdsKey(organization))
+				?.isInvalidated,
+		).toBe(true);
+		expect(
+			queryClient.getQueryState(userCompactionThresholdsKey(otherOrganization))
+				?.isInvalidated,
+		).not.toBe(true);
+	});
+
+	it("disconnects MCP OAuth by ID and invalidates the item and organization list", async () => {
+		const queryClient = createTestQueryClient();
+		queryClient.setQueryData(mcpServerConfigKey(serverId), {});
+		queryClient.setQueryData(mcpServerConfigsKey(organization), []);
+		const variables = { organization, serverId };
+		vi.mocked(API.experimental.disconnectMCPServerOAuth2).mockResolvedValue(
+			{} as TypesGen.MCPServerOAuth2DisconnectResponse,
+		);
+		const mutation = disconnectMCPServerOAuth2(queryClient);
+
+		await mutation.mutationFn(variables);
+		await mutation.onSuccess?.(
+			{} as TypesGen.MCPServerOAuth2DisconnectResponse,
+			variables,
+		);
+
+		expect(API.experimental.disconnectMCPServerOAuth2).toHaveBeenCalledWith(
+			serverId,
+		);
+		expect(
+			queryClient.getQueryState(mcpServerConfigKey(serverId))?.isInvalidated,
+		).toBe(true);
+		expect(
+			queryClient.getQueryState(mcpServerConfigsKey(organization))
+				?.isInvalidated,
+		).toBe(true);
+	});
+
+	it("updates and invalidates one organization model override", async () => {
+		const queryClient = createTestQueryClient();
+		queryClient.setQueryData(chatModelOverrideKey(organization, "general"), {});
+		queryClient.setQueryData(
+			chatModelOverrideKey(otherOrganization, "general"),
+			{},
+		);
+		const req = {} as TypesGen.UpdateChatModelOverrideRequest;
+		const variables = { organization, context: "general" as const, req };
+		vi.mocked(API.experimental.updateChatModelOverride).mockResolvedValue();
+		const mutation = updateChatModelOverride(queryClient);
+
+		await mutation.mutationFn(variables);
+		await mutation.onSuccess?.(undefined, variables);
+
+		expect(API.experimental.updateChatModelOverride).toHaveBeenCalledWith(
+			organization,
+			"general",
+			req,
+		);
+		expect(
+			queryClient.getQueryState(chatModelOverrideKey(organization, "general"))
+				?.isInvalidated,
+		).toBe(true);
+		expect(
+			queryClient.getQueryState(
+				chatModelOverrideKey(otherOrganization, "general"),
+			)?.isInvalidated,
+		).not.toBe(true);
 	});
 });
 

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -1571,6 +1571,11 @@ const chatPersonalModelOverridesAdminSettingsKey = [
 	"admin-personal-model-overrides",
 ] as const;
 
+const userChatPersonalModelOverridesKeyPrefix = [
+	...chatsKey,
+	"user-personal-model-overrides",
+] as const;
+
 export const chatPersonalModelOverridesAdminSettings = () => ({
 	queryKey: chatPersonalModelOverridesAdminSettingsKey,
 	queryFn: () => API.experimental.getChatPersonalModelOverridesAdminSettings(),
@@ -1587,26 +1592,73 @@ export const updateChatPersonalModelOverridesAdminSettings = (
 			queryKey: chatPersonalModelOverridesAdminSettingsKey,
 		});
 		await queryClient.invalidateQueries({
-			queryKey: userChatPersonalModelOverridesKey,
+			queryKey: userChatPersonalModelOverridesKeyPrefix,
 		});
 	},
 });
 
 export * from "./chatDebugLogging";
-export const chatAdvisorConfigKey = ["chat-advisor-config"] as const;
 
-export const chatAdvisorConfig = () => ({
-	queryKey: chatAdvisorConfigKey,
-	queryFn: (): Promise<TypesGen.AdvisorConfig> =>
-		API.experimental.getChatAdvisorConfig(),
+export const chatModelOverrideKey = (
+	organization: string,
+	context: TypesGen.ChatModelOverrideContext,
+) => [...chatsKey, "model-override", organization, context] as const;
+
+export const chatModelOverride = (
+	organization: string,
+	context: TypesGen.ChatModelOverrideContext,
+) => ({
+	queryKey: chatModelOverrideKey(organization, context),
+	queryFn: (): Promise<TypesGen.ChatModelOverrideResponse> =>
+		API.experimental.getChatModelOverride(organization, context),
 });
 
-export const updateChatAdvisorConfig = (queryClient: QueryClient) => ({
-	mutationFn: (req: TypesGen.UpdateAdvisorConfigRequest) =>
-		API.experimental.updateChatAdvisorConfig(req),
-	onSuccess: async () => {
+type UpdateChatModelOverrideMutationArgs = {
+	organization: string;
+	context: TypesGen.ChatModelOverrideContext;
+	req: TypesGen.UpdateChatModelOverrideRequest;
+};
+
+export const updateChatModelOverride = (queryClient: QueryClient) => ({
+	mutationFn: ({
+		organization,
+		context,
+		req,
+	}: UpdateChatModelOverrideMutationArgs) =>
+		API.experimental.updateChatModelOverride(organization, context, req),
+	onSuccess: async (
+		_data: unknown,
+		{ organization, context }: UpdateChatModelOverrideMutationArgs,
+	) => {
 		await queryClient.invalidateQueries({
-			queryKey: chatAdvisorConfigKey,
+			queryKey: chatModelOverrideKey(organization, context),
+		});
+	},
+});
+
+export const chatAdvisorConfigKey = (organization: string) =>
+	[...chatsKey, "advisor-config", organization] as const;
+
+export const chatAdvisorConfig = (organization: string) => ({
+	queryKey: chatAdvisorConfigKey(organization),
+	queryFn: (): Promise<TypesGen.AdvisorConfig> =>
+		API.experimental.getChatAdvisorConfig(organization),
+});
+
+type UpdateChatAdvisorConfigMutationArgs = {
+	organization: string;
+	req: TypesGen.UpdateAdvisorConfigRequest;
+};
+
+export const updateChatAdvisorConfig = (queryClient: QueryClient) => ({
+	mutationFn: ({ organization, req }: UpdateChatAdvisorConfigMutationArgs) =>
+		API.experimental.updateChatAdvisorConfig(organization, req),
+	onSuccess: async (
+		_data: unknown,
+		{ organization }: UpdateChatAdvisorConfigMutationArgs,
+	) => {
+		await queryClient.invalidateQueries({
+			queryKey: chatAdvisorConfigKey(organization),
 		});
 	},
 });
@@ -1723,18 +1775,17 @@ export const updateUserChatCustomPrompt = (queryClient: QueryClient) => ({
 	},
 });
 
-const userChatPersonalModelOverridesKey = [
-	...chatsKey,
-	"user-personal-model-overrides",
-] as const;
+export const userChatPersonalModelOverridesKey = (organization: string) =>
+	[...userChatPersonalModelOverridesKeyPrefix, organization] as const;
 
-export const userChatPersonalModelOverrides = () => ({
-	queryKey: userChatPersonalModelOverridesKey,
+export const userChatPersonalModelOverrides = (organization: string) => ({
+	queryKey: userChatPersonalModelOverridesKey(organization),
 	queryFn: (): Promise<TypesGen.UserChatPersonalModelOverridesResponse> =>
-		API.experimental.getUserChatPersonalModelOverrides(),
+		API.experimental.getUserChatPersonalModelOverrides(organization),
 });
 
 type UpdateUserChatPersonalModelOverrideArgs = {
+	organization: string;
 	context: TypesGen.ChatPersonalModelOverrideContext;
 	req: TypesGen.UpdateUserChatPersonalModelOverrideRequest;
 };
@@ -1742,56 +1793,94 @@ type UpdateUserChatPersonalModelOverrideArgs = {
 export const updateUserChatPersonalModelOverride = (
 	queryClient: QueryClient,
 ) => ({
-	mutationFn: ({ context, req }: UpdateUserChatPersonalModelOverrideArgs) =>
-		API.experimental.updateUserChatPersonalModelOverride(context, req),
-	onSuccess: async () => {
+	mutationFn: ({
+		organization,
+		context,
+		req,
+	}: UpdateUserChatPersonalModelOverrideArgs) =>
+		API.experimental.updateUserChatPersonalModelOverride(
+			organization,
+			context,
+			req,
+		),
+	onSuccess: async (
+		_data: unknown,
+		{ organization }: UpdateUserChatPersonalModelOverrideArgs,
+	) => {
 		await queryClient.invalidateQueries({
-			queryKey: userChatPersonalModelOverridesKey,
+			queryKey: userChatPersonalModelOverridesKey(organization),
 		});
 	},
 });
 
-const userCompactionThresholdsKey = [
-	"chat-user-compaction-thresholds",
-] as const;
+export const userCompactionThresholdsKey = (organization: string) =>
+	[...chatsKey, "user-compaction-thresholds", organization] as const;
 
-export const userCompactionThresholds = () => ({
-	queryKey: userCompactionThresholdsKey,
-	queryFn: () => API.experimental.getUserChatCompactionThresholds(),
+export const userCompactionThresholds = (organization: string) => ({
+	queryKey: userCompactionThresholdsKey(organization),
+	queryFn: () => API.experimental.getUserChatCompactionThresholds(organization),
 });
 
+type UpdateUserCompactionThresholdArgs = {
+	organization: string;
+	modelConfigId: string;
+	req: TypesGen.UpdateUserChatCompactionThresholdRequest;
+};
+
+type DeleteUserCompactionThresholdArgs = Pick<
+	UpdateUserCompactionThresholdArgs,
+	"organization" | "modelConfigId"
+>;
+
 export const updateUserCompactionThreshold = (queryClient: QueryClient) => ({
-	mutationFn: (vars: {
-		modelConfigId: string;
-		req: TypesGen.UpdateUserChatCompactionThresholdRequest;
-	}) =>
+	mutationFn: ({
+		organization,
+		modelConfigId,
+		req,
+	}: UpdateUserCompactionThresholdArgs) =>
 		API.experimental.updateUserChatCompactionThreshold(
-			vars.modelConfigId,
-			vars.req,
+			organization,
+			modelConfigId,
+			req,
 		),
-	onSuccess: async () => {
+	onSuccess: async (
+		_data: TypesGen.UserChatCompactionThreshold,
+		{ organization }: UpdateUserCompactionThresholdArgs,
+	) => {
 		await queryClient.invalidateQueries({
-			queryKey: userCompactionThresholdsKey,
+			queryKey: userCompactionThresholdsKey(organization),
 		});
 	},
 });
 
 export const deleteUserCompactionThreshold = (queryClient: QueryClient) => ({
-	mutationFn: (modelConfigId: string) =>
-		API.experimental.deleteUserChatCompactionThreshold(modelConfigId),
-	onSuccess: async () => {
+	mutationFn: ({
+		organization,
+		modelConfigId,
+	}: DeleteUserCompactionThresholdArgs) =>
+		API.experimental.deleteUserChatCompactionThreshold(
+			organization,
+			modelConfigId,
+		),
+	onSuccess: async (
+		_data: unknown,
+		{ organization }: DeleteUserCompactionThresholdArgs,
+	) => {
 		await queryClient.invalidateQueries({
-			queryKey: userCompactionThresholdsKey,
+			queryKey: userCompactionThresholdsKey(organization),
 		});
 	},
 });
 
-export const chatModelsKey = ["chat-models"] as const;
+const chatModelsKeyPrefix = [...chatsKey, "models"] as const;
 
-export const chatModels = () => ({
-	queryKey: chatModelsKey,
+export const chatModelsKey = (organization: string) =>
+	[...chatModelsKeyPrefix, organization] as const;
+
+export const chatModels = (organization: string) => ({
+	queryKey: chatModelsKey(organization),
 	queryFn: (): Promise<TypesGen.ChatModelsResponse> =>
-		API.experimental.getChatModels(),
+		API.experimental.getChatModels(organization),
 });
 
 const chatProviderConfigsKey = ["chat-provider-configs"] as const;
@@ -1822,12 +1911,33 @@ export const chatProviderConfigs = () => ({
 	},
 });
 
-const chatModelConfigsKey = ["chat-model-configs"] as const;
+const chatModelConfigsKeyPrefix = [...chatsKey, "model-configs"] as const;
 
-export const chatModelConfigs = () => ({
-	queryKey: chatModelConfigsKey,
+export const chatModelConfigsKey = (organization: string) =>
+	[...chatModelConfigsKeyPrefix, organization] as const;
+
+export const chatModelConfigKey = (modelConfigId: string) =>
+	[...chatsKey, "model-config", modelConfigId] as const;
+
+export const chatModelConfigACLKey = (modelConfigId: string) =>
+	[...chatModelConfigKey(modelConfigId), "acl"] as const;
+
+export const chatModelConfigs = (organization: string) => ({
+	queryKey: chatModelConfigsKey(organization),
 	queryFn: (): Promise<TypesGen.ChatModelConfig[]> =>
-		API.experimental.getChatModelConfigs(),
+		API.experimental.getChatModelConfigs(organization),
+});
+
+export const chatModelConfig = (modelConfigId: string) => ({
+	queryKey: chatModelConfigKey(modelConfigId),
+	queryFn: (): Promise<TypesGen.ChatModelConfig> =>
+		API.experimental.getChatModelConfig(modelConfigId),
+});
+
+export const chatModelConfigACL = (modelConfigId: string) => ({
+	queryKey: chatModelConfigACLKey(modelConfigId),
+	queryFn: (): Promise<TypesGen.ChatModelConfigACL> =>
+		API.experimental.getChatModelConfigACL(modelConfigId),
 });
 
 export const userChatProviderConfigsKey = [
@@ -1864,7 +1974,7 @@ export const upsertUserChatProviderKey = (queryClient: QueryClient) => ({
 			queryClient.invalidateQueries({
 				queryKey: userChatProviderConfigsKey,
 			}),
-			queryClient.invalidateQueries({ queryKey: chatModelsKey }),
+			queryClient.invalidateQueries({ queryKey: chatModelsKeyPrefix }),
 		]);
 	},
 });
@@ -1877,55 +1987,113 @@ export const deleteUserChatProviderKey = (queryClient: QueryClient) => ({
 			queryClient.invalidateQueries({
 				queryKey: userChatProviderConfigsKey,
 			}),
-			queryClient.invalidateQueries({ queryKey: chatModelsKey }),
+			queryClient.invalidateQueries({ queryKey: chatModelsKeyPrefix }),
 		]);
 	},
 });
 
-const invalidateChatConfigurationQueries = async (queryClient: QueryClient) => {
+const invalidateChatConfigurationQueries = async (
+	queryClient: QueryClient,
+	organization: string,
+) => {
 	await Promise.all([
-		queryClient.invalidateQueries({ queryKey: chatProviderConfigsKey }),
-		queryClient.invalidateQueries({ queryKey: chatModelConfigsKey }),
-		queryClient.invalidateQueries({ queryKey: chatModelsKey }),
+		queryClient.invalidateQueries({
+			queryKey: chatModelConfigsKey(organization),
+		}),
+		queryClient.invalidateQueries({ queryKey: chatModelsKey(organization) }),
 	]);
 };
 
-// Called after AI provider mutations so open model pickers refresh.
+// Called after AI provider mutations so model lists refresh across organizations.
 export const invalidateChatProviderDependentQueries = async (
 	queryClient: QueryClient,
 ) => {
 	await Promise.all([
-		invalidateChatConfigurationQueries(queryClient),
+		queryClient.invalidateQueries({ queryKey: chatProviderConfigsKey }),
+		queryClient.invalidateQueries({ queryKey: chatModelConfigsKeyPrefix }),
+		queryClient.invalidateQueries({ queryKey: chatModelsKeyPrefix }),
 		queryClient.invalidateQueries({ queryKey: userChatProviderConfigsKey }),
 	]);
 };
 
+type CreateChatModelConfigMutationArgs = {
+	organization: string;
+	req: TypesGen.CreateChatModelConfigRequest;
+};
+
 export const createChatModelConfig = (queryClient: QueryClient) => ({
-	mutationFn: (req: TypesGen.CreateChatModelConfigRequest) =>
-		API.experimental.createChatModelConfig(req),
-	onSuccess: async () => {
-		await invalidateChatConfigurationQueries(queryClient);
-	},
+	mutationFn: ({ organization, req }: CreateChatModelConfigMutationArgs) =>
+		API.experimental.createChatModelConfig(organization, req),
+	onSuccess: async (
+		_data: TypesGen.ChatModelConfig,
+		{ organization }: CreateChatModelConfigMutationArgs,
+	) => invalidateChatConfigurationQueries(queryClient, organization),
 });
 
 type UpdateChatModelConfigMutationArgs = {
+	organization: string;
 	modelConfigId: string;
 	req: TypesGen.UpdateChatModelConfigRequest;
 };
 
+type DeleteChatModelConfigMutationArgs = Pick<
+	UpdateChatModelConfigMutationArgs,
+	"organization" | "modelConfigId"
+>;
+
 export const updateChatModelConfig = (queryClient: QueryClient) => ({
 	mutationFn: ({ modelConfigId, req }: UpdateChatModelConfigMutationArgs) =>
 		API.experimental.updateChatModelConfig(modelConfigId, req),
-	onSuccess: async () => {
-		await invalidateChatConfigurationQueries(queryClient);
+	onSuccess: async (
+		_data: TypesGen.ChatModelConfig,
+		{ organization, modelConfigId }: UpdateChatModelConfigMutationArgs,
+	) => {
+		await Promise.all([
+			invalidateChatConfigurationQueries(queryClient, organization),
+			queryClient.invalidateQueries({
+				queryKey: chatModelConfigKey(modelConfigId),
+			}),
+		]);
 	},
 });
 
 export const deleteChatModelConfig = (queryClient: QueryClient) => ({
-	mutationFn: (modelConfigId: string) =>
+	mutationFn: ({ modelConfigId }: DeleteChatModelConfigMutationArgs) =>
 		API.experimental.deleteChatModelConfig(modelConfigId),
-	onSuccess: async () => {
-		await invalidateChatConfigurationQueries(queryClient);
+	onSuccess: async (
+		_data: unknown,
+		{ organization, modelConfigId }: DeleteChatModelConfigMutationArgs,
+	) => {
+		await Promise.all([
+			invalidateChatConfigurationQueries(queryClient, organization),
+			queryClient.invalidateQueries({
+				queryKey: chatModelConfigKey(modelConfigId),
+			}),
+		]);
+	},
+});
+
+type UpdateChatModelConfigACLMutationArgs = {
+	organization: string;
+	modelConfigId: string;
+	req: TypesGen.UpdateChatModelConfigACL;
+};
+
+export const updateChatModelConfigACL = (queryClient: QueryClient) => ({
+	mutationFn: ({ modelConfigId, req }: UpdateChatModelConfigACLMutationArgs) =>
+		API.experimental.updateChatModelConfigACL(modelConfigId, req),
+	onSuccess: async (
+		_data: unknown,
+		{ organization, modelConfigId }: UpdateChatModelConfigACLMutationArgs,
+	) => {
+		await Promise.all([
+			queryClient.invalidateQueries({
+				queryKey: chatModelConfigACLKey(modelConfigId),
+			}),
+			queryClient.invalidateQueries({
+				queryKey: chatModelConfigsKey(organization),
+			}),
+		]);
 	},
 });
 
@@ -2056,52 +2224,137 @@ export const deleteChatUsageLimitGroupOverride = (
 	},
 });
 
-// ── MCP Server Configs ───────────────────────────────────────
+export const mcpServerConfigsKey = (organization: string) =>
+	[...chatsKey, "mcp-server-configs", organization] as const;
 
-export const mcpServerConfigsKey = ["mcp-server-configs"] as const;
+export const mcpServerConfigKey = (serverId: string) =>
+	[...chatsKey, "mcp-server-config", serverId] as const;
 
-export const mcpServerConfigs = () => ({
-	queryKey: mcpServerConfigsKey,
+export const mcpServerConfigACLKey = (serverId: string) =>
+	[...mcpServerConfigKey(serverId), "acl"] as const;
+
+export const mcpServerConfigs = (organization: string) => ({
+	queryKey: mcpServerConfigsKey(organization),
 	queryFn: (): Promise<TypesGen.MCPServerConfig[]> =>
-		API.experimental.getMCPServerConfigs(),
+		API.experimental.getMCPServerConfigs(organization),
 });
 
-const invalidateMCPServerConfigQueries = async (queryClient: QueryClient) => {
-	await queryClient.invalidateQueries({ queryKey: mcpServerConfigsKey });
+export const mcpServerConfig = (serverId: string) => ({
+	queryKey: mcpServerConfigKey(serverId),
+	queryFn: (): Promise<TypesGen.MCPServerConfig> =>
+		API.experimental.getMCPServerConfig(serverId),
+});
+
+export const mcpServerConfigACL = (serverId: string) => ({
+	queryKey: mcpServerConfigACLKey(serverId),
+	queryFn: (): Promise<TypesGen.MCPServerConfigACL> =>
+		API.experimental.getMCPServerConfigACL(serverId),
+});
+
+type CreateMCPServerConfigMutationArgs = {
+	organization: string;
+	req: TypesGen.CreateMCPServerConfigRequest;
 };
 
 export const createMCPServerConfig = (queryClient: QueryClient) => ({
-	mutationFn: (req: TypesGen.CreateMCPServerConfigRequest) =>
-		API.experimental.createMCPServerConfig(req),
-	onSuccess: async () => {
-		await invalidateMCPServerConfigQueries(queryClient);
+	mutationFn: ({ organization, req }: CreateMCPServerConfigMutationArgs) =>
+		API.experimental.createMCPServerConfig(organization, req),
+	onSuccess: async (
+		_data: TypesGen.MCPServerConfig,
+		{ organization }: CreateMCPServerConfigMutationArgs,
+	) => {
+		await queryClient.invalidateQueries({
+			queryKey: mcpServerConfigsKey(organization),
+		});
 	},
 });
 
 type UpdateMCPServerConfigMutationArgs = {
-	id: string;
+	organization: string;
+	serverId: string;
 	req: TypesGen.UpdateMCPServerConfigRequest;
 };
 
+type DeleteMCPServerConfigMutationArgs = Pick<
+	UpdateMCPServerConfigMutationArgs,
+	"organization" | "serverId"
+>;
+
 export const updateMCPServerConfig = (queryClient: QueryClient) => ({
-	mutationFn: ({ id, req }: UpdateMCPServerConfigMutationArgs) =>
-		API.experimental.updateMCPServerConfig(id, req),
-	onSuccess: async () => {
-		await invalidateMCPServerConfigQueries(queryClient);
+	mutationFn: ({ serverId, req }: UpdateMCPServerConfigMutationArgs) =>
+		API.experimental.updateMCPServerConfig(serverId, req),
+	onSuccess: async (
+		_data: TypesGen.MCPServerConfig,
+		{ organization, serverId }: UpdateMCPServerConfigMutationArgs,
+	) => {
+		await Promise.all([
+			queryClient.invalidateQueries({
+				queryKey: mcpServerConfigKey(serverId),
+			}),
+			queryClient.invalidateQueries({
+				queryKey: mcpServerConfigsKey(organization),
+			}),
+		]);
 	},
 });
 
 export const deleteMCPServerConfig = (queryClient: QueryClient) => ({
-	mutationFn: (id: string) => API.experimental.deleteMCPServerConfig(id),
-	onSuccess: async () => {
-		await invalidateMCPServerConfigQueries(queryClient);
+	mutationFn: ({ serverId }: DeleteMCPServerConfigMutationArgs) =>
+		API.experimental.deleteMCPServerConfig(serverId),
+	onSuccess: async (
+		_data: unknown,
+		{ organization, serverId }: DeleteMCPServerConfigMutationArgs,
+	) => {
+		await Promise.all([
+			queryClient.invalidateQueries({
+				queryKey: mcpServerConfigKey(serverId),
+			}),
+			queryClient.invalidateQueries({
+				queryKey: mcpServerConfigsKey(organization),
+			}),
+		]);
+	},
+});
+
+type UpdateMCPServerConfigACLMutationArgs = {
+	organization: string;
+	serverId: string;
+	req: TypesGen.UpdateMCPServerConfigACL;
+};
+
+export const updateMCPServerConfigACL = (queryClient: QueryClient) => ({
+	mutationFn: ({ serverId, req }: UpdateMCPServerConfigACLMutationArgs) =>
+		API.experimental.updateMCPServerConfigACL(serverId, req),
+	onSuccess: async (
+		_data: unknown,
+		{ organization, serverId }: UpdateMCPServerConfigACLMutationArgs,
+	) => {
+		await Promise.all([
+			queryClient.invalidateQueries({
+				queryKey: mcpServerConfigACLKey(serverId),
+			}),
+			queryClient.invalidateQueries({
+				queryKey: mcpServerConfigsKey(organization),
+			}),
+		]);
 	},
 });
 
 export const disconnectMCPServerOAuth2 = (queryClient: QueryClient) => ({
-	mutationFn: (id: string) => API.experimental.disconnectMCPServerOAuth2(id),
-	onSuccess: async () => {
-		await invalidateMCPServerConfigQueries(queryClient);
+	mutationFn: ({ serverId }: DeleteMCPServerConfigMutationArgs) =>
+		API.experimental.disconnectMCPServerOAuth2(serverId),
+	onSuccess: async (
+		_data: TypesGen.MCPServerOAuth2DisconnectResponse,
+		{ organization, serverId }: DeleteMCPServerConfigMutationArgs,
+	) => {
+		await Promise.all([
+			queryClient.invalidateQueries({
+				queryKey: mcpServerConfigKey(serverId),
+			}),
+			queryClient.invalidateQueries({
+				queryKey: mcpServerConfigsKey(organization),
+			}),
+		]);
 	},
 });
 

--- a/site/src/api/queries/organizations.test.ts
+++ b/site/src/api/queries/organizations.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { API } from "#/api/api";
 import type { AuthorizationCheck, Organization } from "#/api/typesGenerated";
-import { permittedOrganizations } from "./organizations";
+import {
+	aiResourceOrganizationPermissions,
+	permittedOrganizations,
+} from "./organizations";
 
 // Mock the API module
 vi.mock("#/api/api", () => ({
@@ -39,6 +42,51 @@ const templateCreateCheck: AuthorizationCheck = {
 	object: { resource_type: "template" },
 	action: "create",
 };
+
+describe("aiResourceOrganizationPermissions", () => {
+	it("checks every AI resource permission for each organization", async () => {
+		const checkAuthMock = vi.mocked(API.checkAuthorization);
+		checkAuthMock.mockResolvedValue({
+			"org-1.createChat": true,
+			"org-2.createChat": false,
+		});
+
+		const config = aiResourceOrganizationPermissions(["org-2", "org-1"]);
+		const result = await config.queryFn!();
+
+		expect(config.queryKey).toEqual([
+			"organizations",
+			["org-1", "org-2"],
+			"ai-resource-permissions",
+		]);
+		expect(checkAuthMock).toHaveBeenCalledWith({
+			checks: expect.objectContaining({
+				"org-1.createChat": {
+					object: { resource_type: "chat", organization_id: "org-1" },
+					action: "create",
+				},
+				"org-2.viewModels": {
+					object: {
+						resource_type: "chat_model_config",
+						organization_id: "org-2",
+					},
+					action: "read",
+				},
+				"org-2.viewMCPServers": {
+					object: {
+						resource_type: "mcp_server_config",
+						organization_id: "org-2",
+					},
+					action: "read",
+				},
+			}),
+		});
+		expect(result).toEqual({
+			"org-1": { createChat: true },
+			"org-2": { createChat: false },
+		});
+	});
+});
 
 describe("permittedOrganizations", () => {
 	it("returns query config with correct queryKey", () => {

--- a/site/src/api/queries/organizations.ts
+++ b/site/src/api/queries/organizations.ts
@@ -18,6 +18,9 @@ import type {
 import type { MetadataState } from "#/hooks/useEmbeddedMetadata";
 import type { UsePaginatedQueryOptions } from "#/hooks/usePaginatedQuery";
 import {
+	type AIResourceOrganizationPermissionName,
+	type AIResourceOrganizationPermissions,
+	aiResourceOrganizationPermissionChecks,
 	type OrganizationPermissionName,
 	type OrganizationPermissions,
 	organizationPermissionChecks,
@@ -368,6 +371,47 @@ export const organizationsPermissions = (
 			) as Record<string, OrganizationPermissions>;
 		},
 	};
+};
+
+export const aiResourceOrganizationPermissions = (
+	organizationIds: readonly string[],
+) => {
+	const sortedOrganizationIds = [...organizationIds].sort();
+	return {
+		enabled: sortedOrganizationIds.length > 0,
+		queryKey: [
+			"organizations",
+			sortedOrganizationIds,
+			"ai-resource-permissions",
+		] as const,
+		queryFn: async () => {
+			const prefixedChecks = sortedOrganizationIds.flatMap((organizationId) =>
+				Object.entries(
+					aiResourceOrganizationPermissionChecks(organizationId),
+				).map(([name, check]) => [`${organizationId}.${name}`, check]),
+			);
+			const response = await API.checkAuthorization({
+				checks: Object.fromEntries(prefixedChecks),
+			});
+			return Object.entries(response).reduce(
+				(acc, [key, value]) => {
+					const separator = key.indexOf(".");
+					const organizationId = key.substring(0, separator);
+					const permission = key.substring(separator + 1);
+					if (!acc[organizationId]) {
+						acc[organizationId] = {};
+					}
+					acc[organizationId][
+						permission as AIResourceOrganizationPermissionName
+					] = value;
+					return acc;
+				},
+				{} as Record<string, Partial<AIResourceOrganizationPermissions>>,
+			) as Record<string, AIResourceOrganizationPermissions>;
+		},
+	} satisfies UseQueryOptions<
+		Record<string, AIResourceOrganizationPermissions>
+	>;
 };
 
 export const workspacePermissionsByOrganization = (

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2629,6 +2629,7 @@ export interface ChatModelCallConfig {
  */
 export interface ChatModelConfig {
 	readonly id: string;
+	readonly organization_id: string;
 	readonly ai_provider_id: string;
 	readonly model: string;
 	readonly display_name: string;

--- a/site/src/components/AIResourceOrganizationSelector/AIResourceOrganizationSelector.tsx
+++ b/site/src/components/AIResourceOrganizationSelector/AIResourceOrganizationSelector.tsx
@@ -1,0 +1,18 @@
+import type { FC } from "react";
+import { useAIResourceOrganization } from "#/contexts/AIResourceOrganizationContext";
+import { CompactOrgSelector } from "#/pages/AgentsPage/components/ChatElements";
+
+export const AIResourceOrganizationSelector: FC = () => {
+	const { organization, organizations, selectOrganization } =
+		useAIResourceOrganization();
+	if (organizations.length < 2) {
+		return null;
+	}
+	return (
+		<CompactOrgSelector
+			value={organization ?? null}
+			options={organizations}
+			onChange={selectOrganization}
+		/>
+	);
+};

--- a/site/src/contexts/AIResourceOrganizationContext.stories.tsx
+++ b/site/src/contexts/AIResourceOrganizationContext.stories.tsx
@@ -1,0 +1,134 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, spyOn, within } from "storybook/test";
+import { reactRouterParameters } from "storybook-addon-remix-react-router";
+import { API } from "#/api/api";
+import { AIResourceOrganizationSelector } from "#/components/AIResourceOrganizationSelector/AIResourceOrganizationSelector";
+import {
+	MockDefaultOrganization,
+	MockOrganization2,
+} from "#/testHelpers/entities";
+import { withDashboardProvider } from "#/testHelpers/storybook";
+import { AIResourceOrganizationProvider } from "./AIResourceOrganizationContext";
+
+const OrganizationSelection = () => (
+	<AIResourceOrganizationProvider
+		isOrganizationPermitted={(permissions) => permissions.createChat}
+	>
+		<AIResourceOrganizationSelector />
+		<div>Organization-owned content</div>
+	</AIResourceOrganizationProvider>
+);
+
+const allPermissions = (allowed: boolean) =>
+	Object.fromEntries(
+		[MockDefaultOrganization, MockOrganization2].flatMap((organization) =>
+			[
+				"createChat",
+				"createModel",
+				"viewModels",
+				"editModels",
+				"deleteModels",
+				"createMCPServers",
+				"viewMCPServers",
+				"editMCPServers",
+				"deleteMCPServers",
+			].map((permission) => [`${organization.id}.${permission}`, allowed]),
+		),
+	);
+
+const meta: Meta<typeof OrganizationSelection> = {
+	title: "contexts/AIResourceOrganizationContext",
+	component: OrganizationSelection,
+	decorators: [withDashboardProvider],
+	parameters: {
+		organizations: [MockDefaultOrganization, MockOrganization2],
+		showOrganizations: true,
+	},
+	beforeEach: () => {
+		spyOn(API, "checkAuthorization").mockResolvedValue(allPermissions(true));
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof OrganizationSelection>;
+
+export const SelectsURLOrganization: Story = {
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: {
+				path: "/agents",
+				searchParams: {
+					organization: MockOrganization2.name,
+					tab: "recent",
+				},
+			},
+			routing: [{ path: "/agents", useStoryElement: true }],
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.findByRole("button", {
+				name: `Organization: ${MockOrganization2.display_name}`,
+			}),
+		).resolves.toBeVisible();
+		await expect(
+			canvas.findByText("Organization-owned content"),
+		).resolves.toBeVisible();
+	},
+};
+
+export const SelectsPermittedOrganizationForAction: Story = {
+	beforeEach: () => {
+		spyOn(API, "checkAuthorization").mockResolvedValue({
+			...allPermissions(true),
+			[`${MockDefaultOrganization.id}.createChat`]: false,
+		});
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: {
+				path: "/agents",
+				searchParams: {
+					organization: MockDefaultOrganization.name,
+				},
+			},
+			routing: [{ path: "/agents", useStoryElement: true }],
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.findByText("Organization-owned content"),
+		).resolves.toBeVisible();
+		await expect(
+			canvas.queryByRole("button", {
+				name: `Organization: ${MockDefaultOrganization.display_name}`,
+			}),
+		).not.toBeInTheDocument();
+	},
+};
+
+export const NoOrganizations: Story = {
+	parameters: {
+		organizations: [],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.findByText("No permitted organizations found"),
+		).resolves.toBeVisible();
+	},
+};
+
+export const NoPermittedOrganizations: Story = {
+	beforeEach: () => {
+		spyOn(API, "checkAuthorization").mockResolvedValue(allPermissions(false));
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.findByText("No permitted organizations found"),
+		).resolves.toBeVisible();
+	},
+};

--- a/site/src/contexts/AIResourceOrganizationContext.test.ts
+++ b/site/src/contexts/AIResourceOrganizationContext.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { Organization } from "#/api/typesGenerated";
+import { resolveAIResourceOrganization } from "./AIResourceOrganizationContext";
+
+const organizations: Organization[] = [
+	{
+		id: "other-id",
+		name: "other",
+		display_name: "Other",
+		description: "",
+		icon: "",
+		created_at: "",
+		updated_at: "",
+		is_default: false,
+		default_org_member_roles: [],
+	},
+	{
+		id: "default-id",
+		name: "default",
+		display_name: "Default",
+		description: "",
+		icon: "",
+		created_at: "",
+		updated_at: "",
+		is_default: true,
+		default_org_member_roles: [],
+	},
+];
+
+describe("resolveAIResourceOrganization", () => {
+	it("uses the URL organization when it is permitted", () => {
+		expect(resolveAIResourceOrganization(organizations, "other")).toEqual(
+			organizations[0],
+		);
+	});
+
+	it("uses the permitted default for a missing or invalid URL organization", () => {
+		expect(resolveAIResourceOrganization(organizations, null)).toEqual(
+			organizations[1],
+		);
+		expect(resolveAIResourceOrganization(organizations, "invalid")).toEqual(
+			organizations[1],
+		);
+	});
+
+	it("uses the first permitted organization when none is default", () => {
+		expect(
+			resolveAIResourceOrganization(
+				organizations.map((organization) => ({
+					...organization,
+					is_default: false,
+				})),
+				null,
+			),
+		).toMatchObject({ id: "other-id" });
+	});
+
+	it("returns undefined when no organization is permitted", () => {
+		expect(resolveAIResourceOrganization([], "default")).toBeUndefined();
+	});
+});

--- a/site/src/contexts/AIResourceOrganizationContext.tsx
+++ b/site/src/contexts/AIResourceOrganizationContext.tsx
@@ -1,0 +1,187 @@
+import {
+	createContext,
+	type FC,
+	type PropsWithChildren,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+} from "react";
+import { useQuery } from "react-query";
+import { Outlet, useOutletContext, useSearchParams } from "react-router";
+import { aiResourceOrganizationPermissions } from "#/api/queries/organizations";
+import type { Organization } from "#/api/typesGenerated";
+import { ErrorAlert } from "#/components/Alert/ErrorAlert";
+import { EmptyState } from "#/components/EmptyState/EmptyState";
+import { Loader } from "#/components/Loader/Loader";
+import { useDashboard } from "#/modules/dashboard/useDashboard";
+import type { AIResourceOrganizationPermissions } from "#/modules/permissions/organizations";
+
+const organizationSearchParam = "organization";
+
+export const resolveAIResourceOrganization = (
+	organizations: readonly Organization[],
+	organizationName: string | null,
+): Organization | undefined => {
+	const selected = organizationName
+		? organizations.find(
+				(organization) => organization.name === organizationName,
+			)
+		: undefined;
+	return (
+		selected ??
+		organizations.find((organization) => organization.is_default) ??
+		organizations[0]
+	);
+};
+
+type OrganizationChangeGuard = (
+	nextOrganization: Organization,
+) => boolean | Promise<boolean>;
+
+type AIResourceOrganizationContextValue = Readonly<{
+	organizations: readonly Organization[];
+	organization: Organization;
+	permissions: AIResourceOrganizationPermissions;
+	permissionsByOrganizationId: Record<
+		string,
+		AIResourceOrganizationPermissions
+	>;
+	selectOrganization: (organization: Organization) => Promise<void>;
+	registerOrganizationChangeGuard: (
+		guard: OrganizationChangeGuard,
+	) => () => void;
+}>;
+
+const AIResourceOrganizationContext = createContext<
+	AIResourceOrganizationContextValue | undefined
+>(undefined);
+
+type AIResourceOrganizationProviderProps = PropsWithChildren<{
+	isOrganizationPermitted: (
+		permissions: AIResourceOrganizationPermissions,
+	) => boolean;
+}>;
+
+export const AIResourceOrganizationProvider: FC<
+	AIResourceOrganizationProviderProps
+> = ({ children, isOrganizationPermitted }) => {
+	const { organizations } = useDashboard();
+	const [searchParams, setSearchParams] = useSearchParams();
+	const organizationChangeGuardRef = useRef<
+		OrganizationChangeGuard | undefined
+	>(undefined);
+	const organizationIds = useMemo(
+		() => organizations.map((organization) => organization.id),
+		[organizations],
+	);
+	const permissionsQuery = useQuery(
+		aiResourceOrganizationPermissions(organizationIds),
+	);
+	const permittedOrganizations = organizations.filter((organization) => {
+		const permissions = permissionsQuery.data?.[organization.id];
+		return permissions ? isOrganizationPermitted(permissions) : false;
+	});
+	const organization = resolveAIResourceOrganization(
+		permittedOrganizations,
+		searchParams.get(organizationSearchParam),
+	);
+
+	useEffect(() => {
+		if (!organization) {
+			return;
+		}
+		if (searchParams.get(organizationSearchParam) === organization.name) {
+			return;
+		}
+		setSearchParams(
+			(current) => {
+				const next = new URLSearchParams(current);
+				next.set(organizationSearchParam, organization.name);
+				return next;
+			},
+			{ replace: true },
+		);
+	}, [organization, searchParams, setSearchParams]);
+
+	if (organizations.length === 0) {
+		return <EmptyState message="No permitted organizations found" />;
+	}
+	if (permissionsQuery.isLoading) {
+		return <Loader />;
+	}
+	if (permissionsQuery.error) {
+		return <ErrorAlert error={permissionsQuery.error} />;
+	}
+	if (!organization) {
+		return <EmptyState message="No permitted organizations found" />;
+	}
+
+	const selectOrganization = async (nextOrganization: Organization) => {
+		if (
+			organizationChangeGuardRef.current &&
+			!(await organizationChangeGuardRef.current(nextOrganization))
+		) {
+			return;
+		}
+		setSearchParams((current) => {
+			const next = new URLSearchParams(current);
+			next.set(organizationSearchParam, nextOrganization.name);
+			return next;
+		});
+	};
+	const registerOrganizationChangeGuard = (guard: OrganizationChangeGuard) => {
+		organizationChangeGuardRef.current = guard;
+		return () => {
+			if (organizationChangeGuardRef.current === guard) {
+				organizationChangeGuardRef.current = undefined;
+			}
+		};
+	};
+
+	return (
+		<AIResourceOrganizationContext.Provider
+			value={{
+				organizations: permittedOrganizations,
+				organization,
+				permissions: permissionsQuery.data?.[
+					organization.id
+				] as AIResourceOrganizationPermissions,
+				permissionsByOrganizationId: permissionsQuery.data ?? {},
+				selectOrganization,
+				registerOrganizationChangeGuard,
+			}}
+		>
+			{children}
+		</AIResourceOrganizationContext.Provider>
+	);
+};
+
+type AIResourceOrganizationOutletProps = {
+	isOrganizationPermitted: (
+		permissions: AIResourceOrganizationPermissions,
+	) => boolean;
+};
+
+export const AIResourceOrganizationOutlet: FC<
+	AIResourceOrganizationOutletProps
+> = ({ isOrganizationPermitted }) => {
+	const outletContext = useOutletContext();
+	return (
+		<AIResourceOrganizationProvider
+			isOrganizationPermitted={isOrganizationPermitted}
+		>
+			<Outlet context={outletContext} />
+		</AIResourceOrganizationProvider>
+	);
+};
+
+export const useAIResourceOrganization = () => {
+	const context = useContext(AIResourceOrganizationContext);
+	if (!context) {
+		throw new Error(
+			"useAIResourceOrganization must be used inside AIResourceOrganizationProvider",
+		);
+	}
+	return context;
+};

--- a/site/src/modules/dashboard/Navbar/Navbar.tsx
+++ b/site/src/modules/dashboard/Navbar/Navbar.tsx
@@ -29,6 +29,8 @@ export const Navbar: FC = () => {
 		featureVisibility.aibridge && permissions.viewAnyAIBridgeInterception;
 	const canViewAISettings =
 		permissions.viewAnyAIProvider ||
+		permissions.viewAnyChatModelConfig ||
+		permissions.viewAnyMCPServerConfig ||
 		permissions.viewAIGatewayKeys ||
 		permissions.editDeploymentConfig;
 	const canCreateChat = permissions.createChat;

--- a/site/src/modules/management/AISettingsSidebarView.stories.tsx
+++ b/site/src/modules/management/AISettingsSidebarView.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import { MockNoPermissions, MockPermissions } from "#/testHelpers/entities";
 import AISettingsSidebarView from "./AISettingsSidebarView";
@@ -75,6 +76,46 @@ export const NoDeploymentConfig: Story = {
 			...MockPermissions,
 			editDeploymentConfig: false,
 		},
+	},
+};
+
+export const ModelReadOnly: Story = {
+	args: {
+		permissions: {
+			...MockNoPermissions,
+			viewAnyChatModelConfig: true,
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByRole("link", { name: "Models" })).toBeVisible();
+		await expect(
+			canvas.queryByRole("link", { name: "MCP servers" }),
+		).not.toBeInTheDocument();
+		await expect(
+			canvas.queryByRole("link", { name: "Coder Agents" }),
+		).not.toBeInTheDocument();
+	},
+};
+
+export const MCPReadOnly: Story = {
+	args: {
+		permissions: {
+			...MockNoPermissions,
+			viewAnyMCPServerConfig: true,
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("link", { name: "MCP servers" }),
+		).toBeVisible();
+		await expect(
+			canvas.queryByRole("link", { name: "Models" }),
+		).not.toBeInTheDocument();
+		await expect(
+			canvas.queryByRole("link", { name: "Templates" }),
+		).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/modules/management/AISettingsSidebarView.tsx
+++ b/site/src/modules/management/AISettingsSidebarView.tsx
@@ -1,5 +1,5 @@
 import type { FC, ReactNode } from "react";
-import { NavLink } from "react-router";
+import { NavLink, useLocation } from "react-router";
 import {
 	Sidebar as BaseSidebar,
 	SettingsSidebarNavItem as SidebarNavItem,
@@ -15,21 +15,24 @@ interface AISettingsSidebarViewProps {
 const SubNavItem: FC<{ href: string; children?: ReactNode }> = ({
 	href,
 	children,
-}) => (
-	<NavLink
-		to={href}
-		className={({ isActive }) =>
-			cn(
-				"relative -ml-px text-sm text-content-secondary no-underline font-medium py-2 pl-4 pr-3 transition-colors",
-				"border-0 border-solid border-l border-l-transparent hover:text-content-primary",
-				isActive &&
-					"border-l-content-primary font-semibold text-content-primary",
-			)
-		}
-	>
-		{children}
-	</NavLink>
-);
+}) => {
+	const location = useLocation();
+	return (
+		<NavLink
+			to={{ pathname: href, search: location.search }}
+			className={({ isActive }) =>
+				cn(
+					"relative -ml-px text-sm text-content-secondary no-underline font-medium py-2 pl-4 pr-3 transition-colors",
+					"border-0 border-solid border-l border-l-transparent hover:text-content-primary",
+					isActive &&
+						"border-l-content-primary font-semibold text-content-primary",
+				)
+			}
+		>
+			{children}
+		</NavLink>
+	);
+};
 
 const AISettingsSidebarView: FC<AISettingsSidebarViewProps> = ({
 	permissions,
@@ -53,23 +56,35 @@ const AISettingsSidebarView: FC<AISettingsSidebarViewProps> = ({
 					</SidebarNavItem>
 				)}
 				{permissions.editDeploymentConfig && (
-					<>
-						<SidebarNavItem href="/ai/settings/coder-agents">
-							Coder Agents
-						</SidebarNavItem>
-						<div className="flex flex-col gap-1 ml-3 border-0 border-solid border-l border-l-border">
+					<SidebarNavItem href="/ai/settings/coder-agents">
+						Coder Agents
+					</SidebarNavItem>
+				)}
+				{(permissions.editDeploymentConfig ||
+					permissions.viewAnyChatModelConfig ||
+					permissions.viewAnyMCPServerConfig) && (
+					<div className="flex flex-col gap-1 ml-3 border-0 border-solid border-l border-l-border">
+						{(permissions.editDeploymentConfig ||
+							permissions.viewAnyChatModelConfig) && (
 							<SubNavItem href="/ai/settings/models">Models</SubNavItem>
+						)}
+						{(permissions.editDeploymentConfig ||
+							permissions.viewAnyMCPServerConfig) && (
 							<SubNavItem href="/ai/settings/mcp-servers">
 								MCP servers
 							</SubNavItem>
-							<SubNavItem href="/ai/settings/templates">Templates</SubNavItem>
-							<SubNavItem href="/ai/settings/spend">Spend</SubNavItem>
-							<SubNavItem href="/ai/settings/instructions">
-								Instructions
-							</SubNavItem>
-							<SubNavItem href="/ai/settings/lifecycle">Lifecycle</SubNavItem>
-						</div>
-					</>
+						)}
+						{permissions.editDeploymentConfig && (
+							<>
+								<SubNavItem href="/ai/settings/templates">Templates</SubNavItem>
+								<SubNavItem href="/ai/settings/spend">Spend</SubNavItem>
+								<SubNavItem href="/ai/settings/instructions">
+									Instructions
+								</SubNavItem>
+								<SubNavItem href="/ai/settings/lifecycle">Lifecycle</SubNavItem>
+							</>
+						)}
+					</div>
 				)}
 			</div>
 		</BaseSidebar>

--- a/site/src/modules/permissions/organizations.ts
+++ b/site/src/modules/permissions/organizations.ts
@@ -1,5 +1,82 @@
 import type { AuthorizationCheck } from "#/api/typesGenerated";
 
+export type AIResourceOrganizationPermissions = {
+	[k in AIResourceOrganizationPermissionName]: boolean;
+};
+
+export type AIResourceOrganizationPermissionName = keyof ReturnType<
+	typeof aiResourceOrganizationPermissionChecks
+>;
+
+export const aiResourceOrganizationPermissionChecks = (
+	organizationId: string,
+) =>
+	({
+		createChat: {
+			object: {
+				resource_type: "chat",
+				organization_id: organizationId,
+			},
+			action: "create",
+		},
+		createModel: {
+			object: {
+				resource_type: "chat_model_config",
+				organization_id: organizationId,
+			},
+			action: "create",
+		},
+		viewModels: {
+			object: {
+				resource_type: "chat_model_config",
+				organization_id: organizationId,
+			},
+			action: "read",
+		},
+		editModels: {
+			object: {
+				resource_type: "chat_model_config",
+				organization_id: organizationId,
+			},
+			action: "update",
+		},
+		deleteModels: {
+			object: {
+				resource_type: "chat_model_config",
+				organization_id: organizationId,
+			},
+			action: "delete",
+		},
+		createMCPServers: {
+			object: {
+				resource_type: "mcp_server_config",
+				organization_id: organizationId,
+			},
+			action: "create",
+		},
+		viewMCPServers: {
+			object: {
+				resource_type: "mcp_server_config",
+				organization_id: organizationId,
+			},
+			action: "read",
+		},
+		editMCPServers: {
+			object: {
+				resource_type: "mcp_server_config",
+				organization_id: organizationId,
+			},
+			action: "update",
+		},
+		deleteMCPServers: {
+			object: {
+				resource_type: "mcp_server_config",
+				organization_id: organizationId,
+			},
+			action: "delete",
+		},
+	}) as const satisfies Record<string, AuthorizationCheck>;
+
 export type OrganizationPermissions = {
 	[k in OrganizationPermissionName]: boolean;
 };

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPage.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPage.tsx
@@ -1,22 +1,20 @@
 import type { FC } from "react";
-import {
-	type QueryClient,
-	useMutation,
-	useQuery,
-	useQueryClient,
-} from "react-query";
-import { API } from "#/api/api";
+import { useMutation, useQuery, useQueryClient } from "react-query";
 import {
 	chatAdvisorConfig,
 	chatComputerUseProvider,
 	chatModelConfigs,
+	chatModelOverride,
 	chatPersonalModelOverridesAdminSettings,
 	chatProviderConfigs,
 	updateChatAdvisorConfig,
 	updateChatComputerUseProvider,
+	updateChatModelOverride,
 	updateChatPersonalModelOverridesAdminSettings,
 } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
+import { AIResourceOrganizationSelector } from "#/components/AIResourceOrganizationSelector/AIResourceOrganizationSelector";
+import { useAIResourceOrganization } from "#/contexts/AIResourceOrganizationContext";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
 import { useDashboard } from "#/modules/dashboard/useDashboard";
 import { RequirePermission } from "#/modules/permissions/RequirePermission";
@@ -31,33 +29,10 @@ const titleGenerationOverrideContext: TypesGen.ChatModelOverrideContext =
 const compactionOverrideContext: TypesGen.ChatModelOverrideContext =
 	"compaction";
 
-const chatModelOverrideKey = (context: TypesGen.ChatModelOverrideContext) =>
-	["chat-model-override", context] as const;
-
-const chatModelOverrideQuery = (
-	context: TypesGen.ChatModelOverrideContext,
-) => ({
-	queryKey: chatModelOverrideKey(context),
-	queryFn: () => API.experimental.getChatModelOverride(context),
-});
-
-const updateChatModelOverrideMutation = (
-	queryClient: QueryClient,
-	context: TypesGen.ChatModelOverrideContext,
-) => ({
-	mutationFn: (req: TypesGen.UpdateChatModelOverrideRequest) =>
-		API.experimental.updateChatModelOverride(context, req),
-	onSuccess: async () => {
-		await queryClient.invalidateQueries({
-			queryKey: chatModelOverrideKey(context),
-			exact: true,
-		});
-	},
-});
-
 const CoderAgentsPage: FC = () => {
 	const { permissions } = useAuthenticated();
 	const { experiments } = useDashboard();
+	const { organization } = useAIResourceOrganization();
 	const queryClient = useQueryClient();
 	const canEditDeploymentConfig = permissions.editDeploymentConfig;
 	const showAdvisorSettings = experiments.includes("chat-advisor");
@@ -70,24 +45,24 @@ const CoderAgentsPage: FC = () => {
 		enabled: canEditDeploymentConfig,
 	});
 	const generalModelOverrideQuery = useQuery({
-		...chatModelOverrideQuery(generalOverrideContext),
+		...chatModelOverride(organization.name, generalOverrideContext),
 		enabled: canEditDeploymentConfig,
 	});
 	const exploreModelOverrideQuery = useQuery({
-		...chatModelOverrideQuery(exploreOverrideContext),
+		...chatModelOverride(organization.name, exploreOverrideContext),
 		enabled: canEditDeploymentConfig,
 	});
 	const titleGenerationModelQuery = useQuery({
-		...chatModelOverrideQuery(titleGenerationOverrideContext),
+		...chatModelOverride(organization.name, titleGenerationOverrideContext),
 		enabled: canEditDeploymentConfig,
 	});
 	const compactionModelQuery = useQuery({
-		...chatModelOverrideQuery(compactionOverrideContext),
+		...chatModelOverride(organization.name, compactionOverrideContext),
 		enabled: canEditDeploymentConfig,
 	});
-	const modelConfigsQuery = useQuery(chatModelConfigs());
+	const modelConfigsQuery = useQuery(chatModelConfigs(organization.name));
 	const advisorConfigQuery = useQuery({
-		...chatAdvisorConfig(),
+		...chatAdvisorConfig(organization.name),
 		enabled: canEditDeploymentConfig && showAdvisorSettings,
 	});
 	const computerUseProviderQuery = useQuery({
@@ -102,19 +77,16 @@ const CoderAgentsPage: FC = () => {
 		updateChatPersonalModelOverridesAdminSettings(queryClient),
 	);
 	const saveGeneralModelOverrideMutation = useMutation(
-		updateChatModelOverrideMutation(queryClient, generalOverrideContext),
+		updateChatModelOverride(queryClient),
 	);
 	const saveTitleGenerationModelMutation = useMutation(
-		updateChatModelOverrideMutation(
-			queryClient,
-			titleGenerationOverrideContext,
-		),
+		updateChatModelOverride(queryClient),
 	);
 	const saveCompactionModelMutation = useMutation(
-		updateChatModelOverrideMutation(queryClient, compactionOverrideContext),
+		updateChatModelOverride(queryClient),
 	);
 	const saveExploreModelOverrideMutation = useMutation(
-		updateChatModelOverrideMutation(queryClient, exploreOverrideContext),
+		updateChatModelOverride(queryClient),
 	);
 	const saveAdvisorConfigMutation = useMutation(
 		updateChatAdvisorConfig(queryClient),
@@ -130,6 +102,7 @@ const CoderAgentsPage: FC = () => {
 	return (
 		<RequirePermission isFeatureVisible={canEditDeploymentConfig}>
 			<title>{pageTitle("Coder Agents", "AI Settings")}</title>
+			<AIResourceOrganizationSelector />
 			<CoderAgentsPageView
 				adminOverridesData={personalModelOverridesAdminSettingsQuery.data}
 				adminOverridesError={personalModelOverridesAdminSettingsQuery.error}
@@ -163,24 +136,60 @@ const CoderAgentsPage: FC = () => {
 				isFetchingModelConfigs={
 					modelConfigsQuery.isFetching || providerConfigsQuery.isFetching
 				}
-				onSaveGeneralModelOverride={saveGeneralModelOverrideMutation.mutate}
+				onSaveGeneralModelOverride={(req, options) =>
+					saveGeneralModelOverrideMutation.mutate(
+						{
+							organization: organization.name,
+							context: generalOverrideContext,
+							req,
+						},
+						options,
+					)
+				}
 				isSavingGeneralModelOverride={
 					saveGeneralModelOverrideMutation.isPending
 				}
 				isSaveGeneralModelOverrideError={
 					saveGeneralModelOverrideMutation.isError
 				}
-				onSaveTitleGenerationModel={saveTitleGenerationModelMutation.mutate}
+				onSaveTitleGenerationModel={(req, options) =>
+					saveTitleGenerationModelMutation.mutate(
+						{
+							organization: organization.name,
+							context: titleGenerationOverrideContext,
+							req,
+						},
+						options,
+					)
+				}
 				isSavingTitleGenerationModel={
 					saveTitleGenerationModelMutation.isPending
 				}
 				isSaveTitleGenerationModelError={
 					saveTitleGenerationModelMutation.isError
 				}
-				onSaveCompactionModel={saveCompactionModelMutation.mutate}
+				onSaveCompactionModel={(req, options) =>
+					saveCompactionModelMutation.mutate(
+						{
+							organization: organization.name,
+							context: compactionOverrideContext,
+							req,
+						},
+						options,
+					)
+				}
 				isSavingCompactionModel={saveCompactionModelMutation.isPending}
 				isSaveCompactionModelError={saveCompactionModelMutation.isError}
-				onSaveExploreModelOverride={saveExploreModelOverrideMutation.mutate}
+				onSaveExploreModelOverride={(req, options) =>
+					saveExploreModelOverrideMutation.mutate(
+						{
+							organization: organization.name,
+							context: exploreOverrideContext,
+							req,
+						},
+						options,
+					)
+				}
 				isSavingExploreModelOverride={
 					saveExploreModelOverrideMutation.isPending
 				}
@@ -192,7 +201,12 @@ const CoderAgentsPage: FC = () => {
 				isAdvisorConfigLoading={advisorConfigQuery.isLoading}
 				isAdvisorConfigFetching={advisorConfigQuery.isFetching}
 				isAdvisorConfigLoadError={advisorConfigQuery.isError}
-				onSaveAdvisorConfig={saveAdvisorConfigMutation.mutate}
+				onSaveAdvisorConfig={(req, options) =>
+					saveAdvisorConfigMutation.mutate(
+						{ organization: organization.name, req },
+						options,
+					)
+				}
 				isSavingAdvisorConfig={saveAdvisorConfigMutation.isPending}
 				isSaveAdvisorConfigError={saveAdvisorConfigMutation.isError}
 				saveAdvisorConfigError={saveAdvisorConfigMutation.error}

--- a/site/src/pages/AISettingsPage/MCPServersPage/AddMCPServerPage/AddMCPServerPage.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/AddMCPServerPage/AddMCPServerPage.tsx
@@ -1,29 +1,44 @@
 import type { FC } from "react";
 import { useMutation, useQueryClient } from "react-query";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import { toast } from "sonner";
 import { getErrorMessage } from "#/api/errors";
 import { createMCPServerConfig } from "#/api/queries/chats";
-import { useAuthenticated } from "#/hooks/useAuthenticated";
+import { useAIResourceOrganization } from "#/contexts/AIResourceOrganizationContext";
 import { RequirePermission } from "#/modules/permissions/RequirePermission";
 import AddMCPServerPageView from "./AddMCPServerPageView";
 
 const AddMCPServerPage: FC = () => {
-	const { permissions } = useAuthenticated();
+	const { organization, permissions: organizationPermissions } =
+		useAIResourceOrganization();
 	const queryClient = useQueryClient();
 	const navigate = useNavigate();
+	const location = useLocation();
 	const createMutation = useMutation(createMCPServerConfig(queryClient));
 
 	return (
-		<RequirePermission isFeatureVisible={permissions.editDeploymentConfig}>
+		<RequirePermission
+			isFeatureVisible={Boolean(organizationPermissions?.createMCPServers)}
+		>
 			<AddMCPServerPageView
 				isSaving={createMutation.isPending}
-				onCancel={() => void navigate("/ai/settings/mcp-servers")}
+				onCancel={() =>
+					void navigate({
+						pathname: "/ai/settings/mcp-servers",
+						search: location.search,
+					})
+				}
 				onCreateServer={async (req) => {
 					try {
-						const server = await createMutation.mutateAsync(req);
+						const server = await createMutation.mutateAsync({
+							organization: organization.name,
+							req,
+						});
 						toast.success(`MCP server "${server.display_name}" added.`);
-						await navigate(`/ai/settings/mcp-servers/${server.id}`);
+						await navigate({
+							pathname: `/ai/settings/mcp-servers/${server.id}`,
+							search: location.search,
+						});
 					} catch (error) {
 						toast.error(getErrorMessage(error, "Failed to add MCP server."));
 					}

--- a/site/src/pages/AISettingsPage/MCPServersPage/MCPServersPage.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/MCPServersPage.tsx
@@ -1,25 +1,32 @@
 import type { FC } from "react";
 import { useQuery } from "react-query";
 import { mcpServerConfigs } from "#/api/queries/chats";
-import { useAuthenticated } from "#/hooks/useAuthenticated";
+import { AIResourceOrganizationSelector } from "#/components/AIResourceOrganizationSelector/AIResourceOrganizationSelector";
+import { useAIResourceOrganization } from "#/contexts/AIResourceOrganizationContext";
 import { RequirePermission } from "#/modules/permissions/RequirePermission";
 import { pageTitle } from "#/utils/page";
 import MCPServersPageView from "./MCPServersPageView";
 
 const MCPServersPage: FC = () => {
-	const { permissions } = useAuthenticated();
-	const serversQuery = useQuery(mcpServerConfigs());
+	const { organization, permissions: organizationPermissions } =
+		useAIResourceOrganization();
+	const serversQuery = useQuery(mcpServerConfigs(organization.name));
 	const servers = (serversQuery.data ?? []).toSorted((a, b) =>
 		a.display_name.localeCompare(b.display_name),
 	);
 
 	return (
-		<RequirePermission isFeatureVisible={permissions.editDeploymentConfig}>
+		<RequirePermission
+			isFeatureVisible={Boolean(organizationPermissions?.viewMCPServers)}
+		>
 			<title>{pageTitle("MCP servers", "AI Settings")}</title>
+			<AIResourceOrganizationSelector />
 			<MCPServersPageView
 				isLoading={serversQuery.isLoading}
 				error={serversQuery.error}
 				servers={servers}
+				canCreateMCPServers={organizationPermissions.createMCPServers}
+				canEditMCPServers={organizationPermissions.editMCPServers}
 			/>
 		</RequirePermission>
 	);

--- a/site/src/pages/AISettingsPage/MCPServersPage/MCPServersPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/MCPServersPageView.stories.tsx
@@ -21,6 +21,8 @@ const meta: Meta<typeof MCPServersPageView> = {
 			MockImageMCPServer,
 			MockMemoryMCPServer,
 		],
+		canCreateMCPServers: true,
+		canEditMCPServers: true,
 	},
 	parameters: {
 		reactRouter: reactRouterParameters({
@@ -49,6 +51,58 @@ export const Default: Story = {
 		await expect(canvas.getByText("API key")).toBeInTheDocument();
 		await expect(canvas.getAllByText("Enabled").length).toBeGreaterThan(0);
 		await expect(canvas.getByText("Disabled")).toBeInTheDocument();
+	},
+};
+
+export const ReadOnly: Story = {
+	args: {
+		canCreateMCPServers: false,
+		canEditMCPServers: false,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.queryByRole("button", { name: /add server/i }),
+		).not.toBeInTheDocument();
+		await expect(canvas.getByText("Coder")).toBeInTheDocument();
+		await expect(canvas.getByText("Coder").closest("tr")).not.toHaveAttribute(
+			"role",
+			"button",
+		);
+	},
+};
+
+export const CreateOnlyControls: Story = {
+	args: {
+		canCreateMCPServers: true,
+		canEditMCPServers: false,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("button", { name: /add server/i }),
+		).toBeVisible();
+		await expect(canvas.getByText("Coder").closest("tr")).not.toHaveAttribute(
+			"role",
+			"button",
+		);
+	},
+};
+
+export const UpdateOnlyControls: Story = {
+	args: {
+		canCreateMCPServers: false,
+		canEditMCPServers: true,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.queryByRole("button", { name: /add server/i }),
+		).not.toBeInTheDocument();
+		await expect(canvas.getByText("Coder").closest("tr")).toHaveAttribute(
+			"role",
+			"button",
+		);
 	},
 };
 

--- a/site/src/pages/AISettingsPage/MCPServersPage/MCPServersPageView.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/MCPServersPageView.tsx
@@ -1,6 +1,6 @@
 import { PlusIcon } from "lucide-react";
 import type { FC } from "react";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import type * as TypesGen from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Button } from "#/components/Button/Button";
@@ -24,24 +24,35 @@ interface MCPServersPageViewProps {
 	isLoading: boolean;
 	error: unknown;
 	servers: readonly TypesGen.MCPServerConfig[];
+	canCreateMCPServers: boolean;
+	canEditMCPServers: boolean;
 }
 
 const MCPServersPageView: FC<MCPServersPageViewProps> = ({
 	isLoading,
 	error,
 	servers,
+	canCreateMCPServers,
+	canEditMCPServers,
 }) => {
 	const navigate = useNavigate();
-	const goToAddServer = () => void navigate("/ai/settings/mcp-servers/add");
+	const location = useLocation();
+	const goToAddServer = () =>
+		void navigate({
+			pathname: "/ai/settings/mcp-servers/add",
+			search: location.search,
+		});
 
 	return (
 		<div>
 			<SettingsHeader
 				actions={
-					<Button variant="outline" onClick={goToAddServer}>
-						<PlusIcon />
-						<span>Add server</span>
-					</Button>
+					canCreateMCPServers ? (
+						<Button variant="outline" onClick={goToAddServer}>
+							<PlusIcon />
+							<span>Add server</span>
+						</Button>
+					) : undefined
 				}
 			>
 				<SettingsHeaderTitle>MCP servers</SettingsHeaderTitle>
@@ -75,10 +86,12 @@ const MCPServersPageView: FC<MCPServersPageViewProps> = ({
 							message="No MCP servers configured"
 							description="Add a server to give agents access to external tools."
 							cta={
-								<Button variant="outline" onClick={goToAddServer}>
-									<PlusIcon />
-									<span>Add server</span>
-								</Button>
+								canCreateMCPServers ? (
+									<Button variant="outline" onClick={goToAddServer}>
+										<PlusIcon />
+										<span>Add server</span>
+									</Button>
+								) : undefined
 							}
 						/>
 					) : (
@@ -86,8 +99,14 @@ const MCPServersPageView: FC<MCPServersPageViewProps> = ({
 							<MCPServerRow
 								key={server.id}
 								server={server}
-								onClick={() =>
-									void navigate(`/ai/settings/mcp-servers/${server.id}`)
+								onClick={
+									canEditMCPServers
+										? () =>
+												void navigate({
+													pathname: `/ai/settings/mcp-servers/${server.id}`,
+													search: location.search,
+												})
+										: undefined
 								}
 							/>
 						))

--- a/site/src/pages/AISettingsPage/MCPServersPage/UpdateMCPServerPage/UpdateMCPServerPage.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/UpdateMCPServerPage/UpdateMCPServerPage.tsx
@@ -1,71 +1,118 @@
 import type { FC } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
-import { Navigate, useNavigate, useParams } from "react-router";
+import { Navigate, useLocation, useNavigate, useParams } from "react-router";
 import { toast } from "sonner";
 import { getErrorMessage } from "#/api/errors";
 import {
 	deleteMCPServerConfig,
-	mcpServerConfigs,
+	mcpServerConfig,
 	updateMCPServerConfig,
 } from "#/api/queries/chats";
 import { Loader } from "#/components/Loader/Loader";
-import { useAuthenticated } from "#/hooks/useAuthenticated";
+import { useAIResourceOrganization } from "#/contexts/AIResourceOrganizationContext";
 import { RequirePermission } from "#/modules/permissions/RequirePermission";
 import { pageTitle } from "#/utils/page";
 import UpdateMCPServerPageView from "./UpdateMCPServerPageView";
 
 const UpdateMCPServerPage: FC = () => {
-	const { permissions } = useAuthenticated();
+	const { organization, permissions: organizationPermissions } =
+		useAIResourceOrganization();
 	const { serverId } = useParams<{ serverId: string }>();
 	const queryClient = useQueryClient();
 	const navigate = useNavigate();
-	const serversQuery = useQuery(mcpServerConfigs());
+	const location = useLocation();
+	const serverQuery = useQuery({
+		...mcpServerConfig(serverId ?? ""),
+		enabled: Boolean(serverId),
+	});
 	const updateMutation = useMutation(updateMCPServerConfig(queryClient));
 	const deleteMutation = useMutation(deleteMCPServerConfig(queryClient));
-	const server = serversQuery.data?.find((item) => item.id === serverId);
+	const server =
+		serverQuery.data?.organization_id === organization.id
+			? serverQuery.data
+			: undefined;
 
 	return (
-		<RequirePermission isFeatureVisible={permissions.editDeploymentConfig}>
+		<RequirePermission
+			isFeatureVisible={Boolean(organizationPermissions?.editMCPServers)}
+		>
 			{!serverId ? (
-				<Navigate to="/ai/settings/mcp-servers" replace />
-			) : serversQuery.isLoading ? (
+				<Navigate
+					to={{ pathname: "/ai/settings/mcp-servers", search: location.search }}
+					replace
+				/>
+			) : serverQuery.isLoading ? (
 				<>
 					<title>{pageTitle("Loading...", "AI Settings")}</title>
 					<Loader fullscreen />
 				</>
 			) : !server ? (
-				<Navigate to="/ai/settings/mcp-servers" replace />
+				<Navigate
+					to={{ pathname: "/ai/settings/mcp-servers", search: location.search }}
+					replace
+				/>
 			) : (
 				<UpdateMCPServerPageView
 					server={server}
 					isSaving={updateMutation.isPending}
 					isDeleting={deleteMutation.isPending}
-					onCancel={() => void navigate("/ai/settings/mcp-servers")}
+					onCancel={() =>
+						void navigate({
+							pathname: "/ai/settings/mcp-servers",
+							search: location.search,
+						})
+					}
 					onUpdateServer={async (id, req) => {
 						try {
-							const updated = await updateMutation.mutateAsync({ id, req });
+							const updated = await updateMutation.mutateAsync({
+								organization: organization.name,
+								serverId: id,
+								req,
+							});
 							toast.success(`MCP server "${updated.display_name}" updated.`);
-							await navigate("/ai/settings/mcp-servers");
+							await navigate({
+								pathname: "/ai/settings/mcp-servers",
+								search: location.search,
+							});
 						} catch (error) {
 							toast.error(
 								getErrorMessage(error, "Failed to update MCP server."),
 							);
 						}
 					}}
-					onDeleteServer={async (id) => {
-						try {
-							await deleteMutation.mutateAsync(id);
-							toast.success(`MCP server "${server.display_name}" deleted.`);
-							await navigate("/ai/settings/mcp-servers", { replace: true });
-						} catch (error) {
-							toast.error(
-								getErrorMessage(error, "Failed to delete MCP server."),
-							);
-						}
-					}}
+					onDeleteServer={
+						organizationPermissions.deleteMCPServers
+							? async (id) => {
+									try {
+										await deleteMutation.mutateAsync({
+											organization: organization.name,
+											serverId: id,
+										});
+										toast.success(
+											`MCP server "${server.display_name}" deleted.`,
+										);
+										await navigate(
+											{
+												pathname: "/ai/settings/mcp-servers",
+												search: location.search,
+											},
+											{ replace: true },
+										);
+									} catch (error) {
+										toast.error(
+											getErrorMessage(error, "Failed to delete MCP server."),
+										);
+									}
+								}
+							: undefined
+					}
 					onToggleEnabled={(enabled) => {
 						updateMutation.mutate(
-							{ id: server.id, req: { enabled } },
+							{
+								organization: organization.name,
+								serverId: server.id,
+								req: { enabled },
+							},
 							{
 								onSuccess: () => {
 									toast.success(

--- a/site/src/pages/AISettingsPage/MCPServersPage/UpdateMCPServerPage/UpdateMCPServerPageView.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/UpdateMCPServerPage/UpdateMCPServerPageView.tsx
@@ -11,7 +11,7 @@ interface UpdateMCPServerPageViewProps {
 		serverId: string,
 		req: TypesGen.UpdateMCPServerConfigRequest,
 	) => Promise<unknown>;
-	onDeleteServer: (serverId: string) => Promise<void>;
+	onDeleteServer?: (serverId: string) => Promise<void>;
 	onToggleEnabled: (enabled: boolean) => void;
 	onCancel: () => void;
 }

--- a/site/src/pages/AISettingsPage/MCPServersPage/components/MCPServerFormHeader.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/components/MCPServerFormHeader.tsx
@@ -1,6 +1,6 @@
 import { ArrowLeftIcon, EllipsisVerticalIcon, TrashIcon } from "lucide-react";
 import type { FC } from "react";
-import { Link } from "react-router";
+import { Link, useLocation } from "react-router";
 import type * as TypesGen from "#/api/typesGenerated";
 import { Badge } from "#/components/Badge/Badge";
 import { Button } from "#/components/Button/Button";
@@ -21,8 +21,13 @@ import { cn } from "#/utils/cn";
 import { MCPServerIcon } from "./MCPServerIcon";
 
 const MCPServerFormBackLink: FC = () => {
+	const location = useLocation();
+
 	return (
-		<Link to="/ai/settings/mcp-servers" className="-ml-3">
+		<Link
+			to={{ pathname: "/ai/settings/mcp-servers", search: location.search }}
+			className="-ml-3"
+		>
 			<Button variant="subtle" type="button">
 				<ArrowLeftIcon />
 				<span>Back to MCP servers</span>

--- a/site/src/pages/AISettingsPage/MCPServersPage/components/MCPServerRow.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/components/MCPServerRow.tsx
@@ -10,15 +10,18 @@ import { AUTH_TYPE_LABELS, AVAILABILITY_LABELS } from "./mcpServerFormLogic";
 
 interface MCPServerRowProps {
 	server: TypesGen.MCPServerConfig;
-	onClick: () => void;
+	onClick?: () => void;
 }
 
 export const MCPServerRow: FC<MCPServerRowProps> = ({ server, onClick }) => {
-	const clickableProps = useClickableTableRow({ onClick });
+	const clickableProps = useClickableTableRow({
+		onClick: onClick ?? (() => {}),
+	});
+	const rowProps = onClick ? clickableProps : {};
 	const enabled = server.enabled;
 
 	return (
-		<TableRow {...clickableProps}>
+		<TableRow {...rowProps}>
 			<TableCell className="min-w-0 px-4 py-3">
 				<div className="flex min-w-0 items-center gap-3">
 					<MCPServerIcon
@@ -46,7 +49,9 @@ export const MCPServerRow: FC<MCPServerRowProps> = ({ server, onClick }) => {
 				<Badge variant="default">{enabled ? "Enabled" : "Disabled"}</Badge>
 			</TableCell>
 			<TableCell className="w-12">
-				<ChevronRightIcon className="size-5 text-content-primary" />
+				{onClick && (
+					<ChevronRightIcon className="size-5 text-content-primary" />
+				)}
 			</TableCell>
 		</TableRow>
 	);

--- a/site/src/pages/AISettingsPage/ModelsPage/AddModelPage/AddModelPage.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/AddModelPage/AddModelPage.tsx
@@ -9,7 +9,8 @@ import {
 	chatProviderConfigs,
 	createChatModelConfig,
 } from "#/api/queries/chats";
-import { useAuthenticated } from "#/hooks/useAuthenticated";
+import { AIResourceOrganizationSelector } from "#/components/AIResourceOrganizationSelector/AIResourceOrganizationSelector";
+import { useAIResourceOrganization } from "#/contexts/AIResourceOrganizationContext";
 import {
 	canManageProviderModels,
 	deriveProviderStates,
@@ -19,7 +20,8 @@ import { pageTitle } from "#/utils/page";
 import AddModelPageView from "./AddModelPageView";
 
 const AddModelPage: FC = () => {
-	const { permissions } = useAuthenticated();
+	const { organization, permissions: organizationPermissions } =
+		useAIResourceOrganization();
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
 	const [searchParams] = useSearchParams();
@@ -27,8 +29,8 @@ const AddModelPage: FC = () => {
 	const duplicateId = searchParams.get("duplicate");
 
 	const providerConfigsQuery = useQuery(chatProviderConfigs());
-	const modelConfigsQuery = useQuery(chatModelConfigs());
-	const modelCatalogQuery = useQuery(chatModels());
+	const modelConfigsQuery = useQuery(chatModelConfigs(organization.name));
+	const modelCatalogQuery = useQuery(chatModels(organization.name));
 
 	const createMutation = useMutation(createChatModelConfig(queryClient));
 
@@ -56,8 +58,11 @@ const AddModelPage: FC = () => {
 	const currentDefaultModel = modelConfigsQuery.data?.find((m) => m.is_default);
 
 	return (
-		<RequirePermission isFeatureVisible={permissions.editDeploymentConfig}>
+		<RequirePermission
+			isFeatureVisible={Boolean(organizationPermissions?.createModel)}
+		>
 			<title>{pageTitle("Add model", "AI Settings")}</title>
+			<AIResourceOrganizationSelector />
 
 			<AddModelPageView
 				isLoading={isLoading}
@@ -75,11 +80,19 @@ const AddModelPage: FC = () => {
 				}}
 				onCreateModel={async (req) => {
 					try {
-						const created = await createMutation.mutateAsync(req);
+						const created = await createMutation.mutateAsync({
+							organization: organization.name,
+							req,
+						});
 						toast.success(
 							`Model "${created.display_name || created.model}" added.`,
 						);
-						await navigate(`/ai/settings/models/${created.id}`);
+						const next = new URLSearchParams(searchParams);
+						next.delete("provider");
+						next.delete("duplicate");
+						await navigate(
+							`/ai/settings/models/${created.id}?${next.toString()}`,
+						);
 					} catch (error) {
 						toast.error(getErrorMessage(error, "Failed to add model."));
 					}

--- a/site/src/pages/AISettingsPage/ModelsPage/AddModelPage/AddModelPageView.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/AddModelPage/AddModelPageView.tsx
@@ -1,6 +1,6 @@
 import { ArrowLeftIcon } from "lucide-react";
 import type { FC } from "react";
-import { Link } from "react-router";
+import { Link, useLocation } from "react-router";
 import type * as TypesGen from "#/api/typesGenerated";
 import { Alert, AlertDescription, AlertTitle } from "#/components/Alert/Alert";
 import { Button } from "#/components/Button/Button";
@@ -31,6 +31,8 @@ const AddModelPageView: FC<AddModelPageViewProps> = ({
 	onProviderChange,
 	onCreateModel,
 }) => {
+	const location = useLocation();
+
 	if (isLoading) {
 		return <Loader fullscreen />;
 	}
@@ -38,7 +40,10 @@ const AddModelPageView: FC<AddModelPageViewProps> = ({
 	if (!selectedProviderState) {
 		return (
 			<div className="flex flex-col items-start gap-4">
-				<Link to="/ai/settings/models" className="-ml-3">
+				<Link
+					to={{ pathname: "/ai/settings/models", search: location.search }}
+					className="-ml-3"
+				>
 					<Button variant="subtle">
 						<ArrowLeftIcon />
 						<span>Back to models</span>

--- a/site/src/pages/AISettingsPage/ModelsPage/ModelsPage.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/ModelsPage.tsx
@@ -5,6 +5,8 @@ import {
 	chatModels,
 	chatProviderConfigs,
 } from "#/api/queries/chats";
+import { AIResourceOrganizationSelector } from "#/components/AIResourceOrganizationSelector/AIResourceOrganizationSelector";
+import { useAIResourceOrganization } from "#/contexts/AIResourceOrganizationContext";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
 import { deriveProviderStates } from "#/modules/aiModels/providerStates";
 import { RequirePermission } from "#/modules/permissions/RequirePermission";
@@ -14,13 +16,15 @@ import ModelsPageView from "./ModelsPageView";
 
 const ModelsPage: FC = () => {
 	const { permissions } = useAuthenticated();
+	const { organization, permissions: organizationPermissions } =
+		useAIResourceOrganization();
 
 	const providerConfigsQuery = useQuery({
 		...chatProviderConfigs(),
 		enabled: permissions.editDeploymentConfig,
 	});
-	const modelConfigsQuery = useQuery(chatModelConfigs());
-	const modelCatalogQuery = useQuery(chatModels());
+	const modelConfigsQuery = useQuery(chatModelConfigs(organization.name));
+	const modelCatalogQuery = useQuery(chatModels(organization.name));
 
 	const providerTypeByID = providerTypeByIDFromConfigs(
 		providerConfigsQuery.data,
@@ -39,8 +43,11 @@ const ModelsPage: FC = () => {
 	);
 
 	return (
-		<RequirePermission isFeatureVisible={permissions.editDeploymentConfig}>
+		<RequirePermission
+			isFeatureVisible={Boolean(organizationPermissions?.viewModels)}
+		>
 			<title>{pageTitle("Models", "AI Settings")}</title>
+			<AIResourceOrganizationSelector />
 
 			<ModelsPageView
 				isLoading={
@@ -56,6 +63,8 @@ const ModelsPage: FC = () => {
 				models={models}
 				providerStates={providerStates}
 				providerTypeByID={providerTypeByID}
+				canCreateModels={organizationPermissions.createModel}
+				canEditModels={organizationPermissions.editModels}
 			/>
 		</RequirePermission>
 	);

--- a/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.stories.tsx
@@ -32,6 +32,8 @@ const meta: Meta<typeof ModelsPageView> = {
 			["prov-anthropic", "anthropic"],
 			["prov-bedrock", "bedrock"],
 		]),
+		canCreateModels: true,
+		canEditModels: true,
 	},
 	parameters: {
 		reactRouter: reactRouterParameters({
@@ -128,6 +130,56 @@ export const DisabledProviderModelsStillListed: Story = {
 		const canvas = within(canvasElement);
 		await expect(canvas.getByText("GPT-4o Secondary")).toBeInTheDocument();
 		await expect(canvas.getByText("OpenAI Secondary")).toBeInTheDocument();
+	},
+};
+
+export const ReadOnly: Story = {
+	args: {
+		canCreateModels: false,
+		canEditModels: false,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.queryByRole("button", { name: /add model/i }),
+		).not.toBeInTheDocument();
+		await expect(canvas.getByText("GPT-5")).toBeInTheDocument();
+		await expect(
+			canvas.queryByRole("button", { name: /GPT-5/i }),
+		).not.toBeInTheDocument();
+	},
+};
+
+export const CreateOnlyControls: Story = {
+	args: {
+		canCreateModels: true,
+		canEditModels: false,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("button", { name: /add model/i }),
+		).toBeVisible();
+		await expect(
+			canvas.queryByRole("button", { name: /GPT-5/i }),
+		).not.toBeInTheDocument();
+	},
+};
+
+export const UpdateOnlyControls: Story = {
+	args: {
+		canCreateModels: false,
+		canEditModels: true,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.queryByRole("button", { name: /add model/i }),
+		).not.toBeInTheDocument();
+		await expect(canvas.getByText("GPT-5").closest("tr")).toHaveAttribute(
+			"role",
+			"button",
+		);
 	},
 };
 

--- a/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.tsx
@@ -1,6 +1,6 @@
 import { ChevronDownIcon, PlusIcon, SearchIcon } from "lucide-react";
 import { type FC, useMemo, useState } from "react";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import type { ChatModelConfig } from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Button } from "#/components/Button/Button";
@@ -53,6 +53,7 @@ const AddModelDropdown: FC<{
 	align?: "start" | "end";
 }> = ({ providerStates, align = "end" }) => {
 	const navigate = useNavigate();
+	const location = useLocation();
 	const manageableProviderStates = providerStates.filter(
 		canManageProviderModels,
 	);
@@ -76,13 +77,14 @@ const AddModelDropdown: FC<{
 					manageableProviderStates.map((providerState) => (
 						<DropdownMenuItem
 							key={providerState.key}
-							onSelect={() =>
-								void navigate(
-									`/ai/settings/models/add?provider=${encodeURIComponent(
-										providerState.key,
-									)}`,
-								)
-							}
+							onSelect={() => {
+								const params = new URLSearchParams(location.search);
+								params.set("provider", providerState.key);
+								void navigate({
+									pathname: "/ai/settings/models/add",
+									search: params.toString(),
+								});
+							}}
 						>
 							<ProviderIcon provider={providerState.provider} />
 							<span>{providerState.label}</span>
@@ -100,6 +102,8 @@ interface ModelsPageViewProps {
 	models: readonly ChatModelConfig[];
 	providerStates: readonly ProviderState[];
 	providerTypeByID: ReadonlyMap<string, string>;
+	canCreateModels: boolean;
+	canEditModels: boolean;
 }
 
 const ModelsPageView: FC<ModelsPageViewProps> = ({
@@ -108,8 +112,11 @@ const ModelsPageView: FC<ModelsPageViewProps> = ({
 	models,
 	providerStates,
 	providerTypeByID,
+	canCreateModels,
+	canEditModels,
 }) => {
 	const navigate = useNavigate();
+	const location = useLocation();
 	const [page, setPage] = useState(1);
 	const [searchQuery, setSearchQuery] = useState("");
 	const [providerFilter, setProviderFilter] =
@@ -184,7 +191,11 @@ const ModelsPageView: FC<ModelsPageViewProps> = ({
 	return (
 		<div>
 			<SettingsHeader
-				actions={<AddModelDropdown providerStates={providerStates} />}
+				actions={
+					canCreateModels ? (
+						<AddModelDropdown providerStates={providerStates} />
+					) : undefined
+				}
 			>
 				<SettingsHeaderTitle>Models</SettingsHeaderTitle>
 				<SettingsHeaderDescription>
@@ -249,10 +260,12 @@ const ModelsPageView: FC<ModelsPageViewProps> = ({
 							message="No models configured"
 							description="Configured models will appear here."
 							cta={
-								<AddModelDropdown
-									providerStates={providerStates}
-									align="start"
-								/>
+								canCreateModels ? (
+									<AddModelDropdown
+										providerStates={providerStates}
+										align="start"
+									/>
+								) : undefined
 							}
 						/>
 					) : filteredModels.length === 0 ? (
@@ -267,7 +280,15 @@ const ModelsPageView: FC<ModelsPageViewProps> = ({
 								model={model}
 								providerLabel={providerLabelByModelId.get(model.id) ?? ""}
 								providerTypeByID={providerTypeByID}
-								onClick={() => void navigate(`/ai/settings/models/${model.id}`)}
+								onClick={
+									canEditModels
+										? () =>
+												void navigate({
+													pathname: `/ai/settings/models/${model.id}`,
+													search: location.search,
+												})
+										: undefined
+								}
 							/>
 						))
 					)}

--- a/site/src/pages/AISettingsPage/ModelsPage/UpdateModelPage/UpdateModelPage.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/UpdateModelPage/UpdateModelPage.tsx
@@ -1,9 +1,10 @@
 import { type FC, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
-import { Navigate, useNavigate, useParams } from "react-router";
+import { Navigate, useLocation, useNavigate, useParams } from "react-router";
 import { toast } from "sonner";
 import { getErrorMessage } from "#/api/errors";
 import {
+	chatModelConfig,
 	chatModelConfigs,
 	chatModels,
 	chatProviderConfigs,
@@ -11,21 +12,27 @@ import {
 	updateChatModelConfig,
 } from "#/api/queries/chats";
 import { Loader } from "#/components/Loader/Loader";
-import { useAuthenticated } from "#/hooks/useAuthenticated";
+import { useAIResourceOrganization } from "#/contexts/AIResourceOrganizationContext";
 import { deriveProviderStates } from "#/modules/aiModels/providerStates";
 import { RequirePermission } from "#/modules/permissions/RequirePermission";
 import { pageTitle } from "#/utils/page";
 import UpdateModelPageView from "./UpdateModelPageView";
 
 const UpdateModelPage: FC = () => {
-	const { permissions } = useAuthenticated();
+	const { organization, permissions: organizationPermissions } =
+		useAIResourceOrganization();
 	const { modelId } = useParams<{ modelId: string }>();
 	const navigate = useNavigate();
+	const location = useLocation();
 	const queryClient = useQueryClient();
 
 	const providerConfigsQuery = useQuery(chatProviderConfigs());
-	const modelConfigsQuery = useQuery(chatModelConfigs());
-	const modelCatalogQuery = useQuery(chatModels());
+	const modelQuery = useQuery({
+		...chatModelConfig(modelId ?? ""),
+		enabled: Boolean(modelId),
+	});
+	const modelConfigsQuery = useQuery(chatModelConfigs(organization.name));
+	const modelCatalogQuery = useQuery(chatModels(organization.name));
 
 	const updateMutation = useMutation(updateChatModelConfig(queryClient));
 	const deleteMutation = useMutation(deleteChatModelConfig(queryClient));
@@ -42,10 +49,14 @@ const UpdateModelPage: FC = () => {
 
 	const isLoading =
 		providerConfigsQuery.isLoading ||
+		modelQuery.isLoading ||
 		modelConfigsQuery.isLoading ||
 		modelCatalogQuery.isLoading;
 
-	const model = modelConfigsQuery.data?.find((m) => m.id === modelId);
+	const model =
+		modelQuery.data?.organization_id === organization.id
+			? modelQuery.data
+			: undefined;
 	const currentDefaultModel = modelConfigsQuery.data?.find((m) => m.is_default);
 	const [providerKeyOverride, setProviderKeyOverride] = useState<string | null>(
 		null,
@@ -60,16 +71,24 @@ const UpdateModelPage: FC = () => {
 		null;
 
 	return (
-		<RequirePermission isFeatureVisible={permissions.editDeploymentConfig}>
+		<RequirePermission
+			isFeatureVisible={Boolean(organizationPermissions?.editModels)}
+		>
 			{!modelId ? (
-				<Navigate to="/ai/settings/models" replace />
+				<Navigate
+					to={{ pathname: "/ai/settings/models", search: location.search }}
+					replace
+				/>
 			) : isLoading ? (
 				<>
 					<title>{pageTitle("Loading...", "AI Settings")}</title>
 					<Loader fullscreen />
 				</>
 			) : !model ? (
-				<Navigate to="/ai/settings/models" replace />
+				<Navigate
+					to={{ pathname: "/ai/settings/models", search: location.search }}
+					replace
+				/>
 			) : (
 				<UpdateModelPageView
 					model={model}
@@ -82,39 +101,64 @@ const UpdateModelPage: FC = () => {
 					onUpdateModel={async (id, req) => {
 						try {
 							const updated = await updateMutation.mutateAsync({
+								organization: organization.name,
 								modelConfigId: id,
 								req,
 							});
 							toast.success(
 								`Model "${updated.display_name || updated.model}" updated.`,
 							);
-							await navigate("/ai/settings/models");
+							await navigate({
+								pathname: "/ai/settings/models",
+								search: location.search,
+							});
 						} catch (error) {
 							toast.error(getErrorMessage(error, "Failed to update model."));
 						}
 					}}
-					onDeleteModel={async (id) => {
-						try {
-							await deleteMutation.mutateAsync(id);
-							toast.success(
-								`Model "${model.display_name || model.model}" deleted.`,
-							);
-							await navigate("/ai/settings/models", { replace: true });
-						} catch (error) {
-							toast.error(getErrorMessage(error, "Failed to delete model."));
-						}
-					}}
+					onDeleteModel={
+						organizationPermissions.deleteModels
+							? async (id) => {
+									try {
+										await deleteMutation.mutateAsync({
+											organization: organization.name,
+											modelConfigId: id,
+										});
+										toast.success(
+											`Model "${model.display_name || model.model}" deleted.`,
+										);
+										await navigate(
+											{
+												pathname: "/ai/settings/models",
+												search: location.search,
+											},
+											{ replace: true },
+										);
+									} catch (error) {
+										toast.error(
+											getErrorMessage(error, "Failed to delete model."),
+										);
+									}
+								}
+							: undefined
+					}
 					onDuplicate={() => {
 						if (!selectedProviderState) return;
-						void navigate(
-							`/ai/settings/models/add?provider=${encodeURIComponent(
-								selectedProviderState.key,
-							)}&duplicate=${encodeURIComponent(model.id)}`,
-						);
+						const params = new URLSearchParams(location.search);
+						params.set("provider", selectedProviderState.key);
+						params.set("duplicate", model.id);
+						void navigate({
+							pathname: "/ai/settings/models/add",
+							search: params.toString(),
+						});
 					}}
 					onToggleEnabled={(enabled) => {
 						updateMutation.mutate(
-							{ modelConfigId: model.id, req: { enabled } },
+							{
+								organization: organization.name,
+								modelConfigId: model.id,
+								req: { enabled },
+							},
 							{
 								onSuccess: () => {
 									toast.success(

--- a/site/src/pages/AISettingsPage/ModelsPage/UpdateModelPage/UpdateModelPageView.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/UpdateModelPage/UpdateModelPageView.tsx
@@ -16,7 +16,7 @@ interface UpdateModelPageViewProps {
 		modelConfigId: string,
 		req: TypesGen.UpdateChatModelConfigRequest,
 	) => Promise<unknown>;
-	onDeleteModel: (modelConfigId: string) => Promise<void>;
+	onDeleteModel?: (modelConfigId: string) => Promise<void>;
 	onDuplicate: () => void;
 	onToggleEnabled: (enabled: boolean) => void;
 }

--- a/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormFields.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormFields.tsx
@@ -1,7 +1,7 @@
 import type { FormikContextType } from "formik";
 import { ChevronDownIcon, ChevronRightIcon, InfoIcon } from "lucide-react";
 import type { FC, ReactNode } from "react";
-import { Link } from "react-router";
+import { Link, useLocation } from "react-router";
 import { getVisibleProviderFields } from "#/api/chatModelOptions";
 import type * as TypesGen from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
@@ -134,6 +134,7 @@ export const ModelFormFields: FC<{
 	showAdvanced,
 	setShowAdvanced,
 }) => {
+	const location = useLocation();
 	const hasProviderConfigFields =
 		getVisibleProviderFields(selectedProviderState.provider).length > 0;
 
@@ -344,7 +345,9 @@ export const ModelFormFields: FC<{
 				</div>
 
 				<div className="flex items-center justify-end gap-3">
-					<Link to="/ai/settings/models">
+					<Link
+						to={{ pathname: "/ai/settings/models", search: location.search }}
+					>
 						<Button variant="outline" type="button">
 							Cancel
 						</Button>

--- a/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormHeader.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormHeader.tsx
@@ -5,7 +5,7 @@ import {
 	TrashIcon,
 } from "lucide-react";
 import type { FC } from "react";
-import { Link } from "react-router";
+import { Link, useLocation } from "react-router";
 import type * as TypesGen from "#/api/typesGenerated";
 import { Avatar } from "#/components/Avatar/Avatar";
 import { Badge } from "#/components/Badge/Badge";
@@ -29,8 +29,13 @@ import { getProviderIcon } from "#/pages/AISettingsPage/ProvidersPage/components
 import { cn } from "#/utils/cn";
 
 export const ModelFormBackLink: FC = () => {
+	const location = useLocation();
+
 	return (
-		<Link to="/ai/settings/models" className="-ml-3">
+		<Link
+			to={{ pathname: "/ai/settings/models", search: location.search }}
+			className="-ml-3"
+		>
 			<Button variant="subtle" type="button">
 				<ArrowLeftIcon />
 				<span>Back to models</span>

--- a/site/src/pages/AISettingsPage/ModelsPage/components/ModelRow.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ModelRow.tsx
@@ -11,7 +11,7 @@ type ModelRowProps = {
 	model: ChatModelConfig;
 	providerLabel: string;
 	providerTypeByID: ReadonlyMap<string, string>;
-	onClick: () => void;
+	onClick?: () => void;
 };
 
 const formatContextLimit = (contextLimit: number): string => {
@@ -27,11 +27,14 @@ export const ModelRow: FC<ModelRowProps> = ({
 	providerTypeByID,
 	onClick,
 }) => {
-	const clickableProps = useClickableTableRow({ onClick });
+	const clickableProps = useClickableTableRow({
+		onClick: onClick ?? (() => {}),
+	});
+	const rowProps = onClick ? clickableProps : {};
 	const displayName = model.display_name || model.model;
 
 	return (
-		<TableRow {...clickableProps}>
+		<TableRow {...rowProps}>
 			<TableCell className="min-w-0 px-4 py-3">
 				<div className="flex min-w-0 items-center gap-4">
 					<Avatar
@@ -76,12 +79,14 @@ export const ModelRow: FC<ModelRowProps> = ({
 				</Badge>
 			</TableCell>
 			<TableCell className="w-10 text-center">
-				<div className="flex justify-end items-center gap-8 pr-4">
-					<ChevronRightIcon
-						aria-hidden
-						className="size-icon-md text-content-primary flex-shrink-0"
-					/>
-				</div>
+				{onClick && (
+					<div className="flex justify-end items-center gap-8 pr-4">
+						<ChevronRightIcon
+							aria-hidden
+							className="size-icon-md text-content-primary flex-shrink-0"
+						/>
+					</div>
+				)}
 			</TableCell>
 		</TableRow>
 	);

--- a/site/src/pages/AISettingsPage/ModelsPage/testFixtures.ts
+++ b/site/src/pages/AISettingsPage/ModelsPage/testFixtures.ts
@@ -27,6 +27,7 @@ const MockAnthropicProviderConfig: ChatProviderConfig = {
 };
 
 export const mockGPT5: ChatModelConfig = {
+	organization_id: "test-org-id",
 	id: "model-gpt5",
 	ai_provider_id: "prov-openai",
 	model: "gpt-5",

--- a/site/src/pages/AISettingsPage/ProvidersPage/UpdateProviderPage/UpdateProviderPageView.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/UpdateProviderPage/UpdateProviderPageView.tsx
@@ -2,7 +2,13 @@ import { isAxiosError } from "axios";
 import { ArrowLeftIcon } from "lucide-react";
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
-import { Link, Navigate, useNavigate, useParams } from "react-router";
+import {
+	Link,
+	Navigate,
+	useLocation,
+	useNavigate,
+	useParams,
+} from "react-router";
 import { toast } from "sonner";
 import { getErrorMessage } from "#/api/errors";
 import {
@@ -35,6 +41,7 @@ const BACK_HREF = "/ai/settings/providers";
 const UpdateProviderPageView: React.FC = () => {
 	const { providerId } = useParams<{ providerId: string }>();
 	const queryClient = useQueryClient();
+	const location = useLocation();
 	const navigate = useNavigate();
 
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -160,12 +167,12 @@ const UpdateProviderPageView: React.FC = () => {
 				<div className="flex items-center justify-between w-full">
 					<p className="text-sm text-content-secondary m-0">
 						Add or update models for this provider.{" "}
-						<a
-							href="/ai/settings/models"
+						<Link
+							to={{ pathname: "/ai/settings/models", search: location.search }}
 							className="text-content-link no-underline hover:underline"
 						>
 							Model settings
-						</a>
+						</Link>
 					</p>
 					<div className="flex items-center gap-2">
 						<Switch

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -13,7 +13,7 @@ import {
 	chatDiffContentsKey,
 	chatKey,
 	chatMessagesKey,
-	chatModelConfigs,
+	chatModelConfigsKey,
 	chatModelsKey,
 	chatPromptsKey,
 	chatsKey,
@@ -84,6 +84,7 @@ const AgentChatPageLayout: FC = () => {
 // ---------------------------------------------------------------------------
 const CHAT_ID = "chat-1";
 const MODEL_CONFIG_ID = "model-config-1";
+const ORGANIZATION_ID = "test-org-id";
 
 const mockWorkspace: TypesGen.Workspace = {
 	...MockWorkspace,
@@ -276,9 +277,9 @@ const buildQueries = (
 			key: workspaceByIdKey(mockWorkspace.id),
 			data: mockWorkspace,
 		},
-		{ key: chatModelsKey, data: mockModelCatalog },
-		{ key: chatModelConfigs().queryKey, data: mockModelConfigs },
-		{ key: mcpServerConfigsKey, data: [] },
+		{ key: chatModelsKey(ORGANIZATION_ID), data: mockModelCatalog },
+		{ key: chatModelConfigsKey(ORGANIZATION_ID), data: mockModelConfigs },
+		{ key: mcpServerConfigsKey(ORGANIZATION_ID), data: [] },
 		buildChatAuthorizationQuery(chat, {
 			canShareChat: {
 				action: "share",

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -121,7 +121,8 @@ import {
 /** localStorage key controlling whether the right panel is visible. */
 export const RIGHT_PANEL_OPEN_KEY = "agents.right-panel-open";
 
-const lastModelConfigIDStorageKey = "agents.last-model-config-id";
+const lastModelConfigIDStorageKey = (organization: string) =>
+	`agents.last-model-config-id.${organization}`;
 class CompactCommandPendingError extends Error {}
 
 /** @internal Exported for testing. */
@@ -790,17 +791,30 @@ const AgentChatPage: FC = () => {
 	});
 	const workspace = workspaceQuery.data;
 
-	const chatModelsQuery = useQuery(chatModels());
-	const chatModelConfigsQuery = useQuery(chatModelConfigs());
+	const chatOrganization = chatQuery.data?.organization_id ?? "";
+	const chatModelsQuery = useQuery({
+		...chatModels(chatOrganization),
+		enabled: Boolean(chatOrganization),
+	});
+	const chatModelConfigsQuery = useQuery({
+		...chatModelConfigs(chatOrganization),
+		enabled: Boolean(chatOrganization),
+	});
 	const chatProviderConfigsQuery = useQuery({
 		...chatProviderConfigs(),
 		enabled: permissions.editDeploymentConfig,
 	});
 	const userProviderConfigsQuery = useQuery(userChatProviderConfigs());
-	const userThresholdsQuery = useQuery(userCompactionThresholds());
+	const userThresholdsQuery = useQuery({
+		...userCompactionThresholds(chatOrganization),
+		enabled: Boolean(chatOrganization),
+	});
 	const preferencesQuery = useQuery(preferenceSettings());
 	const userDebugLoggingQuery = useQuery(userChatDebugLogging());
-	const mcpServersQuery = useQuery(mcpServerConfigs());
+	const mcpServersQuery = useQuery({
+		...mcpServerConfigs(chatOrganization),
+		enabled: Boolean(chatOrganization),
+	});
 	const workspacesQuery = useQuery(workspaces({ q: "owner:me", limit: 0 }));
 	const workspaceOptions = getWorkspaceOptionsWithLinkedWorkspace(
 		workspacesQuery.data?.workspaces ?? [],
@@ -819,7 +833,7 @@ const AgentChatPage: FC = () => {
 
 	const handleMCPSelectionChange = (ids: string[]) => {
 		setSelectedMCPServerIds(ids);
-		saveMCPSelection(ids);
+		saveMCPSelection(ids, chatOrganization);
 	};
 
 	const handleMCPAuthComplete = (_serverId: string) => {
@@ -971,7 +985,7 @@ const AgentChatPage: FC = () => {
 			return chatRecord.mcp_server_ids;
 		}
 		// Check for a previously saved selection in localStorage.
-		const saved = getSavedMCPSelection(mcpServers);
+		const saved = getSavedMCPSelection(mcpServers, chatOrganization);
 		if (saved !== null) {
 			return saved;
 		}
@@ -1600,7 +1614,7 @@ const AgentChatPage: FC = () => {
 			});
 			if (editSelectedModelConfigID) {
 				localStorage.setItem(
-					lastModelConfigIDStorageKey,
+					lastModelConfigIDStorageKey(chatOrganization),
 					editSelectedModelConfigID,
 				);
 			}
@@ -1659,9 +1673,12 @@ const AgentChatPage: FC = () => {
 			}
 		}
 		if (selectedModelConfigID) {
-			localStorage.setItem(lastModelConfigIDStorageKey, selectedModelConfigID);
+			localStorage.setItem(
+				lastModelConfigIDStorageKey(chatOrganization),
+				selectedModelConfigID,
+			);
 		} else {
-			localStorage.removeItem(lastModelConfigIDStorageKey);
+			localStorage.removeItem(lastModelConfigIDStorageKey(chatOrganization));
 		}
 		if (planModeSwitch !== undefined) {
 			setCachedChatPlanMode(

--- a/site/src/pages/AgentsPage/AgentCreatePage.tsx
+++ b/site/src/pages/AgentsPage/AgentCreatePage.tsx
@@ -15,6 +15,8 @@ import {
 import { preferenceSettings } from "#/api/queries/users";
 import { workspaces } from "#/api/queries/workspaces";
 import type * as TypesGen from "#/api/typesGenerated";
+import { AIResourceOrganizationSelector } from "#/components/AIResourceOrganizationSelector/AIResourceOrganizationSelector";
+import { useAIResourceOrganization } from "#/contexts/AIResourceOrganizationContext";
 import { useWebpushNotifications } from "#/contexts/useWebpushNotifications";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
 import { useAIGatewayEnabled } from "#/hooks/useEmbeddedMetadata";
@@ -34,27 +36,33 @@ import {
 } from "./utils/modelOptions";
 import { buildAgentChatPath } from "./utils/navigation";
 
-const lastModelConfigIDStorageKey = "agents.last-model-config-id";
+const lastModelConfigIDStorageKey = (organization: string) =>
+	`agents.last-model-config-id.${organization}`;
 
 const AgentCreatePage: FC = () => {
 	const queryClient = useQueryClient();
 	const location = useLocation();
 	const navigate = useNavigate();
 	const { permissions } = useAuthenticated();
+	const {
+		organization,
+		permissions: organizationPermissions,
+		registerOrganizationChangeGuard,
+	} = useAIResourceOrganization();
 	const aiGatewayDisabled = !useAIGatewayEnabled();
 
-	const chatModelsQuery = useQuery(chatModels());
-	const chatModelConfigsQuery = useQuery(chatModelConfigs());
+	const chatModelsQuery = useQuery(chatModels(organization.name));
+	const chatModelConfigsQuery = useQuery(chatModelConfigs(organization.name));
 	const chatProviderConfigsQuery = useQuery({
 		...chatProviderConfigs(),
 		enabled: permissions.editDeploymentConfig,
 	});
 	const userProviderConfigsQuery = useQuery(userChatProviderConfigs());
 	const personalModelOverridesQuery = useQuery(
-		userChatPersonalModelOverrides(),
+		userChatPersonalModelOverrides(organization.name),
 	);
 	const preferencesQuery = useQuery(preferenceSettings());
-	const mcpServersQuery = useQuery(mcpServerConfigs());
+	const mcpServersQuery = useQuery(mcpServerConfigs(organization.name));
 	const workspacesQuery = useQuery(workspaces({ q: "owner:me", limit: 0 }));
 	const createMutation = useMutation(createChat(queryClient));
 	const webPush = useWebpushNotifications();
@@ -116,7 +124,10 @@ const AgentCreatePage: FC = () => {
 		const createdChat = await createMutation.mutateAsync(createRequest);
 
 		if (model) {
-			localStorage.setItem(lastModelConfigIDStorageKey, model);
+			localStorage.setItem(
+				lastModelConfigIDStorageKey(organization.name),
+				model,
+			);
 		}
 		navigate({
 			pathname: buildAgentChatPath({ chatId: createdChat.id }),
@@ -158,7 +169,11 @@ const AgentCreatePage: FC = () => {
 				<ChimeButton enabled={chimeEnabled} onToggle={handleChimeToggle} />
 				<WebPushButton webPush={webPush} onToggle={handleNotificationToggle} />
 			</AgentPageHeader>
+			<div className="mx-auto w-full max-w-3xl px-4 pt-3">
+				<AIResourceOrganizationSelector />
+			</div>
 			<AgentCreateForm
+				key={organization.id}
 				onCreateChat={handleCreateChat}
 				sendShortcut={getAgentChatSendShortcut(
 					preferencesQuery.data?.agent_chat_send_shortcut,
@@ -166,7 +181,7 @@ const AgentCreatePage: FC = () => {
 				)}
 				isCreating={createMutation.isPending}
 				createError={createMutation.error}
-				canCreateChat={permissions.createChat}
+				canCreateChat={organizationPermissions.createChat}
 				modelCatalog={chatModelsQuery.data}
 				modelOptions={catalogModelOptions}
 				canConfigureAgentSetup={permissions.editDeploymentConfig}
@@ -185,6 +200,8 @@ const AgentCreatePage: FC = () => {
 				workspaceOptions={workspacesQuery.data?.workspaces ?? []}
 				workspacesError={workspacesQuery.error}
 				isWorkspacesLoading={workspacesQuery.isLoading}
+				organization={organization}
+				registerOrganizationChangeGuard={registerOrganizationChangeGuard}
 			/>{" "}
 		</>
 	);

--- a/site/src/pages/AgentsPage/AgentSettingsAPIKeysPage.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsAPIKeysPage.tsx
@@ -9,6 +9,8 @@ import {
 	upsertUserChatProviderKey,
 	userChatProviderConfigs,
 } from "#/api/queries/chats";
+import { AIResourceOrganizationSelector } from "#/components/AIResourceOrganizationSelector/AIResourceOrganizationSelector";
+import { useAIResourceOrganization } from "#/contexts/AIResourceOrganizationContext";
 import { AgentSettingsAPIKeysPageView } from "./AgentSettingsAPIKeysPageView";
 
 const incrementResetToken = (
@@ -21,12 +23,13 @@ const incrementResetToken = (
 
 const AgentSettingsAPIKeysPage: FC = () => {
 	const queryClient = useQueryClient();
+	const { organization } = useAIResourceOrganization();
 	const [providerPanelResetTokens, setProviderPanelResetTokens] = useState<
 		Record<string, number>
 	>({});
 
 	const providersQuery = useQuery(userChatProviderConfigs());
-	const modelsQuery = useQuery(chatModelConfigs());
+	const modelsQuery = useQuery(chatModelConfigs(organization.name));
 
 	const upsertMutationOptions = upsertUserChatProviderKey(queryClient);
 	const upsertMutation = useMutation({
@@ -74,23 +77,26 @@ const AgentSettingsAPIKeysPage: FC = () => {
 	}));
 
 	return (
-		<AgentSettingsAPIKeysPageView
-			error={providersQuery.error}
-			isLoading={providersQuery.isLoading}
-			providerItems={providerItems}
-			models={modelsQuery.data ?? []}
-			isModelsLoading={modelsQuery.isLoading}
-			areModelsUnavailable={Boolean(modelsQuery.error)}
-			onSave={(providerConfigId, apiKey) => {
-				upsertMutation.mutate({
-					providerConfigId,
-					req: { api_key: apiKey },
-				});
-			}}
-			onRemove={(providerConfigId) => {
-				deleteMutation.mutate(providerConfigId);
-			}}
-		/>
+		<>
+			<AIResourceOrganizationSelector />
+			<AgentSettingsAPIKeysPageView
+				error={providersQuery.error}
+				isLoading={providersQuery.isLoading}
+				providerItems={providerItems}
+				models={modelsQuery.data ?? []}
+				isModelsLoading={modelsQuery.isLoading}
+				areModelsUnavailable={Boolean(modelsQuery.error)}
+				onSave={(providerConfigId, apiKey) => {
+					upsertMutation.mutate({
+						providerConfigId,
+						req: { api_key: apiKey },
+					});
+				}}
+				onRemove={(providerConfigId) => {
+					deleteMutation.mutate(providerConfigId);
+				}}
+			/>
+		</>
 	);
 };
 

--- a/site/src/pages/AgentsPage/AgentSettingsCompactionPage.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsCompactionPage.tsx
@@ -7,14 +7,17 @@ import {
 	userChatProviderConfigs,
 	userCompactionThresholds,
 } from "#/api/queries/chats";
+import { AIResourceOrganizationSelector } from "#/components/AIResourceOrganizationSelector/AIResourceOrganizationSelector";
+import { useAIResourceOrganization } from "#/contexts/AIResourceOrganizationContext";
 import { AgentSettingsCompactionPageView } from "./AgentSettingsCompactionPageView";
 import { providerTypeByIDFromUserConfigs } from "./utils/modelOptions";
 
 const AgentSettingsCompactionPage: FC = () => {
 	const queryClient = useQueryClient();
-	const modelConfigsQuery = useQuery(chatModelConfigs());
+	const { organization } = useAIResourceOrganization();
+	const modelConfigsQuery = useQuery(chatModelConfigs(organization.name));
 	const providerConfigsQuery = useQuery(userChatProviderConfigs());
-	const thresholdsQuery = useQuery(userCompactionThresholds());
+	const thresholdsQuery = useQuery(userCompactionThresholds(organization.name));
 	const saveThresholdMutation = useMutation(
 		updateUserCompactionThreshold(queryClient),
 	);
@@ -27,29 +30,36 @@ const AgentSettingsCompactionPage: FC = () => {
 		thresholdPercent: number,
 	) =>
 		saveThresholdMutation.mutateAsync({
+			organization: organization.name,
 			modelConfigId,
 			req: { threshold_percent: thresholdPercent },
 		});
 
 	const handleResetThreshold = (modelConfigId: string) =>
-		resetThresholdMutation.mutateAsync(modelConfigId);
+		resetThresholdMutation.mutateAsync({
+			organization: organization.name,
+			modelConfigId,
+		});
 
 	const providerTypeByID = providerTypeByIDFromUserConfigs(
 		providerConfigsQuery.data,
 	);
 
 	return (
-		<AgentSettingsCompactionPageView
-			modelConfigsData={modelConfigsQuery.data}
-			providerTypeByID={providerTypeByID}
-			modelConfigsError={modelConfigsQuery.error}
-			isLoadingModelConfigs={modelConfigsQuery.isLoading}
-			thresholds={thresholdsQuery.data?.thresholds}
-			isThresholdsLoading={thresholdsQuery.isLoading}
-			thresholdsError={thresholdsQuery.error}
-			onSaveThreshold={handleSaveThreshold}
-			onResetThreshold={handleResetThreshold}
-		/>
+		<>
+			<AIResourceOrganizationSelector />
+			<AgentSettingsCompactionPageView
+				modelConfigsData={modelConfigsQuery.data}
+				providerTypeByID={providerTypeByID}
+				modelConfigsError={modelConfigsQuery.error}
+				isLoadingModelConfigs={modelConfigsQuery.isLoading}
+				thresholds={thresholdsQuery.data?.thresholds}
+				isThresholdsLoading={thresholdsQuery.isLoading}
+				thresholdsError={thresholdsQuery.error}
+				onSaveThreshold={handleSaveThreshold}
+				onResetThreshold={handleResetThreshold}
+			/>
+		</>
 	);
 };
 

--- a/site/src/pages/AgentsPage/AgentSettingsUserAgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsUserAgentsPage.tsx
@@ -8,14 +8,19 @@ import {
 	userChatProviderConfigs,
 } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
+import { AIResourceOrganizationSelector } from "#/components/AIResourceOrganizationSelector/AIResourceOrganizationSelector";
+import { useAIResourceOrganization } from "#/contexts/AIResourceOrganizationContext";
 import { AgentSettingsUserAgentsPageView } from "./AgentSettingsUserAgentsPageView";
 import { resolveModelSelector } from "./utils/modelOptions";
 
 const AgentSettingsUserAgentsPage: FC = () => {
 	const queryClient = useQueryClient();
-	const overridesQuery = useQuery(userChatPersonalModelOverrides());
-	const chatModelsQuery = useQuery(chatModels());
-	const modelConfigsQuery = useQuery(chatModelConfigs());
+	const { organization } = useAIResourceOrganization();
+	const overridesQuery = useQuery(
+		userChatPersonalModelOverrides(organization.name),
+	);
+	const chatModelsQuery = useQuery(chatModels(organization.name));
+	const modelConfigsQuery = useQuery(chatModelConfigs(organization.name));
 	const providerConfigsQuery = useQuery(userChatProviderConfigs());
 	const saveRootModelOverrideMutation = useMutation(
 		updateUserChatPersonalModelOverride(queryClient),
@@ -41,42 +46,56 @@ const AgentSettingsUserAgentsPage: FC = () => {
 			req: TypesGen.UpdateUserChatPersonalModelOverrideRequest,
 			options?: { onSuccess?: () => void; onError?: () => void },
 		) => {
-			mutation.mutate({ context, req }, options);
+			mutation.mutate(
+				{ organization: organization.name, context, req },
+				options,
+			);
 		};
 	};
 
 	return (
-		<AgentSettingsUserAgentsPageView
-			overridesData={overridesQuery.data}
-			overridesError={overridesQuery.error}
-			onRetryOverrides={() => {
-				void overridesQuery.refetch();
-			}}
-			isRetryingOverrides={overridesQuery.isFetching}
-			isLoadingOverrides={overridesQuery.isLoading}
-			modelOptions={modelOptions}
-			modelConfigs={modelConfigsQuery.data ?? []}
-			modelConfigsError={modelConfigsError}
-			isLoadingModels={isModelCatalogLoading}
-			onSaveRootModelOverride={saveModelOverride(
-				"root",
-				saveRootModelOverrideMutation,
-			)}
-			isSavingRootModelOverride={saveRootModelOverrideMutation.isPending}
-			isSaveRootModelOverrideError={saveRootModelOverrideMutation.isError}
-			onSaveGeneralModelOverride={saveModelOverride(
-				"general",
-				saveGeneralModelOverrideMutation,
-			)}
-			isSavingGeneralModelOverride={saveGeneralModelOverrideMutation.isPending}
-			isSaveGeneralModelOverrideError={saveGeneralModelOverrideMutation.isError}
-			onSaveExploreModelOverride={saveModelOverride(
-				"explore",
-				saveExploreModelOverrideMutation,
-			)}
-			isSavingExploreModelOverride={saveExploreModelOverrideMutation.isPending}
-			isSaveExploreModelOverrideError={saveExploreModelOverrideMutation.isError}
-		/>
+		<>
+			<AIResourceOrganizationSelector />
+			<AgentSettingsUserAgentsPageView
+				overridesData={overridesQuery.data}
+				overridesError={overridesQuery.error}
+				onRetryOverrides={() => {
+					void overridesQuery.refetch();
+				}}
+				isRetryingOverrides={overridesQuery.isFetching}
+				isLoadingOverrides={overridesQuery.isLoading}
+				modelOptions={modelOptions}
+				modelConfigs={modelConfigsQuery.data ?? []}
+				modelConfigsError={modelConfigsError}
+				isLoadingModels={isModelCatalogLoading}
+				onSaveRootModelOverride={saveModelOverride(
+					"root",
+					saveRootModelOverrideMutation,
+				)}
+				isSavingRootModelOverride={saveRootModelOverrideMutation.isPending}
+				isSaveRootModelOverrideError={saveRootModelOverrideMutation.isError}
+				onSaveGeneralModelOverride={saveModelOverride(
+					"general",
+					saveGeneralModelOverrideMutation,
+				)}
+				isSavingGeneralModelOverride={
+					saveGeneralModelOverrideMutation.isPending
+				}
+				isSaveGeneralModelOverrideError={
+					saveGeneralModelOverrideMutation.isError
+				}
+				onSaveExploreModelOverride={saveModelOverride(
+					"explore",
+					saveExploreModelOverrideMutation,
+				)}
+				isSavingExploreModelOverride={
+					saveExploreModelOverrideMutation.isPending
+				}
+				isSaveExploreModelOverrideError={
+					saveExploreModelOverrideMutation.isError
+				}
+			/>
+		</>
 	);
 };
 

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -2,6 +2,7 @@ import { type FC, useEffect, useRef, useState } from "react";
 import {
 	useInfiniteQuery,
 	useMutation,
+	useQueries,
 	useQuery,
 	useQueryClient,
 } from "react-query";
@@ -49,10 +50,7 @@ import type * as TypesGen from "#/api/typesGenerated";
 import { ConfirmDialog } from "#/components/Dialogs/ConfirmDialog/ConfirmDialog";
 import { DeleteDialog } from "#/components/Dialogs/DeleteDialog/DeleteDialog";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
-import {
-	getDefaultOrganizationName,
-	useDashboard,
-} from "#/modules/dashboard/useDashboard";
+import { useDashboard } from "#/modules/dashboard/useDashboard";
 import { createReconnectingWebSocket } from "#/utils/reconnectingWebSocket";
 import { AgentsPageView } from "./AgentsPageView";
 import { emptyInputStorageKey } from "./components/AgentCreateForm";
@@ -101,7 +99,6 @@ const AgentsPage: FC = () => {
 	const { agentId } = useParams();
 	const { permissions, user } = useAuthenticated();
 	const { organizations } = useDashboard();
-	const organizationName = getDefaultOrganizationName(organizations);
 	const isAgentsAdmin = permissions.editDeploymentConfig;
 
 	const [sidebarFilters, setSidebarFilters] = getAgentSidebarFilters(
@@ -166,16 +163,33 @@ const AgentsPage: FC = () => {
 			sources: sidebarFilters.sources,
 		}),
 	);
-	// Model queries are kept here for the sidebar, which displays
-	// model info alongside each chat. Child routes that need models
-	// subscribe to the same queries independently, and react-query
-	// deduplicates the requests.
-	const chatModelsQuery = useQuery(chatModels());
-	const chatModelConfigsQuery = useQuery(chatModelConfigs());
+	const chatList = chatsQuery.data?.pages.flat() ?? [];
+	const organizationNames = [
+		...new Set(chatList.map((chat) => chat.organization_id)),
+	]
+		.map((organizationId) =>
+			organizations.find((organization) => organization.id === organizationId),
+		)
+		.filter((organization): organization is TypesGen.Organization =>
+			Boolean(organization),
+		)
+		.map((organization) => organization.name);
+	// Sidebar resources are fetched for every organization represented by a
+	// visible chat. IDs remain paired with organization-bearing configs.
+	const chatModelsQueries = useQueries({
+		queries: organizationNames.map((organization) => chatModels(organization)),
+	});
+	const chatModelConfigsQueries = useQueries({
+		queries: organizationNames.map((organization) =>
+			chatModelConfigs(organization),
+		),
+	});
+	const personalModelOverridesQueries = useQueries({
+		queries: organizationNames.map((organization) =>
+			userChatPersonalModelOverrides(organization),
+		),
+	});
 	const chatProviderConfigsQuery = useQuery(userChatProviderConfigs());
-	const personalModelOverridesQuery = useQuery(
-		userChatPersonalModelOverrides(),
-	);
 	const [chatErrorReasons, setChatErrorReasons] = useState<
 		Record<string, ChatDetailError>
 	>({});
@@ -254,10 +268,18 @@ const AgentsPage: FC = () => {
 			void queryClient.invalidateQueries({
 				queryKey: chatsByWorkspaceKeyPrefix,
 			});
-			void invalidateWorkspaceMutationQueries(queryClient, {
-				organizationName,
-				username: user.username,
-			});
+			const workspace = queryClient.getQueryData<TypesGen.Workspace>(
+				workspaceByIdKey(workspaceId),
+			);
+			const organization = organizations.find(
+				(item) => item.id === workspace?.organization_id,
+			);
+			if (organization) {
+				void invalidateWorkspaceMutationQueries(queryClient, {
+					organizationName: organization.name,
+					username: user.username,
+				});
+			}
 			notifyDeleteQueueState(
 				queryClient.getQueryData<TypesGen.Workspace>(
 					workspaceByIdKey(workspaceId),
@@ -276,10 +298,18 @@ const AgentsPage: FC = () => {
 			// Archive failed after the delete already ran; refresh
 			// workspace state so consumers see the deletion.
 			if (error instanceof ArchiveAndDeleteError && error.step === "archive") {
-				void invalidateWorkspaceMutationQueries(queryClient, {
-					organizationName,
-					username: user.username,
-				});
+				const workspace = queryClient.getQueryData<TypesGen.Workspace>(
+					workspaceByIdKey(workspaceId),
+				);
+				const organization = organizations.find(
+					(item) => item.id === workspace?.organization_id,
+				);
+				if (organization) {
+					void invalidateWorkspaceMutationQueries(queryClient, {
+						organizationName: organization.name,
+						username: user.username,
+					});
+				}
 			}
 		},
 	});
@@ -328,12 +358,19 @@ const AgentsPage: FC = () => {
 		},
 	});
 	const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
-	const catalogModelOptions = getModelOptionsFromConfigs(
-		chatModelConfigsQuery.data,
-		chatModelsQuery.data,
-		providerInfoByIDFromUserConfigs(chatProviderConfigsQuery.data),
+	const providerInfoByID = providerInfoByIDFromUserConfigs(
+		chatProviderConfigsQuery.data,
 	);
-	const chatList = chatsQuery.data?.pages.flat() ?? [];
+	const modelConfigs = chatModelConfigsQueries.flatMap(
+		(query) => query.data ?? [],
+	);
+	const catalogModelOptions = chatModelConfigsQueries.flatMap((query, index) =>
+		getModelOptionsFromConfigs(
+			query.data,
+			chatModelsQueries[index]?.data,
+			providerInfoByID,
+		),
+	);
 	const isArchiving =
 		archiveAgentMutation.isPending || archiveAndDeleteMutation.isPending;
 	const archivingChatId =
@@ -669,7 +706,7 @@ const AgentsPage: FC = () => {
 				chatList={chatList}
 				currentUserId={user.id}
 				catalogModelOptions={catalogModelOptions}
-				modelConfigs={chatModelConfigsQuery.data ?? []}
+				modelConfigs={modelConfigs}
 				handleNewAgent={handleNewAgent}
 				isSearchDialogOpen={isSearchDialogOpen}
 				onSearchDialogOpenChange={setIsSearchDialogOpen}
@@ -694,9 +731,9 @@ const AgentsPage: FC = () => {
 				onProposeTitle={requestProposeTitle}
 				onRenameTitle={requestRenameTitle}
 				onToggleSidebarCollapsed={handleToggleSidebarCollapsed}
-				isPersonalModelOverridesEnabled={
-					personalModelOverridesQuery.data?.enabled
-				}
+				isPersonalModelOverridesEnabled={personalModelOverridesQueries.some(
+					(query) => query.data?.enabled,
+				)}
 				isAgentsAdmin={isAgentsAdmin}
 				hasNextPage={chatsQuery.hasNextPage}
 				onLoadMore={() => void chatsQuery.fetchNextPage()}

--- a/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
@@ -17,8 +17,10 @@ import { API } from "#/api/api";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { Chat } from "#/api/typesGenerated";
 import { DeleteDialog } from "#/components/Dialogs/DeleteDialog/DeleteDialog";
+import { AIResourceOrganizationOutlet } from "#/contexts/AIResourceOrganizationContext";
 import { MockChat } from "#/testHelpers/chatEntities";
 import {
+	MockDefaultOrganization,
 	MockNoPermissions,
 	MockPermissions,
 	MockUserOwner,
@@ -69,6 +71,7 @@ const defaultModelOptions: ModelSelectorOption[] = [
 const defaultModelConfigs: TypesGen.ChatModelConfig[] = [
 	{
 		id: defaultModelConfigID,
+		organization_id: "test-org-id",
 		ai_provider_id: "provider-openai",
 		model: "gpt-4o",
 		display_name: "GPT-4o",
@@ -254,7 +257,14 @@ const agentsRouting = {
 		},
 		{ path: "analytics", element: <AgentAnalyticsPage now={fixedNow} /> },
 		{ path: ":agentId", element: <div /> },
-		{ index: true, element: <AgentCreatePage /> },
+		{
+			element: (
+				<AIResourceOrganizationOutlet
+					isOrganizationPermitted={(permissions) => permissions.createChat}
+				/>
+			),
+			children: [{ index: true, element: <AgentCreatePage /> }],
+		},
 	],
 };
 
@@ -388,13 +398,19 @@ const meta: Meta<typeof AgentsPageView> = {
 		user: MockUserOwner,
 		permissions: MockPermissions,
 		reactRouter: reactRouterParameters({
-			location: { path: "/agents" },
+			location: {
+				path: "/agents",
+				searchParams: { organization: MockDefaultOrganization.name },
+			},
 			routing: [agentsRouting, aiSettingsRouting],
 		}),
 	},
 	args: defaultArgs,
 	beforeEach: () => {
 		localStorage.removeItem(LEFT_SIDEBAR_STORAGE_KEY);
+		spyOn(API, "checkAuthorization").mockResolvedValue({
+			[`${MockDefaultOrganization.id}.createChat`]: true,
+		});
 		spyOn(API, "getWorkspaces").mockResolvedValue({
 			workspaces: [],
 			count: 0,
@@ -438,6 +454,7 @@ const meta: Meta<typeof AgentsPageView> = {
 		spyOn(API.experimental, "getChatModelConfigs").mockResolvedValue([
 			{
 				id: defaultModelConfigID,
+				organization_id: "test-org-id",
 				ai_provider_id: "provider-openai",
 				model: "gpt-4o",
 				display_name: "GPT-4o",

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -24,6 +24,7 @@ import {
 import { useMutation, useQueryClient } from "react-query";
 import { Link } from "react-router";
 import { toast } from "sonner";
+import { API } from "#/api/api";
 import { getErrorMessage } from "#/api/errors";
 import { disconnectMCPServerOAuth2 } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
@@ -566,9 +567,8 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 
 	const handleMcpConnect = (server: TypesGen.MCPServerConfig) => {
 		setMcpConnectingId(server.id);
-		const connectUrl = `/api/experimental/mcp/servers/${encodeURIComponent(server.id)}/oauth2/connect`;
 		mcpPopupRef.current = window.open(
-			connectUrl,
+			API.experimental.getMCPServerOAuth2ConnectURL(server.id),
 			"_blank",
 			"width=900,height=600",
 		);
@@ -579,21 +579,27 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 			return;
 		}
 		const name = mcpDisconnectTarget.display_name;
-		mcpDisconnectMutation.mutate(mcpDisconnectTarget.id, {
-			onSuccess: (response) => {
-				setMcpDisconnectTarget(null);
-				if (response.token_revocation_error) {
-					toast.warning(`Disconnected ${name}.`, {
-						description: response.token_revocation_error,
-					});
-				} else {
-					toast.success(`Disconnected ${name}.`);
-				}
+		mcpDisconnectMutation.mutate(
+			{
+				organization: mcpDisconnectTarget.organization_id,
+				serverId: mcpDisconnectTarget.id,
 			},
-			onError: (error) => {
-				toast.error(getErrorMessage(error, `Failed to disconnect ${name}.`));
+			{
+				onSuccess: (response) => {
+					setMcpDisconnectTarget(null);
+					if (response.token_revocation_error) {
+						toast.warning(`Disconnected ${name}.`, {
+							description: response.token_revocation_error,
+						});
+					} else {
+						toast.success(`Disconnected ${name}.`);
+					}
+				},
+				onError: (error) => {
+					toast.error(getErrorMessage(error, `Failed to disconnect ${name}.`));
+				},
 			},
-		});
+		);
 	};
 
 	// Only a chat-bound workspace counts: an unbound selection (new chat

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -1,31 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import {
-	expect,
-	fn,
-	screen,
-	spyOn,
-	userEvent,
-	waitFor,
-	within,
-} from "storybook/test";
-import { API } from "#/api/api";
+import { type ComponentProps, useRef, useState } from "react";
+import { expect, fn, screen, userEvent, waitFor, within } from "storybook/test";
 import type * as TypesGen from "#/api/typesGenerated";
 import { ConfirmDialog } from "#/components/Dialogs/ConfirmDialog/ConfirmDialog";
 import { MockChatModelConfig } from "#/testHelpers/chatModels";
-import {
-	MockDefaultOrganization,
-	MockOrganization2,
-	MockWorkspace,
-} from "#/testHelpers/entities";
+import { MockDefaultOrganization, MockWorkspace } from "#/testHelpers/entities";
 import { withDashboardProvider } from "#/testHelpers/storybook";
 import { AgentCreateForm } from "./AgentCreateForm";
-
-// Query key used by permittedOrganizations() in the form.
-const permittedOrgsKey = [
-	"organizations",
-	"permitted",
-	{ object: { resource_type: "chat" }, action: "create" },
-];
 
 const modelConfigID = "model-config-1";
 const claudeModelConfigID = "model-config-claude";
@@ -117,6 +98,7 @@ const meta: Meta<typeof AgentCreateForm> = {
 		workspaceOptions: [],
 		workspacesError: undefined,
 		isWorkspacesLoading: false,
+		organization: MockDefaultOrganization,
 	},
 	beforeEach: () => {
 		localStorage.clear();
@@ -127,13 +109,50 @@ export default meta;
 type Story = StoryObj<typeof AgentCreateForm>;
 
 const defaultArgs = meta.args;
+const agentCreateFormArgs = defaultArgs as ComponentProps<
+	typeof AgentCreateForm
+>;
 
-const mockPermittedOrganizations = (permissions: Record<string, boolean>) => {
-	spyOn(API, "getOrganizations").mockResolvedValue([
-		MockDefaultOrganization,
-		MockOrganization2,
-	]);
-	spyOn(API, "checkAuthorization").mockResolvedValue(permissions);
+type OrganizationChangeGuard = (
+	nextOrganization: TypesGen.Organization,
+) => boolean | Promise<boolean>;
+
+const OrganizationChangeUnmountHarness = () => {
+	const [mounted, setMounted] = useState(true);
+	const [result, setResult] = useState<string>();
+	const guardRef = useRef<OrganizationChangeGuard | undefined>(undefined);
+	const registerOrganizationChangeGuard = (guard: OrganizationChangeGuard) => {
+		guardRef.current = guard;
+		return () => {
+			if (guardRef.current === guard) {
+				guardRef.current = undefined;
+			}
+		};
+	};
+	const requestOrganizationChange = async () => {
+		const guard = guardRef.current;
+		if (!guard) {
+			throw new Error("Expected an organization change guard.");
+		}
+		const result = guard(MockDefaultOrganization);
+		setMounted(false);
+		setResult(String(await result));
+	};
+
+	return (
+		<>
+			<button type="button" onClick={requestOrganizationChange}>
+				Request organization change and unmount
+			</button>
+			{result && <output>Guard result: {result}</output>}
+			{mounted && (
+				<AgentCreateForm
+					{...agentCreateFormArgs}
+					registerOrganizationChangeGuard={registerOrganizationChangeGuard}
+				/>
+			)}
+		</>
+	);
 };
 
 export const Default: Story = {};
@@ -266,7 +285,10 @@ export const LastUsedModelFallbackWithoutRootOverride: Story = {
 	},
 	beforeEach: () => {
 		localStorage.clear();
-		localStorage.setItem("agents.last-model-config-id", claudeModelConfigID);
+		localStorage.setItem(
+			`agents.last-model-config-id.${MockDefaultOrganization.name}`,
+			claudeModelConfigID,
+		);
 	},
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
@@ -673,63 +695,44 @@ export const ForbiddenErrorWithRole: Story = {
 	},
 };
 
-export const WithOrganizationPicker: Story = {
-	parameters: {
-		showOrganizations: true,
-		organizations: [MockDefaultOrganization, MockOrganization2],
-		queries: [
-			{
-				key: permittedOrgsKey,
-				data: [MockDefaultOrganization, MockOrganization2],
-			},
-		],
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		// Verify the org picker rendered (component didn't crash).
-		await waitFor(() => {
-			expect(canvas.getByTestId("compact-org-selector")).toBeInTheDocument();
-		});
-		// Type into the chat input to trigger re-renders. If the
-		// permittedOrgs fallback is referentially unstable, this
-		// causes a render cascade that hits React's update limit.
-		const input = canvas.getByTestId("chat-message-input");
-		await userEvent.click(input);
-		await userEvent.keyboard("hello world");
-		// The org picker should still be present after typing.
-		expect(canvas.getByTestId("compact-org-selector")).toBeInTheDocument();
-	},
-};
-
-export const OrgPickerTightSpacing: Story = {
-	parameters: {
-		showOrganizations: true,
-		organizations: [MockDefaultOrganization, MockOrganization2],
-		queries: [
-			{
-				key: permittedOrgsKey,
-				data: [MockDefaultOrganization, MockOrganization2],
-			},
-		],
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const orgTrigger = await canvas.findByTestId("compact-org-selector");
-		const composer = await canvas.findByTestId("chat-composer");
-
-		const orgRect = orgTrigger.getBoundingClientRect();
-		const composerRect = composer.getBoundingClientRect();
-		const gap = composerRect.top - orgRect.bottom;
-		expect(gap).toBeGreaterThanOrEqual(0);
-		expect(gap).toBeLessThan(16);
-	},
-};
-
 /**
  * Standalone story for the org-change confirmation dialog. Renders
  * the ConfirmDialog directly in its open state, following the same
  * pattern as DeleteConfirmationDialog in AgentsPageView.stories.
  */
+export const CancelsPendingOrganizationChangeOnUnmount: Story = {
+	beforeEach: () => {
+		localStorage.clear();
+		localStorage.setItem(
+			"agents.persisted-attachments",
+			JSON.stringify([
+				{
+					fileId: "persisted-file-1",
+					fileName: "photo.png",
+					fileType: "image/png",
+					lastModified: 1000,
+					organizationId: MockDefaultOrganization.id,
+				},
+			]),
+		);
+	},
+	render: () => <OrganizationChangeUnmountHarness />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await waitFor(() => {
+			expect(canvas.getByLabelText("Remove photo.png")).toBeInTheDocument();
+		});
+		await userEvent.click(
+			canvas.getByRole("button", {
+				name: "Request organization change and unmount",
+			}),
+		);
+		await waitFor(() => {
+			expect(canvas.getByText("Guard result: false")).toBeInTheDocument();
+		});
+	},
+};
+
 export const OrgChangeConfirmation: Story = {
 	render: () => (
 		<ConfirmDialog
@@ -782,109 +785,5 @@ export const ForbiddenNoAgentsRole: Story = {
 		// accidentally trigger the generic error.
 		const textbox = canvas.getByRole("textbox");
 		await expect(textbox).toHaveAttribute("aria-disabled", "true");
-	},
-};
-
-/**
- * Covers the reconciliation path where the permitted-organizations query
- * resolves after mount with fewer orgs than the dashboard provides.
- */
-export const PermittedOrgsResolvesToEmpty: Story = {
-	parameters: {
-		showOrganizations: true,
-		organizations: [MockDefaultOrganization, MockOrganization2],
-		// Deliberately do not pre-seed permittedOrgsKey. Let the
-		// mocked API calls drive the async permission resolution.
-	},
-	args: {
-		...defaultArgs,
-		onCreateChat: fn().mockResolvedValue(undefined),
-	},
-	beforeEach: () => {
-		mockPermittedOrganizations({
-			[MockDefaultOrganization.id]: false,
-			[MockOrganization2.id]: false,
-		});
-	},
-	play: async ({ canvasElement, args }) => {
-		const canvas = within(canvasElement);
-
-		// Wait for the permitted orgs query to resolve. The org picker
-		// should disappear since no org is permitted.
-		await waitFor(
-			() => {
-				expect(
-					canvas.queryByTestId("compact-org-selector"),
-				).not.toBeInTheDocument();
-			},
-			{ timeout: 3000 },
-		);
-
-		// Type a message and submit the form.
-		const input = canvas.getByTestId("chat-message-input");
-		await userEvent.click(input);
-		await userEvent.keyboard("test message");
-		await userEvent.click(canvas.getByRole("button", { name: "Send" }));
-
-		// Verify onCreateChat was called with a non-empty organizationId.
-		await waitFor(() => {
-			expect(args.onCreateChat).toHaveBeenCalled();
-		});
-		const options = (args.onCreateChat as ReturnType<typeof fn>).mock
-			.calls[0]?.[0] as { organizationId: string } | undefined;
-		if (!options) {
-			throw new Error("Expected onCreateChat to receive options");
-		}
-		expect(options.organizationId).not.toBe("");
-		// It should fall back to the default org from the dashboard.
-		expect(options.organizationId).toBe(MockDefaultOrganization.id);
-	},
-};
-
-export const PermittedOrgsResolvesToSubset: Story = {
-	parameters: {
-		showOrganizations: true,
-		organizations: [MockDefaultOrganization, MockOrganization2],
-	},
-	args: {
-		...defaultArgs,
-		onCreateChat: fn().mockResolvedValue(undefined),
-	},
-	beforeEach: () => {
-		mockPermittedOrganizations({
-			[MockDefaultOrganization.id]: false,
-			[MockOrganization2.id]: true,
-		});
-	},
-	play: async ({ canvasElement, args }) => {
-		const canvas = within(canvasElement);
-
-		// Wait for the permitted orgs query to resolve. With only one
-		// permitted org, the picker should disappear.
-		await waitFor(
-			() => {
-				expect(
-					canvas.queryByTestId("compact-org-selector"),
-				).not.toBeInTheDocument();
-			},
-			{ timeout: 3000 },
-		);
-
-		// Type a message and submit.
-		const input = canvas.getByTestId("chat-message-input");
-		await userEvent.click(input);
-		await userEvent.keyboard("test message");
-		await userEvent.click(canvas.getByRole("button", { name: "Send" }));
-
-		// Verify onCreateChat was called with the only permitted org.
-		await waitFor(() => {
-			expect(args.onCreateChat).toHaveBeenCalled();
-		});
-		const options = (args.onCreateChat as ReturnType<typeof fn>).mock
-			.calls[0]?.[0] as { organizationId: string } | undefined;
-		if (!options) {
-			throw new Error("Expected onCreateChat to receive options");
-		}
-		expect(options.organizationId).toBe(MockOrganization2.id);
 	},
 };

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -1,16 +1,13 @@
-import { type FC, useEffect, useEffectEvent, useRef, useState } from "react";
-import { useQuery } from "react-query";
+import { type FC, useEffect, useRef, useState } from "react";
 import { Link } from "react-router";
 import { toast } from "sonner";
 import { isApiError } from "#/api/errors";
-import { permittedOrganizations } from "#/api/queries/organizations";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { AgentChatSendShortcut } from "#/api/typesGenerated";
 import { Alert, AlertDescription } from "#/components/Alert/Alert";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Button } from "#/components/Button/Button";
 import { ConfirmDialog } from "#/components/Dialogs/ConfirmDialog/ConfirmDialog";
-import { useDashboard } from "#/modules/dashboard/useDashboard";
 import { docs } from "#/utils/docs";
 import { useFileAttachments } from "../hooks/useFileAttachments";
 import { parseStoredDraft } from "../utils/draftStorage";
@@ -28,7 +25,6 @@ import {
 import { AgentChatInput } from "./AgentChatInput";
 import { ChatAccessDeniedAlert } from "./ChatAccessDeniedAlert";
 import type { ModelSelectorOption } from "./ChatElements";
-import { CompactOrgSelector } from "./ChatElements";
 import {
 	getDefaultMCPSelection,
 	getSavedMCPSelection,
@@ -39,7 +35,8 @@ import { getModelSelectorHelp } from "./ModelSelectorHelp";
 /** @internal Exported for testing. */
 export const emptyInputStorageKey = "agents.empty-input";
 const selectedWorkspaceIdStorageKey = "agents.selected-workspace-id";
-const lastModelConfigIDStorageKey = "agents.last-model-config-id";
+const lastModelConfigIDStorageKey = (organization: string) =>
+	`agents.last-model-config-id.${organization}`;
 
 type ChatModelOption = ModelSelectorOption;
 
@@ -143,6 +140,12 @@ interface AgentCreateFormProps {
 	workspaceOptions: readonly TypesGen.Workspace[];
 	workspacesError: unknown;
 	isWorkspacesLoading: boolean;
+	organization: TypesGen.Organization;
+	registerOrganizationChangeGuard?: (
+		guard: (
+			nextOrganization: TypesGen.Organization,
+		) => boolean | Promise<boolean>,
+	) => () => void;
 }
 
 export const AgentCreateForm: FC<AgentCreateFormProps> = ({
@@ -169,8 +172,9 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	workspaceOptions,
 	workspacesError,
 	isWorkspacesLoading,
+	organization,
+	registerOrganizationChangeGuard,
 }) => {
-	const { organizations, showOrganizations } = useDashboard();
 	const {
 		initialInputValue,
 		initialEditorState,
@@ -179,7 +183,9 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		resetDraft,
 	} = useEmptyStateDraft();
 	const [initialLastModelConfigID] = useState(() => {
-		return localStorage.getItem(lastModelConfigIDStorageKey) ?? "";
+		return (
+			localStorage.getItem(lastModelConfigIDStorageKey(organization.name)) ?? ""
+		);
 	});
 	/*
 	 * Model precedence: user click > root override (specific model) > root
@@ -251,44 +257,10 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 				selectedModelOption.reasoningEffortDefault,
 			)
 		: undefined;
-	const initialOrg =
-		organizations.find((o) => o.is_default) ?? organizations[0];
+	const organizationId = organization.id;
 	const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(
-		() => {
-			const stored = localStorage.getItem(selectedWorkspaceIdStorageKey);
-			if (!stored) return null;
-
-			// The stored value is kept optimistically until workspaces
-			// load. effectiveWorkspaceId (computed after render) drops
-			// it if it doesn't match the current org's workspaces.
-			if (workspaceOptions.length === 0) return stored;
-
-			// Validate the stored workspace still exists and belongs
-			// to the initial org. Without this, a workspace from a
-			// previously selected org persists across sessions and
-			// gets submitted even though it's hidden from the picker.
-			const workspace = workspaceOptions.find((ws) => ws.id === stored);
-			if (!workspace) {
-				localStorage.removeItem(selectedWorkspaceIdStorageKey);
-				return null;
-			}
-			if (
-				showOrganizations &&
-				initialOrg &&
-				workspace.organization_id !== initialOrg.id
-			) {
-				localStorage.removeItem(selectedWorkspaceIdStorageKey);
-				return null;
-			}
-			return stored;
-		},
+		() => localStorage.getItem(selectedWorkspaceIdStorageKey),
 	);
-	const [selectedOrg, setSelectedOrg] = useState<TypesGen.Organization | null>(
-		initialOrg ?? null,
-	);
-	const [pendingOrgChange, setPendingOrgChange] =
-		useState<TypesGen.Organization | null>(null);
-	const organizationId = selectedOrg?.id ?? "";
 	const [planModeEnabled, setPlanModeEnabled] = useState(false);
 	const hasModelOptions = modelOptions.length > 0;
 	const hasConfiguredModels = hasConfiguredModelsInCatalog(modelCatalog);
@@ -315,12 +287,13 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		if (lastUsedModelID) {
 			return;
 		}
-		localStorage.removeItem(lastModelConfigIDStorageKey);
+		localStorage.removeItem(lastModelConfigIDStorageKey(organization.name));
 	}, [
 		initialLastModelConfigID,
 		isModelCatalogLoading,
 		isModelConfigsLoading,
 		lastUsedModelID,
+		organization.name,
 	]);
 
 	const [userMCPServerIds, setUserMCPServerIds] = useState<string[] | null>(
@@ -330,7 +303,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		if (userMCPServerIds !== null) {
 			return userMCPServerIds;
 		}
-		const saved = getSavedMCPSelection(mcpServers ?? []);
+		const saved = getSavedMCPSelection(mcpServers ?? [], organization.name);
 		if (saved !== null) {
 			return saved;
 		}
@@ -361,10 +334,9 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	// guarantees completeness. If workspace counts grow large
 	// enough to warrant pagination, this should switch to a
 	// server-side organization:<name> query filter.
-	const filteredWorkspaces =
-		showOrganizations && selectedOrg
-			? workspaceOptions.filter((ws) => ws.organization_id === selectedOrg.id)
-			: workspaceOptions;
+	const filteredWorkspaces = workspaceOptions.filter(
+		(workspace) => workspace.organization_id === organization.id,
+	);
 
 	const effectiveWorkspaceId =
 		selectedWorkspaceId !== null &&
@@ -405,6 +377,55 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		persist: true,
 		provider: getProviderForModelOption(modelOptions, selectedModel),
 	});
+	const attachmentsRef = useRef(attachments);
+	useEffect(() => {
+		attachmentsRef.current = attachments;
+	}, [attachments]);
+	const pendingOrganizationChangeRef = useRef<
+		| {
+				promise: Promise<boolean>;
+				resolve: (confirmed: boolean) => void;
+		  }
+		| undefined
+	>(undefined);
+	const [organizationChangePending, setOrganizationChangePending] =
+		useState(false);
+
+	useEffect(() => {
+		if (!registerOrganizationChangeGuard) {
+			return;
+		}
+		const unregister = registerOrganizationChangeGuard(() => {
+			if (attachmentsRef.current.length === 0) {
+				return true;
+			}
+			if (pendingOrganizationChangeRef.current) {
+				return pendingOrganizationChangeRef.current.promise;
+			}
+			setOrganizationChangePending(true);
+			let resolve: (confirmed: boolean) => void = () => undefined;
+			const promise = new Promise<boolean>((promiseResolve) => {
+				resolve = promiseResolve;
+			});
+			pendingOrganizationChangeRef.current = { promise, resolve };
+			return promise;
+		});
+		return () => {
+			unregister();
+			pendingOrganizationChangeRef.current?.resolve(false);
+			pendingOrganizationChangeRef.current = undefined;
+		};
+	}, [registerOrganizationChangeGuard]);
+
+	const resolveOrganizationChange = (confirmed: boolean) => {
+		if (confirmed) {
+			resetAttachments();
+			handleWorkspaceChange(null);
+		}
+		pendingOrganizationChangeRef.current?.resolve(confirmed);
+		pendingOrganizationChangeRef.current = undefined;
+		setOrganizationChangePending(false);
+	};
 
 	const handleSendWithAttachments = async (message: string) => {
 		const fileIds: string[] = [];
@@ -433,50 +454,6 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		}
 	};
 
-	const permittedOrgsQuery = useQuery({
-		...permittedOrganizations({
-			object: { resource_type: "chat" },
-			action: "create",
-		}),
-		enabled: showOrganizations,
-	});
-	const permittedOrgs = permittedOrgsQuery.data ?? organizations;
-
-	// Reconcile selectedOrg when permission filtering removes it.
-	// Only pure state setters run during render; side effects
-	// (localStorage, blob URL cleanup) run in the effect below.
-	const [prevPermittedOrgs, setPrevPermittedOrgs] = useState(permittedOrgs);
-	const [orgWasAdjusted, setOrgWasAdjusted] = useState(false);
-	if (permittedOrgs !== prevPermittedOrgs) {
-		setPrevPermittedOrgs(permittedOrgs);
-		if (selectedOrg && !permittedOrgs.some((o) => o.id === selectedOrg.id)) {
-			// Fall back through: first permitted org, then the
-			// dashboard default. Never null out selectedOrg.
-			// organizationId must always be a valid UUID for the
-			// create-chat request.
-			const nextOrg = permittedOrgs[0] ?? initialOrg ?? null;
-			setSelectedOrg(nextOrg);
-			if (nextOrg?.id !== selectedOrg.id) {
-				setOrgWasAdjusted(true);
-			}
-		}
-	}
-
-	// Clean up workspace and attachment state after a programmatic
-	// org change from permission filtering. These calls have side
-	// effects (localStorage, blob URL revocation) that must not
-	// run during render.
-	const onOrgAdjusted = useEffectEvent(() => {
-		handleWorkspaceChange(null);
-		resetAttachments();
-	});
-	useEffect(() => {
-		if (orgWasAdjusted) {
-			setOrgWasAdjusted(false);
-			onOrgAdjusted();
-		}
-	}, [orgWasAdjusted]);
-
 	return (
 		<>
 			<div className="order-last flex min-h-0 flex-none items-end justify-center overflow-auto px-4 pb-4 sm:order-none sm:h-full sm:flex-1 sm:items-center">
@@ -504,26 +481,6 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						)
 					) : null}
 					{workspacesError != null && <ErrorAlert error={workspacesError} />}
-					{permittedOrgsQuery.error != null && (
-						<ErrorAlert error={permittedOrgsQuery.error} />
-					)}
-					{showOrganizations && permittedOrgs.length > 1 && (
-						<CompactOrgSelector
-							value={selectedOrg}
-							options={permittedOrgs}
-							onChange={(newOrg) => {
-								const orgChanged = newOrg.id !== selectedOrg?.id;
-								if (orgChanged && attachments.length > 0) {
-									setPendingOrgChange(newOrg);
-									return;
-								}
-								if (orgChanged) {
-									handleWorkspaceChange(null);
-								}
-								setSelectedOrg(newOrg);
-							}}
-						/>
-					)}
 					<AgentChatInput
 						onSend={handleSendWithAttachments}
 						sendShortcut={sendShortcut}
@@ -559,7 +516,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						selectedMCPServerIds={effectiveMCPServerIds}
 						onMCPSelectionChange={(ids) => {
 							setUserMCPServerIds(ids);
-							saveMCPSelection(ids);
+							saveMCPSelection(ids, organization.name);
 						}}
 						onMCPAuthComplete={onMCPAuthComplete}
 						workspaceOptions={filteredWorkspaces}
@@ -591,19 +548,14 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 				</div>
 			</div>
 			<ConfirmDialog
-				open={pendingOrgChange !== null}
+				open={organizationChangePending}
 				title="Change organization?"
 				description="Changing organization will remove your current attachments."
 				type="info"
 				hideCancel={false}
 				confirmText="Continue"
-				onConfirm={() => {
-					resetAttachments();
-					handleWorkspaceChange(null);
-					setSelectedOrg(pendingOrgChange);
-					setPendingOrgChange(null);
-				}}
-				onClose={() => setPendingOrgChange(null)}
+				onConfirm={() => resolveOrganizationChange(true)}
+				onClose={() => resolveOrganizationChange(false)}
 			/>
 		</>
 	);

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -1354,6 +1354,7 @@ export const TaskNameGenericRendering: Story = {
 const sampleMCPServers = [
 	{
 		id: "mcp-server-1",
+		organization_id: "test-org-id",
 		slug: "linear",
 		display_name: "Linear",
 		description: "Project management",

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
@@ -52,6 +52,7 @@ const defaultModelOptions: ModelSelectorOption[] = [
 const defaultModelConfigs: TypesGen.ChatModelConfig[] = [
 	{
 		id: "config-openai-gpt-4o",
+		organization_id: "test-org-id",
 		ai_provider_id: "prov-1",
 		model: "gpt-4o",
 		display_name: "GPT-4o",

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.test.tsx
@@ -583,6 +583,7 @@ describe("ChatsSidebar model display names", () => {
 		const modelConfigs: TypesGen.ChatModelConfig[] = [
 			{
 				id: "config-fast",
+				organization_id: "test-org-id",
 				ai_provider_id: "prov-openai",
 				model: "gpt-4o",
 				display_name: "GPT-4o (Fast)",
@@ -595,6 +596,7 @@ describe("ChatsSidebar model display names", () => {
 			},
 			{
 				id: "config-quality",
+				organization_id: "test-org-id",
 				ai_provider_id: "prov-openai",
 				model: "gpt-4o",
 				display_name: "GPT-4o (Quality)",

--- a/site/src/pages/AgentsPage/components/MCPServerPicker.test.ts
+++ b/site/src/pages/AgentsPage/components/MCPServerPicker.test.ts
@@ -19,21 +19,24 @@ const buildServer = (
 });
 
 describe("MCP selection persistence", () => {
+	const organization = "test-org";
 	beforeEach(() => {
 		localStorage.clear();
 	});
 
 	describe("saveMCPSelection", () => {
 		it("writes a JSON array to localStorage", () => {
-			saveMCPSelection(["a", "b"]);
-			expect(localStorage.getItem(mcpSelectionStorageKey)).toBe(
+			saveMCPSelection(["a", "b"], organization);
+			expect(localStorage.getItem(mcpSelectionStorageKey(organization))).toBe(
 				JSON.stringify(["a", "b"]),
 			);
 		});
 
 		it("writes an empty array when no servers are selected", () => {
-			saveMCPSelection([]);
-			expect(localStorage.getItem(mcpSelectionStorageKey)).toBe("[]");
+			saveMCPSelection([], organization);
+			expect(localStorage.getItem(mcpSelectionStorageKey(organization))).toBe(
+				"[]",
+			);
 		});
 	});
 
@@ -45,34 +48,34 @@ describe("MCP selection persistence", () => {
 		];
 
 		it("returns null when nothing is stored", () => {
-			expect(getSavedMCPSelection(servers)).toBeNull();
+			expect(getSavedMCPSelection(servers, organization)).toBeNull();
 		});
 
 		it("returns null when the server list is empty", () => {
-			saveMCPSelection(["s1", "s2"]);
-			expect(getSavedMCPSelection([])).toBeNull();
+			saveMCPSelection(["s1", "s2"], organization);
+			expect(getSavedMCPSelection([], organization)).toBeNull();
 		});
 
 		it("returns null for invalid JSON", () => {
-			localStorage.setItem(mcpSelectionStorageKey, "not-json");
-			expect(getSavedMCPSelection(servers)).toBeNull();
+			localStorage.setItem(mcpSelectionStorageKey(organization), "not-json");
+			expect(getSavedMCPSelection(servers, organization)).toBeNull();
 		});
 
 		it("returns null when stored value is not an array", () => {
-			localStorage.setItem(mcpSelectionStorageKey, '"a string"');
-			expect(getSavedMCPSelection(servers)).toBeNull();
+			localStorage.setItem(mcpSelectionStorageKey(organization), '"a string"');
+			expect(getSavedMCPSelection(servers, organization)).toBeNull();
 		});
 
 		it("restores saved IDs that still exist as enabled servers", () => {
-			saveMCPSelection(["s2", "s3"]);
-			const result = getSavedMCPSelection(servers);
+			saveMCPSelection(["s2", "s3"], organization);
+			const result = getSavedMCPSelection(servers, organization);
 			expect(result).toContain("s2");
 			expect(result).toContain("s3");
 		});
 
 		it("filters out IDs for servers that no longer exist", () => {
-			saveMCPSelection(["s2", "deleted-server"]);
-			const result = getSavedMCPSelection(servers);
+			saveMCPSelection(["s2", "deleted-server"], organization);
+			const result = getSavedMCPSelection(servers, organization);
 			expect(result).toContain("s2");
 			expect(result).not.toContain("deleted-server");
 		});
@@ -82,29 +85,29 @@ describe("MCP selection persistence", () => {
 				...servers,
 				buildServer({ id: "s4", enabled: false }),
 			];
-			saveMCPSelection(["s2", "s4"]);
-			const result = getSavedMCPSelection(withDisabled);
+			saveMCPSelection(["s2", "s4"], organization);
+			const result = getSavedMCPSelection(withDisabled, organization);
 			expect(result).toContain("s2");
 			expect(result).not.toContain("s4");
 		});
 
 		it("always includes force_on servers even if not in saved list", () => {
-			saveMCPSelection(["s3"]);
-			const result = getSavedMCPSelection(servers);
+			saveMCPSelection(["s3"], organization);
+			const result = getSavedMCPSelection(servers, organization);
 			expect(result).toContain("s1");
 			expect(result).toContain("s3");
 		});
 
 		it("does not duplicate force_on servers already in saved list", () => {
-			saveMCPSelection(["s1", "s3"]);
-			const result = getSavedMCPSelection(servers)!;
+			saveMCPSelection(["s1", "s3"], organization);
+			const result = getSavedMCPSelection(servers, organization)!;
 			const s1Count = result.filter((id) => id === "s1").length;
 			expect(s1Count).toBe(1);
 		});
 
 		it("returns an empty selection (plus force_on) when user opted out", () => {
-			saveMCPSelection([]);
-			const result = getSavedMCPSelection(servers);
+			saveMCPSelection([], organization);
+			const result = getSavedMCPSelection(servers, organization);
 			// Only force_on should be present.
 			expect(result).toEqual(["s1"]);
 		});

--- a/site/src/pages/AgentsPage/components/MCPServerPicker.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerPicker.tsx
@@ -1,5 +1,6 @@
 import { ChevronDownIcon, LockIcon, ServerIcon } from "lucide-react";
 import { type FC, useEffect, useRef, useState } from "react";
+import { API } from "#/api/api";
 import type * as TypesGen from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
@@ -91,8 +92,8 @@ export const getDefaultMCPSelection = (
 	return ids;
 };
 
-/** localStorage key for persisting the user's MCP server selection. */
-export const mcpSelectionStorageKey = "agents.selected-mcp-server-ids";
+export const mcpSelectionStorageKey = (organization: string) =>
+	`agents.selected-mcp-server-ids.${organization}`;
 
 /**
  * Read the persisted MCP selection from localStorage, filtered to only
@@ -100,8 +101,9 @@ export const mcpSelectionStorageKey = "agents.selected-mcp-server-ids";
  * Returns `null` when nothing is stored (caller should fall back to defaults).
  */ export const getSavedMCPSelection = (
 	servers: readonly TypesGen.MCPServerConfig[],
+	organization: string,
 ): string[] | null => {
-	const raw = localStorage.getItem(mcpSelectionStorageKey);
+	const raw = localStorage.getItem(mcpSelectionStorageKey(organization));
 	if (raw === null) {
 		return null;
 	}
@@ -143,8 +145,14 @@ export const mcpSelectionStorageKey = "agents.selected-mcp-server-ids";
 
 /**
  * Persist the current MCP selection to localStorage.
- */ export const saveMCPSelection = (ids: readonly string[]): void => {
-	localStorage.setItem(mcpSelectionStorageKey, JSON.stringify(ids));
+ */ export const saveMCPSelection = (
+	ids: readonly string[],
+	organization: string,
+): void => {
+	localStorage.setItem(
+		mcpSelectionStorageKey(organization),
+		JSON.stringify(ids),
+	);
 };
 
 // ── Overlapping icon stack for the trigger ─────────────────────
@@ -254,9 +262,8 @@ export const MCPServerPicker: FC<MCPServerPickerProps> = ({
 
 	const handleConnect = (server: TypesGen.MCPServerConfig) => {
 		setConnectingServerId(server.id);
-		const connectUrl = `/api/experimental/mcp/servers/${encodeURIComponent(server.id)}/oauth2/connect`;
 		popupRef.current = window.open(
-			connectUrl,
+			API.experimental.getMCPServerOAuth2ConnectURL(server.id),
 			"_blank",
 			"width=900,height=600",
 		);

--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -11,6 +11,7 @@ import {
 } from "react-router";
 import { GlobalErrorBoundary } from "./components/ErrorBoundary/GlobalErrorBoundary";
 import { Loader } from "./components/Loader/Loader";
+import { AIResourceOrganizationOutlet } from "./contexts/AIResourceOrganizationContext";
 import { RequireAuth } from "./contexts/auth/RequireAuth";
 import { useAuthenticated } from "./hooks/useAuthenticated";
 import { DashboardLayout } from "./modules/dashboard/DashboardLayout";
@@ -473,18 +474,22 @@ const AISettingsIndexRedirect = () => {
 	const { permissions } = useAuthenticated();
 
 	if (permissions.viewAnyAIProvider) {
-		return <Navigate to="/ai/settings/providers" replace />;
+		return <NavigateWithSearch to="/ai/settings/providers" />;
 	}
 
 	if (permissions.viewAIGatewayKeys) {
 		return <Navigate to="/ai/settings/gateway-keys" replace />;
 	}
 
-	if (permissions.editDeploymentConfig) {
-		return <Navigate to="/ai/settings/models" replace />;
+	if (permissions.viewAnyChatModelConfig || permissions.editDeploymentConfig) {
+		return <NavigateWithSearch to="/ai/settings/models" />;
 	}
 
-	return <Navigate to="/ai/settings/providers" replace />;
+	if (permissions.viewAnyMCPServerConfig) {
+		return <NavigateWithSearch to="/ai/settings/mcp-servers" />;
+	}
+
+	return <NavigateWithSearch to="/ai/settings/providers" />;
 };
 
 const GlobalLayout = () => {
@@ -765,29 +770,92 @@ export const router = createBrowserRouter(
 							element={<AISettingsGatewayKeysPage />}
 						/>
 						<Route index element={<AISettingsIndexRedirect />} />
-						<Route path="models" element={<AISettingsModelsPage />} />
+						<Route
+							element={
+								<AIResourceOrganizationOutlet
+									isOrganizationPermitted={(permissions) =>
+										permissions.viewModels
+									}
+								/>
+							}
+						>
+							<Route path="models" element={<AISettingsModelsPage />} />
+						</Route>
+						<Route
+							element={
+								<AIResourceOrganizationOutlet
+									isOrganizationPermitted={(permissions) =>
+										permissions.createModel
+									}
+								/>
+							}
+						>
+							<Route path="models/add" element={<AISettingsAddModelPage />} />
+						</Route>
+						<Route
+							element={
+								<AIResourceOrganizationOutlet
+									isOrganizationPermitted={(permissions) =>
+										permissions.editModels
+									}
+								/>
+							}
+						>
+							<Route
+								path="models/:modelId"
+								element={<AISettingsUpdateModelPage />}
+							/>
+							<Route path="coder-agents" element={<CoderAgentsPage />} />
+						</Route>
 						<Route path="spend" element={<AISettingsSpendPage />} />
 						<Route
 							path="instructions"
 							element={<AISettingsInstructionsPage />}
 						/>
 						<Route path="lifecycle" element={<AISettingsLifecyclePage />} />
-						<Route path="coder-agents" element={<CoderAgentsPage />} />
 						<Route path="templates" element={<AISettingsTemplatesPage />} />
-						<Route path="models/add" element={<AISettingsAddModelPage />} />
 						<Route
-							path="models/:modelId"
-							element={<AISettingsUpdateModelPage />}
-						/>
-						<Route path="mcp-servers" element={<AISettingsMCPServersPage />} />
+							element={
+								<AIResourceOrganizationOutlet
+									isOrganizationPermitted={(permissions) =>
+										permissions.viewMCPServers
+									}
+								/>
+							}
+						>
+							<Route
+								path="mcp-servers"
+								element={<AISettingsMCPServersPage />}
+							/>
+						</Route>
 						<Route
-							path="mcp-servers/add"
-							element={<AISettingsAddMCPServerPage />}
-						/>
+							element={
+								<AIResourceOrganizationOutlet
+									isOrganizationPermitted={(permissions) =>
+										permissions.createMCPServers
+									}
+								/>
+							}
+						>
+							<Route
+								path="mcp-servers/add"
+								element={<AISettingsAddMCPServerPage />}
+							/>
+						</Route>
 						<Route
-							path="mcp-servers/:serverId"
-							element={<AISettingsUpdateMCPServerPage />}
-						/>
+							element={
+								<AIResourceOrganizationOutlet
+									isOrganizationPermitted={(permissions) =>
+										permissions.editMCPServers
+									}
+								/>
+							}
+						>
+							<Route
+								path="mcp-servers/:serverId"
+								element={<AISettingsUpdateMCPServerPage />}
+							/>
+						</Route>
 						<Route path="providers" element={<AISettingsProvidersPage />} />
 						<Route
 							path="providers/add"
@@ -849,25 +917,46 @@ export const router = createBrowserRouter(
 						</Suspense>
 					}
 				>
-					<Route index element={<AgentCreatePage />} />
+					<Route
+						element={
+							<AIResourceOrganizationOutlet
+								isOrganizationPermitted={(permissions) =>
+									permissions.createChat
+								}
+							/>
+						}
+					>
+						<Route index element={<AgentCreatePage />} />
+					</Route>
 					<Route path="settings" element={<AgentSettingsPage />}>
 						<Route index element={<AgentSettingsGeneralPage />} />
 						<Route path="general" element={<AgentSettingsGeneralPage />} />
 						<Route
-							path="compaction"
-							element={<AgentSettingsCompactionPage />}
-						/>
+							element={
+								<AIResourceOrganizationOutlet
+									isOrganizationPermitted={(permissions) =>
+										permissions.viewModels
+									}
+								/>
+							}
+						>
+							<Route
+								path="compaction"
+								element={<AgentSettingsCompactionPage />}
+							/>
+							<Route
+								path="user-agents"
+								element={<AgentSettingsUserAgentsPage />}
+							/>
+							<Route path="api-keys" element={<AgentSettingsAPIKeysPage />} />
+						</Route>
 						<Route
 							path="instructions"
-							element={<Navigate to="/ai/settings/instructions" replace />}
+							element={<NavigateWithSearch to="/ai/settings/instructions" />}
 						/>
 						<Route
 							path="lifecycle"
-							element={<Navigate to="/ai/settings/lifecycle" replace />}
-						/>
-						<Route
-							path="user-agents"
-							element={<AgentSettingsUserAgentsPage />}
+							element={<NavigateWithSearch to="/ai/settings/lifecycle" />}
 						/>
 						<Route
 							path="personal-skills"
@@ -875,32 +964,31 @@ export const router = createBrowserRouter(
 						/>
 						<Route
 							path="admin"
-							element={<Navigate to="/ai/settings/coder-agents" replace />}
+							element={<NavigateWithSearch to="/ai/settings/coder-agents" />}
 						/>
 						<Route
 							path="agents"
-							element={<Navigate to="/ai/settings/coder-agents" replace />}
+							element={<NavigateWithSearch to="/ai/settings/coder-agents" />}
 						/>
 						<Route
 							path="coder-agents"
-							element={<Navigate to="/ai/settings/coder-agents" replace />}
+							element={<NavigateWithSearch to="/ai/settings/coder-agents" />}
 						/>
 						<Route
 							path="experiments"
-							element={<Navigate to="/ai/settings/coder-agents" replace />}
+							element={<NavigateWithSearch to="/ai/settings/coder-agents" />}
 						/>
-						<Route path="api-keys" element={<AgentSettingsAPIKeysPage />} />
 						<Route
 							path="providers"
-							element={<Navigate to="/ai/settings/providers" replace />}
+							element={<NavigateWithSearch to="/ai/settings/providers" />}
 						/>
 						<Route
 							path="models"
-							element={<Navigate to="/ai/settings/models" replace />}
+							element={<NavigateWithSearch to="/ai/settings/models" />}
 						/>
 						<Route
 							path="mcp-servers"
-							element={<Navigate to="/ai/settings/mcp-servers" replace />}
+							element={<NavigateWithSearch to="/ai/settings/mcp-servers" />}
 						/>
 						<Route
 							path="spend"
@@ -916,7 +1004,7 @@ export const router = createBrowserRouter(
 						/>
 						<Route
 							path="templates"
-							element={<Navigate to="/ai/settings/templates" replace />}
+							element={<NavigateWithSearch to="/ai/settings/templates" />}
 						/>
 					</Route>
 					<Route path="analytics" element={<AgentAnalyticsPage />} />

--- a/site/src/testHelpers/chatEntities.ts
+++ b/site/src/testHelpers/chatEntities.ts
@@ -91,6 +91,7 @@ export const MockChatContextDirty: ChatContext = {
 
 export const MockMCPServerConfig: MCPServerConfig = {
 	id: "mcp-1",
+	organization_id: "test-org-id",
 	display_name: "MCP Server",
 	slug: "mcp-server",
 	description: "",

--- a/site/src/testHelpers/chatModels.ts
+++ b/site/src/testHelpers/chatModels.ts
@@ -7,6 +7,7 @@ import { MOCK_TIMESTAMP } from "./chatEntities";
 
 export const MockChatModelConfig: ChatModelConfig = {
 	id: "model-1",
+	organization_id: "test-org-id",
 	ai_provider_id: "provider-1",
 	model: "gpt-5",
 	display_name: "gpt-5",


### PR DESCRIPTION
This review-only slice hard-cuts the existing frontend onto explicit organization ownership for model and MCP resources. It updates the API and query contracts, shared URL-owned organization selection, action-specific permissions, and existing management, chat, OAuth, sidebar, and model-bearing settings callers without adding sharing UI or compatibility paths.

Depends on #27384. This slice must not merge separately. The complete coordinated stack will be rebuilt and validated in an aggregate validation PR before merge. The next planned slice is the model and MCP sharing UI.

<details>
<summary>Coordinated stack direction</summary>

The stack establishes organization-owned model and MCP contracts and runtime first, applies the frontend hard cut in this PR, then adds model and MCP sharing UI. The aggregate validation PR will rebuild the full dependency chain and run end-to-end validation against the combined result.

</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
