### PR TITLE
feat(coderd/templatebuilder): support multiple coder_agent resources

### DIFF
--- a/coderd/templatebuilder/bases.go
+++ b/coderd/templatebuilder/bases.go
@@ -44,6 +44,22 @@ type BaseManifest struct {
 	OS             string             `json:"os"`
 	DefaultContext BaseDefaultContext `json:"default_context"`
 	Variables      []ModuleVariable   `json:"variables"`
+	// Agents describes the coder_agent resources declared by the base
+	// template. The Name of each entry must match a coder_agent resource
+	// name in main.tf. When a base declares more than one agent, callers
+	// choose which agent a module attaches to.
+	Agents []BaseAgent `json:"agents,omitempty"`
+}
+
+// BaseAgent is the on-disk metadata for one coder_agent resource in a
+// base template. Name must match the Terraform resource name.
+type BaseAgent struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name,omitempty"`
+	// Default marks the agent selected by default when a caller does not
+	// specify one. At most one agent may be default; if none is marked,
+	// the first declared agent is treated as the default.
+	Default bool `json:"default,omitempty"`
 }
 
 // BaseDefaultContext holds default render values stored in base.json.
@@ -162,7 +178,35 @@ func parseManifest(parent fs.FS, dirName string) (BaseManifest, error) {
 		return BaseManifest{}, xerrors.Errorf("base %q has unknown os %q", manifest.ID, manifest.OS)
 	}
 
+	if err := validateBaseAgents(manifest); err != nil {
+		return BaseManifest{}, err
+	}
+
 	return manifest, nil
+}
+
+// validateBaseAgents checks that a base manifest's declared agents have
+// unique, non-empty names and at most one default. Bases with no declared
+// agents are allowed for backward compatibility.
+func validateBaseAgents(manifest BaseManifest) error {
+	seen := make(map[string]bool, len(manifest.Agents))
+	defaults := 0
+	for _, a := range manifest.Agents {
+		if a.Name == "" {
+			return xerrors.Errorf("base %q has an agent with empty name", manifest.ID)
+		}
+		if seen[a.Name] {
+			return xerrors.Errorf("base %q has duplicate agent %q", manifest.ID, a.Name)
+		}
+		seen[a.Name] = true
+		if a.Default {
+			defaults++
+		}
+	}
+	if defaults > 1 {
+		return xerrors.Errorf("base %q declares more than one default agent", manifest.ID)
+	}
+	return nil
 }
 
 // parseTemplatesFromFS walks the filesystem and pre-parses all .tf.tmpl files
@@ -258,6 +302,32 @@ func BaseVariables(exampleID string) []ModuleVariable {
 		return nil
 	}
 	return bases[exampleID].Manifest.Variables
+}
+
+// BaseAgents returns the declared coder_agent resources for a base
+// template. Returns nil if the base is unknown or declares none.
+func BaseAgents(exampleID string) []BaseAgent {
+	bases, err := loadBases()
+	if err != nil || bases[exampleID] == nil {
+		return nil
+	}
+	return bases[exampleID].Manifest.Agents
+}
+
+// BaseDefaultAgent returns the name of the default agent for a base
+// template. When no agent is marked default, the first declared agent is
+// used. Returns an empty string if the base declares no agents.
+func BaseDefaultAgent(exampleID string) string {
+	agents := BaseAgents(exampleID)
+	if len(agents) == 0 {
+		return ""
+	}
+	for _, a := range agents {
+		if a.Default {
+			return a.Name
+		}
+	}
+	return agents[0].Name
 }
 
 // BaseTemplateFS returns a filesystem rooted at the given base template

--- a/coderd/templatebuilder/bases/aws-linux/base.json
+++ b/coderd/templatebuilder/bases/aws-linux/base.json
@@ -2,5 +2,6 @@
 	"id": "aws-linux",
 	"display_name": "AWS EC2 (Linux)",
 	"os": "linux",
+	"agents": [{ "name": "dev", "default": true }],
 	"default_context": {}
 }

--- a/coderd/templatebuilder/bases/aws-windows/base.json
+++ b/coderd/templatebuilder/bases/aws-windows/base.json
@@ -2,5 +2,6 @@
 	"id": "aws-windows",
 	"display_name": "AWS EC2 (Windows)",
 	"os": "windows",
+	"agents": [{ "name": "main", "default": true }],
 	"default_context": {}
 }

--- a/coderd/templatebuilder/bases/azure-linux/base.json
+++ b/coderd/templatebuilder/bases/azure-linux/base.json
@@ -2,5 +2,6 @@
 	"id": "azure-linux",
 	"display_name": "Azure VM (Linux)",
 	"os": "linux",
+	"agents": [{ "name": "main", "default": true }],
 	"default_context": {}
 }

--- a/coderd/templatebuilder/bases/digitalocean-linux/base.json
+++ b/coderd/templatebuilder/bases/digitalocean-linux/base.json
@@ -2,6 +2,7 @@
 	"id": "digitalocean-linux",
 	"display_name": "DigitalOcean Droplet (Linux)",
 	"os": "linux",
+	"agents": [{ "name": "main", "default": true }],
 	"default_context": {},
 	"variables": [
 		{

--- a/coderd/templatebuilder/bases/docker/base.json
+++ b/coderd/templatebuilder/bases/docker/base.json
@@ -2,6 +2,7 @@
 	"id": "docker",
 	"display_name": "Docker",
 	"os": "linux",
+	"agents": [{ "name": "main", "default": true }],
 	"default_context": {
 		"container_image": "codercom/example-base:ubuntu"
 	},

--- a/coderd/templatebuilder/bases/gcp-linux/base.json
+++ b/coderd/templatebuilder/bases/gcp-linux/base.json
@@ -2,6 +2,7 @@
 	"id": "gcp-linux",
 	"display_name": "Google Compute Engine (Linux)",
 	"os": "linux",
+	"agents": [{ "name": "main", "default": true }],
 	"default_context": {},
 	"variables": [
 		{

--- a/coderd/templatebuilder/bases/gcp-windows/base.json
+++ b/coderd/templatebuilder/bases/gcp-windows/base.json
@@ -2,6 +2,7 @@
 	"id": "gcp-windows",
 	"display_name": "Google Compute Engine (Windows)",
 	"os": "windows",
+	"agents": [{ "name": "main", "default": true }],
 	"default_context": {},
 	"variables": [
 		{

--- a/coderd/templatebuilder/bases/kubernetes/base.json
+++ b/coderd/templatebuilder/bases/kubernetes/base.json
@@ -2,6 +2,7 @@
 	"id": "kubernetes",
 	"display_name": "Kubernetes",
 	"os": "linux",
+	"agents": [{ "name": "main", "default": true }],
 	"default_context": {
 		"container_image": "codercom/example-base:ubuntu"
 	},

--- a/coderd/templatebuilder/bases/scratch/base.json
+++ b/coderd/templatebuilder/bases/scratch/base.json
@@ -2,5 +2,6 @@
 	"id": "scratch",
 	"display_name": "Scratch",
 	"os": "linux",
+	"agents": [{ "name": "main", "default": true }],
 	"default_context": {}
 }

--- a/coderd/templatebuilder/bases_internal_test.go
+++ b/coderd/templatebuilder/bases_internal_test.go
@@ -271,4 +271,87 @@ func TestParseBasesFromFS(t *testing.T) {
 		require.Equal(t, "windows", bases["winbox"].Manifest.OS)
 		require.Equal(t, BaseOSWindows, validBaseOS[bases["winbox"].Manifest.OS])
 	})
+
+	t.Run("ParsesAgents", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{
+			"bases/multi/base.json": &fstest.MapFile{
+				Data: []byte(`{"id": "multi", "os": "linux", "agents": [{"name": "main"}, {"name": "dev", "default": true}]}`),
+			},
+			"bases/multi/main.tf.tmpl": &fstest.MapFile{
+				Data: []byte(`resource "coder_agent" "main" {}`),
+			},
+			"bases/multi/README.md": &fstest.MapFile{
+				Data: []byte("# Multi\n"),
+			},
+		}
+
+		bases, err := parseBasesFromFS(fsys)
+		require.NoError(t, err)
+		agents := bases["multi"].Manifest.Agents
+		require.Len(t, agents, 2)
+		require.Equal(t, "main", agents[0].Name)
+		require.Equal(t, "dev", agents[1].Name)
+		require.True(t, agents[1].Default)
+	})
+
+	t.Run("RejectsEmptyAgentName", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{
+			"bases/bad/base.json": &fstest.MapFile{
+				Data: []byte(`{"id": "bad", "os": "linux", "agents": [{"name": ""}]}`),
+			},
+			"bases/bad/README.md": &fstest.MapFile{
+				Data: []byte("# Bad\n"),
+			},
+		}
+
+		_, err := parseBasesFromFS(fsys)
+		require.ErrorContains(t, err, "empty name")
+	})
+
+	t.Run("RejectsDuplicateAgent", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{
+			"bases/bad/base.json": &fstest.MapFile{
+				Data: []byte(`{"id": "bad", "os": "linux", "agents": [{"name": "main"}, {"name": "main"}]}`),
+			},
+			"bases/bad/README.md": &fstest.MapFile{
+				Data: []byte("# Bad\n"),
+			},
+		}
+
+		_, err := parseBasesFromFS(fsys)
+		require.ErrorContains(t, err, "duplicate agent")
+	})
+
+	t.Run("RejectsMultipleDefaultAgents", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{
+			"bases/bad/base.json": &fstest.MapFile{
+				Data: []byte(`{"id": "bad", "os": "linux", "agents": [{"name": "main", "default": true}, {"name": "dev", "default": true}]}`),
+			},
+			"bases/bad/README.md": &fstest.MapFile{
+				Data: []byte("# Bad\n"),
+			},
+		}
+
+		_, err := parseBasesFromFS(fsys)
+		require.ErrorContains(t, err, "more than one default agent")
+	})
+}
+
+func TestBaseDefaultAgent(t *testing.T) {
+	t.Parallel()
+
+	// docker declares a single "main" agent marked default.
+	require.Equal(t, "main", BaseDefaultAgent("docker"))
+	// aws-linux's agent resource is named "dev".
+	require.Equal(t, "dev", BaseDefaultAgent("aws-linux"))
+	// Unknown bases resolve to no agent.
+	require.Equal(t, "", BaseDefaultAgent("nonexistent"))
 }

--- a/coderd/templatebuilder/compose.go
+++ b/coderd/templatebuilder/compose.go
@@ -31,6 +31,10 @@ type ComposeModule struct {
 	// Variables maps variable names to HCL literal values for
 	// non-sensitive, non-computed variables.
 	Variables map[string]string
+	// AgentName is the bare coder_agent resource name the module attaches
+	// to. When empty, the base template's default agent is used. This
+	// preserves behavior for single-agent bases and existing callers.
+	AgentName string
 }
 
 // ComposeResult holds the rendered Terraform files ready for bundling.
@@ -68,9 +72,21 @@ func Compose(req ComposeRequest) (*ComposeResult, error) {
 		}, nil
 	}
 
-	agentName, err := ExtractAgentResourceName(mainTF)
+	agents, err := ExtractAgentResourceNames(mainTF)
 	if err != nil {
-		return nil, xerrors.Errorf("extract agent name: %w", err)
+		return nil, xerrors.Errorf("extract agents: %w", err)
+	}
+	refByName := make(map[string]string, len(agents))
+	for _, a := range agents {
+		refByName[a.Name] = a.Reference
+	}
+
+	// Resolve the default agent from the base manifest, falling back to
+	// the first agent found in the rendered HCL when the manifest declares
+	// none (e.g. bases without agent metadata).
+	defaultAgent := BaseDefaultAgent(req.BaseTemplateID)
+	if defaultAgent == "" {
+		defaultAgent = agents[0].Name
 	}
 
 	catalog, err := loadCatalogMap()
@@ -83,7 +99,7 @@ func Compose(req ComposeRequest) (*ComposeResult, error) {
 		return nil, err
 	}
 
-	modulesTF, err := renderModules(req.Modules, catalog, req.RegistryURL, agentName)
+	modulesTF, err := renderModules(req.Modules, catalog, req.RegistryURL, refByName, defaultAgent)
 	if err != nil {
 		return nil, err
 	}
@@ -231,15 +247,28 @@ func validateModules(requested []ComposeModule, catalog map[string]ModuleManifes
 }
 
 // renderModules renders each module template and concatenates the
-// results with newline separators.
+// results with newline separators. Each module attaches to the agent
+// named by its AgentName, falling back to defaultAgent when empty.
+// refByName maps bare agent names to their HCL reference form.
 func renderModules(
 	requested []ComposeModule,
 	catalog map[string]ModuleManifest,
-	registryURL, agentName string,
+	registryURL string,
+	refByName map[string]string,
+	defaultAgent string,
 ) ([]byte, error) {
 	var buf bytes.Buffer
 	for _, cm := range requested {
 		manifest := catalog[cm.ID]
+
+		agentName := cm.AgentName
+		if agentName == "" {
+			agentName = defaultAgent
+		}
+		agentRef, ok := refByName[agentName]
+		if !ok {
+			return nil, xerrors.Errorf("module %q targets unknown agent %q", cm.ID, agentName)
+		}
 
 		modFS, err := ModuleTemplateFS(cm.ID)
 		if err != nil {
@@ -253,7 +282,7 @@ func renderModules(
 		modCtx := ModuleRenderContext{
 			RegistryBase:      registryURL,
 			PinnedVersion:     manifest.PinnedVersion,
-			AgentResourceName: agentName,
+			AgentResourceName: agentRef,
 			Variables:         vars,
 		}
 

--- a/coderd/templatebuilder/compose_test.go
+++ b/coderd/templatebuilder/compose_test.go
@@ -66,6 +66,34 @@ func TestCompose(t *testing.T) {
 		require.Contains(t, string(result.ModulesTF), `coder_agent.dev[0].id`)
 	})
 
+	t.Run("ModuleTargetsExplicitDefaultAgent", func(t *testing.T) {
+		t.Parallel()
+		// Explicitly naming the base's only agent is equivalent to
+		// leaving AgentName empty.
+		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
+			BaseTemplateID: "docker",
+			RegistryURL:    "https://registry.coder.com",
+			Modules: []templatebuilder.ComposeModule{
+				{ID: "code-server", AgentName: "main"},
+			},
+		})
+		require.NoError(t, err)
+		require.Contains(t, string(result.ModulesTF), `coder_agent.main.id`)
+	})
+
+	t.Run("ModuleTargetsUnknownAgent", func(t *testing.T) {
+		t.Parallel()
+		_, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
+			BaseTemplateID: "docker",
+			RegistryURL:    "https://registry.coder.com",
+			Modules: []templatebuilder.ComposeModule{
+				{ID: "code-server", AgentName: "nonexistent"},
+			},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `unknown agent "nonexistent"`)
+	})
+
 	t.Run("AWSLinuxExtraFiles", func(t *testing.T) {
 		t.Parallel()
 		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{

--- a/coderd/templatebuilder/render.go
+++ b/coderd/templatebuilder/render.go
@@ -3,9 +3,10 @@ package templatebuilder
 import (
 	"bytes"
 	"io/fs"
-	"regexp"
 	"text/template"
 
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
 	"golang.org/x/xerrors"
 )
 
@@ -99,40 +100,69 @@ func renderTemplate(fsys fs.FS, templatePath string, data any) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// agentResourcePattern matches `resource "coder_agent" "<name>"` in HCL.
-var agentResourcePattern = regexp.MustCompile(`resource\s+"coder_agent"\s+"(\w+)"`)
+// ExtractedAgent describes a coder_agent resource found in rendered HCL.
+type ExtractedAgent struct {
+	// Name is the bare Terraform resource name, e.g. "main" or "dev".
+	Name string
+	// Reference is the form used to reference the agent in HCL. When the
+	// agent uses count or for_each it includes an index suffix (e.g.
+	// "dev[0]") so that module templates can reference it as
+	// coder_agent.<Reference>.id.
+	Reference string
+}
 
-// agentCountPattern detects whether a coder_agent block uses count or
-// for_each, which means references to it require an index (e.g. [0]).
-var agentCountPattern = regexp.MustCompile(
-	`resource\s+"coder_agent"\s+"\w+"\s*\{[^}]*\b(?:count|for_each)\s*=`,
-)
+// ExtractAgentResourceNames finds every coder_agent resource declaration
+// in rendered HCL, in document order. When an agent uses count or
+// for_each its Reference includes an index suffix. Returns an error only
+// when the HCL cannot be parsed or declares no coder_agent resource. The
+// input is expected to be rendered output from our own curated base
+// templates, not arbitrary user HCL.
+func ExtractAgentResourceNames(hclSrc []byte) ([]ExtractedAgent, error) {
+	file, diags := hclwrite.ParseConfig(hclSrc, "main.tf", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, xerrors.Errorf("parse rendered template HCL: %s", diags.Error())
+	}
 
-// ExtractAgentResourceName finds the coder_agent resource declaration in
-// rendered HCL and returns the reference form to use in module templates.
-// When the agent uses count or for_each, the returned name includes an
-// index suffix (e.g. "dev[0]") so that module templates can reference it
-// as coder_agent.<name>.id. Returns an error unless exactly one
-// coder_agent resource is found; the builder only supports single-agent
-// templates. The input is expected to be rendered output from our own
-// curated base templates, not arbitrary user HCL.
-func ExtractAgentResourceName(hcl []byte) (string, error) {
-	matches := agentResourcePattern.FindAllSubmatch(hcl, -1)
-	switch len(matches) {
-	case 0:
-		return "", xerrors.New("no coder_agent resource found in rendered template")
-	case 1:
-		name := string(matches[0][1])
-		if agentCountPattern.Match(hcl) {
-			name += "[0]"
+	var agents []ExtractedAgent
+	for _, block := range file.Body().Blocks() {
+		if block.Type() != "resource" {
+			continue
 		}
-		return name, nil
-	default:
-		names := make([]string, 0, len(matches))
-		for _, m := range matches {
-			names = append(names, string(m[1]))
+		labels := block.Labels()
+		if len(labels) != 2 || labels[0] != "coder_agent" {
+			continue
+		}
+		name := labels[1]
+		ref := name
+		body := block.Body()
+		if body.GetAttribute("count") != nil || body.GetAttribute("for_each") != nil {
+			ref = name + "[0]"
+		}
+		agents = append(agents, ExtractedAgent{Name: name, Reference: ref})
+	}
+
+	if len(agents) == 0 {
+		return nil, xerrors.New("no coder_agent resource found in rendered template")
+	}
+	return agents, nil
+}
+
+// ExtractAgentResourceName returns the reference form of the single
+// coder_agent resource in rendered HCL. It errors unless exactly one
+// coder_agent is found. Prefer ExtractAgentResourceNames for templates
+// that may declare multiple agents.
+func ExtractAgentResourceName(hclSrc []byte) (string, error) {
+	agents, err := ExtractAgentResourceNames(hclSrc)
+	if err != nil {
+		return "", err
+	}
+	if len(agents) != 1 {
+		names := make([]string, 0, len(agents))
+		for _, a := range agents {
+			names = append(names, a.Name)
 		}
 		return "", xerrors.Errorf("expected exactly one coder_agent resource, found %d: %v",
-			len(matches), names)
+			len(agents), names)
 	}
+	return agents[0].Reference, nil
 }

--- a/coderd/templatebuilder/render_test.go
+++ b/coderd/templatebuilder/render_test.go
@@ -216,6 +216,94 @@ func TestRenderModuleTemplate(t *testing.T) {
 	})
 }
 
+func TestExtractAgentResourceNames(t *testing.T) {
+	t.Parallel()
+
+	t.Run("MultipleAgents", func(t *testing.T) {
+		t.Parallel()
+		hcl := []byte(`
+resource "coder_agent" "main" {
+  arch = "amd64"
+}
+resource "coder_agent" "dev" {
+  count = data.coder_workspace.me.start_count
+  arch  = "amd64"
+}
+`)
+		agents, err := templatebuilder.ExtractAgentResourceNames(hcl)
+		require.NoError(t, err)
+		require.Equal(t, []templatebuilder.ExtractedAgent{
+			{Name: "main", Reference: "main"},
+			{Name: "dev", Reference: "dev[0]"},
+		}, agents)
+	})
+
+	t.Run("PerBlockCountDetection", func(t *testing.T) {
+		t.Parallel()
+		// The counted agent must not cause the uncounted agent to gain an
+		// index suffix, and nested blocks must not confuse detection.
+		hcl := []byte(`
+resource "coder_agent" "first" {
+  count = 1
+  metadata {
+    key = "a"
+  }
+}
+resource "coder_agent" "second" {
+  metadata {
+    key = "b"
+  }
+}
+`)
+		agents, err := templatebuilder.ExtractAgentResourceNames(hcl)
+		require.NoError(t, err)
+		require.Equal(t, []templatebuilder.ExtractedAgent{
+			{Name: "first", Reference: "first[0]"},
+			{Name: "second", Reference: "second"},
+		}, agents)
+	})
+
+	t.Run("NoAgent", func(t *testing.T) {
+		t.Parallel()
+		_, err := templatebuilder.ExtractAgentResourceNames([]byte(`resource "docker_container" "workspace" {}`))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no coder_agent")
+	})
+}
+
+// TestBaseManifestAgentsMatchHCL guards against drift between the agents
+// declared in each base.json and the coder_agent resources actually
+// present in the rendered main.tf.
+func TestBaseManifestAgentsMatchHCL(t *testing.T) {
+	t.Parallel()
+
+	for _, id := range templatebuilder.BaseTemplateIDs() {
+		t.Run(id, func(t *testing.T) {
+			t.Parallel()
+			rendered, err := templatebuilder.RenderBaseTemplate(id, "main.tf.tmpl", testRenderContext(id))
+			require.NoError(t, err)
+
+			extracted, err := templatebuilder.ExtractAgentResourceNames(rendered)
+			require.NoError(t, err)
+
+			hclNames := make(map[string]bool, len(extracted))
+			for _, a := range extracted {
+				hclNames[a.Name] = true
+			}
+
+			manifestNames := make(map[string]bool)
+			for _, a := range templatebuilder.BaseAgents(id) {
+				manifestNames[a.Name] = true
+			}
+
+			require.Equal(t, hclNames, manifestNames,
+				"base %q agents in base.json must match coder_agent resources in main.tf", id)
+			require.NotEmpty(t, templatebuilder.BaseDefaultAgent(id),
+				"base %q must resolve a default agent", id)
+		})
+	}
+}
+
 func TestExtractAgentResourceName(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Part of [DEVEX-556](https://linear.app/codercom/issue/DEVEX-556/handle-multiple-coder-agent-resources-in-template-builder). **Phase 1 of 5** in a stacked series. Base branch: `main`.

## Summary

Removes the Template Builder's single-`coder_agent` assumption in the backend compose core. Bases can now declare multiple agents, and each composed module can target one of them, with an empty target falling back to the base default so existing single-agent bases and callers are unaffected.

## What changed

- `render.go`: added `ExtractedAgent{Name, Reference}` and `ExtractAgentResourceNames`, using `hclwrite.ParseConfig` to preserve document order and detect `count`/`for_each` per agent block (references like `dev[0]`). Kept singular `ExtractAgentResourceName` as a compatibility helper that errors unless exactly one agent exists.
- `bases.go`: added `BaseManifest.Agents []BaseAgent` (`{Name, DisplayName, Default}`), structural validation (empty/duplicate names, multiple defaults), plus `BaseAgents` and `BaseDefaultAgent` accessors.
- Added a one-entry `agents` array to all nine existing `bases/*/base.json` files (`aws-linux` uses `dev`, others `main`).
- `compose.go`: added `ComposeModule.AgentName`; resolves each module's target (empty -> base default/first agent, unknown -> validation error) and renders each module with its resolved agent reference.

## Testing

- Plural extraction and per-block count detection (`render_test.go`).
- Manifest/HCL drift across curated bases; base manifest structural validation.
- Unknown and explicit per-module agent compose tests.
- Pre-commit hook passed.

<details>
<summary>Design &amp; plan context</summary>

Source of truth for a base's agents: `base.json` carries `agents` metadata (name, optional display name, default flag) while `main.tf.tmpl` stays the real Terraform source. `base.json` decoding uses `DisallowUnknownFields`, so the struct field is added before any manifest declares `agents`; every existing base gets a one-entry `agents` array.

Backend extraction returns every agent's reference form, detecting `count`/`for_each` per block and appending `[0]` only for those, erroring only when zero agents are found. `Compose` resolves each module's target: empty `AgentName` falls back to the base default (back-compat for single-agent bases and existing callers); a non-empty name must be a known agent, else a clear validation error is returned. `renderModules` sets each module's agent reference from its own resolved agent rather than a single shared value.

Backward compatibility: empty `agent_name` resolves to the base default agent, and single-agent bases behave exactly as before.

Validation scope (agreed): name-membership only for now (an agent's OS does not constrain which modules may target it). Devcontainer sub-agent targeting is out of scope: a `coder_devcontainer` yields a runtime sub-agent, not a second static `coder_agent` resource.
</details>

---

Generated by Coder Agents on behalf of @jeremyruppel.
