### PR TITLE
refactor(site): demui `Form.stories.tsx` stories

### DIFF
--- a/site/src/components/Form/Form.stories.tsx
+++ b/site/src/components/Form/Form.stories.tsx
@@ -1,27 +1,47 @@
-import TextField from "@mui/material/TextField";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useFormik } from "formik";
+import type { FC } from "react";
+import { FormField } from "#/components/FormField/FormField";
+import { getFormHelpers } from "#/utils/formUtils";
 import { Form, FormFields, FormSection } from "./Form";
 
-const meta: Meta<typeof Form> = {
-	title: "components/Form",
-	component: Form,
-	args: {
-		children: (
+const ExampleForm: FC<{ direction?: "horizontal" | "vertical" }> = ({
+	direction,
+}) => {
+	const form = useFormik({
+		initialValues: {
+			workspaceName: "",
+			owner: "",
+		},
+		onSubmit: () => {},
+	});
+	const getFieldHelpers = getFormHelpers(form);
+
+	return (
+		<Form direction={direction} onSubmit={form.handleSubmit}>
 			<FormSection
 				title="General"
 				description="The name of the workspace and its owner. Only admins can create workspaces for other users."
 			>
 				<FormFields>
-					<TextField label="Workspace Name" />
-					<TextField label="Owner" />
+					<FormField
+						label="Workspace Name"
+						field={getFieldHelpers("workspaceName")}
+					/>
+					<FormField label="Owner" field={getFieldHelpers("owner")} />
 				</FormFields>
 			</FormSection>
-		),
-	},
+		</Form>
+	);
+};
+
+const meta: Meta<typeof ExampleForm> = {
+	title: "components/Form",
+	component: ExampleForm,
 };
 
 export default meta;
-type Story = StoryObj<typeof Form>;
+type Story = StoryObj<typeof ExampleForm>;
 
 export const Vertical: Story = {
 	args: {

--- a/site/src/components/FullPageForm/FullPageForm.stories.tsx
+++ b/site/src/components/FullPageForm/FullPageForm.stories.tsx
@@ -1,28 +1,37 @@
-import TextField from "@mui/material/TextField";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useFormik } from "formik";
 import type { FC } from "react";
 import { Button } from "#/components/Button/Button";
 import { FormFooter } from "#/components/Form/Form";
+import { FormField } from "#/components/FormField/FormField";
+import { getFormHelpers } from "#/utils/formUtils";
 import { FullPageForm, type FullPageFormProps } from "./FullPageForm";
 
-const Template: FC<FullPageFormProps> = (props) => (
-	<FullPageForm {...props}>
-		<form
-			onSubmit={(e) => {
-				e.preventDefault();
-			}}
-		>
-			<div className="flex flex-col gap-4">
-				<TextField fullWidth label="Field 1" name="field1" />
-				<TextField fullWidth label="Field 2" name="field2" />
-				<FormFooter>
-					<Button variant="outline">Cancel</Button>
-					<Button type="submit">Save</Button>
-				</FormFooter>
-			</div>
-		</form>
-	</FullPageForm>
-);
+const Template: FC<FullPageFormProps> = (props) => {
+	const form = useFormik({
+		initialValues: {
+			field1: "",
+			field2: "",
+		},
+		onSubmit: () => {},
+	});
+	const getFieldHelpers = getFormHelpers(form);
+
+	return (
+		<FullPageForm {...props}>
+			<form onSubmit={form.handleSubmit}>
+				<div className="flex flex-col gap-4">
+					<FormField label="Field 1" field={getFieldHelpers("field1")} />
+					<FormField label="Field 2" field={getFieldHelpers("field2")} />
+					<FormFooter>
+						<Button variant="outline">Cancel</Button>
+						<Button type="submit">Save</Button>
+					</FormFooter>
+				</div>
+			</form>
+		</FullPageForm>
+	);
+};
 
 const meta: Meta<typeof FullPageForm> = {
 	title: "components/FullPageForm",


### PR DESCRIPTION
Replace MUI `TextField` in the Form Storybook stories with `FormField`, wired through Formik and `getFormHelpers` so the examples match how real forms use the layout components.