### PR TITLE
docs: add clarification of install methods in Get Started guide

### DIFF
--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -199,6 +199,8 @@ viewing the page, locate the web UI URL in Coder logs in your terminal. It looks
 like `https://<CUSTOM-STRING>.<TUNNEL>.try.coder.app`. It's one of the first
 lines of output, so you might have to scroll up to find it.
 
+This section includes some of the quicker ways to install Coder. For more detailed options, visit the [Install](../install/index.md) page.
+
 ## Step 3: Initial setup
 
 1. Create your admin account:


### PR DESCRIPTION
I was confused by the difference between the Quickstart page and the Install page.

Fixes DOCS 602

<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->
