### PR TITLE
fix(site/src/pages/AgentsPage/components/ChatElements/tools): delete unreachable WaitForExternalAuth tool code

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
@@ -1,9 +1,7 @@
 import {
-	CheckIcon,
 	CircleAlertIcon,
 	ExternalLinkIcon,
 	LayersIcon,
-	LoaderIcon,
 	OctagonXIcon,
 } from "lucide-react";
 import type React from "react";
@@ -281,83 +279,5 @@ export const ExecuteAuthRequiredTool: React.FC<{
 				</ScrollArea>
 			)}
 		</div>
-	);
-};
-
-export const WaitForExternalAuthTool: React.FC<{
-	providerLabel: string;
-	status: ToolStatus;
-	authenticated: boolean;
-	timedOut: boolean;
-	isError: boolean;
-	errorMessage?: string;
-}> = ({
-	providerLabel,
-	status,
-	authenticated,
-	timedOut,
-	isError,
-	errorMessage,
-}) => {
-	const isRunning = status === "running";
-	let label = `Waiting for ${providerLabel} authentication...`;
-	let statusIcon: React.ReactNode = isRunning ? (
-		<LoaderIcon
-			aria-label="Authentication in progress"
-			role="img"
-			className="size-3.5 shrink-0 animate-spin text-content-link motion-reduce:animate-none"
-		/>
-	) : null;
-	if (isError) {
-		label =
-			errorMessage ||
-			`Failed while waiting for ${providerLabel} authentication`;
-		statusIcon = (
-			<OctagonXIcon
-				aria-label="Authentication failed"
-				role="img"
-				className="size-3.5 shrink-0 text-content-destructive"
-			/>
-		);
-	} else if (timedOut) {
-		label = `Timed out waiting for ${providerLabel} authentication`;
-		statusIcon = (
-			<CircleAlertIcon
-				aria-label="Authentication timed out"
-				role="img"
-				className="size-3.5 shrink-0 text-content-warning"
-			/>
-		);
-	} else if (authenticated && !isRunning) {
-		label = `Authenticated with ${providerLabel}`;
-		statusIcon = (
-			<CheckIcon
-				aria-label="Authentication completed"
-				role="img"
-				className="size-3.5 shrink-0 text-content-success"
-			/>
-		);
-	}
-
-	return (
-		<ToolCall.Root
-			className="w-full overflow-hidden rounded-md border border-solid border-border-default bg-surface-primary px-3 py-2"
-			status={status}
-			isError={isError}
-			errorMessage={
-				errorMessage ||
-				`Failed while waiting for ${providerLabel} authentication`
-			}
-			hasContent={false}
-		>
-			<ToolCall.HeaderLayout>
-				<ToolCall.HeaderButton className="min-w-0 flex-1 font-normal text-content-secondary">
-					<ToolCall.LeadingIcon>{statusIcon}</ToolCall.LeadingIcon>
-					<ToolCall.Label className="text-content-primary">
-						{label}
-					</ToolCall.Label>
-				</ToolCall.HeaderButton>
-			</ToolCall.HeaderLayout>
-		</ToolCall.Root>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -101,11 +101,6 @@ const allToolShowcaseItems: ToolShowcaseItem[] = [
 		result: { success: true },
 	},
 	{
-		name: "wait_for_external_auth",
-		args: { provider: "github" },
-		result: { provider_display_name: "GitHub", authenticated: true },
-	},
-	{
 		name: "read_file",
 		args: { path: "site/src/pages/AgentsPage/AgentChatPage.tsx" },
 		result: { content: "export const AgentChatPage = () => null;" },
@@ -598,68 +593,6 @@ export const ExecuteAuthRequired: Story = {
 			"width=900,height=600",
 		);
 		openSpy.mockRestore();
-	},
-};
-
-// ---------------------------------------------------------------------------
-// WaitForExternalAuth stories
-// ---------------------------------------------------------------------------
-
-export const WaitForExternalAuthRunning: Story = {
-	args: {
-		name: "wait_for_external_auth",
-		status: "running",
-		result: {
-			provider_display_name: "GitHub",
-			authenticated: false,
-		},
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(
-			canvas.getByText("Waiting for GitHub authentication..."),
-		).toBeInTheDocument();
-		expect(
-			canvas.getByRole("img", { name: "Authentication in progress" }),
-		).toBeVisible();
-	},
-};
-
-export const WaitForExternalAuthAuthenticated: Story = {
-	args: {
-		name: "wait_for_external_auth",
-		status: "completed",
-		result: {
-			provider_display_name: "GitHub",
-			authenticated: true,
-		},
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(canvas.getByText("Authenticated with GitHub")).toBeInTheDocument();
-	},
-};
-
-export const WaitForExternalAuthTimedOut: Story = {
-	args: {
-		name: "wait_for_external_auth",
-		status: "completed",
-		result: {
-			provider_display_name: "GitHub",
-			timed_out: true,
-		},
-	},
-};
-
-export const WaitForExternalAuthError: Story = {
-	args: {
-		name: "wait_for_external_auth",
-		status: "error",
-		isError: true,
-		result: {
-			provider_display_name: "GitHub",
-			error: "Authentication failed: token exchange was rejected.",
-		},
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -17,7 +17,6 @@ import { EditFilesTool } from "./EditFilesTool";
 import {
 	ExecuteAuthRequiredTool,
 	ExecuteTool as ExecuteToolComponent,
-	WaitForExternalAuthTool,
 } from "./ExecuteTool";
 import { ListAgentsTool } from "./ListAgentsTool";
 import { ListTemplatesTool } from "./ListTemplatesTool";
@@ -59,7 +58,6 @@ import {
 	parseServerEditDiffText,
 	parseServerEditResults,
 	type ToolStatus,
-	toProviderLabel,
 } from "./utils";
 
 import { WriteFileTool } from "./WriteFileTool";
@@ -281,33 +279,6 @@ const ProcessOutputRenderer: FC<ToolRendererProps> = ({
 			errorMessage={errorMessage || undefined}
 			killedBySignal={killedBySignal}
 			shellToolDisplayMode={shellToolDisplayMode}
-		/>
-	);
-};
-
-const WaitForExternalAuthRenderer: FC<ToolRendererProps> = ({
-	status,
-	result,
-	isError,
-}) => {
-	const rec = asRecord(result);
-	const providerLabel = toProviderLabel(
-		rec ? asString(rec.provider_display_name).trim() : "",
-		rec ? asString(rec.provider_id).trim() : "",
-		rec ? asString(rec.provider_type).trim() : "",
-	);
-	const authenticated = rec ? Boolean(rec.authenticated) : false;
-	const timedOut = rec ? Boolean(rec.timed_out) : false;
-	const errorMessage = rec ? asString(rec.error || rec.message) : "";
-
-	return (
-		<WaitForExternalAuthTool
-			providerLabel={providerLabel}
-			status={status}
-			authenticated={authenticated}
-			timedOut={timedOut}
-			isError={isError}
-			errorMessage={errorMessage || undefined}
 		/>
 	);
 };
@@ -1066,7 +1037,6 @@ const toolRenderers: Record<string, FC<ToolRendererProps>> = {
 	execute: ExecuteRenderer,
 	process_output: ProcessOutputRenderer,
 	process_signal: ProcessSignalRenderer,
-	wait_for_external_auth: WaitForExternalAuthRenderer,
 	read_file: ReadFileRenderer,
 	write_file: WriteFileRenderer,
 	edit_files: EditFilesRenderer,

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolIcon.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolIcon.tsx
@@ -5,7 +5,6 @@ import {
 	FilePenLineIcon,
 	FileTextIcon,
 	LightbulbIcon,
-	LogInIcon,
 	MonitorIcon,
 	PowerIcon,
 	RouteIcon,
@@ -80,8 +79,6 @@ export const ToolIcon: React.FC<{
 		case "process_list":
 		case "process_signal":
 			return <TerminalIcon className={base} />;
-		case "wait_for_external_auth":
-			return <LogInIcon className={base} />;
 		case "read_file":
 		case "read_skill":
 		case "read_skill_file":


### PR DESCRIPTION
The backend never emits a `wait_for_external_auth` tool call (no references in any Go source, the chatd tool registry, or anywhere outside the frontend), so the entire frontend rendering path for it was unreachable.

Removes the `WaitForExternalAuthTool` component, its renderer and `toolRenderers` entry, the `ToolIcon` case, and the four Storybook stories, along with the imports that only they used (`CheckIcon`, `LoaderIcon`, `LogInIcon`, and `toProviderLabel` in `Tool.tsx`).

Kept the separate, live `execute` auth-required flow: `ExecuteAuthRequiredTool` and the `toProviderLabel` usage in `toolVisibility.ts` belong to the `authenticateURL` path, not this dead tool.

Refs #27593

🤖 This pull request was created with Coder Agents.