### PR TITLE
fix(site/src/pages/AgentsPage): align subagent and auth tool spinners with standard right-side status

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
@@ -1,9 +1,7 @@
 import {
-	CheckIcon,
 	CircleAlertIcon,
 	ExternalLinkIcon,
 	LayersIcon,
-	LoaderIcon,
 	OctagonXIcon,
 } from "lucide-react";
 import type React from "react";
@@ -295,42 +293,14 @@ export const WaitForExternalAuthTool: React.FC<{
 }) => {
 	const isRunning = status === "running";
 	let label = `Waiting for ${providerLabel} authentication...`;
-	let statusIcon: React.ReactNode = isRunning ? (
-		<LoaderIcon
-			aria-label="Authentication in progress"
-			role="img"
-			className="size-3.5 shrink-0 animate-spin text-content-link motion-reduce:animate-none"
-		/>
-	) : null;
 	if (isError) {
 		label =
 			errorMessage ||
 			`Failed while waiting for ${providerLabel} authentication`;
-		statusIcon = (
-			<OctagonXIcon
-				aria-label="Authentication failed"
-				role="img"
-				className="size-3.5 shrink-0 text-content-destructive"
-			/>
-		);
 	} else if (timedOut) {
 		label = `Timed out waiting for ${providerLabel} authentication`;
-		statusIcon = (
-			<CircleAlertIcon
-				aria-label="Authentication timed out"
-				role="img"
-				className="size-3.5 shrink-0 text-content-warning"
-			/>
-		);
 	} else if (authenticated && !isRunning) {
 		label = `Authenticated with ${providerLabel}`;
-		statusIcon = (
-			<CheckIcon
-				aria-label="Authentication completed"
-				role="img"
-				className="size-3.5 shrink-0 text-content-success"
-			/>
-		);
 	}
 
 	return (
@@ -346,10 +316,11 @@ export const WaitForExternalAuthTool: React.FC<{
 		>
 			<ToolCall.HeaderLayout>
 				<ToolCall.HeaderButton className="min-w-0 flex-1 font-normal text-content-secondary">
-					<ToolCall.LeadingIcon>{statusIcon}</ToolCall.LeadingIcon>
+					<ToolCall.LeadingIcon name="wait_for_external_auth" />
 					<ToolCall.Label className="text-content-primary">
 						{label}
 					</ToolCall.Label>
+					<ToolCall.Status />
 				</ToolCall.HeaderButton>
 			</ToolCall.HeaderLayout>
 		</ToolCall.Root>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
@@ -3,7 +3,6 @@ import {
 	CircleXIcon,
 	ClockIcon,
 	ExternalLinkIcon,
-	LoaderIcon,
 	MonitorIcon,
 } from "lucide-react";
 import type React from "react";
@@ -115,11 +114,9 @@ function getSubagentLabel(
 }
 
 /**
- * Resolves a sub-agent status string and tool-level status into a
- * display icon. The sub-agent status in the tool result is a
- * snapshot from when the tool returned and may be stale (e.g. a
- * background sub-agent records "running" forever). The icon is
- * therefore driven primarily by the tool-call status itself.
+ * Leading icon for a sub-agent row. Driven by `toolStatus` rather
+ * than the raw sub-agent status, which is a snapshot from when the
+ * tool returned and may be stale.
  */
 const SubagentStatusIcon: React.FC<{
 	subagentStatus: string;
@@ -137,31 +134,22 @@ const SubagentStatusIcon: React.FC<{
 	showDesktopPreview = false,
 }) => {
 	const subagentCompleted = isSubagentSuccessStatus(subagentStatus);
-	const DefaultIcon = iconKind === "monitor" ? MonitorIcon : BotIcon;
+	const DefaultIcon =
+		iconKind === "monitor" || (toolStatus === "running" && showDesktopPreview)
+			? MonitorIcon
+			: BotIcon;
 	if (isTimeout && !subagentCompleted) {
 		return <ClockIcon className="size-4 shrink-0 stroke-[1.5] text-current" />;
 	}
 	if ((isError && !subagentCompleted) || toolStatus === "error") {
 		return <CircleXIcon className="size-4 shrink-0 text-current" />;
 	}
-	if (toolStatus === "running") {
-		if (showDesktopPreview) {
-			return (
-				<MonitorIcon className="size-4 shrink-0 stroke-[1.5] text-current" />
-			);
-		}
-		return (
-			<LoaderIcon className="size-4 shrink-0 animate-spin motion-reduce:animate-none text-content-link" />
-		);
-	}
 	return <DefaultIcon className="size-4 shrink-0 stroke-[1.5] text-current" />;
 };
 
 /**
- * Specialized rendering for delegated sub-agent tool calls.
- * Shows a clickable header row with the sub-agent title, status
- * icon, and a chevron to expand the prompt / report below. A
- * "View Agent" link navigates to the sub-agent chat.
+ * Row for a delegated sub-agent tool call, with a link to the
+ * sub-agent chat and an expandable prompt / report.
  */
 export const SubagentTool: React.FC<{
 	descriptor: SubagentDescriptor;
@@ -248,6 +236,7 @@ export const SubagentTool: React.FC<{
 							modelDisplay,
 						)}
 					</ToolCall.Label>
+					<ToolCall.Status />
 					<ToolCall.Chevron />
 				</ToolCall.HeaderButton>
 				{agentChatPath && (

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -594,7 +594,7 @@ export const WaitForExternalAuthRunning: Story = {
 			canvas.getByText("Waiting for GitHub authentication..."),
 		).toBeInTheDocument();
 		expect(
-			canvas.getByRole("img", { name: "Authentication in progress" }),
+			canvas.getByRole("img", { name: "Tool call running" }),
 		).toBeVisible();
 	},
 };
@@ -661,6 +661,11 @@ export const SubagentRunning: Story = {
 			"href",
 			"/agents/child-chat-id",
 		);
+		// Running state shows the spinner in the standard right-side
+		// status slot, not as the leading icon.
+		expect(
+			canvas.getByRole("img", { name: "Tool call running" }),
+		).toBeVisible();
 	},
 };
 


### PR DESCRIPTION
## Problem

On the AgentsPage, tool calls render a running spinner in different places depending on the tool. Most tools (read_file, execute, etc.) show the spinner in the standard right-side `ToolCall.Status` slot, but `spawn_agent`/subagent calls show it as the leading icon on the left (larger, `text-content-link`), and `wait_for_external_auth` does the same. This makes the transcript look inconsistent while tools are in flight.

## Fix

Aligned both with the shared pattern: a static semantic leading icon, and the running spinner in the standard right-side `ToolCall.Status` slot.

- `SubagentTool`: the leading icon is now static (Bot, or Monitor for computer-use) instead of a spinner that replaced the icon while running. The running spinner now renders in the standard right-side `ToolCall.Status` slot. The leading Clock (timeout) and CircleX (error) icons are kept, since they have no `ToolCall.Status` equivalent and the timeout-vs-error distinction is intentional.
- `WaitForExternalAuthTool`: the leading slot now always shows the semantic `LogInIcon` instead of swapping in a status icon. Running uses the standard right-side `ToolCall.Status` spinner, and failure uses the standard right-side warning triangle rather than a separate colored icon on the left. Timeout and authenticated outcomes are conveyed by the label text, matching how the message already reads.

Updated the `SubagentRunning` and `WaitForExternalAuthRunning` stories to assert the standard `Tool call running` status indicator. The pre-existing `MCP Tool Completed` story failure is unrelated (also fails on `main`).

---

<sub>Generated by Coder Agents on behalf of @DanielleMaywood</sub>
