### PR TITLE
fix(site): apply URL autofill to conditional params

### DIFF
--- a/site/src/modules/hooks/useSyncFormParameters.test.ts
+++ b/site/src/modules/hooks/useSyncFormParameters.test.ts
@@ -1,0 +1,150 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import {
+	MockDropdownParameter,
+	MockPreviewParameter1,
+	MockPreviewParameter2,
+} from "#/testHelpers/entities";
+import type { AutofillBuildParameter } from "#/utils/richParameters";
+import { useSyncFormParameters } from "./useSyncFormParameters";
+
+describe("useSyncFormParameters", () => {
+	it("applies autofill when a parameter is introduced", async () => {
+		const formValues = [
+			{
+				name: MockPreviewParameter1.name,
+				value: MockPreviewParameter1.value.value,
+			},
+		];
+		const autofillParameters: AutofillBuildParameter[] = [
+			{
+				name: MockPreviewParameter2.name,
+				value: "3",
+				source: "url",
+			},
+		];
+		const setFieldValue = vi.fn();
+		const setFieldTouched = vi.fn();
+		const { rerender } = renderHook(
+			({ parameters }) =>
+				useSyncFormParameters({
+					parameters,
+					autofillParameters,
+					formValues,
+					touched: {},
+					setFieldValue,
+					setFieldTouched,
+				}),
+			{ initialProps: { parameters: [MockPreviewParameter1] } },
+		);
+
+		expect(setFieldValue).not.toHaveBeenCalled();
+
+		rerender({
+			parameters: [MockPreviewParameter1, MockPreviewParameter2],
+		});
+
+		await waitFor(() => {
+			expect(setFieldValue).toHaveBeenCalledWith("rich_parameter_values", [
+				...formValues,
+				{ name: MockPreviewParameter2.name, value: "3" },
+			]);
+		});
+		expect(setFieldTouched).toHaveBeenCalledWith(
+			MockPreviewParameter2.name,
+			true,
+			false,
+		);
+	});
+
+	it("ignores invalid autofill when a parameter is introduced", async () => {
+		const formValues = [
+			{
+				name: MockPreviewParameter1.name,
+				value: MockPreviewParameter1.value.value,
+			},
+		];
+		const setFieldValue = vi.fn();
+		const setFieldTouched = vi.fn();
+		const { rerender } = renderHook(
+			({ parameters }) =>
+				useSyncFormParameters({
+					parameters,
+					autofillParameters: [
+						{
+							name: MockDropdownParameter.name,
+							value: "not-an-option",
+							source: "url",
+						},
+					],
+					formValues,
+					touched: {},
+					setFieldValue,
+					setFieldTouched,
+				}),
+			{ initialProps: { parameters: [MockPreviewParameter1] } },
+		);
+
+		rerender({
+			parameters: [MockPreviewParameter1, MockDropdownParameter],
+		});
+
+		await waitFor(() => {
+			expect(setFieldValue).toHaveBeenCalledWith("rich_parameter_values", [
+				...formValues,
+				{
+					name: MockDropdownParameter.name,
+					value: MockDropdownParameter.value.value,
+				},
+			]);
+		});
+		expect(setFieldTouched).not.toHaveBeenCalled();
+	});
+
+	it("ignores autofill for an ephemeral parameter", async () => {
+		const formValues = [
+			{
+				name: MockPreviewParameter1.name,
+				value: MockPreviewParameter1.value.value,
+			},
+		];
+		const ephemeralParameter = {
+			...MockPreviewParameter2,
+			ephemeral: true,
+		};
+		const setFieldValue = vi.fn();
+		const setFieldTouched = vi.fn();
+		const { rerender } = renderHook(
+			({ parameters }) =>
+				useSyncFormParameters({
+					parameters,
+					autofillParameters: [
+						{
+							name: ephemeralParameter.name,
+							value: "3",
+							source: "url",
+						},
+					],
+					formValues,
+					touched: {},
+					setFieldValue,
+					setFieldTouched,
+				}),
+			{ initialProps: { parameters: [MockPreviewParameter1] } },
+		);
+
+		rerender({
+			parameters: [MockPreviewParameter1, ephemeralParameter],
+		});
+
+		await waitFor(() => {
+			expect(setFieldValue).toHaveBeenCalledWith("rich_parameter_values", [
+				...formValues,
+				{
+					name: ephemeralParameter.name,
+					value: ephemeralParameter.value.value,
+				},
+			]);
+		});
+		expect(setFieldTouched).not.toHaveBeenCalled();
+	});
+});

--- a/site/src/modules/hooks/useSyncFormParameters.ts
+++ b/site/src/modules/hooks/useSyncFormParameters.ts
@@ -2,9 +2,14 @@ import type { FormikTouched } from "formik";
 import { useEffect, useRef } from "react";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { PreviewParameter } from "#/api/typesGenerated";
+import {
+	type AutofillBuildParameter,
+	isValidParameterOption,
+} from "#/utils/richParameters";
 
 type UseSyncFormParametersProps = {
 	parameters: readonly PreviewParameter[];
+	autofillParameters: readonly AutofillBuildParameter[];
 	formValues: readonly TypesGen.WorkspaceBuildParameter[];
 	touched: FormikTouched<{
 		rich_parameter_values?: readonly TypesGen.WorkspaceBuildParameter[];
@@ -13,13 +18,20 @@ type UseSyncFormParametersProps = {
 		field: string,
 		value: TypesGen.WorkspaceBuildParameter[],
 	) => void;
+	setFieldTouched: (
+		field: string,
+		isTouched?: boolean,
+		shouldValidate?: boolean,
+	) => void;
 };
 
 export function useSyncFormParameters({
 	parameters,
+	autofillParameters,
 	formValues,
 	touched,
 	setFieldValue,
+	setFieldTouched,
 }: UseSyncFormParametersProps) {
 	// Form values only needs to be updated when parameters change
 	// Keep track of form values in a ref to avoid unnecessary updates to rich_parameter_values
@@ -33,6 +45,10 @@ export function useSyncFormParameters({
 		const currentFormValuesMap = new Map(
 			currentFormValues.map((value) => [value.name, value.value]),
 		);
+		const autofillByName = new Map(
+			autofillParameters.map((value) => [value.name, value]),
+		);
+		const newlyAutofilledParameters: string[] = [];
 
 		const newParameterValues = parameters.map((param) => {
 			// Do not mess with values the user has changed (or were auto-filled).
@@ -51,6 +67,17 @@ export function useSyncFormParameters({
 				}
 			}
 
+			const autofillParameter = autofillByName.get(param.name);
+			if (
+				!currentFormValuesMap.has(param.name) &&
+				!param.ephemeral &&
+				autofillParameter &&
+				isValidParameterOption(param, autofillParameter)
+			) {
+				newlyAutofilledParameters.push(param.name);
+				return { name: param.name, value: autofillParameter.value };
+			}
+
 			return {
 				name: param.name,
 				value: param.value.valid ? param.value.value : "",
@@ -67,6 +94,9 @@ export function useSyncFormParameters({
 
 		if (isChanged) {
 			setFieldValue("rich_parameter_values", newParameterValues);
+			for (const parameterName of newlyAutofilledParameters) {
+				setFieldTouched(parameterName, true, false);
+			}
 		}
-	}, [parameters, touched, setFieldValue]);
+	}, [parameters, autofillParameters, touched, setFieldValue, setFieldTouched]);
 }

--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
@@ -46,7 +46,10 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { cn } from "#/utils/cn";
-import type { AutofillBuildParameter } from "#/utils/richParameters";
+import {
+	type AutofillBuildParameter,
+	isValidParameterOption,
+} from "#/utils/richParameters";
 
 interface DynamicParameterProps {
 	parameter: PreviewParameter;
@@ -707,43 +710,6 @@ export const getInitialParameterValues = (
 
 const validValue = (value: NullHCLString) => {
 	return value.valid ? value.value : "";
-};
-
-const isValidParameterOption = (
-	previewParam: PreviewParameter,
-	buildParam: WorkspaceBuildParameter,
-) => {
-	// multi-select is the only list(string) type with options
-	if (previewParam.form_type === "multi-select") {
-		let values: string[] = [];
-		try {
-			const parsed = JSON.parse(buildParam.value);
-			if (Array.isArray(parsed)) {
-				values = parsed;
-			}
-		} catch {
-			return false;
-		}
-
-		if (previewParam.options.length > 0) {
-			const validValues = previewParam.options.map(
-				(option) => option.value.value,
-			);
-			return values.some((value) => validValues.includes(value));
-		}
-		return false;
-	}
-
-	// For parameters with options (dropdown, radio)
-	if (previewParam.options.length > 0) {
-		const validValues = previewParam.options.map(
-			(option) => option.value.value,
-		);
-		return validValues.includes(buildParam.value);
-	}
-
-	// For parameters without options (input,textarea,switch,checkbox,tag-select)
-	return true;
 };
 
 export const useValidationSchemaForDynamicParameters = (

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, screen, within } from "storybook/test";
+import { useState } from "react";
+import { expect, screen, userEvent, within } from "storybook/test";
 import { DetailedError } from "#/api/errors";
 import type { Preset, PreviewParameter } from "#/api/typesGenerated";
 import { chromatic } from "#/testHelpers/chromatic";
@@ -97,6 +98,26 @@ const parameterInput: PreviewParameter = {
 	required: true,
 	order: 0,
 	ephemeral: false,
+};
+
+const conditionalParameter: PreviewParameter = {
+	...parameterInput,
+	name: "app_name",
+	display_name: "App Name",
+	description: "A name for the conditionally enabled app",
+	value: { valid: true, value: "" },
+	default_value: { valid: true, value: "" },
+	order: 1,
+};
+
+const countParameter: PreviewParameter = {
+	...parameterInput,
+	name: "app_count",
+	display_name: "App Count",
+	description: "The number of apps to create",
+	type: "number",
+	value: { valid: true, value: "0" },
+	default_value: { valid: true, value: "0" },
 };
 
 const parameterDropdown: PreviewParameter = {
@@ -355,6 +376,38 @@ export const WithParameters: Story = {
 					"This story demonstrates a workspace creation form with presets and a variety of parameter types including text inputs, dropdowns, sliders, switches, radio buttons, multi-select, textarea, and checkboxes.",
 			},
 		},
+	},
+};
+
+export const WithConditionalUrlAutofill: Story = {
+	args: {
+		parameters: [countParameter],
+		autofillParameters: [
+			{ name: conditionalParameter.name, value: "Admin", source: "url" },
+		],
+	},
+	render: (args) => {
+		const [parameters, setParameters] = useState(args.parameters);
+		return (
+			<CreateWorkspacePageView
+				{...args}
+				parameters={parameters}
+				sendMessage={(values) => {
+					args.sendMessage(values);
+					if (values[countParameter.name] === "1") {
+						setParameters([...args.parameters, conditionalParameter]);
+					}
+				}}
+			/>
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const countInput = canvas.getByLabelText(/app count/i);
+		await userEvent.clear(countInput);
+		await userEvent.type(countInput, "1");
+		await expect(canvas.findByDisplayValue("Admin")).resolves.toBeVisible();
+		expect(canvas.getByText("URL Autofill")).toBeVisible();
 	},
 };
 

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -377,9 +377,11 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 
 	useSyncFormParameters({
 		parameters,
+		autofillParameters,
 		formValues: form.values.rich_parameter_values ?? [],
 		touched: form.touched,
 		setFieldValue: form.setFieldValue,
+		setFieldTouched: form.setFieldTouched,
 	});
 
 	const disabled =

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageView.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageView.tsx
@@ -113,9 +113,11 @@ export const WorkspaceParametersPageView: FC<
 
 	useSyncFormParameters({
 		parameters,
+		autofillParameters,
 		formValues: form.values.rich_parameter_values ?? [],
 		touched: form.touched,
 		setFieldValue: form.setFieldValue,
+		setFieldTouched: form.setFieldTouched,
 	});
 
 	// True when the form holds values the backend hasn't evaluated

--- a/site/src/utils/richParameters.ts
+++ b/site/src/utils/richParameters.ts
@@ -1,5 +1,6 @@
 import * as Yup from "yup";
 import type {
+	PreviewParameter,
 	TemplateVersionParameter,
 	WorkspaceBuildParameter,
 } from "#/api/typesGenerated";
@@ -48,6 +49,41 @@ const isValidValue = (
 ) => {
 	if (templateParam.options.length > 0) {
 		const validValues = templateParam.options.map((option) => option.value);
+		return validValues.includes(buildParam.value);
+	}
+
+	return true;
+};
+
+export const isValidParameterOption = (
+	previewParam: PreviewParameter,
+	buildParam: WorkspaceBuildParameter,
+) => {
+	// multi-select is the only list(string) type with options
+	if (previewParam.form_type === "multi-select") {
+		let values: string[] = [];
+		try {
+			const parsed = JSON.parse(buildParam.value);
+			if (Array.isArray(parsed)) {
+				values = parsed;
+			}
+		} catch {
+			return false;
+		}
+
+		if (previewParam.options.length > 0) {
+			const validValues = previewParam.options.map(
+				(option) => option.value.value,
+			);
+			return values.some((value) => validValues.includes(value));
+		}
+		return false;
+	}
+
+	if (previewParam.options.length > 0) {
+		const validValues = previewParam.options.map(
+			(option) => option.value.value,
+		);
 		return validValues.includes(buildParam.value);
 	}
 


### PR DESCRIPTION
## Summary

- Seed newly appearing conditional dynamic parameters from valid autofill values.
- Preserve template/server values for invalid option autofill and ephemeral parameters.
- Reuse the option-validation helper in both initial form setup and WebSocket synchronization.
- Add focused hook tests and a Storybook interaction regression.

Fixes #26775.

## Root cause

Formik initializes before count-gated parameters exist. When the WebSocket later introduces one of those parameters, `useSyncFormParameters` previously copied the empty server default without consulting the URL autofill values that had already reached the client. The field therefore showed the `URL Autofill` badge while remaining blank.

## Manual verification

Before: the conditional field appears with the autofill badge but no value.

![Before: conditional App Name is blank](https://raw.githubusercontent.com/sidsri14/coder/evidence-26775/pr-evidence/26775-before.png)

After: the same field is populated with `Admin` when it appears.

![After: conditional App Name contains Admin](https://raw.githubusercontent.com/sidsri14/coder/evidence-26775/pr-evidence/26775-after.png)

## Validation

- `git diff --check origin/main...HEAD`
- Biome check on all 7 changed files
- `pnpm --dir site exec vitest run src/modules/hooks/useSyncFormParameters.test.ts --project unit --maxWorkers 1 --no-file-parallelism` (3 passed)
- `pnpm --dir site run lint:types`
- `pnpm --dir site exec vitest run src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx --project storybook --maxWorkers 1 --no-file-parallelism` (12 passed)

The full frontend unit suite was also attempted with two workers, but produced no summary before the 10-minute local cap and was terminated without failure output. The repository pre-commit wrapper could not run on this Windows checkout because `make` is unavailable; the relevant frontend checks above were run directly.

## AI disclosure

This change was developed with AI assistance. I manually reviewed the final diff, verified the issue before and after in Storybook, captured the screenshots above, and ran the listed checks.