### PR TITLE
feat(site): highlight Deprecated prefix in option descriptions

### DIFF
--- a/site/src/pages/DeploymentSettingsPage/Option.tsx
+++ b/site/src/pages/DeploymentSettingsPage/Option.tsx
@@ -1,5 +1,5 @@
 import { WrenchIcon } from "lucide-react";
-import type { FC, HTMLAttributes, PropsWithChildren } from "react";
+import type { FC, HTMLAttributes, PropsWithChildren, ReactNode } from "react";
 import { DisabledBadge, EnabledBadge } from "#/components/Badges/Badges";
 import { cn } from "#/utils/cn";
 
@@ -11,8 +11,31 @@ export const OptionName: FC<PropsWithChildren> = ({ children }) => {
 	);
 };
 
+// Highlight a leading "Deprecated:" prefix in the destructive/red color so
+// it stands out from the rest of the description.
+const DEPRECATED_PREFIX = "Deprecated:";
+
+const renderDescription = (children: ReactNode): ReactNode => {
+	if (typeof children !== "string") {
+		return children;
+	}
+	if (!children.startsWith(DEPRECATED_PREFIX)) {
+		return children;
+	}
+	return (
+		<>
+			<span className="font-semibold text-content-destructive">
+				{DEPRECATED_PREFIX}
+			</span>
+			{children.slice(DEPRECATED_PREFIX.length)}
+		</>
+	);
+};
+
 export const OptionDescription: FC<PropsWithChildren> = ({ children }) => {
-	return <span className="text-sm font-normal">{children}</span>;
+	return (
+		<span className="text-sm font-normal">{renderDescription(children)}</span>
+	);
 };
 
 interface OptionValueProps {


### PR DESCRIPTION
Makes the leading `Deprecated:` prefix in deployment option descriptions stand out by rendering it in the destructive/red color (`text-content-destructive`) already used across the app (form errors, toaster errors, etc.).

Affects any option on the deployment settings pages whose description starts with `Deprecated:` — most visibly the AI Gateway options on **AI → Settings → Governance**, e.g. _AI Gateway Anthropic Base URL_.

### Before / After
Before: `Deprecated:` blended into the description text.
After: `Deprecated:` is bold and red so the deprecation is immediately obvious.

### Notes
- Implemented in the shared `OptionDescription` component, so every page that uses `OptionsTable` (AI Governance, Network, Security, Observability, User Auth, Notifications, Overview) benefits automatically.
- No changes to the underlying description strings; the prefix is detected at render time.

---
_This PR was opened by Coder Agents on behalf of @tracyjohnsonux._