### PR TITLE
fix: register ai-seats usage cron and grant usage-publisher create permission

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -666,9 +666,9 @@ var (
 				Site: rbac.Permissions(map[string][]policy.Action{
 					rbac.ResourceLicense.Type: {policy.ActionRead},
 					rbac.ResourceAiSeat.Type:  {policy.ActionRead}, // Required for GetActiveAISeatCount.
-					// The usage publisher doesn't create events, just
-					// reads/processes them.
-					rbac.ResourceUsageEvent.Type: {policy.ActionRead, policy.ActionUpdate},
+					// Create is required by the usage cron, which inserts
+					// heartbeat events under this subject.
+					rbac.ResourceUsageEvent.Type: {policy.ActionCreate, policy.ActionRead, policy.ActionUpdate},
 				}),
 				User:    []rbac.Permission{},
 				ByOrgID: map[string]rbac.OrgPermissions{},

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -666,8 +666,8 @@ var (
 				Site: rbac.Permissions(map[string][]policy.Action{
 					rbac.ResourceLicense.Type: {policy.ActionRead},
 					rbac.ResourceAiSeat.Type:  {policy.ActionRead}, // Required for GetActiveAISeatCount.
-					// Create is required by the usage cron, which inserts
-					// heartbeat events under this subject.
+					// Create is required to insert heartbeat usage events
+					// under this subject.
 					rbac.ResourceUsageEvent.Type: {policy.ActionCreate, policy.ActionRead, policy.ActionUpdate},
 				}),
 				User:    []rbac.Permission{},

--- a/enterprise/cli/server.go
+++ b/enterprise/cli/server.go
@@ -16,6 +16,7 @@ import (
 
 	agplcoderd "github.com/coder/coder/v2/coderd"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/usage/usagetypes"
 	"github.com/coder/coder/v2/cryptorand"
 	"github.com/coder/coder/v2/enterprise/audit"
 	"github.com/coder/coder/v2/enterprise/audit/backends"
@@ -145,12 +146,17 @@ func (r *RootCmd) Server(_ func()) *serpent.Command {
 		usageCron := usage.NewCron(quartz.NewReal(), options.Logger.Named("usage-cron"), options.Database, *options.UsageInserter.Load())
 		// ai-seats heartbeats track the number of users that have used an AI feature.
 		// These users consume a seat for the AI addon to our License.
-		_ = usageCron.Register(usage.CronJob{
-			Name:     "ai-seats",
-			Interval: usage.AISeatsInterval,
-			Jitter:   10 * time.Minute,
-			Fn:       usage.AISeatsHeartbeat(options.Database),
+		err = usageCron.Register(usage.CronJob{
+			Name:      "ai-seats",
+			Interval:  usage.AISeatsInterval,
+			EventType: usagetypes.UsageEventTypeHBAISeatsV1,
+			Jitter:    10 * time.Minute,
+			Fn:        usage.AISeatsHeartbeat(options.Database),
 		})
+		if err != nil {
+			_ = closers.Close()
+			return nil, nil, xerrors.Errorf("register ai-seats usage cron job: %w", err)
+		}
 		usageCron.Start(ctx)
 		closers.Add(usageCron)
 

--- a/enterprise/coderd/usage/cron_test.go
+++ b/enterprise/coderd/usage/cron_test.go
@@ -80,6 +80,30 @@ func TestCron(t *testing.T) {
 	})
 }
 
+// TestUsagePublisherCanInsertHeartbeats wraps a mock database with
+// dbauthz to verify that the AsUsagePublisher subject can insert
+// heartbeat usage events; the cron performs its inserts under this
+// subject, so a missing usage_event create permission would make every
+// heartbeat insert fail authz at runtime.
+func TestUsagePublisherCanInsertHeartbeats(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+
+	db.EXPECT().Wrappers().Return([]string{}).AnyTimes()
+	db.EXPECT().InsertUsageEvent(gomock.Any(), gomock.Any()).Return(nil)
+
+	authz := rbac.NewStrictAuthorizer(prometheus.NewRegistry())
+	authzDB := dbauthz.New(db, authz, slogtest.Make(t, nil), coderdtest.AccessControlStorePointer())
+
+	//nolint:gocritic // Testing the usage publisher subject is the point.
+	ctx := dbauthz.AsUsagePublisher(testutil.Context(t, testutil.WaitLong))
+	inserter := usage.NewDBInserter()
+	err := inserter.InsertHeartbeatUsageEvent(ctx, authzDB, "hb_ai_seats_v1:2025-01-01_00:00:00", usagetypes.HBAISeats{Count: 1})
+	require.NoError(t, err)
+}
+
 // TestAISeatsHeartbeat checks that AISeatsHeartbeat returns the
 // correct event type and count. It wraps a mock database with dbauthz
 // to verify that the AsUsagePublisher subject has the required


### PR DESCRIPTION
The ai-seats usage cron never ran on main: its `CronJob` was registered without the required `EventType`, so `Register` rejected it ("event type must be a heartbeat type"), and the error was discarded with `_ =`, leaving the job out of the cron's job list entirely. ai-seats heartbeats drive AI addon seat consumption on the License, so no seat usage events are being generated today.

Registering the job also surfaces a second latent bug: `subjectUsagePublisher` lacked `usage_event` create permission (its doc comment already claimed create), so every heartbeat insert performed under `AsUsagePublisher` would fail authz the moment the cron actually ran. This PR grants the permission and adds a strict-authorizer regression test covering the insert path.

Split out of #27312 per review feedback so this unblocked billing fix is not coupled to that feature's external Tallyman release gate. The two PRs are independent: both carry the identical usage-publisher create permission hunk, so they can land in either order.

