### PR TITLE
fix(site/src/pages/UserSettingsPage/SecretsPage): prevent Add secret dialog overflow

### DIFF
--- a/site/src/pages/UserSettingsPage/SecretsPage/SecretDialog.tsx
+++ b/site/src/pages/UserSettingsPage/SecretsPage/SecretDialog.tsx
@@ -275,11 +275,11 @@ export const SecretDialog: FC<SecretDialogProps> = ({
 								)}
 							</div>
 							<div className="flex items-center">
-								<Separator />
+								<Separator className="flex-1" />
 								<span className="whitespace-nowrap px-3 text-xs text-content-secondary">
 									or add individually
 								</span>
-								<Separator />
+								<Separator className="flex-1" />
 							</div>
 							<SecretFields
 								getFieldHelpers={getFieldHelpers}


### PR DESCRIPTION
closes PLAT-408
Fixes a horizontal overflow in the Add secret dialog introduced by #26725. The "or add individually" divider renders two `Separator` components in a `flex items-center` row. `Separator` is styled `w-full shrink-0`, so each separator took the full dialog width and refused to shrink, making the row roughly twice the dialog width and forcing a horizontal scrollbar.

Adding `flex-1` to both separators sets `flex-basis: 0%`, which overrides `w-full` for main-axis sizing, so the two separators split the space around the label instead of overflowing.

Verified with a local dev instance and a headless browser: the dialog renders at its normal width with no horizontal scroll (`document.body.scrollWidth` no longer exceeds the viewport).

<details>
<summary>Decision log</summary>

- Root cause confirmed by reading `site/src/components/Separator/Separator.tsx`: the base class list is `bg-border shrink-0 ... data-[orientation=horizontal]:w-full ...`, so two horizontal separators in one flex row each demand 100% of the container width.
- Chose `flex-1` on the call site over changing the shared `Separator` component, since the component matches the upstream shadcn/ui implementation and other usages rely on the full-width default.
- `flex-1` works regardless of the `shrink-0` base class because it sets `flex-basis: 0%`; the separators grow equally from zero, so shrink behavior is irrelevant.

</details>

> Generated by Coder Agents on behalf of @dylanhuff-at-coder.
