### PR TITLE
feat(site/src/pages/TemplateBuilder): per-module agent selection state

### DIFF
--- a/site/src/pages/TemplateBuilder/steps.test.ts
+++ b/site/src/pages/TemplateBuilder/steps.test.ts
@@ -37,6 +37,8 @@ describe("shouldSkip", () => {
 				name: "Docker",
 				hasParameters: false,
 				hasPrerequisites: false,
+				agents: [],
+				hasMultipleAgents: false,
 			},
 		});
 		expect(stepById("base-parameters").shouldSkip(noParams)).toBe(true);
@@ -49,6 +51,8 @@ describe("shouldSkip", () => {
 				name: "AWS Linux",
 				hasParameters: true,
 				hasPrerequisites: false,
+				agents: [],
+				hasMultipleAgents: false,
 			},
 		});
 		expect(stepById("base-parameters").shouldSkip(withParams)).toBe(false);
@@ -112,6 +116,32 @@ describe("stepModuleSettingsRequired", () => {
 		expect(stepModuleSettingsRequired(initialWizardState)).toBe(false);
 	});
 
+	it("returns true for a multi-agent base with modules but no configurable vars", () => {
+		const state = stateWith({
+			selectedBase: {
+				id: "docker-multi-agent",
+				name: "Docker (Multiple Agents)",
+				hasParameters: false,
+				hasPrerequisites: false,
+				agents: [
+					{ name: "main", displayName: "Primary", default: true },
+					{ name: "dev", displayName: "Dev", default: false },
+				],
+				hasMultipleAgents: true,
+			},
+			modules: [{ id: "npm-config" }],
+			selectedModules: [
+				{
+					id: "npm-config",
+					name: "npm-config",
+					iconUrl: "/npm.svg",
+					hasConfigurableVars: false,
+				},
+			],
+		});
+		expect(stepModuleSettingsRequired(state)).toBe(true);
+	});
+
 	it("returns true when at least one module has configurable vars", () => {
 		const state = stateWith({
 			selectedModules: [
@@ -141,6 +171,8 @@ describe("findNextVisibleIndex", () => {
 				name: "Docker",
 				hasParameters: false,
 				hasPrerequisites: false,
+				agents: [],
+				hasMultipleAgents: false,
 			},
 		});
 		// From base-infra (index 0), next visible should be module-select (index 2).
@@ -165,6 +197,8 @@ describe("findNextVisibleIndex", () => {
 				name: "AWS Linux",
 				hasParameters: true,
 				hasPrerequisites: false,
+				agents: [],
+				hasMultipleAgents: false,
 			},
 			selectedModules: [
 				{
@@ -192,6 +226,8 @@ describe("findPrevVisibleIndex", () => {
 				name: "Docker",
 				hasParameters: false,
 				hasPrerequisites: false,
+				agents: [],
+				hasMultipleAgents: false,
 			},
 		});
 		// From module-select (index 2), prev visible should be base-infra (index 0).
@@ -227,6 +263,8 @@ describe("nearestVisible", () => {
 				name: "Docker",
 				hasParameters: false,
 				hasPrerequisites: false,
+				agents: [],
+				hasMultipleAgents: false,
 			},
 		};
 		// Index 1 (base-parameters) is skipped, nearest backward is 0 (base-infra).
@@ -246,6 +284,8 @@ describe("furthestAllowedIndex", () => {
 				name: "Docker",
 				hasParameters: false,
 				hasPrerequisites: false,
+				agents: [],
+				hasMultipleAgents: false,
 			},
 		});
 		expect(furthestAllowedIndex(withBase)).toBe(WIZARD_STEPS.length - 1);

--- a/site/src/pages/TemplateBuilder/steps.ts
+++ b/site/src/pages/TemplateBuilder/steps.ts
@@ -16,12 +16,16 @@ type WizardStep = {
 };
 
 /**
- * Returns true when at least one selected module exposes variables that
- * need user configuration (non-sensitive).
+ * Returns true when the module settings step should be shown: either a
+ * selected module exposes configurable variables, or the base declares
+ * multiple agents (so each selected module needs an agent choice).
  */
 export const stepModuleSettingsRequired = (
 	state: TemplateBuilderWizardState,
 ): boolean => {
+	if (state.selectedBase?.hasMultipleAgents && state.modules.length > 0) {
+		return true;
+	}
 	return state.selectedModules.some((m) => m.hasConfigurableVars);
 };
 

--- a/site/src/pages/TemplateBuilder/wizardState.test.ts
+++ b/site/src/pages/TemplateBuilder/wizardState.test.ts
@@ -334,6 +334,76 @@ describe("wizardReducer", () => {
 		});
 	});
 
+	describe("SET_MODULE_AGENT", () => {
+		const multiAgentBase = {
+			id: "docker-multi-agent",
+			name: "Docker (Multiple Agents)",
+			hasParameters: false,
+			hasPrerequisites: false,
+			agents: [
+				{ name: "main", displayName: "Primary", default: true },
+				{ name: "dev", displayName: "Dev", default: false },
+			],
+			hasMultipleAgents: true,
+		};
+		const meta = (id: string) => ({
+			id,
+			name: id,
+			iconUrl: "/icon.svg",
+			hasConfigurableVars: false,
+		});
+
+		it("seeds newly added modules with the base default agent", () => {
+			const state = reduce([
+				{ type: "SET_BASE", base: multiAgentBase },
+				{
+					type: "SET_MODULES",
+					modules: [{ id: "code-server" }],
+					meta: [meta("code-server")],
+				},
+			]);
+			expect(state.modules[0].agent_name).toBe("main");
+		});
+
+		it("updates a module's agent and preserves it across re-selection", () => {
+			const state = reduce([
+				{ type: "SET_BASE", base: multiAgentBase },
+				{
+					type: "SET_MODULES",
+					modules: [{ id: "code-server" }],
+					meta: [meta("code-server")],
+				},
+				{
+					type: "SET_MODULE_AGENT",
+					moduleId: "code-server",
+					agentName: "dev",
+				},
+				{
+					type: "SET_MODULES",
+					modules: [{ id: "code-server" }, { id: "git-clone" }],
+					meta: [meta("code-server"), meta("git-clone")],
+				},
+			]);
+			expect(
+				state.modules.find((m) => m.id === "code-server")?.agent_name,
+			).toBe("dev");
+			expect(state.modules.find((m) => m.id === "git-clone")?.agent_name).toBe(
+				"main",
+			);
+		});
+
+		it("does not seed an agent for single-agent bases", () => {
+			const state = reduce([
+				{
+					type: "SET_MODULES",
+					modules: [{ id: "code-server" }],
+					meta: [meta("code-server")],
+				},
+			]);
+			expect(state.modules[0].agent_name).toBeUndefined();
+		});
+	});
+
 	describe("SET_CUSTOMIZATION", () => {
 		it("updates individual customization fields", () => {
 			const state = reduce([
@@ -576,6 +646,30 @@ describe("toSelectedBaseMeta", () => {
 		expect(meta.name).toBe("Docker Containers");
 		expect(meta.id).toBe("docker");
 	});
+
+	it("maps agents and flags multiple agents", () => {
+		const meta = toSelectedBaseMeta(
+			makeBase({
+				agents: [
+					{ name: "main", display_name: "Primary", default: true },
+					{ name: "dev", display_name: "", default: false },
+				],
+			}),
+		);
+		expect(meta.hasMultipleAgents).toBe(true);
+		expect(meta.agents).toEqual([
+			{ name: "main", displayName: "Primary", default: true },
+			// Falls back to the resource name when display_name is empty.
+			{ name: "dev", displayName: "dev", default: false },
+		]);
+	});
+
+	it("is not multi-agent for a single declared agent", () => {
+		const meta = toSelectedBaseMeta(
+			makeBase({ agents: [{ name: "main", display_name: "", default: true }] }),
+		);
+		expect(meta.hasMultipleAgents).toBe(false);
+	});
 });
 
 describe("baseCustomizationDefaults", () => {
@@ -587,6 +681,8 @@ describe("baseCustomizationDefaults", () => {
 			iconUrl: "/icon/aws.svg",
 			hasParameters: false,
 			hasPrerequisites: false,
+			agents: [],
+			hasMultipleAgents: false,
 		};
 		expect(baseCustomizationDefaults(base)).toEqual({
 			name: "aws-linux",
@@ -602,6 +698,8 @@ describe("baseCustomizationDefaults", () => {
 			name: "Scratch",
 			hasParameters: false,
 			hasPrerequisites: false,
+			agents: [],
+			hasMultipleAgents: false,
 		};
 		expect(baseCustomizationDefaults(base)).toEqual({
 			name: "scratch",
@@ -633,6 +731,8 @@ describe("initWizardState", () => {
 				iconUrl: "/icon/docker.png",
 				hasParameters: false,
 				hasPrerequisites: false,
+				agents: [],
+				hasMultipleAgents: false,
 			},
 		});
 		expect(state.baseTemplateId).toBe("docker");

--- a/site/src/pages/TemplateBuilder/wizardState.ts
+++ b/site/src/pages/TemplateBuilder/wizardState.ts
@@ -7,6 +7,15 @@ import type {
 } from "#/api/typesGenerated";
 
 /**
+ * UI-only metadata for a coder_agent declared by the selected base.
+ */
+type SelectedBaseAgent = {
+	name: string;
+	displayName: string;
+	default: boolean;
+};
+
+/**
  * UI-only metadata for the selected base template.
  * Kept separate from the API request payload.
  */
@@ -18,6 +27,9 @@ export type SelectedBaseMeta = {
 	os?: string;
 	hasParameters: boolean;
 	hasPrerequisites: boolean;
+	/** Agents the base declares. Length > 1 enables per-module selection. */
+	agents?: SelectedBaseAgent[];
+	hasMultipleAgents?: boolean;
 };
 
 /**
@@ -26,6 +38,11 @@ export type SelectedBaseMeta = {
 export function toSelectedBaseMeta(
 	base: TemplateBuilderBase,
 ): SelectedBaseMeta {
+	const agents = (base.agents ?? []).map((a) => ({
+		name: a.name,
+		displayName: a.display_name || a.name,
+		default: a.default,
+	}));
 	return {
 		id: base.id,
 		name: base.name,
@@ -35,7 +52,21 @@ export function toSelectedBaseMeta(
 		hasParameters:
 			base.variables?.length > 0 && base.variables?.some((v) => !v.sensitive),
 		hasPrerequisites: Boolean(base.prerequisites?.length),
+		agents,
+		hasMultipleAgents: agents.length > 1,
 	};
+}
+
+/**
+ * Returns the default agent name for a base: the agent flagged default,
+ * else the first declared agent, else an empty string.
+ */
+function baseDefaultAgentName(base: SelectedBaseMeta | null): string {
+	const agents = base?.agents ?? [];
+	if (agents.length === 0) {
+		return "";
+	}
+	return (agents.find((a) => a.default) ?? agents[0]).name;
 }
 
 /**
@@ -143,6 +174,11 @@ export type WizardAction =
 			variables: Record<string, string>;
 	  }
 	| {
+			type: "SET_MODULE_AGENT";
+			moduleId: string;
+			agentName: string;
+	  }
+	| {
 			type: "SET_CUSTOMIZATION";
 			field: "organizationId" | "name" | "displayName" | "description" | "icon";
 			value: string;
@@ -179,12 +215,25 @@ export function wizardReducer(
 		case "SET_MODULES": {
 			// Preserve existing variable values for modules that remain selected.
 			const existingById = new Map(state.modules.map((m) => [m.id, m]));
+			// Multi-agent bases seed each newly added module with the default
+			// agent so the compose request always names a valid agent.
+			const defaultAgent = state.selectedBase?.hasMultipleAgents
+				? baseDefaultAgentName(state.selectedBase)
+				: "";
 			const merged = action.modules.map((incoming) => {
 				const existing = existingById.get(incoming.id);
+				let next = incoming;
 				if (existing?.variables && !incoming.variables) {
-					return { ...incoming, variables: existing.variables };
+					next = { ...next, variables: existing.variables };
 				}
-				return incoming;
+				// Preserve an existing agent choice; otherwise seed the base
+				// default for multi-agent bases.
+				const agentName =
+					next.agent_name ?? existing?.agent_name ?? defaultAgent;
+				if (agentName) {
+					next = { ...next, agent_name: agentName };
+				}
+				return next;
 			});
 			return {
 				...state,
@@ -197,6 +246,14 @@ export function wizardReducer(
 				...state,
 				modules: state.modules.map((m) =>
 					m.id === action.moduleId ? { ...m, variables: action.variables } : m,
+				),
+			};
+		}
+		case "SET_MODULE_AGENT": {
+			return {
+				...state,
+				modules: state.modules.map((m) =>
+					m.id === action.moduleId ? { ...m, agent_name: action.agentName } : m,
 				),
 			};
 		}


### PR DESCRIPTION
Part of [DEVEX-556](https://linear.app/codercom/issue/DEVEX-556/handle-multiple-coder-agent-resources-in-template-builder). **Phase 4 of 5** in a stacked series. Base branch: `jeremy/devex-556-3-base`.

## Summary

Adds the wizard state and step-flow plumbing for per-module agent selection. No visible radio UI yet (that is Phase 5); this phase makes the reducer carry agent choices and ensures the settings step appears for multi-agent bases.

## What changed

- `wizardState.ts`: added a file-private `SelectedBaseAgent`, optional `SelectedBaseMeta.agents`/`hasMultipleAgents`, and `toSelectedBaseMeta` mapping (falls back to the resource name when the display name is empty). Added `SET_MODULE_AGENT`. `SET_MODULES` seeds newly added modules with the base default agent for multi-agent bases and preserves existing variables and agent choices; single-agent bases get no `agent_name`.
- `steps.ts`: `stepModuleSettingsRequired` also returns true when a multi-agent base has selected modules, so the per-module selector has a home even when modules expose no configurable variables.

## Testing

- `wizardState.test.ts`: mapping, default seeding, update/preservation, single-agent behavior.
- `steps.test.ts`: multi-agent modules with no configurable vars still require settings.
- 56 tests across both files; `make lint/ts` passed; pre-commit hook passed.

<details>
<summary>Design &amp; plan context</summary>

`SelectedBaseMeta` gains `agents` (and derived `hasMultipleAgents`), populated in `toSelectedBaseMeta`. Each stored module is a `TemplateBuilderComposeModule` and now carries `agent_name`; `SET_MODULE_AGENT { moduleId, agentName }` updates it. On `SET_MODULES`, each newly added module's `agent_name` is seeded with the base default agent and existing choices are preserved (mirroring the existing variable-preservation logic). `toComposeRequest` already serializes the module objects, so `agent_name` is included.

The new `SelectedBaseMeta` fields are kept optional as UI metadata (guarded by `base?.agents ?? []`) so existing inline test literals keep type-checking, while `toSelectedBaseMeta` always sets them. `knip` is satisfied by keeping the internal helpers file-private in this phase.
</details>

---

Generated by Coder Agents on behalf of @jeremyruppel.
