### PR TITLE
docs: link Windows quickstart install step to the Install guide

### DIFF
--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -180,6 +180,10 @@ is installed.
    winget install Coder.Coder
    ```
 
+   - For the Windows installer (`.msi`), standalone binary (`.exe`), or other
+     installation methods, refer to the
+     [installation guide](../install/index.md).
+
 1. Start Coder:
 
    ```sh


### PR DESCRIPTION
## What

The Quickstart's Windows install step (Step 2) showed only `winget`, which implied it was the only way to install Coder on Windows. This adds a pointer from that step to the [Install guide](https://coder.com/docs/install), which documents the `.msi` installer, the standalone `.exe` binary, and `winget`.

## Why

We received user feedback that the Get Started guide felt confusing and restrictive for Windows because it looked like `winget` was the only install option. The **Linux/macOS** tab in the same step already links out to alternate install methods; the **Windows** tab did not. This restores that symmetry.

## Scope (deliberately atomic)

This intentionally does **not** advertise every install method in the Quickstart. The Quickstart shows the single fastest path (`winget`) and links out to the Install guide for everything else. The change is one nested bullet, mirroring the existing Linux/macOS "alternate methods" pointer.

```diff
+   - For the Windows installer (`.msi`), standalone binary (`.exe`), or other
+     installation methods, refer to the
+     [installation guide](../install/index.md).
```

Linear: [DOCS-601](https://linear.app/codercom/issue/DOCS-601/get-started-link-windows-install-step-to-the-full-install-guide)

> This PR was created with AI assistance (Coder Agents).