### PR TITLE
fix(site/src/modules/dashboard/DeploymentBanner): keep muted error sections in top-nav banner

### DIFF
--- a/site/src/modules/dashboard/DeploymentBanner/DeploymentBannerView.stories.tsx
+++ b/site/src/modules/dashboard/DeploymentBanner/DeploymentBannerView.stories.tsx
@@ -33,6 +33,8 @@ export const WithHealthIssues: Story = {
 	},
 };
 
+// Muting a section only silences the sidebar bell. An error-severity section
+// stays in the top-nav banner even when it is dismissed.
 export const WithDismissedHealthIssues: Story = {
 	args: {
 		health: {
@@ -47,8 +49,9 @@ export const WithDismissedHealthIssues: Story = {
 		const canvas = within(canvasElement);
 		const trigger = canvas.getByTestId("deployment-health-trigger");
 		await userEvent.hover(trigger);
-		await waitFor(() =>
-			expect(screen.getByRole("tooltip")).toBeInTheDocument(),
-		);
+		const tooltip = await screen.findByRole("tooltip");
+		await expect(
+			within(tooltip).getByText("We're noticing workspace proxy issues."),
+		).toBeInTheDocument();
 	},
 };

--- a/site/src/modules/dashboard/DeploymentBanner/DeploymentBannerView.tsx
+++ b/site/src/modules/dashboard/DeploymentBanner/DeploymentBannerView.tsx
@@ -421,7 +421,7 @@ const getHealthErrors = (health: HealthcheckReport) => {
 	} as const;
 
 	for (const section of sections) {
-		if (health[section].severity === "error" && !health[section].dismissed) {
+		if (health[section].severity === "error") {
 			warnings.push(messages[section]);
 		}
 	}


### PR DESCRIPTION
Closes #27557

The "Mute warnings" button toggles a section's entry in `dismissed_healthchecks`, which drove two consumers: the sidebar bell-off icon and the top-nav outage banner (`getHealthErrors`). Because `getHealthErrors` gated on `severity === "error" && !dismissed`, muting a section that was at ERROR severity silently removed it from the top-nav outage banner.

This change re-scopes muting so it no longer suppresses ERROR-severity sections in the top-nav banner. `getHealthErrors` now surfaces every `severity === "error"` section regardless of the `dismissed` flag. Muting remains a sidebar/UI-noise concern only; the bell-off behavior in `HealthLayout.tsx` and the "Mute warnings" label are unchanged.

The existing `WithDismissedHealthIssues` Storybook story now asserts that a dismissed error section still appears in the banner tooltip.

**Decision:** This implements **Option 2** from the issue discussion (re-scope muting so it never hides ERROR-severity sections from the top-nav banner). A reviewer who prefers a different option (e.g. relabeling the button, or an explicit banner-suppression flag) can request it.

---
This PR was generated by Coder Agents on behalf of @stirby.
