### PR TITLE
chore: add DanielleMaywood as CODEOWNER of AgentsPage

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,7 +28,6 @@ coderd/schedule/autostop.go @deansheather @DanielleMaywood
 coderd/usage/ @deansheather @spikecurtis
 enterprise/coderd/usage/ @deansheather @spikecurtis
 
-# Agents UI pages (agents list, chat, analytics, settings).
 site/src/pages/AgentsPage/ @DanielleMaywood
 
 .github/ 	@jdomeracki-coder

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,6 +28,9 @@ coderd/schedule/autostop.go @deansheather @DanielleMaywood
 coderd/usage/ @deansheather @spikecurtis
 enterprise/coderd/usage/ @deansheather @spikecurtis
 
+# Agents UI pages (agents list, chat, analytics, settings).
+site/src/pages/AgentsPage/ @DanielleMaywood
+
 .github/ 	@jdomeracki-coder
 
 # Shared contract between chatd and aibridge: AI provider configuration and


### PR DESCRIPTION
Adds @DanielleMaywood as a code owner of `site/src/pages/AgentsPage/` (agents list, chat, analytics, and settings pages).

<!-- Generated by Coder Agents on behalf of @DanielleMaywood -->