### PR TITLE
ci: run test-go-pg mise tool install under bash on Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -573,6 +573,7 @@ jobs:
           install-args: "go terraform"
 
       - name: Install Go mise tools
+        shell: bash
         run: ./.github/scripts/retry.sh -- mise install --locked go:gotest.tools/gotestsum go:github.com/slsyy/mtimehash/cmd/mtimehash
 
       - name: Download Test Cache


### PR DESCRIPTION
## What

Add `shell: bash` to the `Install Go mise tools` step in the `test-go-pg` job so it runs under Git bash on the `windows-2022` matrix leg.

## Why

`test-go-pg (windows-2022)` has been failing in the **Normalize File and Directory Timestamps** step with:

```
mtimehash: command not found
##[error]Process completed with exit code 127.
```

before any tests run, which trips the aggregate `required` gate.

Root cause: the `Install Go mise tools` step had no `shell:`, so on Windows it ran under **PowerShell**, while `./.github/scripts/retry.sh` is a bash script (`#!/usr/bin/env bash`). The step silently no-oped on Windows (zero output), so `mtimehash` was only present when the mise tool cache was warm. On a cache miss it was never installed, and the normalize step failed with exit 127. `main` stays green only because the cache is usually warm — both green and failing runs use the same `depot-windows-2022-16` runner, so this is **not** a fork/runner-routing issue.

Pre-existing CI-tooling issue, unrelated to the change that surfaced it (a Helm-only community PR, #27360).

## Fix

One line: pin the step to `shell: bash` so the install actually runs on Windows and repairs a cache miss instead of being silently skipped.

## Verification

<details>
<summary>Local proof that the step's install target builds and <code>mtimehash</code> runs under bash</summary>

```
$ bash ./.github/scripts/retry.sh --max-attempts 1 -- echo "retry.sh OK under bash"
retry.sh OK under bash

$ GOBIN=/tmp/demobin go install github.com/slsyy/mtimehash/cmd/mtimehash@v1.0.0
$ ls -l /tmp/demobin/mtimehash
-rwxr-xr-x 1 coder coder 6692858 /tmp/demobin/mtimehash

# the tool that was "command not found" now runs and rewrites the mtime:
$ printf 'hello' > /tmp/mt.txt                 # mtime 2026-07-24 15:32
$ find /tmp/mt.txt | /tmp/demobin/mtimehash    # exit 0
$ # mtime now 1997-11-30 (content-hash derived)
```
</details>

Final confirmation is this PR's own `test-go-pg (windows-2022)` run. Note: if the mise cache is warm on this run the job passes regardless; the fix specifically hardens the cache-miss path this step exercises on Windows.

## Follow-up (not in this PR)

- Make the normalize step resilient (skip when `mtimehash` is absent / invoke via `mise exec`) so a missing cache optimizer can't hard-fail the job.
- Audit other Windows `run:` steps that invoke `retry.sh`/bash scripts without `shell: bash`.

Linear: DOCS-605

> This PR was created with AI assistance (Coder Agents).
