### PR TITLE
docs: document SCIM 2.0 handler opt-in and legacy flag

### DIFF
--- a/docs/admin/users/oidc-auth/index.md
+++ b/docs/admin/users/oidc-auth/index.md
@@ -163,35 +163,24 @@ CODER_SCIM_AUTH_HEADER="your-api-key"
 
 ### SCIM 2.0 handler
 
-Coder ships two SCIM implementations:
+Coder includes an opt-in SCIM 2.0 handler that follows
+[RFC 7644](https://datatracker.ietf.org/doc/html/rfc7644) and has been
+verified against an external SCIM 2.0 compliance suite. It supports:
 
-- **Legacy handler** (current default): the original implementation, scoped
-  to the provisioning flows used by Okta cloud. It mixes SCIM 1.0 and 2.0
-  behaviors, does not serve the SCIM discovery endpoints, and treats `PATCH`
-  requests as full-resource updates rather than
-  [RFC 7644](https://datatracker.ietf.org/doc/html/rfc7644) patch operations.
-- **SCIM 2.0 handler** (opt-in): a rewrite that follows RFC 7644 and has been
-  verified against an external SCIM 2.0 compliance suite. It adds:
+- User provisioning and deprovisioning
+- User listing
 
-  - Discovery endpoints: `/scim/v2/ServiceProviderConfig`,
-    `/scim/v2/Schemas`, and `/scim/v2/ResourceTypes`.
-  - `GET /scim/v2/Users` with pagination and basic `userName` filtering.
-  - `GET`, `PUT`, `PATCH`, and `DELETE` on `/scim/v2/Users/{id}`, where
-    `PATCH` accepts RFC 7644 patch operations.
-  - Spec-compliant error responses.
-
-To turn off the legacy behavior and opt into the SCIM 2.0 handler, set:
+To opt in, set:
 
 ```dotenv
 CODER_SCIM_USE_LEGACY=false
 ```
 
 This is also available as the `--scim-use-legacy` server flag and the
-`scimUseLegacy` YAML option. Because the setting selects which handler is
-mounted at server startup, changing it requires a restart of the Coder
+`scimUseLegacy` YAML option. Changing it requires a restart of the Coder
 server.
 
-Behavior notes for the SCIM 2.0 handler:
+Behavior notes:
 
 - Coder never hard-deletes users. `DELETE /scim/v2/Users/{id}` and
   deactivation (`active: false`) both [suspend](../index.md#suspend-a-user)
@@ -201,10 +190,7 @@ Behavior notes for the SCIM 2.0 handler:
 - Usernames are immutable. Attempts to change `userName` via `PUT` or `PATCH`
   return a `mutability` error.
 
-The legacy handler remains the default for backward compatibility while the
-new handler is validated in production. In a future release the default will
-flip to the SCIM 2.0 handler, and the legacy handler will eventually be
-removed.
+The SCIM 2.0 handler will eventually become the default behavior.
 
 ## TLS
 

--- a/docs/admin/users/oidc-auth/index.md
+++ b/docs/admin/users/oidc-auth/index.md
@@ -163,9 +163,8 @@ CODER_SCIM_AUTH_HEADER="your-api-key"
 
 ### SCIM 2.0 handler
 
-Coder includes an opt-in SCIM 2.0 handler that follows
-[RFC 7644](https://datatracker.ietf.org/doc/html/rfc7644) and has been
-verified against an external SCIM 2.0 compliance suite. It supports:
+Coder includes an opt-in SCIM 2.0 handler that follows [RFC 7644](https://datatracker.ietf.org/doc/html/rfc7644) and has been verified against an external SCIM 2.0 compliance suite.
+It supports the following:
 
 - User provisioning and deprovisioning
 - User listing

--- a/docs/admin/users/oidc-auth/index.md
+++ b/docs/admin/users/oidc-auth/index.md
@@ -180,13 +180,9 @@ Changing it requires a restart of the Coder server.
 
 Behavior notes:
 
-- Coder never hard-deletes users. `DELETE /scim/v2/Users/{id}` and
-  deactivation (`active: false`) both [suspend](../index.md#suspend-a-user)
-  the user.
-- Re-activating or re-creating a previously suspended user places them in the
-  dormant state, and they become active again on their next login.
-- Usernames are immutable. Attempts to change `userName` via `PUT` or `PATCH`
-  return a `mutability` error.
+- Coder never hard-deletes users. `DELETE /scim/v2/Users/{id}` and deactivation (`active: false`) both [suspend](../index.md#suspend-a-user) the user.
+- Re-activating or re-creating a previously suspended user places them in the dormant state, and they become active again on their next login.
+- Usernames are immutable. Attempts to change `userName` via `PUT` or `PATCH` return a `mutability` error.
 
 The SCIM 2.0 handler will eventually become the default behavior.
 

--- a/docs/admin/users/oidc-auth/index.md
+++ b/docs/admin/users/oidc-auth/index.md
@@ -175,9 +175,8 @@ To opt in, set:
 CODER_SCIM_USE_LEGACY=false
 ```
 
-This is also available as the `--scim-use-legacy` server flag and the
-`scimUseLegacy` YAML option. Changing it requires a restart of the Coder
-server.
+This is also available as the `--scim-use-legacy` server flag and the `scimUseLegacy` YAML option.
+Changing it requires a restart of the Coder server.
 
 Behavior notes:
 

--- a/docs/admin/users/oidc-auth/index.md
+++ b/docs/admin/users/oidc-auth/index.md
@@ -161,6 +161,51 @@ it the Coder server.
 CODER_SCIM_AUTH_HEADER="your-api-key"
 ```
 
+### SCIM 2.0 handler
+
+Coder ships two SCIM implementations:
+
+- **Legacy handler** (current default): the original implementation, scoped
+  to the provisioning flows used by Okta cloud. It mixes SCIM 1.0 and 2.0
+  behaviors, does not serve the SCIM discovery endpoints, and treats `PATCH`
+  requests as full-resource updates rather than
+  [RFC 7644](https://datatracker.ietf.org/doc/html/rfc7644) patch operations.
+- **SCIM 2.0 handler** (opt-in): a rewrite that follows RFC 7644 and has been
+  verified against an external SCIM 2.0 compliance suite. It adds:
+
+  - Discovery endpoints: `/scim/v2/ServiceProviderConfig`,
+    `/scim/v2/Schemas`, and `/scim/v2/ResourceTypes`.
+  - `GET /scim/v2/Users` with pagination and basic `userName` filtering.
+  - `GET`, `PUT`, `PATCH`, and `DELETE` on `/scim/v2/Users/{id}`, where
+    `PATCH` accepts RFC 7644 patch operations.
+  - Spec-compliant error responses.
+
+To turn off the legacy behavior and opt into the SCIM 2.0 handler, set:
+
+```dotenv
+CODER_SCIM_USE_LEGACY=false
+```
+
+This is also available as the `--scim-use-legacy` server flag and the
+`scimUseLegacy` YAML option. Because the setting selects which handler is
+mounted at server startup, changing it requires a restart of the Coder
+server.
+
+Behavior notes for the SCIM 2.0 handler:
+
+- Coder never hard-deletes users. `DELETE /scim/v2/Users/{id}` and
+  deactivation (`active: false`) both [suspend](../index.md#suspend-a-user)
+  the user.
+- Re-activating or re-creating a previously suspended user places them in the
+  dormant state, and they become active again on their next login.
+- Usernames are immutable. Attempts to change `userName` via `PUT` or `PATCH`
+  return a `mutability` error.
+
+The legacy handler remains the default for backward compatibility while the
+new handler is validated in production. In a future release the default will
+flip to the SCIM 2.0 handler, and the legacy handler will eventually be
+removed.
+
 ## TLS
 
 If your OpenID Connect provider requires client TLS certificates for


### PR DESCRIPTION
Documents the SCIM 2.0 handler introduced in #25572 and how to opt in.

Adds a "SCIM 2.0 handler" subsection to the SCIM section of `docs/admin/users/oidc-auth/index.md`:

- The handler follows RFC 7644 and supports user provisioning/deprovisioning and user listing.
- Opt in with `CODER_SCIM_USE_LEGACY=false` (also `--scim-use-legacy` / `scimUseLegacy`); requires a server restart.
- Behavior notes: delete/deactivate suspends (never hard-deletes), reactivation goes through dormant, usernames are immutable.
- Notes it will eventually become the default behavior.

Behavior details were verified against `enterprise/coderd/scimroutes.go`, `enterprise/coderd/scim/`, and the `SCIM Use Legacy` option in `codersdk/deployment.go`.

`make lint/markdown` and `make lint/emdash` pass.

---

Generated by Coder Agents on behalf of @Emyrk.