### PR TITLE
fix(site/src/pages/AISettingsPage/SpendPage): announce cost controls move in v2.36

### DIFF
--- a/site/src/pages/AISettingsPage/SpendPage/SpendPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/SpendPage/SpendPageView.stories.tsx
@@ -302,7 +302,7 @@ export const SpendWithLimitsAndUsers: Story = {
 		await canvas.findByText("Spend limits and usage");
 		await expect(
 			canvas.getByText(
-				/Cost controls features will move to AI Governance in v2\.37\./,
+				/Cost controls features will move to AI Governance in v2\.36\./,
 			),
 		).toBeInTheDocument();
 		await expect(

--- a/site/src/pages/AISettingsPage/SpendPage/SpendPageView.tsx
+++ b/site/src/pages/AISettingsPage/SpendPage/SpendPageView.tsx
@@ -237,7 +237,7 @@ export const SpendPageView: FC<SpendPageViewProps> = ({
 						<div className="flex max-w-[1100px] flex-col gap-8">
 							<Alert severity="info">
 								<AlertDescription>
-									Cost controls features will move to AI Governance in v2.37.{" "}
+									Cost controls features will move to AI Governance in v2.36.{" "}
 									<Link
 										href={docs("/ai-coder/ai-gateway/cost-controls")}
 										target="_blank"


### PR DESCRIPTION
Corrects the version in the AI settings Spend banner: cost controls features move to AI Governance in **v2.36**, not v2.37.

Updates the banner copy in `SpendPageView` and the matching Storybook play assertion. No other changes.

The `release/2.36` backport is opened manually as #27690, so this PR does not carry the `cherry-pick` label.

> Mux, an AI agent, prepared this PR on Mike's behalf.
