### PR TITLE
fix(coderd): preserve signed reasoning during provider-switch sanitization

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -3445,6 +3445,13 @@ func (q *querier) GetChatModelConfigByID(ctx context.Context, id uuid.UUID) (dat
 	return q.db.GetChatModelConfigByID(ctx, id)
 }
 
+func (q *querier) GetChatModelConfigByIDIncludeDeleted(ctx context.Context, id uuid.UUID) (database.ChatModelConfig, error) {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceDeploymentConfig); err != nil {
+		return database.ChatModelConfig{}, err
+	}
+	return q.db.GetChatModelConfigByIDIncludeDeleted(ctx, id)
+}
+
 func (q *querier) GetChatModelConfigs(ctx context.Context) ([]database.ChatModelConfig, error) {
 	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceDeploymentConfig); err != nil {
 		return nil, err

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -1121,6 +1121,11 @@ func (s *MethodTestSuite) TestChats() {
 		dbm.EXPECT().GetChatModelConfigByID(gomock.Any(), config.ID).Return(config, nil).AnyTimes()
 		check.Args(config.ID).Asserts(rbac.ResourceDeploymentConfig, policy.ActionRead).Returns(config)
 	}))
+	s.Run("GetChatModelConfigByIDIncludeDeleted", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		config := testutil.Fake(s.T(), faker, database.ChatModelConfig{})
+		dbm.EXPECT().GetChatModelConfigByIDIncludeDeleted(gomock.Any(), config.ID).Return(config, nil).AnyTimes()
+		check.Args(config.ID).Asserts(rbac.ResourceDeploymentConfig, policy.ActionRead).Returns(config)
+	}))
 	s.Run("GetDefaultChatModelConfig", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		config := testutil.Fake(s.T(), faker, database.ChatModelConfig{})
 		dbm.EXPECT().GetDefaultChatModelConfig(gomock.Any()).Return(config, nil).AnyTimes()

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -1697,6 +1697,14 @@ func (m queryMetricsStore) GetChatModelConfigByID(ctx context.Context, id uuid.U
 	return r0, r1
 }
 
+func (m queryMetricsStore) GetChatModelConfigByIDIncludeDeleted(ctx context.Context, id uuid.UUID) (database.ChatModelConfig, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetChatModelConfigByIDIncludeDeleted(ctx, id)
+	m.queryLatencies.WithLabelValues("GetChatModelConfigByIDIncludeDeleted").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetChatModelConfigByIDIncludeDeleted").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) GetChatModelConfigs(ctx context.Context) ([]database.ChatModelConfig, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetChatModelConfigs(ctx)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -3133,6 +3133,21 @@ func (mr *MockStoreMockRecorder) GetChatModelConfigByID(ctx, id any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatModelConfigByID", reflect.TypeOf((*MockStore)(nil).GetChatModelConfigByID), ctx, id)
 }
 
+// GetChatModelConfigByIDIncludeDeleted mocks base method.
+func (m *MockStore) GetChatModelConfigByIDIncludeDeleted(ctx context.Context, id uuid.UUID) (database.ChatModelConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetChatModelConfigByIDIncludeDeleted", ctx, id)
+	ret0, _ := ret[0].(database.ChatModelConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetChatModelConfigByIDIncludeDeleted indicates an expected call of GetChatModelConfigByIDIncludeDeleted.
+func (mr *MockStoreMockRecorder) GetChatModelConfigByIDIncludeDeleted(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatModelConfigByIDIncludeDeleted", reflect.TypeOf((*MockStore)(nil).GetChatModelConfigByIDIncludeDeleted), ctx, id)
+}
+
 // GetChatModelConfigs mocks base method.
 func (m *MockStore) GetChatModelConfigs(ctx context.Context) ([]database.ChatModelConfig, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -452,6 +452,10 @@ type sqlcQuerier interface {
 	GetChatMessagesByRevisionForStream(ctx context.Context, arg GetChatMessagesByRevisionForStreamParams) ([]ChatMessage, error)
 	GetChatMessagesForPromptByChatID(ctx context.Context, chatID uuid.UUID) ([]ChatMessage, error)
 	GetChatModelConfigByID(ctx context.Context, id uuid.UUID) (ChatModelConfig, error)
+	// Returns the config even when soft-deleted. Historical chat messages keep
+	// referencing configs that a model re-sync has since deleted, and replay
+	// sanitization needs the producing provider identity for those rows.
+	GetChatModelConfigByIDIncludeDeleted(ctx context.Context, id uuid.UUID) (ChatModelConfig, error)
 	GetChatModelConfigs(ctx context.Context) ([]ChatModelConfig, error)
 	// Returns all model configurations for telemetry snapshot collection.
 	// deleted = false guarantees ai_provider_id is non-null, so INNER JOIN is safe.

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -17296,3 +17296,27 @@ func requireAIGatewayKeysViolation(
 		require.FailNow(t, "test case must expect a constraint error")
 	}
 }
+
+func TestGetChatModelConfigByIDIncludeDeleted(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	db, _ := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitMedium)
+	cfg := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
+		Model:   "test-model",
+		Enabled: true,
+	})
+
+	require.NoError(t, db.DeleteChatModelConfigByID(ctx, cfg.ID))
+
+	_, err := db.GetChatModelConfigByID(ctx, cfg.ID)
+	require.ErrorIs(t, err, sql.ErrNoRows)
+
+	got, err := db.GetChatModelConfigByIDIncludeDeleted(ctx, cfg.ID)
+	require.NoError(t, err)
+	require.True(t, got.Deleted)
+	require.Equal(t, cfg.AIProviderID, got.AIProviderID)
+}

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -5529,6 +5529,41 @@ func (q *sqlQuerier) GetChatModelConfigByID(ctx context.Context, id uuid.UUID) (
 	return i, err
 }
 
+const getChatModelConfigByIDIncludeDeleted = `-- name: GetChatModelConfigByIDIncludeDeleted :one
+SELECT
+    id, model, display_name, created_by, updated_by, enabled, is_default, deleted, deleted_at, created_at, updated_at, context_limit, compression_threshold, options, ai_provider_id
+FROM
+    chat_model_configs
+WHERE
+    id = $1::uuid
+`
+
+// Returns the config even when soft-deleted. Historical chat messages keep
+// referencing configs that a model re-sync has since deleted, and replay
+// sanitization needs the producing provider identity for those rows.
+func (q *sqlQuerier) GetChatModelConfigByIDIncludeDeleted(ctx context.Context, id uuid.UUID) (ChatModelConfig, error) {
+	row := q.db.QueryRowContext(ctx, getChatModelConfigByIDIncludeDeleted, id)
+	var i ChatModelConfig
+	err := row.Scan(
+		&i.ID,
+		&i.Model,
+		&i.DisplayName,
+		&i.CreatedBy,
+		&i.UpdatedBy,
+		&i.Enabled,
+		&i.IsDefault,
+		&i.Deleted,
+		&i.DeletedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.ContextLimit,
+		&i.CompressionThreshold,
+		&i.Options,
+		&i.AIProviderID,
+	)
+	return i, err
+}
+
 const getChatModelConfigs = `-- name: GetChatModelConfigs :many
 SELECT
     cmc.id, cmc.model, cmc.display_name, cmc.created_by, cmc.updated_by, cmc.enabled, cmc.is_default, cmc.deleted, cmc.deleted_at, cmc.created_at, cmc.updated_at, cmc.context_limit, cmc.compression_threshold, cmc.options, cmc.ai_provider_id

--- a/coderd/database/queries/chatmodelconfigs.sql
+++ b/coderd/database/queries/chatmodelconfigs.sql
@@ -7,6 +7,17 @@ WHERE
     id = @id::uuid
     AND deleted = FALSE;
 
+-- Returns the config even when soft-deleted. Historical chat messages keep
+-- referencing configs that a model re-sync has since deleted, and replay
+-- sanitization needs the producing provider identity for those rows.
+-- name: GetChatModelConfigByIDIncludeDeleted :one
+SELECT
+    *
+FROM
+    chat_model_configs
+WHERE
+    id = @id::uuid;
+
 -- name: GetDefaultChatModelConfig :one
 SELECT
     *

--- a/coderd/x/chatd/chatprompt/chatprompt.go
+++ b/coderd/x/chatd/chatprompt/chatprompt.go
@@ -1184,6 +1184,27 @@ func isFantasyEnvelopeFormat(raw json.RawMessage) bool {
 	return len(trimmed) > 0 && trimmed[0] == '{'
 }
 
+// PartsHaveAnthropicSignedReasoning reports whether any reasoning part
+// carries Anthropic signed or redacted reasoning metadata. Reasoning
+// metadata that fails to decode counts as signed: callers use this to
+// guard replay-immutable content, so an undecodable part must fail
+// closed rather than lose its protection.
+func PartsHaveAnthropicSignedReasoning(logger slog.Logger, parts []codersdk.ChatMessagePart) bool {
+	for _, part := range parts {
+		if part.Type != codersdk.ChatMessagePartTypeReasoning {
+			continue
+		}
+		if len(part.ProviderMetadata) == 0 {
+			continue
+		}
+		opts := providerMetadataToOptions(logger, part.ProviderMetadata)
+		if opts == nil || chatsanitize.HasAnthropicSignedReasoningOptions(opts) {
+			return true
+		}
+	}
+	return false
+}
+
 // marshalProviderMetadata converts fantasy provider metadata to raw
 // JSON for storage in SDK parts.
 func marshalProviderMetadata(metadata fantasy.ProviderMetadata) json.RawMessage {

--- a/coderd/x/chatd/generation_preparer.go
+++ b/coderd/x/chatd/generation_preparer.go
@@ -222,7 +222,7 @@ func (server *Server) prepareGeneration(
 	// (e.g. Bedrock and Anthropic) can still reject the other's
 	// provider-executed blocks, so a mid-chat provider switch must not replay
 	// them.
-	promptRows = server.sanitizeForeignProviderExecutedToolRows(ctx, logger, promptRows, modelConfig.ID)
+	promptRows = server.sanitizeForeignProviderExecutedToolRows(ctx, logger, promptRows, modelConfig.ID, model.Provider())
 
 	if chat.WorkspaceID.Valid {
 		// Resolve the workspace agent so the chat row's AgentID and

--- a/coderd/x/chatd/provider_switch_sanitize.go
+++ b/coderd/x/chatd/provider_switch_sanitize.go
@@ -3,6 +3,7 @@ package chatd
 import (
 	"context"
 
+	fantasyanthropic "charm.land/fantasy/providers/anthropic"
 	"github.com/google/uuid"
 
 	"cdr.dev/slog/v3"
@@ -17,6 +18,7 @@ type providerSwitchStripStats struct {
 	RemovedToolCalls   int
 	RemovedToolResults int
 	DroppedMessages    int
+	ProtectedRows      int
 }
 
 // modelConfigProviderIdentity returns a stable identity for the upstream provider
@@ -38,24 +40,44 @@ func modelConfigProviderIdentity(modelConfig database.ChatModelConfig, normalize
 // (fail closed). Rows emptied by stripping are dropped; rows that fail to parse
 // or re-marshal are kept unchanged.
 //
+// When protectSignedReasoningRun is non-nil and reports signed reasoning in
+// the trailing run of consecutive assistant rows, no row in that run is
+// stripped: those rows serialize into the latest assistant message on the
+// wire, and Anthropic rejects any request whose latest assistant message
+// differs from the original response. A row in that run that fails to parse
+// also protects the run, since its content cannot be ruled out as signed.
+//
 // See modelConfigProviderIdentity for how identity is derived.
 func stripForeignProviderExecutedToolRows(
 	rows []database.ChatMessage,
 	targetIdentity string,
-	originProvider func(uuid.NullUUID) (string, bool),
+	originIdentity func(uuid.NullUUID) (string, bool),
+	protectSignedReasoningRun func([]codersdk.ChatMessagePart) bool,
 ) ([]database.ChatMessage, providerSwitchStripStats) {
 	var stats providerSwitchStripStats
 	if targetIdentity == "" || len(rows) == 0 {
 		return rows, stats
 	}
 
+	runStart, runEnd := latestAssistantRunBounds(rows)
+	protectedRun := false
+	if protectSignedReasoningRun != nil && runEnd >= 0 {
+		for i := runStart; i <= runEnd; i++ {
+			parts, err := chatprompt.ParseContent(rows[i])
+			if err != nil || protectSignedReasoningRun(parts) {
+				protectedRun = true
+				break
+			}
+		}
+	}
+
 	out := make([]database.ChatMessage, 0, len(rows))
-	for _, row := range rows {
+	for rowIndex, row := range rows {
 		if row.Role != database.ChatMessageRoleAssistant {
 			out = append(out, row)
 			continue
 		}
-		if origin, ok := originProvider(row.ModelConfigID); ok && origin == targetIdentity {
+		if origin, ok := originIdentity(row.ModelConfigID); ok && origin == targetIdentity {
 			out = append(out, row)
 			continue
 		}
@@ -82,6 +104,11 @@ func stripForeignProviderExecutedToolRows(
 			out = append(out, row)
 			continue
 		}
+		if protectedRun && rowIndex >= runStart && rowIndex <= runEnd {
+			stats.ProtectedRows++
+			out = append(out, row)
+			continue
+		}
 		stats.RemovedToolCalls += removedCalls
 		stats.RemovedToolResults += removedResults
 		if len(kept) == 0 {
@@ -101,11 +128,59 @@ func stripForeignProviderExecutedToolRows(
 	return out, stats
 }
 
+// originProviderIdentity derives the producing provider identity for a
+// historical assistant row's config. Unlike target resolution, it ignores
+// enabled/deleted state: a soft-deleted config still records which provider
+// instance produced the row. Legacy configs without a provider FK stay
+// unresolved (fail closed).
+func originProviderIdentity(cfg database.ChatModelConfig) string {
+	if cfg.AIProviderID.Valid {
+		return cfg.AIProviderID.UUID.String()
+	}
+	return ""
+}
+
+// latestAssistantRunBounds returns the inclusive bounds of the trailing run
+// of consecutive assistant rows containing the last assistant row, or
+// (-1, -1) when no assistant row exists. Consecutive assistant rows merge
+// into a single assistant message when serialized for Anthropic, so the
+// whole run forms the latest assistant message on the wire.
+func latestAssistantRunBounds(rows []database.ChatMessage) (start, end int) {
+	runEnd := -1
+	for i := len(rows) - 1; i >= 0; i-- {
+		if rows[i].Role == database.ChatMessageRoleAssistant {
+			runEnd = i
+			break
+		}
+	}
+	if runEnd < 0 {
+		return -1, -1
+	}
+	runStart := runEnd
+	for runStart > 0 && rows[runStart-1].Role == database.ChatMessageRoleAssistant {
+		runStart--
+	}
+	return runStart, runEnd
+}
+
+// signedReasoningRunProtection returns the latest-assistant-run protection
+// predicate for Anthropic wire targets and nil for every other provider,
+// where Anthropic replay validation does not apply.
+func signedReasoningRunProtection(wireProvider string, logger slog.Logger) func([]codersdk.ChatMessagePart) bool {
+	if wireProvider != fantasyanthropic.Name {
+		return nil
+	}
+	return func(parts []codersdk.ChatMessagePart) bool {
+		return chatprompt.PartsHaveAnthropicSignedReasoning(logger, parts)
+	}
+}
+
 func (server *Server) sanitizeForeignProviderExecutedToolRows(
 	ctx context.Context,
 	logger slog.Logger,
 	rows []database.ChatMessage,
 	modelConfigID uuid.UUID,
+	wireProvider string,
 ) []database.ChatMessage {
 	targetCfg, targetProvider, err := server.resolveModelConfigAndNormalizedProvider(ctx, modelConfigID)
 	if err != nil || targetProvider == "" {
@@ -118,14 +193,14 @@ func (server *Server) sanitizeForeignProviderExecutedToolRows(
 	targetIdentity := modelConfigProviderIdentity(targetCfg, targetProvider)
 
 	cache := make(map[uuid.UUID]string)
-	originProvider := func(id uuid.NullUUID) (string, bool) {
+	originIdentity := func(id uuid.NullUUID) (string, bool) {
 		if !id.Valid {
 			return "", false
 		}
 		if identity, seen := cache[id.UUID]; seen {
 			return identity, identity != ""
 		}
-		originCfg, provider, rErr := server.resolveModelConfigAndNormalizedProvider(ctx, id.UUID)
+		originCfg, rErr := server.db.GetChatModelConfigByIDIncludeDeleted(ctx, id.UUID)
 		if rErr != nil {
 			logger.Debug(ctx, "provider-switch sanitization: origin provider unresolved, treating as foreign",
 				slog.F("model_config_id", id.UUID),
@@ -134,12 +209,21 @@ func (server *Server) sanitizeForeignProviderExecutedToolRows(
 			cache[id.UUID] = ""
 			return "", false
 		}
-		identity := modelConfigProviderIdentity(originCfg, provider)
+		identity := originProviderIdentity(originCfg)
 		cache[id.UUID] = identity
 		return identity, identity != ""
 	}
 
-	sanitized, stats := stripForeignProviderExecutedToolRows(rows, targetIdentity, originProvider)
+	protectSignedReasoningRun := signedReasoningRunProtection(wireProvider, logger)
+
+	sanitized, stats := stripForeignProviderExecutedToolRows(rows, targetIdentity, originIdentity, protectSignedReasoningRun)
+	if stats.ProtectedRows > 0 {
+		logger.Warn(ctx, "kept foreign provider-executed tool history in latest signed assistant run",
+			slog.F("phase", "provider_switch"),
+			slog.F("target_provider_identity", targetIdentity),
+			slog.F("protected_rows", stats.ProtectedRows),
+		)
+	}
 	if stats != (providerSwitchStripStats{}) {
 		logger.Debug(ctx, "stripped foreign provider-executed tool history",
 			slog.F("phase", "provider_switch"),

--- a/coderd/x/chatd/provider_switch_sanitize_internal_test.go
+++ b/coderd/x/chatd/provider_switch_sanitize_internal_test.go
@@ -4,10 +4,13 @@ import (
 	"encoding/json"
 	"testing"
 
+	"charm.land/fantasy"
+	fantasyanthropic "charm.land/fantasy/providers/anthropic"
 	"github.com/google/uuid"
 	"github.com/sqlc-dev/pqtype"
 	"github.com/stretchr/testify/require"
 
+	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
 	"github.com/coder/coder/v2/codersdk"
@@ -95,7 +98,7 @@ func TestStripForeignProviderExecutedToolRows(t *testing.T) {
 			userRow(t, "hi"),
 			assistantRow(t, anthropicCfg, peCall("ws"), peResult("ws"), text("done")),
 		}
-		got, stats := stripForeignProviderExecutedToolRows(rows, anthropic, resolver)
+		got, stats := stripForeignProviderExecutedToolRows(rows, anthropic, resolver, nil)
 		require.Equal(t, rows, got)
 		require.Zero(t, stats)
 	})
@@ -106,7 +109,7 @@ func TestStripForeignProviderExecutedToolRows(t *testing.T) {
 			userRow(t, "hi"),
 			assistantRow(t, anthropicCfg, peCall("ws"), peResult("ws"), text("done")),
 		}
-		got, stats := stripForeignProviderExecutedToolRows(rows, bedrock, resolver)
+		got, stats := stripForeignProviderExecutedToolRows(rows, bedrock, resolver, nil)
 		require.Len(t, got, 2)
 		require.Equal(t, []codersdk.ChatMessagePart{text("done")}, partsOf(t, got[1]))
 		require.Equal(t, providerSwitchStripStats{RemovedToolCalls: 1, RemovedToolResults: 1}, stats)
@@ -119,7 +122,7 @@ func TestStripForeignProviderExecutedToolRows(t *testing.T) {
 			assistantRow(t, anthropicCfg, peCall("ws")),
 			userRow(t, "again"),
 		}
-		got, stats := stripForeignProviderExecutedToolRows(rows, bedrock, resolver)
+		got, stats := stripForeignProviderExecutedToolRows(rows, bedrock, resolver, nil)
 		require.Len(t, got, 2)
 		require.Equal(t, database.ChatMessageRoleUser, got[0].Role)
 		require.Equal(t, database.ChatMessageRoleUser, got[1].Role)
@@ -132,7 +135,7 @@ func TestStripForeignProviderExecutedToolRows(t *testing.T) {
 			assistantRow(t, openAICfg, peCall("os"), peResult("os"), text("openai")),
 			assistantRow(t, anthropicCfg, peCall("as"), peResult("as"), text("anthropic")),
 		}
-		got, stats := stripForeignProviderExecutedToolRows(rows, anthropic, resolver)
+		got, stats := stripForeignProviderExecutedToolRows(rows, anthropic, resolver, nil)
 		require.Len(t, got, 2)
 		require.Equal(t, []codersdk.ChatMessagePart{text("openai")}, partsOf(t, got[0]))
 		require.Equal(t, rows[1], got[1])
@@ -144,7 +147,7 @@ func TestStripForeignProviderExecutedToolRows(t *testing.T) {
 		rows := []database.ChatMessage{
 			assistantRow(t, anthropicCfg, text("hello"), localCall("local")),
 		}
-		got, stats := stripForeignProviderExecutedToolRows(rows, bedrock, resolver)
+		got, stats := stripForeignProviderExecutedToolRows(rows, bedrock, resolver, nil)
 		require.Equal(t, rows, got)
 		require.Zero(t, stats)
 	})
@@ -154,7 +157,7 @@ func TestStripForeignProviderExecutedToolRows(t *testing.T) {
 		rows := []database.ChatMessage{
 			assistantRow(t, anthropicCfg, peCall("ws"), peResult("ws")),
 		}
-		got, stats := stripForeignProviderExecutedToolRows(rows, "", resolver)
+		got, stats := stripForeignProviderExecutedToolRows(rows, "", resolver, nil)
 		require.Equal(t, rows, got)
 		require.Zero(t, stats)
 	})
@@ -164,7 +167,7 @@ func TestStripForeignProviderExecutedToolRows(t *testing.T) {
 		rows := []database.ChatMessage{
 			assistantRow(t, unknownCfg, peResult("ws"), text("done")),
 		}
-		got, stats := stripForeignProviderExecutedToolRows(rows, bedrock, resolver)
+		got, stats := stripForeignProviderExecutedToolRows(rows, bedrock, resolver, nil)
 		require.Len(t, got, 1)
 		require.Equal(t, []codersdk.ChatMessagePart{text("done")}, partsOf(t, got[0]))
 		require.Equal(t, providerSwitchStripStats{RemovedToolResults: 1}, stats)
@@ -178,7 +181,7 @@ func TestStripForeignProviderExecutedToolRows(t *testing.T) {
 			Content:        pqtype.NullRawMessage{RawMessage: []byte("{not json"), Valid: true},
 			ContentVersion: chatprompt.ContentVersionV1,
 		}}
-		got, stats := stripForeignProviderExecutedToolRows(rows, bedrock, resolver)
+		got, stats := stripForeignProviderExecutedToolRows(rows, bedrock, resolver, nil)
 		require.Equal(t, rows, got)
 		require.Zero(t, stats)
 	})
@@ -189,7 +192,7 @@ func TestStripForeignProviderExecutedToolRows(t *testing.T) {
 			userRow(t, "hi"),
 			assistantRow(t, vllmCfg, peCall("ws"), peResult("ws"), text("done")),
 		}
-		got, stats := stripForeignProviderExecutedToolRows(rows, togetherProviderID.String(), resolver)
+		got, stats := stripForeignProviderExecutedToolRows(rows, togetherProviderID.String(), resolver, nil)
 		require.Len(t, got, 2)
 		require.Equal(t, []codersdk.ChatMessagePart{text("done")}, partsOf(t, got[1]))
 		require.Equal(t, providerSwitchStripStats{RemovedToolCalls: 1, RemovedToolResults: 1}, stats)
@@ -201,10 +204,149 @@ func TestStripForeignProviderExecutedToolRows(t *testing.T) {
 			userRow(t, "hi"),
 			assistantRow(t, vllmCfg, peCall("ws"), peResult("ws"), text("done")),
 		}
-		got, stats := stripForeignProviderExecutedToolRows(rows, vllmProviderID.String(), resolver)
+		got, stats := stripForeignProviderExecutedToolRows(rows, vllmProviderID.String(), resolver, nil)
 		require.Equal(t, rows, got)
 		require.Zero(t, stats)
 	})
+
+	signedReasoning := func(t *testing.T) codersdk.ChatMessagePart {
+		t.Helper()
+		metadata, err := json.Marshal(fantasy.ProviderMetadata{
+			fantasyanthropic.Name: &fantasyanthropic.ReasoningOptionMetadata{
+				Signature: "sig-1",
+			},
+		})
+		require.NoError(t, err)
+		p := codersdk.ChatMessageReasoning("thinking")
+		p.ProviderMetadata = metadata
+		return p
+	}
+	signedRunPredicate := func(parts []codersdk.ChatMessagePart) bool {
+		return chatprompt.PartsHaveAnthropicSignedReasoning(slogtest.Make(t, nil), parts)
+	}
+
+	t.Run("signed reasoning protects latest assistant run", func(t *testing.T) {
+		t.Parallel()
+		rows := []database.ChatMessage{
+			userRow(t, "hi"),
+			assistantRow(t, unknownCfg, signedReasoning(t), peCall("ws"), peResult("ws"), text("done")),
+		}
+		got, stats := stripForeignProviderExecutedToolRows(rows, bedrock, resolver, signedRunPredicate)
+		require.Equal(t, rows, got)
+		require.Equal(t, providerSwitchStripStats{ProtectedRows: 1}, stats)
+	})
+
+	t.Run("signed run protects adjacent trailing assistant rows", func(t *testing.T) {
+		t.Parallel()
+		rows := []database.ChatMessage{
+			userRow(t, "hi"),
+			assistantRow(t, unknownCfg, peCall("a"), peResult("a"), text("step1")),
+			assistantRow(t, unknownCfg, signedReasoning(t), text("step2")),
+		}
+		got, stats := stripForeignProviderExecutedToolRows(rows, bedrock, resolver, signedRunPredicate)
+		require.Equal(t, rows, got)
+		require.Equal(t, providerSwitchStripStats{ProtectedRows: 1}, stats)
+	})
+
+	t.Run("signed row outside latest run still stripped", func(t *testing.T) {
+		t.Parallel()
+		rows := []database.ChatMessage{
+			assistantRow(t, unknownCfg, signedReasoning(t), peCall("old"), text("old")),
+			userRow(t, "mid"),
+			assistantRow(t, unknownCfg, text("new")),
+		}
+		got, stats := stripForeignProviderExecutedToolRows(rows, bedrock, resolver, signedRunPredicate)
+		require.Len(t, got, 3)
+		require.Len(t, partsOf(t, got[0]), 2)
+		require.Equal(t, providerSwitchStripStats{RemovedToolCalls: 1}, stats)
+	})
+
+	t.Run("nil predicate strips signed run", func(t *testing.T) {
+		t.Parallel()
+		rows := []database.ChatMessage{
+			userRow(t, "hi"),
+			assistantRow(t, unknownCfg, signedReasoning(t), peCall("ws"), peResult("ws"), text("done")),
+		}
+		got, stats := stripForeignProviderExecutedToolRows(rows, bedrock, resolver, nil)
+		require.Len(t, got, 2)
+		require.Len(t, partsOf(t, got[1]), 2)
+		require.Equal(t, providerSwitchStripStats{RemovedToolCalls: 1, RemovedToolResults: 1}, stats)
+	})
+
+	t.Run("redacted reasoning protects latest assistant run", func(t *testing.T) {
+		t.Parallel()
+		metadata, err := json.Marshal(fantasy.ProviderMetadata{
+			fantasyanthropic.Name: &fantasyanthropic.ReasoningOptionMetadata{
+				RedactedData: "redacted-payload",
+			},
+		})
+		require.NoError(t, err)
+		redacted := codersdk.ChatMessagePart{
+			Type:             codersdk.ChatMessagePartTypeReasoning,
+			ProviderMetadata: metadata,
+		}
+		rows := []database.ChatMessage{
+			userRow(t, "hi"),
+			assistantRow(t, unknownCfg, redacted, peCall("ws"), peResult("ws"), text("done")),
+		}
+		got, stats := stripForeignProviderExecutedToolRows(rows, bedrock, resolver, signedRunPredicate)
+		require.Equal(t, rows, got)
+		require.Equal(t, providerSwitchStripStats{ProtectedRows: 1}, stats)
+	})
+
+	t.Run("undecodable reasoning metadata protects run", func(t *testing.T) {
+		t.Parallel()
+		corrupt := codersdk.ChatMessageReasoning("thinking")
+		corrupt.ProviderMetadata = json.RawMessage(`"not-a-metadata-object"`)
+		rows := []database.ChatMessage{
+			userRow(t, "hi"),
+			assistantRow(t, unknownCfg, corrupt, peCall("ws"), peResult("ws"), text("done")),
+		}
+		got, stats := stripForeignProviderExecutedToolRows(rows, bedrock, resolver, signedRunPredicate)
+		require.Equal(t, rows, got)
+		require.Equal(t, providerSwitchStripStats{ProtectedRows: 1}, stats)
+	})
+
+	t.Run("unparseable row in latest run protects run", func(t *testing.T) {
+		t.Parallel()
+		rows := []database.ChatMessage{
+			userRow(t, "hi"),
+			{
+				Role:           database.ChatMessageRoleAssistant,
+				ModelConfigID:  uuid.NullUUID{UUID: unknownCfg, Valid: true},
+				Content:        pqtype.NullRawMessage{RawMessage: []byte("{not json"), Valid: true},
+				ContentVersion: chatprompt.ContentVersionV1,
+			},
+			assistantRow(t, unknownCfg, peCall("ws"), peResult("ws"), text("done")),
+		}
+		got, stats := stripForeignProviderExecutedToolRows(rows, bedrock, resolver, signedRunPredicate)
+		require.Equal(t, rows, got)
+		require.Equal(t, providerSwitchStripStats{ProtectedRows: 1}, stats)
+	})
+}
+
+func TestSignedReasoningRunProtection(t *testing.T) {
+	t.Parallel()
+
+	logger := slogtest.Make(t, nil)
+	require.NotNil(t, signedReasoningRunProtection("anthropic", logger))
+	require.Nil(t, signedReasoningRunProtection("openai", logger))
+	require.Nil(t, signedReasoningRunProtection("bedrock", logger))
+	require.Nil(t, signedReasoningRunProtection("", logger))
+}
+
+func TestOriginProviderIdentityToleratesUnusableConfigs(t *testing.T) {
+	t.Parallel()
+
+	providerID := uuid.New()
+	cfg := database.ChatModelConfig{
+		AIProviderID: uuid.NullUUID{UUID: providerID, Valid: true},
+		Deleted:      true,
+		Enabled:      false,
+	}
+	require.Equal(t, providerID.String(), originProviderIdentity(cfg))
+
+	require.Empty(t, originProviderIdentity(database.ChatModelConfig{Deleted: true}))
 }
 
 func TestModelConfigProviderIdentity(t *testing.T) {


### PR DESCRIPTION
## Problem

Chats (including subagents) on dev.coder.com were permanently stuck with:

```
messages.N.content.M: `thinking` or `redacted_thinking` blocks in the latest
assistant message cannot be modified. These blocks must remain as they were
in the original response.
```

Anthropic validates that the latest assistant message replays byte-for-byte. Production logs and DB state show the failing chats hit this sequence on every generation attempt:

1. Origin lookup for historical assistant rows used `GetChatModelConfigByID`, which filters `deleted = FALSE`. A model-config re-sync had soft-deleted the referenced config row, so resolution failed with `ErrNoRows` even though the row pointed at the same `ai_provider_id` as the active target config.
2. Provider-switch sanitization fails closed: unknown origin means foreign, so it stripped the provider-executed `web_search` tool blocks out of assistant rows, including the latest assistant message carrying signed `thinking` blocks.
3. Anthropic rejected the mutated replay with a 400, deterministically, on every retry.

## Fix

- Resolve origin identity with a new `GetChatModelConfigByIDIncludeDeleted` query and take only `AIProviderID`. A soft-deleted config still records which provider instance produced the row; enabled/deleted/model-resolvability gates are target-usability concerns and stay strict on the target path. Legacy configs without a provider FK remain fail-closed.
- Defense in depth: when the wire provider is Anthropic (`model.Provider()`, so Bedrock-routed Anthropic counts), never strip rows in the trailing run of consecutive assistant rows when that run carries Anthropic signed or redacted reasoning. That run serializes into the latest assistant message on the wire. Rows or reasoning metadata that fail to parse inside the run fail closed and protect it. A WARN log with a `protected_rows` count fires when the protection engages.

Stripping only ever mutated in-memory prompt rows, never DB rows, so already-stuck chats recover on deploy without intervention.

## Testing

- New DB-level test for `GetChatModelConfigByIDIncludeDeleted` (soft-deleted row hidden from the strict query, returned by the new one).
- New unit tests: signed/redacted/undecodable reasoning and unparseable rows protect the latest assistant run; signed rows outside the run still strip; nil predicate (non-Anthropic wire) strips as before; provider gate returns nil for openai/bedrock/empty; origin identity tolerates deleted+disabled configs and stays unresolved without a provider FK.
- Full `coderd/x/chatd`, `chatprompt`, and `dbauthz` suites pass; `make lint` and `make gen` clean.

> This PR was researched and written by Mux, an AI coding agent, on Mike's behalf. Root cause was confirmed against production logs and database state before the fix was written.
