### PR TITLE
🤖 fix(site/e2e): drop flaky success-toast assertion in createUser

### DIFF
--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -1355,8 +1355,11 @@ export async function createUser(
 	const passwordField = page.locator("input[name=password]");
 	await passwordField.fill(password);
 	await page.getByRole("button", { name: /save/i }).click();
-	await expect(page.getByText(/created successfully/)).toBeVisible();
 
+	// Creation success redirects back to the Users page and adds the user to
+	// the table. We assert on those deterministic outcomes rather than the
+	// success toast, which auto-dismisses and races with the redirect. The
+	// toast itself is covered by the CreateUserPage stories.
 	await expect(page).toHaveTitle("Users - Coder");
 	const addedRow = page.locator("tr", { hasText: email });
 	await expect(addedRow).toBeVisible();


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Fixes the flake reported in coder/internal#1627 (`flake: setup deployment (create user)`).

## Problem

The shared `createUser` e2e helper gated on the auto-dismissing sonner success toast:

```ts
await expect(page.getByText(/created successfully/)).toBeVisible();
```

That toast comes from `toast.promise(...)` in `CreateUserPage.tsx`, whose `onSuccess` simultaneously redirects back to the Users page. The success toast has sonner's default \~4s duration and races against the redirect and previously-stacked toasts. When the create mutation resolves quickly (the failing CI run reached `networkidle` \~72ms after Save, then showed no toast for 5s) the transient success state can be missed within Playwright's 5s assertion window. Because this lives in the `testsSetup` project, a single miss fails setup and blocks the remaining \~93 e2e tests.

## Fix

Remove the ephemeral toast assertion and rely on the deterministic post-conditions already asserted immediately afterwards:

* redirect back to the Users page (`toHaveTitle("Users - Coder")`), which only happens on success, and
* the new user's row appearing in the table.

No coverage is lost: the success toast itself is exercised by the `CreateUserPage` `ShowsSuccessNotificationOnSubmit` story.

## Validation

Built the e2e binary + frontend and ran the exact repro from the issue (`--project=testsSetup --grep "setup deployment"`):

* Pre-fix: 22 runs (12 normal + 10 under heavy CPU load to mimic the busy CI host) all passed, confirming the failure is a rare timing flake rather than a deterministic bug.
* Post-fix: 10 runs under heavy CPU load, 10/10 passed.

<details><summary>Decision log</summary>

* Reproduced the CI environment in a Coder-on-Coder workspace and ran the issue's exact repro command repeatedly, including under 120-200 `yes` processes of CPU contention (run time rose from \~14s to \~35s). The exact transient did not reproduce, consistent with the bot's "flaky / timing-sensitive" classification.
* Traced the assertion to `toast.promise` in `CreateUserPage.tsx` and the sonner `Toaster` (no custom duration, so sonner's \~4s default applies). The `onSuccess` redirect races the toast lifecycle.
* Chose to drop the toast assertion rather than add waits/retries: asserting on an auto-dismissing toast is an e2e anti-pattern, and the redirect + row assertions are stronger, deterministic proof of creation. Toast behaviour stays covered at the component level via Storybook.

</details>