### PR TITLE
feat(site): surface chat lifecycle hook outcomes in the chats UI

### DIFF
--- a/site/src/api/queries/chatMessageEdits.test.ts
+++ b/site/src/api/queries/chatMessageEdits.test.ts
@@ -1,6 +1,10 @@
+import type { InfiniteData } from "react-query";
 import { describe, expect, it } from "vitest";
 import type * as TypesGen from "#/api/typesGenerated";
-import { buildOptimisticEditedMessage } from "./chatMessageEdits";
+import {
+	buildOptimisticEditedMessage,
+	reconcileEditedMessageInCache,
+} from "./chatMessageEdits";
 
 const makeUserMessage = (
 	content: readonly TypesGen.ChatMessagePart[] = [
@@ -40,5 +44,52 @@ describe("buildOptimisticEditedMessage", () => {
 		});
 
 		expect(message.content).toEqual([existingFilePart]);
+	});
+});
+
+describe("reconcileEditedMessageInCache", () => {
+	it("drops messages the edit deleted, such as stale hook notices", () => {
+		const staleNotice: TypesGen.ChatMessage = {
+			id: 2,
+			chat_id: "chat-1",
+			created_at: "2025-01-01T00:00:00.000Z",
+			role: "system",
+			content: [{ type: "text", text: "old hook notice" }],
+		};
+		const newNotice: TypesGen.ChatMessage = {
+			id: 5,
+			chat_id: "chat-1",
+			created_at: "2025-01-01T00:01:00.000Z",
+			role: "system",
+			content: [{ type: "text", text: "new hook notice" }],
+		};
+		const replacement: TypesGen.ChatMessage = {
+			id: 6,
+			chat_id: "chat-1",
+			created_at: "2025-01-01T00:01:00.000Z",
+			role: "user",
+			content: [{ type: "text", text: "edited prompt" }],
+		};
+		const currentData: InfiniteData<TypesGen.ChatMessagesResponse> = {
+			pages: [
+				{
+					messages: [staleNotice, makeUserMessage()],
+					queued_messages: [],
+					has_more: false,
+				},
+			],
+			pageParams: [undefined],
+		};
+
+		const reconciled = reconcileEditedMessageInCache({
+			currentData,
+			optimisticMessageId: 1,
+			responseMessages: [newNotice, replacement],
+			deletedMessageIds: [staleNotice.id, 1],
+		});
+
+		const ids = reconciled?.pages[0]?.messages.map((message) => message.id);
+		// The first page is ordered newest first.
+		expect(ids).toEqual([replacement.id, newNotice.id]);
 	});
 });

--- a/site/src/api/queries/chatMessageEdits.test.ts
+++ b/site/src/api/queries/chatMessageEdits.test.ts
@@ -89,7 +89,7 @@ describe("reconcileEditedMessageInCache", () => {
 		});
 
 		const ids = reconciled?.pages[0]?.messages.map((message) => message.id);
-		// The first page is ordered newest first.
+		// Reversed from responseMessages: the first page is newest first.
 		expect(ids).toEqual([replacement.id, newNotice.id]);
 	});
 });

--- a/site/src/api/queries/chatMessageEdits.ts
+++ b/site/src/api/queries/chatMessageEdits.ts
@@ -122,12 +122,7 @@ export const reconcileEditedMessageInCache = ({
 }: {
 	currentData: InfiniteData<TypesGen.ChatMessagesResponse> | undefined;
 	optimisticMessageId: number;
-	// Every message the edit inserted, in insertion order. All of them
-	// must land in the cache, or a stream reconnect keyed on the
-	// highest cached ID would skip rows around the replacement.
 	responseMessages: readonly TypesGen.ChatMessage[];
-	// Messages the edit soft-deleted. Dropped here so the cache does
-	// not keep them if the history reset event is missed.
 	deletedMessageIds?: readonly number[];
 }): InfiniteData<TypesGen.ChatMessagesResponse> | undefined => {
 	if (!currentData?.pages?.length || responseMessages.length === 0) {

--- a/site/src/api/queries/chatMessageEdits.ts
+++ b/site/src/api/queries/chatMessageEdits.ts
@@ -117,28 +117,40 @@ export const projectEditedConversationIntoCache = ({
 export const reconcileEditedMessageInCache = ({
 	currentData,
 	optimisticMessageId,
-	responseMessage,
+	responseMessages,
+	deletedMessageIds,
 }: {
 	currentData: InfiniteData<TypesGen.ChatMessagesResponse> | undefined;
 	optimisticMessageId: number;
-	responseMessage: TypesGen.ChatMessage;
+	// Every message the edit inserted, in insertion order. All of them
+	// must land in the cache, or a stream reconnect keyed on the
+	// highest cached ID would skip rows around the replacement.
+	responseMessages: readonly TypesGen.ChatMessage[];
+	// Messages the edit soft-deleted. Dropped here so the cache does
+	// not keep them if the history reset event is missed.
+	deletedMessageIds?: readonly number[];
 }): InfiniteData<TypesGen.ChatMessagesResponse> | undefined => {
-	if (!currentData?.pages?.length) {
+	if (!currentData?.pages?.length || responseMessages.length === 0) {
 		return currentData;
 	}
 
+	const responseIDs = new Set(responseMessages.map((message) => message.id));
+	const deletedIDs = new Set(deletedMessageIds ?? []);
 	const replacedPages = currentData.pages.map((page, pageIndex) => {
 		const preservedMessages = page.messages.filter(
 			(message) =>
-				message.id !== optimisticMessageId && message.id !== responseMessage.id,
+				message.id !== optimisticMessageId &&
+				!responseIDs.has(message.id) &&
+				!deletedIDs.has(message.id),
 		);
 		if (pageIndex !== 0) {
 			return { ...page, messages: preservedMessages };
 		}
-		return {
-			...page,
-			messages: upsertFirstPageMessage(preservedMessages, responseMessage),
-		};
+		let messages = preservedMessages;
+		for (const responseMessage of responseMessages) {
+			messages = upsertFirstPageMessage(messages, responseMessage);
+		}
+		return { ...page, messages };
 	});
 
 	return {

--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -1061,37 +1061,6 @@ describe("mutation invalidation scope", () => {
 		).toBe(true);
 	});
 
-	it("editChatMessage onError invalidates messages", async () => {
-		const queryClient = createTestQueryClient();
-		const chatId = "chat-1";
-		const messages = [3, 2, 1].map((id) => makeMsg(chatId, id));
-
-		queryClient.setQueryData<InfMessages>(chatMessagesKey(chatId), {
-			pages: [{ messages, queued_messages: [], has_more: false }],
-			pageParams: [undefined],
-		});
-
-		const mutation = editChatMessage(queryClient, chatId);
-		mutation.onError(
-			new Error("fail"),
-			{ messageId: 2, req: editReq },
-			{
-				previousData: {
-					pages: [{ messages, queued_messages: [], has_more: false }],
-					pageParams: [undefined],
-				},
-			},
-		);
-
-		await new Promise((r) => setTimeout(r, 0));
-
-		const messagesState = queryClient.getQueryState(chatMessagesKey(chatId));
-		expect(
-			messagesState?.isInvalidated,
-			"chatMessagesKey should be invalidated on error",
-		).toBe(true);
-	});
-
 	// Shared type for the infinite messages cache shape used by
 	// editChatMessage tests below.
 	type InfMessages = {
@@ -1137,6 +1106,37 @@ describe("mutation invalidation scope", () => {
 			originalMessage: message,
 			requestContent: editReq.content,
 		});
+
+	it("editChatMessage onError invalidates messages", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		const messages = [3, 2, 1].map((id) => makeMsg(chatId, id));
+
+		queryClient.setQueryData<InfMessages>(chatMessagesKey(chatId), {
+			pages: [{ messages, queued_messages: [], has_more: false }],
+			pageParams: [undefined],
+		});
+
+		const mutation = editChatMessage(queryClient, chatId);
+		mutation.onError(
+			new Error("fail"),
+			{ messageId: 2, req: editReq },
+			{
+				previousData: {
+					pages: [{ messages, queued_messages: [], has_more: false }],
+					pageParams: [undefined],
+				},
+			},
+		);
+
+		await new Promise((r) => setTimeout(r, 0));
+
+		const messagesState = queryClient.getQueryState(chatMessagesKey(chatId));
+		expect(
+			messagesState?.isInvalidated,
+			"chatMessagesKey should be invalidated on error",
+		).toBe(true);
+	});
 
 	it("editChatMessage writes the optimistic replacement into cache", async () => {
 		const queryClient = createTestQueryClient();

--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -1061,6 +1061,37 @@ describe("mutation invalidation scope", () => {
 		).toBe(true);
 	});
 
+	it("editChatMessage onError invalidates messages", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		const messages = [3, 2, 1].map((id) => makeMsg(chatId, id));
+
+		queryClient.setQueryData<InfMessages>(chatMessagesKey(chatId), {
+			pages: [{ messages, queued_messages: [], has_more: false }],
+			pageParams: [undefined],
+		});
+
+		const mutation = editChatMessage(queryClient, chatId);
+		mutation.onError(
+			new Error("fail"),
+			{ messageId: 2, req: editReq },
+			{
+				previousData: {
+					pages: [{ messages, queued_messages: [], has_more: false }],
+					pageParams: [undefined],
+				},
+			},
+		);
+
+		await new Promise((r) => setTimeout(r, 0));
+
+		const messagesState = queryClient.getQueryState(chatMessagesKey(chatId));
+		expect(
+			messagesState?.isInvalidated,
+			"chatMessagesKey should be invalidated on error",
+		).toBe(true);
+	});
+
 	// Shared type for the infinite messages cache shape used by
 	// editChatMessage tests below.
 	type InfMessages = {
@@ -1106,37 +1137,6 @@ describe("mutation invalidation scope", () => {
 			originalMessage: message,
 			requestContent: editReq.content,
 		});
-
-	it("editChatMessage onError invalidates messages", async () => {
-		const queryClient = createTestQueryClient();
-		const chatId = "chat-1";
-		const messages = [3, 2, 1].map((id) => makeMsg(chatId, id));
-
-		queryClient.setQueryData<InfMessages>(chatMessagesKey(chatId), {
-			pages: [{ messages, queued_messages: [], has_more: false }],
-			pageParams: [undefined],
-		});
-
-		const mutation = editChatMessage(queryClient, chatId);
-		mutation.onError(
-			new Error("fail"),
-			{ messageId: 2, req: editReq },
-			{
-				previousData: {
-					pages: [{ messages, queued_messages: [], has_more: false }],
-					pageParams: [undefined],
-				},
-			},
-		);
-
-		await new Promise((r) => setTimeout(r, 0));
-
-		const messagesState = queryClient.getQueryState(chatMessagesKey(chatId));
-		expect(
-			messagesState?.isInvalidated,
-			"chatMessagesKey should be invalidated on error",
-		).toBe(true);
-	});
 
 	it("editChatMessage writes the optimistic replacement into cache", async () => {
 		const queryClient = createTestQueryClient();

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -23,6 +23,9 @@ export const chatMessagesKey = (chatId: string) =>
 export const chatPromptsKey = (chatId: string) =>
 	["chats", chatId, "prompts"] as const;
 
+const chatQueueConvergenceKey = (chatId: string) =>
+	["chats", chatId, "queue-convergence"] as const;
+
 export const chatACLKey = (chatId: string) => ["chats", chatId, "acl"] as const;
 
 export type ChatListPRStatusFilter = "draft" | "open" | "merged" | "closed";
@@ -747,6 +750,15 @@ export const chatACL = (chatId: string) => ({
 });
 
 const MESSAGES_PAGE_SIZE = 50;
+
+// The queued messages ride on the uncursored page of the messages endpoint,
+// so settling the queue after a promote needs its own request. Refetching
+// chatMessagesForInfiniteScroll would reload every page already scrolled.
+export const chatQueueConvergence = (chatId: string) => ({
+	queryKey: chatQueueConvergenceKey(chatId),
+	queryFn: () => API.experimental.getChatMessages(chatId),
+	gcTime: 0,
+});
 
 export const chatMessagesForInfiniteScroll = (chatId: string) => ({
 	queryKey: chatMessagesKey(chatId),

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -1427,7 +1427,8 @@ export const editChatMessage = (queryClient: QueryClient, chatId: string) => ({
 			reconcileEditedMessageInCache({
 				currentData: current,
 				optimisticMessageId: variables.messageId,
-				responseMessage: response.message,
+				responseMessages: response.messages ?? [response.message],
+				deletedMessageIds: response.deleted_message_ids,
 			}),
 		);
 	},

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -2916,14 +2916,14 @@ export const QueuedSendPromotesPreviousHead: Story = {
 			expect(sendSpy).toHaveBeenCalledTimes(1);
 		});
 
-		// The promoted head moves from the queue into the transcript and
-		// the new send replaces it as the only queued row.
+		const timeline = within(await canvas.findByTestId("conversation-timeline"));
 		await waitFor(() => {
+			expect(timeline.getByText("Queued head prompt")).toBeVisible();
 			expect(canvas.getAllByText("Queued head prompt")).toHaveLength(1);
 			expect(canvas.getAllByText("Follow-up prompt")).toHaveLength(1);
+			expect(timeline.queryByText("Follow-up prompt")).not.toBeInTheDocument();
 		});
-		// The promotion started a turn: the Thinking indicator replaces
-		// the stale error state.
+		// Promotion starts a turn, so the Thinking indicator replaces the error.
 		expect(await canvas.findByTestId("live-activity-slot")).toBeVisible();
 	},
 };

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -2923,7 +2923,6 @@ export const QueuedSendPromotesPreviousHead: Story = {
 			expect(canvas.getAllByText("Follow-up prompt")).toHaveLength(1);
 			expect(timeline.queryByText("Follow-up prompt")).not.toBeInTheDocument();
 		});
-		// Promotion starts a turn, so the Thinking indicator replaces the error.
 		expect(await canvas.findByTestId("live-activity-slot")).toBeVisible();
 	},
 };

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -2887,9 +2887,6 @@ const promotedQueueHeadMessages: TypesGen.ChatMessagesResponse = {
 	has_more: false,
 };
 
-/** A queued send on an errored chat can promote the previous queue head:
- *  the inserted batch lands in the transcript, the new send becomes the
- *  queued tail, and the stale error flips to a running Thinking state. */
 export const QueuedSendPromotesPreviousHead: Story = {
 	parameters: {
 		queries: buildQueries(promotedQueueHeadChat, promotedQueueHeadMessages, {
@@ -2915,8 +2912,6 @@ export const QueuedSendPromotesPreviousHead: Story = {
 			chat_id: CHAT_ID,
 			content: [{ type: "text", text: "Follow-up prompt" }],
 		};
-		// Another tab queued this while the send was in flight, so only the
-		// post-promotion convergence fetch can reveal it.
 		const otherTabPrompt: TypesGen.ChatQueuedMessage = {
 			...MockChatQueuedMessage,
 			id: 44,
@@ -3064,9 +3059,6 @@ export const SendResponseAfterChatSwitch: Story = {
 	},
 };
 
-/** A send rejected with the structured 502 hook-dispatch-failure body must
- *  render the lifecycle-hook title and the server's detail text, not the
- *  generic request-failure fallback. */
 export const SendRejectedByHookDispatchFailure: Story = {
 	parameters: {
 		queries: buildQueries(

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -2909,18 +2909,31 @@ export const QueuedSendPromotesPreviousHead: Story = {
 			created_at: "2024-01-01T00:01:00Z",
 			content: [{ type: "text", text: "Queued head prompt" }],
 		};
+		const followUp: TypesGen.ChatQueuedMessage = {
+			...MockChatQueuedMessage,
+			id: 43,
+			chat_id: CHAT_ID,
+			content: [{ type: "text", text: "Follow-up prompt" }],
+		};
+		// Another tab queued this while the send was in flight, so only the
+		// post-promotion convergence fetch can reveal it.
+		const otherTabPrompt: TypesGen.ChatQueuedMessage = {
+			...MockChatQueuedMessage,
+			id: 44,
+			chat_id: CHAT_ID,
+			content: [{ type: "text", text: "Other tab prompt" }],
+		};
+		spyOn(API.experimental, "getChatMessages").mockResolvedValue({
+			...promotedQueueHeadMessages,
+			queued_messages: [followUp, otherTabPrompt],
+		});
 		const sendSpy = spyOn(
 			API.experimental,
 			"createChatMessage",
 		).mockResolvedValue({
 			queued: true,
 			messages: [promotedHead],
-			queued_message: {
-				...MockChatQueuedMessage,
-				id: 43,
-				chat_id: CHAT_ID,
-				content: [{ type: "text", text: "Follow-up prompt" }],
-			},
+			queued_message: followUp,
 		});
 
 		expect(await canvas.findByText("Queued head prompt")).toBeVisible();
@@ -2939,6 +2952,8 @@ export const QueuedSendPromotesPreviousHead: Story = {
 			expect(canvas.getAllByText("Queued head prompt")).toHaveLength(1);
 			expect(canvas.getAllByText("Follow-up prompt")).toHaveLength(1);
 			expect(timeline.queryByText("Follow-up prompt")).not.toBeInTheDocument();
+			expect(canvas.getByText("Other tab prompt")).toBeVisible();
+			expect(timeline.queryByText("Other tab prompt")).not.toBeInTheDocument();
 		});
 		expect(await canvas.findByTestId("live-activity-slot")).toBeVisible();
 	},

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -2926,3 +2926,48 @@ export const QueuedSendPromotesPreviousHead: Story = {
 		expect(await canvas.findByTestId("live-activity-slot")).toBeVisible();
 	},
 };
+
+/** A send rejected with the structured 502 hook-dispatch-failure body must
+ *  render the lifecycle-hook title and the server's detail text, not the
+ *  generic request-failure fallback. */
+export const SendRejectedByHookDispatchFailure: Story = {
+	parameters: {
+		queries: buildQueries(
+			{
+				id: CHAT_ID,
+				...baseChatFields,
+				title: "Hook failure",
+				status: "waiting",
+			},
+			{ messages: [], queued_messages: [], has_more: false },
+			{ diffUrl: undefined },
+		),
+	},
+	beforeEach: () => {
+		spyOn(API.experimental, "getUserSkills").mockResolvedValue([]);
+		spyOn(API.experimental, "createChatMessage").mockRejectedValue({
+			isAxiosError: true,
+			response: {
+				status: 502,
+				data: {
+					message: "Lifecycle hook dispatch failed.",
+					detail: "Dispatch 0f2c1f3e timed out after 1.5s.",
+					kind: "hook_dispatch_failed",
+				},
+			},
+		});
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const editor = await canvas.findByTestId("chat-message-input");
+		await userEvent.click(editor);
+		await userEvent.type(editor, "Trigger the hook failure");
+		await userEvent.keyboard("{Enter}");
+
+		expect(await canvas.findByText("Lifecycle hook failed")).toBeVisible();
+		expect(
+			await canvas.findByText("Dispatch 0f2c1f3e timed out after 1.5s."),
+		).toBeVisible();
+		expect(canvas.queryByText("Request failed")).not.toBeInTheDocument();
+	},
+};

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { FC } from "react";
 import { useRef } from "react";
-import { Outlet } from "react-router";
+import { Outlet, useNavigate } from "react-router";
 import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
 import {
 	reactRouterOutlet,
@@ -83,7 +83,24 @@ const AgentChatPageLayout: FC = () => {
 // Shared mock data
 // ---------------------------------------------------------------------------
 const CHAT_ID = "chat-1";
+const SWITCHED_CHAT_ID = "chat-2";
 const MODEL_CONFIG_ID = "model-config-1";
+
+const AgentChatSwitchHarness: FC = () => {
+	const navigate = useNavigate();
+	return (
+		<>
+			<button
+				type="button"
+				className="sr-only"
+				onClick={() => navigate(`/agents/${SWITCHED_CHAT_ID}`)}
+			>
+				Switch chat
+			</button>
+			<AgentChatPageLayout />
+		</>
+	);
+};
 
 const mockWorkspace: TypesGen.Workspace = {
 	...MockWorkspace,
@@ -2924,6 +2941,111 @@ export const QueuedSendPromotesPreviousHead: Story = {
 			expect(timeline.queryByText("Follow-up prompt")).not.toBeInTheDocument();
 		});
 		expect(await canvas.findByTestId("live-activity-slot")).toBeVisible();
+	},
+};
+
+const switchedChat: TypesGen.Chat = {
+	id: SWITCHED_CHAT_ID,
+	...baseChatFields,
+	title: "Switched chat",
+	status: "waiting",
+};
+
+const switchedChatMessage: TypesGen.ChatMessage = {
+	...MockChatMessage,
+	id: 50,
+	chat_id: SWITCHED_CHAT_ID,
+	role: "assistant",
+	content: [{ type: "text", text: "Current chat message" }],
+};
+
+export const SendResponseAfterChatSwitch: Story = {
+	render: () => <AgentChatSwitchHarness />,
+	parameters: {
+		queries: [
+			...buildQueries(
+				{
+					id: CHAT_ID,
+					...baseChatFields,
+					title: "Original chat",
+					status: "waiting",
+				},
+				{ messages: [], queued_messages: [], has_more: false },
+				{ diffUrl: undefined },
+			),
+			{ key: chatKey(SWITCHED_CHAT_ID), data: switchedChat },
+			{
+				key: chatMessagesKey(SWITCHED_CHAT_ID),
+				data: {
+					pages: [
+						{
+							messages: [switchedChatMessage],
+							queued_messages: [],
+							has_more: false,
+						},
+					],
+					pageParams: [undefined],
+				},
+			},
+			{
+				key: chatPromptsKey(SWITCHED_CHAT_ID),
+				data: { prompts: [] } satisfies TypesGen.ChatPromptsResponse,
+			},
+			{
+				key: chatDiffContentsKey(SWITCHED_CHAT_ID),
+				data: { chat_id: SWITCHED_CHAT_ID } satisfies TypesGen.ChatDiffContents,
+			},
+		],
+	},
+	beforeEach: () => {
+		spyOn(API.experimental, "getUserSkills").mockResolvedValue([]);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		let releaseSend: (() => void) | undefined;
+		const sendGate = new Promise<void>((resolve) => {
+			releaseSend = resolve;
+		});
+		const sendSpy = spyOn(
+			API.experimental,
+			"createChatMessage",
+		).mockImplementation(async () => {
+			await sendGate;
+			return {
+				queued: false,
+				message: {
+					...MockChatMessage,
+					id: 51,
+					chat_id: CHAT_ID,
+					role: "user",
+					content: [
+						{ type: "text", text: "Stale response from previous chat" },
+					],
+				},
+			};
+		});
+
+		const editor = await canvas.findByTestId("chat-message-input");
+		await userEvent.click(editor);
+		await userEvent.type(editor, "Send before switching");
+		await userEvent.keyboard("{Enter}");
+		await waitFor(() => {
+			expect(sendSpy).toHaveBeenCalledTimes(1);
+		});
+
+		await userEvent.click(canvas.getByRole("button", { name: "Switch chat" }));
+		const timeline = within(await canvas.findByTestId("conversation-timeline"));
+		expect(await timeline.findByText("Current chat message")).toBeVisible();
+
+		releaseSend?.();
+		await waitFor(() => {
+			expect(
+				timeline.queryByText("Stale response from previous chat"),
+			).not.toBeInTheDocument();
+			expect(
+				canvas.queryByTestId("live-activity-slot"),
+			).not.toBeInTheDocument();
+		});
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -2849,3 +2849,81 @@ export const SlashCompactYieldsToPersonalSkill: Story = {
 		expect(compactSpy).not.toHaveBeenCalled();
 	},
 };
+
+const promotedQueueHeadChat: TypesGen.Chat = {
+	id: CHAT_ID,
+	...baseChatFields,
+	title: "Promoted queue head",
+	status: "error",
+};
+
+const promotedQueueHeadMessages: TypesGen.ChatMessagesResponse = {
+	messages: compactCommandMessages.messages,
+	queued_messages: [
+		{
+			...MockChatQueuedMessage,
+			id: 41,
+			chat_id: CHAT_ID,
+			content: [{ type: "text", text: "Queued head prompt" }],
+		},
+	],
+	has_more: false,
+};
+
+/** A queued send on an errored chat can promote the previous queue head:
+ *  the inserted batch lands in the transcript, the new send becomes the
+ *  queued tail, and the stale error flips to a running Thinking state. */
+export const QueuedSendPromotesPreviousHead: Story = {
+	parameters: {
+		queries: buildQueries(promotedQueueHeadChat, promotedQueueHeadMessages, {
+			diffUrl: undefined,
+		}),
+	},
+	beforeEach: () => {
+		spyOn(API.experimental, "getUserSkills").mockResolvedValue([]);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const promotedHead: TypesGen.ChatMessage = {
+			...MockChatMessage,
+			id: 42,
+			chat_id: CHAT_ID,
+			role: "user",
+			created_at: "2024-01-01T00:01:00Z",
+			content: [{ type: "text", text: "Queued head prompt" }],
+		};
+		const sendSpy = spyOn(
+			API.experimental,
+			"createChatMessage",
+		).mockResolvedValue({
+			queued: true,
+			messages: [promotedHead],
+			queued_message: {
+				...MockChatQueuedMessage,
+				id: 43,
+				chat_id: CHAT_ID,
+				content: [{ type: "text", text: "Follow-up prompt" }],
+			},
+		});
+
+		expect(await canvas.findByText("Queued head prompt")).toBeVisible();
+
+		const editor = await canvas.findByTestId("chat-message-input");
+		await userEvent.click(editor);
+		await userEvent.type(editor, "Follow-up prompt");
+		await userEvent.keyboard("{Enter}");
+		await waitFor(() => {
+			expect(sendSpy).toHaveBeenCalledTimes(1);
+		});
+
+		// The promoted head moves from the queue into the transcript and
+		// the new send replaces it as the only queued row.
+		await waitFor(() => {
+			expect(canvas.getAllByText("Queued head prompt")).toHaveLength(1);
+			expect(canvas.getAllByText("Follow-up prompt")).toHaveLength(1);
+		});
+		// The promotion started a turn: the Thinking indicator replaces
+		// the stale error state.
+		expect(await canvas.findByTestId("live-activity-slot")).toBeVisible();
+	},
+};

--- a/site/src/pages/AgentsPage/AgentChatPage.test.ts
+++ b/site/src/pages/AgentsPage/AgentChatPage.test.ts
@@ -321,7 +321,6 @@ describe("reconcilePromotedQueueHead", () => {
 
 	it("does not suppress the rotated head when a queue_update already applied", () => {
 		const store = createChatStore();
-		// The authoritative [b, c] snapshot arrives before the send response.
 		const a = buildQueuedMessage(1, "A");
 		const b = buildQueuedMessage(2, "B");
 		const c = buildQueuedMessage(3, "C");
@@ -335,7 +334,6 @@ describe("reconcilePromotedQueueHead", () => {
 		expect(snapshot.suppressedQueuedMessageIDs.has(b.id)).toBe(false);
 		expect(snapshot.suppressedQueuedMessageIDs.has(c.id)).toBe(false);
 
-		// A late pre-promotion snapshot must not resurrect the promoted row.
 		store.applyAuthoritativeQueuedMessages([a, b, c]);
 		expect(store.getSnapshot().queuedMessages.map((m) => m.id)).toEqual([
 			b.id,
@@ -364,7 +362,6 @@ describe("reconcilePromotedQueueHead", () => {
 		const store = createChatStore();
 		const a = buildQueuedMessage(1, "A");
 		const c = buildQueuedMessage(3, "C");
-		// The server acknowledged the tail, then a later snapshot deleted it.
 		store.applyAuthoritativeQueuedMessages([a, c]);
 		store.applyAuthoritativeQueuedMessages([a]);
 
@@ -376,8 +373,6 @@ describe("reconcilePromotedQueueHead", () => {
 	it("omits the response tail when a newer queue update was observed", () => {
 		const store = createChatStore();
 		const a = buildQueuedMessage(1, "A");
-		// The caller withholds the tail once it has seen a newer queue,
-		// because that snapshot may already have deleted it.
 		store.setQueuedMessages([a]);
 
 		const next = reconcilePromotedQueueHead(

--- a/site/src/pages/AgentsPage/AgentChatPage.test.ts
+++ b/site/src/pages/AgentsPage/AgentChatPage.test.ts
@@ -343,6 +343,34 @@ describe("reconcilePromotedQueueHead", () => {
 		expect(store.getSnapshot().suppressedQueuedMessageIDs.size).toBe(0);
 	});
 
+	it("keeps the response tail when a stale snapshot arrived mid-request", () => {
+		const store = createChatStore();
+		const a = buildQueuedMessage(1, "A");
+		const b = buildQueuedMessage(2, "B");
+		const c = buildQueuedMessage(3, "C");
+		// A pre-send snapshot lands while the POST is in flight; it cannot
+		// mention the tail the send just created.
+		store.setQueuedMessages([a]);
+		store.applyAuthoritativeQueuedMessages([a, b]);
+
+		const next = reconcilePromotedQueueHead(store, [userMessage], a.id, c);
+
+		expect(next?.map((m) => m.id)).toEqual([b.id, c.id]);
+	});
+
+	it("drops the response tail once the server reported and removed it", () => {
+		const store = createChatStore();
+		const a = buildQueuedMessage(1, "A");
+		const c = buildQueuedMessage(3, "C");
+		// The server acknowledged the tail, then a later snapshot deleted it.
+		store.applyAuthoritativeQueuedMessages([a, c]);
+		store.applyAuthoritativeQueuedMessages([a]);
+
+		const next = reconcilePromotedQueueHead(store, [userMessage], a.id, c);
+
+		expect(next).toEqual([]);
+	});
+
 	it("omits the response tail when a newer queue update was observed", () => {
 		const store = createChatStore();
 		const a = buildQueuedMessage(1, "A");

--- a/site/src/pages/AgentsPage/AgentChatPage.test.ts
+++ b/site/src/pages/AgentsPage/AgentChatPage.test.ts
@@ -343,6 +343,24 @@ describe("reconcilePromotedQueueHead", () => {
 		expect(store.getSnapshot().suppressedQueuedMessageIDs.size).toBe(0);
 	});
 
+	it("omits the response tail when a newer queue update was observed", () => {
+		const store = createChatStore();
+		const a = buildQueuedMessage(1, "A");
+		// The caller withholds the tail once it has seen a newer queue,
+		// because that snapshot may already have deleted it.
+		store.setQueuedMessages([a]);
+
+		const next = reconcilePromotedQueueHead(
+			store,
+			[userMessage],
+			a.id,
+			undefined,
+		);
+
+		expect(next).toEqual([]);
+		expect(store.getSnapshot().queuedMessages).toEqual([]);
+	});
+
 	it("does nothing when no user row was inserted", () => {
 		const store = createChatStore();
 		const a = buildQueuedMessage(1, "A");

--- a/site/src/pages/AgentsPage/AgentChatPage.test.ts
+++ b/site/src/pages/AgentsPage/AgentChatPage.test.ts
@@ -1,14 +1,18 @@
 import { act, renderHook } from "@testing-library/react";
 import { createRef } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ChatQueuedMessage } from "#/api/typesGenerated";
-import { MockChatQueuedMessage } from "#/testHelpers/chatEntities";
+import type { ChatMessage, ChatQueuedMessage } from "#/api/typesGenerated";
+import {
+	MockChatMessage,
+	MockChatQueuedMessage,
+} from "#/testHelpers/chatEntities";
 import { createDeferred } from "#/testHelpers/deferred";
 import { MockUserOwner, MockWorkspace } from "#/testHelpers/entities";
 import {
 	draftInputStorageKeyPrefix,
 	getPersistedDraftInputValue,
 	getWorkspaceOptionsWithLinkedWorkspace,
+	reconcilePromotedQueueHead,
 	restoreOptimisticRequestSnapshot,
 	runPromoteQueuedMessage,
 	submitEditAndScroll,
@@ -281,6 +285,100 @@ describe("runPromoteQueuedMessage", () => {
 		expect(snapshot.queuedMessages.map((m) => m.id)).toEqual([a.id, b.id]);
 		expect(snapshot.chatStatus).toBe("waiting");
 		expect(snapshot.suppressedQueuedMessageIDs.has(b.id)).toBe(false);
+	});
+});
+
+describe("reconcilePromotedQueueHead", () => {
+	const buildQueuedMessage = (id: number, text: string): ChatQueuedMessage => ({
+		...MockChatQueuedMessage,
+		id,
+		content: [{ type: "text", text }],
+	});
+	const userMessage: ChatMessage = { ...MockChatMessage, id: 10, role: "user" };
+	const toolMessage: ChatMessage = { ...MockChatMessage, id: 9, role: "tool" };
+
+	it("suppresses the captured head and appends the queued tail", () => {
+		const store = createChatStore();
+		const a = buildQueuedMessage(1, "A");
+		const b = buildQueuedMessage(2, "B");
+		const tail = buildQueuedMessage(3, "C");
+		store.setQueuedMessages([a, b]);
+
+		const reconciled = reconcilePromotedQueueHead(
+			store,
+			[toolMessage, userMessage],
+			a.id,
+			tail,
+		);
+
+		const snapshot = store.getSnapshot();
+		expect(snapshot.queuedMessages.map((m) => m.id)).toEqual([b.id, tail.id]);
+		expect(snapshot.suppressedQueuedMessageIDs.has(a.id)).toBe(true);
+		expect(reconciled?.map((m) => m.id)).toEqual([b.id, tail.id]);
+	});
+
+	it("does not suppress the rotated head when a queue_update already applied", () => {
+		const store = createChatStore();
+		// Pre-send queue was [a, b]; a was promoted and c was queued,
+		// and the authoritative post-promotion snapshot [b, c] landed
+		// before the send response. Re-appending c must not duplicate it.
+		const a = buildQueuedMessage(1, "A");
+		const b = buildQueuedMessage(2, "B");
+		const c = buildQueuedMessage(3, "C");
+		store.setQueuedMessages([b, c]);
+
+		reconcilePromotedQueueHead(store, [userMessage], a.id, c);
+
+		const snapshot = store.getSnapshot();
+		expect(snapshot.queuedMessages.map((m) => m.id)).toEqual([b.id, c.id]);
+		expect(snapshot.suppressedQueuedMessageIDs.has(a.id)).toBe(true);
+		expect(snapshot.suppressedQueuedMessageIDs.has(b.id)).toBe(false);
+		expect(snapshot.suppressedQueuedMessageIDs.has(c.id)).toBe(false);
+
+		// A late pre-promotion snapshot must not resurrect the
+		// promoted row, while the post-promotion snapshot clears the
+		// suppression entry.
+		store.applyAuthoritativeQueuedMessages([a, b, c]);
+		expect(store.getSnapshot().queuedMessages.map((m) => m.id)).toEqual([
+			b.id,
+			c.id,
+		]);
+		store.applyAuthoritativeQueuedMessages([b, c]);
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.size).toBe(0);
+	});
+
+	it("does nothing when no user row was inserted", () => {
+		const store = createChatStore();
+		const a = buildQueuedMessage(1, "A");
+		store.setQueuedMessages([a]);
+
+		const reconciled = reconcilePromotedQueueHead(
+			store,
+			[toolMessage],
+			a.id,
+			buildQueuedMessage(2, "B"),
+		);
+
+		const snapshot = store.getSnapshot();
+		expect(snapshot.queuedMessages.map((m) => m.id)).toEqual([a.id]);
+		expect(snapshot.suppressedQueuedMessageIDs.size).toBe(0);
+		expect(reconciled).toBeUndefined();
+	});
+
+	it("does nothing when no head was captured before the send", () => {
+		const store = createChatStore();
+
+		const reconciled = reconcilePromotedQueueHead(
+			store,
+			[userMessage],
+			undefined,
+			buildQueuedMessage(1, "A"),
+		);
+
+		const snapshot = store.getSnapshot();
+		expect(snapshot.queuedMessages).toEqual([]);
+		expect(snapshot.suppressedQueuedMessageIDs.size).toBe(0);
+		expect(reconciled).toBeUndefined();
 	});
 });
 

--- a/site/src/pages/AgentsPage/AgentChatPage.test.ts
+++ b/site/src/pages/AgentsPage/AgentChatPage.test.ts
@@ -9,12 +9,14 @@ import {
 import { createDeferred } from "#/testHelpers/deferred";
 import { MockUserOwner, MockWorkspace } from "#/testHelpers/entities";
 import {
+	buildInactiveChatQueueReconciliation,
 	draftInputStorageKeyPrefix,
 	getPersistedDraftInputValue,
 	getWorkspaceOptionsWithLinkedWorkspace,
 	reconcilePromotedQueueHead,
 	restoreOptimisticRequestSnapshot,
 	runPromoteQueuedMessage,
+	settlePromotedQueueHead,
 	submitEditAndScroll,
 	useConversationEditingState,
 	waitForPendingChatSettingsSyncs,
@@ -421,6 +423,147 @@ describe("reconcilePromotedQueueHead", () => {
 		expect(snapshot.queuedMessages).toEqual([]);
 		expect(snapshot.suppressedQueuedMessageIDs.size).toBe(0);
 		expect(reconciled).toBeUndefined();
+	});
+});
+
+describe("buildInactiveChatQueueReconciliation", () => {
+	const buildQueuedMessage = (id: number, text: string): ChatQueuedMessage => ({
+		...MockChatQueuedMessage,
+		id,
+		content: [{ type: "text", text }],
+	});
+	const userMessage: ChatMessage = {
+		...MockChatMessage,
+		id: 42,
+		role: "user",
+	};
+
+	it("keeps a message queued while the send was in flight", () => {
+		const a = buildQueuedMessage(1, "A");
+		const b = buildQueuedMessage(2, "B");
+		const c = buildQueuedMessage(3, "C");
+
+		const next = buildInactiveChatQueueReconciliation(
+			[a, b, c],
+			[a, b],
+			[userMessage],
+			a.id,
+			undefined,
+		);
+
+		expect(next?.map((m) => m.id)).toEqual([b.id, c.id]);
+	});
+
+	it("falls back to the pre-send queue when nothing is cached", () => {
+		const a = buildQueuedMessage(1, "A");
+		const b = buildQueuedMessage(2, "B");
+
+		const next = buildInactiveChatQueueReconciliation(
+			undefined,
+			[a, b],
+			[userMessage],
+			a.id,
+			undefined,
+		);
+
+		expect(next?.map((m) => m.id)).toEqual([b.id]);
+	});
+});
+
+describe("settlePromotedQueueHead", () => {
+	const buildQueuedMessage = (id: number, text: string): ChatQueuedMessage => ({
+		...MockChatQueuedMessage,
+		id,
+		content: [{ type: "text", text }],
+	});
+	const chatID = "chat-abc-123";
+
+	it("restores a head the server still has queued", async () => {
+		const store = createChatStore();
+		const a = buildQueuedMessage(1, "A");
+		const b = buildQueuedMessage(2, "B");
+		store.setActiveChatID(chatID);
+		store.setQueuedMessages([b]);
+		store.markQueuedMessagePromoted(a.id);
+
+		const settled = await settlePromotedQueueHead(
+			store,
+			chatID,
+			a.id,
+			async () => ({ messages: [], has_more: false, queued_messages: [a, b] }),
+		);
+
+		expect(settled?.map((m) => m.id)).toEqual([a.id, b.id]);
+		expect(store.getSnapshot().queuedMessages.map((m) => m.id)).toEqual([
+			a.id,
+			b.id,
+		]);
+	});
+
+	it("leaves the queue alone when the fetch fails", async () => {
+		const store = createChatStore();
+		const a = buildQueuedMessage(1, "A");
+		const b = buildQueuedMessage(2, "B");
+		store.setActiveChatID(chatID);
+		store.setQueuedMessages([b]);
+		store.markQueuedMessagePromoted(a.id);
+
+		const settled = await settlePromotedQueueHead(store, chatID, a.id, () =>
+			Promise.reject(new Error("offline")),
+		);
+
+		expect(settled).toBeUndefined();
+		expect(store.getSnapshot().queuedMessages.map((m) => m.id)).toEqual([b.id]);
+		expect(store.getSnapshot().promotedQueuedMessageIDs.has(a.id)).toBe(true);
+	});
+
+	it("returns the filtered queue the store applied", async () => {
+		const store = createChatStore();
+		const a = buildQueuedMessage(1, "A");
+		const b = buildQueuedMessage(2, "B");
+		const c = buildQueuedMessage(3, "C");
+		store.setActiveChatID(chatID);
+		store.setQueuedMessages([b]);
+		store.markQueuedMessagePromoted(a.id);
+		// An overlapping explicit promotion suppresses C, which the server has
+		// not deleted yet, so the caller must not cache it back.
+		store.suppressQueuedMessageID(c.id);
+
+		const settled = await settlePromotedQueueHead(
+			store,
+			chatID,
+			a.id,
+			async () => ({
+				messages: [],
+				has_more: false,
+				queued_messages: [a, b, c],
+			}),
+		);
+
+		expect(settled?.map((m) => m.id)).toEqual([a.id, b.id]);
+	});
+
+	it("discards a response that resolves after navigating to another chat", async () => {
+		const store = createChatStore();
+		const a = buildQueuedMessage(1, "A");
+		const b = buildQueuedMessage(2, "B");
+		store.setActiveChatID(chatID);
+		store.setQueuedMessages([b]);
+		store.markQueuedMessagePromoted(a.id);
+
+		const settled = await settlePromotedQueueHead(
+			store,
+			chatID,
+			a.id,
+			async () => {
+				store.setActiveChatID("chat-other");
+				store.setQueuedMessages([]);
+				return { messages: [], has_more: false, queued_messages: [a, b] };
+			},
+		);
+
+		expect(settled).toBeUndefined();
+		expect(store.getSnapshot().queuedMessages).toEqual([]);
 	});
 });
 

--- a/site/src/pages/AgentsPage/AgentChatPage.test.ts
+++ b/site/src/pages/AgentsPage/AgentChatPage.test.ts
@@ -319,9 +319,7 @@ describe("reconcilePromotedQueueHead", () => {
 
 	it("does not suppress the rotated head when a queue_update already applied", () => {
 		const store = createChatStore();
-		// Pre-send queue was [a, b]; a was promoted and c was queued,
-		// and the authoritative post-promotion snapshot [b, c] landed
-		// before the send response. Re-appending c must not duplicate it.
+		// The authoritative [b, c] snapshot arrives before the send response.
 		const a = buildQueuedMessage(1, "A");
 		const b = buildQueuedMessage(2, "B");
 		const c = buildQueuedMessage(3, "C");
@@ -335,9 +333,7 @@ describe("reconcilePromotedQueueHead", () => {
 		expect(snapshot.suppressedQueuedMessageIDs.has(b.id)).toBe(false);
 		expect(snapshot.suppressedQueuedMessageIDs.has(c.id)).toBe(false);
 
-		// A late pre-promotion snapshot must not resurrect the
-		// promoted row, while the post-promotion snapshot clears the
-		// suppression entry.
+		// A late pre-promotion snapshot must not resurrect the promoted row.
 		store.applyAuthoritativeQueuedMessages([a, b, c]);
 		expect(store.getSnapshot().queuedMessages.map((m) => m.id)).toEqual([
 			b.id,

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -238,7 +238,11 @@ export const runPromoteQueuedMessage = async (params: {
 export const reconcilePromotedQueueHead = (
 	store: Pick<
 		ChatStore,
-		"batch" | "getSnapshot" | "setQueuedMessages" | "markQueuedMessagePromoted"
+		| "batch"
+		| "getSnapshot"
+		| "setQueuedMessages"
+		| "markQueuedMessagePromoted"
+		| "hasObservedQueuedMessageID"
 	>,
 	insertedMessages: readonly TypesGen.ChatMessage[],
 	promotedHeadID: number | undefined,
@@ -253,10 +257,14 @@ export const reconcilePromotedQueueHead = (
 	const remaining = store
 		.getSnapshot()
 		.queuedMessages.filter((message) => message.id !== promotedHeadID);
-	const next =
-		queuedTail && !remaining.some((message) => message.id === queuedTail.id)
-			? [...remaining, queuedTail]
-			: remaining;
+	// Append the tail only while the server has never reported it. Once a
+	// snapshot has listed it, its later absence means it was deleted, so
+	// re-adding it would resurrect a phantom row.
+	const tailPending =
+		queuedTail !== undefined &&
+		!remaining.some((message) => message.id === queuedTail.id) &&
+		!store.hasObservedQueuedMessageID(queuedTail.id);
+	const next = tailPending ? [...remaining, queuedTail] : remaining;
 	store.batch(() => {
 		// The promoted user row proves the server deleted its queue row.
 		store.markQueuedMessagePromoted(promotedHeadID);
@@ -1678,7 +1686,6 @@ const AgentChatPage: FC = () => {
 
 		// Capture the queue head before sending because an errored chat may promote it.
 		const queueHeadIDBeforeSend = store.getSnapshot().queuedMessages[0]?.id;
-		const queueVersionBeforeSend = store.getAuthoritativeQueueVersion();
 		const statusVersionBeforeSend = store.getChatStatusVersion();
 
 		// Don't clear stream state before the POST completes.
@@ -1723,16 +1730,11 @@ const AgentChatPage: FC = () => {
 			store.upsertDurableMessages(insertedMessages);
 			upsertCacheMessages(insertedMessages);
 			if (response.queued) {
-				// A queue update during the request already accounts for the
-				// tail, and may have deleted it, so merging it back would
-				// resurrect a phantom entry.
-				const sawNewerQueue =
-					store.getAuthoritativeQueueVersion() !== queueVersionBeforeSend;
 				const reconciledQueue = reconcilePromotedQueueHead(
 					store,
 					insertedMessages,
 					queueHeadIDBeforeSend,
-					sawNewerQueue ? undefined : response.queued_message,
+					response.queued_message,
 				);
 				if (reconciledQueue) {
 					setCacheQueuedMessages(reconciledQueue);

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -1676,6 +1676,8 @@ const AgentChatPage: FC = () => {
 
 		// Capture the queue head before sending because an errored chat may promote it.
 		const queueHeadIDBeforeSend = store.getSnapshot().queuedMessages[0]?.id;
+		const queueVersionBeforeSend = store.getAuthoritativeQueueVersion();
+		const statusVersionBeforeSend = store.getChatStatusVersion();
 
 		// Don't clear stream state before the POST completes.
 		// For queued sends the WebSocket status events handle
@@ -1718,19 +1720,27 @@ const AgentChatPage: FC = () => {
 			store.upsertDurableMessages(insertedMessages);
 			upsertCacheMessages(insertedMessages);
 			if (response.queued) {
+				// A queue update during the request already accounts for the
+				// tail, and may have deleted it, so merging it back would
+				// resurrect a phantom entry.
+				const sawNewerQueue =
+					store.getAuthoritativeQueueVersion() !== queueVersionBeforeSend;
 				const reconciledQueue = reconcilePromotedQueueHead(
 					store,
 					insertedMessages,
 					queueHeadIDBeforeSend,
-					response.queued_message,
+					sawNewerQueue ? undefined : response.queued_message,
 				);
 				if (reconciledQueue) {
 					setCacheQueuedMessages(reconciledQueue);
-					// A promoted head means a turn just started; clear the
-					// stale error status so the Thinking indicator can show
-					// before the status websocket event arrives.
-					store.clearStreamState();
-					store.setChatStatus("running");
+					// A promoted head means a turn just started, so clear the
+					// stale error status before the status websocket event
+					// arrives. A status event during the request is already
+					// newer than this optimistic value.
+					if (store.getChatStatusVersion() === statusVersionBeforeSend) {
+						store.clearStreamState();
+						store.setChatStatus("running");
+					}
 				}
 			}
 		}

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -1137,6 +1137,7 @@ const AgentChatPage: FC = () => {
 	const aiGatewayDisabled = !useAIGatewayEnabled();
 	const {
 		store,
+		acceptServerChatStatus,
 		clearStreamError,
 		setCacheQueuedMessages,
 		upsertCacheMessages,
@@ -1639,6 +1640,7 @@ const AgentChatPage: FC = () => {
 					// A failed edit can park the chat in error server-side
 					// (hook dispatch failures); refresh so the status is not
 					// stale if the websocket event is missed.
+					acceptServerChatStatus();
 					void queryClient.invalidateQueries({
 						queryKey: chatKey(agentId),
 						exact: true,
@@ -1689,6 +1691,7 @@ const AgentChatPage: FC = () => {
 		} catch (error) {
 			handleUsageLimitError(error);
 			// Refresh chat details in case the failed request changed server state.
+			acceptServerChatStatus();
 			void queryClient.invalidateQueries({
 				queryKey: chatKey(agentId),
 				exact: true,

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -117,6 +117,7 @@ import {
 import {
 	type ChatDetailError,
 	formatUsageLimitMessage,
+	isChatHookDeniedResponse,
 	isChatHookDispatchFailedResponse,
 	isChatUsageLimitExceededResponse,
 } from "./utils/usageLimitMessage";
@@ -1368,10 +1369,13 @@ const AgentChatPage: FC = () => {
 			setChatErrorReason(agentId, reason);
 		} else if (isApiError(error)) {
 			const detail = error.response?.data?.detail?.trim() || undefined;
-			const reason: ChatDetailError = {
-				kind: isChatHookDispatchFailedResponse(error.response?.data)
+			const kind = isChatHookDeniedResponse(error.response?.data)
+				? "hook_denied"
+				: isChatHookDispatchFailedResponse(error.response?.data)
 					? "hook_dispatch_failed"
-					: "generic",
+					: "generic";
+			const reason: ChatDetailError = {
+				kind,
 				message: getErrorMessage(error, "An unexpected error occurred."),
 				...(detail ? { detail } : {}),
 			};

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -115,6 +115,7 @@ import {
 import {
 	type ChatDetailError,
 	formatUsageLimitMessage,
+	isChatHookDispatchFailedResponse,
 	isChatUsageLimitExceededResponse,
 } from "./utils/usageLimitMessage";
 
@@ -230,6 +231,37 @@ export const runPromoteQueuedMessage = async (params: {
 		handleUsageLimitError(error);
 		throw error;
 	}
+};
+
+// promotedHeadID must be the queue head captured before the send because
+// queue updates can rotate the current head before the response arrives.
+export const reconcilePromotedQueueHead = (
+	store: Pick<
+		ChatStore,
+		"batch" | "getSnapshot" | "setQueuedMessages" | "suppressQueuedMessageID"
+	>,
+	insertedMessages: readonly TypesGen.ChatMessage[],
+	promotedHeadID: number | undefined,
+	queuedTail: TypesGen.ChatQueuedMessage | undefined,
+): readonly TypesGen.ChatQueuedMessage[] | undefined => {
+	if (promotedHeadID === undefined) {
+		return undefined;
+	}
+	if (!insertedMessages.some((message) => message.role === "user")) {
+		return undefined;
+	}
+	const remaining = store
+		.getSnapshot()
+		.queuedMessages.filter((message) => message.id !== promotedHeadID);
+	const next =
+		queuedTail && !remaining.some((message) => message.id === queuedTail.id)
+			? [...remaining, queuedTail]
+			: remaining;
+	store.batch(() => {
+		store.suppressQueuedMessageID(promotedHeadID);
+		store.setQueuedMessages(next);
+	});
+	return next;
 };
 
 export async function submitEditAndScroll({
@@ -1102,7 +1134,12 @@ const AgentChatPage: FC = () => {
 	};
 
 	const aiGatewayDisabled = !useAIGatewayEnabled();
-	const { store, clearStreamError, upsertCacheMessages } = useChatStore({
+	const {
+		store,
+		clearStreamError,
+		setCacheQueuedMessages,
+		upsertCacheMessages,
+	} = useChatStore({
 		chatID: agentId,
 		chatMessages: chatMessagesList,
 		chatRecord,
@@ -1254,7 +1291,9 @@ const AgentChatPage: FC = () => {
 		} else if (isApiError(error)) {
 			const detail = error.response?.data?.detail?.trim() || undefined;
 			const reason: ChatDetailError = {
-				kind: "generic",
+				kind: isChatHookDispatchFailedResponse(error.response?.data)
+					? "hook_dispatch_failed"
+					: "generic",
 				message: getErrorMessage(error, "An unexpected error occurred."),
 				...(detail ? { detail } : {}),
 			};
@@ -1627,6 +1666,9 @@ const AgentChatPage: FC = () => {
 		clearStreamError();
 		scrollToBottomRef.current?.();
 
+		// Capture the queue head before sending because an errored chat may promote it.
+		const queueHeadIDBeforeSend = store.getSnapshot().queuedMessages[0]?.id;
+
 		// Don't clear stream state before the POST completes.
 		// For queued sends the WebSocket status events handle
 		// clearing; for non-queued sends we clear explicitly
@@ -1636,12 +1678,16 @@ const AgentChatPage: FC = () => {
 			response = await sendMessage(request);
 		} catch (error) {
 			handleUsageLimitError(error);
+			// Refresh chat details in case the failed request changed server state.
+			void queryClient.invalidateQueries({
+				queryKey: chatKey(agentId),
+				exact: true,
+			});
 			throw error;
 		}
 		// When the server accepts the message immediately (not
-		// queued), clear the stream and insert the user's message
-		// so it appears in the timeline without waiting for the
-		// WebSocket stream.
+		// queued), clear the stream so the timeline updates without
+		// waiting for the WebSocket stream.
 		if (!response.queued) {
 			store.clearStreamState();
 			// Optimistically set status to "running" so the
@@ -1653,9 +1699,26 @@ const AgentChatPage: FC = () => {
 			// to error/pending instead, the WebSocket event
 			// overrides this optimistic value.
 			store.setChatStatus("running");
-			if (response.message) {
-				store.upsertDurableMessage(response.message);
-				upsertCacheMessages([response.message]);
+		}
+		// Prefer the full inserted batch: queued sends can insert
+		// messages beyond the user row, such as a promoted queue head
+		// on an errored chat, and a stream reconnect keyed on the
+		// highest cached ID would skip them, so upsert unconditionally.
+		const insertedMessages =
+			response.messages ?? (response.message ? [response.message] : []);
+		if (insertedMessages.length > 0) {
+			store.upsertDurableMessages(insertedMessages);
+			upsertCacheMessages(insertedMessages);
+			if (response.queued) {
+				const reconciledQueue = reconcilePromotedQueueHead(
+					store,
+					insertedMessages,
+					queueHeadIDBeforeSend,
+					response.queued_message,
+				);
+				if (reconciledQueue) {
+					setCacheQueuedMessages(reconciledQueue);
+				}
 			}
 		}
 		if (selectedModelConfigID) {

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -238,7 +238,7 @@ export const runPromoteQueuedMessage = async (params: {
 export const reconcilePromotedQueueHead = (
 	store: Pick<
 		ChatStore,
-		"batch" | "getSnapshot" | "setQueuedMessages" | "suppressQueuedMessageID"
+		"batch" | "getSnapshot" | "setQueuedMessages" | "markQueuedMessagePromoted"
 	>,
 	insertedMessages: readonly TypesGen.ChatMessage[],
 	promotedHeadID: number | undefined,
@@ -258,7 +258,9 @@ export const reconcilePromotedQueueHead = (
 			? [...remaining, queuedTail]
 			: remaining;
 	store.batch(() => {
-		store.suppressQueuedMessageID(promotedHeadID);
+		// The response carried the promoted user row, so the server has
+		// already deleted its queue row.
+		store.markQueuedMessagePromoted(promotedHeadID);
 		store.setQueuedMessages(next);
 	});
 	return next;

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -1686,7 +1686,7 @@ const AgentChatPage: FC = () => {
 
 		// Capture the queue head before sending because an errored chat may promote it.
 		const queueHeadIDBeforeSend = store.getSnapshot().queuedMessages[0]?.id;
-		const statusVersionBeforeSend = store.getChatStatusVersion();
+		const statusVersionBeforeSend = store.getServerChatStatusVersion();
 
 		// Don't clear stream state before the POST completes.
 		// For queued sends the WebSocket status events handle
@@ -1742,7 +1742,7 @@ const AgentChatPage: FC = () => {
 					// stale error status before the status websocket event
 					// arrives. A status event during the request is already
 					// newer than this optimistic value.
-					if (store.getChatStatusVersion() === statusVersionBeforeSend) {
+					if (store.getServerChatStatusVersion() === statusVersionBeforeSend) {
 						store.clearStreamState();
 						store.setChatStatus("running");
 					}

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -1635,6 +1635,13 @@ const AgentChatPage: FC = () => {
 				onError: (error) => {
 					restoreOptimisticRequestSnapshot(store, previousSnapshot);
 					handleUsageLimitError(error);
+					// A failed edit can park the chat in error server-side
+					// (hook dispatch failures); refresh so the status is not
+					// stale if the websocket event is missed.
+					void queryClient.invalidateQueries({
+						queryKey: chatKey(agentId),
+						exact: true,
+					});
 				},
 			});
 			if (editSelectedModelConfigID) {
@@ -1718,6 +1725,11 @@ const AgentChatPage: FC = () => {
 				);
 				if (reconciledQueue) {
 					setCacheQueuedMessages(reconciledQueue);
+					// A promoted head means a turn just started; clear the
+					// stale error status so the Thinking indicator can show
+					// before the status websocket event arrives.
+					store.clearStreamState();
+					store.setChatStatus("running");
 				}
 			}
 		}

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -233,6 +233,29 @@ export const runPromoteQueuedMessage = async (params: {
 	}
 };
 
+const buildPromotedQueueReconciliation = (
+	queuedMessages: readonly TypesGen.ChatQueuedMessage[],
+	insertedMessages: readonly TypesGen.ChatMessage[],
+	promotedHeadID: number | undefined,
+	queuedTail: TypesGen.ChatQueuedMessage | undefined,
+	hasObservedQueuedMessageID: (id: number) => boolean,
+): readonly TypesGen.ChatQueuedMessage[] | undefined => {
+	if (promotedHeadID === undefined) {
+		return undefined;
+	}
+	if (!insertedMessages.some((message) => message.role === "user")) {
+		return undefined;
+	}
+	const remaining = queuedMessages.filter(
+		(message) => message.id !== promotedHeadID,
+	);
+	const tailPending =
+		queuedTail !== undefined &&
+		!remaining.some((message) => message.id === queuedTail.id) &&
+		!hasObservedQueuedMessageID(queuedTail.id);
+	return tailPending ? [...remaining, queuedTail] : remaining;
+};
+
 // Use the pre-send queue head because queue updates may rotate it before
 // the response arrives.
 export const reconcilePromotedQueueHead = (
@@ -248,23 +271,16 @@ export const reconcilePromotedQueueHead = (
 	promotedHeadID: number | undefined,
 	queuedTail: TypesGen.ChatQueuedMessage | undefined,
 ): readonly TypesGen.ChatQueuedMessage[] | undefined => {
-	if (promotedHeadID === undefined) {
-		return undefined;
+	const next = buildPromotedQueueReconciliation(
+		store.getSnapshot().queuedMessages,
+		insertedMessages,
+		promotedHeadID,
+		queuedTail,
+		store.hasObservedQueuedMessageID,
+	);
+	if (!next || promotedHeadID === undefined) {
+		return next;
 	}
-	if (!insertedMessages.some((message) => message.role === "user")) {
-		return undefined;
-	}
-	const remaining = store
-		.getSnapshot()
-		.queuedMessages.filter((message) => message.id !== promotedHeadID);
-	// Append the tail only while the server has never reported it. Once a
-	// snapshot has listed it, its later absence means it was deleted, so
-	// re-adding it would resurrect a phantom row.
-	const tailPending =
-		queuedTail !== undefined &&
-		!remaining.some((message) => message.id === queuedTail.id) &&
-		!store.hasObservedQueuedMessageID(queuedTail.id);
-	const next = tailPending ? [...remaining, queuedTail] : remaining;
 	store.batch(() => {
 		// The promoted user row proves the server deleted its queue row.
 		store.markQueuedMessagePromoted(promotedHeadID);
@@ -1685,7 +1701,8 @@ const AgentChatPage: FC = () => {
 		scrollToBottomRef.current?.();
 
 		// Capture the queue head before sending because an errored chat may promote it.
-		const queueHeadIDBeforeSend = store.getSnapshot().queuedMessages[0]?.id;
+		const queuedMessagesBeforeSend = store.getSnapshot().queuedMessages;
+		const queueHeadIDBeforeSend = queuedMessagesBeforeSend[0]?.id;
 		const statusVersionBeforeSend = store.getServerChatStatusVersion();
 
 		// Don't clear stream state before the POST completes.
@@ -1705,10 +1722,11 @@ const AgentChatPage: FC = () => {
 			});
 			throw error;
 		}
+		const isActiveChat = store.getActiveChatID() === agentId;
 		// When the server accepts the message immediately (not
 		// queued), clear the stream so the timeline updates without
 		// waiting for the WebSocket stream.
-		if (!response.queued) {
+		if (!response.queued && isActiveChat) {
 			store.clearStreamState();
 			// Optimistically set status to "running" so the
 			// Thinking indicator appears immediately.
@@ -1727,22 +1745,35 @@ const AgentChatPage: FC = () => {
 		const insertedMessages =
 			response.messages ?? (response.message ? [response.message] : []);
 		if (insertedMessages.length > 0) {
-			store.upsertDurableMessages(insertedMessages);
 			upsertCacheMessages(insertedMessages);
+			if (isActiveChat) {
+				store.upsertDurableMessages(insertedMessages);
+			}
 			if (response.queued) {
-				const reconciledQueue = reconcilePromotedQueueHead(
-					store,
-					insertedMessages,
-					queueHeadIDBeforeSend,
-					response.queued_message,
-				);
+				const reconciledQueue = isActiveChat
+					? reconcilePromotedQueueHead(
+							store,
+							insertedMessages,
+							queueHeadIDBeforeSend,
+							response.queued_message,
+						)
+					: buildPromotedQueueReconciliation(
+							queuedMessagesBeforeSend,
+							insertedMessages,
+							queueHeadIDBeforeSend,
+							response.queued_message,
+							() => false,
+						);
 				if (reconciledQueue) {
 					setCacheQueuedMessages(reconciledQueue);
 					// A promoted head means a turn just started, so clear the
 					// stale error status before the status websocket event
 					// arrives. A status event during the request is already
 					// newer than this optimistic value.
-					if (store.getServerChatStatusVersion() === statusVersionBeforeSend) {
+					if (
+						isActiveChat &&
+						store.getServerChatStatusVersion() === statusVersionBeforeSend
+					) {
 						store.clearStreamState();
 						store.setChatStatus("running");
 					}

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -7,6 +7,7 @@ import {
 	useState,
 } from "react";
 
+import type { QueryClient } from "react-query";
 import {
 	useInfiniteQuery,
 	useMutation,
@@ -31,6 +32,7 @@ import {
 	chatModelConfigs,
 	chatModels,
 	chatProviderConfigs,
+	chatQueueConvergence,
 	compactChat,
 	createChatMessage,
 	deleteChatQueuedMessage,
@@ -256,6 +258,24 @@ const buildPromotedQueueReconciliation = (
 	return tailPending ? [...remaining, queuedTail] : remaining;
 };
 
+// A chat the user navigated away from has no live store to read, so the
+// cached queue is the freshest view of it. Falling back to the pre-send
+// snapshot would drop messages queued while the send was in flight.
+export const buildInactiveChatQueueReconciliation = (
+	cachedQueuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined,
+	queuedMessagesBeforeSend: readonly TypesGen.ChatQueuedMessage[],
+	insertedMessages: readonly TypesGen.ChatMessage[],
+	promotedHeadID: number | undefined,
+	queuedTail: TypesGen.ChatQueuedMessage | undefined,
+): readonly TypesGen.ChatQueuedMessage[] | undefined =>
+	buildPromotedQueueReconciliation(
+		cachedQueuedMessages ?? queuedMessagesBeforeSend,
+		insertedMessages,
+		promotedHeadID,
+		queuedTail,
+		() => false,
+	);
+
 // Use the pre-send queue head because queue updates may rotate it before
 // the response arrives.
 export const reconcilePromotedQueueHead = (
@@ -287,6 +307,36 @@ export const reconcilePromotedQueueHead = (
 		store.setQueuedMessages(next);
 	});
 	return next;
+};
+
+const fetchChatMessages = (queryClient: QueryClient) => (chatID: string) =>
+	queryClient.fetchQuery(chatQueueConvergence(chatID));
+
+// A promoted head is suppressed locally, but another tab can queue or
+// promote concurrently, so only the server knows the resulting queue.
+export const settlePromotedQueueHead = async (
+	store: Pick<
+		ChatStore,
+		"getQueueConvergenceFence" | "applyPromoteRefetchQueuedMessages"
+	>,
+	chatID: string,
+	promotedHeadID: number,
+	fetchMessages: (chatID: string) => Promise<TypesGen.ChatMessagesResponse>,
+): Promise<readonly TypesGen.ChatQueuedMessage[] | undefined> => {
+	const baselineFence = store.getQueueConvergenceFence();
+	let response: TypesGen.ChatMessagesResponse;
+	try {
+		response = await fetchMessages(chatID);
+	} catch {
+		// Convergence is best effort; a later authoritative update can correct it.
+		return undefined;
+	}
+	return store.applyPromoteRefetchQueuedMessages(
+		chatID,
+		promotedHeadID,
+		response.queued_messages ?? [],
+		baselineFence,
+	);
 };
 
 export async function submitEditAndScroll({
@@ -1164,6 +1214,7 @@ const AgentChatPage: FC = () => {
 		acceptServerChatStatus,
 		clearStreamError,
 		setCacheQueuedMessages,
+		getCacheQueuedMessages,
 		upsertCacheMessages,
 	} = useChatStore({
 		chatID: agentId,
@@ -1758,12 +1809,12 @@ const AgentChatPage: FC = () => {
 							queueHeadIDBeforeSend,
 							response.queued_message,
 						)
-					: buildPromotedQueueReconciliation(
+					: buildInactiveChatQueueReconciliation(
+							getCacheQueuedMessages(),
 							queuedMessagesBeforeSend,
 							insertedMessages,
 							queueHeadIDBeforeSend,
 							response.queued_message,
-							() => false,
 						);
 				if (reconciledQueue) {
 					setCacheQueuedMessages(reconciledQueue);
@@ -1777,6 +1828,18 @@ const AgentChatPage: FC = () => {
 					) {
 						store.clearStreamState();
 						store.setChatStatus("running");
+					}
+					if (isActiveChat && queueHeadIDBeforeSend !== undefined) {
+						void settlePromotedQueueHead(
+							store,
+							agentId,
+							queueHeadIDBeforeSend,
+							fetchChatMessages(queryClient),
+						).then((settled) => {
+							if (settled) {
+								setCacheQueuedMessages(settled);
+							}
+						});
 					}
 				}
 			}

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -1169,6 +1169,7 @@ const AgentChatPage: FC = () => {
 		chatID: agentId,
 		chatMessages: chatMessagesList,
 		chatRecord,
+		chatRecordUpdatedAt: chatQuery.dataUpdatedAt,
 		chatMessagesData,
 		chatQueuedMessages,
 		setChatErrorReason,
@@ -1741,7 +1742,7 @@ const AgentChatPage: FC = () => {
 		// Prefer the full inserted batch: queued sends can insert
 		// messages beyond the user row, such as a promoted queue head
 		// on an errored chat, and a stream reconnect keyed on the
-		// highest cached ID would skip them, so upsert unconditionally.
+		// highest cached ID would skip them, so upsert while this chat is active.
 		const insertedMessages =
 			response.messages ?? (response.message ? [response.message] : []);
 		if (insertedMessages.length > 0) {

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -259,9 +259,8 @@ const buildPromotedQueueReconciliation = (
 	return tailPending ? [...remaining, queuedTail] : remaining;
 };
 
-// A chat the user navigated away from has no live store to read, so the
-// cached queue is the freshest view of it. Falling back to the pre-send
-// snapshot would drop messages queued while the send was in flight.
+// Prefer an inactive chat's cached queue so messages queued during the send
+// are not dropped; fall back when no cache exists.
 export const buildInactiveChatQueueReconciliation = (
 	cachedQueuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined,
 	queuedMessagesBeforeSend: readonly TypesGen.ChatQueuedMessage[],
@@ -277,8 +276,7 @@ export const buildInactiveChatQueueReconciliation = (
 		() => false,
 	);
 
-// Use the pre-send queue head because queue updates may rotate it before
-// the response arrives.
+// Queue updates may rotate the head before the response arrives.
 export const reconcilePromotedQueueHead = (
 	store: Pick<
 		ChatStore,
@@ -1717,9 +1715,7 @@ const AgentChatPage: FC = () => {
 				onError: (error) => {
 					restoreOptimisticRequestSnapshot(store, previousSnapshot);
 					handleUsageLimitError(error);
-					// A failed edit can park the chat in error server-side
-					// (hook dispatch failures); refresh so the status is not
-					// stale if the websocket event is missed.
+					// Hook dispatch failures can park an idle chat in error before returning the request error.
 					acceptServerChatStatus();
 					void queryClient.invalidateQueries({
 						queryKey: chatKey(agentId),
@@ -1756,7 +1752,7 @@ const AgentChatPage: FC = () => {
 		clearStreamError();
 		scrollToBottomRef.current?.();
 
-		// Capture the queue head before sending because an errored chat may promote it.
+		// An errored-chat send may promote the queue head that existed when the request began.
 		const queuedMessagesBeforeSend = store.getSnapshot().queuedMessages;
 		const queueHeadIDBeforeSend = queuedMessagesBeforeSend[0]?.id;
 		const statusVersionBeforeSend = store.getServerChatStatusVersion();
@@ -1770,7 +1766,7 @@ const AgentChatPage: FC = () => {
 			response = await sendMessage(request);
 		} catch (error) {
 			handleUsageLimitError(error);
-			// Refresh chat details in case the failed request changed server state.
+			// Hook dispatch failures can park an idle chat in error before returning the request error.
 			acceptServerChatStatus();
 			void queryClient.invalidateQueries({
 				queryKey: chatKey(agentId),
@@ -1779,9 +1775,7 @@ const AgentChatPage: FC = () => {
 			throw error;
 		}
 		const isActiveChat = store.getActiveChatID() === agentId;
-		// When the server accepts the message immediately (not
-		// queued), clear the stream so the timeline updates without
-		// waiting for the WebSocket stream.
+		// Waiting for the WebSocket on non-queued sends leaves stale stream state visible.
 		if (!response.queued && isActiveChat) {
 			store.clearStreamState();
 			// Optimistically set status to "running" so the
@@ -1794,10 +1788,8 @@ const AgentChatPage: FC = () => {
 			// overrides this optimistic value.
 			store.setChatStatus("running");
 		}
-		// Prefer the full inserted batch: queued sends can insert
-		// messages beyond the user row, such as a promoted queue head
-		// on an errored chat, and a stream reconnect keyed on the
-		// highest cached ID would skip them, so upsert while this chat is active.
+		// Upsert the full batch because a queued send can insert a promoted head below
+		// the highest cached ID, which a reconnect would skip.
 		const insertedMessages =
 			response.messages ?? (response.message ? [response.message] : []);
 		if (insertedMessages.length > 0) {
@@ -1822,10 +1814,8 @@ const AgentChatPage: FC = () => {
 						);
 				if (reconciledQueue) {
 					setCacheQueuedMessages(reconciledQueue);
-					// A promoted head means a turn just started, so clear the
-					// stale error status before the status websocket event
-					// arrives. A status event during the request is already
-					// newer than this optimistic value.
+					// A promoted head starts a turn, but any server status received during the
+					// request is newer and must win.
 					if (
 						isActiveChat &&
 						store.getServerChatStatusVersion() === statusVersionBeforeSend

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -233,8 +233,8 @@ export const runPromoteQueuedMessage = async (params: {
 	}
 };
 
-// promotedHeadID must be the queue head captured before the send because
-// queue updates can rotate the current head before the response arrives.
+// Use the pre-send queue head because queue updates may rotate it before
+// the response arrives.
 export const reconcilePromotedQueueHead = (
 	store: Pick<
 		ChatStore,
@@ -258,8 +258,7 @@ export const reconcilePromotedQueueHead = (
 			? [...remaining, queuedTail]
 			: remaining;
 	store.batch(() => {
-		// The response carried the promoted user row, so the server has
-		// already deleted its queue row.
+		// The promoted user row proves the server deleted its queue row.
 		store.markQueuedMessagePromoted(promotedHeadID);
 		store.setQueuedMessages(next);
 	});

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -816,6 +816,84 @@ export const UsageLimitExceeded: Story = {
 	},
 };
 
+export const HookDispatchFailed: Story = {
+	args: {
+		...defaultArgs,
+		createError: Object.assign(
+			new Error("Request failed with status code 502"),
+			{
+				isAxiosError: true,
+				response: {
+					status: 502,
+					statusText: "Bad Gateway",
+					data: {
+						kind: "hook_dispatch_failed",
+						message: "Chat lifecycle hook dispatch failed.",
+						detail:
+							"Lifecycle hook dispatch 00000000-0000-0000-0000-000000000001 failed (http_error).",
+					},
+					headers: {},
+					config: {},
+				},
+				config: {},
+				toJSON: () => ({}),
+			},
+		),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByText("Lifecycle hook failed")).toBeVisible();
+		await expect(
+			canvas.getByText("Chat lifecycle hook dispatch failed."),
+		).toBeVisible();
+		await expect(
+			canvas.getByText(
+				"Lifecycle hook dispatch 00000000-0000-0000-0000-000000000001 failed (http_error).",
+			),
+		).toBeVisible();
+		await expect(canvas.queryByText("Stack Trace")).not.toBeInTheDocument();
+		await expect(canvas.queryByText("Response data")).not.toBeInTheDocument();
+	},
+};
+
+export const HookDenied: Story = {
+	args: {
+		...defaultArgs,
+		createError: Object.assign(
+			new Error("Request failed with status code 403"),
+			{
+				isAxiosError: true,
+				response: {
+					status: 403,
+					statusText: "Forbidden",
+					data: {
+						kind: "hook_denied",
+						message: "This prompt is blocked by policy.",
+					},
+					headers: {},
+					config: {},
+				},
+				config: {},
+				toJSON: () => ({}),
+			},
+		),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByText("This prompt is blocked by policy."),
+		).toBeVisible();
+		await expect(
+			canvas.queryByText("Blocked by policy"),
+		).not.toBeInTheDocument();
+		await expect(
+			canvas.queryByText("Go to workspaces"),
+		).not.toBeInTheDocument();
+		await expect(canvas.queryByText("Stack Trace")).not.toBeInTheDocument();
+		await expect(canvas.queryByText("Response data")).not.toBeInTheDocument();
+	},
+};
+
 export const ForbiddenErrorWithRole: Story = {
 	args: {
 		...defaultArgs,

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -6,7 +6,7 @@ import { isApiError } from "#/api/errors";
 import { permittedOrganizations } from "#/api/queries/organizations";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { AgentChatSendShortcut } from "#/api/typesGenerated";
-import { Alert, AlertDescription } from "#/components/Alert/Alert";
+import { Alert, AlertDescription, AlertTitle } from "#/components/Alert/Alert";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Button } from "#/components/Button/Button";
 import { ConfirmDialog } from "#/components/Dialogs/ConfirmDialog/ConfirmDialog";
@@ -27,10 +27,13 @@ import {
 } from "../utils/reasoningEffort";
 import {
 	formatUsageLimitMessage,
+	isChatHookDeniedResponse,
+	isChatHookDispatchFailedResponse,
 	isChatUsageLimitExceededResponse,
 } from "../utils/usageLimitMessage";
 import { AgentChatInput } from "./AgentChatInput";
 import { ChatAccessDeniedAlert } from "./ChatAccessDeniedAlert";
+import { getErrorTitle } from "./ChatConversation/chatStatusHelpers";
 import type { ModelSelectorOption } from "./ChatElements";
 import { CompactOrgSelector } from "./ChatElements";
 import {
@@ -525,6 +528,30 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 							>
 								<AlertDescription>
 									{formatUsageLimitMessage(createError.response.data)}
+								</AlertDescription>
+							</Alert>
+						) : isApiError(createError) &&
+							createError.response.status === 502 &&
+							isChatHookDispatchFailedResponse(createError.response.data) ? (
+							<Alert severity="error">
+								<AlertTitle>
+									{getErrorTitle("hook_dispatch_failed", "error")}
+								</AlertTitle>
+								<AlertDescription>
+									<span>{createError.response.data.message}</span>
+									{createError.response.data.detail && (
+										<span className="mt-1 block text-content-secondary">
+											{createError.response.data.detail}
+										</span>
+									)}
+								</AlertDescription>
+							</Alert>
+						) : isApiError(createError) &&
+							createError.response.status === 403 &&
+							isChatHookDeniedResponse(createError.response.data) ? (
+							<Alert severity="info">
+								<AlertDescription>
+									{createError.response.data.message}
 								</AlertDescription>
 							</Alert>
 						) : (

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -464,8 +464,6 @@ export const LifecycleHookNoticeOnUserMessage: Story = {
 		expect(notice).toBeVisible();
 		expect(within(notice).getByText("Lifecycle hook")).toBeVisible();
 		expect(canvas.getByText("original prompt")).toBeVisible();
-		// The user-message notice must receive the timeline's
-		// urlTransform even through the sticky message wrapper.
 		const link = within(notice).getByRole("link", { name: "policy" });
 		expect(link).toHaveAttribute("href", "https://proxy.example.com/policy");
 	},

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -469,6 +469,40 @@ export const LifecycleHookNoticeOnUserMessage: Story = {
 	},
 };
 
+export const LifecycleHookNoticeAfterEditedMessage: Story = {
+	args: {
+		...defaultArgs,
+		editingMessageId: 1,
+		parsedMessages: buildMessages([
+			{
+				...baseMessage,
+				id: 1,
+				role: "user",
+				content: [{ type: "text", text: "prompt being edited" }],
+			},
+			{
+				...baseMessage,
+				id: 2,
+				role: "user",
+				content: [
+					{ type: "text", text: "later prompt" },
+					{
+						type: "hook-notice",
+						text: "Deployment context was added: [policy](http://localhost:3000/policy)",
+					},
+				],
+			},
+		]),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("prompt being edited")).toBeVisible();
+		const link = canvas.getByRole("link", { name: "policy" });
+		link.focus();
+		expect(link).not.toHaveFocus();
+	},
+};
+
 export const DurableListTemplatesToolLifecycle: Story = {
 	args: {
 		...defaultArgs,

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -463,7 +463,11 @@ export const LifecycleHookNoticeOnUserMessage: Story = {
 		const notice = canvas.getByRole("note");
 		expect(notice).toBeVisible();
 		expect(within(notice).getByText("Lifecycle hook")).toBeVisible();
-		expect(canvas.getByText("original prompt")).toBeVisible();
+		const prompt = canvas.getByText("original prompt");
+		expect(prompt).toBeVisible();
+		expect(
+			prompt.compareDocumentPosition(notice) & Node.DOCUMENT_POSITION_FOLLOWING,
+		).toBeTruthy();
 		const link = within(notice).getByRole("link", { name: "policy" });
 		expect(link).toHaveAttribute("href", "https://proxy.example.com/policy");
 	},

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -405,6 +405,69 @@ const meta: Meta<typeof ConversationTimeline> = {
 export default meta;
 type Story = StoryObj<typeof ConversationTimeline>;
 
+export const LifecycleHookNotice: Story = {
+	args: {
+		...defaultArgs,
+		parsedMessages: buildMessages([
+			{
+				...baseMessage,
+				id: 1,
+				role: "system",
+				content: [
+					{
+						type: "text",
+						text: "Your organization requires an approval before deployment.",
+					},
+				],
+			},
+		]),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const notice = canvas.getByRole("note");
+		expect(notice).toBeVisible();
+		expect(within(notice).getByText("Lifecycle hook")).toBeVisible();
+		expect(
+			within(notice).getByText(
+				"Your organization requires an approval before deployment.",
+			),
+		).toBeVisible();
+		expect(
+			canvas.queryByRole("button", { name: "Copy message" }),
+		).not.toBeInTheDocument();
+	},
+};
+
+export const LifecycleHookNoticeOnUserMessage: Story = {
+	args: {
+		...defaultArgs,
+		parsedMessages: buildMessages([
+			{
+				...baseMessage,
+				id: 1,
+				role: "user",
+				content: [
+					{ type: "text", text: "original prompt" },
+					{
+						type: "hook-notice",
+						text: "Deployment context was added to this prompt.",
+					},
+				],
+			},
+		]),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const notice = canvas.getByRole("note");
+		expect(notice).toBeVisible();
+		expect(within(notice).getByText("Lifecycle hook")).toBeVisible();
+		expect(
+			within(notice).getByText("Deployment context was added to this prompt."),
+		).toBeVisible();
+		expect(canvas.getByText("original prompt")).toBeVisible();
+	},
+};
+
 export const DurableListTemplatesToolLifecycle: Story = {
 	args: {
 		...defaultArgs,

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -441,6 +441,8 @@ export const LifecycleHookNotice: Story = {
 export const LifecycleHookNoticeOnUserMessage: Story = {
 	args: {
 		...defaultArgs,
+		urlTransform: (url) =>
+			url.replace("http://localhost:3000", "https://proxy.example.com"),
 		parsedMessages: buildMessages([
 			{
 				...baseMessage,
@@ -450,7 +452,7 @@ export const LifecycleHookNoticeOnUserMessage: Story = {
 					{ type: "text", text: "original prompt" },
 					{
 						type: "hook-notice",
-						text: "Deployment context was added to this prompt.",
+						text: "Deployment context was added: [policy](http://localhost:3000/policy)",
 					},
 				],
 			},
@@ -461,10 +463,11 @@ export const LifecycleHookNoticeOnUserMessage: Story = {
 		const notice = canvas.getByRole("note");
 		expect(notice).toBeVisible();
 		expect(within(notice).getByText("Lifecycle hook")).toBeVisible();
-		expect(
-			within(notice).getByText("Deployment context was added to this prompt."),
-		).toBeVisible();
 		expect(canvas.getByText("original prompt")).toBeVisible();
+		// The user-message notice must receive the timeline's
+		// urlTransform even through the sticky message wrapper.
+		const link = within(notice).getByRole("link", { name: "policy" });
+		expect(link).toHaveAttribute("href", "https://proxy.example.com/policy");
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -650,14 +650,6 @@ const ChatMessageItem = memo<{
 				)}
 				inert={isAfterEditingMessage ? true : undefined}
 			>
-				{parsed.hookNotices.map((notice, index) => (
-					<LifecycleHookNotice
-						key={`${message.id}-hook-notice-${index}`}
-						urlTransform={urlTransform}
-					>
-						{notice}
-					</LifecycleHookNotice>
-				))}
 				<ConversationItem {...conversationItemProps}>
 					{isUser ? (
 						<UserMessageContent
@@ -702,6 +694,14 @@ const ChatMessageItem = memo<{
 						</Message>
 					)}
 				</ConversationItem>
+				{parsed.hookNotices.map((notice, index) => (
+					<LifecycleHookNotice
+						key={`${message.id}-hook-notice-${index}`}
+						urlTransform={urlTransform}
+					>
+						{notice}
+					</LifecycleHookNotice>
+				))}
 				{!hideActions &&
 					(displayState.hasCopyableContent ||
 						(isUser && onEditUserMessage)) && (

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -1072,6 +1072,11 @@ const StickyUserMessage = memo<{
 								? { opacity: "calc(1 - var(--overlay-ready, 0))" }
 								: undefined
 						}
+						// While the overlay copy is shown, drop the flow copy
+						// from the accessibility tree so the message and its
+						// hook notices aren't exposed twice.
+						aria-hidden={isStuck && !isTooTall ? true : undefined}
+						inert={isStuck && !isTooTall ? true : undefined}
 					>
 						<ChatMessageItem
 							message={message}

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -1,8 +1,14 @@
-import { ChevronLeftIcon, ChevronRightIcon, PencilIcon } from "lucide-react";
+import {
+	ChevronLeftIcon,
+	ChevronRightIcon,
+	InfoIcon,
+	PencilIcon,
+} from "lucide-react";
 import {
 	type FC,
 	Fragment,
 	memo,
+	type ReactNode,
 	useLayoutEffect,
 	useRef,
 	useState,
@@ -14,6 +20,7 @@ import { preferenceSettings } from "#/api/queries/users";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ThinkingDisplayMode } from "#/api/typesGenerated";
 
+import { AlertTitle } from "#/components/Alert/Alert";
 import { Button } from "#/components/Button/Button";
 import { CopyButton } from "#/components/CopyButton/CopyButton";
 import {
@@ -510,6 +517,31 @@ export const BlockList: FC<{
 	);
 };
 
+// Avoid announcing historical hook notices as live alerts.
+const TimelineNotice: FC<{ children?: ReactNode }> = ({ children }) => (
+	<div
+		role="note"
+		className="relative my-1 w-full rounded-lg border border-solid border-border-default bg-surface-secondary p-4 text-left"
+	>
+		<div className="flex min-w-0 flex-1 flex-row items-start gap-3 text-sm">
+			<InfoIcon className="size-icon-sm mt-[3px] text-highlight-sky" />
+			<div className="min-w-0 flex-1">{children}</div>
+		</div>
+	</div>
+);
+
+const LifecycleHookNotice: FC<{
+	children: string;
+	urlTransform?: UrlTransform;
+}> = ({ children, urlTransform }) => (
+	<TimelineNotice>
+		<div className="flex flex-col gap-1">
+			<AlertTitle>Lifecycle hook</AlertTitle>
+			<Response urlTransform={urlTransform}>{children}</Response>
+		</div>
+	</TimelineNotice>
+);
+
 const ChatMessageItem = memo<{
 	message: TypesGen.ChatMessage;
 	parsed: ParsedMessageContent;
@@ -589,6 +621,22 @@ const ChatMessageItem = memo<{
 		if (displayState.shouldHide) {
 			return null;
 		}
+		if (message.role === "system") {
+			return (
+				<div
+					className={cn(
+						isAfterEditingMessage && "opacity-40 pointer-events-none",
+						"transition-opacity duration-200",
+					)}
+					// Keep links in dimmed notices out of accessibility navigation.
+					inert={isAfterEditingMessage ? true : undefined}
+				>
+					<LifecycleHookNotice urlTransform={urlTransform}>
+						{parsed.markdown}
+					</LifecycleHookNotice>
+				</div>
+			);
+		}
 
 		const conversationItemProps: { role: "user" | "assistant" } = {
 			role: isUser ? "user" : "assistant",
@@ -601,6 +649,14 @@ const ChatMessageItem = memo<{
 					"group/msg relative transition-opacity duration-200",
 				)}
 			>
+				{parsed.hookNotices.map((notice, index) => (
+					<LifecycleHookNotice
+						key={`${message.id}-hook-notice-${index}`}
+						urlTransform={urlTransform}
+					>
+						{notice}
+					</LifecycleHookNotice>
+				))}
 				<ConversationItem {...conversationItemProps}>
 					{isUser ? (
 						<UserMessageContent
@@ -1089,6 +1145,10 @@ function computeLastInChainFlags(
 	let nextVisibleIsUser = true;
 	for (let i = displayMessages.length - 1; i >= 0; i--) {
 		const entry = displayMessages[i];
+		if (entry.message.role === "system") {
+			nextVisibleIsUser = true;
+			continue;
+		}
 		if (entry.message.role !== "user") {
 			flags[i] = nextVisibleIsUser;
 		}

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -833,6 +833,7 @@ const StickyUserMessage = memo<{
 	nextUserMessageId?: number;
 	onJumpToUserMessage?: (messageId: number) => void;
 	registerSentinel?: (messageId: number, el: HTMLDivElement | null) => void;
+	urlTransform?: UrlTransform;
 }>(
 	({
 		message,
@@ -844,6 +845,7 @@ const StickyUserMessage = memo<{
 		nextUserMessageId,
 		onJumpToUserMessage,
 		registerSentinel,
+		urlTransform,
 	}) => {
 		const [isStuck, setIsStuck] = useState(false);
 		const [isReady, setIsReady] = useState(false);
@@ -1087,6 +1089,7 @@ const StickyUserMessage = memo<{
 							prevUserMessageId={prevUserMessageId}
 							nextUserMessageId={nextUserMessageId}
 							onJumpToUserMessage={onJumpToUserMessage}
+							urlTransform={urlTransform}
 						/>
 					</div>
 
@@ -1132,6 +1135,7 @@ const StickyUserMessage = memo<{
 									prevUserMessageId={prevUserMessageId}
 									nextUserMessageId={nextUserMessageId}
 									onJumpToUserMessage={onJumpToUserMessage}
+									urlTransform={urlTransform}
 									fadeFromBottom
 								/>
 							</div>
@@ -1330,6 +1334,7 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 									nextUserMessageId={userNeighborsById.get(message.id)?.nextId}
 									onJumpToUserMessage={jumpToUserMessage}
 									registerSentinel={registerSentinel}
+									urlTransform={urlTransform}
 								/>
 							);
 						}

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -648,6 +648,7 @@ const ChatMessageItem = memo<{
 					isAfterEditingMessage && "opacity-40 pointer-events-none",
 					"group/msg relative transition-opacity duration-200",
 				)}
+				inert={isAfterEditingMessage ? true : undefined}
 			>
 				{parsed.hookNotices.map((notice, index) => (
 					<LifecycleHookNotice

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStatusHelpers.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStatusHelpers.ts
@@ -48,6 +48,8 @@ export const getErrorTitle = (
 			return "Provider disabled";
 		case "content_filter":
 			return "Response blocked";
+		case "hook_dispatch_failed":
+			return "Lifecycle hook failed";
 		default:
 			return mode === "retry" ? "Retrying request" : "Request failed";
 	}

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStatusHelpers.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStatusHelpers.ts
@@ -50,6 +50,8 @@ export const getErrorTitle = (
 			return "Response blocked";
 		case "hook_dispatch_failed":
 			return "Lifecycle hook failed";
+		case "hook_denied":
+			return "Blocked by policy";
 		default:
 			return mode === "retry" ? "Retrying request" : "Request failed";
 	}

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
@@ -553,16 +553,23 @@ describe("suppressQueuedMessageID / applyAuthoritativeQueuedMessages", () => {
 		expect(store.hasObservedQueuedMessageID(a.id)).toBe(false);
 	});
 
-	it("tracks chat status versions for in-flight requests", () => {
+	it("counts every server status report, including repeats", () => {
 		const store = createChatStore();
 
-		expect(store.getChatStatusVersion()).toBe(0);
+		expect(store.getServerChatStatusVersion()).toBe(0);
+
+		// Optimistic writes are not server reports.
 		store.setChatStatus("running");
-		expect(store.getChatStatusVersion()).toBe(1);
-		store.setChatStatus("running");
-		expect(store.getChatStatusVersion()).toBe(1);
-		store.setChatStatus("error");
-		expect(store.getChatStatusVersion()).toBe(2);
+		expect(store.getServerChatStatusVersion()).toBe(0);
+
+		store.applyServerChatStatus("error");
+		expect(store.getServerChatStatusVersion()).toBe(1);
+		expect(store.getSnapshot().chatStatus).toBe("error");
+
+		// A repeat of the current value is still the server speaking.
+		store.applyServerChatStatus("error");
+		expect(store.getServerChatStatusVersion()).toBe(2);
+		expect(store.getSnapshot().chatStatus).toBe("error");
 	});
 
 	it("unsuppressQueuedMessageID clears a promoted marker after a failed promotion", () => {

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
@@ -529,6 +529,34 @@ describe("suppressQueuedMessageID / applyAuthoritativeQueuedMessages", () => {
 		expect(store.getSnapshot().suppressedQueuedMessageIDs.size).toBe(0);
 	});
 
+	it("tracks authoritative queue and status versions for in-flight requests", () => {
+		const store = createChatStore();
+		const a = makeQueuedMessage(1, "A");
+		const b = makeQueuedMessage(2, "B");
+
+		expect(store.getAuthoritativeQueueVersion()).toBe(0);
+		store.applyAuthoritativeQueuedMessages([a, b]);
+		const afterApply = store.getAuthoritativeQueueVersion();
+		expect(afterApply).toBeGreaterThan(0);
+
+		// Optimistic writes are not server observations.
+		store.setQueuedMessages([b]);
+		expect(store.getAuthoritativeQueueVersion()).toBe(afterApply);
+
+		// An ignored stale snapshot is not an observation either.
+		store.markQueuedMessagePromoted(a.id);
+		store.applyAuthoritativeQueuedMessages([a, b]);
+		expect(store.getAuthoritativeQueueVersion()).toBe(afterApply);
+
+		expect(store.getChatStatusVersion()).toBe(0);
+		store.setChatStatus("running");
+		expect(store.getChatStatusVersion()).toBe(1);
+		store.setChatStatus("running");
+		expect(store.getChatStatusVersion()).toBe(1);
+		store.setChatStatus("error");
+		expect(store.getChatStatusVersion()).toBe(2);
+	});
+
 	it("unsuppressQueuedMessageID clears a promoted marker after a failed promotion", () => {
 		const store = createChatStore();
 		const a = makeQueuedMessage(1, "A");

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
@@ -460,8 +460,7 @@ describe("suppressQueuedMessageID / applyAuthoritativeQueuedMessages", () => {
 		store.suppressQueuedMessageID(b.id);
 		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(b.id)).toBe(true);
 
-		// The running-case promote only reorders the queue, so the backend
-		// still reports the suppressed message.
+		// Running-case promotion only reorders the queue; the backend still reports the row.
 		store.applyAuthoritativeQueuedMessages([b, a, c]);
 		expect(
 			store.getSnapshot().queuedMessages.map((message) => message.id),
@@ -513,11 +512,9 @@ describe("suppressQueuedMessageID / applyAuthoritativeQueuedMessages", () => {
 		const b = makeQueuedMessage(2, "B");
 		const c = makeQueuedMessage(3, "C");
 
-		// A was promoted into history and C was queued by the same send.
 		store.setQueuedMessages([b, c]);
 		store.markQueuedMessagePromoted(a.id);
 
-		// This snapshot predates both the promotion and C.
 		store.applyAuthoritativeQueuedMessages([a, b]);
 		expect(
 			store.getSnapshot().queuedMessages.map((message) => message.id),

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
@@ -32,6 +32,8 @@ const makeQueuedMessage = (
 		content: [{ type: "text", text }],
 	}) as TypesGen.ChatQueuedMessage;
 
+const testChatID = "chat-1";
+
 // ---------------------------------------------------------------------------
 // replaceMessages
 // ---------------------------------------------------------------------------
@@ -570,6 +572,192 @@ describe("suppressQueuedMessageID / applyAuthoritativeQueuedMessages", () => {
 		store.applyServerChatStatus("error");
 		expect(store.getServerChatStatusVersion()).toBe(2);
 		expect(store.getSnapshot().chatStatus).toBe("error");
+	});
+
+	it("restores a promoted head that a fresh snapshot still queues", () => {
+		const store = createChatStore();
+		const a = makeQueuedMessage(1, "A");
+		const b = makeQueuedMessage(2, "B");
+
+		store.setActiveChatID(testChatID);
+		store.setQueuedMessages([b]);
+		store.markQueuedMessagePromoted(a.id);
+		const baseline = store.getQueueConvergenceFence();
+
+		// Another tab re-queued A, so the server still lists it.
+		expect(
+			store
+				.applyPromoteRefetchQueuedMessages(testChatID, a.id, [a, b], baseline)
+				?.map((message) => message.id),
+		).toEqual([a.id, b.id]);
+		expect(
+			store.getSnapshot().queuedMessages.map((message) => message.id),
+		).toEqual([a.id, b.id]);
+		expect(store.getSnapshot().promotedQueuedMessageIDs.size).toBe(0);
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.size).toBe(0);
+	});
+
+	it("ignores a promote refetch that a newer snapshot already superseded", () => {
+		const store = createChatStore();
+		const a = makeQueuedMessage(1, "A");
+		const b = makeQueuedMessage(2, "B");
+		const c = makeQueuedMessage(3, "C");
+
+		store.setActiveChatID(testChatID);
+		store.setQueuedMessages([b]);
+		store.markQueuedMessagePromoted(a.id);
+		const baseline = store.getQueueConvergenceFence();
+
+		// An accepted queue_update lands while the refetch is in flight, so it
+		// is newer than the response the refetch is about to deliver.
+		store.applyAuthoritativeQueuedMessages([b, c]);
+
+		expect(
+			store.applyPromoteRefetchQueuedMessages(
+				testChatID,
+				a.id,
+				[a, b],
+				baseline,
+			),
+		).toBeUndefined();
+		expect(
+			store.getSnapshot().queuedMessages.map((message) => message.id),
+		).toEqual([b.id, c.id]);
+		// Accepting the snapshot already settled the promotion.
+		expect(store.getSnapshot().promotedQueuedMessageIDs.size).toBe(0);
+	});
+
+	it("still applies a promote refetch after a stale snapshot was discarded", () => {
+		const store = createChatStore();
+		const a = makeQueuedMessage(1, "A");
+		const b = makeQueuedMessage(2, "B");
+		const c = makeQueuedMessage(3, "C");
+
+		store.setActiveChatID(testChatID);
+		store.setQueuedMessages([b]);
+		store.markQueuedMessagePromoted(a.id);
+		const baseline = store.getQueueConvergenceFence();
+
+		// This snapshot predates the promotion, so it is discarded and must not
+		// supersede the refetch, which is the only way C becomes visible.
+		store.applyAuthoritativeQueuedMessages([a, b, c]);
+
+		expect(
+			store.applyPromoteRefetchQueuedMessages(
+				testChatID,
+				a.id,
+				[b, c],
+				baseline,
+			),
+		).toEqual([b, c]);
+		expect(
+			store.getSnapshot().queuedMessages.map((message) => message.id),
+		).toEqual([b.id, c.id]);
+	});
+
+	it("ignores a promote refetch that resolves after switching chats", () => {
+		const store = createChatStore();
+		const a = makeQueuedMessage(1, "A");
+		const b = makeQueuedMessage(2, "B");
+
+		store.setActiveChatID(testChatID);
+		store.setQueuedMessages([b]);
+		store.markQueuedMessagePromoted(a.id);
+		const baseline = store.getQueueConvergenceFence();
+
+		store.setActiveChatID("chat-other");
+		store.setQueuedMessages([]);
+
+		expect(
+			store.applyPromoteRefetchQueuedMessages(
+				testChatID,
+				a.id,
+				[a, b],
+				baseline,
+			),
+		).toBeUndefined();
+		expect(store.getSnapshot().queuedMessages).toEqual([]);
+	});
+
+	it("ignores a promote refetch spanning a round trip back to the same chat", () => {
+		const store = createChatStore();
+		const a = makeQueuedMessage(1, "A");
+		const b = makeQueuedMessage(2, "B");
+
+		store.setActiveChatID(testChatID);
+		store.setQueuedMessages([b]);
+		store.markQueuedMessagePromoted(a.id);
+		const baseline = store.getQueueConvergenceFence();
+
+		// No authoritative snapshot lands during the round trip, so only the
+		// activations themselves can strand the request.
+		store.setActiveChatID("chat-other");
+		store.setActiveChatID(testChatID);
+
+		expect(
+			store.applyPromoteRefetchQueuedMessages(
+				testChatID,
+				a.id,
+				[a, b],
+				baseline,
+			),
+		).toBeUndefined();
+		expect(
+			store.getSnapshot().queuedMessages.map((message) => message.id),
+		).toEqual([b.id]);
+	});
+
+	it("ignores a promote refetch naming another chat even at a matching fence", () => {
+		const store = createChatStore();
+		const a = makeQueuedMessage(1, "A");
+		const b = makeQueuedMessage(2, "B");
+
+		store.setActiveChatID(testChatID);
+		store.setQueuedMessages([b]);
+		store.markQueuedMessagePromoted(a.id);
+
+		// A caller that captured the fence too late would otherwise pass the
+		// ordering check while carrying another chat's queue.
+		expect(
+			store.applyPromoteRefetchQueuedMessages(
+				"chat-other",
+				a.id,
+				[a, b],
+				store.getQueueConvergenceFence(),
+			),
+		).toBeUndefined();
+		expect(
+			store.getSnapshot().queuedMessages.map((message) => message.id),
+		).toEqual([b.id]);
+	});
+
+	it("returns the queue it applied, not the raw snapshot", () => {
+		const store = createChatStore();
+		const a = makeQueuedMessage(1, "A");
+		const b = makeQueuedMessage(2, "B");
+		const c = makeQueuedMessage(3, "C");
+
+		store.setActiveChatID(testChatID);
+		store.setQueuedMessages([b]);
+		store.markQueuedMessagePromoted(a.id);
+		// An overlapping explicit promotion suppresses C without deleting it
+		// server-side, so the refetched snapshot still lists it.
+		store.suppressQueuedMessageID(c.id);
+		const baseline = store.getQueueConvergenceFence();
+
+		expect(
+			store
+				.applyPromoteRefetchQueuedMessages(
+					testChatID,
+					a.id,
+					[a, b, c],
+					baseline,
+				)
+				?.map((message) => message.id),
+		).toEqual([a.id, b.id]);
+		expect(
+			store.getSnapshot().queuedMessages.map((message) => message.id),
+		).toEqual([a.id, b.id]);
 	});
 
 	it("unsuppressQueuedMessageID clears a promoted marker after a failed promotion", () => {

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
@@ -460,8 +460,8 @@ describe("suppressQueuedMessageID / applyAuthoritativeQueuedMessages", () => {
 		store.suppressQueuedMessageID(b.id);
 		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(b.id)).toBe(true);
 
-		// Transient reordered queue from the running-case backend
-		// must not surface the suppressed message.
+		// The running-case promote only reorders the queue, so the backend
+		// still reports the suppressed message.
 		store.applyAuthoritativeQueuedMessages([b, a, c]);
 		expect(
 			store.getSnapshot().queuedMessages.map((message) => message.id),
@@ -489,6 +489,62 @@ describe("suppressQueuedMessageID / applyAuthoritativeQueuedMessages", () => {
 		expect(
 			store.getSnapshot().queuedMessages.map((message) => message.id),
 		).toEqual([a.id, c.id]);
+	});
+
+	it("still applies newly queued messages while a suppressed message stays queued", () => {
+		const store = createChatStore();
+		const a = makeQueuedMessage(1, "A");
+		const b = makeQueuedMessage(2, "B");
+		const d = makeQueuedMessage(4, "D");
+
+		store.setQueuedMessages([b]);
+		store.suppressQueuedMessageID(a.id);
+
+		store.applyAuthoritativeQueuedMessages([a, b, d]);
+		expect(
+			store.getSnapshot().queuedMessages.map((message) => message.id),
+		).toEqual([b.id, d.id]);
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(a.id)).toBe(true);
+	});
+
+	it("ignores stale snapshots that still list a promoted message", () => {
+		const store = createChatStore();
+		const a = makeQueuedMessage(1, "A");
+		const b = makeQueuedMessage(2, "B");
+		const c = makeQueuedMessage(3, "C");
+
+		// A was promoted into history and C was queued by the same send.
+		store.setQueuedMessages([b, c]);
+		store.markQueuedMessagePromoted(a.id);
+
+		// This snapshot predates both the promotion and C.
+		store.applyAuthoritativeQueuedMessages([a, b]);
+		expect(
+			store.getSnapshot().queuedMessages.map((message) => message.id),
+		).toEqual([b.id, c.id]);
+		expect(store.getSnapshot().promotedQueuedMessageIDs.has(a.id)).toBe(true);
+
+		store.applyAuthoritativeQueuedMessages([b, c]);
+		expect(
+			store.getSnapshot().queuedMessages.map((message) => message.id),
+		).toEqual([b.id, c.id]);
+		expect(store.getSnapshot().promotedQueuedMessageIDs.size).toBe(0);
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.size).toBe(0);
+	});
+
+	it("unsuppressQueuedMessageID clears a promoted marker after a failed promotion", () => {
+		const store = createChatStore();
+		const a = makeQueuedMessage(1, "A");
+		const b = makeQueuedMessage(2, "B");
+
+		store.markQueuedMessagePromoted(a.id);
+		store.unsuppressQueuedMessageID(a.id);
+		expect(store.getSnapshot().promotedQueuedMessageIDs.size).toBe(0);
+
+		store.applyAuthoritativeQueuedMessages([a, b]);
+		expect(
+			store.getSnapshot().queuedMessages.map((message) => message.id),
+		).toEqual([a.id, b.id]);
 	});
 
 	it("unsuppressQueuedMessageID removes IDs from the suppression set", () => {

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
@@ -542,15 +542,12 @@ describe("suppressQueuedMessageID / applyAuthoritativeQueuedMessages", () => {
 		expect(store.hasObservedQueuedMessageID(a.id)).toBe(true);
 		expect(store.hasObservedQueuedMessageID(b.id)).toBe(true);
 
-		// A later snapshot dropping A does not unlearn that A existed.
 		store.applyAuthoritativeQueuedMessages([b]);
 		expect(store.hasObservedQueuedMessageID(a.id)).toBe(true);
 
-		// Optimistic writes are not server reports.
 		store.setQueuedMessages([b, c]);
 		expect(store.hasObservedQueuedMessageID(c.id)).toBe(false);
 
-		// Observations are per-chat.
 		store.clearSuppressedQueuedMessageIDs();
 		expect(store.hasObservedQueuedMessageID(a.id)).toBe(false);
 	});
@@ -560,7 +557,6 @@ describe("suppressQueuedMessageID / applyAuthoritativeQueuedMessages", () => {
 
 		expect(store.getServerChatStatusVersion()).toBe(0);
 
-		// Optimistic writes are not server reports.
 		store.setChatStatus("running");
 		expect(store.getServerChatStatusVersion()).toBe(0);
 
@@ -568,7 +564,6 @@ describe("suppressQueuedMessageID / applyAuthoritativeQueuedMessages", () => {
 		expect(store.getServerChatStatusVersion()).toBe(1);
 		expect(store.getSnapshot().chatStatus).toBe("error");
 
-		// A repeat of the current value is still the server speaking.
 		store.applyServerChatStatus("error");
 		expect(store.getServerChatStatusVersion()).toBe(2);
 		expect(store.getSnapshot().chatStatus).toBe("error");
@@ -584,7 +579,6 @@ describe("suppressQueuedMessageID / applyAuthoritativeQueuedMessages", () => {
 		store.markQueuedMessagePromoted(a.id);
 		const baseline = store.getQueueConvergenceFence();
 
-		// Another tab re-queued A, so the server still lists it.
 		expect(
 			store
 				.applyPromoteRefetchQueuedMessages(testChatID, a.id, [a, b], baseline)
@@ -608,8 +602,6 @@ describe("suppressQueuedMessageID / applyAuthoritativeQueuedMessages", () => {
 		store.markQueuedMessagePromoted(a.id);
 		const baseline = store.getQueueConvergenceFence();
 
-		// An accepted queue_update lands while the refetch is in flight, so it
-		// is newer than the response the refetch is about to deliver.
 		store.applyAuthoritativeQueuedMessages([b, c]);
 
 		expect(
@@ -623,7 +615,6 @@ describe("suppressQueuedMessageID / applyAuthoritativeQueuedMessages", () => {
 		expect(
 			store.getSnapshot().queuedMessages.map((message) => message.id),
 		).toEqual([b.id, c.id]);
-		// Accepting the snapshot already settled the promotion.
 		expect(store.getSnapshot().promotedQueuedMessageIDs.size).toBe(0);
 	});
 
@@ -638,8 +629,6 @@ describe("suppressQueuedMessageID / applyAuthoritativeQueuedMessages", () => {
 		store.markQueuedMessagePromoted(a.id);
 		const baseline = store.getQueueConvergenceFence();
 
-		// This snapshot predates the promotion, so it is discarded and must not
-		// supersede the refetch, which is the only way C becomes visible.
 		store.applyAuthoritativeQueuedMessages([a, b, c]);
 
 		expect(
@@ -689,8 +678,6 @@ describe("suppressQueuedMessageID / applyAuthoritativeQueuedMessages", () => {
 		store.markQueuedMessagePromoted(a.id);
 		const baseline = store.getQueueConvergenceFence();
 
-		// No authoritative snapshot lands during the round trip, so only the
-		// activations themselves can strand the request.
 		store.setActiveChatID("chat-other");
 		store.setActiveChatID(testChatID);
 
@@ -716,8 +703,6 @@ describe("suppressQueuedMessageID / applyAuthoritativeQueuedMessages", () => {
 		store.setQueuedMessages([b]);
 		store.markQueuedMessagePromoted(a.id);
 
-		// A caller that captured the fence too late would otherwise pass the
-		// ordering check while carrying another chat's queue.
 		expect(
 			store.applyPromoteRefetchQueuedMessages(
 				"chat-other",
@@ -740,8 +725,6 @@ describe("suppressQueuedMessageID / applyAuthoritativeQueuedMessages", () => {
 		store.setActiveChatID(testChatID);
 		store.setQueuedMessages([b]);
 		store.markQueuedMessagePromoted(a.id);
-		// An overlapping explicit promotion suppresses C without deleting it
-		// server-side, so the refetched snapshot still lists it.
 		store.suppressQueuedMessageID(c.id);
 		const baseline = store.getQueueConvergenceFence();
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
@@ -529,24 +529,32 @@ describe("suppressQueuedMessageID / applyAuthoritativeQueuedMessages", () => {
 		expect(store.getSnapshot().suppressedQueuedMessageIDs.size).toBe(0);
 	});
 
-	it("tracks authoritative queue and status versions for in-flight requests", () => {
+	it("records queued IDs the server has reported", () => {
 		const store = createChatStore();
 		const a = makeQueuedMessage(1, "A");
 		const b = makeQueuedMessage(2, "B");
+		const c = makeQueuedMessage(3, "C");
 
-		expect(store.getAuthoritativeQueueVersion()).toBe(0);
+		expect(store.hasObservedQueuedMessageID(a.id)).toBe(false);
 		store.applyAuthoritativeQueuedMessages([a, b]);
-		const afterApply = store.getAuthoritativeQueueVersion();
-		expect(afterApply).toBeGreaterThan(0);
+		expect(store.hasObservedQueuedMessageID(a.id)).toBe(true);
+		expect(store.hasObservedQueuedMessageID(b.id)).toBe(true);
 
-		// Optimistic writes are not server observations.
-		store.setQueuedMessages([b]);
-		expect(store.getAuthoritativeQueueVersion()).toBe(afterApply);
+		// A later snapshot dropping A does not unlearn that A existed.
+		store.applyAuthoritativeQueuedMessages([b]);
+		expect(store.hasObservedQueuedMessageID(a.id)).toBe(true);
 
-		// An ignored stale snapshot is not an observation either.
-		store.markQueuedMessagePromoted(a.id);
-		store.applyAuthoritativeQueuedMessages([a, b]);
-		expect(store.getAuthoritativeQueueVersion()).toBe(afterApply);
+		// Optimistic writes are not server reports.
+		store.setQueuedMessages([b, c]);
+		expect(store.hasObservedQueuedMessageID(c.id)).toBe(false);
+
+		// Observations are per-chat.
+		store.clearSuppressedQueuedMessageIDs();
+		expect(store.hasObservedQueuedMessageID(a.id)).toBe(false);
+	});
+
+	it("tracks chat status versions for in-flight requests", () => {
+		const store = createChatStore();
 
 		expect(store.getChatStatusVersion()).toBe(0);
 		store.setChatStatus("running");

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -2410,6 +2410,62 @@ describe("useChatStore", () => {
 		});
 	});
 
+	it("keeps a websocket status delivered while the resync refetch is in flight", async () => {
+		const chatID = "chat-resync-ws-race";
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+		const queryClient = createTestQueryClient();
+		const wrapper = createWrapper(queryClient);
+		const chatRecord = { ...buildChat(chatID), status: "error" as const };
+
+		const { result, rerender } = renderHook(
+			({ updatedAt }: { updatedAt: number }) => {
+				const { store, acceptServerChatStatus } = useChatStore({
+					chatID,
+					chatMessages: [],
+					chatRecord,
+					chatRecordUpdatedAt: updatedAt,
+					chatMessagesData: {
+						messages: [],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason: () => {},
+					clearChatErrorReason: () => {},
+				});
+				return {
+					acceptServerChatStatus,
+					chatStatus: useChatSelector(store, selectChatStatus),
+				};
+			},
+			{ wrapper, initialProps: { updatedAt: 1 } },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
+		});
+
+		act(() => {
+			result.current.acceptServerChatStatus();
+		});
+		act(() => {
+			mockSocket.emitData({
+				type: "status",
+				chat_id: chatID,
+				status: { status: "running" },
+			});
+		});
+		await waitFor(() => {
+			expect(result.current.chatStatus).toBe("running");
+		});
+
+		rerender({ updatedAt: 2 });
+		await waitFor(() => {
+			expect(result.current.chatStatus).toBe("running");
+		});
+	});
+
 	it("sets chatStatus to error and populates streamError on error event", async () => {
 		immediateAnimationFrame();
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -2350,6 +2350,60 @@ describe("useChatStore", () => {
 		});
 	});
 
+	it("hydrates a refetched status that never changed value", async () => {
+		const chatID = "chat-resync-same";
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+		const queryClient = createTestQueryClient();
+		const wrapper = createWrapper(queryClient);
+
+		// The cache already holds "error" while the socket pushes "running",
+		// so opting back in must apply the cached value without it changing.
+		const { result } = renderHook(
+			() => {
+				const { store, acceptServerChatStatus } = useChatStore({
+					chatID,
+					chatMessages: [],
+					chatRecord: { ...buildChat(chatID), status: "error" },
+					chatMessagesData: {
+						messages: [],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason: vi.fn(),
+					clearChatErrorReason: vi.fn(),
+				});
+				return {
+					acceptServerChatStatus,
+					chatStatus: useChatSelector(store, selectChatStatus),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
+		});
+		act(() => {
+			mockSocket.emitData({
+				type: "status",
+				chat_id: chatID,
+				status: { status: "running" },
+			});
+		});
+		await waitFor(() => {
+			expect(result.current.chatStatus).toBe("running");
+		});
+
+		act(() => {
+			result.current.acceptServerChatStatus();
+		});
+		await waitFor(() => {
+			expect(result.current.chatStatus).toBe("error");
+		});
+	});
+
 	it("sets chatStatus to error and populates streamError on error event", async () => {
 		immediateAnimationFrame();
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -2297,6 +2297,7 @@ describe("useChatStore", () => {
 		const queryClient = createTestQueryClient();
 		const wrapper = createWrapper(queryClient);
 
+		const initialProps: { status: TypesGen.ChatStatus } = { status: "waiting" };
 		const { result, rerender } = renderHook(
 			({ status }: { status: TypesGen.ChatStatus }) => {
 				const { store, acceptServerChatStatus } = useChatStore({
@@ -2317,7 +2318,7 @@ describe("useChatStore", () => {
 					chatStatus: useChatSelector(store, selectChatStatus),
 				};
 			},
-			{ wrapper, initialProps: { status: "waiting" as TypesGen.ChatStatus } },
+			{ wrapper, initialProps },
 		);
 
 		await waitFor(() => {

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -34,11 +34,10 @@ import type { FC, PropsWithChildren } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type * as TypesGen from "#/api/typesGenerated";
-import { MockChat, MockChatMessage } from "#/testHelpers/chatEntities";
+import { MockChat } from "#/testHelpers/chatEntities";
 import { createTestQueryClient } from "#/testHelpers/renderHelpers";
 import type { OneWayMessageEvent } from "#/utils/OneWayWebSocket";
 import {
-	createChatStore,
 	selectChatStatus,
 	selectIsAwaitingFirstStreamChunk,
 	selectMessagesByID,
@@ -263,38 +262,6 @@ afterEach(() => {
 	vi.useRealTimers();
 	vi.restoreAllMocks();
 	vi.mocked(watchChat).mockReset();
-});
-
-describe("createChatStore", () => {
-	it("guards send response mutations by active chat", () => {
-		const store = createChatStore();
-		const sendChatID = "chat-old";
-		const activeMessage = {
-			...MockChatMessage,
-			id: 1,
-			chat_id: "chat-new",
-			content: [{ type: "text" as const, text: "New chat message" }],
-		};
-		const staleResponseMessage = {
-			...MockChatMessage,
-			id: 2,
-			chat_id: sendChatID,
-			content: [{ type: "text" as const, text: "Old chat message" }],
-		};
-
-		store.setActiveChatID(sendChatID);
-		store.setActiveChatID("chat-new");
-		store.replaceMessages([activeMessage]);
-		store.setChatStatus("waiting");
-
-		if (store.getActiveChatID() === sendChatID) {
-			store.upsertDurableMessages([staleResponseMessage]);
-			store.setChatStatus("running");
-		}
-
-		expect(store.getSnapshot().orderedMessageIDs).toEqual([activeMessage.id]);
-		expect(store.getSnapshot().chatStatus).toBe("waiting");
-	});
 });
 
 describe("useChatStore", () => {
@@ -2330,13 +2297,17 @@ describe("useChatStore", () => {
 		const queryClient = createTestQueryClient();
 		const wrapper = createWrapper(queryClient);
 
-		const initialProps: { status: TypesGen.ChatStatus } = { status: "waiting" };
+		const initialProps: { status: TypesGen.ChatStatus; updatedAt: number } = {
+			status: "waiting",
+			updatedAt: 1,
+		};
 		const { result, rerender } = renderHook(
-			({ status }: { status: TypesGen.ChatStatus }) => {
+			({ status, updatedAt }: typeof initialProps) => {
 				const { store, acceptServerChatStatus } = useChatStore({
 					chatID,
 					chatMessages: [],
 					chatRecord: { ...buildChat(chatID), status },
+					chatRecordUpdatedAt: updatedAt,
 					chatMessagesData: {
 						messages: [],
 						queued_messages: [],
@@ -2369,35 +2340,35 @@ describe("useChatStore", () => {
 		await waitFor(() => {
 			expect(result.current.chatStatus).toBe("running");
 		});
-		rerender({ status: "error" });
+		rerender({ status: "error", updatedAt: 1 });
 		expect(result.current.chatStatus).toBe("running");
 
-		// A failed request opts back in, so the next refetch applies.
 		act(() => {
 			result.current.acceptServerChatStatus();
 		});
-		rerender({ status: "waiting" });
-		rerender({ status: "error" });
+		rerender({ status: "waiting", updatedAt: 1 });
+		expect(result.current.chatStatus).toBe("running");
+		rerender({ status: "error", updatedAt: 2 });
 		await waitFor(() => {
 			expect(result.current.chatStatus).toBe("error");
 		});
 	});
 
-	it("hydrates a refetched status that never changed value", async () => {
+	it("hydrates an unchanged status after a successful refetch", async () => {
 		const chatID = "chat-resync-same";
 		const mockSocket = createMockSocket();
 		mockWatchChatReturn(mockSocket);
 		const queryClient = createTestQueryClient();
 		const wrapper = createWrapper(queryClient);
+		const chatRecord = { ...buildChat(chatID), status: "error" as const };
 
-		// The cache already holds "error" while the socket pushes "running",
-		// so opting back in must apply the cached value without it changing.
-		const { result } = renderHook(
-			() => {
+		const { result, rerender } = renderHook(
+			({ updatedAt }: { updatedAt: number }) => {
 				const { store, acceptServerChatStatus } = useChatStore({
 					chatID,
 					chatMessages: [],
-					chatRecord: { ...buildChat(chatID), status: "error" },
+					chatRecord,
+					chatRecordUpdatedAt: updatedAt,
 					chatMessagesData: {
 						messages: [],
 						queued_messages: [],
@@ -2412,7 +2383,7 @@ describe("useChatStore", () => {
 					chatStatus: useChatSelector(store, selectChatStatus),
 				};
 			},
-			{ wrapper },
+			{ wrapper, initialProps: { updatedAt: 1 } },
 		);
 
 		await waitFor(() => {
@@ -2432,6 +2403,8 @@ describe("useChatStore", () => {
 		act(() => {
 			result.current.acceptServerChatStatus();
 		});
+		expect(result.current.chatStatus).toBe("running");
+		rerender({ updatedAt: 2 });
 		await waitFor(() => {
 			expect(result.current.chatStatus).toBe("error");
 		});

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -1537,6 +1537,83 @@ describe("useChatStore", () => {
 		expect(cachedData?.pages[0]?.queued_messages).toEqual([]);
 	});
 
+	it("caches the filtered queue when a queue_update still contains a suppressed message", async () => {
+		const chatID = "chat-1";
+		const existingMessage = buildMessage(chatID, 1, "user", "hello");
+		const queuedMessage = buildQueuedMessage(chatID, 10, "queued");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = new QueryClient({
+			defaultOptions: {
+				queries: {
+					retry: false,
+					gcTime: Number.POSITIVE_INFINITY,
+					refetchOnWindowFocus: false,
+					networkMode: "offlineFirst",
+				},
+			},
+		});
+		const initialChatMessagesData: TypesGen.ChatMessagesResponse = {
+			messages: [existingMessage],
+			queued_messages: [queuedMessage],
+			has_more: false,
+		};
+		queryClient.setQueryData(chatMessagesKey(chatID), {
+			pages: [initialChatMessagesData],
+			pageParams: [undefined],
+		});
+
+		const wrapper = createWrapper(queryClient);
+		const setChatErrorReason = vi.fn();
+		const clearChatErrorReason = vi.fn();
+
+		const { result } = renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [existingMessage],
+					chatRecord: buildChat(chatID),
+					chatMessagesData: initialChatMessagesData,
+					chatQueuedMessages: [queuedMessage],
+					setChatErrorReason,
+					clearChatErrorReason,
+				});
+				return {
+					store,
+					queuedMessages: useChatSelector(store, selectQueuedMessages),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		// Promote the queued message, then deliver a stale queue_update
+		// that still contains it.
+		act(() => {
+			result.current.store.suppressQueuedMessageID(queuedMessage.id);
+		});
+		act(() => {
+			mockSocket.emitData({
+				type: "queue_update",
+				chat_id: chatID,
+				queued_messages: [queuedMessage],
+			});
+		});
+
+		await waitFor(() => {
+			expect(result.current.queuedMessages).toEqual([]);
+		});
+		const cachedData = queryClient.getQueryData<{
+			pages: TypesGen.ChatMessagesResponse[];
+			pageParams: unknown[];
+		}>(chatMessagesKey(chatID));
+		expect(cachedData?.pages[0]?.queued_messages).toEqual([]);
+	});
+
 	it("writes WebSocket message events into the chat query cache", async () => {
 		const chatID = "chat-1";
 		const existingMessage = buildMessage(chatID, 1, "user", "hello");

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -2410,6 +2410,70 @@ describe("useChatStore", () => {
 		});
 	});
 
+	it("ignores a resync armed by a request from a chat the user left", async () => {
+		const leftChatID = "chat-resync-left";
+		const activeChatID = "chat-resync-active";
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+		const queryClient = createTestQueryClient();
+		const wrapper = createWrapper(queryClient);
+
+		const { result, rerender } = renderHook(
+			({ chatID, updatedAt }: { chatID: string; updatedAt: number }) => {
+				const { store, acceptServerChatStatus } = useChatStore({
+					chatID,
+					chatMessages: [],
+					chatRecord: { ...buildChat(chatID), status: "waiting" },
+					chatRecordUpdatedAt: updatedAt,
+					chatMessagesData: {
+						messages: [],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason: () => {},
+					clearChatErrorReason: () => {},
+				});
+				return {
+					acceptServerChatStatus,
+					chatStatus: useChatSelector(store, selectChatStatus),
+				};
+			},
+			{
+				wrapper,
+				initialProps: { chatID: leftChatID, updatedAt: 1 },
+			},
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(leftChatID, undefined);
+		});
+		// The in-flight request holds the callback from the render it started in.
+		const staleAcceptServerChatStatus = result.current.acceptServerChatStatus;
+
+		rerender({ chatID: activeChatID, updatedAt: 5 });
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(activeChatID, undefined);
+		});
+		act(() => {
+			mockSocket.emitData({
+				type: "status",
+				chat_id: activeChatID,
+				status: { status: "running" },
+			});
+		});
+		await waitFor(() => {
+			expect(result.current.chatStatus).toBe("running");
+		});
+
+		act(() => {
+			staleAcceptServerChatStatus();
+		});
+		await waitFor(() => {
+			expect(result.current.chatStatus).toBe("running");
+		});
+	});
+
 	it("keeps a websocket status delivered while the resync refetch is in flight", async () => {
 		const chatID = "chat-resync-ws-race";
 		const mockSocket = createMockSocket();

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -1591,8 +1591,6 @@ describe("useChatStore", () => {
 			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
 		});
 
-		// Promote the queued message, then deliver a stale queue_update
-		// that still contains it.
 		act(() => {
 			result.current.store.suppressQueuedMessageID(queuedMessage.id);
 		});

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -34,10 +34,11 @@ import type { FC, PropsWithChildren } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type * as TypesGen from "#/api/typesGenerated";
-import { MockChat } from "#/testHelpers/chatEntities";
+import { MockChat, MockChatMessage } from "#/testHelpers/chatEntities";
 import { createTestQueryClient } from "#/testHelpers/renderHelpers";
 import type { OneWayMessageEvent } from "#/utils/OneWayWebSocket";
 import {
+	createChatStore,
 	selectChatStatus,
 	selectIsAwaitingFirstStreamChunk,
 	selectMessagesByID,
@@ -262,6 +263,38 @@ afterEach(() => {
 	vi.useRealTimers();
 	vi.restoreAllMocks();
 	vi.mocked(watchChat).mockReset();
+});
+
+describe("createChatStore", () => {
+	it("guards send response mutations by active chat", () => {
+		const store = createChatStore();
+		const sendChatID = "chat-old";
+		const activeMessage = {
+			...MockChatMessage,
+			id: 1,
+			chat_id: "chat-new",
+			content: [{ type: "text" as const, text: "New chat message" }],
+		};
+		const staleResponseMessage = {
+			...MockChatMessage,
+			id: 2,
+			chat_id: sendChatID,
+			content: [{ type: "text" as const, text: "Old chat message" }],
+		};
+
+		store.setActiveChatID(sendChatID);
+		store.setActiveChatID("chat-new");
+		store.replaceMessages([activeMessage]);
+		store.setChatStatus("waiting");
+
+		if (store.getActiveChatID() === sendChatID) {
+			store.upsertDurableMessages([staleResponseMessage]);
+			store.setChatStatus("running");
+		}
+
+		expect(store.getSnapshot().orderedMessageIDs).toEqual([activeMessage.id]);
+		expect(store.getSnapshot().chatStatus).toBe("waiting");
+	});
 });
 
 describe("useChatStore", () => {

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -2290,6 +2290,65 @@ describe("useChatStore", () => {
 		});
 	});
 
+	it("applies a refetched status after acceptServerChatStatus", async () => {
+		const chatID = "chat-resync";
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+		const queryClient = createTestQueryClient();
+		const wrapper = createWrapper(queryClient);
+
+		const { result, rerender } = renderHook(
+			({ status }: { status: TypesGen.ChatStatus }) => {
+				const { store, acceptServerChatStatus } = useChatStore({
+					chatID,
+					chatMessages: [],
+					chatRecord: { ...buildChat(chatID), status },
+					chatMessagesData: {
+						messages: [],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason: vi.fn(),
+					clearChatErrorReason: vi.fn(),
+				});
+				return {
+					acceptServerChatStatus,
+					chatStatus: useChatSelector(store, selectChatStatus),
+				};
+			},
+			{ wrapper, initialProps: { status: "waiting" as TypesGen.ChatStatus } },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
+		});
+
+		// The socket becomes authoritative, so a refetched status is ignored.
+		act(() => {
+			mockSocket.emitData({
+				type: "status",
+				chat_id: chatID,
+				status: { status: "running" },
+			});
+		});
+		await waitFor(() => {
+			expect(result.current.chatStatus).toBe("running");
+		});
+		rerender({ status: "error" });
+		expect(result.current.chatStatus).toBe("running");
+
+		// A failed request opts back in, so the next refetch applies.
+		act(() => {
+			result.current.acceptServerChatStatus();
+		});
+		rerender({ status: "waiting" });
+		rerender({ status: "error" });
+		await waitFor(() => {
+			expect(result.current.chatStatus).toBe("error");
+		});
+	});
+
 	it("sets chatStatus to error and populates streamError on error event", async () => {
 		immediateAnimationFrame();
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -2329,7 +2329,6 @@ describe("useChatStore", () => {
 			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
 		});
 
-		// The socket becomes authoritative, so a refetched status is ignored.
 		act(() => {
 			mockSocket.emitData({
 				type: "status",

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
@@ -140,9 +140,8 @@ export type ChatStoreState = {
 	// the running-case promote, where the backend reorders the
 	// queued message to the front before auto-promoting it.
 	suppressedQueuedMessageIDs: ReadonlySet<number>;
-	// Suppressed IDs whose queue row the server has provably deleted,
-	// because the send response carried the promoted user row. A
-	// snapshot that still lists one predates that promotion.
+	// IDs confirmed deleted from the queue because the send response
+	// contained their promoted user rows.
 	promotedQueuedMessageIDs: ReadonlySet<number>;
 	subagentStatusOverrides: Map<string, TypesGen.ChatStatus>;
 };
@@ -172,7 +171,7 @@ export type ChatStore = {
 		queuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined,
 	) => void;
 	suppressQueuedMessageID: (id: number) => void;
-	// Suppresses id and records that its queue row is already gone.
+	// Suppresses id and records that its queue row is already deleted.
 	markQueuedMessagePromoted: (id: number) => void;
 	unsuppressQueuedMessageID: (id: number) => void;
 	clearSuppressedQueuedMessageIDs: () => void;
@@ -412,9 +411,8 @@ export const createChatStore = (): ChatStore => {
 		applyAuthoritativeQueuedMessages: (queuedMessages) => {
 			const incoming = queuedMessages ?? [];
 			setState((current) => {
-				// A snapshot listing an ID whose row the server already
-				// deleted predates that deletion, so applying it would both
-				// revert the queue and drop messages queued since.
+				// A snapshot containing a confirmed promoted ID predates its queue
+				// deletion. Applying it would also drop newer queued messages.
 				if (
 					incoming.some((message) =>
 						current.promotedQueuedMessageIDs.has(message.id),

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
@@ -173,6 +173,10 @@ export type ChatStore = {
 	suppressQueuedMessageID: (id: number) => void;
 	// Suppresses id and records that its queue row is already deleted.
 	markQueuedMessagePromoted: (id: number) => void;
+	// Counters for detecting that the server reported a newer queue or
+	// status while a request was in flight.
+	getAuthoritativeQueueVersion: () => number;
+	getChatStatusVersion: () => number;
 	unsuppressQueuedMessageID: (id: number) => void;
 	clearSuppressedQueuedMessageIDs: () => void;
 	setChatStatus: (status: TypesGen.ChatStatus | null) => void;
@@ -208,6 +212,10 @@ const createInitialState = (): ChatStoreState => ({
 
 export const createChatStore = (): ChatStore => {
 	let state = createInitialState();
+	// Bookkeeping, deliberately outside the rendered state so observing a
+	// server event cannot trigger a re-render.
+	let authoritativeQueueVersion = 0;
+	let chatStatusVersion = 0;
 	const listeners = new Set<() => void>();
 
 	const emit = (): void => {
@@ -420,6 +428,7 @@ export const createChatStore = (): ChatStore => {
 				) {
 					return current;
 				}
+				authoritativeQueueVersion++;
 				let nextSuppressed = current.suppressedQueuedMessageIDs;
 				if (current.suppressedQueuedMessageIDs.size > 0) {
 					const incomingIDs = new Set(incoming.map((message) => message.id));
@@ -462,6 +471,8 @@ export const createChatStore = (): ChatStore => {
 				};
 			});
 		},
+		getAuthoritativeQueueVersion: () => authoritativeQueueVersion,
+		getChatStatusVersion: () => chatStatusVersion,
 		suppressQueuedMessageID: (id) => {
 			setState((current) => {
 				if (current.suppressedQueuedMessageIDs.has(id)) {
@@ -529,6 +540,7 @@ export const createChatStore = (): ChatStore => {
 			if (state.chatStatus === status) {
 				return;
 			}
+			chatStatusVersion++;
 			setState((current) => ({
 				...current,
 				chatStatus: status,

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
@@ -177,8 +177,12 @@ export type ChatStore = {
 	// server never mentioned is still in flight; one it mentioned and then
 	// dropped was deleted.
 	hasObservedQueuedMessageID: (id: number) => boolean;
-	// Detects that the server reported a newer status mid-request.
-	getChatStatusVersion: () => number;
+	// Counts server-reported status events, including repeats of the
+	// current value, so a caller can tell that the server spoke during a
+	// request even when the status did not change.
+	getServerChatStatusVersion: () => number;
+	// Records a server-reported status; always counts as an observation.
+	applyServerChatStatus: (status: TypesGen.ChatStatus | null) => void;
 	unsuppressQueuedMessageID: (id: number) => void;
 	clearSuppressedQueuedMessageIDs: () => void;
 	setChatStatus: (status: TypesGen.ChatStatus | null) => void;
@@ -217,7 +221,7 @@ export const createChatStore = (): ChatStore => {
 	// Bookkeeping, deliberately outside the rendered state so observing a
 	// server event cannot trigger a re-render.
 	let observedQueuedMessageIDs = new Set<number>();
-	let chatStatusVersion = 0;
+	let serverChatStatusVersion = 0;
 	const listeners = new Set<() => void>();
 
 	const emit = (): void => {
@@ -476,7 +480,6 @@ export const createChatStore = (): ChatStore => {
 			});
 		},
 		hasObservedQueuedMessageID: (id) => observedQueuedMessageIDs.has(id),
-		getChatStatusVersion: () => chatStatusVersion,
 		suppressQueuedMessageID: (id) => {
 			setState((current) => {
 				if (current.suppressedQueuedMessageIDs.has(id)) {
@@ -545,7 +548,17 @@ export const createChatStore = (): ChatStore => {
 			if (state.chatStatus === status) {
 				return;
 			}
-			chatStatusVersion++;
+			setState((current) => ({
+				...current,
+				chatStatus: status,
+			}));
+		},
+		getServerChatStatusVersion: () => serverChatStatusVersion,
+		applyServerChatStatus: (status) => {
+			serverChatStatusVersion++;
+			if (state.chatStatus === status) {
+				return;
+			}
 			setState((current) => ({
 				...current,
 				chatStatus: status,

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
@@ -140,6 +140,10 @@ export type ChatStoreState = {
 	// the running-case promote, where the backend reorders the
 	// queued message to the front before auto-promoting it.
 	suppressedQueuedMessageIDs: ReadonlySet<number>;
+	// Suppressed IDs whose queue row the server has provably deleted,
+	// because the send response carried the promoted user row. A
+	// snapshot that still lists one predates that promotion.
+	promotedQueuedMessageIDs: ReadonlySet<number>;
 	subagentStatusOverrides: Map<string, TypesGen.ChatStatus>;
 };
 
@@ -168,6 +172,8 @@ export type ChatStore = {
 		queuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined,
 	) => void;
 	suppressQueuedMessageID: (id: number) => void;
+	// Suppresses id and records that its queue row is already gone.
+	markQueuedMessagePromoted: (id: number) => void;
 	unsuppressQueuedMessageID: (id: number) => void;
 	clearSuppressedQueuedMessageIDs: () => void;
 	setChatStatus: (status: TypesGen.ChatStatus | null) => void;
@@ -197,6 +203,7 @@ const createInitialState = (): ChatStoreState => ({
 	reconnectState: null,
 	queuedMessages: [],
 	suppressedQueuedMessageIDs: new Set(),
+	promotedQueuedMessageIDs: new Set(),
 	subagentStatusOverrides: new Map(),
 });
 
@@ -405,6 +412,16 @@ export const createChatStore = (): ChatStore => {
 		applyAuthoritativeQueuedMessages: (queuedMessages) => {
 			const incoming = queuedMessages ?? [];
 			setState((current) => {
+				// A snapshot listing an ID whose row the server already
+				// deleted predates that deletion, so applying it would both
+				// revert the queue and drop messages queued since.
+				if (
+					incoming.some((message) =>
+						current.promotedQueuedMessageIDs.has(message.id),
+					)
+				) {
+					return current;
+				}
 				let nextSuppressed = current.suppressedQueuedMessageIDs;
 				if (current.suppressedQueuedMessageIDs.size > 0) {
 					const incomingIDs = new Set(incoming.map((message) => message.id));
@@ -431,13 +448,19 @@ export const createChatStore = (): ChatStore => {
 				);
 				const sameSuppressed =
 					nextSuppressed === current.suppressedQueuedMessageIDs;
-				if (sameQueue && sameSuppressed) {
+				const nextPromoted =
+					current.promotedQueuedMessageIDs.size === 0
+						? current.promotedQueuedMessageIDs
+						: new Set<number>();
+				const samePromoted = nextPromoted === current.promotedQueuedMessageIDs;
+				if (sameQueue && sameSuppressed && samePromoted) {
 					return current;
 				}
 				return {
 					...current,
 					queuedMessages: sameQueue ? current.queuedMessages : filtered,
 					suppressedQueuedMessageIDs: nextSuppressed,
+					promotedQueuedMessageIDs: nextPromoted,
 				};
 			});
 		},
@@ -451,22 +474,57 @@ export const createChatStore = (): ChatStore => {
 				return { ...current, suppressedQueuedMessageIDs: next };
 			});
 		},
-		unsuppressQueuedMessageID: (id) => {
+		markQueuedMessagePromoted: (id) => {
 			setState((current) => {
-				if (!current.suppressedQueuedMessageIDs.has(id)) {
+				if (
+					current.suppressedQueuedMessageIDs.has(id) &&
+					current.promotedQueuedMessageIDs.has(id)
+				) {
 					return current;
 				}
-				const next = new Set(current.suppressedQueuedMessageIDs);
-				next.delete(id);
-				return { ...current, suppressedQueuedMessageIDs: next };
+				const suppressed = new Set(current.suppressedQueuedMessageIDs);
+				suppressed.add(id);
+				const promoted = new Set(current.promotedQueuedMessageIDs);
+				promoted.add(id);
+				return {
+					...current,
+					suppressedQueuedMessageIDs: suppressed,
+					promotedQueuedMessageIDs: promoted,
+				};
+			});
+		},
+		unsuppressQueuedMessageID: (id) => {
+			setState((current) => {
+				if (
+					!current.suppressedQueuedMessageIDs.has(id) &&
+					!current.promotedQueuedMessageIDs.has(id)
+				) {
+					return current;
+				}
+				const suppressed = new Set(current.suppressedQueuedMessageIDs);
+				suppressed.delete(id);
+				const promoted = new Set(current.promotedQueuedMessageIDs);
+				promoted.delete(id);
+				return {
+					...current,
+					suppressedQueuedMessageIDs: suppressed,
+					promotedQueuedMessageIDs: promoted,
+				};
 			});
 		},
 		clearSuppressedQueuedMessageIDs: () => {
 			setState((current) => {
-				if (current.suppressedQueuedMessageIDs.size === 0) {
+				if (
+					current.suppressedQueuedMessageIDs.size === 0 &&
+					current.promotedQueuedMessageIDs.size === 0
+				) {
 					return current;
 				}
-				return { ...current, suppressedQueuedMessageIDs: new Set() };
+				return {
+					...current,
+					suppressedQueuedMessageIDs: new Set(),
+					promotedQueuedMessageIDs: new Set(),
+				};
 			});
 		},
 		setChatStatus: (status) => {

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
@@ -173,9 +173,11 @@ export type ChatStore = {
 	suppressQueuedMessageID: (id: number) => void;
 	// Suppresses id and records that its queue row is already deleted.
 	markQueuedMessagePromoted: (id: number) => void;
-	// Counters for detecting that the server reported a newer queue or
-	// status while a request was in flight.
-	getAuthoritativeQueueVersion: () => number;
+	// Reports whether any authoritative snapshot has listed id. A tail the
+	// server never mentioned is still in flight; one it mentioned and then
+	// dropped was deleted.
+	hasObservedQueuedMessageID: (id: number) => boolean;
+	// Detects that the server reported a newer status mid-request.
 	getChatStatusVersion: () => number;
 	unsuppressQueuedMessageID: (id: number) => void;
 	clearSuppressedQueuedMessageIDs: () => void;
@@ -214,7 +216,7 @@ export const createChatStore = (): ChatStore => {
 	let state = createInitialState();
 	// Bookkeeping, deliberately outside the rendered state so observing a
 	// server event cannot trigger a re-render.
-	let authoritativeQueueVersion = 0;
+	let observedQueuedMessageIDs = new Set<number>();
 	let chatStatusVersion = 0;
 	const listeners = new Set<() => void>();
 
@@ -418,6 +420,9 @@ export const createChatStore = (): ChatStore => {
 		},
 		applyAuthoritativeQueuedMessages: (queuedMessages) => {
 			const incoming = queuedMessages ?? [];
+			for (const message of incoming) {
+				observedQueuedMessageIDs.add(message.id);
+			}
 			setState((current) => {
 				// A snapshot containing a confirmed promoted ID predates its queue
 				// deletion. Applying it would also drop newer queued messages.
@@ -428,7 +433,6 @@ export const createChatStore = (): ChatStore => {
 				) {
 					return current;
 				}
-				authoritativeQueueVersion++;
 				let nextSuppressed = current.suppressedQueuedMessageIDs;
 				if (current.suppressedQueuedMessageIDs.size > 0) {
 					const incomingIDs = new Set(incoming.map((message) => message.id));
@@ -471,7 +475,7 @@ export const createChatStore = (): ChatStore => {
 				};
 			});
 		},
-		getAuthoritativeQueueVersion: () => authoritativeQueueVersion,
+		hasObservedQueuedMessageID: (id) => observedQueuedMessageIDs.has(id),
 		getChatStatusVersion: () => chatStatusVersion,
 		suppressQueuedMessageID: (id) => {
 			setState((current) => {
@@ -522,6 +526,7 @@ export const createChatStore = (): ChatStore => {
 			});
 		},
 		clearSuppressedQueuedMessageIDs: () => {
+			observedQueuedMessageIDs = new Set();
 			setState((current) => {
 				if (
 					current.suppressedQueuedMessageIDs.size === 0 &&

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
@@ -170,6 +170,21 @@ export type ChatStore = {
 	applyAuthoritativeQueuedMessages: (
 		queuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined,
 	) => void;
+	// Advances whenever an in-flight convergence request goes stale: an accepted
+	// authoritative snapshot, or a change of active chat. Snapshots discarded as
+	// stale do not advance it, since discarding one leaves the caller's data
+	// fresher.
+	getQueueConvergenceFence: () => number;
+	// Applies a snapshot fetched specifically to settle promotedID, whose
+	// promotion markers this clears. Returns the queue actually applied, which
+	// the caller should mirror into its cache, or undefined when chatID is no
+	// longer active or the fence moved past baselineFence.
+	applyPromoteRefetchQueuedMessages: (
+		chatID: string,
+		promotedID: number,
+		queuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined,
+		baselineFence: number,
+	) => readonly TypesGen.ChatQueuedMessage[] | undefined;
 	suppressQueuedMessageID: (id: number) => void;
 	// Suppresses id and records that its queue row is already deleted.
 	markQueuedMessagePromoted: (id: number) => void;
@@ -223,6 +238,7 @@ export const createChatStore = (): ChatStore => {
 	// Bookkeeping, deliberately outside the rendered state so observing a
 	// server event cannot trigger a re-render.
 	let observedQueuedMessageIDs = new Set<number>();
+	let queueConvergenceFence = 0;
 	let serverChatStatusVersion = 0;
 	let activeChatID: string | null = null;
 	const listeners = new Set<() => void>();
@@ -430,16 +446,18 @@ export const createChatStore = (): ChatStore => {
 			for (const message of incoming) {
 				observedQueuedMessageIDs.add(message.id);
 			}
+			// A snapshot containing a confirmed promoted ID predates its queue
+			// deletion. Applying it would also drop newer queued messages, and
+			// counting it would discard the fresher refetch racing it.
+			if (
+				incoming.some((message) =>
+					state.promotedQueuedMessageIDs.has(message.id),
+				)
+			) {
+				return;
+			}
+			queueConvergenceFence++;
 			setState((current) => {
-				// A snapshot containing a confirmed promoted ID predates its queue
-				// deletion. Applying it would also drop newer queued messages.
-				if (
-					incoming.some((message) =>
-						current.promotedQueuedMessageIDs.has(message.id),
-					)
-				) {
-					return current;
-				}
 				let nextSuppressed = current.suppressedQueuedMessageIDs;
 				if (current.suppressedQueuedMessageIDs.size > 0) {
 					const incomingIDs = new Set(incoming.map((message) => message.id));
@@ -481,6 +499,48 @@ export const createChatStore = (): ChatStore => {
 					promotedQueuedMessageIDs: nextPromoted,
 				};
 			});
+		},
+		getQueueConvergenceFence: () => queueConvergenceFence,
+		applyPromoteRefetchQueuedMessages: (
+			chatID,
+			promotedID,
+			queuedMessages,
+			baselineFence,
+		) => {
+			// The fence covers ordering, including navigation. This identity check
+			// additionally keeps a response that names another chat out of the
+			// shared store even if its caller captured the fence incorrectly.
+			if (activeChatID !== chatID) {
+				return undefined;
+			}
+			if (queueConvergenceFence !== baselineFence) {
+				return undefined;
+			}
+			const incoming = queuedMessages ?? [];
+			queueConvergenceFence++;
+			for (const message of incoming) {
+				observedQueuedMessageIDs.add(message.id);
+			}
+			const suppressed = new Set(state.suppressedQueuedMessageIDs);
+			suppressed.delete(promotedID);
+			const promoted = new Set(state.promotedQueuedMessageIDs);
+			promoted.delete(promotedID);
+			const applied =
+				suppressed.size === 0
+					? incoming
+					: incoming.filter((message) => !suppressed.has(message.id));
+			setState((current) => ({
+				...current,
+				queuedMessages: chatQueuedMessagesEqualByID(
+					current.queuedMessages,
+					applied,
+				)
+					? current.queuedMessages
+					: applied,
+				suppressedQueuedMessageIDs: suppressed,
+				promotedQueuedMessageIDs: promoted,
+			}));
+			return applied;
 		},
 		hasObservedQueuedMessageID: (id) => observedQueuedMessageIDs.has(id),
 		suppressQueuedMessageID: (id) => {
@@ -557,7 +617,13 @@ export const createChatStore = (): ChatStore => {
 			}));
 		},
 		setActiveChatID: (chatID) => {
+			if (activeChatID === chatID) {
+				return;
+			}
 			activeChatID = chatID;
+			// Leaving a chat strands any convergence request issued for it, so a
+			// later return to the same chat cannot revive one.
+			queueConvergenceFence++;
 		},
 		getActiveChatID: () => activeChatID,
 		getServerChatStatusVersion: () => serverChatStatusVersion,

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
@@ -177,6 +177,8 @@ export type ChatStore = {
 	// server never mentioned is still in flight; one it mentioned and then
 	// dropped was deleted.
 	hasObservedQueuedMessageID: (id: number) => boolean;
+	setActiveChatID: (chatID: string | null) => void;
+	getActiveChatID: () => string | null;
 	// Counts server-reported status events, including repeats of the
 	// current value, so a caller can tell that the server spoke during a
 	// request even when the status did not change.
@@ -222,6 +224,7 @@ export const createChatStore = (): ChatStore => {
 	// server event cannot trigger a re-render.
 	let observedQueuedMessageIDs = new Set<number>();
 	let serverChatStatusVersion = 0;
+	let activeChatID: string | null = null;
 	const listeners = new Set<() => void>();
 
 	const emit = (): void => {
@@ -553,6 +556,10 @@ export const createChatStore = (): ChatStore => {
 				chatStatus: status,
 			}));
 		},
+		setActiveChatID: (chatID) => {
+			activeChatID = chatID;
+		},
+		getActiveChatID: () => activeChatID,
 		getServerChatStatusVersion: () => serverChatStatusVersion,
 		applyServerChatStatus: (status) => {
 			serverChatStatusVersion++;

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
@@ -170,15 +170,11 @@ export type ChatStore = {
 	applyAuthoritativeQueuedMessages: (
 		queuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined,
 	) => void;
-	// Advances whenever an in-flight convergence request goes stale: an accepted
-	// authoritative snapshot, or a change of active chat. Snapshots discarded as
-	// stale do not advance it, since discarding one leaves the caller's data
-	// fresher.
+	// Advances when an accepted snapshot or active-chat change invalidates an
+	// in-flight convergence request. Discarded snapshots do not advance it.
 	getQueueConvergenceFence: () => number;
-	// Applies a snapshot fetched specifically to settle promotedID, whose
-	// promotion markers this clears. Returns the queue actually applied, which
-	// the caller should mirror into its cache, or undefined when chatID is no
-	// longer active or the fence moved past baselineFence.
+	// Applies a promotion refetch only while the chat and fence still match.
+	// Clears that ID's markers and returns the filtered queue for cache mirroring.
 	applyPromoteRefetchQueuedMessages: (
 		chatID: string,
 		promotedID: number,
@@ -186,11 +182,8 @@ export type ChatStore = {
 		baselineFence: number,
 	) => readonly TypesGen.ChatQueuedMessage[] | undefined;
 	suppressQueuedMessageID: (id: number) => void;
-	// Suppresses id and records that its queue row is already deleted.
 	markQueuedMessagePromoted: (id: number) => void;
-	// Reports whether any authoritative snapshot has listed id. A tail the
-	// server never mentioned is still in flight; one it mentioned and then
-	// dropped was deleted.
+	// Distinguishes a tail still in flight from one the server listed and later removed.
 	hasObservedQueuedMessageID: (id: number) => boolean;
 	setActiveChatID: (chatID: string | null) => void;
 	getActiveChatID: () => string | null;
@@ -198,7 +191,6 @@ export type ChatStore = {
 	// current value, so a caller can tell that the server spoke during a
 	// request even when the status did not change.
 	getServerChatStatusVersion: () => number;
-	// Records a server-reported status; always counts as an observation.
 	applyServerChatStatus: (status: TypesGen.ChatStatus | null) => void;
 	unsuppressQueuedMessageID: (id: number) => void;
 	clearSuppressedQueuedMessageIDs: () => void;

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -65,6 +65,18 @@ const writeQueuedMessagesToCache = (
 	});
 };
 
+const readQueuedMessagesFromCache = (
+	queryClient: QueryClient,
+	chatID: string | undefined,
+): readonly TypesGen.ChatQueuedMessage[] | undefined => {
+	if (!chatID) {
+		return undefined;
+	}
+	return queryClient.getQueryData<
+		InfiniteData<TypesGen.ChatMessagesResponse> | undefined
+	>(chatMessagesKey(chatID))?.pages[0]?.queued_messages;
+};
+
 const normalizeRetryState = (retry: TypesGen.ChatStreamRetry): RetryState => ({
 	attempt: Math.max(1, retry.attempt),
 	error: retry.error.trim() || "Retrying request shortly.",
@@ -100,6 +112,9 @@ export const useChatStore = (
 	setCacheQueuedMessages: (
 		queuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined,
 	) => void;
+	getCacheQueuedMessages: () =>
+		| readonly TypesGen.ChatQueuedMessage[]
+		| undefined;
 	upsertCacheMessages: (messages: readonly TypesGen.ChatMessage[]) => void;
 } => {
 	const {
@@ -802,6 +817,8 @@ export const useChatStore = (
 		setCacheQueuedMessages: (queuedMessages) => {
 			writeQueuedMessagesToCache(queryClient, chatID, queuedMessages);
 		},
+		getCacheQueuedMessages: () =>
+			readQueuedMessagesFromCache(queryClient, chatID),
 		upsertCacheMessages,
 	};
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -788,6 +788,12 @@ export const useChatStore = (
 		// socket is down, and the socket having already delivered a status
 		// otherwise makes the refetched one inert.
 		acceptServerChatStatus: () => {
+			// A request that resolves after the user navigates away belongs to
+			// the previous chat, whose freshness and status are unrelated to
+			// the one now displayed by this shared store.
+			if (store.getActiveChatID() !== (chatID ?? null)) {
+				return;
+			}
 			pendingStatusResyncUpdatedAtRef.current = chatRecordUpdatedAt;
 			pendingStatusResyncVersionRef.current =
 				store.getServerChatStatusVersion();

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -83,6 +83,7 @@ interface UseChatStoreOptions {
 	chatID: string | undefined;
 	chatMessages: readonly TypesGen.ChatMessage[] | undefined;
 	chatRecord: TypesGen.Chat | undefined;
+	chatRecordUpdatedAt?: number;
 	chatMessagesData: TypesGen.ChatMessagesResponse | undefined;
 	chatQueuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined;
 	setChatErrorReason: (chatID: string, reason: ChatDetailError) => void;
@@ -105,6 +106,7 @@ export const useChatStore = (
 		chatID,
 		chatMessages,
 		chatRecord,
+		chatRecordUpdatedAt = 0,
 		chatMessagesData,
 		chatQueuedMessages,
 		setChatErrorReason,
@@ -131,6 +133,7 @@ export const useChatStore = (
 	// to drop all incoming parts.
 	const wsStatusReceivedRef = useRef(false);
 	const [pendingStatusResync, setPendingStatusResync] = useState(false);
+	const pendingStatusResyncUpdatedAtRef = useRef<number | null>(null);
 	const activeChatIDRef = useRef<string | null>(null);
 	const prevChatIDRef = useRef<string | undefined>(chatID);
 	// Snapshot of the chatMessages elements from the last sync effect
@@ -302,25 +305,34 @@ export const useChatStore = (
 	}, [chatID, chatMessages, store]);
 
 	useEffect(() => {
+		if (pendingStatusResync) {
+			const armedAt = pendingStatusResyncUpdatedAtRef.current;
+			// dataUpdatedAt advances after a fetch even when structural sharing
+			// preserves chatRecord.
+			if (armedAt === null || chatRecordUpdatedAt <= armedAt) {
+				return;
+			}
+			store.setChatStatus(chatRecord?.status ?? null);
+			pendingStatusResyncUpdatedAtRef.current = null;
+			wsStatusReceivedRef.current = false;
+			setPendingStatusResync(false);
+			return;
+		}
 		// Only hydrate from REST when the WebSocket hasn't delivered
 		// a status event yet. Once the WS is the authoritative
 		// source, a stale REST refetch must not overwrite the
 		// fresher WS-delivered value.
-		if (!wsStatusReceivedRef.current || pendingStatusResync) {
+		if (!wsStatusReceivedRef.current) {
 			store.setChatStatus(chatRecord?.status ?? null);
 		}
-		// A resync must apply the cached status even when its value never
-		// changed, which happens when the store drifted ahead of it.
-		if (pendingStatusResync) {
-			setPendingStatusResync(false);
-		}
-	}, [chatRecord?.status, store, pendingStatusResync]);
+	}, [chatRecord?.status, chatRecordUpdatedAt, store, pendingStatusResync]);
 
 	useEffect(() => {
-		store.setActiveChatID(chatID ?? null);
 		queuedMessagesHydratedChatIDRef.current = null;
 		wsQueueUpdateReceivedRef.current = false;
 		wsStatusReceivedRef.current = false;
+		pendingStatusResyncUpdatedAtRef.current = null;
+		setPendingStatusResync(false);
 		store.setQueuedMessages([]);
 		// Suppression entries are scoped to the current chat; clear
 		// them on chat change so a stale promote suppression doesn't
@@ -637,6 +649,7 @@ export const useChatStore = (
 								kind: "generic",
 								message: "Chat processing failed.",
 							};
+							wsStatusReceivedRef.current = true;
 							store.applyServerChatStatus("error");
 							store.setStreamError(reason);
 							store.clearRetryState();
@@ -765,7 +778,7 @@ export const useChatStore = (
 		// socket is down, and the socket having already delivered a status
 		// otherwise makes the refetched one inert.
 		acceptServerChatStatus: () => {
-			wsStatusReceivedRef.current = false;
+			pendingStatusResyncUpdatedAtRef.current = chatRecordUpdatedAt;
 			setPendingStatusResync(true);
 		},
 		setCacheQueuedMessages: (queuedMessages) => {

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -590,7 +590,10 @@ export const useChatStore = (
 							store.applyAuthoritativeQueuedMessages(
 								streamEvent.queued_messages,
 							);
-							setCacheQueuedMessages(streamEvent.queued_messages);
+							// Cache the store's filtered queue, not the raw
+							// event, so a promoted message suppressed by the
+							// store cannot reappear on REST re-hydration.
+							setCacheQueuedMessages(store.getSnapshot().queuedMessages);
 							continue;
 						case "status": {
 							const nextStatus = streamEvent.status?.status;

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -610,7 +610,7 @@ export const useChatStore = (
 
 							wsStatusReceivedRef.current = true;
 							store.clearRetryState();
-							store.setChatStatus(nextStatus);
+							store.applyServerChatStatus(nextStatus);
 							if (nextStatus === "waiting") {
 								discardBufferedParts();
 							}
@@ -629,7 +629,7 @@ export const useChatStore = (
 								kind: "generic",
 								message: "Chat processing failed.",
 							};
-							store.setChatStatus("error");
+							store.applyServerChatStatus("error");
 							store.setStreamError(reason);
 							store.clearRetryState();
 							setChatErrorReasonEvent(chatID, reason);

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -57,6 +57,9 @@ export const useChatStore = (
 ): {
 	store: ChatStore;
 	clearStreamError: () => void;
+	setCacheQueuedMessages: (
+		queuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined,
+	) => void;
 	upsertCacheMessages: (messages: readonly TypesGen.ChatMessage[]) => void;
 } => {
 	const {
@@ -125,6 +128,42 @@ export const useChatStore = (
 	// otherwise the server replays the entire message history as
 	// its snapshot, defeating pagination.
 	const initialDataLoaded = chatMessages !== undefined;
+
+	// Writes an authoritative queued-message snapshot into the
+	// messages query cache so REST re-hydration cannot replay a stale
+	// queue over the store.
+	const setCacheQueuedMessages = useCallback(
+		(queuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined) => {
+			if (!chatID) {
+				return;
+			}
+			const nextQueuedMessages = queuedMessages ?? [];
+			queryClient.setQueryData<
+				InfiniteData<TypesGen.ChatMessagesResponse> | undefined
+			>(chatMessagesKey(chatID), (currentData) => {
+				if (!currentData?.pages?.length) {
+					return currentData;
+				}
+				const firstPage = currentData.pages[0];
+				if (
+					chatQueuedMessagesEqualByID(
+						firstPage.queued_messages,
+						nextQueuedMessages,
+					)
+				) {
+					return currentData;
+				}
+				return {
+					...currentData,
+					pages: [
+						{ ...firstPage, queued_messages: nextQueuedMessages },
+						...currentData.pages.slice(1),
+					],
+				};
+			});
+		},
+		[chatID, queryClient],
+	);
 
 	// Write WebSocket-delivered durable messages into the React
 	// Query infinite cache so that navigating away and back
@@ -321,38 +360,6 @@ export const useChatStore = (
 					return updated;
 				});
 				return didUpdate ? nextChats : chats;
-			});
-		};
-
-		const updateChatQueuedMessages = (
-			queuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined,
-		) => {
-			if (!chatID) {
-				return;
-			}
-			const nextQueuedMessages = queuedMessages ?? [];
-			queryClient.setQueryData<
-				InfiniteData<TypesGen.ChatMessagesResponse> | undefined
-			>(chatMessagesKey(chatID), (currentData) => {
-				if (!currentData?.pages?.length) {
-					return currentData;
-				}
-				const firstPage = currentData.pages[0];
-				if (
-					chatQueuedMessagesEqualByID(
-						firstPage.queued_messages,
-						nextQueuedMessages,
-					)
-				) {
-					return currentData;
-				}
-				return {
-					...currentData,
-					pages: [
-						{ ...firstPage, queued_messages: nextQueuedMessages },
-						...currentData.pages.slice(1),
-					],
-				};
 			});
 		};
 
@@ -570,7 +577,7 @@ export const useChatStore = (
 							store.applyAuthoritativeQueuedMessages(
 								streamEvent.queued_messages,
 							);
-							updateChatQueuedMessages(streamEvent.queued_messages);
+							setCacheQueuedMessages(streamEvent.queued_messages);
 							continue;
 						case "status": {
 							const nextStatus = streamEvent.status?.status;
@@ -714,6 +721,7 @@ export const useChatStore = (
 		initialDataLoaded,
 		queryClient,
 		replaceCacheMessages,
+		setCacheQueuedMessages,
 		store,
 		upsertCacheMessages,
 	]);
@@ -722,6 +730,7 @@ export const useChatStore = (
 		clearStreamError: () => {
 			store.clearStreamError();
 		},
+		setCacheQueuedMessages,
 		upsertCacheMessages,
 	};
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -94,6 +94,7 @@ export const useChatStore = (
 	options: UseChatStoreOptions,
 ): {
 	store: ChatStore;
+	acceptServerChatStatus: () => void;
 	clearStreamError: () => void;
 	setCacheQueuedMessages: (
 		queuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined,
@@ -750,6 +751,12 @@ export const useChatStore = (
 		store,
 		clearStreamError: () => {
 			store.clearStreamError();
+		},
+		// A failed request can change server-side chat status while the
+		// socket is down, and the socket having already delivered a status
+		// otherwise makes the refetched one inert.
+		acceptServerChatStatus: () => {
+			wsStatusReceivedRef.current = false;
 		},
 		setCacheQueuedMessages: (queuedMessages) => {
 			writeQueuedMessagesToCache(queryClient, chatID, queuedMessages);

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -5,7 +5,11 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { type InfiniteData, useQueryClient } from "react-query";
+import {
+	type InfiniteData,
+	type QueryClient,
+	useQueryClient,
+} from "react-query";
 import { watchChat } from "#/api/api";
 import {
 	chatMessagesKey,
@@ -26,6 +30,40 @@ import {
 	isActiveChatStatus,
 } from "./chatStore";
 import type { RetryState } from "./types";
+
+// Writes an authoritative queued-message snapshot into the messages
+// query cache so REST re-hydration cannot replay a stale queue over
+// the store.
+const writeQueuedMessagesToCache = (
+	queryClient: QueryClient,
+	chatID: string | undefined,
+	queuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined,
+): void => {
+	if (!chatID) {
+		return;
+	}
+	const nextQueuedMessages = queuedMessages ?? [];
+	queryClient.setQueryData<
+		InfiniteData<TypesGen.ChatMessagesResponse> | undefined
+	>(chatMessagesKey(chatID), (currentData) => {
+		if (!currentData?.pages?.length) {
+			return currentData;
+		}
+		const firstPage = currentData.pages[0];
+		if (
+			chatQueuedMessagesEqualByID(firstPage.queued_messages, nextQueuedMessages)
+		) {
+			return currentData;
+		}
+		return {
+			...currentData,
+			pages: [
+				{ ...firstPage, queued_messages: nextQueuedMessages },
+				...currentData.pages.slice(1),
+			],
+		};
+	});
+};
 
 const normalizeRetryState = (retry: TypesGen.ChatStreamRetry): RetryState => ({
 	attempt: Math.max(1, retry.attempt),
@@ -128,42 +166,6 @@ export const useChatStore = (
 	// otherwise the server replays the entire message history as
 	// its snapshot, defeating pagination.
 	const initialDataLoaded = chatMessages !== undefined;
-
-	// Writes an authoritative queued-message snapshot into the
-	// messages query cache so REST re-hydration cannot replay a stale
-	// queue over the store.
-	const setCacheQueuedMessages = useCallback(
-		(queuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined) => {
-			if (!chatID) {
-				return;
-			}
-			const nextQueuedMessages = queuedMessages ?? [];
-			queryClient.setQueryData<
-				InfiniteData<TypesGen.ChatMessagesResponse> | undefined
-			>(chatMessagesKey(chatID), (currentData) => {
-				if (!currentData?.pages?.length) {
-					return currentData;
-				}
-				const firstPage = currentData.pages[0];
-				if (
-					chatQueuedMessagesEqualByID(
-						firstPage.queued_messages,
-						nextQueuedMessages,
-					)
-				) {
-					return currentData;
-				}
-				return {
-					...currentData,
-					pages: [
-						{ ...firstPage, queued_messages: nextQueuedMessages },
-						...currentData.pages.slice(1),
-					],
-				};
-			});
-		},
-		[chatID, queryClient],
-	);
 
 	// Write WebSocket-delivered durable messages into the React
 	// Query infinite cache so that navigating away and back
@@ -593,7 +595,11 @@ export const useChatStore = (
 							// Cache the store's filtered queue, not the raw
 							// event, so a promoted message suppressed by the
 							// store cannot reappear on REST re-hydration.
-							setCacheQueuedMessages(store.getSnapshot().queuedMessages);
+							writeQueuedMessagesToCache(
+								queryClient,
+								chatID,
+								store.getSnapshot().queuedMessages,
+							);
 							continue;
 						case "status": {
 							const nextStatus = streamEvent.status?.status;
@@ -737,7 +743,6 @@ export const useChatStore = (
 		initialDataLoaded,
 		queryClient,
 		replaceCacheMessages,
-		setCacheQueuedMessages,
 		store,
 		upsertCacheMessages,
 	]);
@@ -746,7 +751,9 @@ export const useChatStore = (
 		clearStreamError: () => {
 			store.clearStreamError();
 		},
-		setCacheQueuedMessages,
+		setCacheQueuedMessages: (queuedMessages) => {
+			writeQueuedMessagesToCache(queryClient, chatID, queuedMessages);
+		},
 		upsertCacheMessages,
 	};
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -317,6 +317,7 @@ export const useChatStore = (
 	}, [chatRecord?.status, store, pendingStatusResync]);
 
 	useEffect(() => {
+		store.setActiveChatID(chatID ?? null);
 		queuedMessagesHydratedChatIDRef.current = null;
 		wsQueueUpdateReceivedRef.current = false;
 		wsStatusReceivedRef.current = false;
@@ -387,6 +388,7 @@ export const useChatStore = (
 
 		store.resetTransientState();
 		activeChatIDRef.current = chatID ?? null;
+		store.setActiveChatID(chatID ?? null);
 
 		if (!chatID || !initialDataLoaded || aiGatewayDisabled) {
 			return;
@@ -743,6 +745,7 @@ export const useChatStore = (
 				clearTimeout(partsFlushTimer);
 			}
 			activeChatIDRef.current = null;
+			store.setActiveChatID(null);
 		};
 	}, [
 		aiGatewayDisabled,

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -134,6 +134,7 @@ export const useChatStore = (
 	const wsStatusReceivedRef = useRef(false);
 	const [pendingStatusResync, setPendingStatusResync] = useState(false);
 	const pendingStatusResyncUpdatedAtRef = useRef<number | null>(null);
+	const pendingStatusResyncVersionRef = useRef<number | null>(null);
 	const activeChatIDRef = useRef<string | null>(null);
 	const prevChatIDRef = useRef<string | undefined>(chatID);
 	// Snapshot of the chatMessages elements from the last sync effect
@@ -312,9 +313,17 @@ export const useChatStore = (
 			if (armedAt === null || chatRecordUpdatedAt <= armedAt) {
 				return;
 			}
-			store.setChatStatus(chatRecord?.status ?? null);
+			// A websocket status delivered while the refetch was in flight is
+			// newer than its response, so the resync must not undo it.
+			const wsAdvanced =
+				store.getServerChatStatusVersion() !==
+				pendingStatusResyncVersionRef.current;
+			if (!wsAdvanced) {
+				store.setChatStatus(chatRecord?.status ?? null);
+				wsStatusReceivedRef.current = false;
+			}
 			pendingStatusResyncUpdatedAtRef.current = null;
-			wsStatusReceivedRef.current = false;
+			pendingStatusResyncVersionRef.current = null;
 			setPendingStatusResync(false);
 			return;
 		}
@@ -332,6 +341,7 @@ export const useChatStore = (
 		wsQueueUpdateReceivedRef.current = false;
 		wsStatusReceivedRef.current = false;
 		pendingStatusResyncUpdatedAtRef.current = null;
+		pendingStatusResyncVersionRef.current = null;
 		setPendingStatusResync(false);
 		store.setQueuedMessages([]);
 		// Suppression entries are scoped to the current chat; clear
@@ -779,6 +789,8 @@ export const useChatStore = (
 		// otherwise makes the refetched one inert.
 		acceptServerChatStatus: () => {
 			pendingStatusResyncUpdatedAtRef.current = chatRecordUpdatedAt;
+			pendingStatusResyncVersionRef.current =
+				store.getServerChatStatusVersion();
 			setPendingStatusResync(true);
 		},
 		setCacheQueuedMessages: (queuedMessages) => {

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -31,9 +31,7 @@ import {
 } from "./chatStore";
 import type { RetryState } from "./types";
 
-// Writes an authoritative queued-message snapshot into the messages
-// query cache so REST re-hydration cannot replay a stale queue over
-// the store.
+// Prevents REST re-hydration from replaying a stale queue over the store.
 const writeQueuedMessagesToCache = (
 	queryClient: QueryClient,
 	chatID: string | undefined,
@@ -328,8 +326,7 @@ export const useChatStore = (
 			if (armedAt === null || chatRecordUpdatedAt <= armedAt) {
 				return;
 			}
-			// A websocket status delivered while the refetch was in flight is
-			// newer than its response, so the resync must not undo it.
+			// Preserve a websocket status delivered during the refetch instead of applying its response.
 			const wsAdvanced =
 				store.getServerChatStatusVersion() !==
 				pendingStatusResyncVersionRef.current;
@@ -384,11 +381,8 @@ export const useChatStore = (
 			return;
 		}
 		queuedMessagesHydratedChatIDRef.current = chatID;
-		// Skip snapshots identical to the visible queue. The promoted-queue
-		// reconciliation writes its own optimistic snapshot into the cache,
-		// and treating that write as authoritative would lift the promote
-		// suppression while a stale pre-promotion queue_update can still
-		// arrive and re-show the promoted message.
+		// An optimistic promotion cache write must not clear suppression before
+		// a stale pre-promotion queue_update arrives.
 		if (
 			chatQueuedMessagesEqualByID(
 				store.getSnapshot().queuedMessages,

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -337,6 +337,19 @@ export const useChatStore = (
 			return;
 		}
 		queuedMessagesHydratedChatIDRef.current = chatID;
+		// Skip snapshots identical to the visible queue. The promoted-queue
+		// reconciliation writes its own optimistic snapshot into the cache,
+		// and treating that write as authoritative would lift the promote
+		// suppression while a stale pre-promotion queue_update can still
+		// arrive and re-show the promoted message.
+		if (
+			chatQueuedMessagesEqualByID(
+				store.getSnapshot().queuedMessages,
+				chatQueuedMessages ?? [],
+			)
+		) {
+			return;
+		}
 		store.applyAuthoritativeQueuedMessages(chatQueuedMessages);
 	}, [chatMessagesData, chatID, chatQueuedMessages, store]);
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -130,6 +130,7 @@ export const useChatStore = (
 	// stale value like "waiting", causing shouldApplyMessagePart()
 	// to drop all incoming parts.
 	const wsStatusReceivedRef = useRef(false);
+	const [pendingStatusResync, setPendingStatusResync] = useState(false);
 	const activeChatIDRef = useRef<string | null>(null);
 	const prevChatIDRef = useRef<string | undefined>(chatID);
 	// Snapshot of the chatMessages elements from the last sync effect
@@ -305,10 +306,15 @@ export const useChatStore = (
 		// a status event yet. Once the WS is the authoritative
 		// source, a stale REST refetch must not overwrite the
 		// fresher WS-delivered value.
-		if (!wsStatusReceivedRef.current) {
+		if (!wsStatusReceivedRef.current || pendingStatusResync) {
 			store.setChatStatus(chatRecord?.status ?? null);
 		}
-	}, [chatRecord?.status, store]);
+		// A resync must apply the cached status even when its value never
+		// changed, which happens when the store drifted ahead of it.
+		if (pendingStatusResync) {
+			setPendingStatusResync(false);
+		}
+	}, [chatRecord?.status, store, pendingStatusResync]);
 
 	useEffect(() => {
 		queuedMessagesHydratedChatIDRef.current = null;
@@ -757,6 +763,7 @@ export const useChatStore = (
 		// otherwise makes the refetched one inert.
 		acceptServerChatStatus: () => {
 			wsStatusReceivedRef.current = false;
+			setPendingStatusResync(true);
 		},
 		setCacheQueuedMessages: (queuedMessages) => {
 			writeQueuedMessagesToCache(queryClient, chatID, queuedMessages);

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/EditFilesTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/EditFilesTool.tsx
@@ -39,23 +39,20 @@ export const EditFilesTool: React.FC<{
 		EDIT_FILES_AUTO_DISPLAY_STATE,
 	);
 
-	let label: string;
+	let verb = "Edited";
 	if (isRunning) {
-		if (files.length === 1) {
-			label = `Editing ${getPathBasename(files[0].path)}…`;
-		} else if (files.length > 1) {
-			label = `Editing ${files.length} files…`;
-		} else {
-			label = "Editing files…";
-		}
-	} else if (files.length === 1) {
-		const filename = getPathBasename(files[0].path);
-		label = `Edited ${filename}`;
-	} else if (files.length > 1) {
-		label = `Edited ${files.length} files`;
-	} else {
-		label = "Edited files";
+		verb = "Editing";
+	} else if (isError) {
+		verb = "Failed to edit";
 	}
+	let subject = "files";
+	if (files.length === 1) {
+		subject = getPathBasename(files[0].path);
+	} else if (files.length > 1) {
+		subject = `${files.length} files`;
+	}
+	const label = isRunning ? `${verb} ${subject}…` : `${verb} ${subject}`;
+	const errorDetail = isError ? errorMessage?.trim() : undefined;
 
 	return (
 		<ToolCall.Root
@@ -64,11 +61,16 @@ export const EditFilesTool: React.FC<{
 			status={status}
 			isError={isError}
 			errorMessage={errorMessage || "Failed to edit files"}
-			hasContent={hasDiffs}
+			hasContent={hasDiffs || Boolean(errorDetail)}
 			defaultView={displayState}
 		>
 			<ToolCall.Header iconName="edit_files" label={label} />
 			<ToolCall.Content>
+				{errorDetail && (
+					<pre className="m-0 mt-1.5 whitespace-pre-wrap break-all border-0 bg-transparent p-0 font-mono text-xs leading-5 text-content-destructive">
+						{errorDetail}
+					</pre>
+				)}
 				<div className="mt-1.5 space-y-1.5">
 					{diffs.map((diff, i) =>
 						diff ? (

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
@@ -36,6 +36,7 @@ type ExecuteToolProps = {
 	transcriptBlocks: readonly ExecuteTranscriptBlock[];
 	status: ToolStatus;
 	isError: boolean;
+	errorText?: string;
 	durationMs?: number;
 	isBackgrounded?: boolean;
 	killedBySignal?: "kill" | "terminate";
@@ -49,6 +50,7 @@ export const ExecuteTool: React.FC<ExecuteToolProps> = ({
 	transcriptBlocks,
 	status,
 	isError,
+	errorText,
 	durationMs,
 	isBackgrounded = false,
 	killedBySignal,
@@ -83,7 +85,7 @@ export const ExecuteTool: React.FC<ExecuteToolProps> = ({
 			className="group/exec grid w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2 rounded-md bg-surface-primary font-sans font-normal text-xs leading-5"
 			status={status}
 			isError={isError}
-			errorMessage="Command failed"
+			errorMessage={errorText || "Command failed"}
 			hasContent
 			defaultView={defaultView}
 			ariaLabel={(expanded) =>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
@@ -73,6 +73,8 @@ export const ExecuteTool: React.FC<ExecuteToolProps> = ({
 		modelIntent,
 		parsedCommands,
 		durationLabel,
+		isRunning,
+		isError,
 	});
 	const defaultView = resolveAgentDisplayState(
 		shellToolDisplayMode,
@@ -154,6 +156,8 @@ type ShellCommandLineInput = {
 	modelIntent?: string;
 	parsedCommands?: readonly string[][];
 	durationLabel: string;
+	isRunning: boolean;
+	isError: boolean;
 };
 
 const getShellCommandLine = ({
@@ -161,6 +165,8 @@ const getShellCommandLine = ({
 	modelIntent,
 	parsedCommands,
 	durationLabel,
+	isRunning,
+	isError,
 }: ShellCommandLineInput): { commandLabel: string; durationSuffix: string } => {
 	const intentLabel = sanitizeExecuteModelIntent(modelIntent, command);
 	const summary =
@@ -168,9 +174,12 @@ const getShellCommandLine = ({
 			? summarizeParsedCommands(parsedCommands)
 			: "";
 	const commandDisplay = summary || command;
-	const commandLabel = intentLabel
+	let commandLabel = intentLabel
 		? `${intentLabel} using ${commandDisplay}`
 		: `Ran ${commandDisplay}`;
+	if (!isRunning && isError) {
+		commandLabel = `Failed to run ${commandDisplay}`;
+	}
 
 	return {
 		commandLabel,

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -414,6 +414,10 @@ export const ExecuteDeniedByHook: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
+		expect(canvas.getByText(/Failed to run cat \/etc\/secrets/)).toBeVisible();
+		expect(
+			canvas.queryByText(/Ran cat \/etc\/secrets/),
+		).not.toBeInTheDocument();
 		await expect(
 			canvas.getByRole("img", {
 				name: /blocked by an external policy/,

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -409,7 +409,7 @@ export const ExecuteDeniedByHook: Story = {
 		args: { command: "cat /etc/secrets" },
 		result: {
 			error:
-				"This tool usage was blocked by an external policy (the deployment's lifecycle hook). Reason: secret reads are blocked. This is an administrative policy decision, not a tool or workspace failure; retrying the same call will be denied again. Explain the policy block to the user and adjust your approach.",
+				"This tool usage was blocked by an external policy (the deployment's lifecycle hook); the tool call was not executed. Reason: secret reads are blocked. This is an administrative policy decision, not a tool or workspace failure; retrying the same call will be denied again. Explain the policy block to the user and adjust your approach.",
 		},
 	},
 	play: async ({ canvasElement }) => {
@@ -1815,7 +1815,7 @@ export const WriteFileDeniedByHook: Story = {
 		},
 		result: {
 			error:
-				"This tool usage was blocked by an external policy (the deployment's lifecycle hook). Reason: writes to src are blocked.",
+				"This tool usage was blocked by an external policy (the deployment's lifecycle hook); the tool call was not executed. Reason: writes to src are blocked.",
 		},
 	},
 	play: async ({ canvasElement }) => {

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -401,6 +401,28 @@ export const ExecuteError: Story = {
 	},
 };
 
+export const ExecuteDeniedByHook: Story = {
+	args: {
+		name: "execute",
+		status: "error",
+		isError: true,
+		args: { command: "cat /etc/secrets" },
+		result: {
+			error:
+				"Tool call denied by the deployment's lifecycle hook policy. Reason: secret reads are blocked. This is an administrative policy decision, not a tool or workspace failure; retrying the same call will be denied again. Explain the denial to the user and adjust your approach.",
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("img", {
+				name: /denied by the deployment's lifecycle hook policy/,
+			}),
+		).toBeVisible();
+		expect(canvas.getByText(/Reason: secret reads are blocked/)).toBeVisible();
+	},
+};
+
 export const ExecuteBackgrounded: Story = {
 	args: {
 		name: "execute",
@@ -1778,6 +1800,36 @@ export const WriteFileAlwaysExpanded: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		expect(canvas.getByTestId("write-file-diff")).toBeVisible();
+	},
+};
+
+export const WriteFileDeniedByHook: Story = {
+	args: {
+		name: "write_file",
+		status: "error",
+		isError: true,
+		codeDiffDisplayMode: "auto",
+		args: {
+			path: "src/utils/helpers.ts",
+			content: "export const helper = true;\n",
+		},
+		result: {
+			error:
+				"Tool call denied by the deployment's lifecycle hook policy. Reason: writes to src are blocked.",
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText(/Failed to write helpers\.ts/)).toBeInTheDocument();
+		await userEvent.click(
+			canvas.getByRole("button", { name: /Failed to write helpers\.ts/ }),
+		);
+		await waitFor(() => {
+			expect(
+				canvas.getByText(/denied by the deployment's lifecycle hook policy/),
+			).toBeVisible();
+		});
+		expect(canvas.queryByTestId("write-file-diff")).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -409,14 +409,14 @@ export const ExecuteDeniedByHook: Story = {
 		args: { command: "cat /etc/secrets" },
 		result: {
 			error:
-				"Tool call denied by the deployment's lifecycle hook policy. Reason: secret reads are blocked. This is an administrative policy decision, not a tool or workspace failure; retrying the same call will be denied again. Explain the denial to the user and adjust your approach.",
+				"This tool usage was blocked by an external policy (the deployment's lifecycle hook). Reason: secret reads are blocked. This is an administrative policy decision, not a tool or workspace failure; retrying the same call will be denied again. Explain the policy block to the user and adjust your approach.",
 		},
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		await expect(
 			canvas.getByRole("img", {
-				name: /denied by the deployment's lifecycle hook policy/,
+				name: /blocked by an external policy/,
 			}),
 		).toBeVisible();
 		expect(canvas.getByText(/Reason: secret reads are blocked/)).toBeVisible();
@@ -1815,7 +1815,7 @@ export const WriteFileDeniedByHook: Story = {
 		},
 		result: {
 			error:
-				"Tool call denied by the deployment's lifecycle hook policy. Reason: writes to src are blocked.",
+				"This tool usage was blocked by an external policy (the deployment's lifecycle hook). Reason: writes to src are blocked.",
 		},
 	},
 	play: async ({ canvasElement }) => {
@@ -1825,9 +1825,7 @@ export const WriteFileDeniedByHook: Story = {
 			canvas.getByRole("button", { name: /Failed to write helpers\.ts/ }),
 		);
 		await waitFor(() => {
-			expect(
-				canvas.getByText(/denied by the deployment's lifecycle hook policy/),
-			).toBeVisible();
+			expect(canvas.getByText(/blocked by an external policy/)).toBeVisible();
 		});
 		expect(canvas.queryByTestId("write-file-diff")).not.toBeInTheDocument();
 	},

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -2006,7 +2006,10 @@ export const EditFilesError: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		expect(canvas.getByText(/Edited missing\.ts/)).toBeInTheDocument();
+		expect(canvas.getByText(/Failed to edit missing\.ts/)).toBeInTheDocument();
+		await waitFor(() => {
+			expect(canvas.getByText("File not found")).toBeVisible();
+		});
 		// On error, no diff body: the synthetic fallback would
 		// misrepresent a rejected edit as applied.
 		expect(canvas.queryAllByTestId("edit-file-diff")).toHaveLength(0);

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -247,6 +247,7 @@ const ExecuteRenderer: FC<ToolRendererProps> = ({
 			transcriptBlocks={data.transcriptBlocks}
 			status={status}
 			isError={isError}
+			errorText={data.errorText}
 			durationMs={data.durationMs}
 			isBackgrounded={data.isBackgrounded}
 			killedBySignal={killedBySignal}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/WriteFileTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/WriteFileTool.tsx
@@ -39,7 +39,16 @@ export const WriteFileTool: React.FC<{
 	);
 
 	const filename = getPathBasename(path);
-	const label = isRunning ? `Writing ${filename}…` : `Wrote ${filename}`;
+	let label = `Wrote ${filename}`;
+	if (isRunning) {
+		label = `Writing ${filename}…`;
+	} else if (isError) {
+		label = `Failed to write ${filename}`;
+	}
+	// The diff is synthesized from the tool args, so on error it would
+	// show content that was never written.
+	const showDiff = hasDiff && !isError;
+	const errorDetail = isError ? errorMessage?.trim() : undefined;
 
 	return (
 		<ToolCall.Root
@@ -48,12 +57,17 @@ export const WriteFileTool: React.FC<{
 			status={status}
 			isError={isError}
 			errorMessage={errorMessage || "Failed to write file"}
-			hasContent={hasDiff}
+			hasContent={showDiff || Boolean(errorDetail)}
 			defaultView={displayState}
 		>
 			<ToolCall.Header iconName="write_file" label={label} />
 			<ToolCall.Content>
-				{hasDiff && (
+				{errorDetail && (
+					<pre className="m-0 mt-1.5 whitespace-pre-wrap break-all border-0 bg-transparent p-0 font-mono text-xs leading-5 text-content-destructive">
+						{errorDetail}
+					</pre>
+				)}
+				{showDiff && (
 					<ScrollArea
 						data-testid="write-file-diff"
 						className="mt-1.5 rounded-md border border-solid border-border-default text-2xs"

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/WriteFileTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/WriteFileTool.tsx
@@ -45,8 +45,8 @@ export const WriteFileTool: React.FC<{
 	} else if (isError) {
 		label = `Failed to write ${filename}`;
 	}
-	// The diff is synthesized from the tool args, so on error it would
-	// show content that was never written.
+	// The diff is synthesized from tool args, so showing it on error could
+	// misrepresent the content as written.
 	const showDiff = hasDiff && !isError;
 	const errorDetail = isError ? errorMessage?.trim() : undefined;
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/toolVisibility.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/toolVisibility.test.ts
@@ -22,6 +22,7 @@ describe("toolVisibility", () => {
 			).toEqual({
 				command: "git fetch origin",
 				transcriptBlocks: [{ kind: "output", text: "fetched" }],
+				errorText: "",
 				durationMs: 47200,
 				isBackgrounded: true,
 				authenticateURL: "https://example.com/auth",

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/toolVisibility.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/toolVisibility.ts
@@ -16,6 +16,7 @@ export type ExecuteTranscriptBlock = {
 type ExecuteRenderData = {
 	command: string;
 	transcriptBlocks: ExecuteTranscriptBlock[];
+	errorText: string;
 	durationMs?: number;
 	isBackgrounded: boolean;
 	authenticateURL: string;
@@ -63,6 +64,7 @@ export const getExecuteRenderData = (
 	return {
 		command,
 		transcriptBlocks,
+		errorText,
 		durationMs,
 		isBackgrounded,
 		authenticateURL,

--- a/site/src/pages/AgentsPage/components/QueuedMessagesList.stories.tsx
+++ b/site/src/pages/AgentsPage/components/QueuedMessagesList.stories.tsx
@@ -202,9 +202,6 @@ export const MixedQueueWithAttachments: Story = {
 	},
 };
 
-// A queued message carrying a lifecycle hook notice shows an info
-// indicator whose accessible name includes the notice text and whose
-// tooltip opens on keyboard focus.
 export const HookNotice: Story = {
 	args: {
 		messages: [

--- a/site/src/pages/AgentsPage/components/QueuedMessagesList.stories.tsx
+++ b/site/src/pages/AgentsPage/components/QueuedMessagesList.stories.tsx
@@ -211,7 +211,7 @@ export const HookNotice: Story = {
 			buildMessage(1, [
 				{ type: "text", text: "Deploy to production" },
 				{ type: "hook-notice", text: "Deployment prompts are audited." },
-			] as ChatQueuedMessage["content"]),
+			]),
 		],
 	},
 	play: async ({ canvasElement }) => {

--- a/site/src/pages/AgentsPage/components/QueuedMessagesList.stories.tsx
+++ b/site/src/pages/AgentsPage/components/QueuedMessagesList.stories.tsx
@@ -201,3 +201,27 @@ export const MixedQueueWithAttachments: Story = {
 		],
 	},
 };
+
+// A queued message carrying a lifecycle hook notice shows an info
+// indicator whose accessible name includes the notice text and whose
+// tooltip opens on keyboard focus.
+export const HookNotice: Story = {
+	args: {
+		messages: [
+			buildMessage(1, [
+				{ type: "text", text: "Deploy to production" },
+				{ type: "hook-notice", text: "Deployment prompts are audited." },
+			] as ChatQueuedMessage["content"]),
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const trigger = canvas.getByRole("button", {
+			name: "Lifecycle hook notice: Deployment prompts are audited.",
+		});
+		await userEvent.tab();
+		expect(trigger).toHaveFocus();
+		const tooltip = await within(document.body).findByRole("tooltip");
+		expect(tooltip).toHaveTextContent("Deployment prompts are audited.");
+	},
+};

--- a/site/src/pages/AgentsPage/components/QueuedMessagesList.test.ts
+++ b/site/src/pages/AgentsPage/components/QueuedMessagesList.test.ts
@@ -16,6 +16,23 @@ describe("getQueuedMessageInfo", () => {
 			displayText: "hello",
 			rawText: "hello",
 			attachmentCount: 0,
+			hookNotices: [],
+			fileBlocks: [],
+		});
+	});
+
+	it("collects hook notices without polluting the preview text", () => {
+		const result = getQueuedMessageInfo(
+			buildMessage([
+				{ type: "text", text: "hello" },
+				{ type: "hook-notice", text: "policy notice" },
+			]),
+		);
+		expect(result).toEqual({
+			displayText: "hello",
+			rawText: "hello",
+			attachmentCount: 0,
+			hookNotices: ["policy notice"],
 			fileBlocks: [],
 		});
 	});
@@ -28,6 +45,7 @@ describe("getQueuedMessageInfo", () => {
 			displayText: "line1\nline2",
 			rawText: "line1\nline2",
 			attachmentCount: 0,
+			hookNotices: [],
 			fileBlocks: [],
 		});
 	});
@@ -40,6 +58,7 @@ describe("getQueuedMessageInfo", () => {
 			displayText: "[Queued message]",
 			rawText: "",
 			attachmentCount: 1,
+			hookNotices: [],
 			fileBlocks: [{ type: "file", file_id: "a", media_type: "image/png" }],
 		});
 	});
@@ -55,6 +74,7 @@ describe("getQueuedMessageInfo", () => {
 			displayText: "[Queued message]",
 			rawText: "",
 			attachmentCount: 2,
+			hookNotices: [],
 			fileBlocks: [
 				{ type: "file", file_id: "a", media_type: "image/png" },
 				{ type: "file", file_id: "b", media_type: "image/png" },
@@ -73,6 +93,7 @@ describe("getQueuedMessageInfo", () => {
 			displayText: "look",
 			rawText: "look",
 			attachmentCount: 1,
+			hookNotices: [],
 			fileBlocks: [{ type: "file", file_id: "a", media_type: "image/png" }],
 		});
 	});
@@ -83,6 +104,7 @@ describe("getQueuedMessageInfo", () => {
 			displayText: "[Queued message]",
 			rawText: "",
 			attachmentCount: 0,
+			hookNotices: [],
 			fileBlocks: [],
 		});
 	});
@@ -95,6 +117,7 @@ describe("getQueuedMessageInfo", () => {
 			displayText: "[Queued message]",
 			rawText: "",
 			attachmentCount: 0,
+			hookNotices: [],
 			fileBlocks: [],
 		});
 	});
@@ -110,6 +133,7 @@ describe("getQueuedMessageInfo", () => {
 			displayText: "[Queued message]",
 			rawText: "",
 			attachmentCount: 1,
+			hookNotices: [],
 			fileBlocks: [{ type: "file", file_id: "a", media_type: "image/png" }],
 		});
 	});
@@ -125,6 +149,7 @@ describe("getQueuedMessageInfo", () => {
 			displayText: "a b",
 			rawText: "a b",
 			attachmentCount: 0,
+			hookNotices: [],
 			fileBlocks: [],
 		});
 	});
@@ -141,6 +166,7 @@ describe("getQueuedMessageInfo", () => {
 			displayText: "check this",
 			rawText: "check this",
 			attachmentCount: 2,
+			hookNotices: [],
 			fileBlocks: [
 				{ type: "file", file_id: "img-1", media_type: "image/png" },
 				{ type: "file", file_id: "doc-2", media_type: "application/pdf" },

--- a/site/src/pages/AgentsPage/components/QueuedMessagesList.tsx
+++ b/site/src/pages/AgentsPage/components/QueuedMessagesList.tsx
@@ -217,13 +217,13 @@ export const QueuedMessagesList: FC<QueuedMessagesListProps> = ({
 							{item.hookNotices.length > 0 && (
 								<Tooltip>
 									<TooltipTrigger asChild>
-										<span
-											role="note"
-											aria-label="Lifecycle hook notice"
-											className="flex shrink-0 items-center text-highlight-sky"
+										<button
+											type="button"
+											aria-label={`Lifecycle hook notice: ${item.hookNotices.join(" ")}`}
+											className="flex shrink-0 cursor-default items-center border-none bg-transparent p-0 text-highlight-sky"
 										>
-											<InfoIcon className="size-3" />
-										</span>
+											<InfoIcon className="size-3" aria-hidden="true" />
+										</button>
 									</TooltipTrigger>
 									<TooltipContent side="top">
 										{item.hookNotices.join(" ")}

--- a/site/src/pages/AgentsPage/components/QueuedMessagesList.tsx
+++ b/site/src/pages/AgentsPage/components/QueuedMessagesList.tsx
@@ -2,6 +2,7 @@ import {
 	ArrowUpIcon,
 	CornerDownLeftIcon,
 	ImageIcon,
+	InfoIcon,
 	PencilIcon,
 	Trash2Icon,
 } from "lucide-react";
@@ -34,34 +35,32 @@ interface QueuedMessageInfo {
 	rawText: string;
 	attachmentCount: number;
 	fileBlocks: readonly ChatMessagePart[];
+	hookNotices: string[];
 }
 
 export const getQueuedMessageInfo = (
 	message: ChatQueuedMessage,
 ): QueuedMessageInfo => {
-	const { content } = message;
-	const fileBlocks = content.filter((p) => p.type === "file");
+	const fileBlocks: ChatMessagePart[] = [];
 	const textParts: string[] = [];
-	for (const part of content) {
-		if (part.type === "text" && part.text.trim()) {
+	const hookNotices: string[] = [];
+	for (const part of message.content) {
+		if (part.type === "file") {
+			fileBlocks.push(part);
+		} else if (part.type === "text" && part.text?.trim()) {
 			textParts.push(part.text);
+		} else if (part.type === "hook-notice" && part.text?.trim()) {
+			hookNotices.push(part.text);
 		}
 	}
 	const rawText = textParts.join(" ").trim();
 
-	if (rawText) {
-		return {
-			displayText: rawText,
-			rawText,
-			attachmentCount: fileBlocks.length,
-			fileBlocks,
-		};
-	}
 	return {
-		displayText: "[Queued message]",
-		rawText: "",
+		displayText: rawText || "[Queued message]",
+		rawText,
 		attachmentCount: fileBlocks.length,
 		fileBlocks,
+		hookNotices,
 	};
 };
 
@@ -74,7 +73,7 @@ export const QueuedMessagesList: FC<QueuedMessagesListProps> = ({
 	className,
 }) => {
 	const items = messages.map((message) => {
-		const { displayText, rawText, attachmentCount, fileBlocks } =
+		const { displayText, rawText, attachmentCount, fileBlocks, hookNotices } =
 			getQueuedMessageInfo(message);
 		return {
 			id: message.id,
@@ -82,6 +81,7 @@ export const QueuedMessagesList: FC<QueuedMessagesListProps> = ({
 			rawText,
 			attachmentCount,
 			fileBlocks,
+			hookNotices,
 		};
 	});
 
@@ -213,6 +213,22 @@ export const QueuedMessagesList: FC<QueuedMessagesListProps> = ({
 									<ImageIcon className="size-3" aria-hidden="true" />
 									<span aria-hidden="true">{item.attachmentCount}</span>
 								</span>
+							)}
+							{item.hookNotices.length > 0 && (
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<span
+											role="note"
+											aria-label="Lifecycle hook notice"
+											className="flex shrink-0 items-center text-highlight-sky"
+										>
+											<InfoIcon className="size-3" />
+										</span>
+									</TooltipTrigger>
+									<TooltipContent side="top">
+										{item.hookNotices.join(" ")}
+									</TooltipContent>
+								</Tooltip>
 							)}
 							{isFirst && (
 								<span

--- a/site/src/pages/AgentsPage/utils/usageLimitMessage.ts
+++ b/site/src/pages/AgentsPage/utils/usageLimitMessage.ts
@@ -87,11 +87,12 @@ export function isChatUsageLimitExceededResponse(
 export function isChatHookDispatchFailedResponse(
 	value: unknown,
 ): value is TypesGen.ChatHookDispatchFailedResponse {
-	if (value == null || typeof value !== "object") {
-		return false;
-	}
-	const obj = value as Record<string, unknown>;
-	return obj.kind === "hook_dispatch_failed";
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"kind" in value &&
+		value.kind === "hook_dispatch_failed"
+	);
 }
 
 /**

--- a/site/src/pages/AgentsPage/utils/usageLimitMessage.ts
+++ b/site/src/pages/AgentsPage/utils/usageLimitMessage.ts
@@ -96,6 +96,20 @@ export function isChatHookDispatchFailedResponse(
 }
 
 /**
+ * Runtime guard for the structured 403 hook-denial response.
+ */
+export function isChatHookDeniedResponse(
+	value: unknown,
+): value is TypesGen.ChatHookDeniedResponse {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"kind" in value &&
+		value.kind === "hook_denied"
+	);
+}
+
+/**
  * Build a user-friendly usage-limit message from structured 409
  * response data. Falls back to a generic message if structured
  * fields are missing or invalid.

--- a/site/src/pages/AgentsPage/utils/usageLimitMessage.ts
+++ b/site/src/pages/AgentsPage/utils/usageLimitMessage.ts
@@ -81,9 +81,6 @@ export function isChatUsageLimitExceededResponse(
 	);
 }
 
-/**
- * Runtime guard for the structured 502 hook-dispatch-failure response.
- */
 export function isChatHookDispatchFailedResponse(
 	value: unknown,
 ): value is TypesGen.ChatHookDispatchFailedResponse {
@@ -95,9 +92,6 @@ export function isChatHookDispatchFailedResponse(
 	);
 }
 
-/**
- * Runtime guard for the structured 403 hook-denial response.
- */
 export function isChatHookDeniedResponse(
 	value: unknown,
 ): value is TypesGen.ChatHookDeniedResponse {

--- a/site/src/pages/AgentsPage/utils/usageLimitMessage.ts
+++ b/site/src/pages/AgentsPage/utils/usageLimitMessage.ts
@@ -82,6 +82,19 @@ export function isChatUsageLimitExceededResponse(
 }
 
 /**
+ * Runtime guard for the structured 502 hook-dispatch-failure response.
+ */
+export function isChatHookDispatchFailedResponse(
+	value: unknown,
+): value is TypesGen.ChatHookDispatchFailedResponse {
+	if (value == null || typeof value !== "object") {
+		return false;
+	}
+	const obj = value as Record<string, unknown>;
+	return obj.kind === "hook_dispatch_failed";
+}
+
+/**
  * Build a user-friendly usage-limit message from structured 409
  * response data. Falls back to a generic message if structured
  * fields are missing or invalid.

--- a/site/src/pages/UserSettingsPage/SchedulePage/SchedulePage.test.tsx
+++ b/site/src/pages/UserSettingsPage/SchedulePage/SchedulePage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
 import type { UpdateUserQuietHoursScheduleRequest } from "#/api/typesGenerated";
@@ -17,7 +17,9 @@ const fillForm = async ({
 	timezone: string;
 }) => {
 	const user = userEvent.setup();
-	await waitFor(() => screen.findByLabelText("Start time"));
+	// findByLabelText already retries. Wrapping it in waitFor raced two 1s
+	// budgets against each other, so a slow first render timed out.
+	await screen.findByLabelText("Start time", undefined, { timeout: 10_000 });
 	const HH = hour.toString().padStart(2, "0");
 	const mm = minute.toString().padStart(2, "0");
 	fireEvent.change(screen.getByLabelText("Start time"), {
@@ -113,7 +115,7 @@ describe("SchedulePage", () => {
 
 			const errorMessage = await screen.findByText("oh no!");
 			expect(errorMessage).toBeDefined();
-		});
+		}, 15_000);
 	});
 
 	describe("when user custom schedule is disabled", () => {


### PR DESCRIPTION
Surfaces chat lifecycle hook outcomes in the chats UI. Final PR of the lifecycle hooks stack (#27401, #27428, #27429), all now merged.

- Show hook notices attached to their user message as timeline notes (`role="note"` so historical notices stay out of the screen reader's assertive live region), and show an info tooltip for notices on queued messages.
- Cache the full inserted message batch from send and edit responses so hook-inserted messages survive stream reconnects and queue promotion.
- Reconcile the promoted queue head after sending to an errored chat so a missed or delayed queue update neither duplicates nor hides messages, and clear the stale error status so the Thinking indicator appears before the websocket status event.
- Ignore an authoritative queue snapshot that still contains a just-promoted message: queued messages are delete-only, so such a snapshot predates the promotion and would both re-show the promoted message and drop messages queued since. Fresh snapshots apply in full and clear the suppression.
- Cache the store's reconciled queue on `queue_update` instead of the raw event, so a stale update cannot re-show a promoted message after REST re-hydration.
- Refresh chat details when a send or edit fails, because a failed hook dispatch can move the chat to the error state.
- Surface tool result error text in the tool rows: the execute failure tooltip shows the actual error instead of a hardcoded "Command failed", and a failed `write_file` renders an error label with the result error text instead of "Wrote <file>" with an args-derived diff of content that was never written. This makes hook tool denials legible in the timeline, and benefits every failed execute or write.

- Label a tool call blocked by `pre_tool_use` as failed instead of `Ran <command>`, matching what the write and edit tools already do. The wording derives from the tool-result error flag, so a command that ran and exited non-zero is unaffected.
- Render a hook notice below the message it annotates rather than above it, which reads correctly for a "your prompt was rewritten" card.
- Give both hook outcomes their own treatment on the create path, where they previously fell through to the generic error alert and an expected policy decision appeared with a stack trace, response data, and a workspaces action. Classification keys on the structured response body rather than the status code, so ordinary permission errors keep their existing rendering.

- Unrelated to the hooks work, de-flake `SchedulePage.test.tsx`. Its `fillForm` helper wrapped an already-retrying `findByLabelText` in `waitFor`, so the two 1s budgets raced and a slow first render failed `test-js` with "Timed out in waitFor". This is separable from the rest of the PR if you would rather it land on its own.

> This PR was written by Mux, an AI coding agent, on Mike's behalf.



