### PR TITLE
fix(coderd/x/chatd): avoid request recorder race

### DIFF
--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -6343,7 +6343,6 @@ func TestActiveServer_BasicAssistantGenerationAndPromptPreparation(t *testing.T)
 	require.GreaterOrEqual(t, last.RuntimeMs.Int64, int64(0))
 	requireTextPart(t, last, "done")
 
-	requests = newAnthropicRequestRecorder()
 	server = newActiveTestServer(t, db, ps, func(cfg *chatd.Config) {
 		cfg.AIBridgeTransportFactory = chatAIGatewayTransportFactoryPointer(chattest.NewMockAIBridgeTransport(t, anthropicURL, chattest.WithPreservePath()))
 	})
@@ -6358,9 +6357,10 @@ func TestActiveServer_BasicAssistantGenerationAndPromptPreparation(t *testing.T)
 	require.NoError(t, err)
 	waitForChatStatus(ctx, t, db, planChat.ID, database.ChatStatusWaiting)
 
-	planRequests := filterAnthropicStreamingRequests(requests.all())
-	require.Len(t, planRequests, 1)
-	toolNames = anthropicRequestToolNames(planRequests[0])
+	allGenerationRequests := filterAnthropicStreamingRequests(requests.all())
+	require.Len(t, allGenerationRequests, len(generationRequests)+1)
+	planRequest := allGenerationRequests[len(generationRequests)]
+	toolNames = anthropicRequestToolNames(planRequest)
 	require.Contains(t, toolNames, "read_file")
 	require.NotContains(t, toolNames, "write_file")
 }


### PR DESCRIPTION
`TestActiveServer_BasicAssistantGenerationAndPromptPreparation` could race by reassigning a request recorder captured by concurrent callbacks. Keep the recorder immutable across both scenarios.

Closes https://github.com/coder/internal/issues/1626