### PR TITLE
fix: demui `<Form />` emotion usage

### DIFF
--- a/site/src/components/Form/Form.tsx
+++ b/site/src/components/Form/Form.tsx
@@ -1,4 +1,3 @@
-import { useTheme } from "@emotion/react";
 import {
 	type ComponentProps,
 	createContext,
@@ -21,21 +20,14 @@ type FormProps = HTMLProps<HTMLFormElement> & {
 };
 
 export const Form: FC<FormProps> = ({ direction, ...formProps }) => {
-	const theme = useTheme();
-
 	return (
 		<FormContext.Provider value={{ direction }}>
 			<form
 				{...formProps}
-				css={{
-					display: "flex",
-					flexDirection: "column",
-					gap: direction === "horizontal" ? 80 : 40,
-
-					[theme.breakpoints.down("md")]: {
-						gap: 64,
-					},
-				}}
+				className={cn(
+					"flex flex-col gap-16",
+					direction === "horizontal" ? "md:gap-20" : "md:gap-10",
+				)}
 			/>
 		</FormContext.Provider>
 	);

--- a/site/src/components/Form/Form.tsx
+++ b/site/src/components/Form/Form.tsx
@@ -19,7 +19,7 @@ type FormProps = HTMLProps<HTMLFormElement> & {
 	direction?: FormContextValue["direction"];
 };
 
-export const Form: FC<FormProps> = ({ direction, ...formProps }) => {
+export const Form: FC<FormProps> = ({ direction, className, ...formProps }) => {
 	return (
 		<FormContext.Provider value={{ direction }}>
 			<form
@@ -27,6 +27,7 @@ export const Form: FC<FormProps> = ({ direction, ...formProps }) => {
 				className={cn(
 					"flex flex-col gap-16",
 					direction === "horizontal" ? "md:gap-20" : "md:gap-10",
+					className,
 				)}
 			/>
 		</FormContext.Provider>


### PR DESCRIPTION
Tiny simple change just moving us over to Tailwind instead of MUI for `<Form />`. Functionally equivalent minus the mismatch between `md` in `Tailwind` (`≥ 768px`) and `MUI` (`≥ 900px`).