### PR TITLE
refactor(site/src/pages/AgentsPage): make tool failure have one representation

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -243,7 +243,6 @@ const buildParsedReadFileEntry = ({
 	status,
 	content = "",
 	errorMessage,
-	isError = status === "error",
 }: {
 	messageId: number;
 	toolId: string;
@@ -251,7 +250,6 @@ const buildParsedReadFileEntry = ({
 	status: "completed" | "error" | "running";
 	content?: string;
 	errorMessage?: string;
-	isError?: boolean;
 }): ParsedMessageEntry => {
 	const args = { path };
 	const result =
@@ -287,7 +285,6 @@ const buildParsedReadFileEntry = ({
 					name: "read_file",
 					args,
 					result,
-					isError,
 					status,
 				},
 			],
@@ -2368,7 +2365,6 @@ export const ToolDisplayModesFromPreferences: Story = {
 							name: "execute",
 							args: { command: "pnpm test" },
 							result: { output: "tests passed" },
-							isError: false,
 							status: "completed",
 						},
 						{
@@ -2388,7 +2384,6 @@ export const ToolDisplayModesFromPreferences: Story = {
 								],
 							},
 							result: { ok: true },
-							isError: false,
 							status: "completed",
 						},
 					],

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -2695,6 +2695,41 @@ export const SequentialReadFilesRunningState: Story = {
 	},
 };
 
+export const SequentialReadFilesMixedRunningAndError: Story = {
+	args: {
+		...defaultArgs,
+		parsedMessages: [
+			buildParsedReadFileEntry({
+				messageId: 1,
+				toolId: "read-mixed-error",
+				path: "site/src/missing.ts",
+				status: "error",
+				errorMessage: "permission denied",
+			}),
+			buildParsedReadFileEntry({
+				messageId: 2,
+				toolId: "read-mixed-running",
+				path: "site/src/streaming.ts",
+				status: "running",
+			}),
+		] satisfies ParsedMessageEntry[],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// A file still reading keeps the whole group reading; the failure
+		// surfaces once the straggler settles.
+		expect(
+			canvas.getByRole("button", { name: /reading 2 files/i }),
+		).toBeInTheDocument();
+		expect(
+			canvas.getByRole("img", { name: "Tool call running" }),
+		).toBeInTheDocument();
+		expect(
+			canvas.queryByRole("img", { name: "permission denied" }),
+		).not.toBeInTheDocument();
+	},
+};
+
 /** Collapsed thinking should visually align with adjacent tool calls. */
 export const ThinkingBlockWithToolCall: Story = {
 	parameters: {

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -405,7 +405,6 @@ export const BlockList: FC<{
 									key={block.id}
 									name="Tool"
 									status="running"
-									isError={false}
 									shellToolDisplayMode={shellToolDisplayMode}
 									codeDiffDisplayMode={codeDiffDisplayMode}
 									subagentTitles={subagentTitles}
@@ -425,7 +424,6 @@ export const BlockList: FC<{
 								args={tool.args}
 								result={tool.result}
 								status={tool.status}
-								isError={tool.isError}
 								killedBySignal={tool.killedBySignal}
 								shellToolDisplayMode={shellToolDisplayMode}
 								codeDiffDisplayMode={codeDiffDisplayMode}
@@ -485,7 +483,6 @@ export const BlockList: FC<{
 					args={tool.args}
 					result={tool.result}
 					status={tool.status}
-					isError={tool.isError}
 					killedBySignal={tool.killedBySignal}
 					shellToolDisplayMode={shellToolDisplayMode}
 					codeDiffDisplayMode={codeDiffDisplayMode}

--- a/site/src/pages/AgentsPage/components/ChatConversation/blockUtils.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/blockUtils.test.ts
@@ -105,7 +105,6 @@ describe("groupSequentialReadFileBlocks", () => {
 	const tool = (id: string, name = "read_file"): MergedTool => ({
 		id,
 		name,
-		isError: false,
 		status: "completed",
 	});
 	const tools = [tool("read-1"), tool("read-2"), tool("execute-1", "execute")];

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.test.ts
@@ -73,7 +73,6 @@ const readFileTool = (id: string): MergedTool => ({
 	name: "read_file",
 	args: readFileArgs(id),
 	result: { content: id },
-	isError: false,
 	status: "completed",
 });
 
@@ -137,7 +136,6 @@ const executeMessage = (messageID: number): ParsedMessageEntry => {
 		id: "execute-1",
 		name: "execute",
 		args,
-		isError: false,
 		status: "completed",
 	};
 	return entry({
@@ -207,7 +205,6 @@ describe("deriveMessageDisplayState", () => {
 			id: "execute-1",
 			name: "execute",
 			args: { command: "pnpm test" },
-			isError: false,
 			status: "completed",
 		};
 		const message = buildMessage(
@@ -234,7 +231,6 @@ describe("deriveMessageDisplayState", () => {
 			id: "execute-1",
 			name: "execute",
 			args: { command: "pnpm test" },
-			isError: false,
 			status: "completed",
 		};
 		const message = buildMessage(
@@ -372,7 +368,6 @@ describe("deriveMessageDisplayState", () => {
 							id: "tool-1",
 							name: "execute",
 							args: { command: "pnpm test" },
-							isError: false,
 							status: "completed",
 						},
 					],
@@ -392,7 +387,6 @@ describe("deriveMessageDisplayState", () => {
 					id: "wait-1",
 					name: "wait_agent",
 					args: {},
-					isError: false,
 					status: "running",
 				},
 			],
@@ -454,7 +448,6 @@ describe("buildDisplayMessages", () => {
 					count: "1",
 					templates: '[{"name":"docker","display_name":"Docker"}]',
 				},
-				isError: false,
 				status: "completed",
 				mcpServerConfigId: undefined,
 				modelIntent: undefined,

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageParsing.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageParsing.test.ts
@@ -491,7 +491,6 @@ describe("mergeTools", () => {
 			name: "bash",
 			args: { cmd: "ls" },
 			result: "ok",
-			isError: false,
 			status: "completed",
 		});
 	});
@@ -511,7 +510,6 @@ describe("mergeTools", () => {
 			[{ id: "1", name: "bash" }],
 			[{ id: "1", name: "bash", result: "fail", isError: true }],
 		);
-		expect(merged[0].isError).toBe(true);
 		expect(merged[0].status).toBe("error");
 	});
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageParsing.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageParsing.ts
@@ -165,7 +165,6 @@ export const mergeTools = (
 			name: call.name,
 			args: call.args,
 			result: result?.result,
-			isError: result?.isError ?? false,
 			status,
 			mcpServerConfigId: call.mcpServerConfigId || result?.mcpServerConfigId,
 			modelIntent,
@@ -179,7 +178,6 @@ export const mergeTools = (
 				id: result.id,
 				name: result.name,
 				result: result.result,
-				isError: result.isError,
 				status: result.isError ? "error" : "completed",
 				mcpServerConfigId: result.mcpServerConfigId,
 			});

--- a/site/src/pages/AgentsPage/components/ChatConversation/streamState.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/streamState.test.ts
@@ -696,7 +696,6 @@ describe("applyMessagePartToStreamState", () => {
 			name: "bash",
 			args: { command: "rm -rf /" },
 			result: { error: "permission denied" },
-			isError: true,
 			status: "error",
 		});
 	});

--- a/site/src/pages/AgentsPage/components/ChatConversation/streamState.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/streamState.ts
@@ -253,7 +253,6 @@ export const buildStreamTools = (
 			name: call.name,
 			args: call.args,
 			result: result?.result,
-			isError: result?.isError ?? false,
 			status: getStreamToolStatus(result),
 			mcpServerConfigId: call.mcpServerConfigId || result?.mcpServerConfigId,
 			modelIntent: call.modelIntent,
@@ -268,7 +267,6 @@ export const buildStreamTools = (
 					id: result.id,
 					name: result.name,
 					result: result.result,
-					isError: result.isError,
 					status: getStreamToolStatus(result),
 					mcpServerConfigId: result.mcpServerConfigId,
 				});

--- a/site/src/pages/AgentsPage/components/ChatConversation/streamingActivity.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/streamingActivity.test.ts
@@ -51,7 +51,6 @@ const streamState = (blocks: StreamState["blocks"]): StreamState => ({
 const tool = (status: MergedTool["status"]): MergedTool => ({
 	id: status,
 	name: "read_file",
-	isError: false,
 	status,
 });
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/types.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/types.ts
@@ -22,7 +22,6 @@ export type MergedTool = {
 	name: string;
 	args?: unknown;
 	result?: unknown;
-	isError: boolean;
 	status: "completed" | "error" | "running";
 	mcpServerConfigId?: string;
 	modelIntent?: string;

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/AdvisorTool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/AdvisorTool.stories.tsx
@@ -221,8 +221,7 @@ export const EmptyAdvice: Story = {
 
 export const BlankError: Story = {
 	args: {
-		status: "completed",
-		isError: true,
+		status: "error",
 		args: { question: sampleQuestion },
 		result: {
 			type: "error",
@@ -277,8 +276,8 @@ export const StatusErrorWithStringResult: Story = {
 };
 
 // Exercises the plain-string result branch in AdvisorRenderer (Tool.tsx),
-// where a non-object `result` is treated as raw advice text when
-// `isError` is false.
+// where a non-object `result` is treated as raw advice text when the
+// tool call did not fail.
 export const PlainStringResult: Story = {
 	args: {
 		status: "completed",

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/AdvisorTool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/AdvisorTool.stories.tsx
@@ -138,6 +138,20 @@ export const RunningWithStreamedAdvice: Story = {
 	},
 };
 
+/** A body that reads as an error mid-stream must not present the failure card. */
+export const RunningWithErrorShapedPartial: Story = {
+	args: {
+		status: "running",
+		args: { question: sampleQuestion },
+		result: { type: "error", error: "envelopes look like this" },
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("Consulting advisor…")).toBeInTheDocument();
+		expect(canvas.queryByRole("alert")).not.toBeInTheDocument();
+	},
+};
+
 export const LimitReached: Story = {
 	args: {
 		status: "completed",

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/AdvisorTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/AdvisorTool.tsx
@@ -12,7 +12,6 @@ export type AdvisorToolResultType = "advice" | "limit_reached" | "error";
 type AdvisorToolProps = {
 	question: string;
 	status: ToolStatus;
-	isError: boolean;
 	resultType?: AdvisorToolResultType;
 	advice?: string;
 	errorMessage?: string;
@@ -30,7 +29,6 @@ const EMPTY_ADVICE_MESSAGE = "Advisor returned no guidance.";
 export const AdvisorTool: React.FC<AdvisorToolProps> = ({
 	question,
 	status,
-	isError,
 	resultType,
 	advice,
 	errorMessage,
@@ -43,7 +41,7 @@ export const AdvisorTool: React.FC<AdvisorToolProps> = ({
 	const effectiveErrorMessage = errorMessage?.trim() || FALLBACK_ERROR;
 	const isRunning = status === "running";
 	const showLimitReached = resultType === "limit_reached";
-	const showError = isError || resultType === "error";
+	const showError = status === "error";
 
 	const headerStatus = showLimitReached ? (
 		<TriangleAlertIcon className="mt-0.5 size-3.5 shrink-0 text-content-warning" />
@@ -57,7 +55,6 @@ export const AdvisorTool: React.FC<AdvisorToolProps> = ({
 		<ToolCall.Root
 			className="w-full"
 			status={status}
-			isError={showError}
 			errorMessage={effectiveErrorMessage}
 			hasContent
 			defaultExpanded

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/AdvisorTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/AdvisorTool.tsx
@@ -12,7 +12,6 @@ export type AdvisorToolResultType = "advice" | "limit_reached" | "error";
 type AdvisorToolProps = {
 	question: string;
 	status: ToolStatus;
-	/** A body-typed error is folded into `status`, so it never arrives here. */
 	resultType?: Exclude<AdvisorToolResultType, "error">;
 	advice?: string;
 	errorMessage?: string;

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/AdvisorTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/AdvisorTool.tsx
@@ -12,7 +12,8 @@ export type AdvisorToolResultType = "advice" | "limit_reached" | "error";
 type AdvisorToolProps = {
 	question: string;
 	status: ToolStatus;
-	resultType?: AdvisorToolResultType;
+	/** A body-typed error is folded into `status`, so it never arrives here. */
+	resultType?: Exclude<AdvisorToolResultType, "error">;
 	advice?: string;
 	errorMessage?: string;
 	advisorModel?: string;

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/AskUserQuestionTool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/AskUserQuestionTool.stories.tsx
@@ -458,8 +458,7 @@ export const ReadOnlyPreviousCall: Story = {
 
 export const ErrorState: Story = {
 	args: {
-		status: "completed",
-		isError: true,
+		status: "error",
 		result: "The planning agent could not deliver follow-up questions.",
 	},
 	play: async ({ canvasElement }) => {

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/AskUserQuestionTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/AskUserQuestionTool.tsx
@@ -32,7 +32,6 @@ type QuestionAnswer =
 type AskUserQuestionToolProps = {
 	questions: AskUserQuestion[];
 	status: ToolStatus;
-	isError: boolean;
 	errorMessage?: string;
 	isChatCompleted?: boolean;
 	isLatestAskUserQuestion?: boolean;
@@ -371,7 +370,6 @@ const AnsweredQuestionText: FC<AnsweredQuestionTextProps> = ({
 export const AskUserQuestionTool: FC<AskUserQuestionToolProps> = ({
 	questions,
 	status,
-	isError,
 	errorMessage,
 	isChatCompleted = false,
 	isLatestAskUserQuestion = false,
@@ -534,12 +532,11 @@ export const AskUserQuestionTool: FC<AskUserQuestionToolProps> = ({
 		handleSubmit();
 	};
 
-	if (isError) {
+	if (status === "error") {
 		return (
 			<div className="w-full" role="alert">
 				<ToolCall.Root
 					status={status}
-					isError
 					errorMessage={errorMessage || "Failed to ask questions"}
 					hasContent={false}
 				>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ChatSummarizedTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ChatSummarizedTool.tsx
@@ -13,10 +13,9 @@ import type { ToolStatus } from "./utils";
 export const ChatSummarizedTool: React.FC<{
 	summary: string;
 	status: ToolStatus;
-	isError: boolean;
 	errorMessage?: string;
 	source?: string;
-}> = ({ summary, status, isError, errorMessage, source }) => {
+}> = ({ summary, status, errorMessage, source }) => {
 	const hasSummary = summary.trim().length > 0;
 	const isRunning = status === "running";
 	const isManual = source === "manual";
@@ -25,7 +24,6 @@ export const ChatSummarizedTool: React.FC<{
 		<ToolCall.Root
 			className="w-full"
 			status={status}
-			isError={isError}
 			errorMessage={errorMessage || "Failed to summarize conversation"}
 			hasContent={hasSummary}
 		>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ComputerTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ComputerTool.tsx
@@ -16,9 +16,8 @@ export const ComputerTool: React.FC<{
 	mimeType: string;
 	text: string;
 	status: ToolStatus;
-	isError: boolean;
 	errorMessage?: string;
-}> = ({ imageData, mimeType, text, status, isError, errorMessage }) => {
+}> = ({ imageData, mimeType, text, status, errorMessage }) => {
 	const [showLightbox, setShowLightbox] = useState(false);
 	const isRunning = status === "running";
 	const hasImage = imageData.length > 0;
@@ -30,7 +29,6 @@ export const ComputerTool: React.FC<{
 		<ToolCall.Root
 			className="w-full"
 			status={status}
-			isError={isError}
 			errorMessage={errorMessage || "Failed to take screenshot"}
 			hasContent={hasContent}
 			defaultExpanded={hasImage}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/CreateWorkspaceTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/CreateWorkspaceTool.tsx
@@ -16,7 +16,6 @@ export const CreateWorkspaceTool: React.FC<{
 	workspaceName: string;
 	resultJson: string;
 	status: ToolStatus;
-	isError: boolean;
 	errorMessage?: string;
 	buildId?: string;
 	created?: boolean;
@@ -25,13 +24,13 @@ export const CreateWorkspaceTool: React.FC<{
 	workspaceName,
 	resultJson,
 	status,
-	isError,
 	errorMessage,
 	buildId,
 	created = true,
 	labelOverride,
 }) => {
 	const isRunning = status === "running";
+	const isError = status === "error";
 	const rec = parseArgs(resultJson);
 	const ownerName = rec ? asString(rec.owner_name) : "";
 	const wsName = rec ? asString(rec.workspace_name) : workspaceName;
@@ -55,7 +54,6 @@ export const CreateWorkspaceTool: React.FC<{
 		<ToolCall.Root
 			className="w-full"
 			status={status}
-			isError={isError}
 			errorMessage={errorMessage || "Failed to create workspace"}
 			hasContent={hasBuildLogs}
 			defaultExpanded={isRunning}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/EditFilesTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/EditFilesTool.tsx
@@ -26,13 +26,13 @@ export const EditFilesTool: React.FC<{
 	files: EditFilesFileEntry[];
 	diffs: (FileDiffMetadata | null)[];
 	status: ToolStatus;
-	isError: boolean;
 	errorMessage?: string;
 	codeDiffDisplayMode?: TypesGen.AgentDisplayMode;
-}> = ({ files, diffs, status, isError, errorMessage, codeDiffDisplayMode }) => {
+}> = ({ files, diffs, status, errorMessage, codeDiffDisplayMode }) => {
 	const theme = useTheme();
 	const isDark = theme.palette.mode === "dark";
 	const isRunning = status === "running";
+	const isError = status === "error";
 	const hasDiffs = diffs.some((d) => d !== null);
 	const displayState = resolveAgentDisplayState(
 		codeDiffDisplayMode,
@@ -59,7 +59,6 @@ export const EditFilesTool: React.FC<{
 			key={`${codeDiffDisplayMode ?? "auto"}:${EDIT_FILES_AUTO_DISPLAY_STATE}`}
 			className="w-full"
 			status={status}
-			isError={isError}
 			errorMessage={errorMessage || "Failed to edit files"}
 			hasContent={hasDiffs || Boolean(errorDetail)}
 			defaultView={displayState}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.stories.tsx
@@ -13,7 +13,6 @@ const meta: Meta<typeof ExecuteTool> = {
 	component: ExecuteTool,
 	args: {
 		status: "completed",
-		isError: false,
 		transcriptBlocks: [],
 	},
 };
@@ -119,8 +118,7 @@ export const Running: Story = {
 export const ErrorOutput: Story = {
 	args: {
 		command: "make build",
-		status: "completed",
-		isError: true,
+		status: "error",
 		transcriptBlocks: [
 			{
 				kind: "output",
@@ -139,7 +137,6 @@ export const ConnectionError: Story = {
 	args: {
 		command: "ls -la",
 		status: "error",
-		isError: true,
 		shellToolDisplayMode: "auto",
 		transcriptBlocks: [{ kind: "error", text: stoppedWorkspaceError }],
 	},

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
@@ -27,7 +27,6 @@ type ExecuteToolProps = {
 	command: string;
 	transcriptBlocks: readonly ExecuteTranscriptBlock[];
 	status: ToolStatus;
-	isError: boolean;
 	errorText?: string;
 	durationMs?: number;
 	isBackgrounded?: boolean;
@@ -41,7 +40,6 @@ export const ExecuteTool: React.FC<ExecuteToolProps> = ({
 	command,
 	transcriptBlocks,
 	status,
-	isError,
 	errorText,
 	durationMs,
 	isBackgrounded = false,
@@ -59,13 +57,13 @@ export const ExecuteTool: React.FC<ExecuteToolProps> = ({
 			? "preview"
 			: "collapsed";
 	const isRunning = status === "running";
+	const isError = status === "error";
 	const durationLabel = formatShellDurationMs(durationMs);
 	const { commandLabel, durationSuffix } = getShellCommandLine({
 		command,
 		modelIntent,
 		parsedCommands,
 		durationLabel,
-		isRunning,
 		isError,
 	});
 	const defaultView = resolveAgentDisplayState(
@@ -78,7 +76,6 @@ export const ExecuteTool: React.FC<ExecuteToolProps> = ({
 			key={`${shellToolDisplayMode ?? "auto"}:${autoDisplayState}`}
 			className="group/exec grid w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2 rounded-md bg-surface-primary font-sans font-normal text-xs leading-5"
 			status={status}
-			isError={isError}
 			errorMessage={errorText || "Command failed"}
 			hasContent
 			defaultView={defaultView}
@@ -136,7 +133,7 @@ export const ExecuteTool: React.FC<ExecuteToolProps> = ({
 				<ShellTranscriptBody
 					command={command}
 					transcriptBlocks={transcriptBlocks}
-					isError={isError}
+					failed={isError}
 				/>
 			</ToolCall.Content>
 		</ToolCall.Root>
@@ -148,7 +145,6 @@ type ShellCommandLineInput = {
 	modelIntent?: string;
 	parsedCommands?: readonly string[][];
 	durationLabel: string;
-	isRunning: boolean;
 	isError: boolean;
 };
 
@@ -157,7 +153,6 @@ const getShellCommandLine = ({
 	modelIntent,
 	parsedCommands,
 	durationLabel,
-	isRunning,
 	isError,
 }: ShellCommandLineInput): { commandLabel: string; durationSuffix: string } => {
 	const intentLabel = sanitizeExecuteModelIntent(modelIntent, command);
@@ -169,7 +164,7 @@ const getShellCommandLine = ({
 	let commandLabel = intentLabel
 		? `${intentLabel} using ${commandDisplay}`
 		: `Ran ${commandDisplay}`;
-	if (!isRunning && isError) {
+	if (isError) {
 		commandLabel = `Failed to run ${commandDisplay}`;
 	}
 
@@ -182,8 +177,8 @@ const getShellCommandLine = ({
 const ShellTranscriptBody: React.FC<{
 	command: string;
 	transcriptBlocks: readonly ExecuteTranscriptBlock[];
-	isError: boolean;
-}> = ({ command, transcriptBlocks, isError }) => {
+	failed: boolean;
+}> = ({ command, transcriptBlocks, failed }) => {
 	return (
 		<ScrollArea
 			className="col-start-1 col-span-2 mt-2 rounded-xl bg-surface-secondary/60 text-2xs"
@@ -202,7 +197,7 @@ const ShellTranscriptBody: React.FC<{
 						key={block.kind}
 						className={cn(
 							"m-0 mt-4 whitespace-pre-wrap break-all border-0 bg-transparent p-0 font-mono text-xs font-normal leading-5",
-							block.kind === "error" || isError
+							block.kind === "error" || failed
 								? "text-content-destructive"
 								: "text-content-secondary",
 						)}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ListAgentsTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ListAgentsTool.tsx
@@ -14,9 +14,8 @@ export const ListAgentsTool: React.FC<{
 	agents: unknown[];
 	total: number;
 	status: ToolStatus;
-	isError: boolean;
 	errorMessage?: string;
-}> = ({ agents, total, status, isError, errorMessage }) => {
+}> = ({ agents, total, status, errorMessage }) => {
 	const location = useLocation();
 	const hasContent = agents.length > 0;
 	const isRunning = status === "running";
@@ -31,7 +30,6 @@ export const ListAgentsTool: React.FC<{
 		<ToolCall.Root
 			className="w-full"
 			status={status}
-			isError={isError}
 			errorMessage={errorMessage || "Failed to list agents"}
 			hasContent={hasContent}
 		>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ListTemplatesTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ListTemplatesTool.tsx
@@ -12,9 +12,8 @@ export const ListTemplatesTool: React.FC<{
 	templates: unknown[];
 	count: number;
 	status: ToolStatus;
-	isError: boolean;
 	errorMessage?: string;
-}> = ({ templates, count, status, isError, errorMessage }) => {
+}> = ({ templates, count, status, errorMessage }) => {
 	const hasContent = templates.length > 0;
 	const isRunning = status === "running";
 
@@ -29,7 +28,6 @@ export const ListTemplatesTool: React.FC<{
 		<ToolCall.Root
 			className="w-full"
 			status={status}
-			isError={isError}
 			errorMessage={errorMessage || "Failed to list templates"}
 			hasContent={hasContent}
 		>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessOutputTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessOutputTool.tsx
@@ -16,13 +16,16 @@ import {
 	resolveAgentDisplayState,
 } from "./displayMode";
 import { ToolCall } from "./ToolCall";
-import { COLLAPSED_OUTPUT_HEIGHT, signalTooltipLabel } from "./utils";
+import {
+	COLLAPSED_OUTPUT_HEIGHT,
+	signalTooltipLabel,
+	type ToolStatus,
+} from "./utils";
 
 type ProcessOutputToolProps = {
 	output: string;
-	isRunning: boolean;
+	status: ToolStatus;
 	exitCode: number | null;
-	isError: boolean;
 	errorMessage?: string;
 	killedBySignal?: "kill" | "terminate";
 	shellToolDisplayMode?: TypesGen.AgentDisplayMode;
@@ -54,14 +57,15 @@ export const ProcessOutputTool: React.FC<ProcessOutputToolProps> = (props) => {
 
 const ProcessOutputToolInner: React.FC<ProcessOutputToolInnerProps> = ({
 	output,
-	isRunning,
+	status,
 	exitCode,
-	isError,
 	errorMessage,
 	killedBySignal,
 	defaultView,
 	outputInitiallyFullyExpanded,
 }) => {
+	const isRunning = status === "running";
+	const isError = status === "error";
 	const [outputFullyExpanded, setOutputFullyExpanded] = useState(
 		outputInitiallyFullyExpanded,
 	);
@@ -83,8 +87,7 @@ const ProcessOutputToolInner: React.FC<ProcessOutputToolInnerProps> = ({
 	return (
 		<ToolCall.Root
 			className="group/proc w-full"
-			status={isRunning ? "running" : isError ? "error" : "completed"}
-			isError={isError}
+			status={status}
 			errorMessage={errorMessage || "Failed to read process output"}
 			hasContent={hasOutput}
 			defaultView={defaultView}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessSignalTool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessSignalTool.stories.tsx
@@ -89,8 +89,8 @@ export const SuccessTerminate: Story = {
 
 /**
  * Backend errorResult() wraps failures in NewTextResponse (not
- * NewTextErrorResponse), so isError stays false. The renderer
- * detects this via the success=false field.
+ * NewTextErrorResponse), so the protocol status stays "completed".
+ * The renderer detects this via the success=false field.
  */
 export const SoftFailureKill: Story = {
 	args: {
@@ -128,12 +128,11 @@ export const SoftFailureTerminate: Story = {
 
 /**
  * Protocol-level error from NewTextErrorResponse (e.g. missing
- * args). isError is true, result is a plain string.
+ * args). The status is "error", result is a plain string.
  */
 export const ProtocolError: Story = {
 	args: {
-		status: "completed",
-		isError: true,
+		status: "error",
 		args: { process_id: "", signal: "kill" },
 		result: "process_id is required",
 	},
@@ -148,8 +147,7 @@ export const ProtocolError: Story = {
  */
 export const ProtocolErrorStructured: Story = {
 	args: {
-		status: "completed",
-		isError: true,
+		status: "error",
 		args: { process_id: PROCESS_ID, signal: "terminate" },
 		result: {
 			success: false,

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ProposePlanTool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ProposePlanTool.stories.tsx
@@ -146,8 +146,7 @@ export const CompletedCopyButton: Story = {
 
 export const ErrorState: Story = {
 	args: {
-		status: "completed",
-		isError: true,
+		status: "error",
 		args: { path: defaultPlanPath },
 		result: "Failed to read file: file not found",
 	},

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ProposePlanTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ProposePlanTool.tsx
@@ -13,7 +13,7 @@ import { getPathBasename } from "../../../utils/path";
 import { Response } from "../Response";
 import { TranscriptRow } from "../TranscriptRow";
 import { ToolCall } from "./ToolCall";
-import { foldResultFailure, type ToolStatus } from "./utils";
+import type { ToolStatus } from "./utils";
 
 export const ProposePlanTool: React.FC<{
 	content?: string;
@@ -54,9 +54,7 @@ export const ProposePlanTool: React.FC<{
 		? (inlineContent ?? "")
 		: (fileQuery.data ?? "");
 	const filename = getPathBasename(path || "PLAN.md") || "PLAN.md";
-	// A plan whose body could not be fetched is as unusable as one the
-	// tool never produced.
-	const effectiveStatus = foldResultFailure(status, Boolean(fetchError));
+	const effectiveStatus = fetchError ? "error" : status;
 	const isRunning = effectiveStatus === "running";
 	const effectiveErrorMessage = errorMessage || fetchError;
 	const hasDisplayContent = displayContent.trim().length > 0;

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ProposePlanTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ProposePlanTool.tsx
@@ -53,11 +53,11 @@ export const ProposePlanTool: React.FC<{
 	const displayContent = hasInlineContent
 		? (inlineContent ?? "")
 		: (fileQuery.data ?? "");
-	const isRunning = status === "running";
 	const filename = getPathBasename(path || "PLAN.md") || "PLAN.md";
 	// A plan whose body could not be fetched is as unusable as one the
 	// tool never produced.
 	const effectiveStatus = foldResultFailure(status, Boolean(fetchError));
+	const isRunning = effectiveStatus === "running";
 	const effectiveErrorMessage = errorMessage || fetchError;
 	const hasDisplayContent = displayContent.trim().length > 0;
 	const implementPlanMutation = useMutation({

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ProposePlanTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ProposePlanTool.tsx
@@ -13,14 +13,13 @@ import { getPathBasename } from "../../../utils/path";
 import { Response } from "../Response";
 import { TranscriptRow } from "../TranscriptRow";
 import { ToolCall } from "./ToolCall";
-import type { ToolStatus } from "./utils";
+import { foldResultFailure, type ToolStatus } from "./utils";
 
 export const ProposePlanTool: React.FC<{
 	content?: string;
 	fileID?: string;
 	path: string;
 	status: ToolStatus;
-	isError: boolean;
 	errorMessage?: string;
 	onImplementPlan?: () => Promise<void> | void;
 }> = ({
@@ -28,7 +27,6 @@ export const ProposePlanTool: React.FC<{
 	fileID,
 	path,
 	status,
-	isError,
 	errorMessage,
 	onImplementPlan,
 }) => {
@@ -57,7 +55,9 @@ export const ProposePlanTool: React.FC<{
 		: (fileQuery.data ?? "");
 	const isRunning = status === "running";
 	const filename = getPathBasename(path || "PLAN.md") || "PLAN.md";
-	const effectiveError = isError || Boolean(fetchError);
+	// A plan whose body could not be fetched is as unusable as one the
+	// tool never produced.
+	const effectiveStatus = foldResultFailure(status, Boolean(fetchError));
 	const effectiveErrorMessage = errorMessage || fetchError;
 	const hasDisplayContent = displayContent.trim().length > 0;
 	const implementPlanMutation = useMutation({
@@ -67,8 +67,7 @@ export const ProposePlanTool: React.FC<{
 		},
 	});
 	const canImplementPlan =
-		status === "completed" &&
-		!effectiveError &&
+		effectiveStatus === "completed" &&
 		!fetchLoading &&
 		hasDisplayContent &&
 		Boolean(onImplementPlan);
@@ -76,8 +75,7 @@ export const ProposePlanTool: React.FC<{
 	return (
 		<div className="w-full">
 			<ToolCall.Root
-				status={status}
-				isError={effectiveError}
+				status={effectiveStatus}
 				errorMessage={effectiveErrorMessage || "Failed to propose plan"}
 				hasContent={false}
 			>
@@ -127,7 +125,7 @@ export const ProposePlanTool: React.FC<{
 				</>
 			) : (
 				!fetchLoading &&
-				!effectiveError && (
+				effectiveStatus !== "error" && (
 					<p className="text-[13px] text-content-secondary italic">
 						No plan content.
 					</p>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFileTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFileTool.tsx
@@ -42,11 +42,9 @@ const ReadFileContent: React.FC<{
 export const getReadFileToolData = ({
 	args,
 	result,
-	isError,
 }: {
 	args?: unknown;
 	result?: unknown;
-	isError: boolean;
 }) => {
 	const parsedArgs = parseArgs(args);
 	const path = parsedArgs ? asString(parsedArgs.path).trim() : "";
@@ -54,7 +52,6 @@ export const getReadFileToolData = ({
 	return {
 		path: path || "file",
 		content: rec ? asString(rec.content).trim() : "",
-		isError,
 		errorMessage: rec ? asString(rec.error || rec.message) : undefined,
 	};
 };
@@ -67,19 +64,11 @@ export const ReadFileTool: React.FC<{
 	path: string;
 	content: string;
 	status: ToolStatus;
-	isError: boolean;
 	errorMessage?: string;
 	expanded?: boolean;
 	onExpandedChange?: (expanded: boolean) => void;
-}> = ({
-	path,
-	content,
-	status,
-	isError,
-	errorMessage,
-	expanded,
-	onExpandedChange,
-}) => {
+}> = ({ path, content, status, errorMessage, expanded, onExpandedChange }) => {
+	const isError = status === "error";
 	const hasContent = content.length > 0 || isError;
 	const isRunning = status === "running";
 	const filename = getPathBasename(path);
@@ -89,7 +78,6 @@ export const ReadFileTool: React.FC<{
 		<ToolCall.Root
 			className="w-full"
 			status={status}
-			isError={isError}
 			errorMessage={errorMessage || "Failed to read file"}
 			hasContent={hasContent}
 			expanded={expanded}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFilesTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFilesTool.tsx
@@ -8,7 +8,6 @@ type ReadFileItem = {
 	path: string;
 	content: string;
 	status: MergedTool["status"];
-	isError: boolean;
 	errorMessage?: string;
 };
 
@@ -28,7 +27,7 @@ export const ReadFilesTool: FC<{
 	);
 	const items = tools.map(getReadFileItem);
 	const isRunning = tools.some((tool) => tool.status === "running");
-	const isError = tools.some((tool) => tool.isError);
+	const isError = tools.some((tool) => tool.status === "error");
 	const hasContent = items.length > 0;
 	const label = isRunning
 		? `Reading ${tools.length} files…`
@@ -40,7 +39,6 @@ export const ReadFilesTool: FC<{
 			<ToolCall.Root
 				className="w-full"
 				status={isRunning ? "running" : isError ? "error" : "completed"}
-				isError={isError}
 				errorMessage={errorMessage || "Failed to read one or more files"}
 				hasContent={hasContent}
 				expanded={expanded}
@@ -55,7 +53,6 @@ export const ReadFilesTool: FC<{
 									path={item.path}
 									content={item.content}
 									status={item.status}
-									isError={item.isError}
 									errorMessage={item.errorMessage}
 									expanded={expandedFileIDs.has(item.id)}
 									onExpandedChange={(nextExpanded) => {

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFilesTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFilesTool.tsx
@@ -26,19 +26,23 @@ export const ReadFilesTool: FC<{
 		new Set(),
 	);
 	const items = tools.map(getReadFileItem);
-	const isRunning = tools.some((tool) => tool.status === "running");
-	const isError = tools.some((tool) => tool.status === "error");
+	const groupStatus = tools.some((tool) => tool.status === "running")
+		? "running"
+		: tools.some((tool) => tool.status === "error")
+			? "error"
+			: "completed";
 	const hasContent = items.length > 0;
-	const label = isRunning
-		? `Reading ${tools.length} files…`
-		: `Read ${tools.length} files`;
+	const label =
+		groupStatus === "running"
+			? `Reading ${tools.length} files…`
+			: `Read ${tools.length} files`;
 	const errorMessage = items.find((item) => item.errorMessage)?.errorMessage;
 
 	return (
 		<div data-tool-call="">
 			<ToolCall.Root
 				className="w-full"
-				status={isRunning ? "running" : isError ? "error" : "completed"}
+				status={groupStatus}
 				errorMessage={errorMessage || "Failed to read one or more files"}
 				hasContent={hasContent}
 				expanded={expanded}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ReadSkillTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ReadSkillTool.tsx
@@ -8,9 +8,8 @@ export const ReadSkillTool: React.FC<{
 	label: string;
 	body: string;
 	status: ToolStatus;
-	isError: boolean;
 	errorMessage?: string;
-}> = ({ label, body, status, isError, errorMessage }) => {
+}> = ({ label, body, status, errorMessage }) => {
 	const hasContent = body.length > 0;
 	const isRunning = status === "running";
 
@@ -18,7 +17,6 @@ export const ReadSkillTool: React.FC<{
 		<ToolCall.Root
 			className="w-full"
 			status={status}
-			isError={isError}
 			errorMessage={errorMessage || "Failed to read skill"}
 			hasContent={hasContent}
 		>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ReadTemplateTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ReadTemplateTool.tsx
@@ -9,9 +9,8 @@ import type { ToolStatus } from "./utils";
 export const ReadTemplateTool: React.FC<{
 	templateName: string;
 	status: ToolStatus;
-	isError: boolean;
 	errorMessage?: string;
-}> = ({ templateName, status, isError, errorMessage }) => {
+}> = ({ templateName, status, errorMessage }) => {
 	const isRunning = status === "running";
 
 	const label = isRunning
@@ -23,7 +22,6 @@ export const ReadTemplateTool: React.FC<{
 	return (
 		<ToolCall.Root
 			status={status}
-			isError={isError}
 			errorMessage={errorMessage || "Failed to read template"}
 			hasContent={false}
 		>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/StartWorkspaceTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/StartWorkspaceTool.tsx
@@ -7,7 +7,6 @@ interface StartWorkspaceToolProps {
 	status: ToolStatus;
 	buildId?: string;
 	workspaceName: string;
-	isError: boolean;
 	errorMessage?: string;
 	noBuild?: boolean;
 	labelOverride?: string;
@@ -17,12 +16,12 @@ export const StartWorkspaceTool: FC<StartWorkspaceToolProps> = ({
 	status,
 	buildId,
 	workspaceName,
-	isError,
 	errorMessage,
 	noBuild,
 	labelOverride,
 }) => {
 	const isRunning = status === "running";
+	const isError = status === "error";
 
 	const label = isRunning
 		? "Starting workspace…"
@@ -40,7 +39,6 @@ export const StartWorkspaceTool: FC<StartWorkspaceToolProps> = ({
 		<ToolCall.Root
 			className="w-full"
 			status={status}
-			isError={isError}
 			errorMessage={errorMessage || "Failed to start workspace"}
 			hasContent={hasBuildLogs}
 			defaultExpanded={isRunning}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
@@ -118,14 +118,12 @@ function getSubagentLabel(
 const SubagentStatusIcon: React.FC<{
 	subagentStatus: string;
 	toolStatus: ToolStatus;
-	isError: boolean;
 	isTimeout: boolean;
 	iconKind?: SubagentDescriptor["iconKind"];
 	showDesktopPreview?: boolean;
 }> = ({
 	subagentStatus,
 	toolStatus,
-	isError,
 	isTimeout,
 	iconKind = "bot",
 	showDesktopPreview = false,
@@ -135,7 +133,7 @@ const SubagentStatusIcon: React.FC<{
 	if (isTimeout && !subagentCompleted) {
 		return <ClockIcon className="size-4 shrink-0 stroke-[1.5] text-current" />;
 	}
-	if ((isError && !subagentCompleted) || toolStatus === "error") {
+	if (toolStatus === "error") {
 		return <CircleXIcon className="size-4 shrink-0 text-current" />;
 	}
 	if (toolStatus === "running") {
@@ -166,7 +164,6 @@ export const SubagentTool: React.FC<{
 	message?: string;
 	report?: string;
 	toolStatus: ToolStatus;
-	isError: boolean;
 	isTimeout?: boolean;
 	/** Show an inline VNC desktop preview (for computer-use subagents). */
 	showDesktopPreview?: boolean;
@@ -183,7 +180,6 @@ export const SubagentTool: React.FC<{
 	message,
 	report,
 	toolStatus,
-	isError,
 	isTimeout = false,
 	showDesktopPreview,
 	recordingFileId,
@@ -215,7 +211,6 @@ export const SubagentTool: React.FC<{
 		<ToolCall.Root
 			className="w-full"
 			status={toolStatus}
-			isError={isError}
 			hasContent={hasExpandableContent}
 			expanded={expanded}
 			onExpandedChange={setExpanded}
@@ -226,7 +221,6 @@ export const SubagentTool: React.FC<{
 						<SubagentStatusIcon
 							subagentStatus={subagentStatus}
 							toolStatus={toolStatus}
-							isError={isError}
 							isTimeout={isTimeout}
 							iconKind={descriptor.iconKind}
 							showDesktopPreview={showDesktopPreview}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -50,7 +50,6 @@ type ToolShowcaseItem = {
 	status?: React.ComponentProps<typeof Tool>["status"];
 	args?: unknown;
 	result?: unknown;
-	isError?: boolean;
 	killedBySignal?: "kill" | "terminate";
 	modelIntent?: string;
 	parsedCommands?: readonly string[][];
@@ -227,7 +226,6 @@ const allToolShowcaseItems: ToolShowcaseItem[] = [
 		name: "read_file",
 		args: { path: "site/src/pages/AgentsPage/Missing.tsx" },
 		status: "error",
-		isError: true,
 		result: { error: "File not found" },
 	},
 	{
@@ -362,7 +360,6 @@ export const ExecuteError: Story = {
 	args: {
 		name: "execute",
 		status: "error",
-		isError: true,
 		args: { command: longExecuteCommand },
 		shellToolDisplayMode: "always_collapsed",
 		result: {
@@ -392,7 +389,6 @@ export const ExecuteDeniedByHook: Story = {
 	args: {
 		name: "execute",
 		status: "error",
-		isError: true,
 		args: { command: "cat /etc/secrets" },
 		result: {
 			error:
@@ -546,7 +542,6 @@ export const ProcessOutputStringError: Story = {
 	args: {
 		name: "process_output",
 		status: "error",
-		isError: true,
 		result: "permission denied",
 	},
 	play: async ({ canvasElement }) => {
@@ -840,7 +835,6 @@ export const SubagentNoErrorWhenCompleted: Story = {
 			error: "provider metadata noise",
 		},
 		status: "error",
-		isError: true,
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -1193,7 +1187,6 @@ export const ListAgentsError: Story = {
 	args: {
 		name: "list_agents",
 		status: "error",
-		isError: true,
 		args: {},
 		result: "list_agents is only available on root chats",
 	},
@@ -1476,7 +1469,6 @@ export const MCPToolError: Story = {
 	args: {
 		name: "linear__list_issues",
 		status: "error",
-		isError: true,
 		args: { project: "backend" },
 		result: { error: "Authentication token expired" },
 		mcpServerConfigId: "mcp-server-1",
@@ -1705,7 +1697,6 @@ export const WriteFileDeniedByHook: Story = {
 	args: {
 		name: "write_file",
 		status: "error",
-		isError: true,
 		codeDiffDisplayMode: "auto",
 		args: {
 			path: "src/utils/helpers.ts",
@@ -1884,7 +1875,6 @@ export const EditFilesError: Story = {
 	args: {
 		name: "edit_files",
 		status: "error",
-		isError: true,
 		args: {
 			files: [
 				{
@@ -2129,7 +2119,6 @@ export const ComputerError: Story = {
 	args: {
 		name: "computer",
 		status: "error",
-		isError: true,
 		result: {
 			data: "",
 			text: "",
@@ -2221,7 +2210,6 @@ export const GenericToolFailed: Story = {
 	args: {
 		name: "some_custom_tool",
 		status: "error",
-		isError: true,
 		args: { input: "test data" },
 		result: { error: "Connection refused: could not reach upstream service" },
 	},
@@ -2243,7 +2231,6 @@ export const GenericToolFailedNoResult: Story = {
 	args: {
 		name: "web_search",
 		status: "error",
-		isError: true,
 	},
 	play: async ({ canvasElement }) => {
 		expect(
@@ -2256,7 +2243,6 @@ export const GenericToolStringError: Story = {
 	args: {
 		name: "web_search",
 		status: "error",
-		isError: true,
 		result: "Network unreachable",
 	},
 	play: async ({ canvasElement }) => {
@@ -2271,7 +2257,6 @@ export const GenericMCPToolStringError: Story = {
 	args: {
 		name: "linear__list_issues",
 		status: "error",
-		isError: true,
 		result: "Authentication token expired",
 		mcpServerConfigId: "mcp-server-1",
 		mcpServers: sampleMCPServers,
@@ -2353,7 +2338,6 @@ export const SubagentWaitTimedOut: Story = {
 	args: {
 		name: "wait_agent",
 		status: "error",
-		isError: true,
 		args: { chat_id: "timed-out-child" },
 		result: "timed out waiting for delegated subagent completion",
 	},
@@ -2372,7 +2356,6 @@ export const SubagentWaitTimedOutWithTitle: Story = {
 	args: {
 		name: "wait_agent",
 		status: "error",
-		isError: true,
 		args: { chat_id: "timed-out-child" },
 		result: {
 			chat_id: "timed-out-child",
@@ -2392,7 +2375,6 @@ export const SubagentWaitTimedOutTitleFromMap: Story = {
 	args: {
 		name: "wait_agent",
 		status: "error",
-		isError: true,
 		args: { chat_id: "timed-out-child" },
 		result: "timed out waiting for delegated subagent completion",
 		subagentTitles: new Map([["timed-out-child", "Refactor auth module"]]),
@@ -2408,7 +2390,6 @@ export const SubagentWaitTimedOutStructured: Story = {
 	args: {
 		name: "wait_agent",
 		status: "completed",
-		isError: false,
 		args: { chat_id: "timed-out-child" },
 		result: {
 			chat_id: "timed-out-child",
@@ -2433,7 +2414,6 @@ export const SubagentSpawnError: Story = {
 	args: {
 		name: "spawn_agent",
 		status: "error",
-		isError: true,
 		args: {
 			title: "Database migration",
 			prompt: "Run the pending migrations.",
@@ -2459,7 +2439,6 @@ export const SubagentWaitError: Story = {
 	args: {
 		name: "wait_agent",
 		status: "error",
-		isError: true,
 		args: { chat_id: "error-child" },
 		result: {
 			chat_id: "error-child",
@@ -2476,11 +2455,32 @@ export const SubagentWaitError: Story = {
 	},
 };
 
+export const SubagentWaitErrorWhileChildStillRunning: Story = {
+	args: {
+		name: "wait_agent",
+		status: "error",
+		args: { chat_id: "still-running-child" },
+		result: {
+			chat_id: "still-running-child",
+			error: "connection reset",
+			status: "running",
+			title: "Lint codebase",
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// The failed tool call wins over the sub-agent snapshot, which is
+		// only a possibly-stale report about a different entity.
+		expect(canvas.getByText(/Failed waiting for/)).toBeInTheDocument();
+		expect(canvas.queryByText(/Waiting for/)).not.toBeInTheDocument();
+		expect(canvas.getByText("Lint codebase")).toBeInTheDocument();
+	},
+};
+
 export const MCPToolFailedUnifiedStyle: Story = {
 	args: {
 		name: "linear__list_issues",
 		status: "error",
-		isError: true,
 		args: { project: "backend" },
 		result: { error: "Authentication token expired" },
 		mcpServerConfigId: "mcp-server-1",
@@ -2552,7 +2552,6 @@ export const SpawnComputerUseAgentError: Story = {
 	args: {
 		name: "spawn_computer_use_agent",
 		status: "error",
-		isError: true,
 		result: {
 			chat_id: "desktop-child-1",
 			status: "error",
@@ -2646,7 +2645,6 @@ export const WaitAgentComputerUseTimedOutNoRecording: Story = {
 	args: {
 		name: "wait_agent",
 		status: "error",
-		isError: true,
 		args: { chat_id: "desktop-child-1" },
 		result: {
 			chat_id: "desktop-child-1",
@@ -2705,7 +2703,6 @@ export const ReadSkillError: Story = {
 	args: {
 		name: "read_skill",
 		status: "error",
-		isError: true,
 		args: { name: "nonexistent-skill" },
 		result: { error: 'skill "nonexistent-skill" not found' },
 	},
@@ -2762,7 +2759,6 @@ export const ReadSkillFileError: Story = {
 	args: {
 		name: "read_skill_file",
 		status: "error",
-		isError: true,
 		args: { name: "deep-review", path: "missing-file.md" },
 		result: { error: "file not found" },
 	},
@@ -2852,7 +2848,6 @@ export const StartWorkspaceError: Story = {
 	args: {
 		name: "start_workspace",
 		status: "error",
-		isError: true,
 		result: {
 			error: "workspace was deleted; use create_workspace to make a new one",
 		},
@@ -3060,7 +3055,6 @@ export const CreateWorkspaceError: Story = {
 	args: {
 		name: "create_workspace",
 		status: "error",
-		isError: true,
 		result: {
 			error: "template not found",
 		},
@@ -3122,7 +3116,6 @@ export const AllToolIconsTranscript: Story = {
 							status={tool.status ?? "completed"}
 							args={tool.args}
 							result={tool.result}
-							isError={tool.isError}
 							killedBySignal={tool.killedBySignal}
 							modelIntent={tool.modelIntent}
 							parsedCommands={tool.parsedCommands}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -654,9 +654,7 @@ const AdvisorRenderer: FC<ToolRendererProps> = ({ args, status, result }) => {
 				: undefined;
 	const errorMessage =
 		(rec ? asString(rec.error || rec.message) : "") ||
-		(typeof result === "string" && (hasError || resolvedResultType === "error")
-			? result
-			: "");
+		(typeof result === "string" && hasError ? result : "");
 	const advisorModel = rec ? asString(rec.advisor_model) : "";
 	const remainingUses = rec
 		? asNumber(rec.remaining_uses, { parseString: true })
@@ -666,7 +664,9 @@ const AdvisorRenderer: FC<ToolRendererProps> = ({ args, status, result }) => {
 		<AdvisorTool
 			question={question}
 			status={foldResultFailure(status, resolvedResultType === "error")}
-			resultType={resolvedResultType}
+			resultType={
+				resolvedResultType === "error" ? undefined : resolvedResultType
+			}
 			advice={advice}
 			errorMessage={errorMessage || undefined}
 			advisorModel={advisorModel || undefined}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -40,7 +40,6 @@ import {
 	asString,
 	buildEditDiff,
 	DIFFS_FONT_STYLE,
-	foldResultFailure,
 	formatModelIntentLabel,
 	formatResultOutput,
 	formatToolInput,
@@ -373,7 +372,7 @@ const CreateWorkspaceRenderer: FC<ToolRendererProps> = ({ status, result }) => {
 		<CreateWorkspaceTool
 			workspaceName={wsName}
 			resultJson={resultJson}
-			status={foldResultFailure(status, Boolean(rec?.error))}
+			status={rec?.error ? "error" : status}
 			errorMessage={rec ? asString(rec.error || rec.reason) : undefined}
 			buildId={buildId}
 			created={created}
@@ -663,7 +662,7 @@ const AdvisorRenderer: FC<ToolRendererProps> = ({ args, status, result }) => {
 	return (
 		<AdvisorTool
 			question={question}
-			status={foldResultFailure(status, resolvedResultType === "error")}
+			status={resolvedResultType === "error" ? "error" : status}
 			resultType={
 				resolvedResultType === "error" ? undefined : resolvedResultType
 			}
@@ -901,7 +900,7 @@ const ProcessSignalRenderer: FC<ToolRendererProps> = (props) => {
 	return (
 		<GenericToolRenderer
 			{...props}
-			status={foldResultFailure(props.status, rec !== null && !rec.success)}
+			status={rec !== null && !rec.success ? "error" : props.status}
 		/>
 	);
 };
@@ -915,7 +914,7 @@ const StartWorkspaceRenderer: FC<ToolRendererProps> = ({ status, result }) => {
 
 	return (
 		<StartWorkspaceTool
-			status={foldResultFailure(status, Boolean(rec?.error))}
+			status={rec?.error ? "error" : status}
 			buildId={buildId}
 			workspaceName={wsName}
 			errorMessage={rec ? asString(rec.error || rec.reason) : undefined}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -49,7 +49,6 @@ import {
 	getFileViewerOptionsNoHeader,
 	getWriteFileDiff,
 	humanizeMCPToolName,
-	isSubagentSuccessStatus,
 	mapSubagentStatusToToolStatus,
 	parseArgs,
 	parseEditFilesArgs,
@@ -439,14 +438,10 @@ const SubagentRenderer: FC<ToolRendererProps> = ({
 	if (rawTitle) {
 		title = rawTitle;
 	}
-	const subagentCompleted = isSubagentSuccessStatus(subagentStatus);
-	// The tool-call status is authoritative for failure: a failed
-	// spawn/await call is finished, even when the result body's
-	// sub-agent snapshot still reports the sub-agent as active.
-	const subagentToolStatus: ToolStatus =
-		status === "error" && !subagentCompleted
-			? "error"
-			: mapSubagentStatusToToolStatus(subagentStatus, status);
+	const subagentToolStatus = mapSubagentStatusToToolStatus(
+		subagentStatus,
+		status,
+	);
 	const subagentFailed = subagentToolStatus === "error";
 
 	// Detect timeout from the result. A timed-out wait_agent
@@ -900,12 +895,6 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 		</ToolCall.Root>
 	);
 };
-
-// ---------------------------------------------------------------------------
-// process_signal reports failures as success=false in the result body rather
-// than as a protocol error, so fold that into the status for the generic
-// renderer.
-// ---------------------------------------------------------------------------
 
 const ProcessSignalRenderer: FC<ToolRendererProps> = (props) => {
 	const rec = asRecord(props.result);

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -658,14 +658,15 @@ const AdvisorRenderer: FC<ToolRendererProps> = ({ args, status, result }) => {
 	const remainingUses = rec
 		? asNumber(rec.remaining_uses, { parseString: true })
 		: undefined;
+	// A streamed advice delta can partially parse as an error envelope, so
+	// only a settled call counts as failed.
+	const advisorFailed = resolvedResultType === "error";
 
 	return (
 		<AdvisorTool
 			question={question}
-			status={resolvedResultType === "error" ? "error" : status}
-			resultType={
-				resolvedResultType === "error" ? undefined : resolvedResultType
-			}
+			status={advisorFailed && status !== "running" ? "error" : status}
+			resultType={advisorFailed ? undefined : resolvedResultType}
 			advice={advice}
 			errorMessage={errorMessage || undefined}
 			advisorModel={advisorModel || undefined}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -40,6 +40,7 @@ import {
 	asString,
 	buildEditDiff,
 	DIFFS_FONT_STYLE,
+	foldResultFailure,
 	formatModelIntentLabel,
 	formatResultOutput,
 	formatToolInput,
@@ -64,7 +65,6 @@ interface ToolProps extends Omit<ComponentPropsWithRef<"div">, "children"> {
 	status?: ToolStatus;
 	args?: unknown;
 	result?: unknown;
-	isError?: boolean;
 	killedBySignal?: "kill" | "terminate";
 	/** Maps sub-agent chat IDs to their titles, built from transcript metadata. */
 	subagentTitles?: Map<string, string>;
@@ -99,7 +99,6 @@ type ToolRendererProps = {
 	status: ToolStatus;
 	args: unknown;
 	result: unknown;
-	isError: boolean;
 	killedBySignal?: "kill" | "terminate";
 	subagentTitles?: Map<string, string>;
 	subagentVariants?: Map<string, SubagentVariant>;
@@ -215,7 +214,6 @@ const ExecuteRenderer: FC<ToolRendererProps> = ({
 	status,
 	args,
 	result,
-	isError,
 	killedBySignal,
 	modelIntent,
 	parsedCommands,
@@ -227,7 +225,6 @@ const ExecuteRenderer: FC<ToolRendererProps> = ({
 			command={data.command}
 			transcriptBlocks={data.transcriptBlocks}
 			status={status}
-			isError={isError}
 			errorText={data.errorText}
 			durationMs={data.durationMs}
 			isBackgrounded={data.isBackgrounded}
@@ -242,7 +239,6 @@ const ExecuteRenderer: FC<ToolRendererProps> = ({
 const ProcessOutputRenderer: FC<ToolRendererProps> = ({
 	status,
 	result,
-	isError,
 	killedBySignal,
 	shellToolDisplayMode,
 }) => {
@@ -256,9 +252,8 @@ const ProcessOutputRenderer: FC<ToolRendererProps> = ({
 	return (
 		<ProcessOutputTool
 			output={output}
-			isRunning={status === "running"}
+			status={status}
 			exitCode={exitCode}
-			isError={isError}
 			errorMessage={errorMessage || undefined}
 			killedBySignal={killedBySignal}
 			shellToolDisplayMode={shellToolDisplayMode}
@@ -266,24 +261,11 @@ const ProcessOutputRenderer: FC<ToolRendererProps> = ({
 	);
 };
 
-const ReadFileRenderer: FC<ToolRendererProps> = ({
-	status,
-	args,
-	result,
-	isError,
-}) => (
-	<ReadFileTool
-		{...getReadFileToolData({ args, result, isError })}
-		status={status}
-	/>
+const ReadFileRenderer: FC<ToolRendererProps> = ({ status, args, result }) => (
+	<ReadFileTool {...getReadFileToolData({ args, result })} status={status} />
 );
 
-const ReadSkillRenderer: FC<ToolRendererProps> = ({
-	status,
-	args,
-	result,
-	isError,
-}) => {
+const ReadSkillRenderer: FC<ToolRendererProps> = ({ status, args, result }) => {
 	const parsedArgs = parseArgs(args);
 	const skillName = parsedArgs ? asString(parsedArgs.name) : "";
 	const rec = asRecord(result);
@@ -294,7 +276,6 @@ const ReadSkillRenderer: FC<ToolRendererProps> = ({
 			label={skillName ? `skill ${skillName}` : "skill"}
 			body={body}
 			status={status}
-			isError={isError}
 			errorMessage={rec ? asString(rec.error || rec.message) : undefined}
 		/>
 	);
@@ -304,7 +285,6 @@ const ReadSkillFileRenderer: FC<ToolRendererProps> = ({
 	status,
 	args,
 	result,
-	isError,
 }) => {
 	const parsedArgs = parseArgs(args);
 	const skillName = parsedArgs ? asString(parsedArgs.name) : "";
@@ -321,7 +301,6 @@ const ReadSkillFileRenderer: FC<ToolRendererProps> = ({
 			label={label}
 			body={content}
 			status={status}
-			isError={isError}
 			errorMessage={rec ? asString(rec.error || rec.message) : undefined}
 		/>
 	);
@@ -331,7 +310,6 @@ const WriteFileRenderer: FC<ToolRendererProps> = ({
 	status,
 	args,
 	result,
-	isError,
 	codeDiffDisplayMode,
 }) => {
 	const parsedArgs = parseArgs(args);
@@ -344,7 +322,6 @@ const WriteFileRenderer: FC<ToolRendererProps> = ({
 			path={path || "file"}
 			diff={writeFileDiff}
 			status={status}
-			isError={isError}
 			errorMessage={rec ? asString(rec.error || rec.message) : undefined}
 			codeDiffDisplayMode={codeDiffDisplayMode}
 		/>
@@ -355,7 +332,6 @@ const EditFilesRenderer: FC<ToolRendererProps> = ({
 	status,
 	args,
 	result,
-	isError,
 	codeDiffDisplayMode,
 }) => {
 	const rec = asRecord(result);
@@ -363,21 +339,21 @@ const EditFilesRenderer: FC<ToolRendererProps> = ({
 	// On error, render no diff: the agent rejected the edit, so a
 	// synthetic args-derived diff would misrepresent it as applied.
 	const serverResults = parseServerEditResults(result);
-	const editDiffs = isError
-		? editFiles.map(() => null)
-		: editFiles.map((file) => {
-				const entry = serverResults?.find((d) => d.path === file.path);
-				return entry
-					? parseServerEditDiffText(entry.diff)
-					: buildEditDiff(file.path, file.edits);
-			});
+	const editDiffs =
+		status === "error"
+			? editFiles.map(() => null)
+			: editFiles.map((file) => {
+					const entry = serverResults?.find((d) => d.path === file.path);
+					return entry
+						? parseServerEditDiffText(entry.diff)
+						: buildEditDiff(file.path, file.edits);
+				});
 
 	return (
 		<EditFilesTool
 			files={editFiles}
 			diffs={editDiffs}
 			status={status}
-			isError={isError}
 			errorMessage={rec ? asString(rec.error || rec.message) : undefined}
 			codeDiffDisplayMode={codeDiffDisplayMode}
 		/>
@@ -386,16 +362,11 @@ const EditFilesRenderer: FC<ToolRendererProps> = ({
 
 // Once the tool finishes, the result becomes a JSON object
 // with workspace metadata.
-const CreateWorkspaceRenderer: FC<ToolRendererProps> = ({
-	status,
-	result,
-	isError,
-}) => {
+const CreateWorkspaceRenderer: FC<ToolRendererProps> = ({ status, result }) => {
 	const rec = asRecord(result);
 	const wsName = rec ? asString(rec.workspace_name) : "";
 	const buildId = rec ? asString(rec.build_id) : undefined;
 	const resultJson = rec ? JSON.stringify(rec, null, 2) : "";
-	const hasErrorInResult = Boolean(rec?.error);
 	const created = rec?.created !== false;
 	const quotaTitle = getWorkspaceQuotaTitle(rec);
 
@@ -403,8 +374,7 @@ const CreateWorkspaceRenderer: FC<ToolRendererProps> = ({
 		<CreateWorkspaceTool
 			workspaceName={wsName}
 			resultJson={resultJson}
-			status={status}
-			isError={isError || hasErrorInResult}
+			status={foldResultFailure(status, Boolean(rec?.error))}
 			errorMessage={rec ? asString(rec.error || rec.reason) : undefined}
 			buildId={buildId}
 			created={created}
@@ -418,7 +388,6 @@ const SubagentRenderer: FC<ToolRendererProps> = ({
 	status,
 	args,
 	result,
-	isError,
 	subagentTitles,
 	subagentVariants,
 	showDesktopPreviews = true,
@@ -471,17 +440,14 @@ const SubagentRenderer: FC<ToolRendererProps> = ({
 		title = rawTitle;
 	}
 	const subagentCompleted = isSubagentSuccessStatus(subagentStatus);
-	const subagentToolStatus = mapSubagentStatusToToolStatus(
-		subagentStatus,
-		status,
-	);
-	let subagentIsError = subagentToolStatus === "error";
-	if (!subagentIsError) {
-		const toolFailed = status === "error" || isError;
-		if (toolFailed && !subagentCompleted) {
-			subagentIsError = true;
-		}
-	}
+	// The tool-call status is authoritative for failure: a failed
+	// spawn/await call is finished, even when the result body's
+	// sub-agent snapshot still reports the sub-agent as active.
+	const subagentToolStatus: ToolStatus =
+		status === "error" && !subagentCompleted
+			? "error"
+			: mapSubagentStatusToToolStatus(subagentStatus, status);
+	const subagentFailed = subagentToolStatus === "error";
 
 	// Detect timeout from the result. A timed-out wait_agent
 	// returns a structured payload with timed_out: true
@@ -491,7 +457,7 @@ const SubagentRenderer: FC<ToolRendererProps> = ({
 	let isTimeout = false;
 	if (rec && rec.timed_out === true) {
 		isTimeout = true;
-	} else if (subagentIsError) {
+	} else if (subagentFailed) {
 		const timedOutInResult = resultStr.toLowerCase().includes("timed out");
 		const timedOutInError = errorStr.toLowerCase().includes("timed out");
 		if (timedOutInResult || timedOutInError) {
@@ -509,7 +475,6 @@ const SubagentRenderer: FC<ToolRendererProps> = ({
 			message={subagentMessage || undefined}
 			report={chatId ? report || undefined : undefined}
 			toolStatus={subagentToolStatus}
-			isError={subagentIsError}
 			isTimeout={isTimeout}
 			showDesktopPreview={
 				Boolean(chatId) &&
@@ -522,11 +487,7 @@ const SubagentRenderer: FC<ToolRendererProps> = ({
 	);
 };
 
-const ListTemplatesRenderer: FC<ToolRendererProps> = ({
-	status,
-	result,
-	isError,
-}) => {
+const ListTemplatesRenderer: FC<ToolRendererProps> = ({ status, result }) => {
 	const rec = asRecord(result);
 	const templates = rec && Array.isArray(rec.templates) ? rec.templates : [];
 	const count = rec
@@ -538,17 +499,12 @@ const ListTemplatesRenderer: FC<ToolRendererProps> = ({
 			templates={templates}
 			count={count}
 			status={status}
-			isError={isError}
 			errorMessage={rec ? asString(rec.error || rec.message) : undefined}
 		/>
 	);
 };
 
-const ListAgentsRenderer: FC<ToolRendererProps> = ({
-	status,
-	result,
-	isError,
-}) => {
+const ListAgentsRenderer: FC<ToolRendererProps> = ({ status, result }) => {
 	const rec = asRecord(result);
 	const agents = rec && Array.isArray(rec.agents) ? rec.agents : [];
 	const total = rec
@@ -560,11 +516,10 @@ const ListAgentsRenderer: FC<ToolRendererProps> = ({
 			agents={agents}
 			total={total}
 			status={status}
-			isError={isError}
 			errorMessage={
 				rec
 					? asString(rec.error || rec.message)
-					: typeof result === "string" && isError
+					: typeof result === "string" && status === "error"
 						? result
 						: undefined
 			}
@@ -572,11 +527,7 @@ const ListAgentsRenderer: FC<ToolRendererProps> = ({
 	);
 };
 
-const ReadTemplateRenderer: FC<ToolRendererProps> = ({
-	status,
-	result,
-	isError,
-}) => {
+const ReadTemplateRenderer: FC<ToolRendererProps> = ({ status, result }) => {
 	const rec = asRecord(result);
 	const templateRec = rec ? asRecord(rec.template) : undefined;
 	const name = templateRec
@@ -587,7 +538,6 @@ const ReadTemplateRenderer: FC<ToolRendererProps> = ({
 		<ReadTemplateTool
 			templateName={name}
 			status={status}
-			isError={isError}
 			errorMessage={rec ? asString(rec.error || rec.message) : undefined}
 		/>
 	);
@@ -597,7 +547,6 @@ const ChatSummarizedRenderer: FC<ToolRendererProps> = ({
 	status,
 	args,
 	result,
-	isError,
 }) => {
 	const rec = asRecord(result);
 	const summary =
@@ -614,7 +563,6 @@ const ChatSummarizedRenderer: FC<ToolRendererProps> = ({
 		<ChatSummarizedTool
 			summary={summary}
 			status={status}
-			isError={isError}
 			errorMessage={rec ? asString(rec.error || rec.message) : undefined}
 			source={source || undefined}
 		/>
@@ -625,7 +573,6 @@ const AskUserQuestionRenderer: FC<ToolRendererProps> = ({
 	args,
 	status,
 	result,
-	isError,
 	onSendAskUserQuestionResponse,
 	isChatCompleted,
 	isLatestAskUserQuestion,
@@ -646,13 +593,12 @@ const AskUserQuestionRenderer: FC<ToolRendererProps> = ({
 	const errorMessage =
 		(resultRecord
 			? asString(resultRecord.error || resultRecord.message)
-			: "") || (typeof result === "string" && isError ? result : "");
+			: "") || (typeof result === "string" && status === "error" ? result : "");
 
 	return (
 		<AskUserQuestionTool
 			questions={questions}
 			status={status}
-			isError={isError}
 			errorMessage={errorMessage || undefined}
 			onSubmitAnswer={onSendAskUserQuestionResponse}
 			isChatCompleted={isChatCompleted}
@@ -666,7 +612,6 @@ const ProposePlanRenderer: FC<ToolRendererProps> = ({
 	args,
 	status,
 	result,
-	isError,
 	onImplementPlan,
 }) => {
 	const parsedArgs = parseArgs(args);
@@ -674,10 +619,11 @@ const ProposePlanRenderer: FC<ToolRendererProps> = ({
 	const rec = asRecord(result);
 	const content = rec && "content" in rec ? asString(rec.content) : undefined;
 	const fileID = rec && "file_id" in rec ? asString(rec.file_id) : undefined;
-	const errorMessage = isError
-		? (rec ? asString(rec.error || rec.message) : undefined) ||
-			(typeof result === "string" ? result : undefined)
-		: undefined;
+	const errorMessage =
+		status === "error"
+			? (rec ? asString(rec.error || rec.message) : undefined) ||
+				(typeof result === "string" ? result : undefined)
+			: undefined;
 
 	return (
 		<ProposePlanTool
@@ -685,24 +631,18 @@ const ProposePlanRenderer: FC<ToolRendererProps> = ({
 			fileID={fileID}
 			path={path}
 			status={status}
-			isError={isError}
 			errorMessage={errorMessage}
 			onImplementPlan={onImplementPlan}
 		/>
 	);
 };
 
-const AdvisorRenderer: FC<ToolRendererProps> = ({
-	args,
-	status,
-	result,
-	isError,
-}) => {
+const AdvisorRenderer: FC<ToolRendererProps> = ({ args, status, result }) => {
 	const parsedArgs = parseArgs(args);
 	const question = parsedArgs ? asString(parsedArgs.question) : "";
 	const rec = asRecord(result);
 	const rawResultType = rec ? asString(rec.type) : "";
-	const hasError = status === "error" || isError;
+	const hasError = status === "error";
 	const advice = rec
 		? asString(rec.advice)
 		: typeof result === "string" && !hasError
@@ -730,8 +670,7 @@ const AdvisorRenderer: FC<ToolRendererProps> = ({
 	return (
 		<AdvisorTool
 			question={question}
-			status={status}
-			isError={hasError}
+			status={foldResultFailure(status, resolvedResultType === "error")}
 			resultType={resolvedResultType}
 			advice={advice}
 			errorMessage={errorMessage || undefined}
@@ -741,11 +680,7 @@ const AdvisorRenderer: FC<ToolRendererProps> = ({
 	);
 };
 
-const ComputerRenderer: FC<ToolRendererProps> = ({
-	status,
-	result,
-	isError,
-}) => {
+const ComputerRenderer: FC<ToolRendererProps> = ({ status, result }) => {
 	let imageData = "";
 	let mimeType = "image/png";
 	let text = "";
@@ -798,7 +733,6 @@ const ComputerRenderer: FC<ToolRendererProps> = ({
 			mimeType={mimeType}
 			text={text}
 			status={status}
-			isError={isError}
 		/>
 	);
 };
@@ -900,7 +834,6 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 	status,
 	args,
 	result,
-	isError,
 	mcpServerConfigId,
 	mcpServers,
 	modelIntent,
@@ -935,7 +868,6 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 	return (
 		<ToolCall.Root
 			status={status}
-			isError={isError}
 			errorMessage={errorMessage || fallbackErrorMessage}
 			hasContent={hasContent}
 		>
@@ -970,41 +902,33 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 };
 
 // ---------------------------------------------------------------------------
-// process_signal promotes soft failures (success=false
-// in the result body, isError=false at protocol level) so the generic
-// renderer shows the error indicator and tooltip.
+// process_signal reports failures as success=false in the result body rather
+// than as a protocol error, so fold that into the status for the generic
+// renderer.
 // ---------------------------------------------------------------------------
 
 const ProcessSignalRenderer: FC<ToolRendererProps> = (props) => {
 	const rec = asRecord(props.result);
-	const isSoftFailure =
-		!props.isError &&
-		props.status !== "running" &&
-		rec !== null &&
-		!rec.success;
 	return (
-		<GenericToolRenderer {...props} isError={props.isError || isSoftFailure} />
+		<GenericToolRenderer
+			{...props}
+			status={foldResultFailure(props.status, rec !== null && !rec.success)}
+		/>
 	);
 };
 
-const StartWorkspaceRenderer: FC<ToolRendererProps> = ({
-	status,
-	result,
-	isError,
-}) => {
+const StartWorkspaceRenderer: FC<ToolRendererProps> = ({ status, result }) => {
 	const rec = asRecord(result);
 	const wsName = rec ? asString(rec.workspace_name) : "";
 	const buildId = rec ? asString(rec.build_id) : undefined;
-	const hasErrorInResult = Boolean(rec?.error);
 	const noBuild = Boolean(rec?.no_build);
 	const quotaTitle = getWorkspaceQuotaTitle(rec);
 
 	return (
 		<StartWorkspaceTool
-			status={status}
+			status={foldResultFailure(status, Boolean(rec?.error))}
 			buildId={buildId}
 			workspaceName={wsName}
-			isError={isError || hasErrorInResult}
 			errorMessage={rec ? asString(rec.error || rec.reason) : undefined}
 			noBuild={noBuild}
 			labelOverride={quotaTitle}
@@ -1048,7 +972,6 @@ export const Tool = memo(
 		status = "completed",
 		args,
 		result,
-		isError = false,
 		killedBySignal,
 		subagentTitles,
 		subagentVariants,
@@ -1093,7 +1016,6 @@ export const Tool = memo(
 					status={status}
 					args={args}
 					result={result}
-					isError={isError}
 					killedBySignal={killedBySignal}
 					subagentTitles={subagentTitles}
 					subagentVariants={subagentVariants}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.stories.tsx
@@ -51,7 +51,6 @@ export const Failed: Story = {
 	render: () => (
 		<ToolCall.Root
 			status="error"
-			isError
 			errorMessage="Failed to read file"
 			hasContent={false}
 		>
@@ -66,29 +65,6 @@ export const Failed: Story = {
 		).toBeVisible();
 		expect(
 			canvas.queryByRole("img", { name: "Tool call running" }),
-		).not.toBeInTheDocument();
-	},
-};
-
-export const RunningWithBackendError: Story = {
-	render: () => (
-		<ToolCall.Root
-			status="running"
-			isError
-			errorMessage="Failed to read file"
-			hasContent={false}
-		>
-			<ToolCall.Header iconName="read_file" label="Reading README.md" />
-		</ToolCall.Root>
-	),
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(canvas.getByText("Reading README.md")).toBeVisible();
-		expect(
-			canvas.getByRole("img", { name: "Tool call running" }),
-		).toBeVisible();
-		expect(
-			canvas.queryByRole("img", { name: "Failed to read file" }),
 		).not.toBeInTheDocument();
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.stories.tsx
@@ -69,6 +69,29 @@ export const Failed: Story = {
 	},
 };
 
+export const RunningWithErrorCopy: Story = {
+	render: () => (
+		<ToolCall.Root
+			status="running"
+			errorMessage="Failed to read file"
+			hasContent={false}
+		>
+			<ToolCall.Header iconName="read_file" label="Reading README.md" />
+		</ToolCall.Root>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// Every caller passes `errorMessage` as fallback copy regardless of
+		// outcome. Only `status` decides whether the row reads as failed.
+		expect(
+			canvas.getByRole("img", { name: "Tool call running" }),
+		).toBeVisible();
+		expect(
+			canvas.queryByRole("img", { name: "Failed to read file" }),
+		).not.toBeInTheDocument();
+	},
+};
+
 export const Collapsible: Story = {
 	render: () => (
 		<ToolCall.Root

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.tsx
@@ -71,7 +71,6 @@ const useToolCallContext = () => {
 type ToolCallRootProps = Omit<ComponentPropsWithoutRef<"div">, "children"> & {
 	children: ReactNode;
 	status: ToolStatus;
-	isError?: boolean;
 	errorMessage?: string;
 	hasContent?: boolean;
 	defaultExpanded?: boolean;
@@ -93,7 +92,6 @@ type ToolCallRootProps = Omit<ComponentPropsWithoutRef<"div">, "children"> & {
 const Root: FC<ToolCallRootProps> = ({
 	children,
 	status,
-	isError = false,
 	errorMessage,
 	hasContent = true,
 	defaultExpanded = false,
@@ -120,7 +118,7 @@ const Root: FC<ToolCallRootProps> = ({
 	const expanded = view !== "collapsed";
 	const collapsible = hasContent;
 	const active = status === "running";
-	const failed = status !== "running" && (isError || status === "error");
+	const failed = status === "error";
 	const onToggle = () => {
 		const nextView: ToolCallView = expanded ? "collapsed" : "expanded";
 		if (controlledView === undefined) {

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/WriteFileTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/WriteFileTool.tsx
@@ -25,14 +25,14 @@ export const WriteFileTool: React.FC<{
 	path: string;
 	diff: FileDiffMetadata | null;
 	status: ToolStatus;
-	isError: boolean;
 	errorMessage?: string;
 	codeDiffDisplayMode?: TypesGen.AgentDisplayMode;
-}> = ({ path, diff, status, isError, errorMessage, codeDiffDisplayMode }) => {
+}> = ({ path, diff, status, errorMessage, codeDiffDisplayMode }) => {
 	const theme = useTheme();
 	const isDark = theme.palette.mode === "dark";
 	const hasDiff = diff !== null;
 	const isRunning = status === "running";
+	const isError = status === "error";
 	const displayState = resolveAgentDisplayState(
 		codeDiffDisplayMode,
 		WRITE_FILE_AUTO_DISPLAY_STATE,
@@ -55,7 +55,6 @@ export const WriteFileTool: React.FC<{
 			key={`${codeDiffDisplayMode ?? "auto"}:${WRITE_FILE_AUTO_DISPLAY_STATE}`}
 			className="w-full"
 			status={status}
-			isError={isError}
 			errorMessage={errorMessage || "Failed to write file"}
 			hasContent={showDiff || Boolean(errorDetail)}
 			defaultView={displayState}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
@@ -190,11 +190,24 @@ describe("mapSubagentStatusToToolStatus", () => {
 		);
 	});
 
-	it("maps running statuses to running when fallback is not completed", () => {
+	it("maps running statuses to running when the call has not failed", () => {
 		expect(mapSubagentStatusToToolStatus("pending", "running")).toBe("running");
-		expect(mapSubagentStatusToToolStatus("running", "error")).toBe("running");
 		expect(mapSubagentStatusToToolStatus("awaiting", "running")).toBe(
 			"running",
+		);
+	});
+
+	it("keeps a failed call failed even with a running subagent status", () => {
+		// The snapshot describes the sub-agent, not the call. A failed
+		// spawn/await call is finished, so it cannot read as running.
+		expect(mapSubagentStatusToToolStatus("running", "error")).toBe("error");
+	});
+
+	it("prefers a successful snapshot over a failed call", () => {
+		// Pins guard order: the success check must run before the
+		// failed-call check.
+		expect(mapSubagentStatusToToolStatus("completed", "error")).toBe(
+			"completed",
 		);
 	});
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
@@ -7,7 +7,6 @@ import {
 	DIFFS_FONT_STYLE,
 	diffViewerCSS,
 	fileViewerCSS,
-	foldResultFailure,
 	formatModelIntentLabel,
 	formatResultOutput,
 	formatShellDurationMs,
@@ -116,22 +115,6 @@ describe("normalizeStatus", () => {
 
 	it("handles empty string", () => {
 		expect(normalizeStatus("")).toBe("");
-	});
-});
-
-describe("foldResultFailure", () => {
-	it("promotes a completed call whose result body failed", () => {
-		expect(foldResultFailure("completed", true)).toBe("error");
-	});
-
-	it("leaves a running call running even when the body already failed", () => {
-		expect(foldResultFailure("running", true)).toBe("running");
-	});
-
-	it("passes the status through when the result body did not fail", () => {
-		expect(foldResultFailure("completed", false)).toBe("completed");
-		expect(foldResultFailure("running", false)).toBe("running");
-		expect(foldResultFailure("error", false)).toBe("error");
 	});
 });
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
@@ -7,6 +7,7 @@ import {
 	DIFFS_FONT_STYLE,
 	diffViewerCSS,
 	fileViewerCSS,
+	foldResultFailure,
 	formatModelIntentLabel,
 	formatResultOutput,
 	formatShellDurationMs,
@@ -115,6 +116,22 @@ describe("normalizeStatus", () => {
 
 	it("handles empty string", () => {
 		expect(normalizeStatus("")).toBe("");
+	});
+});
+
+describe("foldResultFailure", () => {
+	it("promotes a completed call whose result body failed", () => {
+		expect(foldResultFailure("completed", true)).toBe("error");
+	});
+
+	it("leaves a running call running even when the body already failed", () => {
+		expect(foldResultFailure("running", true)).toBe("running");
+	});
+
+	it("passes the status through when the result body did not fail", () => {
+		expect(foldResultFailure("completed", false)).toBe("completed");
+		expect(foldResultFailure("running", false)).toBe("running");
+		expect(foldResultFailure("error", false)).toBe("error");
 	});
 });
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
@@ -176,7 +176,7 @@ describe("isSubagentRunningStatus", () => {
 });
 
 describe("mapSubagentStatusToToolStatus", () => {
-	it("returns fallback for empty status", () => {
+	it("returns the call status for empty subagent status", () => {
 		expect(mapSubagentStatusToToolStatus("", "running")).toBe("running");
 		expect(mapSubagentStatusToToolStatus("  ", "error")).toBe("error");
 	});
@@ -211,7 +211,7 @@ describe("mapSubagentStatusToToolStatus", () => {
 		);
 	});
 
-	it("preserves completed fallback even with running subagent status", () => {
+	it("preserves a completed call even with running subagent status", () => {
 		expect(mapSubagentStatusToToolStatus("pending", "completed")).toBe(
 			"completed",
 		);
@@ -247,7 +247,7 @@ describe("mapSubagentStatusToToolStatus", () => {
 		expect(mapSubagentStatusToToolStatus("error", "running")).toBe("error");
 	});
 
-	it("returns fallback for unknown statuses", () => {
+	it("returns the call status for unknown subagent statuses", () => {
 		expect(mapSubagentStatusToToolStatus("unknown-status", "running")).toBe(
 			"running",
 		);

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
@@ -131,6 +131,17 @@ export const formatShellDurationMs = (
 export const normalizeStatus = (status: string): string =>
 	status.trim().toLowerCase();
 
+/**
+ * Folds a failure that is only visible in the tool result body (or in a
+ * follow-up fetch) into the tool status, so `status` stays the single
+ * representation of failure. A running call stays running: its partial
+ * result body can already carry error fields.
+ */
+export const foldResultFailure = (
+	status: ToolStatus,
+	failedInResult: boolean,
+): ToolStatus => (status === "running" || !failedInResult ? status : "error");
+
 export const isSubagentSuccessStatus = (status: string): boolean => {
 	switch (normalizeStatus(status)) {
 		case "completed":

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
@@ -132,10 +132,10 @@ export const normalizeStatus = (status: string): string =>
 	status.trim().toLowerCase();
 
 /**
- * Folds a failure that is only visible in the tool result body (or in a
- * follow-up fetch) into the tool status, so `status` stays the single
- * representation of failure. A running call stays running: its partial
- * result body can already carry error fields.
+ * Folds a failure the tool reports in-band (an `error` field or
+ * `success: false` in the result body) into its status. A running call stays
+ * running: only the advisor streams a partial result body, so a mid-stream
+ * body that parses as a failure is noise rather than a verdict.
  */
 export const foldResultFailure = (
 	status: ToolStatus,
@@ -173,6 +173,11 @@ export const mapSubagentStatusToToolStatus = (
 	}
 	if (isSubagentSuccessStatus(normalized)) {
 		return "completed";
+	}
+	if (fallback === "error") {
+		// A failed call is finished, so a stale snapshot cannot put the row
+		// back into a running state.
+		return "error";
 	}
 	if (isSubagentRunningStatus(normalized)) {
 		// If the tool call itself has already completed, don't

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
@@ -131,17 +131,6 @@ export const formatShellDurationMs = (
 export const normalizeStatus = (status: string): string =>
 	status.trim().toLowerCase();
 
-/**
- * Folds a failure the tool reports in-band (an `error` field or
- * `success: false` in the result body) into its status. A running call stays
- * running: only the advisor streams a partial result body, so a mid-stream
- * body that parses as a failure is noise rather than a verdict.
- */
-export const foldResultFailure = (
-	status: ToolStatus,
-	failedInResult: boolean,
-): ToolStatus => (status === "running" || !failedInResult ? status : "error");
-
 export const isSubagentSuccessStatus = (status: string): boolean => {
 	switch (normalizeStatus(status)) {
 		case "completed":

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
@@ -165,16 +165,16 @@ export const isSubagentRunningStatus = (status: string): boolean => {
 
 export const mapSubagentStatusToToolStatus = (
 	subagentStatus: string,
-	fallback: ToolStatus,
+	callStatus: ToolStatus,
 ): ToolStatus => {
 	const normalized = normalizeStatus(subagentStatus);
 	if (!normalized) {
-		return fallback;
+		return callStatus;
 	}
 	if (isSubagentSuccessStatus(normalized)) {
 		return "completed";
 	}
-	if (fallback === "error") {
+	if (callStatus === "error") {
 		// A failed call is finished, so a stale snapshot cannot put the row
 		// back into a running state.
 		return "error";
@@ -184,7 +184,7 @@ export const mapSubagentStatusToToolStatus = (
 		// override to "running". The spawn/await tool is done;
 		// the sub-agent may still be working in the background
 		// but that doesn't mean the tool call is still running.
-		return fallback === "completed" ? "completed" : "running";
+		return callStatus === "completed" ? "completed" : "running";
 	}
 	switch (normalized) {
 		case "waiting":
@@ -193,7 +193,7 @@ export const mapSubagentStatusToToolStatus = (
 		case "error":
 			return "error";
 		default:
-			return fallback;
+			return callStatus;
 	}
 };
 


### PR DESCRIPTION
> **#27587 is stacked on this.** Merge this first; that one holds the advisor streaming display fix.

Failure is currently spelled twice on every tool row: `MergedTool.status === "error"` and a separate `MergedTool.isError` boolean. Both producers compute the same discriminant, so `{ status: "running", isError: true }` is representable, and `streamState.ts` used to produce exactly that. This drops `isError` and makes `status` the only failure signal.

Every leaf component stops taking the pair. Where a renderer needs to know a call failed, it derives it locally with one line, `const isError = status === "error"`, at the boundary where the result body is already in hand.

## Behaviour

No user-visible change. Every label, icon and error message renders as before, including the `Failed to run`, `Failed to write` and `Failed to edit` labels and the `errorText` detail from #27430.

One reachable state stops being representable: a running call that also claims to have failed. `getStreamToolStatus` returned `"running"` while `isError` stayed `true` for a result part that arrived before its call, so a live row could show a spinner and a failure triangle at once.

## Result-body failures

Several renderers treated "the result payload contains an error" as the same fact as "the call failed". Those stay distinct, and each collapses into the status at its own boundary with one ternary rather than a second prop:

- `AdvisorTool` keeps its result classification but no longer receives failure twice. The prop is narrowed to `Exclude<AdvisorToolResultType, "error">` so it cannot.
- A streaming advisor call is never treated as failed. The partial JSON parser returns an object as soon as one key is complete, so advice prose that opens with a JSON object can read as `{type: "error"}` mid-stream. Only a settled call can fail.
- `ProcessOutputTool`, `ReadFileTool`, `CreateWorkspaceTool`, `WriteFileTool`, `EditFilesTool` and `ExecuteTool` each derive failure from the status they already receive.

`ExecuteTool`'s `getShellCommandLine` took both `isRunning` and `isError` to decide the `Failed to run` label. A single status cannot be both, so it now takes one `isError`.

## Deferred, with evidence

Four findings from the previous review round belong to the per-component outcome unions, not here, and are recorded so they are not lost:

- `ProposePlanTool` conflates "the tool failed" with "we could not fetch the tool's output". A plan-body 404 marks a successful call failed, and the header then reads "Proposed PLAN.md" in past tense on a row marked failed. Both predate this series: base rendered the same state through `isError={effectiveError}`, and the effective status was `"running"` iff the raw status was. The fix is a third arm on a `source` union, not an error arm.
- `mapSubagentStatusToToolStatus` answers two questions about two entities through one signature. The second parameter is renamed `callStatus` here to put the distinction in the code; the coupling survives until the sub-agent outcome union lands.
- `AdvisorTool`'s narrowed prop is a stopgap. `limit_reached`, `advice` and failure want to be one discriminated result.

## Size

`+204 / -316` across 39 files. Production only, excluding tests and stories: `+101 / -242`, net **-141**.

## Testing

| | main | this branch |
|---|---|---|
| unit, `src/pages/AgentsPage` | 1502 passed, 2 skipped | 1504 passed, 2 skipped |
| storybook, `src/pages/AgentsPage` | 949 passed, 2 failed | 952 passed, 2 failed |

The two Storybook failures are identical on both and fail on unmodified `main`: `Tool.stories.tsx > MCP Tool Completed`, and `AgentChatPageView.stories.tsx > Scroll To Bottom Button Works With Inverse Scroll`, which is an intermittent shared-highlighter failure.

`pnpm exec tsc --noEmit -p .` and `biome check --error-on-warnings src/pages/AgentsPage` are clean.

## Rebase note

This replaces #27539, which had drifted. The rebase composed three changes that landed separately: #27430 added `errorText` and the new failure labels, while #27684 and #27687 deleted `WaitForExternalAuthTool` and `ExecuteAuthRequiredTool`, which the old branch still carried. All of main's labels and `errorText` are preserved; only the redundant flag is gone.

<details>
<summary>Where this sits in the wider plan</summary>

This is PR 3 of a queue that enforces one rule across `site/src/pages/AgentsPage/**`: we do not write defensive code for states that should be impossible, and where a runtime check is required it happens once, as early as possible, and produces a type that carries the proof.

Corollary in play here: **one representation per fact.** No field pairs that must agree, no boolean that is a function of another boolean.

Already merged: #27513 (defensive code for impossible chat states), #27527 (unreachable tool render paths), #27588 (unused `ChatMessagePart.Signature`), #27684 and #27687 (unreachable external-auth code).

Blocked on this one: the per-component outcome unions carrying the four deferred findings above, the `ToolCall.Root` controlled/uncontrolled prop union, and separating the two status vocabularies currently widened to `Map<string, string>`.
</details>

---
_Generated by Coder Agents._

