### PR TITLE
refactor(site/src/pages): delete unreachable tool render paths

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -23,7 +23,7 @@ const LiveActivitySlot: FC = () => (
 		data-testid="live-activity-slot"
 		className="flex h-6 items-center gap-2 text-content-secondary"
 	>
-		<ToolIcon name="thinking" isError={false} />
+		<ToolIcon name="thinking" />
 		<Shimmer as="span" className="text-[13px] leading-6">
 			Thinking
 		</Shimmer>

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageParsing.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageParsing.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { ChatMessage, ChatMessagePart } from "#/api/typesGenerated";
-import { getSubagentDescriptor } from "../ChatElements/tools/subagentDescriptor";
+import {
+	getSubagentDescriptor,
+	isSubagentToolName,
+} from "../ChatElements/tools/subagentDescriptor";
 import {
 	buildSubagentMaps,
 	getEditableUserMessagePayload,
@@ -1152,29 +1155,8 @@ describe("getSubagentDescriptor", () => {
 		}
 	});
 
-	it("renders list_agents with a fixed generic affordance", () => {
-		const descriptor = getSubagentDescriptor({
-			name: "list_agents",
-			args: {},
-			result: {
-				agents: [
-					{ chat_id: "agent-1", type: "explore", status: "completed" },
-					{ chat_id: "agent-2", type: "computer_use", status: "running" },
-				],
-				total: 2,
-				returned: 2,
-				offset: 0,
-				has_more: false,
-			},
-		});
-
-		// The list result has no single top-level type, so the descriptor
-		// must not derive a variant from per-agent types.
-		expect(descriptor).toMatchObject({
-			action: "list",
-			variant: "general",
-			iconKind: "bot",
-			supportsDesktopAffordance: false,
-		});
+	it("does not treat list_agents as a subagent lifecycle tool", () => {
+		expect(isSubagentToolName("list_agents")).toBe(false);
+		expect(getSubagentDescriptor({ name: "list_agents" })).toBeNull();
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageParsing.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageParsing.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ChatMessage, ChatMessagePart } from "#/api/typesGenerated";
-import {
-	getSubagentDescriptor,
-	isSubagentToolName,
-} from "../ChatElements/tools/subagentDescriptor";
+import { getSubagentDescriptor } from "../ChatElements/tools/subagentDescriptor";
 import {
 	buildSubagentMaps,
 	getEditableUserMessagePayload,
@@ -1153,10 +1150,5 @@ describe("getSubagentDescriptor", () => {
 				supportsDesktopAffordance: false,
 			});
 		}
-	});
-
-	it("does not treat list_agents as a subagent lifecycle tool", () => {
-		expect(isSubagentToolName("list_agents")).toBe(false);
-		expect(getSubagentDescriptor({ name: "list_agents" })).toBeNull();
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/CreateWorkspaceTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/CreateWorkspaceTool.tsx
@@ -2,7 +2,7 @@ import { ExternalLinkIcon } from "lucide-react";
 import type React from "react";
 import { Link } from "react-router";
 import { ToolCall } from "./ToolCall";
-import { asRecord, asString, type ToolStatus } from "./utils";
+import { asString, parseArgs, type ToolStatus } from "./utils";
 import { WorkspaceBuildLogSection } from "./WorkspaceBuildLogSection";
 
 /**
@@ -32,15 +32,7 @@ export const CreateWorkspaceTool: React.FC<{
 	labelOverride,
 }) => {
 	const isRunning = status === "running";
-	let rec: Record<string, unknown> | null = null;
-	if (resultJson) {
-		try {
-			const parsed = JSON.parse(resultJson);
-			rec = asRecord(parsed);
-		} catch {
-			rec = asRecord(resultJson);
-		}
-	}
+	const rec = parseArgs(resultJson);
 	const ownerName = rec ? asString(rec.owner_name) : "";
 	const wsName = rec ? asString(rec.workspace_name) : workspaceName;
 	const workspaceLink = ownerName && wsName ? `/@${ownerName}/${wsName}` : null;

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.stories.tsx
@@ -35,14 +35,6 @@ export const ShortCommand: Story = {
 	},
 };
 
-export const RunningWithoutCommand: Story = {
-	args: {
-		command: "",
-		status: "running",
-		transcriptBlocks: [],
-	},
-};
-
 export const LongCommand: Story = {
 	decorators: [
 		(Story) => (

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
@@ -56,7 +56,6 @@ export const ExecuteTool: React.FC<ExecuteToolProps> = ({
 	parsedCommands,
 	shellToolDisplayMode,
 }) => {
-	const hasCommand = command.trim().length > 0;
 	const hasTranscriptBlocks = transcriptBlocks.length > 0;
 	const autoDisplayState: AgentDisplayState =
 		hasTranscriptBlocks ||
@@ -77,10 +76,6 @@ export const ExecuteTool: React.FC<ExecuteToolProps> = ({
 		shellToolDisplayMode,
 		autoDisplayState,
 	);
-
-	if (!hasCommand) {
-		return null;
-	}
 
 	return (
 		<ToolCall.Root

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
@@ -53,12 +53,6 @@ const SUBAGENT_VERBS: Record<
 		error: "Failed to interrupt ",
 		timeout: "Timed out interrupting ",
 	},
-	list: {
-		completed: "Listed ",
-		running: "Listing ",
-		error: "Failed to list ",
-		timeout: "Timed out listing ",
-	},
 };
 
 /**

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -1122,7 +1122,6 @@ export const WaitAgentExploreStreamingFromHistory: Story = {
 		expect(
 			canvas.getByRole("button", { name: /Waiting for Explore agent/ }),
 		).toBeInTheDocument();
-		expect(canvas.queryByText("Waiting for sub-agent…")).toBeNull();
 	},
 };
 
@@ -1142,7 +1141,6 @@ export const MessageAgentExploreStreamingFromResult: Story = {
 		expect(
 			canvas.getByRole("button", { name: /Messaging Explore agent/ }),
 		).toBeInTheDocument();
-		expect(canvas.queryByText("Messaging sub-agent…")).toBeNull();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -1114,10 +1114,9 @@ export const Tool = memo(
 		ref,
 		...props
 	}: ToolProps) => {
-		const Renderer =
-			isSubagentToolName(name) && name !== "list_agents"
-				? SubagentRenderer
-				: (toolRenderers[name] ?? GenericToolRenderer);
+		const Renderer = isSubagentToolName(name)
+			? SubagentRenderer
+			: (toolRenderers[name] ?? GenericToolRenderer);
 		const isShellTool = name === "execute" || name === "process_output";
 		if (!shouldRenderTool({ name, status, args, result })) {
 			return null;

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.tsx
@@ -15,7 +15,6 @@ import {
 import { cn } from "#/utils/cn";
 import { Shimmer } from "../Shimmer";
 import { TranscriptRow } from "../TranscriptRow";
-import type { SubagentIconKind } from "./subagentDescriptor";
 import { ToolIcon } from "./ToolIcon";
 import type { ToolStatus } from "./utils";
 
@@ -208,7 +207,6 @@ type ToolCallLeadingIconProps = {
 	children?: ReactNode;
 	iconUrl?: string;
 	serverName?: string;
-	subagentIconKind?: SubagentIconKind;
 };
 
 const LeadingIcon: FC<ToolCallLeadingIconProps> = ({
@@ -216,9 +214,8 @@ const LeadingIcon: FC<ToolCallLeadingIconProps> = ({
 	children,
 	iconUrl,
 	serverName,
-	subagentIconKind,
 }) => {
-	const { active, failed } = useToolCallContext();
+	const { active } = useToolCallContext();
 	if (children) {
 		return <>{children}</>;
 	}
@@ -229,11 +226,9 @@ const LeadingIcon: FC<ToolCallLeadingIconProps> = ({
 	return (
 		<ToolIcon
 			name={name}
-			isError={failed}
 			isRunning={active}
 			iconUrl={iconUrl}
 			serverName={serverName}
-			subagentIconKind={subagentIconKind}
 		/>
 	);
 };
@@ -267,16 +262,11 @@ const Label: FC<ToolCallLabelProps> = ({
 
 type ToolCallStatusProps = {
 	className?: string;
-	errorMessage?: string;
 };
 
-const Status: FC<ToolCallStatusProps> = ({ className, errorMessage }) => {
-	const {
-		active,
-		errorMessage: contextErrorMessage,
-		failed,
-	} = useToolCallContext();
-	const message = errorMessage || contextErrorMessage || "Tool call failed";
+const Status: FC<ToolCallStatusProps> = ({ className }) => {
+	const { active, errorMessage, failed } = useToolCallContext();
+	const message = errorMessage || "Tool call failed";
 	return (
 		<>
 			{active && (
@@ -367,7 +357,6 @@ type ToolCallHeaderProps = {
 	label: ReactNode;
 	iconUrl?: string;
 	serverName?: string;
-	subagentIconKind?: SubagentIconKind;
 	secondaryLabel?: ReactNode;
 	trailing?: ReactNode;
 	showStatus?: boolean;
@@ -388,7 +377,6 @@ const Header: FC<ToolCallHeaderProps> = ({
 	label,
 	iconUrl,
 	serverName,
-	subagentIconKind,
 	secondaryLabel,
 	trailing,
 	showStatus = true,
@@ -396,12 +384,7 @@ const Header: FC<ToolCallHeaderProps> = ({
 }) => {
 	return (
 		<HeaderButton className={headerClassName}>
-			<LeadingIcon
-				name={iconName}
-				iconUrl={iconUrl}
-				serverName={serverName}
-				subagentIconKind={subagentIconKind}
-			/>
+			<LeadingIcon name={iconName} iconUrl={iconUrl} serverName={serverName} />
 			<Label>{label}</Label>
 			{secondaryLabel}
 			{showStatus && <Status />}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolIcon.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolIcon.tsx
@@ -22,19 +22,13 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { cn } from "#/utils/cn";
-import {
-	isSubagentToolName,
-	type SubagentIconKind,
-} from "./subagentDescriptor";
 
 export const ToolIcon: React.FC<{
 	name: string;
-	isError: boolean;
 	iconUrl?: string;
 	isRunning?: boolean;
 	serverName?: string;
-	subagentIconKind?: SubagentIconKind;
-}> = ({ name, iconUrl, isRunning, serverName, subagentIconKind }) => {
+}> = ({ name, iconUrl, isRunning, serverName }) => {
 	const [imgError, setImgError] = useState(false);
 	const color = "text-current";
 	const base = cn(
@@ -80,20 +74,6 @@ export const ToolIcon: React.FC<{
 		return img;
 	}
 
-	if (isSubagentToolName(name)) {
-		// This name-based fallback only exists for legacy callers that do
-		// not pass a descriptor. The descriptor path should provide
-		// subagentIconKind for new subagent types instead of extending it.
-		const iconKind =
-			subagentIconKind ||
-			(name === "spawn_computer_use_agent" ? "monitor" : "bot");
-		return iconKind === "monitor" ? (
-			<MonitorIcon className={base} />
-		) : (
-			<BotIcon className={base} />
-		);
-	}
-
 	switch (name) {
 		case "execute":
 		case "process_output":
@@ -116,6 +96,7 @@ export const ToolIcon: React.FC<{
 		case "start_workspace":
 			return <PowerIcon className={base} />;
 		case "chat_summarized":
+		case "list_agents":
 			return <BotIcon className={base} />;
 		case "thinking":
 			return <LightbulbIcon className={base} />;

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolLabel.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolLabel.tsx
@@ -1,57 +1,6 @@
 import type React from "react";
 import { getPathBasename } from "../../../utils/path";
-import {
-	getProvidedSubagentTitle,
-	getSubagentDescriptor,
-} from "./subagentDescriptor";
 import { asRecord, asString, humanizeMCPToolName, parseArgs } from "./utils";
-
-const renderSubagentLabel = (
-	name: string,
-	args: unknown,
-	result: unknown,
-): React.ReactNode | null => {
-	const descriptor = getSubagentDescriptor({ name, args, result });
-	if (!descriptor) {
-		return null;
-	}
-
-	const providedTitle = getProvidedSubagentTitle({ args, result });
-	const fallbackTitle = descriptor.fallbackTitle;
-	const text = (() => {
-		switch (descriptor.action) {
-			case "spawn":
-				if (providedTitle) {
-					return `Spawning ${providedTitle}`;
-				}
-				if (descriptor.variant === "explore") {
-					return "Spawning Explore agent…";
-				}
-				if (descriptor.variant === "computer_use") {
-					return "Spawning computer use sub-agent…";
-				}
-				return `Spawning ${fallbackTitle}…`;
-			case "wait":
-				return providedTitle
-					? `Waiting for ${providedTitle}`
-					: `Waiting for ${fallbackTitle}…`;
-			case "message":
-				return providedTitle
-					? `Messaging ${providedTitle}`
-					: `Messaging ${fallbackTitle}…`;
-			case "interrupt":
-				return providedTitle
-					? `Interrupting ${providedTitle}`
-					: `Interrupting ${fallbackTitle}`;
-			case "list":
-				return providedTitle
-					? `Listing ${providedTitle}`
-					: `Listing ${fallbackTitle}`;
-		}
-	})();
-
-	return <span className="truncate text-[13px]">{text}</span>;
-};
 
 export const ToolLabel: React.FC<{
 	name: string;
@@ -61,14 +10,6 @@ export const ToolLabel: React.FC<{
 }> = ({ name, args, result, mcpSlug }) => {
 	const parsed = parseArgs(args);
 	const parsedResult = asRecord(result);
-	const subagentLabel = renderSubagentLabel(
-		name,
-		parsed ?? args,
-		parsedResult ?? result,
-	);
-	if (subagentLabel) {
-		return subagentLabel;
-	}
 
 	switch (name) {
 		case "execute": {

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/subagentDescriptor.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/subagentDescriptor.ts
@@ -1,14 +1,9 @@
 import { asString } from "../runtimeTypeUtils";
 import { parseArgs } from "./utils";
 
-export type SubagentAction =
-	| "spawn"
-	| "wait"
-	| "message"
-	| "interrupt"
-	| "list";
+export type SubagentAction = "spawn" | "wait" | "message" | "interrupt";
 export type SubagentVariant = "general" | "explore" | "computer_use";
-export type SubagentIconKind = "bot" | "monitor";
+type SubagentIconKind = "bot" | "monitor";
 
 export type SubagentDescriptor = {
 	action: SubagentAction;
@@ -59,11 +54,6 @@ const actionByToolName: Record<string, SubagentAction> = {
 	// Legacy persisted tool name kept so old chat histories still render.
 	close_agent: "interrupt",
 	interrupt_agent: "interrupt",
-	// list_agents is a subagent tool but renders through
-	// ListAgentsRenderer, not SubagentRenderer. The "list" action
-	// exists for isSubagentToolName classification and ToolIcon
-	// dispatch, not for the SubagentRenderer label machinery.
-	list_agents: "list",
 };
 
 const variantBySpawnToolName: Record<string, SubagentVariant> = {

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/toolVisibility.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/toolVisibility.test.ts
@@ -136,7 +136,7 @@ describe("toolVisibility", () => {
 			).toBe(false);
 		});
 
-		it("renders list_agents rows even without a chat_id", () => {
+		it("renders list_agents rows regardless of chat_id", () => {
 			expect(
 				shouldRenderTool({
 					name: "list_agents",


### PR DESCRIPTION
Every deletion here is unreachable by call-site enumeration. No behavior change.

Second PR in a series narrowing the AgentsPage chat types so impossible states are unrepresentable rather than defended against. Follows #27513.

## `list_agents` was classified as a subagent tool through a fake action

`list_agents` renders via `ListAgentsRenderer` and never reaches `SubagentRenderer`, but it was mapped to a `"list"` action purely so `isSubagentToolName` would return true for it. Removing it from `actionByToolName` drops the `"list"` member of `SubagentAction`, and with it the `list:` verb entry in `SubagentTool` and the `name !== "list_agents"` exception in the renderer dispatch.

The icon `list_agents` inherited from that classification is now an explicit `case` in `ToolIcon`, so it no longer depends on being mis-classified. The other three consumers are unaffected, verified individually:

| Consumer | Before | After |
|---|---|---|
| `isCompletedSubagentResult` | name matched, then `status ?? subagent_status` was `""` (the payload is `{agents,total,returned,offset,has_more}`) → `false` | short-circuits at the name check → `false` |
| `shouldRenderSubagentLifecycleTool` | descriptor with `action: "list"` fails the wait/message/interrupt test → `true` | descriptor `null` → `true` |
| `buildSubagentMaps` | included, then skipped for lack of a top-level `chat_id` | skipped at the name check |

## That makes `ToolIcon`'s subagent branch dead

`list_agents` was the only name that reached it. Every other `iconName` is a hard-coded literal, `GenericToolRenderer` can never receive a subagent name (all subagent names route to `SubagentRenderer`), and `SubagentTool` renders `SubagentStatusIcon` as `LeadingIcon` children rather than passing a name. The branch goes, along with the `subagentIconKind` prop that no call site ever passed and that existed only to feed it.

## Remaining deletions

- **`ToolLabel`'s `renderSubagentLabel`**, unreachable for the same reason: the component has two call sites, `GenericToolRenderer` and `AdvisorTool` (`name="advisor"`), and neither can supply a subagent name.
- **`ToolIcon`'s required `isError` prop**, which the implementation never read. Both call sites passed it to satisfy the compiler.
- **`ToolCall.Status`'s `errorMessage` override**, which no call site passed and which shadowed the context value.
- **`ExecuteTool`'s `if (!hasCommand) return null`**. `shouldRenderTool` requires a non-empty trimmed command or an `authenticateURL`, and `ExecuteRenderer` diverts the `authenticateURL` case to `ExecuteAuthRequiredTool` before `ExecuteTool` renders, so an empty command cannot reach it. Both trims match.
- **`CreateWorkspaceTool`'s hand-rolled `try { JSON.parse } catch { asRecord(resultJson) }`**, whose catch branch always produced `null` because `asRecord` rejects strings. Replaced with the shared `parseArgs`, which handles both the object and JSON-string shapes.

## Coverage follows the code

The `RunningWithoutCommand` story rendered `ExecuteTool` with an empty command, a state production cannot produce, and two story assertions checked for label strings that only the deleted `renderSubagentLabel` could emit (`SUBAGENT_VERBS` never emits an ellipsis). Both are removed rather than kept alive artificially. The `getSubagentDescriptor` unit test that asserted the old `action: "list"` descriptor is deleted rather than rewritten: any replacement would only restate that `list_agents` is absent from `actionByToolName`, and the observable regression is already covered by `Tool.stories.tsx > ListAgentsCompleted`, which renders through the real dispatch and would route to `SubagentRenderer` if the classification came back. The preserved icon remains covered by the existing `AllToolIconsTranscript` story, which includes `list_agents`.

## Not in this PR

`SubagentRenderer`'s `if (!descriptor) return null` is also unreachable, since `getSubagentDescriptor` returns `null` only for names that `isSubagentToolName` rejects, which is exactly the condition that routes away from `SubagentRenderer`. Making it provable does not require changing `ToolRendererProps`, but it does require restructuring the dispatch: narrowing from a type-predicate `isSubagentToolName` does not survive past the ternary at `Tool.tsx:1117`, so the single `<Renderer name={name} />` call site would reject the narrowed type. Branching in JSX instead, which means hoisting the 22 shared props into one object, is about 12 to 15 net lines and would also delete the identical guard at `messageParsing.ts:437-439`. It is deferred because this PR is otherwise pure deletion, and that prop threading is rewritten by the queued PR that splits `ToolRendererProps` per renderer, so doing it now means doing it twice.

## Validation

`pnpm lint:types`, `pnpm check`, `knip`, `dpdm`, `check-compiler`, and the full unit suite (3088 passed) are green. Storybook interaction tests under `src/pages/AgentsPage` show the same three failures as the base commit, confirmed by re-running them on `main`: `AgentChatPage.stories.tsx > With Message History` and `Tool.stories.tsx > MCP Tool Completed` fail on `main`, and `AgentChatPageView.stories.tsx > Scroll To Bottom Button Works With Inverse Scroll` is flaky there (failed 1 of 3 runs on `main`).

<details>
<summary>Audit and plan this PR comes from</summary>

The AgentsPage tree was audited against the principle "make impossible states impossible": we should never write defensive code for a state that should be impossible to exist, which requires types narrowed enough that the check is unnecessary. Agreed corollaries:

1. Trust only what we fully control. localStorage, URL and search params, `postMessage`, WebSocket frames, and model-authored tool JSON are untrusted and re-validated on every read.
2. Narrow at the earliest boundary. A validator must return a type that cannot express the invalid case. A `T | null` return from a validator that provably never returns `null` is itself a violation, because it forces every consumer to re-check.
3. One representation per fact. No field pairs that must agree, no parallel collections that must stay in sync, no boolean that is a function of another boolean.
4. Exhaustiveness is a compile error, not a fallback.

The audit found the domain layer has genuinely good unions (`LiveStatusModel`, `UserRightPanelTab`, `RenderBlock`, the `ChatMessagePart` codegen), while the page layer and the tool-rendering layer flatten them back into independent booleans and optionals and re-derive the union with runtime guards one to three layers down.

The remediation is sequenced as one PR per issue:

**Phase 1, delete what is provably unreachable.** #27513 and this PR.

**Phase 2, collapse duplicated facts in the render layer.** `MergedTool` becomes a discriminated union so `isError` can be deleted (`{ status: "running", isError: true }` is currently reachable, and the reconciliation is written four separate times); a single `getToolError` replaces 13 duplicated `asString(rec.error || rec.message)` reads and 17 per-leaf fallback strings; per-component outcome unions for `ProcessOutputTool`, `WaitForExternalAuthTool`, `AdvisorTool`, `ProposePlanTool`, `CreateWorkspaceTool`; split `ToolCall.Root`'s controlled/uncontrolled prop soup; stop widening `Map<string, ChatStatus>` to `Map<string, string>`; inline tools into `RenderBlock` so `blocks` stops referencing `tools` by string ID; collapse `SmoothText`'s two booleans into one.

**Phase 3, fix the generated boundary.** Map `json.RawMessage` to `unknown` instead of `Record<string, string>` in `scripts/apitypings`, generalize the existing `DiscriminatedChatMessagePart` codegen mutation, then apply it to `ChatStreamEvent` (nine event kinds against seven independent optional payloads, costing six runtime guards in one switch plus a silent `default: continue`) and `ChatInputPart`. Type the enum-ish strings the UI branches on.

**Phase 4, page and container layer.** Validate and narrow route params once instead of 8 `?? ""` defaults and 11 guards; pass async state as one union instead of `data | undefined` plus `isLoading` plus `error`; validate persisted tab state on every read and return non-nullable types from the validators; collapse correlated props and both-or-neither pairs; narrow `useDesktopConnection`'s options and result.

**Phase 5, add the principle to the FE rule contract.** FE2 currently covers the symptoms (no `any`, no non-null assertions, required props) but never states the principle.

**Phase 6, per-tool payload schemas.** Give the Go tool results named types, add `chattool` to the codegen directories, parse tool payloads once into a `ToolPayload` union, and delete the per-renderer extraction (~110 ad-hoc `asRecord`/`asString`/`parseArgs` calls across 9 files).

**Phase 7, cleanup.** Delete `ChatMessagePart.Signature`, never populated since it was added in #22290; Anthropic reasoning signatures actually travel in `ProviderMetadata`.

Deliberately out of scope: changing `omitempty` on `ChatMessagePart` (it doubles as the `chat_messages.content` persistence format), a runtime validation framework over `typesGenerated.ts`, `noUncheckedIndexedAccess` (measured at ~800 errors across 224 files, most of them provably-safe code TypeScript cannot prove), and runtime validation of model-authored tool JSON, which is the legitimate trust boundary.

</details>

Generated with Coder Agents.
