### PR TITLE
docs: describe deployment topologies

### DIFF
--- a/docs/admin/infrastructure/architecture.md
+++ b/docs/admin/infrastructure/architecture.md
@@ -138,7 +138,16 @@ as OpenAI and Anthropic. Users authenticate through Coder instead of managing se
 provider API keys. All prompts, token usage, and tool invocations are recorded
 for compliance and cost tracking.
 
-Learn more: [AI Gateway](../../ai-coder/ai-gateway/index.md)
+AI Gateway supports 2 deployment topologies:
+
+- **Embedded:** `coderd` runs the AI Gateway data plane in its own process.
+- **Standalone:** AI Gateway runs outside `coderd`, as replicas that serve AI traffic and send requests directly to upstream providers.
+
+Standalone replicas hold no authoritative state.
+Each replica maintains a control connection to `coderd` for Coder API key validation, provider configuration, and AI session recording, and becomes unready when that connection is unavailable.
+`coderd` remains the source of truth and the only component that writes durable AI Gateway state to PostgreSQL.
+
+Refer to [AI Gateway](../../ai-coder/ai-gateway/index.md) and [standalone deployment](../../ai-coder/ai-gateway/standalone.md) for configuration and operational guidance.
 
 ### Agent Firewall
 

--- a/docs/ai-coder/ai-gateway/mcp.md
+++ b/docs/ai-coder/ai-gateway/mcp.md
@@ -34,7 +34,7 @@ CODER_EXTERNAL_AUTH_0_CLIENT_SECRET=...
 CODER_EXTERNAL_AUTH_0_MCP_URL=https://api.githubcopilot.com/mcp/
 ```
 
-See the diagram in [Implementation Details](./reference.md#implementation-details) for more information.
+Refer to the diagram in [Embedded Gateway](./reference.md#embedded-gateway) for more information.
 
 You can also control which tools are injected by using an allow and/or a deny regular expression on the tool names:
 
@@ -64,7 +64,7 @@ AI Gateway marks automatically injected tools with a prefix `bmcp_` ("bridged MC
 
 ## Tool Injection
 
-If a model decides to invoke a tool and it has a `bmcp_` prefix and AI Gateway has a connection with the related MCP server, it will invoke the tool. The tool result will be passed back to the upstream AI provider, and this will loop until the model has all of its required data. These inner loops are not relayed back to the client; all it sees is the result of this loop. See [Implementation Details](./reference.md#implementation-details).
+If a model decides to invoke a tool and it has a `bmcp_` prefix and AI Gateway has a connection with the related MCP server, it will invoke the tool. The tool result will be passed back to the upstream AI provider, and this will loop until the model has all of its required data. These inner loops are not relayed back to the client. Client only sees the result of this loop. Refer to [Deployment topologies](./reference.md#deployment-topologies).
 
 In contrast, tools which are defined by the client (i.e. the [`Bash` tool](https://docs.claude.com/en/docs/claude-code/settings#tools-available-to-claude) defined by _Claude Code_) cannot be invoked by AI Gateway, and the tool call from the model will be relayed to the client, after which it will invoke the tool.
 

--- a/docs/ai-coder/ai-gateway/mcp.md
+++ b/docs/ai-coder/ai-gateway/mcp.md
@@ -64,7 +64,7 @@ AI Gateway marks automatically injected tools with a prefix `bmcp_` ("bridged MC
 
 ## Tool Injection
 
-If a model decides to invoke a tool and it has a `bmcp_` prefix and AI Gateway has a connection with the related MCP server, it will invoke the tool. The tool result will be passed back to the upstream AI provider, and this will loop until the model has all of its required data. These inner loops are not relayed back to the client. Client only sees the result of this loop. Refer to [Deployment topologies](./reference.md#deployment-topologies).
+If a model decides to invoke a tool and it has a `bmcp_` prefix and AI Gateway has a connection with the related MCP server, it will invoke the tool. The tool result will be passed back to the upstream AI provider, and this will loop until the model has all of its required data. These inner loops are not relayed back to the client. The client only sees the result of this loop. Refer to [Deployment topologies](./reference.md#deployment-topologies).
 
 In contrast, tools which are defined by the client (i.e. the [`Bash` tool](https://docs.claude.com/en/docs/claude-code/settings#tools-available-to-claude) defined by _Claude Code_) cannot be invoked by AI Gateway, and the tool call from the model will be relayed to the client, after which it will invoke the tool.
 

--- a/docs/ai-coder/ai-gateway/reference.md
+++ b/docs/ai-coder/ai-gateway/reference.md
@@ -2,21 +2,67 @@
 
 > [!NOTE]
 > AI Gateway requires the [AI Governance Add-On](../ai-governance.md).
-> As of Coder v2.32, deployments without the add-on will not be able to
-> access AI Gateway.
+> As of Coder v2.32, deployments without the add-on cannot access AI Gateway.
 
-## Implementation Details
+## Deployment topologies
 
-`coderd` runs an in-memory instance of `aibridged`, whose logic is mostly contained in ../../../aibridge. In future releases we will support running external instances for higher throughput and complete memory isolation from `coderd`.
+AI Gateway can run inside `coderd` or as a standalone data-plane service.
+Both topologies use the same Gateway request handling and keep `coderd` as the source of truth for Coder API key validation, provider configuration, and AI session records.
+
+### Embedded Gateway
+
+By default, `coder server` runs an in-memory Gateway instance in the `coderd` process.
+AI clients send requests to the Coder access URL.
+The embedded Gateway uses the same control RPC as a standalone deployment, over an in-process transport rather than a network connection.
+It does not use an AI Gateway key and does not negotiate an API version.
+
+The following diagram shows the embedded topology:
 
 ![AI Gateway implementation details](../../images/aibridge/aibridge-implementation-details.png)
 
+### Standalone Gateway
+
+A [standalone deployment](./standalone.md) runs the AI traffic data plane outside the `coderd` process.
+Each replica accepts client traffic, sends AI requests directly to upstream providers, and maintains a control connection to `coderd` using a [Gateway key](./standalone.md#create-a-gateway-key).
+
+The control connection carries:
+
+- Coder API key validation, which resolves each request to an active Coder user.
+- Provider configuration, plus a change signal when the provider set changes.
+- AI session records.
+- (deprecated) The configuration and access tokens used by [injected MCP](./mcp.md).
+
+Standalone replicas do not own authoritative database state.
+They keep ephemeral provider snapshots, request caches, provider key pools, and metrics in memory, and emit their own logs and traces.
+Each replica writes its own [API dumps](./setup.md#api-dumps) to its own local disk when dumps are enabled.
+
+`coderd` remains required for standalone operation.
+A replica becomes unready when its control connection is unavailable, even if its HTTP listener remains healthy.
+AI Gateway Proxy remains part of `coder server` and can forward its intercepted traffic to either the embedded Gateway or a standalone endpoint.
+
+## Version compatibility
+
+The control connection between a standalone replica and `coderd` is versioned.
+The current version is defined in [`coderd/aibridged/proto/version.go`](https://github.com/coder/coder/blob/main/coderd/aibridged/proto/version.go).
+
+`coderd` validates the version that a standalone replica advertises before it accepts the control connection.
+Compatibility follows these rules:
+
+- The Gateway and `coderd` major versions must match.
+- The Gateway minor version must be less than or equal to the `coderd` minor version.
+- `coderd` rejects a standalone Gateway that advertises a newer minor version.
+
+A rejected replica receives an HTTP 400 response that reports the `client_api_version` and `server_api_version` values.
+Coder build versions are not the compatibility criterion.
+
+For upgrade and rollback ordering, refer to [Version compatibility](./standalone.md#version-compatibility) in the standalone deployment guide.
+
 ## Supported APIs
 
-API support is broken down into two categories:
+API support is divided into two categories:
 
-- **Intercepted**: requests are intercepted, audited, and augmented - full AI Gateway functionality
-- **Passthrough**: requests are proxied directly to the upstream, no auditing or augmentation takes place
+- **Intercepted**: Requests are intercepted, audited, and augmented.
+- **Passthrough**: Requests are proxied directly to the upstream provider without auditing or augmentation.
 
 Where relevant, both streaming and non-streaming requests are supported.
 
@@ -43,4 +89,5 @@ Where relevant, both streaming and non-streaming requests are supported.
 
 ## Troubleshooting
 
-To report a bug, file a feature request, or view a list of known issues, please visit our [GitHub repository](https://github.com/coder/coder/issues). If you encounter issues with AI Gateway, please reach out to us via [Discord](https://discord.gg/coder).
+To report a bug, file a feature request, or review known issues, visit the [Coder GitHub repository](https://github.com/coder/coder/issues).
+For help with AI Gateway, visit the [Coder Discord](https://discord.gg/coder).

--- a/docs/ai-coder/ai-gateway/reference.md
+++ b/docs/ai-coder/ai-gateway/reference.md
@@ -2,19 +2,21 @@
 
 > [!NOTE]
 > AI Gateway requires the [AI Governance Add-On](../ai-governance.md).
-> As of Coder v2.32, deployments without the add-on cannot access AI Gateway.
+> As of Coder v2.32, deployments without the add-on will not be able to
+> access AI Gateway.
 
 ## Deployment topologies
 
 AI Gateway can run inside `coderd` or as a standalone data-plane service.
-Both topologies use the same Gateway request handling and keep `coderd` as the source of truth for Coder API key validation, provider configuration, and AI session records.
+Both topologies run the same Gateway request handling and keep `coderd` as the source of truth for Coder API key validation, provider configuration, and AI session records.
+They differ in how requests are routed to the Gateway.
 
 ### Embedded Gateway
 
 By default, `coder server` runs an in-memory Gateway instance in the `coderd` process.
-AI clients send requests to the Coder access URL.
+AI clients send requests to `<Coder access URL>/api/v2/ai-gateway/<provider-name>/`.
 The embedded Gateway uses the same control RPC as a standalone deployment, over an in-process transport rather than a network connection.
-It does not use an AI Gateway key and does not negotiate an API version.
+It does not use a Gateway key and does not negotiate an API version.
 
 The following diagram shows the embedded topology:
 
@@ -30,7 +32,7 @@ The control connection carries:
 - Coder API key validation, which resolves each request to an active Coder user.
 - Provider configuration, plus a change signal when the provider set changes.
 - AI session records.
-- (deprecated) The configuration and access tokens used by [injected MCP](./mcp.md).
+- **Deprecated**: the configuration and access tokens used by [injected MCP](./mcp.md).
 
 Standalone replicas do not own authoritative database state.
 They keep ephemeral provider snapshots, request caches, provider key pools, and metrics in memory, and emit their own logs and traces.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1331,7 +1331,7 @@
 								},
 								{
 									"title": "Reference",
-									"description": "Technical reference for AI Gateway, including the aibridged component that runs inside coderd.",
+									"description": "Technical reference for AI Gateway, including deployment topologies, version compatibility, and supported APIs.",
 									"path": "./ai-coder/ai-gateway/reference.md",
 									"state": ["ai governance add-on"]
 								},


### PR DESCRIPTION
> AI helped with this PR

Adds documentation regarding the embedded and standalone AI Gateway deployment topologies in the AI Gateway reference and the control-plane architecture overview.