### PR TITLE
fix: add warn log level to unpriced models message

### DIFF
--- a/coderd/aibridgedserver/cost.go
+++ b/coderd/aibridgedserver/cost.go
@@ -71,7 +71,7 @@ func (s *Server) resolveTokenUsageCost(ctx context.Context, intc database.AIBrid
 	switch {
 	case errors.Is(err, sql.ErrNoRows):
 		// Model not in the price table: record tokens but leave cost NULL.
-		s.logger.Debug(ctx, "no price found for model, recording token usage with NULL cost",
+		s.logger.Warn(ctx, "no price found for model, recording token usage with NULL cost",
 			slog.F("provider", intc.Provider), slog.F("model", intc.Model))
 		if s.metrics != nil {
 			s.metrics.UnpricedTokenUsageRecords.WithLabelValues(intc.Provider, intc.Model).Inc()


### PR DESCRIPTION
 When a model is missing from the price table, token usage is still recorded but with a NULL cost, so AI spend for that model goes unattributed. This was logged at debug level, which means it is invisible in a default deployment.                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                                   
Log it at warn level instead so admins can see which provider/model pairs need a price row and act on it.  