### PR TITLE
fix(coderd): preseed AI providers for title tests

### DIFF
--- a/coderd/aibridgedtest/aibridgedtest.go
+++ b/coderd/aibridgedtest/aibridgedtest.go
@@ -15,6 +15,7 @@ import (
 	"github.com/coder/coder/v2/cli"
 	"github.com/coder/coder/v2/coderd"
 	"github.com/coder/coder/v2/coderd/aibridged"
+	"github.com/coder/coder/v2/coderd/database/pubsub"
 )
 
 // StartTestAIBridgeDaemon wires an in-process aibridged daemon onto the
@@ -35,6 +36,21 @@ func StartTestAIBridgeDaemon(
 	t testing.TB,
 	api *coderd.API,
 	metrics *aibridged.Metrics,
+) {
+	t.Helper()
+	StartTestAIBridgeDaemonWithPubsub(ctx, t, api, metrics, api.Pubsub)
+}
+
+// StartTestAIBridgeDaemonWithPubsub is StartTestAIBridgeDaemon with an
+// explicit pubsub for the provider-reload subscription. A pubsub that is
+// disconnected from api.Pubsub cuts the daemon off from provider change
+// events, leaving the initial synchronous load as its only route source.
+func StartTestAIBridgeDaemonWithPubsub(
+	ctx context.Context,
+	t testing.TB,
+	api *coderd.API,
+	metrics *aibridged.Metrics,
+	ps pubsub.Pubsub,
 ) {
 	t.Helper()
 
@@ -63,7 +79,7 @@ func StartTestAIBridgeDaemon(
 	// The reloader fetches providers from coderd over srv's DRPC client; the
 	// subscription drives an initial load and refreshes on change events.
 	reloader := cli.NewPoolRPCReloader(pool, srv.ClientContext, cfg, logger.Named("reloader"), nil, metrics)
-	unsubscribe, err := aibridged.SubscribeProviderReload(ctx, api.Pubsub, reloader, logger.Named("subscriber"))
+	unsubscribe, err := aibridged.SubscribeProviderReload(ctx, ps, reloader, logger.Named("subscriber"))
 	if err != nil {
 		t.Fatalf("subscribe provider reload: %v", err)
 	}

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
+	dbpubsub "github.com/coder/coder/v2/coderd/database/pubsub"
 	"github.com/coder/coder/v2/coderd/externalauth"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/rbac/policy"
@@ -136,6 +137,14 @@ func newChatClientWithAPIAndDatabase(t testing.TB, overrides ...func(*coderdtest
 	opts := newChatTestOptions(t, coderdtest.DeploymentValues(t), overrides...)
 	client, _, api := coderdtest.NewWithAPI(t, opts)
 	aibridgedtest.StartTestAIBridgeDaemon(t.Context(), t, api, nil)
+	return codersdk.NewExperimentalClient(client), api.Database, api
+}
+
+func newChatClientWithoutAIBridge(t testing.TB, overrides ...func(*coderdtest.Options)) (*codersdk.ExperimentalClient, database.Store, *coderd.API) {
+	t.Helper()
+
+	opts := newChatTestOptions(t, coderdtest.DeploymentValues(t), overrides...)
+	client, _, api := coderdtest.NewWithAPI(t, opts)
 	return codersdk.NewExperimentalClient(client), api.Database, api
 }
 
@@ -9714,9 +9723,10 @@ func TestRegenerateChatTitle(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitLong)
-		client, db := newChatClientWithDatabase(t)
+		client, db, api := newChatClientWithoutAIBridge(t)
 		user := coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createTitleGenerationModelConfig(t, client)
+		aibridgedtest.StartTestAIBridgeDaemon(t.Context(), t, api, nil)
 
 		chat := dbgen.Chat(t, db, database.Chat{
 			OrganizationID:    user.OrganizationID,
@@ -9734,13 +9744,45 @@ func TestRegenerateChatTitle(t *testing.T) {
 		require.Equal(t, "Test Chat", updated.Title)
 	})
 
+	t.Run("NoPubsubDelivery", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client, db, api := newChatClientWithoutAIBridge(t)
+		user := coderdtest.CreateFirstUser(t, client.Client)
+		modelConfig := createTitleGenerationModelConfig(t, client)
+
+		// Wire the daemon's reload subscription to a pubsub coderd never
+		// publishes to: gateway routes can then only come from the
+		// synchronous initial load. This guards the invariant the
+		// create-config-before-daemon pattern above relies on; if the
+		// initial load is removed or made asynchronous, this fails
+		// deterministically instead of reintroducing the startup race.
+		isolated := dbpubsub.NewInMemory()
+		t.Cleanup(func() { _ = isolated.Close() })
+		aibridgedtest.StartTestAIBridgeDaemonWithPubsub(t.Context(), t, api, nil, isolated)
+
+		chat := dbgen.Chat(t, db, database.Chat{
+			OrganizationID:    user.OrganizationID,
+			OwnerID:           user.UserID,
+			LastModelConfigID: modelConfig.ID,
+			Title:             "New Chat",
+		})
+		seedManualTitleSourceMessage(t, db, chat, modelConfig.ID)
+
+		updated, err := client.RegenerateChatTitle(ctx, chat.ID)
+		require.NoError(t, err)
+		require.Equal(t, "Test Chat", updated.Title)
+	})
+
 	t.Run("DoesNotBumpHistoryVersion", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitLong)
-		client, db := newChatClientWithDatabase(t)
+		client, db, api := newChatClientWithoutAIBridge(t)
 		user := coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createTitleGenerationModelConfig(t, client)
+		aibridgedtest.StartTestAIBridgeDaemon(t.Context(), t, api, nil)
 
 		chat := dbgen.Chat(t, db, database.Chat{
 			OrganizationID:    user.OrganizationID,
@@ -9788,9 +9830,10 @@ func TestRegenerateChatTitle(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitLong)
-		client, db, api := newChatClientWithAPIAndDatabase(t)
+		client, db, api := newChatClientWithoutAIBridge(t)
 		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfigWithTitleFailure(t, client)
+		aibridgedtest.StartTestAIBridgeDaemon(t.Context(), t, api, nil)
 
 		chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
 			OrganizationID: firstUser.OrganizationID,
@@ -9900,9 +9943,10 @@ func TestProposeChatTitle(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitLong)
-		client, db := newChatClientWithDatabase(t)
+		client, db, api := newChatClientWithoutAIBridge(t)
 		user := coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createTitleGenerationModelConfig(t, client)
+		aibridgedtest.StartTestAIBridgeDaemon(t.Context(), t, api, nil)
 
 		chat := dbgen.Chat(t, db, database.Chat{
 			OrganizationID:    user.OrganizationID,
@@ -9948,9 +9992,10 @@ func TestProposeChatTitle(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitLong)
-		client, db := newChatClientWithDatabase(t)
+		client, db, api := newChatClientWithoutAIBridge(t)
 		user := coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createTitleGenerationModelConfig(t, client)
+		aibridgedtest.StartTestAIBridgeDaemon(t.Context(), t, api, nil)
 
 		workspaceBuild := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
 			OrganizationID: user.OrganizationID,
@@ -9983,9 +10028,10 @@ func TestProposeChatTitle(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitLong)
-		client, db, api := newChatClientWithAPIAndDatabase(t)
+		client, db, api := newChatClientWithoutAIBridge(t)
 		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfigWithTitleFailure(t, client)
+		aibridgedtest.StartTestAIBridgeDaemon(t.Context(), t, api, nil)
 
 		chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
 			OrganizationID: firstUser.OrganizationID,


### PR DESCRIPTION
Fixes [coder/internal#1629](https://github.com/coder/internal/issues/1629) and [CODAGT-876](https://linear.app/codercom/issue/CODAGT-876/flake-testregeneratechattitlepasteonlychat) (`flake: TestRegenerateChatTitle/PasteOnlyChat`).

## Problem

The test failed in CI with a 500 whose detail was:

```
generate manual title: generate structured title: not found:
  route not supported: POST /test-openai-<uuid>/v1/responses
```

`client.CreateAIProvider` returns as soon as the row commits. The in-process AI Gateway pool learns about the new provider asynchronously: the handler publishes on `ai_providers_changed`, and the daemon's subscriber reloads the provider snapshot in the background.

Manual title regeneration and proposal are the only chat endpoints that drive a gateway request *inside* the caller's HTTP request. When the reload has not landed yet, the request hits the aibridge mux catch-all, gets a 404 that is not classified as retryable, and the handler returns 500. Regular chat messages go through the async worker and tolerate the race, which is why only the title tests flaked.

## Fix

The six tests that synchronously reach the gateway now create their AI provider and model configuration *before* starting the in-process bridge daemon (via a new `newChatClientWithoutAIBridge` helper that defers daemon startup). `SubscribeProviderReload` performs a synchronous initial reload before returning, so the routes exist before the first title request. No production code changes and no new test-only API on the daemon.

A new `TestRegenerateChatTitle/NoPubsubDelivery` regression test pins the invariant the pattern relies on: it wires the daemon's reload subscription to an isolated in-memory pubsub (`StartTestAIBridgeDaemonWithPubsub`), so gateway routes can only come from the initial synchronous load, never from a change event.

## Validation

Red-green on the new regression test, both toggles reproducing the exact CI error deterministically:

- Removing the initial reload in `SubscribeProviderReload`: fails in 0.4s with `route not supported: POST /test-openai-<uuid>/v1/responses`.
- Reverting to creating the model config after daemon startup: same deterministic failure.

Restored, the test passes. Also green:

- `TestRegenerateChatTitle|TestProposeChatTitle` at `-count=20`
- `go vet` on all `StartTestAIBridgeDaemon` consumer packages
- `make lint`

The original repro (`-count=100`) never failed locally, so the fix and its guard are deterministic by construction rather than repro-driven.

> Opened by Mux on Mike's behalf.
