### PR TITLE
fix(site): wrong border with in `<WorkspaceBuildLogsSection />`

### DIFF
--- a/site/src/pages/WorkspacePage/WorkspaceBuildLogsSection.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceBuildLogsSection.tsx
@@ -12,11 +12,11 @@ export const WorkspaceBuildLogsSection: FC<WorkspaceBuildLogsSectionProps> = ({
 	logs,
 }) => {
 	return (
-		<div className="rounded-lg border-solid overflow-hidden bg-surface-primary">
+		<div className="rounded-lg border border-solid overflow-hidden bg-surface-primary">
 			<header
 				className={cn(
 					"bg-surface-secondary border-solid border-0 border-b",
-					"px-2 py-2 pl-6 flex items-center rounded-t-lg",
+					"px-2 py-2 pl-6 flex items-center",
 					"text-sm",
 				)}
 			>


### PR DESCRIPTION
I caught this earlier today, annoyed me. `border-width` was coming through wrong due to the use of just a `border-solid`. Furthermore, there was an issue with how we round things, this is already clipped. A secondary border-radius is unnecessary.

| Old | New |
| --- | --- |
| <img width="1220" height="480" alt="PREVIEW_BUILD_LOGS_OLD" src="https://github.com/user-attachments/assets/1a2bbf48-3b65-49b6-9a29-8dc1ac587d0d" /> | <img width="1028" height="475" alt="PREVIEW_BUILD_LOGS_NEW" src="https://github.com/user-attachments/assets/3dcf00b2-4bcb-4588-adbd-ac219e981813" /> |
| <img width="220" height="220" alt="build-logs-corner-old" src="https://github.com/user-attachments/assets/97e03646-2625-4a2b-abfc-0f325fe197d1" /> | <img width="220" height="220" alt="build-logs-corner-new" src="https://github.com/user-attachments/assets/4fd90c9a-0487-49b8-a0b3-4c2f05aa8c92" /> |