### PR TITLE
docs: document per-template agents_allowed

### DIFF
--- a/docs/ai-coder/agents/platform-controls/index.md
+++ b/docs/ai-coder/agents/platform-controls/index.md
@@ -79,14 +79,15 @@ Python backend services in the payments repo" — platform teams can guide the
 agent toward the correct infrastructure without requiring developers to
 understand template selection at all.
 
-Administrators can also restrict which templates are available to agents
-using each template's **Allow Coder Agents** setting, either on the
-template's settings page or at **Agents** > **Settings** >
-**Manage Agents** > **Templates**. Templates allow agents by default; when
-the setting is disabled, the agent cannot see or provision workspaces from
-that template. This is separate from what developers see when manually
-creating workspaces, so you can apply stricter policies to agent-created
-workspaces without affecting the manual workspace experience.
+Administrators can also restrict which templates are available to agents at
+**Agents** > **Settings** > **Manage Agents** > **Templates**. Use the switches
+in the **New workspaces** column. The same control is available on each
+individual template's settings page as **Allow Coder Agents to create
+workspaces with this template**. Templates allow agents by default. When you
+disable the control, the agent cannot see or provision workspaces from that
+template. This is separate from what developers see when manually creating
+workspaces, so you can apply stricter policies to agent-created workspaces
+without affecting the manual workspace experience.
 
 See [Template Optimization](./template-optimization.md) for best practices on writing
 discoverable descriptions, restricting template visibility, configuring network

--- a/docs/ai-coder/agents/platform-controls/index.md
+++ b/docs/ai-coder/agents/platform-controls/index.md
@@ -80,13 +80,13 @@ agent toward the correct infrastructure without requiring developers to
 understand template selection at all.
 
 Administrators can also restrict which templates are available to agents
-using the template allowlist at **Agents** > **Settings** >
-**Manage Agents** > **Templates**. When the allowlist is configured, the
-agent can only see and provision workspaces from the selected templates.
-When the allowlist is empty, all templates are available. This is separate
-from what developers see when manually creating workspaces, so you can apply
-stricter policies to agent-created workspaces without affecting the manual
-workspace experience.
+using each template's **Allow Coder Agents** setting, either on the
+template's settings page or at **Agents** > **Settings** >
+**Manage Agents** > **Templates**. Templates allow agents by default; when
+the setting is disabled, the agent cannot see or provision workspaces from
+that template. This is separate from what developers see when manually
+creating workspaces, so you can apply stricter policies to agent-created
+workspaces without affecting the manual workspace experience.
 
 See [Template Optimization](./template-optimization.md) for best practices on writing
 discoverable descriptions, restricting template visibility, configuring network

--- a/docs/ai-coder/agents/platform-controls/index.md
+++ b/docs/ai-coder/agents/platform-controls/index.md
@@ -79,15 +79,12 @@ Python backend services in the payments repo" — platform teams can guide the
 agent toward the correct infrastructure without requiring developers to
 understand template selection at all.
 
-Administrators can also restrict which templates are available to agents at
-**Agents** > **Settings** > **Manage Agents** > **Templates**. Use the switches
-in the **New workspaces** column. The same control is available on each
-individual template's settings page as **Allow Coder Agents to create
-workspaces with this template**. Templates allow agents by default. When you
-disable the control, the agent cannot see or provision workspaces from that
-template. This is separate from what developers see when manually creating
-workspaces, so you can apply stricter policies to agent-created workspaces
-without affecting the manual workspace experience.
+Administrators can also restrict which templates are available to agents at **Agents** > **Settings** > **Manage Agents** > **Templates**.
+Use the switch for each template in the list.
+The same control is available on each individual template's settings page as **Allow Coder Agents to create workspaces with this template**.
+Templates allow agents by default.
+When you disable the control, the agent cannot see or provision workspaces from that template.
+This is separate from what developers see when manually creating workspaces, so you can apply stricter policies to agent-created workspaces without affecting the manual workspace experience.
 
 See [Template Optimization](./template-optimization.md) for best practices on writing
 discoverable descriptions, restricting template visibility, configuring network

--- a/docs/ai-coder/agents/platform-controls/index.md
+++ b/docs/ai-coder/agents/platform-controls/index.md
@@ -81,7 +81,7 @@ understand template selection at all.
 
 Administrators can also restrict which templates are available to agents at **Agents** > **Settings** > **Manage Agents** > **Templates**.
 Use the switch for each template in the list.
-The same control is available on each individual template's settings page as **Allow Coder Agents to create workspaces with this template**.
+The same control is available on each individual template's settings page as **Allow Coder Agents to create workspaces using this template**.
 Templates allow agents by default.
 When you disable the control, the agent cannot see or provision workspaces from that template.
 This is separate from what developers see when manually creating workspaces, so you can apply stricter policies to agent-created workspaces without affecting the manual workspace experience.

--- a/docs/ai-coder/agents/platform-controls/index.md
+++ b/docs/ai-coder/agents/platform-controls/index.md
@@ -83,8 +83,8 @@ Administrators can also restrict which templates are available to agents at **Ag
 Use the switch for each template in the list.
 The same control is available on each individual template's settings page as **Allow Coder Agents to create workspaces using this template**.
 Templates allow agents by default.
-When you disable the control, the agent cannot see or provision workspaces from that template.
-This is separate from what developers see when manually creating workspaces, so you can apply stricter policies to agent-created workspaces without affecting the manual workspace experience.
+When you disable the control, the agent cannot read the template or provision workspaces from it.
+This is separate from what developers observe when manually creating workspaces, so you can apply stricter policies to agent-created workspaces without affecting the manual workspace experience.
 
 See [Template Optimization](./template-optimization.md) for best practices on writing
 discoverable descriptions, restricting template visibility, configuring network

--- a/docs/ai-coder/agents/platform-controls/template-optimization.md
+++ b/docs/ai-coder/agents/platform-controls/template-optimization.md
@@ -4,36 +4,30 @@ Not every chat with Coder Agents requires a workspace. A workspace is only provi
 agent decides it needs compute — to read files, write code, run commands, or
 execute builds.
 
-When a workspace is needed, the agent reads the available templates, selects
-the appropriate one based on its name and description, and provisions a
-workspace automatically. Administrators can
-[restrict which templates the agent can see](#restrict-available-templates).
+When a workspace is needed, the agent reads the available templates, selects the appropriate one based on its name and description, and provisions a workspace automatically.
+Administrators can [restrict which templates the agent can see](#restrict-available-templates).
 
 This guide covers best practices for creating templates that are discoverable
 and useful to Coder Agents.
 
 ## Restrict available templates
 
-By default, every template allows Coder Agents. Administrators can block
-individual templates from the **New workspaces** column or from each template's
-settings page.
+By default, every template allows Coder Agents.
+Administrators can block individual templates from the template list or from each template's settings page.
 
 To change which templates agents can use:
 
 1. Navigate to **Agents** > **Settings** > **Manage Agents** > **Templates**.
 2. Toggle the switch for each template.
 
-The same control is available on each template's settings page as
-**Allow Coder Agents to create workspaces with this template**.
+The same control is available on each template's settings page as **Allow Coder Agents to create workspaces with this template**.
 
-When a template does not allow agents, the agent's `list_templates`,
-`read_template`, and `create_workspace` tools exclude it. The agent cannot
-see or provision workspaces from that template.
+When a template does not allow agents, the agent's `list_templates`, `read_template`, and `create_workspace` tools exclude it.
+The agent cannot see or provision workspaces from that template.
 
-The setting only affects agent-created workspaces. Developers can still
-manually create workspaces from any template they have access to. This lets
-platform teams apply stricter policies to agent workloads without affecting
-the manual workspace experience.
+The setting only affects agent-created workspaces.
+Developers can still manually create workspaces from any template they have access to.
+This lets platform teams apply stricter policies to agent workloads without affecting the manual workspace experience.
 
 ## Write discoverable template descriptions
 

--- a/docs/ai-coder/agents/platform-controls/template-optimization.md
+++ b/docs/ai-coder/agents/platform-controls/template-optimization.md
@@ -7,32 +7,30 @@ execute builds.
 When a workspace is needed, the agent reads the available templates, selects
 the appropriate one based on its name and description, and provisions a
 workspace automatically. Administrators can restrict which templates the agent
-can see using the [template allowlist](#restrict-available-templates).
+can see using each template's
+[**Allow Coder Agents** setting](#restrict-available-templates).
 
 This guide covers best practices for creating templates that are discoverable
 and useful to Coder Agents.
 
 ## Restrict available templates
 
-By default, the agent can see and provision any template in the deployment.
-Administrators can restrict this to a specific set of templates using the
-template allowlist.
+By default, every template allows Coder Agents. Administrators can block
+individual templates with the per-template **Allow Coder Agents** setting.
 
-To configure the allowlist:
+To change which templates agents can use:
 
 1. Navigate to **Agents** > **Settings** > **Manage Agents** > **Templates**.
-2. Select the templates you want agents to be able to use.
-3. Click **Save**.
+2. Toggle **Agents allowed** for each template.
 
-When the allowlist is configured, the agent's `list_templates`,
-`read_template`, and `create_workspace` tools are filtered to only include
-the selected templates. The agent cannot see or provision templates that are
-not on the list.
+The setting is also available on each template's settings page as
+**Allow Coder Agents to use this template**.
 
-When no templates are selected, the allowlist is inactive and all templates
-are available to agents.
+When a template does not allow agents, the agent's `list_templates`,
+`read_template`, and `create_workspace` tools exclude it. The agent cannot
+see or provision workspaces from that template.
 
-The allowlist only affects agent-created workspaces. Developers can still
+The setting only affects agent-created workspaces. Developers can still
 manually create workspaces from any template they have access to. This lets
 platform teams apply stricter policies to agent workloads without affecting
 the manual workspace experience.

--- a/docs/ai-coder/agents/platform-controls/template-optimization.md
+++ b/docs/ai-coder/agents/platform-controls/template-optimization.md
@@ -20,7 +20,7 @@ To change which templates agents can use:
 1. Navigate to **Agents** > **Settings** > **Manage Agents** > **Templates**.
 2. Toggle the switch for each template.
 
-The same control is available on each template's settings page as **Allow Coder Agents to create workspaces with this template**.
+The same control is available on each template's settings page as **Allow Coder Agents to create workspaces using this template**.
 
 When a template does not allow agents, the agent's `list_templates`, `read_template`, and `create_workspace` tools exclude it.
 The agent cannot see or provision workspaces from that template.

--- a/docs/ai-coder/agents/platform-controls/template-optimization.md
+++ b/docs/ai-coder/agents/platform-controls/template-optimization.md
@@ -6,9 +6,8 @@ execute builds.
 
 When a workspace is needed, the agent reads the available templates, selects
 the appropriate one based on its name and description, and provisions a
-workspace automatically. Administrators can restrict which templates the agent
-can see using each template's
-[**Allow Coder Agents** setting](#restrict-available-templates).
+workspace automatically. Administrators can
+[restrict which templates the agent can see](#restrict-available-templates).
 
 This guide covers best practices for creating templates that are discoverable
 and useful to Coder Agents.
@@ -16,15 +15,16 @@ and useful to Coder Agents.
 ## Restrict available templates
 
 By default, every template allows Coder Agents. Administrators can block
-individual templates with the per-template **Allow Coder Agents** setting.
+individual templates from the **New workspaces** column or from each template's
+settings page.
 
 To change which templates agents can use:
 
 1. Navigate to **Agents** > **Settings** > **Manage Agents** > **Templates**.
-2. Toggle **Agents allowed** for each template.
+2. Toggle the switch for each template.
 
-The setting is also available on each template's settings page as
-**Allow Coder Agents to use this template**.
+The same control is available on each template's settings page as
+**Allow Coder Agents to create workspaces with this template**.
 
 When a template does not allow agents, the agent's `list_templates`,
 `read_template`, and `create_workspace` tools exclude it. The agent cannot

--- a/docs/ai-coder/agents/platform-controls/template-optimization.md
+++ b/docs/ai-coder/agents/platform-controls/template-optimization.md
@@ -5,7 +5,7 @@ agent decides it needs compute — to read files, write code, run commands, or
 execute builds.
 
 When a workspace is needed, the agent reads the available templates, selects the appropriate one based on its name and description, and provisions a workspace automatically.
-Administrators can [restrict which templates the agent can see](#restrict-available-templates).
+Administrators can [restrict which templates the agent can use](#restrict-available-templates).
 
 This guide covers best practices for creating templates that are discoverable
 and useful to Coder Agents.
@@ -23,11 +23,11 @@ To change which templates agents can use:
 The same control is available on each template's settings page as **Allow Coder Agents to create workspaces using this template**.
 
 When a template does not allow agents, the agent's `list_templates`, `read_template`, and `create_workspace` tools exclude it.
-The agent cannot see or provision workspaces from that template.
+The agent cannot read the template or provision workspaces from it.
 
 The setting only affects agent-created workspaces.
-Developers can still manually create workspaces from any template they have access to.
-This lets platform teams apply stricter policies to agent workloads without affecting the manual workspace experience.
+Developers can still manually create workspaces from any template to which they have access.
+With this setting, platform teams can apply stricter policies to agent workloads without affecting the manual workspace experience.
 
 ## Write discoverable template descriptions
 

--- a/docs/ai-coder/agents/tools/index.md
+++ b/docs/ai-coder/agents/tools/index.md
@@ -44,7 +44,7 @@ code), it provisions a workspace using three tools:
 | `read_template`    | Read a template's parameters and presets                  |
 | `create_workspace` | Create the workspace from a chosen template               |
 
-Administrators can restrict which templates these tools can see with the switches on the [Templates page](../platform-controls/template-optimization.md#restrict-available-templates).
+Administrators can restrict which templates these tools can use with the switches on the [Templates page](../platform-controls/template-optimization.md#restrict-available-templates).
 
 ### list_templates
 

--- a/docs/ai-coder/agents/tools/index.md
+++ b/docs/ai-coder/agents/tools/index.md
@@ -44,8 +44,9 @@ code), it provisions a workspace using three tools:
 | `read_template`    | Read a template's parameters and presets                  |
 | `create_workspace` | Create the workspace from a chosen template               |
 
-Administrators can restrict which templates these tools can see with the
-[template allowlist](../platform-controls/template-optimization.md#restrict-available-templates).
+Administrators can restrict which templates these tools can see with each
+template's [**Allow Coder Agents**
+setting](../platform-controls/template-optimization.md#restrict-available-templates).
 
 ### list_templates
 
@@ -214,4 +215,4 @@ Guardrails:
   recommended.
 - The tool is idempotent: if the chat already has a workspace building or
   running, that workspace is returned instead of creating a duplicate.
-- Templates outside the administrator's allowlist are rejected.
+- Templates that do not allow Coder Agents are rejected.

--- a/docs/ai-coder/agents/tools/index.md
+++ b/docs/ai-coder/agents/tools/index.md
@@ -44,9 +44,9 @@ code), it provisions a workspace using three tools:
 | `read_template`    | Read a template's parameters and presets                  |
 | `create_workspace` | Create the workspace from a chosen template               |
 
-Administrators can restrict which templates these tools can see with each
-template's [**Allow Coder Agents**
-setting](../platform-controls/template-optimization.md#restrict-available-templates).
+Administrators can restrict which templates these tools can see with the
+switches in the [**New workspaces**
+column](../platform-controls/template-optimization.md#restrict-available-templates).
 
 ### list_templates
 

--- a/docs/ai-coder/agents/tools/index.md
+++ b/docs/ai-coder/agents/tools/index.md
@@ -44,9 +44,7 @@ code), it provisions a workspace using three tools:
 | `read_template`    | Read a template's parameters and presets                  |
 | `create_workspace` | Create the workspace from a chosen template               |
 
-Administrators can restrict which templates these tools can see with the
-switches in the [**New workspaces**
-column](../platform-controls/template-optimization.md#restrict-available-templates).
+Administrators can restrict which templates these tools can see with the switches on the [Templates page](../platform-controls/template-optimization.md#restrict-available-templates).
 
 ### list_templates
 


### PR DESCRIPTION
Relates to CODAGT-713

Depends on #27517

This updates the Coder Agents platform controls documentation for the per-template `agents_allowed` model. It replaces the deployment-wide allowlist instructions with the **Agents allowed** controls in AI Settings and template settings, documents that templates allow agents by default, and explains that disabled templates are excluded from `list_templates`, `read_template`, and `create_workspace`.

This is the final PR in the stack and aligns the template routing and optimization guidance with the database, API, frontend, cleanup, and CLI changes in the preceding PRs.
