### PR TITLE
refactor(site/src/pages/AgentsPage): add read facade for durable chat state

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -83,10 +83,12 @@ import {
 import {
 	type ChatStore,
 	type ChatStoreState,
-	selectChatStatus,
-	useChatSelector,
 	useChatStore,
 } from "./components/ChatConversation/chatStore";
+import {
+	useDurableChatStatus,
+	useDurableMessageCount,
+} from "./components/ChatConversation/durableChat";
 import { useChatToolInvalidations } from "./components/ChatConversation/useChatToolInvalidations";
 import type { PendingAttachment } from "./components/ChatPageContent";
 import { workspaceSkillsFromChat } from "./components/ChatPageContent";
@@ -1222,7 +1224,9 @@ const AgentChatPage: FC = () => {
 		aiGatewayDisabled,
 	});
 	const liveChatStatus =
-		useChatSelector(store, selectChatStatus) ?? chatRecord?.status ?? null;
+		useDurableChatStatus({ store, chatId: agentId }) ??
+		chatRecord?.status ??
+		null;
 	const persistedError = getPersistedDetailError({
 		chatStatus: liveChatStatus,
 		chatRecord,
@@ -1496,7 +1500,7 @@ const AgentChatPage: FC = () => {
 	// Signal ready only after the store has synced fetched messages,
 	// so the DOM actually contains them when the parent scrolls.
 	const chatReadyFiredRef = useRef<string | null>(null);
-	const storeMessageCount = useChatSelector(store, (s) => s.messagesByID.size);
+	const storeMessageCount = useDurableMessageCount({ store, chatId: agentId });
 	const fetchedMessageCount = chatMessagesList?.length ?? 0;
 	useEffect(() => {
 		if (

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -26,10 +26,8 @@ import {
 	AgentChatPageNotFoundView,
 	AgentChatPageView,
 } from "./AgentChatPageView";
-import {
-	createChatStore,
-	useChatSelector,
-} from "./components/ChatConversation/chatStore";
+import { createChatStore } from "./components/ChatConversation/chatStore";
+import { useDurableMessageCount } from "./components/ChatConversation/durableChat";
 import type { ModelSelectorOption } from "./components/ChatElements";
 import { lastActiveSidebarTabStorageKeyPrefix } from "./utils/sidebarTabStorage";
 import type { ChatDetailError } from "./utils/usageLimitMessage";
@@ -122,13 +120,11 @@ const StoryAgentChatPageView: FC<StoryProps> = ({ editing, ...overrides }) => {
 	const defaultScrollContainerRef = useRef<HTMLDivElement | null>(null);
 	const defaultScrollToBottomRef = useRef<(() => void) | null>(null);
 	const store = overrides.store ?? defaultStoreRef.current;
-	const messageCount = useChatSelector(
-		store,
-		(state) => state.messagesByID.size,
-	);
+	const agentId = overrides.agentId ?? AGENT_ID;
+	const messageCount = useDurableMessageCount({ store, chatId: agentId });
 
 	const props = {
-		agentId: AGENT_ID,
+		agentId,
 		sendShortcut: "enter" as const,
 		organizationId: "test-org-id",
 		chatTitle: "Help me refactor",

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -913,6 +913,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 							<div className="px-4" data-chat-scroll-content>
 								<ChatPageTimeline
 									store={store}
+									chatId={agentId}
 									persistedError={persistedError}
 									onEditUserMessage={
 										isOtherUserReadOnly

--- a/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
@@ -7,7 +7,6 @@ import type { ChatDetailError } from "../../utils/usageLimitMessage";
 import type { SubagentVariant } from "../ChatElements/tools/subagentDescriptor";
 import { ChatStatusCallout } from "./ChatStatusCallout";
 import {
-	selectIsAwaitingFirstStreamChunk,
 	selectReconnectState,
 	selectRetryState,
 	selectStreamError,
@@ -16,6 +15,7 @@ import {
 	useChatSelector,
 	type useChatStore,
 } from "./chatStore";
+import { useIsAwaitingFirstStreamChunk } from "./durableChat";
 import { deriveLiveStatus, type LiveStatusModel } from "./liveStatusModel";
 import { StreamingOutput } from "./StreamingOutput";
 import { buildStreamTools } from "./streamState";
@@ -113,6 +113,7 @@ export const LiveStreamTailContent = ({
 
 interface LiveStreamTailProps {
 	store: ChatStoreHandle;
+	chatId?: string;
 	persistedError: ChatDetailError | undefined;
 	isTranscriptEmpty: boolean;
 	subagentTitles: Map<string, string>;
@@ -123,6 +124,7 @@ interface LiveStreamTailProps {
 
 export const LiveStreamTail = ({
 	store,
+	chatId,
 	persistedError,
 	isTranscriptEmpty,
 	subagentTitles,
@@ -134,10 +136,10 @@ export const LiveStreamTail = ({
 	const streamError = useChatSelector(store, selectStreamError);
 	const retryState = useChatSelector(store, selectRetryState);
 	const reconnectState = useChatSelector(store, selectReconnectState);
-	const isAwaitingFirstStreamChunk = useChatSelector(
+	const isAwaitingFirstStreamChunk = useIsAwaitingFirstStreamChunk({
 		store,
-		selectIsAwaitingFirstStreamChunk,
-	);
+		chatId,
+	});
 	const subagentStatusOverrides = useChatSelector(
 		store,
 		selectSubagentStatusOverrides,

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -37,7 +37,6 @@ import { createTestQueryClient } from "#/testHelpers/renderHelpers";
 import type { OneWayMessageEvent } from "#/utils/OneWayWebSocket";
 import {
 	selectChatStatus,
-	selectIsAwaitingFirstStreamChunk,
 	selectMessagesByID,
 	selectOrderedMessageIDs,
 	selectQueuedMessages,
@@ -49,6 +48,12 @@ import {
 	useChatSelector,
 	useChatStore,
 } from "./chatStore";
+import {
+	useDurableChatStatus,
+	useDurableMessageList,
+	useDurableQueuedMessages,
+	useIsAwaitingFirstStreamChunk,
+} from "./durableChat";
 
 vi.mock("#/api/api", () => ({
 	watchChat: vi.fn(),
@@ -757,15 +762,14 @@ describe("useChatStore", () => {
 				});
 				return {
 					streamState: useChatSelector(store, selectStreamState),
-					messagesByID: useChatSelector(store, selectMessagesByID),
-					orderedMessageIDs: useChatSelector(store, selectOrderedMessageIDs),
+					messages: useDurableMessageList({ store, chatId: chatID }),
 				};
 			},
 			{ wrapper },
 		);
 
 		await waitFor(() => {
-			expect(result.current.orderedMessageIDs).toEqual([1, 2, 3]);
+			expect(result.current.messages.map((m) => m.id)).toEqual([1, 2, 3]);
 		});
 
 		act(() => {
@@ -787,8 +791,8 @@ describe("useChatStore", () => {
 		});
 
 		await waitFor(() => {
-			expect(result.current.orderedMessageIDs).toEqual([1]);
-			expect(result.current.messagesByID.get(1)?.content).toEqual(
+			expect(result.current.messages.map((m) => m.id)).toEqual([1]);
+			expect(result.current.messages.find((m) => m.id === 1)?.content).toEqual(
 				replacementMessage.content,
 			);
 			expect(result.current.streamState).toBeNull();
@@ -1350,7 +1354,10 @@ describe("useChatStore", () => {
 			(options: Parameters<typeof useChatStore>[0]) => {
 				const { store } = useChatStore(options);
 				return {
-					queuedMessages: useChatSelector(store, selectQueuedMessages),
+					queuedMessages: useDurableQueuedMessages({
+						store,
+						chatId: chatID,
+					}),
 				};
 			},
 			{
@@ -3819,7 +3826,7 @@ describe("useChatStore", () => {
 					clearChatErrorReason: vi.fn(),
 				});
 				return {
-					chatStatus: useChatSelector(store, selectChatStatus),
+					chatStatus: useDurableChatStatus({ store, chatId: chatID }),
 				};
 			},
 			{
@@ -4064,8 +4071,11 @@ describe("thinking indicator event ordering", () => {
 				});
 				return {
 					streamState: useChatSelector(store, selectStreamState),
-					chatStatus: useChatSelector(store, selectChatStatus),
-					isAwaiting: useChatSelector(store, selectIsAwaitingFirstStreamChunk),
+					chatStatus: useDurableChatStatus({ store, chatId: chatID }),
+					isAwaiting: useIsAwaitingFirstStreamChunk({
+						store,
+						chatId: chatID,
+					}),
 				};
 			},
 			{ wrapper },
@@ -4147,8 +4157,11 @@ describe("thinking indicator event ordering", () => {
 				});
 				return {
 					streamState: useChatSelector(store, selectStreamState),
-					chatStatus: useChatSelector(store, selectChatStatus),
-					isAwaiting: useChatSelector(store, selectIsAwaitingFirstStreamChunk),
+					chatStatus: useDurableChatStatus({ store, chatId: chatID }),
+					isAwaiting: useIsAwaitingFirstStreamChunk({
+						store,
+						chatId: chatID,
+					}),
 				};
 			},
 			{ wrapper },
@@ -4225,7 +4238,7 @@ describe("thinking indicator event ordering", () => {
 				});
 				return {
 					streamState: useChatSelector(store, selectStreamState),
-					chatStatus: useChatSelector(store, selectChatStatus),
+					chatStatus: useDurableChatStatus({ store, chatId: chatID }),
 				};
 			},
 			{ wrapper },
@@ -4765,8 +4778,7 @@ describe("stream-to-durable transition (Bug 1)", () => {
 				});
 				return {
 					streamState: useChatSelector(store, selectStreamState),
-					orderedIDs: useChatSelector(store, selectOrderedMessageIDs),
-					messagesByID: useChatSelector(store, selectMessagesByID),
+					messages: useDurableMessageList({ store, chatId: chatID }),
 				};
 			},
 			{ wrapper },
@@ -4810,8 +4822,10 @@ describe("stream-to-durable transition (Bug 1)", () => {
 		// The durable message must be present AND streamState
 		// must be null in the same snapshot.
 		await waitFor(() => {
-			expect(result.current.orderedIDs).toContain(2);
-			expect(result.current.messagesByID.get(2)?.role).toBe("assistant");
+			expect(result.current.messages.map((m) => m.id)).toContain(2);
+			expect(result.current.messages.find((m) => m.id === 2)?.role).toBe(
+				"assistant",
+			);
 			expect(result.current.streamState).toBeNull();
 		});
 	});
@@ -4849,8 +4863,8 @@ describe("stream-to-durable transition (Bug 1)", () => {
 					clearChatErrorReason: vi.fn(),
 				});
 				const streamState = useChatSelector(store, selectStreamState);
-				const messagesByID = useChatSelector(store, selectMessagesByID);
-				const hasDurableAssistant = Array.from(messagesByID.values()).some(
+				const messages = useDurableMessageList({ store, chatId: chatID });
+				const hasDurableAssistant = messages.some(
 					(m) => m.role === "assistant",
 				);
 
@@ -4859,7 +4873,7 @@ describe("stream-to-durable transition (Bug 1)", () => {
 					hasDurableAssistant,
 				});
 
-				return { streamState, messagesByID };
+				return { streamState, messages };
 			},
 			{ wrapper },
 		);
@@ -4895,7 +4909,7 @@ describe("stream-to-durable transition (Bug 1)", () => {
 		});
 
 		await waitFor(() => {
-			expect(result.current.messagesByID.has(2)).toBe(true);
+			expect(result.current.messages.some((m) => m.id === 2)).toBe(true);
 		});
 
 		// No snapshot should ever have BOTH a durable assistant

--- a/site/src/pages/AgentsPage/components/ChatConversation/durableChat.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/durableChat.test.tsx
@@ -1,0 +1,225 @@
+import { act, render, renderHook } from "@testing-library/react";
+import type { FC } from "react";
+import { describe, expect, it } from "vitest";
+import type * as TypesGen from "#/api/typesGenerated";
+import {
+	type ChatStore,
+	createChatStore,
+	selectChatStatus,
+	selectIsAwaitingFirstStreamChunk,
+	selectMessagesByID,
+	selectOrderedMessageIDs,
+	selectQueuedMessages,
+	useChatSelector,
+} from "./chatStore";
+import {
+	useDurableChatStatus,
+	useDurableMessageCount,
+	useDurableMessageList,
+	useDurableQueuedMessages,
+	useIsAwaitingFirstStreamChunk,
+} from "./durableChat";
+
+const CHAT_ID = "chat-1";
+
+const buildMessage = (
+	id: number,
+	role: TypesGen.ChatMessageRole,
+	text: string,
+): TypesGen.ChatMessage => ({
+	id,
+	chat_id: CHAT_ID,
+	created_at: "2025-01-01T00:00:00.000Z",
+	role,
+	content: [{ type: "text", text }],
+});
+
+const buildQueuedMessage = (
+	id: number,
+	text: string,
+): TypesGen.ChatQueuedMessage => ({
+	id,
+	chat_id: CHAT_ID,
+	created_at: "2025-01-01T00:00:00.000Z",
+	content: [{ type: "text", text }],
+});
+
+const buildTextPart = (text: string): TypesGen.ChatMessagePart => ({
+	type: "text",
+	text,
+});
+
+describe("durableChat facade", () => {
+	it("matches the underlying store selectors", () => {
+		const store = createChatStore();
+		const messages = [
+			buildMessage(1, "user", "hello"),
+			buildMessage(2, "assistant", "hi"),
+		];
+		store.replaceMessages(messages);
+		store.setQueuedMessages([buildQueuedMessage(10, "later")]);
+		store.setChatStatus("running");
+
+		const { result } = renderHook(() => ({
+			facadeStatus: useDurableChatStatus({ store, chatId: CHAT_ID }),
+			selectorStatus: useChatSelector(store, selectChatStatus),
+			facadeMessages: useDurableMessageList({ store, chatId: CHAT_ID }),
+			selectorMessagesByID: useChatSelector(store, selectMessagesByID),
+			selectorOrderedMessageIDs: useChatSelector(
+				store,
+				selectOrderedMessageIDs,
+			),
+			facadeCount: useDurableMessageCount({ store, chatId: CHAT_ID }),
+			facadeQueued: useDurableQueuedMessages({ store, chatId: CHAT_ID }),
+			selectorQueued: useChatSelector(store, selectQueuedMessages),
+			facadeAwaiting: useIsAwaitingFirstStreamChunk({
+				store,
+				chatId: CHAT_ID,
+			}),
+			selectorAwaiting: useChatSelector(
+				store,
+				selectIsAwaitingFirstStreamChunk,
+			),
+		}));
+
+		const current = result.current;
+		expect(current.facadeStatus).toBe(current.selectorStatus);
+		expect(current.facadeMessages).toEqual(
+			current.selectorOrderedMessageIDs.map((id) =>
+				current.selectorMessagesByID.get(id),
+			),
+		);
+		expect(current.facadeMessages).toEqual(messages);
+		expect(current.facadeCount).toBe(current.selectorMessagesByID.size);
+		expect(current.facadeQueued).toBe(current.selectorQueued);
+		expect(current.facadeAwaiting).toBe(current.selectorAwaiting);
+	});
+
+	it("keeps the message list reference stable when an unrelated field changes", () => {
+		const store = createChatStore();
+		store.replaceMessages([buildMessage(1, "user", "hello")]);
+
+		const { result } = renderHook(() => ({
+			messages: useDurableMessageList({ store, chatId: CHAT_ID }),
+			status: useDurableChatStatus({ store, chatId: CHAT_ID }),
+		}));
+
+		const firstMessages = result.current.messages;
+
+		act(() => {
+			store.setChatStatus("running");
+		});
+
+		expect(result.current.status).toBe("running");
+		expect(result.current.messages).toBe(firstMessages);
+
+		act(() => {
+			store.upsertDurableMessage(buildMessage(2, "assistant", "hi"));
+		});
+
+		expect(result.current.messages).not.toBe(firstMessages);
+		expect(result.current.messages).toHaveLength(2);
+	});
+
+	it("does not re-render a queued-message consumer on a message_part update", () => {
+		const store = createChatStore();
+		store.replaceMessages([buildMessage(1, "user", "hello")]);
+
+		let queueRenderCount = 0;
+		let messageRenderCount = 0;
+
+		const QueueProbe: FC<{ store: ChatStore }> = ({ store: probeStore }) => {
+			useDurableQueuedMessages({ store: probeStore, chatId: CHAT_ID });
+			queueRenderCount += 1;
+			return null;
+		};
+
+		const MessageProbe: FC<{ store: ChatStore }> = ({ store: probeStore }) => {
+			useDurableMessageList({ store: probeStore, chatId: CHAT_ID });
+			messageRenderCount += 1;
+			return null;
+		};
+
+		render(
+			<>
+				<QueueProbe store={store} />
+				<MessageProbe store={store} />
+			</>,
+		);
+
+		const queueBaseline = queueRenderCount;
+		const messageBaseline = messageRenderCount;
+
+		act(() => {
+			store.applyMessagePart(buildTextPart("partial"));
+		});
+
+		expect(queueRenderCount).toBe(queueBaseline);
+		expect(messageRenderCount).toBe(messageBaseline);
+	});
+
+	it("re-renders the awaiting-first-chunk consumer only when the flag flips", () => {
+		const store = createChatStore();
+		store.replaceMessages([buildMessage(1, "user", "hello")]);
+		store.setChatStatus("running");
+
+		let renderCount = 0;
+		const { result } = renderHook(() => {
+			const isAwaiting = useIsAwaitingFirstStreamChunk({
+				store,
+				chatId: CHAT_ID,
+			});
+			renderCount += 1;
+			return isAwaiting;
+		});
+
+		expect(result.current).toBe(true);
+		const baseline = renderCount;
+
+		act(() => {
+			store.applyMessagePart(buildTextPart("first"));
+		});
+
+		expect(result.current).toBe(false);
+		expect(renderCount).toBe(baseline + 1);
+
+		act(() => {
+			store.applyMessagePart(buildTextPart(" second"));
+		});
+		act(() => {
+			store.applyMessagePart(buildTextPart(" third"));
+		});
+
+		expect(result.current).toBe(false);
+		expect(renderCount).toBe(baseline + 1);
+	});
+
+	it("re-renders the message-count consumer only when the count changes", () => {
+		const store = createChatStore();
+		store.replaceMessages([buildMessage(1, "user", "hello")]);
+
+		let renderCount = 0;
+		const { result } = renderHook(() => {
+			const count = useDurableMessageCount({ store, chatId: CHAT_ID });
+			renderCount += 1;
+			return count;
+		});
+
+		expect(result.current).toBe(1);
+		const baseline = renderCount;
+
+		act(() => {
+			store.upsertDurableMessage(buildMessage(1, "user", "hello edited"));
+		});
+
+		expect(result.current).toBe(1);
+		expect(renderCount).toBe(baseline);
+
+		act(() => {
+			store.upsertDurableMessage(buildMessage(2, "assistant", "hi"));
+		});
+
+		expect(result.current).toBe(2);
+		expect(renderCount).toBe(baseline + 1);
+	});
+});

--- a/site/src/pages/AgentsPage/components/ChatConversation/durableChat.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/durableChat.ts
@@ -1,0 +1,83 @@
+import type * as TypesGen from "#/api/typesGenerated";
+import {
+	type ChatStore,
+	type ChatStoreState,
+	selectChatStatus,
+	selectIsAwaitingFirstStreamChunk,
+	selectMessagesByID,
+	selectOrderedMessageIDs,
+	selectQueuedMessages,
+	useChatSelector,
+} from "./chatStore";
+
+// Read facade for durable chat state (messages, queued messages, chat
+// status). Render consumers read durable state through these hooks so the
+// source can move from the store to the query cache without touching call
+// sites. Today every hook resolves to the store, so output is identical to
+// reading the selectors directly.
+//
+// Composition rule: `useChatSelector` feeds its selector result straight to
+// `useSyncExternalStore`, which compares snapshots with Object.is on every
+// render. A selector that allocates a fresh object or array loops forever.
+// Read raw slices through `useChatSelector` and derive in the hook body,
+// never inside the selector. React Compiler covers this directory and
+// memoizes the derivation against the slices it reads.
+type DurableChatArgs = {
+	store: ChatStore;
+	// Accepted for the query key that will back these reads once durable
+	// state moves to the cache. Unused while the store is the source.
+	chatId?: string;
+};
+
+// Primitive selector so count consumers subscribe to the size only, not to
+// messagesByID identity.
+const selectMessageCount = (state: ChatStoreState): number =>
+	state.messagesByID.size;
+
+const isChatMessage = (
+	message: TypesGen.ChatMessage | undefined,
+): message is TypesGen.ChatMessage => Boolean(message);
+
+export const useDurableChatStatus = (
+	args: DurableChatArgs,
+): TypesGen.ChatStatus | null => useChatSelector(args.store, selectChatStatus);
+
+// Flat, ascending message list. messagesByID and orderedMessageIDs stay
+// internal to the store; both durable sources agree on the flat shape.
+export const useDurableMessageList = (
+	args: DurableChatArgs,
+): readonly TypesGen.ChatMessage[] => {
+	const messagesByID = useChatSelector(args.store, selectMessagesByID);
+	const orderedMessageIDs = useChatSelector(
+		args.store,
+		selectOrderedMessageIDs,
+	);
+
+	return orderedMessageIDs
+		.map((messageID) => {
+			const message = messagesByID.get(messageID);
+			if (!message && process.env.NODE_ENV !== "production") {
+				console.warn(
+					`[durableChat] orderedMessageIDs contains ID ${messageID} ` +
+						"not found in messagesByID. This may indicate a store/cache " +
+						"desync bug.",
+				);
+			}
+			return message;
+		})
+		.filter(isChatMessage);
+};
+
+export const useDurableMessageCount = (args: DurableChatArgs): number =>
+	useChatSelector(args.store, selectMessageCount);
+
+export const useDurableQueuedMessages = (
+	args: DurableChatArgs,
+): readonly TypesGen.ChatQueuedMessage[] =>
+	useChatSelector(args.store, selectQueuedMessages);
+
+// Delegates to the boolean selector, which reads only the latest message,
+// the chat status, and whether a stream exists. Composing it from the full
+// message list would widen the subscription to any content change.
+export const useIsAwaitingFirstStreamChunk = (args: DurableChatArgs): boolean =>
+	useChatSelector(args.store, selectIsAwaitingFirstStreamChunk);

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -49,7 +49,13 @@ export const SpacerVisibleWhenNotStreaming: Story = {
 	render: () => {
 		const store = buildThinkingSpacerStore();
 
-		return <ChatPageTimeline store={store} persistedError={undefined} />;
+		return (
+			<ChatPageTimeline
+				store={store}
+				chatId={CHAT_ID}
+				persistedError={undefined}
+			/>
+		);
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -76,7 +82,11 @@ export const DurableUnresolvedWorkspaceToolRuns: Story = {
 
 		return (
 			<ChatWorkspaceContext value={{ workspaceId: "workspace-1" }}>
-				<ChatPageTimeline store={store} persistedError={undefined} />
+				<ChatPageTimeline
+					store={store}
+					chatId={CHAT_ID}
+					persistedError={undefined}
+				/>
 			</ChatWorkspaceContext>
 		);
 	},
@@ -99,7 +109,13 @@ export const HiddenAssistantPlaceholderDoesNotRender: Story = {
 			buildMessage(4, "user", [{ type: "text", text: "Thanks!" }]),
 		]);
 
-		return <ChatPageTimeline store={store} persistedError={undefined} />;
+		return (
+			<ChatPageTimeline
+				store={store}
+				chatId={CHAT_ID}
+				persistedError={undefined}
+			/>
+		);
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -137,7 +153,13 @@ export const MergedMessagesRenderInIDOrder: Story = {
 			batched(2, "assistant", "bravo"),
 		]);
 
-		return <ChatPageTimeline store={store} persistedError={undefined} />;
+		return (
+			<ChatPageTimeline
+				store={store}
+				chatId={CHAT_ID}
+				persistedError={undefined}
+			/>
+		);
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -23,15 +23,16 @@ import {
 import { ConversationTimeline } from "./ChatConversation/ConversationTimeline";
 import { getLatestContextUsage } from "./ChatConversation/chatHelpers";
 import {
-	selectChatStatus,
 	selectHasStreamState,
-	selectIsAwaitingFirstStreamChunk,
-	selectMessagesByID,
-	selectOrderedMessageIDs,
-	selectQueuedMessages,
 	useChatSelector,
 	type useChatStore,
 } from "./ChatConversation/chatStore";
+import {
+	useDurableChatStatus,
+	useDurableMessageList,
+	useDurableQueuedMessages,
+	useIsAwaitingFirstStreamChunk,
+} from "./ChatConversation/durableChat";
 import { LiveStreamTail } from "./ChatConversation/LiveStreamTail";
 import {
 	buildSubagentMaps,
@@ -43,10 +44,6 @@ import type { ModelSelectorOption } from "./ChatElements";
 import type { SkillMetadata } from "./ChatMessageInput/SkillsTriggerMenu";
 
 type ChatStoreHandle = ReturnType<typeof useChatStore>["store"];
-
-const isChatMessage = (
-	message: TypesGen.ChatMessage | undefined,
-): message is TypesGen.ChatMessage => Boolean(message);
 
 // A resolved chat with no context (unpinned) or no resources authoritatively
 // has no workspace skills; only an unresolved chat leaves them unknown.
@@ -77,6 +74,7 @@ export const workspaceSkillsFromChat = (
 
 interface ChatPageTimelineProps {
 	store: ChatStoreHandle;
+	chatId?: string;
 	persistedError: ChatDetailError | undefined;
 	onEditUserMessage?: (
 		messageId: number,
@@ -92,6 +90,7 @@ interface ChatPageTimelineProps {
 
 export const ChatPageTimeline: FC<ChatPageTimelineProps> = ({
 	store,
+	chatId,
 	persistedError,
 	onEditUserMessage,
 	editingMessageId,
@@ -101,29 +100,15 @@ export const ChatPageTimeline: FC<ChatPageTimelineProps> = ({
 	mcpServers,
 }) => {
 	const [chatFullWidth] = useChatFullWidth();
-	const messagesByID = useChatSelector(store, selectMessagesByID);
-	const orderedMessageIDs = useChatSelector(store, selectOrderedMessageIDs);
-	const chatStatus = useChatSelector(store, selectChatStatus);
+	const messages = useDurableMessageList({ store, chatId });
+	const chatStatus = useDurableChatStatus({ store, chatId });
 	const hasStream = useChatSelector(store, selectHasStreamState);
-	const isAwaitingFirstStreamChunk = useChatSelector(
+	const isAwaitingFirstStreamChunk = useIsAwaitingFirstStreamChunk({
 		store,
-		selectIsAwaitingFirstStreamChunk,
-	);
+		chatId,
+	});
 	const isChatCompleted = !hasStream;
 
-	const messages = orderedMessageIDs
-		.map((messageID) => {
-			const message = messagesByID.get(messageID);
-			if (!message && process.env.NODE_ENV !== "production") {
-				console.warn(
-					`[ChatPageContent] orderedMessageIDs contains ID ${messageID} ` +
-						"not found in messagesByID. This may indicate a store/cache " +
-						"desync bug.",
-				);
-			}
-			return message;
-		})
-		.filter(isChatMessage);
 	const pendingToolCallIDs = getPendingToolCallIDs(messages, chatStatus);
 	const parsedMessages = parseMessagesWithMergedTools(messages, {
 		pendingToolCallIDs,
@@ -163,6 +148,7 @@ export const ChatPageTimeline: FC<ChatPageTimelineProps> = ({
 				/>
 				<LiveStreamTail
 					store={store}
+					chatId={chatId}
 					persistedError={persistedError}
 					isTranscriptEmpty={parsedMessages.length === 0}
 					subagentTitles={subagentTitles}
@@ -318,25 +304,11 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	attachedWorkspace,
 	folder,
 }) => {
-	const messagesByID = useChatSelector(store, selectMessagesByID);
-	const orderedMessageIDs = useChatSelector(store, selectOrderedMessageIDs);
+	const messages = useDurableMessageList({ store, chatId });
 	const hasStreamState = useChatSelector(store, selectHasStreamState);
-	const chatStatus = useChatSelector(store, selectChatStatus);
-	const queuedMessages = useChatSelector(store, selectQueuedMessages);
+	const chatStatus = useDurableChatStatus({ store, chatId });
+	const queuedMessages = useDurableQueuedMessages({ store, chatId });
 
-	const messages = orderedMessageIDs
-		.map((messageID) => {
-			const message = messagesByID.get(messageID);
-			if (!message && process.env.NODE_ENV !== "production") {
-				console.warn(
-					`[ChatPageContent] orderedMessageIDs contains ID ${messageID} ` +
-						"not found in messagesByID. This may indicate a store/cache " +
-						"desync bug.",
-				);
-			}
-			return message;
-		})
-		.filter(isChatMessage);
 	// Source the composer's prompt-history cycle from the dedicated /prompts endpoint.
 	const { data: promptsData } = useQuery(chatPromptsQuery(chatId ?? ""));
 	const userPromptHistory: readonly string[] =


### PR DESCRIPTION
This is PR 4 of a stack fixing the Agents/chats feature's misuse of TanStack Query.

Render consumers read durable chat state from many places. This PR adds a read facade (`durableChat.ts`) with per-slice hooks (`useDurableChatStatus`, `useDurableMessageList`, `useDurableMessageCount`, `useDurableQueuedMessages`, `useIsAwaitingFirstStreamChunk`) so the source can move to the query cache without touching call sites. Message flattening moves out of duplicated component code, and behavior-level test probes move to the facade while store unit tests stay store-direct. Memoization relies on the React Compiler (this directory is compiler-covered); the compiler output was inspected and confirmed to emit equivalent memoization.

Depends on #27772

<details>
<summary>Implementation plan and review notes (for reviewers)</summary>

- The facade initially delegated to store selectors; later PRs in the stack re-point it at the cache.
- Render consumers migrated; write/reconciliation code unchanged.
- Reviewed by two independent reviewers; mergeable.

</details>

---

Generated by Coder Agents on behalf of @DanielleMaywood