### PR TITLE
fix: classify chat lifecycle hook denials as policy decisions

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -17341,7 +17341,8 @@ const docTemplate = `{
                 "missing_key",
                 "provider_disabled",
                 "content_filter",
-                "hook_dispatch_failed"
+                "hook_dispatch_failed",
+                "hook_denied"
             ],
             "x-enum-varnames": [
                 "ChatErrorKindGeneric",
@@ -17355,7 +17356,8 @@ const docTemplate = `{
                 "ChatErrorKindMissingKey",
                 "ChatErrorKindProviderDisabled",
                 "ChatErrorKindContentFilter",
-                "ChatErrorKindHookDispatchFailed"
+                "ChatErrorKindHookDispatchFailed",
+                "ChatErrorKindHookDenied"
             ]
         },
         "codersdk.ChatFileMetadata": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -15599,7 +15599,8 @@
 				"missing_key",
 				"provider_disabled",
 				"content_filter",
-				"hook_dispatch_failed"
+				"hook_dispatch_failed",
+				"hook_denied"
 			],
 			"x-enum-varnames": [
 				"ChatErrorKindGeneric",
@@ -15613,7 +15614,8 @@
 				"ChatErrorKindMissingKey",
 				"ChatErrorKindProviderDisabled",
 				"ChatErrorKindContentFilter",
-				"ChatErrorKindHookDispatchFailed"
+				"ChatErrorKindHookDispatchFailed",
+				"ChatErrorKindHookDenied"
 			]
 		},
 		"codersdk.ChatFileMetadata": {

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -132,7 +132,10 @@ func writeChatHookErr(ctx context.Context, rw http.ResponseWriter, err error, de
 		if message == "" {
 			message = deniedFallback
 		}
-		httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{Message: message})
+		httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.ChatHookDeniedResponse{
+			Response: codersdk.Response{Message: message},
+			Kind:     codersdk.ChatErrorKindHookDenied,
+		})
 		return true
 	}
 	if hookErr, ok := errors.AsType[*dispatch.Error](err); ok {

--- a/coderd/exp_chats_hooks_test.go
+++ b/coderd/exp_chats_hooks_test.go
@@ -75,7 +75,7 @@ func TestPostChatsInitialPromptHookErrors(t *testing.T) {
 			model := createAdditionalChatModelConfig(t, client, "openai", "gpt-4.1")
 			ctx := testutil.Context(t, testutil.WaitLong)
 
-			_, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
+			res, err := client.Request(ctx, http.MethodPost, "/api/experimental/chats", codersdk.CreateChatRequest{
 				OrganizationID: user.OrganizationID,
 				ModelConfigID:  &model.ID,
 				Content: []codersdk.ChatInputPart{{
@@ -83,10 +83,14 @@ func TestPostChatsInitialPromptHookErrors(t *testing.T) {
 					Text: "blocked prompt",
 				}},
 			})
-			sdkErr := coderdtest.SDKError(t, err)
-			require.Equal(t, test.wantStatus, sdkErr.StatusCode())
+			require.NoError(t, err)
+			defer res.Body.Close()
+			require.Equal(t, test.wantStatus, res.StatusCode)
+			var response codersdk.ChatHookDeniedResponse
+			require.NoError(t, json.NewDecoder(res.Body).Decode(&response))
 			if test.wantMessage != "" {
-				require.Equal(t, test.wantMessage, sdkErr.Message)
+				require.Equal(t, test.wantMessage, response.Message)
+				require.Equal(t, codersdk.ChatErrorKindHookDenied, response.Kind)
 			}
 			request := testutil.RequireReceive(ctx, t, requests)
 			require.Equal(t, agenthooks.EventUserPromptSubmit, request.Type)

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -1740,6 +1740,7 @@ const (
 	ChatErrorKindProviderDisabled     ChatErrorKind = "provider_disabled"
 	ChatErrorKindContentFilter        ChatErrorKind = "content_filter"
 	ChatErrorKindHookDispatchFailed   ChatErrorKind = "hook_dispatch_failed"
+	ChatErrorKindHookDenied           ChatErrorKind = "hook_denied"
 )
 
 // AllChatErrorKinds contains every ChatErrorKind value.
@@ -1757,6 +1758,7 @@ var AllChatErrorKinds = []ChatErrorKind{
 	ChatErrorKindProviderDisabled,
 	ChatErrorKindContentFilter,
 	ChatErrorKindHookDispatchFailed,
+	ChatErrorKindHookDenied,
 }
 
 // ChatError represents a terminal chat error in persisted chat state or the
@@ -2021,6 +2023,14 @@ type ChatUsageLimitExceededResponse struct {
 // lifecycle hook dispatch fails during a synchronous chat operation.
 // Kind lets clients classify the failure without parsing message text.
 type ChatHookDispatchFailedResponse struct {
+	Response
+	Kind ChatErrorKind `json:"kind"`
+}
+
+// ChatHookDeniedResponse is the error body returned when a lifecycle hook
+// denies a synchronous chat operation. Kind lets clients classify the denial
+// without parsing message text.
+type ChatHookDeniedResponse struct {
 	Response
 	Kind ChatErrorKind `json:"kind"`
 }

--- a/docs/reference/api/chats.md
+++ b/docs/reference/api/chats.md
@@ -225,12 +225,12 @@ Status Code **200**
 
 #### Enumerated Values
 
-| Property      | Value(s)                                                                                                                                                                                                                                           |
-|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `client_type` | `api`, `ui`                                                                                                                                                                                                                                        |
-| `kind`        | `auth`, `config`, `content_filter`, `generic`, `hook_dispatch_failed`, `instruction_file`, `mcp_config`, `mcp_server`, `missing_key`, `overloaded`, `provider_disabled`, `rate_limit`, `skill`, `stream_silence_timeout`, `timeout`, `usage_limit` |
-| `status`      | `error`, `excluded`, `interrupting`, `invalid`, `ok`, `oversize`, `requires_action`, `running`, `unreadable`, `waiting`                                                                                                                            |
-| `plan_mode`   | `plan`                                                                                                                                                                                                                                             |
+| Property      | Value(s)                                                                                                                                                                                                                                                          |
+|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `client_type` | `api`, `ui`                                                                                                                                                                                                                                                       |
+| `kind`        | `auth`, `config`, `content_filter`, `generic`, `hook_denied`, `hook_dispatch_failed`, `instruction_file`, `mcp_config`, `mcp_server`, `missing_key`, `overloaded`, `provider_disabled`, `rate_limit`, `skill`, `stream_silence_timeout`, `timeout`, `usage_limit` |
+| `status`      | `error`, `excluded`, `interrupting`, `invalid`, `ok`, `oversize`, `requires_action`, `running`, `unreadable`, `waiting`                                                                                                                                           |
+| `plan_mode`   | `plan`                                                                                                                                                                                                                                                            |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2658,9 +2658,9 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 #### Enumerated Values
 
-| Value(s)                                                                                                                                                                                  |
-|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `auth`, `config`, `content_filter`, `generic`, `hook_dispatch_failed`, `missing_key`, `overloaded`, `provider_disabled`, `rate_limit`, `stream_silence_timeout`, `timeout`, `usage_limit` |
+| Value(s)                                                                                                                                                                                                 |
+|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `auth`, `config`, `content_filter`, `generic`, `hook_denied`, `hook_dispatch_failed`, `missing_key`, `overloaded`, `provider_disabled`, `rate_limit`, `stream_silence_timeout`, `timeout`, `usage_limit` |
 
 ## codersdk.ChatFileMetadata
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2460,6 +2460,7 @@ export type ChatErrorKind =
 	| "config"
 	| "content_filter"
 	| "generic"
+	| "hook_denied"
 	| "hook_dispatch_failed"
 	| "missing_key"
 	| "overloaded"
@@ -2474,6 +2475,7 @@ export const ChatErrorKinds: ChatErrorKind[] = [
 	"config",
 	"content_filter",
 	"generic",
+	"hook_denied",
 	"hook_dispatch_failed",
 	"missing_key",
 	"overloaded",
@@ -2589,6 +2591,16 @@ export const ChatGitWatchWorkspaceNotFoundMessage = "Chat workspace not found.";
 // From codersdk/chats.go
 export interface ChatGroup extends Group {
 	readonly role: ChatRole;
+}
+
+// From codersdk/chats.go
+/**
+ * ChatHookDeniedResponse is the error body returned when a lifecycle hook
+ * denies a synchronous chat operation. Kind lets clients classify the denial
+ * without parsing message text.
+ */
+export interface ChatHookDeniedResponse extends Response {
+	readonly kind: ChatErrorKind;
 }
 
 // From codersdk/chats.go

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -117,6 +117,7 @@ import {
 import {
 	type ChatDetailError,
 	formatUsageLimitMessage,
+	isChatHookDeniedResponse,
 	isChatHookDispatchFailedResponse,
 	isChatUsageLimitExceededResponse,
 } from "./utils/usageLimitMessage";
@@ -1368,10 +1369,13 @@ const AgentChatPage: FC = () => {
 			setChatErrorReason(agentId, reason);
 		} else if (isApiError(error)) {
 			const detail = error.response?.data?.detail?.trim() || undefined;
-			const reason: ChatDetailError = {
-				kind: isChatHookDispatchFailedResponse(error.response?.data)
+			const kind = isChatHookDeniedResponse(error.response?.data)
+				? "hook_denied"
+				: isChatHookDispatchFailedResponse(error.response?.data)
 					? "hook_dispatch_failed"
-					: "generic",
+					: "generic";
+			const reason: ChatDetailError = {
+				kind,
 				message: getErrorMessage(error, "An unexpected error occurred."),
 				...(detail ? { detail } : {}),
 			};

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -816,6 +816,84 @@ export const UsageLimitExceeded: Story = {
 	},
 };
 
+export const HookDispatchFailed: Story = {
+	args: {
+		...defaultArgs,
+		createError: Object.assign(
+			new Error("Request failed with status code 502"),
+			{
+				isAxiosError: true,
+				response: {
+					status: 502,
+					statusText: "Bad Gateway",
+					data: {
+						kind: "hook_dispatch_failed",
+						message: "Chat lifecycle hook dispatch failed.",
+						detail:
+							"Lifecycle hook dispatch 00000000-0000-0000-0000-000000000001 failed (http_error).",
+					},
+					headers: {},
+					config: {},
+				},
+				config: {},
+				toJSON: () => ({}),
+			},
+		),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByText("Lifecycle hook failed")).toBeVisible();
+		await expect(
+			canvas.getByText("Chat lifecycle hook dispatch failed."),
+		).toBeVisible();
+		await expect(
+			canvas.getByText(
+				"Lifecycle hook dispatch 00000000-0000-0000-0000-000000000001 failed (http_error).",
+			),
+		).toBeVisible();
+		await expect(canvas.queryByText("Stack Trace")).not.toBeInTheDocument();
+		await expect(canvas.queryByText("Response data")).not.toBeInTheDocument();
+	},
+};
+
+export const HookDenied: Story = {
+	args: {
+		...defaultArgs,
+		createError: Object.assign(
+			new Error("Request failed with status code 403"),
+			{
+				isAxiosError: true,
+				response: {
+					status: 403,
+					statusText: "Forbidden",
+					data: {
+						kind: "hook_denied",
+						message: "This prompt is blocked by policy.",
+					},
+					headers: {},
+					config: {},
+				},
+				config: {},
+				toJSON: () => ({}),
+			},
+		),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByText("This prompt is blocked by policy."),
+		).toBeVisible();
+		await expect(
+			canvas.queryByText("Blocked by policy"),
+		).not.toBeInTheDocument();
+		await expect(
+			canvas.queryByText("Go to workspaces"),
+		).not.toBeInTheDocument();
+		await expect(canvas.queryByText("Stack Trace")).not.toBeInTheDocument();
+		await expect(canvas.queryByText("Response data")).not.toBeInTheDocument();
+	},
+};
+
 export const ForbiddenErrorWithRole: Story = {
 	args: {
 		...defaultArgs,

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -6,7 +6,7 @@ import { isApiError } from "#/api/errors";
 import { permittedOrganizations } from "#/api/queries/organizations";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { AgentChatSendShortcut } from "#/api/typesGenerated";
-import { Alert, AlertDescription } from "#/components/Alert/Alert";
+import { Alert, AlertDescription, AlertTitle } from "#/components/Alert/Alert";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Button } from "#/components/Button/Button";
 import { ConfirmDialog } from "#/components/Dialogs/ConfirmDialog/ConfirmDialog";
@@ -27,10 +27,13 @@ import {
 } from "../utils/reasoningEffort";
 import {
 	formatUsageLimitMessage,
+	isChatHookDeniedResponse,
+	isChatHookDispatchFailedResponse,
 	isChatUsageLimitExceededResponse,
 } from "../utils/usageLimitMessage";
 import { AgentChatInput } from "./AgentChatInput";
 import { ChatAccessDeniedAlert } from "./ChatAccessDeniedAlert";
+import { getErrorTitle } from "./ChatConversation/chatStatusHelpers";
 import type { ModelSelectorOption } from "./ChatElements";
 import { CompactOrgSelector } from "./ChatElements";
 import {
@@ -525,6 +528,30 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 							>
 								<AlertDescription>
 									{formatUsageLimitMessage(createError.response.data)}
+								</AlertDescription>
+							</Alert>
+						) : isApiError(createError) &&
+							createError.response.status === 502 &&
+							isChatHookDispatchFailedResponse(createError.response.data) ? (
+							<Alert severity="error">
+								<AlertTitle>
+									{getErrorTitle("hook_dispatch_failed", "error")}
+								</AlertTitle>
+								<AlertDescription>
+									<span>{createError.response.data.message}</span>
+									{createError.response.data.detail && (
+										<span className="mt-1 block text-content-secondary">
+											{createError.response.data.detail}
+										</span>
+									)}
+								</AlertDescription>
+							</Alert>
+						) : isApiError(createError) &&
+							createError.response.status === 403 &&
+							isChatHookDeniedResponse(createError.response.data) ? (
+							<Alert severity="info">
+								<AlertDescription>
+									{createError.response.data.message}
 								</AlertDescription>
 							</Alert>
 						) : (

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStatusHelpers.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStatusHelpers.ts
@@ -50,6 +50,8 @@ export const getErrorTitle = (
 			return "Response blocked";
 		case "hook_dispatch_failed":
 			return "Lifecycle hook failed";
+		case "hook_denied":
+			return "Blocked by policy";
 		default:
 			return mode === "retry" ? "Retrying request" : "Request failed";
 	}

--- a/site/src/pages/AgentsPage/utils/usageLimitMessage.ts
+++ b/site/src/pages/AgentsPage/utils/usageLimitMessage.ts
@@ -96,6 +96,20 @@ export function isChatHookDispatchFailedResponse(
 }
 
 /**
+ * Runtime guard for the structured 403 hook-denial response.
+ */
+export function isChatHookDeniedResponse(
+	value: unknown,
+): value is TypesGen.ChatHookDeniedResponse {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"kind" in value &&
+		value.kind === "hook_denied"
+	);
+}
+
+/**
  * Build a user-friendly usage-limit message from structured 409
  * response data. Falls back to a generic message if structured
  * fields are missing or invalid.


### PR DESCRIPTION
## Stack Context

Top of the chat lifecycle hooks stack (#27401 → #27428 → #27429 → #27430 → #27551). Fixes the last two UAT findings, which are coupled because both need a way to tell a policy **decision** apart from a **failure**.

## What?

Adds a `hook_denied` chat error kind and a structured 403 denial response, then uses it on both surfaces that render hook outcomes.

- An existing chat now titles a denial `Blocked by policy` instead of `Request failed`.
- The landing composer renders both hook outcomes cleanly instead of falling through to a developer error alert with a stack trace, response data, and a `Go to workspaces` action.

## Why?

The dispatch-failure path already returns a structured `ChatHookDispatchFailedResponse` carrying `kind: "hook_dispatch_failed"`, which the frontend uses to title it `Lifecycle hook failed`. The denial path wrote a bare `codersdk.Response` with **no** `kind`, so the frontend could not classify it, fell back to `generic`, and rendered `Request failed`. A policy decision is not a failure, and the old title carried no signal about what happened.

This needs a backend discriminator rather than a frontend-only fix. Matching on `status === 403` alone would misclassify ordinary permission errors, which reach the same create-form branch and must keep their existing treatment. That case is pinned by the pre-existing `ForbiddenErrorWithRole` story, which still passes unchanged.

No migration: `ChatErrorKind` is persisted only inside the JSONB `chats.last_error` column, and the decoder accepts unknown kinds and defaults only blank ones.

## Testing

- Backend denial-response coverage extended to assert the new `kind`.
- Two new create-form stories for the 403 and 502 outcomes, asserting the titles and messages and the **absence** of `Stack Trace` and `Response data`.
- Red-green verified: removing the two create-form branches fails exactly the two new stories, with the other 29 still passing.
- `make gen` confirmed idempotent, `golangci-lint`, `pnpm lint:types`, `pnpm lint:compiler`, `pnpm run lint-docs`.

> Mux prepared this PR on Mike's behalf.
