### PR TITLE
docs: clarify that Coder server should run on a separate machine

### DIFF
--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -37,6 +37,11 @@ explained through a cooking analogy:
 > [!TIP]
 > If you use a coding agent like Claude Code, the [coder/skills](https://github.com/coder/skills) `setup` skill can train the coding agent on the following steps (install a container runtime, install Coder, create your first template, and launch a workspace).
 
+> [!NOTE]
+> This guide installs the Coder server on the same machine you're working from so you can try Coder quickly.
+> That's fine for this walkthrough, but Coder's real value comes from remote development: hosting the Coder server on a separate machine (a cloud VM, a spare desktop, or on-prem hardware) lets you and your team provision workspaces on infrastructure that's more powerful, always-on, and reachable from anywhere, instead of tying your dev environment to your own laptop.
+> When you're ready to move past this quickstart, install the Coder server on a separate machine and connect to it remotely. Refer to [Installing Coder](../install/index.md) for supported platforms and installation methods.
+
 ## Step 1: Install a container runtime
 
 Coder needs a Docker-compatible container runtime running on the host, such as
@@ -145,6 +150,11 @@ Windows Subsystem for Linux (WSL2) or Hyper-V layer if it isn't already enabled.
 ## Step 2: Install and start Coder
 
 Install the `coder` CLI to get started:
+
+> [!NOTE]
+> For this quickstart, install and run the Coder server on the same machine you're using right now.
+> In a real deployment, install the Coder server on a separate machine (not your laptop) so its compute stays available and shareable independent of any one person's device.
+> Refer to [Installing Coder](../install/index.md) for details on installing on a separate host.
 
 <div class="tabs">
 

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -154,8 +154,8 @@ Install the `coder` CLI to get started:
 
 > [!NOTE]
 > For this quickstart, install and run the Coder server on the same machine you're using right now.
-> In a real deployment, install the Coder server on a separate machine (not your laptop) so its compute stays available and shareable independent of any one person's device.
-> Refer to [Installing Coder](../install/index.md) for details on installing on a separate host.
+> In a real deployment, install the Coder server on a separate machine (not your laptop) so its compute stays available and shareable, independent of any one person's device.
+> Refer to the [Install guide](../install/index.md) for details on installing on a separate host.
 
 <div class="tabs">
 

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -39,8 +39,9 @@ explained through a cooking analogy:
 
 > [!NOTE]
 > This guide installs the Coder server on the same machine you're working from so you can try Coder quickly.
-> That's fine for this walkthrough, but Coder's real value comes from remote development: hosting the Coder server on a separate machine (a cloud VM, a spare desktop, or on-prem hardware) lets you and your team provision workspaces on infrastructure that's more powerful, always-on, and reachable from anywhere, instead of tying your dev environment to your own laptop.
-> When you're ready to move past this quickstart, install the Coder server on a separate machine and connect to it remotely. Refer to [Installing Coder](../install/index.md) for supported platforms and installation methods.
+> That's fine for this tutorial, but Coder's real value comes from remote development.
+> By hosting the Coder server on a separate machine (a cloud VM, a spare desktop, or on-premise hardware), you and your team can provision workspaces on infrastructure that's more powerful, always-on, and reachable from anywhere, instead of tying your dev environment to your own laptop.
+> When you're ready to move past this tutorial, install the Coder server on a separate machine and connect to it remotely. Refer to the [Install guide](../install/index.md) for supported platforms and installation methods.
 
 ## Step 1: Install a container runtime
 

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -30,18 +30,23 @@ explained through a cooking analogy:
 
 ## Prerequisites
 
-- A machine with 2+ CPU cores and 4GB+ RAM
+- A machine with 2+ CPU cores and 4GB+ RAM (ideally a separate machine or VM, not your primary dev machine)
 - Familiarity with running commands in the terminal
 - 10 minutes of your time
 
+<details>
+<summary>Why a separate machine?</summary>
+
+Coder's value comes from remote development.
+Hosting the Coder server on a separate machine, such as a cloud VM, a spare desktop, or on-premises hardware, gives you and your team infrastructure that's more powerful, always-on, and reachable from anywhere, instead of tying your dev environment to your own laptop.
+
+When you're ready to move past this tutorial, install the Coder server on a separate machine and connect to it remotely.
+Refer to the [Install guide](../install/index.md) for supported platforms and installation methods.
+
+</details>
+
 > [!TIP]
 > If you use a coding agent like Claude Code, the [coder/skills](https://github.com/coder/skills) `setup` skill can train the coding agent on the following steps (install a container runtime, install Coder, create your first template, and launch a workspace).
-
-> [!NOTE]
-> This guide installs the Coder server on the same machine you're working from so you can try Coder quickly.
-> That's fine for this tutorial, but Coder's real value comes from remote development.
-> By hosting the Coder server on a separate machine (a cloud VM, a spare desktop, or on-premise hardware), you and your team can provision workspaces on infrastructure that's more powerful, always-on, and reachable from anywhere, instead of tying your dev environment to your own laptop.
-> When you're ready to move past this tutorial, install the Coder server on a separate machine and connect to it remotely. Refer to the [Install guide](../install/index.md) for supported platforms and installation methods.
 
 ## Step 1: Install a container runtime
 
@@ -151,11 +156,6 @@ Windows Subsystem for Linux (WSL2) or Hyper-V layer if it isn't already enabled.
 ## Step 2: Install and start Coder
 
 Install the `coder` CLI to get started:
-
-> [!NOTE]
-> For this quickstart, install and run the Coder server on the same machine you're using right now.
-> In a real deployment, install the Coder server on a separate machine (not your laptop) so its compute stays available and shareable, independent of any one person's device.
-> Refer to the [Install guide](../install/index.md) for details on installing on a separate host.
 
 <div class="tabs">
 


### PR DESCRIPTION
Closes [DOCS-600](https://linear.app/codercom/issue/DOCS-600/make-it-clear-in-the-quickstart-that-you-should-install-the-coder).

The Quickstart guide has readers install and run `coder server` on the same machine they're working from, without calling out that this is only for a quick trial. Coder's actual value comes from remote development, so hosting the Coder server on a separate machine has a lot more power than running it locally.

This adds two notes to `docs/get-started/index.md`:
- In **Prerequisites**, explaining that this quickstart runs the server locally for convenience, but a real deployment should host it on a separate machine, and linking to the [Install](https://coder.com/docs/install) page.
- In **Step 2: Install and start Coder**, a shorter reminder right before the install commands.

----

Created using Coder Agents 🤖