### PR TITLE
refactor(site/src/pages/AgentsPage): group chat messages into turn sections

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -1039,16 +1039,15 @@ const waitForFetchCount = async (
 	});
 };
 
-const waitForVisibleText = async (
+const findVisibleElementByText = (
 	canvas: ReturnType<typeof within>,
-	text: string,
-) => {
-	await waitFor(() => {
+	text: string | RegExp,
+): Promise<HTMLElement> =>
+	waitFor(() => {
 		// The chat timeline renders hidden measurement copies for some message
 		// layouts, so pick any visible match instead of assuming the first node is
 		// the one a user sees.
-		const matches = canvas.queryAllByText(text);
-		const hasVisibleMatch = matches.some((element: Element) => {
+		const visible = canvas.queryAllByText(text).find((element: HTMLElement) => {
 			const style = window.getComputedStyle(element);
 			return (
 				style.display !== "none" &&
@@ -1056,8 +1055,17 @@ const waitForVisibleText = async (
 				element.getClientRects().length > 0
 			);
 		});
-		expect(hasVisibleMatch).toBe(true);
+		if (!visible) {
+			throw new Error(`No visible element matching ${String(text)}`);
+		}
+		return visible;
 	});
+
+const waitForVisibleText = async (
+	canvas: ReturnType<typeof within>,
+	text: string,
+) => {
+	await findVisibleElementByText(canvas, text);
 };
 
 const waitForIntersectionObserverTick = async () => {
@@ -1218,11 +1226,17 @@ export const ScrollToBottomButtonWorksWithInverseScroll: Story = {
 
 		scrollToHistoryTop(scrollContainer);
 
-		await waitFor(() => {
-			expect(
-				canvas.getByRole("button", { name: /scroll to bottom/i }),
-			).toBeVisible();
-		});
+		// The button fades in over a CSS transition, and rendering the long
+		// conversation can occupy the main thread for longer than the default
+		// one second budget, so the fade only starts once rendering yields.
+		await waitFor(
+			() => {
+				expect(
+					canvas.getByRole("button", { name: /scroll to bottom/i }),
+				).toBeVisible();
+			},
+			{ timeout: 3000 },
+		);
 
 		await userEvent.click(
 			canvas.getByRole("button", { name: /scroll to bottom/i }),
@@ -1516,6 +1530,111 @@ export const StickyUserMessageClipUpdatesWhilePinned: Story = {
 			expect(measureScrolledPast()).toBeGreaterThan(scrolledPastBefore + 10);
 			expect(Math.abs(readClip() - expectedClip())).toBeLessThanOrEqual(2);
 		});
+	},
+};
+
+const anchoredPrependStore = buildStoreWithMessages(buildLongConversation(60));
+
+/**
+ * The timeline groups messages into per-turn sections, so loading an older page
+ * re-parents every rendered message. Reading mid-transcript must survive that:
+ * the message the reader is looking at stays where it is and the scroll offset
+ * does not move.
+ */
+export const OlderPagePrependKeepsAnchorMessageInPlace: Story = {
+	parameters: { pixel: { exclude: true } },
+	decorators: scrollStoryDecorators,
+	render: () => <StoryAgentChatPageView store={anchoredPrependStore} />,
+	play: async ({ canvasElement }) => {
+		anchoredPrependStore.replaceMessages(buildLongConversation(60));
+		anchoredPrependStore.setChatStatus("waiting");
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+
+		await waitForScrollOverflow(scrollContainer);
+
+		// Park a known prompt in view so "did the transcript jump" has a concrete
+		// subject rather than whatever happened to be on screen.
+		const anchorText = "Question 12: Can you explain concept 12 in detail?";
+		const anchor = await findVisibleElementByText(canvas, anchorText);
+		anchor.scrollIntoView({ block: "center" });
+		await waitForVisibleText(canvas, anchorText);
+		const offsetBeforePrepend = scrollContainer.scrollTop;
+
+		prependOlderMessages(anchoredPrependStore, 10);
+
+		await waitForVisibleText(canvas, "Older question 9.");
+		await waitFor(() => {
+			expect(scrollContainer.scrollTop).toBeCloseTo(offsetBeforePrepend, 0);
+		});
+		await waitForVisibleText(canvas, anchorText);
+	},
+};
+
+// A transcript page can start with assistant replies whose prompt lives on an
+// older page that has not been fetched. Those replies open the timeline as a
+// turn with no prompt of its own.
+const buildOrphanLeadingConversation = (): TypesGen.ChatMessage[] => [
+	buildMessage(
+		20,
+		"assistant",
+		`Reply whose prompt is on an older page. ${"Filler sentence so the transcript overflows the scroll decorator. ".repeat(30)}`,
+	),
+	buildMessage(
+		21,
+		"assistant",
+		`Second orphan reply. ${"More filler so the transcript keeps overflowing. ".repeat(30)}`,
+	),
+	buildMessage(22, "user", "Prompt that is already on this page."),
+	buildMessage(
+		23,
+		"assistant",
+		`Reply to the prompt on this page. ${"Yet more filler. ".repeat(40)}`,
+	),
+];
+
+const orphanLeadingStore = buildStoreWithMessages(
+	buildOrphanLeadingConversation(),
+);
+
+/**
+ * When the older page arrives it carries the prompt that owns the leading
+ * replies, so the headerless opening turn merges into that prompt's turn. The
+ * merge must not drop content or move the scroll offset.
+ */
+export const OrphanLeadingTurnMergesWhenOlderPageArrives: Story = {
+	parameters: { pixel: { exclude: true } },
+	decorators: scrollStoryDecorators,
+	render: () => <StoryAgentChatPageView store={orphanLeadingStore} />,
+	play: async ({ canvasElement }) => {
+		orphanLeadingStore.replaceMessages(buildOrphanLeadingConversation());
+		orphanLeadingStore.setChatStatus("waiting");
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+
+		await waitForScrollOverflow(scrollContainer);
+
+		const orphan = await findVisibleElementByText(
+			canvas,
+			/Second orphan reply\./,
+		);
+		orphan.scrollIntoView({ block: "center" });
+		await waitForVisibleText(canvas, "Prompt that is already on this page.");
+		expect(
+			canvas.queryByText("Prompt fetched with the older page."),
+		).not.toBeInTheDocument();
+		const offsetBeforePrepend = scrollContainer.scrollTop;
+
+		orphanLeadingStore.replaceMessages([
+			buildMessage(19, "user", "Prompt fetched with the older page."),
+			...getStoreMessages(orphanLeadingStore),
+		]);
+
+		await waitForVisibleText(canvas, "Prompt fetched with the older page.");
+		await waitFor(() => {
+			expect(scrollContainer.scrollTop).toBeCloseTo(offsetBeforePrepend, 0);
+		});
+		await waitForVisibleText(canvas, "Prompt that is already on this page.");
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1422,8 +1422,7 @@ export const MetadataOnlyUserMessageDoesNotLeaveStickyGap: Story = {
 };
 
 /**
- * Verifies the structural requirements for sticky user messages
- * in the flat (section-less) message list:
+ * Verifies the structural requirements for sticky user messages:
  * - Each user message renders a data-user-sentinel marker so
  *   the push-up logic can find the next user message via DOM
  *   traversal.

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -820,21 +820,6 @@ const ChatMessageItem = memo<{
 	},
 );
 
-// Each turn renders its prompt's sentinel as the first element of the turn
-// section, so the next prompt's sentinel is the first element of a following
-// section rather than a later sibling of this one.
-const findNextUserSentinel = (sentinel: Element): Element | null => {
-	let turn = sentinel.parentElement?.nextElementSibling ?? null;
-	while (turn) {
-		const candidate = turn.firstElementChild;
-		if (candidate?.hasAttribute("data-user-sentinel")) {
-			return candidate;
-		}
-		turn = turn.nextElementSibling;
-	}
-	return null;
-};
-
 const StickyUserMessage = memo<{
 	message: TypesGen.ChatMessage;
 	parsed: ParsedMessageContent;
@@ -849,6 +834,7 @@ const StickyUserMessage = memo<{
 	nextUserMessageId?: number;
 	onJumpToUserMessage?: (messageId: number) => void;
 	registerSentinel?: (messageId: number, el: HTMLDivElement | null) => void;
+	getSentinel?: (messageId: number) => HTMLDivElement | null;
 	urlTransform?: UrlTransform;
 }>(
 	({
@@ -861,6 +847,7 @@ const StickyUserMessage = memo<{
 		nextUserMessageId,
 		onJumpToUserMessage,
 		registerSentinel,
+		getSentinel,
 		urlTransform,
 	}) => {
 		const [isStuck, setIsStuck] = useState(false);
@@ -874,6 +861,18 @@ const StickyUserMessage = memo<{
 		};
 		const containerRef = useRef<HTMLDivElement>(null);
 		const updateFnRef = useRef<(() => void) | null>(null);
+
+		// The scroll handler below is installed once, so it resolves the
+		// neighbouring prompt's sentinel through a ref instead of the props it
+		// closed over at mount. Declared before that effect so the resolver is
+		// current whenever the handler runs.
+		const nextSentinelRef = useRef<() => HTMLDivElement | null>(() => null);
+		useLayoutEffect(() => {
+			nextSentinelRef.current = () =>
+				nextUserMessageId === undefined
+					? null
+					: (getSentinel?.(nextUserMessageId) ?? null);
+		}, [nextUserMessageId, getSentinel]);
 
 		// useLayoutEffect so isStuck and --clip-h are both resolved
 		// before the browser paints, avoiding a flash on load.
@@ -963,7 +962,7 @@ const StickyUserMessage = memo<{
 				// approaches the bottom of this sticky container, shift
 				// this container upward so it slides out of view — the
 				// same visual as the old section-boundary behavior.
-				const nextSentinel = findNextUserSentinel(sentinel);
+				const nextSentinel = nextSentinelRef.current();
 				if (nextSentinel) {
 					const nextY = nextSentinel.getBoundingClientRect().top - scrollerTop;
 					container.style.top = `${Math.min(STICKY_TOP, nextY - visible + STICKY_TOP)}px`;
@@ -1280,6 +1279,8 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 				block: "start",
 			});
 		};
+		const getSentinel = (messageId: number) =>
+			sentinelsRef.current.get(messageId) ?? null;
 
 		const displayMessages = buildDisplayMessages(parsedMessages);
 		const lastInChainFlags = computeLastInChainFlags(displayMessages);
@@ -1307,19 +1308,12 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 
 		// Ordered list of visible user message IDs, used to drive the
 		// per-bubble prev/next arrow buttons that jump the transcript
-		// to the neighbouring user prompt.
-		const visibleUserMessageIds: number[] = [];
-		for (const { message, parsed } of parsedMessages) {
-			if (message.role !== "user") continue;
-			const { shouldHide } = deriveMessageDisplayState({
-				message,
-				parsed,
-				hideActions: false,
-				hasActiveStream: false,
-				isAwaitingFirstStreamChunk: false,
-			});
-			if (!shouldHide) visibleUserMessageIds.push(message.id);
-		}
+		// to the neighbouring user prompt, and to resolve the next
+		// prompt's sentinel while a prompt is pinned. Turns already hold
+		// exactly the prompts that render, in order.
+		const visibleUserMessageIds = turns.flatMap((turn) =>
+			turn.prompt ? [turn.prompt.entry.message.id] : [],
+		);
 		const userNeighborsById = new Map<
 			number,
 			{ prevId?: number; nextId?: number }
@@ -1398,6 +1392,7 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 									}
 									onJumpToUserMessage={jumpToUserMessage}
 									registerSentinel={registerSentinel}
+									getSentinel={getSentinel}
 									urlTransform={urlTransform}
 								/>
 							)}

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -820,6 +820,21 @@ const ChatMessageItem = memo<{
 	},
 );
 
+// Each turn renders its prompt's sentinel as the first element of the turn
+// section, so the next prompt's sentinel is the first element of a following
+// section rather than a later sibling of this one.
+const findNextUserSentinel = (sentinel: Element): Element | null => {
+	let turn = sentinel.parentElement?.nextElementSibling ?? null;
+	while (turn) {
+		const candidate = turn.firstElementChild;
+		if (candidate?.hasAttribute("data-user-sentinel")) {
+			return candidate;
+		}
+		turn = turn.nextElementSibling;
+	}
+	return null;
+};
+
 const StickyUserMessage = memo<{
 	message: TypesGen.ChatMessage;
 	parsed: ParsedMessageContent;
@@ -948,13 +963,7 @@ const StickyUserMessage = memo<{
 				// approaches the bottom of this sticky container, shift
 				// this container upward so it slides out of view — the
 				// same visual as the old section-boundary behavior.
-				let nextSentinel: Element | null = sentinel.nextElementSibling;
-				while (nextSentinel) {
-					if (nextSentinel.hasAttribute("data-user-sentinel")) {
-						break;
-					}
-					nextSentinel = nextSentinel.nextElementSibling;
-				}
+				const nextSentinel = findNextUserSentinel(sentinel);
 				if (nextSentinel) {
 					const nextY = nextSentinel.getBoundingClientRect().top - scrollerTop;
 					container.style.top = `${Math.min(STICKY_TOP, nextY - visible + STICKY_TOP)}px`;
@@ -1167,6 +1176,60 @@ function computeLastInChainFlags(
 	return flags;
 }
 
+type TimelineTurnEntry = {
+	entry: ParsedMessageEntry;
+	index: number;
+};
+
+type TimelineTurn = {
+	key: string;
+	prompt?: TimelineTurnEntry;
+	items: TimelineTurnEntry[];
+};
+
+const LEADING_TURN_KEY = "turn-leading";
+
+// A turn is one visible user prompt plus every message that follows it up to
+// the next visible prompt. Hidden user messages carry context metadata only, so
+// they never open a turn and the messages after them stay with the preceding
+// prompt. A transcript page can start with assistant replies whose prompt lives
+// on an older page that has not been fetched; those replies form a leading turn
+// with no prompt and join the prompt's turn once that page arrives.
+function groupDisplayMessagesIntoTurns(
+	displayMessages: readonly ParsedMessageEntry[],
+): TimelineTurn[] {
+	const turns: TimelineTurn[] = [];
+	let currentTurn: TimelineTurn | undefined;
+	for (let index = 0; index < displayMessages.length; index++) {
+		const entry = displayMessages[index];
+		if (entry.message.role === "user") {
+			const { shouldHide } = deriveMessageDisplayState({
+				message: entry.message,
+				parsed: entry.parsed,
+				hideActions: false,
+				hasActiveStream: false,
+				isAwaitingFirstStreamChunk: false,
+			});
+			if (shouldHide) {
+				continue;
+			}
+			currentTurn = {
+				key: `turn-${entry.message.id}`,
+				prompt: { entry, index },
+				items: [],
+			};
+			turns.push(currentTurn);
+			continue;
+		}
+		if (!currentTurn) {
+			currentTurn = { key: LEADING_TURN_KEY, items: [] };
+			turns.push(currentTurn);
+		}
+		currentTurn.items.push({ entry, index });
+	}
+	return turns;
+}
+
 interface ConversationTimelineProps {
 	parsedMessages: readonly ParsedMessageEntry[];
 	subagentTitles: Map<string, string>;
@@ -1220,6 +1283,7 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 
 		const displayMessages = buildDisplayMessages(parsedMessages);
 		const lastInChainFlags = computeLastInChainFlags(displayMessages);
+		const turns = groupDisplayMessagesIntoTurns(displayMessages);
 
 		if (parsedMessages.length === 0) {
 			return null;
@@ -1311,66 +1375,68 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 					data-testid="conversation-timeline"
 					className="flex flex-col gap-2"
 				>
-					{displayMessages.map(({ message, parsed }, msgIdx) => {
-						if (message.role === "user") {
-							const { shouldHide } = deriveMessageDisplayState({
-								message,
-								parsed,
-								hideActions: false,
-								hasActiveStream: false,
-								isAwaitingFirstStreamChunk: false,
-							});
-							if (shouldHide) {
-								return null;
-							}
-							return (
+					{turns.map((turn) => (
+						// `display: contents` keeps the turn wrapper out of layout, so
+						// grouping leaves both the spacing between messages and the
+						// containing block that `position: sticky` resolves against
+						// unchanged.
+						<section key={turn.key} className="contents" data-chat-turn>
+							{turn.prompt && (
 								<StickyUserMessage
-									key={message.id}
-									message={message}
-									parsed={parsed}
+									message={turn.prompt.entry.message}
+									parsed={turn.prompt.entry.parsed}
 									onEditUserMessage={onEditUserMessage}
 									editingMessageId={editingMessageId}
-									isAfterEditingMessage={afterEditingMessageIds.has(message.id)}
-									prevUserMessageId={userNeighborsById.get(message.id)?.prevId}
-									nextUserMessageId={userNeighborsById.get(message.id)?.nextId}
+									isAfterEditingMessage={afterEditingMessageIds.has(
+										turn.prompt.entry.message.id,
+									)}
+									prevUserMessageId={
+										userNeighborsById.get(turn.prompt.entry.message.id)?.prevId
+									}
+									nextUserMessageId={
+										userNeighborsById.get(turn.prompt.entry.message.id)?.nextId
+									}
 									onJumpToUserMessage={jumpToUserMessage}
 									registerSentinel={registerSentinel}
 									urlTransform={urlTransform}
 								/>
-							);
-						}
-						// Hide actions on assistant messages that are not the
-						// last in a consecutive assistant chain. Flags are
-						// precomputed in a single reverse pass above.
-						const isLastInChain = lastInChainFlags[msgIdx];
-						return (
-							<ChatMessageItem
-								key={message.id}
-								message={message}
-								parsed={parsed}
-								onImplementPlan={onImplementPlan}
-								onSendAskUserQuestionResponse={onSendAskUserQuestionResponse}
-								isChatCompleted={isChatCompleted}
-								latestAskUserQuestionToolId={latestAskUserQuestionToolId}
-								askUserQuestionResponseTextByToolId={
-									historicalAskUserQuestionResponseTextByToolId
-								}
-								hasUserResponseAfterAskQuestion={
-									hasUserResponseAfterAskQuestion
-								}
-								urlTransform={urlTransform}
-								isAfterEditingMessage={afterEditingMessageIds.has(message.id)}
-								hideActions={!isLastInChain}
-								hasActiveStream={Boolean(hasActiveStream)}
-								isAwaitingFirstStreamChunk={Boolean(isAwaitingFirstStreamChunk)}
-								isLastMessage={msgIdx === displayMessages.length - 1}
-								mcpServers={mcpServers}
-								subagentTitles={subagentTitles}
-								subagentVariants={subagentVariants}
-								showDesktopPreviews={showDesktopPreviews}
-							/>
-						);
-					})}
+							)}
+							{turn.items.map(({ entry, index }) => (
+								<ChatMessageItem
+									key={entry.message.id}
+									message={entry.message}
+									parsed={entry.parsed}
+									onImplementPlan={onImplementPlan}
+									onSendAskUserQuestionResponse={onSendAskUserQuestionResponse}
+									isChatCompleted={isChatCompleted}
+									latestAskUserQuestionToolId={latestAskUserQuestionToolId}
+									askUserQuestionResponseTextByToolId={
+										historicalAskUserQuestionResponseTextByToolId
+									}
+									hasUserResponseAfterAskQuestion={
+										hasUserResponseAfterAskQuestion
+									}
+									urlTransform={urlTransform}
+									isAfterEditingMessage={afterEditingMessageIds.has(
+										entry.message.id,
+									)}
+									// Hide actions on assistant messages that are not the
+									// last in a consecutive assistant chain. Flags are
+									// precomputed in a single reverse pass above.
+									hideActions={!lastInChainFlags[index]}
+									hasActiveStream={Boolean(hasActiveStream)}
+									isAwaitingFirstStreamChunk={Boolean(
+										isAwaitingFirstStreamChunk,
+									)}
+									isLastMessage={index === displayMessages.length - 1}
+									mcpServers={mcpServers}
+									subagentTitles={subagentTitles}
+									subagentVariants={subagentVariants}
+									showDesktopPreviews={showDesktopPreviews}
+								/>
+							))}
+						</section>
+					))}
 				</div>
 			</FileProbeProvider>
 		);

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -141,6 +141,14 @@ const ChatScrollContainer: FC<{
 				ref={setScrollContainer}
 				data-testid="scroll-container"
 				aria-busy={isFetchingMoreMessages || undefined}
+				// Scroll anchoring shifts the scroll offset when the node it
+				// anchored to is removed, and the timeline re-creates the
+				// messages of a turn once an older page supplies the prompt they
+				// belong to. The column-reverse layout already keeps the view
+				// stable while older content is prepended, so anchoring only
+				// contributes a jump. Safari implements no scroll anchoring, so
+				// disabling it also makes the three engines behave the same.
+				//
 				// `react-infinite-scroll-component` renders two wrapper divs
 				// between this scroller and the rendered messages. Force both
 				// out of the layout tree with `display: contents` so that
@@ -149,7 +157,7 @@ const ChatScrollContainer: FC<{
 				// `overflow: auto` baked in by the library), and (b) the
 				// column-reverse inverse layout places the library's
 				// load-more sentinel at the visual top of the content stack.
-				className="flex min-h-0 flex-1 flex-col-reverse overflow-y-auto [&>[class$=outerdiv]]:contents [scrollbar-gutter:stable] [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]"
+				className="flex min-h-0 flex-1 flex-col-reverse overflow-y-auto [overflow-anchor:none] [&>[class$=outerdiv]]:contents [scrollbar-gutter:stable] [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]"
 			>
 				<div aria-hidden className="flex-1 basis-0" />
 				<InfiniteScroll


### PR DESCRIPTION
The chat transcript is a flat list of messages, so the sticky user prompt hand-computes its own pin offset and push-out by walking sibling DOM nodes and measuring geometry on every scroll frame. A DevTools trace of a 151-prompt chat shows that loop is 902 forced layouts and 6.7s of the 12s recording, because each of the 151 instances interleaves layout reads with layout-affecting style writes in the same animation frame.

This PR only changes the structure that makes that possible to fix: each turn (one visible prompt plus every message up to the next visible prompt) now renders as a `<section>`. Once sections are real containing blocks, `position: sticky` produces pinning and push-out natively and the measurement loop can be deleted. That deletion is the follow-up PR; the measurement loop itself is unchanged here.

One thing inside `StickyUserMessage` did have to change. The push-out needs the next prompt's sentinel, and it located that element by walking sibling DOM nodes, which grouping invalidates. Rather than teach the walk about sections, it now resolves the element from the sentinel registry the timeline already maintains, keyed by the neighbour id it is already passed for the jump arrows. The ordered prompt ids come from the turns themselves, so the neighbour map and the rendered prompts share one derivation instead of two filters that have to agree.

Sections are `display: contents` so this lands as a no-op. A real layout box shifts the `gap-2` rhythm and interacts with the existing `-mt-2`, which moves pixels; converting to real boxes belongs with the behavior change.

Verified layout-neutral rather than assumed: 17 scroll offsets captured before and after, including a cluster straddling a turn boundary mid-push-out and a too-tall prompt, all at 0 differing pixels. Per-frame instrumentation over a scripted 40 step scroll is byte-identical in both directions (38.65 `getBoundingClientRect`, 15.3 `offsetHeight`, 15.3 `clientHeight`, 30.6 `setProperty`, 8.75 layouts per step). Node count grows by exactly one per turn, the `<section>` itself. The push-out was checked separately by recomputing its formula from the DOM every 10px of scroll across four stories: 14,573 samples where push-out must be active, zero where the neighbour failed to resolve, and inline `top` identical to the sub-pixel at every offset.

One deliberate behavior change beyond grouping: `overflow-anchor: none` on the chat scroller. When an older page supplies the prompt for replies already rendered, those replies re-parent into the prompt's turn and React re-creates the nodes. Chrome's scroll anchoring compensated for the lost anchor and jumped the transcript 73px. The `column-reverse` layout already keeps the view stable while older content is prepended, and Safari implements no scroll anchoring, so disabling it aligns the three engines. Caught by the new `OrphanLeadingTurnMergesWhenOlderPageArrives` story.

`ScrollToBottomButtonWorksWithInverseScroll` needed `{ timeout: 3000 }`. Rendering the long conversation blocks the main thread past `waitFor`'s default 1000ms budget, so its first callback did not run until 1072ms and the 200ms opacity transition could not advance. Reproduced on `659fb48a1d` without this change.

<details>
<summary>Design decisions and follow-up scope</summary>

Investigation established what a replacement must preserve and which mechanisms can express it. Summarised here so the follow-up PR has the same contract.

**Behavior contract.** Pin at 8px from the scroller top; sticky must resolve against the real scroller rather than an InfiniteScroll wrapper (#24937); push out at the turn boundary; compress 1:1 with scroll floored at 72px with no premature shrink and a 40px fade ramp (#23928); keep the layout box at full height while the visuals shrink; stay in sync while `scrollTop` stays 0 (#23577) by observing `[data-chat-scroll-content]` rather than the collapsing spacer (#26714); opt out of sticky entirely above 75% of the scroller height; no sticky gap for hidden metadata-only prompts (#25316); no first-paint flash; click-through below the clip line; exactly one copy in the accessibility tree (#27430); prev/next jump arrows and post-edit scroll.

**Rejected: scroll-driven CSS animations.** `animation-range: exit 0% / exit calc(100% - 72px)` reproduces the compression formula at 0.00px error, but a `position: sticky` subject never exits the scrollport so its own view timeline is frozen at progress 0; the hidden-sizer workaround reintroduces a duplicate subtree; and both `view()` and `scroll()` timelines are wrong by 97px inside a `column-reverse` scroller in Chromium 140. Independently, the feature is above the `browserslist` floor of chrome 110 / firefox 111 / safari 16.

**Rejected: CSS-only too-tall opt-out.** The 75% rule compares a descendant's intrinsic block size against an ancestor's. Size container queries would impose size containment on the scroller, and CSS cannot query a descendant's intrinsic height. A shared `ResizeObserver` is the minimum, and it runs after layout and before paint, so the flag is applied before any frame can show the wrong state. `observe()` must be called from a layout effect; a passive effect produces a real one-frame flash.

**Rejected: `clip-path` for the compression.** It clips paint only, so the sticky box keeps full height and native sticky pushes out on the full height. Measured 80px of scroll too early on a test header, which extrapolates to roughly 204px at the real 276px headers. The follow-up keeps `max-height` on the bubble and adds a sibling spacer outside the sticky box, measured at 8px of the current timing.

**Follow-up PR scope.** Make the sections real containing blocks; delete the inline `top` write, the sentinel walk, `isStuck`, `isReady`, `--overlay-ready` and the non-compositable `will-change` hints; collapse the duplicate `ChatMessageItem` into one copy, which also removes the `aria-hidden`/`inert` pair; replace the 151 per-message observers and listeners with one coordinator per scroller that touches only the active turn; measure compression from the pin line rather than the scroller border edge, which today leaves a prompt already 8px clipped the moment it pins; convert jump and post-edit scrolling to `scrollIntoView` plus `scroll-margin-top`. Projected per frame at 151 prompts: 76.9 forced layouts to 0.03, and 440.7 rect reads to 1.95.

**Needs manual verification on Safari and Firefox before the follow-up merges.** Section-bounded sticky inside the two `display: contents` wrappers in a `column-reverse` scroller; push-out timing at a turn boundary; the `backdrop-filter` fade layer on Safari; `ResizeObserver`-before-paint ordering outside Chromium; `scrollIntoView` with smooth behavior in a reversed scroller; keyboard focus order with a single copy.

</details>

---

Generated with Coder Agents on behalf of @DanielleMaywood.
