### PR TITLE
fix(scripts/develop): quote project root in dependency check

### DIFF
--- a/scripts/develop/main.go
+++ b/scripts/develop/main.go
@@ -718,8 +718,8 @@ func preflight(ctx context.Context, logger slog.Logger, cfg *devConfig) error {
 	// matching the original develop.sh. Prints helpful install
 	// instructions on failure and exits non-zero.
 	libSh := filepath.Join(cfg.projectRoot, "scripts", "lib.sh")
-	libCheck := exec.CommandContext(ctx, "bash", "-c", //nolint:gosec // libSh is a project-relative path, not user input
-		"source "+libSh+" && dependencies curl git go jq make pnpm")
+	libCheck := exec.CommandContext(ctx, "bash", "-c",
+		`source "$1" && dependencies curl git go jq make pnpm`, "bash", libSh)
 	libCheck.Stdout = os.Stderr
 	libCheck.Stderr = os.Stderr
 	if err := libCheck.Run(); err != nil {


### PR DESCRIPTION
`preflight` builds the dependency check by concatenating the project root into a `bash -c` string:

```go
libCheck := exec.CommandContext(ctx, "bash", "-c",
    "source "+libSh+" && dependencies curl git go jq make pnpm")
```

When the checkout lives under a path containing a space, bash word-splits the argument and `source` receives only the first segment, so `./scripts/develop.sh` fails before it starts:

```
bash: line 1: /home/p/Documentos/GO: No such file or directory
error: running command "develop": dependency check failed, see above
```

Pass the path as a positional argument instead of interpolating it, so the shell never re-splits it. The `#nosec` annotation goes away with the concatenation that motivated it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
