### PR TITLE
refactor(site/src/pages/AgentsPage): make WS-backed chat queries deliberately stale

### DIFF
--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -1,5 +1,5 @@
 import { hashKey, QueryClient } from "react-query";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { API } from "#/api/api";
 import type * as TypesGen from "#/api/typesGenerated";
 import {
@@ -10,6 +10,7 @@ import { buildOptimisticEditedMessage } from "./chatMessageEdits";
 import {
 	addChildToParentInCache,
 	archiveChat,
+	CHAT_SUMMARY_STALE_MS,
 	cancelChatListRefetches,
 	canonicalizeChatListFilters,
 	chatACL,
@@ -17,24 +18,30 @@ import {
 	chatAdvisorConfigKey,
 	chatCost,
 	chatCostSummary,
+	chat as chatDetail,
 	chatKeys,
+	chatMessagesForInfiniteScroll,
 	chatSearch,
+	clearChatUnreadInCaches,
 	createChat,
 	createChatMessage,
+	createCoalescedChatListInvalidator,
 	deleteChatQueuedMessage,
 	editChatMessage,
 	infiniteChats,
 	interruptChat,
 	invalidateChatListQueries,
+	invalidatePRStatusChatListQueries,
+	listFiltersFromKey,
 	mergeWatchedChatIntoCaches,
 	mergeWatchedChatSummary,
 	paginatedChatCostUsers,
 	pinChat,
-	prependToInfiniteChatsCache,
 	promoteChatQueuedMessage,
 	proposeChatTitle,
 	removeChildFromParentInCache,
 	reorderPinnedChat,
+	selectSortedChatList,
 	setChatGroupRole,
 	setChatUserRole,
 	TERMINAL_RUN_STATUSES,
@@ -269,21 +276,6 @@ describe("invalidateChatListQueries", () => {
 			queryClient.getQueryState(chatKeys.messages(otherChatId))?.isInvalidated,
 			"other chat's messages should NOT be invalidated",
 		).not.toBe(true);
-	});
-
-	it("prepends new root chats to filtered list caches", () => {
-		const queryClient = createTestQueryClient();
-		const activeChat = makeChat("active-created", { archived: false });
-
-		seedInfiniteChats(queryClient, [makeChat("active-existing")], {
-			archived: false,
-		});
-
-		prependToInfiniteChatsCache(queryClient, activeChat);
-
-		expect(readInfiniteChats(queryClient, { archived: false })?.[0]).toEqual(
-			activeChat,
-		);
 	});
 });
 
@@ -3000,5 +2992,299 @@ describe("chat ACL query factories", () => {
 		expect(queryClient.getQueryState(chatKeys.acl(chatId))?.isInvalidated).toBe(
 			true,
 		);
+	});
+});
+
+describe("chat query freshness policy", () => {
+	it("keeps the sidebar list finitely fresh and refetching on focus", () => {
+		const query = infiniteChats({ archived: false });
+
+		expect(query.staleTime).toBe(CHAT_SUMMARY_STALE_MS);
+		expect(CHAT_SUMMARY_STALE_MS).toBeGreaterThan(0);
+		expect(Number.isFinite(CHAT_SUMMARY_STALE_MS)).toBe(true);
+		expect(query.refetchOnWindowFocus).toBe(true);
+	});
+
+	it("gives the chat detail the same finite freshness and focus refetch", () => {
+		const query = chatDetail("chat-1");
+
+		expect(query.staleTime).toBe(CHAT_SUMMARY_STALE_MS);
+		expect(query.refetchOnWindowFocus).toBe(true);
+	});
+
+	it("never marks the per-chat message pages stale", () => {
+		const query = chatMessagesForInfiniteScroll("chat-1");
+
+		expect(query.staleTime).toBe(Number.POSITIVE_INFINITY);
+	});
+
+	it("leaves the shared chats prefix free of freshness overrides", () => {
+		// staleTime lives on the three WebSocket-backed factories, not on
+		// chatKeys.all, which also parents search, cost, and ACL queries.
+		expect(chatSearch("title:fix")).not.toHaveProperty("staleTime");
+		expect(chatACL("chat-1")).not.toHaveProperty("staleTime");
+	});
+});
+
+describe(selectSortedChatList.name, () => {
+	const chatAt = (id: string, updatedAt: string, pinOrder = 0): TypesGen.Chat =>
+		makeChat(id, { updated_at: updatedAt, pin_order: pinOrder });
+
+	it("orders pinned chats first by ascending pin_order", () => {
+		const sorted = selectSortedChatList({
+			pages: [
+				[
+					chatAt("unpinned", "2025-01-03T00:00:00.000Z"),
+					chatAt("pinned-second", "2025-01-01T00:00:00.000Z", 2),
+					chatAt("pinned-first", "2025-01-02T00:00:00.000Z", 1),
+				],
+			],
+			pageParams: [0],
+		});
+
+		expect(sorted.map((chat) => chat.id)).toEqual([
+			"pinned-first",
+			"pinned-second",
+			"unpinned",
+		]);
+	});
+
+	it("promotes a chat whose updated_at moved across a page boundary", () => {
+		const sorted = selectSortedChatList({
+			pages: [
+				[
+					chatAt("page-1-newest", "2025-01-05T00:00:00.000Z"),
+					chatAt("page-1-oldest", "2025-01-04T00:00:00.000Z"),
+				],
+				[chatAt("page-2-bumped", "2025-01-06T00:00:00.000Z")],
+			],
+			pageParams: [0, 2],
+		});
+
+		expect(sorted.map((chat) => chat.id)).toEqual([
+			"page-2-bumped",
+			"page-1-newest",
+			"page-1-oldest",
+		]);
+	});
+
+	it("breaks updated_at ties on descending id and leaves the cache pages alone", () => {
+		const pages = [
+			[
+				chatAt("chat-a", "2025-01-01T00:00:00.000Z"),
+				chatAt("chat-b", "2025-01-01T00:00:00.000Z"),
+			],
+		];
+		const cached = { pages, pageParams: [0] };
+
+		const sorted = selectSortedChatList(cached);
+
+		expect(sorted.map((chat) => chat.id)).toEqual(["chat-b", "chat-a"]);
+		expect(cached.pages[0].map((chat) => chat.id)).toEqual([
+			"chat-a",
+			"chat-b",
+		]);
+	});
+
+	it("orders sub-second updated_at values by their fractional part", () => {
+		const sorted = selectSortedChatList({
+			pages: [
+				[
+					chatAt("older", "2025-01-01T00:00:00.000001Z"),
+					chatAt("newer", "2025-01-01T00:00:00.000002Z"),
+				],
+			],
+			pageParams: [0],
+		});
+
+		expect(sorted.map((chat) => chat.id)).toEqual(["newer", "older"]);
+	});
+});
+
+describe(listFiltersFromKey.name, () => {
+	it("round-trips the canonical filters a list key was built from", () => {
+		const filters = {
+			archived: false,
+			prStatuses: ["open", "draft"] as const,
+			chatStatus: "unread" as const,
+			sources: ["created_by_me"] as const,
+		};
+
+		expect(listFiltersFromKey(chatKeys.list(filters))).toEqual(
+			canonicalizeChatListFilters(filters),
+		);
+	});
+
+	it("returns empty filters for the unfiltered list key", () => {
+		expect(listFiltersFromKey(chatKeys.list())).toEqual({});
+	});
+
+	it("rejects keys that are not a single list variant", () => {
+		expect(listFiltersFromKey(chatKeys.lists())).toBeUndefined();
+		expect(listFiltersFromKey(chatKeys.detail("chat-1"))).toBeUndefined();
+		expect(listFiltersFromKey(chatKeys.search("q"))).toBeUndefined();
+	});
+});
+
+describe(invalidatePRStatusChatListQueries.name, () => {
+	it("invalidates only the lists filtered by pull request status", async () => {
+		const queryClient = createTestQueryClient();
+		const prFiltered = { archived: false, prStatuses: ["open"] as const };
+		const unfiltered = { archived: false };
+
+		seedInfiniteChats(queryClient, [makeChat("chat-1")], prFiltered);
+		seedInfiniteChats(queryClient, [makeChat("chat-1")], unfiltered);
+		seedInfiniteChats(queryClient, [makeChat("chat-1")]);
+
+		await invalidatePRStatusChatListQueries(queryClient);
+
+		expect(
+			queryClient.getQueryState(chatKeys.list(prFiltered))?.isInvalidated,
+			"pr_status filtered lists should be invalidated",
+		).toBe(true);
+		expect(
+			queryClient.getQueryState(chatKeys.list(unfiltered))?.isInvalidated,
+			"lists without a pr_status filter should NOT be invalidated",
+		).not.toBe(true);
+		expect(
+			queryClient.getQueryState(chatKeys.list())?.isInvalidated,
+			"the unfiltered list should NOT be invalidated",
+		).not.toBe(true);
+	});
+
+	it("invalidates every cached pr_status variant", async () => {
+		const queryClient = createTestQueryClient();
+		const openOnly = { prStatuses: ["open"] as const };
+		const mergedOnly = { archived: true, prStatuses: ["merged"] as const };
+
+		seedInfiniteChats(queryClient, [makeChat("chat-1")], openOnly);
+		seedInfiniteChats(queryClient, [makeChat("chat-1")], mergedOnly);
+
+		await invalidatePRStatusChatListQueries(queryClient);
+
+		expect(
+			queryClient.getQueryState(chatKeys.list(openOnly))?.isInvalidated,
+		).toBe(true);
+		expect(
+			queryClient.getQueryState(chatKeys.list(mergedOnly))?.isInvalidated,
+		).toBe(true);
+	});
+});
+
+describe(createCoalescedChatListInvalidator.name, () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("collapses a burst of requests into one invalidation", () => {
+		const queryClient = createTestQueryClient();
+		seedInfiniteChats(queryClient, [makeChat("chat-1")]);
+		const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+		const invalidator = createCoalescedChatListInvalidator(queryClient, 500);
+
+		invalidator.schedule();
+		vi.advanceTimersByTime(100);
+		invalidator.schedule();
+		vi.advanceTimersByTime(100);
+		invalidator.schedule();
+
+		expect(invalidateSpy).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime(300);
+
+		expect(invalidateSpy).toHaveBeenCalledTimes(1);
+		expect(queryClient.getQueryState(chatKeys.list())?.isInvalidated).toBe(
+			true,
+		);
+	});
+
+	it("opens a new window after the previous one fired", () => {
+		const queryClient = createTestQueryClient();
+		const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+		const invalidator = createCoalescedChatListInvalidator(queryClient, 500);
+
+		invalidator.schedule();
+		vi.advanceTimersByTime(500);
+		invalidator.schedule();
+		vi.advanceTimersByTime(500);
+
+		expect(invalidateSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("drops a pending invalidation when cancelled", () => {
+		const queryClient = createTestQueryClient();
+		const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+		const invalidator = createCoalescedChatListInvalidator(queryClient, 500);
+
+		invalidator.schedule();
+		invalidator.cancel();
+		vi.advanceTimersByTime(1000);
+
+		expect(invalidateSpy).not.toHaveBeenCalled();
+	});
+});
+
+describe(clearChatUnreadInCaches.name, () => {
+	it("removes the chat from unread-filtered lists", () => {
+		const queryClient = createTestQueryClient();
+		const unreadOnly = { archived: false, chatStatus: "unread" as const };
+		seedInfiniteChats(
+			queryClient,
+			[
+				makeChat("chat-1", { has_unread: true }),
+				makeChat("chat-2", { has_unread: true }),
+			],
+			unreadOnly,
+		);
+
+		clearChatUnreadInCaches(queryClient, "chat-1");
+
+		expect(
+			readInfiniteChats(queryClient, unreadOnly)?.map((chat) => chat.id),
+		).toEqual(["chat-2"]);
+	});
+
+	it("clears has_unread in the other loaded variants", () => {
+		const queryClient = createTestQueryClient();
+		const readOnly = { chatStatus: "read" as const };
+		seedInfiniteChats(queryClient, [makeChat("chat-1", { has_unread: true })]);
+		seedInfiniteChats(
+			queryClient,
+			[makeChat("chat-1", { has_unread: true })],
+			readOnly,
+		);
+
+		clearChatUnreadInCaches(queryClient, "chat-1");
+
+		expect(readInfiniteChats(queryClient)?.[0].has_unread).toBe(false);
+		expect(readInfiniteChats(queryClient, readOnly)?.[0].has_unread).toBe(
+			false,
+		);
+	});
+
+	it("does not invalidate the lists it patched", () => {
+		const queryClient = createTestQueryClient();
+		seedInfiniteChats(queryClient, [makeChat("chat-1", { has_unread: true })]);
+
+		clearChatUnreadInCaches(queryClient, "chat-1");
+
+		expect(
+			queryClient.getQueryState(chatKeys.list())?.isInvalidated,
+			"a refetch here can return has_unread:true and undo the clear",
+		).not.toBe(true);
+	});
+
+	it("leaves unrelated chats and untouched caches by reference", () => {
+		const queryClient = createTestQueryClient();
+		seedInfiniteChats(queryClient, [makeChat("chat-2", { has_unread: true })]);
+		const before = queryClient.getQueryData(chatKeys.list());
+
+		clearChatUnreadInCaches(queryClient, "chat-1");
+
+		expect(queryClient.getQueryData(chatKeys.list())).toBe(before);
 	});
 });

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -19,7 +19,7 @@ import {
 export type ChatListPRStatusFilter = "draft" | "open" | "merged" | "closed";
 export type ChatListStatusFilter = "read" | "unread";
 
-type InfiniteChatsFilters = Readonly<{
+export type InfiniteChatsFilters = Readonly<{
 	archived?: boolean;
 	prStatuses?: readonly ChatListPRStatusFilter[];
 	chatStatus?: ChatListStatusFilter;
@@ -182,35 +182,6 @@ export const updateInfiniteChatsCache = (
 };
 
 /**
- * Prepends a new chat to the first page of every infinite chats query
- * in the cache, but only if the chat doesn't already exist in any
- * page. This avoids the per-page duplication that would occur if
- * a prepend updater were passed to updateInfiniteChatsCache, which
- * runs independently on each page.
- */
-export const prependToInfiniteChatsCache = (
-	queryClient: QueryClient,
-	chat: TypesGen.Chat,
-) => {
-	queryClient.setQueriesData<InfiniteChatsCacheData>(
-		{ queryKey: chatKeys.lists() },
-		(prev) => {
-			if (!prev?.pages) return prev;
-			// Check across ALL pages to avoid duplicates.
-			const exists = prev.pages.some((page) =>
-				page.some((c) => c.id === chat.id),
-			);
-			if (exists) return prev;
-			// Only prepend to the first page.
-			const nextPages = prev.pages.map((page, i) =>
-				i === 0 ? [chat, ...page] : page,
-			);
-			return { ...prev, pages: nextPages };
-		},
-	);
-};
-
-/**
  * Reads the flat list of chats from the first matching infinite query
  * in the cache. Returns undefined when no data is cached yet.
  */
@@ -315,12 +286,17 @@ export const removeChildFromParentInCache = (
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
 	typeof value === "object" && value !== null && !Array.isArray(value);
 
-// Inverse of chatKeys.list, which appends a single { filters } wrapper to the
-// chatKeys.lists() prefix. The length and shape checks narrow the readonly
-// unknown[] the query cache hands back, and reject any other list-prefixed key.
-const archivedFilterFromListKey = (
+/**
+ * Inverse of chatKeys.list, which appends a single { filters } wrapper to the
+ * chatKeys.lists() prefix. The length and shape checks narrow the readonly
+ * unknown[] the query cache hands back, and reject any other list-prefixed
+ * key. Returns the canonical filters a cached list was fetched with, so
+ * event handlers can decide which variants an event can change membership
+ * of instead of invalidating every list.
+ */
+export const listFiltersFromKey = (
 	queryKey: readonly unknown[],
-): boolean | undefined => {
+): InfiniteChatsFilters | undefined => {
 	if (queryKey.length !== chatKeys.lists().length + 1) {
 		return undefined;
 	}
@@ -328,9 +304,23 @@ const archivedFilterFromListKey = (
 	if (!isPlainObject(wrapper) || !isPlainObject(wrapper.filters)) {
 		return undefined;
 	}
-	const archived = wrapper.filters.archived;
-	return typeof archived === "boolean" ? archived : undefined;
+	const { archived, chatStatus, prStatuses, sources } = wrapper.filters;
+	return canonicalizeChatListFilters({
+		archived: typeof archived === "boolean" ? archived : undefined,
+		chatStatus:
+			chatStatus === "read" || chatStatus === "unread" ? chatStatus : undefined,
+		prStatuses: Array.isArray(prStatuses)
+			? canonicalizeChatListPRStatuses(prStatuses)
+			: undefined,
+		sources: Array.isArray(sources)
+			? canonicalizeChatListSources(sources)
+			: undefined,
+	});
 };
+
+const archivedFilterFromListKey = (
+	queryKey: readonly unknown[],
+): boolean | undefined => listFiltersFromKey(queryKey)?.archived;
 
 const isInfiniteChatsCacheData = (
 	data: unknown,
@@ -425,6 +415,66 @@ export const applyChatArchiveStateToCaches = (
 	}
 };
 
+/**
+ * Applies the optimistic read state for the chat the user just opened.
+ * A list filtered to unread chats no longer contains the chat, so it is
+ * dropped from those variants rather than patched; every other loaded
+ * variant keeps the chat with has_unread cleared. Deliberately does not
+ * invalidate: a refetch racing the server-side read marker returns
+ * has_unread:true and undoes the clear. The finite list staleTime and the
+ * focus refetch reconcile a failed server write instead.
+ */
+export const clearChatUnreadInCaches = (
+	queryClient: QueryClient,
+	chatId: string,
+) => {
+	const queries = queryClient.getQueriesData<InfiniteChatsCacheData>({
+		queryKey: chatKeys.lists(),
+	});
+
+	for (const [queryKey, data] of queries) {
+		if (!isInfiniteChatsCacheData(data)) {
+			continue;
+		}
+		const isUnreadOnlyList =
+			listFiltersFromKey(queryKey)?.chatStatus === "unread";
+		queryClient.setQueryData<InfiniteChatsCacheData>(queryKey, (prev) => {
+			if (!isInfiniteChatsCacheData(prev)) {
+				return prev;
+			}
+
+			let changed = false;
+			const pages = prev.pages.map((page) => {
+				let pageChanged = false;
+				const nextPage: TypesGen.Chat[] = [];
+				for (const chat of page) {
+					if (chat.id !== chatId) {
+						nextPage.push(chat);
+						continue;
+					}
+					if (isUnreadOnlyList) {
+						pageChanged = true;
+						continue;
+					}
+					if (!chat.has_unread) {
+						nextPage.push(chat);
+						continue;
+					}
+					pageChanged = true;
+					nextPage.push({ ...chat, has_unread: false });
+				}
+				if (pageChanged) {
+					changed = true;
+					return nextPage;
+				}
+				return page;
+			});
+
+			return changed ? { ...prev, pages } : prev;
+		});
+	}
+};
+
 const parseUpdatedAtInstant = (updatedAt: string) => {
 	const match = updatedAt.match(/^(.*?)(?:\.(\d+))?(Z|[+-]\d\d:\d\d)$/);
 	if (!match) {
@@ -454,6 +504,48 @@ const compareUpdatedAtInstants = (a: string, b: string): number => {
 	}
 	return parsedA.fractionalNanos - parsedB.fractionalNanos;
 };
+
+/**
+ * Mirrors the sidebar ordering the list endpoint applies
+ * (`(pin_order > 0) DESC, -pin_order DESC, updated_at DESC, id DESC`,
+ * GetChats in chats.sql). WebSocket merges patch a cached chat in place,
+ * so without this the sidebar keeps the ordering of the last fetch until
+ * a refetch reorders it.
+ */
+export const compareSidebarChats = (
+	a: TypesGen.Chat,
+	b: TypesGen.Chat,
+): number => {
+	const aPinned = a.pin_order > 0 ? 1 : 0;
+	const bPinned = b.pin_order > 0 ? 1 : 0;
+	if (aPinned !== bPinned) {
+		return bPinned - aPinned;
+	}
+	if (aPinned === 1 && a.pin_order !== b.pin_order) {
+		// -pin_order DESC puts the lowest pin_order first.
+		return a.pin_order - b.pin_order;
+	}
+	const byUpdatedAt = compareUpdatedAtInstants(b.updated_at, a.updated_at);
+	if (byUpdatedAt !== 0) {
+		return byUpdatedAt;
+	}
+	if (a.id === b.id) {
+		return 0;
+	}
+	return a.id < b.id ? 1 : -1;
+};
+
+/**
+ * Flattens the paginated sidebar list and restores the server ordering at
+ * the render layer. Sorting the cache instead would either be limited to a
+ * single page (updateInfiniteChatsCache maps per page) or desync the client
+ * page boundaries from the server offset windows. Only loaded chats can be
+ * promoted; a chat past the last loaded page enters the window on the next
+ * refetch.
+ */
+export const selectSortedChatList = (
+	data: InfiniteData<TypesGen.Chat[]>,
+): TypesGen.Chat[] => data.pages.flat().toSorted(compareSidebarChats);
 
 type MergeWatchedChatOptions = {
 	readonly eventKind: TypesGen.ChatWatchEventKind;
@@ -656,6 +748,60 @@ export const invalidateChatListQueries = (queryClient: QueryClient) => {
 };
 
 /**
+ * Invalidates only the list variants filtered by pull request status.
+ * A diff_status_change can move a chat in or out of those result sets;
+ * no other list filter depends on diff status, and the chat's own
+ * diff_status field is merged into every cached list from the event
+ * payload.
+ */
+export const invalidatePRStatusChatListQueries = (queryClient: QueryClient) => {
+	return queryClient.invalidateQueries({
+		queryKey: chatKeys.lists(),
+		predicate: (query) => {
+			const prStatuses = listFiltersFromKey(query.queryKey)?.prStatuses;
+			return prStatuses !== undefined && prStatuses.length > 0;
+		},
+	});
+};
+
+/** Window a burst of list invalidations collapses into. */
+export const CHAT_LIST_INVALIDATE_COALESCE_MS = 500;
+
+/**
+ * Collapses a burst of chat list invalidations into a single trailing
+ * refetch. A running agent emits status events continuously and each one
+ * bumps updated_at, which every list sorts by, so the list still has to be
+ * invalidated; the window bounds that to one refetch per interval instead
+ * of one per event. The first request opens the window and later requests
+ * ride along, so an invalidation always lands within the window rather
+ * than being pushed back indefinitely by a sustained burst.
+ */
+export const createCoalescedChatListInvalidator = (
+	queryClient: QueryClient,
+	delayMs: number = CHAT_LIST_INVALIDATE_COALESCE_MS,
+) => {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	return {
+		schedule: () => {
+			if (timeout !== undefined) {
+				return;
+			}
+			timeout = setTimeout(() => {
+				timeout = undefined;
+				void invalidateChatListQueries(queryClient);
+			}, delayMs);
+		},
+		cancel: () => {
+			if (timeout === undefined) {
+				return;
+			}
+			clearTimeout(timeout);
+			timeout = undefined;
+		},
+	};
+};
+
+/**
  * Predicate that matches chat-list queries performing a regular
  * refetch (window-focus, invalidation, mount) but not a
  * fetchNextPage or fetchPreviousPage. During pagination fetches
@@ -708,6 +854,18 @@ export const cancelChatListRefetches = (queryClient: QueryClient) => {
 
 const DEFAULT_CHAT_PAGE_LIMIT = 50;
 export const CHAT_SEARCH_LIMIT = 50;
+
+/**
+ * How long a fetched chat summary stays fresh. The watch socket pushes
+ * status, title, summary, and diff status, but PATCH-only fields
+ * (pin_order, plan_mode, labels, mcp_server_ids, workspace_id) and
+ * has_unread have no push path, so these caches must still be
+ * refetchable. Two minutes is short enough that a rename or pin from
+ * another tab converges on the next window focus, and long enough that
+ * mounting the page or navigating between chats no longer refetches every
+ * loaded page.
+ */
+export const CHAT_SUMMARY_STALE_MS = 2 * 60 * 1000;
 
 type UpdateChatWorkspaceVariables = {
 	chatId: string;
@@ -774,6 +932,11 @@ export const infiniteChats = (filters?: InfiniteChatsFilters) => {
 			});
 		},
 		refetchOnWindowFocus: true as const,
+		// refetchOnWindowFocus only fires for a stale query, so a finite
+		// staleTime turns focus into the bounded catch-up path for the
+		// fields the watch socket does not push.
+		staleTime: CHAT_SUMMARY_STALE_MS,
+		select: selectSortedChatList,
 		retry: 3,
 	} satisfies UseInfiniteQueryOptions<TypesGen.Chat[]>;
 };
@@ -791,6 +954,11 @@ export const chatSearch = (q: string) =>
 export const chat = (chatId: string) => ({
 	queryKey: chatKeys.detail(chatId),
 	queryFn: () => API.experimental.getChat(chatId),
+	// Same freshness policy as the sidebar list: the open chat's detail
+	// carries the same non-pushed fields, plus files, context, and
+	// children that the watch payloads do not fully cover.
+	staleTime: CHAT_SUMMARY_STALE_MS,
+	refetchOnWindowFocus: true,
 });
 
 export const chatACL = (chatId: string) => ({
@@ -826,6 +994,14 @@ export const chatMessagesForInfiniteScroll = (chatId: string) => ({
 		// Use its ID as the cursor for the next (older) page.
 		return lastPage.messages[lastPage.messages.length - 1].id;
 	},
+	// The per-chat socket is authoritative for messages: on every connect
+	// it replays messages after the client's cursor, emits history_reset
+	// with the replacement history for edits and deletions below it, and
+	// sends an authoritative queue_update snapshot (including an empty
+	// array once the queue drains). A background refetch would only
+	// re-download pages the socket already reconciled, and default gcTime
+	// evicts the cache once the chat is inactive.
+	staleTime: Number.POSITIVE_INFINITY,
 });
 
 // Cap requested prompts to keep the response small; well under the server-side maximum.

--- a/site/src/pages/AgentsPage/AgentsPageLayout.test.ts
+++ b/site/src/pages/AgentsPage/AgentsPageLayout.test.ts
@@ -1,6 +1,15 @@
 import { act, renderHook } from "@testing-library/react";
+import { QueryClient } from "react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { API } from "#/api/api";
+import {
+	chatKeys,
+	infiniteChats,
+	invalidateChatListQueries,
+	readInfiniteChatsCache,
+} from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
+import { MockChat } from "#/testHelpers/chatEntities";
 import {
 	chatCostIdToInvalidate,
 	shouldInvalidateFilteredChatList,
@@ -13,6 +22,11 @@ import {
 	persistedAttachmentsStorageKey,
 	useFileAttachments,
 } from "./hooks/useFileAttachments";
+import {
+	_resetForTesting,
+	maybePlayChime,
+	setChimeEnabled,
+} from "./utils/chime";
 
 describe("useEmptyStateDraft", () => {
 	beforeEach(() => {
@@ -1052,5 +1066,98 @@ describe(chatCostIdToInvalidate.name, () => {
 		},
 	])("$name", ({ updatedChat, eventKind, expected }) => {
 		expect(chatCostIdToInvalidate(updatedChat, eventKind)).toBe(expected);
+	});
+});
+
+// The `created` watch event no longer prepends the chat into every cached
+// list variant; it invalidates and lets the server decide membership. The
+// completion chime reads the previous status from the list cache, so it has
+// to keep working off the refetched list the invalidation produces.
+describe("chime for a chat created in another tab", () => {
+	class MockLockManager {
+		async request(
+			name: string,
+			_options: LockOptions,
+			callback: (lock: Lock | null) => Promise<void>,
+		): Promise<void> {
+			await callback({ name, mode: "exclusive" } as Lock);
+		}
+	}
+
+	const createdChat: TypesGen.Chat = {
+		...MockChat,
+		id: "chat-created-elsewhere",
+		archived: false,
+		pin_order: 0,
+		has_unread: false,
+		status: "running",
+		updated_at: "2025-01-01T00:00:00.000Z",
+	};
+
+	let playSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		localStorage.clear();
+		_resetForTesting();
+		setChimeEnabled(true);
+		Object.defineProperty(navigator, "locks", {
+			value: new MockLockManager(),
+			writable: true,
+			configurable: true,
+		});
+		vi.spyOn(document, "hidden", "get").mockReturnValue(false);
+		playSpy = vi
+			.spyOn(HTMLMediaElement.prototype, "play")
+			.mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("chimes on completion after the created invalidation refetches the list", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: {
+				queries: {
+					retry: false,
+					gcTime: Number.POSITIVE_INFINITY,
+					refetchOnWindowFocus: false,
+					networkMode: "offlineFirst",
+				},
+			},
+		});
+		const filters = { archived: false };
+		queryClient.setQueryData(chatKeys.list(filters), {
+			pages: [[]],
+			pageParams: [0],
+		});
+		const getChatsSpy = vi
+			.spyOn(API.experimental, "getChats")
+			.mockResolvedValue([createdChat]);
+
+		// The `created` handler only invalidates; the sidebar's own query
+		// refetches and the server decides list membership.
+		await invalidateChatListQueries(queryClient);
+		const { queryKey, queryFn, initialPageParam, getNextPageParam } =
+			infiniteChats(filters);
+		await queryClient.fetchInfiniteQuery({
+			queryKey,
+			queryFn,
+			initialPageParam,
+			getNextPageParam,
+		});
+		expect(getChatsSpy).toHaveBeenCalled();
+
+		// A later status_change reads the previous status out of that
+		// refetched list, exactly as the watch handler does.
+		const prevStatus = readInfiniteChatsCache(queryClient)?.find(
+			(chat) => chat.id === createdChat.id,
+		)?.status;
+		expect(prevStatus).toBe("running");
+
+		maybePlayChime(prevStatus, "waiting", createdChat.id, undefined);
+		await vi.waitFor(() => {
+			expect(playSpy).toHaveBeenCalledTimes(1);
+		});
 	});
 });

--- a/site/src/pages/AgentsPage/AgentsPageLayout.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageLayout.tsx
@@ -23,11 +23,13 @@ import {
 	chatKeys,
 	chatModelConfigs,
 	chatModels,
+	clearChatUnreadInCaches,
+	createCoalescedChatListInvalidator,
 	infiniteChats,
 	invalidateChatListQueries,
+	invalidatePRStatusChatListQueries,
 	mergeWatchedChatIntoCaches,
 	pinChat,
-	prependToInfiniteChatsCache,
 	proposeChatTitle,
 	readInfiniteChatsCache,
 	removeChildFromParentInCache,
@@ -387,7 +389,10 @@ const AgentsPageLayout: FC = () => {
 		chatModelsQuery.data,
 		providerInfoByIDFromUserConfigs(chatProviderConfigsQuery.data),
 	);
-	const chatList = chatsQuery.data?.pages.flat() ?? [];
+	// infiniteChats selects the flattened list already sorted the way the
+	// list endpoint orders it, so in-place WebSocket patches reorder the
+	// sidebar without refetching the loaded pages.
+	const chatList = chatsQuery.data ?? [];
 	const isArchiving =
 		archiveAgentMutation.isPending || archiveAndDeleteMutation.isPending;
 	const archivingChatId =
@@ -556,26 +561,21 @@ const AgentsPageLayout: FC = () => {
 
 	// Optimistically clear the unread indicator for the active
 	// chat. The server marks chats as read on stream connect
-	// and disconnect, but the list cache is not refetched until
-	// window focus. Without this, navigating away from a chat
-	// causes its cached has_unread to reappear as a stale dot.
+	// and disconnect, but publishes no event for it, so the
+	// cached has_unread would reappear as a stale dot when
+	// navigating away from a chat.
 	useEffect(() => {
 		if (!agentId) {
 			return;
 		}
-		updateInfiniteChatsCache(queryClient, (chats) => {
-			let changed = false;
-			const next = chats.map((c) => {
-				if (c.id !== agentId || !c.has_unread) return c;
-				changed = true;
-				return { ...c, has_unread: false };
-			});
-			return changed ? next : chats;
-		});
-		void invalidateChatListQueries(queryClient);
+		clearChatUnreadInCaches(queryClient, agentId);
 	}, [agentId, queryClient]);
 	useEffect(() => {
-		return createReconnectingWebSocket({
+		// A running agent emits status events continuously, so the list
+		// invalidation they trigger is collapsed into one trailing refetch.
+		const coalescedListInvalidate =
+			createCoalescedChatListInvalidator(queryClient);
+		const disposeWebSocket = createReconnectingWebSocket({
 			connect() {
 				const ws = watchChats();
 
@@ -661,7 +661,9 @@ const AgentsPageLayout: FC = () => {
 								updatedChat.parent_chat_id,
 							);
 						} else {
-							prependToInfiniteChatsCache(queryClient, updatedChat);
+							// Only the server knows which filtered lists the
+							// new chat belongs to, so refetch instead of
+							// prepending it into every cached variant.
 							void invalidateChatListQueries(queryClient);
 						}
 					} else {
@@ -670,7 +672,16 @@ const AgentsPageLayout: FC = () => {
 							activeChatId: activeChatIDRef.current,
 						});
 						if (shouldInvalidateFilteredChatList(updatedChat, chatEvent.kind)) {
-							void invalidateChatListQueries(queryClient);
+							if (chatEvent.kind === "diff_status_change") {
+								// Only PR-status-filtered lists can gain or lose
+								// the chat; the merge above already wrote
+								// diff_status into every cached variant.
+								void invalidatePRStatusChatListQueries(queryClient);
+							} else {
+								// Every list sorts by updated_at, which a
+								// status_change bumps.
+								coalescedListInvalidate.schedule();
+							}
 						}
 						const costChatId = chatCostIdToInvalidate(
 							updatedChat,
@@ -702,6 +713,10 @@ const AgentsPageLayout: FC = () => {
 				void invalidateChatListQueries(queryClient);
 			},
 		});
+		return () => {
+			coalescedListInvalidate.cancel();
+			disposeWebSocket();
+		};
 	}, [queryClient]);
 
 	useAgentsPageKeybindings({

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -5478,3 +5478,192 @@ describe("parse errors", () => {
 		});
 	});
 });
+
+// chatMessagesForInfiniteScroll uses staleTime: Infinity because the
+// per-chat socket, not a background refetch, is what reconciles the cached
+// pages. These cover the three resync paths that make the cached pages
+// converge after reconnecting with a stale cache.
+describe("message cache resync over the socket", () => {
+	// The seeded cache entry has no observer (useChatStore writes to it but
+	// never subscribes), so the shared helper's gcTime of 0 would collect it
+	// before the assertions run.
+	const createRetainedQueryClient = (): QueryClient =>
+		new QueryClient({
+			defaultOptions: {
+				queries: {
+					retry: false,
+					gcTime: Number.POSITIVE_INFINITY,
+					refetchOnWindowFocus: false,
+					networkMode: "offlineFirst",
+				},
+			},
+		});
+
+	it("writes messages committed above the cached cursor into the cache", async () => {
+		const chatID = "chat-1";
+		const cachedMessage = buildMessage(chatID, 5, "user", "cached");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createRetainedQueryClient();
+		const initialChatMessagesData: TypesGen.ChatMessagesResponse = {
+			messages: [cachedMessage],
+			queued_messages: [],
+			has_more: false,
+		};
+		queryClient.setQueryData(chatKeys.messages(chatID), {
+			pages: [initialChatMessagesData],
+			pageParams: [undefined],
+		});
+
+		renderHook(
+			() =>
+				useChatStore({
+					chatID,
+					chatMessages: [cachedMessage],
+					chatRecord: buildChat(chatID),
+					chatMessagesData: initialChatMessagesData,
+					chatQueuedMessages: [],
+					setChatErrorReason: vi.fn(),
+					clearChatErrorReason: vi.fn(),
+				}),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		await waitFor(() => {
+			// The socket subscribes with the cached cursor, so the server
+			// replays only what was committed after it.
+			expect(watchChat).toHaveBeenCalledWith(chatID, 5);
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "message",
+				chat_id: chatID,
+				message: buildMessage(chatID, 6, "assistant", "replayed"),
+			});
+		});
+
+		await waitFor(() => {
+			const cachedData = queryClient.getQueryData<{
+				pages: TypesGen.ChatMessagesResponse[];
+				pageParams: unknown[];
+			}>(chatKeys.messages(chatID));
+			expect(cachedData?.pages[0]?.messages.map((m) => m.id)).toEqual([6, 5]);
+		});
+	});
+
+	it("replaces cached messages edited or deleted below the cursor", async () => {
+		const chatID = "chat-1";
+		const cachedMessages = [
+			buildMessage(chatID, 1, "user", "original"),
+			buildMessage(chatID, 2, "assistant", "stale answer"),
+		];
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createRetainedQueryClient();
+		const initialChatMessagesData: TypesGen.ChatMessagesResponse = {
+			messages: cachedMessages,
+			queued_messages: [],
+			has_more: false,
+		};
+		queryClient.setQueryData(chatKeys.messages(chatID), {
+			pages: [initialChatMessagesData],
+			pageParams: [undefined],
+		});
+
+		renderHook(
+			() =>
+				useChatStore({
+					chatID,
+					chatMessages: cachedMessages,
+					chatRecord: buildChat(chatID),
+					chatMessagesData: initialChatMessagesData,
+					chatQueuedMessages: [],
+					setChatErrorReason: vi.fn(),
+					clearChatErrorReason: vi.fn(),
+				}),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 2);
+		});
+
+		act(() => {
+			mockSocket.emitDataBatch([
+				{ type: "history_reset", chat_id: chatID },
+				{
+					type: "message",
+					chat_id: chatID,
+					message: buildMessage(chatID, 1, "user", "edited"),
+				},
+				{ type: "preview_reset", chat_id: chatID },
+			]);
+		});
+
+		await waitFor(() => {
+			const cachedData = queryClient.getQueryData<{
+				pages: TypesGen.ChatMessagesResponse[];
+				pageParams: unknown[];
+			}>(chatKeys.messages(chatID));
+			expect(cachedData?.pages[0]?.messages).toEqual([
+				buildMessage(chatID, 1, "user", "edited"),
+			]);
+		});
+	});
+
+	it("applies the authoritative queue snapshot when the queue has drained", async () => {
+		const chatID = "chat-1";
+		const cachedMessage = buildMessage(chatID, 1, "user", "hello");
+		const queuedMessage = buildQueuedMessage(chatID, 10, "queued");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createRetainedQueryClient();
+		const initialChatMessagesData: TypesGen.ChatMessagesResponse = {
+			messages: [cachedMessage],
+			queued_messages: [queuedMessage],
+			has_more: false,
+		};
+		queryClient.setQueryData(chatKeys.messages(chatID), {
+			pages: [initialChatMessagesData],
+			pageParams: [undefined],
+		});
+
+		renderHook(
+			() =>
+				useChatStore({
+					chatID,
+					chatMessages: [cachedMessage],
+					chatRecord: buildChat(chatID),
+					chatMessagesData: initialChatMessagesData,
+					chatQueuedMessages: [queuedMessage],
+					setChatErrorReason: vi.fn(),
+					clearChatErrorReason: vi.fn(),
+				}),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "queue_update",
+				chat_id: chatID,
+				queued_messages: [],
+			});
+		});
+
+		await waitFor(() => {
+			const cachedData = queryClient.getQueryData<{
+				pages: TypesGen.ChatMessagesResponse[];
+				pageParams: unknown[];
+			}>(chatKeys.messages(chatID));
+			expect(cachedData?.pages[0]?.queued_messages).toEqual([]);
+		});
+	});
+});


### PR DESCRIPTION
This is PR 2 of a stack fixing the Agents/chats feature's misuse of TanStack Query.

WebSocket-backed chat queries had no deliberate freshness policy, so the cache could serve stale data or refetch needlessly. This PR sets a per-factory `staleTime`: finite for list/detail, `Infinity` for durable message history (whose single ordered writer is the socket). It moves sidebar sorting into the render layer instead of reordering the cache, coalesces and narrows invalidations, removes the filter-blind created-chat prepend, and makes unread handling deterministic. `maxPages` was explicitly rejected because pagination derives the next page from `pages.length + 1`, so eviction would repeat page parameters.

Depends on #27770

<details>
<summary>Implementation plan and review notes (for reviewers)</summary>

- Per-factory `staleTime`: finite for list/detail, `Infinity` for durable message history.
- Freshness is deliberate but not assumed complete: some chat fields have no WS event, so finite list/detail staleness plus focus catch-up remains.
- Render-layer sidebar sorting replaces cache reordering.
- The cancel guards and `useChatStore` status fences are deliberately retained: critique showed they guard explicit-invalidation races, not just stale-time behavior.
- Reviewed by two independent reviewers; approved.

</details>

---

Generated by Coder Agents on behalf of @DanielleMaywood