### PR TITLE
feat(site): add AI resource sharing

### DIFF
--- a/site/src/pages/AISettingsPage/MCPServersPage/MCPServerSharingPage/MCPServerSharingPage.stories.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/MCPServerSharingPage/MCPServerSharingPage.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, spyOn, within } from "storybook/test";
+import { reactRouterParameters } from "storybook-addon-remix-react-router";
+import { API } from "#/api/api";
+import type { MCPServerConfigACL } from "#/api/typesGenerated";
+import { MockDefaultOrganization, MockGroup } from "#/testHelpers/entities";
+import { withDashboardProvider } from "#/testHelpers/storybook";
+import { MockCoderMCPServer } from "../testFixtures";
+import MCPServerSharingPage from "./MCPServerSharingPage";
+
+const server = {
+	...MockCoderMCPServer,
+	organization_id: MockDefaultOrganization.id,
+};
+const acl: MCPServerConfigACL = {
+	users: [],
+	groups: [{ ...MockGroup, role: "read" }],
+};
+
+const meta: Meta<typeof MCPServerSharingPage> = {
+	title: "pages/AISettingsPage/MCPServersPage/MCPServerSharingPage",
+	component: MCPServerSharingPage,
+	decorators: [withDashboardProvider],
+	parameters: {
+		features: ["template_rbac"],
+		reactRouter: reactRouterParameters({
+			location: {
+				path: `/ai/settings/mcp-servers/${server.id}/sharing`,
+				searchParams: { organization: MockDefaultOrganization.name },
+			},
+			routing: [
+				{
+					path: "/ai/settings/mcp-servers/:serverId/sharing",
+					useStoryElement: true,
+				},
+			],
+		}),
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof MCPServerSharingPage>;
+
+export const Default: Story = {
+	beforeEach: () => {
+		spyOn(API.experimental, "getMCPServerConfig").mockResolvedValue(server);
+		spyOn(API.experimental, "getMCPServerConfigACL").mockResolvedValue(acl);
+		spyOn(API.experimental, "updateMCPServerConfigACL").mockResolvedValue();
+		spyOn(API, "checkAuthorization").mockResolvedValue({
+			canEdit: true,
+			canShare: true,
+		});
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.findByText(`Share ${server.display_name}`),
+		).resolves.toBeVisible();
+		await expect(
+			canvas.findByText(MockGroup.display_name),
+		).resolves.toBeVisible();
+		expect(API.experimental.getMCPServerConfig).toHaveBeenCalledWith(server.id);
+		expect(API.experimental.getMCPServerConfigACL).toHaveBeenCalledWith(
+			server.id,
+		);
+	},
+};

--- a/site/src/pages/AISettingsPage/MCPServersPage/MCPServerSharingPage/MCPServerSharingPage.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/MCPServerSharingPage/MCPServerSharingPage.tsx
@@ -1,0 +1,164 @@
+import { type FC, useEffect } from "react";
+import { useMutation, useQuery, useQueryClient } from "react-query";
+import { useLocation, useParams, useSearchParams } from "react-router";
+import { toast } from "sonner";
+import { checkAuthorization } from "#/api/queries/authCheck";
+import {
+	mcpServerConfig,
+	mcpServerConfigACL,
+	updateMCPServerConfigACL,
+} from "#/api/queries/chats";
+import { ErrorAlert } from "#/components/Alert/ErrorAlert";
+import { Loader } from "#/components/Loader/Loader";
+import { PaywallPremium } from "#/components/Paywall/PaywallPremium";
+import { useDashboard } from "#/modules/dashboard/useDashboard";
+import { useFeatureVisibility } from "#/modules/dashboard/useFeatureVisibility";
+import { ResourceSharingPageView } from "#/pages/AISettingsPage/components/ResourceSharingPage/ResourceSharingPageView";
+import { docs } from "#/utils/docs";
+import { pageTitle } from "#/utils/page";
+
+const MCPServerSharingPage: FC = () => {
+	const { serverId } = useParams<{ serverId: string }>();
+	const location = useLocation();
+	const [searchParams, setSearchParams] = useSearchParams();
+	const queryClient = useQueryClient();
+	const { organizations } = useDashboard();
+	const { template_rbac: isTemplateRBACEnabled } = useFeatureVisibility();
+	const serverQuery = useQuery({
+		...mcpServerConfig(serverId ?? ""),
+		enabled: Boolean(serverId),
+	});
+	const server = serverQuery.data;
+	const organization = organizations.find(
+		(candidate) => candidate.id === server?.organization_id,
+	);
+
+	useEffect(() => {
+		if (
+			!organization ||
+			searchParams.get("organization") === organization.name
+		) {
+			return;
+		}
+		setSearchParams(
+			(current) => {
+				const next = new URLSearchParams(current);
+				next.set("organization", organization.name);
+				return next;
+			},
+			{ replace: true },
+		);
+	}, [organization, searchParams, setSearchParams]);
+
+	const permissionQuery = useQuery({
+		...checkAuthorization({
+			checks: {
+				canEdit: {
+					object: {
+						resource_type: "mcp_server_config",
+						resource_id: server?.id,
+						organization_id: server?.organization_id,
+					},
+					action: "update",
+				},
+				canShare: {
+					object: {
+						resource_type: "mcp_server_config",
+						resource_id: server?.id,
+						organization_id: server?.organization_id,
+					},
+					action: "share",
+				},
+			},
+		}),
+		enabled: Boolean(server && isTemplateRBACEnabled),
+	});
+	const aclQuery = useQuery({
+		...mcpServerConfigACL(serverId ?? ""),
+		enabled: Boolean(serverId && server && isTemplateRBACEnabled),
+	});
+	const updateMutation = useMutation(updateMCPServerConfigACL(queryClient));
+
+	if (!serverId) {
+		return <ErrorAlert error={new Error("MCP server ID is required.")} />;
+	}
+	if (serverQuery.isLoading) {
+		return <Loader />;
+	}
+	if (serverQuery.error) {
+		return <ErrorAlert error={serverQuery.error} />;
+	}
+	if (!server) {
+		return <ErrorAlert error={new Error("MCP server not found.")} />;
+	}
+	if (!organization) {
+		return (
+			<ErrorAlert error={new Error("MCP server organization not found.")} />
+		);
+	}
+
+	return (
+		<>
+			<title>{pageTitle(`Share ${server.display_name}`, "AI Settings")}</title>
+			{!isTemplateRBACEnabled ? (
+				<PaywallPremium
+					message="MCP server sharing"
+					description="Control user and group access to MCP servers. You need a Premium license to use this feature."
+					documentationLink={docs("/admin/templates/template-permissions")}
+				/>
+			) : (
+				<ResourceSharingPageView
+					resourceName={server.display_name}
+					resourceTypeLabel="MCP server"
+					backPath={
+						permissionQuery.data?.canEdit
+							? `/ai/settings/mcp-servers/${server.id}`
+							: "/ai/settings/mcp-servers"
+					}
+					search={location.search}
+					organizationId={server.organization_id}
+					acl={aclQuery.data}
+					isLoading={aclQuery.isLoading || permissionQuery.isLoading}
+					error={aclQuery.error ?? permissionQuery.error}
+					mutationError={updateMutation.error}
+					canShare={Boolean(permissionQuery.data?.canShare)}
+					isMutating={updateMutation.isPending}
+					onAddUser={async (userId) => {
+						await updateMutation.mutateAsync({
+							organization: organization.name,
+							serverId: server.id,
+							req: { user_roles: { [userId]: "read" } },
+						});
+						toast.success("User granted MCP server access.");
+					}}
+					onAddGroup={async (groupId) => {
+						await updateMutation.mutateAsync({
+							organization: organization.name,
+							serverId: server.id,
+							req: { group_roles: { [groupId]: "read" } },
+						});
+						toast.success("Group granted MCP server access.");
+					}}
+					onRemoveUser={async (userId) => {
+						await updateMutation.mutateAsync({
+							organization: organization.name,
+							serverId: server.id,
+							req: { user_roles: { [userId]: "" } },
+						});
+						toast.success("User MCP server access removed.");
+					}}
+					onRemoveGroup={async (groupId) => {
+						await updateMutation.mutateAsync({
+							organization: organization.name,
+							serverId: server.id,
+							req: { group_roles: { [groupId]: "" } },
+						});
+						toast.success("Group MCP server access removed.");
+					}}
+				/>
+			)}
+		</>
+	);
+};
+
+export default MCPServerSharingPage;

--- a/site/src/pages/AISettingsPage/MCPServersPage/MCPServersPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/MCPServersPageView.stories.tsx
@@ -31,6 +31,10 @@ const meta: Meta<typeof MCPServersPageView> = {
 				{ path: "/ai/settings/mcp-servers", useStoryElement: true },
 				{ path: "/ai/settings/mcp-servers/add", useStoryElement: true },
 				{ path: "/ai/settings/mcp-servers/:serverId", useStoryElement: true },
+				{
+					path: "/ai/settings/mcp-servers/:serverId/sharing",
+					useStoryElement: true,
+				},
 			],
 		}),
 	},
@@ -65,7 +69,7 @@ export const ReadOnly: Story = {
 			canvas.queryByRole("button", { name: /add server/i }),
 		).not.toBeInTheDocument();
 		await expect(canvas.getByText("Coder")).toBeInTheDocument();
-		await expect(canvas.getByText("Coder").closest("tr")).not.toHaveAttribute(
+		await expect(canvas.getByText("Coder").closest("tr")).toHaveAttribute(
 			"role",
 			"button",
 		);
@@ -82,7 +86,7 @@ export const CreateOnlyControls: Story = {
 		await expect(
 			canvas.getByRole("button", { name: /add server/i }),
 		).toBeVisible();
-		await expect(canvas.getByText("Coder").closest("tr")).not.toHaveAttribute(
+		await expect(canvas.getByText("Coder").closest("tr")).toHaveAttribute(
 			"role",
 			"button",
 		);

--- a/site/src/pages/AISettingsPage/MCPServersPage/MCPServersPageView.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/MCPServersPageView.tsx
@@ -99,14 +99,13 @@ const MCPServersPageView: FC<MCPServersPageViewProps> = ({
 							<MCPServerRow
 								key={server.id}
 								server={server}
-								onClick={
-									canEditMCPServers
-										? () =>
-												void navigate({
-													pathname: `/ai/settings/mcp-servers/${server.id}`,
-													search: location.search,
-												})
-										: undefined
+								onClick={() =>
+									void navigate({
+										pathname: canEditMCPServers
+											? `/ai/settings/mcp-servers/${server.id}`
+											: `/ai/settings/mcp-servers/${server.id}/sharing`,
+										search: location.search,
+									})
 								}
 							/>
 						))

--- a/site/src/pages/AISettingsPage/MCPServersPage/UpdateMCPServerPage/UpdateMCPServerPage.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/UpdateMCPServerPage/UpdateMCPServerPage.tsx
@@ -56,6 +56,7 @@ const UpdateMCPServerPage: FC = () => {
 					server={server}
 					isSaving={updateMutation.isPending}
 					isDeleting={deleteMutation.isPending}
+					sharingPath={`/ai/settings/mcp-servers/${server.id}/sharing`}
 					onCancel={() =>
 						void navigate({
 							pathname: "/ai/settings/mcp-servers",

--- a/site/src/pages/AISettingsPage/MCPServersPage/UpdateMCPServerPage/UpdateMCPServerPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/UpdateMCPServerPage/UpdateMCPServerPageView.stories.tsx
@@ -22,6 +22,7 @@ const meta: Meta<typeof UpdateMCPServerPageView> = {
 		onUpdateServer,
 		onDeleteServer: fn(async () => undefined),
 		onToggleEnabled: fn(),
+		sharingPath: `/ai/settings/mcp-servers/${MockCoderMCPServer.id}/sharing`,
 		onCancel: fn(),
 	},
 	parameters: {
@@ -61,5 +62,22 @@ export const Default: Story = {
 			);
 		});
 		expect(onUpdateServer.mock.calls[0]?.[1]).not.toHaveProperty("enabled");
+	},
+};
+
+export const SharingEntryPoint: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Server actions" }),
+		);
+		await expect(
+			within(canvasElement.ownerDocument.body).findByRole("menuitem", {
+				name: "Share server",
+			}),
+		).resolves.toHaveAttribute(
+			"href",
+			"/ai/settings/mcp-servers/mcp-coder/sharing",
+		);
 	},
 };

--- a/site/src/pages/AISettingsPage/MCPServersPage/UpdateMCPServerPage/UpdateMCPServerPageView.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/UpdateMCPServerPage/UpdateMCPServerPageView.tsx
@@ -13,6 +13,7 @@ interface UpdateMCPServerPageViewProps {
 	) => Promise<unknown>;
 	onDeleteServer?: (serverId: string) => Promise<void>;
 	onToggleEnabled: (enabled: boolean) => void;
+	sharingPath: string;
 	onCancel: () => void;
 }
 
@@ -23,6 +24,7 @@ const UpdateMCPServerPageView: FC<UpdateMCPServerPageViewProps> = ({
 	onUpdateServer,
 	onDeleteServer,
 	onToggleEnabled,
+	sharingPath,
 	onCancel,
 }) => {
 	return (
@@ -36,6 +38,7 @@ const UpdateMCPServerPageView: FC<UpdateMCPServerPageViewProps> = ({
 				onUpdateServer={onUpdateServer}
 				onDeleteServer={onDeleteServer}
 				onToggleEnabled={onToggleEnabled}
+				sharingPath={sharingPath}
 				onCancel={onCancel}
 			/>
 		</>

--- a/site/src/pages/AISettingsPage/MCPServersPage/components/MCPServerForm.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/components/MCPServerForm.tsx
@@ -23,6 +23,7 @@ type MCPServerFormCreateProps = {
 	onUpdateServer?: undefined;
 	onDeleteServer?: undefined;
 	onToggleEnabled?: undefined;
+	sharingPath?: undefined;
 	onCancel: () => void;
 };
 
@@ -37,6 +38,7 @@ type MCPServerFormEditProps = {
 	) => Promise<unknown>;
 	onDeleteServer?: (serverId: string) => Promise<void>;
 	onToggleEnabled?: (enabled: boolean) => void;
+	sharingPath?: string;
 	onCancel: () => void;
 };
 
@@ -50,6 +52,7 @@ export const MCPServerForm: FC<MCPServerFormProps> = ({
 	onUpdateServer,
 	onDeleteServer,
 	onToggleEnabled,
+	sharingPath,
 	onCancel,
 }) => {
 	const isEditing = server !== undefined;
@@ -93,6 +96,7 @@ export const MCPServerForm: FC<MCPServerFormProps> = ({
 				isDisabled={isDisabled}
 				onRequestDelete={() => setConfirmingDelete(true)}
 				onToggleEnabled={onToggleEnabled}
+				sharingPath={sharingPath}
 			/>
 			<div className="flex flex-col gap-6 pt-6">
 				<MCPServerFormFields

--- a/site/src/pages/AISettingsPage/MCPServersPage/components/MCPServerFormHeader.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/components/MCPServerFormHeader.tsx
@@ -1,4 +1,9 @@
-import { ArrowLeftIcon, EllipsisVerticalIcon, TrashIcon } from "lucide-react";
+import {
+	ArrowLeftIcon,
+	EllipsisVerticalIcon,
+	Share2Icon,
+	TrashIcon,
+} from "lucide-react";
 import type { FC } from "react";
 import { Link, useLocation } from "react-router";
 import type * as TypesGen from "#/api/typesGenerated";
@@ -44,6 +49,7 @@ interface MCPServerFormHeaderProps {
 	isDisabled: boolean;
 	onRequestDelete: () => void;
 	onToggleEnabled?: (enabled: boolean) => void;
+	sharingPath?: string;
 }
 
 export const MCPServerFormHeader: FC<MCPServerFormHeaderProps> = ({
@@ -54,7 +60,9 @@ export const MCPServerFormHeader: FC<MCPServerFormHeaderProps> = ({
 	isDisabled,
 	onRequestDelete,
 	onToggleEnabled,
+	sharingPath,
 }) => {
+	const location = useLocation();
 	return (
 		<>
 			<div className="flex items-center justify-between">
@@ -73,6 +81,14 @@ export const MCPServerFormHeader: FC<MCPServerFormHeaderProps> = ({
 							</Button>
 						</DropdownMenuTrigger>
 						<DropdownMenuContent align="end">
+							{sharingPath && (
+								<DropdownMenuItem asChild>
+									<Link to={{ pathname: sharingPath, search: location.search }}>
+										<Share2Icon />
+										Share server
+									</Link>
+								</DropdownMenuItem>
+							)}
 							<DropdownMenuItem
 								className="text-content-destructive focus:text-content-destructive"
 								onClick={onRequestDelete}

--- a/site/src/pages/AISettingsPage/ModelsPage/ModelSharingPage/ModelSharingPage.stories.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/ModelSharingPage/ModelSharingPage.stories.tsx
@@ -1,0 +1,117 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, spyOn, waitFor, within } from "storybook/test";
+import { reactRouterParameters } from "storybook-addon-remix-react-router";
+import { API } from "#/api/api";
+import type { ChatModelConfigACL } from "#/api/typesGenerated";
+import {
+	MockDefaultOrganization,
+	MockGroup,
+	MockUserMember,
+} from "#/testHelpers/entities";
+import { withDashboardProvider } from "#/testHelpers/storybook";
+import { mockGPT5 } from "../testFixtures";
+import ModelSharingPage from "./ModelSharingPage";
+
+const model = {
+	...mockGPT5,
+	organization_id: MockDefaultOrganization.id,
+};
+const acl: ChatModelConfigACL = {
+	users: [
+		{
+			id: MockUserMember.id,
+			username: MockUserMember.username,
+			name: MockUserMember.name,
+			avatar_url: MockUserMember.avatar_url,
+			role: "read",
+		},
+	],
+	groups: [{ ...MockGroup, role: "read" }],
+};
+
+const mockRequests = ({ canEdit = true, canShare = true } = {}) => {
+	spyOn(API.experimental, "getChatModelConfig").mockResolvedValue(model);
+	spyOn(API.experimental, "getChatModelConfigACL").mockResolvedValue(acl);
+	spyOn(API.experimental, "updateChatModelConfigACL").mockResolvedValue();
+	spyOn(API, "checkAuthorization").mockResolvedValue({ canEdit, canShare });
+};
+
+const meta: Meta<typeof ModelSharingPage> = {
+	title: "pages/AISettingsPage/ModelsPage/ModelSharingPage",
+	component: ModelSharingPage,
+	decorators: [withDashboardProvider],
+	parameters: {
+		features: ["template_rbac"],
+		reactRouter: reactRouterParameters({
+			location: {
+				path: `/ai/settings/models/${model.id}/sharing`,
+				searchParams: { organization: "wrong-organization" },
+			},
+			routing: [
+				{ path: "/ai/settings/models/:modelId/sharing", useStoryElement: true },
+			],
+		}),
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof ModelSharingPage>;
+
+export const Default: Story = {
+	beforeEach: () => mockRequests(),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.findByText(`Share ${model.display_name}`),
+		).resolves.toBeVisible();
+		await expect(
+			canvas.findByText(MockUserMember.username),
+		).resolves.toBeVisible();
+		await waitFor(() => {
+			expect(
+				canvas.getByRole("link", { name: "Back to model" }),
+			).toHaveAttribute(
+				"href",
+				`/ai/settings/models/${model.id}?organization=${MockDefaultOrganization.name}`,
+			);
+		});
+		expect(API.experimental.getChatModelConfig).toHaveBeenCalledWith(model.id);
+		expect(API.experimental.getChatModelConfigACL).toHaveBeenCalledWith(
+			model.id,
+		);
+	},
+};
+
+export const NoSharePermission: Story = {
+	beforeEach: () => mockRequests({ canEdit: false, canShare: false }),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.findByText(/you do not have permission to change them/i),
+		).resolves.toBeVisible();
+		await expect(
+			canvas.findByRole("link", { name: "Back to model" }),
+		).resolves.toHaveAttribute(
+			"href",
+			`/ai/settings/models?organization=${MockDefaultOrganization.name}`,
+		);
+	},
+};
+
+export const EntitlementPaywall: Story = {
+	parameters: { features: [] },
+	beforeEach: () => {
+		spyOn(API.experimental, "getChatModelConfig").mockResolvedValue(model);
+		spyOn(API.experimental, "getChatModelConfigACL").mockResolvedValue(acl);
+		spyOn(API, "checkAuthorization").mockResolvedValue({
+			canEdit: true,
+			canShare: true,
+		});
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.findByText("Model sharing")).resolves.toBeVisible();
+		expect(API.experimental.getChatModelConfigACL).not.toHaveBeenCalled();
+		expect(API.checkAuthorization).not.toHaveBeenCalled();
+	},
+};

--- a/site/src/pages/AISettingsPage/ModelsPage/ModelSharingPage/ModelSharingPage.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/ModelSharingPage/ModelSharingPage.tsx
@@ -1,0 +1,163 @@
+import { type FC, useEffect } from "react";
+import { useMutation, useQuery, useQueryClient } from "react-query";
+import { useLocation, useParams, useSearchParams } from "react-router";
+import { toast } from "sonner";
+import { checkAuthorization } from "#/api/queries/authCheck";
+import {
+	chatModelConfig,
+	chatModelConfigACL,
+	updateChatModelConfigACL,
+} from "#/api/queries/chats";
+import { ErrorAlert } from "#/components/Alert/ErrorAlert";
+import { Loader } from "#/components/Loader/Loader";
+import { PaywallPremium } from "#/components/Paywall/PaywallPremium";
+import { useDashboard } from "#/modules/dashboard/useDashboard";
+import { useFeatureVisibility } from "#/modules/dashboard/useFeatureVisibility";
+import { ResourceSharingPageView } from "#/pages/AISettingsPage/components/ResourceSharingPage/ResourceSharingPageView";
+import { docs } from "#/utils/docs";
+import { pageTitle } from "#/utils/page";
+
+const ModelSharingPage: FC = () => {
+	const { modelId } = useParams<{ modelId: string }>();
+	const location = useLocation();
+	const [searchParams, setSearchParams] = useSearchParams();
+	const queryClient = useQueryClient();
+	const { organizations } = useDashboard();
+	const { template_rbac: isTemplateRBACEnabled } = useFeatureVisibility();
+	const modelQuery = useQuery({
+		...chatModelConfig(modelId ?? ""),
+		enabled: Boolean(modelId),
+	});
+	const model = modelQuery.data;
+	const organization = organizations.find(
+		(candidate) => candidate.id === model?.organization_id,
+	);
+
+	useEffect(() => {
+		if (
+			!organization ||
+			searchParams.get("organization") === organization.name
+		) {
+			return;
+		}
+		setSearchParams(
+			(current) => {
+				const next = new URLSearchParams(current);
+				next.set("organization", organization.name);
+				return next;
+			},
+			{ replace: true },
+		);
+	}, [organization, searchParams, setSearchParams]);
+
+	const permissionQuery = useQuery({
+		...checkAuthorization({
+			checks: {
+				canEdit: {
+					object: {
+						resource_type: "chat_model_config",
+						resource_id: model?.id,
+						organization_id: model?.organization_id,
+					},
+					action: "update",
+				},
+				canShare: {
+					object: {
+						resource_type: "chat_model_config",
+						resource_id: model?.id,
+						organization_id: model?.organization_id,
+					},
+					action: "share",
+				},
+			},
+		}),
+		enabled: Boolean(model && isTemplateRBACEnabled),
+	});
+	const aclQuery = useQuery({
+		...chatModelConfigACL(modelId ?? ""),
+		enabled: Boolean(modelId && model && isTemplateRBACEnabled),
+	});
+	const updateMutation = useMutation(updateChatModelConfigACL(queryClient));
+
+	if (!modelId) {
+		return <ErrorAlert error={new Error("Model ID is required.")} />;
+	}
+	if (modelQuery.isLoading) {
+		return <Loader />;
+	}
+	if (modelQuery.error) {
+		return <ErrorAlert error={modelQuery.error} />;
+	}
+	if (!model) {
+		return <ErrorAlert error={new Error("Model not found.")} />;
+	}
+	if (!organization) {
+		return <ErrorAlert error={new Error("Model organization not found.")} />;
+	}
+
+	const name = model.display_name || model.model;
+	return (
+		<>
+			<title>{pageTitle(`Share ${name}`, "AI Settings")}</title>
+			{!isTemplateRBACEnabled ? (
+				<PaywallPremium
+					message="Model sharing"
+					description="Control user and group access to models. You need a Premium license to use this feature."
+					documentationLink={docs("/admin/templates/template-permissions")}
+				/>
+			) : (
+				<ResourceSharingPageView
+					resourceName={name}
+					resourceTypeLabel="model"
+					backPath={
+						permissionQuery.data?.canEdit
+							? `/ai/settings/models/${model.id}`
+							: "/ai/settings/models"
+					}
+					search={location.search}
+					organizationId={model.organization_id}
+					acl={aclQuery.data}
+					isLoading={aclQuery.isLoading || permissionQuery.isLoading}
+					error={aclQuery.error ?? permissionQuery.error}
+					mutationError={updateMutation.error}
+					canShare={Boolean(permissionQuery.data?.canShare)}
+					isMutating={updateMutation.isPending}
+					onAddUser={async (userId) => {
+						await updateMutation.mutateAsync({
+							organization: organization.name,
+							modelConfigId: model.id,
+							req: { user_roles: { [userId]: "read" } },
+						});
+						toast.success("User granted model access.");
+					}}
+					onAddGroup={async (groupId) => {
+						await updateMutation.mutateAsync({
+							organization: organization.name,
+							modelConfigId: model.id,
+							req: { group_roles: { [groupId]: "read" } },
+						});
+						toast.success("Group granted model access.");
+					}}
+					onRemoveUser={async (userId) => {
+						await updateMutation.mutateAsync({
+							organization: organization.name,
+							modelConfigId: model.id,
+							req: { user_roles: { [userId]: "" } },
+						});
+						toast.success("User model access removed.");
+					}}
+					onRemoveGroup={async (groupId) => {
+						await updateMutation.mutateAsync({
+							organization: organization.name,
+							modelConfigId: model.id,
+							req: { group_roles: { [groupId]: "" } },
+						});
+						toast.success("Group model access removed.");
+					}}
+				/>
+			)}
+		</>
+	);
+};
+
+export default ModelSharingPage;

--- a/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.stories.tsx
@@ -42,6 +42,10 @@ const meta: Meta<typeof ModelsPageView> = {
 				{ path: "/ai/settings/models", useStoryElement: true },
 				{ path: "/ai/settings/models/add", useStoryElement: true },
 				{ path: "/ai/settings/models/:modelId", useStoryElement: true },
+				{
+					path: "/ai/settings/models/:modelId/sharing",
+					useStoryElement: true,
+				},
 			],
 		}),
 	},
@@ -144,9 +148,10 @@ export const ReadOnly: Story = {
 			canvas.queryByRole("button", { name: /add model/i }),
 		).not.toBeInTheDocument();
 		await expect(canvas.getByText("GPT-5")).toBeInTheDocument();
-		await expect(
-			canvas.queryByRole("button", { name: /GPT-5/i }),
-		).not.toBeInTheDocument();
+		await expect(canvas.getByText("GPT-5").closest("tr")).toHaveAttribute(
+			"role",
+			"button",
+		);
 	},
 };
 
@@ -160,9 +165,10 @@ export const CreateOnlyControls: Story = {
 		await expect(
 			canvas.getByRole("button", { name: /add model/i }),
 		).toBeVisible();
-		await expect(
-			canvas.queryByRole("button", { name: /GPT-5/i }),
-		).not.toBeInTheDocument();
+		await expect(canvas.getByText("GPT-5").closest("tr")).toHaveAttribute(
+			"role",
+			"button",
+		);
 	},
 };
 

--- a/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.tsx
@@ -280,14 +280,13 @@ const ModelsPageView: FC<ModelsPageViewProps> = ({
 								model={model}
 								providerLabel={providerLabelByModelId.get(model.id) ?? ""}
 								providerTypeByID={providerTypeByID}
-								onClick={
-									canEditModels
-										? () =>
-												void navigate({
-													pathname: `/ai/settings/models/${model.id}`,
-													search: location.search,
-												})
-										: undefined
+								onClick={() =>
+									void navigate({
+										pathname: canEditModels
+											? `/ai/settings/models/${model.id}`
+											: `/ai/settings/models/${model.id}/sharing`,
+										search: location.search,
+									})
 								}
 							/>
 						))

--- a/site/src/pages/AISettingsPage/ModelsPage/UpdateModelPage/UpdateModelPage.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/UpdateModelPage/UpdateModelPage.tsx
@@ -142,6 +142,7 @@ const UpdateModelPage: FC = () => {
 								}
 							: undefined
 					}
+					sharingPath={`/ai/settings/models/${model.id}/sharing`}
 					onDuplicate={() => {
 						if (!selectedProviderState) return;
 						const params = new URLSearchParams(location.search);

--- a/site/src/pages/AISettingsPage/ModelsPage/UpdateModelPage/UpdateModelPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/UpdateModelPage/UpdateModelPageView.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, within } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
 import { withToaster } from "#/testHelpers/storybook";
 import {
 	MockAnthropicProviderState,
@@ -22,6 +22,7 @@ const meta: Meta<typeof UpdateModelPageView> = {
 		onUpdateModel: fn(async () => undefined),
 		onDeleteModel: fn(async () => undefined),
 		onDuplicate: fn(),
+		sharingPath: `/ai/settings/models/${mockGPT5.id}/sharing`,
 		onToggleEnabled: fn(),
 	},
 };
@@ -36,5 +37,16 @@ export const Default: Story = {
 			canvas.getByRole("button", { name: /^update model$/i }),
 		).toBeVisible();
 		await expect(canvas.getByLabelText(/model identifier/i)).toBeEnabled();
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Model actions" }),
+		);
+		await expect(
+			within(canvasElement.ownerDocument.body).findByRole("menuitem", {
+				name: "Share model",
+			}),
+		).resolves.toHaveAttribute(
+			"href",
+			"/ai/settings/models/model-gpt5/sharing",
+		);
 	},
 };

--- a/site/src/pages/AISettingsPage/ModelsPage/UpdateModelPage/UpdateModelPageView.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/UpdateModelPage/UpdateModelPageView.tsx
@@ -18,6 +18,7 @@ interface UpdateModelPageViewProps {
 	) => Promise<unknown>;
 	onDeleteModel?: (modelConfigId: string) => Promise<void>;
 	onDuplicate: () => void;
+	sharingPath: string;
 	onToggleEnabled: (enabled: boolean) => void;
 }
 
@@ -32,6 +33,7 @@ const UpdateModelPageView: FC<UpdateModelPageViewProps> = ({
 	onUpdateModel,
 	onDeleteModel,
 	onDuplicate,
+	sharingPath,
 	onToggleEnabled,
 }) => {
 	return (
@@ -52,6 +54,7 @@ const UpdateModelPageView: FC<UpdateModelPageViewProps> = ({
 				onUpdateModel={onUpdateModel}
 				onDeleteModel={onDeleteModel}
 				onDuplicate={onDuplicate}
+				sharingPath={sharingPath}
 				onToggleEnabled={onToggleEnabled}
 			/>
 		</>

--- a/site/src/pages/AISettingsPage/ModelsPage/components/ModelForm.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ModelForm.tsx
@@ -62,6 +62,7 @@ interface ModelFormProps {
 	currentDefaultModel?: TypesGen.ChatModelConfig;
 	onSetDefault?: () => void;
 	onDuplicate?: () => void;
+	sharingPath?: string;
 	onToggleEnabled?: (enabled: boolean) => void;
 }
 
@@ -77,6 +78,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 	onUpdateModel,
 	onDeleteModel,
 	onDuplicate,
+	sharingPath,
 	currentDefaultModel,
 	onToggleEnabled,
 }) => {
@@ -298,6 +300,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 				editingModel={editingModel}
 				onDeleteModel={onDeleteModel}
 				onDuplicate={onDuplicate}
+				sharingPath={sharingPath}
 				onToggleEnabled={onToggleEnabled}
 				isSaving={isSaving}
 				enabledToggleDisabled={enabledToggleDisabled}

--- a/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormHeader.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormHeader.tsx
@@ -2,6 +2,7 @@ import {
 	ArrowLeftIcon,
 	CopyIcon,
 	EllipsisVerticalIcon,
+	Share2Icon,
 	TrashIcon,
 } from "lucide-react";
 import type { FC } from "react";
@@ -51,6 +52,7 @@ export const ModelFormHeader: FC<{
 	editingModel?: TypesGen.ChatModelConfig;
 	onDeleteModel?: (modelConfigId: string) => Promise<void>;
 	onDuplicate?: () => void;
+	sharingPath?: string;
 	onToggleEnabled?: (enabled: boolean) => void;
 	isSaving: boolean;
 	enabledToggleDisabled: boolean;
@@ -62,46 +64,65 @@ export const ModelFormHeader: FC<{
 	editingModel,
 	onDeleteModel,
 	onDuplicate,
+	sharingPath,
 	onToggleEnabled,
 	isSaving,
 	enabledToggleDisabled,
 	onRequestDelete,
 }) => {
+	const location = useLocation();
+
 	return (
 		<>
 			<div className="flex items-center justify-between">
 				<ModelFormBackLink />
-				{isEditing && editingModel && onDeleteModel && (
-					<DropdownMenu>
-						<DropdownMenuTrigger asChild>
-							<Button
-								variant="subtle"
-								size="icon"
-								type="button"
-								disabled={isSaving}
-								aria-label="Model actions"
-							>
-								<EllipsisVerticalIcon />
-							</Button>
-						</DropdownMenuTrigger>
-						<DropdownMenuContent align="end">
-							{onDuplicate && (
-								<DropdownMenuItem onClick={onDuplicate}>
-									<CopyIcon className="size-icon-sm" />
-									Duplicate model
-								</DropdownMenuItem>
-							)}
-							<DropdownMenuSeparator />
-							<DropdownMenuItem
-								className="text-content-destructive focus:text-content-destructive"
-								onClick={onRequestDelete}
-							>
-								<TrashIcon />
-								Delete…
-							</DropdownMenuItem>
-						</DropdownMenuContent>
-					</DropdownMenu>
-				)}
+				{isEditing &&
+					editingModel &&
+					(sharingPath || onDuplicate || onDeleteModel) && (
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<Button
+									variant="subtle"
+									size="icon"
+									type="button"
+									disabled={isSaving}
+									aria-label="Model actions"
+								>
+									<EllipsisVerticalIcon />
+								</Button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent align="end">
+								{sharingPath && (
+									<DropdownMenuItem asChild>
+										<Link
+											to={{ pathname: sharingPath, search: location.search }}
+										>
+											<Share2Icon className="size-icon-sm" />
+											Share model
+										</Link>
+									</DropdownMenuItem>
+								)}
+								{onDuplicate && (
+									<DropdownMenuItem onClick={onDuplicate}>
+										<CopyIcon className="size-icon-sm" />
+										Duplicate model
+									</DropdownMenuItem>
+								)}
+								{onDeleteModel && (
+									<>
+										<DropdownMenuSeparator />
+										<DropdownMenuItem
+											className="text-content-destructive focus:text-content-destructive"
+											onClick={onRequestDelete}
+										>
+											<TrashIcon />
+											Delete…
+										</DropdownMenuItem>
+									</>
+								)}
+							</DropdownMenuContent>
+						</DropdownMenu>
+					)}
 			</div>
 			<div className="flex items-center justify-between gap-4">
 				<div className="flex items-center gap-4 min-w-0">

--- a/site/src/pages/AISettingsPage/components/ResourceSharingPage/ResourceSharingPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/components/ResourceSharingPage/ResourceSharingPageView.stories.tsx
@@ -1,0 +1,246 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { expect, fn, spyOn, userEvent, waitFor, within } from "storybook/test";
+import { API } from "#/api/api";
+import type { ChatModelConfigACL } from "#/api/typesGenerated";
+import {
+	MockDefaultOrganization,
+	MockGroup,
+	MockGroup2,
+	MockOrganizationMember,
+	MockOrganizationMember2,
+	MockUserMember,
+} from "#/testHelpers/entities";
+import { ResourceSharingPageView } from "./ResourceSharingPageView";
+
+const organizationId = MockDefaultOrganization.id;
+const user = {
+	id: MockUserMember.id,
+	username: MockUserMember.username,
+	name: MockUserMember.name,
+	avatar_url: MockUserMember.avatar_url,
+	role: "read" as const,
+};
+const group = { ...MockGroup, role: "read" as const };
+const everyoneGroup = {
+	...MockGroup2,
+	id: organizationId,
+	organization_id: organizationId,
+	name: "Everyone",
+	display_name: "Everyone",
+};
+const emptyACL: ChatModelConfigACL = { users: [], groups: [] };
+const populatedACL: ChatModelConfigACL = { users: [user], groups: [group] };
+
+const baseArgs = {
+	resourceName: "GPT-5",
+	resourceTypeLabel: "model",
+	backPath: "/ai/settings/models/model-gpt5",
+	search: `?organization=${MockDefaultOrganization.name}`,
+	organizationId,
+	acl: emptyACL,
+	isLoading: false,
+	error: undefined,
+	mutationError: undefined,
+	canShare: true,
+	isMutating: false,
+	onAddUser: fn(async () => undefined),
+	onAddGroup: fn(async () => undefined),
+	onRemoveUser: fn(async () => undefined),
+	onRemoveGroup: fn(async () => undefined),
+};
+
+const mockCandidates = () => {
+	spyOn(API, "getOrganizationPaginatedMembers").mockResolvedValue({
+		members: [MockOrganizationMember, MockOrganizationMember2],
+		count: 2,
+	});
+	spyOn(API, "getGroupsByOrganization").mockResolvedValue([
+		everyoneGroup,
+		MockGroup,
+		MockGroup2,
+	]);
+};
+
+const selectCandidate = async (
+	canvasElement: HTMLElement,
+	query: string,
+	optionName: RegExp,
+) => {
+	const body = within(canvasElement.ownerDocument.body);
+	await userEvent.click(
+		within(canvasElement).getByRole("button", {
+			name: "Search for user or group",
+		}),
+	);
+	await userEvent.type(
+		body.getByPlaceholderText("Search for user or group"),
+		query,
+	);
+	await userEvent.click(await body.findByRole("option", { name: optionName }));
+	await userEvent.click(
+		within(canvasElement).getByRole("button", { name: "Add member" }),
+	);
+};
+
+const meta: Meta<typeof ResourceSharingPageView> = {
+	title: "pages/AISettingsPage/ResourceSharingPageView",
+	component: ResourceSharingPageView,
+	args: baseArgs,
+};
+
+export default meta;
+type Story = StoryObj<typeof ResourceSharingPageView>;
+
+export const EmptyACL: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByText("No users or groups have access"),
+		).toBeVisible();
+		await expect(
+			canvas.getByRole("button", { name: "Add member" }),
+		).toBeDisabled();
+	},
+};
+
+export const UserGrant: Story = {
+	beforeEach: mockCandidates,
+	play: async ({ canvasElement, args }) => {
+		await selectCandidate(
+			canvasElement,
+			MockOrganizationMember2.email,
+			new RegExp(MockOrganizationMember2.email, "i"),
+		);
+		await waitFor(() => {
+			expect(args.onAddUser).toHaveBeenCalledWith(
+				MockOrganizationMember2.user_id,
+			);
+		});
+	},
+};
+
+export const GroupGrant: Story = {
+	beforeEach: mockCandidates,
+	play: async ({ canvasElement, args }) => {
+		await selectCandidate(canvasElement, MockGroup2.name, /developer/i);
+		await waitFor(() => {
+			expect(args.onAddGroup).toHaveBeenCalledWith(MockGroup2.id);
+		});
+	},
+};
+
+export const EveryoneGroupGrant: Story = {
+	beforeEach: mockCandidates,
+	play: async ({ canvasElement, args }) => {
+		await selectCandidate(canvasElement, "Everyone", /Everyone All users/i);
+		await waitFor(() => {
+			expect(args.onAddGroup).toHaveBeenCalledWith(organizationId);
+		});
+	},
+};
+
+export const Removal: Story = {
+	args: { acl: populatedACL },
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(
+			canvas.getByRole("button", { name: `Manage ${user.username}` }),
+		);
+		const body = within(canvasElement.ownerDocument.body);
+		await userEvent.click(
+			await body.findByRole("menuitem", { name: "Remove" }),
+		);
+		await waitFor(() => {
+			expect(args.onRemoveUser).toHaveBeenCalledWith(user.id);
+		});
+	},
+};
+
+export const ReadOnly: Story = {
+	args: { acl: populatedACL, canShare: false },
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByText(/you do not have permission to change them/i),
+		).toBeVisible();
+		await expect(
+			canvas.queryByRole("button", { name: "Add member" }),
+		).not.toBeInTheDocument();
+		await expect(canvas.queryByLabelText(/Manage/)).not.toBeInTheDocument();
+	},
+};
+
+export const Loading: Story = {
+	args: { acl: undefined, isLoading: true },
+	play: async ({ canvasElement }) => {
+		await expect(
+			within(canvasElement).getByText("Loading sharing settings"),
+		).toBeVisible();
+	},
+};
+
+export const APIError: Story = {
+	args: { acl: undefined, error: new Error("Unable to load sharing settings") },
+	play: async ({ canvasElement }) => {
+		await expect(
+			within(canvasElement).getByText("Unable to load sharing settings"),
+		).toBeVisible();
+	},
+};
+
+export const OrganizationRestrictedCandidates: Story = {
+	beforeEach: mockCandidates,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(canvasElement.ownerDocument.body);
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Search for user or group" }),
+		);
+		await waitFor(() => {
+			expect(API.getOrganizationPaginatedMembers).toHaveBeenCalledWith(
+				organizationId,
+				{ limit: 0 },
+			);
+			expect(API.getGroupsByOrganization).toHaveBeenCalledWith(organizationId);
+		});
+		await userEvent.type(
+			body.getByPlaceholderText("Search for user or group"),
+			MockOrganizationMember.email,
+		);
+		await expect(
+			body.getByRole("option", {
+				name: new RegExp(MockOrganizationMember.email, "i"),
+			}),
+		).toBeVisible();
+	},
+};
+
+const MutationFailureHarness = () => {
+	const [mutationError, setMutationError] = useState<unknown>();
+	return (
+		<ResourceSharingPageView
+			{...baseArgs}
+			mutationError={mutationError}
+			onAddUser={async () => {
+				setMutationError(new Error("Failed to grant access"));
+				throw new Error("Failed to grant access");
+			}}
+		/>
+	);
+};
+
+export const MutationFailure: Story = {
+	render: () => <MutationFailureHarness />,
+	beforeEach: mockCandidates,
+	play: async ({ canvasElement }) => {
+		await selectCandidate(
+			canvasElement,
+			MockOrganizationMember2.email,
+			new RegExp(MockOrganizationMember2.email, "i"),
+		);
+		await expect(
+			within(canvasElement).findByText("Failed to grant access"),
+		).resolves.toBeVisible();
+	},
+};

--- a/site/src/pages/AISettingsPage/components/ResourceSharingPage/ResourceSharingPageView.tsx
+++ b/site/src/pages/AISettingsPage/components/ResourceSharingPage/ResourceSharingPageView.tsx
@@ -1,0 +1,303 @@
+import {
+	ArrowLeftIcon,
+	EllipsisVerticalIcon,
+	UserPlusIcon,
+} from "lucide-react";
+import { type FC, type FormEvent, useState } from "react";
+import { Link } from "react-router";
+import type {
+	ChatModelConfigACL,
+	ChatModelConfigGroup,
+	ChatModelConfigUser,
+	MCPServerConfigACL,
+	MCPServerConfigGroup,
+	MCPServerConfigUser,
+} from "#/api/typesGenerated";
+import { ErrorAlert } from "#/components/Alert/ErrorAlert";
+import { Avatar } from "#/components/Avatar/Avatar";
+import { AvatarData } from "#/components/Avatar/AvatarData";
+import { Button } from "#/components/Button/Button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "#/components/DropdownMenu/DropdownMenu";
+import {
+	SettingsHeader,
+	SettingsHeaderDescription,
+	SettingsHeaderTitle,
+} from "#/components/SettingsHeader/SettingsHeader";
+import { Spinner } from "#/components/Spinner/Spinner";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "#/components/Table/Table";
+import { getGroupSubtitle, isGroup } from "#/modules/groups";
+import {
+	type ResourceSharingCandidateValue,
+	UserOrGroupAutocomplete,
+} from "./UserOrGroupAutocomplete";
+
+type ResourceACL = ChatModelConfigACL | MCPServerConfigACL;
+type ResourceUser = ChatModelConfigUser | MCPServerConfigUser;
+type ResourceGroup = ChatModelConfigGroup | MCPServerConfigGroup;
+
+type ResourceSharingPageViewProps = {
+	resourceName: string;
+	resourceTypeLabel: string;
+	backPath: string;
+	search: string;
+	organizationId: string;
+	acl?: ResourceACL;
+	isLoading: boolean;
+	error: unknown;
+	mutationError: unknown;
+	canShare: boolean;
+	isMutating: boolean;
+	onAddUser: (userId: string) => Promise<void>;
+	onAddGroup: (groupId: string) => Promise<void>;
+	onRemoveUser: (userId: string) => Promise<void>;
+	onRemoveGroup: (groupId: string) => Promise<void>;
+};
+
+const ReadRoleBadge: FC = () => (
+	<span className="inline-block shrink-0 rounded-md bg-surface-secondary px-2 py-0.5 text-xs leading-5">
+		Read
+	</span>
+);
+
+const MemberIdentity: FC<
+	{ kind: "user"; user: ResourceUser } | { kind: "group"; group: ResourceGroup }
+> = (props) => {
+	if (props.kind === "group") {
+		const { group } = props;
+		return (
+			<AvatarData
+				title={group.display_name || group.name}
+				subtitle={getGroupSubtitle(group)}
+				src={group.avatar_url}
+				avatar={
+					<Avatar
+						src={group.avatar_url}
+						fallback={group.display_name || group.name}
+						variant="icon"
+					/>
+				}
+			/>
+		);
+	}
+	return (
+		<AvatarData
+			title={props.user.username}
+			subtitle={props.user.name}
+			src={props.user.avatar_url}
+		/>
+	);
+};
+
+const RemoveMenu: FC<{
+	disabled: boolean;
+	label: string;
+	onRemove: () => void;
+}> = ({ disabled, label, onRemove }) => (
+	<DropdownMenu>
+		<DropdownMenuTrigger asChild>
+			<Button
+				variant="subtle"
+				size="icon"
+				disabled={disabled}
+				aria-label={`Manage ${label}`}
+			>
+				<EllipsisVerticalIcon />
+			</Button>
+		</DropdownMenuTrigger>
+		<DropdownMenuContent align="end">
+			<DropdownMenuItem
+				className="text-content-destructive focus:text-content-destructive"
+				onClick={onRemove}
+			>
+				Remove
+			</DropdownMenuItem>
+		</DropdownMenuContent>
+	</DropdownMenu>
+);
+
+export const ResourceSharingPageView: FC<ResourceSharingPageViewProps> = ({
+	resourceName,
+	resourceTypeLabel,
+	backPath,
+	search,
+	organizationId,
+	acl,
+	isLoading,
+	error,
+	mutationError,
+	canShare,
+	isMutating,
+	onAddUser,
+	onAddGroup,
+	onRemoveUser,
+	onRemoveGroup,
+}) => {
+	const [selectedCandidate, setSelectedCandidate] =
+		useState<ResourceSharingCandidateValue>(null);
+	const users = acl?.users ?? [];
+	const groups = acl?.groups ?? [];
+	const isEmpty = users.length === 0 && groups.length === 0;
+	const excludeIds = [...users, ...groups].map((entry) => entry.id);
+
+	const handleSubmit = async (event: FormEvent) => {
+		event.preventDefault();
+		if (!selectedCandidate || isMutating) {
+			return;
+		}
+		try {
+			if (isGroup(selectedCandidate)) {
+				await onAddGroup(selectedCandidate.id);
+			} else {
+				await onAddUser(selectedCandidate.id);
+			}
+			setSelectedCandidate(null);
+		} catch {
+			// The page displays the mutation error and keeps the selection for retry.
+		}
+	};
+
+	return (
+		<div>
+			<Link
+				to={{ pathname: backPath, search }}
+				className="mb-4 inline-flex -ml-3 no-underline"
+			>
+				<Button variant="subtle" type="button">
+					<ArrowLeftIcon />
+					Back to {resourceTypeLabel}
+				</Button>
+			</Link>
+			<SettingsHeader>
+				<SettingsHeaderTitle>Share {resourceName}</SettingsHeaderTitle>
+				<SettingsHeaderDescription>
+					Grant users and groups read access to this {resourceTypeLabel}.
+				</SettingsHeaderDescription>
+			</SettingsHeader>
+
+			<div className="flex flex-col gap-4">
+				{Boolean(error) && <ErrorAlert error={error} />}
+				{Boolean(mutationError) && <ErrorAlert error={mutationError} />}
+				{isLoading ? (
+					<div role="status" className="flex flex-col items-center gap-4 py-12">
+						<Spinner loading />
+						<span>Loading sharing settings</span>
+					</div>
+				) : acl ? (
+					<>
+						{canShare ? (
+							<form onSubmit={handleSubmit}>
+								<div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+									<div className="min-w-0 flex-1">
+										<UserOrGroupAutocomplete
+											value={selectedCandidate}
+											onChange={setSelectedCandidate}
+											organizationId={organizationId}
+											excludeIds={excludeIds}
+										/>
+									</div>
+									<Button
+										type="submit"
+										disabled={!selectedCandidate || isMutating}
+									>
+										<Spinner loading={isMutating}>
+											<UserPlusIcon />
+										</Spinner>
+										Add member
+									</Button>
+								</div>
+							</form>
+						) : (
+							<p className="m-0 rounded-md border border-solid border-border bg-surface-secondary p-4 text-sm text-content-secondary">
+								You can view sharing settings, but you do not have permission to
+								change them.
+							</p>
+						)}
+
+						{isEmpty ? (
+							<div className="flex min-h-48 flex-col items-center justify-center rounded-md border border-solid border-border px-6 py-8 text-center">
+								<h3 className="m-0 text-base font-medium">
+									No users or groups have access
+								</h3>
+								<p className="m-0 mt-2 text-sm text-content-secondary">
+									{canShare
+										? "Add a user or group using the controls above."
+										: "A user with sharing permission can grant access."}
+								</p>
+							</div>
+						) : (
+							<Table
+								aria-label={`Users and groups with access to ${resourceName}`}
+							>
+								<TableHeader>
+									<TableRow>
+										<TableHead>Member</TableHead>
+										<TableHead className="w-40">Role</TableHead>
+										{canShare && <TableHead className="w-16" />}
+									</TableRow>
+								</TableHeader>
+								<TableBody>
+									{groups.map((group) => (
+										<TableRow key={group.id}>
+											<TableCell>
+												<MemberIdentity kind="group" group={group} />
+											</TableCell>
+											<TableCell>
+												<ReadRoleBadge />
+											</TableCell>
+											{canShare && (
+												<TableCell>
+													<RemoveMenu
+														disabled={isMutating}
+														label={group.display_name || group.name}
+														onRemove={() => {
+															void onRemoveGroup(group.id).catch(
+																() => undefined,
+															);
+														}}
+													/>
+												</TableCell>
+											)}
+										</TableRow>
+									))}
+									{users.map((user) => (
+										<TableRow key={user.id}>
+											<TableCell>
+												<MemberIdentity kind="user" user={user} />
+											</TableCell>
+											<TableCell>
+												<ReadRoleBadge />
+											</TableCell>
+											{canShare && (
+												<TableCell>
+													<RemoveMenu
+														disabled={isMutating}
+														label={user.username}
+														onRemove={() => {
+															void onRemoveUser(user.id).catch(() => undefined);
+														}}
+													/>
+												</TableCell>
+											)}
+										</TableRow>
+									))}
+								</TableBody>
+							</Table>
+						)}
+					</>
+				) : null}
+			</div>
+		</div>
+	);
+};

--- a/site/src/pages/AISettingsPage/components/ResourceSharingPage/UserOrGroupAutocomplete.tsx
+++ b/site/src/pages/AISettingsPage/components/ResourceSharingPage/UserOrGroupAutocomplete.tsx
@@ -1,0 +1,117 @@
+import { CheckIcon } from "lucide-react";
+import { type FC, useState } from "react";
+import { keepPreviousData, useQuery } from "react-query";
+import { groupsByOrganization } from "#/api/queries/groups";
+import { organizationMembers } from "#/api/queries/organizations";
+import type {
+	Group,
+	OrganizationMemberWithUserData,
+} from "#/api/typesGenerated";
+import { Autocomplete } from "#/components/Autocomplete/Autocomplete";
+import { AvatarData } from "#/components/Avatar/AvatarData";
+import { getGroupSubtitle, isGroup } from "#/modules/groups";
+
+type OrganizationMember = OrganizationMemberWithUserData & { id: string };
+type ResourceSharingCandidate = OrganizationMember | Group;
+export type ResourceSharingCandidateValue = ResourceSharingCandidate | null;
+
+type ResourceSharingAutocompleteProps = {
+	value: ResourceSharingCandidateValue;
+	onChange: (value: ResourceSharingCandidateValue) => void;
+	organizationId: string;
+	excludeIds: readonly string[];
+};
+
+const normalizeMember = (
+	member: OrganizationMemberWithUserData,
+): OrganizationMember => ({
+	...member,
+	id: member.user_id,
+});
+
+export const UserOrGroupAutocomplete: FC<ResourceSharingAutocompleteProps> = ({
+	value,
+	onChange,
+	organizationId,
+	excludeIds,
+}) => {
+	const [inputValue, setInputValue] = useState("");
+	const [open, setOpen] = useState(false);
+
+	const membersQuery = useQuery({
+		...organizationMembers(organizationId, { limit: 0 }),
+		enabled: open,
+		placeholderData: keepPreviousData,
+	});
+	const groupsQuery = useQuery({
+		...groupsByOrganization(organizationId),
+		enabled: open,
+		placeholderData: keepPreviousData,
+	});
+
+	const filterValue = inputValue.trim().toLowerCase();
+	const groups = (groupsQuery.data ?? []).filter((group) => {
+		if (!filterValue) {
+			return true;
+		}
+		return `${group.display_name ?? ""} ${group.name}`
+			.toLowerCase()
+			.includes(filterValue);
+	});
+	const users = (membersQuery.data?.members ?? [])
+		.filter((member) => {
+			if (!filterValue) {
+				return true;
+			}
+			return `${member.name ?? ""} ${member.username} ${member.email}`
+				.toLowerCase()
+				.includes(filterValue);
+		})
+		.map(normalizeMember);
+	const options = [...groups, ...users].filter(
+		(option) => !excludeIds.includes(option.id),
+	);
+
+	return (
+		<Autocomplete
+			value={value}
+			onChange={onChange}
+			options={options}
+			getOptionValue={(option) => option.id}
+			getOptionLabel={(option) =>
+				isGroup(option) ? option.display_name || option.name : option.email
+			}
+			isOptionEqualToValue={(option, optionValue) =>
+				option.id === optionValue.id
+			}
+			renderOption={(option, isSelected) => (
+				<div className="flex w-full items-center justify-between">
+					<AvatarData
+						title={
+							isGroup(option)
+								? option.display_name || option.name
+								: option.username
+						}
+						subtitle={isGroup(option) ? getGroupSubtitle(option) : option.email}
+						src={option.avatar_url}
+					/>
+					{isSelected && <CheckIcon className="size-4 shrink-0" />}
+				</div>
+			)}
+			open={open}
+			onOpenChange={(nextOpen) => {
+				setOpen(nextOpen);
+				if (!nextOpen) {
+					setInputValue("");
+				}
+			}}
+			inputValue={inputValue}
+			onInputChange={setInputValue}
+			loading={membersQuery.isFetching || groupsQuery.isFetching}
+			placeholder="Search for user or group"
+			noOptionsText="No users or groups found"
+			className="w-full sm:w-80"
+			id="ai-resource-user-or-group-autocomplete"
+		/>
+	);
+};

--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -454,6 +454,12 @@ const AISettingsUpdateModelPage = lazy(
 	() =>
 		import("./pages/AISettingsPage/ModelsPage/UpdateModelPage/UpdateModelPage"),
 );
+const AISettingsModelSharingPage = lazy(
+	() =>
+		import(
+			"./pages/AISettingsPage/ModelsPage/ModelSharingPage/ModelSharingPage"
+		),
+);
 const AISettingsMCPServersPage = lazy(
 	() => import("./pages/AISettingsPage/MCPServersPage/MCPServersPage"),
 );
@@ -467,6 +473,12 @@ const AISettingsUpdateMCPServerPage = lazy(
 	() =>
 		import(
 			"./pages/AISettingsPage/MCPServersPage/UpdateMCPServerPage/UpdateMCPServerPage"
+		),
+);
+const AISettingsMCPServerSharingPage = lazy(
+	() =>
+		import(
+			"./pages/AISettingsPage/MCPServersPage/MCPServerSharingPage/MCPServerSharingPage"
 		),
 );
 
@@ -807,6 +819,14 @@ export const router = createBrowserRouter(
 							/>
 							<Route path="coder-agents" element={<CoderAgentsPage />} />
 						</Route>
+						<Route
+							path="models/:modelId/sharing"
+							element={<AISettingsModelSharingPage />}
+						/>
+						<Route
+							path="mcp-servers/:serverId/sharing"
+							element={<AISettingsMCPServerSharingPage />}
+						/>
 						<Route path="spend" element={<AISettingsSpendPage />} />
 						<Route
 							path="instructions"


### PR DESCRIPTION
This is the final review-only implementation slice in the organization-aware AI resource stack. It adds item-scoped model and MCP sharing surfaces without depending on broad organization management permissions.

This PR depends on #27394, must not merge separately, and is intended only for review. The complete coordinated stack will now be rebuilt and validated in a separate aggregate validation PR.

<details>
<summary>Coordinated stack direction</summary>

The aggregate PR will combine the organization-aware API and query contracts, shared organization context, chat callers, model and MCP management, sharing, settings, OAuth callers, permissions, empty states, and Storybook coverage. It keeps required organization arguments, ID-based item and ACL queries, organization-keyed lists and settings, deployment-scoped providers, read-only ACL roles, and no compatibility routes or fallback organization behavior.

</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
