### PR TITLE
docs: remove beta labels from user secrets

### DIFF
--- a/docs/admin/security/secrets.md
+++ b/docs/admin/security/secrets.md
@@ -44,7 +44,7 @@ Users can view their public key in their account settings:
 > SSH keys are never stored in Coder workspaces, and are fetched only when
 > SSH is invoked. The keys are held in-memory and never written to disk.
 
-## User secrets (Beta)
+## User secrets
 
 User secrets are developer-managed values that Coder injects at workspace start.
 If a user secret targets the same environment variable name or file path as a

--- a/docs/install/releases/feature-stages.md
+++ b/docs/install/releases/feature-stages.md
@@ -108,7 +108,6 @@ available in the documentation.
 |------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
 | [MCP Server](../../ai-coder/mcp-server.md)                                   | Connect external AI coding agents to Coder using its built-in Model Context Protocol server.               |
 | [JetBrains Toolbox](../../user-guides/workspace-access/jetbrains/toolbox.md) | Connect to and manage your Coder workspaces from the JetBrains Toolbox app.                                |
-| [User secrets](../../user-guides/user-secrets.md)                            | Store secret values in Coder and automatically inject them into workspaces                                 |
 | [Coder Agents](../../ai-coder/agents/index.md)                               | Delegate development work to coding agents in your deployment with Coder Agents, a chat interface and API. |
 <!-- END: available-beta-features -->
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -401,8 +401,7 @@
 					"title": "User secrets",
 					"description": "Store secret values in Coder and automatically inject them into workspaces",
 					"path": "./user-guides/user-secrets.md",
-					"icon_path": "./images/icons/secrets.svg",
-					"state": ["beta"]
+					"icon_path": "./images/icons/secrets.svg"
 				}
 			]
 		},

--- a/docs/user-guides/user-secrets.md
+++ b/docs/user-guides/user-secrets.md
@@ -1,11 +1,7 @@
-# User secrets (Beta)
+# User secrets
 
 User secrets let you store secret values in Coder and make them available in
 every workspace you own.
-
-> [!NOTE]
-> User secrets are in Beta and may change. For more information, see
-> [feature stages](../install/releases/feature-stages.md#beta).
 
 ## How user secrets work
 


### PR DESCRIPTION
User secrets are GA, so the docs shouldn't still label the feature as Beta.

## Changes

- Drop `(Beta)` from the `User secrets` page title and remove the beta note callout.
- Drop `(Beta)` from the `User secrets` heading in the admin secrets guide.
- Remove `"state": ["beta"]` from the User secrets route in `manifest.json`.
- Regenerate `feature-stages.md` (`scripts/release/docs_update_feature_stages.sh`), which drops the User secrets row from the beta table.

Preview: https://coder.com/docs/@matifali/remove-user-secrets-beta/user-guides/user-secrets

> [!NOTE]
> `site/src/pages/UserSettingsPage/SecretsPage/SecretsPageView.tsx` still renders a `FeatureStageBadge contentType="beta"` on the Secrets settings page. Left out of this docs-only PR, but it should follow so the UI and docs agree.

Closes PLAT-381

> 🤖 This PR was created with the help of Coder Agents, and needs a human review.  🧑‍💻
