### PR TITLE
fix(site): freeze motion animations during Pixel captures

### DIFF
--- a/site/.storybook/preview.tsx
+++ b/site/.storybook/preview.tsx
@@ -1,7 +1,9 @@
 import "../src/index.css";
 import "../src/theme/globalFonts";
+import { isPixel } from "@coder/pixel-storybook/storyapi";
 import { DecoratorHelpers } from "@storybook/addon-themes";
 import type { Decorator, Parameters } from "@storybook/react-vite";
+import { MotionConfig } from "motion/react";
 import { StrictMode } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { withRouter } from "storybook-addon-remix-react-router";
@@ -120,4 +122,15 @@ const withTheme: Decorator = (Story, context) => {
 	);
 };
 
-export const decorators: Decorator[] = [withRouter, withQuery, withTheme];
+const withStaticMotion: Decorator = (Story) => (
+	<MotionConfig skipAnimations={isPixel()}>
+		<Story />
+	</MotionConfig>
+);
+
+export const decorators: Decorator[] = [
+	withRouter,
+	withQuery,
+	withTheme,
+	withStaticMotion,
+];

--- a/site/.storybook/preview.tsx
+++ b/site/.storybook/preview.tsx
@@ -1,5 +1,6 @@
 import "../src/index.css";
 import "../src/theme/globalFonts";
+import { isPixel } from "@coder/pixel-storybook";
 import { ThemeProvider as EmotionThemeProvider } from "@emotion/react";
 import CssBaseline from "@mui/material/CssBaseline";
 import {
@@ -9,6 +10,7 @@ import {
 import { DecoratorHelpers } from "@storybook/addon-themes";
 import type { Decorator, Loader, Parameters } from "@storybook/react-vite";
 import isChromatic from "chromatic/isChromatic";
+import { MotionConfig } from "motion/react";
 import { StrictMode } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { withRouter } from "storybook-addon-remix-react-router";
@@ -131,7 +133,18 @@ const withTheme: Decorator = (Story, context) => {
 	);
 };
 
-export const decorators: Decorator[] = [withRouter, withQuery, withTheme];
+const withStaticMotion: Decorator = (Story) => (
+	<MotionConfig skipAnimations={isPixel()}>
+		<Story />
+	</MotionConfig>
+);
+
+export const decorators: Decorator[] = [
+	withRouter,
+	withQuery,
+	withTheme,
+	withStaticMotion,
+];
 
 // Try to fix storybook rendering fonts inconsistently
 // https://www.chromatic.com/docs/font-loading/#solution-c-check-fonts-have-loaded-in-a-loader

--- a/site/src/pages/AgentsPage/components/ChatElements/Shimmer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/Shimmer.tsx
@@ -37,34 +37,21 @@ const ShimmerComponent = ({
 	duration = 2,
 	spread = 2,
 }: TextShimmerProps) => {
-	// Pixel screenshots are taken once the DOM stops mutating. The shimmer
-	// rewrites inline styles on every frame, so a capture never sees a settled
-	// DOM and the resulting baseline is nondeterministic. Render static text
-	// instead while a capture is in progress.
-	if (isPixel()) {
-		return (
-			<Component
-				className={cn(
-					"relative inline-block text-content-secondary",
-					className,
-				)}
-			>
-				{children}
-			</Component>
-		);
-	}
-
 	const MotionComponent = getMotionComponent(
 		Component as keyof JSX.IntrinsicElements,
 	);
 
 	const dynamicSpread = (children?.length ?? 0) * spread;
 
+	// Pixel screenshots are taken once the DOM stops mutating. Animating the
+	// gradient rewrites the element's inline style on every frame, so a capture
+	// never sees a settled DOM.
+	const animate = isPixel() ? undefined : { backgroundPosition: "0% center" };
+
 	return (
 		<MotionConfig reducedMotion="user">
 			<MotionComponent
-				data-pixel="ignore"
-				animate={{ backgroundPosition: "0% center" }}
+				animate={animate}
 				className={cn(
 					"relative inline-block bg-[length:250%_100%,auto] bg-clip-text text-transparent",
 					"[--bg:linear-gradient(90deg,#0000_calc(50%-var(--spread)),hsl(var(--surface-primary)),#0000_calc(50%+var(--spread)))] [background-repeat:no-repeat,padding-box]",

--- a/site/src/pages/AgentsPage/components/ChatElements/Shimmer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/Shimmer.tsx
@@ -1,3 +1,4 @@
+import { isPixel } from "@coder/pixel-storybook";
 import type { MotionProps } from "motion/react";
 import { MotionConfig, motion } from "motion/react";
 import type { ElementType, JSX } from "react";
@@ -36,6 +37,23 @@ const ShimmerComponent = ({
 	duration = 2,
 	spread = 2,
 }: TextShimmerProps) => {
+	// Pixel screenshots are taken once the DOM stops mutating. The shimmer
+	// rewrites inline styles on every frame, so a capture never sees a settled
+	// DOM and the resulting baseline is nondeterministic. Render static text
+	// instead while a capture is in progress.
+	if (isPixel()) {
+		return (
+			<Component
+				className={cn(
+					"relative inline-block text-content-secondary",
+					className,
+				)}
+			>
+				{children}
+			</Component>
+		);
+	}
+
 	const MotionComponent = getMotionComponent(
 		Component as keyof JSX.IntrinsicElements,
 	);

--- a/site/src/pages/AgentsPage/components/ChatElements/Shimmer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/Shimmer.tsx
@@ -1,4 +1,3 @@
-import { isPixel } from "@coder/pixel-storybook";
 import type { MotionProps } from "motion/react";
 import { MotionConfig, motion } from "motion/react";
 import type { ElementType, JSX } from "react";
@@ -43,15 +42,10 @@ const ShimmerComponent = ({
 
 	const dynamicSpread = (children?.length ?? 0) * spread;
 
-	// Pixel screenshots are taken once the DOM stops mutating. Animating the
-	// gradient rewrites the element's inline style on every frame, so a capture
-	// never sees a settled DOM.
-	const animate = isPixel() ? undefined : { backgroundPosition: "0% center" };
-
 	return (
 		<MotionConfig reducedMotion="user">
 			<MotionComponent
-				animate={animate}
+				animate={{ backgroundPosition: "0% center" }}
 				className={cn(
 					"relative inline-block bg-[length:250%_100%,auto] bg-clip-text text-transparent",
 					"[--bg:linear-gradient(90deg,#0000_calc(50%-var(--spread)),hsl(var(--surface-primary)),#0000_calc(50%+var(--spread)))] [background-repeat:no-repeat,padding-box]",

--- a/site/src/pages/TemplateBuilder/BuildingTemplateLoader.tsx
+++ b/site/src/pages/TemplateBuilder/BuildingTemplateLoader.tsx
@@ -1,3 +1,4 @@
+import { isPixel } from "@coder/pixel-storybook/storyapi";
 import {
 	CodeIcon,
 	DatabaseIcon,
@@ -27,6 +28,8 @@ const ICONS: FloatingIcon[] = [
 	{ name: "template", icon: LayoutTemplateIcon, x: 28, y: -8, delay: 2.0 },
 ];
 
+const DOT_DELAYS = [0, 0.2, 0.4];
+
 /**
  * Full-area animated loader displayed while the template builder compose
  * API call is in flight. Shows floating icon boxes, an indeterminate progress
@@ -34,6 +37,11 @@ const ICONS: FloatingIcon[] = [
  * label.
  */
 export const BuildingTemplateLoader: FC = () => {
+	// The icon and dot loops end blank (icons offscreen, dots faded out), so a
+	// Pixel capture, which holds animations at their final keyframe, would record
+	// an empty loader. Hold them at a representative frame instead.
+	const frozen = isPixel();
+
 	return (
 		<div
 			className="relative flex flex-col items-center justify-end w-full min-h-[480px] overflow-hidden"
@@ -50,10 +58,14 @@ export const BuildingTemplateLoader: FC = () => {
 							left: `calc(50% + ${x}%)`,
 							top: `calc(50% + ${y}%)`,
 						}}
-						animate={{
-							y: ["-100vh", "0vh", "0vh", "0vh", "-100vh", "-100vh"],
-							opacity: [0, 1, 1, 0, 0, 0],
-						}}
+						animate={
+							frozen
+								? { y: "0vh", opacity: 1 }
+								: {
+										y: ["-100vh", "0vh", "0vh", "0vh", "-100vh", "-100vh"],
+										opacity: [0, 1, 1, 0, 0, 0],
+									}
+						}
 						transition={{
 							duration: 7,
 							delay,
@@ -88,38 +100,20 @@ export const BuildingTemplateLoader: FC = () => {
 				<p className="flex items-center gap-0.5 text-xs leading-[18px] text-content-secondary">
 					<span>Building your template</span>
 					<span className="inline-flex gap-0.5">
-						<motion.span
-							animate={{ opacity: [0, 1, 1, 0] }}
-							transition={{
-								duration: 1.5,
-								repeat: Number.POSITIVE_INFINITY,
-								times: [0, 0.2, 0.8, 1],
-							}}
-						>
-							.
-						</motion.span>
-						<motion.span
-							animate={{ opacity: [0, 1, 1, 0] }}
-							transition={{
-								duration: 1.5,
-								delay: 0.2,
-								repeat: Number.POSITIVE_INFINITY,
-								times: [0, 0.2, 0.8, 1],
-							}}
-						>
-							.
-						</motion.span>
-						<motion.span
-							animate={{ opacity: [0, 1, 1, 0] }}
-							transition={{
-								duration: 1.5,
-								delay: 0.4,
-								repeat: Number.POSITIVE_INFINITY,
-								times: [0, 0.2, 0.8, 1],
-							}}
-						>
-							.
-						</motion.span>
+						{DOT_DELAYS.map((delay) => (
+							<motion.span
+								key={delay}
+								animate={frozen ? { opacity: 1 } : { opacity: [0, 1, 1, 0] }}
+								transition={{
+									duration: 1.5,
+									delay,
+									repeat: Number.POSITIVE_INFINITY,
+									times: [0, 0.2, 0.8, 1],
+								}}
+							>
+								.
+							</motion.span>
+						))}
 					</span>
 				</p>
 			</div>

--- a/site/src/pages/TemplateBuilder/BuildingTemplateLoader.tsx
+++ b/site/src/pages/TemplateBuilder/BuildingTemplateLoader.tsx
@@ -1,3 +1,4 @@
+import { isPixel } from "@coder/pixel-storybook";
 import {
 	CodeIcon,
 	DatabaseIcon,
@@ -27,6 +28,8 @@ const ICONS: FloatingIcon[] = [
 	{ name: "template", icon: LayoutTemplateIcon, x: 28, y: -8, delay: 2.0 },
 ];
 
+const DOT_DELAYS = [0, 0.2, 0.4];
+
 /**
  * Full-area animated loader displayed while the template builder compose
  * API call is in flight. Shows floating icon boxes, an indeterminate progress
@@ -34,6 +37,11 @@ const ICONS: FloatingIcon[] = [
  * label.
  */
 export const BuildingTemplateLoader: FC = () => {
+	// The icon and dot loops end blank (icons offscreen, dots faded out), so a
+	// Pixel capture, which holds animations at their final keyframe, would record
+	// an empty loader. Hold them at a representative frame instead.
+	const frozen = isPixel();
+
 	return (
 		<div
 			className="relative flex flex-col items-center justify-end w-full min-h-[480px] overflow-hidden"
@@ -50,10 +58,14 @@ export const BuildingTemplateLoader: FC = () => {
 							left: `calc(50% + ${x}%)`,
 							top: `calc(50% + ${y}%)`,
 						}}
-						animate={{
-							y: ["-100vh", "0vh", "0vh", "0vh", "-100vh", "-100vh"],
-							opacity: [0, 1, 1, 0, 0, 0],
-						}}
+						animate={
+							frozen
+								? { y: "0vh", opacity: 1 }
+								: {
+										y: ["-100vh", "0vh", "0vh", "0vh", "-100vh", "-100vh"],
+										opacity: [0, 1, 1, 0, 0, 0],
+									}
+						}
 						transition={{
 							duration: 7,
 							delay,
@@ -88,38 +100,20 @@ export const BuildingTemplateLoader: FC = () => {
 				<p className="flex items-center gap-0.5 text-xs leading-[18px] text-content-secondary">
 					<span>Building your template</span>
 					<span className="inline-flex gap-0.5">
-						<motion.span
-							animate={{ opacity: [0, 1, 1, 0] }}
-							transition={{
-								duration: 1.5,
-								repeat: Number.POSITIVE_INFINITY,
-								times: [0, 0.2, 0.8, 1],
-							}}
-						>
-							.
-						</motion.span>
-						<motion.span
-							animate={{ opacity: [0, 1, 1, 0] }}
-							transition={{
-								duration: 1.5,
-								delay: 0.2,
-								repeat: Number.POSITIVE_INFINITY,
-								times: [0, 0.2, 0.8, 1],
-							}}
-						>
-							.
-						</motion.span>
-						<motion.span
-							animate={{ opacity: [0, 1, 1, 0] }}
-							transition={{
-								duration: 1.5,
-								delay: 0.4,
-								repeat: Number.POSITIVE_INFINITY,
-								times: [0, 0.2, 0.8, 1],
-							}}
-						>
-							.
-						</motion.span>
+						{DOT_DELAYS.map((delay) => (
+							<motion.span
+								key={delay}
+								animate={frozen ? { opacity: 1 } : { opacity: [0, 1, 1, 0] }}
+								transition={{
+									duration: 1.5,
+									delay,
+									repeat: Number.POSITIVE_INFINITY,
+									times: [0, 0.2, 0.8, 1],
+								}}
+							>
+								.
+							</motion.span>
+						))}
 					</span>
 				</p>
 			</div>


### PR DESCRIPTION
Pixel screenshots a story once its DOM has been idle for 100ms, capped at 5s. Motion drives properties the browser cannot accelerate (`background-position`, `width`, unit-converted transforms) by rewriting the element's inline `style` every frame, so those stories never settle and are captured mid-animation. Playwright's `animations: "disabled"` does not help, because the writes come from JS rather than CSS or WAAPI.

The Storybook preview now wraps every story in `<MotionConfig skipAnimations={isPixel()}>`, which sets each animated value to its final keyframe in a single frame without starting an animation. That covers all current and future motion usage, and keeps the gate out of product code.

`Shimmer` needs nothing further: its final keyframe (`backgroundPosition: 0% center`) is a readable resting frame where the highlight band sits off the text. `BuildingTemplateLoader` does, because its icon and dot loops are authored to end blank (icons at `y: -100vh, opacity: 0`, dots at `opacity: 0`), so it holds them at a representative frame during a capture instead. Its three dot spans differed only by `delay`, so they now map over the delays.

Stability, measured locally by emulating Pixel's gate (100ms idle, 5s cap):

| Story | Normal | Under capture |
|---|---|---|
| `templatebuilder-buildingtemplateloader--default` | 895 mutations, never settles | 0 mutations, settles in 100ms |
| `chatelements-conversation--loading-state` | 300 mutations, never settles | 0 mutations, settles in 100ms |
| `chatelements-tools-toolcall--running` | 300 mutations, never settles | 0 mutations, settles in 100ms |

For reference, the Pixel job on `main` (run 30260626275) had 33 stories hit the cap with `status: domNotIdle`; the first revision of this PR, which gated `Shimmer` alone, brought that to 1 (run 30265053757), the loader.

Freezing to the final keyframe gives determinism but not coverage, which is why the loader is gated explicitly. With a token regression injected on its icon boxes (transparent background and border), a capture that only applies `skipAnimations` diffs **0 pixels** against its own baseline, because the icons are offscreen and invisible in both. With the gate, the same regression diffs **16,173 pixels (3.95%)**.

This also drops `data-pixel="ignore"` from `Shimmer`. The attribute is inert: it arrived in a78982c238 as a find/replace of Chromatic's `data-chromatic="ignore"`, and neither `@coder/pixel-storybook` 0.1.3 nor 0.2.2 has any handling for it. Masking is configured per story through `parameters.pixel.mask`, which no story currently uses. 29 further occurrences remain across `site/src`, along with a placeholder `"data-pixel"` prop in `LastSeen.tsx` and a stale `testHelpers/chromatic.ts`, left for a follow-up since some mark genuine nondeterminism (timestamps, build progress) that needs real masking rather than deletion.

<details>
<summary>Coder Agents disclosure</summary>

This pull request was created by Coder Agents on behalf of @DanielleMaywood.

Approach taken:

1. Traced `Shimmer` and its usages, then read `@coder/pixel-storybook` 0.2.2 to confirm capture semantics: `waitForStability` needs 100ms of DOM idle, `isPixel()` exposes capture state to the page, and `screenshot({ animations: "disabled" })` only freezes CSS and WAAPI animations.
2. Verified with Playwright against a local Storybook by counting mutations and emulating Pixel's idle gate.
3. Confirmed only two files under `site/src` import motion at all, and that of their animations only `background-position`, `width`, and the `vh`-unit `y` keyframes churn the DOM; the dot `opacity` loops run on WAAPI and were never the problem.
4. Checked `MotionConfig`'s `skipAnimations` against motion 12.40.0 source: it calls `makeAnimationInstant`, resolves the final keyframe, sets it on one frame, and constructs no animation. Measured 324 mutations/s to 0 and `document.getAnimations()` 9 to 0. Rejected `reducedMotion="always"`, which only skips positional keys and would leave `background-position` animating.
5. Ran `biome check`, `tsc -p .`, the React Compiler check, and the `TemplateBuilder` and `ChatElements` Storybook tests. Two failures are pre-existing: `SelectionSummary > With Long Name Module` and `Tool > MCP Tool Completed` both fail without these changes.

Revision history for reviewers:

- Round 1 early-returned plain static text under Pixel. That measured 10.7% pixel-different from the real component and left the gradient CSS uncovered (CRF-1), so it was replaced by freezing the real element.
- Round 2 gated `Shimmer` alone, which left `BuildingTemplateLoader` unstable (CRF-4). Rather than add a second per-component gate, the freeze moved to the preview decorator, which let `Shimmer` drop its `isPixel()` import entirely.
- CRF-5 asked for a comment explaining the mechanism at the gate. The author judged the code clear enough there, so the rationale lives in this description instead.

</details>
