### PR TITLE
feat(site/src/pages/TemplateBuilder): add per-module agent radio selector

### DIFF
--- a/site/src/pages/TemplateBuilder/ModuleConfiguration.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleConfiguration.tsx
@@ -1,4 +1,5 @@
 import { CheckIcon, TrashIcon } from "lucide-react";
+import type { ReactNode } from "react";
 import { Button } from "#/components/Button/Button";
 import { CollapsibleSummary } from "#/components/CollapsibleSummary/CollapsibleSummary";
 import { TemplateBuilderAvatarData } from "#/pages/TemplateBuilder/TemplateBuilderAvatarData";
@@ -16,6 +17,8 @@ type ModuleConfigurationProps = {
 	onRemove?: () => void;
 	fields?: ConfigurationFieldDefinition[];
 	optionalFields?: ConfigurationFieldDefinition[];
+	/** Rendered between the header and variable fields, e.g. an agent selector. */
+	agentSelector?: ReactNode;
 };
 
 export const ModuleConfiguration: React.FC<ModuleConfigurationProps> = ({
@@ -26,6 +29,7 @@ export const ModuleConfiguration: React.FC<ModuleConfigurationProps> = ({
 	onRemove,
 	fields,
 	optionalFields,
+	agentSelector,
 }) => {
 	return (
 		<section className="pt-4 px-4 pb-6 rounded bg-surface-secondary">
@@ -49,6 +53,8 @@ export const ModuleConfiguration: React.FC<ModuleConfigurationProps> = ({
 					</Button>
 				)}
 			</header>
+
+			{agentSelector}
 
 			{fields && fields.length > 0 && (
 				<ConfigurationFieldContainer>

--- a/site/src/pages/TemplateBuilder/ModuleSettingsStep.stories.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleSettingsStep.stories.tsx
@@ -1,0 +1,108 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+import type {
+	TemplateBuilderModule,
+	TemplateBuilderModuleVariable,
+} from "#/api/typesGenerated";
+import { ModuleSettingsStep } from "./ModuleSettingsStep";
+import type { SelectedBaseAgent } from "./wizardState";
+
+const baseId = "docker-multi-agent";
+
+const portVariable: TemplateBuilderModuleVariable = {
+	name: "port",
+	type: "number",
+	description: "Port to run code-server on.",
+	required: true,
+	sensitive: false,
+};
+
+const modules: TemplateBuilderModule[] = [
+	{
+		id: "code-server",
+		display_name: "code-server",
+		description: "Run VS Code in the browser.",
+		category: "IDE",
+		icon: "/icon/code.svg",
+		version: "1.0.0",
+		compatible_os: ["linux"],
+		conflicts_with: [],
+		variables: [portVariable],
+	},
+	{
+		id: "git-clone",
+		display_name: "Git Clone",
+		description: "Clone a git repository on workspace start.",
+		category: "Source Control",
+		icon: "",
+		version: "1.0.0",
+		compatible_os: ["linux"],
+		conflicts_with: [],
+		variables: [],
+	},
+];
+
+const agents: SelectedBaseAgent[] = [
+	{ name: "main", displayName: "Primary", default: true },
+	{ name: "dev", displayName: "Dev", default: false },
+];
+
+const meta: Meta<typeof ModuleSettingsStep> = {
+	title: "pages/TemplateBuilder/ModuleSettingsStep",
+	component: ModuleSettingsStep,
+	args: {
+		baseId,
+		selectedModuleIds: ["code-server", "git-clone"],
+		moduleVariables: {},
+		onChangeModuleVariables: fn(),
+		onRemoveModule: fn(),
+		agents,
+		moduleAgents: { "code-server": "main", "git-clone": "main" },
+		onChangeModuleAgent: fn(),
+	},
+	parameters: {
+		queries: [
+			{
+				key: ["templateBuilder", "modules", baseId],
+				data: { modules },
+			},
+		],
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof ModuleSettingsStep>;
+
+// A multi-agent base renders an agent radio group per selected module, seeded
+// to the current selection. Choosing a different agent reports the change for
+// that specific module.
+export const MultipleAgents: Story = {
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+
+		const primaryRadios = await canvas.findAllByRole("radio", {
+			name: "Primary",
+		});
+		const devRadios = canvas.getAllByRole("radio", { name: "Dev" });
+		expect(primaryRadios).toHaveLength(2);
+		expect(devRadios).toHaveLength(2);
+		expect(primaryRadios[0]).toBeChecked();
+
+		await userEvent.click(devRadios[0]);
+		expect(args.onChangeModuleAgent).toHaveBeenCalledWith("code-server", "dev");
+	},
+};
+
+// A single-agent base hides the per-module agent selector entirely, keeping the
+// step focused on variable configuration.
+export const SingleAgent: Story = {
+	args: {
+		agents: [{ name: "main", displayName: "Primary", default: true }],
+		moduleAgents: { "code-server": "", "git-clone": "" },
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await canvas.findByText("code-server");
+		expect(canvas.queryByRole("radio")).not.toBeInTheDocument();
+	},
+};

--- a/site/src/pages/TemplateBuilder/ModuleSettingsStep.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleSettingsStep.tsx
@@ -1,5 +1,5 @@
 import { InfoIcon } from "lucide-react";
-import type { FC } from "react";
+import { type FC, useId } from "react";
 import { useQuery } from "react-query";
 import { templateBuilderModules } from "#/api/queries/templateBuilder";
 import type {
@@ -7,6 +7,8 @@ import type {
 	TemplateBuilderModulesResponse,
 	TemplateBuilderModuleVariable,
 } from "#/api/typesGenerated";
+import { Label } from "#/components/Label/Label";
+import { RadioGroup, RadioGroupItem } from "#/components/RadioGroup/RadioGroup";
 import {
 	TemplateBuilderSubtitle,
 	TemplateBuilderTitle,
@@ -17,6 +19,7 @@ import {
 } from "./ConfigurationField";
 import { defaultPlaceholder } from "./defaultPlaceholder";
 import { ModuleConfiguration } from "./ModuleConfiguration";
+import type { SelectedBaseAgent } from "./wizardState";
 
 interface ModuleSettingsStepProps {
 	baseId: string;
@@ -27,7 +30,52 @@ interface ModuleSettingsStepProps {
 		variables: Record<string, string>,
 	) => void;
 	onRemoveModule: (moduleId: string) => void;
+	/** Agents the base declares. When more than one, each module picks one. */
+	agents: readonly SelectedBaseAgent[];
+	/** Maps module id to its selected agent name. */
+	moduleAgents: Record<string, string>;
+	onChangeModuleAgent: (moduleId: string, agentName: string) => void;
 }
+
+/**
+ * Radio group letting a single module choose which base agent it attaches to.
+ */
+const ModuleAgentSelector: FC<{
+	agents: readonly SelectedBaseAgent[];
+	value: string;
+	onChange: (agentName: string) => void;
+}> = ({ agents, value, onChange }) => {
+	const groupId = useId();
+	const labelId = `${groupId}-label`;
+	return (
+		<div className="mb-6">
+			<Label id={labelId} className="block mb-1">
+				Agent
+			</Label>
+			<p className="mt-0 mb-3 text-sm text-content-secondary">
+				Choose which agent runs this module.
+			</p>
+			<RadioGroup
+				aria-labelledby={labelId}
+				value={value}
+				onValueChange={onChange}
+				className="gap-3"
+			>
+				{agents.map((agent) => {
+					const itemId = `${groupId}-${agent.name}`;
+					return (
+						<div key={agent.name} className="flex items-center gap-2">
+							<RadioGroupItem id={itemId} value={agent.name} />
+							<Label htmlFor={itemId} className="font-normal cursor-pointer">
+								{agent.displayName}
+							</Label>
+						</div>
+					);
+				})}
+			</RadioGroup>
+		</div>
+	);
+};
 
 function variableToField(
 	moduleId: string,
@@ -109,9 +157,13 @@ export const ModuleSettingsStep: FC<ModuleSettingsStepProps> = ({
 	moduleVariables,
 	onChangeModuleVariables,
 	onRemoveModule,
+	agents,
+	moduleAgents,
+	onChangeModuleAgent,
 }) => {
 	const { data } = useQuery(templateBuilderModules(baseId));
 	const modules = data?.modules ?? [];
+	const hasMultipleAgents = agents.length > 1;
 
 	const selectedModules = selectedModuleIds
 		.map((id) => modules.find((m) => m.id === id))
@@ -126,7 +178,9 @@ export const ModuleSettingsStep: FC<ModuleSettingsStepProps> = ({
 		<>
 			<TemplateBuilderTitle>Configure modules</TemplateBuilderTitle>
 			<TemplateBuilderSubtitle>
-				Set values for module variables.
+				{hasMultipleAgents
+					? "Choose an agent for each module and set values for module variables."
+					: "Set values for module variables."}
 			</TemplateBuilderSubtitle>
 
 			<div className="flex flex-col gap-6">
@@ -159,6 +213,17 @@ export const ModuleSettingsStep: FC<ModuleSettingsStepProps> = ({
 								fields={requiredFields}
 								optionalFields={optionalFields}
 								onRemove={() => onRemoveModule(mod.id)}
+								agentSelector={
+									hasMultipleAgents ? (
+										<ModuleAgentSelector
+											agents={agents}
+											value={moduleAgents[mod.id] ?? ""}
+											onChange={(agentName) =>
+												onChangeModuleAgent(mod.id, agentName)
+											}
+										/>
+									) : undefined
+								}
 							/>
 
 							{sensitiveVars.length > 0 && (

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
@@ -311,6 +311,13 @@ function renderStepContent(
 						})
 					}
 					onRemoveModule={onRemoveModule}
+					agents={state.selectedBase.agents ?? []}
+					moduleAgents={Object.fromEntries(
+						state.modules.map((m) => [m.id, m.agent_name ?? ""]),
+					)}
+					onChangeModuleAgent={(moduleId, agentName) =>
+						dispatch({ type: "SET_MODULE_AGENT", moduleId, agentName })
+					}
 				/>
 			);
 		case "customizations":

--- a/site/src/pages/TemplateBuilder/wizardState.ts
+++ b/site/src/pages/TemplateBuilder/wizardState.ts
@@ -9,7 +9,7 @@ import type {
 /**
  * UI-only metadata for a coder_agent declared by the selected base.
  */
-type SelectedBaseAgent = {
+export type SelectedBaseAgent = {
 	name: string;
 	displayName: string;
 	default: boolean;


### PR DESCRIPTION
Part of [DEVEX-556](https://linear.app/codercom/issue/DEVEX-556/handle-multiple-coder-agent-resources-in-template-builder). **Phase 5 of 5** in a stacked series. Base branch: `jeremy/devex-556-4-fe-state`.

## Summary

Renders the per-module agent selector. When the selected base declares more than one agent, each module card shows a labeled radio group to choose which agent the module attaches to. Single-agent bases are unchanged (no radios).

## What changed

- `wizardState.ts`: exported `SelectedBaseAgent` for reuse in the step.
- `ModuleConfiguration.tsx`: added an optional `agentSelector` slot rendered between the card header and variable fields.
- `ModuleSettingsStep.tsx`: new `agents`/`moduleAgents`/`onChangeModuleAgent` props; a local `ModuleAgentSelector` sub-component (per-module `useId`, reusing `RadioGroup`/`RadioGroupItem`/`Label`) shown only for multi-agent bases; the subtitle copy adapts only when multi-agent.
- `TemplateBuilderPageView.tsx`: builds the module-to-agent map from state and dispatches `SET_MODULE_AGENT`.
- `ModuleSettingsStep.stories.tsx` (new): `MultipleAgents` story whose `play` selects the `Dev` radio and asserts the callback fires for the right module; `SingleAgent` story asserts no radios render.

## Testing

- `lint:types`, `biome check`, `knip`, the two story tests, and the full unit suite (3150 pass).
- `frontend-review` audit (FE1-FE10) all PASS.
- Pre-commit hook passed.

<details>
<summary>Design &amp; plan context</summary>

`agents`, the per-module `agentName` map, and `onChangeModuleAgent` are passed into `ModuleSettingsStep`. When the base has more than one agent, a `RadioGroup` renders per module labeled by agent display name; it is hidden entirely for single-agent bases (no behavior change there). Per the frontend rules, UI behavior is covered by a Storybook `play` function rather than a DOM-based unit test.

Accessibility: the group is labeled via `aria-labelledby`, and each `RadioGroupItem` is paired with a `Label` (`htmlFor`/`id`) so each radio has an accessible name and stays keyboard-reachable.
</details>

---

Generated by Coder Agents on behalf of @jeremyruppel.
