### PR TITLE
refactor(site): demui `<ProvisionerTagsField />`

### DIFF
--- a/site/src/modules/provisioners/ProvisionerTagsField.tsx
+++ b/site/src/modules/provisioners/ProvisionerTagsField.tsx
@@ -1,9 +1,9 @@
-import TextField from "@mui/material/TextField";
 import { PlusIcon } from "lucide-react";
 import { type FC, useRef, useState } from "react";
 import * as Yup from "yup";
 import type { ProvisionerDaemon } from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
+import { Input } from "#/components/Input/Input";
 import { ProvisionerTag } from "#/modules/provisioners/ProvisionerTag";
 
 // Users can't delete these tags
@@ -119,9 +119,8 @@ const NewTagControl: FC<NewTagControlProps> = ({ onAdd }) => {
 				<label className="sr-only" htmlFor="tag-key-input">
 					Tag key
 				</label>
-				<TextField
-					inputRef={keyInputRef}
-					size="small"
+				<Input
+					ref={keyInputRef}
 					id="tag-key-input"
 					name="key"
 					placeholder="Key"
@@ -133,8 +132,7 @@ const NewTagControl: FC<NewTagControlProps> = ({ onAdd }) => {
 				<label className="sr-only" htmlFor="tag-value-input">
 					Tag value
 				</label>
-				<TextField
-					size="small"
+				<Input
 					id="tag-value-input"
 					name="value"
 					placeholder="Value"


### PR DESCRIPTION
Replace MUI `TextField` in `ProvisionerTagsField` with the shared `Input` component.