### PR TITLE
chore(site): remove beta labels from user secrets dashboard

### DIFF
--- a/site/src/pages/UserSettingsPage/SecretsPage/SecretsPageView.tsx
+++ b/site/src/pages/UserSettingsPage/SecretsPage/SecretsPageView.tsx
@@ -7,7 +7,6 @@ import type {
 } from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Button } from "#/components/Button/Button";
-import { FeatureStageBadge } from "#/components/FeatureStageBadge/FeatureStageBadge";
 import { Link } from "#/components/Link/Link";
 import {
 	SettingsHeader,
@@ -99,11 +98,7 @@ export const SecretsPageView: FC<SecretsPageViewProps> = ({
 					</div>
 				}
 			>
-				<SettingsHeaderTitle
-					tooltip={<FeatureStageBadge contentType="beta" size="md" />}
-				>
-					Secrets
-				</SettingsHeaderTitle>
+				<SettingsHeaderTitle>Secrets</SettingsHeaderTitle>
 				<SettingsHeaderDescription>
 					Secrets with an environment variable or file path are injected into
 					workspaces you own when they start. Each environment variable and file

--- a/site/src/pages/UserSettingsPage/Sidebar.tsx
+++ b/site/src/pages/UserSettingsPage/Sidebar.tsx
@@ -1,4 +1,3 @@
-import { FeatureStageBadge } from "#/components/FeatureStageBadge/FeatureStageBadge";
 import {
 	Sidebar as BaseSidebar,
 	SettingsSidebarNavItem,
@@ -40,16 +39,7 @@ export const Sidebar: React.FC = () => {
 					SSH Keys
 				</SettingsSidebarNavItem>
 				<SettingsSidebarNavItem href="tokens">Tokens</SettingsSidebarNavItem>
-				<SettingsSidebarNavItem href="secrets">
-					<span className="flex min-w-0 items-center gap-2">
-						<span>Secrets</span>
-						<FeatureStageBadge
-							aria-hidden="true"
-							contentType="beta"
-							size="sm"
-						/>
-					</span>
-				</SettingsSidebarNavItem>
+				<SettingsSidebarNavItem href="secrets">Secrets</SettingsSidebarNavItem>
 				<SettingsSidebarNavItem href="notifications">
 					Notifications
 				</SettingsSidebarNavItem>


### PR DESCRIPTION
User secrets goes GA next release, so the Beta badges in the dashboard need to go.

## Changes

- Removed the Beta badge next to **Secrets** in the user settings sidebar.
- Removed the Beta badge from the Secrets page header.

Docs side is handled in #27510. The two are independent, so they can merge in any order as long as both land in the same release.

Closes PLAT-374

> 🤖 This PR was created with the help of Coder Agents, and needs a human review.  🧑‍💻
