### PR TITLE
refactor(site/src/api/queries): unify chat mutation optimistic/rollback contract

### DIFF
--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -1,7 +1,8 @@
-import { hashKey, QueryClient } from "react-query";
+import { hashKey, MutationObserver, QueryClient } from "react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { API } from "#/api/api";
 import type * as TypesGen from "#/api/typesGenerated";
+import { resolvePinnedChatDrop } from "#/pages/AgentsPage/components/ChatsSidebar/chats/pinnedChatDrag";
 import {
 	ERROR_STATUSES,
 	SUCCESS_STATUSES,
@@ -12,6 +13,7 @@ import {
 	archiveChat,
 	CHAT_SUMMARY_STALE_MS,
 	cancelChatListRefetches,
+	cancelChatMutationRefetches,
 	canonicalizeChatListFilters,
 	chatACL,
 	chatAdvisorConfig,
@@ -28,6 +30,7 @@ import {
 	createCoalescedChatListInvalidator,
 	deleteChatQueuedMessage,
 	editChatMessage,
+	findChatInCaches,
 	infiniteChats,
 	interruptChat,
 	invalidateChatListQueries,
@@ -36,6 +39,7 @@ import {
 	mergeWatchedChatIntoCaches,
 	mergeWatchedChatSummary,
 	paginatedChatCostUsers,
+	patchChatEverywhere,
 	pinChat,
 	promoteChatQueuedMessage,
 	proposeChatTitle,
@@ -141,6 +145,12 @@ const createTestQueryClient = (): QueryClient =>
 				gcTime: Number.POSITIVE_INFINITY,
 				refetchOnWindowFocus: false,
 				networkMode: "offlineFirst",
+			},
+			mutations: {
+				retry: false,
+				// Never pause on the environment's online state: these tests
+				// drive the mutation lifecycle directly.
+				networkMode: "always",
 			},
 		},
 	});
@@ -280,10 +290,11 @@ describe("invalidateChatListQueries", () => {
 });
 
 describe("updateChatPlanMode optimistic update", () => {
-	it("invalidates the chat list on error without a detail cache", async () => {
+	it("rolls back from the list cache when no detail cache exists", async () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";
 		seedInfiniteChats(queryClient, [makeChat(chatId)]);
+		const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
 		const mutation = updateChatPlanMode(queryClient);
 		const context = await mutation.onMutate({
@@ -291,7 +302,8 @@ describe("updateChatPlanMode optimistic update", () => {
 			planMode: "plan",
 		});
 
-		expect(context?.previousChat).toBeUndefined();
+		expect(context.found).toBe(true);
+		expect(context.previousPlanMode).toBeUndefined();
 		expect(readInfiniteChats(queryClient)?.[0].plan_mode).toBe("plan");
 
 		mutation.onError(
@@ -300,10 +312,66 @@ describe("updateChatPlanMode optimistic update", () => {
 			context,
 		);
 
+		expect(readInfiniteChats(queryClient)?.[0].plan_mode).toBeUndefined();
 		expect(
-			queryClient.getQueryState(infiniteChatsTestKey)?.isInvalidated,
-			"chat list should be invalidated when rollback lacks detail cache",
-		).toBe(true);
+			invalidateSpy,
+			"rollback is the inverse patch, not a refetch",
+		).not.toHaveBeenCalled();
+	});
+
+	it("keeps a plan mode a later write installed during the mutation", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		seedInfiniteChats(queryClient, [makeChat(chatId, { plan_mode: "plan" })]);
+		queryClient.setQueryData(
+			chatKeys.detail(chatId),
+			makeChat(chatId, { plan_mode: "plan" }),
+		);
+
+		const mutation = updateChatPlanMode(queryClient);
+		const context = await mutation.onMutate({ chatId, planMode: undefined });
+
+		// A concurrent write lands while the PATCH is in flight.
+		patchChatEverywhere(queryClient, chatId, (chat) => ({
+			...chat,
+			plan_mode: "plan",
+		}));
+
+		mutation.onError(
+			new Error("server error"),
+			{ chatId, planMode: undefined },
+			context,
+		);
+
+		expect(readInfiniteChats(queryClient)?.[0].plan_mode).toBe("plan");
+		expect(
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId))
+				?.plan_mode,
+		).toBe("plan");
+	});
+
+	it("converges a failed toggle without returning pending promises", () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		const invalidateSpy = vi
+			.spyOn(queryClient, "invalidateQueries")
+			.mockReturnValue(new Promise<void>(() => {}));
+
+		const mutation = updateChatPlanMode(queryClient);
+		const result = mutation.onSettled(undefined, new Error("boom"), {
+			chatId,
+			planMode: "plan",
+		});
+
+		expect(result).toBeUndefined();
+		expect(invalidateSpy).toHaveBeenCalledWith(
+			expect.objectContaining({ queryKey: chatKeys.lists() }),
+		);
+		expect(invalidateSpy).toHaveBeenCalledWith({
+			queryKey: chatKeys.detail(chatId),
+			exact: true,
+		});
+		invalidateSpy.mockRestore();
 	});
 });
 
@@ -326,10 +394,11 @@ describe("updateChatTitle cache update", () => {
 		);
 
 		const mutation = updateChatTitle(queryClient);
-		mutation.onSuccess(undefined, { chatId, title: "New" });
+		mutation.onSuccess(undefined, { chatId, title: "  New  " });
 
 		expect(
 			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId))?.title,
+			"the server trims the title, so the cache must too",
 		).toBe("New");
 		expect(
 			readInfiniteChats(queryClient)?.find((chat) => chat.id === chatId),
@@ -402,29 +471,6 @@ describe("archiveChat optimistic update", () => {
 		expect(cachedChat?.archived).toBe(true);
 	});
 
-	it("strips an individually-archived child from its parent's embedded children", async () => {
-		const queryClient = createTestQueryClient();
-		const child = makeChat("child-1", {
-			parent_chat_id: "parent-1",
-			root_chat_id: "parent-1",
-		});
-		const sibling = makeChat("child-2", {
-			parent_chat_id: "parent-1",
-			root_chat_id: "parent-1",
-		});
-		const parent = makeChat("parent-1", { children: [child, sibling] });
-		seedInfiniteChats(queryClient, [parent]);
-
-		vi.mocked(API.experimental.updateChat).mockResolvedValue();
-
-		const mutation = archiveChat(queryClient);
-		await mutation.onMutate("child-1");
-
-		const result = readInfiniteChats(queryClient);
-		expect(result?.[0].children).toHaveLength(1);
-		expect(result?.[0].children?.[0].id).toBe("child-2");
-	});
-
 	it("removes an archived root chat from active filtered lists after success", () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";
@@ -471,27 +517,58 @@ describe("archiveChat optimistic update", () => {
 		});
 	});
 
-	it("rolls back the chats list on error by invalidating", async () => {
+	it("restores the chats list on error with an inverse patch", async () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";
-		const initialChats = [makeChat(chatId)];
-		seedInfiniteChats(queryClient, initialChats);
-		queryClient.setQueryData(chatKeys.detail(chatId), makeChat(chatId));
+		seedInfiniteChats(queryClient, [makeChat(chatId, { pin_order: 4 })]);
+		queryClient.setQueryData(
+			chatKeys.detail(chatId),
+			makeChat(chatId, { pin_order: 4 }),
+		);
 		const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
 		const mutation = archiveChat(queryClient);
 		const context = await mutation.onMutate(chatId);
 
 		// Verify the optimistic update took effect.
-		expect(readInfiniteChats(queryClient)?.[0].archived).toBe(true);
+		expect(readInfiniteChats(queryClient)?.[0]).toMatchObject({
+			archived: true,
+			pin_order: 0,
+		});
 
-		// Simulate an error, the onError handler invalidates the
-		// cache so a re-fetch restores the correct state.
 		mutation.onError(new Error("server error"), chatId, context);
 
-		expect(invalidateSpy).toHaveBeenCalledWith(
-			expect.objectContaining({ queryKey: chatKeys.lists() }),
-		);
+		expect(readInfiniteChats(queryClient)?.[0]).toMatchObject({
+			archived: false,
+			pin_order: 4,
+		});
+		expect(
+			invalidateSpy,
+			"rollback is the inverse patch, not a refetch",
+		).not.toHaveBeenCalled();
+	});
+
+	it("leaves a chat the server already archived alone on error", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		seedInfiniteChats(queryClient, [makeChat(chatId, { pin_order: 4 })]);
+
+		const mutation = archiveChat(queryClient);
+		const context = await mutation.onMutate(chatId);
+
+		// A concurrent write moves pin_order off the optimistic value,
+		// so the value guard must skip the rollback.
+		patchChatEverywhere(queryClient, chatId, (chat) => ({
+			...chat,
+			pin_order: 7,
+		}));
+
+		mutation.onError(new Error("server error"), chatId, context);
+
+		expect(readInfiniteChats(queryClient)?.[0]).toMatchObject({
+			archived: true,
+			pin_order: 7,
+		});
 	});
 
 	it("rolls back the individual chat cache on error", async () => {
@@ -529,10 +606,10 @@ describe("archiveChat optimistic update", () => {
 			mutation.onError(new Error("fail"), chatId, undefined);
 		}).not.toThrow();
 
-		// The handler should still invalidate to trigger a refetch.
-		expect(invalidateSpy).toHaveBeenCalledWith(
-			expect.objectContaining({ queryKey: chatKeys.lists() }),
-		);
+		// Without a captured prior value there is nothing to restore, and
+		// the onSettled invalidation is the only convergence path.
+		expect(readInfiniteChats(queryClient)?.[0].archived).toBe(true);
+		expect(invalidateSpy).not.toHaveBeenCalled();
 	});
 
 	it("handles onMutate when no individual chat cache exists", async () => {
@@ -546,8 +623,21 @@ describe("archiveChat optimistic update", () => {
 
 		// The list should still be optimistically updated.
 		expect(readInfiniteChats(queryClient)?.[0].archived).toBe(true);
-		// previousChat should be undefined.
-		expect(context?.previousChat).toBeUndefined();
+		// The prior state is read from the list cache instead.
+		expect(context).toMatchObject({
+			found: true,
+			previousArchived: false,
+			previousPinOrder: 0,
+		});
+	});
+
+	it("reports nothing to roll back when the chat is in no cache", async () => {
+		const queryClient = createTestQueryClient();
+
+		const mutation = archiveChat(queryClient);
+		const context = await mutation.onMutate("chat-missing");
+
+		expect(context.found).toBe(false);
 	});
 
 	it("invalidates on settled without returning pending promises", () => {
@@ -659,15 +749,13 @@ describe("unarchiveChat optimistic update", () => {
 		// Roll back.
 		mutation.onError(new Error("server error"), chatId, context);
 
-		// The chats list is rolled back via invalidation.
-		expect(invalidateSpy).toHaveBeenCalledWith(
-			expect.objectContaining({ queryKey: chatKeys.lists() }),
-		);
-		// The individual chat cache is restored directly.
+		// Both layers are restored by the inverse patch, with no refetch.
+		expect(readInfiniteChats(queryClient)?.[0].archived).toBe(true);
 		expect(
 			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId))
 				?.archived,
 		).toBe(true);
+		expect(invalidateSpy).not.toHaveBeenCalled();
 	});
 
 	it("invalidates on settled without returning pending promises", () => {
@@ -721,6 +809,29 @@ describe("pinChat optimistic update", () => {
 			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId))
 				?.pin_order,
 		).toBe(5);
+	});
+
+	it("rolls back the optimistic pin order on error", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-new";
+		seedInfiniteChats(queryClient, [
+			makeChat("chat-pinned-1", { pin_order: 1 }),
+			makeChat(chatId),
+		]);
+
+		const mutation = pinChat(queryClient);
+		const context = await mutation.onMutate(chatId);
+		expect(
+			readInfiniteChats(queryClient)?.find((chat) => chat.id === chatId)
+				?.pin_order,
+		).toBe(2);
+
+		mutation.onError(new Error("server error"), chatId, context);
+
+		expect(
+			readInfiniteChats(queryClient)?.find((chat) => chat.id === chatId)
+				?.pin_order,
+		).toBe(0);
 	});
 });
 
@@ -777,15 +888,13 @@ describe("unpinChat optimistic update", () => {
 		// Roll back.
 		mutation.onError(new Error("server error"), chatId, context);
 
-		// The chats list is rolled back via invalidation.
-		expect(invalidateSpy).toHaveBeenCalledWith(
-			expect.objectContaining({ queryKey: chatKeys.lists() }),
-		);
-		// The individual chat cache is restored directly.
+		// Both layers are restored by the inverse patch, with no refetch.
+		expect(readInfiniteChats(queryClient)?.[0].pin_order).toBe(3);
 		expect(
 			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId))
 				?.pin_order,
 		).toBe(3);
+		expect(invalidateSpy).not.toHaveBeenCalled();
 	});
 
 	it("invalidates queries on settled", async () => {
@@ -799,43 +908,392 @@ describe("unpinChat optimistic update", () => {
 		expect(invalidateSpy).toHaveBeenCalledWith(
 			expect.objectContaining({ queryKey: chatKeys.lists() }),
 		);
-		expect(invalidateSpy).toHaveBeenCalledWith({
-			queryKey: chatKeys.detail(chatId),
-			exact: true,
-		});
+		// Unpinning renumbers the remaining pinned chats, so every loaded
+		// chat detail is reconciled, not just this mutation's target.
+		expect(invalidateSpy).toHaveBeenCalledWith(
+			expect.objectContaining({ queryKey: chatKeys.details() }),
+		);
 	});
 });
 
 describe("reorderPinnedChat", () => {
+	const pinnedChats = [
+		makeChat("chat-1", { pin_order: 1 }),
+		makeChat("chat-2", { pin_order: 2 }),
+		makeChat("chat-3", { pin_order: 3 }),
+	];
+
 	it("updates a single chat via updateChat and invalidates list and detail queries", async () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";
+		seedInfiniteChats(queryClient, pinnedChats);
 		vi.mocked(API.experimental.updateChat).mockResolvedValue(undefined);
 		const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 		const cancelSpy = vi.spyOn(queryClient, "cancelQueries");
 
+		const variables = { chatId, pinOrder: 2, visibleChats: pinnedChats };
 		const mutation = reorderPinnedChat(queryClient);
-		await mutation.onMutate?.({ chatId, pinOrder: 2 });
-		await mutation.mutationFn({ chatId, pinOrder: 2 });
-		await mutation.onSettled?.(undefined, undefined, { chatId, pinOrder: 2 });
+		await mutation.onMutate(variables);
+		await mutation.mutationFn(variables);
+		const settledResult = mutation.onSettled(undefined, undefined, variables);
 
+		expect(settledResult).toBeUndefined();
 		expect(cancelSpy).toHaveBeenCalledWith(
 			expect.objectContaining({ queryKey: chatKeys.lists() }),
 		);
-		expect(cancelSpy).toHaveBeenCalledWith({
-			queryKey: chatKeys.detail(chatId),
-			exact: true,
-		});
+		expect(cancelSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				queryKey: chatKeys.detail(chatId),
+				exact: true,
+			}),
+		);
 		expect(API.experimental.updateChat).toHaveBeenCalledWith(chatId, {
 			pin_order: 2,
 		});
 		expect(invalidateSpy).toHaveBeenCalledWith(
 			expect.objectContaining({ queryKey: chatKeys.lists() }),
 		);
-		expect(invalidateSpy).toHaveBeenCalledWith({
-			queryKey: chatKeys.detail(chatId),
-			exact: true,
+		expect(invalidateSpy).toHaveBeenCalledWith(
+			expect.objectContaining({ queryKey: chatKeys.details() }),
+		);
+	});
+
+	it("renumbers from the visible order, not the first cached list variant", async () => {
+		const queryClient = createTestQueryClient();
+		// An archived variant iterates first and holds no pinned chats.
+		seedInfiniteChats(queryClient, [makeChat("chat-archived")], {
+			archived: true,
 		});
+		seedInfiniteChats(queryClient, pinnedChats);
+
+		const mutation = reorderPinnedChat(queryClient);
+		await mutation.onMutate({
+			chatId: "chat-3",
+			pinOrder: 1,
+			visibleChats: pinnedChats,
+		});
+
+		expect(
+			readInfiniteChats(queryClient)?.map((chat) => [chat.id, chat.pin_order]),
+		).toEqual([
+			["chat-1", 2],
+			["chat-2", 3],
+			["chat-3", 1],
+		]);
+	});
+
+	it("restores prior pin orders on error, guarded on the optimistic value", async () => {
+		const queryClient = createTestQueryClient();
+		seedInfiniteChats(queryClient, pinnedChats);
+		const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+		const variables = {
+			chatId: "chat-3",
+			pinOrder: 1,
+			visibleChats: pinnedChats,
+		};
+		const mutation = reorderPinnedChat(queryClient);
+		const context = await mutation.onMutate(variables);
+
+		// chat-2 is moved again while the PATCH is in flight, so its
+		// pin_order no longer matches what this mutation assigned.
+		updateInfiniteChatsCache(queryClient, (chats) =>
+			chats.map((chat) =>
+				chat.id === "chat-2" ? { ...chat, pin_order: 9 } : chat,
+			),
+		);
+
+		mutation.onError(new Error("server error"), variables, context);
+
+		expect(
+			readInfiniteChats(queryClient)?.map((chat) => [chat.id, chat.pin_order]),
+		).toEqual([
+			["chat-1", 1],
+			["chat-2", 9],
+			["chat-3", 3],
+		]);
+		expect(invalidateSpy).not.toHaveBeenCalled();
+	});
+
+	it("is a no-op when the dragged chat is not pinned", async () => {
+		const queryClient = createTestQueryClient();
+		seedInfiniteChats(queryClient, pinnedChats);
+
+		const mutation = reorderPinnedChat(queryClient);
+		const context = await mutation.onMutate({
+			chatId: "chat-unpinned",
+			pinOrder: 1,
+			visibleChats: pinnedChats,
+		});
+
+		expect(context).toBeUndefined();
+		expect(
+			readInfiniteChats(queryClient)?.map((chat) => chat.pin_order),
+		).toEqual([1, 2, 3]);
+	});
+
+	it("serializes overlapping drags and invalidates once, after the last one", async () => {
+		const queryClient = createTestQueryClient();
+		seedInfiniteChats(queryClient, pinnedChats);
+		const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+		const deferred: Array<() => void> = [];
+		vi.mocked(API.experimental.updateChat).mockImplementation(
+			() =>
+				new Promise<void>((resolve) => {
+					deferred.push(resolve);
+				}),
+		);
+
+		const base = reorderPinnedChat(queryClient);
+		const first = new MutationObserver(queryClient, base);
+		const second = new MutationObserver(queryClient, base);
+		const firstResult = first.mutate({
+			chatId: "chat-3",
+			pinOrder: 1,
+			visibleChats: pinnedChats,
+		});
+		await vi.waitFor(() => expect(deferred).toHaveLength(1));
+		expect(
+			readInfiniteChats(queryClient)?.map((chat) => [chat.id, chat.pin_order]),
+		).toEqual([
+			["chat-1", 2],
+			["chat-2", 3],
+			["chat-3", 1],
+		]);
+
+		const secondResult = second.mutate({
+			chatId: "chat-1",
+			pinOrder: 1,
+			// The sidebar renders pinned chats in ascending pin_order, so
+			// the second drag sees the first drag's optimistic ordering.
+			visibleChats: (readInfiniteChats(queryClient) ?? []).toSorted(
+				(a, b) => a.pin_order - b.pin_order,
+			),
+		});
+
+		// The second optimistic write lands immediately: onMutate runs
+		// before the scope gate pauses mutationFn, so the drag is visible
+		// while the first request is still in flight.
+		await vi.waitFor(() =>
+			expect(
+				readInfiniteChats(queryClient)?.find((chat) => chat.id === "chat-1")
+					?.pin_order,
+			).toBe(1),
+		);
+		expect(
+			readInfiniteChats(queryClient)?.map((chat) => [chat.id, chat.pin_order]),
+		).toEqual([
+			["chat-1", 1],
+			["chat-2", 3],
+			["chat-3", 2],
+		]);
+		expect(deferred, "the second PATCH waits on the shared scope").toHaveLength(
+			1,
+		);
+
+		deferred[0]();
+		await firstResult;
+		expect(
+			invalidateSpy,
+			"an early settle refetch would overwrite the pending optimistic write",
+		).not.toHaveBeenCalled();
+
+		await vi.waitFor(() => expect(deferred).toHaveLength(2));
+		deferred[1]();
+		await secondResult;
+
+		expect(invalidateSpy).toHaveBeenCalledWith(
+			expect.objectContaining({ queryKey: chatKeys.lists() }),
+		);
+		expect(invalidateSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("skips the rollback while a later reorder is still pending", async () => {
+		const queryClient = createTestQueryClient();
+		seedInfiniteChats(queryClient, pinnedChats);
+
+		const deferred: Array<{
+			resolve: () => void;
+			reject: (error: Error) => void;
+		}> = [];
+		vi.mocked(API.experimental.updateChat).mockImplementation(
+			() =>
+				new Promise<void>((resolve, reject) => {
+					deferred.push({ resolve, reject });
+				}),
+		);
+
+		const base = reorderPinnedChat(queryClient);
+		const first = new MutationObserver(queryClient, base);
+		const second = new MutationObserver(queryClient, base);
+		const firstResult = first
+			.mutate({ chatId: "chat-3", pinOrder: 1, visibleChats: pinnedChats })
+			.catch(() => {});
+		await vi.waitFor(() => expect(deferred).toHaveLength(1));
+
+		const secondResult = second.mutate({
+			chatId: "chat-1",
+			pinOrder: 1,
+			visibleChats: (readInfiniteChats(queryClient) ?? []).toSorted(
+				(a, b) => a.pin_order - b.pin_order,
+			),
+		});
+		await vi.waitFor(() =>
+			expect(
+				readInfiniteChats(queryClient)?.find((chat) => chat.id === "chat-1")
+					?.pin_order,
+			).toBe(1),
+		);
+
+		deferred[0].reject(new Error("reorder failed"));
+		await firstResult;
+
+		// The first drag's inverse patch would restore chat-2 to 2, which
+		// the second drag has already given to chat-3.
+		expect(
+			readInfiniteChats(queryClient)?.map((chat) => [chat.id, chat.pin_order]),
+			"a superseded rollback would corrupt the pending drag's order",
+		).toEqual([
+			["chat-1", 1],
+			["chat-2", 3],
+			["chat-3", 2],
+		]);
+
+		await vi.waitFor(() => expect(deferred).toHaveLength(2));
+		deferred[1].resolve();
+		await secondResult;
+	});
+
+	it("rolls back to the previous drop's order when the sidebar prop is stale", async () => {
+		const queryClient = createTestQueryClient();
+		seedInfiniteChats(queryClient, pinnedChats);
+		vi.mocked(API.experimental.updateChat)
+			.mockResolvedValueOnce(undefined)
+			.mockRejectedValueOnce(new Error("reorder failed"));
+
+		const base = reorderPinnedChat(queryClient);
+		const readPinOrders = () =>
+			readInfiniteChats(queryClient)?.map((chat) => [chat.id, chat.pin_order]);
+
+		// First drop, against the chats the sidebar was rendered with.
+		const first = resolvePinnedChatDrop({
+			pinnedChats,
+			hasLocalOrder: false,
+			activeId: "chat-3",
+			overId: "chat-1",
+		});
+		if (!first) {
+			throw new Error("expected the first drop to resolve");
+		}
+		await new MutationObserver(queryClient, base).mutate({
+			chatId: first.chatId,
+			pinOrder: first.pinOrder,
+			visibleChats: first.mutationChats,
+		});
+		expect(first.localOrder).toEqual(["chat-3", "chat-1", "chat-2"]);
+		expect(readPinOrders()).toEqual([
+			["chat-1", 2],
+			["chat-2", 3],
+			["chat-3", 1],
+		]);
+
+		// Second drop before the parent rerenders: the panel renders its
+		// local order over chats whose pin_order fields still describe the
+		// pre-first-drop world.
+		const rendered = [pinnedChats[2], pinnedChats[0], pinnedChats[1]];
+		const second = resolvePinnedChatDrop({
+			pinnedChats: rendered,
+			hasLocalOrder: true,
+			activeId: "chat-2",
+			overId: "chat-3",
+		});
+		if (!second) {
+			throw new Error("expected the second drop to resolve");
+		}
+		await new MutationObserver(queryClient, base)
+			.mutate({
+				chatId: second.chatId,
+				pinOrder: second.pinOrder,
+				visibleChats: second.mutationChats,
+			})
+			.catch(() => {});
+
+		// A rollback built from the stale fields would restore the order
+		// from before the first drop, undoing a request the server
+		// accepted.
+		expect(readPinOrders()).toEqual([
+			["chat-1", 2],
+			["chat-2", 3],
+			["chat-3", 1],
+		]);
+	});
+});
+
+describe("pin mutation settlement", () => {
+	it("invalidates every loaded chat detail once the last pin mutation settles", async () => {
+		const queryClient = createTestQueryClient();
+		seedInfiniteChats(queryClient, [
+			makeChat("chat-1", { pin_order: 1 }),
+			makeChat("chat-2", { pin_order: 2 }),
+		]);
+		queryClient.setQueryData(
+			chatKeys.detail("chat-1"),
+			makeChat("chat-1", { pin_order: 1 }),
+		);
+		queryClient.setQueryData(
+			chatKeys.detail("chat-2"),
+			makeChat("chat-2", { pin_order: 2 }),
+		);
+		queryClient.setQueryData(chatKeys.messages("chat-1"), {
+			pages: [],
+			pageParams: [],
+		});
+
+		const deferred: Array<() => void> = [];
+		vi.mocked(API.experimental.updateChat).mockImplementation(
+			() =>
+				new Promise<void>((resolve) => {
+					deferred.push(resolve);
+				}),
+		);
+
+		const pinning = new MutationObserver(
+			queryClient,
+			pinChat(queryClient),
+		).mutate("chat-1");
+		const unpinning = new MutationObserver(
+			queryClient,
+			unpinChat(queryClient),
+		).mutate("chat-2");
+		await vi.waitFor(() => expect(deferred).toHaveLength(2));
+
+		deferred[0]();
+		await pinning;
+		expect(
+			queryClient.getQueryState(chatKeys.detail("chat-2"))?.isInvalidated,
+			"an early settle refetch would overwrite the pending optimistic write",
+		).toBe(false);
+
+		deferred[1]();
+		await unpinning;
+
+		// The server renumbers the whole pinned sequence, so the last
+		// settle has to reconcile every loaded chat detail, not just the
+		// chat it targeted.
+		expect(
+			queryClient.getQueryState(chatKeys.detail("chat-1"))?.isInvalidated,
+		).toBe(true);
+		expect(
+			queryClient.getQueryState(chatKeys.detail("chat-2"))?.isInvalidated,
+		).toBe(true);
+		expect(queryClient.getQueryState(chatKeys.list())?.isInvalidated).toBe(
+			true,
+		);
+		expect(
+			queryClient.getQueryState(chatKeys.messages("chat-1"))?.isInvalidated,
+			"nested detail caches hold nothing a pin_order change invalidates",
+		).toBe(false);
 	});
 });
 
@@ -2186,6 +2644,192 @@ describe("mutation onMutate cancels pagination fetches", () => {
 		// overwrite the cache with stale oldPages.
 		const chat = readInfiniteChats(queryClient)?.find((c) => c.id === chatId);
 		expect(chat?.archived).toBe(true);
+	});
+});
+
+describe("patchChatEverywhere", () => {
+	it("patches the detail cache, every list variant, and embedded children", () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		queryClient.setQueryData(chatKeys.detail(chatId), makeChat(chatId));
+		seedInfiniteChats(queryClient, [makeChat(chatId), makeChat("chat-2")]);
+		seedInfiniteChats(queryClient, [makeChat(chatId, { archived: true })], {
+			archived: true,
+		});
+		seedInfiniteChats(
+			queryClient,
+			[makeChat("parent-1", { children: [makeChat(chatId)] })],
+			{ chatStatus: "unread" },
+		);
+
+		patchChatEverywhere(queryClient, chatId, (chat) => ({
+			...chat,
+			title: "Patched",
+		}));
+
+		expect(
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId))?.title,
+		).toBe("Patched");
+		expect(
+			readInfiniteChats(queryClient)?.find((chat) => chat.id === chatId)?.title,
+		).toBe("Patched");
+		expect(readInfiniteChats(queryClient, { archived: true })?.[0].title).toBe(
+			"Patched",
+		);
+		expect(
+			readInfiniteChats(queryClient, { chatStatus: "unread" })?.[0]
+				.children?.[0].title,
+		).toBe("Patched");
+		expect(
+			readInfiniteChats(queryClient)?.find((chat) => chat.id === "chat-2")
+				?.title,
+		).toBe("Chat chat-2");
+	});
+
+	it("keeps the page reference when the patch changes nothing", () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		seedInfiniteChats(queryClient, [makeChat(chatId)]);
+		const before = queryClient.getQueryData(infiniteChatsTestKey);
+
+		patchChatEverywhere(queryClient, chatId, (chat) => chat);
+
+		expect(queryClient.getQueryData(infiniteChatsTestKey)).toBe(before);
+	});
+
+	it("does not create a detail cache entry for an unopened chat", () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		seedInfiniteChats(queryClient, [makeChat(chatId)]);
+
+		patchChatEverywhere(queryClient, chatId, (chat) => ({
+			...chat,
+			title: "Patched",
+		}));
+
+		expect(queryClient.getQueryData(chatKeys.detail(chatId))).toBeUndefined();
+	});
+});
+
+describe("findChatInCaches", () => {
+	it("prefers the detail cache", () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		queryClient.setQueryData(
+			chatKeys.detail(chatId),
+			makeChat(chatId, { title: "Detail" }),
+		);
+		seedInfiniteChats(queryClient, [makeChat(chatId, { title: "List" })]);
+
+		expect(findChatInCaches(queryClient, chatId)?.title).toBe("Detail");
+	});
+
+	it("falls back to any cached list variant", () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		seedInfiniteChats(queryClient, [makeChat("chat-2")]);
+		seedInfiniteChats(queryClient, [makeChat(chatId, { title: "Archived" })], {
+			archived: true,
+		});
+
+		expect(findChatInCaches(queryClient, chatId)?.title).toBe("Archived");
+	});
+
+	it("falls back to a parent's embedded children", () => {
+		const queryClient = createTestQueryClient();
+		const child = makeChat("child-1", { title: "Child" });
+		seedInfiniteChats(queryClient, [
+			makeChat("parent-1", { children: [child] }),
+		]);
+
+		expect(findChatInCaches(queryClient, "child-1")?.title).toBe("Child");
+	});
+
+	it("returns undefined when no cache holds the chat", () => {
+		const queryClient = createTestQueryClient();
+		seedInfiniteChats(queryClient, [makeChat("chat-2")]);
+
+		expect(findChatInCaches(queryClient, "chat-1")).toBeUndefined();
+	});
+});
+
+describe("cancelChatMutationRefetches", () => {
+	it("cancels a loaded list refetch and the chat detail fetch", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		seedInfiniteChats(queryClient, [makeChat(chatId, { title: "cached" })]);
+		queryClient.setQueryData(
+			chatKeys.detail(chatId),
+			makeChat(chatId, { title: "cached" }),
+		);
+
+		const listFetch = queryClient.prefetchQuery({
+			queryKey: infiniteChatsTestKey,
+			queryFn: () =>
+				new Promise<InfiniteData>((resolve) => {
+					setTimeout(
+						() =>
+							resolve({
+								pages: [[makeChat(chatId, { title: "server" })]],
+								pageParams: [0],
+							}),
+						50,
+					);
+				}),
+		});
+		const detailFetch = queryClient.prefetchQuery({
+			queryKey: chatKeys.detail(chatId),
+			queryFn: () =>
+				new Promise<TypesGen.Chat>((resolve) => {
+					setTimeout(() => resolve(makeChat(chatId, { title: "server" })), 50);
+				}),
+		});
+
+		await cancelChatMutationRefetches(queryClient, chatId);
+		await Promise.all([listFetch, detailFetch]);
+
+		expect(readInfiniteChats(queryClient)?.[0].title).toBe("cached");
+		expect(
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId))?.title,
+		).toBe("cached");
+	});
+
+	it("leaves a never-loaded query alone so it cannot wedge at pending", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+
+		const listFetch = queryClient.prefetchQuery({
+			queryKey: infiniteChatsTestKey,
+			queryFn: () =>
+				new Promise<InfiniteData>((resolve) => {
+					setTimeout(
+						() =>
+							resolve({
+								pages: [[makeChat(chatId, { title: "first-load" })]],
+								pageParams: [0],
+							}),
+						20,
+					);
+				}),
+		});
+		const detailFetch = queryClient.prefetchQuery({
+			queryKey: chatKeys.detail(chatId),
+			queryFn: () =>
+				new Promise<TypesGen.Chat>((resolve) => {
+					setTimeout(
+						() => resolve(makeChat(chatId, { title: "first-load" })),
+						20,
+					);
+				}),
+		});
+
+		await cancelChatMutationRefetches(queryClient, chatId);
+		await Promise.all([listFetch, detailFetch]);
+
+		expect(readInfiniteChats(queryClient)?.[0].title).toBe("first-load");
+		expect(
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId))?.title,
+		).toBe("first-load");
 	});
 });
 

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -332,6 +332,126 @@ const isInfiniteChatsCacheData = (
 	return Array.isArray(maybeData.pages) && Array.isArray(maybeData.pageParams);
 };
 
+/**
+ * Applies a patch to one chat in every cache layer that can hold it: the
+ * detail cache, every cached list variant, and any parent's embedded
+ * `children`. Writing a single layer leaves the others showing the old
+ * value until a refetch.
+ *
+ * `patch` must return the chat it was given when it changes nothing, so
+ * untouched caches keep their reference and skip a rerender.
+ */
+export const patchChatEverywhere = (
+	queryClient: QueryClient,
+	chatId: string,
+	patch: (chat: TypesGen.Chat) => TypesGen.Chat,
+) => {
+	queryClient.setQueryData<TypesGen.Chat | undefined>(
+		chatKeys.detail(chatId),
+		(chat) => (chat ? patch(chat) : chat),
+	);
+	updateInfiniteChatsCache(queryClient, (chats) => {
+		let changed = false;
+		const next = chats.map((chat) => {
+			if (chat.id !== chatId) {
+				return chat;
+			}
+			const patched = patch(chat);
+			if (patched !== chat) {
+				changed = true;
+			}
+			return patched;
+		});
+		return changed ? next : chats;
+	});
+	updateChildInParentCache(queryClient, patch, chatId);
+};
+
+/** Matches only queries that already hold data. */
+const hasLoadedData = (query: { state: { data: unknown } }): boolean =>
+	query.state.data !== undefined;
+
+/**
+ * Cancels the in-flight sidebar list and chat detail fetches that a
+ * mutation's optimistic write would otherwise race, in parallel.
+ *
+ * Unlike cancelChatListRefetches this deliberately cancels pagination
+ * fetches too: fetchNextPage captured its page snapshot before the
+ * mutation, so letting it land would overwrite the optimistic update.
+ * Queries that have never loaded are left alone, because reverting a
+ * first-ever fetch wedges the query at pending/idle with no data and no
+ * automatic recovery.
+ */
+export const cancelChatMutationRefetches = (
+	queryClient: QueryClient,
+	chatId: string,
+) =>
+	Promise.all([
+		queryClient.cancelQueries({
+			queryKey: chatKeys.lists(),
+			predicate: hasLoadedData,
+		}),
+		queryClient.cancelQueries({
+			queryKey: chatKeys.detail(chatId),
+			exact: true,
+			predicate: hasLoadedData,
+		}),
+	]);
+
+/**
+ * Reads a chat from whichever cache layer holds it: the detail cache
+ * first, then every cached list variant, then parents' embedded
+ * children. Sidebar mutations routinely run against a chat the user
+ * never opened, so the detail cache alone cannot supply the prior field
+ * value an inverse-patch rollback needs.
+ */
+export const findChatInCaches = (
+	queryClient: QueryClient,
+	chatId: string,
+): TypesGen.Chat | undefined => {
+	const cachedDetail = queryClient.getQueryData<TypesGen.Chat>(
+		chatKeys.detail(chatId),
+	);
+	if (cachedDetail) {
+		return cachedDetail;
+	}
+
+	const queries = queryClient.getQueriesData<InfiniteChatsCacheData>({
+		queryKey: chatKeys.lists(),
+	});
+
+	for (const [, data] of queries) {
+		if (!isInfiniteChatsCacheData(data)) {
+			continue;
+		}
+		for (const page of data.pages) {
+			for (const chat of page) {
+				if (chat.id === chatId) {
+					return chat;
+				}
+			}
+		}
+	}
+
+	// Children are searched last: a top-level row is the authoritative
+	// summary, an embedded child snapshot only a fallback.
+	for (const [, data] of queries) {
+		if (!isInfiniteChatsCacheData(data)) {
+			continue;
+		}
+		for (const page of data.pages) {
+			for (const chat of page) {
+				const child = chat.children?.find((c) => c.id === chatId);
+				if (child) {
+					return child;
+				}
+			}
+		}
+	}
+
+	return undefined;
+};
+
 const patchChatArchiveState = (
 	chat: TypesGen.Chat,
 	archived: boolean,
@@ -1017,56 +1137,48 @@ export const chatPromptsQuery = (chatId: string) => ({
 	enabled: chatId !== "",
 });
 
+type ChatArchiveContext = {
+	previousArchived: boolean;
+	previousPinOrder: number;
+	found: boolean;
+};
+
 export const archiveChat = (queryClient: QueryClient) => ({
 	mutationFn: (chatId: string) =>
 		API.experimental.updateChat(chatId, { archived: true }),
-	onMutate: async (chatId: string) => {
-		await queryClient.cancelQueries({
-			queryKey: chatKeys.lists(),
-		});
-		await queryClient.cancelQueries({
-			queryKey: chatKeys.detail(chatId),
-			exact: true,
-		});
-		const previousChat = queryClient.getQueryData<TypesGen.Chat>(
-			chatKeys.detail(chatId),
+	onMutate: async (chatId: string): Promise<ChatArchiveContext> => {
+		await cancelChatMutationRefetches(queryClient, chatId);
+		// The sidebar can archive a chat that was never opened, so the
+		// prior state has to come from whichever cache holds it.
+		const previousChat = findChatInCaches(queryClient, chatId);
+		// Reuse patchChatArchiveState so the optimistic state matches the
+		// confirmed onSuccess state, including the pin_order reset the
+		// server applies when archiving.
+		patchChatEverywhere(queryClient, chatId, (chat) =>
+			patchChatArchiveState(chat, true),
 		);
-		// Flip the archived flag in every cached list; strip the
-		// chat from any parent's embedded children (individual
-		// child archive). Reuse patchChatArchiveState so the
-		// optimistic snapshot matches the confirmed onSuccess state,
-		// including the pin_order reset for an archived chat.
-		updateInfiniteChatsCache(queryClient, (chats) =>
-			chats.map((chat) =>
-				chat.id === chatId ? patchChatArchiveState(chat, true) : chat,
-			),
-		);
-		removeChildFromParentInCache(queryClient, chatId);
-		if (previousChat) {
-			queryClient.setQueryData<TypesGen.Chat>(
-				chatKeys.detail(chatId),
-				patchChatArchiveState(previousChat, true),
-			);
-		}
-		return { previousChat };
+		return {
+			previousArchived: previousChat?.archived ?? false,
+			previousPinOrder: previousChat?.pin_order ?? 0,
+			found: previousChat !== undefined,
+		};
 	},
 	onError: (
 		_error: unknown,
 		chatId: string,
-		context:
-			| {
-					previousChat?: TypesGen.Chat;
-			  }
-			| undefined,
+		context: ChatArchiveContext | undefined,
 	) => {
-		// Rollback: invalidate to re-fetch the correct state.
-		void invalidateChatListQueries(queryClient);
-		if (context?.previousChat) {
-			queryClient.setQueryData<TypesGen.Chat>(
-				chatKeys.detail(chatId),
-				context.previousChat,
-			);
+		if (!context?.found) {
+			return;
 		}
+		const { previousArchived, previousPinOrder } = context;
+		// Inverse patch, guarded on the optimistic values still being in
+		// place, so a WebSocket write that landed mid-flight is not undone.
+		patchChatEverywhere(queryClient, chatId, (chat) =>
+			chat.archived && chat.pin_order === 0
+				? { ...chat, archived: previousArchived, pin_order: previousPinOrder }
+				: chat,
+		);
 	},
 	onSuccess: (_data: unknown, chatId: string) => {
 		applyChatArchiveStateToCaches(queryClient, chatId, true);
@@ -1086,49 +1198,32 @@ export const archiveChat = (queryClient: QueryClient) => ({
 export const unarchiveChat = (queryClient: QueryClient) => ({
 	mutationFn: (chatId: string) =>
 		API.experimental.updateChat(chatId, { archived: false }),
-	onMutate: async (chatId: string) => {
-		await queryClient.cancelQueries({
-			queryKey: chatKeys.lists(),
-		});
-		await queryClient.cancelQueries({
-			queryKey: chatKeys.detail(chatId),
-			exact: true,
-		});
-		const previousChat = queryClient.getQueryData<TypesGen.Chat>(
-			chatKeys.detail(chatId),
+	onMutate: async (chatId: string): Promise<ChatArchiveContext> => {
+		await cancelChatMutationRefetches(queryClient, chatId);
+		const previousChat = findChatInCaches(queryClient, chatId);
+		patchChatEverywhere(queryClient, chatId, (chat) =>
+			patchChatArchiveState(chat, false),
 		);
-		// Reuse patchChatArchiveState so the optimistic snapshot
-		// matches the confirmed onSuccess state.
-		updateInfiniteChatsCache(queryClient, (chats) =>
-			chats.map((chat) =>
-				chat.id === chatId ? patchChatArchiveState(chat, false) : chat,
-			),
-		);
-		if (previousChat) {
-			queryClient.setQueryData<TypesGen.Chat>(
-				chatKeys.detail(chatId),
-				patchChatArchiveState(previousChat, false),
-			);
-		}
-		return { previousChat };
+		return {
+			previousArchived: previousChat?.archived ?? true,
+			// Unarchiving leaves pin_order alone, so there is nothing to
+			// restore for it.
+			previousPinOrder: previousChat?.pin_order ?? 0,
+			found: previousChat !== undefined,
+		};
 	},
 	onError: (
 		_error: unknown,
 		chatId: string,
-		context:
-			| {
-					previousChat?: TypesGen.Chat;
-			  }
-			| undefined,
+		context: ChatArchiveContext | undefined,
 	) => {
-		// Rollback: invalidate to re-fetch the correct state.
-		void invalidateChatListQueries(queryClient);
-		if (context?.previousChat) {
-			queryClient.setQueryData<TypesGen.Chat>(
-				chatKeys.detail(chatId),
-				context.previousChat,
-			);
+		if (!context?.found) {
+			return;
 		}
+		const { previousArchived } = context;
+		patchChatEverywhere(queryClient, chatId, (chat) =>
+			chat.archived ? chat : { ...chat, archived: previousArchived },
+		);
 	},
 	onSuccess: (_data: unknown, chatId: string) => {
 		applyChatArchiveStateToCaches(queryClient, chatId, false);
@@ -1145,65 +1240,64 @@ export const unarchiveChat = (queryClient: QueryClient) => ({
 	},
 });
 
+type UpdateChatPlanModeContext = {
+	previousPlanMode: TypesGen.ChatPlanMode | undefined;
+	found: boolean;
+};
+
 export const updateChatPlanMode = (queryClient: QueryClient) => ({
 	mutationFn: ({ chatId, planMode }: UpdateChatPlanModeVariables) =>
 		API.experimental.updateChat(chatId, {
 			plan_mode: toChatPlanModePayload(planMode),
 		}),
-	onMutate: async ({ chatId, planMode }: UpdateChatPlanModeVariables) => {
-		await queryClient.cancelQueries({
-			queryKey: chatKeys.lists(),
-		});
-		await queryClient.cancelQueries({
-			queryKey: chatKeys.detail(chatId),
-			exact: true,
-		});
-		const previousChat = queryClient.getQueryData<TypesGen.Chat>(
-			chatKeys.detail(chatId),
+	onMutate: async ({
+		chatId,
+		planMode,
+	}: UpdateChatPlanModeVariables): Promise<UpdateChatPlanModeContext> => {
+		await cancelChatMutationRefetches(queryClient, chatId);
+		const previousChat = findChatInCaches(queryClient, chatId);
+		patchChatEverywhere(queryClient, chatId, (chat) =>
+			chat.plan_mode === planMode ? chat : { ...chat, plan_mode: planMode },
 		);
-		updateInfiniteChatsCache(queryClient, (chats) =>
-			chats.map((chat) =>
-				chat.id === chatId ? { ...chat, plan_mode: planMode } : chat,
-			),
-		);
-		if (previousChat) {
-			queryClient.setQueryData<TypesGen.Chat>(chatKeys.detail(chatId), {
-				...previousChat,
-				plan_mode: planMode,
-			});
-		}
-		return { previousChat };
+		return {
+			// undefined is a real plan mode (cleared), so the `found` flag
+			// rather than the value decides whether a rollback can run.
+			previousPlanMode: previousChat?.plan_mode,
+			found: previousChat !== undefined,
+		};
 	},
 	onError: (
 		_error: unknown,
-		{ chatId }: UpdateChatPlanModeVariables,
-		context:
-			| {
-					previousChat?: TypesGen.Chat;
-			  }
-			| undefined,
+		{ chatId, planMode }: UpdateChatPlanModeVariables,
+		context: UpdateChatPlanModeContext | undefined,
 	) => {
-		void invalidateChatListQueries(queryClient);
-		const previousChat = context?.previousChat;
-		if (!previousChat) {
+		if (!context?.found) {
 			return;
 		}
-		updateInfiniteChatsCache(queryClient, (chats) =>
-			chats.map((chat) =>
-				chat.id === chatId
-					? {
-							...chat,
-							plan_mode: previousChat.plan_mode,
-						}
-					: chat,
-			),
-		);
-		queryClient.setQueryData<TypesGen.Chat>(
-			chatKeys.detail(chatId),
-			previousChat,
+		const { previousPlanMode } = context;
+		patchChatEverywhere(queryClient, chatId, (chat) =>
+			chat.plan_mode === planMode
+				? { ...chat, plan_mode: previousPlanMode }
+				: chat,
 		);
 	},
+	onSettled: (
+		_data: unknown,
+		_error: unknown,
+		{ chatId }: UpdateChatPlanModeVariables,
+	) => {
+		void invalidateChatListQueries(queryClient);
+		void queryClient.invalidateQueries({
+			queryKey: chatKeys.detail(chatId),
+			exact: true,
+		});
+	},
 });
+
+type UpdateChatWorkspaceContext = {
+	previousWorkspaceId: string | undefined;
+	found: boolean;
+};
 
 export const updateChatWorkspace = (queryClient: QueryClient) => ({
 	mutationFn: ({ chatId, workspaceId }: UpdateChatWorkspaceVariables) =>
@@ -1213,233 +1307,301 @@ export const updateChatWorkspace = (queryClient: QueryClient) => ({
 				// The API uses the nil UUID to clear the workspace association.
 				"00000000-0000-0000-0000-000000000000",
 		}),
-	onMutate: async ({ chatId, workspaceId }: UpdateChatWorkspaceVariables) => {
-		await queryClient.cancelQueries({
-			queryKey: chatKeys.lists(),
-		});
-		await queryClient.cancelQueries({
-			queryKey: chatKeys.detail(chatId),
-			exact: true,
-		});
-		const previousChat = queryClient.getQueryData<TypesGen.Chat>(
-			chatKeys.detail(chatId),
+	onMutate: async ({
+		chatId,
+		workspaceId,
+	}: UpdateChatWorkspaceVariables): Promise<UpdateChatWorkspaceContext> => {
+		await cancelChatMutationRefetches(queryClient, chatId);
+		const previousChat = findChatInCaches(queryClient, chatId);
+		const optimisticWorkspaceId = workspaceId ?? undefined;
+		patchChatEverywhere(queryClient, chatId, (chat) =>
+			chat.workspace_id === optimisticWorkspaceId
+				? chat
+				: { ...chat, workspace_id: optimisticWorkspaceId },
 		);
-		updateInfiniteChatsCache(queryClient, (chats) =>
-			chats.map((chat) =>
-				chat.id === chatId
-					? { ...chat, workspace_id: workspaceId ?? undefined }
-					: chat,
-			),
-		);
-		if (previousChat) {
-			queryClient.setQueryData<TypesGen.Chat>(chatKeys.detail(chatId), {
-				...previousChat,
-				workspace_id: workspaceId ?? undefined,
-			});
-		}
-		return { previousChat };
+		return {
+			previousWorkspaceId: previousChat?.workspace_id,
+			found: previousChat !== undefined,
+		};
 	},
 	onError: (
 		_error: unknown,
-		{ chatId }: UpdateChatWorkspaceVariables,
-		context:
-			| {
-					previousChat?: TypesGen.Chat;
-			  }
-			| undefined,
+		{ chatId, workspaceId }: UpdateChatWorkspaceVariables,
+		context: UpdateChatWorkspaceContext | undefined,
 	) => {
-		void invalidateChatListQueries(queryClient);
-		const previousChat = context?.previousChat;
-		if (previousChat) {
-			updateInfiniteChatsCache(queryClient, (chats) =>
-				chats.map((chat) =>
-					chat.id === chatId
-						? {
-								...chat,
-								workspace_id: previousChat.workspace_id,
-							}
-						: chat,
-				),
-			);
-			queryClient.setQueryData<TypesGen.Chat>(
-				chatKeys.detail(chatId),
-				previousChat,
-			);
+		if (!context?.found) {
+			return;
 		}
+		const { previousWorkspaceId } = context;
+		const optimisticWorkspaceId = workspaceId ?? undefined;
+		patchChatEverywhere(queryClient, chatId, (chat) =>
+			chat.workspace_id === optimisticWorkspaceId
+				? { ...chat, workspace_id: previousWorkspaceId }
+				: chat,
+		);
 	},
-	onSettled: async (
+	onSettled: (
 		_data: unknown,
 		_error: unknown,
 		{ chatId }: UpdateChatWorkspaceVariables,
 	) => {
-		await invalidateChatListQueries(queryClient);
-		await queryClient.invalidateQueries({
+		void invalidateChatListQueries(queryClient);
+		void queryClient.invalidateQueries({
 			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
-		await queryClient.invalidateQueries({
+		void queryClient.invalidateQueries({
 			queryKey: chatKeys.byWorkspacePrefix(),
 		});
 	},
 });
 
+/**
+ * Shared mutation key for the pin, unpin, and reorder mutations. They
+ * all renumber the same pin_order sequence, so each one's settle
+ * invalidation has to know whether another is still in flight.
+ */
+const CHAT_PIN_MUTATION_KEY = [...chatKeys.all, "pin"] as const;
+
+/**
+ * How many pin-family mutations the client still counts as pending. A
+ * mutation is still counted while its own onError and onSettled handlers
+ * run, so one means "I am the only one left"; zero only happens when a
+ * handler is invoked outside a mutation.
+ */
+const pendingPinMutationCount = (queryClient: QueryClient): number =>
+	queryClient.isMutating({ mutationKey: CHAT_PIN_MUTATION_KEY });
+
+/**
+ * True when no other pin-family mutation is still pending. Anything
+ * higher than the settling mutation itself means a later optimistic
+ * write is outstanding and a refetch now would overwrite it.
+ */
+const isLastPinMutation = (queryClient: QueryClient): boolean =>
+	pendingPinMutationCount(queryClient) <= 1;
+
+/**
+ * True when another pin-family mutation is still pending, so this one's
+ * optimistic write is no longer the top layer in the cache.
+ */
+const isPinMutationSuperseded = (queryClient: QueryClient): boolean =>
+	pendingPinMutationCount(queryClient) > 1;
+
+type ChatPinOrderContext = {
+	previousPinOrder: number;
+	optimisticPinOrder: number;
+	found: boolean;
+};
+
+/**
+ * Terminal reconciliation for the pin family. Pinning, unpinning, and
+ * reordering all renumber neighbouring chats server side, so the target
+ * chat is never the only one whose pin_order goes stale: every loaded
+ * chat detail has to be reconciled, not just this mutation's target.
+ *
+ * The whole thing stays behind the last-settle gate because an earlier
+ * refetch would land on top of a later mutation's optimistic write.
+ */
+const settlePinMutation = (queryClient: QueryClient) => {
+	if (!isLastPinMutation(queryClient)) {
+		return;
+	}
+	void invalidateChatListQueries(queryClient);
+	void queryClient.invalidateQueries({
+		queryKey: chatKeys.details(),
+		// Base chat details only. The nested messages, prompts, and acl
+		// caches share the prefix but hold nothing a pin_order change can
+		// invalidate.
+		predicate: (query) =>
+			query.queryKey.length === chatKeys.details().length + 1 &&
+			hasLoadedData(query),
+	});
+};
+
 export const pinChat = (queryClient: QueryClient) => ({
+	mutationKey: CHAT_PIN_MUTATION_KEY,
 	mutationFn: (chatId: string) =>
 		API.experimental.updateChat(chatId, { pin_order: 1 }),
-	onMutate: async (chatId: string) => {
-		await queryClient.cancelQueries({
-			queryKey: chatKeys.lists(),
-		});
-		await queryClient.cancelQueries({
-			queryKey: chatKeys.detail(chatId),
-			exact: true,
-		});
-		const previousChat = queryClient.getQueryData<TypesGen.Chat>(
-			chatKeys.detail(chatId),
-		);
+	onMutate: async (chatId: string): Promise<ChatPinOrderContext> => {
+		await cancelChatMutationRefetches(queryClient, chatId);
+		const previousChat = findChatInCaches(queryClient, chatId);
 		const optimisticPinOrder = getNextOptimisticPinOrder(queryClient);
-		updateInfiniteChatsCache(queryClient, (chats) =>
-			chats.map((chat) =>
-				chat.id === chatId ? { ...chat, pin_order: optimisticPinOrder } : chat,
-			),
+		patchChatEverywhere(queryClient, chatId, (chat) =>
+			chat.pin_order === optimisticPinOrder
+				? chat
+				: { ...chat, pin_order: optimisticPinOrder },
 		);
-		if (previousChat) {
-			queryClient.setQueryData<TypesGen.Chat>(chatKeys.detail(chatId), {
-				...previousChat,
-				pin_order: optimisticPinOrder,
-			});
-		}
-		return { previousChat };
+		return {
+			previousPinOrder: previousChat?.pin_order ?? 0,
+			optimisticPinOrder,
+			found: previousChat !== undefined,
+		};
 	},
 	onError: (
 		_error: unknown,
 		chatId: string,
-		context:
-			| {
-					previousChat?: TypesGen.Chat;
-			  }
-			| undefined,
+		context: ChatPinOrderContext | undefined,
 	) => {
-		// Rollback: invalidate to re-fetch the correct state.
-		void invalidateChatListQueries(queryClient);
-		if (context?.previousChat) {
-			queryClient.setQueryData<TypesGen.Chat>(
-				chatKeys.detail(chatId),
-				context.previousChat,
-			);
+		if (!context?.found) {
+			return;
 		}
+		const { previousPinOrder, optimisticPinOrder } = context;
+		patchChatEverywhere(queryClient, chatId, (chat) =>
+			chat.pin_order === optimisticPinOrder
+				? { ...chat, pin_order: previousPinOrder }
+				: chat,
+		);
 	},
-	onSettled: async (_data: unknown, _error: unknown, chatId: string) => {
-		await invalidateChatListQueries(queryClient);
-		await queryClient.invalidateQueries({
-			queryKey: chatKeys.detail(chatId),
-			exact: true,
-		});
+	onSettled: (_data: unknown, _error: unknown, _chatId: string) => {
+		settlePinMutation(queryClient);
 	},
 });
 
 export const unpinChat = (queryClient: QueryClient) => ({
+	mutationKey: CHAT_PIN_MUTATION_KEY,
 	mutationFn: (chatId: string) =>
 		API.experimental.updateChat(chatId, { pin_order: 0 }),
-	onMutate: async (chatId: string) => {
-		await queryClient.cancelQueries({
-			queryKey: chatKeys.lists(),
-		});
-		await queryClient.cancelQueries({
-			queryKey: chatKeys.detail(chatId),
-			exact: true,
-		});
-		const previousChat = queryClient.getQueryData<TypesGen.Chat>(
-			chatKeys.detail(chatId),
+	onMutate: async (chatId: string): Promise<ChatPinOrderContext> => {
+		await cancelChatMutationRefetches(queryClient, chatId);
+		const previousChat = findChatInCaches(queryClient, chatId);
+		patchChatEverywhere(queryClient, chatId, (chat) =>
+			chat.pin_order === 0 ? chat : { ...chat, pin_order: 0 },
 		);
-		updateInfiniteChatsCache(queryClient, (chats) =>
-			chats.map((chat) =>
-				chat.id === chatId ? { ...chat, pin_order: 0 } : chat,
-			),
-		);
-		if (previousChat) {
-			queryClient.setQueryData<TypesGen.Chat>(chatKeys.detail(chatId), {
-				...previousChat,
-				pin_order: 0,
-			});
-		}
-		return { previousChat };
+		return {
+			previousPinOrder: previousChat?.pin_order ?? 0,
+			optimisticPinOrder: 0,
+			found: previousChat !== undefined,
+		};
 	},
 	onError: (
 		_error: unknown,
 		chatId: string,
-		context:
-			| {
-					previousChat?: TypesGen.Chat;
-			  }
-			| undefined,
+		context: ChatPinOrderContext | undefined,
 	) => {
-		// Rollback: invalidate to re-fetch the correct state.
-		void invalidateChatListQueries(queryClient);
-		if (context?.previousChat) {
-			queryClient.setQueryData<TypesGen.Chat>(
-				chatKeys.detail(chatId),
-				context.previousChat,
-			);
+		if (!context?.found) {
+			return;
 		}
+		const { previousPinOrder } = context;
+		patchChatEverywhere(queryClient, chatId, (chat) =>
+			chat.pin_order === 0 ? { ...chat, pin_order: previousPinOrder } : chat,
+		);
 	},
-	onSettled: async (_data: unknown, _error: unknown, chatId: string) => {
-		await invalidateChatListQueries(queryClient);
-		await queryClient.invalidateQueries({
-			queryKey: chatKeys.detail(chatId),
-			exact: true,
-		});
+	onSettled: (_data: unknown, _error: unknown, _chatId: string) => {
+		settlePinMutation(queryClient);
 	},
 });
 
+type ReorderPinnedChatVariables = {
+	chatId: string;
+	pinOrder: number;
+	/**
+	 * The pinned chats the sidebar is currently rendering, in render
+	 * order, including a drag the parent has not rerendered with yet.
+	 * The pinned set is derived from this rather than from the first
+	 * cached list variant, which can be an archived or filtered list
+	 * that holds no pinned chats at all.
+	 */
+	visibleChats: readonly TypesGen.Chat[];
+};
+
+type ReorderPinnedChatContext = {
+	previousOrders: Map<string, number>;
+	optimisticOrders: Map<string, number>;
+};
+
+const applyPinOrders = (
+	queryClient: QueryClient,
+	resolveOrder: (chat: TypesGen.Chat) => number | undefined,
+) => {
+	updateInfiniteChatsCache(queryClient, (chats) => {
+		let changed = false;
+		const next = chats.map((chat) => {
+			const order = resolveOrder(chat);
+			if (order === undefined || order === chat.pin_order) {
+				return chat;
+			}
+			changed = true;
+			return { ...chat, pin_order: order };
+		});
+		return changed ? next : chats;
+	});
+};
+
 export const reorderPinnedChat = (queryClient: QueryClient) => ({
-	mutationFn: ({ chatId, pinOrder }: { chatId: string; pinOrder: number }) =>
+	mutationKey: CHAT_PIN_MUTATION_KEY,
+	// Overlapping drags share one scope so their PATCHes run one at a
+	// time. onMutate still runs immediately for every drag, before the
+	// scope gate pauses mutationFn, so the sidebar never drops a drop.
+	scope: { id: "chat-reorder" },
+	mutationFn: ({ chatId, pinOrder }: ReorderPinnedChatVariables) =>
 		API.experimental.updateChat(chatId, { pin_order: pinOrder }),
 	onMutate: async ({
 		chatId,
 		pinOrder,
-	}: {
-		chatId: string;
-		pinOrder: number;
-	}) => {
-		await queryClient.cancelQueries({
-			queryKey: chatKeys.lists(),
-		});
-		await queryClient.cancelQueries({
-			queryKey: chatKeys.detail(chatId),
-			exact: true,
-		});
+		visibleChats,
+	}: ReorderPinnedChatVariables): Promise<
+		ReorderPinnedChatContext | undefined
+	> => {
+		await cancelChatMutationRefetches(queryClient, chatId);
 
-		// Optimistically reorder pinned chats in the cache so the
-		// sidebar reflects the new order immediately without waiting
-		// for the server round-trip.
-		const allChats = readInfiniteChatsCache(queryClient) ?? [];
-		const pinned = allChats
-			.filter((c) => c.pin_order > 0)
-			.sort((a, b) => a.pin_order - b.pin_order);
-		const oldIdx = pinned.findIndex((c) => c.id === chatId);
-		if (oldIdx !== -1) {
-			const moved = pinned.splice(oldIdx, 1)[0];
-			pinned.splice(pinOrder - 1, 0, moved);
-			const newOrders = new Map(pinned.map((c, i) => [c.id, i + 1]));
-			updateInfiniteChatsCache(queryClient, (chats) =>
-				chats.map((c) => {
-					const order = newOrders.get(c.id);
-					return order !== undefined ? { ...c, pin_order: order } : c;
-				}),
-			);
+		// Mirror the server's deterministic renumbering so the sidebar
+		// shows the new order immediately. The panel's local drag order
+		// is cleared by any chats reference change, and a running agent
+		// changes that reference constantly, so the cache has to already
+		// hold the new order when the handoff happens.
+		const pinned = visibleChats.filter((chat) => chat.pin_order > 0);
+		const oldIdx = pinned.findIndex((chat) => chat.id === chatId);
+		if (oldIdx === -1) {
+			return undefined;
 		}
+
+		const reordered = [...pinned];
+		const [moved] = reordered.splice(oldIdx, 1);
+		reordered.splice(pinOrder - 1, 0, moved);
+
+		const previousOrders = new Map(
+			pinned.map((chat) => [chat.id, chat.pin_order]),
+		);
+		const optimisticOrders = new Map(
+			reordered.map((chat, index) => [chat.id, index + 1]),
+		);
+		applyPinOrders(queryClient, (chat) => optimisticOrders.get(chat.id));
+		return { previousOrders, optimisticOrders };
 	},
-	onSettled: async (
+	onError: (
+		_error: unknown,
+		_variables: ReorderPinnedChatVariables,
+		context: ReorderPinnedChatContext | undefined,
+	) => {
+		if (!context) {
+			return;
+		}
+		if (isPinMutationSuperseded(queryClient)) {
+			// A later pin-family mutation has already written its own order
+			// on top of this one. Optimistic layers are last-writer-wins,
+			// and the value guard below cannot tell a pin_order this
+			// mutation assigned from the same value a later mutation
+			// assigned, so rolling back here would corrupt the newer order.
+			// Skipping is safe: the last pin-family mutation to settle
+			// refetches the list and every loaded chat detail, so the
+			// server's order always lands.
+			return;
+		}
+		const { previousOrders, optimisticOrders } = context;
+		// Restore each chat only where it still holds the pin_order this
+		// mutation assigned it, so a later reorder is left in place.
+		applyPinOrders(queryClient, (chat) =>
+			chat.pin_order === optimisticOrders.get(chat.id)
+				? previousOrders.get(chat.id)
+				: undefined,
+		);
+	},
+	onSettled: (
 		_data: unknown,
 		_error: unknown,
-		{ chatId }: { chatId: string; pinOrder: number },
+		_variables: ReorderPinnedChatVariables,
 	) => {
-		await invalidateChatListQueries(queryClient);
-		await queryClient.invalidateQueries({
-			queryKey: chatKeys.detail(chatId),
-			exact: true,
-		});
+		settlePinMutation(queryClient);
 	},
 });
 
@@ -1465,12 +1627,12 @@ export const updateChatTitle = (queryClient: QueryClient) => ({
 		API.experimental.updateChat(chatId, { title }),
 
 	onSuccess: (_data: unknown, { chatId, title }: UpdateChatTitleVariables) => {
-		queryClient.setQueryData<TypesGen.Chat | undefined>(
-			chatKeys.detail(chatId),
-			(chat) => (chat ? { ...chat, title } : chat),
-		);
-		updateInfiniteChatsCache(queryClient, (chats) =>
-			chats.map((chat) => (chat.id === chatId ? { ...chat, title } : chat)),
+		// The endpoint answers 204, so there is no entity to write back.
+		// Mirror the server's own TrimSpaces so the optimistic title cannot
+		// differ from what the next fetch returns.
+		const trimmedTitle = title.trim();
+		patchChatEverywhere(queryClient, chatId, (chat) =>
+			chat.title === trimmedTitle ? chat : { ...chat, title: trimmedTitle },
 		);
 	},
 
@@ -1716,25 +1878,15 @@ export const refreshChatContext = (
 ) => ({
 	mutationFn: () => API.experimental.refreshChatContext(chatId),
 	onSuccess: (updatedChat: TypesGen.Chat) => {
-		queryClient.setQueryData<TypesGen.Chat>(
-			chatKeys.detail(chatId),
-			(cached) =>
-				cached ? { ...cached, context: updatedChat.context } : updatedChat,
+		// Only `context` is authoritative on this response: the endpoint
+		// computes Context.Resources the same way getChat does, but omits
+		// diff_status, files, and children. Merge that one field rather
+		// than writing the entity.
+		patchChatEverywhere(queryClient, chatId, (chat) =>
+			chat.context === updatedChat.context
+				? chat
+				: { ...chat, context: updatedChat.context },
 		);
-		const applyContext = (chat: TypesGen.Chat): TypesGen.Chat =>
-			chat.id === chatId ? { ...chat, context: updatedChat.context } : chat;
-		updateInfiniteChatsCache(queryClient, (chats) => {
-			let changed = false;
-			const next = chats.map((chat) => {
-				const updated = applyContext(chat);
-				if (updated !== chat) {
-					changed = true;
-				}
-				return updated;
-			});
-			return changed ? next : chats;
-		});
-		updateChildInParentCache(queryClient, applyContext, chatId);
 	},
 });
 

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -39,10 +39,10 @@ import {
 	editChatMessage,
 	interruptChat,
 	mcpServerConfigs,
+	patchChatEverywhere,
 	promoteChatQueuedMessage,
 	updateChatPlanMode,
 	updateChatWorkspace,
-	updateInfiniteChatsCache,
 	userChatDebugLogging,
 	userChatProviderConfigs,
 	userCompactionThresholds,
@@ -1181,15 +1181,8 @@ const AgentChatPage: FC = () => {
 		chatId: string,
 		planMode?: TypesGen.ChatPlanMode,
 	) => {
-		updateInfiniteChatsCache(queryClient, (chats) =>
-			chats.map((chat) =>
-				chat.id === chatId ? { ...chat, plan_mode: planMode } : chat,
-			),
-		);
-		queryClient.setQueryData<TypesGen.Chat>(
-			chatKeys.detail(chatId),
-			(previousChat) =>
-				previousChat ? { ...previousChat, plan_mode: planMode } : previousChat,
+		patchChatEverywhere(queryClient, chatId, (chat) =>
+			chat.plan_mode === planMode ? chat : { ...chat, plan_mode: planMode },
 		);
 	};
 

--- a/site/src/pages/AgentsPage/AgentsPageLayout.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageLayout.tsx
@@ -102,7 +102,11 @@ export interface AgentsPageOutletContext {
 	) => void;
 	requestPinAgent: (chatId: string) => void;
 	requestUnpinAgent: (chatId: string) => void;
-	requestReorderPinnedAgent?: (chatId: string, pinOrder: number) => void;
+	requestReorderPinnedAgent?: (
+		chatId: string,
+		pinOrder: number,
+		pinnedChats: readonly TypesGen.Chat[],
+	) => void;
 	isArchiving: boolean;
 	archivingChatId: string | undefined;
 	onRenameTitle?: (chatId: string, title: string) => Promise<void>;
@@ -370,9 +374,11 @@ const AgentsPageLayout: FC = () => {
 			toast.error(getErrorMessage(error, "Failed to unpin agent."));
 		},
 	});
+	const reorderPinnedChatBase = reorderPinnedChat(queryClient);
 	const reorderPinnedChatMutation = useMutation({
-		...reorderPinnedChat(queryClient),
-		onError: (error) => {
+		...reorderPinnedChatBase,
+		onError: (error, variables, context) => {
+			reorderPinnedChatBase.onError(error, variables, context);
 			toast.error(getErrorMessage(error, "Failed to reorder pinned agents."));
 		},
 	});
@@ -532,8 +538,20 @@ const AgentsPageLayout: FC = () => {
 	const requestUnpinAgent = (chatId: string) => {
 		unpinAgentMutation.mutate(chatId);
 	};
-	const requestReorderPinnedAgent = (chatId: string, pinOrder: number) => {
-		reorderPinnedChatMutation.mutate({ chatId, pinOrder });
+	const requestReorderPinnedAgent = (
+		chatId: string,
+		pinOrder: number,
+		pinnedChats: readonly TypesGen.Chat[],
+	) => {
+		// The pinned set comes from the sidebar's rendered order rather
+		// than the cache, so a filtered variant without pinned chats
+		// cannot decide the new ordering, and a drag that lands before
+		// this component rerenders still renumbers what the user saw.
+		reorderPinnedChatMutation.mutate({
+			chatId,
+			pinOrder,
+			visibleChats: pinnedChats,
+		});
 	};
 	const requestProposeTitle = async (chatId: string): Promise<string> => {
 		const result = await proposeTitleMutation.mutateAsync(chatId);

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.tsx
@@ -22,7 +22,11 @@ interface ChatsSidebarProps {
 	onArchiveAndDeleteWorkspace: (chatId: string, workspaceId: string) => void;
 	onPinAgent: (chatId: string) => void;
 	onUnpinAgent: (chatId: string) => void;
-	onReorderPinnedAgent?: (chatId: string, pinOrder: number) => void;
+	onReorderPinnedAgent?: (
+		chatId: string,
+		pinOrder: number,
+		pinnedChats: readonly Chat[],
+	) => void;
 	onRenameTitle?: (chatId: string, title: string) => Promise<void>;
 	onProposeTitle?: (chatId: string) => Promise<string>;
 	/**

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
@@ -9,7 +9,6 @@ import {
 	useSensors,
 } from "@dnd-kit/core";
 import {
-	arrayMove,
 	SortableContext,
 	sortableKeyboardCoordinates,
 	verticalListSortingStrategy,
@@ -59,6 +58,7 @@ import {
 	PINNED_SECTION_KEY,
 } from "./ChatSectionHeader";
 import { LoadMoreSentinel } from "./LoadMoreSentinel";
+import { resolvePinnedChatDrop } from "./pinnedChatDrag";
 import { UserSidebarFooter } from "./UserSidebarFooter";
 
 const UNREAD_SECTION_KEY = "Unread";
@@ -78,7 +78,11 @@ interface ChatsPanelProps {
 	) => void;
 	readonly onPinAgent: (chatId: string) => void;
 	readonly onUnpinAgent: (chatId: string) => void;
-	readonly onReorderPinnedAgent?: (chatId: string, pinOrder: number) => void;
+	readonly onReorderPinnedAgent?: (
+		chatId: string,
+		pinOrder: number,
+		pinnedChats: readonly Chat[],
+	) => void;
 	readonly onBeforeNewAgent?: () => void;
 	readonly onOpenSearchDialog?: () => void;
 	readonly onOpenRenameDialog?: (chat: Chat) => void;
@@ -236,15 +240,19 @@ export const ChatsPanel: FC<ChatsPanelProps> = ({
 
 		lastDragEndedAtRef.current = performance.now();
 		if (!over || active.id === over.id) return;
-		const activeId = String(active.id);
-		const overId = String(over.id);
-		const oldIndex = pinnedChatIds.indexOf(activeId);
-		const newIndex = pinnedChatIds.indexOf(overId);
-		if (oldIndex === -1 || newIndex === -1) return;
+		const drop = resolvePinnedChatDrop({
+			pinnedChats: sortedPinnedChats,
+			hasLocalOrder: localPinOrder !== null,
+			activeId: String(active.id),
+			overId: String(over.id),
+		});
+		if (!drop) return;
 
-		const reordered = arrayMove(pinnedChatIds, oldIndex, newIndex);
-		setLocalPinOrder(reordered);
-		onReorderPinnedAgent?.(activeId, newIndex + 1);
+		setLocalPinOrder(drop.localOrder);
+		// The drop ran against this panel's own order, which already
+		// includes an earlier drop the parent has not rerendered with yet,
+		// so the mutation renumbers what the user actually saw.
+		onReorderPinnedAgent?.(drop.chatId, drop.pinOrder, drop.mutationChats);
 	};
 
 	// Auto-expand ancestors of the active chat so it's always visible.

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/chats/pinnedChatDrag.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/chats/pinnedChatDrag.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import type { Chat } from "#/api/typesGenerated";
+import { MockChat } from "#/testHelpers/chatEntities";
+import { resolvePinnedChatDrop } from "./pinnedChatDrag";
+
+const buildPinnedChat = (id: string, pinOrder: number): Chat => ({
+	...MockChat,
+	id,
+	title: `Chat ${id}`,
+	pin_order: pinOrder,
+});
+
+const pinnedChats = [
+	buildPinnedChat("chat-1", 1),
+	buildPinnedChat("chat-2", 2),
+	buildPinnedChat("chat-3", 3),
+];
+
+describe("resolvePinnedChatDrop", () => {
+	it("returns undefined when either end of the drop is not pinned", () => {
+		expect(
+			resolvePinnedChatDrop({
+				pinnedChats,
+				hasLocalOrder: false,
+				activeId: "chat-unpinned",
+				overId: "chat-1",
+			}),
+		).toBeUndefined();
+		expect(
+			resolvePinnedChatDrop({
+				pinnedChats,
+				hasLocalOrder: false,
+				activeId: "chat-1",
+				overId: "chat-unpinned",
+			}),
+		).toBeUndefined();
+	});
+
+	it("renumbers from the rendered order and leaves cache-fresh pin orders alone", () => {
+		// Server-assigned pin orders can hold gaps, which are the freshest
+		// values available while no drop is pending.
+		const gapped = [
+			buildPinnedChat("chat-1", 2),
+			buildPinnedChat("chat-2", 5),
+			buildPinnedChat("chat-3", 9),
+		];
+
+		const drop = resolvePinnedChatDrop({
+			pinnedChats: gapped,
+			hasLocalOrder: false,
+			activeId: "chat-3",
+			overId: "chat-1",
+		});
+
+		expect(drop).toEqual({
+			localOrder: ["chat-3", "chat-1", "chat-2"],
+			chatId: "chat-3",
+			pinOrder: 1,
+			mutationChats: gapped,
+		});
+	});
+
+	it("normalizes the pre-drop order while a local drag order is active", () => {
+		// What the panel renders after a first drop the parent has not
+		// rerendered with: the position is new, the pin_order fields are
+		// the ones the prop was built with.
+		const locallyOrdered = [
+			buildPinnedChat("chat-3", 3),
+			buildPinnedChat("chat-1", 1),
+			buildPinnedChat("chat-2", 2),
+		];
+
+		const drop = resolvePinnedChatDrop({
+			pinnedChats: locallyOrdered,
+			hasLocalOrder: true,
+			activeId: "chat-2",
+			overId: "chat-3",
+		});
+
+		expect(drop?.localOrder).toEqual(["chat-2", "chat-3", "chat-1"]);
+		expect(drop?.chatId).toBe("chat-2");
+		expect(drop?.pinOrder).toBe(1);
+		// Pre-drop positions, so the mutation's rollback snapshot is the
+		// order the user is looking at rather than the stale prop's.
+		expect(
+			drop?.mutationChats.map((chat) => [chat.id, chat.pin_order]),
+		).toEqual([
+			["chat-3", 1],
+			["chat-1", 2],
+			["chat-2", 3],
+		]);
+	});
+
+	it("keeps the two drops of an un-rerendered sequence consistent", () => {
+		const first = resolvePinnedChatDrop({
+			pinnedChats,
+			hasLocalOrder: false,
+			activeId: "chat-3",
+			overId: "chat-1",
+		});
+		expect(first?.pinOrder).toBe(1);
+		expect(first?.localOrder).toEqual(["chat-3", "chat-1", "chat-2"]);
+
+		// The parent still holds the pre-drop chats, so the panel renders
+		// its local order over them and the second drop is renumbered
+		// against that, not against the stale prop order.
+		const rendered = (first?.localOrder ?? []).map(
+			(id) => pinnedChats.find((chat) => chat.id === id) as Chat,
+		);
+		const second = resolvePinnedChatDrop({
+			pinnedChats: rendered,
+			hasLocalOrder: true,
+			activeId: "chat-1",
+			overId: "chat-2",
+		});
+
+		expect(second?.chatId).toBe("chat-1");
+		expect(second?.pinOrder).toBe(3);
+		expect(second?.localOrder).toEqual(["chat-3", "chat-2", "chat-1"]);
+		expect(
+			second?.mutationChats.map((chat) => [chat.id, chat.pin_order]),
+		).toEqual([
+			["chat-3", 1],
+			["chat-1", 2],
+			["chat-2", 3],
+		]);
+	});
+});

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/chats/pinnedChatDrag.ts
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/chats/pinnedChatDrag.ts
@@ -1,0 +1,62 @@
+import { arrayMove } from "@dnd-kit/sortable";
+import type { Chat } from "#/api/typesGenerated";
+
+type PinnedChatDropArgs = {
+	/** Pinned chats in the order the sidebar is rendering them. */
+	pinnedChats: readonly Chat[];
+	/**
+	 * True when the rendered order comes from the panel's own drag
+	 * override rather than straight from the chats prop.
+	 */
+	hasLocalOrder: boolean;
+	activeId: string;
+	overId: string;
+};
+
+type PinnedChatDrop = {
+	/** Chat ids in the post-drop order, for the panel's local override. */
+	localOrder: string[];
+	chatId: string;
+	pinOrder: number;
+	/** The pre-drop pinned chats the reorder mutation renumbers against. */
+	mutationChats: readonly Chat[];
+};
+
+/**
+ * Resolves a pinned-chat drop into the panel's next local order and the
+ * reorder mutation's payload. Returns undefined when either end of the
+ * drop is not a pinned chat.
+ *
+ * While a local drag order is active, the chats still carry the pin_order
+ * fields of the prop the panel last rendered with, which lags behind the
+ * drops already applied to the cache. The mutation reads those fields to
+ * build the snapshot it rolls back to, so it is handed copies renumbered
+ * to their rendered positions instead. The pre-drop order is what gets
+ * renumbered: normalizing the post-drop order would make the rollback
+ * snapshot equal the optimistic one and turn rollback into a no-op.
+ *
+ * Without a local order the fields come from the cache and can hold
+ * legitimate server-assigned gaps, so they are passed through untouched.
+ */
+export const resolvePinnedChatDrop = ({
+	pinnedChats,
+	hasLocalOrder,
+	activeId,
+	overId,
+}: PinnedChatDropArgs): PinnedChatDrop | undefined => {
+	const pinnedChatIds = pinnedChats.map((chat) => chat.id);
+	const oldIndex = pinnedChatIds.indexOf(activeId);
+	const newIndex = pinnedChatIds.indexOf(overId);
+	if (oldIndex === -1 || newIndex === -1) {
+		return undefined;
+	}
+
+	return {
+		localOrder: arrayMove(pinnedChatIds, oldIndex, newIndex),
+		chatId: activeId,
+		pinOrder: newIndex + 1,
+		mutationChats: hasLocalOrder
+			? pinnedChats.map((chat, index) => ({ ...chat, pin_order: index + 1 }))
+			: pinnedChats,
+	};
+};


### PR DESCRIPTION
This is PR 3 of a stack fixing the Agents/chats feature's misuse of TanStack Query.

Chat mutations had an inconsistent optimistic/rollback contract. This PR unifies it with small helpers (`patchChatEverywhere`, `cancelChatMutationRefetches`, `findChatInCaches`) instead of a generic factory, and field-scoped, value-equality-guarded inverse rollback so a failed mutation no longer restores a whole-entity snapshot. Pin/reorder concurrency is reworked with a mutation scope, mutation keys, and last-settle invalidation, plus a `pinnedChatDrag` pure helper for stale `pin_order` fields on repeated drags. `void` invalidations are preserved (tests pin them as an earlier UX bugfix: returning the promises would prolong `isPending`), and `applyChatArchiveStateToCaches` is kept because it has another consumer and provides immediate inactive-filter eviction.

Depends on #27771

<details>
<summary>Implementation plan and review notes (for reviewers)</summary>

- Field-scoped, value-equality-guarded inverse rollback; no whole-entity snapshot restoration.
- Repeated review found and fixed: detail invalidation dropped by settle gating, overlapping reorder rollback corruption, stale drag payloads, and an RTL interaction test violating frontend test policy.
- Final reviewers: mergeable.

</details>

---

Generated by Coder Agents on behalf of @DanielleMaywood