### PR TITLE
feat(codersdk): expose template builder agents and per-module agent

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -24844,6 +24844,13 @@ const docTemplate = `{
         "codersdk.TemplateBuilderBase": {
             "type": "object",
             "properties": {
+                "agents": {
+                    "description": "Agents lists the coder_agent resources the base declares.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.TemplateBuilderBaseAgent"
+                    }
+                },
                 "description": {
                     "type": "string"
                 },
@@ -24870,6 +24877,20 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.TemplateBuilderBaseAgent": {
+            "type": "object",
+            "properties": {
+                "default": {
+                    "type": "boolean"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
         "codersdk.TemplateBuilderBasesResponse": {
             "type": "object",
             "properties": {
@@ -24884,6 +24905,10 @@ const docTemplate = `{
         "codersdk.TemplateBuilderComposeModule": {
             "type": "object",
             "properties": {
+                "agent_name": {
+                    "description": "AgentName is the coder_agent resource the module attaches to. When\nempty, the base template's default agent is used.",
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -22807,6 +22807,13 @@
 		"codersdk.TemplateBuilderBase": {
 			"type": "object",
 			"properties": {
+				"agents": {
+					"description": "Agents lists the coder_agent resources the base declares.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.TemplateBuilderBaseAgent"
+					}
+				},
 				"description": {
 					"type": "string"
 				},
@@ -22833,6 +22840,20 @@
 				}
 			}
 		},
+		"codersdk.TemplateBuilderBaseAgent": {
+			"type": "object",
+			"properties": {
+				"default": {
+					"type": "boolean"
+				},
+				"display_name": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				}
+			}
+		},
 		"codersdk.TemplateBuilderBasesResponse": {
 			"type": "object",
 			"properties": {
@@ -22847,6 +22868,10 @@
 		"codersdk.TemplateBuilderComposeModule": {
 			"type": "object",
 			"properties": {
+				"agent_name": {
+					"description": "AgentName is the coder_agent resource the module attaches to. When\nempty, the base template's default agent is used.",
+					"type": "string"
+				},
 				"id": {
 					"type": "string"
 				},

--- a/coderd/templatebuilder_compose_test.go
+++ b/coderd/templatebuilder_compose_test.go
@@ -142,6 +142,45 @@ func TestTemplateBuilderCompose(t *testing.T) {
 		require.ErrorAs(t, err, &sdkErr)
 		require.Equal(t, http.StatusNotFound, sdkErr.StatusCode())
 	})
+
+	t.Run("ModuleAgentNameRoundTrip", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		tarData, err := client.TemplateBuilderCompose(ctx, codersdk.TemplateBuilderComposeRequest{
+			BaseTemplateID: "docker",
+			Modules: []codersdk.TemplateBuilderComposeModule{
+				{ID: "code-server", AgentName: "main"},
+			},
+		})
+		require.NoError(t, err)
+		files := extractTarFiles(t, tarData)
+		require.Contains(t, files["modules.tf"], `coder_agent.main.id`)
+	})
+
+	t.Run("ModuleUnknownAgentName", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		_, err := client.TemplateBuilderCompose(ctx, codersdk.TemplateBuilderComposeRequest{
+			BaseTemplateID: "docker",
+			Modules: []codersdk.TemplateBuilderComposeModule{
+				{ID: "code-server", AgentName: "nonexistent"},
+			},
+		})
+		require.Error(t, err)
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
+	})
 }
 
 func extractTarFiles(t *testing.T, data []byte) map[string]string {

--- a/coderd/templatebuilder_handler.go
+++ b/coderd/templatebuilder_handler.go
@@ -82,6 +82,7 @@ func (api *API) templateBuilderBases(rw http.ResponseWriter, r *http.Request) {
 			OS:            string(templatebuilder.BaseTemplateOS(id)),
 			Variables:     vars,
 			Prerequisites: templatebuilder.BasePrerequisites(id),
+			Agents:        baseAgentsToSDK(templatebuilder.BaseAgents(id)),
 		})
 	}
 
@@ -92,6 +93,19 @@ func (api *API) templateBuilderBases(rw http.ResponseWriter, r *http.Request) {
 	httpapi.Write(ctx, rw, http.StatusOK, codersdk.TemplateBuilderBasesResponse{
 		Bases: bases,
 	})
+}
+
+// baseAgentsToSDK converts base template agents to the SDK type.
+func baseAgentsToSDK(agents []templatebuilder.BaseAgent) []codersdk.TemplateBuilderBaseAgent {
+	out := make([]codersdk.TemplateBuilderBaseAgent, 0, len(agents))
+	for _, a := range agents {
+		out = append(out, codersdk.TemplateBuilderBaseAgent{
+			Name:        a.Name,
+			DisplayName: a.DisplayName,
+			Default:     a.Default,
+		})
+	}
+	return out
 }
 
 // baseVariablesToSDK converts base template variables to the SDK type,
@@ -203,6 +217,7 @@ func (api *API) templateBuilderCompose(rw http.ResponseWriter, r *http.Request) 
 		composeReq.Modules = append(composeReq.Modules, templatebuilder.ComposeModule{
 			ID:        m.ID,
 			Variables: m.Variables,
+			AgentName: m.AgentName,
 		})
 	}
 
@@ -313,6 +328,7 @@ func (api *API) templateBuilderCreateTemplate(rw http.ResponseWriter, r *http.Re
 		composeReq.Modules = append(composeReq.Modules, templatebuilder.ComposeModule{
 			ID:        m.ID,
 			Variables: m.Variables,
+			AgentName: m.AgentName,
 		})
 	}
 

--- a/coderd/templatebuilder_handler_test.go
+++ b/coderd/templatebuilder_handler_test.go
@@ -40,6 +40,7 @@ func TestTemplateBuilderBases(t *testing.T) {
 			expectedOS   string
 			expectedVars []string
 			hasVariables bool
+			defaultAgent string
 		}
 
 		specs := []baseSpec{
@@ -48,17 +49,20 @@ func TestTemplateBuilderBases(t *testing.T) {
 				expectedOS:   "linux",
 				hasVariables: true,
 				expectedVars: []string{"container_image"},
+				defaultAgent: "main",
 			},
 			{
 				id:           "kubernetes",
 				expectedOS:   "linux",
 				hasVariables: true,
 				expectedVars: []string{"container_image", "namespace", "use_kubeconfig"},
+				defaultAgent: "main",
 			},
 			{
 				id:           "aws-linux",
 				expectedOS:   "linux",
 				hasVariables: false,
+				defaultAgent: "dev",
 			},
 			{
 				id:           "aws-windows",
@@ -80,6 +84,18 @@ func TestTemplateBuilderBases(t *testing.T) {
 			require.NotEmpty(t, b.Icon, "base %q should have an icon", spec.id)
 			require.Equal(t, spec.expectedOS, b.OS, "base %q OS mismatch", spec.id)
 			require.NotNil(t, b.Variables, "base %q should have non-nil variables slice", spec.id)
+
+			if spec.defaultAgent != "" {
+				require.NotEmpty(t, b.Agents, "base %q should expose agents", spec.id)
+				var gotDefault string
+				for _, a := range b.Agents {
+					if a.Default {
+						gotDefault = a.Name
+					}
+				}
+				require.Equal(t, spec.defaultAgent, gotDefault,
+					"base %q default agent mismatch", spec.id)
+			}
 
 			if spec.hasVariables {
 				require.NotEmpty(t, b.Variables, "base %q should have variables", spec.id)

--- a/codersdk/templatebuilder.go
+++ b/codersdk/templatebuilder.go
@@ -49,6 +49,15 @@ type TemplateBuilderModulesResponse struct {
 	Modules []TemplateBuilderModule `json:"modules"`
 }
 
+// TemplateBuilderBaseAgent describes a coder_agent resource declared by a
+// base template. When a base declares more than one agent, callers choose
+// which agent a module attaches to via TemplateBuilderComposeModule.AgentName.
+type TemplateBuilderBaseAgent struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name,omitempty"`
+	Default     bool   `json:"default"`
+}
+
 // TemplateBuilderBase is the API response type for a base template
 // returned by GET /api/v2/templatebuilder/bases.
 type TemplateBuilderBase struct {
@@ -59,6 +68,8 @@ type TemplateBuilderBase struct {
 	OS            string                          `json:"os"`
 	Variables     []TemplateBuilderModuleVariable `json:"variables"`
 	Prerequisites string                          `json:"prerequisites"`
+	// Agents lists the coder_agent resources the base declares.
+	Agents []TemplateBuilderBaseAgent `json:"agents"`
 }
 
 // TemplateBuilderBasesResponse is the response body for listing template builder bases.
@@ -114,6 +125,9 @@ type TemplateBuilderComposeRequest struct {
 type TemplateBuilderComposeModule struct {
 	ID        string            `json:"id"`
 	Variables map[string]string `json:"variables,omitempty"`
+	// AgentName is the coder_agent resource the module attaches to. When
+	// empty, the base template's default agent is used.
+	AgentName string `json:"agent_name,omitempty"`
 }
 
 // TemplateBuilderCompose renders a base template with the selected

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -12560,6 +12560,13 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 
 ```json
 {
+  "agents": [
+    {
+      "default": true,
+      "display_name": "string",
+      "name": "string"
+    }
+  ],
   "description": "string",
   "icon": "string",
   "id": "string",
@@ -12583,15 +12590,34 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 
 ### Properties
 
-| Name            | Type                                                                                      | Required | Restrictions | Description |
-|-----------------|-------------------------------------------------------------------------------------------|----------|--------------|-------------|
-| `description`   | string                                                                                    | false    |              |             |
-| `icon`          | string                                                                                    | false    |              |             |
-| `id`            | string                                                                                    | false    |              |             |
-| `name`          | string                                                                                    | false    |              |             |
-| `os`            | string                                                                                    | false    |              |             |
-| `prerequisites` | string                                                                                    | false    |              |             |
-| `variables`     | array of [codersdk.TemplateBuilderModuleVariable](#codersdktemplatebuildermodulevariable) | false    |              |             |
+| Name            | Type                                                                                      | Required | Restrictions | Description                                               |
+|-----------------|-------------------------------------------------------------------------------------------|----------|--------------|-----------------------------------------------------------|
+| `agents`        | array of [codersdk.TemplateBuilderBaseAgent](#codersdktemplatebuilderbaseagent)           | false    |              | Agents lists the coder_agent resources the base declares. |
+| `description`   | string                                                                                    | false    |              |                                                           |
+| `icon`          | string                                                                                    | false    |              |                                                           |
+| `id`            | string                                                                                    | false    |              |                                                           |
+| `name`          | string                                                                                    | false    |              |                                                           |
+| `os`            | string                                                                                    | false    |              |                                                           |
+| `prerequisites` | string                                                                                    | false    |              |                                                           |
+| `variables`     | array of [codersdk.TemplateBuilderModuleVariable](#codersdktemplatebuildermodulevariable) | false    |              |                                                           |
+
+## codersdk.TemplateBuilderBaseAgent
+
+```json
+{
+  "default": true,
+  "display_name": "string",
+  "name": "string"
+}
+```
+
+### Properties
+
+| Name           | Type    | Required | Restrictions | Description |
+|----------------|---------|----------|--------------|-------------|
+| `default`      | boolean | false    |              |             |
+| `display_name` | string  | false    |              |             |
+| `name`         | string  | false    |              |             |
 
 ## codersdk.TemplateBuilderBasesResponse
 
@@ -12599,6 +12625,13 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 {
   "bases": [
     {
+      "agents": [
+        {
+          "default": true,
+          "display_name": "string",
+          "name": "string"
+        }
+      ],
       "description": "string",
       "icon": "string",
       "id": "string",
@@ -12632,6 +12665,7 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 
 ```json
 {
+  "agent_name": "string",
   "id": "string",
   "variables": {
     "property1": "string",
@@ -12642,11 +12676,12 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 
 ### Properties
 
-| Name               | Type   | Required | Restrictions | Description |
-|--------------------|--------|----------|--------------|-------------|
-| `id`               | string | false    |              |             |
-| `variables`        | object | false    |              |             |
-| » `[any property]` | string | false    |              |             |
+| Name               | Type   | Required | Restrictions | Description                                                                                                           |
+|--------------------|--------|----------|--------------|-----------------------------------------------------------------------------------------------------------------------|
+| `agent_name`       | string | false    |              | Agent name is the coder_agent resource the module attaches to. When empty, the base template's default agent is used. |
+| `id`               | string | false    |              |                                                                                                                       |
+| `variables`        | object | false    |              |                                                                                                                       |
+| » `[any property]` | string | false    |              |                                                                                                                       |
 
 ## codersdk.TemplateBuilderComposeRequest
 
@@ -12659,6 +12694,7 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
   },
   "modules": [
     {
+      "agent_name": "string",
       "id": "string",
       "variables": {
         "property1": "string",
@@ -12708,6 +12744,7 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
   "icon": "string",
   "modules": [
     {
+      "agent_name": "string",
       "id": "string",
       "variables": {
         "property1": "string",

--- a/docs/reference/api/templatebuilder.md
+++ b/docs/reference/api/templatebuilder.md
@@ -21,6 +21,13 @@ curl -X GET http://coder-server:8080/api/v2/templatebuilder/bases \
 {
   "bases": [
     {
+      "agents": [
+        {
+          "default": true,
+          "display_name": "string",
+          "name": "string"
+        }
+      ],
       "description": "string",
       "icon": "string",
       "id": "string",
@@ -76,6 +83,7 @@ curl -X POST http://coder-server:8080/api/v2/templatebuilder/compose \
   },
   "modules": [
     {
+      "agent_name": "string",
       "id": "string",
       "variables": {
         "property1": "string",
@@ -128,6 +136,7 @@ curl -X POST http://coder-server:8080/api/v2/templatebuilder/compose/template \
   "icon": "string",
   "modules": [
     {
+      "agent_name": "string",
       "id": "string",
       "variables": {
         "property1": "string",

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -9062,6 +9062,22 @@ export interface TemplateBuilderBase {
 	readonly os: string;
 	readonly variables: readonly TemplateBuilderModuleVariable[];
 	readonly prerequisites: string;
+	/**
+	 * Agents lists the coder_agent resources the base declares.
+	 */
+	readonly agents: readonly TemplateBuilderBaseAgent[];
+}
+
+// From codersdk/templatebuilder.go
+/**
+ * TemplateBuilderBaseAgent describes a coder_agent resource declared by a
+ * base template. When a base declares more than one agent, callers choose
+ * which agent a module attaches to via TemplateBuilderComposeModule.AgentName.
+ */
+export interface TemplateBuilderBaseAgent {
+	readonly name: string;
+	readonly display_name?: string;
+	readonly default: boolean;
 }
 
 // From codersdk/templatebuilder.go
@@ -9080,6 +9096,11 @@ export interface TemplateBuilderBasesResponse {
 export interface TemplateBuilderComposeModule {
 	readonly id: string;
 	readonly variables?: Record<string, string>;
+	/**
+	 * AgentName is the coder_agent resource the module attaches to. When
+	 * empty, the base template's default agent is used.
+	 */
+	readonly agent_name?: string;
 }
 
 // From codersdk/templatebuilder.go

--- a/site/src/pages/TemplateBuilder/wizardState.test.ts
+++ b/site/src/pages/TemplateBuilder/wizardState.test.ts
@@ -565,6 +565,7 @@ describe("toSelectedBaseMeta", () => {
 		os: "linux",
 		variables: [],
 		prerequisites: "",
+		agents: [],
 		...overrides,
 	});
 


### PR DESCRIPTION
Part of [DEVEX-556](https://linear.app/codercom/issue/DEVEX-556/handle-multiple-coder-agent-resources-in-template-builder). **Phase 2 of 5** in a stacked series. Base branch: `jeremy/devex-556-1-backend`.

## Summary

Exposes the backend multi-agent support through the SDK and HTTP API: the bases endpoint returns each base's agents, and compose/create-template accept a per-module `agent_name`.

## What changed

- `codersdk/templatebuilder.go`: added `TemplateBuilderBaseAgent`, required `TemplateBuilderBase.Agents`, and optional `TemplateBuilderComposeModule.AgentName` (serialized as `agent_name`).
- `coderd/templatebuilder_handler.go`: added `baseAgentsToSDK`; the bases endpoint returns agents, and the compose and create-template endpoints forward `AgentName`.
- `make gen` regenerated `site/src/api/typesGenerated.ts`, `coderd/apidoc/docs.go`, `coderd/apidoc/swagger.json`, `docs/reference/api/schemas.md`, and `docs/reference/api/templatebuilder.md`.

## Testing

- Bases endpoint default-agent assertions.
- Per-module agent round-trip and unknown-agent response tests.
- Updated the `wizardState.test.ts` fixture to include the now-required `agents`.
- Pre-commit hook passed.

<details>
<summary>Design &amp; plan context</summary>

`TemplateBuilderBase` gains `Agents []TemplateBuilderBaseAgent` (`{name, display_name, default}`); `TemplateBuilderComposeModule` gains `AgentName` (`agent_name,omitempty`). Handler wiring populates `Agents` from `templatebuilder.BaseAgents(id)` and passes `m.AgentName` into `templatebuilder.ComposeModule` in both the compose and create-template paths. Generated types and swagger are refreshed via `make gen`.

This change adds in-memory manifest fields and request fields only (no DB schema change), so `enterprise/audit/table.go` is unaffected.
</details>

---

Generated by Coder Agents on behalf of @jeremyruppel.
