### PR TITLE
test(site): isolate httptest server clients

### DIFF
--- a/site/site_test.go
+++ b/site/site_test.go
@@ -576,7 +576,7 @@ func TestServingFiles(t *testing.T) {
 	require.NoError(t, err)
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
-	client := &http.Client{}
+	client := srv.Client()
 
 	// Create a context
 	ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitShort)
@@ -865,7 +865,7 @@ func TestServingBin(t *testing.T) {
 			compressor := middleware.NewCompressor(1, "text/*", "application/*")
 			srv := httptest.NewServer(compressor.Handler(handler))
 			defer srv.Close()
-			client := &http.Client{}
+			client := srv.Client()
 
 			// Create a context
 			ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitShort)


### PR DESCRIPTION
Closes ENG-3094
Closes https://github.com/coder/internal/issues/582

The flake was caused by `TestServingBin` using `&http.Client{}`, which shares `http.DefaultTransport` with every parallel test in the binary. When another `httptest.Server` closed, it called `CloseIdleConnections` on the shared transport and could break our request. I couldn't replicate this locally, but the error comes directly from that cleanup path.

The fix is just to use each test server's `Client()`, which has its own transport. I've also updated `TestServingFiles`, as it had the same setup.
