### PR TITLE
chore: drop stale cost control experiment params

### DIFF
--- a/site/src/pages/GroupsPage/GroupPage.stories.tsx
+++ b/site/src/pages/GroupsPage/GroupPage.stories.tsx
@@ -537,7 +537,6 @@ export const SaveMemberAIBudgetRefreshesRow: Story = {
 	},
 	parameters: {
 		features: ["aibridge"],
-		experiments: ["ai-gateway-cost-control"],
 		queries: [
 			groupQuery(MockGroupWithoutMembers),
 			groupMembersQuery({ users: [MockUserOwner], count: 1 }),
@@ -591,7 +590,6 @@ export const DeleteMemberAIBudgetRefreshesRow: Story = {
 	},
 	parameters: {
 		features: ["aibridge"],
-		experiments: ["ai-gateway-cost-control"],
 		queries: [
 			groupQuery(MockGroupWithoutMembers),
 			groupMembersQuery({ users: [MockUserOwner], count: 1 }),


### PR DESCRIPTION
Removes two stale `experiments: ["ai-gateway-cost-control"]` story parameters from `GroupPage.stories.tsx`.

Refs #27579 #27553