### PR TITLE
chore(dogfood): trust mise configs in mux worktrees

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -662,8 +662,8 @@ resource "coder_script" "install-deps" {
       cat > "$TRUST_FILE" <<'TRUST'
     # mise trust paths for the dogfood workspace. Edit to add your own
     # paths; this file lives on the persistent home volume so changes
-    # survive workspace restart. The install-deps coder_script only
-    # writes this file when it's absent.
+    # survive workspace restart. The install-deps coder_script seeds
+    # this file when absent and backfills new default paths in place.
     [settings]
     trusted_config_paths = [
       "/home/coder/coder",
@@ -673,6 +673,11 @@ resource "coder_script" "install-deps" {
       "/home/coder/.mux/src",
     ]
     TRUST
+    elif ! grep -qF '/home/coder/.mux/src' "$TRUST_FILE"; then
+      # Backfill the Mux path into trust files seeded before it was added.
+      # Only matches the seeded multi-line layout; users who reshaped the
+      # file keep full ownership of its contents.
+      sed -i 's|^trusted_config_paths = \[$|&\n  "/home/coder/.mux/src",|' "$TRUST_FILE"
     fi
 
     # Install playwright dependencies

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -668,6 +668,9 @@ resource "coder_script" "install-deps" {
     trusted_config_paths = [
       "/home/coder/coder",
       "/etc/mise",
+      # Mux worktrees carry the repo's mise.toml; untrusted configs make
+      # mise shims hang on an interactive trust prompt in fresh worktrees.
+      "/home/coder/.mux/src",
     ]
     TRUST
     fi

--- a/dogfood/coder/ubuntu-22.04/Dockerfile.base
+++ b/dogfood/coder/ubuntu-22.04/Dockerfile.base
@@ -204,6 +204,9 @@ COPY --chmod=0644 <<'EOF' /etc/mise/conf.d/00-coder-trust.toml
 trusted_config_paths = [
   "/home/coder/coder",
   "/etc/mise",
+  # Mux worktrees carry the repo's mise.toml; untrusted configs make
+  # mise shims hang on an interactive trust prompt in fresh worktrees.
+  "/home/coder/.mux/src",
 ]
 EOF
 

--- a/dogfood/coder/ubuntu-26.04/Dockerfile.base
+++ b/dogfood/coder/ubuntu-26.04/Dockerfile.base
@@ -214,6 +214,9 @@ COPY --chmod=0644 <<'EOF' /etc/mise/conf.d/00-coder-trust.toml
 trusted_config_paths = [
   "/home/coder/coder",
   "/etc/mise",
+  # Mux worktrees carry the repo's mise.toml; untrusted configs make
+  # mise shims hang on an interactive trust prompt in fresh worktrees.
+  "/home/coder/.mux/src",
 ]
 EOF
 


### PR DESCRIPTION
> This PR was authored by Mux, an AI coding agent, acting on Mike's behalf.

## Summary

Add `/home/coder/.mux/src` to the dogfood mise `trusted_config_paths` defaults so mise configs in Mux-managed worktrees are trusted out of the box.

## Background

Mux creates a fresh worktree per workspace under `~/.mux/src/<project>/<branch>`. For repos that ship a `mise.toml` (like this one), every fresh worktree is an untrusted mise config directory:

- With a TTY, any mise shim or `mise exec` (e.g. `make lint` targets) blocks forever on the interactive `mise trust` prompt. When output is captured, the prompt is invisible and looks like a deadlock.
- Without a TTY, it fails with `Config files ... are not trusted`.

Either way, each new worktree needs a manual `mise trust` before builds work.

## Implementation

The trust list is defined in three places that must stay in lockstep: the `/etc/mise/conf.d/00-coder-trust.toml` fallback baked into both `Dockerfile.base` images, and the user-owned `~/.config/mise/conf.d/00-coder-trust.toml` seeded by the `install-deps` script in `main.tf` (mise does not merge `trusted_config_paths` across config layers). All three get the new path.

For home volumes that already have the seeded trust file, `install-deps` now backfills the Mux path into the existing `trusted_config_paths` array (guarded by a grep so it runs once). The backfill only matches the seeded multi-line layout; files reshaped by the user are left untouched.

## Validation

Verified on a dogfood workspace: with `/home/coder/.mux/src` in `trusted_config_paths`, a fresh directory under `~/.mux/src/coder/` containing this repo's `mise.toml` reports `trusted` from `mise trust --show`, and a mise shim invocation under a PTY that previously hung on the trust prompt returns immediately.

The trust-file block was extracted from the template (with the heredoc indent stripped, matching the rendered script) and executed against three fixtures: a pre-change seeded file (backfill inserts the path once, idempotent on re-run), a missing file (seeds the new default list), and a user-reshaped single-line file (left unmodified).

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$6.34`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=6.34 -->
