### PR TITLE
feat: add network calls summary to AI session detail

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -15309,6 +15309,17 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.AIBridgeSessionNetworkDomain": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "domain": {
+                    "type": "string"
+                }
+            }
+        },
         "codersdk.AIBridgeSessionThreadsResponse": {
             "type": "object",
             "properties": {
@@ -15333,6 +15344,24 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "type": "string"
+                    }
+                },
+                "network_calls": {
+                    "description": "NetworkCalls summarizes the Agent Firewall network calls made during the\nsession. A nil value means the session did not pass through Agent\nFirewall, so network call monitoring was not active, which the UI\nsurfaces as \"Disabled\".",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/codersdk.AIBridgeSessionNetworkCallSummary"
+                        }
+                    ]
+                },
+                "network_domain_count": {
+                    "type": "integer"
+                },
+                "network_top_domains": {
+                    "description": "NetworkTopDomains lists the most contacted destination hosts, ordered by\ncall count descending. NetworkDomainCount is the total number of distinct\ndomains, used to render a \"+N more\" overflow beyond the listed domains.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.AIBridgeSessionNetworkDomain"
                     }
                 },
                 "page_ended_at": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -13635,6 +13635,17 @@
 				}
 			}
 		},
+		"codersdk.AIBridgeSessionNetworkDomain": {
+			"type": "object",
+			"properties": {
+				"count": {
+					"type": "integer"
+				},
+				"domain": {
+					"type": "string"
+				}
+			}
+		},
 		"codersdk.AIBridgeSessionThreadsResponse": {
 			"type": "object",
 			"properties": {
@@ -13659,6 +13670,24 @@
 					"type": "array",
 					"items": {
 						"type": "string"
+					}
+				},
+				"network_calls": {
+					"description": "NetworkCalls summarizes the Agent Firewall network calls made during the\nsession. A nil value means the session did not pass through Agent\nFirewall, so network call monitoring was not active, which the UI\nsurfaces as \"Disabled\".",
+					"allOf": [
+						{
+							"$ref": "#/definitions/codersdk.AIBridgeSessionNetworkCallSummary"
+						}
+					]
+				},
+				"network_domain_count": {
+					"type": "integer"
+				},
+				"network_top_domains": {
+					"description": "NetworkTopDomains lists the most contacted destination hosts, ordered by\ncall count descending. NetworkDomainCount is the total number of distinct\ndomains, used to render a \"+N more\" overflow beyond the listed domains.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.AIBridgeSessionNetworkDomain"
 					}
 				},
 				"page_ended_at": {

--- a/coderd/database/db2sdk/db2sdk.go
+++ b/coderd/database/db2sdk/db2sdk.go
@@ -1153,6 +1153,7 @@ func AIBridgeSessionThreads(
 	toolUsages []database.AIBridgeToolUsage,
 	userPrompts []database.AIBridgeUserPrompt,
 	modelThoughts []database.AIBridgeModelThought,
+	topDomains []database.GetAIBridgeSessionTopDomainsRow,
 ) codersdk.AIBridgeSessionThreadsResponse {
 	// Index subresources by interception ID.
 	tokensByInterception := make(map[uuid.UUID][]database.AIBridgeTokenUsage, len(interceptions))
@@ -1242,6 +1243,24 @@ func AIBridgeSessionThreads(
 	}
 	if !session.EndedAt.IsZero() {
 		resp.EndedAt = &session.EndedAt
+	}
+	// NetworkCalls is only meaningful when the session passed through Agent
+	// Firewall. When it did not, leave it nil so the UI renders "Disabled"
+	// rather than a misleading zero count.
+	if session.FirewallActive {
+		resp.NetworkCalls = &codersdk.AIBridgeSessionNetworkCallSummary{
+			Total:   session.NetworkCallsTotal,
+			Blocked: session.NetworkCallsBlocked,
+		}
+	}
+	for _, d := range topDomains {
+		resp.NetworkTopDomains = append(resp.NetworkTopDomains, codersdk.AIBridgeSessionNetworkDomain{
+			Domain: d.Domain,
+			Count:  d.Count,
+		})
+		// TotalDomains is the same on every row (a window aggregate); take it
+		// from the last row processed.
+		resp.NetworkDomainCount = d.TotalDomains
 	}
 	return resp
 }

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -2773,6 +2773,13 @@ func (q *querier) GetAIBridgeInterceptions(ctx context.Context) ([]database.AIBr
 	return fetchWithPostFilter(q.auth, policy.ActionRead, fetch)(ctx, nil)
 }
 
+func (q *querier) GetAIBridgeSessionTopDomains(ctx context.Context, arg database.GetAIBridgeSessionTopDomainsParams) ([]database.GetAIBridgeSessionTopDomainsRow, error) {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceAibridgeInterception); err != nil {
+		return nil, err
+	}
+	return q.db.GetAIBridgeSessionTopDomains(ctx, arg)
+}
+
 func (q *querier) GetAIBridgeTokenUsagesByInterceptionID(ctx context.Context, interceptionID uuid.UUID) ([]database.AIBridgeTokenUsage, error) {
 	// All aibridge_token_usages records belong to the initiator of their associated interception.
 	if err := q.authorizeAIBridgeInterceptionAction(ctx, policy.ActionRead, interceptionID); err != nil {

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -6875,6 +6875,12 @@ func (s *MethodTestSuite) TestAIBridge() {
 		check.Args(params, emptyPreparedAuthorized{}).Asserts()
 	}))
 
+	s.Run("GetAIBridgeSessionTopDomains", s.Mocked(func(db *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		params := database.GetAIBridgeSessionTopDomainsParams{SessionID: "sess", Limit: 5}
+		db.EXPECT().GetAIBridgeSessionTopDomains(gomock.Any(), params).Return([]database.GetAIBridgeSessionTopDomainsRow{}, nil).AnyTimes()
+		check.Args(params).Asserts(rbac.ResourceAibridgeInterception, policy.ActionRead).Returns([]database.GetAIBridgeSessionTopDomainsRow{})
+	}))
+
 	s.Run("ListAIBridgeTokenUsagesByInterceptionIDs", s.Mocked(func(db *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		ids := []uuid.UUID{{1}}
 		db.EXPECT().ListAIBridgeTokenUsagesByInterceptionIDs(gomock.Any(), ids).Return([]database.AIBridgeTokenUsage{}, nil).AnyTimes()

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -1097,6 +1097,14 @@ func (m queryMetricsStore) GetAIBridgeInterceptions(ctx context.Context) ([]data
 	return r0, r1
 }
 
+func (m queryMetricsStore) GetAIBridgeSessionTopDomains(ctx context.Context, arg database.GetAIBridgeSessionTopDomainsParams) ([]database.GetAIBridgeSessionTopDomainsRow, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetAIBridgeSessionTopDomains(ctx, arg)
+	m.queryLatencies.WithLabelValues("GetAIBridgeSessionTopDomains").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetAIBridgeSessionTopDomains").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) GetAIBridgeTokenUsagesByInterceptionID(ctx context.Context, interceptionID uuid.UUID) ([]database.AIBridgeTokenUsage, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetAIBridgeTokenUsagesByInterceptionID(ctx, interceptionID)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -1888,6 +1888,21 @@ func (mr *MockStoreMockRecorder) GetAIBridgeInterceptions(ctx any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAIBridgeInterceptions", reflect.TypeOf((*MockStore)(nil).GetAIBridgeInterceptions), ctx)
 }
 
+// GetAIBridgeSessionTopDomains mocks base method.
+func (m *MockStore) GetAIBridgeSessionTopDomains(ctx context.Context, arg database.GetAIBridgeSessionTopDomainsParams) ([]database.GetAIBridgeSessionTopDomainsRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAIBridgeSessionTopDomains", ctx, arg)
+	ret0, _ := ret[0].([]database.GetAIBridgeSessionTopDomainsRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAIBridgeSessionTopDomains indicates an expected call of GetAIBridgeSessionTopDomains.
+func (mr *MockStoreMockRecorder) GetAIBridgeSessionTopDomains(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAIBridgeSessionTopDomains", reflect.TypeOf((*MockStore)(nil).GetAIBridgeSessionTopDomains), ctx, arg)
+}
+
 // GetAIBridgeTokenUsagesByInterceptionID mocks base method.
 func (m *MockStore) GetAIBridgeTokenUsagesByInterceptionID(ctx context.Context, interceptionID uuid.UUID) ([]database.AIBridgeTokenUsage, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -297,6 +297,19 @@ type sqlcQuerier interface {
 	// the root), we return its own ID as the root.
 	GetAIBridgeInterceptionLineageByToolCallID(ctx context.Context, toolCallID string) (GetAIBridgeInterceptionLineageByToolCallIDRow, error)
 	GetAIBridgeInterceptions(ctx context.Context) ([]AIBridgeInterception, error)
+	// Returns the most contacted destination hosts for an AI session, ordered by
+	// call count descending and limited to the top @limit_ rows. total_domains is
+	// the number of distinct domains across the whole session, used to render a
+	// "+N more" overflow beyond the returned rows. Only HTTP egress is considered;
+	// dns/git/fs boundary logs do not carry a domain in the same shape.
+	//
+	// Windowing mirrors the network_calls aggregation in ListAIBridgeSessions:
+	// each interception's boundary logs fall in the open interval (this seq, next
+	// interception's seq) within the same firewall session. The exclusive lower
+	// bound drops the interception's own LLM-provider call. next_seq considers all
+	// interceptions in the firewall session so windows never bleed across AI
+	// sessions that share one firewall session.
+	GetAIBridgeSessionTopDomains(ctx context.Context, arg GetAIBridgeSessionTopDomainsParams) ([]GetAIBridgeSessionTopDomainsRow, error)
 	GetAIBridgeTokenUsagesByInterceptionID(ctx context.Context, interceptionID uuid.UUID) ([]AIBridgeTokenUsage, error)
 	GetAIBridgeToolUsagesByInterceptionID(ctx context.Context, interceptionID uuid.UUID) ([]AIBridgeToolUsage, error)
 	GetAIBridgeUserPromptsByInterceptionID(ctx context.Context, interceptionID uuid.UUID) ([]AIBridgeUserPrompt, error)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -1272,6 +1272,95 @@ func (q *sqlQuerier) GetAIBridgeInterceptions(ctx context.Context) ([]AIBridgeIn
 	return items, nil
 }
 
+const getAIBridgeSessionTopDomains = `-- name: GetAIBridgeSessionTopDomains :many
+WITH session_boundary_logs AS (
+	SELECT bl.detail
+	FROM aibridge_interceptions afi
+	LEFT JOIN LATERAL (
+		SELECT MIN(nxt.agent_firewall_sequence_number) AS next_seq
+		FROM aibridge_interceptions nxt
+		WHERE nxt.agent_firewall_session_id = afi.agent_firewall_session_id
+			AND nxt.agent_firewall_sequence_number > afi.agent_firewall_sequence_number
+	) w ON true
+	JOIN boundary_logs bl
+		ON bl.session_id = afi.agent_firewall_session_id
+		AND bl.sequence_number > afi.agent_firewall_sequence_number
+		AND (w.next_seq IS NULL OR bl.sequence_number < w.next_seq)
+	WHERE afi.session_id = $2::text
+		AND afi.ended_at IS NOT NULL
+		AND afi.agent_firewall_session_id IS NOT NULL
+		AND afi.agent_firewall_sequence_number IS NOT NULL
+		AND bl.proto = 'http'
+),
+extracted AS (
+	-- Strip an optional scheme, then keep the host up to the first port, path,
+	-- query, or fragment delimiter.
+	SELECT substring(detail from '^(?:[A-Za-z][A-Za-z0-9+.-]*://)?([^/:?#]+)') AS domain
+	FROM session_boundary_logs
+),
+domains AS (
+	SELECT domain, COUNT(*)::bigint AS count
+	FROM extracted
+	WHERE domain IS NOT NULL AND domain != ''
+	GROUP BY domain
+)
+SELECT
+	-- COALESCE keeps sqlc from typing the grouped column as nullable; the
+	-- domains CTE already filters out NULL/empty hosts.
+	COALESCE(domain, '')::text AS domain,
+	count,
+	COUNT(*) OVER ()::bigint AS total_domains
+FROM domains
+ORDER BY count DESC, domain ASC
+LIMIT COALESCE(NULLIF($1::integer, 0), 5)
+`
+
+type GetAIBridgeSessionTopDomainsParams struct {
+	Limit     int32  `db:"limit_" json:"limit_"`
+	SessionID string `db:"session_id" json:"session_id"`
+}
+
+type GetAIBridgeSessionTopDomainsRow struct {
+	Domain       string `db:"domain" json:"domain"`
+	Count        int64  `db:"count" json:"count"`
+	TotalDomains int64  `db:"total_domains" json:"total_domains"`
+}
+
+// Returns the most contacted destination hosts for an AI session, ordered by
+// call count descending and limited to the top @limit_ rows. total_domains is
+// the number of distinct domains across the whole session, used to render a
+// "+N more" overflow beyond the returned rows. Only HTTP egress is considered;
+// dns/git/fs boundary logs do not carry a domain in the same shape.
+//
+// Windowing mirrors the network_calls aggregation in ListAIBridgeSessions:
+// each interception's boundary logs fall in the open interval (this seq, next
+// interception's seq) within the same firewall session. The exclusive lower
+// bound drops the interception's own LLM-provider call. next_seq considers all
+// interceptions in the firewall session so windows never bleed across AI
+// sessions that share one firewall session.
+func (q *sqlQuerier) GetAIBridgeSessionTopDomains(ctx context.Context, arg GetAIBridgeSessionTopDomainsParams) ([]GetAIBridgeSessionTopDomainsRow, error) {
+	rows, err := q.db.QueryContext(ctx, getAIBridgeSessionTopDomains, arg.Limit, arg.SessionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetAIBridgeSessionTopDomainsRow
+	for rows.Next() {
+		var i GetAIBridgeSessionTopDomainsRow
+		if err := rows.Scan(&i.Domain, &i.Count, &i.TotalDomains); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getAIBridgeTokenUsagesByInterceptionID = `-- name: GetAIBridgeTokenUsagesByInterceptionID :many
 SELECT
 	id, interception_id, provider_response_id, input_tokens, output_tokens, metadata, created_at, cache_read_input_tokens, cache_write_input_tokens, effective_group_id, input_price_micros, output_price_micros, cache_read_price_micros, cache_write_price_micros, cost_micros

--- a/coderd/database/queries/aibridge.sql
+++ b/coderd/database/queries/aibridge.sql
@@ -551,6 +551,60 @@ ORDER BY
 	sp.session_id DESC
 ;
 
+-- name: GetAIBridgeSessionTopDomains :many
+-- Returns the most contacted destination hosts for an AI session, ordered by
+-- call count descending and limited to the top @limit_ rows. total_domains is
+-- the number of distinct domains across the whole session, used to render a
+-- "+N more" overflow beyond the returned rows. Only HTTP egress is considered;
+-- dns/git/fs boundary logs do not carry a domain in the same shape.
+--
+-- Windowing mirrors the network_calls aggregation in ListAIBridgeSessions:
+-- each interception's boundary logs fall in the open interval (this seq, next
+-- interception's seq) within the same firewall session. The exclusive lower
+-- bound drops the interception's own LLM-provider call. next_seq considers all
+-- interceptions in the firewall session so windows never bleed across AI
+-- sessions that share one firewall session.
+WITH session_boundary_logs AS (
+	SELECT bl.detail
+	FROM aibridge_interceptions afi
+	LEFT JOIN LATERAL (
+		SELECT MIN(nxt.agent_firewall_sequence_number) AS next_seq
+		FROM aibridge_interceptions nxt
+		WHERE nxt.agent_firewall_session_id = afi.agent_firewall_session_id
+			AND nxt.agent_firewall_sequence_number > afi.agent_firewall_sequence_number
+	) w ON true
+	JOIN boundary_logs bl
+		ON bl.session_id = afi.agent_firewall_session_id
+		AND bl.sequence_number > afi.agent_firewall_sequence_number
+		AND (w.next_seq IS NULL OR bl.sequence_number < w.next_seq)
+	WHERE afi.session_id = @session_id::text
+		AND afi.ended_at IS NOT NULL
+		AND afi.agent_firewall_session_id IS NOT NULL
+		AND afi.agent_firewall_sequence_number IS NOT NULL
+		AND bl.proto = 'http'
+),
+extracted AS (
+	-- Strip an optional scheme, then keep the host up to the first port, path,
+	-- query, or fragment delimiter.
+	SELECT substring(detail from '^(?:[A-Za-z][A-Za-z0-9+.-]*://)?([^/:?#]+)') AS domain
+	FROM session_boundary_logs
+),
+domains AS (
+	SELECT domain, COUNT(*)::bigint AS count
+	FROM extracted
+	WHERE domain IS NOT NULL AND domain != ''
+	GROUP BY domain
+)
+SELECT
+	-- COALESCE keeps sqlc from typing the grouped column as nullable; the
+	-- domains CTE already filters out NULL/empty hosts.
+	COALESCE(domain, '')::text AS domain,
+	count,
+	COUNT(*) OVER ()::bigint AS total_domains
+FROM domains
+ORDER BY count DESC, domain ASC
+LIMIT COALESCE(NULLIF(@limit_::integer, 0), 5);
+
 -- name: ListAIBridgeSessionThreads :many
 -- Returns all interceptions belonging to paginated threads within a session.
 -- Threads are paginated by (started_at, thread_id) cursor.

--- a/codersdk/aibridge.go
+++ b/codersdk/aibridge.go
@@ -149,6 +149,13 @@ type AIBridgeSessionNetworkCallSummary struct {
 	Blocked int64 `json:"blocked"`
 }
 
+// AIBridgeSessionNetworkDomain is one destination host contacted during a
+// session, with the number of network calls made to it.
+type AIBridgeSessionNetworkDomain struct {
+	Domain string `json:"domain"`
+	Count  int64  `json:"count"`
+}
+
 type AIBridgeListSessionsResponse struct {
 	Count    int64             `json:"count"`
 	Sessions []AIBridgeSession `json:"sessions"`
@@ -169,7 +176,17 @@ type AIBridgeSessionThreadsResponse struct {
 	StartedAt         time.Time                        `json:"started_at" format:"date-time"`
 	EndedAt           *time.Time                       `json:"ended_at,omitempty" format:"date-time"`
 	TokenUsageSummary AIBridgeSessionThreadsTokenUsage `json:"token_usage_summary"`
-	Threads           []AIBridgeThread                 `json:"threads"`
+	// NetworkCalls summarizes the Agent Firewall network calls made during the
+	// session. A nil value means the session did not pass through Agent
+	// Firewall, so network call monitoring was not active, which the UI
+	// surfaces as "Disabled".
+	NetworkCalls *AIBridgeSessionNetworkCallSummary `json:"network_calls,omitempty"`
+	// NetworkTopDomains lists the most contacted destination hosts, ordered by
+	// call count descending. NetworkDomainCount is the total number of distinct
+	// domains, used to render a "+N more" overflow beyond the listed domains.
+	NetworkTopDomains  []AIBridgeSessionNetworkDomain `json:"network_top_domains,omitempty"`
+	NetworkDomainCount int64                          `json:"network_domain_count,omitempty"`
+	Threads            []AIBridgeThread               `json:"threads"`
 }
 
 // AIBridgeSessionThreadsTokenUsage represents aggregated token usage

--- a/docs/reference/api/aigateway.md
+++ b/docs/reference/api/aigateway.md
@@ -195,6 +195,17 @@ Alias: also available at /api/v2/aibridge/sessions/{session_id} for backward com
   "models": [
     "string"
   ],
+  "network_calls": {
+    "blocked": 0,
+    "total": 0
+  },
+  "network_domain_count": 0,
+  "network_top_domains": [
+    {
+      "count": 0,
+      "domain": "string"
+    }
+  ],
   "page_ended_at": "2019-08-24T14:15:22Z",
   "page_started_at": "2019-08-24T14:15:22Z",
   "providers": [

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -655,6 +655,22 @@
 | `blocked` | integer | false    |              |             |
 | `total`   | integer | false    |              |             |
 
+## codersdk.AIBridgeSessionNetworkDomain
+
+```json
+{
+  "count": 0,
+  "domain": "string"
+}
+```
+
+### Properties
+
+| Name     | Type    | Required | Restrictions | Description |
+|----------|---------|----------|--------------|-------------|
+| `count`  | integer | false    |              |             |
+| `domain` | string  | false    |              |             |
+
 ## codersdk.AIBridgeSessionThreadsResponse
 
 ```json
@@ -674,6 +690,17 @@
   },
   "models": [
     "string"
+  ],
+  "network_calls": {
+    "blocked": 0,
+    "total": 0
+  },
+  "network_domain_count": 0,
+  "network_top_domains": [
+    {
+      "count": 0,
+      "domain": "string"
+    }
   ],
   "page_ended_at": "2019-08-24T14:15:22Z",
   "page_started_at": "2019-08-24T14:15:22Z",
@@ -758,21 +785,24 @@
 
 ### Properties
 
-| Name                  | Type                                                                                   | Required | Restrictions | Description |
-|-----------------------|----------------------------------------------------------------------------------------|----------|--------------|-------------|
-| `client`              | string                                                                                 | false    |              |             |
-| `ended_at`            | string                                                                                 | false    |              |             |
-| `id`                  | string                                                                                 | false    |              |             |
-| `initiator`           | [codersdk.MinimalUser](#codersdkminimaluser)                                           | false    |              |             |
-| `metadata`            | object                                                                                 | false    |              |             |
-| » `[any property]`    | any                                                                                    | false    |              |             |
-| `models`              | array of string                                                                        | false    |              |             |
-| `page_ended_at`       | string                                                                                 | false    |              |             |
-| `page_started_at`     | string                                                                                 | false    |              |             |
-| `providers`           | array of string                                                                        | false    |              |             |
-| `started_at`          | string                                                                                 | false    |              |             |
-| `threads`             | array of [codersdk.AIBridgeThread](#codersdkaibridgethread)                            | false    |              |             |
-| `token_usage_summary` | [codersdk.AIBridgeSessionThreadsTokenUsage](#codersdkaibridgesessionthreadstokenusage) | false    |              |             |
+| Name                   | Type                                                                                     | Required | Restrictions | Description                                                                                                                                                                                                                           |
+|------------------------|------------------------------------------------------------------------------------------|----------|--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `client`               | string                                                                                   | false    |              |                                                                                                                                                                                                                                       |
+| `ended_at`             | string                                                                                   | false    |              |                                                                                                                                                                                                                                       |
+| `id`                   | string                                                                                   | false    |              |                                                                                                                                                                                                                                       |
+| `initiator`            | [codersdk.MinimalUser](#codersdkminimaluser)                                             | false    |              |                                                                                                                                                                                                                                       |
+| `metadata`             | object                                                                                   | false    |              |                                                                                                                                                                                                                                       |
+| » `[any property]`     | any                                                                                      | false    |              |                                                                                                                                                                                                                                       |
+| `models`               | array of string                                                                          | false    |              |                                                                                                                                                                                                                                       |
+| `network_calls`        | [codersdk.AIBridgeSessionNetworkCallSummary](#codersdkaibridgesessionnetworkcallsummary) | false    |              | Network calls summarizes the Agent Firewall network calls made during the session. A nil value means the session did not pass through Agent Firewall, so network call monitoring was not active, which the UI surfaces as "Disabled". |
+| `network_domain_count` | integer                                                                                  | false    |              |                                                                                                                                                                                                                                       |
+| `network_top_domains`  | array of [codersdk.AIBridgeSessionNetworkDomain](#codersdkaibridgesessionnetworkdomain)  | false    |              | Network top domains lists the most contacted destination hosts, ordered by call count descending. NetworkDomainCount is the total number of distinct domains, used to render a "+N more" overflow beyond the listed domains.          |
+| `page_ended_at`        | string                                                                                   | false    |              |                                                                                                                                                                                                                                       |
+| `page_started_at`      | string                                                                                   | false    |              |                                                                                                                                                                                                                                       |
+| `providers`            | array of string                                                                          | false    |              |                                                                                                                                                                                                                                       |
+| `started_at`           | string                                                                                   | false    |              |                                                                                                                                                                                                                                       |
+| `threads`              | array of [codersdk.AIBridgeThread](#codersdkaibridgethread)                              | false    |              |                                                                                                                                                                                                                                       |
+| `token_usage_summary`  | [codersdk.AIBridgeSessionThreadsTokenUsage](#codersdkaibridgesessionthreadstokenusage)   | false    |              |                                                                                                                                                                                                                                       |
 
 ## codersdk.AIBridgeSessionThreadsTokenUsage
 

--- a/enterprise/coderd/aibridge.go
+++ b/enterprise/coderd/aibridge.go
@@ -361,6 +361,7 @@ func (api *API) aiBridgeGetSessionThreads(rw http.ResponseWriter, r *http.Reques
 		toolUsages    []database.AIBridgeToolUsage
 		userPrompts   []database.AIBridgeUserPrompt
 		modelThoughts []database.AIBridgeModelThought
+		topDomains    []database.GetAIBridgeSessionTopDomainsRow
 	)
 	err = api.Database.InTx(func(db database.Store) error {
 		// Validate cursor IDs before querying threads. The SQL
@@ -427,6 +428,16 @@ func (api *API) aiBridgeGetSessionThreads(rw http.ResponseWriter, r *http.Reques
 			return xerrors.Errorf("list model thoughts: %w", err)
 		}
 
+		// Aggregate the session's top network destinations. Scoped by
+		// session ID (not the page) so the summary reflects the whole session.
+		topDomains, err = db.GetAIBridgeSessionTopDomains(ctx, database.GetAIBridgeSessionTopDomainsParams{
+			SessionID: sessionIDParam,
+			Limit:     5,
+		})
+		if err != nil {
+			return xerrors.Errorf("get session top domains: %w", err)
+		}
+
 		return nil
 	}, &database.TxOptions{
 		Isolation:    sql.LevelRepeatableRead,
@@ -448,7 +459,7 @@ func (api *API) aiBridgeGetSessionThreads(rw http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	resp := db2sdk.AIBridgeSessionThreads(session, threadRows, tokenUsages, toolUsages, userPrompts, modelThoughts)
+	resp := db2sdk.AIBridgeSessionThreads(session, threadRows, tokenUsages, toolUsages, userPrompts, modelThoughts, topDomains)
 
 	httpapi.Write(ctx, rw, http.StatusOK, resp)
 }

--- a/enterprise/coderd/aibridge_test.go
+++ b/enterprise/coderd/aibridge_test.go
@@ -1666,6 +1666,110 @@ func TestAIBridgeGetSessionThreads(t *testing.T) {
 		require.Nil(t, res.Threads[1].AgentFirewallSequenceNumber)
 	})
 
+	t.Run("NetworkSummary", func(t *testing.T) {
+		t.Parallel()
+		// Use the raw store so boundary logs can be seeded directly. No RBAC
+		// role grants boundary_log:create; they are written by the agent path.
+		db, ps := dbtestutil.NewDB(t)
+		opts := aibridgeOpts(t)
+		opts.Options.Database = db
+		opts.Options.Pubsub = ps
+		client, _, firstUser := coderdenttest.NewWithDatabase(t, opts)
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		now := dbtime.Now()
+		fw := uuid.New()
+
+		// One interception marked at firewall seq 0, so its window is (0, +inf)
+		// and the LLM-provider call logged at seq 0 is excluded.
+		endedAt := now.Add(time.Minute)
+		dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID:                 firstUser.UserID,
+			Provider:                    "anthropic",
+			Model:                       "claude-sonnet-4-20250514",
+			StartedAt:                   now,
+			ClientSessionID:             sql.NullString{String: "net-session", Valid: true},
+			AgentFirewallSessionID:      uuid.NullUUID{UUID: fw, Valid: true},
+			AgentFirewallSequenceNumber: sql.NullInt32{Int32: 0, Valid: true},
+		}, &endedAt)
+
+		type logSeed struct {
+			seq     int32
+			proto   string
+			detail  string
+			allowed bool
+		}
+		seeds := []logSeed{
+			{0, "http", "https://api.github.com/llm", true},         // LLM call, excluded
+			{1, "http", "https://api.github.com/repos/coder", true}, // github egress
+			{2, "http", "https://api.github.com/repos/other", true}, // github egress
+			{3, "http", "https://registry.npmjs.org/lodash", false}, // npm egress, blocked
+			{4, "http", "https://api.github.com/repos/more", true},  // github egress
+			{5, "dns", "example.com", true},                         // non-http, ignored by top domains
+		}
+		logs := make([]database.BoundaryLog, 0, len(seeds))
+		for _, s := range seeds {
+			// A non-empty matched_rule marks the call as allowed; an empty rule
+			// is stored as NULL, which counts as blocked.
+			rule := ""
+			if s.allowed {
+				rule = "allow " + s.detail
+			}
+			logs = append(logs, database.BoundaryLog{
+				SessionID:      fw,
+				OwnerID:        uuid.NullUUID{UUID: firstUser.UserID, Valid: true},
+				SequenceNumber: s.seq,
+				CapturedAt:     now,
+				CreatedAt:      now,
+				Proto:          s.proto,
+				Method:         "GET",
+				Detail:         s.detail,
+				MatchedRule:    sql.NullString{String: rule, Valid: rule != ""},
+			})
+		}
+		dbgen.BoundaryLogs(t, db, logs)
+
+		res, err := client.AIBridgeGetSessionThreads(ctx, "net-session", uuid.Nil, uuid.Nil, 0)
+		require.NoError(t, err)
+
+		// total counts seq 1-5 (LLM call at seq 0 excluded); one blocked.
+		require.NotNil(t, res.NetworkCalls)
+		require.EqualValues(t, 5, res.NetworkCalls.Total)
+		require.EqualValues(t, 1, res.NetworkCalls.Blocked)
+
+		// Top domains covers HTTP egress only: github x3, npm x1. The dns log is
+		// excluded. Two distinct domains, ordered by count descending.
+		require.Len(t, res.NetworkTopDomains, 2)
+		require.Equal(t, "api.github.com", res.NetworkTopDomains[0].Domain)
+		require.EqualValues(t, 3, res.NetworkTopDomains[0].Count)
+		require.Equal(t, "registry.npmjs.org", res.NetworkTopDomains[1].Domain)
+		require.EqualValues(t, 1, res.NetworkTopDomains[1].Count)
+		require.EqualValues(t, 2, res.NetworkDomainCount)
+	})
+
+	t.Run("NetworkSummaryDisabled", func(t *testing.T) {
+		t.Parallel()
+		client, db, firstUser := coderdenttest.NewWithDatabase(t, aibridgeOpts(t))
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		now := dbtime.Now()
+		endedAt := now.Add(time.Minute)
+		// No firewall correlation: network monitoring was not active.
+		dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID:     firstUser.UserID,
+			Provider:        "anthropic",
+			Model:           "claude-sonnet-4-20250514",
+			StartedAt:       now,
+			ClientSessionID: sql.NullString{String: "no-fw-session", Valid: true},
+		}, &endedAt)
+
+		res, err := client.AIBridgeGetSessionThreads(ctx, "no-fw-session", uuid.Nil, uuid.Nil, 0)
+		require.NoError(t, err)
+		require.Nil(t, res.NetworkCalls)
+		require.Empty(t, res.NetworkTopDomains)
+		require.EqualValues(t, 0, res.NetworkDomainCount)
+	})
+
 	t.Run("ThreadsWithAgenticActions", func(t *testing.T) {
 		t.Parallel()
 		client, db, firstUser := coderdenttest.NewWithDatabase(t, aibridgeOpts(t))

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -164,6 +164,16 @@ export interface AIBridgeSessionNetworkCallSummary {
 
 // From codersdk/aibridge.go
 /**
+ * AIBridgeSessionNetworkDomain is one destination host contacted during a
+ * session, with the number of network calls made to it.
+ */
+export interface AIBridgeSessionNetworkDomain {
+	readonly domain: string;
+	readonly count: number;
+}
+
+// From codersdk/aibridge.go
+/**
  * AIBridgeSessionThreadsResponse is the response for GET
  * /api/v2/ai-gateway/sessions/{session_id} which returns a single
  * session with fully expanded threads.
@@ -181,6 +191,20 @@ export interface AIBridgeSessionThreadsResponse {
 	readonly started_at: string;
 	readonly ended_at?: string;
 	readonly token_usage_summary: AIBridgeSessionThreadsTokenUsage;
+	/**
+	 * NetworkCalls summarizes the Agent Firewall network calls made during the
+	 * session. A nil value means the session did not pass through Agent
+	 * Firewall, so network call monitoring was not active, which the UI
+	 * surfaces as "Disabled".
+	 */
+	readonly network_calls?: AIBridgeSessionNetworkCallSummary;
+	/**
+	 * NetworkTopDomains lists the most contacted destination hosts, ordered by
+	 * call count descending. NetworkDomainCount is the total number of distinct
+	 * domains, used to render a "+N more" overflow beyond the listed domains.
+	 */
+	readonly network_top_domains?: readonly AIBridgeSessionNetworkDomain[];
+	readonly network_domain_count?: number;
 	readonly threads: readonly AIBridgeThread[];
 }
 

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionSummaryTable.stories.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionSummaryTable.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect } from "storybook/test";
 import { MockSession } from "#/testHelpers/entities";
 import { SessionSummaryTable } from "./SessionSummaryTable";
 
@@ -54,5 +55,67 @@ export const LargeTokenCounts: Story = {
 		...Default.args,
 		inputTokens: 198_000,
 		outputTokens: 32_000,
+	},
+};
+
+// Session did not pass through Agent Firewall: monitoring was not active.
+export const NetworkDisabled: Story = {
+	args: {
+		...Default.args,
+		networkCalls: undefined,
+	},
+	play: async ({ canvas }) => {
+		await expect(canvas.getByText("Disabled")).toBeInTheDocument();
+		await expect(canvas.queryByText("Blocked network requests")).toBeNull();
+		await expect(canvas.queryByText("Top domains")).toBeNull();
+	},
+};
+
+// Firewall active but no egress recorded.
+export const NetworkNoActivity: Story = {
+	args: {
+		...Default.args,
+		networkCalls: { total: 0, blocked: 0 },
+	},
+	play: async ({ canvas }) => {
+		await expect(canvas.getByText("No activity")).toBeInTheDocument();
+		await expect(canvas.queryByText("Blocked network requests")).toBeNull();
+	},
+};
+
+// Egress recorded, some blocked, across several domains.
+export const NetworkActivity: Story = {
+	args: {
+		...Default.args,
+		networkCalls: { total: 7, blocked: 2 },
+		topDomains: [
+			{ domain: "api.github.com", count: 4 },
+			{ domain: "registry.npmjs.org", count: 2 },
+			{ domain: "hooks.slack.com", count: 1 },
+		],
+		domainCount: 14,
+	},
+	play: async ({ canvas }) => {
+		await expect(canvas.getByText("Network calls")).toBeInTheDocument();
+		await expect(canvas.getByText("7")).toBeInTheDocument();
+		await expect(
+			canvas.getByText("Blocked network requests"),
+		).toBeInTheDocument();
+		await expect(canvas.getByText("api.github.com")).toBeInTheDocument();
+		await expect(canvas.getByText("+13 more")).toBeInTheDocument();
+	},
+};
+
+// A single domain contacted: no "+N more" overflow.
+export const NetworkSingleDomain: Story = {
+	args: {
+		...Default.args,
+		networkCalls: { total: 3, blocked: 0 },
+		topDomains: [{ domain: "api.github.com", count: 3 }],
+		domainCount: 1,
+	},
+	play: async ({ canvas }) => {
+		await expect(canvas.getByText("api.github.com")).toBeInTheDocument();
+		await expect(canvas.queryByText(/more$/)).toBeNull();
 	},
 };

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionSummaryTable.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionSummaryTable.tsx
@@ -1,6 +1,13 @@
-import type { MinimalUser } from "#/api/typesGenerated";
+import { BanIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import type {
+	AIBridgeSessionNetworkCallSummary,
+	AIBridgeSessionNetworkDomain,
+	MinimalUser,
+} from "#/api/typesGenerated";
 import { Avatar } from "#/components/Avatar/Avatar";
 import { Badge } from "#/components/Badge/Badge";
+import { InfoTooltip } from "#/components/InfoTooltip/InfoTooltip";
 import { AIBridgeClientIcon } from "#/pages/AIBridgePage/icons/AIBridgeClientIcon";
 import { AIBridgeProviderIcon } from "#/pages/AIBridgePage/icons/AIBridgeProviderIcon";
 import { formatDateTime } from "#/utils/time";
@@ -21,6 +28,11 @@ interface SessionSummaryTableProps {
 	threadCount: number;
 	toolCallCount: number;
 	tokenUsageMetadata?: Record<string, unknown>;
+	// networkCalls is undefined when the session did not pass through Agent
+	// Firewall, which renders as "Disabled".
+	networkCalls?: AIBridgeSessionNetworkCallSummary;
+	topDomains?: readonly AIBridgeSessionNetworkDomain[];
+	domainCount?: number;
 }
 
 export const SessionSummaryTable = ({
@@ -35,11 +47,34 @@ export const SessionSummaryTable = ({
 	threadCount,
 	toolCallCount,
 	tokenUsageMetadata,
+	networkCalls,
+	topDomains,
+	domainCount,
 }: SessionSummaryTableProps) => {
 	const durationInMs =
 		endTime !== undefined
 			? new Date(endTime).getTime() - new Date(startTime).getTime()
 			: undefined;
+
+	let networkCallsValue: ReactNode;
+	if (networkCalls === undefined) {
+		networkCallsValue = (
+			<span className="inline-flex items-center gap-1 whitespace-nowrap text-content-secondary">
+				Disabled
+				<InfoTooltip message="Network call monitoring was not active for this session." />
+			</span>
+		);
+	} else if (networkCalls.total === 0) {
+		networkCallsValue = (
+			<span className="whitespace-nowrap text-content-secondary">
+				No activity
+			</span>
+		);
+	} else {
+		networkCallsValue = (
+			<Badge>{networkCalls.total.toLocaleString("en-US")}</Badge>
+		);
+	}
 
 	return (
 		<dl className="text-sm text-content-secondary m-0 flex flex-col gap-y-2">
@@ -163,6 +198,53 @@ export const SessionSummaryTable = ({
 					<Badge>{toolCallCount}</Badge>
 				</dd>
 			</div>
+
+			<Separator />
+
+			<div className="flex items-center justify-between">
+				<dt className="shrink-0 font-normal whitespace-nowrap">
+					Network calls
+				</dt>
+				<dd className="ml-4 min-w-0 truncate text-content-primary">
+					{networkCallsValue}
+				</dd>
+			</div>
+
+			{networkCalls !== undefined && networkCalls.total > 0 && (
+				<div className="flex items-center justify-between">
+					<dt className="shrink-0 font-normal whitespace-nowrap">
+						Blocked network requests
+					</dt>
+					<dd className="ml-4 min-w-0 truncate text-content-primary">
+						{networkCalls.blocked > 0 ? (
+							<Badge svgSize="xs" className="gap-1 text-content-warning">
+								<BanIcon className="flex-shrink-0" />
+								{networkCalls.blocked.toLocaleString("en-US")}
+							</Badge>
+						) : (
+							<Badge>{networkCalls.blocked.toLocaleString("en-US")}</Badge>
+						)}
+					</dd>
+				</div>
+			)}
+
+			{topDomains !== undefined && topDomains.length > 0 && (
+				<div className="flex items-start justify-between">
+					<dt className="shrink-0 font-normal whitespace-nowrap mt-px">
+						Top domains
+					</dt>
+					<dd className="ml-4 min-w-0 text-content-primary text-right">
+						<div className="truncate" title={topDomains[0].domain}>
+							{topDomains[0].domain}
+						</div>
+						{domainCount !== undefined && domainCount > 1 && (
+							<div className="text-content-secondary text-xs">
+								+{(domainCount - 1).toLocaleString("en-US")} more
+							</div>
+						)}
+					</dd>
+				</div>
+			)}
 		</dl>
 	);
 };

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionThreadsPageView.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionThreadsPageView.tsx
@@ -115,6 +115,9 @@ export const SessionThreadsPageView: FC<SessionThreadsPageViewProps> = ({
 							threadCount={threads.length}
 							toolCallCount={toolCallCount}
 							tokenUsageMetadata={session.token_usage_summary.metadata}
+							networkCalls={session.network_calls}
+							topDomains={session.network_top_domains}
+							domainCount={session.network_domain_count}
 						/>
 					)}
 				</aside>


### PR DESCRIPTION
Adds total/blocked network calls and top destination domains to the Session summary card on the individual AI session detail page.

Total and blocked reuse the existing Agent Firewall aggregation from the sessions list query, so the card's numbers always match the sessions table. Top domains are a new server-side aggregation (`GetAIBridgeSessionTopDomains`) over boundary logs, using the same interception-window correlation. There is no network-error state, matching the current data model.

Refs AIGOV-463

🤖 Generated with [Claude Code](https://claude.com/claude-code)