### PR TITLE
fix: address chat lifecycle hook UAT findings

### DIFF
--- a/coderd/util/xnet/xnet.go
+++ b/coderd/util/xnet/xnet.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net"
 	"syscall"
+
+	"golang.org/x/net/http2"
 )
 
 // IsTimeoutError reports whether err indicates the peer did not respond in
@@ -31,5 +33,37 @@ func IsConnectionError(err error) bool {
 		return true
 	}
 	var opErr *net.OpError
-	return errors.As(err, &opErr)
+	if errors.As(err, &opErr) {
+		return true
+	}
+
+	// Only codes that can result from transient peer or transport conditions
+	// are safe to retry. Protocol failures must remain terminal.
+	var streamErr http2.StreamError
+	if errors.As(err, &streamErr) && isTransientHTTP2Error(streamErr.Code) {
+		return true
+	}
+	var streamErrPtr *http2.StreamError
+	if errors.As(err, &streamErrPtr) && isTransientHTTP2Error(streamErrPtr.Code) {
+		return true
+	}
+	var goAwayErr http2.GoAwayError
+	if errors.As(err, &goAwayErr) && isTransientHTTP2Error(goAwayErr.ErrCode) {
+		return true
+	}
+	var goAwayErrPtr *http2.GoAwayError
+	return errors.As(err, &goAwayErrPtr) && isTransientHTTP2Error(goAwayErrPtr.ErrCode)
+}
+
+func isTransientHTTP2Error(code http2.ErrCode) bool {
+	switch code {
+	case http2.ErrCodeNo,
+		http2.ErrCodeInternal,
+		http2.ErrCodeRefusedStream,
+		http2.ErrCodeCancel,
+		http2.ErrCodeEnhanceYourCalm:
+		return true
+	default:
+		return false
+	}
 }

--- a/coderd/util/xnet/xnet.go
+++ b/coderd/util/xnet/xnet.go
@@ -37,24 +37,17 @@ func IsConnectionError(err error) bool {
 		return true
 	}
 
-	// Only codes that can result from transient peer or transport conditions
-	// are safe to retry. Protocol failures must remain terminal.
+	// net/http bundles its own HTTP/2 implementation with unexported error
+	// types, and net/http/h2_error.go bridges only the struct form of a
+	// stream error to this package's type. A pointer target never matches,
+	// and GOAWAY errors have no such bridge.
 	var streamErr http2.StreamError
-	if errors.As(err, &streamErr) && isTransientHTTP2Error(streamErr.Code) {
-		return true
-	}
-	var streamErrPtr *http2.StreamError
-	if errors.As(err, &streamErrPtr) && isTransientHTTP2Error(streamErrPtr.Code) {
-		return true
-	}
-	var goAwayErr http2.GoAwayError
-	if errors.As(err, &goAwayErr) && isTransientHTTP2Error(goAwayErr.ErrCode) {
-		return true
-	}
-	var goAwayErrPtr *http2.GoAwayError
-	return errors.As(err, &goAwayErrPtr) && isTransientHTTP2Error(goAwayErrPtr.ErrCode)
+	return errors.As(err, &streamErr) && isTransientHTTP2Error(streamErr.Code)
 }
 
+// isTransientHTTP2Error reports whether an HTTP/2 error code can result from a
+// transient peer or transport condition. Deterministic protocol failures stay
+// terminal so a malformed consumer response is not retried.
 func isTransientHTTP2Error(code http2.ErrCode) bool {
 	switch code {
 	case http2.ErrCodeNo,

--- a/coderd/util/xnet/xnet_test.go
+++ b/coderd/util/xnet/xnet_test.go
@@ -39,16 +39,16 @@ func TestIsConnectionError(t *testing.T) {
 
 	for _, err := range []error{
 		http2.StreamError{Code: http2.ErrCodeNo},
-		&http2.StreamError{Code: http2.ErrCodeInternal},
+		http2.StreamError{Code: http2.ErrCodeInternal},
 		http2.StreamError{Code: http2.ErrCodeRefusedStream},
-		&http2.StreamError{Code: http2.ErrCodeCancel},
-		http2.GoAwayError{ErrCode: http2.ErrCodeEnhanceYourCalm},
-		&http2.GoAwayError{ErrCode: http2.ErrCodeInternal},
+		http2.StreamError{Code: http2.ErrCodeCancel},
+		http2.StreamError{Code: http2.ErrCodeEnhanceYourCalm},
+		xerrors.Errorf("read response: %w", http2.StreamError{Code: http2.ErrCodeInternal}),
 	} {
 		require.True(t, xnet.IsConnectionError(err), err)
 	}
 	require.False(t, xnet.IsConnectionError(http2.StreamError{Code: http2.ErrCodeProtocol}))
-	require.False(t, xnet.IsConnectionError(&http2.GoAwayError{ErrCode: http2.ErrCodeProtocol}))
+	require.False(t, xnet.IsConnectionError(http2.StreamError{Code: http2.ErrCodeFlowControl}))
 }
 
 func TestIsConnectionErrorHTTPResponseAbort(t *testing.T) {

--- a/coderd/util/xnet/xnet_test.go
+++ b/coderd/util/xnet/xnet_test.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"syscall"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
 	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/coderd/util/xnet"
@@ -32,4 +36,54 @@ func TestIsConnectionError(t *testing.T) {
 	require.True(t, xnet.IsConnectionError(io.ErrUnexpectedEOF))
 	require.True(t, xnet.IsConnectionError(xerrors.Errorf("write: %w", syscall.EPIPE)))
 	require.True(t, xnet.IsConnectionError(&net.OpError{Op: "read", Err: syscall.ECONNRESET}))
+
+	for _, err := range []error{
+		http2.StreamError{Code: http2.ErrCodeNo},
+		&http2.StreamError{Code: http2.ErrCodeInternal},
+		http2.StreamError{Code: http2.ErrCodeRefusedStream},
+		&http2.StreamError{Code: http2.ErrCodeCancel},
+		http2.GoAwayError{ErrCode: http2.ErrCodeEnhanceYourCalm},
+		&http2.GoAwayError{ErrCode: http2.ErrCodeInternal},
+	} {
+		require.True(t, xnet.IsConnectionError(err), err)
+	}
+	require.False(t, xnet.IsConnectionError(http2.StreamError{Code: http2.ErrCodeProtocol}))
+	require.False(t, xnet.IsConnectionError(&http2.GoAwayError{ErrCode: http2.ErrCodeProtocol}))
+}
+
+func TestIsConnectionErrorHTTPResponseAbort(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name        string
+		enableHTTP2 bool
+		proto       string
+	}{
+		{name: "http1", proto: "HTTP/1.1"},
+		{name: "http2", enableHTTP2: true, proto: "HTTP/2.0"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, err := w.Write([]byte(`{"partial":`))
+				assert.NoError(t, err)
+				assert.NoError(t, http.NewResponseController(w).Flush())
+				panic(http.ErrAbortHandler)
+			}))
+			server.EnableHTTP2 = tc.enableHTTP2
+			server.StartTLS()
+			t.Cleanup(server.Close)
+
+			request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, nil)
+			require.NoError(t, err)
+			response, err := server.Client().Do(request)
+			require.NoError(t, err)
+			require.Equal(t, tc.proto, response.Proto)
+			_, err = io.ReadAll(response.Body)
+			require.Error(t, err)
+			require.NoError(t, response.Body.Close())
+			require.True(t, xnet.IsConnectionError(err), err)
+		})
+	}
 }

--- a/coderd/x/agenthooks/dispatch/dispatcher.go
+++ b/coderd/x/agenthooks/dispatch/dispatcher.go
@@ -231,7 +231,7 @@ func (d *Dispatcher) finish(
 			slog.F("dispatch_id", dispatchID),
 			slog.F("event", event.Type),
 			slog.F("result", outcome.result),
-			slog.Error(outcome.err),
+			slog.F("error", outcome.err.Error()),
 		)
 	} else {
 		d.logger.Debug(context.WithoutCancel(ctx), "chat hook dispatched",

--- a/coderd/x/agenthooks/dispatch/dispatcher_internal_test.go
+++ b/coderd/x/agenthooks/dispatch/dispatcher_internal_test.go
@@ -252,6 +252,51 @@ func TestDispatcherRetriesConnectionErrorWithSameJTI(t *testing.T) {
 	require.Equal(t, event.ChatID, chatID)
 }
 
+func TestDispatcherRetriesHTTP2AbortWithSameDispatchID(t *testing.T) {
+	t.Parallel()
+
+	event := newTestEvent(t, agenthooks.EventPostCompact, agenthooks.PostCompactData{})
+	type attemptIdentity struct {
+		jti        uuid.UUID
+		dispatchID uuid.UUID
+	}
+	identities := make(chan attemptIdentity, 2)
+	var attempts atomic.Int32
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, 2, r.ProtoMajor)
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		claims, err := agenthooks.Verify(r.Header.Get("Authorization"), []byte(testSecret))
+		assert.NoError(t, err)
+		var request agenthooks.Request
+		assert.NoError(t, json.Unmarshal(body, &request))
+		identities <- attemptIdentity{jti: claims.JTI, dispatchID: request.Meta.DispatchID}
+
+		if attempts.Add(1) == 1 {
+			_, err = w.Write([]byte(`{"partial":`))
+			assert.NoError(t, err)
+			assert.NoError(t, http.NewResponseController(w).Flush())
+			panic(http.ErrAbortHandler)
+		}
+		_, err = w.Write([]byte(`{}`))
+		assert.NoError(t, err)
+	}))
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	_, dispatchID, err := newTestDispatcher(t, server.Client(), server.URL, time.Second).Dispatch(
+		testutil.Context(t, testutil.WaitLong), event,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int32(2), attempts.Load())
+	first := <-identities
+	second := <-identities
+	require.Equal(t, first, second)
+	require.Equal(t, dispatchID, first.jti)
+	require.Equal(t, dispatchID, first.dispatchID)
+}
+
 func TestDispatcherRetriesMidBodyConnectionError(t *testing.T) {
 	t.Parallel()
 

--- a/docs/admin/setup/chat-lifecycle-hooks.md
+++ b/docs/admin/setup/chat-lifecycle-hooks.md
@@ -142,8 +142,8 @@ Coder dispatches `pre_tool_use` once per tool call, after the model finishes pro
 Two consequences follow:
 
 - Clients stream the model's proposed tool input while the dispatch is in flight, then converge on the stored input once the message is committed.
-  A rewritten call can display the original input for up to `CODER_CHAT_HOOK_TIMEOUT`; the row spinner remains after the live **Thinking** indicator clears.
-  Because Coder dispatches tool calls sequentially, step latency increases with each tool call.
+  A rewritten call keeps displaying the original input until the whole batch is admitted, and the row spinner remains after the live **Thinking** indicator clears.
+  Coder dispatches a batch sequentially, so that window is bounded by `CODER_CHAT_HOOK_TIMEOUT` multiplied by the number of tool calls in the step, not by a single timeout.
 - A tool call that is already in chat history was admitted before it was stored, so Coder executes it with the stored input instead of dispatching a second decision. If a consumer's policy changes between those two points, the change applies to later calls, not to calls already admitted. A call stored before hooks were configured is likewise not admitted retroactively, the same way an earlier prompt isn't.
 
 The per-chat debug endpoint records what the model proposed, including tool input that a consumer replaced. It reports provider behavior and is not part of the chat transcript.

--- a/docs/admin/setup/chat-lifecycle-hooks.md
+++ b/docs/admin/setup/chat-lifecycle-hooks.md
@@ -141,7 +141,9 @@ Coder dispatches `pre_tool_use` once per tool call, after the model finishes pro
 
 Two consequences follow:
 
-- Clients stream the model's proposed tool input while the dispatch is in flight, then converge on the stored input once the message is committed. A rewritten call briefly displays the original input.
+- Clients stream the model's proposed tool input while the dispatch is in flight, then converge on the stored input once the message is committed.
+  A rewritten call can display the original input for up to `CODER_CHAT_HOOK_TIMEOUT`; the row spinner remains after the live **Thinking** indicator clears.
+  Because Coder dispatches tool calls sequentially, step latency increases with each tool call.
 - A tool call that is already in chat history was admitted before it was stored, so Coder executes it with the stored input instead of dispatching a second decision. If a consumer's policy changes between those two points, the change applies to later calls, not to calls already admitted. A call stored before hooks were configured is likewise not admitted retroactively, the same way an earlier prompt isn't.
 
 The per-chat debug endpoint records what the model proposed, including tool input that a consumer replaced. It reports provider behavior and is not part of the chat transcript.

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -463,7 +463,11 @@ export const LifecycleHookNoticeOnUserMessage: Story = {
 		const notice = canvas.getByRole("note");
 		expect(notice).toBeVisible();
 		expect(within(notice).getByText("Lifecycle hook")).toBeVisible();
-		expect(canvas.getByText("original prompt")).toBeVisible();
+		const prompt = canvas.getByText("original prompt");
+		expect(prompt).toBeVisible();
+		expect(
+			prompt.compareDocumentPosition(notice) & Node.DOCUMENT_POSITION_FOLLOWING,
+		).toBeTruthy();
 		const link = within(notice).getByRole("link", { name: "policy" });
 		expect(link).toHaveAttribute("href", "https://proxy.example.com/policy");
 	},

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -652,14 +652,6 @@ const ChatMessageItem = memo<{
 				)}
 				inert={isAfterEditingMessage ? true : undefined}
 			>
-				{parsed.hookNotices.map((notice, index) => (
-					<LifecycleHookNotice
-						key={`${message.id}-hook-notice-${index}`}
-						urlTransform={urlTransform}
-					>
-						{notice}
-					</LifecycleHookNotice>
-				))}
 				<ConversationItem {...conversationItemProps}>
 					{isUser ? (
 						<UserMessageContent
@@ -704,6 +696,14 @@ const ChatMessageItem = memo<{
 						</Message>
 					)}
 				</ConversationItem>
+				{parsed.hookNotices.map((notice, index) => (
+					<LifecycleHookNotice
+						key={`${message.id}-hook-notice-${index}`}
+						urlTransform={urlTransform}
+					>
+						{notice}
+					</LifecycleHookNotice>
+				))}
 				{!hideActions &&
 					(displayState.hasCopyableContent ||
 						(isUser && onEditUserMessage)) && (

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
@@ -74,6 +74,8 @@ export const ExecuteTool: React.FC<ExecuteToolProps> = ({
 		modelIntent,
 		parsedCommands,
 		durationLabel,
+		isRunning,
+		isError,
 	});
 	const defaultView = resolveAgentDisplayState(
 		shellToolDisplayMode,
@@ -159,6 +161,8 @@ type ShellCommandLineInput = {
 	modelIntent?: string;
 	parsedCommands?: readonly string[][];
 	durationLabel: string;
+	isRunning: boolean;
+	isError: boolean;
 };
 
 const getShellCommandLine = ({
@@ -166,6 +170,8 @@ const getShellCommandLine = ({
 	modelIntent,
 	parsedCommands,
 	durationLabel,
+	isRunning,
+	isError,
 }: ShellCommandLineInput): { commandLabel: string; durationSuffix: string } => {
 	const intentLabel = sanitizeExecuteModelIntent(modelIntent, command);
 	const summary =
@@ -173,9 +179,12 @@ const getShellCommandLine = ({
 			? summarizeParsedCommands(parsedCommands)
 			: "";
 	const commandDisplay = summary || command;
-	const commandLabel = intentLabel
+	let commandLabel = intentLabel
 		? `${intentLabel} using ${commandDisplay}`
 		: `Ran ${commandDisplay}`;
+	if (!isRunning && isError) {
+		commandLabel = `Failed to run ${commandDisplay}`;
+	}
 
 	return {
 		commandLabel,

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -414,6 +414,10 @@ export const ExecuteDeniedByHook: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
+		expect(canvas.getByText(/Failed to run cat \/etc\/secrets/)).toBeVisible();
+		expect(
+			canvas.queryByText(/Ran cat \/etc\/secrets/),
+		).not.toBeInTheDocument();
 		await expect(
 			canvas.getByRole("img", {
 				name: /blocked by an external policy/,


### PR DESCRIPTION
## Stack Context

This stack adds chat lifecycle hooks (#27401 → #27428 → #27429 → #27430). Full UAT against the stack tip surfaced defects that are in scope for the feature but not yet fixed. This PR carries the self-contained ones.

It sits on top of the stack rather than in the PRs the fixes logically belong to, because those heads already carry green CI and completed reviews. The stack merges together, so placement here changes nothing about what ships.

## What?

Five independent fixes, one per commit:

| Fix | Area | Symptom |
|---|---|---|
| HTTP/2 dispatch retry | `coderd/util/xnet` | The documented single connection retry never fired for HTTP/2 consumers |
| Dispatch log noise | `coderd/x/agenthooks` | Every failed dispatch logged a full stack trace |
| Denied `execute` label | `site` | A blocked command rendered as `Ran cat`, as if it had executed |
| Hook notice placement | `site` | The "prompt was rewritten" card rendered above the message it annotates |
| Convergence latency docs | `docs` | "briefly displays the original input" understated the window |

## Why?

**HTTP/2 retry.** `Dispatcher.post` retries only when `xnet.IsConnectionError` is true. An aborted response mid-request classifies as `connection_error` over HTTP/1.1 and is retried, but over HTTP/2 it arrives as a stream error, classified `protocol_error`, and the chat turn fails. Go's default transport negotiates h2 against any TLS consumer, so this is the common deployment shape, not an edge case.

Only transient codes (`NO_ERROR`, `INTERNAL_ERROR`, `REFUSED_STREAM`, `CANCEL`, `ENHANCE_YOUR_CALM`) are treated as retryable. `PROTOCOL_ERROR` and friends stay terminal so a malformed consumer response is not retried. The retry reuses the dispatch ID, which the consumer contract already requires to be idempotent.

Worth noting for review: `net/http` bundles its own HTTP/2 implementation with unexported error types. `net/http/h2_error.go` bridges only the **struct** form of a stream error to `x/net/http2`, so a pointer target or a GOAWAY target never matches. The check is deliberately narrow for that reason, and a test drives a real h2 server rather than asserting against synthetic `x/net` values that production never produces.

**Denied `execute` label.** #27430 already fixed this misrepresentation for `write_file` and `edit_files`. `execute` was the missed case. The label derives from `isError` (the tool-result protocol flag), not from the execute result's `success` field, so a real command that ran and exited non-zero correctly keeps its "Ran" wording.

**Convergence docs.** A batch dispatches sequentially before the assistant row commits, so the first call's original input stays visible until the whole batch is admitted. The bound scales with the number of tool calls in the step, not a single `CODER_CHAT_HOOK_TIMEOUT`.

## Testing

- New h2 and h1 abort tests drive a real TLS server; red-green verified by reverting the production change and confirming all three new tests fail.
- `go test -race ./coderd/util/xnet/... ./coderd/x/agenthooks/...`
- Story assertions added for the denied-execute label and the notice ordering.
- `pnpm lint:types`, `pnpm lint:compiler`, `pnpm run lint-docs`.

> Mux prepared this PR on Mike's behalf.
