### PR TITLE
fix: remove nodePort from required service fields of ai-gateway chart

### DIFF
--- a/helm/ai-gateway/values.schema.json
+++ b/helm/ai-gateway/values.schema.json
@@ -92,7 +92,7 @@
     },
     "service": {
       "type": "object", "additionalProperties": false,
-      "required": ["enable", "type", "port", "annotations", "sessionAffinity", "externalTrafficPolicy", "loadBalancerClass", "loadBalancerIP", "nodePort"],
+      "required": ["enable", "type", "port", "annotations", "sessionAffinity", "externalTrafficPolicy", "loadBalancerClass", "loadBalancerIP"],
       "properties": {
         "enable": {"type": "boolean"},
         "type": {"enum": ["ClusterIP", "NodePort", "LoadBalancer"]},


### PR DESCRIPTION
Updates schema for ai-gateway chart. Missing piece from https://github.com/coder/coder/pull/27682