### PR TITLE
docs(docs): add AI Gateway cost controls placeholder page

### DIFF
--- a/docs/ai-coder/ai-gateway/cost-controls.md
+++ b/docs/ai-coder/ai-gateway/cost-controls.md
@@ -1,0 +1,8 @@
+# Cost Controls
+
+> [!NOTE]
+> AI Gateway requires the [AI Governance Add-On](../ai-governance.md).
+> As of Coder v2.32, deployments without the add-on will not be able to
+> access AI Gateway.
+
+<!-- TODO(AIGOV-476): Document AI Gateway cost controls. -->

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1318,6 +1318,12 @@
 									"state": ["ai governance add-on"]
 								},
 								{
+									"title": "Cost Controls",
+									"description": "Manage AI Gateway spend with budgets, spend limits, and budget notifications.",
+									"path": "./ai-coder/ai-gateway/cost-controls.md",
+									"state": ["ai governance add-on"]
+								},
+								{
 									"title": "Reference",
 									"description": "Technical reference for AI Gateway, including the aibridged component that runs inside coderd.",
 									"path": "./ai-coder/ai-gateway/reference.md",


### PR DESCRIPTION
## Summary

Adds a placeholder "Cost Controls" page under AI Gateway in the docs, plus its `manifest.json` navigation entry. This is a stub with a title only; the full content will be written in a follow-up.

Relates to [AIGOV-476](https://linear.app/codercom/issue/AIGOV-476/add-documentation-for-ai-bridge-cost-controls).

Related to [internal slack thread](https://codercom.slack.com/archives/C096PFVBZKN/p1785150528587409).

## Changes

- Add `docs/ai-coder/ai-gateway/cost-controls.md` placeholder page
- Register the page in `docs/manifest.json` under AI Gateway (after Monitoring)

---
> [!NOTE]
> This PR was generated with Coder Agents.
