### PR TITLE
fix(coderd/x/chatd): normalize nil MCP tool properties to empty object

### DIFF
--- a/coderd/x/chatd/chatloop/chatloop.go
+++ b/coderd/x/chatd/chatloop/chatloop.go
@@ -1436,9 +1436,16 @@ func buildToolDefinitions(tools []fantasy.AgentTool, activeTools []string, provi
 			continue
 		}
 
+		// Coerce a nil parameter map to an explicit empty object so
+		// that "properties" never serializes to null, which OpenAI
+		// rejects for zero-argument tools.
+		properties := info.Parameters
+		if properties == nil {
+			properties = map[string]any{}
+		}
 		inputSchema := map[string]any{
 			"type":       "object",
-			"properties": info.Parameters,
+			"properties": properties,
 		}
 		// Only include "required" when non-empty so that a nil slice
 		// never serializes to null, which OpenAI rejects.

--- a/coderd/x/chatd/chatloop/tooldefinitions_internal_test.go
+++ b/coderd/x/chatd/chatloop/tooldefinitions_internal_test.go
@@ -1,0 +1,61 @@
+package chatloop
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"charm.land/fantasy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nilParamsTool is an AgentTool whose Info reports a nil parameter map,
+// mirroring a zero-argument MCP tool.
+type nilParamsTool struct {
+	name string
+}
+
+func (t nilParamsTool) Info() fantasy.ToolInfo {
+	return fantasy.ToolInfo{
+		Name:       t.name,
+		Parameters: nil,
+		Required:   nil,
+	}
+}
+
+func (nilParamsTool) Run(context.Context, fantasy.ToolCall) (fantasy.ToolResponse, error) {
+	return fantasy.NewTextResponse("ok"), nil
+}
+
+func (nilParamsTool) ProviderOptions() fantasy.ProviderOptions { return nil }
+
+func (nilParamsTool) SetProviderOptions(fantasy.ProviderOptions) {}
+
+// TestBuildToolDefinitions_NilParametersBecomesEmptyObject verifies that
+// a tool with no parameters produces "properties": {} rather than null.
+// OpenAI rejects a null "properties" value with "None is not of type
+// 'object'".
+func TestBuildToolDefinitions_NilParametersBecomesEmptyObject(t *testing.T) {
+	t.Parallel()
+
+	tools := buildToolDefinitions(
+		[]fantasy.AgentTool{nilParamsTool{name: "no_args"}},
+		[]string{"no_args"},
+		nil,
+	)
+	require.Len(t, tools, 1)
+
+	fn, ok := tools[0].(fantasy.FunctionTool)
+	require.True(t, ok, "expected a FunctionTool")
+
+	properties, ok := fn.InputSchema["properties"]
+	require.True(t, ok, "input schema should have a properties field")
+	require.NotNil(t, properties, "properties should never be nil")
+
+	// The whole schema must serialize with "properties":{}, not null.
+	bs, err := json.Marshal(fn.InputSchema)
+	require.NoError(t, err)
+	assert.Contains(t, string(bs), `"properties":{}`)
+	assert.NotContains(t, string(bs), `"properties":null`)
+}

--- a/coderd/x/chatd/mcpclient/mcpclient.go
+++ b/coderd/x/chatd/mcpclient/mcpclient.go
@@ -583,11 +583,19 @@ func (t *mcpToolWrapper) Info() fantasy.ToolInfo {
 		required = []string{}
 	}
 
+	// Ensure Parameters is never nil so that "properties" serializes to
+	// {} instead of null. OpenAI rejects null for the JSON Schema
+	// "properties" field on zero-argument tools.
+	parameters := t.parameters
+	if parameters == nil {
+		parameters = map[string]any{}
+	}
+
 	if !t.modelIntent {
 		return fantasy.ToolInfo{
 			Name:        t.prefixedName,
 			Description: t.description,
-			Parameters:  t.parameters,
+			Parameters:  parameters,
 			Required:    required,
 			Parallel:    true,
 		}
@@ -610,7 +618,7 @@ func (t *mcpToolWrapper) Info() fantasy.ToolInfo {
 		},
 		"properties": map[string]any{
 			"type":       "object",
-			"properties": t.parameters,
+			"properties": parameters,
 			"required":   required,
 		},
 	}

--- a/coderd/x/chatd/mcpclient/mcpclient_test.go
+++ b/coderd/x/chatd/mcpclient/mcpclient_test.go
@@ -76,6 +76,23 @@ func makeTool(name string) mcpserver.ServerTool {
 	}
 }
 
+// zeroArgTool returns a ServerTool whose advertised input schema omits
+// "properties" entirely, mirroring MCP servers that describe a
+// zero-argument tool as {"type":"object"}. The client decodes the
+// missing key as a nil parameter map.
+func zeroArgTool(name string) mcpserver.ServerTool {
+	return mcpserver.ServerTool{
+		Tool: mcp.Tool{
+			Name:           name,
+			Description:    "A tool with no arguments",
+			RawInputSchema: json.RawMessage(`{"type":"object"}`),
+		},
+		Handler: func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return mcp.NewToolResultText("ok"), nil
+		},
+	}
+}
+
 // makeConfig builds a database.MCPServerConfig suitable for tests.
 func makeConfig(slug, url string) database.MCPServerConfig {
 	return database.MCPServerConfig{
@@ -600,6 +617,60 @@ func TestConnectAll_NilRequiredBecomesEmptySlice(t *testing.T) {
 	bs, err := json.Marshal(info.Required)
 	require.NoError(t, err)
 	assert.Equal(t, "[]", string(bs))
+}
+
+// TestConnectAll_NilParametersBecomesEmptyObject verifies that a
+// zero-argument tool whose inputSchema omits "properties" produces a
+// non-nil parameter map. A nil map serializes to JSON null, which
+// OpenAI rejects with "None is not of type 'object'".
+func TestConnectAll_NilParametersBecomesEmptyObject(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+
+	ts := newTestMCPServer(t, zeroArgTool("no_args"))
+	cfg := makeConfig("srv", ts.URL)
+	tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil, nil)
+	t.Cleanup(cleanup)
+	require.Len(t, tools, 1)
+
+	info := tools[0].Info()
+	// Parameters must be a non-nil empty map, not nil.
+	require.NotNil(t, info.Parameters, "Parameters should never be nil")
+
+	// Verify it serializes to {} not null.
+	bs, err := json.Marshal(info.Parameters)
+	require.NoError(t, err)
+	assert.Equal(t, "{}", string(bs))
+}
+
+// TestConnectAll_NilParametersBecomesEmptyObject_ModelIntent verifies
+// that the same coercion applies to the nested schema built when
+// model_intent wrapping is enabled, so the inner "properties" is {}
+// rather than null.
+func TestConnectAll_NilParametersBecomesEmptyObject_ModelIntent(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+
+	ts := newTestMCPServer(t, zeroArgTool("no_args"))
+	cfg := makeConfig("intent-srv", ts.URL)
+	cfg.ModelIntent = true
+	tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil, nil)
+	t.Cleanup(cleanup)
+	require.Len(t, tools, 1)
+
+	info := tools[0].Info()
+	propsObj, ok := info.Parameters["properties"].(map[string]any)
+	require.True(t, ok, "schema should nest the original schema under properties")
+
+	innerProps, ok := propsObj["properties"]
+	require.True(t, ok, "nested schema should have a properties field")
+	require.NotNil(t, innerProps, "nested properties should never be nil")
+
+	bs, err := json.Marshal(innerProps)
+	require.NoError(t, err)
+	assert.Equal(t, "{}", string(bs))
 }
 
 // TestConnectAll_APIKeyAuth verifies that api_key auth sends the


### PR DESCRIPTION
Zero-argument MCP tools whose input schema omits `properties` reach the OpenAI function schema as `"properties": null`, which OpenAI rejects with `Invalid schema for function '<tool>': None is not of type 'object'` (HTTP 400) before the tool executes. Anthropic-backed chats are unaffected because they do not strict-validate the schema, so the same tool works on Sonnet but fails on GPT.

This is the object-valued counterpart of the already-merged `required` fix (coder/coder#23538): an absent or nil parameter map is passed straight through and serializes to `null` instead of `{}`.

## Fix

Coerce a nil parameter map to an explicit empty object in two places:

- `buildToolDefinitions` (`coderd/x/chatd/chatloop/chatloop.go`) — the provider boundary that every `AgentTool` (MCP, built-in, and dynamic tools) passes through.
- `mcpToolWrapper.Info` (`coderd/x/chatd/mcpclient/mcpclient.go`) — normalizes at the source and additionally covers the nested schema built when `model_intent` wrapping is enabled, which the boundary fix cannot reach.

This mirrors the guard already merged for the sibling `required` field.

Refs coder/coder#27252

## Verification

Added regression tests in both packages using a zero-argument tool whose schema omits `properties` (plain and `model_intent` variants). Each test fails without the guard (parameters come back `nil`, serializing to `null`) and passes with it.

```
$ go test ./coderd/x/chatd/mcpclient/ -run TestConnectAll_NilParametersBecomesEmptyObject -v
--- PASS: TestConnectAll_NilParametersBecomesEmptyObject_ModelIntent (0.00s)
--- PASS: TestConnectAll_NilParametersBecomesEmptyObject (0.00s)
ok  	github.com/coder/coder/v2/coderd/x/chatd/mcpclient

$ go test ./coderd/x/chatd/chatloop/ -run TestBuildToolDefinitions_NilParametersBecomesEmptyObject -v
--- PASS: TestBuildToolDefinitions_NilParametersBecomesEmptyObject (0.00s)
ok  	github.com/coder/coder/v2/coderd/x/chatd/chatloop
```

Confirmed the same two tests fail on the unpatched tree (`Parameters should never be nil` / `properties should never be nil`). `golangci-lint run`, `paralleltestctx`, and `go vet` are clean on both packages; full `mcpclient` and `chatloop` package suites pass, including under `-race`.

## AI disclosure

This change was authored with AI assistance (Claude Code) per the repository's [AI contribution guidelines](https://github.com/coder/coder/blob/main/docs/about/contributing/AI_CONTRIBUTING.md). The diff, test design, and verification above were reviewed manually by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
