### PR TITLE
fix: document HTTP 201 for workspace and build creation endpoints

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -5622,8 +5622,8 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
+                    "201": {
+                        "description": "Created",
                         "schema": {
                             "$ref": "#/definitions/codersdk.Workspace"
                         }
@@ -11690,8 +11690,8 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
+                    "201": {
+                        "description": "Created",
                         "schema": {
                             "$ref": "#/definitions/codersdk.Workspace"
                         }
@@ -13917,8 +13917,8 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
+                    "201": {
+                        "description": "Created",
                         "schema": {
                             "$ref": "#/definitions/codersdk.WorkspaceBuild"
                         }

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -4977,8 +4977,8 @@
 					}
 				],
 				"responses": {
-					"200": {
-						"description": "OK",
+					"201": {
+						"description": "Created",
 						"schema": {
 							"$ref": "#/definitions/codersdk.Workspace"
 						}
@@ -10377,8 +10377,8 @@
 					}
 				],
 				"responses": {
-					"200": {
-						"description": "OK",
+					"201": {
+						"description": "Created",
 						"schema": {
 							"$ref": "#/definitions/codersdk.Workspace"
 						}
@@ -12355,8 +12355,8 @@
 					}
 				],
 				"responses": {
-					"200": {
-						"description": "OK",
+					"201": {
+						"description": "Created",
 						"schema": {
 							"$ref": "#/definitions/codersdk.WorkspaceBuild"
 						}

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -323,7 +323,7 @@ func (api *API) workspaceBuildByBuildNumber(rw http.ResponseWriter, r *http.Requ
 // @Tags Builds
 // @Param workspace path string true "Workspace ID" format(uuid)
 // @Param request body codersdk.CreateWorkspaceBuildRequest true "Create workspace build request"
-// @Success 200 {object} codersdk.WorkspaceBuild
+// @Success 201 {object} codersdk.WorkspaceBuild
 // @Router /api/v2/workspaces/{workspace}/builds [post]
 func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -364,7 +364,7 @@ func (api *API) workspaceByOwnerAndName(rw http.ResponseWriter, r *http.Request)
 // @Param organization path string true "Organization ID" format(uuid)
 // @Param user path string true "Username, UUID, or me"
 // @Param request body codersdk.CreateWorkspaceRequest true "Create workspace request"
-// @Success 200 {object} codersdk.Workspace
+// @Success 201 {object} codersdk.Workspace
 // @Router /api/v2/organizations/{organization}/members/{user}/workspaces [post]
 func (api *API) postWorkspacesByOrganization(rw http.ResponseWriter, r *http.Request) {
 	var (
@@ -425,7 +425,7 @@ func (api *API) postWorkspacesByOrganization(rw http.ResponseWriter, r *http.Req
 // @Tags Workspaces
 // @Param user path string true "Username, UUID, or me"
 // @Param request body codersdk.CreateWorkspaceRequest true "Create workspace request"
-// @Success 200 {object} codersdk.Workspace
+// @Success 201 {object} codersdk.Workspace
 // @Router /api/v2/users/{user}/workspaces [post]
 func (api *API) postUserWorkspaces(rw http.ResponseWriter, r *http.Request) {
 	var (

--- a/docs/reference/api/builds.md
+++ b/docs/reference/api/builds.md
@@ -1804,7 +1804,7 @@ curl -X POST http://coder-server:8080/api/v2/workspaces/{workspace}/builds \
 
 ### Example responses
 
-> 200 Response
+> 201 Response
 
 ```json
 {
@@ -2020,8 +2020,8 @@ curl -X POST http://coder-server:8080/api/v2/workspaces/{workspace}/builds \
 
 ### Responses
 
-| Status | Meaning                                                 | Description | Schema                                                       |
-|--------|---------------------------------------------------------|-------------|--------------------------------------------------------------|
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.WorkspaceBuild](schemas.md#codersdkworkspacebuild) |
+| Status | Meaning                                                      | Description | Schema                                                       |
+|--------|--------------------------------------------------------------|-------------|--------------------------------------------------------------|
+| 201    | [Created](https://tools.ietf.org/html/rfc7231#section-6.3.2) | Created     | [codersdk.WorkspaceBuild](schemas.md#codersdkworkspacebuild) |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).

--- a/docs/reference/api/workspaces.md
+++ b/docs/reference/api/workspaces.md
@@ -49,7 +49,7 @@ of the template will be used.
 
 ### Example responses
 
-> 200 Response
+> 201 Response
 
 ```json
 {
@@ -328,9 +328,9 @@ of the template will be used.
 
 ### Responses
 
-| Status | Meaning                                                 | Description | Schema                                             |
-|--------|---------------------------------------------------------|-------------|----------------------------------------------------|
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.Workspace](schemas.md#codersdkworkspace) |
+| Status | Meaning                                                      | Description | Schema                                             |
+|--------|--------------------------------------------------------------|-------------|----------------------------------------------------|
+| 201    | [Created](https://tools.ietf.org/html/rfc7231#section-6.3.2) | Created     | [codersdk.Workspace](schemas.md#codersdkworkspace) |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
@@ -748,7 +748,7 @@ of the template will be used.
 
 ### Example responses
 
-> 200 Response
+> 201 Response
 
 ```json
 {
@@ -1027,9 +1027,9 @@ of the template will be used.
 
 ### Responses
 
-| Status | Meaning                                                 | Description | Schema                                             |
-|--------|---------------------------------------------------------|-------------|----------------------------------------------------|
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.Workspace](schemas.md#codersdkworkspace) |
+| Status | Meaning                                                      | Description | Schema                                             |
+|--------|--------------------------------------------------------------|-------------|----------------------------------------------------|
+| 201    | [Created](https://tools.ietf.org/html/rfc7231#section-6.3.2) | Created     | [codersdk.Workspace](schemas.md#codersdkworkspace) |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 


### PR DESCRIPTION
Closes #27304

The generated Swagger declared HTTP 200 for three workspace-creation operations whose handlers actually return HTTP 201:

- `POST /api/v2/organizations/{organization}/members/{user}/workspaces` (`postWorkspacesByOrganization`)
- `POST /api/v2/users/{user}/workspaces` (`postUserWorkspaces`)
- `POST /api/v2/workspaces/{workspace}/builds` (`postWorkspaceBuilds`)

Each handler writes `httpapi.Write(ctx, rw, http.StatusCreated, ...)`, so the `@Success 200` annotations were incorrect and go-swagger clients rejected the real 201 responses.

Changed only the three `@Success 200` annotations to `@Success 201` (verified against the `http.StatusCreated` writes in each handler), then ran `make gen` to regenerate `coderd/apidoc/swagger.json`, `coderd/apidoc/docs.go`, and the reference API docs. All other 200/204 annotations in these files are unchanged. `make fmt` and `go build ./coderd/...` pass.

---
This PR was generated by Coder Agents on behalf of @stirby.
