### PR TITLE
fix: recover tailnet after watchdog timeouts

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -156,6 +156,13 @@ type Agent interface {
 	io.Closer
 }
 
+var errTailnetWatchdogTimeout = xerrors.New("tailnet watchdog timeout")
+
+type tailnetWatchdogEvent struct {
+	generation uint64
+	operation  string
+}
+
 func New(options Options) Agent {
 	if options.Filesystem == nil {
 		options.Filesystem = afero.NewOsFs()
@@ -234,6 +241,7 @@ func New(options Options) Agent {
 		lifecycleReported:       make(chan codersdk.WorkspaceAgentLifecycle, 1),
 		lifecycleStates:         []agentsdk.PostLifecycleRequest{{State: codersdk.WorkspaceAgentLifecycleCreated}},
 		reportConnectionsUpdate: make(chan struct{}, 1),
+		tailnetWatchdog:         make(chan struct{}, 1),
 		listeningPortsHandler: listeningPortsHandler{
 			getter:      options.ListeningPortsGetter,
 			ignorePorts: maps.Clone(options.IgnorePorts),
@@ -296,15 +304,19 @@ type agent struct {
 	hardCancel     context.CancelFunc
 
 	// closeMutex protects the following:
-	closeMutex        sync.Mutex
-	closeWaitGroup    sync.WaitGroup
-	coordDisconnected chan struct{}
-	closing           bool
-	// note that once the network is set to non-nil, it is never modified, as with the statsReporter. So, routines
-	// that run after createOrUpdateNetwork and check the networkOK checkpoint do not need to hold the lock to use them.
-	network       *tailnet.Conn
-	statsReporter *statsReporter
+	closeMutex            sync.Mutex
+	closeWaitGroup        sync.WaitGroup
+	coordDisconnected     chan struct{}
+	closing               bool
+	networkGeneration     uint64
+	network               *tailnet.Conn
+	networkTransitionDone chan struct{}
+	statsReporter         *statsReporter
 	// end fields protected by closeMutex
+	tailnetWatchdogMu      sync.Mutex
+	tailnetWatchdog        chan struct{}
+	tailnetWatchdogEvent   tailnetWatchdogEvent
+	tailnetWatchdogPending bool
 
 	environmentVariables map[string]string
 
@@ -1165,6 +1177,8 @@ func (a *agent) fetchServiceBannerLoop(ctx context.Context, aAPI proto.DRPCAgent
 }
 
 func (a *agent) run() (retErr error) {
+	a.discardHandledTailnetWatchdogEvents()
+
 	// This allows the agent to refresh its token if necessary.
 	// For instance identity this is required, since the instance
 	// may not have re-provisioned, but a new agent ID was created.
@@ -1304,6 +1318,10 @@ func (a *agent) run() (retErr error) {
 	//           stats report loop <---------------+
 	networkOK := newCheckpoint(a.logger)
 	manifestOK := newCheckpoint(a.logger)
+	connMan.startAgentAPI("tailnet watchdog recovery", gracefulShutdownBehaviorStop,
+		func(ctx context.Context, _ proto.DRPCAgentClient28) error {
+			return a.recoverTailnetAfterWatchdog(ctx)
+		})
 
 	connMan.startAgentAPI("handle manifest", gracefulShutdownBehaviorStop, a.handleManifest(manifestOK))
 
@@ -1327,7 +1345,11 @@ func (a *agent) run() (retErr error) {
 			if err := networkOK.wait(ctx); err != nil {
 				return xerrors.Errorf("no network: %w", err)
 			}
-			return a.runCoordinator(ctx, tAPI, a.network)
+			network, ok := a.requireNetwork()
+			if !ok {
+				return tailnet.ErrConnClosed
+			}
+			return a.runCoordinator(ctx, tAPI, network)
 		},
 	)
 
@@ -1336,7 +1358,11 @@ func (a *agent) run() (retErr error) {
 			if err := networkOK.wait(ctx); err != nil {
 				return xerrors.Errorf("no network: %w", err)
 			}
-			return a.runDERPMapSubscriber(ctx, tAPI, a.network)
+			network, ok := a.requireNetwork()
+			if !ok {
+				return tailnet.ErrConnClosed
+			}
+			return a.runDERPMapSubscriber(ctx, tAPI, network)
 		})
 
 	connMan.startAgentAPI("fetch service banner loop", gracefulShutdownBehaviorStop, a.fetchServiceBannerLoop)
@@ -1345,7 +1371,11 @@ func (a *agent) run() (retErr error) {
 		if err := networkOK.wait(ctx); err != nil {
 			return xerrors.Errorf("no network: %w", err)
 		}
-		return a.statsReporter.reportLoop(ctx, aAPI)
+		reporter, ok := a.requireStatsReporter()
+		if !ok {
+			return tailnet.ErrConnClosed
+		}
+		return reporter.reportLoop(ctx, aAPI)
 	})
 
 	err = connMan.wait()
@@ -1616,9 +1646,35 @@ func (a *agent) createOrUpdateNetwork(manifestOK, networkOK *checkpoint) func(co
 			networkOK.complete(retErr)
 		}()
 		manifest := a.manifest.Load()
-		a.closeMutex.Lock()
-		network := a.network
-		a.closeMutex.Unlock()
+		var network *tailnet.Conn
+		var networkGeneration uint64
+		var networkTransitionDone chan struct{}
+		for {
+			a.closeMutex.Lock()
+			if a.closing {
+				a.closeMutex.Unlock()
+				return xerrors.Errorf("agent closed before creating tailnet: %w", ErrAgentClosing)
+			}
+			pendingNetworkTransition := a.networkTransitionDone
+			if pendingNetworkTransition == nil {
+				network = a.network
+				networkGeneration = a.networkGeneration
+				if network == nil {
+					a.networkGeneration++
+					networkGeneration = a.networkGeneration
+					networkTransitionDone = make(chan struct{})
+					a.networkTransitionDone = networkTransitionDone
+				}
+				a.closeMutex.Unlock()
+				break
+			}
+			a.closeMutex.Unlock()
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-pendingNetworkTransition:
+			}
+		}
 		if network == nil {
 			keySeed, err := SSHKeySeed(manifest.OwnerName, manifest.WorkspaceName, manifest.AgentName)
 			if err != nil {
@@ -1633,21 +1689,30 @@ func (a *agent) createOrUpdateNetwork(manifestOK, networkOK *checkpoint) func(co
 				manifest.DERPForceWebSockets,
 				manifest.DisableDirectConnections,
 				keySeed,
+				networkGeneration,
 			)
 			if err != nil {
+				a.completeNetworkTransition(networkTransitionDone)
 				return xerrors.Errorf("create tailnet: %w", err)
 			}
 			a.closeMutex.Lock()
-			// Re-check if agent was closed while initializing the network.
+			// Re-check if the agent closed or the watchdog invalidated this
+			// generation while the tailnet was initializing.
 			closing := a.closing
-			if !closing {
+			generationChanged := a.networkGeneration != networkGeneration
+			if !closing && !generationChanged {
 				a.network = network
 				a.statsReporter = newStatsReporter(a.logger, network, a, a.statsReportInterval)
+				a.completeNetworkTransitionLocked(networkTransitionDone)
 			}
 			a.closeMutex.Unlock()
-			if closing {
-				_ = network.Close()
-				return xerrors.Errorf("agent closed while creating tailnet: %w", ErrAgentClosing)
+			if closing || generationChanged {
+				network.Abort()
+				a.completeNetworkTransition(networkTransitionDone)
+				if closing {
+					return xerrors.Errorf("agent closed while creating tailnet: %w", ErrAgentClosing)
+				}
+				return xerrors.Errorf("tailnet invalidated while initializing: %w", errTailnetWatchdogTimeout)
 			}
 		} else {
 			// Update the wireguard IPs if the agent ID changed.
@@ -1666,9 +1731,140 @@ func (a *agent) createOrUpdateNetwork(manifestOK, networkOK *checkpoint) func(co
 				client := agentcontainers.NewSubAgentClientFromAPI(a.logger, aAPI)
 				a.containerAPI.UpdateSubAgentClient(client)
 			}
+			a.closeMutex.Lock()
+			closing := a.closing
+			generationChanged := a.networkGeneration != networkGeneration || a.network != network
+			a.closeMutex.Unlock()
+			if closing {
+				return xerrors.Errorf("agent closed while updating tailnet: %w", ErrAgentClosing)
+			}
+			if generationChanged {
+				return xerrors.Errorf("tailnet invalidated while updating: %w", errTailnetWatchdogTimeout)
+			}
 		}
 		return nil
 	}
+}
+func (a *agent) recoverTailnetAfterWatchdog(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-a.tailnetWatchdog:
+			event, ok := a.takeTailnetWatchdogEvent()
+			if !ok {
+				continue
+			}
+			a.closeMutex.Lock()
+			currentGeneration := a.networkGeneration
+			eventIsCurrent := !a.closing && a.network == nil && currentGeneration == event.generation+1
+			a.closeMutex.Unlock()
+			if !eventIsCurrent {
+				a.logger.Debug(ctx, "ignoring stale wireguard watchdog timeout",
+					slog.F("operation", event.operation),
+					slog.F("generation", event.generation),
+					slog.F("current_generation", currentGeneration),
+				)
+				continue
+			}
+			a.logger.Error(ctx, "resetting tailnet after wireguard watchdog timeout",
+				slog.F("operation", event.operation),
+				slog.F("generation", event.generation),
+			)
+			return xerrors.Errorf("%w: %s", errTailnetWatchdogTimeout, event.operation)
+		}
+	}
+}
+func (a *agent) discardHandledTailnetWatchdogEvents() {
+	a.tailnetWatchdogMu.Lock()
+	event := a.tailnetWatchdogEvent
+	pending := a.tailnetWatchdogPending
+	a.tailnetWatchdogPending = false
+	select {
+	case <-a.tailnetWatchdog:
+	default:
+	}
+	a.tailnetWatchdogMu.Unlock()
+	if pending {
+		a.logger.Debug(a.hardCtx, "discarding handled wireguard watchdog timeout",
+			slog.F("operation", event.operation),
+			slog.F("generation", event.generation),
+		)
+	}
+}
+
+func (a *agent) queueTailnetWatchdogEvent(event tailnetWatchdogEvent) {
+	a.tailnetWatchdogMu.Lock()
+	if !a.tailnetWatchdogPending || event.generation > a.tailnetWatchdogEvent.generation {
+		a.tailnetWatchdogEvent = event
+		a.tailnetWatchdogPending = true
+	}
+	a.tailnetWatchdogMu.Unlock()
+	select {
+	case a.tailnetWatchdog <- struct{}{}:
+	default:
+	}
+}
+
+func (a *agent) takeTailnetWatchdogEvent() (tailnetWatchdogEvent, bool) {
+	a.tailnetWatchdogMu.Lock()
+	defer a.tailnetWatchdogMu.Unlock()
+	event := a.tailnetWatchdogEvent
+	pending := a.tailnetWatchdogPending
+	a.tailnetWatchdogPending = false
+	return event, pending
+}
+
+func (a *agent) completeNetworkTransition(done chan struct{}) {
+	if done == nil {
+		return
+	}
+	a.closeMutex.Lock()
+	a.completeNetworkTransitionLocked(done)
+	a.closeMutex.Unlock()
+}
+
+func (a *agent) completeNetworkTransitionLocked(done chan struct{}) {
+	if done != nil && a.networkTransitionDone == done {
+		close(done)
+		a.networkTransitionDone = nil
+	}
+}
+
+func (a *agent) invalidateTailnetGeneration(generation uint64) (*tailnet.Conn, chan struct{}, bool) {
+	a.closeMutex.Lock()
+	defer a.closeMutex.Unlock()
+	if a.networkGeneration != generation {
+		return nil, nil, false
+	}
+	network := a.network
+	if a.closing {
+		return network, nil, false
+	}
+	networkTransitionDone := a.networkTransitionDone
+	if networkTransitionDone == nil {
+		networkTransitionDone = make(chan struct{})
+		a.networkTransitionDone = networkTransitionDone
+	}
+	a.network = nil
+	a.statsReporter = nil
+	a.networkGeneration++
+	return network, networkTransitionDone, true
+}
+
+func (a *agent) reportTailnetWatchdogTimeout(generation uint64, operation string) {
+	network, networkTransitionDone, reset := a.invalidateTailnetGeneration(generation)
+	if network != nil {
+		network.Abort()
+		a.completeNetworkTransition(networkTransitionDone)
+	}
+	if !reset {
+		return
+	}
+	a.queueTailnetWatchdogEvent(tailnetWatchdogEvent{
+		generation: generation,
+		operation:  operation,
+	})
 }
 
 // updateCommandEnv updates the provided command environment with the
@@ -1868,6 +2064,7 @@ func (a *agent) createTailnet(
 	derpMap *tailcfg.DERPMap,
 	derpForceWebSockets, disableDirectConnections bool,
 	keySeed int64,
+	networkGeneration uint64,
 ) (_ *tailnet.Conn, err error) {
 	// Inject `CODER_AGENT_HEADER` into the DERP header.
 	var header http.Header
@@ -1886,6 +2083,9 @@ func (a *agent) createTailnet(
 		Logger:              a.logger.Named("net.tailnet"),
 		ListenPort:          a.tailnetListenPort,
 		BlockEndpoints:      disableDirectConnections,
+		WatchdogTimeout: func(operation string) {
+			a.reportTailnetWatchdogTimeout(networkGeneration, operation)
+		},
 	})
 	if err != nil {
 		return nil, xerrors.Errorf("create tailnet: %w", err)
@@ -2065,7 +2265,7 @@ func (a *agent) runCoordinator(ctx context.Context, tClient tailnetproto.DRPCTai
 	defer func() {
 		cErr := coordinate.Close()
 		if cErr != nil {
-			a.logger.Debug(ctx, "error closing Coordinate client", slog.Error(err))
+			a.logger.Debug(ctx, "error closing Coordinate client", slog.Error(cErr))
 		}
 	}()
 	a.logger.Info(ctx, "connected to coordination RPC")
@@ -2085,6 +2285,17 @@ func (a *agent) runCoordinator(ctx context.Context, tClient tailnetproto.DRPCTai
 		defer close(errCh)
 		select {
 		case <-ctx.Done():
+			if a.gracefulCtx.Err() == nil {
+				err := coordinate.Close()
+				if err != nil {
+					a.logger.Warn(ctx, "failed to force close remote coordination", slog.Error(err))
+				}
+				err = coordination.Close(a.hardCtx)
+				if err != nil {
+					a.logger.Warn(ctx, "failed to finish closing remote coordination", slog.Error(err))
+				}
+				return
+			}
 			err := coordination.Close(a.hardCtx)
 			if err != nil {
 				a.logger.Warn(ctx, "failed to close remote coordination", slog.Error(err))
@@ -2170,45 +2381,48 @@ func (a *agent) Collect(ctx context.Context, networkStats map[netlogtype.Connect
 
 	stats.SessionCountReconnectingPty = a.reconnectingPTYServer.ConnCount()
 
-	// Compute the median connection latency!
-	a.logger.Debug(ctx, "starting peer latency measurement for stats")
-	var wg sync.WaitGroup
-	var mu sync.Mutex
-	status := a.network.Status()
 	durations := []float64{}
 	p2pConns := 0
 	derpConns := 0
-	pingCtx, cancelFunc := context.WithTimeout(ctx, 5*time.Second)
-	defer cancelFunc()
-	for nodeID, peer := range status.Peer {
-		if !peer.Active {
-			continue
-		}
-		addresses, found := a.network.NodeAddresses(nodeID)
-		if !found {
-			continue
-		}
-		if len(addresses) == 0 {
-			continue
-		}
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			duration, p2p, _, err := a.network.Ping(pingCtx, addresses[0].Addr())
-			if err != nil {
-				return
+	network, networkAvailable := a.requireNetwork()
+	if networkAvailable {
+		// Compute the median connection latency.
+		a.logger.Debug(ctx, "starting peer latency measurement for stats")
+		var wg sync.WaitGroup
+		var mu sync.Mutex
+		status := network.Status()
+		pingCtx, cancelFunc := context.WithTimeout(ctx, 5*time.Second)
+		defer cancelFunc()
+		for nodeID, peer := range status.Peer {
+			if !peer.Active {
+				continue
 			}
-			mu.Lock()
-			defer mu.Unlock()
-			durations = append(durations, float64(duration.Microseconds()))
-			if p2p {
-				p2pConns++
-			} else {
-				derpConns++
+			addresses, found := network.NodeAddresses(nodeID)
+			if !found {
+				continue
 			}
-		}()
+			if len(addresses) == 0 {
+				continue
+			}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				duration, p2p, _, err := network.Ping(pingCtx, addresses[0].Addr())
+				if err != nil {
+					return
+				}
+				mu.Lock()
+				defer mu.Unlock()
+				durations = append(durations, float64(duration.Microseconds()))
+				if p2p {
+					p2pConns++
+				} else {
+					derpConns++
+				}
+			}()
+		}
+		wg.Wait()
 	}
-	wg.Wait()
 	slices.Sort(durations)
 	durationsLength := len(durations)
 	switch {
@@ -2246,6 +2460,11 @@ func (a *agent) requireNetwork() (*tailnet.Conn, bool) {
 	a.closeMutex.Lock()
 	defer a.closeMutex.Unlock()
 	return a.network, a.network != nil
+}
+func (a *agent) requireStatsReporter() (*statsReporter, bool) {
+	a.closeMutex.Lock()
+	defer a.closeMutex.Unlock()
+	return a.statsReporter, a.statsReporter != nil
 }
 
 func (a *agent) HandleHTTPDebugMagicsock(w http.ResponseWriter, r *http.Request) {
@@ -2336,6 +2555,7 @@ func (a *agent) HTTPDebug() http.Handler {
 func (a *agent) Close() error {
 	a.closeMutex.Lock()
 	network := a.network
+	networkTransitionDone := a.networkTransitionDone
 	coordDisconnected := a.coordDisconnected
 	a.closing = true
 	a.closeMutex.Unlock()
@@ -2471,6 +2691,9 @@ lifecycleWaitLoop:
 	}
 
 	a.hardCancel()
+	if networkTransitionDone != nil {
+		<-networkTransitionDone
+	}
 	if network != nil {
 		_ = network.Close()
 	}

--- a/agent/agent_internal_test.go
+++ b/agent/agent_internal_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"net/netip"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -16,6 +17,7 @@ import (
 	"github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/codersdk"
 	agentsdk "github.com/coder/coder/v2/codersdk/agentsdk"
+	"github.com/coder/coder/v2/tailnet"
 	"github.com/coder/coder/v2/testutil"
 )
 
@@ -141,4 +143,120 @@ func TestClassifyCoordinatorRPCExit(t *testing.T) {
 			require.Equal(t, tc.initiator, initiator)
 		})
 	}
+}
+func TestInvalidateTailnetGeneration(t *testing.T) {
+	t.Parallel()
+
+	uut := &agent{
+		networkGeneration: 4,
+		statsReporter:     &statsReporter{},
+	}
+
+	network, networkTransitionDone, reset := uut.invalidateTailnetGeneration(3)
+	require.Nil(t, network)
+	require.Nil(t, networkTransitionDone)
+	require.False(t, reset)
+	require.NotNil(t, uut.statsReporter)
+	require.Equal(t, uint64(4), uut.networkGeneration)
+
+	network, networkTransitionDone, reset = uut.invalidateTailnetGeneration(4)
+	require.Nil(t, network)
+	require.NotNil(t, networkTransitionDone)
+	require.Equal(t, networkTransitionDone, uut.networkTransitionDone)
+	require.True(t, reset)
+	require.Nil(t, uut.statsReporter)
+	require.Equal(t, uint64(5), uut.networkGeneration)
+	uut.completeNetworkTransition(networkTransitionDone)
+	require.Nil(t, uut.networkTransitionDone)
+	_ = testutil.TryReceive(testutil.Context(t, testutil.WaitShort), t, networkTransitionDone)
+
+	uut.closing = true
+	_, _, reset = uut.invalidateTailnetGeneration(5)
+	require.False(t, reset)
+}
+
+func TestRecoverTailnetAfterWatchdog(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitMedium)
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	network, err := tailnet.NewConn(&tailnet.Options{
+		Addresses: []netip.Prefix{tailnet.TailscaleServicePrefix.RandomPrefix()},
+		Logger:    logger.Named("tailnet"),
+	})
+	require.NoError(t, err)
+
+	uut := &agent{
+		logger:            logger,
+		hardCtx:           ctx,
+		tailnetWatchdog:   make(chan struct{}, 1),
+		networkGeneration: 8,
+		network:           network,
+	}
+	uut.reportTailnetWatchdogTimeout(7, "UpdateStatus")
+	require.Same(t, network, uut.network)
+	select {
+	case <-uut.tailnetWatchdog:
+		t.Fatal("stale watchdog event was queued")
+	default:
+	}
+
+	uut.reportTailnetWatchdogTimeout(8, "Reconfig")
+
+	err = uut.recoverTailnetAfterWatchdog(ctx)
+	require.ErrorIs(t, err, errTailnetWatchdogTimeout)
+	require.ErrorContains(t, err, "Reconfig")
+	require.Equal(t, uint64(9), uut.networkGeneration)
+	require.Nil(t, uut.network)
+	require.Nil(t, uut.networkTransitionDone)
+	_ = testutil.TryReceive(ctx, t, network.Closed())
+	require.NoError(t, network.Close())
+
+	uut.closing = true
+	uut.network = network
+	require.NotPanics(t, func() {
+		uut.reportTailnetWatchdogTimeout(9, "Ping")
+	})
+}
+
+func TestDiscardHandledTailnetWatchdogEvents(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	uut := &agent{
+		logger:            slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		hardCtx:           ctx,
+		tailnetWatchdog:   make(chan struct{}, 1),
+		networkGeneration: 8,
+	}
+	uut.reportTailnetWatchdogTimeout(8, "Reconfig")
+	require.Equal(t, uint64(9), uut.networkGeneration)
+
+	uut.discardHandledTailnetWatchdogEvents()
+	select {
+	case <-uut.tailnetWatchdog:
+		t.Fatal("handled watchdog event remained queued")
+	default:
+	}
+}
+
+func TestQueueTailnetWatchdogEventKeepsNewestGeneration(t *testing.T) {
+	t.Parallel()
+
+	uut := &agent{
+		tailnetWatchdog: make(chan struct{}, 1),
+	}
+	assertNewest := func(first, second, want tailnetWatchdogEvent) {
+		t.Helper()
+		uut.queueTailnetWatchdogEvent(first)
+		uut.queueTailnetWatchdogEvent(second)
+		<-uut.tailnetWatchdog
+		got, ok := uut.takeTailnetWatchdogEvent()
+		require.True(t, ok)
+		require.Equal(t, want, got)
+	}
+	older := tailnetWatchdogEvent{generation: 8, operation: "Reconfig"}
+	newer := tailnetWatchdogEvent{generation: 10, operation: "UpdateStatus"}
+	assertNewest(older, newer, newer)
+	assertNewest(newer, older, newer)
 }

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ replace github.com/tcnksm/go-httpstat => github.com/coder/go-httpstat v0.0.0-202
 
 // There are a few minor changes we make to Tailscale that we're slowly upstreaming. Compare here:
 // https://github.com/tailscale/tailscale/compare/main...coder:tailscale:main
-replace tailscale.com => github.com/coder/tailscale v1.1.1-0.20260529105257-b7c5fc6e6399
+replace tailscale.com => github.com/usman-heracles/tailscale v1.1.1-0.20260802160905-8eaea8ff0d67
 
 // This is replaced to include
 // 1. a fix for a data race: c.f. https://github.com/tailscale/wireguard-go/pull/25

--- a/go.sum
+++ b/go.sum
@@ -361,8 +361,6 @@ github.com/coder/serpent v0.15.0 h1:jobR7DnPsxzEMD0cRiailwlY+4v6HAPS/8emIgBpaIU=
 github.com/coder/serpent v0.15.0/go.mod h1:7OIvFBYMd+OqarMy5einBl8AtRr8LliopVU7pyrwucY=
 github.com/coder/ssh v0.0.0-20231128192721-70855dedb788 h1:YoUSJ19E8AtuUFVYBpXuOD6a/zVP3rcxezNsoDseTUw=
 github.com/coder/ssh v0.0.0-20231128192721-70855dedb788/go.mod h1:aGQbuCLyhRLMzZF067xc84Lh7JDs1FKwCmF1Crl9dxQ=
-github.com/coder/tailscale v1.1.1-0.20260529105257-b7c5fc6e6399 h1:4IhFSmu0DSfWrvmHCb8aXDjWqSEYoIDA1L7Ar82Dm84=
-github.com/coder/tailscale v1.1.1-0.20260529105257-b7c5fc6e6399/go.mod h1:IatCC3hlq/ncu6DjZ+GJ/hNjSf5TmO+Xtc6B20k0q/c=
 github.com/coder/terraform-config-inspect v0.0.0-20250107175719-6d06d90c630e h1:JNLPDi2P73laR1oAclY6jWzAbucf70ASAvf5mh2cME0=
 github.com/coder/terraform-config-inspect v0.0.0-20250107175719-6d06d90c630e/go.mod h1:Gz/z9Hbn+4KSp8A2FBtNszfLSdT2Tn/uAKGuVqqWmDI=
 github.com/coder/terraform-provider-coder/v2 v2.19.0 h1:ShiwZiUZ3wyUt4+ccrdWlUKu+24aDgzMLD6Yf6xKtAw=
@@ -1220,6 +1218,8 @@ github.com/unrolled/secure v1.17.0 h1:Io7ifFgo99Bnh0J7+Q+qcMzWM6kaDPCA5FroFZEdbW
 github.com/unrolled/secure v1.17.0/go.mod h1:BmF5hyM6tXczk3MpQkFf1hpKSRqCyhqcbiQtiAF7+40=
 github.com/urfave/cli/v2 v2.27.5 h1:WoHEJLdsXr6dDWoJgMq/CboDmyY/8HMMH1fTECbih+w=
 github.com/urfave/cli/v2 v2.27.5/go.mod h1:3Sevf16NykTbInEnD0yKkjDAeZDS0A6bzhBH5hrMvTQ=
+github.com/usman-heracles/tailscale v1.1.1-0.20260802160905-8eaea8ff0d67 h1:A1pkWMOOBm8A1yiirmeGJightxOWZ0UV+AbtJoK/7SI=
+github.com/usman-heracles/tailscale v1.1.1-0.20260802160905-8eaea8ff0d67/go.mod h1:kHIqIaZBNdlYKkPi7VrmwfGlq/zcuZEpNt/zybpXovE=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.73.0 h1:ocTOORnBWtJ+P8t/6wAjdkchMzdfHmWx2VD/DPbgZ7s=

--- a/tailnet/conn.go
+++ b/tailnet/conn.go
@@ -106,6 +106,9 @@ type Options struct {
 	Logger         slog.Logger
 	ListenPort     uint16
 
+	// WatchdogTimeout is called once if a wireguard engine operation exceeds
+	// the watchdog timeout. The callback must not block.
+	WatchdogTimeout func(operation string)
 	// CaptureHook is a callback that captures Disco packets and packets sent
 	// into the tailnet tunnel.
 	CaptureHook capture.Callback
@@ -233,7 +236,11 @@ func NewConn(options *Options) (conn *Conn, err error) {
 		}
 	}
 
-	wireguardEngine = wgengine.NewWatchdog(wireguardEngine)
+	if options.WatchdogTimeout == nil {
+		wireguardEngine = wgengine.NewWatchdog(wireguardEngine)
+	} else {
+		wireguardEngine = wgengine.NewWatchdogWithTimeoutCallback(wireguardEngine, options.WatchdogTimeout)
+	}
 	sys.Set(wireguardEngine)
 
 	magicConn := sys.MagicSock.Get()
@@ -322,6 +329,8 @@ func NewConn(options *Options) (conn *Conn, err error) {
 	server := &Conn{
 		id:               uuid.New(),
 		closed:           make(chan struct{}),
+		cleanupDone:      make(chan struct{}),
+		dataPlaneClosed:  make(chan struct{}),
 		logger:           options.Logger,
 		magicConn:        magicConn,
 		dialer:           dialer,
@@ -440,10 +449,13 @@ func (p ServicePrefix) AsNetip() netip.Prefix {
 // Conn is an actively listening Wireguard connection.
 type Conn struct {
 	// Unique ID used for telemetry.
-	id     uuid.UUID
-	mutex  sync.Mutex
-	closed chan struct{}
-	logger slog.Logger
+	id              uuid.UUID
+	mutex           sync.Mutex
+	closed          chan struct{}
+	cleanupDone     chan struct{}
+	dataPlaneClosed chan struct{}
+	aborted         bool
+	logger          slog.Logger
 
 	dialer           *tsdial.Dialer
 	tunDevice        *tstun.Wrapper
@@ -669,22 +681,66 @@ func (c *Conn) Closed() <-chan struct{} {
 	return c.closed
 }
 
+// Abort stops the data plane synchronously, then attempts to clean up the
+// poisoned wireguard engine in the background.
+func (c *Conn) Abort() {
+	started, _ := c.beginClose(true)
+	if !started {
+		<-c.dataPlaneClosed
+		return
+	}
+	c.closeNetStack()
+	close(c.dataPlaneClosed)
+	go c.closeResources()
+}
+
 // Close shuts down the Wireguard connection.
 func (c *Conn) Close() error {
+	started, aborted := c.beginClose(false)
+	if started {
+		c.closeNetStack()
+		close(c.dataPlaneClosed)
+		c.closeResources()
+		return nil
+	}
+	<-c.dataPlaneClosed
+	if !aborted {
+		<-c.cleanupDone
+	}
+	return nil
+}
+
+func (c *Conn) beginClose(abort bool) (bool, bool) {
 	c.logger.Info(context.Background(), "closing tailnet Conn")
 	c.watchCancel()
-	c.configMaps.close()
-	c.nodeUpdater.close()
+
 	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	select {
 	case <-c.closed:
-		c.mutex.Unlock()
-		return nil
+		return false, c.aborted
 	default:
 	}
+
+	c.aborted = abort
 	close(c.closed)
+	for _, l := range c.listeners {
+		_ = l.closeNoLock()
+	}
+	c.listeners = nil
+	return true, abort
+}
+
+func (c *Conn) closeNetStack() {
+	_ = c.netStack.Close()
+	c.logger.Debug(context.Background(), "closed netstack")
+}
+
+func (c *Conn) closeResources() {
+	defer close(c.cleanupDone)
+	c.configMaps.close()
+	c.nodeUpdater.close()
 	c.telemetryWg.Wait()
-	c.mutex.Unlock()
 
 	var wg sync.WaitGroup
 	defer wg.Wait()
@@ -699,21 +755,10 @@ func (c *Conn) Close() error {
 		}()
 	}
 
-	_ = c.netStack.Close()
-	c.logger.Debug(context.Background(), "closed netstack")
 	_ = c.wireguardMonitor.Close()
 	_ = c.dialer.Close()
 	// Stops internals, e.g. tunDevice, magicConn and dnsManager.
 	c.wireguardEngine.Close()
-
-	c.mutex.Lock()
-	for _, l := range c.listeners {
-		_ = l.closeNoLock()
-	}
-	c.listeners = nil
-	c.mutex.Unlock()
-
-	return nil
 }
 
 func (c *Conn) isClosed() bool {
@@ -768,11 +813,17 @@ func (c *Conn) Listen(network, addr string) (net.Listener, error) {
 }
 
 func (c *Conn) DialContextTCP(ctx context.Context, ipp netip.AddrPort) (*gonet.TCPConn, error) {
+	if c.isClosed() {
+		return nil, ErrConnClosed
+	}
 	c.logger.Debug(ctx, "dial tcp", slog.F("addr_port", ipp))
 	return c.netStack.DialContextTCP(ctx, ipp)
 }
 
 func (c *Conn) DialContextUDP(ctx context.Context, ipp netip.AddrPort) (*gonet.UDPConn, error) {
+	if c.isClosed() {
+		return nil, ErrConnClosed
+	}
 	c.logger.Debug(ctx, "dial udp", slog.F("addr_port", ipp))
 	return c.netStack.DialContextUDP(ctx, ipp)
 }

--- a/tailnet/conn_test.go
+++ b/tailnet/conn_test.go
@@ -2,7 +2,9 @@ package tailnet_test
 
 import (
 	"context"
+	"io"
 	"net"
+	"net/http"
 	"net/netip"
 	"strings"
 	"testing"
@@ -38,6 +40,96 @@ func TestTailnet(t *testing.T) {
 		require.NoError(t, err)
 		err = conn.Close()
 		require.NoError(t, err)
+	})
+	t.Run("AbortClosesListenersImmediately", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
+		conn, err := tailnet.NewConn(&tailnet.Options{
+			Addresses: []netip.Prefix{tailnet.TailscaleServicePrefix.RandomPrefix()},
+			Logger:    testutil.Logger(t).Named("abort"),
+			DERPMap:   derpMap,
+		})
+		require.NoError(t, err)
+
+		listener, err := conn.Listen("tcp", ":35566")
+		require.NoError(t, err)
+		conn.Abort()
+
+		_ = testutil.TryReceive(ctx, t, conn.Closed())
+		_, err = listener.Accept()
+		require.ErrorIs(t, err, net.ErrClosed)
+		_, err = conn.DialContextTCP(ctx, netip.AddrPort{})
+		require.ErrorIs(t, err, tailnet.ErrConnClosed)
+		_, err = conn.DialContextUDP(ctx, netip.AddrPort{})
+		require.ErrorIs(t, err, tailnet.ErrConnClosed)
+
+		closeDone := make(chan error, 1)
+		go func() {
+			closeDone <- conn.Close()
+		}()
+		require.NoError(t, testutil.TryReceive(ctx, t, closeDone))
+	})
+	t.Run("ReconnectsFrontendAfterAbort", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		logger := testutil.Logger(t)
+		workspaceIP := tailnet.TailscaleServicePrefix.RandomAddr()
+
+		poisoned, err := tailnet.NewConn(&tailnet.Options{
+			Addresses: []netip.Prefix{netip.PrefixFrom(workspaceIP, 128)},
+			Logger:    logger.Named("poisoned"),
+			DERPMap:   derpMap,
+		})
+		require.NoError(t, err)
+		poisoned.Abort()
+		_ = testutil.TryReceive(ctx, t, poisoned.Closed())
+
+		recovered, err := tailnet.NewConn(&tailnet.Options{
+			Addresses: []netip.Prefix{netip.PrefixFrom(workspaceIP, 128)},
+			Logger:    logger.Named("recovered"),
+			DERPMap:   derpMap,
+		})
+		require.NoError(t, err)
+		browser, err := tailnet.NewConn(&tailnet.Options{
+			Addresses: []netip.Prefix{tailnet.TailscaleServicePrefix.RandomPrefix()},
+			Logger:    logger.Named("browser"),
+			DERPMap:   derpMap,
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = recovered.Close()
+			_ = browser.Close()
+		})
+		stitch(t, browser, recovered)
+		stitch(t, recovered, browser)
+		require.True(t, browser.AwaitReachable(ctx, workspaceIP))
+
+		listener, err := recovered.Listen("tcp", ":35567")
+		require.NoError(t, err)
+		server := &http.Server{
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte("workspace frontend recovered"))
+			}),
+		}
+		go func() {
+			_ = server.Serve(listener)
+		}()
+		t.Cleanup(func() {
+			_ = server.Close()
+		})
+
+		transport := &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return browser.DialContextTCP(ctx, netip.AddrPortFrom(workspaceIP, 35567))
+			},
+		}
+		t.Cleanup(transport.CloseIdleConnections)
+		response, err := (&http.Client{Transport: transport}).Get("http://workspace.test/")
+		require.NoError(t, err)
+		defer response.Body.Close()
+		body, err := io.ReadAll(response.Body)
+		require.NoError(t, err)
+		require.Equal(t, "workspace frontend recovered", string(body))
 	})
 	t.Run("Connect", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
## Problem

A single wedged Tailscale engine operation currently reaches `log.Fatalf` after 45 seconds and terminates the entire workspace-agent process. That restores neither connectivity nor process-local state safely: SSH, reconnecting PTYs, scripts, metadata, lifecycle reporting, and the control connection are all collateral damage.

## Change

Recover at the tailnet ownership boundary instead:

- configure the recoverable watchdog from coder/tailscale#129
- poison and invalidate the timed-out tailnet generation exactly once
- synchronously abort its data plane before permitting replacement or agent shutdown
- keep the agent process and non-tailnet subsystems alive
- return a sentinel from the current run so the existing run loop reconnects and constructs a fresh tailnet generation
- quarantine stale callbacks and stale generation events
- force-close and join the old coordinator response loop before reconnecting
- keep ordinary graceful `Close` behavior unchanged

`tailnet.Conn.Abort` closes listeners immediately, then cleans up a potentially wedged wireguard engine asynchronously. A transition barrier prevents a new generation or agent shutdown from crossing that abort boundary early.

## Dependency

This draft temporarily pins `github.com/usman-heracles/tailscale` at the reviewed commit from coder/tailscale#129. Replace it with the merged `github.com/coder/tailscale` revision before merge.

## Validation

- `go test ./agent -count=1`
- `go test ./tailnet -count=1`
- `go test -race ./agent -run 'Test(InvalidateTailnetGeneration|RecoverTailnetAfterWatchdog|DiscardHandledTailnetWatchdogEvents|QueueTailnetWatchdogEventKeepsNewestGeneration)' -count=1`
- `go test -race ./tailnet -run 'TestTailnet/(InstantClose|AbortClosesListenersImmediately)' -count=1`
- `go test -race -v ./tailnet -run 'TestTailnet/ReconnectsFrontendAfterAbort' -count=1` proves a reconstructed tailnet serves an HTTP frontend after the poisoned connection is aborted

All commands were run with `GOWORK=off`, using the pinned fork revision.