### PR TITLE
feat(codersdk): expose snapshot_version on Chat and ChatStreamEvent

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -17326,6 +17326,10 @@ const docTemplate = `{
                     "description": "Shared is true when this chat's root chat has explicit user or group ACL entries.",
                     "type": "boolean"
                 },
+                "snapshot_version": {
+                    "description": "SnapshotVersion is a monotonic per-chat version of the full chat\nsnapshot. Clients use it to order chat payloads received from REST,\nthe per-chat stream, and the global watch stream.",
+                    "type": "integer"
+                },
                 "status": {
                     "$ref": "#/definitions/codersdk.ChatStatus"
                 },
@@ -18318,6 +18322,10 @@ const docTemplate = `{
                 },
                 "retry": {
                     "$ref": "#/definitions/codersdk.ChatStreamRetry"
+                },
+                "snapshot_version": {
+                    "description": "SnapshotVersion is the chat snapshot version the event was derived\nfrom. It is omitted for events that carry no database snapshot, such\nas transport errors, which are not authoritative for ordering.",
+                    "type": "integer"
                 },
                 "status": {
                     "$ref": "#/definitions/codersdk.ChatStreamStatus"

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -15575,6 +15575,10 @@
 					"description": "Shared is true when this chat's root chat has explicit user or group ACL entries.",
 					"type": "boolean"
 				},
+				"snapshot_version": {
+					"description": "SnapshotVersion is a monotonic per-chat version of the full chat\nsnapshot. Clients use it to order chat payloads received from REST,\nthe per-chat stream, and the global watch stream.",
+					"type": "integer"
+				},
 				"status": {
 					"$ref": "#/definitions/codersdk.ChatStatus"
 				},
@@ -16519,6 +16523,10 @@
 				},
 				"retry": {
 					"$ref": "#/definitions/codersdk.ChatStreamRetry"
+				},
+				"snapshot_version": {
+					"description": "SnapshotVersion is the chat snapshot version the event was derived\nfrom. It is omitted for events that carry no database snapshot, such\nas transport errors, which are not authoritative for ordering.",
+					"type": "integer"
 				},
 				"status": {
 					"$ref": "#/definitions/codersdk.ChatStreamStatus"

--- a/coderd/database/db2sdk/db2sdk.go
+++ b/coderd/database/db2sdk/db2sdk.go
@@ -1770,6 +1770,7 @@ func Chat(c database.Chat, diffStatus *database.ChatDiffStatus, files []database
 		PinOrder:          c.PinOrder,
 		CreatedAt:         c.CreatedAt,
 		UpdatedAt:         c.UpdatedAt,
+		SnapshotVersion:   c.SnapshotVersion,
 		MCPServerIDs:      mcpServerIDs,
 		Labels:            labels,
 		ClientType:        codersdk.ChatClientType(c.ClientType),

--- a/coderd/database/db2sdk/db2sdk_test.go
+++ b/coderd/database/db2sdk/db2sdk_test.go
@@ -716,6 +716,7 @@ func TestChat_AllFieldsPopulated(t *testing.T) {
 		Summary:             sql.NullString{String: "summarized the whole chat", Valid: true},
 		CreatedAt:           now,
 		UpdatedAt:           now,
+		SnapshotVersion:     7,
 		Archived:            true,
 		UserACL:             database.ChatACL{uuid.NewString(): database.ChatACLEntry{}},
 		PinOrder:            1,
@@ -754,6 +755,7 @@ func TestChat_AllFieldsPopulated(t *testing.T) {
 	got := db2sdk.Chat(input, diffStatus, fileRows)
 
 	require.Equal(t, &lastErrorPayload, got.LastError)
+	require.Equal(t, input.SnapshotVersion, got.SnapshotVersion)
 
 	v := reflect.ValueOf(got)
 	typ := v.Type()

--- a/coderd/x/chatd/stream_loop.go
+++ b/coderd/x/chatd/stream_loop.go
@@ -292,6 +292,13 @@ func (l *streamLoop) applyDBSnapshot(snapshot streamDBSnapshot) []codersdk.ChatS
 		})
 	}
 
+	// Every event above is derived from this database snapshot, so stamp
+	// them all with the snapshot version. Clients use it to order chat
+	// updates against REST responses and the global watch stream.
+	for i := range events {
+		events[i].SnapshotVersion = chat.SnapshotVersion
+	}
+
 	l.state.snapshotVersion = chat.SnapshotVersion
 	l.state.historyVersion = chat.HistoryVersion
 	l.state.queueVersion = chat.QueueVersion

--- a/coderd/x/chatd/stream_loop_internal_test.go
+++ b/coderd/x/chatd/stream_loop_internal_test.go
@@ -215,6 +215,10 @@ func TestStreamLoopQueueStatusRetryErrorActionRequiredAndPreviewReset(t *testing
 	)
 	require.Equal(t, chatError.Message, events[2].Error.Message)
 	require.Equal(t, retry.Attempt, events[3].Retry.Attempt)
+	for i, event := range events {
+		require.Equal(t, int64(2), event.SnapshotVersion,
+			"event %d (%s) must carry the snapshot version it was derived from", i, event.Type)
+	}
 
 	actionLoop := newStreamLoop(database.Chat{ID: chatID}, nil, slogtest.Make(t, nil), 0)
 	actionEvents := actionLoop.applyDBSnapshot(streamDBSnapshot{
@@ -232,6 +236,10 @@ func TestStreamLoopQueueStatusRetryErrorActionRequiredAndPreviewReset(t *testing
 		codersdk.ChatStreamEventTypePreviewReset,
 	)
 	require.Equal(t, "call-1", actionEvents[1].ActionRequired.ToolCalls[0].ToolCallID)
+	for i, event := range actionEvents {
+		require.Equal(t, int64(1), event.SnapshotVersion,
+			"event %d (%s) must carry the snapshot version it was derived from", i, event.Type)
+	}
 }
 
 func TestStreamLoopActionRequiredFromHistory(t *testing.T) {

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -128,7 +128,14 @@ type Chat struct {
 	DiffStatus *ChatDiffStatus `json:"diff_status,omitempty"`
 	CreatedAt  time.Time       `json:"created_at" format:"date-time"`
 	UpdatedAt  time.Time       `json:"updated_at" format:"date-time"`
-	Archived   bool            `json:"archived"`
+	// SnapshotVersion is a monotonic per-chat version of the chat's durable
+	// execution state, incremented under the chat row lock on every
+	// ChatMachine.Update, so version order equals commit order. Clients use it
+	// to order chat status payloads received from REST, the per-chat stream,
+	// and the global watch stream. Metadata mutations (title, archive,
+	// summary, context) may not advance it.
+	SnapshotVersion int64 `json:"snapshot_version"`
+	Archived        bool  `json:"archived"`
 	// Shared is true when this chat's root chat has explicit user or group ACL entries.
 	Shared       bool               `json:"shared"`
 	PinOrder     int32              `json:"pin_order"`
@@ -1929,6 +1936,10 @@ type ChatStreamEvent struct {
 	Retry          *ChatStreamRetry          `json:"retry,omitempty"`
 	QueuedMessages []ChatQueuedMessage       `json:"queued_messages,omitempty"`
 	ActionRequired *ChatStreamActionRequired `json:"action_required,omitempty"`
+	// SnapshotVersion is the chat snapshot version the event was derived
+	// from. It is omitted for events that carry no database snapshot, such
+	// as transport errors, which are not authoritative for ordering.
+	SnapshotVersion int64 `json:"snapshot_version,omitempty"`
 }
 
 // ChatCostSummaryOptions are optional query parameters for GetChatCostSummary.

--- a/docs/reference/api/chats.md
+++ b/docs/reference/api/chats.md
@@ -121,6 +121,7 @@ Experimental: this endpoint is subject to change.
     "plan_mode": "plan",
     "root_chat_id": "2898031c-fdce-4e3e-8c53-4481dd42fcd7",
     "shared": true,
+    "snapshot_version": 0,
     "status": "waiting",
     "summary": "string",
     "title": "string",
@@ -218,6 +219,7 @@ Status Code **200**
 | `» plan_mode`             | [codersdk.ChatPlanMode](schemas.md#codersdkchatplanmode)                           | false    |              |                                                                                                                                                                                                                                                                            |
 | `» root_chat_id`          | string(uuid)                                                                       | false    |              |                                                                                                                                                                                                                                                                            |
 | `» shared`                | boolean                                                                            | false    |              | Shared is true when this chat's root chat has explicit user or group ACL entries.                                                                                                                                                                                          |
+| `» snapshot_version`      | integer                                                                            | false    |              | Snapshot version is a monotonic per-chat version of the full chat snapshot. Clients use it to order chat payloads received from REST, the per-chat stream, and the global watch stream.                                                                                    |
 | `» status`                | [codersdk.ChatStatus](schemas.md#codersdkchatstatus)                               | false    |              |                                                                                                                                                                                                                                                                            |
 | `» summary`               | string                                                                             | false    |              | Summary is the persisted whole-chat summary, generated in the background. It is nil until the first summary has been produced.                                                                                                                                             |
 | `» title`                 | string                                                                             | false    |              |                                                                                                                                                                                                                                                                            |
@@ -398,6 +400,7 @@ Experimental: this endpoint is subject to change.
       "plan_mode": "plan",
       "root_chat_id": "2898031c-fdce-4e3e-8c53-4481dd42fcd7",
       "shared": true,
+      "snapshot_version": 0,
       "status": "waiting",
       "summary": "string",
       "title": "string",
@@ -492,6 +495,7 @@ Experimental: this endpoint is subject to change.
   "plan_mode": "plan",
   "root_chat_id": "2898031c-fdce-4e3e-8c53-4481dd42fcd7",
   "shared": true,
+  "snapshot_version": 0,
   "status": "waiting",
   "summary": "string",
   "title": "string",
@@ -743,6 +747,7 @@ Experimental: this endpoint is subject to change.
     "plan_mode": "plan",
     "root_chat_id": "2898031c-fdce-4e3e-8c53-4481dd42fcd7",
     "shared": true,
+    "snapshot_version": 0,
     "status": "waiting",
     "summary": "string",
     "title": "string",
@@ -891,6 +896,7 @@ Experimental: this endpoint is subject to change.
       "plan_mode": "plan",
       "root_chat_id": "2898031c-fdce-4e3e-8c53-4481dd42fcd7",
       "shared": true,
+      "snapshot_version": 0,
       "status": "waiting",
       "summary": "string",
       "title": "string",
@@ -985,6 +991,7 @@ Experimental: this endpoint is subject to change.
   "plan_mode": "plan",
   "root_chat_id": "2898031c-fdce-4e3e-8c53-4481dd42fcd7",
   "shared": true,
+  "snapshot_version": 0,
   "status": "waiting",
   "summary": "string",
   "title": "string",
@@ -1170,6 +1177,7 @@ Experimental: this endpoint is subject to change.
       "plan_mode": "plan",
       "root_chat_id": "2898031c-fdce-4e3e-8c53-4481dd42fcd7",
       "shared": true,
+      "snapshot_version": 0,
       "status": "waiting",
       "summary": "string",
       "title": "string",
@@ -1264,6 +1272,7 @@ Experimental: this endpoint is subject to change.
   "plan_mode": "plan",
   "root_chat_id": "2898031c-fdce-4e3e-8c53-4481dd42fcd7",
   "shared": true,
+  "snapshot_version": 0,
   "status": "waiting",
   "summary": "string",
   "title": "string",
@@ -1499,6 +1508,7 @@ Experimental: this endpoint is subject to change.
       "plan_mode": "plan",
       "root_chat_id": "2898031c-fdce-4e3e-8c53-4481dd42fcd7",
       "shared": true,
+      "snapshot_version": 0,
       "status": "waiting",
       "summary": "string",
       "title": "string",
@@ -1593,6 +1603,7 @@ Experimental: this endpoint is subject to change.
   "plan_mode": "plan",
   "root_chat_id": "2898031c-fdce-4e3e-8c53-4481dd42fcd7",
   "shared": true,
+  "snapshot_version": 0,
   "status": "waiting",
   "summary": "string",
   "title": "string",
@@ -2507,6 +2518,7 @@ Experimental: this endpoint is subject to change.
       "plan_mode": "plan",
       "root_chat_id": "2898031c-fdce-4e3e-8c53-4481dd42fcd7",
       "shared": true,
+      "snapshot_version": 0,
       "status": "waiting",
       "summary": "string",
       "title": "string",
@@ -2601,6 +2613,7 @@ Experimental: this endpoint is subject to change.
   "plan_mode": "plan",
   "root_chat_id": "2898031c-fdce-4e3e-8c53-4481dd42fcd7",
   "shared": true,
+  "snapshot_version": 0,
   "status": "waiting",
   "summary": "string",
   "title": "string",
@@ -2892,6 +2905,7 @@ Experimental: this endpoint is subject to change.
     "retrying_at": "2019-08-24T14:15:22Z",
     "status_code": 0
   },
+  "snapshot_version": 0,
   "status": {
     "status": "waiting"
   },
@@ -3106,6 +3120,7 @@ Experimental: this endpoint is subject to change.
       "plan_mode": "plan",
       "root_chat_id": "2898031c-fdce-4e3e-8c53-4481dd42fcd7",
       "shared": true,
+      "snapshot_version": 0,
       "status": "waiting",
       "summary": "string",
       "title": "string",
@@ -3200,6 +3215,7 @@ Experimental: this endpoint is subject to change.
   "plan_mode": "plan",
   "root_chat_id": "2898031c-fdce-4e3e-8c53-4481dd42fcd7",
   "shared": true,
+  "snapshot_version": 0,
   "status": "waiting",
   "summary": "string",
   "title": "string",

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2209,6 +2209,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
       "plan_mode": "plan",
       "root_chat_id": "2898031c-fdce-4e3e-8c53-4481dd42fcd7",
       "shared": true,
+      "snapshot_version": 0,
       "status": "waiting",
       "summary": "string",
       "title": "string",
@@ -2303,6 +2304,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
   "plan_mode": "plan",
   "root_chat_id": "2898031c-fdce-4e3e-8c53-4481dd42fcd7",
   "shared": true,
+  "snapshot_version": 0,
   "status": "waiting",
   "summary": "string",
   "title": "string",
@@ -2345,6 +2347,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `plan_mode`             | [codersdk.ChatPlanMode](#codersdkchatplanmode)                  | false    |              |                                                                                                                                                                                                                                                                            |
 | `root_chat_id`          | string                                                          | false    |              |                                                                                                                                                                                                                                                                            |
 | `shared`                | boolean                                                         | false    |              | Shared is true when this chat's root chat has explicit user or group ACL entries.                                                                                                                                                                                          |
+| `snapshot_version`      | integer                                                         | false    |              | Snapshot version is a monotonic per-chat version of the full chat snapshot. Clients use it to order chat payloads received from REST, the per-chat stream, and the global watch stream.                                                                                    |
 | `status`                | [codersdk.ChatStatus](#codersdkchatstatus)                      | false    |              |                                                                                                                                                                                                                                                                            |
 | `summary`               | string                                                          | false    |              | Summary is the persisted whole-chat summary, generated in the background. It is nil until the first summary has been produced.                                                                                                                                             |
 | `title`                 | string                                                          | false    |              |                                                                                                                                                                                                                                                                            |
@@ -3806,6 +3809,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
     "retrying_at": "2019-08-24T14:15:22Z",
     "status_code": 0
   },
+  "snapshot_version": 0,
   "status": {
     "status": "waiting"
   },
@@ -3815,17 +3819,18 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ### Properties
 
-| Name              | Type                                                                   | Required | Restrictions | Description |
-|-------------------|------------------------------------------------------------------------|----------|--------------|-------------|
-| `action_required` | [codersdk.ChatStreamActionRequired](#codersdkchatstreamactionrequired) | false    |              |             |
-| `chat_id`         | string                                                                 | false    |              |             |
-| `error`           | [codersdk.ChatError](#codersdkchaterror)                               | false    |              |             |
-| `message`         | [codersdk.ChatMessage](#codersdkchatmessage)                           | false    |              |             |
-| `message_part`    | [codersdk.ChatStreamMessagePart](#codersdkchatstreammessagepart)       | false    |              |             |
-| `queued_messages` | array of [codersdk.ChatQueuedMessage](#codersdkchatqueuedmessage)      | false    |              |             |
-| `retry`           | [codersdk.ChatStreamRetry](#codersdkchatstreamretry)                   | false    |              |             |
-| `status`          | [codersdk.ChatStreamStatus](#codersdkchatstreamstatus)                 | false    |              |             |
-| `type`            | [codersdk.ChatStreamEventType](#codersdkchatstreameventtype)           | false    |              |             |
+| Name               | Type                                                                   | Required | Restrictions | Description                                                                                                                                                                                             |
+|--------------------|------------------------------------------------------------------------|----------|--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `action_required`  | [codersdk.ChatStreamActionRequired](#codersdkchatstreamactionrequired) | false    |              |                                                                                                                                                                                                         |
+| `chat_id`          | string                                                                 | false    |              |                                                                                                                                                                                                         |
+| `error`            | [codersdk.ChatError](#codersdkchaterror)                               | false    |              |                                                                                                                                                                                                         |
+| `message`          | [codersdk.ChatMessage](#codersdkchatmessage)                           | false    |              |                                                                                                                                                                                                         |
+| `message_part`     | [codersdk.ChatStreamMessagePart](#codersdkchatstreammessagepart)       | false    |              |                                                                                                                                                                                                         |
+| `queued_messages`  | array of [codersdk.ChatQueuedMessage](#codersdkchatqueuedmessage)      | false    |              |                                                                                                                                                                                                         |
+| `retry`            | [codersdk.ChatStreamRetry](#codersdkchatstreamretry)                   | false    |              |                                                                                                                                                                                                         |
+| `snapshot_version` | integer                                                                | false    |              | Snapshot version is the chat snapshot version the event was derived from. It is omitted for events that carry no database snapshot, such as transport errors, which are not authoritative for ordering. |
+| `status`           | [codersdk.ChatStreamStatus](#codersdkchatstreamstatus)                 | false    |              |                                                                                                                                                                                                         |
+| `type`             | [codersdk.ChatStreamEventType](#codersdkchatstreameventtype)           | false    |              |                                                                                                                                                                                                         |
 
 ## codersdk.ChatStreamEventType
 
@@ -4120,6 +4125,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
     "plan_mode": "plan",
     "root_chat_id": "2898031c-fdce-4e3e-8c53-4481dd42fcd7",
     "shared": true,
+    "snapshot_version": 0,
     "status": "waiting",
     "summary": "string",
     "title": "string",

--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -126,6 +126,7 @@ const makeChat = (
 	status: "running",
 	created_at: "2025-01-01T00:00:00.000Z",
 	updated_at: "2025-01-01T00:00:00.000Z",
+	snapshot_version: 1,
 	archived: false,
 	shared: false,
 	pin_order: 0,

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1915,6 +1915,12 @@ export interface Chat {
 	readonly diff_status?: ChatDiffStatus;
 	readonly created_at: string;
 	readonly updated_at: string;
+	/**
+	 * SnapshotVersion is a monotonic per-chat version of the full chat
+	 * snapshot. Clients use it to order chat payloads received from REST,
+	 * the per-chat stream, and the global watch stream.
+	 */
+	readonly snapshot_version: number;
 	readonly archived: boolean;
 	/**
 	 * Shared is true when this chat's root chat has explicit user or group ACL entries.
@@ -3414,6 +3420,12 @@ export interface ChatStreamEvent {
 	readonly retry?: ChatStreamRetry;
 	readonly queued_messages?: readonly ChatQueuedMessage[];
 	readonly action_required?: ChatStreamActionRequired;
+	/**
+	 * SnapshotVersion is the chat snapshot version the event was derived
+	 * from. It is omitted for events that carry no database snapshot, such
+	 * as transport errors, which are not authoritative for ordering.
+	 */
+	readonly snapshot_version?: number;
 }
 
 // From codersdk/chats.go

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -159,6 +159,7 @@ const baseChatFields = {
 	labels: {},
 	created_at: "2026-02-18T00:00:00.000Z",
 	updated_at: "2026-02-18T00:00:00.000Z",
+	snapshot_version: 1,
 	archived: false,
 	shared: false,
 	pin_order: 0,

--- a/site/src/pages/AgentsPage/components/ChatTopBar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatTopBar.stories.tsx
@@ -77,6 +77,7 @@ export const WithParentChat: Story = {
 			summary: null,
 			created_at: "2026-02-18T00:00:00.000Z",
 			updated_at: "2026-02-18T00:00:00.000Z",
+			snapshot_version: 1,
 			archived: false,
 			shared: false,
 			pin_order: 0,

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchDialog.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchDialog.stories.tsx
@@ -32,6 +32,7 @@ const mockChat: Chat = {
 	summary: "Investigated and fixed a race condition in the auth middleware.",
 	created_at: "2026-05-20T05:00:00.000Z",
 	updated_at: "2026-05-20T07:30:00.000Z",
+	snapshot_version: 1,
 	archived: false,
 	shared: false,
 	pin_order: 0,

--- a/site/src/testHelpers/chatEntities.ts
+++ b/site/src/testHelpers/chatEntities.ts
@@ -23,6 +23,7 @@ export const MockChat: Chat = {
 	summary: null,
 	created_at: MOCK_TIMESTAMP,
 	updated_at: MOCK_TIMESTAMP,
+	snapshot_version: 1,
 	archived: false,
 	shared: false,
 	pin_order: 0,


### PR DESCRIPTION
This is PR 4.5 of a stack fixing the Agents/chats feature's misuse of TanStack Query. It is the backend piece the cache-canonical chat status PR (next in the stack) builds on.

Adds `SnapshotVersion` to `codersdk.Chat` and an optional `SnapshotVersion` to the `ChatStreamEvent` envelope. `db2sdk.Chat` populates it and `stream_loop.go` stamps every DB-snapshot-derived stream event; transport errors and transient `message_part` events stay unversioned. Generated API docs/types updated via `make gen`.

Uses `snapshot_version`, not `updated_at`, as the ordering key because `updated_at` is transaction-start time and is not monotonic under row-lock contention, while the snapshot version is monotonic under the row lock.

Depends on #27773

<details>
<summary>Implementation plan and review notes (for reviewers)</summary>

- `snapshot_version` is the ordering key for status because it is monotonic under the row lock; `updated_at` is not.
- Only DB-snapshot-derived events carry a version; transport and transient events do not.
- Reviewed by two independent reviewers; sound.

</details>

---

Generated by Coder Agents on behalf of @DanielleMaywood