### PR TITLE
refactor(site): remove Emotion from IconField

### DIFF
--- a/site/src/components/IconField/IconField.tsx
+++ b/site/src/components/IconField/IconField.tsx
@@ -1,4 +1,3 @@
-import { css, Global, useTheme } from "@emotion/react";
 import InputAdornment from "@mui/material/InputAdornment";
 import TextField, { type TextFieldProps } from "@mui/material/TextField";
 import { type FC, lazy, Suspense, useState } from "react";
@@ -29,7 +28,6 @@ export const IconField: FC<IconFieldProps> = ({
 		throw new Error(`Invalid icon value "${typeof textFieldProps.value}"`);
 	}
 
-	const theme = useTheme();
 	const hasIcon = textFieldProps.value && textFieldProps.value !== "";
 	const [open, setOpen] = useState(false);
 
@@ -62,15 +60,6 @@ export const IconField: FC<IconFieldProps> = ({
 				}}
 			/>
 
-			<Global
-				styles={css`
-					em-emoji-picker {
-						--rgb-background: ${theme.palette.background.paper};
-						--rgb-input: ${theme.palette.primary.main};
-						--rgb-color: ${theme.palette.text.primary};
-					}
-				`}
-			/>
 			<Popover open={open} onOpenChange={setOpen}>
 				<PopoverTrigger asChild>
 					<Button variant="outline" size="lg" className="group flex-shrink-0">

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -103,6 +103,11 @@
 			-webkit-overflow-scrolling: touch;
 		}
 	}
+	em-emoji-picker {
+		--rgb-background: hsl(var(--surface-primary));
+		--rgb-input: hsl(var(--content-link));
+		--rgb-color: hsl(var(--content-primary));
+	}
 }
 
 @layer base {


### PR DESCRIPTION
TODO need to redefine styles again because vars like `--rgb-color` expect a list of numbers, not an actual color--this is causing top bar hover color styles to break

moves `IconField` component styles from @emotion/react to index.css

Also fixes a bug where the AI settings page's `IconPickerField`'s emoji picker styles were dark regardless of the user's light/dark theme preference

## before

<img width="1840" height="1191" alt="image" src="https://github.com/user-attachments/assets/552884fb-cf61-441c-adb3-505c9eefd679" />

## after

<img width="1840" height="1191" alt="image" src="https://github.com/user-attachments/assets/61ceb394-e832-4a70-a5db-c0389a75a5e9" />