### PR TITLE
fix(site/src/modules/templates/TemplateExampleCard): point Use template to builder

### DIFF
--- a/site/src/modules/templates/TemplateExampleCard/TemplateExampleCard.tsx
+++ b/site/src/modules/templates/TemplateExampleCard/TemplateExampleCard.tsx
@@ -64,7 +64,7 @@ export const TemplateExampleCard: FC<TemplateExampleCardProps> = ({
 
 			<div className="mt-auto flex flex-col items-center gap-3 pt-6">
 				<Button asChild className="w-full">
-					<RouterLink to={`/templates/new?exampleId=${example.id}`}>
+					<RouterLink to={`/templates/new/builder?base=${example.id}`}>
 						Use template
 					</RouterLink>
 				</Button>


### PR DESCRIPTION
## Summary

Updates the "Use template" button on `TemplateExampleCard` to link to the template builder instead of the legacy create flow.

- `/templates/new?exampleId=${example.id}` → `/templates/new/builder?base=${example.id}`

This affects everywhere the card is rendered: the Templates page empty state and the Starter Templates gallery page.

## Notes

The "View all starter templates" button in the empty state keeps its existing `templateBuilderEnabled` conditional (unchanged).

---

_This PR was generated by Coder Agents on behalf of @jeremyruppel._