### PR TITLE
fix: `<BuildingTemplateLoader />` icon sizes

### DIFF
--- a/site/src/pages/TemplateBuilder/BuildingTemplateLoader.tsx
+++ b/site/src/pages/TemplateBuilder/BuildingTemplateLoader.tsx
@@ -45,7 +45,7 @@ export const BuildingTemplateLoader: FC = () => {
 				{ICONS.map(({ name, icon: Icon, x, y, delay }) => (
 					<motion.div
 						key={name}
-						className="absolute rounded-md border border-solid border-border bg-surface-secondary p-3"
+						className="absolute flex size-12 items-center justify-center rounded-md border border-solid border-border bg-surface-secondary"
 						style={{
 							left: `calc(50% + ${x}%)`,
 							top: `calc(50% + ${y}%)`,
@@ -62,7 +62,7 @@ export const BuildingTemplateLoader: FC = () => {
 							times: [0, 0.25, 0.55, 0.7, 0.8, 1],
 						}}
 					>
-						<Icon className="size-6 text-content-primary" />
+						<Icon className="size-6 shrink-0 text-content-primary" />
 					</motion.div>
 				))}
 			</div>


### PR DESCRIPTION
The floating icon tiles in `BuildingTemplateLoader` were taller than wide because padding plus inline SVG baseline spacing stretched the boxes vertically, and the icons sat off-center.

Give each tile a fixed square size with flex centering so the icons stay centered, without changing the commented drop-in animation.

| Old | New |
| --- | --- |
| <img width="300" alt="PREVIEW_TEMPLATE_CREATING_OLD" src="https://github.com/user-attachments/assets/57899c5c-fb26-40c8-8a60-1aa194307301" /> | <img width="300" alt="PREVIEW_TEMPLATE_CREATING_NEW" src="https://github.com/user-attachments/assets/8f7165f8-5d4f-4714-8579-d7e08a7e9869" /> |