### PR TITLE
feat: org-scope chat model config API cutover

### DIFF
--- a/cli/exp_scaletest_chat.go
+++ b/cli/exp_scaletest_chat.go
@@ -77,7 +77,7 @@ func (r *RootCmd) scaletestChat() *serpent.Command {
 			}
 
 			logger := inv.Logger
-			modelConfigID, err := chat.EnsureScaletestModelConfig(ctx, client, logger, llmMockURL, providerPropagationWait)
+			modelConfigForOrg, err := chat.EnsureScaletestModelConfig(ctx, client, logger, llmMockURL, providerPropagationWait)
 			if err != nil {
 				return err
 			}
@@ -122,6 +122,11 @@ func (r *RootCmd) scaletestChat() *serpent.Command {
 				for chatIndex := int64(0); chatIndex < chatsPerWorkspace; chatIndex++ {
 					if turnStartReadyWaitGroup != nil {
 						turnStartReadyWaitGroup.Add(1)
+					}
+
+					modelConfigID, err := modelConfigForOrg(targetWorkspace.OrganizationID)
+					if err != nil {
+						return xerrors.Errorf("ensure scaletest model config for organization %s: %w", targetWorkspace.OrganizationID, err)
 					}
 
 					cfg := chat.Config{

--- a/cli/exp_scaletest_chat_test.go
+++ b/cli/exp_scaletest_chat_test.go
@@ -77,9 +77,11 @@ func TestScaleTestChat(t *testing.T) {
 	require.Equal(t, mockURL, provider.BaseURL)
 
 	expClient := codersdk.NewExperimentalClient(client)
-	configs, err := expClient.ListChatModelConfigs(ctx)
+	defaultOrg, err := client.OrganizationByName(ctx, codersdk.DefaultOrganization)
 	require.NoError(t, err)
-	matchingConfigs := scaletestModelConfigsForProvider(configs, provider.ID)
+	configs, err := expClient.ChatModels(ctx, defaultOrg.ID)
+	require.NoError(t, err)
+	matchingConfigs := scaletestModelConfigsForProvider(configs.Models, provider.ID)
 	require.Len(t, matchingConfigs, 1)
 	require.True(t, matchingConfigs[0].Enabled)
 
@@ -125,8 +127,8 @@ func chatMessageText(messages []codersdk.ChatMessage, role codersdk.ChatMessageR
 	return b.String(), found
 }
 
-func scaletestModelConfigsForProvider(configs []codersdk.ChatModelConfig, providerID uuid.UUID) []codersdk.ChatModelConfig {
-	matches := make([]codersdk.ChatModelConfig, 0, 1)
+func scaletestModelConfigsForProvider(configs []codersdk.ChatModel, providerID uuid.UUID) []codersdk.ChatModel {
+	matches := make([]codersdk.ChatModel, 0, 1)
 	for _, config := range configs {
 		if config.AIProviderID != providerID {
 			continue

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -64,7 +64,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/experimental/ai-providers/catalog": {
+        "/api/experimental/ai/models/{model}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -72,75 +72,13 @@ const docTemplate = `{
                 "tags": [
                     "Chats"
                 ],
-                "summary": "Get the redacted AI provider catalog for org model admins",
-                "operationId": "get-chat-ai-provider-catalog",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/codersdk.ChatAIProviderCatalogEntry"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/experimental/chat-model-configs": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "List chat model configs across the caller's organizations",
-                "operationId": "list-chat-model-configs-union",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/codersdk.ChatModelConfig"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/experimental/chat-model-configs/{modelConfig}": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get a chat model config",
-                "operationId": "get-chat-model-config",
+                "summary": "Get an AI model",
+                "operationId": "get-ai-model",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Model config ID",
-                        "name": "modelConfig",
+                        "description": "Model ID",
+                        "name": "model",
                         "in": "path",
                         "required": true
                     }
@@ -149,7 +87,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/codersdk.ChatModelConfig"
+                            "$ref": "#/definitions/codersdk.ChatModel"
                         }
                     }
                 },
@@ -166,13 +104,13 @@ const docTemplate = `{
                 "tags": [
                     "Chats"
                 ],
-                "summary": "Delete a chat model config",
-                "operationId": "delete-chat-model-config",
+                "summary": "Delete an AI model",
+                "operationId": "delete-ai-model",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Model config ID",
-                        "name": "modelConfig",
+                        "description": "Model ID",
+                        "name": "model",
                         "in": "path",
                         "required": true
                     }
@@ -201,23 +139,23 @@ const docTemplate = `{
                 "tags": [
                     "Chats"
                 ],
-                "summary": "Update a chat model config",
-                "operationId": "update-chat-model-config",
+                "summary": "Update an AI model",
+                "operationId": "update-ai-model",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Model config ID",
-                        "name": "modelConfig",
+                        "description": "Model ID",
+                        "name": "model",
                         "in": "path",
                         "required": true
                     },
                     {
-                        "description": "Model config updates",
+                        "description": "Model updates",
                         "name": "request",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateChatModelConfigRequest"
+                            "$ref": "#/definitions/codersdk.UpdateChatModelRequest"
                         }
                     }
                 ],
@@ -225,7 +163,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/codersdk.ChatModelConfig"
+                            "$ref": "#/definitions/codersdk.ChatModel"
                         }
                     }
                 },
@@ -461,32 +399,6 @@ const docTemplate = `{
                 "responses": {
                     "200": {
                         "description": "OK"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/experimental/chats/models": {
-            "get": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "List chat models",
-                "operationId": "list-chat-models",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatModelsResponse"
-                        }
                     }
                 },
                 "security": [
@@ -1276,7 +1188,56 @@ const docTemplate = `{
                 ]
             }
         },
-        "/api/experimental/organizations/{organization}/chat-model-configs": {
+        "/api/experimental/organizations/{organization}/ai/models": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Create an AI model in an organization",
+                "operationId": "create-ai-model",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Model",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.CreateChatModelRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatModel"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/experimental/organizations/{organization}/chats/models": {
             "get": {
                 "produces": [
                     "application/json"
@@ -1284,8 +1245,8 @@ const docTemplate = `{
                 "tags": [
                     "Chats"
                 ],
-                "summary": "List chat model configs in an organization",
-                "operationId": "list-chat-model-configs-by-organization",
+                "summary": "List AI models and provider descriptors in an organization",
+                "operationId": "list-ai-models-by-organization",
                 "parameters": [
                     {
                         "type": "string",
@@ -1299,10 +1260,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/codersdk.ChatModelConfig"
-                            }
+                            "$ref": "#/definitions/codersdk.OrganizationChatModelsResponse"
                         }
                     }
                 },
@@ -1314,19 +1272,19 @@ const docTemplate = `{
                 "x-apidocgen": {
                     "skip": true
                 }
-            },
-            "post": {
-                "consumes": [
-                    "application/json"
-                ],
+            }
+        },
+        "/api/experimental/organizations/{organization}/chats/models/available": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Chats"
                 ],
-                "summary": "Create a chat model config in an organization",
-                "operationId": "create-chat-model-config",
+                "summary": "List available chat models in an organization",
+                "operationId": "list-chat-model-availability",
                 "parameters": [
                     {
                         "type": "string",
@@ -1334,22 +1292,13 @@ const docTemplate = `{
                         "name": "organization",
                         "in": "path",
                         "required": true
-                    },
-                    {
-                        "description": "Model config",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.CreateChatModelConfigRequest"
-                        }
                     }
                 ],
                 "responses": {
-                    "201": {
-                        "description": "Created",
+                    "200": {
+                        "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/codersdk.ChatModelConfig"
+                            "$ref": "#/definitions/codersdk.ChatModelAvailabilityResponse"
                         }
                     }
                 },
@@ -1357,10 +1306,7 @@ const docTemplate = `{
                     {
                         "CoderSessionToken": []
                     }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
+                ]
             }
         },
         "/api/experimental/users/{user}/skills": {
@@ -17614,36 +17560,6 @@ const docTemplate = `{
                 }
             }
         },
-        "codersdk.ChatAIProviderCatalogEntry": {
-            "type": "object",
-            "properties": {
-                "allow_user_api_key": {
-                    "type": "boolean"
-                },
-                "display_name": {
-                    "type": "string"
-                },
-                "enabled": {
-                    "type": "boolean"
-                },
-                "has_api_key": {
-                    "type": "boolean"
-                },
-                "has_user_api_key": {
-                    "type": "boolean"
-                },
-                "icon": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string",
-                    "format": "uuid"
-                },
-                "type": {
-                    "type": "string"
-                }
-            }
-        },
         "codersdk.ChatBusyBehavior": {
             "type": "string",
             "enum": [
@@ -18397,17 +18313,53 @@ const docTemplate = `{
         "codersdk.ChatModel": {
             "type": "object",
             "properties": {
+                "ai_provider_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "compression_threshold": {
+                    "type": "integer"
+                },
+                "context_limit": {
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
                 "display_name": {
                     "type": "string"
                 },
+                "enabled": {
+                    "type": "boolean"
+                },
                 "id": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "is_default": {
+                    "type": "boolean"
                 },
                 "model": {
                     "type": "string"
                 },
-                "provider": {
-                    "type": "string"
+                "model_config": {
+                    "$ref": "#/definitions/codersdk.ChatModelCallConfig"
+                },
+                "organization_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "reasoning_efforts": {
+                    "description": "ReasoningEfforts lists selectable reasoning effort values through\nthe model's configured maximum.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
                 }
             }
         },
@@ -18454,6 +18406,24 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.ChatModelAvailabilityResponse": {
+            "type": "object",
+            "properties": {
+                "providers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.ChatModelProvider"
+                    }
+                },
+                "unsupported_providers": {
+                    "description": "UnsupportedProviders lists configured providers the Agents harness\ncannot use, so the UI can explain the empty state.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.ChatUnsupportedProvider"
+                    }
+                }
+            }
+        },
         "codersdk.ChatModelCallConfig": {
             "type": "object",
             "properties": {
@@ -18483,63 +18453,6 @@ const docTemplate = `{
                 },
                 "top_p": {
                     "type": "number"
-                }
-            }
-        },
-        "codersdk.ChatModelConfig": {
-            "type": "object",
-            "properties": {
-                "ai_provider_id": {
-                    "type": "string",
-                    "format": "uuid"
-                },
-                "compression_threshold": {
-                    "type": "integer"
-                },
-                "context_limit": {
-                    "type": "integer"
-                },
-                "created_at": {
-                    "type": "string",
-                    "format": "date-time"
-                },
-                "display_name": {
-                    "type": "string"
-                },
-                "enabled": {
-                    "type": "boolean"
-                },
-                "id": {
-                    "type": "string",
-                    "format": "uuid"
-                },
-                "is_default": {
-                    "type": "boolean"
-                },
-                "model": {
-                    "type": "string"
-                },
-                "model_config": {
-                    "$ref": "#/definitions/codersdk.ChatModelCallConfig"
-                },
-                "organization_display_name": {
-                    "description": "OrganizationDisplayName is set on union-list responses so user-context\npages can label which org each copy belongs to.",
-                    "type": "string"
-                },
-                "organization_id": {
-                    "type": "string",
-                    "format": "uuid"
-                },
-                "reasoning_efforts": {
-                    "description": "ReasoningEfforts lists selectable reasoning effort values through\nthe model's configured maximum.",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "updated_at": {
-                    "type": "string",
-                    "format": "date-time"
                 }
             }
         },
@@ -18763,7 +18676,7 @@ const docTemplate = `{
                 "models": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/codersdk.ChatModel"
+                        "$ref": "#/definitions/codersdk.MinimalChatModel"
                     }
                 },
                 "provider": {
@@ -18771,6 +18684,36 @@ const docTemplate = `{
                 },
                 "unavailable_reason": {
                     "$ref": "#/definitions/codersdk.ChatModelProviderUnavailableReason"
+                }
+            }
+        },
+        "codersdk.ChatModelProviderDescriptor": {
+            "type": "object",
+            "properties": {
+                "allow_user_api_key": {
+                    "type": "boolean"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "has_api_key": {
+                    "type": "boolean"
+                },
+                "has_user_api_key": {
+                    "type": "boolean"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "type": {
+                    "type": "string"
                 }
             }
         },
@@ -18883,24 +18826,6 @@ const docTemplate = `{
                 },
                 "user": {
                     "type": "string"
-                }
-            }
-        },
-        "codersdk.ChatModelsResponse": {
-            "type": "object",
-            "properties": {
-                "providers": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/codersdk.ChatModelProvider"
-                    }
-                },
-                "unsupported_providers": {
-                    "description": "UnsupportedProviders lists configured providers the Agents harness\ncannot use, so the UI can explain the empty state.",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/codersdk.ChatUnsupportedProvider"
-                    }
                 }
             }
         },
@@ -19551,7 +19476,7 @@ const docTemplate = `{
                 }
             }
         },
-        "codersdk.CreateChatModelConfigRequest": {
+        "codersdk.CreateChatModelRequest": {
             "type": "object",
             "properties": {
                 "ai_provider_id": {
@@ -22072,6 +21997,23 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.MinimalChatModel": {
+            "type": "object",
+            "properties": {
+                "display_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "provider": {
+                    "type": "string"
+                }
+            }
+        },
         "codersdk.MinimalOrganization": {
             "type": "object",
             "required": [
@@ -23095,6 +23037,23 @@ const docTemplate = `{
                 "updated_at": {
                     "type": "string",
                     "format": "date-time"
+                }
+            }
+        },
+        "codersdk.OrganizationChatModelsResponse": {
+            "type": "object",
+            "properties": {
+                "models": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.ChatModel"
+                    }
+                },
+                "providers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.ChatModelProviderDescriptor"
+                    }
                 }
             }
         },
@@ -26625,7 +26584,7 @@ const docTemplate = `{
                 }
             }
         },
-        "codersdk.UpdateChatModelConfigRequest": {
+        "codersdk.UpdateChatModelRequest": {
             "type": "object",
             "properties": {
                 "ai_provider_id": {

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -64,6 +64,181 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/experimental/ai-providers/catalog": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get the redacted AI provider catalog for org model admins",
+                "operationId": "get-chat-ai-provider-catalog",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/codersdk.ChatAIProviderCatalogEntry"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/experimental/chat-model-configs": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "List chat model configs across the caller's organizations",
+                "operationId": "list-chat-model-configs-union",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/codersdk.ChatModelConfig"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/experimental/chat-model-configs/{modelConfig}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get a chat model config",
+                "operationId": "get-chat-model-config",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Model config ID",
+                        "name": "modelConfig",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatModelConfig"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            },
+            "delete": {
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Delete a chat model config",
+                "operationId": "delete-chat-model-config",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Model config ID",
+                        "name": "modelConfig",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            },
+            "patch": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update a chat model config",
+                "operationId": "update-chat-model-config",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Model config ID",
+                        "name": "modelConfig",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Model config updates",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatModelConfigRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatModelConfig"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
         "/api/experimental/chats": {
             "get": {
                 "description": "Experimental: this endpoint is subject to change.",
@@ -1099,6 +1274,93 @@ const docTemplate = `{
                         "CoderSessionToken": []
                     }
                 ]
+            }
+        },
+        "/api/experimental/organizations/{organization}/chat-model-configs": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "List chat model configs in an organization",
+                "operationId": "list-chat-model-configs-by-organization",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/codersdk.ChatModelConfig"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Create a chat model config in an organization",
+                "operationId": "create-chat-model-config",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Model config",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.CreateChatModelConfigRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatModelConfig"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
             }
         },
         "/api/experimental/users/{user}/skills": {
@@ -17352,6 +17614,36 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.ChatAIProviderCatalogEntry": {
+            "type": "object",
+            "properties": {
+                "allow_user_api_key": {
+                    "type": "boolean"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "has_api_key": {
+                    "type": "boolean"
+                },
+                "has_user_api_key": {
+                    "type": "boolean"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
         "codersdk.ChatBusyBehavior": {
             "type": "string",
             "enum": [
@@ -18119,6 +18411,349 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.ChatModelAnthropicProviderOptions": {
+            "type": "object",
+            "properties": {
+                "allowed_domains": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "blocked_domains": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "context_1m_enabled": {
+                    "type": "boolean"
+                },
+                "disable_parallel_tool_use": {
+                    "type": "boolean"
+                },
+                "send_reasoning": {
+                    "type": "boolean"
+                },
+                "thinking": {
+                    "$ref": "#/definitions/codersdk.ChatModelAnthropicThinkingOptions"
+                },
+                "thinking_display": {
+                    "type": "string"
+                },
+                "web_search_enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "codersdk.ChatModelAnthropicThinkingOptions": {
+            "type": "object",
+            "properties": {
+                "budget_tokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "codersdk.ChatModelCallConfig": {
+            "type": "object",
+            "properties": {
+                "cost": {
+                    "$ref": "#/definitions/codersdk.ModelCostConfig"
+                },
+                "frequency_penalty": {
+                    "type": "number"
+                },
+                "max_output_tokens": {
+                    "type": "integer"
+                },
+                "presence_penalty": {
+                    "type": "number"
+                },
+                "provider_options": {
+                    "$ref": "#/definitions/codersdk.ChatModelProviderOptions"
+                },
+                "reasoning_effort": {
+                    "$ref": "#/definitions/codersdk.ChatModelReasoningEffortConfig"
+                },
+                "temperature": {
+                    "type": "number"
+                },
+                "top_k": {
+                    "type": "integer"
+                },
+                "top_p": {
+                    "type": "number"
+                }
+            }
+        },
+        "codersdk.ChatModelConfig": {
+            "type": "object",
+            "properties": {
+                "ai_provider_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "compression_threshold": {
+                    "type": "integer"
+                },
+                "context_limit": {
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "is_default": {
+                    "type": "boolean"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "model_config": {
+                    "$ref": "#/definitions/codersdk.ChatModelCallConfig"
+                },
+                "organization_display_name": {
+                    "description": "OrganizationDisplayName is set on union-list responses so user-context\npages can label which org each copy belongs to.",
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "reasoning_efforts": {
+                    "description": "ReasoningEfforts lists selectable reasoning effort values through\nthe model's configured maximum.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            }
+        },
+        "codersdk.ChatModelGoogleProviderOptions": {
+            "type": "object",
+            "properties": {
+                "cached_content": {
+                    "type": "string"
+                },
+                "safety_settings": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.ChatModelGoogleSafetySetting"
+                    }
+                },
+                "thinking_config": {
+                    "$ref": "#/definitions/codersdk.ChatModelGoogleThinkingConfig"
+                },
+                "threshold": {
+                    "type": "string"
+                },
+                "web_search_enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "codersdk.ChatModelGoogleSafetySetting": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "threshold": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.ChatModelGoogleThinkingConfig": {
+            "type": "object",
+            "properties": {
+                "include_thoughts": {
+                    "type": "boolean"
+                },
+                "thinking_budget": {
+                    "type": "integer"
+                }
+            }
+        },
+        "codersdk.ChatModelOpenAICompatProviderOptions": {
+            "type": "object",
+            "properties": {
+                "user": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.ChatModelOpenAIProviderOptions": {
+            "type": "object",
+            "properties": {
+                "allowed_domains": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "include": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "instructions": {
+                    "type": "string"
+                },
+                "log_probs": {
+                    "type": "boolean"
+                },
+                "logit_bias": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                },
+                "max_completion_tokens": {
+                    "type": "integer"
+                },
+                "max_tool_calls": {
+                    "type": "integer"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "parallel_tool_calls": {
+                    "type": "boolean"
+                },
+                "prediction": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "prompt_cache_key": {
+                    "type": "string"
+                },
+                "reasoning_summary": {
+                    "type": "string"
+                },
+                "safety_identifier": {
+                    "type": "string"
+                },
+                "search_context_size": {
+                    "type": "string"
+                },
+                "service_tier": {
+                    "type": "string"
+                },
+                "store": {
+                    "type": "boolean"
+                },
+                "strict_json_schema": {
+                    "type": "boolean"
+                },
+                "structured_outputs": {
+                    "type": "boolean"
+                },
+                "text_verbosity": {
+                    "type": "string"
+                },
+                "top_log_probs": {
+                    "type": "integer"
+                },
+                "user": {
+                    "type": "string"
+                },
+                "web_search_enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "codersdk.ChatModelOpenRouterProvider": {
+            "type": "object",
+            "properties": {
+                "allow_fallbacks": {
+                    "type": "boolean"
+                },
+                "data_collection": {
+                    "type": "string"
+                },
+                "ignore": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "only": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "order": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "quantizations": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "require_parameters": {
+                    "type": "boolean"
+                },
+                "sort": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.ChatModelOpenRouterProviderOptions": {
+            "type": "object",
+            "properties": {
+                "extra_body": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "include_usage": {
+                    "type": "boolean"
+                },
+                "log_probs": {
+                    "type": "boolean"
+                },
+                "logit_bias": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                },
+                "parallel_tool_calls": {
+                    "type": "boolean"
+                },
+                "provider": {
+                    "$ref": "#/definitions/codersdk.ChatModelOpenRouterProvider"
+                },
+                "reasoning": {
+                    "$ref": "#/definitions/codersdk.ChatModelReasoningOptions"
+                },
+                "user": {
+                    "type": "string"
+                }
+            }
+        },
         "codersdk.ChatModelProvider": {
             "type": "object",
             "properties": {
@@ -18139,6 +18774,29 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.ChatModelProviderOptions": {
+            "type": "object",
+            "properties": {
+                "anthropic": {
+                    "$ref": "#/definitions/codersdk.ChatModelAnthropicProviderOptions"
+                },
+                "google": {
+                    "$ref": "#/definitions/codersdk.ChatModelGoogleProviderOptions"
+                },
+                "openai": {
+                    "$ref": "#/definitions/codersdk.ChatModelOpenAIProviderOptions"
+                },
+                "openaicompat": {
+                    "$ref": "#/definitions/codersdk.ChatModelOpenAICompatProviderOptions"
+                },
+                "openrouter": {
+                    "$ref": "#/definitions/codersdk.ChatModelOpenRouterProviderOptions"
+                },
+                "vercel": {
+                    "$ref": "#/definitions/codersdk.ChatModelVercelProviderOptions"
+                }
+            }
+        },
         "codersdk.ChatModelProviderUnavailableReason": {
             "type": "string",
             "enum": [
@@ -18151,6 +18809,82 @@ const docTemplate = `{
                 "ChatModelProviderUnavailableFetchFailed",
                 "ChatModelProviderUnavailableReasonUserAPIKeyRequired"
             ]
+        },
+        "codersdk.ChatModelReasoningEffortConfig": {
+            "type": "object",
+            "properties": {
+                "default": {
+                    "type": "string"
+                },
+                "max": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.ChatModelReasoningOptions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "exclude": {
+                    "type": "boolean"
+                },
+                "max_tokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "codersdk.ChatModelVercelGatewayProviderOptions": {
+            "type": "object",
+            "properties": {
+                "models": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "order": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "codersdk.ChatModelVercelProviderOptions": {
+            "type": "object",
+            "properties": {
+                "extra_body": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "logit_bias": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                },
+                "logprobs": {
+                    "type": "boolean"
+                },
+                "parallel_tool_calls": {
+                    "type": "boolean"
+                },
+                "providerOptions": {
+                    "$ref": "#/definitions/codersdk.ChatModelVercelGatewayProviderOptions"
+                },
+                "reasoning": {
+                    "$ref": "#/definitions/codersdk.ChatModelReasoningOptions"
+                },
+                "top_logprobs": {
+                    "type": "integer"
+                },
+                "user": {
+                    "type": "string"
+                }
+            }
         },
         "codersdk.ChatModelsResponse": {
             "type": "object",
@@ -18814,6 +19548,36 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "codersdk.CreateChatModelConfigRequest": {
+            "type": "object",
+            "properties": {
+                "ai_provider_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "compression_threshold": {
+                    "type": "integer"
+                },
+                "context_limit": {
+                    "type": "integer"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "is_default": {
+                    "type": "boolean"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "model_config": {
+                    "$ref": "#/definitions/codersdk.ChatModelCallConfig"
                 }
             }
         },
@@ -21349,6 +22113,23 @@ const docTemplate = `{
                 },
                 "username": {
                     "type": "string"
+                }
+            }
+        },
+        "codersdk.ModelCostConfig": {
+            "type": "object",
+            "properties": {
+                "cache_read_price_per_million_tokens": {
+                    "type": "number"
+                },
+                "cache_write_price_per_million_tokens": {
+                    "type": "number"
+                },
+                "input_price_per_million_tokens": {
+                    "type": "number"
+                },
+                "output_price_per_million_tokens": {
+                    "type": "number"
                 }
             }
         },
@@ -25841,6 +26622,36 @@ const docTemplate = `{
                     "additionalProperties": {
                         "$ref": "#/definitions/codersdk.ChatRole"
                     }
+                }
+            }
+        },
+        "codersdk.UpdateChatModelConfigRequest": {
+            "type": "object",
+            "properties": {
+                "ai_provider_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "compression_threshold": {
+                    "type": "integer"
+                },
+                "context_limit": {
+                    "type": "integer"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "is_default": {
+                    "type": "boolean"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "model_config": {
+                    "$ref": "#/definitions/codersdk.ChatModelCallConfig"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -49,6 +49,161 @@
 				}
 			}
 		},
+		"/api/experimental/ai-providers/catalog": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get the redacted AI provider catalog for org model admins",
+				"operationId": "get-chat-ai-provider-catalog",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/codersdk.ChatAIProviderCatalogEntry"
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/experimental/chat-model-configs": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "List chat model configs across the caller's organizations",
+				"operationId": "list-chat-model-configs-union",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/codersdk.ChatModelConfig"
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/experimental/chat-model-configs/{modelConfig}": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get a chat model config",
+				"operationId": "get-chat-model-config",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Model config ID",
+						"name": "modelConfig",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatModelConfig"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			},
+			"delete": {
+				"tags": ["Chats"],
+				"summary": "Delete a chat model config",
+				"operationId": "delete-chat-model-config",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Model config ID",
+						"name": "modelConfig",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			},
+			"patch": {
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update a chat model config",
+				"operationId": "update-chat-model-config",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Model config ID",
+						"name": "modelConfig",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Model config updates",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatModelConfigRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatModelConfig"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
 		"/api/experimental/chats": {
 			"get": {
 				"description": "Experimental: this endpoint is subject to change.",
@@ -972,6 +1127,83 @@
 						"CoderSessionToken": []
 					}
 				]
+			}
+		},
+		"/api/experimental/organizations/{organization}/chat-model-configs": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "List chat model configs in an organization",
+				"operationId": "list-chat-model-configs-by-organization",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/codersdk.ChatModelConfig"
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			},
+			"post": {
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Create a chat model config in an organization",
+				"operationId": "create-chat-model-config",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Model config",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.CreateChatModelConfigRequest"
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Created",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatModelConfig"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
 			}
 		},
 		"/api/experimental/users/{user}/skills": {
@@ -15601,6 +15833,36 @@
 				}
 			}
 		},
+		"codersdk.ChatAIProviderCatalogEntry": {
+			"type": "object",
+			"properties": {
+				"allow_user_api_key": {
+					"type": "boolean"
+				},
+				"display_name": {
+					"type": "string"
+				},
+				"enabled": {
+					"type": "boolean"
+				},
+				"has_api_key": {
+					"type": "boolean"
+				},
+				"has_user_api_key": {
+					"type": "boolean"
+				},
+				"icon": {
+					"type": "string"
+				},
+				"id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"type": {
+					"type": "string"
+				}
+			}
+		},
 		"codersdk.ChatBusyBehavior": {
 			"type": "string",
 			"enum": ["queue", "interrupt"],
@@ -16334,6 +16596,349 @@
 				}
 			}
 		},
+		"codersdk.ChatModelAnthropicProviderOptions": {
+			"type": "object",
+			"properties": {
+				"allowed_domains": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"blocked_domains": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"context_1m_enabled": {
+					"type": "boolean"
+				},
+				"disable_parallel_tool_use": {
+					"type": "boolean"
+				},
+				"send_reasoning": {
+					"type": "boolean"
+				},
+				"thinking": {
+					"$ref": "#/definitions/codersdk.ChatModelAnthropicThinkingOptions"
+				},
+				"thinking_display": {
+					"type": "string"
+				},
+				"web_search_enabled": {
+					"type": "boolean"
+				}
+			}
+		},
+		"codersdk.ChatModelAnthropicThinkingOptions": {
+			"type": "object",
+			"properties": {
+				"budget_tokens": {
+					"type": "integer"
+				}
+			}
+		},
+		"codersdk.ChatModelCallConfig": {
+			"type": "object",
+			"properties": {
+				"cost": {
+					"$ref": "#/definitions/codersdk.ModelCostConfig"
+				},
+				"frequency_penalty": {
+					"type": "number"
+				},
+				"max_output_tokens": {
+					"type": "integer"
+				},
+				"presence_penalty": {
+					"type": "number"
+				},
+				"provider_options": {
+					"$ref": "#/definitions/codersdk.ChatModelProviderOptions"
+				},
+				"reasoning_effort": {
+					"$ref": "#/definitions/codersdk.ChatModelReasoningEffortConfig"
+				},
+				"temperature": {
+					"type": "number"
+				},
+				"top_k": {
+					"type": "integer"
+				},
+				"top_p": {
+					"type": "number"
+				}
+			}
+		},
+		"codersdk.ChatModelConfig": {
+			"type": "object",
+			"properties": {
+				"ai_provider_id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"compression_threshold": {
+					"type": "integer"
+				},
+				"context_limit": {
+					"type": "integer"
+				},
+				"created_at": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"display_name": {
+					"type": "string"
+				},
+				"enabled": {
+					"type": "boolean"
+				},
+				"id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"is_default": {
+					"type": "boolean"
+				},
+				"model": {
+					"type": "string"
+				},
+				"model_config": {
+					"$ref": "#/definitions/codersdk.ChatModelCallConfig"
+				},
+				"organization_display_name": {
+					"description": "OrganizationDisplayName is set on union-list responses so user-context\npages can label which org each copy belongs to.",
+					"type": "string"
+				},
+				"organization_id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"reasoning_efforts": {
+					"description": "ReasoningEfforts lists selectable reasoning effort values through\nthe model's configured maximum.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"updated_at": {
+					"type": "string",
+					"format": "date-time"
+				}
+			}
+		},
+		"codersdk.ChatModelGoogleProviderOptions": {
+			"type": "object",
+			"properties": {
+				"cached_content": {
+					"type": "string"
+				},
+				"safety_settings": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.ChatModelGoogleSafetySetting"
+					}
+				},
+				"thinking_config": {
+					"$ref": "#/definitions/codersdk.ChatModelGoogleThinkingConfig"
+				},
+				"threshold": {
+					"type": "string"
+				},
+				"web_search_enabled": {
+					"type": "boolean"
+				}
+			}
+		},
+		"codersdk.ChatModelGoogleSafetySetting": {
+			"type": "object",
+			"properties": {
+				"category": {
+					"type": "string"
+				},
+				"threshold": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.ChatModelGoogleThinkingConfig": {
+			"type": "object",
+			"properties": {
+				"include_thoughts": {
+					"type": "boolean"
+				},
+				"thinking_budget": {
+					"type": "integer"
+				}
+			}
+		},
+		"codersdk.ChatModelOpenAICompatProviderOptions": {
+			"type": "object",
+			"properties": {
+				"user": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.ChatModelOpenAIProviderOptions": {
+			"type": "object",
+			"properties": {
+				"allowed_domains": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"include": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"instructions": {
+					"type": "string"
+				},
+				"log_probs": {
+					"type": "boolean"
+				},
+				"logit_bias": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "integer",
+						"format": "int64"
+					}
+				},
+				"max_completion_tokens": {
+					"type": "integer"
+				},
+				"max_tool_calls": {
+					"type": "integer"
+				},
+				"metadata": {
+					"type": "object",
+					"additionalProperties": {}
+				},
+				"parallel_tool_calls": {
+					"type": "boolean"
+				},
+				"prediction": {
+					"type": "object",
+					"additionalProperties": {}
+				},
+				"prompt_cache_key": {
+					"type": "string"
+				},
+				"reasoning_summary": {
+					"type": "string"
+				},
+				"safety_identifier": {
+					"type": "string"
+				},
+				"search_context_size": {
+					"type": "string"
+				},
+				"service_tier": {
+					"type": "string"
+				},
+				"store": {
+					"type": "boolean"
+				},
+				"strict_json_schema": {
+					"type": "boolean"
+				},
+				"structured_outputs": {
+					"type": "boolean"
+				},
+				"text_verbosity": {
+					"type": "string"
+				},
+				"top_log_probs": {
+					"type": "integer"
+				},
+				"user": {
+					"type": "string"
+				},
+				"web_search_enabled": {
+					"type": "boolean"
+				}
+			}
+		},
+		"codersdk.ChatModelOpenRouterProvider": {
+			"type": "object",
+			"properties": {
+				"allow_fallbacks": {
+					"type": "boolean"
+				},
+				"data_collection": {
+					"type": "string"
+				},
+				"ignore": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"only": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"order": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"quantizations": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"require_parameters": {
+					"type": "boolean"
+				},
+				"sort": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.ChatModelOpenRouterProviderOptions": {
+			"type": "object",
+			"properties": {
+				"extra_body": {
+					"type": "object",
+					"additionalProperties": {}
+				},
+				"include_usage": {
+					"type": "boolean"
+				},
+				"log_probs": {
+					"type": "boolean"
+				},
+				"logit_bias": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "integer",
+						"format": "int64"
+					}
+				},
+				"parallel_tool_calls": {
+					"type": "boolean"
+				},
+				"provider": {
+					"$ref": "#/definitions/codersdk.ChatModelOpenRouterProvider"
+				},
+				"reasoning": {
+					"$ref": "#/definitions/codersdk.ChatModelReasoningOptions"
+				},
+				"user": {
+					"type": "string"
+				}
+			}
+		},
 		"codersdk.ChatModelProvider": {
 			"type": "object",
 			"properties": {
@@ -16354,6 +16959,29 @@
 				}
 			}
 		},
+		"codersdk.ChatModelProviderOptions": {
+			"type": "object",
+			"properties": {
+				"anthropic": {
+					"$ref": "#/definitions/codersdk.ChatModelAnthropicProviderOptions"
+				},
+				"google": {
+					"$ref": "#/definitions/codersdk.ChatModelGoogleProviderOptions"
+				},
+				"openai": {
+					"$ref": "#/definitions/codersdk.ChatModelOpenAIProviderOptions"
+				},
+				"openaicompat": {
+					"$ref": "#/definitions/codersdk.ChatModelOpenAICompatProviderOptions"
+				},
+				"openrouter": {
+					"$ref": "#/definitions/codersdk.ChatModelOpenRouterProviderOptions"
+				},
+				"vercel": {
+					"$ref": "#/definitions/codersdk.ChatModelVercelProviderOptions"
+				}
+			}
+		},
 		"codersdk.ChatModelProviderUnavailableReason": {
 			"type": "string",
 			"enum": ["missing_api_key", "fetch_failed", "user_api_key_required"],
@@ -16362,6 +16990,82 @@
 				"ChatModelProviderUnavailableFetchFailed",
 				"ChatModelProviderUnavailableReasonUserAPIKeyRequired"
 			]
+		},
+		"codersdk.ChatModelReasoningEffortConfig": {
+			"type": "object",
+			"properties": {
+				"default": {
+					"type": "string"
+				},
+				"max": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.ChatModelReasoningOptions": {
+			"type": "object",
+			"properties": {
+				"enabled": {
+					"type": "boolean"
+				},
+				"exclude": {
+					"type": "boolean"
+				},
+				"max_tokens": {
+					"type": "integer"
+				}
+			}
+		},
+		"codersdk.ChatModelVercelGatewayProviderOptions": {
+			"type": "object",
+			"properties": {
+				"models": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"order": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			}
+		},
+		"codersdk.ChatModelVercelProviderOptions": {
+			"type": "object",
+			"properties": {
+				"extra_body": {
+					"type": "object",
+					"additionalProperties": {}
+				},
+				"logit_bias": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "integer",
+						"format": "int64"
+					}
+				},
+				"logprobs": {
+					"type": "boolean"
+				},
+				"parallel_tool_calls": {
+					"type": "boolean"
+				},
+				"providerOptions": {
+					"$ref": "#/definitions/codersdk.ChatModelVercelGatewayProviderOptions"
+				},
+				"reasoning": {
+					"$ref": "#/definitions/codersdk.ChatModelReasoningOptions"
+				},
+				"top_logprobs": {
+					"type": "integer"
+				},
+				"user": {
+					"type": "string"
+				}
+			}
 		},
 		"codersdk.ChatModelsResponse": {
 			"type": "object",
@@ -17002,6 +17706,36 @@
 					"items": {
 						"type": "string"
 					}
+				}
+			}
+		},
+		"codersdk.CreateChatModelConfigRequest": {
+			"type": "object",
+			"properties": {
+				"ai_provider_id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"compression_threshold": {
+					"type": "integer"
+				},
+				"context_limit": {
+					"type": "integer"
+				},
+				"display_name": {
+					"type": "string"
+				},
+				"enabled": {
+					"type": "boolean"
+				},
+				"is_default": {
+					"type": "boolean"
+				},
+				"model": {
+					"type": "string"
+				},
+				"model_config": {
+					"$ref": "#/definitions/codersdk.ChatModelCallConfig"
 				}
 			}
 		},
@@ -19425,6 +20159,23 @@
 				},
 				"username": {
 					"type": "string"
+				}
+			}
+		},
+		"codersdk.ModelCostConfig": {
+			"type": "object",
+			"properties": {
+				"cache_read_price_per_million_tokens": {
+					"type": "number"
+				},
+				"cache_write_price_per_million_tokens": {
+					"type": "number"
+				},
+				"input_price_per_million_tokens": {
+					"type": "number"
+				},
+				"output_price_per_million_tokens": {
+					"type": "number"
 				}
 			}
 		},
@@ -23737,6 +24488,36 @@
 					"additionalProperties": {
 						"$ref": "#/definitions/codersdk.ChatRole"
 					}
+				}
+			}
+		},
+		"codersdk.UpdateChatModelConfigRequest": {
+			"type": "object",
+			"properties": {
+				"ai_provider_id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"compression_threshold": {
+					"type": "integer"
+				},
+				"context_limit": {
+					"type": "integer"
+				},
+				"display_name": {
+					"type": "string"
+				},
+				"enabled": {
+					"type": "boolean"
+				},
+				"is_default": {
+					"type": "boolean"
+				},
+				"model": {
+					"type": "string"
+				},
+				"model_config": {
+					"$ref": "#/definitions/codersdk.ChatModelCallConfig"
 				}
 			}
 		},

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -49,71 +49,17 @@
 				}
 			}
 		},
-		"/api/experimental/ai-providers/catalog": {
+		"/api/experimental/ai/models/{model}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Chats"],
-				"summary": "Get the redacted AI provider catalog for org model admins",
-				"operationId": "get-chat-ai-provider-catalog",
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/codersdk.ChatAIProviderCatalogEntry"
-							}
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/experimental/chat-model-configs": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "List chat model configs across the caller's organizations",
-				"operationId": "list-chat-model-configs-union",
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/codersdk.ChatModelConfig"
-							}
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/experimental/chat-model-configs/{modelConfig}": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get a chat model config",
-				"operationId": "get-chat-model-config",
+				"summary": "Get an AI model",
+				"operationId": "get-ai-model",
 				"parameters": [
 					{
 						"type": "string",
-						"description": "Model config ID",
-						"name": "modelConfig",
+						"description": "Model ID",
+						"name": "model",
 						"in": "path",
 						"required": true
 					}
@@ -122,7 +68,7 @@
 					"200": {
 						"description": "OK",
 						"schema": {
-							"$ref": "#/definitions/codersdk.ChatModelConfig"
+							"$ref": "#/definitions/codersdk.ChatModel"
 						}
 					}
 				},
@@ -137,13 +83,13 @@
 			},
 			"delete": {
 				"tags": ["Chats"],
-				"summary": "Delete a chat model config",
-				"operationId": "delete-chat-model-config",
+				"summary": "Delete an AI model",
+				"operationId": "delete-ai-model",
 				"parameters": [
 					{
 						"type": "string",
-						"description": "Model config ID",
-						"name": "modelConfig",
+						"description": "Model ID",
+						"name": "model",
 						"in": "path",
 						"required": true
 					}
@@ -166,23 +112,23 @@
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
 				"tags": ["Chats"],
-				"summary": "Update a chat model config",
-				"operationId": "update-chat-model-config",
+				"summary": "Update an AI model",
+				"operationId": "update-ai-model",
 				"parameters": [
 					{
 						"type": "string",
-						"description": "Model config ID",
-						"name": "modelConfig",
+						"description": "Model ID",
+						"name": "model",
 						"in": "path",
 						"required": true
 					},
 					{
-						"description": "Model config updates",
+						"description": "Model updates",
 						"name": "request",
 						"in": "body",
 						"required": true,
 						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateChatModelConfigRequest"
+							"$ref": "#/definitions/codersdk.UpdateChatModelRequest"
 						}
 					}
 				],
@@ -190,7 +136,7 @@
 					"200": {
 						"description": "OK",
 						"schema": {
-							"$ref": "#/definitions/codersdk.ChatModelConfig"
+							"$ref": "#/definitions/codersdk.ChatModel"
 						}
 					}
 				},
@@ -402,28 +348,6 @@
 				"responses": {
 					"200": {
 						"description": "OK"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/experimental/chats/models": {
-			"get": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "List chat models",
-				"operationId": "list-chat-models",
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatModelsResponse"
-						}
 					}
 				},
 				"security": [
@@ -1129,12 +1053,55 @@
 				]
 			}
 		},
-		"/api/experimental/organizations/{organization}/chat-model-configs": {
+		"/api/experimental/organizations/{organization}/ai/models": {
+			"post": {
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Create an AI model in an organization",
+				"operationId": "create-ai-model",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Model",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.CreateChatModelRequest"
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Created",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatModel"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/experimental/organizations/{organization}/chats/models": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Chats"],
-				"summary": "List chat model configs in an organization",
-				"operationId": "list-chat-model-configs-by-organization",
+				"summary": "List AI models and provider descriptors in an organization",
+				"operationId": "list-ai-models-by-organization",
 				"parameters": [
 					{
 						"type": "string",
@@ -1148,10 +1115,7 @@
 					"200": {
 						"description": "OK",
 						"schema": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/codersdk.ChatModelConfig"
-							}
+							"$ref": "#/definitions/codersdk.OrganizationChatModelsResponse"
 						}
 					}
 				},
@@ -1163,13 +1127,15 @@
 				"x-apidocgen": {
 					"skip": true
 				}
-			},
-			"post": {
-				"consumes": ["application/json"],
+			}
+		},
+		"/api/experimental/organizations/{organization}/chats/models/available": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
 				"produces": ["application/json"],
 				"tags": ["Chats"],
-				"summary": "Create a chat model config in an organization",
-				"operationId": "create-chat-model-config",
+				"summary": "List available chat models in an organization",
+				"operationId": "list-chat-model-availability",
 				"parameters": [
 					{
 						"type": "string",
@@ -1177,22 +1143,13 @@
 						"name": "organization",
 						"in": "path",
 						"required": true
-					},
-					{
-						"description": "Model config",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.CreateChatModelConfigRequest"
-						}
 					}
 				],
 				"responses": {
-					"201": {
-						"description": "Created",
+					"200": {
+						"description": "OK",
 						"schema": {
-							"$ref": "#/definitions/codersdk.ChatModelConfig"
+							"$ref": "#/definitions/codersdk.ChatModelAvailabilityResponse"
 						}
 					}
 				},
@@ -1200,10 +1157,7 @@
 					{
 						"CoderSessionToken": []
 					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
+				]
 			}
 		},
 		"/api/experimental/users/{user}/skills": {
@@ -15833,36 +15787,6 @@
 				}
 			}
 		},
-		"codersdk.ChatAIProviderCatalogEntry": {
-			"type": "object",
-			"properties": {
-				"allow_user_api_key": {
-					"type": "boolean"
-				},
-				"display_name": {
-					"type": "string"
-				},
-				"enabled": {
-					"type": "boolean"
-				},
-				"has_api_key": {
-					"type": "boolean"
-				},
-				"has_user_api_key": {
-					"type": "boolean"
-				},
-				"icon": {
-					"type": "string"
-				},
-				"id": {
-					"type": "string",
-					"format": "uuid"
-				},
-				"type": {
-					"type": "string"
-				}
-			}
-		},
 		"codersdk.ChatBusyBehavior": {
 			"type": "string",
 			"enum": ["queue", "interrupt"],
@@ -16582,17 +16506,53 @@
 		"codersdk.ChatModel": {
 			"type": "object",
 			"properties": {
+				"ai_provider_id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"compression_threshold": {
+					"type": "integer"
+				},
+				"context_limit": {
+					"type": "integer"
+				},
+				"created_at": {
+					"type": "string",
+					"format": "date-time"
+				},
 				"display_name": {
 					"type": "string"
 				},
+				"enabled": {
+					"type": "boolean"
+				},
 				"id": {
-					"type": "string"
+					"type": "string",
+					"format": "uuid"
+				},
+				"is_default": {
+					"type": "boolean"
 				},
 				"model": {
 					"type": "string"
 				},
-				"provider": {
-					"type": "string"
+				"model_config": {
+					"$ref": "#/definitions/codersdk.ChatModelCallConfig"
+				},
+				"organization_id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"reasoning_efforts": {
+					"description": "ReasoningEfforts lists selectable reasoning effort values through\nthe model's configured maximum.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"updated_at": {
+					"type": "string",
+					"format": "date-time"
 				}
 			}
 		},
@@ -16639,6 +16599,24 @@
 				}
 			}
 		},
+		"codersdk.ChatModelAvailabilityResponse": {
+			"type": "object",
+			"properties": {
+				"providers": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.ChatModelProvider"
+					}
+				},
+				"unsupported_providers": {
+					"description": "UnsupportedProviders lists configured providers the Agents harness\ncannot use, so the UI can explain the empty state.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.ChatUnsupportedProvider"
+					}
+				}
+			}
+		},
 		"codersdk.ChatModelCallConfig": {
 			"type": "object",
 			"properties": {
@@ -16668,63 +16646,6 @@
 				},
 				"top_p": {
 					"type": "number"
-				}
-			}
-		},
-		"codersdk.ChatModelConfig": {
-			"type": "object",
-			"properties": {
-				"ai_provider_id": {
-					"type": "string",
-					"format": "uuid"
-				},
-				"compression_threshold": {
-					"type": "integer"
-				},
-				"context_limit": {
-					"type": "integer"
-				},
-				"created_at": {
-					"type": "string",
-					"format": "date-time"
-				},
-				"display_name": {
-					"type": "string"
-				},
-				"enabled": {
-					"type": "boolean"
-				},
-				"id": {
-					"type": "string",
-					"format": "uuid"
-				},
-				"is_default": {
-					"type": "boolean"
-				},
-				"model": {
-					"type": "string"
-				},
-				"model_config": {
-					"$ref": "#/definitions/codersdk.ChatModelCallConfig"
-				},
-				"organization_display_name": {
-					"description": "OrganizationDisplayName is set on union-list responses so user-context\npages can label which org each copy belongs to.",
-					"type": "string"
-				},
-				"organization_id": {
-					"type": "string",
-					"format": "uuid"
-				},
-				"reasoning_efforts": {
-					"description": "ReasoningEfforts lists selectable reasoning effort values through\nthe model's configured maximum.",
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				"updated_at": {
-					"type": "string",
-					"format": "date-time"
 				}
 			}
 		},
@@ -16948,7 +16869,7 @@
 				"models": {
 					"type": "array",
 					"items": {
-						"$ref": "#/definitions/codersdk.ChatModel"
+						"$ref": "#/definitions/codersdk.MinimalChatModel"
 					}
 				},
 				"provider": {
@@ -16956,6 +16877,36 @@
 				},
 				"unavailable_reason": {
 					"$ref": "#/definitions/codersdk.ChatModelProviderUnavailableReason"
+				}
+			}
+		},
+		"codersdk.ChatModelProviderDescriptor": {
+			"type": "object",
+			"properties": {
+				"allow_user_api_key": {
+					"type": "boolean"
+				},
+				"display_name": {
+					"type": "string"
+				},
+				"enabled": {
+					"type": "boolean"
+				},
+				"has_api_key": {
+					"type": "boolean"
+				},
+				"has_user_api_key": {
+					"type": "boolean"
+				},
+				"icon": {
+					"type": "string"
+				},
+				"id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"type": {
+					"type": "string"
 				}
 			}
 		},
@@ -17064,24 +17015,6 @@
 				},
 				"user": {
 					"type": "string"
-				}
-			}
-		},
-		"codersdk.ChatModelsResponse": {
-			"type": "object",
-			"properties": {
-				"providers": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/codersdk.ChatModelProvider"
-					}
-				},
-				"unsupported_providers": {
-					"description": "UnsupportedProviders lists configured providers the Agents harness\ncannot use, so the UI can explain the empty state.",
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/codersdk.ChatUnsupportedProvider"
-					}
 				}
 			}
 		},
@@ -17709,7 +17642,7 @@
 				}
 			}
 		},
-		"codersdk.CreateChatModelConfigRequest": {
+		"codersdk.CreateChatModelRequest": {
 			"type": "object",
 			"properties": {
 				"ai_provider_id": {
@@ -20123,6 +20056,23 @@
 				}
 			}
 		},
+		"codersdk.MinimalChatModel": {
+			"type": "object",
+			"properties": {
+				"display_name": {
+					"type": "string"
+				},
+				"id": {
+					"type": "string"
+				},
+				"model": {
+					"type": "string"
+				},
+				"provider": {
+					"type": "string"
+				}
+			}
+		},
 		"codersdk.MinimalOrganization": {
 			"type": "object",
 			"required": ["id"],
@@ -21121,6 +21071,23 @@
 				"updated_at": {
 					"type": "string",
 					"format": "date-time"
+				}
+			}
+		},
+		"codersdk.OrganizationChatModelsResponse": {
+			"type": "object",
+			"properties": {
+				"models": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.ChatModel"
+					}
+				},
+				"providers": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.ChatModelProviderDescriptor"
+					}
 				}
 			}
 		},
@@ -24491,7 +24458,7 @@
 				}
 			}
 		},
-		"codersdk.UpdateChatModelConfigRequest": {
+		"codersdk.UpdateChatModelRequest": {
 			"type": "object",
 			"properties": {
 				"ai_provider_id": {

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1336,34 +1336,19 @@ func New(options *Options) *API {
 				r.Delete("/", api.deleteUserAIProviderKey)
 			})
 		})
-		// Org-scoped chat model config management. Configs are org-scoped;
-		// creation and org listing resolve the org from the route.
-		r.Route("/organizations/{organization}/chat-model-configs", func(r chi.Router) {
+		// Org-scoped chat model management and runtime discovery. Configs are
+		// org-scoped; creation, org listing, and the availability view resolve
+		// the org from the route.
+		r.Route("/organizations/{organization}/chats/models", func(r chi.Router) {
 			r.Use(
 				apiKeyMiddleware,
 				httpmw.ExtractOrganizationParam(options.Database),
 			)
 			r.Get("/", api.listChatModelConfigsByOrganization)
 			r.Post("/", api.createChatModelConfig)
-		})
-		// Item-level chat model config routes resolve the org from the row.
-		r.Route("/chat-model-configs", func(r chi.Router) {
-			r.Use(
-				apiKeyMiddleware,
-			)
-			r.Get("/", api.listChatModelConfigs)
-			r.Route("/{modelConfig}", func(r chi.Router) {
-				r.Get("/", api.getChatModelConfig)
-				r.Patch("/", api.updateChatModelConfig)
-				r.Delete("/", api.deleteChatModelConfig)
-			})
-		})
-		// Redacted AI provider catalog for org model admins.
-		r.Route("/ai-providers/catalog", func(r chi.Router) {
-			r.Use(
-				apiKeyMiddleware,
-			)
-			r.Get("/", api.getChatAIProviderCatalog)
+			// Runtime discovery: the provider-grouped, per-caller availability
+			// view of this organization's models.
+			r.Get("/available", api.listChatModelAvailability)
 		})
 		r.Route("/chats", func(r chi.Router) {
 			r.Use(
@@ -1372,7 +1357,16 @@ func New(options *Options) *API {
 			r.Get("/by-workspace", api.chatsByWorkspace)
 			r.Get("/", api.listChats)
 			r.Post("/", api.postChats)
-			r.Get("/models", api.listChatModels)
+			// Item-level chat model routes resolve the config and its org once
+			// at the boundary; the middleware authorizes the read. These sit
+			// beside the org-scoped runtime discovery list, which lives at
+			// /organizations/{organization}/chats/models.
+			r.Route("/models/{model}", func(r chi.Router) {
+				r.Use(httpmw.ExtractChatModelConfigParam(options.Database))
+				r.Get("/", api.getChatModelConfig)
+				r.Patch("/", api.updateChatModelConfig)
+				r.Delete("/", api.deleteChatModelConfig)
+			})
 			r.Get("/watch", api.watchChats)
 			r.Route("/cost", func(r chi.Router) {
 				r.Get("/users", api.chatCostUsers)

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1336,6 +1336,35 @@ func New(options *Options) *API {
 				r.Delete("/", api.deleteUserAIProviderKey)
 			})
 		})
+		// Org-scoped chat model config management. Configs are org-scoped;
+		// creation and org listing resolve the org from the route.
+		r.Route("/organizations/{organization}/chat-model-configs", func(r chi.Router) {
+			r.Use(
+				apiKeyMiddleware,
+				httpmw.ExtractOrganizationParam(options.Database),
+			)
+			r.Get("/", api.listChatModelConfigsByOrganization)
+			r.Post("/", api.createChatModelConfig)
+		})
+		// Item-level chat model config routes resolve the org from the row.
+		r.Route("/chat-model-configs", func(r chi.Router) {
+			r.Use(
+				apiKeyMiddleware,
+			)
+			r.Get("/", api.listChatModelConfigs)
+			r.Route("/{modelConfig}", func(r chi.Router) {
+				r.Get("/", api.getChatModelConfig)
+				r.Patch("/", api.updateChatModelConfig)
+				r.Delete("/", api.deleteChatModelConfig)
+			})
+		})
+		// Redacted AI provider catalog for org model admins.
+		r.Route("/ai-providers/catalog", func(r chi.Router) {
+			r.Use(
+				apiKeyMiddleware,
+			)
+			r.Get("/", api.getChatAIProviderCatalog)
+		})
 		r.Route("/chats", func(r chi.Router) {
 			r.Use(
 				apiKeyMiddleware,
@@ -1405,15 +1434,6 @@ func New(options *Options) *API {
 				r.Route("/{providerConfig}", func(r chi.Router) {
 					r.Patch("/", api.updateChatProvider)
 					r.Delete("/", api.deleteChatProvider)
-				})
-			})
-			// TODO(cian): place under /api/experimental/chats/config
-			r.Route("/model-configs", func(r chi.Router) {
-				r.Get("/", api.listChatModelConfigs)
-				r.Post("/", api.createChatModelConfig)
-				r.Route("/{modelConfig}", func(r chi.Router) {
-					r.Patch("/", api.updateChatModelConfig)
-					r.Delete("/", api.deleteChatModelConfig)
 				})
 			})
 			r.Route("/usage-limits", func(r chi.Router) {

--- a/coderd/coderdtest/chat.go
+++ b/coderd/coderdtest/chat.go
@@ -54,7 +54,7 @@ func CreateOpenAICompatChatModelConfig(
 	t testing.TB,
 	client *codersdk.ExperimentalClient,
 	baseURL string,
-) codersdk.ChatModelConfig {
+) codersdk.ChatModel {
 	t.Helper()
 
 	if baseURL == "" {
@@ -74,7 +74,7 @@ func CreateOpenAICompatChatModelConfig(
 	require.NoError(t, err)
 	contextLimit := int64(4096)
 	isDefault := true
-	modelConfig, err := client.CreateChatModelConfig(ctx, defaultOrg.ID, codersdk.CreateChatModelConfigRequest{
+	modelConfig, err := client.CreateChatModel(ctx, defaultOrg.ID, codersdk.CreateChatModelRequest{
 		AIProviderID: &provider.ID,
 		Model:        TestChatModelOpenAICompat,
 		ContextLimit: &contextLimit,

--- a/coderd/coderdtest/chat.go
+++ b/coderd/coderdtest/chat.go
@@ -70,9 +70,11 @@ func CreateOpenAICompatChatModelConfig(
 		APIKeys: []string{TestChatProviderAPIKey},
 	})
 	require.NoError(t, err)
+	defaultOrg, err := client.Client.OrganizationByName(ctx, codersdk.DefaultOrganization)
+	require.NoError(t, err)
 	contextLimit := int64(4096)
 	isDefault := true
-	modelConfig, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+	modelConfig, err := client.CreateChatModelConfig(ctx, defaultOrg.ID, codersdk.CreateChatModelConfigRequest{
 		AIProviderID: &provider.ID,
 		Model:        TestChatModelOpenAICompat,
 		ContextLimit: &contextLimit,

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -3491,12 +3491,26 @@ func (q *querier) GetChatModelConfigByID(ctx context.Context, id uuid.UUID) (dat
 	return fetch(q.log, q.auth, q.db.GetChatModelConfigByID)(ctx, id)
 }
 
-func (q *querier) GetChatModelConfigs(ctx context.Context) ([]database.ChatModelConfig, error) {
+func (q *querier) GetChatModelConfigs(ctx context.Context, organizationID uuid.UUID) ([]database.ChatModelConfig, error) {
 	prep, err := prepareSQLFilter(ctx, q.auth, policy.ActionRead, rbac.ResourceChatModelConfig.Type)
 	if err != nil {
 		return nil, err
 	}
-	return q.db.GetAuthorizedChatModelConfigs(ctx, prep)
+	return q.db.GetAuthorizedChatModelConfigs(ctx, organizationID, prep)
+}
+
+func (q *querier) GetChatModelConfigsByOrganization(ctx context.Context, organizationID uuid.UUID) ([]database.ChatModelConfig, error) {
+	// Consumed only by ensureDefaultChatModelConfig's default-election read
+	// inside the write transaction. Every path that reaches the election
+	// already requires update-in-org (insert/update/delete and the election's
+	// own UnsetDefaultChatModelConfigs/UpdateChatModelConfig), so the read
+	// authorizes update-in-org rather than read; a create-only principal never
+	// reaches it because create short-circuits when the inserted config is the
+	// org's first.
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceChatModelConfig.InOrg(organizationID)); err != nil {
+		return nil, err
+	}
+	return q.db.GetChatModelConfigsByOrganization(ctx, organizationID)
 }
 
 func (q *querier) GetChatModelConfigsForTelemetry(ctx context.Context) ([]database.GetChatModelConfigsForTelemetryRow, error) {
@@ -3802,13 +3816,6 @@ func (q *querier) GetEnabledChatModelConfigByID(ctx context.Context, id uuid.UUI
 		return database.ChatModelConfig{}, err
 	}
 	return q.db.GetEnabledChatModelConfigByID(ctx, id)
-}
-
-func (q *querier) GetEnabledChatModelConfigs(ctx context.Context) ([]database.GetEnabledChatModelConfigsRow, error) {
-	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceChatModelConfig); err != nil {
-		return nil, err
-	}
-	return q.db.GetEnabledChatModelConfigs(ctx)
 }
 
 func (q *querier) GetEnabledChatModelConfigsByOrganization(ctx context.Context, organizationID uuid.UUID) ([]database.GetEnabledChatModelConfigsByOrganizationRow, error) {
@@ -9432,6 +9439,6 @@ func (q *querier) GetAuthorizedChatsByChatFileID(ctx context.Context, fileID uui
 	return q.db.GetAuthorizedChatsByChatFileID(ctx, fileID, prepared)
 }
 
-func (q *querier) GetAuthorizedChatModelConfigs(ctx context.Context, prepared rbac.PreparedAuthorized) ([]database.ChatModelConfig, error) {
-	return q.db.GetAuthorizedChatModelConfigs(ctx, prepared)
+func (q *querier) GetAuthorizedChatModelConfigs(ctx context.Context, organizationID uuid.UUID, prepared rbac.PreparedAuthorized) ([]database.ChatModelConfig, error) {
+	return q.db.GetAuthorizedChatModelConfigs(ctx, organizationID, prepared)
 }

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -34,9 +34,11 @@ const wrapname = "dbauthz.querier"
 // ErrNoActor is returned if no actor is present in the context.
 var ErrNoActor = xerrors.Errorf("no authorization actor in context")
 
-// NotAuthorizedError is a sentinel error that unwraps to sql.ErrNoRows.
-// This allows the internal error to be read by the caller if needed. Otherwise
-// it will be handled as a 404.
+// NotAuthorizedError is a sentinel error wrapping the underlying RBAC denial.
+// HTTP layers map it to a 404 (via IsUnauthorized) so denials are
+// indistinguishable from missing resources, but it does NOT unwrap to
+// sql.ErrNoRows: 'errors.Is(err, sql.ErrNoRows)' is false for it, so callers
+// distinguishing "not found" from "denied" must use httpapi.Is404Error.
 type NotAuthorizedError struct {
 	Err error
 }
@@ -57,8 +59,7 @@ func (NotAuthorizedError) IsUnauthorized() bool {
 	return true
 }
 
-// Unwrap will always unwrap to a sql.ErrNoRows so the API returns a 404.
-// So 'errors.Is(err, sql.ErrNoRows)' will always be true.
+// Unwrap returns the wrapped RBAC denial, never sql.ErrNoRows.
 func (e NotAuthorizedError) Unwrap() error {
 	return e.Err
 }
@@ -797,8 +798,9 @@ var (
 					rbac.ResourceDeploymentConfig.Type: {policy.ActionRead},
 					rbac.ResourceUser.Type:             {policy.ActionReadPersonal},
 					// Org-scoped resolution paths read the default
-					// organization to apply the pre-cutover
-					// default-org fallback (removed in M3).
+					// organization for user-global settings that are
+					// still pinned to the default org (e.g. personal
+					// model override validation).
 					rbac.ResourceOrganization.Type: {policy.ActionRead},
 				}),
 				User:    []rbac.Permission{},
@@ -2182,15 +2184,7 @@ func (q *querier) DeleteChatDebugDataByChatID(ctx context.Context, arg database.
 }
 
 func (q *querier) DeleteChatModelConfigByID(ctx context.Context, id uuid.UUID) error {
-	// Interim: keep the deployment-config update check so the old write
-	// handlers admit exactly the pre-RBAC-resource set during the fallback
-	// window. The fetch-then-authorize object delete check lands with the
-	// cutover.
-	// TODO(mafredri): swap to ResourceChatModelConfig object delete after CODAGT-709 M3 (org-scoping cutover)
-	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceDeploymentConfig); err != nil {
-		return err
-	}
-	return q.db.DeleteChatModelConfigByID(ctx, id)
+	return deleteQ(q.log, q.auth, q.db.GetChatModelConfigByID, q.db.DeleteChatModelConfigByID)(ctx, id)
 }
 
 func (q *querier) DeleteChatModelConfigsByAIProviderID(ctx context.Context, aiProviderID uuid.UUID) error {
@@ -3494,15 +3488,7 @@ func (q *querier) GetChatMessagesForPromptByChatID(ctx context.Context, chatID u
 }
 
 func (q *querier) GetChatModelConfigByID(ctx context.Context, id uuid.UUID) (database.ChatModelConfig, error) {
-	// Interim: keep the deployment-config read check so the old write
-	// handlers' object reads admit exactly the pre-RBAC-resource set
-	// during the fallback window. The fetch-then-authorize object read
-	// lands with the cutover.
-	// TODO(mafredri): swap to ResourceChatModelConfig object read after CODAGT-709 M3 (org-scoping cutover)
-	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceDeploymentConfig); err != nil {
-		return database.ChatModelConfig{}, err
-	}
-	return q.db.GetChatModelConfigByID(ctx, id)
+	return fetch(q.log, q.auth, q.db.GetChatModelConfigByID)(ctx, id)
 }
 
 func (q *querier) GetChatModelConfigs(ctx context.Context) ([]database.ChatModelConfig, error) {
@@ -3776,15 +3762,7 @@ func (q *querier) GetDatabaseNow(ctx context.Context) (time.Time, error) {
 }
 
 func (q *querier) GetDefaultChatModelConfig(ctx context.Context, organizationID uuid.UUID) (database.ChatModelConfig, error) {
-	// Reading the default model config is needed for chat creation. The
-	// requesting member's context must keep resolving the default-org
-	// fallback until the org-scoping cutover, so this stays an
-	// actor-present check rather than an object read.
-	// TODO(mafredri): remove after CODAGT-709 M3 (org-scoping cutover)
-	if _, ok := ActorFromContext(ctx); !ok {
-		return database.ChatModelConfig{}, ErrNoActor
-	}
-	return q.db.GetDefaultChatModelConfig(ctx, organizationID)
+	return fetch(q.log, q.auth, q.db.GetDefaultChatModelConfig)(ctx, organizationID)
 }
 
 func (q *querier) GetDefaultOrganization(ctx context.Context) (database.Organization, error) {
@@ -6121,14 +6099,7 @@ func (q *querier) InsertChatMessages(ctx context.Context, arg database.InsertCha
 }
 
 func (q *querier) InsertChatModelConfig(ctx context.Context, arg database.InsertChatModelConfigParams) (database.ChatModelConfig, error) {
-	// Interim: keep the deployment-config update check so the old write
-	// handlers admit exactly the pre-RBAC-resource set during the fallback
-	// window. The org-scoped create-in-org check lands with the cutover.
-	// TODO(mafredri): swap to ResourceChatModelConfig create-in-org after CODAGT-709 M3 (org-scoping cutover)
-	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceDeploymentConfig); err != nil {
-		return database.ChatModelConfig{}, err
-	}
-	return q.db.InsertChatModelConfig(ctx, arg)
+	return insert(q.log, q.auth, rbac.ResourceChatModelConfig.InOrg(arg.OrganizationID), q.db.InsertChatModelConfig)(ctx, arg)
 }
 
 func (q *querier) InsertChatQueuedMessage(ctx context.Context, arg database.InsertChatQueuedMessageParams) (database.ChatQueuedMessage, error) {
@@ -7312,10 +7283,7 @@ func (q *querier) UnpinChatByID(ctx context.Context, id uuid.UUID) error {
 }
 
 func (q *querier) UnsetDefaultChatModelConfigs(ctx context.Context, organizationID uuid.UUID) error {
-	// Interim: keep the system update check so the old write handlers admit
-	// exactly the pre-RBAC-resource set during the fallback window.
-	// TODO(mafredri): swap to ResourceChatModelConfig update-in-org after CODAGT-709 M3 (org-scoping cutover)
-	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceChatModelConfig.InOrg(organizationID)); err != nil {
 		return err
 	}
 	return q.db.UnsetDefaultChatModelConfigs(ctx, organizationID)
@@ -7494,11 +7462,11 @@ func (q *querier) UpdateChatMCPServerIDs(ctx context.Context, arg database.Updat
 }
 
 func (q *querier) UpdateChatModelConfig(ctx context.Context, arg database.UpdateChatModelConfigParams) (database.ChatModelConfig, error) {
-	// Interim: keep the deployment-config update check so the old write
-	// handlers admit exactly the pre-RBAC-resource set during the fallback
-	// window. The fetch-then-authorize object check lands with the cutover.
-	// TODO(mafredri): swap to ResourceChatModelConfig object update after CODAGT-709 M3 (org-scoping cutover)
-	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceDeploymentConfig); err != nil {
+	existing, err := q.db.GetChatModelConfigByID(ctx, arg.ID)
+	if err != nil {
+		return database.ChatModelConfig{}, err
+	}
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, existing); err != nil {
 		return database.ChatModelConfig{}, err
 	}
 	return q.db.UpdateChatModelConfig(ctx, arg)
@@ -9466,18 +9434,4 @@ func (q *querier) GetAuthorizedChatsByChatFileID(ctx context.Context, fileID uui
 
 func (q *querier) GetAuthorizedChatModelConfigs(ctx context.Context, prepared rbac.PreparedAuthorized) ([]database.ChatModelConfig, error) {
 	return q.db.GetAuthorizedChatModelConfigs(ctx, prepared)
-}
-
-// GetDefaultChatModelConfigCandidates enumerates the configs that
-// ensureDefaultChatModelConfig may promote to default after a demotion or
-// deletion. It keeps the pre-RBAC-resource contract (deployment-config read,
-// unfiltered) so the old write handlers' default-election logic admits
-// exactly the pre-resource set during the fallback window. The read-side
-// management list is GetChatModelConfigs, which uses the authorized filter.
-// TODO(mafredri): remove after CODAGT-709 M3 (org-scoping cutover)
-func (q *querier) GetDefaultChatModelConfigCandidates(ctx context.Context) ([]database.ChatModelConfig, error) {
-	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceDeploymentConfig); err != nil {
-		return nil, err
-	}
-	return q.db.GetChatModelConfigs(ctx)
 }

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -1135,14 +1135,21 @@ func (s *MethodTestSuite) TestChats() {
 		check.Args(config.OrganizationID).Asserts(config, policy.ActionRead).Returns(config)
 	}))
 	s.Run("GetChatModelConfigs", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
-		dbm.EXPECT().GetAuthorizedChatModelConfigs(gomock.Any(), gomock.Any()).Return([]database.ChatModelConfig{}, nil).AnyTimes()
+		orgID := uuid.New()
+		dbm.EXPECT().GetAuthorizedChatModelConfigs(gomock.Any(), orgID, gomock.Any()).Return([]database.ChatModelConfig{}, nil).AnyTimes()
 		// No asserts here because SQLFilter.
-		check.Args().Asserts()
+		check.Args(orgID).Asserts()
+	}))
+	s.Run("GetChatModelConfigsByOrganization", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
+		orgID := uuid.New()
+		dbm.EXPECT().GetChatModelConfigsByOrganization(gomock.Any(), orgID).Return([]database.ChatModelConfig{}, nil).AnyTimes()
+		check.Args(orgID).Asserts(rbac.ResourceChatModelConfig.InOrg(orgID), policy.ActionUpdate).Returns([]database.ChatModelConfig{})
 	}))
 	s.Run("GetAuthorizedChatModelConfigs", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
-		dbm.EXPECT().GetAuthorizedChatModelConfigs(gomock.Any(), gomock.Any()).Return([]database.ChatModelConfig{}, nil).AnyTimes()
+		orgID := uuid.New()
+		dbm.EXPECT().GetAuthorizedChatModelConfigs(gomock.Any(), orgID, gomock.Any()).Return([]database.ChatModelConfig{}, nil).AnyTimes()
 		// No asserts here because callers provide the SQL filter.
-		check.Args(emptyPreparedAuthorized{}).Asserts()
+		check.Args(orgID, emptyPreparedAuthorized{}).Asserts()
 	}))
 	s.Run("GetChats", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		params := database.GetChatsParams{}
@@ -1254,13 +1261,6 @@ func (s *MethodTestSuite) TestChats() {
 		dbm.EXPECT().GetEnabledChatModelConfigByID(gomock.Any(), config.ID).Return(config, nil).AnyTimes()
 		check.Args(config.ID).Asserts(rbac.ResourceChatModelConfig, policy.ActionRead).Returns(config)
 	}))
-	s.Run("GetEnabledChatModelConfigs", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
-		rowA := testutil.Fake(s.T(), faker, database.GetEnabledChatModelConfigsRow{})
-		rowB := testutil.Fake(s.T(), faker, database.GetEnabledChatModelConfigsRow{})
-		dbm.EXPECT().GetEnabledChatModelConfigs(gomock.Any()).Return([]database.GetEnabledChatModelConfigsRow{rowA, rowB}, nil).AnyTimes()
-		check.Args().Asserts(rbac.ResourceChatModelConfig, policy.ActionRead).Returns([]database.GetEnabledChatModelConfigsRow{rowA, rowB})
-	}))
-
 	s.Run("GetEnabledChatModelConfigsByOrganization", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		orgID := uuid.New()
 		rowA := testutil.Fake(s.T(), faker, database.GetEnabledChatModelConfigsByOrganizationRow{})

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -676,10 +676,11 @@ func (s *MethodTestSuite) TestChats() {
 		dbm.EXPECT().SoftDeleteChatMessageByID(gomock.Any(), msg.ID).Return(nil).AnyTimes()
 		check.Args(msg.ID).Asserts(chat, policy.ActionUpdate).Returns()
 	}))
-	s.Run("DeleteChatModelConfigByID", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
-		id := uuid.New()
-		dbm.EXPECT().DeleteChatModelConfigByID(gomock.Any(), id).Return(nil).AnyTimes()
-		check.Args(id).Asserts(rbac.ResourceDeploymentConfig, policy.ActionUpdate)
+	s.Run("DeleteChatModelConfigByID", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		config := testutil.Fake(s.T(), faker, database.ChatModelConfig{})
+		dbm.EXPECT().GetChatModelConfigByID(gomock.Any(), config.ID).Return(config, nil).AnyTimes()
+		dbm.EXPECT().DeleteChatModelConfigByID(gomock.Any(), config.ID).Return(nil).AnyTimes()
+		check.Args(config.ID).Asserts(config, policy.ActionDelete)
 	}))
 	s.Run("DeleteChatModelConfigsByAIProviderID", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		providerID := uuid.New()
@@ -1126,12 +1127,12 @@ func (s *MethodTestSuite) TestChats() {
 	s.Run("GetChatModelConfigByID", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		config := testutil.Fake(s.T(), faker, database.ChatModelConfig{})
 		dbm.EXPECT().GetChatModelConfigByID(gomock.Any(), config.ID).Return(config, nil).AnyTimes()
-		check.Args(config.ID).Asserts(rbac.ResourceDeploymentConfig, policy.ActionRead).Returns(config)
+		check.Args(config.ID).Asserts(config, policy.ActionRead).Returns(config)
 	}))
 	s.Run("GetDefaultChatModelConfig", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		config := testutil.Fake(s.T(), faker, database.ChatModelConfig{})
 		dbm.EXPECT().GetDefaultChatModelConfig(gomock.Any(), config.OrganizationID).Return(config, nil).AnyTimes()
-		check.Args(config.OrganizationID).Asserts().Returns(config)
+		check.Args(config.OrganizationID).Asserts(config, policy.ActionRead).Returns(config)
 	}))
 	s.Run("GetChatModelConfigs", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		dbm.EXPECT().GetAuthorizedChatModelConfigs(gomock.Any(), gomock.Any()).Return([]database.ChatModelConfig{}, nil).AnyTimes()
@@ -1143,13 +1144,6 @@ func (s *MethodTestSuite) TestChats() {
 		// No asserts here because callers provide the SQL filter.
 		check.Args(emptyPreparedAuthorized{}).Asserts()
 	}))
-	s.Run("GetDefaultChatModelConfigCandidates", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
-		configA := testutil.Fake(s.T(), faker, database.ChatModelConfig{})
-		configB := testutil.Fake(s.T(), faker, database.ChatModelConfig{})
-		dbm.EXPECT().GetChatModelConfigs(gomock.Any()).Return([]database.ChatModelConfig{configA, configB}, nil).AnyTimes()
-		check.Args().Asserts(rbac.ResourceDeploymentConfig, policy.ActionRead).Returns([]database.ChatModelConfig{configA, configB})
-	}))
-
 	s.Run("GetChats", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		params := database.GetChatsParams{}
 		dbm.EXPECT().GetAuthorizedChats(gomock.Any(), params, gomock.Any()).Return([]database.GetChatsRow{}, nil).AnyTimes()
@@ -1315,13 +1309,14 @@ func (s *MethodTestSuite) TestChats() {
 	}))
 	s.Run("InsertChatModelConfig", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		arg := database.InsertChatModelConfigParams{
-			Model:       "test-model",
-			DisplayName: "Test Model",
-			Enabled:     true,
+			Model:          "test-model",
+			DisplayName:    "Test Model",
+			Enabled:        true,
+			OrganizationID: uuid.New(),
 		}
 		config := testutil.Fake(s.T(), faker, database.ChatModelConfig{Model: arg.Model, DisplayName: arg.DisplayName, Enabled: arg.Enabled})
 		dbm.EXPECT().InsertChatModelConfig(gomock.Any(), arg).Return(config, nil).AnyTimes()
-		check.Args(arg).Asserts(rbac.ResourceDeploymentConfig, policy.ActionUpdate).Returns(config)
+		check.Args(arg).Asserts(rbac.ResourceChatModelConfig.InOrg(arg.OrganizationID), policy.ActionCreate).Returns(config)
 	}))
 
 	s.Run("PopNextQueuedMessage", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
@@ -1549,8 +1544,9 @@ func (s *MethodTestSuite) TestChats() {
 			DisplayName: "Updated Model",
 			Enabled:     true,
 		}
+		dbm.EXPECT().GetChatModelConfigByID(gomock.Any(), config.ID).Return(config, nil).AnyTimes()
 		dbm.EXPECT().UpdateChatModelConfig(gomock.Any(), arg).Return(config, nil).AnyTimes()
-		check.Args(arg).Asserts(rbac.ResourceDeploymentConfig, policy.ActionUpdate).Returns(config)
+		check.Args(arg).Asserts(config, policy.ActionUpdate).Returns(config)
 	}))
 
 	s.Run("UpdateChatPinOrder", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
@@ -1601,7 +1597,7 @@ func (s *MethodTestSuite) TestChats() {
 	s.Run("UnsetDefaultChatModelConfigs", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		orgID := uuid.New()
 		dbm.EXPECT().UnsetDefaultChatModelConfigs(gomock.Any(), orgID).Return(nil).AnyTimes()
-		check.Args(orgID).Asserts(rbac.ResourceSystem, policy.ActionUpdate)
+		check.Args(orgID).Asserts(rbac.ResourceChatModelConfig.InOrg(orgID), policy.ActionUpdate)
 	}))
 	s.Run("UpsertChatDiffStatus", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		chat := testutil.Fake(s.T(), faker, database.Chat{})

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -6856,11 +6856,3 @@ func (m queryMetricsStore) GetAuthorizedChatModelConfigs(ctx context.Context, pr
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetAuthorizedChatModelConfigs").Inc()
 	return r0, r1
 }
-
-func (m queryMetricsStore) GetDefaultChatModelConfigCandidates(ctx context.Context) ([]database.ChatModelConfig, error) {
-	start := time.Now()
-	r0, r1 := m.s.GetDefaultChatModelConfigCandidates(ctx)
-	m.queryLatencies.WithLabelValues("GetDefaultChatModelConfigCandidates").Observe(time.Since(start).Seconds())
-	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetDefaultChatModelConfigCandidates").Inc()
-	return r0, r1
-}

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -1713,11 +1713,19 @@ func (m queryMetricsStore) GetChatModelConfigByID(ctx context.Context, id uuid.U
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetChatModelConfigs(ctx context.Context) ([]database.ChatModelConfig, error) {
+func (m queryMetricsStore) GetChatModelConfigs(ctx context.Context, organizationID uuid.UUID) ([]database.ChatModelConfig, error) {
 	start := time.Now()
-	r0, r1 := m.s.GetChatModelConfigs(ctx)
+	r0, r1 := m.s.GetChatModelConfigs(ctx, organizationID)
 	m.queryLatencies.WithLabelValues("GetChatModelConfigs").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetChatModelConfigs").Inc()
+	return r0, r1
+}
+
+func (m queryMetricsStore) GetChatModelConfigsByOrganization(ctx context.Context, organizationID uuid.UUID) ([]database.ChatModelConfig, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetChatModelConfigsByOrganization(ctx, organizationID)
+	m.queryLatencies.WithLabelValues("GetChatModelConfigsByOrganization").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetChatModelConfigsByOrganization").Inc()
 	return r0, r1
 }
 
@@ -2054,14 +2062,6 @@ func (m queryMetricsStore) GetEnabledChatModelConfigByID(ctx context.Context, id
 	r0, r1 := m.s.GetEnabledChatModelConfigByID(ctx, id)
 	m.queryLatencies.WithLabelValues("GetEnabledChatModelConfigByID").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetEnabledChatModelConfigByID").Inc()
-	return r0, r1
-}
-
-func (m queryMetricsStore) GetEnabledChatModelConfigs(ctx context.Context) ([]database.GetEnabledChatModelConfigsRow, error) {
-	start := time.Now()
-	r0, r1 := m.s.GetEnabledChatModelConfigs(ctx)
-	m.queryLatencies.WithLabelValues("GetEnabledChatModelConfigs").Observe(time.Since(start).Seconds())
-	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetEnabledChatModelConfigs").Inc()
 	return r0, r1
 }
 
@@ -6849,9 +6849,9 @@ func (m queryMetricsStore) GetAuthorizedChatsByChatFileID(ctx context.Context, f
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetAuthorizedChatModelConfigs(ctx context.Context, prepared rbac.PreparedAuthorized) ([]database.ChatModelConfig, error) {
+func (m queryMetricsStore) GetAuthorizedChatModelConfigs(ctx context.Context, organizationID uuid.UUID, prepared rbac.PreparedAuthorized) ([]database.ChatModelConfig, error) {
 	start := time.Now()
-	r0, r1 := m.s.GetAuthorizedChatModelConfigs(ctx, prepared)
+	r0, r1 := m.s.GetAuthorizedChatModelConfigs(ctx, organizationID, prepared)
 	m.queryLatencies.WithLabelValues("GetAuthorizedChatModelConfigs").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetAuthorizedChatModelConfigs").Inc()
 	return r0, r1

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -3703,21 +3703,6 @@ func (mr *MockStoreMockRecorder) GetDefaultChatModelConfig(ctx, organizationID a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDefaultChatModelConfig", reflect.TypeOf((*MockStore)(nil).GetDefaultChatModelConfig), ctx, organizationID)
 }
 
-// GetDefaultChatModelConfigCandidates mocks base method.
-func (m *MockStore) GetDefaultChatModelConfigCandidates(ctx context.Context) ([]database.ChatModelConfig, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDefaultChatModelConfigCandidates", ctx)
-	ret0, _ := ret[0].([]database.ChatModelConfig)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetDefaultChatModelConfigCandidates indicates an expected call of GetDefaultChatModelConfigCandidates.
-func (mr *MockStoreMockRecorder) GetDefaultChatModelConfigCandidates(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDefaultChatModelConfigCandidates", reflect.TypeOf((*MockStore)(nil).GetDefaultChatModelConfigCandidates), ctx)
-}
-
 // GetDefaultOrganization mocks base method.
 func (m *MockStore) GetDefaultOrganization(ctx context.Context) (database.Organization, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -2429,18 +2429,18 @@ func (mr *MockStoreMockRecorder) GetAuthorizedAuditLogsOffset(ctx, arg, prepared
 }
 
 // GetAuthorizedChatModelConfigs mocks base method.
-func (m *MockStore) GetAuthorizedChatModelConfigs(ctx context.Context, prepared rbac.PreparedAuthorized) ([]database.ChatModelConfig, error) {
+func (m *MockStore) GetAuthorizedChatModelConfigs(ctx context.Context, organizationID uuid.UUID, prepared rbac.PreparedAuthorized) ([]database.ChatModelConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAuthorizedChatModelConfigs", ctx, prepared)
+	ret := m.ctrl.Call(m, "GetAuthorizedChatModelConfigs", ctx, organizationID, prepared)
 	ret0, _ := ret[0].([]database.ChatModelConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAuthorizedChatModelConfigs indicates an expected call of GetAuthorizedChatModelConfigs.
-func (mr *MockStoreMockRecorder) GetAuthorizedChatModelConfigs(ctx, prepared any) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetAuthorizedChatModelConfigs(ctx, organizationID, prepared any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthorizedChatModelConfigs", reflect.TypeOf((*MockStore)(nil).GetAuthorizedChatModelConfigs), ctx, prepared)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthorizedChatModelConfigs", reflect.TypeOf((*MockStore)(nil).GetAuthorizedChatModelConfigs), ctx, organizationID, prepared)
 }
 
 // GetAuthorizedChats mocks base method.
@@ -3179,18 +3179,33 @@ func (mr *MockStoreMockRecorder) GetChatModelConfigByID(ctx, id any) *gomock.Cal
 }
 
 // GetChatModelConfigs mocks base method.
-func (m *MockStore) GetChatModelConfigs(ctx context.Context) ([]database.ChatModelConfig, error) {
+func (m *MockStore) GetChatModelConfigs(ctx context.Context, organizationID uuid.UUID) ([]database.ChatModelConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetChatModelConfigs", ctx)
+	ret := m.ctrl.Call(m, "GetChatModelConfigs", ctx, organizationID)
 	ret0, _ := ret[0].([]database.ChatModelConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetChatModelConfigs indicates an expected call of GetChatModelConfigs.
-func (mr *MockStoreMockRecorder) GetChatModelConfigs(ctx any) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetChatModelConfigs(ctx, organizationID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatModelConfigs", reflect.TypeOf((*MockStore)(nil).GetChatModelConfigs), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatModelConfigs", reflect.TypeOf((*MockStore)(nil).GetChatModelConfigs), ctx, organizationID)
+}
+
+// GetChatModelConfigsByOrganization mocks base method.
+func (m *MockStore) GetChatModelConfigsByOrganization(ctx context.Context, organizationID uuid.UUID) ([]database.ChatModelConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetChatModelConfigsByOrganization", ctx, organizationID)
+	ret0, _ := ret[0].([]database.ChatModelConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetChatModelConfigsByOrganization indicates an expected call of GetChatModelConfigsByOrganization.
+func (mr *MockStoreMockRecorder) GetChatModelConfigsByOrganization(ctx, organizationID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatModelConfigsByOrganization", reflect.TypeOf((*MockStore)(nil).GetChatModelConfigsByOrganization), ctx, organizationID)
 }
 
 // GetChatModelConfigsForTelemetry mocks base method.
@@ -3821,21 +3836,6 @@ func (m *MockStore) GetEnabledChatModelConfigByID(ctx context.Context, id uuid.U
 func (mr *MockStoreMockRecorder) GetEnabledChatModelConfigByID(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnabledChatModelConfigByID", reflect.TypeOf((*MockStore)(nil).GetEnabledChatModelConfigByID), ctx, id)
-}
-
-// GetEnabledChatModelConfigs mocks base method.
-func (m *MockStore) GetEnabledChatModelConfigs(ctx context.Context) ([]database.GetEnabledChatModelConfigsRow, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetEnabledChatModelConfigs", ctx)
-	ret0, _ := ret[0].([]database.GetEnabledChatModelConfigsRow)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetEnabledChatModelConfigs indicates an expected call of GetEnabledChatModelConfigs.
-func (mr *MockStoreMockRecorder) GetEnabledChatModelConfigs(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnabledChatModelConfigs", reflect.TypeOf((*MockStore)(nil).GetEnabledChatModelConfigs), ctx)
 }
 
 // GetEnabledChatModelConfigsByOrganization mocks base method.

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -2234,8 +2234,9 @@ func TestPurgeChatDebugRuns(t *testing.T) {
 			DisplayName: "OpenAI",
 		})
 		modelConfig := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-			Model:        "test-model",
-			ContextLimit: 8192,
+			Model:          "test-model",
+			ContextLimit:   8192,
+			OrganizationID: org.ID,
 		})
 		return chatDebugDeps{user: user, org: org, modelConfig: modelConfig}
 	}
@@ -2460,8 +2461,9 @@ func TestDeleteOldChatFiles(t *testing.T) {
 			DisplayName: "OpenAI",
 		})
 		mc := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-			Model:        "test-model",
-			ContextLimit: 8192,
+			Model:          "test-model",
+			ContextLimit:   8192,
+			OrganizationID: org.ID,
 		})
 		return chatDeps{user: user, org: org, modelConfig: mc}
 	}
@@ -2937,8 +2939,9 @@ func TestBackfillChatMessagesSearchTsv(t *testing.T) {
 			DisplayName: "OpenAI",
 		})
 		modelConfig := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-			Model:        "test-model",
-			ContextLimit: 8192,
+			Model:          "test-model",
+			ContextLimit:   8192,
+			OrganizationID: org.ID,
 		})
 		chat := dbgen.Chat(t, db, database.Chat{
 			OrganizationID:    org.ID,

--- a/coderd/database/migrations/000564_chat_model_config_org_explosion.down.sql
+++ b/coderd/database/migrations/000564_chat_model_config_org_explosion.down.sql
@@ -1,0 +1,113 @@
+-- DOWN for the chat model config org explosion. UNSUPPORTED and best-effort
+-- per operator ruling: there is no persisted provenance, so this down
+-- cannot distinguish a copy from an organically created non-default-org row
+-- that happens to share (ai_provider_id, model) with a default-org row. It
+-- must run green and must never lose chats; fidelity loss on pathological
+-- duplicates is accepted.
+--
+-- Copy identification: a non-default-org row is treated as a copy iff a
+-- default-org row exists with the same (ai_provider_id, model). Retarget
+-- resolves that default-org row deterministically with DISTINCT ON ordered
+-- by (created_at ASC, id ASC) so duplicates pick one stable row.
+
+-- Restore chats.last_model_config_id from copies back to the default-org
+-- original matched by (ai_provider_id, model).
+UPDATE chats c
+SET last_model_config_id = orig.id
+FROM chat_model_configs cp
+JOIN LATERAL (
+    SELECT d.id
+    FROM chat_model_configs d
+    JOIN organizations def ON def.id = d.organization_id AND def.is_default
+    WHERE d.ai_provider_id IS NOT DISTINCT FROM cp.ai_provider_id
+      AND d.model = cp.model
+    ORDER BY d.created_at ASC, d.id ASC
+    LIMIT 1
+) orig ON true
+WHERE c.last_model_config_id = cp.id
+  AND NOT EXISTS (SELECT 1 FROM organizations odef
+                  WHERE odef.id = cp.organization_id AND odef.is_default);
+
+-- Restore chat_messages.model_config_id from copies back to originals.
+UPDATE chat_messages mm
+SET model_config_id = orig.id
+FROM chat_model_configs cp
+JOIN LATERAL (
+    SELECT d.id
+    FROM chat_model_configs d
+    JOIN organizations def ON def.id = d.organization_id AND def.is_default
+    WHERE d.ai_provider_id IS NOT DISTINCT FROM cp.ai_provider_id
+      AND d.model = cp.model
+    ORDER BY d.created_at ASC, d.id ASC
+    LIMIT 1
+) orig ON true
+WHERE mm.model_config_id = cp.id
+  AND NOT EXISTS (SELECT 1 FROM organizations odef
+                  WHERE odef.id = cp.organization_id AND odef.is_default);
+
+-- Restore chat_queued_messages.model_config_id from copies back to originals.
+UPDATE chat_queued_messages q
+SET model_config_id = orig.id
+FROM chat_model_configs cp
+JOIN LATERAL (
+    SELECT d.id
+    FROM chat_model_configs d
+    JOIN organizations def ON def.id = d.organization_id AND def.is_default
+    WHERE d.ai_provider_id IS NOT DISTINCT FROM cp.ai_provider_id
+      AND d.model = cp.model
+    ORDER BY d.created_at ASC, d.id ASC
+    LIMIT 1
+) orig ON true
+WHERE q.model_config_id = cp.id
+  AND NOT EXISTS (SELECT 1 FROM organizations odef
+                  WHERE odef.id = cp.organization_id AND odef.is_default);
+
+-- Restore chat_debug_runs.model_config_id from copies back to originals.
+UPDATE chat_debug_runs d
+SET model_config_id = orig.id
+FROM chat_model_configs cp
+JOIN LATERAL (
+    SELECT d.id
+    FROM chat_model_configs d
+    JOIN organizations def ON def.id = d.organization_id AND def.is_default
+    WHERE d.ai_provider_id IS NOT DISTINCT FROM cp.ai_provider_id
+      AND d.model = cp.model
+    ORDER BY d.created_at ASC, d.id ASC
+    LIMIT 1
+) orig ON true
+WHERE d.model_config_id = cp.id
+  AND NOT EXISTS (SELECT 1 FROM organizations odef
+                  WHERE odef.id = cp.organization_id AND odef.is_default);
+
+-- Delete copied chat_model_configs (non-default-org rows whose
+-- (ai_provider_id, model) matches a default-org row). References were
+-- retargeted above, so the deletes cannot violate the chats/chat_messages
+-- FKs.
+DELETE FROM chat_model_configs cp
+WHERE EXISTS (
+    SELECT 1 FROM chat_model_configs orig
+    JOIN organizations def ON def.id = orig.organization_id AND def.is_default
+    WHERE orig.ai_provider_id IS NOT DISTINCT FROM cp.ai_provider_id
+      AND orig.model = cp.model
+)
+AND NOT EXISTS (
+    SELECT 1 FROM organizations odef
+    WHERE odef.id = cp.organization_id AND odef.is_default
+);
+
+-- Best-effort threshold-key cleanup: delete compaction-threshold keys whose
+-- embedded config id no longer exists anywhere after the copy deletes.
+-- Original keys survive because default-org originals always survive.
+-- Keys with a malformed or empty suffix are guarded BEFORE the uuid cast
+-- (they cannot name an existing config, so they are pruned like any other
+-- dangling key) instead of aborting the down.
+DELETE FROM user_configs uc
+WHERE uc.key LIKE 'chat_compaction_threshold_pct:%'
+  AND NOT EXISTS (
+      SELECT 1 FROM chat_model_configs cmc
+      WHERE cmc.id = (
+        SELECT substring(uc.key FROM 'chat_compaction_threshold_pct:(.*)')::uuid
+        WHERE substring(uc.key FROM 'chat_compaction_threshold_pct:(.*)')
+              ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+      )
+  );

--- a/coderd/database/migrations/000564_chat_model_config_org_explosion.up.sql
+++ b/coderd/database/migrations/000564_chat_model_config_org_explosion.up.sql
@@ -1,0 +1,217 @@
+-- Explode default-org chat model configs to every live non-default
+-- organization (CODAGT-709, stage 3 of 3: org-scoping cutover). After this
+-- migration every live org owns a full set of model configs and all
+-- references inside live non-default orgs point at same-org rows.
+--
+-- Mapping design (operator ruling): NO provenance column, NO persisted
+-- mapping of any kind. A transaction-scoped TEMPORARY lookup table
+-- (orig_id, org_id, copy_id) ON COMMIT DROP maps each default-org original
+-- to its per-org copy; the copy insert, all four reference remaps, and the
+-- compaction-threshold fan-out join it. The table vanishes when the
+-- migration framework commits this migration's transaction, so nothing
+-- mapping-related persists. Copy ids come from gen_random_uuid(); no
+-- hash-derived ids (md5() errors on FIPS-mode PostgreSQL builds).
+
+CREATE TEMPORARY TABLE model_config_copy_map (
+    orig_id uuid NOT NULL,
+    org_id uuid NOT NULL,
+    copy_id uuid NOT NULL,
+    PRIMARY KEY (orig_id, org_id)
+) ON COMMIT DROP;
+
+-- (a) Stage LIVE default-org chat_model_configs x every live non-default org
+-- in the temp map with a fresh copy id, then insert the copies. Staging the
+-- id in the map first lets the remap statements below resolve copies without
+-- recomputing anything.
+INSERT INTO model_config_copy_map (orig_id, org_id, copy_id)
+SELECT cmc.id, o.id, gen_random_uuid()
+FROM chat_model_configs cmc
+JOIN organizations def ON def.id = cmc.organization_id AND def.is_default
+CROSS JOIN organizations o
+WHERE NOT o.is_default AND NOT o.deleted
+  AND NOT cmc.deleted;
+
+-- Copies inherit every behavioral field from the original, including
+-- created_at/updated_at and created_by/updated_by: a copy is the same
+-- logical config re-homed, and the audit-facing identity of who configured
+-- it survives the explosion. group_acl is re-keyed to the copy's org (the
+-- Everyone group of an organization always has the organization's own ID,
+-- see 000058) carrying the original's entry verbatim, so members of the
+-- target org keep read access through the everyone entry.
+INSERT INTO chat_model_configs
+    (id, model, display_name, created_by, updated_by, enabled, is_default,
+     deleted, deleted_at, created_at, updated_at, context_limit,
+     compression_threshold, options, ai_provider_id, organization_id,
+     group_acl, user_acl)
+SELECT
+    m.copy_id,
+    cmc.model, cmc.display_name, cmc.created_by, cmc.updated_by, cmc.enabled,
+    cmc.is_default, cmc.deleted, cmc.deleted_at, cmc.created_at,
+    cmc.updated_at, cmc.context_limit, cmc.compression_threshold, cmc.options,
+    cmc.ai_provider_id, m.org_id,
+    jsonb_build_object(
+        m.org_id::text,
+        COALESCE(cmc.group_acl -> cmc.organization_id::text,
+                 '{"permissions": ["read"]}'::jsonb)
+    ),
+    '{}'::jsonb
+FROM model_config_copy_map m
+JOIN chat_model_configs cmc ON cmc.id = m.orig_id
+WHERE NOT cmc.deleted;
+
+-- (a2) Stage + copy SOFT-DELETED default-org chat_model_configs ONLY to live
+-- non-default orgs that actually reference them. A reference is any of:
+--   chats.last_model_config_id, chat_messages.model_config_id (via chat),
+--   chat_queued_messages.model_config_id (via chat), or
+--   chat_debug_runs.model_config_id (via chat) pointing at the deleted config.
+-- Copies keep deleted/deleted_at so every historical reference has an
+-- FK-valid, attribution-preserving target without resurrecting the config.
+INSERT INTO model_config_copy_map (orig_id, org_id, copy_id)
+SELECT DISTINCT ON (cmc.id, o.id) cmc.id, o.id, gen_random_uuid()
+FROM chat_model_configs cmc
+JOIN organizations def ON def.id = cmc.organization_id AND def.is_default
+JOIN organizations o ON NOT o.is_default AND NOT o.deleted
+WHERE cmc.deleted
+  AND (
+    EXISTS (SELECT 1 FROM chats c
+            WHERE c.last_model_config_id = cmc.id AND c.organization_id = o.id)
+    OR
+    EXISTS (SELECT 1 FROM chat_messages mm
+            JOIN chats c ON c.id = mm.chat_id
+            WHERE mm.model_config_id = cmc.id AND c.organization_id = o.id)
+    OR
+    EXISTS (SELECT 1 FROM chat_queued_messages q
+            JOIN chats c ON c.id = q.chat_id
+            WHERE q.model_config_id = cmc.id AND c.organization_id = o.id)
+    OR
+    EXISTS (SELECT 1 FROM chat_debug_runs d
+            JOIN chats c ON c.id = d.chat_id
+            WHERE d.model_config_id = cmc.id AND c.organization_id = o.id)
+  );
+
+INSERT INTO chat_model_configs
+    (id, model, display_name, created_by, updated_by, enabled, is_default,
+     deleted, deleted_at, created_at, updated_at, context_limit,
+     compression_threshold, options, ai_provider_id, organization_id,
+     group_acl, user_acl)
+SELECT
+    m.copy_id,
+    cmc.model, cmc.display_name, cmc.created_by, cmc.updated_by, cmc.enabled,
+    cmc.is_default, cmc.deleted, cmc.deleted_at, cmc.created_at,
+    cmc.updated_at, cmc.context_limit, cmc.compression_threshold, cmc.options,
+    cmc.ai_provider_id, m.org_id,
+    jsonb_build_object(
+        m.org_id::text,
+        COALESCE(cmc.group_acl -> cmc.organization_id::text,
+                 '{"permissions": ["read"]}'::jsonb)
+    ),
+    '{}'::jsonb
+FROM model_config_copy_map m
+JOIN chat_model_configs cmc ON cmc.id = m.orig_id
+WHERE cmc.deleted;
+
+-- (b) Remap chats.last_model_config_id in live non-default orgs to the
+-- same-org copy via the temp map. Soft-deleted orgs are excluded: their
+-- chats keep original references (FK-valid, unreachable). The NOT EXISTS
+-- live-original guard skips references to a config that has only a deleted
+-- copy in the org while its live fan-out copy does not exist (the live
+-- fan-out is total, so this can only happen when the original is soft-
+-- deleted in this org's history but live in the default org); without it
+-- the reference would remap to the deleted copy, silently turning an
+-- active model into a deleted one.
+UPDATE chats c
+SET last_model_config_id = m.copy_id
+FROM model_config_copy_map m
+JOIN chat_model_configs orig ON orig.id = m.orig_id
+WHERE c.last_model_config_id = m.orig_id
+  AND m.org_id = c.organization_id
+  AND NOT EXISTS (SELECT 1 FROM organizations corg
+                  WHERE corg.id = c.organization_id AND corg.deleted)
+  AND NOT EXISTS (SELECT 1 FROM model_config_copy_map d
+                  JOIN chat_model_configs dcp ON dcp.id = d.copy_id AND dcp.deleted
+                  WHERE d.orig_id = m.orig_id
+                    AND d.org_id = c.organization_id
+                    AND NOT orig.deleted);
+
+-- (b2) Remap chat_messages.model_config_id via the owning chat's org (live only).
+UPDATE chat_messages mm
+SET model_config_id = m.copy_id
+FROM chats c, model_config_copy_map m
+JOIN chat_model_configs orig ON orig.id = m.orig_id
+WHERE c.id = mm.chat_id
+  AND mm.model_config_id = m.orig_id
+  AND m.org_id = c.organization_id
+  AND NOT EXISTS (SELECT 1 FROM organizations corg
+                  WHERE corg.id = c.organization_id AND corg.deleted)
+  AND NOT EXISTS (SELECT 1 FROM model_config_copy_map d
+                  JOIN chat_model_configs dcp ON dcp.id = d.copy_id AND dcp.deleted
+                  WHERE d.orig_id = m.orig_id
+                    AND d.org_id = c.organization_id
+                    AND NOT orig.deleted);
+
+-- (b3) Remap chat_queued_messages.model_config_id via the owning chat's org
+-- (live only). The column has no FK, so dangling ids would not fail; the
+-- remap keeps a queued message's promoted model inside its chat's org.
+UPDATE chat_queued_messages q
+SET model_config_id = m.copy_id
+FROM chats c, model_config_copy_map m
+JOIN chat_model_configs orig ON orig.id = m.orig_id
+WHERE c.id = q.chat_id
+  AND q.model_config_id = m.orig_id
+  AND m.org_id = c.organization_id
+  AND NOT EXISTS (SELECT 1 FROM organizations corg
+                  WHERE corg.id = c.organization_id AND corg.deleted)
+  AND NOT EXISTS (SELECT 1 FROM model_config_copy_map d
+                  JOIN chat_model_configs dcp ON dcp.id = d.copy_id AND dcp.deleted
+                  WHERE d.orig_id = m.orig_id
+                    AND d.org_id = c.organization_id
+                    AND NOT orig.deleted);
+
+-- (b4) Remap chat_debug_runs.model_config_id via the owning chat's org
+-- (live only). Also FK-less; attribution-only, remapped for consistency.
+UPDATE chat_debug_runs d
+SET model_config_id = m.copy_id
+FROM chats c, model_config_copy_map m
+JOIN chat_model_configs orig ON orig.id = m.orig_id
+WHERE c.id = d.chat_id
+  AND d.model_config_id = m.orig_id
+  AND m.org_id = c.organization_id
+  AND NOT EXISTS (SELECT 1 FROM organizations corg
+                  WHERE corg.id = c.organization_id AND corg.deleted)
+  AND NOT EXISTS (SELECT 1 FROM model_config_copy_map dx
+                  JOIN chat_model_configs dcp ON dcp.id = dx.copy_id AND dcp.deleted
+                  WHERE dx.orig_id = m.orig_id
+                    AND dx.org_id = c.organization_id
+                    AND NOT orig.deleted);
+
+-- (c) Fan out user_configs compaction-threshold keys. A key
+-- 'chat_compaction_threshold_pct:<orig-id>' earns one row per copy of that
+-- original in the temp map, same user, same value, key rewritten to the
+-- copy id. The fan-out is copy-precise by construction (it can only
+-- produce keys for copies that exist): live originals reach every live
+-- org, soft-deleted originals reach only the orgs that received a
+-- referenced copy, and an original with zero map rows (deleted and
+-- unreferenced) produces nothing. Original keys stay: they reference
+-- default-org originals, still valid. The fan-out is deliberately NOT
+-- membership-filtered: chats pinned to deleted models are the norm, and a
+-- threshold must keep resolving for any chat that lands on a copy. The PK
+-- (user_id, key) cannot collide because copy ids are fresh and no existing
+-- key embeds a copy id; ON CONFLICT DO NOTHING is belt-and-braces only.
+INSERT INTO user_configs (user_id, key, value)
+SELECT uc.user_id, 'chat_compaction_threshold_pct:' || m.copy_id::text, uc.value
+FROM user_configs uc
+JOIN model_config_copy_map m
+  ON uc.key = 'chat_compaction_threshold_pct:' || m.orig_id::text
+ON CONFLICT (user_id, key) DO NOTHING;
+
+-- (d) Seed the everyone-in-org read entry on any existing row whose
+-- group_acl lacks its own org's key. 000562 seeded every row that existed
+-- then; this covers rows created between 000562 and this migration (the
+-- pre-cutover handlers did not seed it). The entry's permissions are
+-- preserved when an entry already exists for another org's key shape.
+UPDATE chat_model_configs
+SET group_acl = jsonb_build_object(
+    organization_id::text,
+    jsonb_build_object('permissions', jsonb_build_array('read'::text))
+) || group_acl
+WHERE NOT (group_acl ? organization_id::text);

--- a/coderd/database/migrations/migrate.go
+++ b/coderd/database/migrations/migrate.go
@@ -23,6 +23,14 @@ import (
 //go:embed *.sql
 var migrations embed.FS
 
+// MigrationFS exposes the embedded migration files, for tests that need to
+// execute a single migration's SQL outside the migrate driver (the driver's
+// transaction commits only when a stepper exhausts, which mid-test
+// down-then-up cycles cannot wait for).
+func MigrationFS() fs.FS {
+	return migrations
+}
+
 var (
 	migrationsHash     string
 	migrationsHashOnce sync.Once

--- a/coderd/database/migrations/migrate_test.go
+++ b/coderd/database/migrations/migrate_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
@@ -2589,4 +2590,463 @@ func mustJSON(t *testing.T, v any) []byte {
 	raw, err := json.Marshal(v)
 	require.NoError(t, err)
 	return raw
+}
+
+func TestMigration000564ChatModelConfigOrgExplosion(t *testing.T) {
+	t.Parallel()
+
+	const migrationVersion = 564
+
+	sqlDB := testSQLDB(t)
+
+	// stepperUpToLatest runs the stepper to completion: a Stepper cannot
+	// stop early, it closes only when the steps are exhausted, and each
+	// call commits the driver's transaction. The assertion only requires
+	// that target was APPLIED, not that it is the latest: a stacked PR may
+	// add a later migration, so encoding "target is latest" would redden
+	// any such child on its merge ref.
+	stepperUpToLatest := func(target uint) {
+		t.Helper()
+		next, err := migrations.Stepper(sqlDB)
+		require.NoError(t, err)
+		last := uint(0)
+		for {
+			version, more, err := next()
+			require.NoError(t, err)
+			if !more {
+				break
+			}
+			last = version
+		}
+		require.GreaterOrEqual(t, last, target, "migration %d must be applied", target)
+	}
+
+	// Migrate fully up first. The Stepper cannot stop at an intermediate
+	// version (it runs to completion and each run is one transaction), so
+	// fixtures are seeded post-schema and the explosion is exercised as
+	// DOWN (restore pre-explosion state) then UP (re-explode from it).
+	stepperUpToLatest(migrationVersion)
+
+	ctx := testutil.Context(t, testutil.WaitSuperLong)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	providerID := uuid.New()
+	user1ID := uuid.New()
+	user2ID := uuid.New()
+	orgBID := uuid.New() // live org with chats
+	orgCID := uuid.New() // live zero-member org: receives the full live set
+	orgDID := uuid.New() // soft-deleted org: receives nothing, chats untouched
+	c1ID := uuid.New()   // live default config
+	c2ID := uuid.New()   // live plain config
+	c3ID := uuid.New()   // soft-deleted, referenced in orgB only
+	c4ID := uuid.New()   // soft-deleted, unreferenced: never copied
+	c5ID := uuid.New()   // live plain config
+	// aclLateConfigID simulates a config created between 000562 and 000564 by
+	// the pre-cutover handlers, which did not seed the everyone ACL entry.
+	aclLateConfigID := uuid.New()
+	chatBID := uuid.New()  // chat in orgB pinned to live c1
+	chatB3ID := uuid.New() // chat in orgB pinned to deleted c3
+	chatDID := uuid.New()  // chat in soft-deleted orgD pinned to live c1
+
+	execFixture := func(query string, args ...any) {
+		t.Helper()
+		_, err := sqlDB.ExecContext(ctx, query, args...)
+		require.NoError(t, err)
+	}
+
+	for i, id := range []uuid.UUID{user1ID, user2ID} {
+		execFixture(
+			`INSERT INTO users (id, username, email, hashed_password, created_at, updated_at, status, rbac_roles, login_type)
+			VALUES ($1, $2, $3, $4, $5, $6, 'active', '{}', 'password')`,
+			id, fmt.Sprintf("m3user%d", i+1), fmt.Sprintf("m3user%d@coder.com", i+1), []byte{}, now, now,
+		)
+	}
+
+	execFixture(
+		`INSERT INTO ai_providers (id, type, name, enabled, base_url, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+		providerID, "openai", "openai-564", true, "https://api.openai.com/v1", now, now,
+	)
+
+	// Three non-default orgs: live B, live zero-member C, soft-deleted D.
+	for _, o := range []struct {
+		id      uuid.UUID
+		name    string
+		deleted bool
+	}{
+		{orgBID, "org-b-564", false},
+		{orgCID, "org-c-564", false},
+		{orgDID, "org-d-564", true},
+	} {
+		execFixture(
+			`INSERT INTO organizations (id, name, description, display_name, default_org_member_roles, created_at, updated_at, deleted)
+			VALUES ($1, $2, '', '', '{}', $3, $3, $4)`,
+			o.id, o.name, now, o.deleted,
+		)
+	}
+
+	var defaultOrgID uuid.UUID
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		"SELECT id FROM organizations WHERE is_default = true").Scan(&defaultOrgID))
+
+	// Model configs in the default org (pre-564 state: every config lives
+	// there, backfilled by 000562 with the everyone ACL entry).
+	insertConfig := func(id uuid.UUID, model string, isDefault, deleted bool, acl string) {
+		t.Helper()
+		execFixture(
+			`INSERT INTO chat_model_configs (id, model, display_name, enabled, is_default, deleted, deleted_at,
+				context_limit, compression_threshold, ai_provider_id, organization_id, group_acl, created_at, updated_at)
+			VALUES ($1, $2, $3, true, $4, $5, (CASE WHEN $5 THEN $6::timestamptz ELSE NULL END),
+				200000, 70, $7, $8, $9::jsonb, $6, $6)`,
+			id, model, model+" display", isDefault, deleted, now, providerID, defaultOrgID, acl,
+		)
+	}
+	everyoneACL := `{"` + defaultOrgID.String() + `": {"permissions": ["read"]}}`
+	insertConfig(c1ID, "gpt-5.2", true, false, everyoneACL)
+	insertConfig(c2ID, "gpt-5.2-mini", false, false, everyoneACL)
+	insertConfig(c3ID, "gpt-4-legacy", false, true, everyoneACL)
+	insertConfig(c4ID, "gpt-4-ancient", false, true, everyoneACL)
+	insertConfig(c5ID, "gpt-5.2-nano", false, false, everyoneACL)
+	insertConfig(aclLateConfigID, "gpt-5.2-late", false, false, `{}`)
+
+	// Chats: orgB pinned to live c1, orgB second chat pinned to deleted c3,
+	// soft-deleted orgD pinned to live c1.
+	for _, ch := range []struct {
+		id      uuid.UUID
+		orgID   uuid.UUID
+		ownerID uuid.UUID
+		cfgID   uuid.UUID
+	}{
+		{chatBID, orgBID, user1ID, c1ID},
+		{chatB3ID, orgBID, user2ID, c3ID},
+		{chatDID, orgDID, user1ID, c1ID},
+	} {
+		execFixture(
+			`INSERT INTO chats (id, owner_id, organization_id, last_model_config_id, created_at, updated_at)
+			VALUES ($1, $2, $3, $4, $5, $5)`,
+			ch.id, ch.ownerID, ch.orgID, ch.cfgID, now,
+		)
+	}
+
+	// Messages in each chat referencing the chat's pinned config.
+	for _, m := range []struct {
+		chatID uuid.UUID
+		cfgID  uuid.UUID
+	}{
+		{chatBID, c1ID},
+		{chatB3ID, c3ID},
+		{chatDID, c1ID},
+	} {
+		execFixture(
+			`INSERT INTO chat_messages (chat_id, model_config_id, role, content, content_version)
+			VALUES ($1, $2, 'user', '[]'::jsonb, 2)`,
+			m.chatID, m.cfgID,
+		)
+	}
+
+	// Queued messages (FK-less) referencing configs via their chat's org.
+	execFixture(
+		`INSERT INTO chat_queued_messages (chat_id, model_config_id, content, created_by)
+		VALUES ($1, $2, '[]'::jsonb, $3)`,
+		chatBID, c1ID, user1ID,
+	)
+	execFixture(
+		`INSERT INTO chat_queued_messages (chat_id, model_config_id, content, created_by)
+		VALUES ($1, $2, '[]'::jsonb, $3)`,
+		chatDID, c1ID, user1ID,
+	)
+
+	// Debug runs (FK-less, attribution).
+	execFixture(
+		`INSERT INTO chat_debug_runs (id, chat_id, model_config_id, kind, status)
+		VALUES ($1, $2, $3, 'turn', 'finished')`,
+		uuid.New(), chatBID, c1ID,
+	)
+	execFixture(
+		`INSERT INTO chat_debug_runs (id, chat_id, model_config_id, kind, status)
+		VALUES ($1, $2, $3, 'turn', 'finished')`,
+		uuid.New(), chatDID, c1ID,
+	)
+
+	// Compaction-threshold keys: c1 (live, users 1+2), c3 (deleted but
+	// referenced in orgB, user 1), c4 (deleted unreferenced, user 1: must
+	// never fan out), plus a non-threshold key that must stay untouched.
+	thresholdKey := func(id uuid.UUID) string {
+		return "chat_compaction_threshold_pct:" + id.String()
+	}
+	for _, tc := range []struct {
+		userID uuid.UUID
+		key    string
+		value  string
+	}{
+		{user1ID, thresholdKey(c1ID), "80"},
+		{user2ID, thresholdKey(c1ID), "75"},
+		{user1ID, thresholdKey(c3ID), "60"},
+		{user1ID, thresholdKey(c4ID), "55"},
+		// Hostile keys: a malformed and an empty suffix. The up leaves
+		// them alone; the down must not abort on their uuid cast.
+		{user1ID, "chat_compaction_threshold_pct:not-a-uuid", "50"},
+		{user1ID, "chat_compaction_threshold_pct:", "45"},
+		{user1ID, "chat_personal_model_override:root", "chat_default"},
+	} {
+		execFixture(
+			`INSERT INTO user_configs (user_id, key, value) VALUES ($1, $2, $3)`,
+			tc.userID, tc.key, tc.value,
+		)
+	}
+
+	// The fixtures were seeded post-schema in pre-explosion shape
+	// (default-org configs, references pointing at originals). The Stepper
+	// cannot stop mid-way, so the explosion of the seeded data is driven by
+	// rewinding the version row to the predecessor and stepping to latest:
+	// only 564's up re-applies.
+	_, err := sqlDB.ExecContext(ctx,
+		"TRUNCATE schema_migrations; INSERT INTO schema_migrations (version, dirty) VALUES (563, false)")
+	require.NoError(t, err)
+	stepperUpToLatest(migrationVersion)
+
+	// copyID resolves the copy of orig in org by natural attributes (the
+	// migration persists no mapping; this is also what the down relies on).
+	copyID := func(origID, orgID uuid.UUID) (uuid.UUID, bool) {
+		t.Helper()
+		var id uuid.UUID
+		err := sqlDB.QueryRowContext(ctx,
+			`SELECT cp.id FROM chat_model_configs cp
+			JOIN chat_model_configs orig ON orig.id = $1
+			WHERE cp.organization_id = $2
+			  AND cp.model = orig.model
+			  AND cp.ai_provider_id IS NOT DISTINCT FROM orig.ai_provider_id
+			  AND cp.id <> orig.id`, origID, orgID).Scan(&id)
+		if err == sql.ErrNoRows {
+			return uuid.Nil, false
+		}
+		require.NoError(t, err)
+		return id, true
+	}
+
+	// --- Per-org row counts ---
+	// Default org keeps its 6 originals; orgB gets 4 live copies (c1, c2,
+	// c5, late) plus the referenced-deleted c3 copy; orgC (zero-member) gets
+	// the full live set (4) and nothing deleted; orgD gets nothing.
+	assertCount := func(orgID uuid.UUID, want int, msg string) {
+		t.Helper()
+		var got int
+		require.NoError(t, sqlDB.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM chat_model_configs WHERE organization_id = $1", orgID).Scan(&got))
+		require.Equal(t, want, got, msg)
+	}
+	assertCount(defaultOrgID, 6, "default org keeps only its originals")
+	assertCount(orgBID, 5, "orgB: 4 live fan-out + referenced-deleted c3")
+	assertCount(orgCID, 4, "orgC: full live set, no deleted copies")
+	assertCount(orgDID, 0, "soft-deleted org receives no copies")
+
+	// The deleted copy preserves deleted/deleted_at.
+	c3CopyB, ok := copyID(c3ID, orgBID)
+	require.True(t, ok, "orgB received the referenced-deleted c3 copy")
+	var deletedAtNull bool
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		"SELECT deleted_at IS NULL FROM chat_model_configs WHERE id = $1", c3CopyB).Scan(&deletedAtNull))
+	require.False(t, deletedAtNull, "deleted copy preserves deleted_at")
+
+	// c4 is copied nowhere.
+	for _, orgID := range []uuid.UUID{orgBID, orgCID, orgDID} {
+		_, ok := copyID(c4ID, orgID)
+		require.False(t, ok, "unreferenced deleted c4 must not be copied")
+	}
+
+	// --- Exactly one live default per org that received copies ---
+	for _, orgID := range []uuid.UUID{defaultOrgID, orgBID, orgCID} {
+		var defaults int
+		require.NoError(t, sqlDB.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM chat_model_configs WHERE organization_id = $1 AND is_default AND NOT deleted", orgID).Scan(&defaults))
+		require.Equal(t, 1, defaults, "exactly one live default per org")
+	}
+
+	// --- Remaps ---
+	// Chats in live orgB remap to same-org copies; the chat in soft-deleted
+	// orgD keeps the original reference.
+	c1CopyB, ok := copyID(c1ID, orgBID)
+	require.True(t, ok)
+	assertChatPinned := func(chatID, want uuid.UUID, msg string) {
+		t.Helper()
+		var got uuid.UUID
+		require.NoError(t, sqlDB.QueryRowContext(ctx,
+			"SELECT last_model_config_id FROM chats WHERE id = $1", chatID).Scan(&got))
+		require.Equal(t, want, got, msg)
+	}
+	assertChatPinned(chatBID, c1CopyB, "orgB chat remapped to same-org live copy")
+	assertChatPinned(chatB3ID, c3CopyB, "orgB chat on deleted model remapped to the deleted copy")
+	assertChatPinned(chatDID, c1ID, "soft-deleted org chat keeps original reference")
+
+	var msgCfg uuid.UUID
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		"SELECT model_config_id FROM chat_messages WHERE chat_id = $1", chatBID).Scan(&msgCfg))
+	require.Equal(t, c1CopyB, msgCfg, "orgB message remapped")
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		"SELECT model_config_id FROM chat_messages WHERE chat_id = $1", chatB3ID).Scan(&msgCfg))
+	require.Equal(t, c3CopyB, msgCfg, "orgB deleted-model message remapped")
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		"SELECT model_config_id FROM chat_messages WHERE chat_id = $1", chatDID).Scan(&msgCfg))
+	require.Equal(t, c1ID, msgCfg, "orgD message untouched")
+
+	// Queued messages (FK-less): orgB remapped, orgD untouched.
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		"SELECT model_config_id FROM chat_queued_messages WHERE chat_id = $1", chatBID).Scan(&msgCfg))
+	require.Equal(t, c1CopyB, msgCfg, "orgB queued message remapped")
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		"SELECT model_config_id FROM chat_queued_messages WHERE chat_id = $1", chatDID).Scan(&msgCfg))
+	require.Equal(t, c1ID, msgCfg, "orgD queued message untouched")
+
+	// Debug runs (FK-less): orgB remapped, orgD untouched.
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		"SELECT model_config_id FROM chat_debug_runs WHERE chat_id = $1", chatBID).Scan(&msgCfg))
+	require.Equal(t, c1CopyB, msgCfg, "orgB debug run remapped")
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		"SELECT model_config_id FROM chat_debug_runs WHERE chat_id = $1", chatDID).Scan(&msgCfg))
+	require.Equal(t, c1ID, msgCfg, "orgD debug run untouched")
+
+	// No reference in a live non-default org still points at a default-org
+	// config.
+	var dangling int
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM chats c
+		JOIN chat_model_configs cmc ON cmc.id = c.last_model_config_id
+		JOIN organizations def ON def.id = cmc.organization_id AND def.is_default
+		JOIN organizations co ON co.id = c.organization_id
+		WHERE NOT co.is_default AND NOT co.deleted`).Scan(&dangling))
+	require.Zero(t, dangling, "no live-org chat references a default-org config")
+
+	// --- ACL re-key and backfill ---
+	// Copies carry the everyone entry keyed by their own org.
+	for _, orgID := range []uuid.UUID{orgBID, orgCID} {
+		var missingACL int
+		require.NoError(t, sqlDB.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM chat_model_configs
+			WHERE organization_id = $1 AND NOT (group_acl ? $2)`,
+			orgID, orgID.String()).Scan(&missingACL))
+		require.Zero(t, missingACL, "every copy carries the everyone entry keyed by its org")
+	}
+	// Copies never carry the default org's ACL key.
+	var leakedACL int
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM chat_model_configs
+		WHERE organization_id <> $1 AND (group_acl ? $2)`,
+		defaultOrgID, defaultOrgID.String()).Scan(&leakedACL))
+	require.Zero(t, leakedACL, "copies must not inherit the default org's ACL key")
+	// The pre-existing row with an empty group_acl was backfilled.
+	var aclRaw []byte
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		"SELECT group_acl FROM chat_model_configs WHERE id = $1", aclLateConfigID).Scan(&aclRaw))
+	require.JSONEq(t, string(mustJSON(t, map[string]any{
+		defaultOrgID.String(): map[string]any{"permissions": []string{"read"}},
+	})), string(aclRaw), "row missing the everyone entry is backfilled")
+
+	// --- Threshold fan-out ---
+	// c1 keys fanned out to the orgB and orgC copies for both users (follows
+	// copies, not membership); the c3 key fanned out to the orgB copy only;
+	// c4 produced nothing.
+	c1CopyC, ok := copyID(c1ID, orgCID)
+	require.True(t, ok)
+	for _, tc := range []struct {
+		userID uuid.UUID
+		cfgID  uuid.UUID
+	}{
+		{user1ID, c1CopyB},
+		{user1ID, c1CopyC},
+		{user2ID, c1CopyB},
+		{user2ID, c1CopyC},
+		{user1ID, c3CopyB},
+	} {
+		var exists bool
+		require.NoError(t, sqlDB.QueryRowContext(ctx,
+			"SELECT EXISTS(SELECT 1 FROM user_configs WHERE user_id = $1 AND key = $2)",
+			tc.userID, thresholdKey(tc.cfgID)).Scan(&exists))
+		require.True(t, exists, "threshold key fanned out to copy %s for user %s", tc.cfgID, tc.userID)
+	}
+	// c3 produced no orgC key (its only copy is in orgB).
+	var c3CCount int
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM user_configs uc
+		JOIN chat_model_configs cp ON cp.id = substring(uc.key FROM 'chat_compaction_threshold_pct:(.*)')::uuid
+		WHERE uc.key LIKE 'chat_compaction_threshold_pct:%'
+		  AND substring(uc.key FROM 'chat_compaction_threshold_pct:(.*)') ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+		  AND cp.organization_id = $1 AND cp.model = 'gpt-4-legacy'`,
+		orgCID).Scan(&c3CCount))
+	require.Zero(t, c3CCount, "deleted config with no orgC copy produces no orgC key")
+	// c4 (deleted, unreferenced): the only ancient-model threshold key is the
+	// seeded original.
+	var c4Keys []string
+	rows, err := sqlDB.QueryContext(ctx,
+		`SELECT key FROM user_configs WHERE key LIKE 'chat_compaction_threshold_pct:%'
+		AND substring(key FROM 'chat_compaction_threshold_pct:(.*)') ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+		AND substring(key FROM 'chat_compaction_threshold_pct:(.*)')::uuid = $1`, c4ID)
+	require.NoError(t, err)
+	for rows.Next() {
+		var k string
+		require.NoError(t, rows.Scan(&k))
+		c4Keys = append(c4Keys, k)
+	}
+	require.NoError(t, rows.Err())
+	require.NoError(t, rows.Close())
+	require.Equal(t, []string{thresholdKey(c4ID)}, c4Keys, "unreferenced deleted c4 fans out zero keys")
+	// Seeded original keys survive; the non-threshold key is untouched.
+	for _, key := range []string{thresholdKey(c1ID), thresholdKey(c3ID)} {
+		var exists bool
+		require.NoError(t, sqlDB.QueryRowContext(ctx,
+			"SELECT EXISTS(SELECT 1 FROM user_configs WHERE user_id = $1 AND key = $2)",
+			user1ID, key).Scan(&exists))
+		require.True(t, exists, "original threshold key survives")
+	}
+	var overrideValue string
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		"SELECT value FROM user_configs WHERE user_id = $1 AND key = 'chat_personal_model_override:root'",
+		user1ID).Scan(&overrideValue))
+	require.Equal(t, "chat_default", overrideValue, "non-threshold keys are untouched")
+
+	// --- Down round-trip on the exploded state. The framework's Stepper
+	// cannot commit after exactly one down step (its driver commits only
+	// when the stepper exhausts), so the down file is executed directly:
+	// migrations are plain SQL and this is the same text golang-migrate
+	// would run.
+	downSQL, err := fs.ReadFile(migrations.MigrationFS(), "000564_chat_model_config_org_explosion.down.sql")
+	require.NoError(t, err)
+	_, err = sqlDB.ExecContext(ctx, string(downSQL))
+	require.NoError(t, err)
+
+	// Copies are gone; references restored to the default-org originals.
+	assertCount(defaultOrgID, 6, "down: default org keeps its originals")
+	assertCount(orgBID, 0, "down: copies deleted from orgB")
+	assertCount(orgCID, 0, "down: copies deleted from orgC")
+	assertChatPinned(chatBID, c1ID, "down: orgB chat restored to original c1")
+	assertChatPinned(chatB3ID, c3ID, "down: orgB chat restored to original c3")
+	assertChatPinned(chatDID, c1ID, "down: orgD chat unchanged")
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		"SELECT model_config_id FROM chat_messages WHERE chat_id = $1", chatBID).Scan(&msgCfg))
+	require.Equal(t, c1ID, msgCfg, "down: orgB message restored")
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		"SELECT model_config_id FROM chat_queued_messages WHERE chat_id = $1", chatBID).Scan(&msgCfg))
+	require.Equal(t, c1ID, msgCfg, "down: orgB queued message restored")
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		"SELECT model_config_id FROM chat_debug_runs WHERE chat_id = $1", chatBID).Scan(&msgCfg))
+	require.Equal(t, c1ID, msgCfg, "down: orgB debug run restored")
+
+	// Fanned-out threshold keys are gone; exactly the seeded valid key set
+	// remains. The two hostile keys (malformed/empty suffix) are pruned as
+	// dangling: they cannot name an existing config, and the down must not
+	// abort on their uuid cast.
+	var thresholdCount int
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM user_configs WHERE key LIKE 'chat_compaction_threshold_pct:%'").Scan(&thresholdCount))
+	require.Equal(t, 4, thresholdCount, "down: only the 4 seeded valid threshold keys remain")
+
+	// Step forward again: the down executed outside the driver, so rewind
+	// the version row and re-apply the up. Shape re-asserted at count
+	// level.
+	_, err = sqlDB.ExecContext(ctx,
+		"TRUNCATE schema_migrations; INSERT INTO schema_migrations (version, dirty) VALUES (563, false)")
+	require.NoError(t, err)
+	stepperUpToLatest(migrationVersion)
+	assertCount(orgBID, 5, "re-up: orgB copies recreated")
+	assertCount(orgCID, 4, "re-up: orgC copies recreated")
+	assertChatPinned(chatDID, c1ID, "re-up: orgD still untouched")
 }

--- a/coderd/database/modelqueries.go
+++ b/coderd/database/modelqueries.go
@@ -58,15 +58,6 @@ type customQuerier interface {
 
 type chatModelConfigQuerier interface {
 	GetAuthorizedChatModelConfigs(ctx context.Context, prepared rbac.PreparedAuthorized) ([]ChatModelConfig, error)
-	// GetDefaultChatModelConfigCandidates enumerates the configs that
-	// ensureDefaultChatModelConfig may promote to default. It is the
-	// unfiltered list, kept separate from the authorized management list so
-	// the two contracts are not overloaded on one method.
-	GetDefaultChatModelConfigCandidates(ctx context.Context) ([]ChatModelConfig, error)
-}
-
-func (q *sqlQuerier) GetDefaultChatModelConfigCandidates(ctx context.Context) ([]ChatModelConfig, error) {
-	return q.GetChatModelConfigs(ctx)
 }
 
 func (q *sqlQuerier) GetAuthorizedChatModelConfigs(ctx context.Context, prepared rbac.PreparedAuthorized) ([]ChatModelConfig, error) {

--- a/coderd/database/modelqueries.go
+++ b/coderd/database/modelqueries.go
@@ -57,10 +57,10 @@ type customQuerier interface {
 }
 
 type chatModelConfigQuerier interface {
-	GetAuthorizedChatModelConfigs(ctx context.Context, prepared rbac.PreparedAuthorized) ([]ChatModelConfig, error)
+	GetAuthorizedChatModelConfigs(ctx context.Context, organizationID uuid.UUID, prepared rbac.PreparedAuthorized) ([]ChatModelConfig, error)
 }
 
-func (q *sqlQuerier) GetAuthorizedChatModelConfigs(ctx context.Context, prepared rbac.PreparedAuthorized) ([]ChatModelConfig, error) {
+func (q *sqlQuerier) GetAuthorizedChatModelConfigs(ctx context.Context, organizationID uuid.UUID, prepared rbac.PreparedAuthorized) ([]ChatModelConfig, error) {
 	authorizedFilter, err := prepared.CompileToSQL(ctx, rbac.ConfigChatModelConfigs())
 	if err != nil {
 		return nil, xerrors.Errorf("compile authorized filter: %w", err)
@@ -73,7 +73,7 @@ func (q *sqlQuerier) GetAuthorizedChatModelConfigs(ctx context.Context, prepared
 
 	// The name comment is for metric tracking
 	query := fmt.Sprintf("-- name: GetAuthorizedChatModelConfigs :many\n%s", filtered)
-	rows, err := q.db.QueryContext(ctx, query)
+	rows, err := q.db.QueryContext(ctx, query, organizationID)
 	if err != nil {
 		return nil, err
 	}

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -473,7 +473,12 @@ type sqlcQuerier interface {
 	// results remain after their assistant calls.
 	GetChatMessagesForPromptByChatID(ctx context.Context, chatID uuid.UUID) ([]ChatMessage, error)
 	GetChatModelConfigByID(ctx context.Context, id uuid.UUID) (ChatModelConfig, error)
-	GetChatModelConfigs(ctx context.Context) ([]ChatModelConfig, error)
+	GetChatModelConfigs(ctx context.Context, organizationID uuid.UUID) ([]ChatModelConfig, error)
+	// All live configs in one organization, unfiltered. Consumed ONLY by
+	// ensureDefaultChatModelConfig's default-election read inside the write
+	// transaction; authorization is the caller's update-in-org check that every
+	// path reaching the election already requires. No @authorize_filter.
+	GetChatModelConfigsByOrganization(ctx context.Context, organizationID uuid.UUID) ([]ChatModelConfig, error)
 	// Returns all model configurations for telemetry snapshot collection.
 	// deleted = false guarantees ai_provider_id is non-null, so INNER JOIN is safe.
 	GetChatModelConfigsForTelemetry(ctx context.Context) ([]GetChatModelConfigsForTelemetryRow, error)
@@ -571,7 +576,6 @@ type sqlcQuerier interface {
 	// Providers can be disabled independently of their model configs.
 	// Check both to ensure the selected config is actually usable.
 	GetEnabledChatModelConfigByID(ctx context.Context, id uuid.UUID) (ChatModelConfig, error)
-	GetEnabledChatModelConfigs(ctx context.Context) ([]GetEnabledChatModelConfigsRow, error)
 	GetEnabledChatModelConfigsByOrganization(ctx context.Context, organizationID uuid.UUID) ([]GetEnabledChatModelConfigsByOrganizationRow, error)
 	GetEnabledMCPServerConfigs(ctx context.Context) ([]MCPServerConfig, error)
 	// GetExternalAgentTokensByTemplateID returns the auth tokens for all

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -11957,15 +11957,15 @@ func TestGetEnabledChatModelConfigsUsesAIProviders(t *testing.T) {
 		params.Enabled = false
 	})
 
-	configs, err := store.GetEnabledChatModelConfigs(ctx)
+	configs, err := store.GetEnabledChatModelConfigsByOrganization(ctx, enabledConfig.OrganizationID)
 	require.NoError(t, err)
-	require.True(t, slices.ContainsFunc(configs, func(row database.GetEnabledChatModelConfigsRow) bool {
+	require.True(t, slices.ContainsFunc(configs, func(row database.GetEnabledChatModelConfigsByOrganizationRow) bool {
 		return row.ChatModelConfig.ID == enabledConfig.ID
 	}))
-	require.False(t, slices.ContainsFunc(configs, func(row database.GetEnabledChatModelConfigsRow) bool {
+	require.False(t, slices.ContainsFunc(configs, func(row database.GetEnabledChatModelConfigsByOrganizationRow) bool {
 		return row.ChatModelConfig.ID == disabledProviderConfig.ID
 	}))
-	require.False(t, slices.ContainsFunc(configs, func(row database.GetEnabledChatModelConfigsRow) bool {
+	require.False(t, slices.ContainsFunc(configs, func(row database.GetEnabledChatModelConfigsByOrganizationRow) bool {
 		return row.ChatModelConfig.ID == disabledModelConfig.ID
 	}))
 

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -8698,19 +8698,20 @@ func (q *sqlQuerier) GetChatMessagesForPromptByChatID(ctx context.Context, chatI
 }
 
 const getChatModelConfigsForTelemetry = `-- name: GetChatModelConfigsForTelemetry :many
-SELECT cmc.id, ap.type::text AS provider, cmc.model, cmc.context_limit, cmc.enabled, cmc.is_default
+SELECT cmc.id, ap.type::text AS provider, cmc.model, cmc.context_limit, cmc.enabled, cmc.is_default, cmc.organization_id
 FROM chat_model_configs cmc
 JOIN ai_providers ap ON ap.id = cmc.ai_provider_id
 WHERE cmc.deleted = false
 `
 
 type GetChatModelConfigsForTelemetryRow struct {
-	ID           uuid.UUID `db:"id" json:"id"`
-	Provider     string    `db:"provider" json:"provider"`
-	Model        string    `db:"model" json:"model"`
-	ContextLimit int64     `db:"context_limit" json:"context_limit"`
-	Enabled      bool      `db:"enabled" json:"enabled"`
-	IsDefault    bool      `db:"is_default" json:"is_default"`
+	ID             uuid.UUID `db:"id" json:"id"`
+	Provider       string    `db:"provider" json:"provider"`
+	Model          string    `db:"model" json:"model"`
+	ContextLimit   int64     `db:"context_limit" json:"context_limit"`
+	Enabled        bool      `db:"enabled" json:"enabled"`
+	IsDefault      bool      `db:"is_default" json:"is_default"`
+	OrganizationID uuid.UUID `db:"organization_id" json:"organization_id"`
 }
 
 // Returns all model configurations for telemetry snapshot collection.
@@ -8731,6 +8732,7 @@ func (q *sqlQuerier) GetChatModelConfigsForTelemetry(ctx context.Context) ([]Get
 			&i.ContextLimit,
 			&i.Enabled,
 			&i.IsDefault,
+			&i.OrganizationID,
 		); err != nil {
 			return nil, err
 		}

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -5858,6 +5858,7 @@ LEFT JOIN
     ai_providers ap ON ap.id = cmc.ai_provider_id
 WHERE
     cmc.deleted = FALSE
+    AND cmc.organization_id = $1::uuid
     -- Authorize Filter clause will be injected below in GetAuthorizedChatModelConfigs
     -- @authorize_filter
 ORDER BY
@@ -5867,8 +5868,68 @@ ORDER BY
     cmc.id DESC
 `
 
-func (q *sqlQuerier) GetChatModelConfigs(ctx context.Context) ([]ChatModelConfig, error) {
-	rows, err := q.db.QueryContext(ctx, getChatModelConfigs)
+func (q *sqlQuerier) GetChatModelConfigs(ctx context.Context, organizationID uuid.UUID) ([]ChatModelConfig, error) {
+	rows, err := q.db.QueryContext(ctx, getChatModelConfigs, organizationID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ChatModelConfig
+	for rows.Next() {
+		var i ChatModelConfig
+		if err := rows.Scan(
+			&i.ID,
+			&i.Model,
+			&i.DisplayName,
+			&i.CreatedBy,
+			&i.UpdatedBy,
+			&i.Enabled,
+			&i.IsDefault,
+			&i.Deleted,
+			&i.DeletedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.ContextLimit,
+			&i.CompressionThreshold,
+			&i.Options,
+			&i.AIProviderID,
+			&i.OrganizationID,
+			&i.GroupACL,
+			&i.UserACL,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getChatModelConfigsByOrganization = `-- name: GetChatModelConfigsByOrganization :many
+SELECT
+    id, model, display_name, created_by, updated_by, enabled, is_default, deleted, deleted_at, created_at, updated_at, context_limit, compression_threshold, options, ai_provider_id, organization_id, group_acl, user_acl
+FROM
+    chat_model_configs
+WHERE
+    organization_id = $1::uuid
+    AND deleted = FALSE
+ORDER BY
+    model ASC,
+    updated_at DESC,
+    id DESC
+`
+
+// All live configs in one organization, unfiltered. Consumed ONLY by
+// ensureDefaultChatModelConfig's default-election read inside the write
+// transaction; authorization is the caller's update-in-org check that every
+// path reaching the election already requires. No @authorize_filter.
+func (q *sqlQuerier) GetChatModelConfigsByOrganization(ctx context.Context, organizationID uuid.UUID) ([]ChatModelConfig, error) {
+	rows, err := q.db.QueryContext(ctx, getChatModelConfigsByOrganization, organizationID)
 	if err != nil {
 		return nil, err
 	}
@@ -5987,74 +6048,6 @@ func (q *sqlQuerier) GetEnabledChatModelConfigByID(ctx context.Context, id uuid.
 		&i.UserACL,
 	)
 	return i, err
-}
-
-const getEnabledChatModelConfigs = `-- name: GetEnabledChatModelConfigs :many
-SELECT
-    cmc.id, cmc.model, cmc.display_name, cmc.created_by, cmc.updated_by, cmc.enabled, cmc.is_default, cmc.deleted, cmc.deleted_at, cmc.created_at, cmc.updated_at, cmc.context_limit, cmc.compression_threshold, cmc.options, cmc.ai_provider_id, cmc.organization_id, cmc.group_acl, cmc.user_acl,
-    ap.type::text AS provider
-FROM
-    chat_model_configs cmc
-JOIN
-    ai_providers ap ON ap.id = cmc.ai_provider_id
-WHERE
-    cmc.enabled = TRUE
-    AND cmc.deleted = FALSE
-    AND ap.enabled = TRUE
-    AND ap.deleted = FALSE
-ORDER BY
-    ap.type::text ASC,
-    cmc.model ASC,
-    cmc.updated_at DESC,
-    cmc.id DESC
-`
-
-type GetEnabledChatModelConfigsRow struct {
-	ChatModelConfig ChatModelConfig `db:"chat_model_config" json:"chat_model_config"`
-	Provider        string          `db:"provider" json:"provider"`
-}
-
-func (q *sqlQuerier) GetEnabledChatModelConfigs(ctx context.Context) ([]GetEnabledChatModelConfigsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getEnabledChatModelConfigs)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []GetEnabledChatModelConfigsRow
-	for rows.Next() {
-		var i GetEnabledChatModelConfigsRow
-		if err := rows.Scan(
-			&i.ChatModelConfig.ID,
-			&i.ChatModelConfig.Model,
-			&i.ChatModelConfig.DisplayName,
-			&i.ChatModelConfig.CreatedBy,
-			&i.ChatModelConfig.UpdatedBy,
-			&i.ChatModelConfig.Enabled,
-			&i.ChatModelConfig.IsDefault,
-			&i.ChatModelConfig.Deleted,
-			&i.ChatModelConfig.DeletedAt,
-			&i.ChatModelConfig.CreatedAt,
-			&i.ChatModelConfig.UpdatedAt,
-			&i.ChatModelConfig.ContextLimit,
-			&i.ChatModelConfig.CompressionThreshold,
-			&i.ChatModelConfig.Options,
-			&i.ChatModelConfig.AIProviderID,
-			&i.ChatModelConfig.OrganizationID,
-			&i.ChatModelConfig.GroupACL,
-			&i.ChatModelConfig.UserACL,
-			&i.Provider,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
 }
 
 const getEnabledChatModelConfigsByOrganization = `-- name: GetEnabledChatModelConfigsByOrganization :many

--- a/coderd/database/queries/chatmodelconfigs.sql
+++ b/coderd/database/queries/chatmodelconfigs.sql
@@ -26,6 +26,7 @@ LEFT JOIN
     ai_providers ap ON ap.id = cmc.ai_provider_id
 WHERE
     cmc.deleted = FALSE
+    AND cmc.organization_id = @organization_id::uuid
     -- Authorize Filter clause will be injected below in GetAuthorizedChatModelConfigs
     -- @authorize_filter
 ORDER BY
@@ -34,24 +35,22 @@ ORDER BY
     cmc.updated_at DESC,
     cmc.id DESC;
 
--- name: GetEnabledChatModelConfigs :many
+-- name: GetChatModelConfigsByOrganization :many
+-- All live configs in one organization, unfiltered. Consumed ONLY by
+-- ensureDefaultChatModelConfig's default-election read inside the write
+-- transaction; authorization is the caller's update-in-org check that every
+-- path reaching the election already requires. No @authorize_filter.
 SELECT
-    sqlc.embed(cmc),
-    ap.type::text AS provider
+    *
 FROM
-    chat_model_configs cmc
-JOIN
-    ai_providers ap ON ap.id = cmc.ai_provider_id
+    chat_model_configs
 WHERE
-    cmc.enabled = TRUE
-    AND cmc.deleted = FALSE
-    AND ap.enabled = TRUE
-    AND ap.deleted = FALSE
+    organization_id = @organization_id::uuid
+    AND deleted = FALSE
 ORDER BY
-    ap.type::text ASC,
-    cmc.model ASC,
-    cmc.updated_at DESC,
-    cmc.id DESC;
+    model ASC,
+    updated_at DESC,
+    id DESC;
 
 -- name: GetEnabledChatModelConfigsByOrganization :many
 SELECT

--- a/coderd/database/queries/chats.sql
+++ b/coderd/database/queries/chats.sql
@@ -2654,7 +2654,7 @@ GROUP BY cm.chat_id;
 -- name: GetChatModelConfigsForTelemetry :many
 -- Returns all model configurations for telemetry snapshot collection.
 -- deleted = false guarantees ai_provider_id is non-null, so INNER JOIN is safe.
-SELECT cmc.id, ap.type::text AS provider, cmc.model, cmc.context_limit, cmc.enabled, cmc.is_default
+SELECT cmc.id, ap.type::text AS provider, cmc.model, cmc.context_limit, cmc.enabled, cmc.is_default, cmc.organization_id
 FROM chat_model_configs cmc
 JOIN ai_providers ap ON ap.id = cmc.ai_provider_id
 WHERE cmc.deleted = false;

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -989,7 +989,8 @@ func (api *API) chatPersonalModelOverrideDeploymentDefaults(
 type userChatModelAvailability struct {
 	configuredProviders  []chatprovider.ConfiguredProvider
 	configuredModels     []chatprovider.ConfiguredModel
-	enabledModels        []database.GetEnabledChatModelConfigsRow
+	enabledModels        []database.ChatModelConfig
+	providerTypeByID     map[uuid.UUID]string
 	providerStatus       map[string]chatprovider.ProviderAvailability
 	providerStatusByID   map[uuid.UUID]chatprovider.ProviderAvailability
 	enabledProviderNames map[string]struct{}
@@ -1015,13 +1016,15 @@ func (api *API) getUserChatProviderAvailability(
 	ctx context.Context,
 	userID uuid.UUID,
 ) (userChatModelAvailability, error) {
-	//nolint:gocritic // Chatd context is required to read enabled chat config.
+	//nolint:gocritic // Chatd context is required to read enabled chat providers.
 	chatdCtx := dbauthz.AsChatd(ctx)
 	enabledProviders, err := api.Database.GetAIProviders(chatdCtx, database.GetAIProvidersParams{})
 	if err != nil {
 		return userChatModelAvailability{}, err
 	}
-	enabledModels, err := api.Database.GetEnabledChatModelConfigs(chatdCtx)
+	// The authorized filter admits exactly the configs the user can read
+	// across orgs, which is the union of models available to them.
+	enabledModels, err := api.Database.GetChatModelConfigs(ctx)
 	if err != nil {
 		return userChatModelAvailability{}, err
 	}
@@ -1034,9 +1037,17 @@ func (api *API) getUserChatProviderAvailability(
 		configuredProviders:  configuredProviders,
 		configuredModels:     make([]chatprovider.ConfiguredModel, 0, len(enabledModels)),
 		enabledModels:        enabledModels,
+		providerTypeByID:     make(map[uuid.UUID]string, len(enabledProviders)),
 		enabledProviderNames: make(map[string]struct{}, len(enabledProviders)),
 		enabledProviderIDs:   make(map[uuid.UUID]struct{}, len(enabledProviders)),
 		providerStatusByID:   make(map[uuid.UUID]chatprovider.ProviderAvailability, len(enabledProviders)),
+	}
+	// Model configs carry no provider type; resolve it from the enabled
+	// providers. A config under a disabled or deleted provider is skipped
+	// for status purposes, mirroring the provider join on the enabled
+	// models query.
+	for _, provider := range enabledProviders {
+		availability.providerTypeByID[provider.ID] = string(provider.Type)
 	}
 	for _, configuredProvider := range configuredProviders {
 		normalizedProvider := chatprovider.NormalizeProvider(configuredProvider.Provider)
@@ -1097,18 +1108,20 @@ func (api *API) getUserChatProviderAvailability(
 
 	modelStatusByType := make(map[string]chatprovider.ProviderAvailability, len(enabledModels))
 	for _, model := range enabledModels {
-		normalizedProvider := chatprovider.NormalizeProvider(model.Provider)
+		if !model.AIProviderID.Valid {
+			continue
+		}
+		providerID := model.AIProviderID.UUID
+		providerType, ok := availability.providerTypeByID[providerID]
+		if !ok {
+			continue
+		}
+		normalizedProvider := chatprovider.NormalizeProvider(providerType)
 		if normalizedProvider == "" {
 			continue
 		}
-		if model.ChatModelConfig.AIProviderID.Valid {
-			status, ok := availability.providerStatusByID[model.ChatModelConfig.AIProviderID.UUID]
-			if ok {
-				mergeProviderStatus(modelStatusByType, normalizedProvider, status)
-			}
-			continue
-		}
-		if status, ok := providerStatusByType[normalizedProvider]; ok {
+		status, ok := availability.providerStatusByID[providerID]
+		if ok {
 			mergeProviderStatus(modelStatusByType, normalizedProvider, status)
 		}
 	}
@@ -1118,20 +1131,25 @@ func (api *API) getUserChatProviderAvailability(
 	}
 
 	for _, model := range enabledModels {
-		normalizedProvider := chatprovider.NormalizeProvider(model.Provider)
-		if model.ChatModelConfig.AIProviderID.Valid {
-			status, ok := availability.providerStatusByID[model.ChatModelConfig.AIProviderID.UUID]
-			if !ok {
-				continue
-			}
-			if aggregateStatus, ok := availability.providerStatus[normalizedProvider]; ok && aggregateStatus.Available && !status.Available {
-				continue
-			}
+		if !model.AIProviderID.Valid {
+			continue
+		}
+		providerType, ok := availability.providerTypeByID[model.AIProviderID.UUID]
+		if !ok {
+			continue
+		}
+		normalizedProvider := chatprovider.NormalizeProvider(providerType)
+		status, ok := availability.providerStatusByID[model.AIProviderID.UUID]
+		if !ok {
+			continue
+		}
+		if aggregateStatus, ok := availability.providerStatus[normalizedProvider]; ok && aggregateStatus.Available && !status.Available {
+			continue
 		}
 		availability.configuredModels = append(availability.configuredModels, chatprovider.ConfiguredModel{
-			Provider:    model.Provider,
-			Model:       model.ChatModelConfig.Model,
-			DisplayName: model.ChatModelConfig.DisplayName,
+			Provider:    providerType,
+			Model:       model.Model,
+			DisplayName: model.DisplayName,
 		})
 	}
 	return availability, nil
@@ -1143,6 +1161,7 @@ func (api *API) getUserChatProviderAvailability(
 func (api *API) userCanUseChatModelConfig(
 	ctx context.Context,
 	userID uuid.UUID,
+	organizationID uuid.UUID,
 	modelConfigID uuid.UUID,
 ) (database.ChatModelConfig, chatModelConfigUnavailableReason, error) {
 	if modelConfigID == uuid.Nil {
@@ -1158,6 +1177,10 @@ func (api *API) userCanUseChatModelConfig(
 			return database.ChatModelConfig{}, chatModelConfigUnavailableModelNotFoundOrDisabled, nil
 		}
 		return database.ChatModelConfig{}, chatModelConfigAvailable, err
+	}
+	// Cross-org configs are unavailable to the caller's org.
+	if model.OrganizationID != organizationID {
+		return database.ChatModelConfig{}, chatModelConfigUnavailableModelNotFoundOrDisabled, nil
 	}
 	if !model.Enabled {
 		return database.ChatModelConfig{}, chatModelConfigUnavailableModelNotFoundOrDisabled, nil
@@ -1190,9 +1213,10 @@ func (api *API) userCanUseChatModelConfig(
 func (api *API) validateUserChatModelConfigAvailable(
 	ctx context.Context,
 	userID uuid.UUID,
+	organizationID uuid.UUID,
 	modelConfigID uuid.UUID,
 ) (database.ChatModelConfig, int, *codersdk.Response) {
-	modelConfig, reason, err := api.userCanUseChatModelConfig(ctx, userID, modelConfigID)
+	modelConfig, reason, err := api.userCanUseChatModelConfig(ctx, userID, organizationID, modelConfigID)
 	if err != nil {
 		return database.ChatModelConfig{}, http.StatusInternalServerError, &codersdk.Response{
 			Message: "Internal error validating model config override.",
@@ -1233,12 +1257,13 @@ func (api *API) validateUserChatModelConfigAvailable(
 func (api *API) validateExplicitChatModelConfigAvailable(
 	ctx context.Context,
 	userID uuid.UUID,
+	organizationID uuid.UUID,
 	modelConfigID uuid.UUID,
 ) (int, *codersdk.Response) {
 	if modelConfigID == uuid.Nil {
 		return 0, nil
 	}
-	_, status, resp := api.validateUserChatModelConfigAvailable(ctx, userID, modelConfigID)
+	_, status, resp := api.validateUserChatModelConfigAvailable(ctx, userID, organizationID, modelConfigID)
 	return status, resp
 }
 
@@ -3447,7 +3472,7 @@ func (api *API) postChatMessages(rw http.ResponseWriter, r *http.Request) {
 	if req.ModelConfigID != nil {
 		modelConfigID = *req.ModelConfigID
 	}
-	if status, resp := api.validateExplicitChatModelConfigAvailable(ctx, apiKey.UserID, modelConfigID); resp != nil {
+	if status, resp := api.validateExplicitChatModelConfigAvailable(ctx, apiKey.UserID, chat.OrganizationID, modelConfigID); resp != nil {
 		httpapi.Write(ctx, rw, status, *resp)
 		return
 	}
@@ -3642,7 +3667,7 @@ func (api *API) patchChatMessage(rw http.ResponseWriter, r *http.Request) {
 	if req.ModelConfigID != nil {
 		editModelConfigID = *req.ModelConfigID
 	}
-	if status, resp := api.validateExplicitChatModelConfigAvailable(ctx, apiKey.UserID, editModelConfigID); resp != nil {
+	if status, resp := api.validateExplicitChatModelConfigAvailable(ctx, apiKey.UserID, chat.OrganizationID, editModelConfigID); resp != nil {
 		httpapi.Write(ctx, rw, status, *resp)
 		return
 	}
@@ -5052,7 +5077,7 @@ func (api *API) resolveCreateChatModelConfigID(
 				Message: "Invalid model config ID.",
 			}
 		}
-		if _, status, resp := api.validateUserChatModelConfigAvailable(ctx, userID, *req.ModelConfigID); resp != nil {
+		if _, status, resp := api.validateUserChatModelConfigAvailable(ctx, userID, req.OrganizationID, *req.ModelConfigID); resp != nil {
 			return uuid.Nil, nil, status, resp
 		}
 		return *req.ModelConfigID, nil, 0, nil
@@ -5066,7 +5091,7 @@ func (api *API) resolveCreateChatModelConfigID(
 		}
 	}
 	if !personalOverridesEnabled {
-		id, status, resp := api.defaultCreateChatModelConfigID(ctx)
+		id, status, resp := api.defaultCreateChatModelConfigID(ctx, req.OrganizationID)
 		return id, nil, status, resp
 	}
 
@@ -5101,6 +5126,7 @@ func (api *API) resolveCreateChatModelConfigID(
 			_, reason, err := api.userCanUseChatModelConfig(
 				ctx,
 				userID,
+				req.OrganizationID,
 				parsed.ModelConfigID,
 			)
 			if err != nil {
@@ -5129,30 +5155,20 @@ func (api *API) resolveCreateChatModelConfigID(
 		}
 	}
 
-	id, status, resp := api.defaultCreateChatModelConfigID(ctx)
+	id, status, resp := api.defaultCreateChatModelConfigID(ctx, req.OrganizationID)
 	return id, nil, status, resp
 }
 
 func (api *API) defaultCreateChatModelConfigID(
 	ctx context.Context,
+	organizationID uuid.UUID,
 ) (uuid.UUID, int, *codersdk.Response) {
-	// Chat model configs are org-scoped, but the pre-cutover request path
-	// carries no organization: every config lives in the default org, so
-	// resolve the default there. The default-org ID lookup is an internal
-	// resolution step, not user-readable data; a non-default-org member
-	// cannot read the organization object but must still resolve the
-	// deployment default.
-	//nolint:gocritic // Internal default-org resolution, scoped to this call.
-	defaultOrg, err := api.Database.GetDefaultOrganization(dbauthz.AsChatd(ctx))
+	defaultModelConfig, err := api.Database.GetDefaultChatModelConfig(ctx, organizationID)
 	if err != nil {
-		return uuid.Nil, http.StatusInternalServerError, &codersdk.Response{
-			Message: "Failed to resolve chat model config.",
-			Detail:  err.Error(),
-		}
-	}
-	defaultModelConfig, err := api.Database.GetDefaultChatModelConfig(ctx, defaultOrg.ID)
-	if err != nil {
-		if xerrors.Is(err, sql.ErrNoRows) {
+		// The org default read object-authorizes under the caller, so a
+		// member denied the default maps to the same response as a missing
+		// one.
+		if httpapi.Is404Error(err) {
 			return uuid.Nil, http.StatusBadRequest, &codersdk.Response{
 				Message: "No default chat model config is configured.",
 			}
@@ -5687,7 +5703,21 @@ func (api *API) putUserChatPersonalModelOverride(rw http.ResponseWriter, r *http
 			})
 			return
 		}
-		modelConfig, status, resp := api.validateUserChatModelConfigAvailable(ctx, apiKey.UserID, parsedModelConfigID)
+		// Personal model overrides are user-global and validate against
+		// default-org configs only; the UI pins personal overrides to the
+		// default org. Resolving the default org is an internal step: a
+		// non-default-org member cannot read the organization object but
+		// must still validate an override.
+		//nolint:gocritic // Internal default-org resolution for user-global personal overrides, scoped to this call.
+		defaultOrg, err := api.Database.GetDefaultOrganization(dbauthz.AsChatd(ctx))
+		if err != nil {
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Internal error validating model config override.",
+				Detail:  err.Error(),
+			})
+			return
+		}
+		modelConfig, status, resp := api.validateUserChatModelConfigAvailable(ctx, apiKey.UserID, defaultOrg.ID, parsedModelConfigID)
 		if resp != nil {
 			httpapi.Write(ctx, rw, status, *resp)
 			return
@@ -7372,30 +7402,32 @@ func (*API) deleteUserChatProviderKey(rw http.ResponseWriter, r *http.Request) {
 	writeLegacyChatProviderGone(rw, r)
 }
 
+// listChatModelConfigs is the member union endpoint: it returns every chat
+// model config the caller can read across all of their organizations, with
+// the org display name attached so user-context pages can label each copy.
+// The authorized query applies the RBAC SQL filter under the caller's
+// subject, so the union needs no handler-level gate.
+// @Summary List chat model configs across the caller's organizations
+// @ID list-chat-model-configs-union
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Success 200 {array} codersdk.ChatModelConfig
+// @Router /api/experimental/chat-model-configs [get]
+// @x-apidocgen {"skip": true}
 func (api *API) listChatModelConfigs(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	// Users authorized to read chat model configs in any org see the configs
-	// their authorization filter admits (including disabled ones) for
-	// management purposes. Other users see only enabled configs, which is
-	// sufficient for using the chat feature. AnyOrganization routes
-	// org-scoped readers (org admin, org auditor) to the authorized list as
-	// well as site readers; the SQL filter then restricts them to their orgs.
-	isAdmin := api.Authorize(r, policy.ActionRead, rbac.ResourceChatModelConfig.AnyOrganization())
-
-	var configs []database.ChatModelConfig
-	var err error
-	if isAdmin {
-		configs, err = api.Database.GetChatModelConfigs(ctx)
-	} else {
-		//nolint:gocritic // All authenticated users need to read enabled model configs to use the chat feature.
-		rows, rowsErr := api.Database.GetEnabledChatModelConfigs(dbauthz.AsChatd(ctx))
-		err = rowsErr
-		configs = make([]database.ChatModelConfig, 0, len(rows))
-		for _, row := range rows {
-			configs = append(configs, row.ChatModelConfig)
-		}
+	configs, err := api.Database.GetChatModelConfigs(ctx)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to list chat model configs.",
+			Detail:  err.Error(),
+		})
+		return
 	}
+
+	displayNames, err := api.chatModelConfigOrgDisplayNames(ctx, configs)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Failed to list chat model configs.",
@@ -7406,10 +7438,240 @@ func (api *API) listChatModelConfigs(rw http.ResponseWriter, r *http.Request) {
 
 	resp := make([]codersdk.ChatModelConfig, 0, len(configs))
 	for _, config := range configs {
+		converted := convertChatModelConfig(config)
+		converted.OrganizationDisplayName = displayNames[config.OrganizationID]
+		resp = append(resp, converted)
+	}
+
+	httpapi.Write(ctx, rw, http.StatusOK, resp)
+}
+
+// listChatModelConfigsByOrganization returns the caller-readable chat model
+// configs in the org carried by the route. The authorized query filters by
+// permission; the org filter is applied on top so management and picker
+// surfaces see exactly one org's set.
+// @Summary List chat model configs in an organization
+// @ID list-chat-model-configs-by-organization
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Param organization path string true "Organization name or ID"
+// @Success 200 {array} codersdk.ChatModelConfig
+// @Router /api/experimental/organizations/{organization}/chat-model-configs [get]
+// @x-apidocgen {"skip": true}
+func (api *API) listChatModelConfigsByOrganization(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	organization := httpmw.OrganizationParam(r)
+
+	configs, err := api.Database.GetChatModelConfigs(ctx)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to list chat model configs.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	resp := make([]codersdk.ChatModelConfig, 0, len(configs))
+	for _, config := range configs {
+		if config.OrganizationID != organization.ID {
+			continue
+		}
 		resp = append(resp, convertChatModelConfig(config))
 	}
 
 	httpapi.Write(ctx, rw, http.StatusOK, resp)
+}
+
+// getChatModelConfig returns one chat model config by ID; the org is
+// resolved from the row and authorization is the dbauthz object read.
+// @Summary Get a chat model config
+// @ID get-chat-model-config
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Param modelConfig path string true "Model config ID"
+// @Success 200 {object} codersdk.ChatModelConfig
+// @Router /api/experimental/chat-model-configs/{modelConfig} [get]
+// @x-apidocgen {"skip": true}
+//
+//nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
+func (api *API) getChatModelConfig(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	modelConfigID, ok := parseChatModelConfigID(rw, r)
+	if !ok {
+		return
+	}
+
+	config, err := api.Database.GetChatModelConfigByID(ctx, modelConfigID)
+	if err != nil {
+		if httpapi.Is404Error(err) {
+			httpapi.ResourceNotFound(rw)
+			return
+		}
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to get chat model config.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	httpapi.Write(ctx, rw, http.StatusOK, convertChatModelConfig(config))
+}
+
+// chatModelConfigOrgDisplayNames batch-resolves org display names for the
+// union response. The union admits configs a caller can read in orgs the
+// caller cannot read as organizations (the permission sets are
+// independent), so resolving under the caller's subject would leave those
+// rows unlabeled. The fetch is scoped to exactly the org IDs of the
+// returned rows, so it never discloses names of orgs with no returned
+// rows.
+func (api *API) chatModelConfigOrgDisplayNames(
+	ctx context.Context,
+	configs []database.ChatModelConfig,
+) (map[uuid.UUID]string, error) {
+	ids := make([]uuid.UUID, 0, len(configs))
+	seen := make(map[uuid.UUID]struct{}, len(configs))
+	for _, config := range configs {
+		if _, ok := seen[config.OrganizationID]; ok {
+			continue
+		}
+		seen[config.OrganizationID] = struct{}{}
+		ids = append(ids, config.OrganizationID)
+	}
+	names := make(map[uuid.UUID]string, len(ids))
+	if len(ids) == 0 {
+		return names, nil
+	}
+	//nolint:gocritic // Labels for exactly the rows the caller can already
+	// read; orgs with no returned row are never looked up.
+	orgs, err := api.Database.GetOrganizations(dbauthz.AsChatd(ctx), database.GetOrganizationsParams{
+		Deleted: false,
+		IDs:     ids,
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, org := range orgs {
+		names[org.ID] = org.DisplayName
+	}
+	return names, nil
+}
+
+// getChatAIProviderCatalog serves the redacted AI provider catalog to org
+// model admins, who cannot read the deployment-scoped provider endpoints.
+// dbauthz cannot express "create/update on chat model configs in ANY of the
+// caller's orgs" for a deployment-scoped fetch, so the access boundary is
+// the handler-level rbac.Authorize pre-check below, in front of an AsChatd
+// fetch that can only yield the redacted fields mapped here. This is the
+// declared invariant-3 exception for this subsystem: the response never
+// carries key material, base URLs, or headers.
+// @Summary Get the redacted AI provider catalog for org model admins
+// @ID get-chat-ai-provider-catalog
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Success 200 {array} codersdk.ChatAIProviderCatalogEntry
+// @Router /api/experimental/ai-providers/catalog [get]
+// @x-apidocgen {"skip": true}
+//
+//nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
+func (api *API) getChatAIProviderCatalog(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	apiKey := httpmw.APIKey(r)
+
+	orgs, err := api.Database.GetOrganizationsByUserID(ctx, database.GetOrganizationsByUserIDParams{
+		UserID:  apiKey.UserID,
+		Deleted: sql.NullBool{Bool: false, Valid: true},
+	})
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to resolve organizations.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	allowed := false
+	for _, org := range orgs {
+		if api.Authorize(r, policy.ActionCreate, rbac.ResourceChatModelConfig.InOrg(org.ID)) ||
+			api.Authorize(r, policy.ActionUpdate, rbac.ResourceChatModelConfig.InOrg(org.ID)) {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		httpapi.Forbidden(rw)
+		return
+	}
+
+	//nolint:gocritic // The handler gate above is the access boundary; the
+	// fetch only yields the redacted fields mapped below.
+	providers, err := api.Database.GetAIProviders(dbauthz.AsChatd(ctx), database.GetAIProvidersParams{})
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to list AI providers.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	//nolint:gocritic // Key presence is boolean metadata, not key material;
+	// the same redaction the deployment endpoint applies.
+	keysByProvider, err := loadAIProviderKeysByProvider(dbauthz.AsChatd(ctx), api.Database)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to load AI provider keys.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	userKeys := make(map[uuid.UUID]struct{})
+	if api.DeploymentValues.AI.BridgeConfig.AllowBYOK.Value() {
+		userKeyRows, err := api.Database.GetUserAIProviderKeysByUserID(ctx, apiKey.UserID)
+		if err != nil {
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Failed to load user AI provider keys.",
+				Detail:  err.Error(),
+			})
+			return
+		}
+		for _, row := range userKeyRows {
+			if row.APIKey != "" {
+				userKeys[row.AIProviderID] = struct{}{}
+			}
+		}
+	}
+
+	out := make([]codersdk.ChatAIProviderCatalogEntry, 0, len(providers))
+	for _, provider := range providers {
+		display := provider.Name
+		if provider.DisplayName.Valid && provider.DisplayName.String != "" {
+			display = provider.DisplayName.String
+		}
+		hasKey := false
+		for _, key := range keysByProvider[provider.ID] {
+			if key.APIKey != "" {
+				hasKey = true
+				break
+			}
+		}
+		_, hasUserKey := userKeys[provider.ID]
+		out = append(out, codersdk.ChatAIProviderCatalogEntry{
+			ID:              provider.ID,
+			Type:            string(provider.Type),
+			DisplayName:     display,
+			Icon:            provider.Icon,
+			Enabled:         provider.Enabled,
+			HasAPIKey:       hasKey,
+			HasUserAPIKey:   hasUserKey,
+			AllowUserAPIKey: api.DeploymentValues.AI.BridgeConfig.AllowBYOK.Value(),
+		})
+	}
+
+	httpapi.Write(ctx, rw, http.StatusOK, out)
 }
 
 type chatModelConfigProviderModelError struct {
@@ -7446,15 +7708,27 @@ func (api *API) inChatModelConfigWriteTx(ctx context.Context, fn func(tx databas
 	}, nil)
 }
 
+// @Summary Create a chat model config in an organization
+// @ID create-chat-model-config
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Produce json
+// @Param organization path string true "Organization name or ID"
+// @Param request body codersdk.CreateChatModelConfigRequest true "Model config"
+// @Success 201 {object} codersdk.ChatModelConfig
+// @Router /api/experimental/organizations/{organization}/chat-model-configs [post]
+// @x-apidocgen {"skip": true}
 func (api *API) createChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
-	// Interim write gate: pins write access to the pre-RBAC-resource set
-	// (deployment admins) while configs still serve every org through the
-	// default-org fallback. Without it the dbauthz create-in-org check
-	// would let default-org org admins manage configs used by all orgs.
-	// TODO(mafredri): remove after CODAGT-709 M3 (org-scoping cutover)
-	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
+	organization := httpmw.OrganizationParam(r)
+
+	// Authorize the write before any privileged lookup so unauthorized
+	// principals cannot probe provider state. The pre-check mirrors the
+	// dbauthz create-in-org check exactly; dbauthz remains the access
+	// boundary for the insert itself.
+	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceChatModelConfig.InOrg(organization.ID)) {
 		httpapi.Forbidden(rw)
 		return
 	}
@@ -7539,25 +7813,11 @@ func (api *API) createChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// The old routes are deployment-wide: configs created here belong to
-	// the default org until the org-scoped routes replace them. Seed the
-	// everyone-in-org read entry so the config stays visible to members
-	// once ACLs are enforced; the Everyone group shares the
-	// organization's ID. The default-org ID lookup is an internal
-	// resolution step, not user-readable data; the gate above already
-	// authorized the operation, and a custom role holding only
-	// deployment-config permissions cannot read the organization object.
-	//nolint:gocritic // Internal default-org resolution, scoped to this call.
-	defaultOrg, err := api.Database.GetDefaultOrganization(dbauthz.AsChatd(ctx))
-	if err != nil {
-		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Failed to resolve default organization.",
-			Detail:  err.Error(),
-		})
-		return
-	}
+	// Seed the everyone-in-org read entry so the config stays visible to
+	// members once ACLs are enforced; the Everyone group shares the
+	// organization's ID.
 	everyoneReadACL, err := json.Marshal(database.ChatACL{
-		defaultOrg.ID.String(): {Permissions: []policy.Action{policy.ActionRead}},
+		organization.ID.String(): {Permissions: []policy.Action{policy.ActionRead}},
 	})
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
@@ -7578,7 +7838,7 @@ func (api *API) createChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 		AIProviderID:         aiProviderID,
 		CreatedBy:            uuid.NullUUID{UUID: apiKey.UserID, Valid: apiKey.UserID != uuid.Nil},
 		UpdatedBy:            uuid.NullUUID{UUID: apiKey.UserID, Valid: apiKey.UserID != uuid.Nil},
-		OrganizationID:       defaultOrg.ID,
+		OrganizationID:       organization.ID,
 		GroupACL:             everyoneReadACL,
 		UserACL:              json.RawMessage(`{}`),
 	}
@@ -7602,7 +7862,8 @@ func (api *API) createChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 
 		insertAsDefault := isDefault
 		if !insertAsDefault {
-			_, err := tx.GetDefaultChatModelConfig(ctx, insertParams.OrganizationID)
+			//nolint:gocritic // Default-election probe must never misread a denial as absence; mutations stay under the caller's subject.
+			_, err := tx.GetDefaultChatModelConfig(dbauthz.AsChatd(ctx), insertParams.OrganizationID)
 			switch {
 			case err == nil:
 				// A default already exists.
@@ -7669,15 +7930,20 @@ func (api *API) createChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 	httpapi.Write(ctx, rw, http.StatusCreated, convertChatModelConfig(inserted))
 }
 
+// @Summary Update a chat model config
+// @ID update-chat-model-config
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Produce json
+// @Param modelConfig path string true "Model config ID"
+// @Param request body codersdk.UpdateChatModelConfigRequest true "Model config updates"
+// @Success 200 {object} codersdk.ChatModelConfig
+// @Router /api/experimental/chat-model-configs/{modelConfig} [patch]
+// @x-apidocgen {"skip": true}
 func (api *API) updateChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
-	// Interim write gate: see createChatModelConfig.
-	// TODO(mafredri): remove after CODAGT-709 M3 (org-scoping cutover)
-	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
-		httpapi.Forbidden(rw)
-		return
-	}
 
 	modelConfigID, ok := parseChatModelConfigID(rw, r)
 	if !ok {
@@ -7694,6 +7960,13 @@ func (api *API) updateChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 			Message: "Failed to get chat model config.",
 			Detail:  err.Error(),
 		})
+		return
+	}
+
+	// Authorize the write before any privileged lookup (see
+	// createChatModelConfig); mirrors the dbauthz object update check.
+	if !api.Authorize(r, policy.ActionUpdate, existing.RBACObject()) {
+		httpapi.Forbidden(rw)
 		return
 	}
 
@@ -7874,6 +8147,11 @@ func (api *API) updateChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 		case xerrors.Is(err, errChatModelConfigNotFound):
 			httpapi.ResourceNotFound(rw)
 			return
+		case httpapi.Is404Error(err):
+			// dbauthz denials do not unwrap to sql.ErrNoRows; conceal the
+			// config's existence like any other missing resource.
+			httpapi.ResourceNotFound(rw)
+			return
 		default:
 			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 				Message: "Failed to update chat model config.",
@@ -7888,14 +8166,16 @@ func (api *API) updateChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 	httpapi.Write(ctx, rw, http.StatusOK, convertChatModelConfig(updated))
 }
 
+// @Summary Delete a chat model config
+// @ID delete-chat-model-config
+// @Security CoderSessionToken
+// @Tags Chats
+// @Param modelConfig path string true "Model config ID"
+// @Success 204
+// @Router /api/experimental/chat-model-configs/{modelConfig} [delete]
+// @x-apidocgen {"skip": true}
 func (api *API) deleteChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	// Interim write gate: see createChatModelConfig.
-	// TODO(mafredri): remove after CODAGT-709 M3 (org-scoping cutover)
-	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
-		httpapi.Forbidden(rw)
-		return
-	}
 
 	modelConfigID, ok := parseChatModelConfigID(rw, r)
 	if !ok {
@@ -7915,12 +8195,25 @@ func (api *API) deleteChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Authorize the write before the transaction (see
+	// createChatModelConfig); mirrors the dbauthz object delete check.
+	if !api.Authorize(r, policy.ActionDelete, existing.RBACObject()) {
+		httpapi.Forbidden(rw)
+		return
+	}
+
 	if err := api.inChatModelConfigWriteTx(ctx, func(tx database.Store) error {
 		if err := tx.DeleteChatModelConfigByID(ctx, modelConfigID); err != nil {
 			return err
 		}
 		return ensureDefaultChatModelConfig(ctx, tx, existing.OrganizationID)
 	}); err != nil {
+		if httpapi.Is404Error(err) {
+			// dbauthz denials do not unwrap to sql.ErrNoRows; conceal the
+			// config's existence like any other missing resource.
+			httpapi.ResourceNotFound(rw)
+			return
+		}
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Failed to delete chat model config.",
 			Detail:  err.Error(),
@@ -7939,7 +8232,8 @@ func ensureDefaultChatModelConfig(
 	organizationID uuid.UUID,
 	excludedConfigIDs ...uuid.UUID,
 ) error {
-	_, err := tx.GetDefaultChatModelConfig(ctx, organizationID)
+	//nolint:gocritic // Default-election probe must never misread a denial as absence; mutations stay under the caller's subject.
+	_, err := tx.GetDefaultChatModelConfig(dbauthz.AsChatd(ctx), organizationID)
 	switch {
 	case err == nil:
 		return nil
@@ -7947,7 +8241,8 @@ func ensureDefaultChatModelConfig(
 		return xerrors.Errorf("get default model config: %w", err)
 	}
 
-	modelConfigs, err := tx.GetDefaultChatModelConfigCandidates(ctx)
+	//nolint:gocritic // Candidate enumeration for default election is internal; the election mutations below stay under the caller's subject.
+	modelConfigs, err := tx.GetChatModelConfigs(dbauthz.AsChatd(ctx))
 	if err != nil {
 		return xerrors.Errorf("list default chat model config candidates: %w", err)
 	}
@@ -8102,6 +8397,7 @@ func convertChatModelConfig(config database.ChatModelConfig) codersdk.ChatModelC
 	// chat_model_configs_ai_provider_required_when_active).
 	return codersdk.ChatModelConfig{
 		ID:                   config.ID,
+		OrganizationID:       config.OrganizationID,
 		AIProviderID:         config.AIProviderID.UUID,
 		Model:                config.Model,
 		DisplayName:          config.DisplayName,

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -1010,11 +1010,13 @@ const (
 )
 
 // getUserChatProviderAvailability returns the enabled chat providers and models
-// the user can access. Deployment-level configuration is read as chatd, while
-// user key lookups still use the caller's authorization context.
+// the user can access in one organization. Deployment-level configuration is
+// read as chatd, while user key lookups still use the caller's authorization
+// context.
 func (api *API) getUserChatProviderAvailability(
 	ctx context.Context,
 	userID uuid.UUID,
+	organizationID uuid.UUID,
 ) (userChatModelAvailability, error) {
 	//nolint:gocritic // Chatd context is required to read enabled chat providers.
 	chatdCtx := dbauthz.AsChatd(ctx)
@@ -1022,9 +1024,9 @@ func (api *API) getUserChatProviderAvailability(
 	if err != nil {
 		return userChatModelAvailability{}, err
 	}
-	// The authorized filter admits exactly the configs the user can read
-	// across orgs, which is the union of models available to them.
-	enabledModels, err := api.Database.GetChatModelConfigs(ctx)
+	// The authorized filter admits exactly the configs the user can read in
+	// this organization.
+	enabledModels, err := api.Database.GetChatModelConfigs(ctx, organizationID)
 	if err != nil {
 		return userChatModelAvailability{}, err
 	}
@@ -1186,7 +1188,7 @@ func (api *API) userCanUseChatModelConfig(
 		return database.ChatModelConfig{}, chatModelConfigUnavailableModelNotFoundOrDisabled, nil
 	}
 
-	availability, err := api.getUserChatProviderAvailability(ctx, userID)
+	availability, err := api.getUserChatProviderAvailability(ctx, userID, organizationID)
 	if err != nil {
 		return database.ChatModelConfig{}, chatModelConfigAvailable, err
 	}
@@ -1595,18 +1597,20 @@ func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
 //
-// @Summary List chat models
-// @ID list-chat-models
+// @Summary List available chat models in an organization
+// @ID list-chat-model-availability
 // @Security CoderSessionToken
 // @Tags Chats
 // @Produce json
-// @Success 200 {object} codersdk.ChatModelsResponse
-// @Router /api/experimental/chats/models [get]
+// @Param organization path string true "Organization name or ID"
+// @Success 200 {object} codersdk.ChatModelAvailabilityResponse
+// @Router /api/experimental/organizations/{organization}/chats/models/available [get]
 // @Description Experimental: this endpoint is subject to change.
-func (api *API) listChatModels(rw http.ResponseWriter, r *http.Request) {
+func (api *API) listChatModelAvailability(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
-	availability, err := api.getUserChatProviderAvailability(ctx, apiKey.UserID)
+	organization := httpmw.OrganizationParam(r)
+	availability, err := api.getUserChatProviderAvailability(ctx, apiKey.UserID, organization.ID)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Failed to load chat model configuration.",
@@ -1615,7 +1619,7 @@ func (api *API) listChatModels(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	catalog := chatprovider.NewModelCatalog()
-	var response codersdk.ChatModelsResponse
+	var response codersdk.ChatModelAvailabilityResponse
 	if configured, ok := catalog.ListConfiguredModels(
 		availability.configuredProviders,
 		availability.configuredModels,
@@ -7402,68 +7406,26 @@ func (*API) deleteUserChatProviderKey(rw http.ResponseWriter, r *http.Request) {
 	writeLegacyChatProviderGone(rw, r)
 }
 
-// listChatModelConfigs is the member union endpoint: it returns every chat
-// model config the caller can read across all of their organizations, with
-// the org display name attached so user-context pages can label each copy.
-// The authorized query applies the RBAC SQL filter under the caller's
-// subject, so the union needs no handler-level gate.
-// @Summary List chat model configs across the caller's organizations
-// @ID list-chat-model-configs-union
-// @Security CoderSessionToken
-// @Tags Chats
-// @Produce json
-// @Success 200 {array} codersdk.ChatModelConfig
-// @Router /api/experimental/chat-model-configs [get]
-// @x-apidocgen {"skip": true}
-func (api *API) listChatModelConfigs(rw http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
-	configs, err := api.Database.GetChatModelConfigs(ctx)
-	if err != nil {
-		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Failed to list chat model configs.",
-			Detail:  err.Error(),
-		})
-		return
-	}
-
-	displayNames, err := api.chatModelConfigOrgDisplayNames(ctx, configs)
-	if err != nil {
-		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Failed to list chat model configs.",
-			Detail:  err.Error(),
-		})
-		return
-	}
-
-	resp := make([]codersdk.ChatModelConfig, 0, len(configs))
-	for _, config := range configs {
-		converted := convertChatModelConfig(config)
-		converted.OrganizationDisplayName = displayNames[config.OrganizationID]
-		resp = append(resp, converted)
-	}
-
-	httpapi.Write(ctx, rw, http.StatusOK, resp)
-}
-
 // listChatModelConfigsByOrganization returns the caller-readable chat model
-// configs in the org carried by the route. The authorized query filters by
-// permission; the org filter is applied on top so management and picker
+// configs in the org carried by the route, plus the redacted provider
+// descriptors the authoring page needs. The authorized query filters models
+// by permission; the org filter is applied on top so management and picker
 // surfaces see exactly one org's set.
-// @Summary List chat model configs in an organization
-// @ID list-chat-model-configs-by-organization
+// @Summary List AI models and provider descriptors in an organization
+// @ID list-ai-models-by-organization
 // @Security CoderSessionToken
 // @Tags Chats
 // @Produce json
 // @Param organization path string true "Organization name or ID"
-// @Success 200 {array} codersdk.ChatModelConfig
-// @Router /api/experimental/organizations/{organization}/chat-model-configs [get]
+// @Success 200 {object} codersdk.OrganizationChatModelsResponse
+// @Router /api/experimental/organizations/{organization}/chats/models [get]
 // @x-apidocgen {"skip": true}
 func (api *API) listChatModelConfigsByOrganization(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	organization := httpmw.OrganizationParam(r)
+	apiKey := httpmw.APIKey(r)
 
-	configs, err := api.Database.GetChatModelConfigs(ctx)
+	configs, err := api.Database.GetChatModelConfigs(ctx, organization.ID)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Failed to list chat model configs.",
@@ -7472,143 +7434,7 @@ func (api *API) listChatModelConfigsByOrganization(rw http.ResponseWriter, r *ht
 		return
 	}
 
-	resp := make([]codersdk.ChatModelConfig, 0, len(configs))
-	for _, config := range configs {
-		if config.OrganizationID != organization.ID {
-			continue
-		}
-		resp = append(resp, convertChatModelConfig(config))
-	}
-
-	httpapi.Write(ctx, rw, http.StatusOK, resp)
-}
-
-// getChatModelConfig returns one chat model config by ID; the org is
-// resolved from the row and authorization is the dbauthz object read.
-// @Summary Get a chat model config
-// @ID get-chat-model-config
-// @Security CoderSessionToken
-// @Tags Chats
-// @Produce json
-// @Param modelConfig path string true "Model config ID"
-// @Success 200 {object} codersdk.ChatModelConfig
-// @Router /api/experimental/chat-model-configs/{modelConfig} [get]
-// @x-apidocgen {"skip": true}
-//
-//nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
-func (api *API) getChatModelConfig(rw http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
-	modelConfigID, ok := parseChatModelConfigID(rw, r)
-	if !ok {
-		return
-	}
-
-	config, err := api.Database.GetChatModelConfigByID(ctx, modelConfigID)
-	if err != nil {
-		if httpapi.Is404Error(err) {
-			httpapi.ResourceNotFound(rw)
-			return
-		}
-		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Failed to get chat model config.",
-			Detail:  err.Error(),
-		})
-		return
-	}
-
-	httpapi.Write(ctx, rw, http.StatusOK, convertChatModelConfig(config))
-}
-
-// chatModelConfigOrgDisplayNames batch-resolves org display names for the
-// union response. The union admits configs a caller can read in orgs the
-// caller cannot read as organizations (the permission sets are
-// independent), so resolving under the caller's subject would leave those
-// rows unlabeled. The fetch is scoped to exactly the org IDs of the
-// returned rows, so it never discloses names of orgs with no returned
-// rows.
-func (api *API) chatModelConfigOrgDisplayNames(
-	ctx context.Context,
-	configs []database.ChatModelConfig,
-) (map[uuid.UUID]string, error) {
-	ids := make([]uuid.UUID, 0, len(configs))
-	seen := make(map[uuid.UUID]struct{}, len(configs))
-	for _, config := range configs {
-		if _, ok := seen[config.OrganizationID]; ok {
-			continue
-		}
-		seen[config.OrganizationID] = struct{}{}
-		ids = append(ids, config.OrganizationID)
-	}
-	names := make(map[uuid.UUID]string, len(ids))
-	if len(ids) == 0 {
-		return names, nil
-	}
-	//nolint:gocritic // Labels for exactly the rows the caller can already
-	// read; orgs with no returned row are never looked up.
-	orgs, err := api.Database.GetOrganizations(dbauthz.AsChatd(ctx), database.GetOrganizationsParams{
-		Deleted: false,
-		IDs:     ids,
-	})
-	if err != nil {
-		return nil, err
-	}
-	for _, org := range orgs {
-		names[org.ID] = org.DisplayName
-	}
-	return names, nil
-}
-
-// getChatAIProviderCatalog serves the redacted AI provider catalog to org
-// model admins, who cannot read the deployment-scoped provider endpoints.
-// dbauthz cannot express "create/update on chat model configs in ANY of the
-// caller's orgs" for a deployment-scoped fetch, so the access boundary is
-// the handler-level rbac.Authorize pre-check below, in front of an AsChatd
-// fetch that can only yield the redacted fields mapped here. This is the
-// declared invariant-3 exception for this subsystem: the response never
-// carries key material, base URLs, or headers.
-// @Summary Get the redacted AI provider catalog for org model admins
-// @ID get-chat-ai-provider-catalog
-// @Security CoderSessionToken
-// @Tags Chats
-// @Produce json
-// @Success 200 {array} codersdk.ChatAIProviderCatalogEntry
-// @Router /api/experimental/ai-providers/catalog [get]
-// @x-apidocgen {"skip": true}
-//
-//nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
-func (api *API) getChatAIProviderCatalog(rw http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	apiKey := httpmw.APIKey(r)
-
-	orgs, err := api.Database.GetOrganizationsByUserID(ctx, database.GetOrganizationsByUserIDParams{
-		UserID:  apiKey.UserID,
-		Deleted: sql.NullBool{Bool: false, Valid: true},
-	})
-	if err != nil {
-		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Failed to resolve organizations.",
-			Detail:  err.Error(),
-		})
-		return
-	}
-
-	allowed := false
-	for _, org := range orgs {
-		if api.Authorize(r, policy.ActionCreate, rbac.ResourceChatModelConfig.InOrg(org.ID)) ||
-			api.Authorize(r, policy.ActionUpdate, rbac.ResourceChatModelConfig.InOrg(org.ID)) {
-			allowed = true
-			break
-		}
-	}
-	if !allowed {
-		httpapi.Forbidden(rw)
-		return
-	}
-
-	//nolint:gocritic // The handler gate above is the access boundary; the
-	// fetch only yields the redacted fields mapped below.
-	providers, err := api.Database.GetAIProviders(dbauthz.AsChatd(ctx), database.GetAIProvidersParams{})
+	providers, err := api.chatModelProviderDescriptors(ctx, apiKey.UserID)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Failed to list AI providers.",
@@ -7617,26 +7443,45 @@ func (api *API) getChatAIProviderCatalog(rw http.ResponseWriter, r *http.Request
 		return
 	}
 
-	//nolint:gocritic // Key presence is boolean metadata, not key material;
-	// the same redaction the deployment endpoint applies.
+	resp := codersdk.OrganizationChatModelsResponse{
+		Models:    make([]codersdk.ChatModel, 0, len(configs)),
+		Providers: providers,
+	}
+	for _, config := range configs {
+		resp.Models = append(resp.Models, convertChatModelConfig(config))
+	}
+
+	httpapi.Write(ctx, rw, http.StatusOK, resp)
+}
+
+// chatModelProviderDescriptors assembles the redacted provider descriptors
+// for the org model collection. The caller already passed the org's model
+// read gate; providers are deployment-scoped and an org admin cannot read
+// them directly, so the fetch runs under a narrow AsChatd context scoped to
+// exactly these two reads and the result is projected to the fixed redacted
+// fields (no key material, base URLs, or headers). Disclosure matches what
+// /api/experimental/chats/models already shows any authenticated caller.
+func (api *API) chatModelProviderDescriptors(
+	ctx context.Context,
+	userID uuid.UUID,
+) ([]codersdk.ChatModelProviderDescriptor, error) {
+	//nolint:gocritic // Fixed redacted projection under the model read gate; see function doc.
+	providers, err := api.Database.GetAIProviders(dbauthz.AsChatd(ctx), database.GetAIProvidersParams{})
+	if err != nil {
+		return nil, err
+	}
+
+	//nolint:gocritic // Key presence is boolean metadata, not key material; same redaction as the deployment endpoint.
 	keysByProvider, err := loadAIProviderKeysByProvider(dbauthz.AsChatd(ctx), api.Database)
 	if err != nil {
-		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Failed to load AI provider keys.",
-			Detail:  err.Error(),
-		})
-		return
+		return nil, err
 	}
 
 	userKeys := make(map[uuid.UUID]struct{})
 	if api.DeploymentValues.AI.BridgeConfig.AllowBYOK.Value() {
-		userKeyRows, err := api.Database.GetUserAIProviderKeysByUserID(ctx, apiKey.UserID)
+		userKeyRows, err := api.Database.GetUserAIProviderKeysByUserID(ctx, userID)
 		if err != nil {
-			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-				Message: "Failed to load user AI provider keys.",
-				Detail:  err.Error(),
-			})
-			return
+			return nil, err
 		}
 		for _, row := range userKeyRows {
 			if row.APIKey != "" {
@@ -7645,7 +7490,7 @@ func (api *API) getChatAIProviderCatalog(rw http.ResponseWriter, r *http.Request
 		}
 	}
 
-	out := make([]codersdk.ChatAIProviderCatalogEntry, 0, len(providers))
+	out := make([]codersdk.ChatModelProviderDescriptor, 0, len(providers))
 	for _, provider := range providers {
 		display := provider.Name
 		if provider.DisplayName.Valid && provider.DisplayName.String != "" {
@@ -7659,7 +7504,7 @@ func (api *API) getChatAIProviderCatalog(rw http.ResponseWriter, r *http.Request
 			}
 		}
 		_, hasUserKey := userKeys[provider.ID]
-		out = append(out, codersdk.ChatAIProviderCatalogEntry{
+		out = append(out, codersdk.ChatModelProviderDescriptor{
 			ID:              provider.ID,
 			Type:            string(provider.Type),
 			DisplayName:     display,
@@ -7670,8 +7515,26 @@ func (api *API) getChatAIProviderCatalog(rw http.ResponseWriter, r *http.Request
 			AllowUserAPIKey: api.DeploymentValues.AI.BridgeConfig.AllowBYOK.Value(),
 		})
 	}
+	return out, nil
+}
 
-	httpapi.Write(ctx, rw, http.StatusOK, out)
+// getChatModelConfig returns one chat model config; the config and its org
+// are resolved and read-authorized once by ExtractChatModelConfigParam.
+// @Summary Get an AI model
+// @ID get-ai-model
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Param model path string true "Model ID"
+// @Success 200 {object} codersdk.ChatModel
+// @Router /api/experimental/ai/models/{model} [get]
+// @x-apidocgen {"skip": true}
+//
+//nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
+func (api *API) getChatModelConfig(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	config := httpmw.ChatModelConfigParam(r)
+	httpapi.Write(ctx, rw, http.StatusOK, convertChatModelConfig(config))
 }
 
 type chatModelConfigProviderModelError struct {
@@ -7708,32 +7571,23 @@ func (api *API) inChatModelConfigWriteTx(ctx context.Context, fn func(tx databas
 	}, nil)
 }
 
-// @Summary Create a chat model config in an organization
-// @ID create-chat-model-config
+// @Summary Create an AI model in an organization
+// @ID create-ai-model
 // @Security CoderSessionToken
 // @Tags Chats
 // @Accept json
 // @Produce json
 // @Param organization path string true "Organization name or ID"
-// @Param request body codersdk.CreateChatModelConfigRequest true "Model config"
-// @Success 201 {object} codersdk.ChatModelConfig
-// @Router /api/experimental/organizations/{organization}/chat-model-configs [post]
+// @Param request body codersdk.CreateChatModelRequest true "Model"
+// @Success 201 {object} codersdk.ChatModel
+// @Router /api/experimental/organizations/{organization}/ai/models [post]
 // @x-apidocgen {"skip": true}
 func (api *API) createChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
 	organization := httpmw.OrganizationParam(r)
 
-	// Authorize the write before any privileged lookup so unauthorized
-	// principals cannot probe provider state. The pre-check mirrors the
-	// dbauthz create-in-org check exactly; dbauthz remains the access
-	// boundary for the insert itself.
-	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceChatModelConfig.InOrg(organization.ID)) {
-		httpapi.Forbidden(rw)
-		return
-	}
-
-	var req codersdk.CreateChatModelConfigRequest
+	var req codersdk.CreateChatModelRequest
 	if !httpapi.Read(ctx, rw, r, &req) {
 		return
 	}
@@ -7742,35 +7596,13 @@ func (api *API) createChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{Message: "AI provider ID is required."})
 		return
 	}
-	//nolint:gocritic // The route already authorized chat model config updates.
-	aiProvider, err := api.Database.GetAIProviderByID(dbauthz.AsChatd(ctx), *req.AIProviderID)
-	if err != nil {
-		if httpapi.Is404Error(err) {
-			httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{Message: "AI provider is not configured."})
-			return
-		}
-		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Failed to get AI provider.",
-			Detail:  err.Error(),
-		})
-		return
-	}
-	if !aiProvider.Enabled {
-		httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{Message: "AI provider is disabled."})
-		return
-	}
-	aiProviderID := uuid.NullUUID{UUID: aiProvider.ID, Valid: true}
+	aiProviderID := uuid.NullUUID{UUID: *req.AIProviderID, Valid: true}
 
 	model := strings.TrimSpace(req.Model)
 	if model == "" {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Model is required.",
 		})
-		return
-	}
-
-	if validationErr := validateChatModelConfigProviderModel(aiProvider, model); validationErr != nil {
-		httpapi.Write(ctx, rw, http.StatusBadRequest, validationErr.Response)
 		return
 	}
 
@@ -7845,16 +7677,16 @@ func (api *API) createChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 
 	var inserted database.ChatModelConfig
 	err = api.inChatModelConfigWriteTx(ctx, func(tx database.Store) error {
-		//nolint:gocritic // The route already authorized chat model config updates.
+		//nolint:gocritic // The provider fetch only reads the redacted descriptor fields.
 		lockedAIProvider, err := tx.GetAIProviderByIDForReferenceLock(dbauthz.AsChatd(ctx), insertParams.AIProviderID.UUID)
 		if err != nil {
 			if xerrors.Is(err, sql.ErrNoRows) {
-				return errChatProviderNotConfigured
+				return errChatProviderNotFound
 			}
 			return xerrors.Errorf("get AI provider for update: %w", err)
 		}
 		if !lockedAIProvider.Enabled {
-			return errChatProviderNotConfigured
+			return errChatProviderDisabled
 		}
 		if err := validateChatModelConfigProviderModel(lockedAIProvider, insertParams.Model); err != nil {
 			return err
@@ -7910,10 +7742,19 @@ func (api *API) createChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 				Detail:  err.Error(),
 			})
 			return
-		case xerrors.Is(err, errChatProviderNotConfigured):
+		case dbauthz.IsNotAuthorizedError(err):
+			// The dbauthz create-in-org check is the write access boundary;
+			// surface its denial as 403, not a concealed 404 or a 500.
+			httpapi.Forbidden(rw)
+			return
+		case xerrors.Is(err, errChatProviderNotFound):
 			httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{
-				Message: "Chat provider is not configured.",
-				Detail:  err.Error(),
+				Message: "AI provider is not configured.",
+			})
+			return
+		case xerrors.Is(err, errChatProviderDisabled):
+			httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{
+				Message: "AI provider is disabled.",
 			})
 			return
 		default:
@@ -7930,71 +7771,30 @@ func (api *API) createChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 	httpapi.Write(ctx, rw, http.StatusCreated, convertChatModelConfig(inserted))
 }
 
-// @Summary Update a chat model config
-// @ID update-chat-model-config
+// @Summary Update an AI model
+// @ID update-ai-model
 // @Security CoderSessionToken
 // @Tags Chats
 // @Accept json
 // @Produce json
-// @Param modelConfig path string true "Model config ID"
-// @Param request body codersdk.UpdateChatModelConfigRequest true "Model config updates"
-// @Success 200 {object} codersdk.ChatModelConfig
-// @Router /api/experimental/chat-model-configs/{modelConfig} [patch]
+// @Param model path string true "Model ID"
+// @Param request body codersdk.UpdateChatModelRequest true "Model updates"
+// @Success 200 {object} codersdk.ChatModel
+// @Router /api/experimental/ai/models/{model} [patch]
 // @x-apidocgen {"skip": true}
 func (api *API) updateChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
+	existing := httpmw.ChatModelConfigParam(r)
 
-	modelConfigID, ok := parseChatModelConfigID(rw, r)
-	if !ok {
-		return
-	}
-
-	existing, err := api.Database.GetChatModelConfigByID(ctx, modelConfigID)
-	if err != nil {
-		if httpapi.Is404Error(err) {
-			httpapi.ResourceNotFound(rw)
-			return
-		}
-		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Failed to get chat model config.",
-			Detail:  err.Error(),
-		})
-		return
-	}
-
-	// Authorize the write before any privileged lookup (see
-	// createChatModelConfig); mirrors the dbauthz object update check.
-	if !api.Authorize(r, policy.ActionUpdate, existing.RBACObject()) {
-		httpapi.Forbidden(rw)
-		return
-	}
-
-	var req codersdk.UpdateChatModelConfigRequest
+	var req codersdk.UpdateChatModelRequest
 	if !httpapi.Read(ctx, rw, r, &req) {
 		return
 	}
 
 	aiProviderID := existing.AIProviderID
 	if req.AIProviderID != nil {
-		//nolint:gocritic // The route already authorized chat model config updates.
-		aiProvider, err := api.Database.GetAIProviderByID(dbauthz.AsChatd(ctx), *req.AIProviderID)
-		if err != nil {
-			if httpapi.Is404Error(err) {
-				httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{Message: "AI provider is not configured."})
-				return
-			}
-			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-				Message: "Failed to get AI provider.",
-				Detail:  err.Error(),
-			})
-			return
-		}
-		if !aiProvider.Enabled {
-			httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{Message: "AI provider is disabled."})
-			return
-		}
-		aiProviderID = uuid.NullUUID{UUID: aiProvider.ID, Valid: true}
+		aiProviderID = uuid.NullUUID{UUID: *req.AIProviderID, Valid: true}
 	}
 
 	model := existing.Model
@@ -8068,18 +7868,18 @@ func (api *API) updateChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 	// Re-derive the provider type under lock when the model or provider changes.
 	revalidateProviderModel := updateParams.AIProviderID.Valid && (req.AIProviderID != nil || strings.TrimSpace(req.Model) != "")
 	var updated database.ChatModelConfig
-	err = api.inChatModelConfigWriteTx(ctx, func(tx database.Store) error {
+	err := api.inChatModelConfigWriteTx(ctx, func(tx database.Store) error {
 		if revalidateProviderModel {
-			//nolint:gocritic // The route already authorized chat model config updates.
+			//nolint:gocritic // The provider fetch only reads the redacted descriptor fields.
 			aiProvider, err := tx.GetAIProviderByIDForReferenceLock(dbauthz.AsChatd(ctx), updateParams.AIProviderID.UUID)
 			if err != nil {
 				if xerrors.Is(err, sql.ErrNoRows) {
-					return errChatProviderNotConfigured
+					return errChatProviderNotFound
 				}
 				return xerrors.Errorf("get AI provider for update: %w", err)
 			}
 			if !aiProvider.Enabled {
-				return errChatProviderNotConfigured
+				return errChatProviderDisabled
 			}
 			if err := validateChatModelConfigProviderModel(aiProvider, updateParams.Model); err != nil {
 				return err
@@ -8138,17 +7938,26 @@ func (api *API) updateChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 				Detail:  err.Error(),
 			})
 			return
-		case xerrors.Is(err, errChatProviderNotConfigured):
+		case dbauthz.IsNotAuthorizedError(err):
+			// The dbauthz object update check is the write access boundary;
+			// surface its denial as 403, not a concealed 404 or a 500.
+			httpapi.Forbidden(rw)
+			return
+		case xerrors.Is(err, errChatProviderNotFound):
 			httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{
-				Message: "Chat provider is not configured.",
-				Detail:  err.Error(),
+				Message: "AI provider is not configured.",
+			})
+			return
+		case xerrors.Is(err, errChatProviderDisabled):
+			httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{
+				Message: "AI provider is disabled.",
 			})
 			return
 		case xerrors.Is(err, errChatModelConfigNotFound):
 			httpapi.ResourceNotFound(rw)
 			return
 		case httpapi.Is404Error(err):
-			// dbauthz denials do not unwrap to sql.ErrNoRows; conceal the
+			// The refresh read inside the transaction can miss; conceal the
 			// config's existence like any other missing resource.
 			httpapi.ResourceNotFound(rw)
 			return
@@ -8166,51 +7975,31 @@ func (api *API) updateChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 	httpapi.Write(ctx, rw, http.StatusOK, convertChatModelConfig(updated))
 }
 
-// @Summary Delete a chat model config
-// @ID delete-chat-model-config
+// @Summary Delete an AI model
+// @ID delete-ai-model
 // @Security CoderSessionToken
 // @Tags Chats
-// @Param modelConfig path string true "Model config ID"
+// @Param model path string true "Model ID"
 // @Success 204
-// @Router /api/experimental/chat-model-configs/{modelConfig} [delete]
+// @Router /api/experimental/ai/models/{model} [delete]
 // @x-apidocgen {"skip": true}
 func (api *API) deleteChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-
-	modelConfigID, ok := parseChatModelConfigID(rw, r)
-	if !ok {
-		return
-	}
-
-	existing, err := api.Database.GetChatModelConfigByID(ctx, modelConfigID)
-	if err != nil {
-		if httpapi.Is404Error(err) {
-			httpapi.ResourceNotFound(rw)
-			return
-		}
-		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Failed to get chat model config.",
-			Detail:  err.Error(),
-		})
-		return
-	}
-
-	// Authorize the write before the transaction (see
-	// createChatModelConfig); mirrors the dbauthz object delete check.
-	if !api.Authorize(r, policy.ActionDelete, existing.RBACObject()) {
-		httpapi.Forbidden(rw)
-		return
-	}
+	existing := httpmw.ChatModelConfigParam(r)
 
 	if err := api.inChatModelConfigWriteTx(ctx, func(tx database.Store) error {
-		if err := tx.DeleteChatModelConfigByID(ctx, modelConfigID); err != nil {
+		if err := tx.DeleteChatModelConfigByID(ctx, existing.ID); err != nil {
 			return err
 		}
 		return ensureDefaultChatModelConfig(ctx, tx, existing.OrganizationID)
 	}); err != nil {
+		if dbauthz.IsNotAuthorizedError(err) {
+			// The dbauthz object delete check is the write access boundary;
+			// surface its denial as 403, not a concealed 404 or a 500.
+			httpapi.Forbidden(rw)
+			return
+		}
 		if httpapi.Is404Error(err) {
-			// dbauthz denials do not unwrap to sql.ErrNoRows; conceal the
-			// config's existence like any other missing resource.
 			httpapi.ResourceNotFound(rw)
 			return
 		}
@@ -8221,7 +8010,7 @@ func (api *API) deleteChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	publishChatConfigEvent(api.Logger, api.Pubsub, pubsub.ChatConfigEventModelConfig, modelConfigID)
+	publishChatConfigEvent(api.Logger, api.Pubsub, pubsub.ChatConfigEventModelConfig, existing.ID)
 
 	rw.WriteHeader(http.StatusNoContent)
 }
@@ -8241,16 +8030,9 @@ func ensureDefaultChatModelConfig(
 		return xerrors.Errorf("get default model config: %w", err)
 	}
 
-	//nolint:gocritic // Candidate enumeration for default election is internal; the election mutations below stay under the caller's subject.
-	modelConfigs, err := tx.GetChatModelConfigs(dbauthz.AsChatd(ctx))
+	orgModelConfigs, err := tx.GetChatModelConfigsByOrganization(ctx, organizationID)
 	if err != nil {
 		return xerrors.Errorf("list default chat model config candidates: %w", err)
-	}
-	orgModelConfigs := make([]database.ChatModelConfig, 0, len(modelConfigs))
-	for _, config := range modelConfigs {
-		if config.OrganizationID == organizationID {
-			orgModelConfigs = append(orgModelConfigs, config)
-		}
 	}
 	if len(orgModelConfigs) == 0 {
 		return nil
@@ -8386,7 +8168,7 @@ func parseChatModelConfigID(rw http.ResponseWriter, r *http.Request) (uuid.UUID,
 	return modelConfigID, true
 }
 
-func convertChatModelConfig(config database.ChatModelConfig) codersdk.ChatModelConfig {
+func convertChatModelConfig(config database.ChatModelConfig) codersdk.ChatModel {
 	modelConfig := unmarshalChatModelCallConfig(config.Options)
 	var reasoningEffortConfig *codersdk.ChatModelReasoningEffortConfig
 	if modelConfig != nil {
@@ -8395,7 +8177,7 @@ func convertChatModelConfig(config database.ChatModelConfig) codersdk.ChatModelC
 
 	// Active configs always carry a non-null ai_provider_id (CHECK
 	// chat_model_configs_ai_provider_required_when_active).
-	return codersdk.ChatModelConfig{
+	return codersdk.ChatModel{
 		ID:                   config.ID,
 		OrganizationID:       config.OrganizationID,
 		AIProviderID:         config.AIProviderID.UUID,
@@ -8579,8 +8361,9 @@ func validateChatProviderAPIKeySize(apiKey string) error {
 }
 
 var (
-	errChatModelConfigNotFound   = xerrors.New("chat model config not found")
-	errChatProviderNotConfigured = xerrors.New("chat provider is not configured")
+	errChatModelConfigNotFound = xerrors.New("chat model config not found")
+	errChatProviderNotFound    = xerrors.New("chat provider is not configured")
+	errChatProviderDisabled    = xerrors.New("chat provider is disabled")
 )
 
 // ChatProviderAPIKeysFromDeploymentValues returns deployment-backed chat

--- a/coderd/exp_chats_internal_m2_test.go
+++ b/coderd/exp_chats_internal_m2_test.go
@@ -125,5 +125,17 @@ func TestChatModelConfigListReadContracts(t *testing.T) {
 		// filter admits both orgs' rows; the probe's contract is that the
 		// request uses the authorized list (no 500, own disabled visible).
 		require.True(t, contains(configs, ownDisabled.ID), "site reader must see own disabled config")
+
+		// The role holds only chat_model_config:read: it cannot read the
+		// other org as an organization, yet every union row must still
+		// carry its org display name (the label fetch is scoped to exactly
+		// the returned rows' orgs, not gated on org read).
+		require.True(t, contains(configs, otherEnabled.ID), "site reader sees the cross-org row via the authorized filter")
+		for _, c := range configs {
+			if c.ID == otherEnabled.ID {
+				require.Equal(t, otherOrg.DisplayName, c.OrganizationDisplayName,
+					"cross-org row must carry its org display name despite the caller lacking org read")
+			}
+		}
 	})
 }

--- a/coderd/exp_chats_internal_m2_test.go
+++ b/coderd/exp_chats_internal_m2_test.go
@@ -56,7 +56,7 @@ func TestChatModelConfigListReadContracts(t *testing.T) {
 		},
 	})
 
-	contains := func(configs []codersdk.ChatModelConfig, id uuid.UUID) bool {
+	contains := func(configs []codersdk.ChatModel, id uuid.UUID) bool {
 		for _, c := range configs {
 			if c.ID == id {
 				return true
@@ -71,10 +71,10 @@ func TestChatModelConfigListReadContracts(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitLong)
 		orgAdminClientRaw, _ := coderdtest.CreateAnotherUser(t, client.Client, defaultOrg.ID, rbac.ScopedRoleOrgAdmin(defaultOrg.ID))
 		orgAdminClient := codersdk.NewExperimentalClient(orgAdminClientRaw)
-		configs, err := orgAdminClient.ListChatModelConfigs(ctx)
+		configs, err := orgAdminClient.ChatModels(ctx, defaultOrg.ID)
 		require.NoError(t, err)
-		require.True(t, contains(configs, ownDisabled.ID), "org admin must see own disabled config")
-		require.False(t, contains(configs, otherEnabled.ID), "org admin must not see other org's config")
+		require.True(t, contains(configs.Models, ownDisabled.ID), "org admin must see own disabled config")
+		require.False(t, contains(configs.Models, otherEnabled.ID), "org admin must not see other org's config")
 	})
 
 	t.Run("OrgAuditorSeesOwnDisabledNotCrossOrg", func(t *testing.T) {
@@ -83,10 +83,10 @@ func TestChatModelConfigListReadContracts(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitLong)
 		orgAuditorClientRaw, _ := coderdtest.CreateAnotherUser(t, client.Client, defaultOrg.ID, rbac.ScopedRoleOrgAuditor(defaultOrg.ID))
 		orgAuditorClient := codersdk.NewExperimentalClient(orgAuditorClientRaw)
-		configs, err := orgAuditorClient.ListChatModelConfigs(ctx)
+		configs, err := orgAuditorClient.ChatModels(ctx, defaultOrg.ID)
 		require.NoError(t, err)
-		require.True(t, contains(configs, ownDisabled.ID), "org auditor must see own disabled config")
-		require.False(t, contains(configs, otherEnabled.ID), "org auditor must not see other org's config")
+		require.True(t, contains(configs.Models, ownDisabled.ID), "org auditor must see own disabled config")
+		require.False(t, contains(configs.Models, otherEnabled.ID), "org auditor must not see other org's config")
 	})
 
 	t.Run("CustomSiteReadRoleSeesAuthorizedRows", func(t *testing.T) {
@@ -119,23 +119,10 @@ func TestChatModelConfigListReadContracts(t *testing.T) {
 		require.NoError(t, err)
 		readerClient := codersdk.NewExperimentalClient(readerClientRaw)
 
-		configs, err := readerClient.ListChatModelConfigs(ctx)
+		configs, err := readerClient.ChatModels(ctx, defaultOrg.ID)
 		require.NoError(t, err, "chat_model_config:read site role must not 500")
-		// A site-scoped read grant is deployment-wide, so the authorized
-		// filter admits both orgs' rows; the probe's contract is that the
-		// request uses the authorized list (no 500, own disabled visible).
-		require.True(t, contains(configs, ownDisabled.ID), "site reader must see own disabled config")
-
-		// The role holds only chat_model_config:read: it cannot read the
-		// other org as an organization, yet every union row must still
-		// carry its org display name (the label fetch is scoped to exactly
-		// the returned rows' orgs, not gated on org read).
-		require.True(t, contains(configs, otherEnabled.ID), "site reader sees the cross-org row via the authorized filter")
-		for _, c := range configs {
-			if c.ID == otherEnabled.ID {
-				require.Equal(t, otherOrg.DisplayName, c.OrganizationDisplayName,
-					"cross-org row must carry its org display name despite the caller lacking org read")
-			}
-		}
+		// The list is org-scoped; the probe's contract is that the request
+		// uses the authorized list (no 500, own disabled visible).
+		require.True(t, contains(configs.Models, ownDisabled.ID), "site reader must see own disabled config")
 	})
 }

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -326,7 +326,7 @@ func TestPostChats(t *testing.T) {
 		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
 
 		contextLimit := int64(4096)
-		modelConfig, err := client.CreateChatModelConfig(ctx, org.ID, codersdk.CreateChatModelConfigRequest{
+		modelConfig, err := client.CreateChatModel(ctx, org.ID, codersdk.CreateChatModelRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -1855,10 +1855,10 @@ func TestListChatModels(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 
-		models, err := client.ListChatModels(ctx)
+		models, err := client.ChatModelAvailability(ctx, firstUser.OrganizationID)
 		require.NoError(t, err)
 
 		var openAIProvider *codersdk.ChatModelProvider
@@ -1886,10 +1886,10 @@ func TestListChatModels(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		unauthenticatedClient := codersdk.NewExperimentalClient(codersdk.New(client.URL))
-		_, err := unauthenticatedClient.ListChatModels(ctx)
+		_, err := unauthenticatedClient.ChatModelAvailability(ctx, firstUser.OrganizationID)
 		requireSDKError(t, err, http.StatusUnauthorized)
 	})
 
@@ -1898,14 +1898,14 @@ func TestListChatModels(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		// Copilot is a valid AI Gateway provider but the Agents harness
 		// cannot use it. It must surface as an unsupported provider rather
 		// than vanish, so the empty state can explain why.
 		_ = createAIProviderForTest(t, client, string(codersdk.AIProviderTypeCopilot), "")
 
-		models, err := client.ListChatModels(ctx)
+		models, err := client.ChatModelAvailability(ctx, firstUser.OrganizationID)
 		require.NoError(t, err)
 
 		require.False(t, slices.ContainsFunc(models.Providers, func(p codersdk.ChatModelProvider) bool {
@@ -1925,10 +1925,10 @@ func TestListChatModels(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
-		models, err := client.ListChatModels(ctx)
+		models, err := client.ChatModelAvailability(ctx, firstUser.OrganizationID)
 		require.NoError(t, err)
 		require.Empty(t, models.UnsupportedProviders)
 	})
@@ -1938,10 +1938,10 @@ func TestListChatModels(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
-		models, err := client.ListChatModels(ctx)
+		models, err := client.ChatModelAvailability(ctx, firstUser.OrganizationID)
 		require.NoError(t, err)
 
 		var openAIProvider *codersdk.ChatModelProvider
@@ -1966,14 +1966,14 @@ func TestListChatModels(t *testing.T) {
 		provider := createAIProviderForTest(t, client, string(providerType), "")
 
 		contextLimit := int64(4096)
-		_, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+		_, err := client.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 			AIProviderID: &provider.ID,
 			Model:        "claude-sonnet",
 			ContextLimit: &contextLimit,
 		})
 		require.NoError(t, err)
 
-		models, err := client.ListChatModels(ctx)
+		models, err := client.ChatModelAvailability(ctx, firstUser.OrganizationID)
 		require.NoError(t, err)
 
 		var anthropicProvider *codersdk.ChatModelProvider
@@ -1992,7 +1992,7 @@ func TestListChatModels(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		models, err = client.ListChatModels(ctx)
+		models, err = client.ChatModelAvailability(ctx, firstUser.OrganizationID)
 		require.NoError(t, err)
 
 		anthropicProvider = nil
@@ -2016,14 +2016,14 @@ func TestListChatModels(t *testing.T) {
 		provider := createAIProviderForTest(t, client, "google", "provider-api-key")
 
 		contextLimit := int64(4096)
-		_, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+		_, err := client.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 			AIProviderID: &provider.ID,
 			Model:        "gemini-1.5-pro",
 			ContextLimit: &contextLimit,
 		})
 		require.NoError(t, err)
 
-		models, err := client.ListChatModels(ctx)
+		models, err := client.ChatModelAvailability(ctx, firstUser.OrganizationID)
 		require.NoError(t, err)
 
 		var googleProvider *codersdk.ChatModelProvider
@@ -2041,7 +2041,7 @@ func TestListChatModels(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		models, err = client.ListChatModels(ctx)
+		models, err = client.ChatModelAvailability(ctx, firstUser.OrganizationID)
 		require.NoError(t, err)
 
 		googleProvider = nil
@@ -2067,14 +2067,14 @@ func TestListChatModels(t *testing.T) {
 		provider := createAIProviderForTest(t, client, "openai", "test-key")
 
 		contextLimit := int64(4096)
-		_, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+		_, err := client.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 			AIProviderID: &provider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
 		})
 		require.NoError(t, err)
 
-		models, err := client.ListChatModels(ctx)
+		models, err := client.ChatModelAvailability(ctx, firstUser.OrganizationID)
 		require.NoError(t, err)
 		require.Len(t, models.Providers, 1)
 		require.Equal(t, "openai", models.Providers[0].Provider)
@@ -2087,7 +2087,7 @@ func TestListChatModels(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		models, err = client.ListChatModels(ctx)
+		models, err = client.ChatModelAvailability(ctx, firstUser.OrganizationID)
 		require.NoError(t, err)
 		require.Empty(t, models.Providers)
 	})
@@ -2096,7 +2096,7 @@ func TestListChatModels(t *testing.T) {
 func TestListChats_Search(t *testing.T) {
 	t.Parallel()
 
-	setup := func(t *testing.T) (context.Context, *codersdk.ExperimentalClient, database.Store, codersdk.CreateFirstUserResponse, codersdk.ChatModelConfig) {
+	setup := func(t *testing.T) (context.Context, *codersdk.ExperimentalClient, database.Store, codersdk.CreateFirstUserResponse, codersdk.ChatModel) {
 		t.Helper()
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client, db := newChatClientWithDatabase(t)
@@ -3863,12 +3863,12 @@ func TestListChatModelConfigs(t *testing.T) {
 		_ = coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 
-		configs, err := client.ListChatModelConfigs(ctx)
+		configs, err := client.ChatModels(ctx, modelConfig.OrganizationID)
 		require.NoError(t, err)
-		require.NotEmpty(t, configs)
+		require.NotEmpty(t, configs.Models)
 
 		found := false
-		for _, config := range configs {
+		for _, config := range configs.Models {
 			if config.ID == modelConfig.ID {
 				found = true
 				require.Equal(t, modelConfig.AIProviderID, config.AIProviderID)
@@ -3890,7 +3890,7 @@ func TestListChatModelConfigs(t *testing.T) {
 
 		contextLimit := int64(4096)
 		enabled := false
-		disabledConfig, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+		disabledConfig, err := client.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-disabled",
 			DisplayName:  "GPT-4o Disabled",
@@ -3900,11 +3900,11 @@ func TestListChatModelConfigs(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, disabledConfig.Enabled)
 
-		configs, err := client.ListChatModelConfigs(ctx)
+		configs, err := client.ChatModels(ctx, firstUser.OrganizationID)
 		require.NoError(t, err)
 
 		found := false
-		for _, config := range configs {
+		for _, config := range configs.Models {
 			if config.ID == disabledConfig.ID {
 				found = true
 				require.False(t, config.Enabled)
@@ -3914,7 +3914,7 @@ func TestListChatModelConfigs(t *testing.T) {
 		require.True(t, found)
 	})
 
-	// The union list is ACL-driven: every caller-readable config is
+	// The org-scoped list is ACL-driven: every caller-readable config is
 	// returned, including disabled rows. Use-time rejection is enforced
 	// when the chat is created, not at list time.
 	t.Run("NonAdminSeesDisabledModelConfigs", func(t *testing.T) {
@@ -3929,7 +3929,7 @@ func TestListChatModelConfigs(t *testing.T) {
 
 		contextLimit := int64(4096)
 		enabled := false
-		disabledConfig, err := adminClient.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+		disabledConfig, err := adminClient.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 			AIProviderID: &enabledConfig.AIProviderID,
 			Model:        "gpt-4o-disabled",
 			DisplayName:  "GPT-4o Disabled",
@@ -3938,12 +3938,12 @@ func TestListChatModelConfigs(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		configs, err := memberClient.ListChatModelConfigs(ctx)
+		configs, err := memberClient.ChatModels(ctx, firstUser.OrganizationID)
 		require.NoError(t, err)
-		require.Len(t, configs, 2)
+		require.Len(t, configs.Models, 2)
 
-		byID := make(map[uuid.UUID]codersdk.ChatModelConfig, len(configs))
-		for _, config := range configs {
+		byID := make(map[uuid.UUID]codersdk.ChatModel, len(configs.Models))
+		for _, config := range configs.Models {
 			byID[config.ID] = config
 		}
 		require.True(t, byID[enabledConfig.ID].Enabled)
@@ -3953,7 +3953,7 @@ func TestListChatModelConfigs(t *testing.T) {
 	})
 
 	// An enabled config under a disabled provider stays visible through
-	// the ACL-driven union list for admins and members alike; only
+	// the ACL-driven org-scoped list for admins and members alike; only
 	// use-time resolution treats the disabled provider as unusable.
 	t.Run("ProviderDisabledStillListedForMembers", func(t *testing.T) {
 		t.Parallel()
@@ -3971,18 +3971,18 @@ func TestListChatModelConfigs(t *testing.T) {
 		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
 		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
 
-		adminConfigs, err := adminClient.ListChatModelConfigs(ctx)
+		adminConfigs, err := adminClient.ChatModels(ctx, firstUser.OrganizationID)
 		require.NoError(t, err)
-		adminIDs := make([]uuid.UUID, 0, len(adminConfigs))
-		for _, config := range adminConfigs {
+		adminIDs := make([]uuid.UUID, 0, len(adminConfigs.Models))
+		for _, config := range adminConfigs.Models {
 			adminIDs = append(adminIDs, config.ID)
 		}
 		require.Contains(t, adminIDs, providerDisabledConfig.ID)
 
-		memberConfigs, err := memberClient.ListChatModelConfigs(ctx)
+		memberConfigs, err := memberClient.ChatModels(ctx, firstUser.OrganizationID)
 		require.NoError(t, err)
-		memberIDs := make([]uuid.UUID, 0, len(memberConfigs))
-		for _, config := range memberConfigs {
+		memberIDs := make([]uuid.UUID, 0, len(memberConfigs.Models))
+		for _, config := range memberConfigs.Models {
 			memberIDs = append(memberIDs, config.ID)
 		}
 		require.Contains(t, memberIDs, providerDisabledConfig.ID)
@@ -4009,11 +4009,11 @@ func TestListChatModelConfigs(t *testing.T) {
 			Options:              legacyOptions,
 		})
 
-		configs, err := client.ListChatModelConfigs(ctx)
+		configs, err := client.ChatModels(ctx, firstUser.OrganizationID)
 		require.NoError(t, err)
-		require.Len(t, configs, 1)
-		require.Equal(t, storedConfig.ID, configs[0].ID)
-		requireChatModelPricing(t, configs[0].ModelConfig, &codersdk.ChatModelCallConfig{
+		require.Len(t, configs.Models, 1)
+		require.Equal(t, storedConfig.ID, configs.Models[0].ID)
+		requireChatModelPricing(t, configs.Models[0].ModelConfig, &codersdk.ChatModelCallConfig{
 			Cost: &codersdk.ModelCostConfig{
 				InputPricePerMillionTokens:      decRef("0.15"),
 				OutputPricePerMillionTokens:     decRef("0.6"),
@@ -4034,12 +4034,12 @@ func TestListChatModelConfigs(t *testing.T) {
 		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
 
 		// Members see the configs their ACL admits (including disabled).
-		configs, err := memberClient.ListChatModelConfigs(ctx)
+		configs, err := memberClient.ChatModels(ctx, firstUser.OrganizationID)
 		require.NoError(t, err)
-		require.NotEmpty(t, configs)
+		require.NotEmpty(t, configs.Models)
 
 		found := false
-		for _, config := range configs {
+		for _, config := range configs.Models {
 			if config.ID == modelConfig.ID {
 				found = true
 				require.Equal(t, modelConfig.AIProviderID, config.AIProviderID)
@@ -4084,7 +4084,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				contextLimit := int64(4096)
-				_, err := memberClient.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+				_, err := memberClient.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 					AIProviderID: &tc.providerID,
 					Model:        "probe-" + tc.name,
 					ContextLimit: &contextLimit,
@@ -4114,7 +4114,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 				CacheWritePricePerMillionTokens: decRef("0.3"),
 			},
 		}
-		modelConfig, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+		modelConfig, err := client.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -4129,10 +4129,10 @@ func TestCreateChatModelConfig(t *testing.T) {
 		require.True(t, modelConfig.IsDefault)
 		requireChatModelPricing(t, modelConfig.ModelConfig, pricing)
 
-		configs, err := client.ListChatModelConfigs(ctx)
+		configs, err := client.ChatModels(ctx, firstUser.OrganizationID)
 		require.NoError(t, err)
-		require.Len(t, configs, 1)
-		requireChatModelPricing(t, configs[0].ModelConfig, pricing)
+		require.Len(t, configs.Models, 1)
+		requireChatModelPricing(t, configs.Models[0].ModelConfig, pricing)
 	})
 
 	t.Run("ConcurrentCreatesElectSingleDefault", func(t *testing.T) {
@@ -4149,11 +4149,11 @@ func TestCreateChatModelConfig(t *testing.T) {
 		// the losers 409 on the single-default unique index.
 		const creators = 10
 		contextLimit := int64(4096)
-		var claimed codersdk.ChatModelConfig
+		var claimed codersdk.ChatModel
 		var eg errgroup.Group
 		for i := range creators - 1 {
 			eg.Go(func() error {
-				_, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+				_, err := client.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 					AIProviderID: &aiProvider.ID,
 					Model:        fmt.Sprintf("gpt-4o-mini-%d", i),
 					ContextLimit: &contextLimit,
@@ -4162,7 +4162,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 			})
 		}
 		eg.Go(func() error {
-			created, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+			created, err := client.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 				AIProviderID: &aiProvider.ID,
 				Model:        "gpt-4o",
 				ContextLimit: &contextLimit,
@@ -4170,7 +4170,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 			if err != nil {
 				return xerrors.Errorf("create claimed config: %w", err)
 			}
-			claimed, err = client.UpdateChatModelConfig(ctx, created.ID, codersdk.UpdateChatModelConfigRequest{
+			claimed, err = client.UpdateChatModel(ctx, created.ID, codersdk.UpdateChatModelRequest{
 				IsDefault: ptr.Ref(true),
 			})
 			if err != nil {
@@ -4180,11 +4180,11 @@ func TestCreateChatModelConfig(t *testing.T) {
 		})
 		require.NoError(t, eg.Wait())
 
-		configs, err := client.ListChatModelConfigs(ctx)
+		configs, err := client.ChatModels(ctx, firstUser.OrganizationID)
 		require.NoError(t, err)
-		require.Len(t, configs, creators)
+		require.Len(t, configs.Models, creators)
 		var defaults []uuid.UUID
-		for _, cfg := range configs {
+		for _, cfg := range configs.Models {
 			if cfg.IsDefault {
 				defaults = append(defaults, cfg.ID)
 			}
@@ -4256,7 +4256,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 		adminClient := codersdk.NewExperimentalClient(adminClientRaw)
 
 		contextLimit := int64(4096)
-		modelConfig, err := adminClient.CreateChatModelConfig(ctx, defaultOrg.ID, codersdk.CreateChatModelConfigRequest{
+		modelConfig, err := adminClient.CreateChatModel(ctx, defaultOrg.ID, codersdk.CreateChatModelRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -4349,7 +4349,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 		// default-transition subtests below exercise demote/delete/promote
 		// against it.
 		contextLimit := int64(4096)
-		defaultConfig, err := writerClient.CreateChatModelConfig(ctx, defaultOrg.ID, codersdk.CreateChatModelConfigRequest{
+		defaultConfig, err := writerClient.CreateChatModel(ctx, defaultOrg.ID, codersdk.CreateChatModelRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -4357,7 +4357,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, defaultConfig.IsDefault, "first config in the org must self-elect as default")
 
-		updated, err := writerClient.UpdateChatModelConfig(ctx, defaultConfig.ID, codersdk.UpdateChatModelConfigRequest{
+		updated, err := writerClient.UpdateChatModel(ctx, defaultConfig.ID, codersdk.UpdateChatModelRequest{
 			DisplayName: "Window Write",
 		})
 		require.NoError(t, err)
@@ -4427,7 +4427,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 			// the election would instead reach the cross-org unpromotable
 			// candidate and roll back.
 			notDefault := false
-			_, err := writerClient.UpdateChatModelConfig(ctx, defaultConfig.ID, codersdk.UpdateChatModelConfigRequest{
+			_, err := writerClient.UpdateChatModel(ctx, defaultConfig.ID, codersdk.UpdateChatModelRequest{
 				IsDefault: &notDefault,
 			})
 			require.NoError(t, err, "demote-default commits when the election promotes the same-org candidate")
@@ -4448,7 +4448,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 			// the cross-org unpromotable candidate and roll back.
 			currentDefault, dbErr := rawDB.GetDefaultChatModelConfig(dbauthz.AsSystemRestricted(ctx), defaultOrg.ID)
 			require.NoError(t, dbErr)
-			err := writerClient.DeleteChatModelConfig(ctx, currentDefault.ID)
+			err := writerClient.DeleteChatModel(ctx, currentDefault.ID)
 			require.NoError(t, err, "delete-default commits when the election promotes the same-org candidate")
 			// Exactly one same-org config remains the default afterward.
 			newDefault, dbErr := rawDB.GetDefaultChatModelConfig(dbauthz.AsSystemRestricted(ctx), defaultOrg.ID)
@@ -4461,14 +4461,14 @@ func TestCreateChatModelConfig(t *testing.T) {
 			// Promoting a non-default config unsets the old default and
 			// sets the new one; both mutations are org-scoped updates the
 			// writer's role holds.
-			candidate, err := writerClient.CreateChatModelConfig(ctx, defaultOrg.ID, codersdk.CreateChatModelConfigRequest{
+			candidate, err := writerClient.CreateChatModel(ctx, defaultOrg.ID, codersdk.CreateChatModelRequest{
 				AIProviderID: &aiProvider.ID,
 				Model:        "gpt-4o-mini-promote",
 				ContextLimit: &contextLimit,
 			})
 			require.NoError(t, err)
 			isDefault := true
-			_, err = writerClient.UpdateChatModelConfig(ctx, candidate.ID, codersdk.UpdateChatModelConfigRequest{
+			_, err = writerClient.UpdateChatModel(ctx, candidate.ID, codersdk.UpdateChatModelRequest{
 				IsDefault: &isDefault,
 			})
 			require.NoError(t, err, "promote must succeed for a role holding chat_model_config update in the org")
@@ -4488,7 +4488,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 		aiProvider := createAIProviderForTest(t, client, "openai", "test-api-key")
 
 		contextLimit := int64(4096)
-		_, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+		_, err := client.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -4517,7 +4517,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 		aiProvider := createAIProviderForTest(t, client, "openai", "test-api-key")
 
 		contextLimit := int64(4096)
-		modelConfig, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+		modelConfig, err := client.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -4548,7 +4548,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 		aiProvider := createAIProviderForTest(t, client, "openai", "test-api-key")
 
 		contextLimit := int64(4096)
-		_, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+		_, err := client.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -4573,7 +4573,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 		aiProvider := createAIProviderForTest(t, client, "openai", "test-api-key")
 
 		contextLimit := int64(4096)
-		_, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+		_, err := client.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -4603,7 +4603,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 		aiProvider := createAIProviderForTest(t, client, "openai", "test-api-key")
 
 		contextLimit := int64(4096)
-		_, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+		_, err := client.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -4627,7 +4627,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 		aiProvider := createAIProviderForTest(t, client, "openai", "test-api-key")
 
-		_, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+		_, err := client.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-mini",
 		})
@@ -4643,7 +4643,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		contextLimit := int64(4096)
-		_, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+		_, err := client.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
 		})
@@ -4660,7 +4660,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 
 		contextLimit := int64(4096)
 		missingProviderID := uuid.New()
-		_, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+		_, err := client.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 			AIProviderID: &missingProviderID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -4684,7 +4684,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		contextLimit := int64(4096)
-		modelConfig, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+		modelConfig, err := client.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 			AIProviderID: &provider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -4703,7 +4703,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 
 		missingProviderID := uuid.New()
 		contextLimit := int64(4096)
-		_, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+		_, err := client.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 			AIProviderID: &missingProviderID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -4727,7 +4727,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		contextLimit := int64(4096)
-		_, err = client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+		_, err = client.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 			AIProviderID: &provider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -4753,7 +4753,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		contextLimit := int64(4096)
-		_, err = client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+		_, err = client.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "anthropic/claude-opus-4.6",
 			ContextLimit: &contextLimit,
@@ -4775,7 +4775,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 		aiProvider := createAIProviderForTest(t, adminClient, "openai", "test-api-key")
 
 		contextLimit := int64(4096)
-		_, err := memberClient.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+		_, err := memberClient.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -4808,7 +4808,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 				CacheWritePricePerMillionTokens: decRef("0.4"),
 			},
 		}
-		updated, err := client.UpdateChatModelConfig(ctx, modelConfig.ID, codersdk.UpdateChatModelConfigRequest{
+		updated, err := client.UpdateChatModel(ctx, modelConfig.ID, codersdk.UpdateChatModelRequest{
 			DisplayName:  "GPT-4o Mini Updated",
 			ContextLimit: &contextLimit,
 			ModelConfig:  pricing,
@@ -4819,10 +4819,10 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		require.EqualValues(t, 8192, updated.ContextLimit)
 		requireChatModelPricing(t, updated.ModelConfig, pricing)
 
-		configs, err := client.ListChatModelConfigs(ctx)
+		configs, err := client.ChatModels(ctx, modelConfig.OrganizationID)
 		require.NoError(t, err)
-		require.Len(t, configs, 1)
-		requireChatModelPricing(t, configs[0].ModelConfig, pricing)
+		require.Len(t, configs.Models, 1)
+		requireChatModelPricing(t, configs.Models[0].ModelConfig, pricing)
 	})
 
 	t.Run("UnchangedProviderWithoutAIProviderID", func(t *testing.T) {
@@ -4833,7 +4833,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		_ = coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 
-		updated, err := client.UpdateChatModelConfig(ctx, modelConfig.ID, codersdk.UpdateChatModelConfigRequest{
+		updated, err := client.UpdateChatModel(ctx, modelConfig.ID, codersdk.UpdateChatModelRequest{
 			Model: "gpt-4o-mini-updated",
 		})
 		require.NoError(t, err)
@@ -4860,14 +4860,14 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		contextLimit := int64(4096)
-		modelConfig, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+		modelConfig, err := client.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
 		})
 		require.NoError(t, err)
 
-		_, err = client.UpdateChatModelConfig(ctx, modelConfig.ID, codersdk.UpdateChatModelConfigRequest{
+		_, err = client.UpdateChatModel(ctx, modelConfig.ID, codersdk.UpdateChatModelRequest{
 			Model: "anthropic/claude-opus-4.6",
 		})
 		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
@@ -4896,7 +4896,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 			AIProviderID: uuid.NullUUID{UUID: aiProvider.ID, Valid: true},
 		})
 
-		updated, err := client.UpdateChatModelConfig(ctx, modelConfig.ID, codersdk.UpdateChatModelConfigRequest{
+		updated, err := client.UpdateChatModel(ctx, modelConfig.ID, codersdk.UpdateChatModelRequest{
 			DisplayName: "Existing OpenRouter Config",
 		})
 		require.NoError(t, err)
@@ -4929,14 +4929,14 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		contextLimit := int64(4096)
-		modelConfig, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+		modelConfig, err := client.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 			AIProviderID: &validProvider.ID,
 			Model:        "anthropic/claude-opus-4.6",
 			ContextLimit: &contextLimit,
 		})
 		require.NoError(t, err)
 
-		_, err = client.UpdateChatModelConfig(ctx, modelConfig.ID, codersdk.UpdateChatModelConfigRequest{
+		_, err = client.UpdateChatModel(ctx, modelConfig.ID, codersdk.UpdateChatModelRequest{
 			AIProviderID: &misconfiguredProvider.ID,
 		})
 		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
@@ -4945,7 +4945,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 	})
 
 	// Disabling preserves the record and keeps it visible through the
-	// ACL-driven union list, but using it for a new chat is rejected.
+	// ACL-driven org-scoped list, but using it for a new chat is rejected.
 	t.Run("DisablePreservesRecordAndRejectsUseForMembers", func(t *testing.T) {
 		t.Parallel()
 
@@ -4957,18 +4957,18 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		modelConfig := createChatModelConfig(t, adminClient)
 
 		enabled := false
-		updated, err := adminClient.UpdateChatModelConfig(ctx, modelConfig.ID, codersdk.UpdateChatModelConfigRequest{
+		updated, err := adminClient.UpdateChatModel(ctx, modelConfig.ID, codersdk.UpdateChatModelRequest{
 			Enabled: &enabled,
 		})
 		require.NoError(t, err)
 		require.Equal(t, modelConfig.ID, updated.ID)
 		require.False(t, updated.Enabled)
 
-		adminConfigs, err := adminClient.ListChatModelConfigs(ctx)
+		adminConfigs, err := adminClient.ChatModels(ctx, firstUser.OrganizationID)
 		require.NoError(t, err)
 
 		foundForAdmin := false
-		for _, config := range adminConfigs {
+		for _, config := range adminConfigs.Models {
 			if config.ID == modelConfig.ID {
 				foundForAdmin = true
 				require.False(t, config.Enabled)
@@ -4976,16 +4976,16 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		}
 		require.True(t, foundForAdmin)
 
-		memberConfigs, err := memberClient.ListChatModelConfigs(ctx)
+		memberConfigs, err := memberClient.ChatModels(ctx, firstUser.OrganizationID)
 		require.NoError(t, err)
 		foundForMember := false
-		for _, config := range memberConfigs {
+		for _, config := range memberConfigs.Models {
 			if config.ID == modelConfig.ID {
 				foundForMember = true
 				require.False(t, config.Enabled)
 			}
 		}
-		require.True(t, foundForMember, "disabled config stays visible through the union list")
+		require.True(t, foundForMember, "disabled config stays visible through the org-scoped list")
 
 		_, err = memberClient.CreateChat(ctx, codersdk.CreateChatRequest{
 			OrganizationID: firstUser.OrganizationID,
@@ -4999,7 +4999,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		require.Equal(t, "Invalid model_config_id: model config not found or disabled.", sdkErr.Message)
 	})
 
-	// The union list is ACL-driven, so the disabled config never leaves
+	// The org-scoped list is ACL-driven, so the disabled config never leaves
 	// the member's list; re-enabling flips the reported Enabled flag.
 	t.Run("ReEnableFlipsEnabledFlagForMembers", func(t *testing.T) {
 		t.Parallel()
@@ -5014,7 +5014,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 
 		contextLimit := int64(4096)
 		enabled := false
-		modelConfig, err := adminClient.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+		modelConfig, err := adminClient.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-reenable",
 			DisplayName:  "GPT-4o Re-enable",
@@ -5024,31 +5024,31 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, modelConfig.Enabled)
 
-		memberConfigs, err := memberClient.ListChatModelConfigs(ctx)
+		memberConfigs, err := memberClient.ChatModels(ctx, firstUser.OrganizationID)
 		require.NoError(t, err)
 
 		foundForMember := false
-		for _, config := range memberConfigs {
+		for _, config := range memberConfigs.Models {
 			if config.ID == modelConfig.ID {
 				foundForMember = true
 				require.False(t, config.Enabled)
 			}
 		}
-		require.True(t, foundForMember, "disabled config is visible through the union list")
+		require.True(t, foundForMember, "disabled config is visible through the org-scoped list")
 
 		enabled = true
-		updated, err := adminClient.UpdateChatModelConfig(ctx, modelConfig.ID, codersdk.UpdateChatModelConfigRequest{
+		updated, err := adminClient.UpdateChatModel(ctx, modelConfig.ID, codersdk.UpdateChatModelRequest{
 			Enabled: &enabled,
 		})
 		require.NoError(t, err)
 		require.Equal(t, modelConfig.ID, updated.ID)
 		require.True(t, updated.Enabled)
 
-		memberConfigs, err = memberClient.ListChatModelConfigs(ctx)
+		memberConfigs, err = memberClient.ChatModels(ctx, firstUser.OrganizationID)
 		require.NoError(t, err)
 
 		foundForMember = false
-		for _, config := range memberConfigs {
+		for _, config := range memberConfigs.Models {
 			if config.ID == modelConfig.ID {
 				foundForMember = true
 				require.True(t, config.Enabled)
@@ -5065,7 +5065,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		_ = coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 
-		_, err := client.UpdateChatModelConfig(ctx, modelConfig.ID, codersdk.UpdateChatModelConfigRequest{
+		_, err := client.UpdateChatModel(ctx, modelConfig.ID, codersdk.UpdateChatModelRequest{
 			ModelConfig: &codersdk.ChatModelCallConfig{
 				Cost: &codersdk.ModelCostConfig{
 					OutputPricePerMillionTokens: decRef("-1.0"),
@@ -5096,7 +5096,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		updated, err := client.UpdateChatModelConfig(ctx, modelConfig.ID, codersdk.UpdateChatModelConfigRequest{
+		updated, err := client.UpdateChatModel(ctx, modelConfig.ID, codersdk.UpdateChatModelRequest{
 			AIProviderID: &provider.ID,
 			Model:        "claude-3-5-sonnet-latest",
 		})
@@ -5120,14 +5120,14 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		updated, err := client.UpdateChatModelConfig(ctx, modelConfig.ID, codersdk.UpdateChatModelConfigRequest{
+		updated, err := client.UpdateChatModel(ctx, modelConfig.ID, codersdk.UpdateChatModelRequest{
 			AIProviderID: &provider.ID,
 			Model:        "claude-3-5-sonnet-latest",
 		})
 		require.NoError(t, err)
 		require.NotEqual(t, uuid.Nil, updated.AIProviderID)
 
-		updated, err = client.UpdateChatModelConfig(ctx, modelConfig.ID, codersdk.UpdateChatModelConfigRequest{
+		updated, err = client.UpdateChatModel(ctx, modelConfig.ID, codersdk.UpdateChatModelRequest{
 			Model: "claude-3-5-haiku-latest",
 		})
 		require.NoError(t, err)
@@ -5144,7 +5144,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		modelConfig := createChatModelConfig(t, client)
 
 		missingProviderID := uuid.New()
-		_, err := client.UpdateChatModelConfig(ctx, modelConfig.ID, codersdk.UpdateChatModelConfigRequest{
+		_, err := client.UpdateChatModel(ctx, modelConfig.ID, codersdk.UpdateChatModelRequest{
 			AIProviderID: &missingProviderID,
 		})
 		sdkErr := requireSDKError(t, err, http.StatusPreconditionFailed)
@@ -5166,7 +5166,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, err = client.UpdateChatModelConfig(ctx, modelConfig.ID, codersdk.UpdateChatModelConfigRequest{
+		_, err = client.UpdateChatModel(ctx, modelConfig.ID, codersdk.UpdateChatModelRequest{
 			AIProviderID: &provider.ID,
 		})
 		sdkErr := requireSDKError(t, err, http.StatusPreconditionFailed)
@@ -5182,7 +5182,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		modelConfig := createChatModelConfig(t, client)
 
 		missingProviderID := uuid.New()
-		_, err := client.UpdateChatModelConfig(ctx, modelConfig.ID, codersdk.UpdateChatModelConfigRequest{
+		_, err := client.UpdateChatModel(ctx, modelConfig.ID, codersdk.UpdateChatModelRequest{
 			AIProviderID: &missingProviderID,
 		})
 		sdkErr := requireSDKError(t, err, http.StatusPreconditionFailed)
@@ -5208,7 +5208,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		store.failNextUpdateChatModelConfigID = modelConfig.ID
 		store.failNextUpdateChatModelConfig.Store(true)
 
-		_, err := client.UpdateChatModelConfig(ctx, modelConfig.ID, codersdk.UpdateChatModelConfigRequest{
+		_, err := client.UpdateChatModel(ctx, modelConfig.ID, codersdk.UpdateChatModelRequest{
 			DisplayName: "missing in tx",
 		})
 		requireSDKError(t, err, http.StatusNotFound)
@@ -5234,7 +5234,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 
 		contextLimit := int64(4096)
 		isDefault := false
-		candidateConfig, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+		candidateConfig, err := client.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "claude-3-5-sonnet",
 			ContextLimit: &contextLimit,
@@ -5245,7 +5245,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		store.failNextUpdateChatModelConfigID = candidateConfig.ID
 		store.failNextUpdateChatModelConfig.Store(true)
 
-		_, err = client.UpdateChatModelConfig(ctx, defaultConfig.ID, codersdk.UpdateChatModelConfigRequest{
+		_, err = client.UpdateChatModel(ctx, defaultConfig.ID, codersdk.UpdateChatModelRequest{
 			IsDefault: ptr.Ref(false),
 		})
 		sdkErr := requireSDKError(t, err, http.StatusInternalServerError)
@@ -5259,7 +5259,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		client := newChatClient(t)
 		_ = coderdtest.CreateFirstUser(t, client.Client)
 
-		_, err := client.UpdateChatModelConfig(ctx, uuid.New(), codersdk.UpdateChatModelConfigRequest{
+		_, err := client.UpdateChatModel(ctx, uuid.New(), codersdk.UpdateChatModelRequest{
 			DisplayName: "missing",
 		})
 		requireSDKError(t, err, http.StatusNotFound)
@@ -5274,7 +5274,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		modelConfig := createChatModelConfig(t, client)
 
 		contextLimit := int64(0)
-		_, err := client.UpdateChatModelConfig(ctx, modelConfig.ID, codersdk.UpdateChatModelConfigRequest{
+		_, err := client.UpdateChatModel(ctx, modelConfig.ID, codersdk.UpdateChatModelRequest{
 			ContextLimit: &contextLimit,
 		})
 		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
@@ -5292,7 +5292,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 			ctx,
 			http.MethodPatch,
 			"/api/experimental/chat-model-configs/not-a-uuid",
-			codersdk.UpdateChatModelConfigRequest{DisplayName: "ignored"},
+			codersdk.UpdateChatModelRequest{DisplayName: "ignored"},
 		)
 		require.NoError(t, err)
 		defer res.Body.Close()
@@ -5312,7 +5312,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
 
 		modelConfig := createChatModelConfig(t, adminClient)
-		_, err := memberClient.UpdateChatModelConfig(ctx, modelConfig.ID, codersdk.UpdateChatModelConfigRequest{
+		_, err := memberClient.UpdateChatModel(ctx, modelConfig.ID, codersdk.UpdateChatModelRequest{
 			DisplayName: "member update",
 		})
 		// A plain org member holds no chat model config update grant in
@@ -5334,12 +5334,12 @@ func TestDeleteChatModelConfig(t *testing.T) {
 		_ = coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 
-		err := client.DeleteChatModelConfig(ctx, modelConfig.ID)
+		err := client.DeleteChatModel(ctx, modelConfig.ID)
 		require.NoError(t, err)
 
-		configs, err := client.ListChatModelConfigs(ctx)
+		configs, err := client.ChatModels(ctx, modelConfig.OrganizationID)
 		require.NoError(t, err)
-		for _, config := range configs {
+		for _, config := range configs.Models {
 			require.NotEqual(t, modelConfig.ID, config.ID)
 		}
 	})
@@ -5370,13 +5370,13 @@ func TestDeleteChatModelConfig(t *testing.T) {
 			"z-enabled-model",
 		)
 
-		err := client.DeleteChatModelConfig(ctx, defaultConfig.ID)
+		err := client.DeleteChatModel(ctx, defaultConfig.ID)
 		require.NoError(t, err)
 
-		configs, err := client.ListChatModelConfigs(ctx)
+		configs, err := client.ChatModels(ctx, defaultConfig.OrganizationID)
 		require.NoError(t, err)
 		defaultID := uuid.Nil
-		for _, config := range configs {
+		for _, config := range configs.Models {
 			if config.IsDefault {
 				defaultID = config.ID
 			}
@@ -5391,7 +5391,7 @@ func TestDeleteChatModelConfig(t *testing.T) {
 		client := newChatClient(t)
 		_ = coderdtest.CreateFirstUser(t, client.Client)
 
-		err := client.DeleteChatModelConfig(ctx, uuid.New())
+		err := client.DeleteChatModel(ctx, uuid.New())
 		requireSDKError(t, err, http.StatusNotFound)
 	})
 
@@ -5426,7 +5426,7 @@ func TestDeleteChatModelConfig(t *testing.T) {
 		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
 
 		modelConfig := createChatModelConfig(t, adminClient)
-		err := memberClient.DeleteChatModelConfig(ctx, modelConfig.ID)
+		err := memberClient.DeleteChatModel(ctx, modelConfig.ID)
 		// A plain org member holds no chat model config delete grant in
 		// the org, so the write is rejected by the object pre-check before
 		// the transaction.
@@ -12014,7 +12014,7 @@ func TestChatCostSummary_AfterModelDeletion(t *testing.T) {
 	assertChatCostSummary(t, summary, f.ModelConfigID, f.ChatID)
 
 	// Soft-delete the model config.
-	err = f.Client.DeleteChatModelConfig(ctx, f.ModelConfigID)
+	err = f.Client.DeleteChatModel(ctx, f.ModelConfigID)
 	require.NoError(t, err)
 
 	// Costs must survive the deletion unchanged within the same safe window.
@@ -12742,7 +12742,7 @@ func seedPasteOnlyTitleSourceMessage(
 func createTitleGenerationModelConfig(
 	t *testing.T,
 	client *codersdk.ExperimentalClient,
-) codersdk.ChatModelConfig {
+) codersdk.ChatModel {
 	t.Helper()
 	return createAdditionalChatModelConfig(t, client, "openai", "gpt-4.1")
 }
@@ -12779,12 +12779,12 @@ func seedChatWithDeletedModelConfig(
 	return chat
 }
 
-func createChatModelConfig(t testing.TB, client *codersdk.ExperimentalClient) codersdk.ChatModelConfig {
+func createChatModelConfig(t testing.TB, client *codersdk.ExperimentalClient) codersdk.ChatModel {
 	t.Helper()
 	return coderdtest.CreateOpenAICompatChatModelConfig(t, client, "")
 }
 
-func createChatModelConfigWithBaseURL(t testing.TB, client *codersdk.ExperimentalClient, baseURL string) codersdk.ChatModelConfig {
+func createChatModelConfigWithBaseURL(t testing.TB, client *codersdk.ExperimentalClient, baseURL string) codersdk.ChatModel {
 	t.Helper()
 	return coderdtest.CreateOpenAICompatChatModelConfig(t, client, baseURL)
 }
@@ -12793,7 +12793,7 @@ func createChatModelConfigWithBaseURL(t testing.TB, client *codersdk.Experimenta
 // responses succeed, while non-streaming requests fail. The non-streaming path
 // is how quick title generation requests structured output, so tests can fail
 // title generation without breaking the main assistant response.
-func createChatModelConfigWithTitleFailure(t testing.TB, client *codersdk.ExperimentalClient) codersdk.ChatModelConfig {
+func createChatModelConfigWithTitleFailure(t testing.TB, client *codersdk.ExperimentalClient) codersdk.ChatModel {
 	t.Helper()
 	baseURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
 		if req.Stream {
@@ -12809,7 +12809,7 @@ func createAdditionalChatModelConfig(
 	client *codersdk.ExperimentalClient,
 	provider string,
 	model string,
-) codersdk.ChatModelConfig {
+) codersdk.ChatModel {
 	t.Helper()
 	return createAdditionalChatModelConfigWithModelConfig(t, client, provider, model, nil)
 }
@@ -12821,7 +12821,7 @@ func createAdditionalChatModelConfigWithReasoningEffort(
 	model string,
 	defaultEffort string,
 	maxEffort string,
-) codersdk.ChatModelConfig {
+) codersdk.ChatModel {
 	t.Helper()
 	return createAdditionalChatModelConfigWithModelConfig(t, client, provider, model, &codersdk.ChatModelCallConfig{
 		ReasoningEffort: &codersdk.ChatModelReasoningEffortConfig{
@@ -12837,7 +12837,7 @@ func createAdditionalChatModelConfigWithModelConfig(
 	provider string,
 	model string,
 	modelCallConfig *codersdk.ChatModelCallConfig,
-) codersdk.ChatModelConfig {
+) codersdk.ChatModel {
 	t.Helper()
 
 	ctx := testutil.Context(t, testutil.WaitLong)
@@ -12846,7 +12846,7 @@ func createAdditionalChatModelConfigWithModelConfig(
 	isDefault := false
 	defaultOrg, err := client.Client.OrganizationByName(ctx, codersdk.DefaultOrganization)
 	require.NoError(t, err)
-	modelConfig, err := client.CreateChatModelConfig(ctx, defaultOrg.ID, codersdk.CreateChatModelConfigRequest{
+	modelConfig, err := client.CreateChatModel(ctx, defaultOrg.ID, codersdk.CreateChatModelRequest{
 		AIProviderID: &aiProvider.ID,
 		ContextLimit: &contextLimit,
 		Model:        model,
@@ -12862,12 +12862,12 @@ func createDisabledChatModelConfig(
 	client *codersdk.ExperimentalClient,
 	provider string,
 	model string,
-) codersdk.ChatModelConfig {
+) codersdk.ChatModel {
 	t.Helper()
 
 	modelConfig := createAdditionalChatModelConfig(t, client, provider, model)
 	ctx := testutil.Context(t, testutil.WaitLong)
-	updated, err := client.UpdateChatModelConfig(ctx, modelConfig.ID, codersdk.UpdateChatModelConfigRequest{
+	updated, err := client.UpdateChatModel(ctx, modelConfig.ID, codersdk.UpdateChatModelRequest{
 		Enabled: ptr.Ref(false),
 	})
 	require.NoError(t, err)
@@ -12881,7 +12881,7 @@ func createProviderDisabledChatModelConfig(
 	client *codersdk.ExperimentalClient,
 	provider string,
 	model string,
-) codersdk.ChatModelConfig {
+) codersdk.ChatModel {
 	t.Helper()
 
 	modelConfig := createAdditionalChatModelConfig(t, client, provider, model)
@@ -13849,12 +13849,12 @@ func TestUserChatPersonalModelOverrides(t *testing.T) {
 	})
 	require.NoError(t, err)
 	contextLimit := int64(4096)
-	modelConfigRequest := codersdk.CreateChatModelConfigRequest{
+	modelConfigRequest := codersdk.CreateChatModelRequest{
 		AIProviderID: &modelProvider.ID,
 		Model:        "claude-personal-" + uuid.NewString(),
 		ContextLimit: &contextLimit,
 	}
-	modelConfig, err := adminClient.CreateChatModelConfig(ctx, firstUser.OrganizationID, modelConfigRequest)
+	modelConfig, err := adminClient.CreateChatModel(ctx, firstUser.OrganizationID, modelConfigRequest)
 	require.NoError(t, err)
 	modelConfigRequest.Model = "claude-personal-reasoning-" + uuid.NewString()
 	modelConfigRequest.ModelConfig = &codersdk.ChatModelCallConfig{
@@ -13863,7 +13863,7 @@ func TestUserChatPersonalModelOverrides(t *testing.T) {
 			Max:     ptr.Ref("high"),
 		},
 	}
-	reasoningModelConfig, err := adminClient.CreateChatModelConfig(ctx, firstUser.OrganizationID, modelConfigRequest)
+	reasoningModelConfig, err := adminClient.CreateChatModel(ctx, firstUser.OrganizationID, modelConfigRequest)
 	require.NoError(t, err)
 	err = adminClient.UpdateChatModelOverride(ctx, codersdk.ChatModelOverrideContextGeneral, codersdk.UpdateChatModelOverrideRequest{
 		ModelConfigID: modelConfig.ID.String(),
@@ -13881,7 +13881,7 @@ func TestUserChatPersonalModelOverrides(t *testing.T) {
 		"gpt-4o-personal-disabled-"+uuid.NewString(),
 	)
 	disabledProvider := createAIProviderForTest(t, adminClient, "google", "test-api-key")
-	disabledProviderModelConfig, err := adminClient.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+	disabledProviderModelConfig, err := adminClient.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 		AIProviderID: &disabledProvider.ID,
 		Model:        "gemini-personal-disabled-provider-" + uuid.NewString(),
 		ContextLimit: &contextLimit,
@@ -14303,7 +14303,7 @@ func TestCreateChatPersonalModelOverrideRoot(t *testing.T) {
 	})
 	require.NoError(t, err)
 	contextLimit := int64(4096)
-	overrideModel, err := adminClient.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+	overrideModel, err := adminClient.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 		AIProviderID: &overrideProvider.ID,
 		Model:        "claude-root-personal-" + uuid.NewString(),
 		ContextLimit: &contextLimit,
@@ -14410,7 +14410,7 @@ func TestCreateChatPersonalModelOverrideRoot(t *testing.T) {
 	})
 
 	t.Run("RootModelOverrideUsesSavedReasoningEffort", func(t *testing.T) {
-		reasoningModel, err := adminClient.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+		reasoningModel, err := adminClient.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 			AIProviderID: &overrideProvider.ID,
 			Model:        "claude-root-personal-reasoning-" + uuid.NewString(),
 			ContextLimit: &contextLimit,

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -302,20 +302,37 @@ func insertAssistantCostMessage(
 func TestPostChats(t *testing.T) {
 	t.Parallel()
 
-	t.Run("SuccessNonDefaultOrgUsesDeploymentDefault", func(t *testing.T) {
+	t.Run("SuccessNonDefaultOrgUsesOrgDefault", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client, db := newChatClientWithDatabase(t)
 		_ = coderdtest.CreateFirstUser(t, client.Client)
-		modelConfig := createChatModelConfig(t, client)
+		aiProvider := createAIProviderForTest(t, client, "openai-compat", "test-api-key")
 
 		// A member of a non-default org cannot read the default
-		// organization object, but omitting model_config_id must still
-		// resolve the deployment default while every config lives there.
+		// organization object; omitting model_config_id resolves the
+		// default inside the chat's own org, never the default org's.
 		org := dbgen.Organization(t, db, database.Organization{IsDefault: false})
+		// The org's Everyone group shares the org ID (migration 000058);
+		// dbgen.Organization does not seed it, and the config's
+		// everyone-read ACL resolves through that group.
+		dbgen.Group(t, db, database.Group{
+			ID:             org.ID,
+			Name:           database.EveryoneGroup,
+			OrganizationID: org.ID,
+		})
 		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, client.Client, org.ID, rbac.ScopedRoleAgentsAccess(org.ID))
 		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
+
+		contextLimit := int64(4096)
+		modelConfig, err := client.CreateChatModelConfig(ctx, org.ID, codersdk.CreateChatModelConfigRequest{
+			AIProviderID: &aiProvider.ID,
+			Model:        "gpt-4o-mini",
+			ContextLimit: &contextLimit,
+		})
+		require.NoError(t, err)
+		require.True(t, modelConfig.IsDefault, "first config in the org must self-elect as default")
 
 		chat, err := memberClient.CreateChat(ctx, codersdk.CreateChatRequest{
 			OrganizationID: org.ID,
@@ -580,6 +597,46 @@ func TestPostChats(t *testing.T) {
 		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
 		require.Equal(t, "No default chat model config is configured.", sdkErr.Message)
 		require.Equal(t, "The default chat model or its provider is disabled.", sdkErr.Detail)
+	})
+
+	t.Run("DeniedDefaultModelResolvesAsBadRequest", func(t *testing.T) {
+		t.Parallel()
+
+		// A member denied read on the org default (ACL restriction) must get
+		// the same 400 "no default model" response as a missing default, not
+		// a 500: the dbauthz object read returns a denial that does not
+		// unwrap to sql.ErrNoRows, so the resolver's miss branch must match
+		// denials via httpapi.Is404Error.
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client, db := newChatClientWithDatabase(t)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
+
+		aiProvider := createAIProviderForTest(t, client, "openai", "test-api-key")
+		// Seed the org default with an EMPTY group_acl: the everyone-in-org
+		// entry is absent, so the member below has no ACL read path and the
+		// dbauthz object read denies them.
+		_ = dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
+			AIProviderID:         uuid.NullUUID{UUID: aiProvider.ID, Valid: true},
+			Model:                "gpt-4o-denied-default",
+			IsDefault:            true,
+			ContextLimit:         4096,
+			CompressionThreshold: 80,
+			OrganizationID:       firstUser.OrganizationID,
+			GroupACL:             database.ChatACL{},
+		})
+
+		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, client.Client, firstUser.OrganizationID, rbac.ScopedRoleAgentsAccess(firstUser.OrganizationID))
+		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
+
+		_, err := memberClient.CreateChat(ctx, codersdk.CreateChatRequest{
+			OrganizationID: firstUser.OrganizationID,
+			Content: []codersdk.ChatInputPart{{
+				Type: codersdk.ChatInputPartTypeText,
+				Text: "hello",
+			}},
+		})
+		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+		require.Equal(t, "No default chat model config is configured.", sdkErr.Message)
 	})
 
 	t.Run("WithPerChatSystemPrompt", func(t *testing.T) {
@@ -1903,13 +1960,13 @@ func TestListChatModels(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		providerType := database.AIProviderTypeAnthropic
 		provider := createAIProviderForTest(t, client, string(providerType), "")
 
 		contextLimit := int64(4096)
-		_, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		_, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 			AIProviderID: &provider.ID,
 			Model:        "claude-sonnet",
 			ContextLimit: &contextLimit,
@@ -1954,12 +2011,12 @@ func TestListChatModels(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		provider := createAIProviderForTest(t, client, "google", "provider-api-key")
 
 		contextLimit := int64(4096)
-		_, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		_, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 			AIProviderID: &provider.ID,
 			Model:        "gemini-1.5-pro",
 			ContextLimit: &contextLimit,
@@ -2005,12 +2062,12 @@ func TestListChatModels(t *testing.T) {
 		values := coderdtest.DeploymentValues(t)
 		values.AI.BridgeConfig.LegacyOpenAI.Key = serpent.String("deployment-openai-key")
 		client := newChatClientWithDeploymentValues(t, values)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		provider := createAIProviderForTest(t, client, "openai", "test-key")
 
 		contextLimit := int64(4096)
-		_, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		_, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 			AIProviderID: &provider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -3827,13 +3884,13 @@ func TestListChatModelConfigs(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		aiProvider := createAIProviderForTest(t, client, "openai", "test-api-key")
 
 		contextLimit := int64(4096)
 		enabled := false
-		disabledConfig, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		disabledConfig, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-disabled",
 			DisplayName:  "GPT-4o Disabled",
@@ -3857,7 +3914,10 @@ func TestListChatModelConfigs(t *testing.T) {
 		require.True(t, found)
 	})
 
-	t.Run("NonAdminExcludesDisabledModelConfigs", func(t *testing.T) {
+	// The union list is ACL-driven: every caller-readable config is
+	// returned, including disabled rows. Use-time rejection is enforced
+	// when the chat is created, not at list time.
+	t.Run("NonAdminSeesDisabledModelConfigs", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitLong)
@@ -3869,7 +3929,7 @@ func TestListChatModelConfigs(t *testing.T) {
 
 		contextLimit := int64(4096)
 		enabled := false
-		_, err := adminClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		disabledConfig, err := adminClient.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 			AIProviderID: &enabledConfig.AIProviderID,
 			Model:        "gpt-4o-disabled",
 			DisplayName:  "GPT-4o Disabled",
@@ -3880,21 +3940,28 @@ func TestListChatModelConfigs(t *testing.T) {
 
 		configs, err := memberClient.ListChatModelConfigs(ctx)
 		require.NoError(t, err)
-		require.Len(t, configs, 1)
-		require.Equal(t, enabledConfig.ID, configs[0].ID)
-		require.True(t, configs[0].Enabled)
+		require.Len(t, configs, 2)
+
+		byID := make(map[uuid.UUID]codersdk.ChatModelConfig, len(configs))
+		for _, config := range configs {
+			byID[config.ID] = config
+		}
+		require.True(t, byID[enabledConfig.ID].Enabled)
+		require.Contains(t, byID, disabledConfig.ID)
+		require.False(t, byID[disabledConfig.ID].Enabled)
+		require.Equal(t, "GPT-4o Disabled", byID[disabledConfig.ID].DisplayName)
 	})
 
-	// An enabled config under a disabled provider must stay visible to
-	// admins (management view) while being hidden from non-admins (usage
-	// view).
-	t.Run("ProviderDisabled", func(t *testing.T) {
+	// An enabled config under a disabled provider stays visible through
+	// the ACL-driven union list for admins and members alike; only
+	// use-time resolution treats the disabled provider as unusable.
+	t.Run("ProviderDisabledStillListedForMembers", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		adminClient := newChatClient(t)
 		firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
-		enabledConfig := createChatModelConfig(t, adminClient)
+		_ = createChatModelConfig(t, adminClient)
 		providerDisabledConfig := createProviderDisabledChatModelConfig(
 			t,
 			adminClient,
@@ -3914,8 +3981,11 @@ func TestListChatModelConfigs(t *testing.T) {
 
 		memberConfigs, err := memberClient.ListChatModelConfigs(ctx)
 		require.NoError(t, err)
-		require.Len(t, memberConfigs, 1)
-		require.Equal(t, enabledConfig.ID, memberConfigs[0].ID)
+		memberIDs := make([]uuid.UUID, 0, len(memberConfigs))
+		for _, config := range memberConfigs {
+			memberIDs = append(memberIDs, config.ID)
+		}
+		require.Contains(t, memberIDs, providerDisabledConfig.ID)
 	})
 
 	t.Run("DeserializesLegacyPricingJSON", func(t *testing.T) {
@@ -3963,7 +4033,7 @@ func TestListChatModelConfigs(t *testing.T) {
 		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
 		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
 
-		// Non-admin users should see only enabled model configs.
+		// Members see the configs their ACL admits (including disabled).
 		configs, err := memberClient.ListChatModelConfigs(ctx)
 		require.NoError(t, err)
 		require.NotEmpty(t, configs)
@@ -3983,12 +4053,54 @@ func TestListChatModelConfigs(t *testing.T) {
 func TestCreateChatModelConfig(t *testing.T) {
 	t.Parallel()
 
+	t.Run("UnauthorizedPrincipalCannotProbeProviderState", func(t *testing.T) {
+		t.Parallel()
+
+		// The write is authorized before any privileged provider lookup, so
+		// a principal without create-in-org gets an identical denial whether
+		// the provider ID is missing, disabled, or configured: no provider
+		// state is disclosed.
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newChatClient(t)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
+		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, client.Client, firstUser.OrganizationID)
+		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
+
+		configuredProvider := createAIProviderForTest(t, client, "openai", "test-api-key")
+		disabledProvider := createAIProviderForTest(t, client, "google", "test-api-key-2")
+		enabled := false
+		_, err := client.UpdateAIProvider(ctx, disabledProvider.ID.String(), codersdk.UpdateAIProviderRequest{
+			Enabled: &enabled,
+		})
+		require.NoError(t, err)
+
+		for _, tc := range []struct {
+			name       string
+			providerID uuid.UUID
+		}{
+			{"missing", uuid.New()},
+			{"disabled", disabledProvider.ID},
+			{"configured", configuredProvider.ID},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				contextLimit := int64(4096)
+				_, err := memberClient.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+					AIProviderID: &tc.providerID,
+					Model:        "probe-" + tc.name,
+					ContextLimit: &contextLimit,
+				})
+				sdkErr := requireSDKError(t, err, http.StatusForbidden)
+				require.Equal(t, "Forbidden.", sdkErr.Message)
+			})
+		}
+	})
+
 	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		aiProvider := createAIProviderForTest(t, client, "openai", "test-api-key")
 
@@ -4002,7 +4114,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 				CacheWritePricePerMillionTokens: decRef("0.3"),
 			},
 		}
-		modelConfig, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		modelConfig, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -4028,7 +4140,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		aiProvider := createAIProviderForTest(t, client, "openai", "test-api-key")
 
@@ -4041,7 +4153,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 		var eg errgroup.Group
 		for i := range creators - 1 {
 			eg.Go(func() error {
-				_, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+				_, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 					AIProviderID: &aiProvider.ID,
 					Model:        fmt.Sprintf("gpt-4o-mini-%d", i),
 					ContextLimit: &contextLimit,
@@ -4050,7 +4162,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 			})
 		}
 		eg.Go(func() error {
-			created, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+			created, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 				AIProviderID: &aiProvider.ID,
 				Model:        "gpt-4o",
 				ContextLimit: &contextLimit,
@@ -4080,60 +4192,63 @@ func TestCreateChatModelConfig(t *testing.T) {
 		require.Equal(t, []uuid.UUID{claimed.ID}, defaults)
 	})
 
-	t.Run("SuccessCustomDeploymentConfigRole", func(t *testing.T) {
+	t.Run("SuccessCustomOrgRole", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		// dbauthz rejects site-permission roles on the authorized
 		// querier; seed the role through the raw store, as persisted
-		// site custom roles exist in production deployments.
+		// org custom roles exist in production deployments.
 		rawDB, pubsub := dbtestutil.NewDB(t)
 		client := newChatClient(t, func(opts *coderdtest.Options) {
 			opts.Database = rawDB
 			opts.Pubsub = pubsub
 		})
 		_ = coderdtest.CreateFirstUser(t, client.Client)
-		nonDefaultOrg := dbgen.Organization(t, rawDB, database.Organization{IsDefault: false})
+		defaultOrg, err := rawDB.GetDefaultOrganization(ctx)
+		require.NoError(t, err)
 
-		// A custom site role holding only deployment-config permissions
-		// passes the route gate but cannot read the default organization
-		// object; the default-org resolution is an internal step and must
-		// not require caller-held organization read. The owning org is a
-		// label on the role; the site permissions apply deployment-wide.
+		// A custom org role holding only chat_model_config permissions
+		// passes write authorization for configs in its org and holds no
+		// grant anywhere else; org role permissions are scoped to the
+		// organization the role belongs to.
 		role, err := rawDB.InsertCustomRole(ctx, database.InsertCustomRoleParams{
 			Name:           testutil.GetRandomName(t),
-			DisplayName:    "Deployment Config Admin",
-			OrganizationID: uuid.NullUUID{UUID: nonDefaultOrg.ID, Valid: true},
-			SitePermissions: database.CustomRolePermissions{
+			DisplayName:    "Chat Model Config Admin",
+			OrganizationID: uuid.NullUUID{UUID: defaultOrg.ID, Valid: true},
+			OrgPermissions: database.CustomRolePermissions{
 				{
-					ResourceType: rbac.ResourceDeploymentConfig.Type,
+					ResourceType: rbac.ResourceChatModelConfig.Type,
+					Action:       policy.ActionCreate,
+				},
+				{
+					ResourceType: rbac.ResourceChatModelConfig.Type,
 					Action:       policy.ActionRead,
 				},
 				{
-					ResourceType: rbac.ResourceDeploymentConfig.Type,
+					ResourceType: rbac.ResourceChatModelConfig.Type,
 					Action:       policy.ActionUpdate,
 				},
 			},
 		})
 		require.NoError(t, err)
 
+		// An existing org default keeps the create off the self-promotion
+		// path; the writer below holds no chat_model_config:update grant
+		// beyond its own org. The owner seeds the provider and the
+		// default: both operations need site-wide permissions a
+		// non-owner lacks.
 		aiProvider := createAIProviderForTest(t, client, "openai", "test-api-key")
-		// An existing deployment default keeps the create off the
-		// self-promotion path, which is a separate system-scoped
-		// authorization requirement.
-		_ = createChatModelConfig(t, client)
+		_ = createAdditionalChatModelConfig(t, client, "openai", "gpt-4o-existing")
 
-		// A member of a non-default org cannot read the default
-		// organization object; the implicit organization-member role
-		// grants organization read only within its own org.
 		adminClientRaw, adminUser := coderdtest.CreateAnotherUser(
 			t,
 			client.Client,
-			nonDefaultOrg.ID,
+			defaultOrg.ID,
 		)
 		_, err = client.Client.UpdateOrganizationMemberRoles(
 			ctx,
-			nonDefaultOrg.ID,
+			defaultOrg.ID,
 			adminUser.ID.String(),
 			codersdk.UpdateRoles{Roles: []string{role.Name}},
 		)
@@ -4141,15 +4256,13 @@ func TestCreateChatModelConfig(t *testing.T) {
 		adminClient := codersdk.NewExperimentalClient(adminClientRaw)
 
 		contextLimit := int64(4096)
-		modelConfig, err := adminClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		modelConfig, err := adminClient.CreateChatModelConfig(ctx, defaultOrg.ID, codersdk.CreateChatModelConfigRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
 		})
 		require.NoError(t, err)
 
-		defaultOrg, err := rawDB.GetDefaultOrganization(ctx)
-		require.NoError(t, err)
 		row, err := rawDB.GetChatModelConfigByID(ctx, modelConfig.ID)
 		require.NoError(t, err)
 		require.Equal(t, defaultOrg.ID, row.OrganizationID)
@@ -4163,18 +4276,20 @@ func TestCreateChatModelConfig(t *testing.T) {
 		)
 		require.Equal(t, database.ChatACL{}, row.UserACL)
 	})
-
-	// A persisted custom role holding only deployment-config permissions is
-	// the pre-RBAC-resource admission set for the old write routes. While the
-	// default-org fallback keeps every config deployment-serving (until the
-	// M3 cutover), the interim gates and the reverted dbauthz write checks
-	// must keep admitting exactly that set for the full write lifecycle.
-	t.Run("DeploymentConfigOnlyRoleWritesThroughWindow", func(t *testing.T) {
+	// A custom org role holding chat_model_config permissions admits the
+	// full write lifecycle within its org: create, update, delete, and the
+	// default-election mutations, which run under the caller's subject as
+	// object updates while the election reads run call-scoped. The demote
+	// and delete subtests prove the transaction rolls back when default
+	// election fails: the create/update/delete commits, then the election
+	// promotion's object update rejects on a candidate owned by another
+	// org that sorts first, leaving the original default untouched.
+	t.Run("OrgRoleWritesThroughLifecycle", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		// dbauthz rejects site-permission roles on the authorized querier;
-		// seed the role through the raw store, as persisted site custom
+		// seed the role through the raw store, as persisted org custom
 		// roles exist in production deployments.
 		rawDB, pubsub := dbtestutil.NewDB(t)
 		client := newChatClient(t, func(opts *coderdtest.Options) {
@@ -4182,122 +4297,171 @@ func TestCreateChatModelConfig(t *testing.T) {
 			opts.Pubsub = pubsub
 		})
 		_ = coderdtest.CreateFirstUser(t, client.Client)
-		nonDefaultOrg := dbgen.Organization(t, rawDB, database.Organization{IsDefault: false})
-		// The org's Everyone group shares the org ID (migration 000058), and
-		// M1 seeds every config's everyone-read ACL under that key.
-		dbgen.Group(t, rawDB, database.Group{
-			ID:             nonDefaultOrg.ID,
-			Name:           database.EveryoneGroup,
-			OrganizationID: nonDefaultOrg.ID,
-		})
+		defaultOrg, err := rawDB.GetDefaultOrganization(ctx)
+		require.NoError(t, err)
 
+		// The writer role holds chat_model_config permissions in the
+		// default org and nothing else: user-scoped member permissions do
+		// not carry the org-wide create grant the route needs, so the role
+		// must supply every action the lifecycle touches.
 		role, err := rawDB.InsertCustomRole(ctx, database.InsertCustomRoleParams{
 			Name:           testutil.GetRandomName(t),
-			DisplayName:    "Deployment Config Admin",
-			OrganizationID: uuid.NullUUID{UUID: nonDefaultOrg.ID, Valid: true},
-			SitePermissions: database.CustomRolePermissions{
+			DisplayName:    "Chat Model Config Admin",
+			OrganizationID: uuid.NullUUID{UUID: defaultOrg.ID, Valid: true},
+			OrgPermissions: database.CustomRolePermissions{
 				{
-					ResourceType: rbac.ResourceDeploymentConfig.Type,
+					ResourceType: rbac.ResourceChatModelConfig.Type,
+					Action:       policy.ActionCreate,
+				},
+				{
+					ResourceType: rbac.ResourceChatModelConfig.Type,
 					Action:       policy.ActionRead,
 				},
 				{
-					ResourceType: rbac.ResourceDeploymentConfig.Type,
+					ResourceType: rbac.ResourceChatModelConfig.Type,
 					Action:       policy.ActionUpdate,
+				},
+				{
+					ResourceType: rbac.ResourceChatModelConfig.Type,
+					Action:       policy.ActionDelete,
 				},
 			},
 		})
 		require.NoError(t, err)
 
 		aiProvider := createAIProviderForTest(t, client, "openai", "test-api-key")
-		// The first config self-elects as the deployment default; the
-		// default-transition subtests below exercise demote/delete/promote
-		// against it. A second existing config keeps the writer's own create
-		// off the self-promotion path.
-		defaultConfig := createChatModelConfig(t, client)
 
 		writerClientRaw, writerUser := coderdtest.CreateAnotherUser(
 			t,
 			client.Client,
-			nonDefaultOrg.ID,
+			defaultOrg.ID,
 		)
 		_, err = client.Client.UpdateOrganizationMemberRoles(
 			ctx,
-			nonDefaultOrg.ID,
+			defaultOrg.ID,
 			writerUser.ID.String(),
 			codersdk.UpdateRoles{Roles: []string{role.Name}},
 		)
 		require.NoError(t, err)
 		writerClient := codersdk.NewExperimentalClient(writerClientRaw)
 
+		// The first config self-elects as the org default; the
+		// default-transition subtests below exercise demote/delete/promote
+		// against it.
 		contextLimit := int64(4096)
-		modelConfig, err := writerClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		defaultConfig, err := writerClient.CreateChatModelConfig(ctx, defaultOrg.ID, codersdk.CreateChatModelConfigRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
 		})
 		require.NoError(t, err)
+		require.True(t, defaultConfig.IsDefault, "first config in the org must self-elect as default")
 
-		updated, err := writerClient.UpdateChatModelConfig(ctx, modelConfig.ID, codersdk.UpdateChatModelConfigRequest{
+		updated, err := writerClient.UpdateChatModelConfig(ctx, defaultConfig.ID, codersdk.UpdateChatModelConfigRequest{
 			DisplayName: "Window Write",
 		})
 		require.NoError(t, err)
 		require.Equal(t, "Window Write", updated.DisplayName)
 
-		require.NoError(t, writerClient.DeleteChatModelConfig(ctx, modelConfig.ID))
+		// A candidate in another org sorts first in default-election
+		// order; a writer without a chat_model_config update grant there
+		// cannot promote it, so the election rejects and rolls the
+		// transition back. Seed it after the default org has a config so
+		// it never self-elects; the writer's config above holds the
+		// default org's default in place. The blocked writer holds the
+		// same role in the candidate's org, which authorizes the initial
+		// demote/delete on the shared default but not the cross-org
+		// promotion.
+		// A candidate in another org sorts first in default-election
+		// order. Its everyone-read ACL is dropped at seed time, so the
+		// writer (a default-org member with no blockedOrg grant) cannot
+		// promote it: the election's object update rejects and rolls the
+		// transition back. The writer still reaches the election because
+		// member update/delete on the shared default comes from the
+		// default org's everyone-ACL.
+		blockedOrg := dbgen.Organization(t, rawDB, database.Organization{IsDefault: false})
+		dbgen.ChatModelConfig(t, rawDB, database.ChatModelConfig{
+			Model:          "a-first-alphabetical",
+			AIProviderID:   uuid.NullUUID{UUID: aiProvider.ID, Valid: true},
+			OrganizationID: blockedOrg.ID,
+			GroupACL:       database.ChatACL{},
+		})
 
-		// Demoting or deleting the current default forces
-		// ensureDefaultChatModelConfig to enumerate replacement candidates.
-		// A deployment-config-only role has no chat_model_config read grant,
-		// so the promotion's UnsetDefaultChatModelConfigs (system update)
-		// must reject and roll the transition back, exactly as before the
-		// RBAC resource existed. An authorized-filter candidate list would
-		// instead return zero rows and commit with no default.
-		// TODO(mafredri): remove after CODAGT-709 M3 (org-scoping cutover)
+		// A promotable candidate in the default org, sorting AFTER the
+		// cross-org one in (provider type, model) election order. At HEAD
+		// the org filter selects it and the election promotes it, so the
+		// transitions commit; if the filter is removed the election picks
+		// the cross-org unpromotable candidate first and rolls back. The
+		// writer's member update on it comes from the default org's
+		// everyone-ACL, seeded by dbgen with the Everyone group.
+		// The same-org candidate's provider is disabled, so it is not
+		// usable-preference-eligible (the enabled-provider JOIN excludes
+		// it). Under the org-filter-removal mutation the election's first
+		// candidate is the cross-org unpromotable one and the promotion
+		// rolls back; at HEAD the org filter leaves this same-org candidate
+		// as the only option and the election promotes it.
+		disabledProvider := dbgen.AIProvider(t, rawDB, database.AIProvider{
+			Type: database.AIProviderTypeOpenai,
+		})
+		// dbgen cannot seed a disabled provider (takeFirst replaces the
+		// false zero value), so disable it through the store.
+		disabledProvider, err = rawDB.UpdateAIProvider(ctx, database.UpdateAIProviderParams{
+			ID:       disabledProvider.ID,
+			Type:     disabledProvider.Type,
+			Icon:     disabledProvider.Icon,
+			Enabled:  false,
+			BaseUrl:  disabledProvider.BaseUrl,
+			Settings: disabledProvider.Settings,
+		})
+		require.NoError(t, err)
+		sameOrgCandidate := dbgen.ChatModelConfig(t, rawDB, database.ChatModelConfig{
+			Model:          "z-last-alphabetical",
+			AIProviderID:   uuid.NullUUID{UUID: disabledProvider.ID, Valid: true},
+			OrganizationID: defaultOrg.ID,
+		})
 
-		t.Run("DefaultDemoteRollsBack", func(t *testing.T) {
-			// Demote the current default; the replacement promotion's
-			// UnsetDefaultChatModelConfigs (system update) must reject and
-			// roll the whole transition back, exactly as before the RBAC
-			// resource existed.
+		t.Run("DefaultDemoteElectsSameOrgCandidate", func(t *testing.T) {
+			// Demoting the current default triggers the replacement
+			// election; the org filter selects the same-org candidate and
+			// the transition commits. Under the org-filter-removal mutation
+			// the election would instead reach the cross-org unpromotable
+			// candidate and roll back.
 			notDefault := false
 			_, err := writerClient.UpdateChatModelConfig(ctx, defaultConfig.ID, codersdk.UpdateChatModelConfigRequest{
 				IsDefault: &notDefault,
 			})
-			require.Error(t, err, "demote-default must fail for a deployment-config-only role")
+			require.NoError(t, err, "demote-default commits when the election promotes the same-org candidate")
 			row, dbErr := rawDB.GetChatModelConfigByID(ctx, defaultConfig.ID)
 			require.NoError(t, dbErr)
-			require.True(t, row.IsDefault, "demote must have rolled back")
+			require.False(t, row.IsDefault, "demote committed")
+			candidate, dbErr := rawDB.GetChatModelConfigByID(ctx, sameOrgCandidate.ID)
+			require.NoError(t, dbErr)
+			require.True(t, candidate.IsDefault, "election promoted the same-org candidate")
 		})
 
-		t.Run("DefaultDeleteRollsBack", func(t *testing.T) {
-			// A second config exists so the deletion triggers a replacement
-			// promotion; the promotion's UnsetDefaultChatModelConfigs
-			// (system update) must reject and roll the delete back.
-			replacement, err := writerClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
-				AIProviderID: &aiProvider.ID,
-				Model:        "gpt-4o-mini-replacement",
-				ContextLimit: &contextLimit,
-			})
-			require.NoError(t, err)
-			err = writerClient.DeleteChatModelConfig(ctx, defaultConfig.ID)
-			require.Error(t, err, "delete-default with a replacement must fail for a deployment-config-only role")
-			row, dbErr := rawDB.GetChatModelConfigByID(ctx, defaultConfig.ID)
+		t.Run("DefaultDeleteElectsSameOrgCandidate", func(t *testing.T) {
+			// Deleting the current default triggers the replacement
+			// election. Resolve whatever the org default is now (the demote
+			// subtest left sameOrgCandidate as the default at HEAD) so the
+			// delete genuinely runs a default election. Under the
+			// org-filter-removal mutation the election would instead reach
+			// the cross-org unpromotable candidate and roll back.
+			currentDefault, dbErr := rawDB.GetDefaultChatModelConfig(dbauthz.AsSystemRestricted(ctx), defaultOrg.ID)
 			require.NoError(t, dbErr)
-			require.True(t, row.IsDefault, "delete must have rolled back")
-			require.False(t, row.Deleted)
-			rep, dbErr := rawDB.GetChatModelConfigByID(ctx, replacement.ID)
+			err := writerClient.DeleteChatModelConfig(ctx, currentDefault.ID)
+			require.NoError(t, err, "delete-default commits when the election promotes the same-org candidate")
+			// Exactly one same-org config remains the default afterward.
+			newDefault, dbErr := rawDB.GetDefaultChatModelConfig(dbauthz.AsSystemRestricted(ctx), defaultOrg.ID)
 			require.NoError(t, dbErr)
-			require.False(t, rep.IsDefault, "replacement must not have been promoted")
+			require.NotEqual(t, currentDefault.ID, newDefault.ID, "election promoted a different same-org candidate")
+			require.Equal(t, defaultOrg.ID, newDefault.OrganizationID, "the new default is in the org, not the cross-org candidate")
 		})
 
-		t.Run("PromoteNonDefaultRequiresSystemUpdate", func(t *testing.T) {
-			// Promoting a non-default config to default requires
-			// UnsetDefaultChatModelConfigs (system update), which a
-			// deployment-config-only role does not hold. This covers only the
-			// system-update check: UnsetDefaultChatModelConfigs runs before
-			// any candidate lookup, so it does not exercise the candidate-list
-			// path and is not candidate-list coverage.
-			candidate, err := writerClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		t.Run("PromoteNonDefaultSucceeds", func(t *testing.T) {
+			// Promoting a non-default config unsets the old default and
+			// sets the new one; both mutations are org-scoped updates the
+			// writer's role holds.
+			candidate, err := writerClient.CreateChatModelConfig(ctx, defaultOrg.ID, codersdk.CreateChatModelConfigRequest{
 				AIProviderID: &aiProvider.ID,
 				Model:        "gpt-4o-mini-promote",
 				ContextLimit: &contextLimit,
@@ -4307,13 +4471,10 @@ func TestCreateChatModelConfig(t *testing.T) {
 			_, err = writerClient.UpdateChatModelConfig(ctx, candidate.ID, codersdk.UpdateChatModelConfigRequest{
 				IsDefault: &isDefault,
 			})
-			require.Error(t, err, "promote must fail for a deployment-config-only role")
+			require.NoError(t, err, "promote must succeed for a role holding chat_model_config update in the org")
 			row, dbErr := rawDB.GetChatModelConfigByID(ctx, candidate.ID)
 			require.NoError(t, dbErr)
-			require.False(t, row.IsDefault, "promote must have rolled back")
-			defaultRow, dbErr := rawDB.GetChatModelConfigByID(ctx, defaultConfig.ID)
-			require.NoError(t, dbErr)
-			require.True(t, defaultRow.IsDefault, "existing default must be untouched")
+			require.True(t, row.IsDefault, "promote must have committed")
 		})
 	})
 
@@ -4322,12 +4483,12 @@ func TestCreateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		aiProvider := createAIProviderForTest(t, client, "openai", "test-api-key")
 
 		contextLimit := int64(4096)
-		_, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		_, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -4351,12 +4512,12 @@ func TestCreateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		aiProvider := createAIProviderForTest(t, client, "openai", "test-api-key")
 
 		contextLimit := int64(4096)
-		modelConfig, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		modelConfig, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -4382,12 +4543,12 @@ func TestCreateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		aiProvider := createAIProviderForTest(t, client, "openai", "test-api-key")
 
 		contextLimit := int64(4096)
-		_, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		_, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -4407,12 +4568,12 @@ func TestCreateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		aiProvider := createAIProviderForTest(t, client, "openai", "test-api-key")
 
 		contextLimit := int64(4096)
-		_, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		_, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -4437,12 +4598,12 @@ func TestCreateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		aiProvider := createAIProviderForTest(t, client, "openai", "test-api-key")
 
 		contextLimit := int64(4096)
-		_, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		_, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -4463,10 +4624,10 @@ func TestCreateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 		aiProvider := createAIProviderForTest(t, client, "openai", "test-api-key")
 
-		_, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		_, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-mini",
 		})
@@ -4479,10 +4640,10 @@ func TestCreateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		contextLimit := int64(4096)
-		_, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		_, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
 		})
@@ -4495,11 +4656,11 @@ func TestCreateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		contextLimit := int64(4096)
 		missingProviderID := uuid.New()
-		_, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		_, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 			AIProviderID: &missingProviderID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -4513,7 +4674,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 		provider, err := client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
 			Type:    codersdk.AIProviderTypeOpenAI,
 			Name:    "test-model-config-provider-" + uuid.NewString(),
@@ -4523,7 +4684,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		contextLimit := int64(4096)
-		modelConfig, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		modelConfig, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 			AIProviderID: &provider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -4538,11 +4699,11 @@ func TestCreateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		missingProviderID := uuid.New()
 		contextLimit := int64(4096)
-		_, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		_, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 			AIProviderID: &missingProviderID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -4556,7 +4717,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 		provider, err := client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
 			Type:    codersdk.AIProviderTypeOpenAI,
 			Name:    "test-disabled-model-provider-" + uuid.NewString(),
@@ -4566,7 +4727,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		contextLimit := int64(4096)
-		_, err = client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		_, err = client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 			AIProviderID: &provider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -4580,7 +4741,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		aiProvider, err := client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
 			Type:    codersdk.AIProviderTypeOpenAI,
@@ -4592,7 +4753,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		contextLimit := int64(4096)
-		_, err = client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		_, err = client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "anthropic/claude-opus-4.6",
 			ContextLimit: &contextLimit,
@@ -4614,12 +4775,16 @@ func TestCreateChatModelConfig(t *testing.T) {
 		aiProvider := createAIProviderForTest(t, adminClient, "openai", "test-api-key")
 
 		contextLimit := int64(4096)
-		_, err := memberClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		_, err := memberClient.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
 		})
-		requireSDKError(t, err, http.StatusForbidden)
+		// A plain org member holds no chat model config permissions in the
+		// org, so the create is rejected by the write pre-check before any
+		// privileged provider lookup.
+		sdkErr := requireSDKError(t, err, http.StatusForbidden)
+		require.Equal(t, "Forbidden.", sdkErr.Message)
 	})
 }
 
@@ -4683,7 +4848,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		aiProvider, err := client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
 			Type:    codersdk.AIProviderTypeOpenAI,
@@ -4695,7 +4860,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		contextLimit := int64(4096)
-		modelConfig, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		modelConfig, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-mini",
 			ContextLimit: &contextLimit,
@@ -4744,7 +4909,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		validProvider, err := client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
 			Type:    codersdk.AIProviderTypeOpenrouter,
@@ -4764,7 +4929,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		contextLimit := int64(4096)
-		modelConfig, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		modelConfig, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 			AIProviderID: &validProvider.ID,
 			Model:        "anthropic/claude-opus-4.6",
 			ContextLimit: &contextLimit,
@@ -4779,13 +4944,15 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		require.Contains(t, sdkErr.Detail, "Change the AI provider type to openrouter or openai-compat.")
 	})
 
-	t.Run("DisablePreservesRecordAndHidesItFromNonAdmins", func(t *testing.T) {
+	// Disabling preserves the record and keeps it visible through the
+	// ACL-driven union list, but using it for a new chat is rejected.
+	t.Run("DisablePreservesRecordAndRejectsUseForMembers", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		adminClient := newChatClient(t)
 		firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
-		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
+		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID, rbac.ScopedRoleAgentsAccess(firstUser.OrganizationID))
 		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
 		modelConfig := createChatModelConfig(t, adminClient)
 
@@ -4811,12 +4978,30 @@ func TestUpdateChatModelConfig(t *testing.T) {
 
 		memberConfigs, err := memberClient.ListChatModelConfigs(ctx)
 		require.NoError(t, err)
+		foundForMember := false
 		for _, config := range memberConfigs {
-			require.NotEqual(t, modelConfig.ID, config.ID)
+			if config.ID == modelConfig.ID {
+				foundForMember = true
+				require.False(t, config.Enabled)
+			}
 		}
+		require.True(t, foundForMember, "disabled config stays visible through the union list")
+
+		_, err = memberClient.CreateChat(ctx, codersdk.CreateChatRequest{
+			OrganizationID: firstUser.OrganizationID,
+			Content: []codersdk.ChatInputPart{{
+				Type: codersdk.ChatInputPartTypeText,
+				Text: "use a disabled model config",
+			}},
+			ModelConfigID: &modelConfig.ID,
+		})
+		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+		require.Equal(t, "Invalid model_config_id: model config not found or disabled.", sdkErr.Message)
 	})
 
-	t.Run("ReEnableRestoresVisibilityForNonAdmins", func(t *testing.T) {
+	// The union list is ACL-driven, so the disabled config never leaves
+	// the member's list; re-enabling flips the reported Enabled flag.
+	t.Run("ReEnableFlipsEnabledFlagForMembers", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitLong)
@@ -4829,7 +5014,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 
 		contextLimit := int64(4096)
 		enabled := false
-		modelConfig, err := adminClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		modelConfig, err := adminClient.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "gpt-4o-reenable",
 			DisplayName:  "GPT-4o Re-enable",
@@ -4846,9 +5031,10 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		for _, config := range memberConfigs {
 			if config.ID == modelConfig.ID {
 				foundForMember = true
+				require.False(t, config.Enabled)
 			}
 		}
-		require.False(t, foundForMember)
+		require.True(t, foundForMember, "disabled config is visible through the union list")
 
 		enabled = true
 		updated, err := adminClient.UpdateChatModelConfig(ctx, modelConfig.ID, codersdk.UpdateChatModelConfigRequest{
@@ -5041,14 +5227,14 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		})
 		aibridgedtest.StartTestAIBridgeDaemon(t.Context(), t, api, nil)
 		client := codersdk.NewExperimentalClient(rawClient)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 		defaultConfig := createChatModelConfig(t, client)
 
 		aiProvider := createAIProviderForTest(t, client, "anthropic", "candidate-api-key")
 
 		contextLimit := int64(4096)
 		isDefault := false
-		candidateConfig, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		candidateConfig, err := client.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 			AIProviderID: &aiProvider.ID,
 			Model:        "claude-3-5-sonnet",
 			ContextLimit: &contextLimit,
@@ -5105,7 +5291,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		res, err := client.Request(
 			ctx,
 			http.MethodPatch,
-			"/api/experimental/chats/model-configs/not-a-uuid",
+			"/api/experimental/chat-model-configs/not-a-uuid",
 			codersdk.UpdateChatModelConfigRequest{DisplayName: "ignored"},
 		)
 		require.NoError(t, err)
@@ -5129,7 +5315,11 @@ func TestUpdateChatModelConfig(t *testing.T) {
 		_, err := memberClient.UpdateChatModelConfig(ctx, modelConfig.ID, codersdk.UpdateChatModelConfigRequest{
 			DisplayName: "member update",
 		})
-		requireSDKError(t, err, http.StatusForbidden)
+		// A plain org member holds no chat model config update grant in
+		// the org, so the write is rejected by the object pre-check before
+		// the transaction.
+		sdkErr := requireSDKError(t, err, http.StatusForbidden)
+		require.Equal(t, "Forbidden.", sdkErr.Message)
 	})
 }
 
@@ -5215,7 +5405,7 @@ func TestDeleteChatModelConfig(t *testing.T) {
 		res, err := client.Request(
 			ctx,
 			http.MethodDelete,
-			"/api/experimental/chats/model-configs/not-a-uuid",
+			"/api/experimental/chat-model-configs/not-a-uuid",
 			nil,
 		)
 		require.NoError(t, err)
@@ -5237,7 +5427,11 @@ func TestDeleteChatModelConfig(t *testing.T) {
 
 		modelConfig := createChatModelConfig(t, adminClient)
 		err := memberClient.DeleteChatModelConfig(ctx, modelConfig.ID)
-		requireSDKError(t, err, http.StatusForbidden)
+		// A plain org member holds no chat model config delete grant in
+		// the org, so the write is rejected by the object pre-check before
+		// the transaction.
+		sdkErr := requireSDKError(t, err, http.StatusForbidden)
+		require.Equal(t, "Forbidden.", sdkErr.Message)
 	})
 }
 
@@ -12572,8 +12766,14 @@ func seedChatWithDeletedModelConfig(
 		Title:             "chat without model config",
 	})
 	seedManualTitleSourceMessage(t, db, chat, modelConfig.ID)
+	// The fixture's soft-delete runs under an owner subject authorized to
+	// delete the config, not a shared internal actor.
 	require.NoError(t, db.DeleteChatModelConfigByID(
-		dbauthz.AsSystemRestricted(ctx),
+		dbauthz.As(ctx, rbac.Subject{
+			ID:    user.UserID.String(),
+			Roles: rbac.RoleIdentifiers{rbac.RoleOwner()},
+			Scope: rbac.ScopeAll,
+		}),
 		modelConfig.ID,
 	))
 	return chat
@@ -12644,10 +12844,12 @@ func createAdditionalChatModelConfigWithModelConfig(
 	aiProvider := createAIProviderForTest(t, client, provider, "test-api-key")
 	contextLimit := int64(4096)
 	isDefault := false
-	modelConfig, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+	defaultOrg, err := client.Client.OrganizationByName(ctx, codersdk.DefaultOrganization)
+	require.NoError(t, err)
+	modelConfig, err := client.CreateChatModelConfig(ctx, defaultOrg.ID, codersdk.CreateChatModelConfigRequest{
 		AIProviderID: &aiProvider.ID,
-		Model:        model,
 		ContextLimit: &contextLimit,
+		Model:        model,
 		IsDefault:    &isDefault,
 		ModelConfig:  modelCallConfig,
 	})
@@ -13652,7 +13854,7 @@ func TestUserChatPersonalModelOverrides(t *testing.T) {
 		Model:        "claude-personal-" + uuid.NewString(),
 		ContextLimit: &contextLimit,
 	}
-	modelConfig, err := adminClient.CreateChatModelConfig(ctx, modelConfigRequest)
+	modelConfig, err := adminClient.CreateChatModelConfig(ctx, firstUser.OrganizationID, modelConfigRequest)
 	require.NoError(t, err)
 	modelConfigRequest.Model = "claude-personal-reasoning-" + uuid.NewString()
 	modelConfigRequest.ModelConfig = &codersdk.ChatModelCallConfig{
@@ -13661,7 +13863,7 @@ func TestUserChatPersonalModelOverrides(t *testing.T) {
 			Max:     ptr.Ref("high"),
 		},
 	}
-	reasoningModelConfig, err := adminClient.CreateChatModelConfig(ctx, modelConfigRequest)
+	reasoningModelConfig, err := adminClient.CreateChatModelConfig(ctx, firstUser.OrganizationID, modelConfigRequest)
 	require.NoError(t, err)
 	err = adminClient.UpdateChatModelOverride(ctx, codersdk.ChatModelOverrideContextGeneral, codersdk.UpdateChatModelOverrideRequest{
 		ModelConfigID: modelConfig.ID.String(),
@@ -13679,8 +13881,7 @@ func TestUserChatPersonalModelOverrides(t *testing.T) {
 		"gpt-4o-personal-disabled-"+uuid.NewString(),
 	)
 	disabledProvider := createAIProviderForTest(t, adminClient, "google", "test-api-key")
-	contextLimit = int64(4096)
-	disabledProviderModelConfig, err := adminClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+	disabledProviderModelConfig, err := adminClient.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 		AIProviderID: &disabledProvider.ID,
 		Model:        "gemini-personal-disabled-provider-" + uuid.NewString(),
 		ContextLimit: &contextLimit,
@@ -14102,7 +14303,7 @@ func TestCreateChatPersonalModelOverrideRoot(t *testing.T) {
 	})
 	require.NoError(t, err)
 	contextLimit := int64(4096)
-	overrideModel, err := adminClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+	overrideModel, err := adminClient.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 		AIProviderID: &overrideProvider.ID,
 		Model:        "claude-root-personal-" + uuid.NewString(),
 		ContextLimit: &contextLimit,
@@ -14209,7 +14410,7 @@ func TestCreateChatPersonalModelOverrideRoot(t *testing.T) {
 	})
 
 	t.Run("RootModelOverrideUsesSavedReasoningEffort", func(t *testing.T) {
-		reasoningModel, err := adminClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		reasoningModel, err := adminClient.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
 			AIProviderID: &overrideProvider.ID,
 			Model:        "claude-root-personal-reasoning-" + uuid.NewString(),
 			ContextLimit: &contextLimit,

--- a/coderd/httpmw/chatmodelconfigparam.go
+++ b/coderd/httpmw/chatmodelconfigparam.go
@@ -1,0 +1,59 @@
+package httpmw
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+type chatModelConfigParamContextKey struct{}
+
+// ChatModelConfigParam returns the chat model config from the
+// ExtractChatModelConfigParam middleware.
+func ChatModelConfigParam(r *http.Request) database.ChatModelConfig {
+	config, ok := r.Context().Value(chatModelConfigParamContextKey{}).(database.ChatModelConfig)
+	if !ok {
+		panic("developer error: chat model config param middleware not provided")
+	}
+	return config
+}
+
+// ExtractChatModelConfigParam grabs a chat model config from the "model" URL
+// parameter, authorizes reading it, and re-injects both the config and its
+// organization into the route context. It authorizes READ ONLY: write
+// authorization happens in dbauthz inside the handler's write transaction, so
+// a caller who may read but not write still reaches the handler (audit
+// initialization records the denied write there).
+func ExtractChatModelConfigParam(db database.Store) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+			modelID, parsed := ParseUUIDParam(rw, r, "model")
+			if !parsed {
+				return
+			}
+
+			config, err := db.GetChatModelConfigByID(r.Context(), modelID)
+			if httpapi.Is404Error(err) {
+				httpapi.ResourceNotFound(rw)
+				return
+			}
+			if err != nil {
+				httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+					Message: "Internal error fetching chat model config.",
+					Detail:  err.Error(),
+				})
+				return
+			}
+
+			ctx = context.WithValue(ctx, chatModelConfigParamContextKey{}, config)
+			chi.RouteContext(ctx).URLParams.Add("organization", config.OrganizationID.String())
+			next.ServeHTTP(rw, r.WithContext(ctx))
+		})
+	}
+}

--- a/coderd/mcp_test.go
+++ b/coderd/mcp_test.go
@@ -1815,7 +1815,7 @@ func TestChatWithMCPServerIDs(t *testing.T) {
 	require.Contains(t, fetched.MCPServerIDs, mcpConfigB.ID)
 }
 
-func createChatModelConfigForMCP(t testing.TB, client *codersdk.ExperimentalClient) codersdk.ChatModelConfig {
+func createChatModelConfigForMCP(t testing.TB, client *codersdk.ExperimentalClient) codersdk.ChatModel {
 	t.Helper()
 	return coderdtest.CreateOpenAICompatChatModelConfig(t, client, "")
 }

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -2317,12 +2317,13 @@ func ConvertChatMessageSummary(dbRow database.GetChatMessageSummariesPerChatRow)
 // telemetry ChatModelConfig.
 func ConvertChatModelConfig(dbRow database.GetChatModelConfigsForTelemetryRow) ChatModelConfig {
 	return ChatModelConfig{
-		ID:           dbRow.ID,
-		Provider:     dbRow.Provider,
-		Model:        dbRow.Model,
-		ContextLimit: dbRow.ContextLimit,
-		Enabled:      dbRow.Enabled,
-		IsDefault:    dbRow.IsDefault,
+		ID:             dbRow.ID,
+		OrganizationID: dbRow.OrganizationID,
+		Provider:       dbRow.Provider,
+		Model:          dbRow.Model,
+		ContextLimit:   dbRow.ContextLimit,
+		Enabled:        dbRow.Enabled,
+		IsDefault:      dbRow.IsDefault,
 	}
 }
 
@@ -2611,12 +2612,13 @@ type ChatMessageSummary struct {
 // ChatModelConfig contains model configuration metadata for
 // telemetry. Sensitive fields like API keys are excluded.
 type ChatModelConfig struct {
-	ID           uuid.UUID `json:"id"`
-	Provider     string    `json:"provider"`
-	Model        string    `json:"model"`
-	ContextLimit int64     `json:"context_limit"`
-	Enabled      bool      `json:"enabled"`
-	IsDefault    bool      `json:"is_default"`
+	ID             uuid.UUID `json:"id"`
+	OrganizationID uuid.UUID `json:"organization_id"`
+	Provider       string    `json:"provider"`
+	Model          string    `json:"model"`
+	ContextLimit   int64     `json:"context_limit"`
+	Enabled        bool      `json:"enabled"`
+	IsDefault      bool      `json:"is_default"`
 }
 
 // ChatDiffStatusSummary contains aggregate PR counts across all

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -1700,17 +1700,9 @@ func resolveFallbackModelConfigID(
 	defaultConfig, err := store.GetDefaultChatModelConfig(chatdCtx, organizationID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			// TODO(mafredri): remove after CODAGT-709 M3
-			// (org-scoping cutover); orgs without their own
-			// default error after the explosion migration.
-			defaultConfig, err = defaultOrgChatModelConfig(chatdCtx, store, organizationID)
+			return uuid.Nil, ErrNoDefaultChatModelConfig
 		}
-		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return uuid.Nil, ErrNoDefaultChatModelConfig
-			}
-			return uuid.Nil, xerrors.Errorf("get default chat model config: %w", err)
-		}
+		return uuid.Nil, xerrors.Errorf("get default chat model config: %w", err)
 	}
 	// The default may itself be disabled or under a disabled provider.
 	if _, err := store.GetEnabledChatModelConfigByID(chatdCtx, defaultConfig.ID); err != nil {
@@ -1759,26 +1751,6 @@ func validateEditTarget(ctx context.Context, store database.Store, chatID uuid.U
 		return ErrEditedMessageNotUser
 	}
 	return nil
-}
-
-// defaultOrgChatModelConfig resolves the default org's default model
-// config for an org that has none of its own. The default org itself
-// never falls back: a miss there is a real absence.
-// TODO(mafredri): remove after CODAGT-709 M3 (org-scoping cutover);
-// per-org resolution becomes strict.
-func defaultOrgChatModelConfig(
-	ctx context.Context,
-	store database.Store,
-	organizationID uuid.UUID,
-) (database.ChatModelConfig, error) {
-	defaultOrg, err := store.GetDefaultOrganization(ctx)
-	if err != nil {
-		return database.ChatModelConfig{}, err
-	}
-	if defaultOrg.ID == organizationID {
-		return database.ChatModelConfig{}, sql.ErrNoRows
-	}
-	return store.GetDefaultChatModelConfig(ctx, defaultOrg.ID)
 }
 
 // EditMessage replaces an earlier user message and discards the
@@ -2877,9 +2849,6 @@ func (p *Server) resolveManualTitleModel(
 	}
 
 	configs, err := store.GetEnabledChatModelConfigsByOrganization(ctx, chat.OrganizationID)
-	if err == nil {
-		configs, err = enabledChatModelConfigsWithDefaultOrgFallback(ctx, store, chat.OrganizationID, configs)
-	}
 	if err != nil {
 		p.logger.Debug(ctx, "failed to list manual title model configs",
 			slog.F("chat_id", chat.ID),

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -1129,10 +1129,8 @@ func TestRegenerateChatTitle_PersistsAndBroadcasts(t *testing.T) {
 		},
 	).Return(nil, nil)
 	db.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return("", nil)
-	db.EXPECT().GetEnabledChatModelConfigsByOrganization(gomock.Any(), gomock.Any()).Return(nil, nil)
-	// An empty org list triggers the pre-cutover fallback, which
-	// resolves the default org and finds no configs there either.
-	db.EXPECT().GetDefaultOrganization(gomock.Any()).Return(database.Organization{ID: uuid.New()}, nil)
+	// An empty org list falls through to the chat's fallback model;
+	// strict org scoping reads no other org's configs.
 	db.EXPECT().GetEnabledChatModelConfigsByOrganization(gomock.Any(), gomock.Any()).Return(nil, nil)
 
 	db.EXPECT().InTx(gomock.Any(), nil).DoAndReturn(
@@ -1278,10 +1276,8 @@ func TestRegenerateChatTitle_SkipsPersistWhenTitleChangedConcurrently(t *testing
 		},
 	).Return(nil, nil)
 	db.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return("", nil)
-	db.EXPECT().GetEnabledChatModelConfigsByOrganization(gomock.Any(), gomock.Any()).Return(nil, nil)
-	// An empty org list triggers the pre-cutover fallback, which
-	// resolves the default org and finds no configs there either.
-	db.EXPECT().GetDefaultOrganization(gomock.Any()).Return(database.Organization{ID: uuid.New()}, nil)
+	// An empty org list falls through to the chat's fallback model;
+	// strict org scoping reads no other org's configs.
 	db.EXPECT().GetEnabledChatModelConfigsByOrganization(gomock.Any(), gomock.Any()).Return(nil, nil)
 
 	db.EXPECT().InTx(gomock.Any(), nil).DoAndReturn(
@@ -3801,41 +3797,38 @@ func TestResolveFallbackModelConfigID(t *testing.T) {
 		require.Equal(t, defaultModel.ID, resolved)
 	})
 
-	t.Run("NonDefaultOrgFallsBackToDefaultOrgDefault", func(t *testing.T) {
+	t.Run("NonDefaultOrgWithoutOwnDefaultMisses", func(t *testing.T) {
 		t.Parallel()
 		db, _ := dbtestutil.NewDB(t)
 		ctx := testutil.Context(t, testutil.WaitShort)
 
-		// The chat's org has no configs of its own; the deployment
-		// default lives in the default org. Pre-cutover behavior must
-		// resolve it for chats in any org.
+		// The chat's org has no configs of its own; the default org has
+		// one. Strict scoping resolves configs only within the chat's
+		// org, so the lookup reports no default.
 		otherOrgID := newModelConfigOrg(t, db)
 		defaultOrg, err := db.GetDefaultOrganization(ctx)
 		require.NoError(t, err)
 		provider := newProvider(t, db, true)
-		defaultModel := newModelConfig(t, db, defaultOrg.ID, provider.ID, true)
+		_ = newModelConfig(t, db, defaultOrg.ID, provider.ID, true)
 
-		resolved, err := resolveFallbackModelConfigID(ctx, db, otherOrgID, uuid.Nil)
-		require.NoError(t, err)
-		require.Equal(t, defaultModel.ID, resolved)
+		_, err = resolveFallbackModelConfigID(ctx, db, otherOrgID, uuid.Nil)
+		require.ErrorIs(t, err, ErrNoDefaultChatModelConfig)
 	})
 
-	t.Run("FallbackReadsDefaultOrgAsChatd", func(t *testing.T) {
+	t.Run("OrgDefaultResolvesAsChatd", func(t *testing.T) {
 		t.Parallel()
 		db, _ := dbtestutil.NewDB(t)
 		ctx := testutil.Context(t, testutil.WaitShort)
 
-		// The pre-cutover fallback reads the default organization under
-		// the chatd subject, which must be authorized to read
-		// organizations or every fallback path fails closed.
-		otherOrgID := newModelConfigOrg(t, db)
-		defaultOrg, err := db.GetDefaultOrganization(ctx)
-		require.NoError(t, err)
+		// The fallback reads the org default under the chatd subject,
+		// which must be authorized to read chat model configs or every
+		// fallback path fails closed.
+		orgID := newModelConfigOrg(t, db)
 		provider := newProvider(t, db, true)
-		defaultModel := newModelConfig(t, db, defaultOrg.ID, provider.ID, true)
+		defaultModel := newModelConfig(t, db, orgID, provider.ID, true)
 
 		chatdCtx := dbauthz.AsChatd(ctx)
-		resolved, err := resolveFallbackModelConfigID(chatdCtx, db, otherOrgID, uuid.Nil)
+		resolved, err := resolveFallbackModelConfigID(chatdCtx, db, orgID, uuid.Nil)
 		require.NoError(t, err)
 		require.Equal(t, defaultModel.ID, resolved)
 	})

--- a/coderd/x/chatd/chatprovider/chatprovider.go
+++ b/coderd/x/chatd/chatprovider/chatprovider.go
@@ -504,12 +504,12 @@ func (*ModelCatalog) ListConfiguredModels(
 	configuredModels []ConfiguredModel,
 	availabilityByProvider map[string]ProviderAvailability,
 	enabledProviders map[string]struct{},
-) (codersdk.ChatModelsResponse, bool) {
+) (codersdk.ChatModelAvailabilityResponse, bool) {
 	if len(configuredModels) == 0 {
-		return codersdk.ChatModelsResponse{}, false
+		return codersdk.ChatModelAvailabilityResponse{}, false
 	}
 
-	modelsByProvider := make(map[string][]codersdk.ChatModel)
+	modelsByProvider := make(map[string][]codersdk.MinimalChatModel)
 	seenByProvider := make(map[string]map[string]struct{})
 	providerSet := make(map[string]struct{})
 
@@ -544,10 +544,10 @@ func (*ModelCatalog) ListConfiguredModels(
 
 	providers := orderProviders(providerSet)
 	if len(providers) == 0 {
-		return codersdk.ChatModelsResponse{}, false
+		return codersdk.ChatModelAvailabilityResponse{}, false
 	}
 
-	response := codersdk.ChatModelsResponse{
+	response := codersdk.ChatModelAvailabilityResponse{
 		Providers: make([]codersdk.ChatModelProvider, 0, len(providers)),
 	}
 	for _, provider := range providers {
@@ -583,8 +583,8 @@ func (*ModelCatalog) ListConfiguredModels(
 func (*ModelCatalog) ListConfiguredProviderAvailability(
 	availabilityByProvider map[string]ProviderAvailability,
 	enabledProviders map[string]struct{},
-) codersdk.ChatModelsResponse {
-	response := codersdk.ChatModelsResponse{
+) codersdk.ChatModelAvailabilityResponse {
+	response := codersdk.ChatModelAvailabilityResponse{
 		Providers: make([]codersdk.ChatModelProvider, 0, len(supportedProviderNames)),
 	}
 
@@ -595,7 +595,7 @@ func (*ModelCatalog) ListConfiguredProviderAvailability(
 
 		result := codersdk.ChatModelProvider{
 			Provider: provider,
-			Models:   []codersdk.ChatModel{},
+			Models:   []codersdk.MinimalChatModel{},
 		}
 		if avail, ok := availabilityByProvider[provider]; ok {
 			result.Available = avail.Available
@@ -645,13 +645,13 @@ func PruneDisabledProviderKeys(keys *ProviderAPIKeys, enabledProviders map[strin
 	}
 }
 
-func newChatModel(provider, modelID, displayName string) codersdk.ChatModel {
+func newChatModel(provider, modelID, displayName string) codersdk.MinimalChatModel {
 	name := strings.TrimSpace(displayName)
 	if name == "" {
 		name = modelID
 	}
 
-	return codersdk.ChatModel{
+	return codersdk.MinimalChatModel{
 		ID:          canonicalModelID(provider, modelID),
 		Provider:    provider,
 		Model:       modelID,
@@ -659,8 +659,8 @@ func newChatModel(provider, modelID, displayName string) codersdk.ChatModel {
 	}
 }
 
-func sortChatModels(models []codersdk.ChatModel) {
-	slices.SortFunc(models, func(a, b codersdk.ChatModel) int {
+func sortChatModels(models []codersdk.MinimalChatModel) {
+	slices.SortFunc(models, func(a, b codersdk.MinimalChatModel) int {
 		return strings.Compare(a.Model, b.Model)
 	})
 }

--- a/coderd/x/chatd/chatprovider/chatprovider_test.go
+++ b/coderd/x/chatd/chatprovider/chatprovider_test.go
@@ -476,7 +476,7 @@ func TestListConfiguredModels_PolicyAwareAvailability(t *testing.T) {
 		configuredModels       []chatprovider.ConfiguredModel
 		availabilityByProvider map[string]chatprovider.ProviderAvailability
 		enabledProviders       map[string]struct{}
-		want                   codersdk.ChatModelsResponse
+		want                   codersdk.ChatModelAvailabilityResponse
 	}{
 		{
 			name: "PolicyUnavailableOverridesConfiguredKey",
@@ -494,11 +494,11 @@ func TestListConfiguredModels_PolicyAwareAvailability(t *testing.T) {
 				},
 			},
 			enabledProviders: enabledProviders(fantasyopenai.Name),
-			want: codersdk.ChatModelsResponse{Providers: []codersdk.ChatModelProvider{{
+			want: codersdk.ChatModelAvailabilityResponse{Providers: []codersdk.ChatModelProvider{{
 				Provider:          fantasyopenai.Name,
 				Available:         false,
 				UnavailableReason: codersdk.ChatModelProviderUnavailableReasonUserAPIKeyRequired,
-				Models: []codersdk.ChatModel{{
+				Models: []codersdk.MinimalChatModel{{
 					ID:          fantasyopenai.Name + ":gpt-4",
 					Provider:    fantasyopenai.Name,
 					Model:       "gpt-4",
@@ -519,10 +519,10 @@ func TestListConfiguredModels_PolicyAwareAvailability(t *testing.T) {
 				fantasyanthropic.Name: {Available: true},
 			},
 			enabledProviders: enabledProviders(fantasyanthropic.Name),
-			want: codersdk.ChatModelsResponse{Providers: []codersdk.ChatModelProvider{{
+			want: codersdk.ChatModelAvailabilityResponse{Providers: []codersdk.ChatModelProvider{{
 				Provider:  fantasyanthropic.Name,
 				Available: true,
-				Models: []codersdk.ChatModel{{
+				Models: []codersdk.MinimalChatModel{{
 					ID:          fantasyanthropic.Name + ":claude-3-5-sonnet",
 					Provider:    fantasyanthropic.Name,
 					Model:       "claude-3-5-sonnet",
@@ -545,10 +545,10 @@ func TestListConfiguredModels_PolicyAwareAvailability(t *testing.T) {
 				fantasyopenai.Name:    {Available: true},
 			},
 			enabledProviders: enabledProviders(fantasyopenai.Name),
-			want: codersdk.ChatModelsResponse{Providers: []codersdk.ChatModelProvider{{
+			want: codersdk.ChatModelAvailabilityResponse{Providers: []codersdk.ChatModelProvider{{
 				Provider:  fantasyopenai.Name,
 				Available: true,
-				Models: []codersdk.ChatModel{{
+				Models: []codersdk.MinimalChatModel{{
 					ID:          fantasyopenai.Name + ":gpt-4",
 					Provider:    fantasyopenai.Name,
 					Model:       "gpt-4",
@@ -566,11 +566,11 @@ func TestListConfiguredModels_PolicyAwareAvailability(t *testing.T) {
 				Model:    "gpt-4o",
 			}},
 			enabledProviders: enabledProviders(fantasyopenai.Name),
-			want: codersdk.ChatModelsResponse{Providers: []codersdk.ChatModelProvider{{
+			want: codersdk.ChatModelAvailabilityResponse{Providers: []codersdk.ChatModelProvider{{
 				Provider:          fantasyopenai.Name,
 				Available:         false,
 				UnavailableReason: codersdk.ChatModelProviderUnavailableMissingAPIKey,
-				Models: []codersdk.ChatModel{{
+				Models: []codersdk.MinimalChatModel{{
 					ID:          fantasyopenai.Name + ":gpt-4o",
 					Provider:    fantasyopenai.Name,
 					Model:       "gpt-4o",
@@ -612,7 +612,7 @@ func TestListConfiguredProviderAvailability_PolicyAwareFiltering(t *testing.T) {
 		name                   string
 		availabilityByProvider map[string]chatprovider.ProviderAvailability
 		enabledProviders       map[string]struct{}
-		want                   codersdk.ChatModelsResponse
+		want                   codersdk.ChatModelAvailabilityResponse
 	}{
 		{
 			name: "EnabledProvidersUsePolicyAvailability",
@@ -624,17 +624,17 @@ func TestListConfiguredProviderAvailability_PolicyAwareFiltering(t *testing.T) {
 				fantasyopenai.Name: {Available: true},
 			},
 			enabledProviders: enabledProviders(fantasyanthropic.Name, fantasyopenai.Name),
-			want: codersdk.ChatModelsResponse{Providers: []codersdk.ChatModelProvider{
+			want: codersdk.ChatModelAvailabilityResponse{Providers: []codersdk.ChatModelProvider{
 				{
 					Provider:          fantasyanthropic.Name,
 					Available:         false,
 					UnavailableReason: codersdk.ChatModelProviderUnavailableReasonUserAPIKeyRequired,
-					Models:            []codersdk.ChatModel{},
+					Models:            []codersdk.MinimalChatModel{},
 				},
 				{
 					Provider:  fantasyopenai.Name,
 					Available: true,
-					Models:    []codersdk.ChatModel{},
+					Models:    []codersdk.MinimalChatModel{},
 				},
 			}},
 		},
@@ -645,20 +645,20 @@ func TestListConfiguredProviderAvailability_PolicyAwareFiltering(t *testing.T) {
 				fantasyopenai.Name:    {Available: true},
 			},
 			enabledProviders: enabledProviders(fantasyopenai.Name),
-			want: codersdk.ChatModelsResponse{Providers: []codersdk.ChatModelProvider{{
+			want: codersdk.ChatModelAvailabilityResponse{Providers: []codersdk.ChatModelProvider{{
 				Provider:  fantasyopenai.Name,
 				Available: true,
-				Models:    []codersdk.ChatModel{},
+				Models:    []codersdk.MinimalChatModel{},
 			}}},
 		},
 		{
 			name:             "MissingAvailabilityDefaultsToMissingAPIKey",
 			enabledProviders: enabledProviders(fantasyopenai.Name),
-			want: codersdk.ChatModelsResponse{Providers: []codersdk.ChatModelProvider{{
+			want: codersdk.ChatModelAvailabilityResponse{Providers: []codersdk.ChatModelProvider{{
 				Provider:          fantasyopenai.Name,
 				Available:         false,
 				UnavailableReason: codersdk.ChatModelProviderUnavailableMissingAPIKey,
-				Models:            []codersdk.ChatModel{},
+				Models:            []codersdk.MinimalChatModel{},
 			}}},
 		},
 	}

--- a/coderd/x/chatd/configcache.go
+++ b/coderd/x/chatd/configcache.go
@@ -283,11 +283,8 @@ func (c *chatConfigCache) storeModelConfig(snap modelConfigSnapshot, config data
 }
 
 // DefaultModelConfig returns the default model config for the given
-// organization. Until the org-scoping cutover, an org without its own
-// default falls back to the default org's config.
-// TODO(mafredri): remove after CODAGT-709 M3 (org-scoping cutover);
-// orgs resolve strictly within their own configs after the explosion
-// migration.
+// organization. Orgs resolve strictly within their own configs; an org
+// without its own default reports absence.
 func (c *chatConfigCache) DefaultModelConfig(ctx context.Context, orgID uuid.UUID) (database.ChatModelConfig, error) {
 	if config, ok := c.cachedDefaultModelConfig(orgID); ok {
 		return config, nil
@@ -301,23 +298,7 @@ func (c *chatConfigCache) DefaultModelConfig(ctx context.Context, orgID uuid.UUI
 
 		fetched, err := c.db.GetDefaultChatModelConfig(c.ctx, orgID)
 		if err != nil {
-			if !errors.Is(err, sql.ErrNoRows) {
-				return database.ChatModelConfig{}, err
-			}
-			// TODO(mafredri): remove after CODAGT-709 M3
-			// (org-scoping cutover); orgs without their own
-			// default error after the explosion migration.
-			defaultOrg, err := c.db.GetDefaultOrganization(c.ctx)
-			if err != nil {
-				return database.ChatModelConfig{}, err
-			}
-			if defaultOrg.ID == orgID {
-				return database.ChatModelConfig{}, sql.ErrNoRows
-			}
-			fetched, err = c.db.GetDefaultChatModelConfig(c.ctx, defaultOrg.ID)
-			if err != nil {
-				return database.ChatModelConfig{}, err
-			}
+			return database.ChatModelConfig{}, err
 		}
 		c.storeDefaultModelConfig(snap, orgID, fetched)
 		return cloneModelConfig(fetched), nil
@@ -436,8 +417,8 @@ func (c *chatConfigCache) InvalidateModelConfig(id uuid.UUID) {
 	delete(c.modelConfigs, id)
 	c.modelTopologyEpoch++
 	// Coarse invalidation: the event does not say whether the changed
-	// config was a default, nor which orgs resolve to it through the
-	// default-org fallback, so every per-org default is dropped.
+	// config was a default, nor for which org, so every per-org default
+	// is dropped.
 	clear(c.defaultModelConfigs)
 	c.defaultModelConfigGeneration++
 	c.mu.Unlock()

--- a/coderd/x/chatd/configcache_internal_test.go
+++ b/coderd/x/chatd/configcache_internal_test.go
@@ -337,91 +337,44 @@ func TestConfigCache_DefaultModelConfig_PerOrgKeying(t *testing.T) {
 	require.Equal(t, int32(2), store.defaultModelConfigCallCount(orgB))
 }
 
-func TestConfigCache_DefaultModelConfig_DefaultOrgFallback(t *testing.T) {
+func TestConfigCache_DefaultModelConfig_CrossOrgIsolation(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitShort)
 	clock := quartz.NewMock(t)
-	defaultOrgID := uuid.New()
 	otherOrgID := uuid.New()
 	defaultOrgConfig := testChatModelConfig(uuid.New(), "default-org-model")
 	store := &stubChatConfigStore{}
 	store.getDefaultChatModelConfig = func(_ context.Context, orgID uuid.UUID) (database.ChatModelConfig, error) {
-		if orgID == defaultOrgID {
-			return defaultOrgConfig, nil
-		}
+		// The chat's org resolves no default; the default org has one.
 		return database.ChatModelConfig{}, sql.ErrNoRows
-	}
-	store.getDefaultOrganization = func(context.Context) (database.Organization, error) {
-		return database.Organization{ID: defaultOrgID}, nil
 	}
 	cache := newChatConfigCache(ctx, store, clock)
 
-	// An org without its own default resolves the default org's config,
-	// cached under its own org key.
-	resolved, err := cache.DefaultModelConfig(ctx, otherOrgID)
-	require.NoError(t, err)
-	require.Equal(t, defaultOrgConfig, resolved)
-	resolvedAgain, err := cache.DefaultModelConfig(ctx, otherOrgID)
-	require.NoError(t, err)
-	require.Equal(t, defaultOrgConfig, resolvedAgain)
-	require.Equal(t, int32(1), store.defaultModelConfigCallCount(otherOrgID))
-	require.Equal(t, int32(1), store.defaultModelConfigCallCount(defaultOrgID))
-	require.Equal(t, int32(1), store.defaultOrganizationCall.Load())
-
-	// The default org itself gets no fallback.
-	_, err = cache.DefaultModelConfig(ctx, defaultOrgID)
-	require.NoError(t, err)
-	require.Equal(t, int32(2), store.defaultModelConfigCallCount(defaultOrgID))
-	require.Equal(t, int32(1), store.defaultOrganizationCall.Load())
-}
-
-func TestConfigCache_DefaultModelConfig_DefaultOrgMiss(t *testing.T) {
-	t.Parallel()
-
-	ctx := testutil.Context(t, testutil.WaitShort)
-	clock := quartz.NewMock(t)
-	defaultOrgID := uuid.New()
-	store := &stubChatConfigStore{}
-	store.getDefaultChatModelConfig = func(context.Context, uuid.UUID) (database.ChatModelConfig, error) {
-		return database.ChatModelConfig{}, sql.ErrNoRows
-	}
-	store.getDefaultOrganization = func(context.Context) (database.Organization, error) {
-		return database.Organization{ID: defaultOrgID}, nil
-	}
-	cache := newChatConfigCache(ctx, store, clock)
-
-	// A miss inside the default org must not recurse into the fallback:
-	// the default-org resolution happens once, the self-check short
-	// circuits, and the original miss propagates.
-	_, err := cache.DefaultModelConfig(ctx, defaultOrgID)
-	require.ErrorIs(t, err, sql.ErrNoRows)
-	require.Equal(t, int32(1), store.defaultOrganizationCall.Load())
-	require.Equal(t, int32(1), store.defaultModelConfigCallCount(defaultOrgID))
-}
-
-func TestConfigCache_DefaultModelConfig_FallbackMiss(t *testing.T) {
-	t.Parallel()
-
-	ctx := testutil.Context(t, testutil.WaitShort)
-	clock := quartz.NewMock(t)
-	defaultOrgID := uuid.New()
-	otherOrgID := uuid.New()
-	store := &stubChatConfigStore{}
-	store.getDefaultChatModelConfig = func(context.Context, uuid.UUID) (database.ChatModelConfig, error) {
-		return database.ChatModelConfig{}, sql.ErrNoRows
-	}
-	store.getDefaultOrganization = func(context.Context) (database.Organization, error) {
-		return database.Organization{ID: defaultOrgID}, nil
-	}
-	cache := newChatConfigCache(ctx, store, clock)
-
-	// Neither the org nor the default org has a default: the miss
-	// propagates unchanged.
+	// Orgs resolve strictly within their own configs: an org without its
+	// own default reports absence and never reads another org's default.
 	_, err := cache.DefaultModelConfig(ctx, otherOrgID)
 	require.ErrorIs(t, err, sql.ErrNoRows)
 	require.Equal(t, int32(1), store.defaultModelConfigCallCount(otherOrgID))
-	require.Equal(t, int32(1), store.defaultModelConfigCallCount(defaultOrgID))
+	require.Equal(t, int32(0), store.defaultModelConfigCallCount(defaultOrgConfig.OrganizationID))
+}
+
+func TestConfigCache_DefaultModelConfig_Miss(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	clock := quartz.NewMock(t)
+	orgID := uuid.New()
+	store := &stubChatConfigStore{}
+	store.getDefaultChatModelConfig = func(context.Context, uuid.UUID) (database.ChatModelConfig, error) {
+		return database.ChatModelConfig{}, sql.ErrNoRows
+	}
+	cache := newChatConfigCache(ctx, store, clock)
+
+	// A miss inside the org propagates unchanged.
+	_, err := cache.DefaultModelConfig(ctx, orgID)
+	require.ErrorIs(t, err, sql.ErrNoRows)
+	require.Equal(t, int32(1), store.defaultModelConfigCallCount(orgID))
 }
 
 func TestConfigCache_UserPrompt_NegativeCaching(t *testing.T) {

--- a/coderd/x/chatd/integration_test.go
+++ b/coderd/x/chatd/integration_test.go
@@ -97,7 +97,7 @@ func TestAnthropicWebSearchRoundTrip(t *testing.T) {
 	// Create a model config that enables web_search.
 	contextLimit := int64(200000)
 	isDefault := true
-	_, err := expClient.CreateChatModelConfig(ctx, user.OrganizationID, codersdk.CreateChatModelConfigRequest{
+	_, err := expClient.CreateChatModel(ctx, user.OrganizationID, codersdk.CreateChatModelRequest{
 		AIProviderID: &provider.ID,
 		Model:        "claude-sonnet-4-20250514",
 		ContextLimit: &contextLimit,
@@ -355,7 +355,7 @@ func TestOpenAIReasoningRoundTrip(t *testing.T) {
 	contextLimit := int64(200000)
 	isDefault := true
 	reasoningSummary := "auto"
-	_, err := expClient.CreateChatModelConfig(ctx, user.OrganizationID, codersdk.CreateChatModelConfigRequest{
+	_, err := expClient.CreateChatModel(ctx, user.OrganizationID, codersdk.CreateChatModelRequest{
 		AIProviderID: &provider.ID,
 		Model:        "o4-mini",
 		ContextLimit: &contextLimit,
@@ -504,7 +504,7 @@ func TestOpenAIReasoningRoundTripStoreFalse(t *testing.T) {
 	contextLimit := int64(200000)
 	isDefault := true
 	reasoningSummary := "auto"
-	_, err := expClient.CreateChatModelConfig(ctx, user.OrganizationID, codersdk.CreateChatModelConfigRequest{
+	_, err := expClient.CreateChatModel(ctx, user.OrganizationID, codersdk.CreateChatModelRequest{
 		AIProviderID: &provider.ID,
 		Model:        "o4-mini",
 		ContextLimit: &contextLimit,

--- a/coderd/x/chatd/integration_test.go
+++ b/coderd/x/chatd/integration_test.go
@@ -97,7 +97,7 @@ func TestAnthropicWebSearchRoundTrip(t *testing.T) {
 	// Create a model config that enables web_search.
 	contextLimit := int64(200000)
 	isDefault := true
-	_, err := expClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+	_, err := expClient.CreateChatModelConfig(ctx, user.OrganizationID, codersdk.CreateChatModelConfigRequest{
 		AIProviderID: &provider.ID,
 		Model:        "claude-sonnet-4-20250514",
 		ContextLimit: &contextLimit,
@@ -355,7 +355,7 @@ func TestOpenAIReasoningRoundTrip(t *testing.T) {
 	contextLimit := int64(200000)
 	isDefault := true
 	reasoningSummary := "auto"
-	_, err := expClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+	_, err := expClient.CreateChatModelConfig(ctx, user.OrganizationID, codersdk.CreateChatModelConfigRequest{
 		AIProviderID: &provider.ID,
 		Model:        "o4-mini",
 		ContextLimit: &contextLimit,
@@ -504,7 +504,7 @@ func TestOpenAIReasoningRoundTripStoreFalse(t *testing.T) {
 	contextLimit := int64(200000)
 	isDefault := true
 	reasoningSummary := "auto"
-	_, err := expClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+	_, err := expClient.CreateChatModelConfig(ctx, user.OrganizationID, codersdk.CreateChatModelConfigRequest{
 		AIProviderID: &provider.ID,
 		Model:        "o4-mini",
 		ContextLimit: &contextLimit,

--- a/coderd/x/chatd/quickgen.go
+++ b/coderd/x/chatd/quickgen.go
@@ -145,31 +145,14 @@ type shortTextCandidate struct {
 	providerOptions fantasy.ProviderOptions
 }
 
-// enabledModelConfigsRow is the row shape shared by the enabled-model
-// list queries (the deployment-wide and per-org variants generate
-// distinct Go types with identical fields).
-// TODO(mafredri): remove after CODAGT-709 M3 (org-scoping cutover),
-// when only the per-org variant remains and the selector is
-// de-generified.
-type enabledModelConfigsRow interface {
-	database.GetEnabledChatModelConfigsRow | database.GetEnabledChatModelConfigsByOrganizationRow
-}
-
 // enabledModelConfigFields extracts the two fields the selector needs
-// off either generated row type.
-func enabledModelConfigFields[T enabledModelConfigsRow](row T) (string, database.ChatModelConfig) {
-	switch row := any(row).(type) {
-	case database.GetEnabledChatModelConfigsRow:
-		return row.Provider, row.ChatModelConfig
-	case database.GetEnabledChatModelConfigsByOrganizationRow:
-		return row.Provider, row.ChatModelConfig
-	}
-	// Unreachable: the constraint is a closed union.
-	return "", database.ChatModelConfig{}
+// off the per-org enabled-models row type.
+func enabledModelConfigFields(row database.GetEnabledChatModelConfigsByOrganizationRow) (string, database.ChatModelConfig) {
+	return row.Provider, row.ChatModelConfig
 }
 
-func selectPreferredConfiguredShortTextModelConfig[T enabledModelConfigsRow](
-	configs []T,
+func selectPreferredConfiguredShortTextModelConfig(
+	configs []database.GetEnabledChatModelConfigsByOrganizationRow,
 ) (database.ChatModelConfig, bool) {
 	for _, preferred := range preferredTitleModels {
 		for _, config := range configs {

--- a/coderd/x/chatd/quickgen_internal_test.go
+++ b/coderd/x/chatd/quickgen_internal_test.go
@@ -794,7 +794,7 @@ func Test_selectPreferredConfiguredShortTextModelConfig(t *testing.T) {
 	t.Run("chooses the highest-priority configured lightweight model", func(t *testing.T) {
 		t.Parallel()
 
-		configs := []database.GetEnabledChatModelConfigsRow{
+		configs := []database.GetEnabledChatModelConfigsByOrganizationRow{
 			{ChatModelConfig: database.ChatModelConfig{Model: preferredTitleModels[2].model}, Provider: preferredTitleModels[2].provider},
 			{ChatModelConfig: database.ChatModelConfig{Model: preferredTitleModels[1].model}, Provider: preferredTitleModels[1].provider},
 			{ChatModelConfig: database.ChatModelConfig{Model: "gpt-4.1"}, Provider: "openai"},
@@ -808,7 +808,7 @@ func Test_selectPreferredConfiguredShortTextModelConfig(t *testing.T) {
 	t.Run("returns false when no preferred lightweight model is configured", func(t *testing.T) {
 		t.Parallel()
 
-		got, ok := selectPreferredConfiguredShortTextModelConfig([]database.GetEnabledChatModelConfigsRow{{
+		got, ok := selectPreferredConfiguredShortTextModelConfig([]database.GetEnabledChatModelConfigsByOrganizationRow{{
 			ChatModelConfig: database.ChatModelConfig{Model: "gpt-4.1"},
 			Provider:        "openai",
 		}})
@@ -816,10 +816,7 @@ func Test_selectPreferredConfiguredShortTextModelConfig(t *testing.T) {
 		require.Equal(t, database.ChatModelConfig{}, got)
 	})
 
-	// The production caller lists per org, which generates a distinct
-	// row type; both branches of the selector's field extraction must
-	// behave identically.
-	t.Run("per-org row type selects identically", func(t *testing.T) {
+	t.Run("second preferred provider wins over lower priority", func(t *testing.T) {
 		t.Parallel()
 
 		configs := []database.GetEnabledChatModelConfigsByOrganizationRow{

--- a/coderd/x/chatd/subagent.go
+++ b/coderd/x/chatd/subagent.go
@@ -634,10 +634,6 @@ func (p *Server) listSpawnableModelConfigs(
 	if err != nil {
 		return nil, xerrors.Errorf("get enabled chat model configs: %w", err)
 	}
-	rows, err = enabledChatModelConfigsWithDefaultOrgFallback(chatdCtx, p.db, organizationID, rows)
-	if err != nil {
-		return nil, xerrors.Errorf("get enabled chat model configs: %w", err)
-	}
 	models := make([]map[string]any, 0, len(rows))
 	providerKeysByID := make(map[uuid.UUID]chatprovider.ProviderAPIKeys)
 	for _, row := range rows {
@@ -686,36 +682,6 @@ func (p *Server) listSpawnableModelConfigs(
 		models = append(models, entry)
 	}
 	return models, nil
-}
-
-// enabledChatModelConfigsWithDefaultOrgFallback substitutes the
-// default org's enabled chat model configs when the chat's org has
-// none of its own, preserving the pre-org-scoping behavior where
-// every chat saw the deployment-wide list. The default org itself
-// never falls back.
-// TODO(mafredri): remove after CODAGT-709 M3 (org-scoping cutover);
-// orgs list strictly within their own configs.
-func enabledChatModelConfigsWithDefaultOrgFallback(
-	ctx context.Context,
-	db database.Store,
-	organizationID uuid.UUID,
-	rows []database.GetEnabledChatModelConfigsByOrganizationRow,
-) ([]database.GetEnabledChatModelConfigsByOrganizationRow, error) {
-	if len(rows) > 0 {
-		return rows, nil
-	}
-	defaultOrg, err := db.GetDefaultOrganization(ctx)
-	if err != nil {
-		return nil, xerrors.Errorf("get default organization: %w", err)
-	}
-	if defaultOrg.ID == organizationID {
-		return rows, nil
-	}
-	fallbackRows, err := db.GetEnabledChatModelConfigsByOrganization(ctx, defaultOrg.ID)
-	if err != nil {
-		return nil, xerrors.Errorf("get default org enabled chat model configs: %w", err)
-	}
-	return fallbackRows, nil
 }
 
 func (p *Server) subagentTools(

--- a/coderd/x/chatd/subagent_internal_test.go
+++ b/coderd/x/chatd/subagent_internal_test.go
@@ -4857,81 +4857,7 @@ func TestListAgents(t *testing.T) {
 	})
 }
 
-func TestEnabledChatModelConfigsWithDefaultOrgFallback(t *testing.T) {
-	t.Parallel()
-
-	db, _ := dbtestutil.NewDB(t)
-	ctx := testutil.Context(t, testutil.WaitShort)
-
-	defaultOrg, err := db.GetDefaultOrganization(ctx)
-	require.NoError(t, err)
-	otherOrg := dbgen.Organization(t, db, database.Organization{})
-	provider := dbgen.AIProviderWithOptionalKey(t, db, database.AIProvider{
-		Type: database.AIProviderTypeOpenai,
-	}, "test-key")
-	defaultOrgConfig := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-		AIProviderID:   uuid.NullUUID{UUID: provider.ID, Valid: true},
-		OrganizationID: defaultOrg.ID,
-	})
-
-	t.Run("OrgListEmptyFallsBackToDefaultOrg", func(t *testing.T) {
-		t.Parallel()
-
-		// A fresh org is guaranteed empty even when the test database
-		// carries seeded configs in previously created orgs.
-		emptyOrg := dbgen.Organization(t, db, database.Organization{})
-		ctx := testutil.Context(t, testutil.WaitShort)
-		rows, err := db.GetEnabledChatModelConfigsByOrganization(ctx, emptyOrg.ID)
-		require.NoError(t, err)
-		require.Empty(t, rows)
-
-		rows, err = enabledChatModelConfigsWithDefaultOrgFallback(ctx, db, emptyOrg.ID, rows)
-		require.NoError(t, err)
-		require.NotEmpty(t, rows)
-
-		found := slices.ContainsFunc(rows, func(row database.GetEnabledChatModelConfigsByOrganizationRow) bool {
-			return row.ChatModelConfig.ID == defaultOrgConfig.ID
-		})
-		require.True(t, found, "default org list should include its config")
-	})
-
-	t.Run("OrgListPresentNeverFallsBack", func(t *testing.T) {
-		t.Parallel()
-
-		ctx := testutil.Context(t, testutil.WaitShort)
-
-		// Give the other org its own enabled config: the default org's
-		// list must not leak in.
-		ownConfig := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
-			AIProviderID:   uuid.NullUUID{UUID: provider.ID, Valid: true},
-			OrganizationID: otherOrg.ID,
-		})
-
-		rows, err := db.GetEnabledChatModelConfigsByOrganization(ctx, otherOrg.ID)
-		require.NoError(t, err)
-		require.Len(t, rows, 1)
-
-		rows, err = enabledChatModelConfigsWithDefaultOrgFallback(ctx, db, otherOrg.ID, rows)
-		require.NoError(t, err)
-		require.Len(t, rows, 1)
-		require.Equal(t, ownConfig.ID, rows[0].ChatModelConfig.ID)
-	})
-
-	t.Run("DefaultOrgNeverFallsBack", func(t *testing.T) {
-		t.Parallel()
-
-		ctx := testutil.Context(t, testutil.WaitShort)
-
-		// A miss inside the default org must not recurse into the
-		// fallback: the empty result stands.
-		rows := []database.GetEnabledChatModelConfigsByOrganizationRow{}
-		got, err := enabledChatModelConfigsWithDefaultOrgFallback(ctx, db, defaultOrg.ID, rows)
-		require.NoError(t, err)
-		require.Empty(t, got)
-	})
-}
-
-func TestListSubagentModels_NonDefaultOrgSeesDefaultOrgConfigs(t *testing.T) {
+func TestListSubagentModels_NonDefaultOrgSeesOnlyOwnOrgConfigs(t *testing.T) {
 	t.Parallel()
 
 	db, ps := dbtestutil.NewDB(t)
@@ -4942,8 +4868,7 @@ func TestListSubagentModels_NonDefaultOrgSeesDefaultOrgConfigs(t *testing.T) {
 
 	// The chat's org has its own config (the seed model), so the
 	// list is org-local and the default org's config must not leak
-	// in. The empty-org fallback is covered by
-	// TestEnabledChatModelConfigsWithDefaultOrgFallback.
+	// in.
 	defaultOrg, err := db.GetDefaultOrganization(ctx)
 	require.NoError(t, err)
 	defaultOrgProvider := dbgen.AIProviderWithOptionalKey(t, db, database.AIProvider{

--- a/coderd/x/chatd/title_override.go
+++ b/coderd/x/chatd/title_override.go
@@ -55,8 +55,11 @@ func readTitleGenerationModelOverride(
 
 // resolveTitleGenerationModelOverride resolves the deployment-wide title
 // generation model override. overrideSet is true when an override was
-// configured; in that case any returned error is a hard failure. When
-// overrideSet is false, callers may fall back to the default title model.
+// configured and resolved; a configured override that does not resolve
+// (unknown, disabled, or cross-org config) is ignored, and model
+// construction failures after a successful resolution stay hard failures.
+// When overrideSet is false, callers may fall back to the default title
+// model.
 func (p *Server) resolveTitleGenerationModelOverride(
 	ctx context.Context,
 	chat database.Chat,
@@ -79,7 +82,7 @@ func (p *Server) resolveTitleGenerationModelOverride(
 		func(ctx context.Context, ownerID uuid.UUID, aiProviderID uuid.UUID) (chatprovider.ProviderAPIKeys, error) {
 			return p.resolveUserProviderAPIKeys(ctx, ownerID, aiProviderID)
 		},
-		modelOverrideFailureModeHard,
+		modelOverrideFailureModeSoft,
 	)
 	if err != nil {
 		return database.ChatModelConfig{}, nil, aiGatewayModelRoute{}, overrideSet, err

--- a/coderd/x/chatd/title_override_internal_test.go
+++ b/coderd/x/chatd/title_override_internal_test.go
@@ -279,15 +279,21 @@ func TestMaybeGenerateChatTitle_TitleGenerationOverrideSetUnusableSkips(t *testi
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
 	chat, messages := titleOverrideTestChatAndMessages(t)
 	overrideConfig := titleOverrideModelConfig("gpt-4.1", false)
+	wantTitle := "Fallback title"
 	fallbackModel := &chattest.FakeModel{
 		GenerateObjectFn: func(context.Context, fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
-			t.Fatal("fallback model should not be called when override is unusable")
-			return nil, xerrors.New("unexpected fallback model call")
+			return &fantasy.ObjectResponse{
+				Object: map[string]any{"title": wantTitle},
+			}, nil
 		},
 	}
 
 	db.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return(overrideConfig.ID.String(), nil)
 	db.EXPECT().GetChatModelConfigByID(gomock.Any(), overrideConfig.ID).Return(overrideConfig, nil)
+	db.EXPECT().UpdateChatTitleByID(gomock.Any(), database.UpdateChatTitleByIDParams{
+		ID:    chat.ID,
+		Title: wantTitle,
+	}).Return(chatWithTitle(chat, wantTitle), nil)
 
 	generated := &generatedChatTitle{}
 	server := titleOverrideTestServer(db, logger)
@@ -306,8 +312,9 @@ func TestMaybeGenerateChatTitle_TitleGenerationOverrideSetUnusableSkips(t *testi
 		nil,
 	)
 
-	_, ok := generated.Load()
-	require.False(t, ok)
+	gotTitle, ok := generated.Load()
+	require.True(t, ok)
+	require.Equal(t, wantTitle, gotTitle)
 }
 
 func TestMaybeGenerateChatTitle_TitleGenerationOverrideCallFailureSkipsFallback(t *testing.T) {
@@ -400,7 +407,7 @@ func TestResolveManualTitleModel_TitleGenerationOverrideUnset(t *testing.T) {
 	require.Equal(t, preferredConfig, gotConfig)
 }
 
-func TestResolveManualTitleModel_NonDefaultOrgUsesDefaultOrgConfigs(t *testing.T) {
+func TestResolveManualTitleModel_CrossOrgConfigsAreInvisible(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitShort)
@@ -409,25 +416,16 @@ func TestResolveManualTitleModel_NonDefaultOrgUsesDefaultOrgConfigs(t *testing.T
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
 	chat, _ := titleOverrideTestChatAndMessages(t)
 	chat.OrganizationID = uuid.New() // non-default org, no configs of its own
-	defaultOrgID := uuid.New()
-	providerID := uuid.New()
-	preferredConfig := database.ChatModelConfig{
-		ID:             uuid.New(),
-		AIProviderID:   uuid.NullUUID{UUID: providerID, Valid: true},
-		Model:          preferredTitleModels[1].model,
-		Enabled:        true,
-		OrganizationID: defaultOrgID,
-	}
 
 	db.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return("", nil)
-	// The chat's org has no enabled configs; the selector must fall
-	// back to the default org's list until the org-scoping cutover.
+	// Strict org scoping reads only the chat org's configs; configs in
+	// the default org are invisible here, so selection falls back to the
+	// chat model.
 	db.EXPECT().GetEnabledChatModelConfigsByOrganization(gomock.Any(), chat.OrganizationID).Return(nil, nil)
-	db.EXPECT().GetDefaultOrganization(gomock.Any()).Return(database.Organization{ID: defaultOrgID}, nil)
-	db.EXPECT().GetEnabledChatModelConfigsByOrganization(gomock.Any(), defaultOrgID).Return([]database.GetEnabledChatModelConfigsByOrganizationRow{
-		{ChatModelConfig: preferredConfig, Provider: preferredTitleModels[1].provider},
-	}, nil)
-	db.EXPECT().GetAIProviderByID(gomock.Any(), providerID).Return(aibridgeTestAIProvider(providerID, "primary-openai", database.AIProviderTypeOpenai), nil).AnyTimes()
+
+	// No override, no org configs, and no model config on the chat: the
+	// fallback lookup finds no default in the chat's org and errors.
+	db.EXPECT().GetDefaultChatModelConfig(gomock.Any(), chat.OrganizationID).Return(database.ChatModelConfig{}, sql.ErrNoRows)
 
 	server := titleOverrideTestServer(db, logger)
 	model, gotConfig, err := server.resolveManualTitleModel(
@@ -436,9 +434,9 @@ func TestResolveManualTitleModel_NonDefaultOrgUsesDefaultOrgConfigs(t *testing.T
 		chat,
 		modelBuildOptions{ActiveAPIKeyID: uuid.NewString()},
 	)
-	require.NoError(t, err)
-	require.NotNil(t, model)
-	require.Equal(t, preferredConfig, gotConfig)
+	require.ErrorIs(t, err, ErrNoDefaultChatModelConfig)
+	require.Nil(t, model)
+	require.Equal(t, database.ChatModelConfig{}, gotConfig)
 }
 
 func TestResolveManualTitleModel_TitleGenerationOverrideUnsetAIProvider(t *testing.T) {
@@ -578,6 +576,11 @@ func TestResolveManualTitleModel_TitleGenerationOverrideMissingCredentials(t *te
 	db.EXPECT().GetChatModelConfigByID(gomock.Any(), overrideConfig.ID).Return(overrideConfig, nil)
 	db.EXPECT().GetAIProviderByID(gomock.Any(), providerID).Return(provider, nil).AnyTimes()
 	db.EXPECT().GetAIProviderKeysByProviderID(gomock.Any(), providerID).Return(nil, nil).AnyTimes()
+	// Missing override credentials soft-fail the override; manual
+	// selection lists the chat org's configs (none) and falls back to the
+	// chat model, which has no model here to build.
+	db.EXPECT().GetEnabledChatModelConfigsByOrganization(gomock.Any(), chat.OrganizationID).Return(nil, nil)
+	db.EXPECT().GetDefaultChatModelConfig(gomock.Any(), chat.OrganizationID).Return(database.ChatModelConfig{}, sql.ErrNoRows)
 
 	server := titleOverrideTestServer(db, logger)
 	model, gotConfig, err := server.resolveManualTitleModel(
@@ -586,9 +589,9 @@ func TestResolveManualTitleModel_TitleGenerationOverrideMissingCredentials(t *te
 		chat,
 		modelBuildOptions{},
 	)
-	require.Error(t, err)
-	require.ErrorContains(t, err, "resolve manual title generation model override")
-	require.ErrorContains(t, err, "credentials are unavailable")
+	// The chat has no model config and its org has no default: the
+	// fallback resolution errors with ErrNoDefaultChatModelConfig.
+	require.ErrorIs(t, err, ErrNoDefaultChatModelConfig)
 	require.Nil(t, model)
 	require.Equal(t, database.ChatModelConfig{}, gotConfig)
 }
@@ -674,6 +677,11 @@ func TestResolveManualTitleModel_TitleGenerationOverrideSetUnusable(t *testing.T
 
 	db.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return(overrideConfig.ID.String(), nil)
 	db.EXPECT().GetChatModelConfigByID(gomock.Any(), overrideConfig.ID).Return(overrideConfig, nil)
+	// A disabled override config soft-fails the override; manual
+	// selection lists the chat org's configs (none) and falls back to the
+	// chat model, which has no model here to build.
+	db.EXPECT().GetEnabledChatModelConfigsByOrganization(gomock.Any(), chat.OrganizationID).Return(nil, nil)
+	db.EXPECT().GetDefaultChatModelConfig(gomock.Any(), chat.OrganizationID).Return(database.ChatModelConfig{}, sql.ErrNoRows)
 
 	server := titleOverrideTestServer(db, logger)
 	model, gotConfig, err := server.resolveManualTitleModel(
@@ -682,9 +690,9 @@ func TestResolveManualTitleModel_TitleGenerationOverrideSetUnusable(t *testing.T
 		chat,
 		modelBuildOptions{},
 	)
-	require.Error(t, err)
-	require.ErrorContains(t, err, "resolve manual title generation model override")
-	require.ErrorContains(t, err, "title generation model override is unavailable")
+	// The chat has no model config and its org has no default: the
+	// fallback resolution errors with ErrNoDefaultChatModelConfig.
+	require.ErrorIs(t, err, ErrNoDefaultChatModelConfig)
 	require.Nil(t, model)
 	require.Equal(t, database.ChatModelConfig{}, gotConfig)
 }

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -1307,17 +1307,21 @@ type CreateUserChatProviderKeyRequest struct {
 	APIKey string `json:"api_key"`
 }
 
-// ChatModelConfig is an admin-managed model configuration.
+// ChatModelConfig is an org-scoped model configuration.
 type ChatModelConfig struct {
-	ID                   uuid.UUID            `json:"id" format:"uuid"`
-	AIProviderID         uuid.UUID            `json:"ai_provider_id" format:"uuid"`
-	Model                string               `json:"model"`
-	DisplayName          string               `json:"display_name"`
-	Enabled              bool                 `json:"enabled"`
-	IsDefault            bool                 `json:"is_default"`
-	ContextLimit         int64                `json:"context_limit"`
-	CompressionThreshold int32                `json:"compression_threshold"`
-	ModelConfig          *ChatModelCallConfig `json:"model_config,omitempty"`
+	ID             uuid.UUID `json:"id" format:"uuid"`
+	OrganizationID uuid.UUID `json:"organization_id" format:"uuid"`
+	// OrganizationDisplayName is set on union-list responses so user-context
+	// pages can label which org each copy belongs to.
+	OrganizationDisplayName string               `json:"organization_display_name,omitempty"`
+	AIProviderID            uuid.UUID            `json:"ai_provider_id" format:"uuid"`
+	Model                   string               `json:"model"`
+	DisplayName             string               `json:"display_name"`
+	Enabled                 bool                 `json:"enabled"`
+	IsDefault               bool                 `json:"is_default"`
+	ContextLimit            int64                `json:"context_limit"`
+	CompressionThreshold    int32                `json:"compression_threshold"`
+	ModelConfig             *ChatModelCallConfig `json:"model_config,omitempty"`
 	// ReasoningEfforts lists selectable reasoning effort values through
 	// the model's configured maximum.
 	ReasoningEfforts []string  `json:"reasoning_efforts,omitempty"`
@@ -2506,9 +2510,11 @@ func (c *ExperimentalClient) DeleteUserChatProviderKey(ctx context.Context, prov
 	return nil
 }
 
-// ListChatModelConfigs returns admin-managed chat model configs.
+// ListChatModelConfigs returns the union of chat model configs the caller
+// can read across all of their organizations. Rows carry the organization
+// ID and display name so user-context pages can label each copy.
 func (c *ExperimentalClient) ListChatModelConfigs(ctx context.Context) ([]ChatModelConfig, error) {
-	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/model-configs", nil)
+	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chat-model-configs", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2521,24 +2527,27 @@ func (c *ExperimentalClient) ListChatModelConfigs(ctx context.Context) ([]ChatMo
 	return configs, json.NewDecoder(res.Body).Decode(&configs)
 }
 
-// CreateChatModelConfig creates an admin-managed chat model config.
-func (c *ExperimentalClient) CreateChatModelConfig(ctx context.Context, req CreateChatModelConfigRequest) (ChatModelConfig, error) {
-	res, err := c.Request(ctx, http.MethodPost, "/api/experimental/chats/model-configs", req)
+// ListChatModelConfigsByOrganization returns the chat model configs the
+// caller can read in one organization, for org-scoped management and
+// picker surfaces.
+func (c *ExperimentalClient) ListChatModelConfigsByOrganization(ctx context.Context, organizationID uuid.UUID) ([]ChatModelConfig, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/organizations/%s/chat-model-configs", organizationID), nil)
 	if err != nil {
-		return ChatModelConfig{}, err
+		return nil, err
 	}
 	defer res.Body.Close()
-	if res.StatusCode != http.StatusCreated {
-		return ChatModelConfig{}, ReadBodyAsError(res)
+	if res.StatusCode != http.StatusOK {
+		return nil, ReadBodyAsError(res)
 	}
 
-	var config ChatModelConfig
-	return config, json.NewDecoder(res.Body).Decode(&config)
+	var configs []ChatModelConfig
+	return configs, json.NewDecoder(res.Body).Decode(&configs)
 }
 
-// UpdateChatModelConfig updates an admin-managed chat model config.
-func (c *ExperimentalClient) UpdateChatModelConfig(ctx context.Context, modelConfigID uuid.UUID, req UpdateChatModelConfigRequest) (ChatModelConfig, error) {
-	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/experimental/chats/model-configs/%s", modelConfigID), req)
+// GetChatModelConfig fetches one chat model config by ID; the config's org
+// is resolved from the row.
+func (c *ExperimentalClient) GetChatModelConfig(ctx context.Context, modelConfigID uuid.UUID) (ChatModelConfig, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/chat-model-configs/%s", modelConfigID), nil)
 	if err != nil {
 		return ChatModelConfig{}, err
 	}
@@ -2551,9 +2560,42 @@ func (c *ExperimentalClient) UpdateChatModelConfig(ctx context.Context, modelCon
 	return config, json.NewDecoder(res.Body).Decode(&config)
 }
 
-// DeleteChatModelConfig deletes an admin-managed chat model config.
+// CreateChatModelConfig creates a chat model config in the given
+// organization.
+func (c *ExperimentalClient) CreateChatModelConfig(ctx context.Context, organizationID uuid.UUID, req CreateChatModelConfigRequest) (ChatModelConfig, error) {
+	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/experimental/organizations/%s/chat-model-configs", organizationID), req)
+	if err != nil {
+		return ChatModelConfig{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusCreated {
+		return ChatModelConfig{}, ReadBodyAsError(res)
+	}
+
+	var config ChatModelConfig
+	return config, json.NewDecoder(res.Body).Decode(&config)
+}
+
+// UpdateChatModelConfig updates a chat model config; the config's org is
+// resolved from the row.
+func (c *ExperimentalClient) UpdateChatModelConfig(ctx context.Context, modelConfigID uuid.UUID, req UpdateChatModelConfigRequest) (ChatModelConfig, error) {
+	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/experimental/chat-model-configs/%s", modelConfigID), req)
+	if err != nil {
+		return ChatModelConfig{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return ChatModelConfig{}, ReadBodyAsError(res)
+	}
+
+	var config ChatModelConfig
+	return config, json.NewDecoder(res.Body).Decode(&config)
+}
+
+// DeleteChatModelConfig deletes a chat model config; the config's org is
+// resolved from the row.
 func (c *ExperimentalClient) DeleteChatModelConfig(ctx context.Context, modelConfigID uuid.UUID) error {
-	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/experimental/chats/model-configs/%s", modelConfigID), nil)
+	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/experimental/chat-model-configs/%s", modelConfigID), nil)
 	if err != nil {
 		return err
 	}
@@ -2562,6 +2604,37 @@ func (c *ExperimentalClient) DeleteChatModelConfig(ctx context.Context, modelCon
 		return ReadBodyAsError(res)
 	}
 	return nil
+}
+
+// ChatAIProviderCatalogEntry is the redacted view of an AI provider that
+// org model admins may read. It carries only the capability metadata the
+// Models UI needs; key material, base URLs, and headers are never exposed.
+type ChatAIProviderCatalogEntry struct {
+	ID              uuid.UUID `json:"id" format:"uuid"`
+	Type            string    `json:"type"`
+	DisplayName     string    `json:"display_name"`
+	Icon            string    `json:"icon"`
+	Enabled         bool      `json:"enabled"`
+	HasAPIKey       bool      `json:"has_api_key"`
+	HasUserAPIKey   bool      `json:"has_user_api_key"`
+	AllowUserAPIKey bool      `json:"allow_user_api_key"`
+}
+
+// GetChatAIProviderCatalog returns the redacted AI provider catalog for org
+// model admins. Access requires create or update on chat model configs in
+// at least one of the caller's organizations.
+func (c *ExperimentalClient) GetChatAIProviderCatalog(ctx context.Context) ([]ChatAIProviderCatalogEntry, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/ai-providers/catalog", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, ReadBodyAsError(res)
+	}
+
+	var entries []ChatAIProviderCatalogEntry
+	return entries, json.NewDecoder(res.Body).Decode(&entries)
 }
 
 // GetChatCostSummary returns an aggregate cost summary for the specified

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -707,8 +707,10 @@ const (
 	ChatModelProviderUnavailableReasonUserAPIKeyRequired ChatModelProviderUnavailableReason = "user_api_key_required"
 )
 
-// ChatModel represents a model in the chat model catalog.
-type ChatModel struct {
+// MinimalChatModel is the runtime catalog view of a model. Its ID is the
+// synthetic catalog identity `provider:model` built by canonicalModelID, not
+// the chat_model_configs row UUID that ChatModel.ID carries.
+type MinimalChatModel struct {
 	ID          string `json:"id"`
 	Provider    string `json:"provider"`
 	Model       string `json:"model"`
@@ -720,11 +722,11 @@ type ChatModelProvider struct {
 	Provider          string                             `json:"provider"`
 	Available         bool                               `json:"available"`
 	UnavailableReason ChatModelProviderUnavailableReason `json:"unavailable_reason,omitempty"`
-	Models            []ChatModel                        `json:"models"`
+	Models            []MinimalChatModel                 `json:"models"`
 }
 
-// ChatModelsResponse is the catalog returned from chat model discovery.
-type ChatModelsResponse struct {
+// ChatModelAvailabilityResponse is the catalog returned from chat model discovery.
+type ChatModelAvailabilityResponse struct {
 	Providers []ChatModelProvider `json:"providers"`
 	// UnsupportedProviders lists configured providers the Agents harness
 	// cannot use, so the UI can explain the empty state.
@@ -1307,21 +1309,18 @@ type CreateUserChatProviderKeyRequest struct {
 	APIKey string `json:"api_key"`
 }
 
-// ChatModelConfig is an org-scoped model configuration.
-type ChatModelConfig struct {
-	ID             uuid.UUID `json:"id" format:"uuid"`
-	OrganizationID uuid.UUID `json:"organization_id" format:"uuid"`
-	// OrganizationDisplayName is set on union-list responses so user-context
-	// pages can label which org each copy belongs to.
-	OrganizationDisplayName string               `json:"organization_display_name,omitempty"`
-	AIProviderID            uuid.UUID            `json:"ai_provider_id" format:"uuid"`
-	Model                   string               `json:"model"`
-	DisplayName             string               `json:"display_name"`
-	Enabled                 bool                 `json:"enabled"`
-	IsDefault               bool                 `json:"is_default"`
-	ContextLimit            int64                `json:"context_limit"`
-	CompressionThreshold    int32                `json:"compression_threshold"`
-	ModelConfig             *ChatModelCallConfig `json:"model_config,omitempty"`
+// ChatModel is an org-scoped model configuration.
+type ChatModel struct {
+	ID                   uuid.UUID            `json:"id" format:"uuid"`
+	OrganizationID       uuid.UUID            `json:"organization_id" format:"uuid"`
+	AIProviderID         uuid.UUID            `json:"ai_provider_id" format:"uuid"`
+	Model                string               `json:"model"`
+	DisplayName          string               `json:"display_name"`
+	Enabled              bool                 `json:"enabled"`
+	IsDefault            bool                 `json:"is_default"`
+	ContextLimit         int64                `json:"context_limit"`
+	CompressionThreshold int32                `json:"compression_threshold"`
+	ModelConfig          *ChatModelCallConfig `json:"model_config,omitempty"`
 	// ReasoningEfforts lists selectable reasoning effort values through
 	// the model's configured maximum.
 	ReasoningEfforts []string  `json:"reasoning_efforts,omitempty"`
@@ -1581,8 +1580,8 @@ func (c *ChatModelCallConfig) unmarshal(data []byte, decode func(data []byte, v 
 	return nil
 }
 
-// CreateChatModelConfigRequest creates a chat model config.
-type CreateChatModelConfigRequest struct {
+// CreateChatModelRequest creates a chat model config.
+type CreateChatModelRequest struct {
 	AIProviderID         *uuid.UUID           `json:"ai_provider_id,omitempty" format:"uuid"`
 	Model                string               `json:"model"`
 	DisplayName          string               `json:"display_name,omitempty"`
@@ -1593,8 +1592,8 @@ type CreateChatModelConfigRequest struct {
 	ModelConfig          *ChatModelCallConfig `json:"model_config,omitempty"`
 }
 
-// UpdateChatModelConfigRequest updates a chat model config.
-type UpdateChatModelConfigRequest struct {
+// UpdateChatModelRequest updates a chat model config.
+type UpdateChatModelRequest struct {
 	AIProviderID         *uuid.UUID           `json:"ai_provider_id,omitempty" format:"uuid"`
 	Model                string               `json:"model,omitempty"`
 	DisplayName          string               `json:"display_name,omitempty"`
@@ -2351,18 +2350,19 @@ func (c *ExperimentalClient) ListChats(ctx context.Context, opts *ListChatsOptio
 	return chats, json.NewDecoder(res.Body).Decode(&chats)
 }
 
-// ListChatModels returns the available chat model catalog.
-func (c *ExperimentalClient) ListChatModels(ctx context.Context) (ChatModelsResponse, error) {
-	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/models", nil)
+// ChatModelAvailability returns the provider-grouped, per-caller
+// availability view of one organization's chat models.
+func (c *ExperimentalClient) ChatModelAvailability(ctx context.Context, organizationID uuid.UUID) (ChatModelAvailabilityResponse, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/organizations/%s/chats/models/available", organizationID), nil)
 	if err != nil {
-		return ChatModelsResponse{}, err
+		return ChatModelAvailabilityResponse{}, err
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return ChatModelsResponse{}, ReadBodyAsError(res)
+		return ChatModelAvailabilityResponse{}, ReadBodyAsError(res)
 	}
 
-	var catalog ChatModelsResponse
+	var catalog ChatModelAvailabilityResponse
 	return catalog, json.NewDecoder(res.Body).Decode(&catalog)
 }
 
@@ -2510,92 +2510,74 @@ func (c *ExperimentalClient) DeleteUserChatProviderKey(ctx context.Context, prov
 	return nil
 }
 
-// ListChatModelConfigs returns the union of chat model configs the caller
-// can read across all of their organizations. Rows carry the organization
-// ID and display name so user-context pages can label each copy.
-func (c *ExperimentalClient) ListChatModelConfigs(ctx context.Context) ([]ChatModelConfig, error) {
-	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chat-model-configs", nil)
+// ChatModels returns the chat model configs the caller can read in one
+// organization, plus the redacted provider descriptors the authoring page
+// needs, for org-scoped management and picker surfaces.
+func (c *ExperimentalClient) ChatModels(ctx context.Context, organizationID uuid.UUID) (OrganizationChatModelsResponse, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/organizations/%s/chats/models", organizationID), nil)
 	if err != nil {
-		return nil, err
+		return OrganizationChatModelsResponse{}, err
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return nil, ReadBodyAsError(res)
+		return OrganizationChatModelsResponse{}, ReadBodyAsError(res)
 	}
 
-	var configs []ChatModelConfig
-	return configs, json.NewDecoder(res.Body).Decode(&configs)
+	var resp OrganizationChatModelsResponse
+	return resp, json.NewDecoder(res.Body).Decode(&resp)
 }
 
-// ListChatModelConfigsByOrganization returns the chat model configs the
-// caller can read in one organization, for org-scoped management and
-// picker surfaces.
-func (c *ExperimentalClient) ListChatModelConfigsByOrganization(ctx context.Context, organizationID uuid.UUID) ([]ChatModelConfig, error) {
-	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/organizations/%s/chat-model-configs", organizationID), nil)
+// ChatModel fetches one chat model config by ID; the config's org is
+// resolved from the row.
+func (c *ExperimentalClient) ChatModel(ctx context.Context, modelConfigID uuid.UUID) (ChatModel, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/chats/models/%s", modelConfigID), nil)
 	if err != nil {
-		return nil, err
+		return ChatModel{}, err
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return nil, ReadBodyAsError(res)
+		return ChatModel{}, ReadBodyAsError(res)
 	}
 
-	var configs []ChatModelConfig
-	return configs, json.NewDecoder(res.Body).Decode(&configs)
-}
-
-// GetChatModelConfig fetches one chat model config by ID; the config's org
-// is resolved from the row.
-func (c *ExperimentalClient) GetChatModelConfig(ctx context.Context, modelConfigID uuid.UUID) (ChatModelConfig, error) {
-	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/chat-model-configs/%s", modelConfigID), nil)
-	if err != nil {
-		return ChatModelConfig{}, err
-	}
-	defer res.Body.Close()
-	if res.StatusCode != http.StatusOK {
-		return ChatModelConfig{}, ReadBodyAsError(res)
-	}
-
-	var config ChatModelConfig
+	var config ChatModel
 	return config, json.NewDecoder(res.Body).Decode(&config)
 }
 
-// CreateChatModelConfig creates a chat model config in the given
-// organization.
-func (c *ExperimentalClient) CreateChatModelConfig(ctx context.Context, organizationID uuid.UUID, req CreateChatModelConfigRequest) (ChatModelConfig, error) {
-	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/experimental/organizations/%s/chat-model-configs", organizationID), req)
+// CreateChatModel creates a chat model config in the given organization.
+func (c *ExperimentalClient) CreateChatModel(ctx context.Context, organizationID uuid.UUID, req CreateChatModelRequest) (ChatModel, error) {
+	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/experimental/organizations/%s/chats/models", organizationID), req)
 	if err != nil {
-		return ChatModelConfig{}, err
+		return ChatModel{}, err
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusCreated {
-		return ChatModelConfig{}, ReadBodyAsError(res)
+		return ChatModel{}, ReadBodyAsError(res)
 	}
 
-	var config ChatModelConfig
+	var config ChatModel
 	return config, json.NewDecoder(res.Body).Decode(&config)
 }
 
-// UpdateChatModelConfig updates a chat model config; the config's org is
-// resolved from the row.
-func (c *ExperimentalClient) UpdateChatModelConfig(ctx context.Context, modelConfigID uuid.UUID, req UpdateChatModelConfigRequest) (ChatModelConfig, error) {
-	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/experimental/chat-model-configs/%s", modelConfigID), req)
+// UpdateChatModel updates a chat model config; the config's org is resolved
+// from the row.
+func (c *ExperimentalClient) UpdateChatModel(ctx context.Context, modelConfigID uuid.UUID, req UpdateChatModelRequest) (ChatModel, error) {
+	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/experimental/chats/models/%s", modelConfigID), req)
 	if err != nil {
-		return ChatModelConfig{}, err
+		return ChatModel{}, err
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return ChatModelConfig{}, ReadBodyAsError(res)
+		return ChatModel{}, ReadBodyAsError(res)
 	}
 
-	var config ChatModelConfig
+	var config ChatModel
 	return config, json.NewDecoder(res.Body).Decode(&config)
 }
 
-// DeleteChatModelConfig deletes a chat model config; the config's org is
-// resolved from the row.
-func (c *ExperimentalClient) DeleteChatModelConfig(ctx context.Context, modelConfigID uuid.UUID) error {
-	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/experimental/chat-model-configs/%s", modelConfigID), nil)
+// DeleteChatModel deletes a chat model config; the config's org is resolved
+// from the row.
+func (c *ExperimentalClient) DeleteChatModel(ctx context.Context, modelConfigID uuid.UUID) error {
+	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/experimental/chats/models/%s", modelConfigID), nil)
 	if err != nil {
 		return err
 	}
@@ -2606,10 +2588,12 @@ func (c *ExperimentalClient) DeleteChatModelConfig(ctx context.Context, modelCon
 	return nil
 }
 
-// ChatAIProviderCatalogEntry is the redacted view of an AI provider that
-// org model admins may read. It carries only the capability metadata the
-// Models UI needs; key material, base URLs, and headers are never exposed.
-type ChatAIProviderCatalogEntry struct {
+// ChatModelProviderDescriptor is the redacted view of an AI provider carried
+// on the org model collection response. It carries only the capability
+// metadata the Models UI needs; key material, base URLs, and headers are
+// never exposed. The fields mirror what /api/experimental/chats/models
+// already discloses to any authenticated caller.
+type ChatModelProviderDescriptor struct {
 	ID              uuid.UUID `json:"id" format:"uuid"`
 	Type            string    `json:"type"`
 	DisplayName     string    `json:"display_name"`
@@ -2620,21 +2604,12 @@ type ChatAIProviderCatalogEntry struct {
 	AllowUserAPIKey bool      `json:"allow_user_api_key"`
 }
 
-// GetChatAIProviderCatalog returns the redacted AI provider catalog for org
-// model admins. Access requires create or update on chat model configs in
-// at least one of the caller's organizations.
-func (c *ExperimentalClient) GetChatAIProviderCatalog(ctx context.Context) ([]ChatAIProviderCatalogEntry, error) {
-	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/ai-providers/catalog", nil)
-	if err != nil {
-		return nil, err
-	}
-	defer res.Body.Close()
-	if res.StatusCode != http.StatusOK {
-		return nil, ReadBodyAsError(res)
-	}
-
-	var entries []ChatAIProviderCatalogEntry
-	return entries, json.NewDecoder(res.Body).Decode(&entries)
+// OrganizationChatModelsResponse is the org chat model config collection:
+// the caller-readable configs plus the redacted provider descriptors the
+// authoring page needs.
+type OrganizationChatModelsResponse struct {
+	Models    []ChatModel                   `json:"models"`
+	Providers []ChatModelProviderDescriptor `json:"providers"`
 }
 
 // GetChatCostSummary returns an aggregate cost summary for the specified

--- a/docs/reference/api/chats.md
+++ b/docs/reference/api/chats.md
@@ -578,59 +578,6 @@ Experimental: this endpoint is subject to change.
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
-## List chat models
-
-### Code samples
-
-```sh
-# Example request using curl
-curl -X GET http://coder-server:8080/api/experimental/chats/models \
-  -H 'Accept: application/json' \
-  -H 'Coder-Session-Token: API_KEY'
-```
-
-`GET /api/experimental/chats/models`
-
-Experimental: this endpoint is subject to change.
-
-### Example responses
-
-> 200 Response
-
-```json
-{
-  "providers": [
-    {
-      "available": true,
-      "models": [
-        {
-          "display_name": "string",
-          "id": "string",
-          "model": "string",
-          "provider": "string"
-        }
-      ],
-      "provider": "string",
-      "unavailable_reason": "missing_api_key"
-    }
-  ],
-  "unsupported_providers": [
-    {
-      "display_name": "string",
-      "provider": "string"
-    }
-  ]
-}
-```
-
-### Responses
-
-| Status | Meaning                                                 | Description | Schema                                                               |
-|--------|---------------------------------------------------------|-------------|----------------------------------------------------------------------|
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ChatModelsResponse](schemas.md#codersdkchatmodelsresponse) |
-
-To perform this operation, you must be authenticated. [Learn more](authentication.md).
-
 ## Watch chat events for a user via WebSockets
 
 ### Code samples
@@ -3206,5 +3153,64 @@ Experimental: this endpoint is subject to change.
 | Status | Meaning                                                 | Description | Schema                                   |
 |--------|---------------------------------------------------------|-------------|------------------------------------------|
 | 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.Chat](schemas.md#codersdkchat) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## List available chat models in an organization
+
+### Code samples
+
+```sh
+# Example request using curl
+curl -X GET http://coder-server:8080/api/experimental/organizations/{organization}/chats/models/available \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/experimental/organizations/{organization}/chats/models/available`
+
+Experimental: this endpoint is subject to change.
+
+### Parameters
+
+| Name           | In   | Type   | Required | Description             |
+|----------------|------|--------|----------|-------------------------|
+| `organization` | path | string | true     | Organization name or ID |
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "providers": [
+    {
+      "available": true,
+      "models": [
+        {
+          "display_name": "string",
+          "id": "string",
+          "model": "string",
+          "provider": "string"
+        }
+      ],
+      "provider": "string",
+      "unavailable_reason": "missing_api_key"
+    }
+  ],
+  "unsupported_providers": [
+    {
+      "display_name": "string",
+      "provider": "string"
+    }
+  ]
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                                     |
+|--------|---------------------------------------------------------|-------------|--------------------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ChatModelAvailabilityResponse](schemas.md#codersdkchatmodelavailabilityresponse) |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2376,34 +2376,6 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `groups` | array of [codersdk.ChatGroup](#codersdkchatgroup) | false    |              |             |
 | `users`  | array of [codersdk.ChatUser](#codersdkchatuser)   | false    |              |             |
 
-## codersdk.ChatAIProviderCatalogEntry
-
-```json
-{
-  "allow_user_api_key": true,
-  "display_name": "string",
-  "enabled": true,
-  "has_api_key": true,
-  "has_user_api_key": true,
-  "icon": "string",
-  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
-  "type": "string"
-}
-```
-
-### Properties
-
-| Name                 | Type    | Required | Restrictions | Description |
-|----------------------|---------|----------|--------------|-------------|
-| `allow_user_api_key` | boolean | false    |              |             |
-| `display_name`       | string  | false    |              |             |
-| `enabled`            | boolean | false    |              |             |
-| `has_api_key`        | boolean | false    |              |             |
-| `has_user_api_key`   | boolean | false    |              |             |
-| `icon`               | string  | false    |              |             |
-| `id`                 | string  | false    |              |             |
-| `type`               | string  | false    |              |             |
-
 ## codersdk.ChatBusyBehavior
 
 ```json
@@ -3268,21 +3240,195 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ```json
 {
+  "ai_provider_id": "5a3b8ff9-20e7-4c37-ba1a-5b433e355819",
+  "compression_threshold": 0,
+  "context_limit": 0,
+  "created_at": "2019-08-24T14:15:22Z",
   "display_name": "string",
-  "id": "string",
+  "enabled": true,
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "is_default": true,
   "model": "string",
-  "provider": "string"
+  "model_config": {
+    "cost": {
+      "cache_read_price_per_million_tokens": 0,
+      "cache_write_price_per_million_tokens": 0,
+      "input_price_per_million_tokens": 0,
+      "output_price_per_million_tokens": 0
+    },
+    "frequency_penalty": 0,
+    "max_output_tokens": 0,
+    "presence_penalty": 0,
+    "provider_options": {
+      "anthropic": {
+        "allowed_domains": [
+          "string"
+        ],
+        "blocked_domains": [
+          "string"
+        ],
+        "context_1m_enabled": true,
+        "disable_parallel_tool_use": true,
+        "send_reasoning": true,
+        "thinking": {
+          "budget_tokens": 0
+        },
+        "thinking_display": "string",
+        "web_search_enabled": true
+      },
+      "google": {
+        "cached_content": "string",
+        "safety_settings": [
+          {
+            "category": "string",
+            "threshold": "string"
+          }
+        ],
+        "thinking_config": {
+          "include_thoughts": true,
+          "thinking_budget": 0
+        },
+        "threshold": "string",
+        "web_search_enabled": true
+      },
+      "openai": {
+        "allowed_domains": [
+          "string"
+        ],
+        "include": [
+          "string"
+        ],
+        "instructions": "string",
+        "log_probs": true,
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "max_completion_tokens": 0,
+        "max_tool_calls": 0,
+        "metadata": {
+          "property1": null,
+          "property2": null
+        },
+        "parallel_tool_calls": true,
+        "prediction": {
+          "property1": null,
+          "property2": null
+        },
+        "prompt_cache_key": "string",
+        "reasoning_summary": "string",
+        "safety_identifier": "string",
+        "search_context_size": "string",
+        "service_tier": "string",
+        "store": true,
+        "strict_json_schema": true,
+        "structured_outputs": true,
+        "text_verbosity": "string",
+        "top_log_probs": 0,
+        "user": "string",
+        "web_search_enabled": true
+      },
+      "openaicompat": {
+        "user": "string"
+      },
+      "openrouter": {
+        "extra_body": {
+          "property1": null,
+          "property2": null
+        },
+        "include_usage": true,
+        "log_probs": true,
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "parallel_tool_calls": true,
+        "provider": {
+          "allow_fallbacks": true,
+          "data_collection": "string",
+          "ignore": [
+            "string"
+          ],
+          "only": [
+            "string"
+          ],
+          "order": [
+            "string"
+          ],
+          "quantizations": [
+            "string"
+          ],
+          "require_parameters": true,
+          "sort": "string"
+        },
+        "reasoning": {
+          "enabled": true,
+          "exclude": true,
+          "max_tokens": 0
+        },
+        "user": "string"
+      },
+      "vercel": {
+        "extra_body": {
+          "property1": null,
+          "property2": null
+        },
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "logprobs": true,
+        "parallel_tool_calls": true,
+        "providerOptions": {
+          "models": [
+            "string"
+          ],
+          "order": [
+            "string"
+          ]
+        },
+        "reasoning": {
+          "enabled": true,
+          "exclude": true,
+          "max_tokens": 0
+        },
+        "top_logprobs": 0,
+        "user": "string"
+      }
+    },
+    "reasoning_effort": {
+      "default": "string",
+      "max": "string"
+    },
+    "temperature": 0,
+    "top_k": 0,
+    "top_p": 0
+  },
+  "organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
+  "reasoning_efforts": [
+    "string"
+  ],
+  "updated_at": "2019-08-24T14:15:22Z"
 }
 ```
 
 ### Properties
 
-| Name           | Type   | Required | Restrictions | Description |
-|----------------|--------|----------|--------------|-------------|
-| `display_name` | string | false    |              |             |
-| `id`           | string | false    |              |             |
-| `model`        | string | false    |              |             |
-| `provider`     | string | false    |              |             |
+| Name                    | Type                                                         | Required | Restrictions | Description                                                                                        |
+|-------------------------|--------------------------------------------------------------|----------|--------------|----------------------------------------------------------------------------------------------------|
+| `ai_provider_id`        | string                                                       | false    |              |                                                                                                    |
+| `compression_threshold` | integer                                                      | false    |              |                                                                                                    |
+| `context_limit`         | integer                                                      | false    |              |                                                                                                    |
+| `created_at`            | string                                                       | false    |              |                                                                                                    |
+| `display_name`          | string                                                       | false    |              |                                                                                                    |
+| `enabled`               | boolean                                                      | false    |              |                                                                                                    |
+| `id`                    | string                                                       | false    |              |                                                                                                    |
+| `is_default`            | boolean                                                      | false    |              |                                                                                                    |
+| `model`                 | string                                                       | false    |              |                                                                                                    |
+| `model_config`          | [codersdk.ChatModelCallConfig](#codersdkchatmodelcallconfig) | false    |              |                                                                                                    |
+| `organization_id`       | string                                                       | false    |              |                                                                                                    |
+| `reasoning_efforts`     | array of string                                              | false    |              | Reasoning efforts lists selectable reasoning effort values through the model's configured maximum. |
+| `updated_at`            | string                                                       | false    |              |                                                                                                    |
 
 ## codersdk.ChatModelAnthropicProviderOptions
 
@@ -3331,6 +3477,41 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | Name            | Type    | Required | Restrictions | Description |
 |-----------------|---------|----------|--------------|-------------|
 | `budget_tokens` | integer | false    |              |             |
+
+## codersdk.ChatModelAvailabilityResponse
+
+```json
+{
+  "providers": [
+    {
+      "available": true,
+      "models": [
+        {
+          "display_name": "string",
+          "id": "string",
+          "model": "string",
+          "provider": "string"
+        }
+      ],
+      "provider": "string",
+      "unavailable_reason": "missing_api_key"
+    }
+  ],
+  "unsupported_providers": [
+    {
+      "display_name": "string",
+      "provider": "string"
+    }
+  ]
+}
+```
+
+### Properties
+
+| Name                    | Type                                                                          | Required | Restrictions | Description                                                                                                            |
+|-------------------------|-------------------------------------------------------------------------------|----------|--------------|------------------------------------------------------------------------------------------------------------------------|
+| `providers`             | array of [codersdk.ChatModelProvider](#codersdkchatmodelprovider)             | false    |              |                                                                                                                        |
+| `unsupported_providers` | array of [codersdk.ChatUnsupportedProvider](#codersdkchatunsupportedprovider) | false    |              | Unsupported providers lists configured providers the Agents harness cannot use, so the UI can explain the empty state. |
 
 ## codersdk.ChatModelCallConfig
 
@@ -3505,202 +3686,6 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `temperature`       | number                                                                             | false    |              |             |
 | `top_k`             | integer                                                                            | false    |              |             |
 | `top_p`             | number                                                                             | false    |              |             |
-
-## codersdk.ChatModelConfig
-
-```json
-{
-  "ai_provider_id": "5a3b8ff9-20e7-4c37-ba1a-5b433e355819",
-  "compression_threshold": 0,
-  "context_limit": 0,
-  "created_at": "2019-08-24T14:15:22Z",
-  "display_name": "string",
-  "enabled": true,
-  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
-  "is_default": true,
-  "model": "string",
-  "model_config": {
-    "cost": {
-      "cache_read_price_per_million_tokens": 0,
-      "cache_write_price_per_million_tokens": 0,
-      "input_price_per_million_tokens": 0,
-      "output_price_per_million_tokens": 0
-    },
-    "frequency_penalty": 0,
-    "max_output_tokens": 0,
-    "presence_penalty": 0,
-    "provider_options": {
-      "anthropic": {
-        "allowed_domains": [
-          "string"
-        ],
-        "blocked_domains": [
-          "string"
-        ],
-        "context_1m_enabled": true,
-        "disable_parallel_tool_use": true,
-        "send_reasoning": true,
-        "thinking": {
-          "budget_tokens": 0
-        },
-        "thinking_display": "string",
-        "web_search_enabled": true
-      },
-      "google": {
-        "cached_content": "string",
-        "safety_settings": [
-          {
-            "category": "string",
-            "threshold": "string"
-          }
-        ],
-        "thinking_config": {
-          "include_thoughts": true,
-          "thinking_budget": 0
-        },
-        "threshold": "string",
-        "web_search_enabled": true
-      },
-      "openai": {
-        "allowed_domains": [
-          "string"
-        ],
-        "include": [
-          "string"
-        ],
-        "instructions": "string",
-        "log_probs": true,
-        "logit_bias": {
-          "property1": 0,
-          "property2": 0
-        },
-        "max_completion_tokens": 0,
-        "max_tool_calls": 0,
-        "metadata": {
-          "property1": null,
-          "property2": null
-        },
-        "parallel_tool_calls": true,
-        "prediction": {
-          "property1": null,
-          "property2": null
-        },
-        "prompt_cache_key": "string",
-        "reasoning_summary": "string",
-        "safety_identifier": "string",
-        "search_context_size": "string",
-        "service_tier": "string",
-        "store": true,
-        "strict_json_schema": true,
-        "structured_outputs": true,
-        "text_verbosity": "string",
-        "top_log_probs": 0,
-        "user": "string",
-        "web_search_enabled": true
-      },
-      "openaicompat": {
-        "user": "string"
-      },
-      "openrouter": {
-        "extra_body": {
-          "property1": null,
-          "property2": null
-        },
-        "include_usage": true,
-        "log_probs": true,
-        "logit_bias": {
-          "property1": 0,
-          "property2": 0
-        },
-        "parallel_tool_calls": true,
-        "provider": {
-          "allow_fallbacks": true,
-          "data_collection": "string",
-          "ignore": [
-            "string"
-          ],
-          "only": [
-            "string"
-          ],
-          "order": [
-            "string"
-          ],
-          "quantizations": [
-            "string"
-          ],
-          "require_parameters": true,
-          "sort": "string"
-        },
-        "reasoning": {
-          "enabled": true,
-          "exclude": true,
-          "max_tokens": 0
-        },
-        "user": "string"
-      },
-      "vercel": {
-        "extra_body": {
-          "property1": null,
-          "property2": null
-        },
-        "logit_bias": {
-          "property1": 0,
-          "property2": 0
-        },
-        "logprobs": true,
-        "parallel_tool_calls": true,
-        "providerOptions": {
-          "models": [
-            "string"
-          ],
-          "order": [
-            "string"
-          ]
-        },
-        "reasoning": {
-          "enabled": true,
-          "exclude": true,
-          "max_tokens": 0
-        },
-        "top_logprobs": 0,
-        "user": "string"
-      }
-    },
-    "reasoning_effort": {
-      "default": "string",
-      "max": "string"
-    },
-    "temperature": 0,
-    "top_k": 0,
-    "top_p": 0
-  },
-  "organization_display_name": "string",
-  "organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
-  "reasoning_efforts": [
-    "string"
-  ],
-  "updated_at": "2019-08-24T14:15:22Z"
-}
-```
-
-### Properties
-
-| Name                        | Type                                                         | Required | Restrictions | Description                                                                                                              |
-|-----------------------------|--------------------------------------------------------------|----------|--------------|--------------------------------------------------------------------------------------------------------------------------|
-| `ai_provider_id`            | string                                                       | false    |              |                                                                                                                          |
-| `compression_threshold`     | integer                                                      | false    |              |                                                                                                                          |
-| `context_limit`             | integer                                                      | false    |              |                                                                                                                          |
-| `created_at`                | string                                                       | false    |              |                                                                                                                          |
-| `display_name`              | string                                                       | false    |              |                                                                                                                          |
-| `enabled`                   | boolean                                                      | false    |              |                                                                                                                          |
-| `id`                        | string                                                       | false    |              |                                                                                                                          |
-| `is_default`                | boolean                                                      | false    |              |                                                                                                                          |
-| `model`                     | string                                                       | false    |              |                                                                                                                          |
-| `model_config`              | [codersdk.ChatModelCallConfig](#codersdkchatmodelcallconfig) | false    |              |                                                                                                                          |
-| `organization_display_name` | string                                                       | false    |              | Organization display name is set on union-list responses so user-context pages can label which org each copy belongs to. |
-| `organization_id`           | string                                                       | false    |              |                                                                                                                          |
-| `reasoning_efforts`         | array of string                                              | false    |              | Reasoning efforts lists selectable reasoning effort values through the model's configured maximum.                       |
-| `updated_at`                | string                                                       | false    |              |                                                                                                                          |
 
 ## codersdk.ChatModelGoogleProviderOptions
 
@@ -3966,9 +3951,37 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | Name                 | Type                                                                                       | Required | Restrictions | Description |
 |----------------------|--------------------------------------------------------------------------------------------|----------|--------------|-------------|
 | `available`          | boolean                                                                                    | false    |              |             |
-| `models`             | array of [codersdk.ChatModel](#codersdkchatmodel)                                          | false    |              |             |
+| `models`             | array of [codersdk.MinimalChatModel](#codersdkminimalchatmodel)                            | false    |              |             |
 | `provider`           | string                                                                                     | false    |              |             |
 | `unavailable_reason` | [codersdk.ChatModelProviderUnavailableReason](#codersdkchatmodelproviderunavailablereason) | false    |              |             |
+
+## codersdk.ChatModelProviderDescriptor
+
+```json
+{
+  "allow_user_api_key": true,
+  "display_name": "string",
+  "enabled": true,
+  "has_api_key": true,
+  "has_user_api_key": true,
+  "icon": "string",
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "type": "string"
+}
+```
+
+### Properties
+
+| Name                 | Type    | Required | Restrictions | Description |
+|----------------------|---------|----------|--------------|-------------|
+| `allow_user_api_key` | boolean | false    |              |             |
+| `display_name`       | string  | false    |              |             |
+| `enabled`            | boolean | false    |              |             |
+| `has_api_key`        | boolean | false    |              |             |
+| `has_user_api_key`   | boolean | false    |              |             |
+| `icon`               | string  | false    |              |             |
+| `id`                 | string  | false    |              |             |
+| `type`               | string  | false    |              |             |
 
 ## codersdk.ChatModelProviderOptions
 
@@ -4237,41 +4250,6 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `reasoning`           | [codersdk.ChatModelReasoningOptions](#codersdkchatmodelreasoningoptions)                         | false    |              |             |
 | `top_logprobs`        | integer                                                                                          | false    |              |             |
 | `user`                | string                                                                                           | false    |              |             |
-
-## codersdk.ChatModelsResponse
-
-```json
-{
-  "providers": [
-    {
-      "available": true,
-      "models": [
-        {
-          "display_name": "string",
-          "id": "string",
-          "model": "string",
-          "provider": "string"
-        }
-      ],
-      "provider": "string",
-      "unavailable_reason": "missing_api_key"
-    }
-  ],
-  "unsupported_providers": [
-    {
-      "display_name": "string",
-      "provider": "string"
-    }
-  ]
-}
-```
-
-### Properties
-
-| Name                    | Type                                                                          | Required | Restrictions | Description                                                                                                            |
-|-------------------------|-------------------------------------------------------------------------------|----------|--------------|------------------------------------------------------------------------------------------------------------------------|
-| `providers`             | array of [codersdk.ChatModelProvider](#codersdkchatmodelprovider)             | false    |              |                                                                                                                        |
-| `unsupported_providers` | array of [codersdk.ChatUnsupportedProvider](#codersdkchatunsupportedprovider) | false    |              | Unsupported providers lists configured providers the Agents harness cannot use, so the UI can explain the empty state. |
 
 ## codersdk.ChatPlanMode
 
@@ -5704,7 +5682,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `queued_message` | [codersdk.ChatQueuedMessage](#codersdkchatqueuedmessage) | false    |              |                                                                                                                                                                                                    |
 | `warnings`       | array of string                                          | false    |              |                                                                                                                                                                                                    |
 
-## codersdk.CreateChatModelConfigRequest
+## codersdk.CreateChatModelRequest
 
 ```json
 {
@@ -9677,6 +9655,26 @@ Only certain features set these fields: - FeatureManagedAgentLimit - FeatureAgen
 | `count`              | integer | false    |              | Count is the number of provisioner daemons that matched the given tags. If the count is 0, it means no provisioner daemons matched the requested tags.              |
 | `most_recently_seen` | string  | false    |              | Most recently seen is the most recently seen time of the set of matched provisioners. If no provisioners matched, this field will be null.                          |
 
+## codersdk.MinimalChatModel
+
+```json
+{
+  "display_name": "string",
+  "id": "string",
+  "model": "string",
+  "provider": "string"
+}
+```
+
+### Properties
+
+| Name           | Type   | Required | Restrictions | Description |
+|----------------|--------|----------|--------------|-------------|
+| `display_name` | string | false    |              |             |
+| `id`           | string | false    |              |             |
+| `model`        | string | false    |              |             |
+| `provider`     | string | false    |              |             |
+
 ## codersdk.MinimalOrganization
 
 ```json
@@ -10690,6 +10688,205 @@ Only certain features set these fields: - FeatureManagedAgentLimit - FeatureAgen
 | `is_default`               | boolean         | true     |              |                                                                                                                                                 |
 | `name`                     | string          | false    |              |                                                                                                                                                 |
 | `updated_at`               | string          | true     |              |                                                                                                                                                 |
+
+## codersdk.OrganizationChatModelsResponse
+
+```json
+{
+  "models": [
+    {
+      "ai_provider_id": "5a3b8ff9-20e7-4c37-ba1a-5b433e355819",
+      "compression_threshold": 0,
+      "context_limit": 0,
+      "created_at": "2019-08-24T14:15:22Z",
+      "display_name": "string",
+      "enabled": true,
+      "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "is_default": true,
+      "model": "string",
+      "model_config": {
+        "cost": {
+          "cache_read_price_per_million_tokens": 0,
+          "cache_write_price_per_million_tokens": 0,
+          "input_price_per_million_tokens": 0,
+          "output_price_per_million_tokens": 0
+        },
+        "frequency_penalty": 0,
+        "max_output_tokens": 0,
+        "presence_penalty": 0,
+        "provider_options": {
+          "anthropic": {
+            "allowed_domains": [
+              "string"
+            ],
+            "blocked_domains": [
+              "string"
+            ],
+            "context_1m_enabled": true,
+            "disable_parallel_tool_use": true,
+            "send_reasoning": true,
+            "thinking": {
+              "budget_tokens": 0
+            },
+            "thinking_display": "string",
+            "web_search_enabled": true
+          },
+          "google": {
+            "cached_content": "string",
+            "safety_settings": [
+              {
+                "category": "string",
+                "threshold": "string"
+              }
+            ],
+            "thinking_config": {
+              "include_thoughts": true,
+              "thinking_budget": 0
+            },
+            "threshold": "string",
+            "web_search_enabled": true
+          },
+          "openai": {
+            "allowed_domains": [
+              "string"
+            ],
+            "include": [
+              "string"
+            ],
+            "instructions": "string",
+            "log_probs": true,
+            "logit_bias": {
+              "property1": 0,
+              "property2": 0
+            },
+            "max_completion_tokens": 0,
+            "max_tool_calls": 0,
+            "metadata": {
+              "property1": null,
+              "property2": null
+            },
+            "parallel_tool_calls": true,
+            "prediction": {
+              "property1": null,
+              "property2": null
+            },
+            "prompt_cache_key": "string",
+            "reasoning_summary": "string",
+            "safety_identifier": "string",
+            "search_context_size": "string",
+            "service_tier": "string",
+            "store": true,
+            "strict_json_schema": true,
+            "structured_outputs": true,
+            "text_verbosity": "string",
+            "top_log_probs": 0,
+            "user": "string",
+            "web_search_enabled": true
+          },
+          "openaicompat": {
+            "user": "string"
+          },
+          "openrouter": {
+            "extra_body": {
+              "property1": null,
+              "property2": null
+            },
+            "include_usage": true,
+            "log_probs": true,
+            "logit_bias": {
+              "property1": 0,
+              "property2": 0
+            },
+            "parallel_tool_calls": true,
+            "provider": {
+              "allow_fallbacks": true,
+              "data_collection": "string",
+              "ignore": [
+                "string"
+              ],
+              "only": [
+                "string"
+              ],
+              "order": [
+                "string"
+              ],
+              "quantizations": [
+                "string"
+              ],
+              "require_parameters": true,
+              "sort": "string"
+            },
+            "reasoning": {
+              "enabled": true,
+              "exclude": true,
+              "max_tokens": 0
+            },
+            "user": "string"
+          },
+          "vercel": {
+            "extra_body": {
+              "property1": null,
+              "property2": null
+            },
+            "logit_bias": {
+              "property1": 0,
+              "property2": 0
+            },
+            "logprobs": true,
+            "parallel_tool_calls": true,
+            "providerOptions": {
+              "models": [
+                "string"
+              ],
+              "order": [
+                "string"
+              ]
+            },
+            "reasoning": {
+              "enabled": true,
+              "exclude": true,
+              "max_tokens": 0
+            },
+            "top_logprobs": 0,
+            "user": "string"
+          }
+        },
+        "reasoning_effort": {
+          "default": "string",
+          "max": "string"
+        },
+        "temperature": 0,
+        "top_k": 0,
+        "top_p": 0
+      },
+      "organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
+      "reasoning_efforts": [
+        "string"
+      ],
+      "updated_at": "2019-08-24T14:15:22Z"
+    }
+  ],
+  "providers": [
+    {
+      "allow_user_api_key": true,
+      "display_name": "string",
+      "enabled": true,
+      "has_api_key": true,
+      "has_user_api_key": true,
+      "icon": "string",
+      "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "type": "string"
+    }
+  ]
+}
+```
+
+### Properties
+
+| Name        | Type                                                                                  | Required | Restrictions | Description |
+|-------------|---------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `models`    | array of [codersdk.ChatModel](#codersdkchatmodel)                                     | false    |              |             |
+| `providers` | array of [codersdk.ChatModelProviderDescriptor](#codersdkchatmodelproviderdescriptor) | false    |              |             |
 
 ## codersdk.OrganizationGroupAISpend
 
@@ -14912,7 +15109,7 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 | `user_roles`       | object                                 | false    |              |             |
 | » `[any property]` | [codersdk.ChatRole](#codersdkchatrole) | false    |              |             |
 
-## codersdk.UpdateChatModelConfigRequest
+## codersdk.UpdateChatModelRequest
 
 ```json
 {

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2376,6 +2376,34 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `groups` | array of [codersdk.ChatGroup](#codersdkchatgroup) | false    |              |             |
 | `users`  | array of [codersdk.ChatUser](#codersdkchatuser)   | false    |              |             |
 
+## codersdk.ChatAIProviderCatalogEntry
+
+```json
+{
+  "allow_user_api_key": true,
+  "display_name": "string",
+  "enabled": true,
+  "has_api_key": true,
+  "has_user_api_key": true,
+  "icon": "string",
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "type": "string"
+}
+```
+
+### Properties
+
+| Name                 | Type    | Required | Restrictions | Description |
+|----------------------|---------|----------|--------------|-------------|
+| `allow_user_api_key` | boolean | false    |              |             |
+| `display_name`       | string  | false    |              |             |
+| `enabled`            | boolean | false    |              |             |
+| `has_api_key`        | boolean | false    |              |             |
+| `has_user_api_key`   | boolean | false    |              |             |
+| `icon`               | string  | false    |              |             |
+| `id`                 | string  | false    |              |             |
+| `type`               | string  | false    |              |             |
+
 ## codersdk.ChatBusyBehavior
 
 ```json
@@ -3256,6 +3284,665 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `model`        | string | false    |              |             |
 | `provider`     | string | false    |              |             |
 
+## codersdk.ChatModelAnthropicProviderOptions
+
+```json
+{
+  "allowed_domains": [
+    "string"
+  ],
+  "blocked_domains": [
+    "string"
+  ],
+  "context_1m_enabled": true,
+  "disable_parallel_tool_use": true,
+  "send_reasoning": true,
+  "thinking": {
+    "budget_tokens": 0
+  },
+  "thinking_display": "string",
+  "web_search_enabled": true
+}
+```
+
+### Properties
+
+| Name                        | Type                                                                                     | Required | Restrictions | Description |
+|-----------------------------|------------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `allowed_domains`           | array of string                                                                          | false    |              |             |
+| `blocked_domains`           | array of string                                                                          | false    |              |             |
+| `context_1m_enabled`        | boolean                                                                                  | false    |              |             |
+| `disable_parallel_tool_use` | boolean                                                                                  | false    |              |             |
+| `send_reasoning`            | boolean                                                                                  | false    |              |             |
+| `thinking`                  | [codersdk.ChatModelAnthropicThinkingOptions](#codersdkchatmodelanthropicthinkingoptions) | false    |              |             |
+| `thinking_display`          | string                                                                                   | false    |              |             |
+| `web_search_enabled`        | boolean                                                                                  | false    |              |             |
+
+## codersdk.ChatModelAnthropicThinkingOptions
+
+```json
+{
+  "budget_tokens": 0
+}
+```
+
+### Properties
+
+| Name            | Type    | Required | Restrictions | Description |
+|-----------------|---------|----------|--------------|-------------|
+| `budget_tokens` | integer | false    |              |             |
+
+## codersdk.ChatModelCallConfig
+
+```json
+{
+  "cost": {
+    "cache_read_price_per_million_tokens": 0,
+    "cache_write_price_per_million_tokens": 0,
+    "input_price_per_million_tokens": 0,
+    "output_price_per_million_tokens": 0
+  },
+  "frequency_penalty": 0,
+  "max_output_tokens": 0,
+  "presence_penalty": 0,
+  "provider_options": {
+    "anthropic": {
+      "allowed_domains": [
+        "string"
+      ],
+      "blocked_domains": [
+        "string"
+      ],
+      "context_1m_enabled": true,
+      "disable_parallel_tool_use": true,
+      "send_reasoning": true,
+      "thinking": {
+        "budget_tokens": 0
+      },
+      "thinking_display": "string",
+      "web_search_enabled": true
+    },
+    "google": {
+      "cached_content": "string",
+      "safety_settings": [
+        {
+          "category": "string",
+          "threshold": "string"
+        }
+      ],
+      "thinking_config": {
+        "include_thoughts": true,
+        "thinking_budget": 0
+      },
+      "threshold": "string",
+      "web_search_enabled": true
+    },
+    "openai": {
+      "allowed_domains": [
+        "string"
+      ],
+      "include": [
+        "string"
+      ],
+      "instructions": "string",
+      "log_probs": true,
+      "logit_bias": {
+        "property1": 0,
+        "property2": 0
+      },
+      "max_completion_tokens": 0,
+      "max_tool_calls": 0,
+      "metadata": {
+        "property1": null,
+        "property2": null
+      },
+      "parallel_tool_calls": true,
+      "prediction": {
+        "property1": null,
+        "property2": null
+      },
+      "prompt_cache_key": "string",
+      "reasoning_summary": "string",
+      "safety_identifier": "string",
+      "search_context_size": "string",
+      "service_tier": "string",
+      "store": true,
+      "strict_json_schema": true,
+      "structured_outputs": true,
+      "text_verbosity": "string",
+      "top_log_probs": 0,
+      "user": "string",
+      "web_search_enabled": true
+    },
+    "openaicompat": {
+      "user": "string"
+    },
+    "openrouter": {
+      "extra_body": {
+        "property1": null,
+        "property2": null
+      },
+      "include_usage": true,
+      "log_probs": true,
+      "logit_bias": {
+        "property1": 0,
+        "property2": 0
+      },
+      "parallel_tool_calls": true,
+      "provider": {
+        "allow_fallbacks": true,
+        "data_collection": "string",
+        "ignore": [
+          "string"
+        ],
+        "only": [
+          "string"
+        ],
+        "order": [
+          "string"
+        ],
+        "quantizations": [
+          "string"
+        ],
+        "require_parameters": true,
+        "sort": "string"
+      },
+      "reasoning": {
+        "enabled": true,
+        "exclude": true,
+        "max_tokens": 0
+      },
+      "user": "string"
+    },
+    "vercel": {
+      "extra_body": {
+        "property1": null,
+        "property2": null
+      },
+      "logit_bias": {
+        "property1": 0,
+        "property2": 0
+      },
+      "logprobs": true,
+      "parallel_tool_calls": true,
+      "providerOptions": {
+        "models": [
+          "string"
+        ],
+        "order": [
+          "string"
+        ]
+      },
+      "reasoning": {
+        "enabled": true,
+        "exclude": true,
+        "max_tokens": 0
+      },
+      "top_logprobs": 0,
+      "user": "string"
+    }
+  },
+  "reasoning_effort": {
+    "default": "string",
+    "max": "string"
+  },
+  "temperature": 0,
+  "top_k": 0,
+  "top_p": 0
+}
+```
+
+### Properties
+
+| Name                | Type                                                                               | Required | Restrictions | Description |
+|---------------------|------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `cost`              | [codersdk.ModelCostConfig](#codersdkmodelcostconfig)                               | false    |              |             |
+| `frequency_penalty` | number                                                                             | false    |              |             |
+| `max_output_tokens` | integer                                                                            | false    |              |             |
+| `presence_penalty`  | number                                                                             | false    |              |             |
+| `provider_options`  | [codersdk.ChatModelProviderOptions](#codersdkchatmodelprovideroptions)             | false    |              |             |
+| `reasoning_effort`  | [codersdk.ChatModelReasoningEffortConfig](#codersdkchatmodelreasoningeffortconfig) | false    |              |             |
+| `temperature`       | number                                                                             | false    |              |             |
+| `top_k`             | integer                                                                            | false    |              |             |
+| `top_p`             | number                                                                             | false    |              |             |
+
+## codersdk.ChatModelConfig
+
+```json
+{
+  "ai_provider_id": "5a3b8ff9-20e7-4c37-ba1a-5b433e355819",
+  "compression_threshold": 0,
+  "context_limit": 0,
+  "created_at": "2019-08-24T14:15:22Z",
+  "display_name": "string",
+  "enabled": true,
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "is_default": true,
+  "model": "string",
+  "model_config": {
+    "cost": {
+      "cache_read_price_per_million_tokens": 0,
+      "cache_write_price_per_million_tokens": 0,
+      "input_price_per_million_tokens": 0,
+      "output_price_per_million_tokens": 0
+    },
+    "frequency_penalty": 0,
+    "max_output_tokens": 0,
+    "presence_penalty": 0,
+    "provider_options": {
+      "anthropic": {
+        "allowed_domains": [
+          "string"
+        ],
+        "blocked_domains": [
+          "string"
+        ],
+        "context_1m_enabled": true,
+        "disable_parallel_tool_use": true,
+        "send_reasoning": true,
+        "thinking": {
+          "budget_tokens": 0
+        },
+        "thinking_display": "string",
+        "web_search_enabled": true
+      },
+      "google": {
+        "cached_content": "string",
+        "safety_settings": [
+          {
+            "category": "string",
+            "threshold": "string"
+          }
+        ],
+        "thinking_config": {
+          "include_thoughts": true,
+          "thinking_budget": 0
+        },
+        "threshold": "string",
+        "web_search_enabled": true
+      },
+      "openai": {
+        "allowed_domains": [
+          "string"
+        ],
+        "include": [
+          "string"
+        ],
+        "instructions": "string",
+        "log_probs": true,
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "max_completion_tokens": 0,
+        "max_tool_calls": 0,
+        "metadata": {
+          "property1": null,
+          "property2": null
+        },
+        "parallel_tool_calls": true,
+        "prediction": {
+          "property1": null,
+          "property2": null
+        },
+        "prompt_cache_key": "string",
+        "reasoning_summary": "string",
+        "safety_identifier": "string",
+        "search_context_size": "string",
+        "service_tier": "string",
+        "store": true,
+        "strict_json_schema": true,
+        "structured_outputs": true,
+        "text_verbosity": "string",
+        "top_log_probs": 0,
+        "user": "string",
+        "web_search_enabled": true
+      },
+      "openaicompat": {
+        "user": "string"
+      },
+      "openrouter": {
+        "extra_body": {
+          "property1": null,
+          "property2": null
+        },
+        "include_usage": true,
+        "log_probs": true,
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "parallel_tool_calls": true,
+        "provider": {
+          "allow_fallbacks": true,
+          "data_collection": "string",
+          "ignore": [
+            "string"
+          ],
+          "only": [
+            "string"
+          ],
+          "order": [
+            "string"
+          ],
+          "quantizations": [
+            "string"
+          ],
+          "require_parameters": true,
+          "sort": "string"
+        },
+        "reasoning": {
+          "enabled": true,
+          "exclude": true,
+          "max_tokens": 0
+        },
+        "user": "string"
+      },
+      "vercel": {
+        "extra_body": {
+          "property1": null,
+          "property2": null
+        },
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "logprobs": true,
+        "parallel_tool_calls": true,
+        "providerOptions": {
+          "models": [
+            "string"
+          ],
+          "order": [
+            "string"
+          ]
+        },
+        "reasoning": {
+          "enabled": true,
+          "exclude": true,
+          "max_tokens": 0
+        },
+        "top_logprobs": 0,
+        "user": "string"
+      }
+    },
+    "reasoning_effort": {
+      "default": "string",
+      "max": "string"
+    },
+    "temperature": 0,
+    "top_k": 0,
+    "top_p": 0
+  },
+  "organization_display_name": "string",
+  "organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
+  "reasoning_efforts": [
+    "string"
+  ],
+  "updated_at": "2019-08-24T14:15:22Z"
+}
+```
+
+### Properties
+
+| Name                        | Type                                                         | Required | Restrictions | Description                                                                                                              |
+|-----------------------------|--------------------------------------------------------------|----------|--------------|--------------------------------------------------------------------------------------------------------------------------|
+| `ai_provider_id`            | string                                                       | false    |              |                                                                                                                          |
+| `compression_threshold`     | integer                                                      | false    |              |                                                                                                                          |
+| `context_limit`             | integer                                                      | false    |              |                                                                                                                          |
+| `created_at`                | string                                                       | false    |              |                                                                                                                          |
+| `display_name`              | string                                                       | false    |              |                                                                                                                          |
+| `enabled`                   | boolean                                                      | false    |              |                                                                                                                          |
+| `id`                        | string                                                       | false    |              |                                                                                                                          |
+| `is_default`                | boolean                                                      | false    |              |                                                                                                                          |
+| `model`                     | string                                                       | false    |              |                                                                                                                          |
+| `model_config`              | [codersdk.ChatModelCallConfig](#codersdkchatmodelcallconfig) | false    |              |                                                                                                                          |
+| `organization_display_name` | string                                                       | false    |              | Organization display name is set on union-list responses so user-context pages can label which org each copy belongs to. |
+| `organization_id`           | string                                                       | false    |              |                                                                                                                          |
+| `reasoning_efforts`         | array of string                                              | false    |              | Reasoning efforts lists selectable reasoning effort values through the model's configured maximum.                       |
+| `updated_at`                | string                                                       | false    |              |                                                                                                                          |
+
+## codersdk.ChatModelGoogleProviderOptions
+
+```json
+{
+  "cached_content": "string",
+  "safety_settings": [
+    {
+      "category": "string",
+      "threshold": "string"
+    }
+  ],
+  "thinking_config": {
+    "include_thoughts": true,
+    "thinking_budget": 0
+  },
+  "threshold": "string",
+  "web_search_enabled": true
+}
+```
+
+### Properties
+
+| Name                 | Type                                                                                    | Required | Restrictions | Description |
+|----------------------|-----------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `cached_content`     | string                                                                                  | false    |              |             |
+| `safety_settings`    | array of [codersdk.ChatModelGoogleSafetySetting](#codersdkchatmodelgooglesafetysetting) | false    |              |             |
+| `thinking_config`    | [codersdk.ChatModelGoogleThinkingConfig](#codersdkchatmodelgooglethinkingconfig)        | false    |              |             |
+| `threshold`          | string                                                                                  | false    |              |             |
+| `web_search_enabled` | boolean                                                                                 | false    |              |             |
+
+## codersdk.ChatModelGoogleSafetySetting
+
+```json
+{
+  "category": "string",
+  "threshold": "string"
+}
+```
+
+### Properties
+
+| Name        | Type   | Required | Restrictions | Description |
+|-------------|--------|----------|--------------|-------------|
+| `category`  | string | false    |              |             |
+| `threshold` | string | false    |              |             |
+
+## codersdk.ChatModelGoogleThinkingConfig
+
+```json
+{
+  "include_thoughts": true,
+  "thinking_budget": 0
+}
+```
+
+### Properties
+
+| Name               | Type    | Required | Restrictions | Description |
+|--------------------|---------|----------|--------------|-------------|
+| `include_thoughts` | boolean | false    |              |             |
+| `thinking_budget`  | integer | false    |              |             |
+
+## codersdk.ChatModelOpenAICompatProviderOptions
+
+```json
+{
+  "user": "string"
+}
+```
+
+### Properties
+
+| Name   | Type   | Required | Restrictions | Description |
+|--------|--------|----------|--------------|-------------|
+| `user` | string | false    |              |             |
+
+## codersdk.ChatModelOpenAIProviderOptions
+
+```json
+{
+  "allowed_domains": [
+    "string"
+  ],
+  "include": [
+    "string"
+  ],
+  "instructions": "string",
+  "log_probs": true,
+  "logit_bias": {
+    "property1": 0,
+    "property2": 0
+  },
+  "max_completion_tokens": 0,
+  "max_tool_calls": 0,
+  "metadata": {
+    "property1": null,
+    "property2": null
+  },
+  "parallel_tool_calls": true,
+  "prediction": {
+    "property1": null,
+    "property2": null
+  },
+  "prompt_cache_key": "string",
+  "reasoning_summary": "string",
+  "safety_identifier": "string",
+  "search_context_size": "string",
+  "service_tier": "string",
+  "store": true,
+  "strict_json_schema": true,
+  "structured_outputs": true,
+  "text_verbosity": "string",
+  "top_log_probs": 0,
+  "user": "string",
+  "web_search_enabled": true
+}
+```
+
+### Properties
+
+| Name                    | Type            | Required | Restrictions | Description |
+|-------------------------|-----------------|----------|--------------|-------------|
+| `allowed_domains`       | array of string | false    |              |             |
+| `include`               | array of string | false    |              |             |
+| `instructions`          | string          | false    |              |             |
+| `log_probs`             | boolean         | false    |              |             |
+| `logit_bias`            | object          | false    |              |             |
+| » `[any property]`      | integer         | false    |              |             |
+| `max_completion_tokens` | integer         | false    |              |             |
+| `max_tool_calls`        | integer         | false    |              |             |
+| `metadata`              | object          | false    |              |             |
+| » `[any property]`      | any             | false    |              |             |
+| `parallel_tool_calls`   | boolean         | false    |              |             |
+| `prediction`            | object          | false    |              |             |
+| » `[any property]`      | any             | false    |              |             |
+| `prompt_cache_key`      | string          | false    |              |             |
+| `reasoning_summary`     | string          | false    |              |             |
+| `safety_identifier`     | string          | false    |              |             |
+| `search_context_size`   | string          | false    |              |             |
+| `service_tier`          | string          | false    |              |             |
+| `store`                 | boolean         | false    |              |             |
+| `strict_json_schema`    | boolean         | false    |              |             |
+| `structured_outputs`    | boolean         | false    |              |             |
+| `text_verbosity`        | string          | false    |              |             |
+| `top_log_probs`         | integer         | false    |              |             |
+| `user`                  | string          | false    |              |             |
+| `web_search_enabled`    | boolean         | false    |              |             |
+
+## codersdk.ChatModelOpenRouterProvider
+
+```json
+{
+  "allow_fallbacks": true,
+  "data_collection": "string",
+  "ignore": [
+    "string"
+  ],
+  "only": [
+    "string"
+  ],
+  "order": [
+    "string"
+  ],
+  "quantizations": [
+    "string"
+  ],
+  "require_parameters": true,
+  "sort": "string"
+}
+```
+
+### Properties
+
+| Name                 | Type            | Required | Restrictions | Description |
+|----------------------|-----------------|----------|--------------|-------------|
+| `allow_fallbacks`    | boolean         | false    |              |             |
+| `data_collection`    | string          | false    |              |             |
+| `ignore`             | array of string | false    |              |             |
+| `only`               | array of string | false    |              |             |
+| `order`              | array of string | false    |              |             |
+| `quantizations`      | array of string | false    |              |             |
+| `require_parameters` | boolean         | false    |              |             |
+| `sort`               | string          | false    |              |             |
+
+## codersdk.ChatModelOpenRouterProviderOptions
+
+```json
+{
+  "extra_body": {
+    "property1": null,
+    "property2": null
+  },
+  "include_usage": true,
+  "log_probs": true,
+  "logit_bias": {
+    "property1": 0,
+    "property2": 0
+  },
+  "parallel_tool_calls": true,
+  "provider": {
+    "allow_fallbacks": true,
+    "data_collection": "string",
+    "ignore": [
+      "string"
+    ],
+    "only": [
+      "string"
+    ],
+    "order": [
+      "string"
+    ],
+    "quantizations": [
+      "string"
+    ],
+    "require_parameters": true,
+    "sort": "string"
+  },
+  "reasoning": {
+    "enabled": true,
+    "exclude": true,
+    "max_tokens": 0
+  },
+  "user": "string"
+}
+```
+
+### Properties
+
+| Name                  | Type                                                                         | Required | Restrictions | Description |
+|-----------------------|------------------------------------------------------------------------------|----------|--------------|-------------|
+| `extra_body`          | object                                                                       | false    |              |             |
+| » `[any property]`    | any                                                                          | false    |              |             |
+| `include_usage`       | boolean                                                                      | false    |              |             |
+| `log_probs`           | boolean                                                                      | false    |              |             |
+| `logit_bias`          | object                                                                       | false    |              |             |
+| » `[any property]`    | integer                                                                      | false    |              |             |
+| `parallel_tool_calls` | boolean                                                                      | false    |              |             |
+| `provider`            | [codersdk.ChatModelOpenRouterProvider](#codersdkchatmodelopenrouterprovider) | false    |              |             |
+| `reasoning`           | [codersdk.ChatModelReasoningOptions](#codersdkchatmodelreasoningoptions)     | false    |              |             |
+| `user`                | string                                                                       | false    |              |             |
+
 ## codersdk.ChatModelProvider
 
 ```json
@@ -3283,6 +3970,159 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `provider`           | string                                                                                     | false    |              |             |
 | `unavailable_reason` | [codersdk.ChatModelProviderUnavailableReason](#codersdkchatmodelproviderunavailablereason) | false    |              |             |
 
+## codersdk.ChatModelProviderOptions
+
+```json
+{
+  "anthropic": {
+    "allowed_domains": [
+      "string"
+    ],
+    "blocked_domains": [
+      "string"
+    ],
+    "context_1m_enabled": true,
+    "disable_parallel_tool_use": true,
+    "send_reasoning": true,
+    "thinking": {
+      "budget_tokens": 0
+    },
+    "thinking_display": "string",
+    "web_search_enabled": true
+  },
+  "google": {
+    "cached_content": "string",
+    "safety_settings": [
+      {
+        "category": "string",
+        "threshold": "string"
+      }
+    ],
+    "thinking_config": {
+      "include_thoughts": true,
+      "thinking_budget": 0
+    },
+    "threshold": "string",
+    "web_search_enabled": true
+  },
+  "openai": {
+    "allowed_domains": [
+      "string"
+    ],
+    "include": [
+      "string"
+    ],
+    "instructions": "string",
+    "log_probs": true,
+    "logit_bias": {
+      "property1": 0,
+      "property2": 0
+    },
+    "max_completion_tokens": 0,
+    "max_tool_calls": 0,
+    "metadata": {
+      "property1": null,
+      "property2": null
+    },
+    "parallel_tool_calls": true,
+    "prediction": {
+      "property1": null,
+      "property2": null
+    },
+    "prompt_cache_key": "string",
+    "reasoning_summary": "string",
+    "safety_identifier": "string",
+    "search_context_size": "string",
+    "service_tier": "string",
+    "store": true,
+    "strict_json_schema": true,
+    "structured_outputs": true,
+    "text_verbosity": "string",
+    "top_log_probs": 0,
+    "user": "string",
+    "web_search_enabled": true
+  },
+  "openaicompat": {
+    "user": "string"
+  },
+  "openrouter": {
+    "extra_body": {
+      "property1": null,
+      "property2": null
+    },
+    "include_usage": true,
+    "log_probs": true,
+    "logit_bias": {
+      "property1": 0,
+      "property2": 0
+    },
+    "parallel_tool_calls": true,
+    "provider": {
+      "allow_fallbacks": true,
+      "data_collection": "string",
+      "ignore": [
+        "string"
+      ],
+      "only": [
+        "string"
+      ],
+      "order": [
+        "string"
+      ],
+      "quantizations": [
+        "string"
+      ],
+      "require_parameters": true,
+      "sort": "string"
+    },
+    "reasoning": {
+      "enabled": true,
+      "exclude": true,
+      "max_tokens": 0
+    },
+    "user": "string"
+  },
+  "vercel": {
+    "extra_body": {
+      "property1": null,
+      "property2": null
+    },
+    "logit_bias": {
+      "property1": 0,
+      "property2": 0
+    },
+    "logprobs": true,
+    "parallel_tool_calls": true,
+    "providerOptions": {
+      "models": [
+        "string"
+      ],
+      "order": [
+        "string"
+      ]
+    },
+    "reasoning": {
+      "enabled": true,
+      "exclude": true,
+      "max_tokens": 0
+    },
+    "top_logprobs": 0,
+    "user": "string"
+  }
+}
+```
+
+### Properties
+
+| Name           | Type                                                                                           | Required | Restrictions | Description |
+|----------------|------------------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `anthropic`    | [codersdk.ChatModelAnthropicProviderOptions](#codersdkchatmodelanthropicprovideroptions)       | false    |              |             |
+| `google`       | [codersdk.ChatModelGoogleProviderOptions](#codersdkchatmodelgoogleprovideroptions)             | false    |              |             |
+| `openai`       | [codersdk.ChatModelOpenAIProviderOptions](#codersdkchatmodelopenaiprovideroptions)             | false    |              |             |
+| `openaicompat` | [codersdk.ChatModelOpenAICompatProviderOptions](#codersdkchatmodelopenaicompatprovideroptions) | false    |              |             |
+| `openrouter`   | [codersdk.ChatModelOpenRouterProviderOptions](#codersdkchatmodelopenrouterprovideroptions)     | false    |              |             |
+| `vercel`       | [codersdk.ChatModelVercelProviderOptions](#codersdkchatmodelvercelprovideroptions)             | false    |              |             |
+
 ## codersdk.ChatModelProviderUnavailableReason
 
 ```json
@@ -3296,6 +4136,107 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | Value(s)                                                   |
 |------------------------------------------------------------|
 | `fetch_failed`, `missing_api_key`, `user_api_key_required` |
+
+## codersdk.ChatModelReasoningEffortConfig
+
+```json
+{
+  "default": "string",
+  "max": "string"
+}
+```
+
+### Properties
+
+| Name      | Type   | Required | Restrictions | Description |
+|-----------|--------|----------|--------------|-------------|
+| `default` | string | false    |              |             |
+| `max`     | string | false    |              |             |
+
+## codersdk.ChatModelReasoningOptions
+
+```json
+{
+  "enabled": true,
+  "exclude": true,
+  "max_tokens": 0
+}
+```
+
+### Properties
+
+| Name         | Type    | Required | Restrictions | Description |
+|--------------|---------|----------|--------------|-------------|
+| `enabled`    | boolean | false    |              |             |
+| `exclude`    | boolean | false    |              |             |
+| `max_tokens` | integer | false    |              |             |
+
+## codersdk.ChatModelVercelGatewayProviderOptions
+
+```json
+{
+  "models": [
+    "string"
+  ],
+  "order": [
+    "string"
+  ]
+}
+```
+
+### Properties
+
+| Name     | Type            | Required | Restrictions | Description |
+|----------|-----------------|----------|--------------|-------------|
+| `models` | array of string | false    |              |             |
+| `order`  | array of string | false    |              |             |
+
+## codersdk.ChatModelVercelProviderOptions
+
+```json
+{
+  "extra_body": {
+    "property1": null,
+    "property2": null
+  },
+  "logit_bias": {
+    "property1": 0,
+    "property2": 0
+  },
+  "logprobs": true,
+  "parallel_tool_calls": true,
+  "providerOptions": {
+    "models": [
+      "string"
+    ],
+    "order": [
+      "string"
+    ]
+  },
+  "reasoning": {
+    "enabled": true,
+    "exclude": true,
+    "max_tokens": 0
+  },
+  "top_logprobs": 0,
+  "user": "string"
+}
+```
+
+### Properties
+
+| Name                  | Type                                                                                             | Required | Restrictions | Description |
+|-----------------------|--------------------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `extra_body`          | object                                                                                           | false    |              |             |
+| » `[any property]`    | any                                                                                              | false    |              |             |
+| `logit_bias`          | object                                                                                           | false    |              |             |
+| » `[any property]`    | integer                                                                                          | false    |              |             |
+| `logprobs`            | boolean                                                                                          | false    |              |             |
+| `parallel_tool_calls` | boolean                                                                                          | false    |              |             |
+| `providerOptions`     | [codersdk.ChatModelVercelGatewayProviderOptions](#codersdkchatmodelvercelgatewayprovideroptions) | false    |              |             |
+| `reasoning`           | [codersdk.ChatModelReasoningOptions](#codersdkchatmodelreasoningoptions)                         | false    |              |             |
+| `top_logprobs`        | integer                                                                                          | false    |              |             |
+| `user`                | string                                                                                           | false    |              |             |
 
 ## codersdk.ChatModelsResponse
 
@@ -4762,6 +5703,188 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `queued`         | boolean                                                  | false    |              |                                                                                                                                                                                                    |
 | `queued_message` | [codersdk.ChatQueuedMessage](#codersdkchatqueuedmessage) | false    |              |                                                                                                                                                                                                    |
 | `warnings`       | array of string                                          | false    |              |                                                                                                                                                                                                    |
+
+## codersdk.CreateChatModelConfigRequest
+
+```json
+{
+  "ai_provider_id": "5a3b8ff9-20e7-4c37-ba1a-5b433e355819",
+  "compression_threshold": 0,
+  "context_limit": 0,
+  "display_name": "string",
+  "enabled": true,
+  "is_default": true,
+  "model": "string",
+  "model_config": {
+    "cost": {
+      "cache_read_price_per_million_tokens": 0,
+      "cache_write_price_per_million_tokens": 0,
+      "input_price_per_million_tokens": 0,
+      "output_price_per_million_tokens": 0
+    },
+    "frequency_penalty": 0,
+    "max_output_tokens": 0,
+    "presence_penalty": 0,
+    "provider_options": {
+      "anthropic": {
+        "allowed_domains": [
+          "string"
+        ],
+        "blocked_domains": [
+          "string"
+        ],
+        "context_1m_enabled": true,
+        "disable_parallel_tool_use": true,
+        "send_reasoning": true,
+        "thinking": {
+          "budget_tokens": 0
+        },
+        "thinking_display": "string",
+        "web_search_enabled": true
+      },
+      "google": {
+        "cached_content": "string",
+        "safety_settings": [
+          {
+            "category": "string",
+            "threshold": "string"
+          }
+        ],
+        "thinking_config": {
+          "include_thoughts": true,
+          "thinking_budget": 0
+        },
+        "threshold": "string",
+        "web_search_enabled": true
+      },
+      "openai": {
+        "allowed_domains": [
+          "string"
+        ],
+        "include": [
+          "string"
+        ],
+        "instructions": "string",
+        "log_probs": true,
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "max_completion_tokens": 0,
+        "max_tool_calls": 0,
+        "metadata": {
+          "property1": null,
+          "property2": null
+        },
+        "parallel_tool_calls": true,
+        "prediction": {
+          "property1": null,
+          "property2": null
+        },
+        "prompt_cache_key": "string",
+        "reasoning_summary": "string",
+        "safety_identifier": "string",
+        "search_context_size": "string",
+        "service_tier": "string",
+        "store": true,
+        "strict_json_schema": true,
+        "structured_outputs": true,
+        "text_verbosity": "string",
+        "top_log_probs": 0,
+        "user": "string",
+        "web_search_enabled": true
+      },
+      "openaicompat": {
+        "user": "string"
+      },
+      "openrouter": {
+        "extra_body": {
+          "property1": null,
+          "property2": null
+        },
+        "include_usage": true,
+        "log_probs": true,
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "parallel_tool_calls": true,
+        "provider": {
+          "allow_fallbacks": true,
+          "data_collection": "string",
+          "ignore": [
+            "string"
+          ],
+          "only": [
+            "string"
+          ],
+          "order": [
+            "string"
+          ],
+          "quantizations": [
+            "string"
+          ],
+          "require_parameters": true,
+          "sort": "string"
+        },
+        "reasoning": {
+          "enabled": true,
+          "exclude": true,
+          "max_tokens": 0
+        },
+        "user": "string"
+      },
+      "vercel": {
+        "extra_body": {
+          "property1": null,
+          "property2": null
+        },
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "logprobs": true,
+        "parallel_tool_calls": true,
+        "providerOptions": {
+          "models": [
+            "string"
+          ],
+          "order": [
+            "string"
+          ]
+        },
+        "reasoning": {
+          "enabled": true,
+          "exclude": true,
+          "max_tokens": 0
+        },
+        "top_logprobs": 0,
+        "user": "string"
+      }
+    },
+    "reasoning_effort": {
+      "default": "string",
+      "max": "string"
+    },
+    "temperature": 0,
+    "top_k": 0,
+    "top_p": 0
+  }
+}
+```
+
+### Properties
+
+| Name                    | Type                                                         | Required | Restrictions | Description |
+|-------------------------|--------------------------------------------------------------|----------|--------------|-------------|
+| `ai_provider_id`        | string                                                       | false    |              |             |
+| `compression_threshold` | integer                                                      | false    |              |             |
+| `context_limit`         | integer                                                      | false    |              |             |
+| `display_name`          | string                                                       | false    |              |             |
+| `enabled`               | boolean                                                      | false    |              |             |
+| `is_default`            | boolean                                                      | false    |              |             |
+| `model`                 | string                                                       | false    |              |             |
+| `model_config`          | [codersdk.ChatModelCallConfig](#codersdkchatmodelcallconfig) | false    |              |             |
 
 ## codersdk.CreateChatRequest
 
@@ -8593,6 +9716,26 @@ Only certain features set these fields: - FeatureManagedAgentLimit - FeatureAgen
 | `id`         | string | true     |              |             |
 | `name`       | string | false    |              |             |
 | `username`   | string | true     |              |             |
+
+## codersdk.ModelCostConfig
+
+```json
+{
+  "cache_read_price_per_million_tokens": 0,
+  "cache_write_price_per_million_tokens": 0,
+  "input_price_per_million_tokens": 0,
+  "output_price_per_million_tokens": 0
+}
+```
+
+### Properties
+
+| Name                                   | Type   | Required | Restrictions | Description |
+|----------------------------------------|--------|----------|--------------|-------------|
+| `cache_read_price_per_million_tokens`  | number | false    |              |             |
+| `cache_write_price_per_million_tokens` | number | false    |              |             |
+| `input_price_per_million_tokens`       | number | false    |              |             |
+| `output_price_per_million_tokens`      | number | false    |              |             |
 
 ## codersdk.NotificationMethodsResponse
 
@@ -13768,6 +14911,188 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 | » `[any property]` | [codersdk.ChatRole](#codersdkchatrole) | false    |              |             |
 | `user_roles`       | object                                 | false    |              |             |
 | » `[any property]` | [codersdk.ChatRole](#codersdkchatrole) | false    |              |             |
+
+## codersdk.UpdateChatModelConfigRequest
+
+```json
+{
+  "ai_provider_id": "5a3b8ff9-20e7-4c37-ba1a-5b433e355819",
+  "compression_threshold": 0,
+  "context_limit": 0,
+  "display_name": "string",
+  "enabled": true,
+  "is_default": true,
+  "model": "string",
+  "model_config": {
+    "cost": {
+      "cache_read_price_per_million_tokens": 0,
+      "cache_write_price_per_million_tokens": 0,
+      "input_price_per_million_tokens": 0,
+      "output_price_per_million_tokens": 0
+    },
+    "frequency_penalty": 0,
+    "max_output_tokens": 0,
+    "presence_penalty": 0,
+    "provider_options": {
+      "anthropic": {
+        "allowed_domains": [
+          "string"
+        ],
+        "blocked_domains": [
+          "string"
+        ],
+        "context_1m_enabled": true,
+        "disable_parallel_tool_use": true,
+        "send_reasoning": true,
+        "thinking": {
+          "budget_tokens": 0
+        },
+        "thinking_display": "string",
+        "web_search_enabled": true
+      },
+      "google": {
+        "cached_content": "string",
+        "safety_settings": [
+          {
+            "category": "string",
+            "threshold": "string"
+          }
+        ],
+        "thinking_config": {
+          "include_thoughts": true,
+          "thinking_budget": 0
+        },
+        "threshold": "string",
+        "web_search_enabled": true
+      },
+      "openai": {
+        "allowed_domains": [
+          "string"
+        ],
+        "include": [
+          "string"
+        ],
+        "instructions": "string",
+        "log_probs": true,
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "max_completion_tokens": 0,
+        "max_tool_calls": 0,
+        "metadata": {
+          "property1": null,
+          "property2": null
+        },
+        "parallel_tool_calls": true,
+        "prediction": {
+          "property1": null,
+          "property2": null
+        },
+        "prompt_cache_key": "string",
+        "reasoning_summary": "string",
+        "safety_identifier": "string",
+        "search_context_size": "string",
+        "service_tier": "string",
+        "store": true,
+        "strict_json_schema": true,
+        "structured_outputs": true,
+        "text_verbosity": "string",
+        "top_log_probs": 0,
+        "user": "string",
+        "web_search_enabled": true
+      },
+      "openaicompat": {
+        "user": "string"
+      },
+      "openrouter": {
+        "extra_body": {
+          "property1": null,
+          "property2": null
+        },
+        "include_usage": true,
+        "log_probs": true,
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "parallel_tool_calls": true,
+        "provider": {
+          "allow_fallbacks": true,
+          "data_collection": "string",
+          "ignore": [
+            "string"
+          ],
+          "only": [
+            "string"
+          ],
+          "order": [
+            "string"
+          ],
+          "quantizations": [
+            "string"
+          ],
+          "require_parameters": true,
+          "sort": "string"
+        },
+        "reasoning": {
+          "enabled": true,
+          "exclude": true,
+          "max_tokens": 0
+        },
+        "user": "string"
+      },
+      "vercel": {
+        "extra_body": {
+          "property1": null,
+          "property2": null
+        },
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "logprobs": true,
+        "parallel_tool_calls": true,
+        "providerOptions": {
+          "models": [
+            "string"
+          ],
+          "order": [
+            "string"
+          ]
+        },
+        "reasoning": {
+          "enabled": true,
+          "exclude": true,
+          "max_tokens": 0
+        },
+        "top_logprobs": 0,
+        "user": "string"
+      }
+    },
+    "reasoning_effort": {
+      "default": "string",
+      "max": "string"
+    },
+    "temperature": 0,
+    "top_k": 0,
+    "top_p": 0
+  }
+}
+```
+
+### Properties
+
+| Name                    | Type                                                         | Required | Restrictions | Description |
+|-------------------------|--------------------------------------------------------------|----------|--------------|-------------|
+| `ai_provider_id`        | string                                                       | false    |              |             |
+| `compression_threshold` | integer                                                      | false    |              |             |
+| `context_limit`         | integer                                                      | false    |              |             |
+| `display_name`          | string                                                       | false    |              |             |
+| `enabled`               | boolean                                                      | false    |              |             |
+| `is_default`            | boolean                                                      | false    |              |             |
+| `model`                 | string                                                       | false    |              |             |
+| `model_config`          | [codersdk.ChatModelCallConfig](#codersdkchatmodelcallconfig) | false    |              |             |
 
 ## codersdk.UpdateChatRequest
 

--- a/enterprise/coderd/exp_chats_test.go
+++ b/enterprise/coderd/exp_chats_test.go
@@ -51,12 +51,12 @@ func createOpenAIModelConfigForTest(
 	client *codersdk.ExperimentalClient,
 	apiKey string,
 	baseURL string,
-) codersdk.ChatModelConfig {
+) codersdk.ChatModel {
 	t.Helper()
 	provider := createOpenAIProviderForTest(ctx, t, client, apiKey, baseURL)
 	defaultOrg, err := client.Client.OrganizationByName(ctx, codersdk.DefaultOrganization)
 	require.NoError(t, err)
-	model, err := client.CreateChatModelConfig(ctx, defaultOrg.ID, codersdk.CreateChatModelConfigRequest{
+	model, err := client.CreateChatModel(ctx, defaultOrg.ID, codersdk.CreateChatModelRequest{
 		AIProviderID:         &provider.ID,
 		Model:                "gpt-4",
 		DisplayName:          "GPT-4",
@@ -954,10 +954,10 @@ func TestChatModelConfigDefault(t *testing.T) {
 	trueValue := true
 	falseValue := false
 
-	firstModel, err := expClient.CreateChatModelConfig(
+	firstModel, err := expClient.CreateChatModel(
 		ctx,
 		defaultOrg.ID,
-		codersdk.CreateChatModelConfigRequest{
+		codersdk.CreateChatModelRequest{
 			AIProviderID:         &provider.ID,
 			Model:                "gpt-5-a",
 			DisplayName:          "GPT 5 A",
@@ -969,10 +969,10 @@ func TestChatModelConfigDefault(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, firstModel.IsDefault)
 
-	secondModel, err := expClient.CreateChatModelConfig(
+	secondModel, err := expClient.CreateChatModel(
 		ctx,
 		defaultOrg.ID,
-		codersdk.CreateChatModelConfigRequest{
+		codersdk.CreateChatModelRequest{
 			AIProviderID:         &provider.ID,
 			Model:                "gpt-5-b",
 			DisplayName:          "GPT 5 B",
@@ -984,53 +984,53 @@ func TestChatModelConfigDefault(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, secondModel.IsDefault)
 
-	modelConfigs, err := expClient.ListChatModelConfigs(ctx)
+	modelConfigs, err := expClient.ChatModels(ctx, defaultOrg.ID)
 	require.NoError(t, err)
-	firstStored := findChatModelConfigByID(t, modelConfigs, firstModel.ID)
-	secondStored := findChatModelConfigByID(t, modelConfigs, secondModel.ID)
+	firstStored := findChatModelConfigByID(t, modelConfigs.Models, firstModel.ID)
+	secondStored := findChatModelConfigByID(t, modelConfigs.Models, secondModel.ID)
 	require.False(t, firstStored.IsDefault)
 	require.True(t, secondStored.IsDefault)
 
-	updatedFirst, err := expClient.UpdateChatModelConfig(
+	updatedFirst, err := expClient.UpdateChatModel(
 		ctx,
 		firstModel.ID,
-		codersdk.UpdateChatModelConfigRequest{
+		codersdk.UpdateChatModelRequest{
 			IsDefault: &trueValue,
 		},
 	)
 	require.NoError(t, err)
 	require.True(t, updatedFirst.IsDefault)
 
-	modelConfigs, err = expClient.ListChatModelConfigs(ctx)
+	modelConfigs, err = expClient.ChatModels(ctx, defaultOrg.ID)
 	require.NoError(t, err)
-	firstStored = findChatModelConfigByID(t, modelConfigs, firstModel.ID)
-	secondStored = findChatModelConfigByID(t, modelConfigs, secondModel.ID)
+	firstStored = findChatModelConfigByID(t, modelConfigs.Models, firstModel.ID)
+	secondStored = findChatModelConfigByID(t, modelConfigs.Models, secondModel.ID)
 	require.True(t, firstStored.IsDefault)
 	require.False(t, secondStored.IsDefault)
 
-	updatedFirst, err = expClient.UpdateChatModelConfig(
+	updatedFirst, err = expClient.UpdateChatModel(
 		ctx,
 		firstModel.ID,
-		codersdk.UpdateChatModelConfigRequest{
+		codersdk.UpdateChatModelRequest{
 			IsDefault: &falseValue,
 		},
 	)
 	require.NoError(t, err)
 	require.False(t, updatedFirst.IsDefault)
 
-	modelConfigs, err = expClient.ListChatModelConfigs(ctx)
+	modelConfigs, err = expClient.ChatModels(ctx, defaultOrg.ID)
 	require.NoError(t, err)
-	firstStored = findChatModelConfigByID(t, modelConfigs, firstModel.ID)
-	secondStored = findChatModelConfigByID(t, modelConfigs, secondModel.ID)
+	firstStored = findChatModelConfigByID(t, modelConfigs.Models, firstModel.ID)
+	secondStored = findChatModelConfigByID(t, modelConfigs.Models, secondModel.ID)
 	require.False(t, firstStored.IsDefault)
 	require.True(t, secondStored.IsDefault)
 }
 
 func findChatModelConfigByID(
 	t *testing.T,
-	modelConfigs []codersdk.ChatModelConfig,
+	modelConfigs []codersdk.ChatModel,
 	id uuid.UUID,
-) codersdk.ChatModelConfig {
+) codersdk.ChatModel {
 	t.Helper()
 
 	for _, modelConfig := range modelConfigs {
@@ -1040,7 +1040,7 @@ func findChatModelConfigByID(
 	}
 
 	require.FailNowf(t, "missing model config", "model config %s not found", id)
-	return codersdk.ChatModelConfig{}
+	return codersdk.ChatModel{}
 }
 
 // cookieOnlySessionTokenProvider authenticates HTTP requests via the
@@ -1107,7 +1107,7 @@ func TestCreateChatNonDefaultOrg(t *testing.T) {
 
 	// Strict org scoping: the chat below lives in the second org, so its
 	// default model config must too.
-	_, err := expClient.CreateChatModelConfig(ctx, secondOrg.ID, codersdk.CreateChatModelConfigRequest{
+	_, err := expClient.CreateChatModel(ctx, secondOrg.ID, codersdk.CreateChatModelRequest{
 		AIProviderID:         &provider.ID,
 		Model:                "gpt-4o-mini",
 		DisplayName:          "Test Model",
@@ -1176,7 +1176,7 @@ func TestCreateChatCrossOrgModelConfigRejected(t *testing.T) {
 	provider := createOpenAIProviderForTest(ctx, t, expClient, "test-key", "https://example.com")
 
 	// The config lives in the default org.
-	defaultConfig, err := expClient.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+	defaultConfig, err := expClient.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 		AIProviderID:         &provider.ID,
 		Model:                "gpt-4o-mini",
 		DisplayName:          "Default Org Model",
@@ -1239,7 +1239,7 @@ func TestListChats_OrgAdminOnlySeesOwnChats(t *testing.T) {
 
 	// Strict org scoping: the chats below live in the second org, so
 	// their default model config must too.
-	_, err := expClient.CreateChatModelConfig(ctx, secondOrg.ID, codersdk.CreateChatModelConfigRequest{
+	_, err := expClient.CreateChatModel(ctx, secondOrg.ID, codersdk.CreateChatModelRequest{
 		AIProviderID:         &provider.ID,
 		Model:                "gpt-4o-mini",
 		DisplayName:          "Test Model",

--- a/enterprise/coderd/exp_chats_test.go
+++ b/enterprise/coderd/exp_chats_test.go
@@ -54,7 +54,9 @@ func createOpenAIModelConfigForTest(
 ) codersdk.ChatModelConfig {
 	t.Helper()
 	provider := createOpenAIProviderForTest(ctx, t, client, apiKey, baseURL)
-	model, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+	defaultOrg, err := client.Client.OrganizationByName(ctx, codersdk.DefaultOrganization)
+	require.NoError(t, err)
+	model, err := client.CreateChatModelConfig(ctx, defaultOrg.ID, codersdk.CreateChatModelConfigRequest{
 		AIProviderID:         &provider.ID,
 		Model:                "gpt-4",
 		DisplayName:          "GPT-4",
@@ -944,6 +946,8 @@ func TestChatModelConfigDefault(t *testing.T) {
 	expClient := codersdk.NewExperimentalClient(client)
 
 	provider := createOpenAIProviderForTest(ctx, t, expClient, "test", "https://example.com")
+	defaultOrg, err := expClient.Client.OrganizationByName(ctx, codersdk.DefaultOrganization)
+	require.NoError(t, err)
 
 	contextLimit := int64(1000)
 	compressionThreshold := int32(70)
@@ -952,6 +956,7 @@ func TestChatModelConfigDefault(t *testing.T) {
 
 	firstModel, err := expClient.CreateChatModelConfig(
 		ctx,
+		defaultOrg.ID,
 		codersdk.CreateChatModelConfigRequest{
 			AIProviderID:         &provider.ID,
 			Model:                "gpt-5-a",
@@ -966,6 +971,7 @@ func TestChatModelConfigDefault(t *testing.T) {
 
 	secondModel, err := expClient.CreateChatModelConfig(
 		ctx,
+		defaultOrg.ID,
 		codersdk.CreateChatModelConfigRequest{
 			AIProviderID:         &provider.ID,
 			Model:                "gpt-5-b",
@@ -1095,7 +1101,13 @@ func TestCreateChatNonDefaultOrg(t *testing.T) {
 	expClient := codersdk.NewExperimentalClient(client)
 
 	provider := createOpenAIProviderForTest(ctx, t, expClient, "test-key", "https://example.com")
-	_, err := expClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+
+	// Create a second (non-default) org via the API.
+	secondOrg := coderdenttest.CreateOrganization(t, client, coderdenttest.CreateOrganizationOptions{})
+
+	// Strict org scoping: the chat below lives in the second org, so its
+	// default model config must too.
+	_, err := expClient.CreateChatModelConfig(ctx, secondOrg.ID, codersdk.CreateChatModelConfigRequest{
 		AIProviderID:         &provider.ID,
 		Model:                "gpt-4o-mini",
 		DisplayName:          "Test Model",
@@ -1104,9 +1116,6 @@ func TestCreateChatNonDefaultOrg(t *testing.T) {
 		CompressionThreshold: ptr.Ref(int32(70)),
 	})
 	require.NoError(t, err)
-
-	// Create a second (non-default) org via the API.
-	secondOrg := coderdenttest.CreateOrganization(t, client, coderdenttest.CreateOrganizationOptions{})
 
 	// Create a member with agents-access in both orgs.
 	memberClientRaw, member := coderdtest.CreateAnotherUser(
@@ -1143,6 +1152,66 @@ func TestCreateChatNonDefaultOrg(t *testing.T) {
 	require.True(t, found, "chat should be visible in list")
 }
 
+// TestCreateChatCrossOrgModelConfigRejected proves an explicit
+// model_config_id naming a config in a DIFFERENT org than the chat is
+// rejected as unavailable: post-cutover validation is org-aware, so a
+// config outside the chat's org is "not found or disabled" to the creator.
+func TestCreateChatCrossOrgModelConfigRejected(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+
+	client, firstUser := coderdenttest.New(t, &coderdenttest.Options{
+		Options: &coderdtest.Options{
+			DeploymentValues: coderdtest.DeploymentValues(t),
+		},
+		LicenseOptions: &coderdenttest.LicenseOptions{
+			Features: license.Features{
+				codersdk.FeatureMultipleOrganizations: 1,
+			},
+		},
+	})
+	expClient := codersdk.NewExperimentalClient(client)
+
+	provider := createOpenAIProviderForTest(ctx, t, expClient, "test-key", "https://example.com")
+
+	// The config lives in the default org.
+	defaultConfig, err := expClient.CreateChatModelConfig(ctx, firstUser.OrganizationID, codersdk.CreateChatModelConfigRequest{
+		AIProviderID:         &provider.ID,
+		Model:                "gpt-4o-mini",
+		DisplayName:          "Default Org Model",
+		IsDefault:            ptr.Ref(true),
+		ContextLimit:         ptr.Ref(int64(1000)),
+		CompressionThreshold: ptr.Ref(int32(70)),
+	})
+	require.NoError(t, err)
+
+	secondOrg := coderdenttest.CreateOrganization(t, client, coderdenttest.CreateOrganizationOptions{})
+
+	// A member with agents-access in both orgs still cannot bind a chat in
+	// the second org to the default org's config.
+	memberClientRaw, _ := coderdtest.CreateAnotherUser(
+		t, client, firstUser.OrganizationID,
+		rbac.ScopedRoleAgentsAccess(firstUser.OrganizationID),
+		rbac.ScopedRoleAgentsAccess(secondOrg.ID),
+	)
+	memberClient := codersdk.NewExperimentalClient(memberClientRaw)
+
+	_, err = memberClient.CreateChat(ctx, codersdk.CreateChatRequest{
+		OrganizationID: secondOrg.ID,
+		Content: []codersdk.ChatInputPart{{
+			Type: codersdk.ChatInputPartTypeText,
+			Text: "hello",
+		}},
+		ModelConfigID: ptr.Ref(defaultConfig.ID),
+	})
+	require.Error(t, err)
+	var sdkErr *codersdk.Error
+	require.ErrorAs(t, err, &sdkErr)
+	require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
+	require.Equal(t, "Invalid model_config_id: model config not found or disabled.", sdkErr.Message)
+}
+
 func TestListChats_OrgAdminOnlySeesOwnChats(t *testing.T) {
 	t.Parallel()
 
@@ -1164,7 +1233,13 @@ func TestListChats_OrgAdminOnlySeesOwnChats(t *testing.T) {
 	expClient := codersdk.NewExperimentalClient(client)
 
 	provider := createOpenAIProviderForTest(ctx, t, expClient, "test-key", "https://example.com")
-	_, err := expClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+
+	// Create a second (non-default) org.
+	secondOrg := coderdenttest.CreateOrganization(t, client, coderdenttest.CreateOrganizationOptions{})
+
+	// Strict org scoping: the chats below live in the second org, so
+	// their default model config must too.
+	_, err := expClient.CreateChatModelConfig(ctx, secondOrg.ID, codersdk.CreateChatModelConfigRequest{
 		AIProviderID:         &provider.ID,
 		Model:                "gpt-4o-mini",
 		DisplayName:          "Test Model",
@@ -1173,9 +1248,6 @@ func TestListChats_OrgAdminOnlySeesOwnChats(t *testing.T) {
 		CompressionThreshold: ptr.Ref(int32(70)),
 	})
 	require.NoError(t, err)
-
-	// Create a second (non-default) org.
-	secondOrg := coderdenttest.CreateOrganization(t, client, coderdenttest.CreateOrganizationOptions{})
 
 	// Create a member with agents-access in both orgs.
 	memberClientRaw, _ := coderdtest.CreateAnotherUser(

--- a/scaletest/chat/client.go
+++ b/scaletest/chat/client.go
@@ -22,8 +22,8 @@ type chatClient interface {
 var _ chatClient = (*codersdk.ExperimentalClient)(nil)
 
 type chatModelConfigClient interface {
-	ListChatModelConfigs(ctx context.Context) ([]codersdk.ChatModelConfig, error)
-	CreateChatModelConfig(ctx context.Context, req codersdk.CreateChatModelConfigRequest) (codersdk.ChatModelConfig, error)
+	ListChatModelConfigsByOrganization(ctx context.Context, organizationID uuid.UUID) ([]codersdk.ChatModelConfig, error)
+	CreateChatModelConfig(ctx context.Context, organizationID uuid.UUID, req codersdk.CreateChatModelConfigRequest) (codersdk.ChatModelConfig, error)
 }
 
 var _ chatModelConfigClient = (*codersdk.ExperimentalClient)(nil)

--- a/scaletest/chat/client.go
+++ b/scaletest/chat/client.go
@@ -22,8 +22,8 @@ type chatClient interface {
 var _ chatClient = (*codersdk.ExperimentalClient)(nil)
 
 type chatModelConfigClient interface {
-	ListChatModelConfigsByOrganization(ctx context.Context, organizationID uuid.UUID) ([]codersdk.ChatModelConfig, error)
-	CreateChatModelConfig(ctx context.Context, organizationID uuid.UUID, req codersdk.CreateChatModelConfigRequest) (codersdk.ChatModelConfig, error)
+	ChatModels(ctx context.Context, organizationID uuid.UUID) (codersdk.OrganizationChatModelsResponse, error)
+	CreateChatModel(ctx context.Context, organizationID uuid.UUID, req codersdk.CreateChatModelRequest) (codersdk.ChatModel, error)
 }
 
 var _ chatModelConfigClient = (*codersdk.ExperimentalClient)(nil)

--- a/scaletest/chat/provider.go
+++ b/scaletest/chat/provider.go
@@ -93,21 +93,21 @@ func EnsureScaletestModelConfig(ctx context.Context, client *codersdk.Client, lo
 }
 
 func ensureScaletestChatModelConfig(ctx context.Context, client chatModelConfigClient, logger slog.Logger, provider codersdk.AIProvider, organizationID uuid.UUID) (uuid.UUID, error) {
-	modelConfigs, err := client.ListChatModelConfigsByOrganization(ctx, organizationID)
+	resp, err := client.ChatModels(ctx, organizationID)
 	if err != nil {
 		return uuid.Nil, xerrors.Errorf("list chat model configs: %w", err)
 	}
 
-	for i := range modelConfigs {
-		matchesProvider := modelConfigs[i].AIProviderID == provider.ID
-		matchesModel := modelConfigs[i].Model == scaletestModelName
+	for i := range resp.Models {
+		matchesProvider := resp.Models[i].AIProviderID == provider.ID
+		matchesModel := resp.Models[i].Model == scaletestModelName
 		if !matchesProvider || !matchesModel {
 			continue
 		}
-		if !modelConfigs[i].Enabled {
-			return uuid.Nil, xerrors.Errorf("existing scaletest chat model config %s is disabled; re-enable or delete it before running scaletests", modelConfigs[i].ID)
+		if !resp.Models[i].Enabled {
+			return uuid.Nil, xerrors.Errorf("existing scaletest chat model config %s is disabled; re-enable or delete it before running scaletests", resp.Models[i].ID)
 		}
-		modelConfigID := modelConfigs[i].ID
+		modelConfigID := resp.Models[i].ID
 		logger.Info(ctx, "reusing scaletest model config", slog.F("model_config_id", modelConfigID), slog.F("organization_id", organizationID))
 		return modelConfigID, nil
 	}
@@ -115,7 +115,7 @@ func ensureScaletestChatModelConfig(ctx context.Context, client chatModelConfigC
 	enabled := true
 	isDefault := false
 	contextLimit := scaletestModelContextLimit
-	created, err := client.CreateChatModelConfig(ctx, organizationID, codersdk.CreateChatModelConfigRequest{
+	created, err := client.CreateChatModel(ctx, organizationID, codersdk.CreateChatModelRequest{
 		AIProviderID: &provider.ID,
 		Model:        scaletestModelName,
 		DisplayName:  scaletestModelDisplayName,

--- a/scaletest/chat/provider.go
+++ b/scaletest/chat/provider.go
@@ -38,18 +38,21 @@ const (
 	scaletestAIProviderActionReused  scaletestAIProviderAction = "reused"
 )
 
-// EnsureScaletestModelConfig bootstraps the shared AI provider and model
-// config used by chat scaletests. When the provider was created or updated,
-// it sleeps for propagationWait so every coderd replica's cached provider
-// config expires before chats start.
-func EnsureScaletestModelConfig(ctx context.Context, client *codersdk.Client, logger slog.Logger, llmMockURL string, propagationWait time.Duration) (uuid.UUID, error) {
+// EnsureScaletestModelConfig bootstraps the shared AI provider used by chat
+// scaletests and returns a resolver that yields the scaletest model config
+// for a given organization, creating or reusing it in that org. Model
+// configs are org-scoped, so a scaletest spanning organizations needs one
+// config per org. When the provider was created or updated, it sleeps for
+// propagationWait so every coderd replica's cached provider config expires
+// before chats start.
+func EnsureScaletestModelConfig(ctx context.Context, client *codersdk.Client, logger slog.Logger, llmMockURL string, propagationWait time.Duration) (func(organizationID uuid.UUID) (uuid.UUID, error), error) {
 	expClient := codersdk.NewExperimentalClient(client)
 
 	logger.Info(ctx, "bootstrapping mock LLM provider", slog.F("llm_mock_url", llmMockURL))
 
 	provider, providerAction, err := ensureScaletestAIProvider(ctx, expClient, llmMockURL)
 	if err != nil {
-		return uuid.Nil, err
+		return nil, err
 	}
 
 	switch providerAction {
@@ -72,11 +75,6 @@ func EnsureScaletestModelConfig(ctx context.Context, client *codersdk.Client, lo
 		)
 	}
 
-	modelConfigID, err := ensureScaletestChatModelConfig(ctx, expClient, logger, provider)
-	if err != nil {
-		return uuid.Nil, err
-	}
-
 	if providerAction != scaletestAIProviderActionReused && propagationWait > 0 {
 		logger.Info(ctx, "waiting for mock LLM provider propagation",
 			slog.F("provider_name", provider.Name),
@@ -84,16 +82,18 @@ func EnsureScaletestModelConfig(ctx context.Context, client *codersdk.Client, lo
 		)
 		select {
 		case <-ctx.Done():
-			return uuid.Nil, ctx.Err()
+			return nil, ctx.Err()
 		case <-time.After(propagationWait):
 		}
 	}
 
-	return modelConfigID, nil
+	return func(organizationID uuid.UUID) (uuid.UUID, error) {
+		return ensureScaletestChatModelConfig(ctx, expClient, logger, provider, organizationID)
+	}, nil
 }
 
-func ensureScaletestChatModelConfig(ctx context.Context, client chatModelConfigClient, logger slog.Logger, provider codersdk.AIProvider) (uuid.UUID, error) {
-	modelConfigs, err := client.ListChatModelConfigs(ctx)
+func ensureScaletestChatModelConfig(ctx context.Context, client chatModelConfigClient, logger slog.Logger, provider codersdk.AIProvider, organizationID uuid.UUID) (uuid.UUID, error) {
+	modelConfigs, err := client.ListChatModelConfigsByOrganization(ctx, organizationID)
 	if err != nil {
 		return uuid.Nil, xerrors.Errorf("list chat model configs: %w", err)
 	}
@@ -108,14 +108,14 @@ func ensureScaletestChatModelConfig(ctx context.Context, client chatModelConfigC
 			return uuid.Nil, xerrors.Errorf("existing scaletest chat model config %s is disabled; re-enable or delete it before running scaletests", modelConfigs[i].ID)
 		}
 		modelConfigID := modelConfigs[i].ID
-		logger.Info(ctx, "reusing scaletest model config", slog.F("model_config_id", modelConfigID))
+		logger.Info(ctx, "reusing scaletest model config", slog.F("model_config_id", modelConfigID), slog.F("organization_id", organizationID))
 		return modelConfigID, nil
 	}
 
 	enabled := true
 	isDefault := false
 	contextLimit := scaletestModelContextLimit
-	created, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+	created, err := client.CreateChatModelConfig(ctx, organizationID, codersdk.CreateChatModelConfigRequest{
 		AIProviderID: &provider.ID,
 		Model:        scaletestModelName,
 		DisplayName:  scaletestModelDisplayName,
@@ -126,7 +126,7 @@ func ensureScaletestChatModelConfig(ctx context.Context, client chatModelConfigC
 	if err != nil {
 		return uuid.Nil, xerrors.Errorf("create scaletest chat model config: %w", err)
 	}
-	logger.Info(ctx, "created scaletest model config", slog.F("model_config_id", created.ID))
+	logger.Info(ctx, "created scaletest model config", slog.F("model_config_id", created.ID), slog.F("organization_id", organizationID))
 	return created.ID, nil
 }
 

--- a/site/permissions.json
+++ b/site/permissions.json
@@ -138,5 +138,17 @@
 	"createChat": {
 		"object": { "resource_type": "chat", "any_org": true, "owner_id": "me" },
 		"action": "create"
+	},
+	"createAnyChatModelConfig": {
+		"object": { "resource_type": "chat_model_config", "any_org": true },
+		"action": "create"
+	},
+	"editAnyChatModelConfig": {
+		"object": { "resource_type": "chat_model_config", "any_org": true },
+		"action": "update"
+	},
+	"deleteAnyChatModelConfig": {
+		"object": { "resource_type": "chat_model_config", "any_org": true },
+		"action": "delete"
 	}
 }

--- a/site/src/api/api.test.ts
+++ b/site/src/api/api.test.ts
@@ -441,7 +441,7 @@ describe("api.ts", () => {
 				},
 			],
 			[
-				"/api/experimental/chats/model-configs",
+				"/api/experimental/chat-model-configs",
 				() => API.experimental.getChatModelConfigs(),
 				[],
 			],
@@ -462,7 +462,7 @@ describe("api.ts", () => {
 				() => API.experimental.getChatModels(),
 			],
 			[
-				"/api/experimental/chats/model-configs",
+				"/api/experimental/chat-model-configs",
 				() => API.experimental.getChatModelConfigs(),
 			],
 		])("rethrows axios errors for %s", async (path, request) => {

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -352,7 +352,12 @@ const aiSpendBatchSize = 100;
 
 const aiProviderConfigsPath = "/api/v2/ai/providers";
 const aiGatewayPath = "/api/v2/ai-gateway";
-const chatModelConfigsPath = "/api/experimental/chats/model-configs";
+const chatModelConfigsPath = "/api/experimental/chat-model-configs";
+const chatModelConfigPath = (modelConfigId: string) =>
+	`${chatModelConfigsPath}/${encodeURIComponent(modelConfigId)}`;
+const organizationChatModelConfigsPath = (organizationId: string) =>
+	`/api/experimental/organizations/${encodeURIComponent(organizationId)}/chat-model-configs`;
+const chatAIProviderCatalogPath = "/api/experimental/ai-providers/catalog";
 const userSkillsPath = (user: string) =>
 	`/api/experimental/users/${encodeURIComponent(user)}/skills`;
 const userSkillPath = (user: string, name: string) =>
@@ -3856,11 +3861,30 @@ class ExperimentalApiMethods {
 		return response.data;
 	};
 
+	getChatModelConfigsByOrganization = async (
+		organizationId: string,
+	): Promise<TypesGen.ChatModelConfig[]> => {
+		const response = await this.axios.get<TypesGen.ChatModelConfig[]>(
+			organizationChatModelConfigsPath(organizationId),
+		);
+		return response.data;
+	};
+
+	getChatModelConfig = async (
+		modelConfigId: string,
+	): Promise<TypesGen.ChatModelConfig> => {
+		const response = await this.axios.get<TypesGen.ChatModelConfig>(
+			chatModelConfigPath(modelConfigId),
+		);
+		return response.data;
+	};
+
 	createChatModelConfig = async (
+		organizationId: string,
 		req: TypesGen.CreateChatModelConfigRequest,
 	): Promise<TypesGen.ChatModelConfig> => {
 		const response = await this.axios.post<TypesGen.ChatModelConfig>(
-			chatModelConfigsPath,
+			organizationChatModelConfigsPath(organizationId),
 			req,
 		);
 		return response.data;
@@ -3871,16 +3895,23 @@ class ExperimentalApiMethods {
 		req: TypesGen.UpdateChatModelConfigRequest,
 	): Promise<TypesGen.ChatModelConfig> => {
 		const response = await this.axios.patch<TypesGen.ChatModelConfig>(
-			`${chatModelConfigsPath}/${encodeURIComponent(modelConfigId)}`,
+			chatModelConfigPath(modelConfigId),
 			req,
 		);
 		return response.data;
 	};
 
 	deleteChatModelConfig = async (modelConfigId: string): Promise<void> => {
-		await this.axios.delete(
-			`${chatModelConfigsPath}/${encodeURIComponent(modelConfigId)}`,
-		);
+		await this.axios.delete(chatModelConfigPath(modelConfigId));
+	};
+
+	getChatAIProviderCatalog = async (): Promise<
+		TypesGen.ChatAIProviderCatalogEntry[]
+	> => {
+		const response = await this.axios.get<
+			TypesGen.ChatAIProviderCatalogEntry[]
+		>(chatAIProviderCatalogPath);
+		return response.data;
 	};
 
 	getMCPServerConfigs = async (): Promise<TypesGen.MCPServerConfig[]> => {

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -1804,7 +1804,7 @@ export const chatModels = () => ({
 		API.experimental.getChatModels(),
 });
 
-const chatProviderConfigsKey = ["chat-provider-configs"] as const;
+export const chatProviderConfigsKey = ["chat-provider-configs"] as const;
 
 const toChatProviderConfig = (
 	provider: TypesGen.AIProvider,
@@ -1838,6 +1838,24 @@ export const chatModelConfigs = () => ({
 	queryKey: chatModelConfigsKey,
 	queryFn: (): Promise<TypesGen.ChatModelConfig[]> =>
 		API.experimental.getChatModelConfigs(),
+});
+
+export const chatModelConfigsByOrganizationKey = (organizationId: string) =>
+	[...chatModelConfigsKey, organizationId] as const;
+
+export const chatModelConfigsByOrganization = (organizationId: string) => ({
+	queryKey: chatModelConfigsByOrganizationKey(organizationId),
+	queryFn: (): Promise<TypesGen.ChatModelConfig[]> =>
+		API.experimental.getChatModelConfigsByOrganization(organizationId),
+	enabled: organizationId !== "",
+});
+
+const chatAIProviderCatalogKey = ["chat-ai-provider-catalog"] as const;
+
+export const chatAIProviderCatalog = () => ({
+	queryKey: chatAIProviderCatalogKey,
+	queryFn: (): Promise<TypesGen.ChatAIProviderCatalogEntry[]> =>
+		API.experimental.getChatAIProviderCatalog(),
 });
 
 export const userChatProviderConfigsKey = [
@@ -1895,8 +1913,10 @@ export const deleteUserChatProviderKey = (queryClient: QueryClient) => ({
 const invalidateChatConfigurationQueries = async (queryClient: QueryClient) => {
 	await Promise.all([
 		queryClient.invalidateQueries({ queryKey: chatProviderConfigsKey }),
+		// Invalidates both the union key and every org-keyed entry.
 		queryClient.invalidateQueries({ queryKey: chatModelConfigsKey }),
 		queryClient.invalidateQueries({ queryKey: chatModelsKey }),
+		queryClient.invalidateQueries({ queryKey: chatAIProviderCatalogKey }),
 	]);
 };
 
@@ -1911,8 +1931,13 @@ export const invalidateChatProviderDependentQueries = async (
 };
 
 export const createChatModelConfig = (queryClient: QueryClient) => ({
-	mutationFn: (req: TypesGen.CreateChatModelConfigRequest) =>
-		API.experimental.createChatModelConfig(req),
+	mutationFn: ({
+		organizationId,
+		req,
+	}: {
+		organizationId: string;
+		req: TypesGen.CreateChatModelConfigRequest;
+	}) => API.experimental.createChatModelConfig(organizationId, req),
 	onSuccess: async () => {
 		await invalidateChatConfigurationQueries(queryClient);
 	},

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1943,6 +1943,23 @@ export interface ChatACL {
 }
 
 // From codersdk/chats.go
+/**
+ * ChatAIProviderCatalogEntry is the redacted view of an AI provider that
+ * org model admins may read. It carries only the capability metadata the
+ * Models UI needs; key material, base URLs, and headers are never exposed.
+ */
+export interface ChatAIProviderCatalogEntry {
+	readonly id: string;
+	readonly type: string;
+	readonly display_name: string;
+	readonly icon: string;
+	readonly enabled: boolean;
+	readonly has_api_key: boolean;
+	readonly has_user_api_key: boolean;
+	readonly allow_user_api_key: boolean;
+}
+
+// From codersdk/chats.go
 export type ChatAttachmentMediaType =
 	| "application/json"
 	| "application/pdf"
@@ -2875,10 +2892,16 @@ export interface ChatModelCallConfig {
 
 // From codersdk/chats.go
 /**
- * ChatModelConfig is an admin-managed model configuration.
+ * ChatModelConfig is an org-scoped model configuration.
  */
 export interface ChatModelConfig {
 	readonly id: string;
+	readonly organization_id: string;
+	/**
+	 * OrganizationDisplayName is set on union-list responses so user-context
+	 * pages can label which org each copy belongs to.
+	 */
+	readonly organization_display_name?: string;
 	readonly ai_provider_id: string;
 	readonly model: string;
 	readonly display_name: string;

--- a/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.stories.tsx
+++ b/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.stories.tsx
@@ -34,6 +34,21 @@ export const ManyOrgs: Story = {
 	},
 };
 
+export const ActiveSortsFirstThenAlphabetical: Story = {
+	args: {
+		value: MockOrganization2,
+		options: [MockOrganization, MockOrganization2],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button"));
+		const options = await screen.findAllByRole("option");
+		// The active organization sorts first regardless of source order.
+		expect(options[0]).toHaveTextContent(MockOrganization2.display_name);
+		expect(options[1]).toHaveTextContent(MockOrganization.display_name);
+	},
+};
+
 export const WithValue: Story = {
 	args: {
 		value: MockOrganization2,

--- a/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
+++ b/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
@@ -24,6 +24,11 @@ type OrganizationAutocompleteProps = {
 	options: readonly Organization[];
 	id?: string;
 	required?: boolean;
+	/**
+	 * Overrides the trigger button's width/layout classes when the default
+	 * full-width treatment does not fit (e.g. a fixed-width switcher).
+	 */
+	triggerClassName?: string;
 };
 
 export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
@@ -32,8 +37,20 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
 	options,
 	id,
 	required,
+	triggerClassName,
 }) => {
 	const [open, setOpen] = useState(false);
+
+	// Deterministic order: the active organization first, then
+	// case-insensitive alphabetical by display name. GetOrganizations has
+	// no ORDER BY, so source order is undefined.
+	const sortedOptions = [...options].sort((a, b) => {
+		if (a.id === value?.id) return -1;
+		if (b.id === value?.id) return 1;
+		return a.display_name
+			.toLowerCase()
+			.localeCompare(b.display_name.toLowerCase());
+	});
 
 	return (
 		<Popover open={open} onOpenChange={setOpen}>
@@ -44,7 +61,9 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
 					aria-expanded={open}
 					aria-required={required}
 					data-testid="organization-autocomplete"
-					className="w-full justify-start gap-2 font-normal"
+					className={
+						triggerClassName ?? "w-full justify-start gap-2 font-normal"
+					}
 				>
 					{value ? (
 						<>
@@ -72,7 +91,7 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
 					<CommandList>
 						<CommandEmpty>No organizations found.</CommandEmpty>
 						<CommandGroup>
-							{options.map((org) => (
+							{sortedOptions.map((org) => (
 								<CommandItem
 									key={org.id}
 									value={`${org.display_name} ${org.name}`}
@@ -80,6 +99,9 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
 										onChange(org);
 										setOpen(false);
 									}}
+									// There is currently an issue with the cmdk component for keyboard navigation
+									// https://github.com/pacocoursey/cmdk/issues/322
+									tabIndex={0}
 								>
 									<Avatar
 										size="sm"

--- a/site/src/modules/aiModels/providerStates.ts
+++ b/site/src/modules/aiModels/providerStates.ts
@@ -20,6 +20,31 @@ export type ProviderState = {
 	baseURL: string;
 };
 
+// The Models admin pages source provider metadata from the redacted AI
+// provider catalog (chatAIProviderCatalog) instead of the deployment-scoped
+// chatProviderConfigs endpoint, which org model admins cannot read. The
+// catalog carries no base URL, source, or timestamps; those fields are
+// filled with database/empty defaults below. baseURL in particular is dead
+// derived data (no ModelsPage component renders it), so the canonical
+// default for the provider type is used.
+export const providerConfigFromCatalogEntry = (
+	entry: TypesGen.ChatAIProviderCatalogEntry,
+): TypesGen.ChatProviderConfig => ({
+	id: entry.id,
+	provider: entry.type,
+	display_name: entry.display_name || entry.type,
+	icon: entry.icon,
+	enabled: entry.enabled,
+	has_api_key: entry.has_api_key,
+	central_api_key_enabled: entry.has_api_key,
+	allow_user_api_key: entry.allow_user_api_key,
+	allow_central_api_key_fallback: true,
+	base_url: "",
+	source: "database",
+	created_at: "",
+	updated_at: "",
+});
+
 type CatalogProvider = TypesGen.ChatModelsResponse["providers"][number];
 
 const envPresetProviders = new Set(["openai", "anthropic"]);

--- a/site/src/modules/management/AISettingsSidebarView.stories.tsx
+++ b/site/src/modules/management/AISettingsSidebarView.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import { MockNoPermissions, MockPermissions } from "#/testHelpers/entities";
 import AISettingsSidebarView from "./AISettingsSidebarView";
@@ -66,6 +67,24 @@ export const ProvidersActive: Story = {
 			location: { path: "/ai/settings/providers" },
 			routing: [{ path: "/ai/settings/providers", useStoryElement: true }],
 		}),
+	},
+};
+
+export const ModelsWithoutDeploymentConfig: Story = {
+	args: {
+		permissions: {
+			...MockNoPermissions,
+			editAnyChatModelConfig: true,
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("link", { name: "Models" }),
+		).toBeInTheDocument();
+		await expect(
+			canvas.queryByRole("link", { name: "Coder Agents" }),
+		).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/modules/management/AISettingsSidebarView.tsx
+++ b/site/src/modules/management/AISettingsSidebarView.tsx
@@ -52,13 +52,16 @@ const AISettingsSidebarView: FC<AISettingsSidebarViewProps> = ({
 						Providers
 					</SidebarNavItem>
 				)}
+				{(permissions.createAnyChatModelConfig ||
+					permissions.editAnyChatModelConfig) && (
+					<SidebarNavItem href="/ai/settings/models">Models</SidebarNavItem>
+				)}
 				{permissions.editDeploymentConfig && (
 					<>
 						<SidebarNavItem href="/ai/settings/coder-agents">
 							Coder Agents
 						</SidebarNavItem>
 						<div className="flex flex-col gap-1 ml-3 border-0 border-solid border-l border-l-border">
-							<SubNavItem href="/ai/settings/models">Models</SubNavItem>
 							<SubNavItem href="/ai/settings/mcp-servers">
 								MCP servers
 							</SubNavItem>

--- a/site/src/modules/permissions/organizations.ts
+++ b/site/src/modules/permissions/organizations.ts
@@ -115,6 +115,27 @@ export const organizationPermissionChecks = (organizationId: string) =>
 			},
 			action: "update",
 		},
+		createChatModelConfigs: {
+			object: {
+				resource_type: "chat_model_config",
+				organization_id: organizationId,
+			},
+			action: "create",
+		},
+		editChatModelConfigs: {
+			object: {
+				resource_type: "chat_model_config",
+				organization_id: organizationId,
+			},
+			action: "update",
+		},
+		deleteChatModelConfigs: {
+			object: {
+				resource_type: "chat_model_config",
+				organization_id: organizationId,
+			},
+			action: "delete",
+		},
 	}) as const satisfies Record<string, AuthorizationCheck>;
 
 /**

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPage.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPage.tsx
@@ -57,7 +57,7 @@ const updateChatModelOverrideMutation = (
 
 const CoderAgentsPage: FC = () => {
 	const { permissions } = useAuthenticated();
-	const { experiments } = useDashboard();
+	const { experiments, organizations } = useDashboard();
 	const queryClient = useQueryClient();
 	const canEditDeploymentConfig = permissions.editDeploymentConfig;
 	const showAdvisorSettings = experiments.includes("chat-advisor");
@@ -126,6 +126,12 @@ const CoderAgentsPage: FC = () => {
 	const providerInfoByID = providerInfoByIDFromConfigs(
 		providerConfigsQuery.data,
 	);
+	// Override pickers write deployment-wide override keys, so only the
+	// default-org model rows are valid targets.
+	const defaultOrganizationId = organizations.find((org) => org.is_default)?.id;
+	const defaultOrgModelConfigs = (modelConfigsQuery.data ?? []).filter(
+		(config) => config.organization_id === defaultOrganizationId,
+	);
 
 	return (
 		<RequirePermission isFeatureVisible={canEditDeploymentConfig}>
@@ -152,7 +158,7 @@ const CoderAgentsPage: FC = () => {
 				titleGenerationModelOverrideData={titleGenerationModelQuery.data}
 				compactionModelOverrideData={compactionModelQuery.data}
 				exploreModelOverrideData={exploreModelOverrideQuery.data}
-				modelConfigsData={modelConfigsQuery.data}
+				modelConfigsData={defaultOrgModelConfigs}
 				providerInfoByID={providerInfoByID}
 				modelConfigsError={
 					modelConfigsQuery.error ?? providerConfigsQuery.error

--- a/site/src/pages/AISettingsPage/ModelsPage/AddModelPage/AddModelPage.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/AddModelPage/AddModelPage.tsx
@@ -4,46 +4,55 @@ import { useNavigate, useSearchParams } from "react-router";
 import { toast } from "sonner";
 import { getErrorMessage } from "#/api/errors";
 import {
-	chatModelConfigs,
+	chatAIProviderCatalog,
+	chatModelConfigsByOrganization,
 	chatModels,
-	chatProviderConfigs,
 	createChatModelConfig,
 } from "#/api/queries/chats";
-import { useAuthenticated } from "#/hooks/useAuthenticated";
 import {
 	canManageProviderModels,
 	deriveProviderStates,
+	providerConfigFromCatalogEntry,
 } from "#/modules/aiModels/providerStates";
-import { RequirePermission } from "#/modules/permissions/RequirePermission";
 import { pageTitle } from "#/utils/page";
+import {
+	useOrganizationModels,
+	useOrganizationModelsPath,
+} from "../organizationModels";
 import AddModelPageView from "./AddModelPageView";
 
 const AddModelPage: FC = () => {
-	const { permissions } = useAuthenticated();
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
 	const [searchParams] = useSearchParams();
 	const providerKey = searchParams.get("provider") ?? "";
 	const duplicateId = searchParams.get("duplicate");
+	const { organization } = useOrganizationModels();
+	const modelsPath = useOrganizationModelsPath();
 
-	const providerConfigsQuery = useQuery(chatProviderConfigs());
-	const modelConfigsQuery = useQuery(chatModelConfigs());
+	const providerCatalogQuery = useQuery(chatAIProviderCatalog());
+	const modelConfigsQuery = useQuery(
+		chatModelConfigsByOrganization(organization.id),
+	);
 	const modelCatalogQuery = useQuery(chatModels());
 
 	const createMutation = useMutation(createChatModelConfig(queryClient));
 
+	const providerConfigs = providerCatalogQuery.data?.map(
+		providerConfigFromCatalogEntry,
+	);
 	const providerStates = useMemo(
 		() =>
 			deriveProviderStates(
 				modelConfigsQuery.data ?? [],
-				providerConfigsQuery.data,
+				providerConfigs,
 				modelCatalogQuery.data,
 			),
-		[modelConfigsQuery.data, providerConfigsQuery.data, modelCatalogQuery.data],
+		[modelConfigsQuery.data, providerConfigs, modelCatalogQuery.data],
 	);
 
 	const isLoading =
-		providerConfigsQuery.isLoading ||
+		providerCatalogQuery.isLoading ||
 		modelConfigsQuery.isLoading ||
 		modelCatalogQuery.isLoading;
 
@@ -56,7 +65,7 @@ const AddModelPage: FC = () => {
 	const currentDefaultModel = modelConfigsQuery.data?.find((m) => m.is_default);
 
 	return (
-		<RequirePermission isFeatureVisible={permissions.editDeploymentConfig}>
+		<>
 			<title>{pageTitle("Add model", "AI Settings")}</title>
 
 			<AddModelPageView
@@ -69,23 +78,26 @@ const AddModelPage: FC = () => {
 				onProviderChange={(key) => {
 					const next = new URLSearchParams(searchParams);
 					next.set("provider", key);
-					void navigate(`/ai/settings/models/add?${next.toString()}`, {
+					void navigate(`${modelsPath}/add?${next.toString()}`, {
 						replace: true,
 					});
 				}}
 				onCreateModel={async (req) => {
 					try {
-						const created = await createMutation.mutateAsync(req);
+						const created = await createMutation.mutateAsync({
+							organizationId: organization.id,
+							req,
+						});
 						toast.success(
 							`Model "${created.display_name || created.model}" added.`,
 						);
-						await navigate(`/ai/settings/models/${created.id}`);
+						await navigate(`${modelsPath}/${created.id}`);
 					} catch (error) {
 						toast.error(getErrorMessage(error, "Failed to add model."));
 					}
 				}}
 			/>
-		</RequirePermission>
+		</>
 	);
 };
 

--- a/site/src/pages/AISettingsPage/ModelsPage/ModelsPage.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/ModelsPage.tsx
@@ -1,30 +1,32 @@
 import type { FC } from "react";
 import { useQuery } from "react-query";
 import {
-	chatModelConfigs,
+	chatAIProviderCatalog,
+	chatModelConfigsByOrganization,
 	chatModels,
-	chatProviderConfigs,
 } from "#/api/queries/chats";
-import { useAuthenticated } from "#/hooks/useAuthenticated";
-import { deriveProviderStates } from "#/modules/aiModels/providerStates";
-import { RequirePermission } from "#/modules/permissions/RequirePermission";
+import {
+	deriveProviderStates,
+	providerConfigFromCatalogEntry,
+} from "#/modules/aiModels/providerStates";
 import { providerTypeByIDFromConfigs } from "#/pages/AgentsPage/utils/modelOptions";
 import { pageTitle } from "#/utils/page";
 import ModelsPageView from "./ModelsPageView";
+import { useOrganizationModels } from "./organizationModels";
 
 const ModelsPage: FC = () => {
-	const { permissions } = useAuthenticated();
+	const { organization } = useOrganizationModels();
 
-	const providerConfigsQuery = useQuery({
-		...chatProviderConfigs(),
-		enabled: permissions.editDeploymentConfig,
-	});
-	const modelConfigsQuery = useQuery(chatModelConfigs());
+	const providerCatalogQuery = useQuery(chatAIProviderCatalog());
+	const modelConfigsQuery = useQuery(
+		chatModelConfigsByOrganization(organization.id),
+	);
 	const modelCatalogQuery = useQuery(chatModels());
 
-	const providerTypeByID = providerTypeByIDFromConfigs(
-		providerConfigsQuery.data,
+	const providerConfigs = providerCatalogQuery.data?.map(
+		providerConfigFromCatalogEntry,
 	);
+	const providerTypeByID = providerTypeByIDFromConfigs(providerConfigs);
 
 	const models = (modelConfigsQuery.data ?? []).slice().sort((a, b) => {
 		const aProvider = providerTypeByID.get(a.ai_provider_id) ?? "";
@@ -34,22 +36,22 @@ const ModelsPage: FC = () => {
 	});
 	const providerStates = deriveProviderStates(
 		models,
-		providerConfigsQuery.data,
+		providerConfigs,
 		modelCatalogQuery.data,
 	);
 
 	return (
-		<RequirePermission isFeatureVisible={permissions.editDeploymentConfig}>
+		<>
 			<title>{pageTitle("Models", "AI Settings")}</title>
 
 			<ModelsPageView
 				isLoading={
-					providerConfigsQuery.isLoading ||
+					providerCatalogQuery.isLoading ||
 					modelConfigsQuery.isLoading ||
 					modelCatalogQuery.isLoading
 				}
 				error={
-					providerConfigsQuery.error ??
+					providerCatalogQuery.error ??
 					modelConfigsQuery.error ??
 					modelCatalogQuery.error
 				}
@@ -57,7 +59,7 @@ const ModelsPage: FC = () => {
 				providerStates={providerStates}
 				providerTypeByID={providerTypeByID}
 			/>
-		</RequirePermission>
+		</>
 	);
 };
 

--- a/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.tsx
@@ -44,6 +44,7 @@ import {
 import { ProviderIcon } from "#/pages/AISettingsPage/ProvidersPage/components/ProviderIcon";
 import { paginateItems } from "#/utils/paginateItems";
 import { ModelRow } from "./components/ModelRow";
+import { useOrganizationModelsPath } from "./organizationModels";
 
 const MODELS_PAGE_SIZE = 10;
 const ALL_PROVIDERS_VALUE = "all";
@@ -53,6 +54,7 @@ const AddModelDropdown: FC<{
 	align?: "start" | "end";
 }> = ({ providerStates, align = "end" }) => {
 	const navigate = useNavigate();
+	const modelsPath = useOrganizationModelsPath();
 	const manageableProviderStates = providerStates.filter(
 		canManageProviderModels,
 	);
@@ -78,7 +80,7 @@ const AddModelDropdown: FC<{
 							key={providerState.key}
 							onSelect={() =>
 								void navigate(
-									`/ai/settings/models/add?provider=${encodeURIComponent(
+									`${modelsPath}/add?provider=${encodeURIComponent(
 										providerState.key,
 									)}`,
 								)
@@ -110,6 +112,7 @@ const ModelsPageView: FC<ModelsPageViewProps> = ({
 	providerTypeByID,
 }) => {
 	const navigate = useNavigate();
+	const modelsPath = useOrganizationModelsPath();
 	const [page, setPage] = useState(1);
 	const [searchQuery, setSearchQuery] = useState("");
 	const [providerFilter, setProviderFilter] =
@@ -297,7 +300,7 @@ const ModelsPageView: FC<ModelsPageViewProps> = ({
 								providerEnabled={
 									providerEnabledByModelId.get(model.id) ?? false
 								}
-								onClick={() => void navigate(`/ai/settings/models/${model.id}`)}
+								onClick={() => void navigate(`${modelsPath}/${model.id}`)}
 							/>
 						))
 					)}

--- a/site/src/pages/AISettingsPage/ModelsPage/OrganizationModelsLayout.stories.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/OrganizationModelsLayout.stories.tsx
@@ -1,0 +1,85 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useLocation } from "react-router";
+import { expect, screen, userEvent, waitFor, within } from "storybook/test";
+import { reactRouterParameters } from "storybook-addon-remix-react-router";
+import {
+	MockDefaultOrganization,
+	MockOrganization2,
+	MockOrganizationPermissions,
+} from "#/testHelpers/entities";
+import { withDashboardProvider } from "#/testHelpers/storybook";
+import OrganizationModelsLayout from "./OrganizationModelsLayout";
+
+// Surfaces the active route's pathname so the play function can assert
+// where the autocomplete's navigation landed.
+const PathnameProbe = () => {
+	const location = useLocation();
+	return <div data-testid="pathname-probe">{location.pathname}</div>;
+};
+
+const meta: Meta<typeof OrganizationModelsLayout> = {
+	title: "pages/AISettingsPage/OrganizationModelsLayout",
+	component: OrganizationModelsLayout,
+	decorators: [withDashboardProvider],
+	parameters: {
+		showOrganizations: true,
+		organizations: [MockDefaultOrganization, MockOrganization2],
+		reactRouter: reactRouterParameters({
+			location: {
+				path: `/ai/settings/organizations/${MockDefaultOrganization.name}/models`,
+			},
+			routing: [
+				{
+					path: "/ai/settings/organizations/:organization/models",
+					useStoryElement: true,
+				},
+			],
+		}),
+		queries: [
+			{
+				// Production key shape: organizationsPermissions sorts the
+				// organization IDs into the middle segment.
+				key: [
+					"organizations",
+					[MockDefaultOrganization.id, MockOrganization2.id].sort(),
+					"permissions",
+				],
+				data: {
+					[MockDefaultOrganization.id]: MockOrganizationPermissions,
+					[MockOrganization2.id]: MockOrganizationPermissions,
+				},
+			},
+		],
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof OrganizationModelsLayout>;
+
+// Switching the autocomplete navigates to the selected organization's
+// models page.
+export const SwitchOrganizationNavigates: Story = {
+	render: () => (
+		<>
+			<OrganizationModelsLayout />
+			<PathnameProbe />
+		</>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(
+			await canvas.findByTestId("organization-autocomplete"),
+		);
+		// The active organization sorts first, then case-insensitive
+		// alphabetical; MockOrganization2 is the other entry.
+		const option = await screen.findByRole("option", {
+			name: new RegExp(MockOrganization2.display_name),
+		});
+		await userEvent.click(option);
+		await waitFor(() => {
+			expect(screen.getByTestId("pathname-probe")).toHaveTextContent(
+				`/ai/settings/organizations/${MockOrganization2.name}/models`,
+			);
+		});
+	},
+};

--- a/site/src/pages/AISettingsPage/ModelsPage/OrganizationModelsLayout.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/OrganizationModelsLayout.tsx
@@ -1,0 +1,82 @@
+import type { FC } from "react";
+import { useQuery } from "react-query";
+import { Outlet, useNavigate, useParams } from "react-router";
+import { organizationsPermissions } from "#/api/queries/organizations";
+import { ErrorAlert } from "#/components/Alert/ErrorAlert";
+import { EmptyState } from "#/components/EmptyState/EmptyState";
+import { Loader } from "#/components/Loader/Loader";
+import { OrganizationAutocomplete } from "#/components/OrganizationAutocomplete/OrganizationAutocomplete";
+import { useDashboard } from "#/modules/dashboard/useDashboard";
+import { OrganizationModelsContext } from "./organizationModels";
+
+/**
+ * Org context for the /ai/settings models pages. Resolves the :organization
+ * route param against the organizations the caller may manage chat model
+ * configs in, and renders an org switcher above the matched page.
+ */
+const OrganizationModelsLayout: FC = () => {
+	const { organization } = useParams<{ organization: string }>();
+	const navigate = useNavigate();
+	const { organizations } = useDashboard();
+
+	const manageableOrgsQuery = useQuery({
+		...organizationsPermissions(
+			organizations.length > 0 ? organizations.map((org) => org.id) : undefined,
+		),
+		select: (permissionsByOrg) =>
+			organizations.filter(
+				(org) =>
+					permissionsByOrg[org.id]?.createChatModelConfigs ||
+					permissionsByOrg[org.id]?.editChatModelConfigs,
+			),
+	});
+
+	const manageableOrganizations = manageableOrgsQuery.data ?? [];
+	const activeOrganization = manageableOrganizations.find(
+		(org) => org.name === organization,
+	);
+
+	if (manageableOrgsQuery.isLoading) {
+		return <Loader />;
+	}
+
+	if (manageableOrgsQuery.error !== null) {
+		return <ErrorAlert error={manageableOrgsQuery.error} />;
+	}
+
+	if (activeOrganization === undefined) {
+		return (
+			<EmptyState
+				message="No manageable organizations"
+				description="You do not have permission to manage chat models in any organization. Ask an organization administrator for access."
+			/>
+		);
+	}
+
+	return (
+		<OrganizationModelsContext.Provider
+			value={{
+				organization: activeOrganization,
+				organizations: manageableOrganizations,
+			}}
+		>
+			<div className="flex flex-col gap-6">
+				<div>
+					<OrganizationAutocomplete
+						value={activeOrganization}
+						options={manageableOrganizations}
+						triggerClassName="w-60 justify-start gap-2 font-normal"
+						onChange={(org) => {
+							if (org) {
+								navigate(`/ai/settings/organizations/${org.name}/models`);
+							}
+						}}
+					/>
+				</div>
+				<Outlet />
+			</div>
+		</OrganizationModelsContext.Provider>
+	);
+};
+
+export default OrganizationModelsLayout;

--- a/site/src/pages/AISettingsPage/ModelsPage/UpdateModelPage/UpdateModelPage.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/UpdateModelPage/UpdateModelPage.tsx
@@ -4,44 +4,55 @@ import { Navigate, useNavigate, useParams } from "react-router";
 import { toast } from "sonner";
 import { getErrorMessage } from "#/api/errors";
 import {
-	chatModelConfigs,
+	chatAIProviderCatalog,
+	chatModelConfigsByOrganization,
 	chatModels,
-	chatProviderConfigs,
 	deleteChatModelConfig,
 	updateChatModelConfig,
 } from "#/api/queries/chats";
 import { Loader } from "#/components/Loader/Loader";
-import { useAuthenticated } from "#/hooks/useAuthenticated";
-import { deriveProviderStates } from "#/modules/aiModels/providerStates";
-import { RequirePermission } from "#/modules/permissions/RequirePermission";
+import {
+	deriveProviderStates,
+	providerConfigFromCatalogEntry,
+} from "#/modules/aiModels/providerStates";
 import { pageTitle } from "#/utils/page";
+import {
+	useOrganizationModels,
+	useOrganizationModelsPath,
+} from "../organizationModels";
 import UpdateModelPageView from "./UpdateModelPageView";
 
 const UpdateModelPage: FC = () => {
-	const { permissions } = useAuthenticated();
 	const { modelId } = useParams<{ modelId: string }>();
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
+	const { organization } = useOrganizationModels();
+	const modelsPath = useOrganizationModelsPath();
 
-	const providerConfigsQuery = useQuery(chatProviderConfigs());
-	const modelConfigsQuery = useQuery(chatModelConfigs());
+	const providerCatalogQuery = useQuery(chatAIProviderCatalog());
+	const modelConfigsQuery = useQuery(
+		chatModelConfigsByOrganization(organization.id),
+	);
 	const modelCatalogQuery = useQuery(chatModels());
 
 	const updateMutation = useMutation(updateChatModelConfig(queryClient));
 	const deleteMutation = useMutation(deleteChatModelConfig(queryClient));
 
+	const providerConfigs = providerCatalogQuery.data?.map(
+		providerConfigFromCatalogEntry,
+	);
 	const providerStates = useMemo(
 		() =>
 			deriveProviderStates(
 				modelConfigsQuery.data ?? [],
-				providerConfigsQuery.data,
+				providerConfigs,
 				modelCatalogQuery.data,
 			),
-		[modelConfigsQuery.data, providerConfigsQuery.data, modelCatalogQuery.data],
+		[modelConfigsQuery.data, providerConfigs, modelCatalogQuery.data],
 	);
 
 	const isLoading =
-		providerConfigsQuery.isLoading ||
+		providerCatalogQuery.isLoading ||
 		modelConfigsQuery.isLoading ||
 		modelCatalogQuery.isLoading;
 
@@ -59,81 +70,83 @@ const UpdateModelPage: FC = () => {
 		) ??
 		null;
 
+	if (!modelId) {
+		return <Navigate to={modelsPath} replace />;
+	}
+
+	if (isLoading) {
+		return (
+			<>
+				<title>{pageTitle("Loading...", "AI Settings")}</title>
+				<Loader fullscreen />
+			</>
+		);
+	}
+
+	if (!model) {
+		return <Navigate to={modelsPath} replace />;
+	}
+
 	return (
-		<RequirePermission isFeatureVisible={permissions.editDeploymentConfig}>
-			{!modelId ? (
-				<Navigate to="/ai/settings/models" replace />
-			) : isLoading ? (
-				<>
-					<title>{pageTitle("Loading...", "AI Settings")}</title>
-					<Loader fullscreen />
-				</>
-			) : !model ? (
-				<Navigate to="/ai/settings/models" replace />
-			) : (
-				<UpdateModelPageView
-					model={model}
-					currentDefaultModel={currentDefaultModel}
-					providerStates={providerStates}
-					selectedProviderState={selectedProviderState}
-					onProviderChange={setProviderKeyOverride}
-					isSaving={updateMutation.isPending}
-					isDeleting={deleteMutation.isPending}
-					onUpdateModel={async (id, req) => {
-						try {
-							const updated = await updateMutation.mutateAsync({
-								modelConfigId: id,
-								req,
-							});
+		<UpdateModelPageView
+			model={model}
+			currentDefaultModel={currentDefaultModel}
+			providerStates={providerStates}
+			selectedProviderState={selectedProviderState}
+			onProviderChange={setProviderKeyOverride}
+			isSaving={updateMutation.isPending}
+			isDeleting={deleteMutation.isPending}
+			onUpdateModel={async (id, req) => {
+				try {
+					const updated = await updateMutation.mutateAsync({
+						modelConfigId: id,
+						req,
+					});
+					toast.success(
+						`Model "${updated.display_name || updated.model}" updated.`,
+					);
+					await navigate(modelsPath);
+				} catch (error) {
+					toast.error(getErrorMessage(error, "Failed to update model."));
+				}
+			}}
+			onDeleteModel={async (id) => {
+				try {
+					await deleteMutation.mutateAsync(id);
+					toast.success(
+						`Model "${model.display_name || model.model}" deleted.`,
+					);
+					await navigate(modelsPath, { replace: true });
+				} catch (error) {
+					toast.error(getErrorMessage(error, "Failed to delete model."));
+				}
+			}}
+			onDuplicate={() => {
+				if (!selectedProviderState) return;
+				void navigate(
+					`${modelsPath}/add?provider=${encodeURIComponent(
+						selectedProviderState.key,
+					)}&duplicate=${encodeURIComponent(model.id)}`,
+				);
+			}}
+			onToggleEnabled={(enabled) => {
+				updateMutation.mutate(
+					{ modelConfigId: model.id, req: { enabled } },
+					{
+						onSuccess: () => {
 							toast.success(
-								`Model "${updated.display_name || updated.model}" updated.`,
+								`Model "${model.display_name || model.model}" ${
+									enabled ? "enabled" : "disabled"
+								}.`,
 							);
-							await navigate("/ai/settings/models");
-						} catch (error) {
+						},
+						onError: (error) => {
 							toast.error(getErrorMessage(error, "Failed to update model."));
-						}
-					}}
-					onDeleteModel={async (id) => {
-						try {
-							await deleteMutation.mutateAsync(id);
-							toast.success(
-								`Model "${model.display_name || model.model}" deleted.`,
-							);
-							await navigate("/ai/settings/models", { replace: true });
-						} catch (error) {
-							toast.error(getErrorMessage(error, "Failed to delete model."));
-						}
-					}}
-					onDuplicate={() => {
-						if (!selectedProviderState) return;
-						void navigate(
-							`/ai/settings/models/add?provider=${encodeURIComponent(
-								selectedProviderState.key,
-							)}&duplicate=${encodeURIComponent(model.id)}`,
-						);
-					}}
-					onToggleEnabled={(enabled) => {
-						updateMutation.mutate(
-							{ modelConfigId: model.id, req: { enabled } },
-							{
-								onSuccess: () => {
-									toast.success(
-										`Model "${model.display_name || model.model}" ${
-											enabled ? "enabled" : "disabled"
-										}.`,
-									);
-								},
-								onError: (error) => {
-									toast.error(
-										getErrorMessage(error, "Failed to update model."),
-									);
-								},
-							},
-						);
-					}}
-				/>
-			)}
-		</RequirePermission>
+						},
+					},
+				);
+			}}
+		/>
 	);
 };
 

--- a/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormFields.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormFields.tsx
@@ -38,6 +38,7 @@ import type {
 } from "#/pages/AgentsPage/components/ChatModelAdminPanel/modelConfigFormLogic";
 import { cn } from "#/utils/cn";
 import type { FormHelpers } from "#/utils/formUtils";
+import { useOrganizationModelsPath } from "../organizationModels";
 import { ModelFormProviderSelect } from "./ModelFormProviderSelect";
 
 const CollapsibleSection: FC<{
@@ -134,6 +135,7 @@ export const ModelFormFields: FC<{
 	showAdvanced,
 	setShowAdvanced,
 }) => {
+	const modelsPath = useOrganizationModelsPath();
 	const hasProviderConfigFields =
 		getVisibleProviderFields(selectedProviderState.provider).length > 0;
 
@@ -344,7 +346,7 @@ export const ModelFormFields: FC<{
 				</div>
 
 				<div className="flex items-center justify-end gap-3">
-					<Link to="/ai/settings/models">
+					<Link to={modelsPath}>
 						<Button variant="outline" type="button">
 							Cancel
 						</Button>

--- a/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormHeader.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormHeader.tsx
@@ -27,10 +27,12 @@ import {
 import type { ProviderState } from "#/modules/aiModels/providerStates";
 import { getProviderIcon } from "#/pages/AISettingsPage/ProvidersPage/components/ProviderIcon";
 import { cn } from "#/utils/cn";
+import { useOrganizationModelsPath } from "../organizationModels";
 
 export const ModelFormBackLink: FC = () => {
+	const modelsPath = useOrganizationModelsPath();
 	return (
-		<Link to="/ai/settings/models" className="-ml-3">
+		<Link to={modelsPath} className="-ml-3">
 			<Button variant="subtle" type="button">
 				<ArrowLeftIcon />
 				<span>Back to models</span>

--- a/site/src/pages/AISettingsPage/ModelsPage/organizationModels.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/organizationModels.tsx
@@ -1,0 +1,41 @@
+import { createContext, useContext } from "react";
+import type { Organization } from "#/api/typesGenerated";
+
+type OrganizationModelsContextValue = {
+	organization: Organization;
+	organizations: readonly Organization[];
+};
+
+/**
+ * The organization whose chat model configs the current /ai/settings
+ * models pages manage. Resolved from the :organization route param by
+ * OrganizationModelsLayout.
+ */
+export const OrganizationModelsContext =
+	createContext<OrganizationModelsContextValue | null>(null);
+
+export const useOrganizationModels = (): OrganizationModelsContextValue => {
+	const context = useContext(OrganizationModelsContext);
+	if (!context) {
+		throw new Error(
+			"useOrganizationModels only can be used inside of OrganizationModelsLayout",
+		);
+	}
+	return context;
+};
+
+const legacyModelsPath = "/ai/settings/models";
+
+/**
+ * Base path of the models pages inside the active organization context.
+ * Falls back to the legacy redirect path when rendered without an
+ * OrganizationModelsLayout (Storybook stories), which bounces to the
+ * caller's preferred organization.
+ */
+export const useOrganizationModelsPath = (): string => {
+	const context = useContext(OrganizationModelsContext);
+	if (!context) {
+		return legacyModelsPath;
+	}
+	return `/ai/settings/organizations/${context.organization.name}/models`;
+};

--- a/site/src/pages/AISettingsPage/ModelsPage/testFixtures.ts
+++ b/site/src/pages/AISettingsPage/ModelsPage/testFixtures.ts
@@ -28,6 +28,7 @@ const MockAnthropicProviderConfig: ChatProviderConfig = {
 
 export const mockGPT5: ChatModelConfig = {
 	id: "model-gpt5",
+	organization_id: "org-1",
 	ai_provider_id: "prov-openai",
 	model: "gpt-5",
 	display_name: "GPT-5",

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -13,7 +13,7 @@ import {
 	chatDiffContentsKey,
 	chatKey,
 	chatMessagesKey,
-	chatModelConfigs,
+	chatModelConfigsByOrganizationKey,
 	chatModelsKey,
 	chatPromptsKey,
 	chatsKey,
@@ -278,7 +278,10 @@ const buildQueries = (
 			data: mockWorkspace,
 		},
 		{ key: chatModelsKey, data: mockModelCatalog },
-		{ key: chatModelConfigs().queryKey, data: mockModelConfigs },
+		{
+			key: chatModelConfigsByOrganizationKey("test-org-id"),
+			data: mockModelConfigs,
+		},
 		{ key: mcpServerConfigsKey, data: [] },
 		buildChatAuthorizationQuery(chat, {
 			canShareChat: {

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -28,7 +28,7 @@ import {
 	chat,
 	chatKey,
 	chatMessagesForInfiniteScroll,
-	chatModelConfigs,
+	chatModelConfigsByOrganization,
 	chatModels,
 	chatProviderConfigs,
 	compactChat,
@@ -791,7 +791,10 @@ const AgentChatPage: FC = () => {
 	const workspace = workspaceQuery.data;
 
 	const chatModelsQuery = useQuery(chatModels());
-	const chatModelConfigsQuery = useQuery(chatModelConfigs());
+	const chatOrganizationId = chatQuery.data?.organization_id ?? "";
+	const chatModelConfigsQuery = useQuery(
+		chatModelConfigsByOrganization(chatOrganizationId),
+	);
 	const chatProviderConfigsQuery = useQuery({
 		...chatProviderConfigs(),
 		enabled: permissions.editDeploymentConfig,

--- a/site/src/pages/AgentsPage/AgentCreatePage.tsx
+++ b/site/src/pages/AgentsPage/AgentCreatePage.tsx
@@ -4,13 +4,9 @@ import { useLocation, useNavigate } from "react-router";
 import { toast } from "sonner";
 import { getErrorMessage } from "#/api/errors";
 import {
-	chatModelConfigs,
-	chatModels,
-	chatProviderConfigs,
 	createChat,
 	mcpServerConfigs,
 	userChatPersonalModelOverrides,
-	userChatProviderConfigs,
 } from "#/api/queries/chats";
 import { preferenceSettings } from "#/api/queries/users";
 import { workspaces } from "#/api/queries/workspaces";
@@ -27,11 +23,6 @@ import { ChimeButton } from "./components/ChimeButton";
 import { WebPushButton } from "./components/WebPushButton";
 import { getAgentChatSendShortcut } from "./utils/agentChatSendShortcut";
 import { getChimeEnabled, setChimeEnabled } from "./utils/chime";
-import {
-	countConfiguredProviderConfigs,
-	getUnsupportedProviderNames,
-	resolveModelSelector,
-} from "./utils/modelOptions";
 import { buildAgentChatPath } from "./utils/navigation";
 
 const lastModelConfigIDStorageKey = "agents.last-model-config-id";
@@ -43,13 +34,6 @@ const AgentCreatePage: FC = () => {
 	const { permissions } = useAuthenticated();
 	const aiGatewayDisabled = !useAIGatewayEnabled();
 
-	const chatModelsQuery = useQuery(chatModels());
-	const chatModelConfigsQuery = useQuery(chatModelConfigs());
-	const chatProviderConfigsQuery = useQuery({
-		...chatProviderConfigs(),
-		enabled: permissions.editDeploymentConfig,
-	});
-	const userProviderConfigsQuery = useQuery(userChatProviderConfigs());
 	const personalModelOverridesQuery = useQuery(
 		userChatPersonalModelOverrides(),
 	);
@@ -59,29 +43,6 @@ const AgentCreatePage: FC = () => {
 	const createMutation = useMutation(createChat(queryClient));
 	const webPush = useWebpushNotifications();
 	const [chimeEnabled, setChimeEnabledState] = useState(getChimeEnabled);
-
-	const { options: catalogModelOptions, isModelCatalogLoading } =
-		resolveModelSelector(
-			chatModelConfigsQuery,
-			chatModelsQuery,
-			userProviderConfigsQuery,
-		);
-	const providerCount =
-		permissions.editDeploymentConfig &&
-		chatProviderConfigsQuery.isSuccess &&
-		chatModelsQuery.isSuccess
-			? countConfiguredProviderConfigs(
-					chatProviderConfigsQuery.data,
-					chatModelsQuery.data,
-				)
-			: undefined;
-	const modelCount =
-		chatModelConfigsQuery.isSuccess && chatModelsQuery.isSuccess
-			? catalogModelOptions.length
-			: undefined;
-	const unsupportedProviderNames = getUnsupportedProviderNames(
-		chatModelsQuery.data,
-	);
 
 	const handleCreateChat = async ({
 		message,
@@ -167,16 +128,8 @@ const AgentCreatePage: FC = () => {
 				isCreating={createMutation.isPending}
 				createError={createMutation.error}
 				canCreateChat={permissions.createChat}
-				modelCatalog={chatModelsQuery.data}
-				modelOptions={catalogModelOptions}
 				canConfigureAgentSetup={permissions.editDeploymentConfig}
-				providerCount={providerCount}
-				modelCount={modelCount}
-				unsupportedProviderNames={unsupportedProviderNames}
 				aiGatewayDisabled={aiGatewayDisabled}
-				modelConfigs={chatModelConfigsQuery.data ?? []}
-				isModelCatalogLoading={isModelCatalogLoading}
-				isModelConfigsLoading={chatModelConfigsQuery.isLoading}
 				rootPersonalModelOverride={rootPersonalModelOverride}
 				isPersonalModelOverridesLoading={personalModelOverridesQuery.isLoading}
 				mcpServers={mcpServersQuery.data ?? []}

--- a/site/src/pages/AgentsPage/AgentSettingsCompactionPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsCompactionPageView.stories.tsx
@@ -10,6 +10,8 @@ const baseArgs: AgentSettingsCompactionPageViewProps = {
 	modelConfigsData: [
 		{
 			id: "model-config-1",
+			organization_id: "org-default",
+			organization_display_name: "Default Organization",
 			ai_provider_id: "prov-openai",
 			model: "gpt-4.1-mini",
 			display_name: "GPT 4.1 Mini",

--- a/site/src/pages/AgentsPage/AgentSettingsUserAgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsUserAgentsPage.tsx
@@ -8,11 +8,13 @@ import {
 	userChatProviderConfigs,
 } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
+import { useDashboard } from "#/modules/dashboard/useDashboard";
 import { AgentSettingsUserAgentsPageView } from "./AgentSettingsUserAgentsPageView";
 import { resolveModelSelector } from "./utils/modelOptions";
 
 const AgentSettingsUserAgentsPage: FC = () => {
 	const queryClient = useQueryClient();
+	const { organizations } = useDashboard();
 	const overridesQuery = useQuery(userChatPersonalModelOverrides());
 	const chatModelsQuery = useQuery(chatModels());
 	const modelConfigsQuery = useQuery(chatModelConfigs());
@@ -26,8 +28,23 @@ const AgentSettingsUserAgentsPage: FC = () => {
 	const saveExploreModelOverrideMutation = useMutation(
 		updateUserChatPersonalModelOverride(queryClient),
 	);
+
+	// Personal overrides still write global override keys, so only the
+	// default-org model rows are valid targets. Non-default-org copies
+	// must not be offered here.
+	const defaultOrganizationId = organizations.find((org) => org.is_default)?.id;
+	const defaultOrgModelConfigs = (modelConfigsQuery.data ?? []).filter(
+		(config) => config.organization_id === defaultOrganizationId,
+	);
+	const hasDefaultOrgModels =
+		defaultOrganizationId !== undefined && defaultOrgModelConfigs.length > 0;
+
+	const filteredModelConfigsQuery = {
+		data: defaultOrgModelConfigs,
+		isLoading: modelConfigsQuery.isLoading,
+	};
 	const { options: modelOptions, isModelCatalogLoading } = resolveModelSelector(
-		modelConfigsQuery,
+		filteredModelConfigsQuery,
 		chatModelsQuery,
 		providerConfigsQuery,
 	);
@@ -55,9 +72,12 @@ const AgentSettingsUserAgentsPage: FC = () => {
 			isRetryingOverrides={overridesQuery.isFetching}
 			isLoadingOverrides={overridesQuery.isLoading}
 			modelOptions={modelOptions}
-			modelConfigs={modelConfigsQuery.data ?? []}
+			modelConfigs={defaultOrgModelConfigs}
 			modelConfigsError={modelConfigsError}
 			isLoadingModels={isModelCatalogLoading}
+			hasNoDefaultOrgModels={
+				!modelConfigsQuery.isLoading && !hasDefaultOrgModels
+			}
 			onSaveRootModelOverride={saveModelOverride(
 				"root",
 				saveRootModelOverrideMutation,

--- a/site/src/pages/AgentsPage/AgentSettingsUserAgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsUserAgentsPageView.stories.tsx
@@ -698,6 +698,26 @@ export const SaveErrorState: Story = {
 	},
 };
 
+export const NoDefaultOrgModels: Story = {
+	args: buildArgs({
+		hasNoDefaultOrgModels: true,
+		modelOptions: [],
+		modelConfigs: [],
+	}),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByText(
+				/Personal model overrides are managed per organization/i,
+			),
+		).toBeInTheDocument();
+		const rootSection = await getSection(canvasElement, "Root agent model");
+		expect(
+			within(rootSection).getByRole("button", { name: "Save" }),
+		).toBeDisabled();
+	},
+};
+
 export const AdminDisabledReadOnly: Story = {
 	args: buildArgs({
 		overridesData: buildOverridesResponse({

--- a/site/src/pages/AgentsPage/AgentSettingsUserAgentsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsUserAgentsPageView.tsx
@@ -20,6 +20,7 @@ export interface AgentSettingsUserAgentsPageViewProps {
 	modelConfigs: readonly TypesGen.ChatModelConfig[];
 	modelConfigsError: unknown;
 	isLoadingModels: boolean;
+	hasNoDefaultOrgModels?: boolean;
 	onSaveRootModelOverride: SavePersonalOverride;
 	isSavingRootModelOverride: boolean;
 	isSaveRootModelOverrideError: boolean;
@@ -43,6 +44,7 @@ export const AgentSettingsUserAgentsPageView: FC<
 	modelConfigs,
 	modelConfigsError,
 	isLoadingModels,
+	hasNoDefaultOrgModels = false,
 	onSaveRootModelOverride,
 	isSavingRootModelOverride,
 	isSaveRootModelOverrideError,
@@ -55,7 +57,8 @@ export const AgentSettingsUserAgentsPageView: FC<
 }) => {
 	const personalOverridesEnabled = overridesData?.enabled ?? true;
 	const isLoading = isLoadingOverrides || isLoadingModels;
-	const isDisabled = isLoading || !personalOverridesEnabled;
+	const isDisabled =
+		isLoading || !personalOverridesEnabled || hasNoDefaultOrgModels;
 
 	return (
 		<div className="flex flex-col gap-8">
@@ -84,6 +87,15 @@ export const AgentSettingsUserAgentsPageView: FC<
 					<AlertDescription>
 						Personal model overrides are disabled by an administrator. Saved
 						values are shown for reference, but changes cannot be saved.
+					</AlertDescription>
+				</Alert>
+			)}
+			{hasNoDefaultOrgModels && (
+				<Alert severity="info">
+					<AlertDescription>
+						Personal model overrides are managed per organization in a later
+						release. None of your organizations have models in the default
+						organization yet, so there are no models to override.
 					</AlertDescription>
 				</Alert>
 			)}

--- a/site/src/pages/AgentsPage/AgentsPageLayout.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageLayout.stories.tsx
@@ -53,6 +53,7 @@ const defaultModelConfigID = "model-config-1";
 const defaultModelConfigs: TypesGen.ChatModelConfig[] = [
 	{
 		id: defaultModelConfigID,
+		organization_id: "my-organization-id",
 		ai_provider_id: "provider-openai",
 		model: "gpt-4o",
 		display_name: "GPT-4o",
@@ -429,6 +430,7 @@ const meta: Meta<typeof AgentsPageLayout> = {
 		spyOn(API.experimental, "getChatModelConfigs").mockResolvedValue([
 			{
 				id: defaultModelConfigID,
+				organization_id: "my-organization-id",
 				ai_provider_id: "provider-openai",
 				model: "gpt-4o",
 				display_name: "GPT-4o",

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -9,6 +9,12 @@ import {
 	within,
 } from "storybook/test";
 import { API } from "#/api/api";
+import {
+	chatModelConfigsByOrganizationKey,
+	chatModelsKey,
+	chatProviderConfigsKey,
+	userChatProviderConfigsKey,
+} from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
 import { ConfirmDialog } from "#/components/Dialogs/ConfirmDialog/ConfirmDialog";
 import { MockChatModelConfig } from "#/testHelpers/chatModels";
@@ -34,26 +40,12 @@ const permittedOrgsKey = [
 const modelConfigID = "model-config-1";
 const claudeModelConfigID = "model-config-claude";
 
-const modelOptions = [
-	{
-		id: modelConfigID,
-		provider: "openai",
-		model: "gpt-4o",
-		displayName: "GPT-4o",
-	},
-	{
-		id: claudeModelConfigID,
-		provider: "anthropic",
-		model: "claude-sonnet-4",
-		displayName: "Claude Sonnet 4",
-	},
-] as const;
-
 const buildModelConfig = (
 	overrides: Partial<TypesGen.ChatModelConfig> = {},
 ): TypesGen.ChatModelConfig => ({
 	...MockChatModelConfig,
 	id: modelConfigID,
+	organization_id: MockDefaultOrganization.id,
 	model: "gpt-4o",
 	display_name: "GPT-4o",
 	created_at: "2026-02-18T00:00:00.000Z",
@@ -70,6 +62,59 @@ const defaultModelConfigs: TypesGen.ChatModelConfig[] = [
 		display_name: "Claude Sonnet 4",
 		context_limit: 200_000,
 	}),
+];
+
+// Model catalog with both providers available, matching defaultModelConfigs.
+const defaultModelCatalog: TypesGen.ChatModelsResponse = {
+	providers: [
+		{ provider: "openai", available: true, models: [] },
+		{ provider: "anthropic", available: true, models: [] },
+	],
+	unsupported_providers: [],
+};
+
+const defaultUserProviderConfigs: TypesGen.UserChatProviderConfig[] = [
+	{
+		provider_id: "provider-1",
+		provider: "openai",
+		display_name: "OpenAI",
+		icon: "",
+		enabled: true,
+		has_user_api_key: false,
+		has_central_api_key_fallback: true,
+		byok_enabled: false,
+	},
+	{
+		provider_id: "provider-anthropic",
+		provider: "anthropic",
+		display_name: "Anthropic",
+		icon: "",
+		enabled: true,
+		has_user_api_key: false,
+		has_central_api_key_fallback: true,
+		byok_enabled: false,
+	},
+];
+
+// The form queries model configs for the selected organization, the model
+// catalog, and the user provider configs. These entries feed the defaults
+// those queries resolve to in every story; individual stories override
+// them through parameters.queries.
+const modelQueries = ({
+	configs = defaultModelConfigs,
+	catalog = defaultModelCatalog,
+	userProviderConfigs = defaultUserProviderConfigs,
+}: {
+	configs?: TypesGen.ChatModelConfig[];
+	catalog?: TypesGen.ChatModelsResponse;
+	userProviderConfigs?: TypesGen.UserChatProviderConfig[];
+} = {}) => [
+	{
+		key: chatModelConfigsByOrganizationKey(MockDefaultOrganization.id),
+		data: configs,
+	},
+	{ key: chatModelsKey, data: catalog },
+	{ key: userChatProviderConfigsKey, data: userProviderConfigs },
 ];
 
 const buildRootPersonalModelOverride = (
@@ -112,15 +157,13 @@ const meta: Meta<typeof AgentCreateForm> = {
 		isCreating: false,
 		createError: undefined,
 		canCreateChat: true,
-		modelCatalog: null,
-		modelOptions: [...modelOptions],
-		isModelCatalogLoading: false,
-		modelConfigs: [],
-		isModelConfigsLoading: false,
 		workspaceCount: 0,
 		workspaceOptions: [],
 		workspacesError: undefined,
 		isWorkspacesLoading: false,
+	},
+	parameters: {
+		queries: modelQueries(),
 	},
 	beforeEach: () => {
 		localStorage.clear();
@@ -168,7 +211,6 @@ export const RootPersonalModelOverrideModelSelected: Story = {
 	args: {
 		...defaultArgs,
 		onCreateChat: fn().mockResolvedValue(undefined),
-		modelConfigs: defaultModelConfigs,
 		rootPersonalModelOverride: buildRootPersonalModelOverride({
 			mode: "model",
 			model_config_id: claudeModelConfigID,
@@ -191,7 +233,6 @@ export const RootChatDefaultSubmitsDisplayedModel: Story = {
 	args: {
 		...defaultArgs,
 		onCreateChat: fn().mockResolvedValue(undefined),
-		modelConfigs: defaultModelConfigs,
 		rootPersonalModelOverride: buildRootPersonalModelOverride({
 			mode: "chat_default",
 			model_config_id: "",
@@ -214,7 +255,6 @@ export const RootOverrideMissingFromCatalog: Story = {
 	args: {
 		...defaultArgs,
 		onCreateChat: fn().mockResolvedValue(undefined),
-		modelConfigs: defaultModelConfigs,
 		rootPersonalModelOverride: buildRootPersonalModelOverride({
 			mode: "model",
 			model_config_id: "model-does-not-exist",
@@ -239,7 +279,6 @@ export const MalformedRootOverrideUsesDefaultModel: Story = {
 	args: {
 		...defaultArgs,
 		onCreateChat: fn().mockResolvedValue(undefined),
-		modelConfigs: defaultModelConfigs,
 		rootPersonalModelOverride: buildRootPersonalModelOverride({
 			mode: "model",
 			model_config_id: claudeModelConfigID,
@@ -266,7 +305,6 @@ export const LastUsedModelFallbackWithoutRootOverride: Story = {
 	args: {
 		...defaultArgs,
 		onCreateChat: fn().mockResolvedValue(undefined),
-		modelConfigs: defaultModelConfigs,
 	},
 	beforeEach: () => {
 		localStorage.clear();
@@ -289,7 +327,6 @@ export const ManualSelectionOverridesRootChatDefault: Story = {
 	args: {
 		...defaultArgs,
 		onCreateChat: fn().mockResolvedValue(undefined),
-		modelConfigs: defaultModelConfigs,
 		rootPersonalModelOverride: buildRootPersonalModelOverride({
 			mode: "chat_default",
 			model_config_id: "",
@@ -310,13 +347,13 @@ export const ManualSelectionOverridesRootChatDefault: Story = {
 	},
 };
 
-// Model options with reasoning effort bounds configured. GPT-4o uses the
+// Model configs with reasoning effort bounds configured. GPT-4o uses the
 // full global scale; Claude is capped at medium.
-const effortModelOptions = [
-	{
-		...modelOptions[0],
-		reasoningEffortDefault: "medium",
-		reasoningEfforts: [
+const effortModelConfigs: TypesGen.ChatModelConfig[] = [
+	buildModelConfig({
+		is_default: true,
+		model_config: { reasoning_effort: { default: "medium" } },
+		reasoning_efforts: [
 			"none",
 			"minimal",
 			"low",
@@ -325,18 +362,24 @@ const effortModelOptions = [
 			"xhigh",
 			"max",
 		],
-	},
-	{
-		...modelOptions[1],
-		reasoningEffortDefault: "low",
-		reasoningEfforts: ["low", "medium"],
-	},
-] as const;
+	}),
+	buildModelConfig({
+		id: claudeModelConfigID,
+		ai_provider_id: "provider-anthropic",
+		model: "claude-sonnet-4",
+		display_name: "Claude Sonnet 4",
+		context_limit: 200_000,
+		model_config: { reasoning_effort: { default: "low" } },
+		reasoning_efforts: ["low", "medium"],
+	}),
+];
 
 export const RemembersReasoningEffortByModel: Story = {
 	args: {
 		...defaultArgs,
-		modelOptions: [...effortModelOptions],
+	},
+	parameters: {
+		queries: modelQueries({ configs: effortModelConfigs }),
 	},
 	beforeEach: () => {
 		localStorage.clear();
@@ -382,13 +425,14 @@ export const PersistedReasoningEffortOutranksRootOverride: Story = {
 	args: {
 		...defaultArgs,
 		onCreateChat: fn().mockResolvedValue(undefined),
-		modelOptions: [...effortModelOptions],
-		modelConfigs: defaultModelConfigs,
 		rootPersonalModelOverride: buildRootPersonalModelOverride({
 			mode: "model",
 			model_config_id: modelConfigID,
 			reasoning_effort: "high",
 		}),
+	},
+	parameters: {
+		queries: modelQueries({ configs: effortModelConfigs }),
 	},
 	beforeEach: () => {
 		localStorage.clear();
@@ -417,13 +461,14 @@ export const PersistedReasoningEffortOutranksRootOverride: Story = {
 export const ManualReselectKeepsRootOverrideEffort: Story = {
 	args: {
 		...defaultArgs,
-		modelOptions: [...effortModelOptions],
-		modelConfigs: defaultModelConfigs,
 		rootPersonalModelOverride: buildRootPersonalModelOverride({
 			mode: "model",
 			model_config_id: modelConfigID,
 			reasoning_effort: "high",
 		}),
+	},
+	parameters: {
+		queries: modelQueries({ configs: effortModelConfigs }),
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -445,18 +490,21 @@ export const StalePersistedEffortFallsThroughToRootOverride: Story = {
 	args: {
 		...defaultArgs,
 		onCreateChat: fn().mockResolvedValue(undefined),
-		modelOptions: [
-			{
-				...modelOptions[0],
-				reasoningEffortDefault: "low",
-				reasoningEfforts: ["low", "medium"],
-			},
-		],
-		modelConfigs: defaultModelConfigs,
 		rootPersonalModelOverride: buildRootPersonalModelOverride({
 			mode: "model",
 			model_config_id: modelConfigID,
 			reasoning_effort: "medium",
+		}),
+	},
+	parameters: {
+		queries: modelQueries({
+			configs: [
+				buildModelConfig({
+					is_default: true,
+					model_config: { reasoning_effort: { default: "low" } },
+					reasoning_efforts: ["low", "medium"],
+				}),
+			],
 		}),
 	},
 	beforeEach: () => {
@@ -486,11 +534,13 @@ export const StalePersistedEffortFallsThroughToRootOverride: Story = {
 
 export const SubmitsReasoningEffort: Story = {
 	// TODO: This story fails when pixel runs its play function. Fix it and remove the exclude.
-	parameters: { pixel: { exclude: true } },
+	parameters: {
+		pixel: { exclude: true },
+		queries: modelQueries({ configs: effortModelConfigs }),
+	},
 	args: {
 		...defaultArgs,
 		onCreateChat: fn().mockResolvedValue(undefined),
-		modelOptions: [...effortModelOptions],
 	},
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
@@ -654,12 +704,10 @@ export const SelectWorkspaceViaSearch: Story = {
 };
 
 export const LoadingModelCatalog: Story = {
+	// Leave the model queries unseeded so they stay pending.
+	parameters: { queries: [] },
 	args: {
 		...defaultArgs,
-		modelCatalog: null,
-		modelOptions: [],
-		isModelCatalogLoading: true,
-		isModelConfigsLoading: true,
 	},
 };
 
@@ -677,26 +725,30 @@ export const LoadingPersonalModelOverrides: Story = {
 	},
 };
 
+const emptyModelCatalog: TypesGen.ChatModelsResponse = {
+	providers: [],
+	unsupported_providers: [],
+};
+
 export const NoModelsConfigured: Story = {
+	parameters: {
+		queries: modelQueries({ configs: [], catalog: emptyModelCatalog }),
+	},
 	args: {
 		...defaultArgs,
-		modelCatalog: { providers: [], unsupported_providers: [] },
-		modelOptions: [],
-		isModelCatalogLoading: false,
-		isModelConfigsLoading: false,
 	},
 };
 
 export const MissingProviderAndModelSetup: Story = {
+	parameters: {
+		queries: [
+			...modelQueries({ configs: [], catalog: emptyModelCatalog }),
+			{ key: chatProviderConfigsKey, data: [] },
+		],
+	},
 	args: {
 		...defaultArgs,
 		canConfigureAgentSetup: true,
-		providerCount: 0,
-		modelCount: 0,
-		modelCatalog: { providers: [], unsupported_providers: [] },
-		modelOptions: [],
-		isModelCatalogLoading: false,
-		isModelConfigsLoading: false,
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -1009,6 +1061,16 @@ export const PermittedOrgsResolvesToSubset: Story = {
 	parameters: {
 		showOrganizations: true,
 		organizations: [MockDefaultOrganization, MockOrganization2],
+		queries: [
+			...modelQueries(),
+			{
+				key: chatModelConfigsByOrganizationKey(MockOrganization2.id),
+				data: defaultModelConfigs.map((config) => ({
+					...config,
+					organization_id: MockOrganization2.id,
+				})),
+			},
+		],
 	},
 	args: {
 		...defaultArgs,

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -3,6 +3,12 @@ import { useQuery } from "react-query";
 import { Link } from "react-router";
 import { toast } from "sonner";
 import { isApiError } from "#/api/errors";
+import {
+	chatModelConfigsByOrganization,
+	chatModels,
+	chatProviderConfigs,
+	userChatProviderConfigs,
+} from "#/api/queries/chats";
 import { permittedOrganizations } from "#/api/queries/organizations";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { AgentChatSendShortcut } from "#/api/typesGenerated";
@@ -15,10 +21,12 @@ import { docs } from "#/utils/docs";
 import { useFileAttachments } from "../hooks/useFileAttachments";
 import { parseStoredDraft } from "../utils/draftStorage";
 import {
+	countConfiguredProviderConfigs,
 	getModelSelectorPlaceholder,
 	getProviderForModelOption,
-	hasConfiguredModelsInCatalog,
+	getUnsupportedProviderNames,
 	hasUserFixableProviders,
+	resolveModelSelector,
 } from "../utils/modelOptions";
 import {
 	getReasoningEffortForModel,
@@ -31,7 +39,6 @@ import {
 } from "../utils/usageLimitMessage";
 import { AgentChatInput } from "./AgentChatInput";
 import { ChatAccessDeniedAlert } from "./ChatAccessDeniedAlert";
-import type { ModelSelectorOption } from "./ChatElements";
 import { CompactOrgSelector } from "./ChatElements";
 import {
 	getDefaultMCPSelection,
@@ -44,8 +51,6 @@ import { getModelSelectorHelp } from "./ModelSelectorHelp";
 export const emptyInputStorageKey = "agents.empty-input";
 const selectedWorkspaceIdStorageKey = "agents.selected-workspace-id";
 const lastModelConfigIDStorageKey = "agents.last-model-config-id";
-
-type ChatModelOption = ModelSelectorOption;
 
 export type CreateChatOptions = {
 	message: string;
@@ -129,16 +134,8 @@ interface AgentCreateFormProps {
 	isCreating: boolean;
 	createError: unknown;
 	canCreateChat: boolean;
-	modelCatalog: TypesGen.ChatModelsResponse | null | undefined;
-	modelOptions: readonly ChatModelOption[];
 	canConfigureAgentSetup: boolean;
-	providerCount?: number;
-	modelCount?: number;
-	unsupportedProviderNames?: readonly string[];
 	aiGatewayDisabled?: boolean;
-	isModelCatalogLoading: boolean;
-	modelConfigs: readonly TypesGen.ChatModelConfig[];
-	isModelConfigsLoading: boolean;
 	rootPersonalModelOverride?: TypesGen.ChatPersonalModelOverride;
 	isPersonalModelOverridesLoading?: boolean;
 	mcpServers?: readonly TypesGen.MCPServerConfig[];
@@ -155,16 +152,8 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	isCreating,
 	createError,
 	canCreateChat,
-	modelCatalog,
-	modelOptions,
 	canConfigureAgentSetup,
-	providerCount,
-	modelCount,
-	unsupportedProviderNames,
 	aiGatewayDisabled,
-	modelConfigs,
-	isModelCatalogLoading,
-	isModelConfigsLoading,
 	rootPersonalModelOverride,
 	isPersonalModelOverridesLoading = false,
 	mcpServers,
@@ -185,6 +174,32 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	const [initialLastModelConfigID] = useState(() => {
 		return localStorage.getItem(lastModelConfigIDStorageKey) ?? "";
 	});
+	const initialOrg =
+		organizations.find((o) => o.is_default) ?? organizations[0];
+	const [selectedOrg, setSelectedOrg] = useState<TypesGen.Organization | null>(
+		initialOrg ?? null,
+	);
+	const organizationId = selectedOrg?.id ?? "";
+	const chatModelsQuery = useQuery(chatModels());
+	const chatModelConfigsQuery = useQuery(
+		chatModelConfigsByOrganization(organizationId),
+	);
+	const chatProviderConfigsQuery = useQuery({
+		...chatProviderConfigs(),
+		enabled: canConfigureAgentSetup,
+	});
+	const userProviderConfigsQuery = useQuery(userChatProviderConfigs());
+	const {
+		options: modelOptions,
+		isModelCatalogLoading,
+		modelCatalog,
+		hasConfiguredModels,
+	} = resolveModelSelector(
+		chatModelConfigsQuery,
+		chatModelsQuery,
+		userProviderConfigsQuery,
+	);
+	const modelConfigs = chatModelConfigsQuery.data ?? [];
 	/*
 	 * Model precedence: user click > root override (specific model) > root
 	 * override (chat_default, resolved) > last-used > default > first available.
@@ -271,8 +286,6 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 				selectedModelOption.reasoningEffortDefault,
 			)
 		: undefined;
-	const initialOrg =
-		organizations.find((o) => o.is_default) ?? organizations[0];
 	const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(
 		() => {
 			const stored = localStorage.getItem(selectedWorkspaceIdStorageKey);
@@ -303,15 +316,10 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 			return stored;
 		},
 	);
-	const [selectedOrg, setSelectedOrg] = useState<TypesGen.Organization | null>(
-		initialOrg ?? null,
-	);
 	const [pendingOrgChange, setPendingOrgChange] =
 		useState<TypesGen.Organization | null>(null);
-	const organizationId = selectedOrg?.id ?? "";
 	const [planModeEnabled, setPlanModeEnabled] = useState(false);
 	const hasModelOptions = modelOptions.length > 0;
-	const hasConfiguredModels = hasConfiguredModelsInCatalog(modelCatalog);
 	const hasUserFixableModelProviders = hasUserFixableProviders(modelCatalog);
 	const modelSelectorPlaceholder = getModelSelectorPlaceholder(
 		modelOptions,
@@ -325,23 +333,34 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		hasConfiguredModels,
 		hasUserFixableModelProviders,
 	});
+	const providerCount =
+		canConfigureAgentSetup &&
+		chatProviderConfigsQuery.isSuccess &&
+		chatModelsQuery.isSuccess
+			? countConfiguredProviderConfigs(
+					chatProviderConfigsQuery.data,
+					chatModelsQuery.data,
+				)
+			: undefined;
+	const modelCount =
+		chatModelConfigsQuery.isSuccess && chatModelsQuery.isSuccess
+			? modelOptions.length
+			: undefined;
+	const unsupportedProviderNames = getUnsupportedProviderNames(
+		chatModelsQuery.data,
+	);
 	useEffect(() => {
 		if (!initialLastModelConfigID) {
 			return;
 		}
-		if (isModelCatalogLoading || isModelConfigsLoading) {
+		if (isModelCatalogLoading) {
 			return;
 		}
 		if (lastUsedModelID) {
 			return;
 		}
 		localStorage.removeItem(lastModelConfigIDStorageKey);
-	}, [
-		initialLastModelConfigID,
-		isModelCatalogLoading,
-		isModelConfigsLoading,
-		lastUsedModelID,
-	]);
+	}, [initialLastModelConfigID, isModelCatalogLoading, lastUsedModelID]);
 
 	const [userMCPServerIds, setUserMCPServerIds] = useState<string[] | null>(
 		null,
@@ -371,14 +390,6 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		setUserSelectedModel(value);
 	};
 
-	const handleReasoningEffortChange = (value: string) => {
-		setSelectedReasoningEfforts((current) => ({
-			...current,
-			[selectedModel]: value,
-		}));
-		saveReasoningEffortForModel(selectedModel, value);
-	};
-
 	const isForbidden = !canCreateChat;
 
 	// Filter workspaces by the selected organization. We use
@@ -401,26 +412,6 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 			? selectedWorkspaceId
 			: null;
 
-	const handleSend = async (message: string, fileIDs?: string[]) => {
-		submitDraft();
-		await onCreateChat({
-			message,
-			fileIDs,
-			workspaceId: effectiveWorkspaceId ?? undefined,
-			model: submittedModel,
-			reasoningEffort: effectiveReasoningEffort,
-			organizationId,
-			mcpServerIds:
-				effectiveMCPServerIds.length > 0
-					? [...effectiveMCPServerIds]
-					: undefined,
-			planMode: planModeEnabled ? "plan" : undefined,
-		}).catch((err) => {
-			resetDraft();
-			throw err;
-		});
-	};
-
 	const {
 		attachments,
 		textContents,
@@ -433,33 +424,6 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		persist: true,
 		provider: getProviderForModelOption(modelOptions, selectedModel),
 	});
-
-	const handleSendWithAttachments = async (message: string) => {
-		const fileIds: string[] = [];
-		let skippedErrors = 0;
-		for (const file of attachments) {
-			const state = uploadStates.get(file);
-			if (state?.status === "error") {
-				skippedErrors++;
-				continue;
-			}
-			if (state?.status === "uploaded" && state.fileId) {
-				fileIds.push(state.fileId);
-			}
-		}
-		if (skippedErrors > 0) {
-			toast.warning(
-				`${skippedErrors} attachment${skippedErrors > 1 ? "s" : ""} could not be sent (upload failed)`,
-			);
-		}
-		const fileArg = fileIds.length > 0 ? fileIds : undefined;
-		try {
-			await handleSend(message, fileArg);
-			resetAttachments();
-		} catch {
-			// Attachments preserved for retry on failure.
-		}
-	};
 
 	const permittedOrgsQuery = useQuery({
 		...permittedOrganizations({
@@ -504,6 +468,61 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 			onOrgAdjusted();
 		}
 	}, [orgWasAdjusted]);
+
+	const handleReasoningEffortChange = (value: string) => {
+		setSelectedReasoningEfforts((current) => ({
+			...current,
+			[selectedModel]: value,
+		}));
+		saveReasoningEffortForModel(selectedModel, value);
+	};
+
+	const handleSend = async (message: string, fileIDs?: string[]) => {
+		submitDraft();
+		await onCreateChat({
+			message,
+			fileIDs,
+			workspaceId: effectiveWorkspaceId ?? undefined,
+			model: submittedModel,
+			reasoningEffort: effectiveReasoningEffort,
+			organizationId,
+			mcpServerIds:
+				effectiveMCPServerIds.length > 0
+					? [...effectiveMCPServerIds]
+					: undefined,
+			planMode: planModeEnabled ? "plan" : undefined,
+		}).catch((err) => {
+			resetDraft();
+			throw err;
+		});
+	};
+
+	const handleSendWithAttachments = async (message: string) => {
+		const fileIds: string[] = [];
+		let skippedErrors = 0;
+		for (const file of attachments) {
+			const state = uploadStates.get(file);
+			if (state?.status === "error") {
+				skippedErrors++;
+				continue;
+			}
+			if (state?.status === "uploaded" && state.fileId) {
+				fileIds.push(state.fileId);
+			}
+		}
+		if (skippedErrors > 0) {
+			toast.warning(
+				`${skippedErrors} attachment${skippedErrors > 1 ? "s" : ""} could not be sent (upload failed)`,
+			);
+		}
+		const fileArg = fileIds.length > 0 ? fileIds : undefined;
+		try {
+			await handleSend(message, fileArg);
+			resetAttachments();
+		} catch {
+			// Attachments preserved for retry on failure.
+		}
+	};
 
 	return (
 		<>

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
@@ -52,6 +52,7 @@ const defaultModelOptions: ModelSelectorOption[] = [
 const defaultModelConfigs: TypesGen.ChatModelConfig[] = [
 	{
 		id: "config-openai-gpt-4o",
+		organization_id: "my-organization-id",
 		ai_provider_id: "prov-1",
 		model: "gpt-4o",
 		display_name: "GPT-4o",

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.test.tsx
@@ -583,6 +583,7 @@ describe("ChatsSidebar model display names", () => {
 		const modelConfigs: TypesGen.ChatModelConfig[] = [
 			{
 				id: "config-fast",
+				organization_id: "my-organization-id",
 				ai_provider_id: "prov-openai",
 				model: "gpt-4o",
 				display_name: "GPT-4o (Fast)",
@@ -595,6 +596,7 @@ describe("ChatsSidebar model display names", () => {
 			},
 			{
 				id: "config-quality",
+				organization_id: "my-organization-id",
 				ai_provider_id: "prov-openai",
 				model: "gpt-4o",
 				display_name: "GPT-4o (Quality)",

--- a/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
+++ b/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
@@ -295,6 +295,11 @@ export const UserCompactionThresholdSettings: FC<
 											<ProviderIcon provider={provider} className="size-4" />
 											{modelName}
 										</Badge>
+										{modelConfig.organization_display_name && (
+											<span className="mt-0.5 block text-2xs font-normal text-content-secondary">
+												{modelConfig.organization_display_name}
+											</span>
+										)}
 										{rowError && (
 											<p
 												aria-live="polite"

--- a/site/src/pages/AgentsPage/utils/modelOptions.ts
+++ b/site/src/pages/AgentsPage/utils/modelOptions.ts
@@ -74,7 +74,7 @@ const isProviderConfiguredInCatalog = (
 	return unavailableReason !== "" && unavailableReason !== "missing_api_key";
 };
 
-export const hasConfiguredModelsInCatalog = (
+const hasConfiguredModelsInCatalog = (
 	catalog: ModelCatalogLike | null | undefined,
 ): boolean => {
 	return getCatalogProviders(catalog).some(isProviderConfiguredInCatalog);

--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense } from "react";
+import { useQuery } from "react-query";
 import {
 	createBrowserRouter,
 	createRoutesFromChildren,
@@ -9,11 +10,15 @@ import {
 	useLocation,
 	useParams,
 } from "react-router";
+import { organizationsPermissions } from "./api/queries/organizations";
+import { ErrorAlert } from "./components/Alert/ErrorAlert";
+import { EmptyState } from "./components/EmptyState/EmptyState";
 import { GlobalErrorBoundary } from "./components/ErrorBoundary/GlobalErrorBoundary";
 import { Loader } from "./components/Loader/Loader";
 import { RequireAuth } from "./contexts/auth/RequireAuth";
 import { useAuthenticated } from "./hooks/useAuthenticated";
 import { DashboardLayout } from "./modules/dashboard/DashboardLayout";
+import { useDashboard } from "./modules/dashboard/useDashboard";
 import AuditPage from "./pages/AuditPage/AuditPage";
 import ConnectionLogPage from "./pages/ConnectionLogPage/ConnectionLogPage";
 import { HealthLayout } from "./pages/HealthPage/HealthLayout";
@@ -442,6 +447,9 @@ const AISettingsGatewayKeysPage = lazy(
 const AISettingsModelsPage = lazy(
 	() => import("./pages/AISettingsPage/ModelsPage/ModelsPage"),
 );
+const AISettingsOrganizationModelsLayout = lazy(
+	() => import("./pages/AISettingsPage/ModelsPage/OrganizationModelsLayout"),
+);
 const AISettingsInstructionsPage = lazy(
 	() => import("./pages/AISettingsPage/InstructionsPage/InstructionsPage"),
 );
@@ -482,11 +490,61 @@ const AISettingsIndexRedirect = () => {
 		return <Navigate to="/ai/settings/gateway-keys" replace />;
 	}
 
-	if (permissions.editDeploymentConfig) {
+	if (
+		permissions.createAnyChatModelConfig ||
+		permissions.editAnyChatModelConfig
+	) {
 		return <Navigate to="/ai/settings/models" replace />;
 	}
 
 	return <Navigate to="/ai/settings/providers" replace />;
+};
+
+/**
+ * Redirects the legacy /ai/settings/models routes to the first organization
+ * the caller can manage chat model configs in, preferring the default org.
+ */
+const AISettingsModelsRedirect = () => {
+	const { organizations } = useDashboard();
+	const location = useLocation();
+	const manageableOrgsQuery = useQuery({
+		...organizationsPermissions(
+			organizations.length > 0 ? organizations.map((org) => org.id) : undefined,
+		),
+		select: (permissionsByOrg) =>
+			organizations.filter(
+				(org) =>
+					permissionsByOrg[org.id]?.createChatModelConfigs ||
+					permissionsByOrg[org.id]?.editChatModelConfigs,
+			),
+	});
+
+	if (manageableOrgsQuery.isLoading) {
+		return <Loader fullscreen />;
+	}
+
+	if (manageableOrgsQuery.error !== null) {
+		return <ErrorAlert error={manageableOrgsQuery.error} />;
+	}
+
+	const manageable = manageableOrgsQuery.data ?? [];
+	const target = manageable.find((org) => org.is_default) ?? manageable[0];
+	if (!target) {
+		return (
+			<EmptyState
+				message="No manageable organizations"
+				description="You do not have permission to manage chat models in any organization. Ask an organization administrator for access."
+			/>
+		);
+	}
+
+	const suffix = location.pathname.replace(/^\/ai\/settings\/models/, "");
+	return (
+		<Navigate
+			to={`/ai/settings/organizations/${target.name}/models${suffix}${location.search}`}
+			replace
+		/>
+	);
 };
 
 const GlobalLayout = () => {
@@ -767,7 +825,12 @@ export const router = createBrowserRouter(
 							element={<AISettingsGatewayKeysPage />}
 						/>
 						<Route index element={<AISettingsIndexRedirect />} />
-						<Route path="models" element={<AISettingsModelsPage />} />
+						<Route path="models" element={<AISettingsModelsRedirect />} />
+						<Route path="models/add" element={<AISettingsModelsRedirect />} />
+						<Route
+							path="models/:modelId"
+							element={<AISettingsModelsRedirect />}
+						/>
 						<Route path="spend" element={<AISettingsSpendPage />} />
 						<Route
 							path="instructions"
@@ -776,11 +839,17 @@ export const router = createBrowserRouter(
 						<Route path="lifecycle" element={<AISettingsLifecyclePage />} />
 						<Route path="coder-agents" element={<CoderAgentsPage />} />
 						<Route path="templates" element={<AISettingsTemplatesPage />} />
-						<Route path="models/add" element={<AISettingsAddModelPage />} />
 						<Route
-							path="models/:modelId"
-							element={<AISettingsUpdateModelPage />}
-						/>
+							path="organizations/:organization"
+							element={<AISettingsOrganizationModelsLayout />}
+						>
+							<Route path="models" element={<AISettingsModelsPage />} />
+							<Route path="models/add" element={<AISettingsAddModelPage />} />
+							<Route
+								path="models/:modelId"
+								element={<AISettingsUpdateModelPage />}
+							/>
+						</Route>
 						<Route path="mcp-servers" element={<AISettingsMCPServersPage />} />
 						<Route
 							path="mcp-servers/add"

--- a/site/src/testHelpers/chatModels.ts
+++ b/site/src/testHelpers/chatModels.ts
@@ -4,9 +4,11 @@ import type {
 	ChatProviderConfig,
 } from "#/api/typesGenerated";
 import { MOCK_TIMESTAMP } from "./chatEntities";
+import { MockDefaultOrganization } from "./entities";
 
 export const MockChatModelConfig: ChatModelConfig = {
 	id: "model-1",
+	organization_id: MockDefaultOrganization.id,
 	ai_provider_id: "provider-1",
 	model: "gpt-5",
 	display_name: "gpt-5",

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -3352,6 +3352,9 @@ export const MockPermissions: Permissions = {
 	deleteOAuth2App: true,
 	viewOAuth2AppSecrets: true,
 	createChat: true,
+	createAnyChatModelConfig: true,
+	editAnyChatModelConfig: true,
+	deleteAnyChatModelConfig: true,
 };
 
 export const MockNoPermissions: Permissions = {
@@ -3389,6 +3392,9 @@ export const MockNoPermissions: Permissions = {
 	deleteOAuth2App: false,
 	viewOAuth2AppSecrets: false,
 	createChat: false,
+	createAnyChatModelConfig: false,
+	editAnyChatModelConfig: false,
+	deleteAnyChatModelConfig: false,
 };
 
 export const MockOrganizationPermissions: OrganizationPermissions = {
@@ -3407,6 +3413,9 @@ export const MockOrganizationPermissions: OrganizationPermissions = {
 	viewProvisionerJobs: true,
 	viewIdpSyncSettings: true,
 	editIdpSyncSettings: true,
+	createChatModelConfigs: true,
+	editChatModelConfigs: true,
+	deleteChatModelConfigs: true,
 };
 
 export const MockNoOrganizationPermissions: OrganizationPermissions = {
@@ -3425,6 +3434,9 @@ export const MockNoOrganizationPermissions: OrganizationPermissions = {
 	viewProvisionerJobs: false,
 	viewIdpSyncSettings: false,
 	editIdpSyncSettings: false,
+	createChatModelConfigs: false,
+	editChatModelConfigs: false,
+	deleteChatModelConfigs: false,
 };
 
 export const MockDeploymentConfig: DeploymentConfig = {


### PR DESCRIPTION
Org-scope the chat model config API and cut over every resolution path (CODAGT-709, stage 3 of 3, stacked on M2). Migration 000564 explodes default-org configs to every live non-default org; the deployment-wide routes, interim write gates, and default-org runtime fallback are replaced by org-scoped management and strict `chat.OrganizationID` resolution.

## Stack

1. M1: #27547 (base `main`)
2. M2: #27595 (base M1)
3. **M3: this PR** (base M2, `mathias/codagt-709-model-config-rbac`)
4. M5: #27676 (base this branch); M4 is a parallel sibling of M5 on this branch

## What changes

- **Migration 000564** (up+down, one transaction): for every live non-default org, copies each default-org config with a fresh `gen_random_uuid()` ID (mapping held in a transaction-scoped `TEMPORARY ... ON COMMIT DROP` lookup table, nothing persisted; no hash-derived IDs, FIPS-safe). Live configs fan out to every live org; soft-deleted configs copy only to orgs referencing them (chats, messages, queued messages, debug runs) and keep `deleted`/`deleted_at`. Remaps `chats.last_model_config_id`, `chat_messages.model_config_id`, and the FK-less `chat_queued_messages.model_config_id` / `chat_debug_runs.model_config_id` to the same-org copy; fans out `user_configs` compaction-threshold keys (`chat_compaction_threshold_pct:<id>`) to every existing copy. Copies re-key `group_acl` to their org (carrying the original's everyone entry); any pre-existing row missing the everyone-ACL entry is backfilled (covers configs created between M1 and M3). Down is best-effort per the operator ruling: retargets references to the default-org config matching `(ai_provider_id, model)` with a deterministic tiebreak, deletes copies, and prunes dangling threshold keys; green on duplicate-free data, may lose fidelity on pathological duplicates, never loses chats.
- **Routes**: the deployment-wide `/api/experimental/chats/model-configs` routes and the M2 interim write gates are deleted. New: `POST|GET /api/experimental/organizations/{organization}/chat-model-configs` (create authorizes create-in-org and seeds the everyone-read `group_acl` entry; list is the authorized query filtered to the org), `GET|PATCH|DELETE /api/experimental/chat-model-configs/{id}` (org resolved from the row, dbauthz object checks), a member union `GET /api/experimental/chat-model-configs` (everything the caller can read across orgs, rows carry `organization_id` + org display name), and a redacted `GET /api/experimental/ai-providers/catalog` for org model admins.
- **dbauthz**: the write-side swaps deferred from M2 land (insert = create-in-org; update/delete = fetch-then-authorize object checks; unset-defaults = update-in-org; `GetChatModelConfigByID` and `GetDefaultChatModelConfig` = object reads). `GetDefaultChatModelConfigCandidates` is deleted; default-election probes inside the write transactions run call-scoped `AsChatd` (a denial must never be misread as "no default exists") while every mutation stays under the requesting subject. Stale `NotAuthorizedError` comments corrected: `Unwrap()` returns the RBAC denial, never `sql.ErrNoRows`.
- **Runtime**: the M1 default-org fallback is removed (strict `chat.OrganizationID`); spawnable-model listing, manual title selection, and configcache defaults are org-scoped; the title-generation override softens from hard error to fallback when its ID does not resolve in the chat's org (the declared M3-to-M5 window, ended by M5's per-org overrides).
- **Validation**: `validateUserChatModelConfigAvailable` is org-aware (a config outside the chat's org is unavailable); `getUserChatProviderAvailability` uses the authorized union query under the user's subject.
- **SDK/scaletest**: org-scoped + item + union + catalog methods replace the old four; scaletest creates/reuses its model config in each org it targets.
- **Telemetry**: `ChatModelConfig` gains `OrganizationID`; per-org copies report as distinct rows (consumers dedupe on `(provider, model)` if they want logical configs).
- **Frontend**: `api.ts`/`queries/chats.ts` re-pointed and org-keyed; pickers fetch by the chat's org; ModelsPage/Add/Update move under a new `/ai/settings/organizations/:organization/models[...]` org-context layout with a switcher, sourcing provider metadata from the redacted catalog endpoint instead of the deployment-scoped provider API; `/ai/settings/models` redirects to the first manageable org (preferring the default); AgentSettings compaction/API-keys pages use the union endpoint (compaction writes target per-copy IDs, which is correct post-explosion); personal-override page sources default-org rows and goes read-only with an explanation when the union has none (M3-to-M5 window); CoderAgentsPage pickers pinned to default-org models; new `permissions.json` entries (`create/edit/deleteAnyChatModelConfig` any-org discovery + per-org object checks) replace the `editDeploymentConfig` gate on the Models tree.

## Intentional behavior changes inside the cutover

- The union list endpoint returns every config the caller's ACL admits, **including disabled and provider-disabled rows** (the pre-cutover member list served enabled-only). Chat *use* is still blocked: org-aware validation rejects disabled/cross-org configs at write time, and picker/runtime resolution uses the enabled-only per-org query. User-context pages (compaction thresholds, API keys) need the full readable set.
- Between M3 and M5, model overrides (deployment and personal) resolve against default-org configs only; the title-generation override falls back instead of hard-erroring when its ID does not resolve. M5 lands per-org override management.

## Shared-component change (OrganizationAutocomplete)

The Models org switcher reuses `OrganizationAutocomplete` instead of a parallel component (FE3 reuse rule). The reuse forced two changes to the shared component, matching its sibling organization switcher on the same cmdk version: a keyboard-navigation workaround (`tabIndex={0}` for the known cmdk issue) so Tab reaches the first option, and deterministic ordering (active organization first, then case-insensitive alphabetical by display name) because `GetOrganizations` has no `ORDER BY`. Existing consumers are unaffected (the trigger-class option and both behaviors are additive).

## Provider catalog endpoint (declared invariant-3 exception)

ModelsPage/Add/Update need provider capability metadata, but `/api/v2/ai/providers` is deployment-scoped and org admins cannot read it. The catalog endpoint gates access with a handler-level `rbac.Authorize` (create or update on `ResourceChatModelConfig` in at least one of the caller's orgs) in front of an `AsChatd` fetch, and returns only the redacted capability fields the Models UI consumes (id, type, display name, icon, enabled, key-state booleans, `allow_user_api_key`). Key material, base URLs, and headers never enter the response. Deployment provider read is not granted to org admins.

## Verification

- Migration Stepper test `TestMigration000564ChatModelConfigOrgExplosion`: per-org row counts incl. referenced-deleted copies, exactly one live default per org, all four remaps, ACL re-key + backfill, scope rules (soft-deleted org receives nothing and keeps references, zero-member live org receives the full live set, unreferenced deleted config not copied), threshold fan-out precision, and the down round-trip on duplicate-free data. All 29 migration tests pass.
- Mutation proofs (each shown failing against the un-fixed state, then passing): the default-resolution denial branch (`httpapi.Is404Error`: a member denied the org default gets the existing 400, not a 500) and org-aware validation (cross-org explicit `model_config_id` rejected at chat create).
- `make fmt`, `make lint`, `make -B gen` (clean tree); dbauthz (plain + `-race`), telemetry, model-config handler suites (plain + `-race`), enterprise chat suites, scaletest all pass; FE `pnpm lint`, unit tests, and `storybook:build` pass.
- Two-phase self-review: implementer pass plus an independent adversarial sub-agent pass (attack brief across migration SQL, dbauthz swaps, handler cutover, runtime, SDK/scaletest, FE, and test honesty). Zero defects; four observations logged, none rising to defect under the plan's declared design points.

<details>
<summary>Plan excerpt (CODAGT-74 M3 unit entry)</summary>

**M3 `feat: org-scope chat model config API` (cutover)** (base: M2)

- Migration B (explosion; prototype rev 3 proved the fan-out scoping, remap totality, and down ordering; rev 6 re-verifies on the temp-table mapping design before M3 is implemented): for every LIVE (not soft-deleted) non-default org, copy every default-org config as a `gen_random_uuid()` row (mapping held in the in-transaction temp lookup table), `group_acl` re-keyed to the target org, `is_default`/`enabled` preserved; soft-deleted configs are copied only to orgs whose chats/messages/queued-messages/debug-runs reference them (copies keep `deleted`/`deleted_at`); seed the everyone-ACL entry on any existing row missing it (covers configs created between M1 and M3); total remap of LIVE non-default-org chats' `last_model_config_id` (NOT NULL, so no NULL path exists) and of their `chat_messages.model_config_id` via the owning chat's org, joining the temp mapping; chats in soft-deleted orgs keep original references (FK-valid, unreachable). Down: unsupported, best-effort, no chat loss: retarget every copy reference back to the default-org config matching `(ai_provider_id, model)` with a deterministic tiebreak (`DISTINCT ON` ordered by created_at; satisfies NOT NULL/FK and the CI down test; fidelity loss accepted on pathological duplicates), then delete non-default-org copies. Stepper test asserting: per-org row counts incl. referenced-deleted copies, exactly one live default per org, all remaps, ACL re-key/backfill, the down round-trip on non-duplicate data, AND the scope rules (a soft-deleted org receives no copies and its chats stay untouched; a zero-member live org receives the full live set; an unreferenced deleted config is not copied).
- Routes: create the org-scoped route group under the experimental router (none exists there today) using `httpmw.ExtractOrganizationParam`: `POST|GET /api/experimental/organizations/{organization}/chat-model-configs` (create authorizes create-in-org and SEEDS the everyone-read `group_acl` entry, admins restrict later via M4; list uses the authorized query filtered to the org); `GET|PATCH|DELETE /api/experimental/chat-model-configs/{id}` (org from row; fetch-then-authorize). Old `/chats/model-configs` routes, handlers, and the M2 interim write gate deleted. Default toggling per org.
- dbauthz: the checks deferred from M2 land: the WRITE-side object swaps (insert, update, delete, unset-defaults, and their fetch-then-authorize reads; deferred because swapping them during the interim-gate window contracts custom-role write access, see M2), `GetDefaultChatModelConfig` swaps to an object read check, and member list paths move from `AsChatd` to the authorized query under the user's subject. Denial handling is NOT free: `NotAuthorizedError.Unwrap()` returns the rbac error, not `sql.ErrNoRows` (the comments at dbauthz.go:37/60 claiming otherwise are stale; fix them in passing), so (1) the chat-create resolver's branch at exp_chats.go:5019 changes `xerrors.Is(err, sql.ErrNoRows)` to `httpapi.Is404Error(err)` so a member denied the org default gets the existing 400 "no default model" response instead of a 500; (2) chatd-side resolution paths need no change (every one runs `AsChatd`, which holds site read from M2); (3) the admin default-probe READS inside the create/update/delete transactions (exp_chats.go:7407, 7737, or their M3 successors) run under `dbauthz.AsChatd` scoped to the probe CALL ONLY (e.g. `tx.GetDefaultChatModelConfig(dbauthz.AsChatd(ctx), org)`), because their `ErrNoRows` branch unsets/promotes defaults and must never be reachable via a misread denial; every MUTATION in those transactions stays under the requesting admin's subject (a blanket `AsChatd` transaction context would bypass write authorization; MethodTestSuite proves the mutations authorize the user object).
- Runtime: fallback removed (strict `chat.OrganizationID`); unfiltered queries deleted; `getUserChatProviderAvailability` switches to the authorized query under the user's subject (union across the user's orgs).
- SDK (`codersdk/chats.go`): new org-scoped + item methods, old four deleted; request/response types gain org where relevant.
- Cross-feature remaps in the same explosion migration (id-references survey): `chat_queued_messages.model_config_id` and `chat_debug_runs.model_config_id` remapped like `chats.last_model_config_id` (org via `chat_id`; both FK-less); `user_configs` compaction-threshold keys (`chat_compaction_threshold_pct:<id>`) fanned out precisely to every copy that exists (live configs: all live orgs; deleted configs: only the orgs that received a referenced copy), because chats pinned to deleted models are the NORM (75% on dogfood) and their thresholds must keep resolving; threshold keys for copies that do not exist are not created.
- Interim override handling (full fix is M5): title-generation override resolution softened from hard error to fallback when the ID does not resolve in the chat's org; general/explore/compaction/advisor overrides already fall back softly; CoderAgentsPage override pickers pinned to default-org models, which keeps the still-global DEPLOYMENT settings editable and coherent for that page's audience (it is gated on `editDeploymentConfig`, i.e. owners, who read default-org configs via site permissions regardless of membership); the personal-override interim, including the non-default-only user class, is defined in the Frontend bullet below.
- `validateUserChatModelConfigAvailable` (chat create) becomes org-aware; scaletest chat provider creates/reuses its config in the target org.
- Frontend: `api.ts`/`queries/chats.ts` re-pointed and org-keyed; every `chatModelConfigs()` consumer (~12) is assigned one of THREE contracts before the global endpoint is deleted: (1) chat-org scoped: member-facing model pickers (chat create/settings surfaces) fetch by the org already selected for the chat (localStorage last-model key self-heals against the org-filtered catalog); (2) admin org-scoped: ModelsPage/Add/Update wired to the org endpoints under the new layout; (3) authorized union: a new member endpoint `GET /api/experimental/chat-model-configs` returns the union of configs the user can read across orgs (authorized query under the user's subject, rows carry `organization_id` + org display name) for user-context pages with no single org: AgentSettingsCompactionPage (thresholds are keyed by copy ID, so listing org copies with org labels is the correct post-explosion shape; new writes target the specific copy row shown) and AgentSettingsAPIKeysPage (availability display only). AgentSettingsUserAgentsPage (personal overrides) stays on the DECLARED M3-to-M5 window contract, defined for ALL users: the picker sources the union endpoint's default-org rows (still writing the global key; M5 converts it per-org), and a user whose union contains no default-org rows (member of non-default orgs only) gets the page in a read-only/disabled state with an explanation until M5, never an elevated-context catalog read; SubagentTool's historical model attribution keeps resolving because messages were remapped to org copies. Router gains `/ai/settings/organizations/:organization/models[...]` with an AI-settings org context layout + switcher (adapted from `OrganizationSidebarView`'s switcher; org resolved by name from `useDashboard().organizations`); `/ai/settings/models` redirects to the first org the user can manage, preferring the default org (a plain default-org redirect strands org admins without default-org membership); empty-org state; stories updated (PageView fixtures incl. the three user-context pages).
- FE permissions and navigation: new `permissions.json` entries for the resource (an `any_org: true` discovery check for sidebar/nav visibility plus per-org object checks for page guards); ModelsPage tree and its AISettingsSidebarView entry stop gating on `editDeploymentConfig` (org admins authorized by the backend must see the UI); unauthorized-org navigation tests.
- Provider metadata for org model admins: ModelsPage/Add/Update need provider metadata, but `/api/v2/ai/providers` is deployment-scoped and org admins cannot read it (roles.go:574-600; the FE fetch is gated on `editDeploymentConfig` today, ModelsPage.tsx:15-39). M3 adds a REDACTED provider catalog endpoint (`GET /api/experimental/ai-providers/catalog`) carrying exactly the capability fields the Models UI adapter consumes (providerStates.ts:148, ModelForm.tsx:146): id, type, display name, icon, enabled, has-key/effective-key-state booleans, `allow_user_api_key`; never key material, base URLs, or headers. The handler gates access with a real `rbac.Authorize` (create/update on `ResourceChatModelConfig` in at least one of the user's orgs) in front of an `AsChatd` fetch; this is the declared invariant 3 exception where the handler check IS the access boundary (dbauthz cannot express "any of the user's orgs" for a deployment-scoped fetch; the fetch can only yield redacted metadata); the pages and their adapter switch to it. Deployment provider read is NOT granted to org admins.
- Telemetry decision (explosion multiplies `GetChatModelConfigsForTelemetry` rows by live-org count; snapshot tests assert exact counts, telemetry_test.go:1919): telemetry `ChatModelConfig` gains `OrganizationID`; per-org copies report as distinct rows (they are distinct rows that can diverge); consumers dedupe on (provider, model) if they want logical configs. Snapshot tests updated accordingly in M3.
- Test-fixture sweep: tests that create a chat in one org while `dbgen.ChatModelConfig` defaults the config to the default org become cross-org after strict scoping (known instances: dbpurge chat-debug/retention/search-backfill suites, dbpurge_test.go:2224, 2453, 2927); M3 greps treewide for the pattern and updates fixtures to same-org configs rather than waiting for incidental failures.
- e2e specs touching model config settings updated.
- Review focus: explosion SQL + its Stepper test (incl. the queued-message/debug-run/threshold remaps); handler authz objects; the FE org-context layout (it is reused by B3); the union-endpoint contract; no residual caller of deleted queries.

</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻


