### PR TITLE
docs: document Gateway key authentication

### DIFF
--- a/docs/admin/users/sessions-tokens.md
+++ b/docs/admin/users/sessions-tokens.md
@@ -119,6 +119,8 @@ To hard-delete a token, use the `--delete` flag:
 coder tokens remove --delete <name|id>
 ```
 
+Deleting the user that owns a token revokes every token that user holds at the same time.
+
 ## API Key Scopes
 
 API key scopes allow you to limit the permissions of a token to specific operations. By default, tokens are created with the `all` scope, granting full access to all actions the user can perform. For improved security, you can create tokens with limited scopes that restrict access to only the operations needed.

--- a/docs/ai-coder/ai-gateway/auth.md
+++ b/docs/ai-coder/ai-gateway/auth.md
@@ -3,25 +3,33 @@
 > [!NOTE]
 > AI Gateway requires the [AI Governance Add-On](../ai-governance.md).
 
-AI Gateway authenticates clients with the same Coder API token
-that a user already uses against the rest of the Coder API.
-No separate AI Gateway login or credential is required.
+AI Gateway uses different credentials for connections from clients to the Gateway, standalone Gateway replicas to the Coder control plane, and the Gateway to upstream providers:
 
-Authenticating with a Coder token avoids distributing provider-specific API keys
-(such as OpenAI or Anthropic keys) to individual users.
+- AI clients use a Coder API token to authenticate as a user.
+- Standalone Gateway replicas use AI Gateway keys to connect to `coderd`.
+- AI Gateway uses provider credentials configured by an administrator to authenticate to upstream AI services.
+- In Bring Your Own Key (BYOK) mode, a user also supplies a personal provider credential or subscription token.
+
+These credentials are not interchangeable.
+A Gateway key does not authenticate an AI client, and a Coder API token does not authenticate a standalone replica.
+
+## Authenticate AI clients
+
+AI Gateway authenticates clients with the same Coder API token
+that a user uses for the rest of the Coder API.
+No separate AI Gateway login is required for client traffic.
+For token creation, expiration, and revocation, refer to [Sessions and API tokens](../../admin/users/sessions-tokens.md).
+
+Authenticating with a Coder token avoids distributing centralized provider API keys,
+such as OpenAI or Anthropic keys, to individual users.
 AI Gateway handles upstream credentials centrally and
 forwards each request to the configured provider on the user's behalf.
 
-> [!NOTE]
-> Only Coder-issued tokens can authenticate users to AI Gateway.
-> AI Gateway will use provider-specific API keys to
-> [authenticate against upstream AI services](./setup.md#configure-providers).
+The exact environment variable or setting name differs between tools.
+Refer to the list of [supported clients](./clients/index.md) and
+your tool's documentation for details.
 
-The exact environment variable or setting naming may differ from tool to tool.
-Refer to the list of [supported clients](./clients/index.md),
-and consult your tool's documentation for details.
-
-## Create a Coder API token
+### Create a Coder API token
 
 You can generate a token from the Coder dashboard or the CLI.
 
@@ -43,22 +51,17 @@ coder tokens create --lifetime 30d -n my-ai-token
 
 Use short lifetimes for automation and CI to limit the blast radius if a token leaks.
 
-## Retrieve your session token
+### Retrieve your session token
 
-If you're logged in with the Coder CLI, you can retrieve your current session token
-by using [`coder login token`](../../reference/cli/login_token.md):
+If you're logged in with the Coder CLI, retrieve your current session token
+with [`coder login token`](../../reference/cli/login_token.md):
 
 ```sh
 export ANTHROPIC_API_KEY=$(coder login token)
 export ANTHROPIC_BASE_URL="https://coder.example.com/api/v2/ai-gateway/anthropic"
 ```
 
-Alternatively, you can [generate a long-lived API token](../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)
-from the Coder dashboard.
-
-For headless or service-account use, refer to [Headless authentication](../../admin/users/headless-auth.md).
-
-## AI Gateway Proxy authentication
+### AI Gateway Proxy authentication
 
 For tools that don't support a configurable base URL,
 [AI Gateway Proxy](./ai-gateway-proxy/index.md) intercepts traffic and forwards it to AI Gateway.
@@ -71,25 +74,87 @@ export HTTPS_PROXY="https://coder:$(coder login token)@<proxy-host>:8888"
 The client machine also needs to trust the proxy's CA certificate.
 For full setup, refer to [AI Gateway Proxy setup](./ai-gateway-proxy/setup.md).
 
+## Authenticate standalone Gateway replicas
+
+AI Gateway keys are scoped to the Coder deployment.
+A [standalone AI Gateway](./standalone.md) uses one of these keys to connect to `coderd`.
+The built-in Owner role can create, list, and delete these keys.
+A site-level custom role can also manage them when it has the corresponding `ai_gateway_key` permissions.
+
+Create a key with a descriptive name:
+
+```console
+coder ai-gateway keys create standalone-production
+```
+
+The command displays the plaintext key once.
+Save it immediately in your secret manager because Coder cannot retrieve it later.
+Coder stores only a visible prefix and a SHA-256 hash of the secret.
+
+Configure the standalone process with exactly 1 of the following options:
+
+- `CODER_AI_GATEWAY_KEY` or `--key` supplies the key directly.
+- `CODER_AI_GATEWAY_KEY_FILE` or `--key-file` reads the key from a file.
+
+A user login and `CODER_SESSION_TOKEN` are not used by `coder ai-gateway start`.
+The same Gateway key can authenticate multiple replicas. Separate keys make it easier to rotate or revoke each deployment independently.
+
+List keys and their most recent usage heartbeat:
+
+```console
+coder ai-gateway keys list
+```
+
+A replica records a heartbeat when it connects and updates the timestamp every 60 seconds while the session remains active.
+
+For command options, refer to the generated CLI reference for [creating](../../reference/cli/ai-gateway_keys_create.md), [listing](../../reference/cli/ai-gateway_keys_list.md), and [deleting](../../reference/cli/ai-gateway_keys_delete.md) Gateway keys.
+
+### Rotate a Gateway key
+
+Rotate a key without interrupting traffic:
+
+1. Create a new Gateway key.
+1. Update the Secret, environment variable, or key file used by every replica.
+1. Restart or roll out the standalone deployment so every replica uses the new key.
+1. Verify readiness and confirm that the new key has a recent heartbeat.
+1. Delete the old key.
+
+Delete a key by name or ID:
+
+```console
+coder ai-gateway keys delete standalone-production
+```
+
+Deleting a key rejects new connections immediately.
+An existing session closes after a later heartbeat detects the deletion. Gateway may retry connecting with the same key, that attempt will be rejected.
+Stop or update every replica before deleting its key for an orderly rotation.
+
+## Authenticate to upstream providers
+
+Administrators configure provider credentials in the Coder dashboard or with the [AI Providers API](../../reference/api/aiproviders.md).
+Standalone replicas fetch this provider configuration from `coderd`, so do not copy centralized provider credentials into each standalone deployment.
+
+For provider setup and credential failover, refer to [Provider configuration](./providers.md).
+
 ## Bring Your Own Key (BYOK)
 
-In addition to centralized key management, AI Gateway supports **Bring Your Own Key** (BYOK) mode.
-Users can provide their own LLM API keys or use provider subscriptions
-(such as Claude Pro/Max or ChatGPT Plus/Pro),
+In addition to centralized key management, AI Gateway supports Bring Your Own Key (BYOK) mode.
+Users can provide their own LLM API keys or provider subscriptions,
+such as Claude Pro or Max and ChatGPT Plus or Pro,
 while AI Gateway continues to provide observability and governance.
 
 ![BYOK authentication flow](../../images/aibridge/clients/byok_auth_flow.png)
 
 In BYOK mode, users need two credentials:
 
-- A **Coder API token** to authenticate with AI Gateway.
-- Their **own LLM credential** (personal API key or subscription token)
+- A Coder API token to authenticate with AI Gateway.
+- Their own LLM credential, such as a personal API key or subscription token,
   which AI Gateway forwards to the upstream provider.
 
 BYOK and centralized modes can be used together.
 When a user provides their own credential, AI Gateway forwards it directly.
-When no user credential is present, AI Gateway uses the admin-configured provider key.
-This approach offers centralized keys as a default,
+When no user credential is present, AI Gateway uses the administrator-configured provider key.
+This approach offers centralized keys as a default
 while allowing individual users to bring their own key.
 
 > [!NOTE]
@@ -97,11 +162,11 @@ while allowing individual users to bring their own key.
 > is skipped.
 
 Coder Agents requests routed through AI Gateway are in-process control plane
-requests, not external client requests that send their own AI Gateway bearer
-token. Coder Agents use this same global BYOK setting. When BYOK is enabled,
-users can save personal API keys for any enabled AI provider from the Agents
-settings page. See
-[Agents credential selection](../agents/models.md#credential-selection)
+requests, not external client requests that send their own AI Gateway bearer token.
+Coder Agents use the same global BYOK setting.
+When BYOK is enabled, users can save personal API keys for any enabled AI provider
+from the Agents settings page.
+Refer to [Agents credential selection](../agents/models.md#credential-selection)
 for the Agents-specific behavior.
 
 Visit individual [client pages](./clients/index.md) for configuration details.
@@ -109,21 +174,17 @@ Visit individual [client pages](./clients/index.md) for configuration details.
 ### Enable or disable BYOK
 
 BYOK is enabled by default.
-Administrators can disable it using `--ai-gateway-allow-byok=false` or `CODER_AI_GATEWAY_ALLOW_BYOK=false`:
+Administrators can disable it for the embedded Gateway with `--ai-gateway-allow-byok=false` or `CODER_AI_GATEWAY_ALLOW_BYOK=false`:
 
 ```sh
 coder server --ai-gateway-allow-byok=false
 ```
 
-When disabled, BYOK requests are rejected with a `403 Forbidden` response and only centralized key authentication is permitted.
+For a standalone Gateway, set the option on each replica:
 
-## Rotate or revoke a token
+```sh
+CODER_AI_GATEWAY_ALLOW_BYOK=false coder ai-gateway start
+```
 
-To rotate a token without downtime:
-
-1. Create a new token with `coder tokens create`.
-2. Update the client's configuration to use the new token.
-3. Delete the old token from the dashboard or with `coder tokens rm <name>`.
-
-Deleting a token immediately revokes access.
-Deleting the user that owns a token revokes every token that user holds at the same time.
+Keep this setting consistent across replicas.
+When disabled, BYOK requests are rejected with a `403 Forbidden` response, and only centralized provider credentials are permitted.

--- a/docs/ai-coder/ai-gateway/auth.md
+++ b/docs/ai-coder/ai-gateway/auth.md
@@ -78,55 +78,65 @@ For full setup, refer to [AI Gateway Proxy setup](./ai-gateway-proxy/setup.md).
 
 AI Gateway keys are scoped to the Coder deployment.
 A [standalone AI Gateway](./standalone.md) uses one of these keys to connect to `coderd`.
-The built-in Owner role can create, list, and delete these keys.
-A site-level custom role can also manage them when it has the corresponding `ai_gateway_key` permissions.
+Only the built-in Owner role can create, list, and delete these keys.
+Coder custom roles are organization-scoped and cannot grant the site-level `ai_gateway_key` permissions.
 
 Create a key with a descriptive name:
 
-```console
+```sh
 coder ai-gateway keys create standalone-production
 ```
 
 The command displays the plaintext key once.
 Save it immediately in your secret manager because Coder cannot retrieve it later.
-Coder stores only a visible prefix and a SHA-256 hash of the secret.
+Coder never stores the secret itself, only a visible prefix for display and a SHA-256 hash used for authentication.
 
-Configure the standalone process with exactly 1 of the following options:
+Names must be unique, 64 characters or fewer, and use only lowercase letters, numbers, and non-consecutive hyphens.
+Gateway keys do not expire and cannot be scoped or restricted.
+
+Configure the standalone process with either of the following options, but not both:
 
 - `CODER_AI_GATEWAY_KEY` or `--key` supplies the key directly.
 - `CODER_AI_GATEWAY_KEY_FILE` or `--key-file` reads the key from a file.
 
 A user login and `CODER_SESSION_TOKEN` are not used by `coder ai-gateway start`.
-The same Gateway key can authenticate multiple replicas. Separate keys make it easier to rotate or revoke each deployment independently.
+The same Gateway key can authenticate multiple replicas.
+Separate keys make it easier to rotate or revoke each deployment independently.
 
-List keys and their most recent usage heartbeat:
+List keys and the most recent heartbeat for each:
 
-```console
+```sh
 coder ai-gateway keys list
 ```
 
-A replica records a heartbeat when it connects and updates the timestamp every 60 seconds while the session remains active.
+A replica records a heartbeat when its control connection is established, then refreshes it every 60 seconds while that connection is active.
+The heartbeat reports control-connection liveness rather than client request volume.
+Coder stores one timestamp per key, so replicas that share a key cannot be distinguished.
 
-For command options, refer to the generated CLI reference for [creating](../../reference/cli/ai-gateway_keys_create.md), [listing](../../reference/cli/ai-gateway_keys_list.md), and [deleting](../../reference/cli/ai-gateway_keys_delete.md) Gateway keys.
+For usage and flags, refer to the generated CLI reference for [creating](../../reference/cli/ai-gateway_keys_create.md), [listing](../../reference/cli/ai-gateway_keys_list.md), and [deleting](../../reference/cli/ai-gateway_keys_delete.md) Gateway keys.
 
 ### Rotate a Gateway key
 
-Rotate a key without interrupting traffic:
+Rotate a key with a rolling restart.
+Run more than 1 replica behind a load balancer so client traffic continues during the rollout:
 
 1. Create a new Gateway key.
-1. Update the Secret, environment variable, or key file used by every replica.
+1. Update the Kubernetes Secret, environment variable, or key file used by every replica.
 1. Restart or roll out the standalone deployment so every replica uses the new key.
 1. Verify readiness and confirm that the new key has a recent heartbeat.
 1. Delete the old key.
 
 Delete a key by name or ID:
 
-```console
+```sh
 coder ai-gateway keys delete standalone-production
 ```
 
+Add `--yes` to skip the confirmation prompt in automation.
+
 Deleting a key rejects new connections immediately.
-An existing session closes after a later heartbeat detects the deletion. Gateway may retry connecting with the same key, that attempt will be rejected.
+An established session closes when its next heartbeat detects the deletion, within 60 seconds.
+The replica then tries to reconnect, receives HTTP 401, and treats that as fatal: the process exits non-zero rather than retrying.
 Stop or update every replica before deleting its key for an orderly rotation.
 
 ## Authenticate to upstream providers

--- a/docs/ai-coder/ai-gateway/auth.md
+++ b/docs/ai-coder/ai-gateway/auth.md
@@ -89,9 +89,10 @@ coder ai-gateway keys create standalone-production
 
 The command displays the plaintext key once.
 Save it immediately in your secret manager because Coder cannot retrieve it later.
-Coder never stores the secret itself, only a visible prefix for display and a SHA-256 hash used for authentication.
+Coder stores only a short prefix of the key for display and a SHA-256 hash for authentication, never the full secret.
 
-Names must be unique, 64 characters or fewer, and use only lowercase letters, numbers, and non-consecutive hyphens.
+Names must be unique, 64 characters or fewer, and use only lowercase letters, numbers, and hyphens.
+A name cannot start or end with a hyphen or contain consecutive hyphens.
 Gateway keys do not expire and cannot be scoped or restricted.
 
 Configure the standalone process with either of the following options, but not both:

--- a/docs/ai-coder/ai-gateway/auth.md
+++ b/docs/ai-coder/ai-gateway/auth.md
@@ -197,5 +197,6 @@ For a standalone Gateway, set the option on each replica:
 CODER_AI_GATEWAY_ALLOW_BYOK=false coder ai-gateway start
 ```
 
-Keep this setting consistent across replicas.
+Each replica enforces its own local value, which governs only the traffic that replica handles.
+The standalone process does not receive the `coderd` value, so set the option on every replica that should reject BYOK requests.
 When disabled, BYOK requests are rejected with a `403 Forbidden` response, and only centralized provider credentials are permitted.


### PR DESCRIPTION
> AI helped with this PR

Expands the AI Gateway authentication guide to distinguish client tokens, standalone Gateway keys, upstream provider credentials, and BYOK credentials.
Documents Gateway key creation, configuration, heartbeats, and rotation, and adds standalone-specific BYOK configuration.