### PR TITLE
fix(site): avoid block elements nested inside paragraph tags

### DIFF
--- a/site/src/components/GitDeviceAuth/GitDeviceAuth.tsx
+++ b/site/src/components/GitDeviceAuth/GitDeviceAuth.tsx
@@ -131,7 +131,7 @@ export const GitDeviceAuth: FC<GitDeviceAuthProps> = ({
 
 	return (
 		<div>
-			<p className="m-0 text-center text-base leading-relaxed text-content-secondary">
+			<div className="m-0 text-center text-base leading-relaxed text-content-secondary">
 				Copy your one-time code:&nbsp;
 				<span className="inline-flex items-center">
 					<span className="font-bold text-content-primary">
@@ -145,7 +145,7 @@ export const GitDeviceAuth: FC<GitDeviceAuthProps> = ({
 				</span>
 				<br />
 				Then open the link below and paste it:
-			</p>
+			</div>
 			<div className="m-4 flex flex-col gap-1">
 				<Link
 					className="flex items-center justify-center gap-2 text-base"

--- a/site/src/pages/OrganizationSettingsPage/OrganizationMembersPage.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationMembersPage.tsx
@@ -205,7 +205,7 @@ const OrganizationMembersPage: FC = () => {
 				}}
 				description={
 					<div className="flex flex-col gap-4">
-						<p>
+						<div>
 							Removing this member will:
 							<ul>
 								<li>Remove the member from all groups in this organization</li>
@@ -215,7 +215,7 @@ const OrganizationMembersPage: FC = () => {
 									organization
 								</li>
 							</ul>
-						</p>
+						</div>
 
 						<p className="pb-5">Are you sure you want to remove this member?</p>
 					</div>


### PR DESCRIPTION
Closes #26933

Two components rendered block-level elements inside `<p>` tags, which browsers implicitly close before the block element. This produced a DOM that did not match the JSX, affecting layout, the accessibility tree, and hydration.

- `GitDeviceAuth`: the paragraph wrapping the one-time code and `CopyButton` is now a `<div>` (same classes/text).
- `OrganizationMembersPage`: the remove-member confirmation dialog previously wrapped a `<ul>` inside a `<p>`; the wrapper is now a `<div>`.

Structural-only changes; visible text, styling, and spacing are unchanged.

Checks: `biome check`, `tsc -p .`, and LSP diagnostics all pass. No new tests added per FE1; no Storybook story renders the affected dialog/component.

---
This PR was generated by Coder Agents on behalf of @stirby.
