### PR TITLE
feat: add CSV export for AI spend data

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -4798,7 +4798,7 @@ const docTemplate = `{
                     "Enterprise"
                 ],
                 "summary": "Export organization AI spend as CSV",
-                "operationId": "export-organization-ai-spend",
+                "operationId": "export-organization-ai-spend-as-csv",
                 "parameters": [
                     {
                         "type": "string",

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -4754,7 +4754,7 @@ const docTemplate = `{
         },
         "/api/v2/organizations/{organization}/ai/spend/export": {
             "get": {
-                "description": "Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.\nThe optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days; when both are omitted the current UTC monthly period is used.",
+                "description": "Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.\nThe optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days; when both are omitted the current UTC monthly period is used.\nperiod_start must fall within the configured AI Gateway data retention window, since older token usage is purged and would produce incomplete results.",
                 "produces": [
                     "text/csv"
                 ],

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -580,6 +580,42 @@ const docTemplate = `{
                 ]
             }
         },
+        "/api/experimental/chats/{chat}/cost": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat cost",
+                "operationId": "get-chat-cost",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatCost"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
         "/api/experimental/chats/{chat}/diff": {
             "get": {
                 "description": "Experimental: this endpoint is subject to change.",
@@ -4754,7 +4790,7 @@ const docTemplate = `{
         },
         "/api/v2/organizations/{organization}/ai/spend/export": {
             "get": {
-                "description": "Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.\nThe optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days; when both are omitted the current UTC monthly period is used.\nperiod_start must fall within the configured AI Gateway data retention window, since older token usage is purged and would produce incomplete results.",
+                "description": "Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.\nThe optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days. When both are omitted, the current UTC monthly period is used.\nAn explicit period_start must fall within the configured AI Gateway data retention window, since older token usage is purged. The default period is narrowed to that window instead, and every row echoes the applied bounds.\nRequires organization-level administrator permissions.",
                 "produces": [
                     "text/csv"
                 ],
@@ -17348,6 +17384,24 @@ const docTemplate = `{
                 "name": {
                     "description": "Name is the tool name with the \"\u003cserver\u003e__\" prefix the agent adds\nstripped, so it reads as the server exposes it.",
                     "type": "string"
+                }
+            }
+        },
+        "codersdk.ChatCost": {
+            "type": "object",
+            "properties": {
+                "chat_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "priced_message_count": {
+                    "type": "integer"
+                },
+                "total_cost_micros": {
+                    "type": "integer"
+                },
+                "unpriced_messages_having_usage_count": {
+                    "type": "integer"
                 }
             }
         },

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -580,42 +580,6 @@ const docTemplate = `{
                 ]
             }
         },
-        "/api/experimental/chats/{chat}/cost": {
-            "get": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get chat cost",
-                "operationId": "get-chat-cost",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatCost"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
         "/api/experimental/chats/{chat}/diff": {
             "get": {
                 "description": "Experimental: this endpoint is subject to change.",
@@ -4790,7 +4754,7 @@ const docTemplate = `{
         },
         "/api/v2/organizations/{organization}/ai/spend/export": {
             "get": {
-                "description": "Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.\nThe optional start and end query parameters bound the period and are interpreted as UTC; both default to the current budget period when omitted.",
+                "description": "Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.\nThe optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days; when both are omitted the current UTC monthly period is used.",
                 "produces": [
                     "text/csv"
                 ],
@@ -4812,14 +4776,14 @@ const docTemplate = `{
                         "type": "string",
                         "format": "date-time",
                         "description": "Inclusive lower bound (RFC3339)",
-                        "name": "start",
+                        "name": "period_start",
                         "in": "query"
                     },
                     {
                         "type": "string",
                         "format": "date-time",
                         "description": "Exclusive upper bound (RFC3339)",
-                        "name": "end",
+                        "name": "period_end",
                         "in": "query"
                     }
                 ],
@@ -17384,24 +17348,6 @@ const docTemplate = `{
                 "name": {
                     "description": "Name is the tool name with the \"\u003cserver\u003e__\" prefix the agent adds\nstripped, so it reads as the server exposes it.",
                     "type": "string"
-                }
-            }
-        },
-        "codersdk.ChatCost": {
-            "type": "object",
-            "properties": {
-                "chat_id": {
-                    "type": "string",
-                    "format": "uuid"
-                },
-                "priced_message_count": {
-                    "type": "integer"
-                },
-                "total_cost_micros": {
-                    "type": "integer"
-                },
-                "unpriced_messages_having_usage_count": {
-                    "type": "integer"
                 }
             }
         },

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -4788,6 +4788,53 @@ const docTemplate = `{
                 ]
             }
         },
+        "/api/v2/organizations/{organization}/ai/spend/export": {
+            "get": {
+                "description": "Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.\nThe optional start and end query parameters bound the period and are interpreted as UTC; both default to the current budget period when omitted.",
+                "produces": [
+                    "text/csv"
+                ],
+                "tags": [
+                    "Enterprise"
+                ],
+                "summary": "Export organization AI spend as CSV",
+                "operationId": "export-organization-ai-spend",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Organization ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Inclusive lower bound (RFC3339)",
+                        "name": "start",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Exclusive upper bound (RFC3339)",
+                        "name": "end",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
         "/api/v2/organizations/{organization}/groups": {
             "get": {
                 "produces": [

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -4233,7 +4233,7 @@
 				"produces": ["text/csv"],
 				"tags": ["Enterprise"],
 				"summary": "Export organization AI spend as CSV",
-				"operationId": "export-organization-ai-spend",
+				"operationId": "export-organization-ai-spend-as-csv",
 				"parameters": [
 					{
 						"type": "string",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -4197,7 +4197,7 @@
 		},
 		"/api/v2/organizations/{organization}/ai/spend/export": {
 			"get": {
-				"description": "Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.\nThe optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days; when both are omitted the current UTC monthly period is used.",
+				"description": "Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.\nThe optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days; when both are omitted the current UTC monthly period is used.\nperiod_start must fall within the configured AI Gateway data retention window, since older token usage is purged and would produce incomplete results.",
 				"produces": ["text/csv"],
 				"tags": ["Enterprise"],
 				"summary": "Export organization AI spend as CSV",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -509,6 +509,38 @@
 				]
 			}
 		},
+		"/api/experimental/chats/{chat}/cost": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat cost",
+				"operationId": "get-chat-cost",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatCost"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
 		"/api/experimental/chats/{chat}/diff": {
 			"get": {
 				"description": "Experimental: this endpoint is subject to change.",
@@ -4197,7 +4229,7 @@
 		},
 		"/api/v2/organizations/{organization}/ai/spend/export": {
 			"get": {
-				"description": "Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.\nThe optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days; when both are omitted the current UTC monthly period is used.\nperiod_start must fall within the configured AI Gateway data retention window, since older token usage is purged and would produce incomplete results.",
+				"description": "Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.\nThe optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days. When both are omitted, the current UTC monthly period is used.\nAn explicit period_start must fall within the configured AI Gateway data retention window, since older token usage is purged. The default period is narrowed to that window instead, and every row echoes the applied bounds.\nRequires organization-level administrator permissions.",
 				"produces": ["text/csv"],
 				"tags": ["Enterprise"],
 				"summary": "Export organization AI spend as CSV",
@@ -15592,6 +15624,24 @@
 				"name": {
 					"description": "Name is the tool name with the \"\u003cserver\u003e__\" prefix the agent adds\nstripped, so it reads as the server exposes it.",
 					"type": "string"
+				}
+			}
+		},
+		"codersdk.ChatCost": {
+			"type": "object",
+			"properties": {
+				"chat_id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"priced_message_count": {
+					"type": "integer"
+				},
+				"total_cost_micros": {
+					"type": "integer"
+				},
+				"unpriced_messages_having_usage_count": {
+					"type": "integer"
 				}
 			}
 		},

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -509,38 +509,6 @@
 				]
 			}
 		},
-		"/api/experimental/chats/{chat}/cost": {
-			"get": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get chat cost",
-				"operationId": "get-chat-cost",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatCost"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
 		"/api/experimental/chats/{chat}/diff": {
 			"get": {
 				"description": "Experimental: this endpoint is subject to change.",
@@ -4229,7 +4197,7 @@
 		},
 		"/api/v2/organizations/{organization}/ai/spend/export": {
 			"get": {
-				"description": "Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.\nThe optional start and end query parameters bound the period and are interpreted as UTC; both default to the current budget period when omitted.",
+				"description": "Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.\nThe optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days; when both are omitted the current UTC monthly period is used.",
 				"produces": ["text/csv"],
 				"tags": ["Enterprise"],
 				"summary": "Export organization AI spend as CSV",
@@ -4247,14 +4215,14 @@
 						"type": "string",
 						"format": "date-time",
 						"description": "Inclusive lower bound (RFC3339)",
-						"name": "start",
+						"name": "period_start",
 						"in": "query"
 					},
 					{
 						"type": "string",
 						"format": "date-time",
 						"description": "Exclusive upper bound (RFC3339)",
-						"name": "end",
+						"name": "period_end",
 						"in": "query"
 					}
 				],
@@ -15624,24 +15592,6 @@
 				"name": {
 					"description": "Name is the tool name with the \"\u003cserver\u003e__\" prefix the agent adds\nstripped, so it reads as the server exposes it.",
 					"type": "string"
-				}
-			}
-		},
-		"codersdk.ChatCost": {
-			"type": "object",
-			"properties": {
-				"chat_id": {
-					"type": "string",
-					"format": "uuid"
-				},
-				"priced_message_count": {
-					"type": "integer"
-				},
-				"total_cost_micros": {
-					"type": "integer"
-				},
-				"unpriced_messages_having_usage_count": {
-					"type": "integer"
 				}
 			}
 		},

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -4227,6 +4227,49 @@
 				]
 			}
 		},
+		"/api/v2/organizations/{organization}/ai/spend/export": {
+			"get": {
+				"description": "Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.\nThe optional start and end query parameters bound the period and are interpreted as UTC; both default to the current budget period when omitted.",
+				"produces": ["text/csv"],
+				"tags": ["Enterprise"],
+				"summary": "Export organization AI spend as CSV",
+				"operationId": "export-organization-ai-spend",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Organization ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "date-time",
+						"description": "Inclusive lower bound (RFC3339)",
+						"name": "start",
+						"in": "query"
+					},
+					{
+						"type": "string",
+						"format": "date-time",
+						"description": "Exclusive upper bound (RFC3339)",
+						"name": "end",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
 		"/api/v2/organizations/{organization}/groups": {
 			"get": {
 				"produces": ["application/json"],

--- a/coderd/coderdtest/swaggerparser.go
+++ b/coderd/coderdtest/swaggerparser.go
@@ -426,6 +426,7 @@ func assertProduce(t *testing.T, comment SwaggerComment) {
 			(comment.router == "/api/v2/debug/tailnet" && comment.method == "get") ||
 			(comment.router == "/api/v2/workspaces/{workspace}/acl" && comment.method == "patch") ||
 			(comment.router == "/api/v2/init-script/{os}/{arch}" && comment.method == "get") ||
+			(comment.router == "/api/v2/organizations/{organization}/ai/spend/export" && comment.method == "get") ||
 			(comment.router == "/api/v2/templatebuilder/compose" && comment.method == "post") {
 			return // Exception: HTTP 200 is returned without response entity
 		}

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -2704,6 +2704,10 @@ func (q *querier) ExpirePrebuildsAPIKeys(ctx context.Context, now time.Time) err
 	return q.db.ExpirePrebuildsAPIKeys(ctx, now)
 }
 
+func (q *querier) ExportOrganizationAISpend(ctx context.Context, arg database.ExportOrganizationAISpendParams) ([]database.ExportOrganizationAISpendRow, error) {
+	return fetchWithPostFilter(q.auth, policy.ActionRead, q.db.ExportOrganizationAISpend)(ctx, arg)
+}
+
 func (q *querier) FavoriteWorkspace(ctx context.Context, id uuid.UUID) error {
 	fetch := func(ctx context.Context, id uuid.UUID) (database.Workspace, error) {
 		return q.db.GetWorkspaceByID(ctx, id)

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -6992,6 +6992,22 @@ func (s *MethodTestSuite) TestAIBridge() {
 			Returns([]database.GetGroupMembersAISpendRow{row1, row2})
 	}))
 
+	s.Run("ExportOrganizationAISpend", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		org := testutil.Fake(s.T(), faker, database.Organization{})
+		row1 := testutil.Fake(s.T(), faker, database.ExportOrganizationAISpendRow{OrganizationID: org.ID})
+		row2 := testutil.Fake(s.T(), faker, database.ExportOrganizationAISpendRow{OrganizationID: org.ID})
+		arg := database.ExportOrganizationAISpendParams{
+			OrganizationID: org.ID,
+			PeriodStart:    time.Now().UTC().Truncate(24 * time.Hour),
+			PeriodEnd:      time.Now().UTC(),
+		}
+		dbm.EXPECT().ExportOrganizationAISpend(gomock.Any(), arg).
+			Return([]database.ExportOrganizationAISpendRow{row1, row2}, nil).AnyTimes()
+		check.Args(arg).
+			Asserts(row1, policy.ActionRead, row2, policy.ActionRead).
+			Returns([]database.ExportOrganizationAISpendRow{row1, row2})
+	}))
+
 	s.Run("GetGroupAIBudget", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		g := testutil.Fake(s.T(), faker, database.Group{})
 		b := testutil.Fake(s.T(), faker, database.GroupAIBudget{GroupID: g.ID})

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -1009,6 +1009,14 @@ func (m queryMetricsStore) ExpirePrebuildsAPIKeys(ctx context.Context, now time.
 	return r0
 }
 
+func (m queryMetricsStore) ExportOrganizationAISpend(ctx context.Context, arg database.ExportOrganizationAISpendParams) ([]database.ExportOrganizationAISpendRow, error) {
+	start := time.Now()
+	r0, r1 := m.s.ExportOrganizationAISpend(ctx, arg)
+	m.queryLatencies.WithLabelValues("ExportOrganizationAISpend").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "ExportOrganizationAISpend").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) FavoriteWorkspace(ctx context.Context, id uuid.UUID) error {
 	start := time.Now()
 	r0 := m.s.FavoriteWorkspace(ctx, id)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -1724,6 +1724,21 @@ func (mr *MockStoreMockRecorder) ExpirePrebuildsAPIKeys(ctx, now any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExpirePrebuildsAPIKeys", reflect.TypeOf((*MockStore)(nil).ExpirePrebuildsAPIKeys), ctx, now)
 }
 
+// ExportOrganizationAISpend mocks base method.
+func (m *MockStore) ExportOrganizationAISpend(ctx context.Context, arg database.ExportOrganizationAISpendParams) ([]database.ExportOrganizationAISpendRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExportOrganizationAISpend", ctx, arg)
+	ret0, _ := ret[0].([]database.ExportOrganizationAISpendRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExportOrganizationAISpend indicates an expected call of ExportOrganizationAISpend.
+func (mr *MockStoreMockRecorder) ExportOrganizationAISpend(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportOrganizationAISpend", reflect.TypeOf((*MockStore)(nil).ExportOrganizationAISpend), ctx, arg)
+}
+
 // FavoriteWorkspace mocks base method.
 func (m *MockStore) FavoriteWorkspace(ctx context.Context, id uuid.UUID) error {
 	m.ctrl.T.Helper()

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -4698,6 +4698,8 @@ CREATE INDEX idx_aibridge_interceptions_thread_root_id ON aibridge_interceptions
 
 CREATE INDEX idx_aibridge_model_thoughts_interception_id ON aibridge_model_thoughts USING btree (interception_id);
 
+CREATE INDEX idx_aibridge_token_usages_effective_group_id_created_at ON aibridge_token_usages USING btree (effective_group_id, created_at) WHERE (effective_group_id IS NOT NULL);
+
 CREATE INDEX idx_aibridge_token_usages_interception_id ON aibridge_token_usages USING btree (interception_id);
 
 CREATE INDEX idx_aibridge_token_usages_provider_response_id ON aibridge_token_usages USING btree (provider_response_id);

--- a/coderd/database/migrations/000554_aibridge_token_usage_spend_export_index.down.sql
+++ b/coderd/database/migrations/000554_aibridge_token_usage_spend_export_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_aibridge_token_usages_effective_group_id_created_at;

--- a/coderd/database/migrations/000554_aibridge_token_usage_spend_export_index.up.sql
+++ b/coderd/database/migrations/000554_aibridge_token_usage_spend_export_index.up.sql
@@ -1,0 +1,5 @@
+-- Serves spend queries that filter token usage by effective group over a time
+-- range. Rows with no effective group are excluded.
+CREATE INDEX idx_aibridge_token_usages_effective_group_id_created_at
+    ON aibridge_token_usages (effective_group_id, created_at)
+    WHERE effective_group_id IS NOT NULL;

--- a/coderd/database/modelmethods.go
+++ b/coderd/database/modelmethods.go
@@ -474,6 +474,13 @@ func (r GetGroupMembersAISpendRow) RBACObject() rbac.Object {
 	return rbac.ResourceGroupMember.WithID(r.UserID).InOrg(r.OrganizationID).WithOwner(r.UserID.String())
 }
 
+// ExportOrganizationAISpendRow is authorized per row like group member spend:
+// admins with org-wide group member read see every row, while a regular member
+// only matches rows they own (WithOwner), so they see only their own spend.
+func (r ExportOrganizationAISpendRow) RBACObject() rbac.Object {
+	return rbac.ResourceGroupMember.WithID(r.UserID).InOrg(r.OrganizationID).WithOwner(r.UserID.String())
+}
+
 // PrebuiltWorkspaceResource defines the interface for types that can be identified as prebuilt workspaces
 // and converted to their corresponding prebuilt workspace RBAC object.
 type PrebuiltWorkspaceResource interface {

--- a/coderd/database/modelmethods.go
+++ b/coderd/database/modelmethods.go
@@ -474,9 +474,6 @@ func (r GetGroupMembersAISpendRow) RBACObject() rbac.Object {
 	return rbac.ResourceGroupMember.WithID(r.UserID).InOrg(r.OrganizationID).WithOwner(r.UserID.String())
 }
 
-// ExportOrganizationAISpendRow is authorized per row like group member spend:
-// admins with org-wide group member read see every row, while a regular member
-// only matches rows they own (WithOwner), so they see only their own spend.
 func (r ExportOrganizationAISpendRow) RBACObject() rbac.Object {
 	return rbac.ResourceGroupMember.WithID(r.UserID).InOrg(r.OrganizationID).WithOwner(r.UserID.String())
 }

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -265,6 +265,13 @@ type sqlcQuerier interface {
 	// Next, collect api_keys that belong to the prebuilds user but have no token name.
 	// These were most likely created via 'coder login' as the prebuilds user.
 	ExpirePrebuildsAPIKeys(ctx context.Context, now time.Time) error
+	// Returns per-user, per-group, per-model, per-provider aggregated AI spend for
+	// @organization_id over the [period_start, period_end) window, built from raw
+	// AI Gateway token usage rather than the daily spend rollup. Spend is
+	// attributed through the token usage's effective group, and rows are bucketed
+	// by the token usage created_at, matching how ai_user_daily_spend is derived.
+	// Only token usage with an effective group in the organization is included.
+	ExportOrganizationAISpend(ctx context.Context, arg ExportOrganizationAISpendParams) ([]ExportOrganizationAISpendRow, error)
 	FavoriteWorkspace(ctx context.Context, id uuid.UUID) error
 	FetchMemoryResourceMonitorsByAgentID(ctx context.Context, agentID uuid.UUID) (WorkspaceAgentMemoryResourceMonitor, error)
 	FetchMemoryResourceMonitorsUpdatedAfter(ctx context.Context, updatedAt time.Time) ([]WorkspaceAgentMemoryResourceMonitor, error)

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -266,11 +266,9 @@ type sqlcQuerier interface {
 	// These were most likely created via 'coder login' as the prebuilds user.
 	ExpirePrebuildsAPIKeys(ctx context.Context, now time.Time) error
 	// Returns per-user, per-group, per-model, per-provider aggregated AI spend for
-	// @organization_id over the [period_start, period_end) window, built from raw
-	// AI Gateway token usage rather than the daily spend rollup. Spend is
+	// @organization_id over the [period_start, period_end) window. Spend is
 	// attributed through the token usage's effective group, and rows are bucketed
 	// by the token usage created_at, matching how ai_user_daily_spend is derived.
-	// Only token usage with an effective group in the organization is included.
 	ExportOrganizationAISpend(ctx context.Context, arg ExportOrganizationAISpendParams) ([]ExportOrganizationAISpendRow, error)
 	FavoriteWorkspace(ctx context.Context, id uuid.UUID) error
 	FetchMemoryResourceMonitorsByAgentID(ctx context.Context, agentID uuid.UUID) (WorkspaceAgentMemoryResourceMonitor, error)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -2572,11 +2572,9 @@ type ExportOrganizationAISpendRow struct {
 }
 
 // Returns per-user, per-group, per-model, per-provider aggregated AI spend for
-// @organization_id over the [period_start, period_end) window, built from raw
-// AI Gateway token usage rather than the daily spend rollup. Spend is
+// @organization_id over the [period_start, period_end) window. Spend is
 // attributed through the token usage's effective group, and rows are bucketed
 // by the token usage created_at, matching how ai_user_daily_spend is derived.
-// Only token usage with an effective group in the organization is included.
 func (q *sqlQuerier) ExportOrganizationAISpend(ctx context.Context, arg ExportOrganizationAISpendParams) ([]ExportOrganizationAISpendRow, error) {
 	rows, err := q.db.QueryContext(ctx, exportOrganizationAISpend, arg.OrganizationID, arg.PeriodStart, arg.PeriodEnd)
 	if err != nil {

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -2528,8 +2528,11 @@ func (q *sqlQuerier) DeleteUserAIBudgetOverride(ctx context.Context, userID uuid
 const exportOrganizationAISpend = `-- name: ExportOrganizationAISpend :many
 SELECT
 	ai.initiator_id AS user_id,
+	users.username AS username,
 	tu.effective_group_id AS group_id,
+	groups.name AS group_name,
 	groups.organization_id AS organization_id,
+	organizations.name AS organization_name,
 	ai.model AS model,
 	ai.provider AS provider,
 	ai.provider_name AS provider_name,
@@ -2540,14 +2543,19 @@ SELECT
 	COALESCE(SUM(tu.cost_micros), 0)::BIGINT AS cost_micros
 FROM aibridge_token_usages tu
 JOIN aibridge_interceptions ai ON ai.id = tu.interception_id
+JOIN users ON users.id = ai.initiator_id
 JOIN groups ON groups.id = tu.effective_group_id
+JOIN organizations ON organizations.id = groups.organization_id
 WHERE groups.organization_id = $1
 	AND tu.created_at >= $2::timestamptz
 	AND tu.created_at < $3::timestamptz
 GROUP BY
 	ai.initiator_id,
+	users.username,
 	tu.effective_group_id,
+	groups.name,
 	groups.organization_id,
+	organizations.name,
 	ai.model,
 	ai.provider,
 	ai.provider_name
@@ -2562,8 +2570,11 @@ type ExportOrganizationAISpendParams struct {
 
 type ExportOrganizationAISpendRow struct {
 	UserID           uuid.UUID     `db:"user_id" json:"user_id"`
+	Username         string        `db:"username" json:"username"`
 	GroupID          uuid.NullUUID `db:"group_id" json:"group_id"`
+	GroupName        string        `db:"group_name" json:"group_name"`
 	OrganizationID   uuid.UUID     `db:"organization_id" json:"organization_id"`
+	OrganizationName string        `db:"organization_name" json:"organization_name"`
 	Model            string        `db:"model" json:"model"`
 	Provider         string        `db:"provider" json:"provider"`
 	ProviderName     string        `db:"provider_name" json:"provider_name"`
@@ -2589,8 +2600,11 @@ func (q *sqlQuerier) ExportOrganizationAISpend(ctx context.Context, arg ExportOr
 		var i ExportOrganizationAISpendRow
 		if err := rows.Scan(
 			&i.UserID,
+			&i.Username,
 			&i.GroupID,
+			&i.GroupName,
 			&i.OrganizationID,
+			&i.OrganizationName,
 			&i.Model,
 			&i.Provider,
 			&i.ProviderName,

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -2525,6 +2525,92 @@ func (q *sqlQuerier) DeleteUserAIBudgetOverride(ctx context.Context, userID uuid
 	return i, err
 }
 
+const exportOrganizationAISpend = `-- name: ExportOrganizationAISpend :many
+SELECT
+	ai.initiator_id AS user_id,
+	tu.effective_group_id AS group_id,
+	groups.organization_id AS organization_id,
+	ai.model AS model,
+	ai.provider AS provider,
+	COALESCE(SUM(tu.input_tokens), 0)::BIGINT AS input_tokens,
+	COALESCE(SUM(tu.output_tokens), 0)::BIGINT AS output_tokens,
+	COALESCE(SUM(tu.cache_read_input_tokens), 0)::BIGINT AS cache_read_tokens,
+	COALESCE(SUM(tu.cache_write_input_tokens), 0)::BIGINT AS cache_write_tokens,
+	COALESCE(SUM(tu.cost_micros), 0)::BIGINT AS cost_micros
+FROM aibridge_token_usages tu
+JOIN aibridge_interceptions ai ON ai.id = tu.interception_id
+JOIN groups ON groups.id = tu.effective_group_id
+WHERE groups.organization_id = $1
+	AND tu.created_at >= $2::timestamptz
+	AND tu.created_at < $3::timestamptz
+GROUP BY
+	ai.initiator_id,
+	tu.effective_group_id,
+	groups.organization_id,
+	ai.model,
+	ai.provider
+ORDER BY ai.initiator_id, tu.effective_group_id, ai.provider, ai.model
+`
+
+type ExportOrganizationAISpendParams struct {
+	OrganizationID uuid.UUID `db:"organization_id" json:"organization_id"`
+	PeriodStart    time.Time `db:"period_start" json:"period_start"`
+	PeriodEnd      time.Time `db:"period_end" json:"period_end"`
+}
+
+type ExportOrganizationAISpendRow struct {
+	UserID           uuid.UUID     `db:"user_id" json:"user_id"`
+	GroupID          uuid.NullUUID `db:"group_id" json:"group_id"`
+	OrganizationID   uuid.UUID     `db:"organization_id" json:"organization_id"`
+	Model            string        `db:"model" json:"model"`
+	Provider         string        `db:"provider" json:"provider"`
+	InputTokens      int64         `db:"input_tokens" json:"input_tokens"`
+	OutputTokens     int64         `db:"output_tokens" json:"output_tokens"`
+	CacheReadTokens  int64         `db:"cache_read_tokens" json:"cache_read_tokens"`
+	CacheWriteTokens int64         `db:"cache_write_tokens" json:"cache_write_tokens"`
+	CostMicros       int64         `db:"cost_micros" json:"cost_micros"`
+}
+
+// Returns per-user, per-group, per-model, per-provider aggregated AI spend for
+// @organization_id over the [period_start, period_end) window, built from raw
+// AI Gateway token usage rather than the daily spend rollup. Spend is
+// attributed through the token usage's effective group, and rows are bucketed
+// by the token usage created_at, matching how ai_user_daily_spend is derived.
+// Only token usage with an effective group in the organization is included.
+func (q *sqlQuerier) ExportOrganizationAISpend(ctx context.Context, arg ExportOrganizationAISpendParams) ([]ExportOrganizationAISpendRow, error) {
+	rows, err := q.db.QueryContext(ctx, exportOrganizationAISpend, arg.OrganizationID, arg.PeriodStart, arg.PeriodEnd)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ExportOrganizationAISpendRow
+	for rows.Next() {
+		var i ExportOrganizationAISpendRow
+		if err := rows.Scan(
+			&i.UserID,
+			&i.GroupID,
+			&i.OrganizationID,
+			&i.Model,
+			&i.Provider,
+			&i.InputTokens,
+			&i.OutputTokens,
+			&i.CacheReadTokens,
+			&i.CacheWriteTokens,
+			&i.CostMicros,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getAIModelPriceByProviderModel = `-- name: GetAIModelPriceByProviderModel :one
 SELECT provider, model, input_price, output_price, cache_read_price, cache_write_price, created_at, updated_at
 FROM ai_model_prices

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -2532,6 +2532,7 @@ SELECT
 	groups.organization_id AS organization_id,
 	ai.model AS model,
 	ai.provider AS provider,
+	ai.provider_name AS provider_name,
 	COALESCE(SUM(tu.input_tokens), 0)::BIGINT AS input_tokens,
 	COALESCE(SUM(tu.output_tokens), 0)::BIGINT AS output_tokens,
 	COALESCE(SUM(tu.cache_read_input_tokens), 0)::BIGINT AS cache_read_tokens,
@@ -2548,8 +2549,9 @@ GROUP BY
 	tu.effective_group_id,
 	groups.organization_id,
 	ai.model,
-	ai.provider
-ORDER BY ai.initiator_id, tu.effective_group_id, ai.provider, ai.model
+	ai.provider,
+	ai.provider_name
+ORDER BY ai.initiator_id, tu.effective_group_id, ai.provider, ai.provider_name, ai.model
 `
 
 type ExportOrganizationAISpendParams struct {
@@ -2564,6 +2566,7 @@ type ExportOrganizationAISpendRow struct {
 	OrganizationID   uuid.UUID     `db:"organization_id" json:"organization_id"`
 	Model            string        `db:"model" json:"model"`
 	Provider         string        `db:"provider" json:"provider"`
+	ProviderName     string        `db:"provider_name" json:"provider_name"`
 	InputTokens      int64         `db:"input_tokens" json:"input_tokens"`
 	OutputTokens     int64         `db:"output_tokens" json:"output_tokens"`
 	CacheReadTokens  int64         `db:"cache_read_tokens" json:"cache_read_tokens"`
@@ -2590,6 +2593,7 @@ func (q *sqlQuerier) ExportOrganizationAISpend(ctx context.Context, arg ExportOr
 			&i.OrganizationID,
 			&i.Model,
 			&i.Provider,
+			&i.ProviderName,
 			&i.InputTokens,
 			&i.OutputTokens,
 			&i.CacheReadTokens,

--- a/coderd/database/queries/aicostcontrol.sql
+++ b/coderd/database/queries/aicostcontrol.sql
@@ -317,6 +317,7 @@ SELECT
 	groups.organization_id AS organization_id,
 	ai.model AS model,
 	ai.provider AS provider,
+	ai.provider_name AS provider_name,
 	COALESCE(SUM(tu.input_tokens), 0)::BIGINT AS input_tokens,
 	COALESCE(SUM(tu.output_tokens), 0)::BIGINT AS output_tokens,
 	COALESCE(SUM(tu.cache_read_input_tokens), 0)::BIGINT AS cache_read_tokens,
@@ -333,5 +334,6 @@ GROUP BY
 	tu.effective_group_id,
 	groups.organization_id,
 	ai.model,
-	ai.provider
-ORDER BY ai.initiator_id, tu.effective_group_id, ai.provider, ai.model;
+	ai.provider,
+	ai.provider_name
+ORDER BY ai.initiator_id, tu.effective_group_id, ai.provider, ai.provider_name, ai.model;

--- a/coderd/database/queries/aicostcontrol.sql
+++ b/coderd/database/queries/aicostcontrol.sql
@@ -313,8 +313,11 @@ ORDER BY effective_group_id;
 -- by the token usage created_at, matching how ai_user_daily_spend is derived.
 SELECT
 	ai.initiator_id AS user_id,
+	users.username AS username,
 	tu.effective_group_id AS group_id,
+	groups.name AS group_name,
 	groups.organization_id AS organization_id,
+	organizations.name AS organization_name,
 	ai.model AS model,
 	ai.provider AS provider,
 	ai.provider_name AS provider_name,
@@ -325,14 +328,19 @@ SELECT
 	COALESCE(SUM(tu.cost_micros), 0)::BIGINT AS cost_micros
 FROM aibridge_token_usages tu
 JOIN aibridge_interceptions ai ON ai.id = tu.interception_id
+JOIN users ON users.id = ai.initiator_id
 JOIN groups ON groups.id = tu.effective_group_id
+JOIN organizations ON organizations.id = groups.organization_id
 WHERE groups.organization_id = @organization_id
 	AND tu.created_at >= @period_start::timestamptz
 	AND tu.created_at < @period_end::timestamptz
 GROUP BY
 	ai.initiator_id,
+	users.username,
 	tu.effective_group_id,
+	groups.name,
 	groups.organization_id,
+	organizations.name,
 	ai.model,
 	ai.provider,
 	ai.provider_name

--- a/coderd/database/queries/aicostcontrol.sql
+++ b/coderd/database/queries/aicostcontrol.sql
@@ -308,11 +308,9 @@ ORDER BY effective_group_id;
 
 -- name: ExportOrganizationAISpend :many
 -- Returns per-user, per-group, per-model, per-provider aggregated AI spend for
--- @organization_id over the [period_start, period_end) window, built from raw
--- AI Gateway token usage rather than the daily spend rollup. Spend is
+-- @organization_id over the [period_start, period_end) window. Spend is
 -- attributed through the token usage's effective group, and rows are bucketed
 -- by the token usage created_at, matching how ai_user_daily_spend is derived.
--- Only token usage with an effective group in the organization is included.
 SELECT
 	ai.initiator_id AS user_id,
 	tu.effective_group_id AS group_id,

--- a/coderd/database/queries/aicostcontrol.sql
+++ b/coderd/database/queries/aicostcontrol.sql
@@ -305,3 +305,35 @@ FROM user_spend
 WHERE current_spend_micros >= spend_limit_micros
 GROUP BY effective_group_id
 ORDER BY effective_group_id;
+
+-- name: ExportOrganizationAISpend :many
+-- Returns per-user, per-group, per-model, per-provider aggregated AI spend for
+-- @organization_id over the [period_start, period_end) window, built from raw
+-- AI Gateway token usage rather than the daily spend rollup. Spend is
+-- attributed through the token usage's effective group, and rows are bucketed
+-- by the token usage created_at, matching how ai_user_daily_spend is derived.
+-- Only token usage with an effective group in the organization is included.
+SELECT
+	ai.initiator_id AS user_id,
+	tu.effective_group_id AS group_id,
+	groups.organization_id AS organization_id,
+	ai.model AS model,
+	ai.provider AS provider,
+	COALESCE(SUM(tu.input_tokens), 0)::BIGINT AS input_tokens,
+	COALESCE(SUM(tu.output_tokens), 0)::BIGINT AS output_tokens,
+	COALESCE(SUM(tu.cache_read_input_tokens), 0)::BIGINT AS cache_read_tokens,
+	COALESCE(SUM(tu.cache_write_input_tokens), 0)::BIGINT AS cache_write_tokens,
+	COALESCE(SUM(tu.cost_micros), 0)::BIGINT AS cost_micros
+FROM aibridge_token_usages tu
+JOIN aibridge_interceptions ai ON ai.id = tu.interception_id
+JOIN groups ON groups.id = tu.effective_group_id
+WHERE groups.organization_id = @organization_id
+	AND tu.created_at >= @period_start::timestamptz
+	AND tu.created_at < @period_end::timestamptz
+GROUP BY
+	ai.initiator_id,
+	tu.effective_group_id,
+	groups.organization_id,
+	ai.model,
+	ai.provider
+ORDER BY ai.initiator_id, tu.effective_group_id, ai.provider, ai.model;

--- a/codersdk/aibridge.go
+++ b/codersdk/aibridge.go
@@ -369,20 +369,12 @@ func (c *Client) AIBridgeListClients(ctx context.Context) ([]string, error) {
 	return clients, json.NewDecoder(res.Body).Decode(&clients)
 }
 
-// AISpendExportOptions bounds the period exported by ExportOrganizationAISpend.
-// Both bounds are optional and interpreted as UTC; zero values fall back to the
-// current budget period on the server.
-type AISpendExportOptions struct {
-	// PeriodStart is the inclusive lower bound of the export window.
-	PeriodStart time.Time
-	// PeriodEnd is the exclusive upper bound of the export window.
-	PeriodEnd time.Time
-}
-
 // ExportOrganizationAISpend returns a CSV of per-user, per-group, per-model,
-// per-provider AI spend for the organization over the requested period. The
-// caller is responsible for closing the returned ReadCloser.
-func (c *Client) ExportOrganizationAISpend(ctx context.Context, organization uuid.UUID, opts AISpendExportOptions) (io.ReadCloser, error) {
+// per-provider AI spend for the organization over the requested period. Both
+// bounds are optional and interpreted as UTC, and zero values fall back to the
+// current budget period on the server. The caller is responsible for closing
+// the returned ReadCloser.
+func (c *Client) ExportOrganizationAISpend(ctx context.Context, organization uuid.UUID, opts AISpendPeriodWindow) (io.ReadCloser, error) {
 	res, err := c.Request(ctx, http.MethodGet,
 		fmt.Sprintf("/api/v2/organizations/%s/ai/spend/export", organization.String()),
 		nil,

--- a/codersdk/aibridge.go
+++ b/codersdk/aibridge.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -366,6 +367,44 @@ func (c *Client) AIBridgeListClients(ctx context.Context) ([]string, error) {
 	}
 	var clients []string
 	return clients, json.NewDecoder(res.Body).Decode(&clients)
+}
+
+// AISpendExportOptions bounds the period exported by ExportOrganizationAISpend.
+// Both bounds are optional and interpreted as UTC; zero values fall back to the
+// current budget period on the server.
+type AISpendExportOptions struct {
+	// Start is the inclusive lower bound of the export window.
+	Start time.Time
+	// End is the exclusive upper bound of the export window.
+	End time.Time
+}
+
+// ExportOrganizationAISpend returns a CSV of per-user, per-group, per-model,
+// per-provider AI spend for the organization over the requested period. The
+// caller is responsible for closing the returned ReadCloser.
+func (c *Client) ExportOrganizationAISpend(ctx context.Context, organization uuid.UUID, opts AISpendExportOptions) (io.ReadCloser, error) {
+	res, err := c.Request(ctx, http.MethodGet,
+		fmt.Sprintf("/api/v2/organizations/%s/ai/spend/export", organization.String()),
+		nil,
+		func(r *http.Request) {
+			q := r.URL.Query()
+			if !opts.Start.IsZero() {
+				q.Set("start", opts.Start.UTC().Format(time.RFC3339Nano))
+			}
+			if !opts.End.IsZero() {
+				q.Set("end", opts.End.UTC().Format(time.RFC3339Nano))
+			}
+			r.URL.RawQuery = q.Encode()
+		},
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("make request: %w", err)
+	}
+	if res.StatusCode != http.StatusOK {
+		defer res.Body.Close()
+		return nil, ReadBodyAsError(res)
+	}
+	return res.Body, nil
 }
 
 type GroupAIBudget struct {

--- a/codersdk/aibridge.go
+++ b/codersdk/aibridge.go
@@ -373,10 +373,10 @@ func (c *Client) AIBridgeListClients(ctx context.Context) ([]string, error) {
 // Both bounds are optional and interpreted as UTC; zero values fall back to the
 // current budget period on the server.
 type AISpendExportOptions struct {
-	// Start is the inclusive lower bound of the export window.
-	Start time.Time
-	// End is the exclusive upper bound of the export window.
-	End time.Time
+	// PeriodStart is the inclusive lower bound of the export window.
+	PeriodStart time.Time
+	// PeriodEnd is the exclusive upper bound of the export window.
+	PeriodEnd time.Time
 }
 
 // ExportOrganizationAISpend returns a CSV of per-user, per-group, per-model,
@@ -388,11 +388,11 @@ func (c *Client) ExportOrganizationAISpend(ctx context.Context, organization uui
 		nil,
 		func(r *http.Request) {
 			q := r.URL.Query()
-			if !opts.Start.IsZero() {
-				q.Set("start", opts.Start.UTC().Format(time.RFC3339Nano))
+			if !opts.PeriodStart.IsZero() {
+				q.Set("period_start", opts.PeriodStart.UTC().Format(time.RFC3339Nano))
 			}
-			if !opts.End.IsZero() {
-				q.Set("end", opts.End.UTC().Format(time.RFC3339Nano))
+			if !opts.PeriodEnd.IsZero() {
+				q.Set("period_end", opts.PeriodEnd.UTC().Format(time.RFC3339Nano))
 			}
 			r.URL.RawQuery = q.Encode()
 		},

--- a/docs/reference/api/enterprise.md
+++ b/docs/reference/api/enterprise.md
@@ -1728,8 +1728,9 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/ai/spen
 `GET /api/v2/organizations/{organization}/ai/spend/export`
 
 Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.
-The optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days; when both are omitted the current UTC monthly period is used.
-period_start must fall within the configured AI Gateway data retention window, since older token usage is purged and would produce incomplete results.
+The optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days. When both are omitted, the current UTC monthly period is used.
+An explicit period_start must fall within the configured AI Gateway data retention window, since older token usage is purged. The default period is narrowed to that window instead, and every row echoes the applied bounds.
+Requires organization-level administrator permissions.
 
 ### Parameters
 

--- a/docs/reference/api/enterprise.md
+++ b/docs/reference/api/enterprise.md
@@ -1728,15 +1728,15 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/ai/spen
 `GET /api/v2/organizations/{organization}/ai/spend/export`
 
 Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.
-The optional start and end query parameters bound the period and are interpreted as UTC; both default to the current budget period when omitted.
+The optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days; when both are omitted the current UTC monthly period is used.
 
 ### Parameters
 
 | Name           | In    | Type              | Required | Description                     |
 |----------------|-------|-------------------|----------|---------------------------------|
 | `organization` | path  | string(uuid)      | true     | Organization ID                 |
-| `start`        | query | string(date-time) | false    | Inclusive lower bound (RFC3339) |
-| `end`          | query | string(date-time) | false    | Exclusive upper bound (RFC3339) |
+| `period_start` | query | string(date-time) | false    | Inclusive lower bound (RFC3339) |
+| `period_end`   | query | string(date-time) | false    | Exclusive upper bound (RFC3339) |
 
 ### Responses
 

--- a/docs/reference/api/enterprise.md
+++ b/docs/reference/api/enterprise.md
@@ -1729,6 +1729,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/ai/spen
 
 Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.
 The optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days; when both are omitted the current UTC monthly period is used.
+period_start must fall within the configured AI Gateway data retention window, since older token usage is purged and would produce incomplete results.
 
 ### Parameters
 

--- a/docs/reference/api/enterprise.md
+++ b/docs/reference/api/enterprise.md
@@ -1715,6 +1715,37 @@ curl -X DELETE http://coder-server:8080/api/v2/oauth2-provider/apps/{app}/secret
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## Export organization AI spend as CSV
+
+### Code samples
+
+```sh
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/ai/spend/export \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/v2/organizations/{organization}/ai/spend/export`
+
+Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.
+The optional start and end query parameters bound the period and are interpreted as UTC; both default to the current budget period when omitted.
+
+### Parameters
+
+| Name           | In    | Type              | Required | Description                     |
+|----------------|-------|-------------------|----------|---------------------------------|
+| `organization` | path  | string(uuid)      | true     | Organization ID                 |
+| `start`        | query | string(date-time) | false    | Inclusive lower bound (RFC3339) |
+| `end`          | query | string(date-time) | false    | Exclusive upper bound (RFC3339) |
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema |
+|--------|---------------------------------------------------------|-------------|--------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## Get groups by organization
 
 ### Code samples

--- a/enterprise/coderd/aibridge.go
+++ b/enterprise/coderd/aibridge.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -25,6 +26,8 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
+	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/coderd/searchquery"
 	"github.com/coder/coder/v2/codersdk"
 )
@@ -915,8 +918,8 @@ func (api *API) userAISpendStatus(rw http.ResponseWriter, r *http.Request) {
 		slog.F("period_end", periodWindow.End),
 	)
 
-	policy := codersdk.NewAIBudgetPolicyFromString(api.DeploymentValues.AI.BridgeConfig.BudgetPolicy)
-	effectiveGroup, ok, err := budget.ResolveUserEffectiveGroup(ctx, api.Database, user.ID, policy)
+	budgetPolicy := codersdk.NewAIBudgetPolicyFromString(api.DeploymentValues.AI.BridgeConfig.BudgetPolicy)
+	effectiveGroup, ok, err := budget.ResolveUserEffectiveGroup(ctx, api.Database, user.ID, budgetPolicy)
 	if err != nil {
 		logger.Error(ctx, "failed to resolve user AI budget", slog.Error(err))
 		httpapi.InternalServerError(rw, err)
@@ -1031,25 +1034,52 @@ func (api *API) organizationGroupsAISpend(rw http.ResponseWriter, r *http.Reques
 	httpapi.Write(ctx, rw, http.StatusOK, resp)
 }
 
-// aiSpendExportCSVHeader is the CSV column order for the AI spend export.
-var aiSpendExportCSVHeader = []string{
-	"user", "group", "organization", "model", "provider", "provider_name",
+// AISpendExportCSVHeader is the CSV column order for the AI spend export.
+var AISpendExportCSVHeader = []string{
+	"user_id", "username", "group_id", "group_name", "organization_id", "organization_name",
+	"model", "provider", "provider_name",
 	"input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",
 	"cost_micros", "period_start", "period_end",
 }
 
+// csvFormulaPrefixes are the leading characters a spreadsheet treats as the
+// start of a formula rather than text.
+const csvFormulaPrefixes = "=+-@\t\r"
+
+// escapeCSVCell prefixes a leading formula character with a single quote, which
+// spreadsheets strip on display, so the value renders as its original text
+// instead of being evaluated.
+func escapeCSVCell(value string) string {
+	if value == "" || !strings.ContainsRune(csvFormulaPrefixes, rune(value[0])) {
+		return value
+	}
+	return "'" + value
+}
+
 // aiSpendExportPeriod resolves the export window from the request. When neither
 // start nor end is supplied it defaults to the current UTC monthly budget
-// period. Both bounds must be supplied together and are interpreted as UTC, and
-// an explicit window must be non-empty and span at most 31 days. On invalid
-// input it writes the error response and returns ok=false.
+// period, narrowed to the retention window. Both bounds must be supplied
+// together and are interpreted as UTC, and an explicit window must be non-empty,
+// span at most 31 days, and begin within the retention window. On invalid input
+// it writes the error response and returns ok=false.
 func (api *API) aiSpendExportPeriod(ctx context.Context, rw http.ResponseWriter, r *http.Request) (start, end time.Time, ok bool) {
 	query := r.URL.Query()
 	hasStart := query.Has("period_start")
 	hasEnd := query.Has("period_end")
 
+	// retentionStart is the oldest token usage still available, since anything
+	// older has been purged. A retention of zero disables purging.
+	retention := api.DeploymentValues.AI.BridgeConfig.Retention.Value()
+	hasRetention := retention > 0
+	var retentionStart time.Time
+	if hasRetention {
+		retentionStart = api.Clock.Now().Add(-retention)
+	}
+
 	switch {
 	case !hasStart && !hasEnd:
+		// No period was requested, so start at the budget period or the
+		// retention window, whichever is later.
 		window, err := api.currentAIBudgetWindow()
 		if err != nil {
 			api.Logger.Error(ctx, "failed to compute AI budget period", slog.Error(err))
@@ -1057,12 +1087,16 @@ func (api *API) aiSpendExportPeriod(ctx context.Context, rw http.ResponseWriter,
 			return time.Time{}, time.Time{}, false
 		}
 		start, end = window.Start, window.End
+		if hasRetention && start.Before(retentionStart) {
+			start = retentionStart
+		}
 	case hasStart != hasEnd:
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Query parameters \"period_start\" and \"period_end\" must be provided together.",
 		})
 		return time.Time{}, time.Time{}, false
 	default:
+		// The caller asked for this period, so validate it.
 		parser := httpapi.NewQueryParamParser()
 		start = parser.Time3339Nano(query, time.Time{}, "period_start")
 		end = parser.Time3339Nano(query, time.Time{}, "period_end")
@@ -1086,15 +1120,8 @@ func (api *API) aiSpendExportPeriod(ctx context.Context, rw http.ResponseWriter,
 			})
 			return time.Time{}, time.Time{}, false
 		}
-	}
-
-	// The export is built from raw AI Gateway token usage, which is purged once
-	// it is older than the configured retention duration. A period that begins
-	// before the retention window would return missing or partial rows, so
-	// reject it rather than silently exporting incomplete data.
-	if retention := api.DeploymentValues.AI.BridgeConfig.Retention.Value(); retention > 0 {
-		cutoff := api.Clock.Now().Add(-retention)
-		if start.Before(cutoff) {
+		// Fail if the period starts before the oldest retained data
+		if hasRetention && start.Before(retentionStart) {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 				Message: fmt.Sprintf("Query parameter \"period_start\" is older than the configured AI Gateway data retention window (%s).", retention),
 			})
@@ -1107,8 +1134,9 @@ func (api *API) aiSpendExportPeriod(ctx context.Context, rw http.ResponseWriter,
 
 // @Summary Export organization AI spend as CSV
 // @Description Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.
-// @Description The optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days; when both are omitted the current UTC monthly period is used.
-// @Description period_start must fall within the configured AI Gateway data retention window, since older token usage is purged and would produce incomplete results.
+// @Description The optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days. When both are omitted, the current UTC monthly period is used.
+// @Description An explicit period_start must fall within the configured AI Gateway data retention window, since older token usage is purged. The default period is narrowed to that window instead, and every row echoes the applied bounds.
+// @Description Requires organization-level administrator permissions.
 // @ID export-organization-ai-spend-as-csv
 // @Security CoderSessionToken
 // @Produce text/csv
@@ -1122,6 +1150,13 @@ func (api *API) exportOrganizationAISpend(rw http.ResponseWriter, r *http.Reques
 	ctx := r.Context()
 	org := httpmw.OrganizationParam(r)
 	logger := api.Logger.With(slog.F("organization_id", org.ID))
+
+	// The export aggregates the whole organization, so require organization-wide
+	// read rather than letting the per-row filter narrow it to the caller.
+	if !api.Authorize(r, policy.ActionRead, rbac.ResourceGroupMember.InOrg(org.ID)) {
+		httpapi.Forbidden(rw)
+		return
+	}
 
 	periodStart, periodEnd, ok := api.aiSpendExportPeriod(ctx, rw, r)
 	if !ok {
@@ -1148,7 +1183,7 @@ func (api *API) exportOrganizationAISpend(rw http.ResponseWriter, r *http.Reques
 
 	var buf bytes.Buffer
 	cw := csv.NewWriter(&buf)
-	if err := cw.Write(aiSpendExportCSVHeader); err != nil {
+	if err := cw.Write(AISpendExportCSVHeader); err != nil {
 		logger.Error(ctx, "failed to write AI spend export header", slog.Error(err))
 		httpapi.InternalServerError(rw, err)
 		return
@@ -1156,11 +1191,14 @@ func (api *API) exportOrganizationAISpend(rw http.ResponseWriter, r *http.Reques
 	for _, row := range rows {
 		if err := cw.Write([]string{
 			row.UserID.String(),
+			escapeCSVCell(row.Username),
 			row.GroupID.UUID.String(),
+			escapeCSVCell(row.GroupName),
 			row.OrganizationID.String(),
-			row.Model,
-			row.Provider,
-			row.ProviderName,
+			escapeCSVCell(row.OrganizationName),
+			escapeCSVCell(row.Model),
+			escapeCSVCell(row.Provider),
+			escapeCSVCell(row.ProviderName),
 			strconv.FormatInt(row.InputTokens, 10),
 			strconv.FormatInt(row.OutputTokens, 10),
 			strconv.FormatInt(row.CacheReadTokens, 10),
@@ -1181,8 +1219,12 @@ func (api *API) exportOrganizationAISpend(rw http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	rw.Header().Set("Content-Type", "text/csv")
-	rw.Header().Set("Content-Disposition", "attachment; filename=\"ai-spend-export.csv\"")
+	// Name the file after the organization and period so separate exports stay
+	// distinguishable once downloaded.
+	filename := fmt.Sprintf("ai-spend-export-%s-%s-to-%s.csv",
+		org.Name, periodStart.UTC().Format(time.DateOnly), periodEnd.UTC().Format(time.DateOnly))
+	rw.Header().Set("Content-Type", "text/csv; charset=utf-8")
+	rw.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
 	rw.Header().Set("Content-Length", strconv.Itoa(buf.Len()))
 	rw.WriteHeader(http.StatusOK)
 	if _, err := rw.Write(buf.Bytes()); err != nil {

--- a/enterprise/coderd/aibridge.go
+++ b/enterprise/coderd/aibridge.go
@@ -1033,7 +1033,7 @@ func (api *API) organizationGroupsAISpend(rw http.ResponseWriter, r *http.Reques
 
 // aiSpendExportCSVHeader is the CSV column order for the AI spend export.
 var aiSpendExportCSVHeader = []string{
-	"user", "group", "organization", "model", "provider",
+	"user", "group", "organization", "model", "provider", "provider_name",
 	"input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",
 	"cost_micros", "period_start", "period_end",
 }
@@ -1160,6 +1160,7 @@ func (api *API) exportOrganizationAISpend(rw http.ResponseWriter, r *http.Reques
 			row.OrganizationID.String(),
 			row.Model,
 			row.Provider,
+			row.ProviderName,
 			strconv.FormatInt(row.InputTokens, 10),
 			strconv.FormatInt(row.OutputTokens, 10),
 			strconv.FormatInt(row.CacheReadTokens, 10),

--- a/enterprise/coderd/aibridge.go
+++ b/enterprise/coderd/aibridge.go
@@ -1040,9 +1040,9 @@ var aiSpendExportCSVHeader = []string{
 
 // aiSpendExportPeriod resolves the export window from the request. When neither
 // start nor end is supplied it defaults to the current UTC monthly budget
-// period. Both bounds must be supplied together and are interpreted as UTC; an
-// explicit window must be non-empty and span at most 31 days. On invalid input
-// it writes the error response and returns ok=false.
+// period. Both bounds must be supplied together and are interpreted as UTC, and
+// an explicit window must be non-empty and span at most 31 days. On invalid
+// input it writes the error response and returns ok=false.
 func (api *API) aiSpendExportPeriod(ctx context.Context, rw http.ResponseWriter, r *http.Request) (start, end time.Time, ok bool) {
 	query := r.URL.Query()
 	hasStart := query.Has("period_start")
@@ -1096,7 +1096,7 @@ func (api *API) aiSpendExportPeriod(ctx context.Context, rw http.ResponseWriter,
 		cutoff := api.Clock.Now().Add(-retention)
 		if start.Before(cutoff) {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-				Message: "Query parameter \"period_start\" is older than the configured AI Gateway data retention window.",
+				Message: fmt.Sprintf("Query parameter \"period_start\" is older than the configured AI Gateway data retention window (%s).", retention),
 			})
 			return time.Time{}, time.Time{}, false
 		}
@@ -1146,9 +1146,6 @@ func (api *API) exportOrganizationAISpend(rw http.ResponseWriter, r *http.Reques
 	start := periodStart.UTC().Format(time.RFC3339)
 	end := periodEnd.UTC().Format(time.RFC3339)
 
-	// Build the full CSV in memory so the response is sent once with a
-	// Content-Length, and so a write error surfaces as a 500 before any
-	// status is written. The row count is bounded by the 31-day period cap.
 	var buf bytes.Buffer
 	cw := csv.NewWriter(&buf)
 	if err := cw.Write(aiSpendExportCSVHeader); err != nil {

--- a/enterprise/coderd/aibridge.go
+++ b/enterprise/coderd/aibridge.go
@@ -1048,52 +1048,67 @@ func (api *API) aiSpendExportPeriod(ctx context.Context, rw http.ResponseWriter,
 	hasStart := query.Has("period_start")
 	hasEnd := query.Has("period_end")
 
-	if !hasStart && !hasEnd {
+	switch {
+	case !hasStart && !hasEnd:
 		window, err := api.currentAIBudgetWindow()
 		if err != nil {
 			api.Logger.Error(ctx, "failed to compute AI budget period", slog.Error(err))
 			httpapi.InternalServerError(rw, err)
 			return time.Time{}, time.Time{}, false
 		}
-		return window.Start, window.End, true
-	}
-
-	if hasStart != hasEnd {
+		start, end = window.Start, window.End
+	case hasStart != hasEnd:
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Query parameters \"period_start\" and \"period_end\" must be provided together.",
 		})
 		return time.Time{}, time.Time{}, false
+	default:
+		parser := httpapi.NewQueryParamParser()
+		start = parser.Time3339Nano(query, time.Time{}, "period_start")
+		end = parser.Time3339Nano(query, time.Time{}, "period_end")
+		parser.ErrorExcessParams(query)
+		if len(parser.Errors) > 0 {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message:     "Query parameters have invalid values.",
+				Validations: parser.Errors,
+			})
+			return time.Time{}, time.Time{}, false
+		}
+		if !start.Before(end) {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "Query parameter \"period_start\" must be before \"period_end\".",
+			})
+			return time.Time{}, time.Time{}, false
+		}
+		if end.Sub(start) > maxAISpendExportPeriod {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "Query period must not exceed 31 days.",
+			})
+			return time.Time{}, time.Time{}, false
+		}
 	}
 
-	parser := httpapi.NewQueryParamParser()
-	start = parser.Time3339Nano(query, time.Time{}, "period_start")
-	end = parser.Time3339Nano(query, time.Time{}, "period_end")
-	parser.ErrorExcessParams(query)
-	if len(parser.Errors) > 0 {
-		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message:     "Query parameters have invalid values.",
-			Validations: parser.Errors,
-		})
-		return time.Time{}, time.Time{}, false
+	// The export is built from raw AI Gateway token usage, which is purged once
+	// it is older than the configured retention duration. A period that begins
+	// before the retention window would return missing or partial rows, so
+	// reject it rather than silently exporting incomplete data.
+	if retention := api.DeploymentValues.AI.BridgeConfig.Retention.Value(); retention > 0 {
+		cutoff := api.Clock.Now().Add(-retention)
+		if start.Before(cutoff) {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "Query parameter \"period_start\" is older than the configured AI Gateway data retention window.",
+			})
+			return time.Time{}, time.Time{}, false
+		}
 	}
-	if !start.Before(end) {
-		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: "Query parameter \"period_start\" must be before \"period_end\".",
-		})
-		return time.Time{}, time.Time{}, false
-	}
-	if end.Sub(start) > maxAISpendExportPeriod {
-		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: "Query period must not exceed 31 days.",
-		})
-		return time.Time{}, time.Time{}, false
-	}
+
 	return start, end, true
 }
 
 // @Summary Export organization AI spend as CSV
 // @Description Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.
 // @Description The optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days; when both are omitted the current UTC monthly period is used.
+// @Description period_start must fall within the configured AI Gateway data retention window, since older token usage is purged and would produce incomplete results.
 // @ID export-organization-ai-spend-as-csv
 // @Security CoderSessionToken
 // @Produce text/csv

--- a/enterprise/coderd/aibridge.go
+++ b/enterprise/coderd/aibridge.go
@@ -1094,7 +1094,7 @@ func (api *API) aiSpendExportPeriod(ctx context.Context, rw http.ResponseWriter,
 // @Summary Export organization AI spend as CSV
 // @Description Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.
 // @Description The optional start and end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days; when both are omitted the current UTC monthly period is used.
-// @ID export-organization-ai-spend
+// @ID export-organization-ai-spend-as-csv
 // @Security CoderSessionToken
 // @Produce text/csv
 // @Tags Enterprise

--- a/enterprise/coderd/aibridge.go
+++ b/enterprise/coderd/aibridge.go
@@ -1045,8 +1045,8 @@ var aiSpendExportCSVHeader = []string{
 // it writes the error response and returns ok=false.
 func (api *API) aiSpendExportPeriod(ctx context.Context, rw http.ResponseWriter, r *http.Request) (start, end time.Time, ok bool) {
 	query := r.URL.Query()
-	hasStart := query.Has("start")
-	hasEnd := query.Has("end")
+	hasStart := query.Has("period_start")
+	hasEnd := query.Has("period_end")
 
 	if !hasStart && !hasEnd {
 		window, err := api.currentAIBudgetWindow()
@@ -1060,14 +1060,14 @@ func (api *API) aiSpendExportPeriod(ctx context.Context, rw http.ResponseWriter,
 
 	if hasStart != hasEnd {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: "Query parameters \"start\" and \"end\" must be provided together.",
+			Message: "Query parameters \"period_start\" and \"period_end\" must be provided together.",
 		})
 		return time.Time{}, time.Time{}, false
 	}
 
 	parser := httpapi.NewQueryParamParser()
-	start = parser.Time3339Nano(query, time.Time{}, "start")
-	end = parser.Time3339Nano(query, time.Time{}, "end")
+	start = parser.Time3339Nano(query, time.Time{}, "period_start")
+	end = parser.Time3339Nano(query, time.Time{}, "period_end")
 	parser.ErrorExcessParams(query)
 	if len(parser.Errors) > 0 {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
@@ -1078,7 +1078,7 @@ func (api *API) aiSpendExportPeriod(ctx context.Context, rw http.ResponseWriter,
 	}
 	if !start.Before(end) {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: "Query parameter \"start\" must be before \"end\".",
+			Message: "Query parameter \"period_start\" must be before \"period_end\".",
 		})
 		return time.Time{}, time.Time{}, false
 	}
@@ -1093,14 +1093,14 @@ func (api *API) aiSpendExportPeriod(ctx context.Context, rw http.ResponseWriter,
 
 // @Summary Export organization AI spend as CSV
 // @Description Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.
-// @Description The optional start and end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days; when both are omitted the current UTC monthly period is used.
+// @Description The optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days; when both are omitted the current UTC monthly period is used.
 // @ID export-organization-ai-spend-as-csv
 // @Security CoderSessionToken
 // @Produce text/csv
 // @Tags Enterprise
 // @Param organization path string true "Organization ID" format(uuid)
-// @Param start query string false "Inclusive lower bound (RFC3339)" format(date-time)
-// @Param end query string false "Exclusive upper bound (RFC3339)" format(date-time)
+// @Param period_start query string false "Inclusive lower bound (RFC3339)" format(date-time)
+// @Param period_end query string false "Exclusive upper bound (RFC3339)" format(date-time)
 // @Success 200
 // @Router /api/v2/organizations/{organization}/ai/spend/export [get]
 func (api *API) exportOrganizationAISpend(rw http.ResponseWriter, r *http.Request) {

--- a/enterprise/coderd/aibridge.go
+++ b/enterprise/coderd/aibridge.go
@@ -1,8 +1,10 @@
 package coderd
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
+	"encoding/csv"
 	"errors"
 	"fmt"
 	"net/http"
@@ -39,6 +41,9 @@ const (
 	aiBridgeRateLimitWindow              = time.Second
 	maxOrganizationGroupsAISpendGroupIDs = 100
 	maxGroupMembersAISpendUserIDs        = 100
+	// maxAISpendExportPeriod bounds an explicit AI spend export window to at
+	// most 31 days, matching the maximum length of the monthly default period.
+	maxAISpendExportPeriod = 31 * 24 * time.Hour
 )
 
 // errInvalidCursor is returned when a pagination cursor does not
@@ -1024,6 +1029,152 @@ func (api *API) organizationGroupsAISpend(rw http.ResponseWriter, r *http.Reques
 	}
 
 	httpapi.Write(ctx, rw, http.StatusOK, resp)
+}
+
+// aiSpendExportCSVHeader is the CSV column order for the AI spend export.
+var aiSpendExportCSVHeader = []string{
+	"user", "group", "organization", "model", "provider",
+	"input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",
+	"cost_micros", "period_start", "period_end",
+}
+
+// aiSpendExportPeriod resolves the export window from the request. When neither
+// start nor end is supplied it defaults to the current UTC monthly budget
+// period. Both bounds must be supplied together and are interpreted as UTC; an
+// explicit window must be non-empty and span at most 31 days. On invalid input
+// it writes the error response and returns ok=false.
+func (api *API) aiSpendExportPeriod(ctx context.Context, rw http.ResponseWriter, r *http.Request) (start, end time.Time, ok bool) {
+	query := r.URL.Query()
+	hasStart := query.Has("start")
+	hasEnd := query.Has("end")
+
+	if !hasStart && !hasEnd {
+		window, err := api.currentAIBudgetWindow()
+		if err != nil {
+			api.Logger.Error(ctx, "failed to compute AI budget period", slog.Error(err))
+			httpapi.InternalServerError(rw, err)
+			return time.Time{}, time.Time{}, false
+		}
+		return window.Start, window.End, true
+	}
+
+	if hasStart != hasEnd {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Query parameters \"start\" and \"end\" must be provided together.",
+		})
+		return time.Time{}, time.Time{}, false
+	}
+
+	parser := httpapi.NewQueryParamParser()
+	start = parser.Time3339Nano(query, time.Time{}, "start")
+	end = parser.Time3339Nano(query, time.Time{}, "end")
+	parser.ErrorExcessParams(query)
+	if len(parser.Errors) > 0 {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message:     "Query parameters have invalid values.",
+			Validations: parser.Errors,
+		})
+		return time.Time{}, time.Time{}, false
+	}
+	if !start.Before(end) {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Query parameter \"start\" must be before \"end\".",
+		})
+		return time.Time{}, time.Time{}, false
+	}
+	if end.Sub(start) > maxAISpendExportPeriod {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Query period must not exceed 31 days.",
+		})
+		return time.Time{}, time.Time{}, false
+	}
+	return start, end, true
+}
+
+// @Summary Export organization AI spend as CSV
+// @Description Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.
+// @Description The optional start and end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days; when both are omitted the current UTC monthly period is used.
+// @ID export-organization-ai-spend
+// @Security CoderSessionToken
+// @Produce text/csv
+// @Tags Enterprise
+// @Param organization path string true "Organization ID" format(uuid)
+// @Param start query string false "Inclusive lower bound (RFC3339)" format(date-time)
+// @Param end query string false "Exclusive upper bound (RFC3339)" format(date-time)
+// @Success 200
+// @Router /api/v2/organizations/{organization}/ai/spend/export [get]
+func (api *API) exportOrganizationAISpend(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	org := httpmw.OrganizationParam(r)
+	logger := api.Logger.With(slog.F("organization_id", org.ID))
+
+	periodStart, periodEnd, ok := api.aiSpendExportPeriod(ctx, rw, r)
+	if !ok {
+		return
+	}
+	logger = logger.With(
+		slog.F("period_start", periodStart),
+		slog.F("period_end", periodEnd),
+	)
+
+	rows, err := api.Database.ExportOrganizationAISpend(ctx, database.ExportOrganizationAISpendParams{
+		OrganizationID: org.ID,
+		PeriodStart:    periodStart,
+		PeriodEnd:      periodEnd,
+	})
+	if err != nil {
+		logger.Error(ctx, "failed to export organization AI spend", slog.Error(err))
+		httpapi.InternalServerError(rw, err)
+		return
+	}
+
+	start := periodStart.UTC().Format(time.RFC3339)
+	end := periodEnd.UTC().Format(time.RFC3339)
+
+	// Build the full CSV in memory so the response is sent once with a
+	// Content-Length, and so a write error surfaces as a 500 before any
+	// status is written. The row count is bounded by the 31-day period cap.
+	var buf bytes.Buffer
+	cw := csv.NewWriter(&buf)
+	if err := cw.Write(aiSpendExportCSVHeader); err != nil {
+		logger.Error(ctx, "failed to write AI spend export header", slog.Error(err))
+		httpapi.InternalServerError(rw, err)
+		return
+	}
+	for _, row := range rows {
+		if err := cw.Write([]string{
+			row.UserID.String(),
+			row.GroupID.UUID.String(),
+			row.OrganizationID.String(),
+			row.Model,
+			row.Provider,
+			strconv.FormatInt(row.InputTokens, 10),
+			strconv.FormatInt(row.OutputTokens, 10),
+			strconv.FormatInt(row.CacheReadTokens, 10),
+			strconv.FormatInt(row.CacheWriteTokens, 10),
+			strconv.FormatInt(row.CostMicros, 10),
+			start,
+			end,
+		}); err != nil {
+			logger.Error(ctx, "failed to write AI spend export row", slog.Error(err))
+			httpapi.InternalServerError(rw, err)
+			return
+		}
+	}
+	cw.Flush()
+	if err := cw.Error(); err != nil {
+		logger.Error(ctx, "failed to build AI spend export", slog.Error(err))
+		httpapi.InternalServerError(rw, err)
+		return
+	}
+
+	rw.Header().Set("Content-Type", "text/csv")
+	rw.Header().Set("Content-Disposition", "attachment; filename=\"ai-spend-export.csv\"")
+	rw.Header().Set("Content-Length", strconv.Itoa(buf.Len()))
+	rw.WriteHeader(http.StatusOK)
+	if _, err := rw.Write(buf.Bytes()); err != nil {
+		logger.Error(ctx, "failed to write AI spend export", slog.Error(err))
+	}
 }
 
 // @Summary Get group members AI spend by organization

--- a/enterprise/coderd/aibridge_test.go
+++ b/enterprise/coderd/aibridge_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 	entaudit "github.com/coder/coder/v2/enterprise/audit"
 	"github.com/coder/coder/v2/enterprise/audit/backends"
+	entcoderd "github.com/coder/coder/v2/enterprise/coderd"
 	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
 	"github.com/coder/coder/v2/enterprise/coderd/license"
 	"github.com/coder/coder/v2/testutil"
@@ -3750,13 +3751,13 @@ func TestExportOrganizationAISpend(t *testing.T) {
 			{
 				name:            "RequiresLicenseFeature",
 				experiments:     []string{string(codersdk.ExperimentAIGatewayCostControl)},
-				features:        license.Features{codersdk.FeatureTemplateRBAC: 1},
+				features:        license.Features{},
 				wantMsgContains: "AI Gateway is a Premium feature",
 			},
 			{
 				name:            "RequiresExperiment",
 				experiments:     nil,
-				features:        license.Features{codersdk.FeatureTemplateRBAC: 1, codersdk.FeatureAIBridge: 1},
+				features:        license.Features{codersdk.FeatureAIBridge: 1},
 				wantMsgContains: "ai-gateway-cost-control",
 			},
 		}
@@ -3775,7 +3776,7 @@ func TestExportOrganizationAISpend(t *testing.T) {
 				})
 				ctx := testutil.Context(t, testutil.WaitLong)
 
-				//nolint:gocritic // Owner role is irrelevant; the request is blocked before RBAC.
+				//nolint:gocritic // Owner role is irrelevant because the request is blocked before RBAC.
 				_, err := client.ExportOrganizationAISpend(ctx, owner.OrganizationID, codersdk.AISpendPeriodWindow{})
 				var sdkErr *codersdk.Error
 				require.ErrorAs(t, err, &sdkErr)
@@ -3788,8 +3789,11 @@ func TestExportOrganizationAISpend(t *testing.T) {
 	t.Run("PeriodValidation", func(t *testing.T) {
 		t.Parallel()
 
+		// Use fixed dates to keep the test deterministic.
+		now := time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC)
 		clock := quartz.NewMock(t)
-		clock.Set(time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC))
+		clock.Set(now)
+
 		adminClient, _, group := setupAICostControlTest(t, aiCostControlTestOptions{
 			GroupName: "export-period-validation-group",
 			Clock:     clock,
@@ -3798,35 +3802,43 @@ func TestExportOrganizationAISpend(t *testing.T) {
 		// Older than the default 60d retention window relative to the clock.
 		beforeRetention := time.Date(2025, time.December, 1, 0, 0, 0, 0, time.UTC)
 
+		// wantMsgContains pins the branch each case exercises, since every
+		// rejection returns 400 and would otherwise be indistinguishable.
 		cases := []struct {
-			name       string
-			params     map[string]string
-			wantStatus int
+			name            string
+			params          map[string]string
+			wantStatus      int
+			wantMsgContains string
 		}{
 			{
-				name:       "OnlyStart",
-				params:     map[string]string{"period_start": start.Format(time.RFC3339Nano)},
-				wantStatus: http.StatusBadRequest,
+				name:            "OnlyStart",
+				params:          map[string]string{"period_start": start.Format(time.RFC3339Nano)},
+				wantStatus:      http.StatusBadRequest,
+				wantMsgContains: "must be provided together",
 			},
 			{
-				name:       "OnlyEnd",
-				params:     map[string]string{"period_end": start.Format(time.RFC3339Nano)},
-				wantStatus: http.StatusBadRequest,
+				name:            "OnlyEnd",
+				params:          map[string]string{"period_end": start.Format(time.RFC3339Nano)},
+				wantStatus:      http.StatusBadRequest,
+				wantMsgContains: "must be provided together",
 			},
 			{
-				name:       "StartEqualsEnd",
-				params:     map[string]string{"period_start": start.Format(time.RFC3339Nano), "period_end": start.Format(time.RFC3339Nano)},
-				wantStatus: http.StatusBadRequest,
+				name:            "StartEqualsEnd",
+				params:          map[string]string{"period_start": start.Format(time.RFC3339Nano), "period_end": start.Format(time.RFC3339Nano)},
+				wantStatus:      http.StatusBadRequest,
+				wantMsgContains: `"period_start" must be before "period_end"`,
 			},
 			{
-				name:       "InvalidFormat",
-				params:     map[string]string{"period_start": "not-a-date", "period_end": start.AddDate(0, 0, 1).Format(time.RFC3339Nano)},
-				wantStatus: http.StatusBadRequest,
+				name:            "InvalidFormat",
+				params:          map[string]string{"period_start": "not-a-date", "period_end": start.AddDate(0, 0, 1).Format(time.RFC3339Nano)},
+				wantStatus:      http.StatusBadRequest,
+				wantMsgContains: "have invalid values",
 			},
 			{
-				name:       "PeriodTooLong",
-				params:     map[string]string{"period_start": start.Format(time.RFC3339Nano), "period_end": start.AddDate(0, 0, 32).Format(time.RFC3339Nano)},
-				wantStatus: http.StatusBadRequest,
+				name:            "PeriodTooLong",
+				params:          map[string]string{"period_start": start.Format(time.RFC3339Nano), "period_end": start.AddDate(0, 0, 32).Format(time.RFC3339Nano)},
+				wantStatus:      http.StatusBadRequest,
+				wantMsgContains: "must not exceed 31 days",
 			},
 			{
 				name:       "MaxPeriodAllowed",
@@ -3836,9 +3848,10 @@ func TestExportOrganizationAISpend(t *testing.T) {
 			{
 				// period_start predates the retention window, so the raw
 				// token usage would be purged and results incomplete.
-				name:       "BeforeRetentionWindow",
-				params:     map[string]string{"period_start": beforeRetention.Format(time.RFC3339Nano), "period_end": beforeRetention.AddDate(0, 0, 1).Format(time.RFC3339Nano)},
-				wantStatus: http.StatusBadRequest,
+				name:            "BeforeRetentionWindow",
+				params:          map[string]string{"period_start": beforeRetention.Format(time.RFC3339Nano), "period_end": beforeRetention.AddDate(0, 0, 1).Format(time.RFC3339Nano)},
+				wantStatus:      http.StatusBadRequest,
+				wantMsgContains: "retention window",
 			},
 		}
 		for _, tc := range cases {
@@ -3847,8 +3860,14 @@ func TestExportOrganizationAISpend(t *testing.T) {
 				ctx := testutil.Context(t, testutil.WaitLong)
 
 				res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, tc.params)
-				_ = res.Body.Close()
+				defer res.Body.Close()
 				require.Equal(t, tc.wantStatus, res.StatusCode)
+				if tc.wantMsgContains == "" {
+					return
+				}
+				var sdkErr *codersdk.Error
+				require.ErrorAs(t, codersdk.ReadBodyAsError(res), &sdkErr)
+				require.Contains(t, sdkErr.Message, tc.wantMsgContains)
 			})
 		}
 	})
@@ -3856,7 +3875,11 @@ func TestExportOrganizationAISpend(t *testing.T) {
 	t.Run("DefaultsToCurrentMonthAndAggregates", func(t *testing.T) {
 		t.Parallel()
 
+		// Use fixed dates to keep the test deterministic.
+		now := time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC)
 		clock := quartz.NewMock(t)
+		clock.Set(now)
+
 		db, ps := dbtestutil.NewDB(t)
 		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
 			GroupName: "export-default-group",
@@ -3865,7 +3888,6 @@ func TestExportOrganizationAISpend(t *testing.T) {
 			Pubsub:    ps,
 		})
 		ctx := testutil.Context(t, testutil.WaitLong)
-		clock.Set(time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC))
 		inMonth := time.Date(2026, time.March, 10, 8, 0, 0, 0, time.UTC)
 		groupID := uuid.NullUUID{UUID: group.ID, Valid: true}
 
@@ -3883,171 +3905,93 @@ func TestExportOrganizationAISpend(t *testing.T) {
 			dbgen.AIBridgeTokenUsage(t, db, tu)
 		}
 
+		// Now: 15 March 2026 12:00 UTC.
 		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, nil)
 		defer res.Body.Close()
 		require.Equal(t, http.StatusOK, res.StatusCode)
-		require.Equal(t, "text/csv", res.Header.Get("Content-Type"))
-		require.Contains(t, res.Header.Get("Content-Disposition"), "ai-spend-export.csv")
 
 		records := readAISpendExportResponse(t, res)
-		require.Equal(t, aiSpendExportCSVHeaderForTest, records[0])
+		require.Equal(t, entcoderd.AISpendExportCSVHeader, records[0])
 		require.Len(t, records, 2) // header + single aggregated row
 
 		// The default window echoes the current UTC month.
 		require.Equal(t, []string{
-			targetUser.ID.String(), group.ID.String(), group.OrganizationID.String(),
+			targetUser.ID.String(), targetUser.Username,
+			group.ID.String(), group.Name,
+			group.OrganizationID.String(), group.OrganizationName,
 			"claude-4", "anthropic", "anthropic-prod", "300", "150", "30", "15", "3000",
 			"2026-03-01T00:00:00Z", "2026-04-01T00:00:00Z",
 		}, records[1])
 	})
 
-	t.Run("SeparateRowPerModel", func(t *testing.T) {
+	t.Run("DefaultPeriodClampedToRetention", func(t *testing.T) {
 		t.Parallel()
 
+		// Use fixed dates to keep the test deterministic.
+		now := time.Date(2026, time.March, 20, 12, 0, 0, 0, time.UTC)
 		clock := quartz.NewMock(t)
+		clock.Set(now)
+
 		db, ps := dbtestutil.NewDB(t)
+		retention := 14 * 24 * time.Hour
 		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
-			GroupName: "export-per-model-group",
+			GroupName: "export-retention-clamp-group",
 			Clock:     clock,
 			Database:  db,
 			Pubsub:    ps,
+			Retention: &retention,
 		})
 		ctx := testutil.Context(t, testutil.WaitLong)
-		clock.Set(time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC))
-		inMonth := time.Date(2026, time.March, 10, 8, 0, 0, 0, time.UTC)
+		// Retention starts on 6 March 2026 12:00 UTC.
+		retentionStart := now.Add(-retention)
 		groupID := uuid.NullUUID{UUID: group.ID, Valid: true}
 
-		// Usage for two different models produces one row each.
-		claudeIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
-			InitiatorID: targetUser.ID, Provider: "anthropic", ProviderName: "anthropic-prod", Model: "claude-4", StartedAt: inMonth,
-		}, nil)
-		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
-			InterceptionID: claudeIntc.ID, CreatedAt: inMonth, EffectiveGroupID: groupID,
-			InputTokens: 100, OutputTokens: 50, CostMicros: sql.NullInt64{Int64: 1000, Valid: true},
-		})
-		gptIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
-			InitiatorID: targetUser.ID, Provider: "openai", ProviderName: "openai-prod", Model: "gpt-4", StartedAt: inMonth,
-		}, nil)
-		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
-			InterceptionID: gptIntc.ID, CreatedAt: inMonth, EffectiveGroupID: groupID,
-			InputTokens: 500, OutputTokens: 250, CostMicros: sql.NullInt64{Int64: 5000, Valid: true},
-		})
+		// Usage before the retention start falls outside the narrowed period.
+		for _, seed := range []struct {
+			at           time.Time
+			inputTokens  int64
+			outputTokens int64
+			costMicros   int64
+		}{
+			{at: retentionStart.Add(-time.Hour), inputTokens: 999, outputTokens: 999, costMicros: 9999},
+			{at: retentionStart.Add(time.Hour), inputTokens: 100, outputTokens: 50, costMicros: 1000},
+		} {
+			intc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+				InitiatorID: targetUser.ID, Provider: "anthropic", ProviderName: "anthropic-prod", Model: "claude-4", StartedAt: seed.at,
+			}, nil)
+			dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+				InterceptionID: intc.ID, CreatedAt: seed.at, EffectiveGroupID: groupID,
+				InputTokens: seed.inputTokens, OutputTokens: seed.outputTokens,
+				CostMicros: sql.NullInt64{Int64: seed.costMicros, Valid: true},
+			})
+		}
 
+		// Start: 6 March 2026 12:00 UTC (inclusive).
+		// End:   1 April 2026 00:00 UTC (exclusive).
+		// Now:   20 March 2026 12:00 UTC.
 		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, nil)
 		defer res.Body.Close()
 		require.Equal(t, http.StatusOK, res.StatusCode)
 
 		records := readAISpendExportResponse(t, res)
-		require.Len(t, records, 3) // header + one row per model
-
-		userID := targetUser.ID.String()
-		groupStr := group.ID.String()
-		orgStr := group.OrganizationID.String()
-		wantStart := "2026-03-01T00:00:00Z"
-		wantEnd := "2026-04-01T00:00:00Z"
-		// Ordered by provider then model: anthropic/claude-4, then openai/gpt-4.
-		require.Equal(t, []string{userID, groupStr, orgStr, "claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000", wantStart, wantEnd}, records[1])
-		require.Equal(t, []string{userID, groupStr, orgStr, "gpt-4", "openai", "openai-prod", "500", "250", "0", "0", "5000", wantStart, wantEnd}, records[2])
-	})
-
-	t.Run("PreviousMonthExcluded", func(t *testing.T) {
-		t.Parallel()
-
-		clock := quartz.NewMock(t)
-		db, ps := dbtestutil.NewDB(t)
-		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
-			GroupName: "export-prev-month-group",
-			Clock:     clock,
-			Database:  db,
-			Pubsub:    ps,
-		})
-		ctx := testutil.Context(t, testutil.WaitLong)
-		clock.Set(time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC))
-		inMonth := time.Date(2026, time.March, 10, 8, 0, 0, 0, time.UTC)
-		prevMonth := time.Date(2026, time.February, 20, 8, 0, 0, 0, time.UTC)
-		groupID := uuid.NullUUID{UUID: group.ID, Valid: true}
-
-		// Current-month usage is included.
-		intc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
-			InitiatorID: targetUser.ID, Provider: "anthropic", Model: "claude-4", StartedAt: inMonth,
-		}, nil)
-		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
-			InterceptionID: intc.ID, CreatedAt: inMonth, EffectiveGroupID: groupID,
-			InputTokens: 100, CostMicros: sql.NullInt64{Int64: 1000, Valid: true},
-		})
-
-		// Previous-month usage falls outside the default window and is excluded.
-		prevIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
-			InitiatorID: targetUser.ID, Provider: "anthropic", Model: "claude-4", StartedAt: prevMonth,
-		}, nil)
-		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
-			InterceptionID: prevIntc.ID, CreatedAt: prevMonth, EffectiveGroupID: groupID,
-			InputTokens: 999, CostMicros: sql.NullInt64{Int64: 9999, Valid: true},
-		})
-
-		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, nil)
-		defer res.Body.Close()
-		require.Equal(t, http.StatusOK, res.StatusCode)
-
-		records := readAISpendExportResponse(t, res)
-		// Only the current-month usage is present, so its values exclude the
-		// previous month.
-		require.Len(t, records, 2)               // header + current-month row
-		require.Equal(t, "100", records[1][6])   // input_tokens
-		require.Equal(t, "1000", records[1][10]) // cost_micros
-	})
-
-	t.Run("ExcludesNullEffectiveGroup", func(t *testing.T) {
-		t.Parallel()
-
-		clock := quartz.NewMock(t)
-		db, ps := dbtestutil.NewDB(t)
-		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
-			GroupName: "export-null-group",
-			Clock:     clock,
-			Database:  db,
-			Pubsub:    ps,
-		})
-		ctx := testutil.Context(t, testutil.WaitLong)
-		clock.Set(time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC))
-		at := time.Date(2026, time.March, 10, 8, 0, 0, 0, time.UTC)
-
-		// Usage attributed to a group is included.
-		groupedIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
-			InitiatorID: targetUser.ID, Provider: "anthropic", Model: "claude-4", StartedAt: at,
-		}, nil)
-		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
-			InterceptionID: groupedIntc.ID, CreatedAt: at,
-			EffectiveGroupID: uuid.NullUUID{UUID: group.ID, Valid: true},
-			InputTokens:      100, CostMicros: sql.NullInt64{Int64: 1000, Valid: true},
-		})
-
-		// Usage with no effective group must be excluded entirely, so its
-		// tokens and cost never reach the CSV.
-		nullIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
-			InitiatorID: targetUser.ID, Provider: "anthropic", Model: "claude-4", StartedAt: at,
-		}, nil)
-		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
-			InterceptionID: nullIntc.ID, CreatedAt: at,
-			InputTokens: 500, CostMicros: sql.NullInt64{Int64: 5000, Valid: true},
-		})
-
-		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, nil)
-		defer res.Body.Close()
-		require.Equal(t, http.StatusOK, res.StatusCode)
-
-		records := readAISpendExportResponse(t, res)
-		// Only the grouped row is present; the null-group usage is dropped, so
-		// both the row count and the aggregated values exclude it.
-		require.Len(t, records, 2)               // header + single grouped row
-		require.Equal(t, "100", records[1][6])   // input_tokens
-		require.Equal(t, "1000", records[1][10]) // cost_micros
+		require.Len(t, records, 2) // header + only the retained row
+		require.Equal(t, []string{
+			targetUser.ID.String(), targetUser.Username,
+			group.ID.String(), group.Name,
+			group.OrganizationID.String(), group.OrganizationName,
+			"claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000",
+			"2026-03-06T12:00:00Z", "2026-04-01T00:00:00Z",
+		}, records[1])
 	})
 
 	t.Run("CustomPeriodHalfOpen", func(t *testing.T) {
 		t.Parallel()
 
+		// Use fixed dates to keep the test deterministic.
+		now := time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC)
 		clock := quartz.NewMock(t)
+		clock.Set(now)
+
 		db, ps := dbtestutil.NewDB(t)
 		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
 			GroupName: "export-custom-group",
@@ -4056,23 +4000,24 @@ func TestExportOrganizationAISpend(t *testing.T) {
 			Pubsub:    ps,
 		})
 		ctx := testutil.Context(t, testutil.WaitLong)
-		clock.Set(time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC))
-		groupID := uuid.NullUUID{UUID: group.ID, Valid: true}
-
+		effectiveGroupID := uuid.NullUUID{UUID: group.ID, Valid: true}
 		start := time.Date(2026, time.March, 10, 0, 0, 0, 0, time.UTC)
 		end := time.Date(2026, time.March, 11, 0, 0, 0, 0, time.UTC)
 
-		// At start (inclusive): included. At end (exclusive): excluded.
+		// Usage at start is included, usage at end is excluded.
 		for _, at := range []time.Time{start, end} {
 			intc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
-				InitiatorID: targetUser.ID, Provider: "anthropic", Model: "claude-4", StartedAt: at,
+				InitiatorID: targetUser.ID, Provider: "anthropic", ProviderName: "anthropic-prod", Model: "claude-4", StartedAt: at,
 			}, nil)
 			dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
-				InterceptionID: intc.ID, CreatedAt: at, EffectiveGroupID: groupID,
-				InputTokens: 100, CostMicros: sql.NullInt64{Int64: 1000, Valid: true},
+				InterceptionID: intc.ID, CreatedAt: at, EffectiveGroupID: effectiveGroupID,
+				InputTokens: 100, OutputTokens: 50, CostMicros: sql.NullInt64{Int64: 1000, Valid: true},
 			})
 		}
 
+		// Start: 10 March 2026 00:00 UTC (inclusive).
+		// End:   11 March 2026 00:00 UTC (exclusive).
+		// Now:   15 March 2026 12:00 UTC.
 		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, map[string]string{
 			"period_start": start.Format(time.RFC3339Nano),
 			"period_end":   end.Format(time.RFC3339Nano),
@@ -4082,28 +4027,566 @@ func TestExportOrganizationAISpend(t *testing.T) {
 
 		records := readAISpendExportResponse(t, res)
 		require.Len(t, records, 2) // header + only the start-boundary row
-		require.Equal(t, "1000", records[1][10])
-		require.Equal(t, start.Format(time.RFC3339), records[1][11])
-		require.Equal(t, end.Format(time.RFC3339), records[1][12])
+		require.Equal(t, []string{
+			targetUser.ID.String(), targetUser.Username,
+			group.ID.String(), group.Name,
+			group.OrganizationID.String(), group.OrganizationName,
+			"claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000",
+			start.Format(time.RFC3339), end.Format(time.RFC3339),
+		}, records[1])
 	})
-}
 
-// aiSpendExportCSVHeaderForTest mirrors the handler's CSV column order.
-var aiSpendExportCSVHeaderForTest = []string{
-	"user", "group", "organization", "model", "provider", "provider_name",
-	"input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",
-	"cost_micros", "period_start", "period_end",
+	t.Run("ExplicitPeriodBeforeRetentionRejected", func(t *testing.T) {
+		t.Parallel()
+
+		// Use fixed dates to keep the test deterministic.
+		now := time.Date(2026, time.March, 20, 12, 0, 0, 0, time.UTC)
+		clock := quartz.NewMock(t)
+		clock.Set(now)
+
+		retention := 14 * 24 * time.Hour
+		adminClient, _, group := setupAICostControlTest(t, aiCostControlTestOptions{
+			GroupName: "export-retention-reject-group",
+			Clock:     clock,
+			Retention: &retention,
+		})
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		// The requested start is an hour before the retention window begins, so
+		// the request fails instead of being shortened like the default period.
+		start := now.Add(-retention).Add(-time.Hour)
+
+		_, err := adminClient.ExportOrganizationAISpend(ctx, group.OrganizationID, codersdk.AISpendPeriodWindow{
+			PeriodStart: start,
+			PeriodEnd:   now,
+		})
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
+		require.Contains(t, sdkErr.Message, "retention window")
+		require.Contains(t, sdkErr.Message, retention.String())
+	})
+
+	t.Run("RetentionDisabledAllowsOldPeriod", func(t *testing.T) {
+		t.Parallel()
+
+		// Use fixed dates to keep the test deterministic.
+		now := time.Date(2026, time.March, 20, 12, 0, 0, 0, time.UTC)
+		clock := quartz.NewMock(t)
+		clock.Set(now)
+
+		db, ps := dbtestutil.NewDB(t)
+		// A retention of zero disables purging, so no period is too old to
+		// export and neither the narrowing nor the rejection applies.
+		retention := time.Duration(0)
+		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
+			GroupName: "export-retention-disabled-group",
+			Clock:     clock,
+			Database:  db,
+			Pubsub:    ps,
+			Retention: &retention,
+		})
+		ctx := testutil.Context(t, testutil.WaitLong)
+		// Two years before the request, far outside any retention window.
+		at := time.Date(2024, time.March, 10, 8, 0, 0, 0, time.UTC)
+		effectiveGroupID := uuid.NullUUID{UUID: group.ID, Valid: true}
+
+		intc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: targetUser.ID, Provider: "anthropic", ProviderName: "anthropic-prod", Model: "claude-4", StartedAt: at,
+		}, nil)
+		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+			InterceptionID: intc.ID, CreatedAt: at, EffectiveGroupID: effectiveGroupID,
+			InputTokens: 100, OutputTokens: 50, CostMicros: sql.NullInt64{Int64: 1000, Valid: true},
+		})
+
+		// Start: 10 March 2024 07:00 UTC (inclusive).
+		// End:   10 March 2024 09:00 UTC (exclusive).
+		// Now:   20 March 2026 12:00 UTC.
+		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, map[string]string{
+			"period_start": at.Add(-time.Hour).Format(time.RFC3339Nano),
+			"period_end":   at.Add(time.Hour).Format(time.RFC3339Nano),
+		})
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		records := readAISpendExportResponse(t, res)
+		require.Len(t, records, 2) // header + the retained row
+		require.Equal(t, []string{
+			targetUser.ID.String(), targetUser.Username,
+			group.ID.String(), group.Name,
+			group.OrganizationID.String(), group.OrganizationName,
+			"claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000",
+			"2024-03-10T07:00:00Z", "2024-03-10T09:00:00Z",
+		}, records[1])
+	})
+
+	t.Run("SeparateRowPerModel", func(t *testing.T) {
+		t.Parallel()
+
+		// Use fixed dates to keep the test deterministic.
+		now := time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC)
+		clock := quartz.NewMock(t)
+		clock.Set(now)
+
+		db, ps := dbtestutil.NewDB(t)
+		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
+			GroupName: "export-per-model-group",
+			Clock:     clock,
+			Database:  db,
+			Pubsub:    ps,
+		})
+		ctx := testutil.Context(t, testutil.WaitLong)
+		inMonth := time.Date(2026, time.March, 10, 8, 0, 0, 0, time.UTC)
+		effectiveGroupID := uuid.NullUUID{UUID: group.ID, Valid: true}
+
+		// Usage for two different models produces one row each.
+		claudeIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: targetUser.ID, Provider: "anthropic", ProviderName: "anthropic-prod", Model: "claude-4", StartedAt: inMonth,
+		}, nil)
+		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+			InterceptionID: claudeIntc.ID, CreatedAt: inMonth, EffectiveGroupID: effectiveGroupID,
+			InputTokens: 100, OutputTokens: 50, CostMicros: sql.NullInt64{Int64: 1000, Valid: true},
+		})
+		gptIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: targetUser.ID, Provider: "openai", ProviderName: "openai-prod", Model: "gpt-4", StartedAt: inMonth,
+		}, nil)
+		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+			InterceptionID: gptIntc.ID, CreatedAt: inMonth, EffectiveGroupID: effectiveGroupID,
+			InputTokens: 500, OutputTokens: 250, CostMicros: sql.NullInt64{Int64: 5000, Valid: true},
+		})
+
+		// Now: 15 March 2026 12:00 UTC.
+		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, nil)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		records := readAISpendExportResponse(t, res)
+		require.Len(t, records, 3) // header + one row per model
+
+		userID := targetUser.ID.String()
+		username := targetUser.Username
+		groupID := group.ID.String()
+		groupName := group.Name
+		orgID := group.OrganizationID.String()
+		orgName := group.OrganizationName
+		periodStart := "2026-03-01T00:00:00Z"
+		periodEnd := "2026-04-01T00:00:00Z"
+		// Ordered by provider then model: anthropic/claude-4, then openai/gpt-4.
+		require.Equal(t, []string{userID, username, groupID, groupName, orgID, orgName, "claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000", periodStart, periodEnd}, records[1])
+		require.Equal(t, []string{userID, username, groupID, groupName, orgID, orgName, "gpt-4", "openai", "openai-prod", "500", "250", "0", "0", "5000", periodStart, periodEnd}, records[2])
+	})
+
+	t.Run("SeparateRowPerProviderName", func(t *testing.T) {
+		t.Parallel()
+
+		// Use fixed dates to keep the test deterministic.
+		now := time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC)
+		clock := quartz.NewMock(t)
+		clock.Set(now)
+
+		db, ps := dbtestutil.NewDB(t)
+		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
+			GroupName: "export-per-provider-name-group",
+			Clock:     clock,
+			Database:  db,
+			Pubsub:    ps,
+		})
+		ctx := testutil.Context(t, testutil.WaitLong)
+		inMonth := time.Date(2026, time.March, 10, 8, 0, 0, 0, time.UTC)
+		effectiveGroupID := uuid.NullUUID{UUID: group.ID, Valid: true}
+
+		// Two configurations of the same provider, same model. Spend is reported
+		// per configuration rather than merged into one provider row.
+		for _, seed := range []struct {
+			providerName string
+			inputTokens  int64
+			outputTokens int64
+			costMicros   int64
+		}{
+			{providerName: "anthropic-dev", inputTokens: 100, outputTokens: 50, costMicros: 1000},
+			{providerName: "anthropic-prod", inputTokens: 500, outputTokens: 250, costMicros: 5000},
+		} {
+			intc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+				InitiatorID: targetUser.ID, Provider: "anthropic", ProviderName: seed.providerName, Model: "claude-4", StartedAt: inMonth,
+			}, nil)
+			dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+				InterceptionID: intc.ID, CreatedAt: inMonth, EffectiveGroupID: effectiveGroupID,
+				InputTokens: seed.inputTokens, OutputTokens: seed.outputTokens,
+				CostMicros: sql.NullInt64{Int64: seed.costMicros, Valid: true},
+			})
+		}
+
+		// Now: 15 March 2026 12:00 UTC.
+		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, nil)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		records := readAISpendExportResponse(t, res)
+		require.Len(t, records, 3) // header + one row per provider name
+
+		userID := targetUser.ID.String()
+		username := targetUser.Username
+		groupID := group.ID.String()
+		groupName := group.Name
+		orgID := group.OrganizationID.String()
+		orgName := group.OrganizationName
+		periodStart := "2026-03-01T00:00:00Z"
+		periodEnd := "2026-04-01T00:00:00Z"
+		// Ordered by provider name: anthropic-dev, then anthropic-prod.
+		require.Equal(t, []string{userID, username, groupID, groupName, orgID, orgName, "claude-4", "anthropic", "anthropic-dev", "100", "50", "0", "0", "1000", periodStart, periodEnd}, records[1])
+		require.Equal(t, []string{userID, username, groupID, groupName, orgID, orgName, "claude-4", "anthropic", "anthropic-prod", "500", "250", "0", "0", "5000", periodStart, periodEnd}, records[2])
+	})
+
+	t.Run("SeparateRowPerGroup", func(t *testing.T) {
+		t.Parallel()
+
+		// Use fixed dates to keep the test deterministic.
+		now := time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC)
+		clock := quartz.NewMock(t)
+		clock.Set(now)
+
+		db, ps := dbtestutil.NewDB(t)
+		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
+			GroupName: "export-per-group-first",
+			Clock:     clock,
+			Database:  db,
+			Pubsub:    ps,
+		})
+		ctx := testutil.Context(t, testutil.WaitLong)
+		inMonth := time.Date(2026, time.March, 10, 8, 0, 0, 0, time.UTC)
+
+		// A second group in the same organization. The user is not added to it:
+		// the effective group is snapshotted on each token usage, so spend from
+		// before a membership or budget change stays attributed to the old group.
+		secondGroup, err := adminClient.CreateGroup(ctx, group.OrganizationID, codersdk.CreateGroupRequest{
+			Name: "export-per-group-second",
+		})
+		require.NoError(t, err)
+
+		for _, seed := range []struct {
+			groupID      uuid.UUID
+			inputTokens  int64
+			outputTokens int64
+			costMicros   int64
+		}{
+			{groupID: group.ID, inputTokens: 100, outputTokens: 50, costMicros: 1000},
+			{groupID: secondGroup.ID, inputTokens: 500, outputTokens: 250, costMicros: 5000},
+		} {
+			intc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+				InitiatorID: targetUser.ID, Provider: "anthropic", ProviderName: "anthropic-prod", Model: "claude-4", StartedAt: inMonth,
+			}, nil)
+			dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+				InterceptionID: intc.ID, CreatedAt: inMonth,
+				EffectiveGroupID: uuid.NullUUID{UUID: seed.groupID, Valid: true},
+				InputTokens:      seed.inputTokens, OutputTokens: seed.outputTokens,
+				CostMicros: sql.NullInt64{Int64: seed.costMicros, Valid: true},
+			})
+		}
+
+		// Now: 15 March 2026 12:00 UTC.
+		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, nil)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		records := readAISpendExportResponse(t, res)
+		require.Len(t, records, 3) // header + one row per group
+
+		userID := targetUser.ID.String()
+		username := targetUser.Username
+		orgID := group.OrganizationID.String()
+		orgName := group.OrganizationName
+		periodStart := "2026-03-01T00:00:00Z"
+		periodEnd := "2026-04-01T00:00:00Z"
+		// Rows are ordered by group ID, which is a random UUID, so compare
+		// without depending on which group sorts first.
+		require.ElementsMatch(t, [][]string{
+			{userID, username, group.ID.String(), group.Name, orgID, orgName, "claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000", periodStart, periodEnd},
+			{userID, username, secondGroup.ID.String(), secondGroup.Name, orgID, orgName, "claude-4", "anthropic", "anthropic-prod", "500", "250", "0", "0", "5000", periodStart, periodEnd},
+		}, records[1:])
+	})
+
+	t.Run("PreviousMonthExcluded", func(t *testing.T) {
+		t.Parallel()
+
+		// Use fixed dates to keep the test deterministic.
+		now := time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC)
+		clock := quartz.NewMock(t)
+		clock.Set(now)
+
+		db, ps := dbtestutil.NewDB(t)
+		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
+			GroupName: "export-prev-month-group",
+			Clock:     clock,
+			Database:  db,
+			Pubsub:    ps,
+		})
+		ctx := testutil.Context(t, testutil.WaitLong)
+		prevMonth := time.Date(2026, time.February, 20, 8, 0, 0, 0, time.UTC)
+		inMonth := time.Date(2026, time.March, 10, 8, 0, 0, 0, time.UTC)
+		groupID := uuid.NullUUID{UUID: group.ID, Valid: true}
+
+		// Previous-month usage falls outside the default window and is excluded.
+		prevIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: targetUser.ID, Provider: "anthropic", ProviderName: "anthropic-prod", Model: "claude-4", StartedAt: prevMonth,
+		}, nil)
+		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+			InterceptionID: prevIntc.ID, CreatedAt: prevMonth, EffectiveGroupID: groupID,
+			InputTokens: 999, OutputTokens: 999, CostMicros: sql.NullInt64{Int64: 9999, Valid: true},
+		})
+
+		// Current-month usage is included.
+		intc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: targetUser.ID, Provider: "anthropic", ProviderName: "anthropic-prod", Model: "claude-4", StartedAt: inMonth,
+		}, nil)
+		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+			InterceptionID: intc.ID, CreatedAt: inMonth, EffectiveGroupID: groupID,
+			InputTokens: 100, OutputTokens: 50, CostMicros: sql.NullInt64{Int64: 1000, Valid: true},
+		})
+
+		// Now: 15 March 2026 12:00 UTC.
+		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, nil)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		records := readAISpendExportResponse(t, res)
+		// Only the current-month usage is present, so the row carries none of the
+		// previous month's tokens or cost.
+		require.Len(t, records, 2) // header + current-month row
+		require.Equal(t, []string{
+			targetUser.ID.String(), targetUser.Username,
+			group.ID.String(), group.Name,
+			group.OrganizationID.String(), group.OrganizationName,
+			"claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000",
+			"2026-03-01T00:00:00Z", "2026-04-01T00:00:00Z",
+		}, records[1])
+	})
+
+	t.Run("ExcludesNullEffectiveGroup", func(t *testing.T) {
+		t.Parallel()
+
+		// Use fixed dates to keep the test deterministic.
+		now := time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC)
+		clock := quartz.NewMock(t)
+		clock.Set(now)
+
+		db, ps := dbtestutil.NewDB(t)
+		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
+			GroupName: "export-null-group",
+			Clock:     clock,
+			Database:  db,
+			Pubsub:    ps,
+		})
+		ctx := testutil.Context(t, testutil.WaitLong)
+		at := time.Date(2026, time.March, 10, 8, 0, 0, 0, time.UTC)
+
+		// Usage with no effective group cannot be attributed to an organization,
+		// so it is excluded entirely and the export returns no rows at all.
+		nullIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: targetUser.ID, Provider: "anthropic", ProviderName: "anthropic-prod", Model: "claude-4", StartedAt: at,
+		}, nil)
+		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+			InterceptionID: nullIntc.ID, CreatedAt: at,
+			InputTokens: 500, CostMicros: sql.NullInt64{Int64: 5000, Valid: true},
+		})
+
+		// Now: 15 March 2026 12:00 UTC.
+		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, nil)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		records := readAISpendExportResponse(t, res)
+		require.Equal(t, entcoderd.AISpendExportCSVHeader, records[0])
+		require.Len(t, records, 1) // header only
+	})
+
+	t.Run("ExcludesOtherOrganizations", func(t *testing.T) {
+		t.Parallel()
+
+		// Use fixed dates to keep the test deterministic.
+		now := time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC)
+		clock := quartz.NewMock(t)
+		clock.Set(now)
+
+		// Built inline rather than through setupAICostControlTest, which
+		// licenses a single organization and returns no owner client.
+		db, ps := dbtestutil.NewDB(t)
+		dv := coderdtest.DeploymentValues(t)
+		dv.AI.BridgeConfig.Enabled = serpent.Bool(true)
+		dv.Experiments = []string{string(codersdk.ExperimentAIGatewayCostControl)}
+		ownerClient, owner := coderdenttest.New(t, &coderdenttest.Options{
+			Options: &coderdtest.Options{DeploymentValues: dv, Database: db, Pubsub: ps, Clock: clock},
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureTemplateRBAC:          1,
+					codersdk.FeatureAIBridge:              1,
+					codersdk.FeatureMultipleOrganizations: 1,
+				},
+			},
+		})
+		ctx := testutil.Context(t, testutil.WaitLong)
+		inMonth := time.Date(2026, time.March, 10, 8, 0, 0, 0, time.UTC)
+
+		otherOrg := coderdenttest.CreateOrganization(t, ownerClient, coderdenttest.CreateOrganizationOptions{})
+		_, otherOrgMember := coderdtest.CreateAnotherUser(t, ownerClient, otherOrg.ID)
+		userAdminClient, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID, rbac.RoleUserAdmin())
+		group, err := userAdminClient.CreateGroup(ctx, owner.OrganizationID, codersdk.CreateGroupRequest{
+			Name: "export-org-scope-group",
+		})
+		require.NoError(t, err)
+		otherOrgGroup, err := userAdminClient.CreateGroup(ctx, otherOrg.ID, codersdk.CreateGroupRequest{
+			Name: "export-org-scope-other-org-group",
+		})
+		require.NoError(t, err)
+
+		// Usage in each organization, attributed through that organization's
+		// group.
+		for _, seed := range []struct {
+			initiator uuid.UUID
+			groupID   uuid.UUID
+		}{
+			{initiator: owner.UserID, groupID: group.ID},
+			{initiator: otherOrgMember.ID, groupID: otherOrgGroup.ID},
+		} {
+			intc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+				InitiatorID: seed.initiator, Provider: "anthropic", ProviderName: "anthropic-prod", Model: "claude-4", StartedAt: inMonth,
+			}, nil)
+			dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+				InterceptionID: intc.ID, CreatedAt: inMonth,
+				EffectiveGroupID: uuid.NullUUID{UUID: seed.groupID, Valid: true},
+				InputTokens:      100, OutputTokens: 50, CostMicros: sql.NullInt64{Int64: 1000, Valid: true},
+			})
+		}
+
+		// The owner can read group members in both organizations, so only the
+		// query's organization filter keeps the other organization out.
+		// Now: 15 March 2026 12:00 UTC.
+		//nolint:gocritic // The owner is required to rule out RBAC filtering.
+		res := requestAISpendExport(ctx, t, ownerClient, owner.OrganizationID, nil)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		records := readAISpendExportResponse(t, res)
+		require.Len(t, records, 2) // header + the requested organization's row
+		require.Equal(t, []string{
+			owner.UserID.String(), coderdtest.FirstUserParams.Username,
+			group.ID.String(), group.Name,
+			owner.OrganizationID.String(), group.OrganizationName,
+			"claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000",
+			"2026-03-01T00:00:00Z", "2026-04-01T00:00:00Z",
+		}, records[1])
+	})
+
+	t.Run("EscapesFormulaCells", func(t *testing.T) {
+		t.Parallel()
+
+		// Use fixed dates to keep the test deterministic.
+		now := time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC)
+		clock := quartz.NewMock(t)
+		clock.Set(now)
+
+		db, ps := dbtestutil.NewDB(t)
+		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
+			GroupName: "export-formula-escape-group",
+			Clock:     clock,
+			Database:  db,
+			Pubsub:    ps,
+		})
+		ctx := testutil.Context(t, testutil.WaitLong)
+		inMonth := time.Date(2026, time.March, 10, 8, 0, 0, 0, time.UTC)
+		groupID := uuid.NullUUID{UUID: group.ID, Valid: true}
+
+		// Model, provider, and provider name are recorded verbatim from the
+		// intercepted request, so a leading formula character must be escaped.
+		intc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID:  targetUser.ID,
+			Provider:     "+openai",
+			ProviderName: "@prod",
+			Model:        `=HYPERLINK("http://insecure/","invoice")`,
+			StartedAt:    inMonth,
+		}, nil)
+		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+			InterceptionID: intc.ID, CreatedAt: inMonth, EffectiveGroupID: groupID,
+			InputTokens: 100, OutputTokens: 50, CostMicros: sql.NullInt64{Int64: 1000, Valid: true},
+		})
+
+		// Now: 15 March 2026 12:00 UTC.
+		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, nil)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		records := readAISpendExportResponse(t, res)
+		require.Len(t, records, 2) // header + the escaped row
+		require.Equal(t, []string{
+			targetUser.ID.String(), targetUser.Username,
+			group.ID.String(), group.Name,
+			group.OrganizationID.String(), group.OrganizationName,
+			`'=HYPERLINK("http://insecure/","invoice")`, "'+openai", "'@prod",
+			"100", "50", "0", "0", "1000",
+			"2026-03-01T00:00:00Z", "2026-04-01T00:00:00Z",
+		}, records[1])
+	})
+
+	t.Run("DownloadHeaders", func(t *testing.T) {
+		t.Parallel()
+
+		// Use fixed dates to keep the test deterministic.
+		now := time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC)
+		clock := quartz.NewMock(t)
+		clock.Set(now)
+
+		adminClient, _, group := setupAICostControlTest(t, aiCostControlTestOptions{
+			GroupName: "export-download-headers-group",
+			Clock:     clock,
+		})
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		// Start: 10 March 2026 00:00 UTC (inclusive).
+		// End:   11 March 2026 00:00 UTC (exclusive).
+		// Now:   15 March 2026 12:00 UTC.
+		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, map[string]string{
+			"period_start": time.Date(2026, time.March, 10, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
+			"period_end":   time.Date(2026, time.March, 11, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
+		})
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		require.Equal(t, "text/csv; charset=utf-8", res.Header.Get("Content-Type"))
+		// The filename carries the organization name and the exported period.
+		require.Equal(t,
+			fmt.Sprintf(`attachment; filename="ai-spend-export-%s-2026-03-10-to-2026-03-11.csv"`, group.OrganizationName),
+			res.Header.Get("Content-Disposition"))
+
+		// No usage is seeded, so only the column header is written. Spelled out
+		// rather than compared against the handler's own variable, since the
+		// column names are a published contract that a rename would break.
+		records := readAISpendExportResponse(t, res)
+		require.Equal(t, []string{
+			"user_id", "username", "group_id", "group_name", "organization_id", "organization_name",
+			"model", "provider", "provider_name",
+			"input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",
+			"cost_micros", "period_start", "period_end",
+		}, records[0])
+		require.Len(t, records, 1)
+	})
 }
 
 func TestExportOrganizationAISpendRoleAccess(t *testing.T) {
 	t.Parallel()
+
+	// Use fixed dates to keep the test deterministic. Seeding at time.Now()
+	// against the default month period fails when a run crosses a UTC month
+	// boundary.
+	now := time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC)
+	inMonth := time.Date(2026, time.March, 10, 8, 0, 0, 0, time.UTC)
+	clock := quartz.NewMock(t)
+	clock.Set(now)
 
 	db, ps := dbtestutil.NewDB(t)
 	dv := coderdtest.DeploymentValues(t)
 	dv.AI.BridgeConfig.Enabled = serpent.Bool(true)
 	dv.Experiments = []string{string(codersdk.ExperimentAIGatewayCostControl)}
 	ownerClient, owner := coderdenttest.New(t, &coderdenttest.Options{
-		Options: &coderdtest.Options{DeploymentValues: dv, Database: db, Pubsub: ps},
+		Options: &coderdtest.Options{DeploymentValues: dv, Database: db, Pubsub: ps, Clock: clock},
 		LicenseOptions: &coderdenttest.LicenseOptions{
 			Features: license.Features{
 				codersdk.FeatureTemplateRBAC:          1,
@@ -4128,16 +4611,16 @@ func TestExportOrganizationAISpendRoleAccess(t *testing.T) {
 
 	// Seed spend for two users in the current month: the owner and a regular
 	// member. Both are attributed to the group.
-	now := time.Now().UTC()
 	for _, initiator := range []uuid.UUID{owner.UserID, member.ID} {
 		intc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
-			InitiatorID: initiator, Provider: "anthropic", Model: "claude-4", StartedAt: now,
+			InitiatorID: initiator, Provider: "anthropic", ProviderName: "anthropic-prod", Model: "claude-4", StartedAt: inMonth,
 		}, nil)
 		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
 			InterceptionID:   intc.ID,
-			CreatedAt:        now,
+			CreatedAt:        inMonth,
 			EffectiveGroupID: uuid.NullUUID{UUID: group.ID, Valid: true},
 			InputTokens:      100,
+			OutputTokens:     50,
 			CostMicros:       sql.NullInt64{Int64: 1000, Valid: true},
 		})
 	}
@@ -4145,18 +4628,20 @@ func TestExportOrganizationAISpendRoleAccess(t *testing.T) {
 	cases := []struct {
 		name        string
 		client      *codersdk.Client
-		wantUserIDs []string // expected user_id column values; empty with wantErr means 404
-		wantErr     bool
+		wantUserIDs []string // expected user_id column values when wantStatus is unset
+		wantStatus  int      // non-zero means the request is rejected with this status
 	}{
 		// Admins see every user's rows.
 		{name: "Owner", client: ownerClient, wantUserIDs: []string{owner.UserID.String(), member.ID.String()}},
 		{name: "UserAdmin", client: userAdminClient, wantUserIDs: []string{owner.UserID.String(), member.ID.String()}},
 		{name: "OrgAdmin", client: orgAdminClient, wantUserIDs: []string{owner.UserID.String(), member.ID.String()}},
 		{name: "OrgUserAdmin", client: orgUserAdminClient, wantUserIDs: []string{owner.UserID.String(), member.ID.String()}},
-		// A regular member only sees their own row.
-		{name: "Member", client: memberClient, wantUserIDs: []string{member.ID.String()}},
-		// A member of another org cannot read this org at all.
-		{name: "OtherOrgMember", client: otherOrgMemberClient, wantErr: true},
+		// The export covers the whole organization, so a regular member is
+		// rejected rather than served their own rows.
+		{name: "Member", client: memberClient, wantStatus: http.StatusForbidden},
+		// A member of another org cannot read this org at all, so it fails
+		// earlier, when the organization is resolved.
+		{name: "OtherOrgMember", client: otherOrgMemberClient, wantStatus: http.StatusNotFound},
 	}
 
 	for _, tc := range cases {
@@ -4165,10 +4650,10 @@ func TestExportOrganizationAISpendRoleAccess(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitLong)
 
 			body, err := tc.client.ExportOrganizationAISpend(ctx, owner.OrganizationID, codersdk.AISpendPeriodWindow{})
-			if tc.wantErr {
+			if tc.wantStatus != 0 {
 				var sdkErr *codersdk.Error
 				require.ErrorAs(t, err, &sdkErr)
-				require.Equal(t, http.StatusNotFound, sdkErr.StatusCode())
+				require.Equal(t, tc.wantStatus, sdkErr.StatusCode())
 				return
 			}
 			require.NoError(t, err)
@@ -4705,6 +5190,9 @@ type aiCostControlTestOptions struct {
 	Clock     quartz.Clock
 	Database  database.Store
 	Pubsub    pubsub.Pubsub
+	// Retention overrides the AI Gateway data retention duration. Nil leaves the
+	// deployment default in place, and zero disables purging.
+	Retention *time.Duration
 }
 
 // setupAICostControlTest builds a deployment with FeatureAIBridge licensed
@@ -4717,6 +5205,9 @@ func setupAICostControlTest(t *testing.T, opts aiCostControlTestOptions) (*coder
 	dv := coderdtest.DeploymentValues(t)
 	dv.AI.BridgeConfig.Enabled = serpent.Bool(true)
 	dv.Experiments = []string{string(codersdk.ExperimentAIGatewayCostControl)}
+	if opts.Retention != nil {
+		dv.AI.BridgeConfig.Retention = serpent.Duration(*opts.Retention)
+	}
 	coderdOpts := &coderdtest.Options{DeploymentValues: dv}
 	if opts.Clock != nil {
 		coderdOpts.Clock = opts.Clock

--- a/enterprise/coderd/aibridge_test.go
+++ b/enterprise/coderd/aibridge_test.go
@@ -3738,7 +3738,7 @@ func requestAISpendExport(ctx context.Context, t *testing.T, client *codersdk.Cl
 func TestExportOrganizationAISpend(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Gating", func(t *testing.T) {
+	t.Run("Enablement", func(t *testing.T) {
 		t.Parallel()
 
 		cases := []struct {
@@ -3776,181 +3776,13 @@ func TestExportOrganizationAISpend(t *testing.T) {
 				ctx := testutil.Context(t, testutil.WaitLong)
 
 				//nolint:gocritic // Owner role is irrelevant; the request is blocked before RBAC.
-				_, err := client.ExportOrganizationAISpend(ctx, owner.OrganizationID, codersdk.AISpendExportOptions{})
+				_, err := client.ExportOrganizationAISpend(ctx, owner.OrganizationID, codersdk.AISpendPeriodWindow{})
 				var sdkErr *codersdk.Error
 				require.ErrorAs(t, err, &sdkErr)
 				require.Equal(t, http.StatusForbidden, sdkErr.StatusCode())
 				require.Contains(t, sdkErr.Message, tc.wantMsgContains)
 			})
 		}
-	})
-
-	t.Run("DefaultsToCurrentMonthAndAggregates", func(t *testing.T) {
-		t.Parallel()
-
-		clock := quartz.NewMock(t)
-		db, ps := dbtestutil.NewDB(t)
-		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
-			GroupName: "export-default-group",
-			Clock:     clock,
-			Database:  db,
-			Pubsub:    ps,
-		})
-		ctx := testutil.Context(t, testutil.WaitLong)
-		clock.Set(time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC))
-		inMonth := time.Date(2026, time.March, 10, 8, 0, 0, 0, time.UTC)
-		prevMonth := time.Date(2026, time.February, 20, 8, 0, 0, 0, time.UTC)
-		groupID := uuid.NullUUID{UUID: group.ID, Valid: true}
-
-		// Two claude-4 interceptions for the same user aggregate into one row.
-		for _, tu := range []database.InsertAIBridgeTokenUsageParams{
-			{InputTokens: 100, OutputTokens: 50, CacheReadInputTokens: 10, CacheWriteInputTokens: 5, CostMicros: sql.NullInt64{Int64: 1000, Valid: true}},
-			{InputTokens: 200, OutputTokens: 100, CacheReadInputTokens: 20, CacheWriteInputTokens: 10, CostMicros: sql.NullInt64{Int64: 2000, Valid: true}},
-		} {
-			intc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
-				InitiatorID: targetUser.ID, Provider: "anthropic", Model: "claude-4", StartedAt: inMonth,
-			}, nil)
-			tu.InterceptionID = intc.ID
-			tu.CreatedAt = inMonth
-			tu.EffectiveGroupID = groupID
-			dbgen.AIBridgeTokenUsage(t, db, tu)
-		}
-
-		// A different model produces a separate row.
-		gptIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
-			InitiatorID: targetUser.ID, Provider: "openai", Model: "gpt-4", StartedAt: inMonth,
-		}, nil)
-		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
-			InterceptionID: gptIntc.ID, CreatedAt: inMonth, EffectiveGroupID: groupID,
-			InputTokens: 500, OutputTokens: 250, CostMicros: sql.NullInt64{Int64: 5000, Valid: true},
-		})
-
-		// Previous-month usage is outside the default window.
-		prevIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
-			InitiatorID: targetUser.ID, Provider: "anthropic", Model: "claude-4", StartedAt: prevMonth,
-		}, nil)
-		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
-			InterceptionID: prevIntc.ID, CreatedAt: prevMonth, EffectiveGroupID: groupID,
-			InputTokens: 999, CostMicros: sql.NullInt64{Int64: 9999, Valid: true},
-		})
-
-		// Usage with no effective group is excluded.
-		nullIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
-			InitiatorID: targetUser.ID, Provider: "openai", Model: "gpt-4", StartedAt: inMonth,
-		}, nil)
-		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
-			InterceptionID: nullIntc.ID, CreatedAt: inMonth,
-			InputTokens: 888, CostMicros: sql.NullInt64{Int64: 8888, Valid: true},
-		})
-
-		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, nil)
-		defer res.Body.Close()
-		require.Equal(t, http.StatusOK, res.StatusCode)
-		require.Equal(t, "text/csv", res.Header.Get("Content-Type"))
-		require.Contains(t, res.Header.Get("Content-Disposition"), "ai-spend-export.csv")
-
-		records := readAISpendExportResponse(t, res)
-		require.Equal(t, aiSpendExportCSVHeaderForTest, records[0])
-		require.Len(t, records, 3) // header + 2 data rows
-
-		userID := targetUser.ID.String()
-		groupStr := group.ID.String()
-		orgStr := group.OrganizationID.String()
-		wantStart := "2026-03-01T00:00:00Z"
-		wantEnd := "2026-04-01T00:00:00Z"
-		// Ordered by provider then model: anthropic/claude-4, then openai/gpt-4.
-		require.Equal(t, []string{userID, groupStr, orgStr, "claude-4", "anthropic", "300", "150", "30", "15", "3000", wantStart, wantEnd}, records[1])
-		require.Equal(t, []string{userID, groupStr, orgStr, "gpt-4", "openai", "500", "250", "0", "0", "5000", wantStart, wantEnd}, records[2])
-	})
-
-	t.Run("CustomPeriodHalfOpen", func(t *testing.T) {
-		t.Parallel()
-
-		clock := quartz.NewMock(t)
-		db, ps := dbtestutil.NewDB(t)
-		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
-			GroupName: "export-custom-group",
-			Clock:     clock,
-			Database:  db,
-			Pubsub:    ps,
-		})
-		ctx := testutil.Context(t, testutil.WaitLong)
-		clock.Set(time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC))
-		groupID := uuid.NullUUID{UUID: group.ID, Valid: true}
-
-		start := time.Date(2026, time.March, 10, 0, 0, 0, 0, time.UTC)
-		end := time.Date(2026, time.March, 11, 0, 0, 0, 0, time.UTC)
-
-		// At start (inclusive): included. At end (exclusive): excluded.
-		for _, at := range []time.Time{start, end} {
-			intc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
-				InitiatorID: targetUser.ID, Provider: "anthropic", Model: "claude-4", StartedAt: at,
-			}, nil)
-			dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
-				InterceptionID: intc.ID, CreatedAt: at, EffectiveGroupID: groupID,
-				InputTokens: 100, CostMicros: sql.NullInt64{Int64: 1000, Valid: true},
-			})
-		}
-
-		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, map[string]string{
-			"period_start": start.Format(time.RFC3339Nano),
-			"period_end":   end.Format(time.RFC3339Nano),
-		})
-		defer res.Body.Close()
-		require.Equal(t, http.StatusOK, res.StatusCode)
-
-		records := readAISpendExportResponse(t, res)
-		require.Len(t, records, 2) // header + only the start-boundary row
-		require.Equal(t, "1000", records[1][9])
-		require.Equal(t, start.Format(time.RFC3339), records[1][10])
-		require.Equal(t, end.Format(time.RFC3339), records[1][11])
-	})
-
-	t.Run("ExcludesNullEffectiveGroup", func(t *testing.T) {
-		t.Parallel()
-
-		clock := quartz.NewMock(t)
-		db, ps := dbtestutil.NewDB(t)
-		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
-			GroupName: "export-null-group",
-			Clock:     clock,
-			Database:  db,
-			Pubsub:    ps,
-		})
-		ctx := testutil.Context(t, testutil.WaitLong)
-		clock.Set(time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC))
-		at := time.Date(2026, time.March, 10, 8, 0, 0, 0, time.UTC)
-
-		// Usage attributed to a group is included.
-		groupedIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
-			InitiatorID: targetUser.ID, Provider: "anthropic", Model: "claude-4", StartedAt: at,
-		}, nil)
-		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
-			InterceptionID: groupedIntc.ID, CreatedAt: at,
-			EffectiveGroupID: uuid.NullUUID{UUID: group.ID, Valid: true},
-			InputTokens:      100, CostMicros: sql.NullInt64{Int64: 1000, Valid: true},
-		})
-
-		// Usage with no effective group must be excluded entirely, so its
-		// tokens and cost never reach the CSV.
-		nullIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
-			InitiatorID: targetUser.ID, Provider: "anthropic", Model: "claude-4", StartedAt: at,
-		}, nil)
-		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
-			InterceptionID: nullIntc.ID, CreatedAt: at,
-			InputTokens: 500, CostMicros: sql.NullInt64{Int64: 5000, Valid: true},
-		})
-
-		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, nil)
-		defer res.Body.Close()
-		require.Equal(t, http.StatusOK, res.StatusCode)
-
-		records := readAISpendExportResponse(t, res)
-		// Only the grouped row is present; the null-group usage is dropped, so
-		// both the row count and the aggregated values exclude it.
-		require.Len(t, records, 2)              // header + single grouped row
-		require.Equal(t, "100", records[1][5])  // input_tokens
-		require.Equal(t, "1000", records[1][9]) // cost_micros
 	})
 
 	t.Run("PeriodValidation", func(t *testing.T) {
@@ -4019,6 +3851,240 @@ func TestExportOrganizationAISpend(t *testing.T) {
 				require.Equal(t, tc.wantStatus, res.StatusCode)
 			})
 		}
+	})
+
+	t.Run("DefaultsToCurrentMonthAndAggregates", func(t *testing.T) {
+		t.Parallel()
+
+		clock := quartz.NewMock(t)
+		db, ps := dbtestutil.NewDB(t)
+		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
+			GroupName: "export-default-group",
+			Clock:     clock,
+			Database:  db,
+			Pubsub:    ps,
+		})
+		ctx := testutil.Context(t, testutil.WaitLong)
+		clock.Set(time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC))
+		inMonth := time.Date(2026, time.March, 10, 8, 0, 0, 0, time.UTC)
+		groupID := uuid.NullUUID{UUID: group.ID, Valid: true}
+
+		// Two claude-4 interceptions for the same user aggregate into one row.
+		for _, tu := range []database.InsertAIBridgeTokenUsageParams{
+			{InputTokens: 100, OutputTokens: 50, CacheReadInputTokens: 10, CacheWriteInputTokens: 5, CostMicros: sql.NullInt64{Int64: 1000, Valid: true}},
+			{InputTokens: 200, OutputTokens: 100, CacheReadInputTokens: 20, CacheWriteInputTokens: 10, CostMicros: sql.NullInt64{Int64: 2000, Valid: true}},
+		} {
+			intc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+				InitiatorID: targetUser.ID, Provider: "anthropic", Model: "claude-4", StartedAt: inMonth,
+			}, nil)
+			tu.InterceptionID = intc.ID
+			tu.CreatedAt = inMonth
+			tu.EffectiveGroupID = groupID
+			dbgen.AIBridgeTokenUsage(t, db, tu)
+		}
+
+		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, nil)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		require.Equal(t, "text/csv", res.Header.Get("Content-Type"))
+		require.Contains(t, res.Header.Get("Content-Disposition"), "ai-spend-export.csv")
+
+		records := readAISpendExportResponse(t, res)
+		require.Equal(t, aiSpendExportCSVHeaderForTest, records[0])
+		require.Len(t, records, 2) // header + single aggregated row
+
+		// The default window echoes the current UTC month.
+		require.Equal(t, []string{
+			targetUser.ID.String(), group.ID.String(), group.OrganizationID.String(),
+			"claude-4", "anthropic", "300", "150", "30", "15", "3000",
+			"2026-03-01T00:00:00Z", "2026-04-01T00:00:00Z",
+		}, records[1])
+	})
+
+	t.Run("SeparateRowPerModel", func(t *testing.T) {
+		t.Parallel()
+
+		clock := quartz.NewMock(t)
+		db, ps := dbtestutil.NewDB(t)
+		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
+			GroupName: "export-per-model-group",
+			Clock:     clock,
+			Database:  db,
+			Pubsub:    ps,
+		})
+		ctx := testutil.Context(t, testutil.WaitLong)
+		clock.Set(time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC))
+		inMonth := time.Date(2026, time.March, 10, 8, 0, 0, 0, time.UTC)
+		groupID := uuid.NullUUID{UUID: group.ID, Valid: true}
+
+		// Usage for two different models produces one row each.
+		claudeIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: targetUser.ID, Provider: "anthropic", Model: "claude-4", StartedAt: inMonth,
+		}, nil)
+		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+			InterceptionID: claudeIntc.ID, CreatedAt: inMonth, EffectiveGroupID: groupID,
+			InputTokens: 100, OutputTokens: 50, CostMicros: sql.NullInt64{Int64: 1000, Valid: true},
+		})
+		gptIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: targetUser.ID, Provider: "openai", Model: "gpt-4", StartedAt: inMonth,
+		}, nil)
+		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+			InterceptionID: gptIntc.ID, CreatedAt: inMonth, EffectiveGroupID: groupID,
+			InputTokens: 500, OutputTokens: 250, CostMicros: sql.NullInt64{Int64: 5000, Valid: true},
+		})
+
+		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, nil)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		records := readAISpendExportResponse(t, res)
+		require.Len(t, records, 3) // header + one row per model
+
+		userID := targetUser.ID.String()
+		groupStr := group.ID.String()
+		orgStr := group.OrganizationID.String()
+		wantStart := "2026-03-01T00:00:00Z"
+		wantEnd := "2026-04-01T00:00:00Z"
+		// Ordered by provider then model: anthropic/claude-4, then openai/gpt-4.
+		require.Equal(t, []string{userID, groupStr, orgStr, "claude-4", "anthropic", "100", "50", "0", "0", "1000", wantStart, wantEnd}, records[1])
+		require.Equal(t, []string{userID, groupStr, orgStr, "gpt-4", "openai", "500", "250", "0", "0", "5000", wantStart, wantEnd}, records[2])
+	})
+
+	t.Run("PreviousMonthExcluded", func(t *testing.T) {
+		t.Parallel()
+
+		clock := quartz.NewMock(t)
+		db, ps := dbtestutil.NewDB(t)
+		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
+			GroupName: "export-prev-month-group",
+			Clock:     clock,
+			Database:  db,
+			Pubsub:    ps,
+		})
+		ctx := testutil.Context(t, testutil.WaitLong)
+		clock.Set(time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC))
+		inMonth := time.Date(2026, time.March, 10, 8, 0, 0, 0, time.UTC)
+		prevMonth := time.Date(2026, time.February, 20, 8, 0, 0, 0, time.UTC)
+		groupID := uuid.NullUUID{UUID: group.ID, Valid: true}
+
+		// Current-month usage is included.
+		intc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: targetUser.ID, Provider: "anthropic", Model: "claude-4", StartedAt: inMonth,
+		}, nil)
+		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+			InterceptionID: intc.ID, CreatedAt: inMonth, EffectiveGroupID: groupID,
+			InputTokens: 100, CostMicros: sql.NullInt64{Int64: 1000, Valid: true},
+		})
+
+		// Previous-month usage falls outside the default window and is excluded.
+		prevIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: targetUser.ID, Provider: "anthropic", Model: "claude-4", StartedAt: prevMonth,
+		}, nil)
+		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+			InterceptionID: prevIntc.ID, CreatedAt: prevMonth, EffectiveGroupID: groupID,
+			InputTokens: 999, CostMicros: sql.NullInt64{Int64: 9999, Valid: true},
+		})
+
+		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, nil)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		records := readAISpendExportResponse(t, res)
+		// Only the current-month usage is present, so its values exclude the
+		// previous month.
+		require.Len(t, records, 2)              // header + current-month row
+		require.Equal(t, "100", records[1][5])  // input_tokens
+		require.Equal(t, "1000", records[1][9]) // cost_micros
+	})
+
+	t.Run("ExcludesNullEffectiveGroup", func(t *testing.T) {
+		t.Parallel()
+
+		clock := quartz.NewMock(t)
+		db, ps := dbtestutil.NewDB(t)
+		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
+			GroupName: "export-null-group",
+			Clock:     clock,
+			Database:  db,
+			Pubsub:    ps,
+		})
+		ctx := testutil.Context(t, testutil.WaitLong)
+		clock.Set(time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC))
+		at := time.Date(2026, time.March, 10, 8, 0, 0, 0, time.UTC)
+
+		// Usage attributed to a group is included.
+		groupedIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: targetUser.ID, Provider: "anthropic", Model: "claude-4", StartedAt: at,
+		}, nil)
+		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+			InterceptionID: groupedIntc.ID, CreatedAt: at,
+			EffectiveGroupID: uuid.NullUUID{UUID: group.ID, Valid: true},
+			InputTokens:      100, CostMicros: sql.NullInt64{Int64: 1000, Valid: true},
+		})
+
+		// Usage with no effective group must be excluded entirely, so its
+		// tokens and cost never reach the CSV.
+		nullIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: targetUser.ID, Provider: "anthropic", Model: "claude-4", StartedAt: at,
+		}, nil)
+		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+			InterceptionID: nullIntc.ID, CreatedAt: at,
+			InputTokens: 500, CostMicros: sql.NullInt64{Int64: 5000, Valid: true},
+		})
+
+		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, nil)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		records := readAISpendExportResponse(t, res)
+		// Only the grouped row is present; the null-group usage is dropped, so
+		// both the row count and the aggregated values exclude it.
+		require.Len(t, records, 2)              // header + single grouped row
+		require.Equal(t, "100", records[1][5])  // input_tokens
+		require.Equal(t, "1000", records[1][9]) // cost_micros
+	})
+
+	t.Run("CustomPeriodHalfOpen", func(t *testing.T) {
+		t.Parallel()
+
+		clock := quartz.NewMock(t)
+		db, ps := dbtestutil.NewDB(t)
+		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
+			GroupName: "export-custom-group",
+			Clock:     clock,
+			Database:  db,
+			Pubsub:    ps,
+		})
+		ctx := testutil.Context(t, testutil.WaitLong)
+		clock.Set(time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC))
+		groupID := uuid.NullUUID{UUID: group.ID, Valid: true}
+
+		start := time.Date(2026, time.March, 10, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2026, time.March, 11, 0, 0, 0, 0, time.UTC)
+
+		// At start (inclusive): included. At end (exclusive): excluded.
+		for _, at := range []time.Time{start, end} {
+			intc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+				InitiatorID: targetUser.ID, Provider: "anthropic", Model: "claude-4", StartedAt: at,
+			}, nil)
+			dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+				InterceptionID: intc.ID, CreatedAt: at, EffectiveGroupID: groupID,
+				InputTokens: 100, CostMicros: sql.NullInt64{Int64: 1000, Valid: true},
+			})
+		}
+
+		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, map[string]string{
+			"period_start": start.Format(time.RFC3339Nano),
+			"period_end":   end.Format(time.RFC3339Nano),
+		})
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		records := readAISpendExportResponse(t, res)
+		require.Len(t, records, 2) // header + only the start-boundary row
+		require.Equal(t, "1000", records[1][9])
+		require.Equal(t, start.Format(time.RFC3339), records[1][10])
+		require.Equal(t, end.Format(time.RFC3339), records[1][11])
 	})
 }
 
@@ -4098,7 +4164,7 @@ func TestExportOrganizationAISpendRoleAccess(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.Context(t, testutil.WaitLong)
 
-			body, err := tc.client.ExportOrganizationAISpend(ctx, owner.OrganizationID, codersdk.AISpendExportOptions{})
+			body, err := tc.client.ExportOrganizationAISpend(ctx, owner.OrganizationID, codersdk.AISpendPeriodWindow{})
 			if tc.wantErr {
 				var sdkErr *codersdk.Error
 				require.ErrorAs(t, err, &sdkErr)

--- a/enterprise/coderd/aibridge_test.go
+++ b/enterprise/coderd/aibridge_test.go
@@ -3875,7 +3875,7 @@ func TestExportOrganizationAISpend(t *testing.T) {
 			{InputTokens: 200, OutputTokens: 100, CacheReadInputTokens: 20, CacheWriteInputTokens: 10, CostMicros: sql.NullInt64{Int64: 2000, Valid: true}},
 		} {
 			intc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
-				InitiatorID: targetUser.ID, Provider: "anthropic", Model: "claude-4", StartedAt: inMonth,
+				InitiatorID: targetUser.ID, Provider: "anthropic", ProviderName: "anthropic-prod", Model: "claude-4", StartedAt: inMonth,
 			}, nil)
 			tu.InterceptionID = intc.ID
 			tu.CreatedAt = inMonth
@@ -3896,7 +3896,7 @@ func TestExportOrganizationAISpend(t *testing.T) {
 		// The default window echoes the current UTC month.
 		require.Equal(t, []string{
 			targetUser.ID.String(), group.ID.String(), group.OrganizationID.String(),
-			"claude-4", "anthropic", "300", "150", "30", "15", "3000",
+			"claude-4", "anthropic", "anthropic-prod", "300", "150", "30", "15", "3000",
 			"2026-03-01T00:00:00Z", "2026-04-01T00:00:00Z",
 		}, records[1])
 	})
@@ -3919,14 +3919,14 @@ func TestExportOrganizationAISpend(t *testing.T) {
 
 		// Usage for two different models produces one row each.
 		claudeIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
-			InitiatorID: targetUser.ID, Provider: "anthropic", Model: "claude-4", StartedAt: inMonth,
+			InitiatorID: targetUser.ID, Provider: "anthropic", ProviderName: "anthropic-prod", Model: "claude-4", StartedAt: inMonth,
 		}, nil)
 		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
 			InterceptionID: claudeIntc.ID, CreatedAt: inMonth, EffectiveGroupID: groupID,
 			InputTokens: 100, OutputTokens: 50, CostMicros: sql.NullInt64{Int64: 1000, Valid: true},
 		})
 		gptIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
-			InitiatorID: targetUser.ID, Provider: "openai", Model: "gpt-4", StartedAt: inMonth,
+			InitiatorID: targetUser.ID, Provider: "openai", ProviderName: "openai-prod", Model: "gpt-4", StartedAt: inMonth,
 		}, nil)
 		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
 			InterceptionID: gptIntc.ID, CreatedAt: inMonth, EffectiveGroupID: groupID,
@@ -3946,8 +3946,8 @@ func TestExportOrganizationAISpend(t *testing.T) {
 		wantStart := "2026-03-01T00:00:00Z"
 		wantEnd := "2026-04-01T00:00:00Z"
 		// Ordered by provider then model: anthropic/claude-4, then openai/gpt-4.
-		require.Equal(t, []string{userID, groupStr, orgStr, "claude-4", "anthropic", "100", "50", "0", "0", "1000", wantStart, wantEnd}, records[1])
-		require.Equal(t, []string{userID, groupStr, orgStr, "gpt-4", "openai", "500", "250", "0", "0", "5000", wantStart, wantEnd}, records[2])
+		require.Equal(t, []string{userID, groupStr, orgStr, "claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000", wantStart, wantEnd}, records[1])
+		require.Equal(t, []string{userID, groupStr, orgStr, "gpt-4", "openai", "openai-prod", "500", "250", "0", "0", "5000", wantStart, wantEnd}, records[2])
 	})
 
 	t.Run("PreviousMonthExcluded", func(t *testing.T) {
@@ -3992,9 +3992,9 @@ func TestExportOrganizationAISpend(t *testing.T) {
 		records := readAISpendExportResponse(t, res)
 		// Only the current-month usage is present, so its values exclude the
 		// previous month.
-		require.Len(t, records, 2)              // header + current-month row
-		require.Equal(t, "100", records[1][5])  // input_tokens
-		require.Equal(t, "1000", records[1][9]) // cost_micros
+		require.Len(t, records, 2)               // header + current-month row
+		require.Equal(t, "100", records[1][6])   // input_tokens
+		require.Equal(t, "1000", records[1][10]) // cost_micros
 	})
 
 	t.Run("ExcludesNullEffectiveGroup", func(t *testing.T) {
@@ -4039,9 +4039,9 @@ func TestExportOrganizationAISpend(t *testing.T) {
 		records := readAISpendExportResponse(t, res)
 		// Only the grouped row is present; the null-group usage is dropped, so
 		// both the row count and the aggregated values exclude it.
-		require.Len(t, records, 2)              // header + single grouped row
-		require.Equal(t, "100", records[1][5])  // input_tokens
-		require.Equal(t, "1000", records[1][9]) // cost_micros
+		require.Len(t, records, 2)               // header + single grouped row
+		require.Equal(t, "100", records[1][6])   // input_tokens
+		require.Equal(t, "1000", records[1][10]) // cost_micros
 	})
 
 	t.Run("CustomPeriodHalfOpen", func(t *testing.T) {
@@ -4082,15 +4082,15 @@ func TestExportOrganizationAISpend(t *testing.T) {
 
 		records := readAISpendExportResponse(t, res)
 		require.Len(t, records, 2) // header + only the start-boundary row
-		require.Equal(t, "1000", records[1][9])
-		require.Equal(t, start.Format(time.RFC3339), records[1][10])
-		require.Equal(t, end.Format(time.RFC3339), records[1][11])
+		require.Equal(t, "1000", records[1][10])
+		require.Equal(t, start.Format(time.RFC3339), records[1][11])
+		require.Equal(t, end.Format(time.RFC3339), records[1][12])
 	})
 }
 
 // aiSpendExportCSVHeaderForTest mirrors the handler's CSV column order.
 var aiSpendExportCSVHeaderForTest = []string{
-	"user", "group", "organization", "model", "provider",
+	"user", "group", "organization", "model", "provider", "provider_name",
 	"input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",
 	"cost_micros", "period_start", "period_end",
 }

--- a/enterprise/coderd/aibridge_test.go
+++ b/enterprise/coderd/aibridge_test.go
@@ -3893,8 +3893,8 @@ func TestExportOrganizationAISpend(t *testing.T) {
 		}
 
 		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, map[string]string{
-			"start": start.Format(time.RFC3339Nano),
-			"end":   end.Format(time.RFC3339Nano),
+			"period_start": start.Format(time.RFC3339Nano),
+			"period_end":   end.Format(time.RFC3339Nano),
 		})
 		defer res.Body.Close()
 		require.Equal(t, http.StatusOK, res.StatusCode)
@@ -3919,32 +3919,32 @@ func TestExportOrganizationAISpend(t *testing.T) {
 		}{
 			{
 				name:       "OnlyStart",
-				params:     map[string]string{"start": start.Format(time.RFC3339Nano)},
+				params:     map[string]string{"period_start": start.Format(time.RFC3339Nano)},
 				wantStatus: http.StatusBadRequest,
 			},
 			{
 				name:       "OnlyEnd",
-				params:     map[string]string{"end": start.Format(time.RFC3339Nano)},
+				params:     map[string]string{"period_end": start.Format(time.RFC3339Nano)},
 				wantStatus: http.StatusBadRequest,
 			},
 			{
 				name:       "StartEqualsEnd",
-				params:     map[string]string{"start": start.Format(time.RFC3339Nano), "end": start.Format(time.RFC3339Nano)},
+				params:     map[string]string{"period_start": start.Format(time.RFC3339Nano), "period_end": start.Format(time.RFC3339Nano)},
 				wantStatus: http.StatusBadRequest,
 			},
 			{
 				name:       "InvalidFormat",
-				params:     map[string]string{"start": "not-a-date", "end": start.AddDate(0, 0, 1).Format(time.RFC3339Nano)},
+				params:     map[string]string{"period_start": "not-a-date", "period_end": start.AddDate(0, 0, 1).Format(time.RFC3339Nano)},
 				wantStatus: http.StatusBadRequest,
 			},
 			{
 				name:       "PeriodTooLong",
-				params:     map[string]string{"start": start.Format(time.RFC3339Nano), "end": start.AddDate(0, 0, 32).Format(time.RFC3339Nano)},
+				params:     map[string]string{"period_start": start.Format(time.RFC3339Nano), "period_end": start.AddDate(0, 0, 32).Format(time.RFC3339Nano)},
 				wantStatus: http.StatusBadRequest,
 			},
 			{
 				name:       "MaxPeriodAllowed",
-				params:     map[string]string{"start": start.Format(time.RFC3339Nano), "end": start.AddDate(0, 0, 31).Format(time.RFC3339Nano)},
+				params:     map[string]string{"period_start": start.Format(time.RFC3339Nano), "period_end": start.AddDate(0, 0, 31).Format(time.RFC3339Nano)},
 				wantStatus: http.StatusOK,
 			},
 		}

--- a/enterprise/coderd/aibridge_test.go
+++ b/enterprise/coderd/aibridge_test.go
@@ -1,10 +1,15 @@
 package coderd_test
 
 import (
+	"bytes"
+	"context"
 	"database/sql"
+	"encoding/csv"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 
@@ -3689,6 +3694,365 @@ func TestOrganizationGroupsAISpendRoleAccess(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, resp.Groups, 1)
 			require.Equal(t, group.ID, resp.Groups[0].GroupID)
+		})
+	}
+}
+
+// readAISpendExportCSV parses a CSV export body into its records.
+func readAISpendExportCSV(t *testing.T, body io.Reader) [][]string {
+	t.Helper()
+	records, err := csv.NewReader(body).ReadAll()
+	require.NoError(t, err)
+	return records
+}
+
+// readAISpendExportResponse asserts the response is sent once with an accurate
+// Content-Length and returns the parsed CSV records.
+func readAISpendExportResponse(t *testing.T, res *http.Response) [][]string {
+	t.Helper()
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	require.Equal(t, strconv.Itoa(len(body)), res.Header.Get("Content-Length"))
+	return readAISpendExportCSV(t, bytes.NewReader(body))
+}
+
+// requestAISpendExport issues a raw export request so callers can inspect the
+// status code, headers, and CSV body directly.
+func requestAISpendExport(ctx context.Context, t *testing.T, client *codersdk.Client, orgID uuid.UUID, params map[string]string) *http.Response {
+	t.Helper()
+	res, err := client.Request(ctx, http.MethodGet,
+		fmt.Sprintf("/api/v2/organizations/%s/ai/spend/export", orgID),
+		nil,
+		func(r *http.Request) {
+			q := r.URL.Query()
+			for k, v := range params {
+				q.Set(k, v)
+			}
+			r.URL.RawQuery = q.Encode()
+		},
+	)
+	require.NoError(t, err)
+	return res
+}
+
+func TestExportOrganizationAISpend(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Gating", func(t *testing.T) {
+		t.Parallel()
+
+		cases := []struct {
+			name            string
+			experiments     []string
+			features        license.Features
+			wantMsgContains string
+		}{
+			{
+				name:            "RequiresLicenseFeature",
+				experiments:     []string{string(codersdk.ExperimentAIGatewayCostControl)},
+				features:        license.Features{codersdk.FeatureTemplateRBAC: 1},
+				wantMsgContains: "AI Gateway is a Premium feature",
+			},
+			{
+				name:            "RequiresExperiment",
+				experiments:     nil,
+				features:        license.Features{codersdk.FeatureTemplateRBAC: 1, codersdk.FeatureAIBridge: 1},
+				wantMsgContains: "ai-gateway-cost-control",
+			},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				dv := coderdtest.DeploymentValues(t)
+				dv.AI.BridgeConfig.Enabled = serpent.Bool(true)
+				if len(tc.experiments) > 0 {
+					dv.Experiments = tc.experiments
+				}
+				client, owner := coderdenttest.New(t, &coderdenttest.Options{
+					Options:        &coderdtest.Options{DeploymentValues: dv},
+					LicenseOptions: &coderdenttest.LicenseOptions{Features: tc.features},
+				})
+				ctx := testutil.Context(t, testutil.WaitLong)
+
+				//nolint:gocritic // Owner role is irrelevant; the request is blocked before RBAC.
+				_, err := client.ExportOrganizationAISpend(ctx, owner.OrganizationID, codersdk.AISpendExportOptions{})
+				var sdkErr *codersdk.Error
+				require.ErrorAs(t, err, &sdkErr)
+				require.Equal(t, http.StatusForbidden, sdkErr.StatusCode())
+				require.Contains(t, sdkErr.Message, tc.wantMsgContains)
+			})
+		}
+	})
+
+	t.Run("DefaultsToCurrentMonthAndAggregates", func(t *testing.T) {
+		t.Parallel()
+
+		clock := quartz.NewMock(t)
+		db, ps := dbtestutil.NewDB(t)
+		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
+			GroupName: "export-default-group",
+			Clock:     clock,
+			Database:  db,
+			Pubsub:    ps,
+		})
+		ctx := testutil.Context(t, testutil.WaitLong)
+		clock.Set(time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC))
+		inMonth := time.Date(2026, time.March, 10, 8, 0, 0, 0, time.UTC)
+		prevMonth := time.Date(2026, time.February, 20, 8, 0, 0, 0, time.UTC)
+		groupID := uuid.NullUUID{UUID: group.ID, Valid: true}
+
+		// Two claude-4 interceptions for the same user aggregate into one row.
+		for _, tu := range []database.InsertAIBridgeTokenUsageParams{
+			{InputTokens: 100, OutputTokens: 50, CacheReadInputTokens: 10, CacheWriteInputTokens: 5, CostMicros: sql.NullInt64{Int64: 1000, Valid: true}},
+			{InputTokens: 200, OutputTokens: 100, CacheReadInputTokens: 20, CacheWriteInputTokens: 10, CostMicros: sql.NullInt64{Int64: 2000, Valid: true}},
+		} {
+			intc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+				InitiatorID: targetUser.ID, Provider: "anthropic", Model: "claude-4", StartedAt: inMonth,
+			}, nil)
+			tu.InterceptionID = intc.ID
+			tu.CreatedAt = inMonth
+			tu.EffectiveGroupID = groupID
+			dbgen.AIBridgeTokenUsage(t, db, tu)
+		}
+
+		// A different model produces a separate row.
+		gptIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: targetUser.ID, Provider: "openai", Model: "gpt-4", StartedAt: inMonth,
+		}, nil)
+		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+			InterceptionID: gptIntc.ID, CreatedAt: inMonth, EffectiveGroupID: groupID,
+			InputTokens: 500, OutputTokens: 250, CostMicros: sql.NullInt64{Int64: 5000, Valid: true},
+		})
+
+		// Previous-month usage is outside the default window.
+		prevIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: targetUser.ID, Provider: "anthropic", Model: "claude-4", StartedAt: prevMonth,
+		}, nil)
+		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+			InterceptionID: prevIntc.ID, CreatedAt: prevMonth, EffectiveGroupID: groupID,
+			InputTokens: 999, CostMicros: sql.NullInt64{Int64: 9999, Valid: true},
+		})
+
+		// Usage with no effective group is excluded.
+		nullIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: targetUser.ID, Provider: "openai", Model: "gpt-4", StartedAt: inMonth,
+		}, nil)
+		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+			InterceptionID: nullIntc.ID, CreatedAt: inMonth,
+			InputTokens: 888, CostMicros: sql.NullInt64{Int64: 8888, Valid: true},
+		})
+
+		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, nil)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		require.Equal(t, "text/csv", res.Header.Get("Content-Type"))
+		require.Contains(t, res.Header.Get("Content-Disposition"), "ai-spend-export.csv")
+
+		records := readAISpendExportResponse(t, res)
+		require.Equal(t, aiSpendExportCSVHeaderForTest, records[0])
+		require.Len(t, records, 3) // header + 2 data rows
+
+		userID := targetUser.ID.String()
+		groupStr := group.ID.String()
+		orgStr := group.OrganizationID.String()
+		wantStart := "2026-03-01T00:00:00Z"
+		wantEnd := "2026-04-01T00:00:00Z"
+		// Ordered by provider then model: anthropic/claude-4, then openai/gpt-4.
+		require.Equal(t, []string{userID, groupStr, orgStr, "claude-4", "anthropic", "300", "150", "30", "15", "3000", wantStart, wantEnd}, records[1])
+		require.Equal(t, []string{userID, groupStr, orgStr, "gpt-4", "openai", "500", "250", "0", "0", "5000", wantStart, wantEnd}, records[2])
+	})
+
+	t.Run("CustomPeriodHalfOpen", func(t *testing.T) {
+		t.Parallel()
+
+		clock := quartz.NewMock(t)
+		db, ps := dbtestutil.NewDB(t)
+		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
+			GroupName: "export-custom-group",
+			Clock:     clock,
+			Database:  db,
+			Pubsub:    ps,
+		})
+		ctx := testutil.Context(t, testutil.WaitLong)
+		clock.Set(time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC))
+		groupID := uuid.NullUUID{UUID: group.ID, Valid: true}
+
+		start := time.Date(2026, time.March, 10, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2026, time.March, 11, 0, 0, 0, 0, time.UTC)
+
+		// At start (inclusive): included. At end (exclusive): excluded.
+		for _, at := range []time.Time{start, end} {
+			intc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+				InitiatorID: targetUser.ID, Provider: "anthropic", Model: "claude-4", StartedAt: at,
+			}, nil)
+			dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+				InterceptionID: intc.ID, CreatedAt: at, EffectiveGroupID: groupID,
+				InputTokens: 100, CostMicros: sql.NullInt64{Int64: 1000, Valid: true},
+			})
+		}
+
+		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, map[string]string{
+			"start": start.Format(time.RFC3339Nano),
+			"end":   end.Format(time.RFC3339Nano),
+		})
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		records := readAISpendExportResponse(t, res)
+		require.Len(t, records, 2) // header + only the start-boundary row
+		require.Equal(t, "1000", records[1][9])
+		require.Equal(t, start.Format(time.RFC3339), records[1][10])
+		require.Equal(t, end.Format(time.RFC3339), records[1][11])
+	})
+
+	t.Run("PeriodValidation", func(t *testing.T) {
+		t.Parallel()
+
+		adminClient, _, group := setupAICostControlTest(t, aiCostControlTestOptions{GroupName: "export-period-validation-group"})
+		start := time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC)
+
+		cases := []struct {
+			name       string
+			params     map[string]string
+			wantStatus int
+		}{
+			{
+				name:       "OnlyStart",
+				params:     map[string]string{"start": start.Format(time.RFC3339Nano)},
+				wantStatus: http.StatusBadRequest,
+			},
+			{
+				name:       "OnlyEnd",
+				params:     map[string]string{"end": start.Format(time.RFC3339Nano)},
+				wantStatus: http.StatusBadRequest,
+			},
+			{
+				name:       "StartEqualsEnd",
+				params:     map[string]string{"start": start.Format(time.RFC3339Nano), "end": start.Format(time.RFC3339Nano)},
+				wantStatus: http.StatusBadRequest,
+			},
+			{
+				name:       "InvalidFormat",
+				params:     map[string]string{"start": "not-a-date", "end": start.AddDate(0, 0, 1).Format(time.RFC3339Nano)},
+				wantStatus: http.StatusBadRequest,
+			},
+			{
+				name:       "PeriodTooLong",
+				params:     map[string]string{"start": start.Format(time.RFC3339Nano), "end": start.AddDate(0, 0, 32).Format(time.RFC3339Nano)},
+				wantStatus: http.StatusBadRequest,
+			},
+			{
+				name:       "MaxPeriodAllowed",
+				params:     map[string]string{"start": start.Format(time.RFC3339Nano), "end": start.AddDate(0, 0, 31).Format(time.RFC3339Nano)},
+				wantStatus: http.StatusOK,
+			},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				ctx := testutil.Context(t, testutil.WaitLong)
+
+				res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, tc.params)
+				_ = res.Body.Close()
+				require.Equal(t, tc.wantStatus, res.StatusCode)
+			})
+		}
+	})
+}
+
+// aiSpendExportCSVHeaderForTest mirrors the handler's CSV column order.
+var aiSpendExportCSVHeaderForTest = []string{
+	"user", "group", "organization", "model", "provider",
+	"input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",
+	"cost_micros", "period_start", "period_end",
+}
+
+func TestExportOrganizationAISpendRoleAccess(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	dv := coderdtest.DeploymentValues(t)
+	dv.AI.BridgeConfig.Enabled = serpent.Bool(true)
+	dv.Experiments = []string{string(codersdk.ExperimentAIGatewayCostControl)}
+	ownerClient, owner := coderdenttest.New(t, &coderdenttest.Options{
+		Options: &coderdtest.Options{DeploymentValues: dv, Database: db, Pubsub: ps},
+		LicenseOptions: &coderdenttest.LicenseOptions{
+			Features: license.Features{
+				codersdk.FeatureTemplateRBAC:          1,
+				codersdk.FeatureAIBridge:              1,
+				codersdk.FeatureMultipleOrganizations: 1,
+			},
+		},
+	})
+	userAdminClient, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID, rbac.RoleUserAdmin())
+	orgAdminClient, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID, rbac.ScopedRoleOrgAdmin(owner.OrganizationID))
+	orgUserAdminClient, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID, rbac.ScopedRoleOrgUserAdmin(owner.OrganizationID))
+	memberClient, member := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID)
+
+	otherOrg := coderdenttest.CreateOrganization(t, ownerClient, coderdenttest.CreateOrganizationOptions{})
+	otherOrgMemberClient, _ := coderdtest.CreateAnotherUser(t, ownerClient, otherOrg.ID)
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	group, err := userAdminClient.CreateGroup(ctx, owner.OrganizationID, codersdk.CreateGroupRequest{
+		Name: "export-role-access-group",
+	})
+	require.NoError(t, err)
+
+	// Seed spend for two users in the current month: the owner and a regular
+	// member. Both are attributed to the group.
+	now := time.Now().UTC()
+	for _, initiator := range []uuid.UUID{owner.UserID, member.ID} {
+		intc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: initiator, Provider: "anthropic", Model: "claude-4", StartedAt: now,
+		}, nil)
+		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+			InterceptionID:   intc.ID,
+			CreatedAt:        now,
+			EffectiveGroupID: uuid.NullUUID{UUID: group.ID, Valid: true},
+			InputTokens:      100,
+			CostMicros:       sql.NullInt64{Int64: 1000, Valid: true},
+		})
+	}
+
+	cases := []struct {
+		name        string
+		client      *codersdk.Client
+		wantUserIDs []string // expected user_id column values; empty with wantErr means 404
+		wantErr     bool
+	}{
+		// Admins see every user's rows.
+		{name: "Owner", client: ownerClient, wantUserIDs: []string{owner.UserID.String(), member.ID.String()}},
+		{name: "UserAdmin", client: userAdminClient, wantUserIDs: []string{owner.UserID.String(), member.ID.String()}},
+		{name: "OrgAdmin", client: orgAdminClient, wantUserIDs: []string{owner.UserID.String(), member.ID.String()}},
+		{name: "OrgUserAdmin", client: orgUserAdminClient, wantUserIDs: []string{owner.UserID.String(), member.ID.String()}},
+		// A regular member only sees their own row.
+		{name: "Member", client: memberClient, wantUserIDs: []string{member.ID.String()}},
+		// A member of another org cannot read this org at all.
+		{name: "OtherOrgMember", client: otherOrgMemberClient, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitLong)
+
+			body, err := tc.client.ExportOrganizationAISpend(ctx, owner.OrganizationID, codersdk.AISpendExportOptions{})
+			if tc.wantErr {
+				var sdkErr *codersdk.Error
+				require.ErrorAs(t, err, &sdkErr)
+				require.Equal(t, http.StatusNotFound, sdkErr.StatusCode())
+				return
+			}
+			require.NoError(t, err)
+			defer body.Close()
+
+			records := readAISpendExportCSV(t, body)
+			var gotUserIDs []string
+			for _, row := range records[1:] {
+				gotUserIDs = append(gotUserIDs, row[0])
+			}
+			require.ElementsMatch(t, tc.wantUserIDs, gotUserIDs)
 		})
 	}
 }

--- a/enterprise/coderd/aibridge_test.go
+++ b/enterprise/coderd/aibridge_test.go
@@ -3906,11 +3906,65 @@ func TestExportOrganizationAISpend(t *testing.T) {
 		require.Equal(t, end.Format(time.RFC3339), records[1][11])
 	})
 
+	t.Run("ExcludesNullEffectiveGroup", func(t *testing.T) {
+		t.Parallel()
+
+		clock := quartz.NewMock(t)
+		db, ps := dbtestutil.NewDB(t)
+		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
+			GroupName: "export-null-group",
+			Clock:     clock,
+			Database:  db,
+			Pubsub:    ps,
+		})
+		ctx := testutil.Context(t, testutil.WaitLong)
+		clock.Set(time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC))
+		at := time.Date(2026, time.March, 10, 8, 0, 0, 0, time.UTC)
+
+		// Usage attributed to a group is included.
+		groupedIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: targetUser.ID, Provider: "anthropic", Model: "claude-4", StartedAt: at,
+		}, nil)
+		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+			InterceptionID: groupedIntc.ID, CreatedAt: at,
+			EffectiveGroupID: uuid.NullUUID{UUID: group.ID, Valid: true},
+			InputTokens:      100, CostMicros: sql.NullInt64{Int64: 1000, Valid: true},
+		})
+
+		// Usage with no effective group must be excluded entirely, so its
+		// tokens and cost never reach the CSV.
+		nullIntc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: targetUser.ID, Provider: "anthropic", Model: "claude-4", StartedAt: at,
+		}, nil)
+		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+			InterceptionID: nullIntc.ID, CreatedAt: at,
+			InputTokens: 500, CostMicros: sql.NullInt64{Int64: 5000, Valid: true},
+		})
+
+		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, nil)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		records := readAISpendExportResponse(t, res)
+		// Only the grouped row is present; the null-group usage is dropped, so
+		// both the row count and the aggregated values exclude it.
+		require.Len(t, records, 2)              // header + single grouped row
+		require.Equal(t, "100", records[1][5])  // input_tokens
+		require.Equal(t, "1000", records[1][9]) // cost_micros
+	})
+
 	t.Run("PeriodValidation", func(t *testing.T) {
 		t.Parallel()
 
-		adminClient, _, group := setupAICostControlTest(t, aiCostControlTestOptions{GroupName: "export-period-validation-group"})
+		clock := quartz.NewMock(t)
+		clock.Set(time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC))
+		adminClient, _, group := setupAICostControlTest(t, aiCostControlTestOptions{
+			GroupName: "export-period-validation-group",
+			Clock:     clock,
+		})
 		start := time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC)
+		// Older than the default 60d retention window relative to the clock.
+		beforeRetention := time.Date(2025, time.December, 1, 0, 0, 0, 0, time.UTC)
 
 		cases := []struct {
 			name       string
@@ -3946,6 +4000,13 @@ func TestExportOrganizationAISpend(t *testing.T) {
 				name:       "MaxPeriodAllowed",
 				params:     map[string]string{"period_start": start.Format(time.RFC3339Nano), "period_end": start.AddDate(0, 0, 31).Format(time.RFC3339Nano)},
 				wantStatus: http.StatusOK,
+			},
+			{
+				// period_start predates the retention window, so the raw
+				// token usage would be purged and results incomplete.
+				name:       "BeforeRetentionWindow",
+				params:     map[string]string{"period_start": beforeRetention.Format(time.RFC3339Nano), "period_end": beforeRetention.AddDate(0, 0, 1).Format(time.RFC3339Nano)},
+				wantStatus: http.StatusBadRequest,
 			},
 		}
 		for _, tc := range cases {

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -530,6 +530,17 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 				})
 			})
 		})
+		r.Route("/organizations/{organization}/ai/spend", func(r chi.Router) {
+			// AI cost controls are a paid feature (AI Governance add-on).
+			r.Use(
+				apiKeyMiddleware,
+				httpmw.ExtractOrganizationParam(api.Database),
+				// TODO(AIGOV-443): remove once AI Gateway cost control functionality is stable.
+				httpmw.RequireExperiment(api.AGPL.Experiments, codersdk.ExperimentAIGatewayCostControl),
+				api.RequireFeatureMW(codersdk.FeatureAIBridge),
+			)
+			r.Get("/export", api.exportOrganizationAISpend)
+		})
 		r.Route("/provisionerkeys", func(r chi.Router) {
 			r.Use(
 				httpmw.ExtractProvisionerDaemonAuthenticated(httpmw.ExtractProvisionerAuthConfig{

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -540,13 +540,13 @@ export const AIProviderTypes: AIProviderType[] = [
  */
 export interface AISpendExportOptions {
 	/**
-	 * Start is the inclusive lower bound of the export window.
+	 * PeriodStart is the inclusive lower bound of the export window.
 	 */
-	readonly Start: string;
+	readonly PeriodStart: string;
 	/**
-	 * End is the exclusive upper bound of the export window.
+	 * PeriodEnd is the exclusive upper bound of the export window.
 	 */
-	readonly End: string;
+	readonly PeriodEnd: string;
 }
 
 // From codersdk/aibridge.go

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -534,6 +534,23 @@ export const AIProviderTypes: AIProviderType[] = [
 
 // From codersdk/aibridge.go
 /**
+ * AISpendExportOptions bounds the period exported by ExportOrganizationAISpend.
+ * Both bounds are optional and interpreted as UTC; zero values fall back to the
+ * current budget period on the server.
+ */
+export interface AISpendExportOptions {
+	/**
+	 * Start is the inclusive lower bound of the export window.
+	 */
+	readonly Start: string;
+	/**
+	 * End is the exclusive upper bound of the export window.
+	 */
+	readonly End: string;
+}
+
+// From codersdk/aibridge.go
+/**
  * AISpendPeriodWindow is the [Start, End) window over which AI spend is
  * aggregated.
  */

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -534,23 +534,6 @@ export const AIProviderTypes: AIProviderType[] = [
 
 // From codersdk/aibridge.go
 /**
- * AISpendExportOptions bounds the period exported by ExportOrganizationAISpend.
- * Both bounds are optional and interpreted as UTC; zero values fall back to the
- * current budget period on the server.
- */
-export interface AISpendExportOptions {
-	/**
-	 * PeriodStart is the inclusive lower bound of the export window.
-	 */
-	readonly PeriodStart: string;
-	/**
-	 * PeriodEnd is the exclusive upper bound of the export window.
-	 */
-	readonly PeriodEnd: string;
-}
-
-// From codersdk/aibridge.go
-/**
  * AISpendPeriodWindow is the [Start, End) window over which AI spend is
  * aggregated.
  */


### PR DESCRIPTION
## Description

Adds `GET /api/v2/organizations/{organization}/ai/spend/export`, returning `text/csv` with per-user, per-group, per-model, per-provider aggregated AI spend. The data is built from the raw AI Gateway token usage tables rather than the `ai_user_daily_spend` rollup, but stays consistent with it: spend is attributed through the token usage's effective group and bucketed by the token usage `created_at`, the same values the daily rollup derives from.

The period defaults to the current UTC month, narrowed to the configured AI Gateway retention window when the month begins before retained data does. Explicit `period_start`/`period_end` params must be provided together, are interpreted as UTC, and may span at most 31 days. Unlike the default period, an explicit period that begins before the retention window is rejected rather than narrowed. Every row echoes the applied bounds, so a narrowed window is visible in the export.

The endpoint requires organization-level admin permissions.

## Changes

- Add the `ExportOrganizationAISpend` query aggregating `aibridge_token_usages` joined to `aibridge_interceptions`, scoped to the organization via the effective group, resolving the username, group name, and organization name alongside their IDs.
- Add the `exportOrganizationAISpend` handler and route, gated by the `aigateway-cost-control` experiment and the `AIBridge` feature, returning the CSV in a single response.
- Add the `ExportOrganizationAISpend` codersdk client method.
- Require organization-wide `ResourceGroupMember` read, since the export aggregates every user in the organization. The per-row filter stays in `dbauthz` as defence in depth.
- Escape leading formula characters in the free-text columns, so a model or provider name recorded from an intercepted request cannot be evaluated when the CSV is opened in a spreadsheet.
- Add an index on `aibridge_token_usages (effective_group_id, created_at)`, which the period and group predicates otherwise cannot use.

Closes https://linear.app/codercom/issue/AIGOV-293/add-csv-export-for-ai-spend-data

> [!NOTE]
> Generated by Coder Agents on behalf of @ssncferreira
