### PR TITLE
fix(coderd/aibridged): retain dialer notification

### DIFF
--- a/coderd/aibridged/aibridged_test.go
+++ b/coderd/aibridged/aibridged_test.go
@@ -1008,7 +1008,7 @@ func TestReady(t *testing.T) {
 		pool := mock.NewMockPooler(ctrl)
 		pool.EXPECT().Shutdown(gomock.Any()).MinTimes(1).Return(nil)
 
-		dialerCalled := make(chan struct{})
+		dialerCalled := make(chan struct{}, 1)
 		blockDialer := func(ctx context.Context) (aibridged.DRPCClient, error) {
 			select {
 			case dialerCalled <- struct{}{}:

--- a/coderd/aibridged/aibridged_test.go
+++ b/coderd/aibridged/aibridged_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -1022,7 +1021,6 @@ func TestReady(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() { srv.Close() })
 
-		time.Sleep(testutil.IntervalFast)
 		testutil.RequireReceive(t.Context(), t, dialerCalled)
 		require.False(t, srv.Ready(), "expected not ready before first connection")
 	})

--- a/coderd/aibridged/aibridged_test.go
+++ b/coderd/aibridged/aibridged_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -1021,6 +1022,7 @@ func TestReady(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() { srv.Close() })
 
+		time.Sleep(testutil.IntervalFast)
 		testutil.RequireReceive(t.Context(), t, dialerCalled)
 		require.False(t, srv.Ready(), "expected not ready before first connection")
 	})


### PR DESCRIPTION
Fixes flake in `TestReady/FalseBeforeConnection` test.
Test used an unbuffered channel with a nonblocking send to report that the dialer had started. If the dialer ran before the test began receiving, the notification was discarded and the test waited until the package timeout.

Buffer the one-shot notification so it remains available regardless of goroutine scheduling.

Commit sequence proves the fix works.
* https://github.com/coder/coder/pull/27529/changes/32e59bbbeae529926d7095a57bfb39a94bf6b183 reproduces the race by adding delay
```
$ go test -test.fullpath=true -timeout 30s -run ^TestReady$/^FalseBeforeConnection$ github.com/coder/coder/v2/coderd/aibridged -short --count 1
panic: test timed out after 30s
	running tests:
		TestReady/FalseBeforeConnection (30s)
```
* https://github.com/coder/coder/pull/27529/changes/84f802ede4da0f4768e173f0adbe08ac1e300f6e applies the fix while retaining the reproduction
```
$ go test -test.fullpath=true -timeout 30s -run ^TestReady$/^FalseBeforeConnection$ github.com/coder/coder/v2/coderd/aibridged -short --count 1
ok  	github.com/coder/coder/v2/coderd/aibridged	0.051s
```
* https://github.com/coder/coder/pull/27529/changes/7046a8b994fa7246e7661244dad138ce43733a33 removes the temporary added reproduction.
```
$ go test -test.fullpath=true -timeout 30s -run ^TestReady$/^FalseBeforeConnection$ github.com/coder/coder/v2/coderd/aibridged -short --count 1
ok  	github.com/coder/coder/v2/coderd/aibridged	0.024s
```

Generated by Coder Agents on behalf of @pawbana.
