### PR TITLE
fix(coderd): document workspace create status codes

### DIFF
--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -4870,8 +4870,8 @@
 					}
 				],
 				"responses": {
-					"200": {
-						"description": "OK",
+					"201": {
+						"description": "Created",
 						"schema": {
 							"$ref": "#/definitions/codersdk.Workspace"
 						}
@@ -10241,8 +10241,8 @@
 					}
 				],
 				"responses": {
-					"200": {
-						"description": "OK",
+					"201": {
+						"description": "Created",
 						"schema": {
 							"$ref": "#/definitions/codersdk.Workspace"
 						}
@@ -12219,8 +12219,8 @@
 					}
 				],
 				"responses": {
-					"200": {
-						"description": "OK",
+					"201": {
+						"description": "Created",
 						"schema": {
 							"$ref": "#/definitions/codersdk.WorkspaceBuild"
 						}

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -323,7 +323,7 @@ func (api *API) workspaceBuildByBuildNumber(rw http.ResponseWriter, r *http.Requ
 // @Tags Builds
 // @Param workspace path string true "Workspace ID" format(uuid)
 // @Param request body codersdk.CreateWorkspaceBuildRequest true "Create workspace build request"
-// @Success 200 {object} codersdk.WorkspaceBuild
+// @Success 201 {object} codersdk.WorkspaceBuild
 // @Router /api/v2/workspaces/{workspace}/builds [post]
 func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -364,7 +364,7 @@ func (api *API) workspaceByOwnerAndName(rw http.ResponseWriter, r *http.Request)
 // @Param organization path string true "Organization ID" format(uuid)
 // @Param user path string true "Username, UUID, or me"
 // @Param request body codersdk.CreateWorkspaceRequest true "Create workspace request"
-// @Success 200 {object} codersdk.Workspace
+// @Success 201 {object} codersdk.Workspace
 // @Router /api/v2/organizations/{organization}/members/{user}/workspaces [post]
 func (api *API) postWorkspacesByOrganization(rw http.ResponseWriter, r *http.Request) {
 	var (
@@ -425,7 +425,7 @@ func (api *API) postWorkspacesByOrganization(rw http.ResponseWriter, r *http.Req
 // @Tags Workspaces
 // @Param user path string true "Username, UUID, or me"
 // @Param request body codersdk.CreateWorkspaceRequest true "Create workspace request"
-// @Success 200 {object} codersdk.Workspace
+// @Success 201 {object} codersdk.Workspace
 // @Router /api/v2/users/{user}/workspaces [post]
 func (api *API) postUserWorkspaces(rw http.ResponseWriter, r *http.Request) {
 	var (


### PR DESCRIPTION
## Summary
- update the workspace/workspace-build create Swagger annotations to declare `201 Created`
- update the committed generated Swagger responses for the three affected operations

Fixes #27304

## Test plan
- `python3 -m json.tool coderd/apidoc/swagger.json`
- local assertion that the three affected Swagger operations expose `201` and no longer expose `200`
- `git diff --check`

## AI disclosure
This PR was prepared with AI assistance and manually verified with the commands above.
