### PR TITLE
fix: add prefix to standalone metrics

### DIFF
--- a/aibridge/metrics/metrics.go
+++ b/aibridge/metrics/metrics.go
@@ -8,6 +8,8 @@ import (
 var baseLabels = []string{"provider", "model"}
 
 const (
+	PrometheusMetricPrefix = "coder_ai_gateway_"
+
 	InterceptionCountStatusFailed    = "failed"
 	InterceptionCountStatusCompleted = "completed"
 )

--- a/cli/server.go
+++ b/cli/server.go
@@ -57,6 +57,7 @@ import (
 	"cdr.dev/slog/v3"
 	"cdr.dev/slog/v3/sloggers/sloghuman"
 	"github.com/coder/coder/v2/aibridge"
+	aibridgemetrics "github.com/coder/coder/v2/aibridge/metrics"
 	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/cli/clilog"
 	"github.com/coder/coder/v2/cli/cliui"
@@ -1180,7 +1181,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				// TODO(deprecation): Remove "coder_aibridged_" in v2.37.
 				// See AIGOV-447:
 				// https://linear.app/codercom/issue/AIGOV-447/remove-legacy-ai-gateway-metric-aliases
-				aibridgeReg := prometheusmetrics.NewMetricAliasRegisterer(coderAPI.PrometheusRegistry, "coder_ai_gateway_", "coder_aibridged_")
+				aibridgeReg := prometheusmetrics.NewMetricAliasRegisterer(coderAPI.PrometheusRegistry, aibridgemetrics.PrometheusMetricPrefix, "coder_aibridged_")
 				aibridgeMetrics := aibridge.NewMetrics(aibridgeReg)
 				var unsubscribeProviderReload func()
 				aibridgeDaemon, unsubscribeProviderReload, err = newAIBridgeDaemon(coderAPI, vals.AI.BridgeConfig, aibridgeReg, aibridgeMetrics)

--- a/enterprise/cli/aigatewaystart.go
+++ b/enterprise/cli/aigatewaystart.go
@@ -25,6 +25,7 @@ import (
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/aibridge"
 	"github.com/coder/coder/v2/aibridge/keypool"
+	aibridgemetrics "github.com/coder/coder/v2/aibridge/metrics"
 	agpl "github.com/coder/coder/v2/cli"
 	"github.com/coder/coder/v2/cli/clilog"
 	"github.com/coder/coder/v2/coderd/aibridged"
@@ -143,8 +144,9 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 			registry.MustRegister(collectors.NewGoCollector())
 			registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 
-			metrics := aibridge.NewMetrics(registry)
-			providerMetrics := aibridged.NewMetrics(registry)
+			gatewayRegisterer := prometheus.WrapRegistererWithPrefix(aibridgemetrics.PrometheusMetricPrefix, registry)
+			metrics := aibridge.NewMetrics(gatewayRegisterer)
+			providerMetrics := aibridged.NewMetrics(gatewayRegisterer)
 
 			tracerProvider, _, closeTracing := agpl.ConfigureTraceProviderWithService(signalCtx, logger, vals, "coder-ai-gateway")
 			// The tracer is shared by the gateway's HTTP middleware, pool, and
@@ -172,7 +174,7 @@ func (r *RootCmd) aiGatewayStart() *serpent.Command {
 			if err != nil {
 				return xerrors.Errorf("create request pool: %w", err)
 			}
-			registry.MustRegister(keypool.NewStateCollector(pool.KeyPools))
+			gatewayRegisterer.MustRegister(keypool.NewStateCollector(pool.KeyPools))
 
 			return runStandaloneGateway(signalCtx, standaloneGatewayParams{
 				bridgeConfig: vals.AI.BridgeConfig,


### PR DESCRIPTION
Adds `coder_ai_gateway_` to standalone Gateway metics to match embedded case.