### PR TITLE
fix(site/src/pages/AgentsPage/components): show streamed advice that parses as a record

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -423,6 +423,7 @@ export const BlockList: FC<{
 								name={tool.name}
 								args={tool.args}
 								result={tool.result}
+								resultRaw={tool.resultRaw}
 								status={tool.status}
 								killedBySignal={tool.killedBySignal}
 								shellToolDisplayMode={shellToolDisplayMode}
@@ -482,6 +483,7 @@ export const BlockList: FC<{
 					name={tool.name}
 					args={tool.args}
 					result={tool.result}
+					resultRaw={tool.resultRaw}
 					status={tool.status}
 					killedBySignal={tool.killedBySignal}
 					shellToolDisplayMode={shellToolDisplayMode}

--- a/site/src/pages/AgentsPage/components/ChatConversation/streamState.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/streamState.ts
@@ -253,6 +253,7 @@ export const buildStreamTools = (
 			name: call.name,
 			args: call.args,
 			result: result?.result,
+			resultRaw: result?.resultRaw,
 			status: getStreamToolStatus(result),
 			mcpServerConfigId: call.mcpServerConfigId || result?.mcpServerConfigId,
 			modelIntent: call.modelIntent,
@@ -267,6 +268,7 @@ export const buildStreamTools = (
 					id: result.id,
 					name: result.name,
 					result: result.result,
+					resultRaw: result.resultRaw,
 					status: getStreamToolStatus(result),
 					mcpServerConfigId: result.mcpServerConfigId,
 				});

--- a/site/src/pages/AgentsPage/components/ChatConversation/types.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/types.ts
@@ -22,6 +22,8 @@ export type MergedTool = {
 	name: string;
 	args?: unknown;
 	result?: unknown;
+	/** Accumulated result text before parsing, set while result deltas stream. */
+	resultRaw?: string;
 	status: "completed" | "error" | "running";
 	mcpServerConfigId?: string;
 	modelIntent?: string;

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/AdvisorTool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/AdvisorTool.stories.tsx
@@ -152,6 +152,25 @@ export const RunningWithErrorShapedPartial: Story = {
 	},
 };
 
+/** Prose opening with a JSON object partially parses into a record. */
+export const RunningWithProseThatParsesAsRecord: Story = {
+	args: {
+		status: "running",
+		args: { question: sampleQuestion },
+		result: { key: "value" },
+		resultRaw: '{"key": "value"} is the shape you want.',
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			await canvas.findByText('{"key": "value"} is the shape you want.'),
+		).toBeInTheDocument();
+		expect(
+			canvas.queryByText("Reviewing context and preparing guidance."),
+		).not.toBeInTheDocument();
+	},
+};
+
 export const LimitReached: Story = {
 	args: {
 		status: "completed",

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -63,6 +63,8 @@ interface ToolProps extends Omit<ComponentPropsWithRef<"div">, "children"> {
 	status?: ToolStatus;
 	args?: unknown;
 	result?: unknown;
+	/** Accumulated result text before parsing, set while result deltas stream. */
+	resultRaw?: string;
 	killedBySignal?: "kill" | "terminate";
 	/** Maps sub-agent chat IDs to their titles, built from transcript metadata. */
 	subagentTitles?: Map<string, string>;
@@ -97,6 +99,7 @@ type ToolRendererProps = {
 	status: ToolStatus;
 	args: unknown;
 	result: unknown;
+	resultRaw?: string;
 	killedBySignal?: "kill" | "terminate";
 	subagentTitles?: Map<string, string>;
 	subagentVariants?: Map<string, SubagentVariant>;
@@ -373,7 +376,7 @@ const CreateWorkspaceRenderer: FC<ToolRendererProps> = ({ status, result }) => {
 			workspaceName={wsName}
 			resultJson={resultJson}
 			status={rec?.error ? "error" : status}
-			errorMessage={rec ? asString(rec.error || rec.reason) : undefined}
+			errorMessage={rec ? asString(rec.error) : undefined}
 			buildId={buildId}
 			created={created}
 			labelOverride={quotaTitle}
@@ -631,29 +634,36 @@ const ProposePlanRenderer: FC<ToolRendererProps> = ({
 	);
 };
 
-const AdvisorRenderer: FC<ToolRendererProps> = ({ args, status, result }) => {
+const AdvisorRenderer: FC<ToolRendererProps> = ({
+	args,
+	status,
+	result,
+	resultRaw,
+}) => {
 	const parsedArgs = parseArgs(args);
 	const question = parsedArgs ? asString(parsedArgs.question) : "";
 	const rec = asRecord(result);
 	const rawResultType = rec ? asString(rec.type) : "";
-	const hasError = status === "error";
-	const advice = rec
-		? asString(rec.advice)
-		: typeof result === "string" && !hasError
-			? result
-			: undefined;
-	const adviceText = (advice ?? "").trim();
-	const resolvedResultType: AdvisorToolResultType | undefined =
+	const envelopeType: AdvisorToolResultType | undefined =
 		rawResultType === "advice" ||
 		rawResultType === "limit_reached" ||
 		rawResultType === "error"
 			? rawResultType
-			: adviceText
-				? "advice"
-				: undefined;
+			: undefined;
+	// Streamed advice is re-parsed on every chunk, so prose opening with a
+	// JSON object accretes into a record carrying no advice. Outside a real
+	// envelope the accumulated text is the advice.
+	const advice = envelopeType
+		? asString(rec?.advice)
+		: status === "error"
+			? undefined
+			: (resultRaw ?? (typeof result === "string" ? result : undefined));
+	const adviceText = (advice ?? "").trim();
+	const resolvedResultType =
+		envelopeType ?? (adviceText ? "advice" : undefined);
 	const errorMessage =
 		(rec ? asString(rec.error || rec.message) : "") ||
-		(typeof result === "string" && hasError ? result : "");
+		(typeof result === "string" && status === "error" ? result : "");
 	const advisorModel = rec ? asString(rec.advisor_model) : "";
 	const remainingUses = rec
 		? asNumber(rec.remaining_uses, { parseString: true })
@@ -918,7 +928,7 @@ const StartWorkspaceRenderer: FC<ToolRendererProps> = ({ status, result }) => {
 			status={rec?.error ? "error" : status}
 			buildId={buildId}
 			workspaceName={wsName}
-			errorMessage={rec ? asString(rec.error || rec.reason) : undefined}
+			errorMessage={rec ? asString(rec.error) : undefined}
 			noBuild={noBuild}
 			labelOverride={quotaTitle}
 		/>
@@ -961,6 +971,7 @@ export const Tool = memo(
 		status = "completed",
 		args,
 		result,
+		resultRaw,
 		killedBySignal,
 		subagentTitles,
 		subagentVariants,
@@ -1005,6 +1016,7 @@ export const Tool = memo(
 					status={status}
 					args={args}
 					result={result}
+					resultRaw={resultRaw}
 					killedBySignal={killedBySignal}
 					subagentTitles={subagentTitles}
 					subagentVariants={subagentVariants}


### PR DESCRIPTION
> **Stacked on #27715.** Review that first; this PR's diff is only the advisor change on top of it. Merge order is #27715, then this.

Streamed advisor advice stopped displaying when the prose happened to open with a JSON object.

## Cause

`mergeStreamPayload` appends each `result_delta` and re-parses the whole accumulation on every chunk (`streamingJson.ts:425-433`), returning `value: parsed ?? rawText`. The partial parser needs only a leading `{` plus one complete key to return an object (`streamingJson.ts:295-301`, `:361-374`), and it is prefix-monotonic: once one pair sets `hasFields`, every exit path returns the object, so later text cannot restore the string.

`AdvisorRenderer` read `advice` from `asRecord(result)`, so once that record formed, the raw text was unreachable. Two symptoms:

- Prose whose first non-whitespace character is `{` renders "Reviewing context and preparing guidance." for the whole stream while advice streams in.
- Prose that accretes an `advice` key freezes at whatever parsed first, dropping later text.

Both are confined to the streaming window, since the terminal envelope replaces the accreted record. A JSON example quoted mid-prose does not trigger it, because the parser requires the accumulation to *start* with `{`.

## Fix

`resultRaw` is already stored in stream state (`streamState.ts:154`) and was simply discarded. Thread it to the renderer, and key on a recognised advisor envelope type rather than on the body being a record, so a body that is not a real envelope falls back to the accumulated text.

Also drops the read of `rec.reason` on the workspace tools. No chatd tool emits a `reason` field.

## Testing

`RunningWithProseThatParsesAsRecord` pins it. Verified non-vacuous by stashing the fix: the story fails without it and passes with it.

`tsc`, Biome, knip and the React compiler check pass. Unit 3089 passed / 2 skipped. Story suites for `ChatElements` and `ChatConversation` 321 passed, with only the pre-existing `Tool.stories.tsx > MCP Tool Completed` failing, which also fails on base.

<details>
<summary>Why this is not the planned tool-error extractor PR</summary>

This branch started as a larger change: one `getToolError(result: unknown)` replacing 18 duplicated result-body error reads, plus a per-tool fallback-copy table consumed by `ToolCall.Root`. Both were investigated and dropped.

**The fallback table does not work.** `ToolCall.Root` receives no tool name, and neither does `Status`, which renders the copy. `iconName` cannot key it, because `AdvisorTool` and `SubagentTool` never use `ToolCall.Header`, `ReadFileTool` and `ReadFilesTool` share `iconName="read_file"` but need different copy, and `read_skill` and `read_skill_file` share one leaf. Two fallbacks are derived and need inputs `Root` lacks (`mcpSlug`, `providerLabel`). Four leaves render the copy in their own body rather than only through `Root`, so they would still need the string.

**The extractor works but did not earn a PR.** Measured at net +1 production lines and +45 test lines, because 13 of the 18 sites were already one-liners: replacing an expression with a call removes a concept, not a line. The divergence it removed is inert, since `reason` is dead and `message` is only emitted on success by three tools, where it never reaches the DOM because display is gated on `status === "error"`. Its one behavioural win, surfacing bare-string bodies at all 18 sites rather than 4, is a clear gain for MCP text but roughly lateral for synthetic cancellations. And it changed behaviour pinned by four existing tests, making it a behaviour change dressed as a refactor.

`getToolError` moves into the per-component outcome-union work, which rewrites all 18 call sites anyway, so introducing it there costs no extra review surface.

**Related gaps found while investigating, none owned yet:** `wait_agent` reports a failed subagent with `IsError:false` and the text under `last_error` (`subagent.go:936-954`), which no `error`-based extractor reaches. Frontend and backend disagree on precedence when a part carries both `result` and `result_delta` (`streamingJson.ts:396` prefers the result, `message_conversion.go:723-738` prefers the delta). And a byte-capped JSON body is rewrapped as `{"output": ...}` (`tooltruncate.go:76-107`), discarding `error` entirely.

</details>

🤖 This pull request was created with Coder Agents.

