### PR TITLE
test: fix tailnet connection teardown flake

### DIFF
--- a/codersdk/workspacesdk/agentconn_test.go
+++ b/codersdk/workspacesdk/agentconn_test.go
@@ -243,7 +243,9 @@ func stitchTailnet(t *testing.T, conns map[uuid.UUID]*tailnet.Conn) {
 				Node: protoNode,
 				Kind: proto.CoordinateResponse_PeerUpdate_NODE,
 			}})
-			assert.NoError(t, err)
+			if err != nil && !errors.Is(err, tailnet.ErrConnClosed) {
+				assert.NoError(t, err)
+			}
 		}
 	}
 

--- a/tailnet/conn_test.go
+++ b/tailnet/conn_test.go
@@ -2,6 +2,7 @@ package tailnet_test
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/netip"
 	"strings"
@@ -483,7 +484,9 @@ func stitch(t *testing.T, dst, src *tailnet.Conn) {
 			Node: pn,
 			Kind: proto.CoordinateResponse_PeerUpdate_NODE,
 		}})
-		assert.NoError(t, err)
+		if err != nil && !errors.Is(err, tailnet.ErrConnClosed) {
+			assert.NoError(t, err)
+		}
 	})
 	// ensures we don't send callbacks after the test ends and connections are closed.
 	t.Cleanup(func() {


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/1620
Closes ENG-3043

The callback cleanup added in #20687 stops new node callbacks, but it can still race with one that's already in flight. That callback may call `UpdatePeers` after the destination `tailnet.Conn` closes, so the test fails with `connection closed` even though the redirect behaviour is correct.

To fix, we'll just ignore `tailnet.ErrConnClosed` in the asynchronous `stitch` helpers, whilst continuing to assert on every other error.
