### PR TITLE
refactor(site/src/api/queries): restructure chat query keys into a chatKeys factory

### DIFF
--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -1,4 +1,4 @@
-import { QueryClient } from "react-query";
+import { hashKey, QueryClient } from "react-query";
 import { describe, expect, it, vi } from "vitest";
 import { API } from "#/api/api";
 import type * as TypesGen from "#/api/typesGenerated";
@@ -11,26 +11,19 @@ import {
 	addChildToParentInCache,
 	archiveChat,
 	cancelChatListRefetches,
+	canonicalizeChatListFilters,
 	chatACL,
-	chatACLKey,
 	chatAdvisorConfig,
 	chatAdvisorConfigKey,
 	chatCost,
-	chatCostKey,
 	chatCostSummary,
-	chatCostSummaryKey,
-	chatDebugRunsKey,
-	chatDiffContentsKey,
-	chatKey,
-	chatMessagesKey,
+	chatKeys,
 	chatSearch,
-	chatsKey,
 	createChat,
 	createChatMessage,
 	deleteChatQueuedMessage,
 	editChatMessage,
 	infiniteChats,
-	infiniteChatsKey,
 	interruptChat,
 	invalidateChatListQueries,
 	mergeWatchedChatIntoCaches,
@@ -77,9 +70,9 @@ vi.mock("#/api/api", () => ({
 	},
 }));
 
-type InfiniteChatsTestOptions = Parameters<typeof infiniteChatsKey>[0];
+type InfiniteChatsTestOptions = Parameters<typeof chatKeys.list>[0];
 
-const infiniteChatsTestKey = infiniteChatsKey();
+const infiniteChatsTestKey = chatKeys.list();
 
 type InfiniteData = {
 	pages: TypesGen.Chat[][];
@@ -92,7 +85,7 @@ const seedInfiniteChats = (
 	chats: TypesGen.Chat[],
 	opts?: InfiniteChatsTestOptions,
 ) => {
-	queryClient.setQueryData<InfiniteData>(infiniteChatsKey(opts), {
+	queryClient.setQueryData<InfiniteData>(chatKeys.list(opts), {
 		pages: [chats],
 		pageParams: [0],
 	});
@@ -103,7 +96,7 @@ const readInfiniteChats = (
 	queryClient: QueryClient,
 	opts?: InfiniteChatsTestOptions,
 ): TypesGen.Chat[] | undefined => {
-	const data = queryClient.getQueryData<InfiniteData>(infiniteChatsKey(opts));
+	const data = queryClient.getQueryData<InfiniteData>(chatKeys.list(opts));
 	return data?.pages.flat();
 };
 
@@ -193,22 +186,21 @@ describe("advisor config query factories", () => {
 });
 
 describe("invalidateChatListQueries", () => {
-	it("invalidates flat and infinite chat list queries", async () => {
+	it("invalidates infinite chat list queries", async () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";
 
 		// Sidebar queries.
-		queryClient.setQueryData(chatsKey, [makeChat(chatId)]);
-		queryClient.setQueryData(infiniteChatsKey({ archived: false }), {
+		queryClient.setQueryData(chatKeys.list({ archived: false }), {
 			pages: [[makeChat(chatId)]],
 			pageParams: [0],
 		});
 		// Per-chat queries that should NOT be touched.
-		queryClient.setQueryData(chatKey(chatId), makeChat(chatId));
-		queryClient.setQueryData(chatMessagesKey(chatId), []);
-		queryClient.setQueryData(chatDiffContentsKey(chatId), {});
+		queryClient.setQueryData(chatKeys.detail(chatId), makeChat(chatId));
+		queryClient.setQueryData(chatKeys.messages(chatId), []);
+		queryClient.setQueryData(chatKeys.diffContents(chatId), {});
 		queryClient.setQueryData(
-			chatCostSummaryKey("me", undefined),
+			chatKeys.costSummary("me", undefined),
 			{} as TypesGen.ChatCostSummary,
 		);
 
@@ -216,39 +208,35 @@ describe("invalidateChatListQueries", () => {
 
 		// Sidebar queries should be invalidated.
 		expect(
-			queryClient.getQueryState(chatsKey)?.isInvalidated,
-			"flat chats should be invalidated",
-		).toBe(true);
-		expect(
-			queryClient.getQueryState(infiniteChatsKey({ archived: false }))
+			queryClient.getQueryState(chatKeys.list({ archived: false }))
 				?.isInvalidated,
 			"infinite chats should be invalidated",
 		).toBe(true);
 
 		// Per-chat queries should NOT be invalidated.
 		expect(
-			queryClient.getQueryState(chatKey(chatId))?.isInvalidated,
-			"chatKey should NOT be invalidated",
+			queryClient.getQueryState(chatKeys.detail(chatId))?.isInvalidated,
+			"the chat detail should NOT be invalidated",
 		).not.toBe(true);
 		expect(
-			queryClient.getQueryState(chatMessagesKey(chatId))?.isInvalidated,
-			"chatMessagesKey should NOT be invalidated",
+			queryClient.getQueryState(chatKeys.messages(chatId))?.isInvalidated,
+			"chat messages should NOT be invalidated",
 		).not.toBe(true);
 		expect(
-			queryClient.getQueryState(chatDiffContentsKey(chatId))?.isInvalidated,
-			"chatDiffContentsKey should NOT be invalidated",
+			queryClient.getQueryState(chatKeys.diffContents(chatId))?.isInvalidated,
+			"chat diff contents should NOT be invalidated",
 		).not.toBe(true);
 		expect(
-			queryClient.getQueryState(chatCostSummaryKey("me", undefined))
+			queryClient.getQueryState(chatKeys.costSummary("me", undefined))
 				?.isInvalidated,
-			"chatCostSummaryKey should NOT be invalidated",
+			"the cost summary should NOT be invalidated",
 		).not.toBe(true);
 	});
 
 	it("invalidates the infinite query with undefined opts", async () => {
 		const queryClient = createTestQueryClient();
 
-		queryClient.setQueryData(infiniteChatsKey(), {
+		queryClient.setQueryData(chatKeys.list(), {
 			pages: [[makeChat("chat-1")]],
 			pageParams: [0],
 		});
@@ -256,29 +244,30 @@ describe("invalidateChatListQueries", () => {
 		await invalidateChatListQueries(queryClient);
 
 		expect(
-			queryClient.getQueryState(infiniteChatsKey())?.isInvalidated,
+			queryClient.getQueryState(chatKeys.list())?.isInvalidated,
 			"infinite chats with undefined opts should be invalidated",
 		).toBe(true);
 	});
 
 	it("does not invalidate a different chat's queries", async () => {
 		const queryClient = createTestQueryClient();
-		const chatId = "chat-1";
 		const otherChatId = "chat-2";
 
-		queryClient.setQueryData(chatsKey, [makeChat(chatId)]);
-		queryClient.setQueryData(chatKey(otherChatId), makeChat(otherChatId));
-		queryClient.setQueryData(chatMessagesKey(otherChatId), []);
+		queryClient.setQueryData(
+			chatKeys.detail(otherChatId),
+			makeChat(otherChatId),
+		);
+		queryClient.setQueryData(chatKeys.messages(otherChatId), []);
 
 		await invalidateChatListQueries(queryClient);
 
 		expect(
-			queryClient.getQueryState(chatKey(otherChatId))?.isInvalidated,
-			"other chat's chatKey should NOT be invalidated",
+			queryClient.getQueryState(chatKeys.detail(otherChatId))?.isInvalidated,
+			"other chat's detail should NOT be invalidated",
 		).not.toBe(true);
 		expect(
-			queryClient.getQueryState(chatMessagesKey(otherChatId))?.isInvalidated,
-			"other chat's chatMessagesKey should NOT be invalidated",
+			queryClient.getQueryState(chatKeys.messages(otherChatId))?.isInvalidated,
+			"other chat's messages should NOT be invalidated",
 		).not.toBe(true);
 	});
 
@@ -331,7 +320,7 @@ describe("updateChatTitle cache update", () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";
 		queryClient.setQueryData(
-			chatKey(chatId),
+			chatKeys.detail(chatId),
 			makeChat(chatId, { title: "Old" }),
 		);
 		seedInfiniteChats(queryClient, [
@@ -348,7 +337,7 @@ describe("updateChatTitle cache update", () => {
 		mutation.onSuccess(undefined, { chatId, title: "New" });
 
 		expect(
-			queryClient.getQueryData<TypesGen.Chat>(chatKey(chatId))?.title,
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId))?.title,
 		).toBe("New");
 		expect(
 			readInfiniteChats(queryClient)?.find((chat) => chat.id === chatId),
@@ -375,10 +364,10 @@ describe("updateChatTitle cache update", () => {
 
 		expect(result).toBeUndefined();
 		expect(invalidateSpy).toHaveBeenCalledWith(
-			expect.objectContaining({ queryKey: chatsKey }),
+			expect.objectContaining({ queryKey: chatKeys.lists() }),
 		);
 		expect(invalidateSpy).toHaveBeenCalledWith({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
 		invalidateSpy.mockRestore();
@@ -408,14 +397,16 @@ describe("archiveChat optimistic update", () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";
 		seedInfiniteChats(queryClient, [makeChat(chatId)]);
-		queryClient.setQueryData(chatKey(chatId), makeChat(chatId));
+		queryClient.setQueryData(chatKeys.detail(chatId), makeChat(chatId));
 
 		vi.mocked(API.experimental.updateChat).mockResolvedValue();
 
 		const mutation = archiveChat(queryClient);
 		await mutation.onMutate(chatId);
 
-		const cachedChat = queryClient.getQueryData<TypesGen.Chat>(chatKey(chatId));
+		const cachedChat = queryClient.getQueryData<TypesGen.Chat>(
+			chatKeys.detail(chatId),
+		);
 		expect(cachedChat?.archived).toBe(true);
 	});
 
@@ -454,7 +445,7 @@ describe("archiveChat optimistic update", () => {
 			{ archived: false },
 		);
 		queryClient.setQueryData(
-			chatKey(chatId),
+			chatKeys.detail(chatId),
 			makeChat(chatId, { pin_order: 2 }),
 		);
 
@@ -467,7 +458,7 @@ describe("archiveChat optimistic update", () => {
 			),
 		).toEqual(["chat-2"]);
 		expect(
-			queryClient.getQueryData<TypesGen.Chat>(chatKey(chatId)),
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId)),
 		).toMatchObject({
 			archived: true,
 			pin_order: 0,
@@ -493,7 +484,7 @@ describe("archiveChat optimistic update", () => {
 		const chatId = "chat-1";
 		const initialChats = [makeChat(chatId)];
 		seedInfiniteChats(queryClient, initialChats);
-		queryClient.setQueryData(chatKey(chatId), makeChat(chatId));
+		queryClient.setQueryData(chatKeys.detail(chatId), makeChat(chatId));
 		const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
 		const mutation = archiveChat(queryClient);
@@ -507,7 +498,7 @@ describe("archiveChat optimistic update", () => {
 		mutation.onError(new Error("server error"), chatId, context);
 
 		expect(invalidateSpy).toHaveBeenCalledWith(
-			expect.objectContaining({ queryKey: chatsKey }),
+			expect.objectContaining({ queryKey: chatKeys.lists() }),
 		);
 	});
 
@@ -515,18 +506,21 @@ describe("archiveChat optimistic update", () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";
 		seedInfiniteChats(queryClient, [makeChat(chatId)]);
-		queryClient.setQueryData(chatKey(chatId), makeChat(chatId));
+		queryClient.setQueryData(chatKeys.detail(chatId), makeChat(chatId));
 
 		const mutation = archiveChat(queryClient);
 		const context = await mutation.onMutate(chatId);
 
 		expect(
-			queryClient.getQueryData<TypesGen.Chat>(chatKey(chatId))?.archived,
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId))
+				?.archived,
 		).toBe(true);
 
 		mutation.onError(new Error("server error"), chatId, context);
 
-		const rolledBack = queryClient.getQueryData<TypesGen.Chat>(chatKey(chatId));
+		const rolledBack = queryClient.getQueryData<TypesGen.Chat>(
+			chatKeys.detail(chatId),
+		);
 		expect(rolledBack?.archived).toBe(false);
 	});
 
@@ -545,7 +539,7 @@ describe("archiveChat optimistic update", () => {
 
 		// The handler should still invalidate to trigger a refetch.
 		expect(invalidateSpy).toHaveBeenCalledWith(
-			expect.objectContaining({ queryKey: chatsKey }),
+			expect.objectContaining({ queryKey: chatKeys.lists() }),
 		);
 	});
 
@@ -553,7 +547,7 @@ describe("archiveChat optimistic update", () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";
 		seedInfiniteChats(queryClient, [makeChat(chatId)]);
-		// Deliberately do NOT set chatKey(chatId) data.
+		// Deliberately do NOT set chatKeys.detail(chatId) data.
 
 		const mutation = archiveChat(queryClient);
 		const context = await mutation.onMutate(chatId);
@@ -579,10 +573,10 @@ describe("archiveChat optimistic update", () => {
 
 		expect(result).toBeUndefined();
 		expect(invalidateSpy).toHaveBeenCalledWith(
-			expect.objectContaining({ queryKey: chatsKey }),
+			expect.objectContaining({ queryKey: chatKeys.lists() }),
 		);
 		expect(invalidateSpy).toHaveBeenCalledWith({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
 		invalidateSpy.mockRestore();
@@ -606,7 +600,7 @@ describe("unarchiveChat optimistic update", () => {
 		const chatId = "chat-1";
 		seedInfiniteChats(queryClient, [makeChat(chatId, { archived: true })]);
 		queryClient.setQueryData(
-			chatKey(chatId),
+			chatKeys.detail(chatId),
 			makeChat(chatId, { archived: true }),
 		);
 
@@ -614,7 +608,8 @@ describe("unarchiveChat optimistic update", () => {
 		await mutation.onMutate(chatId);
 
 		expect(
-			queryClient.getQueryData<TypesGen.Chat>(chatKey(chatId))?.archived,
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId))
+				?.archived,
 		).toBe(false);
 	});
 
@@ -630,7 +625,7 @@ describe("unarchiveChat optimistic update", () => {
 			{ archived: true },
 		);
 		queryClient.setQueryData(
-			chatKey(chatId),
+			chatKeys.detail(chatId),
 			makeChat(chatId, { archived: true }),
 		);
 
@@ -643,7 +638,7 @@ describe("unarchiveChat optimistic update", () => {
 			),
 		).toEqual(["chat-2"]);
 		expect(
-			queryClient.getQueryData<TypesGen.Chat>(chatKey(chatId)),
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId)),
 		).toMatchObject({
 			archived: false,
 		});
@@ -654,7 +649,7 @@ describe("unarchiveChat optimistic update", () => {
 		const chatId = "chat-1";
 		seedInfiniteChats(queryClient, [makeChat(chatId, { archived: true })]);
 		queryClient.setQueryData(
-			chatKey(chatId),
+			chatKeys.detail(chatId),
 			makeChat(chatId, { archived: true }),
 		);
 		const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
@@ -665,7 +660,8 @@ describe("unarchiveChat optimistic update", () => {
 		// Verify optimistic update.
 		expect(readInfiniteChats(queryClient)?.[0].archived).toBe(false);
 		expect(
-			queryClient.getQueryData<TypesGen.Chat>(chatKey(chatId))?.archived,
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId))
+				?.archived,
 		).toBe(false);
 
 		// Roll back.
@@ -673,11 +669,12 @@ describe("unarchiveChat optimistic update", () => {
 
 		// The chats list is rolled back via invalidation.
 		expect(invalidateSpy).toHaveBeenCalledWith(
-			expect.objectContaining({ queryKey: chatsKey }),
+			expect.objectContaining({ queryKey: chatKeys.lists() }),
 		);
 		// The individual chat cache is restored directly.
 		expect(
-			queryClient.getQueryData<TypesGen.Chat>(chatKey(chatId))?.archived,
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId))
+				?.archived,
 		).toBe(true);
 	});
 
@@ -696,10 +693,10 @@ describe("unarchiveChat optimistic update", () => {
 
 		expect(result).toBeUndefined();
 		expect(invalidateSpy).toHaveBeenCalledWith(
-			expect.objectContaining({ queryKey: chatsKey }),
+			expect.objectContaining({ queryKey: chatKeys.lists() }),
 		);
 		expect(invalidateSpy).toHaveBeenCalledWith({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
 		invalidateSpy.mockRestore();
@@ -715,11 +712,11 @@ describe("pinChat optimistic update", () => {
 			makeChat(chatId),
 			makeChat("chat-pinned-2", { pin_order: 2 }),
 		]);
-		queryClient.setQueryData(infiniteChatsKey({ archived: true }), {
+		queryClient.setQueryData(chatKeys.list({ archived: true }), {
 			pages: [[makeChat("chat-pinned-archived", { pin_order: 4 })]],
 			pageParams: [0],
 		});
-		queryClient.setQueryData(chatKey(chatId), makeChat(chatId));
+		queryClient.setQueryData(chatKeys.detail(chatId), makeChat(chatId));
 
 		const mutation = pinChat(queryClient);
 		await mutation.onMutate(chatId);
@@ -729,7 +726,8 @@ describe("pinChat optimistic update", () => {
 				?.pin_order,
 		).toBe(5);
 		expect(
-			queryClient.getQueryData<TypesGen.Chat>(chatKey(chatId))?.pin_order,
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId))
+				?.pin_order,
 		).toBe(5);
 	});
 });
@@ -751,7 +749,7 @@ describe("unpinChat optimistic update", () => {
 		const chatId = "chat-1";
 		seedInfiniteChats(queryClient, [makeChat(chatId, { pin_order: 2 })]);
 		queryClient.setQueryData(
-			chatKey(chatId),
+			chatKeys.detail(chatId),
 			makeChat(chatId, { pin_order: 2 }),
 		);
 
@@ -759,7 +757,8 @@ describe("unpinChat optimistic update", () => {
 		await mutation.onMutate(chatId);
 
 		expect(
-			queryClient.getQueryData<TypesGen.Chat>(chatKey(chatId))?.pin_order,
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId))
+				?.pin_order,
 		).toBe(0);
 	});
 
@@ -768,7 +767,7 @@ describe("unpinChat optimistic update", () => {
 		const chatId = "chat-1";
 		seedInfiniteChats(queryClient, [makeChat(chatId, { pin_order: 3 })]);
 		queryClient.setQueryData(
-			chatKey(chatId),
+			chatKeys.detail(chatId),
 			makeChat(chatId, { pin_order: 3 }),
 		);
 		const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
@@ -779,7 +778,8 @@ describe("unpinChat optimistic update", () => {
 		// Verify optimistic update.
 		expect(readInfiniteChats(queryClient)?.[0].pin_order).toBe(0);
 		expect(
-			queryClient.getQueryData<TypesGen.Chat>(chatKey(chatId))?.pin_order,
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId))
+				?.pin_order,
 		).toBe(0);
 
 		// Roll back.
@@ -787,11 +787,12 @@ describe("unpinChat optimistic update", () => {
 
 		// The chats list is rolled back via invalidation.
 		expect(invalidateSpy).toHaveBeenCalledWith(
-			expect.objectContaining({ queryKey: chatsKey }),
+			expect.objectContaining({ queryKey: chatKeys.lists() }),
 		);
 		// The individual chat cache is restored directly.
 		expect(
-			queryClient.getQueryData<TypesGen.Chat>(chatKey(chatId))?.pin_order,
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId))
+				?.pin_order,
 		).toBe(3);
 	});
 
@@ -804,10 +805,10 @@ describe("unpinChat optimistic update", () => {
 		await mutation.onSettled(undefined, undefined, chatId);
 
 		expect(invalidateSpy).toHaveBeenCalledWith(
-			expect.objectContaining({ queryKey: chatsKey }),
+			expect.objectContaining({ queryKey: chatKeys.lists() }),
 		);
 		expect(invalidateSpy).toHaveBeenCalledWith({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
 	});
@@ -827,20 +828,20 @@ describe("reorderPinnedChat", () => {
 		await mutation.onSettled?.(undefined, undefined, { chatId, pinOrder: 2 });
 
 		expect(cancelSpy).toHaveBeenCalledWith(
-			expect.objectContaining({ queryKey: chatsKey }),
+			expect.objectContaining({ queryKey: chatKeys.lists() }),
 		);
 		expect(cancelSpy).toHaveBeenCalledWith({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
 		expect(API.experimental.updateChat).toHaveBeenCalledWith(chatId, {
 			pin_order: 2,
 		});
 		expect(invalidateSpy).toHaveBeenCalledWith(
-			expect.objectContaining({ queryKey: chatsKey }),
+			expect.objectContaining({ queryKey: chatKeys.lists() }),
 		);
 		expect(invalidateSpy).toHaveBeenCalledWith({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
 	});
@@ -859,13 +860,13 @@ describe("chat cost query factories", () => {
 
 		const query = chatCostSummary(user, params);
 
-		expect(chatCostSummaryKey(user, params)).toEqual([
+		expect(chatKeys.costSummary(user, params)).toEqual([
 			"chats",
-			"costSummary",
+			"cost-summary",
 			user,
 			params,
 		]);
-		expect(query.queryKey).toEqual(["chats", "costSummary", user, params]);
+		expect(query.queryKey).toEqual(["chats", "cost-summary", user, params]);
 		await query.queryFn();
 		expect(API.experimental.getChatCostSummary).toHaveBeenCalledWith(
 			user,
@@ -881,8 +882,8 @@ describe("chat cost query factories", () => {
 
 		const query = chatCost(chatId);
 
-		expect(chatCostKey(chatId)).toEqual(["chats", chatId, "cost"]);
-		expect(query.queryKey).toEqual(["chats", chatId, "cost"]);
+		expect(chatKeys.cost(chatId)).toEqual(["chats", "detail", chatId, "cost"]);
+		expect(query.queryKey).toEqual(["chats", "detail", chatId, "cost"]);
 		await query.queryFn();
 		expect(API.experimental.getChatCost).toHaveBeenCalledWith(chatId);
 	});
@@ -909,7 +910,7 @@ describe("chat cost query factories", () => {
 
 		// queryKey includes the payload and page number.
 		const key = result.queryKey({ ...pageParams, payload });
-		expect(key).toEqual(["chats", "costUsers", payload, 2]);
+		expect(key).toEqual(["chats", "cost-users", payload, 2]);
 
 		// queryFn coerces empty username to undefined.
 		// Cast needed because PaginatedQueryFnContext includes
@@ -929,7 +930,7 @@ describe("chat cost query factories", () => {
 describe("mutation invalidation scope", () => {
 	// These tests assert the CORRECT (narrow) invalidation behaviour.
 	// Each mutation should only invalidate the queries it actually
-	// needs to refresh, not the entire ["chats"] prefix tree. The
+	// needs to refresh, not the entire chatKeys.all prefix tree. The
 	// WebSocket stream already delivers real-time updates for
 	// messages, status changes, and sidebar ordering, so broad
 	// prefix invalidation causes a burst of redundant HTTP requests
@@ -938,24 +939,16 @@ describe("mutation invalidation scope", () => {
 	/** Populate the QueryClient with every query key that is actively
 	 *  observed on the /agents/:id detail page. */
 	const seedAllActiveQueries = (queryClient: QueryClient, chatId: string) => {
-		// Infinite sidebar list: ["chats", { archived: false }]
-		queryClient.setQueryData(infiniteChatsKey({ archived: false }), {
+		queryClient.setQueryData(chatKeys.list({ archived: false }), {
 			pages: [[makeChat(chatId)]],
 			pageParams: [0],
 		});
-		// Flat chats list: ["chats"]
-		queryClient.setQueryData(chatsKey, [makeChat(chatId)]);
-		// Individual chat: ["chats", chatId]
-		queryClient.setQueryData(chatKey(chatId), makeChat(chatId));
-		// Messages: ["chats", chatId, "messages"]
-		queryClient.setQueryData(chatMessagesKey(chatId), []);
-		// Debug runs: ["chats", chatId, "debug-runs"]
-		queryClient.setQueryData(chatDebugRunsKey(chatId), []);
-		// Diff contents: ["chats", chatId, "diff-contents"]
-		queryClient.setQueryData(chatDiffContentsKey(chatId), { files: [] });
-		// Cost summary: ["chats", "costSummary", "me", undefined]
+		queryClient.setQueryData(chatKeys.detail(chatId), makeChat(chatId));
+		queryClient.setQueryData(chatKeys.messages(chatId), []);
+		queryClient.setQueryData(chatKeys.debugRuns(chatId), []);
+		queryClient.setQueryData(chatKeys.diffContents(chatId), { files: [] });
 		queryClient.setQueryData(
-			chatCostSummaryKey("me", undefined),
+			chatKeys.costSummary("me", undefined),
 			{} as TypesGen.ChatCostSummary,
 		);
 	};
@@ -963,8 +956,8 @@ describe("mutation invalidation scope", () => {
 	/** Keys that should NEVER be invalidated by chat message mutations
 	 *  because they are completely unrelated to the message flow. */
 	const unrelatedKeys = (chatId: string) => [
-		{ label: "diff-contents", key: chatDiffContentsKey(chatId) },
-		{ label: "cost-summary", key: chatCostSummaryKey("me", undefined) },
+		{ label: "diff-contents", key: chatKeys.diffContents(chatId) },
+		{ label: "cost-summary", key: chatKeys.costSummary("me", undefined) },
 	];
 
 	it("createChatMessage does not invalidate unrelated queries", async () => {
@@ -993,19 +986,20 @@ describe("mutation invalidation scope", () => {
 		await mutation.onSuccess?.();
 
 		expect(
-			queryClient.getQueryState(chatDebugRunsKey(chatId))?.isInvalidated,
-			"chatDebugRunsKey should be invalidated",
+			queryClient.getQueryState(chatKeys.debugRuns(chatId))?.isInvalidated,
+			"debug runs should be invalidated",
 		).toBe(true);
 
-		const chatState = queryClient.getQueryState(chatKey(chatId));
-		expect(chatState?.isInvalidated, "chatKey should be invalidated").toBe(
-			true,
-		);
+		const chatState = queryClient.getQueryState(chatKeys.detail(chatId));
+		expect(
+			chatState?.isInvalidated,
+			"the chat detail should be invalidated",
+		).toBe(true);
 
-		const messagesState = queryClient.getQueryState(chatMessagesKey(chatId));
+		const messagesState = queryClient.getQueryState(chatKeys.messages(chatId));
 		expect(
 			messagesState?.isInvalidated,
-			"chatMessagesKey should NOT be invalidated",
+			"chat messages should NOT be invalidated",
 		).not.toBe(true);
 	});
 
@@ -1041,23 +1035,24 @@ describe("mutation invalidation scope", () => {
 		// Chat metadata and debug runs should be invalidated because
 		// editing changes the chat's updated_at and can start a new
 		// debug run.
-		const chatState = queryClient.getQueryState(chatKey(chatId));
-		expect(chatState?.isInvalidated, "chatKey should be invalidated").toBe(
-			true,
-		);
+		const chatState = queryClient.getQueryState(chatKeys.detail(chatId));
+		expect(
+			chatState?.isInvalidated,
+			"the chat detail should be invalidated",
+		).toBe(true);
 
 		// Messages are NOT invalidated. The per-chat WebSocket handles
 		// post-edit message delivery, making REST invalidation
 		// unnecessary.
-		const messagesState = queryClient.getQueryState(chatMessagesKey(chatId));
+		const messagesState = queryClient.getQueryState(chatKeys.messages(chatId));
 		expect(
 			messagesState?.isInvalidated,
-			"chatMessagesKey should not be invalidated",
+			"chat messages should not be invalidated",
 		).not.toBe(true);
 
 		expect(
-			queryClient.getQueryState(chatDebugRunsKey(chatId))?.isInvalidated,
-			"chatDebugRunsKey should be invalidated",
+			queryClient.getQueryState(chatKeys.debugRuns(chatId))?.isInvalidated,
+			"debug runs should be invalidated",
 		).toBe(true);
 	});
 
@@ -1066,7 +1061,7 @@ describe("mutation invalidation scope", () => {
 		const chatId = "chat-1";
 		const messages = [3, 2, 1].map((id) => makeMsg(chatId, id));
 
-		queryClient.setQueryData<InfMessages>(chatMessagesKey(chatId), {
+		queryClient.setQueryData<InfMessages>(chatKeys.messages(chatId), {
 			pages: [{ messages, queued_messages: [], has_more: false }],
 			pageParams: [undefined],
 		});
@@ -1085,10 +1080,10 @@ describe("mutation invalidation scope", () => {
 
 		await new Promise((r) => setTimeout(r, 0));
 
-		const messagesState = queryClient.getQueryState(chatMessagesKey(chatId));
+		const messagesState = queryClient.getQueryState(chatKeys.messages(chatId));
 		expect(
 			messagesState?.isInvalidated,
-			"chatMessagesKey should be invalidated on error",
+			"chat messages should be invalidated on error",
 		).toBe(true);
 	});
 
@@ -1146,7 +1141,7 @@ describe("mutation invalidation scope", () => {
 			requireMessage(messages, 3),
 		);
 
-		queryClient.setQueryData<InfMessages>(chatMessagesKey(chatId), {
+		queryClient.setQueryData<InfMessages>(chatKeys.messages(chatId), {
 			pages: [{ messages, queued_messages: [], has_more: false }],
 			pageParams: [undefined],
 		});
@@ -1158,7 +1153,9 @@ describe("mutation invalidation scope", () => {
 			req: editReq,
 		});
 
-		const data = queryClient.getQueryData<InfMessages>(chatMessagesKey(chatId));
+		const data = queryClient.getQueryData<InfMessages>(
+			chatKeys.messages(chatId),
+		);
 		expect(data?.pages[0]?.messages.map((message) => message.id)).toEqual([
 			3, 2, 1,
 		]);
@@ -1177,7 +1174,7 @@ describe("mutation invalidation scope", () => {
 		);
 		const queuedMessages = [makeQueuedMessage(chatId, 11)];
 
-		queryClient.setQueryData<InfMessages>(chatMessagesKey(chatId), {
+		queryClient.setQueryData<InfMessages>(chatKeys.messages(chatId), {
 			pages: [
 				{
 					messages,
@@ -1195,7 +1192,9 @@ describe("mutation invalidation scope", () => {
 			req: editReq,
 		});
 
-		const data = queryClient.getQueryData<InfMessages>(chatMessagesKey(chatId));
+		const data = queryClient.getQueryData<InfMessages>(
+			chatKeys.messages(chatId),
+		);
 		expect(data?.pages[0]?.queued_messages).toEqual([]);
 	});
 
@@ -1207,7 +1206,7 @@ describe("mutation invalidation scope", () => {
 			requireMessage(messages, 3),
 		);
 
-		queryClient.setQueryData<InfMessages>(chatMessagesKey(chatId), {
+		queryClient.setQueryData<InfMessages>(chatKeys.messages(chatId), {
 			pages: [{ messages, queued_messages: [], has_more: false }],
 			pageParams: [undefined],
 		});
@@ -1220,7 +1219,7 @@ describe("mutation invalidation scope", () => {
 		});
 
 		expect(
-			queryClient.getQueryData<InfMessages>(chatMessagesKey(chatId))?.pages[0]
+			queryClient.getQueryData<InfMessages>(chatKeys.messages(chatId))?.pages[0]
 				?.messages,
 		).toHaveLength(3);
 
@@ -1230,7 +1229,9 @@ describe("mutation invalidation scope", () => {
 			context,
 		);
 
-		const data = queryClient.getQueryData<InfMessages>(chatMessagesKey(chatId));
+		const data = queryClient.getQueryData<InfMessages>(
+			chatKeys.messages(chatId),
+		);
 		expect(data?.pages[0]?.messages.map((message) => message.id)).toEqual([
 			5, 4, 3, 2, 1,
 		]);
@@ -1253,7 +1254,7 @@ describe("mutation invalidation scope", () => {
 			role: "assistant" as const,
 		};
 
-		queryClient.setQueryData<InfMessages>(chatMessagesKey(chatId), {
+		queryClient.setQueryData<InfMessages>(chatKeys.messages(chatId), {
 			pages: [{ messages, queued_messages: [], has_more: false }],
 			pageParams: [undefined],
 		});
@@ -1265,7 +1266,7 @@ describe("mutation invalidation scope", () => {
 			req: editReq,
 		});
 		queryClient.setQueryData<InfMessages | undefined>(
-			chatMessagesKey(chatId),
+			chatKeys.messages(chatId),
 			(current) => {
 				if (!current) {
 					return current;
@@ -1287,7 +1288,9 @@ describe("mutation invalidation scope", () => {
 			{ messageId: 3, optimisticMessage, req: editReq },
 		);
 
-		const data = queryClient.getQueryData<InfMessages>(chatMessagesKey(chatId));
+		const data = queryClient.getQueryData<InfMessages>(
+			chatKeys.messages(chatId),
+		);
 		expect(data?.pages[0]?.messages.map((message) => message.id)).toEqual([
 			10, 9, 2, 1,
 		]);
@@ -1307,7 +1310,7 @@ describe("mutation invalidation scope", () => {
 		});
 
 		expect(context.previousData).toBeUndefined();
-		expect(queryClient.getQueryData(chatMessagesKey(chatId))).toBeUndefined();
+		expect(queryClient.getQueryData(chatKeys.messages(chatId))).toBeUndefined();
 	});
 
 	it("editChatMessage onError handles undefined context gracefully", async () => {
@@ -1315,7 +1318,7 @@ describe("mutation invalidation scope", () => {
 		const chatId = "chat-1";
 		const messages = [3, 2, 1].map((id) => makeMsg(chatId, id));
 
-		queryClient.setQueryData<InfMessages>(chatMessagesKey(chatId), {
+		queryClient.setQueryData<InfMessages>(chatKeys.messages(chatId), {
 			pages: [{ messages, queued_messages: [], has_more: false }],
 			pageParams: [undefined],
 		});
@@ -1331,14 +1334,16 @@ describe("mutation invalidation scope", () => {
 		);
 
 		// Cache should be untouched: no crash, no corruption.
-		const data = queryClient.getQueryData<InfMessages>(chatMessagesKey(chatId));
+		const data = queryClient.getQueryData<InfMessages>(
+			chatKeys.messages(chatId),
+		);
 		expect(data?.pages[0]?.messages.map((m) => m.id)).toEqual([3, 2, 1]);
 
 		await new Promise((r) => setTimeout(r, 0));
-		const messagesState = queryClient.getQueryState(chatMessagesKey(chatId));
+		const messagesState = queryClient.getQueryState(chatKeys.messages(chatId));
 		expect(
 			messagesState?.isInvalidated,
-			"chatMessagesKey should be invalidated even without context",
+			"chat messages should be invalidated even without context",
 		).toBe(true);
 	});
 
@@ -1351,7 +1356,7 @@ describe("mutation invalidation scope", () => {
 		const page1 = [5, 4, 3, 2, 1].map((id) => makeMsg(chatId, id));
 		const optimisticMessage = buildOptimisticMessage(requireMessage(page0, 7));
 
-		queryClient.setQueryData<InfMessages>(chatMessagesKey(chatId), {
+		queryClient.setQueryData<InfMessages>(chatKeys.messages(chatId), {
 			pages: [
 				{ messages: page0, queued_messages: [], has_more: true },
 				{ messages: page1, queued_messages: [], has_more: false },
@@ -1366,7 +1371,9 @@ describe("mutation invalidation scope", () => {
 			req: editReq,
 		});
 
-		const data = queryClient.getQueryData<InfMessages>(chatMessagesKey(chatId));
+		const data = queryClient.getQueryData<InfMessages>(
+			chatKeys.messages(chatId),
+		);
 		expect(data?.pages[0]?.messages.map((message) => message.id)).toEqual([
 			7, 6,
 		]);
@@ -1383,7 +1390,7 @@ describe("mutation invalidation scope", () => {
 			requireMessage(messages, 1),
 		);
 
-		queryClient.setQueryData<InfMessages>(chatMessagesKey(chatId), {
+		queryClient.setQueryData<InfMessages>(chatKeys.messages(chatId), {
 			pages: [{ messages, queued_messages: [], has_more: false }],
 			pageParams: [undefined],
 		});
@@ -1395,7 +1402,9 @@ describe("mutation invalidation scope", () => {
 			req: editReq,
 		});
 
-		const data = queryClient.getQueryData<InfMessages>(chatMessagesKey(chatId));
+		const data = queryClient.getQueryData<InfMessages>(
+			chatKeys.messages(chatId),
+		);
 		expect(data?.pages[0]?.messages.map((message) => message.id)).toEqual([1]);
 		expect(data?.pages[0]?.queued_messages).toEqual([]);
 		expect(data?.pages[0]?.has_more).toBe(false);
@@ -1409,7 +1418,7 @@ describe("mutation invalidation scope", () => {
 			requireMessage(messages, 5),
 		);
 
-		queryClient.setQueryData<InfMessages>(chatMessagesKey(chatId), {
+		queryClient.setQueryData<InfMessages>(chatKeys.messages(chatId), {
 			pages: [{ messages, queued_messages: [], has_more: false }],
 			pageParams: [undefined],
 		});
@@ -1421,7 +1430,9 @@ describe("mutation invalidation scope", () => {
 			req: editReq,
 		});
 
-		const data = queryClient.getQueryData<InfMessages>(chatMessagesKey(chatId));
+		const data = queryClient.getQueryData<InfMessages>(
+			chatKeys.messages(chatId),
+		);
 		expect(data?.pages[0]?.messages.map((message) => message.id)).toEqual([
 			5, 4, 3, 2, 1,
 		]);
@@ -1439,8 +1450,8 @@ describe("mutation invalidation scope", () => {
 		await mutation.onSuccess?.();
 
 		expect(
-			queryClient.getQueryState(chatDebugRunsKey(chatId))?.isInvalidated,
-			"chatDebugRunsKey should be invalidated",
+			queryClient.getQueryState(chatKeys.debugRuns(chatId))?.isInvalidated,
+			"debug runs should be invalidated",
 		).toBe(true);
 
 		for (const { label, key } of unrelatedKeys(chatId)) {
@@ -1461,8 +1472,8 @@ describe("mutation invalidation scope", () => {
 		await mutation.onSuccess?.();
 
 		expect(
-			queryClient.getQueryState(chatDebugRunsKey(chatId))?.isInvalidated,
-			"chatDebugRunsKey should be invalidated",
+			queryClient.getQueryState(chatKeys.debugRuns(chatId))?.isInvalidated,
+			"debug runs should be invalidated",
 		).toBe(true);
 
 		for (const { label, key } of unrelatedKeys(chatId)) {
@@ -1487,18 +1498,17 @@ describe("mutation invalidation scope", () => {
 			await mutation.onSettled(undefined, error, chatId);
 
 			expect(
-				queryClient.getQueryState(chatDebugRunsKey(chatId))?.isInvalidated,
-				"chatDebugRunsKey should be invalidated",
+				queryClient.getQueryState(chatKeys.debugRuns(chatId))?.isInvalidated,
+				"debug runs should be invalidated",
 			).toBe(true);
 
 			for (const { label, key } of [
-				{ label: "flat chats", key: chatsKey },
 				{
 					label: "infinite chats",
-					key: infiniteChatsKey({ archived: false }),
+					key: chatKeys.list({ archived: false }),
 				},
-				{ label: "chat detail", key: chatKey(chatId) },
-				{ label: "messages", key: chatMessagesKey(chatId) },
+				{ label: "chat detail", key: chatKeys.detail(chatId) },
+				{ label: "messages", key: chatKeys.messages(chatId) },
 				...unrelatedKeys(chatId),
 			]) {
 				const state = queryClient.getQueryState(key);
@@ -1522,11 +1532,7 @@ describe("mutation invalidation scope", () => {
 
 		// Sidebar lists SHOULD be invalidated.
 		expect(
-			queryClient.getQueryState(chatsKey)?.isInvalidated,
-			"flat chats should be invalidated",
-		).toBe(true);
-		expect(
-			queryClient.getQueryState(infiniteChatsKey({ archived: false }))
+			queryClient.getQueryState(chatKeys.list({ archived: false }))
 				?.isInvalidated,
 			"infinite chats should be invalidated",
 		).toBe(true);
@@ -1539,12 +1545,12 @@ describe("mutation invalidation scope", () => {
 			).not.toBe(true);
 		}
 		expect(
-			queryClient.getQueryState(chatKey(chatId))?.isInvalidated,
-			"chatKey should NOT be invalidated",
+			queryClient.getQueryState(chatKeys.detail(chatId))?.isInvalidated,
+			"the chat detail should NOT be invalidated",
 		).not.toBe(true);
 		expect(
-			queryClient.getQueryState(chatMessagesKey(chatId))?.isInvalidated,
-			"chatMessagesKey should NOT be invalidated",
+			queryClient.getQueryState(chatKeys.messages(chatId))?.isInvalidated,
+			"chat messages should NOT be invalidated",
 		).not.toBe(true);
 	});
 
@@ -1558,12 +1564,12 @@ describe("mutation invalidation scope", () => {
 
 		// These two should be invalidated (exact match).
 		expect(
-			queryClient.getQueryState(chatKey(chatId))?.isInvalidated,
-			"chatKey should be invalidated",
+			queryClient.getQueryState(chatKeys.detail(chatId))?.isInvalidated,
+			"the chat detail should be invalidated",
 		).toBe(true);
 		expect(
-			queryClient.getQueryState(chatMessagesKey(chatId))?.isInvalidated,
-			"chatMessagesKey should be invalidated",
+			queryClient.getQueryState(chatKeys.messages(chatId))?.isInvalidated,
+			"chat messages should be invalidated",
 		).toBe(true);
 
 		// Unrelated queries should NOT be touched.
@@ -1576,21 +1582,141 @@ describe("mutation invalidation scope", () => {
 
 		// Sidebar list should NOT be touched.
 		expect(
-			queryClient.getQueryState(chatsKey)?.isInvalidated,
-			"flat chats should NOT be invalidated",
+			queryClient.getQueryState(chatKeys.list({ archived: false }))
+				?.isInvalidated,
+			"infinite chats should NOT be invalidated",
 		).not.toBe(true);
 	});
 });
 
-describe("infiniteChatsKey shape", () => {
-	it("places the filter object one slot after the chatsKey prefix", () => {
-		// archivedFilterForChatListKey reads the archived filter from the
-		// slot immediately after the chatsKey prefix. If this layout ever
-		// changes, that helper silently stops removing chats from
-		// conflicting filtered lists, so keep the two in sync.
-		const key = infiniteChatsKey({ archived: true });
-		expect(key.length).toBe(chatsKey.length + 1);
-		expect(key[chatsKey.length]).toEqual({ archived: true });
+describe("chatKeys", () => {
+	it("composes every key from a literal in slot 1", () => {
+		const chatId = "chat-1";
+
+		expect(chatKeys.all).toEqual(["chats"]);
+		expect(chatKeys.lists()).toEqual(["chats", "list"]);
+		expect(chatKeys.list({ archived: true })).toEqual([
+			"chats",
+			"list",
+			{ filters: { archived: true } },
+		]);
+		expect(chatKeys.details()).toEqual(["chats", "detail"]);
+		expect(chatKeys.detail(chatId)).toEqual(["chats", "detail", chatId]);
+		expect(chatKeys.messages(chatId)).toEqual([
+			"chats",
+			"detail",
+			chatId,
+			"messages",
+		]);
+		expect(chatKeys.debugRun(chatId, "run-1")).toEqual([
+			"chats",
+			"detail",
+			chatId,
+			"debug-runs",
+			"run-1",
+		]);
+		expect(chatKeys.search("title:fix")).toEqual([
+			"chats",
+			"search",
+			{ q: "title:fix" },
+		]);
+		expect(chatKeys.byWorkspacePrefix()).toEqual(["chats", "by-workspace"]);
+	});
+
+	it("sorts workspace ids so argument order cannot fork the cache", () => {
+		expect(hashKey(chatKeys.byWorkspace(["ws-2", "ws-1"]))).toBe(
+			hashKey(chatKeys.byWorkspace(["ws-1", "ws-2"])),
+		);
+	});
+
+	it("hashes every empty filter input to one cache entry", () => {
+		const expected = hashKey(chatKeys.list());
+
+		expect(hashKey(chatKeys.list({}))).toBe(expected);
+		expect(hashKey(chatKeys.list({ prStatuses: [] }))).toBe(expected);
+		expect(hashKey(chatKeys.list({ sources: [] }))).toBe(expected);
+		expect(hashKey(chatKeys.list({ chatStatus: undefined }))).toBe(expected);
+	});
+
+	it("keeps archived:false, which is a real filter value", () => {
+		expect(hashKey(chatKeys.list({ archived: false }))).not.toBe(
+			hashKey(chatKeys.list({})),
+		);
+	});
+
+	it("hashes array order variants together and requests the same q", () => {
+		const ascending = infiniteChats({
+			prStatuses: ["open", "draft"],
+			sources: ["shared_with_me", "created_by_me"],
+		});
+		const descending = infiniteChats({
+			prStatuses: ["draft", "open"],
+			sources: ["created_by_me", "shared_with_me"],
+		});
+
+		expect(hashKey(ascending.queryKey)).toBe(hashKey(descending.queryKey));
+
+		vi.mocked(API.experimental.getChats).mockResolvedValue([]);
+		ascending.queryFn({ pageParam: 0 });
+		descending.queryFn({ pageParam: 0 });
+		const [firstCall, secondCall] = vi.mocked(API.experimental.getChats).mock
+			.calls;
+		expect(firstCall[0]?.q).toBe(
+			"pr_status:draft,open source:created_by_me,shared_with_me",
+		);
+		expect(secondCall[0]?.q).toBe(firstCall[0]?.q);
+	});
+
+	it("matches only infinite lists under the lists() prefix", () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+
+		queryClient.setQueryData(chatKeys.list({ archived: false }), {
+			pages: [[makeChat(chatId)]],
+			pageParams: [0],
+		});
+		queryClient.setQueryData(chatKeys.search("fix"), [makeChat(chatId)]);
+		queryClient.setQueryData(chatKeys.byWorkspace(["ws-1"]), {
+			"ws-1": chatId,
+		});
+		queryClient.setQueryData(chatKeys.detail(chatId), makeChat(chatId));
+		queryClient.setQueryData(chatKeys.messages(chatId), []);
+		queryClient.setQueryData(
+			chatKeys.costSummary("me"),
+			{} as TypesGen.ChatCostSummary,
+		);
+
+		const matched = queryClient
+			.getQueryCache()
+			.findAll({ queryKey: chatKeys.lists() })
+			.map((query) => query.queryKey);
+
+		expect(matched).toEqual([chatKeys.list({ archived: false })]);
+	});
+});
+
+describe("canonicalizeChatListFilters", () => {
+	it("drops absent fields and empty arrays", () => {
+		expect(
+			canonicalizeChatListFilters({
+				archived: false,
+				chatStatus: undefined,
+				prStatuses: [],
+				sources: [],
+			}),
+		).toEqual({ archived: false });
+	});
+
+	it("orders array values", () => {
+		expect(
+			canonicalizeChatListFilters({
+				prStatuses: ["closed", "draft"],
+				sources: ["shared_with_me", "created_by_me"],
+			}),
+		).toEqual({
+			prStatuses: ["draft", "closed"],
+			sources: ["created_by_me", "shared_with_me"],
+		});
 	});
 });
 
@@ -1718,70 +1844,73 @@ describe("diff_status_change invalidation scope", () => {
 	// invalidate only the individual chat detail and diff-contents
 	// queries, NOT the chat list (sidebar) or messages.
 
-	it("exact chatKey invalidation does not cascade to messages or diff-contents", async () => {
+	it("exact detail invalidation does not cascade to messages or diff-contents", async () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";
 
 		// Seed all the queries that are active on the /agents/:id page.
-		queryClient.setQueryData(chatKey(chatId), makeChat(chatId));
-		queryClient.setQueryData(chatMessagesKey(chatId), []);
-		queryClient.setQueryData(chatDiffContentsKey(chatId), { files: [] });
-		queryClient.setQueryData(chatsKey, [makeChat(chatId)]);
+		queryClient.setQueryData(chatKeys.detail(chatId), makeChat(chatId));
+		queryClient.setQueryData(chatKeys.messages(chatId), []);
+		queryClient.setQueryData(chatKeys.diffContents(chatId), { files: [] });
+		queryClient.setQueryData(chatKeys.list(), {
+			pages: [[makeChat(chatId)]],
+			pageParams: [0],
+		});
 
 		// This is what the fixed handler does, exact: true.
 		await queryClient.invalidateQueries({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
 
-		// chatKey itself should be invalidated.
+		// The chat detail itself should be invalidated.
 		expect(
-			queryClient.getQueryState(chatKey(chatId))?.isInvalidated,
-			"chatKey should be invalidated",
+			queryClient.getQueryState(chatKeys.detail(chatId))?.isInvalidated,
+			"the chat detail should be invalidated",
 		).toBe(true);
 
 		// Messages should NOT be invalidated.
 		expect(
-			queryClient.getQueryState(chatMessagesKey(chatId))?.isInvalidated,
-			"chatMessagesKey should NOT be invalidated by exact chatKey",
+			queryClient.getQueryState(chatKeys.messages(chatId))?.isInvalidated,
+			"chat messages should NOT be invalidated by an exact detail filter",
 		).not.toBe(true);
 
 		// Diff-contents should NOT be invalidated.
 		expect(
-			queryClient.getQueryState(chatDiffContentsKey(chatId))?.isInvalidated,
-			"chatDiffContentsKey should NOT be invalidated by exact chatKey",
+			queryClient.getQueryState(chatKeys.diffContents(chatId))?.isInvalidated,
+			"chat diff contents should NOT be invalidated by an exact detail filter",
 		).not.toBe(true);
 
 		// Chat list should NOT be invalidated.
 		expect(
-			queryClient.getQueryState(chatsKey)?.isInvalidated,
-			"chatsKey should NOT be invalidated by exact chatKey",
+			queryClient.getQueryState(chatKeys.list())?.isInvalidated,
+			"infinite chats should NOT be invalidated by an exact detail filter",
 		).not.toBe(true);
 	});
 
-	it("without exact: true, chatKey invalidation cascades to messages and diff-contents (the old bug)", async () => {
+	it("without exact: true, detail invalidation cascades to messages and diff-contents (the old bug)", async () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";
 
-		queryClient.setQueryData(chatKey(chatId), makeChat(chatId));
-		queryClient.setQueryData(chatMessagesKey(chatId), []);
-		queryClient.setQueryData(chatDiffContentsKey(chatId), { files: [] });
+		queryClient.setQueryData(chatKeys.detail(chatId), makeChat(chatId));
+		queryClient.setQueryData(chatKeys.messages(chatId), []);
+		queryClient.setQueryData(chatKeys.diffContents(chatId), { files: [] });
 
 		// This is what the OLD (broken) handler did, no exact: true.
 		await queryClient.invalidateQueries({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 		});
 
-		// Without exact: true, ALL queries starting with ["chats", chatId]
-		// get invalidated, including messages and diff-contents.
+		// Without exact: true, every sub-resource of the chat detail key
+		// gets invalidated, including messages and diff-contents.
 		expect(
-			queryClient.getQueryState(chatMessagesKey(chatId))?.isInvalidated,
-			"chatMessagesKey IS invalidated without exact: true (old bug)",
+			queryClient.getQueryState(chatKeys.messages(chatId))?.isInvalidated,
+			"chat messages ARE invalidated without exact: true (old bug)",
 		).toBe(true);
 
 		expect(
-			queryClient.getQueryState(chatDiffContentsKey(chatId))?.isInvalidated,
-			"chatDiffContentsKey IS invalidated without exact: true (old bug)",
+			queryClient.getQueryState(chatKeys.diffContents(chatId))?.isInvalidated,
+			"chat diff contents ARE invalidated without exact: true (old bug)",
 		).toBe(true);
 	});
 });
@@ -2637,7 +2766,7 @@ describe("mergeWatchedChatIntoCaches", () => {
 		});
 
 		seedInfiniteChats(queryClient, [cachedChat]);
-		queryClient.setQueryData(chatKey(chatId), cachedChat);
+		queryClient.setQueryData(chatKeys.detail(chatId), cachedChat);
 
 		mergeWatchedChatIntoCaches(queryClient, watchedChat, {
 			eventKind: "status_change",
@@ -2649,7 +2778,7 @@ describe("mergeWatchedChatIntoCaches", () => {
 			updated_at: "2025-01-01T00:05:00.000Z",
 		});
 		expect(
-			queryClient.getQueryData<TypesGen.Chat>(chatKey(chatId)),
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId)),
 		).toMatchObject({
 			status: "running",
 			last_model_config_id: "model-new",
@@ -2677,7 +2806,7 @@ describe("mergeWatchedChatIntoCaches", () => {
 		});
 
 		seedInfiniteChats(queryClient, [parent]);
-		queryClient.setQueryData(chatKey(childId), cachedChild);
+		queryClient.setQueryData(chatKeys.detail(childId), cachedChild);
 
 		mergeWatchedChatIntoCaches(queryClient, watchedChild, {
 			eventKind: "status_change",
@@ -2689,7 +2818,7 @@ describe("mergeWatchedChatIntoCaches", () => {
 			updated_at: "2025-01-01T00:05:00.000Z",
 		});
 		expect(
-			queryClient.getQueryData<TypesGen.Chat>(chatKey(childId)),
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(childId)),
 		).toMatchObject({
 			status: "running",
 			last_model_config_id: "model-new",
@@ -2718,7 +2847,7 @@ describe("mergeWatchedChatIntoCaches", () => {
 		});
 
 		seedInfiniteChats(queryClient, [cachedChat]);
-		queryClient.setQueryData(chatKey(chatId), cachedChat);
+		queryClient.setQueryData(chatKeys.detail(chatId), cachedChat);
 
 		mergeWatchedChatIntoCaches(queryClient, staleWatchChat, {
 			eventKind: "status_change",
@@ -2733,7 +2862,7 @@ describe("mergeWatchedChatIntoCaches", () => {
 			updated_at: "2025-01-01T00:05:00.000Z",
 		});
 		expect(
-			queryClient.getQueryData<TypesGen.Chat>(chatKey(chatId)),
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId)),
 		).toMatchObject({
 			status: "waiting",
 			title: "Fresh title",
@@ -2829,8 +2958,8 @@ describe("chat ACL query factories", () => {
 
 		const query = chatACL(chatId);
 
-		expect(chatACLKey(chatId)).toEqual(["chats", chatId, "acl"]);
-		expect(query.queryKey).toEqual(chatACLKey(chatId));
+		expect(chatKeys.acl(chatId)).toEqual(["chats", "detail", chatId, "acl"]);
+		expect(query.queryKey).toEqual(chatKeys.acl(chatId));
 		await expect(query.queryFn()).resolves.toEqual(acl);
 		expect(API.experimental.getChatACL).toHaveBeenCalledWith(chatId);
 	});
@@ -2838,7 +2967,7 @@ describe("chat ACL query factories", () => {
 	it("sets one chat user role and invalidates the ACL", async () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";
-		queryClient.setQueryData(chatACLKey(chatId), { users: [], groups: [] });
+		queryClient.setQueryData(chatKeys.acl(chatId), { users: [], groups: [] });
 		vi.mocked(API.experimental.updateChatACL).mockResolvedValue();
 
 		const mutation = setChatUserRole(queryClient);
@@ -2849,7 +2978,7 @@ describe("chat ACL query factories", () => {
 		});
 
 		await mutation.onSuccess?.(undefined, variables);
-		expect(queryClient.getQueryState(chatACLKey(chatId))?.isInvalidated).toBe(
+		expect(queryClient.getQueryState(chatKeys.acl(chatId))?.isInvalidated).toBe(
 			true,
 		);
 	});
@@ -2857,7 +2986,7 @@ describe("chat ACL query factories", () => {
 	it("sets one chat group role and invalidates the ACL", async () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";
-		queryClient.setQueryData(chatACLKey(chatId), { users: [], groups: [] });
+		queryClient.setQueryData(chatKeys.acl(chatId), { users: [], groups: [] });
 		vi.mocked(API.experimental.updateChatACL).mockResolvedValue();
 
 		const mutation = setChatGroupRole(queryClient);
@@ -2868,7 +2997,7 @@ describe("chat ACL query factories", () => {
 		});
 
 		await mutation.onSuccess?.(undefined, variables);
-		expect(queryClient.getQueryState(chatACLKey(chatId))?.isInvalidated).toBe(
+		expect(queryClient.getQueryState(chatKeys.acl(chatId))?.isInvalidated).toBe(
 			true,
 		);
 	});

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -9,24 +9,12 @@ import {
 	type ChatPlanModeOrClear,
 	type CreateChatMessageRequestWithClearablePlanMode,
 } from "#/api/api";
-import type * as TypesGen from "#/api/typesGenerated";
+import * as TypesGen from "#/api/typesGenerated";
 import type { UsePaginatedQueryOptions } from "#/hooks/usePaginatedQuery";
 import {
 	projectEditedConversationIntoCache,
 	reconcileEditedMessageInCache,
 } from "./chatMessageEdits";
-
-export const chatsKey = ["chats"] as const;
-export const chatKey = (chatId: string) => ["chats", chatId] as const;
-export const chatMessagesKey = (chatId: string) =>
-	["chats", chatId, "messages"] as const;
-export const chatPromptsKey = (chatId: string) =>
-	["chats", chatId, "prompts"] as const;
-
-const chatQueueConvergenceKey = (chatId: string) =>
-	["chats", chatId, "queue-convergence"] as const;
-
-export const chatACLKey = (chatId: string) => ["chats", chatId, "acl"] as const;
 
 export type ChatListPRStatusFilter = "draft" | "open" | "merged" | "closed";
 export type ChatListStatusFilter = "read" | "unread";
@@ -37,9 +25,6 @@ type InfiniteChatsFilters = Readonly<{
 	chatStatus?: ChatListStatusFilter;
 	sources?: readonly TypesGen.ChatListSource[];
 }>;
-
-export const infiniteChatsKey = (filters?: InfiniteChatsFilters) =>
-	[...chatsKey, filters] as const;
 
 export const CHAT_LIST_PR_STATUS_ORDER = [
 	"draft",
@@ -71,12 +56,104 @@ export const canonicalizeChatListPRStatuses = (
 	return CHAT_LIST_PR_STATUS_ORDER.filter((status) => selected.has(status));
 };
 
-export const chatsByWorkspaceKeyPrefix = [...chatsKey, "by-workspace"] as const;
+/** Shared ordering keeps URL serialization stable. */
+const canonicalizeChatListSources = (
+	sources: Iterable<unknown>,
+): readonly TypesGen.ChatListSource[] => {
+	const selected = new Set<unknown>(sources);
+	return TypesGen.ChatListSources.filter((source) => selected.has(source));
+};
+
+/**
+ * Canonical filter form shared by the sidebar list key and its request query
+ * string. Equivalent inputs must produce one cache entry and one `q`, so
+ * absent fields and empty arrays are dropped and array values are ordered.
+ * Only `undefined` is dropped: `archived: false` is a real filter value.
+ */
+export const canonicalizeChatListFilters = (
+	filters?: InfiniteChatsFilters,
+): InfiniteChatsFilters => {
+	const canonical: {
+		archived?: boolean;
+		prStatuses?: readonly ChatListPRStatusFilter[];
+		chatStatus?: ChatListStatusFilter;
+		sources?: readonly TypesGen.ChatListSource[];
+	} = {};
+
+	if (filters?.archived !== undefined) {
+		canonical.archived = filters.archived;
+	}
+	if (filters?.chatStatus !== undefined) {
+		canonical.chatStatus = filters.chatStatus;
+	}
+	const prStatuses = canonicalizeChatListPRStatuses(filters?.prStatuses ?? []);
+	if (prStatuses.length > 0) {
+		canonical.prStatuses = prStatuses;
+	}
+	const sources = canonicalizeChatListSources(filters?.sources ?? []);
+	if (sources.length > 0) {
+		canonical.sources = sources;
+	}
+
+	return canonical;
+};
+
+/**
+ * Query keys for the Agents feature. Slot 1 is always a literal, so every
+ * prefix is unambiguous: `list` for the sidebar's infinite filtered lists,
+ * `detail` for a chat and its sub-resources, and one literal per remaining
+ * resource.
+ *
+ * `search` and `byWorkspace` are siblings of `list`, not children. They cache
+ * plain arrays and records rather than InfiniteData, so the `lists()` prefix
+ * must never reach them.
+ */
+export const chatKeys = {
+	all: ["chats"] as const,
+
+	lists: () => [...chatKeys.all, "list"] as const,
+	list: (filters?: InfiniteChatsFilters) =>
+		[
+			...chatKeys.lists(),
+			{ filters: canonicalizeChatListFilters(filters) },
+		] as const,
+
+	details: () => [...chatKeys.all, "detail"] as const,
+	detail: (chatId: string) => [...chatKeys.details(), chatId] as const,
+	messages: (chatId: string) =>
+		[...chatKeys.detail(chatId), "messages"] as const,
+	prompts: (chatId: string) => [...chatKeys.detail(chatId), "prompts"] as const,
+	queueConvergence: (chatId: string) =>
+		[...chatKeys.detail(chatId), "queue-convergence"] as const,
+	acl: (chatId: string) => [...chatKeys.detail(chatId), "acl"] as const,
+	diffContents: (chatId: string) =>
+		[...chatKeys.detail(chatId), "diff-contents"] as const,
+	cost: (chatId: string) => [...chatKeys.detail(chatId), "cost"] as const,
+	debugRuns: (chatId: string) =>
+		[...chatKeys.detail(chatId), "debug-runs"] as const,
+	debugRun: (chatId: string, runId: string) =>
+		[...chatKeys.debugRuns(chatId), runId] as const,
+
+	search: (q: string) => [...chatKeys.all, "search", { q }] as const,
+	byWorkspacePrefix: () => [...chatKeys.all, "by-workspace"] as const,
+	byWorkspace: (workspaceIds: string[]) =>
+		[...chatKeys.byWorkspacePrefix(), workspaceIds.toSorted()] as const,
+	costSummary: (user: string, params?: ChatCostDateParams) =>
+		[...chatKeys.all, "cost-summary", user, params ?? {}] as const,
+	costUsers: (payload: PaginatedChatCostUsersPayload, pageNumber: number) =>
+		[...chatKeys.all, "cost-users", payload, pageNumber] as const,
+	usageLimitStatus: () => [...chatKeys.all, "usage-limit-status"] as const,
+	usageLimitConfig: () => [...chatKeys.all, "usage-limit-config"] as const,
+	adminPersonalModelOverrides: () =>
+		[...chatKeys.all, "admin-personal-model-overrides"] as const,
+	userPersonalModelOverrides: () =>
+		[...chatKeys.all, "user-personal-model-overrides"] as const,
+};
 
 export const chatsByWorkspace = (workspaceIds: string[]) => {
 	const sorted = workspaceIds.toSorted();
 	return {
-		queryKey: [...chatsKey, "by-workspace", sorted],
+		queryKey: chatKeys.byWorkspace(sorted),
 		queryFn: () => API.experimental.getChatsByWorkspace(sorted),
 		enabled: workspaceIds.length > 0,
 	};
@@ -84,8 +161,8 @@ export const chatsByWorkspace = (workspaceIds: string[]) => {
 
 /**
  * Updates a single chat inside every page of the infinite chats query
- * cache. Use this instead of setQueryData(chatsKey, ...) which writes
- * to the wrong key (the flat list key, not the infinite query key).
+ * cache. Use this instead of writing one list key directly, which would
+ * leave the other cached filter combinations stale.
  */
 export const updateInfiniteChatsCache = (
 	queryClient: QueryClient,
@@ -93,7 +170,7 @@ export const updateInfiniteChatsCache = (
 ) => {
 	// Update ALL infinite chat queries regardless of their filter opts.
 	queryClient.setQueriesData<InfiniteChatsCacheData>(
-		{ queryKey: chatsKey, predicate: isChatListQuery },
+		{ queryKey: chatKeys.lists() },
 		(prev) => {
 			if (!prev?.pages) return prev;
 			const nextPages = prev.pages.map((page) => updater(page));
@@ -116,7 +193,7 @@ export const prependToInfiniteChatsCache = (
 	chat: TypesGen.Chat,
 ) => {
 	queryClient.setQueriesData<InfiniteChatsCacheData>(
-		{ queryKey: chatsKey, predicate: isChatListQuery },
+		{ queryKey: chatKeys.lists() },
 		(prev) => {
 			if (!prev?.pages) return prev;
 			// Check across ALL pages to avoid duplicates.
@@ -141,8 +218,7 @@ export const readInfiniteChatsCache = (
 	queryClient: QueryClient,
 ): TypesGen.Chat[] | undefined => {
 	const queries = queryClient.getQueriesData<InfiniteChatsCacheData>({
-		queryKey: chatsKey,
-		predicate: isChatListQuery,
+		queryKey: chatKeys.lists(),
 	});
 	for (const [, data] of queries) {
 		if (data?.pages) {
@@ -236,22 +312,23 @@ export const removeChildFromParentInCache = (
 	return found;
 };
 
-// Inverse of infiniteChatsKey, which builds keys as [...chatsKey, filters?].
-// The optional filter object lives in the slot immediately after the
-// chatsKey prefix, so derive both the expected length and the filter index
-// from chatsKey. If infiniteChatsKey's shape changes, this must change with
-// it; the "infiniteChatsKey shape" test in chats.test.ts guards that contract.
-const archivedFilterForChatListKey = (
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+
+// Inverse of chatKeys.list, which appends a single { filters } wrapper to the
+// chatKeys.lists() prefix. The length and shape checks narrow the readonly
+// unknown[] the query cache hands back, and reject any other list-prefixed key.
+const archivedFilterFromListKey = (
 	queryKey: readonly unknown[],
 ): boolean | undefined => {
-	if (queryKey.length !== chatsKey.length + 1) {
+	if (queryKey.length !== chatKeys.lists().length + 1) {
 		return undefined;
 	}
-	const filters = queryKey[chatsKey.length];
-	if (!filters || typeof filters !== "object") {
+	const wrapper = queryKey[chatKeys.lists().length];
+	if (!isPlainObject(wrapper) || !isPlainObject(wrapper.filters)) {
 		return undefined;
 	}
-	const archived = (filters as { archived?: unknown }).archived;
+	const archived = wrapper.filters.archived;
 	return typeof archived === "boolean" ? archived : undefined;
 };
 
@@ -287,7 +364,7 @@ export const applyChatArchiveStateToCaches = (
 	archived: boolean,
 ) => {
 	queryClient.setQueryData<TypesGen.Chat | undefined>(
-		chatKey(chatId),
+		chatKeys.detail(chatId),
 		(chat) => (chat ? patchChatArchiveState(chat, archived) : chat),
 	);
 
@@ -302,15 +379,14 @@ export const applyChatArchiveStateToCaches = (
 	}
 
 	const queries = queryClient.getQueriesData<InfiniteChatsCacheData>({
-		queryKey: chatsKey,
-		predicate: isChatListQuery,
+		queryKey: chatKeys.lists(),
 	});
 
 	for (const [queryKey, data] of queries) {
 		if (!isInfiniteChatsCacheData(data)) {
 			continue;
 		}
-		const archivedFilter = archivedFilterForChatListKey(queryKey);
+		const archivedFilter = archivedFilterFromListKey(queryKey);
 		queryClient.setQueryData<InfiniteChatsCacheData>(queryKey, (prev) => {
 			if (!isInfiniteChatsCacheData(prev)) {
 				return prev;
@@ -542,7 +618,7 @@ export const mergeWatchedChatIntoCaches = (
 
 	updateChildInParentCache(queryClient, mergeCachedChat, watchedChat.id);
 	queryClient.setQueryData<TypesGen.Chat | undefined>(
-		chatKey(watchedChat.id),
+		chatKeys.detail(watchedChat.id),
 		(cachedChat) => {
 			if (!cachedChat) {
 				return cachedChat;
@@ -554,22 +630,12 @@ export const mergeWatchedChatIntoCaches = (
 
 const getNextOptimisticPinOrder = (queryClient: QueryClient): number => {
 	let maxPinOrder = 0;
-	const queries = queryClient.getQueriesData<
-		TypesGen.Chat[] | { pages: TypesGen.Chat[][]; pageParams: unknown[] }
-	>({
-		queryKey: chatsKey,
-		predicate: isChatListQuery,
+	const queries = queryClient.getQueriesData<InfiniteChatsCacheData>({
+		queryKey: chatKeys.lists(),
 	});
 
 	for (const [, data] of queries) {
 		if (!data) {
-			continue;
-		}
-
-		if (Array.isArray(data)) {
-			for (const chat of data) {
-				maxPinOrder = Math.max(maxPinOrder, chat.pin_order);
-			}
 			continue;
 		}
 
@@ -583,27 +649,9 @@ const getNextOptimisticPinOrder = (queryClient: QueryClient): number => {
 	return maxPinOrder + 1;
 };
 
-/**
- * Predicate that matches only chat-list queries (the sidebar), not
- * per-chat queries (detail, messages, diffs, cost).
- *
- * Sidebar keys look like ["chats"] or ["chats", <object|undefined>].
- * Per-chat keys look like ["chats", <string-id>, ...].
- */
-const isChatListQuery = (query: { queryKey: readonly unknown[] }): boolean => {
-	const key = query.queryKey;
-	// Match: ["chats"] (flat list).
-	if (key.length <= 1) return true;
-	// Match: ["chats", <object | undefined>] (infinite query
-	// with optional filter opts like {archived, q}).
-	const segment = key[1];
-	return segment === undefined || typeof segment === "object";
-};
-
 export const invalidateChatListQueries = (queryClient: QueryClient) => {
 	return queryClient.invalidateQueries({
-		queryKey: chatsKey,
-		predicate: isChatListQuery,
+		queryKey: chatKeys.lists(),
 	});
 };
 
@@ -621,10 +669,8 @@ export const invalidateChatListQueries = (queryClient: QueryClient) => {
  * forever until the user refocuses the window.
  */
 const isChatListRefetch = (query: {
-	queryKey: readonly unknown[];
 	state: { data: unknown; fetchMeta: unknown };
 }): boolean => {
-	if (!isChatListQuery(query)) return false;
 	// Never cancel the initial load. Reverting a first-ever
 	// fetch produces a stuck pending/idle state that react-query
 	// does not automatically recover from.
@@ -647,15 +693,15 @@ const isChatListRefetch = (query: {
  * cancelling them would prevent the sidebar from loading
  * additional pages when WebSocket events arrive frequently.
  *
- * Mutation onMutate handlers should keep the broad
- * isChatListQuery predicate instead: mutations are infrequent
+ * Mutation onMutate handlers should keep cancelling the whole
+ * chatKeys.lists() prefix instead: mutations are infrequent
  * and must cancel pagination fetches to protect optimistic
  * updates from being overwritten by the oldPages snapshot
  * that fetchNextPage captured before the mutation.
  */
 export const cancelChatListRefetches = (queryClient: QueryClient) => {
 	return queryClient.cancelQueries({
-		queryKey: chatsKey,
+		queryKey: chatKeys.lists(),
 		predicate: isChatListRefetch,
 	});
 };
@@ -703,10 +749,13 @@ const getInfiniteChatsQueryString = (
 
 export const infiniteChats = (filters?: InfiniteChatsFilters) => {
 	const limit = DEFAULT_CHAT_PAGE_LIMIT;
-	const q = getInfiniteChatsQueryString(filters);
+	// One canonical object feeds both the key and the request, so equivalent
+	// filter inputs can never share a cache entry while issuing different `q`.
+	const canonicalFilters = canonicalizeChatListFilters(filters);
+	const q = getInfiniteChatsQueryString(canonicalFilters);
 
 	return {
-		queryKey: infiniteChatsKey(filters),
+		queryKey: chatKeys.list(canonicalFilters),
 		getNextPageParam: (lastPage: TypesGen.Chat[], pages: TypesGen.Chat[][]) => {
 			if (lastPage.length < limit) {
 				return undefined;
@@ -731,7 +780,7 @@ export const infiniteChats = (filters?: InfiniteChatsFilters) => {
 
 export const chatSearch = (q: string) =>
 	queryOptions({
-		queryKey: [...chatsKey, "search", { q }],
+		queryKey: chatKeys.search(q),
 		queryFn: () =>
 			API.experimental.getChats({
 				limit: CHAT_SEARCH_LIMIT,
@@ -740,12 +789,12 @@ export const chatSearch = (q: string) =>
 	});
 
 export const chat = (chatId: string) => ({
-	queryKey: chatKey(chatId),
+	queryKey: chatKeys.detail(chatId),
 	queryFn: () => API.experimental.getChat(chatId),
 });
 
 export const chatACL = (chatId: string) => ({
-	queryKey: chatACLKey(chatId),
+	queryKey: chatKeys.acl(chatId),
 	queryFn: () => API.experimental.getChatACL(chatId),
 });
 
@@ -755,13 +804,13 @@ const MESSAGES_PAGE_SIZE = 50;
 // so settling the queue after a promote needs its own request. Refetching
 // chatMessagesForInfiniteScroll would reload every page already scrolled.
 export const chatQueueConvergence = (chatId: string) => ({
-	queryKey: chatQueueConvergenceKey(chatId),
+	queryKey: chatKeys.queueConvergence(chatId),
 	queryFn: () => API.experimental.getChatMessages(chatId),
 	gcTime: 0,
 });
 
 export const chatMessagesForInfiniteScroll = (chatId: string) => ({
-	queryKey: chatMessagesKey(chatId),
+	queryKey: chatKeys.messages(chatId),
 	initialPageParam: undefined as number | undefined,
 	queryFn: ({ pageParam }: { pageParam: number | undefined }) =>
 		API.experimental.getChatMessages(chatId, {
@@ -785,7 +834,7 @@ const PROMPT_HISTORY_LIMIT = 500;
 const PROMPTS_STALE_MS = 30_000;
 
 export const chatPromptsQuery = (chatId: string) => ({
-	queryKey: chatPromptsKey(chatId),
+	queryKey: chatKeys.prompts(chatId),
 	queryFn: () =>
 		API.experimental.getChatPrompts(chatId, { limit: PROMPT_HISTORY_LIMIT }),
 	staleTime: PROMPTS_STALE_MS,
@@ -797,17 +846,16 @@ export const archiveChat = (queryClient: QueryClient) => ({
 		API.experimental.updateChat(chatId, { archived: true }),
 	onMutate: async (chatId: string) => {
 		await queryClient.cancelQueries({
-			queryKey: chatsKey,
-			predicate: isChatListQuery,
+			queryKey: chatKeys.lists(),
 		});
 		await queryClient.cancelQueries({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
 		const previousChat = queryClient.getQueryData<TypesGen.Chat>(
-			chatKey(chatId),
+			chatKeys.detail(chatId),
 		);
-		// Flip archived flag in the flat root list; strip the
+		// Flip the archived flag in every cached list; strip the
 		// chat from any parent's embedded children (individual
 		// child archive). Reuse patchChatArchiveState so the
 		// optimistic snapshot matches the confirmed onSuccess state,
@@ -820,7 +868,7 @@ export const archiveChat = (queryClient: QueryClient) => ({
 		removeChildFromParentInCache(queryClient, chatId);
 		if (previousChat) {
 			queryClient.setQueryData<TypesGen.Chat>(
-				chatKey(chatId),
+				chatKeys.detail(chatId),
 				patchChatArchiveState(previousChat, true),
 			);
 		}
@@ -839,7 +887,7 @@ export const archiveChat = (queryClient: QueryClient) => ({
 		void invalidateChatListQueries(queryClient);
 		if (context?.previousChat) {
 			queryClient.setQueryData<TypesGen.Chat>(
-				chatKey(chatId),
+				chatKeys.detail(chatId),
 				context.previousChat,
 			);
 		}
@@ -850,11 +898,11 @@ export const archiveChat = (queryClient: QueryClient) => ({
 	onSettled: (_data: unknown, _error: unknown, chatId: string) => {
 		void invalidateChatListQueries(queryClient);
 		void queryClient.invalidateQueries({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
 		void queryClient.invalidateQueries({
-			queryKey: chatsByWorkspaceKeyPrefix,
+			queryKey: chatKeys.byWorkspacePrefix(),
 		});
 	},
 });
@@ -864,15 +912,14 @@ export const unarchiveChat = (queryClient: QueryClient) => ({
 		API.experimental.updateChat(chatId, { archived: false }),
 	onMutate: async (chatId: string) => {
 		await queryClient.cancelQueries({
-			queryKey: chatsKey,
-			predicate: isChatListQuery,
+			queryKey: chatKeys.lists(),
 		});
 		await queryClient.cancelQueries({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
 		const previousChat = queryClient.getQueryData<TypesGen.Chat>(
-			chatKey(chatId),
+			chatKeys.detail(chatId),
 		);
 		// Reuse patchChatArchiveState so the optimistic snapshot
 		// matches the confirmed onSuccess state.
@@ -883,7 +930,7 @@ export const unarchiveChat = (queryClient: QueryClient) => ({
 		);
 		if (previousChat) {
 			queryClient.setQueryData<TypesGen.Chat>(
-				chatKey(chatId),
+				chatKeys.detail(chatId),
 				patchChatArchiveState(previousChat, false),
 			);
 		}
@@ -902,7 +949,7 @@ export const unarchiveChat = (queryClient: QueryClient) => ({
 		void invalidateChatListQueries(queryClient);
 		if (context?.previousChat) {
 			queryClient.setQueryData<TypesGen.Chat>(
-				chatKey(chatId),
+				chatKeys.detail(chatId),
 				context.previousChat,
 			);
 		}
@@ -913,11 +960,11 @@ export const unarchiveChat = (queryClient: QueryClient) => ({
 	onSettled: (_data: unknown, _error: unknown, chatId: string) => {
 		void invalidateChatListQueries(queryClient);
 		void queryClient.invalidateQueries({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
 		void queryClient.invalidateQueries({
-			queryKey: chatsByWorkspaceKeyPrefix,
+			queryKey: chatKeys.byWorkspacePrefix(),
 		});
 	},
 });
@@ -929,15 +976,14 @@ export const updateChatPlanMode = (queryClient: QueryClient) => ({
 		}),
 	onMutate: async ({ chatId, planMode }: UpdateChatPlanModeVariables) => {
 		await queryClient.cancelQueries({
-			queryKey: chatsKey,
-			predicate: isChatListQuery,
+			queryKey: chatKeys.lists(),
 		});
 		await queryClient.cancelQueries({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
 		const previousChat = queryClient.getQueryData<TypesGen.Chat>(
-			chatKey(chatId),
+			chatKeys.detail(chatId),
 		);
 		updateInfiniteChatsCache(queryClient, (chats) =>
 			chats.map((chat) =>
@@ -945,7 +991,7 @@ export const updateChatPlanMode = (queryClient: QueryClient) => ({
 			),
 		);
 		if (previousChat) {
-			queryClient.setQueryData<TypesGen.Chat>(chatKey(chatId), {
+			queryClient.setQueryData<TypesGen.Chat>(chatKeys.detail(chatId), {
 				...previousChat,
 				plan_mode: planMode,
 			});
@@ -976,7 +1022,10 @@ export const updateChatPlanMode = (queryClient: QueryClient) => ({
 					: chat,
 			),
 		);
-		queryClient.setQueryData<TypesGen.Chat>(chatKey(chatId), previousChat);
+		queryClient.setQueryData<TypesGen.Chat>(
+			chatKeys.detail(chatId),
+			previousChat,
+		);
 	},
 });
 
@@ -990,15 +1039,14 @@ export const updateChatWorkspace = (queryClient: QueryClient) => ({
 		}),
 	onMutate: async ({ chatId, workspaceId }: UpdateChatWorkspaceVariables) => {
 		await queryClient.cancelQueries({
-			queryKey: chatsKey,
-			predicate: isChatListQuery,
+			queryKey: chatKeys.lists(),
 		});
 		await queryClient.cancelQueries({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
 		const previousChat = queryClient.getQueryData<TypesGen.Chat>(
-			chatKey(chatId),
+			chatKeys.detail(chatId),
 		);
 		updateInfiniteChatsCache(queryClient, (chats) =>
 			chats.map((chat) =>
@@ -1008,7 +1056,7 @@ export const updateChatWorkspace = (queryClient: QueryClient) => ({
 			),
 		);
 		if (previousChat) {
-			queryClient.setQueryData<TypesGen.Chat>(chatKey(chatId), {
+			queryClient.setQueryData<TypesGen.Chat>(chatKeys.detail(chatId), {
 				...previousChat,
 				workspace_id: workspaceId ?? undefined,
 			});
@@ -1037,7 +1085,10 @@ export const updateChatWorkspace = (queryClient: QueryClient) => ({
 						: chat,
 				),
 			);
-			queryClient.setQueryData<TypesGen.Chat>(chatKey(chatId), previousChat);
+			queryClient.setQueryData<TypesGen.Chat>(
+				chatKeys.detail(chatId),
+				previousChat,
+			);
 		}
 	},
 	onSettled: async (
@@ -1047,11 +1098,11 @@ export const updateChatWorkspace = (queryClient: QueryClient) => ({
 	) => {
 		await invalidateChatListQueries(queryClient);
 		await queryClient.invalidateQueries({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
 		await queryClient.invalidateQueries({
-			queryKey: chatsByWorkspaceKeyPrefix,
+			queryKey: chatKeys.byWorkspacePrefix(),
 		});
 	},
 });
@@ -1061,15 +1112,14 @@ export const pinChat = (queryClient: QueryClient) => ({
 		API.experimental.updateChat(chatId, { pin_order: 1 }),
 	onMutate: async (chatId: string) => {
 		await queryClient.cancelQueries({
-			queryKey: chatsKey,
-			predicate: isChatListQuery,
+			queryKey: chatKeys.lists(),
 		});
 		await queryClient.cancelQueries({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
 		const previousChat = queryClient.getQueryData<TypesGen.Chat>(
-			chatKey(chatId),
+			chatKeys.detail(chatId),
 		);
 		const optimisticPinOrder = getNextOptimisticPinOrder(queryClient);
 		updateInfiniteChatsCache(queryClient, (chats) =>
@@ -1078,7 +1128,7 @@ export const pinChat = (queryClient: QueryClient) => ({
 			),
 		);
 		if (previousChat) {
-			queryClient.setQueryData<TypesGen.Chat>(chatKey(chatId), {
+			queryClient.setQueryData<TypesGen.Chat>(chatKeys.detail(chatId), {
 				...previousChat,
 				pin_order: optimisticPinOrder,
 			});
@@ -1098,7 +1148,7 @@ export const pinChat = (queryClient: QueryClient) => ({
 		void invalidateChatListQueries(queryClient);
 		if (context?.previousChat) {
 			queryClient.setQueryData<TypesGen.Chat>(
-				chatKey(chatId),
+				chatKeys.detail(chatId),
 				context.previousChat,
 			);
 		}
@@ -1106,7 +1156,7 @@ export const pinChat = (queryClient: QueryClient) => ({
 	onSettled: async (_data: unknown, _error: unknown, chatId: string) => {
 		await invalidateChatListQueries(queryClient);
 		await queryClient.invalidateQueries({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
 	},
@@ -1117,15 +1167,14 @@ export const unpinChat = (queryClient: QueryClient) => ({
 		API.experimental.updateChat(chatId, { pin_order: 0 }),
 	onMutate: async (chatId: string) => {
 		await queryClient.cancelQueries({
-			queryKey: chatsKey,
-			predicate: isChatListQuery,
+			queryKey: chatKeys.lists(),
 		});
 		await queryClient.cancelQueries({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
 		const previousChat = queryClient.getQueryData<TypesGen.Chat>(
-			chatKey(chatId),
+			chatKeys.detail(chatId),
 		);
 		updateInfiniteChatsCache(queryClient, (chats) =>
 			chats.map((chat) =>
@@ -1133,7 +1182,7 @@ export const unpinChat = (queryClient: QueryClient) => ({
 			),
 		);
 		if (previousChat) {
-			queryClient.setQueryData<TypesGen.Chat>(chatKey(chatId), {
+			queryClient.setQueryData<TypesGen.Chat>(chatKeys.detail(chatId), {
 				...previousChat,
 				pin_order: 0,
 			});
@@ -1153,7 +1202,7 @@ export const unpinChat = (queryClient: QueryClient) => ({
 		void invalidateChatListQueries(queryClient);
 		if (context?.previousChat) {
 			queryClient.setQueryData<TypesGen.Chat>(
-				chatKey(chatId),
+				chatKeys.detail(chatId),
 				context.previousChat,
 			);
 		}
@@ -1161,7 +1210,7 @@ export const unpinChat = (queryClient: QueryClient) => ({
 	onSettled: async (_data: unknown, _error: unknown, chatId: string) => {
 		await invalidateChatListQueries(queryClient);
 		await queryClient.invalidateQueries({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
 	},
@@ -1178,11 +1227,10 @@ export const reorderPinnedChat = (queryClient: QueryClient) => ({
 		pinOrder: number;
 	}) => {
 		await queryClient.cancelQueries({
-			queryKey: chatsKey,
-			predicate: isChatListQuery,
+			queryKey: chatKeys.lists(),
 		});
 		await queryClient.cancelQueries({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
 
@@ -1213,7 +1261,7 @@ export const reorderPinnedChat = (queryClient: QueryClient) => ({
 	) => {
 		await invalidateChatListQueries(queryClient);
 		await queryClient.invalidateQueries({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
 	},
@@ -1242,7 +1290,7 @@ export const updateChatTitle = (queryClient: QueryClient) => ({
 
 	onSuccess: (_data: unknown, { chatId, title }: UpdateChatTitleVariables) => {
 		queryClient.setQueryData<TypesGen.Chat | undefined>(
-			chatKey(chatId),
+			chatKeys.detail(chatId),
 			(chat) => (chat ? { ...chat, title } : chat),
 		);
 		updateInfiniteChatsCache(queryClient, (chats) =>
@@ -1257,17 +1305,11 @@ export const updateChatTitle = (queryClient: QueryClient) => ({
 	) => {
 		void invalidateChatListQueries(queryClient);
 		void queryClient.invalidateQueries({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
 	},
 });
-
-export const chatDebugRunsKey = (chatId: string) =>
-	[...chatKey(chatId), "debug-runs"] as const;
-
-const chatDebugRunKey = (chatId: string, runId: string) =>
-	[...chatDebugRunsKey(chatId), runId] as const;
 
 // Foreground poll cadence when the Debug tab is open. The error cadence
 // is slower so a transiently unreachable backend is not hammered, but
@@ -1301,7 +1343,7 @@ export const TERMINAL_RUN_STATUSES = new Set([
 
 export const chatDebugRuns = (chatId: string) =>
 	queryOptions({
-		queryKey: chatDebugRunsKey(chatId),
+		queryKey: chatKeys.debugRuns(chatId),
 		queryFn: () => API.experimental.getChatDebugRuns(chatId),
 		refetchInterval: ({ state }) => {
 			// Keep polling on error with backoff so a transient fetch
@@ -1319,7 +1361,7 @@ export const chatDebugRuns = (chatId: string) =>
 
 export const chatDebugRun = (chatId: string, runId: string) =>
 	queryOptions({
-		queryKey: chatDebugRunKey(chatId, runId),
+		queryKey: chatKeys.debugRun(chatId, runId),
 		queryFn: () => API.experimental.getChatDebugRun(chatId, runId),
 		refetchInterval: ({ state }) => {
 			if (state.status === "error") {
@@ -1336,7 +1378,7 @@ export const chatDebugRun = (chatId: string, runId: string) =>
 
 const invalidateChatDebugRuns = (queryClient: QueryClient, chatId: string) => {
 	return queryClient.invalidateQueries({
-		queryKey: chatDebugRunsKey(chatId),
+		queryKey: chatKeys.debugRuns(chatId),
 	});
 };
 
@@ -1346,7 +1388,7 @@ export const createChat = (queryClient: QueryClient) => ({
 	onSuccess: () => {
 		void invalidateChatListQueries(queryClient);
 		void queryClient.invalidateQueries({
-			queryKey: chatsByWorkspaceKeyPrefix,
+			queryKey: chatKeys.byWorkspacePrefix(),
 		});
 	},
 });
@@ -1360,11 +1402,11 @@ export const createChatMessage = (
 	onSuccess: () => {
 		void invalidateChatDebugRuns(queryClient, chatId);
 		void queryClient.invalidateQueries({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
 		void queryClient.invalidateQueries({
-			queryKey: chatPromptsKey(chatId),
+			queryKey: chatKeys.prompts(chatId),
 			exact: true,
 		});
 	},
@@ -1390,17 +1432,17 @@ export const editChatMessage = (queryClient: QueryClient, chatId: string) => ({
 		// Cancel in-flight refetches so they don't overwrite the
 		// optimistic update before the mutation completes.
 		await queryClient.cancelQueries({
-			queryKey: chatMessagesKey(chatId),
+			queryKey: chatKeys.messages(chatId),
 			exact: true,
 		});
 
 		const previousData = queryClient.getQueryData<
 			InfiniteData<TypesGen.ChatMessagesResponse>
-		>(chatMessagesKey(chatId));
+		>(chatKeys.messages(chatId));
 
 		queryClient.setQueryData<
 			InfiniteData<TypesGen.ChatMessagesResponse> | undefined
-		>(chatMessagesKey(chatId), (current) =>
+		>(chatKeys.messages(chatId), (current) =>
 			projectEditedConversationIntoCache({
 				currentData: current,
 				editedMessageId: messageId,
@@ -1419,13 +1461,13 @@ export const editChatMessage = (queryClient: QueryClient, chatId: string) => ({
 		// Restore the cache on failure so the user sees the
 		// original messages again.
 		if (context?.previousData) {
-			queryClient.setQueryData(chatMessagesKey(chatId), context.previousData);
+			queryClient.setQueryData(chatKeys.messages(chatId), context.previousData);
 		}
 		// Invalidate messages as a safety net: the restored snapshot
 		// may be missing WebSocket-delivered messages that arrived
 		// during the mutation's flight time.
 		void queryClient.invalidateQueries({
-			queryKey: chatMessagesKey(chatId),
+			queryKey: chatKeys.messages(chatId),
 			exact: true,
 		});
 	},
@@ -1435,7 +1477,7 @@ export const editChatMessage = (queryClient: QueryClient, chatId: string) => ({
 	) => {
 		queryClient.setQueryData<
 			InfiniteData<TypesGen.ChatMessagesResponse> | undefined
-		>(chatMessagesKey(chatId), (current) =>
+		>(chatKeys.messages(chatId), (current) =>
 			reconcileEditedMessageInCache({
 				currentData: current,
 				optimisticMessageId: variables.messageId,
@@ -1449,16 +1491,16 @@ export const editChatMessage = (queryClient: QueryClient, chatId: string) => ({
 		// query is intentionally NOT invalidated here. The per-chat
 		// WebSocket handles post-edit message delivery via
 		// FullRefresh, making REST invalidation unnecessary.
-		// Invalidating chatMessagesKey would trigger a redundant
+		// Invalidating the messages key would trigger a redundant
 		// refetch that causes extra store mutations while the
 		// sticky user message is settling after the optimistic
 		// truncation.
 		void queryClient.invalidateQueries({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
 		void queryClient.invalidateQueries({
-			queryKey: chatPromptsKey(chatId),
+			queryKey: chatKeys.prompts(chatId),
 			exact: true,
 		});
 		void invalidateChatDebugRuns(queryClient, chatId);
@@ -1478,7 +1520,7 @@ export const compactChat = (queryClient: QueryClient, chatId: string) => ({
 		// The compaction transitions the chat to running; the summary
 		// rows stream in over the websocket like any other turn.
 		void queryClient.invalidateQueries({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
 		void invalidateChatDebugRuns(queryClient, chatId);
@@ -1498,8 +1540,10 @@ export const refreshChatContext = (
 ) => ({
 	mutationFn: () => API.experimental.refreshChatContext(chatId),
 	onSuccess: (updatedChat: TypesGen.Chat) => {
-		queryClient.setQueryData<TypesGen.Chat>(chatKey(chatId), (cached) =>
-			cached ? { ...cached, context: updatedChat.context } : updatedChat,
+		queryClient.setQueryData<TypesGen.Chat>(
+			chatKeys.detail(chatId),
+			(cached) =>
+				cached ? { ...cached, context: updatedChat.context } : updatedChat,
 		);
 		const applyContext = (chat: TypesGen.Chat): TypesGen.Chat =>
 			chat.id === chatId ? { ...chat, context: updatedChat.context } : chat;
@@ -1526,11 +1570,11 @@ export const deleteChatQueuedMessage = (
 		API.experimental.deleteChatQueuedMessage(chatId, queuedMessageId),
 	onSuccess: async () => {
 		await queryClient.invalidateQueries({
-			queryKey: chatKey(chatId),
+			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
 		await queryClient.invalidateQueries({
-			queryKey: chatMessagesKey(chatId),
+			queryKey: chatKeys.messages(chatId),
 			exact: true,
 		});
 	},
@@ -1547,13 +1591,17 @@ export const promoteChatQueuedMessage = (
 	},
 });
 
-export const chatDiffContentsKey = (chatId: string) =>
-	["chats", chatId, "diff-contents"] as const;
-
 export const chatDiffContents = (chatId: string) => ({
-	queryKey: chatDiffContentsKey(chatId),
+	queryKey: chatKeys.diffContents(chatId),
 	queryFn: () => API.experimental.getChatDiffContents(chatId),
 });
+
+export const chatFile = (fileId: string) =>
+	queryOptions({
+		queryKey: ["chatFile", fileId] as const,
+		queryFn: () => API.experimental.getChatFileText(fileId),
+		staleTime: Number.POSITIVE_INFINITY,
+	});
 
 const chatSystemPromptKey = ["chat-system-prompt"] as const;
 
@@ -1589,10 +1637,8 @@ export const updateChatPlanModeInstructions = (queryClient: QueryClient) => ({
 	},
 });
 
-const chatPersonalModelOverridesAdminSettingsKey = [
-	...chatsKey,
-	"admin-personal-model-overrides",
-] as const;
+const chatPersonalModelOverridesAdminSettingsKey =
+	chatKeys.adminPersonalModelOverrides();
 
 export const chatPersonalModelOverridesAdminSettings = () => ({
 	queryKey: chatPersonalModelOverridesAdminSettingsKey,
@@ -1746,10 +1792,7 @@ export const updateUserChatCustomPrompt = (queryClient: QueryClient) => ({
 	},
 });
 
-const userChatPersonalModelOverridesKey = [
-	...chatsKey,
-	"user-personal-model-overrides",
-] as const;
+const userChatPersonalModelOverridesKey = chatKeys.userPersonalModelOverrides();
 
 export const userChatPersonalModelOverrides = () => ({
 	queryKey: userChatPersonalModelOverridesKey,
@@ -1957,22 +2000,16 @@ type ChatCostDateParams = {
 	end_date?: string;
 };
 
-export const chatCostSummaryKey = (user = "me", params?: ChatCostDateParams) =>
-	[...chatsKey, "costSummary", user, params] as const;
-
 export const chatCostSummary = (user = "me", params?: ChatCostDateParams) => ({
-	queryKey: chatCostSummaryKey(user, params),
+	queryKey: chatKeys.costSummary(user, params),
 	queryFn: () => API.experimental.getChatCostSummary(user, params),
 	staleTime: 60_000,
 });
 
-export const chatCostKey = (rootChatId: string) =>
-	[...chatsKey, rootChatId, "cost"] as const;
-
 const GATEWAY_REQUEST_STALE_MS = 30_000;
 
 export const chatCost = (rootChatId: string) => ({
-	queryKey: chatCostKey(rootChatId),
+	queryKey: chatKeys.cost(rootChatId),
 	queryFn: () => API.experimental.getChatCost(rootChatId),
 	staleTime: GATEWAY_REQUEST_STALE_MS,
 });
@@ -1992,7 +2029,7 @@ export function paginatedChatCostUsers(
 	return {
 		queryPayload: () => payload,
 		queryKey: ({ payload, pageNumber }) =>
-			[...chatsKey, "costUsers", payload, pageNumber] as const,
+			chatKeys.costUsers(payload, pageNumber),
 		queryFn: ({ payload, limit, offset }) =>
 			API.experimental.getChatCostUsers({
 				start_date: payload.start_date,
@@ -2005,18 +2042,13 @@ export function paginatedChatCostUsers(
 	};
 }
 
-export const chatUsageLimitStatusKey = [
-	...chatsKey,
-	"usageLimitStatus",
-] as const;
-
 export const chatUsageLimitStatus = () => ({
-	queryKey: chatUsageLimitStatusKey,
+	queryKey: chatKeys.usageLimitStatus(),
 	queryFn: () => API.experimental.getChatUsageLimitStatus(),
 	refetchInterval: 60_000,
 });
 
-const chatUsageLimitConfigKey = [...chatsKey, "usageLimitConfig"] as const;
+const chatUsageLimitConfigKey = chatKeys.usageLimitConfig();
 
 export const chatUsageLimitConfig = () => ({
 	queryKey: chatUsageLimitConfigKey,
@@ -2158,7 +2190,7 @@ export const setChatUserRole = (queryClient: QueryClient) => ({
 		}),
 	onSuccess: async (_data: unknown, { chatId }: SetChatUserRoleVariables) => {
 		await queryClient.invalidateQueries({
-			queryKey: chatACLKey(chatId),
+			queryKey: chatKeys.acl(chatId),
 			exact: true,
 		});
 	},
@@ -2171,7 +2203,7 @@ export const setChatGroupRole = (queryClient: QueryClient) => ({
 		}),
 	onSuccess: async (_data: unknown, { chatId }: SetChatGroupRoleVariables) => {
 		await queryClient.invalidateQueries({
-			queryKey: chatACLKey(chatId),
+			queryKey: chatKeys.acl(chatId),
 			exact: true,
 		});
 	},

--- a/site/src/api/queries/workspaceBuilds.ts
+++ b/site/src/api/queries/workspaceBuilds.ts
@@ -39,6 +39,10 @@ export const workspaceBuildsKey = (workspaceId: string) => [
 	workspaceId,
 ];
 
+// Nested under workspaceBuildsKey so the existing build invalidations reach it.
+export const workspaceBuildsArchiveResolverKey = (workspaceId: string) =>
+	[...workspaceBuildsKey(workspaceId), "archive-and-delete-resolver"] as const;
+
 export const infiniteWorkspaceBuilds = (
 	workspaceId: string,
 	req?: WorkspaceBuildsRequest,

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -10,13 +10,9 @@ import {
 import { API } from "#/api/api";
 import { getAuthorizationKey } from "#/api/queries/authCheck";
 import {
-	chatDiffContentsKey,
-	chatKey,
-	chatMessagesKey,
+	chatKeys,
 	chatModelConfigs,
 	chatModelsKey,
-	chatPromptsKey,
-	chatsKey,
 	mcpServerConfigsKey,
 } from "#/api/queries/chats";
 import { workspaceByIdKey } from "#/api/queries/workspaces";
@@ -270,20 +266,19 @@ const buildQueries = (
 		diff_status: diffStatus,
 	};
 	return [
-		{ key: chatKey(CHAT_ID), data: chatWithDiffStatus },
+		{ key: chatKeys.detail(CHAT_ID), data: chatWithDiffStatus },
 		{
-			key: chatMessagesKey(CHAT_ID),
+			key: chatKeys.messages(CHAT_ID),
 			data: { pages: [messagesData], pageParams: [undefined] },
 		},
 		{
-			key: chatPromptsKey(CHAT_ID),
+			key: chatKeys.prompts(CHAT_ID),
 			data: {
 				prompts: extractPromptsFromMessages(messagesData.messages),
 			} satisfies TypesGen.ChatPromptsResponse,
 		},
-		{ key: chatsKey, data: [chatWithDiffStatus] },
 		{
-			key: chatDiffContentsKey(CHAT_ID),
+			key: chatKeys.diffContents(CHAT_ID),
 			data: {
 				chat_id: CHAT_ID,
 				diff: opts?.diffUrl ? sampleDiff : undefined,
@@ -2983,9 +2978,9 @@ export const SendResponseAfterChatSwitch: Story = {
 				{ messages: [], queued_messages: [], has_more: false },
 				{ diffUrl: undefined },
 			),
-			{ key: chatKey(SWITCHED_CHAT_ID), data: switchedChat },
+			{ key: chatKeys.detail(SWITCHED_CHAT_ID), data: switchedChat },
 			{
-				key: chatMessagesKey(SWITCHED_CHAT_ID),
+				key: chatKeys.messages(SWITCHED_CHAT_ID),
 				data: {
 					pages: [
 						{
@@ -2998,11 +2993,11 @@ export const SendResponseAfterChatSwitch: Story = {
 				},
 			},
 			{
-				key: chatPromptsKey(SWITCHED_CHAT_ID),
+				key: chatKeys.prompts(SWITCHED_CHAT_ID),
 				data: { prompts: [] } satisfies TypesGen.ChatPromptsResponse,
 			},
 			{
-				key: chatDiffContentsKey(SWITCHED_CHAT_ID),
+				key: chatKeys.diffContents(SWITCHED_CHAT_ID),
 				data: { chat_id: SWITCHED_CHAT_ID } satisfies TypesGen.ChatDiffContents,
 			},
 		],

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -27,7 +27,7 @@ import { checkAuthorization } from "#/api/queries/authCheck";
 import { buildOptimisticEditedMessage } from "#/api/queries/chatMessageEdits";
 import {
 	chat,
-	chatKey,
+	chatKeys,
 	chatMessagesForInfiniteScroll,
 	chatModelConfigs,
 	chatModels,
@@ -1186,8 +1186,10 @@ const AgentChatPage: FC = () => {
 				chat.id === chatId ? { ...chat, plan_mode: planMode } : chat,
 			),
 		);
-		queryClient.setQueryData<TypesGen.Chat>(chatKey(chatId), (previousChat) =>
-			previousChat ? { ...previousChat, plan_mode: planMode } : previousChat,
+		queryClient.setQueryData<TypesGen.Chat>(
+			chatKeys.detail(chatId),
+			(previousChat) =>
+				previousChat ? { ...previousChat, plan_mode: planMode } : previousChat,
 		);
 	};
 
@@ -1718,7 +1720,7 @@ const AgentChatPage: FC = () => {
 					// Hook dispatch failures can park an idle chat in error before returning the request error.
 					acceptServerChatStatus();
 					void queryClient.invalidateQueries({
-						queryKey: chatKey(agentId),
+						queryKey: chatKeys.detail(agentId),
 						exact: true,
 					});
 				},
@@ -1769,7 +1771,7 @@ const AgentChatPage: FC = () => {
 			// Hook dispatch failures can park an idle chat in error before returning the request error.
 			acceptServerChatStatus();
 			void queryClient.invalidateQueries({
-				queryKey: chatKey(agentId),
+				queryKey: chatKeys.detail(agentId),
 				exact: true,
 			});
 			throw error;

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -11,7 +11,7 @@ import {
 import { useQueryClient } from "react-query";
 import type { UrlTransform } from "streamdown";
 import { v4 as uuidv4 } from "uuid";
-import { chatDiffContentsKey } from "#/api/queries/chats";
+import { chatKeys } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
 import type {
 	AgentChatSendShortcut,
@@ -408,7 +408,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 		const sent = gitWatcher.refresh();
 		if (sent && agentId) {
 			void queryClient.invalidateQueries({
-				queryKey: chatDiffContentsKey(agentId),
+				queryKey: chatKeys.diffContents(agentId),
 				exact: true,
 			});
 		}

--- a/site/src/pages/AgentsPage/AgentsPageLayout.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageLayout.tsx
@@ -20,12 +20,9 @@ import {
 	applyChatArchiveStateToCaches,
 	archiveChat,
 	cancelChatListRefetches,
-	chatCostKey,
-	chatDiffContentsKey,
-	chatKey,
+	chatKeys,
 	chatModelConfigs,
 	chatModels,
-	chatsByWorkspaceKeyPrefix,
 	infiniteChats,
 	invalidateChatListQueries,
 	mergeWatchedChatIntoCaches,
@@ -42,6 +39,7 @@ import {
 	userChatPersonalModelOverrides,
 	userChatProviderConfigs,
 } from "#/api/queries/chats";
+import { workspaceBuildsArchiveResolverKey } from "#/api/queries/workspaceBuilds";
 import {
 	invalidateWorkspaceMutationQueries,
 	workspaceById,
@@ -304,11 +302,11 @@ const AgentsPageLayout: FC = () => {
 			clearPersistedRightPanelState(chatId);
 			void invalidateChatListQueries(queryClient);
 			void queryClient.invalidateQueries({
-				queryKey: chatKey(chatId),
+				queryKey: chatKeys.detail(chatId),
 				exact: true,
 			});
 			void queryClient.invalidateQueries({
-				queryKey: chatsByWorkspaceKeyPrefix,
+				queryKey: chatKeys.byWorkspacePrefix(),
 			});
 			void invalidateWorkspaceMutationQueries(queryClient, {
 				organizationName,
@@ -410,7 +408,7 @@ const AgentsPageLayout: FC = () => {
 			return;
 		}
 		const chat =
-			queryClient.getQueryData<TypesGen.Chat>(chatKey(chatId)) ??
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId)) ??
 			chatList.find((candidate) => candidate.id === chatId);
 		if (chat === undefined || isActiveChat(chat)) {
 			setPendingArchiveChatId(chatId);
@@ -441,12 +439,13 @@ const AgentsPageLayout: FC = () => {
 				archivedChatId,
 				// Read root_chat_id from the per-chat cache, which
 				// survives WebSocket eviction of sub-agents (only the
-				// parent's chatKey is removed). This must be read at
+				// parent's detail cache is removed). This must be read at
 				// callback time so it reflects the user's current
 				// location.
 				activeChatId
-					? queryClient.getQueryData<TypesGen.Chat>(chatKey(activeChatId))
-							?.root_chat_id
+					? queryClient.getQueryData<TypesGen.Chat>(
+							chatKeys.detail(activeChatId),
+						)?.root_chat_id
 					: undefined,
 			)
 		) {
@@ -470,11 +469,7 @@ const AgentsPageLayout: FC = () => {
 				// aren't in the returned slice.
 				() =>
 					queryClient.fetchQuery({
-						queryKey: [
-							"workspaceBuilds",
-							workspaceId,
-							"archive-and-delete-resolver",
-						],
+						queryKey: workspaceBuildsArchiveResolverKey(workspaceId),
 						queryFn: () => API.getWorkspaceBuilds(workspaceId),
 					}),
 				() =>
@@ -617,7 +612,7 @@ const AgentsPageLayout: FC = () => {
 						);
 						removeChildFromParentInCache(queryClient, updatedChat.id);
 						queryClient.removeQueries({
-							queryKey: chatKey(updatedChat.id),
+							queryKey: chatKeys.detail(updatedChat.id),
 							exact: true,
 						});
 						return;
@@ -625,9 +620,9 @@ const AgentsPageLayout: FC = () => {
 					if (chatEvent.kind === "diff_status_change") {
 						// Only refetch the diff file contents. The chat's
 						// diff_status field is already written into the
-						// chatKey and infinite-list caches below.
+						// chat detail and infinite-list caches below.
 						void queryClient.invalidateQueries({
-							queryKey: chatDiffContentsKey(updatedChat.id),
+							queryKey: chatKeys.diffContents(updatedChat.id),
 							exact: true,
 						});
 					}
@@ -648,9 +643,9 @@ const AgentsPageLayout: FC = () => {
 					// reverts the query to pending/idle with no data
 					// and no retry, which AgentChatPage shows as
 					// "Chat not found".
-					if (queryClient.getQueryData(chatKey(updatedChat.id))) {
+					if (queryClient.getQueryData(chatKeys.detail(updatedChat.id))) {
 						void queryClient.cancelQueries({
-							queryKey: chatKey(updatedChat.id),
+							queryKey: chatKeys.detail(updatedChat.id),
 							exact: true,
 						});
 					}
@@ -683,7 +678,7 @@ const AgentsPageLayout: FC = () => {
 						);
 						if (costChatId) {
 							void queryClient.invalidateQueries({
-								queryKey: chatCostKey(costChatId),
+								queryKey: chatKeys.cost(costChatId),
 								exact: true,
 							});
 						}
@@ -695,7 +690,7 @@ const AgentsPageLayout: FC = () => {
 							// active chat has an observer, so other chats are
 							// merely marked stale.
 							void queryClient.invalidateQueries({
-								queryKey: chatKey(updatedChat.id),
+								queryKey: chatKeys.detail(updatedChat.id),
 								exact: true,
 							});
 						}

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -1,10 +1,8 @@
 import { act, render, renderHook, waitFor } from "@testing-library/react";
 import { watchChat } from "#/api/api";
-import { chatMessagesKey, chatsKey } from "#/api/queries/chats";
+import { chatKeys } from "#/api/queries/chats";
 
-// The infinite query key used by useInfiniteQuery(infiniteChats())
-// is [...chatsKey, undefined] = ["chats", undefined].
-const infiniteChatsTestKey = [...chatsKey, undefined];
+const infiniteChatsTestKey = chatKeys.list();
 
 type InfiniteData = {
 	pages: TypesGen.Chat[][];
@@ -728,7 +726,7 @@ describe("useChatStore", () => {
 				},
 			},
 		});
-		queryClient.setQueryData(chatMessagesKey(chatID), {
+		queryClient.setQueryData(chatKeys.messages(chatID), {
 			pages: [
 				{
 					messages: [...initialMessages].reverse(),
@@ -799,7 +797,7 @@ describe("useChatStore", () => {
 		const cached = queryClient.getQueryData<{
 			pages: TypesGen.ChatMessagesResponse[];
 			pageParams: unknown[];
-		}>(chatMessagesKey(chatID));
+		}>(chatKeys.messages(chatID));
 		expect(cached?.pages[0]?.messages.map((message) => message.id)).toEqual([
 			1,
 		]);
@@ -827,7 +825,7 @@ describe("useChatStore", () => {
 				},
 			},
 		});
-		queryClient.setQueryData(chatMessagesKey(chatID), {
+		queryClient.setQueryData(chatKeys.messages(chatID), {
 			pages: [
 				{
 					messages: [...initialMessages].reverse(),
@@ -902,7 +900,7 @@ describe("useChatStore", () => {
 		const cached = queryClient.getQueryData<{
 			pages: TypesGen.ChatMessagesResponse[];
 			pageParams: unknown[];
-		}>(chatMessagesKey(chatID));
+		}>(chatKeys.messages(chatID));
 		expect(cached?.pages[0]?.messages.map((message) => message.id)).toEqual([
 			2, 1,
 		]);
@@ -1488,7 +1486,7 @@ describe("useChatStore", () => {
 		};
 		// The cache is InfiniteData<ChatMessagesResponse> after the
 		// migration to useInfiniteQuery for chat messages.
-		queryClient.setQueryData(chatMessagesKey(chatID), {
+		queryClient.setQueryData(chatKeys.messages(chatID), {
 			pages: [initialChatMessagesData],
 			pageParams: [undefined],
 		});
@@ -1533,7 +1531,7 @@ describe("useChatStore", () => {
 		const cachedData = queryClient.getQueryData<{
 			pages: TypesGen.ChatMessagesResponse[];
 			pageParams: unknown[];
-		}>(chatMessagesKey(chatID));
+		}>(chatKeys.messages(chatID));
 		expect(cachedData?.pages[0]?.queued_messages).toEqual([]);
 	});
 
@@ -1559,7 +1557,7 @@ describe("useChatStore", () => {
 			queued_messages: [queuedMessage],
 			has_more: false,
 		};
-		queryClient.setQueryData(chatMessagesKey(chatID), {
+		queryClient.setQueryData(chatKeys.messages(chatID), {
 			pages: [initialChatMessagesData],
 			pageParams: [undefined],
 		});
@@ -1608,7 +1606,7 @@ describe("useChatStore", () => {
 		const cachedData = queryClient.getQueryData<{
 			pages: TypesGen.ChatMessagesResponse[];
 			pageParams: unknown[];
-		}>(chatMessagesKey(chatID));
+		}>(chatKeys.messages(chatID));
 		expect(cachedData?.pages[0]?.queued_messages).toEqual([]);
 	});
 
@@ -1633,7 +1631,7 @@ describe("useChatStore", () => {
 			queued_messages: [],
 			has_more: false,
 		};
-		queryClient.setQueryData(chatMessagesKey(chatID), {
+		queryClient.setQueryData(chatKeys.messages(chatID), {
 			pages: [initialChatMessagesData],
 			pageParams: [undefined],
 		});
@@ -1681,13 +1679,13 @@ describe("useChatStore", () => {
 		const cachedData = queryClient.getQueryData<{
 			pages: TypesGen.ChatMessagesResponse[];
 			pageParams: unknown[];
-		}>(chatMessagesKey(chatID));
+		}>(chatKeys.messages(chatID));
 		const cachedMessages = cachedData?.pages[0]?.messages ?? [];
 		// Verifies insertion, preservation, and DESC order.
 		expect(cachedMessages.map((m) => m.id)).toEqual([2, 1]);
 		// Emitting the same message again should not change the
 		// cache reference (reference stability).
-		const refBefore = queryClient.getQueryData(chatMessagesKey(chatID));
+		const refBefore = queryClient.getQueryData(chatKeys.messages(chatID));
 		act(() => {
 			mockSocket.emitData({
 				type: "message",
@@ -1695,7 +1693,7 @@ describe("useChatStore", () => {
 				message: newMessage,
 			});
 		});
-		const refAfter = queryClient.getQueryData(chatMessagesKey(chatID));
+		const refAfter = queryClient.getQueryData(chatKeys.messages(chatID));
 		expect(refAfter).toBe(refBefore);
 
 		// Emitting the same message ID with different content should
@@ -1711,7 +1709,7 @@ describe("useChatStore", () => {
 		const updatedCache = queryClient.getQueryData<{
 			pages: TypesGen.ChatMessagesResponse[];
 			pageParams: unknown[];
-		}>(chatMessagesKey(chatID));
+		}>(chatKeys.messages(chatID));
 		const updatedFirst = updatedCache?.pages[0]?.messages[0];
 		expect(updatedFirst?.content).toEqual([{ type: "text", text: "revised" }]);
 	});
@@ -5033,7 +5031,7 @@ describe("store/cache desync protection", () => {
 		mockWatchChatReturn(mockSocket);
 
 		const queryClient = createTestQueryClient();
-		queryClient.setQueryData(chatMessagesKey(chatID), {
+		queryClient.setQueryData(chatKeys.messages(chatID), {
 			pages: [
 				{
 					messages: [msg2, msg1],
@@ -5122,7 +5120,7 @@ describe("store/cache desync protection", () => {
 		mockWatchChatReturn(mockSocket);
 
 		const queryClient = createTestQueryClient();
-		queryClient.setQueryData(chatMessagesKey(chatID), {
+		queryClient.setQueryData(chatKeys.messages(chatID), {
 			pages: [
 				{
 					messages: [msg3, msg2, msg1],

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -11,11 +11,7 @@ import {
 	useQueryClient,
 } from "react-query";
 import { watchChat } from "#/api/api";
-import {
-	chatMessagesKey,
-	chatPromptsKey,
-	updateInfiniteChatsCache,
-} from "#/api/queries/chats";
+import { chatKeys, updateInfiniteChatsCache } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { OneWayMessageEvent } from "#/utils/OneWayWebSocket";
 import { createReconnectingWebSocket } from "#/utils/reconnectingWebSocket";
@@ -43,7 +39,7 @@ const writeQueuedMessagesToCache = (
 	const nextQueuedMessages = queuedMessages ?? [];
 	queryClient.setQueryData<
 		InfiniteData<TypesGen.ChatMessagesResponse> | undefined
-	>(chatMessagesKey(chatID), (currentData) => {
+	>(chatKeys.messages(chatID), (currentData) => {
 		if (!currentData?.pages?.length) {
 			return currentData;
 		}
@@ -72,7 +68,7 @@ const readQueuedMessagesFromCache = (
 	}
 	return queryClient.getQueryData<
 		InfiniteData<TypesGen.ChatMessagesResponse> | undefined
-	>(chatMessagesKey(chatID))?.pages[0]?.queued_messages;
+	>(chatKeys.messages(chatID))?.pages[0]?.queued_messages;
 };
 
 const normalizeRetryState = (retry: TypesGen.ChatStreamRetry): RetryState => ({
@@ -200,7 +196,7 @@ export const useChatStore = (
 			}
 			queryClient.setQueryData<
 				InfiniteData<TypesGen.ChatMessagesResponse> | undefined
-			>(chatMessagesKey(chatID), (currentData) => {
+			>(chatKeys.messages(chatID), (currentData) => {
 				if (!currentData?.pages?.length) {
 					return currentData;
 				}
@@ -237,7 +233,7 @@ export const useChatStore = (
 			const hasNewUserPrompt = messages.some((msg) => msg.role === "user");
 			if (hasNewUserPrompt) {
 				void queryClient.invalidateQueries({
-					queryKey: chatPromptsKey(chatID),
+					queryKey: chatKeys.prompts(chatID),
 					exact: true,
 				});
 			}
@@ -252,7 +248,7 @@ export const useChatStore = (
 			}
 			queryClient.setQueryData<
 				InfiniteData<TypesGen.ChatMessagesResponse> | undefined
-			>(chatMessagesKey(chatID), (currentData) => {
+			>(chatKeys.messages(chatID), (currentData) => {
 				if (!currentData?.pages?.length) {
 					return currentData;
 				}

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatToolInvalidations.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatToolInvalidations.test.tsx
@@ -3,6 +3,7 @@ import type { FC, PropsWithChildren } from "react";
 import { act } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { chatKeys } from "#/api/queries/chats";
 import { getWorkspaceQuotaQueryKey } from "#/api/queries/workspaceQuota";
 import { workspacesQueryKeyPrefix } from "#/api/queries/workspaces";
 import { createChatStore } from "./chatStore";
@@ -106,7 +107,8 @@ describe("useChatToolInvalidations", () => {
 
 		await waitFor(() => {
 			expect(invalidateSpy).toHaveBeenCalledWith({
-				queryKey: ["chats", "chat-1"],
+				queryKey: chatKeys.detail("chat-1"),
+				exact: true,
 			});
 			expect(invalidateSpy).toHaveBeenCalledWith(
 				expect.objectContaining({
@@ -144,7 +146,8 @@ describe("useChatToolInvalidations", () => {
 		});
 
 		expect(invalidateSpy).not.toHaveBeenCalledWith({
-			queryKey: ["chats", "chat-1"],
+			queryKey: chatKeys.detail("chat-1"),
+			exact: true,
 		});
 	});
 
@@ -183,7 +186,8 @@ describe("useChatToolInvalidations", () => {
 
 		await waitFor(() => {
 			expect(invalidateSpy).toHaveBeenCalledWith({
-				queryKey: ["chats", "chat-1"],
+				queryKey: chatKeys.detail("chat-1"),
+				exact: true,
 			});
 			expect(invalidateSpy).toHaveBeenCalledWith(
 				expect.objectContaining({
@@ -250,7 +254,8 @@ describe("useChatToolInvalidations", () => {
 		await waitFor(() => {
 			expect(invalidateSpy).toHaveBeenCalledTimes(6);
 			expect(invalidateSpy).toHaveBeenCalledWith({
-				queryKey: ["chats", "chat-2"],
+				queryKey: chatKeys.detail("chat-2"),
+				exact: true,
 			});
 		});
 	});

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatToolInvalidations.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatToolInvalidations.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 import { useQueryClient } from "react-query";
-import { chatKey } from "#/api/queries/chats";
+import { chatKeys } from "#/api/queries/chats";
 import { invalidateWorkspaceMutationQueries } from "#/api/queries/workspaces";
 import { type ChatStore, useChatSelector } from "./chatStore";
 import type { StreamState } from "./types";
@@ -87,8 +87,11 @@ export function useChatToolInvalidations({
 		}
 
 		if (shouldInvalidateChat) {
+			// A workspace binding writes chat fields only. Messages and the other
+			// per-chat sub-resources are unaffected, so stay off their keys.
 			void queryClient.invalidateQueries({
-				queryKey: chatKey(chatID),
+				queryKey: chatKeys.detail(chatID),
+				exact: true,
 			});
 		}
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ProposePlanTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ProposePlanTool.tsx
@@ -1,7 +1,7 @@
 import { LoaderIcon, PlayIcon } from "lucide-react";
 import type React from "react";
 import { useMutation, useQuery } from "react-query";
-import { API } from "#/api/api";
+import { chatFile } from "#/api/queries/chats";
 import { Button } from "#/components/Button/Button";
 import { CopyButton } from "#/components/CopyButton/CopyButton";
 import {
@@ -34,16 +34,8 @@ export const ProposePlanTool: React.FC<{
 }) => {
 	const hasInlineContent = (inlineContent?.trim().length ?? 0) > 0;
 	const fileQuery = useQuery({
-		queryKey: ["chatFile", fileID],
-		queryFn: async () => {
-			if (!fileID) {
-				throw new Error("Missing file ID");
-			}
-
-			return API.experimental.getChatFileText(fileID);
-		},
+		...chatFile(fileID ?? ""),
 		enabled: Boolean(fileID) && !hasInlineContent,
-		staleTime: Number.POSITIVE_INFINITY,
 	});
 
 	const fetchError = fileQuery.isError

--- a/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugPanel.stories.tsx
@@ -3,6 +3,7 @@ import { toast } from "sonner";
 import { expect, fn, spyOn, userEvent, waitFor, within } from "storybook/test";
 import type { Mock } from "vitest";
 import { API } from "#/api/api";
+import { chatKeys } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
 import { DebugPanel } from "./DebugPanel";
 import { CHAT_ID, MockRun, MockStep } from "./debugFixtures";
@@ -456,7 +457,7 @@ const getAllRunSummaries = () =>
 const getDebugRunDetailById = () =>
 	new Map(getAllRunDetails().map((run) => [run.id, run]));
 
-const debugRunsQueryKey = ["chats", CHAT_ID, "debug-runs"] as const;
+const debugRunsQueryKey = chatKeys.debugRuns(CHAT_ID);
 
 const getSeededRunSummaries = (
 	queries: readonly { key: readonly unknown[]; data: unknown }[] | undefined,
@@ -535,7 +536,7 @@ export const Empty: Story = {
 	parameters: {
 		queries: [
 			{
-				key: ["chats", CHAT_ID, "debug-runs"],
+				key: chatKeys.debugRuns(CHAT_ID),
 				data: [],
 			},
 		],
@@ -615,7 +616,7 @@ export const RunDetailLoading: Story = {
 	parameters: {
 		queries: [
 			{
-				key: ["chats", CHAT_ID, "debug-runs"],
+				key: chatKeys.debugRuns(CHAT_ID),
 				data: [detailProbeSummary],
 			},
 		],
@@ -649,7 +650,7 @@ export const RunDetailError: Story = {
 	parameters: {
 		queries: [
 			{
-				key: ["chats", CHAT_ID, "debug-runs"],
+				key: chatKeys.debugRuns(CHAT_ID),
 				data: [detailProbeSummary],
 			},
 		],
@@ -682,11 +683,11 @@ export const RunWithNoSteps: Story = {
 	parameters: {
 		queries: [
 			{
-				key: ["chats", CHAT_ID, "debug-runs"],
+				key: chatKeys.debugRuns(CHAT_ID),
 				data: [detailProbeSummary],
 			},
 			{
-				key: ["chats", CHAT_ID, "debug-runs", detailProbeRunId],
+				key: chatKeys.debugRun(CHAT_ID, detailProbeRunId),
 				data: {
 					...MockRun,
 					id: detailProbeRunId,
@@ -719,7 +720,7 @@ export const SingleStepSuccessfulRun: Story = {
 	parameters: {
 		queries: [
 			{
-				key: ["chats", CHAT_ID, "debug-runs"],
+				key: chatKeys.debugRuns(CHAT_ID),
 				data: [
 					buildRunSummary({
 						id: successfulRunDetail.id,
@@ -728,7 +729,7 @@ export const SingleStepSuccessfulRun: Story = {
 				],
 			},
 			{
-				key: ["chats", CHAT_ID, "debug-runs", successfulRunDetail.id],
+				key: chatKeys.debugRun(CHAT_ID, successfulRunDetail.id),
 				data: successfulRunDetail,
 			},
 		],
@@ -770,7 +771,7 @@ export const ExportAllRuns: Story = {
 	parameters: {
 		queries: [
 			{
-				key: ["chats", CHAT_ID, "debug-runs"],
+				key: chatKeys.debugRuns(CHAT_ID),
 				data: [
 					buildRunSummary({
 						id: successfulRunDetail.id,
@@ -819,7 +820,7 @@ export const ExportAllRunsUsesCachedTerminalRunDetails: Story = {
 	parameters: {
 		queries: [
 			{
-				key: ["chats", CHAT_ID, "debug-runs"],
+				key: chatKeys.debugRuns(CHAT_ID),
 				data: [
 					buildRunSummary({
 						id: successfulRunDetail.id,
@@ -828,7 +829,7 @@ export const ExportAllRunsUsesCachedTerminalRunDetails: Story = {
 				],
 			},
 			{
-				key: ["chats", CHAT_ID, "debug-runs", successfulRunDetail.id],
+				key: chatKeys.debugRun(CHAT_ID, successfulRunDetail.id),
 				data: successfulRunDetail,
 			},
 		],
@@ -979,7 +980,7 @@ export const ExportSingleRun: Story = {
 	parameters: {
 		queries: [
 			{
-				key: ["chats", CHAT_ID, "debug-runs"],
+				key: chatKeys.debugRuns(CHAT_ID),
 				data: [
 					buildRunSummary({
 						id: successfulRunDetail.id,
@@ -988,7 +989,7 @@ export const ExportSingleRun: Story = {
 				],
 			},
 			{
-				key: ["chats", CHAT_ID, "debug-runs", successfulRunDetail.id],
+				key: chatKeys.debugRun(CHAT_ID, successfulRunDetail.id),
 				data: successfulRunDetail,
 			},
 		],
@@ -1060,7 +1061,7 @@ export const MultiStepRunWithRetries: Story = {
 	parameters: {
 		queries: [
 			{
-				key: ["chats", CHAT_ID, "debug-runs"],
+				key: chatKeys.debugRuns(CHAT_ID),
 				data: [
 					buildRunSummary({
 						id: multiStepRunDetail.id,
@@ -1073,7 +1074,7 @@ export const MultiStepRunWithRetries: Story = {
 				],
 			},
 			{
-				key: ["chats", CHAT_ID, "debug-runs", multiStepRunDetail.id],
+				key: chatKeys.debugRun(CHAT_ID, multiStepRunDetail.id),
 				data: multiStepRunDetail,
 			},
 		],
@@ -1118,7 +1119,7 @@ export const ErrorStateWithRedactedHeaders: Story = {
 	parameters: {
 		queries: [
 			{
-				key: ["chats", CHAT_ID, "debug-runs"],
+				key: chatKeys.debugRuns(CHAT_ID),
 				data: [
 					buildRunSummary({
 						id: errorRunDetail.id,
@@ -1131,7 +1132,7 @@ export const ErrorStateWithRedactedHeaders: Story = {
 				],
 			},
 			{
-				key: ["chats", CHAT_ID, "debug-runs", errorRunDetail.id],
+				key: chatKeys.debugRun(CHAT_ID, errorRunDetail.id),
 				data: errorRunDetail,
 			},
 		],
@@ -1174,7 +1175,7 @@ export const CompactionAndTitleGenerationBadges: Story = {
 	parameters: {
 		queries: [
 			{
-				key: ["chats", CHAT_ID, "debug-runs"],
+				key: chatKeys.debugRuns(CHAT_ID),
 				data: [
 					buildRunSummary({
 						id: "run-compaction",
@@ -1222,7 +1223,7 @@ export const LongRawPayloads: Story = {
 	parameters: {
 		queries: [
 			{
-				key: ["chats", CHAT_ID, "debug-runs"],
+				key: chatKeys.debugRuns(CHAT_ID),
 				data: [
 					buildRunSummary({
 						id: longPayloadRunDetail.id,
@@ -1234,7 +1235,7 @@ export const LongRawPayloads: Story = {
 				],
 			},
 			{
-				key: ["chats", CHAT_ID, "debug-runs", longPayloadRunDetail.id],
+				key: chatKeys.debugRun(CHAT_ID, longPayloadRunDetail.id),
 				data: longPayloadRunDetail,
 			},
 		],
@@ -1266,7 +1267,7 @@ export const RichPayloadWithTranscript: Story = {
 	parameters: {
 		queries: [
 			{
-				key: ["chats", CHAT_ID, "debug-runs"],
+				key: chatKeys.debugRuns(CHAT_ID),
 				data: [
 					buildRunSummary({
 						id: richRunDetail.id,
@@ -1275,7 +1276,7 @@ export const RichPayloadWithTranscript: Story = {
 				],
 			},
 			{
-				key: ["chats", CHAT_ID, "debug-runs", richRunDetail.id],
+				key: chatKeys.debugRun(CHAT_ID, richRunDetail.id),
 				data: richRunDetail,
 			},
 		],
@@ -1343,7 +1344,7 @@ export const ToolCallStep: Story = {
 	parameters: {
 		queries: [
 			{
-				key: ["chats", CHAT_ID, "debug-runs"],
+				key: chatKeys.debugRuns(CHAT_ID),
 				data: [
 					buildRunSummary({
 						id: toolCallRunDetail.id,
@@ -1352,7 +1353,7 @@ export const ToolCallStep: Story = {
 				],
 			},
 			{
-				key: ["chats", CHAT_ID, "debug-runs", toolCallRunDetail.id],
+				key: chatKeys.debugRun(CHAT_ID, toolCallRunDetail.id),
 				data: toolCallRunDetail,
 			},
 		],
@@ -1380,7 +1381,7 @@ export const FallbackLabeledRun: Story = {
 	parameters: {
 		queries: [
 			{
-				key: ["chats", CHAT_ID, "debug-runs"],
+				key: chatKeys.debugRuns(CHAT_ID),
 				data: [
 					buildRunSummary({
 						id: "run-fallback",
@@ -1409,7 +1410,7 @@ export const InProgressRun: Story = {
 	parameters: {
 		queries: [
 			{
-				key: ["chats", CHAT_ID, "debug-runs"],
+				key: chatKeys.debugRuns(CHAT_ID),
 				data: [
 					buildRunSummary({
 						id: "run-progress",
@@ -1586,7 +1587,7 @@ export const BackendNormalizedShape: Story = {
 	parameters: {
 		queries: [
 			{
-				key: ["chats", CHAT_ID, "debug-runs"],
+				key: chatKeys.debugRuns(CHAT_ID),
 				data: [
 					buildRunSummary({
 						id: backendShapeRunDetail.id,
@@ -1597,7 +1598,7 @@ export const BackendNormalizedShape: Story = {
 				],
 			},
 			{
-				key: ["chats", CHAT_ID, "debug-runs", backendShapeRunDetail.id],
+				key: chatKeys.debugRun(CHAT_ID, backendShapeRunDetail.id),
 				data: backendShapeRunDetail,
 			},
 		],

--- a/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
@@ -2,7 +2,7 @@ import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
 import type { FC } from "react";
 import { useQueryClient } from "react-query";
 import { expect, userEvent, within } from "storybook/test";
-import { chatUsageLimitStatusKey } from "#/api/queries/chats";
+import { chatKeys } from "#/api/queries/chats";
 import { getWorkspaceQuotaQueryKey } from "#/api/queries/workspaceQuota";
 import { workspacesKey } from "#/api/queries/workspaces";
 import type {
@@ -23,7 +23,7 @@ import { UsageIndicator } from "./UsageIndicator";
 
 const withUsageLimitStatus = (status: ChatUsageLimitStatus) => (Story: FC) => {
 	const queryClient = useQueryClient();
-	queryClient.setQueryData(chatUsageLimitStatusKey, status);
+	queryClient.setQueryData(chatKeys.usageLimitStatus(), status);
 	return <Story />;
 };
 


### PR DESCRIPTION
This is PR 1 of a stack fixing the Agents/chats feature's misuse of TanStack Query.

The polymorphic `["chats", <filter|id|literal>]` key put lists, details, and several top-level literals in one slot, so prefix invalidation was impossible and a list matcher could not tell shapes apart. This PR replaces it with one `chatKeys` factory using explicit namespaces: `["chats","list",...]`, `["chats","detail",chatId,...]`, and top-level siblings (search, by-workspace, cost). Search and by-workspace stay outside `lists()` because they hold incompatible cache shapes, which removes a reachable `getNextOptimisticPinOrder` crash. It also deletes `isChatListQuery` (13 call sites converted to prefix matching), canonicalizes list filters so the key and the request query share one value, and routes the ad hoc `chatFile` and workspace-build resolver keys through factories.

No behavior change intended; this is the foundation the rest of the stack builds on.

<details>
<summary>Implementation plan and review notes (for reviewers)</summary>

- One `chatKeys` factory in `site/src/api/queries/chats.ts`; all chat query keys route through it.
- Explicit `list` / `detail` namespaces enable prefix invalidation from generic to specific.
- Search and by-workspace are siblings of list, not members, because their cache data shapes differ from `InfiniteData`.
- List filters are canonicalized and the canonical value is used for both the key and the request query.
- Reviewed by two independent reviewers; approved.

</details>

---

Generated by Coder Agents on behalf of @DanielleMaywood