### PR TITLE
chore(scripts/releaser): remove GPG signing key check

### DIFF
--- a/scripts/releaser/executor.go
+++ b/scripts/releaser/executor.go
@@ -18,8 +18,8 @@ import (
 // here. Safe operations (file writes, fetches, editor) are
 // called directly.
 type ReleaseExecutor interface {
-	// CreateTag creates an annotated (optionally signed) git tag.
-	CreateTag(ctx context.Context, tag, ref, message string, sign bool) error
+	// CreateTag creates an annotated git tag.
+	CreateTag(ctx context.Context, tag, ref, message string) error
 	// PushTag pushes a tag to the origin remote.
 	PushTag(ctx context.Context, tag string) error
 	// TriggerWorkflow dispatches the release.yaml GitHub Actions
@@ -30,14 +30,8 @@ type ReleaseExecutor interface {
 // liveExecutor performs real operations.
 type liveExecutor struct{}
 
-//nolint:revive // sign flag is part of the ReleaseExecutor interface contract.
-func (e *liveExecutor) CreateTag(_ context.Context, tag, ref, message string, sign bool) error {
-	args := []string{"tag", "-a"}
-	if sign {
-		args = append(args, "-s")
-	}
-	args = append(args, tag, "-m", message, ref)
-	return gitRun(args...)
+func (*liveExecutor) CreateTag(_ context.Context, tag, ref, message string) error {
+	return gitRun("tag", "-a", tag, "-m", message, ref)
 }
 
 func (*liveExecutor) PushTag(_ context.Context, tag string) error {
@@ -70,13 +64,8 @@ type dryRunExecutor struct {
 	w io.Writer
 }
 
-//nolint:revive // sign flag is part of the ReleaseExecutor interface contract.
-func (e *dryRunExecutor) CreateTag(_ context.Context, tag, ref, message string, sign bool) error {
-	signFlag := ""
-	if sign {
-		signFlag = "-s "
-	}
-	_, _ = fmt.Fprintf(e.w, "[DRYRUN] would run: git tag %s-a %s -m %q %s\n", signFlag, tag, message, ref)
+func (e *dryRunExecutor) CreateTag(_ context.Context, tag, ref, message string) error {
+	_, _ = fmt.Fprintf(e.w, "[DRYRUN] would run: git tag -a %s -m %q %s\n", tag, message, ref)
 	return nil
 }
 

--- a/scripts/releaser/release.go
+++ b/scripts/releaser/release.go
@@ -19,7 +19,7 @@ import (
 )
 
 //nolint:revive // Long function is fine for a sequential release flow.
-func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseExecutor, ghAvailable, gpgConfigured, dryRun bool) error {
+func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseExecutor, ghAvailable, dryRun bool) error {
 	w := inv.Stderr
 
 	// --- Release landscape ---
@@ -767,7 +767,7 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 		if err := confirm(inv, "Create tag?"); err != nil {
 			return xerrors.New("cannot proceed without a tag")
 		}
-		if err := executor.CreateTag(ctx, newVersion.String(), ref, "Release "+newVersion.String(), gpgConfigured); err != nil {
+		if err := executor.CreateTag(ctx, newVersion.String(), ref, "Release "+newVersion.String()); err != nil {
 			return xerrors.Errorf("creating tag: %w", err)
 		}
 		successf(w, "Tag %s created.", newVersion)

--- a/scripts/releaser/run.go
+++ b/scripts/releaser/run.go
@@ -6,7 +6,6 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/coder/coder/v2/cli/cliui"
 	"github.com/coder/serpent"
 )
 
@@ -17,10 +16,9 @@ const (
 
 // Run executes the interactive release wizard.
 //
-// It verifies dependencies, warns when GPG signing or the gh CLI are not
-// configured, wires up a live or dry-run executor, and then walks the
-// operator through tagging, pushing, and triggering the release
-// workflow.
+// It verifies dependencies, warns when the gh CLI is not configured, wires
+// up a live or dry-run executor, and then walks the operator through
+// tagging, pushing, and triggering the release workflow.
 //
 //nolint:revive // dryRun selects the dry-run executor for the wizard.
 func Run(inv *serpent.Invocation, dryRun bool) error {
@@ -30,19 +28,6 @@ func Run(inv *serpent.Invocation, dryRun bool) error {
 	// --- Check dependencies ---
 	if _, err := exec.LookPath("git"); err != nil {
 		return xerrors.New("git is required but not found in PATH")
-	}
-
-	// --- Check GPG signing ---
-	signingKey, _ := gitOutput("config", "--get", "user.signingkey")
-	gpgFormat, _ := gitOutput("config", "--get", "gpg.format")
-	gpgConfigured := signingKey != "" || gpgFormat != ""
-	if !gpgConfigured {
-		warnf(w, "GPG signing is not configured. Tags will be unsigned, so there will be no way to verify who pushed the tag.")
-		_, _ = fmt.Fprintf(w, "  To fix: set git config user.signingkey or gpg.format\n")
-		if err := confirmWithDefault(inv, "Continue without signing?", cliui.ConfirmNo); err != nil {
-			return err
-		}
-		_, _ = fmt.Fprintln(w)
 	}
 
 	// --- Check gh CLI auth ---
@@ -62,5 +47,5 @@ func Run(inv *serpent.Invocation, dryRun bool) error {
 		executor = &liveExecutor{}
 	}
 
-	return runRelease(ctx, inv, executor, ghAvailable, gpgConfigured, dryRun)
+	return runRelease(ctx, inv, executor, ghAvailable, dryRun)
 }


### PR DESCRIPTION
## Summary

Removes the GPG signing key check from the release wizard. The preflight check warned and prompted "Continue without signing?" when GPG signing was not configured, and the same `gpgConfigured` value gated whether the release tag was signed. Both are removed; release tags are now plain annotated tags (`git tag -a`).

## Changes

- Remove the GPG preflight check and `gpgConfigured` plumbing from `run.go` and `runRelease` in `release.go`.
- Drop the `sign` parameter from `ReleaseExecutor.CreateTag` and both implementations (`liveExecutor` no longer appends `-s`).

## Validation

- `go build ./scripts/releaser/...`
- `go test ./scripts/releaser/...`
- `go vet` + `golangci-lint run ./scripts/releaser/...`
- `gofmt -l` clean

> [!IMPORTANT]
> Stacked on top of #27421 (base branch `remove-releaser-v2`). Review/merge that PR first, then retarget this one to `main`.

---
Generated by Coder Agents on behalf of @f0ssel.
