### PR TITLE
fix: tweak `Pill` styles

### DIFF
--- a/site/src/components/Pill/Pill.tsx
+++ b/site/src/components/Pill/Pill.tsx
@@ -39,7 +39,7 @@ const pillLayoutVariants = cva(
 		variants: {
 			size: {
 				md: "h-6",
-				lg: "",
+				lg: "h-[30px]",
 			},
 			withIcon: {
 				true: "",
@@ -60,12 +60,12 @@ const pillLayoutVariants = cva(
 			{
 				size: "lg",
 				withIcon: false,
-				class: "gap-2.5 py-3.5 px-4",
+				class: "gap-2.5 px-4",
 			},
 			{
 				size: "lg",
 				withIcon: true,
-				class: "gap-2.5 py-3.5 pr-4 pl-2.5",
+				class: "gap-2.5 pr-4 pl-2.5",
 			},
 		],
 		defaultVariants: {


### PR DESCRIPTION
noticed a regression in the large variant being waaaaaaay taller than it's supposed to be

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="321" height="310" alt="Screenshot 2026-07-23 at 5 13 50 PM" src="https://github.com/user-attachments/assets/62479d15-96c1-43b7-ab17-3bcc0a62d1f1" />
</td>
<td>
<img width="321" height="296" alt="Screenshot 2026-07-23 at 5 13 38 PM" src="https://github.com/user-attachments/assets/db7ca4ba-8c97-4353-a09f-62152c8649b0" />
</td>
</table>