### PR TITLE
fix(site/src/pages/TaskPage): select primary agent deterministically

### DIFF
--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -899,5 +899,10 @@ const TaskStartingAgent: FC<TaskStartingAgentProps> = ({ task, agent }) => {
 };
 
 function selectAgent(workspace: Workspace) {
-	return getWorkspaceAgents(workspace).at(0);
+	// Select the primary (root) agent, the one without a `parent_id`. Sub-agents,
+	// such as those created by devcontainers, are skipped so agent ordering does
+	// not determine which agent the task uses.
+	return getWorkspaceAgents(workspace).find(
+		(agent) => agent.parent_id === null,
+	);
 }


### PR DESCRIPTION
Closes #27004

`selectAgent` in `TaskPage.tsx` used `getWorkspaceAgents(workspace).at(0)`, a nondeterministic positional pick. When a dev container is present, `.at(0)` could return the sub-agent instead of the primary agent.

This mirrors the deterministic root-agent selection introduced in #26959 (backend `agentselect.FindChatAgent` filters to agents with a null `ParentID`), matching the existing frontend pattern in `WorkspacesTable.tsx` that selects the agent with `parent_id === null` and skips devcontainer sub-agents. The change is confined to the selection logic; the return type and caller handling of `undefined` are unchanged.

_Implementation note: TaskPage has no chat record, so it can't consume the backend-selected `agent_id` like AgentChatPage does; the equivalent root-agent (`parent_id === null`) filter is applied client-side instead._

Checks: `tsc -p .` and `biome check` pass.

---
This PR was generated by Coder Agents on behalf of @stirby.
