### PR TITLE
fix(coderd): reject workspace proxy hostname prefixes

### DIFF
--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -2076,6 +2076,13 @@ func TestProxyByHostname(t *testing.T) {
 			matchProxyName:    "one",
 		},
 		{
+			name:              "RejectAccessURLPrefix",
+			testHostname:      "one.coder",
+			allowAccessURL:    true,
+			allowWildcardHost: false,
+			matchProxyName:    "",
+		},
+		{
 			name:              "MatchWildcard",
 			testHostname:      "something.wildcard.one.coder.com",
 			allowAccessURL:    true,
@@ -2083,11 +2090,25 @@ func TestProxyByHostname(t *testing.T) {
 			matchProxyName:    "one",
 		},
 		{
+			name:              "RejectWildcardHostnamePrefix",
+			testHostname:      "something.wildcard.one.coder",
+			allowAccessURL:    false,
+			allowWildcardHost: true,
+			matchProxyName:    "",
+		},
+		{
 			name:              "MatchSuffix",
 			testHostname:      "something--suffix.two.coder.com",
 			allowAccessURL:    true,
 			allowWildcardHost: true,
 			matchProxyName:    "two",
+		},
+		{
+			name:              "RejectSuffixHostnamePrefix",
+			testHostname:      "something--suffix.two.coder",
+			allowAccessURL:    false,
+			allowWildcardHost: true,
+			matchProxyName:    "",
 		},
 		{
 			name:              "ValidateHostname/1",

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -2083,6 +2083,13 @@ func TestProxyByHostname(t *testing.T) {
 			matchProxyName:    "",
 		},
 		{
+			name:              "RejectAccessURLTLDPrefix",
+			testHostname:      "one.coder.co",
+			allowAccessURL:    true,
+			allowWildcardHost: false,
+			matchProxyName:    "",
+		},
+		{
 			name:              "MatchWildcard",
 			testHostname:      "something.wildcard.one.coder.com",
 			allowAccessURL:    true,

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -2045,6 +2045,16 @@ func TestProxyByHostname(t *testing.T) {
 			accessURL:        "https://two.coder.com",
 			wildcardHostname: "*--suffix.two.coder.com",
 		},
+		{
+			name:             "three",
+			accessURL:        "https://three.coder.com:8443",
+			wildcardHostname: "*.wildcard.three.coder.com",
+		},
+		{
+			name:             "four",
+			accessURL:        "https://four.coder.com/",
+			wildcardHostname: "*.wildcard.four.coder.com",
+		},
 	}
 	for _, p := range proxies {
 		dbgen.WorkspaceProxy(t, db, database.WorkspaceProxy{
@@ -2074,6 +2084,20 @@ func TestProxyByHostname(t *testing.T) {
 			allowAccessURL:    true,
 			allowWildcardHost: true,
 			matchProxyName:    "one",
+		},
+		{
+			name:              "MatchAccessURLWithPort",
+			testHostname:      "three.coder.com",
+			allowAccessURL:    true,
+			allowWildcardHost: false,
+			matchProxyName:    "three",
+		},
+		{
+			name:              "MatchAccessURLWithTrailingSlash",
+			testHostname:      "four.coder.com",
+			allowAccessURL:    true,
+			allowWildcardHost: false,
+			matchProxyName:    "four",
 		},
 		{
 			name:              "RejectAccessURLPrefix",

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -24017,7 +24017,7 @@ WHERE
 	(
 		(
 			$2 :: bool = true AND
-			url SIMILAR TO '[^:]*://' || $1 :: text || '([:/]?%)*'
+			url SIMILAR TO '[^:]*://' || $1 :: text || '([:/]%)*'
 		) OR
 		(
 			$3 :: bool = true AND

--- a/coderd/database/queries/proxies.sql
+++ b/coderd/database/queries/proxies.sql
@@ -120,7 +120,7 @@ WHERE
 	(
 		(
 			@allow_access_url :: bool = true AND
-			url SIMILAR TO '[^:]*://' || @hostname :: text || '([:/]?%)*'
+			url SIMILAR TO '[^:]*://' || @hostname :: text || '([:/]%)*'
 		) OR
 		(
 			@allow_wildcard_hostname :: bool = true AND

--- a/coderd/workspaceapps_test.go
+++ b/coderd/workspaceapps_test.go
@@ -116,6 +116,15 @@ func TestWorkspaceApplicationAuth(t *testing.T) {
 			expectRedirect:   "https://proxy.test.coder.com/path",
 		},
 		{
+			name:             "RejectProxyAccessURLPrefix",
+			accessURL:        "https://test.coder.com",
+			appHostname:      "*.test.coder.com",
+			proxyURL:         "https://proxy.test.coder.com",
+			proxyAppHostname: "*.proxy.test.coder.com",
+			redirectURI:      "https://proxy.test.coder/path",
+			expectRedirect:   "",
+		},
+		{
 			name:             "ProxySubdomainOK",
 			accessURL:        "https://test.coder.com",
 			appHostname:      "*.test.coder.com",


### PR DESCRIPTION
A workspace proxy hostname prefix could be accepted as a valid proxy
access URL. An authenticated user could then be redirected to an
attacker-controlled domain with an application-connect API key in the
URL.

Require proxy access URL matches to have a hostname boundary after the
candidate hostname, allowing only the end of the URL, a port, or a
path.

Add regression coverage for proxy access URL and wildcard hostname
prefixes.

Refs: https://linear.app/codercom/issue/PLAT-384
