### PR TITLE
fix(site/src/pages/WorkspaceSettingsPage): correct workspace rename warning

### DIFF
--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
@@ -90,7 +90,7 @@ export const WorkspaceSettingsForm: FC<WorkspaceSettingsFormProps> = ({
 											destructive
 										</span>
 									)
-								: "Renaming your workspace can be destructive and is disabled by the template.",
+								: "Renaming your workspace can be destructive, and is not enabled for this deployment. Contact your Coder administrator if you need it.",
 						})}
 						label="Name"
 						disabled={!workspace.allow_renames || form.isSubmitting}


### PR DESCRIPTION
Resolves DEVEX-674.

The workspace settings page tells users that renames are "disabled by the template", but no template-level rename setting exists. `Workspace.allow_renames` is populated solely from the deployment-wide `--allow-workspace-renames` / `CODER_ALLOW_WORKSPACE_RENAMES` flag, and `patchWorkspace` enforces that flag alone. The message therefore points users at a control that does not exist.

This restores the wording [#11189](https://github.com/coder/coder/pull/11189) originally shipped with the flag, and names who can change it. The copy drifted in [#13887](https://github.com/coder/coder/commit/0a71c34d46c2d96826f490f6ca0f26ef43aa1512) (2024-07-22), an unrelated org-groups PR, and has been wrong since.

Copy only. No behavior change.

Note: [#27558](https://github.com/coder/coder/pull/27558) adds a real per-template setting, which would make template-facing wording correct. It does not touch this file, so the string needs updating there too; this PR is the backportable correction for `main` as it stands today.

## Proof

`pages/WorkspaceSettingsPage/WorkspaceSettingsPageView` &rarr; `RenamesDisabled` story.

Before:

<img width="1100" alt="Workspace settings form with helper text reading: Renaming your workspace can be destructive and is disabled by the template." src="https://raw.githubusercontent.com/david-fraley/coder/ab6dc44ff74f848c66ed919a71faf90938c0d443/before.png" />

After:

<img width="1100" alt="Workspace settings form with helper text reading: Renaming your workspace can be destructive, and is not enabled for this deployment. Contact your Coder administrator if you need it." src="https://raw.githubusercontent.com/david-fraley/coder/ab6dc44ff74f848c66ed919a71faf90938c0d443/after.png" />

---

🤖 Generated by [Coder Agents](https://coder.com) on behalf of @david-fraley.
