### PR TITLE
chore: raise Biome max file size so swagger.json stays formatted

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -9,7 +9,8 @@
 		// static/*.html are Go templates with {{ }} directives that
 		// Biome's HTML parser does not support.
 		"includes": ["**", "!**/pnpm-lock.yaml", "!**/static/*.html"],
-		"ignoreUnknown": true
+		"ignoreUnknown": true,
+		"maxSize": 2097152
 	},
 	"linter": {
 		"rules": {


### PR DESCRIPTION
Raises Biome's max file size so `coderd/apidoc/swagger.json` keeps getting formatted.

The raw swaggo output sits just under Biome's 1 MiB default, so adding a new endpoint tips it over. Biome then skips the file with an info rather than an error, which means `scripts/biome_format.sh` and `make gen` both exit 0 while silently leaving it unformatted. Any PR that introduces a new endpoint ends up with a large spurious diff in `swagger.json` and a failing `gen` check.

This is what `make gen` prints when it happens:

```
/home/coder/coder/_gen/tmp.NVD90urqoA/swagger.json format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  i The size of the file is 1.0 MiB, which exceeds the configured maximum of 1.0 MiB for this project.
    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.includes` to ignore the file.


Formatted 0 files in 3ms. No fixes applied.
Found 1 info.
format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  × No files were processed in the specified paths.

  i Check your biome.json or biome.jsonc to ensure the paths are not ignored by the configuration.

  i These paths were provided but ignored:

  - /home/coder/coder/_gen/tmp.NVD90urqoA/swagger.json
```

Generated output is unchanged on main, so this is config only.
