### PR TITLE
fix(site): require organization before creating template

### DIFF
--- a/site/src/api/queries/organizations.ts
+++ b/site/src/api/queries/organizations.ts
@@ -299,9 +299,15 @@ export const provisionerJobs = (
  * action. Fetches all organizations, runs a per-org authorization
  * check, and returns only those that pass.
  */
+export const permittedOrganizationsKey = (check: AuthorizationCheck) => [
+	"organizations",
+	"permitted",
+	check,
+];
+
 export const permittedOrganizations = (check: AuthorizationCheck) => {
 	return {
-		queryKey: ["organizations", "permitted", check],
+		queryKey: permittedOrganizationsKey(check),
 		queryFn: async (): Promise<Organization[]> => {
 			const orgs = await API.getOrganizations();
 			const checks = Object.fromEntries(

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
@@ -45,7 +45,10 @@ import {
 	WIZARD_STEPS,
 } from "./steps";
 import { TemplateAlternatives } from "./TemplateAlternatives";
-import { TemplateCustomizationsStep } from "./TemplateCustomizationsStep";
+import {
+	customizationsComplete,
+	TemplateCustomizationsStep,
+} from "./TemplateCustomizationsStep";
 import {
 	initWizardState,
 	type SelectedBaseMeta,
@@ -358,7 +361,7 @@ function computeCanContinue(
 				moduleVarMap,
 			);
 		case "customizations":
-			return state.name.trim() !== "" && state.hasProvisioners !== false;
+			return customizationsComplete(state);
 		default:
 			return true;
 	}

--- a/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.stories.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.stories.tsx
@@ -1,6 +1,19 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, screen, userEvent, waitFor, within } from "storybook/test";
-import { getProvisionerDaemonsKey } from "#/api/queries/organizations";
+import {
+	expect,
+	fn,
+	screen,
+	spyOn,
+	userEvent,
+	waitFor,
+	within,
+} from "storybook/test";
+import { API } from "#/api/api";
+import {
+	getProvisionerDaemonsKey,
+	permittedOrganizationsKey,
+} from "#/api/queries/organizations";
+import type { AuthorizationCheck } from "#/api/typesGenerated";
 import {
 	MockDefaultOrganization,
 	MockOrganization2,
@@ -8,11 +21,11 @@ import {
 import { TemplateCustomizationsStep } from "./TemplateCustomizationsStep";
 import { initialWizardState } from "./wizardState";
 
-const permittedOrgsKey = [
-	"organizations",
-	"permitted",
-	{ object: { resource_type: "template" }, action: "create" },
-];
+const permittedOrgsCheck: AuthorizationCheck = {
+	object: { resource_type: "template" },
+	action: "create",
+};
+const permittedOrgsKey = permittedOrganizationsKey(permittedOrgsCheck);
 
 const meta: Meta<typeof TemplateCustomizationsStep> = {
 	title: "pages/TemplateBuilder/TemplateCustomizationsStep",
@@ -53,12 +66,11 @@ export const RequiresOrganizationSelection: Story = {
 	},
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
-		const organizationPicker = canvas.getByTestId("organization-autocomplete");
+		const organizationPicker = canvas.getByRole("button", {
+			name: /organization/i,
+		});
 
 		await expect(organizationPicker).toHaveAttribute("aria-required", "true");
-		await expect(organizationPicker).toHaveTextContent(
-			"Select an organization",
-		);
 
 		await userEvent.click(organizationPicker);
 		// Popover content portals outside the canvas root.
@@ -91,7 +103,7 @@ export const HidesPickerForSingleOrganization: Story = {
 		const canvas = within(canvasElement);
 
 		await expect(
-			canvas.queryByTestId("organization-autocomplete"),
+			canvas.queryByRole("button", { name: /organization/i }),
 		).not.toBeInTheDocument();
 
 		await waitFor(() =>
@@ -100,5 +112,48 @@ export const HidesPickerForSingleOrganization: Story = {
 				MockDefaultOrganization.id,
 			),
 		);
+	},
+};
+
+export const NoPermittedOrganizations: Story = {
+	parameters: {
+		queries: [
+			{
+				key: permittedOrgsKey,
+				data: [],
+			},
+		],
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+
+		await expect(
+			canvas.queryByRole("button", { name: /organization/i }),
+		).not.toBeInTheDocument();
+		await expect(
+			canvas.getByText(/do not have permission to create templates/i),
+		).toBeVisible();
+		await expect(args.onChangeField).not.toHaveBeenCalledWith(
+			"organizationId",
+			expect.anything(),
+		);
+	},
+};
+
+export const FailsToLoadOrganizations: Story = {
+	beforeEach: () => {
+		spyOn(API, "getOrganizations").mockRejectedValue(
+			new Error("failed to load organizations"),
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		await expect(
+			await canvas.findByText("Failed to load organizations."),
+		).toBeVisible();
+		await expect(
+			canvas.getByRole("button", { name: /retry/i }),
+		).toBeInTheDocument();
 	},
 };

--- a/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.stories.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.stories.tsx
@@ -1,0 +1,104 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, screen, userEvent, waitFor, within } from "storybook/test";
+import { getProvisionerDaemonsKey } from "#/api/queries/organizations";
+import {
+	MockDefaultOrganization,
+	MockOrganization2,
+} from "#/testHelpers/entities";
+import { TemplateCustomizationsStep } from "./TemplateCustomizationsStep";
+import { initialWizardState } from "./wizardState";
+
+const permittedOrgsKey = [
+	"organizations",
+	"permitted",
+	{ object: { resource_type: "template" }, action: "create" },
+];
+
+const meta: Meta<typeof TemplateCustomizationsStep> = {
+	title: "pages/TemplateBuilder/TemplateCustomizationsStep",
+	component: TemplateCustomizationsStep,
+	args: {
+		state: {
+			...initialWizardState,
+			selectedBase: {
+				id: "docker",
+				name: "Docker Containers",
+				iconUrl: "/icon/docker.svg",
+				hasParameters: false,
+				hasPrerequisites: false,
+			},
+			name: "my-template",
+			displayName: "My Template",
+		},
+		onChangeField: fn(),
+		onProvisionerStatusChange: fn(),
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof TemplateCustomizationsStep>;
+
+export const RequiresOrganizationSelection: Story = {
+	parameters: {
+		queries: [
+			{
+				key: permittedOrgsKey,
+				data: [MockDefaultOrganization, MockOrganization2],
+			},
+			{
+				key: getProvisionerDaemonsKey(MockOrganization2.id),
+				data: [{ id: "provisioner-1" }],
+			},
+		],
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		const organizationPicker = canvas.getByTestId("organization-autocomplete");
+
+		await expect(organizationPicker).toHaveAttribute("aria-required", "true");
+		await expect(organizationPicker).toHaveTextContent(
+			"Select an organization",
+		);
+
+		await userEvent.click(organizationPicker);
+		// Popover content portals outside the canvas root.
+		const org2 = await screen.findByText(MockOrganization2.display_name);
+		await userEvent.click(org2);
+
+		await waitFor(() =>
+			expect(args.onChangeField).toHaveBeenCalledWith(
+				"organizationId",
+				MockOrganization2.id,
+			),
+		);
+	},
+};
+
+export const HidesPickerForSingleOrganization: Story = {
+	parameters: {
+		queries: [
+			{
+				key: permittedOrgsKey,
+				data: [MockDefaultOrganization],
+			},
+			{
+				key: getProvisionerDaemonsKey(MockDefaultOrganization.id),
+				data: [{ id: "provisioner-1" }],
+			},
+		],
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+
+		await expect(
+			canvas.queryByTestId("organization-autocomplete"),
+		).not.toBeInTheDocument();
+
+		await waitFor(() =>
+			expect(args.onChangeField).toHaveBeenCalledWith(
+				"organizationId",
+				MockDefaultOrganization.id,
+			),
+		);
+	},
+};

--- a/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.test.ts
+++ b/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { customizationsComplete } from "./TemplateCustomizationsStep";
+
+describe("customizationsComplete", () => {
+	it("requires a non-empty name and organization", () => {
+		expect(
+			customizationsComplete({
+				name: "",
+				organizationId: "org-123",
+				hasProvisioners: true,
+			}),
+		).toBe(false);
+		expect(
+			customizationsComplete({
+				name: "my-template",
+				organizationId: undefined,
+				hasProvisioners: true,
+			}),
+		).toBe(false);
+		expect(
+			customizationsComplete({
+				name: "my-template",
+				organizationId: "",
+				hasProvisioners: true,
+			}),
+		).toBe(false);
+	});
+
+	it("blocks create when the organization has no provisioners", () => {
+		expect(
+			customizationsComplete({
+				name: "my-template",
+				organizationId: "org-123",
+				hasProvisioners: false,
+			}),
+		).toBe(false);
+	});
+
+	it("allows create when name and organization are set", () => {
+		expect(
+			customizationsComplete({
+				name: "my-template",
+				organizationId: "org-123",
+				hasProvisioners: true,
+			}),
+		).toBe(true);
+		expect(
+			customizationsComplete({
+				name: "my-template",
+				organizationId: "org-123",
+				hasProvisioners: undefined,
+			}),
+		).toBe(true);
+	});
+});

--- a/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect, useState } from "react";
+import { type FC, useEffect } from "react";
 import { useQuery } from "react-query";
 import {
 	permittedOrganizations,
@@ -7,11 +7,13 @@ import {
 import type { Organization } from "#/api/typesGenerated";
 import { Alert } from "#/components/Alert/Alert";
 import { Avatar } from "#/components/Avatar/Avatar";
+import { Button } from "#/components/Button/Button";
 import { IconField } from "#/components/IconField/IconField";
 import { Input } from "#/components/Input/Input";
 import { Label } from "#/components/Label/Label";
 import { Link } from "#/components/Link/Link";
 import { OrganizationAutocomplete } from "#/components/OrganizationAutocomplete/OrganizationAutocomplete";
+import { Spinner } from "#/components/Spinner/Spinner";
 import { Textarea } from "#/components/Textarea/Textarea";
 import {
 	TemplateBuilderSubtitle,
@@ -60,8 +62,10 @@ export const TemplateCustomizationsStep: FC<
 		}),
 	);
 	const orgOptions = permittedOrgsQuery.data ?? [];
-
-	const [selectedOrg, setSelectedOrg] = useState<Organization | null>(null);
+	const selectedOrg =
+		orgOptions.find((org) => org.id === state.organizationId) ?? null;
+	const autoSelectedSingleOrg =
+		permittedOrgsQuery.isSuccess && orgOptions.length === 1;
 
 	const { data: provisioners } = useQuery({
 		...provisionerDaemons(selectedOrg?.id ?? ""),
@@ -76,16 +80,29 @@ export const TemplateCustomizationsStep: FC<
 		onProvisionerStatusChange(hasProvisioners);
 	}, [hasProvisioners, onProvisionerStatusChange]);
 
-	// Auto-select when exactly one org is available.
+	// Keep the wizard's organization in sync with the fetched permitted orgs:
+	// auto-select the sole option, and drop a selection that a later refetch no
+	// longer permits so a stale organization can't be submitted.
 	useEffect(() => {
-		if (orgOptions.length === 1 && !selectedOrg) {
-			setSelectedOrg(orgOptions[0]);
-			onChangeField("organizationId", orgOptions[0].id);
+		const orgs = permittedOrgsQuery.data;
+		if (!orgs) {
+			return;
 		}
-	}, [orgOptions, selectedOrg, onChangeField]);
+		if (orgs.length === 1) {
+			if (state.organizationId !== orgs[0].id) {
+				onChangeField("organizationId", orgs[0].id);
+			}
+			return;
+		}
+		if (
+			state.organizationId &&
+			!orgs.some((org) => org.id === state.organizationId)
+		) {
+			onChangeField("organizationId", "");
+		}
+	}, [permittedOrgsQuery.data, state.organizationId, onChangeField]);
 
 	const handleOrgChange = (org: Organization | null) => {
-		setSelectedOrg(org);
 		onChangeField("organizationId", org?.id ?? "");
 	};
 
@@ -107,7 +124,7 @@ export const TemplateCustomizationsStep: FC<
 					<div
 						className={cn(
 							"flex flex-col gap-2",
-							orgOptions.length <= 1 && "col-span-2",
+							autoSelectedSingleOrg && "col-span-2",
 						)}
 					>
 						<Label htmlFor="template-display-name">Display name</Label>
@@ -119,8 +136,7 @@ export const TemplateCustomizationsStep: FC<
 						/>
 					</div>
 
-					{/* Only ask when the user has a real choice. */}
-					{orgOptions.length > 1 && (
+					{!autoSelectedSingleOrg && (
 						<div className="flex flex-col gap-2">
 							<Label htmlFor="organization">
 								Organization
@@ -128,13 +144,41 @@ export const TemplateCustomizationsStep: FC<
 									*
 								</span>
 							</Label>
-							<OrganizationAutocomplete
-								id="organization"
-								required
-								value={selectedOrg}
-								onChange={handleOrgChange}
-								options={orgOptions}
-							/>
+							{permittedOrgsQuery.isLoading ? (
+								<div className="flex h-10 items-center">
+									<Spinner
+										loading
+										size="sm"
+										aria-label="Loading organizations"
+									/>
+								</div>
+							) : permittedOrgsQuery.isError ? (
+								<div className="flex flex-col items-start gap-2">
+									<p className="text-xs text-content-destructive">
+										Failed to load organizations.
+									</p>
+									<Button
+										variant="outline"
+										size="sm"
+										onClick={() => permittedOrgsQuery.refetch()}
+									>
+										Retry
+									</Button>
+								</div>
+							) : orgOptions.length === 0 ? (
+								<p className="text-xs text-content-secondary">
+									You do not have permission to create templates in any
+									organization.
+								</p>
+							) : (
+								<OrganizationAutocomplete
+									id="organization"
+									required
+									value={selectedOrg}
+									onChange={handleOrgChange}
+									options={orgOptions}
+								/>
+							)}
 						</div>
 					)}
 

--- a/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
@@ -17,6 +17,7 @@ import {
 	TemplateBuilderSubtitle,
 	TemplateBuilderTitle,
 } from "#/pages/TemplateBuilder/TemplateBuilderHeader";
+import { cn } from "#/utils/cn";
 import { docs } from "#/utils/docs";
 import type {
 	SelectedBaseMeta,
@@ -30,6 +31,23 @@ interface TemplateCustomizationsStepProps {
 		value: string,
 	) => void;
 	onProvisionerStatusChange: (hasProvisioners: boolean | undefined) => void;
+}
+
+/**
+ * Returns true when required customization fields are set and the selected
+ * organization has provisioners (or provisioner status is still unknown).
+ */
+export function customizationsComplete(
+	state: Pick<
+		TemplateBuilderWizardState,
+		"name" | "organizationId" | "hasProvisioners"
+	>,
+): boolean {
+	return (
+		state.name.trim() !== "" &&
+		Boolean(state.organizationId) &&
+		state.hasProvisioners !== false
+	);
 }
 
 export const TemplateCustomizationsStep: FC<
@@ -86,8 +104,12 @@ export const TemplateCustomizationsStep: FC<
 
 				{/* Two-column form grid */}
 				<div className="grid grid-cols-2 gap-x-6 gap-y-6 content-start">
-					{/* Left column */}
-					<div className="flex flex-col gap-2">
+					<div
+						className={cn(
+							"flex flex-col gap-2",
+							orgOptions.length <= 1 && "col-span-2",
+						)}
+					>
 						<Label htmlFor="template-display-name">Display name</Label>
 						<Input
 							id="template-display-name"
@@ -97,8 +119,8 @@ export const TemplateCustomizationsStep: FC<
 						/>
 					</div>
 
-					{/* Right column */}
-					{orgOptions.length > 0 && (
+					{/* Only ask when the user has a real choice. */}
+					{orgOptions.length > 1 && (
 						<div className="flex flex-col gap-2">
 							<Label htmlFor="organization">
 								Organization
@@ -116,7 +138,6 @@ export const TemplateCustomizationsStep: FC<
 						</div>
 					)}
 
-					{/* Left column */}
 					<div className="flex flex-col gap-2">
 						<Label htmlFor="template-description">Description</Label>
 						<Textarea
@@ -140,7 +161,6 @@ export const TemplateCustomizationsStep: FC<
 						/>
 					</div>
 
-					{/* Right column */}
 					<div className="flex flex-col gap-2">
 						<Label htmlFor="template-name">
 							ID


### PR DESCRIPTION
> 🤖 This PR was modified by Coder Agents on behalf of Jake Howell.

Submitting the template builder without an organization sent `organization_id: ""` and surfaced a cryptic JSON/UUID parse error, because Create Template only required a name.

Require an organization before enabling create. Hide the organization picker when there is only one permitted org (still auto-select it), and show display name full-width in that case; with multiple orgs, keep display name and organization side by side. Covered with unit tests and Storybook interactions.

| Old | New |
| --- | --- |
| <img width="1065" height="661" alt="CUSTOMIZATIONS_ERROR_OLD" src="https://github.com/user-attachments/assets/829fb4cc-40d8-4b65-9d92-ac55e6679fc5"/> | <img width="1065" height="518" alt="CUSTOMIZATIONS_ERROR_NEW" src="https://github.com/user-attachments/assets/baa0dcfe-1ece-41ab-bd15-5a1f3d961d0d"/> |