### PR TITLE
refactor(site): remove horizontal Form layout

### DIFF
--- a/site/src/components/Form/Form.stories.tsx
+++ b/site/src/components/Form/Form.stories.tsx
@@ -23,14 +23,4 @@ const meta: Meta<typeof Form> = {
 export default meta;
 type Story = StoryObj<typeof Form>;
 
-export const Vertical: Story = {
-	args: {
-		direction: "vertical",
-	},
-};
-
-export const Horizontal: Story = {
-	args: {
-		direction: "horizontal",
-	},
-};
+export const Default: Story = {};

--- a/site/src/components/Form/Form.tsx
+++ b/site/src/components/Form/Form.tsx
@@ -1,58 +1,16 @@
-import {
-	type ComponentProps,
-	createContext,
-	type FC,
-	type HTMLProps,
-	type ReactNode,
-	useContext,
-} from "react";
+import type { ComponentProps, FC, HTMLProps, ReactNode, Ref } from "react";
 import { AlphaBadge, DeprecatedBadge } from "#/components/Badges/Badges";
 import { cn } from "#/utils/cn";
 
-type FormContextValue = { direction?: "horizontal" | "vertical" };
-
-const FormContext = createContext<FormContextValue>({
-	direction: "horizontal",
-});
-
-type FormProps = HTMLProps<HTMLFormElement> & {
-	direction?: FormContextValue["direction"];
-};
-
-export const Form: FC<FormProps> = ({ direction, className, ...formProps }) => {
-	return (
-		<FormContext.Provider value={{ direction }}>
-			<form
-				{...formProps}
-				className={cn(
-					"flex flex-col gap-16",
-					direction === "horizontal" ? "md:gap-20" : "md:gap-10",
-					className,
-				)}
-			/>
-		</FormContext.Provider>
-	);
-};
-
-export const HorizontalForm: FC<HTMLProps<HTMLFormElement>> = ({
-	children,
+export const Form: FC<HTMLProps<HTMLFormElement>> = ({
+	className,
 	...formProps
 }) => {
 	return (
-		<Form direction="horizontal" {...formProps}>
-			{children}
-		</Form>
-	);
-};
-
-export const VerticalForm: FC<HTMLProps<HTMLFormElement>> = ({
-	children,
-	...formProps
-}) => {
-	return (
-		<Form direction="vertical" {...formProps}>
-			{children}
-		</Form>
+		<form
+			{...formProps}
+			className={cn("flex flex-col gap-16 md:gap-10", className)}
+		/>
 	);
 };
 
@@ -67,7 +25,7 @@ interface FormSectionProps {
 	};
 	alpha?: boolean;
 	deprecated?: boolean;
-	ref?: React.Ref<HTMLElement>;
+	ref?: Ref<HTMLElement>;
 }
 
 export const FormSection: FC<FormSectionProps> = ({
@@ -79,24 +37,12 @@ export const FormSection: FC<FormSectionProps> = ({
 	deprecated = false,
 	ref,
 }) => {
-	const { direction } = useContext(FormContext);
-
 	return (
 		<section
 			ref={ref}
-			className={cn(
-				"flex items-start flex-col gap-4 lg:gap-6",
-				direction === "horizontal" && "lg:flex-row lg:gap-[120px]",
-				classes.root,
-			)}
+			className={cn("flex items-start flex-col gap-4 lg:gap-6", classes.root)}
 		>
-			<div
-				className={cn(
-					"w-full shrink-0 top-24",
-					direction === "horizontal" && "lg:sticky lg:max-w-[312px]",
-					classes.sectionInfo,
-				)}
-			>
+			<div className={cn("w-full shrink-0 top-24", classes.sectionInfo)}>
 				<header className="flex items-center gap-4">
 					<h2
 						className={cn(

--- a/site/src/pages/CreateTemplatePage/CreateTemplateForm.tsx
+++ b/site/src/pages/CreateTemplatePage/CreateTemplateForm.tsx
@@ -27,7 +27,7 @@ import {
 	FormFields,
 	FormFooter,
 	FormSection,
-	HorizontalForm,
+	Form,
 } from "#/components/Form/Form";
 import { IconField } from "#/components/IconField/IconField";
 import { Label } from "#/components/Label/Label";
@@ -271,7 +271,7 @@ export const CreateTemplateForm: FC<CreateTemplateFormProps> = (props) => {
 	const showProvisionerWarning = provisioners ? provisioners.length < 1 : false;
 
 	return (
-		<HorizontalForm onSubmit={form.handleSubmit} className="pb-12">
+		<Form onSubmit={form.handleSubmit} className="pb-12">
 			{/* General info */}
 			<FormSection
 				title="General"
@@ -446,7 +446,7 @@ export const CreateTemplateForm: FC<CreateTemplateFormProps> = (props) => {
 					</button>
 				)}
 			</FormFooter>
-		</HorizontalForm>
+		</Form>
 	);
 };
 

--- a/site/src/pages/CreateTemplatePage/CreateTemplateForm.tsx
+++ b/site/src/pages/CreateTemplatePage/CreateTemplateForm.tsx
@@ -24,10 +24,10 @@ import type {
 import { Alert } from "#/components/Alert/Alert";
 import { Button } from "#/components/Button/Button";
 import {
+	Form,
 	FormFields,
 	FormFooter,
 	FormSection,
-	Form,
 } from "#/components/Form/Form";
 import { IconField } from "#/components/IconField/IconField";
 import { Label } from "#/components/Label/Label";

--- a/site/src/pages/CreateTokenPage/CreateTokenForm.tsx
+++ b/site/src/pages/CreateTokenPage/CreateTokenForm.tsx
@@ -11,7 +11,7 @@ import {
 	FormFields,
 	FormFooter,
 	FormSection,
-	HorizontalForm,
+	Form,
 } from "#/components/Form/Form";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { getFormHelpers, onChangeTrimmed } from "#/utils/formUtils";
@@ -64,7 +64,7 @@ export const CreateTokenForm: FC<CreateTokenFormProps> = ({
 	const getFieldHelpers = getFormHelpers<CreateTokenData>(form, formError);
 
 	return (
-		<HorizontalForm onSubmit={form.handleSubmit}>
+		<Form onSubmit={form.handleSubmit}>
 			<FormSection
 				title="Name"
 				description="What is this token for?"
@@ -165,7 +165,7 @@ export const CreateTokenForm: FC<CreateTokenFormProps> = ({
 					{creationFailed ? "Retry" : "Create token"}
 				</Button>
 			</FormFooter>
-		</HorizontalForm>
+		</Form>
 	);
 };
 

--- a/site/src/pages/CreateTokenPage/CreateTokenForm.tsx
+++ b/site/src/pages/CreateTokenPage/CreateTokenForm.tsx
@@ -8,10 +8,10 @@ import { type FC, useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { Button } from "#/components/Button/Button";
 import {
+	Form,
 	FormFields,
 	FormFooter,
 	FormSection,
-	Form,
 } from "#/components/Form/Form";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { getFormHelpers, onChangeTrimmed } from "#/utils/formUtils";

--- a/site/src/pages/OrganizationSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
@@ -18,7 +18,7 @@ import type {
 } from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Button } from "#/components/Button/Button";
-import { FormFields, FormFooter, VerticalForm } from "#/components/Form/Form";
+import { FormFields, FormFooter, Form } from "#/components/Form/Form";
 import {
 	SettingsHeader,
 	SettingsHeaderDescription,
@@ -108,7 +108,7 @@ const CreateEditRolePageView: FC<CreateEditRolePageViewProps> = ({
 				</div>
 			</div>
 
-			<VerticalForm onSubmit={form.handleSubmit}>
+			<Form onSubmit={form.handleSubmit}>
 				<FormFields>
 					{Boolean(error) && !isApiValidationError(error) && (
 						<ErrorAlert error={error} />
@@ -147,7 +147,7 @@ const CreateEditRolePageView: FC<CreateEditRolePageViewProps> = ({
 						{role ? "Save role" : "Create Role"}
 					</Button>
 				</FormFooter>
-			</VerticalForm>
+			</Form>
 		</>
 	);
 };

--- a/site/src/pages/OrganizationSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
@@ -18,7 +18,7 @@ import type {
 } from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Button } from "#/components/Button/Button";
-import { FormFields, FormFooter, Form } from "#/components/Form/Form";
+import { Form, FormFields, FormFooter } from "#/components/Form/Form";
 import {
 	SettingsHeader,
 	SettingsHeaderDescription,

--- a/site/src/pages/OrganizationSettingsPage/OrganizationSettingsPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationSettingsPageView.tsx
@@ -14,10 +14,10 @@ import { Button } from "#/components/Button/Button";
 import { Checkbox } from "#/components/Checkbox/Checkbox";
 import { DeleteDialog } from "#/components/Dialog/DeleteDialog/DeleteDialog";
 import {
+	Form,
 	FormFields,
 	FormFooter,
 	FormSection,
-	Form,
 } from "#/components/Form/Form";
 import { IconField } from "#/components/IconField/IconField";
 import { RadioGroup, RadioGroupItem } from "#/components/RadioGroup/RadioGroup";

--- a/site/src/pages/OrganizationSettingsPage/OrganizationSettingsPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationSettingsPageView.tsx
@@ -17,7 +17,7 @@ import {
 	FormFields,
 	FormFooter,
 	FormSection,
-	HorizontalForm,
+	Form,
 } from "#/components/Form/Form";
 import { IconField } from "#/components/IconField/IconField";
 import { RadioGroup, RadioGroupItem } from "#/components/RadioGroup/RadioGroup";
@@ -98,7 +98,7 @@ export const OrganizationSettingsPageView: FC<
 				</div>
 			)}
 
-			<HorizontalForm
+			<Form
 				onSubmit={form.handleSubmit}
 				aria-label="Organization settings form"
 			>
@@ -146,10 +146,10 @@ export const OrganizationSettingsPageView: FC<
 						Save
 					</Button>
 				</FormFooter>
-			</HorizontalForm>
+			</Form>
 
 			{onChangeShareableOwners && (
-				<HorizontalForm className="mt-12">
+				<Form className="mt-12">
 					<FormSection
 						title="Workspace Sharing"
 						description="Control whether workspace owners can share their workspaces."
@@ -255,11 +255,11 @@ export const OrganizationSettingsPageView: FC<
 							</div>
 						</div>
 					</FormSection>
-				</HorizontalForm>
+				</Form>
 			)}
 
 			{!organization.is_default && (
-				<HorizontalForm className="mt-12">
+				<Form className="mt-12">
 					<FormSection
 						title="Delete Organization"
 						description="Delete your organization permanently."
@@ -277,7 +277,7 @@ export const OrganizationSettingsPageView: FC<
 							</div>
 						</div>
 					</FormSection>
-				</HorizontalForm>
+				</Form>
 			)}
 
 			<DeleteDialog

--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
@@ -15,10 +15,10 @@ import {
 import { PremiumBadge } from "#/components/Badges/Badges";
 import { Button } from "#/components/Button/Button";
 import {
+	Form,
 	FormFields,
 	FormFooter,
 	FormSection,
-	Form,
 } from "#/components/Form/Form";
 import { IconField } from "#/components/IconField/IconField";
 import { Spinner } from "#/components/Spinner/Spinner";
@@ -101,10 +101,7 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
 	const getFieldHelpers = getFormHelpers(form, error);
 
 	return (
-		<Form
-			onSubmit={form.handleSubmit}
-			aria-label="Template settings form"
-		>
+		<Form onSubmit={form.handleSubmit} aria-label="Template settings form">
 			<FormSection
 				title="General info"
 				description="The name is used to identify the template in URLs and the API."

--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
@@ -18,7 +18,7 @@ import {
 	FormFields,
 	FormFooter,
 	FormSection,
-	HorizontalForm,
+	Form,
 } from "#/components/Form/Form";
 import { IconField } from "#/components/IconField/IconField";
 import { Spinner } from "#/components/Spinner/Spinner";
@@ -101,7 +101,7 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
 	const getFieldHelpers = getFormHelpers(form, error);
 
 	return (
-		<HorizontalForm
+		<Form
 			onSubmit={form.handleSubmit}
 			aria-label="Template settings form"
 		>
@@ -349,6 +349,6 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
 					Save
 				</Button>
 			</FormFooter>
-		</HorizontalForm>
+		</Form>
 	);
 };

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
@@ -10,7 +10,7 @@ import {
 	FormFields,
 	FormFooter,
 	FormSection,
-	HorizontalForm,
+	Form,
 } from "#/components/Form/Form";
 import { Label } from "#/components/Label/Label";
 import { Spinner } from "#/components/Spinner/Spinner";
@@ -288,7 +288,7 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 	};
 
 	return (
-		<HorizontalForm
+		<Form
 			onSubmit={form.handleSubmit}
 			aria-label="Template settings form"
 		>
@@ -648,6 +648,6 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 					Save
 				</Button>
 			</FormFooter>
-		</HorizontalForm>
+		</Form>
 	);
 };

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
@@ -7,10 +7,10 @@ import { Button } from "#/components/Button/Button";
 import { Checkbox } from "#/components/Checkbox/Checkbox";
 import { DurationField } from "#/components/DurationField/DurationField";
 import {
+	Form,
 	FormFields,
 	FormFooter,
 	FormSection,
-	Form,
 } from "#/components/Form/Form";
 import { Label } from "#/components/Label/Label";
 import { Spinner } from "#/components/Spinner/Spinner";
@@ -288,10 +288,7 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 	};
 
 	return (
-		<Form
-			onSubmit={form.handleSubmit}
-			aria-label="Template settings form"
-		>
+		<Form onSubmit={form.handleSubmit} aria-label="Template settings form">
 			<FormSection
 				title="Autostop"
 				description="Define when workspaces created from this template are stopped."

--- a/site/src/pages/TemplateSettingsPage/TemplateVariablesPage/TemplateVariablesForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateVariablesPage/TemplateVariablesForm.tsx
@@ -12,7 +12,7 @@ import {
 	FormFields,
 	FormFooter,
 	FormSection,
-	HorizontalForm,
+	Form,
 } from "#/components/Form/Form";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { type FormHelpers, getFormHelpers } from "#/utils/formUtils";
@@ -67,7 +67,7 @@ export const TemplateVariablesForm: FC<TemplateVariablesForm> = ({
 	);
 
 	return (
-		<HorizontalForm
+		<Form
 			onSubmit={form.handleSubmit}
 			aria-label="Template variables"
 		>
@@ -118,7 +118,7 @@ export const TemplateVariablesForm: FC<TemplateVariablesForm> = ({
 					Save
 				</Button>
 			</FormFooter>
-		</HorizontalForm>
+		</Form>
 	);
 };
 

--- a/site/src/pages/TemplateSettingsPage/TemplateVariablesPage/TemplateVariablesForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateVariablesPage/TemplateVariablesForm.tsx
@@ -9,10 +9,10 @@ import type {
 } from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
 import {
+	Form,
 	FormFields,
 	FormFooter,
 	FormSection,
-	Form,
 } from "#/components/Form/Form";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { type FormHelpers, getFormHelpers } from "#/utils/formUtils";
@@ -67,10 +67,7 @@ export const TemplateVariablesForm: FC<TemplateVariablesForm> = ({
 	);
 
 	return (
-		<Form
-			onSubmit={form.handleSubmit}
-			aria-label="Template variables"
-		>
+		<Form onSubmit={form.handleSubmit} aria-label="Template variables">
 			{templateVariables.map((templateVariable, index) => {
 				let fieldHelpers: FormHelpers;
 				if (templateVariable.sensitive) {

--- a/site/src/pages/TemplateVersionEditorPage/MissingTemplateVariablesDialog.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/MissingTemplateVariablesDialog.tsx
@@ -12,7 +12,7 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "#/components/Dialog/Dialog";
-import { FormFields, VerticalForm } from "#/components/Form/Form";
+import { FormFields, Form } from "#/components/Form/Form";
 import { Loader } from "#/components/Loader/Loader";
 import { VariableInput } from "#/pages/CreateTemplatePage/VariableInput";
 
@@ -56,7 +56,7 @@ export const MissingTemplateVariablesDialog: FC<
 					</DialogDescription>
 				</DialogHeader>
 
-				<VerticalForm
+				<Form
 					id="updateVariables"
 					onSubmit={(e) => {
 						e.preventDefault();
@@ -83,7 +83,7 @@ export const MissingTemplateVariablesDialog: FC<
 					) : (
 						<Loader />
 					)}
-				</VerticalForm>
+				</Form>
 
 				<DialogFooter>
 					<Button variant="outline" type="button" onClick={onClose}>

--- a/site/src/pages/TemplateVersionEditorPage/MissingTemplateVariablesDialog.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/MissingTemplateVariablesDialog.tsx
@@ -12,7 +12,7 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "#/components/Dialog/Dialog";
-import { FormFields, Form } from "#/components/Form/Form";
+import { Form, FormFields } from "#/components/Form/Form";
 import { Loader } from "#/components/Loader/Loader";
 import { VariableInput } from "#/pages/CreateTemplatePage/VariableInput";
 

--- a/site/src/pages/TemplateVersionEditorPage/ProvisionerTagsPopover.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ProvisionerTagsPopover.tsx
@@ -3,7 +3,7 @@ import useTheme from "@mui/system/useTheme";
 import type { FC } from "react";
 import type { ProvisionerDaemon } from "#/api/typesGenerated";
 import { ChevronDownIcon } from "#/components/AnimatedIcons/ChevronDown";
-import { FormSection, VerticalForm } from "#/components/Form/Form";
+import { Form, FormSection } from "#/components/Form/Form";
 import { TopbarButton } from "#/components/FullPageLayout/Topbar";
 import {
 	Popover,
@@ -43,13 +43,11 @@ export const ProvisionerTagsPopover: FC<ProvisionerTagsPopoverProps> = ({
 						borderBottom: `1px solid ${theme.palette.divider}`,
 					}}
 				>
-					<VerticalForm>
+					<Form>
 						<FormSection
 							classes={{
-								// Override lg:gap-6 from FormSection defaults. The
-								// lg:flex-col counters the default FormContext
-								// direction ("horizontal") which adds lg:flex-row.
-								root: "flex-col lg:flex-col gap-4 lg:gap-4",
+								// Tighter gap than FormSection's default lg:gap-6.
+								root: "gap-4 lg:gap-4",
 							}}
 							title="Provisioner Tags"
 							description={
@@ -68,7 +66,7 @@ export const ProvisionerTagsPopover: FC<ProvisionerTagsPopoverProps> = ({
 						>
 							<ProvisionerTagsField value={tags} onChange={onTagsChange} />
 						</FormSection>
-					</VerticalForm>
+					</Form>
 				</div>
 			</PopoverContent>
 		</Popover>

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.tsx
@@ -7,10 +7,10 @@ import type { Template } from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
 import { Checkbox } from "#/components/Checkbox/Checkbox";
 import {
+	Form,
 	FormFields,
 	FormFooter,
 	FormSection,
-	Form,
 } from "#/components/Form/Form";
 import { Input } from "#/components/Input/Input";
 import { Label } from "#/components/Label/Label";

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.tsx
@@ -10,7 +10,7 @@ import {
 	FormFields,
 	FormFooter,
 	FormSection,
-	HorizontalForm,
+	Form,
 } from "#/components/Form/Form";
 import { Input } from "#/components/Input/Input";
 import { Label } from "#/components/Label/Label";
@@ -227,7 +227,7 @@ export const WorkspaceScheduleForm: FC<WorkspaceScheduleFormProps> = ({
 		isLoading || !template.allow_user_autostop || !form.values.autostopEnabled;
 
 	return (
-		<HorizontalForm onSubmit={form.handleSubmit}>
+		<Form onSubmit={form.handleSubmit}>
 			<FormSection
 				title="Autostart"
 				description="Select the time and days of week on which you want the workspace starting automatically."
@@ -434,7 +434,7 @@ export const WorkspaceScheduleForm: FC<WorkspaceScheduleFormProps> = ({
 					Save
 				</Button>
 			</FormFooter>
-		</HorizontalForm>
+		</Form>
 	);
 };
 

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
@@ -12,7 +12,7 @@ import {
 	FormFields,
 	FormFooter,
 	FormSection,
-	HorizontalForm,
+	Form,
 } from "#/components/Form/Form";
 import { FormField } from "#/components/FormField/FormField";
 import { Label } from "#/components/Label/Label";
@@ -75,7 +75,7 @@ export const WorkspaceSettingsForm: FC<WorkspaceSettingsFormProps> = ({
 	const automaticUpdatesHelperId = `${automaticUpdatesField.id}-helper`;
 
 	return (
-		<HorizontalForm onSubmit={form.handleSubmit} data-testid="form">
+		<Form onSubmit={form.handleSubmit} data-testid="form">
 			<FormSection
 				title="Workspace Name"
 				description="Update the name of your workspace."
@@ -171,6 +171,6 @@ export const WorkspaceSettingsForm: FC<WorkspaceSettingsFormProps> = ({
 					</Button>
 				</FormFooter>
 			)}
-		</HorizontalForm>
+		</Form>
 	);
 };

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
@@ -9,10 +9,10 @@ import {
 } from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
 import {
+	Form,
 	FormFields,
 	FormFooter,
 	FormSection,
-	Form,
 } from "#/components/Form/Form";
 import { FormField } from "#/components/FormField/FormField";
 import { Label } from "#/components/Label/Label";


### PR DESCRIPTION
Drops the `direction` prop, Form context, `HorizontalForm`, and `VerticalForm` from the shared Form component. Sections are always stacked vertically.

Call sites now use `Form` directly. This simplifies the API and aligns settings forms with the vertical layout we want going forward.
