### PR TITLE
chore: update stale Chromatic comments

### DIFF
--- a/site/src/components/LastSeen/LastSeen.stories.tsx
+++ b/site/src/components/LastSeen/LastSeen.stories.tsx
@@ -6,8 +6,8 @@ const meta: Meta<typeof LastSeen> = {
 	title: "components/LastSeen",
 	component: LastSeen,
 	args: {
-		// We typically want this component to be excluded from Chromatic's snapshots,
-		// because it creates a lot of noise when a static dates roles over from eg.
+		// We typically want this component to be excluded from snapshot tests,
+		// because it creates a lot of noise when a static date rolls over from eg.
 		// "2 months ago" to "3 months ago", but these stories use relative dates,
 		// and test specific cases that we want to be validated.
 		"data-pixel": "",

--- a/site/src/components/LastSeen/LastSeen.stories.tsx
+++ b/site/src/components/LastSeen/LastSeen.stories.tsx
@@ -6,8 +6,8 @@ const meta: Meta<typeof LastSeen> = {
 	title: "components/LastSeen",
 	component: LastSeen,
 	args: {
-		// We typically want this component to be excluded from Chromatic's snapshots,
-		// because it creates a lot of noise when a static dates roles over from eg.
+		// We typically want this component to be excluded from visual snapshots,
+		// because it creates a lot of noise when a static date rolls over from eg.
 		// "2 months ago" to "3 months ago", but these stories use relative dates,
 		// and test specific cases that we want to be validated.
 		"data-pixel": "",

--- a/site/src/components/PaginationWidget/PaginationContainer.mocks.ts
+++ b/site/src/components/PaginationWidget/PaginationContainer.mocks.ts
@@ -2,8 +2,8 @@
  * @file Mock input props for use with PaginationContainer's tests and stories.
  *
  * Had to split this off into a separate file because housing these in the test
- * file and then importing them from the stories file was causing Chromatic's
- * Vite test environment to break
+ * file and then importing them from the stories file was breaking the visual
+ * testing environment's Vite build
  */
 import type { PaginationResult } from "./PaginationContainer";
 

--- a/site/src/components/PaginationWidget/PaginationContainer.mocks.ts
+++ b/site/src/components/PaginationWidget/PaginationContainer.mocks.ts
@@ -2,8 +2,8 @@
  * @file Mock input props for use with PaginationContainer's tests and stories.
  *
  * Had to split this off into a separate file because housing these in the test
- * file and then importing them from the stories file was causing Chromatic's
- * Vite test environment to break
+ * file and then importing them from the stories file was breaking Storybook's
+ * build
  */
 import type { PaginationResult } from "./PaginationContainer";
 

--- a/site/src/modules/workspaces/WorkspaceTiming/Chart/Blocks.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/Chart/Blocks.tsx
@@ -14,7 +14,7 @@ export const Blocks: FC<BlocksProps> = ({ count }) => {
 	const [availableWidth, setAvailableWidth] = useState<number>(0);
 	const blocksRef = useRef<HTMLDivElement>(null);
 
-	// Fix: When using useLayoutEffect, Chromatic fails to calculate the right width.
+	// Fix: When using useLayoutEffect, snapshot tests fail to calculate the right width.
 	useEffect(() => {
 		if (availableWidth || !blocksRef.current) {
 			return;

--- a/site/src/modules/workspaces/WorkspaceTiming/Chart/Blocks.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/Chart/Blocks.tsx
@@ -14,7 +14,7 @@ export const Blocks: FC<BlocksProps> = ({ count }) => {
 	const [availableWidth, setAvailableWidth] = useState<number>(0);
 	const blocksRef = useRef<HTMLDivElement>(null);
 
-	// Fix: When using useLayoutEffect, Chromatic fails to calculate the right width.
+	// Fix: When using useLayoutEffect, visual snapshots fail to calculate the right width.
 	useEffect(() => {
 		if (availableWidth || !blocksRef.current) {
 			return;

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -570,8 +570,8 @@ export const WithWorkspaces: Story = {
 		await userEvent.click(
 			body.getByText("Attach workspace").closest("button")!,
 		);
-		// Wait for the workspace combobox dropdown to appear so
-		// Chromatic captures it.
+		// Wait for the workspace combobox dropdown to appear so snapshot tests
+		// capture it.
 		await body.findByPlaceholderText("Search workspaces...");
 	},
 };

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -571,7 +571,7 @@ export const WithWorkspaces: Story = {
 			body.getByText("Attach workspace").closest("button")!,
 		);
 		// Wait for the workspace combobox dropdown to appear so
-		// Chromatic captures it.
+		// the snapshot captures it.
 		await body.findByPlaceholderText("Search workspaces...");
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/storyFixtures.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/storyFixtures.ts
@@ -56,7 +56,7 @@ export const buildStreamRenderState = (
 /**
  * Pinned clock for stories that render countdown timers. Stories
  * should mock `Date.now` to return this value so the countdowns
- * are deterministic across Chromatic snapshots.
+ * are deterministic across snapshot tests.
  *
  * Set to midnight UTC on the same day as the fixture deadlines,
  * giving reconnect a 1s countdown and retry a 2s countdown.

--- a/site/src/pages/AgentsPage/components/ChatConversation/storyFixtures.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/storyFixtures.ts
@@ -56,7 +56,7 @@ export const buildStreamRenderState = (
 /**
  * Pinned clock for stories that render countdown timers. Stories
  * should mock `Date.now` to return this value so the countdowns
- * are deterministic across Chromatic snapshots.
+ * are deterministic across visual snapshots.
  *
  * Set to midnight UTC on the same day as the fixture deadlines,
  * giving reconnect a 1s countdown and retry a 2s countdown.

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchResults.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchResults.tsx
@@ -297,7 +297,7 @@ const ChatSearchResultRow: FC<ChatSearchResultRowProps> = ({
 						aria-hidden="true"
 					/>
 				)}
-				{/* Pin the ignored mask width so Chromatic does not diff bounding rect changes. */}
+				{/* Pin the ignored mask width so pixel does not diff bounding rect changes. */}
 				<span data-pixel="ignore" className="inline-block w-7 text-right">
 					{shortRelativeTime(chat.updated_at)}
 				</span>

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchResults.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchResults.tsx
@@ -297,7 +297,7 @@ const ChatSearchResultRow: FC<ChatSearchResultRowProps> = ({
 						aria-hidden="true"
 					/>
 				)}
-				{/* Pin the ignored mask width so Chromatic does not diff bounding rect changes. */}
+				{/* Pin the ignored mask width so Pixel does not diff bounding rect changes. */}
 				<span data-pixel="ignore" className="inline-block w-7 text-right">
 					{shortRelativeTime(chat.updated_at)}
 				</span>

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
@@ -294,7 +294,7 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 											/>
 										) : (
 											<>
-												{/* Pin the ignored mask width so Chromatic does not diff bounding rect changes. */}
+												{/* Pin the ignored mask width so pixel does not diff bounding rect changes. */}
 												<span
 													data-pixel="ignore"
 													className="inline-block w-7 text-right"

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
@@ -294,7 +294,7 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 											/>
 										) : (
 											<>
-												{/* Pin the ignored mask width so Chromatic does not diff bounding rect changes. */}
+												{/* Pin the ignored mask width so Pixel does not diff bounding rect changes. */}
 												<span
 													data-pixel="ignore"
 													className="inline-block w-7 text-right"

--- a/site/src/pages/ResetPasswordPage/ChangePasswordPage.tsx
+++ b/site/src/pages/ResetPasswordPage/ChangePasswordPage.tsx
@@ -27,8 +27,7 @@ const validationSchema = yup.object({
 });
 
 type ChangePasswordChangeProps = {
-	// This is used to prevent redirection when testing the page in Storybook and
-	// capturing Chromatic snapshots.
+	// This is used to prevent redirection in Storybook.
 	redirect?: boolean;
 };
 

--- a/site/src/pages/ResetPasswordPage/ChangePasswordPage.tsx
+++ b/site/src/pages/ResetPasswordPage/ChangePasswordPage.tsx
@@ -28,7 +28,7 @@ const validationSchema = yup.object({
 
 type ChangePasswordChangeProps = {
 	// This is used to prevent redirection when testing the page in Storybook and
-	// capturing Chromatic snapshots.
+	// capturing visual snapshots.
 	redirect?: boolean;
 };
 

--- a/site/src/pages/TasksPage/TasksTable.tsx
+++ b/site/src/pages/TasksPage/TasksTable.tsx
@@ -188,7 +188,7 @@ const TaskRow: FC<TaskRowProps> = ({ task, checked, onCheckChange }) => {
 	});
 
 	const taskPageLink = `/tasks/${task.owner_name}/${task.id}`;
-	// Discard role, breaks Chromatic.
+	// Discard role, breaks snapshot tests.
 	const { role, ...clickableRowProps } = useClickableTableRow({
 		onClick: () => {
 			navigate(taskPageLink);

--- a/site/src/pages/TasksPage/TasksTable.tsx
+++ b/site/src/pages/TasksPage/TasksTable.tsx
@@ -205,7 +205,7 @@ const TaskRow: FC<TaskRowProps> = ({ task, checked, onCheckChange }) => {
 	});
 
 	const taskPageLink = `/tasks/${task.owner_name}/${task.id}`;
-	// Discard role, breaks Chromatic.
+	// Discard role, breaks visual snapshots.
 	const { role, ...clickableRowProps } = useClickableTableRow({
 		onClick: () => {
 			navigate(taskPageLink);


### PR DESCRIPTION
Rewords the comments that still talk about Chromatic; those snapshots are
captured by pixel-storybook now. Comments only, no code changes.

The five `desktopZoom200` stories keep their `CLEANUP:` markers since their
Chromatic viewport params are intentionally still in place.

> Generated by Coder Agents on behalf of @aslilac.
