### PR TITLE
fix(site): use "Create token" wording in token settings

### DIFF
--- a/site/src/pages/UserSettingsPage/TokensPage/TokensPage.tsx
+++ b/site/src/pages/UserSettingsPage/TokensPage/TokensPage.tsx
@@ -39,7 +39,7 @@ const TokensPage: FC = () => {
 					<Button asChild variant="outline">
 						<RouterLink to="new">
 							<PlusIcon />
-							Add token
+							Create token
 						</RouterLink>
 					</Button>
 				}


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

The token settings page button read **"Add token"**, while everything else uses **"Create"**:

- The page the button navigates to is titled "Create Token" with a "Create token" submit button (`CreateTokenPage` / `CreateTokenForm`).
- CLI: `coder tokens create`
- SDK: `CreateToken`
- API: `create-token-api-key` / `CreateTokenRequest`

This aligns the button with the dominant nomenclature by changing "Add token" → "Create token".