### PR TITLE
fix(coderd): clarify error when chat model config is disabled

### DIFF
--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -967,10 +967,11 @@ type userChatModelAvailability struct {
 type chatModelConfigUnavailableReason string
 
 const (
-	chatModelConfigAvailable                          chatModelConfigUnavailableReason = ""
-	chatModelConfigUnavailableModelNotFoundOrDisabled chatModelConfigUnavailableReason = "model_not_found_or_disabled"
-	chatModelConfigUnavailableProviderDisabled        chatModelConfigUnavailableReason = "provider_disabled"
-	chatModelConfigUnavailableCredentialsMissing      chatModelConfigUnavailableReason = "credentials_missing"
+	chatModelConfigAvailable                     chatModelConfigUnavailableReason = ""
+	chatModelConfigUnavailableModelNotFound      chatModelConfigUnavailableReason = "model_not_found"
+	chatModelConfigUnavailableModelDisabled      chatModelConfigUnavailableReason = "model_disabled"
+	chatModelConfigUnavailableProviderDisabled   chatModelConfigUnavailableReason = "provider_disabled"
+	chatModelConfigUnavailableCredentialsMissing chatModelConfigUnavailableReason = "credentials_missing"
 )
 
 // getUserChatProviderAvailability returns the enabled chat providers and models
@@ -1111,7 +1112,7 @@ func (api *API) userCanUseChatModelConfig(
 	modelConfigID uuid.UUID,
 ) (database.ChatModelConfig, chatModelConfigUnavailableReason, error) {
 	if modelConfigID == uuid.Nil {
-		return database.ChatModelConfig{}, chatModelConfigUnavailableModelNotFoundOrDisabled, nil
+		return database.ChatModelConfig{}, chatModelConfigUnavailableModelNotFound, nil
 	}
 	//nolint:gocritic // Non-admin users need deployment config validation.
 	model, err := api.Database.GetChatModelConfigByID(
@@ -1120,12 +1121,12 @@ func (api *API) userCanUseChatModelConfig(
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) || httpapi.Is404Error(err) {
-			return database.ChatModelConfig{}, chatModelConfigUnavailableModelNotFoundOrDisabled, nil
+			return database.ChatModelConfig{}, chatModelConfigUnavailableModelNotFound, nil
 		}
 		return database.ChatModelConfig{}, chatModelConfigAvailable, err
 	}
 	if !model.Enabled {
-		return database.ChatModelConfig{}, chatModelConfigUnavailableModelNotFoundOrDisabled, nil
+		return database.ChatModelConfig{}, chatModelConfigUnavailableModelDisabled, nil
 	}
 
 	availability, err := api.getUserChatProviderAvailability(ctx, userID)
@@ -1149,7 +1150,7 @@ func (api *API) userCanUseChatModelConfig(
 	// Active configs always carry a provider FK (CHECK
 	// chat_model_configs_ai_provider_required_when_active), so an unset FK
 	// means the config is not usable.
-	return database.ChatModelConfig{}, chatModelConfigUnavailableModelNotFoundOrDisabled, nil
+	return database.ChatModelConfig{}, chatModelConfigUnavailableModelNotFound, nil
 }
 
 func (api *API) validateUserChatModelConfigAvailable(
@@ -1167,9 +1168,13 @@ func (api *API) validateUserChatModelConfigAvailable(
 	switch reason {
 	case chatModelConfigAvailable:
 		return modelConfig, 0, nil
-	case chatModelConfigUnavailableModelNotFoundOrDisabled:
+	case chatModelConfigUnavailableModelNotFound:
 		return database.ChatModelConfig{}, http.StatusBadRequest, &codersdk.Response{
-			Message: "Invalid model_config_id: model config not found or disabled.",
+			Message: "Invalid model_config_id: model config not found.",
+		}
+	case chatModelConfigUnavailableModelDisabled:
+		return database.ChatModelConfig{}, http.StatusBadRequest, &codersdk.Response{
+			Message: "Invalid model_config_id: this model is disabled. Enable it or choose another model.",
 		}
 	case chatModelConfigUnavailableCredentialsMissing:
 		return database.ChatModelConfig{}, http.StatusBadRequest, &codersdk.Response{

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -498,7 +498,27 @@ func TestPostChats(t *testing.T) {
 			ModelConfigID: ptr.Ref(disabledConfig.ID),
 		})
 		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
-		require.Equal(t, "Invalid model_config_id: model config not found or disabled.", sdkErr.Message)
+		require.Equal(t, "Invalid model_config_id: this model is disabled. Enable it or choose another model.", sdkErr.Message)
+	})
+
+	t.Run("NotFoundModelConfigRejected", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newChatClient(t)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
+		_ = createChatModelConfig(t, client)
+
+		_, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
+			OrganizationID: firstUser.OrganizationID,
+			Content: []codersdk.ChatInputPart{{
+				Type: codersdk.ChatInputPartTypeText,
+				Text: "hello",
+			}},
+			ModelConfigID: ptr.Ref(uuid.New()),
+		})
+		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+		require.Equal(t, "Invalid model_config_id: model config not found.", sdkErr.Message)
 	})
 
 	t.Run("ProviderDisabledModelConfigRejected", func(t *testing.T) {


### PR DESCRIPTION
Closes #27290

The `model_config_id` validation in `coderd/exp_chats.go` returned a single ambiguous message, "Invalid model_config_id: model config not found or disabled.", for both the not-found and disabled-model cases.

Split the shared `chatModelConfigUnavailableModelNotFoundOrDisabled` reason into `chatModelConfigUnavailableModelNotFound` and `chatModelConfigUnavailableModelDisabled` so each maps to a distinct, actionable message:

- not found: "Invalid model_config_id: model config not found."
- disabled: "Invalid model_config_id: this model is disabled. Enable it or choose another model."

The provider-disabled and credentials-missing reasons already had their own distinct messages and are unchanged.

Tests: updated the existing disabled-model assertion and added a not-found case under `TestPostChats`.

> Note: the (guarded, should-never-happen) branch for an enabled config with an unset provider FK now maps to the "not found" message rather than introducing a fourth reason for an unreachable state. Happy to add a dedicated message if a reviewer prefers.

---
This PR was generated by Coder Agents on behalf of @stirby.
